### PR TITLE
fix(hooks): prevenir falso positivo 'Agentes finalizados' en monitor de sprint

### DIFF
--- a/.claude/hooks/agent-monitor.js
+++ b/.claude/hooks/agent-monitor.js
@@ -73,10 +73,25 @@ function isProcessAlive(pid) {
 }
 
 function isAgentDone(agente) {
-    const wtDir = getWorktreePath(agente);
+    // Guard: agentes con status "queued" NUNCA están done (no se han lanzado)
+    if (agente.status === "queued") {
+        return false;
+    }
 
-    // Worktree no existe → done
-    if (!fs.existsSync(wtDir)) return true;
+    const wtDir = getWorktreePath(agente);
+    if (!fs.existsSync(wtDir)) {
+        // Sin worktree: verificar si tiene PID registrado
+        let hasPid = false;
+        if (fs.existsSync(PIDS_FILE) && agente.numero) {
+            try {
+                const pidsData = JSON.parse(fs.readFileSync(PIDS_FILE, "utf8"));
+                hasPid = !!pidsData["agente_" + agente.numero];
+            } catch (e) {}
+        }
+        // Sin worktree + sin PID → nunca se lanzó → NOT done
+        // Sin worktree + con PID → terminó y se limpió → done
+        return hasPid;
+    }
 
     // Check PID del agente desde sprint-pids.json
     if (fs.existsSync(PIDS_FILE) && agente.numero) {
@@ -181,6 +196,10 @@ function hasAgentWorktrees() {
 // ─── Watch-Agentes (polling de estado de agentes) ────────────────────────────
 
 function checkAgents() {
+    // Re-leer el plan en cada ciclo para detectar cambios de status (queued→active)
+    const freshPlan = loadPlan();
+    if (freshPlan) _plan = freshPlan;
+
     if (!_plan || !_plan.agentes || _plan.agentes.length === 0) return;
 
     const agentes = _plan.agentes;


### PR DESCRIPTION
## Resumen

Agent-monitor detectaba incorrectamente que todos los agentes habían terminado (3/3 done) momentos después de lanzar el sprint, disparando el mensaje "🏁 Agentes finalizados" cuando en realidad nunca se habían ejecutado.

## Cambios

1. **Guard por status="queued"**: `isAgentDone()` retorna `false` inmediatamente si el agente tiene `status: "queued"`. Un agente que no se ha lanzado nunca puede estar "done".

2. **Re-lectura del plan en cada ciclo**: `checkAgents()` ahora re-lee `sprint-plan.json` en cada polling (cada 30s) para detectar cuando `Start-Agente.ps1` cambia el status de "queued" a "active".

## Causa raíz

Condición de carrera donde worktrees huérfanos, session files residuales, o ausencia del archivo `sprint-pids.json` causaban que `isAgentDone()` retornara `true` para agentes que nunca fueron lanzados.

## Tests

- Monitor ejecutándose: 0/3 finalizados consistentemente durante 2+ minutos sin disparar falso positivo ✅
- Fix verificado en simulación: agentes con status="queued" siempre retornan NOT done ✅

🤖 Generado con [Claude Code](https://claude.com/claude-code)