### PR TITLE
[auto] Ajuste servicios de registro por perfil

### DIFF
--- a/app/composeApp/src/commonMain/kotlin/DIManager.kt
+++ b/app/composeApp/src/commonMain/kotlin/DIManager.kt
@@ -96,6 +96,9 @@ class DIManager {
                 bindSingleton<CommKeyValueStorage> { KeyValueStorageService() }
                 bindSingleton<CommLoginService> { ClientLoginService(instance()) }
                 bindSingleton<CommSignUpService> { ClientSignUpService(instance()) }
+                bindSingleton<CommSignUpPlatformAdminService> { ClientSignUpPlatformAdminService(instance()) }
+                bindSingleton<CommSignUpDeliveryService> { ClientSignUpDeliveryService(instance()) }
+                bindSingleton<CommSignUpSalerService> { ClientSignUpSalerService(instance()) }
 
                 bindSingleton<ToDoLogin> { DoLogin(instance(), instance()) }
                 bindSingleton<ToDoSignUp> { DoSignUp(instance()) }

--- a/app/composeApp/src/commonMain/kotlin/asdo/DoSignUpDelivery.kt
+++ b/app/composeApp/src/commonMain/kotlin/asdo/DoSignUpDelivery.kt
@@ -1,9 +1,9 @@
 package asdo
 
-import ext.CommSignUpService
+import ext.CommSignUpDeliveryService
 import ext.ExceptionResponse
 
-class DoSignUpDelivery(private val service: CommSignUpService) : ToDoSignUpDelivery {
+class DoSignUpDelivery(private val service: CommSignUpDeliveryService) : ToDoSignUpDelivery {
     override suspend fun execute(email: String): Result<DoSignUpResult> {
         return try {
             service.execute(/*"signupDelivery",*/ email).fold(

--- a/app/composeApp/src/commonMain/kotlin/asdo/DoSignUpPlatformAdmin.kt
+++ b/app/composeApp/src/commonMain/kotlin/asdo/DoSignUpPlatformAdmin.kt
@@ -1,9 +1,9 @@
 package asdo
 
-import ext.CommSignUpService
+import ext.CommSignUpPlatformAdminService
 import ext.ExceptionResponse
 
-class DoSignUpPlatformAdmin(private val service: CommSignUpService) : ToDoSignUpPlatformAdmin {
+class DoSignUpPlatformAdmin(private val service: CommSignUpPlatformAdminService) : ToDoSignUpPlatformAdmin {
     override suspend fun execute(email: String): Result<DoSignUpResult> {
         return try {
             service.execute(/*"signupPlatformAdmin",*/ email).fold(

--- a/app/composeApp/src/commonMain/kotlin/asdo/DoSignUpSaler.kt
+++ b/app/composeApp/src/commonMain/kotlin/asdo/DoSignUpSaler.kt
@@ -1,9 +1,9 @@
 package asdo
 
-import ext.CommSignUpService
+import ext.CommSignUpSalerService
 import ext.ExceptionResponse
 
-class DoSignUpSaler(private val service: CommSignUpService) : ToDoSignUpSaler {
+class DoSignUpSaler(private val service: CommSignUpSalerService) : ToDoSignUpSaler {
     override suspend fun execute(email: String): Result<DoSignUpResult> {
         return try {
             service.execute(/*"signupSaler",*/ email).fold(

--- a/app/composeApp/src/commonMain/kotlin/ext/ClientSignUpDeliveryService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/ClientSignUpDeliveryService.kt
@@ -1,0 +1,33 @@
+package ext
+
+import ar.com.intrale.BuildKonfig
+import io.ktor.client.HttpClient
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.isSuccess
+import io.ktor.utils.io.InternalAPI
+import kotlinx.serialization.json.Json
+
+class ClientSignUpDeliveryService(private val httpClient: HttpClient) : CommSignUpDeliveryService {
+    @OptIn(InternalAPI::class)
+    override suspend fun execute(email: String): Result<SignUpResponse> {
+        return try {
+            val response: HttpResponse = httpClient.post("${BuildKonfig.BASE_URL}${BuildKonfig.BUSINESS}/signupDelivery") {
+                setBody(SignUpRequest(email))
+            }
+            if (response.status.isSuccess()) {
+                Result.success(
+                    SignUpResponse(StatusCodeDTO(response.status.value, response.status.description))
+                )
+            } else {
+                val bodyText = response.bodyAsText()
+                val exception = Json.decodeFromString(ExceptionResponse.serializer(), bodyText)
+                Result.failure(exception)
+            }
+        } catch (e: Exception) {
+            Result.failure(e.toExceptionResponse())
+        }
+    }
+}

--- a/app/composeApp/src/commonMain/kotlin/ext/ClientSignUpPlatformAdminService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/ClientSignUpPlatformAdminService.kt
@@ -1,0 +1,33 @@
+package ext
+
+import ar.com.intrale.BuildKonfig
+import io.ktor.client.HttpClient
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.isSuccess
+import io.ktor.utils.io.InternalAPI
+import kotlinx.serialization.json.Json
+
+class ClientSignUpPlatformAdminService(private val httpClient: HttpClient) : CommSignUpPlatformAdminService {
+    @OptIn(InternalAPI::class)
+    override suspend fun execute(email: String): Result<SignUpResponse> {
+        return try {
+            val response: HttpResponse = httpClient.post("${BuildKonfig.BASE_URL}${BuildKonfig.BUSINESS}/signupPlatformAdmin") {
+                setBody(SignUpRequest(email))
+            }
+            if (response.status.isSuccess()) {
+                Result.success(
+                    SignUpResponse(StatusCodeDTO(response.status.value, response.status.description))
+                )
+            } else {
+                val bodyText = response.bodyAsText()
+                val exception = Json.decodeFromString(ExceptionResponse.serializer(), bodyText)
+                Result.failure(exception)
+            }
+        } catch (e: Exception) {
+            Result.failure(e.toExceptionResponse())
+        }
+    }
+}

--- a/app/composeApp/src/commonMain/kotlin/ext/ClientSignUpSalerService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/ClientSignUpSalerService.kt
@@ -1,0 +1,33 @@
+package ext
+
+import ar.com.intrale.BuildKonfig
+import io.ktor.client.HttpClient
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.isSuccess
+import io.ktor.utils.io.InternalAPI
+import kotlinx.serialization.json.Json
+
+class ClientSignUpSalerService(private val httpClient: HttpClient) : CommSignUpSalerService {
+    @OptIn(InternalAPI::class)
+    override suspend fun execute(email: String): Result<SignUpResponse> {
+        return try {
+            val response: HttpResponse = httpClient.post("${BuildKonfig.BASE_URL}${BuildKonfig.BUSINESS}/signupSaler") {
+                setBody(SignUpRequest(email))
+            }
+            if (response.status.isSuccess()) {
+                Result.success(
+                    SignUpResponse(StatusCodeDTO(response.status.value, response.status.description))
+                )
+            } else {
+                val bodyText = response.bodyAsText()
+                val exception = Json.decodeFromString(ExceptionResponse.serializer(), bodyText)
+                Result.failure(exception)
+            }
+        } catch (e: Exception) {
+            Result.failure(e.toExceptionResponse())
+        }
+    }
+}

--- a/app/composeApp/src/commonMain/kotlin/ext/CommSignUpDeliveryService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/CommSignUpDeliveryService.kt
@@ -1,0 +1,5 @@
+package ext
+
+interface CommSignUpDeliveryService {
+    suspend fun execute(email: String): Result<SignUpResponse>
+}

--- a/app/composeApp/src/commonMain/kotlin/ext/CommSignUpPlatformAdminService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/CommSignUpPlatformAdminService.kt
@@ -1,0 +1,5 @@
+package ext
+
+interface CommSignUpPlatformAdminService {
+    suspend fun execute(email: String): Result<SignUpResponse>
+}

--- a/app/composeApp/src/commonMain/kotlin/ext/CommSignUpSalerService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/CommSignUpSalerService.kt
@@ -1,0 +1,5 @@
+package ext
+
+interface CommSignUpSalerService {
+    suspend fun execute(email: String): Result<SignUpResponse>
+}

--- a/docs/signup-por-perfil.md
+++ b/docs/signup-por-perfil.md
@@ -7,6 +7,9 @@ Cada una muestra un campo para ingresar el correo electrónico y un botón **"Re
 
 Al presionar el botón se invoca la acción correspondiente del paquete `asdo`,
 la cual consume los endpoints expuestos por el módulo `users`.
+Cada acción utiliza un servicio HTTP específico:
+`ClientSignUpPlatformAdminService`, `ClientSignUpDeliveryService` y
+`ClientSignUpSalerService` según el perfil seleccionado.
 
 ## Flujo de selección de perfil
 


### PR DESCRIPTION
Se implementaron servicios HTTP específicos para cada tipo de registro y se actualizó la inyección de dependencias.

Closes #128

------
https://chatgpt.com/codex/tasks/task_e_6884075560a08325948d1d057215827c