### PR TITLE
fix: corregir formato JSON del hook PermissionRequest para aprobación remota vía Telegram

### DIFF
--- a/.claude/hooks/notify-telegram.js
+++ b/.claude/hooks/notify-telegram.js
@@ -84,6 +84,12 @@ async function processInput() {
         "elicitation_dialog": "\u2753"
     }[type] || "\ud83d\udd14";
 
+    // Ignorar permission_prompt: ya lo maneja permission-approver.js con botones inline
+    if (type === "permission_prompt") {
+        log("Ignorado permission_prompt (manejado por permission-approver.js)");
+        return;
+    }
+
     const displayTitle = TIPO_TITULO[type] || title || type;
 
     let displayMessage = message;

--- a/scripts/dev-functions.sh
+++ b/scripts/dev-functions.sh
@@ -200,4 +200,5 @@ dev-home() {
     cd "$_INTRALE_MAIN" 2>/dev/null && echo ">> En main: $(pwd)"
 }
 
-echo "[dev-functions] Cargado. Usa 'dev <issue> [slug]' para empezar."
+# Solo mostrar mensaje en sesiones interactivas (evita contaminar stdout de hooks)
+[[ $- == *i* ]] && echo "[dev-functions] Cargado. Usa 'dev <issue> [slug]' para empezar."


### PR DESCRIPTION
## Resumen

- Corrige el formato de respuesta del hook `PermissionRequest`: ahora usa `hookSpecificOutput.decision.behavior` (formato que Claude Code realmente espera), en lugar de `{"behavior":"allow"}` que era ignorado
- Filtra notificaciones duplicadas `permission_prompt` en `notify-telegram.js` (ya manejadas por `permission-approver.js` con botones inline)
- Espera flush de stdout antes de `process.exit()` para evitar pérdida de datos en pipe
- Extiende timeout de polling Telegram de 40s a 5 minutos (`MAX_POLL_CYCLES`: 2→15)
- `dev-functions.sh`: solo imprime mensaje de bienvenida en sesiones interactivas (`[[ $- == *i* ]]`) para no contaminar stdout de hooks

## Test plan

- [x] Botón "Permitir" en Telegram aprueba el permiso sin prompt local
- [x] Botón "Siempre" aprueba y persiste el patrón en `settings.local.json`
- [x] Solo llega 1 mensaje a Telegram (sin duplicado "Aprobación requerida")

Closes #834

🤖 Generado con [Claude Code](https://claude.ai/claude-code)