### PR TITLE
fix(infra): corregir detección de procesos Claude y agregar panel de zombies

### DIFF
--- a/.claude/dashboard-web.js
+++ b/.claude/dashboard-web.js
@@ -91,14 +91,65 @@ function livenessStatus(session) {
   return "stale";
 }
 
+// Cache de CPU snapshots para detectar zombies (CPU=0 entre polls)
+let prevCpuSnapshot = {};
+
+function getClaudeProcesses() {
+  try {
+    const output = execSync(
+      'wmic process where "Name=\'node.exe\'" get ProcessId,CommandLine,CreationDate,UserModeTime /format:list',
+      { cwd: REPO_ROOT, timeout: 10000, windowsHide: true }
+    ).toString();
+
+    const records = output.split(/\r?\n\r?\n/).filter(r => r.trim());
+    const claudeProcs = [];
+
+    for (const record of records) {
+      const fields = {};
+      for (const line of record.split(/\r?\n/)) {
+        const eq = line.indexOf("=");
+        if (eq === -1) continue;
+        fields[line.substring(0, eq).trim()] = line.substring(eq + 1).trim();
+      }
+      if (!fields.CommandLine || !fields.CommandLine.match(/claude-code[/\\]cli\.js/)) continue;
+
+      const pid = parseInt(fields.ProcessId, 10);
+      const isAgent = /bypassPermissions/.test(fields.CommandLine);
+      const cpuTime = parseInt(fields.UserModeTime, 10) || 0;
+
+      // Detectar zombie: CPU identica entre polls
+      const prevCpu = prevCpuSnapshot[pid];
+      const isZombie = prevCpu !== undefined && prevCpu === cpuTime;
+
+      // Parsear CreationDate de WMI (yyyyMMddHHmmss.ffffff±UUU)
+      let startedAt = null;
+      if (fields.CreationDate) {
+        const m = fields.CreationDate.match(/^(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})/);
+        if (m) startedAt = new Date(+m[1], +m[2]-1, +m[3], +m[4], +m[5], +m[6]).toISOString();
+      }
+
+      claudeProcs.push({ pid, isAgent, startedAt, cpuTime, isZombie });
+    }
+
+    // Actualizar snapshot de CPU
+    const newSnapshot = {};
+    for (const p of claudeProcs) newSnapshot[p.pid] = p.cpuTime;
+    prevCpuSnapshot = newSnapshot;
+
+    return claudeProcs;
+  } catch (e) { return []; }
+}
+
 function collectData() {
   const allSessions = loadSessions();
   const sessions = allSessions.map(s => ({
     ...s,
     liveness: livenessStatus(s)
   }));
+  const processes = getClaudeProcesses();
   return {
     sessions,
+    processes,
     activity: loadRecentActivity(),
     sprintPlan: loadSprintPlan(),
     git: getGitInfo(),
@@ -403,6 +454,8 @@ function getHTML() {
   ::-webkit-scrollbar-thumb { background: #30363d; border-radius: 3px; }
   ::-webkit-scrollbar-thumb:hover { background: #484f58; }
 
+  .status-zombie { color: #f85149; }
+  .row-zombie { background: #3d1f1f !important; }
   .hidden { display: none !important; }
 </style>
 </head>
@@ -439,6 +492,25 @@ function getHTML() {
           </tr>
         </thead>
         <tbody id="sessions-body"></tbody>
+      </table>
+    </div>
+  </div>
+
+  <!-- Procesos Claude -->
+  <div id="processes-panel" class="panel panel-sessions hidden">
+    <div class="panel-header">Procesos Claude</div>
+    <div class="panel-body">
+      <table>
+        <thead>
+          <tr>
+            <th>PID</th>
+            <th>Tipo</th>
+            <th>Inicio</th>
+            <th>CPU (s)</th>
+            <th>Estado</th>
+          </tr>
+        </thead>
+        <tbody id="processes-body"></tbody>
       </table>
     </div>
   </div>
@@ -530,6 +602,8 @@ function getHTML() {
   var activityList = document.getElementById("activity-list");
   var gitBranch = document.getElementById("git-branch");
   var gitCommit = document.getElementById("git-commit");
+  var processesPanel = document.getElementById("processes-panel");
+  var processesBody = document.getElementById("processes-body");
   var sprintPanel = document.getElementById("sprint-panel");
   var sprintTitle = document.getElementById("sprint-title");
   var sprintBody = document.getElementById("sprint-body");
@@ -710,8 +784,46 @@ function getHTML() {
     sprintBody.innerHTML = html;
   }
 
+  function renderProcesses(processes, sessions) {
+    if (!processes || processes.length === 0) {
+      processesPanel.classList.add("hidden");
+      return;
+    }
+    // Solo mostrar agentes (bypassPermissions) — los procesos interactivos no interesan
+    var agents = processes.filter(function(p) { return p.isAgent; });
+    if (agents.length === 0) {
+      processesPanel.classList.add("hidden");
+      return;
+    }
+    processesPanel.classList.remove("hidden");
+    var html = "";
+    for (var i = 0; i < agents.length; i++) {
+      var p = agents[i];
+      var tipo = "Agente";
+      var cpuSecs = Math.round((p.cpuTime || 0) / 10000000);
+      var started = p.startedAt ? formatTime(p.startedAt) : "--";
+      var statusHtml;
+      var rowClass = "";
+      if (p.isZombie) {
+        statusHtml = '<span class="status-dot status-zombie">&#x2620;</span> zombie';
+        rowClass = ' class="row-zombie"';
+      } else {
+        statusHtml = '<span class="status-dot status-active">&#x25CF;</span> activo';
+      }
+      html += "<tr" + rowClass + ">" +
+        "<td><code>" + p.pid + "</code></td>" +
+        "<td>" + tipo + "</td>" +
+        "<td>" + started + "</td>" +
+        "<td>" + cpuSecs + "</td>" +
+        "<td>" + statusHtml + "</td>" +
+        "</tr>";
+    }
+    processesBody.innerHTML = html;
+  }
+
   function renderAll(data) {
     renderSessions(data.sessions || []);
+    renderProcesses(data.processes || [], data.sessions || []);
     renderActivity(data.activity || []);
     renderGit(data.git || {});
     renderSprint(data.sprintPlan);

--- a/.claude/dashboard.js
+++ b/.claude/dashboard.js
@@ -174,6 +174,41 @@ function getGitInfo() {
   } catch(e) { return { branch: "???", commit: "???" }; }
 }
 
+// Cache de CPU snapshots para detectar zombies
+let _prevCpuSnap = {};
+
+function getClaudeAgentCount() {
+  try {
+    const output = execSync(
+      'wmic process where "Name=\'node.exe\'" get ProcessId,CommandLine,UserModeTime /format:list',
+      { cwd: REPO_ROOT, timeout: 10000, windowsHide: true }
+    ).toString();
+
+    const records = output.split(/\r?\n\r?\n/).filter(r => r.trim());
+    let agents = 0, zombies = 0;
+    const newSnap = {};
+
+    for (const record of records) {
+      const fields = {};
+      for (const line of record.split(/\r?\n/)) {
+        const eq = line.indexOf("=");
+        if (eq === -1) continue;
+        fields[line.substring(0, eq).trim()] = line.substring(eq + 1).trim();
+      }
+      if (!fields.CommandLine || !fields.CommandLine.match(/claude-code[/\\]cli\.js/)) continue;
+      if (!/bypassPermissions/.test(fields.CommandLine)) continue;
+
+      const pid = parseInt(fields.ProcessId, 10);
+      const cpu = parseInt(fields.UserModeTime, 10) || 0;
+      newSnap[pid] = cpu;
+      agents++;
+      if (_prevCpuSnap[pid] !== undefined && _prevCpuSnap[pid] === cpu) zombies++;
+    }
+    _prevCpuSnap = newSnap;
+    return { agents, zombies };
+  } catch(e) { return { agents: 0, zombies: 0 }; }
+}
+
 function getCIStatus() {
   try {
     // Usar bash explicitamente para compatibilidad Windows (Git Bash / MSYS2)
@@ -395,6 +430,17 @@ function render() {
         lines.push(boxLine(truncate(detail, W - 4), W));
       }
     }
+  }
+
+  // Panel PROCESOS CLAUDE
+  const procInfo = getClaudeAgentCount();
+  if (procInfo.agents > 0) {
+    lines.push(boxMid("PROCESOS", W));
+    let procLine = C.green + "\u25CF " + procInfo.agents + " agente(s)" + C.reset;
+    if (procInfo.zombies > 0) {
+      procLine += "  " + C.red + "\u2620 " + procInfo.zombies + " zombie(s)" + C.reset;
+    }
+    lines.push(boxLine(procLine, W));
   }
 
   // Panel ACTIVIDAD RECIENTE

--- a/.claude/hooks/activity-logger.js
+++ b/.claude/hooks/activity-logger.js
@@ -196,14 +196,7 @@ function updateSession(sessionId, ts, toolName, target, toolInput) {
             }
         }
 
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
->>>>>>> cd2988b (chore: delivery automático)
-        // Capturar tarea activa desde TaskUpdate (activeForm)
-=======
         // Mantener current_task (singular) para activeForm en panel SESIONES
->>>>>>> e09e95d (feat: protocolo de tareas con checkboxes para agentes y monitor (#920))
         if (toolName === "TaskUpdate") {
             if (toolInput.status === "in_progress" && toolInput.activeForm) {
                 session.current_task = toolInput.activeForm;

--- a/scripts/Guardian-Sprint.ps1
+++ b/scripts/Guardian-Sprint.ps1
@@ -70,8 +70,14 @@ function Send-TelegramMessage {
 # --- Deteccion de actividad ---
 
 function Test-ClaudeRunning {
-    $procs = Get-Process -Name 'claude' -ErrorAction SilentlyContinue
-    return ($procs -and @($procs).Count -gt 0)
+    # Claude Code corre como node.exe ejecutando cli.js, no como "claude"
+    # Usar Get-CimInstance porque Get-Process no expone CommandLine en PS 5.1
+    $nodeProcs = Get-CimInstance Win32_Process -Filter "Name='node.exe'" -ErrorAction SilentlyContinue
+    if (-not $nodeProcs) { return $false }
+    foreach ($p in $nodeProcs) {
+        if ($p.CommandLine -match 'claude-code[/\\]cli\.js') { return $true }
+    }
+    return $false
 }
 
 function Test-CodexWorktrees {
@@ -86,14 +92,48 @@ function Test-CodexWorktrees {
 }
 
 function Test-WatcherRunning {
-    $psProcs = Get-Process -Name 'powershell' -ErrorAction SilentlyContinue
+    # Usar Get-CimInstance porque Get-Process no expone CommandLine en PS 5.1
+    $psProcs = Get-CimInstance Win32_Process -Filter "Name='powershell.exe'" -ErrorAction SilentlyContinue
     if (-not $psProcs) { return $false }
     foreach ($p in $psProcs) {
-        try {
-            if ($p.CommandLine -match 'Watch-Agentes') { return $true }
-        } catch {}
+        if ($p.CommandLine -match 'Watch-Agentes') { return $true }
     }
     return $false
+}
+
+function Get-ClaudeAgentPids {
+    # Retorna hashtable PID → UserModeTime de agentes Claude (bypassPermissions)
+    $result = @{}
+    $procs = Get-CimInstance Win32_Process -Filter "Name='node.exe'" -ErrorAction SilentlyContinue
+    if (-not $procs) { return $result }
+    foreach ($p in $procs) {
+        if ($p.CommandLine -match 'claude-code[/\\]cli\.js' -and $p.CommandLine -match 'bypassPermissions') {
+            $result[[int]$p.ProcessId] = [long]$p.UserModeTime
+        }
+    }
+    return $result
+}
+
+function Find-ZombieAgents {
+    param([hashtable]$PrevSnapshot, [hashtable]$CurrSnapshot)
+    # Zombie = PID presente en ambos snapshots con CPU identico
+    $zombies = @()
+    foreach ($pid in $CurrSnapshot.Keys) {
+        if ($PrevSnapshot.ContainsKey($pid) -and $CurrSnapshot[$pid] -eq $PrevSnapshot[$pid]) {
+            $zombies += $pid
+        }
+    }
+    return $zombies
+}
+
+function Stop-ZombieAgents {
+    param([int[]]$Pids)
+    foreach ($pid in $Pids) {
+        try {
+            Stop-Process -Id $pid -Force -ErrorAction SilentlyContinue
+            Write-Log ('Zombie eliminado: PID {0}' -f $pid) 'Red'
+        } catch {}
+    }
 }
 
 function Test-IsActive {
@@ -124,12 +164,28 @@ Send-TelegramMessage "🛡️ <b>Guardian-Sprint iniciado</b>`nPolling cada $([m
 # --- Loop principal ---
 $lastLaunchTime = [DateTime]::MinValue
 $cycleCount = 0
+$prevCpuSnapshot = @{}
 
 while ($true) {
     $cycleCount++
     $state = Test-IsActive
 
+    # Deteccion de zombies: comparar CPU entre ciclos
+    $currCpuSnapshot = Get-ClaudeAgentPids
+    if ($prevCpuSnapshot.Count -gt 0 -and $currCpuSnapshot.Count -gt 0) {
+        $zombies = Find-ZombieAgents -PrevSnapshot $prevCpuSnapshot -CurrSnapshot $currCpuSnapshot
+        if ($zombies.Count -gt 0) {
+            $zombieStr = ($zombies | ForEach-Object { $_.ToString() }) -join ', '
+            Write-Log ('ZOMBIE detectado: PID {0} (CPU=0 entre ciclos). Eliminando...' -f $zombieStr) 'Red'
+            Send-TelegramMessage "🛡️ <b>Guardian: zombie(s) detectado(s)</b>`nPID: $zombieStr — CPU inactiva entre ciclos.`nEliminando procesos..."
+            Stop-ZombieAgents -Pids $zombies
+        }
+    }
+    $prevCpuSnapshot = $currCpuSnapshot
+
     $stateStr = 'claude={0} worktrees={1} watcher={2}' -f $state.Claude, $state.Worktrees, $state.Watcher
+    $agentCount = $currCpuSnapshot.Count
+    if ($agentCount -gt 0) { $stateStr += ' agents={0}' -f $agentCount }
 
     if ($state.Active) {
         Write-Log ('Ciclo {0}: activo [{1}]' -f $cycleCount, $stateStr)

--- a/scripts/Start-Agente.ps1
+++ b/scripts/Start-Agente.ps1
@@ -12,20 +12,15 @@
 .PARAMETER SkipMerge
     Si se indica, se pasa -SkipMerge al Watch-Agentes (PRs sin merge automatico).
 
-.PARAMETER WithGuardian
-    Si se indica, lanza Guardian-Sprint.ps1 en background (keepalive autonomo).
-
 .EXAMPLE
     .\Start-Agente.ps1 1
     .\Start-Agente.ps1 all
     .\Start-Agente.ps1 all -SkipMerge
-    .\Start-Agente.ps1 all -WithGuardian
 #>
 param(
     [Parameter(Mandatory = $true, Position = 0)]
     [string]$Numero,
-    [switch]$SkipMerge,
-    [switch]$WithGuardian
+    [switch]$SkipMerge
 )
 
 Set-StrictMode -Version Latest
@@ -220,24 +215,22 @@ if ($Numero -eq "all") {
         Write-Host ">> Watch-Agentes.ps1 no encontrado, omitiendo watcher." -ForegroundColor Yellow
     }
 
-    # Lanzar Guardian-Sprint si se solicito
-    if ($WithGuardian) {
-        $guardianScript = Join-Path $PSScriptRoot 'Guardian-Sprint.ps1'
-        if (Test-Path $guardianScript) {
-            # Verificar si ya hay un guardian corriendo
-            $guardianRunning = Get-Process -Name 'powershell' -ErrorAction SilentlyContinue |
-                Where-Object { try { $_.CommandLine -match 'Guardian-Sprint' } catch { $false } }
-            if ($guardianRunning) {
-                Write-Host ">> Guardian-Sprint ya esta corriendo (PID: $($guardianRunning.Id)). Reutilizando." -ForegroundColor Yellow
-            }
-            else {
-                Start-Process powershell -ArgumentList '-NonInteractive', '-File', $guardianScript
-                Write-Host ">> Guardian-Sprint lanzado en background (keepalive autonomo)." -ForegroundColor Green
-            }
+    # Lanzar Guardian-Sprint automaticamente (siempre con 'all')
+    $guardianScript = Join-Path $PSScriptRoot 'Guardian-Sprint.ps1'
+    if (Test-Path $guardianScript) {
+        # Verificar si ya hay un guardian corriendo
+        $guardianRunning = Get-Process -Name 'powershell' -ErrorAction SilentlyContinue |
+            Where-Object { try { $_.CommandLine -match 'Guardian-Sprint' } catch { $false } }
+        if ($guardianRunning) {
+            Write-Host ">> Guardian-Sprint ya esta corriendo (PID: $($guardianRunning.Id)). Reutilizando." -ForegroundColor Yellow
         }
         else {
-            Write-Host ">> Guardian-Sprint.ps1 no encontrado, omitiendo guardian." -ForegroundColor Yellow
+            Start-Process powershell -ArgumentList '-NonInteractive', '-File', $guardianScript
+            Write-Host ">> Guardian-Sprint lanzado en background (keepalive autonomo)." -ForegroundColor Green
         }
+    }
+    else {
+        Write-Host ">> Guardian-Sprint.ps1 no encontrado, omitiendo guardian." -ForegroundColor Yellow
     }
 }
 else {

--- a/scripts/Watch-Agentes.ps1
+++ b/scripts/Watch-Agentes.ps1
@@ -152,8 +152,16 @@ function Test-AgentDone {
 
 function Test-NoClaude {
     # Failsafe: verificar si hay ALGUN proceso claude corriendo
-    $procs = Get-Process -Name 'claude' -ErrorAction SilentlyContinue
-    return (-not $procs -or @($procs).Count -eq 0)
+    # Claude Code corre como node.exe ejecutando cli.js, no como "claude"
+    # Usar Get-CimInstance porque Get-Process no expone CommandLine en PS 5.1
+    $nodeProcs = Get-CimInstance Win32_Process -Filter "Name='node.exe'" -ErrorAction SilentlyContinue
+    if (-not $nodeProcs) { return $true }
+    foreach ($p in $nodeProcs) {
+        if ($p.CommandLine -match 'claude-code[/\\]cli\.js' -and $p.CommandLine -match 'bypassPermissions') {
+            return $false
+        }
+    }
+    return $true
 }
 
 # --- Polling loop ---


### PR DESCRIPTION
## Resumen

Correcciones críticas de infraestructura para que Guardian, Watch-Agentes y Monitor funcionen correctamente:

- **Detección de procesos fija**: PowerShell 5.1 no expone `CommandLine` en `Get-Process`. Cambiar a `Get-CimInstance Win32_Process` para detectar procesos node.exe ejecutando claude-code/cli.js
- **Zombies detectados**: Guardian-Sprint ahora compara CPU entre ciclos y elimina automáticamente procesos muertos
- **Monitor mejorado**: Dashboard web y terminal ahora muestran panel de procesos Claude vivos vs zombies
- **Hooks reparados**: Limpiar conflictos de merge irreconciliables en activity-logger.js que rompían PostToolUse en worktrees

## Cambios técnicos

| Archivo | Cambios |
|---------|---------|
| `Guardian-Sprint.ps1` | +66 líneas: Get-ClaudeAgentPids, Find-ZombieAgents, Stop-ZombieAgents, snapshot CPU entre ciclos |
| `Watch-Agentes.ps1` | +12 líneas: Get-CimInstance en Test-NoClaude |
| `Start-Agente.ps1` | -35 líneas: Guardian lanzado automáticamente (sin parámetro -WithGuardian) |
| `dashboard-web.js` | +112 líneas: getClaudeProcesses(), panel "Procesos Claude", renderProcesses() |
| `dashboard.js` | +46 líneas: getClaudeAgentCount(), sección PROCESOS en render |
| `activity-logger.js` | -7 líneas: limpiar conflictos de merge |

## Plan de tests

- [x] Guardian detecta procesos vivos correctamente (Get-CimInstance funciona)
- [x] Dashboard-web renderiza panel de procesos sin errores
- [x] Dashboard-terminal muestra conteo de agentes activos
- [x] Rebase limpio contra main (1 commit nuevo)

Closes #928 #920 #918

Rebase: actualizado con 1 commit de main

🤖 Generado con [Claude Code](https://claude.com/claude-code)