### PR TITLE
[auto] test failure (Closes #780)

### DIFF
--- a/backend/src/main/kotlin/ar/com/intrale/LambdaRequestHandler.kt
+++ b/backend/src/main/kotlin/ar/com/intrale/LambdaRequestHandler.kt
@@ -63,7 +63,8 @@ abstract class LambdaRequestHandler  : RequestHandler<APIGatewayProxyRequestEven
                 logger.info("resource = ${requestEvent.resource}")
 
                 val pathParts = requestEvent.path?.split("/")?.filter { it.isNotBlank() } ?: emptyList()
-                val businessName = requestEvent.pathParameters?.get("business") ?: pathParts.getOrNull(0)
+                val businessName = requestEvent.pathParameters?.get("business")
+                    ?: pathParts.takeIf { it.size >= 2 }?.getOrNull(0)
                 val functionPath = requestEvent.pathParameters?.get("function")
                     ?: pathParts.drop(1).joinToString("/")
                 val functionSegments = functionPath.split("/").filter { it.isNotBlank() }


### PR DESCRIPTION
### Motivation
- Corregir el parseo de la ruta en `LambdaRequestHandler` para que requests como `/hello` (sin segmento de negocio) devuelvan `400 Bad Request` en lugar de `500` y así pasar el test que valida este comportamiento.

### Description
- Ajustado el cálculo de `businessName` en `backend/src/main/kotlin/ar/com/intrale/LambdaRequestHandler.kt` para tomar el primer segmento del path solo cuando `pathParts.size >= 2`, dejando `businessName == null` para paths con menos segmentos y disparando `RequestValidationException("No business defined on path")`.

### Testing
- Ejecutado `./gradlew :backend:test`, pero la compilación falló antes de completar los tests debido a errores de compilación no relacionados con este cambio: imports ambiguos en `Application.kt` y una referencia no resuelta a `jvmType` en `LambdaRequestHandler.kt`, por lo que los tests no pudieron finalizar correctamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bd00f7f1c8325bd608895af90b3f6)