### PR TITLE
[auto] Reemplazo de botones en flujos de registro y recuperación

### DIFF
--- a/app/composeApp/src/commonMain/kotlin/ui/cp/buttons/IntraleButtonDefaults.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/cp/buttons/IntraleButtonDefaults.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import org.kodein.log.Logger
 import org.kodein.log.LoggerFactory
 import org.kodein.log.newLogger
+import ui.cp.icons.IntraleIcon
 import ui.th.spacing
 
 internal object IntraleButtonDefaults {
@@ -95,6 +96,7 @@ internal fun IntraleButtonLayout(
 @Composable
 internal fun IntraleButtonContent(
     text: String,
+    iconAssetName: String?,
     leadingIcon: ImageVector?,
     leadingPainter: Painter?,
     iconContentDescription: String?,
@@ -125,6 +127,16 @@ internal fun IntraleButtonContent(
             )
         } else {
             when {
+                iconAssetName != null -> {
+                    IntraleIcon(
+                        assetName = iconAssetName,
+                        contentDesc = iconContentDescription ?: text,
+                        modifier = Modifier.size(MaterialTheme.spacing.x3),
+                        tint = iconTint ?: textColor
+                    )
+                    Spacer(modifier = Modifier.width(MaterialTheme.spacing.x2))
+                }
+
                 leadingIcon != null -> {
                     Icon(
                         imageVector = leadingIcon,

--- a/app/composeApp/src/commonMain/kotlin/ui/cp/buttons/IntraleGhostButton.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/cp/buttons/IntraleGhostButton.kt
@@ -14,6 +14,7 @@ fun IntraleGhostButton(
     text: String,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    iconAsset: String? = null,
     leadingIcon: ImageVector? = null,
     leadingPainter: Painter? = null,
     enabled: Boolean = true,
@@ -37,6 +38,7 @@ fun IntraleGhostButton(
         IntraleButtonLayout(modifier = Modifier.fillMaxSize()) {
             IntraleButtonContent(
                 text = text,
+                iconAssetName = iconAsset,
                 leadingIcon = leadingIcon,
                 leadingPainter = leadingPainter,
                 iconContentDescription = iconContentDescription,

--- a/app/composeApp/src/commonMain/kotlin/ui/cp/buttons/IntraleOutlinedButton.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/cp/buttons/IntraleOutlinedButton.kt
@@ -16,6 +16,7 @@ fun IntraleOutlinedButton(
     text: String,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    iconAsset: String? = null,
     leadingIcon: ImageVector? = null,
     leadingPainter: Painter? = null,
     enabled: Boolean = true,
@@ -40,6 +41,7 @@ fun IntraleOutlinedButton(
         IntraleButtonLayout(modifier = Modifier.fillMaxSize()) {
             IntraleButtonContent(
                 text = text,
+                iconAssetName = iconAsset,
                 leadingIcon = leadingIcon,
                 leadingPainter = leadingPainter,
                 iconContentDescription = iconContentDescription,

--- a/app/composeApp/src/commonMain/kotlin/ui/cp/buttons/IntralePrimaryButton.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/cp/buttons/IntralePrimaryButton.kt
@@ -32,6 +32,7 @@ fun IntralePrimaryButton(
     text: String,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    iconAsset: String? = null,
     leadingIcon: ImageVector? = null,
     leadingPainter: Painter? = null,
     enabled: Boolean = true,
@@ -109,6 +110,7 @@ fun IntralePrimaryButton(
         }
         IntraleButtonContent(
             text = text,
+            iconAssetName = iconAsset,
             leadingIcon = leadingIcon,
             leadingPainter = leadingPainter,
             iconContentDescription = iconContentDescription,

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/auth/ConfirmPasswordRecoveryScreen.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/auth/ConfirmPasswordRecoveryScreen.kt
@@ -22,7 +22,7 @@ import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.stringResource
 import org.kodein.log.LoggerFactory
 import org.kodein.log.newLogger
-import ui.cp.buttons.Button
+import ui.cp.buttons.IntralePrimaryButton
 import ui.cp.inputs.TextField
 import ui.rs.Res
 import ui.rs.email
@@ -83,8 +83,11 @@ class ConfirmPasswordRecoveryScreen : Screen(CONFIRM_PASSWORD_RECOVERY_PATH, Res
                     onValueChange = { viewModel.state = viewModel.state.copy(password = it) }
                 )
                 Spacer(modifier = Modifier.size(MaterialTheme.spacing.x1_5))
-                Button(
-                    label = stringResource(Res.string.confirm_password_recovery),
+                val confirmLabel = stringResource(Res.string.confirm_password_recovery)
+                IntralePrimaryButton(
+                    text = confirmLabel,
+                    iconAsset = "ic_recover.svg",
+                    iconContentDescription = confirmLabel,
                     loading = viewModel.loading,
                     enabled = !viewModel.loading,
                     onClick = {

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/auth/PasswordRecoveryScreen.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/auth/PasswordRecoveryScreen.kt
@@ -22,7 +22,7 @@ import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.stringResource
 import org.kodein.log.LoggerFactory
 import org.kodein.log.newLogger
-import ui.cp.buttons.Button
+import ui.cp.buttons.IntralePrimaryButton
 import ui.cp.inputs.TextField
 import ui.rs.Res
 import ui.rs.email
@@ -66,8 +66,11 @@ class PasswordRecoveryScreen : Screen(PASSWORD_RECOVERY_PATH, Res.string.passwor
                     onValueChange = { viewModel.state = viewModel.state.copy(email = it) }
                 )
                 Spacer(modifier = Modifier.size(MaterialTheme.spacing.x1_5))
-                Button(
-                    label = stringResource(Res.string.password_recovery),
+                val recoveryLabel = stringResource(Res.string.password_recovery)
+                IntralePrimaryButton(
+                    text = recoveryLabel,
+                    iconAsset = "ic_recover.svg",
+                    iconContentDescription = recoveryLabel,
                     loading = viewModel.loading,
                     enabled = !viewModel.loading,
                     onClick = {

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/business/RegisterNewBusinessScreen.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/business/RegisterNewBusinessScreen.kt
@@ -22,7 +22,7 @@ import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.stringResource
 import org.kodein.log.LoggerFactory
 import org.kodein.log.newLogger
-import ui.cp.buttons.Button
+import ui.cp.buttons.IntralePrimaryButton
 import ui.cp.inputs.TextField
 import ui.rs.Res
 import ui.rs.name
@@ -83,8 +83,11 @@ class RegisterNewBusinessScreen : Screen(REGISTER_NEW_BUSINESS_PATH, Res.string.
                     onValueChange = { viewModel.state = viewModel.state.copy(description = it) }
                 )
                 Spacer(Modifier.size(MaterialTheme.spacing.x1_5))
-                Button(
-                    label = stringResource(Res.string.register_business),
+                val registerLabel = stringResource(Res.string.register_business)
+                IntralePrimaryButton(
+                    text = registerLabel,
+                    iconAsset = "ic_register_business.svg",
+                    iconContentDescription = registerLabel,
                     loading = viewModel.loading,
                     enabled = !viewModel.loading,
                     onClick = {

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/signup/SignUpDeliveryScreen.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/signup/SignUpDeliveryScreen.kt
@@ -23,7 +23,7 @@ import androidx.compose.material3.MaterialTheme
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.stringResource
-import ui.cp.buttons.Button
+import ui.cp.buttons.IntralePrimaryButton
 import ui.cp.inputs.TextField
 import ui.rs.Res
 import ui.rs.email
@@ -101,8 +101,11 @@ class SignUpDeliveryScreen : Screen(SIGNUP_DELIVERY_PATH, Res.string.signup_deli
                     }
                 }
                 Spacer(modifier = Modifier.size(MaterialTheme.spacing.x1_5))
-                Button(
-                    label = stringResource(Res.string.signup_delivery),
+                val signupDeliveryLabel = stringResource(Res.string.signup_delivery)
+                IntralePrimaryButton(
+                    text = signupDeliveryLabel,
+                    iconAsset = "ic_delivery.svg",
+                    iconContentDescription = signupDeliveryLabel,
                     loading = viewModel.loading,
                     enabled = !viewModel.loading,
                     onClick = {


### PR DESCRIPTION
## Resumen
- agregué soporte de `iconAsset` al set de botones Intrale para reutilizar íconos corporativos
- reemplacé los botones genéricos de recuperación de contraseña, registro de negocio y alta de repartidores por `IntralePrimaryButton` con íconos y estados de carga

## Pruebas
- `./gradlew :app:composeApp:check` *(falla por ausencia de Android SDK en el entorno de ejecución)*

Closes #231

------
https://chatgpt.com/codex/tasks/task_e_68cd948b51508325819e8941ed546120