### PR TITLE
test(qa): agregar test positivo E2E para endpoint validate con JWT

### DIFF
--- a/qa/src/test/kotlin/ar/com/intrale/e2e/api/ApiValidateTokenE2ETest.kt
+++ b/qa/src/test/kotlin/ar/com/intrale/e2e/api/ApiValidateTokenE2ETest.kt
@@ -2,16 +2,70 @@ package ar.com.intrale.e2e.api
 
 import ar.com.intrale.e2e.QATestBase
 import com.microsoft.playwright.options.RequestOptions
+import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestMethodOrder
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 @DisplayName("E2E — Validate token JWT contra backend real")
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
 class ApiValidateTokenE2ETest : QATestBase() {
+
+    @Test
+    @Order(0)
+    @DisplayName("POST /intrale/validate con JWT valido de signin responde 200")
+    fun `validate con token valido obtenido via signin responde 200`() {
+        // Paso 1: Obtener accessToken valido via signin con credenciales seed
+        val signinResponse = apiContext.post(
+            "/intrale/signin",
+            RequestOptions.create()
+                .setHeader("Content-Type", "application/json")
+                .setData(mapOf(
+                    "email" to "admin@intrale.com",
+                    "password" to "Admin1234!",
+                    "newPassword" to "Admin1234!",
+                    "name" to "Admin",
+                    "familyName" to "Intrale"
+                ))
+        )
+
+        logger.info("SignIn para validate: status=${signinResponse.status()}")
+        val signinBody = signinResponse.text()
+        logger.info("SignIn body (truncado): ${signinBody.take(200)}")
+
+        // Si signin no retorna 200 con accessToken, skip (el entorno no tiene usuario seed)
+        assumeTrue(
+            signinResponse.status() == 200 && signinBody.contains("accessToken"),
+            "Signin debe retornar 200 con accessToken para ejecutar este test"
+        )
+
+        // Extraer accessToken del JSON de respuesta
+        val accessToken = Regex(""""accessToken"\s*:\s*"([^"]+)"""")
+            .find(signinBody)?.groupValues?.get(1)
+        assumeTrue(
+            accessToken != null,
+            "No se pudo extraer accessToken de la respuesta de signin"
+        )
+
+        // Paso 2: Llamar a validate con el token real
+        val validateResponse = apiContext.post(
+            "/intrale/validate",
+            RequestOptions.create()
+                .setHeader("Content-Type", "application/json")
+                .setHeader("Authorization", accessToken!!)
+                .setData("{}")
+        )
+
+        logger.info("Validate con token valido: status=${validateResponse.status()}")
+        assertEquals(
+            200, validateResponse.status(),
+            "Validate con JWT valido de signin debe responder 200. Actual: ${validateResponse.status()}"
+        )
+    }
 
     @Test
     @Order(1)


### PR DESCRIPTION
## Resumen
- Rescate del test que estaba en branch `agent/984-qa-validate` (commit d807866) pero no llegó a main en PR #1067
- Test que obtiene un accessToken válido vía signin y llama al endpoint `/intrale/validate`, verificando respuesta 200
- Complementa los 5 tests negativos existentes

Closes #984

🤖 Generated with [Claude Code](https://claude.ai/claude-code)