### PR TITLE
[auto] acceso a registro y revisión de deliverys

### DIFF
--- a/app/composeApp/src/commonMain/kotlin/ui/sc/Home.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/Home.kt
@@ -23,6 +23,7 @@ import ui.rs.logout
 import ui.rs.change_password
 import ui.rs.register_business
 import ui.rs.review_business
+import ui.rs.review_join_business
 
 
 const val HOME_PATH = "/home"
@@ -70,6 +71,14 @@ class Home() : Screen(HOME_PATH, Res.string.app_name){
                 onClick = {
                     logger.info { "Navegando a $REVIEW_BUSINESS_PATH" }
                     navigate(REVIEW_BUSINESS_PATH)
+                }
+            )
+
+            Button(
+                label = stringResource(Res.string.review_join_business),
+                onClick = {
+                    logger.info { "Navegando a $REVIEW_JOIN_BUSINESS_PATH" }
+                    navigate(REVIEW_JOIN_BUSINESS_PATH)
                 }
             )
 

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/Login.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/Login.kt
@@ -50,6 +50,7 @@ import ui.rs.name
 import ui.rs.family_name
 import ui.rs.update_password
 import ui.rs.signup
+import ui.rs.signup_delivery
 import ui.rs.register_business
 import io.ktor.client.plugins.ClientRequestException
 import org.kodein.log.LoggerFactory
@@ -60,6 +61,7 @@ import ui.rs.confirm_password_recovery
 import ui.sc.PASSWORD_RECOVERY_PATH
 import ui.sc.CONFIRM_PASSWORD_RECOVERY_PATH
 import ui.sc.REGISTER_NEW_BUSINESS_PATH
+import ui.sc.SIGNUP_DELIVERY_PATH
 
 const val LOGIN_PATH = "/login"
 
@@ -199,6 +201,12 @@ class Login() : Screen(LOGIN_PATH, Res.string.login){
                             Button(
                                 label = stringResource(Res.string.register_business),
                                 onClick = { navigate(REGISTER_NEW_BUSINESS_PATH) },
+                                colors = ButtonDefaults.buttonColors(containerColor = Color.Transparent, contentColor = Color(0xFF2C71C7))
+                            )
+                            Spacer(modifier = Modifier.size(16.dp))
+                            Button(
+                                label = stringResource(Res.string.signup_delivery),
+                                onClick = { navigate(SIGNUP_DELIVERY_PATH) },
                                 colors = ButtonDefaults.buttonColors(containerColor = Color.Transparent, contentColor = Color(0xFF2C71C7))
                             )
                             Spacer(modifier = Modifier.size(16.dp))


### PR DESCRIPTION
## Resumen
- agrega botón en login para registrar delivery en un negocio
- permite revisar solicitudes de delivery desde el home

## Testing
- `./gradlew test` (falla: SDK location not found)

Closes #203

------
https://chatgpt.com/codex/tasks/task_e_68b0c463ef088325834a0aad0249f23d