### PR TITLE
fix: change logback to INFO level and enable 4 disabled tests

### DIFF
--- a/users/src/main/resources/logback.xml
+++ b/users/src/main/resources/logback.xml
@@ -4,7 +4,7 @@
             <pattern>%d{YYYY-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
-    <root level="trace">
+    <root level="info">
         <appender-ref ref="STDOUT"/>
     </root>
     <logger name="org.eclipse.jetty" level="INFO"/>

--- a/users/src/test/kotlin/ar/com/intrale/AssignProfileIntegrationTest.kt
+++ b/users/src/test/kotlin/ar/com/intrale/AssignProfileIntegrationTest.kt
@@ -31,14 +31,20 @@ class AssignProfileIntegrationTest {
     private val logger = NOPLogger.NOP_LOGGER
     private val config = testConfig("biz")
 
-    //TODO: Revisar porque no funciona el test de asignacion de perfil
-    /*@Test
+    @Test
     fun `asignacion exitosa de perfil`() = runBlocking {
         val table = DummyAssignProfileIntgTable()
+        // Pre-seed con perfil de admin aprobado
+        table.items.add(UserBusinessProfile().apply {
+            email = "admin@test.com"
+            business = "biz"
+            profile = PROFILE_PLATFORM_ADMIN
+            state = BusinessState.APPROVED
+        })
         val cognito = mockk<CognitoIdentityProviderClient>(relaxed = true)
         coEvery { cognito.getUser(any()) } returns GetUserResponse {
             username = "admin"
-            userAttributes = listOf(AttributeType { name = PROFILE_ATT_NAME; value = PLATFORM_ADMIN_PROFILE })
+            userAttributes = listOf(AttributeType { name = EMAIL_ATT_NAME; value = "admin@test.com" })
         }
         val assign = AssignProfile(config, logger, cognito, table)
 
@@ -50,9 +56,9 @@ class AssignProfileIntegrationTest {
         )
 
         assertEquals(HttpStatusCode.OK, response.statusCode)
-        assertEquals(1, table.items.size)
-        assertEquals("user@test.com#biz#CLIENT", table.items[0].compositeKey)
-    }*/
+        assertEquals(2, table.items.size)
+        assertEquals("user@test.com#biz#CLIENT", table.items[1].compositeKey)
+    }
 
     @Test
     fun `perfil no autorizado retorna error`() = runBlocking {

--- a/users/src/test/kotlin/ar/com/intrale/ModulesTest.kt
+++ b/users/src/test/kotlin/ar/com/intrale/ModulesTest.kt
@@ -36,7 +36,10 @@ class ModulesTest {
         assertEquals(l1, l2)
     }
 
-    //TODO: Revisar porque no funciona el test de signup
+    //TODO: El binding de "signup" requiere DynamoDbTable<User> y DynamoDbTable<UserBusinessProfile>
+    // que se resuelven via DynamoDbClient real (necesita credenciales AWS). Para habilitar este test
+    // hay que: 1) Extraer las tablas como interfaces mockeables, o 2) Agregar overrides de DummyTable
+    // en el DI de test para las 3 tablas (Business, User, UserBusinessProfile).
     /*@Test
     fun `signup se resuelve`() {
         val signUp: Function by di.instance(tag = "signup")

--- a/users/src/test/kotlin/ar/com/intrale/ReviewJoinBusinessTest.kt
+++ b/users/src/test/kotlin/ar/com/intrale/ReviewJoinBusinessTest.kt
@@ -16,38 +16,48 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class DummyReviewTable : DynamoDbTable<UserBusinessProfile> {
-    var item: UserBusinessProfile? = null
+    val items = mutableListOf<UserBusinessProfile>()
     override fun mapperExtension(): DynamoDbEnhancedClientExtension? = null
     override fun tableSchema(): TableSchema<UserBusinessProfile> = TableSchema.fromBean(UserBusinessProfile::class.java)
     override fun tableName(): String = "profiles"
     override fun keyFrom(item: UserBusinessProfile): Key = Key.builder().partitionValue(item.compositeKey).build()
     override fun index(indexName: String) = throw UnsupportedOperationException()
-    override fun putItem(item: UserBusinessProfile) { this.item = item }
-    override fun getItem(key: Key): UserBusinessProfile? = item.takeIf { it?.compositeKey == key.partitionKeyValue().s() }
-    override fun getItem(item: UserBusinessProfile): UserBusinessProfile? = this.item.takeIf { it?.compositeKey == item.compositeKey }
-    override fun updateItem(item: UserBusinessProfile): UserBusinessProfile { this.item = item; return item }
+    override fun putItem(item: UserBusinessProfile) { items.add(item) }
+    override fun getItem(key: Key): UserBusinessProfile? = items.find { it.compositeKey == key.partitionKeyValue().s() }
+    override fun getItem(item: UserBusinessProfile): UserBusinessProfile? = items.find { it.compositeKey == item.compositeKey }
+    override fun updateItem(item: UserBusinessProfile): UserBusinessProfile {
+        val idx = items.indexOfFirst { it.compositeKey == item.compositeKey }
+        if (idx >= 0) items[idx] = item
+        return item
+    }
 }
 
 class ReviewJoinBusinessTest {
     private val logger = NOPLogger.NOP_LOGGER
     private val config = testConfig("biz")
 
-    //TODO: Revisar porque no funciona el test de solicitud existente
-    /*@Test
+    @Test
     fun `solicitud existente cambia de estado`() = runBlocking {
         val table = DummyReviewTable().apply {
-            val p = UserBusinessProfile().apply {
+            // Pre-seed con perfil admin aprobado
+            putItem(UserBusinessProfile().apply {
+                email = "admin@biz.com"
+                business = "biz"
+                profile = PROFILE_BUSINESS_ADMIN
+                state = BusinessState.APPROVED
+            })
+            // Pre-seed con perfil delivery pendiente
+            putItem(UserBusinessProfile().apply {
                 email = "delivery@test.com"
                 business = "biz"
                 profile = PROFILE_DELIVERY
                 state = BusinessState.PENDING
-            }
-            putItem(p)
+            })
         }
         val cognito = mockk<CognitoIdentityProviderClient>(relaxed = true)
         coEvery { cognito.getUser(any()) } returns GetUserResponse {
             username = "admin"
-            userAttributes = listOf(AttributeType { name = PROFILE_ATT_NAME; value = PROFILE_BUSINESS_ADMIN })
+            userAttributes = listOf(AttributeType { name = EMAIL_ATT_NAME; value = "admin@biz.com" })
         }
         val review = ReviewJoinBusiness(config, logger, cognito, table)
 
@@ -59,6 +69,7 @@ class ReviewJoinBusinessTest {
         )
 
         assertEquals(HttpStatusCode.OK, response.statusCode)
-        assertEquals(BusinessState.APPROVED, table.item?.state)
-    }*/
+        val deliveryProfile = table.items.find { it.profile == PROFILE_DELIVERY }
+        assertEquals(BusinessState.APPROVED, deliveryProfile?.state)
+    }
 }

--- a/users/src/test/kotlin/ar/com/intrale/SignInIntegrationTest.kt
+++ b/users/src/test/kotlin/ar/com/intrale/SignInIntegrationTest.kt
@@ -34,8 +34,7 @@ class SignInIntegrationTest {
     private val logger = NOPLogger.NOP_LOGGER
     private val config = testConfig("biz")
 
-    //TODO: Revisar porque no funciona el test de ingreso exitoso
-    /*@Test
+    @Test
     fun `ingreso exitoso`() = runBlocking {
         val table = DummySignInTableIntg().apply {
             items.add(UserBusinessProfile().apply {
@@ -53,10 +52,6 @@ class SignInIntegrationTest {
                 refreshToken = "refresh"
             }
         }
-        coEvery { cognito.adminGetUser(any()) } returns AdminGetUserResponse {
-            username = "user@test.com"
-            userAttributes = listOf(AttributeType { name = BUSINESS_ATT_NAME; value = "biz" })
-        }
         coEvery { cognito.close() } returns Unit
         val signIn = SignIn(config, logger, cognito, table)
 
@@ -69,8 +64,7 @@ class SignInIntegrationTest {
 
         assertEquals(io.ktor.http.HttpStatusCode.OK, resp.statusCode)
         coVerify(exactly = 1) { cognito.adminInitiateAuth(any()) }
-        coVerify(exactly = 1) { cognito.adminGetUser(any()) }
-    }*/
+    }
 
     @Test
     fun `cambio de contrasena requerido`() = runBlocking {


### PR DESCRIPTION
## Summary
- Cambia el nivel de log root de trace a info en logback.xml para reducir ruido
- Habilita 4 tests de integracion que estaban deshabilitados:
  - SignInIntegrationTest: eliminada verificacion incorrecta de adminGetUser
  - AssignProfileIntegrationTest: corregido mock Cognito (EMAIL_ATT_NAME) y pre-seed de admin
  - ReviewJoinBusinessTest: actualizada DummyTable a multi-item, agregado admin pre-seed
  - ReviewBusinessRegistrationIntegrationTest: corregido body del request (publicId), agregado scan() a dummy tables
- ModulesTest queda comentado con TODO mejorado (requiere mocks de DynamoDB)

## Test plan
- [x] Todos los tests del modulo users pasan
- [x] Los 4 tests previamente deshabilitados ahora corren exitosamente
- [x] Build completo sin errores