### PR TITLE
[auto] Agregar pruebas de integración para SignUpPlatformAdmin

### DIFF
--- a/users/src/test/kotlin/ar/com/intrale/SignUpPlatformAdminIntegrationTest.kt
+++ b/users/src/test/kotlin/ar/com/intrale/SignUpPlatformAdminIntegrationTest.kt
@@ -1,0 +1,151 @@
+package ar.com.intrale
+
+import aws.sdk.kotlin.services.cognitoidentityprovider.CognitoIdentityProviderClient
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.request.receiveText
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.*
+import io.ktor.server.testing.*
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import org.kodein.di.*
+import org.kodein.di.ktor.closestDI
+import org.kodein.di.ktor.di
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SignUpPlatformAdminIntegrationTest {
+
+    private fun testModule(cognito: CognitoIdentityProviderClient): DI.Module {
+        val config = UsersConfig(setOf("biz"), "us-east-1", "key", "secret", "pool", "client")
+        return DI.Module(name = "test", allowSilentOverride = true) {
+            bind<UsersConfig>(overrides = true) { singleton { config } }
+            bind<CognitoIdentityProviderClient>(overrides = true) { singleton { cognito } }
+        }
+    }
+
+    @Test
+    fun `primer usuario se registra correctamente`() = testApplication {
+        val cognito = mockk<CognitoIdentityProviderClient>()
+        coEvery { cognito.listUsers(any()) } returns ListUsersResponse { users = listOf() }
+        coEvery { cognito.adminCreateUser(any()) } returns AdminCreateUserResponse { }
+        coEvery { cognito.close() } returns Unit
+
+        application {
+            di {
+                import(appModule, allowOverride = true)
+                import(testModule(cognito), allowOverride = true)
+            }
+            routing {
+                post("/{business}/{function}") {
+                    val di = closestDI()
+                    val logger: org.slf4j.Logger by di.instance()
+
+                    val businessName = call.parameters["business"]
+                    val functionName = call.parameters["function"]
+
+                    val functionResponse: Response = if (businessName == null) {
+                        RequestValidationException("No business defined on path")
+                    } else {
+                        val config = di.direct.instance<Config>()
+                        logger.info("config.businesses: ${'$'}{config.businesses}")
+                        if (!config.businesses.contains(businessName)) {
+                            ExceptionResponse("Business not available with name ${'$'}businessName")
+                        } else if (functionName == null) {
+                            RequestValidationException("No function defined on path")
+                        } else {
+                            try {
+                                val function = di.direct.instance<Function>(tag = functionName)
+                                val headers = call.request.headers.entries().associate { it.key to it.value.joinToString(",") }
+                                function.execute(businessName, functionName, headers, call.receiveText())
+                            } catch (e: DI.NotFoundException) {
+                                ExceptionResponse("No function with name ${'$'}functionName found")
+                            }
+                        }
+                    }
+
+                    call.respondText(
+                        text = com.google.gson.Gson().toJson(functionResponse),
+                        contentType = ContentType.Application.Json,
+                        status = functionResponse.statusCode
+                    )
+                }
+            }
+        }
+
+        val response = client.post("/biz/signupPlatformAdmin") {
+            header(HttpHeaders.ContentType, ContentType.Application.Json)
+            setBody("{\"email\":\"admin@test.com\"}")
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        coVerify(exactly = 1) { cognito.listUsers(any()) }
+        coVerify(exactly = 1) { cognito.adminCreateUser(any()) }
+    }
+
+    @Test
+    fun `segundo usuario retorna no autorizado`() = testApplication {
+        val cognito = mockk<CognitoIdentityProviderClient>()
+        coEvery { cognito.listUsers(any()) } returns ListUsersResponse {
+            users = listOf(UserType { username = "existing" })
+        }
+        coEvery { cognito.close() } returns Unit
+
+        application {
+            di {
+                import(appModule, allowOverride = true)
+                import(testModule(cognito), allowOverride = true)
+            }
+            routing {
+                post("/{business}/{function}") {
+                    val di = closestDI()
+                    val logger: org.slf4j.Logger by di.instance()
+
+                    val businessName = call.parameters["business"]
+                    val functionName = call.parameters["function"]
+
+                    val functionResponse: Response = if (businessName == null) {
+                        RequestValidationException("No business defined on path")
+                    } else {
+                        val config = di.direct.instance<Config>()
+                        logger.info("config.businesses: ${'$'}{config.businesses}")
+                        if (!config.businesses.contains(businessName)) {
+                            ExceptionResponse("Business not available with name ${'$'}businessName")
+                        } else if (functionName == null) {
+                            RequestValidationException("No function defined on path")
+                        } else {
+                            try {
+                                val function = di.direct.instance<Function>(tag = functionName)
+                                val headers = call.request.headers.entries().associate { it.key to it.value.joinToString(",") }
+                                function.execute(businessName, functionName, headers, call.receiveText())
+                            } catch (e: DI.NotFoundException) {
+                                ExceptionResponse("No function with name ${'$'}functionName found")
+                            }
+                        }
+                    }
+
+                    call.respondText(
+                        text = com.google.gson.Gson().toJson(functionResponse),
+                        contentType = ContentType.Application.Json,
+                        status = functionResponse.statusCode
+                    )
+                }
+            }
+        }
+
+        val response = client.post("/biz/signupPlatformAdmin") {
+            header(HttpHeaders.ContentType, ContentType.Application.Json)
+            setBody("{\"email\":\"admin@test.com\"}")
+        }
+
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+        coVerify(exactly = 1) { cognito.listUsers(any()) }
+        coVerify(exactly = 0) { cognito.adminCreateUser(any()) }
+    }
+}
+

--- a/users/src/test/kotlin/ar/com/intrale/TwoFactorVerifyIntegrationTest.kt
+++ b/users/src/test/kotlin/ar/com/intrale/TwoFactorVerifyIntegrationTest.kt
@@ -27,6 +27,7 @@ class DummyVerifyTable : DynamoDbTable<User> {
     override fun index(indexName: String) = throw UnsupportedOperationException()
     override fun putItem(item: User) { items.add(item) }
     override fun getItem(key: Key): User? = items.find { it.email == key.partitionKeyValue().s() }
+    override fun getItem(item: User): User? = items.find { it.email == item.email }
 }
 
 class TwoFactorVerifyIntegrationTest {


### PR DESCRIPTION
Se añaden pruebas de integración que validan el flujo de registro del administrador de plataforma. Incluyen escenarios exitoso y con error cuando ya existe un usuario.

Closes #14

------
https://chatgpt.com/codex/tasks/task_e_6866bf3fa1108325ab1d8d4994b868d7