### PR TITLE
[auto] Agrega token a la revisión de negocios

### DIFF
--- a/app/composeApp/build.gradle.kts
+++ b/app/composeApp/build.gradle.kts
@@ -98,6 +98,8 @@ kotlin {
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)
+            implementation(libs.ktor.client.mock)
+            implementation(libs.kotlinx.coroutines.test)
         }
         desktopMain.dependencies {
             implementation(compose.desktop.currentOs)

--- a/app/composeApp/src/commonMain/kotlin/DIManager.kt
+++ b/app/composeApp/src/commonMain/kotlin/DIManager.kt
@@ -148,7 +148,7 @@ class DIManager {
                 bindSingleton<ToDoPasswordRecovery> { DoPasswordRecovery(instance()) }
                 bindSingleton<ToDoConfirmPasswordRecovery> { DoConfirmPasswordRecovery(instance()) }
                 bindSingleton<ToDoRegisterBusiness> { DoRegisterBusiness(instance()) }
-                bindSingleton<ToDoReviewBusinessRegistration> { DoReviewBusinessRegistration(instance()) }
+                bindSingleton<ToDoReviewBusinessRegistration> { DoReviewBusinessRegistration(instance(), instance()) }
                 bindSingleton<ToDoRequestJoinBusiness> { DoRequestJoinBusiness(instance()) }
                 bindSingleton<ToDoReviewJoinBusiness> { DoReviewJoinBusiness(instance()) }
                 bindSingleton<ToDoTwoFactorSetup> { DoTwoFactorSetup(instance(), instance()) }

--- a/app/composeApp/src/commonMain/kotlin/asdo/DoReviewBusinessRegistration.kt
+++ b/app/composeApp/src/commonMain/kotlin/asdo/DoReviewBusinessRegistration.kt
@@ -1,9 +1,19 @@
 package asdo
 
+import ext.CommKeyValueStorage
 import ext.CommReviewBusinessRegistrationService
 import ext.ReviewBusinessRegistrationResponse
 
-class DoReviewBusinessRegistration(private val service: CommReviewBusinessRegistrationService) : ToDoReviewBusinessRegistration {
-    override suspend fun execute(publicId: String, decision: String, twoFactorCode: String): Result<ReviewBusinessRegistrationResponse> =
-        service.execute(publicId, decision, twoFactorCode)
+class DoReviewBusinessRegistration(
+    private val service: CommReviewBusinessRegistrationService,
+    private val storage: CommKeyValueStorage
+) : ToDoReviewBusinessRegistration {
+    override suspend fun execute(
+        publicId: String,
+        decision: String,
+        twoFactorCode: String
+    ): Result<ReviewBusinessRegistrationResponse> {
+        val token = storage.token ?: return Result.failure(Exception("Token no encontrado"))
+        return service.execute(publicId, decision, twoFactorCode, token)
+    }
 }

--- a/app/composeApp/src/commonMain/kotlin/ext/ClientReviewBusinessRegistrationService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/ClientReviewBusinessRegistrationService.kt
@@ -2,6 +2,7 @@ package ext
 
 import ar.com.intrale.BuildKonfig
 import io.ktor.client.HttpClient
+import io.ktor.client.request.headers
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.HttpResponse
@@ -13,9 +14,15 @@ import kotlinx.serialization.json.Json
 
 class ClientReviewBusinessRegistrationService(private val httpClient: HttpClient) : CommReviewBusinessRegistrationService {
     @OptIn(InternalAPI::class)
-    override suspend fun execute(publicId: String, decision: String, twoFactorCode: String): Result<ReviewBusinessRegistrationResponse> {
+    override suspend fun execute(
+        publicId: String,
+        decision: String,
+        twoFactorCode: String,
+        token: String
+    ): Result<ReviewBusinessRegistrationResponse> {
         return try {
             val response: HttpResponse = httpClient.post("${BuildKonfig.BASE_URL}${BuildKonfig.BUSINESS}/reviewBusiness") {
+                headers { append("Authorization", token) }
                 setBody(ReviewBusinessRegistrationRequest(publicId, decision, twoFactorCode))
             }
             if (response.status.isSuccess()) {

--- a/app/composeApp/src/commonMain/kotlin/ext/CommReviewBusinessRegistrationService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/CommReviewBusinessRegistrationService.kt
@@ -1,5 +1,10 @@
 package ext
 
 interface CommReviewBusinessRegistrationService {
-    suspend fun execute(publicId: String, decision: String, twoFactorCode: String): Result<ReviewBusinessRegistrationResponse>
+    suspend fun execute(
+        publicId: String,
+        decision: String,
+        twoFactorCode: String,
+        token: String
+    ): Result<ReviewBusinessRegistrationResponse>
 }

--- a/app/composeApp/src/commonTest/kotlin/ar/com/intrale/RegisterBusinessIntegrationTest.kt
+++ b/app/composeApp/src/commonTest/kotlin/ar/com/intrale/RegisterBusinessIntegrationTest.kt
@@ -16,7 +16,12 @@ class RegisterBusinessIntegrationTest {
     }
 
     private class FakeReviewService : CommReviewBusinessRegistrationService {
-        override suspend fun execute(name: String, decision: String, twoFactorCode: String): Result<ReviewBusinessRegistrationResponse> {
+        override suspend fun execute(
+            name: String,
+            decision: String,
+            twoFactorCode: String,
+            token: String
+        ): Result<ReviewBusinessRegistrationResponse> {
             return Result.success(ReviewBusinessRegistrationResponse(StatusCodeDTO(200, "OK")))
         }
     }

--- a/app/composeApp/src/commonTest/kotlin/asdo/DoReviewBusinessRegistrationTest.kt
+++ b/app/composeApp/src/commonTest/kotlin/asdo/DoReviewBusinessRegistrationTest.kt
@@ -1,0 +1,62 @@
+package asdo
+
+import ext.CommKeyValueStorage
+import ext.CommReviewBusinessRegistrationService
+import ext.ReviewBusinessRegistrationResponse
+import ext.StatusCodeDTO
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+private class FakeStorage(initialToken: String?) : CommKeyValueStorage {
+    override var token: String? = initialToken
+}
+
+private class CapturingReviewService : CommReviewBusinessRegistrationService {
+    var receivedToken: String? = null
+    override suspend fun execute(
+        publicId: String,
+        decision: String,
+        twoFactorCode: String,
+        token: String
+    ): Result<ReviewBusinessRegistrationResponse> {
+        receivedToken = token
+        return Result.success(ReviewBusinessRegistrationResponse(StatusCodeDTO(200, "OK")))
+    }
+}
+
+class DoReviewBusinessRegistrationTest {
+    @Test
+    fun `retorna error cuando no existe token`() = runTest {
+        val service = object : CommReviewBusinessRegistrationService {
+            override suspend fun execute(
+                publicId: String,
+                decision: String,
+                twoFactorCode: String,
+                token: String
+            ): Result<ReviewBusinessRegistrationResponse> {
+                error("El servicio no debería ejecutarse sin token")
+            }
+        }
+        val storage = FakeStorage(null)
+        val useCase = DoReviewBusinessRegistration(service, storage)
+
+        val result = useCase.execute("pub-1", "approved", "123456")
+
+        assertTrue(result.isFailure)
+        assertEquals("Token no encontrado", result.exceptionOrNull()?.message)
+    }
+
+    @Test
+    fun `envia el token al servicio cuando existe`() = runTest {
+        val service = CapturingReviewService()
+        val storage = FakeStorage("Bearer token-123")
+        val useCase = DoReviewBusinessRegistration(service, storage)
+
+        val result = useCase.execute("pub-2", "rejected", "654321")
+
+        assertTrue(result.isSuccess)
+        assertEquals("Bearer token-123", service.receivedToken)
+    }
+}

--- a/app/composeApp/src/commonTest/kotlin/ext/ClientReviewBusinessRegistrationServiceTest.kt
+++ b/app/composeApp/src/commonTest/kotlin/ext/ClientReviewBusinessRegistrationServiceTest.kt
@@ -1,0 +1,60 @@
+package ext
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.DefaultRequest
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.header
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.http.content.TextContent
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ClientReviewBusinessRegistrationServiceTest {
+    @Test
+    fun `adjunta el token en Authorization y conserva el cuerpo`() = runTest {
+        var capturedAuthorization: String? = null
+        var capturedBody: String? = null
+
+        val engine = MockEngine { request ->
+            capturedAuthorization = request.headers[HttpHeaders.Authorization]
+            capturedBody = (request.body as TextContent).text
+            respond(
+                content = """{"statusCode":{"value":200,"description":"OK"}}""",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+            )
+        }
+
+        val client = HttpClient(engine) {
+            install(ContentNegotiation) {
+                json(Json { ignoreUnknownKeys = true })
+            }
+            install(DefaultRequest) {
+                header(HttpHeaders.ContentType, ContentType.Application.Json)
+            }
+        }
+
+        val service = ClientReviewBusinessRegistrationService(client)
+        val result = service.execute("pub-123", "approved", "654321", "Bearer token-xyz")
+
+        assertTrue(result.isSuccess)
+        assertEquals("Bearer token-xyz", capturedAuthorization)
+
+        val json = Json { ignoreUnknownKeys = true }
+        val body = requireNotNull(capturedBody) { "El cuerpo de la petición no fue capturado" }
+        val requestPayload = json.decodeFromString(ReviewBusinessRegistrationRequest.serializer(), body)
+        assertEquals(
+            ReviewBusinessRegistrationRequest("pub-123", "approved", "654321"),
+            requestPayload
+        )
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -64,6 +64,7 @@ ktor-client-serialization = { group = "io.ktor", name = "ktor-client-serializati
 ktor-client-content-negotiation = { group = "io.ktor", name = "ktor-client-content-negotiation", version.ref = "ktor-wasm2" }
 ktor-client-android = { group = "io.ktor", name = "ktor-client-android", version.ref = "ktor-wasm2" }
 ktor-serialization-kotlinx-json = { group = "io.ktor", name = "ktor-serialization-kotlinx-json", version.ref = "ktor-wasm2" }
+ktor-client-mock = { group = "io.ktor", name = "ktor-client-mock", version.ref = "ktor-wasm2" }
 
 kodein-di = { module = "org.kodein.di:kodein-di", version.ref = "kodein" }
 kodein-di-framework-ktor-server-jvm = { module = "org.kodein.di:kodein-di-framework-ktor-server-jvm", version.ref = "kodein" }
@@ -114,6 +115,7 @@ canard = { module = "org.kodein.log:canard", version.ref = "canard" }
 settings-no-arg = { module = "com.russhwolf:multiplatform-settings-no-arg", version.ref = "russhwolf" }
 settings-serialization = { module = "com.russhwolf:multiplatform-settings-serialization", version.ref = "russhwolf" }
 settings-coroutines = { module = "com.russhwolf:multiplatform-settings-coroutines", version.ref = "russhwolf" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 
 [bundles]
 ktor-common = ["ktor-client-core", "ktor-client-json", "ktor-client-logging", "ktor-client-serialization", "ktor-client-content-negotiation", "ktor-serialization-kotlinx-json"]


### PR DESCRIPTION
## Resumen
- actualizo CommReviewBusinessRegistrationService y su cliente para aceptar el token y enviarlo en Authorization
- obtengo el token desde CommKeyValueStorage en DoReviewBusinessRegistration y ajusto la configuración de dependencias
- agrego dependencias y pruebas que cubren el envío del encabezado y el fallo cuando falta el token

## Pruebas
- `./gradlew :app:composeApp:desktopTest --console=plain`

Closes #218

------
https://chatgpt.com/codex/tasks/task_e_68c84a21139c832593fae6c07722718e