### PR TITLE
[auto] Externalizar URL base en ClientSignUpService

### DIFF
--- a/app/composeApp/src/commonMain/composeResources/config.properties
+++ b/app/composeApp/src/commonMain/composeResources/config.properties
@@ -1,0 +1,1 @@
+baseUrl=https://mgnr0htbvd.execute-api.us-east-2.amazonaws.com/dev/

--- a/app/composeApp/src/commonMain/kotlin/ext/AppConfig.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/AppConfig.kt
@@ -1,0 +1,17 @@
+package ext
+
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.resource
+
+@OptIn(ExperimentalResourceApi::class)
+object AppConfig {
+    val baseUrl: String by lazy {
+        val text = resource("config.properties").readBytes().decodeToString()
+        text.lineSequence()
+            .map { it.trim() }
+            .firstOrNull { it.startsWith("baseUrl=") }
+            ?.substringAfter("=")
+            ?.trim()
+            ?: ""
+    }
+}

--- a/app/composeApp/src/commonMain/kotlin/ext/ClientSignUpService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/ClientSignUpService.kt
@@ -5,11 +5,12 @@ import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.utils.io.InternalAPI
 import kotlinx.serialization.Serializable
+import ext.AppConfig
 
 class ClientSignUpService(private val httpClient: HttpClient) : CommSignUpService {
     @OptIn(InternalAPI::class)
     override suspend fun execute(function: String, email: String) {
-        httpClient.post("https://66d32be4184dce1713cf7f64.mockapi.io/intrale/v1/$function") {
+        httpClient.post("${AppConfig.baseUrl}$function") {
             setBody(SignUpRequest(email))
         }
     }


### PR DESCRIPTION
Se externalizó la URL base utilizada en `ClientSignUpService`.

- Se agregó archivo de configuración `config.properties` con la clave `baseUrl`.
- Se creó `AppConfig` para leer dicha propiedad usando recursos de Compose.
- `ClientSignUpService` ahora utiliza `AppConfig.baseUrl` para construir la URL.

Closes #109

------
https://chatgpt.com/codex/tasks/task_e_687157e881488325aa82b7c0b029bd94