### PR TITLE
fix: corregir prefijo codex en Watch-Agentes

### DIFF
--- a/scripts/Start-Agente.ps1
+++ b/scripts/Start-Agente.ps1
@@ -143,7 +143,7 @@ function Start-UnAgente {
 
     # Pre-crear trust directory para que Claude no muestre el dialogo interactivo
     # Claude Code almacena confianza en ~/.claude/projects/<path-mangled>/
-    # Path mangling: C:/Workspaces/Intrale/platform.codex-123-slug → C--Workspaces-Intrale-platform.codex-123-slug
+    # Path mangling: C:/Workspaces/Intrale/platform.agent-123-slug → C--Workspaces-Intrale-platform.agent-123-slug
     $wtAbsPath = (Resolve-Path $wtDirResolved).Path -replace '\\', '/'
     $mangledPath = ($wtAbsPath -replace '^/', '' -replace '/', '-' -replace ':', '-')
     $trustDir = Join-Path $env:USERPROFILE ".claude\projects\$mangledPath"

--- a/scripts/Watch-Agentes.ps1
+++ b/scripts/Watch-Agentes.ps1
@@ -106,7 +106,7 @@ Write-Host ''
 
 function Get-WorktreePath {
     param($Agente)
-    return '{0}\..\platform.codex-{1}-{2}' -f $MainRepo, $Agente.issue, $Agente.slug
+    return '{0}\..\platform.agent-{1}-{2}' -f $MainRepo, $Agente.issue, $Agente.slug
 }
 
 function Test-AgentDone {


### PR DESCRIPTION
## Resumen

- Corregir mismatch de prefijo en Watch-Agentes.ps1: 'platform.codex-' → 'platform.agent-'
- Actualizar comentario en Start-Agente.ps1 (solo documentación)
- Esto evita que Watch-Agentes declare 'Sprint completado' antes de tiempo

## Problema

Watch-Agentes buscaba worktrees en `platform.codex-{issue}-{slug}` (convención vieja pre-#1042)
mientras que Start-Agente los crea en `platform.agent-{issue}-{slug}` (convención nueva).
Como el path no existía, Watch-Agentes los consideraba como "done" inmediatamente.

## Plan de tests

- [x] Verificar que los cambios no rompen la sintaxis PowerShell
- [ ] Relanizar sprint y verificar que Watch-Agentes detecta worktrees correctamente
- [ ] Verificar que las 4 historias que se lanzan en paralelo se completan sin false positives

🤖 Generado con [Claude Code](https://claude.com/claude-code)