### PR TITLE
feat: ciclo continuo — relanzar planner sprint al finalizar Stop-Agente (Closes #878)

### DIFF
--- a/scripts/Watch-Agentes.ps1
+++ b/scripts/Watch-Agentes.ps1
@@ -1,0 +1,236 @@
+<#
+.SYNOPSIS
+    Vigila agentes Claude y ejecuta ciclo continuo al finalizar.
+
+.DESCRIPTION
+    Lee sprint-plan.json y monitorea las sesiones de cada agente.
+    Al detectar que todos finalizaron:
+    1. Ejecuta Stop-Agente.ps1 all (commit + PR + merge + cleanup)
+    2. Pregunta via Telegram si planificar el siguiente sprint
+    3. Si confirma: git pull + nueva terminal con claude '/planner sprint'
+
+.PARAMETER PollInterval
+    Intervalo de polling en segundos (default: 30).
+
+.EXAMPLE
+    .\Watch-Agentes.ps1
+    .\Watch-Agentes.ps1 -PollInterval 60
+#>
+param(
+    [int]$PollInterval = 30
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+# --- Paths ---
+$MainRepo  = "C:\Workspaces\Intrale\platform"
+$PlanFile  = Join-Path $PSScriptRoot "sprint-plan.json"
+$AskScript = Join-Path $PSScriptRoot "ask-next-sprint.js"
+
+# --- Helpers ---
+$P = '>>'
+
+function Write-Log {
+    param([string]$Msg, [string]$Color = 'White')
+    $ts = Get-Date -Format 'HH:mm:ss'
+    Write-Host "$P [$ts] $Msg" -ForegroundColor $Color
+}
+
+# --- Validaciones ---
+if (-not (Test-Path $PlanFile)) {
+    Write-Error ('No se encontro el plan: {0}' -f $PlanFile)
+    exit 1
+}
+
+# --- Leer plan ---
+$Plan = Get-Content $PlanFile -Raw | ConvertFrom-Json
+$AgentCount = $Plan.agentes.Count
+
+if ($AgentCount -eq 0) {
+    Write-Log 'El plan no tiene agentes. Nada que vigilar.' 'Yellow'
+    exit 0
+}
+
+Write-Host ''
+Write-Host '============================================' -ForegroundColor Magenta
+Write-Host '  Watch-Agentes -- Ciclo Continuo'            -ForegroundColor Magenta
+Write-Host '============================================' -ForegroundColor Magenta
+Write-Host ''
+Write-Log ('Vigilando {0} agente(s) del sprint {1}' -f $AgentCount, $Plan.fecha) 'Cyan'
+Write-Log ('Intervalo de polling: {0}s' -f $PollInterval) 'Cyan'
+Write-Host ''
+
+foreach ($a in $Plan.agentes) {
+    Write-Log ('  Agente {0}: issue #{1} ({2})' -f $a.numero, $a.issue, $a.slug)
+}
+Write-Host ''
+
+# --- Funciones de deteccion ---
+
+function Get-WorktreePath {
+    param($Agente)
+    return '{0}\..\platform.codex-{1}-{2}' -f $MainRepo, $Agente.issue, $Agente.slug
+}
+
+function Test-AgentDone {
+    param([string]$WtDir)
+
+    # Worktree no existe → done (nunca arranco o ya fue limpiado)
+    if (-not (Test-Path $WtDir)) { return $true }
+
+    $wtResolved = (Resolve-Path $WtDir -ErrorAction SilentlyContinue)
+    if (-not $wtResolved) { return $true }
+
+    # Buscar session files con status "done" en .claude/sessions/ del worktree
+    # El hook stop-notify.js marca la sesion como "done" cuando claude finaliza
+    $sessionsDir = Join-Path $wtResolved '.claude' 'sessions'
+    if (Test-Path $sessionsDir) {
+        $sessionFiles = Get-ChildItem $sessionsDir -Filter '*.json' -ErrorAction SilentlyContinue
+        foreach ($sf in $sessionFiles) {
+            try {
+                $sess = Get-Content $sf.FullName -Raw | ConvertFrom-Json
+                if ($sess.status -eq 'done') { return $true }
+            }
+            catch { }
+        }
+    }
+
+    return $false
+}
+
+function Test-NoClaude {
+    # Failsafe: verificar si hay ALGUN proceso claude corriendo
+    $procs = Get-Process -Name 'claude' -ErrorAction SilentlyContinue
+    return (-not $procs -or @($procs).Count -eq 0)
+}
+
+# --- Polling loop ---
+$startTime = Get-Date
+$allDone = $false
+$FailsafeMinutes = 240  # 4 horas
+
+while (-not $allDone) {
+    $doneCount = 0
+    $statusParts = @()
+
+    foreach ($a in $Plan.agentes) {
+        $wtDir = Get-WorktreePath $a
+        $isDone = Test-AgentDone $wtDir
+        if ($isDone) {
+            $doneCount++
+            $statusParts += ('{0}:OK' -f $a.numero)
+        }
+        else {
+            $statusParts += ('{0}:...' -f $a.numero)
+        }
+    }
+
+    $elapsed = [math]::Round(((Get-Date) - $startTime).TotalMinutes, 1)
+    $statusLine = $statusParts -join '  '
+    Write-Log ('{0}/{1} finalizados  [{2}]  ({3} min)' -f $doneCount, $AgentCount, $statusLine, $elapsed)
+
+    if ($doneCount -ge $AgentCount) {
+        $allDone = $true
+        break
+    }
+
+    # Failsafe: si paso mucho tiempo y no hay procesos claude, considerar terminados
+    if ($elapsed -gt $FailsafeMinutes -and (Test-NoClaude)) {
+        Write-Log 'Failsafe: no hay procesos claude activos tras {0} min. Procediendo.' 'Yellow' -f $elapsed
+        $allDone = $true
+        break
+    }
+
+    Start-Sleep -Seconds $PollInterval
+}
+
+Write-Host ''
+Write-Log 'Todos los agentes finalizaron!' 'Green'
+Write-Host ''
+
+# --- Ejecutar Stop-Agente.ps1 all ---
+Write-Log 'Ejecutando Stop-Agente.ps1 all...' 'Cyan'
+$stopScript = Join-Path $PSScriptRoot 'Stop-Agente.ps1'
+try {
+    & $stopScript all
+    Write-Log 'Stop-Agente.ps1 finalizado.' 'Green'
+}
+catch {
+    Write-Log ('Error en Stop-Agente: {0}' -f $_.Exception.Message) 'Red'
+    # Continuar igualmente -- el usuario puede resolver manualmente
+}
+
+Write-Host ''
+
+# --- Preguntar si planificar el siguiente sprint ---
+$confirmed = $false
+
+if (Test-Path $AskScript) {
+    # Intentar via Telegram (Node.js helper)
+    Write-Log 'Consultando via Telegram...' 'Cyan'
+    try {
+        $rawResult = & node $AskScript 2>$null
+        $result = $rawResult | ConvertFrom-Json
+        if ($result.confirmed -eq $true) {
+            $confirmed = $true
+            Write-Log 'Usuario confirmo: planificar siguiente sprint.' 'Green'
+        }
+        elseif ($result.timeout -eq $true) {
+            Write-Log 'Timeout en Telegram, preguntando en terminal...' 'Yellow'
+            $resp = Read-Host '>> Sprint completado. Planificar siguiente sprint? (s/N)'
+            if ($resp -match '^[sS]') { $confirmed = $true }
+        }
+        else {
+            Write-Log 'Usuario rechazo: fin del ciclo.' 'Yellow'
+        }
+    }
+    catch {
+        Write-Log ('Telegram no disponible ({0}), preguntando en terminal...' -f $_.Exception.Message) 'Yellow'
+        $resp = Read-Host '>> Sprint completado. Planificar siguiente sprint? (s/N)'
+        if ($resp -match '^[sS]') { $confirmed = $true }
+    }
+}
+else {
+    # Fallback: preguntar en terminal
+    $resp = Read-Host '>> Sprint completado. Planificar siguiente sprint? (s/N)'
+    if ($resp -match '^[sS]') { $confirmed = $true }
+}
+
+if (-not $confirmed) {
+    Write-Host ''
+    Write-Log 'Ciclo continuo finalizado. Hasta la proxima!' 'Magenta'
+    exit 0
+}
+
+# --- Actualizar main y relanzar planner ---
+Write-Host ''
+Write-Log 'Actualizando main con merges del sprint anterior...' 'Cyan'
+Push-Location $MainRepo
+try {
+    git fetch origin main --quiet
+    git pull origin main --quiet
+    Write-Log 'Main actualizado.' 'Green'
+}
+catch {
+    Write-Log ('Error actualizando main: {0}' -f $_.Exception.Message) 'Red'
+}
+finally {
+    Pop-Location
+}
+
+# Lanzar nueva terminal con /planner sprint
+Write-Log 'Lanzando nuevo ciclo de planificacion...' 'Cyan'
+$command = "Set-Location '$MainRepo'; " +
+           "Write-Host ''; " +
+           "Write-Host '  Nuevo sprint -- planificando...' -ForegroundColor Cyan; " +
+           "Write-Host ''; " +
+           "claude '/planner sprint'"
+
+Start-Process powershell -ArgumentList "-NoExit", "-Command", $command
+
+Write-Log 'Nuevo ciclo lanzado en nueva terminal.' 'Green'
+Write-Host ''
+Write-Host '============================================' -ForegroundColor Magenta
+Write-Host '  Ciclo continuo -- nuevo sprint iniciado'    -ForegroundColor Magenta
+Write-Host '============================================' -ForegroundColor Magenta

--- a/scripts/ask-next-sprint.js
+++ b/scripts/ask-next-sprint.js
@@ -1,0 +1,264 @@
+// ask-next-sprint.js — Confirmacion via Telegram para siguiente sprint
+// Envia mensaje con botones inline (Si/No) y espera respuesta via polling.
+// Salida stdout: { "confirmed": true/false }
+// Sigue patron de permission-approver.js
+//
+// Uso: node ask-next-sprint.js
+//   stdout → {"confirmed":true}   si el usuario acepta
+//   stdout → {"confirmed":false}  si el usuario rechaza o timeout
+
+const https = require("https");
+const crypto = require("crypto");
+const fs = require("fs");
+const path = require("path");
+
+const BOT_TOKEN = "8403197784:AAG07242gOCKwZ-G-DI8eLC6R1HwfhG6Exk";
+const CHAT_ID = "6529617704";
+const POLL_TIMEOUT_SEC = 20;   // Telegram long-poll: esperar hasta 20s por update
+const MAX_POLL_CYCLES = 15;    // 15 ciclos × 20s = ~5 minutos antes de timeout
+const ANSWER_TIMEOUT = 5000;   // Timeout para answerCallbackQuery y editMessage
+
+const REPO_ROOT = "C:\\Workspaces\\Intrale\\platform";
+const LOG_FILE = path.join(REPO_ROOT, ".claude", "hooks", "hook-debug.log");
+const OFFSET_FILE = path.join(REPO_ROOT, ".claude", "hooks", "tg-approver-offset.json");
+
+function log(msg) {
+    try { fs.appendFileSync(LOG_FILE, "[" + new Date().toISOString() + "] NextSprint: " + msg + "\n"); } catch(e) {}
+}
+
+// --- Helpers HTTP (misma API que permission-approver.js) ---
+
+function telegramPost(method, params, timeoutMs) {
+    return new Promise((resolve, reject) => {
+        const postData = JSON.stringify(params);
+        const req = https.request({
+            hostname: "api.telegram.org",
+            path: "/bot" + BOT_TOKEN + "/" + method,
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "Content-Length": Buffer.byteLength(postData)
+            },
+            timeout: timeoutMs || 8000
+        }, (res) => {
+            let d = "";
+            res.on("data", (c) => d += c);
+            res.on("end", () => {
+                try {
+                    const r = JSON.parse(d);
+                    if (r.ok) resolve(r.result);
+                    else reject(new Error(JSON.stringify(r)));
+                } catch(e) { reject(e); }
+            });
+        });
+        req.on("timeout", () => { req.destroy(); reject(new Error("timeout " + method)); });
+        req.on("error", (e) => reject(e));
+        req.write(postData);
+        req.end();
+    });
+}
+
+// --- Offset persistente (compartido con permission-approver.js) ---
+
+function loadOffset() {
+    try {
+        const data = JSON.parse(fs.readFileSync(OFFSET_FILE, "utf8"));
+        return data.offset || 0;
+    } catch(e) { return 0; }
+}
+
+function saveOffset(offset) {
+    try { fs.writeFileSync(OFFSET_FILE, JSON.stringify({ offset }), "utf8"); } catch(e) {}
+}
+
+async function getCurrentOffset() {
+    const saved = loadOffset();
+    try {
+        const updates = await telegramPost("getUpdates", {
+            limit: 1,
+            timeout: 0,
+            allowed_updates: ["callback_query"]
+        }, 5000);
+        if (updates && updates.length > 0) {
+            const fresh = updates[updates.length - 1].update_id + 1;
+            return Math.max(saved, fresh);
+        }
+        return saved;
+    } catch(e) {
+        log("getCurrentOffset error: " + e.message);
+        return saved;
+    }
+}
+
+// --- Polling para nuestra solicitud ---
+
+async function pollForDecision(requestId, msgId, offset) {
+    let currentOffset = offset;
+
+    for (let cycle = 0; cycle < MAX_POLL_CYCLES; cycle++) {
+        log("Poll ciclo " + (cycle + 1) + "/" + MAX_POLL_CYCLES + " offset=" + currentOffset);
+
+        let updates;
+        try {
+            updates = await telegramPost("getUpdates", {
+                offset: currentOffset,
+                timeout: POLL_TIMEOUT_SEC,
+                allowed_updates: ["callback_query"]
+            }, (POLL_TIMEOUT_SEC + 5) * 1000);
+        } catch(e) {
+            log("getUpdates error ciclo " + cycle + ": " + e.message);
+            continue;
+        }
+
+        if (!updates || !Array.isArray(updates)) continue;
+
+        for (const update of updates) {
+            if (update.update_id >= currentOffset) {
+                currentOffset = update.update_id + 1;
+            }
+
+            const cq = update.callback_query;
+            if (!cq || !cq.data) continue;
+
+            // Seguridad: solo aceptar del chat correcto
+            if (String(cq.message && cq.message.chat && cq.message.chat.id) !== String(CHAT_ID)) {
+                log("Callback de chat desconocido: " + JSON.stringify(cq.message && cq.message.chat));
+                continue;
+            }
+
+            // Verificar que el callback es para NUESTRO mensaje
+            if (cq.message && cq.message.message_id !== msgId) {
+                log("Callback de otro mensaje: " + cq.message.message_id + " (esperaba " + msgId + ")");
+                continue;
+            }
+
+            // Extraer accion y requestId del callback_data
+            const parts = cq.data.split(":");
+            if (parts.length < 2) continue;
+            const action = parts[0];
+            const cbRequestId = parts.slice(1).join(":");
+
+            if (cbRequestId !== requestId) {
+                log("Callback de otra solicitud: " + cbRequestId + " (esperaba " + requestId + ")");
+                continue;
+            }
+
+            log("Decision recibida: " + action + " en ciclo " + cycle);
+            saveOffset(currentOffset);
+            return { action, callbackQueryId: cq.id, messageId: cq.message.message_id };
+        }
+    }
+
+    return null; // timeout
+}
+
+// --- Main ---
+
+async function main() {
+    const requestId = crypto.randomBytes(8).toString("hex");
+    const startTime = Date.now();
+    log("Iniciando consulta next-sprint requestId=" + requestId);
+
+    // Leer info del plan para contexto en el mensaje
+    let planInfo = "";
+    try {
+        const planPath = path.join(path.dirname(process.argv[1] || __filename), "sprint-plan.json");
+        if (fs.existsSync(planPath)) {
+            const plan = JSON.parse(fs.readFileSync(planPath, "utf8"));
+            const count = plan.agentes ? plan.agentes.length : "?";
+            planInfo = "\n\n\uD83D\uDCCB Sprint " + (plan.fecha || "?") + " \u2014 " + count + " agente(s)";
+        }
+    } catch(e) {}
+
+    const msgText = "\u2705 <b>Sprint completado</b>\n\n"
+        + "Todos los agentes finalizaron y los worktrees estan limpios."
+        + planInfo + "\n\n"
+        + "\u00BFPlanificar el siguiente sprint ahora?";
+
+    // 1. Obtener offset actual ANTES de enviar el mensaje
+    let offset;
+    try {
+        offset = await getCurrentOffset();
+        log("Offset inicial: " + offset);
+    } catch(e) {
+        log("Error obteniendo offset: " + e.message);
+        process.stdout.write(JSON.stringify({ confirmed: false, error: "offset" }) + "\n");
+        process.exit(0);
+    }
+
+    // 2. Enviar mensaje con inline buttons
+    let sentMsg;
+    try {
+        sentMsg = await telegramPost("sendMessage", {
+            chat_id: CHAT_ID,
+            text: msgText,
+            parse_mode: "HTML",
+            reply_markup: {
+                inline_keyboard: [[
+                    { text: "\uD83D\uDE80 Si, planificar", callback_data: "yes:" + requestId },
+                    { text: "\u23F9 No, terminar",         callback_data: "no:" + requestId }
+                ]]
+            }
+        }, 8000);
+        log("Mensaje enviado msg_id=" + sentMsg.message_id + " requestId=" + requestId);
+    } catch(e) {
+        log("Error enviando mensaje: " + e.message);
+        process.stdout.write(JSON.stringify({ confirmed: false, error: "send" }) + "\n");
+        process.exit(0);
+    }
+
+    const msgId = sentMsg.message_id;
+
+    // 3. Polling esperando la decision del usuario
+    const decision = await pollForDecision(requestId, msgId, offset);
+    const latencyMs = Date.now() - startTime;
+
+    if (!decision) {
+        // Timeout: editar mensaje y salir
+        log("Timeout sin respuesta. Latencia: " + latencyMs + "ms");
+        saveOffset(offset);
+        try {
+            await telegramPost("editMessageText", {
+                chat_id: CHAT_ID,
+                message_id: msgId,
+                text: msgText + "\n\n\u23F1 <i>Sin respuesta \u2014 ciclo finalizado</i>",
+                parse_mode: "HTML"
+            }, ANSWER_TIMEOUT);
+        } catch(e) { log("Error editando mensaje timeout: " + e.message); }
+        process.stdout.write(JSON.stringify({ confirmed: false, timeout: true }) + "\n");
+        process.exit(0);
+    }
+
+    // 4. Responder al callback (quitar spinner del boton en Telegram)
+    const isYes = decision.action === "yes";
+    const confirmText = isYes ? "\uD83D\uDE80 Planificando siguiente sprint..." : "\u23F9 Ciclo finalizado";
+    try {
+        await telegramPost("answerCallbackQuery", {
+            callback_query_id: decision.callbackQueryId,
+            text: confirmText,
+            show_alert: false
+        }, ANSWER_TIMEOUT);
+    } catch(e) { log("Error en answerCallbackQuery: " + e.message); }
+
+    // 5. Editar mensaje: quitar botones, mostrar decision tomada
+    const emoji = isYes ? "\uD83D\uDE80" : "\u23F9";
+    try {
+        await telegramPost("editMessageText", {
+            chat_id: CHAT_ID,
+            message_id: msgId,
+            text: msgText + "\n\n" + emoji + " <b>" + confirmText + "</b>"
+                + " <i>(" + latencyMs + "ms)</i>",
+            parse_mode: "HTML"
+        }, ANSWER_TIMEOUT);
+    } catch(e) { log("Error editando mensaje con decision: " + e.message); }
+
+    log("Resultado: " + (isYes ? "confirmed" : "rejected") + " en " + latencyMs + "ms");
+    process.stdout.write(JSON.stringify({ confirmed: isYes }) + "\n");
+    process.exit(0);
+}
+
+main().catch((e) => {
+    log("Error fatal: " + e.message);
+    process.stdout.write(JSON.stringify({ confirmed: false, error: e.message }) + "\n");
+    process.exit(0);
+});


### PR DESCRIPTION
## Summary
- **Watch-Agentes.ps1**: Watcher que monitorea sesiones de agentes Claude via session files (`.claude/sessions/*.json` con status `done`), con failsafe de deteccion de procesos. Al finalizar todos ejecuta `Stop-Agente.ps1 all`.
- **ask-next-sprint.js**: Helper Node.js que envia mensaje Telegram con botones inline (Si/No) preguntando si planificar el siguiente sprint, siguiendo el patron de `permission-approver.js` (offset compartido, polling callback_query, timeout 5 min).
- Ciclo completo: watcher detecta fin → Stop-Agente → Telegram confirm → git pull main → nueva terminal con `claude '/planner sprint'`
- Fallback a terminal interactiva si Telegram no esta disponible

Closes #878

## Test plan
- [ ] Verificar que Watch-Agentes.ps1 arranca y muestra estado de agentes del plan
- [ ] Verificar que detecta correctamente agentes finalizados via session files
- [ ] Verificar que Stop-Agente.ps1 all se ejecuta al detectar todos finalizados
- [ ] Verificar que ask-next-sprint.js envia mensaje Telegram con botones inline
- [ ] Verificar que al confirmar: git pull + nueva terminal con planner
- [ ] Verificar que al rechazar: exit limpio
- [ ] Verificar fallback a terminal si Telegram falla

🤖 Generated with [Claude Code](https://claude.com/claude-code)