### PR TITLE
feat: lanzar monitor live al iniciar sprint, evitando instancias duplicadas

### DIFF
--- a/scripts/Start-Agente.ps1
+++ b/scripts/Start-Agente.ps1
@@ -112,6 +112,28 @@ function Start-UnAgente {
     Write-Host ">> Agente $($Agente.numero) lanzado en nueva terminal" -ForegroundColor Green
 }
 
+function Start-MonitorLive {
+    $monitorProcs = Get-Process -Name 'node' -ErrorAction SilentlyContinue |
+        Where-Object { $_.CommandLine -match 'dashboard\.js' }
+
+    if ($monitorProcs) {
+        Write-Host ">> Monitor ya activo (PID: $($monitorProcs.Id)) — reutilizando." -ForegroundColor Yellow
+        return
+    }
+
+    $dashboardPath = Join-Path $MainRepo ".claude\dashboard.js"
+    if (-not (Test-Path $dashboardPath)) {
+        Write-Host ">> dashboard.js no encontrado en: $dashboardPath — omitiendo monitor." -ForegroundColor Yellow
+        return
+    }
+
+    $command = "Set-Location '$MainRepo'; " +
+               "Write-Host '  Monitor Live — Dashboard multi-sesion' -ForegroundColor Cyan; " +
+               "node '$dashboardPath'"
+    Start-Process powershell -ArgumentList "-NoExit", "-Command", $command
+    Write-Host ">> Monitor live lanzado." -ForegroundColor Green
+}
+
 # --- Ejecutar ---
 if ($Numero -eq "all") {
     Write-Host ">> Lanzando TODOS los agentes del plan ($($Plan.agentes.Count))..." -ForegroundColor Magenta
@@ -120,6 +142,7 @@ if ($Numero -eq "all") {
     }
     Write-Host ""
     Write-Host ">> Todos los agentes lanzados." -ForegroundColor Green
+    Start-MonitorLive
 }
 else {
     $num = [int]$Numero
@@ -131,4 +154,5 @@ else {
     }
 
     Start-UnAgente -Agente $agente
+    Start-MonitorLive
 }


### PR DESCRIPTION
## Resumen

- Implementa función `Start-MonitorLive` en `scripts/Start-Agente.ps1`
- Detecta procesos node con `dashboard.js` activos para evitar instancias duplicadas
- Si no hay monitor corriendo, lo lanza automáticamente al iniciar agentes
- Se invoca tanto en modo `all` como en lanzamiento individual

## Plan de tests

- [x] Sintaxis PowerShell validada
- [ ] Verificar que no se lancen procesos duplicados
- [ ] Confirmar que el dashboard se abre correctamente en terminal independiente

Closes #879

🤖 Generado con [Claude Code](https://claude.ai/claude-code)