### PR TITLE
[auto] [strings] Crear script tools/verify_no_legacy_strings.sh que bloquee usos legacy (Closes #547)

### DIFF
--- a/tools/verify_no_legacy_strings.sh
+++ b/tools/verify_no_legacy_strings.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+INCLUDE_DIRS=(
+  "$ROOT_DIR"
+)
+
+EXCLUDES=(
+  ".git"
+  "build"
+  ".gradle"
+  "node_modules"
+  "ios/"
+  "wasm/"
+  "desktop/"
+)
+
+PATTERNS=(
+  "R\\.string\\."
+  "stringResource\\("
+  "\\bgetString\\("
+  "Resources\\.getString\\("
+  "LocalContext\\.current\\.getString\\("
+)
+
+found=0
+
+exclude_expr=()
+for ex in "${EXCLUDES[@]}"; do
+  exclude_expr+=( -not -path "*/$ex/*" )
+done
+
+for dir in "${INCLUDE_DIRS[@]}"; do
+  for pat in "${PATTERNS[@]}"; do
+    matches=$(find "$dir" -type f -name '*.kt' "${exclude_expr[@]}" -print0 \
+      | xargs -0 grep -nE "$pat" || true)
+    if [[ -n "$matches" ]]; then
+      echo "❌ Encontrado patrón prohibido: /$pat/"
+      echo "$matches"
+      echo
+      found=1
+    fi
+  done
+done
+
+if [[ "$found" -ne 0 ]]; then
+  cat <<EOF2
+🚫 Se detectó uso de String Resources legacy.
+Solución: migrar a Txt(MessageKey, params).
+
+Sugerencias:
+- stringResource(R.string.foo_title)  →  Txt(MessageKey.Foo_Title)
+- context.getString(R.string.bar, x)  →  Txt(MessageKey.Bar, mapOf("x" to x))
+EOF2
+  exit 1
+fi
+
+echo "✅ Sin uso de String Resources legacy."


### PR DESCRIPTION
## Summary
- add `tools/verify_no_legacy_strings.sh` to scan Kotlin sources for legacy string resource APIs
- ignore generated and platform-specific folders so only relevant source files are inspected
- report each forbidden match with remediation tips and exit with a non-zero status when violations are detected

## Testing
- `./tools/verify_no_legacy_strings.sh` *(fails, as expected, while the codebase still contains legacy usages)*

------
https://chatgpt.com/codex/tasks/task_e_6904e23eeb488325b62923eac7ee4220