### PR TITLE
[auto] Gestos del menú semicircular con swipe y tooltip

### DIFF
--- a/app/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/app/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -28,8 +28,9 @@
     <string name="home_headline">Impulsamos tu operación con Intrale</string>
     <string name="home_subtitle">Ingresá o registrate para centralizar tu negocio y la gestión de tu red comercial.</string>
     <string name="dashboard">Panel principal</string>
-    <string name="semi_circular_menu_open">Abrir menú de acciones</string>
+    <string name="semi_circular_menu_open">Menú. Desliza a la derecha para volver. Desliza hacia abajo para abrir. Toca para abrir o cerrar.</string>
     <string name="semi_circular_menu_close">Cerrar menú de acciones</string>
+    <string name="semi_circular_menu_long_press_hint">Desliza a la derecha para volver · hacia abajo para abrir</string>
     <string name="dashboard_menu_hint">Desplegá el menú para acceder a las acciones principales.</string>
     <string name="signup">Registrarme</string>
     <string name="signup_platform_admin">Registro Platform Admin</string>

--- a/app/composeApp/src/commonMain/kotlin/ui/rs/DashboardStrings.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/rs/DashboardStrings.kt
@@ -20,6 +20,10 @@ val dashboard: StringResource by lazy {
     )
 }
 
+val back_button: StringResource by lazy {
+    Res.string.back_button
+}
+
 val semi_circular_menu_open: StringResource by lazy {
     StringResource(
         "string:semi_circular_menu_open",
@@ -38,6 +42,10 @@ val semi_circular_menu_close: StringResource by lazy {
             ResourceItem(setOf(), "${RESOURCE_PREFIX}values/strings.commonMain.cvr", 3012, 64)
         )
     )
+}
+
+val semi_circular_menu_long_press_hint: StringResource by lazy {
+    Res.string.semi_circular_menu_long_press_hint
 }
 
 val dashboard_menu_hint: StringResource by lazy {

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/business/DashboardScreen.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/business/DashboardScreen.kt
@@ -60,6 +60,7 @@ import ui.rs.request_join_business
 import ui.rs.review_business
 import ui.rs.review_join_business
 import ui.rs.semi_circular_menu_close
+import ui.rs.semi_circular_menu_long_press_hint
 import ui.rs.semi_circular_menu_open
 import ui.rs.two_factor_setup
 import ui.rs.two_factor_verify
@@ -120,6 +121,7 @@ class DashboardScreen : Screen(DASHBOARD_PATH, dashboard) {
     ) {
         val openDescription = stringResource(semi_circular_menu_open)
         val closeDescription = stringResource(semi_circular_menu_close)
+        val longPressHint = stringResource(semi_circular_menu_long_press_hint)
         val hint = stringResource(dashboard_menu_hint)
         val statusBarPadding = WindowInsets.statusBars.asPaddingValues()
 
@@ -155,6 +157,8 @@ class DashboardScreen : Screen(DASHBOARD_PATH, dashboard) {
                     .padding(start = 12.dp, top = 8.dp)
                     .align(Alignment.TopStart)
                     .zIndex(10f),
+                onBack = { goBack() },
+                collapsedLongPressHint = longPressHint,
                 onStateChange = { state ->
                     when (state) {
                         MenuState.Expanding -> logger.info { "SemiCircularHamburgerMenu abriendo" }

--- a/local.properties
+++ b/local.properties
@@ -5,4 +5,4 @@
 # For customization when using a Version Control System, please read the
 # header note.
 
-sdk.dir=
+sdk.dir=/workspace/android-sdk


### PR DESCRIPTION
## Resumen
- agrega lógica de detección de swipes y foco accesible en `SemiCircularHamburgerMenu`
- expone nuevas cadenas para el hint táctil y la descripción de accesibilidad
- ajusta el dashboard para inyectar callback de back y el texto de tooltip

## Pruebas
- `./gradlew :app:composeApp:compileKotlinDesktop --console=plain`
- `./gradlew :app:composeApp:compileDebugKotlinAndroid --console=plain`
- `./gradlew :app:composeApp:compileReleaseKotlinAndroid --console=plain`

Closes #278

------
https://chatgpt.com/codex/tasks/task_e_68cf412c915483258d964ab47487073e