### PR TITLE
[auto] Manejo defensivo de ResStrings Android (Closes #456)

### DIFF
--- a/app/composeApp/src/androidMain/kotlin/ui/util/ResStrings.android.kt
+++ b/app/composeApp/src/androidMain/kotlin/ui/util/ResStrings.android.kt
@@ -1,10 +1,16 @@
 package ui.util
 
 import android.content.Context
+import android.util.Base64
+import android.util.Log
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource as composeStringResource
+import kotlin.text.Charsets
+
+private const val RES_STRINGS_TAG = "ResStrings"
+private val base64CandidateRegex = Regex("^[A-Za-z0-9+/=_-]+$")
 
 @Composable
 actual fun resString(
@@ -24,11 +30,13 @@ actual fun resString(
     }
 
     composeId?.let { cid ->
+        logComposeId(identifier)
         return resolveComposeOrFallback(
             identifier = identifier,
             fallback = fallbackAsciiSafe,
         ) {
-            composeStringResource(cid)
+            val resolved = composeStringResource(cid)
+            decodeIfBase64OrReturn(identifier, resolved)
         }
     }
 
@@ -47,4 +55,27 @@ private fun resolveComposeOrFallback(
             onFailure(error)
             logFallback(identifier, fallback, error)
         }
+}
+
+private fun logComposeId(identifier: String) {
+    Log.d(RES_STRINGS_TAG, "Resolviendo composeId=$identifier")
+}
+
+private fun decodeIfBase64OrReturn(identifier: String, value: String): String {
+    val trimmed = value.trim()
+    if (trimmed.isEmpty()) return value
+    if (!base64CandidateRegex.matches(trimmed)) {
+        return value
+    }
+
+    return decodeBase64OrNull(identifier, trimmed) ?: value
+}
+
+private fun decodeBase64OrNull(identifier: String, rawValue: String): String? {
+    return runCatching {
+        String(Base64.decode(rawValue, Base64.DEFAULT), Charsets.UTF_8)
+    }.getOrElse { error ->
+        Log.e(RES_STRINGS_TAG, "composeId=$identifier - valor inválido", error)
+        null
+    }
 }


### PR DESCRIPTION
## Resumen
- agrega registro temporal del identificador de composeId antes de resolver recursos
- decodifica con seguridad los valores sospechosos de Base64 usando la implementación de Android
- mantiene fallbacks y logs cuando la decodificación falla para evitar crashes en Compose

## Testing
- ./gradlew :app:composeApp:compileDebugKotlinAndroid --console=plain --no-daemon

------
https://chatgpt.com/codex/tasks/task_e_68ebd9c83a448325a34324be135df66b