### PR TITLE
[auto] Migrar App.kt a Txt + MessageKey (Closes #496)

### DIFF
--- a/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/catalog/DefaultCatalog_en.kt
+++ b/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/catalog/DefaultCatalog_en.kt
@@ -4,6 +4,9 @@ import ar.com.intrale.strings.model.MessageKey
 
 internal val DefaultCatalog_en: Map<MessageKey, String> = mapOf(
     MessageKey.app_name to "Intrale",
+    MessageKey.app_back_button to "Go back",
+    MessageKey.app_home_icon_content_description to "Go to home",
+    MessageKey.app_missing_title to "Screen without title",
     MessageKey.confirm_password_recovery to "Confirm recovery",
     MessageKey.error_generic to "Something went wrong. Please try again.",
     MessageKey.family_name to "Last name",

--- a/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/catalog/DefaultCatalog_es.kt
+++ b/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/catalog/DefaultCatalog_es.kt
@@ -4,6 +4,9 @@ import ar.com.intrale.strings.model.MessageKey
 
 internal val DefaultCatalog_es: Map<MessageKey, String> = mapOf(
     MessageKey.app_name to "Intrale",
+    MessageKey.app_back_button to "Volver",
+    MessageKey.app_home_icon_content_description to "Ir al inicio",
+    MessageKey.app_missing_title to "Pantalla sin título",
     MessageKey.confirm_password_recovery to "Confirmar recuperación",
     MessageKey.error_generic to "Ocurrió un error. Intentá nuevamente.",
     MessageKey.family_name to "Apellido",

--- a/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/model/MessageKey.kt
+++ b/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/model/MessageKey.kt
@@ -7,6 +7,9 @@ package ar.com.intrale.strings.model
 @Suppress("EnumEntryName")
 enum class MessageKey {
     app_name,
+    app_back_button,
+    app_home_icon_content_description,
+    app_missing_title,
     confirm_password_recovery,
     error_generic,
     family_name,

--- a/app/composeApp/src/commonMain/kotlin/ui/App.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/App.kt
@@ -27,12 +27,8 @@ import org.kodein.log.newLogger
 import ar.com.intrale.strings.Txt
 import ui.sc.shared.Screen
 import ui.ro.Router
-import ui.rs.Res
-import ui.rs.back_button
 import ui.th.IntraleTheme
-import ui.util.RES_ERROR_PREFIX
-import ui.util.fb
-import ui.util.resString
+import ar.com.intrale.strings.model.MessageKey
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -42,14 +38,7 @@ fun AppBar(
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val titleText = screen.messageTitle?.let { Txt(it) }
-        ?: screen.title?.let {
-            resString(
-                composeId = it,
-                fallbackAsciiSafe = RES_ERROR_PREFIX + fb("Pantalla sin titulo"),
-            )
-        }
-        ?: RES_ERROR_PREFIX + fb("Pantalla sin titulo")
+    val titleText = screen.titleText()
 
     TopAppBar(
         title = {
@@ -66,19 +55,13 @@ fun AppBar(
                 IconButton(onClick = onClick) {
                     Icon(
                         imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                        contentDescription = resString(
-                            composeId = Res.string.back_button,
-                            fallbackAsciiSafe = RES_ERROR_PREFIX + fb("Accion volver"),
-                        )
+                        contentDescription = Txt(MessageKey.app_back_button)
                     )
                 }
             } else {
                 Icon(
                     imageVector = Icons.Default.Home,
-                    contentDescription = resString(
-                        composeId = Res.string.back_button,
-                        fallbackAsciiSafe = RES_ERROR_PREFIX + fb("Accion volver"),
-                    )
+                    contentDescription = Txt(MessageKey.app_home_icon_content_description)
                 )
             }
         }

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/shared/Screen.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/shared/Screen.kt
@@ -1,10 +1,14 @@
 package ui.sc.shared
 
 import androidx.compose.runtime.Composable
+import ar.com.intrale.strings.Txt
 import ar.com.intrale.strings.model.MessageKey
 import org.jetbrains.compose.resources.StringResource
 import org.kodein.log.LoggerFactory
 import org.kodein.log.newLogger
+import ui.util.RES_ERROR_PREFIX
+import ui.util.fb
+import ui.util.resString
 
 abstract class Screen(
     val route: String,
@@ -40,4 +44,15 @@ abstract class Screen(
     @Composable
     abstract fun screen()
 
+    @Composable
+    open fun titleText(): String {
+        messageTitle?.let { return Txt(it) }
+        title?.let {
+            return resString(
+                composeId = it,
+                fallbackAsciiSafe = RES_ERROR_PREFIX + fb("Pantalla sin titulo"),
+            )
+        }
+        return Txt(MessageKey.app_missing_title)
+    }
 }


### PR DESCRIPTION
## Resumen
- Reemplazar el uso de `resString` en `AppBar` por `Txt` y nuevas claves `MessageKey`.
- Agregar traducciones en los catálogos `DefaultCatalog_es` y `DefaultCatalog_en` para los textos globales de navegación.
- Exponer `Screen.titleText()` para resolver títulos vía `Txt` o recursos legados sin depender de `App.kt`.

## Checklist
- [x] Base del PR en `main`
- [x] Título con formato `[auto] Migrar App.kt a Txt + MessageKey (Closes #496)`.
- [x] Cuerpo incluye `Closes #496` y, si aplica, `target:main`.
- [x] PR asignado a @leitolarreta.

Closes #496

## Evidencias
- Tests:
  - No se ejecutaron (la tarea `:app:composeApp:compileKotlinJvm` no está disponible).
- Notas:
  - Se detuvo `:app:composeApp:build` para evitar descargas de SDK innecesarias.


------
https://chatgpt.com/codex/tasks/task_e_690381bf1398832596942ab9792417d7