### PR TITLE
[auto] pantallas unión de deliveries a negocio

### DIFF
--- a/app/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/app/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -39,4 +39,9 @@
     <string name="approve_selected">Aprobar seleccionados</string>
     <string name="reject_selected">Rechazar seleccionados</string>
     <string name="auto_accept_deliveries">Auto acepta entregas</string>
+    <string name="request_join_business">Solicitar unión</string>
+    <string name="request_join_business_sent">Solicitud enviada</string>
+    <string name="review_join_business">Revisar solicitudes de unión</string>
+    <string name="review_join_business_approved">Aprobar</string>
+    <string name="review_join_business_rejected">Rechazar</string>
 </resources>

--- a/app/composeApp/src/commonMain/kotlin/DIManager.kt
+++ b/app/composeApp/src/commonMain/kotlin/DIManager.kt
@@ -39,6 +39,8 @@ public const val PASSWORD_RECOVERY = "passwordRecovery"
 public const val CONFIRM_PASSWORD_RECOVERY = "confirmPasswordRecovery"
 public const val REVIEW_BUSINESS = "reviewBusiness"
 public const val REGISTER_NEW_BUSINESS = "registerNewBusiness"
+public const val REQUEST_JOIN_BUSINESS = "requestJoinBusiness"
+public const val REVIEW_JOIN_BUSINESS = "reviewJoinBusiness"
 
 const val LOGIN_PATH = "/login"
 
@@ -67,6 +69,8 @@ class DIManager {
                 bindSingleton(tag = CONFIRM_PASSWORD_RECOVERY) { ConfirmPasswordRecoveryScreen() }
                 bindSingleton(tag = REGISTER_NEW_BUSINESS) { RegisterNewBusinessScreen() }
                 bindSingleton(tag = REVIEW_BUSINESS) { ReviewBusinessScreen() }
+                bindSingleton(tag = REQUEST_JOIN_BUSINESS) { RequestJoinBusinessScreen() }
+                bindSingleton(tag = REVIEW_JOIN_BUSINESS) { ReviewJoinBusinessScreen() }
 
                 bindSingleton (tag = SCREENS) {
                     arrayListOf<Screen>(
@@ -82,7 +86,9 @@ class DIManager {
                         instance(tag = PASSWORD_RECOVERY),
                         instance(tag = CONFIRM_PASSWORD_RECOVERY),
                         instance(tag = REVIEW_BUSINESS),
-                        instance(tag = REGISTER_NEW_BUSINESS)
+                        instance(tag = REGISTER_NEW_BUSINESS),
+                        instance(tag = REQUEST_JOIN_BUSINESS),
+                        instance(tag = REVIEW_JOIN_BUSINESS)
                     )
                 }
 
@@ -119,6 +125,8 @@ class DIManager {
                 bindSingleton<CommPasswordRecoveryService> { ClientPasswordRecoveryService(instance()) }
                 bindSingleton<CommRegisterBusinessService> { ClientRegisterBusinessService(instance()) }
                 bindSingleton<CommReviewBusinessRegistrationService> { ClientReviewBusinessRegistrationService(instance()) }
+                bindSingleton<CommRequestJoinBusinessService> { ClientRequestJoinBusinessService(instance()) }
+                bindSingleton<CommReviewJoinBusinessService> { ClientReviewJoinBusinessService(instance()) }
 
                 bindSingleton<ToDoLogin> { DoLogin(instance(), instance()) }
                 bindSingleton<ToDoSignUp> { DoSignUp(instance()) }
@@ -133,6 +141,8 @@ class DIManager {
                 bindSingleton<ToDoConfirmPasswordRecovery> { DoConfirmPasswordRecovery(instance()) }
                 bindSingleton<ToDoRegisterBusiness> { DoRegisterBusiness(instance()) }
                 bindSingleton<ToDoReviewBusinessRegistration> { DoReviewBusinessRegistration(instance()) }
+                bindSingleton<ToDoRequestJoinBusiness> { DoRequestJoinBusiness(instance()) }
+                bindSingleton<ToDoReviewJoinBusiness> { DoReviewJoinBusiness(instance()) }
 
             }
     }

--- a/app/composeApp/src/commonMain/kotlin/asdo/DoRequestJoinBusiness.kt
+++ b/app/composeApp/src/commonMain/kotlin/asdo/DoRequestJoinBusiness.kt
@@ -1,0 +1,9 @@
+package asdo
+
+import ext.CommRequestJoinBusinessService
+import ext.RequestJoinBusinessResponse
+
+class DoRequestJoinBusiness(private val service: CommRequestJoinBusinessService) : ToDoRequestJoinBusiness {
+    override suspend fun execute(business: String): Result<RequestJoinBusinessResponse> =
+        service.execute(business)
+}

--- a/app/composeApp/src/commonMain/kotlin/asdo/DoReviewJoinBusiness.kt
+++ b/app/composeApp/src/commonMain/kotlin/asdo/DoReviewJoinBusiness.kt
@@ -1,0 +1,9 @@
+package asdo
+
+import ext.CommReviewJoinBusinessService
+import ext.ReviewJoinBusinessResponse
+
+class DoReviewJoinBusiness(private val service: CommReviewJoinBusinessService) : ToDoReviewJoinBusiness {
+    override suspend fun execute(business: String, email: String, decision: String): Result<ReviewJoinBusinessResponse> =
+        service.execute(business, email, decision)
+}

--- a/app/composeApp/src/commonMain/kotlin/asdo/ToDoRequestJoinBusiness.kt
+++ b/app/composeApp/src/commonMain/kotlin/asdo/ToDoRequestJoinBusiness.kt
@@ -1,0 +1,7 @@
+package asdo
+
+import ext.RequestJoinBusinessResponse
+
+interface ToDoRequestJoinBusiness {
+    suspend fun execute(business: String): Result<RequestJoinBusinessResponse>
+}

--- a/app/composeApp/src/commonMain/kotlin/asdo/ToDoReviewJoinBusiness.kt
+++ b/app/composeApp/src/commonMain/kotlin/asdo/ToDoReviewJoinBusiness.kt
@@ -1,0 +1,7 @@
+package asdo
+
+import ext.ReviewJoinBusinessResponse
+
+interface ToDoReviewJoinBusiness {
+    suspend fun execute(business: String, email: String, decision: String): Result<ReviewJoinBusinessResponse>
+}

--- a/app/composeApp/src/commonMain/kotlin/ext/ClientRequestJoinBusinessService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/ClientRequestJoinBusinessService.kt
@@ -1,0 +1,40 @@
+package ext
+
+import ar.com.intrale.BuildKonfig
+import io.ktor.client.HttpClient
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.isSuccess
+import io.ktor.utils.io.InternalAPI
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+class ClientRequestJoinBusinessService(private val httpClient: HttpClient) : CommRequestJoinBusinessService {
+    @OptIn(InternalAPI::class)
+    override suspend fun execute(business: String): Result<RequestJoinBusinessResponse> {
+        return try {
+            val response: HttpResponse = httpClient.post("${BuildKonfig.BASE_URL}${business}/requestJoinBusiness") {
+                setBody(RequestJoinBusinessRequest())
+            }
+            if (response.status.isSuccess()) {
+                val bodyText = response.bodyAsText()
+                val result = Json.decodeFromString(RequestJoinBusinessResponse.serializer(), bodyText)
+                Result.success(result)
+            } else {
+                val bodyText = response.bodyAsText()
+                val exception = Json.decodeFromString(ExceptionResponse.serializer(), bodyText)
+                Result.failure(exception)
+            }
+        } catch (e: Exception) {
+            Result.failure(e.toExceptionResponse())
+        }
+    }
+}
+
+@Serializable
+data class RequestJoinBusinessRequest(val placeholder: String? = null)
+
+@Serializable
+data class RequestJoinBusinessResponse(val state: String)

--- a/app/composeApp/src/commonMain/kotlin/ext/ClientReviewJoinBusinessService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/ClientReviewJoinBusinessService.kt
@@ -1,0 +1,38 @@
+package ext
+
+import ar.com.intrale.BuildKonfig
+import io.ktor.client.HttpClient
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.isSuccess
+import io.ktor.utils.io.InternalAPI
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+class ClientReviewJoinBusinessService(private val httpClient: HttpClient) : CommReviewJoinBusinessService {
+    @OptIn(InternalAPI::class)
+    override suspend fun execute(business: String, email: String, decision: String): Result<ReviewJoinBusinessResponse> {
+        return try {
+            val response: HttpResponse = httpClient.post("${BuildKonfig.BASE_URL}${business}/reviewJoinBusiness") {
+                setBody(ReviewJoinBusinessRequest(email, decision))
+            }
+            if (response.status.isSuccess()) {
+                Result.success(ReviewJoinBusinessResponse(StatusCodeDTO(response.status.value, response.status.description)))
+            } else {
+                val bodyText = response.bodyAsText()
+                val exception = Json.decodeFromString(ExceptionResponse.serializer(), bodyText)
+                Result.failure(exception)
+            }
+        } catch (e: Exception) {
+            Result.failure(e.toExceptionResponse())
+        }
+    }
+}
+
+@Serializable
+data class ReviewJoinBusinessRequest(val email: String, val decision: String)
+
+@Serializable
+data class ReviewJoinBusinessResponse(val statusCode: StatusCodeDTO)

--- a/app/composeApp/src/commonMain/kotlin/ext/CommRequestJoinBusinessService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/CommRequestJoinBusinessService.kt
@@ -1,0 +1,6 @@
+package ext
+
+interface CommRequestJoinBusinessService {
+    suspend fun execute(business: String): Result<RequestJoinBusinessResponse>
+}
+

--- a/app/composeApp/src/commonMain/kotlin/ext/CommReviewJoinBusinessService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/CommReviewJoinBusinessService.kt
@@ -1,0 +1,6 @@
+package ext
+
+interface CommReviewJoinBusinessService {
+    suspend fun execute(business: String, email: String, decision: String): Result<ReviewJoinBusinessResponse>
+}
+

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/RequestJoinBusinessScreen.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/RequestJoinBusinessScreen.kt
@@ -1,0 +1,81 @@
+package ui.sc
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.stringResource
+import org.kodein.log.LoggerFactory
+import org.kodein.log.newLogger
+import ui.cp.Button
+import ui.cp.TextField
+import ui.rs.Res
+import ui.rs.business
+import ui.rs.request_join_business
+import ui.rs.request_join_business_sent
+
+const val REQUEST_JOIN_BUSINESS_PATH = "/requestJoinBusiness"
+
+class RequestJoinBusinessScreen : Screen(REQUEST_JOIN_BUSINESS_PATH, Res.string.request_join_business) {
+    private val logger = LoggerFactory.default.newLogger<RequestJoinBusinessScreen>()
+
+    @Composable
+    override fun screen() { screenImpl() }
+
+    @OptIn(ExperimentalResourceApi::class)
+    @Composable
+    private fun screenImpl(viewModel: RequestJoinBusinessViewModel = viewModel { RequestJoinBusinessViewModel() }) {
+        val coroutine = rememberCoroutineScope()
+        val snackbarHostState = remember { SnackbarHostState() }
+        val requestSent = stringResource(Res.string.request_join_business_sent)
+
+        Scaffold(snackbarHost = { SnackbarHost(snackbarHostState) }) {
+            Column(
+                Modifier
+                    .fillMaxWidth()
+                    .verticalScroll(rememberScrollState()),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Spacer(Modifier.size(10.dp))
+                TextField(
+                    Res.string.business,
+                    value = viewModel.state.business,
+                    state = viewModel.inputsStates[RequestJoinBusinessViewModel.UIState::business.name]!!,
+                    onValueChange = { viewModel.state = viewModel.state.copy(business = it) }
+                )
+                Spacer(Modifier.size(10.dp))
+                Button(
+                    label = stringResource(Res.string.request_join_business),
+                    loading = viewModel.loading,
+                    enabled = !viewModel.loading,
+                    onClick = {
+                        if (viewModel.isValid()) {
+                            logger.info { "Solicitud de unión a negocio" }
+                            callService(
+                                coroutineScope = coroutine,
+                                snackbarHostState = snackbarHostState,
+                                setLoading = { viewModel.loading = it },
+                                serviceCall = { viewModel.request() },
+                                onSuccess = {
+                                    coroutine.launch { snackbarHostState.showSnackbar(requestSent) }
+                                    viewModel.state = RequestJoinBusinessViewModel.UIState()
+                                    viewModel.initInputState()
+                                }
+                            )
+                        }
+                    }
+                )
+                Spacer(Modifier.size(10.dp))
+            }
+        }
+    }
+}

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/RequestJoinBusinessViewModel.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/RequestJoinBusinessViewModel.kt
@@ -1,0 +1,45 @@
+package ui.sc
+
+import DIManager
+import asdo.ToDoRequestJoinBusiness
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import io.konform.validation.Validation
+import io.konform.validation.required
+import org.kodein.di.instance
+import org.kodein.log.LoggerFactory
+import org.kodein.log.newLogger
+
+class RequestJoinBusinessViewModel : ViewModel() {
+    private val logger = LoggerFactory.default.newLogger<RequestJoinBusinessViewModel>()
+    private val requestJoin: ToDoRequestJoinBusiness by DIManager.di.instance()
+
+    var state by mutableStateOf(UIState())
+    var loading by mutableStateOf(false)
+
+    data class UIState(
+        val business: String = "",
+        val resultState: String? = null
+    )
+
+    override fun getState(): Any = state
+
+    init {
+        validation = Validation<UIState> {
+            UIState::business required {}
+        } as Validation<Any>
+        initInputState()
+    }
+
+    override fun initInputState() {
+        inputsStates = mutableMapOf(
+            entry(UIState::business.name)
+        )
+    }
+
+    suspend fun request() =
+        requestJoin.execute(state.business)
+            .onSuccess { state = state.copy(resultState = it.state) }
+            .onFailure { error -> logger.error { "Error al solicitar unión: ${error.message}" } }
+}

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/ReviewJoinBusinessScreen.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/ReviewJoinBusinessScreen.kt
@@ -1,0 +1,107 @@
+package ui.sc
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.stringResource
+import org.kodein.log.LoggerFactory
+import org.kodein.log.newLogger
+import ui.cp.Button
+import ui.cp.TextField
+import ui.rs.Res
+import ui.rs.email
+import ui.rs.review_join_business
+import ui.rs.review_join_business_approved
+import ui.rs.review_join_business_rejected
+
+const val REVIEW_JOIN_BUSINESS_PATH = "/reviewJoinBusiness"
+
+class ReviewJoinBusinessScreen : Screen(REVIEW_JOIN_BUSINESS_PATH, Res.string.review_join_business) {
+    private val logger = LoggerFactory.default.newLogger<ReviewJoinBusinessScreen>()
+
+    @Composable
+    override fun screen() { screenImpl() }
+
+    @OptIn(ExperimentalResourceApi::class)
+    @Composable
+    private fun screenImpl(viewModel: ReviewJoinBusinessViewModel = viewModel { ReviewJoinBusinessViewModel() }) {
+        val coroutine = rememberCoroutineScope()
+        val snackbarHostState = remember { SnackbarHostState() }
+        val approvedMsg = stringResource(Res.string.review_join_business_approved)
+        val rejectedMsg = stringResource(Res.string.review_join_business_rejected)
+
+        Scaffold(snackbarHost = { SnackbarHost(snackbarHostState) }) {
+            Column(
+                Modifier
+                    .fillMaxWidth()
+                    .verticalScroll(rememberScrollState()),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Spacer(Modifier.size(10.dp))
+                TextField(
+                    Res.string.email,
+                    value = viewModel.state.email,
+                    state = viewModel.inputsStates[ReviewJoinBusinessViewModel.UIState::email.name]!!,
+                    onValueChange = { viewModel.state = viewModel.state.copy(email = it) }
+                )
+                Spacer(Modifier.size(10.dp))
+                Row {
+                    Button(
+                        label = stringResource(Res.string.review_join_business_approved),
+                        loading = viewModel.loading,
+                        enabled = !viewModel.loading,
+                        onClick = {
+                            if (viewModel.isValid()) {
+                                logger.info { "Aprobando unión" }
+                                callService(
+                                    coroutineScope = coroutine,
+                                    snackbarHostState = snackbarHostState,
+                                    setLoading = { viewModel.loading = it },
+                                    serviceCall = { viewModel.approve() },
+                                    onSuccess = {
+                                        coroutine.launch { snackbarHostState.showSnackbar(approvedMsg) }
+                                        viewModel.state = ReviewJoinBusinessViewModel.UIState()
+                                        viewModel.initInputState()
+                                    }
+                                )
+                            }
+                        }
+                    )
+                    Spacer(Modifier.size(10.dp))
+                    Button(
+                        label = stringResource(Res.string.review_join_business_rejected),
+                        loading = viewModel.loading,
+                        enabled = !viewModel.loading,
+                        onClick = {
+                            if (viewModel.isValid()) {
+                                logger.info { "Rechazando unión" }
+                                callService(
+                                    coroutineScope = coroutine,
+                                    snackbarHostState = snackbarHostState,
+                                    setLoading = { viewModel.loading = it },
+                                    serviceCall = { viewModel.reject() },
+                                    onSuccess = {
+                                        coroutine.launch { snackbarHostState.showSnackbar(rejectedMsg) }
+                                        viewModel.state = ReviewJoinBusinessViewModel.UIState()
+                                        viewModel.initInputState()
+                                    }
+                                )
+                            }
+                        }
+                    )
+                }
+                Spacer(Modifier.size(10.dp))
+            }
+        }
+    }
+}

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/ReviewJoinBusinessViewModel.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/ReviewJoinBusinessViewModel.kt
@@ -1,0 +1,49 @@
+package ui.sc
+
+import DIManager
+import ar.com.intrale.BuildKonfig
+import asdo.ToDoReviewJoinBusiness
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import io.konform.validation.Validation
+import io.konform.validation.jsonschema.pattern
+import io.konform.validation.required
+import org.kodein.di.instance
+import org.kodein.log.LoggerFactory
+import org.kodein.log.newLogger
+
+class ReviewJoinBusinessViewModel : ViewModel() {
+    private val logger = LoggerFactory.default.newLogger<ReviewJoinBusinessViewModel>()
+    private val reviewJoin: ToDoReviewJoinBusiness by DIManager.di.instance()
+
+    var state by mutableStateOf(UIState())
+    var loading by mutableStateOf(false)
+
+    data class UIState(
+        val email: String = ""
+    )
+
+    override fun getState(): Any = state
+
+    init {
+        validation = Validation<UIState> {
+            UIState::email required { pattern(".+@.+\\..+") hint "Correo inválido" }
+        } as Validation<Any>
+        initInputState()
+    }
+
+    override fun initInputState() {
+        inputsStates = mutableMapOf(
+            entry(UIState::email.name)
+        )
+    }
+
+    suspend fun approve() =
+        reviewJoin.execute(BuildKonfig.BUSINESS, state.email, "APPROVED")
+            .onFailure { error -> logger.error { "Error aprobando solicitud: ${error.message}" } }
+
+    suspend fun reject() =
+        reviewJoin.execute(BuildKonfig.BUSINESS, state.email, "REJECTED")
+            .onFailure { error -> logger.error { "Error rechazando solicitud: ${error.message}" } }
+}

--- a/app/composeApp/src/commonTest/kotlin/ui/sc/RequestJoinBusinessViewModelTest.kt
+++ b/app/composeApp/src/commonTest/kotlin/ui/sc/RequestJoinBusinessViewModelTest.kt
@@ -1,0 +1,15 @@
+package ui.sc
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class RequestJoinBusinessViewModelTest {
+    @Test
+    fun `business requerido`() {
+        val vm = RequestJoinBusinessViewModel()
+        assertFalse(vm.isValid())
+        vm.state = vm.state.copy(business = "intrale")
+        assertTrue(vm.isValid())
+    }
+}

--- a/app/composeApp/src/commonTest/kotlin/ui/sc/ReviewJoinBusinessViewModelTest.kt
+++ b/app/composeApp/src/commonTest/kotlin/ui/sc/ReviewJoinBusinessViewModelTest.kt
@@ -1,0 +1,15 @@
+package ui.sc
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ReviewJoinBusinessViewModelTest {
+    @Test
+    fun `email requerido y valido`() {
+        val vm = ReviewJoinBusinessViewModel()
+        assertFalse(vm.isValid())
+        vm.state = vm.state.copy(email = "correo@dominio.com")
+        assertTrue(vm.isValid())
+    }
+}

--- a/docs/request-join-business.md
+++ b/docs/request-join-business.md
@@ -10,3 +10,7 @@ POST /{business}/requestJoinBusiness
 Se requiere un token JWT válido del Delivery. Al recibir la petición se guarda un registro en `UserBusinessProfile` con estado `PENDING`.
 
 Desde la versión actual el cliente `CognitoIdentityProviderClient` se mantiene abierto para evitar fallos por cierre inesperado.
+
+### Pantallas de la aplicación
+- `RequestJoinBusinessScreen` permite al delivery enviar la solicitud indicando el negocio.
+- `ReviewJoinBusinessScreen` habilita al administrador del negocio aprobar o rechazar las solicitudes recibidas.


### PR DESCRIPTION
## Summary
- nuevas pantallas para solicitar y revisar unión de deliveries
- servicios y casos de uso para requestJoinBusiness y reviewJoinBusiness
- documentación y pruebas básicas

## Testing
- `./gradlew test` *(falló: SDK location not found)*

Closes #65

------
https://chatgpt.com/codex/tasks/task_e_68b0bbfd38ac8325a1d2e48c022b8c6f