### PR TITLE
[auto] Corrige errores de compilación en Compose

### DIFF
--- a/app/composeApp/src/commonMain/kotlin/ui/cp/Button.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/cp/Button.kt
@@ -1,6 +1,7 @@
 package ui.cp
 
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -38,7 +39,7 @@ fun Button(
             CircularProgressIndicator(
                 strokeWidth = MaterialTheme.spacing.x0_5 / 2,
                 modifier = Modifier.size(MaterialTheme.spacing.x3),
-                color = colors.contentColor(enabled = true).value
+                color = MaterialTheme.colorScheme.onPrimary
             )
         } else {
             Text(

--- a/app/composeApp/src/commonMain/kotlin/ui/cp/IntralePrimaryButton.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/cp/IntralePrimaryButton.kt
@@ -1,6 +1,7 @@
 package ui.cp
 
 import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
@@ -55,6 +56,14 @@ fun IntralePrimaryButton(
     )
 
     val gradientBrush = IntraleButtonDefaults.primaryBrush()
+    val colorScheme = MaterialTheme.colorScheme
+    val shimmerColors = remember(colorScheme) {
+        listOf(
+            colorScheme.onPrimary.copy(alpha = 0f),
+            colorScheme.onPrimary.copy(alpha = 0.25f),
+            colorScheme.onPrimary.copy(alpha = 0f)
+        )
+    }
 
     var buttonModifier = IntraleButtonDefaults
         .baseModifier(modifier, isInteractive)
@@ -88,11 +97,7 @@ fun IntralePrimaryButton(
         Canvas(modifier = Modifier.fillMaxSize()) {
             drawRect(
                 brush = Brush.linearGradient(
-                    colors = listOf(
-                        MaterialTheme.colorScheme.onPrimary.copy(alpha = 0f),
-                        MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.25f),
-                        MaterialTheme.colorScheme.onPrimary.copy(alpha = 0f)
-                    ),
+                    colors = shimmerColors,
                     start = Offset(shimmerOffset, 0f),
                     end = Offset(shimmerOffset + size.width / 3f, size.height)
                 ),

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/ReviewBusinessScreen.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/ReviewBusinessScreen.kt
@@ -1,7 +1,6 @@
 package ui.sc
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Card
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -10,6 +9,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.MaterialTheme

--- a/app/composeApp/src/commonMain/kotlin/ui/th/Theme.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/th/Theme.kt
@@ -99,7 +99,7 @@ fun IntraleTheme(
     ) {
         MaterialTheme(
             colorScheme = colorScheme,
-            typography = IntraleTypography,
+            typography = IntraleTypography(),
             shapes = IntraleShapes,
             content = content
         )

--- a/app/composeApp/src/commonMain/kotlin/ui/th/Type.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/th/Type.kt
@@ -3,6 +3,8 @@
 package ui.th
 
 import androidx.compose.material3.Typography
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -11,77 +13,84 @@ import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.Font
 import ui.rs.Res
 
-private val IntraleFontFamily = FontFamily(
-    Font(Res.font.intrale_regular, weight = FontWeight.Normal),
-    Font(Res.font.intrale_medium, weight = FontWeight.Medium),
-    Font(Res.font.intrale_semibold, weight = FontWeight.SemiBold)
-)
+@Composable
+fun IntraleTypography(): Typography {
+    val regular = Font(Res.font.intrale_regular, weight = FontWeight.Normal)
+    val medium = Font(Res.font.intrale_medium, weight = FontWeight.Medium)
+    val semiBold = Font(Res.font.intrale_semibold, weight = FontWeight.SemiBold)
 
-val IntraleTypography = Typography(
-    displayLarge = TextStyle(
-        fontFamily = IntraleFontFamily,
-        fontWeight = FontWeight.SemiBold,
-        fontSize = 40.sp,
-        lineHeight = 48.sp
-    ),
-    headlineMedium = TextStyle(
-        fontFamily = IntraleFontFamily,
-        fontWeight = FontWeight.SemiBold,
-        fontSize = 28.sp,
-        lineHeight = 36.sp
-    ),
-    titleLarge = TextStyle(
-        fontFamily = IntraleFontFamily,
-        fontWeight = FontWeight.SemiBold,
-        fontSize = 22.sp,
-        lineHeight = 28.sp
-    ),
-    titleMedium = TextStyle(
-        fontFamily = IntraleFontFamily,
-        fontWeight = FontWeight.Medium,
-        fontSize = 18.sp,
-        lineHeight = 24.sp
-    ),
-    titleSmall = TextStyle(
-        fontFamily = IntraleFontFamily,
-        fontWeight = FontWeight.Medium,
-        fontSize = 16.sp,
-        lineHeight = 22.sp
-    ),
-    bodyLarge = TextStyle(
-        fontFamily = IntraleFontFamily,
-        fontWeight = FontWeight.Normal,
-        fontSize = 16.sp,
-        lineHeight = 24.sp
-    ),
-    bodyMedium = TextStyle(
-        fontFamily = IntraleFontFamily,
-        fontWeight = FontWeight.Normal,
-        fontSize = 14.sp,
-        lineHeight = 20.sp
-    ),
-    bodySmall = TextStyle(
-        fontFamily = IntraleFontFamily,
-        fontWeight = FontWeight.Normal,
-        fontSize = 12.sp,
-        lineHeight = 16.sp
-    ),
-    labelLarge = TextStyle(
-        fontFamily = IntraleFontFamily,
-        fontWeight = FontWeight.SemiBold,
-        fontSize = 16.sp,
-        lineHeight = 20.sp
-    ),
-    labelMedium = TextStyle(
-        fontFamily = IntraleFontFamily,
-        fontWeight = FontWeight.Medium,
-        fontSize = 14.sp,
-        lineHeight = 18.sp
-    ),
-    labelSmall = TextStyle(
-        fontFamily = IntraleFontFamily,
-        fontWeight = FontWeight.Medium,
-        fontSize = 12.sp,
-        lineHeight = 16.sp
-    )
-)
+    val intraleFontFamily = remember(regular, medium, semiBold) {
+        FontFamily(regular, medium, semiBold)
+    }
+
+    return remember(intraleFontFamily) {
+        Typography(
+            displayLarge = TextStyle(
+                fontFamily = intraleFontFamily,
+                fontWeight = FontWeight.SemiBold,
+                fontSize = 40.sp,
+                lineHeight = 48.sp
+            ),
+            headlineMedium = TextStyle(
+                fontFamily = intraleFontFamily,
+                fontWeight = FontWeight.SemiBold,
+                fontSize = 28.sp,
+                lineHeight = 36.sp
+            ),
+            titleLarge = TextStyle(
+                fontFamily = intraleFontFamily,
+                fontWeight = FontWeight.SemiBold,
+                fontSize = 22.sp,
+                lineHeight = 28.sp
+            ),
+            titleMedium = TextStyle(
+                fontFamily = intraleFontFamily,
+                fontWeight = FontWeight.Medium,
+                fontSize = 18.sp,
+                lineHeight = 24.sp
+            ),
+            titleSmall = TextStyle(
+                fontFamily = intraleFontFamily,
+                fontWeight = FontWeight.Medium,
+                fontSize = 16.sp,
+                lineHeight = 22.sp
+            ),
+            bodyLarge = TextStyle(
+                fontFamily = intraleFontFamily,
+                fontWeight = FontWeight.Normal,
+                fontSize = 16.sp,
+                lineHeight = 24.sp
+            ),
+            bodyMedium = TextStyle(
+                fontFamily = intraleFontFamily,
+                fontWeight = FontWeight.Normal,
+                fontSize = 14.sp,
+                lineHeight = 20.sp
+            ),
+            bodySmall = TextStyle(
+                fontFamily = intraleFontFamily,
+                fontWeight = FontWeight.Normal,
+                fontSize = 12.sp,
+                lineHeight = 16.sp
+            ),
+            labelLarge = TextStyle(
+                fontFamily = intraleFontFamily,
+                fontWeight = FontWeight.SemiBold,
+                fontSize = 16.sp,
+                lineHeight = 20.sp
+            ),
+            labelMedium = TextStyle(
+                fontFamily = intraleFontFamily,
+                fontWeight = FontWeight.Medium,
+                fontSize = 14.sp,
+                lineHeight = 18.sp
+            ),
+            labelSmall = TextStyle(
+                fontFamily = intraleFontFamily,
+                fontWeight = FontWeight.Medium,
+                fontSize = 12.sp,
+                lineHeight = 16.sp
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Resumen
- ajusta IntralePrimaryButton para evitar lecturas de MaterialTheme en DrawScope y corrige la animación de shimmer
- actualiza el botón genérico y las tarjetas de ReviewBusinessScreen para usar APIs válidas de Material 3
- mueve la definición tipográfica a una función composable segura para inicializar fuentes

Closes #240

------
https://chatgpt.com/codex/tasks/task_e_68cbee6abab483258135db5894cb54fe