### PR TITLE
[auto] Ajustar verifyNoLegacyStrings: excluir tools/** y corregir logging de líneas (Closes #567)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,6 +39,8 @@ tasks.register("verifyNoLegacyStrings") {
             "ios",
             "wasm",
             "desktop",
+            "tools",
+            "forbidden-strings-processor",
         )
         val excludedTestSegments = setOf(
             "test",
@@ -117,7 +119,7 @@ tasks.register("verifyNoLegacyStrings") {
                     logger.error("")
                     logger.error(path)
                     entries.forEach { match ->
-                        logger.error("  L${'$'}{match.line} (${match.pattern}): ${'$'}{match.snippet}")
+                        logger.error("  L${match.line} | ${match.pattern} | ${match.snippet}")
                     }
                 }
             logger.error("")


### PR DESCRIPTION
## Resumen
- excluir los directorios tooling (`tools/**` y `**/forbidden-strings-processor/**`) del escaneo de `verifyNoLegacyStrings`
- corregir el formato del log para interpolar línea, patrón y snippet detectado

Closes #567

## Checklist
- [x] Base del PR en `main`
- [x] Título con formato `[auto] ... (Closes #<n>)`.
- [x] Cuerpo incluye `Closes #<n>` y, si aplica, `target:main`.
- [x] PR asignado a @leitolarreta.

## Evidencias
- Tests:
  - `./gradlew verifyNoLegacyStrings`
- Notas:
  - El escaneo omite tooling pero conserva las exclusiones previas.


------
https://chatgpt.com/codex/tasks/task_e_690cb0ff1b0c832586c540034f87a533