### PR TITLE
fix: Stop-Agente excluye .claude/ transientes y cierra terminal antes de cleanup

### DIFF
--- a/docs/qa/generate-pdf.js
+++ b/docs/qa/generate-pdf.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+// Uso: node generate-pdf.js <nombre-reporte>
+// Ejemplo: node generate-pdf.js reporte-login-flujos-y-casos
+// Genera el PDF a partir del HTML con el mismo nombre base.
+
+const puppeteer = require('puppeteer');
+const path = require('path');
+
+const reportName = process.argv[2];
+if (!reportName) {
+  console.error('Uso: node generate-pdf.js <nombre-reporte-sin-extension>');
+  console.error('Ejemplo: node generate-pdf.js reporte-login-flujos-y-casos');
+  process.exit(1);
+}
+
+const htmlFile = reportName.endsWith('.html') ? reportName : reportName + '.html';
+const pdfFile = htmlFile.replace(/\.html$/, '.pdf');
+
+(async () => {
+  const browser = await puppeteer.launch({ headless: 'new' });
+  const page = await browser.newPage();
+
+  const htmlPath = path.resolve(__dirname, htmlFile);
+  console.log('Cargando:', htmlPath);
+  await page.goto('file:///' + htmlPath.replace(/\\/g, '/'), {
+    waitUntil: 'networkidle0',
+    timeout: 60000
+  });
+
+  // Esperar a que Mermaid renderice todos los diagramas (si hay)
+  const hasMermaid = await page.evaluate(() => document.querySelectorAll('.mermaid').length > 0);
+  if (hasMermaid) {
+    console.log('Esperando renderizado de Mermaid...');
+    await page.waitForFunction(() => {
+      const mermaidDivs = document.querySelectorAll('.mermaid');
+      return mermaidDivs.length > 0 && Array.from(mermaidDivs).every(d => d.querySelector('svg'));
+    }, { timeout: 30000 });
+    // Extra wait para estabilizar SVGs
+    await new Promise(r => setTimeout(r, 2000));
+  }
+
+  const pdfPath = path.resolve(__dirname, pdfFile);
+  await page.pdf({
+    path: pdfPath,
+    format: 'A4',
+    printBackground: true,
+    margin: { top: '18mm', bottom: '18mm', left: '14mm', right: '14mm' },
+    displayHeaderFooter: true,
+    headerTemplate: `<div style="font-size:8px; color:#999; width:100%; text-align:center; margin-top:5mm;">Intrale Platform — ${reportName} — v2.0</div>`,
+    footerTemplate: '<div style="font-size:8px; color:#999; width:100%; text-align:center; margin-bottom:5mm;">Pagina <span class="pageNumber"></span> de <span class="totalPages"></span></div>'
+  });
+
+  console.log('PDF generado:', pdfPath);
+  await browser.close();
+})();

--- a/scripts/Stop-Agente.ps1
+++ b/scripts/Stop-Agente.ps1
@@ -128,6 +128,8 @@ function Stop-UnAgente {
 
     # --- Modo Abort: descartar todo y limpiar ---
     if ($Abort) {
+        Close-AgenteTerminal -Agente $Agente
+        Start-Sleep -Seconds 2  # Dar tiempo al proceso para liberar file handles
         Write-Log 'ABORT: descartando cambios y limpiando worktree...' 'Red'
         Push-Location $wtDirResolved
         try {
@@ -149,7 +151,6 @@ function Stop-UnAgente {
             Pop-Location
         }
 
-        Close-AgenteTerminal -Agente $Agente
         Write-Log ('Agente {0} abortado y limpiado.' -f $Agente.numero) 'Green'
         return
     }
@@ -182,15 +183,24 @@ function Stop-UnAgente {
         return
     }
 
+    # --- Cerrar terminal ANTES de cleanup (evita Permission denied en worktree removal) ---
+    Close-AgenteTerminal -Agente $Agente
+    Start-Sleep -Seconds 2  # Dar tiempo al proceso para liberar file handles
+
     Push-Location $wtDirResolved
     try {
-        # --- Verificar cambios ---
+        # --- Verificar cambios REALES (excluir .claude/ transientes) ---
         $prevEAP = $ErrorActionPreference
         $ErrorActionPreference = 'SilentlyContinue'
         $status = git status --porcelain 2>$null
+        # Filtrar cambios en .claude/ — son transientes y NUNCA deben commitearse por Stop-Agente
+        $realChanges = $status | Where-Object { $_ -and $_ -notmatch '^\s*\??\s*\.claude/' -and $_ -notmatch '^\s*M\s*\.claude/' }
         $ErrorActionPreference = $prevEAP
-        if (-not $status) {
-            Write-Log 'Sin cambios en el worktree.' 'Yellow'
+        if (-not $realChanges) {
+            Write-Log 'Sin cambios reales en el worktree (solo .claude/ transientes).' 'Yellow'
+
+            # Descartar cambios transientes de .claude/ antes de limpiar
+            git checkout -- .claude/ 2>$null
 
             # Solo limpiar
             Pop-Location
@@ -203,13 +213,12 @@ function Stop-UnAgente {
             $ErrorActionPreference = $prevEAP
             # Safe: desvincula junction .claude/ antes de borrar
             Safe-RemoveWorktreeDir $wtDirResolved
-            Close-AgenteTerminal -Agente $Agente
-            Write-Log 'Worktree limpiado (sin cambios).' 'Green'
+            Write-Log 'Worktree limpiado (sin cambios reales).' 'Green'
             return
         }
 
-        Write-Log 'Cambios detectados:' 'Yellow'
-        git status --short
+        Write-Log 'Cambios reales detectados:' 'Yellow'
+        $realChanges | ForEach-Object { Write-Host "  $_" }
 
         # --- Obtener titulo del issue desde GitHub ---
         $issueTitle = ''
@@ -221,9 +230,25 @@ function Stop-UnAgente {
         }
         if (-not $issueTitle) { $issueTitle = $slug }
 
-        # --- Commit ---
-        Write-Log 'Committing cambios...' 'White'
-        git add -A
+        # --- Commit (excluir .claude/ transientes) ---
+        Write-Log 'Committing cambios reales...' 'White'
+        git add -A -- ':!.claude/'
+        # Verificar que hay algo staged despues de excluir .claude/
+        $staged = git diff --cached --name-only 2>$null
+        if (-not $staged) {
+            Write-Log 'Nada staged despues de excluir .claude/ — abortando commit.' 'Yellow'
+            Pop-Location
+            Push-Location $MainRepo
+            $prevEAP = $ErrorActionPreference
+            $ErrorActionPreference = 'SilentlyContinue'
+            git worktree remove $wtDirResolved --force 2>$null
+            git branch -D $branch 2>$null
+            git worktree prune 2>$null
+            $ErrorActionPreference = $prevEAP
+            Safe-RemoveWorktreeDir $wtDirResolved
+            Write-Log 'Worktree limpiado (nada real que commitear).' 'Green'
+            return
+        }
         $coAuthor = 'Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>'
         $commitMsg = ('feat: {0} (Closes #{1})' -f $issueTitle, $issue) + "`n`n$coAuthor"
         git commit -m $commitMsg
@@ -307,7 +332,7 @@ function Stop-UnAgente {
         Pop-Location
     }
 
-    Close-AgenteTerminal -Agente $Agente
+    # Close-AgenteTerminal ya se ejecuto al inicio de Stop-UnAgente
     Write-Log ('Agente {0} finalizado.' -f $Agente.numero) 'Green'
 }
 


### PR DESCRIPTION
## Resumen

- Stop-Agente ya no commitea archivos `.claude/` transientes (hooks state files)
- `git add -A` reemplazado por `git add -A -- ':!.claude/'`
- Validación post-staging: si solo hay `.claude/` staged, aborta el commit
- `Close-AgenteTerminal` se ejecuta ANTES del worktree removal (evita Permission denied)
- Nuevo `generate-pdf.js` genérico reutilizable para todos los reportes QA

## Contexto

Sprint anterior (#1128-#1130) commiteó solo archivos `.claude/` transientes sin reportes reales.
Causa raíz: `git add -A` en Stop-Agente incluía hooks state files como "cambios".

## Test plan

- [ ] Stop-Agente con worktree que solo tiene cambios en `.claude/` → debe tratar como "sin cambios"
- [ ] Stop-Agente con cambios reales → commit solo archivos relevantes
- [ ] Terminal se cierra antes de intentar worktree removal

🤖 Generated with [Claude Code](https://claude.ai/claude-code)