### PR TITLE
[auto] Fix crash de Compose por altura infinita

### DIFF
--- a/app/composeApp/src/commonMain/kotlin/ui/cp/TextField.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/cp/TextField.kt
@@ -66,7 +66,7 @@ fun TextField(label: StringResource,
             }
         )
 
-    Spacer(modifier = Modifier.fillMaxHeight())
+    Spacer(modifier = Modifier.weight(1f))
 
             AnimatedVisibility(!state.isValid){
                 Text(


### PR DESCRIPTION
Se reemplazó un `Modifier.fillMaxHeight()` por `Modifier.weight(1f)` en `TextField.kt` para evitar un tamaño fuera de rango que provocaba un crash en el `Scaffold`. Closes #115

------
https://chatgpt.com/codex/tasks/task_e_68766da22bb083259862eb0407a63222