### PR TITLE
[auto] agrega pruebas de servicios signup

### DIFF
--- a/app/composeApp/src/commonMain/kotlin/ui/sc/SignUpDeliveryViewModel.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/SignUpDeliveryViewModel.kt
@@ -11,7 +11,7 @@ import io.konform.validation.jsonschema.pattern
 import org.kodein.di.instance
 
 class SignUpDeliveryViewModel : ViewModel() {
-    private val toDoSignUp: ToDoSignUpDelivery by DIManager.di.instance()
+    private val toDoSignUpDelivery: ToDoSignUpDelivery by DIManager.di.instance()
 
     var state by mutableStateOf(SignUpUIState())
     var loading by mutableStateOf(false)
@@ -32,5 +32,5 @@ class SignUpDeliveryViewModel : ViewModel() {
     }
 
     suspend fun signup(): Result<DoSignUpResult> =
-        toDoSignUp.execute(state.email)
+        toDoSignUpDelivery.execute(state.email)
 }

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/SignUpPlatformAdminViewModel.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/SignUpPlatformAdminViewModel.kt
@@ -11,7 +11,7 @@ import io.konform.validation.jsonschema.pattern
 import org.kodein.di.instance
 
 class SignUpPlatformAdminViewModel : ViewModel() {
-    private val toDoSignUp: ToDoSignUpPlatformAdmin by DIManager.di.instance()
+    private val toDoSignUpPlatformAdmin: ToDoSignUpPlatformAdmin by DIManager.di.instance()
 
     var state by mutableStateOf(SignUpUIState())
     var loading by mutableStateOf(false)
@@ -32,5 +32,5 @@ class SignUpPlatformAdminViewModel : ViewModel() {
     }
 
     suspend fun signup(): Result<DoSignUpResult> =
-        toDoSignUp.execute(state.email)
+        toDoSignUpPlatformAdmin.execute(state.email)
 }

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/SignUpSalerViewModel.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/SignUpSalerViewModel.kt
@@ -11,7 +11,7 @@ import io.konform.validation.jsonschema.pattern
 import org.kodein.di.instance
 
 class SignUpSalerViewModel : ViewModel() {
-    private val toDoSignUp: ToDoSignUpSaler by DIManager.di.instance()
+    private val toDoSignUpSaler: ToDoSignUpSaler by DIManager.di.instance()
 
     var state by mutableStateOf(SignUpUIState())
     var loading by mutableStateOf(false)
@@ -32,5 +32,5 @@ class SignUpSalerViewModel : ViewModel() {
     }
 
     suspend fun signup(): Result<DoSignUpResult> =
-        toDoSignUp.execute(state.email)
+        toDoSignUpSaler.execute(state.email)
 }

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/SignUpViewModel.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/SignUpViewModel.kt
@@ -11,7 +11,7 @@ import io.konform.validation.jsonschema.pattern
 import org.kodein.di.instance
 
 class SignUpViewModel : ViewModel() {
-    private val toDoSignUp: ToDoSignUp by DIManager.di.instance()
+    private val toDoSignUpGeneric: ToDoSignUp by DIManager.di.instance()
 
     var state by mutableStateOf(SignUpUIState())
     var loading by mutableStateOf(false)
@@ -32,5 +32,5 @@ class SignUpViewModel : ViewModel() {
     }
 
     suspend fun signup(): Result<DoSignUpResult> =
-        toDoSignUp.execute(state.email)
+        toDoSignUpGeneric.execute(state.email)
 }

--- a/app/composeApp/src/commonTest/kotlin/ar/com/intrale/SignUpViewModelsTest.kt
+++ b/app/composeApp/src/commonTest/kotlin/ar/com/intrale/SignUpViewModelsTest.kt
@@ -1,0 +1,89 @@
+package ar.com.intrale
+
+import DIManager
+import asdo.*
+import kotlinx.coroutines.runBlocking
+import org.kodein.di.DI
+import org.kodein.di.bindSingleton
+import ui.sc.SignUpDeliveryViewModel
+import ui.sc.SignUpPlatformAdminViewModel
+import ui.sc.SignUpSalerViewModel
+import ui.sc.SignUpViewModel
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class SignUpViewModelsTest {
+
+    private class FakePlatformAdminSignUp : ToDoSignUpPlatformAdmin {
+        var executed = false
+        override suspend fun execute(email: String): Result<DoSignUpResult> {
+            executed = true
+            return Result.success(DoSignUpResult(SignUpStatusCode(200, null)))
+        }
+    }
+
+    private class FakeDeliverySignUp : ToDoSignUpDelivery {
+        var executed = false
+        override suspend fun execute(email: String): Result<DoSignUpResult> {
+            executed = true
+            return Result.success(DoSignUpResult(SignUpStatusCode(200, null)))
+        }
+    }
+
+    private class FakeSalerSignUp : ToDoSignUpSaler {
+        var executed = false
+        override suspend fun execute(email: String): Result<DoSignUpResult> {
+            executed = true
+            return Result.success(DoSignUpResult(SignUpStatusCode(200, null)))
+        }
+    }
+
+    private class FakeSignUp : ToDoSignUp {
+        var executed = false
+        override suspend fun execute(email: String): Result<DoSignUpResult> {
+            executed = true
+            return Result.success(DoSignUpResult(SignUpStatusCode(200, null)))
+        }
+    }
+
+    @Test
+    fun signupPlatformAdminInvokesService() = runBlocking {
+        val fake = FakePlatformAdminSignUp()
+        DIManager.di = DI { bindSingleton<ToDoSignUpPlatformAdmin> { fake } }
+        val vm = SignUpPlatformAdminViewModel()
+        vm.state = SignUpPlatformAdminViewModel.SignUpUIState("test@example.com")
+        vm.signup()
+        assertTrue(fake.executed)
+    }
+
+    @Test
+    fun signupDeliveryInvokesService() = runBlocking {
+        val fake = FakeDeliverySignUp()
+        DIManager.di = DI { bindSingleton<ToDoSignUpDelivery> { fake } }
+        val vm = SignUpDeliveryViewModel()
+        vm.state = SignUpDeliveryViewModel.SignUpUIState("test@example.com")
+        vm.signup()
+        assertTrue(fake.executed)
+    }
+
+    @Test
+    fun signupSalerInvokesService() = runBlocking {
+        val fake = FakeSalerSignUp()
+        DIManager.di = DI { bindSingleton<ToDoSignUpSaler> { fake } }
+        val vm = SignUpSalerViewModel()
+        vm.state = SignUpSalerViewModel.SignUpUIState("test@example.com")
+        vm.signup()
+        assertTrue(fake.executed)
+    }
+
+    @Test
+    fun signupGenericInvokesService() = runBlocking {
+        val fake = FakeSignUp()
+        DIManager.di = DI { bindSingleton<ToDoSignUp> { fake } }
+        val vm = SignUpViewModel()
+        vm.state = SignUpViewModel.SignUpUIState("test@example.com")
+        vm.signup()
+        assertTrue(fake.executed)
+    }
+}
+


### PR DESCRIPTION
Se actualizan los view models de registro para hacer explícita la inyección de cada `ToDoSignUp` específico y se mantienen las pruebas unitarias para validar la invocación correcta de los servicios.

Closes #126

------
https://chatgpt.com/codex/tasks/task_e_6882b4588d2083259f3f509e8325af9c