### PR TITLE
fix(hooks): re-agregar post-merge-qa hook en settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -114,6 +114,11 @@
             "type": "command",
             "command": "node /c/Workspaces/Intrale/platform/.claude/hooks/post-issue-close.js",
             "timeout": 10000
+          },
+          {
+            "type": "command",
+            "command": "node /c/Workspaces/Intrale/platform/.claude/hooks/post-merge-qa.js",
+            "timeout": 15000
           }
         ]
       },


### PR DESCRIPTION
## Summary
- Re-agrega el registro del hook `post-merge-qa.js` en `settings.json` que fue accidentalmente removido en PR #1285
- El hook detecta merges sin QA E2E y etiqueta issues con `qa:pending`

Closes #1259

## Test plan
- [x] Tests: 29/29 (P-19)
- [x] Security: APROBADO
- [x] Build: 443 tasks

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>