### PR TITLE
feat: ext/client ΓÇö Servicio de pedidos del cliente (CommClientOrdersService) (Closes #848)

### DIFF
--- a/app/composeApp/src/commonMain/kotlin/DIManager.kt
+++ b/app/composeApp/src/commonMain/kotlin/DIManager.kt
@@ -86,8 +86,10 @@ import ext.auth.CommPasswordRecoveryService
 import ext.auth.CommTwoFactorSetupService
 import ext.auth.CommTwoFactorVerifyService
 import ext.client.ClientAddressesService
+import ext.client.ClientOrdersService
 import ext.client.ClientProfileService
 import ext.client.CommClientAddressesService
+import ext.client.CommClientOrdersService
 import ext.client.CommClientProfileService
 import ext.delivery.CommDeliveryAvailabilityService
 import ext.delivery.CommDeliveryProfileService
@@ -310,6 +312,7 @@ private val businessModule = DI.Module("business") {
 private val clientModule = DI.Module("client") {
     bindSingleton<CommClientProfileService> { ClientProfileService(instance(), instance()) }
     bindSingleton<CommClientAddressesService> { ClientAddressesService(instance(), instance()) }
+    bindSingleton<CommClientOrdersService> { ClientOrdersService(instance(), instance()) }
 
     bindSingleton<ToDoGetClientProfile> { DoGetClientProfile(instance(), instance(), instance()) }
     bindSingleton<ToDoUpdateClientProfile> { DoUpdateClientProfile(instance(), instance(), instance()) }

--- a/app/composeApp/src/commonMain/kotlin/ext/client/ClientOrdersDtos.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/client/ClientOrdersDtos.kt
@@ -1,0 +1,53 @@
+package ext.client
+
+import ext.dto.StatusCodeDTO
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ClientOrderDTO(
+    val id: String? = null,
+    val publicId: String = "",
+    val shortCode: String = "",
+    val businessName: String = "",
+    val status: String = "",
+    val createdAt: String = "",
+    val promisedAt: String? = null,
+    val total: Double = 0.0,
+    val itemCount: Int = 0
+)
+
+@Serializable
+data class ClientOrderDetailDTO(
+    val id: String? = null,
+    val publicId: String = "",
+    val shortCode: String = "",
+    val businessName: String = "",
+    val status: String = "",
+    val createdAt: String = "",
+    val promisedAt: String? = null,
+    val total: Double = 0.0,
+    val itemCount: Int = 0,
+    val items: List<ClientOrderItemDTO> = emptyList(),
+    val address: ClientAddressDTO? = null
+)
+
+@Serializable
+data class ClientOrderItemDTO(
+    val id: String? = null,
+    val name: String = "",
+    val quantity: Int = 0,
+    val unitPrice: Double = 0.0,
+    val subtotal: Double = 0.0
+)
+
+@Serializable
+data class ClientOrdersResponse(
+    val statusCode: StatusCodeDTO? = null,
+    val orders: List<ClientOrderDTO>? = null
+)
+
+@Serializable
+data class ClientOrderDetailResponse(
+    val statusCode: StatusCodeDTO? = null,
+    val order: ClientOrderDetailDTO? = null
+)

--- a/app/composeApp/src/commonMain/kotlin/ext/client/ClientOrdersService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/client/ClientOrdersService.kt
@@ -1,0 +1,90 @@
+package ext.client
+
+import ar.com.intrale.BuildKonfig
+import ext.dto.StatusCodeDTO
+import ext.storage.CommKeyValueStorage
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.isSuccess
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.Json
+import org.kodein.log.LoggerFactory
+import org.kodein.log.newLogger
+
+class ClientOrdersService(
+    private val httpClient: HttpClient,
+    private val keyValueStorage: CommKeyValueStorage
+) : CommClientOrdersService {
+
+    private val logger = LoggerFactory.default.newLogger<ClientOrdersService>()
+
+    override suspend fun listOrders(): Result<List<ClientOrderDTO>> {
+        return try {
+            logger.info { "Listando pedidos del cliente" }
+            val response = httpClient.get("${BuildKonfig.BASE_URL}${BuildKonfig.BUSINESS}/client/orders") {
+                authorize()
+            }
+            Result.success(response.toOrders())
+        } catch (throwable: Throwable) {
+            logger.error(throwable) { "Error al listar pedidos" }
+            Result.failure(throwable.toClientException())
+        }
+    }
+
+    override suspend fun fetchOrderDetail(orderId: String): Result<ClientOrderDetailDTO> {
+        return try {
+            logger.info { "Obteniendo detalle del pedido $orderId" }
+            val response = httpClient.get("${BuildKonfig.BASE_URL}${BuildKonfig.BUSINESS}/client/orders/$orderId") {
+                authorize()
+            }
+            Result.success(response.toOrderDetail())
+        } catch (throwable: Throwable) {
+            logger.error(throwable) { "Error al obtener detalle del pedido" }
+            Result.failure(throwable.toClientException())
+        }
+    }
+
+    private suspend fun HttpResponse.toOrders(): List<ClientOrderDTO> {
+        val bodyText = bodyAsText()
+        if (status.isSuccess()) {
+            if (bodyText.isBlank()) return emptyList()
+            val parsedResponse = runCatching {
+                Json.decodeFromString(ClientOrdersResponse.serializer(), bodyText).orders
+            }.getOrNull()
+            if (parsedResponse != null) {
+                return parsedResponse
+            }
+            return Json.decodeFromString(ListSerializer(ClientOrderDTO.serializer()), bodyText)
+        }
+        throw bodyText.toClientException()
+    }
+
+    private suspend fun HttpResponse.toOrderDetail(): ClientOrderDetailDTO {
+        val bodyText = bodyAsText()
+        if (status.isSuccess()) {
+            if (bodyText.isBlank()) return ClientOrderDetailDTO()
+            val parsedResponse = runCatching {
+                Json.decodeFromString(ClientOrderDetailResponse.serializer(), bodyText).order
+            }.getOrNull()
+            if (parsedResponse != null) {
+                return parsedResponse
+            }
+            return Json.decodeFromString(ClientOrderDetailDTO.serializer(), bodyText)
+        }
+        throw bodyText.toClientException()
+    }
+
+    private fun String.toClientException(): ClientExceptionResponse =
+        runCatching { Json.decodeFromString(ClientExceptionResponse.serializer(), this) }
+            .getOrElse { ClientExceptionResponse(message = this) }
+
+    private fun io.ktor.client.request.HttpRequestBuilder.authorize() {
+        val token = keyValueStorage.token
+            ?: throw ClientExceptionResponse(message = "Token no disponible", statusCode = StatusCodeDTO(401, "Unauthorized"))
+        header(HttpHeaders.Authorization, "Bearer $token")
+    }
+}

--- a/app/composeApp/src/commonMain/kotlin/ext/client/CommClientOrdersService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/client/CommClientOrdersService.kt
@@ -1,0 +1,6 @@
+package ext.client
+
+interface CommClientOrdersService {
+    suspend fun listOrders(): Result<List<ClientOrderDTO>>
+    suspend fun fetchOrderDetail(orderId: String): Result<ClientOrderDetailDTO>
+}

--- a/app/composeApp/src/commonTest/kotlin/ext/client/ClientOrdersServiceTest.kt
+++ b/app/composeApp/src/commonTest/kotlin/ext/client/ClientOrdersServiceTest.kt
@@ -1,0 +1,152 @@
+package ext.client
+
+import ext.dto.StatusCodeDTO
+import ext.storage.CommKeyValueStorage
+import ext.storage.model.ClientProfileCache
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.DefaultRequest
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.header
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+private val ordersJsonHeaders = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+
+private fun ordersMockClient(status: HttpStatusCode, body: String): HttpClient {
+    val engine = MockEngine { respond(body, status, ordersJsonHeaders) }
+    return HttpClient(engine) {
+        install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+        install(DefaultRequest) { header(HttpHeaders.ContentType, ContentType.Application.Json) }
+    }
+}
+
+private class OrdersFakeStorage(override var token: String? = "Bearer tok") : CommKeyValueStorage {
+    override var profileCache: ClientProfileCache? = null
+    override var preferredLanguage: String? = null
+    override var onboardingCompleted: Boolean = false
+}
+
+class ClientOrdersServiceTest {
+
+    // region listOrders
+
+    @Test
+    fun `listOrders exitoso con response envolvente retorna lista`() = runTest {
+        val body = """{"orders":[{"id":"ord-1","publicId":"PUB-001","shortCode":"SC01","businessName":"Tienda","status":"PENDING","createdAt":"2025-01-01","total":150.0,"itemCount":3}]}"""
+        val service = ClientOrdersService(ordersMockClient(HttpStatusCode.OK, body), OrdersFakeStorage())
+
+        val result = service.listOrders()
+
+        assertTrue(result.isSuccess)
+        assertEquals(1, result.getOrThrow().size)
+        assertEquals("ord-1", result.getOrThrow()[0].id)
+    }
+
+    @Test
+    fun `listOrders con body vacio retorna lista vacia`() = runTest {
+        val service = ClientOrdersService(ordersMockClient(HttpStatusCode.OK, ""), OrdersFakeStorage())
+
+        val result = service.listOrders()
+
+        assertTrue(result.isSuccess)
+        assertTrue(result.getOrThrow().isEmpty())
+    }
+
+    @Test
+    fun `listOrders con lista JSON directa retorna lista`() = runTest {
+        val body = """[{"id":"ord-1","publicId":"PUB-001","shortCode":"SC01","businessName":"Tienda","status":"PENDING","createdAt":"2025-01-01","total":100.0,"itemCount":2}]"""
+        val service = ClientOrdersService(ordersMockClient(HttpStatusCode.OK, body), OrdersFakeStorage())
+
+        val result = service.listOrders()
+
+        assertTrue(result.isSuccess)
+        assertEquals(1, result.getOrThrow().size)
+    }
+
+    @Test
+    fun `listOrders sin token retorna error 401`() = runTest {
+        val service = ClientOrdersService(ordersMockClient(HttpStatusCode.OK, "{}"), OrdersFakeStorage(token = null))
+
+        val result = service.listOrders()
+
+        assertTrue(result.isFailure)
+        val exception = result.exceptionOrNull()
+        assertTrue(exception is ClientExceptionResponse)
+        assertEquals(401, (exception as ClientExceptionResponse).statusCode.value)
+    }
+
+    @Test
+    fun `listOrders error servidor retorna failure`() = runTest {
+        val body = """{"statusCode":{"code":500,"description":"Internal Server Error"},"message":"Error interno"}"""
+        val service = ClientOrdersService(ordersMockClient(HttpStatusCode.InternalServerError, body), OrdersFakeStorage())
+
+        val result = service.listOrders()
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is ClientExceptionResponse)
+    }
+
+    // endregion
+
+    // region fetchOrderDetail
+
+    @Test
+    fun `fetchOrderDetail exitoso con response envolvente retorna detalle`() = runTest {
+        val body = """{"order":{"id":"ord-1","publicId":"PUB-001","shortCode":"SC01","businessName":"Tienda","status":"DELIVERED","createdAt":"2025-01-01","total":250.0,"itemCount":2,"items":[{"id":"item-1","name":"Producto A","quantity":2,"unitPrice":125.0,"subtotal":250.0}]}}"""
+        val service = ClientOrdersService(ordersMockClient(HttpStatusCode.OK, body), OrdersFakeStorage())
+
+        val result = service.fetchOrderDetail("ord-1")
+
+        assertTrue(result.isSuccess)
+        val detail = result.getOrThrow()
+        assertEquals("ord-1", detail.id)
+        assertEquals(1, detail.items.size)
+        assertEquals("Producto A", detail.items[0].name)
+    }
+
+    @Test
+    fun `fetchOrderDetail con body vacio retorna DTO default`() = runTest {
+        val service = ClientOrdersService(ordersMockClient(HttpStatusCode.OK, ""), OrdersFakeStorage())
+
+        val result = service.fetchOrderDetail("ord-1")
+
+        assertTrue(result.isSuccess)
+        assertNotNull(result.getOrThrow())
+    }
+
+    @Test
+    fun `fetchOrderDetail sin token retorna error 401`() = runTest {
+        val service = ClientOrdersService(ordersMockClient(HttpStatusCode.OK, "{}"), OrdersFakeStorage(token = null))
+
+        val result = service.fetchOrderDetail("ord-1")
+
+        assertTrue(result.isFailure)
+        val exception = result.exceptionOrNull()
+        assertTrue(exception is ClientExceptionResponse)
+        assertEquals(401, (exception as ClientExceptionResponse).statusCode.value)
+    }
+
+    @Test
+    fun `fetchOrderDetail error servidor 404 retorna failure`() = runTest {
+        val body = """{"statusCode":{"code":404,"description":"Not Found"},"message":"Pedido no encontrado"}"""
+        val service = ClientOrdersService(ordersMockClient(HttpStatusCode.NotFound, body), OrdersFakeStorage())
+
+        val result = service.fetchOrderDetail("ord-inexistente")
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is ClientExceptionResponse)
+    }
+
+    // endregion
+}


### PR DESCRIPTION
## Summary
- Implementacion automatizada del issue #848
- Branch: `codex/848-ext-client-orders-service`

Closes #848

## Test plan
- Verificar que compila: `./gradlew clean build`
- Verificar tests: `./gradlew check`

:robot: Generated with [Claude Code](https://claude.com/claude-code)