### PR TITLE
docs: agregar Paso 4 al planner sprint para lanzar agentes automáticamente

### DIFF
--- a/.claude/skills/planner/SKILL.md
+++ b/.claude/skills/planner/SKILL.md
@@ -235,6 +235,36 @@ Reglas del JSON:
 - `size`: S/M/L/XL segun estimacion de esfuerzo
 - El archivo NO se commitea (esta en .gitignore)
 
+### Ofrecer lanzar agentes
+
+Tras escribir `sprint-plan.json`, preguntar al usuario usando AskUserQuestion:
+
+> ✅ Plan generado con N agentes. ¿Lanzar los agentes ahora?
+
+Opciones:
+- **Todos** — lanza todos los agentes del plan en paralelo
+- **Uno específico** — preguntar cuál número y lanzar solo ese
+- **No, solo mostrar el plan** — terminar sin lanzar
+
+Si confirma "todos":
+```bash
+powershell.exe -NonInteractive -File /c/Workspaces/Intrale/platform/scripts/Start-Agente.ps1 all
+```
+
+Si confirma uno específico (reemplazar `<N>` por el número elegido):
+```bash
+powershell.exe -NonInteractive -File /c/Workspaces/Intrale/platform/scripts/Start-Agente.ps1 <N>
+```
+
+Tras ejecutar, reportar al usuario cuántos agentes fueron lanzados:
+> 🚀 N agente(s) lanzado(s) en terminales independientes.
+
+Consideraciones:
+- **Siempre** pedir confirmación antes de ejecutar — nunca lanzar sin preguntar
+- `Start-Agente.ps1` usa `Start-Process` internamente para abrir terminales, retorna rápido y no bloquea al planner
+- `powershell.exe -NonInteractive` evita que el script espere input del usuario
+- Si el usuario rechaza, el flujo termina normalmente mostrando solo el plan
+
 ---
 
 ## Modo: `proponer`


### PR DESCRIPTION
## Resumen

Implementar **Paso 4** (Ofrecer lanzar agentes) al modo `sprint` en `.claude/skills/planner/SKILL.md`:

- Tras escribir `sprint-plan.json`, el planner pregunta si desea lanzar agentes
- Opciones: **Todos**, **Uno específico**, o **solo mostrar el plan**
- Si confirma, ejecuta `Start-Agente.ps1` desde Bash sin abrir otra terminal
- Reporta cuántos agentes fueron lanzados

### Consideraciones técnicas

- **Siempre** pide confirmación antes de ejecutar — nunca lanza sin preguntar
- `Start-Agente.ps1` usa `Start-Process` internamente, retorna rápido sin bloquear
- `powershell.exe -NonInteractive` evita que el script espere input
- Si el usuario rechaza, el flujo termina normalmente

## Plan de tests

- [x] Documentación clara y completa
- [x] Instrucciones reproducibles en SKILL.md
- [x] Pasos alineados con Start-Agente.ps1

Closes #876

🤖 Generado con [Claude Code](https://claude.ai/claude-code)