### PR TITLE
feat(sprint): bloquear ejecución de agentes fuera de sprint activo

### DIFF
--- a/.claude/skills/planner/SKILL.md
+++ b/.claude/skills/planner/SKILL.md
@@ -217,6 +217,8 @@ para que `Start-Agente.ps1` pueda lanzar agentes automaticamente:
 ```json
 {
   "fecha": "2026-02-20",
+  "fechaInicio": "2026-02-20",
+  "fechaFin": "2026-02-26",
   "agentes": [
     {
       "numero": 1,
@@ -232,6 +234,9 @@ para que `Start-Agente.ps1` pueda lanzar agentes automaticamente:
 ```
 
 Reglas del JSON:
+- `fecha`: fecha de creacion del plan (backward compat, mismo valor que `fechaInicio`)
+- `fechaInicio`: fecha de inicio del sprint (ISO 8601, ej: `"2026-03-03"`) — siempre la fecha actual al momento de planificar
+- `fechaFin`: fecha de fin del sprint (ISO 8601, ej: `"2026-03-07"`) — `fechaInicio` + duracion del sprint (default: 5 dias habiles / 1 semana, excluyendo fines de semana). Si el sprint se planifica un lunes, `fechaFin` es el viernes de esa semana. **OBLIGATORIO** — `Start-Agente.ps1` y `Watch-Agentes.ps1` bloquean la ejecucion si `fechaFin` no existe o ya paso
 - `numero`: secuencial empezando en 1
 - `issue`: numero del issue de GitHub
 - `slug`: identificador corto sin espacios ni caracteres especiales (usado para branch y worktree)

--- a/scripts/Start-Agente.ps1
+++ b/scripts/Start-Agente.ps1
@@ -51,6 +51,36 @@ if (-not (Test-Path $MainRepo)) {
 # --- Leer plan ---
 $Plan = Get-Content $PlanFile -Raw | ConvertFrom-Json
 
+# --- Validar sprint activo ---
+function Test-SprintActivo {
+    param([Parameter(Mandatory)] $Plan)
+
+    if (-not $Plan.fechaFin) {
+        Write-Error ("El plan no tiene campo 'fechaFin'. El sprint no es valido.`n" +
+                     "Ejecuta /planner sprint para planificar un nuevo sprint antes de lanzar agentes.")
+        exit 1
+    }
+
+    try {
+        $fechaFin = [DateTime]::ParseExact($Plan.fechaFin, 'yyyy-MM-dd', $null)
+    }
+    catch {
+        Write-Error ("No se pudo parsear fechaFin '{0}'. Formato esperado: yyyy-MM-dd.`n" +
+                     "Ejecuta /planner sprint para generar un plan valido." -f $Plan.fechaFin)
+        exit 1
+    }
+
+    if ((Get-Date).Date -gt $fechaFin.Date) {
+        Write-Error ("El sprint del plan actual ha expirado (fechaFin: {0}).`n" +
+                     "Ejecuta /planner sprint para planificar un nuevo sprint antes de lanzar agentes." -f $Plan.fechaFin)
+        exit 1
+    }
+
+    Write-Host ">> Sprint activo (fechaFin: $($Plan.fechaFin))" -ForegroundColor Green
+}
+
+Test-SprintActivo -Plan $Plan
+
 # Pre-registrar confianza del worktree en Claude Code para evitar dialogo interactivo de trust
 function PreRegister-Trust {
     param([string]$AbsPath)

--- a/scripts/Watch-Agentes.ps1
+++ b/scripts/Watch-Agentes.ps1
@@ -72,6 +72,37 @@ if (-not (Test-Path $PlanFile)) {
 
 # --- Leer plan ---
 $Plan = Get-Content $PlanFile -Raw | ConvertFrom-Json
+
+# --- Validar sprint activo ---
+function Test-SprintActivo {
+    param([Parameter(Mandatory)] $Plan)
+
+    if (-not $Plan.fechaFin) {
+        Write-Error ("El plan no tiene campo 'fechaFin'. El sprint no es valido.`n" +
+                     "Ejecuta /planner sprint para planificar un nuevo sprint antes de lanzar agentes.")
+        exit 1
+    }
+
+    try {
+        $fechaFin = [DateTime]::ParseExact($Plan.fechaFin, 'yyyy-MM-dd', $null)
+    }
+    catch {
+        Write-Error ("No se pudo parsear fechaFin '{0}'. Formato esperado: yyyy-MM-dd.`n" +
+                     "Ejecuta /planner sprint para generar un plan valido." -f $Plan.fechaFin)
+        exit 1
+    }
+
+    if ((Get-Date).Date -gt $fechaFin.Date) {
+        Write-Error ("El sprint del plan actual ha expirado (fechaFin: {0}).`n" +
+                     "Ejecuta /planner sprint para planificar un nuevo sprint antes de lanzar agentes." -f $Plan.fechaFin)
+        exit 1
+    }
+
+    Write-Log ('Sprint activo (fechaFin: {0})' -f $Plan.fechaFin) 'Green'
+}
+
+Test-SprintActivo -Plan $Plan
+
 $AgentCount = $Plan.agentes.Count
 
 if ($AgentCount -eq 0) {


### PR DESCRIPTION
## Resumen

- Agregar función `Test-SprintActivo` en `Start-Agente.ps1` que valida `fechaFin` y bloquea con error descriptivo si el sprint expiró
- Aplicar la misma validación en `Watch-Agentes.ps1` al iniciar vigilancia
- Actualizar `.claude/skills/planner/SKILL.md` para documentar `fechaInicio` y `fechaFin` en el JSON generado por `/planner sprint`
- Default de vigencia: 5 días hábiles (1 semana) desde la fecha de planificación
- Bloqueo automático si `fechaFin` no existe o ya pasó

## Criterios de aceptación

- ✅ `sprint-plan.json` generado por `/planner sprint` incluye `fechaInicio` y `fechaFin`
- ✅ `Start-Agente.ps1` rechaza con error descriptivo si `fechaFin` no existe
- ✅ `Start-Agente.ps1` rechaza con error descriptivo si la fecha actual supera `fechaFin`
- ✅ `Watch-Agentes.ps1` aplica la misma validación de vigencia al iniciar
- ✅ Mensaje de error indica claramente que se debe ejecutar `/planner sprint`

## Cambios

- `scripts/Start-Agente.ps1`: +30 líneas (función de validación)
- `scripts/Watch-Agentes.ps1`: +31 líneas (función de validación)
- `.claude/skills/planner/SKILL.md`: documentación de campos obligatorios

Closes #1195

🤖 Generado con [Claude Code](https://claude.com/claude-code)