### PR TITLE
[auto] Parametrizar placeholders de branding Android

### DIFF
--- a/app/composeApp/build.gradle.kts
+++ b/app/composeApp/build.gradle.kts
@@ -222,6 +222,10 @@ android {
         versionName = "1.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "BRAND_ID", "\"$escapedBrandIdForBuildConfig\"")
+        manifestPlaceholders += mapOf(
+            "appLabel" to brandName,
+            "deeplinkHost" to deeplinkHost
+        )
     }
     buildFeatures {
         buildConfig = true

--- a/app/composeApp/src/androidMain/AndroidManifest.xml
+++ b/app/composeApp/src/androidMain/AndroidManifest.xml
@@ -6,7 +6,7 @@
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
-        android:label="@string/app_name"
+        android:label="${appLabel}"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@android:style/Theme.Material.Light.NoActionBar">
@@ -18,6 +18,17 @@
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:host="${deeplinkHost}"
+                    android:scheme="https" />
             </intent-filter>
         </activity>
     </application>

--- a/docs/branding/manifest-placeholders.md
+++ b/docs/branding/manifest-placeholders.md
@@ -1,0 +1,11 @@
+# Manifest placeholders de branding
+
+Los valores visibles de la app Android y los deeplinks se parametrizan mediante *manifest placeholders* definidos en el módulo `composeApp`.
+
+- **Archivo**: `app/composeApp/build.gradle.kts`
+- **Sección**: `android > defaultConfig`
+- **Placeholders**:
+  - `appLabel`: se alimenta con el valor calculado de `brandName` y define el atributo `android:label` del `AndroidManifest`.
+  - `deeplinkHost`: se genera a partir de la propiedad `deeplinkHost` y se utiliza en el `<data android:host=…>` del intent-filter de deeplinks.
+
+Para verificar el wiring, ejecutar un build con los parámetros de marca correspondientes (`-PbrandId`, `-PbrandName`, `-PdeeplinkHost`) y revisar el `AndroidManifest.xml` empaquetado mediante `aapt dump badging`.


### PR DESCRIPTION
Closes #310

## Resumen
- Reemplazo del label fijo por placeholder `appLabel` y agregado del intent-filter con `deeplinkHost`.
- Definición de `manifestPlaceholders` en la configuración Android.
- Documentación rápida sobre dónde actualizar los valores para QA.


------
https://chatgpt.com/codex/tasks/task_e_68d723a483348325940bcdcc76ad9082