### PR TITLE
[auto] Error de compilacion en RegisterBusinessViewModel (Closes #530)

### DIFF
--- a/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/MessageResolver.kt
+++ b/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/MessageResolver.kt
@@ -1,0 +1,44 @@
+package ar.com.intrale.strings
+
+import ar.com.intrale.strings.catalog.DefaultCatalog_en
+import ar.com.intrale.strings.catalog.DefaultCatalog_es
+import ar.com.intrale.strings.model.MessageKey
+
+private fun defaultCatalogFor(lang: String): Map<MessageKey, String> = when (lang) {
+    "es" -> DefaultCatalog_es
+    "en" -> DefaultCatalog_en
+    else -> DefaultCatalog_en
+}
+
+private fun brandCatalogFor(brand: String?, lang: String): Map<MessageKey, String> {
+    // Todavía no tenemos catálogos específicos por marca.
+    // Dejamos el hook armado para futuras extensiones.
+    return emptyMap()
+}
+
+private fun resolveTemplate(
+    key: MessageKey,
+    lang: String,
+    brand: String?
+): String {
+    val brandCatalog = brandCatalogFor(brand, lang)
+    val defaultCatalog = defaultCatalogFor(lang)
+    return brandCatalog[key] ?: defaultCatalog[key] ?: key.name
+}
+
+private fun interpolate(
+    template: String,
+    params: Map<String, String>
+): String {
+    if (params.isEmpty()) return template
+    return params.entries.fold(template) { acc, (param, value) ->
+        acc.replace("{$param}", value)
+    }
+}
+
+fun resolveMessage(
+    key: MessageKey,
+    params: Map<String, String> = emptyMap(),
+    lang: String = "es",
+    brand: String? = "default"
+): String = interpolate(resolveTemplate(key, lang, brand), params)

--- a/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/Strings.kt
+++ b/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/Strings.kt
@@ -1,8 +1,6 @@
 package ar.com.intrale.strings
 
 import androidx.compose.runtime.Composable
-import ar.com.intrale.strings.catalog.DefaultCatalog_en
-import ar.com.intrale.strings.catalog.DefaultCatalog_es
 import ar.com.intrale.strings.model.MessageKey
 import ar.com.intrale.strings.runtime.currentBrand
 import ar.com.intrale.strings.runtime.currentLang
@@ -22,27 +20,7 @@ fun Txt(
 ): String {
     val lang = currentLang()
     val brand = currentBrand()
-
-    // 1) Catálogo default por idioma (expandible)
-    val defaultCatalog = when (lang) {
-        "es" -> DefaultCatalog_es
-        "en" -> DefaultCatalog_en
-        else -> DefaultCatalog_en
-    }
-
-    // 2) Catálogo por brand+idioma (a futuro)
-    val brandCatalog: Map<MessageKey, String> = emptyMap()
-
-    val template = brandCatalog[key] ?: defaultCatalog[key] ?: key.name
-
-    val interpolated = if (params.isEmpty()) {
-        template
-    } else {
-        // Interpolación súper simple: reemplaza {param}
-        params.entries.fold(template) { acc, (k, v) ->
-            acc.replace("{$k}", v)
-        }
-    }
+    val interpolated = resolveMessage(key, params, lang, brand)
 
     // Usamos el wrapper multiplataforma. No hay llamada composable adentro (va por fallback).
     return resString(

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/business/RegisterBusinessViewModel.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/business/RegisterBusinessViewModel.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import ar.com.intrale.strings.model.MessageKey
+import ar.com.intrale.strings.resolveMessage
 import io.konform.validation.Validation
 import io.konform.validation.jsonschema.pattern
 import org.kodein.di.instance
@@ -31,14 +32,14 @@ class RegisterBusinessViewModel : ViewModel() {
     init {
         validation = Validation<UIState> {
             UIState::name required {
-                hint(MessageKey.form_error_required.name)
+                hint(resolveMessage(MessageKey.form_error_required))
             }
             UIState::email required {
-                hint(MessageKey.form_error_required.name)
-                pattern(".+@.+\\..+") hint MessageKey.form_error_invalid_email.name
+                hint(resolveMessage(MessageKey.form_error_required))
+                pattern(".+@.+\\..+") hint resolveMessage(MessageKey.form_error_invalid_email)
             }
             UIState::description required {
-                hint(MessageKey.form_error_required.name)
+                hint(resolveMessage(MessageKey.form_error_required))
             }
         } as Validation<Any>
         initInputState()

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/signup/RegisterSalerViewModel.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/signup/RegisterSalerViewModel.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import ar.com.intrale.strings.model.MessageKey
+import ar.com.intrale.strings.resolveMessage
 import io.konform.validation.Validation
 import io.konform.validation.jsonschema.pattern
 import org.kodein.di.instance
@@ -28,7 +29,7 @@ class RegisterSalerViewModel : ViewModel() {
     init {
         validation = Validation<RegisterSalerUIState> {
             RegisterSalerUIState::email required {
-                pattern(".+@.+\\..+") hint MessageKey.register_saler_email_invalid.name
+                pattern(".+@.+\\..+") hint resolveMessage(MessageKey.register_saler_email_invalid)
             }
         } as Validation<Any>
         initInputState()


### PR DESCRIPTION
## Resumen
- Agrego un resolvedor de mensajes para obtener los textos de `MessageKey` fuera de Compose.
- Reutilizo el resolvedor desde `Txt` para evitar lógica duplicada.
- Actualizo las validaciones de RegisterBusiness y RegisterSaler para usar los mensajes resueltos.

Closes #530

## Checklist
- [x] Base del PR en `main`
- [x] Título con formato `[auto] ... (Closes #<n>)`.
- [x] Cuerpo incluye `Closes #<n>` y, si aplica, `target:main`.
- [x] PR asignado a @leitolarreta.

## Evidencias
- Tests: `./gradlew :app:composeApp:compileKotlinMetadata --no-daemon --console=plain`
- Notas:


------
https://chatgpt.com/codex/tasks/task_e_6903c843d6c083259681bce5568badae