### PR TITLE
[auto] Rediseño relación usuarios-perfiles

### DIFF
--- a/docs/arquitectura-users.md
+++ b/docs/arquitectura-users.md
@@ -17,6 +17,7 @@ Gestiona el ciclo de vida de los usuarios finales: registro, autenticación y ad
 ## 3. Funcionalidades implementadas
 
 - Registro e inicio de sesión de usuarios mediante Cognito.
+- Persistencia de la relación usuario-negocio-perfil en la tabla `userbusinessprofile`.
 - Recuperación y confirmación de contraseña.
 - Registro y revisión de negocios asociados.
 - Configuración y verificación de autenticación en dos pasos.

--- a/users/src/main/kotlin/ar/com/intrale/Modules.kt
+++ b/users/src/main/kotlin/ar/com/intrale/Modules.kt
@@ -126,19 +126,19 @@ val appModule = DI.Module("appModule") {
     }
 
     bind<Function> (tag="signup") {
-        singleton  { SignUp(instance(), instance(), instance()) }
+        singleton  { SignUp(instance(), instance(), instance(), instance()) }
     }
     bind<Function> (tag="signupPlatformAdmin") {
-        singleton  { SignUpPlatformAdmin(instance(), instance(), instance()) }
+        singleton  { SignUpPlatformAdmin(instance(), instance(), instance(), instance()) }
     }
     bind<Function> (tag="signupDelivery") {
-        singleton  { SignUpDelivery(instance(), instance(), instance()) }
-    }    
+        singleton  { SignUpDelivery(instance(), instance(), instance(), instance()) }
+    }
     bind<Function> (tag="signupSaler") {
-        singleton  { SignUpSaler(instance(), instance(), instance()) }
+        singleton  { SignUpSaler(instance(), instance(), instance(), instance()) }
     }
     bind<Function> (tag="signin") {
-        singleton {  SignIn(instance(), instance(), instance()) }
+        singleton {  SignIn(instance(), instance(), instance(), instance()) }
     }
     bind<Function> (tag="validate") {
         singleton {  Validate(instance(), instance()) }
@@ -179,6 +179,6 @@ val appModule = DI.Module("appModule") {
         singleton { ReviewJoinBusiness(instance(), instance(), instance(), instance()) }
     }
     bind<Function> (tag="configAutoAcceptDeliveries") {
-        singleton { ConfigAutoAcceptDeliveries(instance(), instance(), instance(), instance()) }
+        singleton { ConfigAutoAcceptDeliveries(instance(), instance(), instance(), instance(), instance()) }
     }
 }

--- a/users/src/main/kotlin/ar/com/intrale/ReviewBusinessRegistration.kt
+++ b/users/src/main/kotlin/ar/com/intrale/ReviewBusinessRegistration.kt
@@ -73,11 +73,12 @@ class ReviewBusinessRegistration (val config: UsersConfig, val logger: Logger,
 
             logger.debug("trying to get user $responseCognito")
             val email = responseCognito.userAttributes?.firstOrNull { it.name == EMAIL_ATT_NAME }?.value
-            val profile = responseCognito.userAttributes?.firstOrNull { it.name == PROFILE_ATT_NAME }?.value
-
-            if (PLATFORM_ADMIN_PROFILE != profile) {
+            if (email == null) {
                 return UnauthorizedException()
             }
+            val adminProfile = tableProfiles.scan().items().firstOrNull {
+                it.email == email && it.business == business && it.profile == PLATFORM_ADMIN_PROFILE && it.state == BusinessState.APPROVED
+            } ?: return UnauthorizedException()
 
             // Validar el segundo factor para ese usuario
             logger.debug("checking Two Factor")

--- a/users/src/main/kotlin/ar/com/intrale/SignUp.kt
+++ b/users/src/main/kotlin/ar/com/intrale/SignUp.kt
@@ -7,13 +7,19 @@ import io.konform.validation.Validation
 import io.konform.validation.ValidationResult
 import io.konform.validation.jsonschema.pattern
 import org.slf4j.Logger
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable
 
 const val PROFILE_ATT_NAME = "profile"
 const val BUSINESS_ATT_NAME = "locale"
 const val EMAIL_ATT_NAME = "email"
 const val DEFAULT_PROFILE = "DEFAULT"
 
-open class SignUp (open val config: UsersConfig, open val logger: Logger, open val cognito: CognitoIdentityProviderClient): Function {
+open class SignUp (
+    open val config: UsersConfig,
+    open val logger: Logger,
+    open val cognito: CognitoIdentityProviderClient,
+    private val tableProfiles: DynamoDbTable<UserBusinessProfile>
+) : Function {
 
     open fun getProfile() : String {
         return DEFAULT_PROFILE
@@ -47,14 +53,6 @@ open class SignUp (open val config: UsersConfig, open val logger: Logger, open v
                 this.name = EMAIL_ATT_NAME
                 this.value = email
             })
-            attrs.add(AttributeType {
-                this.name = PROFILE_ATT_NAME
-                this.value = getProfile()
-            })
-            attrs.add(AttributeType {
-                this.name = BUSINESS_ATT_NAME
-                this.value = business
-            })
 
             try {
                 logger.info("Call to Cognito to create user with email $email")
@@ -65,35 +63,19 @@ open class SignUp (open val config: UsersConfig, open val logger: Logger, open v
                                 userAttributes = attrs
                             })
             } catch (e:UsernameExistsException) {
-                // Obtenemos la informacion del usuario
-                logger.info("Obtenemos la informacion del usuario")
-                val user = cognito.adminGetUser(AdminGetUserRequest {
-                    userPoolId = config.awsCognitoUserPoolId
-                    username = body.email
-                })
-                val businesses = user.userAttributes?.find { it.name == BUSINESS_ATT_NAME }?.value
-                logger.info("businesses: $businesses")
-                if (businesses?.contains(business) == true){
-                    return ExceptionResponse(e.message ?: "Internal Server Error")
-                }
-
-                logger.debug("Actualizamos el usuario con el nuevo negocio")
-                //Actualizamos la informacion de negocio para el usuario
-                val updateUserAttributesResponse = cognito.adminUpdateUserAttributes (
-                    AdminUpdateUserAttributesRequest {
-                        userPoolId = config.awsCognitoUserPoolId
-                        username = body.email
-                        userAttributes = listOf(
-                            AttributeType {
-                                name = BUSINESS_ATT_NAME
-                                value = businesses + "," + business
-                            }
-                        )
-                    })
+                logger.info("Usuario ya existe, se omitirá creación en Cognito")
             } catch (e:Exception) {
                 logger.error("Error creating user", e)
                 return ExceptionResponse(e.message ?: "Internal Server Error")
             }
+
+            val userProfile = UserBusinessProfile().apply {
+                this.email = email
+                this.business = business
+                this.profile = getProfile()
+                this.state = BusinessState.APPROVED
+            }
+            tableProfiles.putItem(userProfile)
 
             return Response()
         }

--- a/users/src/main/kotlin/ar/com/intrale/SignUpDelivery.kt
+++ b/users/src/main/kotlin/ar/com/intrale/SignUpDelivery.kt
@@ -2,12 +2,14 @@ package ar.com.intrale
 
 import aws.sdk.kotlin.services.cognitoidentityprovider.CognitoIdentityProviderClient
 import org.slf4j.Logger
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable
 
 class SignUpDelivery(
     override val config: UsersConfig,
     override val logger: Logger,
-    override val cognito: CognitoIdentityProviderClient
-) : SignUp(config = config, logger = logger, cognito = cognito) {
+    override val cognito: CognitoIdentityProviderClient,
+    tableProfiles: DynamoDbTable<UserBusinessProfile>
+) : SignUp(config = config, logger = logger, cognito = cognito, tableProfiles = tableProfiles) {
 
     override fun getProfile(): String {
         return PROFILE_DELIVERY

--- a/users/src/main/kotlin/ar/com/intrale/SignUpPlatformAdmin.kt
+++ b/users/src/main/kotlin/ar/com/intrale/SignUpPlatformAdmin.kt
@@ -4,10 +4,16 @@ import aws.sdk.kotlin.services.cognitoidentityprovider.CognitoIdentityProviderCl
 import aws.sdk.kotlin.services.cognitoidentityprovider.model.ListUsersRequest
 import aws.sdk.kotlin.services.cognitoidentityprovider.model.UnauthorizedException
 import org.slf4j.Logger
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable
 import kotlin.math.log
 
-class SignUpPlatformAdmin(override val config: UsersConfig, override val logger: Logger, override val cognito: CognitoIdentityProviderClient) :
-                SignUp(config = config, logger = logger, cognito = cognito) {
+class SignUpPlatformAdmin(
+    override val config: UsersConfig,
+    override val logger: Logger,
+    override val cognito: CognitoIdentityProviderClient,
+    tableProfiles: DynamoDbTable<UserBusinessProfile>
+) :
+                SignUp(config = config, logger = logger, cognito = cognito, tableProfiles = tableProfiles) {
 
     override fun getProfile() : String {
         return PROFILE_PLATFORM_ADMIN

--- a/users/src/main/kotlin/ar/com/intrale/SignUpSaler.kt
+++ b/users/src/main/kotlin/ar/com/intrale/SignUpSaler.kt
@@ -2,12 +2,14 @@ package ar.com.intrale
 
 import aws.sdk.kotlin.services.cognitoidentityprovider.CognitoIdentityProviderClient
 import org.slf4j.Logger
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable
 
 class SignUpSaler(
     override val config: UsersConfig,
     override val logger: Logger,
-    override val cognito: CognitoIdentityProviderClient
-) : SignUp(config = config, logger = logger, cognito = cognito) {
+    override val cognito: CognitoIdentityProviderClient,
+    tableProfiles: DynamoDbTable<UserBusinessProfile>
+) : SignUp(config = config, logger = logger, cognito = cognito, tableProfiles = tableProfiles) {
     override fun getProfile(): String {
         return PROFILE_SALER
     }

--- a/users/src/test/kotlin/ar/com/intrale/SignInTest.kt
+++ b/users/src/test/kotlin/ar/com/intrale/SignInTest.kt
@@ -3,13 +3,34 @@ package ar.com.intrale
 import aws.sdk.kotlin.services.cognitoidentityprovider.CognitoIdentityProviderClient
 import kotlinx.coroutines.runBlocking
 import org.slf4j.helpers.NOPLogger
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClientExtension
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable
+import software.amazon.awssdk.enhanced.dynamodb.Key
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema
+import software.amazon.awssdk.enhanced.dynamodb.model.Page
+import software.amazon.awssdk.enhanced.dynamodb.model.PageIterable
+import software.amazon.awssdk.core.pagination.sync.SdkIterable
 import kotlin.test.Test
 import kotlin.test.assertEquals
+
+class DummySignInTableUnit : DynamoDbTable<UserBusinessProfile> {
+    val items = mutableListOf<UserBusinessProfile>()
+    override fun mapperExtension(): DynamoDbEnhancedClientExtension? = null
+    override fun tableSchema(): TableSchema<UserBusinessProfile> = TableSchema.fromBean(UserBusinessProfile::class.java)
+    override fun tableName(): String = "profiles"
+    override fun keyFrom(item: UserBusinessProfile): Key = Key.builder().partitionValue(item.compositeKey).build()
+    override fun index(indexName: String) = throw UnsupportedOperationException()
+    override fun putItem(item: UserBusinessProfile) { items.add(item) }
+    override fun scan(): PageIterable<UserBusinessProfile> =
+        PageIterable.create(SdkIterable { mutableListOf(Page.create(items)).iterator() })
+    override fun getItem(key: Key): UserBusinessProfile? = items.find { it.compositeKey == key.partitionKeyValue().s() }
+}
 
 class SignInTest {
     private val logger = NOPLogger.NOP_LOGGER
     private val config = UsersConfig(setOf("biz"), "us-east-1", "key", "secret", "pool", "client")
-    private val signIn = SignIn(config, logger, CognitoIdentityProviderClient { region = "us-east-1" })
+    private val table = DummySignInTableUnit()
+    private val signIn = SignIn(config, logger, CognitoIdentityProviderClient { region = "us-east-1" }, table)
 
     @Test
     fun validRequestPassesValidation() {

--- a/users/src/test/kotlin/ar/com/intrale/SignUpDeliveryTest.kt
+++ b/users/src/test/kotlin/ar/com/intrale/SignUpDeliveryTest.kt
@@ -2,6 +2,13 @@ package ar.com.intrale
 
 import aws.sdk.kotlin.services.cognitoidentityprovider.CognitoIdentityProviderClient
 import org.slf4j.helpers.NOPLogger
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClientExtension
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable
+import software.amazon.awssdk.enhanced.dynamodb.Key
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema
+import software.amazon.awssdk.enhanced.dynamodb.model.Page
+import software.amazon.awssdk.enhanced.dynamodb.model.PageIterable
+import software.amazon.awssdk.core.pagination.sync.SdkIterable
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -21,7 +28,19 @@ class SignUpDeliveryTest {
 
     @Test
     fun profileIsDelivery() {
-        val signup = SignUpDelivery(config, logger, cognito)
+        val table = object : DynamoDbTable<UserBusinessProfile> {
+            val items = mutableListOf<UserBusinessProfile>()
+            override fun mapperExtension(): DynamoDbEnhancedClientExtension? = null
+            override fun tableSchema(): TableSchema<UserBusinessProfile> = TableSchema.fromBean(UserBusinessProfile::class.java)
+            override fun tableName(): String = "profiles"
+            override fun keyFrom(item: UserBusinessProfile): Key = Key.builder().partitionValue(item.compositeKey).build()
+            override fun index(indexName: String) = throw UnsupportedOperationException()
+            override fun putItem(item: UserBusinessProfile) { items.add(item) }
+            override fun scan(): PageIterable<UserBusinessProfile> =
+                PageIterable.create(SdkIterable { mutableListOf(Page.create(items)).iterator() })
+            override fun getItem(key: Key): UserBusinessProfile? = null
+        }
+        val signup = SignUpDelivery(config, logger, cognito, table)
         assertEquals(PROFILE_DELIVERY, signup.getProfile())
     }
 }

--- a/users/src/test/kotlin/ar/com/intrale/SignUpIntegrationTest.kt
+++ b/users/src/test/kotlin/ar/com/intrale/SignUpIntegrationTest.kt
@@ -14,6 +14,13 @@ import io.ktor.server.testing.*
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClientExtension
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable
+import software.amazon.awssdk.enhanced.dynamodb.Key
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema
+import software.amazon.awssdk.enhanced.dynamodb.model.Page
+import software.amazon.awssdk.enhanced.dynamodb.model.PageIterable
+import software.amazon.awssdk.core.pagination.sync.SdkIterable
 import org.kodein.di.*
 import org.kodein.di.ktor.closestDI
 import org.kodein.di.ktor.di
@@ -27,6 +34,21 @@ class SignUpIntegrationTest {
         return DI.Module(name = "test", allowSilentOverride = true) {
             bind<UsersConfig>(overrides = true) { singleton { config } }
             bind<CognitoIdentityProviderClient>(overrides = true) { singleton { cognito } }
+            bind<DynamoDbTable<UserBusinessProfile>>(overrides = true) {
+                singleton {
+                    object : DynamoDbTable<UserBusinessProfile> {
+                        val items = mutableListOf<UserBusinessProfile>()
+                        override fun mapperExtension(): DynamoDbEnhancedClientExtension? = null
+                        override fun tableSchema(): TableSchema<UserBusinessProfile> = TableSchema.fromBean(UserBusinessProfile::class.java)
+                        override fun tableName() = "profiles"
+                        override fun keyFrom(item: UserBusinessProfile) = Key.builder().partitionValue(item.compositeKey).build()
+                        override fun index(indexName: String) = throw UnsupportedOperationException()
+                        override fun putItem(item: UserBusinessProfile) { items.add(item) }
+                        override fun scan(): PageIterable<UserBusinessProfile> = PageIterable.create(SdkIterable { mutableListOf(Page.create(items)).iterator() })
+                        override fun getItem(key: Key): UserBusinessProfile? = null
+                    }
+                }
+            }
         }
     }
 

--- a/users/src/test/kotlin/ar/com/intrale/SignUpPlatformAdminIntegrationTest.kt
+++ b/users/src/test/kotlin/ar/com/intrale/SignUpPlatformAdminIntegrationTest.kt
@@ -13,6 +13,13 @@ import io.ktor.server.testing.*
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClientExtension
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable
+import software.amazon.awssdk.enhanced.dynamodb.Key
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema
+import software.amazon.awssdk.enhanced.dynamodb.model.Page
+import software.amazon.awssdk.enhanced.dynamodb.model.PageIterable
+import software.amazon.awssdk.core.pagination.sync.SdkIterable
 import org.kodein.di.*
 import org.kodein.di.ktor.closestDI
 import org.kodein.di.ktor.di
@@ -26,6 +33,21 @@ class SignUpPlatformAdminIntegrationTest {
         return DI.Module(name = "test", allowSilentOverride = true) {
             bind<UsersConfig>(overrides = true) { singleton { config } }
             bind<CognitoIdentityProviderClient>(overrides = true) { singleton { cognito } }
+            bind<DynamoDbTable<UserBusinessProfile>>(overrides = true) {
+                singleton {
+                    object : DynamoDbTable<UserBusinessProfile> {
+                        val items = mutableListOf<UserBusinessProfile>()
+                        override fun mapperExtension(): DynamoDbEnhancedClientExtension? = null
+                        override fun tableSchema(): TableSchema<UserBusinessProfile> = TableSchema.fromBean(UserBusinessProfile::class.java)
+                        override fun tableName() = "profiles"
+                        override fun keyFrom(item: UserBusinessProfile) = Key.builder().partitionValue(item.compositeKey).build()
+                        override fun index(indexName: String) = throw UnsupportedOperationException()
+                        override fun putItem(item: UserBusinessProfile) { items.add(item) }
+                        override fun scan(): PageIterable<UserBusinessProfile> = PageIterable.create(SdkIterable { mutableListOf(Page.create(items)).iterator() })
+                        override fun getItem(key: Key): UserBusinessProfile? = null
+                    }
+                }
+            }
         }
     }
 

--- a/users/src/test/kotlin/ar/com/intrale/SignUpPlatformAdminTest.kt
+++ b/users/src/test/kotlin/ar/com/intrale/SignUpPlatformAdminTest.kt
@@ -2,13 +2,31 @@ package ar.com.intrale
 
 import aws.sdk.kotlin.services.cognitoidentityprovider.CognitoIdentityProviderClient
 import org.slf4j.helpers.NOPLogger
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClientExtension
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable
+import software.amazon.awssdk.enhanced.dynamodb.Key
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema
+import software.amazon.awssdk.enhanced.dynamodb.model.Page
+import software.amazon.awssdk.enhanced.dynamodb.model.PageIterable
+import software.amazon.awssdk.core.pagination.sync.SdkIterable
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class SignUpPlatformAdminTest {
     private val config = UsersConfig(setOf("test"), "us-east-1", "key", "secret", "pool", "client")
     private val cognito = CognitoIdentityProviderClient { region = config.region }
-    private val signUp = SignUpPlatformAdmin(config, NOPLogger.NOP_LOGGER, cognito)
+    private val table = object : DynamoDbTable<UserBusinessProfile> {
+        val items = mutableListOf<UserBusinessProfile>()
+        override fun mapperExtension(): DynamoDbEnhancedClientExtension? = null
+        override fun tableSchema(): TableSchema<UserBusinessProfile> = TableSchema.fromBean(UserBusinessProfile::class.java)
+        override fun tableName(): String = "profiles"
+        override fun keyFrom(item: UserBusinessProfile): Key = Key.builder().partitionValue(item.compositeKey).build()
+        override fun index(indexName: String) = throw UnsupportedOperationException()
+        override fun putItem(item: UserBusinessProfile) { items.add(item) }
+        override fun scan(): PageIterable<UserBusinessProfile> = PageIterable.create(SdkIterable { mutableListOf(Page.create(items)).iterator() })
+        override fun getItem(key: Key): UserBusinessProfile? = null
+    }
+    private val signUp = SignUpPlatformAdmin(config, NOPLogger.NOP_LOGGER, cognito, table)
 
     @Test
     fun profileIsPlatformAdmin() {

--- a/users/src/test/kotlin/ar/com/intrale/SignUpSalerIntegrationTest.kt
+++ b/users/src/test/kotlin/ar/com/intrale/SignUpSalerIntegrationTest.kt
@@ -13,6 +13,13 @@ import io.ktor.server.testing.*
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClientExtension
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable
+import software.amazon.awssdk.enhanced.dynamodb.Key
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema
+import software.amazon.awssdk.enhanced.dynamodb.model.Page
+import software.amazon.awssdk.enhanced.dynamodb.model.PageIterable
+import software.amazon.awssdk.core.pagination.sync.SdkIterable
 import org.kodein.di.*
 import org.kodein.di.ktor.closestDI
 import org.kodein.di.ktor.di
@@ -26,6 +33,21 @@ class SignUpSalerIntegrationTest {
         return DI.Module(name = "test", allowSilentOverride = true) {
             bind<UsersConfig>(overrides = true) { singleton { config } }
             bind<CognitoIdentityProviderClient>(overrides = true) { singleton { cognito } }
+            bind<DynamoDbTable<UserBusinessProfile>>(overrides = true) {
+                singleton {
+                    object : DynamoDbTable<UserBusinessProfile> {
+                        val items = mutableListOf<UserBusinessProfile>()
+                        override fun mapperExtension(): DynamoDbEnhancedClientExtension? = null
+                        override fun tableSchema(): TableSchema<UserBusinessProfile> = TableSchema.fromBean(UserBusinessProfile::class.java)
+                        override fun tableName() = "profiles"
+                        override fun keyFrom(item: UserBusinessProfile) = Key.builder().partitionValue(item.compositeKey).build()
+                        override fun index(indexName: String) = throw UnsupportedOperationException()
+                        override fun putItem(item: UserBusinessProfile) { items.add(item) }
+                        override fun scan(): PageIterable<UserBusinessProfile> = PageIterable.create(SdkIterable { mutableListOf(Page.create(items)).iterator() })
+                        override fun getItem(key: Key): UserBusinessProfile? = null
+                    }
+                }
+            }
         }
     }
 

--- a/users/src/test/kotlin/ar/com/intrale/SignUpSalerTest.kt
+++ b/users/src/test/kotlin/ar/com/intrale/SignUpSalerTest.kt
@@ -2,13 +2,31 @@ package ar.com.intrale
 
 import aws.sdk.kotlin.services.cognitoidentityprovider.CognitoIdentityProviderClient
 import org.slf4j.helpers.NOPLogger
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClientExtension
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable
+import software.amazon.awssdk.enhanced.dynamodb.Key
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema
+import software.amazon.awssdk.enhanced.dynamodb.model.Page
+import software.amazon.awssdk.enhanced.dynamodb.model.PageIterable
+import software.amazon.awssdk.core.pagination.sync.SdkIterable
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class SignUpSalerTest {
     private val config = UsersConfig(setOf("test"), "us-east-1", "key", "secret", "pool", "client")
     private val cognito = CognitoIdentityProviderClient { region = config.region }
-    private val signUp = SignUpSaler(config, NOPLogger.NOP_LOGGER, cognito)
+    private val table = object : DynamoDbTable<UserBusinessProfile> {
+        val items = mutableListOf<UserBusinessProfile>()
+        override fun mapperExtension(): DynamoDbEnhancedClientExtension? = null
+        override fun tableSchema(): TableSchema<UserBusinessProfile> = TableSchema.fromBean(UserBusinessProfile::class.java)
+        override fun tableName(): String = "profiles"
+        override fun keyFrom(item: UserBusinessProfile): Key = Key.builder().partitionValue(item.compositeKey).build()
+        override fun index(indexName: String) = throw UnsupportedOperationException()
+        override fun putItem(item: UserBusinessProfile) { items.add(item) }
+        override fun scan(): PageIterable<UserBusinessProfile> = PageIterable.create(SdkIterable { mutableListOf(Page.create(items)).iterator() })
+        override fun getItem(key: Key): UserBusinessProfile? = null
+    }
+    private val signUp = SignUpSaler(config, NOPLogger.NOP_LOGGER, cognito, table)
 
     @Test
     fun profileIsSaler() {

--- a/users/src/test/kotlin/ar/com/intrale/SignUpTest.kt
+++ b/users/src/test/kotlin/ar/com/intrale/SignUpTest.kt
@@ -3,13 +3,32 @@ package ar.com.intrale
 import aws.sdk.kotlin.services.cognitoidentityprovider.CognitoIdentityProviderClient
 import kotlinx.coroutines.runBlocking
 import org.slf4j.helpers.NOPLogger
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClientExtension
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable
+import software.amazon.awssdk.enhanced.dynamodb.Key
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema
+import software.amazon.awssdk.enhanced.dynamodb.model.Page
+import software.amazon.awssdk.enhanced.dynamodb.model.PageIterable
+import software.amazon.awssdk.core.pagination.sync.SdkIterable
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class SignUpTest {
     private val config = UsersConfig(setOf("test"), "us-east-1", "key", "secret", "pool", "client")
     private val cognito = CognitoIdentityProviderClient { region = config.region }
-    private val signUp = SignUp(config, NOPLogger.NOP_LOGGER, cognito)
+    private val table = object : DynamoDbTable<UserBusinessProfile> {
+        val items = mutableListOf<UserBusinessProfile>()
+        override fun mapperExtension(): DynamoDbEnhancedClientExtension? = null
+        override fun tableSchema(): TableSchema<UserBusinessProfile> = TableSchema.fromBean(UserBusinessProfile::class.java)
+        override fun tableName(): String = "profiles"
+        override fun keyFrom(item: UserBusinessProfile): Key = Key.builder().partitionValue(item.compositeKey).build()
+        override fun index(indexName: String) = throw UnsupportedOperationException()
+        override fun putItem(item: UserBusinessProfile) { items.add(item) }
+        override fun scan(): PageIterable<UserBusinessProfile> =
+            PageIterable.create(SdkIterable { mutableListOf(Page.create(items)).iterator() })
+        override fun getItem(key: Key): UserBusinessProfile? = items.find { it.compositeKey == key.partitionKeyValue().s() }
+    }
+    private val signUp = SignUp(config, NOPLogger.NOP_LOGGER, cognito, table)
 
     @Test
     fun profileIsDefault() {


### PR DESCRIPTION
Se actualizó la lógica de registro y autenticación para eliminar el uso de atributos personalizados en Cognito. Ahora los perfiles y negocios se registran exclusivamente en la tabla `userbusinessprofile`. Se modificaron las funciones de sign‑up y sign‑in, así como las pruebas y documentación asociada. Closes #133

------
https://chatgpt.com/codex/tasks/task_e_6888fb27baa4832584c6e16a998860fe