### PR TITLE
fix: evitar error de sesion anidada al lanzar agentes desde Claude Code

### DIFF
--- a/scripts/Start-Agente.ps1
+++ b/scripts/Start-Agente.ps1
@@ -130,7 +130,7 @@ function Start-UnAgente {
 
     # Abrir nueva terminal PowerShell con claude ejecutando
     $escapedPrompt = $prompt -replace '"', '\"'
-    $command = "Set-Location '$wtDirResolved'; Write-Host ''; Write-Host '  Agente $($Agente.numero) - issue #$issue ($slug)' -ForegroundColor Cyan; Write-Host '  Branch: $branch' -ForegroundColor Cyan; Write-Host ''; claude `"$escapedPrompt`""
+    $command = "Remove-Item Env:CLAUDECODE -ErrorAction SilentlyContinue; Set-Location '$wtDirResolved'; Write-Host ''; Write-Host '  Agente $($Agente.numero) - issue #$issue ($slug)' -ForegroundColor Cyan; Write-Host '  Branch: $branch' -ForegroundColor Cyan; Write-Host ''; claude `"$escapedPrompt`""
 
     Write-Host ">> Abriendo terminal con claude..."
     $proc = Start-Process powershell -ArgumentList "-NoExit", "-Command", $command -PassThru
@@ -164,7 +164,7 @@ function Start-MonitorLive {
     }
 
     $command = "Set-Location '$MainRepo'; " +
-               "Write-Host '  Monitor Live — Dashboard multi-sesion' -ForegroundColor Cyan; " +
+               "Write-Host '  Monitor Live - Dashboard multi-sesion' -ForegroundColor Cyan; " +
                "node '$dashboardPath'"
     Start-Process powershell -ArgumentList "-NoExit", "-Command", $command
     Write-Host ">> Monitor live lanzado." -ForegroundColor Green


### PR DESCRIPTION
## Summary
- Limpia variable de entorno `CLAUDECODE` en terminales hijas antes de invocar `claude`, evitando el error "cannot be launched inside another Claude Code session"
- Corrige em dash que rompia el parsing de PowerShell en `Start-MonitorLive`

## Test plan
- [ ] Ejecutar `Start-Agente.ps1 all` desde una sesion de Claude Code y verificar que los agentes arrancan sin error de nested session
- [ ] Verificar que el monitor live se lanza sin error de parsing

🤖 Generated with [Claude Code](https://claude.com/claude-code)