### PR TITLE
Integrate backend and users modules

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -7,3 +7,18 @@ plugins {
 kotlin {
     jvmToolchain(21)
 }
+
+dependencies {
+    implementation(libs.ktor.server.core)
+    implementation(libs.logback.classic)
+    implementation(libs.kodein.di)
+    implementation(libs.kodein.di.framework.ktor.server.jvm)
+    implementation(libs.ktor.server.rate.limiting)
+    implementation(libs.java.jwt)
+    implementation(libs.jwks.rsa)
+    implementation(libs.gson)
+
+    testImplementation(kotlin("test"))
+    testImplementation(libs.ktor.server.tests)
+    testImplementation(libs.mockk)
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,8 @@ ktor-server-rate-limiting = "1.2.10"
 shadow = "8.1.1"
 mockk = "1.13.10"
 backend = "0.25.0"
+aws-sdk-java = "2.25.28"
+gson = "2.10.1"
 
 [libraries]
 # Example libraries
@@ -44,6 +46,10 @@ backend = { module = "ar.com.intrale:backend", version.ref = "backend" }
 ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
+gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
+aws-sdk-dynamodb = { module = "software.amazon.awssdk:dynamodb", version.ref = "aws-sdk-java" }
+aws-sdk-dynamodb-enhanced = { module = "software.amazon.awssdk:dynamodb-enhanced", version.ref = "aws-sdk-java" }
+aws-sdk-regions = { module = "software.amazon.awssdk:regions", version.ref = "aws-sdk-java" }
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/users/build.gradle.kts
+++ b/users/build.gradle.kts
@@ -7,3 +7,27 @@ plugins {
 kotlin {
     jvmToolchain(21)
 }
+
+dependencies {
+    implementation(project(":backend"))
+
+    implementation(libs.ktor.server.core)
+    implementation(libs.logback.classic)
+    implementation(libs.kodein.di)
+    implementation(libs.kodein.di.framework.ktor.server.jvm)
+    implementation(libs.cognito.identity.provider)
+    implementation(libs.cognito.identity)
+    implementation(libs.secretsmanager)
+    implementation(libs.aws.sdk.dynamodb)
+    implementation(libs.aws.sdk.dynamodb.enhanced)
+    implementation(libs.aws.sdk.regions)
+    implementation(libs.datafaker)
+    implementation(libs.konform)
+    implementation(libs.java.jwt)
+    implementation(libs.jwks.rsa)
+    implementation(libs.gson)
+
+    testImplementation(kotlin("test"))
+    testImplementation(libs.ktor.server.tests)
+    testImplementation(libs.mockk)
+}


### PR DESCRIPTION
## Summary
- centralize dependency versions for Gson and AWS Java SDK
- set up dependencies for backend module
- set up dependencies and project reference for users module

## Testing
- `gradle clean build` *(fails: Plugin not found because internet access is disabled)*

------
https://chatgpt.com/codex/tasks/task_e_685d70970eb083258967f1852cba2778