### PR TITLE
[auto] Migrar Login a Txt/MessageKey

### DIFF
--- a/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/ComposeExt.kt
+++ b/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/ComposeExt.kt
@@ -1,0 +1,16 @@
+package ar.com.intrale.strings
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.staticCompositionLocalOf
+
+val LocalBrand = staticCompositionLocalOf<BrandId?> { null }
+val LocalLang = staticCompositionLocalOf { Lang("es") }
+
+/** Helpers de conveniencia */
+@Composable
+fun tr(key: StringKey): String =
+    Strings.t(key, LocalBrand.current, LocalLang.current)
+
+@Composable
+fun tr(key: StringKey, args: Map<String, String>): String =
+    Strings.t(key, args, LocalBrand.current, LocalLang.current)

--- a/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/StringCatalog.kt
+++ b/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/StringCatalog.kt
@@ -1,0 +1,29 @@
+package ar.com.intrale.strings
+
+import kotlin.jvm.JvmInline
+
+/** Id de marca (ej: "intrale", "clienteX"). */
+@JvmInline
+value class BrandId(val value: String)
+
+/** Idioma en formato BCP-47 simple (ej: "es", "en"). */
+@JvmInline
+value class Lang(val value: String)
+
+/** Catálogo inmutable para un idioma. */
+typealias LangBundle = Map<StringKey, String>
+
+/** Catálogo completo: por idioma, bundles; y overrides por marca. */
+data class StringCatalog(
+    val defaultsByLang: Map<Lang, LangBundle>,
+    val brandOverrides: Map<BrandId, Map<Lang, LangBundle>> = emptyMap()
+) {
+    fun resolve(key: StringKey, brand: BrandId?, lang: Lang): String? {
+        // 1) si hay override de marca+lang, gana
+        brand?.let { b ->
+            brandOverrides[b]?.get(lang)?.get(key)?.let { return it }
+        }
+        // 2) si no, default del lang
+        return defaultsByLang[lang]?.get(key)
+    }
+}

--- a/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/StringKey.kt
+++ b/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/StringKey.kt
@@ -1,0 +1,9 @@
+package ar.com.intrale.strings
+
+/** Claves tipadas. Podés empezar con pocas y después crecer. */
+enum class StringKey {
+    App_Name,
+    Login_Title,
+    Login_Button,
+    Error_Generic,
+}

--- a/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/StringProvider.kt
+++ b/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/StringProvider.kt
@@ -1,0 +1,48 @@
+package ar.com.intrale.strings
+
+/** Punto de entrada global (simple y testable). */
+object Strings {
+    // Config por defecto mínima (es/en) para arrancar
+    private var catalog: StringCatalog = StringCatalog(
+        defaultsByLang = mapOf(
+            Lang("es") to mapOf(
+                StringKey.App_Name to "Intrale",
+                StringKey.Login_Title to "Iniciar sesión",
+                StringKey.Login_Button to "Entrar",
+                StringKey.Error_Generic to "Ocurrió un error"
+            ),
+            Lang("en") to mapOf(
+                StringKey.App_Name to "Intrale",
+                StringKey.Login_Title to "Sign in",
+                StringKey.Login_Button to "Enter",
+                StringKey.Error_Generic to "Something went wrong"
+            )
+        )
+    )
+    private var currentBrand: BrandId? = null
+    private var currentLang: Lang = Lang("es")
+
+    /** setters pensados para app startup / tests */
+    fun setCatalog(newCatalog: StringCatalog) { catalog = newCatalog }
+    fun setBrand(brandId: BrandId?) { currentBrand = brandId }
+    fun setLang(lang: Lang) { currentLang = lang }
+
+    /** API de acceso simple */
+    fun t(key: StringKey, brand: BrandId? = currentBrand, lang: Lang = currentLang): String {
+        return catalog.resolve(key, brand, lang) ?: "⟪$key⟫"
+    }
+
+    /** Con reemplazos: "{{name}}" -> args["name"] */
+    fun t(
+        key: StringKey,
+        args: Map<String, String>,
+        brand: BrandId? = currentBrand,
+        lang: Lang = currentLang
+    ): String {
+        val base = t(key, brand, lang)
+        if (args.isEmpty()) return base
+        var out = base
+        args.forEach { (k, v) -> out = out.replace("{{$k}}", v) }
+        return out
+    }
+}

--- a/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/Strings.kt
+++ b/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/Strings.kt
@@ -1,0 +1,53 @@
+package ar.com.intrale.strings
+
+import androidx.compose.runtime.Composable
+import ar.com.intrale.strings.catalog.DefaultCatalog_en
+import ar.com.intrale.strings.catalog.DefaultCatalog_es
+import ar.com.intrale.strings.model.MessageKey
+import ar.com.intrale.strings.runtime.currentBrand
+import ar.com.intrale.strings.runtime.currentLang
+import ui.util.resString
+
+/**
+ * Punto único de acceso a textos.
+ * Prioridad: catálogo del brand (si existe) > catálogo default > key.name
+ *
+ * Por ahora no usamos composeId ni androidId: todo pasa por fallback.
+ * Cuando termines la migración, podremos borrar Compose Resources y strings.xml.
+ */
+@Composable
+fun Txt(
+    key: MessageKey,
+    params: Map<String, String> = emptyMap()
+): String {
+    val lang = currentLang()
+    val brand = currentBrand()
+
+    // 1) Catálogo default por idioma (expandible)
+    val defaultCatalog = when (lang) {
+        "es" -> DefaultCatalog_es
+        "en" -> DefaultCatalog_en
+        else -> DefaultCatalog_en
+    }
+
+    // 2) Catálogo por brand+idioma (a futuro)
+    val brandCatalog: Map<MessageKey, String> = emptyMap()
+
+    val template = brandCatalog[key] ?: defaultCatalog[key] ?: key.name
+
+    val interpolated = if (params.isEmpty()) {
+        template
+    } else {
+        // Interpolación súper simple: reemplaza {param}
+        params.entries.fold(template) { acc, (k, v) ->
+            acc.replace("{$k}", v)
+        }
+    }
+
+    // Usamos el wrapper multiplataforma. No hay llamada composable adentro (va por fallback).
+    return resString(
+        androidId = null,
+        composeId = null,
+        fallbackAsciiSafe = interpolated
+    )
+}

--- a/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/catalog/DefaultCatalog_en.kt
+++ b/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/catalog/DefaultCatalog_en.kt
@@ -1,0 +1,35 @@
+package ar.com.intrale.strings.catalog
+
+import ar.com.intrale.strings.model.MessageKey
+
+internal val DefaultCatalog_en: Map<MessageKey, String> = mapOf(
+    MessageKey.app_name to "Intrale",
+    MessageKey.login_title to "Welcome to Intrale",
+    MessageKey.login_subtitle to "Sign in with your corporate email to continue.",
+    MessageKey.login_button to "Sign in",
+    MessageKey.login_error_credentials to "Incorrect username or password",
+    MessageKey.login_change_password_required to "Update your password to continue",
+    MessageKey.login_generic_error to "We couldn't sign you in. Please try again.",
+    MessageKey.login_user_icon_content_description to "User icon",
+    MessageKey.login_password_icon_content_description to "Password icon",
+    MessageKey.login_change_password_title to "Update your password",
+    MessageKey.login_change_password_description to "Your account needs a password update before signing in.",
+    MessageKey.signup to "Sign up",
+    MessageKey.register_business to "Register business",
+    MessageKey.signup_delivery to "Delivery signup",
+    MessageKey.password_recovery to "Recover password",
+    MessageKey.confirm_password_recovery to "Confirm recovery",
+    MessageKey.username to "Username",
+    MessageKey.password to "Password",
+    MessageKey.login_email_placeholder to "email@intrale.com",
+    MessageKey.login_password_placeholder to "Your password",
+    MessageKey.login_new_password_placeholder to "New secure password",
+    MessageKey.login_name_placeholder to "Name",
+    MessageKey.login_family_name_placeholder to "Last name",
+    MessageKey.new_password to "New password",
+    MessageKey.login_name_label to "Name",
+    MessageKey.login_family_name_label to "Last name",
+    MessageKey.text_field_show_password to "Show password",
+    MessageKey.text_field_hide_password to "Hide password",
+    MessageKey.error_generic to "Something went wrong. Please try again.",
+)

--- a/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/catalog/DefaultCatalog_es.kt
+++ b/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/catalog/DefaultCatalog_es.kt
@@ -1,0 +1,35 @@
+package ar.com.intrale.strings.catalog
+
+import ar.com.intrale.strings.model.MessageKey
+
+internal val DefaultCatalog_es: Map<MessageKey, String> = mapOf(
+    MessageKey.app_name to "Intrale",
+    MessageKey.login_title to "Bienvenido a Intrale",
+    MessageKey.login_subtitle to "Ingresá con tu correo corporativo para continuar.",
+    MessageKey.login_button to "Ingresar",
+    MessageKey.login_error_credentials to "Usuario o contraseña incorrectos",
+    MessageKey.login_change_password_required to "Actualizá tu contraseña para continuar",
+    MessageKey.login_generic_error to "Ocurrió un error al iniciar sesión. Intentá nuevamente.",
+    MessageKey.login_user_icon_content_description to "Ícono de usuario",
+    MessageKey.login_password_icon_content_description to "Ícono de contraseña",
+    MessageKey.login_change_password_title to "Actualizá tu contraseña",
+    MessageKey.login_change_password_description to "Tu cuenta requiere actualizar la contraseña antes de ingresar.",
+    MessageKey.signup to "Registrarme",
+    MessageKey.register_business to "Registrar negocio",
+    MessageKey.signup_delivery to "Registro Delivery",
+    MessageKey.password_recovery to "Recuperar contraseña",
+    MessageKey.confirm_password_recovery to "Confirmar recuperación",
+    MessageKey.username to "Usuario",
+    MessageKey.password to "Contraseña",
+    MessageKey.login_email_placeholder to "correo@intrale.com",
+    MessageKey.login_password_placeholder to "Tu contraseña",
+    MessageKey.login_new_password_placeholder to "Nueva contraseña segura",
+    MessageKey.login_name_placeholder to "Nombre",
+    MessageKey.login_family_name_placeholder to "Apellido",
+    MessageKey.new_password to "Nueva contraseña",
+    MessageKey.login_name_label to "Nombre",
+    MessageKey.login_family_name_label to "Apellido",
+    MessageKey.text_field_show_password to "Mostrar contraseña",
+    MessageKey.text_field_hide_password to "Ocultar contraseña",
+    MessageKey.error_generic to "Ocurrió un error. Intenta nuevamente.",
+)

--- a/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/model/MessageKey.kt
+++ b/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/model/MessageKey.kt
@@ -1,0 +1,38 @@
+package ar.com.intrale.strings.model
+
+/**
+ * Claves type-safe para todos los textos de la app.
+ * Agregá aquí las que vayas necesitando.
+ */
+@Suppress("EnumEntryName")
+enum class MessageKey {
+    app_name,
+    login_title,
+    login_subtitle,
+    login_button,
+    login_error_credentials,
+    login_change_password_required,
+    login_generic_error,
+    login_user_icon_content_description,
+    login_password_icon_content_description,
+    login_change_password_title,
+    login_change_password_description,
+    signup,
+    register_business,
+    signup_delivery,
+    password_recovery,
+    confirm_password_recovery,
+    username,
+    password,
+    login_email_placeholder,
+    login_password_placeholder,
+    login_new_password_placeholder,
+    login_name_placeholder,
+    login_family_name_placeholder,
+    new_password,
+    login_name_label,
+    login_family_name_label,
+    text_field_show_password,
+    text_field_hide_password,
+    error_generic,
+}

--- a/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/runtime/BrandContext.kt
+++ b/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/runtime/BrandContext.kt
@@ -1,0 +1,11 @@
+package ar.com.intrale.strings.runtime
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+
+/**
+ * Stub: por ahora "default".
+ * Más adelante lo conectamos a BuildKonfig o a tu propiedad -PbrandId.
+ */
+@Composable
+fun currentBrand(): String = remember { "default" }

--- a/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/runtime/LocaleResolver.kt
+++ b/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/runtime/LocaleResolver.kt
@@ -1,0 +1,11 @@
+package ar.com.intrale.strings.runtime
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+
+/**
+ * Muy simple: devolvemos "es" por ahora.
+ * Luego si querés, hacé expect/actual para leer idioma real por plataforma.
+ */
+@Composable
+fun currentLang(): String = remember { "es" }

--- a/app/composeApp/src/commonMain/kotlin/ui/App.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/App.kt
@@ -21,7 +21,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.navigation.compose.rememberNavController
-import org.jetbrains.compose.resources.StringResource
 import org.kodein.di.instance
 import org.kodein.log.LoggerFactory
 import org.kodein.log.newLogger
@@ -31,24 +30,20 @@ import ui.rs.back_button
 import ui.th.IntraleTheme
 import ui.util.RES_ERROR_PREFIX
 import ui.util.fb
+import ui.sc.shared.ScreenTitle
 import ui.util.resString
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AppBar(
-    title: StringResource,
+    title: ScreenTitle,
     canNavigateBack: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     TopAppBar(
         title = {
-            Text(
-                resString(
-                    composeId = title,
-                    fallbackAsciiSafe = RES_ERROR_PREFIX + fb("Pantalla sin titulo"),
-                )
-            )
+            Text(title.resolve())
         },
         colors = TopAppBarDefaults.mediumTopAppBarColors(
             containerColor = MaterialTheme.colorScheme.primaryContainer

--- a/app/composeApp/src/commonMain/kotlin/ui/cp/inputs/TextField.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/cp/inputs/TextField.kt
@@ -47,8 +47,6 @@ fun TextField(
     supportingText: (@Composable () -> Unit)? = null,
     enabled: Boolean = true,
 ) {
-    var isVisible by remember { mutableStateOf(!visualTransformation) }
-
     val labelString = resString(
         composeId = label,
         fallbackAsciiSafe = RES_ERROR_PREFIX + fb("Etiqueta de campo"),
@@ -67,6 +65,89 @@ fun TextField(
         composeId = ui.rs.Res.string.text_field_hide_password,
         fallbackAsciiSafe = RES_ERROR_PREFIX + fb("Ocultar contrasena"),
     )
+
+    TextFieldContent(
+        labelString = labelString,
+        value = value,
+        state = state,
+        visualTransformation = visualTransformation,
+        onValueChange = onValueChange,
+        modifier = modifier,
+        leadingIcon = leadingIcon,
+        keyboardOptions = keyboardOptions,
+        keyboardActions = keyboardActions,
+        placeholderString = placeholderString,
+        supportingText = supportingText,
+        enabled = enabled,
+        showPasswordText = showPassword,
+        hidePasswordText = hidePassword,
+    )
+}
+
+@OptIn(ExperimentalResourceApi::class)
+@Composable
+fun TextField(
+    labelText: String,
+    value: String,
+    state: MutableState<InputState>,
+    visualTransformation: Boolean = false,
+    onValueChange: (value: String) -> Unit = {},
+    modifier: Modifier = Modifier,
+    leadingIcon: (@Composable () -> Unit)? = null,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
+    placeholderText: String? = null,
+    supportingText: (@Composable () -> Unit)? = null,
+    enabled: Boolean = true,
+    showPasswordText: String? = null,
+    hidePasswordText: String? = null,
+) {
+    val showPassword = showPasswordText ?: resString(
+        composeId = ui.rs.Res.string.text_field_show_password,
+        fallbackAsciiSafe = RES_ERROR_PREFIX + fb("Mostrar contrasena"),
+    )
+    val hidePassword = hidePasswordText ?: resString(
+        composeId = ui.rs.Res.string.text_field_hide_password,
+        fallbackAsciiSafe = RES_ERROR_PREFIX + fb("Ocultar contrasena"),
+    )
+
+    TextFieldContent(
+        labelString = labelText,
+        value = value,
+        state = state,
+        visualTransformation = visualTransformation,
+        onValueChange = onValueChange,
+        modifier = modifier,
+        leadingIcon = leadingIcon,
+        keyboardOptions = keyboardOptions,
+        keyboardActions = keyboardActions,
+        placeholderString = placeholderText,
+        supportingText = supportingText,
+        enabled = enabled,
+        showPasswordText = showPassword,
+        hidePasswordText = hidePassword,
+    )
+}
+
+@Composable
+private fun TextFieldContent(
+    labelString: String,
+    value: String,
+    state: MutableState<InputState>,
+    visualTransformation: Boolean,
+    onValueChange: (value: String) -> Unit,
+    modifier: Modifier,
+    leadingIcon: (@Composable () -> Unit)?,
+    keyboardOptions: KeyboardOptions,
+    keyboardActions: KeyboardActions,
+    placeholderString: String?,
+    supportingText: (@Composable () -> Unit)?,
+    enabled: Boolean,
+    showPasswordText: String,
+    hidePasswordText: String,
+) {
+    var isVisible by remember { mutableStateOf(!visualTransformation) }
+
     val errorMessage = state.value.details.takeIf { !state.value.isValid }
 
     val fieldModifier = if (errorMessage != null) {
@@ -86,7 +167,7 @@ fun TextField(
                 {
                     IconButton(onClick = { isVisible = !isVisible }) {
                         val icon = if (isVisible) Icons.Outlined.VisibilityOff else Icons.Outlined.Visibility
-                        val description = if (isVisible) hidePassword else showPassword
+                        val description = if (isVisible) hidePasswordText else showPasswordText
                         Icon(imageVector = icon, contentDescription = description)
                     }
                 }

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/auth/Login.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/auth/Login.kt
@@ -37,53 +37,26 @@ import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.lifecycle.viewmodel.compose.viewModel
+import ar.com.intrale.strings.Txt
+import ar.com.intrale.strings.model.MessageKey
 import asdo.auth.DoLoginException
-import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.kodein.log.LoggerFactory
 import org.kodein.log.newLogger
 import ui.cp.buttons.IntralePrimaryButton
 import ui.cp.inputs.TextField
-import ui.rs.Res
-import ui.rs.confirm_password_recovery
-import ui.rs.error_credentials
-import ui.rs.family_name
-import ui.rs.login
-import ui.rs.login_change_password_description
-import ui.rs.login_change_password_required
-import ui.rs.login_change_password_title
-import ui.rs.login_email_placeholder
-import ui.rs.login_family_name_placeholder
-import ui.rs.login_generic_error
-import ui.rs.login_name_placeholder
-import ui.rs.login_new_password_placeholder
-import ui.rs.login_password_icon_content_description
-import ui.rs.login_password_placeholder
-import ui.rs.login_subtitle
-import ui.rs.login_title
-import ui.rs.login_user_icon_content_description
-import ui.rs.name
-import ui.rs.new_password
-import ui.rs.password
-import ui.rs.password_recovery
-import ui.rs.register_business
-import ui.rs.signup
-import ui.rs.signup_delivery
-import ui.rs.username
 import ui.sc.business.DASHBOARD_PATH
 import ui.sc.business.REGISTER_NEW_BUSINESS_PATH
 import ui.sc.shared.Screen
+import ui.sc.shared.ScreenTitle
 import ui.sc.shared.callService
 import ui.sc.signup.SELECT_SIGNUP_PROFILE_PATH
 import ui.sc.signup.SIGNUP_DELIVERY_PATH
 import ui.th.elevations
 import ui.th.spacing
-import ui.util.RES_ERROR_PREFIX
-import ui.util.fb
-import ui.util.resString
 
 const val LOGIN_PATH = "/login"
 
-class Login : Screen(LOGIN_PATH, Res.string.login) {
+class Login : Screen(LOGIN_PATH, ScreenTitle.Message(MessageKey.login_title)) {
 
     private val logger = LoggerFactory.default.newLogger<Login>()
 
@@ -92,7 +65,6 @@ class Login : Screen(LOGIN_PATH, Res.string.login) {
         screenImplementation()
     }
 
-    @OptIn(ExperimentalResourceApi::class)
     @Composable
     private fun screenImplementation(viewModel: LoginViewModel = viewModel { LoginViewModel() }) {
         val snackbarHostState = remember { SnackbarHostState() }
@@ -100,66 +72,33 @@ class Login : Screen(LOGIN_PATH, Res.string.login) {
         val focusManager = LocalFocusManager.current
         val scrollState = rememberScrollState()
 
-        val loginText = resString(
-            composeId = Res.string.login,
-            fallbackAsciiSafe = RES_ERROR_PREFIX + fb("Iniciar sesion"),
-        )
-        val errorCredentials = resString(
-            composeId = Res.string.error_credentials,
-            fallbackAsciiSafe = RES_ERROR_PREFIX + fb("Credenciales invalidas"),
-        )
-        val changePasswordMessage = resString(
-            composeId = Res.string.login_change_password_required,
-            fallbackAsciiSafe = RES_ERROR_PREFIX + fb("Cambio de contrasena requerido"),
-        )
-        val genericError = resString(
-            composeId = Res.string.login_generic_error,
-            fallbackAsciiSafe = RES_ERROR_PREFIX + fb("Error inesperado en login"),
-        )
-        val loginTitle = resString(
-            composeId = Res.string.login_title,
-            fallbackAsciiSafe = RES_ERROR_PREFIX + fb("Titulo de ingreso"),
-        )
-        val loginSubtitle = resString(
-            composeId = Res.string.login_subtitle,
-            fallbackAsciiSafe = RES_ERROR_PREFIX + fb("Descripcion de ingreso"),
-        )
-        val userIconDescription = resString(
-            composeId = Res.string.login_user_icon_content_description,
-            fallbackAsciiSafe = RES_ERROR_PREFIX + fb("Icono usuario"),
-        )
-        val passwordIconDescription = resString(
-            composeId = Res.string.login_password_icon_content_description,
-            fallbackAsciiSafe = RES_ERROR_PREFIX + fb("Icono contrasena"),
-        )
-        val changePasswordTitle = resString(
-            composeId = Res.string.login_change_password_title,
-            fallbackAsciiSafe = RES_ERROR_PREFIX + fb("Actualizar contrasena"),
-        )
-        val changePasswordDescription = resString(
-            composeId = Res.string.login_change_password_description,
-            fallbackAsciiSafe = RES_ERROR_PREFIX + fb("Instrucciones para actualizar"),
-        )
-        val signupLinkLabel = resString(
-            composeId = Res.string.signup,
-            fallbackAsciiSafe = RES_ERROR_PREFIX + fb("Crear cuenta"),
-        )
-        val registerBusinessLinkLabel = resString(
-            composeId = Res.string.register_business,
-            fallbackAsciiSafe = RES_ERROR_PREFIX + fb("Registrar negocio"),
-        )
-        val signupDeliveryLinkLabel = resString(
-            composeId = Res.string.signup_delivery,
-            fallbackAsciiSafe = RES_ERROR_PREFIX + fb("Registrar repartidor"),
-        )
-        val passwordRecoveryLinkLabel = resString(
-            composeId = Res.string.password_recovery,
-            fallbackAsciiSafe = RES_ERROR_PREFIX + fb("Recuperar contrasena"),
-        )
-        val confirmRecoveryLinkLabel = resString(
-            composeId = Res.string.confirm_password_recovery,
-            fallbackAsciiSafe = RES_ERROR_PREFIX + fb("Confirmar recuperacion"),
-        )
+        val loginText = Txt(MessageKey.login_button)
+        val errorCredentials = Txt(MessageKey.login_error_credentials)
+        val changePasswordMessage = Txt(MessageKey.login_change_password_required)
+        val genericError = Txt(MessageKey.login_generic_error)
+        val loginTitle = Txt(MessageKey.login_title)
+        val loginSubtitle = Txt(MessageKey.login_subtitle)
+        val userIconDescription = Txt(MessageKey.login_user_icon_content_description)
+        val passwordIconDescription = Txt(MessageKey.login_password_icon_content_description)
+        val changePasswordTitle = Txt(MessageKey.login_change_password_title)
+        val changePasswordDescription = Txt(MessageKey.login_change_password_description)
+        val signupLinkLabel = Txt(MessageKey.signup)
+        val registerBusinessLinkLabel = Txt(MessageKey.register_business)
+        val signupDeliveryLinkLabel = Txt(MessageKey.signup_delivery)
+        val passwordRecoveryLinkLabel = Txt(MessageKey.password_recovery)
+        val confirmRecoveryLinkLabel = Txt(MessageKey.confirm_password_recovery)
+        val usernameLabel = Txt(MessageKey.username)
+        val usernamePlaceholder = Txt(MessageKey.login_email_placeholder)
+        val passwordLabel = Txt(MessageKey.password)
+        val passwordPlaceholder = Txt(MessageKey.login_password_placeholder)
+        val newPasswordLabel = Txt(MessageKey.new_password)
+        val newPasswordPlaceholder = Txt(MessageKey.login_new_password_placeholder)
+        val nameLabel = Txt(MessageKey.login_name_label)
+        val namePlaceholder = Txt(MessageKey.login_name_placeholder)
+        val familyNameLabel = Txt(MessageKey.login_family_name_label)
+        val familyNamePlaceholder = Txt(MessageKey.login_family_name_placeholder)
+        val showPasswordText = Txt(MessageKey.text_field_show_password)
+        val hidePasswordText = Txt(MessageKey.text_field_hide_password)
 
         val loginErrorHandler: suspend (Throwable) -> Unit = { error ->
             when (error) {
@@ -256,7 +195,7 @@ class Login : Screen(LOGIN_PATH, Res.string.login) {
                         verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.x2)
                     ) {
                         TextField(
-                            label = Res.string.username,
+                            labelText = usernameLabel,
                             value = viewModel.state.user,
                             state = viewModel.inputsStates[LoginViewModel.LoginUIState::user.name]!!,
                             onValueChange = viewModel::onUserChange,
@@ -272,12 +211,12 @@ class Login : Screen(LOGIN_PATH, Res.string.login) {
                                 imeAction = ImeAction.Next
                             ),
                             keyboardActions = KeyboardActions(onNext = { focusManager.moveFocus(FocusDirection.Down) }),
-                            placeholder = Res.string.login_email_placeholder,
+                            placeholderText = usernamePlaceholder,
                             enabled = !viewModel.loading
                         )
 
                         TextField(
-                            label = Res.string.password,
+                            labelText = passwordLabel,
                             value = viewModel.state.password,
                             state = viewModel.inputsStates[LoginViewModel.LoginUIState::password.name]!!,
                             visualTransformation = true,
@@ -298,71 +237,75 @@ class Login : Screen(LOGIN_PATH, Res.string.login) {
                             } else {
                                 KeyboardActions(onDone = { submitLogin() })
                             },
-                            placeholder = Res.string.login_password_placeholder,
-                            enabled = !viewModel.loading
+                            placeholderText = passwordPlaceholder,
+                            enabled = !viewModel.loading,
+                            showPasswordText = showPasswordText,
+                            hidePasswordText = hidePasswordText
                         )
 
                         AnimatedVisibility(visible = viewModel.changePasswordRequired) {
                             Column(
                                 modifier = Modifier.fillMaxWidth(),
                                 verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.x2)
-                            ) {
-                                Divider()
-                                Text(
-                                    text = changePasswordTitle,
-                                    style = MaterialTheme.typography.titleLarge
+                                ) {
+                                    Divider()
+                                    Text(
+                                        text = changePasswordTitle,
+                                        style = MaterialTheme.typography.titleLarge
                                 )
                                 Text(
                                     text = changePasswordDescription,
                                     style = MaterialTheme.typography.bodyMedium,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                                )
-                                TextField(
-                                    label = Res.string.new_password,
-                                    value = viewModel.state.newPassword,
-                                    state = viewModel.inputsStates[LoginViewModel.LoginUIState::newPassword.name]!!,
-                                    visualTransformation = true,
-                                    onValueChange = viewModel::onNewPasswordChange,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                    TextField(
+                                        labelText = newPasswordLabel,
+                                        value = viewModel.state.newPassword,
+                                        state = viewModel.inputsStates[LoginViewModel.LoginUIState::newPassword.name]!!,
+                                        visualTransformation = true,
+                                        onValueChange = viewModel::onNewPasswordChange,
                                     modifier = Modifier.fillMaxWidth(),
                                     keyboardOptions = KeyboardOptions.Default.copy(
                                         keyboardType = KeyboardType.Password,
                                         imeAction = ImeAction.Next
                                     ),
-                                    keyboardActions = KeyboardActions(onNext = { focusManager.moveFocus(FocusDirection.Down) }),
-                                    placeholder = Res.string.login_new_password_placeholder,
-                                    enabled = !viewModel.loading
-                                )
-                                TextField(
-                                    label = Res.string.name,
-                                    value = viewModel.state.name,
-                                    state = viewModel.inputsStates[LoginViewModel.LoginUIState::name.name]!!,
-                                    onValueChange = viewModel::onNameChange,
-                                    modifier = Modifier.fillMaxWidth(),
+                                        keyboardActions = KeyboardActions(onNext = { focusManager.moveFocus(FocusDirection.Down) }),
+                                        placeholderText = newPasswordPlaceholder,
+                                        enabled = !viewModel.loading,
+                                        showPasswordText = showPasswordText,
+                                        hidePasswordText = hidePasswordText
+                                    )
+                                    TextField(
+                                        labelText = nameLabel,
+                                        value = viewModel.state.name,
+                                        state = viewModel.inputsStates[LoginViewModel.LoginUIState::name.name]!!,
+                                        onValueChange = viewModel::onNameChange,
+                                        modifier = Modifier.fillMaxWidth(),
                                     keyboardOptions = KeyboardOptions.Default.copy(
                                         capitalization = KeyboardCapitalization.Words,
                                         imeAction = ImeAction.Next
-                                    ),
-                                    keyboardActions = KeyboardActions(onNext = { focusManager.moveFocus(FocusDirection.Down) }),
-                                    placeholder = Res.string.login_name_placeholder,
-                                    enabled = !viewModel.loading
-                                )
-                                TextField(
-                                    label = Res.string.family_name,
-                                    value = viewModel.state.familyName,
-                                    state = viewModel.inputsStates[LoginViewModel.LoginUIState::familyName.name]!!,
-                                    onValueChange = viewModel::onFamilyNameChange,
+                                        ),
+                                        keyboardActions = KeyboardActions(onNext = { focusManager.moveFocus(FocusDirection.Down) }),
+                                        placeholderText = namePlaceholder,
+                                        enabled = !viewModel.loading
+                                    )
+                                    TextField(
+                                        labelText = familyNameLabel,
+                                        value = viewModel.state.familyName,
+                                        state = viewModel.inputsStates[LoginViewModel.LoginUIState::familyName.name]!!,
+                                        onValueChange = viewModel::onFamilyNameChange,
                                     modifier = Modifier.fillMaxWidth(),
                                     keyboardOptions = KeyboardOptions.Default.copy(
                                         capitalization = KeyboardCapitalization.Words,
                                         imeAction = ImeAction.Done
-                                    ),
-                                    keyboardActions = KeyboardActions(onDone = { submitLogin() }),
-                                    placeholder = Res.string.login_family_name_placeholder,
-                                    enabled = !viewModel.loading
-                                )
+                                        ),
+                                        keyboardActions = KeyboardActions(onDone = { submitLogin() }),
+                                        placeholderText = familyNamePlaceholder,
+                                        enabled = !viewModel.loading
+                                    )
+                                }
                             }
                         }
-                    }
                 }
 
                 IntralePrimaryButton(

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/shared/Screen.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/shared/Screen.kt
@@ -1,11 +1,18 @@
 package ui.sc.shared
 
 import androidx.compose.runtime.Composable
+import ar.com.intrale.strings.Txt
+import ar.com.intrale.strings.model.MessageKey
 import org.jetbrains.compose.resources.StringResource
 import org.kodein.log.LoggerFactory
 import org.kodein.log.newLogger
+import ui.util.RES_ERROR_PREFIX
+import ui.util.fb
+import ui.util.resString
 
-abstract class Screen (val route: String, val title: StringResource) {
+abstract class Screen(val route: String, val title: ScreenTitle) {
+
+    constructor(route: String, title: StringResource) : this(route, ScreenTitle.Resource(title))
 
     protected val screenLogger = LoggerFactory.default.newLogger<Screen>()
 
@@ -34,4 +41,25 @@ abstract class Screen (val route: String, val title: StringResource) {
     @Composable
     abstract fun screen()
 
+}
+
+sealed interface ScreenTitle {
+    @Composable
+    fun resolve(): String
+
+    data class Resource(private val value: StringResource) : ScreenTitle {
+        @Composable
+        override fun resolve(): String = resString(
+            composeId = value,
+            fallbackAsciiSafe = RES_ERROR_PREFIX + fb("Pantalla sin titulo"),
+        )
+    }
+
+    data class Message(
+        private val key: MessageKey,
+        private val params: Map<String, String> = emptyMap(),
+    ) : ScreenTitle {
+        @Composable
+        override fun resolve(): String = Txt(key, params)
+    }
 }


### PR DESCRIPTION
## Resumen
- migra la pantalla de Login para consumir textos mediante `Txt(MessageKey)` y elimina dependencias de `Res.string`
- amplía `MessageKey` y los catálogos ES/EN con todas las claves usadas por Login
- agrega `ScreenTitle` para resolver títulos via Txt y permite `TextField` con textos pre-resueltos

## Pruebas
- ./gradlew :app:composeApp:forbidDirectComposeStringResource --console=plain
- ./gradlew :app:composeApp:build -PbrandId=intrale --console=plain

Closes #477

------
https://chatgpt.com/codex/tasks/task_e_69013e10e55483258ad78f96878e290d