### PR TITLE
fix(hooks): solo notificar permission_prompt cuando approver crasheó

### DIFF
--- a/.claude/hooks/notify-telegram.js
+++ b/.claude/hooks/notify-telegram.js
@@ -298,9 +298,11 @@ async function processInput() {
         "elicitation_dialog":  "Informaci\u00f3n requerida"
     };
 
-    // permission_prompt: verificar si permission-approver.js lo está manejando
-    // Solo ignorar si el approver está activamente esperando respuesta via Telegram (PID vivo)
-    // Si auto-aprobó o crasheó, enviar la notificación normalmente
+    // permission_prompt: solo notificar si el approver crasheó (PID muerto)
+    // Todos los demás casos se ignoran:
+    //   - Approver activo (PID vivo) → ya tiene mensaje con botones en Telegram
+    //   - Auto-approve → usuario ya aprobó el patrón permanentemente
+    //   - Sin PID file → Claude resolvió internamente (settings allow), no hay nada pendiente
     if (type === "permission_prompt") {
         const approverPidFile = path.join(MAIN_REPO_ROOT, ".claude", "hooks", "approver-active.pid");
         try {
@@ -311,34 +313,29 @@ async function processInput() {
                     log("Ignorado permission_prompt: approver PID " + pidData.pid + " activo (Telegram buttons)");
                     return;
                 } catch(e) {
-                    // Proceso muerto — approver crasheó, enviar notificación
-                    log("permission_prompt: approver PID " + pidData.pid + " muerto, enviando notificación");
+                    // Proceso muerto — approver crasheó, notificar al usuario
+                    log("permission_prompt: approver PID " + pidData.pid + " muerto, enviando notificación de fallback");
+                    // Continuar al flujo normal pero no llegar como "Aprobación requerida"
+                    // sino como alerta de que hay un prompt esperando en consola
                 }
             } else {
-                // Sin PID file — el approver auto-aprobó o no corrió
-                // Verificar timestamp: si el approver auto-aprobó hace <10s, ignorar
-                const autoApproveFile = path.join(MAIN_REPO_ROOT, ".claude", "hooks", "approver-last-auto.json");
-                try {
-                    if (fs.existsSync(autoApproveFile)) {
-                        const autoData = JSON.parse(fs.readFileSync(autoApproveFile, "utf8"));
-                        const age = Date.now() - new Date(autoData.timestamp).getTime();
-                        if (age < 10000) {
-                            log("Ignorado permission_prompt: auto-aprobado hace " + Math.round(age/1000) + "s");
-                            return;
-                        }
-                    }
-                } catch(e) {}
-                // No auto-approve reciente — el approver no corrió, enviar notificación
-                log("permission_prompt: sin approver activo ni auto-approve reciente, enviando notificación");
+                // Sin PID file → auto-approve, settings allow, o hook no corrió
+                // En todos estos casos no hay nada pendiente para el usuario
+                log("Ignorado permission_prompt: sin approver activo (auto-resuelto)");
+                return;
             }
         } catch(e) {
-            log("permission_prompt: error verificando approver (" + e.message + "), enviando notificación");
+            log("Ignorado permission_prompt: error verificando approver (" + e.message + ")");
+            return;
         }
     }
 
     // Clasificar urgencia y tipo de notificación
     const classification = classifyNotification(type, message, title);
-    const displayTitle = TIPO_TITULO[type] || title || type;
+    // Para permission_prompt que llega aquí (approver crasheó), usar título de fallback
+    const displayTitle = (type === "permission_prompt")
+        ? "Permiso pendiente en consola"
+        : (TIPO_TITULO[type] || title || type);
 
     let displayMessage = message;
 


### PR DESCRIPTION
## Resumen

- Corrige #1164: el fix anterior enviaba `permission_prompt` como texto sin botones para TODOS los casos sin approver activo
- Ahora la lógica es conservadora: solo notifica cuando el PID del approver existe pero el proceso murió (crash real)
- Todos los demás casos se ignoran silenciosamente (auto-approve, settings allow, hook no corrió)
- Cambia el título de "Aprobación requerida" a "Permiso pendiente en consola" para el caso de crash

## Lógica de decisión

| Caso | PID file | Proceso | Acción |
|------|----------|---------|--------|
| Approver activo | Existe | Vivo | Ignorar (Telegram buttons ya enviados) |
| Approver crasheó | Existe | Muerto | Notificar ("Permiso pendiente en consola") |
| Auto-approve | No existe | — | Ignorar |
| Settings allow | No existe | — | Ignorar |

## Plan de tests

- [x] Sin PID file → se ignora (no genera mensaje sin botones)
- [x] PID file con proceso muerto → notifica con título correcto
- [x] PID file con proceso vivo → se ignora

🤖 Generado con [Claude Code](https://claude.ai/claude-code)