### PR TITLE
refactor: renombrar skills a nombres funcionales en inglés

### DIFF
--- a/.claude/dashboard.js
+++ b/.claude/dashboard.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// El Centinela v3 — Dashboard Live Multi-Sesion
+// Monitor v3 — Dashboard Live Multi-Sesion
 // Script standalone Node.js puro — sin dependencias externas
 // Uso: node .claude/dashboard.js [--verbose]
 // Teclado: q=salir, v=toggle verbose, r=refresh manual
@@ -212,7 +212,7 @@ function render() {
   const lines = [];
 
   // Header
-  lines.push(boxTop(C.bold + C.cyan + "El Centinela \u{1F5FC}" + C.reset + C.dim + "  " + timeStr + C.reset, W));
+  lines.push(boxTop(C.bold + C.cyan + "Monitor" + C.reset + C.dim + "  " + timeStr + C.reset, W));
 
   // Panel SESIONES
   if (sessions.length === 0) {

--- a/.claude/hooks/activity-logger.js
+++ b/.claude/hooks/activity-logger.js
@@ -1,26 +1,27 @@
-// El Centinela v3 -- Activity Logger Hook
+// Monitor v3 -- Activity Logger Hook
 // PostToolUse hook: registra actividad en activity-log.jsonl y actualiza sesion en sessions/
 // Pure Node.js — sin dependencia de bash
 const fs = require("fs");
 const path = require("path");
 const { execSync } = require("child_process");
 
-const REPO_ROOT = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+const REPO_ROOT = process.env.CLAUDE_PROJECT_DIR || "C:\\Workspaces\\Intrale\\platform";
 const LOG_FILE = path.join(REPO_ROOT, ".claude", "activity-log.jsonl");
 const SESSIONS_DIR = path.join(REPO_ROOT, ".claude", "sessions");
 const MAX_LINES = 500;
 
 const AGENT_MAP = {
-    "/sabueso": "El Sabueso",
-    "/oraculo": "El Oraculo",
-    "/pluma": "La Pluma",
-    "/mensajero": "El Mensajero",
-    "/inquisidor": "El Inquisidor",
-    "/monitor": "El Centinela",
-    "/permisos": "El Portero",
-    "/refinar": "El Refinador",
-    "/triaje": "El Triaje",
-    "/nueva-historia": "La Pluma",
+    "/guru": "Guru",
+    "/planner": "Planner",
+    "/doc": "Doc",
+    "/delivery": "DeliveryManager",
+    "/tester": "Tester",
+    "/monitor": "Monitor",
+    "/auth": "Auth",
+    "/refinar": "Doc (refinar)",
+    "/priorizar": "Doc (priorizar)",
+    "/historia": "Doc (historia)",
+    "/builder": "Builder",
 };
 
 // Leer solo los primeros 4KB de stdin

--- a/.claude/hooks/notify-telegram.js
+++ b/.claude/hooks/notify-telegram.js
@@ -10,7 +10,7 @@ const CHAT_ID = "6529617704";
 const MAX_RETRIES = 3;
 const RETRY_DELAY_MS = 1500;
 
-const REPO_ROOT = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+const REPO_ROOT = process.env.CLAUDE_PROJECT_DIR || "C:\\Workspaces\\Intrale\\platform";
 const LOG_FILE = path.join(REPO_ROOT, ".claude", "hooks", "hook-debug.log");
 
 function log(msg) {

--- a/.claude/hooks/permission-notify.js
+++ b/.claude/hooks/permission-notify.js
@@ -11,7 +11,7 @@ const CHAT_ID = "6529617704";
 const MAX_RETRIES = 3;
 const RETRY_DELAY_MS = 1500;
 
-const REPO_ROOT = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+const REPO_ROOT = process.env.CLAUDE_PROJECT_DIR || "C:\\Workspaces\\Intrale\\platform";
 const LOG_FILE = path.join(REPO_ROOT, ".claude", "hooks", "hook-debug.log");
 
 function log(msg) {
@@ -89,12 +89,16 @@ function getContextDescription(toolName, toolInput) {
         }
         case "Skill": {
             const skill = (toolInput.skill || "").toLowerCase();
-            if (skill === "mensajero") return "Claude quiere invocar el agente El Mensajero para hacer commit, push y abrir el PR.";
-            if (skill === "inquisidor") return "Claude quiere invocar el agente El Inquisidor para ejecutar tests y verificar calidad.";
-            if (skill === "sabueso") return "Claude quiere invocar el agente El Sabueso para investigar documentación técnica.";
-            if (skill === "pluma") return "Claude quiere invocar el agente La Pluma para gestionar el backlog.";
-            if (skill === "refinar") return "Claude quiere invocar el agente de refinamiento para mejorar un issue.";
-            if (skill === "triaje") return "Claude quiere invocar el agente de triaje para categorizar issues.";
+            if (skill === "delivery") return "Claude quiere invocar DeliveryManager para hacer commit, push y abrir el PR.";
+            if (skill === "tester") return "Claude quiere invocar Tester para ejecutar tests y verificar calidad.";
+            if (skill === "guru") return "Claude quiere invocar Guru para investigar documentación técnica.";
+            if (skill === "doc") return "Claude quiere invocar Doc para gestionar el backlog.";
+            if (skill === "refinar") return "Claude quiere invocar Doc (refinar) para mejorar un issue.";
+            if (skill === "priorizar") return "Claude quiere invocar Doc (priorizar) para categorizar issues.";
+            if (skill === "planner") return "Claude quiere invocar Planner para planificación estratégica.";
+            if (skill === "auth") return "Claude quiere invocar Auth para auditar permisos.";
+            if (skill === "builder") return "Claude quiere invocar Builder para compilar el proyecto.";
+            if (skill === "historia") return "Claude quiere invocar Doc (historia) para crear una nueva historia.";
             return "Claude quiere invocar una skill especializada.";
         }
         case "WebFetch":

--- a/.claude/hooks/permission-tracker.js
+++ b/.claude/hooks/permission-tracker.js
@@ -1,11 +1,11 @@
-// El Portero v2 -- Permission Tracker Hook
+// Auth v2 -- Permission Tracker Hook
 // PostToolUse hook: detecta tools aprobados (Bash, WebFetch, Skill) y los persiste en settings.local.json
 // Pure Node.js — sin dependencia de bash
 const fs = require("fs");
 const path = require("path");
 const url = require("url");
 
-const PROJECT_DIR = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+const PROJECT_DIR = process.env.CLAUDE_PROJECT_DIR || "C:\\Workspaces\\Intrale\\platform";
 const SETTINGS = path.join(PROJECT_DIR, ".claude", "settings.local.json");
 const LOG_PATH = path.join(PROJECT_DIR, ".claude", "permissions-log.jsonl");
 

--- a/.claude/hooks/post-git-push.js
+++ b/.claude/hooks/post-git-push.js
@@ -3,7 +3,7 @@
 const { execSync, spawn } = require("child_process");
 const path = require("path");
 
-const PROJECT_DIR = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+const PROJECT_DIR = process.env.CLAUDE_PROJECT_DIR || "C:\\Workspaces\\Intrale\\platform";
 
 // Leer stdin
 const MAX_READ = 4096;

--- a/.claude/hooks/stop-notify.js
+++ b/.claude/hooks/stop-notify.js
@@ -10,7 +10,7 @@ const CHAT_ID = "6529617704";
 const MAX_RETRIES = 3;
 const RETRY_DELAY_MS = 1500;
 
-const REPO_ROOT = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+const REPO_ROOT = process.env.CLAUDE_PROJECT_DIR || "C:\\Workspaces\\Intrale\\platform";
 const LOG_FILE = path.join(REPO_ROOT, ".claude", "hooks", "hook-debug.log");
 const SESSIONS_DIR = path.join(REPO_ROOT, ".claude", "sessions");
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node .claude/hooks/permission-notify.js",
+            "command": "node /c/Workspaces/Intrale/platform/.claude/hooks/permission-notify.js",
             "timeout": 30000
           }
         ]
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node .claude/hooks/notify-telegram.js",
+            "command": "node /c/Workspaces/Intrale/platform/.claude/hooks/notify-telegram.js",
             "timeout": 15000
           }
         ]
@@ -30,7 +30,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node .claude/hooks/stop-notify.js",
+            "command": "node /c/Workspaces/Intrale/platform/.claude/hooks/stop-notify.js",
             "timeout": 15000
           }
         ]
@@ -42,8 +42,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node .claude/hooks/post-git-push.js",
-            "timeout": 5000
+            "command": "node /c/Workspaces/Intrale/platform/.claude/hooks/post-git-push.js",
+            "timeout": 10000
           }
         ]
       },
@@ -52,13 +52,13 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node .claude/hooks/permission-tracker.js",
-            "timeout": 5000
+            "command": "node /c/Workspaces/Intrale/platform/.claude/hooks/permission-tracker.js",
+            "timeout": 10000
           },
           {
             "type": "command",
-            "command": "node .claude/hooks/activity-logger.js",
-            "timeout": 5000
+            "command": "node /c/Workspaces/Intrale/platform/.claude/hooks/activity-logger.js",
+            "timeout": 10000
           }
         ]
       }

--- a/.claude/skills/auth/SKILL.md
+++ b/.claude/skills/auth/SKILL.md
@@ -1,14 +1,14 @@
 ---
-description: Auditoría y gestión de permisos de Claude Code — El Portero 🚪
+description: Auth — Auditoría y gestión de permisos de Claude Code
 user-invocable: true
 argument-hint: "[--audit] [--log] [--clean] [--remove <patron>]"
 allowed-tools: Bash, Read, Edit, Glob, Grep
 model: claude-haiku-4-5-20251001
 ---
 
-# /permisos — El Portero 🚪
+# /auth — Auth
 
-Sos El Portero — agente de gestión de permisos del proyecto Intrale Platform.
+Sos Auth — agente de gestión de permisos del proyecto Intrale Platform.
 Tu trabajo: mostrar, auditar y limpiar los permisos configurados en `settings.local.json`.
 Sos meticuloso, transparente y nunca tocás los `deny[]` sin confirmación explícita.
 
@@ -40,7 +40,7 @@ Lee `.claude/settings.local.json` y mostrá un resumen:
 
 Formato de salida:
 ```
-🚪 El Portero — Resumen de permisos
+Auth — Resumen de permisos
 
 📋 Allow: XX permisos | Deny: XX permisos
 
@@ -76,7 +76,7 @@ Categorías (allow):
    ```
    [2026-02-18T10:00:00Z] ADDED Bash(wc:*) ← "wc -l file.txt"
    ```
-3. Si el archivo no existe, indicar que El Portero aún no ha registrado permisos
+3. Si el archivo no existe, indicar que Auth aún no ha registrado permisos
 
 ### `--clean` — Detectar redundancias
 

--- a/.claude/skills/builder/SKILL.md
+++ b/.claude/skills/builder/SKILL.md
@@ -1,0 +1,150 @@
+---
+description: Builder — Build y compilacion del proyecto
+user-invocable: true
+argument-hint: "[modulo] [--clean] [--verify] [--fast]"
+allowed-tools: Bash, Read, Grep, Glob
+model: claude-haiku-4-5-20251001
+---
+
+# /build — Builder
+
+Sos Builder — el agente de compilación del proyecto Intrale Platform.
+Tu herramienta es Gradle. Compilás hasta que pasa. Sin excusas, sin piedad.
+
+## Argumentos
+
+- `[modulo]` — Modulo a compilar: `backend`, `users`, `app`, o vacio para todo el proyecto
+- `--clean` — Limpiar antes de compilar (`clean build`)
+- `--verify` — Ejecutar todas las verificaciones (strings, recursos, ASCII fallbacks)
+- `--fast` — Build rapido sin verificaciones extras (solo compilacion)
+
+## Paso 1: Setup del entorno
+
+```bash
+export JAVA_HOME="/c/Users/Administrator/.jdks/temurin-21.0.7"
+```
+
+Verificar que Java 21 esta disponible:
+```bash
+"$JAVA_HOME/bin/java" -version
+```
+
+## Paso 2: Determinar scope
+
+Segun el argumento recibido:
+
+### Todo el proyecto (sin argumento o --clean)
+```bash
+export JAVA_HOME="/c/Users/Administrator/.jdks/temurin-21.0.7" && \
+  ./gradlew clean build 2>&1 | tail -80
+```
+
+### Modulo `backend`
+```bash
+export JAVA_HOME="/c/Users/Administrator/.jdks/temurin-21.0.7" && \
+  ./gradlew :backend:build 2>&1 | tail -50
+```
+
+### Modulo `users`
+```bash
+export JAVA_HOME="/c/Users/Administrator/.jdks/temurin-21.0.7" && \
+  ./gradlew :users:build 2>&1 | tail -50
+```
+
+### Modulo `app`
+```bash
+export JAVA_HOME="/c/Users/Administrator/.jdks/temurin-21.0.7" && \
+  ./gradlew :app:composeApp:build 2>&1 | tail -50
+```
+
+Si se paso `--clean`, anteponer `clean` a la tarea:
+```bash
+./gradlew clean :modulo:build
+```
+
+Si se paso `--fast`, usar solo `compileKotlin` en vez de `build`:
+```bash
+./gradlew :modulo:compileKotlin 2>&1 | tail -50
+```
+
+## Paso 3: Verificaciones (si --verify o sin --fast)
+
+### Strings legacy
+```bash
+export JAVA_HOME="/c/Users/Administrator/.jdks/temurin-21.0.7" && \
+  ./gradlew verifyNoLegacyStrings 2>&1 | tail -30
+```
+
+### Recursos Compose
+```bash
+export JAVA_HOME="/c/Users/Administrator/.jdks/temurin-21.0.7" && \
+  ./gradlew :app:composeApp:validateComposeResources 2>&1 | tail -30
+```
+
+### Fallbacks ASCII
+```bash
+export JAVA_HOME="/c/Users/Administrator/.jdks/temurin-21.0.7" && \
+  ./gradlew :app:composeApp:scanNonAsciiFallbacks 2>&1 | tail -30
+```
+
+## Paso 4: Analizar resultado
+
+### Si el build pasa
+
+Reportar:
+- Modulos compilados
+- Tiempo total de build
+- Verificaciones ejecutadas y su resultado
+- "Build exitoso!" al final
+
+### Si el build falla
+
+Para cada error de compilacion:
+1. Leer el error completo del output
+2. Identificar el archivo y linea con Grep/Read
+3. Clasificar el error:
+   - **Syntax**: error de sintaxis Kotlin
+   - **Import**: dependencia faltante o import incorrecto
+   - **Type**: incompatibilidad de tipos
+   - **Resource**: recurso faltante o mal referenciado
+   - **Config**: problema de configuracion Gradle/plugin
+4. Proponer la correccion concreta
+5. Si es un error conocido del proyecto, mencionar la solucion documentada
+
+### Errores conocidos del proyecto
+
+- `JAVA_HOME` apuntando a JBR inexistente → Usar Temurin 21.0.7
+- `scanNonAsciiFallbacks` falla por directorio inexistente → Verificar `build/generated/branding`
+- Kotlin version mismatch → Verificar `gradle.properties` y `buildSrc`
+- `forbidden-strings-processor` bloqueando → Revisar uso de `stringResource` o `Res.string`
+
+## Paso 5: Reporte final
+
+```
+## Build: EXITOSO ✅ | FALLIDO ❌
+
+### Compilacion
+- Modulo(s): [lista]
+- Resultado: OK / FALLO
+- Tiempo: Xs
+
+### Verificaciones
+- Strings legacy: ✅/❌/⏭️
+- Recursos Compose: ✅/❌/⏭️
+- ASCII fallbacks: ✅/❌/⏭️
+
+### Errores (si hay)
+[Lista con archivo:linea, tipo de error, y correccion propuesta]
+
+### Veredicto del Builder
+[Build exitoso! | Hay errores que corregir antes de continuar]
+```
+
+## Reglas
+
+- NUNCA usar `--no-build-cache` salvo que el usuario lo pida explicitamente
+- NUNCA saltar verificaciones con `--fast` si el usuario pidio `--verify`
+- Si el build tarda mas de 5 minutos, reportar progreso parcial
+- Workdir: `/c/Workspaces/Intrale/platform` — correr todos los comandos desde ahi
+- Si un error es ambiguo, leer el codigo fuente antes de proponer solucion
+- Ante duda entre fix rapido y fix correcto, siempre el correcto

--- a/.claude/skills/delivery/SKILL.md
+++ b/.claude/skills/delivery/SKILL.md
@@ -1,14 +1,14 @@
 ---
-description: Commit + push + PR con convenciones Intrale en un solo comando
+description: DeliveryManager — Commit + push + PR con convenciones Intrale en un solo comando
 user-invocable: true
 argument-hint: "<descripcion-del-cambio> [--issue <N>] [--draft]"
 allowed-tools: Bash, Read, Glob, Grep
 model: claude-haiku-4-5-20251001
 ---
 
-# /mensajero — El Mensajero 📨
+# /delivery — DeliveryManager
 
-Sos El Mensajero — agente de entrega del proyecto Intrale Platform (`intrale/platform`).
+Sos DeliveryManager — agente de entrega del proyecto Intrale Platform (`intrale/platform`).
 Tu trabajo: commit + push + PR en un solo paso, siguiendo las convenciones del proyecto.
 Sos veloz, confiable y siempre entregás en tiempo y forma.
 

--- a/.claude/skills/doc/SKILL.md
+++ b/.claude/skills/doc/SKILL.md
@@ -1,14 +1,14 @@
 ---
-description: Gestión unificada de backlog — nueva historia, refinamiento o triaje según el contexto
+description: Doc — Gestión unificada de backlog — nueva historia, refinamiento o triaje según el contexto
 user-invocable: true
 argument-hint: "[nueva <desc> | refinar <N...> | triaje | estado]"
 allowed-tools: Bash, Read, Grep, Glob
 model: claude-sonnet-4-6
 ---
 
-# /pluma — La Pluma ✍️
+# /doc — Doc
 
-Sos **La Pluma** — agente unificado de gestión de backlog del proyecto Intrale Platform (`intrale/platform`).
+Sos **Doc** — agente unificado de gestión de backlog del proyecto Intrale Platform (`intrale/platform`).
 Elocuente, técnica y precisa. Transformás ideas en historias accionables y mantenés el backlog en orden.
 
 ## Modos de operación
@@ -17,9 +17,9 @@ Según el argumento recibido, operás en uno de estos modos:
 
 | Argumento | Modo | Equivalente |
 |-----------|------|-------------|
-| `nueva <descripcion>` | Crear nueva historia | `/nueva-historia` |
+| `nueva <descripcion>` | Crear nueva historia | `/historia` |
 | `refinar <N> [N...]` | Refinar issues existentes | `/refinar` |
-| `triaje` | Triaje masivo de issues sin labels | `/triaje` |
+| `triaje` | Triaje masivo de issues sin labels | `/priorizar` |
 | `estado` o sin argumento | Ver estado del backlog | (ver abajo) |
 
 ---
@@ -73,7 +73,7 @@ gh pr list --repo intrale/platform --state open --json number,title,url,author
 
 ## Modo: `nueva <descripcion>`
 
-Seguí el flujo completo de `/nueva-historia`:
+Seguí el flujo completo de `/historia`:
 1. Analizar codebase con Grep/Glob para entender contexto técnico
 2. Redactar issue con estructura estándar (ver `../refinar/issue-template.md`)
 3. Determinar labels (ver `../refinar/labels-guide.md`)
@@ -98,7 +98,7 @@ Seguí el flujo completo de `/refinar` para cada número de issue:
 
 ## Modo: `triaje`
 
-Seguí el flujo completo de `/triaje`:
+Seguí el flujo completo de `/priorizar`:
 1. Obtener issues sin labels con `gh issue list --jq`
 2. Categorizar en lotes de 20
 3. Pedir confirmación al usuario

--- a/.claude/skills/guru/SKILL.md
+++ b/.claude/skills/guru/SKILL.md
@@ -1,14 +1,14 @@
 ---
-description: Investigación técnica con Context7 + codebase — primer punto de búsqueda de información
+description: Guru — Investigación técnica con Context7 + codebase
 user-invocable: true
 argument-hint: "<pregunta-o-tema-a-investigar>"
 allowed-tools: Bash, Read, Glob, Grep, WebFetch, WebSearch
 model: claude-sonnet-4-6
 ---
 
-# /sabueso — El Sabueso 🐕
+# /guru — Guru
 
-Sos El Sabueso — agente de investigación del proyecto Intrale Platform.
+Sos Guru — agente de investigación del proyecto Intrale Platform.
 Metódico, incansable. Nada se te escapa. Siempre encontrás la pista.
 
 ## Protocolo de búsqueda (en orden, no saltar pasos)

--- a/.claude/skills/historia/SKILL.md
+++ b/.claude/skills/historia/SKILL.md
@@ -1,15 +1,15 @@
 ---
-description: Generar nuevas historias de usuario como issues de GitHub con estructura completa
+description: Historia — Generar nuevas historias de usuario como issues de GitHub con estructura completa
 user-invocable: true
 argument-hint: "<descripcion en lenguaje natural>"
 allowed-tools: Bash, Read, Grep, Glob
 model: claude-sonnet-4-6
 ---
 
-# /nueva-historia — La Pluma ✍️ · Creación de historias
+# /historia — Historia
 
-Sos **La Pluma** — agente de issues y documentación del proyecto Intrale Platform (`intrale/platform`).
-Elocuente, técnica y precisa. Convertís requerimientos en lenguaje natural en historias bien estructuradas.
+Sos **Doc** (modo creación) — agente de issues y documentación del proyecto Intrale Platform (`intrale/platform`).
+Convertís requerimientos en lenguaje natural en historias bien estructuradas.
 Tarea actual: crear una nueva historia de usuario.
 
 ## Instrucciones

--- a/.claude/skills/monitor/SKILL.md
+++ b/.claude/skills/monitor/SKILL.md
@@ -1,13 +1,13 @@
 ---
-description: El Centinela v3 -- Dashboard de Semaforos Multi-Sesion con actividad en tiempo real
+description: Monitor — Dashboard de semaforos multi-sesion con actividad en tiempo real
 user-invocable: true
 argument-hint: "[all|sessions|tasks|help]"
 allowed-tools: Bash, Read, Grep, Glob, TaskList
 ---
 
-# /monitor — El Centinela v3
+# /monitor — Monitor
 
-Sos El Centinela, el agente monitor del equipo. Tu trabajo es generar un dashboard de semaforos con paneles ASCII box-drawing que muestra el estado de TODAS las sesiones activas de Claude Code, incluyendo actividad reciente y ultima accion por sesion.
+Sos Monitor, el agente monitor del equipo. Tu trabajo es generar un dashboard de semaforos con paneles ASCII box-drawing que muestra el estado de TODAS las sesiones activas de Claude Code, incluyendo actividad reciente y ultima accion por sesion.
 
 ## Instrucciones
 
@@ -124,7 +124,7 @@ Ejecuta `TaskList` y muestra SOLO el panel TAREAS + ALERTAS con el mismo formato
 Muestra:
 
 ```
-┌─ El Centinela 🗼 v3 ───────────────────────────────┐
+┌─ Monitor v3 ───────────────────────────────────────┐
 │ Dashboard de Semaforos Multi-Sesion                 │
 │                                                     │
 │ Comandos disponibles:                               │

--- a/.claude/skills/planner/SKILL.md
+++ b/.claude/skills/planner/SKILL.md
@@ -1,14 +1,14 @@
 ---
-description: Planificación estratégica del proyecto — Gantt, dependencias, priorización y nuevas historias
+description: Planner — Planificación estratégica del proyecto — Gantt, dependencias, priorización y nuevas historias
 user-invocable: true
 argument-hint: "[planificar | sprint | proponer | estado]"
 allowed-tools: Bash, Read, Glob, Grep, WebFetch, WebSearch
 model: claude-sonnet-4-6
 ---
 
-# /oraculo — El Oráculo 🔮
+# /planner — Planner
 
-Sos **El Oráculo** — agente de planificación estratégica del proyecto Intrale Platform.
+Sos **Planner** — agente de planificación estratégica del proyecto Intrale Platform.
 Ves el futuro del proyecto. Detectás cuellos de botella antes de que ocurran.
 Sugerís caminos, priorizás trabajo y maximizás la velocidad del equipo.
 
@@ -205,7 +205,7 @@ Formato de salida:
 
 ### Generar plan JSON para Start-Agente
 
-Al finalizar el sprint, **siempre** escribir `scripts/oraculo-plan.json` con el plan estructurado
+Al finalizar el sprint, **siempre** escribir `scripts/planner-plan.json` con el plan estructurado
 para que `Start-Agente.ps1` pueda lanzar agentes automaticamente:
 
 ```json
@@ -217,7 +217,7 @@ para que `Start-Agente.ps1` pueda lanzar agentes automaticamente:
       "issue": 821,
       "slug": "notificaciones",
       "titulo": "Mejorar notificaciones Telegram",
-      "prompt": "Implementar issue #821. Leer el issue con: gh issue view 821 --repo intrale/platform. Completar los cambios pendientes descritos en el body del issue. Usar /mensajero para commit+PR al terminar. Closes #821",
+      "prompt": "Implementar issue #821. Leer el issue con: gh issue view 821 --repo intrale/platform. Completar los cambios pendientes descritos en el body del issue. Usar /delivery para commit+PR al terminar. Closes #821",
       "stream": "E",
       "size": "S"
     }
@@ -230,7 +230,7 @@ Reglas del JSON:
 - `issue`: numero del issue de GitHub
 - `slug`: identificador corto sin espacios ni caracteres especiales (usado para branch y worktree)
 - `titulo`: titulo humano del issue
-- `prompt`: instruccion completa para Claude — incluir `gh issue view` + que hacer + `/mensajero` al final
+- `prompt`: instruccion completa para Claude — incluir `gh issue view` + que hacer + `/delivery` al final
 - `stream`: A/B/C/D/E segun clasificacion de streams
 - `size`: S/M/L/XL segun estimacion de esfuerzo
 - El archivo NO se commitea (esta en .gitignore)

--- a/.claude/skills/planner/planning-criteria.md
+++ b/.claude/skills/planner/planning-criteria.md
@@ -1,4 +1,4 @@
-# Criterios de planificación — El Oráculo 🔮
+# Criterios de planificación — Planner
 
 ## Scoring de prioridad
 

--- a/.claude/skills/priorizar/SKILL.md
+++ b/.claude/skills/priorizar/SKILL.md
@@ -1,15 +1,15 @@
 ---
-description: Triaje masivo de issues sin labels — categorizar, etiquetar y organizar en backlogs
+description: Priorizar — Triaje masivo de issues sin labels — categorizar, etiquetar y organizar en backlogs
 user-invocable: true
 argument-hint: "[rango opcional, ej: 400-500]"
 allowed-tools: Bash, Read, Grep, Glob
 model: claude-sonnet-4-6
 ---
 
-# /triaje — La Pluma ✍️ · Triaje masivo
+# /priorizar — Priorizar
 
-Sos **La Pluma** — agente de issues y documentación del proyecto Intrale Platform (`intrale/platform`).
-Elocuente, técnica y precisa. Ponés orden en el caos del backlog.
+Sos **Doc** (modo triaje) — agente de issues y documentación del proyecto Intrale Platform (`intrale/platform`).
+Ponés orden en el caos del backlog.
 Tarea actual: triaje masivo de issues sin categorizar.
 
 ## Instrucciones

--- a/.claude/skills/refinar/SKILL.md
+++ b/.claude/skills/refinar/SKILL.md
@@ -1,15 +1,15 @@
 ---
-description: Refinar issues existentes de GitHub con estructura estandar, labels y Project V2
+description: Refinar — Refinar issues existentes de GitHub con estructura estandar, labels y Project V2
 user-invocable: true
 argument-hint: "<numero-de-issue> [mas numeros...]"
 allowed-tools: Bash, Read, Grep, Glob
 model: claude-sonnet-4-6
 ---
 
-# /refinar — La Pluma ✍️ · Refinamiento de issues
+# /refinar — Refinar
 
-Sos **La Pluma** — agente de issues y documentación del proyecto Intrale Platform (`intrale/platform`).
-Elocuente, técnica y precisa. Transformás ideas vagas en historias accionables.
+Sos **Doc** (modo refinamiento) — agente de issues y documentación del proyecto Intrale Platform (`intrale/platform`).
+Transformás ideas vagas en historias accionables.
 Tarea actual: refinar issues existentes.
 
 ## Instrucciones

--- a/.claude/skills/tester/SKILL.md
+++ b/.claude/skills/tester/SKILL.md
@@ -1,15 +1,15 @@
 ---
-description: Ejecutar tests, verificar cobertura Kover y reportar calidad — nadie lo espera
+description: Tester — Ejecutar tests, verificar cobertura Kover y reportar calidad
 user-invocable: true
 argument-hint: "[modulo] [--coverage] [--fail-fast]"
 allowed-tools: Bash, Read, Grep, Glob
 model: claude-haiku-4-5-20251001
 ---
 
-# /inquisidor — El Inquisidor 🕵️
+# /tester — Tester
 
-Sos El Inquisidor — agente de testing del proyecto Intrale Platform.
-Nadie te espera. Cuestionás todo. No das el visto bueno fácil.
+Sos Tester — agente de testing del proyecto Intrale Platform.
+Cuestionás todo. No das el visto bueno fácil.
 Si algo puede fallar, lo encontrás.
 
 ## Argumentos
@@ -126,7 +126,7 @@ export JAVA_HOME="/c/Users/Administrator/.jdks/temurin-21.0.7" && \
 ### Fallos detectados
 [Lista de fallos con causa raíz y corrección propuesta]
 
-### Veredicto del Inquisidor
+### Veredicto del Tester
 [Aprobación para PR | Correcciones requeridas antes de mergear]
 ```
 

--- a/docs/planificacion-agentes-y-hooks.md
+++ b/docs/planificacion-agentes-y-hooks.md
@@ -18,7 +18,7 @@
 
 Los agentes tienen nombres propios para hacer el trabajo más ameno y distinguirlos fácilmente.
 
-### El Sabueso 🐕 — Research & Información
+### Guru — Research & Información
 
 **Rol**: Investigación técnica, búsqueda de documentación, exploración de codebase.
 **Personalidad**: Metódico, incansable, nada se le escapa. Siempre encuentra la pista.
@@ -30,7 +30,7 @@ Los agentes tienen nombres propios para hacer el trabajo más ameno y distinguir
 - "Investigá las opciones para implementar Z"
 - "Buscá la documentación de esta librería"
 
-**Skill a crear**: `/sabueso <pregunta>` — lanza al agente con Context7 activado
+**Skill**: `/guru <pregunta>` — lanza al agente con Context7 activado
 
 ---
 
@@ -47,7 +47,7 @@ Los agentes tienen nombres propios para hacer el trabajo más ameno y distinguir
 
 ---
 
-### El Vigía 🔭 — CI Monitor (Background)
+### CI Monitor (Background)
 
 **Rol**: Monitorear GitHub Actions después de cada push. Notifica resultado.
 **Personalidad**: Siempre mirando, nunca duerme. Reporta sin que se lo pidan.
@@ -57,33 +57,33 @@ Los agentes tienen nombres propios para hacer el trabajo más ameno y distinguir
 
 ---
 
-### La Pluma ✍️ — Issues & Docs
+### Doc — Issues & Docs
 
 **Rol**: Crear, refinar y documentar issues de GitHub. Redactar docs técnicas.
 **Personalidad**: Elocuente, bilingüe (español/inglés en código), estructurado.
 **Modelo**: `claude-sonnet-4-6` — Escribir bien requiere calidad. Haiku produce texto genérico.
 **Herramientas**: GitHub API, Read, Write.
-**Skills existentes**: `/refinar`, `/nueva-historia`, `/triaje`
+**Skills**: `/doc`, `/refinar`, `/historia`, `/priorizar`
 
 ---
 
-### El Inquisidor 🕵️ — Testing
+### Tester — Testing
 
 **Rol**: Ejecutar tests, verificar cobertura, revisar calidad de código.
-**Personalidad**: Nadie lo espera. Cuestiona todo. No da el visto bueno fácil.
+**Personalidad**: Cuestiona todo. No da el visto bueno fácil.
 **Modelo**: `claude-haiku-4-5-20251001` para correr tests y parsear resultados. `claude-sonnet-4-6` si hay que analizar fallos complejos.
 **Herramientas**: Bash (Gradle test/kover), Read, Grep.
-**Skill a crear**: `/inquisidor` — corre tests + verifica coverage + reporta
+**Skill**: `/tester` — corre tests + verifica coverage + reporta
 
 ---
 
-### El Mensajero 📨 — PR & Deploy
+### DeliveryManager — PR & Deploy
 
 **Rol**: Commit + push + PR con convenciones Intrale en un solo comando.
 **Personalidad**: Veloz y confiable. Siempre entrega en tiempo y forma.
 **Modelo**: `claude-haiku-4-5-20251001` — Es una tarea mecánica basada en plantilla. Haiku lo hace igual de bien que Sonnet a la mitad del costo.
-**Herramientas**: Bash (git), GitHub API (curl).
-**Skill a crear**: `/mensajero <descripcion>` — workflow completo de entrega
+**Herramientas**: Bash (git), GitHub API (gh).
+**Skill**: `/delivery <descripcion>` — workflow completo de entrega
 
 ---
 
@@ -127,7 +127,7 @@ git push (Bash tool)
 }
 ```
 
-**Uso esperado por El Sabueso**:
+**Uso esperado por Guru**:
 1. Primero consultar Context7 para documentación oficial actualizada
 2. Si no hay resultado, usar WebSearch
 3. Último recurso: leer directamente el código fuente de librerías
@@ -140,10 +140,10 @@ git push (Bash tool)
 - [x] Hook `Stop` + `stop-notify.sh`
 - [x] Hook `PostToolUse` + `post-git-push.sh` + `ci-monitor.sh`
 - [x] MCP Context7 en global settings.json
-- [x] Agente **El Sabueso** (skill `/sabueso`)
-- [x] Agente **El Mensajero** (skill `/mensajero`)
-- [x] Agente **El Inquisidor** (skill `/inquisidor`)
-- [x] Agente **La Pluma** (skill `/pluma`, unificando `/nueva-historia`, `/refinar`, `/triaje`)
-- [x] Agente **El Oráculo** (skill `/oraculo` — planificación, sprint, propuestas, digest)
+- [x] Agente **Guru** (skill `/guru`)
+- [x] Agente **DeliveryManager** (skill `/delivery`)
+- [x] Agente **Tester** (skill `/tester`)
+- [x] Agente **Doc** (skill `/doc`, unificando `/historia`, `/refinar`, `/priorizar`)
+- [x] Agente **Planner** (skill `/planner` — planificación, sprint, propuestas, digest)
 - [x] Instalar `gh` CLI 2.86.0 y migrar todos los skills de `curl` a `gh`
-- [x] Mejorar MEMORY.md con patrones de arquitectura y debugging (completado con reporte de El Sabueso)
+- [x] Mejorar MEMORY.md con patrones de arquitectura y debugging (completado con reporte de Guru)

--- a/docs/worktrunk.md
+++ b/docs/worktrunk.md
@@ -54,7 +54,7 @@ dev-done          # squash merge a main + cleanup
 dev 42 auth-2fa
 claude "Implementar auth 2FA - Closes #42"
 
-# Claude pushea y crea PR (via /mensajero)
+# Claude pushea y crea PR (via /delivery)
 # PR se mergea en GitHub
 # Limpiar worktree local:
 dev-go 42


### PR DESCRIPTION
## Summary
- Renombra todos los skills/agentes de nombres temáticos en español (El Sabueso, El Inquisidor, La Pluma, El Oráculo, El Portero, El Mensajero, Gimli, Triaje, Nueva Historia) a nombres funcionales en inglés (guru, tester, doc, planner, auth, delivery, builder, priorizar, historia)
- Actualiza hooks (activity-logger, permission-notify, permission-tracker, stop-notify, notify-telegram, post-git-push), dashboard, settings.json (paths absolutos + timeout 10s), settings.local.json (permisos Skill()), y documentación
- Hardcodea rutas absolutas en hooks para evitar errores de resolución en MSYS2

## Test plan
- [x] Verificar que `.claude/skills/` contiene solo los nuevos nombres
- [x] Grep residual de nombres viejos en `.claude/` y `docs/` — sin matches
- [x] Hooks funcionan correctamente (probados manualmente)

🤖 Generated with [Claude Code](https://claude.com/claude-code)