### PR TITLE
refactor(infra): reemplazar prefijo "codex/" por "agent/" en convención de ramas automáticas

### DIFF
--- a/.claude/skills/delivery/SKILL.md
+++ b/.claude/skills/delivery/SKILL.md
@@ -17,7 +17,7 @@ Sos veloz, confiable y siempre entregás en tiempo y forma.
 - `<descripcion>` — Descripción breve del cambio (obligatorio)
 - `--issue <N>` — Número de issue que cierra este PR (opcional, agrega `Closes #N` al body)
 - `--draft` — Crear el PR como draft (opcional)
-- `--all` — Entregar todos los worktrees activos con branch `codex/*` (ejecuta el flujo completo por cada uno)
+- `--all` — Entregar todos los worktrees activos con branch `agent/*` (ejecuta el flujo completo por cada uno)
 
 ## Pre-flight: Registrar tareas
 
@@ -32,7 +32,7 @@ Si se pasó `--all`:
 git worktree list --porcelain
 ```
 
-2. Filtrar solo los worktrees cuya branch tenga prefijo `codex/` (parsear líneas `branch refs/heads/codex/...`).
+2. Filtrar solo los worktrees cuya branch tenga prefijo `agent/` (parsear líneas `branch refs/heads/agent/...`).
 
 3. Para cada worktree encontrado:
    - `cd` al directorio del worktree
@@ -43,8 +43,8 @@ git worktree list --porcelain
 ```
 | Branch              | PR URL                          | Estado    |
 |---------------------|---------------------------------|-----------|
-| codex/123-feature   | https://github.com/.../pull/45  | OK        |
-| codex/456-bugfix    | —                               | ERROR: …  |
+| agent/123-feature   | https://github.com/.../pull/45  | OK        |
+| agent/456-bugfix    | —                               | ERROR: …  |
 ```
 
 5. En modo `--all`: **SÍ mergear** cada PR inmediatamente después de crearlo (squash + delete-branch), siguiendo el Paso 6.5. Si el merge falla, registrar el error y continuar con el siguiente.

--- a/.claude/skills/monitor/SKILL.md
+++ b/.claude/skills/monitor/SKILL.md
@@ -51,9 +51,9 @@ Genera el dashboard con este formato (ajustando ancho a ~70 columnas):
 │ 14:31:45  b08b96a2  Bash      git status                       │
 │ 14:30:12  67eb3124  Write     LoginViewModel.kt                │
 ├─ REPO ──────────────────────────────────────────────────────────┤
-│ Rama: codex/829-centinela-v3                                     │
+│ Rama: agent/829-centinela-v3                                     │
 │ Commit: 2b29ad5 migrar hooks de bash…                            │
-│ CI: ⏳ in_progress (codex/829-centinela-v3)                       │
+│ CI: ⏳ in_progress (agent/829-centinela-v3)                       │
 ├─ PLAN (2026-02-20) ────────────────────────────────────────────┤
 │ #1  #821  notificaciones     S  Stream E                         │
 │ #2  #845  refactor-login     M  Stream A                         │

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,7 +133,7 @@ Todas las respuestas de servicio deben incluir `statusCode` con valor numérico 
 
 | Contexto       | Formato                          | Base           |
 |----------------|----------------------------------|----------------|
-| Codex (bots)   | `codex/<issue>-<slug>`           | `origin/main`  |
+| Agentes IA     | `agent/<issue>-<slug>`           | `origin/main`  |
 | Feature manual | `feature/<desc>`                 | `develop`      |
 | Bugfix manual  | `bugfix/<desc>`                  | `develop`      |
 | Docs manual    | `docs/<desc>`                    | `develop`      |

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Estas tareas también se ejecutan automáticamente como parte de `./gradlew buil
 
 | Contexto | Formato de rama | Base |
 |---|---|---|
-| Codex (bots) | `codex/<issue>-<slug>` | `origin/main` |
+| Agentes IA | `agent/<issue>-<slug>` | `origin/main` |
 | Feature manual | `feature/<desc>` | `develop` |
 | Bugfix manual | `bugfix/<desc>` | `develop` |
 | Docs manual | `docs/<desc>` | `develop` |

--- a/agents/08-branch-naming.md
+++ b/agents/08-branch-naming.md
@@ -12,6 +12,6 @@ Prefijos:
 | Documentación   | docs/<desc>        |
 | Refactorización | refactor/<desc>    |
 
-**Regla de agentes (Codex)**
-- Las ramas creadas automáticamente **siempre** usan el formato **`codex/<issue>-<slug>`** y base **`origin/main`**.
+**Regla de agentes IA**
+- Las ramas creadas automáticamente **siempre** usan el formato **`agent/<issue>-<slug>`** y base **`origin/main`**.
 - Los prefijos `feature/`, `bugfix/`, `refactor/`, `docs/` se reservan para trabajo **manual**.

--- a/agents/12-web-interface-contract.md
+++ b/agents/12-web-interface-contract.md
@@ -1,10 +1,10 @@
-# 🕹️ Contrato con la Interfaz Web de Codex (Actualizado a `main`)
+# 🕹️ Contrato con la Interfaz Web de Agentes (Actualizado a `main`)
 
 Interpretación de órdenes (lenguaje natural)
 
 Si el usuario pide “crear PR”, el agente debe:
 1) Resolver `issue-number` y `repo`.
-2) Crear rama **desde `origin/main`** con el formato **`codex/<issue-number>-<slug>`**.
+2) Crear rama **desde `origin/main`** con el formato **`agent/<issue-number>-<slug>`**.
 3) Hacer el cambio mínimo solicitado (si aplica).
 4) Crear **PR contra `main`** con `Closes #<issue>`.
 
@@ -13,7 +13,7 @@ Validaciones previas
 
 Criterios de aceptación
 - PR apunta a `main`.
-- Rama cumple `codex/<issue>-<slug>`.
+- Rama cumple `agent/<issue>-<slug>`.
 - Issue referenciado en título/cuerpo del PR (`Closes #N`).
 
 En caso de incumplimiento

--- a/agents/18-project-v2-api-examples.md
+++ b/agents/18-project-v2-api-examples.md
@@ -69,7 +69,7 @@ curl -s -H "Authorization: token $GITHUB_TOKEN" \
 # crear rama a partir de main
 BASE_SHA=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
   https://api.github.com/repos/$GH_OWNER/$GH_REPO/git/ref/heads/main | jq -r '.object.sha')
-BRANCH="codex/${ISSUE_NUMBER}-auto"
+BRANCH="agent/${ISSUE_NUMBER}-auto"
 
 curl -s -H "Authorization: token $GITHUB_TOKEN" \
   -X POST https://api.github.com/repos/$GH_OWNER/$GH_REPO/git/refs \

--- a/agents/19-README-commands.md
+++ b/agents/19-README-commands.md
@@ -1,6 +1,6 @@
-# Comandos básicos para Codex (lenguaje natural) — intrale/platform
+# Comandos básicos para Agentes IA (lenguaje natural) — intrale/platform
 
-Estos comandos están alineados con nuestras reglas: PRs desde `main`, ramas `codex/<issue>-<slug>`, y estados del Project V2: **Backlog, Refined, Todo, In Progress, Ready, Done, Blocked**. Se aplican al repo **intrale/platform** y al Project **“Intrale” nº 1**.
+Estos comandos están alineados con nuestras reglas: PRs desde `main`, ramas `agent/<issue>-<slug>`, y estados del Project V2: **Backlog, Refined, Todo, In Progress, Ready, Done, Blocked**. Se aplican al repo **intrale/platform** y al Project **“Intrale” nº 1**.
 
 > **Frase canónica (refinamiento) — usar exactamente esta:**
 > **Refinar la issue #<N> del repo intrale/platform escribiendo el detalle en el CUERPO de la issue (sobrescribí el cuerpo con la plantilla estándar). No crees ni modifiques archivos en docs/ ni publiques comentarios. Dejala en Refined.**
@@ -33,7 +33,7 @@ Usar exactamente estos nombres: **Backlog, Refined, Todo, In Progress, Ready, Do
 ## 3) Crear PR correcto desde `main` (una rama por issue)
 **Prompt:**
 > Para la **issue #{N}** en **intrale/platform**:
-> 1) Crear rama **`codex/{N}-{slug-del-título}`** **desde `origin/main`**.
+> 1) Crear rama **`agent/{N}-{slug-del-título}`** **desde `origin/main`**.
 > 2) Hacer un **commit mínimo**: {descripción breve}.
 > 3) Abrir **PR contra `main`** con título: `[auto] {título} (Closes #{N})`.
 > 4) Asignar el PR a **leitolarreta** y devolver los links.
@@ -80,29 +80,29 @@ Usar exactamente estos nombres: **Backlog, Refined, Todo, In Progress, Ready, Do
 
 ## 8) Agrupadores: Desarrollar (una o varias)
 
-> Regla: **siempre** crear rama desde `origin/main` con formato `codex/{N}-{slug}`, abrir PR **contra `main`**, título `[auto] {título} (Closes #{N})`, asignado a **leitolarreta**. No hacer merge.
+> Regla: **siempre** crear rama desde `origin/main` con formato `agent/{N}-{slug}`, abrir PR **contra `main`**, título `[auto] {título} (Closes #{N})`, asignado a **leitolarreta**. No hacer merge.
 
 ### 8.1 Desarrollar UNA historia
 > **Desarrollar la issue #{N}** en **intrale/platform**:
 > - Mover la issue a **In Progress**.
-> - Crear rama **`codex/{N}-{slug}`** desde `origin/main`.
+> - Crear rama **`agent/{N}-{slug}`** desde `origin/main`.
 > - Implementar lo mínimo para cumplir criterios de aceptación (o lo indicado).
 > - Abrir **PR a `main`** con `[auto] {título} (Closes #{N})`, asignar a **leitolarreta**.
 > - **Mover la issue a “Ready”** y devolver links de rama y PR.
 
 ### 8.2 Desarrollar VARIAS historias por lista
 > **Desarrollar las issues #{N1}, #{N2}, #{N3}** en **intrale/platform**:
-> - Para **cada** issue: mover a **In Progress**; crear rama **`codex/{N}-{slug}`** desde `origin/main`; implementar lo mínimo; abrir **PR a `main`** con `[auto] {título} (Closes #{N})`, asignar a **leitolarreta**; **mover a “Ready”**.
+> - Para **cada** issue: mover a **In Progress**; crear rama **`agent/{N}-{slug}`** desde `origin/main`; implementar lo mínimo; abrir **PR a `main`** con `[auto] {título} (Closes #{N})`, asignar a **leitolarreta**; **mover a “Ready”**.
 > - Entregar una **tabla** con: issue, rama, PR, estado final.
 
 ### 8.3 Desarrollar las próximas K priorizadas en “Todo”
 > **Desarrollar las próximas {K} historias en “Todo”** del Project **“Intrale” nº 1** (según prioridad):
-> - Para **cada** issue: mover a **In Progress**; crear rama **`codex/{N}-{slug}`** desde `origin/main`; implementar lo mínimo; abrir **PR a `main`** con `[auto] {título} (Closes #{N})`, asignar a **leitolarreta**; **mover a “Ready”**.
+> - Para **cada** issue: mover a **In Progress**; crear rama **`agent/{N}-{slug}`** desde `origin/main`; implementar lo mínimo; abrir **PR a `main`** con `[auto] {título} (Closes #{N})`, asignar a **leitolarreta**; **mover a “Ready”**.
 > - Devolver links y un **resumen** de progreso.
 
 ### 8.4 Finalizar desarrollo pendiente (reintentos de PR)
 > **Para todas las issues en “In Progress”** del Project **“Intrale” nº 1**:
-> - Si **no** existe PR: crear rama **`codex/{N}-{slug}`** desde `origin/main`, hacer commit mínimo, abrir **PR a `main`** con `[auto] {título} (Closes #{N})`, asignar a **leitolarreta**.
+> - Si **no** existe PR: crear rama **`agent/{N}-{slug}`** desde `origin/main`, hacer commit mínimo, abrir **PR a `main`** con `[auto] {título} (Closes #{N})`, asignar a **leitolarreta**.
 > - Si **ya hay** PR: actualizar con los cambios pendientes y **mover la issue a “Ready”** si cumple criterios.
 > - Entregar una **tabla** con: issue, rama, PR, estado final.
 

--- a/delivery-all.sh
+++ b/delivery-all.sh
@@ -151,7 +151,7 @@ Closes #$ISSUE
 # Procesar cada worktree
 cd "$MAIN_REPO"
 while IFS= read -r line; do
-    if [[ $line =~ ^branch\ refs/heads/codex/ ]]; then
+    if [[ $line =~ ^branch\ refs/heads/agent/ ]]; then
         BRANCH=$(echo "$line" | sed 's/branch refs\/heads\///')
         WT_DIR=$(git worktree list --porcelain | grep "branch refs/heads/$BRANCH" | awk '{print $1}')
 

--- a/docs/worktrunk.md
+++ b/docs/worktrunk.md
@@ -7,9 +7,9 @@ propio directorio aislado (worktree), sin riesgo de que se pisen entre sí.
 
 ```
 platform/                          ← main (coordinación, nunca se codea)
-platform.codex-42-auth/            ← Claude #1 trabajando en issue #42
-platform.codex-43-catalogo/        ← Claude #2 trabajando en issue #43
-platform.codex-44-pagos/           ← Claude #3 trabajando en issue #44
+platform.agent-42-auth/            ← Claude #1 trabajando en issue #42
+platform.agent-43-catalogo/        ← Claude #2 trabajando en issue #43
+platform.agent-44-pagos/           ← Claude #3 trabajando en issue #44
 ```
 
 Cada worktree comparte el mismo `.git/` (objetos, refs), pero tiene su propio
@@ -21,7 +21,7 @@ Solo 6 comandos, todos empiezan con `dev`:
 
 | Comando | Qué hace |
 |---------|----------|
-| `dev 42 auth-2fa` | Crear worktree + branch `codex/42-auth-2fa` |
+| `dev 42 auth-2fa` | Crear worktree + branch `agent/42-auth-2fa` |
 | `dev-list` | Ver todos los worktrees activos |
 | `dev-go 42` | Ir a un worktree existente |
 | `dev-done` | Mergear a main (squash) + limpiar |
@@ -66,8 +66,8 @@ dev-clean
 ```
 dev 42 auth
   ├─ git fetch origin main
-  ├─ git-wt switch --create codex/42-auth
-  │    └─ crea worktree en ../platform.codex-42-auth
+  ├─ git-wt switch --create agent/42-auth
+  │    └─ crea worktree en ../platform.agent-42-auth
   ├─ copia .claude/settings.local.json (permisos de Claude Code)
   └─ imprime instrucciones
 ```
@@ -101,7 +101,7 @@ source "/c/Workspaces/Intrale/platform/scripts/dev-functions.sh"
 
 | Origen | Formato | Ejemplo |
 |--------|---------|---------|
-| Agente Claude | `codex/<issue>-<slug>` | `codex/42-auth-2fa` |
+| Agente Claude | `agent/<issue>-<slug>` | `agent/42-auth-2fa` |
 | Feature manual | `feature/<desc>` | `feature/dark-mode` |
 | Bugfix manual | `bugfix/<desc>` | `bugfix/login-crash` |
 

--- a/scripts/Guardian-Sprint.ps1
+++ b/scripts/Guardian-Sprint.ps1
@@ -9,7 +9,7 @@
 
     Condiciones de inactividad (TODAS deben cumplirse):
     - No hay procesos claude corriendo
-    - No hay worktrees codex/* activos
+    - No hay worktrees agent/* activos
     - No hay Watch-Agentes.ps1 corriendo
 
     Cooldown de 10 minutos entre relanzamientos para evitar loops.
@@ -80,12 +80,12 @@ function Test-ClaudeRunning {
     return $false
 }
 
-function Test-CodexWorktrees {
+function Test-AgentWorktrees {
     Push-Location $MainRepo
     try {
         $wtOutput = git worktree list --porcelain 2>$null
-        $codexBranches = $wtOutput | Select-String 'branch refs/heads/codex/'
-        return ($codexBranches -and @($codexBranches).Count -gt 0)
+        $agentBranches = $wtOutput | Select-String 'branch refs/heads/agent/'
+        return ($agentBranches -and @($agentBranches).Count -gt 0)
     }
     catch { return $false }
     finally { Pop-Location }
@@ -138,7 +138,7 @@ function Stop-ZombieAgents {
 
 function Test-IsActive {
     $claude   = Test-ClaudeRunning
-    $worktrees = Test-CodexWorktrees
+    $worktrees = Test-AgentWorktrees
     $watcher  = Test-WatcherRunning
 
     return @{

--- a/scripts/Start-Agente.ps1
+++ b/scripts/Start-Agente.ps1
@@ -72,8 +72,8 @@ function Start-UnAgente {
     $issue  = $Agente.issue
     $slug   = $Agente.slug
     $prompt = $Agente.prompt
-    $branch = "codex/$issue-$slug"
-    $wtDir  = "$MainRepo\..\platform.codex-$issue-$slug"
+    $branch = "agent/$issue-$slug"
+    $wtDir  = "$MainRepo\..\platform.agent-$issue-$slug"
 
     Write-Host ""
     Write-Host "============================================" -ForegroundColor Cyan

--- a/scripts/Stop-Agente.ps1
+++ b/scripts/Stop-Agente.ps1
@@ -86,8 +86,8 @@ function Stop-UnAgente {
 
     $issue  = $Agente.issue
     $slug   = $Agente.slug
-    $branch = 'codex/{0}-{1}' -f $issue, $slug
-    $wtDir  = '{0}\..\platform.codex-{1}-{2}' -f $MainRepo, $issue, $slug
+    $branch = 'agent/{0}-{1}' -f $issue, $slug
+    $wtDir  = '{0}\..\platform.agent-{1}-{2}' -f $MainRepo, $issue, $slug
 
     Write-Host ''
     Write-Host '============================================' -ForegroundColor Cyan

--- a/scripts/dev-functions.sh
+++ b/scripts/dev-functions.sh
@@ -36,9 +36,9 @@ _pre_trust_worktree() {
 # Copia automaticamente la config de Claude Code (permisos, etc).
 #
 # Ejemplos:
-#   dev 42 auth-2fa        → branch codex/42-auth-2fa
-#   dev 43 catalogo        → branch codex/43-catalogo
-#   dev 50                 → branch codex/50-feature
+#   dev 42 auth-2fa        → branch agent/42-auth-2fa
+#   dev 43 catalogo        → branch agent/43-catalogo
+#   dev 50                 → branch agent/50-feature
 # =============================================================================
 dev() {
     local issue="${1}"
@@ -62,8 +62,8 @@ HELP
         return 1
     fi
 
-    local branch="codex/${issue}-${slug}"
-    local wt_dir="${_INTRALE_MAIN}/../platform.codex-${issue}-${slug}"
+    local branch="agent/${issue}-${slug}"
+    local wt_dir="${_INTRALE_MAIN}/../platform.agent-${issue}-${slug}"
 
     # Ir al worktree principal
     cd "$_INTRALE_MAIN" 2>/dev/null || {
@@ -129,7 +129,7 @@ dev-go() {
     cd "$_INTRALE_MAIN" 2>/dev/null
 
     # Intentar match exacto primero
-    git-wt switch "codex/${search}" 2>/dev/null && return 0
+    git-wt switch "agent/${search}" 2>/dev/null && return 0
 
     # Buscar parcial en branches con worktrees
     local match=$(git worktree list --porcelain 2>/dev/null \


### PR DESCRIPTION
## Resumen

Reemplazar el prefijo `codex/` (heredado de OpenAI Codex) por `agent/` en la convención de ramas automáticas creadas por agentes IA.

- Actualizar convención en CLAUDE.md y README.md
- Actualizar scripts de desarrollo (dev-functions.sh, Start-Agente.ps1, Stop-Agente.ps1, Guardian-Sprint.ps1)
- Actualizar skills y documentación (.claude/skills/*, agents/*, docs/worktrunk.md)
- Actualizar delivery-all.sh para filtro de worktrees

## Cambios afectados (14 archivos)

| Archivo | Cambio |
|---------|--------|
| CLAUDE.md | Tabla de convención |
| README.md | Tabla de convención |
| scripts/dev-functions.sh | Branch naming + worktree dirs |
| scripts/Start-Agente.ps1 | Branch + wtDir |
| scripts/Stop-Agente.ps1 | Branch + wtDir |
| scripts/Guardian-Sprint.ps1 | Function rename + pattern |
| .claude/skills/delivery/SKILL.md | Docs actualizadas |
| .claude/skills/monitor/SKILL.md | Ejemplo output |
| agents/08-branch-naming.md | Regla de agentes |
| agents/12-web-interface-contract.md | Título + refs |
| agents/18-project-v2-api-examples.md | Ejemplo de branch |
| agents/19-README-commands.md | Título + todos los ejemplos |
| docs/worktrunk.md | Tabla + diagrama + ejemplos |
| delivery-all.sh | Pattern de filtrado |

## Plan de tests

- [x] Verificar que no queden referencias residuales a `codex/` en archivos principales
- [x] Confirmar que las referencias en worktrees temporales NO se modifican (se descartarán al limpiarse)

Closes #1042

Rebase: actualizado con 1 commit de main (conflictos en config resueltos automáticamente)

🤖 Generado con [Claude Code](https://claude.com/claude-code)