### PR TITLE
[auto] Agrega accesos de recuperación de contraseña en login

### DIFF
--- a/app/composeApp/src/commonMain/kotlin/ui/sc/Login.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/Login.kt
@@ -37,6 +37,10 @@ import io.ktor.client.plugins.ClientRequestException
 import org.kodein.log.LoggerFactory
 import org.kodein.log.newLogger
 import ui.rs.error_credentials
+import ui.rs.password_recovery
+import ui.rs.confirm_password_recovery
+import ui.sc.PASSWORD_RECOVERY_PATH
+import ui.sc.CONFIRM_PASSWORD_RECOVERY_PATH
 
 const val LOGIN_PATH = "/login"
 
@@ -128,6 +132,20 @@ class Login() : Screen(LOGIN_PATH, Res.string.login){
                 label = stringResource(Res.string.signup),
                 onClick = {
                     navigate(SELECT_SIGNUP_PROFILE_PATH)
+                }
+            )
+
+            Button(
+                label = stringResource(Res.string.password_recovery),
+                onClick = {
+                    navigate(PASSWORD_RECOVERY_PATH)
+                }
+            )
+
+            Button(
+                label = stringResource(Res.string.confirm_password_recovery),
+                onClick = {
+                    navigate(CONFIRM_PASSWORD_RECOVERY_PATH)
                 }
             )
 


### PR DESCRIPTION
## Summary
- Se importaron las rutas y recursos necesarios para la recuperación y confirmación de contraseña en la pantalla de login.
- Se añadieron botones que navegan a los flujos de recuperación y confirmación de contraseña.

## Testing
- `./gradlew test` (falló: Unresolved reference `ExposedDropdownMenu` en `SignUpDeliveryScreen.kt`).

------
https://chatgpt.com/codex/tasks/task_e_688beaec205483258eae835112c54d06