### PR TITLE
fix(infra): proteger .claude/ de eliminación accidental por junctions en worktrees

### DIFF
--- a/scripts/Start-Agente.ps1
+++ b/scripts/Start-Agente.ps1
@@ -112,8 +112,19 @@ function Start-UnAgente {
     # Pre-registrar confianza del worktree para evitar dialogo interactivo de trust
     PreRegister-Trust -AbsPath "$wtDirResolved"
 
-    # Symlink de .claude/ para heredar confianza y permisos del repo principal
+    # Verificar integridad de .claude/ en el repo principal antes de linkear
     $claudeSrc = Join-Path $MainRepo ".claude"
+    $settingsCheck = Join-Path $claudeSrc "settings.json"
+    $skillsCheck = Join-Path $claudeSrc "skills"
+    if (-not (Test-Path $settingsCheck) -or -not (Test-Path $skillsCheck)) {
+        Write-Host ">> ADVERTENCIA: .claude/ danado en repo principal. Restaurando desde git..." -ForegroundColor Red
+        Push-Location $MainRepo
+        git checkout HEAD -- .claude/ 2>$null
+        Pop-Location
+        Write-Host ">> .claude/ restaurado." -ForegroundColor Green
+    }
+
+    # Symlink de .claude/ para heredar confianza y permisos del repo principal
     $claudeDst = Join-Path $wtDirResolved ".claude"
     if (Test-Path $claudeSrc) {
         $createSymlink = $false

--- a/scripts/Stop-Agente.ps1
+++ b/scripts/Stop-Agente.ps1
@@ -47,6 +47,29 @@ function Write-Log {
     Write-Host "$P $Msg" -ForegroundColor $Color
 }
 
+# --- Safe worktree removal ---
+# Remove-Item -Recurse -Force sigue junctions/symlinks y BORRA el contenido real de .claude/.
+# Esta funcion primero desvincula la junction con rmdir (sin /s), que NO sigue el enlace.
+function Safe-RemoveWorktreeDir {
+    param([string]$WtPath)
+
+    if (-not (Test-Path $WtPath)) { return }
+
+    # Desvincular junction/symlink .claude/ ANTES de borrar recursivamente
+    $claudeLink = Join-Path $WtPath ".claude"
+    if (Test-Path $claudeLink) {
+        $item = Get-Item $claudeLink -Force -ErrorAction SilentlyContinue
+        if ($item -and ($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint)) {
+            # Es junction o symlink: usar rmdir que NO sigue el enlace
+            cmd /c rmdir "$claudeLink" 2>$null
+            Write-Log "Junction .claude/ desvinculada (contenido real preservado)." "Cyan"
+        }
+    }
+
+    # Ahora si es seguro borrar recursivamente
+    Remove-Item $WtPath -Recurse -Force -ErrorAction SilentlyContinue
+}
+
 # --- Validaciones ---
 if (-not (Test-Path $PlanFile)) {
     Write-Error ('No se encontro el plan: {0}' -f $PlanFile)
@@ -152,10 +175,8 @@ function Stop-UnAgente {
         }
         catch { }
         finally { Pop-Location }
-        # Fallback: borrar directorio si sigue existiendo
-        if (Test-Path $wtDirResolved) {
-            Remove-Item $wtDirResolved -Recurse -Force -ErrorAction SilentlyContinue
-        }
+        # Fallback: borrar directorio si sigue existiendo (safe: desvincula junction primero)
+        Safe-RemoveWorktreeDir $wtDirResolved
         Close-AgenteTerminal -Agente $Agente
         Write-Log 'Limpiado.' 'Green'
         return
@@ -180,9 +201,8 @@ function Stop-UnAgente {
             git branch -D $branch 2>$null
             git worktree prune 2>$null
             $ErrorActionPreference = $prevEAP
-            if (Test-Path $wtDirResolved) {
-                Remove-Item $wtDirResolved -Recurse -Force -ErrorAction SilentlyContinue
-            }
+            # Safe: desvincula junction .claude/ antes de borrar
+            Safe-RemoveWorktreeDir $wtDirResolved
             Close-AgenteTerminal -Agente $Agente
             Write-Log 'Worktree limpiado (sin cambios).' 'Green'
             return


### PR DESCRIPTION
## Summary
- `Stop-Agente.ps1` usaba `Remove-Item -Recurse -Force` como fallback al limpiar worktrees, lo que seguía junctions y borraba el `.claude/` real del repo principal
- Se agrega función `Safe-RemoveWorktreeDir` que desvincula la junction con `rmdir` (sin `/s`) antes de borrar recursivamente
- Se agrega verificación de integridad en `Start-Agente.ps1` que restaura `.claude/` desde git si detecta daño antes de crear la junction

## Test plan
- [ ] Verificar que `Stop-Agente.ps1 1 -Abort` no borra `.claude/` del repo principal
- [ ] Verificar que `Start-Agente.ps1 all` detecta `.claude/` dañado y lo restaura
- [ ] Verificar que worktrees se limpian correctamente tras el fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)