### PR TITLE
[auto] Consumo resiliente de branding remoto para app_name

### DIFF
--- a/app/composeApp/build.gradle.kts
+++ b/app/composeApp/build.gradle.kts
@@ -41,7 +41,8 @@ val brandName: String = providers.trimmedProperty("brandName") ?: brandId.replac
 
 val deeplinkHost: String = providers.trimmedProperty("deeplinkHost") ?: "$brandId.intrale.app"
 
-val brandingEndpoint: String? = providers.trimmedProperty("brandingEndpoint")
+val brandingEndpointParam: String? = providers.trimmedProperty("brandingEndpoint")
+val brandingPreviewVersionParam: String? = providers.trimmedProperty("brandingPreviewVersion")
 
 val applicationIdSuffixValue = ".${normalizedAppIdSuffix}"
 val escapedBrandIdForBuildConfig = brandId.replace("\"", "\\\"")
@@ -52,7 +53,10 @@ logger.lifecycle(" - appIdSuffix: $normalizedAppIdSuffix")
 logger.lifecycle(" - brandName: $brandName")
 logger.lifecycle(" - deeplinkHost: $deeplinkHost")
 logger.lifecycle(
-    " - brandingEndpoint: ${brandingEndpoint ?: "(no definido)"}"
+    " - brandingEndpoint: ${brandingEndpointParam ?: "(no definido)"}"
+)
+logger.lifecycle(
+    " - brandingPreviewVersion: ${brandingPreviewVersionParam ?: "(no definido)"}"
 )
 
 extra.apply {
@@ -60,7 +64,8 @@ extra.apply {
     set("appIdSuffix", normalizedAppIdSuffix)
     set("brandName", brandName)
     set("deeplinkHost", deeplinkHost)
-    brandingEndpoint?.let { set("brandingEndpoint", it) }
+    brandingEndpointParam?.let { set("brandingEndpoint", it) }
+    brandingPreviewVersionParam?.let { set("brandingPreviewVersion", it) }
 }
 
 
@@ -303,6 +308,8 @@ val generateBrandResources by tasks.registering(GenerateBrandResourcesTask::clas
     brandIdentifier.set(brandId)
     appDisplayName.set(brandName)
     brandStorageDirectory.set(brandingOut.map { it.dir(brandId).dir("res") })
+    brandingEndpointParam?.let { endpoint -> brandingEndpoint.set(endpoint) }
+    brandingPreviewVersionParam?.let { preview -> brandingPreviewVersion.set(preview) }
 }
 
 tasks.named("preBuild").configure {

--- a/buildSrc/src/main/kotlin/ar/com/intrale/branding/BrandingFetcher.kt
+++ b/buildSrc/src/main/kotlin/ar/com/intrale/branding/BrandingFetcher.kt
@@ -1,0 +1,66 @@
+package ar.com.intrale.branding
+
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+import java.time.Duration
+import java.util.Locale
+import kotlin.io.use
+
+data class BrandingFetchResult(
+    val envelope: BrandingEnvelope,
+    val rawJson: String
+)
+
+fun fetchBrandingEnvelope(
+    endpoint: String,
+    brandId: String,
+    previewVersion: String? = null,
+    timeout: Duration = Duration.ofSeconds(10),
+    headers: Map<String, String> = emptyMap(),
+    parser: BrandingParser = BrandingParser(),
+    httpFetcher: (url: String, headers: Map<String, String>, timeout: Duration) -> BrandingHttpResponse = ::defaultBrandingHttpFetch,
+): BrandingFetchResult {
+    val url = buildBrandingUrl(endpoint, brandId, previewVersion)
+    val response = httpFetcher(url, headers, timeout)
+
+    if (!response.successful) {
+        throw IllegalStateException("Respuesta inválida (${response.code}) al descargar branding desde $url")
+    }
+
+    val envelope = try {
+        parser.parseEnvelope(response.body)
+    } catch (ex: Exception) {
+        throw IllegalStateException("El JSON de branding recibido no es válido", ex)
+    }
+
+    return BrandingFetchResult(envelope = envelope, rawJson = response.body)
+}
+
+private fun defaultBrandingHttpFetch(
+    url: String,
+    headers: Map<String, String>,
+    timeout: Duration,
+): BrandingHttpResponse = BrandingHttpClient(timeout).use { client ->
+    client.fetch(url, headers)
+}
+
+private fun buildBrandingUrl(
+    endpoint: String,
+    brandId: String,
+    previewVersion: String?,
+): String {
+    val sanitized = endpoint.trim()
+    require(sanitized.isNotEmpty()) { "El endpoint de branding es obligatorio" }
+
+    val base = when {
+        sanitized.contains("{brandId}") -> sanitized.replace("{brandId}", brandId)
+        sanitized.contains("{{brandId}}") -> sanitized.replace("{{brandId}}", brandId)
+        sanitized.contains("%s") -> String.format(Locale.ROOT, sanitized, brandId)
+        else -> sanitized.trimEnd('/') + "/" + brandId
+    }
+
+    val preview = previewVersion?.takeIf { it.isNotBlank() } ?: return base
+    val encodedPreview = URLEncoder.encode(preview, StandardCharsets.UTF_8)
+    val separator = if (base.contains('?')) '&' else '?'
+    return base + separator + "previewVersion=" + encodedPreview
+}

--- a/buildSrc/src/main/kotlin/ar/com/intrale/branding/GenerateBrandResourcesTask.kt
+++ b/buildSrc/src/main/kotlin/ar/com/intrale/branding/GenerateBrandResourcesTask.kt
@@ -1,9 +1,11 @@
 package ar.com.intrale.branding
 
+import java.time.Duration
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 
@@ -15,6 +17,14 @@ abstract class GenerateBrandResourcesTask : DefaultTask() {
     @get:Input
     abstract val appDisplayName: Property<String>
 
+    @get:Input
+    @get:Optional
+    abstract val brandingEndpoint: Property<String>
+
+    @get:Input
+    @get:Optional
+    abstract val brandingPreviewVersion: Property<String>
+
     @get:OutputDirectory
     abstract val outputResDirectory: DirectoryProperty
 
@@ -23,21 +33,66 @@ abstract class GenerateBrandResourcesTask : DefaultTask() {
 
     @TaskAction
     fun generate() {
+        val brandId = brandIdentifier.get()
+        val fallbackName = appDisplayName.get()
+        val endpoint = brandingEndpoint.orNull?.takeIf { it.isNotBlank() }
+        val previewVersion = brandingPreviewVersion.orNull?.takeIf { it.isNotBlank() }
+
+        var appliedAppName = fallbackName
+        var downloadedJson: String? = null
+
+        if (endpoint != null) {
+            try {
+                val result = fetchBrandingEnvelope(
+                    endpoint = endpoint,
+                    brandId = brandId,
+                    previewVersion = previewVersion,
+                    timeout = Duration.ofSeconds(10)
+                )
+                downloadedJson = result.rawJson
+                val remoteAppName = result.envelope.payload.appName.trim()
+                if (remoteAppName.isNotEmpty()) {
+                    appliedAppName = remoteAppName
+                    logger.lifecycle(
+                        "Branding remoto aplicado para $brandId con appName=\"${appliedAppName.escapeForXmlText()}\""
+                    )
+                } else {
+                    logger.warn(
+                        "WARNING: El branding remoto de $brandId no incluye payload.appName válido. " +
+                            "Se utilizará el valor local \"${fallbackName.escapeForXmlText()}\""
+                    )
+                }
+            } catch (ex: Exception) {
+                logger.warn(
+                    "WARNING: No se pudo obtener branding remoto para $brandId desde $endpoint. " +
+                        "Se usará el fallback local \"${fallbackName.escapeForXmlText()}\". Detalle: ${ex.message}"
+                )
+            }
+        }
+
         val valuesDir = outputResDirectory.get().dir("values").asFile.also { it.mkdirs() }
         val stringsFile = valuesDir.resolve("strings.xml")
 
         val content = """
             <?xml version="1.0" encoding="utf-8"?>
             <resources>
-                <string name="app_name">${appDisplayName.get().escapeForXmlText()}</string>
+                <string name="app_name">${appliedAppName.escapeForXmlText()}</string>
             </resources>
         """.trimIndent() + "\n"
 
-        logger.lifecycle("Generando recursos de marca para ${brandIdentifier.get()} en ${stringsFile.absolutePath}")
+        logger.lifecycle("Generando recursos de marca para $brandId en ${stringsFile.absolutePath}")
         stringsFile.writeText(content)
 
         val brandValuesDir = brandStorageDirectory.get().dir("values").asFile.also { it.mkdirs() }
         brandValuesDir.resolve("strings.xml").writeText(content)
+
+        downloadedJson?.let { raw ->
+            val storageRoot = brandValuesDir.parentFile ?: brandValuesDir
+            val jsonFile = storageRoot.resolve("branding.json")
+            jsonFile.parentFile?.mkdirs()
+            jsonFile.writeText(raw)
+            logger.lifecycle("Branding remoto almacenado en ${jsonFile.absolutePath}")
+        }
     }
 
     private fun String.escapeForXmlText(): String = this

--- a/buildSrc/src/test/kotlin/ar/com/intrale/branding/BrandingFetcherTest.kt
+++ b/buildSrc/src/test/kotlin/ar/com/intrale/branding/BrandingFetcherTest.kt
@@ -1,0 +1,82 @@
+package ar.com.intrale.branding
+
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class BrandingFetcherTest {
+
+    private val sampleJson = """
+        {
+          "version": 1,
+          "schemaVersion": 0,
+          "payload": {
+            "appName": "Intrale"
+          }
+        }
+    """.trimIndent()
+
+    @Test
+    fun `compone la url agregando brandId y preview cuando corresponde`() {
+        val capturedUrls = mutableListOf<String>()
+
+        val result = fetchBrandingEnvelope(
+            endpoint = "https://branding.intrale.dev/api/brands",
+            brandId = "intrale",
+            previewVersion = "beta-1",
+            httpFetcher = { url, _, _ ->
+                capturedUrls += url
+                BrandingHttpResponse(code = 200, body = sampleJson, successful = true)
+            }
+        )
+
+        assertEquals("Intrale", result.envelope.payload.appName)
+        assertEquals(sampleJson, result.rawJson)
+        assertEquals(
+            listOf("https://branding.intrale.dev/api/brands/intrale?previewVersion=beta-1"),
+            capturedUrls,
+            "La URL debe incluir brandId y previewVersion"
+        )
+    }
+
+    @Test
+    fun `reemplaza placeholders de brandId y escapa el preview`() {
+        val capturedUrls = mutableListOf<String>()
+
+        fetchBrandingEnvelope(
+            endpoint = "https://branding.dev/brands/{brandId}",
+            brandId = "intrale",
+            previewVersion = "QA sprint/1",
+            httpFetcher = { url, _, _ ->
+                capturedUrls += url
+                BrandingHttpResponse(code = 200, body = sampleJson, successful = true)
+            }
+        )
+
+        assertEquals(1, capturedUrls.size)
+        val expectedPreview = URLEncoder.encode("QA sprint/1", StandardCharsets.UTF_8)
+        assertEquals(
+            "https://branding.dev/brands/intrale?previewVersion=$expectedPreview",
+            capturedUrls.first(),
+            "La URL debe interpolar el brandId y codificar el preview"
+        )
+    }
+
+    @Test
+    fun `lanza excepcion ante respuestas no exitosas`() {
+        val error = assertFailsWith<IllegalStateException> {
+            fetchBrandingEnvelope(
+                endpoint = "https://branding.dev/brands",
+                brandId = "intrale",
+                httpFetcher = { _, _, _ ->
+                    BrandingHttpResponse(code = 503, body = "", successful = false)
+                }
+            )
+        }
+
+        assertTrue(error.message?.contains("Respuesta inválida") == true)
+    }
+}


### PR DESCRIPTION
## Resumen
- Agrego utilidad `fetchBrandingEnvelope` para descargar y validar el JSON de branding con soporte de vista previa.
- Extiendo `GenerateBrandResourcesTask` para aplicar el `app_name` remoto, guardar la evidencia y registrar advertencias cuando se use el fallback local.
- Cableo los parámetros `brandingEndpoint` y `brandingPreviewVersion` en `composeApp` para propagar valores desde propiedades de Gradle.

## Testing
- ./gradlew :buildSrc:test --console=plain -PbrandId=intrale

Closes #313

------
https://chatgpt.com/codex/tasks/task_e_68da9d19b8f483258419b50821876eb0