### PR TITLE
[auto] Ajuste de recursos generados por Compose

### DIFF
--- a/app/composeApp/build.gradle.kts
+++ b/app/composeApp/build.gradle.kts
@@ -4,6 +4,7 @@ import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
@@ -63,52 +64,79 @@ kotlin {
     }
     
     sourceSets {
+        val generatedCollectorsRoot = layout.buildDirectory.dir("generated/compose/resourceGenerator/kotlin")
+
+        fun KotlinSourceSet.includeGeneratedCollectors(directoryName: String) {
+            kotlin.srcDir(generatedCollectorsRoot.map { it.dir(directoryName).asFile })
+        }
+
         val commonMain by getting {
-            val generatedSources = layout.buildDirectory.dir("generated/compose/resourceGenerator/kotlin")
-            kotlin.srcDir(generatedSources)
+            includeGeneratedCollectors("commonMainResourceCollectors")
+
+            dependencies {
+                implementation(compose.runtime)
+                implementation(compose.foundation)
+                implementation(compose.material3)
+                implementation(compose.materialIconsExtended)
+                implementation(compose.ui)
+                implementation(compose.components.resources)
+                implementation(compose.components.uiToolingPreview)
+                implementation(libs.androidx.lifecycle.viewmodel)
+                implementation(libs.androidx.lifecycle.runtimeCompose)
+
+                implementation(libs.androidx.navigation.compose)
+
+                implementation(libs.bundles.ktor.common)
+                implementation(libs.kodein.di)
+                implementation(libs.canard)
+
+                implementation(libs.settings.no.arg)
+                implementation(libs.settings.serialization)
+                implementation(libs.settings.coroutines)
+
+                implementation(libs.konform)
+            }
         }
-        val desktopMain by getting
 
-        androidMain.dependencies {
-            implementation(compose.preview)
-            implementation(libs.androidx.activity.compose)
-            implementation(libs.ktor.client.android)
-            implementation("io.coil-kt:coil-compose:2.6.0")
-            implementation("io.coil-kt:coil-svg:2.6.0")
+        val androidMain by getting {
+            includeGeneratedCollectors("androidMainResourceCollectors")
+
+            dependencies {
+                implementation(compose.preview)
+                implementation(libs.androidx.activity.compose)
+                implementation(libs.ktor.client.android)
+                implementation("io.coil-kt:coil-compose:2.6.0")
+                implementation("io.coil-kt:coil-svg:2.6.0")
+            }
         }
-        commonMain.dependencies {
-            implementation(compose.runtime)
-            implementation(compose.foundation)
-            implementation(compose.material3)
-            implementation(compose.materialIconsExtended)
-            implementation(compose.ui)
-            implementation(compose.components.resources)
-            implementation(compose.components.uiToolingPreview)
-            implementation(libs.androidx.lifecycle.viewmodel)
-            implementation(libs.androidx.lifecycle.runtimeCompose)
 
-            implementation(libs.androidx.navigation.compose)
+        val desktopMain by getting {
+            includeGeneratedCollectors("desktopMainResourceCollectors")
 
-            implementation(libs.bundles.ktor.common)
-            implementation(libs.kodein.di)
-            implementation(libs.canard)
-
-            implementation(libs.settings.no.arg)
-            implementation(libs.settings.serialization)
-            implementation(libs.settings.coroutines)
-
-            implementation(libs.konform)
-
-
+            dependencies {
+                implementation(compose.desktop.currentOs)
+                implementation(libs.kotlinx.coroutinesSwing)
+            }
         }
-        commonTest.dependencies {
-            implementation(libs.kotlin.test)
-            implementation(libs.ktor.client.mock)
-            implementation(libs.kotlinx.coroutines.test)
+
+        val commonTest by getting {
+            dependencies {
+                implementation(libs.kotlin.test)
+                implementation(libs.ktor.client.mock)
+                implementation(libs.kotlinx.coroutines.test)
+            }
         }
-        desktopMain.dependencies {
-            implementation(compose.desktop.currentOs)
-            implementation(libs.kotlinx.coroutinesSwing)
+
+        listOf(
+            "iosX64Main",
+            "iosArm64Main",
+            "iosSimulatorArm64Main",
+            "wasmJsMain"
+        ).forEach { name ->
+            findByName(name)?.let { sourceSet ->
+                val collectorsDirectory = "${name}ResourceCollectors"
+                sourceSet.kotlin.srcDir(generatedCollectorsRoot.map { it.dir(collectorsDirectory).asFile })
+            }
         }
     }
 }
@@ -163,6 +191,12 @@ compose.resources {
     publicResClass = true
     packageOfResClass = "ui.rs"
     generateResClass = always
+}
+
+tasks.matching { task ->
+    task.name == "compileCommonMainKotlinMetadata" || task.name == "compileKotlinMetadata"
+}.configureEach {
+    dependsOn("generateExpectResourceCollectorsForCommonMain")
 }
 
 val syncBrandingIcons by tasks.registering(SyncBrandingIconsTask::class) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,5 @@ android.useAndroidX=true
 kotlin.mpp.androidSourceSetLayoutVersion=2
 kotlin.mpp.enableCInteropCommonization=true
 
-kotlin.mpp.androidGradlePluginCompatibility.nowarn=true
-
 kotlin.native.ignoreDisabledTargets=true
 


### PR DESCRIPTION
## Resumen
- reorganizar la configuración de sourceSets en app/composeApp para aislar los colectores expect/actual por plataforma y agregar la dependencia del compilado común al generador de expect
- eliminar la propiedad obsoleta kotlin.mpp.androidGradlePluginCompatibility.nowarn de gradle.properties

## Pruebas
- ./gradlew build (falla: el entorno no dispone de ChromeHeadless para ejecutar wasmJsBrowserTest)

Closes #269

------
https://chatgpt.com/codex/tasks/task_e_68ce90ca129c8325aa14cee7e3785aa0