### PR TITLE
[auto] Pantalla de registro de negocios

### DIFF
--- a/app/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/app/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -27,4 +27,10 @@
     <string name="password_recovery">Recuperar contraseña</string>
     <string name="confirm_password_recovery">Confirmar recuperación</string>
     <string name="code">Código</string>
+    <string name="register_business">Registrar negocio</string>
+    <string name="description">Descripción</string>
+    <string name="email_admin">Correo del administrador</string>
+    <string name="pending_requests">Solicitudes pendientes</string>
+    <string name="approve">Aprobar</string>
+    <string name="reject">Rechazar</string>
 </resources>

--- a/app/composeApp/src/commonMain/kotlin/DIManager.kt
+++ b/app/composeApp/src/commonMain/kotlin/DIManager.kt
@@ -37,6 +37,7 @@ public const val SELECT_SIGNUP_PROFILE = "selectSignupProfile"
 public const val CHANGE_PASSWORD = "changePassword"
 public const val PASSWORD_RECOVERY = "passwordRecovery"
 public const val CONFIRM_PASSWORD_RECOVERY = "confirmPasswordRecovery"
+public const val REGISTER_BUSINESS = "registerBusiness"
 
 const val LOGIN_PATH = "/login"
 
@@ -63,6 +64,7 @@ class DIManager {
                 bindSingleton(tag = CHANGE_PASSWORD) { ChangePasswordScreen() }
                 bindSingleton(tag = PASSWORD_RECOVERY) { PasswordRecoveryScreen() }
                 bindSingleton(tag = CONFIRM_PASSWORD_RECOVERY) { ConfirmPasswordRecoveryScreen() }
+                bindSingleton(tag = REGISTER_BUSINESS) { RegisterBusinessScreen() }
 
                 bindSingleton (tag = SCREENS) {
                     arrayListOf<Screen>(
@@ -76,7 +78,8 @@ class DIManager {
                         instance(tag = SIGNUP_SALER),
                         instance(tag = CHANGE_PASSWORD),
                         instance(tag = PASSWORD_RECOVERY),
-                        instance(tag = CONFIRM_PASSWORD_RECOVERY)
+                        instance(tag = CONFIRM_PASSWORD_RECOVERY),
+                        instance(tag = REGISTER_BUSINESS)
                     )
                 }
 
@@ -111,6 +114,8 @@ class DIManager {
                 bindSingleton<CommSearchBusinessesService> { ClientSearchBusinessesService(instance()) }
                 bindSingleton<CommChangePasswordService> { ClientChangePasswordService(instance()) }
                 bindSingleton<CommPasswordRecoveryService> { ClientPasswordRecoveryService(instance()) }
+                bindSingleton<CommRegisterBusinessService> { ClientRegisterBusinessService(instance()) }
+                bindSingleton<CommReviewBusinessRegistrationService> { ClientReviewBusinessRegistrationService(instance()) }
 
                 bindSingleton<ToDoLogin> { DoLogin(instance(), instance()) }
                 bindSingleton<ToDoSignUp> { DoSignUp(instance()) }
@@ -123,6 +128,8 @@ class DIManager {
                 bindSingleton<ToDoChangePassword> { DoChangePassword(instance(), instance()) }
                 bindSingleton<ToDoPasswordRecovery> { DoPasswordRecovery(instance()) }
                 bindSingleton<ToDoConfirmPasswordRecovery> { DoConfirmPasswordRecovery(instance()) }
+                bindSingleton<ToDoRegisterBusiness> { DoRegisterBusiness(instance()) }
+                bindSingleton<ToDoReviewBusinessRegistration> { DoReviewBusinessRegistration(instance()) }
 
             }
     }

--- a/app/composeApp/src/commonMain/kotlin/asdo/DoRegisterBusiness.kt
+++ b/app/composeApp/src/commonMain/kotlin/asdo/DoRegisterBusiness.kt
@@ -1,0 +1,9 @@
+package asdo
+
+import ext.CommRegisterBusinessService
+import ext.RegisterBusinessResponse
+
+class DoRegisterBusiness(private val service: CommRegisterBusinessService) : ToDoRegisterBusiness {
+    override suspend fun execute(name: String, emailAdmin: String, description: String): Result<RegisterBusinessResponse> =
+        service.execute(name, emailAdmin, description)
+}

--- a/app/composeApp/src/commonMain/kotlin/asdo/DoReviewBusinessRegistration.kt
+++ b/app/composeApp/src/commonMain/kotlin/asdo/DoReviewBusinessRegistration.kt
@@ -1,0 +1,9 @@
+package asdo
+
+import ext.CommReviewBusinessRegistrationService
+import ext.ReviewBusinessRegistrationResponse
+
+class DoReviewBusinessRegistration(private val service: CommReviewBusinessRegistrationService) : ToDoReviewBusinessRegistration {
+    override suspend fun execute(name: String, decision: String, twoFactorCode: String): Result<ReviewBusinessRegistrationResponse> =
+        service.execute(name, decision, twoFactorCode)
+}

--- a/app/composeApp/src/commonMain/kotlin/asdo/ToDoRegisterBusiness.kt
+++ b/app/composeApp/src/commonMain/kotlin/asdo/ToDoRegisterBusiness.kt
@@ -1,0 +1,7 @@
+package asdo
+
+import ext.RegisterBusinessResponse
+
+interface ToDoRegisterBusiness {
+    suspend fun execute(name: String, emailAdmin: String, description: String): Result<RegisterBusinessResponse>
+}

--- a/app/composeApp/src/commonMain/kotlin/asdo/ToDoReviewBusinessRegistration.kt
+++ b/app/composeApp/src/commonMain/kotlin/asdo/ToDoReviewBusinessRegistration.kt
@@ -1,0 +1,7 @@
+package asdo
+
+import ext.ReviewBusinessRegistrationResponse
+
+interface ToDoReviewBusinessRegistration {
+    suspend fun execute(name: String, decision: String, twoFactorCode: String): Result<ReviewBusinessRegistrationResponse>
+}

--- a/app/composeApp/src/commonMain/kotlin/ext/ClientRegisterBusinessService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/ClientRegisterBusinessService.kt
@@ -1,0 +1,38 @@
+package ext
+
+import ar.com.intrale.BuildKonfig
+import io.ktor.client.HttpClient
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.isSuccess
+import io.ktor.utils.io.InternalAPI
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+class ClientRegisterBusinessService(private val httpClient: HttpClient) : CommRegisterBusinessService {
+    @OptIn(InternalAPI::class)
+    override suspend fun execute(name: String, emailAdmin: String, description: String): Result<RegisterBusinessResponse> {
+        return try {
+            val response: HttpResponse = httpClient.post("${BuildKonfig.BASE_URL}${BuildKonfig.BUSINESS}/registerBusiness") {
+                setBody(RegisterBusinessRequest(name, emailAdmin, description))
+            }
+            if (response.status.isSuccess()) {
+                Result.success(RegisterBusinessResponse(StatusCodeDTO(response.status.value, response.status.description)))
+            } else {
+                val bodyText = response.bodyAsText()
+                val exception = Json.decodeFromString(ExceptionResponse.serializer(), bodyText)
+                Result.failure(exception)
+            }
+        } catch (e: Exception) {
+            Result.failure(e.toExceptionResponse())
+        }
+    }
+}
+
+@Serializable
+data class RegisterBusinessRequest(val name: String, val emailAdmin: String, val description: String)
+
+@Serializable
+data class RegisterBusinessResponse(val statusCode: StatusCodeDTO)

--- a/app/composeApp/src/commonMain/kotlin/ext/ClientReviewBusinessRegistrationService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/ClientReviewBusinessRegistrationService.kt
@@ -1,0 +1,38 @@
+package ext
+
+import ar.com.intrale.BuildKonfig
+import io.ktor.client.HttpClient
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.isSuccess
+import io.ktor.utils.io.InternalAPI
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+class ClientReviewBusinessRegistrationService(private val httpClient: HttpClient) : CommReviewBusinessRegistrationService {
+    @OptIn(InternalAPI::class)
+    override suspend fun execute(name: String, decision: String, twoFactorCode: String): Result<ReviewBusinessRegistrationResponse> {
+        return try {
+            val response: HttpResponse = httpClient.post("${BuildKonfig.BASE_URL}${BuildKonfig.BUSINESS}/reviewBusiness") {
+                setBody(ReviewBusinessRegistrationRequest(name, decision, twoFactorCode))
+            }
+            if (response.status.isSuccess()) {
+                Result.success(ReviewBusinessRegistrationResponse(StatusCodeDTO(response.status.value, response.status.description)))
+            } else {
+                val bodyText = response.bodyAsText()
+                val exception = Json.decodeFromString(ExceptionResponse.serializer(), bodyText)
+                Result.failure(exception)
+            }
+        } catch (e: Exception) {
+            Result.failure(e.toExceptionResponse())
+        }
+    }
+}
+
+@Serializable
+data class ReviewBusinessRegistrationRequest(val name: String, val decision: String, val twoFactorCode: String)
+
+@Serializable
+data class ReviewBusinessRegistrationResponse(val statusCode: StatusCodeDTO)

--- a/app/composeApp/src/commonMain/kotlin/ext/CommRegisterBusinessService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/CommRegisterBusinessService.kt
@@ -1,0 +1,5 @@
+package ext
+
+interface CommRegisterBusinessService {
+    suspend fun execute(name: String, emailAdmin: String, description: String): Result<RegisterBusinessResponse>
+}

--- a/app/composeApp/src/commonMain/kotlin/ext/CommReviewBusinessRegistrationService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/CommReviewBusinessRegistrationService.kt
@@ -1,0 +1,5 @@
+package ext
+
+interface CommReviewBusinessRegistrationService {
+    suspend fun execute(name: String, decision: String, twoFactorCode: String): Result<ReviewBusinessRegistrationResponse>
+}

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/Home.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/Home.kt
@@ -20,6 +20,7 @@ import ui.rs.login
 import ui.rs.logout
 import ui.rs.signup
 import ui.rs.change_password
+import ui.rs.register_business
 
 
 const val HOME_PATH = "/home"
@@ -54,6 +55,13 @@ class Home() : Screen(HOME_PATH, Res.string.app_name){
                 label = stringResource(Res.string.change_password),
                 onClick = {
                     navigate(CHANGE_PASSWORD_PATH)
+                }
+            )
+
+            Button(
+                label = stringResource(Res.string.register_business),
+                onClick = {
+                    navigate(REGISTER_BUSINESS_PATH)
                 }
             )
 

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/RegisterBusinessScreen.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/RegisterBusinessScreen.kt
@@ -1,0 +1,136 @@
+package ui.sc
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.stringResource
+import ui.cp.Button
+import ui.cp.TextField
+import kotlinx.coroutines.launch
+import ui.rs.Res
+import ui.rs.register_business
+import ui.rs.name
+import ui.rs.email_admin
+import ui.rs.description
+import ui.rs.pending_requests
+import ui.rs.approve
+import ui.rs.reject
+import ui.rs.code
+
+const val REGISTER_BUSINESS_PATH = "/registerBusiness"
+
+class RegisterBusinessScreen : Screen(REGISTER_BUSINESS_PATH, Res.string.register_business) {
+    @Composable
+    override fun screen() { screenImpl() }
+
+    @OptIn(ExperimentalResourceApi::class)
+    @Composable
+    private fun screenImpl(viewModel: RegisterBusinessViewModel = viewModel { RegisterBusinessViewModel() }) {
+        val coroutine = rememberCoroutineScope()
+        val snackbarHostState = remember { SnackbarHostState() }
+
+        LaunchedEffect(true) { viewModel.loadPending() }
+
+        Scaffold(snackbarHost = { SnackbarHost(snackbarHostState) }) {
+            Column(
+                Modifier
+                    .fillMaxWidth()
+                    .verticalScroll(rememberScrollState()),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Spacer(Modifier.size(10.dp))
+                TextField(
+                    Res.string.name,
+                    value = viewModel.state.name,
+                    state = viewModel.inputsStates[RegisterBusinessViewModel.UIState::name.name]!!,
+                    onValueChange = { viewModel.state = viewModel.state.copy(name = it) }
+                )
+                Spacer(Modifier.size(10.dp))
+                TextField(
+                    Res.string.email_admin,
+                    value = viewModel.state.email,
+                    state = viewModel.inputsStates[RegisterBusinessViewModel.UIState::email.name]!!,
+                    onValueChange = { viewModel.state = viewModel.state.copy(email = it) }
+                )
+                Spacer(Modifier.size(10.dp))
+                TextField(
+                    Res.string.description,
+                    value = viewModel.state.description,
+                    state = viewModel.inputsStates[RegisterBusinessViewModel.UIState::description.name]!!,
+                    onValueChange = { viewModel.state = viewModel.state.copy(description = it) }
+                )
+                Spacer(Modifier.size(10.dp))
+                Button(
+                    label = stringResource(Res.string.register_business),
+                    loading = viewModel.loading,
+                    enabled = !viewModel.loading,
+                    onClick = {
+                        if (viewModel.isValid()) {
+                            callService(
+                                coroutineScope = coroutine,
+                                snackbarHostState = snackbarHostState,
+                                setLoading = { viewModel.loading = it },
+                                serviceCall = { viewModel.register() },
+                                onSuccess = { coroutine.launch { viewModel.loadPending() } }
+                            )
+                        }
+                    }
+                )
+                Spacer(Modifier.size(20.dp))
+                Text(stringResource(Res.string.pending_requests))
+                Spacer(Modifier.size(10.dp))
+                TextField(
+                    Res.string.code,
+                    value = viewModel.state.twoFactorCode,
+                    state = viewModel.inputsStates[RegisterBusinessViewModel.UIState::twoFactorCode.name]!!,
+                    onValueChange = { viewModel.state = viewModel.state.copy(twoFactorCode = it) }
+                )
+                viewModel.pending.forEach { biz ->
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Text(biz, modifier = Modifier.weight(1f))
+                        Button(
+                            label = stringResource(Res.string.approve),
+                            loading = viewModel.loading,
+                            enabled = !viewModel.loading,
+                            onClick = {
+                                callService(
+                                    coroutineScope = coroutine,
+                                    snackbarHostState = snackbarHostState,
+                                    setLoading = { viewModel.loading = it },
+                                    serviceCall = { viewModel.approve(biz) },
+                                    onSuccess = { coroutine.launch { viewModel.loadPending() } }
+                                )
+                            }
+                        )
+                        Spacer(Modifier.size(4.dp))
+                        Button(
+                            label = stringResource(Res.string.reject),
+                            loading = viewModel.loading,
+                            enabled = !viewModel.loading,
+                            onClick = {
+                                callService(
+                                    coroutineScope = coroutine,
+                                    snackbarHostState = snackbarHostState,
+                                    setLoading = { viewModel.loading = it },
+                                    serviceCall = { viewModel.reject(biz) },
+                                    onSuccess = { coroutine.launch { viewModel.loadPending() } }
+                                )
+                            }
+                        )
+                    }
+                    Spacer(Modifier.size(8.dp))
+                }
+            }
+        }
+    }
+}

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/RegisterBusinessViewModel.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/RegisterBusinessViewModel.kt
@@ -1,0 +1,59 @@
+package ui.sc
+
+import DIManager
+import asdo.ToDoRegisterBusiness
+import asdo.ToDoReviewBusinessRegistration
+import asdo.ToGetBusinesses
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import io.konform.validation.Validation
+import io.konform.validation.jsonschema.pattern
+import org.kodein.di.instance
+
+class RegisterBusinessViewModel : ViewModel() {
+    private val register: ToDoRegisterBusiness by DIManager.di.instance()
+    private val review: ToDoReviewBusinessRegistration by DIManager.di.instance()
+    private val getBusinesses: ToGetBusinesses by DIManager.di.instance()
+
+    var state by mutableStateOf(UIState())
+    var loading by mutableStateOf(false)
+    var pending by mutableStateOf(listOf<String>())
+
+    data class UIState(
+        val name: String = "",
+        val email: String = "",
+        val description: String = "",
+        val twoFactorCode: String = ""
+    )
+
+    override fun getState(): Any = state
+
+    init {
+        validation = Validation<UIState> {
+            UIState::name required {}
+            UIState::email required { pattern(".+@.+\\..+") hint "Correo inválido" }
+            UIState::description required {}
+        } as Validation<Any>
+        initInputState()
+    }
+
+    override fun initInputState() {
+        inputsStates = mutableMapOf(
+            entry(UIState::name.name),
+            entry(UIState::email.name),
+            entry(UIState::description.name),
+            entry(UIState::twoFactorCode.name)
+        )
+    }
+
+    suspend fun register() = register.execute(state.name, state.email, state.description)
+
+    suspend fun approve(business: String) = review.execute(business, "approved", state.twoFactorCode)
+
+    suspend fun reject(business: String) = review.execute(business, "rejected", state.twoFactorCode)
+
+    suspend fun loadPending() {
+        getBusinesses.execute("PENDING").onSuccess { pending = it.businesses }
+    }
+}

--- a/app/composeApp/src/commonTest/kotlin/ar/com/intrale/RegisterBusinessIntegrationTest.kt
+++ b/app/composeApp/src/commonTest/kotlin/ar/com/intrale/RegisterBusinessIntegrationTest.kt
@@ -1,0 +1,34 @@
+package ar.com.intrale
+
+import asdo.DoRegisterBusiness
+import asdo.DoReviewBusinessRegistration
+import asdo.ToDoRegisterBusiness
+import asdo.ToDoReviewBusinessRegistration
+import ext.*
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class RegisterBusinessIntegrationTest {
+    private class FakeRegisterService : CommRegisterBusinessService {
+        override suspend fun execute(name: String, emailAdmin: String, description: String): Result<RegisterBusinessResponse> {
+            return Result.success(RegisterBusinessResponse(StatusCodeDTO(200, "OK")))
+        }
+    }
+
+    private class FakeReviewService : CommReviewBusinessRegistrationService {
+        override suspend fun execute(name: String, decision: String, twoFactorCode: String): Result<ReviewBusinessRegistrationResponse> {
+            return Result.success(ReviewBusinessRegistrationResponse(StatusCodeDTO(200, "OK")))
+        }
+    }
+
+    @Test
+    fun registerAndApprove() = runBlocking {
+        val register: ToDoRegisterBusiness = DoRegisterBusiness(FakeRegisterService())
+        val review: ToDoReviewBusinessRegistration = DoReviewBusinessRegistration(FakeReviewService())
+        val regResult = register.execute("Biz", "admin@biz.com", "desc")
+        assertTrue(regResult.isSuccess)
+        val revResult = review.execute("Biz", "approved", "123456")
+        assertTrue(revResult.isSuccess)
+    }
+}

--- a/docs/register-business.md
+++ b/docs/register-business.md
@@ -14,6 +14,15 @@ Este documento describe el proceso que permite registrar un nuevo negocio dentro
 - Este proceso está relacionado con la funcionalidad principal detallada en el issue #13.
 - Los detalles de implementación y pruebas se encuentran en la documentación del módulo `users`.
 
+## Interfaz en la aplicación
+
+La aplicación móvil incorpora la pantalla `RegisterBusinessScreen` que permite:
+
+1. Registrar un negocio indicando nombre, correo del administrador y descripción.
+2. Consultar las solicitudes en estado `PENDING` y aprobarlas o rechazarlas mediante el servicio `reviewBusiness`.
+
+La navegación hacia esta pantalla se encuentra disponible desde el menú principal.
+
 
 ## Revisión y aprobación de registros
 
@@ -26,4 +35,4 @@ Cuando un negocio queda registrado en estado `PENDING`, un usuario con perfil *P
 
 Para más detalles consultar la clase `ReviewBusinessRegistration` en `/workspace/users/src/main/kotlin/ar/com/intrale/ReviewBusinessRegistration.kt`.
 
-Relacionado con #64.
+Relacionado con #63.


### PR DESCRIPTION
## Resumen
- agrega servicios y casos de uso para registro y revisión de negocios
- incorpora RegisterBusinessScreen y navegación desde Home
- documenta flujo de registro de negocios
- restaura SignUpDeliveryScreen a su versión anterior

## Testing
- `ANDROID_HOME=/workspace/android-sdk ./gradlew test` *(falla: Compilation error: ExposedDropdownMenu no disponible)*

Closes #63

------
https://chatgpt.com/codex/tasks/task_e_688bf7a221cc83259a2de3e1855df53c