### PR TITLE
[auto] Corrección de parseo de PID en PrettyLogcat

### DIFF
--- a/app/PrettyLogcat.ps1
+++ b/app/PrettyLogcat.ps1
@@ -64,8 +64,8 @@ function Get-AppPids([string]$pkg) {
     foreach ($ln in ($lines -split "`n")) {
       if (-not $ln.Trim()) { continue }
       $parts = $ln -split '\s+'
-      $pid = $parts | Where-Object { $_ -match '^\d+$' } | Select-Object -First 1
-      if ($pid) { $pids += $pid }
+      $procId = $parts | Where-Object { $_ -match '^\d+$' } | Select-Object -First 1
+      if ($procId) { $pids += $procId }
     }
     if ($pids.Count -gt 0) { return $pids | Select-Object -Unique }
   }


### PR DESCRIPTION
## Resumen
- Evitar la colisión con la variable reservada PID al obtener procesos del paquete

## Pruebas
- No se ejecutaron pruebas (script de PowerShell)

Closes #369

------
https://chatgpt.com/codex/tasks/task_e_68dd2edae8f083258e6e60a5fff04e1d