### PR TITLE
[auto] Configura placeholders de deeplinks para iOS

### DIFF
--- a/app/iosApp/iosApp/Info.plist
+++ b/app/iosApp/iosApp/Info.plist
@@ -20,8 +20,25 @@
     <string>$(MARKETING_VERSION)</string>
     <key>CFBundleVersion</key>
     <string>$(CURRENT_PROJECT_VERSION)</string>
+    <key>CFBundleURLTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleTypeRole</key>
+            <string>Viewer</string>
+            <key>CFBundleURLName</key>
+            <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+            <key>CFBundleURLSchemes</key>
+            <array>
+                <string>$(DEEPLINK_SCHEME)</string>
+            </array>
+        </dict>
+    </array>
     <key>LSRequiresIPhoneOS</key>
     <true/>
+    <key>NSUserActivityTypes</key>
+    <array>
+        <string>applinks:$(DEEPLINK_HOST)</string>
+    </array>
     <key>UIApplicationSceneManifest</key>
     <dict>
         <key>UIApplicationSupportsMultipleScenes</key>

--- a/ios/BrandingTemplate.xcconfig
+++ b/ios/BrandingTemplate.xcconfig
@@ -5,6 +5,7 @@ BRAND_ID = default
 BUNDLE_ID_SUFFIX = default
 BRAND_NAME = Default
 DEEPLINK_HOST = default.intrale.app
+DEEPLINK_SCHEME = intrale
 BRANDING_ENDPOINT = https://branding.intrale.app/default
 BRANDING_PREVIEW_VERSION =
 PRODUCT_BUNDLE_IDENTIFIER = ar.com.intrale.platform.$(BUNDLE_ID_SUFFIX)


### PR DESCRIPTION
## Resumen
- Ajusta Info.plist para definir placeholders de deeplinks y universal links parametrizados por marca.
- Declara el esquema de deeplink en la plantilla de branding para permitir configurarlo por entorno.

## Pruebas
- No se ejecutaron pruebas automáticas (cambio de configuración)

Closes #321

------
https://chatgpt.com/codex/tasks/task_e_68dc84b6d11c83259d11ad7c7954f007