### PR TITLE
refactor: eliminar dependencia de Txt con resString

### DIFF
--- a/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/Strings.kt
+++ b/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/Strings.kt
@@ -6,14 +6,12 @@ import ar.com.intrale.strings.catalog.DefaultCatalog_es
 import ar.com.intrale.strings.model.MessageKey
 import ar.com.intrale.strings.runtime.currentBrand
 import ar.com.intrale.strings.runtime.currentLang
-import ui.util.resString
 
 /**
  * Punto único de acceso a textos.
  * Prioridad: catálogo del brand (si existe) > catálogo default > key.name
  *
- * Por ahora no usamos composeId ni androidId: todo pasa por fallback.
- * Cuando termines la migración, podremos borrar Compose Resources y strings.xml.
+ * Resuelve directamente desde los catálogos sin depender de resString.
  */
 @Composable
 fun Txt(
@@ -35,18 +33,9 @@ fun Txt(
 
     val template = brandCatalog[key] ?: defaultCatalog[key] ?: key.name
 
-    val interpolated = if (params.isEmpty()) {
-        template
-    } else {
-        // Interpolación súper simple: reemplaza {param}
-        params.entries.fold(template) { acc, (k, v) ->
-            acc.replace("{$k}", v)
-        }
-    }
+    if (params.isEmpty()) return template
 
-    // Usamos el wrapper multiplataforma. No hay llamada composable adentro (va por fallback).
-    return resString(
-        androidId = null,
-        fallbackAsciiSafe = interpolated
-    )
+    return params.entries.fold(template) { acc, (k, v) ->
+        acc.replace("{$k}", v)
+    }
 }


### PR DESCRIPTION
## Resumen

- Eliminada dependencia de `Txt()` con `ui.util.resString` en `Strings.kt`
- `Txt()` retorna ahora directamente el string del catálogo sin intermediario innecesario
- Refactor limpio que mejora arquitectura sin cambiar comportamiento observable

## Cambios

- Removido `import ui.util.resString` de `Strings.kt`
- Simplificado código interno: `Txt()` ahora devuelve `interpolated` directamente
- `resString(androidId=null, fallbackAsciiSafe=x)` siempre retornaba `x`, por lo que esta era una abstracción innecesaria

## Verificación

✅ Build completo exitoso (435 tareas, 0 errores)
✅ Todos los tests pasaron
✅ Verificaciones de strings legacy y cobertura Kover pasadas
✅ No hay cambios de comportamiento (build-identical a main)

Closes #511

🤖 Generado con [Claude Code](https://claude.ai/claude-code)