### PR TITLE
refactor: nombre genérico para archivo de planificación de sprint

### DIFF
--- a/.claude/skills/monitor/SKILL.md
+++ b/.claude/skills/monitor/SKILL.md
@@ -22,6 +22,7 @@ Recolecta datos de TODAS estas fuentes en paralelo:
 3. **Tareas**: Usa `TaskList` para obtener todas las tareas
 4. **Git info**: Ejecuta en un solo Bash: `git branch --show-current && git log --oneline -1`
 5. **CI**: Ejecuta `export PATH="/c/Workspaces/gh-cli/bin:$PATH" && export GH_TOKEN=$(printf 'protocol=https\nhost=github.com\n' | git credential fill 2>/dev/null | sed -n 's/^password=//p') && gh run list --limit 1 --json status,conclusion,headBranch,event,createdAt --jq '.[0] | "\(.status) \(.conclusion // "—") \(.headBranch)"'`
+6. **Sprint plan**: Lee `scripts/sprint-plan.json` con `Read` (puede no existir — si no existe, omitir panel PLAN)
 
 Luego, para cada sesion de tipo `"parent"`, determina su estado de liveness usando `last_activity_ts` del JSON:
 
@@ -51,6 +52,9 @@ Genera el dashboard con este formato (ajustando ancho a ~70 columnas):
 │ Rama: codex/829-centinela-v3                                     │
 │ Commit: 2b29ad5 migrar hooks de bash…                            │
 │ CI: ⏳ in_progress (codex/829-centinela-v3)                       │
+├─ PLAN (2026-02-20) ────────────────────────────────────────────┤
+│ #1  #821  notificaciones     S  Stream E                         │
+│ #2  #845  refactor-login     M  Stream A                         │
 ├─ TAREAS ────────────────────────────────────────────────────────┤
 │ ● #1  Implementar login          Vulcano 🔥                      │
 │ ○ #2  Tests de login             — (◄#1)                         │
@@ -90,6 +94,15 @@ Genera el dashboard con este formato (ajustando ancho a ~70 columnas):
   - `queued` → `🔄`
   - Sin datos → `—`
 - Incluir la rama del CI entre parentesis
+
+**Reglas del panel PLAN:**
+
+- Fuente: `scripts/sprint-plan.json` (generado por `/planner sprint`)
+- Si el archivo no existe, omitir este panel completamente
+- Titulo del panel: `PLAN (fecha)` donde fecha viene del campo `fecha` del JSON
+- Cada fila muestra: `#numero  #issue  slug  size  Stream X`
+- Ordenar por `numero` ascendente
+- Si no hay agentes en el plan: "Plan vacio"
 
 **Reglas del panel TAREAS:**
 

--- a/.claude/skills/planner/SKILL.md
+++ b/.claude/skills/planner/SKILL.md
@@ -205,7 +205,7 @@ Formato de salida:
 
 ### Generar plan JSON para Start-Agente
 
-Al finalizar el sprint, **siempre** escribir `scripts/planner-plan.json` con el plan estructurado
+Al finalizar el sprint, **siempre** escribir `scripts/sprint-plan.json` con el plan estructurado
 para que `Start-Agente.ps1` pueda lanzar agentes automaticamente:
 
 ```json

--- a/.gitignore
+++ b/.gitignore
@@ -51,8 +51,8 @@ deps_commonMain.txt
 .claude/hooks/hook-debug.log
 .claude/hooks/tg-approver-offset.json
 
-# Planner — plan de agentes (no commitear, local de trabajo)
-scripts/planner-plan.json
+# Sprint plan — plan de agentes (no commitear, local de trabajo)
+scripts/sprint-plan.json
 
 # Binarios de gh-cli descargados localmente
 gh-cli/
@@ -67,8 +67,9 @@ app/composeApp/src/wasmJsMain/resources/*.ico
 app/iosApp/iosApp/Assets.xcassets/AppIcon.appiconset/*.png
 docs/branding/icons/icon_master.png
 
-# Plan del Oraculo (generado por /oraculo sprint)
+# (legacy — se puede borrar cuando no queden archivos locales)
 scripts/oraculo-plan.json
+scripts/planner-plan.json
 
 # Claude Code
 .claude/activity-log.jsonl

--- a/scripts/Start-Agente.ps1
+++ b/scripts/Start-Agente.ps1
@@ -3,7 +3,7 @@
     Lanza agentes Claude en worktrees aislados consumiendo el plan del Oraculo.
 
 .DESCRIPTION
-    Lee oraculo-plan.json y crea worktrees para los agentes indicados.
+    Lee sprint-plan.json y crea worktrees para los agentes indicados.
     Copia permisos de Claude Code y abre nueva terminal PowerShell con claude ejecutando.
 
 .PARAMETER Numero
@@ -25,7 +25,7 @@ $ErrorActionPreference = "Stop"
 $GitWt    = "C:\Users\Administrator\AppData\Local\Microsoft\WinGet\Packages\max-sixty.worktrunk_Microsoft.Winget.Source_8wekyb3d8bbwe\git-wt.exe"
 $Gh       = "C:\Workspaces\gh-cli\bin\gh.exe"
 $MainRepo = "C:\Workspaces\Intrale\platform"
-$PlanFile = Join-Path $PSScriptRoot "planner-plan.json"
+$PlanFile = Join-Path $PSScriptRoot "sprint-plan.json"
 
 # --- Validaciones ---
 if (-not (Test-Path $PlanFile)) {

--- a/scripts/Stop-Agente.ps1
+++ b/scripts/Stop-Agente.ps1
@@ -3,7 +3,7 @@
     Finaliza agentes Claude: commit + push + PR + merge + cleanup.
 
 .DESCRIPTION
-    Lee planner-plan.json y procesa el cierre de agentes.
+    Lee sprint-plan.json y procesa el cierre de agentes.
     Flujo: commit, push, PR, squash-merge y limpieza de worktree.
 
 .PARAMETER Numero
@@ -37,7 +37,7 @@ $ErrorActionPreference = "Stop"
 $GitWt    = "C:\Users\Administrator\AppData\Local\Microsoft\WinGet\Packages\max-sixty.worktrunk_Microsoft.Winget.Source_8wekyb3d8bbwe\git-wt.exe"
 $Gh       = "C:\Workspaces\gh-cli\bin\gh.exe"
 $MainRepo = "C:\Workspaces\Intrale\platform"
-$PlanFile = Join-Path $PSScriptRoot "planner-plan.json"
+$PlanFile = Join-Path $PSScriptRoot "sprint-plan.json"
 
 # --- Helpers ---
 $P = '>>'  # prefijo para mensajes de log


### PR DESCRIPTION
## Resumen

- Renombrar `planner-plan.json` → `sprint-plan.json` (agnóstico del agente que lo genera)
- Actualizar referencias en `Start-Agente.ps1`, `Stop-Agente.ps1` y SKILL.md del planner
- Integrar `sprint-plan.json` en el monitor como nuevo panel PLAN
- Mantener entradas legacy en `.gitignore` para compatibilidad local

## Motivo

El nombre del archivo de planificación no debe depender del nombre del agente/skill que lo genera. Si en el futuro el skill planner se renombra, todos sus consumidores (Start-Agente, Stop-Agente, Monitor) se verían afectados. Usar un nombre genérico como `sprint-plan.json` desacopla esta dependencia.

## Plan de tests

- [x] Verificar que `start-agente` lee `sprint-plan.json` correctamente
- [x] Verificar que `stop-agente` lee `sprint-plan.json` correctamente
- [x] Verificar que el monitor lee `sprint-plan.json` (graceful fallback si no existe)
- [x] Verificar que no hay referencias a nombres legacy en código (solo en `.gitignore`)

🤖 Generado con [Claude Code](https://claude.com/claude-code)