### PR TITLE
fix: reemplazar em-dash Unicode por guión ASCII en Start-Agente.ps1

### DIFF
--- a/scripts/Start-Agente.ps1
+++ b/scripts/Start-Agente.ps1
@@ -104,7 +104,7 @@ function Start-UnAgente {
 
     # Abrir nueva terminal PowerShell con claude ejecutando
     $escapedPrompt = $prompt -replace '"', '\"'
-    $command = "Set-Location '$wtDirResolved'; Write-Host ''; Write-Host '  Agente $($Agente.numero) — issue #$issue ($slug)' -ForegroundColor Cyan; Write-Host '  Branch: $branch' -ForegroundColor Cyan; Write-Host ''; claude `"$escapedPrompt`""
+    $command = "Set-Location '$wtDirResolved'; Write-Host ''; Write-Host '  Agente $($Agente.numero) - issue #$issue ($slug)' -ForegroundColor Cyan; Write-Host '  Branch: $branch' -ForegroundColor Cyan; Write-Host ''; claude `"$escapedPrompt`""
 
     Write-Host ">> Abriendo terminal con claude..."
     Start-Process powershell -ArgumentList "-NoExit", "-Command", $command


### PR DESCRIPTION
## Summary
- Reemplaza el carácter em-dash (`—`, U+2014) por guión ASCII (`-`) en la línea 107 de `Start-Agente.ps1`
- El em-dash causaba `ParseException` al construir el comando para `Start-Process`, impidiendo lanzar agentes

## Test plan
- [x] Ejecutar `.\scripts\Start-Agente.ps1 all` sin error de parseo

🤖 Generated with [Claude Code](https://claude.com/claude-code)