### PR TITLE
[auto] Pulido del menú semicircular y layout del panel principal

### DIFF
--- a/app/composeApp/src/commonMain/kotlin/ui/cp/menu/SemiCircularHamburgerMenu.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/cp/menu/SemiCircularHamburgerMenu.kt
@@ -1,22 +1,31 @@
 package ui.cp.menu
 
 import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AutoAwesome
@@ -27,6 +36,7 @@ import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -39,17 +49,19 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.rotate
-import androidx.compose.foundation.focusable
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.lerp as lerpColor
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.consumePositionChange
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.onClick
@@ -59,9 +71,11 @@ import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.lerp
 import kotlin.math.PI
 import kotlin.math.cos
 import kotlin.math.max
+import kotlin.math.min
 import kotlin.math.roundToInt
 import kotlin.math.sin
 import org.jetbrains.compose.ui.tooling.preview.Preview
@@ -88,7 +102,17 @@ enum class MenuState {
 }
 
 /**
- * Muestra un menú en forma de semicírculo que se despliega desde la esquina superior izquierda.
+ * Esquinas disponibles para anclar el menú semicircular.
+ */
+enum class Corner {
+    TopLeft,
+    TopRight,
+    BottomLeft,
+    BottomRight,
+}
+
+/**
+ * Muestra un menú en forma de semicírculo anclado a una esquina del contenedor.
  */
 @Composable
 fun SemiCircularHamburgerMenu(
@@ -100,6 +124,8 @@ fun SemiCircularHamburgerMenu(
     startAngleDegrees: Float = 20f,
     collapsedRadius: Dp = 64.dp,
     expandedRadius: Dp = 220.dp,
+    anchorCorner: Corner = Corner.TopRight,
+    windowInsets: WindowInsets = WindowInsets.statusBars,
     initiallyExpanded: Boolean = false,
     onStateChange: ((MenuState) -> Unit)? = null,
     onItemSelected: ((MainMenuItem) -> Unit)? = null,
@@ -135,141 +161,208 @@ fun SemiCircularHamburgerMenu(
 
     val displayedProgress = if (isDragging) dragProgress else if (expanded) 1f else 0f
 
-    val radius by animateDpAsState(
-        targetValue = collapsedRadius + (expandedRadius - collapsedRadius) * displayedProgress,
-        animationSpec = spring(
-            dampingRatio = Spring.DampingRatioMediumBouncy,
-            stiffness = Spring.StiffnessMediumLow
+    val infiniteTransition = rememberInfiniteTransition(label = "semiCircularMenuGlow")
+    val glowProgress by infiniteTransition.animateFloat(
+        initialValue = 0f,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 1600, easing = FastOutSlowInEasing),
+            repeatMode = RepeatMode.Restart
         ),
-        label = "semiCircularMenuRadius"
-    )
-    val sweepAngle by animateFloatAsState(
-        targetValue = arcDegrees * (0.25f + 0.75f * displayedProgress),
-        animationSpec = tween(durationMillis = 240, easing = FastOutSlowInEasing),
-        label = "semiCircularMenuSweep"
-    )
-    val toggleRotation by animateFloatAsState(
-        targetValue = if (expanded) 0f else -90f,
-        animationSpec = tween(durationMillis = 220, easing = FastOutSlowInEasing),
-        label = "semiCircularMenuToggleRotation"
+        label = "semiCircularMenuGlowProgress"
     )
 
-    val density = LocalDensity.current
-    val dragRangePx = remember(collapsedRadius, expandedRadius, density) {
-        max(1f, with(density) { (expandedRadius - collapsedRadius).coerceAtLeast(0.dp).toPx() })
-    }
+    BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+        val density = LocalDensity.current
+        val layoutDirection = LocalLayoutDirection.current
+        val safePadding = windowInsets.asPaddingValues()
+        val maxWidthPx = with(density) { maxWidth.toPx() }
+        val maxHeightPx = with(density) { maxHeight.toPx() }
+        val horizontalInsetsPx = with(density) {
+            safePadding.calculateLeftPadding(layoutDirection).toPx() +
+                safePadding.calculateRightPadding(layoutDirection).toPx()
+        }
+        val verticalInsetsPx = with(density) {
+            safePadding.calculateTopPadding().toPx() +
+                safePadding.calculateBottomPadding().toPx()
+        }
+        val safeMarginPx = with(density) { MenuOuterMargin.toPx() }
+        val safeWidthPx = (maxWidthPx - horizontalInsetsPx - safeMarginPx).coerceAtLeast(0f)
+        val safeHeightPx = (maxHeightPx - verticalInsetsPx - safeMarginPx).coerceAtLeast(0f)
+        val collapsedRadiusPx = with(density) { collapsedRadius.toPx() }
+        val configuredExpandedRadiusPx = with(density) { expandedRadius.toPx() }
+        val computedExpandedRadiusPx = min(
+            configuredExpandedRadiusPx,
+            min(safeWidthPx, safeHeightPx * 0.48f)
+        ).coerceAtLeast(collapsedRadiusPx)
+        val effectiveExpandedRadius = with(density) { computedExpandedRadiusPx.toDp() }
+        val effectiveArcDegrees = arcDegrees.coerceIn(120f, 170f)
 
-    LaunchedEffect(expanded, displayedProgress, isDragging) {
-        if (!isDragging) {
-            if (expanded && displayedProgress >= 0.99f) {
-                updateState(MenuState.Expanded)
-                hapticFeedback.performHapticFeedback(HapticFeedbackType.TextHandleMove)
-            } else if (!expanded && displayedProgress <= 0.01f) {
-                updateState(MenuState.Collapsed)
+        val targetRadius = lerp(
+            start = collapsedRadius,
+            stop = effectiveExpandedRadius,
+            fraction = displayedProgress.coerceIn(0f, 1f)
+        )
+
+        val radius by animateDpAsState(
+            targetValue = targetRadius,
+            animationSpec = spring(
+                dampingRatio = Spring.DampingRatioMediumBouncy,
+                stiffness = Spring.StiffnessMediumLow
+            ),
+            label = "semiCircularMenuRadius"
+        )
+
+        val sweepAngle by animateFloatAsState(
+            targetValue = effectiveArcDegrees * (0.25f + 0.75f * displayedProgress.coerceIn(0f, 1f)),
+            animationSpec = tween(durationMillis = 240, easing = FastOutSlowInEasing),
+            label = "semiCircularMenuSweep"
+        )
+
+        val toggleRotation by animateFloatAsState(
+            targetValue = if (expanded) 0f else -90f,
+            animationSpec = tween(durationMillis = 220, easing = FastOutSlowInEasing),
+            label = "semiCircularMenuToggleRotation"
+        )
+
+        val dragRangePx = remember(collapsedRadius, effectiveExpandedRadius) {
+            max(1f, with(density) { (effectiveExpandedRadius - collapsedRadius).coerceAtLeast(0.dp).toPx() })
+        }
+
+        LaunchedEffect(expanded, displayedProgress, isDragging) {
+            if (!isDragging) {
+                when {
+                    expanded && displayedProgress >= 0.99f -> {
+                        updateState(MenuState.Expanded)
+                        hapticFeedback.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                    }
+
+                    !expanded && displayedProgress <= 0.01f -> {
+                        updateState(MenuState.Collapsed)
+                    }
+                }
             }
         }
-    }
 
-    Box(modifier = modifier) {
-        if (displayedProgress > 0.05f) {
-            Box(
-                modifier = Modifier
-                    .matchParentSize()
-                    .pointerInput(Unit) {
-                        detectTapGestures { collapseMenu() }
-                    }
-            )
-        }
-
-        Box(
-            modifier = Modifier
-                .align(Alignment.TopStart)
-                .size(expandedRadius * 2f)
-        ) {
-            Box(
-                modifier = Modifier
-                    .size(radius * 2f)
-                    .semantics(mergeDescendants = true) {
-                        contentDescription = if (expanded) expandedContentDescription else collapsedContentDescription
-                        stateDescription = when (menuState) {
-                            MenuState.Collapsed -> "Colapsado"
-                            MenuState.Expanding -> "Expandiéndose"
-                            MenuState.Expanded -> "Expandido"
-                            MenuState.Collapsing -> "Colapsando"
-                        }
-                        role = Role.Button
-                        onClick {
-                            if (expanded) collapseMenu() else expandMenu()
-                            true
-                        }
-                    }
-                    .pointerInput(expanded) {
-                        detectTapGestures {
-                            if (expanded) collapseMenu() else expandMenu()
-                        }
-                    }
-                    .pointerInput(dragRangePx, expanded) {
-                        detectDragGestures(
-                            onDragStart = {
-                                isDragging = true
-                                dragProgress = if (expanded) 1f else 0f
-                                updateState(if (expanded) MenuState.Collapsing else MenuState.Expanding)
-                            },
-                            onDragEnd = {
-                                isDragging = false
-                                val shouldExpand = dragProgress > 0.4f
-                                if (shouldExpand) {
-                                    expanded = true
-                                    dragProgress = 1f
-                                    updateState(MenuState.Expanding)
-                                } else {
-                                    expanded = false
-                                    dragProgress = 0f
-                                    updateState(MenuState.Collapsing)
-                                }
-                            },
-                            onDragCancel = {
-                                isDragging = false
-                                dragProgress = if (expanded) 1f else 0f
-                                updateState(if (expanded) MenuState.Expanded else MenuState.Collapsed)
-                            }
-                        ) { change, dragAmount ->
-                            val weightedDelta = dragAmount.x * 0.7f + dragAmount.y * 0.3f
-                            dragProgress = (dragProgress + weightedDelta / dragRangePx).coerceIn(0f, 1f)
-                            change.consumePositionChange()
-                        }
-                    }
-            ) {
-                val arcColor = MaterialTheme.colorScheme.primary
+        Box(modifier = Modifier.fillMaxSize()) {
+            if (displayedProgress > 0.05f) {
                 Box(
                     modifier = Modifier
                         .matchParentSize()
-                        .drawBehind {
-                            drawSemiCircle(
-                                sweepAngle = sweepAngle.coerceIn(0f, arcDegrees),
-                                startAngle = startAngleDegrees,
-                                color = arcColor
-                            )
+                        .pointerInput(Unit) {
+                            detectTapGestures { collapseMenu() }
                         }
                 )
+            }
 
-                MenuToggleIcon(
-                    expanded = expanded,
-                    rotation = toggleRotation,
-                    collapsedContentDescription = collapsedContentDescription,
-                    expandedContentDescription = expandedContentDescription
-                )
+            Box(
+                modifier = modifier
+                    .then(Modifier.size(radius * 2f))
+            ) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .semantics(mergeDescendants = true) {
+                            contentDescription = if (expanded) expandedContentDescription else collapsedContentDescription
+                            stateDescription = when (menuState) {
+                                MenuState.Collapsed -> "Colapsado"
+                                MenuState.Expanding -> "Expandiéndose"
+                                MenuState.Expanded -> "Expandido"
+                                MenuState.Collapsing -> "Colapsando"
+                            }
+                            role = Role.Button
+                            onClick {
+                                if (expanded) collapseMenu() else expandMenu()
+                                true
+                            }
+                        }
+                        .pointerInput(expanded) {
+                            detectTapGestures {
+                                if (expanded) collapseMenu() else expandMenu()
+                            }
+                        }
+                        .pointerInput(dragRangePx, expanded) {
+                            detectDragGestures(
+                                onDragStart = {
+                                    isDragging = true
+                                    dragProgress = if (expanded) 1f else 0f
+                                    updateState(if (expanded) MenuState.Collapsing else MenuState.Expanding)
+                                },
+                                onDragEnd = {
+                                    isDragging = false
+                                    val shouldExpand = dragProgress > 0.4f
+                                    if (shouldExpand) {
+                                        expanded = true
+                                        dragProgress = 1f
+                                        updateState(MenuState.Expanding)
+                                    } else {
+                                        expanded = false
+                                        dragProgress = 0f
+                                        updateState(MenuState.Collapsing)
+                                    }
+                                },
+                                onDragCancel = {
+                                    isDragging = false
+                                    dragProgress = if (expanded) 1f else 0f
+                                    updateState(if (expanded) MenuState.Expanded else MenuState.Collapsed)
+                                }
+                            ) { change, dragAmount ->
+                                val weightedDelta =
+                                    dragAmount.x * 0.7f * anchorCorner.horizontalDirection() +
+                                        dragAmount.y * 0.3f * anchorCorner.verticalDirection()
+                                dragProgress = (dragProgress + weightedDelta / dragRangePx).coerceIn(0f, 1f)
+                                change.consumePositionChange()
+                            }
+                        }
+                ) {
+                    val tintedPrimary = lerpColor(
+                        MaterialTheme.colorScheme.primary,
+                        MaterialTheme.colorScheme.tertiary,
+                        displayedProgress.coerceIn(0f, 1f)
+                    )
 
-                RadialMenuItems(
-                    items = filteredItems,
-                    progress = displayedProgress,
-                    radius = radius,
-                    arcDegrees = arcDegrees,
-                    startAngleDegrees = startAngleDegrees
-                ) { item ->
-                    collapseMenu()
-                    onItemSelected?.invoke(item)
-                    item.onClick()
+                    Box(
+                        modifier = Modifier
+                            .matchParentSize()
+                            .drawBehind {
+                                val brush = Brush.sweepGradient(
+                                    colorStops = arrayOf(
+                                        0f to tintedPrimary.copy(alpha = 0.95f),
+                                        0.4f to MaterialTheme.colorScheme.primaryContainer,
+                                        0.7f to tintedPrimary.copy(alpha = 0.9f),
+                                        1f to tintedPrimary.copy(alpha = 0.95f)
+                                    ),
+                                    center = Offset(size.width / 2f, size.height / 2f),
+                                    rotation = glowProgress * 360f
+                                )
+                                drawSemiCircle(
+                                    anchorCorner = anchorCorner,
+                                    startAngle = startAngleDegrees,
+                                    sweepAngle = sweepAngle.coerceIn(0f, effectiveArcDegrees),
+                                    brush = brush
+                                )
+                            }
+                    )
+
+                    MenuToggleIcon(
+                        expanded = expanded,
+                        rotation = toggleRotation,
+                        collapsedContentDescription = collapsedContentDescription,
+                        expandedContentDescription = expandedContentDescription
+                    )
+
+                    RadialMenuItems(
+                        items = filteredItems,
+                        progress = displayedProgress,
+                        radius = radius,
+                        arcDegrees = effectiveArcDegrees,
+                        startAngleDegrees = startAngleDegrees,
+                        anchorCorner = anchorCorner
+                    ) { item ->
+                        collapseMenu()
+                        onItemSelected?.invoke(item)
+                        item.onClick()
+                    }
                 }
             }
         }
@@ -277,15 +370,17 @@ fun SemiCircularHamburgerMenu(
 }
 
 private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawSemiCircle(
-    sweepAngle: Float,
+    anchorCorner: Corner,
     startAngle: Float,
-    color: Color,
+    sweepAngle: Float,
+    brush: Brush,
 ) {
-    val diameter = minOf(size.width, size.height)
+    val diameter = min(size.width, size.height)
+    val (resolvedStart, resolvedSweep) = anchorCorner.orientArc(startAngle, sweepAngle)
     drawArc(
-        color = color,
-        startAngle = startAngle,
-        sweepAngle = sweepAngle,
+        brush = brush,
+        startAngle = resolvedStart,
+        sweepAngle = resolvedSweep,
         useCenter = true,
         size = Size(diameter, diameter),
         topLeft = Offset.Zero
@@ -302,7 +397,7 @@ private fun BoxScope.MenuToggleIcon(
     Surface(
         modifier = Modifier
             .align(Alignment.Center)
-            .size(56.dp),
+            .size(MenuToggleSize),
         shape = CircleShape,
         tonalElevation = 4.dp,
         color = MaterialTheme.colorScheme.primaryContainer
@@ -313,7 +408,7 @@ private fun BoxScope.MenuToggleIcon(
             tint = MaterialTheme.colorScheme.onPrimaryContainer,
             modifier = Modifier
                 .fillMaxSize()
-                .padding(12.dp)
+                .padding(MenuIconPadding)
                 .rotate(rotation)
         )
     }
@@ -326,24 +421,29 @@ private fun BoxScope.RadialMenuItems(
     radius: Dp,
     arcDegrees: Float,
     startAngleDegrees: Float,
+    anchorCorner: Corner,
     onItemClick: (MainMenuItem) -> Unit
 ) {
     if (items.isEmpty()) return
 
     val density = LocalDensity.current
     val radiusPx = with(density) { radius.toPx() }
-    val itemSize = 56.dp
+    val itemSize = MenuItemSize
     val itemSizePx = with(density) { itemSize.toPx() }
+    val innerPaddingPx = with(density) { MenuItemPadding.toPx() }
     val showItems = progress > 0.1f
     val enableItems = progress > 0.6f
+    val iconRadius = (radiusPx - itemSizePx / 2f - innerPaddingPx).coerceAtLeast(0f)
+    val maxOffsetPx = max(radiusPx * 2f - itemSizePx, 0f)
 
     items.forEachIndexed { index, item ->
         val fraction = if (items.size <= 1) 0.5f else index.toFloat() / (items.size - 1).coerceAtLeast(1)
-        val angle = startAngleDegrees + arcDegrees * fraction
-        val radian = angle * PI / 180f
-        val center = radiusPx
-        val x = center + cos(radian) * radiusPx - itemSizePx / 2f
-        val y = center + sin(radian) * radiusPx - itemSizePx / 2f
+        val orientedAngle = anchorCorner.orientAngle(startAngleDegrees + arcDegrees * fraction)
+        val radian = orientedAngle * PI.toFloat() / 180f
+        val rawX = radiusPx + cos(radian) * iconRadius - itemSizePx / 2f
+        val rawY = radiusPx + sin(radian) * iconRadius - itemSizePx / 2f
+        val clampedX = rawX.coerceIn(0f, maxOffsetPx)
+        val clampedY = rawY.coerceIn(0f, maxOffsetPx)
 
         val alpha by animateFloatAsState(
             targetValue = if (showItems) 1f else 0f,
@@ -360,7 +460,7 @@ private fun BoxScope.RadialMenuItems(
 
         Surface(
             modifier = Modifier
-                .offset { IntOffset(x.roundToInt(), y.roundToInt()) }
+                .offset { IntOffset(clampedX.roundToInt(), clampedY.roundToInt()) }
                 .size(itemSize)
                 .graphicsLayer {
                     this.alpha = alpha
@@ -379,7 +479,7 @@ private fun BoxScope.RadialMenuItems(
                     .background(MaterialTheme.colorScheme.surface)
                     .clickable(
                         interactionSource = interactionSource,
-                        indication = null,
+                        indication = rememberRipple(bounded = true, radius = itemSize / 2),
                         enabled = enableItems,
                         role = Role.Button
                     ) { onItemClick(item) },
@@ -395,6 +495,49 @@ private fun BoxScope.RadialMenuItems(
     }
 }
 
+private val MenuItemSize = 56.dp
+private val MenuItemPadding = 12.dp
+private val MenuToggleSize = 56.dp
+private val MenuIconPadding = 12.dp
+private val MenuOuterMargin = 32.dp
+
+private fun Corner.horizontalDirection(): Float = when (this) {
+    Corner.TopLeft, Corner.BottomLeft -> 1f
+    Corner.TopRight, Corner.BottomRight -> -1f
+}
+
+private fun Corner.verticalDirection(): Float = when (this) {
+    Corner.TopLeft, Corner.TopRight -> 1f
+    Corner.BottomLeft, Corner.BottomRight -> -1f
+}
+
+private fun Corner.orientAngle(angle: Float): Float = when (this) {
+    Corner.TopLeft -> angle
+    Corner.TopRight -> 180f - angle
+    Corner.BottomLeft -> 360f - angle
+    Corner.BottomRight -> 180f + angle
+}.let(::normalizeAngle)
+
+private fun Corner.orientArc(start: Float, sweep: Float): Pair<Float, Float> {
+    val end = start + sweep
+    val (rawStart, rawEnd) = when (this) {
+        Corner.TopLeft -> start to end
+        Corner.TopRight -> (180f - end) to (180f - start)
+        Corner.BottomLeft -> (360f - end) to (360f - start)
+        Corner.BottomRight -> (180f + start) to (180f + end)
+    }
+    val orientedStart = normalizeAngle(rawStart)
+    val orientedEnd = normalizeAngle(rawEnd)
+    val sweepAngle = ((orientedEnd - orientedStart).let { if (it < 0f) it + 360f else it }).coerceAtMost(360f)
+    return orientedStart to sweepAngle
+}
+
+private fun normalizeAngle(value: Float): Float {
+    var result = value % 360f
+    if (result < 0f) result += 360f
+    return result
+}
+
 @Preview
 @Composable
 private fun SemiCircularHamburgerMenuPreview() {
@@ -404,7 +547,9 @@ private fun SemiCircularHamburgerMenuPreview() {
                 items = previewMenuItems(),
                 collapsedContentDescription = "Abrir menú",
                 expandedContentDescription = "Cerrar menú",
-                modifier = Modifier.fillMaxSize()
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(top = 16.dp, end = 16.dp)
             )
         }
     }
@@ -420,7 +565,9 @@ private fun SemiCircularHamburgerMenuExpandedPreview() {
                 collapsedContentDescription = "Abrir menú",
                 expandedContentDescription = "Cerrar menú",
                 initiallyExpanded = true,
-                modifier = Modifier.fillMaxSize()
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(top = 16.dp, end = 16.dp)
             )
         }
     }

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/business/DashboardScreen.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/business/DashboardScreen.kt
@@ -2,12 +2,16 @@ package ui.sc.business
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -22,13 +26,18 @@ import androidx.compose.material.icons.filled.Security
 import androidx.compose.material.icons.filled.Store
 import androidx.compose.material.icons.filled.VerifiedUser
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import androidx.lifecycle.viewmodel.compose.viewModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -37,6 +46,7 @@ import org.jetbrains.compose.resources.stringResource
 import org.kodein.log.LoggerFactory
 import org.kodein.log.newLogger
 import ui.cp.buttons.Button
+import ui.cp.menu.Corner
 import ui.cp.menu.MainMenuItem
 import ui.cp.menu.MenuState
 import ui.cp.menu.SemiCircularHamburgerMenu
@@ -112,51 +122,77 @@ class DashboardScreen : Screen(DASHBOARD_PATH, dashboard) {
         val openDescription = stringResource(semi_circular_menu_open)
         val closeDescription = stringResource(semi_circular_menu_close)
         val hint = stringResource(dashboard_menu_hint)
-
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(MaterialTheme.spacing.x3)
-        ) {
-            Column(
-                modifier = Modifier
-                    .align(Alignment.TopCenter)
-                    .padding(top = MaterialTheme.spacing.x6)
-                    .fillMaxWidth(),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.x2)
-            ) {
-                Text(
-                    text = title,
-                    style = MaterialTheme.typography.headlineMedium,
-                    textAlign = TextAlign.Center
-                )
-                Text(
-                    text = hint,
-                    style = MaterialTheme.typography.bodyMedium,
-                    textAlign = TextAlign.Center
+        Scaffold(
+            modifier = Modifier.fillMaxSize(),
+            topBar = {
+                TopAppBar(
+                    title = {
+                        Text(
+                            text = title,
+                            style = MaterialTheme.typography.titleMedium,
+                            maxLines = 1
+                        )
+                    },
+                    colors = TopAppBarDefaults.smallTopAppBarColors(),
+                    windowInsets = WindowInsets.statusBars
                 )
             }
-
-            SemiCircularHamburgerMenu(
-                items = items,
-                collapsedContentDescription = openDescription,
-                expandedContentDescription = closeDescription,
+        ) { innerPadding ->
+            val statusBarPadding = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
+            Box(
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(MaterialTheme.spacing.x2),
-                onStateChange = { state ->
-                    when (state) {
-                        MenuState.Expanding -> logger.info { "SemiCircularHamburgerMenu abriendo" }
-                        MenuState.Expanded -> logger.info { "SemiCircularHamburgerMenu expandido" }
-                        MenuState.Collapsing -> logger.info { "SemiCircularHamburgerMenu cerrando" }
-                        MenuState.Collapsed -> logger.info { "SemiCircularHamburgerMenu colapsado" }
-                    }
-                },
-                onItemSelected = { item ->
-                    logger.info { "SemiCircularHamburgerMenu item seleccionado: ${item.id}" }
+                    .padding(innerPadding)
+            ) {
+                Column(
+                    modifier = Modifier
+                        .align(Alignment.TopStart)
+                        .fillMaxWidth()
+                        .padding(horizontal = MaterialTheme.spacing.x3)
+                        .padding(top = statusBarPadding + 8.dp)
+                        .padding(bottom = MaterialTheme.spacing.x3),
+                    horizontalAlignment = Alignment.Start,
+                    verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.x2)
+                ) {
+                    Text(
+                        text = title,
+                        style = MaterialTheme.typography.headlineMedium,
+                        textAlign = TextAlign.Start,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                    Text(
+                        text = hint,
+                        style = MaterialTheme.typography.bodyMedium,
+                        textAlign = TextAlign.Start,
+                        maxLines = 2,
+                        modifier = Modifier.fillMaxWidth()
+                    )
                 }
-            )
+
+                SemiCircularHamburgerMenu(
+                    items = items,
+                    collapsedContentDescription = openDescription,
+                    expandedContentDescription = closeDescription,
+                    anchorCorner = Corner.TopRight,
+                    windowInsets = WindowInsets.systemBars,
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .padding(WindowInsets.statusBars.asPaddingValues())
+                        .padding(top = MaterialTheme.spacing.x2, end = MaterialTheme.spacing.x2)
+                        .zIndex(10f),
+                    onStateChange = { state ->
+                        when (state) {
+                            MenuState.Expanding -> logger.info { "SemiCircularHamburgerMenu abriendo" }
+                            MenuState.Expanded -> logger.info { "SemiCircularHamburgerMenu expandido" }
+                            MenuState.Collapsing -> logger.info { "SemiCircularHamburgerMenu cerrando" }
+                            MenuState.Collapsed -> logger.info { "SemiCircularHamburgerMenu colapsado" }
+                        }
+                    },
+                    onItemSelected = { item ->
+                        logger.info { "SemiCircularHamburgerMenu item seleccionado: ${item.id}" }
+                    }
+                )
+            }
         }
     }
 


### PR DESCRIPTION
## Resumen
- Actualicé `SemiCircularHamburgerMenu` para soportar anclaje en la esquina superior derecha, respetar WindowInsets, animar el gradiente y evitar que los íconos salgan del viewport.
- Ajusté la pantalla de panel principal para usar Scaffold con TopAppBar compacta, jerarquía visual ordenada y el menú semicircular posicionado con padding seguro.

## Pruebas
- `./gradlew :app:composeApp:check` *(falló: SDK de Android no disponible en el entorno de ejecución)*

Closes #271

------
https://chatgpt.com/codex/tasks/task_e_68cea7d1c30883258f58a95c92e33484