### PR TITLE
fix(scripts): actualizar flag de permisos en Start-Agente

### DIFF
--- a/scripts/Start-Agente.ps1
+++ b/scripts/Start-Agente.ps1
@@ -149,7 +149,7 @@ function Start-UnAgente {
                "Write-Host '  Branch: $branch' -ForegroundColor Cyan; " +
                "Write-Host '  Log: $logFile' -ForegroundColor DarkGray; " +
                "Write-Host ''; " +
-               "claude --permission-mode bypassPermissions `"$escapedPrompt`"; " +
+               "claude --dangerously-skip-permissions `"$escapedPrompt`"; " +
                "Write-Host ''; " +
                "Write-Host ('  claude finalizo (exit ' + `$LASTEXITCODE + ')') -ForegroundColor Yellow; " +
                "Stop-Transcript | Out-Null; " +


### PR DESCRIPTION
## Resumen

- Reemplazar `--permission-mode bypassPermissions` (deprecado) por `--dangerously-skip-permissions` (API actual de Claude Code)

## Plan de tests

- [x] Cambio puntual en script PowerShell, sin impacto en código Kotlin

🤖 Generado con [Claude Code](https://claude.ai/claude-code)