### PR TITLE
feat: tarea Gradle runGetStringCodemod para codemod getString → Txt

### DIFF
--- a/tools/forbidden-strings-processor/build.gradle.kts
+++ b/tools/forbidden-strings-processor/build.gradle.kts
@@ -1,5 +1,10 @@
 plugins {
     alias(libs.plugins.kotlin.jvm)
+    application
+}
+
+application {
+    mainClass.set("ar.com.intrale.i18nscan.codemod.GetStringToTxtCodemodKt")
 }
 
 kotlin {
@@ -22,4 +27,19 @@ dependencies {
 
 tasks.test {
     useJUnitPlatform()
+}
+
+tasks.register<JavaExec>("runGetStringCodemod") {
+    group = "codemod"
+    description = "Ejecuta el codemod getString → Txt sobre app/composeApp/src"
+    classpath = sourceSets["main"].output + sourceSets["main"].compileClasspath
+    mainClass.set("ar.com.intrale.i18nscan.codemod.GetStringToTxtCodemodKt")
+
+    val applyMode = providers.gradleProperty("codemod.apply").orElse("false")
+    val targetDir = rootProject.layout.projectDirectory.dir("app/composeApp/src")
+
+    argumentProviders.add(CommandLineArgumentProvider {
+        val flag = if (applyMode.get() == "true") "--apply" else "--dry-run"
+        listOf(flag, targetDir.asFile.absolutePath)
+    })
 }


### PR DESCRIPTION
## Summary
- Registra plugin `application` y tarea `runGetStringCodemod` (JavaExec) en `tools/forbidden-strings-processor/build.gradle.kts`
- Ejecuta el codemod existente `GetStringToTxtCodemod` sobre `app/composeApp/src`
- Modo dry-run por defecto; aplicar cambios con `-Pcodemod.apply=true`

Closes #550

## Test plan
- [x] `./gradlew :tools:forbidden-strings-processor:test` — tests existentes pasan
- [x] `./gradlew runGetStringCodemod` — dry-run sin coincidencias legacy
- [x] `./gradlew check` — build completo exitoso (259 tasks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)