### PR TITLE
[auto] agregar loggers en pantallas de autenticación

### DIFF
--- a/app/composeApp/src/commonMain/kotlin/ui/sc/ChangePasswordScreen.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/ChangePasswordScreen.kt
@@ -20,6 +20,8 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.stringResource
+import org.kodein.log.LoggerFactory
+import org.kodein.log.newLogger
 import ui.cp.Button
 import ui.cp.TextField
 import ui.rs.Res
@@ -30,6 +32,9 @@ import ui.rs.update_password
 const val CHANGE_PASSWORD_PATH = "/change-password"
 
 class ChangePasswordScreen : Screen(CHANGE_PASSWORD_PATH, Res.string.update_password) {
+
+    private val logger = LoggerFactory.default.newLogger<ChangePasswordScreen>()
+
     @Composable
     override fun screen() { screenImpl() }
 
@@ -70,12 +75,18 @@ class ChangePasswordScreen : Screen(CHANGE_PASSWORD_PATH, Res.string.update_pass
                     enabled = !viewModel.loading,
                     onClick = {
                         if (viewModel.isValid()) {
+                            logger.debug { "Formulario válido" }
+                            logger.debug { "Invocando cambio de contraseña" }
                             callService(
                                 coroutineScope = coroutine,
                                 snackbarHostState = snackbarHostState,
                                 setLoading = { viewModel.loading = it },
                                 serviceCall = { viewModel.changePassword() },
-                                onSuccess = { coroutine.launch { snackbarHostState.showSnackbar("Contraseña actualizada") } }
+                                onSuccess = { coroutine.launch { snackbarHostState.showSnackbar("Contraseña actualizada") } },
+                                onError = { error ->
+                                    logger.error { "Error al cambiar contraseña: ${error.message}" }
+                                    snackbarHostState.showSnackbar(error.message ?: "Error")
+                                }
                             )
                         }
                     }

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/ChangePasswordViewModel.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/ChangePasswordViewModel.kt
@@ -9,10 +9,13 @@ import asdo.ToDoChangePassword
 import io.konform.validation.Validation
 import io.konform.validation.jsonschema.minLength
 import org.kodein.di.instance
+import org.kodein.log.LoggerFactory
+import org.kodein.log.newLogger
 
 class ChangePasswordViewModel : ViewModel() {
 
     private val toDoChangePassword: ToDoChangePassword by DIManager.di.instance()
+    private val logger = LoggerFactory.default.newLogger<ChangePasswordViewModel>()
 
     var state by mutableStateOf(ChangePasswordUIState())
     var loading by mutableStateOf(false)
@@ -47,6 +50,11 @@ class ChangePasswordViewModel : ViewModel() {
         )
     }
 
-    suspend fun changePassword(): Result<DoChangePasswordResult> =
-        toDoChangePassword.execute(state.oldPassword, state.newPassword)
+    suspend fun changePassword(): Result<DoChangePasswordResult> {
+        logger.debug { "Ejecutando cambio de contraseña" }
+        val result = toDoChangePassword.execute(state.oldPassword, state.newPassword)
+        result.onSuccess { logger.debug { "Cambio de contraseña exitoso" } }
+            .onFailure { error -> logger.error { "Error al cambiar contraseña: ${error.message}" } }
+        return result
+    }
 }

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/ConfirmPasswordRecoveryScreen.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/ConfirmPasswordRecoveryScreen.kt
@@ -20,6 +20,8 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.stringResource
+import org.kodein.log.LoggerFactory
+import org.kodein.log.newLogger
 import ui.cp.Button
 import ui.cp.TextField
 import ui.rs.Res
@@ -31,6 +33,9 @@ import ui.rs.confirm_password_recovery
 const val CONFIRM_PASSWORD_RECOVERY_PATH = "/confirmPasswordRecovery"
 
 class ConfirmPasswordRecoveryScreen : Screen(CONFIRM_PASSWORD_RECOVERY_PATH, Res.string.confirm_password_recovery) {
+
+    private val logger = LoggerFactory.default.newLogger<ConfirmPasswordRecoveryScreen>()
+
     @Composable
     override fun screen() { screenImpl() }
 
@@ -77,12 +82,18 @@ class ConfirmPasswordRecoveryScreen : Screen(CONFIRM_PASSWORD_RECOVERY_PATH, Res
                     enabled = !viewModel.loading,
                     onClick = {
                         if (viewModel.isValid()) {
+                            logger.debug { "Formulario válido" }
+                            logger.debug { "Confirmando recuperación de contraseña" }
                             callService(
                                 coroutineScope = coroutine,
                                 snackbarHostState = snackbarHostState,
                                 setLoading = { viewModel.loading = it },
                                 serviceCall = { viewModel.confirm() },
-                                onSuccess = { coroutine.launch { snackbarHostState.showSnackbar("Contraseña actualizada") } }
+                                onSuccess = { coroutine.launch { snackbarHostState.showSnackbar("Contraseña actualizada") } },
+                                onError = { error ->
+                                    logger.error { "Error al confirmar recuperación: ${error.message}" }
+                                    snackbarHostState.showSnackbar(error.message ?: "Error")
+                                }
                             )
                         }
                     }

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/ConfirmPasswordRecoveryViewModel.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/ConfirmPasswordRecoveryViewModel.kt
@@ -10,9 +10,12 @@ import io.konform.validation.Validation
 import io.konform.validation.jsonschema.minLength
 import io.konform.validation.jsonschema.pattern
 import org.kodein.di.instance
+import org.kodein.log.LoggerFactory
+import org.kodein.log.newLogger
 
 class ConfirmPasswordRecoveryViewModel : ViewModel() {
     private val toDoConfirmPasswordRecovery: ToDoConfirmPasswordRecovery by DIManager.di.instance()
+    private val logger = LoggerFactory.default.newLogger<ConfirmPasswordRecoveryViewModel>()
 
     var state by mutableStateOf(ConfirmPasswordRecoveryUIState())
     var loading by mutableStateOf(false)
@@ -50,6 +53,11 @@ class ConfirmPasswordRecoveryViewModel : ViewModel() {
         )
     }
 
-    suspend fun confirm(): Result<DoConfirmPasswordRecoveryResult> =
-        toDoConfirmPasswordRecovery.execute(state.email, state.code, state.password)
+    suspend fun confirm(): Result<DoConfirmPasswordRecoveryResult> {
+        logger.debug { "Ejecutando confirmación de recuperación" }
+        val result = toDoConfirmPasswordRecovery.execute(state.email, state.code, state.password)
+        result.onSuccess { logger.debug { "Confirmación de recuperación exitosa" } }
+            .onFailure { error -> logger.error { "Error en confirmación de recuperación: ${error.message}" } }
+        return result
+    }
 }

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/LoginViewModel.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/LoginViewModel.kt
@@ -10,12 +10,15 @@ import asdo.ToDoLogin
 import io.konform.validation.Validation
 import io.konform.validation.jsonschema.minLength
 import org.kodein.di.instance
+import org.kodein.log.LoggerFactory
+import org.kodein.log.newLogger
 import ui.cp.InputState
 
 class LoginViewModel : ViewModel() {
 
     private val todoLogin: ToDoLogin by DIManager.di.instance()
     private val toDoCheckPreviousLogin: ToDoCheckPreviousLogin by DIManager.di.instance()
+    private val logger = LoggerFactory.default.newLogger<LoginViewModel>()
 
     // data state initialize
     var state by mutableStateOf(LoginUIState())
@@ -73,18 +76,25 @@ class LoginViewModel : ViewModel() {
 
     // Features
     suspend fun login(): Result<DoLoginResult> {
+        logger.debug { "Iniciando login" }
         setupValidation()
-        return todoLogin.execute(
+        val result = todoLogin.execute(
             user = state.user,
             password = state.password,
             newPassword = if (changePasswordRequired) state.newPassword else null,
             name = if (changePasswordRequired) state.name else null,
             familyName = if (changePasswordRequired) state.familyName else null
         )
+        result.onSuccess { logger.debug { "Login exitoso" } }
+            .onFailure { error -> logger.error { "Error al iniciar sesión: ${error.message}" } }
+        return result
     }
 
-    suspend fun  previousLogin(): Boolean = toDoCheckPreviousLogin.execute()
-
+    suspend fun previousLogin(): Boolean {
+        logger.debug { "Verificando inicio de sesión previo" }
+        val result = toDoCheckPreviousLogin.execute()
+        logger.debug { "Resultado verificación: $result" }
+        return result
+    }
 }
-
 

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/PasswordRecoveryScreen.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/PasswordRecoveryScreen.kt
@@ -20,6 +20,8 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.stringResource
+import org.kodein.log.LoggerFactory
+import org.kodein.log.newLogger
 import ui.cp.Button
 import ui.cp.TextField
 import ui.rs.Res
@@ -29,6 +31,9 @@ import ui.rs.password_recovery
 const val PASSWORD_RECOVERY_PATH = "/passwordRecovery"
 
 class PasswordRecoveryScreen : Screen(PASSWORD_RECOVERY_PATH, Res.string.password_recovery) {
+
+    private val logger = LoggerFactory.default.newLogger<PasswordRecoveryScreen>()
+
     @Composable
     override fun screen() { screenImpl() }
 
@@ -60,12 +65,18 @@ class PasswordRecoveryScreen : Screen(PASSWORD_RECOVERY_PATH, Res.string.passwor
                     enabled = !viewModel.loading,
                     onClick = {
                         if (viewModel.isValid()) {
+                            logger.debug { "Formulario válido" }
+                            logger.debug { "Solicitando recuperación de contraseña" }
                             callService(
                                 coroutineScope = coroutine,
                                 snackbarHostState = snackbarHostState,
                                 setLoading = { viewModel.loading = it },
                                 serviceCall = { viewModel.recovery() },
-                                onSuccess = { coroutine.launch { snackbarHostState.showSnackbar("Correo enviado") } }
+                                onSuccess = { coroutine.launch { snackbarHostState.showSnackbar("Correo enviado") } },
+                                onError = { error ->
+                                    logger.error { "Error en recuperación de contraseña: ${error.message}" }
+                                    snackbarHostState.showSnackbar(error.message ?: "Error")
+                                }
                             )
                         }
                     }

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/PasswordRecoveryViewModel.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/PasswordRecoveryViewModel.kt
@@ -9,9 +9,12 @@ import asdo.ToDoPasswordRecovery
 import io.konform.validation.Validation
 import io.konform.validation.jsonschema.pattern
 import org.kodein.di.instance
+import org.kodein.log.LoggerFactory
+import org.kodein.log.newLogger
 
 class PasswordRecoveryViewModel : ViewModel() {
     private val toDoPasswordRecovery: ToDoPasswordRecovery by DIManager.di.instance()
+    private val logger = LoggerFactory.default.newLogger<PasswordRecoveryViewModel>()
 
     var state by mutableStateOf(PasswordRecoveryUIState())
     var loading by mutableStateOf(false)
@@ -37,6 +40,11 @@ class PasswordRecoveryViewModel : ViewModel() {
         inputsStates = mutableMapOf(entry(PasswordRecoveryUIState::email.name))
     }
 
-    suspend fun recovery(): Result<DoPasswordRecoveryResult> =
-        toDoPasswordRecovery.execute(state.email)
+    suspend fun recovery(): Result<DoPasswordRecoveryResult> {
+        logger.debug { "Ejecutando recuperación de contraseña" }
+        val result = toDoPasswordRecovery.execute(state.email)
+        result.onSuccess { logger.debug { "Correo de recuperación enviado" } }
+            .onFailure { error -> logger.error { "Error en recuperación de contraseña: ${error.message}" } }
+        return result
+    }
 }


### PR DESCRIPTION
## Resumen
- añadir LoggerFactory en pantallas y viewmodels de autenticación
- registrar flujos y errores en cambio y recuperación de contraseña y login

Closes #164

------
https://chatgpt.com/codex/tasks/task_e_68925661ac7c832582eaf45466c883be