### PR TITLE
feat: automatizar tagging de Git para sprints y releases

### DIFF
--- a/docs/sprint-tagging.md
+++ b/docs/sprint-tagging.md
@@ -1,0 +1,153 @@
+# Sprint Tagging y Releases Automáticas
+
+> Convenciones de tags Git y sistema de releases automáticas para Intrale Platform.
+
+## Convención de tags
+
+| Tipo | Formato | Ejemplo | Cuándo |
+|------|---------|---------|--------|
+| Sprint | `sprint/YYYY-MM-DD` | `sprint/2026-03-14` | Siempre al cerrar un sprint |
+| Release | `v*.*.*` (semver) | `v1.6.0` | Cuando el agente decide que hay masa crítica |
+
+## Flujo automático
+
+Al cerrar un sprint, `sprint-report.js` encadena automáticamente:
+
+```
+sprint-report.js
+    ↓
+sprint-tagger.js     ← Tag sprint/YYYY-MM-DD (SIEMPRE)
+    ↓
+evaluate-and-release.js  ← Evalúa autónomamente si crear release
+    ↓
+Telegram (informativo)
+```
+
+El proceso es **completamente automático** — no hay aprobación manual ni sugerencias. El agente decide y ejecuta.
+
+## Tags de sprint
+
+### Creación
+
+```bash
+# Se crea automáticamente via sprint-report.js
+# No se ejecuta manualmente en operación normal
+node scripts/sprint-tagger.js scripts/sprint-plan.json
+```
+
+### Formato del mensaje del tag
+
+```
+Sprint 2026-03-14 — cierre
+
+Issues cerrados: #1258, #1257, #1259, #1260
+
+## Features (2)
+- #1258: pipeline: agregar /qa E2E
+- #1254: Selección de tipografías por componente
+
+## Infrastructure (2)
+- #1264: timeout y cancelación automática de agentes
+- #1262: docs: agregar /qa como gate obligatorio
+```
+
+### Consultar historial de sprint tags
+
+```bash
+# Listar todos los sprint tags (más reciente primero)
+git tag -l 'sprint/*' --sort=-v:refname
+
+# Ver mensaje de un tag específico
+git show sprint/2026-03-14
+```
+
+## Releases automáticas
+
+### Criterios de decisión (heurística del agente)
+
+El agente evalúa los commits desde la última `v*.*.*` y aplica estas reglas:
+
+| Condición | Tipo de release |
+|-----------|----------------|
+| 1+ breaking change en commits | `major` (vX.0.0) |
+| 3+ features de producto (`feat:` commits) | `minor` (v0.X.0) |
+| 5+ bugfixes acumulados (`fix:` commits) | `patch` (v0.0.X) |
+| Solo infra/docs/refactor | **Sin release** |
+| Menos de los mínimos | **Sin release** |
+
+Los criterios están basados en [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `feat!:` para breaking).
+
+### Historial de releases
+
+```bash
+# Listar todas las releases (más reciente primero)
+git tag -l 'v*' --sort=-v:refname
+
+# Ver changelog de una release
+git show v1.6.0
+
+# Ver cambios entre dos releases
+git log v1.5.0..v1.6.0 --oneline
+```
+
+### Release history JSON
+
+El archivo `.release-history.json` en la raíz del repo mantiene un registro de todas las releases creadas automáticamente:
+
+```json
+{
+  "releases": [
+    {
+      "version": "v1.6.0",
+      "date": "2026-03-14",
+      "sprint": "SPR-001",
+      "sprintTag": "sprint/2026-03-14",
+      "type": "minor",
+      "reason": "4 features de producto (mínimo 3 para release minor)",
+      "commitsCount": 47,
+      "lastRelease": "v1.5.0",
+      "createdAt": "2026-03-14T18:30:00.000Z"
+    }
+  ]
+}
+```
+
+## Rollback de tags
+
+Si un tag fue creado por error:
+
+```bash
+# Eliminar tag local
+git tag -d sprint/2026-03-14
+git tag -d v1.6.0
+
+# Eliminar tag remoto (CUIDADO: irreversible para otros que ya lo tengan)
+git push origin --delete sprint/2026-03-14
+git push origin --delete v1.6.0
+```
+
+> **Advertencia**: eliminar tags remotos afecta a todos los clones que ya los descargaron. Coordinar con el equipo antes de hacerlo.
+
+## Scripts involucrados
+
+| Script | Descripción |
+|--------|-------------|
+| `scripts/sprint-tagger.js` | Crea el tag `sprint/YYYY-MM-DD` con issues categorizados |
+| `scripts/evaluate-and-release.js` | Evalúa heurística y crea release si corresponde |
+| `scripts/sprint-report.js` | Orquestador — encadena ambos al final del reporte |
+
+## Logs
+
+Los logs de ejecución se guardan en:
+- `scripts/logs/sprint-tagger.log`
+- `scripts/logs/evaluate-release.log`
+
+## Notificaciones Telegram
+
+El sistema envía notificaciones **informativas** (no consultivas):
+
+- **Sprint tag creado**: lista de issues y link al tag
+- **Release creada**: versión, tipo, razón, commits
+- **Sin release**: razón breve en 1-2 líneas
+
+Las notificaciones no tienen botones de acción — el agente ya tomó la decisión.

--- a/scripts/evaluate-and-release.js
+++ b/scripts/evaluate-and-release.js
@@ -1,0 +1,408 @@
+#!/usr/bin/env node
+// evaluate-and-release.js — Evalúa autónomamente si corresponde crear una release
+// El agente decide y ejecuta sin pedir aprobación.
+// Uso: node scripts/evaluate-and-release.js [path-to-sprint-plan.json]
+// Fail-open: errores no fatales quedan en logs sin interrumpir el flujo.
+
+const fs = require("fs");
+const path = require("path");
+const https = require("https");
+const { execSync } = require("child_process");
+
+const REPO_ROOT = path.resolve(__dirname, "..");
+const GH_PATH = "C:\\Workspaces\\gh-cli\\bin\\gh.exe";
+const LOG_DIR = path.join(__dirname, "logs");
+const LOG_FILE = path.join(LOG_DIR, "evaluate-release.log");
+const RELEASE_HISTORY_FILE = path.join(REPO_ROOT, ".release-history.json");
+
+// --- Logging ---
+function ensureDir(dir) {
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+}
+
+function log(msg) {
+    ensureDir(LOG_DIR);
+    const ts = new Date().toISOString();
+    try { fs.appendFileSync(LOG_FILE, `[${ts}] ${msg}\n`); } catch (e) { /* ignore */ }
+    console.log(`[evaluate-release] ${msg}`);
+}
+
+function execSafe(cmd, opts = {}) {
+    try {
+        return execSync(cmd, { encoding: "utf8", timeout: 30000, ...opts }).trim();
+    } catch (e) {
+        log(`execSafe failed: ${cmd.substring(0, 120)} → ${e.message}`);
+        return null;
+    }
+}
+
+// --- Telegram ---
+function sendTelegram(message) {
+    try {
+        const cfgPath = path.join(REPO_ROOT, ".claude", "hooks", "telegram-config.json");
+        if (!fs.existsSync(cfgPath)) { log("telegram-config.json no encontrado — skip"); return; }
+        const cfg = JSON.parse(fs.readFileSync(cfgPath, "utf8"));
+        const postData = JSON.stringify({
+            chat_id: cfg.chat_id,
+            text: message,
+            parse_mode: "HTML",
+            disable_notification: false
+        });
+        const req = https.request({
+            hostname: "api.telegram.org",
+            path: "/bot" + cfg.bot_token + "/sendMessage",
+            method: "POST",
+            headers: { "Content-Type": "application/json", "Content-Length": Buffer.byteLength(postData) },
+            timeout: 10000
+        }, (res) => {
+            let d = "";
+            res.on("data", (c) => d += c);
+            res.on("end", () => log("Telegram response: " + d.substring(0, 100)));
+        });
+        req.on("error", (e) => log("Telegram error: " + e.message));
+        req.write(postData);
+        req.end();
+    } catch (e) {
+        log("Error enviando Telegram: " + e.message);
+    }
+}
+
+// --- Semver ---
+function parseVersion(tag) {
+    const match = (tag || "").match(/^v?(\d+)\.(\d+)\.(\d+)/);
+    if (!match) return null;
+    return { major: parseInt(match[1]), minor: parseInt(match[2]), patch: parseInt(match[3]), raw: tag };
+}
+
+function bumpVersion(current, type) {
+    if (!current) {
+        // Sin releases previas: versión inicial
+        return type === "major" ? "v1.0.0" : type === "minor" ? "v0.1.0" : "v0.0.1";
+    }
+    const { major, minor, patch } = current;
+    if (type === "major") return `v${major + 1}.0.0`;
+    if (type === "minor") return `v${major}.${minor + 1}.0`;
+    return `v${major}.${minor}.${patch + 1}`;
+}
+
+// --- Obtener última release ---
+function getLastRelease() {
+    const raw = execSafe(`git tag -l 'v*' --sort=-v:refname`, { cwd: REPO_ROOT });
+    if (!raw) return null;
+    const tags = raw.split("\n").filter(t => t.trim() && /^v\d+\.\d+\.\d+/.test(t.trim()));
+    return tags.length > 0 ? parseVersion(tags[0]) : null;
+}
+
+// --- Obtener commits desde la última release ---
+function getCommitsSinceRelease(lastRelease) {
+    let rangeCmd;
+    if (!lastRelease) {
+        rangeCmd = `git log --oneline --no-decorate --max-count=200`;
+    } else {
+        rangeCmd = `git log ${lastRelease.raw}..HEAD --oneline --no-decorate --max-count=200`;
+    }
+    const raw = execSafe(rangeCmd, { cwd: REPO_ROOT });
+    if (!raw) return [];
+    return raw.split("\n").filter(Boolean).map(line => {
+        const [hash, ...rest] = line.split(" ");
+        return { hash: hash.trim(), message: rest.join(" ").trim() };
+    });
+}
+
+// --- Obtener sprint tags desde la última release ---
+function getSprintTagsSinceRelease(lastRelease) {
+    let rangeCmd;
+    if (!lastRelease) {
+        rangeCmd = `git tag -l 'sprint/*' --sort=-v:refname`;
+    } else {
+        rangeCmd = `git log ${lastRelease.raw}..HEAD --decorate --simplify-by-decoration --oneline --no-walk=sorted`;
+    }
+    const tagsRaw = execSafe(`git tag -l 'sprint/*' --sort=v:refname`, { cwd: REPO_ROOT }) || "";
+    return tagsRaw.split("\n").filter(Boolean);
+}
+
+// --- Categorizar commit por mensaje convencional ---
+function categorizeCommit(message) {
+    const lower = message.toLowerCase();
+    if (/^feat(\(.+?\))?!?:/.test(lower) || /breaking change/i.test(lower)) return "breaking";
+    if (/^feat(\(.+?\))?:/.test(lower)) return "feature";
+    if (/^fix(\(.+?\))?:/.test(lower)) return "fix";
+    if (/^docs?(\(.+?\))?:/.test(lower)) return "docs";
+    if (/^refactor(\(.+?\))?:/.test(lower)) return "refactor";
+    if (/^(chore|infra|ci|build|style|test)(\(.+?\))?:/.test(lower)) return "infra";
+    if (/^perf(\(.+?\))?:/.test(lower)) return "perf";
+    return "other";
+}
+
+// --- Heurística de decisión de release ---
+/**
+ * Evalúa si corresponde crear una release y qué tipo.
+ * Retorna: { shouldRelease: bool, type: 'major'|'minor'|'patch'|null, reason: string }
+ */
+function evaluateRelease(commits) {
+    const categories = { breaking: [], feature: [], fix: [], perf: [], docs: [], refactor: [], infra: [], other: [] };
+
+    for (const c of commits) {
+        const cat = categorizeCommit(c.message);
+        categories[cat].push(c);
+    }
+
+    log(`Categorías de commits: ${JSON.stringify(Object.fromEntries(
+        Object.entries(categories).map(([k, v]) => [k, v.length])
+    ))}`);
+
+    // Breaking changes → release major
+    if (categories.breaking.length > 0) {
+        return {
+            shouldRelease: true,
+            type: "major",
+            reason: `${categories.breaking.length} breaking change(s) detectados`,
+            categories
+        };
+    }
+
+    // 3+ features de producto → release minor
+    const productFeatures = categories.feature.length + categories.perf.length;
+    if (productFeatures >= 3) {
+        return {
+            shouldRelease: true,
+            type: "minor",
+            reason: `${productFeatures} features de producto (mínimo 3 para release minor)`,
+            categories
+        };
+    }
+
+    // 5+ fixes acumulados → release patch
+    if (categories.fix.length >= 5) {
+        return {
+            shouldRelease: true,
+            type: "patch",
+            reason: `${categories.fix.length} fixes acumulados (mínimo 5 para release patch)`,
+            categories
+        };
+    }
+
+    // Solo infra/docs/refactor → no release
+    const nonReleaseOnly = categories.infra.length + categories.docs.length + categories.refactor.length + categories.other.length;
+    const releaseRelevant = productFeatures + categories.fix.length;
+    if (nonReleaseOnly > 0 && releaseRelevant === 0) {
+        return {
+            shouldRelease: false,
+            type: null,
+            reason: `Solo cambios de infra/docs/refactor (${nonReleaseOnly} commits) — sin impacto en producto`,
+            categories
+        };
+    }
+
+    // Insuficiente masa crítica
+    return {
+        shouldRelease: false,
+        type: null,
+        reason: `Masa insuficiente: ${categories.feature.length} features (necesita 3+), ${categories.fix.length} fixes (necesita 5+)`,
+        categories
+    };
+}
+
+// --- Construir changelog ---
+function buildChangelog(commits, lastRelease, categories) {
+    const lines = [];
+    const currentDate = new Date().toISOString().split("T")[0];
+    lines.push(`Changelog — generado automáticamente el ${currentDate}`);
+    lines.push("");
+    if (lastRelease) {
+        lines.push(`Cambios desde ${lastRelease.raw}:`);
+    } else {
+        lines.push("Cambios iniciales del proyecto:");
+    }
+    lines.push("");
+
+    const ORDER = [
+        ["breaking", "Breaking Changes"],
+        ["feature", "Features"],
+        ["fix", "Fixes"],
+        ["perf", "Mejoras de rendimiento"],
+        ["docs", "Documentación"],
+        ["refactor", "Refactoring"],
+        ["infra", "Infraestructura"],
+    ];
+
+    for (const [cat, label] of ORDER) {
+        const items = (categories[cat] || []).filter(c => c.message);
+        if (items.length === 0) continue;
+        lines.push(`## ${label} (${items.length})`);
+        for (const c of items.slice(0, 30)) {
+            lines.push(`- ${c.message.substring(0, 120)}`);
+        }
+        if (items.length > 30) lines.push(`- ... y ${items.length - 30} más`);
+        lines.push("");
+    }
+
+    lines.push(`Total commits: ${commits.length}`);
+
+    return lines.join("\n").trim();
+}
+
+// --- Leer/escribir release history ---
+function loadReleaseHistory() {
+    try {
+        if (fs.existsSync(RELEASE_HISTORY_FILE)) {
+            return JSON.parse(fs.readFileSync(RELEASE_HISTORY_FILE, "utf8"));
+        }
+    } catch (e) { /* ignore */ }
+    return { releases: [] };
+}
+
+function saveReleaseHistory(history) {
+    try {
+        fs.writeFileSync(RELEASE_HISTORY_FILE, JSON.stringify(history, null, 2), "utf8");
+    } catch (e) { log("Error guardando release-history: " + e.message); }
+}
+
+// --- Main ---
+async function main() {
+    log("=== evaluate-and-release.js iniciado ===");
+
+    // SEGURIDAD: Solo ejecutar desde main branch
+    const currentBranch = execSafe(`git branch --show-current`, { cwd: REPO_ROOT });
+    if (currentBranch !== "main") {
+        log(`SEGURIDAD: Ejecutado desde rama '${currentBranch}' — abortando. Las releases solo se crean desde 'main'.`);
+        console.log(`Releases can only be created from 'main' branch, not '${currentBranch}'.`);
+        process.exit(0);
+    }
+
+    // Leer sprint plan (para contexto)
+    const planPath = process.argv[2] || path.join(__dirname, "sprint-plan.json");
+    let plan = null;
+    try {
+        plan = JSON.parse(fs.readFileSync(planPath, "utf8"));
+    } catch (e) {
+        log(`Sprint plan no disponible: ${e.message} — continuando sin él`);
+    }
+
+    const sprintDate = plan?.fechaFin || plan?.fecha || new Date().toISOString().split("T")[0];
+    const sprintId = plan?.sprint_id || null;
+    const sprintTag = `sprint/${sprintDate}`;
+
+    // Obtener última release
+    const lastRelease = getLastRelease();
+    log(`Última release: ${lastRelease ? lastRelease.raw : "ninguna (primera release)"}`);
+
+    // Obtener commits desde la última release
+    const commits = getCommitsSinceRelease(lastRelease);
+    log(`Commits desde última release: ${commits.length}`);
+
+    if (commits.length === 0) {
+        log("Sin commits nuevos desde la última release — no se crea release");
+        const msg = [
+            `ℹ️ <b>${sprintId || "Sprint"} ${sprintDate} cerrado</b>`,
+            `Sin release — 0 commits desde ${lastRelease ? lastRelease.raw : "el inicio"}.`
+        ].join("\n");
+        sendTelegram(msg);
+        return;
+    }
+
+    // Evaluar si corresponde release
+    const decision = evaluateRelease(commits);
+    log(`Decisión: shouldRelease=${decision.shouldRelease}, type=${decision.type}, reason=${decision.reason}`);
+
+    if (!decision.shouldRelease) {
+        log(`Sin release — ${decision.reason}`);
+        const msg = [
+            `ℹ️ <b>${sprintId || "Sprint"} ${sprintDate} cerrado.</b>`,
+            `Sin release — ${decision.reason}.`,
+            "",
+            `Sprint tag: <code>${sprintTag}</code>`,
+            lastRelease ? `Última release: <code>${lastRelease.raw}</code>` : "Sin releases previas."
+        ].join("\n");
+        sendTelegram(msg);
+        return;
+    }
+
+    // Determinar nueva versión
+    const newVersion = bumpVersion(lastRelease, decision.type);
+    log(`Nueva versión: ${newVersion} (tipo: ${decision.type})`);
+
+    // Verificar que el tag no exista
+    const tagExists = execSafe(`git tag -l "${newVersion}"`, { cwd: REPO_ROOT });
+    if (tagExists === newVersion) {
+        log(`Tag ${newVersion} ya existe — saltando`);
+        return;
+    }
+
+    // Construir changelog
+    const changelog = buildChangelog(commits, lastRelease, decision.categories);
+    log(`Changelog generado (${changelog.length} chars)`);
+
+    // Crear tag anotado
+    const tagMsgFile = path.join(LOG_DIR, `release-msg-${newVersion}.txt`);
+    ensureDir(LOG_DIR);
+    fs.writeFileSync(tagMsgFile, changelog, "utf8");
+
+    const tagResult = execSafe(
+        `git tag -a "${newVersion}" -F "${tagMsgFile}"`,
+        { cwd: REPO_ROOT }
+    );
+
+    if (tagResult === null) {
+        log(`Error creando tag ${newVersion} — abortando release`);
+        try { fs.unlinkSync(tagMsgFile); } catch (e) { /* ignore */ }
+        return;
+    }
+
+    log(`Tag ${newVersion} creado`);
+
+    // Push del tag
+    const pushResult = execSafe(`git push origin "${newVersion}"`, { cwd: REPO_ROOT });
+    if (pushResult === null) {
+        log(`Error pusheando ${newVersion} — tag existe localmente solamente`);
+    } else {
+        log(`Tag ${newVersion} pusheado a origin`);
+    }
+
+    // Limpiar archivo temporal
+    try { fs.unlinkSync(tagMsgFile); } catch (e) { /* ignore */ }
+
+    // Guardar en release history
+    const history = loadReleaseHistory();
+    history.releases.push({
+        version: newVersion,
+        date: sprintDate,
+        sprint: sprintId,
+        sprintTag,
+        type: decision.type,
+        reason: decision.reason,
+        commitsCount: commits.length,
+        lastRelease: lastRelease ? lastRelease.raw : null,
+        createdAt: new Date().toISOString()
+    });
+    saveReleaseHistory(history);
+
+    // Notificación Telegram — informativa, no consultiva
+    const sprintTags = getSprintTagsSinceRelease(lastRelease);
+    const msg = [
+        `🏷️ <b>Release ${newVersion} creada automáticamente</b>`,
+        "",
+        `📋 Razón: ${decision.reason}`,
+        `📊 Commits: ${commits.length} | Tipo: ${decision.type.toUpperCase()}`,
+        "",
+        lastRelease ? `Cambios desde: <code>${lastRelease.raw}</code>` : "Primera release del proyecto",
+        sprintTags.length > 0 ? `Sprint tags incluidos: ${sprintTags.slice(-3).join(", ")}` : "",
+        "",
+        `<b>Categorías:</b>`,
+        decision.categories.breaking.length > 0 ? `  ⚠️ Breaking: ${decision.categories.breaking.length}` : null,
+        decision.categories.feature.length > 0 ? `  ✨ Features: ${decision.categories.feature.length}` : null,
+        decision.categories.fix.length > 0 ? `  🐛 Fixes: ${decision.categories.fix.length}` : null,
+        decision.categories.infra.length > 0 ? `  🔧 Infra: ${decision.categories.infra.length}` : null,
+        "",
+        `<code>git tag -l 'v*' --sort=-v:refname</code>`
+    ].filter(l => l !== null).join("\n");
+
+    sendTelegram(msg);
+    log(`Notificación Telegram enviada — release ${newVersion}`);
+    log("=== evaluate-and-release.js completado ===");
+}
+
+main().catch(e => {
+    log("ERROR FATAL: " + e.message + "\n" + e.stack);
+    process.exit(0); // fail-open
+});

--- a/scripts/sprint-report.js
+++ b/scripts/sprint-report.js
@@ -763,6 +763,16 @@ async function main() {
     const caption = `📋 ${sprintIdLabel}Sprint ${fecha} — ${plan.agentes.length} issues, ${mergedCount} PRs merged`;
     sendReportViaTelegram(htmlPath, caption);
 
+    // Paso 1: Tag de sprint (siempre, sin condiciones)
+    log("--- Iniciando sprint-tagger.js ---");
+    execSafe(`node "${path.join(__dirname, "sprint-tagger.js")}" "${planPath}"`, { timeout: 60000 });
+    log("--- sprint-tagger.js completado ---");
+
+    // Paso 2: Evaluar y crear release (autónomo)
+    log("--- Iniciando evaluate-and-release.js ---");
+    execSafe(`node "${path.join(__dirname, "evaluate-and-release.js")}" "${planPath}"`, { timeout: 60000 });
+    log("--- evaluate-and-release.js completado ---");
+
     const elapsed = Math.round((Date.now() - startTime) / 1000);
     log(`=== sprint-report.js completado en ${elapsed}s ===`);
 }

--- a/scripts/sprint-tagger.js
+++ b/scripts/sprint-tagger.js
@@ -1,0 +1,254 @@
+#!/usr/bin/env node
+// sprint-tagger.js — Crea tag Git anotado al cerrar un sprint
+// Uso: node scripts/sprint-tagger.js [path-to-sprint-plan.json]
+// Comportamiento: SIEMPRE crea el tag sprint/YYYY-MM-DD — sin condiciones.
+// Fail-open: errores no fatales quedan en logs sin interrumpir el flujo.
+
+const fs = require("fs");
+const path = require("path");
+const https = require("https");
+const { execSync } = require("child_process");
+
+const REPO_ROOT = path.resolve(__dirname, "..");
+const GH_PATH = "C:\\Workspaces\\gh-cli\\bin\\gh.exe";
+const LOG_DIR = path.join(__dirname, "logs");
+const LOG_FILE = path.join(LOG_DIR, "sprint-tagger.log");
+
+// --- Logging ---
+function ensureDir(dir) {
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+}
+
+function log(msg) {
+    ensureDir(LOG_DIR);
+    const ts = new Date().toISOString();
+    try { fs.appendFileSync(LOG_FILE, `[${ts}] ${msg}\n`); } catch (e) { /* ignore */ }
+    console.log(`[sprint-tagger] ${msg}`);
+}
+
+function execSafe(cmd, opts = {}) {
+    try {
+        return execSync(cmd, { encoding: "utf8", timeout: 30000, ...opts }).trim();
+    } catch (e) {
+        log(`execSafe failed: ${cmd.substring(0, 120)} → ${e.message}`);
+        return null;
+    }
+}
+
+// --- Telegram ---
+function sendTelegram(message) {
+    try {
+        const cfgPath = path.join(REPO_ROOT, ".claude", "hooks", "telegram-config.json");
+        if (!fs.existsSync(cfgPath)) { log("telegram-config.json no encontrado — skip notificación"); return; }
+        const cfg = JSON.parse(fs.readFileSync(cfgPath, "utf8"));
+        const postData = JSON.stringify({
+            chat_id: cfg.chat_id,
+            text: message,
+            parse_mode: "HTML",
+            disable_notification: false
+        });
+        const req = https.request({
+            hostname: "api.telegram.org",
+            path: "/bot" + cfg.bot_token + "/sendMessage",
+            method: "POST",
+            headers: { "Content-Type": "application/json", "Content-Length": Buffer.byteLength(postData) },
+            timeout: 10000
+        }, (res) => {
+            let d = "";
+            res.on("data", (c) => d += c);
+            res.on("end", () => log("Telegram response: " + d.substring(0, 100)));
+        });
+        req.on("error", (e) => log("Telegram error: " + e.message));
+        req.write(postData);
+        req.end();
+    } catch (e) {
+        log("Error enviando Telegram: " + e.message);
+    }
+}
+
+// --- GitHub: obtener info de issues ---
+function getIssueDetails(issueNumber) {
+    const raw = execSafe(
+        `"${GH_PATH}" issue view ${issueNumber} --repo intrale/platform --json title,labels,state`
+    );
+    if (!raw) return { title: `Issue #${issueNumber}`, labels: [], state: "UNKNOWN" };
+    try { return JSON.parse(raw); } catch (e) { return { title: `Issue #${issueNumber}`, labels: [], state: "UNKNOWN" }; }
+}
+
+// --- Categorizar issues por labels ---
+function categorizeIssue(labels) {
+    const names = (labels || []).map(l => (l.name || "").toLowerCase());
+    if (names.some(n => n.includes("bug") || n.includes("fix"))) return "fix";
+    if (names.some(n => n.includes("feat") || n.includes("feature") || n.includes("enhancement"))) return "feature";
+    if (names.some(n => n.includes("infra") || n.includes("tipo:infra") || n.includes("area:infra"))) return "infra";
+    if (names.some(n => n.includes("doc"))) return "docs";
+    if (names.some(n => n.includes("refactor"))) return "refactor";
+    return "other";
+}
+
+function categoryLabel(cat) {
+    const map = {
+        feature: "Features",
+        fix: "Fixes",
+        infra: "Infrastructure",
+        docs: "Documentation",
+        refactor: "Refactoring",
+        other: "Otros"
+    };
+    return map[cat] || cat;
+}
+
+// --- Construir mensaje del tag ---
+function buildTagMessage(sprintDate, issues) {
+    const grouped = {};
+    for (const iss of issues) {
+        const cat = categorizeIssue(iss.labels);
+        if (!grouped[cat]) grouped[cat] = [];
+        grouped[cat].push(iss);
+    }
+
+    const ORDER = ["feature", "fix", "infra", "docs", "refactor", "other"];
+    const lines = [];
+    lines.push(`Sprint ${sprintDate} — cierre`);
+    lines.push("");
+
+    const issueNums = issues.map(i => `#${i.number}`).join(", ");
+    lines.push(`Issues cerrados: ${issueNums || "ninguno"}`);
+    lines.push("");
+
+    for (const cat of ORDER) {
+        if (!grouped[cat] || grouped[cat].length === 0) continue;
+        lines.push(`## ${categoryLabel(cat)} (${grouped[cat].length})`);
+        for (const iss of grouped[cat]) {
+            lines.push(`- #${iss.number}: ${iss.title}`);
+        }
+        lines.push("");
+    }
+
+    return lines.join("\n").trim();
+}
+
+// --- Verificar si el tag ya existe ---
+function tagExists(tagName) {
+    const result = execSafe(`git tag -l "${tagName}"`, { cwd: REPO_ROOT });
+    return result !== null && result.trim() === tagName;
+}
+
+// --- Main ---
+async function main() {
+    log("=== sprint-tagger.js iniciado ===");
+
+    // SEGURIDAD: Solo ejecutar desde main branch (tags de sprint se crean solo en main)
+    const currentBranch = execSafe(`git branch --show-current`, { cwd: REPO_ROOT });
+    if (currentBranch !== "main") {
+        log(`SEGURIDAD: Ejecutado desde rama '${currentBranch}' — abortando. Tags de sprint solo se crean desde 'main'.`);
+        console.log(`Sprint tags can only be created from 'main' branch, not '${currentBranch}'.`);
+        process.exit(0);
+    }
+
+    // Leer sprint plan
+    const planPath = process.argv[2] || path.join(__dirname, "sprint-plan.json");
+    let plan;
+    try {
+        plan = JSON.parse(fs.readFileSync(planPath, "utf8"));
+    } catch (e) {
+        log(`Error leyendo sprint plan: ${e.message} — abortando`);
+        process.exit(0); // fail-open
+    }
+
+    if (!plan) {
+        log("Plan nulo — abortando");
+        process.exit(0);
+    }
+
+    // Fecha de cierre del sprint
+    const sprintDate = plan.fechaFin || plan.fecha || new Date().toISOString().split("T")[0];
+    const tagName = `sprint/${sprintDate}`;
+    const sprintId = plan.sprint_id || null;
+
+    log(`Sprint: ${sprintId || "sin ID"}, fecha cierre: ${sprintDate}, tag: ${tagName}`);
+
+    // Verificar si el tag ya existe
+    if (tagExists(tagName)) {
+        log(`Tag ${tagName} ya existe — saltando creación`);
+        console.log(`Tag ${tagName} ya existe.`);
+        return;
+    }
+
+    // Obtener issues cerrados (agentes + _completed del sprint actual, no sprint_prev)
+    const allAgentes = [
+        ...(plan.agentes || []),
+        ...((plan._completed || []).filter(a => !a.sprint_prev))
+    ];
+
+    log(`Recopilando info de ${allAgentes.length} issues...`);
+
+    const issues = [];
+    for (const ag of allAgentes) {
+        const info = getIssueDetails(ag.issue);
+        issues.push({
+            number: ag.issue,
+            title: info.title || ag.titulo || `Issue #${ag.issue}`,
+            labels: info.labels || [],
+            state: info.state
+        });
+    }
+
+    // Construir mensaje del tag
+    const tagMessage = buildTagMessage(sprintDate, issues);
+    log(`Mensaje del tag:\n${tagMessage}`);
+
+    // Crear tag anotado
+    const tagMsgFile = path.join(LOG_DIR, `tag-msg-${sprintDate}.txt`);
+    ensureDir(LOG_DIR);
+    fs.writeFileSync(tagMsgFile, tagMessage, "utf8");
+
+    const tagResult = execSafe(
+        `git tag -a "${tagName}" -F "${tagMsgFile}"`,
+        { cwd: REPO_ROOT }
+    );
+
+    if (tagResult === null) {
+        log(`Error creando tag ${tagName}`);
+        // No hacer exit 1 — fail-open para no interrumpir sprint-report
+        return;
+    }
+
+    log(`Tag ${tagName} creado exitosamente`);
+
+    // Push del tag a origin
+    const pushResult = execSafe(`git push origin "${tagName}"`, { cwd: REPO_ROOT });
+    if (pushResult === null) {
+        log(`Error pusheando tag ${tagName} — tag existe localmente`);
+    } else {
+        log(`Tag ${tagName} pusheado a origin`);
+    }
+
+    // Limpiar archivo temporal
+    try { fs.unlinkSync(tagMsgFile); } catch (e) { /* ignore */ }
+
+    // Notificación Telegram — informativa, no consultiva
+    const closedCount = issues.filter(i => i.state === "CLOSED").length;
+    const sprintLabel = sprintId ? `${sprintId} — ` : "";
+    const telegram = [
+        `🏷️ <b>Sprint tag creado: <code>${tagName}</code></b>`,
+        "",
+        `📋 <b>${sprintLabel}Sprint ${sprintDate}</b>`,
+        `✅ Issues cerrados: ${closedCount}/${issues.length}`,
+        "",
+        issues.length > 0
+            ? `<b>Issues:</b> ${issues.slice(0, 8).map(i => `#${i.number}`).join(", ")}${issues.length > 8 ? ` y ${issues.length - 8} más` : ""}`
+            : "Sin issues registrados",
+        "",
+        `<code>git tag -l 'sprint/*' --sort=-v:refname</code> para consultar historial`
+    ].join("\n");
+
+    sendTelegram(telegram);
+    log("Notificación Telegram enviada");
+    log("=== sprint-tagger.js completado ===");
+}
+
+main().catch(e => {
+    log("ERROR FATAL: " + e.message + "\n" + e.stack);
+    process.exit(0); // fail-open
+});


### PR DESCRIPTION
## Resumen

Implementa un sistema completamente automático de versionamiento Git:

- **`scripts/sprint-tagger.js`**: Crea tags `sprint/YYYY-MM-DD` al cerrar cada sprint (SIEMPRE, sin condiciones)
- **`scripts/evaluate-and-release.js`**: El agente evalúa autónomamente si crear release `v*.*.*` basándose en masa crítica de features/fixes
- **Integración**: `sprint-report.js` encadena ambos scripts automáticamente al finalizar el reporte del sprint
- **Documentación**: `docs/sprint-tagging.md` define convenciones y criterios de decisión

## Heurística de releases (autónoma, sin intervención humana)

- **major** (v*.0.0) — 1+ breaking changes (`feat!:`)
- **minor** (v.*.0) — 3+ features de producto
- **patch** (v.*.*.*)  — 5+ bugfixes sin features
- **sin release** — solo infra/docs/refactor

## Seguridad

- ✅ Validación de rama: ambos scripts solo ejecutan desde `main` (previene releases accidentales desde feature branches)
- ✅ Fail-open: errores no fatales no interrumpen `sprint-report.js`
- ✅ Notificaciones informativas (no consultivas) → no hay botones de acción, el agente ya decidió

## Cambios

| Archivo | Tipo | Descripción |
|---------|------|-------------|
| `scripts/sprint-tagger.js` | Nuevo | Crea tag anotado con listado categorizado de issues |
| `scripts/evaluate-and-release.js` | Nuevo | Evalúa e implementa releases automáticamente |
| `scripts/sprint-report.js` | Modificado | Encadena ambos scripts al final (+10 líneas) |
| `docs/sprint-tagging.md` | Nuevo | Convenciones, criterios, consultas, rollback |

## Tests realizados

- ✅ Sintaxis válida de Node.js en ambos scripts
- ✅ Validación de seguridad: scripts rechazan ejecución desde non-main branches
- ✅ Build de Gradle no afectado
- ✅ Sin strings legacy

Closes #1265

🤖 Generado con [Claude Code](https://claude.com/claude-code)