### PR TITLE
fix(hooks): botón Guardar de smart-suggestion crashea por path null

### DIFF
--- a/.claude/hooks/telegram-commander.js
+++ b/.claude/hooks/telegram-commander.js
@@ -2866,7 +2866,7 @@ async function pollingLoop() {
                         try {
                             if (action === "persist") {
                                 const pattern = Buffer.from(encodedPattern, "base64url").toString("utf8");
-                                const settingsPaths = getSettingsPaths(resolveMainRepoRoot());
+                                const settingsPaths = getSettingsPaths(REPO_ROOT);
                                 persistPattern(pattern, settingsPaths, log);
                                 await telegramPost("answerCallbackQuery", {
                                     callback_query_id: cq.id,


### PR DESCRIPTION
## Summary
- resolveMainRepoRoot() se llamaba sin argumento en el callback de smart-suggestion
- currentRoot era undefined → path.join(undefined, .git) → crash
- Fix: usar REPO_ROOT (constante ya definida) en lugar de resolveMainRepoRoot()

Closes #1298

## Test plan
- [ ] Aprobar un patrón de permiso 3+ veces → aparece smart-suggestion
- [ ] Presionar Guardar → debe persistir en settings.local.json sin crash

Generated with Claude Code