### PR TITLE
fix: cooldown en commander-launcher tras error 409

### DIFF
--- a/.claude/hooks/commander-launcher.js
+++ b/.claude/hooks/commander-launcher.js
@@ -10,10 +10,12 @@ const { spawn } = require("child_process");
 const HOOKS_DIR = __dirname;
 const LOCK_FILE = path.join(HOOKS_DIR, "telegram-commander.lock");
 const LAUNCHING_FILE = path.join(HOOKS_DIR, "telegram-commander.launching");
+const CONFLICT_COOLDOWN_FILE = path.join(HOOKS_DIR, "telegram-commander.conflict");
 const COMMANDER_SCRIPT = path.join(HOOKS_DIR, "telegram-commander.js");
 const LOG_FILE = path.join(HOOKS_DIR, "hook-debug.log");
 
 const LAUNCHING_STALE_MS = 30000; // 30s — si el flag de launching tiene más de esto, es stale
+const CONFLICT_COOLDOWN_MS = 45000; // 45s — esperar después de un 409 (> POLL_TIMEOUT_SEC=30s)
 
 function log(msg) {
     const line = "[" + new Date().toISOString() + "] Launcher: " + msg;
@@ -128,11 +130,35 @@ function launchCommander() {
 
 // ─── Main ────────────────────────────────────────────────────────────────────
 
+function isConflictCooldownActive() {
+    if (!fs.existsSync(CONFLICT_COOLDOWN_FILE)) return false;
+    try {
+        const data = JSON.parse(fs.readFileSync(CONFLICT_COOLDOWN_FILE, "utf8"));
+        const age = Date.now() - (data.ts || 0);
+        if (age < CONFLICT_COOLDOWN_MS) {
+            return true; // Cooldown activo — no relanzar aún
+        }
+        // Cooldown expirado — limpiar y continuar
+        try { fs.unlinkSync(CONFLICT_COOLDOWN_FILE); } catch (e2) {}
+    } catch (e) {
+        // Archivo corrupto — limpiar
+        try { fs.unlinkSync(CONFLICT_COOLDOWN_FILE); } catch (e2) {}
+    }
+    return false;
+}
+
 function main() {
     const status = checkLockfile();
 
     if (status.running) {
         // Commander ya corriendo — nada que hacer
+        return;
+    }
+
+    // Verificar cooldown por 409 — el commander anterior murió por conflicto,
+    // esperar a que Telegram libere la conexión vieja (POLL_TIMEOUT_SEC + margen)
+    if (isConflictCooldownActive()) {
+        // NO logear — esto se ejecuta en cada tool use y llenaría el log
         return;
     }
 

--- a/.claude/hooks/telegram-commander.js
+++ b/.claude/hooks/telegram-commander.js
@@ -31,8 +31,8 @@ const PENDING_QUESTIONS_FILE = path.join(HOOKS_DIR, "pending-questions.json");
 const POLL_TIMEOUT_SEC = 30;
 const SESSION_TTL_MS = 30 * 60 * 1000; // 30 minutos de inactividad
 const POLL_CONFLICT_RETRY_MS = 5000;  // Espera tras error 409 (otro poller activo)
-const POLL_CONFLICT_MAX = 3;          // Máx reintentos seguidos por 409 antes de bajar a short-poll
-// SHORT_POLL_INTERVAL_MS removido: si hay 409 persistente, el proceso se mata (no degrada a short-poll)
+const POLL_CONFLICT_MAX = 8;          // 8 reintentos × 5s = 40s (debe superar POLL_TIMEOUT_SEC=30s para outlast stale connections)
+const CONFLICT_COOLDOWN_FILE = path.join(HOOKS_DIR, "telegram-commander.conflict");
 const EXEC_TIMEOUT_MS = 15 * 60 * 1000; // 15 minutos
 const TG_MSG_MAX = 4096;
 const SPRINT_MONITOR_INTERVAL_MS = 5 * 60 * 1000; // 5 minutos
@@ -1615,11 +1615,16 @@ async function pollingLoop() {
     // Si todos los intentos de startup dieron 409, otro commander está activo — SALIR
     if (startupConflicts >= 3) {
         log("FATAL: 3 conflictos 409 en startup — otro Commander ya controla el polling. SALIENDO.");
+        // Escribir cooldown para que el launcher NO relance inmediatamente
+        try { fs.writeFileSync(CONFLICT_COOLDOWN_FILE, JSON.stringify({ ts: Date.now(), pid: process.pid }), "utf8"); } catch (e2) {}
         releaseLock();
         process.exit(1);
     }
 
     saveOffset(offset);
+
+    // Startup exitoso — limpiar cooldown si existe
+    try { fs.unlinkSync(CONFLICT_COOLDOWN_FILE); } catch (e) {}
 
     let conflictStreak = 0;  // Contador de 409s consecutivos
 
@@ -1646,7 +1651,9 @@ async function pollingLoop() {
                     await sleep(POLL_CONFLICT_RETRY_MS);
                 } else {
                     // Otro poller activo — este proceso DEBE morir para evitar respuestas duplicadas
-                    log("FATAL: Conflicto 409 persistente (" + conflictStreak + " seguidos) — otro Commander ya controla el polling. SALIENDO.");
+                    log("FATAL: Conflicto 409 persistente (" + conflictStreak + " seguidos, " + (conflictStreak * POLL_CONFLICT_RETRY_MS / 1000) + "s) — otro Commander ya controla el polling. SALIENDO.");
+                    // Escribir cooldown para que el launcher NO relance inmediatamente
+                    try { fs.writeFileSync(CONFLICT_COOLDOWN_FILE, JSON.stringify({ ts: Date.now(), pid: process.pid }), "utf8"); } catch (e2) {}
                     running = false;
                     releaseLock();
                     process.exit(1);


### PR DESCRIPTION
## Resumen

- Nuevo mecanismo de cooldown (45s) en `commander-launcher.js` para evitar el ciclo muere→relanza→409→muere
- `POLL_CONFLICT_MAX` aumentado de 3 a 8 en `telegram-commander.js` (8×5s = 40s > timeout 30s) para superar conexiones stale
- Escribe archivo `.conflict` al morir por 409 persistente; el launcher lo lee antes de relanzar

## Plan de tests

- [x] Commander sobrevive conflictos 409 transitorios (8 reintentos)
- [x] Launcher respeta cooldown y no relanza durante 45s post-409
- [x] Cooldown se limpia tras startup exitoso

QA Validate: omitido — cambio en hooks internos, no afecta código de producción ⚠️

🤖 Generado con [Claude Code](https://claude.ai/claude-code)