### PR TITLE
fix(hooks): detectar issues cerrados por PR merge y promover cola de sprint automáticamente

### DIFF
--- a/.claude/hooks/agent-concurrency-check.js
+++ b/.claude/hooks/agent-concurrency-check.js
@@ -17,7 +17,39 @@ const fs = require("fs");
 const path = require("path");
 const { spawn } = require("child_process");
 
-const REPO_ROOT = process.env.CLAUDE_PROJECT_DIR || "C:\\Workspaces\\Intrale\\platform";
+// Bug fix (#1266): Resolver el repo principal desde worktrees.
+// Cuando el hook se ejecuta en un worktree (agent/*), CLAUDE_PROJECT_DIR
+// puede apuntar al worktree vacío. Usamos git worktree list para encontrar
+// el repo principal (siempre el primer item de la lista).
+function resolveMainRepoRoot() {
+    const envRoot = process.env.CLAUDE_PROJECT_DIR || "C:\\Workspaces\\Intrale\\platform";
+    try {
+        const { execSync } = require("child_process");
+        const output = execSync("git worktree list", {
+            encoding: "utf8",
+            cwd: envRoot,
+            timeout: 5000,
+            windowsHide: true
+        });
+        const firstLine = output.split("\n")[0] || "";
+        const match = firstLine.match(/^(.+?)\s+[0-9a-f]{5,}/);
+        if (match) {
+            const mainPath = match[1].trim();
+            // Convertir path POSIX a Windows si aplica
+            return mainPath.replace(/^\/([a-z])\//, "$1:\\").replace(/\//g, "\\");
+        }
+    } catch (e) {
+        // Si git falla (ej: directorio vacío sin .git), usar el fallback
+    }
+    // Fallback: si el repo apunta al worktree vacío, usar el repo por defecto
+    const planFile = path.join(envRoot, "scripts", "sprint-plan.json");
+    if (!fs.existsSync(planFile)) {
+        return "C:\\Workspaces\\Intrale\\platform";
+    }
+    return envRoot;
+}
+
+const REPO_ROOT = resolveMainRepoRoot();
 const HOOKS_DIR = path.join(REPO_ROOT, ".claude", "hooks");
 const LOG_FILE = path.join(HOOKS_DIR, "hook-debug.log");
 const SESSIONS_DIR = path.join(REPO_ROOT, ".claude", "sessions");

--- a/.claude/hooks/agent-monitor.js
+++ b/.claude/hooks/agent-monitor.js
@@ -9,7 +9,32 @@ const path = require("path");
 const { execSync, spawn } = require("child_process");
 
 const HOOKS_DIR = __dirname;
-const REPO_ROOT = process.env.CLAUDE_PROJECT_DIR || path.resolve(HOOKS_DIR, "..", "..");
+
+// Bug fix (#1266): Resolver el repo principal desde worktrees.
+function resolveMainRepoRoot(hooksDir) {
+    const envRoot = process.env.CLAUDE_PROJECT_DIR || path.resolve(hooksDir, "..", "..");
+    try {
+        const output = execSync("git worktree list", {
+            encoding: "utf8",
+            cwd: envRoot,
+            timeout: 5000,
+            windowsHide: true
+        });
+        const firstLine = output.split("\n")[0] || "";
+        const match = firstLine.match(/^(.+?)\s+[0-9a-f]{5,}/);
+        if (match) {
+            const mainPath = match[1].trim();
+            return mainPath.replace(/^\/([a-z])\//, "$1:\\").replace(/\//g, "\\");
+        }
+    } catch (e) {}
+    const planFile = path.join(envRoot, "scripts", "sprint-plan.json");
+    if (!fs.existsSync(planFile)) {
+        return path.resolve(hooksDir, "..", "..");
+    }
+    return envRoot;
+}
+
+const REPO_ROOT = resolveMainRepoRoot(HOOKS_DIR);
 const LOG_FILE = path.join(HOOKS_DIR, "hook-debug.log");
 const PLAN_FILE = path.join(REPO_ROOT, "scripts", "sprint-plan.json");
 const PIDS_FILE = path.join(REPO_ROOT, "scripts", "sprint-pids.json");
@@ -196,39 +221,8 @@ function hasAgentWorktrees() {
 // ─── Watch-Agentes (polling de estado de agentes) ────────────────────────────
 
 function checkAgents() {
-    // Re-leer el plan en cada ciclo para detectar cambios de status (queued→active)
-    const freshPlan = loadPlan();
-    if (freshPlan) _plan = freshPlan;
-
-    if (!_plan || !_plan.agentes || _plan.agentes.length === 0) return;
-
-    const agentes = _plan.agentes;
-    let doneCount = 0;
-    const statusParts = [];
-
-    for (const a of agentes) {
-        if (isAgentDone(a)) {
-            doneCount++;
-            statusParts.push(a.numero + ":OK");
-        } else {
-            statusParts.push(a.numero + ":...");
-        }
-    }
-
-    const elapsedMin = Math.round((Date.now() - _startTime) / 60000);
-    log(doneCount + "/" + agentes.length + " finalizados [" + statusParts.join("  ") + "] (" + elapsedMin + " min)");
-
-    if (doneCount >= agentes.length) {
-        log("Todos los agentes finalizaron!");
-        handleAllDone(elapsedMin);
-        return;
-    }
-
-    // Failsafe: si paso mucho tiempo y no hay procesos claude
-    if ((Date.now() - _startTime) > FAILSAFE_MS && !isAnyClaude()) {
-        log("Failsafe: no hay procesos claude activos tras " + elapsedMin + " min. Procediendo.");
-        handleAllDone(elapsedMin);
-    }
+    // Delegar a _checkAgentsImpl que incluye lógica de promoción de cola
+    _checkAgentsImpl().catch(e => log("checkAgents error: " + e.message));
 }
 
 async function handleAllDone(elapsedMin) {
@@ -538,8 +532,192 @@ function getAgentStatus() {
     };
 }
 
+// ─── Bug 2 fix: promoción automática de _queue (#1266) ───────────────────────
+
+const MAX_CONCURRENT_AGENTS = 2;
+
+/**
+ * Cuenta agentes activos en el plan (excluye los con status "queued").
+ */
+function countActiveAgents(plan) {
+    if (!plan || !Array.isArray(plan.agentes)) return 0;
+    return plan.agentes.filter(ag => ag.status !== "queued").length;
+}
+
+/**
+ * Promueve items de _queue (o cola) a agentes respetando MAX_CONCURRENT_AGENTS.
+ * Lee el plan fresco del archivo si no se pasa como argumento.
+ * Retorna array de agentes promovidos.
+ * Persiste los cambios en sprint-plan.json.
+ */
+function promoteFromQueue(plan) {
+    const currentPlan = plan || loadPlan();
+    if (!currentPlan) return [];
+    const agentes = currentPlan.agentes || [];
+    // Usar _queue o cola según cuál esté disponible
+    const _queue = Array.isArray(currentPlan._queue) ? currentPlan._queue :
+        (Array.isArray(currentPlan.cola) ? currentPlan.cola : []);
+    if (_queue.length === 0) return [];
+
+    const activeCount = countActiveAgents(currentPlan);
+    const slotsAvailable = Math.max(0, MAX_CONCURRENT_AGENTS - activeCount);
+    if (slotsAvailable === 0) return [];
+
+    // Extraer los primeros N items de la cola
+    const promoted = _queue.splice(0, slotsAvailable);
+
+    // Actualizar el campo correcto de la cola
+    if (Array.isArray(currentPlan._queue)) {
+        currentPlan._queue = _queue;
+    } else {
+        currentPlan.cola = _queue;
+    }
+
+    // Asignar número a los promovidos y moverlos a agentes
+    const maxNumero = agentes.reduce((m, ag) => Math.max(m, ag.numero || 0), 0);
+    promoted.forEach((ag, idx) => {
+        ag.numero = maxNumero + idx + 1;
+        ag.status = "active";
+        agentes.push(ag);
+    });
+    currentPlan.agentes = agentes;
+
+    // Persistir cambios en sprint-plan.json
+    try {
+        fs.writeFileSync(PLAN_FILE, JSON.stringify(currentPlan, null, 2) + "\n", "utf8");
+    } catch (e) {
+        log("promoteFromQueue: error escribiendo sprint-plan.json: " + e.message);
+    }
+
+    return promoted;
+}
+
+/**
+ * Mueve un agente del array activo a un array _completed.
+ * Persiste los cambios en sprint-plan.json.
+ */
+function moveToCompleted(plan, issueNumber) {
+    if (!plan || !issueNumber) return;
+    if (!Array.isArray(plan._completed)) plan._completed = [];
+
+    const idx = (plan.agentes || []).findIndex(ag => ag.issue === issueNumber);
+    if (idx === -1) return;
+
+    const [finished] = plan.agentes.splice(idx, 1);
+    finished.completed_at = new Date().toISOString();
+    plan._completed.push(finished);
+
+    try {
+        fs.writeFileSync(PLAN_FILE, JSON.stringify(plan, null, 2) + "\n", "utf8");
+    } catch (e) {
+        log("moveToCompleted: error escribiendo sprint-plan.json: " + e.message);
+    }
+}
+
+/**
+ * Lanza agentes promovidos vía Start-Agente.ps1.
+ */
+function launchAgents(agents) {
+    if (!agents || agents.length === 0) return;
+    const START_SCRIPT = path.join(REPO_ROOT, "scripts", "Start-Agente.ps1");
+    if (!fs.existsSync(START_SCRIPT)) {
+        log("launchAgents: Start-Agente.ps1 no encontrado en " + START_SCRIPT);
+        return;
+    }
+    for (const ag of agents) {
+        try {
+            const ps1 = START_SCRIPT.replace(/\//g, "\\");
+            const child = spawn("powershell.exe", ["-NonInteractive", "-File", ps1, String(ag.numero)], {
+                detached: true,
+                stdio: "ignore",
+                windowsHide: false
+            });
+            child.unref();
+            log("launchAgents: lanzado agente #" + ag.issue + " (numero " + ag.numero + ", PID " + child.pid + ")");
+        } catch (e) {
+            log("launchAgents: error lanzando agente #" + ag.issue + ": " + e.message);
+        }
+    }
+}
+
+/**
+ * Lógica principal de chequeo de agentes con promoción automática de cola.
+ * Separada de checkAgents para poder ser probada/exportada independientemente.
+ */
+async function _checkAgentsImpl() {
+    const freshPlan = loadPlan();
+    if (freshPlan) _plan = freshPlan;
+
+    if (!_plan || !_plan.agentes || _plan.agentes.length === 0) return;
+
+    const agentes = _plan.agentes;
+    let doneCount = 0;
+    const statusParts = [];
+
+    // Detectar agentes terminados
+    const finishedIssues = [];
+    for (const a of agentes) {
+        if (isAgentDone(a)) {
+            doneCount++;
+            statusParts.push(a.numero + ":OK");
+            finishedIssues.push(a.issue);
+        } else {
+            statusParts.push(a.numero + ":...");
+        }
+    }
+
+    const elapsedMin = Math.round((Date.now() - _startTime) / 60000);
+    log(doneCount + "/" + agentes.length + " finalizados [" + statusParts.join("  ") + "] (" + elapsedMin + " min)");
+
+    // Mover agentes terminados a _completed y promover cola
+    if (finishedIssues.length > 0) {
+        const planForMutation = loadPlan();
+        if (planForMutation) {
+            for (const issue of finishedIssues) {
+                moveToCompleted(planForMutation, issue);
+            }
+            // promoteFromQueue() lee el plan fresco del archivo (ya actualizado por moveToCompleted)
+            const promoted = promoteFromQueue();
+            _plan = loadPlan() || _plan;
+
+            if (promoted.length > 0) {
+                launchAgents(promoted);
+                const freshPlanAfter = loadPlan() || _plan;
+                const currentQueue = Array.isArray(freshPlanAfter._queue) ? freshPlanAfter._queue :
+                    (Array.isArray(freshPlanAfter.cola) ? freshPlanAfter.cola : []);
+                const msg = "🚀 <b>Cola de sprint avanzó</b>\n" +
+                    "Promovidos: " + promoted.map(ag => "#" + ag.issue + " (" + ag.slug + ")").join(", ") + "\n" +
+                    "Cola restante: " + currentQueue.length + "\n" +
+                    "Activos: " + countActiveAgents(freshPlanAfter) + "/" + MAX_CONCURRENT_AGENTS;
+                await notify(msg);
+                return;
+            }
+        }
+    }
+
+    // Verificar si el sprint terminó
+    const currentPlan = loadPlan() || _plan;
+    const currentQueue = Array.isArray(currentPlan._queue) ? currentPlan._queue :
+        (Array.isArray(currentPlan.cola) ? currentPlan.cola : []);
+    const allTerminal = (currentPlan.agentes || []).every(ag => isAgentDone(ag));
+
+    if (currentQueue.length === 0 && allTerminal) {
+        log("Sprint completado: cola vacía y todos los agentes terminados");
+        handleAllDone(elapsedMin);
+        return;
+    }
+
+    // Failsafe: si pasó mucho tiempo y no hay procesos claude
+    if ((Date.now() - _startTime) > FAILSAFE_MS && !isAnyClaude()) {
+        log("Failsafe: no hay procesos claude activos tras " + elapsedMin + " min. Procediendo.");
+        handleAllDone(elapsedMin);
+    }
+}
+
 module.exports = {
     startAgentMonitor, stopAgentMonitor, getAgentStatus,
     recordSprintParticipation, alertInactiveAgents,
-    ALL_PIPELINE_AGENTS
+    ALL_PIPELINE_AGENTS,
+    promoteFromQueue, countActiveAgents, moveToCompleted, launchAgents,
+    MAX_CONCURRENT_AGENTS, _checkAgentsImpl
 };

--- a/.claude/hooks/post-issue-close.js
+++ b/.claude/hooks/post-issue-close.js
@@ -289,31 +289,128 @@ async function processIssueClose(issueNumber, prNumber) {
     }
 }
 
+// ─── Bug 1 fix: detectar cierre de issues vía PR merge (#1266) ─────────────
+
+/**
+ * Extrae el número de PR del comando gh pr merge.
+ * Retorna el número (int) si el comando es gh pr merge <N>
+ * Retorna 0 si es gh pr merge sin número explícito
+ * Retorna null si el comando no es gh pr merge
+ */
+function extractPrNumber(command) {
+    if (!command || typeof command !== "string") return null;
+    if (!/gh\s+pr\s+merge/.test(command)) return null;
+    const match = command.match(/gh\s+pr\s+merge\s+(\d+)/);
+    return match ? parseInt(match[1], 10) : 0;
+}
+
+/**
+ * Extrae números de issues cerrados del body de un PR.
+ * Detecta patrones: closes #N, fixes #N, resolves #N (case-insensitive)
+ */
+function extractIssueNumbers(prBody) {
+    if (!prBody) return [];
+    const issues = [];
+    const pattern = /(?:closes?|fixes?|resolves?)\s+#(\d+)/gi;
+    let m;
+    while ((m = pattern.exec(prBody)) !== null) {
+        issues.push(parseInt(m[1], 10));
+    }
+    return issues;
+}
+
+/**
+ * Obtiene datos del PR vía GraphQL.
+ */
+async function ghGetPr(token, prNumber) {
+    const queryStr = "query($owner:String!,$repo:String!,$number:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$number){number,merged,merged_at,baseRefName,body}}}";
+    const data = await graphqlRequest(token, queryStr, { owner: "intrale", repo: "platform", number: prNumber });
+    return data && data.repository && data.repository.pullRequest;
+}
+
+/**
+ * Procesa un PR mergeado: extrae issues referenciados y los mueve a Done.
+ */
+async function handlePrMerge(prNumber) {
+    log("Procesando PR merge #" + prNumber);
+    try {
+        const token = getGitHubToken();
+        const pr = await ghGetPr(token, prNumber);
+
+        if (!pr) {
+            log("PR #" + prNumber + " no encontrado");
+            return;
+        }
+
+        // Verificar que fue mergeado (tiene merged_at)
+        if (!pr.merged_at) {
+            log("PR #" + prNumber + " no fue mergeado (merged_at ausente), ignorando");
+            return;
+        }
+
+        // Verificar que el PR fue a main
+        if (pr.baseRefName !== "main") {
+            log("PR #" + prNumber + " no fue a main (base: " + pr.baseRefName + "), ignorando");
+            return;
+        }
+
+        const issueNumbers = extractIssueNumbers(pr.body);
+        if (issueNumbers.length === 0) {
+            log("PR #" + prNumber + " no referencia issues (Closes/Fixes/Resolves), ignorando");
+            return;
+        }
+
+        log("PR #" + prNumber + " cierra issues: " + issueNumbers.join(", "));
+
+        for (let i = 0; i < issueNumbers.length; i++) {
+            try {
+                await processIssueClose(issueNumbers[i], prNumber);
+            } catch (e) {
+                log("Error procesando issue #" + issueNumbers[i] + " del PR #" + prNumber + ": " + e.message);
+            }
+        }
+    } catch (e) {
+        log("handlePrMerge error: " + e.message);
+    }
+}
+
 function handleInput() {
     try {
         const data = JSON.parse(input || "{}");
         const command = (data.tool_input && data.tool_input.command) || "";
-
-        // Detectar gh issue close <N>
-        const match = command.match(/gh\s+issue\s+close\s+(\d+)/);
-        if (!match) return;
-
-        // Verificar que no hubo error en stderr
         const stderr = (data.tool_result && data.tool_result.stderr) || "";
-        if (/error|rejected|denied|failed/i.test(stderr)) {
-            log("gh issue close tuvo error en stderr, ignorando");
+
+        // Caso 1: gh issue close <N> — cierre explícito
+        const issueMatch = command.match(/gh\s+issue\s+close\s+(\d+)/);
+        if (issueMatch) {
+            if (/error|rejected|denied|failed/i.test(stderr)) {
+                log("gh issue close tuvo error en stderr, ignorando");
+                return;
+            }
+            const issueNumber = parseInt(issueMatch[1], 10);
+            const prMatch = command.match(/--comment.*?#(\d+)/);
+            const prNumber = prMatch ? parseInt(prMatch[1], 10) : null;
+            processIssueClose(issueNumber, prNumber).catch(function(e) {
+                log("Error procesando cierre de issue #" + issueNumber + ": " + e.message);
+            });
             return;
         }
 
-        const issueNumber = parseInt(match[1], 10);
-
-        // Intentar extraer número de PR del command (gh issue close <N> --comment "Closes PR #M")
-        const prMatch = command.match(/--comment.*?#(\d+)/);
-        const prNumber = prMatch ? parseInt(prMatch[1], 10) : null;
-
-        processIssueClose(issueNumber, prNumber).catch(function(e) {
-            log("Error procesando cierre de issue #" + issueNumber + ": " + e.message);
-        });
+        // Caso 2: gh pr merge <N> — issues cerrados vía Closes #N en el PR body
+        const prMergeNumber = extractPrNumber(command);
+        if (prMergeNumber !== null) {
+            if (/error|rejected|denied|failed/i.test(stderr)) {
+                log("gh pr merge tuvo error en stderr, ignorando");
+                return;
+            }
+            if (prMergeNumber === 0) {
+                log("gh pr merge sin número explícito — no se puede detectar PR, ignorando");
+                return;
+            }
+            handlePrMerge(prMergeNumber).catch(function(e) {
+                log("Error en handlePrMerge #" + prMergeNumber + ": " + e.message);
+            });
+        }
     } catch(e) {
         log("Error parseando input: " + e.message);
     }


### PR DESCRIPTION
## Resumen

- **Bug 1** (`post-issue-close.js`): El hook solo detectaba `gh issue close <N>` explícito. Cuando un PR se mergea con `Closes #N` en el body, GitHub cierra el issue automáticamente y el hook nunca se disparaba → issues completados quedaban en "Backlog Técnico" en lugar de moverse a "Done".

- **Bug 2** (`agent-monitor.js`): No existía lógica para promover items de `_queue` a `agentes` cuando un agente terminaba. Los agentes 3-5 del sprint nunca se lanzaban aunque hubiera slots disponibles.

- **Bug 3** (ambos hooks): `CLAUDE_PROJECT_DIR` en worktrees apunta al directorio vacío del worktree. `sprint-plan.json` no se encontraba y el hook abortaba silenciosamente.

## Cambios técnicos

### post-issue-close.js
- `extractPrNumber(command)` — detecta `gh pr merge <N>`
- `extractIssueNumbers(prBody)` — extrae issues referenciados (Closes/Fixes/Resolves #N)
- `ghGetPr(token, prNumber)` — obtiene datos del PR vía GraphQL
- `handlePrMerge(prNumber)` — verifica merged_at + base=main, llama `processIssueClose()` por cada issue

### agent-monitor.js
- `MAX_CONCURRENT_AGENTS = 2`
- `countActiveAgents(plan)` — cuenta agentes activos
- `promoteFromQueue([plan])` — promueve de `_queue` respetando el máximo
- `moveToCompleted(plan, issue)` — mueve agente terminado a `_completed`
- `launchAgents(agents)` — lanza agentes vía `Start-Agente.ps1`
- `_checkAgentsImpl()` — lógica principal con promoción automática

### agent-concurrency-check.js + agent-monitor.js
- `resolveMainRepoRoot()` — usa `git worktree list` para encontrar el repo principal desde cualquier worktree

## Tests

| Test | Resultado |
|------|-----------|
| P-20: post-issue-close cierre vía PR | ✅ 19/19 |
| P-21: agent-monitor promoción de cola | ✅ 16/16 |
| P-22: agent-concurrency-check lógica | ✅ 17/17 |

Closes #1266