### PR TITLE
feat(monitor): descripción de tarea activa por sesión en dashboard

### DIFF
--- a/.claude/dashboard.js
+++ b/.claude/dashboard.js
@@ -251,6 +251,9 @@ function buildReportMessage() {
     const action = lastActionLabel(s);
     const age = formatAge(s.last_activity_ts);
     msg += icon + " " + truncate(agent, 22) + " \u2014 " + action + " (" + age + ")\n";
+    if (s.current_task && label !== "done") {
+      msg += "  \u2514 \u2699 " + truncate(s.current_task, 40) + "\n";
+    }
   }
 
   // Actividad reciente (top 3)
@@ -378,14 +381,18 @@ function render() {
         padEnd(action, 25) +
         icon;
 
+      lines.push(boxLine(row, W));
+      // Mostrar tarea activa si existe
+      if (s.current_task && s.status !== "done") {
+        const taskLine = C.dim + "  \u2514\u2500 \u2699 " + C.reset +
+          C.cyan + truncate(s.current_task, W - 12) + C.reset;
+        lines.push(boxLine(taskLine, W));
+      }
       if (verbose) {
-        lines.push(boxLine(row, W));
         const skills = (s.skills_invoked || []).join(", ") || "\u2014";
         const detail = C.dim + "  rama: " + (s.branch || "?") + "  sub: " + (s.sub_count || 0) +
           "  skills: " + skills + "  mode: " + (s.permission_mode || "?") + C.reset;
         lines.push(boxLine(truncate(detail, W - 4), W));
-      } else {
-        lines.push(boxLine(row, W));
       }
     }
   }

--- a/.claude/hooks/activity-logger.js
+++ b/.claude/hooks/activity-logger.js
@@ -144,6 +144,7 @@ function updateSession(sessionId, ts, toolName, target, toolInput) {
                 skills_invoked: [],
                 sub_count: 0,
                 permission_mode: "unknown",
+                current_task: null,
             };
         }
 
@@ -161,6 +162,15 @@ function updateSession(sessionId, ts, toolName, target, toolInput) {
             }
             if (AGENT_MAP[skillName] && !session.agent_name) {
                 session.agent_name = AGENT_MAP[skillName];
+            }
+        }
+
+        // Capturar tarea activa desde TaskUpdate (activeForm)
+        if (toolName === "TaskUpdate") {
+            if (toolInput.status === "in_progress" && toolInput.activeForm) {
+                session.current_task = toolInput.activeForm;
+            } else if (toolInput.status === "completed") {
+                session.current_task = null;
             }
         }
 

--- a/.claude/skills/monitor/SKILL.md
+++ b/.claude/skills/monitor/SKILL.md
@@ -44,6 +44,7 @@ Genera el dashboard con este formato (ajustando ancho a ~70 columnas):
 │ Sesion   │ Agente         │Accs│ Dur. │ Ultima accion    │Estado│
 │──────────┼────────────────┼────┼──────┼──────────────────┼──────│
 │ b08b96a2 │ El Centinela 🗼│ 15 │ 32m  │ Edit: LoginVM…   │ ● ▶ │
+│   └─ ⚙ Compilando APK cliente con testTagsAsResourceId...         │
 │ 67eb3124 │ Claude 🤖      │  3 │ 5m   │ Bash: git diff…  │ ○    │
 ├─ ACTIVIDAD RECIENTE ────────────────────────────────────────────┤
 │ 14:32:00  b08b96a2  Edit      activity-logger.js               │
@@ -73,6 +74,7 @@ Genera el dashboard con este formato (ajustando ancho a ~70 columnas):
 - Columna "Dur.": duracion calculada desde `started_ts` hasta `last_activity_ts`
 - Columna "Ultima accion": `last_tool: last_target` truncado (ej: `Edit: LoginVM…`)
 - Columna "Estado": icono de liveness segun las reglas de arriba
+- Si la sesion tiene `current_task` (y no es `done`), mostrar fila adicional debajo: `  └─ ⚙ [descripcion]` — es el `activeForm` de la tarea en progreso
 - Ordenar por `last_activity_ts` descendente (mas reciente primero)
 - Si no hay sesiones, mostrar "Sin sesiones registradas"
 


### PR DESCRIPTION
## Resumen

Se implementa la captura y visualización de `current_task` (tarea activa) en el Monitor dashboard, mejorando la visibilidad del trabajo en tiempo real:

- **activity-logger.js**: Captura `activeForm` de `TaskUpdate` cuando status es `in_progress`, guardando en `session.current_task`
- **dashboard.js**: Muestra la tarea activa como fila adicional bajo cada sesión, con formato `└─ ⚙ [descripción]`
- **dashboard.js (Telegram)**: Incluye `current_task` en reportes periódicos
- **SKILL.md**: Documenta el nuevo campo en las reglas del panel SESIONES

## Plan de tests

- [x] Sintaxis JavaScript validada (`node -c`)
- [x] Cambios limitados a infraestructura (hooks, docs)
- [ ] Manual: Ejecutar `node .claude/dashboard.js` y verificar display de `current_task`
- [ ] Manual: Cambiar una tarea a `in_progress` con `activeForm` y verificar que aparece en sesión

Cierra #918

🤖 Generado con [Claude Code](https://claude.ai/claude-code)