### PR TITLE
[auto] Blindar strings nativos del Dashboard con animaciones

### DIFF
--- a/app/composeApp/src/androidMain/kotlin/ui/util/ResStrings.android.kt
+++ b/app/composeApp/src/androidMain/kotlin/ui/util/ResStrings.android.kt
@@ -24,11 +24,27 @@ actual fun resString(
     }
 
     composeId?.let { cid ->
-        return runCatching { composeStringResource(cid) }
-            .getOrElse { error ->
-                logFallback(identifier, fallbackAsciiSafe, error)
-            }
+        return resolveComposeOrFallback(
+            identifier = identifier,
+            fallback = fallbackAsciiSafe,
+        ) {
+            composeStringResource(cid)
+        }
     }
 
     return logFallback(identifier, fallbackAsciiSafe)
+}
+
+@Composable
+private fun resolveComposeOrFallback(
+    identifier: String,
+    fallback: String,
+    onFailure: (Throwable) -> Unit = {},
+    resolver: @Composable () -> String,
+): String {
+    return runCatching { resolver() }
+        .getOrElse { error ->
+            onFailure(error)
+            logFallback(identifier, fallback, error)
+        }
 }

--- a/app/composeApp/src/androidMain/res/values/strings.xml
+++ b/app/composeApp/src/androidMain/res/values/strings.xml
@@ -3,4 +3,12 @@
     <string name="app_name">Intrale</string>
     <string name="two_factor_setup">Configurar autenticación en dos pasos</string>
     <string name="two_factor_verify">Verificar autenticación en dos pasos</string>
+
+    <!-- Menú semicircular (accesibilidad / hints) -->
+    <string name="semi_circular_menu_open">
+        Menú. Desliza a la derecha para volver. Desliza hacia abajo para abrir. Toca para abrir o cerrar.
+    </string>
+    <string name="semi_circular_menu_close">Cerrar menú de acciones</string>
+    <string name="semi_circular_menu_long_press_hint">Desliza a la derecha para volver - hacia abajo para abrir</string>
+    <string name="dashboard_menu_hint">Desplegá el menú para acceder a las acciones principales.</string>
 </resources>

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/business/DashboardScreen.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/business/DashboardScreen.kt
@@ -130,18 +130,22 @@ class DashboardScreen : Screen(DASHBOARD_PATH, dashboard) {
         title: String,
     ) {
         val openDescription = resString(
+            androidId = androidStringId("semi_circular_menu_open"),
             composeId = semi_circular_menu_open,
             fallbackAsciiSafe = RES_ERROR_PREFIX + fb("Menu. Desliza a la derecha para volver. Desliza hacia abajo para abrir. Toca para abrir o cerrar."),
         )
         val closeDescription = resString(
+            androidId = androidStringId("semi_circular_menu_close"),
             composeId = semi_circular_menu_close,
             fallbackAsciiSafe = RES_ERROR_PREFIX + fb("Cerrar menu de acciones"),
         )
         val longPressHint = resString(
+            androidId = androidStringId("semi_circular_menu_long_press_hint"),
             composeId = semi_circular_menu_long_press_hint,
             fallbackAsciiSafe = RES_ERROR_PREFIX + fb("Desliza a la derecha para volver - hacia abajo para abrir"),
         )
         val hint = resString(
+            androidId = androidStringId("dashboard_menu_hint"),
             composeId = dashboard_menu_hint,
             fallbackAsciiSafe = RES_ERROR_PREFIX + fb("Desplega el menu para acceder a las acciones principales."),
         )

--- a/docs/engineering/strings.md
+++ b/docs/engineering/strings.md
@@ -1,6 +1,6 @@
 # Buenas prácticas de strings (Android/Compose MPP)
 
-Relacionado con #304.
+Relacionado con #304 y #306.
 
 ## Motivación
 
@@ -43,3 +43,23 @@ recurso y un contador acumulado. Esto permite auditar problemas de empaquetado s
 Si un bundle de Compose se distribuye con claves corruptas, se puede habilitar un _kill-switch_ (por ejemplo, desde `BuildConfig` o
 propiedades de gradle) para forzar el uso del fallback en claves específicas mientras se publica un hotfix del recurso. Este
 switch debe respetar las reglas anteriores: nunca exponer `stringResource` directamente y siempre delegar en `resString(...)`.
+
+## Caso Dashboard (menú semicircular)
+
+Como seguimiento al incidente de `DashboardMenuWithSemiCircle` (#306) se agregaron claves nativas en
+`app/composeApp/src/androidMain/res/values/strings.xml` para las descripciones de accesibilidad del menú. El consumo desde
+`DashboardScreen` queda así:
+
+```kotlin
+val openDescription = resString(
+    androidId = androidStringId("semi_circular_menu_open"),
+    composeId = semi_circular_menu_open,
+    fallbackAsciiSafe = RES_ERROR_PREFIX + fb("Menu. Desliza a la derecha para volver. Desliza hacia abajo para abrir. Toca para abrir o cerrar."),
+)
+```
+
+Puntos clave:
+
+1. El `androidId` apunta a la clave real de `strings.xml`, garantizando compatibilidad con lectores de pantalla.
+2. Las versiones multiplataforma siguen usando los `StringResource` de Compose.
+3. El fallback ASCII mantiene la app estable incluso si `stringResource` vuelve a fallar.


### PR DESCRIPTION
## Resumen
- agrega los recursos nativos del menú semicircular para Android
- prioriza androidId + composeId + fallback en DashboardMenuWithSemiCircle
- encapsula la resolución Compose en Android para asegurar fallback y documenta la práctica

## Testing
- ./gradlew clean assembleDebug --console=plain

Closes #306

------
https://chatgpt.com/codex/tasks/task_e_68d581b3bcb88325841a1be6b621c6b5