### PR TITLE
feat(hooks): auto-aprobar permisos Low/Medium al expirar reintentos sin rechazo

### DIFF
--- a/.claude/hooks/permission-approver.js
+++ b/.claude/hooks/permission-approver.js
@@ -16,7 +16,7 @@ const https = require("https");
 const crypto = require("crypto");
 const fs = require("fs");
 const path = require("path");
-const { generatePattern, getSettingsPaths, persistPattern, resolveMainRepoRoot, isAlreadyCovered, extractFirstCommand, generateBashPattern, splitCompoundCommand, classifySeverity, Severity } = require("./permission-utils");
+const { generatePattern, getSettingsPaths, persistPattern, resolveMainRepoRoot, isAlreadyCovered, extractFirstCommand, generateBashPattern, splitCompoundCommand, classifySeverity, Severity, AUTO_APPROVE_ON_TIMEOUT } = require("./permission-utils");
 
 const { addPendingQuestion, resolveQuestion, getQuestionById, updateQuestionField } = require("./pending-questions");
 const { readSessionContext } = require("./context-reader");
@@ -695,17 +695,40 @@ async function processInput() {
                     }, ANSWER_TIMEOUT);
                 } catch(e) { /* ok — puede fallar si ya fue editado */ }
             }
-            try {
-                await telegramPost("editMessageText", {
-                    chat_id: CHAT_ID,
-                    message_id: currentMsgId,
-                    text: msgText + "\n\n⏱ <i>Expirado (" + totalAttempts + " intentos, " + elapsedTotal + "s) — respondiendo en consola</i>"
-                        + "\n📝 Responder <b>siempre</b> para guardar el permiso",
-                    parse_mode: "HTML",
-                    reply_markup: { inline_keyboard: [] }
-                }, ANSWER_TIMEOUT);
-            } catch(e) { log("Error editando mensaje final: " + e.message); }
-            process.exit(0); // fallback al prompt local
+            if (AUTO_APPROVE_ON_TIMEOUT.includes(severity)) {
+                // Auto-aprobación por timeout completo sin rechazo explícito (Low/Medium)
+                log("AUTO_APPROVE_TIMEOUT: severity=" + severity + " tool=" + toolName + " attempts=" + totalAttempts);
+                try {
+                    await telegramPost("editMessageText", {
+                        chat_id: CHAT_ID,
+                        message_id: currentMsgId,
+                        text: msgText + "\n\n✅ <i>Auto-aprobado (reintentos agotados — sin rechazo)</i>",
+                        parse_mode: "HTML",
+                        reply_markup: { inline_keyboard: [] }
+                    }, ANSWER_TIMEOUT);
+                } catch(e) { log("Error editando mensaje de auto-aprobación: " + e.message); }
+                const response = {
+                    hookSpecificOutput: {
+                        hookEventName: "PermissionRequest",
+                        decision: { behavior: "allow" }
+                    }
+                };
+                process.stdout.write(JSON.stringify(response) + "\n", () => process.exit(0));
+                setTimeout(() => process.exit(0), 2000);
+            } else {
+                // HIGH/CRITICAL: fallback al prompt local (comportamiento original)
+                try {
+                    await telegramPost("editMessageText", {
+                        chat_id: CHAT_ID,
+                        message_id: currentMsgId,
+                        text: msgText + "\n\n⏱ <i>Expirado (" + totalAttempts + " intentos, " + elapsedTotal + "s) — respondiendo en consola</i>"
+                            + "\n📝 Responder <b>siempre</b> para guardar el permiso",
+                        parse_mode: "HTML",
+                        reply_markup: { inline_keyboard: [] }
+                    }, ANSWER_TIMEOUT);
+                } catch(e) { log("Error editando mensaje final: " + e.message); }
+                process.exit(0); // fallback al prompt local
+            }
             return;
         }
 

--- a/.claude/hooks/permission-gate.js
+++ b/.claude/hooks/permission-gate.js
@@ -17,7 +17,7 @@ const crypto = require("crypto");
 const fs = require("fs");
 const path = require("path");
 
-const { generatePattern, generateBashPattern, getSettingsPaths, persistPattern, resolveMainRepoRoot, isAlreadyCovered, splitCompoundCommand, classifySeverity, loadSeverityTimeouts, Severity } = require("./permission-utils");
+const { generatePattern, generateBashPattern, getSettingsPaths, persistPattern, resolveMainRepoRoot, isAlreadyCovered, splitCompoundCommand, classifySeverity, loadSeverityTimeouts, Severity, AUTO_APPROVE_ON_TIMEOUT } = require("./permission-utils");
 const { addPendingQuestion, resolveQuestion, getQuestionById, updateQuestionField } = require("./pending-questions");
 const { incrementApproval, isPatternPersisted } = require("./approval-history");
 const { readSessionContext } = require("./context-reader");
@@ -552,18 +552,34 @@ async function processInput() {
         const elapsedTotal = Math.round((Date.now() - startTime) / 1000);
 
         if (isLastAttempt) {
-            log("Todos los reintentos agotados (" + elapsedTotal + "s total). Fallback a consola.");
             resolveQuestion(requestId, "expired", null);
-            try {
-                await telegramPost("editMessageText", {
-                    chat_id: CHAT_ID,
-                    message_id: currentMsgId,
-                    text: msgText + "\n\n\u23F1 <i>Expirado (" + totalAttempts + " intentos) \u2014 respondiendo en consola</i>",
-                    parse_mode: "HTML",
-                    reply_markup: { inline_keyboard: [] }
-                }, ANSWER_TIMEOUT);
-            } catch(e) { log("Error editando mensaje final: " + e.message); }
-            exitSilent(); // fallback a dialogo local
+            if (AUTO_APPROVE_ON_TIMEOUT.includes(severity)) {
+                // Auto-aprobación por timeout completo sin rechazo explícito (Low/Medium)
+                log("AUTO_APPROVE_TIMEOUT: severity=" + severity + " tool=" + toolName + " attempts=" + totalAttempts);
+                try {
+                    await telegramPost("editMessageText", {
+                        chat_id: CHAT_ID,
+                        message_id: currentMsgId,
+                        text: msgText + "\n\n\u2705 <i>Auto-aprobado (todos los reintentos expirados sin rechazo)</i>",
+                        parse_mode: "HTML",
+                        reply_markup: { inline_keyboard: [] }
+                    }, ANSWER_TIMEOUT);
+                } catch(e) { log("Error editando mensaje de auto-aprobación: " + e.message); }
+                outputAllow("auto: timeout completo sin rechazo explícito — Low/Medium");
+            } else {
+                // HIGH/CRITICAL: fallback a diálogo local (comportamiento original)
+                log("Todos los reintentos agotados (" + elapsedTotal + "s total). Fallback a consola.");
+                try {
+                    await telegramPost("editMessageText", {
+                        chat_id: CHAT_ID,
+                        message_id: currentMsgId,
+                        text: msgText + "\n\n\u23F1 <i>Expirado (" + totalAttempts + " intentos) \u2014 respondiendo en consola</i>",
+                        parse_mode: "HTML",
+                        reply_markup: { inline_keyboard: [] }
+                    }, ANSWER_TIMEOUT);
+                } catch(e) { log("Error editando mensaje final: " + e.message); }
+                exitSilent(); // fallback a dialogo local
+            }
             return;
         }
 

--- a/.claude/hooks/permission-utils.js
+++ b/.claude/hooks/permission-utils.js
@@ -647,6 +647,13 @@ function classifySeverity(toolName, toolInput, repoRoot) {
     return Severity.MEDIUM;
 }
 
+/**
+ * Severidades que califican para auto-aprobación cuando el último reintento expira
+ * sin rechazo explícito del usuario. HIGH y CRITICAL siguen requiriendo respuesta.
+ * Centraliza la decisión para facilitar configuración futura.
+ */
+const AUTO_APPROVE_ON_TIMEOUT = [Severity.LOW, Severity.MEDIUM];
+
 module.exports = {
     resolveMainRepoRoot,
     getSettingsPaths,
@@ -664,5 +671,6 @@ module.exports = {
     loadAutoAllowTools,
     loadSeverityTimeouts,
     Severity,
-    DESTRUCTIVE_PATTERNS
+    DESTRUCTIVE_PATTERNS,
+    AUTO_APPROVE_ON_TIMEOUT
 };


### PR DESCRIPTION
## Resumen

Implementa auto-aprobación automática para permisos de severidad **Low** y **Medium** cuando todos los reintentos expiran sin rechazo explícito del usuario.

**Comportamiento**:
- Los agentes NO quedan bloqueados esperando respuesta en acciones no destructivas
- Rechazo explícito (❌ en Telegram) siempre prevalece
- HIGH/CRITICAL mantienen comportamiento actual (fallback a consola)
- Auto-aprobación ocurre **SOLO después del último reintento**

## Cambios técnicos

- ✨ `permission-utils.js`: Constante exportada `AUTO_APPROVE_ON_TIMEOUT = [Severity.LOW, Severity.MEDIUM]`
- ✨ `permission-gate.js` (PreToolUse): Auto-aprobar en `isLastAttempt` si severidad aplica
- ✨ `permission-approver.js` (PermissionRequest): Auto-aprobar si severidad aplica
- 📝 Ambos hooks emiten respuesta apropiada (`outputAllow` / `hookSpecificOutput.decision.allow`)
- 💬 Telegram: "✅ Auto-aprobado (reintentos agotados — sin rechazo)" en lugar de "respondiendo en consola"
- 📊 Logging: `AUTO_APPROVE_TIMEOUT: severity=X tool=Y attempts=N` para auditoría

## Plan de tests

- ✅ Tests de hooks pasan (176/176)
- ✅ Build backend/users exitoso
- ✅ Análisis de seguridad: APROBADO (A01-A10)
- ✅ Sin secrets hardcodeados
- ✅ Rechazo explícito respetado antes del timeout

Closes #1243

🤖 Generado con [Claude Code](https://claude.ai/claude-code)