### PR TITLE
Corregir errores de compilación de Compose en Category/Product/Client (Closes #778)

### DIFF
--- a/app/composeApp/src/commonMain/kotlin/ui/sc/business/CategoryListScreen.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/business/CategoryListScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -100,6 +101,8 @@ class CategoryListScreen(
         val deleteConfirmMessage = Txt(MessageKey.category_form_delete_confirm_message)
         val deleteConfirmAccept = Txt(MessageKey.category_form_delete_confirm_accept)
         val deleteConfirmCancel = Txt(MessageKey.category_form_delete_confirm_cancel)
+        val deletedMessage = Txt(MessageKey.category_form_deleted)
+        val genericError = Txt(MessageKey.error_generic)
 
         Scaffold(snackbarHost = { SnackbarHost(snackbarHostState) }) { padding ->
             when {
@@ -153,13 +156,13 @@ class CategoryListScreen(
                                 serviceCall = { viewModel.deleteCategory(item.id) },
                                 onSuccess = {
                                     coroutineScope.launch {
-                                        snackbarHostState.showSnackbar(Txt(MessageKey.category_form_deleted))
+                                        snackbarHostState.showSnackbar(deletedMessage)
                                     }
                                     categoryToDelete = null
                                 },
                                 onError = { error ->
                                     snackbarHostState.showSnackbar(
-                                        error.message ?: Txt(MessageKey.error_generic)
+                                        error.message ?: genericError
                                     )
                                 }
                             )

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/business/ProductListScreen.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/business/ProductListScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.AssistChip
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/client/ClientCartScreen.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/client/ClientCartScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -500,7 +501,16 @@ private fun DeliveryAddressRow(
                         )
                     }
                 }
-                Text(text = address.line1, style = MaterialTheme.typography.bodyMedium)
+                val mainLine = listOf(address.street, address.number)
+                    .filter { it.isNotBlank() }
+                    .joinToString(" ")
+                val addressLine = listOfNotNull(
+                    mainLine.takeIf { it.isNotBlank() },
+                    address.reference?.takeIf { it.isNotBlank() }
+                ).joinToString(" • ")
+                if (addressLine.isNotBlank()) {
+                    Text(text = addressLine, style = MaterialTheme.typography.bodyMedium)
+                }
                 val location = listOfNotNull(address.city, address.state, address.postalCode, address.country)
                     .filter { it.isNotBlank() }
                     .joinToString(" • ")


### PR DESCRIPTION
### Motivation
- Resolver errores de compilación de Compose en las pantallas de categorías, productos y carrito de cliente causados por imports faltantes, uso de `Txt(...)` en callbacks no-composable y una propiedad de modelo inexistente (`line1`).

### Description
- Cacheé los textos `Txt(...)` en el scope composable y agregué el import de `Row` para evitar invocar composables desde callbacks en `CategoryListScreen.kt`.
- Añadí el import faltante de `FilterChip` en `ProductListScreen.kt` para corregir referencias en el filtro de categorías.
- Reemplacé `address.line1` por una construcción basada en `street` + `number` y `reference`, y añadí el import de `LaunchedEffect` en `ClientCartScreen.kt` para cargar el perfil correctamente.
- Creé la rama `codex/778-mas-issues-de-compilacion`, hice commit de los cambios y abrí el PR con título `"[auto] Mas issues de compilacion (Closes #778)"` asignado a `@leitolarreta`.

### Testing
- No se ejecutaron tests automatizados de compilación o unitarios en esta rama durante el cambio; solo se realizaron commits locales y se abrió el PR (changes committed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b6965a3d0832594f20fa58e485fa6)