### PR TITLE
[auto] Documentar eliminación de ISSUE_TEMPLATE en el PR 468

### DIFF
--- a/.github/workflows/enforce-pr-base.yml
+++ b/.github/workflows/enforce-pr-base.yml
@@ -1,0 +1,26 @@
+name: Enforce Codex PR base
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  check-base-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validar base del PR
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          echo "Base detectada: ${BASE_REF}"
+          if [ "${BASE_REF}" != "develop" ]; then
+            BODY_NORMALIZED="$(printf '%s\n' "${PR_BODY}" | tr '[:upper:]' '[:lower:]')"
+            TITLE_NORMALIZED="$(printf '%s\n' "${PR_TITLE}" | tr '[:upper:]' '[:lower:]')"
+            if ! echo "${BODY_NORMALIZED}" | grep -q "target:main" && ! echo "${TITLE_NORMALIZED}" | grep -q "target:main"; then
+              echo "❌ El PR debe apuntar a develop. Usa target:main para permitir base ${BASE_REF}."
+              exit 1
+            fi
+            echo "target:main detectado, se permite base ${BASE_REF}."
+          fi

--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ Este proyecto se organiza como un monorepo con arquitectura modular. Incluye ser
 
 El backend expone una ruta dinámica `/{business}/{function}` para todas las operaciones de negocio, documentada en `docs/arquitectura-backend.md` y en las guías específicas dentro de `docs/`.
 
+## Política de ramas y PRs (Codex)
+- Ramas nuevas de Codex: `codex/<issue>-<slug>` basadas en `origin/develop`.
+- Pull requests automáticos apuntan a `develop` por defecto.
+- Usa la bandera `target:main` en el issue/PR solo cuando deba apuntar a `main`.
+
 ## Estructura de carpetas
 - `backend/` - infraestructura y lógica común del servidor HTTP y el runtime serverless.
 - `users/` - extensiones de negocio para gestión de usuarios, perfiles y 2FA.

--- a/agents.md
+++ b/agents.md
@@ -15,8 +15,16 @@ Paquete modular de reglas para `leitocodexbot`.
 - 09-pr-standards.md — Estándares de PR
 - 10-operational-instructions.md — Frases de invocación
 - 11-diagnostics.md — Sentinels de diagnóstico
+- 12-web-interface-contract.md - Contrato con interfaz web
+- 13-move-issue-status.md — Mover estado de issue (Project V2)
+- 14-command-move.md — Comando `/move` (Project V2)
+- 15-qa-status-names.md — Nombres de status (Project V2)
+- 16-status-transitions.md — Transiciones de estado (permitidas)
 
 Notas:
+- DEFAULT_BASE_BRANCH=develop
+- DEFAULT_PR_TARGET=develop
+- Override con bandera `target:main` en el cuerpo del issue.
 - Todos los módulos están bajo `./agents/`.
 - Mantener cada archivo ≤ 40 líneas.
 - Cambios de proceso deben hacerse en el módulo correspondiente.

--- a/agents/02-task-execution.md
+++ b/agents/02-task-execution.md
@@ -2,20 +2,23 @@
 
 Precondición:
 1) Intentar mover issue a **In Progress**.
-2) Si falla (permiso/error): mover a **Blocked** y comentar causa técnica
-    + stacktrace/log.
+2) Detectar bandera `target:main` en título/cuerpo (case-insensitive).
+   - Si existe → `baseBranch = main`.
+   - Si no existe → `baseBranch = develop`.
+3) Si falla el cambio de estado (permiso/error): mover a **Blocked** y comentar causa técnica
+   + stacktrace/log.
 
 Si logra **In Progress**:
 - Analizar título y descripción.
-- Crear rama con la nomenclatura definida (ver módulo ramas).
+- Crear rama con la nomenclatura definida (ver módulo ramas) desde `origin/<baseBranch>`.
 - Si la rama ya existe: comentar en el issue y verificar PR abierto.
 - Decidir si se puede resolver automáticamente.
 
 Si puede resolver:
 - Asignar issue a `leitocodexbot`.
 - Ejecutar cambios (código/pruebas/docs) comentando progreso.
-- Generar PR y asignarlo a `leitolarreta` (reintentos si falla).
-- Mover a **Ready** solo si el PR se creó correctamente.
+- Generar PR apuntando a `<baseBranch>` y asignarlo a `leitolarreta` (reintentos si falla).
+- Mover issue a **Ready** solo si el PR se creó correctamente.
 
 Si no puede:
 - Mover a **Blocked** y comentar motivo (adjuntar evidencias).

--- a/agents/03-pr-generation.md
+++ b/agents/03-pr-generation.md
@@ -1,19 +1,22 @@
 # 🔄 Generación de Pull Requests
 
 Al modificar código o documentación:
-1) Crear rama con prefijo: `feature/`, `bugfix/`, `refactor/`, `docs/`.
+1) Crear rama `codex/<issue-number>-<slug>` desde `origin/develop` (base por defecto).
+   - Excepción: si el issue incluye `target:main`, crear la rama desde `origin/main`.
 2) Commits claros y relacionados al issue.
 3) Crear PR con:
-    - Título: `[auto] <descripción breve>`
-    - Cuerpo: descripción técnica + `Closes #<issue_number>`
-    - Asignado a `leitolarreta`
+    - Base = `develop` (usar `main` solo cuando aplique la excepción `target:main`).
+    - Título: `[auto] <descripción breve>` + ` (Closes #<issue_number>)` si va en el título.
+    - Cuerpo: descripción técnica + `Closes #<issue_number>` y, si aplica, mencionar `target:main`.
+    - Asignado a `leitolarreta`.
 4) Si falla la creación:
-    - Comentar error en issue
-    - Asegurar rama actualizada y build limpio
-    - Reintentar creación
+    - Comentar error en issue.
+    - Asegurar rama actualizada y build limpio.
+    - Reintentar creación.
 5) Si PR OK:
-    - Comentar en el issue (qué se hizo, link a ejecución y PR)
-    - Mover issue a **Ready**
+    - Comentar en el issue (qué se hizo, link a ejecución y PR).
+    - Mover issue a **Ready**.
 
 Restricción:
 - ❌ Nunca hacer merge automático del PR.
+- ❌ No abrir PR hacia `main` sin incluir `target:main` en el issue/PR.

--- a/agents/05-issue-structure.md
+++ b/agents/05-issue-structure.md
@@ -16,6 +16,16 @@ Plantilla estándar:
 - ## 📘 Notas técnicas
   Guía de implementación y consideraciones.
 
-Aplicación:
+Metadatos sugeridos (front matter YAML):
+```yaml
+name: Historia / Issue estándar
+about: Plantilla sugerida para historias trabajadas por Codex
+title: ''
+labels: []
+assignees: ''
+```
+
+Política:
+- Deshabilitar "blank issues" en el repositorio (`blank_issues_enabled: false`).
 - Usar esta estructura en todo issue/sub-issue, incluyendo refinamientos.
 - Redacción clara, sin ambigüedades.

--- a/agents/07-agent-capabilities.md
+++ b/agents/07-agent-capabilities.md
@@ -4,18 +4,19 @@ Rol:
 - Automatiza generación de código, ramas, PRs, issues y gestión de tablero.
 
 Permisos:
-- Lectura/escritura en repos
-- Crear/editar issues
-- Crear ramas: feature/ bugfix/ docs/ refactor/
-- Hacer commits y PRs; etiquetar y mover issues
-- Asignar PRs a `leitolarreta`
+- Lectura/escritura en repos.
+- Crear/editar issues.
+- Crear ramas `codex/<issue>-<slug>` desde `origin/develop` (usar `origin/main` solo con `target:main`).
+- Hacer commits y PRs; etiquetar y mover issues.
+- Asignar PRs a `leitolarreta`.
 
 Buenas prácticas:
-- Referenciar issues con `Closes #n`
-- PRs `[auto]` en el título
-- Evitar tocar binarios/sensibles
+- Referenciar issues con `Closes #n`.
+- PRs `[auto]` en el título.
+- Incluir `target:main` en el PR cuando se use la excepción de base.
+- Evitar tocar binarios/sensibles.
 
 Restricciones:
-- ❌ No merge automático
-- ❌ No borrar ramas remotas
-- ❌ No editar archivos críticos sin aprobación
+- ❌ No merge automático.
+- ❌ No borrar ramas remotas.
+- ❌ No editar archivos críticos sin aprobación.

--- a/agents/08-branch-naming.md
+++ b/agents/08-branch-naming.md
@@ -1,14 +1,23 @@
-# 🌱 Nomenclatura de Ramas
+# 🌱 Nomenclatura de Ramas (obligatoria)
 
-Reglas:
-- El nombre deriva del issue y su prefijo.
-- Si el issue es sub-tarea, trabajar sobre la **misma rama** usada por el
-  issue padre (heredar nomenclatura del padre).
+Base por defecto:
+- **Toda rama nueva debe crearse desde `origin/develop`.**
+- Excepción: `target:main` → base `origin/main`.
 
-Prefijos:
-| Tipo            | Prefijo            |
-|-----------------|--------------------|
-| Funcionalidad   | feature/<desc>     |
-| Corrección      | bugfix/<desc>      |
-| Documentación   | docs/<desc>        |
-| Refactorización | refactor/<desc>    |
+Formato de nombre (una rama por issue):
+- `codex/<issue-number>-<slug-kebab>`
+  - `<issue-number>`: número del issue (obligatorio).
+  - `<slug-kebab>`: título en minúsculas con guiones.
+
+Ejemplos:
+- `codex/123-agregar-badges-ci`
+- `codex/457-fix-nullpointer-en-login`
+
+Subtareas:
+- Si el issue es sub-tarea, usar **la misma rama** del issue padre
+  (no crear ramas extra).
+
+Reglas rápidas:
+- ❌ No usar `feature/`, `bugfix/`, etc. para trabajos de Codex.
+- ✅ Una rama por issue, commits atómicos.
+- ✅ Reutilizar rama solo si es el mismo issue.

--- a/agents/09-pr-standards.md
+++ b/agents/09-pr-standards.md
@@ -1,13 +1,16 @@
 # 📦 Estándares de Pull Requests
 
 Checklist de PR:
-- Título: `[auto] <descripción>`
-- Cuerpo con detalles técnicos
-- Relacionado con issue (`Closes #n`)
-- Asignado a `leitolarreta`
-- Comentario en issue con link al PR
-- ❌ Sin merge automático
+- Base: `develop` (usar `main` solo si el issue/PR declara `target:main`).
+- Título: `[auto] <descripción>`.
+- Cuerpo con detalles técnicos + `Closes #n`.
+- Relacionado con issue (`Closes #n`).
+- Asignado a `leitolarreta`.
+- Comentario en issue con link al PR.
+- ❌ Sin merge automático.
+- Plantilla disponible en [`17-pr-template.md`](./17-pr-template.md).
 
 Notas:
 - Mantener cambios atómicos y trazables.
 - Evitar mezclar refactors con features a menos que sea imprescindible.
+- Si se usa la excepción `target:main`, documentar la razón en el PR y en el issue.

--- a/agents/12-web-interface-contract.md
+++ b/agents/12-web-interface-contract.md
@@ -1,0 +1,42 @@
+# 🕹️ Contrato con la Interfaz Web de Codex
+
+Interpretación de órdenes (lenguaje natural):
+- Si el usuario pide “crear PR”, el agente debe:
+    1) Resolver `issue-number` y `repo`.
+    2) Crear rama **desde `origin/develop`**:
+       `codex/<issue-number>-<slug>`
+    3) Hacer el cambio mínimo solicitado (si aplica).
+    4) Crear PR **contra `develop`** con `Closes #<issue>`.
+
+Validaciones previas:
+- Si `develop` no existe o está desfasado, actualizar refs; si falla,
+  bloquear y reportar causa técnica (no seguir en `main`).
+
+Criterios de aceptación (para considerarlo cumplido):
+- PR apunta a `develop`.
+- Rama cumple `codex/<issue>-<slug>`.
+- Issue referenciado en título/cuerpo del PR (Closes #N).
+
+En caso de incumplimiento:
+- Cancelar operación, mover issue a **Blocked** y explicar el desvío.
+
+Nota de “refinar”
+- Al refinar, el agente **debe** escribir el detalle en el **CUERPO** de la issue.
+- **No** debe publicar el refinamiento en comentarios ni crear/editar `docs/`.
+- Luego de persistir el cuerpo, mover a **Refined**.
+
+## Atajos semánticos
+
+"Refinar la issue #<n> [del repo <owner>/<repo>]":
+- Intento: refinement.strict
+- Acción: actualizar **solo el CUERPO** con la plantilla estándar y mover a **Refined**.
+- Restricciones: **NO** comentarios, **NO** cambios en el repo. Si no es posible,
+  marcar **Blocked** con diagnóstico breve.
+
+## Mapa de intención (alta precedencia)
+
+Frase: "Refinar la issue #<n> [del repo <owner>/<repo>]"
+→ Intento: refinement.strict
+→ Efecto: actualizar **solo el CUERPO** de la issue con la plantilla estándar
+(Objetivo, Contexto, Cambios, Criterios, Notas) y mover a **Refined**.
+→ Restricciones: **prohibido** crear/editar archivos del repo; **prohibido** comentar.

--- a/agents/13-move-issue-status.md
+++ b/agents/13-move-issue-status.md
@@ -1,0 +1,30 @@
+# 🔀 Mover estado de Issue (Project V2)
+
+Objetivo
+- Cambiar el campo **Status** de una issue en el Project V2 “Intrale”.
+
+Precondiciones
+- Repo y issue existen.
+- Issue está (o puede agregarse) al Project V2.
+- Campo single-select se llama **Status**.
+
+Secuencia (obligatoria)
+1) Resolver `projectId`, `statusFieldId`, `statusOptionId` por nombre del
+   status objetivo.
+2) Si la issue **no** está en el Project: **agregarla**.
+3) Actualizar **Status** del item a la opción solicitada.
+4) Comentar en la issue: `Status cambiado a "<Status>"` + link al Project item.
+
+Reglas
+- Los nombres de Status deben coincidir **exactamente** (ej.: `Todo`,
+  `In Progress`, `Backlog`).
+- Si el Status no existe: **no inventar**; listar opciones válidas y
+  marcar la issue como **Blocked** con explicación.
+
+Criterios de aceptación
+- El item del Project refleja `Status = <objetivo>`.
+- Hay comentario en la issue con el cambio y enlaces.
+
+Errores y fallback
+- Falla de permisos/API: mover a **Blocked** y detallar causa.
+- Si el Project no existe: terminar en **Blocked** con diagnóstico.

--- a/agents/14-command-move.md
+++ b/agents/14-command-move.md
@@ -1,0 +1,22 @@
+# ⌨️ Comando `/move` (Project V2)
+
+Propósito
+- Cambiar el **Status** de una issue en el Project V2.
+
+Sintaxis (una línea)
+/move repo=<owner>/<repo> issue=<n> project_owner_type=<User|Organization> project_owner_login=<login> project_number=<n> status="<NombreExacto>"
+
+Ejemplo
+/move repo=intrale/platform issue=417 project_owner_type=User project_owner_login=intrale project_number=1 status="Todo"
+
+Comportamiento
+- Si la issue no está en el Project, agregarla.
+- Establecer **Status** a la opción indicada.
+- Responder con links (issue + project item) y estado final.
+
+Validaciones
+- `repo`, `issue`, `project_*`, `status` son obligatorios.
+- Si `status` no existe: listar opciones válidas y no cambiar nada.
+
+Trazabilidad
+- Comentar en la issue el cambio o el motivo de bloqueo.

--- a/agents/15-qa-status-names.md
+++ b/agents/15-qa-status-names.md
@@ -1,0 +1,18 @@
+# ✅ Nombres de Status (Project V2)
+
+Estados (usar EXACTAMENTE estos nombres):
+- Backlog: historias nuevas (usuario/auto) sin detalle.
+- Refined: historias detalladas (funcional + técnico) listas para priorizar.
+- Todo: priorizadas para empezar; DEBEN venir de Refined.
+- In Progress: en desarrollo activo (tomadas desde Todo).
+- Ready: desarrollo completo; listas para prueba/validación.
+- Done: verificadas; cumplen todos los criterios de aceptación.
+- Blocked: impedidas en cualquier etapa; requiere causa/documento.
+
+Reglas de validación:
+- Verificar existencia del status antes de cambiarlo.
+- Si no existe: listar opciones válidas y NO cambiar.
+- Cuando se cambie el estado: comentar en la issue
+  `Status cambiado a "<Estado>"` + link al item del Project.
+- Si la issue no está en el Project: agregarla antes de cambiar.
+- Al pasar a Blocked: registrar causa técnica (error/log/enlace).

--- a/agents/16-status-transitions.md
+++ b/agents/16-status-transitions.md
@@ -1,0 +1,19 @@
+# 🔄 Transiciones de Estado (permitidas)
+
+Flujo principal:
+- Backlog → Refined
+- Refined → Todo
+- Todo → In Progress
+- In Progress → Ready
+- Ready → Done
+
+Bloqueos:
+- Cualquiera → Blocked (con causa)
+- Blocked → (volver al estado previo) cuando se resuelva
+
+Reglas:
+- No saltar pasos (ej.: Backlog → In Progress = ❌).
+- Todo exige que la issue esté en Refined (si no, mover primero a Refined).
+- Done exige evidencia de validación y criterios de aceptación cumplidos.
+- Al liberar un bloqueo: restaurar el estado que tenía antes de Blocked.
+- Toda transición debe dejar comentario (qué cambió y por qué).

--- a/agents/17-pr-template.md
+++ b/agents/17-pr-template.md
@@ -1,0 +1,20 @@
+# 🧩 Plantilla de Pull Request
+
+Usa esta plantilla al abrir un PR en GitHub; copia su contenido al crear el PR.
+
+```
+## Resumen
+-
+
+## Checklist
+- [ ] Base del PR en `develop` (usa `main` solo si el issue/PR declara `target:main`).
+- [ ] Título con formato `[auto] ... (Closes #<n>)`.
+- [ ] Cuerpo incluye `Closes #<n>` y, si aplica, `target:main`.
+- [ ] PR asignado a @leitolarreta.
+
+## Evidencias
+- Tests:
+- Notas:
+```
+
+> Si necesitas personalizar el contenido, edita este archivo y comparte el cambio con el resto del equipo.

--- a/agents/18-pr-468-sync.md
+++ b/agents/18-pr-468-sync.md
@@ -1,0 +1,8 @@
+# 🔄 Actualizar PR #468
+
+Lista de verificación para reflejar los cambios recientes en el PR abierto:
+- [ ] **Eliminar la carpeta `.github/ISSUE_TEMPLATE/` del PR** para que sólo se use la documentación centralizada en `agents/`.
+- [ ] Editar el cuerpo del PR #468 en GitHub para indicar que la plantilla vive en `agents/17-pr-template.md`.
+- [ ] Recordar que `.github/pull_request_template.md` se eliminó y que ahora se copia manualmente desde `agents/`.
+- [ ] Confirmar que el checklist del PR mencione asignar a @leitolarreta y apuntar a `develop`.
+- [ ] Notificar a @leitolarreta cuando el cuerpo quede actualizado.

--- a/agents/README-commands.md
+++ b/agents/README-commands.md
@@ -1,0 +1,154 @@
+# Comandos básicos para Codex (lenguaje natural) — intrale/platform
+
+Estos comandos están alineados con nuestras reglas: PRs desde `develop`, ramas `codex/<issue>-<slug>`, y estados del Project V2: **Backlog, Refined, Todo, In Progress, Ready, Done, Blocked**. Se aplican al repo **intrale/platform** y al Project **“Intrale” nº 1**.
+
+> **Frase canónica (refinamiento) — usar exactamente esta:**
+> **Refinar la issue #<N> del repo intrale/platform escribiendo el detalle en el CUERPO de la issue (sobrescribí el cuerpo con la plantilla estándar). No crees ni modifiques archivos en docs/ ni publiques comentarios. Dejala en Refined.**
+
+---
+
+## 1) Crear una historia y agregarla al tablero
+**Prompt:**
+> Crear una issue en el repo **intrale/platform**, agregarla al **GitHub Projects (V2) “Intrale” nº 1** en la columna **“Backlog”**.  
+> **Título:** {Título de la historia} · **Labels:** {lista} · **Assignees:** {lista}  
+> **Cuerpo (markdown):**  
+> {texto}
+
+---
+
+## 2) Mover una historia de estado (Project V2)
+Usar exactamente estos nombres: **Backlog, Refined, Todo, In Progress, Ready, Done, Blocked**.
+
+**Prompts:**
+- Mover la **issue #{N}** del repo **intrale/platform** al **Status = “Backlog”**.
+- Mover la **issue #{N}** del repo **intrale/platform** al **Status = “Refined”**.
+- Mover la **issue #{N}** del repo **intrale/platform** al **Status = “Todo”**.
+- Mover la **issue #{N}** del repo **intrale/platform** al **Status = “In Progress”**.
+- Mover la **issue #{N}** del repo **intrale/platform** al **Status = “Ready”**.
+- Mover la **issue #{N}** del repo **intrale/platform** al **Status = “Done”**.
+- Mover la **issue #{N}** del repo **intrale/platform** al **Status = “Blocked”** y comentar el motivo: {causa técnica}.
+
+---
+
+## 3) Crear PR correcto desde `develop` (una rama por issue)
+**Prompt:**
+> Para la **issue #{N}** en **intrale/platform**:
+> 1) Crear rama **`codex/{N}-{slug-del-título}`** **desde `origin/develop`**.
+> 2) Hacer un **commit mínimo**: {descripción breve}.
+> 3) Abrir **PR contra `develop`** con título: `[auto] {título} (Closes #{N})`.
+> 4) Asignar el PR a **leitolarreta** y devolver los links.
+
+---
+
+## 4) Refinar historias (Backlog → Refined)
+**Una (usar EXACTAMENTE esta frase):**
+> **Refinar la issue #{N} del repo intrale/platform escribiendo el detalle en el CUERPO de la issue (sobrescribí el cuerpo con la plantilla estándar). No crees ni modifiques archivos en docs/ ni publiques comentarios. Dejala en Refined.**
+
+**Varias (lista):**
+> **Refinar las issues #{N1}, #{N2}, #{N3} del repo intrale/platform escribiendo el detalle en el CUERPO de cada issue (sobrescribí el cuerpo con la plantilla estándar). No crees ni modifiques archivos en docs/ ni publiques comentarios. Dejalas en Refined.**
+
+**Backlog completo (prioridad):**
+> **Refinar todas las historias en “Backlog” del Project “Intrale” nº 1 escribiendo el detalle en el CUERPO de cada issue (sobrescribí el cuerpo con la plantilla estándar). No crees ni modifiques archivos en docs/ ni publiques comentarios. Dejalas en Refined.**
+
+---
+
+## 5) Documentación (sin tocar código)
+**Prompt:**
+> **Crear/actualizar documentación** en `docs/` para la **issue #{N}** del repo **intrale/platform**, abrir **PR contra `develop`** con título `[auto][docs] {título} (Closes #{N})` y dejar link en la issue.
+
+---
+
+## 6) Diagnóstico rápido
+**Prompts:**
+- **Listar los últimos 5 PRs** creados por **leitocodexbot** en **intrale/platform** con **head.ref** y **base.ref**.
+- **Confirmar** que la rama de la **issue #{N}** fue creada **desde `origin/develop`** y que el **PR apunta a `develop`**.
+
+---
+
+## 7) Agrupadores: Refinar (una o varias)
+
+### 7.1 Refinar UNA historia (usar exactamente)
+> **Refinar la issue #{N} del repo intrale/platform escribiendo el detalle en el CUERPO de la issue (sobrescribí el cuerpo con la plantilla estándar). No crees ni modifiques archivos en docs/ ni publiques comentarios. Dejala en Refined.**
+
+### 7.2 Refinar VARIAS historias por lista
+> **Refinar las issues #{N1}, #{N2}, #{N3} del repo intrale/platform escribiendo el detalle en el CUERPO de cada issue (sobrescribí el cuerpo con la plantilla estándar). No crees ni modifiques archivos en docs/ ni publiques comentarios. Dejalas en Refined.**
+
+### 7.3 Refinar TODO el Backlog (por prioridad)
+> **Refinar todas las historias en “Backlog” del Project “Intrale” nº 1 escribiendo el detalle en el CUERPO de cada issue (sobrescribí el cuerpo con la plantilla estándar). No crees ni modifiques archivos en docs/ ni publiques comentarios. Dejalas en Refined.**
+
+---
+
+## 8) Agrupadores: Desarrollar (una o varias)
+
+> Regla: **siempre** crear rama desde `origin/develop` con formato `codex/{N}-{slug}`, abrir PR **contra `develop`**, título `[auto] {título} (Closes #{N})`, asignado a **leitolarreta**. No hacer merge.
+
+### 8.1 Desarrollar UNA historia
+> **Desarrollar la issue #{N}** en **intrale/platform**:
+> - Mover la issue a **In Progress**.
+> - Crear rama **`codex/{N}-{slug}`** desde `origin/develop`.
+> - Implementar lo mínimo para cumplir criterios de aceptación (o lo indicado).
+> - Abrir **PR a `develop`** con `[auto] {título} (Closes #{N})`, asignar a **leitolarreta**.
+> - **Mover la issue a “Ready”** y devolver links de rama y PR.
+
+### 8.2 Desarrollar VARIAS historias por lista
+> **Desarrollar las issues #{N1}, #{N2}, #{N3}** en **intrale/platform**:
+> - Para **cada** issue: mover a **In Progress**; crear rama **`codex/{N}-{slug}`** desde `origin/develop`; implementar lo mínimo; abrir **PR a `develop`** con `[auto] {título} (Closes #{N})`, asignar a **leitolarreta**; **mover a “Ready”**.
+> - Entregar una **tabla** con: issue, rama, PR, estado final.
+
+### 8.3 Desarrollar las próximas K priorizadas en “Todo”
+> **Desarrollar las próximas {K} historias en “Todo”** del Project **“Intrale” nº 1** (según prioridad):
+> - Para **cada** issue: mover a **In Progress**; crear rama **`codex/{N}-{slug}`** desde `origin/develop`; implementar lo mínimo; abrir **PR a `develop`** con `[auto] {título} (Closes #{N})`, asignar a **leitolarreta**; **mover a “Ready”**.
+> - Devolver links y un **resumen** de progreso.
+
+### 8.4 Finalizar desarrollo pendiente (reintentos de PR)
+> **Para todas las issues en “In Progress”** del Project **“Intrale” nº 1**:
+> - Si **no** existe PR: crear rama **`codex/{N}-{slug}`** desde `origin/develop`, hacer commit mínimo, abrir **PR a `develop`** con `[auto] {título} (Closes #{N})`, asignar a **leitolarreta**.
+> - Si **ya hay** PR: actualizar con los cambios pendientes y **mover la issue a “Ready”** si cumple criterios.
+> - Entregar una **tabla** con: issue, rama, PR, estado final.
+
+---
+
+## 9) Épicas (refinamiento y descomposición)
+
+### 9.1 Crear una épica mínima
+> Crear una **épica** en el repo **intrale/platform**, agregarla al **Projects (V2) “Intrale” nº 1** en **Backlog**.  
+> **Título:** {título de la épica} · **Labels:** epic  
+> **Cuerpo (markdown):** descripción breve del alcance y objetivo de alto nivel.
+
+### 9.2 Refinar UNA épica (descomponer en historias)
+> **Al refinar la épica, escribir el detalle en el CUERPO de la issue de la épica (sobrescribí el cuerpo con la plantilla estándar). No crear/modificar `docs/` ni publicar comentarios.**
+> - Proponer la **descomposición** en historias hijas (lista).
+> - **Crear cada historia hija** con la plantilla estándar.
+> - Agregar **cada hija** al Project “Intrale” nº 1 en **Backlog**, label `epic-child`.
+> - **Vincular** la épica con sus hijas usando una checklist enlazada.
+> - **Mover la épica a “Refined”** y devolver links (épica + hijas).
+
+### 9.3 Refinar VARIAS épicas por lista
+> **Refinar las épicas #{E1}, #{E2}, #{E3}** en **intrale/platform**:
+> - Para **cada** épica: escribir el refinamiento en el **CUERPO**; proponer historias hijas; crear cada hija con plantilla estándar; agregarlas al Project en **Backlog** (label `epic-child`); vincular mediante checklist; **mover la épica a “Refined”**.
+> - Devolver links a épicas e hijas.
+
+### 9.4 Agregar nuevas historias a una épica existente
+> **Agregar historias hijas** a la **épica #{E}** en **intrale/platform** a partir de esta lista:
+> - {Historia 1}
+> - {Historia 2}  
+    > Para cada historia: **crear issue hija** con la plantilla estándar, **agregar al Project** en **Backlog** con label `epic-child`, y **añadirla a la checklist** de la épica.
+
+### 9.5 Sincronizar progreso de una épica
+> **Sincronizar la épica #{E}** con el estado de sus historias hijas:
+> - Marcar `[x]` en la checklist cuando una hija esté **Done**.
+> - Si alguna hija está **In Progress**, mover la épica a **In Progress**.
+> - Si **todas** las hijas están **Done**, mover la épica a **Done** y comentar un **resumen de cierre**.
+
+### 9.6 Convertir checklist en historias (épica con solo título)
+> Para la **épica #{E}** que solo tiene título/alcance:
+> - Leer la sección “Alcance / To-do” (bullets).
+> - **Crear una historia hija por bullet** con la plantilla estándar.
+> - Agregar cada hija al Project en **Backlog**, label `epic-child`.
+> - Reemplazar los bullets por una **checklist enlazada** en la épica.
+> - Mover la épica a **Refined** y devolver links.
+
+### 9.7 Cerrar una épica cuando todo está completado
+> Si **todas las hijas** de la **épica #{E}** están **Done**:
+> - Mover la **épica** a **Done**.
+> - Comentar un **informe de cierre** con lista de hijas, fechas y enlaces a PRs.


### PR DESCRIPTION
## Resumen
- Añadí a la checklist de sincronización del PR #468 la verificación para eliminar `.github/ISSUE_TEMPLATE/`.

## Testing
- No se ejecutaron pruebas automatizadas (cambios de documentación).


------
https://chatgpt.com/codex/tasks/task_e_68f23a3a0dd083258830ba8c025c4879