### PR TITLE
feat(monitor): visualización de interacción entre agentes en tiempo real

### DIFF
--- a/.claude/dashboard-server.js
+++ b/.claude/dashboard-server.js
@@ -36,8 +36,10 @@ const SSE_INTERVAL_MS = 5000;
 const ACTIVE_THRESHOLD_MS = 5 * 60 * 1000;
 const IDLE_THRESHOLD_MS = 15 * 60 * 1000;
 const AUTO_STOP_MS = 30 * 60 * 1000;
-const RECENT_ACTIVITY_COUNT = 8;
+const RECENT_ACTIVITY_COUNT = 20;
 const MAX_CI_ENTRIES = 5;
+const PENDING_QUESTIONS_FILE = path.join(CLAUDE_DIR, "hooks", "pending-questions.json");
+const APPROVAL_HISTORY_FILE = path.join(CLAUDE_DIR, "hooks", "approval-history.json");
 
 // --- Parse args ---
 const portIdx = process.argv.indexOf("--port");
@@ -158,6 +160,35 @@ function collectData() {
     }
   } catch {}
 
+  // Pending questions (blocking data)
+  let pendingQuestions = [];
+  try {
+    const pq = readJson(PENDING_QUESTIONS_FILE);
+    if (pq && Array.isArray(pq.questions)) {
+      pendingQuestions = pq.questions.filter(q => q.status === "pending");
+    }
+  } catch {}
+
+  // Map approver_pid to session/agent for blocking relationships
+  const pidToSession = {};
+  for (const s of sessions) {
+    if (s.pid) pidToSession[s.pid] = s;
+  }
+  const blockingRelations = [];
+  for (const q of pendingQuestions) {
+    if (q.approver_pid && pidToSession[q.approver_pid]) {
+      const blockedSession = pidToSession[q.approver_pid];
+      blockingRelations.push({
+        blockedAgent: blockedSession.agent_name || "Ad-hoc (" + blockedSession.id + ")",
+        blockedSessionId: blockedSession.id,
+        reason: q.type === "permission" ? "Esperando permiso" : "Pregunta pendiente",
+        message: (q.message || "").substring(0, 120),
+        waitingSince: q.timestamp,
+        waitingMs: Date.now() - new Date(q.timestamp).getTime(),
+      });
+    }
+  }
+
   // Compute KPIs
   const activeSessions = sessions.filter(s => s._status === "active");
   const idleSessions = sessions.filter(s => s._status === "idle");
@@ -220,6 +251,8 @@ function collectData() {
     branch,
     lastCommits,
     allTasks,
+    pendingQuestions,
+    blockingRelations,
   };
 
   cachedData = data;
@@ -259,31 +292,86 @@ function renderHTML(data, theme) {
     return `${x},${y}`;
   }).join(" ");
 
-  // Agent icons
+  // Agent icons (character emojis)
   const AGENT_ICONS = {
-    "Guru": "&#128269;", "Doc": "&#128203;", "Doc (historia)": "&#128203;",
-    "Doc (refinar)": "&#128203;", "Doc (priorizar)": "&#128203;",
-    "Planner": "&#128197;", "DeliveryManager": "&#128230;", "Tester": "&#129514;",
-    "Monitor": "&#128202;", "Builder": "&#128296;", "Review": "&#128270;",
-    "QA": "&#129514;", "Auth": "&#128274;", "UX Specialist": "&#127912;",
-    "Scrum Master": "&#128203;", "PO": "&#128188;",
+    "Guru": "&#129497;", // mago
+    "Doc": "&#128214;", "Doc (historia)": "&#128214;",
+    "Doc (refinar)": "&#128214;", "Doc (priorizar)": "&#128214;",
+    "Planner": "&#128218;", // libro abierto
+    "DeliveryManager": "&#127939;", // corredor
+    "Tester": "&#128373;&#65039;", // detective
+    "Monitor": "&#128065;&#65039;", // ojo
+    "Builder": "&#127959;&#65039;", // construccion
+    "Review": "&#128270;", // lupa
+    "QA": "&#128373;&#65039;", // detective
+    "Auth": "&#128274;", // candado
+    "UX Specialist": "&#127912;", // arte
+    "Scrum Master": "&#128203;", // clipboard
+    "PO": "&#128188;", // maletin
+    "BackendDev": "&#9881;&#65039;", // gear
+    "AndroidDev": "&#128241;", // phone
+    "iOSDev": "&#127823;", // apple
+    "WebDev": "&#127760;", // globe
+    "DesktopDev": "&#128187;", // laptop
+    "Ops": "&#128295;", // wrench
+  };
+
+  // Personalidades de agentes (para tooltips/feed)
+  const AGENT_PERSONALITIES = {
+    "Guru": "Siempre encuentra la pista",
+    "DeliveryManager": "Entrega en tiempo y forma",
+    "Tester": "Cuestiona todo",
+    "Builder": "Forja c\u00f3digo s\u00f3lido",
+    "Planner": "Organiza el caos",
+    "Monitor": "Nunca duerme",
+    "Doc": "Documenta el camino",
+    "Review": "Ojo cr\u00edtico",
+    "QA": "Nada pasa sin prueba",
+    "Auth": "Guardi\u00e1n de accesos",
+    "PO": "La voz del usuario",
+    "UX Specialist": "Dise\u00f1a experiencias",
+    "Scrum Master": "Facilita el flujo",
+    "Ops": "Mantiene todo andando",
   };
 
   const AGENT_GRADIENTS = {
-    "Guru": "linear-gradient(135deg, #3b82f6, #60a5fa)",
+    "Guru": "linear-gradient(135deg, #6366f1, #a78bfa)",
     "Doc": "linear-gradient(135deg, #8b5cf6, #a78bfa)",
-    "Planner": "linear-gradient(135deg, #f59e0b, #fbbf24)",
+    "Planner": "linear-gradient(135deg, #eab308, #fbbf24)",
     "DeliveryManager": "linear-gradient(135deg, #10b981, #34d399)",
-    "Tester": "linear-gradient(135deg, #10b981, #34d399)",
-    "QA": "linear-gradient(135deg, #10b981, #34d399)",
-    "Builder": "linear-gradient(135deg, #f59e0b, #fb923c)",
+    "Tester": "linear-gradient(135deg, #a855f7, #ec4899)",
+    "QA": "linear-gradient(135deg, #a855f7, #ec4899)",
+    "Builder": "linear-gradient(135deg, #f97316, #fb923c)",
     "Review": "linear-gradient(135deg, #3b82f6, #8b5cf6)",
+    "Monitor": "linear-gradient(135deg, #06b6d4, #22d3ee)",
+    "Auth": "linear-gradient(135deg, #64748b, #94a3b8)",
+    "PO": "linear-gradient(135deg, #0ea5e9, #38bdf8)",
+    "UX Specialist": "linear-gradient(135deg, #ec4899, #f472b6)",
+    "Scrum Master": "linear-gradient(135deg, #14b8a6, #2dd4bf)",
+    "Ops": "linear-gradient(135deg, #78716c, #a8a29e)",
+    "BackendDev": "linear-gradient(135deg, #ef4444, #f87171)",
+    "AndroidDev": "linear-gradient(135deg, #22c55e, #4ade80)",
+    "WebDev": "linear-gradient(135deg, #3b82f6, #60a5fa)",
+  };
+
+  // Agent color (solid, for SVG bars)
+  const AGENT_COLORS = {
+    "Guru": "#818cf8", "Doc": "#a78bfa", "Planner": "#fbbf24",
+    "DeliveryManager": "#34d399", "Tester": "#d946ef", "QA": "#d946ef",
+    "Builder": "#fb923c", "Review": "#818cf8", "Monitor": "#22d3ee",
+    "Auth": "#94a3b8", "PO": "#38bdf8", "UX Specialist": "#f472b6",
+    "Scrum Master": "#2dd4bf", "Ops": "#a8a29e",
+    "BackendDev": "#f87171", "AndroidDev": "#4ade80", "WebDev": "#60a5fa",
   };
 
   const STATUS_COLORS = { active: "#34d399", idle: "#fbbf24", done: "#6C7086", stale: "#555872" };
   const STATUS_LABELS = { active: "Activo", idle: "Idle", done: "Terminado", stale: "Stale" };
 
-  // Render sessions HTML
+  // Check which agents are blocked
+  const blockedPids = new Set(data.blockingRelations.map(b => b.blockedSessionId));
+  const blockedAgentNames = new Set(data.blockingRelations.map(b => b.blockedAgent));
+
+  // Render sessions HTML (agent cards)
   let agentsHtml = "";
   const visibleSessions = data.sessions.filter(s => s._status !== "stale");
   for (const s of visibleSessions) {
@@ -296,22 +384,156 @@ function renderHTML(data, theme) {
     const duration = formatDuration(s.started_ts);
     const idleInfo = s._status === "idle" ? " " + formatAge(s.last_activity_ts) : "";
     const lastAction = s.last_tool ? (escHtml(s.last_tool) + ": " + escHtml((s.last_target || "").substring(0, 50))) : "--";
+    const isBlocked = blockedPids.has(s.id);
+    const personality = AGENT_PERSONALITIES[s.agent_name] || "";
 
     agentsHtml += `
-      <div class="agent-card">
+      <div class="agent-card ${isBlocked ? 'agent-blocked' : ''}" title="${escHtml(personality)}">
         <div class="agent-avatar" style="background:${gradient};">${icon}</div>
         <div class="agent-info">
           <div style="display:flex;justify-content:space-between;align-items:center;">
             <div class="agent-name">${name}</div>
-            <span class="agent-status" style="background:${statusColor}20;color:${statusColor};border-color:${statusColor}40;">${statusLabel}${idleInfo}</span>
+            ${isBlocked
+              ? '<span class="agent-status agent-status-blocked">&#128721; Bloqueado</span>'
+              : '<span class="agent-status" style="background:' + statusColor + '20;color:' + statusColor + ';border-color:' + statusColor + '40;">' + statusLabel + idleInfo + '</span>'
+            }
           </div>
           <div class="agent-meta">${branchDisplay} &middot; ${s.action_count || 0} acc &middot; ${duration}</div>
-          <div class="agent-action"><div class="dot" style="background:${statusColor};"></div>${lastAction}</div>
+          <div class="agent-action"><div class="dot" style="background:${isBlocked ? 'var(--red)' : statusColor};${isBlocked ? 'animation:pulse-red 1.5s infinite;' : ''}"></div>${lastAction}</div>
         </div>
       </div>`;
   }
   if (visibleSessions.length === 0) {
     agentsHtml = '<div class="empty-state">Sin agentes activos</div>';
+  }
+
+  // --- Timeline SVG bars (Fase 2) ---
+  let timelineBarsHtml = "";
+  if (visibleSessions.length > 0) {
+    const barHeight = 36;
+    const barGap = 8;
+    const svgH = visibleSessions.length * (barHeight + barGap) + 10;
+    const labelW = 130;
+    const barW = 400;
+    let bars = "";
+    for (let i = 0; i < visibleSessions.length; i++) {
+      const s = visibleSessions[i];
+      const y = 5 + i * (barHeight + barGap);
+      const agentIcon = AGENT_ICONS[s.agent_name] || "&#129302;";
+      const agentColor = AGENT_COLORS[s.agent_name] || "#6C7086";
+      const agentName = escHtml(s.agent_name || "Ad-hoc");
+      const isBlocked = blockedPids.has(s.id);
+
+      // Calculate progress from tasks
+      const sessionTasks = (s.current_tasks || []);
+      const totalT = sessionTasks.length;
+      const doneT = sessionTasks.filter(t => t.status === "completed").length;
+      const progressPct = totalT > 0 ? Math.round((doneT / totalT) * 100) : 0;
+      const barFillW = Math.round(barW * progressPct / 100);
+
+      // Sub-steps for expandable detail
+      const hasSteps = sessionTasks.some(t => t.steps && t.steps.length > 0);
+
+      bars += `
+        <g class="timeline-agent-row" data-session="${escHtml(s.id)}" style="cursor:${hasSteps ? 'pointer' : 'default'};">
+          <text x="30" y="${y + 23}" font-size="12" fill="var(--text)" font-weight="600">${agentName}</text>
+          <text x="4" y="${y + 24}" font-size="14">${agentIcon}</text>
+          <rect x="${labelW}" y="${y + 4}" width="${barW}" height="${barHeight - 8}" rx="4" fill="var(--surface3)" />
+          <rect x="${labelW}" y="${y + 4}" width="${barFillW}" height="${barHeight - 8}" rx="4" fill="${agentColor}" opacity="0.85">
+            ${isBlocked ? '<animate attributeName="opacity" values="0.85;0.3;0.85" dur="1.5s" repeatCount="indefinite"/>' : ''}
+          </rect>
+          ${isBlocked ? '<rect x="' + labelW + '" y="' + (y + 4) + '" width="' + barW + '" height="' + (barHeight - 8) + '" rx="4" fill="none" stroke="var(--red)" stroke-width="2"><animate attributeName="stroke-opacity" values="1;0.2;1" dur="1.5s" repeatCount="indefinite"/></rect>' : ''}
+          <text x="${labelW + barW + 8}" y="${y + 23}" font-size="11" fill="var(--text-dim)" font-weight="700">${progressPct}%</text>
+          ${isBlocked ? '<text x="' + (labelW + barW + 40) + '" y="' + (y + 23) + '" font-size="11" fill="var(--red)">&#128721; Bloqueado</text>' : ''}
+        </g>`;
+    }
+    timelineBarsHtml = `
+      <svg class="timeline-svg" viewBox="0 0 600 ${svgH}" preserveAspectRatio="xMinYMin meet" style="width:100%;height:${svgH}px;">
+        ${bars}
+      </svg>`;
+  } else {
+    timelineBarsHtml = '<div class="empty-state">Sin agentes para el timeline</div>';
+  }
+
+  // --- Sub-steps expandable HTML ---
+  let substepsHtml = "";
+  for (const s of visibleSessions) {
+    const sessionTasks = s.current_tasks || [];
+    const tasksWithSteps = sessionTasks.filter(t => t.steps && t.steps.length > 0);
+    if (tasksWithSteps.length > 0) {
+      substepsHtml += `<div class="substeps-detail" id="substeps-${escHtml(s.id)}" style="display:none;">`;
+      substepsHtml += `<div class="substeps-title">${AGENT_ICONS[s.agent_name] || "&#129302;"} ${escHtml(s.agent_name || "Ad-hoc")} — Sub-pasos</div>`;
+      for (const t of tasksWithSteps) {
+        substepsHtml += `<div class="substeps-task">${escHtml(t.subject)}</div>`;
+        for (let si = 0; si < t.steps.length; si++) {
+          const step = t.steps[si];
+          const isCompleted = t.completed_steps && t.completed_steps.includes(step);
+          const isCurrent = (t.current_step || 0) === si + 1 && !isCompleted;
+          const stepIcon = isCompleted ? "&#10003;" : isCurrent ? "&#9654;" : "&#9675;";
+          const stepClass = isCompleted ? "step-done" : isCurrent ? "step-active" : "step-pending";
+          substepsHtml += `<div class="substep ${stepClass}">${stepIcon} ${escHtml(step)}</div>`;
+        }
+      }
+      substepsHtml += `</div>`;
+    }
+  }
+
+  // --- Activity Feed (Fase 1) ---
+  let activityFeedHtml = "";
+  for (const a of data.activities) {
+    const time = a.ts ? new Date(a.ts).toLocaleTimeString("es-AR", { hour12: false, hour: "2-digit", minute: "2-digit", second: "2-digit" }) : "??:??";
+    // Match session to agent name
+    let agentName = a.session || "?";
+    let agentIcon = "&#129302;";
+    for (const s of data.sessions) {
+      if (s.id === a.session) {
+        agentName = s.agent_name || "Ad-hoc (" + s.id + ")";
+        agentIcon = AGENT_ICONS[s.agent_name] || "&#129302;";
+        break;
+      }
+    }
+    const toolLabel = escHtml(a.tool || "");
+    const target = escHtml((a.target || "").substring(0, 80));
+    activityFeedHtml += `
+      <div class="feed-item">
+        <div class="feed-time">${time}</div>
+        <div class="feed-icon">${agentIcon}</div>
+        <div class="feed-body">
+          <span class="feed-agent">${escHtml(agentName)}</span>
+          <span class="feed-tool">${toolLabel}</span>
+          <span class="feed-target">${target}</span>
+        </div>
+      </div>`;
+  }
+
+  // Blocking events in feed (highlighted)
+  let blockingFeedHtml = "";
+  for (const b of data.blockingRelations) {
+    const waitTime = formatAge(b.waitingSince);
+    blockingFeedHtml += `
+      <div class="feed-item feed-blocked">
+        <div class="feed-time">&#128721;</div>
+        <div class="feed-icon" style="filter:grayscale(1) brightness(1.5);">&#9888;&#65039;</div>
+        <div class="feed-body">
+          <span class="feed-agent">${escHtml(b.blockedAgent)}</span>
+          <span class="feed-reason">${escHtml(b.reason)} (${waitTime})</span>
+        </div>
+      </div>`;
+  }
+
+  // Blocking relations section
+  let relationsHtml = "";
+  if (data.blockingRelations.length > 0) {
+    relationsHtml = '<div class="relations-section"><div class="relations-title">&#128279; Relaciones activas</div>';
+    for (const b of data.blockingRelations) {
+      relationsHtml += `<div class="relation-item">
+        <span class="relation-blocked">&#128721; ${escHtml(b.blockedAgent)}</span>
+        <span class="relation-arrow">&larr;</span>
+        <span class="relation-reason">${escHtml(b.reason)}</span>
+        <span class="relation-time">${formatAge(b.waitingSince)}</span>
+      </div>`;
+    }
+    relationsHtml += '</div>';
   }
 
   // Render tasks HTML
@@ -537,6 +759,55 @@ function renderHTML(data, theme) {
     /* Empty state */
     .empty-state { font-size: 12px; color: var(--text-muted); font-style: italic; padding: 12px 0; text-align: center; }
 
+    /* Agent blocked state */
+    .agent-blocked { border-color: var(--red) !important; border-left: 3px solid var(--red); animation: pulse-blocked 2s infinite; }
+    .agent-status-blocked { background: var(--red-dim); color: var(--red); border: 1px solid rgba(248,113,113,0.4); font-size: 10px; font-weight: 600; padding: 2px 8px; border-radius: 100px; white-space: nowrap; animation: pulse-red 1.5s infinite; }
+    @keyframes pulse-blocked { 0%, 100% { box-shadow: 0 0 0 0 rgba(248,113,113,0); } 50% { box-shadow: 0 0 12px 2px rgba(248,113,113,0.15); } }
+    @keyframes pulse-red { 0%, 100% { opacity: 1; } 50% { opacity: 0.5; } }
+
+    /* Timeline SVG bars */
+    .timeline-svg { overflow: visible; }
+    .timeline-agent-row:hover rect { filter: brightness(1.2); }
+    .timeline-panel { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 16px; overflow-x: auto; }
+
+    /* Sub-steps expandable */
+    .substeps-detail { background: var(--surface2); border: 1px solid var(--border); border-radius: var(--radius-xs); padding: 12px; margin-top: 8px; }
+    .substeps-title { font-size: 12px; font-weight: 700; color: var(--white); margin-bottom: 8px; }
+    .substeps-task { font-size: 11px; font-weight: 600; color: var(--text-dim); margin: 6px 0 4px 0; }
+    .substep { font-size: 11px; color: var(--text-dim); padding: 2px 0 2px 16px; }
+    .step-done { color: var(--green); }
+    .step-active { color: var(--blue); font-weight: 600; }
+    .step-pending { color: var(--text-muted); }
+
+    /* Activity Feed (chat-style) */
+    .feed-panel { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 16px; max-height: 400px; overflow-y: auto; }
+    .feed-item { display: flex; align-items: flex-start; gap: 8px; padding: 6px 8px; border-radius: var(--radius-xs); margin-bottom: 2px; transition: background 0.15s; }
+    .feed-item:hover { background: var(--surface2); }
+    .feed-blocked { background: var(--red-dim) !important; border-left: 3px solid var(--red); border-radius: var(--radius-xs); }
+    .feed-time { font-size: 10px; color: var(--text-muted); font-weight: 600; min-width: 60px; flex-shrink: 0; font-family: 'SF Mono', 'Cascadia Code', monospace; }
+    .feed-icon { font-size: 14px; flex-shrink: 0; width: 20px; text-align: center; }
+    .feed-body { font-size: 11px; color: var(--text-dim); flex: 1; min-width: 0; }
+    .feed-agent { font-weight: 700; color: var(--white); margin-right: 4px; }
+    .feed-tool { background: var(--blue-dim); color: var(--blue); font-size: 10px; padding: 1px 6px; border-radius: 4px; font-weight: 600; margin-right: 4px; }
+    .feed-target { color: var(--text-dim); word-break: break-all; }
+    .feed-reason { color: var(--red); font-weight: 600; }
+
+    /* Blocking relations */
+    .relations-section { background: var(--red-dim); border: 1px solid rgba(248,113,113,0.3); border-radius: var(--radius-xs); padding: 12px; margin-top: 10px; }
+    .relations-title { font-size: 11px; font-weight: 700; color: var(--red); margin-bottom: 8px; }
+    .relation-item { display: flex; align-items: center; gap: 8px; font-size: 11px; padding: 4px 0; }
+    .relation-blocked { color: var(--red); font-weight: 600; }
+    .relation-arrow { color: var(--text-muted); }
+    .relation-reason { color: var(--text-dim); }
+    .relation-time { color: var(--text-muted); font-size: 10px; margin-left: auto; }
+
+    /* Sprint global bar */
+    .sprint-global-bar { display: flex; align-items: center; gap: 12px; background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 12px 16px; margin-bottom: 16px; }
+    .sprint-bar-track { flex: 1; height: 10px; background: var(--surface3); border-radius: 5px; overflow: hidden; }
+    .sprint-bar-fill { height: 100%; border-radius: 5px; background: var(--gradient-green); transition: width 0.5s; }
+    .sprint-bar-label { font-size: 13px; font-weight: 800; color: var(--white); min-width: 48px; text-align: right; }
+    .sprint-bar-detail { font-size: 10px; color: var(--text-dim); min-width: 100px; }
+
     /* Responsive */
     @media (max-width: 768px) {
       .kpi-row { grid-template-columns: repeat(3, 1fr); }
@@ -548,6 +819,9 @@ function renderHTML(data, theme) {
       .kpi-row { grid-template-columns: repeat(2, 1fr); }
       .container { padding: 8px; }
       .agent-card { padding: 8px; }
+      .feed-panel { max-height: 300px; }
+      .feed-time { min-width: 48px; font-size: 9px; }
+      .timeline-panel { overflow-x: scroll; }
     }
 
     /* Animations */
@@ -607,6 +881,16 @@ function renderHTML(data, theme) {
       </div>
     </div>
 
+    <!-- Sprint Global Progress Bar -->
+    <div class="sprint-global-bar">
+      <span style="font-size:11px;font-weight:700;color:var(--text-dim);">Sprint</span>
+      <div class="sprint-bar-track">
+        <div class="sprint-bar-fill" style="width:${sprintProgress}%;"></div>
+      </div>
+      <div class="sprint-bar-label">${sprintProgress}%</div>
+      <div class="sprint-bar-detail">${data.completedTasks}/${data.totalTasks} tareas</div>
+    </div>
+
     <!-- Agents + Progress Ring -->
     <div class="grid-2col">
       <div>
@@ -640,6 +924,22 @@ function renderHTML(data, theme) {
           </div>
         </div>
       </div>
+    </div>
+
+    <!-- Timeline with SVG progress bars (Fase 2) -->
+    <div class="timeline-panel" style="margin-bottom:16px;">
+      <div class="panel-title">Timeline de agentes <span class="chip chip-blue">${visibleSessions.length} activos</span></div>
+      ${timelineBarsHtml}
+      <div id="substeps-container">${substepsHtml}</div>
+    </div>
+
+    <!-- Activity Feed (Fase 1) -->
+    <div class="feed-panel" style="margin-bottom:16px;" id="activity-feed">
+      <div class="panel-title">Interacciones en vivo <span class="chip ${data.blockingRelations.length > 0 ? 'chip-red' : 'chip-green'}">${data.blockingRelations.length > 0 ? data.blockingRelations.length + ' bloqueado(s)' : 'Sin bloqueos'}</span></div>
+      ${blockingFeedHtml}
+      ${activityFeedHtml}
+      ${activityFeedHtml.length === 0 && blockingFeedHtml.length === 0 ? '<div class="empty-state">Sin actividad reciente</div>' : ''}
+      ${relationsHtml}
     </div>
 
     <!-- Tasks Panel -->
@@ -695,6 +995,21 @@ function renderHTML(data, theme) {
     // Restore theme
     const saved = localStorage.getItem('theme');
     if (saved) document.documentElement.setAttribute('data-theme', saved);
+
+    // Expandable sub-steps on timeline click
+    document.querySelectorAll('.timeline-agent-row').forEach(function(row) {
+      row.addEventListener('click', function() {
+        var sid = this.getAttribute('data-session');
+        var detail = document.getElementById('substeps-' + sid);
+        if (detail) {
+          detail.style.display = detail.style.display === 'none' ? 'block' : 'none';
+        }
+      });
+    });
+
+    // Auto-scroll activity feed to top (latest events)
+    var feed = document.getElementById('activity-feed');
+    if (feed) { feed.scrollTop = 0; }
 
     // SSE auto-refresh (deshabilitado con ?nosse=1 para screenshot)
     if (location.search.includes('nosse=1')) { return; }
@@ -803,6 +1118,8 @@ function handleRequest(req, res) {
         }))
       })),
       activities: data.activities,
+      blockingRelations: data.blockingRelations,
+      pendingQuestionsCount: data.pendingQuestions.length,
     });
     res.writeHead(200, { "Content-Type": "application/json", "Cache-Control": "no-cache" });
     res.end(json);


### PR DESCRIPTION
## Resumen

Implementación completa de visualización en vivo de interacciones entre agentes en el dashboard del Monitor (`localhost:3100`):

- **Activity Feed**: Chat-style con eventos cronológicos de todos los agentes, bloqueos destacados, relaciones activas
- **Timeline SVG**: Barras de progreso horizontales por agente con animación pulsante en bloqueados
- **Personajes**: Emojis únicos por agente (🧙 Guru, 🏃 DeliveryManager, 🕵️ Tester, 🏗️ Builder, 📚 Planner, 👁️ Monitor)
- **Sprint Progress**: Barra global con % actualizado en tiempo real
- **Sub-pasos expandibles**: Click en timeline para ver detalles de tareas

## Plan de tests

- [x] Syntax check Node.js (--check)
- [x] Datos de pending-questions.json se recolectan
- [x] Mapping approver_pid → sesiones funciona
- [x] CSS vanilla sin dependencias externas
- [x] Responsive en mobile (feed max-height, timeline scroll)
- [x] SVG bars con animación pulsante (red en bloqueados)
- [x] Sub-pasos expandibles sin reload
- [x] Auto-scroll activity feed al más reciente

## Criterios de aceptación

- [x] Feed de actividad visible en el dashboard con eventos de todos los agentes
- [x] Bloqueos (permisos pendientes) destacados visualmente con tiempo de espera
- [x] Sección de relaciones activas muestra dependencias entre agentes
- [x] Funciona en mobile (responsive)
- [x] SSE actualiza el feed sin refresh manual
- [x] Emojis de personaje identifican a cada agente
- [x] Barras de progreso por agente con % real de tareas
- [x] Animación pulsante en agentes bloqueados
- [x] Sub-pasos expandibles al hacer click/tap
- [x] Sprint progress bar global

## Cambios

- `.claude/dashboard-server.js`: +334 líneas, -17 líneas
  - Extendidas AGENT_ICONS, AGENT_GRADIENTS, AGENT_COLORS
  - Nueva estructura AGENT_PERSONALITIES
  - Recolección de pending-questions.json y mapeo de relaciones de bloqueo
  - Rendering de Activity Feed, Timeline SVG, Sub-steps expandibles
  - CSS nuevo: .feed-panel, .timeline-panel, .sprint-global-bar, .agent-blocked, @keyframes pulse-red
  - JavaScript interactivo para expandir sub-pasos

Closes #1212

🤖 Generado con [Claude Code](https://claude.com/claude-code)