### PR TITLE
feat: Cambiar intervalo del reporter de monitor a 10 minutos (Closes #1075)

### DIFF
--- a/.claude/hooks/reporter-bg.js
+++ b/.claude/hooks/reporter-bg.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // Reporter Background — Inicia/detiene el reporter PNG de Telegram
 // Uso:
-//   node .claude/hooks/reporter-bg.js start [minutos]   (defecto: 5)
+//   node .claude/hooks/reporter-bg.js start [minutos]   (defecto: 10)
 //   node .claude/hooks/reporter-bg.js stop
 //   node .claude/hooks/reporter-bg.js status
 const { spawn, execSync } = require("child_process");
@@ -104,7 +104,7 @@ function status() {
 
 // --- CLI ---
 const cmd = process.argv[2] || "start";
-const interval = parseInt(process.argv[3], 10) || 5;
+const interval = parseInt(process.argv[3], 10) || 10;
 
 if (cmd === "start") {
   start(interval);

--- a/.claude/hooks/telegram-config.json
+++ b/.claude/hooks/telegram-config.json
@@ -2,5 +2,5 @@
   "bot_token": "8403197784:AAG07242gOCKwZ-G-DI8eLC6R1HwfhG6Exk",
   "chat_id": "6529617704",
   "permission_timeout_min": 60,
-  "task_report_interval_min": 5
+  "task_report_interval_min": 10
 }

--- a/.claude/skills/monitor/SKILL.md
+++ b/.claude/skills/monitor/SKILL.md
@@ -198,7 +198,7 @@ Muestra:
 │ Hook:  activity-logger.js (PostToolUse)             │
 │        stop-notify.js (Stop → marca "done")         │
 │                                                     │
-│ Reporter PNG automatico (cada 5 min):               │
+│ Reporter PNG automatico (cada 10 min):              │
 │   Auto-inicia con activity-logger.js                │
 │   node .claude/hooks/reporter-bg.js status          │
 │   node .claude/hooks/reporter-bg.js stop            │
@@ -220,7 +220,7 @@ Muestra:
 - Para monitoreo en tiempo real con auto-refresh: `node .claude/dashboard.js` en terminal externa
 - El flag `--report N` envía una imagen PNG del dashboard a Telegram cada N minutos
 - `--headless` ejecuta solo el reporter sin UI de terminal (ideal para background)
-- **Auto-inicio**: el hook `activity-logger.js` inicia automaticamente el reporter PNG en background (cada 5 min) al detectar actividad de agentes; se auto-detiene si no hay sesiones activas por 30 min
+- **Auto-inicio**: el hook `activity-logger.js` inicia automaticamente el reporter PNG en background (cada 10 min) al detectar actividad de agentes; se auto-detiene si no hay sesiones activas por 30 min
 - Control manual: `node .claude/hooks/reporter-bg.js [start|stop|status] [minutos]`
 - Requiere `npm install canvas` para generar imágenes PNG; sin canvas, el reporte se envía como texto plano (fallback automático)
 - La imagen incluye: lista de agentes con color según estado (verde/amarillo/gris), última acción, duración, métricas de CI y contadores


### PR DESCRIPTION
## Resumen

- Cambia `task_report_interval_min` de 5 a 10 en `telegram-config.json` (fuente de verdad)
- Actualiza el fallback CLI en `reporter-bg.js` de `|| 5` a `|| 10`
- Actualiza la documentación del skill `/monitor` para reflejar "cada 10 min"

## Archivos modificados

| Archivo | Cambio |
|---------|--------|
| `.claude/hooks/telegram-config.json` | `task_report_interval_min: 5` → `10` |
| `.claude/hooks/reporter-bg.js` | Default fallback `\|\| 5` → `\|\| 10` + comentario |
| `.claude/skills/monitor/SKILL.md` | Referencias de "5 min" → "10 min" en texto de ayuda |

## Plan de tests

- [x] Cambios son config/docs — no requieren build
- [x] Verificar que `activity-logger.js` lee dinámicamente de `telegram-config.json` (ya lo hace, sin cambio necesario)

QA E2E: omitido — cambio solo afecta config de hooks y documentación

Rebase: actualizado con 2 commits de main

Closes #1075

🤖 Generado con [Claude Code](https://claude.ai/claude-code)