### PR TITLE
fix(permisos): proteger settings.local.json de race conditions

### DIFF
--- a/.claude/hooks/permission-tracker.js
+++ b/.claude/hooks/permission-tracker.js
@@ -53,6 +53,12 @@ function handleInput() {
                 const allow = (settings.permissions && settings.permissions.allow) || [];
                 const deny = (settings.permissions && settings.permissions.deny) || [];
 
+                // Si el archivo tiene patrones amplios (Read(*), Glob(*), etc.),
+                // está gestionado manualmente — no auto-aprender para evitar
+                // race conditions con múltiples agentes escribiendo simultáneamente
+                const broadPatterns = allow.filter(p => /^(Read|Glob|Grep|Edit|Write)\(\*\)$/.test(p));
+                if (broadPatterns.length >= 3) continue;
+
                 // Ya cubierto?
                 if (isAlreadyCovered(pattern, allow)) continue;
 


### PR DESCRIPTION
## Resumen

- Detectar cuando `settings.local.json` tiene patrones amplios (`Read(*)`, `Glob(*)`, etc.)
- En esos casos, saltar el auto-learning del permission-tracker
- Evita sobreescrituras por race conditions cuando múltiples agentes escriben simultáneamente vía junction de `.claude/`

## Plan de tests

- [x] Cambio es solo en hook de permisos
- [x] No afecta lógica de app/backend

QA E2E: omitido por decisión del usuario — cambio de infraestructura

Closes #891

🤖 Generado con [Claude Code](https://claude.ai/claude-code)