### PR TITLE
[auto] Soporte de modifier en TextField

### DIFF
--- a/app/composeApp/src/commonMain/kotlin/ui/cp/TextField.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/cp/TextField.kt
@@ -34,6 +34,7 @@ fun TextField(label: StringResource,
               state: MutableState<InputState>,
               visualTransformation: Boolean = false,
               onValueChange:(value:String) -> Unit = {},
+              modifier: Modifier = Modifier
                   ){
 
     var logger = LoggerFactory.default.newLogger(Logger.Tag("ui.cp", "TextField"))
@@ -50,6 +51,7 @@ fun TextField(label: StringResource,
             onValueChange={
                           onValueChange(it)
             }, label = { Text(labelString) },
+            modifier = modifier,
             visualTransformation = if (isVisible)
                             VisualTransformation.None else PasswordVisualTransformation(),
             trailingIcon = {


### PR DESCRIPTION
Se agrega un parámetro `modifier` opcional en `ui.cp.TextField` y se aplica al componente interno. Esto permite usar `Modifier.menuAnchor()` en la pantalla de registro de repartidores.

Closes #144

------
https://chatgpt.com/codex/tasks/task_e_688a2f9f96b48325b40a7dd3978e9aed