### PR TITLE
fix(hooks): migrar permisos de PermissionRequest a PreToolUse

### DIFF
--- a/.claude/hooks/approval-history.js
+++ b/.claude/hooks/approval-history.js
@@ -1,0 +1,88 @@
+// approval-history.js — Tracking de aprobaciones por patrón
+// Cuenta cuántas veces se aprobó cada patrón de permiso.
+// Después de N aprobaciones, el approver sugiere persistir la regla.
+
+const fs = require("fs");
+const path = require("path");
+
+const HISTORY_FILE = path.join(__dirname, "approval-history.json");
+const SUGGEST_THRESHOLD = 3; // sugerir persistencia después de N aprobaciones
+
+function loadHistory() {
+    try {
+        return JSON.parse(fs.readFileSync(HISTORY_FILE, "utf8"));
+    } catch (e) {
+        return { patterns: {} };
+    }
+}
+
+function saveHistory(data) {
+    try {
+        fs.writeFileSync(HISTORY_FILE, JSON.stringify(data, null, 2), "utf8");
+    } catch (e) {}
+}
+
+/**
+ * Incrementar contador de aprobaciones para un patrón.
+ * @param {string} pattern - Ej: "Bash(echo:*)", "Edit(/tmp/*.txt)"
+ * @returns {{ count: number, shouldSuggest: boolean }} estado actual
+ */
+function incrementApproval(pattern) {
+    if (!pattern) return { count: 0, shouldSuggest: false };
+    const data = loadHistory();
+    if (!data.patterns[pattern]) {
+        data.patterns[pattern] = { count: 0, first: new Date().toISOString() };
+    }
+    data.patterns[pattern].count++;
+    data.patterns[pattern].last = new Date().toISOString();
+    const count = data.patterns[pattern].count;
+    saveHistory(data);
+    return {
+        count,
+        shouldSuggest: count === SUGGEST_THRESHOLD // solo en el umbral exacto
+    };
+}
+
+/**
+ * Obtener contador de aprobaciones de un patrón.
+ * @param {string} pattern
+ * @returns {number}
+ */
+function getApprovalCount(pattern) {
+    if (!pattern) return 0;
+    const data = loadHistory();
+    return (data.patterns[pattern] && data.patterns[pattern].count) || 0;
+}
+
+/**
+ * Marcar un patrón como persistido (ya no sugerir).
+ * @param {string} pattern
+ */
+function markPersisted(pattern) {
+    if (!pattern) return;
+    const data = loadHistory();
+    if (data.patterns[pattern]) {
+        data.patterns[pattern].persisted = true;
+        data.patterns[pattern].persisted_at = new Date().toISOString();
+        saveHistory(data);
+    }
+}
+
+/**
+ * Verificar si un patrón ya fue persistido.
+ * @param {string} pattern
+ * @returns {boolean}
+ */
+function isPatternPersisted(pattern) {
+    if (!pattern) return false;
+    const data = loadHistory();
+    return !!(data.patterns[pattern] && data.patterns[pattern].persisted);
+}
+
+module.exports = {
+    incrementApproval,
+    getApprovalCount,
+    markPersisted,
+    isPatternPersisted,
+    SUGGEST_THRESHOLD
+};

--- a/.claude/hooks/permission-gate.js
+++ b/.claude/hooks/permission-gate.js
@@ -1,0 +1,529 @@
+// permission-gate.js — Hook PreToolUse para permisos via Telegram
+// Reemplaza a permission-approver.js (PermissionRequest) que no dispara de forma confiable
+// (bugs conocidos de Claude Code: #12176, #29212)
+//
+// Flujo PreToolUse:
+//   permissionDecision: "allow" → bypass del dialogo de permisos (tool se ejecuta)
+//   permissionDecision: "deny"  → bloquear tool
+//   Sin output                  → flujo normal de Claude Code (dialogo local)
+//
+// Solo maneja Bash — otros tools salen sin output (no interferir)
+//
+// IMPORTANTE: Este hook NO usa getUpdates de Telegram. El telegram-commander.js
+// es el unico consumidor de getUpdates, evitando conflictos de offset/409.
+
+const https = require("https");
+const crypto = require("crypto");
+const fs = require("fs");
+const path = require("path");
+
+const { generatePattern, generateBashPattern, getSettingsPaths, persistPattern, resolveMainRepoRoot, isAlreadyCovered } = require("./permission-utils");
+const { addPendingQuestion, resolveQuestion, getQuestionById, updateQuestionField } = require("./pending-questions");
+const { incrementApproval, isPatternPersisted } = require("./approval-history");
+const { readSessionContext } = require("./context-reader");
+const { registerMessage } = require("./telegram-message-registry");
+
+const _tgCfg = JSON.parse(fs.readFileSync(path.join(__dirname, "telegram-config.json"), "utf8"));
+const BOT_TOKEN = _tgCfg.bot_token;
+const CHAT_ID = _tgCfg.chat_id;
+const ANSWER_TIMEOUT = 5000;
+const POLL_INTERVAL_MS = 150;
+
+// ─── Retry schedule con urgencia escalada ────────────────────────────────────
+// Default: [15, 8, 5, 2] = 30 min total
+// Configurable desde telegram-config.json → gate_retry_intervals_min
+const DEFAULT_GATE_RETRY_INTERVALS = [15, 8, 5, 2]; // minutos
+const RETRY_INTERVALS = (_tgCfg.gate_retry_intervals_min || DEFAULT_GATE_RETRY_INTERVALS)
+    .map(m => m * 60 * 1000);
+
+const RETRY_ESCALATION = [
+    { emoji: "\u{1F510}", title: "PERMISO REQUERIDO", desc: "" },
+    { emoji: "\u{1F514}", title: "Recordatorio", desc: "Hay un permiso pendiente desde hace rato" },
+    { emoji: "\u26A0\uFE0F", title: "Agente bloqueado", desc: "El agente no puede continuar sin tu aprobacion" },
+    { emoji: "\u{1F6A8}", title: "Ultimo aviso", desc: "Si no respondes, el agente pedira en consola" }
+];
+
+const REPO_ROOT = process.env.CLAUDE_PROJECT_DIR || "C:\\Workspaces\\Intrale\\platform";
+const MAIN_REPO_ROOT = resolveMainRepoRoot(REPO_ROOT) || REPO_ROOT;
+const LOG_FILE = path.join(MAIN_REPO_ROOT, ".claude", "hooks", "hook-debug.log");
+const SESSION_STORE_FILE = path.join(MAIN_REPO_ROOT, ".claude", "hooks", "tg-session-store.json");
+const APPROVER_PID_FILE = path.join(MAIN_REPO_ROOT, ".claude", "hooks", "approver-active.pid");
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function log(msg) {
+    try { fs.appendFileSync(LOG_FILE, "[" + new Date().toISOString() + "] Gate: " + msg + "\n"); } catch(e) {}
+}
+
+function telegramPost(method, params, timeoutMs) {
+    return new Promise((resolve, reject) => {
+        const postData = JSON.stringify(params);
+        const req = https.request({
+            hostname: "api.telegram.org",
+            path: "/bot" + BOT_TOKEN + "/" + method,
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "Content-Length": Buffer.byteLength(postData)
+            },
+            timeout: timeoutMs || 8000
+        }, (res) => {
+            let d = "";
+            res.on("data", (c) => d += c);
+            res.on("end", () => {
+                try {
+                    const r = JSON.parse(d);
+                    if (r.ok) resolve(r.result);
+                    else reject(new Error(JSON.stringify(r)));
+                } catch(e) { reject(e); }
+            });
+        });
+        req.on("timeout", () => { req.destroy(); reject(new Error("timeout " + method)); });
+        req.on("error", (e) => reject(e));
+        req.write(postData);
+        req.end();
+    });
+}
+
+function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
+
+function escHtml(s) {
+    return String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+function abbreviate(str, max) {
+    if (!str) return "";
+    str = str.trim();
+    return str.length > max ? str.substring(0, max) + "\u2026" : str;
+}
+
+function getSkillContext() {
+    try {
+        const data = JSON.parse(fs.readFileSync(SESSION_STORE_FILE, "utf8"));
+        const session = data.active_session;
+        if (!session || !session.skill) return null;
+        const elapsed = Date.now() - new Date(session.last_used).getTime();
+        if (elapsed > 30 * 60 * 1000) return null;
+        return session.skill;
+    } catch (e) {
+        return null;
+    }
+}
+
+// ─── Formato de accion para el mensaje ────────────────────────────────────────
+
+function formatBashAction(toolInput) {
+    const cmd = (toolInput.command || "").trim();
+    const desc = (toolInput.description || "").trim();
+    const display = cmd.length > 250 ? cmd.substring(0, 250) + "\u2026" : cmd;
+    let result = "";
+    if (desc) {
+        result += "\u{1F527} <b>" + escHtml(abbreviate(desc, 80)) + "</b>\n";
+    }
+    result += "<code>$ " + escHtml(display) + "</code>";
+    return result;
+}
+
+function formatContext(sessionId, repoRoot) {
+    const ctx = readSessionContext(sessionId, repoRoot);
+    const lines = [];
+    if (ctx.agentName) {
+        lines.push("\u{1F916} " + escHtml(ctx.agentName));
+    } else if (ctx.skill) {
+        lines.push("\u26A1 /" + escHtml(ctx.skill));
+    }
+    if (ctx.branch && ctx.branch !== "main" && ctx.branch !== "develop") {
+        let branchDisplay = escHtml(ctx.branch);
+        const issueMatch = ctx.branch.match(/(?:agent|feature|bugfix)\/(\d+)/);
+        if (issueMatch) branchDisplay += " (#" + issueMatch[1] + ")";
+        lines.push("\u{1F500} " + branchDisplay);
+    }
+    if (ctx.task) {
+        lines.push("\u{1F4CC} " + escHtml(abbreviate(ctx.task, 60)));
+    }
+    return lines.length > 0 ? lines.join("  \u00B7  ") : "";
+}
+
+// ─── Auto-approve: fast-path para comandos ya cubiertos ─────────────────────
+
+function isCommandCoveredByRules(toolInput) {
+    const pattern = generatePattern("Bash", toolInput);
+    if (!pattern) return false;
+
+    const cmd = (toolInput.command || "").trim();
+    const separators = /;|&&/;
+
+    // Para comandos compuestos, verificar cada sub-comando
+    if (separators.test(cmd)) {
+        const subCmds = cmd.split(separators).map(s => s.trim()).filter(Boolean);
+        const settingsPaths = getSettingsPaths(REPO_ROOT);
+        for (const sp of settingsPaths) {
+            try {
+                const s = JSON.parse(fs.readFileSync(sp, "utf8"));
+                const allow = (s.permissions && s.permissions.allow) || [];
+                const deny = (s.permissions && s.permissions.deny) || [];
+                const allCovered = subCmds.every(sub => {
+                    const subPattern = generateBashPattern(sub);
+                    return subPattern && isAlreadyCovered(subPattern, allow);
+                });
+                const denyMatch = deny.some(d => {
+                    const dm = d.match(/^Bash\((.+?):\*\)$/);
+                    if (!dm) return false;
+                    return subCmds.some(sub => sub.startsWith(dm[1]));
+                });
+                if (allCovered && !denyMatch) return true;
+            } catch(e) {}
+        }
+        return false;
+    }
+
+    // Caso simple: un solo comando
+    const settingsPaths = getSettingsPaths(REPO_ROOT);
+    for (const sp of settingsPaths) {
+        try {
+            const s = JSON.parse(fs.readFileSync(sp, "utf8"));
+            const allow = (s.permissions && s.permissions.allow) || [];
+            if (isAlreadyCovered(pattern, allow)) return true;
+        } catch(e) {}
+    }
+    return false;
+}
+
+// ─── Polling ──────────────────────────────────────────────────────────────────
+
+async function pollQuestionStatus(requestId, durationMs, attemptLabel) {
+    const pollStart = Date.now();
+    let logCounter = 0;
+    while (Date.now() - pollStart < durationMs) {
+        try {
+            const q = getQuestionById(requestId);
+            if (!q) {
+                log("Pregunta " + requestId + " desaparecio");
+                return null;
+            }
+            if (q.status !== "pending") {
+                log("Pregunta " + requestId + " cambio a: " + q.status
+                    + " via=" + (q.answered_via || "?")
+                    + " action=" + (q.action_result || "?"));
+                return q;
+            }
+        } catch(e) {
+            log("Error leyendo pregunta " + requestId + ": " + e.message);
+        }
+        logCounter++;
+        if (logCounter % 200 === 0) {
+            const elapsed = Math.round((Date.now() - pollStart) / 1000);
+            log("Polling " + attemptLabel + " " + requestId + ": " + elapsed + "s elapsed, pid=" + process.pid);
+        }
+        await sleep(POLL_INTERVAL_MS);
+    }
+    return null;
+}
+
+// ─── PreToolUse response helpers ──────────────────────────────────────────────
+
+function outputAllow(reason) {
+    const response = JSON.stringify({
+        hookSpecificOutput: {
+            hookEventName: "PreToolUse",
+            permissionDecision: "allow",
+            permissionDecisionReason: reason || "Aprobado via Telegram"
+        }
+    });
+    process.stdout.write(response + "\n", () => process.exit(0));
+    setTimeout(() => process.exit(0), 500);
+}
+
+function outputDeny(reason) {
+    const response = JSON.stringify({
+        hookSpecificOutput: {
+            hookEventName: "PreToolUse",
+            permissionDecision: "deny",
+            permissionDecisionReason: reason || "Denegado por el usuario via Telegram"
+        }
+    });
+    process.stdout.write(response + "\n", () => process.exit(0));
+    setTimeout(() => process.exit(0), 500);
+}
+
+function exitSilent() {
+    process.exit(0);
+}
+
+// ─── Smart suggestion (tras 3ra aprobacion del mismo patron) ──────────────────
+
+async function maybeSuggestPersistence(toolInput) {
+    try {
+        const pattern = generatePattern("Bash", toolInput);
+        if (!pattern || isPatternPersisted(pattern)) return;
+
+        const { count, shouldSuggest } = incrementApproval(pattern);
+        if (!shouldSuggest) return;
+
+        const encodedPattern = Buffer.from(pattern).toString("base64url");
+        const suggestionText = "\u{1F4A1} Has aprobado <code>" + escHtml(pattern) + "</code> " + count + " veces.\n"
+            + "\u00BFGuardar como regla permanente?";
+
+        const msg = await telegramPost("sendMessage", {
+            chat_id: CHAT_ID,
+            text: suggestionText,
+            parse_mode: "HTML",
+            reply_markup: {
+                inline_keyboard: [[
+                    { text: "\u2705 Guardar", callback_data: "persist:" + encodedPattern },
+                    { text: "\u274C No", callback_data: "dismiss:" + encodedPattern }
+                ]]
+            }
+        }, 8000);
+        registerMessage(msg.message_id, "permission");
+        log("Smart suggestion enviada para " + pattern + " (count=" + count + ")");
+    } catch(e) {
+        log("Error en smart suggestion: " + e.message);
+    }
+}
+
+// ─── Persist "always" ─────────────────────────────────────────────────────────
+
+function persistAlways(toolInput) {
+    const pattern = generatePattern("Bash", toolInput);
+    log("persistAlways: pattern=" + (pattern || "NULL"));
+    if (!pattern) return;
+    const settingsPaths = getSettingsPaths(REPO_ROOT);
+    persistPattern(pattern, settingsPaths, log);
+}
+
+// ─── Stdin reader ─────────────────────────────────────────────────────────────
+
+const MAX_READ = 8192;
+let rawInput = "";
+let done = false;
+
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => {
+    if (done) return;
+    rawInput += chunk;
+    if (rawInput.length >= MAX_READ) {
+        done = true;
+        process.stdin.destroy();
+        processInput().catch(fatalExit);
+    }
+});
+process.stdin.on("end", () => {
+    if (!done) { done = true; processInput().catch(fatalExit); }
+});
+process.stdin.on("error", () => {
+    if (!done) { done = true; processInput().catch(fatalExit); }
+});
+setTimeout(() => {
+    if (!done) {
+        done = true;
+        try { process.stdin.destroy(); } catch(e) {}
+        processInput().catch(fatalExit);
+    }
+}, 3000);
+
+function fatalExit(e) {
+    log("Fatal error: " + (e && e.message || e));
+    process.exit(0); // fallback a dialogo local
+}
+
+// ─── Main ──────────────────────────────────────────────────────────────────────
+
+async function processInput() {
+    const startTime = Date.now();
+    log("INPUT: " + rawInput.substring(0, 300));
+
+    let data;
+    try { data = JSON.parse(rawInput); } catch(e) {
+        log("JSON parse failed: " + rawInput.substring(0, 200));
+        exitSilent();
+        return;
+    }
+
+    const toolName = data.tool_name || data.toolName || "";
+    const toolInput = data.tool_input || data.toolInput || {};
+
+    // Solo manejar Bash — otros tools salen sin output
+    if (toolName !== "Bash") {
+        exitSilent();
+        return;
+    }
+
+    const agent = process.env.CLAUDE_AGENT_NAME || "Claude Code";
+    const requestId = crypto.randomBytes(8).toString("hex");
+
+    log("REPO_ROOT=" + REPO_ROOT + " MAIN=" + MAIN_REPO_ROOT + " tool=Bash");
+
+    // Fast-path: auto-allow si esta cubierto por reglas existentes
+    if (isCommandCoveredByRules(toolInput)) {
+        log("COVERED: comando ya cubierto por settings rules — saliendo sin output");
+        exitSilent(); // Claude Code lo aprobara via su propia logica
+        return;
+    }
+
+    // ─── Necesita permiso → Enviar a Telegram ────────────────────────────────
+    const action = formatBashAction(toolInput);
+    const sessionId = data.session_id || "";
+    const contextLine = formatContext(sessionId, MAIN_REPO_ROOT);
+    const waitMin = Math.round(RETRY_INTERVALS[0] / 60000);
+
+    let msgText = "\u{1F510} <b>" + escHtml(agent) + " \u2014 PERMISO REQUERIDO</b>\n";
+    if (contextLine) msgText += contextLine + "\n";
+    msgText += "\n" + action + "\n\n"
+        + "\u23F3 Expira en " + waitMin + " min"
+        + "\n\u{1F4DD} Usar botones o responder: <b>siempre</b> (para persistir)";
+
+    let sentMsg;
+    try {
+        sentMsg = await telegramPost("sendMessage", {
+            chat_id: CHAT_ID,
+            text: msgText,
+            parse_mode: "HTML",
+            reply_markup: {
+                inline_keyboard: [[
+                    { text: "\u2705 Permitir", callback_data: "allow:" + requestId },
+                    { text: "\u274C Rechazar", callback_data: "deny:" + requestId }
+                ]]
+            }
+        }, 8000);
+        log("Mensaje enviado: msg_id=" + sentMsg.message_id + " requestId=" + requestId);
+        registerMessage(sentMsg.message_id, "permission");
+
+        addPendingQuestion({
+            id: requestId,
+            type: "permission",
+            message: action,
+            original_html: msgText,
+            telegram_message_id: sentMsg.message_id,
+            options: [
+                { label: "Permitir", action: "allow" },
+                { label: "Rechazar", action: "deny" }
+            ],
+            action_data: { tool_name: "Bash", tool_input: toolInput, agent: agent },
+            skill_context: getSkillContext(),
+            approver_pid: process.pid
+        });
+    } catch(e) {
+        log("Error enviando mensaje: " + e.message);
+        exitSilent(); // fallback a dialogo local
+        return;
+    }
+
+    let currentMsgId = sentMsg.message_id;
+
+    // PID file para deteccion por otros hooks
+    try {
+        fs.writeFileSync(APPROVER_PID_FILE, JSON.stringify({
+            pid: process.pid,
+            requestId,
+            msgId: currentMsgId,
+            timestamp: new Date().toISOString()
+        }));
+    } catch(e) {}
+    function cleanupPidFile() { try { fs.unlinkSync(APPROVER_PID_FILE); } catch(e) {} }
+    process.on("exit", cleanupPidFile);
+
+    // ─── Retry loop con urgencia escalada ────────────────────────────────────
+    const totalAttempts = RETRY_INTERVALS.length;
+
+    for (let attempt = 0; attempt < totalAttempts; attempt++) {
+        const waitMs = RETRY_INTERVALS[attempt];
+        const label = "intento " + (attempt + 1) + "/" + totalAttempts;
+        log("Polling " + label + " para " + requestId
+            + " (PID=" + process.pid + ", espera=" + Math.round(waitMs / 60000) + "min)");
+
+        const result = await pollQuestionStatus(requestId, waitMs, label);
+
+        // ── Respondido ──
+        if (result && result.status === "answered") {
+            const actionResult = result.action_result;
+            const latencyMs = Date.now() - startTime;
+
+            log("Decision via Telegram: " + actionResult + " en " + latencyMs + "ms (" + label + ")");
+
+            const isAllow = (actionResult === "allow" || actionResult === "always");
+
+            if (isAllow) {
+                // Track approval + smart suggestion (no bloquea la respuesta)
+                maybeSuggestPersistence(toolInput).catch(e => log("Suggestion error: " + e.message));
+
+                if (actionResult === "always") {
+                    persistAlways(toolInput);
+                }
+
+                outputAllow("Aprobado via Telegram por el usuario (" + latencyMs + "ms)");
+            } else {
+                outputDeny("Denegado por el usuario via Telegram (" + latencyMs + "ms)");
+            }
+            return;
+        }
+
+        // ── Timeout de este intento ──
+        const isLastAttempt = (attempt === totalAttempts - 1);
+        const elapsedTotal = Math.round((Date.now() - startTime) / 1000);
+
+        if (isLastAttempt) {
+            log("Todos los reintentos agotados (" + elapsedTotal + "s total). Fallback a consola.");
+            resolveQuestion(requestId, "expired", null);
+            try {
+                await telegramPost("editMessageText", {
+                    chat_id: CHAT_ID,
+                    message_id: currentMsgId,
+                    text: msgText + "\n\n\u23F1 <i>Expirado (" + totalAttempts + " intentos) \u2014 respondiendo en consola</i>",
+                    parse_mode: "HTML",
+                    reply_markup: { inline_keyboard: [] }
+                }, ANSWER_TIMEOUT);
+            } catch(e) { log("Error editando mensaje final: " + e.message); }
+            exitSilent(); // fallback a dialogo local
+            return;
+        }
+
+        // ── Enviar reintento con urgencia escalada ──
+        const nextAttempt = attempt + 1;
+        const escalation = RETRY_ESCALATION[nextAttempt] || RETRY_ESCALATION[RETRY_ESCALATION.length - 1];
+        const nextWaitMin = Math.round(RETRY_INTERVALS[nextAttempt] / 60000);
+
+        log("Timeout " + label + " (" + elapsedTotal + "s). Enviando reintento " + (nextAttempt + 1) + "/" + totalAttempts);
+
+        // Editar mensaje anterior: quitar botones, marcar como expirado
+        try {
+            await telegramPost("editMessageText", {
+                chat_id: CHAT_ID,
+                message_id: currentMsgId,
+                text: msgText + "\n\n\u23F1 <i>Sin respuesta \u2014 reintentando\u2026</i>",
+                parse_mode: "HTML",
+                reply_markup: { inline_keyboard: [] }
+            }, ANSWER_TIMEOUT);
+        } catch(e) { log("Error editando mensaje expirado: " + e.message); }
+
+        // Construir mensaje de reintento
+        let retryText = escalation.emoji + " <b>" + escHtml(agent) + " \u2014 " + escalation.title + "</b>"
+            + "  <i>(" + (nextAttempt + 1) + "/" + totalAttempts + ")</i>\n";
+        if (contextLine) retryText += contextLine + "\n";
+        if (escalation.desc) retryText += "\n" + escalation.desc + "\n";
+        retryText += "\n" + action + "\n\n"
+            + "\u23F3 Expira en " + nextWaitMin + " min"
+            + "\n\u{1F4DD} Usar botones o responder: <b>siempre</b> (para persistir)";
+
+        try {
+            const retryMsg = await telegramPost("sendMessage", {
+                chat_id: CHAT_ID,
+                text: retryText,
+                parse_mode: "HTML",
+                reply_markup: {
+                    inline_keyboard: [[
+                        { text: "\u2705 Permitir", callback_data: "allow:" + requestId },
+                        { text: "\u274C Rechazar", callback_data: "deny:" + requestId }
+                    ]]
+                }
+            }, 8000);
+            currentMsgId = retryMsg.message_id;
+            registerMessage(retryMsg.message_id, "permission");
+            updateQuestionField(requestId, { telegram_message_id: retryMsg.message_id });
+            msgText = retryText;
+            log("Reintento " + (nextAttempt + 1) + "/" + totalAttempts + " enviado: msg_id=" + retryMsg.message_id);
+        } catch(e) {
+            log("Error enviando reintento: " + e.message);
+        }
+    }
+}

--- a/.claude/hooks/telegram-config.json
+++ b/.claude/hooks/telegram-config.json
@@ -3,5 +3,6 @@
   "chat_id": "6529617704",
   "permission_timeout_min": 60,
   "task_report_interval_min": 10,
-  "retry_intervals_min": [30, 15, 10, 10]
+  "retry_intervals_min": [30, 15, 10, 10],
+  "gate_retry_intervals_min": [15, 8, 5, 2]
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,17 +1,5 @@
 {
   "hooks": {
-    "PermissionRequest": [
-      {
-        "matcher": "",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node /c/Workspaces/Intrale/platform/.claude/hooks/permission-approver.js",
-            "timeout": 4020000
-          }
-        ]
-      }
-    ],
     "Notification": [
       {
         "matcher": "",
@@ -49,6 +37,11 @@
             "type": "command",
             "command": "node /c/Workspaces/Intrale/platform/.claude/hooks/branch-guard.js",
             "timeout": 5000
+          },
+          {
+            "type": "command",
+            "command": "node /c/Workspaces/Intrale/platform/.claude/hooks/permission-gate.js",
+            "timeout": 1830000
           }
         ]
       }


### PR DESCRIPTION
## Resumen

- Reemplaza el hook `PermissionRequest` (bugs #12176, #29212 en Claude Code) por `PreToolUse` que dispara **siempre** antes de cada tool use
- Crea `permission-gate.js`: intercepta solo Bash, envía a Telegram con botones inline, retry escalado 🔐→🔔→⚠️→🚨 en 30 min, fallback silencioso a diálogo local
- Crea `approval-history.js`: tracking de aprobaciones por patrón + smart suggestion tras 3 aprobaciones
- Respuesta `"siempre"` como texto libre persiste el patrón en `settings.local.json`
- Agrega clave `gate_retry_intervals_min` en `telegram-config.json` para configurar reintentos del gate independientemente del approver legacy

## Plan de tests

- [x] Comando no cubierto → llega a Telegram con botones inline
- [x] Botón "✅ Permitir" → Claude Code ejecuta sin diálogo local (11.2s)
- [x] Botón "❌ Rechazar" → Tool bloqueado "Denegado por el usuario via Telegram" (6.5s)
- [x] Texto libre "siempre" → aprueba + persiste `Bash(id:*)` en settings.local.json
- [x] Comando cubierto por allow list → fast-path silencioso, sin preguntar
- [x] Sin respuesta → 4 reintentos escalados → fallback a consola local (41s en test)

Closes #1167

🤖 Generado con [Claude Code](https://claude.ai/claude-code)