### PR TITLE
feat(monitor): dividir heartbeat Telegram en screenshots por sección semántica

### DIFF
--- a/.claude/dashboard-server.js
+++ b/.claude/dashboard-server.js
@@ -1485,7 +1485,7 @@ function renderHTML(data, theme) {
     </div>
 
     <!-- Ejecución + Agents -->
-    <div class="grid-2col">
+    <div class="grid-2col" data-panel="exec">
       <div class="panel">
         <div class="panel-title">Ejecuci&oacute;n <span class="chip chip-green">${sprintProgress}% completado</span></div>
         <div class="tasks-progress-bar">
@@ -1500,7 +1500,7 @@ function renderHTML(data, theme) {
     </div>
 
     <!-- Flow Graph + Feed -->
-    <div class="grid-flow">
+    <div class="grid-flow" data-panel="sessions">
       <div class="panel">
         <div class="panel-title">Flujo de agentes <span class="chip chip-blue">${data.agentNodes.length} nodos</span></div>
         ${flowGraphHtml}
@@ -1512,7 +1512,7 @@ function renderHTML(data, theme) {
     </div>
 
     <!-- Métricas Claude + Tasks -->
-    <div class="grid-2equal">
+    <div class="grid-2equal" data-panel="metrics">
       <div class="panel">
         <div class="panel-title">Uso de agentes <span class="chip chip-purple">${totalSkillInvocations} inv.</span></div>
         ${metricsHtml}
@@ -1533,7 +1533,7 @@ function renderHTML(data, theme) {
     </div>
 
     <!-- CI -->
-    <div class="panel" style="margin-bottom:16px;">
+    <div class="panel" style="margin-bottom:16px;" data-panel="ci">
       <div class="panel-title">CI / CD</div>
       ${ciHtml}
     </div>
@@ -1700,6 +1700,15 @@ function handleRequest(req, res) {
       res.writeHead(500, { "Content-Type": "text/plain" });
       res.end("Screenshots error: " + err.message);
     });
+  } else if (pathname === "/screenshots/sections") {
+    const width = parseInt(url.searchParams.get("w")) || 390;
+    takeScreenshotSections(width).then(sections => {
+      res.writeHead(200, { "Content-Type": "application/json", "Cache-Control": "no-store" });
+      res.end(JSON.stringify(sections));
+    }).catch(err => {
+      res.writeHead(500, { "Content-Type": "text/plain" });
+      res.end("Sections screenshot error: " + err.message);
+    });
   } else if (pathname === "/health") {
     res.writeHead(200, { "Content-Type": "application/json" });
     res.end(JSON.stringify({ status: "ok", uptime: process.uptime(), port: PORT }));
@@ -1742,6 +1751,69 @@ async function takeScreenshot(width, height, options) {
     }
 
     return await page.screenshot({ type: "png", fullPage: true });
+  } finally {
+    await page.close();
+  }
+}
+
+// Captura cada sección semántica del dashboard usando getBoundingClientRect()
+// Retorna array de { id, image: "<base64>" } — omite paneles vacíos o inexistentes
+async function takeScreenshotSections(width) {
+  let puppeteer;
+  try { puppeteer = require("puppeteer"); } catch {
+    try { puppeteer = require(path.join(REPO_ROOT, "docs", "qa", "node_modules", "puppeteer")); }
+    catch { throw new Error("puppeteer not installed — run: cd docs/qa && npm install"); }
+  }
+
+  if (!puppeteerBrowser || !puppeteerBrowser.isConnected()) {
+    puppeteerBrowser = await puppeteer.launch({
+      headless: "new",
+      args: ["--no-sandbox", "--disable-setuid-sandbox", "--disable-gpu"],
+    });
+  }
+
+  const page = await puppeteerBrowser.newPage();
+  try {
+    // Viewport alto para que todos los paneles rendericen antes del scroll
+    await page.setViewport({ width, height: 2400 });
+    await page.goto("http://localhost:" + PORT + "/?theme=dark&nosse=1", { waitUntil: "domcontentloaded", timeout: 15000 });
+    await new Promise(r => setTimeout(r, 1000));
+
+    const sections = await page.evaluate(() => {
+      const selectors = [
+        { id: "kpis",      sel: ".kpi-row" },
+        { id: "ejecucion", sel: "[data-panel='exec']" },
+        { id: "sesiones",  sel: "[data-panel='sessions']" },
+        { id: "metricas",  sel: "[data-panel='metrics']" },
+        { id: "ci",        sel: "[data-panel='ci']" },
+      ];
+      return selectors.map(function(s) {
+        var el = document.querySelector(s.sel);
+        if (!el) return null;
+        var r = el.getBoundingClientRect();
+        // Ignorar paneles vacíos o sin altura visible
+        if (r.height < 20 || r.width < 20) return null;
+        return { id: s.id, x: Math.max(0, r.x), y: r.y + window.scrollY, width: r.width, height: r.height };
+      }).filter(Boolean);
+    });
+
+    const results = [];
+    for (const section of sections) {
+      const buf = await page.screenshot({
+        type: "png",
+        clip: {
+          x: section.x,
+          y: section.y,
+          width: section.width,
+          height: section.height,
+        },
+      });
+      // Solo incluir si la imagen tiene contenido real (> 5KB)
+      if (buf.length > 5000) {
+        results.push({ id: section.id, image: buf.toString("base64") });
+      }
+    }
+    return results;
   } finally {
     await page.close();
   }

--- a/.claude/hooks/reporter-bg.js
+++ b/.claude/hooks/reporter-bg.js
@@ -148,6 +148,27 @@ function sendTelegramPhoto(photoBuffer, caption, silent) {
   });
 }
 
+// Obtener screenshots por sección semántica del dashboard (nuevo endpoint #1263)
+// Retorna array de { id, buf } o null si el endpoint no está disponible
+function fetchScreenshotSections(width) {
+  return new Promise((resolve) => {
+    const req = http.get("http://localhost:" + DASHBOARD_PORT + "/screenshots/sections?w=" + width, { timeout: 30000 }, (res) => {
+      if (res.statusCode !== 200) { resolve(null); return; }
+      let d = "";
+      res.on("data", (c) => d += c);
+      res.on("end", () => {
+        try {
+          const sections = JSON.parse(d);
+          if (!Array.isArray(sections) || sections.length === 0) { resolve(null); return; }
+          resolve(sections.map(function(s) { return { id: s.id, buf: Buffer.from(s.image, "base64") }; }));
+        } catch { resolve(null); }
+      });
+    });
+    req.on("error", () => resolve(null));
+    req.on("timeout", () => { req.destroy(); resolve(null); });
+  });
+}
+
 // Obtener screenshots partidos del dashboard web (para álbum)
 function fetchScreenshots(width, height) {
   return new Promise((resolve) => {
@@ -254,9 +275,27 @@ async function sendPeriodicReport() {
   // Esperar un momento para que arranque
   await new Promise(r => setTimeout(r, 2000));
 
-  const caption = "\ud83d\udc9a <b>Intrale Monitor</b> \u2014 Heartbeat\n" + new Date().toLocaleString("es-AR");
+  const dateStr = new Date().toLocaleString("es-AR");
 
-  // Intentar álbum de 2 fotos primero
+  // 1. Intentar álbum por secciones semánticas (mobile-first 390px, #1263)
+  try {
+    const sections = await fetchScreenshotSections(390);
+    if (sections && sections.length >= 2) {
+      const validBufs = sections.map(function(s) { return s.buf; }).filter(function(b) { return b.length > 1000; });
+      if (validBufs.length >= 2) {
+        const caption = "\ud83d\udc9a <b>Intrale Monitor</b> \u2014 " + dateStr + "\n" + validBufs.length + " paneles";
+        await sendTelegramMediaGroup(validBufs, caption, true);
+        debugLog("Heartbeat secciones OK (" + validBufs.length + " paneles)");
+        return;
+      }
+    }
+  } catch (e) {
+    debugLog("Error con secciones: " + e.message);
+  }
+
+  const caption = "\ud83d\udc9a <b>Intrale Monitor</b> \u2014 Heartbeat\n" + dateStr;
+
+  // 2. Fallback: álbum top/bottom (endpoint /screenshots)
   try {
     const parts = await fetchScreenshots(600, 800);
     if (parts && parts.top.length > 1000 && parts.bottom.length > 1000) {
@@ -267,14 +306,14 @@ async function sendPeriodicReport() {
     debugLog("Error con álbum screenshots: " + e.message);
   }
 
-  // Fallback: single screenshot
+  // 3. Fallback: foto única
   const screenshot = await fetchScreenshot(375, 640);
   if (screenshot && screenshot.length > 1000) {
     try {
       await sendTelegramPhoto(screenshot, caption, true);
     } catch(e) {
       debugLog("Error enviando screenshot: " + e.message);
-      await sendTelegramText("\ud83d\udc9a <b>Heartbeat</b>\nDashboard activo en localhost:" + DASHBOARD_PORT + "\n" + new Date().toLocaleString("es-AR"), true);
+      await sendTelegramText("\ud83d\udc9a <b>Heartbeat</b>\nDashboard activo en localhost:" + DASHBOARD_PORT + "\n" + dateStr, true);
     }
   } else {
     debugLog("Screenshot no disponible, enviando texto");


### PR DESCRIPTION
## Resumen

- Nuevo endpoint `GET /screenshots/sections?w=390` en `dashboard-server.js` que captura cada panel del dashboard usando `getBoundingClientRect()` real
- Función `takeScreenshotSections(width)`: viewport 2400px alto, 5 selectores semánticos (`kpis`, `exec`, `sessions`, `metrics`, `ci`)
- Atributos `data-panel` agregados al HTML: `exec` en `.grid-2col`, `sessions` en `.grid-flow`, `metrics` en `.grid-2equal`, `ci` en el panel CI/CD
- `reporter-bg.js` usa `/screenshots/sections?w=390` como primera opción (mobile-first 390px)
- Fallback automático a `/screenshots` (top/bottom geométrico) si el endpoint falla
- Caption del álbum incluye cantidad de paneles: `💚 Intrale Monitor — {fecha}\n{N} paneles`
- Retrocompatibilidad: `/screenshots` (split geométrico) sigue funcionando para otros consumers

## Criterios cumplidos

- [x] Heartbeat envía 3–5 fotos por sección semántica en lugar de 2
- [x] Cada foto corresponde a una sección del dashboard (KPIs, Ejecución, Sesiones, Métricas, CI)
- [x] Corte respeta bordes de paneles — usa `getBoundingClientRect()` + `window.scrollY`
- [x] Ancho 390px (iPhone 14, mobile-first)
- [x] Paneles vacíos omitidos (`height < 20` o imagen `< 5KB`)
- [x] Fallback automático a `/screenshots` si el nuevo endpoint falla
- [x] Álbum enviado silencioso (`disable_notification: true`)

Closes #1263