### PR TITLE
[auto] Unifica registro con feedback de login

### DIFF
--- a/app/composeApp/src/commonMain/kotlin/asdo/DoSignUp.kt
+++ b/app/composeApp/src/commonMain/kotlin/asdo/DoSignUp.kt
@@ -1,9 +1,22 @@
 package asdo
 
 import ext.CommSignUpService
+import ext.ExceptionResponse
+import ext.SignUpResponse
 
 class DoSignUp(private val service: CommSignUpService) : ToDoSignUp {
-    override suspend fun execute(email: String) {
-        service.execute(email)
+    override suspend fun execute(email: String): Result<DoSignUpResult> {
+        return try {
+            service.execute(email).fold(
+                onSuccess = { Result.success(it.toDoSignUpResult()) },
+                onFailure = { error ->
+                    Result.failure(
+                        (error as? ExceptionResponse)?.toDoSignUpException() ?: (error as Exception).toDoSignUpException()
+                    )
+                }
+            )
+        } catch (e: Exception) {
+            Result.failure(e.toDoSignUpException())
+        }
     }
 }

--- a/app/composeApp/src/commonMain/kotlin/asdo/DoSignUpDelivery.kt
+++ b/app/composeApp/src/commonMain/kotlin/asdo/DoSignUpDelivery.kt
@@ -1,9 +1,21 @@
 package asdo
 
 import ext.CommSignUpService
+import ext.ExceptionResponse
 
 class DoSignUpDelivery(private val service: CommSignUpService) : ToDoSignUpDelivery {
-    override suspend fun execute(email: String) {
-        service.execute(/*"signupDelivery",*/ email)
+    override suspend fun execute(email: String): Result<DoSignUpResult> {
+        return try {
+            service.execute(/*"signupDelivery",*/ email).fold(
+                onSuccess = { Result.success(it.toDoSignUpResult()) },
+                onFailure = { error ->
+                    Result.failure(
+                        (error as? ExceptionResponse)?.toDoSignUpException() ?: (error as Exception).toDoSignUpException()
+                    )
+                }
+            )
+        } catch (e: Exception) {
+            Result.failure(e.toDoSignUpException())
+        }
     }
 }

--- a/app/composeApp/src/commonMain/kotlin/asdo/DoSignUpPlatformAdmin.kt
+++ b/app/composeApp/src/commonMain/kotlin/asdo/DoSignUpPlatformAdmin.kt
@@ -1,9 +1,21 @@
 package asdo
 
 import ext.CommSignUpService
+import ext.ExceptionResponse
 
 class DoSignUpPlatformAdmin(private val service: CommSignUpService) : ToDoSignUpPlatformAdmin {
-    override suspend fun execute(email: String) {
-        service.execute(/*"signupPlatformAdmin",*/ email)
+    override suspend fun execute(email: String): Result<DoSignUpResult> {
+        return try {
+            service.execute(/*"signupPlatformAdmin",*/ email).fold(
+                onSuccess = { Result.success(it.toDoSignUpResult()) },
+                onFailure = { error ->
+                    Result.failure(
+                        (error as? ExceptionResponse)?.toDoSignUpException() ?: (error as Exception).toDoSignUpException()
+                    )
+                }
+            )
+        } catch (e: Exception) {
+            Result.failure(e.toDoSignUpException())
+        }
     }
 }

--- a/app/composeApp/src/commonMain/kotlin/asdo/DoSignUpSaler.kt
+++ b/app/composeApp/src/commonMain/kotlin/asdo/DoSignUpSaler.kt
@@ -1,10 +1,22 @@
 package asdo
 
 import ext.CommSignUpService
+import ext.ExceptionResponse
 
 class DoSignUpSaler(private val service: CommSignUpService) : ToDoSignUpSaler {
-    override suspend fun execute(email: String) {
-        service.execute(/*"signupSaler",*/ email)
+    override suspend fun execute(email: String): Result<DoSignUpResult> {
+        return try {
+            service.execute(/*"signupSaler",*/ email).fold(
+                onSuccess = { Result.success(it.toDoSignUpResult()) },
+                onFailure = { error ->
+                    Result.failure(
+                        (error as? ExceptionResponse)?.toDoSignUpException() ?: (error as Exception).toDoSignUpException()
+                    )
+                }
+            )
+        } catch (e: Exception) {
+            Result.failure(e.toDoSignUpException())
+        }
     }
 }
 

--- a/app/composeApp/src/commonMain/kotlin/asdo/SignUpResult.kt
+++ b/app/composeApp/src/commonMain/kotlin/asdo/SignUpResult.kt
@@ -1,0 +1,24 @@
+package asdo
+
+import ext.SignUpResponse
+import ext.ExceptionResponse
+
+data class SignUpStatusCode(val value: Int, val description: String?)
+
+data class DoSignUpResult(val statusCode: SignUpStatusCode)
+
+data class DoSignUpException(val statusCode: SignUpStatusCode, override val message: String?): Throwable(message)
+
+fun SignUpResponse.toDoSignUpResult() = DoSignUpResult(
+    SignUpStatusCode(statusCode.value, statusCode.description)
+)
+
+fun ExceptionResponse.toDoSignUpException() = DoSignUpException(
+    SignUpStatusCode(statusCode.value, statusCode.description),
+    message ?: "Error desconocido durante el registro"
+)
+
+fun Exception.toDoSignUpException() = DoSignUpException(
+    SignUpStatusCode(500, "Internal Server Error"),
+    message ?: "Error desconocido durante la operación"
+)

--- a/app/composeApp/src/commonMain/kotlin/asdo/ToDoSignUp.kt
+++ b/app/composeApp/src/commonMain/kotlin/asdo/ToDoSignUp.kt
@@ -1,3 +1,3 @@
 package asdo
 
-interface ToDoSignUp { suspend fun execute(email:String) }
+interface ToDoSignUp { suspend fun execute(email:String): Result<DoSignUpResult> }

--- a/app/composeApp/src/commonMain/kotlin/asdo/ToDoSignUpDelivery.kt
+++ b/app/composeApp/src/commonMain/kotlin/asdo/ToDoSignUpDelivery.kt
@@ -1,3 +1,3 @@
 package asdo
 
-interface ToDoSignUpDelivery { suspend fun execute(email:String) }
+interface ToDoSignUpDelivery { suspend fun execute(email:String): Result<DoSignUpResult> }

--- a/app/composeApp/src/commonMain/kotlin/asdo/ToDoSignUpPlatformAdmin.kt
+++ b/app/composeApp/src/commonMain/kotlin/asdo/ToDoSignUpPlatformAdmin.kt
@@ -1,3 +1,3 @@
 package asdo
 
-interface ToDoSignUpPlatformAdmin { suspend fun execute(email:String) }
+interface ToDoSignUpPlatformAdmin { suspend fun execute(email:String): Result<DoSignUpResult> }

--- a/app/composeApp/src/commonMain/kotlin/asdo/ToDoSignUpSaler.kt
+++ b/app/composeApp/src/commonMain/kotlin/asdo/ToDoSignUpSaler.kt
@@ -1,3 +1,3 @@
 package asdo
 
-interface ToDoSignUpSaler { suspend fun execute(email:String) }
+interface ToDoSignUpSaler { suspend fun execute(email:String): Result<DoSignUpResult> }

--- a/app/composeApp/src/commonMain/kotlin/ext/ClientSignUpService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/ClientSignUpService.kt
@@ -4,18 +4,42 @@ import ar.com.intrale.BuildKonfig
 import io.ktor.client.HttpClient
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.isSuccess
 import io.ktor.utils.io.InternalAPI
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import ext.StatusCodeDTO
+import ext.ExceptionResponse
+import ext.toExceptionResponse
 
 class ClientSignUpService(private val httpClient: HttpClient) : CommSignUpService {
     @OptIn(InternalAPI::class)
-    override suspend fun execute(email: String) {
+    override suspend fun execute(email: String): Result<SignUpResponse> {
 
-        httpClient.post("${BuildKonfig.BASE_URL}${BuildKonfig.BUSINESS}/signup") {
-            setBody(SignUpRequest(email))
+        return try {
+            val response: HttpResponse = httpClient.post("${BuildKonfig.BASE_URL}${BuildKonfig.BUSINESS}/signup") {
+                setBody(SignUpRequest(email))
+            }
+
+            if (response.status.isSuccess()) {
+                Result.success(
+                    SignUpResponse(StatusCodeDTO(response.status.value, response.status.description))
+                )
+            } else {
+                val bodyText = response.bodyAsText()
+                val exception = Json.decodeFromString(ExceptionResponse.serializer(), bodyText)
+                Result.failure(exception)
+            }
+        } catch (e: Exception) {
+            Result.failure(e.toExceptionResponse())
         }
     }
 }
 
 @Serializable
 data class SignUpRequest(val email: String)
+
+@Serializable
+data class SignUpResponse(val statusCode: StatusCodeDTO)

--- a/app/composeApp/src/commonMain/kotlin/ext/CommSignUpService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/CommSignUpService.kt
@@ -1,5 +1,7 @@
 package ext
 
+import ext.SignUpResponse
+
 interface CommSignUpService {
-    suspend fun execute(email:String)
+    suspend fun execute(email:String): Result<SignUpResponse>
 }

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/Login.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/Login.kt
@@ -28,6 +28,7 @@ import ui.rs.Res
 import ui.rs.login
 import ui.rs.password
 import ui.rs.username
+import ui.rs.signup
 import io.ktor.client.plugins.ClientRequestException
 import org.kodein.log.LoggerFactory
 import org.kodein.log.newLogger

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/ServiceCaller.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/ServiceCaller.kt
@@ -1,0 +1,26 @@
+package ui.sc
+
+import androidx.compose.material3.SnackbarHostState
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+fun <T> callService(
+    coroutineScope: CoroutineScope,
+    snackbarHostState: SnackbarHostState,
+    setLoading: (Boolean) -> Unit,
+    serviceCall: suspend () -> Result<T>,
+    onSuccess: (T) -> Unit,
+    onError: suspend (Throwable) -> Unit = { snackbarHostState.showSnackbar(it.message ?: "Error") }
+) {
+    coroutineScope.launch {
+        setLoading(true)
+        val result = serviceCall()
+        result.onSuccess {
+            setLoading(false)
+            onSuccess(it)
+        }.onFailure { error ->
+            setLoading(false)
+            onError(error)
+        }
+    }
+}

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/SignUpDeliveryScreen.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/SignUpDeliveryScreen.kt
@@ -7,11 +7,15 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Scaffold
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.stringResource
@@ -20,6 +24,8 @@ import ui.cp.TextField
 import ui.rs.Res
 import ui.rs.email
 import ui.rs.signup_delivery
+import ui.sc.callService
+import LOGIN_PATH
 
 const val SIGNUP_DELIVERY_PATH = "/signupDelivery"
 
@@ -31,6 +37,9 @@ class SignUpDeliveryScreen : Screen(SIGNUP_DELIVERY_PATH, Res.string.signup_deli
     @Composable
     private fun screenImpl(viewModel: SignUpDeliveryViewModel = viewModel { SignUpDeliveryViewModel() }) {
         val coroutine = rememberCoroutineScope()
+        val snackbarHostState = remember { SnackbarHostState() }
+
+        Scaffold(snackbarHost = { SnackbarHost(snackbarHostState) }) {
         Column(
             Modifier
                 .fillMaxWidth()
@@ -51,9 +60,16 @@ class SignUpDeliveryScreen : Screen(SIGNUP_DELIVERY_PATH, Res.string.signup_deli
                 enabled = !viewModel.loading,
                 onClick =  {
                 if (viewModel.isValid()) {
-                    coroutine.launch { viewModel.signup() }
+                    callService(
+                        coroutineScope = coroutine,
+                        snackbarHostState = snackbarHostState,
+                        setLoading = { viewModel.loading = it },
+                        serviceCall = { viewModel.signup() },
+                        onSuccess = { navigate(LOGIN_PATH) }
+                    )
                 }
             })
+        }
         }
     }
 }

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/SignUpDeliveryViewModel.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/SignUpDeliveryViewModel.kt
@@ -1,6 +1,7 @@
 package ui.sc
 
 import DIManager
+import asdo.DoSignUpResult
 import asdo.ToDoSignUpDelivery
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -30,7 +31,6 @@ class SignUpDeliveryViewModel : ViewModel() {
         inputsStates = mutableMapOf(entry(SignUpUIState::email.name))
     }
 
-    suspend fun signup() {
+    suspend fun signup(): Result<DoSignUpResult> =
         toDoSignUp.execute(state.email)
-    }
 }

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/SignUpPlatformAdminScreen.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/SignUpPlatformAdminScreen.kt
@@ -7,11 +7,15 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Scaffold
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.stringResource
@@ -20,6 +24,8 @@ import ui.cp.TextField
 import ui.rs.Res
 import ui.rs.email
 import ui.rs.signup_platform_admin
+import ui.sc.callService
+import LOGIN_PATH
 
 const val SIGNUP_PLATFORM_ADMIN_PATH = "/signupPlatformAdmin"
 
@@ -31,6 +37,9 @@ class SignUpPlatformAdminScreen : Screen(SIGNUP_PLATFORM_ADMIN_PATH, Res.string.
     @Composable
     private fun screenImpl(viewModel: SignUpPlatformAdminViewModel = viewModel { SignUpPlatformAdminViewModel() }) {
         val coroutine = rememberCoroutineScope()
+        val snackbarHostState = remember { SnackbarHostState() }
+
+        Scaffold(snackbarHost = { SnackbarHost(snackbarHostState) }) {
         Column(
             Modifier
                 .fillMaxWidth()
@@ -50,9 +59,16 @@ class SignUpPlatformAdminScreen : Screen(SIGNUP_PLATFORM_ADMIN_PATH, Res.string.
                 enabled = !viewModel.loading,
                 onClick =  {
                 if (viewModel.isValid()) {
-                    coroutine.launch { viewModel.signup() }
+                    callService(
+                        coroutineScope = coroutine,
+                        snackbarHostState = snackbarHostState,
+                        setLoading = { viewModel.loading = it },
+                        serviceCall = { viewModel.signup() },
+                        onSuccess = { navigate(LOGIN_PATH) }
+                    )
                 }
             })
+        }
         }
     }
 }

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/SignUpPlatformAdminViewModel.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/SignUpPlatformAdminViewModel.kt
@@ -1,6 +1,7 @@
 package ui.sc
 
 import DIManager
+import asdo.DoSignUpResult
 import asdo.ToDoSignUpPlatformAdmin
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -30,7 +31,6 @@ class SignUpPlatformAdminViewModel : ViewModel() {
         inputsStates = mutableMapOf(entry(SignUpUIState::email.name))
     }
 
-    suspend fun signup() {
+    suspend fun signup(): Result<DoSignUpResult> =
         toDoSignUp.execute(state.email)
-    }
 }

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/SignUpSalerScreen.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/SignUpSalerScreen.kt
@@ -7,11 +7,15 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Scaffold
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.stringResource
@@ -20,6 +24,8 @@ import ui.cp.TextField
 import ui.rs.Res
 import ui.rs.email
 import ui.rs.signup_saler
+import ui.sc.callService
+import LOGIN_PATH
 
 const val SIGNUP_SALER_PATH = "/signupSaler"
 
@@ -31,6 +37,9 @@ class SignUpSalerScreen : Screen(SIGNUP_SALER_PATH, Res.string.signup_saler) {
     @Composable
     private fun screenImpl(viewModel: SignUpSalerViewModel = viewModel { SignUpSalerViewModel() }) {
         val coroutine = rememberCoroutineScope()
+        val snackbarHostState = remember { SnackbarHostState() }
+
+        Scaffold(snackbarHost = { SnackbarHost(snackbarHostState) }) {
         Column(
             Modifier
                 .fillMaxWidth()
@@ -50,9 +59,16 @@ class SignUpSalerScreen : Screen(SIGNUP_SALER_PATH, Res.string.signup_saler) {
                 enabled = !viewModel.loading,
                 onClick =  {
                 if (viewModel.isValid()) {
-                    coroutine.launch { viewModel.signup() }
+                    callService(
+                        coroutineScope = coroutine,
+                        snackbarHostState = snackbarHostState,
+                        setLoading = { viewModel.loading = it },
+                        serviceCall = { viewModel.signup() },
+                        onSuccess = { navigate(LOGIN_PATH) }
+                    )
                 }
             })
+        }
         }
     }
 }

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/SignUpSalerViewModel.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/SignUpSalerViewModel.kt
@@ -1,6 +1,7 @@
 package ui.sc
 
 import DIManager
+import asdo.DoSignUpResult
 import asdo.ToDoSignUpSaler
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -30,7 +31,6 @@ class SignUpSalerViewModel : ViewModel() {
         inputsStates = mutableMapOf(entry(SignUpUIState::email.name))
     }
 
-    suspend fun signup() {
+    suspend fun signup(): Result<DoSignUpResult> =
         toDoSignUp.execute(state.email)
-    }
 }

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/SignUpScreen.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/SignUpScreen.kt
@@ -7,11 +7,15 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Scaffold
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.stringResource
@@ -20,6 +24,8 @@ import ui.cp.TextField
 import ui.rs.Res
 import ui.rs.email
 import ui.rs.signup
+import ui.sc.callService
+import LOGIN_PATH
 
 const val SIGNUP_PATH = "/signup"
 
@@ -31,6 +37,9 @@ class SignUpScreen : Screen(SIGNUP_PATH, Res.string.signup) {
     @Composable
     private fun screenImpl(viewModel: SignUpViewModel = viewModel { SignUpViewModel() }) {
         val coroutine = rememberCoroutineScope()
+        val snackbarHostState = remember { SnackbarHostState() }
+
+        Scaffold(snackbarHost = { SnackbarHost(snackbarHostState) }) {
         Column(
             Modifier
                 .fillMaxWidth()
@@ -50,9 +59,16 @@ class SignUpScreen : Screen(SIGNUP_PATH, Res.string.signup) {
                 enabled = !viewModel.loading,
                 onClick = {
                 if (viewModel.isValid()) {
-                    coroutine.launch { viewModel.signup() }
+                    callService(
+                        coroutineScope = coroutine,
+                        snackbarHostState = snackbarHostState,
+                        setLoading = { viewModel.loading = it },
+                        serviceCall = { viewModel.signup() },
+                        onSuccess = { navigate(LOGIN_PATH) }
+                    )
                 }
             })
+        }
         }
     }
 }

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/SignUpViewModel.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/SignUpViewModel.kt
@@ -4,6 +4,7 @@ import DIManager
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import asdo.DoSignUpResult
 import asdo.ToDoSignUp
 import io.konform.validation.Validation
 import io.konform.validation.jsonschema.pattern
@@ -30,7 +31,6 @@ class SignUpViewModel : ViewModel() {
         inputsStates = mutableMapOf(entry(SignUpUIState::email.name))
     }
 
-    suspend fun signup() {
+    suspend fun signup(): Result<DoSignUpResult> =
         toDoSignUp.execute(state.email)
-    }
 }

--- a/docs/signup-por-perfil.md
+++ b/docs/signup-por-perfil.md
@@ -15,3 +15,7 @@ Relacionado con #75.
 Se agregó la pantalla `SelectSignUpProfileScreen` que permite elegir el tipo de registro antes de mostrar la pantalla específica.
 Desde `Login` ahora aparece el botón **"Registrarme"** que navega a dicha pantalla.
 Cada opción lleva a `SignUpPlatformAdminScreen`, `SignUpDeliveryScreen` o `SignUpSalerScreen` según corresponda.
+
+### Manejo de respuestas
+Ahora cada pantalla de registro utiliza `callService` para mostrar mensajes de éxito o error.
+Los `ViewModel` devuelven `Result<DoSignUpResult>` permitiendo feedback consistente con el login.


### PR DESCRIPTION
Se implementó el manejo de resultados en todas las pantallas de registro.
- Se agregaron `DoSignUpResult` y excepciones asociadas.
- `CommSignUpService` y `ClientSignUpService` ahora retornan `Result` con `SignUpResponse`.
- Se actualizó cada `ViewModel` y pantalla de registro para usar `callService`.
- Documentación actualizada.

Closes #124

------
https://chatgpt.com/codex/tasks/task_e_68829a290780832598e63baf232e1742