### PR TITLE
[auto] Corregir dependencias de Ktor en buildSrc

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -6,6 +6,8 @@ plugins {
     alias(libs.plugins.kotlin.jvm)
 }
 
+val ktorClientVersion = libs.ktor.client.core.jvm.stable.get().versionConstraint.requiredVersion.removeSuffix("-wasm2")
+
 repositories {
     mavenCentral()
     gradlePluginPortal()
@@ -18,8 +20,8 @@ dependencies {
     testImplementation(libs.kotlin.test.base)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.kotlinx.coroutines.core)
-    implementation(libs.ktor.client.core.jvm.stable)
-    implementation(libs.ktor.client.cio.stable)
+    implementation("io.ktor:ktor-client-core:$ktorClientVersion")
+    implementation("io.ktor:ktor-client-cio:$ktorClientVersion")
 }
 
 tasks.test {


### PR DESCRIPTION
## Resumen
- Actualicé buildSrc para derivar la versión de Ktor desde el catálogo y publicar las dependencias JVM sin el sufijo `-wasm2`.

Closes #350

------
https://chatgpt.com/codex/tasks/task_e_68d951787cdc8325bdb309c6ac7b7c5e