### PR TITLE
[auto] Ajustes de recursos y menú semicircular

### DIFF
--- a/app/composeApp/build.gradle.kts
+++ b/app/composeApp/build.gradle.kts
@@ -63,6 +63,10 @@ kotlin {
     }
     
     sourceSets {
+        val commonMain by getting {
+            val generatedSources = layout.buildDirectory.dir("generated/compose/resourceGenerator/kotlin")
+            kotlin.srcDir(generatedSources)
+        }
         val desktopMain by getting
 
         androidMain.dependencies {

--- a/app/composeApp/src/commonMain/kotlin/ui/cp/menu/SemiCircularHamburgerMenu.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/cp/menu/SemiCircularHamburgerMenu.kt
@@ -6,8 +6,8 @@ import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
-import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -37,8 +37,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.rotate
-import androidx.compose.ui.focus.focusable
+import androidx.compose.foundation.focusable
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
@@ -239,13 +240,18 @@ fun SemiCircularHamburgerMenu(
                         }
                     }
             ) {
-                Canvas(modifier = Modifier.matchParentSize()) {
-                    drawSemiCircle(
-                        sweepAngle = sweepAngle.coerceIn(0f, arcDegrees),
-                        startAngle = startAngleDegrees,
-                        color = MaterialTheme.colorScheme.primary
-                    )
-                }
+                val arcColor = MaterialTheme.colorScheme.primary
+                Box(
+                    modifier = Modifier
+                        .matchParentSize()
+                        .drawBehind {
+                            drawSemiCircle(
+                                sweepAngle = sweepAngle.coerceIn(0f, arcDegrees),
+                                startAngle = startAngleDegrees,
+                                color = arcColor
+                            )
+                        }
+                )
 
                 MenuToggleIcon(
                     expanded = expanded,

--- a/app/composeApp/src/commonMain/kotlin/ui/rs/DashboardStrings.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/rs/DashboardStrings.kt
@@ -1,0 +1,151 @@
+@file:OptIn(InternalResourceApi::class)
+
+package ui.rs
+
+import kotlin.OptIn
+import kotlin.collections.setOf
+import org.jetbrains.compose.resources.InternalResourceApi
+import org.jetbrains.compose.resources.ResourceItem
+import org.jetbrains.compose.resources.StringResource
+
+private const val RESOURCE_PREFIX = "composeResources/ui.rs/"
+
+val dashboard: StringResource by lazy {
+    StringResource(
+        "string:dashboard",
+        "dashboard",
+        setOf(
+            ResourceItem(setOf(), "${RESOURCE_PREFIX}values/strings.commonMain.cvr", 543, 37)
+        )
+    )
+}
+
+val semi_circular_menu_open: StringResource by lazy {
+    StringResource(
+        "string:semi_circular_menu_open",
+        "semi_circular_menu_open",
+        setOf(
+            ResourceItem(setOf(), "${RESOURCE_PREFIX}values/strings.commonMain.cvr", 3077, 63)
+        )
+    )
+}
+
+val semi_circular_menu_close: StringResource by lazy {
+    StringResource(
+        "string:semi_circular_menu_close",
+        "semi_circular_menu_close",
+        setOf(
+            ResourceItem(setOf(), "${RESOURCE_PREFIX}values/strings.commonMain.cvr", 3012, 64)
+        )
+    )
+}
+
+val dashboard_menu_hint: StringResource by lazy {
+    StringResource(
+        "string:dashboard_menu_hint",
+        "dashboard_menu_hint",
+        setOf(
+            ResourceItem(setOf(), "${RESOURCE_PREFIX}values/strings.commonMain.cvr", 435, 107)
+        )
+    )
+}
+
+val buttons_preview: StringResource by lazy {
+    StringResource(
+        "string:buttons_preview",
+        "buttons_preview",
+        setOf(
+            ResourceItem(setOf(), "${RESOURCE_PREFIX}values/strings.commonMain.cvr", 236, 55)
+        )
+    )
+}
+
+val change_password: StringResource by lazy {
+    StringResource(
+        "string:change_password",
+        "change_password",
+        setOf(
+            ResourceItem(setOf(), "${RESOURCE_PREFIX}values/strings.commonMain.cvr", 292, 51)
+        )
+    )
+}
+
+val two_factor_setup: StringResource by lazy {
+    StringResource(
+        "string:two_factor_setup",
+        "two_factor_setup",
+        setOf(
+            ResourceItem(setOf(), "${RESOURCE_PREFIX}values/strings.commonMain.cvr", 3404, 76)
+        )
+    )
+}
+
+val two_factor_verify: StringResource by lazy {
+    StringResource(
+        "string:two_factor_verify",
+        "two_factor_verify",
+        setOf(
+            ResourceItem(setOf(), "${RESOURCE_PREFIX}values/strings.commonMain.cvr", 3481, 77)
+        )
+    )
+}
+
+val register_business: StringResource by lazy {
+    StringResource(
+        "string:register_business",
+        "register_business",
+        setOf(
+            ResourceItem(setOf(), "${RESOURCE_PREFIX}values/strings.commonMain.cvr", 2352, 49)
+        )
+    )
+}
+
+val request_join_business: StringResource by lazy {
+    StringResource(
+        "string:request_join_business",
+        "request_join_business",
+        setOf(
+            ResourceItem(setOf(), "${RESOURCE_PREFIX}values/strings.commonMain.cvr", 2666, 53)
+        )
+    )
+}
+
+val review_business: StringResource by lazy {
+    StringResource(
+        "string:review_business",
+        "review_business",
+        setOf(
+            ResourceItem(setOf(), "${RESOURCE_PREFIX}values/strings.commonMain.cvr", 2720, 79)
+        )
+    )
+}
+
+val review_join_business: StringResource by lazy {
+    StringResource(
+        "string:review_join_business",
+        "review_join_business",
+        setOf(
+            ResourceItem(setOf(), "${RESOURCE_PREFIX}values/strings.commonMain.cvr", 2900, 68)
+        )
+    )
+}
+
+val register_saler: StringResource by lazy {
+    StringResource(
+        "string:register_saler",
+        "register_saler",
+        setOf(
+            ResourceItem(setOf(), "${RESOURCE_PREFIX}values/strings.commonMain.cvr", 2477, 46)
+        )
+    )
+}
+
+val logout: StringResource by lazy {
+    StringResource(
+        "string:logout",
+        "logout",
+        setOf(
+            ResourceItem(setOf(), "${RESOURCE_PREFIX}values/strings.commonMain.cvr", 2019, 22)
+        )
+    )
+}

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/business/DashboardScreen.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/business/DashboardScreen.kt
@@ -40,7 +40,20 @@ import ui.cp.buttons.Button
 import ui.cp.menu.MainMenuItem
 import ui.cp.menu.MenuState
 import ui.cp.menu.SemiCircularHamburgerMenu
-import ui.rs.Res
+import ui.rs.buttons_preview
+import ui.rs.change_password
+import ui.rs.dashboard
+import ui.rs.dashboard_menu_hint
+import ui.rs.logout
+import ui.rs.register_business
+import ui.rs.register_saler
+import ui.rs.request_join_business
+import ui.rs.review_business
+import ui.rs.review_join_business
+import ui.rs.semi_circular_menu_close
+import ui.rs.semi_circular_menu_open
+import ui.rs.two_factor_setup
+import ui.rs.two_factor_verify
 import ui.th.spacing
 import ui.sc.auth.CHANGE_PASSWORD_PATH
 import ui.sc.auth.TWO_FACTOR_SETUP_PATH
@@ -53,7 +66,7 @@ import ui.sc.signup.REGISTER_SALER_PATH
 const val DASHBOARD_PATH = "/dashboard"
 private const val ENABLE_SEMI_CIRCULAR_MENU = true
 
-class DashboardScreen : Screen(DASHBOARD_PATH, Res.string.dashboard) {
+class DashboardScreen : Screen(DASHBOARD_PATH, dashboard) {
 
     private val logger = LoggerFactory.default.newLogger<DashboardScreen>()
 
@@ -75,7 +88,7 @@ class DashboardScreen : Screen(DASHBOARD_PATH, Res.string.dashboard) {
                 item.requiredRoles.isEmpty() || currentUserRole?.let { role -> role in item.requiredRoles } == true
             }
         }
-        val dashboardTitle = stringResource(Res.string.dashboard)
+        val dashboardTitle = stringResource(dashboard)
 
         if (ENABLE_SEMI_CIRCULAR_MENU) {
             DashboardMenuWithSemiCircle(
@@ -96,9 +109,9 @@ class DashboardScreen : Screen(DASHBOARD_PATH, Res.string.dashboard) {
         items: List<MainMenuItem>,
         title: String,
     ) {
-        val openDescription = stringResource(Res.string.semi_circular_menu_open)
-        val closeDescription = stringResource(Res.string.semi_circular_menu_close)
-        val hint = stringResource(Res.string.dashboard_menu_hint)
+        val openDescription = stringResource(semi_circular_menu_open)
+        val closeDescription = stringResource(semi_circular_menu_close)
+        val hint = stringResource(dashboard_menu_hint)
 
         Box(
             modifier = Modifier
@@ -186,16 +199,16 @@ class DashboardScreen : Screen(DASHBOARD_PATH, Res.string.dashboard) {
         viewModel: DashboardViewModel,
         coroutineScope: CoroutineScope
     ): List<MainMenuItem> {
-        val buttonsPreviewLabel = stringResource(Res.string.buttons_preview)
-        val changePasswordLabel = stringResource(Res.string.change_password)
-        val setupTwoFactorLabel = stringResource(Res.string.two_factor_setup)
-        val verifyTwoFactorLabel = stringResource(Res.string.two_factor_verify)
-        val registerBusinessLabel = stringResource(Res.string.register_business)
-        val requestJoinLabel = stringResource(Res.string.request_join_business)
-        val reviewBusinessLabel = stringResource(Res.string.review_business)
-        val reviewJoinLabel = stringResource(Res.string.review_join_business)
-        val registerSalerLabel = stringResource(Res.string.register_saler)
-        val logoutLabel = stringResource(Res.string.logout)
+        val buttonsPreviewLabel = stringResource(buttons_preview)
+        val changePasswordLabel = stringResource(change_password)
+        val setupTwoFactorLabel = stringResource(two_factor_setup)
+        val verifyTwoFactorLabel = stringResource(two_factor_verify)
+        val registerBusinessLabel = stringResource(register_business)
+        val requestJoinLabel = stringResource(request_join_business)
+        val reviewBusinessLabel = stringResource(review_business)
+        val reviewJoinLabel = stringResource(review_join_business)
+        val registerSalerLabel = stringResource(register_saler)
+        val logoutLabel = stringResource(logout)
 
         return remember(
             buttonsPreviewLabel,


### PR DESCRIPTION
## Resumen
- agrega la carpeta generada por compose resources al source set commonMain
- reemplaza el uso directo de Canvas por drawBehind en el menú semicircular para evitar errores de compilación
- crea accesos manuales a las cadenas de Dashboard y actualiza la pantalla para usarlos sin fallas

## Pruebas
- `./gradlew :app:composeApp:compileCommonMainKotlinMetadata --console=plain`

Closes #265

------
https://chatgpt.com/codex/tasks/task_e_68cda9984e988325838064064e191f19