### PR TITLE
Setup Gradle multi-module skeleton

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,0 +1,11 @@
+plugins {
+    alias(libs.plugins.kotlin.multiplatform)
+}
+
+kotlin {
+    jvmToolchain(21)
+    jvm()
+    js(IR) {
+        browser()
+    }
+}

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -1,0 +1,7 @@
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+}
+
+kotlin {
+    jvmToolchain(21)
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,8 @@
+plugins {
+}
+
+allprojects {
+    repositories {
+        mavenCentral()
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,13 @@
+[versions]
+kotlin = "1.9.22"
+ktor = "2.3.9"
+coroutines = "1.7.3"
+
+[libraries]
+# Example libraries
+kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
+ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }
+
+[plugins]
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,15 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+    }
+}
+
+rootProject.name = "plataforma"
+include("backend", "users", "app")

--- a/users/build.gradle.kts
+++ b/users/build.gradle.kts
@@ -1,0 +1,7 @@
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+}
+
+kotlin {
+    jvmToolchain(21)
+}


### PR DESCRIPTION
## Summary
- add Gradle multi-module skeleton with backend, users and app modules
- configure Kotlin JVM modules to use version catalog plugin aliases and jvmToolchain 21
- setup multiplatform module for JVM & JS browser
- centralize versions with `libs.versions.toml`
- configure plugin and dependency repositories in `settings.gradle.kts`

## Testing
- `gradle build` *(fails: Plugin not found due to lack of network access)*

------
https://chatgpt.com/codex/tasks/task_e_685d5c280f8c8325a7c6038055cfb5d7