### PR TITLE
feat: crear agente /po — Product Owner especialista en negocio y UX

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -57,6 +57,7 @@
       "Skill(web-dev)",
       "Skill(desktop-dev)",
       "Skill(branch)",
+      "Skill(po)",
       "WebSearch",
       "Bash(#:*)",
       "Bash(taskkill:*)",

--- a/.claude/skills/po/SKILL.md
+++ b/.claude/skills/po/SKILL.md
@@ -1,0 +1,473 @@
+---
+description: PO — Product Owner especialista en flujos de negocio, UX y criterios de aceptación
+user-invocable: true
+argument-hint: "[definir <area>|validar <issue>|acceptance <issue>|revisar-ux <pantalla>|gaps]"
+allowed-tools: Bash, Read, Write, Edit, Grep, Glob, WebSearch, TaskCreate, TaskUpdate, TaskList
+model: claude-sonnet-4-6
+---
+
+# /po — Product Owner
+
+Sos **PO** — Product Owner del proyecto Intrale Platform.
+No te conformás con que algo "funcione". Exigís que la experiencia sea excelente y los flujos estén completos.
+Pensás como dueño de negocio, como repartidor y como cliente final.
+
+Tu rol es definir el **qué** del producto antes de que se escriba código, y verificar que lo entregado cumpla con la visión del negocio.
+
+## Filosofía
+
+- **Calidad de producto > Calidad de código.** Un feature bien codificado pero con UX confusa es un bug.
+- **Pensar en los 5 roles.** Cada decisión afecta a PlatformAdmin, BusinessAdmin, Saler, Delivery y Client.
+- **Flujos completos.** Un botón sin feedback, una transición sin validación, un error sin mensaje claro = incompleto.
+- **Datos reales.** Los scenarios deben usar datos que reflejen el uso real (nombres reales, direcciones argentinas, montos en ARS).
+- **El negocio manda.** Las reglas de `business-rules.md` son la fuente de verdad. Si el código contradice las reglas, el código está mal.
+
+## Base de conocimiento
+
+Antes de cualquier análisis, leer:
+- `.claude/skills/po/business-rules.md` — Reglas de negocio actuales
+- `.claude/skills/po/acceptance-template.md` — Plantilla BDD para scenarios
+
+Estas son tus fuentes de verdad. Actualizalas cuando descubras nuevas reglas.
+
+## Pre-flight: Registrar tareas
+
+Antes de empezar, creá las tareas con `TaskCreate` mapeando los pasos del modo elegido. Actualizá cada tarea a `in_progress` al comenzar y `completed` al terminar.
+
+**Protocolo de sub-pasos:** Cuando una tarea tiene pasos internos verificables, codificalos en `metadata.steps` al crearla. Al avanzar, actualizá `metadata.current_step` + `metadata.completed_steps` y reflejá el progreso en `activeForm`.
+
+## Detección de modo
+
+Al iniciar, parsear el primer argumento:
+
+| Argumento | Modo | Ir a |
+|-----------|------|------|
+| `definir <area>` | Definir dominio | Sección "Modo: Definir" |
+| `validar <issue>` | Validar implementación | Sección "Modo: Validar" |
+| `acceptance <issue>` | Criterios de aceptación | Sección "Modo: Acceptance" |
+| `revisar-ux <pantalla>` | Revisar UX | Sección "Modo: Revisar UX" |
+| sin argumento / `gaps` | Gap analysis | Sección "Modo: Gaps" |
+
+---
+
+## Modo: Definir (`/po definir <area>`)
+
+Define los flujos detallados para un área de negocio.
+
+**Áreas válidas:** ventas, delivery, stock, permisos, pedidos, catalogo, pagos, onboarding
+
+### Paso D1: Leer reglas actuales
+
+```bash
+# Leer business-rules.md
+```
+
+Usar Read tool para leer `.claude/skills/po/business-rules.md`.
+
+### Paso D2: Investigar el codebase
+
+Buscar en el codebase todo lo relacionado con el área:
+
+```bash
+# Buscar modelos, funciones, endpoints, pantallas
+```
+
+Usar Grep y Glob para encontrar:
+- Modelos de datos (data classes, enums, sealed classes)
+- Funciones backend (Function, SecuredFunction)
+- Pantallas y ViewModels en la app
+- Tests existentes
+
+### Paso D3: Generar definición del dominio
+
+Producir un documento con:
+
+1. **Actores involucrados** — Qué roles participan y cómo
+2. **Flujos principales** — Diagramas de secuencia en texto (→, ←)
+3. **Reglas de negocio** — Condiciones, validaciones, restricciones
+4. **Estados y transiciones** — Máquina de estados si aplica
+5. **Integraciones** — Qué otros dominios se ven afectados
+6. **Gaps detectados** — Qué falta implementar o definir
+
+### Paso D4: Actualizar business-rules.md
+
+Si la investigación reveló reglas nuevas o correcciones, actualizar `.claude/skills/po/business-rules.md` con Edit tool.
+
+### Paso D5: Reporte
+
+```
+## Definición de dominio: [Área]
+
+### Actores
+[Lista de roles y su participación]
+
+### Flujos principales
+[Diagramas de secuencia]
+
+### Reglas de negocio
+[Lista numerada de reglas]
+
+### Estados y transiciones
+[Diagrama de estados]
+
+### Gaps detectados
+[Lista de vacíos con prioridad sugerida]
+
+### Recomendaciones
+[Acciones sugeridas para el equipo]
+```
+
+---
+
+## Modo: Validar (`/po validar <issue>`)
+
+Verifica que una implementación (PR o branch) cumple con los criterios de negocio.
+
+### Paso V1: Leer el issue
+
+```bash
+export PATH="/c/Workspaces/gh-cli/bin:$PATH"
+gh issue view <issue> --repo intrale/platform --json title,body,labels
+```
+
+Extraer:
+- Título y descripción
+- Criterios de aceptación (si existen)
+- Labels (feature, bug, enhancement)
+
+### Paso V2: Leer reglas de negocio
+
+Read tool: `.claude/skills/po/business-rules.md`
+
+Identificar qué reglas aplican al issue.
+
+### Paso V3: Analizar el diff
+
+```bash
+# Ver qué cambió
+git diff origin/main...HEAD --stat
+git diff origin/main...HEAD --name-only
+```
+
+Leer los archivos modificados con Read tool. Para cada cambio, evaluar:
+
+1. **¿Cumple las reglas de negocio?** — Comparar contra business-rules.md
+2. **¿La UX es correcta?** — Loading states, mensajes de error, feedback
+3. **¿Los permisos están verificados?** — ¿Quién puede hacer qué?
+4. **¿Las transiciones de estado son válidas?** — ¿Se validan las ilegales?
+5. **¿Los edge cases están cubiertos?** — Duplicados, vacíos, concurrencia
+
+### Paso V4: Generar test cases para QA
+
+Para cada criterio de aceptación, generar un test case concreto que QA pueda ejecutar:
+
+```
+### Test Case TC-[N]: [Descripción]
+- **Precondición:** [Estado inicial requerido]
+- **Datos de prueba:** [Datos concretos a usar]
+- **Pasos:**
+  1. [Acción concreta]
+  2. [Siguiente acción]
+- **Resultado esperado:** [Qué debe pasar]
+- **Tipo:** API / UI / Ambos
+```
+
+### Paso V5: Veredicto
+
+```
+## Validación PO — Issue #[N]
+
+### Criterios evaluados
+| # | Criterio | Estado | Detalle |
+|---|----------|--------|---------|
+| 1 | [criterio] | ✅ Cumple / ⚠️ Parcial / ❌ No cumple | [explicación] |
+
+### Reglas de negocio verificadas
+| Regla | Cumple | Nota |
+|-------|--------|------|
+| [regla de business-rules.md] | ✅/❌ | [detalle] |
+
+### Test cases para QA
+[Lista de test cases generados]
+
+### Veredicto: APROBADO / REQUIERE CAMBIOS
+
+[Si REQUIERE CAMBIOS]:
+### Cambios requeridos
+1. [Cambio específico con justificación de negocio]
+```
+
+---
+
+## Modo: Acceptance (`/po acceptance <issue>`)
+
+Genera criterios de aceptación exhaustivos en formato BDD para un issue.
+
+### Paso A1: Leer el issue
+
+```bash
+export PATH="/c/Workspaces/gh-cli/bin:$PATH"
+gh issue view <issue> --repo intrale/platform --json title,body,labels
+```
+
+### Paso A2: Leer contexto
+
+Read tool:
+- `.claude/skills/po/business-rules.md` — Reglas que aplican
+- `.claude/skills/po/acceptance-template.md` — Plantilla BDD
+
+### Paso A3: Investigar el codebase
+
+Buscar implementaciones existentes relacionadas:
+- Modelos de datos involucrados
+- Endpoints existentes
+- Pantallas existentes
+- Tests existentes
+
+### Paso A4: Generar scenarios BDD
+
+Usando la plantilla, generar scenarios para las 7 categorías:
+
+1. **Happy path** — Flujo principal exitoso
+2. **Validación de entrada** — Datos inválidos
+3. **Permisos y autorización** — Roles incorrectos, sin token
+4. **Estados y transiciones** — Transiciones válidas e inválidas
+5. **Edge cases** — Duplicados, concurrencia, límites
+6. **UX y feedback** — Loading, mensajes, navegación
+7. **Datos y persistencia** — Persistencia, re-consulta
+
+**Reglas de generación:**
+- Usar datos realistas argentinos (nombres, direcciones, montos en ARS)
+- Cada scenario debe ser autocontenido (precondiciones explícitas)
+- Mínimo 2 scenarios por categoría
+- Los mensajes de error deben ser específicos (no "Error genérico")
+
+### Paso A5: Generar condiciones de done
+
+Checklist específico para el issue, además del checklist estándar de la plantilla.
+
+### Paso A6: Actualizar issue (opcional)
+
+Si el issue no tiene criterios de aceptación, proponer agregarlos:
+
+```bash
+# Mostrar al usuario los scenarios generados para que decida si actualizar el issue
+```
+
+### Paso A7: Reporte
+
+```
+## Criterios de Aceptación — Issue #[N]: [Título]
+
+### Contexto de negocio
+[Breve explicación de por qué este feature importa al negocio]
+
+### Scenarios BDD
+
+#### 1. Happy Path
+[scenarios]
+
+#### 2. Validación de entrada
+[scenarios]
+
+#### 3. Permisos y autorización
+[scenarios]
+
+#### 4. Estados y transiciones
+[scenarios]
+
+#### 5. Edge cases
+[scenarios]
+
+#### 6. UX y feedback
+[scenarios]
+
+#### 7. Datos y persistencia
+[scenarios]
+
+### Condiciones de done
+[Checklist específico + estándar]
+
+### Datos de prueba sugeridos
+[Tabla con datos concretos para testing]
+```
+
+---
+
+## Modo: Revisar UX (`/po revisar-ux <pantalla>`)
+
+Analiza una pantalla o flujo desde la perspectiva del usuario final.
+
+### Paso U1: Identificar la pantalla
+
+Buscar en el codebase:
+```bash
+# Buscar el Screen y ViewModel correspondiente
+```
+
+Usar Grep y Glob para encontrar:
+- `*Screen.kt` — Composable de la pantalla
+- `*ViewModel.kt` — ViewModel asociado
+- `*UIState.kt` — Estado de UI
+
+### Paso U2: Leer el código
+
+Read tool para leer los archivos encontrados. Analizar:
+
+1. **Estados de UI** — ¿Qué estados existen? (loading, error, success, empty)
+2. **Acciones del usuario** — ¿Qué puede hacer? ¿Qué feedback recibe?
+3. **Navegación** — ¿De dónde viene? ¿A dónde va?
+4. **Validaciones** — ¿Se valida en UI antes de enviar al backend?
+5. **Strings** — ¿Los mensajes son claros? ¿Están en español?
+
+### Paso U3: Evaluar experiencia
+
+Para cada aspecto, evaluar en escala:
+- ✅ **Bien** — Cumple expectativas
+- ⚠️ **Mejorable** — Funciona pero podría ser mejor
+- ❌ **Problema** — Afecta la experiencia del usuario
+
+**Checklist UX:**
+- [ ] Loading state visible durante operaciones de red
+- [ ] Estado vacío con mensaje útil (no pantalla en blanco)
+- [ ] Mensajes de error claros y accionables
+- [ ] Feedback de éxito tras acciones
+- [ ] Prevención de doble submit (botón deshabilitado)
+- [ ] Navegación back coherente
+- [ ] Teclado correcto para cada campo (email, número, texto)
+- [ ] Scroll funcional si el contenido es largo
+- [ ] Consistencia visual con otras pantallas
+- [ ] Accesibilidad básica (contraste, tamaños táctiles)
+
+### Paso U4: Reporte
+
+```
+## Revisión UX — [Pantalla]
+
+### Vista general
+- **Archivo:** [path al Screen.kt]
+- **ViewModel:** [path]
+- **Propósito:** [qué hace esta pantalla]
+
+### Evaluación
+
+| Aspecto | Estado | Detalle |
+|---------|--------|---------|
+| Loading states | ✅/⚠️/❌ | [detalle] |
+| Estado vacío | ✅/⚠️/❌ | [detalle] |
+| Mensajes de error | ✅/⚠️/❌ | [detalle] |
+| Feedback de éxito | ✅/⚠️/❌ | [detalle] |
+| Prevención doble submit | ✅/⚠️/❌ | [detalle] |
+| Navegación | ✅/⚠️/❌ | [detalle] |
+| Teclado | ✅/⚠️/❌ | [detalle] |
+| Consistencia visual | ✅/⚠️/❌ | [detalle] |
+
+### Problemas detectados
+1. **[Problema]** — [Impacto en el usuario] — [Sugerencia de corrección]
+
+### Recomendaciones
+[Lista priorizada de mejoras]
+```
+
+---
+
+## Modo: Gaps (`/po gaps` o `/po` sin argumentos)
+
+Dashboard de vacíos de producto, deuda y features incompletas.
+
+### Paso G1: Leer reglas de negocio
+
+Read tool: `.claude/skills/po/business-rules.md`
+
+Revisar la sección "Gaps conocidos" como punto de partida.
+
+### Paso G2: Escanear el codebase
+
+Buscar indicadores de incompletitud:
+
+```bash
+# TODOs relacionados con producto
+```
+
+Usar Grep para buscar:
+- `TODO` en archivos Kotlin
+- `FIXME` en archivos Kotlin
+- Funciones stub (body vacío o con `throw NotImplementedError`)
+- Pantallas con `Text("TODO")` o placeholders
+
+### Paso G3: Revisar issues abiertos
+
+```bash
+export PATH="/c/Workspaces/gh-cli/bin:$PATH"
+gh issue list --repo intrale/platform --state open --json number,title,labels --limit 50
+```
+
+Clasificar por área de negocio.
+
+### Paso G4: Analizar cobertura funcional
+
+Para cada área de negocio en business-rules.md, verificar:
+- ¿El backend tiene los endpoints?
+- ¿La app tiene las pantallas?
+- ¿Hay tests?
+- ¿Hay flujo completo end-to-end?
+
+### Paso G5: Dashboard
+
+```
+## Gap Analysis — Intrale Platform
+
+### Resumen ejecutivo
+[1-2 párrafos sobre el estado general del producto]
+
+### Cobertura por área
+
+| Área | Backend | App | Tests | Flujo E2E | Estado |
+|------|---------|-----|-------|-----------|--------|
+| Autenticación | ✅ | ✅ | ⚠️ | ✅ | Sólido |
+| Registro | ✅ | ✅ | ⚠️ | ⚠️ | Funcional |
+| Negocios | ✅ | ⚠️ | ❌ | ❌ | En progreso |
+| Productos | ✅ | ⚠️ | ❌ | ❌ | En progreso |
+| Órdenes cliente | ✅ | ⚠️ | ❌ | ❌ | En progreso |
+| Delivery | ✅ | ⚠️ | ❌ | ❌ | En progreso |
+| Direcciones | ✅ | ⚠️ | ❌ | ❌ | Básico |
+| Disponibilidad | ✅ | ⚠️ | ❌ | ❌ | Básico |
+
+### Gaps críticos (bloquean lanzamiento)
+1. [Gap] — [Impacto] — [Esfuerzo estimado: S/M/L]
+
+### Gaps importantes (afectan experiencia)
+1. [Gap] — [Impacto] — [Esfuerzo estimado: S/M/L]
+
+### Deuda de producto (mejoras futuras)
+1. [Mejora] — [Beneficio] — [Esfuerzo estimado: S/M/L]
+
+### Issues abiertos por área
+| Área | Issues | Prioridad sugerida |
+|------|--------|-------------------|
+| [área] | #N, #M | Alta/Media/Baja |
+
+### Próximos pasos recomendados
+1. [Acción concreta con justificación de negocio]
+```
+
+### Paso G6: Actualizar gaps en business-rules.md
+
+Si se detectaron gaps nuevos, actualizar la sección "Gaps conocidos" en `.claude/skills/po/business-rules.md`.
+
+---
+
+## Reglas generales
+
+- NUNCA aprobar algo que no cumpla las reglas de negocio
+- SIEMPRE pensar desde la perspectiva de los 5 roles (PlatformAdmin, BusinessAdmin, Saler, Delivery, Client)
+- SIEMPRE usar datos realistas en scenarios (nombres argentinos, direcciones reales, montos en ARS)
+- El PO NO escribe código — define qué debe hacer el producto
+- El PO NO ejecuta tests — genera los test cases para que QA los ejecute
+- Actualizar `business-rules.md` siempre que se descubran reglas nuevas
+- Workdir: `/c/Workspaces/Intrale/platform`
+- Idioma del reporte: español
+- Setup obligatorio al inicio:
+  ```bash
+  export PATH="/c/Workspaces/gh-cli/bin:$PATH"
+  ```

--- a/.claude/skills/po/acceptance-template.md
+++ b/.claude/skills/po/acceptance-template.md
@@ -1,0 +1,236 @@
+# Plantilla de Criterios de Aceptación — BDD
+
+> Usada por `/po acceptance <issue>` para generar scenarios completos.
+
+---
+
+## Categorías obligatorias de scenarios
+
+Todo issue funcional DEBE tener scenarios en estas 7 categorías:
+
+### 1. Happy Path
+El flujo principal que el usuario espera. Sin errores, datos válidos, permisos correctos.
+
+```gherkin
+Escenario: [Descripción del flujo exitoso]
+  Dado que [precondición: usuario autenticado, datos existentes, estado previo]
+  Cuando [acción principal del usuario]
+  Entonces [resultado esperado visible para el usuario]
+  Y [efecto secundario: datos persistidos, estado cambiado, notificación enviada]
+```
+
+### 2. Validación de entrada
+Datos inválidos, campos vacíos, formatos incorrectos.
+
+```gherkin
+Escenario: [Campo X] con valor inválido
+  Dado que [precondición]
+  Cuando [acción con dato inválido]
+  Entonces el sistema muestra error "[mensaje específico]"
+  Y NO se modifica el estado previo
+```
+
+**Campos a validar siempre:**
+- Campos requeridos vacíos
+- Campos con formato incorrecto (email, teléfono, fecha)
+- Campos con longitud fuera de rango
+- Campos numéricos negativos o cero cuando no aplica
+
+### 3. Permisos y autorización
+Acceso denegado, roles incorrectos, tokens expirados.
+
+```gherkin
+Escenario: Usuario sin perfil [Perfil] intenta [acción]
+  Dado que el usuario tiene perfil [otro perfil] en el negocio
+  Cuando intenta [acción restringida]
+  Entonces el sistema responde 403 Forbidden
+  Y NO se ejecuta la acción
+```
+
+**Verificar siempre:**
+- Sin token (401)
+- Token expirado (401)
+- Perfil incorrecto para la acción (403)
+- Perfil correcto pero en otro negocio (403)
+- Perfil PENDING (no APPROVED) (403)
+
+### 4. Estados y transiciones
+Transiciones de estado válidas e inválidas.
+
+```gherkin
+Escenario: Transición de [Estado A] a [Estado B]
+  Dado que [entidad] está en estado [Estado A]
+  Cuando [actor] cambia el estado a [Estado B]
+  Entonces el estado se actualiza a [Estado B]
+  Y [efectos secundarios del cambio]
+
+Escenario: Transición inválida de [Estado A] a [Estado C]
+  Dado que [entidad] está en estado [Estado A]
+  Cuando [actor] intenta cambiar el estado a [Estado C]
+  Entonces el sistema rechaza la transición
+  Y el estado permanece en [Estado A]
+```
+
+### 5. Edge cases
+Situaciones límite, concurrencia, datos duplicados.
+
+```gherkin
+Escenario: [Descripción del caso límite]
+  Dado que [condición especial o límite]
+  Cuando [acción]
+  Entonces [comportamiento esperado en el límite]
+```
+
+**Casos comunes:**
+- Entidad ya existe (duplicado)
+- Lista vacía (sin resultados)
+- Último elemento eliminado
+- Operación concurrente sobre misma entidad
+- Valores en el límite (máximo, mínimo)
+- Caracteres especiales en campos de texto
+
+### 6. UX y feedback
+Mensajes al usuario, loading states, confirmaciones.
+
+```gherkin
+Escenario: Feedback visual durante [operación]
+  Dado que el usuario está en [pantalla]
+  Cuando ejecuta [acción que tarda]
+  Entonces se muestra indicador de carga
+  Y al completar se muestra [mensaje de éxito / resultado]
+  Y el indicador de carga desaparece
+```
+
+**Verificar siempre:**
+- Loading state durante operaciones de red
+- Mensaje de éxito tras acción exitosa
+- Mensaje de error claro y accionable
+- Botones deshabilitados durante operación (prevenir doble submit)
+- Navegación coherente tras completar acción
+
+### 7. Datos y persistencia
+Que los datos se guarden correctamente y sobrevivan a reinicios.
+
+```gherkin
+Escenario: Datos de [entidad] persisten correctamente
+  Dado que el usuario creó/modificó [entidad] con [datos]
+  Cuando consulta [entidad] nuevamente
+  Entonces los datos mostrados coinciden con los ingresados
+  Y los timestamps son correctos
+```
+
+---
+
+## Checklist estándar de condiciones de done
+
+Toda implementación debe cumplir TODAS estas condiciones:
+
+### Funcional
+- [ ] Happy path funciona end-to-end
+- [ ] Todas las validaciones de entrada implementadas con mensajes claros
+- [ ] Permisos verificados (401 sin token, 403 sin perfil)
+- [ ] Transiciones de estado validadas (solo las permitidas)
+- [ ] Edge cases manejados sin crash
+
+### UX
+- [ ] Loading states visibles durante operaciones de red
+- [ ] Mensajes de error claros y accionables (no errores genéricos)
+- [ ] Feedback de éxito tras acciones completadas
+- [ ] Navegación coherente (back, forward, deep link)
+- [ ] No hay doble submit posible
+
+### Técnico
+- [ ] Tests unitarios con cobertura de happy path + error path
+- [ ] Logger presente en todas las clases nuevas
+- [ ] Patrón Do/Result implementado correctamente
+- [ ] Strings via resString (no stringResource directo)
+- [ ] StatusCode con valor numérico y descripción en responses
+
+### Datos
+- [ ] Datos persisten correctamente en DynamoDB
+- [ ] Datos se muestran correctamente al re-consultar
+- [ ] No hay data leak entre negocios (aislamiento multi-tenant)
+- [ ] Timestamps en ISO-8601
+
+---
+
+## Ejemplo completo
+
+### Issue: "Agregar funcionalidad de cancelar orden como cliente"
+
+```gherkin
+# 1. Happy Path
+Escenario: Cliente cancela orden en estado PENDING
+  Dado que el cliente tiene una orden en estado PENDING
+  Cuando presiona "Cancelar orden" y confirma
+  Entonces la orden cambia a estado CANCELLED
+  Y se muestra mensaje "Orden cancelada exitosamente"
+  Y la orden aparece como cancelada en el historial
+
+# 2. Validación de entrada
+Escenario: Cancelar orden sin motivo cuando es requerido
+  Dado que el negocio requiere motivo de cancelación
+  Cuando el cliente intenta cancelar sin escribir motivo
+  Entonces se muestra error "Debe ingresar un motivo de cancelación"
+  Y la orden permanece en su estado actual
+
+# 3. Permisos y autorización
+Escenario: Cliente intenta cancelar orden de otro cliente
+  Dado que existe una orden de otro cliente
+  Cuando el cliente intenta cancelarla
+  Entonces el sistema responde 403
+  Y la orden no se modifica
+
+Escenario: Repartidor intenta cancelar orden como cliente
+  Dado que el usuario tiene perfil Delivery (no Client)
+  Cuando intenta cancelar una orden de cliente
+  Entonces el sistema responde 403
+
+# 4. Estados y transiciones
+Escenario: Cancelar orden en estado DELIVERING
+  Dado que la orden está en estado DELIVERING
+  Cuando el cliente intenta cancelarla
+  Entonces el sistema rechaza con "No se puede cancelar una orden en reparto"
+  Y la orden permanece en DELIVERING
+
+Escenario: Cancelar orden ya entregada
+  Dado que la orden está en estado DELIVERED
+  Cuando el cliente intenta cancelarla
+  Entonces el sistema rechaza con "No se puede cancelar una orden entregada"
+
+# 5. Edge cases
+Escenario: Cancelar orden mientras el negocio la está confirmando
+  Dado que la orden está en PENDING
+  Y el negocio está procesando la confirmación simultáneamente
+  Cuando el cliente cancela
+  Entonces prevalece la cancelación (last-write-wins o conflicto explícito)
+
+# 6. UX y feedback
+Escenario: Diálogo de confirmación antes de cancelar
+  Dado que el cliente presiona "Cancelar orden"
+  Cuando aparece el diálogo de confirmación
+  Entonces muestra "¿Estás seguro de cancelar esta orden?"
+  Y ofrece opciones "Sí, cancelar" y "No, volver"
+
+Escenario: Loading state durante cancelación
+  Dado que el cliente confirma la cancelación
+  Cuando se envía la request al backend
+  Entonces se muestra spinner en el botón
+  Y el botón se deshabilita (prevenir doble click)
+
+# 7. Datos y persistencia
+Escenario: Orden cancelada persiste correctamente
+  Dado que el cliente canceló una orden
+  Cuando cierra y reabre la app
+  Entonces la orden aparece como CANCELLED en el historial
+  Y el timestamp de actualización refleja el momento de cancelación
+```
+
+### Condiciones de done específicas
+- [ ] Endpoint `PUT /{business}/client/orders/{id}/cancel` implementado
+- [ ] Solo el cliente dueño de la orden puede cancelar
+- [ ] Solo cancelable desde estados: PENDING, CONFIRMED, PREPARING
+- [ ] No cancelable desde: READY, DELIVERING, DELIVERED, CANCELLED
+- [ ] Diálogo de confirmación en UI
+- [ ] Test unitario del Do con happy path y error path
+- [ ] Test E2E del endpoint (200, 403, 409)

--- a/.claude/skills/po/business-rules.md
+++ b/.claude/skills/po/business-rules.md
@@ -1,0 +1,308 @@
+# Reglas de Negocio — Intrale Platform
+
+> Este archivo es la base de conocimiento del Product Owner.
+> Crece con cada iteración. Última actualización: 2026-02-28.
+
+---
+
+## 1. Roles y Perfiles
+
+| Perfil | Código | Capacidades principales |
+|--------|--------|------------------------|
+| PlatformAdmin | `PlatformAdmin` | Revisar registros de negocios (requiere 2FA), asignar perfiles, verificar códigos TOTP |
+| BusinessAdmin | `BusinessAdmin` | Registrar Salers, configurar autoAcceptDeliveries, gestionar productos y categorías, revisar solicitudes de delivery |
+| Saler | `Saler` | CRUD productos, gestionar categorías, ver órdenes del negocio |
+| Delivery | `Delivery` | Solicitar unirse a negocio, consultar órdenes disponibles/activas, actualizar estado de entrega |
+| Client | `Client` | Crear órdenes, gestionar direcciones, ver historial de pedidos |
+
+**Regla**: Un usuario puede tener múltiples perfiles en diferentes negocios. La combinación `email + business + profile` es única.
+
+**Estados de UserBusinessProfile**: `PENDING` → `APPROVED` / `REJECTED`
+
+---
+
+## 2. Negocios (Business)
+
+### Estados
+```
+PENDING → APPROVED (por PlatformAdmin con 2FA)
+PENDING → REJECTED (por PlatformAdmin con 2FA)
+```
+
+### Registro de negocio
+- **Quién**: Cualquier usuario autenticado
+- **Campos obligatorios**: name (≥7 caracteres), emailAdmin (email válido), description
+- **Opcionales**: autoAcceptDeliveries (Boolean, default false)
+- **publicId**: Se genera como slug del nombre. Si hay colisión → slug + UUID
+- **Estado inicial**: `PENDING`
+
+### Aprobación de negocio
+- **Quién**: Solo PlatformAdmin
+- **Requisito**: Verificación 2FA (código TOTP 6 dígitos)
+- **Si APPROVED**: Se crea usuario BusinessAdmin en Cognito (si no existe) y se asigna perfil
+- **Si REJECTED**: Se marca estado como REJECTED, sin efectos adicionales
+
+### Configuración
+- `autoAcceptDeliveries`: Si true, repartidores se aprueban automáticamente al solicitar unirse
+- Solo modificable por BusinessAdmin del negocio
+
+### Búsqueda de negocios
+- Paginada con `lastKey` (nombre del último negocio)
+- Filtro por query (insensible a mayúsculas) y por status
+- Límite de resultados configurable
+
+---
+
+## 3. Productos
+
+### Estados
+- `DRAFT` — Borrador, no visible para clientes
+- `PUBLISHED` — Publicado, visible para clientes
+
+### Propiedades
+| Campo | Tipo | Requerido | Notas |
+|-------|------|-----------|-------|
+| name | String | Sí | — |
+| basePrice | Double | Sí | — |
+| unit | String | Sí | Unidad de medida |
+| categoryId | String | Sí | Referencia a categoría |
+| shortDescription | String | No | — |
+| status | Enum | No | Default: DRAFT |
+| isAvailable | Boolean | No | Default: true |
+| stockQuantity | Int? | No | Null = sin control de stock |
+
+### Categorías
+- CRUD completo por BusinessAdmin/Saler
+- Campos: name (requerido), description (opcional)
+- `productCount`: conteo de productos asociados (calculado)
+
+### Permisos
+- Solo Saler o BusinessAdmin del negocio pueden gestionar productos
+
+---
+
+## 4. Órdenes de Cliente
+
+### Estados y transiciones
+```
+PENDING → CONFIRMED → PREPARING → READY → DELIVERING → DELIVERED
+                                                      ↘ CANCELLED
+(CANCELLED puede ocurrir desde cualquier estado previo a DELIVERED)
+```
+
+### Propiedades
+| Campo | Tipo | Notas |
+|-------|------|-------|
+| shortCode | String(6) | Alfanumérico sin vocales ni confundibles (A-Z sin AEIOU, 2-9) |
+| publicId | UUID | Identificador público |
+| items | List | productId, productName, quantity, unitPrice, subtotal |
+| total | Double | Suma de subtotals |
+| deliveryAddress | ClientAddressPayload | Dirección de entrega |
+| notes | String? | Notas del cliente |
+| createdAt / updatedAt | ISO-8601 | Timestamps automáticos |
+
+### Reglas de shortCode
+- 6 caracteres
+- Alfabeto: `BCDFGHJKLMNPQRSTVWXYZ23456789` (sin A,E,I,O,U,0,1 para evitar confusión)
+- Generado aleatoriamente
+
+### Permisos
+- Cliente solo ve sus propias órdenes dentro de un negocio específico
+
+---
+
+## 5. Órdenes de Delivery
+
+### Estados
+```
+pending → in_progress/assigned → picked_up → in_transit → arriving → delivered
+```
+
+### Propiedades específicas
+| Campo | Tipo | Notas |
+|-------|------|-------|
+| neighborhood | String | Barrio de entrega |
+| promisedAt | ISO-8601 | Hora prometida |
+| eta | String | Tiempo estimado de llegada |
+| distance | String | Distancia estimada |
+| customerName | String | Nombre del cliente |
+| customerPhone | String | Teléfono del cliente |
+| paymentMethod | String | Método de pago |
+| collectOnDelivery | Boolean | Si el repartidor cobra al entregar |
+| assignedTo | String? | Email del repartidor asignado |
+
+### Endpoints del repartidor
+- `GET /delivery/orders/summary` — Resumen: pending, inProgress, delivered (conteos)
+- `GET /delivery/orders/active` — Órdenes asignadas al repartidor (picked_up, in_transit, arriving)
+- `GET /delivery/orders/available` — Órdenes sin asignar (pending)
+- `GET /delivery/orders/{id}` — Detalle de orden
+- `PUT /delivery/orders/{id}/status` — Cambiar status
+- `PUT /delivery/orders/{id}/state` — Cambiar estado de entrega
+
+---
+
+## 6. Estado de Entrega (Delivery State)
+
+### Transiciones
+```
+PENDING → PICKED_UP → IN_TRANSIT → DELIVERED
+                                  ↘ CANCELLED
+(CANCELLED puede ocurrir desde cualquier estado previo a DELIVERED)
+```
+
+### Regla
+- No hay restricciones explícitas de transición en el código actual
+- **Gap identificado**: Debería haber validación de transiciones (ej: no saltar de PENDING a DELIVERED)
+
+---
+
+## 7. Disponibilidad de Repartidores
+
+### Modos
+- `BLOCK` — Bloque predefinido de horas
+- `CUSTOM` — Horario personalizado
+
+### Bloques predefinidos
+| Bloque | Horario |
+|--------|---------|
+| MORNING | 06:00 - 12:00 |
+| AFTERNOON | 12:00 - 18:00 |
+| NIGHT | 18:00 - 23:00 |
+
+### Validaciones
+- Mínimo 1 slot activo
+- Día válido: lunes a domingo (case-insensitive)
+- Si mode=BLOCK: block debe ser MORNING, AFTERNOON o NIGHT
+- Si mode=CUSTOM: start y end obligatorios, start < end
+- Timezone requerido (no se impone formato específico)
+
+### Perfil del repartidor
+- fullName, email, phone (opcional)
+- vehicle: type, model, plate (opcional)
+- zones: id, name, description (opcional)
+
+---
+
+## 8. Direcciones de Cliente
+
+### Propiedades
+| Campo | Tipo | Requerido |
+|-------|------|-----------|
+| label | String | Sí | (ej: "Casa", "Trabajo") |
+| street | String | Sí |
+| number | String | Sí |
+| reference | String | No | Punto de referencia |
+| city | String | Sí |
+| state | String | No |
+| postalCode | String | No |
+| country | String | No |
+| isDefault | Boolean | No |
+
+### Reglas
+- Un cliente puede tener múltiples direcciones
+- Solo UNA puede ser default a la vez
+- Si se marcan dos como default, solo la última prevalece
+- Si no hay default, se asigna la primera
+- Las direcciones están asociadas a un cliente en un negocio específico
+
+---
+
+## 9. Autenticación y Seguridad
+
+### Proveedores
+- AWS Cognito (Identity Provider principal)
+- JWT local (fallback)
+
+### Flujos
+
+#### Sign In
+- Email + contraseña contra Cognito
+- Retorna JWT con claims: email, subject
+- Si contraseña es temporal (primer login) → requiere cambio inmediato
+
+#### Sign Up (Cliente)
+- Perfil: DEFAULT
+- Crea usuario en Cognito si no existe
+- Estado: APPROVED inmediato
+
+#### Sign Up Delivery
+- Perfil: Delivery
+- No puede duplicarse (email + business + Delivery debe ser único)
+- Estado: PENDING (requiere aprobación)
+
+#### 2FA (Two-Factor Authentication)
+- **Setup**: Genera secret Base32 de 20 bytes → URI otpauth://totp
+- **Algoritmo**: SHA1, 6 dígitos, período 30 segundos
+- **Verify**: Compara código TOTP del usuario vs calculado
+- **Uso**: Requerido para operaciones sensibles (aprobación de negocios)
+
+#### Recuperación de contraseña
+1. `PasswordRecovery` → Cognito envía código por email
+2. `ConfirmPasswordRecovery` → Email + código + nueva contraseña
+
+#### Cambio de contraseña
+- `ChangePassword` → Usuario autenticado cambia directamente
+
+### Validación de email
+- Patrón: `.+@.+\..+`
+- Mensaje: "El campo email debe tener formato de email. Valor actual: '{value}'"
+
+### Tipos de función backend
+- `Function` — Pública, sin autenticación
+- `SecuredFunction` — Requiere JWT válido de Cognito
+
+### Resolución de identidad
+- Desde claim `email` del JWT
+- O desde claim `subject`
+- O desde header `X-Debug-User` (solo desarrollo)
+
+---
+
+## 10. Flujos de Registro
+
+### Cliente
+1. Sign Up con perfil DEFAULT → APPROVED inmediato
+2. Puede crear órdenes en cualquier negocio aprobado
+
+### Negocio
+1. `RegisterBusiness` (cualquiera) → PENDING
+2. `ReviewBusinessRegistration` (PlatformAdmin + 2FA) → APPROVED/REJECTED
+3. Si APPROVED: crea BusinessAdmin en Cognito y asigna perfil
+
+### Saler
+1. `RegisterSaler` (solo BusinessAdmin)
+2. Crea usuario en Cognito si no existe
+3. Estado: APPROVED inmediato
+4. No puede duplicarse para el mismo negocio
+
+### Delivery (dos caminos)
+
+**Camino 1: Sign Up Delivery**
+1. Repartidor se registra → PENDING
+2. Espera aprobación de BusinessAdmin
+
+**Camino 2: Request Join Business**
+1. Repartidor autenticado solicita unirse
+2. Si `autoAcceptDeliveries = true` → APPROVED inmediato
+3. Si `autoAcceptDeliveries = false` → PENDING → ReviewJoinBusiness → APPROVED/REJECTED
+
+### Asignación directa
+- `AssignProfile` (solo PlatformAdmin)
+- Asigna cualquier perfil con estado APPROVED inmediato
+
+---
+
+## Gaps conocidos
+
+> Esta sección documenta vacíos detectados en las reglas de negocio actuales.
+
+1. **Sin validación de transiciones de estado**: Las órdenes no validan que la transición de estado sea legal (ej: de PENDING a DELIVERED directamente)
+2. **Sin notificaciones**: No hay sistema de notificaciones push para cambios de estado de órdenes
+3. **Sin historial de cambios**: No se guarda log de quién cambió el estado de una orden y cuándo
+4. **Sin cancelación con motivo**: CANCELLED no requiere motivo ni tiene ventana de tiempo
+5. **Sin stock automático**: stockQuantity existe pero no se decrementa al crear órdenes
+6. **Sin horarios de negocio**: No hay modelo de horarios de apertura/cierre
+7. **Sin zonas de cobertura**: No hay modelo de áreas geográficas de entrega
+8. **Sin tarifas de delivery**: No hay cálculo de costo de envío
+9. **Sin calificaciones**: No hay sistema de rating para repartidores ni negocios
+10. **Sin métricas de SLA**: No hay tracking de tiempos prometidos vs reales


### PR DESCRIPTION
## Resumen

- Nuevo skill `/po` (Product Owner) con 5 modos de operación: `definir`, `validar`, `acceptance`, `revisar-ux` y `gaps`
- Base de conocimiento `business-rules.md` con reglas de negocio extraídas del codebase (10 áreas + 10 gaps identificados)
- Plantilla BDD `acceptance-template.md` con 7 categorías de scenarios y checklist de condiciones de done
- Permiso `Skill(po)` registrado en settings.local.json

## Detalle

El PO es el guardián de la calidad del producto desde la perspectiva del negocio y del usuario final. Define el "qué" antes de que se escriba código, genera criterios de aceptación BDD exhaustivos, y verifica que lo entregado cumpla con las reglas de negocio.

**Diferenciación con skills existentes:**
- `/historia` crea issues técnicos → `/po` define el negocio profundo
- `/review` verifica código → `/po` verifica producto
- `/qa` ejecuta tests → `/po` define qué testear

## Plan de tests

- [x] Skill aparece en lista de skills disponibles
- [x] Permiso registrado en settings.local.json
- [ ] `/po gaps` genera gap analysis
- [ ] `/po acceptance <issue>` genera scenarios BDD

QA Validate: omitido — cambios solo en configuración de skills (sin código funcional) ⚠️

🤖 Generado con [Claude Code](https://claude.ai/claude-code)