### PR TITLE
[auto] Hotfix Dashboard sin animaciones y SafeString

### DIFF
--- a/app/composeApp/src/commonMain/kotlin/ui/sc/business/DashboardScreen.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/business/DashboardScreen.kt
@@ -40,6 +40,8 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.StringResource
+import org.jetbrains.compose.resources.stringResource
 import org.kodein.log.LoggerFactory
 import org.kodein.log.newLogger
 import ui.cp.buttons.Button
@@ -71,10 +73,9 @@ import ui.sc.shared.BUTTONS_PREVIEW_PATH
 import ui.sc.shared.HOME_PATH
 import ui.sc.shared.Screen
 import ui.sc.signup.REGISTER_SALER_PATH
-import ui.util.safeString
 
 const val DASHBOARD_PATH = "/dashboard"
-private const val ENABLE_SEMI_CIRCULAR_MENU = true
+private const val DASHBOARD_ANIMATIONS_ENABLED = false
 
 class DashboardScreen : Screen(DASHBOARD_PATH, dashboard) {
 
@@ -98,9 +99,9 @@ class DashboardScreen : Screen(DASHBOARD_PATH, dashboard) {
                 item.requiredRoles.isEmpty() || currentUserRole?.let { role -> role in item.requiredRoles } == true
             }
         }
-        val dashboardTitle = safeString(dashboard, "Panel principal")
+        val dashboardTitle = stringOrFallback(dashboard, "Panel principal")
 
-        if (ENABLE_SEMI_CIRCULAR_MENU) {
+        if (DASHBOARD_ANIMATIONS_ENABLED) {
             DashboardMenuWithSemiCircle(
                 items = visibleItems,
                 title = dashboardTitle
@@ -119,19 +120,19 @@ class DashboardScreen : Screen(DASHBOARD_PATH, dashboard) {
         items: List<MainMenuItem>,
         title: String,
     ) {
-        val openDescription = safeString(
+        val openDescription = stringOrFallback(
             semi_circular_menu_open,
             "Menú. Deslizá a la derecha para volver. Deslizá hacia abajo para abrir. Tocá para abrir o cerrar."
         )
-        val closeDescription = safeString(
+        val closeDescription = stringOrFallback(
             semi_circular_menu_close,
             "Cerrar menú de acciones"
         )
-        val longPressHint = safeString(
+        val longPressHint = stringOrFallback(
             semi_circular_menu_long_press_hint,
             "Deslizá a la derecha para volver · hacia abajo para abrir"
         )
-        val hint = safeString(
+        val hint = stringOrFallback(
             dashboard_menu_hint,
             "Desplegá el menú para acceder a las acciones principales."
         )
@@ -225,17 +226,17 @@ class DashboardScreen : Screen(DASHBOARD_PATH, dashboard) {
         viewModel: DashboardViewModel,
         coroutineScope: CoroutineScope
     ): List<MainMenuItem> {
-        val backLabel = safeString(back_button, "Volver")
-        val buttonsPreviewLabel = safeString(buttons_preview, "Demo de botones Intrale")
-        val changePasswordLabel = safeString(change_password, "Cambiar contraseña")
-        val setupTwoFactorLabel = safeString(two_factor_setup, "Configurar autenticación en dos pasos")
-        val verifyTwoFactorLabel = safeString(two_factor_verify, "Verificar autenticación en dos pasos")
-        val registerBusinessLabel = safeString(register_business, "Registrar negocio")
-        val requestJoinLabel = safeString(request_join_business, "Solicitar unión")
-        val reviewBusinessLabel = safeString(review_business, "Revisar solicitudes de negocio pendientes")
-        val reviewJoinLabel = safeString(review_join_business, "Revisar solicitudes de unión")
-        val registerSalerLabel = safeString(register_saler, "Registrar vendedor")
-        val logoutLabel = safeString(logout, "Salir")
+        val backLabel = stringOrFallback(back_button, "Volver")
+        val buttonsPreviewLabel = stringOrFallback(buttons_preview, "Demo de botones Intrale")
+        val changePasswordLabel = stringOrFallback(change_password, "Cambiar contraseña")
+        val setupTwoFactorLabel = stringOrFallback(two_factor_setup, "Configurar autenticación en dos pasos")
+        val verifyTwoFactorLabel = stringOrFallback(two_factor_verify, "Verificar autenticación en dos pasos")
+        val registerBusinessLabel = stringOrFallback(register_business, "Registrar negocio")
+        val requestJoinLabel = stringOrFallback(request_join_business, "Solicitar unión")
+        val reviewBusinessLabel = stringOrFallback(review_business, "Revisar solicitudes de negocio pendientes")
+        val reviewJoinLabel = stringOrFallback(review_join_business, "Revisar solicitudes de unión")
+        val registerSalerLabel = stringOrFallback(register_saler, "Registrar vendedor")
+        val logoutLabel = stringOrFallback(logout, "Salir")
 
         return remember(
             backLabel,
@@ -368,3 +369,8 @@ class DashboardScreen : Screen(DASHBOARD_PATH, dashboard) {
         }
     }
 }
+
+@OptIn(ExperimentalResourceApi::class)
+@Composable
+private fun stringOrFallback(id: StringResource, fallback: String): String =
+    runCatching { stringResource(id) }.getOrElse { fallback }

--- a/app/composeApp/src/commonMain/kotlin/ui/util/SafeString.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/util/SafeString.kt
@@ -9,26 +9,36 @@ import org.jetbrains.compose.resources.stringResource
 import org.kodein.log.Logger
 import org.kodein.log.LoggerFactory
 import org.kodein.log.newLogger
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
 
 private val safeStringLogger: Logger = LoggerFactory.default.newLogger("ui.util", "SafeString")
+
+private val BASE64_REGEX = Regex("^[A-Za-z0-9+/]+={0,2}$")
 
 @OptIn(ExperimentalResourceApi::class)
 @Composable
 fun safeString(id: StringResource, fallback: String = "—"): String =
-    safeResource(
-        load = { stringResource(id) },
-        fallback = fallback,
-        onFailure = { error ->
-            safeStringLogger.error(error) { "[RES_FALLBACK] fallo al decodificar id=$id" }
+    runCatching { stringResource(id) }
+        .onFailure { error ->
+            safeStringLogger.error(error) { "[RES_FALLBACK] fallo al cargar id=$id" }
         }
-    )
-
-internal inline fun <T> safeResource(
-    load: () -> T,
-    fallback: T,
-    onFailure: (Throwable) -> Unit,
-): T =
-    runCatching(load)
-        .onFailure(onFailure)
         .getOrElse { fallback }
+
+/**
+ * Decodifica una cadena solo si cumple claramente con el formato Base64.
+ * Si la validación o la decodificación fallan, devuelve el valor original.
+ */
+@OptIn(ExperimentalEncodingApi::class)
+fun decodeIfBase64OrReturn(original: String): String {
+    val candidate = original.trim()
+    if (candidate.isEmpty()) return candidate
+    if (candidate.contains('\n') || candidate.contains('\r')) return original
+    if (candidate.length % 4 != 0) return original
+    if (!BASE64_REGEX.matches(candidate)) return original
+
+    return runCatching {
+        Base64.decode(candidate).decodeToString()
+    }.getOrElse { original }
+}
 

--- a/app/composeApp/src/commonTest/kotlin/ui/util/SafeResourceTest.kt
+++ b/app/composeApp/src/commonTest/kotlin/ui/util/SafeResourceTest.kt
@@ -1,35 +1,38 @@
 package ui.util
 
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 class SafeResourceTest {
 
+    @OptIn(ExperimentalEncodingApi::class)
     @Test
-    fun `returns loaded value when no failure happens`() {
-        val result = safeResource(
-            load = { "ok" },
-            fallback = "fallback",
-            onFailure = { error -> error.printStackTrace() },
-        )
+    fun `decodeIfBase64OrReturn decodes valid payload`() {
+        val original = "Dashboard"
+        val encoded = Base64.encode(original.encodeToByteArray())
 
-        assertEquals("ok", result)
+        val result = decodeIfBase64OrReturn(encoded)
+
+        assertEquals(original, result)
     }
 
     @Test
-    fun `returns fallback and reports error when load throws`() {
-        val recorded = mutableListOf<Throwable>()
+    fun `decodeIfBase64OrReturn returns original when input is not Base64`() {
+        val original = "Texto plano sin codificar"
 
-        val result = safeResource(
-            load = { error("boom") },
-            fallback = "fallback",
-            onFailure = { recorded += it },
-        )
+        val result = decodeIfBase64OrReturn(original)
 
-        assertEquals("fallback", result)
-        assertEquals(1, recorded.size)
-        assertTrue(recorded.first() is IllegalStateException)
-        assertEquals("boom", recorded.first().message)
+        assertEquals(original, result)
+    }
+
+    @Test
+    fun `decodeIfBase64OrReturn ignora cadenas inválidas`() {
+        val invalid = "Zm9vYmFy==\n"
+
+        val result = decodeIfBase64OrReturn(invalid)
+
+        assertEquals(invalid, result)
     }
 }

--- a/docs/dashboard-animations-flag.md
+++ b/docs/dashboard-animations-flag.md
@@ -1,0 +1,29 @@
+# Bandera `DASHBOARD_ANIMATIONS_ENABLED`
+
+Relacionado con #290.
+
+## Contexto
+
+Se detectó un crash al navegar hacia `/dashboard` luego del login. La causa principal se
+relacionó con excepciones propagadas durante composiciones animadas del menú semicircular
+y el uso inseguro de `safeString`. Como medida de contingencia se incorporó la bandera
+`DASHBOARD_ANIMATIONS_ENABLED` en `ui/sc/business/DashboardScreen.kt` para desactivar
+transiciones y mantener la experiencia estable.
+
+## Valor actual
+
+- `DASHBOARD_ANIMATIONS_ENABLED = false`
+
+Con este valor la pantalla utiliza el layout estático (`LegacyDashboardLayout`) y evita
+invocar el componente `SemiCircularHamburgerMenu` que depende de animaciones complejas.
+
+## Cómo reactivar las animaciones
+
+1. Cambiar el valor de la constante a `true`.
+2. Verificar manualmente el flujo **Login → Dashboard** durante varias iteraciones.
+3. Revisar logs para asegurarse de que no aparezcan excepciones relacionadas con
+   `safeString` o `ComposeRuntimeError`.
+4. Confirmar que el menú semicircular funciona correctamente antes de liberar el cambio.
+
+> ⚠️ Mantener esta bandera en `false` hasta completar una solución definitiva para las
+> animaciones del Dashboard.


### PR DESCRIPTION
## Resumen
- Sanitizar `safeString` para que no propague excepciones y exponer `decodeIfBase64OrReturn`.
- Desactivar temporalmente las animaciones del Dashboard y utilizar `stringOrFallback` para los recursos.
- Documentar la bandera `DASHBOARD_ANIMATIONS_ENABLED`.

## Pruebas
- `./gradlew --console=plain :app:composeApp:check` *(falla por ausencia de Chrome Headless en el entorno de CI)*

Closes #290

------
https://chatgpt.com/codex/tasks/task_e_68d131a8a5908325b200c250248fda88