### PR TITLE
fix: Monitor muestra sesiones stale/fantasma — filtrar por PID y umbrales

### DIFF
--- a/.claude/dashboard.js
+++ b/.claude/dashboard.js
@@ -23,8 +23,8 @@ const LOG_FILE = path.join(REPO_ROOT, ".claude", "activity-log.jsonl");
 const REFRESH_MS = 5000;
 const ACTIVE_THRESHOLD = 5 * 60 * 1000;   // 5 min
 const IDLE_THRESHOLD = 15 * 60 * 1000;    // 15 min
-const DONE_DISPLAY_HOURS = 1;
-const STALE_EXPIRY_HOURS = 2;          // sesiones "active" sin actividad → tratar como expiradas
+const DONE_DISPLAY_HOURS = 0.25;       // 15 min — sesiones "done" desaparecen rápido
+const STALE_EXPIRY_HOURS = 0.5;        // 30 min — sesiones "active" sin actividad → tratar como expiradas
 const RECENT_ACTIVITY_COUNT = 5;
 
 // --- ANSI colors ---
@@ -166,26 +166,78 @@ function livenessLabel(session) {
 
 // --- data collection ---
 
+/**
+ * Descubre sesiones en worktrees activos (evita duplicados por session id).
+ */
+function discoverWorktreeSessions(knownIds) {
+  const extra = [];
+  try {
+    const output = execSync("git worktree list --porcelain", { cwd: REPO_ROOT, timeout: 5000 })
+      .toString();
+    const lines = output.split(/\r?\n/);
+    for (const line of lines) {
+      if (!line.startsWith("worktree ")) continue;
+      const wtPath = line.substring(9).trim();
+      // Saltar el repo principal (ya lo leímos)
+      if (path.resolve(wtPath) === path.resolve(REPO_ROOT)) continue;
+      const wtSessions = path.join(wtPath, ".claude", "sessions");
+      if (!fs.existsSync(wtSessions)) continue;
+      for (const file of fs.readdirSync(wtSessions)) {
+        if (!file.endsWith(".json")) continue;
+        const sid = file.replace(".json", "");
+        if (knownIds.has(sid)) continue; // evitar duplicados
+        try {
+          const data = JSON.parse(fs.readFileSync(path.join(wtSessions, file), "utf8"));
+          extra.push(data);
+          knownIds.add(sid);
+        } catch(e) { /* skip corrupt */ }
+      }
+    }
+  } catch(e) { /* git worktree no disponible — ignorar */ }
+  return extra;
+}
+
 function loadSessions() {
   const sessions = [];
+  const knownIds = new Set();
+  const livePids = getLiveClaudePids();
+
+  // Función interna para filtrar una sesión
+  function shouldInclude(data) {
+    if (data.type === "sub") return false;
+    const age = Date.now() - new Date(data.last_activity_ts).getTime();
+    if (data.status === "done") {
+      if (age > DONE_DISPLAY_HOURS * 3600 * 1000) return false;
+    }
+    // Auto-expirar sesiones "active" sin actividad por más de STALE_EXPIRY_HOURS
+    if (data.status === "active" && age > STALE_EXPIRY_HOURS * 3600 * 1000) return false;
+    // Cruce PID: si la sesión tiene PID y podemos verificar, descartar zombies
+    if (data.pid && livePids !== null && data.status === "active") {
+      if (!livePids.has(data.pid)) return false;
+    }
+    return true;
+  }
+
   try {
-    if (!fs.existsSync(SESSIONS_DIR)) return sessions;
-    for (const file of fs.readdirSync(SESSIONS_DIR)) {
-      if (!file.endsWith(".json")) continue;
-      try {
-        const data = JSON.parse(fs.readFileSync(path.join(SESSIONS_DIR, file), "utf8"));
-        // Solo parent, filtrar done expiradas y zombis stale
-        if (data.type === "sub") continue;
-        const age = Date.now() - new Date(data.last_activity_ts).getTime();
-        if (data.status === "done") {
-          if (age > DONE_DISPLAY_HOURS * 3600 * 1000) continue;
-        }
-        // Auto-expirar sesiones "active" sin actividad por más de STALE_EXPIRY_HOURS
-        if (data.status === "active" && age > STALE_EXPIRY_HOURS * 3600 * 1000) continue;
-        sessions.push(data);
-      } catch(e) { /* skip corrupt */ }
+    if (fs.existsSync(SESSIONS_DIR)) {
+      for (const file of fs.readdirSync(SESSIONS_DIR)) {
+        if (!file.endsWith(".json")) continue;
+        try {
+          const data = JSON.parse(fs.readFileSync(path.join(SESSIONS_DIR, file), "utf8"));
+          if (!shouldInclude(data)) continue;
+          sessions.push(data);
+          knownIds.add(data.id || file.replace(".json", ""));
+        } catch(e) { /* skip corrupt */ }
+      }
     }
   } catch(e) {}
+
+  // Escanear worktrees para sesiones adicionales
+  const wtSessions = discoverWorktreeSessions(knownIds);
+  for (const data of wtSessions) {
+    if (shouldInclude(data)) sessions.push(data);
+  }
+
   // Ordenar por last_activity_ts desc
   sessions.sort((a, b) => new Date(b.last_activity_ts) - new Date(a.last_activity_ts));
   return sessions;
@@ -247,6 +299,42 @@ function getClaudeAgentCount() {
     _prevCpuSnap = newSnap;
     return { agents, zombies };
   } catch(e) { return { agents: 0, zombies: 0 }; }
+}
+
+// Cache de PIDs vivos de Claude Code (refresco cada 10s)
+let _livePidsCache = null;
+let _livePidsCacheTs = 0;
+const LIVE_PIDS_CACHE_MS = 10000;
+
+function getLiveClaudePids() {
+  const now = Date.now();
+  if (_livePidsCache !== null && (now - _livePidsCacheTs) < LIVE_PIDS_CACHE_MS) return _livePidsCache;
+  try {
+    const output = execSync(
+      'wmic process where "Name=\'node.exe\'" get ProcessId,CommandLine /format:list',
+      { cwd: REPO_ROOT, timeout: 10000, windowsHide: true }
+    ).toString();
+    const records = output.split(/\r?\n\r?\n/).filter(r => r.trim());
+    const pids = new Set();
+    for (const record of records) {
+      const fields = {};
+      for (const line of record.split(/\r?\n/)) {
+        const eq = line.indexOf("=");
+        if (eq === -1) continue;
+        fields[line.substring(0, eq).trim()] = line.substring(eq + 1).trim();
+      }
+      if (!fields.CommandLine || !fields.CommandLine.match(/claude/i)) continue;
+      const pid = parseInt(fields.ProcessId, 10);
+      if (!isNaN(pid)) pids.add(pid);
+    }
+    _livePidsCache = pids;
+    _livePidsCacheTs = now;
+    return pids;
+  } catch(e) {
+    _livePidsCache = null;
+    _livePidsCacheTs = now;
+    return null; // degradación elegante — sin filtro PID
+  }
 }
 
 function getCIStatus() {

--- a/.claude/hooks/activity-logger.js
+++ b/.claude/hooks/activity-logger.js
@@ -5,7 +5,25 @@ const fs = require("fs");
 const path = require("path");
 const { execSync } = require("child_process");
 
-const REPO_ROOT = process.env.CLAUDE_PROJECT_DIR || "C:\\Workspaces\\Intrale\\platform";
+// Resolver REPO_ROOT al repo principal (no al worktree)
+function resolveMainRepoRoot() {
+    const candidate = process.env.CLAUDE_PROJECT_DIR || "C:\\Workspaces\\Intrale\\platform";
+    try {
+        const gitCommon = execSync("git rev-parse --git-common-dir", { cwd: candidate, timeout: 3000 })
+            .toString().trim().replace(/\\/g, "/");
+        // Si retorna ".git" → estamos en el repo principal
+        if (gitCommon === ".git") return candidate;
+        // Si retorna ruta absoluta (ej: /c/Workspaces/Intrale/platform/.git/worktrees/...)
+        // buscar el componente ".git" y tomar su padre
+        const gitIdx = gitCommon.indexOf("/.git");
+        if (gitIdx !== -1) return gitCommon.substring(0, gitIdx);
+        // Fallback: subir desde gitCommon hasta encontrar .git
+        return path.resolve(gitCommon, "..");
+    } catch(e) { return candidate; }
+}
+
+const WORKTREE_ROOT = process.env.CLAUDE_PROJECT_DIR || "C:\\Workspaces\\Intrale\\platform";
+const REPO_ROOT = resolveMainRepoRoot();
 const LOG_FILE = path.join(REPO_ROOT, ".claude", "activity-log.jsonl");
 const SESSIONS_DIR = path.join(REPO_ROOT, ".claude", "sessions");
 const MAX_LINES = 500;
@@ -43,7 +61,7 @@ setTimeout(() => { if (!done) { done = true; try { process.stdin.destroy(); } ca
 
 function getBranch() {
     try {
-        return execSync("git branch --show-current", { cwd: REPO_ROOT, timeout: 3000 })
+        return execSync("git branch --show-current", { cwd: WORKTREE_ROOT, timeout: 3000 })
             .toString().trim();
     } catch(e) { return "unknown"; }
 }
@@ -178,6 +196,7 @@ function updateSession(sessionId, ts, toolName, target, toolInput) {
                 action_count: 0,
                 status: "active",
                 branch: getBranch(),
+                pid: process.ppid,
                 last_tool: toolName,
                 last_target: target.substring(0, 120),
                 agent_name: null,
@@ -203,6 +222,17 @@ function updateSession(sessionId, ts, toolName, target, toolInput) {
             }
             if (AGENT_MAP[skillName] && !session.agent_name) {
                 session.agent_name = AGENT_MAP[skillName];
+            }
+        }
+
+        // Fallback agent_name desde branch (solo si aún es null y tiene >2 acciones)
+        if (!session.agent_name && session.action_count > 2 && session.branch) {
+            const branchMatch = session.branch.match(/^agent\/(\d+)/);
+            if (branchMatch) {
+                session.agent_name = "Ad-hoc (#" + branchMatch[1] + ")";
+            } else if (session.branch !== "main" && session.branch !== "develop" && session.branch !== "unknown") {
+                const slug = session.branch.replace(/^[^/]+\//, "").substring(0, 20);
+                session.agent_name = "Ad-hoc (" + slug + ")";
             }
         }
 

--- a/.claude/hooks/stop-notify.js
+++ b/.claude/hooks/stop-notify.js
@@ -91,7 +91,7 @@ function cleanOldSessions() {
         if (!fs.existsSync(SESSIONS_DIR)) return;
         const files = fs.readdirSync(SESSIONS_DIR).filter(f => f.endsWith(".json"));
         const now = Date.now();
-        const MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24 horas
+        const MAX_AGE_MS = 2 * 60 * 60 * 1000; // 2 horas (safety net — dashboard ya filtra a 15min)
         let cleaned = 0;
 
         for (const file of files) {
@@ -159,7 +159,7 @@ async function processInput() {
     // Marcar sesion como terminada
     markSessionDone(data.session_id || "");
 
-    // Rotacion: limpiar sessions "done" con mas de 24h de antiguedad
+    // Rotacion: limpiar sessions "done" con mas de 2h de antiguedad
     cleanOldSessions();
 
     const raw = (data.last_assistant_message || "").trim();

--- a/.claude/skills/monitor/SKILL.md
+++ b/.claude/skills/monitor/SKILL.md
@@ -33,7 +33,9 @@ Calcula la diferencia entre `last_activity_ts` y el momento actual:
 - **< 5 minutos** → `active` → icono `●`
 - **5-15 minutos** → `idle` → icono `◐`
 - **> 15 minutos** → `stale` → icono `○`
-- **`status: "done"`** → sesion terminada → icono `✗` (mostrar solo si < 1 hora de antiguedad)
+- **`status: "done"`** → sesion terminada → icono `✗` (mostrar solo si < 15 minutos de antiguedad)
+- **`status: "active"`** con `last_activity_ts > 30 min` → omitir (zombie sin hook Stop)
+- **`status: "active"`** con `pid` y proceso muerto → omitir (zombie detectado por PID)
 
 Para identificar la sesion actual (la que ejecuta `/monitor`): lee `.claude/session-state.json` y usa `current_session` como ID de la sesion propia. Agrega `▶` al lado del icono de estado de esa sesion.
 
@@ -73,7 +75,7 @@ Genera el dashboard con este formato (ajustando ancho a ~70 columnas):
 **Reglas del panel SESIONES:**
 
 - Solo mostrar sesiones con `type: "parent"` (ignorar `type: "sub"`)
-- Columna "Agente": usar `agent_name` del JSON. Si es `null`, mostrar `Claude 🤖`
+- Columna "Agente": usar `agent_name` del JSON. Si es `null` y la branch tiene formato `agent/<N>-<slug>`, mostrar `Ad-hoc (#N)`. Si es `null` y branch es otra, mostrar `Claude 🤖`
 - Columna "Accs": valor de `action_count`
 - Columna "Dur.": duracion calculada desde `started_ts` hasta `last_activity_ts`
 - Columna "Ultima accion": `last_tool: last_target` truncado (ej: `Edit: LoginVM…`)
@@ -214,7 +216,8 @@ Muestra:
 - Cada sesion de Claude Code genera su propio archivo en `.claude/sessions/`
 - Sub-agentes (type: "sub") NO se muestran en el dashboard — su actividad incrementa `sub_count` en la sesion padre
 - La deteccion de liveness usa `last_activity_ts` del JSON de sesion (actualizado en cada PostToolUse por el hook)
-- Sesiones marcadas como `status: "done"` por el hook Stop se muestran con `✗` (solo si < 1h de antiguedad)
+- Sesiones marcadas como `status: "done"` por el hook Stop se muestran con `✗` (solo si < 15min de antiguedad)
+- Sesiones `"active"` sin actividad por >30 min o con PID muerto se omiten automáticamente (zombie)
 - `last_tool` y `last_target` muestran la ultima herramienta usada y su objetivo
 - `activity-log.jsonl` ahora incluye `session` (ID corto) en cada entrada
 - Para monitoreo en tiempo real con auto-refresh: `node .claude/dashboard.js` en terminal externa


### PR DESCRIPTION
## Resumen

El monitor (`/monitor`) muestra 8 sesiones cuando solo 1 está activa. Los umbrales de expiración son demasiado permisivos (2h para zombie, 1h para done), las sesiones de worktrees no se consolidaban, y las sesiones ad-hoc aparecían como "Claude" genérico.

## Cambios

- **activity-logger.js**:
  - Resolver REPO_ROOT al repo principal (no al worktree)
  - Persistir PID en sesión nueva (process.ppid)
  - Fallback agent_name desde branch (Ad-hoc #N para sesiones sin Skill)

- **dashboard.js**:
  - Reducir umbrales: 15 min para done (era 1h), 30 min para stale (era 2h)
  - Nueva función getLiveClaudePids() para detectar zombies por PID
  - Cruce PID en loadSessions() — omitir sesiones sin proceso vivo
  - Escaneo de worktrees con discoverWorktreeSessions()

- **stop-notify.js**:
  - Reducir MAX_AGE_MS: 2h cleanup (era 24h) — safety net de disco

- **SKILL.md**:
  - Sincronizar reglas de liveness con código
  - Documentar detección de zombies por PID
  - Actualizar identificación de agentes ad-hoc

## Verificación

- [ ] Monitor muestra solo sesiones recientes (< 15 min done, < 30 min stale)
- [ ] Sesiones sin proceso vivo (zombie) se omiten
- [ ] Sesiones de worktrees se consolidan
- [ ] Branch `agent/N-slug` muestra como `Ad-hoc (#N)`

Closes #1078

🤖 Generado con [Claude Code](https://claude.ai/claude-code)