### PR TITLE
[auto] Corrige compilación del menú semicircular Compose

### DIFF
--- a/app/composeApp/src/commonMain/kotlin/ui/cp/menu/SemiCircularHamburgerMenu.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/cp/menu/SemiCircularHamburgerMenu.kt
@@ -11,6 +11,7 @@ import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
+import androidx.compose.foundation.indication
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.gestures.detectDragGestures
@@ -36,7 +37,7 @@ import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.material.ripple.rememberRipple
+import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -54,6 +55,7 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.drawscope.rotate
 import androidx.compose.ui.graphics.lerp as lerpColor
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
@@ -325,22 +327,24 @@ fun SemiCircularHamburgerMenu(
                         modifier = Modifier
                             .matchParentSize()
                             .drawBehind {
+                                val rotationDegrees = glowProgress * 360f
                                 val brush = Brush.sweepGradient(
-                                    colorStops = arrayOf(
-                                        0f to tintedPrimary.copy(alpha = 0.95f),
-                                        0.4f to MaterialTheme.colorScheme.primaryContainer,
-                                        0.7f to tintedPrimary.copy(alpha = 0.9f),
-                                        1f to tintedPrimary.copy(alpha = 0.95f)
+                                    colors = listOf(
+                                        tintedPrimary.copy(alpha = 0.95f),
+                                        MaterialTheme.colorScheme.primaryContainer,
+                                        tintedPrimary.copy(alpha = 0.9f),
+                                        tintedPrimary.copy(alpha = 0.95f)
                                     ),
-                                    center = Offset(size.width / 2f, size.height / 2f),
-                                    rotation = glowProgress * 360f
+                                    center = Offset(size.width / 2f, size.height / 2f)
                                 )
-                                drawSemiCircle(
-                                    anchorCorner = anchorCorner,
-                                    startAngle = startAngleDegrees,
-                                    sweepAngle = sweepAngle.coerceIn(0f, effectiveArcDegrees),
-                                    brush = brush
-                                )
+                                rotate(degrees = rotationDegrees) {
+                                    drawSemiCircle(
+                                        anchorCorner = anchorCorner,
+                                        startAngle = startAngleDegrees,
+                                        sweepAngle = sweepAngle.coerceIn(0f, effectiveArcDegrees),
+                                        brush = brush
+                                    )
+                                }
                             }
                     )
 
@@ -456,7 +460,7 @@ private fun BoxScope.RadialMenuItems(
             label = "menuItemScale$index"
         )
 
-        val interactionSource = remember { MutableInteractionSource() }
+        val interactionSource = remember(item.id) { MutableInteractionSource() }
 
         Surface(
             modifier = Modifier
@@ -477,9 +481,11 @@ private fun BoxScope.RadialMenuItems(
                     .fillMaxSize()
                     .clip(CircleShape)
                     .background(MaterialTheme.colorScheme.surface)
+                    .indication(interactionSource, null)
+                    .ripple(bounded = true, radius = itemSize / 2)
                     .clickable(
                         interactionSource = interactionSource,
-                        indication = rememberRipple(bounded = true, radius = itemSize / 2),
+                        indication = null,
                         enabled = enableItems,
                         role = Role.Button
                     ) { onItemClick(item) },

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/business/DashboardScreen.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/business/DashboardScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.material.icons.filled.PersonAdd
 import androidx.compose.material.icons.filled.Security
 import androidx.compose.material.icons.filled.Store
 import androidx.compose.material.icons.filled.VerifiedUser
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -113,7 +114,7 @@ class DashboardScreen : Screen(DASHBOARD_PATH, dashboard) {
         }
     }
 
-    @OptIn(ExperimentalResourceApi::class)
+    @OptIn(ExperimentalResourceApi::class, ExperimentalMaterial3Api::class)
     @Composable
     private fun DashboardMenuWithSemiCircle(
         items: List<MainMenuItem>,
@@ -133,7 +134,12 @@ class DashboardScreen : Screen(DASHBOARD_PATH, dashboard) {
                             maxLines = 1
                         )
                     },
-                    colors = TopAppBarDefaults.smallTopAppBarColors(),
+                    colors = TopAppBarDefaults.topAppBarColors(
+                        containerColor = MaterialTheme.colorScheme.surface,
+                        titleContentColor = MaterialTheme.colorScheme.onSurface,
+                        navigationIconContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                        actionIconContentColor = MaterialTheme.colorScheme.onSurfaceVariant
+                    ),
                     windowInsets = WindowInsets.statusBars
                 )
             }


### PR DESCRIPTION
## Resumen
- Ajusta el gradiente animado del menú semicircular para usar Brush.sweepGradient compatible y rotación del lienzo.
- Migra el ripple del menú a la API de Material 3 y memoriza la interacción por elemento.
- Actualiza la TopAppBar del Dashboard con los nuevos colores de Material 3 y agrega el opt-in requerido.

## Pruebas
- `./gradlew :app:composeApp:build` *(falla: falta SDK de Android en el entorno de CI)*

Closes #273

------
https://chatgpt.com/codex/tasks/task_e_68ceb4ef111883258c9019171c797cb3