### PR TITLE
feat(infra): pre-registrar confianza de workspace en worktrees para evitar diálogo de trust

### DIFF
--- a/.claude/hooks/telegram-commander.js
+++ b/.claude/hooks/telegram-commander.js
@@ -59,6 +59,20 @@ function log(msg) {
     console.log(line);
 }
 
+// ─── Trust pre-registration ──────────────────────────────────────────────────
+
+function preTrustDirectory(absPath) {
+    // Claude Code almacena trust en ~/.claude/projects/<path-mangled>/
+    // Path mangling: reemplazar :, \, / con -
+    const mangled = absPath.replace(/[:\\/]/g, "-");
+    const homeDir = process.env.USERPROFILE || process.env.HOME;
+    const trustDir = path.join(homeDir, ".claude", "projects", mangled);
+    if (!fs.existsSync(trustDir)) {
+        fs.mkdirSync(trustDir, { recursive: true });
+        log("Trust pre-registrado: " + mangled);
+    }
+}
+
 // ─── Lockfile ────────────────────────────────────────────────────────────────
 
 const LOCK_STALE_MS = 24 * 60 * 60 * 1000; // 24h — si el lockfile tiene más de esto, es stale seguro
@@ -752,6 +766,9 @@ async function handleSprint(agentNumber) {
     await sendMessage(header);
 
     // Arrancar monitor periódico
+    // Pre-registrar confianza del directorio de trabajo
+    preTrustDirectory(REPO_ROOT);
+
     startSprintMonitor();
 
     for (let i = 0; i < agentes.length; i++) {
@@ -848,6 +865,9 @@ function executeClaude(prompt, extraArgs, options) {
         }
 
         log("Ejecutando: claude " + args.join(" ") + " (prompt via stdin, " + prompt.length + " chars)");
+
+        // Pre-registrar confianza del directorio de trabajo
+        preTrustDirectory(REPO_ROOT);
 
         const cleanEnv = { ...process.env, CLAUDE_PROJECT_DIR: REPO_ROOT };
         delete cleanEnv.CLAUDECODE;

--- a/scripts/Start-Agente.ps1
+++ b/scripts/Start-Agente.ps1
@@ -51,6 +51,19 @@ if (-not (Test-Path $MainRepo)) {
 # --- Leer plan ---
 $Plan = Get-Content $PlanFile -Raw | ConvertFrom-Json
 
+# Pre-registrar confianza del worktree en Claude Code para evitar dialogo interactivo de trust
+function PreRegister-Trust {
+    param([string]$AbsPath)
+    # Claude Code almacena trust en ~/.claude/projects/<path-mangled>/
+    # Path mangling: reemplazar :, \, / con -
+    $mangled = $AbsPath -replace '[:\\/]', '-'
+    $trustDir = Join-Path $env:USERPROFILE ".claude\projects\$mangled"
+    if (-not (Test-Path $trustDir)) {
+        New-Item -ItemType Directory -Path $trustDir -Force | Out-Null
+        Write-Host ">> Trust pre-registrado: $mangled"
+    }
+}
+
 function Start-UnAgente {
     param(
         [Parameter(Mandatory)] $Agente
@@ -95,6 +108,9 @@ function Start-UnAgente {
         # Fallback: buscar en worktree list
         $wtDirResolved = $wtDir
     }
+
+    # Pre-registrar confianza del worktree para evitar dialogo interactivo de trust
+    PreRegister-Trust -AbsPath "$wtDirResolved"
 
     # Symlink de .claude/ para heredar confianza y permisos del repo principal
     $claudeSrc = Join-Path $MainRepo ".claude"

--- a/scripts/dev-functions.sh
+++ b/scripts/dev-functions.sh
@@ -13,6 +13,22 @@ export JAVA_HOME="/c/Users/Administrator/.jdks/temurin-21.0.7"
 # Directorio principal del repo
 _INTRALE_MAIN="/c/Workspaces/Intrale/platform"
 
+# Pre-registrar confianza del worktree en Claude Code para evitar dialogo de trust
+_pre_trust_worktree() {
+    local abs_path="$1"
+    # Convertir a path Windows para matching con Claude Code
+    local win_path
+    win_path=$(cygpath -w "$abs_path" 2>/dev/null || echo "$abs_path")
+    # Path mangling: reemplazar :, \, / con -
+    local mangled
+    mangled=$(echo "$win_path" | sed 's/[:\\/]/-/g')
+    local trust_dir="$HOME/.claude/projects/$mangled"
+    if [ ! -d "$trust_dir" ]; then
+        mkdir -p "$trust_dir"
+        echo ">> Trust pre-registrado: $mangled"
+    fi
+}
+
 # =============================================================================
 # dev <issue> [slug]
 #
@@ -65,6 +81,9 @@ HELP
 
     # El directorio actual ya cambio (shell integration de worktrunk)
     local current_dir="$(pwd)"
+
+    # Pre-registrar confianza del worktree en Claude Code
+    _pre_trust_worktree "$current_dir"
 
     # Copiar settings.local.json de Claude Code (permisos)
     if [ -f "$_INTRALE_MAIN/.claude/settings.local.json" ]; then


### PR DESCRIPTION
## Resumen

Se eliminó el diálogo interactivo de confianza de workspace que bloqueaba el lanzamiento automático de agentes en nuevos worktrees.

### Cambios:
- **scripts/Start-Agente.ps1**: Función `PreRegister-Trust()` que pre-crea el directorio de trust antes de lanzar claude
- **.claude/hooks/telegram-commander.js**: Función `preTrustDirectory()` en `handleSprint()` y `executeClaude()`
- **scripts/dev-functions.sh**: Función `_pre_trust_worktree()` en `dev()`

El path mangling sigue la convención de Claude Code (reemplazar `:`, `\`, `/` con `-`).

## Plan de tests

- [x] Pre-registración de trust en worktrees nuevos (verificado con `ls ~/.claude/projects/`)
- [x] Compatibilidad con el symlink de `.claude/` del repo principal
- [x] Funcionamiento en PowerShell (Start-Agente.ps1), Node.js (telegram-commander.js) y Bash (dev-functions.sh)

QA E2E: tests ejecutados en 2026-02-24 08:39

Rebase: actualizado con 4 commits de main

Closes #976

🤖 Generado con [Claude Code](https://claude.ai/claude-code)