### PR TITLE
[auto] Preflight de Codex y sentinel de diagnóstico

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -1,3 +1,4 @@
+<!-- AGENTS_MD_VERSION: 2025-09-24T00:51:43Z -->
 # agents.md
 
 ## 📘 Descripción General
@@ -262,3 +263,19 @@ Esto indicará al agente que debe buscar todos los issues en estado "Todo" y eje
 ### 🔹 Recomendaciones adicionales
 - No deben utilizarse comandos ambiguos como solo `"refinar"` o `"trabajar"` sin contexto, ya que el agente puede solicitar información adicional.
 - Si se desea refinar o trabajar un issue puntual, se debe indicar el número del issue de forma explícita.
+
+---
+
+## 🛡️ Sentinel de diagnóstico para preflight
+
+Estos elementos permiten validar rápidamente que el archivo `agents.md` correcto fue cargado por Codex sin interferir con el flujo normal.
+
+### agent: diag-echo
+- description: Diagnóstico: debe imprimir un texto fijo si agents.md fue cargado.
+- run:
+  - echo "DIAG_OK from agents.md"
+
+### task: diag-echo-task
+- agent: diag-echo
+- steps:
+  - run: echo "DIAG_TASK_OK"

--- a/init.sh
+++ b/init.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
 # Instalando Android SDK...
 echo "📦 Instalando Android SDK..."
 
@@ -97,3 +99,66 @@ else
     fi
   fi
 fi
+
+# --- Preflight Codex (seguro e idempotente) ---
+pushd "$SCRIPT_DIR" >/dev/null
+
+: "${CODEX_AGENTS_PATH:="$PWD/agents.md"}"
+export CODEX_AGENTS_PATH
+
+echo "[INIT] Limpiando caché de Codex..."
+rm -rf ~/.codex/cache 2>/dev/null || true
+rm -rf /tmp/codex* 2>/dev/null || true
+
+if [ -n "${CODEX_VERSION:-}" ]; then
+  echo "[INIT] Usando Codex versión fijada: $CODEX_VERSION"
+  # (Place holder: lógica de selección/descarga si aplica a su entorno)
+fi
+
+if [ "${CODEX_PREFLIGHT_SKIP:-false}" != "true" ]; then
+  (
+    set -euo pipefail
+
+    echo "[INIT] PWD=$(pwd)"
+    echo "[INIT] GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo 'unknown')"
+    if [ -f "$CODEX_AGENTS_PATH" ]; then
+      echo "[INIT] agents.md PATH=$CODEX_AGENTS_PATH"
+      echo "[INIT] agents.md SHA1=$(sha1sum "$CODEX_AGENTS_PATH" | cut -d' ' -f1)"
+      # Show first 1 line to see version marker (safe, no secrets)
+      head -n 1 "$CODEX_AGENTS_PATH"
+    else
+      echo "[ERROR] agents.md no encontrado en $CODEX_AGENTS_PATH"
+      exit 1
+    fi
+
+    if command -v codex >/dev/null 2>&1; then
+      echo "[INIT] codex --debug --dry-run --print-config (primeros 200 lines)"
+      codex --debug --dry-run --print-config | sed -n '1,200p' || true
+    else
+      echo "[ERROR] 'codex' no está en PATH"
+      exit 1
+    fi
+
+    echo "[INIT] Ejecutando sentinel diag-echo-task"
+    if codex run diag-echo-task --debug 2>&1 | tee /tmp/codex_diag.log; then
+      if ! grep -qE 'DIAG_OK from agents.md|DIAG_TASK_OK' /tmp/codex_diag.log; then
+        echo "[ERROR] Sentinel ejecutado pero no se detectó salida esperada (¿no cargó agents.md?)"
+        exit 1
+      fi
+      echo "[INIT] Sentinel OK"
+    else
+      echo "[ERROR] No se pudo ejecutar diag-echo-task (posible no-carga de agents.md)"
+      exit 1
+    fi
+  )
+  preflight_status=$?
+  popd >/dev/null
+  if [ "$preflight_status" -ne 0 ]; then
+    exit "$preflight_status"
+  fi
+else
+  echo "[INIT] CODEX_PREFLIGHT_SKIP=true → Saltando preflight"
+  popd >/dev/null
+fi
+
+# --- Fin preflight ---


### PR DESCRIPTION
## Resumen
- se incorporó marcador de versión y un sentinel de diagnóstico en agents.md para validar la carga real del archivo
- se añadieron limpiezas de caché y un preflight de Codex en init.sh con soporte para omitirlo y fijar versión opcionalmente

## Pruebas
- bash -n init.sh

Closes #295

------
https://chatgpt.com/codex/tasks/task_e_68d3403d88f88325bc02075b83072750