### PR TITLE
[auto] Issue: Crash en stringResource por decodificación Base64 — Corrección y alineación de versiones Compose Resources (Closes #458)

### DIFF
--- a/app/composeApp/src/androidMain/kotlin/ui/util/ResStrings.android.kt
+++ b/app/composeApp/src/androidMain/kotlin/ui/util/ResStrings.android.kt
@@ -1,16 +1,10 @@
 package ui.util
 
 import android.content.Context
-import android.util.Base64
-import android.util.Log
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource as composeStringResource
-import kotlin.text.Charsets
-
-private const val RES_STRINGS_TAG = "ResStrings"
-private val base64CandidateRegex = Regex("^[A-Za-z0-9+/=_-]+$")
 
 @Composable
 actual fun resString(
@@ -30,13 +24,11 @@ actual fun resString(
     }
 
     composeId?.let { cid ->
-        logComposeId(identifier)
         return resolveComposeOrFallback(
             identifier = identifier,
             fallback = fallbackAsciiSafe,
         ) {
-            val resolved = composeStringResource(cid)
-            decodeIfBase64OrReturn(identifier, resolved)
+            composeStringResource(cid)
         }
     }
 
@@ -55,27 +47,4 @@ private fun resolveComposeOrFallback(
             onFailure(error)
             logFallback(identifier, fallback, error)
         }
-}
-
-private fun logComposeId(identifier: String) {
-    Log.d(RES_STRINGS_TAG, "Resolviendo composeId=$identifier")
-}
-
-private fun decodeIfBase64OrReturn(identifier: String, value: String): String {
-    val trimmed = value.trim()
-    if (trimmed.isEmpty()) return value
-    if (!base64CandidateRegex.matches(trimmed)) {
-        return value
-    }
-
-    return decodeBase64OrNull(identifier, trimmed) ?: value
-}
-
-private fun decodeBase64OrNull(identifier: String, rawValue: String): String? {
-    return runCatching {
-        String(Base64.decode(rawValue, Base64.DEFAULT), Charsets.UTF_8)
-    }.getOrElse { error ->
-        Log.e(RES_STRINGS_TAG, "composeId=$identifier - valor inválido", error)
-        null
-    }
 }


### PR DESCRIPTION
## Resumen
- Se elimina la lógica de detección y decodificación Base64 en `resString` para confiar únicamente en los recursos provistos por Compose.
- Se mantiene el flujo de fallback existente aprovechando las utilidades compartidas para registrar cualquier error.

## Pruebas
- No se ejecutaron pruebas automatizadas en este entorno.

------
https://chatgpt.com/codex/tasks/task_e_68ebe34d4d508325910ed00e9de43cf9