### PR TITLE
[auto] Agregar loggers en pantallas generales del frontend

### DIFF
--- a/app/composeApp/src/commonMain/kotlin/ui/ro/CommonRouter.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/ro/CommonRouter.kt
@@ -53,13 +53,8 @@ class CommonRouter(navigator: NavHostController) : Router(navigator) {
 
                 // sharing the navigator for navigate into the screen composable
                 val actual = iterator.next()
-                actual.navigate = { route: String ->
-                    logger.info { "Navegando a $route" }
-                    try {
-                        navigator.navigate(route)
-                    } catch (e: Exception) {
-                        logger.error(e) { "Error al navegar a $route" }
-                    }
+                actual.navigator = { route: String ->
+                    navigator.navigate(route)
                 }
 
                 // relationship between screen and route

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/Home.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/Home.kt
@@ -13,12 +13,13 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.stringResource
+import org.kodein.log.LoggerFactory
+import org.kodein.log.newLogger
 import ui.cp.Button
 import ui.rs.Res
 import ui.rs.app_name
 import ui.rs.login
 import ui.rs.logout
-import ui.rs.signup
 import ui.rs.change_password
 import ui.rs.register_business
 
@@ -27,8 +28,11 @@ const val HOME_PATH = "/home"
 
 class Home() : Screen(HOME_PATH, Res.string.app_name){
 
+    private val logger = LoggerFactory.default.newLogger<Home>()
+
     @Composable
     override fun screen() {
+        logger.info { "Renderizando Home" }
         screenImplementation()
     }
 
@@ -47,6 +51,7 @@ class Home() : Screen(HOME_PATH, Res.string.app_name){
             Button(
                 label = stringResource(Res.string.login),
                 onClick = {
+                    logger.info { "Navegando a Secundary" }
                     navigate(SECUNDARY_PATH)
                 }
             )
@@ -54,6 +59,7 @@ class Home() : Screen(HOME_PATH, Res.string.app_name){
             Button(
                 label = stringResource(Res.string.change_password),
                 onClick = {
+                    logger.info { "Navegando a ChangePassword" }
                     navigate(CHANGE_PASSWORD_PATH)
                 }
             )
@@ -61,6 +67,7 @@ class Home() : Screen(HOME_PATH, Res.string.app_name){
             Button(
                 label = stringResource(Res.string.register_business),
                 onClick = {
+                    logger.info { "Navegando a RegisterBusiness" }
                     navigate(REGISTER_BUSINESS_PATH)
                 }
             )
@@ -69,8 +76,14 @@ class Home() : Screen(HOME_PATH, Res.string.app_name){
                 label = stringResource(Res.string.logout),
                 onClick = {
                     coroutineScope.launch {
-                        viewModel.logout()
-                        navigate(LOGIN_PATH)
+                        logger.info { "Solicitando logout" }
+                        try {
+                            viewModel.logout()
+                            logger.info { "Logout exitoso" }
+                            navigate(LOGIN_PATH)
+                        } catch (e: Exception) {
+                            logger.error(e) { "Error en logout" }
+                        }
                     }
 
                 }

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/HomeViewModel.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/HomeViewModel.kt
@@ -3,10 +3,14 @@ package ui.sc
 import DIManager
 import asdo.ToDoResetLoginCache
 import org.kodein.di.instance
+import org.kodein.log.LoggerFactory
+import org.kodein.log.newLogger
 
 class HomeViewModel : ViewModel()  {
 
     private val toDoResetLoginCache: ToDoResetLoginCache by DIManager.di.instance()
+
+    private val logger = LoggerFactory.default.newLogger<HomeViewModel>()
 
     // data state initialize
     override fun getState(): Any  = Unit
@@ -14,6 +18,13 @@ class HomeViewModel : ViewModel()  {
     override fun initInputState() { /* Do nothing */ }
 
     suspend fun logout(){
-        toDoResetLoginCache.execute()
+        logger.info { "Ejecutando logout" }
+        try {
+            toDoResetLoginCache.execute()
+            logger.info { "Logout completado" }
+        } catch (e: Exception){
+            logger.error(e) { "Error al cerrar sesión" }
+            throw e
+        }
     }
 }

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/Screen.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/Screen.kt
@@ -2,10 +2,23 @@ package ui.sc
 
 import androidx.compose.runtime.Composable
 import org.jetbrains.compose.resources.StringResource
+import org.kodein.log.LoggerFactory
+import org.kodein.log.newLogger
 
 abstract class Screen (val route: String, val title: StringResource) {
 
-    lateinit var navigate: (route:String) -> Unit
+    private val logger = LoggerFactory.default.newLogger<Screen>()
+
+    lateinit var navigator: (route:String) -> Unit
+
+    fun navigate(route:String){
+        logger.info { "Navegando a $route" }
+        try {
+            navigator(route)
+        }catch (e: Exception){
+            logger.error(e) { "Error al navegar a $route" }
+        }
+    }
 
     @Composable
     abstract fun screen()

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/Secundary.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/Secundary.kt
@@ -23,14 +23,20 @@ import ui.rs.secundary
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
+import org.kodein.log.LoggerFactory
+import org.kodein.log.newLogger
 
 
 const val SECUNDARY_PATH = "/secundary"
 
 class Secundary : Screen (SECUNDARY_PATH, Res.string.secundary) {
+
+    private val logger = LoggerFactory.default.newLogger<Secundary>()
+
     @OptIn(ExperimentalResourceApi::class)
     @Composable
     override fun screen() {
+        logger.info { "Renderizando Secundary" }
         var showContent by remember { mutableStateOf(false) }
 
         Column(
@@ -45,6 +51,7 @@ class Secundary : Screen (SECUNDARY_PATH, Res.string.secundary) {
                 label = stringResource(Res.string.login),
                 onClick = {
                     showContent = !showContent
+                    logger.info { "Mostrar contenido adicional: $showContent" }
                 }
             )
 

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/ServiceCaller.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/ServiceCaller.kt
@@ -3,6 +3,10 @@ package ui.sc
 import androidx.compose.material3.SnackbarHostState
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import org.kodein.log.LoggerFactory
+import org.kodein.log.newLogger
+
+private val logger = LoggerFactory.default.newLogger("ui.sc", "ServiceCaller")
 
 fun <T> callService(
     coroutineScope: CoroutineScope,
@@ -13,12 +17,15 @@ fun <T> callService(
     onError: suspend (Throwable) -> Unit = { snackbarHostState.showSnackbar(it.message ?: "Error") }
 ) {
     coroutineScope.launch {
+        logger.info { "Iniciando llamada de servicio" }
         setLoading(true)
         val result = serviceCall()
         result.onSuccess {
+            logger.info { "Servicio exitoso" }
             setLoading(false)
             onSuccess(it)
         }.onFailure { error ->
+            logger.error(error) { "Error en servicio" }
             setLoading(false)
             onError(error)
         }


### PR DESCRIPTION
## Resumen
- se agregaron loggers en pantallas y utilitarios del frontend
- se centralizó la navegación con registros de errores

## Pruebas
- `./gradlew test` (falla: SDK Android no configurado)

Closes #165

------
https://chatgpt.com/codex/tasks/task_e_689256641d8c8325b934a1ccc67645a2