### PR TITLE
[auto] Declarar dependencia scanNonAsciiFallbacks -> generateBrandResources

### DIFF
--- a/app/composeApp/build.gradle.kts
+++ b/app/composeApp/build.gradle.kts
@@ -327,6 +327,8 @@ val scanNonAsciiFallbacks by tasks.registering {
     inputs.files(brandingOut).skipWhenEmpty()
 
     dependsOn(ensureBrandingOut)
+    dependsOn(generateBrandResources)
+    inputs.dir(generateBrandResources.flatMap { it.outputResDirectory })
 
     doLast {
         val violations = mutableListOf<String>()


### PR DESCRIPTION
## Resumen
- Declara la dependencia explícita de scanNonAsciiFallbacks hacia generateBrandResources
- Registra los recursos generados como insumo de la verificación ASCII

Closes #340

------
https://chatgpt.com/codex/tasks/task_e_68d73b2070508325a473e3b9748b55ff