### PR TITLE
refactor(strings): migrar validaciones de LoginViewModel a MessageKey y resolveMessage

### DIFF
--- a/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/catalog/DefaultCatalog_en.kt
+++ b/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/catalog/DefaultCatalog_en.kt
@@ -272,6 +272,7 @@ internal val DefaultCatalog_en: Map<MessageKey, String> = mapOf(
     MessageKey.form_error_required to "Required field",
     MessageKey.form_error_invalid_email to "Invalid email",
     MessageKey.form_error_invalid_code to "Code must be 6 digits",
+    MessageKey.form_error_min_length_8 to "Must contain at least 8 characters",
     MessageKey.family_name to "Last name",
     MessageKey.login_button to "Sign in",
     MessageKey.login_change_password_description to "Your account must update the password before signing in.",

--- a/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/catalog/DefaultCatalog_es.kt
+++ b/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/catalog/DefaultCatalog_es.kt
@@ -272,6 +272,7 @@ internal val DefaultCatalog_es: Map<MessageKey, String> = mapOf(
     MessageKey.form_error_required to "Campo obligatorio",
     MessageKey.form_error_invalid_email to "Correo inválido",
     MessageKey.form_error_invalid_code to "El código debe tener 6 dígitos",
+    MessageKey.form_error_min_length_8 to "Debe contener al menos 8 caracteres",
     MessageKey.family_name to "Apellido",
     MessageKey.login_button to "Ingresar",
     MessageKey.login_change_password_description to "Tu cuenta requiere actualizar la contraseña antes de ingresar.",

--- a/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/model/MessageKey.kt
+++ b/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/model/MessageKey.kt
@@ -275,6 +275,7 @@ enum class MessageKey {
     form_error_required,
     form_error_invalid_email,
     form_error_invalid_code,
+    form_error_min_length_8,
     family_name,
     login_button,
     login_change_password_description,

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/auth/LoginViewModel.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/auth/LoginViewModel.kt
@@ -4,6 +4,8 @@ import DIManager
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import ar.com.intrale.strings.model.MessageKey
+import ar.com.intrale.strings.resolveMessage
 import asdo.auth.DoLoginResult
 import asdo.auth.ToDoCheckPreviousLogin
 import asdo.auth.ToDoLogin
@@ -150,23 +152,23 @@ class LoginViewModel(
 
     private fun buildValidation(): Validation<LoginUIState> = Validation {
         LoginUIState::user required {
-            minLength(1) hint "Ingresá tu correo electrónico"
-            pattern(".+@.+\\..+") hint "Ingresá un correo electrónico válido"
+            minLength(1) hint resolveMessage(MessageKey.form_error_required)
+            pattern(".+@.+\\..+") hint resolveMessage(MessageKey.form_error_invalid_email)
         }
         LoginUIState::password required {
-            minLength(1) hint "Ingresá tu contraseña"
-            minLength(8) hint "Debe contener al menos 8 caracteres"
+            minLength(1) hint resolveMessage(MessageKey.form_error_required)
+            minLength(8) hint resolveMessage(MessageKey.form_error_min_length_8)
         }
         if (changePasswordRequired) {
             LoginUIState::newPassword required {
-                minLength(1) hint "Ingresá tu nueva contraseña"
-                minLength(8) hint "Debe contener al menos 8 caracteres"
+                minLength(1) hint resolveMessage(MessageKey.form_error_required)
+                minLength(8) hint resolveMessage(MessageKey.form_error_min_length_8)
             }
             LoginUIState::name required {
-                minLength(1) hint "Ingresá tu nombre"
+                minLength(1) hint resolveMessage(MessageKey.form_error_required)
             }
             LoginUIState::familyName required {
-                minLength(1) hint "Ingresá tu apellido"
+                minLength(1) hint resolveMessage(MessageKey.form_error_required)
             }
         }
     }


### PR DESCRIPTION
## Resumen

Completa la migración del Login a la nueva API de strings completando las validaciones del ViewModel:

- Agregar `MessageKey.form_error_min_length_8` para validaciones de longitud mínima (8 caracteres)
- Actualizar `DefaultCatalog_es.kt` y `DefaultCatalog_en.kt` con la nueva clave y traducciones
- Migrar `LoginViewModel.kt` para usar `resolveMessage(MessageKey.*)` en lugar de strings hardcodeados en las validaciones Konform

Esta migración mantiene consistencia con el resto del codebase (SignUpViewModel, RegisterBusinessViewModel, etc.) que ya usan el patrón de `resolveMessage()` para mensajes de validación no-composables.

## Criterios de aceptación

- [x] Todos los strings de validación usan `resolveMessage(MessageKey.*)`
- [x] Se agregan nuevas claves de MessageKey (form_error_min_length_8)
- [x] Se actualizan catálogos ES/EN
- [x] Compilación exitosa
- [x] Tests pasan
- [x] verifyNoLegacyStrings pasa sin violaciones
- [x] Cambios son totalmente no-breaking

## Plan de tests

- [x] Compilación desktop exitosa
- [x] Tests unitarios pasan
- [x] verifyNoLegacyStrings valida correctamente

Closes #477

🤖 Generado con [Claude Code](https://claude.com/claude-code)