### PR TITLE
[auto] Resolver issues de compilacion (Closes #776)

### DIFF
--- a/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/catalog/DefaultCatalog_en.kt
+++ b/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/catalog/DefaultCatalog_en.kt
@@ -211,6 +211,8 @@ internal val DefaultCatalog_en: Map<MessageKey, String> = mapOf(
     MessageKey.client_profile_make_default to "Set as default",
     MessageKey.client_profile_address_label to "Label",
     MessageKey.client_profile_address_line1 to "Address",
+    MessageKey.client_profile_address_number to "Number",
+    MessageKey.client_profile_address_reference to "Reference",
     MessageKey.client_profile_address_city to "City",
     MessageKey.client_profile_address_state to "State/Province",
     MessageKey.client_profile_address_zip to "Postal code",

--- a/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/catalog/DefaultCatalog_es.kt
+++ b/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/catalog/DefaultCatalog_es.kt
@@ -211,6 +211,8 @@ internal val DefaultCatalog_es: Map<MessageKey, String> = mapOf(
     MessageKey.client_profile_make_default to "Marcar como predeterminada",
     MessageKey.client_profile_address_label to "Etiqueta",
     MessageKey.client_profile_address_line1 to "Dirección",
+    MessageKey.client_profile_address_number to "Número",
+    MessageKey.client_profile_address_reference to "Referencia",
     MessageKey.client_profile_address_city to "Ciudad",
     MessageKey.client_profile_address_state to "Provincia/Estado",
     MessageKey.client_profile_address_zip to "Código postal",

--- a/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/model/MessageKey.kt
+++ b/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/model/MessageKey.kt
@@ -214,6 +214,8 @@ enum class MessageKey {
     client_profile_make_default,
     client_profile_address_label,
     client_profile_address_line1,
+    client_profile_address_number,
+    client_profile_address_reference,
     client_profile_address_city,
     client_profile_address_state,
     client_profile_address_zip,

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/business/CategoryListScreen.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/business/CategoryListScreen.kt
@@ -152,7 +152,9 @@ class CategoryListScreen(
                                 setLoading = { deleting = it },
                                 serviceCall = { viewModel.deleteCategory(item.id) },
                                 onSuccess = {
-                                    snackbarHostState.showSnackbar(Txt(MessageKey.category_form_deleted))
+                                    coroutineScope.launch {
+                                        snackbarHostState.showSnackbar(Txt(MessageKey.category_form_deleted))
+                                    }
                                     categoryToDelete = null
                                 },
                                 onError = { error ->

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/client/ClientCartScreen.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/client/ClientCartScreen.kt
@@ -501,7 +501,7 @@ private fun DeliveryAddressRow(
                     }
                 }
                 Text(text = address.line1, style = MaterialTheme.typography.bodyMedium)
-                val location = listOfNotNull(address.city, address.state, address.zip, address.country)
+                val location = listOfNotNull(address.city, address.state, address.postalCode, address.country)
                     .filter { it.isNotBlank() }
                     .joinToString(" • ")
                 if (location.isNotBlank()) {

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/delivery/DeliveryProfileScreen.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/delivery/DeliveryProfileScreen.kt
@@ -47,6 +47,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.lifecycle.viewmodel.compose.viewModel
 import ar.com.intrale.strings.Txt
 import ar.com.intrale.strings.model.MessageKey
+import asdo.delivery.DeliveryAvailabilityBlock
+import asdo.delivery.DeliveryAvailabilityMode
 import kotlinx.coroutines.launch
 import kotlinx.datetime.DayOfWeek
 import ui.cp.buttons.IntralePrimaryButton

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/delivery/DeliveryProfileViewModel.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/delivery/DeliveryProfileViewModel.kt
@@ -18,7 +18,6 @@ import asdo.delivery.ToDoGetDeliveryAvailability
 import asdo.delivery.ToDoUpdateDeliveryAvailability
 import ar.com.intrale.strings.model.MessageKey
 import io.konform.validation.Validation
-import io.konform.validation.addConstraint
 import io.konform.validation.onEach
 import io.konform.validation.jsonschema.minLength
 import io.konform.validation.jsonschema.pattern
@@ -329,8 +328,10 @@ class DeliveryProfileViewModel(
         DeliveryAvailabilityForm::timezone required {
             minLength(1) hint MessageKey.delivery_availability_error_timezone_required.name
         }
-        DeliveryAvailabilityForm::slots addConstraint MessageKey.delivery_availability_error_no_days.name { slots ->
-            slots.any { it.enabled }
+        DeliveryAvailabilityForm::slots {
+            addConstraint(MessageKey.delivery_availability_error_no_days.name) { slots ->
+                slots.any { it.enabled }
+            }
         }
         DeliveryAvailabilityForm::slots onEach {
             addConstraint(MessageKey.delivery_availability_error_block_required.name) { slot ->


### PR DESCRIPTION
### Motivation
- Corregir errores de compilación en el módulo `app/composeApp` provocados por llamadas a `showSnackbar` fuera de una corrutina, uso de propiedades inexistentes en `ClientAddress`, claves de mensajes faltantes y desajustes con la API de validación (Konform) y referencias de disponibilidad de delivery.
- Aplicar cambios mínimos y localizables para que las pantallas Compose vuelvan a compilar y los mensajes de UI estén disponibles en ES/EN.

### Description
- `ui/sc/business/CategoryListScreen.kt`: envolver la llamada a `snackbarHostState.showSnackbar(...)` dentro de `coroutineScope.launch { ... }` para asegurar ejecución en coroutine. 
- `ui/sc/client/ClientCartScreen.kt`: reemplazo de `address.zip` por `address.postalCode` al construir la cadena de ubicación. 
- `ar/com/intrale/strings/model/MessageKey.kt`: se agregaron `client_profile_address_number` y `client_profile_address_reference` como claves de texto. 
- `ar/com/intrale/strings/catalog/DefaultCatalog_es.kt` y `DefaultCatalog_en.kt`: se añadieron traducciones para las nuevas claves (`Número`/`Number`, `Referencia`/`Reference`). 
- `ui/sc/delivery/DeliveryProfileScreen.kt`: importadas `DeliveryAvailabilityBlock` y `DeliveryAvailabilityMode` para resolver referencias de UI. 
- `ui/sc/delivery/DeliveryProfileViewModel.kt`: adaptada la construcción de validaciones Konform para usar el DSL correcto de la versión usada (mover `addConstraint` dentro del bloque de la propiedad `slots`) y eliminado el import redundante que causaba incompatibilidad con la DSL actual.

### Testing
- No se ejecutaron tests automáticos ni tareas de compilación en este entorno, por lo que los cambios fueron verificados mediante revisión de código y edición de los ficheros fuente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a78933df08325985b9474863396a0)