### PR TITLE
[auto] Corrige imports de teclado en TextField

### DIFF
--- a/app/composeApp/src/commonMain/kotlin/ui/cp/TextField.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/cp/TextField.kt
@@ -1,6 +1,8 @@
 package ui.cp
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Visibility
 import androidx.compose.material.icons.outlined.VisibilityOff
@@ -18,7 +20,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.error
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.input.KeyboardOptions
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextOverflow
@@ -38,7 +39,7 @@ fun TextField(
     modifier: Modifier = Modifier,
     leadingIcon: (@Composable () -> Unit)? = null,
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
-    keyboardActions: androidx.compose.ui.text.input.KeyboardActions = androidx.compose.ui.text.input.KeyboardActions.Default,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
     placeholder: StringResource? = null,
     supportingText: (@Composable () -> Unit)? = null,
     enabled: Boolean = true,


### PR DESCRIPTION
## Resumen
- Actualicé los imports de KeyboardOptions y KeyboardActions en `TextField` para utilizar las clases provistas por `androidx.compose.foundation.text`.

## Pruebas
- ./gradlew build *(falla por ausencia de Android SDK en el entorno de CI)*

Closes #236

------
https://chatgpt.com/codex/tasks/task_e_68cac47016948325b031c9669d48b8ce