### PR TITLE
[auto] Agrega pruebas de integración para ChangePassword

### DIFF
--- a/users/src/test/kotlin/ar/com/intrale/ChangePasswordIntegrationTest.kt
+++ b/users/src/test/kotlin/ar/com/intrale/ChangePasswordIntegrationTest.kt
@@ -1,0 +1,51 @@
+package ar.com.intrale
+
+import aws.sdk.kotlin.services.cognitoidentityprovider.CognitoIdentityProviderClient
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.ChangePasswordResponse
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.slf4j.helpers.NOPLogger
+import io.ktor.http.HttpStatusCode
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ChangePasswordIntegrationTest {
+    private val logger = NOPLogger.NOP_LOGGER
+    private val config = UsersConfig(setOf("biz"), "us-east-1", "key", "secret", "pool", "client")
+
+    @Test
+    fun `cambio exitoso de contrasena`() = runBlocking {
+        val cognito = mockk<CognitoIdentityProviderClient>()
+        coEvery { cognito.changePassword(any()) } returns ChangePasswordResponse {}
+        coEvery { cognito.close() } returns Unit
+        val change = ChangePassword(config, logger, cognito)
+
+        val response = change.securedExecute(
+            business = "biz",
+            function = "changePassword",
+            headers = mapOf("Authorization" to "token"),
+            textBody = "{\"oldPassword\":\"old\",\"newPassword\":\"new\"}"
+        )
+
+        assertEquals(HttpStatusCode.OK, response.statusCode)
+        coVerify(exactly = 1) { cognito.changePassword(any()) }
+    }
+
+    @Test
+    fun `token faltante retorna no autorizado`() = runBlocking {
+        val cognito = mockk<CognitoIdentityProviderClient>(relaxed = true)
+        val change = ChangePassword(config, logger, cognito)
+
+        val response = change.securedExecute(
+            business = "biz",
+            function = "changePassword",
+            headers = emptyMap(),
+            textBody = "{\"oldPassword\":\"old\",\"newPassword\":\"new\"}"
+        )
+
+        assertEquals(HttpStatusCode.Unauthorized, response.statusCode)
+        coVerify(exactly = 0) { cognito.changePassword(any()) }
+    }
+}


### PR DESCRIPTION
Se añaden pruebas de integración para la función ChangePassword en el módulo `users`. Las pruebas cubren un caso exitoso de cambio de contraseña y la respuesta de error cuando falta el token de autorización.

Closes #20

------
https://chatgpt.com/codex/tasks/task_e_6866a349dd6483258bb05163d4783ff3