### PR TITLE
feat(ux): validación inline de email en PasswordRecoveryScreen

### DIFF
--- a/app/composeApp/src/commonMain/kotlin/ui/sc/auth/PasswordRecoveryScreen.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/auth/PasswordRecoveryScreen.kt
@@ -114,7 +114,7 @@ class PasswordRecoveryScreen : Screen(PASSWORD_RECOVERY_PATH) {
                             label = MessageKey.email,
                             value = viewModel.state.email,
                             state = viewModel.inputsStates[PasswordRecoveryViewModel.PasswordRecoveryUIState::email.name]!!,
-                            onValueChange = { viewModel.state = viewModel.state.copy(email = it) },
+                            onValueChange = viewModel::onEmailChange,
                             modifier = Modifier.fillMaxWidth(),
                             leadingIcon = {
                                 Icon(

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/auth/PasswordRecoveryViewModel.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/auth/PasswordRecoveryViewModel.kt
@@ -14,6 +14,7 @@ import org.kodein.di.direct
 import org.kodein.di.instance
 import org.kodein.log.LoggerFactory
 import org.kodein.log.newLogger
+import ui.cp.inputs.InputState
 import ui.sc.shared.ViewModel
 
 class PasswordRecoveryViewModel(
@@ -44,6 +45,26 @@ class PasswordRecoveryViewModel(
 
     override fun initInputState() {
         inputsStates = mutableMapOf(entry(PasswordRecoveryUIState::email.name))
+    }
+
+    fun onEmailChange(value: String) {
+        state = state.copy(email = value)
+        validateCurrentState()
+    }
+
+    private fun validateCurrentState() {
+        inputsStates.forEach { (_, inputState) ->
+            inputState.value = inputState.value.copy(isValid = true, details = "")
+        }
+        val result = validation(state)
+        result.errors.forEach { error ->
+            val key = error.dataPath.substring(1)
+            val mutableState = inputsStates.getOrPut(key) { mutableStateOf(InputState(key)) }
+            mutableState.value = mutableState.value.copy(
+                isValid = false,
+                details = error.message
+            )
+        }
     }
 
     suspend fun recovery(): Result<DoPasswordRecoveryResult> {


### PR DESCRIPTION
## Resumen

Agrega validación en tiempo real del campo email en `PasswordRecoveryScreen`, mejorando la consistencia con `LoginScreen` y la experiencia del usuario.

## Cambios
- Agregar método `onEmailChange(value: String)` en `PasswordRecoveryViewModel` que:
  - Actualiza el estado del email
  - Valida inline con regex Konform (`.+@.+\..+`)
  - Muestra errores de validación bajo el campo inmediatamente
- Actualizar `PasswordRecoveryScreen` para usar `viewModel::onEmailChange` en el TextField
- Validación sigue el mismo patrón que `LoginViewModel`

## Consistencia UX
- Heurística #4 (Consistencia y estándares) — validación inline igual que Login
- Heurística #5 (Prevención de errores) — feedback inmediato al usuario

## Tests
- Backend tests: ✅ PASSED
- String verification: ✅ PASSED (sin legacy strings)
- Build dry-run: ✅ SUCCESSFUL
- Security scan: ✅ APROBADO (cambios defensivos, sin nuevas vulnerabilidades)

## Plan de tests
- [ ] Tests unitarios pasan
- [ ] Build completo sin errores

Closes #1146

🤖 Generado con [Claude Code](https://claude.com/claude-code)