### PR TITLE
[auto] Ajustar importaciones de tipografía Intrale

### DIFF
--- a/app/composeApp/src/commonMain/kotlin/ui/th/Type.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/th/Type.kt
@@ -12,6 +12,9 @@ import androidx.compose.ui.unit.sp
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.Font
 import ui.rs.Res
+import ui.rs.intrale_medium
+import ui.rs.intrale_regular
+import ui.rs.intrale_semibold
 
 @Composable
 fun IntraleTypography(): Typography {


### PR DESCRIPTION
## Resumen
- Ajustar las importaciones de fuentes generadas en `IntraleTypography` para que utilice los recursos disponibles en `Res.font`.

## Pruebas
- `./gradlew :app:composeApp:compileCommonMainKotlinMetadata --console=plain`

Closes #246

------
https://chatgpt.com/codex/tasks/task_e_68cc39efa2ac83258782631b7335b56c