### PR TITLE
fix: corregir ParseException en Stop-Agente.ps1

### DIFF
--- a/scripts/Stop-Agente.ps1
+++ b/scripts/Stop-Agente.ps1
@@ -142,7 +142,7 @@ function Stop-UnAgente {
         # --- Commit ---
         Write-Host ">> Committing cambios..."
         git add -A
-        $commitMsg = "feat: $issueTitle (Closes #$issue)`n`nCo-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+        $commitMsg = ('feat: {0} (Closes #{1})' -f $issueTitle, $issue) + "`n`nCo-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
         git commit -m $commitMsg
 
         # --- Push ---
@@ -151,7 +151,7 @@ function Stop-UnAgente {
 
         # --- Crear PR ---
         Write-Host ">> Creando PR..."
-        $prTitle = "feat: $issueTitle (Closes #$issue)"
+        $prTitle = 'feat: {0} (Closes #{1})' -f $issueTitle, $issue
         $prBody = @"
 ## Summary
 - Implementacion automatizada del issue #$issue


### PR DESCRIPTION
## Summary
- Corrige ParseException en líneas 145 y 154 de `Stop-Agente.ps1`
- PowerShell interpretaba `(Closes #$issue)` como subexpresión dentro de strings con comillas dobles
- Usa `-f` format operator con single quotes para evitar el problema

## Test plan
- [x] Ejecutar `.\scripts\Stop-Agente.ps1 all` sin error de parseo

🤖 Generated with [Claude Code](https://claude.com/claude-code)