### PR TITLE
fix: Start-Agente.ps1 lee planner-plan.json en lugar de oraculo-plan.json

### DIFF
--- a/scripts/Start-Agente.ps1
+++ b/scripts/Start-Agente.ps1
@@ -25,11 +25,11 @@ $ErrorActionPreference = "Stop"
 $GitWt    = "C:\Users\Administrator\AppData\Local\Microsoft\WinGet\Packages\max-sixty.worktrunk_Microsoft.Winget.Source_8wekyb3d8bbwe\git-wt.exe"
 $Gh       = "C:\Workspaces\gh-cli\bin\gh.exe"
 $MainRepo = "C:\Workspaces\Intrale\platform"
-$PlanFile = Join-Path $PSScriptRoot "oraculo-plan.json"
+$PlanFile = Join-Path $PSScriptRoot "planner-plan.json"
 
 # --- Validaciones ---
 if (-not (Test-Path $PlanFile)) {
-    Write-Error "No se encontro el plan: $PlanFile`nEjecuta /oraculo sprint para generarlo."
+    Write-Error "No se encontro el plan: $PlanFile`nEjecuta /planner sprint para generarlo."
     exit 1
 }
 


### PR DESCRIPTION
## Resumen

- Cambiar referencia de plan: `oraculo-plan.json` → `planner-plan.json`
- Actualizar mensaje de error para mencionar `/planner sprint`
- Sincronizar `Start-Agente.ps1` con el output real de `/planner sprint`

## Plan de tests

- [x] Build sin errores
- [x] Script apunta al archivo correcto
- [ ] Ejecutar `/planner sprint` y verificar que `.\Start-Agente.ps1 all` lee el plan actualizado

Closes #859

🤖 Generado con [Claude Code](https://claude.ai/claude-code)