### PR TITLE
[auto] fix ProviderClosedException

### DIFF
--- a/users/src/main/kotlin/ar/com/intrale/ConfirmPasswordRecovery.kt
+++ b/users/src/main/kotlin/ar/com/intrale/ConfirmPasswordRecovery.kt
@@ -54,21 +54,19 @@ class ConfirmPasswordRecovery(val config: UsersConfig, val logger: Logger, val c
         // Se intenta realizar el signin normalmente contra el proveedor de autenticacion
         try {
             logger.info("Se intenta realizar el signin normalmente contra el proveedor de autenticacion")
-            cognito.use { identityProviderClient ->
+            val identityProviderClient = cognito
 
-                val confirmPassword = ConfirmForgotPasswordRequest {
-                    clientId = config.awsCognitoClientId
-                    username = body.email
-                    confirmationCode = body.code
-                    password = body.password
-                }
-
-                val forgotPasswordResponse = identityProviderClient.confirmForgotPassword(confirmPassword)
-
-                logger.info("retornando ok")
-                return Response()
-
+            val confirmPassword = ConfirmForgotPasswordRequest {
+                clientId = config.awsCognitoClientId
+                username = body.email
+                confirmationCode = body.code
+                password = body.password
             }
+
+            val forgotPasswordResponse = identityProviderClient.confirmForgotPassword(confirmPassword)
+
+            logger.info("retornando ok")
+            return Response()
         } catch (e: NotAuthorizedException) {
             logger.error("Error al consultar Cognito: ${e.message}", e)
             return UnauthorizedException()


### PR DESCRIPTION
Se actualizó ConfirmPasswordRecovery para dejar de utilizar `use {}` sobre el cliente de Cognito y así evitar que se cierre la instancia compartida.

Closes #83

------
https://chatgpt.com/codex/tasks/task_e_687022de625083258c029fb7e9cf91b7