### PR TITLE
[auto] Manejo de errores Do y doc

### DIFF
--- a/app/composeApp/src/commonMain/kotlin/asdo/DoLogin.kt
+++ b/app/composeApp/src/commonMain/kotlin/asdo/DoLogin.kt
@@ -32,7 +32,8 @@ class DoLogin(val commLogin: CommLoginService, val commKeyValueStorage: CommKeyV
 
                             .recoverCatching { e ->
                                 logger.error { "recoverCatching Error during login: ${e.message}" }
-                                throw (e as ExceptionResponse).toDoLoginException()
+                                throw (e as? ExceptionResponse)?.toDoLoginException()
+                                    ?: e.toDoLoginException()
                              }
             }
             return Result.success(commKeyValueStorage.toDoLoginResult())

--- a/app/composeApp/src/commonMain/kotlin/asdo/DoSignUp.kt
+++ b/app/composeApp/src/commonMain/kotlin/asdo/DoSignUp.kt
@@ -7,14 +7,12 @@ import ext.SignUpResponse
 class DoSignUp(private val service: CommSignUpService) : ToDoSignUp {
     override suspend fun execute(email: String): Result<DoSignUpResult> {
         return try {
-            service.execute(email).fold(
-                onSuccess = { Result.success(it.toDoSignUpResult()) },
-                onFailure = { error ->
-                    Result.failure(
-                        (error as? ExceptionResponse)?.toDoSignUpException() ?: (error as Exception).toDoSignUpException()
-                    )
+            service.execute(email)
+                .mapCatching { it.toDoSignUpResult() }
+                .recoverCatching { e ->
+                    throw (e as? ExceptionResponse)?.toDoSignUpException()
+                        ?: e.toDoSignUpException()
                 }
-            )
         } catch (e: Exception) {
             Result.failure(e.toDoSignUpException())
         }

--- a/app/composeApp/src/commonMain/kotlin/asdo/DoSignUpDelivery.kt
+++ b/app/composeApp/src/commonMain/kotlin/asdo/DoSignUpDelivery.kt
@@ -6,14 +6,12 @@ import ext.ExceptionResponse
 class DoSignUpDelivery(private val service: CommSignUpDeliveryService) : ToDoSignUpDelivery {
     override suspend fun execute(email: String): Result<DoSignUpResult> {
         return try {
-            service.execute(/*"signupDelivery",*/ email).fold(
-                onSuccess = { Result.success(it.toDoSignUpResult()) },
-                onFailure = { error ->
-                    Result.failure(
-                        (error as? ExceptionResponse)?.toDoSignUpException() ?: (error as Exception).toDoSignUpException()
-                    )
+            service.execute(/*"signupDelivery",*/ email)
+                .mapCatching { it.toDoSignUpResult() }
+                .recoverCatching { e ->
+                    throw (e as? ExceptionResponse)?.toDoSignUpException()
+                        ?: e.toDoSignUpException()
                 }
-            )
         } catch (e: Exception) {
             Result.failure(e.toDoSignUpException())
         }

--- a/app/composeApp/src/commonMain/kotlin/asdo/DoSignUpPlatformAdmin.kt
+++ b/app/composeApp/src/commonMain/kotlin/asdo/DoSignUpPlatformAdmin.kt
@@ -6,14 +6,12 @@ import ext.ExceptionResponse
 class DoSignUpPlatformAdmin(private val service: CommSignUpPlatformAdminService) : ToDoSignUpPlatformAdmin {
     override suspend fun execute(email: String): Result<DoSignUpResult> {
         return try {
-            service.execute(/*"signupPlatformAdmin",*/ email).fold(
-                onSuccess = { Result.success(it.toDoSignUpResult()) },
-                onFailure = { error ->
-                    Result.failure(
-                        (error as? ExceptionResponse)?.toDoSignUpException() ?: (error as Exception).toDoSignUpException()
-                    )
+            service.execute(/*"signupPlatformAdmin",*/ email)
+                .mapCatching { it.toDoSignUpResult() }
+                .recoverCatching { e ->
+                    throw (e as? ExceptionResponse)?.toDoSignUpException()
+                        ?: e.toDoSignUpException()
                 }
-            )
         } catch (e: Exception) {
             Result.failure(e.toDoSignUpException())
         }

--- a/app/composeApp/src/commonMain/kotlin/asdo/DoSignUpSaler.kt
+++ b/app/composeApp/src/commonMain/kotlin/asdo/DoSignUpSaler.kt
@@ -6,14 +6,12 @@ import ext.ExceptionResponse
 class DoSignUpSaler(private val service: CommSignUpSalerService) : ToDoSignUpSaler {
     override suspend fun execute(email: String): Result<DoSignUpResult> {
         return try {
-            service.execute(/*"signupSaler",*/ email).fold(
-                onSuccess = { Result.success(it.toDoSignUpResult()) },
-                onFailure = { error ->
-                    Result.failure(
-                        (error as? ExceptionResponse)?.toDoSignUpException() ?: (error as Exception).toDoSignUpException()
-                    )
+            service.execute(/*"signupSaler",*/ email)
+                .mapCatching { it.toDoSignUpResult() }
+                .recoverCatching { e ->
+                    throw (e as? ExceptionResponse)?.toDoSignUpException()
+                        ?: e.toDoSignUpException()
                 }
-            )
         } catch (e: Exception) {
             Result.failure(e.toDoSignUpException())
         }

--- a/docs/manejo-errores-do.md
+++ b/docs/manejo-errores-do.md
@@ -1,0 +1,29 @@
+# Estándar de Manejo de Errores en Clases `Do[Nombre]`
+
+Este documento describe el patrón recomendado para el manejo de excepciones en las clases `Do[...]` del módulo `app`.
+
+## Patrón recomendado
+
+Las implementaciones deben envolver la ejecución del servicio en un bloque `try` y utilizar `mapCatching` junto con `recoverCatching` para transformar resultados y propagar errores de manera uniforme.
+
+```kotlin
+override suspend fun execute(...): Result<DoXXXResult> {
+    return try {
+        service.execute(...)
+            .mapCatching { it.toDoXXXResult() }
+            .recoverCatching { e ->
+                throw (e as? ExceptionResponse)?.toDoXXXException()
+                    ?: e.toDoXXXException()
+            }
+    } catch (e: Exception) {
+        Result.failure(e.toDoXXXException())
+    }
+}
+```
+
+### Beneficios
+- Trazabilidad de fallos consistente.
+- Propagación segura de excepciones de dominio.
+- Mayor claridad en las pruebas de casos fallidos.
+
+Relacionado con #130


### PR DESCRIPTION
## Resumen
- refactorizar clases DoSignUp* para uso de mapCatching/recoverCatching
- ajustar cast defensivo en DoLogin
- agregar guia de manejo de errores en docs

Closes #130

------
https://chatgpt.com/codex/tasks/task_e_6887c972e0348325923b562b0303fb93