### PR TITLE
[auto] Validar BRAND_ID en la generación de Branding.xcconfig

### DIFF
--- a/docs/branding-build-ios.md
+++ b/docs/branding-build-ios.md
@@ -29,8 +29,9 @@ El script `ios/scripts/generate_branding_xcconfig.py` aplica el siguiente flujo:
 
 1. Lee la plantilla conservando comentarios y orden de claves.
 2. Reemplaza los valores mediante variables de entorno o parámetros `--set KEY=VALUE`.
-3. Valida que `BRAND_ID`, `DEEPLINK_HOST` y `BRANDING_ENDPOINT` no sean vacíos y que
-   `BUNDLE_ID_SUFFIX` no contenga espacios ni puntos duplicados.
+3. Exige que `BRAND_ID` esté definido vía entorno o `--set` y valida que `DEEPLINK_HOST`
+   y `BRANDING_ENDPOINT` no sean vacíos y que `BUNDLE_ID_SUFFIX` no contenga espacios ni
+   puntos duplicados.
 4. Emite `ios/Branding.xcconfig` listo para ser consumido por el proyecto Xcode y muestra
    en consola el resumen de parámetros finales.
 

--- a/ios/scripts/generate_branding_xcconfig.py
+++ b/ios/scripts/generate_branding_xcconfig.py
@@ -166,6 +166,10 @@ def main() -> int:
             if env_value is not None:
                 value = env_value
             else:
+                if key == "BRAND_ID":
+                    raise ValueError(
+                        "BRAND_ID debe definirse mediante variable de entorno o --set"
+                    )
                 value = defaults.get(key, "")
 
         if value is None:


### PR DESCRIPTION
## Resumen
- hacer fallar la generación de Branding.xcconfig cuando BRAND_ID no está definido
- documentar el requisito obligatorio para BRAND_ID en el procedimiento de build

Closes #319

------
https://chatgpt.com/codex/tasks/task_e_68dc48d4d0b88325be5e9cf049ea205f