### PR TITLE
[auto] Scheme único de IntraleApp con xcconfig compartido

### DIFF
--- a/app/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/app/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -171,6 +171,7 @@ runOnlyForDeploymentPostprocessing = 0;
 /* Begin XCBuildConfiguration section */
 D4F909042C9C00A100F4A0D2 /* Debug */ = {
 isa = XCBuildConfiguration;
+baseConfigurationReference = D4F909002C9C00A100F4A0D2 /* Branding.xcconfig */;
 buildSettings = {
 ALWAYS_SEARCH_USER_PATHS = NO;
 CLANG_ANALYZER_NONNULL = YES;
@@ -224,6 +225,7 @@ name = Debug;
 };
 D4F909052C9C00A100F4A0D2 /* Release */ = {
 isa = XCBuildConfiguration;
+baseConfigurationReference = D4F909002C9C00A100F4A0D2 /* Branding.xcconfig */;
 buildSettings = {
 ALWAYS_SEARCH_USER_PATHS = NO;
 CLANG_ANALYZER_NONNULL = YES;

--- a/app/iosApp/iosApp.xcodeproj/xcshareddata/xcschemes/IntraleApp.xcscheme
+++ b/app/iosApp/iosApp.xcodeproj/xcshareddata/xcschemes/IntraleApp.xcscheme
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1530"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D4F908F22C9C00A100F4A0D2"
+               BuildableName = "IntraleApp.app"
+               BlueprintName = "IntraleApp"
+               ReferencedContainer = "container:iosApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D4F908F22C9C00A100F4A0D2"
+            BuildableName = "IntraleApp.app"
+            BlueprintName = "IntraleApp"
+            ReferencedContainer = "container:iosApp.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D4F908F22C9C00A100F4A0D2"
+            BuildableName = "IntraleApp.app"
+            BlueprintName = "IntraleApp"
+            ReferencedContainer = "container:iosApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D4F908F22C9C00A100F4A0D2"
+            BuildableName = "IntraleApp.app"
+            BlueprintName = "IntraleApp"
+            ReferencedContainer = "container:iosApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
## Resumen
- Comparte el scheme `IntraleApp` para exponer un único flujo de build en Xcode/xcodebuild.
- Ajusta las configuraciones Debug y Release para reutilizar `Branding.xcconfig` como base compartida.

Closes #324

------
https://chatgpt.com/codex/tasks/task_e_68dd16eda33083259efc168be1e07720