### PR TITLE
fix(hooks): diagnóstico y notificación de permisos pendientes cuando commander cae

### DIFF
--- a/.claude/hooks/health-check.js
+++ b/.claude/hooks/health-check.js
@@ -267,11 +267,12 @@ function isProcessAlive(pid) {
 // ─── Check 1: telegram-commander vivo ──────────────────────────────────────
 
 function checkCommander() {
-    const result = { ok: true, detail: "" };
+    const result = { ok: true, detail: "", pendingPermissions: [] };
     try {
         if (!fs.existsSync(COMMANDER_LOCK)) {
             result.ok = false;
             result.detail = "No hay lockfile — commander no activo";
+            result.pendingPermissions = _getPendingPermissions();
             return result;
         }
         const data = JSON.parse(fs.readFileSync(COMMANDER_LOCK, "utf8"));
@@ -281,14 +282,32 @@ function checkCommander() {
             // Auto-fix: limpiar lockfile para que commander-launcher.js lo relance
             try { fs.unlinkSync(COMMANDER_LOCK); } catch (e) {}
             result.detail += " (lockfile limpiado, se relanzará automáticamente)";
+            result.pendingPermissions = _getPendingPermissions();
             return result;
         }
         result.detail = "PID " + data.pid + " activo";
     } catch (e) {
         result.ok = false;
         result.detail = "Error leyendo lockfile: " + e.message;
+        result.pendingPermissions = _getPendingPermissions();
     }
     return result;
+}
+
+/**
+ * Lee las preguntas de tipo "permission" con status "pending" de pending-questions.json.
+ * Retorna array vacío si no hay archivo o hay error.
+ */
+function _getPendingPermissions() {
+    try {
+        const pqFile = path.join(HOOKS_DIR, "pending-questions.json");
+        if (!fs.existsSync(pqFile)) return [];
+        const data = JSON.parse(fs.readFileSync(pqFile, "utf8"));
+        if (!data || !Array.isArray(data.questions)) return [];
+        return data.questions.filter(q => q.type === "permission" && q.status === "pending");
+    } catch (e) {
+        return [];
+    }
 }
 
 // ─── Check 2: permission-approver huérfanos ────────────────────────────────
@@ -819,6 +838,21 @@ async function main() {
     if (issues.length > 0 || issuesCreated.length > 0) {
         let msg = "🏥 <b>Health Check — Problemas detectados</b>\n\n";
         msg += issues.map(i => "• " + i).join("\n");
+
+        // Si el commander estaba caído y hay permisos pendientes, incluirlos en el mensaje
+        const pendingPerms = checks.commander && checks.commander.pendingPermissions;
+        if (!checks.commander.ok && pendingPerms && pendingPerms.length > 0) {
+            msg += "\n\n🔐 <b>Permisos bloqueados sin commander:</b>\n";
+            pendingPerms.forEach(q => {
+                const ageMin = Math.round((Date.now() - new Date(q.timestamp).getTime()) / 60000);
+                // Escapar HTML para evitar que Telegram rechace el mensaje (parse_mode HTML)
+                const rawMsg = (q.message || "Permiso solicitado").substring(0, 120);
+                const shortMsg = rawMsg.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+                msg += "• [" + ageMin + " min] " + shortMsg + "\n";
+            });
+            msg += "\n<i>El commander se relanzará automáticamente. Los permisos pendientes serán procesados al reconectarse.</i>";
+            log("Commander caído con " + pendingPerms.length + " permiso(s) pendiente(s)");
+        }
 
         if (issuesCreated.length > 0) {
             msg += "\n\n📋 <b>Issues creados en GitHub:</b>\n";

--- a/.claude/hooks/telegram-commander.js
+++ b/.claude/hooks/telegram-commander.js
@@ -2406,8 +2406,8 @@ async function pollingLoop() {
                 const cbChatId = cq.message && cq.message.chat && cq.message.chat.id;
                 if (String(cbChatId) === String(CHAT_ID)) {
                     const cbData = cq.data;
-                    // Solo manejar callbacks de propuestas — los de permisos (allow:/always:/deny:)
-                    // los maneja permission-approver.js
+                    // Callbacks de propuestas (create_proposal:, discard_proposal:, etc.)
+                    // Los callbacks de permisos (allow:/always:/deny:) los maneja este mismo commander más abajo.
                     if (cbData.startsWith("create_proposal:") || cbData.startsWith("discard_proposal:") || cbData === "create_all_proposals") {
                         log("Callback de propuesta recibido: " + cbData);
                         try {
@@ -2538,7 +2538,13 @@ async function pollingLoop() {
                             }
                             log("Permiso procesado: action=" + permAction + " requestId=" + cbRequestId + " msgId=" + cbMsgId + " ts=" + new Date().toISOString());
                         } else {
-                            // Pregunta no encontrada
+                            // Pregunta no encontrada — loggear contenido del archivo para diagnóstico
+                            const fileSnapshot = (() => {
+                                try {
+                                    return JSON.stringify(loadQuestions()).substring(0, 500);
+                                } catch (e) { return "error: " + e.message; }
+                            })();
+                            log("Pregunta no encontrada: requestId=" + cbRequestId + " estado_q=" + (q ? q.status : "null") + " archivo=" + fileSnapshot);
                             try {
                                 await telegramPost("answerCallbackQuery", {
                                     callback_query_id: cq.id,


### PR DESCRIPTION
## Resumen

Diagnóstico y auto-reparación mejorada para el fallo periódico de botones de aprobación de permisos en Telegram (#1171):

- **Logging diagnóstico**: Al no encontrar una pregunta de permiso pendiente, se loggea el contenido del archivo (primeros 500 chars) para diagnosticar fallos de race condition
- **Comentario actualizado**: Aclaración de que el telegram-commander SÍ maneja callbacks de permisos (`allow:/always:/deny:`)
- **Notificación proactiva**: Health-check detecta permisos pendientes cuando el commander está caído y notifica por Telegram
- **Robustez**: Escape HTML en mensajes de Telegram para evitar malformación si la descripción contiene caracteres especiales

## Tests ejecutados

✅ Tests de hooks: 176/176 pass (P-01, P-07, P-09, P-18)
✅ Escaneo de seguridad: APROBADO (OWASP A01-A10)
✅ Sintaxis JavaScript: OK (telegram-commander.js, health-check.js)

## Plan de tests

- [x] Tests unitarios de hooks pasan
- [x] Verificación sintáctica de archivos modificados
- [x] Escaneo de seguridad completado

Closes #1171

🤖 Generado con [Claude Code](https://claude.ai/claude-code)