### PR TITLE
feat: cerrar terminales de agentes automáticamente (Closes #977)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ qa/.backend.pid
 # Sprint — archivos de agentes (no commitear, local de trabajo)
 scripts/sprint-plan.json
 scripts/sprint-pids.json
+scripts/logs/
 
 # Binarios de gh-cli descargados localmente
 gh-cli/

--- a/scripts/Start-Agente.ps1
+++ b/scripts/Start-Agente.ps1
@@ -139,11 +139,29 @@ function Start-UnAgente {
     }
 
     # Abrir nueva terminal PowerShell con claude ejecutando
+    # La terminal se cierra automaticamente al terminar claude (sin -NoExit)
+    # Output se loguea a scripts/logs/agente_N.log via Start-Transcript
+    $logDir = Join-Path $PSScriptRoot 'logs'
+    if (-not (Test-Path $logDir)) { New-Item -ItemType Directory -Path $logDir -Force | Out-Null }
+    $logFile = Join-Path $logDir "agente_$($Agente.numero).log"
+
     $escapedPrompt = $prompt -replace '"', '\"'
-    $command = "Remove-Item Env:CLAUDECODE -ErrorAction SilentlyContinue; Set-Location '$wtDirResolved'; Write-Host ''; Write-Host '  Agente $($Agente.numero) - issue #$issue ($slug)' -ForegroundColor Cyan; Write-Host '  Branch: $branch' -ForegroundColor Cyan; Write-Host ''; claude --permission-mode bypassPermissions `"$escapedPrompt`""
+    $command = "Start-Transcript -Path '$logFile' -Force | Out-Null; " +
+               "Remove-Item Env:CLAUDECODE -ErrorAction SilentlyContinue; " +
+               "Set-Location '$wtDirResolved'; " +
+               "Write-Host ''; " +
+               "Write-Host '  Agente $($Agente.numero) - issue #$issue ($slug)' -ForegroundColor Cyan; " +
+               "Write-Host '  Branch: $branch' -ForegroundColor Cyan; " +
+               "Write-Host '  Log: $logFile' -ForegroundColor DarkGray; " +
+               "Write-Host ''; " +
+               "claude --permission-mode bypassPermissions `"$escapedPrompt`"; " +
+               "Write-Host ''; " +
+               "Write-Host ('  claude finalizo (exit ' + `$LASTEXITCODE + ')') -ForegroundColor Yellow; " +
+               "Stop-Transcript | Out-Null; " +
+               "Start-Sleep -Seconds 3"
 
     Write-Host ">> Abriendo terminal con claude..."
-    $proc = Start-Process powershell -ArgumentList "-NoExit", "-Command", $command -PassThru
+    $proc = Start-Process powershell -ArgumentList "-Command", $command -PassThru
 
     # Guardar PID en sprint-pids.json
     $pidsFile = Join-Path $PSScriptRoot "sprint-pids.json"
@@ -176,7 +194,7 @@ function Start-MonitorLive {
     $command = "Set-Location '$MainRepo'; " +
                "Write-Host '  Monitor Live - Dashboard multi-sesion' -ForegroundColor Cyan; " +
                "node '$dashboardPath'"
-    Start-Process powershell -ArgumentList "-NoExit", "-Command", $command
+    Start-Process powershell -ArgumentList "-Command", $command
     Write-Host ">> Monitor live lanzado." -ForegroundColor Green
 }
 

--- a/scripts/Watch-Agentes.ps1
+++ b/scripts/Watch-Agentes.ps1
@@ -110,7 +110,10 @@ function Get-WorktreePath {
 }
 
 function Test-AgentDone {
-    param([string]$WtDir)
+    param(
+        [string]$WtDir,
+        [int]$AgentNumber
+    )
 
     # Worktree no existe → done (nunca arranco o ya fue limpiado)
     if (-not (Test-Path $WtDir)) { return $true }
@@ -118,8 +121,20 @@ function Test-AgentDone {
     $wtResolved = (Resolve-Path $WtDir -ErrorAction SilentlyContinue)
     if (-not $wtResolved) { return $true }
 
-    # Buscar session files con status "done" en .claude/sessions/ del worktree
-    # El hook stop-notify.js marca la sesion como "done" cuando claude finaliza
+    # Check principal: verificar si la terminal del agente sigue viva (via PID)
+    # Sin -NoExit, la terminal se cierra cuando claude termina → PID muerto = done
+    $pidsFile = Join-Path $PSScriptRoot "sprint-pids.json"
+    if ((Test-Path $pidsFile) -and $AgentNumber -gt 0) {
+        $pidsData = Get-Content $pidsFile -Raw | ConvertFrom-Json
+        $pidKey = "agente_$AgentNumber"
+        $terminalPid = $pidsData.$pidKey
+        if ($terminalPid) {
+            $proc = Get-Process -Id $terminalPid -ErrorAction SilentlyContinue
+            if (-not $proc) { return $true }
+        }
+    }
+
+    # Fallback: buscar session files con status "done" en .claude/sessions/
     $sessionsDir = Join-Path $wtResolved '.claude' 'sessions'
     if (Test-Path $sessionsDir) {
         $sessionFiles = Get-ChildItem $sessionsDir -Filter '*.json' -ErrorAction SilentlyContinue
@@ -152,7 +167,7 @@ while (-not $allDone) {
 
     foreach ($a in $Plan.agentes) {
         $wtDir = Get-WorktreePath $a
-        $isDone = Test-AgentDone $wtDir
+        $isDone = Test-AgentDone -WtDir $wtDir -AgentNumber $a.numero
         if ($isDone) {
             $doneCount++
             $statusParts += ('{0}:OK' -f $a.numero)
@@ -267,7 +282,7 @@ $cmdSprint = "Set-Location '$MainRepo'; " +
              "Write-Host ''; " +
              "claude '/planner sprint'"
 
-Start-Process powershell -ArgumentList "-NoExit", "-Command", $cmdSprint
+Start-Process powershell -ArgumentList "-Command", $cmdSprint
 
 # Lanzar /planner proponer en paralelo (segunda terminal)
 if (-not $NoAutoProponer) {
@@ -277,7 +292,7 @@ if (-not $NoAutoProponer) {
                    "Write-Host '  Analizando codebase para nuevas propuestas...' -ForegroundColor Magenta; " +
                    "Write-Host ''; " +
                    "claude '/planner proponer'"
-    Start-Process powershell -ArgumentList "-NoExit", "-Command", $cmdProponer
+    Start-Process powershell -ArgumentList "-Command", $cmdProponer
 }
 
 $bannerMsg = if ($NoAutoProponer) { 'sprint iniciado' } else { 'sprint + proponer iniciados' }


### PR DESCRIPTION
## Resumen

- Quitar \`-NoExit\` de \`Start-Agente.ps1\` para que terminales cierren automáticamente cuando claude finaliza
- Agregar logging a \`scripts/logs/agente_N.log\` via \`Start-Transcript\` (visibilidad de errores sin interfering con auto-cierre)
- Mejorar \`Test-AgentDone\` en \`Watch-Agentes.ps1\`: monitorear PID de terminal como check principal (mucho más confiable que depender de archivos \`.claude/sessions/\` compartidos via symlink)
- Quitar \`-NoExit\` de terminales del monitor live y planner
- Agregar \`scripts/logs/\` al \`.gitignore\`

## Plan de tests

- [x] Scripts modificados compilan sin errores de sintaxis PowerShell
- [ ] Tests en Windows: lanzar \`Start-Agente.ps1 all\` y verificar que terminales se cierren automáticamente tras ~30s
- [ ] Verificar que \`Watch-Agentes.ps1\` detecta finalización por PID (no espera 4 horas en failsafe)
- [ ] Revisar logs en \`scripts/logs/\` para confirmar que claude finalizo correctamente
- [ ] Verificar que \`Stop-Agente.ps1\` sigue pudiendo cerrar terminales manualmente

Closes #977

🤖 Generado con [Claude Code](https://claude.com/claude-code)