### PR TITLE
[auto] Validación de deeplink host parametrizado

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,6 @@ El backend expone una ruta dinámica `/{business}/{function}` para todas las ope
 - `app/` - cliente Compose Multiplatform con código compartido y targets específicos.
 - `docs/` - documentación técnica de la plataforma.
 - `gradle/` y archivos `*.gradle.kts` - configuración de construcción y catálogo de dependencias.
+
+## Guías de QA
+- [Smoke test de deeplinks parametrizados](docs/engineering/deeplink-smoke-test.md)

--- a/app/composeApp/build.gradle.kts
+++ b/app/composeApp/build.gradle.kts
@@ -46,6 +46,7 @@ val brandingPreviewVersionParam: String? = providers.trimmedProperty("brandingPr
 
 val applicationIdSuffixValue = ".${normalizedAppIdSuffix}"
 val escapedBrandIdForBuildConfig = brandId.replace("\"", "\\\"")
+val escapedDeeplinkHostForBuildConfig = deeplinkHost.replace("\"", "\\\"")
 
 logger.lifecycle("Parámetros de branding aplicados:")
 logger.lifecycle(" - brandId: $brandId")
@@ -228,6 +229,7 @@ android {
         versionName = "1.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "BRAND_ID", "\"$escapedBrandIdForBuildConfig\"")
+        buildConfigField("String", "DEEPLINK_HOST", "\"$escapedDeeplinkHostForBuildConfig\"")
         manifestPlaceholders += mapOf(
             "appLabel" to brandName,
             "deeplinkHost" to deeplinkHost

--- a/app/composeApp/src/androidInstrumentedTest/kotlin/ui/deeplink/DeeplinkHostIntentFilterTest.kt
+++ b/app/composeApp/src/androidInstrumentedTest/kotlin/ui/deeplink/DeeplinkHostIntentFilterTest.kt
@@ -1,0 +1,73 @@
+package ui.deeplink
+
+import android.content.Intent
+import android.content.IntentFilter
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Build
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import ar.com.intrale.BuildConfig
+import ar.com.intrale.MainActivity
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class DeeplinkHostIntentFilterTest {
+
+    @Test
+    fun deeplinkIntentResolvesWithDynamicHost() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val context = instrumentation.targetContext
+        val deeplinkUri = Uri.parse("https://${BuildConfig.DEEPLINK_HOST}/test")
+        val deeplinkIntent = Intent(Intent.ACTION_VIEW, deeplinkUri).apply {
+            addCategory(Intent.CATEGORY_DEFAULT)
+            addCategory(Intent.CATEGORY_BROWSABLE)
+            setPackage(context.packageName)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+
+        val resolveInfos = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            context.packageManager.queryIntentActivities(
+                deeplinkIntent,
+                PackageManager.ResolveInfoFlags.of(PackageManager.MATCH_DEFAULT_ONLY.toLong())
+            )
+        } else {
+            @Suppress("DEPRECATION")
+            context.packageManager.queryIntentActivities(
+                deeplinkIntent,
+                PackageManager.MATCH_DEFAULT_ONLY
+            )
+        }
+
+        assertTrue(resolveInfos.isNotEmpty(), "No se pudo resolver el intent de deeplink para el host configurado.")
+
+        val matchesMainActivity = resolveInfos.any { it.activityInfo?.name == MainActivity::class.java.name }
+        assertTrue(matchesMainActivity, "El deeplink no está apuntando a MainActivity.")
+
+        val hostMatches = resolveInfos.any { resolveInfo ->
+            val filter: IntentFilter = resolveInfo.filter ?: return@any false
+            val iterator = filter.authoritiesIterator() ?: return@any false
+            while (iterator.hasNext()) {
+                if (iterator.next().host == BuildConfig.DEEPLINK_HOST) {
+                    return@any true
+                }
+            }
+            false
+        }
+        assertTrue(hostMatches, "El intent-filter no declara el host dinámico ${BuildConfig.DEEPLINK_HOST}.")
+
+        val launchedActivity = instrumentation.startActivitySync(deeplinkIntent)
+        try {
+            assertEquals(
+                MainActivity::class.java.name,
+                launchedActivity::class.java.name,
+                "El deeplink no abre la actividad esperada."
+            )
+        } finally {
+            instrumentation.runOnMainSync { launchedActivity.finish() }
+        }
+    }
+}

--- a/docs/engineering/deeplink-smoke-test.md
+++ b/docs/engineering/deeplink-smoke-test.md
@@ -1,0 +1,38 @@
+# Smoke test de deeplinks parametrizados
+
+Este procedimiento valida que la aplicación Android responda correctamente a deeplinks HTTPS utilizando el `deeplinkHost` suministrado por parámetros de Gradle.
+
+## Preparación
+1. Conectá un dispositivo físico o iniciá un emulador Android con la depuración habilitada.
+2. Generá e instalá la build de depuración con los parámetros de branding necesarios:
+   ```bash
+   ./gradlew :app:composeApp:installDebug \
+       -PbrandId=<identificador_de_marca> \
+       -PdeeplinkHost=<host.dinamico>
+   ```
+   - Si omitís `-PdeeplinkHost`, se utilizará el valor por defecto `<brandId>.intrale.app`.
+
+## Ejecución manual del smoke test
+1. Abrí la actividad mediante un intent `VIEW` apuntando al host configurado:
+   ```bash
+   adb shell am start \
+       -a android.intent.action.VIEW \
+       -d "https://<host.dinamico>/test"
+   ```
+2. Verificá en el dispositivo que la aplicación se abra en la pantalla principal (actividad `MainActivity`).
+3. Revisá los logs (`adb logcat`) para confirmar que la navegación se resolvió sin errores.
+
+## Verificación automatizada (opcional)
+- Ejecutá el siguiente comando para correr únicamente la prueba instrumental que valida el intent-filter con el host dinámico:
+  ```bash
+  ./gradlew :app:composeApp:connectedAndroidTest \
+      -PbrandId=<identificador_de_marca> \
+      -PdeeplinkHost=<host.dinamico> \
+      -Pandroid.testInstrumentationRunnerArguments.class=ui.deeplink.DeeplinkHostIntentFilterTest
+  ```
+- La prueba `DeeplinkHostIntentFilterTest` comprueba que:
+  1. El `PackageManager` resuelve el deeplink hacia `MainActivity`.
+  2. El `intent-filter` declara el `host` dinámico recibido en `BuildConfig`.
+  3. El intent abre efectivamente la actividad esperada.
+
+Con esto queda cubierto el smoke test requerido para QA/CI.


### PR DESCRIPTION
## Resumen
- se expone `DEEPLINK_HOST` en BuildConfig y se añade una prueba instrumental que asegura que el intent-filter resuelva el host dinámico hacia MainActivity
- se documenta el procedimiento manual/automatizado del smoke test de deeplinks y se enlaza desde el README

## Pruebas
- `./gradlew :app:composeApp:assembleDebug -PbrandId=intrale -PdeeplinkHost=demo.intrale.app --console=plain`

Closes #315

------
https://chatgpt.com/codex/tasks/task_e_68dc13334f088325a092cc2944ae5960