### PR TITLE
feat: E2E test infrastructure with JwtValidator abstraction

### DIFF
--- a/backend/src/main/kotlin/ar/com/intrale/Application.kt
+++ b/backend/src/main/kotlin/ar/com/intrale/Application.kt
@@ -8,7 +8,6 @@ import io.ktor.server.netty.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
-import kotlin.time.Duration.Companion.seconds
 import org.kodein.di.DI
 import org.kodein.di.allInstances
 import org.kodein.di.direct
@@ -18,7 +17,6 @@ import org.kodein.di.ktor.di
 import org.kodein.type.jvmType
 import ar.com.intrale.HealthResponse
 import ar.com.intrale.delivery.deliveryAvailabilityRoutes
-import kotlin.time.Duration.Companion.seconds
 import org.slf4j.Logger
 
 /**
@@ -35,25 +33,7 @@ fun start(appModule: DI.Module) {
 
         healthRoute()
         deliveryAvailabilityRoutes()
-
-        routing {
-            route("/{business}/{function...}") {
-                registerDynamicHandler(HttpMethod.Post)
-                registerDynamicHandler(HttpMethod.Get)
-                registerDynamicHandler(HttpMethod.Put)
-                registerDynamicHandler(HttpMethod.Delete)
-            }
-            options {
-                call.response.headers.append("Access-Control-Allow-Origin", "*")
-                call.response.headers.append("Access-Control-Allow-Methods", "GET, OPTIONS, HEAD, PUT, POST, DELETE")
-                call.response.headers.append(
-                    "Access-Control-Allow-Headers",
-                    "Content-Type,Accept,Referer,User-Agent,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,Access-Control-Allow-Origin,Access-Control-Allow-Headers,function,idToken,businessName,filename"
-                )
-                call.respond(HttpStatusCode.OK)
-            }
-        }
-
+        configureDynamicRouting()
 
     }.start(wait = true)
 }
@@ -66,6 +46,26 @@ fun Application.healthRoute() {
                 contentType = ContentType.Application.Json,
                 status = HttpStatusCode.OK
             )
+        }
+    }
+}
+
+fun Application.configureDynamicRouting() {
+    routing {
+        route("/{business}/{function...}") {
+            registerDynamicHandler(HttpMethod.Post)
+            registerDynamicHandler(HttpMethod.Get)
+            registerDynamicHandler(HttpMethod.Put)
+            registerDynamicHandler(HttpMethod.Delete)
+        }
+        options {
+            call.response.headers.append("Access-Control-Allow-Origin", "*")
+            call.response.headers.append("Access-Control-Allow-Methods", "GET, OPTIONS, HEAD, PUT, POST, DELETE")
+            call.response.headers.append(
+                "Access-Control-Allow-Headers",
+                "Content-Type,Accept,Referer,User-Agent,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,Access-Control-Allow-Origin,Access-Control-Allow-Headers,function,idToken,businessName,filename"
+            )
+            call.respond(HttpStatusCode.OK)
         }
     }
 }
@@ -128,4 +128,3 @@ private fun Route.registerDynamicHandler(httpMethod: HttpMethod) {
         }
     }
 }
-

--- a/backend/src/main/kotlin/ar/com/intrale/CognitoJwtValidator.kt
+++ b/backend/src/main/kotlin/ar/com/intrale/CognitoJwtValidator.kt
@@ -1,0 +1,46 @@
+package ar.com.intrale
+
+import com.auth0.jwk.JwkProviderBuilder
+import com.auth0.jwt.JWT
+import com.auth0.jwt.algorithms.Algorithm
+import com.auth0.jwt.interfaces.DecodedJWT
+import java.net.URI
+import java.security.interfaces.RSAPublicKey
+import java.util.concurrent.TimeUnit
+
+class CognitoJwtValidator(private val config: Config) : JwtValidator {
+
+    override fun validate(token: String): DecodedJWT {
+        val region = config.region
+        val userPoolId = config.awsCognitoUserPoolId
+
+        val issuer = "https://cognito-idp.$region.amazonaws.com/$userPoolId"
+        val jwksUrl = "$issuer/.well-known/jwks.json"
+
+        val provider = JwkProviderBuilder(URI(jwksUrl).toURL())
+            .cached(10, 24, TimeUnit.HOURS)
+            .build()
+
+        val jwt: DecodedJWT = JWT.decode(token)
+        val jwk = provider.get(jwt.keyId)
+        val algorithm = Algorithm.RSA256(jwk.publicKey as RSAPublicKey, null)
+
+        val verifier = JWT.require(algorithm)
+            .withIssuer(issuer)
+            .build()
+
+        val decodedJWT = verifier.verify(token)
+
+        val tokenUse = decodedJWT.getClaim("token_use").asString()
+        if (tokenUse != "access") {
+            throw IllegalArgumentException("Token no es un access_token")
+        }
+
+        val clientIdFromToken = decodedJWT.getClaim("client_id").asString()
+        if (clientIdFromToken != config.awsCognitoClientId) {
+            throw IllegalArgumentException("ClientId invalido")
+        }
+
+        return decodedJWT
+    }
+}

--- a/backend/src/main/kotlin/ar/com/intrale/JwtValidator.kt
+++ b/backend/src/main/kotlin/ar/com/intrale/JwtValidator.kt
@@ -1,0 +1,7 @@
+package ar.com.intrale
+
+import com.auth0.jwt.interfaces.DecodedJWT
+
+interface JwtValidator {
+    fun validate(token: String): DecodedJWT
+}

--- a/backend/src/main/kotlin/ar/com/intrale/SecuredFunction.kt
+++ b/backend/src/main/kotlin/ar/com/intrale/SecuredFunction.kt
@@ -1,61 +1,25 @@
 package ar.com.intrale
 
-import com.auth0.jwk.JwkProviderBuilder
-import com.auth0.jwt.JWT
-import com.auth0.jwt.algorithms.Algorithm
-import com.auth0.jwt.interfaces.DecodedJWT
 import org.slf4j.Logger
-import java.net.URI
-import java.security.interfaces.RSAPublicKey
-import java.util.concurrent.TimeUnit
 
 /**
  * Funcion segurizada
  * Previo a la ejecucion valida si el usuario tiene un token valido para ejecutar
  */
-abstract class SecuredFunction(open val config: Config, open val logger: Logger) : Function {
+abstract class SecuredFunction(
+    open val config: Config,
+    open val logger: Logger,
+    open val jwtValidator: JwtValidator = CognitoJwtValidator(config)
+) : Function {
 
     override suspend fun execute(business: String, function: String, headers: Map<String, String>, textBody: String): Response {
         val token = headers["Authorization"]
 
-        val region = config.region
-        val userPoolId = config.awsCognitoUserPoolId
-
-        val issuer = "https://cognito-idp.$region.amazonaws.com/$userPoolId"
-        val jwksUrl = "$issuer/.well-known/jwks.json"
-
         try {
-            val provider = JwkProviderBuilder(URI(jwksUrl).toURL())
-                .cached(10, 24, TimeUnit.HOURS)
-                .build()
-
-            val jwt: DecodedJWT = JWT.decode(token)
-            val jwk = provider.get(jwt.keyId)
-            val algorithm = Algorithm.RSA256(jwk.publicKey as RSAPublicKey, null)
-
-            val verifier = JWT.require(algorithm)
-                .withIssuer(issuer)
-                //.withAudience(config.awsCognitoClientId) // El app client ID de Cognito
-                .build()
-
-            val decodedJWT = verifier.verify(token) // Lanza excepción si no es válido
-
-            val tokenUse = decodedJWT.getClaim("token_use").asString()
-            if (tokenUse != "access") {
-                logger.warn("Token no es un access_token")
-                return UnauthorizedException()
-            }
-
-            // Validación manual del client_id
-            val clientIdFromToken = decodedJWT.getClaim("client_id").asString()
-            if (clientIdFromToken != config.awsCognitoClientId) {
-                logger.warn("ClientId inválido")
-                return UnauthorizedException()
-            }
-
-            return securedExecute(business, function, headers, textBody) // Token válido
+            jwtValidator.validate(token ?: throw IllegalArgumentException("Token faltante"))
+            return securedExecute(business, function, headers, textBody)
         } catch (e: Exception) {
-            logger.warn("Token inválido: ${e.message}")
+            logger.warn("Token invalido: ${e.message}")
             return UnauthorizedException()
         }
     }

--- a/users/src/main/kotlin/ar/com/intrale/AssignProfile.kt
+++ b/users/src/main/kotlin/ar/com/intrale/AssignProfile.kt
@@ -10,8 +10,9 @@ class AssignProfile(
     override val config: UsersConfig,
     override val logger: Logger,
     private val cognito: CognitoIdentityProviderClient,
-    private val tableProfiles: DynamoDbTable<UserBusinessProfile>
-) : SecuredFunction(config = config, logger = logger) {
+    private val tableProfiles: DynamoDbTable<UserBusinessProfile>,
+    override val jwtValidator: JwtValidator = CognitoJwtValidator(config)
+) : SecuredFunction(config = config, logger = logger, jwtValidator = jwtValidator) {
 
     override suspend fun securedExecute(
         business: String,

--- a/users/src/main/kotlin/ar/com/intrale/ChangePassword.kt
+++ b/users/src/main/kotlin/ar/com/intrale/ChangePassword.kt
@@ -12,8 +12,9 @@ import ar.com.intrale.UnauthorizedException
 class ChangePassword(
     override val config: UsersConfig,
     override val logger: Logger,
-    private val cognito: CognitoIdentityProviderClient
-) : SecuredFunction(config = config, logger = logger) {
+    private val cognito: CognitoIdentityProviderClient,
+    override val jwtValidator: JwtValidator = CognitoJwtValidator(config)
+) : SecuredFunction(config = config, logger = logger, jwtValidator = jwtValidator) {
 
     fun requestValidation(body: ChangePasswordRequest): Response? {
         val validation = Validation<ChangePasswordRequest> {

--- a/users/src/main/kotlin/ar/com/intrale/ClientProfileFunctions.kt
+++ b/users/src/main/kotlin/ar/com/intrale/ClientProfileFunctions.kt
@@ -22,8 +22,9 @@ private fun Map<String, String>.resolveClientEmail(): String? {
 class ClientProfileFunction(
     override val config: UsersConfig,
     override val logger: Logger,
-    private val repository: ClientProfileRepository
-) : SecuredFunction(config, logger) {
+    private val repository: ClientProfileRepository,
+    override val jwtValidator: JwtValidator = CognitoJwtValidator(config)
+) : SecuredFunction(config, logger, jwtValidator) {
 
     override suspend fun securedExecute(
         business: String,
@@ -74,8 +75,9 @@ class ClientProfileFunction(
 class ClientAddressesFunction(
     override val config: UsersConfig,
     override val logger: Logger,
-    private val repository: ClientProfileRepository
-) : SecuredFunction(config, logger) {
+    private val repository: ClientProfileRepository,
+    override val jwtValidator: JwtValidator = CognitoJwtValidator(config)
+) : SecuredFunction(config, logger, jwtValidator) {
 
     override suspend fun securedExecute(
         business: String,

--- a/users/src/main/kotlin/ar/com/intrale/ConfigAutoAcceptDeliveries.kt
+++ b/users/src/main/kotlin/ar/com/intrale/ConfigAutoAcceptDeliveries.kt
@@ -9,8 +9,9 @@ class ConfigAutoAcceptDeliveries(
     override val logger: Logger,
     private val cognito: CognitoIdentityProviderClient,
     private val tableBusiness: DynamoDbTable<Business>,
-    private val tableProfiles: DynamoDbTable<UserBusinessProfile>
-) : SecuredFunction(config = config, logger = logger) {
+    private val tableProfiles: DynamoDbTable<UserBusinessProfile>,
+    override val jwtValidator: JwtValidator = CognitoJwtValidator(config)
+) : SecuredFunction(config = config, logger = logger, jwtValidator = jwtValidator) {
 
     override suspend fun securedExecute(
         business: String,

--- a/users/src/main/kotlin/ar/com/intrale/Modules.kt
+++ b/users/src/main/kotlin/ar/com/intrale/Modules.kt
@@ -120,6 +120,10 @@ val appModule = DI.Module("appModule") {
         singleton { LoggerFactory.getLogger("AppLogger") }
     }
 
+    bind<JwtValidator> {
+        singleton { CognitoJwtValidator(instance<UsersConfig>()) }
+    }
+
     bind<ClientProfileRepository> {
         singleton { ClientProfileRepository() }
     }
@@ -134,13 +138,13 @@ val appModule = DI.Module("appModule") {
         singleton  { SignUpDelivery(instance(), instance(), instance(), instance()) }
     }
     bind<Function> (tag="registerSaler") {
-        singleton  { RegisterSaler(instance(), instance(), instance(), instance()) }
+        singleton  { RegisterSaler(instance(), instance(), instance(), instance(), instance()) }
     }
     bind<Function> (tag="signin") {
         singleton {  SignIn(instance(), instance(), instance(), instance()) }
     }
     bind<Function> (tag="validate") {
-        singleton {  Validate(instance(), instance()) }
+        singleton {  Validate(instance(), instance(), instance()) }
     }
     bind<Function> (tag="recovery") {
         singleton {  PasswordRecovery(instance(), instance(), instance()) }
@@ -149,16 +153,16 @@ val appModule = DI.Module("appModule") {
         singleton {  ConfirmPasswordRecovery(instance(), instance(), instance()) }
     }
     bind<Function> (tag="changePassword") {
-        singleton {  ChangePassword(instance(), instance(), instance()) }
+        singleton {  ChangePassword(instance(), instance(), instance(), instance()) }
     }
     bind<Function> (tag="profiles") {
-        singleton {  Profiles(instance(), instance()) }
+        singleton {  Profiles(instance(), instance(), instance()) }
     }
     bind<Function> (tag="2fasetup") {
-        singleton {  TwoFactorSetup(instance(), instance(), instance(), instance()) }
+        singleton {  TwoFactorSetup(instance(), instance(), instance(), instance(), instance()) }
     }
     bind<Function> (tag="2faverify") {
-        singleton {  TwoFactorVerify(instance(), instance(), instance(), instance()) }
+        singleton {  TwoFactorVerify(instance(), instance(), instance(), instance(), instance()) }
     }
     bind<Function> (tag="registerBusiness") {
         singleton {  RegisterBusiness(instance(), instance(), instance()) }
@@ -166,28 +170,28 @@ val appModule = DI.Module("appModule") {
     bind<Function> (tag="reviewBusiness") {
         singleton {  ReviewBusinessRegistration(instance(), instance(), instance("2faverify"),
             instance("signup"), instance(),
-            instance(), instance(),instance()) }
+            instance(), instance(),instance(), instance()) }
     }
     bind<Function> (tag="assignProfile") {
-        singleton { AssignProfile(instance(), instance(), instance(), instance()) }
+        singleton { AssignProfile(instance(), instance(), instance(), instance(), instance()) }
     }
     bind<Function> (tag="requestJoinBusiness") {
-        singleton { RequestJoinBusiness(instance(), instance(), instance(), instance(), instance()) }
+        singleton { RequestJoinBusiness(instance(), instance(), instance(), instance(), instance(), instance()) }
     }
     bind<Function> (tag="reviewJoinBusiness") {
-        singleton { ReviewJoinBusiness(instance(), instance(), instance(), instance()) }
+        singleton { ReviewJoinBusiness(instance(), instance(), instance(), instance(), instance()) }
     }
     bind<Function> (tag="searchBusinesses") {
         singleton { SearchBusinesses(instance<DynamoDbTable<Business>>(), instance()) }
     }
     bind<Function> (tag="configAutoAcceptDeliveries") {
-        singleton { ConfigAutoAcceptDeliveries(instance(), instance(), instance(), instance(), instance()) }
+        singleton { ConfigAutoAcceptDeliveries(instance(), instance(), instance(), instance(), instance(), instance()) }
     }
     bind<Function> (tag="client/profile") {
-        singleton { ClientProfileFunction(instance(), instance(), instance()) }
+        singleton { ClientProfileFunction(instance(), instance(), instance(), instance()) }
     }
     bind<Function> (tag="client/addresses") {
-        singleton { ClientAddressesFunction(instance(), instance(), instance()) }
+        singleton { ClientAddressesFunction(instance(), instance(), instance(), instance()) }
     }
 }
 

--- a/users/src/main/kotlin/ar/com/intrale/Profiles.kt
+++ b/users/src/main/kotlin/ar/com/intrale/Profiles.kt
@@ -12,8 +12,8 @@ const val PROFILE_SALER = "Saler"
 
 const val PROFILE_CLIENT = "Client"
 
-class Profiles(override val config: UsersConfig, override val logger: Logger) :
-    SecuredFunction(config=config, logger=logger ) {
+class Profiles(override val config: UsersConfig, override val logger: Logger, override val jwtValidator: JwtValidator = CognitoJwtValidator(config)) :
+    SecuredFunction(config=config, logger=logger, jwtValidator=jwtValidator) {
     override suspend fun securedExecute(
         business: String,
         function: String,

--- a/users/src/main/kotlin/ar/com/intrale/RegisterSaler.kt
+++ b/users/src/main/kotlin/ar/com/intrale/RegisterSaler.kt
@@ -15,7 +15,8 @@ class RegisterSaler(
     override val logger: Logger,
     private val cognito: CognitoIdentityProviderClient,
     private val tableProfiles: DynamoDbTable<UserBusinessProfile>,
-) : SecuredFunction(config = config, logger = logger) {
+    override val jwtValidator: JwtValidator = CognitoJwtValidator(config)
+) : SecuredFunction(config = config, logger = logger, jwtValidator = jwtValidator) {
 
     override suspend fun securedExecute(
         business: String,

--- a/users/src/main/kotlin/ar/com/intrale/RequestJoinBusiness.kt
+++ b/users/src/main/kotlin/ar/com/intrale/RequestJoinBusiness.kt
@@ -10,8 +10,9 @@ class RequestJoinBusiness(
     override val logger: Logger,
     private val cognito: CognitoIdentityProviderClient,
     private val tableProfiles: DynamoDbTable<UserBusinessProfile>,
-    private val tableBusiness: DynamoDbTable<Business>
-) : SecuredFunction(config = config, logger = logger) {
+    private val tableBusiness: DynamoDbTable<Business>,
+    override val jwtValidator: JwtValidator = CognitoJwtValidator(config)
+) : SecuredFunction(config = config, logger = logger, jwtValidator = jwtValidator) {
 
     fun requestValidation(body: RequestJoinBusinessRequest): Response? {
         return null

--- a/users/src/main/kotlin/ar/com/intrale/ReviewBusinessRegistration.kt
+++ b/users/src/main/kotlin/ar/com/intrale/ReviewBusinessRegistration.kt
@@ -17,8 +17,9 @@ class ReviewBusinessRegistration(
     private val cognito: CognitoIdentityProviderClient,
     private val tableBusiness: DynamoDbTable<Business>,
     private val tableUsers: DynamoDbTable<User>,
-    private val tableProfiles: DynamoDbTable<UserBusinessProfile>
-) : SecuredFunction(config = config, logger = logger) {
+    private val tableProfiles: DynamoDbTable<UserBusinessProfile>,
+    override val jwtValidator: JwtValidator = CognitoJwtValidator(config)
+) : SecuredFunction(config = config, logger = logger, jwtValidator = jwtValidator) {
 
     override suspend fun securedExecute(
         business: String,

--- a/users/src/main/kotlin/ar/com/intrale/ReviewJoinBusiness.kt
+++ b/users/src/main/kotlin/ar/com/intrale/ReviewJoinBusiness.kt
@@ -11,7 +11,8 @@ class ReviewJoinBusiness(
     override val logger: Logger,
     private val cognito: CognitoIdentityProviderClient,
     private val tableProfiles: DynamoDbTable<UserBusinessProfile>,
-) : SecuredFunction(config = config, logger = logger) {
+    override val jwtValidator: JwtValidator = CognitoJwtValidator(config)
+) : SecuredFunction(config = config, logger = logger, jwtValidator = jwtValidator) {
 
     override suspend fun securedExecute(
         business: String,

--- a/users/src/main/kotlin/ar/com/intrale/TestDynamoDB.kt
+++ b/users/src/main/kotlin/ar/com/intrale/TestDynamoDB.kt
@@ -13,8 +13,8 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.dynamodb.model.*
 
 
-class TestDynamoDB(override val config: UsersConfig, val faker: Faker, override val logger: Logger) :
-    SecuredFunction(config=config, logger=logger ) {
+class TestDynamoDB(override val config: UsersConfig, val faker: Faker, override val logger: Logger, override val jwtValidator: JwtValidator = CognitoJwtValidator(config)) :
+    SecuredFunction(config=config, logger=logger, jwtValidator=jwtValidator) {
     override suspend fun securedExecute(
         business: String,
         function: String,

--- a/users/src/main/kotlin/ar/com/intrale/TwoFactorSetup.kt
+++ b/users/src/main/kotlin/ar/com/intrale/TwoFactorSetup.kt
@@ -7,8 +7,8 @@ import org.slf4j.Logger
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable
 import java.security.SecureRandom
 
-class TwoFactorSetup (override val config: UsersConfig, override val logger: Logger, val cognito: CognitoIdentityProviderClient, val tableUsers: DynamoDbTable<User>) :
-    SecuredFunction(config=config, logger=logger ) {
+class TwoFactorSetup (override val config: UsersConfig, override val logger: Logger, val cognito: CognitoIdentityProviderClient, val tableUsers: DynamoDbTable<User>, override val jwtValidator: JwtValidator = CognitoJwtValidator(config)) :
+    SecuredFunction(config=config, logger=logger, jwtValidator=jwtValidator) {
 
         override suspend fun securedExecute(
         business: String,

--- a/users/src/main/kotlin/ar/com/intrale/TwoFactorVerify.kt
+++ b/users/src/main/kotlin/ar/com/intrale/TwoFactorVerify.kt
@@ -14,8 +14,8 @@ import java.security.SecureRandom
 import java.time.Instant
 import javax.crypto.spec.SecretKeySpec
 
-class TwoFactorVerify (override val config: UsersConfig, override val logger: Logger, val cognito: CognitoIdentityProviderClient, val tableUsers: DynamoDbTable<User>) :
-    SecuredFunction(config=config, logger=logger ) {
+class TwoFactorVerify (override val config: UsersConfig, override val logger: Logger, val cognito: CognitoIdentityProviderClient, val tableUsers: DynamoDbTable<User>, override val jwtValidator: JwtValidator = CognitoJwtValidator(config)) :
+    SecuredFunction(config=config, logger=logger, jwtValidator=jwtValidator) {
 
 
     fun requestValidation(body:TwoFactorVerifyRequest): Response? {

--- a/users/src/main/kotlin/ar/com/intrale/Validate.kt
+++ b/users/src/main/kotlin/ar/com/intrale/Validate.kt
@@ -3,8 +3,8 @@ package ar.com.intrale
 import net.datafaker.Faker
 import org.slf4j.Logger
 
-class Validate(override val config: UsersConfig, override val logger: Logger) :
-    SecuredFunction(config=config, logger=logger ) {
+class Validate(override val config: UsersConfig, override val logger: Logger, override val jwtValidator: JwtValidator = CognitoJwtValidator(config)) :
+    SecuredFunction(config=config, logger=logger, jwtValidator=jwtValidator) {
 
 
     override suspend fun securedExecute(business: String, function: String, headers: Map<String, String>, textBody: String): Response {

--- a/users/src/test/kotlin/ar/com/intrale/E2EAssignProfileTest.kt
+++ b/users/src/test/kotlin/ar/com/intrale/E2EAssignProfileTest.kt
@@ -1,0 +1,65 @@
+package ar.com.intrale
+
+import com.google.gson.Gson
+import io.ktor.client.request.*
+import io.ktor.http.*
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class E2EAssignProfileTest : E2ETestBase() {
+
+    @Test
+    fun `asignacion de perfil por platform admin via HTTP`() {
+        val adminEmail = "admin@intrale.com"
+        seedBusiness("intrale")
+        seedPlatformAdmin(adminEmail, "intrale")
+        configureCognitoGetUser(adminEmail)
+
+        e2eTest { client ->
+            val response = client.post("/intrale/assignProfile") {
+                header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                header("Authorization", tokenFor(adminEmail))
+                setBody(
+                    Gson().toJson(
+                        AssignProfileRequest(
+                            email = "newuser@test.com",
+                            profile = PROFILE_BUSINESS_ADMIN
+                        )
+                    )
+                )
+            }
+            assertEquals(HttpStatusCode.OK, response.status)
+
+            val assigned = tableProfiles.items.find {
+                it.email == "newuser@test.com" && it.profile == PROFILE_BUSINESS_ADMIN
+            }
+            assertTrue(assigned != null, "El perfil debe haber sido asignado")
+            assertEquals(BusinessState.APPROVED, assigned.state)
+        }
+    }
+
+    @Test
+    fun `asignacion sin perfil admin retorna no autorizado`() {
+        val userEmail = "user@test.com"
+        seedBusiness("intrale")
+        // No seedeamos perfil de admin para este usuario
+        configureCognitoGetUser(userEmail)
+
+        e2eTest { client ->
+            val response = client.post("/intrale/assignProfile") {
+                header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                header("Authorization", tokenFor(userEmail))
+                setBody(
+                    Gson().toJson(
+                        AssignProfileRequest(
+                            email = "otro@test.com",
+                            profile = PROFILE_BUSINESS_ADMIN
+                        )
+                    )
+                )
+            }
+            assertEquals(HttpStatusCode.Unauthorized, response.status)
+        }
+    }
+}

--- a/users/src/test/kotlin/ar/com/intrale/E2EBusinessRegistrationTest.kt
+++ b/users/src/test/kotlin/ar/com/intrale/E2EBusinessRegistrationTest.kt
@@ -1,0 +1,67 @@
+package ar.com.intrale
+
+import com.google.gson.Gson
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class E2EBusinessRegistrationTest : E2ETestBase() {
+
+    @Test
+    fun `registro de negocio crea negocio en estado pendiente`() {
+        seedBusiness("intrale")
+
+        e2eTest { client ->
+            val response = client.post("/intrale/registerBusiness") {
+                header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                setBody(
+                    Gson().toJson(
+                        RegisterBusinessRequest(
+                            name = "Mi Nuevo Negocio",
+                            emailAdmin = "admin@nuevonegocio.com",
+                            description = "Descripcion del negocio"
+                        )
+                    )
+                )
+            }
+            assertEquals(HttpStatusCode.OK, response.status)
+
+            val created = tableBusiness.items.find { it.emailAdmin == "admin@nuevonegocio.com" }
+            assertTrue(created != null, "El negocio debe existir en la tabla")
+            assertEquals(BusinessState.PENDING, created.state)
+            assertEquals("Descripcion del negocio", created.description)
+        }
+    }
+
+    @Test
+    fun `negocio pendiente duplicado retorna error`() {
+        seedBusiness("intrale")
+        tableBusiness.putItem(
+            Business(
+                name = "Negocio Existente",
+                publicId = "negocio-existente",
+                emailAdmin = "admin@existente.com",
+                state = BusinessState.PENDING
+            )
+        )
+
+        e2eTest { client ->
+            val response = client.post("/intrale/registerBusiness") {
+                header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                setBody(
+                    Gson().toJson(
+                        RegisterBusinessRequest(
+                            name = "Negocio Existente",
+                            emailAdmin = "admin@existente.com",
+                            description = "Duplicado"
+                        )
+                    )
+                )
+            }
+            assertEquals(HttpStatusCode.BadRequest, response.status)
+        }
+    }
+}

--- a/users/src/test/kotlin/ar/com/intrale/E2EJoinBusinessTest.kt
+++ b/users/src/test/kotlin/ar/com/intrale/E2EJoinBusinessTest.kt
@@ -1,0 +1,62 @@
+package ar.com.intrale
+
+import com.google.gson.Gson
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class E2EJoinBusinessTest : E2ETestBase() {
+
+    @Test
+    fun `solicitud de union y aprobacion por business admin`() {
+        val deliveryEmail = "delivery@test.com"
+        val adminEmail = "admin@biz.com"
+        seedBusiness("intrale")
+        seedBusiness("biz", emailAdmin = adminEmail)
+        seedBusinessAdmin(adminEmail, "biz")
+        configureCognitoGetUser(deliveryEmail)
+
+        e2eTest { client ->
+            // 1. Delivery solicita unirse al negocio
+            val joinResponse = client.post("/biz/requestJoinBusiness") {
+                header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                header("Authorization", tokenFor(deliveryEmail))
+                setBody("{}")
+            }
+            assertEquals(HttpStatusCode.OK, joinResponse.status)
+            val body = joinResponse.bodyAsText()
+            assertTrue(body.contains("PENDING"), "El estado inicial debe ser PENDING")
+
+            val pendingProfile = tableProfiles.items.find {
+                it.email == deliveryEmail && it.profile == PROFILE_DELIVERY && it.business == "biz"
+            }
+            assertTrue(pendingProfile != null, "Debe existir el perfil de delivery pendiente")
+            assertEquals(BusinessState.PENDING, pendingProfile.state)
+
+            // 2. Business admin aprueba la solicitud
+            configureCognitoGetUser(adminEmail)
+            val reviewResponse = client.post("/biz/reviewJoinBusiness") {
+                header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                header("Authorization", tokenFor(adminEmail))
+                setBody(
+                    Gson().toJson(
+                        ReviewJoinBusinessRequest(
+                            email = deliveryEmail,
+                            decision = "APPROVED"
+                        )
+                    )
+                )
+            }
+            assertEquals(HttpStatusCode.OK, reviewResponse.status)
+
+            val approvedProfile = tableProfiles.items.find {
+                it.email == deliveryEmail && it.profile == PROFILE_DELIVERY && it.business == "biz"
+            }
+            assertTrue(approvedProfile != null, "El perfil debe existir")
+            assertEquals(BusinessState.APPROVED, approvedProfile.state)
+        }
+    }
+}

--- a/users/src/test/kotlin/ar/com/intrale/E2ESignUpSignInTest.kt
+++ b/users/src/test/kotlin/ar/com/intrale/E2ESignUpSignInTest.kt
@@ -1,0 +1,72 @@
+package ar.com.intrale
+
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.*
+import com.google.gson.Gson
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import io.mockk.coEvery
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class E2ESignUpSignInTest : E2ETestBase() {
+
+    @Test
+    fun `registro de usuario y luego inicio de sesion exitoso`() {
+        seedBusiness("intrale")
+        val email = "user@test.com"
+
+        coEvery { cognito.adminCreateUser(any<AdminCreateUserRequest>()) } returns AdminCreateUserResponse {
+            user = UserType {
+                username = email
+                attributes = listOf(AttributeType { name = EMAIL_ATT_NAME; value = email })
+            }
+        }
+
+        coEvery { cognito.adminInitiateAuth(any<AdminInitiateAuthRequest>()) } returns AdminInitiateAuthResponse {
+            authenticationResult = AuthenticationResultType {
+                idToken = "test-id-token"
+                accessToken = "test-access-token"
+                refreshToken = "test-refresh-token"
+            }
+        }
+
+        e2eTest { client ->
+            // 1. SignUp
+            val signUpResponse = client.post("/intrale/signup") {
+                header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                setBody(Gson().toJson(SignUpRequest(email)))
+            }
+            assertEquals(HttpStatusCode.OK, signUpResponse.status)
+
+            // 2. Simular aprobacion del perfil (en produccion lo haria un admin)
+            seedClientProfile(email, "intrale", DEFAULT_PROFILE, BusinessState.APPROVED)
+
+            // 3. SignIn
+            val signInResponse = client.post("/intrale/signin") {
+                header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                setBody(Gson().toJson(SignInRequest(email, "Password123!", "", "", "")))
+            }
+            assertEquals(HttpStatusCode.OK, signInResponse.status)
+            val body = signInResponse.bodyAsText()
+            assertTrue(body.contains("test-access-token"))
+        }
+    }
+
+    @Test
+    fun `inicio de sesion con usuario no registrado falla`() {
+        seedBusiness("intrale")
+
+        coEvery { cognito.adminInitiateAuth(any<AdminInitiateAuthRequest>()) } throws
+            NotAuthorizedException.invoke { message = "Incorrect username or password." }
+
+        e2eTest { client ->
+            val response = client.post("/intrale/signin") {
+                header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                setBody(Gson().toJson(SignInRequest("nobody@test.com", "wrong", "", "", "")))
+            }
+            assertEquals(HttpStatusCode.Unauthorized, response.status)
+        }
+    }
+}

--- a/users/src/test/kotlin/ar/com/intrale/E2ETestBase.kt
+++ b/users/src/test/kotlin/ar/com/intrale/E2ETestBase.kt
@@ -1,0 +1,203 @@
+package ar.com.intrale
+
+import aws.sdk.kotlin.services.cognitoidentityprovider.CognitoIdentityProviderClient
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.AttributeType
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.GetUserResponse
+import io.ktor.server.testing.*
+import io.mockk.coEvery
+import io.mockk.mockk
+import net.datafaker.Faker
+import org.kodein.di.*
+import org.kodein.di.ktor.di
+import org.slf4j.LoggerFactory
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable
+
+/**
+ * Base abstracta para tests E2E.
+ * Levanta el servidor Ktor con DI real, tablas in-memory, JWT local y Cognito mock.
+ */
+abstract class E2ETestBase {
+
+    protected val jwtValidator = LocalJwtValidator()
+    protected val tableBusiness = InMemoryDynamoDbTable.forBusiness()
+    protected val tableUsers = InMemoryDynamoDbTable.forUser()
+    protected val tableProfiles = InMemoryDynamoDbTable.forProfile()
+    protected val cognito: CognitoIdentityProviderClient = mockk(relaxed = true)
+    protected val logger = LoggerFactory.getLogger("ar.com.intrale.e2e")
+
+    protected fun e2eModule(): DI.Module {
+        val config = UsersConfig(
+            region = "us-east-1",
+            accessKeyId = "key",
+            secretAccessKey = "secret",
+            awsCognitoUserPoolId = "pool",
+            awsCognitoClientId = "test-client-id",
+            tableBusiness = tableBusiness
+        )
+        return DI.Module("e2e", allowSilentOverride = true) {
+            bind<UsersConfig>() { singleton { config } }
+            bind<Config>() { singleton { config } }
+            bind<JwtValidator>() { singleton { jwtValidator } }
+            bind<org.slf4j.Logger>() { singleton { logger } }
+            bind<CognitoIdentityProviderClient>() { singleton { cognito } }
+            bind<DynamoDbTable<Business>>() { singleton { tableBusiness } }
+            bind<DynamoDbTable<User>>() { singleton { tableUsers } }
+            bind<DynamoDbTable<UserBusinessProfile>>() { singleton { tableProfiles } }
+            bind<Faker>() { singleton { Faker() } }
+            bind<ClientProfileRepository>() { singleton { ClientProfileRepository() } }
+
+            // Funciones no seguras
+            bind<Function>(tag = "signup") {
+                singleton { SignUp(instance(), instance(), instance(), instance()) }
+            }
+            bind<Function>(tag = "signupPlatformAdmin") {
+                singleton { SignUpPlatformAdmin(instance(), instance(), instance(), instance()) }
+            }
+            bind<Function>(tag = "signupDelivery") {
+                singleton { SignUpDelivery(instance(), instance(), instance(), instance()) }
+            }
+            bind<Function>(tag = "signin") {
+                singleton { SignIn(instance(), instance(), instance(), instance()) }
+            }
+            bind<Function>(tag = "validate") {
+                singleton { Validate(instance(), instance(), instance()) }
+            }
+            bind<Function>(tag = "recovery") {
+                singleton { PasswordRecovery(instance(), instance(), instance()) }
+            }
+            bind<Function>(tag = "confirm") {
+                singleton { ConfirmPasswordRecovery(instance(), instance(), instance()) }
+            }
+            bind<Function>(tag = "registerBusiness") {
+                singleton { RegisterBusiness(instance(), instance(), instance()) }
+            }
+            bind<Function>(tag = "searchBusinesses") {
+                singleton { SearchBusinesses(instance<DynamoDbTable<Business>>(), instance()) }
+            }
+
+            // Funciones seguras (con JwtValidator inyectado)
+            bind<Function>(tag = "changePassword") {
+                singleton { ChangePassword(instance(), instance(), instance(), instance()) }
+            }
+            bind<Function>(tag = "profiles") {
+                singleton { Profiles(instance(), instance(), instance()) }
+            }
+            bind<Function>(tag = "2fasetup") {
+                singleton { TwoFactorSetup(instance(), instance(), instance(), instance(), instance()) }
+            }
+            bind<Function>(tag = "2faverify") {
+                singleton { TwoFactorVerify(instance(), instance(), instance(), instance(), instance()) }
+            }
+            bind<Function>(tag = "reviewBusiness") {
+                singleton {
+                    ReviewBusinessRegistration(
+                        instance(), instance(), instance("2faverify"),
+                        instance("signup"), instance(),
+                        instance(), instance(), instance(), instance()
+                    )
+                }
+            }
+            bind<Function>(tag = "assignProfile") {
+                singleton { AssignProfile(instance(), instance(), instance(), instance(), instance()) }
+            }
+            bind<Function>(tag = "registerSaler") {
+                singleton { RegisterSaler(instance(), instance(), instance(), instance(), instance()) }
+            }
+            bind<Function>(tag = "requestJoinBusiness") {
+                singleton { RequestJoinBusiness(instance(), instance(), instance(), instance(), instance(), instance()) }
+            }
+            bind<Function>(tag = "reviewJoinBusiness") {
+                singleton { ReviewJoinBusiness(instance(), instance(), instance(), instance(), instance()) }
+            }
+            bind<Function>(tag = "configAutoAcceptDeliveries") {
+                singleton { ConfigAutoAcceptDeliveries(instance(), instance(), instance(), instance(), instance(), instance()) }
+            }
+            bind<Function>(tag = "client/profile") {
+                singleton { ClientProfileFunction(instance(), instance(), instance(), instance()) }
+            }
+            bind<Function>(tag = "client/addresses") {
+                singleton { ClientAddressesFunction(instance(), instance(), instance(), instance()) }
+            }
+        }
+    }
+
+    protected fun e2eTest(block: suspend ApplicationTestBuilder.(io.ktor.client.HttpClient) -> Unit) =
+        testApplication {
+            application {
+                di { import(e2eModule()) }
+                configureDynamicRouting()
+            }
+            block(client)
+        }
+
+    // --- Helpers de seeding ---
+
+    protected fun seedBusiness(
+        name: String,
+        publicId: String = name,
+        state: BusinessState = BusinessState.APPROVED,
+        emailAdmin: String = "admin@$name.com",
+        autoAcceptDeliveries: Boolean = false
+    ) {
+        tableBusiness.putItem(
+            Business(
+                businessId = java.util.UUID.randomUUID().toString(),
+                publicId = publicId,
+                name = name,
+                emailAdmin = emailAdmin,
+                state = state,
+                autoAcceptDeliveries = autoAcceptDeliveries
+            )
+        )
+    }
+
+    protected fun seedPlatformAdmin(email: String, business: String) {
+        tableProfiles.putItem(
+            UserBusinessProfile().apply {
+                this.email = email
+                this.business = business
+                this.profile = PROFILE_PLATFORM_ADMIN
+                this.state = BusinessState.APPROVED
+            }
+        )
+    }
+
+    protected fun seedBusinessAdmin(email: String, business: String) {
+        tableProfiles.putItem(
+            UserBusinessProfile().apply {
+                this.email = email
+                this.business = business
+                this.profile = PROFILE_BUSINESS_ADMIN
+                this.state = BusinessState.APPROVED
+            }
+        )
+    }
+
+    protected fun seedClientProfile(email: String, business: String, profile: String, state: BusinessState = BusinessState.APPROVED) {
+        tableProfiles.putItem(
+            UserBusinessProfile().apply {
+                this.email = email
+                this.business = business
+                this.profile = profile
+                this.state = state
+            }
+        )
+    }
+
+    protected fun tokenFor(email: String): String = jwtValidator.generateToken(email)
+
+    protected fun configureCognitoGetUser(email: String) {
+        coEvery { cognito.getUser(any()) } returns GetUserResponse {
+            username = email
+            userAttributes = listOf(
+                AttributeType { name = EMAIL_ATT_NAME; value = email }
+            )
+        }
+    }
+
+    protected fun resetTables() {
+        tableBusiness.items.clear()
+        tableUsers.items.clear()
+        tableProfiles.items.clear()
+    }
+}

--- a/users/src/test/kotlin/ar/com/intrale/InMemoryDynamoDbTable.kt
+++ b/users/src/test/kotlin/ar/com/intrale/InMemoryDynamoDbTable.kt
@@ -1,0 +1,87 @@
+package ar.com.intrale
+
+import software.amazon.awssdk.core.pagination.sync.SdkIterable
+import software.amazon.awssdk.enhanced.dynamodb.*
+import software.amazon.awssdk.enhanced.dynamodb.model.GetItemEnhancedRequest
+import software.amazon.awssdk.enhanced.dynamodb.model.Page
+import software.amazon.awssdk.enhanced.dynamodb.model.PageIterable
+import java.util.function.Consumer
+
+/**
+ * Implementacion generica in-memory de DynamoDbTable para tests.
+ * Reemplaza las multiples DummyTable classes dispersas en los tests.
+ */
+class InMemoryDynamoDbTable<T>(
+    private val tableName: String,
+    private val schema: TableSchema<T>,
+    private val keyExtractor: (T) -> String
+) : DynamoDbTable<T> {
+
+    val items = mutableListOf<T>()
+
+    override fun mapperExtension(): DynamoDbEnhancedClientExtension? = null
+    override fun tableSchema(): TableSchema<T> = schema
+    override fun tableName(): String = tableName
+    override fun keyFrom(item: T): Key = Key.builder().partitionValue(keyExtractor(item)).build()
+    override fun index(indexName: String): DynamoDbIndex<T> = throw UnsupportedOperationException()
+
+    override fun putItem(item: T) {
+        val key = keyExtractor(item)
+        val index = items.indexOfFirst { keyExtractor(it) == key }
+        if (index >= 0) {
+            items[index] = item
+        } else {
+            items.add(item)
+        }
+    }
+
+    override fun getItem(key: Key): T? =
+        items.firstOrNull { keyExtractor(it) == key.partitionKeyValue().s() }
+
+    override fun getItem(item: T): T? =
+        items.firstOrNull { keyExtractor(it) == keyExtractor(item) }
+
+    override fun getItem(request: GetItemEnhancedRequest): T? = getItem(request.key())
+
+    override fun getItem(requestConsumer: Consumer<GetItemEnhancedRequest.Builder>): T? {
+        val builder = GetItemEnhancedRequest.builder()
+        requestConsumer.accept(builder)
+        return getItem(builder.build().key())
+    }
+
+    override fun updateItem(item: T): T {
+        val key = keyExtractor(item)
+        val index = items.indexOfFirst { keyExtractor(it) == key }
+        if (index >= 0) {
+            items[index] = item
+        } else {
+            items.add(item)
+        }
+        return item
+    }
+
+    override fun deleteItem(key: Key): T? {
+        val index = items.indexOfFirst { keyExtractor(it) == key.partitionKeyValue().s() }
+        return if (index >= 0) items.removeAt(index) else null
+    }
+
+    override fun deleteItem(item: T): T? {
+        val key = keyExtractor(item)
+        val index = items.indexOfFirst { keyExtractor(it) == key }
+        return if (index >= 0) items.removeAt(index) else null
+    }
+
+    override fun scan(): PageIterable<T> =
+        PageIterable.create(SdkIterable { mutableListOf(Page.create(items.toList())).iterator() })
+
+    companion object {
+        fun forBusiness(): InMemoryDynamoDbTable<Business> =
+            InMemoryDynamoDbTable("business", TableSchema.fromBean(Business::class.java)) { it.name ?: "" }
+
+        fun forUser(): InMemoryDynamoDbTable<User> =
+            InMemoryDynamoDbTable("users", TableSchema.fromBean(User::class.java)) { it.email ?: "" }
+
+        fun forProfile(): InMemoryDynamoDbTable<UserBusinessProfile> =
+            InMemoryDynamoDbTable("userbusinessprofile", TableSchema.fromBean(UserBusinessProfile::class.java)) { it.compositeKey }
+    }
+}

--- a/users/src/test/kotlin/ar/com/intrale/LocalJwtValidator.kt
+++ b/users/src/test/kotlin/ar/com/intrale/LocalJwtValidator.kt
@@ -1,0 +1,60 @@
+package ar.com.intrale
+
+import com.auth0.jwt.JWT
+import com.auth0.jwt.algorithms.Algorithm
+import com.auth0.jwt.interfaces.DecodedJWT
+import java.security.KeyPairGenerator
+import java.security.interfaces.RSAPrivateKey
+import java.security.interfaces.RSAPublicKey
+import java.util.Date
+
+/**
+ * JwtValidator local para tests E2E.
+ * Genera y valida JWTs con un par de claves RSA generado en memoria.
+ */
+class LocalJwtValidator(
+    private val clientId: String = "test-client-id"
+) : JwtValidator {
+
+    private val keyPair = KeyPairGenerator.getInstance("RSA").apply { initialize(2048) }.generateKeyPair()
+    private val publicKey = keyPair.public as RSAPublicKey
+    private val privateKey = keyPair.private as RSAPrivateKey
+    private val algorithm = Algorithm.RSA256(publicKey, privateKey)
+    private val issuer = "https://cognito-idp.us-east-1.amazonaws.com/test-pool"
+
+    fun generateToken(
+        email: String,
+        tokenUse: String = "access",
+        overrideClientId: String = clientId
+    ): String {
+        return JWT.create()
+            .withIssuer(issuer)
+            .withClaim("token_use", tokenUse)
+            .withClaim("client_id", overrideClientId)
+            .withClaim("email", email)
+            .withSubject(email)
+            .withIssuedAt(Date())
+            .withExpiresAt(Date(System.currentTimeMillis() + 3600_000))
+            .sign(algorithm)
+    }
+
+    override fun validate(token: String): DecodedJWT {
+        val verifier = JWT.require(algorithm)
+            .withIssuer(issuer)
+            .build()
+
+        val decoded = verifier.verify(token)
+
+        val tokenUse = decoded.getClaim("token_use").asString()
+        if (tokenUse != "access") {
+            throw IllegalArgumentException("Token no es un access_token")
+        }
+
+        val tokenClientId = decoded.getClaim("client_id").asString()
+        if (tokenClientId != clientId) {
+            throw IllegalArgumentException("ClientId invalido")
+        }
+
+        return decoded
+    }
+}


### PR DESCRIPTION
## Summary

- Extract JWT validation from `SecuredFunction` into `JwtValidator` interface (`CognitoJwtValidator` for production, `LocalJwtValidator` for tests)
- Extract routing as `Application.configureDynamicRouting()` for reuse in tests
- Add generic `InMemoryDynamoDbTable<T>` replacing multiple DummyTable classes
- Create `E2ETestBase` with full DI, in-memory tables, and seeding helpers
- 7 new E2E tests covering: signup/signin, business registration, profile assignment, and join business flow

## Production changes

- `JwtValidator` interface + `CognitoJwtValidator` implementation (backward compatible)
- `SecuredFunction` accepts `jwtValidator` parameter with default `CognitoJwtValidator`
- 13 subclasses updated mechanically to pass the new parameter
- `Modules.kt` updated with `JwtValidator` binding
- `Application.kt`: routing extracted as public function

## Test plan

- [x] `backend:test` passes
- [x] `users:test` - 144 tests pass (7 new E2E + 137 existing), 0 failures