### PR TITLE
[auto] Evitar aprobación de negocios con nombre duplicado

### DIFF
--- a/docs/register-business.md
+++ b/docs/register-business.md
@@ -14,6 +14,7 @@ Este documento describe el proceso que permite registrar un nuevo negocio dentro
 - Este proceso está relacionado con la funcionalidad principal detallada en el issue #13.
 - Los detalles de implementación y pruebas se encuentran en la documentación del módulo `users`.
 - Si existe un negocio en estado `PENDING` con igual nombre y correo de administrador, se rechaza un nuevo registro. Relacionado con #184.
+- Los nombres de negocios aprobados son únicos sin diferenciar mayúsculas/minúsculas. Relacionado con #185.
 
 ## Interfaz en la aplicación
 

--- a/users/src/main/kotlin/ar/com/intrale/ReviewBusinessRegistration.kt
+++ b/users/src/main/kotlin/ar/com/intrale/ReviewBusinessRegistration.kt
@@ -102,6 +102,13 @@ class ReviewBusinessRegistration (val config: UsersConfig, val logger: Logger,
 
             // Cambiar el estado del negocio segun la bandera de aceptado o rechazado
             if (body.decision.uppercase() == "APPROVED") {
+                val existing = tableBusiness.scan().items().firstOrNull {
+                    it.name.equals(body.name, ignoreCase = true) && it.state == BusinessState.APPROVED
+                }
+                if (existing != null) {
+                    return ExceptionResponse("El nombre del negocio ya existe")
+                }
+
                 businessData.state = BusinessState.APPROVED
                 // Si el negocio es aceptado, Validar si el usuario Business Admin ya se encuentra registrado en intrale en caso de que No, enviar mail para signup del usuario
                 logger.debug("checking User Business Admin")

--- a/users/src/test/kotlin/ar/com/intrale/ReviewBusinessRegistrationTest.kt
+++ b/users/src/test/kotlin/ar/com/intrale/ReviewBusinessRegistrationTest.kt
@@ -1,14 +1,23 @@
 import ar.com.intrale.*
 import ar.com.intrale.Function
-import io.ktor.http.HttpStatusCode
-import org.slf4j.helpers.NOPLogger
-import aws.sdk.kotlin.runtime.auth.credentials.StaticCredentialsProvider
 import aws.sdk.kotlin.services.cognitoidentityprovider.CognitoIdentityProviderClient
-import aws.smithy.kotlin.runtime.auth.awscredentials.Credentials
-import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable
-import software.amazon.awssdk.enhanced.dynamodb.TableSchema
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.AttributeType
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.GetUserResponse
+import com.google.gson.Gson
+import io.ktor.http.HttpStatusCode
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.slf4j.helpers.NOPLogger
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClientExtension
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable
 import software.amazon.awssdk.enhanced.dynamodb.Key
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema
+import software.amazon.awssdk.enhanced.dynamodb.model.Page
+import software.amazon.awssdk.enhanced.dynamodb.model.PageIterable
+import software.amazon.awssdk.core.pagination.sync.SdkIterable
+import java.util.function.Consumer
+import software.amazon.awssdk.enhanced.dynamodb.model.GetItemEnhancedRequest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -21,6 +30,24 @@ class DummyBusinessTable : DynamoDbTable<Business> {
     override fun index(indexName: String) = throw UnsupportedOperationException()
     override fun putItem(item: Business) { items.add(item) }
     override fun getItem(key: Key): Business? = items.find { it.name == key.partitionKeyValue().s() }
+    override fun getItem(item: Business): Business? = items.find { it.name == item.name }
+    override fun getItem(request: GetItemEnhancedRequest): Business? = getItem(request.key())
+    override fun getItem(requestConsumer: Consumer<GetItemEnhancedRequest.Builder>): Business? {
+        val builder = GetItemEnhancedRequest.builder()
+        requestConsumer.accept(builder)
+        return getItem(builder.build().key())
+    }
+    override fun scan(): PageIterable<Business> =
+        PageIterable.create(SdkIterable { mutableListOf(Page.create(items)).iterator() })
+    override fun updateItem(item: Business): Business {
+        val index = items.indexOfFirst { it.name == item.name }
+        if (index >= 0) {
+            items[index] = item
+        } else {
+            items.add(item)
+        }
+        return item
+    }
 }
 
 class DummyUserTable : DynamoDbTable<User> {
@@ -31,6 +58,11 @@ class DummyUserTable : DynamoDbTable<User> {
     override fun keyFrom(item: User): Key = Key.builder().partitionValue(item.email).build()
     override fun index(indexName: String) = throw UnsupportedOperationException()
     override fun getItem(key: Key): User? = items.find { it.email == key.partitionKeyValue().s() }
+    override fun getItem(requestConsumer: Consumer<GetItemEnhancedRequest.Builder>): User? {
+        val builder = GetItemEnhancedRequest.builder()
+        requestConsumer.accept(builder)
+        return getItem(builder.build().key())
+    }
     override fun putItem(item: User) { items.add(item) }
 }
 
@@ -42,6 +74,8 @@ class DummyProfileTable : DynamoDbTable<UserBusinessProfile> {
     override fun keyFrom(item: UserBusinessProfile): Key = Key.builder().partitionValue(item.email).sortValue(item.business).build()
     override fun index(indexName: String) = throw UnsupportedOperationException()
     override fun putItem(item: UserBusinessProfile) { items.add(item) }
+    override fun scan(): PageIterable<UserBusinessProfile> =
+        PageIterable.create(SdkIterable { mutableListOf(Page.create(items)).iterator() })
 }
 
 class ReviewBusinessRegistrationTest {
@@ -60,12 +94,7 @@ class ReviewBusinessRegistrationTest {
         ) = Response()
     }
 
-    private val cognito = CognitoIdentityProviderClient {
-        region = config.region
-        credentialsProvider = StaticCredentialsProvider(
-            Credentials(accessKeyId = "key", secretAccessKey = "secret")
-        )
-    }
+    private val cognito = mockk<CognitoIdentityProviderClient>()
 
     private val review = ReviewBusinessRegistration(
         config,
@@ -90,5 +119,30 @@ class ReviewBusinessRegistrationTest {
         val req = ReviewBusinessRegistrationRequest("Biz", "invalid", "123456")
         val resp = review.requestValidation(req)
         assertEquals(HttpStatusCode.BadRequest, (resp as RequestValidationException).statusCode)
+    }
+
+    @Test
+    fun negocioDuplicadoNoSeAprueba() = runBlocking {
+        tableBusiness.items.clear()
+        tableProfiles.items.clear()
+        tableUsers.items.clear()
+
+        tableBusiness.putItem(Business(name = "Tienda", state = BusinessState.APPROVED))
+        tableBusiness.putItem(Business(name = "tienda", emailAdmin = "admin@biz.com", state = BusinessState.PENDING))
+        tableProfiles.putItem(UserBusinessProfile().apply {
+            email = "admin@biz.com"
+            business = "biz"
+            profile = PLATFORM_ADMIN_PROFILE
+            state = BusinessState.APPROVED
+        })
+        coEvery { cognito.getUser(any()) } returns GetUserResponse {
+            username = "admin"
+            userAttributes = listOf(AttributeType { name = EMAIL_ATT_NAME; value = "admin@biz.com" })
+        }
+
+        val req = ReviewBusinessRegistrationRequest("tienda", "approved", "123456")
+        val resp = review.execute("biz", "review", mapOf("Authorization" to "token"), Gson().toJson(req))
+
+        assertEquals("El nombre del negocio ya existe", (resp as ExceptionResponse).message)
     }
 }


### PR DESCRIPTION
## Resumen
- valida nombres únicos de negocios al aprobar
- agrega prueba unitaria para nombre duplicado
- documenta restricción de nombres

Closes #185

------
https://chatgpt.com/codex/tasks/task_e_6899e01f0a8c8325a3903179f148b4e1