### PR TITLE
[auto] Documentar smoke test deeplinks parametrizados

### DIFF
--- a/docs/engineering/deeplink-smoke-test.md
+++ b/docs/engineering/deeplink-smoke-test.md
@@ -1,8 +1,15 @@
-# Smoke test de deeplinks parametrizados
+# Smoke test de deeplinks y applinks parametrizados
 
-Este procedimiento valida que la aplicación Android responda correctamente a deeplinks HTTPS utilizando el `deeplinkHost` suministrado por parámetros de Gradle.
+Este procedimiento valida que la aplicación responda a deeplinks/applinks utilizando el host definido en tiempo de build, tanto en Android como en iOS. Está pensado como guía rápida para QA/CI cuando se actualiza `-PdeeplinkHost` (Android) o `DEEPLINK_HOST` (iOS).
 
-## Preparación
+## Alcance
+
+- Android: intent-filter HTTPS configurado desde Gradle (`BuildConfig.DEEPLINK_HOST`).
+- iOS: `CFBundleURLTypes` y `NSUserActivityTypes` alimentados por `DEEPLINK_HOST`/`DEEPLINK_SCHEME` en `Branding.xcconfig`.
+
+## Android
+
+### Preparación
 1. Conectá un dispositivo físico o iniciá un emulador Android con la depuración habilitada.
 2. Generá e instalá la build de depuración con los parámetros de branding necesarios:
    ```bash
@@ -12,7 +19,7 @@ Este procedimiento valida que la aplicación Android responda correctamente a de
    ```
    - Si omitís `-PdeeplinkHost`, se utilizará el valor por defecto `<brandId>.intrale.app`.
 
-## Ejecución manual del smoke test
+### Ejecución manual del smoke test
 1. Abrí la actividad mediante un intent `VIEW` apuntando al host configurado:
    ```bash
    adb shell am start \
@@ -22,7 +29,7 @@ Este procedimiento valida que la aplicación Android responda correctamente a de
 2. Verificá en el dispositivo que la aplicación se abra en la pantalla principal (actividad `MainActivity`).
 3. Revisá los logs (`adb logcat`) para confirmar que la navegación se resolvió sin errores.
 
-## Verificación automatizada (opcional)
+### Verificación automatizada (opcional)
 - Ejecutá el siguiente comando para correr únicamente la prueba instrumental que valida el intent-filter con el host dinámico:
   ```bash
   ./gradlew :app:composeApp:connectedAndroidTest \
@@ -35,4 +42,49 @@ Este procedimiento valida que la aplicación Android responda correctamente a de
   2. El `intent-filter` declara el `host` dinámico recibido en `BuildConfig`.
   3. El intent abre efectivamente la actividad esperada.
 
-Con esto queda cubierto el smoke test requerido para QA/CI.
+## iOS
+
+### Preparación
+1. Abrí el simulador deseado (`xcrun simctl boot "iPhone 15"`, por ejemplo) o conectá un dispositivo físico.
+2. Generá la configuración de branding utilizando el wrapper de Xcode incluido en el repositorio:
+   ```bash
+   ./ios/scripts/xcodebuild_with_branding.sh \
+       -scheme IntraleApp \
+       -configuration Debug \
+       -destination 'platform=iOS Simulator,name=iPhone 15' \
+       BRAND_ID=<identificador_de_marca> \
+       DEEPLINK_HOST=<host.dinamico> \
+       DEEPLINK_SCHEME=<esquema_temporal>
+   ```
+   - El script regenera `ios/Branding.xcconfig` inyectando los valores anteriores antes de compilar.
+
+### Smoke test con `CFBundleURLTypes`
+1. Instalá la app generada en el simulador/dispositivo desde Xcode o con `xcrun simctl install`.
+2. Ejecutá el deeplink utilizando el esquema configurado (por defecto `intrale`):
+   ```bash
+   xcrun simctl openurl booted "<esquema_temporal>://test"
+   ```
+3. Confirmá que la aplicación se active y llegue a la escena inicial sin errores en la consola de Xcode.
+
+### Validación del host en `Info.plist`
+1. Localizá la ruta del bundle resultante (por ejemplo `app/build/ios/Debug-iphonesimulator/IntraleApp.app`).
+2. Ejecutá:
+   ```bash
+   plutil -extract CFBundleURLTypes xml1 <ruta_al_bundle>/Info.plist
+   plutil -extract NSUserActivityTypes xml1 <ruta_al_bundle>/Info.plist
+   ```
+3. Verificá que:
+   - `CFBundleURLSchemes` contenga el esquema usado en el paso anterior.
+   - `NSUserActivityTypes` liste `applinks:<host.dinamico>`, demostrando que el placeholder `$(DEEPLINK_HOST)` fue reemplazado.
+
+### Notas sobre Universal Links (`applinks`)
+
+- Para una validación punta a punta se necesita publicar el archivo `apple-app-site-association` con el host configurado. Si el dominio todavía no lo expone, limitate al smoke test con `CFBundleURLTypes` anterior.
+- Una vez disponible el dominio, podés disparar la prueba con:
+  ```bash
+  xcrun simctl openurl booted "https://<host.dinamico>/test"
+  ```
+  y revisar en la consola que la escena se active vía `NSUserActivity`.
+- Documentá el resultado (éxito o bloqueo por falta de dominio) en el ticket correspondiente.
+
+Con estas validaciones queda cubierto el smoke test requerido para QA/CI en ambas plataformas.


### PR DESCRIPTION
## Resumen
- Extendí la guía de smoke test para cubrir iOS y Android cuando se parametriza el host de deeplink.
- Documenté los comandos de verificación manual y la inspección de Info.plist para confirmar el reemplazo del placeholder.

## Pruebas
- No aplica, solo se actualizó documentación.

Closes #325

------
https://chatgpt.com/codex/tasks/task_e_68dd18967eb08325a2d4c9ab90f1a603