### PR TITLE
[auto] Manejo de errores en TwoFactorSetupScreen

### DIFF
--- a/app/composeApp/src/commonMain/kotlin/ui/sc/TwoFactorSetupScreen.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/TwoFactorSetupScreen.kt
@@ -24,6 +24,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.kodein.log.LoggerFactory
 import org.kodein.log.newLogger
+import kotlinx.coroutines.launch
 import ui.rs.Res
 import ui.rs.two_factor_setup
 
@@ -86,11 +87,27 @@ class TwoFactorSetupScreen : Screen(TWO_FACTOR_SETUP_PATH, Res.string.two_factor
                         Text("Copiar enlace")
                     }
                     Button(onClick = {
-                        uriHandler.openUri("https://play.google.com/store/search?q=authenticator")
+                        try {
+                            uriHandler.openUri("https://play.google.com/store/search?q=authenticator")
+                        } catch (e: Throwable) {
+                            logger.error(e) { "No fue posible abrir la aplicación de autenticación" }
+                            coroutine.launch {
+                                snackbarHostState.showSnackbar("No fue posible abrir la aplicación de autenticación")
+                            }
+                        }
                     }) {
                         Text("Buscar autenticador")
                     }
-                    Button(onClick = { uriHandler.openUri(viewModel.copyLink()) }) {
+                    Button(onClick = {
+                        try {
+                            uriHandler.openUri(viewModel.copyLink())
+                        } catch (e: Throwable) {
+                            logger.error(e) { "No se pudo compartir el enlace" }
+                            coroutine.launch {
+                                snackbarHostState.showSnackbar("No se pudo compartir el enlace")
+                            }
+                        }
+                    }) {
                         Text("Compartir")
                     }
                 }

--- a/docs/two_factor_authentication.md
+++ b/docs/two_factor_authentication.md
@@ -8,6 +8,8 @@ La pantalla `TwoFactorSetupScreen` solicita al backend el enlace `otpauth://` me
 Al recibirlo intenta abrir la aplicación autenticadora con `openUri()`.
 Si no existe una app compatible o ocurre un error, se muestra un QR generado localmente junto con el texto `issuer:account` y el secreto enmascarado.
 Desde esta vista es posible copiar solo el valor de `secret`, copiar el enlace completo, buscar una app autenticadora en la tienda o compartir el enlace.
+Si al intentar buscar la aplicación de autenticación no se puede abrir la tienda, se muestra el mensaje "No fue posible abrir la aplicación de autenticación".
+Si la acción de compartir falla, se informa al usuario con "No se pudo compartir el enlace" y la pantalla continúa disponible.
 
 ## Verificación
 `TwoFactorVerifyScreen` permite ingresar el código de seis dígitos y lo valida contra el endpoint `/2faverify`.


### PR DESCRIPTION
## Resumen
- evitar crash al buscar autenticador o compartir
- documentar manejo de errores

## Testing
- `./gradlew test` (falla: SDK location not found)

Closes #215

------
https://chatgpt.com/codex/tasks/task_e_68c7ffa086248325b893368088dc958c