### PR TITLE
[auto] Refuerzos de validación de recursos y guardias del Dashboard

### DIFF
--- a/app/composeApp/build.gradle.kts
+++ b/app/composeApp/build.gradle.kts
@@ -109,6 +109,7 @@ kotlin {
             includeGeneratedCollectors("androidMainResourceCollectors")
 
             dependencies {
+                implementation(platform(libs.androidx.compose.bom.get()))
                 implementation(compose.preview)
                 implementation(libs.androidx.activity.compose)
                 implementation(libs.ktor.client.android)
@@ -120,6 +121,7 @@ kotlin {
         @OptIn(ExperimentalComposeLibrary::class)
         val androidInstrumentedTest by getting {
             dependencies {
+                implementation(platform(libs.androidx.compose.bom.get()))
                 implementation(libs.androidx.testExt.junit)
                 implementation(libs.androidx.espresso.core)
                 implementation(compose.uiTestJUnit4)
@@ -197,6 +199,7 @@ android {
 }
 
 dependencies {
+    debugImplementation(platform(libs.androidx.compose.bom.get()))
     debugImplementation(compose.uiTooling)
 }
 
@@ -247,6 +250,14 @@ tasks.matching { task ->
 }
 
 tasks.withType(KotlinCompilationTask::class).configureEach {
+    dependsOn(validateComposeResources)
+}
+
+tasks.named("check").configure {
+    dependsOn(validateComposeResources)
+}
+
+tasks.named("assemble").configure {
     dependsOn(validateComposeResources)
 }
 

--- a/app/composeApp/src/androidInstrumentedTest/kotlin/ui/sc/business/DashboardGuardTest.kt
+++ b/app/composeApp/src/androidInstrumentedTest/kotlin/ui/sc/business/DashboardGuardTest.kt
@@ -1,7 +1,6 @@
 package ui.sc.business
 
 import androidx.activity.ComponentActivity
-import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
@@ -10,17 +9,18 @@ import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import kotlin.test.assertEquals
 import ui.util.RES_ERROR_PREFIX
 
 @RunWith(AndroidJUnit4::class)
-class DashboardSmokeTest {
+class DashboardGuardTest {
 
     @get:Rule
     val composeRule = createAndroidComposeRule<ComponentActivity>()
 
     @OptIn(ExperimentalResourceApi::class)
     @Test
-    fun dashboardFirstFrame_withoutFallbacks() {
+    fun dashboardGuard_withoutFallbackPrefix() {
         composeRule.setContent {
             DashboardScreen().screen()
         }
@@ -28,8 +28,13 @@ class DashboardSmokeTest {
         composeRule.waitForIdle()
 
         composeRule.onNodeWithText("Panel principal").assertExists()
-        composeRule
-            .onAllNodesWithText(RES_ERROR_PREFIX, substring = true)
-            .assertCountEquals(0)
+
+        val fallbackNodes = composeRule.onAllNodesWithText(RES_ERROR_PREFIX, substring = true)
+        val fallbackCount = fallbackNodes.fetchSemanticsNodes().size
+        assertEquals(
+            0,
+            fallbackCount,
+            "Se detectaron $fallbackCount textos con prefijo de fallback en Dashboard."
+        )
     }
 }

--- a/buildSrc/src/main/kotlin/compose/ResourcePackValidator.kt
+++ b/buildSrc/src/main/kotlin/compose/ResourcePackValidator.kt
@@ -1,6 +1,10 @@
 package compose
 
 import java.io.File
+import java.nio.ByteBuffer
+import java.nio.charset.CharacterCodingException
+import java.nio.charset.CodingErrorAction
+import java.nio.charset.StandardCharsets
 import java.util.Base64
 
 data class ResourceValidationError(
@@ -15,6 +19,48 @@ data class ResourcePackValidationResult(
 )
 
 object ResourcePackValidator {
+
+    private val allowedControlCharacters = setOf('\n', '\r', '\t')
+    private val base64Alphabet = (
+        ('A'..'Z') + ('a'..'z') + ('0'..'9') + listOf('+', '/', '=')
+    ).toSet()
+
+    private fun ByteArray.decodeUtf8OrNull(): String? {
+        return try {
+            StandardCharsets.UTF_8
+                .newDecoder()
+                .onMalformedInput(CodingErrorAction.REPORT)
+                .onUnmappableCharacter(CodingErrorAction.REPORT)
+                .decode(ByteBuffer.wrap(this))
+                .toString()
+        } catch (_: CharacterCodingException) {
+            null
+        }
+    }
+
+    private fun looksLikeBase64Candidate(value: String): Boolean {
+        if (value.isBlank()) return false
+
+        val collapsed = value.trim().replace("\n", "").replace("\r", "")
+        if (collapsed.length < 8) return false
+        if (collapsed.length % 4 != 0) return false
+        if (!collapsed.all { it in base64Alphabet }) return false
+
+        val hasExplicitPadding = '=' in collapsed
+        val longEnough = collapsed.length >= 16
+
+        return hasExplicitPadding || longEnough
+    }
+
+    private fun decodedLooksPrintable(bytes: ByteArray): Boolean {
+        if (bytes.isEmpty()) return false
+
+        val printable = bytes.count { byte ->
+            val value = byte.toInt()
+            value >= 32 || value == 10 || value == 13 || value == 9 || value < 0
+        }
+        return printable.toDouble() / bytes.size >= 0.85
+    }
 
     fun validate(resourceRoot: File): ResourcePackValidationResult {
         if (!resourceRoot.exists()) {
@@ -53,8 +99,9 @@ object ResourcePackValidator {
                             return@forEachIndexed
                         }
 
+                        val key = parts[1]
                         val encodedValue = parts[2]
-                        try {
+                        val decodedBytes = try {
                             decoder.decode(encodedValue)
                         } catch (failure: IllegalArgumentException) {
                             errors += ResourceValidationError(
@@ -62,6 +109,44 @@ object ResourcePackValidator {
                                 lineNumber = index + 1,
                                 reason = "Base64 inválido (${failure.message}).",
                             )
+                            return@forEachIndexed
+                        }
+
+                        val decodedText = decodedBytes.decodeUtf8OrNull()
+                        if (decodedText == null) {
+                            errors += ResourceValidationError(
+                                file = file,
+                                lineNumber = index + 1,
+                                reason = "El valor asociado a '$key' no está codificado en UTF-8 legible.",
+                            )
+                            return@forEachIndexed
+                        }
+
+                        val invalidControls = decodedText.filter { char ->
+                            char.isISOControl() && char !in allowedControlCharacters
+                        }
+                        if (invalidControls.isNotEmpty()) {
+                            errors += ResourceValidationError(
+                                file = file,
+                                lineNumber = index + 1,
+                                reason = "La clave '$key' contiene caracteres no imprimibles tras decodificar.",
+                            )
+                        }
+
+                        val candidate = decodedText.trim()
+                        if (looksLikeBase64Candidate(candidate)) {
+                            val stripped = candidate.replace("\n", "").replace("\r", "")
+                            val decodedCandidate = runCatching { decoder.decode(stripped) }.getOrNull()
+                            if (decodedCandidate != null && decodedLooksPrintable(decodedCandidate)) {
+                                val readableText = decodedCandidate.decodeUtf8OrNull()
+                                if (readableText != null && readableText.any { it.isLetterOrDigit() }) {
+                                    errors += ResourceValidationError(
+                                        file = file,
+                                        lineNumber = index + 1,
+                                        reason = "La clave '$key' parece contener Base64 incrustado. Valor sospechoso: '${candidate.take(32)}'",
+                                    )
+                                }
+                            }
                         }
                     }
                 }

--- a/docs/dashboard-animations-flag.md
+++ b/docs/dashboard-animations-flag.md
@@ -33,3 +33,11 @@ invocar el componente `SemiCircularHamburgerMenu` que depende de animaciones com
 
 > ⚠️ Mantener esta bandera en `false` hasta completar una solución definitiva para las
 > animaciones del Dashboard.
+
+## Guardia automática de recursos
+
+- El test instrumental `DashboardGuardTest` (ubicado en `app/composeApp/src/androidInstrumentedTest/...`) monta la pantalla del Dashboard y falla si detecta nodos que contengan el prefijo `RES_ERROR_PREFIX` (`⚠`).
+- Cuando ese test falle:
+  1. Revisá los logs de la ejecución (`adb logcat` o reporte de CI) buscando entradas `[RES_FALLBACK]`.
+  2. Corregí los recursos involucrados en `strings.xml` o en los catálogos `.cvr` regenerando con `./gradlew :app:composeApp:assembleDebug`.
+  3. Ejecutá `./gradlew :app:composeApp:connectedAndroidTest` para validar el fix antes de subir el cambio.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -42,6 +42,7 @@ androidx-lifecycle = "2.9.1"
 androidx-testExt = "1.2.1"
 composeHotReload = "1.0.0-alpha11"
 composeMultiplatform = "1.8.2"
+androidx-compose-bom = "2024.09.02"
 junit = "4.13.2"
 kotlin-multiplatform = "2.2.0"
 kotlinx-coroutines = "1.10.2"
@@ -111,6 +112,7 @@ androidx-lifecycle-viewmodel = { module = "org.jetbrains.androidx.lifecycle:life
 androidx-lifecycle-runtimeCompose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
 androidx-navigation-compose = { module = "org.jetbrains.androidx.navigation:navigation-compose", version.ref = "androidx-navigation" }
 kotlinx-coroutinesSwing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }
+androidx-compose-bom = { module = "androidx.compose:compose-bom", version.ref = "androidx-compose-bom" }
 canard = { module = "org.kodein.log:canard", version.ref = "canard" }
 settings-no-arg = { module = "com.russhwolf:multiplatform-settings-no-arg", version.ref = "russhwolf" }
 settings-serialization = { module = "com.russhwolf:multiplatform-settings-serialization", version.ref = "russhwolf" }


### PR DESCRIPTION
## Resumen
- Extender `ResourcePackValidator` para detectar valores no UTF-8, caracteres no imprimibles y cadenas que aparentan ser Base64 incrustado.
- Encadenar la validación de recursos a `assemble`, `check` y actualizar las dependencias Android con Compose BOM alineada.
- Migrar el test instrumental a `DashboardGuardTest` y documentar el nuevo flujo de auditoría y guardias en los manuales.

Closes #294

## Pruebas
- ./gradlew :app:composeApp:assembleDebug
- ./gradlew :app:composeApp:check *(falla: daemon de Gradle se detuvo por módulos Kotlin 2.2.0 compilados con metadata incompatible con 2.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_68d3bc0e57148325ae4058f18dc7e21f