### PR TITLE
fix: Start-Agente.ps1 lee planner-plan.json en lugar de oraculo-plan.json

### DIFF
--- a/scripts/Start-Agente.ps1
+++ b/scripts/Start-Agente.ps1
@@ -25,11 +25,11 @@ $ErrorActionPreference = "Stop"
 $GitWt    = "C:\Users\Administrator\AppData\Local\Microsoft\WinGet\Packages\max-sixty.worktrunk_Microsoft.Winget.Source_8wekyb3d8bbwe\git-wt.exe"
 $Gh       = "C:\Workspaces\gh-cli\bin\gh.exe"
 $MainRepo = "C:\Workspaces\Intrale\platform"
-$PlanFile = Join-Path $PSScriptRoot "oraculo-plan.json"
+$PlanFile = Join-Path $PSScriptRoot "planner-plan.json"
 
 # --- Validaciones ---
 if (-not (Test-Path $PlanFile)) {
-    Write-Error "No se encontro el plan: $PlanFile`nEjecuta /oraculo sprint para generarlo."
+    Write-Error "No se encontro el plan: $PlanFile`nEjecuta /planner sprint para generarlo."
     exit 1
 }
 


### PR DESCRIPTION
## Resumen

- Renombra referencia de `oraculo-plan.json` → `planner-plan.json` en `Start-Agente.ps1`
- Actualiza mensaje de error para indicar `/planner sprint` en lugar de `/oraculo sprint`
- Alinea con el refactor de skills (#857)

## Plan de tests

- [x] Cambio trivial, solo renombra strings

🤖 Generado con [Claude Code](https://claude.ai/claude-code)