### PR TITLE
refactor: migrar PasswordRecovery ViewModels a MessageKey para validaciones

### DIFF
--- a/app/composeApp/src/commonMain/kotlin/ui/sc/auth/ConfirmPasswordRecoveryViewModel.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/auth/ConfirmPasswordRecoveryViewModel.kt
@@ -6,6 +6,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import asdo.auth.DoConfirmPasswordRecoveryResult
 import asdo.auth.ToDoConfirmPasswordRecovery
+import ar.com.intrale.strings.model.MessageKey
+import ar.com.intrale.strings.resolveMessage
 import io.konform.validation.Validation
 import io.konform.validation.jsonschema.minLength
 import io.konform.validation.jsonschema.pattern
@@ -40,11 +42,11 @@ class ConfirmPasswordRecoveryViewModel(
     fun setupValidation() {
         validation = Validation<ConfirmPasswordRecoveryUIState> {
             ConfirmPasswordRecoveryUIState::email required {
-                pattern(".+@.+\\..+") hint "Correo inválido"
+                pattern(".+@.+\\..+") hint resolveMessage(MessageKey.form_error_invalid_email)
             }
             ConfirmPasswordRecoveryUIState::code required {}
             ConfirmPasswordRecoveryUIState::password required {
-                minLength(8) hint "Debe contener al menos 8 caracteres."
+                minLength(8) hint resolveMessage(MessageKey.form_error_min_length_8)
             }
         } as Validation<Any>
     }

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/auth/PasswordRecoveryViewModel.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/auth/PasswordRecoveryViewModel.kt
@@ -6,6 +6,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import asdo.auth.DoPasswordRecoveryResult
 import asdo.auth.ToDoPasswordRecovery
+import ar.com.intrale.strings.model.MessageKey
+import ar.com.intrale.strings.resolveMessage
 import io.konform.validation.Validation
 import io.konform.validation.jsonschema.pattern
 import org.kodein.di.direct
@@ -35,7 +37,7 @@ class PasswordRecoveryViewModel(
     fun setupValidation() {
         validation = Validation<PasswordRecoveryUIState> {
             PasswordRecoveryUIState::email required {
-                pattern(".+@.+\\..+") hint "Correo inválido"
+                pattern(".+@.+\\..+") hint resolveMessage(MessageKey.form_error_invalid_email)
             }
         } as Validation<Any>
     }

--- a/app/composeApp/src/commonTest/kotlin/ui/sc/auth/AuthViewModelsTest.kt
+++ b/app/composeApp/src/commonTest/kotlin/ui/sc/auth/AuthViewModelsTest.kt
@@ -1,5 +1,7 @@
 package ui.sc.auth
 
+import ar.com.intrale.strings.model.MessageKey
+import ar.com.intrale.strings.resolveMessage
 import asdo.auth.*
 import kotlinx.coroutines.test.runTest
 import org.kodein.log.LoggerFactory
@@ -213,6 +215,16 @@ class PasswordRecoveryViewModelTest {
         vm.state = PasswordRecoveryViewModel.PasswordRecoveryUIState("invalido")
         assertFalse(vm.isValid())
     }
+
+    @Test
+    fun `validacion de email invalido muestra mensaje desde MessageKey`() {
+        val vm = PasswordRecoveryViewModel(FakePasswordRecovery(), testLoggerFactory)
+        vm.state = PasswordRecoveryViewModel.PasswordRecoveryUIState("invalido")
+        vm.isValid()
+        val emailState = vm.inputsStates[PasswordRecoveryViewModel.PasswordRecoveryUIState::email.name]!!.value
+        assertFalse(emailState.isValid)
+        assertEquals(resolveMessage(MessageKey.form_error_invalid_email), emailState.details)
+    }
 }
 
 // endregion
@@ -249,6 +261,30 @@ class ConfirmPasswordRecoveryViewModelTest {
             email = "invalido", code = "123456", password = "newpass12"
         )
         assertFalse(vm.isValid())
+    }
+
+    @Test
+    fun `validacion de email invalido muestra mensaje desde MessageKey`() {
+        val vm = ConfirmPasswordRecoveryViewModel(FakeConfirmPasswordRecovery(), testLoggerFactory)
+        vm.state = ConfirmPasswordRecoveryViewModel.ConfirmPasswordRecoveryUIState(
+            email = "invalido", code = "123456", password = "newpass12"
+        )
+        vm.isValid()
+        val emailState = vm.inputsStates[ConfirmPasswordRecoveryViewModel.ConfirmPasswordRecoveryUIState::email.name]!!.value
+        assertFalse(emailState.isValid)
+        assertEquals(resolveMessage(MessageKey.form_error_invalid_email), emailState.details)
+    }
+
+    @Test
+    fun `validacion de password corta muestra mensaje desde MessageKey`() {
+        val vm = ConfirmPasswordRecoveryViewModel(FakeConfirmPasswordRecovery(), testLoggerFactory)
+        vm.state = ConfirmPasswordRecoveryViewModel.ConfirmPasswordRecoveryUIState(
+            email = "test@test.com", code = "123456", password = "short"
+        )
+        vm.isValid()
+        val passwordState = vm.inputsStates[ConfirmPasswordRecoveryViewModel.ConfirmPasswordRecoveryUIState::password.name]!!.value
+        assertFalse(passwordState.isValid)
+        assertEquals(resolveMessage(MessageKey.form_error_min_length_8), passwordState.details)
     }
 }
 


### PR DESCRIPTION
## Resumen

Completa la migración del issue #502 migrando los hints de validación en los ViewModels de recuperación de contraseña a `MessageKey`:

- **PasswordRecoveryViewModel**: Reemplazar hint hardcodeado por `resolveMessage(MessageKey.form_error_invalid_email)`
- **ConfirmPasswordRecoveryViewModel**: Reemplazar dos hints por `resolveMessage(MessageKey.form_error_invalid_email)` y `resolveMessage(MessageKey.form_error_min_length_8)`
- Agregar tests unitarios que verifiquen los mensajes de error usan las claves MessageKey correctas

## Plan de tests

- [x] Tests unitarios pasan
- [x] Build completo sin errores
- [x] No se detectaron warnings nuevos

Closes #502

QA E2E: omitido

🤖 Generado con [Claude Code](https://claude.ai/claude-code)