### PR TITLE
[auto] Externalizar URL base en ClientLoginService

### DIFF
--- a/app/composeApp/src/androidMain/kotlin/ext/BaseUrlProvider.android.kt
+++ b/app/composeApp/src/androidMain/kotlin/ext/BaseUrlProvider.android.kt
@@ -1,0 +1,10 @@
+package ext
+
+import java.util.Properties
+
+actual fun getBaseUrl(): String {
+    val props = Properties()
+    val stream = ClassLoader.getSystemResourceAsStream("application.properties")
+    stream.use { props.load(it) }
+    return props.getProperty("baseUrl")
+}

--- a/app/composeApp/src/commonMain/kotlin/ext/BaseUrlProvider.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/BaseUrlProvider.kt
@@ -1,0 +1,3 @@
+package ext
+
+expect fun getBaseUrl(): String

--- a/app/composeApp/src/commonMain/kotlin/ext/ClientLoginService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/ClientLoginService.kt
@@ -5,6 +5,7 @@ import io.ktor.client.call.body
 import io.ktor.client.request.headers
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
+import ext.getBaseUrl
 import io.ktor.utils.io.InternalAPI
 import kotlinx.serialization.Serializable
 import org.kodein.log.LoggerFactory
@@ -17,7 +18,7 @@ class ClientLoginService(val httpClient: HttpClient) : CommLoginService {
     @OptIn(InternalAPI::class)
     override suspend fun execute(user: String, password: String): LoginResponse {
         val response: LoginResponse =
-            httpClient.post("https://66d32be4184dce1713cf7f64.mockapi.io/intrale/v1/login"){
+            httpClient.post(getBaseUrl() + "login"){
                 headers {
 
                 }

--- a/app/composeApp/src/commonMain/resources/application.properties
+++ b/app/composeApp/src/commonMain/resources/application.properties
@@ -1,0 +1,1 @@
+baseUrl=https://mgnr0htbvd.execute-api.us-east-2.amazonaws.com/dev/

--- a/app/composeApp/src/desktopMain/kotlin/ext/BaseUrlProvider.jvm.kt
+++ b/app/composeApp/src/desktopMain/kotlin/ext/BaseUrlProvider.jvm.kt
@@ -1,0 +1,10 @@
+package ext
+
+import java.util.Properties
+
+actual fun getBaseUrl(): String {
+    val props = Properties()
+    val stream = ClassLoader.getSystemResourceAsStream("application.properties")
+    stream.use { props.load(it) }
+    return props.getProperty("baseUrl")
+}

--- a/app/composeApp/src/iosMain/kotlin/ext/BaseUrlProvider.ios.kt
+++ b/app/composeApp/src/iosMain/kotlin/ext/BaseUrlProvider.ios.kt
@@ -1,0 +1,3 @@
+package ext
+
+actual fun getBaseUrl(): String = "https://mgnr0htbvd.execute-api.us-east-2.amazonaws.com/dev/"

--- a/app/composeApp/src/wasmJsMain/kotlin/ext/BaseUrlProvider.wasmJs.kt
+++ b/app/composeApp/src/wasmJsMain/kotlin/ext/BaseUrlProvider.wasmJs.kt
@@ -1,0 +1,3 @@
+package ext
+
+actual fun getBaseUrl(): String = "https://mgnr0htbvd.execute-api.us-east-2.amazonaws.com/dev/"


### PR DESCRIPTION
Se externalizó la URL base en un archivo de propiedades y se agregó un proveedor de URL con implementaciones por plataforma. Closes #108

------
https://chatgpt.com/codex/tasks/task_e_687157e604388325a49b55b52d435cdf