### PR TITLE
feat: ClientOrdersViewModel para pantalla de pedidos del cliente

### DIFF
--- a/app/composeApp/src/commonMain/kotlin/DIManager.kt
+++ b/app/composeApp/src/commonMain/kotlin/DIManager.kt
@@ -16,9 +16,13 @@ import asdo.auth.ToDoPasswordRecovery
 import asdo.auth.ToDoResetLoginCache
 import asdo.auth.ToDoTwoFactorSetup
 import asdo.auth.ToDoTwoFactorVerify
+import asdo.client.DoGetClientOrderDetail
+import asdo.client.DoGetClientOrders
 import asdo.client.DoGetClientProfile
 import asdo.client.DoManageClientAddress
 import asdo.client.DoUpdateClientProfile
+import asdo.client.ToDoGetClientOrderDetail
+import asdo.client.ToDoGetClientOrders
 import asdo.client.ToDoGetClientProfile
 import asdo.client.ToDoManageClientAddress
 import asdo.client.ToDoUpdateClientProfile
@@ -331,6 +335,8 @@ private val clientModule = DI.Module("client") {
     bindSingleton<ToDoGetClientProfile> { DoGetClientProfile(instance(), instance(), instance()) }
     bindSingleton<ToDoUpdateClientProfile> { DoUpdateClientProfile(instance(), instance(), instance()) }
     bindSingleton<ToDoManageClientAddress> { DoManageClientAddress(instance(), instance(), instance()) }
+    bindSingleton<ToDoGetClientOrders> { DoGetClientOrders(instance()) }
+    bindSingleton<ToDoGetClientOrderDetail> { DoGetClientOrderDetail(instance()) }
 }
 
 private val deliveryModule = DI.Module("delivery") {

--- a/app/composeApp/src/commonMain/kotlin/asdo/client/ClientOrderModels.kt
+++ b/app/composeApp/src/commonMain/kotlin/asdo/client/ClientOrderModels.kt
@@ -1,0 +1,97 @@
+package asdo.client
+
+import ext.client.ClientAddressDTO
+import ext.client.ClientOrderDTO
+import ext.client.ClientOrderDetailDTO
+import ext.client.ClientOrderItemDTO
+
+enum class ClientOrderStatus {
+    PENDING, CONFIRMED, IN_PROGRESS, DELIVERED, CANCELLED, UNKNOWN
+}
+
+data class ClientOrder(
+    val id: String,
+    val label: String,
+    val businessName: String,
+    val status: ClientOrderStatus,
+    val createdAt: String,
+    val promisedAt: String?,
+    val total: Double,
+    val itemCount: Int
+)
+
+data class ClientOrderDetail(
+    val id: String,
+    val label: String,
+    val businessName: String,
+    val status: ClientOrderStatus,
+    val createdAt: String,
+    val promisedAt: String?,
+    val total: Double,
+    val itemCount: Int,
+    val items: List<ClientOrderItem>,
+    val address: ClientOrderAddress?
+)
+
+data class ClientOrderItem(
+    val id: String,
+    val name: String,
+    val quantity: Int,
+    val unitPrice: Double,
+    val subtotal: Double
+)
+
+data class ClientOrderAddress(
+    val label: String,
+    val street: String,
+    val number: String,
+    val city: String
+)
+
+fun ClientOrderDTO.toDomain(): ClientOrder = ClientOrder(
+    id = id ?: "",
+    label = publicId.ifEmpty { shortCode.ifEmpty { id ?: "" } },
+    businessName = businessName,
+    status = status.toClientOrderStatus(),
+    createdAt = createdAt,
+    promisedAt = promisedAt,
+    total = total,
+    itemCount = itemCount
+)
+
+fun ClientOrderDetailDTO.toDomain(): ClientOrderDetail = ClientOrderDetail(
+    id = id ?: "",
+    label = publicId.ifEmpty { shortCode.ifEmpty { id ?: "" } },
+    businessName = businessName,
+    status = status.toClientOrderStatus(),
+    createdAt = createdAt,
+    promisedAt = promisedAt,
+    total = total,
+    itemCount = itemCount,
+    items = items.map { it.toDomain() },
+    address = address?.toOrderAddress()
+)
+
+fun ClientOrderItemDTO.toDomain(): ClientOrderItem = ClientOrderItem(
+    id = id ?: "",
+    name = name,
+    quantity = quantity,
+    unitPrice = unitPrice,
+    subtotal = subtotal
+)
+
+fun ClientAddressDTO.toOrderAddress(): ClientOrderAddress = ClientOrderAddress(
+    label = label,
+    street = street,
+    number = number,
+    city = city
+)
+
+fun String.toClientOrderStatus(): ClientOrderStatus = when (this.lowercase()) {
+    "pending" -> ClientOrderStatus.PENDING
+    "confirmed" -> ClientOrderStatus.CONFIRMED
+    "inprogress", "in_progress" -> ClientOrderStatus.IN_PROGRESS
+    "delivered" -> ClientOrderStatus.DELIVERED
+    "cancelled", "canceled" -> ClientOrderStatus.CANCELLED
+    else -> ClientOrderStatus.UNKNOWN
+}

--- a/app/composeApp/src/commonMain/kotlin/asdo/client/DoClientOrders.kt
+++ b/app/composeApp/src/commonMain/kotlin/asdo/client/DoClientOrders.kt
@@ -1,0 +1,38 @@
+package asdo.client
+
+import ext.client.CommClientOrdersService
+import ext.client.toClientException
+import org.kodein.log.LoggerFactory
+import org.kodein.log.newLogger
+
+class DoGetClientOrders(
+    private val ordersService: CommClientOrdersService
+) : ToDoGetClientOrders {
+
+    private val logger = LoggerFactory.default.newLogger<DoGetClientOrders>()
+
+    override suspend fun execute(): Result<List<ClientOrder>> = runCatching {
+        logger.info { "Obteniendo pedidos del cliente" }
+        ordersService.listOrders().getOrThrow()
+            .map { it.toDomain() }
+            .sortedByDescending { it.createdAt }
+    }.recoverCatching { throwable ->
+        logger.error(throwable) { "Fallo al obtener pedidos del cliente" }
+        throw throwable.toClientException()
+    }
+}
+
+class DoGetClientOrderDetail(
+    private val ordersService: CommClientOrdersService
+) : ToDoGetClientOrderDetail {
+
+    private val logger = LoggerFactory.default.newLogger<DoGetClientOrderDetail>()
+
+    override suspend fun execute(orderId: String): Result<ClientOrderDetail> = runCatching {
+        logger.info { "Obteniendo detalle del pedido $orderId" }
+        ordersService.fetchOrderDetail(orderId).getOrThrow().toDomain()
+    }.recoverCatching { throwable ->
+        logger.error(throwable) { "Fallo al obtener detalle del pedido $orderId" }
+        throw throwable.toClientException()
+    }
+}

--- a/app/composeApp/src/commonMain/kotlin/asdo/client/ToDoClientOrders.kt
+++ b/app/composeApp/src/commonMain/kotlin/asdo/client/ToDoClientOrders.kt
@@ -1,0 +1,9 @@
+package asdo.client
+
+interface ToDoGetClientOrders {
+    suspend fun execute(): Result<List<ClientOrder>>
+}
+
+interface ToDoGetClientOrderDetail {
+    suspend fun execute(orderId: String): Result<ClientOrderDetail>
+}

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/client/ClientOrdersViewModel.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/client/ClientOrdersViewModel.kt
@@ -1,0 +1,104 @@
+package ui.sc.client
+
+import DIManager
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import asdo.client.ClientOrder
+import asdo.client.ClientOrderDetail
+import asdo.client.ClientOrderStatus
+import asdo.client.ToDoGetClientOrderDetail
+import asdo.client.ToDoGetClientOrders
+import ext.client.toClientException
+import org.kodein.di.direct
+import org.kodein.di.instance
+import org.kodein.log.LoggerFactory
+import org.kodein.log.newLogger
+import ui.sc.shared.ViewModel
+
+enum class ClientOrdersStatus { Idle, Loading, Loaded, Empty, Error }
+
+data class ClientOrdersUiState(
+    val status: ClientOrdersStatus = ClientOrdersStatus.Idle,
+    val orders: List<ClientOrder> = emptyList(),
+    val errorMessage: String? = null,
+    val selectedFilter: ClientOrderStatus? = null,
+    val selectedOrderDetail: ClientOrderDetail? = null,
+    val detailLoading: Boolean = false,
+    val detailError: String? = null
+)
+
+class ClientOrdersViewModel(
+    private val getClientOrders: ToDoGetClientOrders = DIManager.di.direct.instance(),
+    private val getClientOrderDetail: ToDoGetClientOrderDetail = DIManager.di.direct.instance(),
+    loggerFactory: LoggerFactory = LoggerFactory.default
+) : ViewModel() {
+
+    private val logger = loggerFactory.newLogger<ClientOrdersViewModel>()
+
+    var state by mutableStateOf(ClientOrdersUiState())
+        private set
+
+    private var allOrders: List<ClientOrder> = emptyList()
+
+    override fun getState(): Any = state
+
+    override fun initInputState() {
+        // Sin inputs de formulario para listado de pedidos
+    }
+
+    suspend fun loadOrders() {
+        state = state.copy(status = ClientOrdersStatus.Loading, errorMessage = null)
+        getClientOrders.execute()
+            .onSuccess { orders ->
+                allOrders = orders
+                applyFilter()
+            }
+            .onFailure { throwable ->
+                val clientError = throwable.toClientException()
+                logger.error(throwable) { "Error al cargar pedidos del cliente" }
+                state = state.copy(
+                    status = ClientOrdersStatus.Error,
+                    errorMessage = clientError.message ?: "Error al cargar pedidos"
+                )
+            }
+    }
+
+    fun selectFilter(filter: ClientOrderStatus?) {
+        state = state.copy(selectedFilter = filter)
+        applyFilter()
+    }
+
+    private fun applyFilter() {
+        val filtered = state.selectedFilter?.let { f -> allOrders.filter { it.status == f } } ?: allOrders
+        state = if (filtered.isEmpty()) {
+            state.copy(status = ClientOrdersStatus.Empty, orders = emptyList())
+        } else {
+            state.copy(status = ClientOrdersStatus.Loaded, orders = filtered)
+        }
+    }
+
+    suspend fun loadOrderDetail(orderId: String) {
+        state = state.copy(detailLoading = true, detailError = null, selectedOrderDetail = null)
+        getClientOrderDetail.execute(orderId)
+            .onSuccess { detail ->
+                state = state.copy(detailLoading = false, selectedOrderDetail = detail)
+            }
+            .onFailure { throwable ->
+                val clientError = throwable.toClientException()
+                logger.error(throwable) { "Error al cargar detalle del pedido $orderId" }
+                state = state.copy(
+                    detailLoading = false,
+                    detailError = clientError.message ?: "Error al cargar detalle del pedido"
+                )
+            }
+    }
+
+    fun clearOrderDetail() {
+        state = state.copy(selectedOrderDetail = null, detailError = null, detailLoading = false)
+    }
+
+    fun clearError() {
+        state = state.copy(errorMessage = null)
+    }
+}

--- a/app/composeApp/src/commonTest/kotlin/ui/sc/client/ClientOrdersViewModelTest.kt
+++ b/app/composeApp/src/commonTest/kotlin/ui/sc/client/ClientOrdersViewModelTest.kt
@@ -1,0 +1,216 @@
+package ui.sc.client
+
+import asdo.client.ClientOrder
+import asdo.client.ClientOrderDetail
+import asdo.client.ClientOrderItem
+import asdo.client.ClientOrderStatus
+import asdo.client.ToDoGetClientOrderDetail
+import asdo.client.ToDoGetClientOrders
+import kotlinx.coroutines.test.runTest
+import org.kodein.log.LoggerFactory
+import org.kodein.log.frontend.simplePrintFrontend
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+private val testLoggerFactory = LoggerFactory(listOf(simplePrintFrontend))
+
+private val sampleOrders = listOf(
+    ClientOrder(
+        id = "o1",
+        label = "PED-001",
+        businessName = "Pizzeria Roma",
+        status = ClientOrderStatus.PENDING,
+        createdAt = "2026-02-20T10:00:00",
+        promisedAt = "2026-02-20T11:00:00",
+        total = 2500.0,
+        itemCount = 3
+    ),
+    ClientOrder(
+        id = "o2",
+        label = "PED-002",
+        businessName = "Farmacia Norte",
+        status = ClientOrderStatus.DELIVERED,
+        createdAt = "2026-02-19T15:00:00",
+        promisedAt = null,
+        total = 1800.0,
+        itemCount = 2
+    ),
+    ClientOrder(
+        id = "o3",
+        label = "PED-003",
+        businessName = "Panaderia Sur",
+        status = ClientOrderStatus.CANCELLED,
+        createdAt = "2026-02-18T09:00:00",
+        promisedAt = null,
+        total = 500.0,
+        itemCount = 1
+    )
+)
+
+private val sampleOrderDetail = ClientOrderDetail(
+    id = "o1",
+    label = "PED-001",
+    businessName = "Pizzeria Roma",
+    status = ClientOrderStatus.PENDING,
+    createdAt = "2026-02-20T10:00:00",
+    promisedAt = "2026-02-20T11:00:00",
+    total = 2500.0,
+    itemCount = 3,
+    items = listOf(
+        ClientOrderItem(id = "i1", name = "Pizza Grande", quantity = 1, unitPrice = 1500.0, subtotal = 1500.0),
+        ClientOrderItem(id = "i2", name = "Empanada", quantity = 4, unitPrice = 250.0, subtotal = 1000.0)
+    ),
+    address = null
+)
+
+private class FakeGetClientOrders(
+    private val result: Result<List<ClientOrder>> = Result.success(sampleOrders)
+) : ToDoGetClientOrders {
+    override suspend fun execute(): Result<List<ClientOrder>> = result
+}
+
+private class FakeGetClientOrderDetail(
+    private val result: Result<ClientOrderDetail> = Result.success(sampleOrderDetail)
+) : ToDoGetClientOrderDetail {
+    override suspend fun execute(orderId: String): Result<ClientOrderDetail> = result
+}
+
+class ClientOrdersViewModelTest {
+
+    private fun createViewModel(
+        getClientOrders: ToDoGetClientOrders = FakeGetClientOrders(),
+        getClientOrderDetail: ToDoGetClientOrderDetail = FakeGetClientOrderDetail()
+    ): ClientOrdersViewModel = ClientOrdersViewModel(
+        getClientOrders = getClientOrders,
+        getClientOrderDetail = getClientOrderDetail,
+        loggerFactory = testLoggerFactory
+    )
+
+    @Test
+    fun `loadOrders exitoso muestra lista de pedidos`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.loadOrders()
+
+        assertEquals(ClientOrdersStatus.Loaded, viewModel.state.status)
+        assertEquals(3, viewModel.state.orders.size)
+        assertEquals("PED-001", viewModel.state.orders[0].label)
+    }
+
+    @Test
+    fun `loadOrders vacio muestra Empty`() = runTest {
+        val viewModel = createViewModel(
+            getClientOrders = FakeGetClientOrders(Result.success(emptyList()))
+        )
+
+        viewModel.loadOrders()
+
+        assertEquals(ClientOrdersStatus.Empty, viewModel.state.status)
+        assertTrue(viewModel.state.orders.isEmpty())
+    }
+
+    @Test
+    fun `loadOrders con error muestra Error`() = runTest {
+        val viewModel = createViewModel(
+            getClientOrders = FakeGetClientOrders(Result.failure(RuntimeException("Sin conexion")))
+        )
+
+        viewModel.loadOrders()
+
+        assertEquals(ClientOrdersStatus.Error, viewModel.state.status)
+        assertTrue(viewModel.state.errorMessage != null)
+    }
+
+    @Test
+    fun `selectFilter filtra pedidos por estado pendiente`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.loadOrders()
+        viewModel.selectFilter(ClientOrderStatus.PENDING)
+
+        assertEquals(ClientOrdersStatus.Loaded, viewModel.state.status)
+        assertEquals(1, viewModel.state.orders.size)
+        assertEquals(ClientOrderStatus.PENDING, viewModel.state.orders[0].status)
+        assertEquals(ClientOrderStatus.PENDING, viewModel.state.selectedFilter)
+    }
+
+    @Test
+    fun `selectFilter null muestra todos los pedidos`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.loadOrders()
+        viewModel.selectFilter(ClientOrderStatus.PENDING)
+        viewModel.selectFilter(null)
+
+        assertEquals(ClientOrdersStatus.Loaded, viewModel.state.status)
+        assertEquals(3, viewModel.state.orders.size)
+        assertNull(viewModel.state.selectedFilter)
+    }
+
+    @Test
+    fun `selectFilter con estado sin resultados muestra Empty`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.loadOrders()
+        viewModel.selectFilter(ClientOrderStatus.IN_PROGRESS)
+
+        assertEquals(ClientOrdersStatus.Empty, viewModel.state.status)
+        assertTrue(viewModel.state.orders.isEmpty())
+    }
+
+    @Test
+    fun `loadOrderDetail exitoso carga el detalle`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.loadOrderDetail("o1")
+
+        assertFalse(viewModel.state.detailLoading)
+        assertNull(viewModel.state.detailError)
+        assertEquals("o1", viewModel.state.selectedOrderDetail?.id)
+        assertEquals(2, viewModel.state.selectedOrderDetail?.items?.size)
+    }
+
+    @Test
+    fun `loadOrderDetail con error muestra mensaje de error`() = runTest {
+        val viewModel = createViewModel(
+            getClientOrderDetail = FakeGetClientOrderDetail(
+                Result.failure(RuntimeException("Pedido no encontrado"))
+            )
+        )
+
+        viewModel.loadOrderDetail("o1")
+
+        assertFalse(viewModel.state.detailLoading)
+        assertTrue(viewModel.state.detailError != null)
+        assertNull(viewModel.state.selectedOrderDetail)
+    }
+
+    @Test
+    fun `clearOrderDetail limpia el detalle seleccionado`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.loadOrderDetail("o1")
+        viewModel.clearOrderDetail()
+
+        assertNull(viewModel.state.selectedOrderDetail)
+        assertNull(viewModel.state.detailError)
+        assertFalse(viewModel.state.detailLoading)
+    }
+
+    @Test
+    fun `clearError limpia el mensaje de error`() = runTest {
+        val viewModel = createViewModel(
+            getClientOrders = FakeGetClientOrders(Result.failure(RuntimeException("Error")))
+        )
+
+        viewModel.loadOrders()
+        assertTrue(viewModel.state.errorMessage != null)
+
+        viewModel.clearError()
+
+        assertNull(viewModel.state.errorMessage)
+    }
+}


### PR DESCRIPTION
## Resumen

Implementación completa del issue #854 — ViewModel para la pantalla de pedidos del cliente.

- **Modelos de dominio**: `ClientOrder`, `ClientOrderDetail`, `ClientOrderItem`, `ClientOrderAddress`, `ClientOrderStatus` enum
- **Casos de uso**: Interfaces `ToDoGetClientOrders` e `ToDoGetClientOrderDetail` + implementaciones con logging y manejo de errores
- **ViewModel**: `ClientOrdersViewModel` con state management (`ClientOrdersUiState`), operaciones de carga, filtrado por estado y carga de detalles
- **Tests**: 10 tests con Fakes cubriendo carga exitosa, vacío, error, filtros y detalle
- **DI**: Registrados en `DIManager.kt` dentro de `clientModule`

## Plan de tests

- [x] Tests unitarios pasan (10/10)
- [x] Build completo sin errores
- [x] Compilación Kotlin exitosa (compileKotlinDesktop)
- [x] Ejecución de tests exitosa (desktopTest)

Closes #854

🤖 Generado con [Claude Code](https://claude.com/claude-code)