### PR TITLE
fix: eliminar junctions de .claude/ — reemplazar con copias

### DIFF
--- a/scripts/Start-Agente.ps1
+++ b/scripts/Start-Agente.ps1
@@ -4,7 +4,7 @@
 
 .DESCRIPTION
     Lee sprint-plan.json y crea worktrees para los agentes indicados.
-    Enlaza .claude/ del repo principal via symlink y abre nueva terminal PowerShell con claude ejecutando.
+    Copia .claude/ del repo principal y abre nueva terminal PowerShell con claude ejecutando.
 
 .PARAMETER Numero
     Numero de agente (1, 2, 3...) o "all" para lanzar todos en paralelo.
@@ -112,7 +112,7 @@ function Start-UnAgente {
     # Pre-registrar confianza del worktree para evitar dialogo interactivo de trust
     PreRegister-Trust -AbsPath "$wtDirResolved"
 
-    # Verificar integridad de .claude/ en el repo principal antes de linkear
+    # Verificar integridad de .claude/ en el repo principal antes de copiar
     $claudeSrc = Join-Path $MainRepo ".claude"
     $settingsCheck = Join-Path $claudeSrc "settings.json"
     $skillsCheck = Join-Path $claudeSrc "skills"
@@ -124,40 +124,21 @@ function Start-UnAgente {
         Write-Host ">> .claude/ restaurado." -ForegroundColor Green
     }
 
-    # Symlink de .claude/ para heredar confianza y permisos del repo principal
+    # Copiar .claude/ del repo principal (NO junction/symlink — seguro contra rm -rf)
     $claudeDst = Join-Path $wtDirResolved ".claude"
     if (Test-Path $claudeSrc) {
-        $createSymlink = $false
-
         if (Test-Path $claudeDst) {
             $item = Get-Item $claudeDst -Force
             if ($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) {
-                Write-Host ">> Symlink .claude/ ya existe, reutilizando"
-            }
-            elseif (-not $wtExists) {
-                # Worktree recien creado: reemplazar .claude/ checkeado por git con symlink
+                # Legacy: junction de ejecucion anterior — desvincular primero
+                cmd /c rmdir "$claudeDst" 2>$null
+            } else {
+                # Directorio real de git checkout — eliminar para reemplazar con copia fresca
                 Remove-Item $claudeDst -Recurse -Force
-                $createSymlink = $true
-            }
-            else {
-                Write-Host ">> .claude/ real existente, no se sobreescribe" -ForegroundColor Yellow
             }
         }
-        else {
-            $createSymlink = $true
-        }
-
-        if ($createSymlink) {
-            try {
-                New-Item -ItemType SymbolicLink -Path $claudeDst -Target $claudeSrc -Force | Out-Null
-                Write-Host ">> Symlink .claude/ creado"
-            }
-            catch {
-                # Fallback: junction si symlink falla (permisos Windows)
-                cmd /c mklink /J "$claudeDst" "$claudeSrc" 2>$null | Out-Null
-                Write-Host ">> Junction .claude/ creado (fallback)"
-            }
-        }
+        Copy-Item -Path $claudeSrc -Destination $claudeDst -Recurse -Force
+        Write-Host ">> .claude/ copiado (sin junction)"
     }
 
     # Pre-crear trust directory para que Claude no muestre el dialogo interactivo

--- a/scripts/Stop-Agente.ps1
+++ b/scripts/Stop-Agente.ps1
@@ -48,25 +48,25 @@ function Write-Log {
 }
 
 # --- Safe worktree removal ---
-# Remove-Item -Recurse -Force sigue junctions/symlinks y BORRA el contenido real de .claude/.
-# Esta funcion primero desvincula la junction con rmdir (sin /s), que NO sigue el enlace.
+# Maneja junctions legacy de .claude/ (creadas antes de 2026-02-27).
+# Desde esa fecha, Start-Agente usa Copy-Item en vez de junction, por lo que
+# Remove-Item -Recurse es seguro. Esta proteccion se mantiene para worktrees
+# creados antes del cambio.
 function Safe-RemoveWorktreeDir {
     param([string]$WtPath)
 
     if (-not (Test-Path $WtPath)) { return }
 
-    # Desvincular junction/symlink .claude/ ANTES de borrar recursivamente
+    # Desvincular junction/symlink legacy de .claude/ ANTES de borrar recursivamente
     $claudeLink = Join-Path $WtPath ".claude"
     if (Test-Path $claudeLink) {
         $item = Get-Item $claudeLink -Force -ErrorAction SilentlyContinue
         if ($item -and ($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint)) {
-            # Es junction o symlink: usar rmdir que NO sigue el enlace
             cmd /c rmdir "$claudeLink" 2>$null
-            Write-Log "Junction .claude/ desvinculada (contenido real preservado)." "Cyan"
+            Write-Log "Junction legacy .claude/ desvinculada." "Yellow"
         }
     }
 
-    # Ahora si es seguro borrar recursivamente
     Remove-Item $WtPath -Recurse -Force -ErrorAction SilentlyContinue
 }
 

--- a/scripts/dev-functions.sh
+++ b/scripts/dev-functions.sh
@@ -85,11 +85,16 @@ HELP
     # Pre-registrar confianza del worktree en Claude Code
     _pre_trust_worktree "$current_dir"
 
-    # Copiar settings.local.json de Claude Code (permisos)
-    if [ -f "$_INTRALE_MAIN/.claude/settings.local.json" ]; then
-        mkdir -p "$current_dir/.claude" 2>/dev/null
-        cp "$_INTRALE_MAIN/.claude/settings.local.json" "$current_dir/.claude/settings.local.json"
-        echo ">> Copiado permisos de Claude Code"
+    # Copiar .claude/ completo (NO junction — seguro contra rm -rf)
+    if [ -d "$_INTRALE_MAIN/.claude" ]; then
+        # Si hay junction legacy, desvincular primero
+        if [ -L "$current_dir/.claude" ]; then
+            local win_path=$(cygpath -w "$current_dir/.claude" 2>/dev/null)
+            cmd /c rmdir "$win_path" 2>/dev/null
+        fi
+        rm -rf "$current_dir/.claude" 2>/dev/null
+        cp -r "$_INTRALE_MAIN/.claude" "$current_dir/.claude"
+        echo ">> .claude/ copiado completo (sin junction)"
     fi
 
     echo ""
@@ -203,9 +208,9 @@ dev-clean-all() {
             | sed 's/worktree //' \
             | while read wt_path; do
                 echo "  Eliminando: $wt_path"
-                # CRITICO: desvincular junction .claude antes de borrar
-                # cmd /c rmdir sin /s solo remueve el junction, no sigue el enlace
-                if [ -L "$wt_path/.claude" ] || [ -d "$wt_path/.claude" ]; then
+                # Desvincular junction legacy .claude/ si existe (worktrees creados antes de 2026-02-27)
+                # Worktrees nuevos usan copia, no junction — pero mantenemos para backward compat
+                if [ -L "$wt_path/.claude" ] || [ -h "$wt_path/.claude" ]; then
                     local win_path=$(cygpath -w "$wt_path/.claude" 2>/dev/null || echo "$wt_path/.claude")
                     cmd /c rmdir "$win_path" 2>/dev/null
                 fi


### PR DESCRIPTION
## Resumen

- Reemplazar symlinks/junctions NTFS con **copias completas** de `.claude/` en worktrees
- `Start-Agente.ps1`: `Copy-Item` en vez de `New-Item -SymbolicLink` / `mklink /J`
- `Stop-Agente.ps1`: `Safe-RemoveWorktreeDir` actualizado con comentarios legacy
- `dev-functions.sh`: `cp -r .claude/` completo en vez de solo `settings.local.json`
- Mantiene detección de junctions legacy para backward compat en todos los scripts

**Problema**: junctions NTFS causaban que `rm -rf` / `Remove-Item -Recurse` siguiera el enlace y borrara el `.claude/` real del repo principal (incidente 2026-02-27).

**Solución**: `.claude/` pesa ~500KB — copiar es instantáneo y completamente seguro contra operaciones recursivas.

QA E2E: omitido (cambios en scripts de infraestructura, no código de negocio)

## Plan de tests

- [x] Verificar que `Start-Agente.ps1` usa `Copy-Item` en vez de symlink
- [x] Verificar que `Stop-Agente.ps1` mantiene protección legacy
- [x] Verificar que `dev-functions.sh` copia `.claude/` completo
- [ ] Crear worktree con `Start-Agente.ps1` y verificar que `.claude/` NO es junction
- [ ] Eliminar worktree y verificar que `.claude/` del repo principal sigue intacto

🤖 Generado con [Claude Code](https://claude.ai/claude-code)