### PR TITLE
[auto] Corregir tests de ProductFormViewModel y ProductListViewModel que usan runBlocking en commonTest (Closes #764)

### DIFF
--- a/app/composeApp/src/commonMain/kotlin/ui/sc/business/ProductFormViewModel.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/business/ProductFormViewModel.kt
@@ -38,10 +38,11 @@ class ProductFormViewModel(
     private val createProduct: ToDoCreateProduct = DIManager.di.direct.instance(),
     private val updateProduct: ToDoUpdateProduct = DIManager.di.direct.instance(),
     private val deleteProduct: ToDoDeleteProduct = DIManager.di.direct.instance(),
-    private val listProducts: ToDoListProducts = DIManager.di.direct.instance()
+    private val listProducts: ToDoListProducts = DIManager.di.direct.instance(),
+    loggerFactory: LoggerFactory = LoggerFactory.default
 ) : ViewModel() {
 
-    private val logger = LoggerFactory.default.newLogger<ProductFormViewModel>()
+    private val logger = loggerFactory.newLogger<ProductFormViewModel>()
 
     var uiState by mutableStateOf(ProductFormUiState())
     var loading by mutableStateOf(false)

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/business/ProductListViewModel.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/business/ProductListViewModel.kt
@@ -36,10 +36,11 @@ data class ProductListUiState(
 )
 
 class ProductListViewModel(
-    private val listProducts: ToDoListProducts = DIManager.di.direct.instance()
+    private val listProducts: ToDoListProducts = DIManager.di.direct.instance(),
+    loggerFactory: LoggerFactory = LoggerFactory.default
 ) : ViewModel() {
 
-    private val logger = LoggerFactory.default.newLogger<ProductListViewModel>()
+    private val logger = loggerFactory.newLogger<ProductListViewModel>()
     private var currentBusinessId: String? = null
 
     var state by mutableStateOf(ProductListUiState())

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/client/ClientProfileViewModel.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/client/ClientProfileViewModel.kt
@@ -60,10 +60,11 @@ class ClientProfileViewModel(
     private val getClientProfile: ToDoGetClientProfile = DIManager.di.direct.instance(),
     private val updateClientProfile: ToDoUpdateClientProfile = DIManager.di.direct.instance(),
     private val manageClientAddress: ToDoManageClientAddress = DIManager.di.direct.instance(),
-    private val toDoResetLoginCache: ToDoResetLoginCache = DIManager.di.direct.instance()
+    private val toDoResetLoginCache: ToDoResetLoginCache = DIManager.di.direct.instance(),
+    loggerFactory: LoggerFactory = LoggerFactory.default
 ) : ViewModel() {
 
-    private val logger = LoggerFactory.default.newLogger<ClientProfileViewModel>()
+    private val logger = loggerFactory.newLogger<ClientProfileViewModel>()
 
     private var profileValidation: Validation<ClientProfileForm> = buildProfileValidation()
     private var addressValidation: Validation<AddressForm> = buildAddressValidation()

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/delivery/DeliveryProfileViewModel.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/delivery/DeliveryProfileViewModel.kt
@@ -43,10 +43,11 @@ data class DeliveryProfileUiState(
 class DeliveryProfileViewModel(
     private val getDeliveryProfile: ToDoGetDeliveryProfile = DIManager.di.direct.instance(),
     private val updateDeliveryProfile: ToDoUpdateDeliveryProfile = DIManager.di.direct.instance(),
-    private val toDoResetLoginCache: ToDoResetLoginCache = DIManager.di.direct.instance()
+    private val toDoResetLoginCache: ToDoResetLoginCache = DIManager.di.direct.instance(),
+    loggerFactory: LoggerFactory = LoggerFactory.default
 ) : ViewModel() {
 
-    private val logger = LoggerFactory.default.newLogger<DeliveryProfileViewModel>()
+    private val logger = loggerFactory.newLogger<DeliveryProfileViewModel>()
     private val profileValidation: Validation<DeliveryProfileForm> = buildProfileValidation()
 
     var state by mutableStateOf(DeliveryProfileUiState())

--- a/app/composeApp/src/commonTest/kotlin/ui/sc/business/ProductFormViewModelTest.kt
+++ b/app/composeApp/src/commonTest/kotlin/ui/sc/business/ProductFormViewModelTest.kt
@@ -7,7 +7,7 @@ import asdo.business.ToDoUpdateProduct
 import ext.business.ProductDTO
 import ext.business.ProductRequest
 import ext.business.ProductStatus
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -46,7 +46,7 @@ private fun sampleProduct(id: String = "new-id") = ProductDTO(
 class ProductFormViewModelTest {
 
     @Test
-    fun `precio invalido bloquea guardado`() = runBlocking {
+    fun `precio invalido bloquea guardado`() = runTest {
         val fake = FakeProductCrud()
         val viewModel = ProductFormViewModel(fake, fake, fake, fake)
         viewModel.uiState = viewModel.uiState.copy(
@@ -60,7 +60,7 @@ class ProductFormViewModelTest {
     }
 
     @Test
-    fun `creacion exitosa cambia a modo edicion`() = runBlocking {
+    fun `creacion exitosa cambia a modo edicion`() = runTest {
         val fake = FakeProductCrud()
         val viewModel = ProductFormViewModel(fake, fake, fake, fake)
         viewModel.uiState = viewModel.uiState.copy(
@@ -76,7 +76,7 @@ class ProductFormViewModelTest {
     }
 
     @Test
-    fun `no se puede eliminar sin id`() = runBlocking {
+    fun `no se puede eliminar sin id`() = runTest {
         val fake = FakeProductCrud()
         val viewModel = ProductFormViewModel(fake, fake, fake, fake)
         val result = viewModel.delete("biz-1")

--- a/app/composeApp/src/commonTest/kotlin/ui/sc/business/ProductListViewModelTest.kt
+++ b/app/composeApp/src/commonTest/kotlin/ui/sc/business/ProductListViewModelTest.kt
@@ -3,7 +3,9 @@ package ui.sc.business
 import ext.business.ProductDTO
 import ext.business.ProductStatus
 import asdo.business.ToDoListProducts
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import org.kodein.log.LoggerFactory
+import org.kodein.log.frontend.simplePrintFrontend
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -14,17 +16,22 @@ private class FakeListProducts(
     override suspend fun execute(businessId: String): Result<List<ProductDTO>> = result
 }
 
+private val testLoggerFactory = LoggerFactory(listOf(simplePrintFrontend))
+
 class ProductListViewModelTest {
 
     @Test
-    fun `estado missing cuando no hay negocio seleccionado`() = runBlocking {
-        val viewModel = ProductListViewModel(FakeListProducts(Result.success(emptyList())))
+    fun `estado missing cuando no hay negocio seleccionado`() = runTest {
+        val viewModel = ProductListViewModel(
+            FakeListProducts(Result.success(emptyList())),
+            loggerFactory = testLoggerFactory
+        )
         viewModel.loadProducts(null)
         assertEquals(ProductListStatus.MissingBusiness, viewModel.state.status)
     }
 
     @Test
-    fun `carga exitosa popula items`() = runBlocking {
+    fun `carga exitosa popula items`() = runTest {
         val products = listOf(
             ProductDTO(
                 id = "1",
@@ -36,15 +43,21 @@ class ProductListViewModelTest {
                 status = ProductStatus.Published
             )
         )
-        val viewModel = ProductListViewModel(FakeListProducts(Result.success(products)))
+        val viewModel = ProductListViewModel(
+            FakeListProducts(Result.success(products)),
+            loggerFactory = testLoggerFactory
+        )
         viewModel.loadProducts("biz-1")
         assertEquals(ProductListStatus.Loaded, viewModel.state.status)
         assertEquals(1, viewModel.state.items.size)
     }
 
     @Test
-    fun `error al cargar cambia estado`() = runBlocking {
-        val viewModel = ProductListViewModel(FakeListProducts(Result.failure(Exception("boom"))))
+    fun `error al cargar cambia estado`() = runTest {
+        val viewModel = ProductListViewModel(
+            FakeListProducts(Result.failure(Exception("boom"))),
+            loggerFactory = testLoggerFactory
+        )
         viewModel.loadProducts("biz-1")
         assertEquals(ProductListStatus.Error, viewModel.state.status)
         assertTrue(viewModel.state.errorMessage?.isNotBlank() == true)

--- a/app/composeApp/src/commonTest/kotlin/ui/sc/client/ClientProfileViewModelTest.kt
+++ b/app/composeApp/src/commonTest/kotlin/ui/sc/client/ClientProfileViewModelTest.kt
@@ -9,6 +9,8 @@ import asdo.client.ManageAddressAction
 import asdo.client.ToDoGetClientProfile
 import asdo.client.ToDoManageClientAddress
 import asdo.client.ToDoUpdateClientProfile
+import org.kodein.log.LoggerFactory
+import org.kodein.log.frontend.simplePrintFrontend
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -29,6 +31,8 @@ private val sampleData = ClientProfileData(
     preferences = ClientPreferences(language = "es")
 )
 
+private val testLoggerFactory = LoggerFactory(listOf(simplePrintFrontend))
+
 class ClientProfileViewModelTest {
 
     @Test
@@ -37,7 +41,8 @@ class ClientProfileViewModelTest {
             getClientProfile = FakeGetProfile(),
             updateClientProfile = FakeUpdateProfile(),
             manageClientAddress = FakeManageAddress(),
-            toDoResetLoginCache = FakeResetLoginCache()
+            toDoResetLoginCache = FakeResetLoginCache(),
+            loggerFactory = testLoggerFactory
         )
 
         viewModel.loadProfile()
@@ -56,7 +61,8 @@ class ClientProfileViewModelTest {
             getClientProfile = FakeGetProfile(),
             updateClientProfile = FakeUpdateProfile(),
             manageClientAddress = FakeManageAddress(),
-            toDoResetLoginCache = reset
+            toDoResetLoginCache = reset,
+            loggerFactory = testLoggerFactory
         )
 
         viewModel.logout()

--- a/app/composeApp/src/commonTest/kotlin/ui/sc/delivery/DeliveryProfileViewModelTest.kt
+++ b/app/composeApp/src/commonTest/kotlin/ui/sc/delivery/DeliveryProfileViewModelTest.kt
@@ -8,6 +8,8 @@ import asdo.delivery.DeliveryZone
 import asdo.delivery.ToDoGetDeliveryProfile
 import asdo.delivery.ToDoUpdateDeliveryProfile
 import ar.com.intrale.strings.model.MessageKey
+import org.kodein.log.LoggerFactory
+import org.kodein.log.frontend.simplePrintFrontend
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -26,6 +28,8 @@ private val sampleData = DeliveryProfileData(
     zones = listOf(DeliveryZone(id = "zone-1", name = "Centro", description = "Cobertura urbana"))
 )
 
+private val testLoggerFactory = LoggerFactory(listOf(simplePrintFrontend))
+
 class DeliveryProfileViewModelTest {
 
     @Test
@@ -33,7 +37,8 @@ class DeliveryProfileViewModelTest {
         val viewModel = DeliveryProfileViewModel(
             getDeliveryProfile = FakeGetProfile(),
             updateDeliveryProfile = FakeUpdateProfile(),
-            toDoResetLoginCache = FakeResetLoginCache()
+            toDoResetLoginCache = FakeResetLoginCache(),
+            loggerFactory = testLoggerFactory
         )
 
         viewModel.loadProfile()
@@ -48,7 +53,8 @@ class DeliveryProfileViewModelTest {
         val viewModel = DeliveryProfileViewModel(
             getDeliveryProfile = FakeGetProfile(),
             updateDeliveryProfile = FakeUpdateProfile(),
-            toDoResetLoginCache = FakeResetLoginCache()
+            toDoResetLoginCache = FakeResetLoginCache(),
+            loggerFactory = testLoggerFactory
         )
 
         viewModel.loadProfile()
@@ -64,7 +70,8 @@ class DeliveryProfileViewModelTest {
         val viewModel = DeliveryProfileViewModel(
             getDeliveryProfile = FakeGetProfile(),
             updateDeliveryProfile = FakeUpdateProfile(),
-            toDoResetLoginCache = reset
+            toDoResetLoginCache = reset,
+            loggerFactory = testLoggerFactory
         )
 
         viewModel.logout()


### PR DESCRIPTION
## Resumen
- Se inyecta `loggerFactory` en los viewmodels de productos, cliente y delivery para usar frontends de logging seguros en tests.
- Se actualizan los tests de ProductForm/ProductList a `runTest` y a un logger de pruebas basado en `simplePrintFrontend`.
- Se reutiliza el logger de pruebas en los tests de perfiles de cliente y delivery para evitar dependencias de Android Log.

## Checklist
- [x] Base del PR en `main` 
- [x] Título con formato `[auto] ... (Closes #<n>)`.
- [x] Cuerpo incluye `Closes #764` y, si aplica, `target:main`.
- [x] PR asignado a @leitolarreta.

## Evidencias
- Tests: `./gradlew :app:composeApp:allTests`
- Notas:
Closes #764

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951b753af508325a1e0b4f20bbd2eb3)