### PR TITLE
fix(hooks): corregir countdown de permisos y config de reintentos

### DIFF
--- a/.claude/hooks/permission-approver.js
+++ b/.claude/hooks/permission-approver.js
@@ -282,8 +282,8 @@ async function pollQuestionStatus(requestId, durationMs, attemptLabel, countdown
         // Actualizar countdown cada 30s
         countdownCounter++;
         if (countdownOptions && countdownOptions.msgId && countdownCounter % COUNTDOWN_INTERVAL === 0) {
-            const elapsed = Math.round((Date.now() - pollStart) / 1000);
-            const remaining = Math.round((durationMs - elapsed) / 1000);
+            const elapsedMs = Date.now() - pollStart;
+            const remaining = Math.max(0, Math.round((durationMs - elapsedMs) / 1000));
             if (remaining > 0) {
                 const minRemaining = Math.floor(remaining / 60);
                 const secRemaining = remaining % 60;
@@ -421,12 +421,13 @@ async function processInput() {
     const contextLine = formatContext(sessionId, MAIN_REPO_ROOT);
     const totalAttempts = RETRY_INTERVALS.length;
 
+    const firstWaitMin = Math.round(RETRY_INTERVALS[0] / 60000);
     let msgText = "⚠️ <b>" + escHtml(agent) + " — Permiso requerido</b> <i>(Intento 1/" + totalAttempts + ")</i>\n";
     if (contextLine) {
         msgText += contextLine + "\n";
     }
     msgText += "\n" + action + "\n\n"
-        + "⏳ Expira en 3:00\n"
+        + "⏳ Expira en " + firstWaitMin + ":00\n"
         + "📝 Usar botones o responder: <b>siempre</b> (para persistir)";
 
     // 1. Enviar mensaje con botones inline + instrucción de texto libre

--- a/.claude/hooks/telegram-config.json
+++ b/.claude/hooks/telegram-config.json
@@ -3,6 +3,6 @@
   "chat_id": "6529617704",
   "permission_timeout_min": 60,
   "task_report_interval_min": 10,
-  "retry_intervals_min": [30, 15, 10, 10],
+  "retry_intervals_min": [3, 3, 3, 3, 3, 3, 3, 3, 3, 3],
   "gate_retry_intervals_min": [15, 8, 5, 2]
 }


### PR DESCRIPTION
## Resumen

- Corregir bug de unidades en countdown del permission-approver: `remaining = (durationMs - elapsed) / 1000` mezclaba milliseconds con seconds, haciendo que el timer nunca se moviera
- Hacer dinámico el mensaje inicial "Expira en X:00" leyendo de `RETRY_INTERVALS[0]` en vez de hardcodear "3:00"
- Actualizar `telegram-config.json`: `retry_intervals_min` de `[30, 15, 10, 10]` a `[3, 3, 3, 3, 3, 3, 3, 3, 3, 3]` (10 reintentos de 3 min)

## Plan de tests

- [ ] Verificar que el mensaje de permiso muestra "Expira en 3:00"
- [ ] Verificar que el countdown se actualiza cada 30s (2:30, 2:00, 1:30...)
- [ ] Verificar que tras 3 min sin respuesta se envía reintento con escalada

QA Validate: omitido por decisión del usuario ⚠️

🤖 Generado con [Claude Code](https://claude.com/claude-code)