### PR TITLE
[auto] Script pre-build para Branding.xcconfig

### DIFF
--- a/docs/branding-build-ios.md
+++ b/docs/branding-build-ios.md
@@ -76,6 +76,33 @@ El wrapper mantiene intactos el resto de los parámetros (`-destination`, `-arch
  etc.) por lo que puede integrarse en los workflows existentes. Si el proyecto ya define
 `Branding.xcconfig` como *Base Configuration* no es necesario pasar `-xcconfig` manualmente.
 
+## Script de Pre-Build para Xcode
+
+Para automatizar la generación dentro del propio proyecto Xcode se incluye el script
+`ios/scripts/prebuild_generate_branding.sh`. Este script está pensado para ejecutarse en
+una fase **Run Script** configurada como *Pre-build* y aplica el siguiente flujo:
+
+1. Valida que la variable de entorno `BRAND_ID` esté presente. Si falta, aborta la build
+   con un mensaje claro.
+2. Lee, cuando están disponibles, los valores de `BUNDLE_ID_SUFFIX`, `BRAND_NAME`,
+   `DEEPLINK_HOST`, `BRANDING_ENDPOINT`, `BRANDING_PREVIEW_VERSION`,
+   `PRODUCT_BUNDLE_IDENTIFIER` y `DISPLAY_NAME`.
+3. Invoca `generate_branding_xcconfig.py` para renderizar `ios/Branding.xcconfig` a partir
+   de la plantilla.
+4. Reporta la ruta del archivo generado para facilitar el diagnóstico en los logs.
+
+Ejemplo de configuración de la fase Run Script:
+
+```bash
+export BRAND_ID=${BRAND_ID:?Debe definirse BRAND_ID}
+export BRAND_NAME="Intrale Demo"
+export BUNDLE_ID_SUFFIX=demo
+"${SRCROOT}/../ios/scripts/prebuild_generate_branding.sh"
+```
+
+Al ejecutarse antes de `Compile Sources`, el proyecto siempre utilizará la versión más
+reciente de `Branding.xcconfig` sin requerir intervención manual.
+
 ## Validaciones esperadas en CI
 
 - Los logs de `xcodebuild` deben listar las variables inyectadas en `OTHER_CFLAGS` o en el

--- a/ios/scripts/prebuild_generate_branding.sh
+++ b/ios/scripts/prebuild_generate_branding.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TEMPLATE_PATH="$PROJECT_ROOT/BrandingTemplate.xcconfig"
+OUTPUT_PATH="$PROJECT_ROOT/Branding.xcconfig"
+PYTHON_SCRIPT="$SCRIPT_DIR/generate_branding_xcconfig.py"
+
+REQUIRED_VARS=(
+  BRAND_ID
+)
+OPTIONAL_VARS=(
+  BUNDLE_ID_SUFFIX
+  BRAND_NAME
+  DEEPLINK_HOST
+  BRANDING_ENDPOINT
+  BRANDING_PREVIEW_VERSION
+  PRODUCT_BUNDLE_IDENTIFIER
+  DISPLAY_NAME
+)
+
+for var_name in "${REQUIRED_VARS[@]}"; do
+  if [[ -z "${!var_name-}" ]]; then
+    echo "[Branding] Variable obligatoria faltante: $var_name" >&2
+    exit 1
+  fi
+done
+
+if [[ ! -f "$TEMPLATE_PATH" ]]; then
+  echo "[Branding] No se encontró la plantilla en $TEMPLATE_PATH" >&2
+  exit 1
+fi
+
+if [[ ! -x "$PYTHON_SCRIPT" ]]; then
+  echo "[Branding] No se puede ejecutar $PYTHON_SCRIPT" >&2
+  exit 1
+fi
+
+ARGS=("--template" "$TEMPLATE_PATH" "--output" "$OUTPUT_PATH")
+
+append_if_set() {
+  local key="$1"
+  local value="${!key-}"
+  if [[ -n "$value" ]]; then
+    ARGS+=("--set" "$key=$value")
+  fi
+}
+
+for key in "${REQUIRED_VARS[@]}"; do
+  append_if_set "$key"
+done
+for key in "${OPTIONAL_VARS[@]}"; do
+  append_if_set "$key"
+done
+
+"$PYTHON_SCRIPT" "${ARGS[@]}"
+
+echo "[Branding] Archivo generado en $OUTPUT_PATH"


### PR DESCRIPTION
Closes #319

## Resumen
- agrega un script de pre-build en Bash que genera ios/Branding.xcconfig desde la plantilla
- documenta la integración del script dentro de una fase Run Script de Xcode

------
https://chatgpt.com/codex/tasks/task_e_68dc46fb2f5c8325bfaa95264e6ca427