### PR TITLE
[auto] Corrige renderizado de íconos en botones primarios

### DIFF
--- a/app/composeApp/src/androidMain/kotlin/ui/cp/IntraleIcon.android.kt
+++ b/app/composeApp/src/androidMain/kotlin/ui/cp/IntraleIcon.android.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.platform.LocalContext
+import coil.compose.AsyncImagePainter
 import coil.compose.rememberAsyncImagePainter
 import coil.decode.SvgDecoder
 import coil.request.ImageRequest
@@ -19,17 +20,22 @@ actual fun IntraleIcon(
     tint: Color?
 ) {
     val context = LocalContext.current
-    val request = remember(assetName, context) {
+    val normalizedAssetName = remember(assetName) {
+        assetName.substringAfterLast('/').ifEmpty { assetName }
+    }
+    val request = remember(normalizedAssetName, context) {
         ImageRequest.Builder(context)
-            .data("file:///android_asset/icons/$assetName")
+            .data("file:///android_asset/icons/$normalizedAssetName")
             .decoderFactory(SvgDecoder.Factory())
             .build()
     }
     val painter = rememberAsyncImagePainter(model = request)
-    Image(
-        painter = painter,
-        contentDescription = contentDesc,
-        modifier = modifier,
-        colorFilter = tint?.let(ColorFilter::tint)
-    )
+    if (painter.state is AsyncImagePainter.State.Success) {
+        Image(
+            painter = painter,
+            contentDescription = contentDesc,
+            modifier = modifier,
+            colorFilter = tint?.let(ColorFilter::tint)
+        )
+    }
 }

--- a/app/composeApp/src/commonMain/kotlin/ui/cp/IntraleButtonDefaults.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/cp/IntraleButtonDefaults.kt
@@ -112,19 +112,28 @@ internal fun IntraleButtonContent(
                 color = progressColor,
                 modifier = Modifier.size(MaterialTheme.spacing.x3)
             )
+
+            Spacer(modifier = Modifier.width(MaterialTheme.spacing.x2))
+            Text(
+                text = text,
+                color = textColor,
+                style = MaterialTheme.typography.labelLarge
+            )
         } else {
-            IntraleIcon(
-                assetName = iconAsset,
-                contentDesc = iconContentDescription ?: text,
-                modifier = Modifier.size(MaterialTheme.spacing.x3),
-                tint = iconTint
+            if (iconAsset.isNotBlank()) {
+                IntraleIcon(
+                    assetName = iconAsset,
+                    contentDesc = iconContentDescription ?: text,
+                    modifier = Modifier.size(MaterialTheme.spacing.x3),
+                    tint = iconTint
+                )
+                Spacer(modifier = Modifier.width(MaterialTheme.spacing.x2))
+            }
+            Text(
+                text = text,
+                color = textColor,
+                style = MaterialTheme.typography.labelLarge
             )
         }
-        Spacer(modifier = Modifier.width(MaterialTheme.spacing.x2))
-        Text(
-            text = text,
-            color = textColor,
-            style = MaterialTheme.typography.labelLarge
-        )
     }
 }

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/Login.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/Login.kt
@@ -303,7 +303,7 @@ class Login : Screen(LOGIN_PATH, Res.string.login) {
 
                 IntralePrimaryButton(
                     text = loginText,
-                    iconAsset = "icons/ic_login.svg",
+                    iconAsset = "ic_login.svg",
                     onClick = submitLogin,
                     enabled = !viewModel.loading,
                     loading = viewModel.loading,

--- a/app/composeApp/src/desktopMain/kotlin/ui/cp/IntraleIcon.desktop.kt
+++ b/app/composeApp/src/desktopMain/kotlin/ui/cp/IntraleIcon.desktop.kt
@@ -29,7 +29,7 @@ actual fun IntraleIcon(
         contentAlignment = Alignment.Center
     ) {
         Text(
-            text = assetName.removeSuffix(".svg"),
+            text = assetName.substringAfterLast('/').removeSuffix(".svg"),
             style = MaterialTheme.typography.labelSmall,
             color = tint ?: MaterialTheme.colorScheme.onSurfaceVariant,
             maxLines = 1,

--- a/app/composeApp/src/iosMain/kotlin/ui/cp/IntraleIcon.ios.kt
+++ b/app/composeApp/src/iosMain/kotlin/ui/cp/IntraleIcon.ios.kt
@@ -29,7 +29,7 @@ actual fun IntraleIcon(
         contentAlignment = Alignment.Center
     ) {
         Text(
-            text = assetName.removeSuffix(".svg"),
+            text = assetName.substringAfterLast('/').removeSuffix(".svg"),
             style = MaterialTheme.typography.labelSmall,
             color = tint ?: MaterialTheme.colorScheme.onSurfaceVariant,
             maxLines = 1,

--- a/app/composeApp/src/wasmJsMain/kotlin/ui/cp/IntraleIcon.wasm.kt
+++ b/app/composeApp/src/wasmJsMain/kotlin/ui/cp/IntraleIcon.wasm.kt
@@ -29,7 +29,7 @@ actual fun IntraleIcon(
         contentAlignment = Alignment.Center
     ) {
         Text(
-            text = assetName.removeSuffix(".svg"),
+            text = assetName.substringAfterLast('/').removeSuffix(".svg"),
             style = MaterialTheme.typography.labelSmall,
             color = tint ?: MaterialTheme.colorScheme.onSurfaceVariant,
             maxLines = 1,


### PR DESCRIPTION
## Resumen
- Normaliza la resolución de los assets de íconos en Android y omite el renderizado cuando la carga falla.
- Evita mostrar espacios vacíos cuando no hay ícono disponible y alinea el botón de ingreso con la convención de nombres.
- Ajusta los placeholders multiplataforma para que muestren solo el nombre del recurso.

## Pruebas
- ./gradlew :app:composeApp:compileDebugKotlinAndroid --console=plain *(falla por SDK de Android no configurado en el entorno)*

Closes #248

------
https://chatgpt.com/codex/tasks/task_e_68cc4791129c8325969db9b00c2650ba