### PR TITLE
fix: unificar encabezado de login (evitar doble título)

### DIFF
--- a/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/catalog/DefaultCatalog_en.kt
+++ b/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/catalog/DefaultCatalog_en.kt
@@ -284,6 +284,7 @@ internal val DefaultCatalog_en: Map<MessageKey, String> = mapOf(
     MessageKey.login_generic_error to "There was an error while signing in. Try again.",
     MessageKey.login_name_placeholder to "First name",
     MessageKey.login_new_password_placeholder to "Secure new password",
+    MessageKey.login_appbar_title to "Sign in",
     MessageKey.login_business_title to "Sign in as business admin",
     MessageKey.login_business_subtitle to "Use your business credentials to access the dashboard, team, and orders.",
     MessageKey.login_password_icon_content_description to "Password icon",

--- a/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/catalog/DefaultCatalog_es.kt
+++ b/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/catalog/DefaultCatalog_es.kt
@@ -284,6 +284,7 @@ internal val DefaultCatalog_es: Map<MessageKey, String> = mapOf(
     MessageKey.login_generic_error to "Ocurrió un error al iniciar sesión. Intentá nuevamente.",
     MessageKey.login_name_placeholder to "Nombre",
     MessageKey.login_new_password_placeholder to "Nueva contraseña segura",
+    MessageKey.login_appbar_title to "Inicio de sesion",
     MessageKey.login_business_title to "Ingresá como administrador de negocio",
     MessageKey.login_business_subtitle to "Usá tus credenciales para acceder al panel, tu equipo y los pedidos de tu tienda.",
     MessageKey.login_password_icon_content_description to "Ícono de contraseña",

--- a/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/model/MessageKey.kt
+++ b/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/model/MessageKey.kt
@@ -287,6 +287,7 @@ enum class MessageKey {
     login_generic_error,
     login_name_placeholder,
     login_new_password_placeholder,
+    login_appbar_title,
     login_business_title,
     login_business_subtitle,
     login_password_icon_content_description,

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/auth/Login.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/auth/Login.kt
@@ -63,15 +63,7 @@ const val LOGIN_PATH = "/login"
 
 class Login : Screen(LOGIN_PATH) {
 
-    @Composable
-    override fun titleText(): String {
-        val key = when {
-            AppRuntimeConfig.isDelivery -> MessageKey.login_delivery_title
-            AppRuntimeConfig.isBusiness -> MessageKey.login_business_title
-            else -> MessageKey.login_title
-        }
-        return Txt(key)
-    }
+    override val messageTitle: MessageKey = MessageKey.login_appbar_title
 
     private val logger = LoggerFactory.default.newLogger<Login>()
 


### PR DESCRIPTION
## Resumen

Corrige la duplicación de título en la pantalla de login:
- El AppBar muestra "Inicio de sesión" (neutral, sin duplicar el body)
- El body muestra los títulos contextuales ("Ingresá a tu cuenta", "Ingresá como administrador...", etc.)
- Afecta a Business y Delivery (Client ya tenía AppBar oculto)

## Cambios

- **MessageKey.kt**: Agrega `login_appbar_title`
- **DefaultCatalog_es.kt**: Agrega "Inicio de sesion"
- **DefaultCatalog_en.kt**: Agrega "Sign in"
- **Login.kt**: Reemplaza `titleText()` override por `messageTitle` property

## Plan de tests

- [x] Compilación exitosa (./gradlew :app:composeApp:compileKotlinMetadata)
- [x] Tests de desktop pasan (./gradlew :app:composeApp:desktopTest)
- Verificar visualmente en emulador/device que AppBar y body no tienen título duplicado

Closes #582

🤖 Generado con [Claude Code](https://claude.com/claude-code)