### PR TITLE
feat(scrum): generar y enviar reporte automático al finalizar sprint y ejecuciones

### DIFF
--- a/.claude/hooks/stop-notify.js
+++ b/.claude/hooks/stop-notify.js
@@ -1,4 +1,6 @@
-// Hook Stop: notifica a Telegram (imagen card) y marca sesion como "done"
+// Hook Stop: notifica a Telegram (imagen card o mini-reporte) y marca sesion como "done"
+// Para ejecuciones individuales: enriquece con datos de sesión (issue, tareas, PR, duración)
+// Para ejecuciones de sprint: mantiene comportamiento simple (sprint-report.js cubre)
 // Pure Node.js — sin dependencia de bash
 const https = require("https");
 const querystring = require("querystring");
@@ -148,6 +150,57 @@ function escapeHtml(text) {
     return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
+/**
+ * Detecta si la sesión actual es parte de un sprint (PID en sprint-pids.json).
+ */
+function isSprintSession(sessionId) {
+    try {
+        const pidsFile = path.join(REPO_ROOT, "scripts", "sprint-pids.json");
+        if (!fs.existsSync(pidsFile)) return false;
+        const pidsData = JSON.parse(fs.readFileSync(pidsFile, "utf8"));
+        // sprint-pids.json tiene: { "agente_1": PID, "agente_2": PID }
+        // Verificar si el PID actual coincide con alguno del sprint
+        const currentPid = process.ppid || process.pid;
+        for (const key of Object.keys(pidsData)) {
+            if (pidsData[key] === currentPid) return true;
+        }
+        // También verificar por sessionId en las sesiones del sprint
+        // Buscar en sessions/ alguna sesión que matchee las ramas del sprint plan
+        const planFile = path.join(REPO_ROOT, "scripts", "sprint-plan.json");
+        if (!fs.existsSync(planFile)) return false;
+        const plan = JSON.parse(fs.readFileSync(planFile, "utf8"));
+        const shortId = (sessionId || "").substring(0, 8);
+        const sessionFile = path.join(SESSIONS_DIR, shortId + ".json");
+        if (!fs.existsSync(sessionFile)) return false;
+        const session = JSON.parse(fs.readFileSync(sessionFile, "utf8"));
+        if (!session.branch) return false;
+        // Si la rama de la sesión matchea un agente del plan, es sprint
+        for (const ag of (plan.agentes || [])) {
+            if (session.branch.includes(String(ag.issue))) return true;
+        }
+        return false;
+    } catch(e) {
+        log("isSprintSession error: " + e.message);
+        return false;
+    }
+}
+
+/**
+ * Intenta construir un mini-reporte enriquecido para ejecuciones individuales.
+ */
+function buildMiniReport(sessionId) {
+    try {
+        const executionReport = require(path.join(REPO_ROOT, "scripts", "execution-report.js"));
+        const shortId = (sessionId || "").substring(0, 8);
+        const summary = executionReport.buildExecutionSummary(shortId, REPO_ROOT);
+        if (!summary || !summary.found) return null;
+        return executionReport.formatTelegramHtml(summary);
+    } catch(e) {
+        log("buildMiniReport error: " + e.message);
+        return null;
+    }
+}
+
 async function processInput() {
     log("INPUT: " + rawInput.substring(0, 300));
 
@@ -156,11 +209,49 @@ async function processInput() {
 
     if (data.stop_hook_active) return;
 
+    const sessionId = data.session_id || "";
+
     // Marcar sesion como terminada
-    markSessionDone(data.session_id || "");
+    markSessionDone(sessionId);
 
     // Rotacion: limpiar sessions "done" con mas de 2h de antiguedad
     cleanOldSessions();
+
+    // Detectar si es ejecución de sprint
+    const isSprint = isSprintSession(sessionId);
+
+    if (!isSprint) {
+        // Ejecución individual: intentar mini-reporte enriquecido
+        const miniReport = buildMiniReport(sessionId);
+        if (miniReport) {
+            log("Enviando mini-reporte enriquecido (individual)");
+            // Agregar último mensaje truncado al final
+            const raw = (data.last_assistant_message || "").trim();
+            const clean = stripMarkdown(raw);
+            const lastMsg = clean.length > 0 ? "\n\n💬 " + escapeHtml(truncateSmart(clean, 200)) : "";
+            const fullText = miniReport + lastMsg;
+
+            for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+                try {
+                    const r = await sendTelegram(fullText, attempt);
+                    if (r && r.result && r.result.message_id) {
+                        registerMessage(r.result.message_id, "stop");
+                    }
+                    return;
+                } catch(e) {
+                    if (attempt < MAX_RETRIES) {
+                        log("Mini-reporte reintentando en " + RETRY_DELAY_MS + "ms...");
+                        await new Promise(r => setTimeout(r, RETRY_DELAY_MS));
+                    } else {
+                        log("Mini-reporte FALLO, fallback a texto simple");
+                    }
+                }
+            }
+            // Si falla el mini-reporte, caer al texto simple (abajo)
+        }
+    } else {
+        log("Ejecución de sprint detectada — omitiendo mini-reporte (sprint-report.js lo cubre)");
+    }
 
     const raw = (data.last_assistant_message || "").trim();
     const clean = stripMarkdown(raw);

--- a/scripts/Watch-Agentes.ps1
+++ b/scripts/Watch-Agentes.ps1
@@ -226,6 +226,25 @@ catch {
 
 Write-Host ''
 
+# --- Generar reporte de sprint ---
+$sprintReportScript = Join-Path $PSScriptRoot 'sprint-report.js'
+if (Test-Path $sprintReportScript) {
+    Write-Log 'Generando reporte de sprint...' 'Cyan'
+    try {
+        & node $sprintReportScript $PlanFile
+        Write-Log 'Reporte de sprint generado.' 'Green'
+    }
+    catch {
+        Write-Log ('Error generando reporte: {0}' -f $_.Exception.Message) 'Yellow'
+        # Fail-open: continuar igualmente
+    }
+}
+else {
+    Write-Log 'sprint-report.js no encontrado, omitiendo reporte.' 'Yellow'
+}
+
+Write-Host ''
+
 # --- Preguntar si planificar el siguiente sprint ---
 $confirmed = $false
 

--- a/scripts/execution-report.js
+++ b/scripts/execution-report.js
@@ -1,0 +1,242 @@
+#!/usr/bin/env node
+// execution-report.js — Módulo reutilizable para resúmenes de sesión
+// Exporta buildExecutionSummary(sessionId, repoRoot) → objeto con datos del mini-reporte
+// Usado desde stop-notify.js (individual) y sprint-report.js (por agente)
+
+const fs = require("fs");
+const path = require("path");
+const { execSync } = require("child_process");
+
+const GH_PATH = "/c/Workspaces/gh-cli/bin/gh.exe";
+
+/**
+ * Ejecuta un comando shell y retorna stdout (trimmed). Retorna null si falla.
+ */
+function execSafe(cmd, opts = {}) {
+    try {
+        return execSync(cmd, { encoding: "utf8", timeout: 15000, ...opts }).trim();
+    } catch (e) {
+        return null;
+    }
+}
+
+/**
+ * Lee un JSON file de forma segura.
+ */
+function readJsonSafe(filePath) {
+    try {
+        if (!fs.existsSync(filePath)) return null;
+        return JSON.parse(fs.readFileSync(filePath, "utf8"));
+    } catch (e) {
+        return null;
+    }
+}
+
+/**
+ * Extrae el issue number desde un nombre de rama.
+ * "agent/1177-ops-skill" → 1177
+ */
+function extractIssueFromBranch(branch) {
+    if (!branch) return null;
+    const m = branch.match(/(?:agent|feature|bugfix)\/(\d+)/);
+    return m ? parseInt(m[1], 10) : null;
+}
+
+/**
+ * Cuenta herramientas usadas en activity-log.jsonl filtrando por sessionId.
+ * Retorna { total, byTool: { Bash: N, Edit: N, ... }, topTools: "Bash(5), Edit(3)" }
+ */
+function countToolsFromActivityLog(activityLogPath, sessionId) {
+    const result = { total: 0, byTool: {}, topTools: "" };
+    try {
+        if (!fs.existsSync(activityLogPath)) return result;
+        const lines = fs.readFileSync(activityLogPath, "utf8").split("\n").filter(Boolean);
+        for (const line of lines) {
+            try {
+                const entry = JSON.parse(line);
+                if (sessionId && entry.session !== sessionId) continue;
+                const tool = entry.tool || "unknown";
+                result.byTool[tool] = (result.byTool[tool] || 0) + 1;
+                result.total++;
+            } catch (e) { /* skip malformed lines */ }
+        }
+        // Top tools (top 3)
+        const sorted = Object.entries(result.byTool).sort((a, b) => b[1] - a[1]).slice(0, 3);
+        result.topTools = sorted.map(([t, n]) => `${t}(${n})`).join(", ");
+    } catch (e) { /* ignore */ }
+    return result;
+}
+
+/**
+ * Busca el PR asociado a una rama via gh CLI.
+ * Retorna { number, title, state, url } o null.
+ */
+function findPRForBranch(branch, repoRoot) {
+    if (!branch) return null;
+    const raw = execSafe(
+        `"${GH_PATH}" pr list --head "${branch}" --json number,title,state,url --limit 1 --repo intrale/platform`,
+        { cwd: repoRoot }
+    );
+    if (!raw) return null;
+    try {
+        const prs = JSON.parse(raw);
+        return prs.length > 0 ? prs[0] : null;
+    } catch (e) { return null; }
+}
+
+/**
+ * Obtiene título de un issue via gh CLI.
+ */
+function getIssueTitle(issueNumber, repoRoot) {
+    if (!issueNumber) return null;
+    const raw = execSafe(
+        `"${GH_PATH}" issue view ${issueNumber} --json title --jq .title --repo intrale/platform`,
+        { cwd: repoRoot }
+    );
+    return raw || null;
+}
+
+/**
+ * Calcula la duración en minutos entre dos timestamps ISO.
+ */
+function durationMinutes(startTs, endTs) {
+    try {
+        const start = new Date(startTs).getTime();
+        const end = endTs ? new Date(endTs).getTime() : Date.now();
+        return Math.round((end - start) / 60000);
+    } catch (e) { return 0; }
+}
+
+/**
+ * Construye el resumen de ejecución para una sesión.
+ * @param {string} sessionId - ID corto de la sesión (8 chars)
+ * @param {string} repoRoot - Ruta raíz del repo
+ * @returns {object} Resumen con todos los datos del mini-reporte
+ */
+function buildExecutionSummary(sessionId, repoRoot) {
+    repoRoot = repoRoot || process.env.CLAUDE_PROJECT_DIR || "C:\\Workspaces\\Intrale\\platform";
+
+    const sessionsDir = path.join(repoRoot, ".claude", "sessions");
+    const activityLog = path.join(repoRoot, ".claude", "activity-log.jsonl");
+
+    // Leer session file
+    const sessionFile = path.join(sessionsDir, sessionId + ".json");
+    const session = readJsonSafe(sessionFile);
+
+    if (!session) {
+        return {
+            sessionId,
+            found: false,
+            agentName: "Desconocido",
+            branch: null,
+            issueNumber: null,
+            issueTitle: null,
+            tasksCompleted: 0,
+            tasksTotal: 0,
+            actionCount: 0,
+            toolsSummary: "",
+            topTools: "",
+            pr: null,
+            durationMin: 0,
+            startedTs: null,
+            endedTs: null,
+            skillsInvoked: [],
+            status: "unknown"
+        };
+    }
+
+    const branch = session.branch || null;
+    const issueNumber = extractIssueFromBranch(branch);
+    const issueTitle = getIssueTitle(issueNumber, repoRoot);
+
+    // Tareas
+    const tasks = session.current_tasks || [];
+    const tasksCompleted = tasks.filter(t => t.status === "completed").length;
+    const tasksTotal = tasks.length;
+
+    // Herramientas desde activity log
+    const tools = countToolsFromActivityLog(activityLog, sessionId);
+
+    // PR asociado
+    const pr = findPRForBranch(branch, repoRoot);
+
+    // Duración
+    const durationMin = durationMinutes(session.started_ts, session.last_activity_ts);
+
+    // Nombre del agente
+    const agentName = session.agent_name
+        || (session.skills_invoked && session.skills_invoked.length > 0
+            ? session.skills_invoked.join(", ")
+            : "Ad-hoc");
+
+    return {
+        sessionId,
+        found: true,
+        agentName,
+        branch,
+        issueNumber,
+        issueTitle,
+        tasksCompleted,
+        tasksTotal,
+        actionCount: session.action_count || tools.total,
+        toolsSummary: tools.topTools,
+        topTools: tools.topTools,
+        byTool: tools.byTool,
+        pr,
+        durationMin,
+        startedTs: session.started_ts,
+        endedTs: session.last_activity_ts,
+        skillsInvoked: session.skills_invoked || [],
+        status: session.status || "unknown"
+    };
+}
+
+/**
+ * Formatea el resumen como mensaje HTML para Telegram.
+ */
+function formatTelegramHtml(summary) {
+    const lines = [];
+    lines.push("🤖 <b>Ejecución finalizada</b>");
+    lines.push("");
+    lines.push(`🎯 <b>Agente:</b> ${escapeHtml(summary.agentName)}`);
+
+    if (summary.issueNumber) {
+        const title = summary.issueTitle ? ` — ${escapeHtml(summary.issueTitle)}` : "";
+        lines.push(`🔖 <b>Issue:</b> #${summary.issueNumber}${title}`);
+    }
+
+    if (summary.tasksTotal > 0) {
+        lines.push(`✅ <b>Tareas:</b> ${summary.tasksCompleted}/${summary.tasksTotal}`);
+    }
+
+    lines.push(`🛠 <b>Herramientas:</b> ${summary.actionCount} acciones${summary.topTools ? ` (${escapeHtml(summary.topTools)})` : ""}`);
+
+    if (summary.branch) {
+        lines.push(`🌿 <b>Rama:</b> ${escapeHtml(summary.branch)}`);
+    }
+
+    if (summary.pr) {
+        const stateEmoji = summary.pr.state === "MERGED" ? "🟣" : summary.pr.state === "OPEN" ? "🟢" : "🔴";
+        lines.push(`🔗 <b>PR:</b> #${summary.pr.number} ${escapeHtml(summary.pr.title)} [${stateEmoji} ${summary.pr.state}]`);
+    }
+
+    lines.push(`⏱ <b>Duración:</b> ${summary.durationMin} min`);
+
+    return lines.join("\n");
+}
+
+function escapeHtml(text) {
+    if (!text) return "";
+    return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+module.exports = {
+    buildExecutionSummary,
+    formatTelegramHtml,
+    extractIssueFromBranch,
+    countToolsFromActivityLog,
+    findPRForBranch,
+    getIssueTitle,
+    durationMinutes,
+    escapeHtml
+};

--- a/scripts/sprint-report.js
+++ b/scripts/sprint-report.js
@@ -1,0 +1,608 @@
+#!/usr/bin/env node
+// sprint-report.js — Genera HTML+PDF del sprint y lo envía a Telegram
+// Uso: node sprint-report.js [path-to-sprint-plan.json]
+// Fail-open: cualquier error queda en scripts/logs/sprint-report.log sin interrumpir el flujo
+
+const fs = require("fs");
+const path = require("path");
+const { execSync } = require("child_process");
+const { buildExecutionSummary, escapeHtml, durationMinutes } = require("./execution-report");
+
+// --- Config ---
+const REPO_ROOT = path.resolve(__dirname, "..");
+const GH_PATH = "/c/Workspaces/gh-cli/bin/gh.exe";
+const LOG_DIR = path.join(__dirname, "logs");
+const LOG_FILE = path.join(LOG_DIR, "sprint-report.log");
+const QA_DIR = path.join(REPO_ROOT, "docs", "qa");
+const GENERATE_PDF = path.join(QA_DIR, "generate-pdf.js");
+const TG_CONFIG_PATH = path.join(REPO_ROOT, ".claude", "hooks", "telegram-config.json");
+
+// --- Logging ---
+function ensureDir(dir) {
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+}
+
+function log(msg) {
+    ensureDir(LOG_DIR);
+    const ts = new Date().toISOString();
+    try { fs.appendFileSync(LOG_FILE, `[${ts}] ${msg}\n`); } catch (e) { /* ignore */ }
+}
+
+function execSafe(cmd, opts = {}) {
+    try {
+        return execSync(cmd, { encoding: "utf8", timeout: 30000, ...opts }).trim();
+    } catch (e) {
+        log(`execSafe failed: ${cmd.substring(0, 100)} → ${e.message}`);
+        return null;
+    }
+}
+
+// --- Telegram ---
+function loadTelegramConfig() {
+    try {
+        return JSON.parse(fs.readFileSync(TG_CONFIG_PATH, "utf8"));
+    } catch (e) {
+        log("No se pudo leer telegram-config.json: " + e.message);
+        return null;
+    }
+}
+
+function sendTelegramDocument(botToken, chatId, filePath, caption) {
+    // Usar curl para enviar documento (multipart/form-data no es trivial con https nativo)
+    const cmd = `curl -s -X POST "https://api.telegram.org/bot${botToken}/sendDocument" ` +
+        `-F "chat_id=${chatId}" ` +
+        `-F "document=@${filePath.replace(/\\/g, "/")}" ` +
+        `-F "caption=${caption.replace(/"/g, '\\"')}"`;
+    const result = execSafe(cmd);
+    if (result) {
+        try {
+            const parsed = JSON.parse(result);
+            if (parsed.ok) {
+                log("Documento enviado a Telegram OK");
+                return true;
+            }
+            log("Telegram API error: " + result);
+        } catch (e) {
+            log("Error parseando respuesta Telegram: " + result);
+        }
+    }
+    return false;
+}
+
+function sendTelegramMessage(botToken, chatId, text) {
+    const cmd = `curl -s -X POST "https://api.telegram.org/bot${botToken}/sendMessage" ` +
+        `-d "chat_id=${chatId}" ` +
+        `-d "parse_mode=HTML" ` +
+        `--data-urlencode "text=${text}"`;
+    return execSafe(cmd);
+}
+
+// --- Snapshot de sesiones ---
+function snapshotSessions() {
+    const sessionsDir = path.join(REPO_ROOT, ".claude", "sessions");
+    const snapshot = {};
+    try {
+        if (!fs.existsSync(sessionsDir)) return snapshot;
+        const files = fs.readdirSync(sessionsDir).filter(f => f.endsWith(".json"));
+        for (const file of files) {
+            try {
+                const data = JSON.parse(fs.readFileSync(path.join(sessionsDir, file), "utf8"));
+                snapshot[file.replace(".json", "")] = data;
+            } catch (e) { /* skip */ }
+        }
+    } catch (e) { log("Error snapshot sesiones: " + e.message); }
+    return snapshot;
+}
+
+// --- GitHub queries ---
+function getIssueInfo(issueNumber) {
+    const raw = execSafe(
+        `"${GH_PATH}" issue view ${issueNumber} --json title,state,closedAt --repo intrale/platform`
+    );
+    if (!raw) return { title: `Issue #${issueNumber}`, state: "UNKNOWN", closedAt: null };
+    try { return JSON.parse(raw); } catch (e) { return { title: `Issue #${issueNumber}`, state: "UNKNOWN", closedAt: null }; }
+}
+
+function getPRsForSprint() {
+    const raw = execSafe(
+        `"${GH_PATH}" pr list --search "head:agent/" --state all --json number,url,title,state,mergedAt,headRefName --limit 20 --repo intrale/platform`
+    );
+    if (!raw) return [];
+    try { return JSON.parse(raw); } catch (e) { return []; }
+}
+
+function getCIRuns() {
+    const raw = execSafe(
+        `"${GH_PATH}" run list --limit 10 --json status,conclusion,headBranch,updatedAt --repo intrale/platform`
+    );
+    if (!raw) return [];
+    try { return JSON.parse(raw); } catch (e) { return []; }
+}
+
+function getWorktreeList() {
+    const raw = execSafe("git worktree list --porcelain", { cwd: REPO_ROOT });
+    if (!raw) return [];
+    const worktrees = [];
+    let current = {};
+    for (const line of raw.split("\n")) {
+        if (line.startsWith("worktree ")) {
+            if (current.path) worktrees.push(current);
+            current = { path: line.replace("worktree ", "").trim() };
+        } else if (line.startsWith("HEAD ")) {
+            current.head = line.replace("HEAD ", "").trim();
+        } else if (line.startsWith("branch ")) {
+            current.branch = line.replace("branch refs/heads/", "").trim();
+        } else if (line === "detached") {
+            current.detached = true;
+        }
+    }
+    if (current.path) worktrees.push(current);
+    return worktrees;
+}
+
+// --- Formato de fecha Argentina ---
+function formatDateAR(isoStr) {
+    if (!isoStr) return "N/A";
+    try {
+        return new Date(isoStr).toLocaleString("es-AR", { timeZone: "America/Argentina/Buenos_Aires" });
+    } catch (e) { return isoStr; }
+}
+
+// --- HTML Template ---
+const CSS = `
+  @page { size: A4; margin: 20mm; }
+  body { font-family: 'Segoe UI', Arial, sans-serif; color: #1a1a2e; background: #fff; margin: 0; padding: 30px; line-height: 1.6; }
+  h1 { color: #16213e; border-bottom: 3px solid #0f3460; padding-bottom: 10px; font-size: 28px; }
+  h2 { color: #0f3460; border-bottom: 2px solid #e2e8f0; padding-bottom: 6px; margin-top: 30px; font-size: 20px; }
+  h3 { color: #533483; margin-top: 20px; font-size: 16px; }
+  .badge { display: inline-block; padding: 2px 10px; border-radius: 12px; font-size: 12px; font-weight: bold; margin-right: 4px; }
+  .badge-open { background: #dcfce7; color: #166534; }
+  .badge-closed { background: #f3e8ff; color: #6b21a8; }
+  .badge-merged { background: #dbeafe; color: #1e40af; }
+  .badge-stream { background: #fef3c7; color: #92400e; }
+  .badge-size { background: #e0e7ff; color: #3730a3; }
+  table { width: 100%; border-collapse: collapse; margin: 15px 0; font-size: 14px; }
+  th { background: #0f3460; color: #fff; padding: 10px 12px; text-align: left; font-weight: 600; }
+  td { padding: 8px 12px; border-bottom: 1px solid #e2e8f0; }
+  tr:nth-child(even) { background: #f8fafc; }
+  tr:hover { background: #eef2ff; }
+  .metric-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 15px; margin: 20px 0; }
+  .metric-card { background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: #fff; padding: 20px; border-radius: 12px; text-align: center; }
+  .metric-card.green { background: linear-gradient(135deg, #11998e 0%, #38ef7d 100%); }
+  .metric-card.blue { background: linear-gradient(135deg, #4facfe 0%, #00f2fe 100%); }
+  .metric-card.orange { background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%); }
+  .metric-number { font-size: 36px; font-weight: bold; }
+  .metric-label { font-size: 13px; opacity: 0.9; margin-top: 4px; }
+  .timeline { border-left: 3px solid #0f3460; padding-left: 20px; margin: 20px 0; }
+  .timeline-item { position: relative; margin-bottom: 15px; padding: 10px 15px; background: #f8fafc; border-radius: 8px; border-left: 4px solid #667eea; }
+  .timeline-item.success { border-left-color: #22c55e; }
+  .timeline-item.warning { border-left-color: #f59e0b; }
+  .timeline-item.info { border-left-color: #3b82f6; }
+  .timeline-time { font-size: 12px; color: #64748b; font-weight: bold; }
+  .timeline-title { font-weight: 600; margin: 4px 0; }
+  .timeline-detail { font-size: 13px; color: #475569; }
+  .section-box { background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 10px; padding: 20px; margin: 15px 0; }
+  code { background: #f1f5f9; padding: 2px 6px; border-radius: 4px; font-size: 13px; color: #334155; }
+  .footer { margin-top: 40px; padding-top: 15px; border-top: 2px solid #e2e8f0; font-size: 12px; color: #94a3b8; text-align: center; }
+`;
+
+function buildHtml(plan, issueInfos, agentSummaries, prs, ciRuns, worktrees, sprintDurationMin) {
+    const fecha = plan.fecha || new Date().toISOString().split("T")[0];
+    const tema = plan.tema || "Sprint";
+    const agentes = plan.agentes || [];
+
+    // Filtrar PRs relevantes al sprint
+    const sprintBranches = new Set(agentes.map(a => `agent/${a.issue}-${a.slug}`));
+    const sprintPRs = prs.filter(pr => sprintBranches.has(pr.headRefName));
+    const mergedPRs = sprintPRs.filter(pr => pr.state === "MERGED");
+    const closedIssues = Object.values(issueInfos).filter(i => i.state === "CLOSED").length;
+
+    // Filtrar CI runs relevantes
+    const sprintCIRuns = ciRuns.filter(r => sprintBranches.has(r.headBranch));
+
+    let html = `<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<title>Reporte Sprint — ${fecha} — Intrale Platform</title>
+<style>${CSS}</style>
+</head>
+<body>
+
+<h1>Reporte de Sprint — ${fecha}</h1>
+<p><strong>Proyecto:</strong> Intrale Platform (<code>intrale/platform</code>)<br>
+<strong>Fecha:</strong> ${fecha}<br>
+<strong>Tema:</strong> ${escapeHtml(tema)}<br>
+<strong>Duración total:</strong> ${sprintDurationMin} min</p>
+
+<!-- MÉTRICAS -->
+<h2>1. Métricas del Sprint</h2>
+<div class="metric-grid">
+  <div class="metric-card">
+    <div class="metric-number">${agentes.length}</div>
+    <div class="metric-label">Issues del sprint</div>
+  </div>
+  <div class="metric-card green">
+    <div class="metric-number">${closedIssues}</div>
+    <div class="metric-label">Issues cerrados</div>
+  </div>
+  <div class="metric-card blue">
+    <div class="metric-number">${mergedPRs.length}</div>
+    <div class="metric-label">PRs merged</div>
+  </div>
+  <div class="metric-card orange">
+    <div class="metric-number">${sprintDurationMin}</div>
+    <div class="metric-label">Minutos totales</div>
+  </div>
+</div>
+
+<!-- ISSUES -->
+<h2>2. Issues del Sprint</h2>
+<table>
+  <thead>
+    <tr><th>#</th><th>Issue</th><th>Título</th><th>Stream</th><th>Size</th><th>Estado</th><th>Duración</th></tr>
+  </thead>
+  <tbody>`;
+
+    for (const ag of agentes) {
+        const info = issueInfos[ag.issue] || {};
+        const summary = agentSummaries[ag.issue] || {};
+        const pr = sprintPRs.find(p => p.headRefName === `agent/${ag.issue}-${ag.slug}`);
+        const stateBadge = info.state === "CLOSED"
+            ? `<span class="badge badge-closed">CLOSED</span>`
+            : `<span class="badge badge-open">OPEN</span>`;
+        const prInfo = pr
+            ? ` — PR <a href="${pr.url || ""}">#${pr.number}</a> <span class="badge badge-${pr.state === "MERGED" ? "merged" : "open"}">${pr.state}</span>`
+            : "";
+        const dur = summary.durationMin != null ? `${summary.durationMin} min` : "N/A";
+
+        html += `
+    <tr>
+      <td>${ag.numero}</td>
+      <td><a href="https://github.com/intrale/platform/issues/${ag.issue}">#${ag.issue}</a></td>
+      <td>${escapeHtml(ag.titulo || info.title || "")}</td>
+      <td><span class="badge badge-stream">${ag.stream || "E"}</span></td>
+      <td><span class="badge badge-size">${ag.size || "M"}</span></td>
+      <td>${stateBadge}${prInfo}</td>
+      <td>${dur}</td>
+    </tr>`;
+    }
+
+    html += `
+  </tbody>
+</table>
+
+<!-- DETALLE POR AGENTE -->
+<h2>3. Detalle por Agente</h2>`;
+
+    for (const ag of agentes) {
+        const summary = agentSummaries[ag.issue] || {};
+        if (!summary.found) {
+            html += `
+<div class="section-box">
+  <h3>Agente ${ag.numero} — #${ag.issue} ${escapeHtml(ag.slug)}</h3>
+  <p><em>Sin datos de sesión disponibles</em></p>
+</div>`;
+            continue;
+        }
+
+        const taskBar = summary.tasksTotal > 0
+            ? `${summary.tasksCompleted}/${summary.tasksTotal} completadas`
+            : "Sin tareas registradas";
+
+        html += `
+<div class="section-box">
+  <h3>Agente ${ag.numero} — #${ag.issue} ${escapeHtml(ag.slug)}</h3>
+  <table>
+    <tr><td><strong>Nombre</strong></td><td>${escapeHtml(summary.agentName)}</td></tr>
+    <tr><td><strong>Rama</strong></td><td><code>${escapeHtml(summary.branch || "N/A")}</code></td></tr>
+    <tr><td><strong>Tareas</strong></td><td>${taskBar}</td></tr>
+    <tr><td><strong>Acciones</strong></td><td>${summary.actionCount} (${escapeHtml(summary.topTools || "N/A")})</td></tr>
+    <tr><td><strong>Skills</strong></td><td>${summary.skillsInvoked.length > 0 ? escapeHtml(summary.skillsInvoked.join(", ")) : "Ninguno"}</td></tr>
+    <tr><td><strong>Duración</strong></td><td>${summary.durationMin} min</td></tr>
+    <tr><td><strong>Inicio</strong></td><td>${formatDateAR(summary.startedTs)}</td></tr>
+    <tr><td><strong>Fin</strong></td><td>${formatDateAR(summary.endedTs)}</td></tr>
+  </table>
+</div>`;
+    }
+
+    // --- Timeline desde activity-log ---
+    html += `
+<!-- TIMELINE -->
+<h2>4. Línea de Tiempo</h2>
+<div class="timeline">`;
+
+    // Reconstruir timeline desde activity-log
+    const activityLog = path.join(REPO_ROOT, ".claude", "activity-log.jsonl");
+    const timelineEvents = buildTimelineEvents(activityLog, agentes, plan);
+    for (const evt of timelineEvents) {
+        html += `
+  <div class="timeline-item ${evt.type}">
+    <div class="timeline-time">${evt.time}</div>
+    <div class="timeline-title">${escapeHtml(evt.title)}</div>
+    <div class="timeline-detail">${escapeHtml(evt.detail)}</div>
+  </div>`;
+    }
+
+    html += `
+</div>
+
+<!-- WORKTREES -->
+<h2>5. Estado de Worktrees</h2>
+<table>
+  <thead>
+    <tr><th>Ruta</th><th>Rama</th></tr>
+  </thead>
+  <tbody>`;
+
+    for (const wt of worktrees) {
+        const dirName = path.basename(wt.path);
+        html += `
+    <tr>
+      <td><code>${escapeHtml(dirName)}</code></td>
+      <td><code>${escapeHtml(wt.branch || (wt.detached ? "detached" : "N/A"))}</code></td>
+    </tr>`;
+    }
+
+    html += `
+  </tbody>
+</table>
+
+<!-- PRs -->
+<h2>6. Pull Requests del Sprint</h2>`;
+
+    if (sprintPRs.length > 0) {
+        html += `
+<table>
+  <thead>
+    <tr><th>PR</th><th>Título</th><th>Rama</th><th>Estado</th></tr>
+  </thead>
+  <tbody>`;
+
+        for (const pr of sprintPRs) {
+            const badge = pr.state === "MERGED" ? "merged" : pr.state === "OPEN" ? "open" : "closed";
+            html += `
+    <tr>
+      <td><a href="${pr.url || ""}">#${pr.number}</a></td>
+      <td>${escapeHtml(pr.title)}</td>
+      <td><code>${escapeHtml(pr.headRefName || "")}</code></td>
+      <td><span class="badge badge-${badge}">${pr.state}</span></td>
+    </tr>`;
+        }
+
+        html += `
+  </tbody>
+</table>`;
+    } else {
+        html += `<p><em>No se encontraron PRs asociados al sprint.</em></p>`;
+    }
+
+    // --- CI ---
+    if (sprintCIRuns.length > 0) {
+        html += `
+<!-- CI -->
+<h2>7. Estado de CI</h2>
+<table>
+  <thead>
+    <tr><th>Rama</th><th>Estado</th><th>Conclusión</th><th>Actualizado</th></tr>
+  </thead>
+  <tbody>`;
+
+        for (const run of sprintCIRuns) {
+            html += `
+    <tr>
+      <td><code>${escapeHtml(run.headBranch)}</code></td>
+      <td>${escapeHtml(run.status)}</td>
+      <td>${escapeHtml(run.conclusion || "en progreso")}</td>
+      <td>${formatDateAR(run.updatedAt)}</td>
+    </tr>`;
+        }
+
+        html += `
+  </tbody>
+</table>`;
+    }
+
+    // --- Footer ---
+    html += `
+<div class="footer">
+  <p>Generado automáticamente el ${fecha} | Intrale Platform | Sprint Report</p>
+  <p>Modelo: Claude Opus 4.6 | Tema: <code>${escapeHtml(tema)}</code></p>
+</div>
+
+</body>
+</html>`;
+
+    return html;
+}
+
+/**
+ * Construye eventos de timeline desde activity-log.
+ */
+function buildTimelineEvents(activityLogPath, agentes, plan) {
+    const events = [];
+
+    // Evento de inicio del sprint
+    events.push({
+        time: plan.fecha || "Sprint",
+        title: `Sprint iniciado — ${agentes.length} agentes`,
+        detail: `Tema: ${plan.tema || "N/A"}`,
+        type: "info"
+    });
+
+    // Agregar skills invocados como eventos
+    try {
+        if (!fs.existsSync(activityLogPath)) return events;
+        const lines = fs.readFileSync(activityLogPath, "utf8").split("\n").filter(Boolean);
+        const sessionIds = new Set();
+
+        // Recopilar session IDs de agentes del sprint (sesiones que matchean ramas del sprint)
+        const sessionsDir = path.join(REPO_ROOT, ".claude", "sessions");
+        if (fs.existsSync(sessionsDir)) {
+            const files = fs.readdirSync(sessionsDir).filter(f => f.endsWith(".json"));
+            for (const file of files) {
+                try {
+                    const sess = JSON.parse(fs.readFileSync(path.join(sessionsDir, file), "utf8"));
+                    for (const ag of agentes) {
+                        if (sess.branch && sess.branch.includes(String(ag.issue))) {
+                            sessionIds.add(file.replace(".json", ""));
+                        }
+                    }
+                } catch (e) { /* skip */ }
+            }
+        }
+
+        // Filtrar y resumir entradas de activity log
+        const skillEvents = {};
+        for (const line of lines) {
+            try {
+                const entry = JSON.parse(line);
+                if (!sessionIds.has(entry.session)) continue;
+                if (entry.tool === "Skill") {
+                    const key = `${entry.session}-${entry.target}`;
+                    if (!skillEvents[key]) {
+                        skillEvents[key] = {
+                            time: formatDateAR(entry.ts),
+                            title: `Skill invocado: ${entry.target}`,
+                            detail: `Sesión: ${entry.session}`,
+                            type: "success"
+                        };
+                    }
+                }
+            } catch (e) { /* skip */ }
+        }
+        events.push(...Object.values(skillEvents));
+    } catch (e) {
+        log("Error construyendo timeline: " + e.message);
+    }
+
+    // Evento de fin
+    events.push({
+        time: formatDateAR(new Date().toISOString()),
+        title: "Sprint finalizado — Reporte generado",
+        detail: `${agentes.length} agentes procesados`,
+        type: "success"
+    });
+
+    return events;
+}
+
+// --- Main ---
+async function main() {
+    const startTime = Date.now();
+    log("=== sprint-report.js iniciado ===");
+
+    // Leer sprint plan
+    const planPath = process.argv[2] || path.join(__dirname, "sprint-plan.json");
+    const plan = (() => {
+        try {
+            return JSON.parse(fs.readFileSync(planPath, "utf8"));
+        } catch (e) {
+            log("Error leyendo sprint plan: " + e.message);
+            return null;
+        }
+    })();
+
+    if (!plan || !plan.agentes || plan.agentes.length === 0) {
+        log("Plan vacío o inválido. Abortando.");
+        process.exit(0);
+    }
+
+    log(`Plan: ${plan.fecha}, ${plan.agentes.length} agentes`);
+
+    // Snapshot de sesiones (antes de que se limpien)
+    const sessions = snapshotSessions();
+    log(`Sesiones snapshot: ${Object.keys(sessions).length}`);
+
+    // Recopilar datos de cada agente
+    const issueInfos = {};
+    const agentSummaries = {};
+
+    for (const ag of plan.agentes) {
+        // Issue info desde GitHub
+        issueInfos[ag.issue] = getIssueInfo(ag.issue);
+
+        // Buscar sesión correspondiente al agente
+        let sessionId = null;
+        for (const [sid, sess] of Object.entries(sessions)) {
+            if (sess.branch && sess.branch.includes(String(ag.issue))) {
+                sessionId = sid;
+                break;
+            }
+        }
+
+        if (sessionId) {
+            agentSummaries[ag.issue] = buildExecutionSummary(sessionId, REPO_ROOT);
+            log(`Agente ${ag.numero} (issue #${ag.issue}): sesión ${sessionId}`);
+        } else {
+            agentSummaries[ag.issue] = { found: false };
+            log(`Agente ${ag.numero} (issue #${ag.issue}): sin sesión encontrada`);
+        }
+    }
+
+    // PRs y CI
+    const prs = getPRsForSprint();
+    const ciRuns = getCIRuns();
+    const worktrees = getWorktreeList();
+
+    // Duración total
+    const sprintDurationMin = Math.round((Date.now() - startTime) / 60000) || (() => {
+        // Intentar calcular desde sesiones
+        let minStart = Infinity, maxEnd = 0;
+        for (const s of Object.values(agentSummaries)) {
+            if (s.startedTs) minStart = Math.min(minStart, new Date(s.startedTs).getTime());
+            if (s.endedTs) maxEnd = Math.max(maxEnd, new Date(s.endedTs).getTime());
+        }
+        return minStart < Infinity && maxEnd > 0 ? Math.round((maxEnd - minStart) / 60000) : 0;
+    })();
+
+    // Generar HTML
+    const fecha = plan.fecha || new Date().toISOString().split("T")[0];
+    const htmlFileName = `reporte-sprint-${fecha}.html`;
+    const htmlPath = path.join(QA_DIR, htmlFileName);
+    const html = buildHtml(plan, issueInfos, agentSummaries, prs, ciRuns, worktrees, sprintDurationMin);
+
+    ensureDir(QA_DIR);
+    fs.writeFileSync(htmlPath, html, "utf8");
+    log(`HTML generado: ${htmlPath}`);
+
+    // Generar PDF con generate-pdf.js
+    let pdfPath = htmlPath.replace(/\.html$/, ".pdf");
+    if (fs.existsSync(GENERATE_PDF)) {
+        const pdfResult = execSafe(`node "${GENERATE_PDF}" "${htmlFileName}"`, { cwd: QA_DIR, timeout: 60000 });
+        if (pdfResult !== null && fs.existsSync(pdfPath)) {
+            log(`PDF generado: ${pdfPath}`);
+        } else {
+            log("PDF no se pudo generar, se enviará mensaje de texto");
+            pdfPath = null;
+        }
+    } else {
+        log("generate-pdf.js no encontrado, omitiendo PDF");
+        pdfPath = null;
+    }
+
+    // Enviar a Telegram
+    const tgConfig = loadTelegramConfig();
+    if (tgConfig) {
+        const mergedCount = prs.filter(p =>
+            plan.agentes.some(a => p.headRefName === `agent/${a.issue}-${a.slug}`) && p.state === "MERGED"
+        ).length;
+        const caption = `📊 Reporte Sprint ${fecha} — ${plan.agentes.length} issues, ${mergedCount} PRs merged`;
+
+        if (pdfPath && fs.existsSync(pdfPath)) {
+            sendTelegramDocument(tgConfig.bot_token, tgConfig.chat_id, pdfPath, caption);
+        } else {
+            // Fallback: enviar mensaje con resumen
+            sendTelegramMessage(tgConfig.bot_token, tgConfig.chat_id, caption + "\n(PDF no disponible, ver HTML en docs/qa/)");
+        }
+    }
+
+    const elapsed = Math.round((Date.now() - startTime) / 1000);
+    log(`=== sprint-report.js completado en ${elapsed}s ===`);
+}
+
+// Ejecutar y capturar errores (fail-open)
+main().catch(e => {
+    log("ERROR FATAL: " + e.message + "\n" + e.stack);
+    process.exit(0); // exit 0 para no interrumpir el flujo
+});


### PR DESCRIPTION
## Resumen

Automatizar la generación y envío de reportes HTML+PDF al finalizar sprints y enriquecer las notificaciones de ejecuciones individuales con contexto de sesión.

- **NUEVO** `scripts/sprint-report.js` — genera HTML+PDF del sprint con métricas y lo envía a Telegram como documento adjunto
- **NUEVO** `scripts/execution-report.js` — módulo reutilizable que construye resúmenes de sesión (issue, tareas, herramientas, PR, duración)
- **MODIFICAR** `scripts/Watch-Agentes.ps1` — integrar llamada a sprint-report.js tras Stop-Agente.ps1 all
- **MODIFICAR** `.claude/hooks/stop-notify.js` — detectar si sesión es parte de sprint, enriquecer notificación individual con mini-reporte

Reutiliza `docs/qa/generate-pdf.js` y Puppeteer ya instalados. Compatible con flujo existente de planificación.

## Plan de tests

- [x] Code review: cambios de script validados
- [x] Build completo: sin errores de integración
- [x] Integración con Watch-Agentes: verifica existencia de sprint-report.js
- [x] Fallback robusto: si sprint-report.js falla, Watch-Agentes continúa normalmente
- [x] Compatibilidad backward: sesiones individuales siguen funcionando sin sprint-plan.json

Closes #1181

🤖 Generado con [Claude Code](https://claude.com/claude-code)