### PR TITLE
Docs: snapshots de refinamiento H2.1

### DIFF
--- a/docs/refinements/issue-372-h21s0-adr-modelo-single-table-dynamodb.md
+++ b/docs/refinements/issue-372-h21s0-adr-modelo-single-table-dynamodb.md
@@ -1,0 +1,39 @@
+# Refinamiento – Issue #372
+
+_Repositorio: intrale/platform_
+
+## Objetivo
+Documentar una decisión arquitectónica (ADR) que formalice el modelo single-table de DynamoDB para el servicio de branding, detallando claves, tipos de ítems, patrones de acceso y consideraciones operativas.
+
+## Contexto
+- El frontend multiplataforma ya soporta recursos de branding dinámico (`buildSrc/ar/com/intrale/branding/**` y `app/composeApp/**`), pero falta una fuente de verdad consolidada que sirva temas publicados, borradores y assets.
+- Los issues H2.1.S1–H2.1.S6 dependen de una definición estable de la tabla para ejecutar runbooks, seeds y pruebas automatizadas.
+- Actualmente no existe un ADR que deje asentada la convención `BUS#<businessId>` / `THEME#<version>` ni las garantías de publicación única.
+
+## Cambios requeridos
+- Crear `docs/branding/adr-modelo-datos-dynamodb.md` (o actualizarlo si ya existe) siguiendo la estructura estándar de ADR (Estado, Fecha, Contexto, Decisión, Consecuencias, Notas operativas).
+- Incluir en la decisión:
+  - Nombre de la tabla (`branding`) y convención de prefijo para ambientes (`branding-dev`, `branding-stg`, `branding-prd`).
+  - Claves primarias `PK` (String) y `SK` (String) con `BUS#<businessId>` y `THEME#<versionPad>` / `PUBLISHED`.
+  - Tipos de ítem necesarios (`THEME`, `PUBLISHED_MARKER`, `ASSET`, `ASSET_LINK`, opcional `BUSINESS`).
+  - Atributos obligatorios (`status`, `version`, `metadata`, `assets`, `updatedAt`, `publishedAt`, `publishedBy`).
+- Documentar patrones de acceso prioritarios:
+  - Recuperar tema publicado (GetItem al marcador + GetItem de la versión).
+  - Listar borradores vía `Query` con `begins_with(SK, "THEME#")` + filtro `status = draft`.
+  - Obtener assets individuales por `ASSET#<assetId>`.
+- Describir las operaciones críticas de publicación/rollback usando `ConditionExpression` para asegurar unicidad del marcador.
+- Añadir ejemplos JSON de ítems reales (marker publicado, theme draft/published, asset) para guiar futuras seeds/tests.
+- Registrar consecuencias operativas (PITR, TTL opcional, costos on-demand) y riesgos (padding de versión, consistencia fuerte, necesidad de GSIs futuros).
+- Referenciar los issues dependientes (#373, #374, #375, #376, #377, #378) como consumidores del ADR.
+
+## Criterios de aceptación
+- [ ] El ADR está versionado en `docs/branding/adr-modelo-datos-dynamodb.md` con todos los apartados descritos.
+- [ ] Se documentan al menos tres patrones de acceso con ejemplos concretos.
+- [ ] Se incluyen fragmentos de `ConditionExpression` para publish/rollback que puedan reutilizarse en la implementación del repositorio.
+- [ ] Se listan consecuencias y riesgos que permitan trazar decisiones futuras (por ejemplo, cuándo crear un GSI).
+
+## Notas técnicas
+- Mantener el lenguaje en Español Latinoamericano y enlazar con documentación existente (`docs/branding-build-android.md`, `docs/branding-build-ios.md`) para mostrar impacto en clientes.
+- Utilizar tablas Markdown para resumir tipos de ítem y atributos.
+- Citar referencias de AWS DynamoDB (links oficiales) sólo si aportan contexto adicional y están disponibles públicamente.
+- Validar que el ADR siga el formato empleado en otros documentos (`docs/branding/manifest-placeholders.md` etc.) para consistencia editorial.

--- a/docs/refinements/issue-373-h21s1-runbook-crear-tabla-manual.md
+++ b/docs/refinements/issue-373-h21s1-runbook-crear-tabla-manual.md
@@ -1,0 +1,42 @@
+# Refinamiento – Issue #373
+
+_Repositorio: intrale/platform_
+
+## Objetivo
+Definir un runbook operativo para crear manualmente la tabla `branding` de DynamoDB en AWS Console, asegurando que cualquier operador pueda provisionarla de forma repetible en cada ambiente (dev/stg/prd).
+
+## Contexto
+- La tabla respaldará los endpoints de branding descritos en la iniciativa H2.x y debe existir antes de desplegar el backend.
+- El ADR de #372 establece la estructura single-table; este runbook traduce esa decisión en pasos accionables dentro de la consola.
+- Otros issues (ej. #376 seeds, #378 OpenAPI draft) dependen de que la tabla esté disponible con claves correctas y protecciones activadas.
+
+## Cambios requeridos
+- Crear `docs/runbooks/dynamodb-branding-manual.md` con las secciones:
+  1. **Prerequisitos**: cuenta AWS, permisos `dynamodb:*` sobre tabla, región objetivo (usar `us-east-1` como ejemplo y aclarar que puede variar por ambiente), y confirmar naming convention `branding-<env>`.
+  2. **Pasos en consola**:
+     - Navegar a DynamoDB → Create table.
+     - Completar nombre `branding-dev` (parametrizable) y claves: Partition key `PK` (String), Sort key `SK` (String).
+     - Seleccionar `On-demand` billing mode.
+     - Activar `Point-in-Time Recovery` y `Deletion protection`.
+     - Configurar `Encryption` con AWS owned CMK (default) y registrar cómo cambiarlo si compliance lo exige.
+     - (Opcional) Definir `TTL` en atributo `expiresAt` pero dejarlo deshabilitado hasta que #376 confirme uso.
+     - Agregar tags sugeridas (`service=branding`, `owner=platform`, `environment=<env>`).
+  3. **Verificación post-creación**:
+     - Revisar pestaña `Indexes` (debe mostrar sólo la clave primaria; GSI quedará documentado en #375 si se requiere).
+     - Ejecutar `Explore items` → `Create item` en modo JSON con plantilla base del marcador publicado para validar estructura.
+     - Registrar ARN de la tabla y compartirlo vía parámetro SSM (`/platform/branding/<env>/tableArn`).
+  4. **Checklist de salida** con capturas/opciones a validar (estado `Active`, PITR `Enabled`, protección `Enabled`).
+- Incluir notas para ambientes adicionales (staging, producción) y la convención de sufijos.
+- Añadir un apéndice con troubleshooting común (errores de permisos, regiones equivocadas, naming conflict) y enlaces a documentación oficial de AWS.
+
+## Criterios de aceptación
+- [ ] El runbook está publicado en `docs/runbooks/dynamodb-branding-manual.md` con pasos numerados y checklist final.
+- [ ] Describe explícitamente claves (`PK`, `SK`) y configuraciones obligatorias (On-demand, PITR, Deletion protection, tags).
+- [ ] Incluye sección de verificación post-creación con ejemplo JSON de marcador publicado y cómo confirmar estado `Active`.
+- [ ] Señala dependencias con otros issues (GSI opcional #375, seeds #376) para mantener trazabilidad.
+
+## Notas técnicas
+- Mantener el runbook orientado a operadores (tono imperativo, pasos claros, sin asumir acceso por CLI).
+- Usar tablas o bloques destacados para parámetros (`branding-dev`, `branding-stg`, `branding-prd`).
+- Evitar exponer ARN reales; utilizar placeholders `<account-id>` / `<env>`.
+- Agregar referencias a AWS docs (Create table, PITR) solo si ayudan al lector a profundizar.

--- a/docs/refinements/issue-374-h21s1b-doc-naming-iam-servicio.md
+++ b/docs/refinements/issue-374-h21s1b-doc-naming-iam-servicio.md
@@ -1,0 +1,42 @@
+# Refinamiento – Issue #374
+
+_Repositorio: intrale/platform_
+
+## Objetivo
+Documentar la convención de nombres de recursos y la política IAM mínima para el servicio de branding que operará sobre la tabla DynamoDB, asegurando coherencia entre ambientes y permisos restrictivos.
+
+## Contexto
+- La iniciativa H2.1 introduce infraestructura propia (tabla, seeds, pipelines) que requiere alineación con los módulos existentes (`backend`, `users`, scripts de despliegue).
+- Sin una guía formal, cada ambiente podría definir nombres o políticas distintas, generando fricción en CI/CD y riesgos de seguridad.
+- El backend actual usa Ktor y funciones serverless; es necesario precisar cómo mapeará variables (`BRANDING_TABLE_NAME`, `AWS_REGION`) y qué rol IAM consumirá la tabla.
+
+## Cambios requeridos
+- Crear `docs/branding/naming-iam.md` (nombre sugerido) con:
+  - **Mapa de nombres por ambiente**:
+    | Recurso | dev | stg | prd |
+    |---------|-----|-----|-----|
+    | Tabla DynamoDB | `branding-dev` | `branding-stg` | `branding-prd` |
+    | Alias de rol Lambda/API | `branding-service-dev` | `branding-service-stg` | `branding-service-prd` |
+    | Parámetro SSM (table name) | `/platform/branding/dev/tableName` | `/platform/branding/stg/tableName` | `/platform/branding/prd/tableName` |
+  - Convención para buckets/eventuales assets si se habilitan (placeholder documentado pero marcado como opcional).
+- Especificar la política IAM mínima en JSON, otorgando sólo acciones requeridas:
+  - `dynamodb:GetItem`, `dynamodb:Query`, `dynamodb:PutItem`, `dynamodb:UpdateItem`, `dynamodb:DeleteItem` (para drafts), `dynamodb:TransactWriteItems` (publish/rollback), `dynamodb:ConditionCheckItem` si se usa en transacciones.
+  - Restricción por `Resource` al ARN de la tabla correspondiente y, si aplica, a `index/*` cuando se cree el GSI opcional (#375).
+- Detallar cómo se inyectará el nombre de tabla en el backend:
+  - Variables de entorno consumidas por `backend` (por ejemplo `BRANDING_TABLE_NAME`, `AWS_REGION`).
+  - Integración con `init.sh`/`deploy-lambda` si se requiere exportar parámetros.
+- Documentar procedimiento para crear el rol (CloudFormation/Terraform manual o consola) y asociar la política, incluyendo tags (`service=branding`).
+- Añadir sección de auditoría/logging: registrar en CloudWatch los accesos y habilitar AWS CloudTrail data events si compliance lo exige.
+- Referenciar a #373 (creación de tabla) y #379 (integración de auth) para mantener coherencia.
+
+## Criterios de aceptación
+- [ ] Existe `docs/branding/naming-iam.md` con tabla de convenciones y rutas SSM/ARNs parametrizados.
+- [ ] La política IAM propuesta limita acciones y recursos al mínimo necesario e incluye notas sobre futuros índices.
+- [ ] Se documenta claramente cómo las funciones del backend leerán el nombre de la tabla (variables/env, configuración DI).
+- [ ] Se incluyen pasos de creación/asociación de roles y recomendaciones de auditoría.
+
+## Notas técnicas
+- Mantener snippets IAM en JSON validado por AWS Policy Simulator cuando se implemente.
+- Usar placeholders (`<account-id>`, `<env>`) en ARN para evitar exponer datos sensibles.
+- Alinear el documento con convenciones existentes en `docs/branding-build-android.md` (uso de `<brandId>` como variable) para coherencia editorial.
+- Considerar agregar sección FAQ (por ejemplo, cómo manejar cuentas sandbox o ambientes efímeros).

--- a/docs/refinements/issue-376-h21s5-seed-dev-manual-cli.md
+++ b/docs/refinements/issue-376-h21s5-seed-dev-manual-cli.md
@@ -1,0 +1,45 @@
+# Refinamiento – Issue #376
+
+_Repositorio: intrale/platform_
+
+## Objetivo
+Definir cómo poblar datos de desarrollo para la tabla `branding`, ofreciendo tanto un procedimiento manual en AWS Console como un script CLI reproducible que cargue temas de ejemplo.
+
+## Contexto
+- Tras crear la tabla (issue #373) los equipos necesitan datos de referencia para probar endpoints (`/branding/{businessId}/draft`, publish, etc.).
+- El ADR de #372 describe estructura y tipos de ítems; este refinamiento debe convertirlo en seeds tangibles.
+- Los módulos `buildSrc` y `app` ya consumen branding dinámico; contar con datos en dev acelera validaciones end-to-end y smoke tests.
+
+## Cambios requeridos
+- Documentar en `docs/runbooks/dynamodb-branding-seed.md` (nuevo) dos secciones principales:
+  1. **Carga manual (AWS Console)**
+     - Precondiciones: tabla `branding-dev` existente, usuario con permisos `PutItem`/`BatchWriteItem`.
+     - Pasos para insertar:
+       - Ítem marcador publicado (`PK = BUS#intrale`, `SK = PUBLISHED`, `type = PUBLISHED_MARKER`, `version = 1`, timestamps).
+       - Ítem `THEME` publicado `version=1` con `status = published`, `metadata.palette`, `assets` y `schemaVersion=1`.
+       - Ítem `THEME` draft `version=2` con cambios visibles (colores distintos) y `status = draft`.
+       - Asset de ejemplo (`PK = ASSET#logo-intrale`, `SK = META`, `assetType = logo`, `uri = s3://...` placeholder).
+     - Checklist para validar: `Query` por `PK = BUS#intrale` retorna 3 ítems, published marker apunta a versión 1.
+  2. **Script CLI**
+     - Crear script en `tools/branding_seed_dev.py` (o `.sh`) que use AWS CLI/SDK para ejecutar `batch-write-item` con los mismos ítems.
+     - Parámetros: `--table-name`, `--region`, `--profile` opcional, bandera `--reset` para borrar ítems previos (`delete-item` condicional).
+     - Incluir manejo de errores y mensajes claros (`print`/`logging`) en Español.
+     - Documentar dependencias (Python 3 + boto3 o AWS CLI v2) y ejemplos de ejecución:
+       ```bash
+       python tools/branding_seed_dev.py --table-name branding-dev --region us-east-1
+       ```
+- Indicar cómo extender seeds para nuevos negocios (`BUS#acme`) reutilizando la plantilla.
+- Añadir sección "Datos esperados" describiendo qué atributos debería leer el backend tras correr el seed (ej. `publishedAt`, `metadata.palette.primary`).
+- Referenciar a #377 para reutilizar el script contra DynamoDB Local (`--endpoint-url http://localhost:8000`).
+
+## Criterios de aceptación
+- [ ] Existe documentación en `docs/runbooks/dynamodb-branding-seed.md` cubriendo guía manual y script CLI.
+- [ ] El script propuesto acepta parámetros de tabla/región y puede apuntar a endpoints personalizados (local/remote).
+- [ ] Los ejemplos de datos incluyen al menos un tema publicado, un draft y un asset vinculado al negocio `intrale`.
+- [ ] Se describe cómo validar que el marcador publicado y los drafts se insertaron correctamente.
+
+## Notas técnicas
+- Recomendar uso de `Decimal` en boto3 para valores numéricos y asegurar padding de versiones (`THEME#00000001`).
+- Para la bandera `--reset`, sugerir uso de `TransactWriteItems` o, en su defecto, borrar ítems individuales con `ConditionExpression` para evitar race conditions.
+- Considerar compatibilidad con AWS CLI (`aws dynamodb batch-write-item --request-items file://...`) como alternativa si no se usa Python.
+- Mantener ejemplos libres de credenciales; recordar exportar `AWS_PROFILE`/`AWS_ACCESS_KEY_ID` cuando aplique.

--- a/docs/refinements/issue-377-h21s6-dynamodb-local-tests.md
+++ b/docs/refinements/issue-377-h21s6-dynamodb-local-tests.md
@@ -1,0 +1,41 @@
+# Refinamiento – Issue #377
+
+_Repositorio: intrale/platform_
+
+## Objetivo
+Establecer la estrategia para correr DynamoDB Local en desarrollo/CI y cubrir el repositorio de branding con pruebas automatizadas que verifiquen operaciones de lectura/escritura.
+
+## Contexto
+- Los módulos existentes (`backend`, `users`) aún no contemplan una tabla de branding; se necesita infraestructura local para iterar sin impactar AWS real.
+- El script de seeds (#376) debe reutilizarse contra un endpoint local para smoke tests y pipelines.
+- El backend se ejecuta con Gradle/Ktor y los tests actuales viven en `backend/src/test/kotlin`; hay que definir dónde agregar las pruebas del repositorio de branding.
+
+## Cambios requeridos
+- Añadir infraestructura local:
+  - Crear `tools/docker/dynamodb-local.yml` (o ampliar un compose existente) con servicio `dynamodb` usando imagen `amazon/dynamodb-local`, puerto `8000`, volumen temporal y variables (`-jar DynamoDBLocal.jar -inMemory -sharedDb`).
+  - Documentar comando de arranque: `docker compose -f tools/docker/dynamodb-local.yml up -d`.
+- Ajustes en build/test:
+  - Incorporar un task Gradle (`backend:dynamodbLocalStart` / `Stop`) o hooks en tests para levantar el contenedor (usando Testcontainers o `Exec` + `ProcessBuilder`).
+  - Configurar tests para apuntar a `http://localhost:8000` mediante variable `DYNAMODB_ENDPOINT_OVERRIDE` o similar.
+  - Asegurar que `./gradlew backend:test` arranque y detenga Dynamo local automáticamente en CI.
+- Implementar pruebas del repositorio:
+  - Crear paquete `backend/src/main/kotlin/ar/com/intrale/branding/` con interfaces `BrandingRepository` (planificado en otros issues) y `DynamoBrandingRepository` (implementación). Este issue debe definir qué escenarios cubrirán las pruebas aunque la implementación llegue luego.
+  - Escribir tests en `backend/src/test/kotlin/ar/com/intrale/branding/DynamoBrandingRepositoryTest.kt` que validen:
+    - Inserción/actualización de drafts (`putDraft`), incluyendo `ConditionExpression` para evitar sobrescrituras.
+    - Publicación (actualiza marcador y theme en transacción) y rollback.
+    - Lectura de tema publicado y listado de drafts.
+    - Manejo de errores (conflictos de versión, item inexistente).
+  - Reutilizar seeds definidos en #376 para poblar datos iniciales durante `@BeforeEach`.
+- Actualizar documentación de desarrolladores (`docs/runbooks/dynamodb-branding-seed.md` o nuevo `docs/engineering/dynamodb-local.md`) con instrucciones para correr la pila local y ejecutar tests.
+
+## Criterios de aceptación
+- [ ] Existe definición de docker-compose (o Testcontainers equivalente) para DynamoDB Local versionada en `tools/docker/dynamodb-local.yml`.
+- [ ] Los tests del backend pueden ejecutarse contra Dynamo local sin requerir AWS (comando documentado y automatizado en Gradle/CI).
+- [ ] Se describen claramente los casos de prueba obligatorios para el repositorio de branding (draft, publish, rollback, lecturas).
+- [ ] La documentación explica cómo iniciar/parar Dynamo local y cómo reutilizar seeds/fixtures.
+
+## Notas técnicas
+- Evaluar usar Testcontainers (JVM) para evitar dependencias externas en CI; en caso de usar docker-compose, asegurar limpieza (`docker compose down -v`).
+- Configurar tabla local via `CreateTable` al inicio de las pruebas (mismo esquema que runbook #373) usando SDK o AWS CLI.
+- Evitar puertos hardcodeados en tests; permitir override por variable (`DYNAMODB_LOCAL_PORT`).
+- Incluir recomendaciones para tiempos de espera y retries en pruebas (Dynamo local puede tardar unos segundos en estar listo).


### PR DESCRIPTION
## Resumen
- Agrega snapshot de refinamiento para el ADR single-table de branding (issue #372).
- Documenta el runbook manual de creación de tabla y la guía de naming/IAM para branding (issues #373 y #374).
- Define seeds de desarrollo y lineamientos de DynamoDB Local + pruebas para branding (issues #376 y #377).

## Pruebas
- No se ejecutaron pruebas; cambios de documentación.


------
https://chatgpt.com/codex/tasks/task_e_68def806bd7083259b5b5391836e94ec