### PR TITLE
[auto] Branding dinámico en build iOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ app/composeApp/src/wasmJsMain/resources/*.png
 app/composeApp/src/wasmJsMain/resources/*.ico
 app/iosApp/iosApp/Assets.xcassets/AppIcon.appiconset/*.png
 docs/branding/icons/icon_master.png
+
+ios/Branding.xcconfig

--- a/docs/branding-build-ios.md
+++ b/docs/branding-build-ios.md
@@ -1,0 +1,85 @@
+# Build iOS con parámetros de branding dinámicos
+
+Este procedimiento permite compilar el cliente iOS inyectando la configuración de marca
+(identificador, sufijos de bundle, nombre visible y endpoints) sin necesidad de mantener
+`schemes` por cada marca. La generación del archivo `Branding.xcconfig` se realiza en
+runtime antes de invocar `xcodebuild`.
+
+## Plantilla de parámetros
+
+El repositorio incorpora `ios/BrandingTemplate.xcconfig` como base con valores por defecto:
+
+```
+BRAND_ID = default
+BUNDLE_ID_SUFFIX = default
+BRAND_NAME = Default
+DEEPLINK_HOST = default.intrale.app
+BRANDING_ENDPOINT = https://branding.intrale.app/default
+BRANDING_PREVIEW_VERSION =
+PRODUCT_BUNDLE_IDENTIFIER = ar.com.intrale.platform.$(BUNDLE_ID_SUFFIX)
+DISPLAY_NAME = $(BRAND_NAME)
+```
+
+La plantilla no se modifica directamente. El pipeline genera `ios/Branding.xcconfig` a
+partir de este archivo aplicando los parámetros recibidos.
+
+## Script de generación
+
+El script `ios/scripts/generate_branding_xcconfig.py` aplica el siguiente flujo:
+
+1. Lee la plantilla conservando comentarios y orden de claves.
+2. Reemplaza los valores mediante variables de entorno o parámetros `--set KEY=VALUE`.
+3. Valida que `BRAND_ID`, `DEEPLINK_HOST` y `BRANDING_ENDPOINT` no sean vacíos y que
+   `BUNDLE_ID_SUFFIX` no contenga espacios ni puntos duplicados.
+4. Emite `ios/Branding.xcconfig` listo para ser consumido por el proyecto Xcode y muestra
+   en consola el resumen de parámetros finales.
+
+Se puede ejecutar de forma aislada:
+
+```bash
+BRAND_ID=acme \
+BUNDLE_ID_SUFFIX=acme \
+BRAND_NAME="Acme" \
+DEEPLINK_HOST=acme.intrale.app \
+BRANDING_ENDPOINT="https://api.intrale.app/branding/acme" \
+BRANDING_PREVIEW_VERSION=latest \
+python ios/scripts/generate_branding_xcconfig.py \
+  --template ios/BrandingTemplate.xcconfig \
+  --output ios/Branding.xcconfig
+```
+
+## Wrapper de xcodebuild
+
+Para CI/CD se incluye `ios/scripts/xcodebuild_with_branding.sh`, que automatiza el flujo:
+
+1. Detecta parámetros `KEY=VALUE` compatibles con branding dentro de los argumentos
+   entregados a `xcodebuild` y los exporta como variables de entorno.
+2. Ejecuta el script anterior para regenerar `Branding.xcconfig` antes de compilar.
+3. Inyecta el `-xcconfig ios/Branding.xcconfig` a la invocación de `xcodebuild` cuando el
+   comando original no lo especifica.
+
+Ejemplo de uso para una build Release:
+
+```bash
+./ios/scripts/xcodebuild_with_branding.sh \
+  -scheme IntraleApp \
+  -configuration Release \
+  BRAND_ID=acme \
+  BUNDLE_ID_SUFFIX=acme \
+  BRAND_NAME="Acme" \
+  DEEPLINK_HOST=acme.intrale.app \
+  BRANDING_ENDPOINT="https://api.intrale.app/branding/acme" \
+  BRANDING_PREVIEW_VERSION=latest
+```
+
+El wrapper mantiene intactos el resto de los parámetros (`-destination`, `-archivePath`,
+ etc.) por lo que puede integrarse en los workflows existentes. Si el proyecto ya define
+`Branding.xcconfig` como *Base Configuration* no es necesario pasar `-xcconfig` manualmente.
+
+## Validaciones esperadas en CI
+
+- Los logs de `xcodebuild` deben listar las variables inyectadas en `OTHER_CFLAGS` o en el
+  entorno, confirmando que el wrapper propagó los parámetros.
+- El archivo `ios/Branding.xcconfig` debe regenerarse en cada ejecución del pipeline con
+  los valores solicitados antes de que inicie la compilación.
+- No se versiona el resultado final porque está ignorado vía `.gitignore`.

--- a/ios/BrandingTemplate.xcconfig
+++ b/ios/BrandingTemplate.xcconfig
@@ -1,0 +1,11 @@
+// Plantilla base de parámetros de branding.
+// Los valores se sobrescriben en Branding.xcconfig según los argumentos recibidos.
+
+BRAND_ID = default
+BUNDLE_ID_SUFFIX = default
+BRAND_NAME = Default
+DEEPLINK_HOST = default.intrale.app
+BRANDING_ENDPOINT = https://branding.intrale.app/default
+BRANDING_PREVIEW_VERSION =
+PRODUCT_BUNDLE_IDENTIFIER = ar.com.intrale.platform.$(BUNDLE_ID_SUFFIX)
+DISPLAY_NAME = $(BRAND_NAME)

--- a/ios/scripts/generate_branding_xcconfig.py
+++ b/ios/scripts/generate_branding_xcconfig.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Genera ios/Branding.xcconfig a partir de la plantilla y overrides."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+BRANDING_KEYS = [
+    "BRAND_ID",
+    "BUNDLE_ID_SUFFIX",
+    "BRAND_NAME",
+    "DEEPLINK_HOST",
+    "BRANDING_ENDPOINT",
+    "BRANDING_PREVIEW_VERSION",
+    "PRODUCT_BUNDLE_IDENTIFIER",
+    "DISPLAY_NAME",
+]
+
+_ASSIGNMENT_RE = re.compile(r"^([A-Z0-9_]+)\s*=\s*(.*)$")
+
+
+def _parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Genera Branding.xcconfig en base a BrandingTemplate.xcconfig y a "
+            "los parámetros recibidos por entorno o mediante --set"
+        )
+    )
+    parser.add_argument(
+        "--template",
+        type=Path,
+        required=True,
+        help="Ruta al archivo BrandingTemplate.xcconfig",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        required=True,
+        help="Ruta destino del archivo Branding.xcconfig",
+    )
+    parser.add_argument(
+        "--set",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help="Override explícito del valor de una clave",
+    )
+    return parser.parse_args()
+
+
+def _load_template(path: Path) -> Tuple[List[Tuple[str, str]], Dict[str, str]]:
+    if not path.exists():
+        raise FileNotFoundError(f"No se encontró la plantilla: {path}")
+
+    entries: List[Tuple[str, str]] = []
+    defaults: Dict[str, str] = {}
+
+    with path.open("r", encoding="utf-8") as fh:
+        for raw_line in fh.readlines():
+            stripped = raw_line.strip()
+            match = _ASSIGNMENT_RE.match(stripped)
+            if not stripped or stripped.startswith("//") or match is None:
+                entries.append(("raw", raw_line))
+                continue
+
+            key, value = match.group(1), match.group(2).strip()
+            entries.append(("setting", key))
+            defaults[key] = value
+
+    return entries, defaults
+
+
+def _parse_overrides(raw_overrides: List[str]) -> Dict[str, str]:
+    overrides: Dict[str, str] = {}
+    for item in raw_overrides:
+        if "=" not in item:
+            raise ValueError(
+                f"El parámetro '{item}' no respeta el formato KEY=VALUE requerido por --set"
+            )
+        key, value = item.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        if key not in BRANDING_KEYS:
+            raise KeyError(f"'{key}' no es una clave soportada para Branding.xcconfig")
+        overrides[key] = value
+    return overrides
+
+
+def _value_from_environment(key: str) -> str | None:
+    value = os.environ.get(key)
+    if value is None:
+        return None
+    return value.strip()
+
+
+def _normalize_value(key: str, value: str) -> str:
+    if key == "BUNDLE_ID_SUFFIX":
+        sanitized = value.replace("\u200b", "").strip()
+        if any(ch.isspace() for ch in sanitized):
+            raise ValueError("BUNDLE_ID_SUFFIX no puede contener espacios")
+        # Evitar prefijos con punto duplicado.
+        sanitized = sanitized.lstrip(".")
+        return sanitized
+
+    if key == "BRAND_ID":
+        sanitized = value.strip()
+        if not sanitized:
+            raise ValueError("BRAND_ID es obligatorio")
+        return sanitized
+
+    if key == "DEEPLINK_HOST":
+        sanitized = value.strip()
+        if not sanitized:
+            raise ValueError("DEEPLINK_HOST es obligatorio")
+        return sanitized
+
+    if key == "BRAND_NAME":
+        return value.strip()
+
+    if key == "BRANDING_PREVIEW_VERSION":
+        return value.strip()
+
+    if key == "BRANDING_ENDPOINT":
+        sanitized = value.strip()
+        if not sanitized:
+            raise ValueError("BRANDING_ENDPOINT es obligatorio")
+        return sanitized
+
+    if key == "PRODUCT_BUNDLE_IDENTIFIER":
+        return value.strip()
+
+    if key == "DISPLAY_NAME":
+        return value.strip()
+
+    return value
+
+
+def _format_value(value: str) -> str:
+    if value == "":
+        return ""
+
+    escaped = value.replace("\"", "\\\"")
+    if any(ch.isspace() for ch in escaped) or "#" in escaped:
+        return f'"{escaped}"'
+    return escaped
+
+
+def main() -> int:
+    args = _parse_arguments()
+
+    entries, defaults = _load_template(args.template)
+    overrides = _parse_overrides(args.set)
+
+    resolved: Dict[str, str] = {}
+    for key in BRANDING_KEYS:
+        # Prioridad: override CLI -> variable de entorno -> plantilla -> string vacío.
+        if key in overrides:
+            value = overrides[key]
+        else:
+            env_value = _value_from_environment(key)
+            if env_value is not None:
+                value = env_value
+            else:
+                value = defaults.get(key, "")
+
+        if value is None:
+            value = ""
+
+        resolved[key] = _normalize_value(key, value)
+
+    output_lines: List[str] = []
+    for entry_type, payload in entries:
+        if entry_type == "raw":
+            output_lines.append(payload)
+            continue
+
+        key = payload
+        value = resolved.get(key, defaults.get(key, ""))
+        formatted_value = _format_value(value)
+        output_lines.append(f"{key} = {formatted_value}\n")
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with args.output.open("w", encoding="utf-8") as fh:
+        fh.writelines(output_lines)
+
+    summary = [
+        "Branding.xcconfig generado con parámetros:",
+    ]
+    for key in BRANDING_KEYS:
+        display_value = resolved.get(key, "") or "(vacío)"
+        summary.append(f" - {key}: {display_value}")
+
+    print("\n".join(summary))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as exc:  # pragma: no cover - manejo global para logs del pipeline
+        print(f"Error generando Branding.xcconfig: {exc}", file=sys.stderr)
+        sys.exit(1)

--- a/ios/scripts/xcodebuild_with_branding.sh
+++ b/ios/scripts/xcodebuild_with_branding.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TEMPLATE_PATH="$PROJECT_ROOT/BrandingTemplate.xcconfig"
+OUTPUT_PATH="$PROJECT_ROOT/Branding.xcconfig"
+
+BRANDING_KEYS=(
+  BRAND_ID
+  BUNDLE_ID_SUFFIX
+  BRAND_NAME
+  DEEPLINK_HOST
+  BRANDING_ENDPOINT
+  BRANDING_PREVIEW_VERSION
+)
+
+declare -A BRANDING_OVERRIDES=()
+
+declare -a FORWARDED_ARGS=()
+
+for arg in "$@"; do
+  if [[ "$arg" == -* ]]; then
+    FORWARDED_ARGS+=("$arg")
+    continue
+  fi
+
+  if [[ "$arg" == *=* ]]; then
+    key="${arg%%=*}"
+    value="${arg#*=}"
+    for known_key in "${BRANDING_KEYS[@]}"; do
+      if [[ "$key" == "$known_key" ]]; then
+        BRANDING_OVERRIDES["$key"]="$value"
+        break
+      fi
+    done
+    FORWARDED_ARGS+=("$arg")
+  else
+    FORWARDED_ARGS+=("$arg")
+  fi
+done
+
+for key in "${!BRANDING_OVERRIDES[@]}"; do
+  export "$key"="${BRANDING_OVERRIDES[$key]}"
+done
+
+PYTHON_SCRIPT="$SCRIPT_DIR/generate_branding_xcconfig.py"
+
+if [[ ! -x "$PYTHON_SCRIPT" ]]; then
+  echo "Error: no se puede ejecutar $PYTHON_SCRIPT" >&2
+  exit 1
+fi
+
+"$PYTHON_SCRIPT" --template "$TEMPLATE_PATH" --output "$OUTPUT_PATH"
+
+has_xcconfig=false
+for arg in "${FORWARDED_ARGS[@]}"; do
+  if [[ "$arg" == "-xcconfig" ]]; then
+    has_xcconfig=true
+    break
+  fi
+done
+
+if [[ "$has_xcconfig" == false ]]; then
+  FORWARDED_ARGS+=("-xcconfig" "$OUTPUT_PATH")
+fi
+
+exec xcodebuild "${FORWARDED_ARGS[@]}"


### PR DESCRIPTION
## Resumen
- agrega la plantilla `BrandingTemplate.xcconfig` con valores por defecto
- automatiza la generación de `Branding.xcconfig` y el passthrough a `xcodebuild`
- documenta cómo invocar el wrapper en CI/CD

Closes #318

------
https://chatgpt.com/codex/tasks/task_e_68dc39cecae4832599013263269277b4