### PR TITLE
[auto] Configuración básica de 2FA con fallback

### DIFF
--- a/app/composeApp/src/commonTest/kotlin/ui/sc/TwoFactorSetupViewModelTest.kt
+++ b/app/composeApp/src/commonTest/kotlin/ui/sc/TwoFactorSetupViewModelTest.kt
@@ -1,0 +1,26 @@
+package ui.sc
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class TwoFactorSetupViewModelTest {
+    @Test
+    fun `deep link exitoso y fallback a QR`() {
+        val vm = TwoFactorSetupViewModel()
+        vm.onDeepLinkResult(true)
+        assertFalse(vm.state.showQr)
+        vm.onDeepLinkResult(false)
+        assertTrue(vm.state.showQr)
+    }
+
+    @Test
+    fun `copia de secret y url`() {
+        val vm = TwoFactorSetupViewModel()
+        val uri = "otpauth://totp/intrale:demo?secret=ABCDEF123456&issuer=intrale"
+        vm.onOtpAuthUri(uri)
+        assertEquals("ABCDEF123456", vm.copySecret())
+        assertEquals(uri, vm.copyLink())
+    }
+}

--- a/docs/two_factor_authentication.md
+++ b/docs/two_factor_authentication.md
@@ -1,10 +1,13 @@
 # Autenticación en dos pasos
-> Relacionado con #61
+> Relacionado con #213
 
 Este flujo permite a los usuarios configurar y validar un segundo factor de autenticación.
 
 ## Configuración
-La pantalla `TwoFactorSetupScreen` solicita al backend el enlace `otpauth://` mediante el endpoint `/2fasetup` y lo muestra para ser escaneado o copiado.
+La pantalla `TwoFactorSetupScreen` solicita al backend el enlace `otpauth://` mediante el endpoint `/2fasetup`.
+Al recibirlo intenta abrir la aplicación autenticadora con `openUri()`.
+Si no existe una app compatible o ocurre un error, se muestra un QR generado localmente junto con el texto `issuer:account` y el secreto enmascarado.
+Desde esta vista es posible copiar solo el valor de `secret`, copiar el enlace completo, buscar una app autenticadora en la tienda o compartir el enlace.
 
 ## Verificación
 `TwoFactorVerifyScreen` permite ingresar el código de seis dígitos y lo valida contra el endpoint `/2faverify`.


### PR DESCRIPTION
## Resumen
- abre enlace otpauth y si falla muestra QR y datos de la cuenta
- agrega acciones para copiar, compartir y buscar autenticador
- documentación del flujo actualizada

Closes #213

------
https://chatgpt.com/codex/tasks/task_e_68bf04757624832589ff1f86507c1472