### PR TITLE
feat: planner con atajos de foco + fix permission-gate para todas las herramientas

### DIFF
--- a/.claude/hooks/permission-gate.js
+++ b/.claude/hooks/permission-gate.js
@@ -7,7 +7,7 @@
 //   permissionDecision: "deny"  → bloquear tool
 //   Sin output                  → flujo normal de Claude Code (dialogo local)
 //
-// Solo maneja Bash — otros tools salen sin output (no interferir)
+// Maneja TODAS las herramientas que disparan PreToolUse (Bash, Edit, Write, etc.)
 //
 // IMPORTANTE: Este hook NO usa getUpdates de Telegram. El telegram-commander.js
 // es el unico consumidor de getUpdates, evitando conflictos de offset/409.
@@ -112,16 +112,73 @@ function getSkillContext() {
 
 // ─── Formato de accion para el mensaje ────────────────────────────────────────
 
-function formatBashAction(toolInput) {
-    const cmd = (toolInput.command || "").trim();
-    const desc = (toolInput.description || "").trim();
-    const display = cmd.length > 250 ? cmd.substring(0, 250) + "\u2026" : cmd;
-    let result = "";
-    if (desc) {
-        result += "\u{1F527} <b>" + escHtml(abbreviate(desc, 80)) + "</b>\n";
+function shortenPath(filePath) {
+    if (!filePath) return "";
+    const normalized = filePath.replace(/\\/g, "/");
+    const markers = ["/platform/", "/Intrale/"];
+    for (const m of markers) {
+        const idx = normalized.indexOf(m);
+        if (idx >= 0) return normalized.substring(idx + m.length);
     }
-    result += "<code>$ " + escHtml(display) + "</code>";
-    return result;
+    const parts = normalized.split("/");
+    return parts.length > 3 ? "\u2026/" + parts.slice(-3).join("/") : normalized;
+}
+
+function formatAction(toolName, toolInput) {
+    switch (toolName) {
+        case "Bash": {
+            const cmd = (toolInput.command || "").trim();
+            const desc = (toolInput.description || "").trim();
+            const display = cmd.length > 250 ? cmd.substring(0, 250) + "\u2026" : cmd;
+            let result = "";
+            if (desc) {
+                result += "\u{1F527} <b>" + escHtml(abbreviate(desc, 80)) + "</b>\n";
+            }
+            result += "<code>$ " + escHtml(display) + "</code>";
+            return result;
+        }
+        case "Edit": {
+            const shortPath = shortenPath(toolInput.file_path);
+            let result = "\u{1F4DD} <b>Editar</b> <code>" + escHtml(shortPath) + "</code>";
+            const oldStr = (toolInput.old_string || "").trim();
+            const newStr = (toolInput.new_string || "").trim();
+            if (oldStr || newStr) {
+                result += "\n<pre>";
+                if (oldStr) result += "- " + escHtml(abbreviate(oldStr, 120)) + "\n";
+                if (newStr) result += "+ " + escHtml(abbreviate(newStr, 120));
+                result += "</pre>";
+            }
+            return result;
+        }
+        case "Write": {
+            const shortPath = shortenPath(toolInput.file_path);
+            const content = (toolInput.content || "").trim();
+            let result = "\u{1F4C4} <b>Escribir</b> <code>" + escHtml(shortPath) + "</code>";
+            if (content) {
+                const preview = content.split("\n").slice(0, 3).join("\n");
+                result += "\n<pre>" + escHtml(abbreviate(preview, 150)) + "</pre>";
+            }
+            return result;
+        }
+        case "Task":
+            return "\u{1F916} <b>Subagente</b> [" + escHtml(toolInput.subagent_type || "?") + "] " + escHtml(abbreviate(toolInput.description || "", 80));
+        case "TaskUpdate":
+        case "Update":
+            return "\u{1F4CB} <b>TaskUpdate</b> #" + escHtml(toolInput.taskId || "?") + " \u2192 " + escHtml(toolInput.status || toolInput.subject || JSON.stringify(toolInput).substring(0, 80));
+        case "TaskCreate":
+        case "Create":
+            return "\u{1F4CB} <b>TaskCreate</b> " + escHtml(abbreviate(toolInput.subject || "", 80));
+        case "Skill":
+            return "\u26A1 <b>Skill</b> /" + escHtml(toolInput.skill || "") + (toolInput.args ? " " + escHtml(abbreviate(toolInput.args, 60)) : "");
+        case "WebFetch":
+            return "\u{1F310} <b>Fetch</b> " + escHtml(abbreviate(toolInput.url || "", 100));
+        case "WebSearch":
+            return "\u{1F50D} <b>Buscar</b> " + escHtml(abbreviate(toolInput.query || "", 80));
+        case "NotebookEdit":
+            return "\u{1F4D3} <b>NotebookEdit</b> " + escHtml(abbreviate(toolInput.notebook_path || "", 80));
+        default:
+            return "\u{1F6E0} <b>" + escHtml(toolName) + "</b> " + escHtml(abbreviate(JSON.stringify(toolInput), 120));
+    }
 }
 
 function formatContext(sessionId, repoRoot) {
@@ -146,38 +203,40 @@ function formatContext(sessionId, repoRoot) {
 
 // ─── Auto-approve: fast-path para comandos ya cubiertos ─────────────────────
 
-function isCommandCoveredByRules(toolInput) {
-    const pattern = generatePattern("Bash", toolInput);
+function isToolCoveredByRules(toolName, toolInput) {
+    const pattern = generatePattern(toolName, toolInput);
     if (!pattern) return false;
 
-    const cmd = (toolInput.command || "").trim();
-    const separators = /;|&&/;
+    // Para Bash con comandos compuestos (;, &&, |), verificar cada sub-comando
+    if (toolName === "Bash" && toolInput.command) {
+        const cmd = (toolInput.command || "").trim();
+        const separators = /;|&&/;
 
-    // Para comandos compuestos, verificar cada sub-comando
-    if (separators.test(cmd)) {
-        const subCmds = cmd.split(separators).map(s => s.trim()).filter(Boolean);
-        const settingsPaths = getSettingsPaths(REPO_ROOT);
-        for (const sp of settingsPaths) {
-            try {
-                const s = JSON.parse(fs.readFileSync(sp, "utf8"));
-                const allow = (s.permissions && s.permissions.allow) || [];
-                const deny = (s.permissions && s.permissions.deny) || [];
-                const allCovered = subCmds.every(sub => {
-                    const subPattern = generateBashPattern(sub);
-                    return subPattern && isAlreadyCovered(subPattern, allow);
-                });
-                const denyMatch = deny.some(d => {
-                    const dm = d.match(/^Bash\((.+?):\*\)$/);
-                    if (!dm) return false;
-                    return subCmds.some(sub => sub.startsWith(dm[1]));
-                });
-                if (allCovered && !denyMatch) return true;
-            } catch(e) {}
+        if (separators.test(cmd)) {
+            const subCmds = cmd.split(separators).map(s => s.trim()).filter(Boolean);
+            const settingsPaths = getSettingsPaths(REPO_ROOT);
+            for (const sp of settingsPaths) {
+                try {
+                    const s = JSON.parse(fs.readFileSync(sp, "utf8"));
+                    const allow = (s.permissions && s.permissions.allow) || [];
+                    const deny = (s.permissions && s.permissions.deny) || [];
+                    const allCovered = subCmds.every(sub => {
+                        const subPattern = generateBashPattern(sub);
+                        return subPattern && isAlreadyCovered(subPattern, allow);
+                    });
+                    const denyMatch = deny.some(d => {
+                        const dm = d.match(/^Bash\((.+?):\*\)$/);
+                        if (!dm) return false;
+                        return subCmds.some(sub => sub.startsWith(dm[1]));
+                    });
+                    if (allCovered && !denyMatch) return true;
+                } catch(e) {}
+            }
+            return false;
         }
-        return false;
     }
 
-    // Caso simple: un solo comando
+    // Caso simple: un solo comando o tool no-Bash
     const settingsPaths = getSettingsPaths(REPO_ROOT);
     for (const sp of settingsPaths) {
         try {
@@ -252,9 +311,9 @@ function exitSilent() {
 
 // ─── Smart suggestion (tras 3ra aprobacion del mismo patron) ──────────────────
 
-async function maybeSuggestPersistence(toolInput) {
+async function maybeSuggestPersistence(toolName, toolInput) {
     try {
-        const pattern = generatePattern("Bash", toolInput);
+        const pattern = generatePattern(toolName, toolInput);
         if (!pattern || isPatternPersisted(pattern)) return;
 
         const { count, shouldSuggest } = incrementApproval(pattern);
@@ -284,8 +343,8 @@ async function maybeSuggestPersistence(toolInput) {
 
 // ─── Persist "always" ─────────────────────────────────────────────────────────
 
-function persistAlways(toolInput) {
-    const pattern = generatePattern("Bash", toolInput);
+function persistAlways(toolName, toolInput) {
+    const pattern = generatePattern(toolName, toolInput);
     log("persistAlways: pattern=" + (pattern || "NULL"));
     if (!pattern) return;
     const settingsPaths = getSettingsPaths(REPO_ROOT);
@@ -343,8 +402,9 @@ async function processInput() {
     const toolName = data.tool_name || data.toolName || "";
     const toolInput = data.tool_input || data.toolInput || {};
 
-    // Solo manejar Bash — otros tools salen sin output
-    if (toolName !== "Bash") {
+    // Tools que nunca necesitan aprobacion remota (read-only, internas)
+    const SKIP_TOOLS = ["Read", "Glob", "Grep", "TodoRead", "TaskList", "TaskGet"];
+    if (SKIP_TOOLS.includes(toolName)) {
         exitSilent();
         return;
     }
@@ -352,17 +412,17 @@ async function processInput() {
     const agent = process.env.CLAUDE_AGENT_NAME || "Claude Code";
     const requestId = crypto.randomBytes(8).toString("hex");
 
-    log("REPO_ROOT=" + REPO_ROOT + " MAIN=" + MAIN_REPO_ROOT + " tool=Bash");
+    log("REPO_ROOT=" + REPO_ROOT + " MAIN=" + MAIN_REPO_ROOT + " tool=" + toolName);
 
     // Fast-path: auto-allow si esta cubierto por reglas existentes
-    if (isCommandCoveredByRules(toolInput)) {
-        log("COVERED: comando ya cubierto por settings rules — saliendo sin output");
+    if (isToolCoveredByRules(toolName, toolInput)) {
+        log("COVERED: " + toolName + " ya cubierto por settings rules — saliendo sin output");
         exitSilent(); // Claude Code lo aprobara via su propia logica
         return;
     }
 
     // ─── Necesita permiso → Enviar a Telegram ────────────────────────────────
-    const action = formatBashAction(toolInput);
+    const action = formatAction(toolName, toolInput);
     const sessionId = data.session_id || "";
     const contextLine = formatContext(sessionId, MAIN_REPO_ROOT);
     const waitMin = Math.round(RETRY_INTERVALS[0] / 60000);
@@ -399,7 +459,7 @@ async function processInput() {
                 { label: "Permitir", action: "allow" },
                 { label: "Rechazar", action: "deny" }
             ],
-            action_data: { tool_name: "Bash", tool_input: toolInput, agent: agent },
+            action_data: { tool_name: toolName, tool_input: toolInput, agent: agent },
             skill_context: getSkillContext(),
             approver_pid: process.pid
         });
@@ -445,10 +505,10 @@ async function processInput() {
 
             if (isAllow) {
                 // Track approval + smart suggestion (no bloquea la respuesta)
-                maybeSuggestPersistence(toolInput).catch(e => log("Suggestion error: " + e.message));
+                maybeSuggestPersistence(toolName, toolInput).catch(e => log("Suggestion error: " + e.message));
 
                 if (actionResult === "always") {
-                    persistAlways(toolInput);
+                    persistAlways(toolName, toolInput);
                 }
 
                 outputAllow("Aprobado via Telegram por el usuario (" + latencyMs + "ms)");

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -42,11 +42,6 @@
             "type": "command",
             "command": "node /c/Workspaces/Intrale/platform/.claude/hooks/worktree-guard.js",
             "timeout": 5000
-          },
-          {
-            "type": "command",
-            "command": "node /c/Workspaces/Intrale/platform/.claude/hooks/permission-gate.js",
-            "timeout": 1830000
           }
         ]
       },
@@ -67,6 +62,16 @@
             "type": "command",
             "command": "node /c/Workspaces/Intrale/platform/.claude/hooks/worktree-guard.js",
             "timeout": 5000
+          }
+        ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node /c/Workspaces/Intrale/platform/.claude/hooks/permission-gate.js",
+            "timeout": 1830000
           }
         ]
       }

--- a/.claude/skills/planner/SKILL.md
+++ b/.claude/skills/planner/SKILL.md
@@ -1,7 +1,7 @@
 ---
 description: Planner — Planificación estratégica del proyecto — Gantt, dependencias, priorización y nuevas historias
 user-invocable: true
-argument-hint: "[planificar | sprint [N] | proponer | estado]"
+argument-hint: "[planificar | sprint [N] [foco] | proponer | estado | <foco> [N]]"
 allowed-tools: Bash, Read, Glob, Grep, WebFetch, WebSearch
 model: claude-sonnet-4-6
 ---
@@ -17,9 +17,33 @@ Sugerís caminos, priorizás trabajo y maximizás la velocidad del equipo.
 | Argumento | Modo |
 |-----------|------|
 | `planificar` | Plan completo: Gantt, dependencias, streams paralelos |
-| `sprint [N]` | Qué hacer en los próximos días — top N accionables (default: 5) |
+| `sprint [N] [foco]` | Qué hacer en los próximos días — top N accionables (default: 5) |
 | `proponer` | Sugerir nuevas historias basadas en gaps del codebase |
+| `<foco> [N]` | **Atajo** — equivale a `sprint N <foco>` (ver tabla de focos abajo) |
 | sin argumento | Digest rápido: qué bloquea, qué está listo, qué sigue |
+
+### Atajos de foco temático
+
+Cualquier foco puede usarse **directamente como argumento** sin escribir `sprint`:
+
+| Atajo | Alias | Equivale a | Prioriza |
+|-------|-------|------------|----------|
+| `tecnico` | `tech`, `infra` | `sprint 5 tecnico` | `area:infra`, `tipo:infra`, `refactor`, CI/CD, build |
+| `qa` | `testing`, `tests` | `sprint 5 qa` | `bug`, issues con tests pendientes, QA, cobertura |
+| `bugs` | `fix` | `sprint 5 bugs` | Solo issues con label `bug` |
+| `features` | `feat` | `sprint 5 features` | Features nuevas (sin label `bug`/`refactor`/`tipo:infra`) |
+| `deuda` | `debt` | `sprint 5 deuda` | `refactor`, tech debt, cleanup, migrations |
+| `backend` | `back` | `sprint 5 backend` | Stream A (`:backend`, `:users`) |
+| `app` | `front` | `sprint 5 app` | Streams B/C/D (`:app`, UI, pantallas) |
+| `cross` | — | `sprint 5 cross` | Stream E (strings, DI, router, buildSrc) |
+| `rapido` | `quick`, `wins` | `sprint 5 rapido` | Solo issues tamaño S/M para wins rápidos |
+
+**Ejemplos de uso:**
+- `/planner tecnico` → sprint de 5 issues técnicos/infra
+- `/planner qa 3` → sprint de 3 issues de QA/bugs
+- `/planner feat 8` → sprint de 8 features
+- `/planner sprint 4 backend` → sprint de 4 issues de backend
+- `/planner bugs` → sprint de 5 bugs
 
 ---
 
@@ -175,14 +199,32 @@ gantt
 
 ---
 
-## Modo: `sprint`
+## Modo: `sprint` (y atajos de foco)
+
+### Parsing de argumentos
+
+El modo sprint acepta múltiples formas de invocación:
+
+```
+/planner sprint              → sprint genérico, 5 issues
+/planner sprint 8            → sprint genérico, 8 issues
+/planner sprint 4 backend    → sprint con foco backend, 4 issues
+/planner tecnico             → atajo: sprint con foco técnico, 5 issues
+/planner qa 3                → atajo: sprint con foco QA, 3 issues
+/planner bugs                → atajo: sprint solo bugs, 5 issues
+```
+
+**Reglas de parsing:**
+1. Si el argumento es un foco conocido (ver tabla de atajos): activar modo `sprint` con ese foco
+2. Si viene un número junto al foco: usarlo como N
+3. Si no hay número: default **5**
+4. Los alias son intercambiables (`tech` = `tecnico` = `infra`)
 
 ### Límite de issues
 
-El modo sprint acepta un número opcional **N** como parte del argumento (ej: `/planner sprint 8`).
-Si no se especifica, el default es **5**. Este límite controla cuántos issues se incluyen en el
-`sprint-plan.json` y en el reporte textual. La recolección y el scoring se hacen sobre todos los
-issues del repo; el recorte a N ocurre al final tras el ranking.
+El límite N controla cuántos issues se incluyen en el `sprint-plan.json` y en el reporte textual.
+La recolección y el scoring se hacen sobre todos los issues del repo; el recorte a N ocurre al
+final tras el ranking (con bonus de foco si aplica).
 
 Seleccionar las **top N tareas accionables** para los próximos días:
 
@@ -208,6 +250,32 @@ Formato de salida (máximo N issues, default 5):
 
 (máximo N issues en total — si hay más candidatos, priorizar por score)
 ```
+
+### Modificador de scoring por foco temático
+
+Cuando se especifica un foco (ya sea via atajo o `sprint N foco`), **se aplica un bonus de +30 pts**
+a los issues que coincidan con el foco, además del scoring normal de `planning-criteria.md`.
+
+| Foco | Bonus +30 si el issue... |
+|------|--------------------------|
+| `tecnico`/`tech`/`infra` | Tiene label `area:infra`, `tipo:infra`, `refactor`, o afecta CI/build/gradle |
+| `qa`/`testing`/`tests` | Tiene label `bug`, menciona "test" en título/body, o tiene tests pendientes |
+| `bugs`/`fix` | Tiene label `bug` (EXCLUSIVO: **descarta** issues sin label `bug`) |
+| `features`/`feat` | NO tiene label `bug`, `refactor` ni `tipo:infra` |
+| `deuda`/`debt` | Tiene label `refactor`, `strings`, o menciona "deuda técnica"/"tech debt"/"cleanup"/"migración" |
+| `backend`/`back` | Afecta módulos `:backend` o `:users` (Stream A) |
+| `app`/`front` | Afecta módulo `:app` o tiene label `app:*` (Streams B/C/D) |
+| `cross` | Afecta strings, buildSrc, DI, router (Stream E) |
+| `rapido`/`quick`/`wins` | Estimado como S o M (EXCLUSIVO: **descarta** L y XL) |
+
+**Focos exclusivos** (`bugs`, `rapido`): filtran issues que no coinciden en vez de solo dar bonus.
+**Focos con bonus**: priorizan issues del foco pero NO excluyen otros si faltan candidatos.
+
+Los 🔴 BLOQUEANTES siempre van primero, independientemente del foco.
+
+El campo `tema` del `sprint-plan.json` debe reflejar el foco elegido:
+- Sin foco: `"tema": "Sprint general — mix de prioridades"`
+- Con foco: `"tema": "Sprint QA — prioridad en bugs y testing"`, `"tema": "Sprint técnico — infra y refactors"`, etc.
 
 ### Generar plan JSON para Start-Agente
 


### PR DESCRIPTION
## Resumen

### 1. Planner — Atajos de foco temático

Agregué **9 atajos** para planificación más rápida. Ahora puedes escribir:

- `/planner tecnico` → sprint de 5 issues técnicos/infra
- `/planner qa 3` → sprint de 3 issues de QA/bugs  
- `/planner features` → solo features nuevas
- `/planner bugs` → solo bugs (exclusivo)
- `/planner rapido` → solo S/M (wins rápidos, exclusivo)
- `/planner backend` → Stream A
- `/planner app` → Streams B/C/D
- `/planner cross` → Stream E
- `/planner deuda` → tech debt, refactors

Cada foco aplica **bonus +30 pts** al scoring. Algunos focos (bugs, rapido) filtran en lugar de priorizar.

### 2. Fix: permission-gate.js para todas las herramientas

**Problema**: `TaskUpdate`, `Edit`, `Write` no mostraban botones en Telegram → fallaban a diálogo local.

**Solución**:
- Extendí `permission-gate.js` para manejar **todas las herramientas** (no solo Bash)
- Agregué `formatAction()` con cases para Edit, Write, Task, TaskUpdate, TaskCreate, Skill, WebFetch, WebSearch, NotebookEdit
- Registré el hook PreToolUse con matcher vacío (aplica a todos)
- Tools read-only (Read, Glob, Grep) se omiten

**Resultado**: Ahora permisos para **cualquier herramienta** aparecen con botones en Telegram ✅

## Plan de tests

- [x] Sintaxis valid en permission-gate.js (node -c)
- [x] JSON válido en settings.json
- [x] Cambios mergeados a main
- [ ] Probar `/planner tecnico` en siguiente sesión
- [ ] Probar TaskUpdate con botones Telegram

Closes #1204

🤖 Generado con [Claude Code](https://claude.ai/claude-code)