### PR TITLE
[auto] Mueve boton Registrarme al login

### DIFF
--- a/app/composeApp/src/commonMain/kotlin/ui/sc/Home.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/Home.kt
@@ -50,13 +50,6 @@ class Home() : Screen(HOME_PATH, Res.string.app_name){
             )
 
             Button(
-                label = stringResource(Res.string.signup),
-                onClick = {
-                    navigate(SELECT_SIGNUP_PROFILE_PATH)
-                }
-            )
-
-            Button(
                 label = stringResource(Res.string.logout),
                 onClick = {
                     coroutineScope.launch {

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/Login.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/Login.kt
@@ -91,6 +91,13 @@ class Login() : Screen(LOGIN_PATH, Res.string.login){
                 }
             )
 
+            Button(
+                label = stringResource(Res.string.signup),
+                onClick = {
+                    navigate(SELECT_SIGNUP_PROFILE_PATH)
+                }
+            )
+
 
         }
         }

--- a/docs/signup-por-perfil.md
+++ b/docs/signup-por-perfil.md
@@ -13,5 +13,5 @@ la cual consume los endpoints expuestos por el módulo `users`.
 Relacionado con #75.
 
 Se agregó la pantalla `SelectSignUpProfileScreen` que permite elegir el tipo de registro antes de mostrar la pantalla específica.
-Desde `Home` ahora aparece el botón **"Registrarme"** que navega a dicha pantalla.
+Desde `Login` ahora aparece el botón **"Registrarme"** que navega a dicha pantalla.
 Cada opción lleva a `SignUpPlatformAdminScreen`, `SignUpDeliveryScreen` o `SignUpSalerScreen` según corresponda.


### PR DESCRIPTION
Se reubicó el botón de registro para iniciar el flujo de alta sin autenticarse.

- Se eliminó el botón **Registrarme** de la pantalla Home y se añadió en Login
  para navegar a `SELECT_SIGNUP_PROFILE_PATH`.
- Se actualizó la documentación correspondiente.

Closes #120

------
https://chatgpt.com/codex/tasks/task_e_688294f5570883259687a223cc5ae02f