### PR TITLE
test(qa): E2E test para endpoint validate con JWT real

### DIFF
--- a/qa/src/test/kotlin/ar/com/intrale/e2e/api/ApiValidateTokenE2ETest.kt
+++ b/qa/src/test/kotlin/ar/com/intrale/e2e/api/ApiValidateTokenE2ETest.kt
@@ -2,16 +2,70 @@ package ar.com.intrale.e2e.api
 
 import ar.com.intrale.e2e.QATestBase
 import com.microsoft.playwright.options.RequestOptions
+import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestMethodOrder
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 @DisplayName("E2E — Validate token JWT contra backend real")
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
 class ApiValidateTokenE2ETest : QATestBase() {
+
+    @Test
+    @Order(0)
+    @DisplayName("POST /intrale/validate con JWT valido de signin responde 200")
+    fun `validate con token valido obtenido via signin responde 200`() {
+        // Paso 1: Obtener accessToken valido via signin con credenciales seed
+        val signinResponse = apiContext.post(
+            "/intrale/signin",
+            RequestOptions.create()
+                .setHeader("Content-Type", "application/json")
+                .setData(mapOf(
+                    "email" to "admin@intrale.com",
+                    "password" to "Admin1234!",
+                    "newPassword" to "Admin1234!",
+                    "name" to "Admin",
+                    "familyName" to "Intrale"
+                ))
+        )
+
+        logger.info("SignIn para validate: status=${signinResponse.status()}")
+        val signinBody = signinResponse.text()
+        logger.info("SignIn body (truncado): ${signinBody.take(200)}")
+
+        // Si signin no retorna 200 con accessToken, skip (el entorno no tiene usuario seed)
+        assumeTrue(
+            signinResponse.status() == 200 && signinBody.contains("accessToken"),
+            "Signin debe retornar 200 con accessToken para ejecutar este test"
+        )
+
+        // Extraer accessToken del JSON de respuesta
+        val accessToken = Regex(""""accessToken"\s*:\s*"([^"]+)"""")
+            .find(signinBody)?.groupValues?.get(1)
+        assumeTrue(
+            accessToken != null,
+            "No se pudo extraer accessToken de la respuesta de signin"
+        )
+
+        // Paso 2: Llamar a validate con el token real
+        val validateResponse = apiContext.post(
+            "/intrale/validate",
+            RequestOptions.create()
+                .setHeader("Content-Type", "application/json")
+                .setHeader("Authorization", accessToken!!)
+                .setData("{}")
+        )
+
+        logger.info("Validate con token valido: status=${validateResponse.status()}")
+        assertEquals(
+            200, validateResponse.status(),
+            "Validate con JWT valido de signin debe responder 200. Actual: ${validateResponse.status()}"
+        )
+    }
 
     @Test
     @Order(1)


### PR DESCRIPTION
## Summary
- Agrega test positivo E2E que obtiene un `accessToken` real via `/intrale/signin` y lo usa para validar contra `/intrale/validate`, esperando respuesta 200
- Complementa los 5 tests negativos existentes (sin body, sin token, token invalido, token expirado, Authorization malformado)
- El test positivo usa `assumeTrue` para skip graceful si el entorno no tiene usuario seed configurado

## Test plan
- [ ] Verificar que `./gradlew :qa:compileTestKotlin` compila sin errores
- [ ] Verificar que los 6 tests se ejecutan contra backend real (`./gradlew :qa:test`)
- [ ] Test positivo pasa cuando el backend + Cognito estan disponibles
- [ ] Tests negativos siguen respondiendo 4xx

Closes #984

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>