### PR TITLE
[auto] Corrige la carga de iconos en Android

### DIFF
--- a/app/composeApp/src/androidMain/kotlin/ui/cp/IntraleIcon.android.kt
+++ b/app/composeApp/src/androidMain/kotlin/ui/cp/IntraleIcon.android.kt
@@ -1,14 +1,26 @@
 package ui.cp
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.draw.clip
 import coil.compose.AsyncImagePainter
 import coil.compose.rememberAsyncImagePainter
+import coil.ImageLoader
 import coil.decode.SvgDecoder
 import coil.request.ImageRequest
 
@@ -23,19 +35,83 @@ actual fun IntraleIcon(
     val normalizedAssetName = remember(assetName) {
         assetName.substringAfterLast('/').ifEmpty { assetName }
     }
+    val imageLoader = remember(context) {
+        ImageLoader.Builder(context)
+            .components { add(SvgDecoder.Factory()) }
+            .respectCacheHeaders(false)
+            .build()
+    }
     val request = remember(normalizedAssetName, context) {
         ImageRequest.Builder(context)
             .data("file:///android_asset/icons/$normalizedAssetName")
             .decoderFactory(SvgDecoder.Factory())
+            .allowHardware(false)
             .build()
     }
-    val painter = rememberAsyncImagePainter(model = request)
-    if (painter.state is AsyncImagePainter.State.Success) {
-        Image(
-            painter = painter,
-            contentDescription = contentDesc,
-            modifier = modifier,
-            colorFilter = tint?.let(ColorFilter::tint)
+    val painter = rememberAsyncImagePainter(
+        model = request,
+        imageLoader = imageLoader
+    )
+    when (painter.state) {
+        is AsyncImagePainter.State.Success -> {
+            Image(
+                painter = painter,
+                contentDescription = contentDesc,
+                modifier = modifier,
+                colorFilter = tint?.let(ColorFilter::tint)
+            )
+        }
+
+        is AsyncImagePainter.State.Loading -> {
+            IntraleIconPlaceholder(
+                normalizedAssetName = normalizedAssetName,
+                modifier = modifier,
+                tint = tint
+            )
+        }
+
+        is AsyncImagePainter.State.Error,
+        AsyncImagePainter.State.Empty -> {
+            IntraleIconPlaceholder(
+                normalizedAssetName = normalizedAssetName,
+                modifier = modifier,
+                tint = tint
+            )
+        }
+    }
+}
+
+@Composable
+private fun IntraleIconPlaceholder(
+    normalizedAssetName: String,
+    modifier: Modifier,
+    tint: Color?
+) {
+    val label = remember(normalizedAssetName) {
+        normalizedAssetName
+            .substringAfterLast('/')
+            .removeSuffix(".svg")
+            .replace('_', ' ')
+            .trim()
+            .ifEmpty { normalizedAssetName }
+            .take(10)
+    }
+
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(12.dp))
+            .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f)),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            color = tint ?: MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 6.dp, vertical = 4.dp)
         )
     }
 }


### PR DESCRIPTION
## Resumen
- Ajusta `IntraleIcon` para crear un `ImageLoader` con decodificador SVG y deshabilitar bitmaps hardware.
- Agrega un marcador de posición textual cuando la imagen aún no está disponible o falla la carga.

## Pruebas
- `./gradlew :app:composeApp:compileDebugKotlinAndroid` *(falla: el entorno no tiene un SDK de Android configurado).* 

Closes #250

------
https://chatgpt.com/codex/tasks/task_e_68cc606d2d988325a17f2382797b3a8f