### PR TITLE
[auto] Agregar loggers en pantallas generales del frontend

### DIFF
--- a/app/composeApp/src/commonMain/kotlin/ui/sc/Home.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/Home.kt
@@ -13,6 +13,8 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.stringResource
+import org.kodein.log.LoggerFactory
+import org.kodein.log.newLogger
 import ui.cp.Button
 import ui.rs.Res
 import ui.rs.app_name
@@ -27,8 +29,11 @@ const val HOME_PATH = "/home"
 
 class Home() : Screen(HOME_PATH, Res.string.app_name){
 
+    private val logger = LoggerFactory.default.newLogger<Home>()
+
     @Composable
     override fun screen() {
+        logger.debug { "Renderizando pantalla Home" }
         screenImplementation()
     }
 
@@ -47,6 +52,7 @@ class Home() : Screen(HOME_PATH, Res.string.app_name){
             Button(
                 label = stringResource(Res.string.login),
                 onClick = {
+                    logger.info { "Navegando a $SECUNDARY_PATH" }
                     navigate(SECUNDARY_PATH)
                 }
             )
@@ -54,6 +60,7 @@ class Home() : Screen(HOME_PATH, Res.string.app_name){
             Button(
                 label = stringResource(Res.string.change_password),
                 onClick = {
+                    logger.info { "Navegando a $CHANGE_PASSWORD_PATH" }
                     navigate(CHANGE_PASSWORD_PATH)
                 }
             )
@@ -61,6 +68,7 @@ class Home() : Screen(HOME_PATH, Res.string.app_name){
             Button(
                 label = stringResource(Res.string.register_business),
                 onClick = {
+                    logger.info { "Navegando a $REGISTER_BUSINESS_PATH" }
                     navigate(REGISTER_BUSINESS_PATH)
                 }
             )
@@ -69,8 +77,14 @@ class Home() : Screen(HOME_PATH, Res.string.app_name){
                 label = stringResource(Res.string.logout),
                 onClick = {
                     coroutineScope.launch {
-                        viewModel.logout()
-                        navigate(LOGIN_PATH)
+                        logger.info { "Solicitando logout" }
+                        try {
+                            viewModel.logout()
+                            logger.info { "Logout exitoso" }
+                            navigate(LOGIN_PATH)
+                        } catch (e: Throwable) {
+                            logger.error(e) { "Error durante logout" }
+                        }
                     }
 
                 }

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/HomeViewModel.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/HomeViewModel.kt
@@ -3,8 +3,12 @@ package ui.sc
 import DIManager
 import asdo.ToDoResetLoginCache
 import org.kodein.di.instance
+import org.kodein.log.LoggerFactory
+import org.kodein.log.newLogger
 
 class HomeViewModel : ViewModel()  {
+
+    private val logger = LoggerFactory.default.newLogger<HomeViewModel>()
 
     private val toDoResetLoginCache: ToDoResetLoginCache by DIManager.di.instance()
 
@@ -14,6 +18,13 @@ class HomeViewModel : ViewModel()  {
     override fun initInputState() { /* Do nothing */ }
 
     suspend fun logout(){
-        toDoResetLoginCache.execute()
+        logger.info { "Ejecutando logout" }
+        try {
+            toDoResetLoginCache.execute()
+            logger.info { "Logout completado" }
+        } catch (e: Throwable) {
+            logger.error(e) { "Error al ejecutar logout" }
+            throw e
+        }
     }
 }

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/Screen.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/Screen.kt
@@ -2,8 +2,12 @@ package ui.sc
 
 import androidx.compose.runtime.Composable
 import org.jetbrains.compose.resources.StringResource
+import org.kodein.log.LoggerFactory
+import org.kodein.log.newLogger
 
 abstract class Screen (val route: String, val title: StringResource) {
+
+    protected val logger = LoggerFactory.default.newLogger<Screen>()
 
     lateinit var navigate: (route:String) -> Unit
 

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/Secundary.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/Secundary.kt
@@ -15,6 +15,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import org.kodein.log.LoggerFactory
+import org.kodein.log.newLogger
 import ui.cp.Button
 import ui.rs.Res
 import ui.rs.compose_multiplatform
@@ -28,9 +30,11 @@ import org.jetbrains.compose.resources.stringResource
 const val SECUNDARY_PATH = "/secundary"
 
 class Secundary : Screen (SECUNDARY_PATH, Res.string.secundary) {
+    private val logger = LoggerFactory.default.newLogger<Secundary>()
     @OptIn(ExperimentalResourceApi::class)
     @Composable
     override fun screen() {
+        logger.debug { "Renderizando pantalla Secundary" }
         var showContent by remember { mutableStateOf(false) }
 
         Column(
@@ -44,6 +48,7 @@ class Secundary : Screen (SECUNDARY_PATH, Res.string.secundary) {
             Button(
                 label = stringResource(Res.string.login),
                 onClick = {
+                    logger.info { "Mostrando contenido alternativo" }
                     showContent = !showContent
                 }
             )


### PR DESCRIPTION
Se incorporaron loggers utilizando LoggerFactory en las pantallas y utilitarios principales para mejorar la observabilidad.

Closes #165

------
https://chatgpt.com/codex/tasks/task_e_68925668cfdc8325a7c5cb4c0b9339fa