### PR TITLE
feat: habilitar DynamoDB local para repositorio de branding

### DIFF
--- a/backend/src/main/kotlin/ar/com/intrale/branding/BrandingAsset.kt
+++ b/backend/src/main/kotlin/ar/com/intrale/branding/BrandingAsset.kt
@@ -1,0 +1,8 @@
+package ar.com.intrale.branding
+
+data class BrandingAsset(
+    val assetId: String,
+    val assetType: String,
+    val uri: String,
+    val metadata: Map<String, String> = emptyMap()
+)

--- a/backend/src/main/kotlin/ar/com/intrale/branding/BrandingRepository.kt
+++ b/backend/src/main/kotlin/ar/com/intrale/branding/BrandingRepository.kt
@@ -1,0 +1,17 @@
+package ar.com.intrale.branding
+
+import java.time.Instant
+
+interface BrandingRepository {
+    fun putDraft(theme: BrandingTheme, allowOverwrite: Boolean = false)
+
+    fun getPublishedTheme(businessId: String): BrandingTheme?
+
+    fun getTheme(businessId: String, version: Int): BrandingTheme?
+
+    fun listDrafts(businessId: String): List<BrandingTheme>
+
+    fun publishTheme(businessId: String, version: Int, userId: String, timestamp: Instant)
+
+    fun rollbackToVersion(businessId: String, targetVersion: Int, userId: String, timestamp: Instant)
+}

--- a/backend/src/main/kotlin/ar/com/intrale/branding/BrandingTheme.kt
+++ b/backend/src/main/kotlin/ar/com/intrale/branding/BrandingTheme.kt
@@ -1,0 +1,35 @@
+package ar.com.intrale.branding
+
+import java.time.Instant
+
+data class BrandingTheme(
+    val businessId: String,
+    val version: Int,
+    val status: ThemeStatus,
+    val metadata: Map<String, String>,
+    val assets: List<BrandingAsset>,
+    val updatedAt: Instant,
+    val publishedAt: Instant? = null,
+    val publishedBy: String? = null
+) {
+    init {
+        require(businessId.isNotBlank()) { "El businessId no puede ser vacío" }
+        require(version > 0) { "La versión debe ser positiva" }
+    }
+
+    fun isDraft(): Boolean = status == ThemeStatus.DRAFT
+
+    fun asPublished(timestamp: Instant, userId: String): BrandingTheme = copy(
+        status = ThemeStatus.PUBLISHED,
+        publishedAt = timestamp,
+        publishedBy = userId,
+        updatedAt = timestamp
+    )
+
+    fun asDraft(timestamp: Instant): BrandingTheme = copy(
+        status = ThemeStatus.DRAFT,
+        updatedAt = timestamp,
+        publishedAt = null,
+        publishedBy = null
+    )
+}

--- a/backend/src/main/kotlin/ar/com/intrale/branding/DynamoBrandingRepository.kt
+++ b/backend/src/main/kotlin/ar/com/intrale/branding/DynamoBrandingRepository.kt
@@ -1,0 +1,347 @@
+package ar.com.intrale.branding
+
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue
+import software.amazon.awssdk.services.dynamodb.model.GetItemRequest
+import software.amazon.awssdk.services.dynamodb.model.PutItemRequest
+import software.amazon.awssdk.services.dynamodb.model.QueryRequest
+import software.amazon.awssdk.services.dynamodb.model.TransactWriteItem
+import software.amazon.awssdk.services.dynamodb.model.TransactWriteItemsRequest
+import software.amazon.awssdk.services.dynamodb.model.Update
+import java.time.Instant
+
+class DynamoBrandingRepository(
+    private val dynamoDbClient: DynamoDbClient,
+    private val tableName: String
+) : BrandingRepository {
+
+    override fun putDraft(theme: BrandingTheme, allowOverwrite: Boolean) {
+        require(theme.isDraft()) { "Solo se pueden persistir borradores mediante putDraft" }
+        val item = theme.toItem()
+        val requestBuilder = PutItemRequest.builder()
+            .tableName(tableName)
+            .item(item)
+        if (!allowOverwrite) {
+            requestBuilder.conditionExpression("attribute_not_exists(#pk)")
+            requestBuilder.expressionAttributeNames(mapOf("#pk" to PK))
+        }
+        dynamoDbClient.putItem(requestBuilder.build())
+    }
+
+    override fun getPublishedTheme(businessId: String): BrandingTheme? {
+        val marker = fetchMarker(businessId) ?: return null
+        val versionAttr = marker[VERSION] ?: return null
+        val version = versionAttr.n()?.toInt() ?: return null
+        return getTheme(businessId, version)
+    }
+
+    override fun getTheme(businessId: String, version: Int): BrandingTheme? {
+        val response = dynamoDbClient.getItem(
+            GetItemRequest.builder()
+                .tableName(tableName)
+                .key(themeKey(businessId, version))
+                .build()
+        )
+        if (!response.hasItem()) {
+            return null
+        }
+        return response.item().toTheme()
+    }
+
+    override fun listDrafts(businessId: String): List<BrandingTheme> {
+        val request = QueryRequest.builder()
+            .tableName(tableName)
+            .keyConditionExpression("#pk = :pk and begins_with(#sk, :prefix)")
+            .filterExpression("#status = :draft")
+            .expressionAttributeNames(
+                mapOf(
+                    "#pk" to PK,
+                    "#sk" to SK,
+                    "#status" to STATUS
+                )
+            )
+            .expressionAttributeValues(
+                mapOf(
+                    ":pk" to s(businessKey(businessId)),
+                    ":prefix" to s(THEME_PREFIX),
+                    ":draft" to s(ThemeStatus.DRAFT.name)
+                )
+            )
+            .build()
+        val response = dynamoDbClient.query(request)
+        if (!response.hasItems()) {
+            return emptyList()
+        }
+        return response.items().mapNotNull { it.toTheme() }
+            .sortedBy { it.version }
+    }
+
+    override fun publishTheme(businessId: String, version: Int, userId: String, timestamp: Instant) {
+        val theme = getTheme(businessId, version)
+            ?: throw IllegalArgumentException("No existe la versión $version para $businessId")
+        val currentMarker = fetchMarker(businessId)
+        val currentVersion = currentMarker?.get(VERSION)?.n()?.toInt()
+
+        val operations = mutableListOf<TransactWriteItem>()
+        operations += updateThemeToPublished(businessId, version, userId, timestamp)
+        operations += upsertMarker(businessId, version, userId, timestamp, allowDowngrade = false)
+        if (currentVersion != null && currentVersion != version) {
+            operations += revertThemeToDraft(businessId, currentVersion, timestamp)
+        }
+        dynamoDbClient.transactWriteItems(
+            TransactWriteItemsRequest.builder()
+                .transactItems(operations)
+                .build()
+        )
+    }
+
+    override fun rollbackToVersion(businessId: String, targetVersion: Int, userId: String, timestamp: Instant) {
+        val targetTheme = getTheme(businessId, targetVersion)
+            ?: throw IllegalArgumentException("No existe la versión $targetVersion para $businessId")
+        val currentMarker = fetchMarker(businessId)
+        val currentVersion = currentMarker?.get(VERSION)?.n()?.toInt()
+
+        val operations = mutableListOf<TransactWriteItem>()
+        operations += updateThemeToPublished(businessId, targetVersion, userId, timestamp)
+        operations += upsertMarker(businessId, targetVersion, userId, timestamp, allowDowngrade = true)
+        if (currentVersion != null && currentVersion != targetVersion) {
+            operations += revertThemeToDraft(businessId, currentVersion, timestamp)
+        }
+        dynamoDbClient.transactWriteItems(
+            TransactWriteItemsRequest.builder()
+                .transactItems(operations)
+                .build()
+        )
+    }
+
+    private fun fetchMarker(businessId: String): Map<String, AttributeValue>? {
+        val response = dynamoDbClient.getItem(
+            GetItemRequest.builder()
+                .tableName(tableName)
+                .key(markerKey(businessId))
+                .build()
+        )
+        if (!response.hasItem()) {
+            return null
+        }
+        return response.item()
+    }
+
+    private fun updateThemeToPublished(
+        businessId: String,
+        version: Int,
+        userId: String,
+        timestamp: Instant
+    ): TransactWriteItem {
+        val key = themeKey(businessId, version)
+        val expressionAttributeNames = mapOf("#status" to STATUS)
+        val expressionAttributeValues = mapOf(
+            ":published" to s(ThemeStatus.PUBLISHED.name),
+            ":draft" to s(ThemeStatus.DRAFT.name),
+            ":updatedAt" to s(timestamp.toString()),
+            ":publishedAt" to s(timestamp.toString()),
+            ":publishedBy" to s(userId)
+        )
+        val updateExpression = "SET #status = :published, updatedAt = :updatedAt, publishedAt = :publishedAt, publishedBy = :publishedBy"
+        val conditionExpression = "attribute_exists($PK) AND (#status = :draft OR #status = :published)"
+        return TransactWriteItem.builder()
+            .update(
+                Update.builder()
+                    .tableName(tableName)
+                    .key(key)
+                    .updateExpression(updateExpression)
+                    .conditionExpression(conditionExpression)
+                    .expressionAttributeNames(expressionAttributeNames)
+                    .expressionAttributeValues(expressionAttributeValues)
+                    .build()
+            )
+            .build()
+    }
+
+    private fun upsertMarker(
+        businessId: String,
+        version: Int,
+        userId: String,
+        timestamp: Instant,
+        allowDowngrade: Boolean
+    ): TransactWriteItem {
+        val key = markerKey(businessId)
+        val expressionAttributeNames = mapOf(
+            "#type" to TYPE,
+            "#version" to VERSION
+        )
+        val expressionAttributeValues = mapOf(
+            ":type" to s(PUBLISHED_MARKER),
+            ":version" to n(version),
+            ":updatedAt" to s(timestamp.toString()),
+            ":publishedAt" to s(timestamp.toString()),
+            ":publishedBy" to s(userId)
+        )
+        val updateExpression = "SET #type = :type, #version = :version, updatedAt = :updatedAt, publishedAt = :publishedAt, publishedBy = :publishedBy"
+        val conditionExpression = if (allowDowngrade) {
+            "attribute_not_exists(#version) OR #version >= :version"
+        } else {
+            "attribute_not_exists(#version) OR #version <= :version"
+        }
+        return TransactWriteItem.builder()
+            .update(
+                Update.builder()
+                    .tableName(tableName)
+                    .key(key)
+                    .updateExpression(updateExpression)
+                    .conditionExpression(conditionExpression)
+                    .expressionAttributeNames(expressionAttributeNames)
+                    .expressionAttributeValues(expressionAttributeValues)
+                    .build()
+            )
+            .build()
+    }
+
+    private fun revertThemeToDraft(
+        businessId: String,
+        version: Int,
+        timestamp: Instant
+    ): TransactWriteItem {
+        val key = themeKey(businessId, version)
+        val expressionAttributeNames = mapOf("#status" to STATUS)
+        val expressionAttributeValues = mapOf(
+            ":draft" to s(ThemeStatus.DRAFT.name),
+            ":updatedAt" to s(timestamp.toString())
+        )
+        val updateExpression = "SET #status = :draft, updatedAt = :updatedAt REMOVE publishedAt, publishedBy"
+        val conditionExpression = "attribute_exists($PK) AND #status = :published"
+        val extendedValues = expressionAttributeValues + mapOf(":published" to s(ThemeStatus.PUBLISHED.name))
+        return TransactWriteItem.builder()
+            .update(
+                Update.builder()
+                    .tableName(tableName)
+                    .key(key)
+                    .updateExpression(updateExpression)
+                    .conditionExpression(conditionExpression)
+                    .expressionAttributeNames(expressionAttributeNames)
+                    .expressionAttributeValues(extendedValues)
+                    .build()
+            )
+            .build()
+    }
+
+    private fun BrandingTheme.toItem(): Map<String, AttributeValue> {
+        val item = mutableMapOf<String, AttributeValue>()
+        item[PK] = s(businessKey(businessId))
+        item[SK] = s(themeSortKey(version))
+        item[TYPE] = s(THEME_TYPE)
+        item[STATUS] = s(status.name)
+        item[VERSION] = n(version)
+        item[UPDATED_AT] = s(updatedAt.toString())
+        if (publishedAt != null) {
+            item[PUBLISHED_AT] = s(publishedAt.toString())
+        }
+        if (publishedBy != null) {
+            item[PUBLISHED_BY] = s(publishedBy)
+        }
+        if (metadata.isNotEmpty()) {
+            item[METADATA] = AttributeValue.builder().m(
+                metadata.mapValues { s(it.value) }
+            ).build()
+        }
+        if (assets.isNotEmpty()) {
+            item[ASSETS] = AttributeValue.builder().l(
+                assets.map { asset ->
+                    AttributeValue.builder().m(
+                        buildMap {
+                            put(ASSET_ID, s(asset.assetId))
+                            put(ASSET_TYPE, s(asset.assetType))
+                            put(ASSET_URI, s(asset.uri))
+                            if (asset.metadata.isNotEmpty()) {
+                                put(
+                                    ASSET_METADATA,
+                                    AttributeValue.builder().m(asset.metadata.mapValues { s(it.value) }).build()
+                                )
+                            }
+                        }
+                    ).build()
+                }
+            ).build()
+        }
+        return item
+    }
+
+    private fun Map<String, AttributeValue>.toTheme(): BrandingTheme? {
+        val pkValue = this[PK]?.s() ?: return null
+        val businessId = pkValue.removePrefix("$BUS_PREFIX")
+        val skValue = this[SK]?.s() ?: return null
+        if (!skValue.startsWith(THEME_PREFIX)) {
+            return null
+        }
+        val version = skValue.removePrefix(THEME_PREFIX).toInt()
+        val status = ThemeStatus.from(this[STATUS]?.s() ?: return null)
+        val metadataMap = this[METADATA]?.m()?.mapValues { it.value.s() } ?: emptyMap()
+        val assetsList = if (this.containsKey(ASSETS)) {
+            this[ASSETS]?.l()?.map { value ->
+                val assetMap = value.m()
+                BrandingAsset(
+                    assetId = assetMap[ASSET_ID]?.s() ?: "",
+                    assetType = assetMap[ASSET_TYPE]?.s() ?: "",
+                    uri = assetMap[ASSET_URI]?.s() ?: "",
+                    metadata = assetMap[ASSET_METADATA]?.m()?.mapValues { it.value.s() } ?: emptyMap()
+                )
+            } ?: emptyList()
+        } else {
+            emptyList()
+        }
+        val updatedAt = this[UPDATED_AT]?.s()?.let(Instant::parse) ?: Instant.EPOCH
+        val publishedAt = this[PUBLISHED_AT]?.s()?.let(Instant::parse)
+        val publishedBy = this[PUBLISHED_BY]?.s()
+        return BrandingTheme(
+            businessId = businessId,
+            version = version,
+            status = status,
+            metadata = metadataMap,
+            assets = assetsList,
+            updatedAt = updatedAt,
+            publishedAt = publishedAt,
+            publishedBy = publishedBy
+        )
+    }
+
+    companion object {
+        private const val PK = "PK"
+        private const val SK = "SK"
+        private const val TYPE = "type"
+        private const val STATUS = "status"
+        private const val VERSION = "version"
+        private const val UPDATED_AT = "updatedAt"
+        private const val PUBLISHED_AT = "publishedAt"
+        private const val PUBLISHED_BY = "publishedBy"
+        private const val METADATA = "metadata"
+        private const val ASSETS = "assets"
+        private const val ASSET_ID = "assetId"
+        private const val ASSET_TYPE = "assetType"
+        private const val ASSET_URI = "uri"
+        private const val ASSET_METADATA = "metadata"
+        private const val BUS_PREFIX = "BUS#"
+        private const val THEME_PREFIX = "THEME#"
+        private const val PUBLISHED_MARKER = "PUBLISHED_MARKER"
+        private const val THEME_TYPE = "THEME"
+
+        fun businessKey(businessId: String): String = "$BUS_PREFIX$businessId"
+
+        private fun themeSortKey(version: Int): String = "${THEME_PREFIX}${version.toString().padStart(8, '0')}"
+
+        private fun markerKey(businessId: String): Map<String, AttributeValue> = mapOf(
+            PK to s(businessKey(businessId)),
+            SK to s(PUBLISHED)
+        )
+
+        private fun themeKey(businessId: String, version: Int): Map<String, AttributeValue> = mapOf(
+            PK to s(businessKey(businessId)),
+            SK to s(themeSortKey(version))
+        )
+
+        private fun s(value: String): AttributeValue = AttributeValue.builder().s(value).build()
+
+        private fun n(value: Int): AttributeValue = AttributeValue.builder().n(value.toString()).build()
+
+        private const val PUBLISHED = "PUBLISHED"
+    }
+}

--- a/backend/src/main/kotlin/ar/com/intrale/branding/ThemeStatus.kt
+++ b/backend/src/main/kotlin/ar/com/intrale/branding/ThemeStatus.kt
@@ -1,0 +1,11 @@
+package ar.com.intrale.branding
+
+enum class ThemeStatus {
+    DRAFT,
+    PUBLISHED;
+
+    companion object {
+        fun from(value: String): ThemeStatus = entries.firstOrNull { it.name.equals(value, ignoreCase = true) }
+            ?: throw IllegalArgumentException("Estado de tema desconocido: $value")
+    }
+}

--- a/backend/src/test/kotlin/ar/com/intrale/branding/DynamoBrandingRepositoryTest.kt
+++ b/backend/src/test/kotlin/ar/com/intrale/branding/DynamoBrandingRepositoryTest.kt
@@ -1,0 +1,298 @@
+package ar.com.intrale.branding
+
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition
+import software.amazon.awssdk.services.dynamodb.model.BillingMode
+import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException
+import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement
+import software.amazon.awssdk.services.dynamodb.model.KeyType
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType
+import software.amazon.awssdk.services.dynamodb.waiters.DynamoDbWaiter
+import java.io.File
+import java.io.IOException
+import java.net.ServerSocket
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.time.Instant
+import java.time.Duration
+
+class DynamoBrandingRepositoryTest {
+
+    private var dynamoProcess: Process? = null
+    private lateinit var client: DynamoDbClient
+    private lateinit var repository: BrandingRepository
+
+    @BeforeTest
+    fun setUp() {
+        val port = randomPort()
+        startLocalDynamoDb(port)
+
+        client = DynamoDbClient.builder()
+            .endpointOverride(URI.create("http://localhost:$port"))
+            .region(Region.US_EAST_1)
+            .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("dummy", "dummy")))
+            .build()
+
+        ensureTable()
+        repository = DynamoBrandingRepository(client, TABLE_NAME)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        if (this::client.isInitialized) {
+            client.close()
+        }
+        dynamoProcess?.let { process ->
+            process.destroy()
+            try {
+                if (!process.waitFor(Duration.ofSeconds(5).toMillis(), java.util.concurrent.TimeUnit.MILLISECONDS)) {
+                    process.destroyForcibly()
+                }
+            } catch (_: InterruptedException) {
+                process.destroyForcibly()
+                Thread.currentThread().interrupt()
+            }
+        }
+        dynamoProcess = null
+    }
+
+    @Test
+    fun putDraftPersistsTheme() {
+        val draft = sampleDraft(version = 1)
+
+        repository.putDraft(draft)
+
+        val stored = repository.getTheme(BUSINESS_ID, 1)
+        assertNotNull(stored)
+        assertEquals(ThemeStatus.DRAFT, stored.status)
+        assertEquals(draft.metadata, stored.metadata)
+        assertEquals(draft.assets.first().uri, stored.assets.first().uri)
+    }
+
+    @Test
+    fun putDraftPreventsOverwriteWhenFlagIsFalse() {
+        val draft = sampleDraft(version = 1)
+        repository.putDraft(draft)
+
+        assertFailsWith<ConditionalCheckFailedException> {
+            repository.putDraft(draft.copy(metadata = mapOf("palette.primary" to "#FFFFFF")))
+        }
+    }
+
+    @Test
+    fun putDraftAllowsOverwriteWhenFlagIsTrue() {
+        val draft = sampleDraft(version = 1)
+        repository.putDraft(draft)
+
+        val updated = draft.copy(metadata = draft.metadata + ("palette.primary" to "#111111"))
+        repository.putDraft(updated, allowOverwrite = true)
+
+        val stored = repository.getTheme(BUSINESS_ID, 1)
+        assertNotNull(stored)
+        assertEquals("#111111", stored.metadata["palette.primary"])
+    }
+
+    @Test
+    fun publishThemePromotesDraftAndCreatesMarker() {
+        val draftV1 = sampleDraft(version = 1)
+        val draftV2 = sampleDraft(version = 2)
+        val publishTime = Instant.parse("2024-05-01T10:15:30Z")
+
+        repository.putDraft(draftV1)
+        repository.putDraft(draftV2)
+
+        repository.publishTheme(BUSINESS_ID, 1, USER_ID, publishTime)
+
+        val published = repository.getPublishedTheme(BUSINESS_ID)
+        assertNotNull(published)
+        assertEquals(1, published.version)
+        assertEquals(ThemeStatus.PUBLISHED, published.status)
+        assertEquals(publishTime, published.publishedAt)
+        assertEquals(USER_ID, published.publishedBy)
+
+        val drafts = repository.listDrafts(BUSINESS_ID)
+        assertEquals(listOf(2), drafts.map { it.version })
+    }
+
+    @Test
+    fun publishThemeReplacesPreviousPublishedVersion() {
+        val publishTime1 = Instant.parse("2024-05-01T10:15:30Z")
+        val publishTime2 = Instant.parse("2024-05-02T08:00:00Z")
+        repository.putDraft(sampleDraft(version = 1))
+        repository.publishTheme(BUSINESS_ID, 1, USER_ID, publishTime1)
+        repository.putDraft(sampleDraft(version = 2))
+
+        repository.publishTheme(BUSINESS_ID, 2, USER_ID, publishTime2)
+
+        val published = repository.getPublishedTheme(BUSINESS_ID)
+        assertNotNull(published)
+        assertEquals(2, published.version)
+        assertEquals(publishTime2, published.publishedAt)
+
+        val previous = repository.getTheme(BUSINESS_ID, 1)
+        assertNotNull(previous)
+        assertEquals(ThemeStatus.DRAFT, previous.status)
+        assertNull(previous.publishedAt)
+        assertNull(previous.publishedBy)
+    }
+
+    @Test
+    fun rollbackToVersionRestoresOlderTheme() {
+        val publishTime1 = Instant.parse("2024-05-01T10:15:30Z")
+        val publishTime2 = Instant.parse("2024-05-02T08:00:00Z")
+        val rollbackTime = Instant.parse("2024-05-03T09:30:00Z")
+
+        repository.putDraft(sampleDraft(version = 1))
+        repository.publishTheme(BUSINESS_ID, 1, USER_ID, publishTime1)
+        repository.putDraft(sampleDraft(version = 2))
+        repository.publishTheme(BUSINESS_ID, 2, USER_ID, publishTime2)
+
+        repository.rollbackToVersion(BUSINESS_ID, 1, USER_ID, rollbackTime)
+
+        val published = repository.getPublishedTheme(BUSINESS_ID)
+        assertNotNull(published)
+        assertEquals(1, published.version)
+        assertEquals(rollbackTime, published.publishedAt)
+        assertEquals(USER_ID, published.publishedBy)
+
+        val draft = repository.getTheme(BUSINESS_ID, 2)
+        assertNotNull(draft)
+        assertEquals(ThemeStatus.DRAFT, draft.status)
+        assertNull(draft.publishedAt)
+    }
+
+    @Test
+    fun listDraftsReturnsSortedVersions() {
+        repository.putDraft(sampleDraft(version = 3))
+        repository.putDraft(sampleDraft(version = 1))
+        repository.putDraft(sampleDraft(version = 2))
+
+        val drafts = repository.listDrafts(BUSINESS_ID)
+        assertEquals(listOf(1, 2, 3), drafts.map { it.version })
+        assertTrue(drafts.all { it.status == ThemeStatus.DRAFT })
+    }
+
+    private fun ensureTable() {
+        val tables = client.listTables()
+        if (tables.tableNames().contains(TABLE_NAME)) {
+            return
+        }
+        val request = CreateTableRequest.builder()
+            .tableName(TABLE_NAME)
+            .attributeDefinitions(
+                AttributeDefinition.builder().attributeName("PK").attributeType(ScalarAttributeType.S).build(),
+                AttributeDefinition.builder().attributeName("SK").attributeType(ScalarAttributeType.S).build()
+            )
+            .keySchema(
+                KeySchemaElement.builder().attributeName("PK").keyType(KeyType.HASH).build(),
+                KeySchemaElement.builder().attributeName("SK").keyType(KeyType.RANGE).build()
+            )
+            .billingMode(BillingMode.PAY_PER_REQUEST)
+            .build()
+        client.createTable(request)
+        val waiter: DynamoDbWaiter = client.waiter()
+        waiter.waitUntilTableExists { it.tableName(TABLE_NAME) }
+    }
+
+    private fun sampleDraft(version: Int): BrandingTheme = BrandingTheme(
+        businessId = BUSINESS_ID,
+        version = version,
+        status = ThemeStatus.DRAFT,
+        metadata = mapOf(
+            "palette.primary" to "#3366FF",
+            "palette.secondary" to "#00CC99",
+            "metadata.version" to version.toString()
+        ),
+        assets = listOf(
+            BrandingAsset(
+                assetId = "logo-intrale",
+                assetType = "logo",
+                uri = "s3://branding-dev/logo-intrale.png"
+            )
+        ),
+        updatedAt = Instant.parse("2024-04-30T00:00:00Z")
+    )
+
+    private fun randomPort(): Int = ServerSocket(0).use { it.localPort }
+
+    private fun startLocalDynamoDb(port: Int) {
+        val dynamoDirPath = System.getProperty("dynamodbLocalDir")
+            ?: error("dynamodbLocalDir system property was not set. Did you run prepareDynamoDbLocal?")
+        val dynamoDir = File(dynamoDirPath)
+        val dynamoJar = dynamoDir.resolve("DynamoDBLocal.jar")
+        val dynamoLibDir = dynamoDir.resolve("DynamoDBLocal_lib")
+        require(dynamoJar.exists()) {
+            "No se encontró DynamoDBLocal.jar en ${dynamoJar.absolutePath}"
+        }
+        require(dynamoLibDir.exists()) {
+            "No se encontró el directorio DynamoDBLocal_lib en ${dynamoLibDir.absolutePath}"
+        }
+
+        val javaBinary = File(System.getProperty("java.home"), "bin/java")
+        val classpath = listOf(
+            dynamoJar.absolutePath,
+            dynamoLibDir.resolve("*").absolutePath
+        ).joinToString(File.pathSeparator)
+        val command = listOf(
+            javaBinary.absolutePath,
+            "-Djava.library.path=${dynamoLibDir.absolutePath}",
+            "-cp",
+            classpath,
+            "com.amazonaws.services.dynamodbv2.local.main.ServerRunner",
+            "-inMemory",
+            "-port",
+            port.toString()
+        )
+
+        dynamoProcess = ProcessBuilder(command)
+            .inheritIO()
+            .start()
+
+        waitForServer(port)
+    }
+
+    private fun waitForServer(port: Int, timeout: Duration = Duration.ofSeconds(10)) {
+        val deadline = System.nanoTime() + timeout.toNanos()
+        val client = HttpClient.newHttpClient()
+        val request = HttpRequest.newBuilder()
+            .uri(URI.create("http://localhost:$port/shell"))
+            .timeout(Duration.ofSeconds(1))
+            .build()
+
+        while (System.nanoTime() < deadline) {
+            try {
+                val response = client.send(request, HttpResponse.BodyHandlers.discarding())
+                if (response.statusCode() in 200..499) {
+                    return
+                }
+            } catch (_: IOException) {
+                // Esperar y reintentar
+            } catch (_: InterruptedException) {
+                Thread.currentThread().interrupt()
+                throw IllegalStateException("Interrupted while waiting for DynamoDB Local")
+            }
+            Thread.sleep(200)
+        }
+        throw IllegalStateException("DynamoDB Local no inició en el tiempo esperado")
+    }
+
+    companion object {
+        private const val TABLE_NAME = "branding-test"
+        private const val BUSINESS_ID = "intrale"
+        private const val USER_ID = "user-123"
+    }
+}


### PR DESCRIPTION
## Resumen
- agrega modelos y un `DynamoBrandingRepository` que opera sobre la tabla single-table de branding
- configura Gradle para descargar y preparar DynamoDB Local en los tests del backend
- incorpora pruebas de integración que validan publicación, rollback y listados de temas

## Pruebas
- `./gradlew backend:test`


------
https://chatgpt.com/codex/tasks/task_e_68df0894cfdc8325b3d4ec2c501ba148