### PR TITLE
fix(hooks): re-agregar post-merge-qa hook en settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -114,6 +114,11 @@
             "type": "command",
             "command": "node /c/Workspaces/Intrale/platform/.claude/hooks/post-issue-close.js",
             "timeout": 10000
+          },
+          {
+            "type": "command",
+            "command": "node /c/Workspaces/Intrale/platform/.claude/hooks/post-merge-qa.js",
+            "timeout": 15000
           }
         ]
       },


### PR DESCRIPTION
## Resumen

Re-agrega el registro del hook `post-merge-qa.js` en `.claude/settings.json` que fue accidentalmente removido en PR #1285. El hook detecta merges exitosos a main y verifica cobertura QA E2E de los issues asociados.

## Contexto

**Problema origen**: Incidente Sprint UX (2026-03-07) — Post-merge QA fallback no estaba implementado.

**Causa raíz**: PR #1268 implementó `post-merge-qa.js` y lo registró en settings.json. Posteriormente, PR #1285 (validación de concurrencia) removió accidentalmente el registro al hacer merge, creando un conflicto que se resolvió con `--ours` (nuestra versión antigua sin post-merge-qa).

**Solución**: Re-agregar el registro en `PostToolUse[Bash]` con timeout de 15000ms.

## Cambios

- ✅ `.claude/settings.json`: agrega `post-merge-qa.js` en PostToolUse[Bash]
- ✅ Hook implementado (29/29 tests P-19)
- ✅ Labels qa:passed, qa:pending, qa:skipped, qa:failed existen en el repositorio
- ✅ QA skill ya tiene Paso V9 (agrega `qa:passed` al completarse)

## Plan de tests

- [x] Tests unitarios pasan (29/29 P-19)
- [x] Build completo sin errores (443 tasks)
- [x] Security audit aprobado
- [x] Code review aprobado
- [x] No regresiones en tests kotlin

## Verificaciones

- Tester: BUILD SUCCESSFUL (443 tasks, 0 errores)
- Builder: Recursos validados, fallbacks ASCII OK
- Security: APROBADO (0 bloqueantes, 1 info minor)
- Review: APROBADO (0 bloqueantes, 0 warnings)

Closes #1259

🤖 Generado con [Claude Code](https://claude.ai/claude-code)