### PR TITLE
fix: alinear versión de Kotlin en gradle.properties y fix buildSrc

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-kotlin.version=2.2.0
+kotlin.version=2.2.21
 
 kotlin.code.style=official
 

--- a/tools/forbidden-strings-processor/build.gradle.kts
+++ b/tools/forbidden-strings-processor/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(21)
 }
 
 dependencies {
@@ -17,8 +17,6 @@ dependencies {
 
     // KSP API alineado por catálogo
     compileOnly(libs.ksp.api)
-
-    implementation("com.google.devtools.ksp:symbol-processing-api:2.2.0-2.0.2")
     testImplementation(kotlin("test"))
 }
 


### PR DESCRIPTION
## Resumen

Alineación de versiones de Kotlin en el monorepo para resolver errores de metadata y permitir compilación exitosa de artefactos multiplataforma.

### Cambios

- **gradle.properties**: Actualizar `kotlin.version` de `2.2.0` → `2.2.21` para alinear con `libs.versions.toml` (version catalog)
- **tools/forbidden-strings-processor/build.gradle.kts**:
  - Eliminar dependencia hardcodeada duplicada: `implementation("com.google.devtools.ksp:symbol-processing-api:2.2.0-2.0.2")` (ya existía `compileOnly(libs.ksp.api)` con `2.2.21-2.0.4`)
  - Actualizar `jvmToolchain(17)` → `jvmToolchain(21)` para respetar el toolchain Java 21 obligatorio del proyecto

## Plan de tests

- [x] Ejecutado `./gradlew clean build --console=plain`
- [x] BUILD SUCCESSFUL en 25m 59s
- [x] 436 tareas: 405 ejecutadas, 31 up-to-date
- [x] Sin errores de metadata de Kotlin
- [x] Sin errores de compilación en ningún módulo (Android, Desktop, Wasm, iOS, backend)

Closes #445

🤖 Generado con [Claude Code](https://claude.com/claude-code)