### PR TITLE
feat: habilitar acceso al panel de personalización para admins

### DIFF
--- a/app/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/app/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -35,6 +35,17 @@
     <string name="semi_circular_menu_close">Cerrar men\u00fa de acciones</string>
     <string name="semi_circular_menu_long_press_hint">Desliz\u00e1 a la derecha para volver \u00b7 hacia abajo para abrir</string>
     <string name="dashboard_menu_hint">Despleg\u00e1 el men\u00fa para acceder a las acciones principales.</string>
+    <string name="personalization_panel">Personalizaci\u00f3n</string>
+    <string name="personalization_title">Panel de personalizaci\u00f3n</string>
+    <string name="personalization_description">Configura la apariencia de tu negocio.</string>
+    <string name="personalization_business_context">Negocio actual</string>
+    <string name="personalization_section_colors">Colores</string>
+    <string name="personalization_section_typography">Tipograf\u00edas</string>
+    <string name="personalization_section_images">Im\u00e1genes</string>
+    <string name="personalization_section_app_icon">\u00cdcono de App</string>
+    <string name="personalization_section_preview">Previsualizaci\u00f3n</string>
+    <string name="personalization_section_pending">Disponible pr\u00f3ximamente</string>
+    <string name="personalization_access_denied">No ten\u00e9s permisos para acceder a esta secci\u00f3n.</string>
 
     <string name="signup">Registrarme</string>
     <string name="signup_platform_admin">Registro Platform Admin</string>

--- a/app/composeApp/src/commonMain/kotlin/DIManager.kt
+++ b/app/composeApp/src/commonMain/kotlin/DIManager.kt
@@ -90,6 +90,7 @@ import ui.sc.auth.PasswordRecoveryScreen
 import ui.sc.auth.TwoFactorSetupScreen
 import ui.sc.auth.TwoFactorVerifyScreen
 import ui.sc.business.DashboardScreen
+import ui.sc.business.PersonalizationScreen
 import ui.sc.business.RegisterNewBusinessScreen
 import ui.sc.business.RequestJoinBusinessScreen
 import ui.sc.business.ReviewBusinessScreen
@@ -122,6 +123,7 @@ public const val REVIEW_BUSINESS = "reviewBusiness"
 public const val REGISTER_NEW_BUSINESS = "registerNewBusiness"
 public const val REQUEST_JOIN_BUSINESS = "requestJoinBusiness"
 public const val REVIEW_JOIN_BUSINESS = "reviewJoinBusiness"
+public const val PERSONALIZATION = "personalization"
 public const val TWO_FACTOR_SETUP = "twoFactorSetup"
 public const val TWO_FACTOR_VERIFY = "twoFactorVerify"
 
@@ -155,6 +157,7 @@ class DIManager {
                 bindSingleton(tag = REVIEW_BUSINESS) { ReviewBusinessScreen() }
                 bindSingleton(tag = REQUEST_JOIN_BUSINESS) { RequestJoinBusinessScreen() }
                 bindSingleton(tag = REVIEW_JOIN_BUSINESS) { ReviewJoinBusinessScreen() }
+                bindSingleton(tag = PERSONALIZATION) { PersonalizationScreen() }
                 bindSingleton(tag = TWO_FACTOR_SETUP) { TwoFactorSetupScreen() }
                 bindSingleton(tag = TWO_FACTOR_VERIFY) { TwoFactorVerifyScreen() }
 
@@ -176,6 +179,7 @@ class DIManager {
                         instance(tag = REGISTER_NEW_BUSINESS),
                         instance(tag = REQUEST_JOIN_BUSINESS),
                         instance(tag = REVIEW_JOIN_BUSINESS),
+                        instance(tag = PERSONALIZATION),
                         instance(tag = TWO_FACTOR_SETUP),
                         instance(tag = TWO_FACTOR_VERIFY)
                     )

--- a/app/composeApp/src/commonMain/kotlin/ui/cp/menu/SemiCircularHamburgerMenu.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/cp/menu/SemiCircularHamburgerMenu.kt
@@ -105,6 +105,7 @@ data class MainMenuItem(
     val label: String,
     val icon: ImageVector,
     val requiredRoles: Set<String> = emptySet(),
+    val requiresBusinessSelection: Boolean = false,
     val onClick: () -> Unit
 )
 

--- a/app/composeApp/src/commonMain/kotlin/ui/rs/PersonalizationStrings.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/rs/PersonalizationStrings.kt
@@ -1,0 +1,121 @@
+@file:OptIn(InternalResourceApi::class)
+
+package ui.rs
+
+import kotlin.OptIn
+import kotlin.collections.setOf
+import org.jetbrains.compose.resources.InternalResourceApi
+import org.jetbrains.compose.resources.ResourceItem
+import org.jetbrains.compose.resources.StringResource
+
+private const val RESOURCE_PREFIX = "composeResources/ui.rs/"
+
+val personalization_title: StringResource by lazy {
+    StringResource(
+        "string:personalization_title",
+        "personalization_title",
+        setOf(
+            ResourceItem(setOf(), "${RESOURCE_PREFIX}values/strings.commonMain.cvr", 2960, 65)
+        )
+    )
+}
+
+val personalization_panel: StringResource by lazy {
+    StringResource(
+        "string:personalization_panel",
+        "personalization_panel",
+        setOf(
+            ResourceItem(setOf(), "${RESOURCE_PREFIX}values/strings.commonMain.cvr", 2548, 53)
+        )
+    )
+}
+
+val personalization_description: StringResource by lazy {
+    StringResource(
+        "string:personalization_description",
+        "personalization_description",
+        setOf(
+            ResourceItem(setOf(), "${RESOURCE_PREFIX}values/strings.commonMain.cvr", 2460, 87)
+        )
+    )
+}
+
+val personalization_access_denied: StringResource by lazy {
+    StringResource(
+        "string:personalization_access_denied",
+        "personalization_access_denied",
+        setOf(
+            ResourceItem(setOf(), "${RESOURCE_PREFIX}values/strings.commonMain.cvr", 2297, 101)
+        )
+    )
+}
+
+val personalization_business_context: StringResource by lazy {
+    StringResource(
+        "string:personalization_business_context",
+        "personalization_business_context",
+        setOf(
+            ResourceItem(setOf(), "${RESOURCE_PREFIX}values/strings.commonMain.cvr", 2399, 60)
+        )
+    )
+}
+
+val personalization_section_pending: StringResource by lazy {
+    StringResource(
+        "string:personalization_section_pending",
+        "personalization_section_pending",
+        setOf(
+            ResourceItem(setOf(), "${RESOURCE_PREFIX}values/strings.commonMain.cvr", 2765, 71)
+        )
+    )
+}
+
+val personalization_section_colors: StringResource by lazy {
+    StringResource(
+        "string:personalization_section_colors",
+        "personalization_section_colors",
+        setOf(
+            ResourceItem(setOf(), "${RESOURCE_PREFIX}values/strings.commonMain.cvr", 2663, 50)
+        )
+    )
+}
+
+val personalization_section_typography: StringResource by lazy {
+    StringResource(
+        "string:personalization_section_typography",
+        "personalization_section_typography",
+        setOf(
+            ResourceItem(setOf(), "${RESOURCE_PREFIX}values/strings.commonMain.cvr", 2901, 58)
+        )
+    )
+}
+
+val personalization_section_images: StringResource by lazy {
+    StringResource(
+        "string:personalization_section_images",
+        "personalization_section_images",
+        setOf(
+            ResourceItem(setOf(), "${RESOURCE_PREFIX}values/strings.commonMain.cvr", 2714, 50)
+        )
+    )
+}
+
+val personalization_section_app_icon: StringResource by lazy {
+    StringResource(
+        "string:personalization_section_app_icon",
+        "personalization_section_app_icon",
+        setOf(
+            ResourceItem(setOf(), "${RESOURCE_PREFIX}values/strings.commonMain.cvr", 2602, 60)
+        )
+    )
+}
+
+val personalization_section_preview: StringResource by lazy {
+    StringResource(
+        "string:personalization_section_preview",
+        "personalization_section_preview",
+        setOf(
+            ResourceItem(setOf(), "${RESOURCE_PREFIX}values/strings.commonMain.cvr", 2837, 63)
+        )
+    )
+}

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/business/DashboardViewModel.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/business/DashboardViewModel.kt
@@ -5,6 +5,7 @@ import asdo.auth.ToDoResetLoginCache
 import org.kodein.di.instance
 import org.kodein.log.LoggerFactory
 import org.kodein.log.newLogger
+import ui.session.SessionStore
 import ui.sc.shared.ViewModel
 
 class DashboardViewModel : ViewModel() {
@@ -22,6 +23,7 @@ class DashboardViewModel : ViewModel() {
         try {
             toDoResetLoginCache.execute()
             logger.info { "Logout completado" }
+            SessionStore.clear()
         } catch (e: Throwable) {
             logger.error(e) { "Error al ejecutar logout" }
             throw e

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/business/PersonalizationScreen.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/business/PersonalizationScreen.kt
@@ -1,0 +1,208 @@
+package ui.sc.business
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.Row
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Brush
+import androidx.compose.material.icons.filled.Title
+import androidx.compose.material.icons.filled.Image
+import androidx.compose.material.icons.filled.Palette
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material3.Card
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.kodein.log.LoggerFactory
+import org.kodein.log.newLogger
+import ui.rs.personalization_access_denied
+import ui.rs.personalization_business_context
+import ui.rs.personalization_description
+import ui.rs.personalization_section_app_icon
+import ui.rs.personalization_section_colors
+import ui.rs.personalization_section_images
+import ui.rs.personalization_section_pending
+import ui.rs.personalization_section_preview
+import ui.rs.personalization_section_typography
+import ui.rs.personalization_title
+import ui.sc.shared.Screen
+import ui.session.SessionStore
+import ui.session.UserRole
+import ui.th.spacing
+import ui.util.RES_ERROR_PREFIX
+import ui.util.fb
+import ui.util.resString
+
+const val PERSONALIZATION_PATH = "/personalization"
+
+private val ALLOWED_ROLES = setOf(UserRole.BusinessAdmin, UserRole.PlatformAdmin)
+
+class PersonalizationScreen : Screen(PERSONALIZATION_PATH, personalization_title) {
+
+    private val logger = LoggerFactory.default.newLogger<PersonalizationScreen>()
+
+    @Composable
+    override fun screen() {
+        logger.info { "Renderizando PersonalizationScreen" }
+        PersonalizationContent()
+    }
+
+    @OptIn(ExperimentalResourceApi::class)
+    @Composable
+    private fun PersonalizationContent() {
+        val sessionStateState = SessionStore.sessionState.collectAsState()
+        val sessionState = sessionStateState.value
+        val role = sessionState.role
+        val hasAccess = role in ALLOWED_ROLES && sessionState.selectedBusinessId?.isNotBlank() == true
+
+        val accessDeniedMessage = resString(
+            composeId = personalization_access_denied,
+            fallbackAsciiSafe = RES_ERROR_PREFIX + fb("No tienes permiso para acceder a esta seccion"),
+        )
+
+        if (!hasAccess) {
+            Text(
+                text = accessDeniedMessage,
+                style = MaterialTheme.typography.bodyLarge,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(MaterialTheme.spacing.x4)
+            )
+            return
+        }
+
+        val businessLabel = resString(
+            composeId = personalization_business_context,
+            fallbackAsciiSafe = RES_ERROR_PREFIX + fb("Negocio actual"),
+        )
+        val description = resString(
+            composeId = personalization_description,
+            fallbackAsciiSafe = RES_ERROR_PREFIX + fb("Configura la apariencia de tu negocio"),
+        )
+        val pendingLabel = resString(
+            composeId = personalization_section_pending,
+            fallbackAsciiSafe = RES_ERROR_PREFIX + fb("Disponible proximamente"),
+        )
+
+        val sections = listOf(
+            PersonalizationSection(
+                icon = Icons.Default.Palette,
+                title = resString(
+                    composeId = personalization_section_colors,
+                    fallbackAsciiSafe = RES_ERROR_PREFIX + fb("Colores"),
+                ),
+                description = pendingLabel,
+            ),
+            PersonalizationSection(
+                icon = Icons.Default.Title,
+                title = resString(
+                    composeId = personalization_section_typography,
+                    fallbackAsciiSafe = RES_ERROR_PREFIX + fb("Tipografias"),
+                ),
+                description = pendingLabel,
+            ),
+            PersonalizationSection(
+                icon = Icons.Default.Image,
+                title = resString(
+                    composeId = personalization_section_images,
+                    fallbackAsciiSafe = RES_ERROR_PREFIX + fb("Imagenes"),
+                ),
+                description = pendingLabel,
+            ),
+            PersonalizationSection(
+                icon = Icons.Default.Brush,
+                title = resString(
+                    composeId = personalization_section_app_icon,
+                    fallbackAsciiSafe = RES_ERROR_PREFIX + fb("Icono de app"),
+                ),
+                description = pendingLabel,
+            ),
+            PersonalizationSection(
+                icon = Icons.Default.Visibility,
+                title = resString(
+                    composeId = personalization_section_preview,
+                    fallbackAsciiSafe = RES_ERROR_PREFIX + fb("Previsualizacion"),
+                ),
+                description = pendingLabel,
+            ),
+        )
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(
+                    horizontal = MaterialTheme.spacing.x3,
+                    vertical = MaterialTheme.spacing.x4
+                ),
+            verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.x3),
+        ) {
+            Text(
+                text = description,
+                style = MaterialTheme.typography.bodyLarge,
+            )
+
+            Text(
+                text = "$businessLabel: ${sessionState.selectedBusinessId.orEmpty()}",
+                style = MaterialTheme.typography.labelLarge.copy(fontWeight = FontWeight.Bold),
+            )
+
+            sections.forEach { section ->
+                PersonalizationCard(section)
+            }
+        }
+    }
+
+    @Composable
+    private fun PersonalizationCard(section: PersonalizationSection) {
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(MaterialTheme.spacing.x3),
+                verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.x2)
+            ) {
+                RowHeader(section)
+
+                Text(
+                    text = section.description,
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            }
+        }
+    }
+
+    @Composable
+    private fun RowHeader(section: PersonalizationSection) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.x2)
+        ) {
+            Icon(
+                imageVector = section.icon,
+                contentDescription = null
+            )
+            Text(
+                text = section.title,
+                style = MaterialTheme.typography.titleMedium,
+            )
+        }
+    }
+}
+
+private data class PersonalizationSection(
+    val icon: androidx.compose.ui.graphics.vector.ImageVector,
+    val title: String,
+    val description: String,
+)

--- a/app/composeApp/src/commonMain/kotlin/ui/session/SessionStore.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/session/SessionStore.kt
@@ -1,0 +1,50 @@
+package ui.session
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+/**
+ * Representa los roles disponibles dentro de la aplicación.
+ */
+enum class UserRole(val rawValue: String) {
+    PlatformAdmin("PlatformAdmin"),
+    BusinessAdmin("BusinessAdmin"),
+    Delivery("Delivery"),
+    Saler("Saler"),
+    Client("Client");
+
+    companion object {
+        fun fromRaw(value: String?): UserRole? = values().firstOrNull { it.rawValue == value }
+    }
+}
+
+/**
+ * Estado actual de la sesión del usuario.
+ */
+data class SessionState(
+    val role: UserRole? = null,
+    val selectedBusinessId: String? = null,
+)
+
+/**
+ * Almacena y expone el estado global de la sesión en memoria.
+ */
+object SessionStore {
+    private val mutableState = MutableStateFlow(SessionState())
+
+    val sessionState: StateFlow<SessionState> = mutableState.asStateFlow()
+
+    fun updateRole(role: UserRole?) {
+        mutableState.update { current -> current.copy(role = role) }
+    }
+
+    fun updateSelectedBusiness(businessId: String?) {
+        mutableState.update { current -> current.copy(selectedBusinessId = businessId) }
+    }
+
+    fun clear() {
+        mutableState.value = SessionState()
+    }
+}


### PR DESCRIPTION
## Resumen
- agrega un `SessionStore` global con el rol y negocio actual para controlar accesos
- incorpora la pantalla `PersonalizationScreen` y los recursos necesarios para el panel inicial
- actualiza el dashboard y el router para exponer la opción de personalización solo a businessAdmin y platformAdmin con negocio activo

## Pruebas
- `./gradlew :app:composeApp:compileKotlinDesktop --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68ebb6071d4c8325bdfab955e7f71045