### PR TITLE
[auto] [strings] Integrar script al build y fallar check (Closes #548)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.api.GradleException
+
 plugins {
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.ktor) apply false
@@ -12,4 +14,30 @@ plugins {
     alias(libs.plugins.composeMultiplatform) apply false
     alias(libs.plugins.composeCompiler) apply false
     alias(libs.plugins.kotlinMultiplatform) apply false
+}
+
+tasks.register("verifyNoLegacyStrings") {
+    group = "verification"
+    description = "Falla si hay usos legacy de string resources"
+    doLast {
+        val script = project.rootProject.file("tools/verify_no_legacy_strings.sh")
+        if (!script.exists()) {
+            throw GradleException("Falta tools/verify_no_legacy_strings.sh")
+        }
+        if (!script.canExecute()) {
+            script.setExecutable(true)
+        }
+        val proc = ProcessBuilder(script.absolutePath)
+            .directory(project.rootDir)
+            .inheritIO()
+            .start()
+        val exit = proc.waitFor()
+        if (exit != 0) {
+            throw GradleException("Uso legacy de strings detectado (ver log).")
+        }
+    }
+}
+
+tasks.matching { it.name == "check" }.configureEach {
+    dependsOn("verifyNoLegacyStrings")
 }


### PR DESCRIPTION
## Resumen
- Registra la tarea `verifyNoLegacyStrings` en el `build.gradle.kts` raíz.
- Agrega la tarea como dependencia de `check` para bloquear builds con strings legacy.

## Checklist
- [x] Base del PR en `main`
- [x] Título con formato `[auto] ... (Closes #<n>)`.
- [x] Cuerpo incluye `Closes #<n>` y, si aplica, `target:main`.
- [x] PR asignado a @leitolarreta.

## Evidencias
- Tests:
  - `./gradlew --no-daemon --console=plain verifyNoLegacyStrings` *(falla por strings legacy existentes)*
- Notas:
  - Closes #548


------
https://chatgpt.com/codex/tasks/task_e_69050dcec3f48325a90df441d8940d79