### PR TITLE
feat: Stop-Agente — cerrar terminales de agentes finalizados (Closes #887)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,8 +51,9 @@ deps_commonMain.txt
 .claude/hooks/hook-debug.log
 .claude/hooks/tg-approver-offset.json
 
-# Sprint plan — plan de agentes (no commitear, local de trabajo)
+# Sprint — archivos de agentes (no commitear, local de trabajo)
 scripts/sprint-plan.json
+scripts/sprint-pids.json
 
 # Binarios de gh-cli descargados localmente
 gh-cli/

--- a/scripts/Start-Agente.ps1
+++ b/scripts/Start-Agente.ps1
@@ -107,9 +107,19 @@ function Start-UnAgente {
     $command = "Set-Location '$wtDirResolved'; Write-Host ''; Write-Host '  Agente $($Agente.numero) - issue #$issue ($slug)' -ForegroundColor Cyan; Write-Host '  Branch: $branch' -ForegroundColor Cyan; Write-Host ''; claude `"$escapedPrompt`""
 
     Write-Host ">> Abriendo terminal con claude..."
-    Start-Process powershell -ArgumentList "-NoExit", "-Command", $command
+    $proc = Start-Process powershell -ArgumentList "-NoExit", "-Command", $command -PassThru
 
-    Write-Host ">> Agente $($Agente.numero) lanzado en nueva terminal" -ForegroundColor Green
+    # Guardar PID en sprint-pids.json
+    $pidsFile = Join-Path $PSScriptRoot "sprint-pids.json"
+    $pidsData = if (Test-Path $pidsFile) {
+        Get-Content $pidsFile -Raw | ConvertFrom-Json
+    } else {
+        [PSCustomObject]@{}
+    }
+    $pidsData | Add-Member -NotePropertyName "agente_$($Agente.numero)" -NotePropertyValue $proc.Id -Force
+    $pidsData | ConvertTo-Json | Set-Content $pidsFile
+
+    Write-Host ">> Agente $($Agente.numero) lanzado en nueva terminal (PID $($proc.Id))" -ForegroundColor Green
 }
 
 # --- Ejecutar ---


### PR DESCRIPTION
## Resumen

Implementación del cierre automático de terminales PowerShell de agentes al finalizar el sprint (#887):

- **Start-Agente.ps1**: Captura PID con `-PassThru` y guarda en `scripts/sprint-pids.json`
- **Stop-Agente.ps1**: Nueva función `Close-AgenteTerminal` que cierra la terminal usando el PID guardado
  - Se llama en todos los puntos de salida (normal, --Abort, sin cambios, worktree no encontrado)
- **Limpieza**: `sprint-pids.json` se elimina al procesar `Stop-Agente.ps1 all`
- **.gitignore**: `scripts/sprint-pids.json` agregado para no commitar archivo temporal

## Criterios de aceptación

- [x] Al lanzar cada agente, `Start-Agente.ps1` guarda el PID en `sprint-pids.json`
- [x] Al procesar cada agente, `Stop-Agente.ps1` cierra la terminal usando el PID registrado
- [x] Si la terminal ya fue cerrada, el script no falla (`-ErrorAction SilentlyContinue`)
- [x] Al finalizar `Stop-Agente.ps1 all`, se elimina `sprint-pids.json`
- [x] `scripts/sprint-pids.json` está en `.gitignore`
- [x] El cierre de terminal ocurre incluso en modo `-Abort`

## Plan de tests

- [x] Scripts PowerShell verificados sintácticamente
- [x] Cambios a archivos revisados
- [x] Manejo de errores verificado (sin PID, proceso ya cerrado, archivo no existe)

🤖 Generado con [Claude Code](https://claude.com/claude-code)