### PR TITLE
feat: QA Validate — gate obligatorio para cierre de issues

### DIFF
--- a/.claude/skills/delivery/SKILL.md
+++ b/.claude/skills/delivery/SKILL.md
@@ -87,22 +87,54 @@ Basándote en el diff, clasificá:
 - `docs:` — solo documentación
 - `chore:` — tareas de mantenimiento
 
-## Paso 3.5: Verificar QA E2E
+## Paso 3.5: Verificar QA E2E (gate obligatorio)
 
-Antes de crear el PR, verificar si hay resultados recientes de QA:
+Antes de crear el PR, verificar que QA validó el issue:
+
+### 3.5.1: Extraer issue number del branch
 
 ```bash
-# Buscar resultados de tests QA recientes (ultimas 2 horas)
+BRANCH=$(git branch --show-current)
+ISSUE_NUM=$(echo "$BRANCH" | sed -E 's/(agent|codex)\/([0-9]+).*/\2/')
+```
+
+### 3.5.2: Buscar qa-report.json
+
+Si se pudo extraer `ISSUE_NUM` (no vacío y numérico):
+
+```bash
+QA_REPORT="qa/evidence/$ISSUE_NUM/qa-report.json"
+[ -f "$QA_REPORT" ] && cat "$QA_REPORT" || echo "NO_REPORT"
+```
+
+**Evaluar resultado:**
+
+- Si **existe** y `verdict == "APROBADO"`:
+  - Continuar normalmente
+  - Agregar al body del PR: `QA Validate #<issue>: APROBADO ✅ — [ver reporte](qa/evidence/<issue>/qa-report.json)`
+  - Incluir resumen de tests: `Tests: <generated_passed>/<generated_executed> generados + <pre_existing_passed>/<pre_existing_executed> regresión`
+
+- Si **existe** y `verdict == "RECHAZADO"`:
+  - **BLOQUEAR**: "QA Validate #<issue> RECHAZADO ❌ — corregir los fallos y re-ejecutar `/qa validate <issue>`"
+  - Mostrar `verdict_reason` del reporte
+  - NO continuar. NO ofrecer saltear.
+
+- Si **NO existe** (`NO_REPORT`):
+  - **BLOQUEAR**: "No se encontró qa-report.json para issue #<issue>. Ejecutar `/qa validate <issue>` antes de delivery."
+  - NO continuar hasta que el usuario confirme explícitamente que quiere saltear QA.
+  - Si el usuario confirma saltear, agregar al body del PR: `QA Validate: omitido por decisión del usuario ⚠️`
+
+### 3.5.3: Fallback (sin issue number)
+
+Si NO se pudo extraer `ISSUE_NUM` del branch (branch no sigue convención `agent/<N>-*`):
+
+Usar el check legacy:
+```bash
 find qa/build/test-results/test -name "*.xml" -mmin -120 2>/dev/null | head -5
 ```
 
-- Si **NO hay resultados** de QA recientes (directorio vacio o archivos antiguos):
-  - BLOQUEAR: "No se detectaron tests E2E recientes. Ejecuta /qa antes de crear el PR."
-  - NO continuar hasta que el usuario confirme explicitamente que quiere saltear QA.
-  - Si el usuario confirma saltear, agregar al body del PR: `QA E2E: omitido por decision del usuario`
-
-- Si **HAY resultados** recientes: agregar al body del PR la linea:
-  `QA E2E: tests ejecutados [fecha del ultimo resultado]`
+- Si hay resultados recientes: `QA E2E: tests ejecutados [fecha]`
+- Si no hay resultados: BLOQUEAR como antes (pedir `/qa` o confirmación del usuario)
 
 ## Paso 4: Stage y commit
 

--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -1,8 +1,8 @@
 ---
 description: QA — Tests E2E contra entorno real con video y reporte de calidad
 user-invocable: true
-argument-hint: "[api|desktop|android|all] [--skip-env] [--keep-env]"
-allowed-tools: Bash, Read, Grep, Glob, TaskCreate, TaskUpdate, TaskList
+argument-hint: "[api|desktop|android|all|validate <issue-number>] [--skip-env] [--keep-env]"
+allowed-tools: Bash, Read, Write, Grep, Glob, TaskCreate, TaskUpdate, TaskList
 model: claude-sonnet-4-6
 ---
 
@@ -15,8 +15,16 @@ No aprobás nada sin haberlo probado de punta a punta.
 ## Argumentos
 
 - `[plataforma]` — Qué tests correr: `api` (default), `desktop`, `android`, `all`
+- `validate <issue-number>` — Modo validación: lee el issue, genera tests efímeros, ejecuta, genera reporte
 - `--skip-env` — No levantar entorno (asumir que ya está corriendo). Solo aplica a `api`.
 - `--keep-env` — No tirar abajo el entorno al terminar. Solo aplica a `api`.
+
+## Detección de modo
+
+Al iniciar, parsear el primer argumento:
+
+- Si el primer argumento es `validate` → ejecutar **flujo de validación** (Pasos V1-V8 abajo). El segundo argumento es el `<issue-number>`.
+- Si el primer argumento es otra cosa (`api`, `desktop`, `android`, `all`) o no hay argumentos → ejecutar **flujo original** (Pasos 1-5 de siempre, sin cambios).
 
 ## Pre-flight: Registrar tareas
 
@@ -166,6 +174,315 @@ No hay cleanup necesario.
 ### Veredicto
 [Aprobado para PR | Correcciones requeridas]
 ```
+
+---
+
+# Flujo de validación (`validate <issue-number>`)
+
+Este flujo se ejecuta SOLO cuando el primer argumento es `validate`. El flujo original (Pasos 1-5) NO se modifica.
+
+## Paso V1: Leer issue de GitHub
+
+```bash
+export PATH="/c/Workspaces/gh-cli/bin:$PATH"
+ISSUE_NUM=<issue-number>
+gh issue view "$ISSUE_NUM" --repo intrale/platform --json title,body,labels
+```
+
+Del body del issue, extraer:
+- **Título** del issue
+- **Criterios de aceptación** (buscar secciones como "Criterios de aceptación", "Acceptance criteria", listas con checkbox `- [ ]`, o condiciones en el body)
+- Si el issue NO tiene criterios de aceptación explícitos, anotar que se generarán tests básicos desde el diff (Paso V2)
+
+## Paso V2: Analizar diff contra main
+
+```bash
+git diff origin/main...HEAD --stat
+git diff origin/main...HEAD --name-only
+```
+
+Clasificar los archivos modificados por capa:
+- **backend/users** (`backend/`, `users/`) → se necesitan tests API
+- **app UI** (`app/composeApp/`) → se necesitan flows Maestro
+- **docs/config** (`.md`, `.json`, `.toml`, `.gradle.kts`, `.claude/`) → sin cambios funcionales
+- **qa/tools/buildSrc** → infraestructura, no requiere tests funcionales
+
+Si TODOS los cambios son docs/config/infra:
+- Generar `qa-report.json` con `verdict: "APROBADO"` y `verdict_reason: "Sin cambios funcionales — solo docs/config/infra"`
+- Saltar a Paso V7 directamente
+
+## Paso V3: Generar tests API (si hay cambios backend/users)
+
+Crear directorio y tests en `qa/generated/api/`:
+
+```bash
+mkdir -p qa/generated/api
+```
+
+Para cada endpoint modificado/agregado en el diff, generar un archivo Kotlin siguiendo el patrón de `ApiSignInE2ETest.kt`:
+
+**Patrón del test generado:**
+```kotlin
+package ar.com.intrale.e2e.generated
+
+import ar.com.intrale.e2e.QATestBase
+import com.microsoft.playwright.options.RequestOptions
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestMethodOrder
+import kotlin.test.assertTrue
+
+@DisplayName("E2E Validate #<issue> — <endpoint> contra backend real")
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
+class Api<Endpoint>ValidateE2ETest : QATestBase() {
+
+    @Test
+    @Order(1)
+    @DisplayName("POST /intrale/<endpoint> con datos válidos responde 200")
+    fun `<endpoint> happy path responde 200`() {
+        val response = apiContext.post(
+            "/intrale/<endpoint>",
+            RequestOptions.create()
+                .setHeader("Content-Type", "application/json")
+                .setData(mapOf(/* datos válidos según el issue */))
+        )
+        logger.info("<Endpoint> happy path: status=${response.status()}")
+        assertTrue(response.status() in 200..299,
+            "<Endpoint> con datos válidos debe responder 2xx. Actual: ${response.status()}")
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("POST /intrale/<endpoint> sin body responde 400")
+    fun `<endpoint> sin body responde 400`() {
+        val response = apiContext.post(
+            "/intrale/<endpoint>",
+            RequestOptions.create()
+                .setHeader("Content-Type", "application/json")
+                .setData("")
+        )
+        logger.info("<Endpoint> sin body: status=${response.status()}")
+        assertTrue(response.status() in 400..499,
+            "<Endpoint> sin body debe responder 4xx. Actual: ${response.status()}")
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("POST /intrale/<endpoint> sin token responde 401")
+    fun `<endpoint> sin token responde 401`() {
+        // Solo para SecuredFunction — omitir si es función pública
+        val response = apiContext.post(
+            "/intrale/<endpoint>",
+            RequestOptions.create()
+                .setHeader("Content-Type", "application/json")
+                .setData(mapOf(/* datos válidos */))
+                // Sin header Authorization
+        )
+        logger.info("<Endpoint> sin token: status=${response.status()}")
+        assertTrue(response.status() in 400..499,
+            "<Endpoint> sin token debe responder 4xx. Actual: ${response.status()}")
+    }
+}
+```
+
+**Reglas de generación:**
+- Usar `Write` tool para crear cada archivo `.kt` en `qa/generated/api/`
+- Package: `ar.com.intrale.e2e.generated`
+- Clase extiende `QATestBase()` (reutiliza Playwright context)
+- Nombre de clase: `Api<Endpoint>ValidateE2ETest`
+- Generar mínimo: happy path (200), sin body (400), sin token (401) por endpoint
+- Adaptar datos del body según lo que el diff muestra (clases de request, campos requeridos)
+- Si el endpoint es `Function` (pública, no JWT): omitir test de "sin token"
+- Si el endpoint es `SecuredFunction` (requiere JWT): incluir test de "sin token"
+
+## Paso V4: Generar flows Maestro (si hay cambios UI app)
+
+Crear directorio y flows en `qa/generated/maestro/`:
+
+```bash
+mkdir -p qa/generated/maestro
+```
+
+Para cada pantalla/flujo modificado en el diff, generar un archivo YAML siguiendo el patrón de `login.yaml`:
+
+**Patrón del flow generado:**
+```yaml
+appId: com.intrale.app.client
+---
+# Flujo: Validación #<issue> — <descripción>
+- launchApp
+- waitForAnimationToEnd
+
+# Navegación al punto de entrada
+- tapOn:
+    text: "<texto de navegación>"
+    optional: true
+- waitForAnimationToEnd
+
+# Interacción con la funcionalidad
+- tapOn:
+    id: "<testId del componente>"
+- inputText: "<datos de prueba>"
+
+# Verificación
+- assertVisible:
+    text: "<texto esperado>"
+```
+
+**Reglas de generación:**
+- Usar `Write` tool para crear cada archivo `.yaml` en `qa/generated/maestro/`
+- Nombre: `validate-<issue>-<descripción>.yaml`
+- Usar `id:` (testId) de los componentes Compose cuando estén disponibles en el diff
+- Si no hay testIds, usar `text:` con los labels visibles
+- Cada flow debe ser autocontenido (comienza con `launchApp`)
+
+## Paso V5: Setup entorno
+
+Mismo que Paso 1 del flujo original:
+
+```bash
+export JAVA_HOME="/c/Users/Administrator/.jdks/temurin-21.0.7"
+```
+
+### Verificar backend (si hay tests API):
+
+```bash
+STATUS=$(curl -so /dev/null -w '%{http_code}' -X POST http://localhost:80/intrale/signin -H 'Content-Type: application/json' -d '{}' 2>/dev/null)
+[ "$STATUS" = "400" ] && echo "BACKEND_UP" || echo "BACKEND_DOWN"
+```
+
+Si `BACKEND_DOWN`, levantar:
+```bash
+bash qa/scripts/qa-env-up.sh
+```
+
+## Paso V6: Ejecutar tests
+
+### Tests API generados + pre-existentes (regresión):
+
+```bash
+export JAVA_HOME="/c/Users/Administrator/.jdks/temurin-21.0.7" && \
+  export QA_BASE_URL="http://localhost:80" && \
+  ./gradlew :qa:test --info 2>&1 | tail -80
+```
+
+Esto ejecuta tanto los tests en `src/test/kotlin/` (regresión) como los generados en `generated/api/` (validación del issue).
+
+### Flows Maestro generados (si hay):
+
+```bash
+# Verificar que hay emulador conectado
+adb devices | grep -v "List" | grep -v "^$" | head -1
+```
+
+Si hay emulador:
+```bash
+maestro test qa/generated/maestro/ --format junit --output qa/recordings/maestro-validate-results.xml
+```
+
+Si NO hay emulador: anotar en el reporte pero NO bloquear el veredicto.
+
+## Paso V7: Generar reporte y evidencia
+
+Crear directorio de evidencia:
+```bash
+mkdir -p qa/evidence/$ISSUE_NUM
+```
+
+Copiar artefactos relevantes:
+```bash
+# Reportes HTML de tests API
+cp -r qa/build/reports/tests/test/ qa/evidence/$ISSUE_NUM/api/ 2>/dev/null || true
+# Traces de Playwright
+cp qa/recordings/*-trace.zip qa/evidence/$ISSUE_NUM/ 2>/dev/null || true
+# Resultados Maestro
+cp qa/recordings/maestro-validate-results.xml qa/evidence/$ISSUE_NUM/ 2>/dev/null || true
+# Videos de Maestro
+cp -r qa/recordings/*.mp4 qa/evidence/$ISSUE_NUM/ 2>/dev/null || true
+```
+
+Generar `qa/evidence/<issue>/qa-report.json` con la estructura:
+
+```json
+{
+  "issue_number": <N>,
+  "issue_title": "<título del issue>",
+  "branch": "<branch actual>",
+  "timestamp": "<ISO 8601>",
+  "acceptance_criteria": ["criterio 1", "criterio 2"],
+  "test_cases": [
+    {
+      "id": "tc-1",
+      "criterion": "criterio 1",
+      "type": "api",
+      "file": "qa/generated/api/ApiXxxValidateE2ETest.kt",
+      "tests": [
+        { "name": "nombre del test", "result": "PASSED" }
+      ]
+    }
+  ],
+  "pre_existing_tests": { "executed": 0, "passed": 0, "failed": 0 },
+  "generated_tests": { "executed": 0, "passed": 0, "failed": 0 },
+  "evidence": {
+    "videos": [],
+    "traces": [],
+    "html_report": "qa/evidence/<issue>/api/index.html"
+  },
+  "verdict": "APROBADO|RECHAZADO",
+  "verdict_reason": "Texto explicativo"
+}
+```
+
+**Lógica del veredicto:**
+- `APROBADO` si: todos los tests generados pasan Y todos los tests pre-existentes pasan (regresión)
+- `RECHAZADO` si: algún test generado falla O algún test pre-existente falla
+- Rellenar `test_cases` mapeando cada criterio de aceptación al test que lo valida
+- Rellenar contadores `pre_existing_tests` y `generated_tests` parseando la salida de Gradle
+- Rellenar `evidence` con las rutas reales de los artefactos copiados
+
+Usar `Write` tool para crear el `qa-report.json`.
+
+## Paso V8: Reporte final
+
+```
+## Veredicto QA Validate #<issue>: APROBADO | RECHAZADO
+
+### Issue
+- #<N>: <título>
+
+### Criterios de aceptación
+| # | Criterio | Test | Resultado |
+|---|----------|------|-----------|
+| 1 | criterio 1 | ApiXxxValidateE2ETest | PASSED |
+| 2 | criterio 2 | validate-N-desc.yaml | PASSED |
+
+### Tests ejecutados
+- Pre-existentes (regresión): X pasaron, Y fallaron de Z total
+- Generados (validación): X pasaron, Y fallaron de Z total
+- Maestro: X pasaron, Y fallaron de Z total (o N/A)
+
+### Evidencia
+- Reporte: qa/evidence/<issue>/qa-report.json
+- HTML: qa/evidence/<issue>/api/index.html
+- Traces: qa/evidence/<issue>/*.zip
+
+### Veredicto
+[APROBADO: todos los criterios validados | RECHAZADO: detalle de fallos]
+```
+
+Limpiar entorno (si se levantó en V5):
+```bash
+bash qa/scripts/qa-env-down.sh
+```
+
+Limpiar tests generados:
+```bash
+rm -rf qa/generated/api/ qa/generated/maestro/
+```
+
+---
 
 ## Reglas
 

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,9 @@ deps_commonMain.txt
 qa/recordings/
 qa/.backend.pid
 
+# QA E2E — tests generados (efímeros, se regeneran con /qa validate)
+qa/generated/
+
 # QA E2E — evidencias versionadas (NO ignorar)
 !qa/evidence/
 .maestro/tests/

--- a/qa/build.gradle.kts
+++ b/qa/build.gradle.kts
@@ -2,7 +2,14 @@ plugins {
     alias(libs.plugins.kotlin.jvm)
 }
 
-kotlin { jvmToolchain(21) }
+kotlin {
+    jvmToolchain(21)
+    sourceSets {
+        test {
+            kotlin.srcDirs("src/test/kotlin", "generated/api")
+        }
+    }
+}
 
 tasks.withType<Test> {
     useJUnitPlatform()


### PR DESCRIPTION
## Resumen

- Agrega modo `validate <issue>` al skill `/qa` con pasos V1-V8: lee issue, genera tests efímeros (API Playwright + Maestro YAML), ejecuta contra entorno real, y persiste `qa-report.json`
- Modifica `/delivery` paso 3.5 para usar `qa-report.json` como gate obligatorio (APROBADO/RECHAZADO/no-existe)
- Configura `qa/build.gradle.kts` con source set para tests generados en `generated/api/`
- Agrega `qa/generated/` a `.gitignore` (tests efímeros, se regeneran cada vez)

## Archivos modificados

| Archivo | Cambio |
|---------|--------|
| `.claude/skills/qa/SKILL.md` | Modo validate, Write en allowed-tools, pasos V1-V8 |
| `.claude/skills/delivery/SKILL.md` | Gate con qa-report.json + fallback legacy |
| `qa/build.gradle.kts` | Source set `generated/api` para tests efímeros |
| `.gitignore` | Excluir `qa/generated/` |

## Plan de tests

- [x] `qa/generated/` no aparece en `git status`
- [x] Flujo original de `/qa` (api/desktop/android/all) no se modifica
- [x] Delivery tiene 3 niveles: APROBADO → continúa, RECHAZADO → bloquea, no-existe → bloquea con opción

QA Validate: omitido — cambios solo en docs/config/infra (skills + gitignore + build config) ⚠️

🤖 Generado con [Claude Code](https://claude.ai/claude-code)