### PR TITLE
[auto] registro delivery requiere negocio

### DIFF
--- a/app/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/app/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -15,6 +15,7 @@
     <string name="signup_delivery">Registro Delivery</string>
     <string name="signup_saler">Registro Vendedor</string>
     <string name="email">Correo electrónico</string>
+    <string name="business">Negocio</string>
 
     <string name="error_credentials">Usuario o contraseña incorrectos</string>
     <string name="new_password">Nueva contraseña</string>

--- a/app/composeApp/src/commonMain/kotlin/DIManager.kt
+++ b/app/composeApp/src/commonMain/kotlin/DIManager.kt
@@ -99,12 +99,14 @@ class DIManager {
                 bindSingleton<CommSignUpPlatformAdminService> { ClientSignUpPlatformAdminService(instance()) }
                 bindSingleton<CommSignUpDeliveryService> { ClientSignUpDeliveryService(instance()) }
                 bindSingleton<CommSignUpSalerService> { ClientSignUpSalerService(instance()) }
+                bindSingleton<CommSearchBusinessesService> { ClientSearchBusinessesService(instance()) }
 
                 bindSingleton<ToDoLogin> { DoLogin(instance(), instance()) }
                 bindSingleton<ToDoSignUp> { DoSignUp(instance()) }
                 bindSingleton<ToDoSignUpPlatformAdmin> { DoSignUpPlatformAdmin(instance()) }
                 bindSingleton<ToDoSignUpDelivery> { DoSignUpDelivery(instance()) }
                 bindSingleton<ToDoSignUpSaler> { DoSignUpSaler(instance()) }
+                bindSingleton<ToGetBusinesses> { DoGetBusinesses(instance()) }
                 bindSingleton<ToDoCheckPreviousLogin> { DoCheckPreviousLogin(instance()) }
                 bindSingleton<ToDoResetLoginCache> { DoResetLoginCache(instance()) }
 

--- a/app/composeApp/src/commonMain/kotlin/asdo/DoGetBusinesses.kt
+++ b/app/composeApp/src/commonMain/kotlin/asdo/DoGetBusinesses.kt
@@ -1,0 +1,8 @@
+package asdo
+
+import ext.CommSearchBusinessesService
+import ext.SearchBusinessesResponse
+
+class DoGetBusinesses(private val service: CommSearchBusinessesService) : ToGetBusinesses {
+    override suspend fun execute(query: String): Result<SearchBusinessesResponse> = service.execute(query)
+}

--- a/app/composeApp/src/commonMain/kotlin/asdo/DoSignUpDelivery.kt
+++ b/app/composeApp/src/commonMain/kotlin/asdo/DoSignUpDelivery.kt
@@ -4,9 +4,9 @@ import ext.CommSignUpDeliveryService
 import ext.ExceptionResponse
 
 class DoSignUpDelivery(private val service: CommSignUpDeliveryService) : ToDoSignUpDelivery {
-    override suspend fun execute(email: String): Result<DoSignUpResult> {
+    override suspend fun execute(business: String, email: String): Result<DoSignUpResult> {
         return try {
-            service.execute(/*"signupDelivery",*/ email)
+            service.execute(business, email)
                 .mapCatching { it.toDoSignUpResult() }
                 .recoverCatching { e ->
                     throw (e as? ExceptionResponse)?.toDoSignUpException()

--- a/app/composeApp/src/commonMain/kotlin/asdo/ToDoSignUpDelivery.kt
+++ b/app/composeApp/src/commonMain/kotlin/asdo/ToDoSignUpDelivery.kt
@@ -1,3 +1,3 @@
 package asdo
 
-interface ToDoSignUpDelivery { suspend fun execute(email:String): Result<DoSignUpResult> }
+interface ToDoSignUpDelivery { suspend fun execute(business: String, email:String): Result<DoSignUpResult> }

--- a/app/composeApp/src/commonMain/kotlin/asdo/ToGetBusinesses.kt
+++ b/app/composeApp/src/commonMain/kotlin/asdo/ToGetBusinesses.kt
@@ -1,0 +1,5 @@
+package asdo
+
+import ext.SearchBusinessesResponse
+
+interface ToGetBusinesses { suspend fun execute(query: String): Result<SearchBusinessesResponse> }

--- a/app/composeApp/src/commonMain/kotlin/ext/CommSearchBusinessesService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/CommSearchBusinessesService.kt
@@ -1,0 +1,5 @@
+package ext
+
+interface CommSearchBusinessesService {
+    suspend fun execute(query: String): Result<SearchBusinessesResponse>
+}

--- a/app/composeApp/src/commonMain/kotlin/ext/CommSignUpDeliveryService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/CommSignUpDeliveryService.kt
@@ -1,5 +1,5 @@
 package ext
 
 interface CommSignUpDeliveryService {
-    suspend fun execute(email: String): Result<SignUpResponse>
+    suspend fun execute(business: String, email: String): Result<SignUpResponse>
 }

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/SignUpDeliveryScreen.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/SignUpDeliveryScreen.kt
@@ -6,9 +6,12 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -53,6 +56,26 @@ class SignUpDeliveryScreen : Screen(SIGNUP_DELIVERY_PATH, Res.string.signup_deli
                 state = viewModel.inputsStates[SignUpDeliveryViewModel.SignUpUIState::email.name]!!,
                 onValueChange = { viewModel.state = viewModel.state.copy(email = it) }
             )
+            Spacer(modifier = Modifier.size(10.dp))
+            var expanded by remember { mutableStateOf(false) }
+            TextField(
+                Res.string.business,
+                value = viewModel.state.business,
+                state = viewModel.inputsStates[SignUpDeliveryViewModel.SignUpUIState::business.name]!!,
+                onValueChange = {
+                    viewModel.state = viewModel.state.copy(business = it)
+                    coroutine.launch { viewModel.searchBusinesses(it) }
+                    expanded = true
+                }
+            )
+            DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+                viewModel.suggestions.forEach { name ->
+                    DropdownMenuItem(text = { androidx.compose.material3.Text(name) }, onClick = {
+                        viewModel.state = viewModel.state.copy(business = name)
+                        expanded = false
+                    })
+                }
+            }
             Spacer(modifier = Modifier.size(10.dp))
             Button(
                 label = stringResource(Res.string.signup_delivery),

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/SignUpDeliveryViewModel.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/SignUpDeliveryViewModel.kt
@@ -3,6 +3,7 @@ package ui.sc
 import DIManager
 import asdo.DoSignUpResult
 import asdo.ToDoSignUpDelivery
+import asdo.ToGetBusinesses
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -12,10 +13,12 @@ import org.kodein.di.instance
 
 class SignUpDeliveryViewModel : ViewModel() {
     private val toDoSignUpDelivery: ToDoSignUpDelivery by DIManager.di.instance()
+    private val toGetBusinesses: ToGetBusinesses by DIManager.di.instance()
 
     var state by mutableStateOf(SignUpUIState())
+    var suggestions by mutableStateOf(listOf<String>())
     var loading by mutableStateOf(false)
-    data class SignUpUIState(val email: String = "")
+    data class SignUpUIState(val email: String = "", val business: String = "")
     override fun getState(): Any = state
 
     init {
@@ -23,14 +26,19 @@ class SignUpDeliveryViewModel : ViewModel() {
             SignUpUIState::email required {
                 pattern(".+@.+\\..+") hint "Correo inválido"
             }
+            SignUpUIState::business required {}
         } as Validation<Any>
         initInputState()
     }
 
     override fun initInputState() {
-        inputsStates = mutableMapOf(entry(SignUpUIState::email.name))
+        inputsStates = mutableMapOf(entry(SignUpUIState::email.name), entry(SignUpUIState::business.name))
     }
 
     suspend fun signup(): Result<DoSignUpResult> =
-        toDoSignUpDelivery.execute(state.email)
+        toDoSignUpDelivery.execute(state.business, state.email)
+
+    suspend fun searchBusinesses(query: String) {
+        toGetBusinesses.execute(query).onSuccess { suggestions = it.businesses }
+    }
 }

--- a/docs/search-businesses.md
+++ b/docs/search-businesses.md
@@ -1,0 +1,18 @@
+# Buscar negocios
+Pertenece al módulo `users`.
+
+Permite obtener sugerencias de negocios aprobados filtrando por texto.
+
+```
+POST /intrale/searchBusinesses
+```
+
+Cuerpo de la solicitud:
+```json
+{ "query": "caf" }
+```
+
+Respuesta:
+```json
+{ "businesses": ["cafe-roma", "cafeteria-centro"] }
+```

--- a/docs/signup-por-perfil.md
+++ b/docs/signup-por-perfil.md
@@ -22,3 +22,11 @@ Cada opción lleva a `SignUpPlatformAdminScreen`, `SignUpDeliveryScreen` o `Sign
 ### Manejo de respuestas
 Ahora cada pantalla de registro utiliza `callService` para mostrar mensajes de éxito o error.
 Los `ViewModel` devuelven `Result<DoSignUpResult>` permitiendo feedback consistente con el login.
+
+## Registro de Delivery por negocio
+
+Relacionado con #137.
+
+El formulario de `SignUpDeliveryScreen` ahora incluye un campo adicional para seleccionar el negocio. Este campo posee búsqueda dinámica y sugiere en tiempo real los negocios disponibles mediante el servicio `searchBusinesses` del módulo `users`.
+
+Al enviar el registro se valida que el correo no esté ya registrado como Delivery para el negocio elegido. Si existe, se informa un mensaje de error. De lo contrario, el usuario queda en estado `PENDING` hasta que el Business Admin apruebe su solicitud.

--- a/users/src/main/kotlin/ar/com/intrale/Modules.kt
+++ b/users/src/main/kotlin/ar/com/intrale/Modules.kt
@@ -178,6 +178,9 @@ val appModule = DI.Module("appModule") {
     bind<Function> (tag="reviewJoinBusiness") {
         singleton { ReviewJoinBusiness(instance(), instance(), instance(), instance()) }
     }
+    bind<Function> (tag="searchBusinesses") {
+        singleton { SearchBusinesses(instance(), instance(), instance()) }
+    }
     bind<Function> (tag="configAutoAcceptDeliveries") {
         singleton { ConfigAutoAcceptDeliveries(instance(), instance(), instance(), instance(), instance()) }
     }

--- a/users/src/main/kotlin/ar/com/intrale/SearchBusinesses.kt
+++ b/users/src/main/kotlin/ar/com/intrale/SearchBusinesses.kt
@@ -1,0 +1,34 @@
+package ar.com.intrale
+
+import com.google.gson.Gson
+import org.slf4j.Logger
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable
+import ar.com.intrale.BusinessState
+
+
+
+class SearchBusinesses(
+    val config: UsersConfig,
+    val logger: Logger,
+    private val tableBusiness: DynamoDbTable<Business>
+) : Function {
+
+    override suspend fun execute(
+        business: String,
+        function: String,
+        headers: Map<String, String>,
+        textBody: String
+    ): Response {
+        logger.debug("starting search businesses $function")
+        val body = if (textBody.isNotEmpty()) {
+            Gson().fromJson(textBody, SearchBusinessesRequest::class.java)
+        } else {
+            SearchBusinessesRequest()
+        }
+        val items = tableBusiness.scan().items().filter { it.state == BusinessState.APPROVED }
+        val filtered = if (body.query.isBlank()) items else items.filter { it.name?.contains(body.query, ignoreCase = true) == true }
+        val names = filtered.mapNotNull { it.name }.toTypedArray()
+        logger.debug("return search businesses $function")
+        return SearchBusinessesResponse(names)
+    }
+}

--- a/users/src/main/kotlin/ar/com/intrale/SearchBusinessesRequest.kt
+++ b/users/src/main/kotlin/ar/com/intrale/SearchBusinessesRequest.kt
@@ -1,0 +1,3 @@
+package ar.com.intrale
+
+data class SearchBusinessesRequest(val query: String = "")

--- a/users/src/main/kotlin/ar/com/intrale/SearchBusinessesResponse.kt
+++ b/users/src/main/kotlin/ar/com/intrale/SearchBusinessesResponse.kt
@@ -1,0 +1,3 @@
+package ar.com.intrale
+
+class SearchBusinessesResponse(val businesses: Array<String>) : Response()

--- a/users/src/main/kotlin/ar/com/intrale/SignUpDelivery.kt
+++ b/users/src/main/kotlin/ar/com/intrale/SignUpDelivery.kt
@@ -1,6 +1,11 @@
 package ar.com.intrale
 
 import aws.sdk.kotlin.services.cognitoidentityprovider.CognitoIdentityProviderClient
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.*
+import com.google.gson.Gson
+import io.konform.validation.Validation
+import io.konform.validation.ValidationResult
+import io.konform.validation.jsonschema.pattern
 import org.slf4j.Logger
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable
 
@@ -8,10 +13,82 @@ class SignUpDelivery(
     override val config: UsersConfig,
     override val logger: Logger,
     override val cognito: CognitoIdentityProviderClient,
-    tableProfiles: DynamoDbTable<UserBusinessProfile>
+    private val tableProfiles: DynamoDbTable<UserBusinessProfile>
 ) : SignUp(config = config, logger = logger, cognito = cognito, tableProfiles = tableProfiles) {
 
     override fun getProfile(): String {
         return PROFILE_DELIVERY
+    }
+
+    override suspend fun execute(
+        business: String,
+        function: String,
+        headers: Map<String, String>,
+        textBody: String
+    ): Response {
+        logger.debug("Executing delivery signup $function with $textBody")
+        if (textBody.isEmpty()) return RequestValidationException("Request body not found")
+
+        val body = Gson().fromJson(textBody, SignUpRequest::class.java)
+
+        val validation = Validation<SignUpRequest> {
+            SignUpRequest::email required {
+                pattern(".+@.+\\..+") hint "El campo email debe tener formato de email. Valor actual: '{value}'"
+            }
+        }
+
+        val validationResult: ValidationResult<Any> = try {
+            validation(body)
+        } catch (e: Exception) {
+            return RequestValidationException("Request is empty")
+        }
+
+        if (!validationResult.isValid) {
+            val errorsMessage = validationResult.errors.joinToString(" ") { it.dataPath.substring(1) + ' ' + it.message }
+            return RequestValidationException(errorsMessage)
+        }
+
+        val email = body.email
+        val key = UserBusinessProfile().apply {
+            this.email = email
+            this.business = business
+            this.profile = getProfile()
+        }
+        val existing = tableProfiles.getItem(key)
+        if (existing != null) {
+            return ExceptionResponse("Delivery ya registrado para el negocio")
+        }
+
+        val attrs = mutableListOf<AttributeType>()
+        attrs.add(AttributeType {
+            this.name = EMAIL_ATT_NAME
+            this.value = email
+        })
+
+        try {
+            logger.info("Call to Cognito to create user with email $email")
+            cognito.adminCreateUser(
+                AdminCreateUserRequest {
+                    userPoolId = config.awsCognitoUserPoolId
+                    username = email
+                    userAttributes = attrs
+                }
+            )
+        } catch (e: UsernameExistsException) {
+            logger.info("Usuario ya existe, se omitirá creación en Cognito")
+        } catch (e: Exception) {
+            logger.error("Error creating user", e)
+            return ExceptionResponse(e.message ?: "Internal Server Error")
+        }
+
+        val userProfile = UserBusinessProfile().apply {
+            this.email = email
+            this.business = business
+            this.profile = getProfile()
+            this.state = BusinessState.PENDING
+        }
+        tableProfiles.putItem(userProfile)
+
+        return Response()
     }
 }


### PR DESCRIPTION
Se implementó selección de negocio en el registro de Delivery.

- Nuevo endpoint `searchBusinesses` para sugerencias de negocios.
- Validación de duplicados y estado `PENDING` al registrar Deliveries.
- Actualización de pantallas y servicios en `app` para búsqueda dinámica.
- Documentación ampliada sobre el proceso de registro.

Closes #137

------
https://chatgpt.com/codex/tasks/task_e_68896388da5483259203c91e3258dea4