### PR TITLE
fix(hooks): health-check auto-repara worktrees muertos

### DIFF
--- a/.claude/hooks/health-check.js
+++ b/.claude/hooks/health-check.js
@@ -199,7 +199,7 @@ function processCheckResult(history, checkName, checkResult, detail) {
         }
 
         for (const id of problemIds) {
-            const autoFixed = checkName === "commander" || checkName === "approvers";
+            const autoFixed = checkName === "commander" || checkName === "approvers" || checkName === "worktrees";
             const problem = recordProblem(history, id, mapping.category, detail, autoFixed);
             const canEscalate = !NO_ESCALATE.has(id);
 
@@ -411,7 +411,7 @@ function checkCriticalHooks() {
 // ─── Check 6: Worktrees muertos ───────────────────────────────────────────
 
 function checkDeadWorktrees() {
-    const result = { ok: true, dead: [] };
+    const result = { ok: true, dead: [], cleaned: [] };
     try {
         const parentDir = path.resolve(REPO_ROOT, "..");
         const entries = fs.readdirSync(parentDir);
@@ -422,14 +422,28 @@ function checkDeadWorktrees() {
                 try {
                     const stat = fs.statSync(fullPath);
                     if (stat.isDirectory()) {
-                        // Verificar si tiene contenido real (más de solo . y ..)
                         const contents = fs.readdirSync(fullPath);
                         if (contents.length <= 1) {
-                            result.dead.push(entry);
+                            // Auto-repair: intentar eliminar directorio vacío/residual
+                            try {
+                                if (contents.length === 1) {
+                                    fs.rmSync(path.join(fullPath, contents[0]), { recursive: true, force: true });
+                                }
+                                fs.rmdirSync(fullPath);
+                                result.cleaned.push(entry);
+                                log("Worktree muerto limpiado: " + entry);
+                            } catch (cleanErr) {
+                                result.dead.push(entry);
+                                log("No se pudo limpiar worktree: " + entry + " — " + cleanErr.message);
+                            }
                         }
                     }
                 } catch (e) {}
             }
+        }
+        // Si se limpió algo, podar referencias huérfanas de git
+        if (result.cleaned.length > 0) {
+            try { execSync("git worktree prune", { cwd: REPO_ROOT, timeout: 5000 }); } catch (e) {}
         }
         if (result.dead.length > 0) result.ok = false;
     } catch (e) {}
@@ -594,7 +608,11 @@ async function main() {
         telegram: checks.telegram.detail,
         settings: checks.settings.details.join(", "),
         hooks: checks.hooks.missing.length > 0 ? "Faltantes: " + checks.hooks.missing.join(", ") : "Todos presentes",
-        worktrees: checks.worktrees.dead.length > 0 ? checks.worktrees.dead.length + " muertos" : "OK"
+        worktrees: checks.worktrees.dead.length > 0
+            ? checks.worktrees.dead.length + " muertos" + (checks.worktrees.cleaned.length > 0 ? " (" + checks.worktrees.cleaned.length + " limpiados)" : "")
+            : checks.worktrees.cleaned.length > 0
+                ? checks.worktrees.cleaned.length + " limpiados ✅"
+                : "OK"
     };
 
     const allResults = {};

--- a/.claude/hooks/tests/test-p07-health-backoff.js
+++ b/.claude/hooks/tests/test-p07-health-backoff.js
@@ -32,4 +32,14 @@ describe("P-07: Health check backoff por componente", () => {
     it("contiene lógica de consecutivePasses para duplicar intervalo", () => {
         assert.ok(source.includes("consecutivePasses"), "Debería trackear consecutivePasses");
     });
+
+    it("checkDeadWorktrees auto-repara con rmdirSync", () => {
+        assert.ok(source.includes("rmdirSync"), "Debería usar rmdirSync para auto-limpiar worktrees vacíos");
+        assert.ok(source.includes("result.cleaned"), "Debería trackear worktrees limpiados en result.cleaned");
+    });
+
+    it("worktrees se marca como auto-reparable", () => {
+        assert.ok(source.includes('"worktrees"') || source.includes("'worktrees'"),
+            "worktrees debería estar en la lista de checks auto-reparables");
+    });
 });


### PR DESCRIPTION
## Resumen

El health check detectaba 11 directorios vacíos de worktrees cada 2 minutos sin poder limpiarlos, generando spam infinito en Telegram (36+ notificaciones repetidas).

- `checkDeadWorktrees()` ahora auto-limpia directorios vacíos con `rmdirSync`
- Directorios con residuos (`.claude/` copia) se limpian con `rmSync` + `rmdirSync`
- Ejecuta `git worktree prune` tras limpieza exitosa
- Worktrees marcados como `autoFixed` para ops-learnings
- 2 tests nuevos (100/100 total)

## Plan de tests

- [x] Test P-07 incluye verificación de auto-repair (rmdirSync + result.cleaned)
- [x] Suite completa: 100/100 passing

🤖 Generado con [Claude Code](https://claude.ai/claude-code)