### PR TITLE
[auto] Restaurar íconos personalizados en botones de Compose

### DIFF
--- a/app/composeApp/src/androidMain/kotlin/ui/cp/IntraleButtonsPreview.kt
+++ b/app/composeApp/src/androidMain/kotlin/ui/cp/IntraleButtonsPreview.kt
@@ -5,6 +5,10 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.HowToReg
+import androidx.compose.material.icons.filled.Login
+import androidx.compose.material.icons.filled.Logout
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -49,50 +53,50 @@ private fun IntraleButtonsPreviewContent() {
         // Contraste AA validado: primary vs fondo claro ≈ 6.42:1, primary vs fondo oscuro ≈ 10.90:1.
         IntralePrimaryButton(
             text = "Primario",
-            iconAsset = "ic_login.svg",
-            onClick = {}
+            onClick = {},
+            leadingIcon = Icons.Filled.Login
         )
         IntralePrimaryButton(
             text = "Primario deshabilitado",
-            iconAsset = "ic_login.svg",
             enabled = false,
-            onClick = {}
+            onClick = {},
+            leadingIcon = Icons.Filled.Login
         )
 
         IntraleOutlinedButton(
             text = "Outlined",
-            iconAsset = "ic_register.svg",
-            onClick = {}
+            onClick = {},
+            leadingIcon = Icons.Filled.HowToReg
         )
         IntraleOutlinedButton(
             text = "Outlined cargando",
-            iconAsset = "ic_register.svg",
             loading = true,
-            onClick = {}
+            onClick = {},
+            leadingIcon = Icons.Filled.HowToReg
         )
         IntraleOutlinedButton(
             text = "Outlined deshabilitado",
-            iconAsset = "ic_register.svg",
             enabled = false,
-            onClick = {}
+            onClick = {},
+            leadingIcon = Icons.Filled.HowToReg
         )
 
         IntraleGhostButton(
             text = "Ghost",
-            iconAsset = "ic_logout.svg",
-            onClick = {}
+            onClick = {},
+            leadingIcon = Icons.Filled.Logout
         )
         IntraleGhostButton(
             text = "Ghost cargando",
-            iconAsset = "ic_logout.svg",
             loading = true,
-            onClick = {}
+            onClick = {},
+            leadingIcon = Icons.Filled.Logout
         )
         IntraleGhostButton(
             text = "Ghost deshabilitado",
-            iconAsset = "ic_logout.svg",
             enabled = false,
-            onClick = {}
+            onClick = {},
+            leadingIcon = Icons.Filled.Logout
         )
     }
 }

--- a/app/composeApp/src/commonMain/kotlin/ui/cp/IntraleButtonDefaults.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/cp/IntraleButtonDefaults.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -21,6 +22,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.graphics.vector.ImageVector
 import org.kodein.log.Logger
 import org.kodein.log.LoggerFactory
 import org.kodein.log.newLogger
@@ -92,7 +95,8 @@ internal fun IntraleButtonLayout(
 @Composable
 internal fun IntraleButtonContent(
     text: String,
-    iconAsset: String,
+    leadingIcon: ImageVector?,
+    leadingPainter: Painter?,
     iconContentDescription: String?,
     loading: Boolean,
     textColor: Color,
@@ -120,14 +124,26 @@ internal fun IntraleButtonContent(
                 style = MaterialTheme.typography.labelLarge
             )
         } else {
-            if (iconAsset.isNotBlank()) {
-                IntraleIcon(
-                    assetName = iconAsset,
-                    contentDesc = iconContentDescription ?: text,
-                    modifier = Modifier.size(MaterialTheme.spacing.x3),
-                    tint = iconTint
-                )
-                Spacer(modifier = Modifier.width(MaterialTheme.spacing.x2))
+            when {
+                leadingIcon != null -> {
+                    Icon(
+                        imageVector = leadingIcon,
+                        contentDescription = iconContentDescription ?: text,
+                        modifier = Modifier.size(MaterialTheme.spacing.x3),
+                        tint = iconTint ?: textColor
+                    )
+                    Spacer(modifier = Modifier.width(MaterialTheme.spacing.x2))
+                }
+
+                leadingPainter != null -> {
+                    Icon(
+                        painter = leadingPainter,
+                        contentDescription = iconContentDescription ?: text,
+                        modifier = Modifier.size(MaterialTheme.spacing.x3),
+                        tint = iconTint ?: textColor
+                    )
+                    Spacer(modifier = Modifier.width(MaterialTheme.spacing.x2))
+                }
             }
             Text(
                 text = text,

--- a/app/composeApp/src/commonMain/kotlin/ui/cp/IntraleGhostButton.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/cp/IntraleGhostButton.kt
@@ -6,13 +6,16 @@ import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.graphics.vector.ImageVector
 
 @Composable
 fun IntraleGhostButton(
     text: String,
-    iconAsset: String,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    leadingIcon: ImageVector? = null,
+    leadingPainter: Painter? = null,
     enabled: Boolean = true,
     loading: Boolean = false,
     iconContentDescription: String? = null
@@ -34,7 +37,8 @@ fun IntraleGhostButton(
         IntraleButtonLayout(modifier = Modifier.fillMaxSize()) {
             IntraleButtonContent(
                 text = text,
-                iconAsset = iconAsset,
+                leadingIcon = leadingIcon,
+                leadingPainter = leadingPainter,
                 iconContentDescription = iconContentDescription,
                 loading = loading,
                 textColor = IntraleButtonDefaults.ghostContentColor(),

--- a/app/composeApp/src/commonMain/kotlin/ui/cp/IntraleOutlinedButton.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/cp/IntraleOutlinedButton.kt
@@ -7,14 +7,17 @@ import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.graphics.vector.ImageVector
 import ui.th.spacing
 
 @Composable
 fun IntraleOutlinedButton(
     text: String,
-    iconAsset: String,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    leadingIcon: ImageVector? = null,
+    leadingPainter: Painter? = null,
     enabled: Boolean = true,
     loading: Boolean = false,
     iconContentDescription: String? = null
@@ -37,7 +40,8 @@ fun IntraleOutlinedButton(
         IntraleButtonLayout(modifier = Modifier.fillMaxSize()) {
             IntraleButtonContent(
                 text = text,
-                iconAsset = iconAsset,
+                leadingIcon = leadingIcon,
+                leadingPainter = leadingPainter,
                 iconContentDescription = iconContentDescription,
                 loading = loading,
                 textColor = IntraleButtonDefaults.outlinedContentColor(),

--- a/app/composeApp/src/commonMain/kotlin/ui/cp/IntralePrimaryButton.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/cp/IntralePrimaryButton.kt
@@ -22,15 +22,18 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.pointer.pointerInput
 import ui.th.spacing
 
 @Composable
 fun IntralePrimaryButton(
     text: String,
-    iconAsset: String,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    leadingIcon: ImageVector? = null,
+    leadingPainter: Painter? = null,
     enabled: Boolean = true,
     loading: Boolean = false,
     iconContentDescription: String? = null
@@ -75,7 +78,7 @@ fun IntralePrimaryButton(
         .background(gradientBrush)
 
     if (isInteractive) {
-        buttonModifier = buttonModifier.pointerInput(text, iconAsset) {
+        buttonModifier = buttonModifier.pointerInput(text, leadingIcon, leadingPainter, enabled, loading) {
             detectTapGestures(
                 onPress = {
                     pressed = true
@@ -106,7 +109,8 @@ fun IntralePrimaryButton(
         }
         IntraleButtonContent(
             text = text,
-            iconAsset = iconAsset,
+            leadingIcon = leadingIcon,
+            leadingPainter = leadingPainter,
             iconContentDescription = iconContentDescription,
             loading = loading,
             textColor = IntraleButtonDefaults.primaryContentColor(),

--- a/app/composeApp/src/commonMain/kotlin/ui/cp/readme.txt
+++ b/app/composeApp/src/commonMain/kotlin/ui/cp/readme.txt
@@ -9,7 +9,8 @@ Esta capa contiene componentes reutilizables para las pantallas.
 Características compartidas:
 
 - Ancho relativo al contenedor del 90 % y altura fija de 54 dp.
-- Soporte para icono SVG mediante `IntraleIcon` en tamaño 22 dp.
+- Soporte opcional para íconos mediante `ImageVector` o `Painter`, respetando el color del contenido sin mostrar monogramas de
+  respaldo.
 - Propiedades `enabled` y `loading` que desactivan la interacción y muestran un indicador circular cuando corresponde.
 - Registro de interacción en `org.kodein.log` con el nombre del componente.
 - Estado deshabilitado con opacidad reducida (~0.6) aplicado de forma consistente.

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/ButtonsPreviewScreen.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/ButtonsPreviewScreen.kt
@@ -4,6 +4,10 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.HowToReg
+import androidx.compose.material.icons.filled.Login
+import androidx.compose.material.icons.filled.Logout
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -50,22 +54,22 @@ class ButtonsPreviewScreen : Screen(BUTTONS_PREVIEW_PATH, Res.string.buttons_pre
 
             IntralePrimaryButton(
                 text = stringResource(Res.string.login),
-                iconAsset = "ic_login.svg",
-                onClick = { logger.info { "Vista previa: ingresar" } }
+                onClick = { logger.info { "Vista previa: ingresar" } },
+                leadingIcon = Icons.Filled.Login
             )
 
             IntralePrimaryButton(
                 text = stringResource(Res.string.signup),
-                iconAsset = "ic_register.svg",
-                loading = true,
-                onClick = { logger.info { "Vista previa: registrarme (loading)" } }
+                onClick = { logger.info { "Vista previa: registrarme (loading)" } },
+                leadingIcon = Icons.Filled.HowToReg,
+                loading = true
             )
 
             IntralePrimaryButton(
                 text = stringResource(Res.string.logout),
-                iconAsset = "ic_logout.svg",
-                enabled = false,
-                onClick = { logger.info { "Vista previa: salir" } }
+                onClick = { logger.info { "Vista previa: salir" } },
+                leadingIcon = Icons.Filled.Logout,
+                enabled = false
             )
         }
     }

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/Home.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/Home.kt
@@ -10,6 +10,9 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.HowToReg
+import androidx.compose.material.icons.filled.Login
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -80,24 +83,24 @@ class Home : Screen(HOME_PATH, Res.string.home) {
 
                 IntralePrimaryButton(
                     text = loginLabel,
-                    iconAsset = "ic_login.svg",
-                    iconContentDescription = loginLabel,
-                    modifier = Modifier.fillMaxWidth(),
                     onClick = {
                         logger.info { "Navegando a $LOGIN_PATH" }
                         navigate(LOGIN_PATH)
-                    }
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                    leadingIcon = Icons.Filled.Login,
+                    iconContentDescription = loginLabel
                 )
 
                 IntralePrimaryButton(
                     text = signupLabel,
-                    iconAsset = "ic_register.svg",
-                    iconContentDescription = signupLabel,
-                    modifier = Modifier.fillMaxWidth(),
                     onClick = {
                         logger.info { "Navegando a $SELECT_SIGNUP_PROFILE_PATH" }
                         navigate(SELECT_SIGNUP_PROFILE_PATH)
-                    }
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                    leadingIcon = Icons.Filled.HowToReg,
+                    iconContentDescription = signupLabel
                 )
             }
         }

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/Login.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/Login.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Login
 import androidx.compose.material.icons.outlined.Lock
 import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material3.Divider
@@ -303,11 +304,11 @@ class Login : Screen(LOGIN_PATH, Res.string.login) {
 
                 IntralePrimaryButton(
                     text = loginText,
-                    iconAsset = "ic_login.svg",
                     onClick = submitLogin,
+                    modifier = Modifier.fillMaxWidth(),
+                    leadingIcon = Icons.Filled.Login,
                     enabled = !viewModel.loading,
-                    loading = viewModel.loading,
-                    modifier = Modifier.fillMaxWidth()
+                    loading = viewModel.loading
                 )
 
                 Column(


### PR DESCRIPTION
## Resumen
* Actualicé los botones Intrale para recibir `ImageVector` o `Painter` y eliminar el monograma de fallback.
* Ajusté las pantallas de Home, Login y previsualizaciones para usar los íconos de Material apropiados.
* Documenté el nuevo soporte de íconos en la guía de componentes.

## Pruebas
* `./gradlew :app:composeApp:compileKotlinMetadata --console=plain --no-daemon`

Closes #255

------
https://chatgpt.com/codex/tasks/task_e_68cc6bdc858c8325a7adfa9dd9716537