### PR TITLE
[auto] Registrar BRAND_ID y applicationId en logs de arranque

### DIFF
--- a/app/composeApp/src/androidMain/kotlin/ar/com/intrale/MainActivity.kt
+++ b/app/composeApp/src/androidMain/kotlin/ar/com/intrale/MainActivity.kt
@@ -1,6 +1,7 @@
 package ar.com.intrale
 
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.runtime.Composable
@@ -11,9 +12,21 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        logBrandContext()
+
         setContent {
             App()
         }
+    }
+
+    private fun logBrandContext() {
+        val brandId = BuildConfig.BRAND_ID
+        val applicationId = BuildConfig.APPLICATION_ID
+        Log.i(TAG, "Brand context — BRAND_ID=$brandId, applicationId=$applicationId")
+    }
+
+    companion object {
+        private const val TAG = "IntraleBrandCheck"
     }
 }
 


### PR DESCRIPTION
## Resumen
- Agrega un registro informativo en `MainActivity` para imprimir los valores de `BRAND_ID` y `applicationId` al iniciar la app Android.

## Pruebas
- `./gradlew :app:composeApp:assembleDebug --no-daemon --console=plain -PbrandId=intrale`

Closes #316

------
https://chatgpt.com/codex/tasks/task_e_68dc20323c388325956ec7ac7c98302a