### PR TITLE
feat(hooks): auto-aprobar permisos MEDIUM y panel Permisos en Monitor

### DIFF
--- a/.claude/hooks/permission-approver.js
+++ b/.claude/hooks/permission-approver.js
@@ -489,11 +489,16 @@ async function processInput() {
 
     log("REPO_ROOT=" + REPO_ROOT + " MAIN=" + MAIN_REPO_ROOT + " tool=" + toolName);
 
-    // Fast-path: auto-aprobar si la severidad es AUTO_ALLOW (directorio seguro / tool interno)
+    // Fast-path: auto-aprobar si la severidad es AUTO_ALLOW, LOW o MEDIUM
+    // MEDIUM se auto-aprueba inmediatamente (git push, curl POST, Task/Agent) sin esperar timeout.
+    // git push a main sigue bloqueado por branch-guard.js independientemente de esto.
+    // HIGH sigue requiriendo aprobación manual vía Telegram.
     const severity = classifySeverity(toolName, toolInput, REPO_ROOT);
     log("SEVERITY: " + toolName + " → " + severity);
-    if (severity === Severity.AUTO_ALLOW || severity === Severity.LOW) {
-        const autoReason = severity === Severity.AUTO_ALLOW ? "AUTO_ALLOW (safe dir)" : "LOW severity";
+    if (severity === Severity.AUTO_ALLOW || severity === Severity.LOW || severity === Severity.MEDIUM) {
+        const autoReason = severity === Severity.AUTO_ALLOW ? "AUTO_ALLOW (safe dir)"
+            : severity === Severity.LOW ? "LOW severity"
+            : "MEDIUM severity";
         log("Auto-aprobando sin Telegram: " + toolName + " (" + autoReason + ")");
         const response = {
             hookSpecificOutput: {

--- a/.claude/hooks/permission-utils.js
+++ b/.claude/hooks/permission-utils.js
@@ -524,9 +524,11 @@ function isReversibleAction(toolName, toolInput, repoRoot) {
 /**
  * Enum de severidad:
  *   AUTO_ALLOW — acción reversible en directorio seguro → auto-aprobar sin Telegram
- *   LOW        — acción nueva pero recuperable → timeout reducido
- *   MEDIUM     — impacto externo pero reversible → flujo normal
- *   HIGH       — destructiva o irreversible → retry + fallback obligatorio
+ *   LOW        — acción nueva pero recuperable → auto-aprobar inmediatamente
+ *   MEDIUM     — impacto externo pero reversible → auto-aprobar inmediatamente (desde #1302)
+ *                Incluye: git push (a ramas no-main), curl POST, Task/Agent, npm publish
+ *                Protección: branch-guard.js bloquea git push a main independientemente
+ *   HIGH       — destructiva o irreversible → requiere aprobación manual via Telegram
  */
 const Severity = {
     AUTO_ALLOW: "AUTO_ALLOW",

--- a/.claude/skills/monitor/SKILL.md
+++ b/.claude/skills/monitor/SKILL.md
@@ -27,6 +27,7 @@ Recolecta datos de TODAS estas fuentes en paralelo:
 7. **Metricas config**: Lee `.claude/hooks/telegram-config.json` y extrae `claude_metrics` para calcular costos
 8. **Metricas de agentes**: Lee `.claude/hooks/agent-metrics.json` con `Read` (puede no existir — omitir panel si no existe)
 9. **Participacion de agentes**: Lee `.claude/hooks/agent-participation.json` con `Read` (puede no existir — omitir panel COBERTURA si no existe)
+10. **Permisos**: Lee `.claude/hooks/pending-questions.json` y `.claude/hooks/approval-history.json` con `Read` (pueden no existir — omitir panel PERMISOS si no existen)
 
 Luego, para cada sesion de tipo `"parent"`, determina su estado de liveness usando `last_activity_ts` del JSON:
 
@@ -273,6 +274,42 @@ Reglas para los sub-pasos:
 - Tarea `in_progress` sin owner → `⚠ #N in_progress sin owner`
 - Si no hay alertas → `✓ Sin alertas`
 
+**Reglas del panel PERMISOS:**
+
+- Fuentes: `.claude/hooks/pending-questions.json` (permisos recientes) + `.claude/hooks/approval-history.json` (estadísticas por patrón)
+- Si ambos archivos no existen o están vacíos: omitir el panel completamente
+- Formato del panel:
+
+```
+├─ PERMISOS ──────────────────────────────────────────────────────┤
+│ Auto: 42  │ Aprobados: 15  │ Rechazados: 1  │ Pendientes: 2    │
+│                                                                   │
+│ Recientes (últimos 10):                                           │
+│ ✓ AUTO  TaskCreate         (AUTO_ALLOW) hace 2m                  │
+│ ✓ AUTO  WebFetch           (LOW)        hace 5m                  │
+│ ✓ AUTO  git push agent/... (MEDIUM)     hace 8m                  │
+│ ✓ TELE  Bash: curl -X POST (MEDIUM)     hace 12m · @leitolarreta│
+│ ✗ RECH  rm -rf /tmp/*      (HIGH)       hace 1h  · @leitolarreta│
+│ ☐ PEND  git reset --hard   (HIGH)       hace 3m  · esperando... │
+│                                                                   │
+│ Top patrones: Bash(node:*) ×42 | Edit(*) ×38 | WebFetch ×15     │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+- **Resumen numérico** (primera fila):
+  - `Auto`: contar entradas en `pending-questions.json` donde `answered_via === "auto"` o `action_result === "allow"` y `answered_via === "auto"`
+  - `Aprobados`: contar donde `answered_via === "telegram"` o `answered_via === "console"` y `action_result === "allow"`
+  - `Rechazados`: contar donde `action_result === "deny"`
+  - `Pendientes`: contar donde `status === "pending"`
+- **Permisos recientes**: listar las últimas 10 entradas del array `questions[]` de `pending-questions.json` ordenadas por `created_at` descendente
+  - Estado: `✓ AUTO` = auto-aprobado | `✓ TELE` = aprobado vía Telegram | `✓ CONS` = aprobado vía consola | `✗ RECH` = rechazado | `☐ PEND` = pendiente
+  - Herramienta: campo `tool_name` (truncar a 20 chars)
+  - Severidad: entre paréntesis — inferir desde `tool_name`: TaskCreate/Edit/Write/Read → AUTO_ALLOW; WebFetch/WebSearch/Skill → LOW; git push/curl POST/Task/Agent → MEDIUM; rm/reset → HIGH
+  - Tiempo: calcular diferencia entre `created_at` y ahora (hace Xm / hace Xh)
+  - Aprobador: si fue via Telegram o consola, mostrar ` · @leitolarreta`; si pendiente, mostrar ` · esperando...`
+- **Top patrones**: leer `approval-history.json`, ordenar por `count` descendente, mostrar los top 3 en formato `Patrón ×N`
+- Si `pending-questions.json` existe pero no tiene entradas recientes (últimas 24h), mostrar solo resumen y top patrones
+
 **Formato general:**
 
 - Usa caracteres box-drawing Unicode: `┌ ┐ └ ┘ ├ ┤ ┬ ┴ │ ─`
@@ -319,6 +356,7 @@ Muestra:
 │   TAREAS       Progreso con sub-pasos               │
 │   REPO         Branch, commit, CI                   │
 │   ALERTAS      Bloqueos y advertencias              │
+│   PERMISOS     Solicitudes, clasificación, resultado│
 │                                                     │
 │ Dashboard web (auto-arranca con agentes):           │
 │   http://localhost:3100                             │


### PR DESCRIPTION
## Resumen

- **Auto-aprobación MEDIUM**: permisos de severidad MEDIUM (git push a ramas no-main, curl POST, Task/Agent) se auto-aprueban inmediatamente sin esperar el timeout de 15 minutos, igual que LOW.
- **Panel PERMISOS en Monitor**: el `/monitor` ahora incluye un panel dedicado que muestra resumen numérico, permisos recientes con severidad/resultado/aprobador, y top patrones desde `approval-history.json`.

## Cambios técnicos

### `permission-approver.js`
- Agrega `|| severity === Severity.MEDIUM` al fast-path de auto-aprobación (línea ~495)
- Log claro: `"Auto-aprobando sin Telegram: [tool] (MEDIUM severity)"`
- `git push` a `main` sigue bloqueado por `branch-guard.js` independientemente

### `permission-utils.js`
- Actualiza documentación del enum `Severity` para reflejar el nuevo comportamiento

### `monitor/SKILL.md`
- Agrega fuente de datos #10 (`pending-questions.json` + `approval-history.json`)
- Agrega reglas completas del panel PERMISOS con formato box-drawing
- Agrega PERMISOS a la lista de paneles en el `help`

## Tests

- 45/45 tests en `test-p18-smart-permissions.js` pasan sin regresión
- Sintaxis JS verificada con `node --check`

## Criterios de aceptación verificados

- [x] Permisos MEDIUM se auto-aprueban inmediatamente (sin timeout)
- [x] Log `"Auto-aprobando sin Telegram: [tool] (MEDIUM severity)"` presente
- [x] HIGH sigue requiriendo aprobación manual vía Telegram
- [x] branch-guard.js sigue bloqueando git push a main
- [x] Panel PERMISOS en Monitor con resumen numérico y recientes
- [x] Top patrones desde approval-history.json
- [x] No hay regresión en AUTO_ALLOW y LOW

Closes #1302

🤖 Generated with [Claude Code](https://claude.com/claude-code)