### PR TITLE
fix(hooks): actualizar mensaje Telegram cuando permiso se resuelve desde consola

### DIFF
--- a/.claude/hooks/permission-approver.js
+++ b/.claude/hooks/permission-approver.js
@@ -635,6 +635,29 @@ async function processInput() {
 
             if (result.answered_via === "console") {
                 log("Respondido en consola — requestId=" + requestId + " latency=" + latencyMs + "ms (" + label + ")");
+                // Editar mensaje Telegram para reflejar el resultado y remover botones
+                if (currentMsgId) {
+                    const consoleAction = result.action_result;
+                    let consoleResultLine;
+                    if (consoleAction === "allow" || consoleAction === "always") {
+                        consoleResultLine = "\n\n✅ <i>Aprobado desde consola</i>";
+                    } else if (consoleAction === "deny") {
+                        consoleResultLine = "\n\n❌ <i>Rechazado desde consola</i>";
+                    } else {
+                        consoleResultLine = "\n\n⌨️ <i>Respondido desde consola</i>";
+                    }
+                    try {
+                        await telegramPost("editMessageText", {
+                            chat_id: CHAT_ID,
+                            message_id: currentMsgId,
+                            text: msgText + consoleResultLine,
+                            parse_mode: "HTML",
+                            reply_markup: { inline_keyboard: [] }
+                        }, ANSWER_TIMEOUT);
+                        // Marcar como sincronizado para que post-console-response.js no lo vuelva a editar
+                        updateQuestionField(requestId, { telegram_synced: true });
+                    } catch(e) { log("Error editando mensaje (console resolve): " + e.message); }
+                }
                 process.exit(0);
             }
 

--- a/.claude/hooks/telegram-commander.js
+++ b/.claude/hooks/telegram-commander.js
@@ -2815,7 +2815,7 @@ function takePqSnapshot() {
         const data = JSON.parse(fs.readFileSync(PENDING_QUESTIONS_FILE, "utf8"));
         const snap = {};
         for (const q of (data.questions || [])) {
-            snap[q.id] = { status: q.status, answered_via: q.answered_via || null, msgId: q.telegram_message_id };
+            snap[q.id] = { status: q.status, answered_via: q.answered_via || null, msgId: q.telegram_message_id, telegram_synced: q.telegram_synced || false };
         }
         return snap;
     } catch (e) { return {}; }
@@ -2826,8 +2826,8 @@ async function onPendingQuestionsChange() {
     for (const id of Object.keys(newSnap)) {
         const cur = newSnap[id];
         const prev = _pqLastSnapshot[id];
-        // Detectar transición a answered_via:"console"
-        if (cur.answered_via === "console" && (!prev || prev.answered_via !== "console") && cur.msgId) {
+        // Detectar transición a answered_via:"console" (saltar si ya fue sincronizado por el approver)
+        if (cur.answered_via === "console" && (!prev || prev.answered_via !== "console") && cur.msgId && !cur.telegram_synced) {
             log("PQ Watch: pregunta " + id + " respondida en consola — editando mensaje " + cur.msgId);
             try {
                 await telegramPost("editMessageText", {


### PR DESCRIPTION
## Resumen

- **Objetivo**: Actualizar el mensaje de Telegram cuando el usuario aprueba o deniega un permiso desde la terminal de Claude Code
- **Cambio**: Al resolver desde consola, editar el mensaje Telegram para mostrar "✅ Aprobado desde consola" o "❌ Rechazado desde consola" y remover los botones inline
- **Riesgo mitigado**: Evitar confusión del operador que no sabe si fue aprobado o rechazado

## Cambios técnicos

### permission-approver.js (líneas 636-657)
- Agregar edición de mensaje Telegram cuando `answered_via === "console"`
- Detectar si fue allow/deny desde `result.action_result`
- Marcar `telegram_synced: true` para evitar sobreescritura por post-console-response.js
- Manejo de errores silencioso (timeout 5000ms no bloquea el agente)

### telegram-commander.js (línea 2812-2824)
- Incluir `telegram_synced` en snapshot para coordinación con approver
- Saltear edición genérica si `telegram_synced` ya está marcado (evitar doble-edit)

## Verificación

- ✅ Tests hooks: 176/176 pass
- ✅ Sintaxis Node.js válida
- ✅ Seguridad: 
  - A03 (Injection): `consoleResultLine` es literal, no contiene inputs externos
  - A09 (Logging): No se loguea PII ni secrets
  - A04 (Design): Timeout 5000ms, error handling silencioso

## Criterios de aceptación cumplidos

- [x] Al aprobar desde terminal → mensaje editado "✅ Aprobado desde consola" + botones desaparecen
- [x] Al denegar desde terminal → mensaje editado "❌ Rechazado desde consola" + botones desaparecen
- [x] Si edit de Telegram falla → approver continúa normalmente (error silencioso)
- [x] No hay regresión en flujo normal de aprobación vía botones de Telegram

Closes #1169

🤖 Generado con [Claude Code](https://claude.ai/claude-code)