### PR TITLE
fix(scripts): terminales de agentes se cierran cuando claude muere inesperadamente

### DIFF
--- a/scripts/Start-Agente.ps1
+++ b/scripts/Start-Agente.ps1
@@ -239,19 +239,25 @@ function Start-UnAgente {
     $promptFile = Join-Path $logDir "prompt_$($Agente.numero).txt"
     Set-Content -Path $promptFile -Value $prompt -Encoding UTF8 -NoNewline
 
-    $command = "Start-Transcript -Path '$logFile' -Force | Out-Null; " +
-               "Remove-Item Env:CLAUDECODE -ErrorAction SilentlyContinue; " +
-               "Set-Location '$wtDirResolved'; " +
-               "Write-Host ''; " +
-               "Write-Host '  Agente $($Agente.numero) - issue #$issue ($slug)' -ForegroundColor Cyan; " +
-               "Write-Host '  Branch: $branch' -ForegroundColor Cyan; " +
-               "Write-Host '  Log: $logFile' -ForegroundColor DarkGray; " +
-               "Write-Host ''; " +
-               "Get-Content '$promptFile' -Raw | claude -p --dangerously-skip-permissions; " +
-               "Write-Host ''; " +
-               "Write-Host ('  claude finalizo (exit ' + `$LASTEXITCODE + ')') -ForegroundColor Yellow; " +
-               "Stop-Transcript | Out-Null; " +
-               "Start-Sleep -Seconds 3"
+    # try/finally garantiza que la terminal se cierre aunque claude crashee o muera inesperadamente (#1350)
+    $command = "try { " +
+               "  Start-Transcript -Path '$logFile' -Force | Out-Null; " +
+               "  Remove-Item Env:CLAUDECODE -ErrorAction SilentlyContinue; " +
+               "  Set-Location '$wtDirResolved'; " +
+               "  Write-Host ''; " +
+               "  Write-Host '  Agente $($Agente.numero) - issue #$issue ($slug)' -ForegroundColor Cyan; " +
+               "  Write-Host '  Branch: $branch' -ForegroundColor Cyan; " +
+               "  Write-Host '  Log: $logFile' -ForegroundColor DarkGray; " +
+               "  Write-Host ''; " +
+               "  Get-Content '$promptFile' -Raw | claude -p --dangerously-skip-permissions; " +
+               "  `$exitCode = `$LASTEXITCODE; " +
+               "  Write-Host ''; " +
+               "  Write-Host ('  claude finalizo (exit ' + `$exitCode + ')') -ForegroundColor Yellow; " +
+               "} finally { " +
+               "  Stop-Transcript -ErrorAction SilentlyContinue | Out-Null; " +
+               "  Start-Sleep -Seconds 3; " +
+               "  exit " +
+               "}"
 
     Write-Host ">> Abriendo terminal con claude..."
     $proc = Start-Process powershell -ArgumentList "-Command", $command -PassThru


### PR DESCRIPTION
## Resumen

Fix para issue #1350: garantizar que las terminales PowerShell de los agentes se cierren automáticamente cuando claude termina, incluso si crashea o sale con error.

## Cambios

- Envolver la cadena de comandos en bloque `try/finally` en `Start-Agente.ps1`
- Mover `Stop-Transcript` al bloque `finally` con `-ErrorAction SilentlyContinue`
- Agregar `exit` en el bloque `finally` para cierre incondicional
- Capturar `$LASTEXITCODE` en variable local para preservar el código de salida

## Plan de tests

- [x] Tests unitarios pasan (`./gradlew check`)
- [x] Build completo sin errores
- [x] Verificación de strings legacy OK
- [x] Code review: APROBADO
- [x] Security review: APROBADO (0 findings críticos/altos)

Closes #1350

🤖 Generado con [Claude Code](https://claude.ai/claude-code)