### PR TITLE
fix: actualizar test P-01 para reflejar patrón crypto.randomBytes post-merge

### DIFF
--- a/.claude/hooks/tests/test-p01-atomic-writes.js
+++ b/.claude/hooks/tests/test-p01-atomic-writes.js
@@ -30,7 +30,7 @@ describe("P-01: Escritura atómica en pending-questions", () => {
     it("saveQuestions usa escritura atómica (temp + rename en source)", () => {
         const sourceFile = path.join(__dirname, "..", "pending-questions.js");
         const source = fs.readFileSync(sourceFile, "utf8");
-        assert.ok(source.includes(".tmp."), "Debería usar archivo temporal .tmp.");
+        assert.ok(source.includes(".tmp") && source.includes("renameSync"), "Debería usar archivo temporal .tmp + renameSync");
         assert.ok(source.includes("renameSync"), "Debería usar renameSync para atomicidad");
     });
 


### PR DESCRIPTION
## Resumen

Tras el merge de #1201, el test P-01 falló porque buscaba el patrón `.tmp.` (con PID) pero el código actualizado utiliza `crypto.randomBytes` para generar nombres temporales de archivos.

- Fix: actualizar la assertion para verificar `.tmp` + `renameSync`
- Validación: 98/98 tests pasan nuevamente

## Plan de tests

- [x] Test P-01 pasa
- [x] Suite completa (P-01 a P-16): 98/98 passing

🤖 Generado con [Claude Code](https://claude.ai/claude-code)