### PR TITLE
[auto] BAPP-001 – Variante de build para app de negocio (APP_TYPE=BUSINESS) (Closes #665)

### DIFF
--- a/app/composeApp/build.gradle.kts
+++ b/app/composeApp/build.gradle.kts
@@ -21,9 +21,18 @@ plugins {
 }
 
 val business = providers.gradleProperty("business").orElse("intrale")
+val inferredAppType = providers.provider {
+    val taskNames = gradle.startParameter.taskNames
+    if (taskNames.any { it.contains("business", ignoreCase = true) }) {
+        "BUSINESS"
+    } else {
+        "CLIENT"
+    }
+}
+
 val appType = providers.gradleProperty("appType")
     .orElse(providers.environmentVariable("APP_TYPE"))
-    .orElse("CLIENT")
+    .orElse(inferredAppType)
     .map(String::uppercase)
 
 buildkonfig {
@@ -206,6 +215,14 @@ android {
             applicationIdSuffix = ".client"
             manifestPlaceholders += mapOf("appName" to appName)
             resValue("string", "app_name", appName)
+        }
+
+        create("business") {
+            dimension = "appType"
+            applicationIdSuffix = ".business"
+            val businessAppName = "Intrale Negocios"
+            manifestPlaceholders += mapOf("appName" to businessAppName)
+            resValue("string", "app_name", businessAppName)
         }
     }
 

--- a/app/composeApp/src/business/res/drawable/ic_intrale_business_background.xml
+++ b/app/composeApp/src/business/res/drawable/ic_intrale_business_background.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="#0F1F3D" />
+</shape>

--- a/app/composeApp/src/business/res/drawable/ic_intrale_business_foreground.xml
+++ b/app/composeApp/src/business/res/drawable/ic_intrale_business_foreground.xml
@@ -1,0 +1,41 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="1024"
+    android:viewportHeight="1024">
+
+    <path
+        android:pathData="M512 59.357 L120 738.321 L904 738.321 Z"
+        android:strokeWidth="84"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:fillColor="@android:color/transparent">
+        <aapt:attr name="android:strokeColor">
+            <gradient
+                android:type="linear"
+                android:startX="512"
+                android:startY="59.357"
+                android:endX="512"
+                android:endY="738.321">
+                <item android:offset="0" android:color="#FF00C853" />
+                <item android:offset="1" android:color="#FF009688" />
+            </gradient>
+        </aapt:attr>
+    </path>
+
+    <path
+        android:pathData="M512,384.983 L402,575.508 L622,575.508 Z">
+        <aapt:attr name="android:fillColor">
+            <gradient
+                android:type="linear"
+                android:startX="512"
+                android:startY="384.983"
+                android:endX="512"
+                android:endY="575.508">
+                <item android:offset="0" android:color="#FF00C853" />
+                <item android:offset="1" android:color="#FF009688" />
+            </gradient>
+        </aapt:attr>
+    </path>
+</vector>

--- a/app/composeApp/src/business/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/composeApp/src/business/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_intrale_business_background" />
+    <foreground android:drawable="@drawable/ic_intrale_business_foreground" />
+</adaptive-icon>

--- a/app/composeApp/src/business/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/composeApp/src/business/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_intrale_business_background" />
+    <foreground android:drawable="@drawable/ic_intrale_business_foreground" />
+</adaptive-icon>

--- a/app/composeApp/src/business/res/values/strings.xml
+++ b/app/composeApp/src/business/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">Intrale Negocios</string>
+</resources>

--- a/app/composeApp/src/commonMain/kotlin/DIManager.kt
+++ b/app/composeApp/src/commonMain/kotlin/DIManager.kt
@@ -78,6 +78,7 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
+import ar.com.intrale.appconfig.AppRuntimeConfig
 import org.kodein.di.DI
 import org.kodein.di.bindFactory
 import org.kodein.di.bindSingleton
@@ -172,7 +173,7 @@ class DIManager {
                 bindSingleton(tag = TWO_FACTOR_VERIFY) { TwoFactorVerifyScreen() }
 
                 bindSingleton (tag = SCREENS) {
-                    val isClientApp = BuildKonfig.APP_TYPE.equals("CLIENT", ignoreCase = true)
+                    val isClientApp = AppRuntimeConfig.isClient
 
                     arrayListOf<Screen>().apply {
                         if (isClientApp) {

--- a/app/composeApp/src/commonMain/kotlin/ar/com/intrale/appconfig/AppType.kt
+++ b/app/composeApp/src/commonMain/kotlin/ar/com/intrale/appconfig/AppType.kt
@@ -1,0 +1,28 @@
+package ar.com.intrale.appconfig
+
+import ar.com.intrale.BuildKonfig
+
+enum class AppType {
+    CLIENT,
+    BUSINESS,
+    UNKNOWN;
+
+    companion object {
+        fun fromValue(raw: String): AppType = when {
+            raw.equals(CLIENT.name, ignoreCase = true) -> CLIENT
+            raw.equals(BUSINESS.name, ignoreCase = true) -> BUSINESS
+            else -> UNKNOWN
+        }
+    }
+}
+
+object AppRuntimeConfig {
+    val appType: AppType
+        get() = AppType.fromValue(BuildKonfig.APP_TYPE)
+
+    val isClient: Boolean
+        get() = appType == AppType.CLIENT
+
+    val isBusiness: Boolean
+        get() = appType == AppType.BUSINESS
+}

--- a/app/composeApp/src/commonMain/kotlin/ui/App.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/App.kt
@@ -1,7 +1,7 @@
 package ui
 
-import ar.com.intrale.BuildKonfig
 import DIManager
+import ar.com.intrale.appconfig.AppRuntimeConfig
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -75,7 +75,7 @@ fun App() {
     val router: Router by DIManager.di.instance(arg = rememberNavController())
     val useDarkTheme = isSystemInDarkTheme()
     var animationsEnabled by remember { mutableStateOf(false) }
-    val isClientApp = BuildKonfig.APP_TYPE.equals("CLIENT", ignoreCase = true)
+    val isClientApp = AppRuntimeConfig.isClient
 
     logger.info { "Starting Intrale" }
 

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/auth/Login.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/auth/Login.kt
@@ -1,6 +1,6 @@
 package ui.sc.auth
 
-import ar.com.intrale.BuildKonfig
+import ar.com.intrale.appconfig.AppRuntimeConfig
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -59,7 +59,6 @@ import ui.th.elevations
 import ui.th.spacing
 
 const val LOGIN_PATH = "/login"
-private const val CLIENT_APP_TYPE = "CLIENT"
 
 class Login : Screen(LOGIN_PATH) {
 
@@ -125,7 +124,7 @@ class Login : Screen(LOGIN_PATH) {
                 setLoading = { viewModel.loading = it },
                 serviceCall = { viewModel.login() },
                 onSuccess = {
-                    val destination = if (BuildKonfig.APP_TYPE.equals(CLIENT_APP_TYPE, ignoreCase = true)) {
+                    val destination = if (AppRuntimeConfig.isClient) {
                         SessionStore.updateRole(UserRole.Client)
                         CLIENT_ENTRY_PATH
                     } else {
@@ -153,7 +152,7 @@ class Login : Screen(LOGIN_PATH) {
             }
         }
 
-        val isClientApp = BuildKonfig.APP_TYPE.equals(CLIENT_APP_TYPE, ignoreCase = true)
+        val isClientApp = AppRuntimeConfig.isClient
         val signupDestination = if (isClientApp) SIGNUP_PATH else SELECT_SIGNUP_PROFILE_PATH
 
         Scaffold(snackbarHost = { SnackbarHost(snackbarHostState) }) { padding ->

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/client/ClientEntryScreen.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/client/ClientEntryScreen.kt
@@ -4,6 +4,8 @@ import DIManager
 import ar.com.intrale.BuildKonfig
 import ar.com.intrale.strings.Txt
 import ar.com.intrale.strings.model.MessageKey
+import ar.com.intrale.appconfig.AppRuntimeConfig
+import ar.com.intrale.appconfig.AppType
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -46,7 +48,6 @@ import ui.session.UserRole
 import ui.th.spacing
 
 const val CLIENT_ENTRY_PATH = "/client/entry"
-private const val CLIENT_APP_TYPE = "CLIENT"
 
 enum class ClientEntryStatus { Loading, Welcome, NavigateClientHome, NavigateClassic, StoreUnavailable }
 
@@ -72,10 +73,10 @@ class ClientEntryViewModel : ViewModel() {
     override fun getState(): Any = state
     override fun initInputState() { /* No-op: no inputs in entry point */ }
 
-    suspend fun resolveEntry(appType: String = BuildKonfig.APP_TYPE) {
+    suspend fun resolveEntry(appType: AppType = AppRuntimeConfig.appType) {
         logger.info { "Resolviendo entry con APP_TYPE=$appType" }
 
-        if (!appType.equals(CLIENT_APP_TYPE, ignoreCase = true)) {
+        if (appType != AppType.CLIENT) {
             state = state.copy(status = ClientEntryStatus.NavigateClassic)
             return
         }
@@ -112,7 +113,7 @@ class ClientEntryScreen : Screen(CLIENT_ENTRY_PATH) {
         val state = viewModel.state
 
         LaunchedEffect(Unit) {
-            logger.info { "Evaluando entrypoint para APP_TYPE=${BuildKonfig.APP_TYPE}" }
+            logger.info { "Evaluando entrypoint para APP_TYPE=${AppRuntimeConfig.appType}" }
             viewModel.resolveEntry()
         }
 


### PR DESCRIPTION
## Resumen
- Se agregó la inferencia de `APP_TYPE` y una variante de producto `business` con nombre e íconos diferenciados para generar el APK de negocios.
- Se creó `AppRuntimeConfig` para consultar el tipo de app en tiempo de ejecución y se ajustaron las rutas iniciales de login y cliente según el modo de negocio.

## Checklist
- [x] Base del PR en `main`
- [x] Título con formato `[auto] ... (Closes #<n>).`
- [x] Cuerpo incluye `Closes #<n>` y, si aplica, `target:main`.
- [x] PR asignado a @leitolarreta.

## Evidencias
- Tests:
  - `./gradlew :app:composeApp:assembleBusinessDebug -x test --console=plain --no-daemon`
- Notas:
  - Closes #665

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69447249e2108325a24e4e0970e8426f)