### PR TITLE
[auto] SearchBusinesses usa DynamoDB para listar negocios

### DIFF
--- a/users/src/main/kotlin/ar/com/intrale/Modules.kt
+++ b/users/src/main/kotlin/ar/com/intrale/Modules.kt
@@ -179,7 +179,7 @@ val appModule = DI.Module("appModule") {
         singleton { ReviewJoinBusiness(instance(), instance(), instance(), instance()) }
     }
     bind<Function> (tag="searchBusinesses") {
-        singleton { SearchBusinesses(instance(), instance()) }
+        singleton { SearchBusinesses(instance<DynamoDbTable<Business>>(), instance()) }
     }
     bind<Function> (tag="configAutoAcceptDeliveries") {
         singleton { ConfigAutoAcceptDeliveries(instance(), instance(), instance(), instance(), instance()) }

--- a/users/src/main/kotlin/ar/com/intrale/SearchBusinesses.kt
+++ b/users/src/main/kotlin/ar/com/intrale/SearchBusinesses.kt
@@ -2,10 +2,11 @@ package ar.com.intrale
 
 import com.google.gson.Gson
 import org.slf4j.Logger
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable
 
 class SearchBusinesses(
-    val config: UsersConfig,
-    val logger: Logger
+    private val tableBusiness: DynamoDbTable<Business>,
+    private val logger: Logger
 ) : Function {
 
     override suspend fun execute(
@@ -20,22 +21,40 @@ class SearchBusinesses(
         } else {
             SearchBusinessesRequest()
         }
-        val businesses = config.businesses
-        val filtered = businesses
-            .filter { body.query.isBlank() || it.contains(body.query, ignoreCase = true) }
-            .map {
-                BusinessDTO(
-                    id = it,
-                    name = it,
-                    description = "",
-                    emailAdmin = "${it}@admin.com",
-                    autoAcceptDeliveries = false,
-                    status = "PENDING"
-                )
-            }
-            .filter { body.status == null || it.status.equals(body.status, ignoreCase = true) }
-        val limited = if (body.limit != null) filtered.take(body.limit) else filtered
+
+        val items = tableBusiness.scan().items().toList()
+
+        val filtered = items
+            .filter { body.query.isBlank() || it.name?.contains(body.query, ignoreCase = true) == true }
+            .filter { body.status == null || it.state.name.equals(body.status, ignoreCase = true) }
+            .sortedBy { it.name ?: "" }
+
+        val startIndex = body.lastKey?.let { key -> filtered.indexOfFirst { it.name == key } + 1 } ?: 0
+
+        val paged = if (body.limit != null) {
+            filtered.drop(startIndex).take(body.limit)
+        } else {
+            filtered.drop(startIndex)
+        }
+
+        val lastKey = if (body.limit != null && startIndex + body.limit < filtered.size) {
+            filtered[startIndex + body.limit - 1].name
+        } else {
+            null
+        }
+
+        val responseItems = paged.map {
+            BusinessDTO(
+                id = it.name ?: "",
+                name = it.name ?: "",
+                description = it.description ?: "",
+                emailAdmin = it.emailAdmin ?: "",
+                autoAcceptDeliveries = it.autoAcceptDeliveries,
+                status = it.state.name
+            )
+        }
+
         logger.debug("return search businesses $function")
-        return SearchBusinessesResponse(limited.toTypedArray(), null)
+        return SearchBusinessesResponse(responseItems.toTypedArray(), lastKey)
     }
 }

--- a/users/src/test/kotlin/ar/com/intrale/SearchBusinessesTest.kt
+++ b/users/src/test/kotlin/ar/com/intrale/SearchBusinessesTest.kt
@@ -1,0 +1,69 @@
+package ar.com.intrale
+
+import com.google.gson.Gson
+import kotlinx.coroutines.runBlocking
+import org.slf4j.helpers.NOPLogger
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClientExtension
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable
+import software.amazon.awssdk.enhanced.dynamodb.Key
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema
+import software.amazon.awssdk.enhanced.dynamodb.model.Page
+import software.amazon.awssdk.enhanced.dynamodb.model.PageIterable
+import software.amazon.awssdk.enhanced.dynamodb.model.ScanEnhancedRequest
+import software.amazon.awssdk.core.pagination.sync.SdkIterable
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class SearchDummyBusinessTable : DynamoDbTable<Business> {
+    val items = mutableListOf<Business>()
+    override fun mapperExtension(): DynamoDbEnhancedClientExtension? = null
+    override fun tableSchema(): TableSchema<Business> = TableSchema.fromBean(Business::class.java)
+    override fun tableName(): String = "business"
+    override fun keyFrom(item: Business): Key = Key.builder().partitionValue(item.name).build()
+    override fun index(indexName: String) = throw UnsupportedOperationException()
+    override fun scan(request: ScanEnhancedRequest?): PageIterable<Business> {
+        val sorted = items.sortedBy { it.name }
+        val startKey = request?.exclusiveStartKey()?.get("name")?.s()
+        val startIndex = startKey?.let { sorted.indexOfFirst { b -> b.name == it } + 1 } ?: 0
+        val limit = request?.limit() ?: sorted.size
+        val pageItems = sorted.drop(startIndex).take(limit)
+        val last = if (startIndex + pageItems.size < sorted.size) sorted[startIndex + pageItems.size - 1].name else null
+        val page = if (last != null)
+            Page.create(pageItems, mutableMapOf("name" to AttributeValue.builder().s(last).build()))
+        else Page.create(pageItems)
+        return PageIterable.create(SdkIterable { mutableListOf(page).iterator() })
+    }
+
+    override fun scan(): PageIterable<Business> {
+        val page = Page.create(items)
+        return PageIterable.create(SdkIterable { mutableListOf(page).iterator() })
+    }
+}
+
+class SearchBusinessesTest {
+    private val logger = NOPLogger.NOP_LOGGER
+
+    @Test
+    fun `busca negocios con filtros y paginacion`() = runBlocking {
+        val table = SearchDummyBusinessTable()
+        table.items += Business(name = "Alpha", emailAdmin = "a@admin.com", description = "", state = BusinessState.APPROVED, autoAcceptDeliveries = false)
+        table.items += Business(name = "Beta", emailAdmin = "b@admin.com", description = "", state = BusinessState.PENDING, autoAcceptDeliveries = false)
+        table.items += Business(name = "Gamma", emailAdmin = "g@admin.com", description = "", state = BusinessState.APPROVED, autoAcceptDeliveries = true)
+
+        val search = SearchBusinesses(table, logger)
+
+        val req1 = SearchBusinessesRequest(query = "a", status = "APPROVED", limit = 1)
+        val resp1 = search.execute("biz", "searchBusinesses", emptyMap(), Gson().toJson(req1)) as SearchBusinessesResponse
+        assertEquals(1, resp1.businesses.size)
+        assertEquals("Alpha", resp1.businesses[0].name)
+        assertEquals("Alpha", resp1.lastKey)
+
+        val req2 = SearchBusinessesRequest(query = "a", status = "APPROVED", limit = 1, lastKey = resp1.lastKey)
+        val resp2 = search.execute("biz", "searchBusinesses", emptyMap(), Gson().toJson(req2)) as SearchBusinessesResponse
+        assertEquals(1, resp2.businesses.size)
+        assertEquals("Gamma", resp2.businesses[0].name)
+        assertNull(resp2.lastKey)
+    }
+}


### PR DESCRIPTION
## Resumen
- reemplazo de UsersConfig por consulta a DynamoDB en SearchBusinesses
- se inyecta tableBusiness y se agrega paginación
- prueba unitaria para filtros y paginación

Closes #182

------
https://chatgpt.com/codex/tasks/task_e_6894949e89f083259318273e0fd76958