### PR TITLE
feat(monitor): mostrar sprint_id (SPR-NNN) y estado finalizado en dashboard

### DIFF
--- a/.claude/dashboard-server.js
+++ b/.claude/dashboard-server.js
@@ -511,6 +511,8 @@ function mockEjecucionData() {
   ];
 
   const mockSprintPlan = {
+    sprint_id: "SPR-013",
+    estado: "activo",
     fecha: new Date().toISOString().split("T")[0],
     fechaInicio: new Date().toISOString().split("T")[0],
     fechaFin: new Date(Date.now() + 5 * 86400000).toISOString().split("T")[0],
@@ -716,6 +718,9 @@ function renderHTML(data, theme) {
   // Sprint sub-view
   if (data.sprintPlan && Array.isArray(data.sprintPlan.agentes) && data.sprintPlan.agentes.length > 0) {
     const spDate = data.sprintPlan.fecha || "";
+    const sprintId = data.sprintPlan.sprint_id || null;
+    const sprintEstado = (data.sprintPlan.estado || "activo").toLowerCase();
+    const isFinalizado = sprintEstado === "finalizado";
     // Progreso del sprint: usar tareas si existen, si no, contar agentes done/total
     const agentesTotal = data.sprintPlan.agentes.length;
     const sprintTasksTotal = data.sprintSessions.reduce((sum, s) => sum + (s.current_tasks || []).length, 0);
@@ -742,10 +747,14 @@ function renderHTML(data, theme) {
       sprintPct = agentesTotal > 0 ? Math.round(totalPctSum / agentesTotal) : 0;
     }
 
+    const sprintLabelId = sprintId ? escHtml(sprintId) : (spDate ? escHtml(spDate) : "Sprint");
+    const sprintEstadoBadge = isFinalizado
+      ? `<span class="sprint-status-badge sprint-finalizado">&#10003; FINALIZADO</span>`
+      : `<span class="sprint-status-badge sprint-activo">ACTIVO</span>`;
     ejecutionHtml += `<div class="exec-subview">
       <div class="exec-subview-header">
-        <span class="exec-label">&#128640; Sprint${spDate ? ' (' + escHtml(spDate) + ')' : ''}</span>
-        <span class="exec-progress-badge">${sprintPct}%</span>
+        <span class="exec-label">&#128640; Sprint ${sprintLabelId} &#9656; ${sprintEstadoBadge}</span>
+        <span class="exec-progress-badge">${isFinalizado ? '&#10003; ' : ''}${sprintPct}%</span>
       </div>
       <div class="exec-bar"><div class="exec-bar-fill" style="width:${sprintPct}%;background:var(--gradient-green);"></div></div>
       <div class="exec-table">`;
@@ -1312,8 +1321,11 @@ function renderHTML(data, theme) {
     .exec-subview { margin-bottom: 12px; padding-bottom: 12px; border-bottom: 1px solid var(--border); }
     .exec-subview:last-child { border-bottom: none; margin-bottom: 0; padding-bottom: 0; }
     .exec-subview-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px; }
-    .exec-label { font-size: 12px; font-weight: 700; color: var(--white); }
+    .exec-label { font-size: 12px; font-weight: 700; color: var(--white); display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
     .exec-progress-badge { font-size: 13px; font-weight: 800; color: var(--green); }
+    .sprint-status-badge { font-size: 10px; font-weight: 700; padding: 2px 7px; border-radius: 100px; letter-spacing: 0.04em; }
+    .sprint-activo { background: var(--green-dim, rgba(34,197,94,0.15)); color: var(--green, #22c55e); }
+    .sprint-finalizado { background: var(--blue-dim, rgba(59,130,246,0.15)); color: var(--blue, #60a5fa); }
     .exec-bar { height: 6px; background: var(--surface3); border-radius: 3px; overflow: hidden; margin-bottom: 8px; }
     .exec-bar-fill { height: 100%; border-radius: 3px; transition: width 0.5s; }
     .exec-table { display: flex; flex-direction: column; gap: 4px; }

--- a/.claude/skills/monitor/SKILL.md
+++ b/.claude/skills/monitor/SKILL.md
@@ -53,7 +53,7 @@ Genera el dashboard con este formato (ajustando ancho a ~70 columnas):
 │   └─ ⚙ Compilando APK cliente con testTagsAsResourceId...         │
 │ 67eb3124 │ Claude 🤖      │  3 │ 5m   │ Bash: git diff…  │ ○    │
 ├─ EJECUCIÓN ───────────────────────────────────────────────────────┤
-│ Sprint (2026-03-06)        [████████░░ 75%]                       │
+│ Sprint SPR-013 ▸ ACTIVO   [████████░░ 75%]                        │
 │  #1  #821  notificaciones     S  ●                                 │
 │  #2  #845  refactor-login     M  ◐                                 │
 │ Historias en curso                                                 │
@@ -117,7 +117,10 @@ Genera el dashboard con este formato (ajustando ancho a ~70 columnas):
 Este panel unifica lo que antes eran "Sprint" y "Progreso del Sprint" en tres sub-vistas:
 
 1. **Sprint activo** (si `scripts/sprint-plan.json` existe):
-   - Titulo: `Sprint (fecha)` con barra de progreso global
+   - Titulo: `Sprint SPR-NNN ▸ ACTIVO` o `Sprint SPR-NNN ▸ FINALIZADO` (usando campos `sprint_id` y `estado`)
+   - Si `sprint_id` no existe en el JSON, fallback a mostrar la fecha
+   - Si `estado` es `"finalizado"`, mostrar indicador `FINALIZADO` prominente (no solo 100%)
+   - Si `estado` es `"activo"` o no está definido, mostrar `ACTIVO`
    - Cada fila: `#numero  #issue  slug  size  estado_icono`
    - El estado se determina cruzando issues del plan con sesiones activas (● activo, ◐ idle, ○ sin sesion, ✓ completado)
    - **Porcentaje global del sprint** (OBLIGATORIO — calcular siempre asi):
@@ -129,8 +132,9 @@ Este panel unifica lo que antes eran "Sprint" y "Progreso del Sprint" en tres su
      porcentaje  = total > 0 ? Math.round(completadas / total * 100) : 0
      ```
    - Retrocompatibilidad: si `_completed` no existe en el JSON, asumir `[]` (0 completadas)
-   - Formato de barra: `Sprint SPR-XXX: N/M (XX%) ████████░░ [N OK, 0 FAIL, M en progreso]`
+   - Formato de barra: `Sprint SPR-XXX ▸ ACTIVO: N/M (XX%) ████████░░` o `Sprint SPR-XXX ▸ FINALIZADO: M/M (100%) ✓`
    - Las historias en `_completed` cuentan como procesadas; mostrar `✓` en su fila
+   - Cuando el sprint está finalizado: barra al 100% + ✓ al final
 
 2. **Historias en curso** (issues en sprint con sesion activa, o sessions cuya branch tiene patron `agent/<N>-*`/`feature/<N>-*` fuera del sprint):
    - Mostrar como: `📌 agente  branch  progreso%  acciones`


### PR DESCRIPTION
## Resumen

- Mostrar sprint_id (SPR-NNN) en el header del dashboard Monitor en lugar de solo la fecha
- Indicador claro ACTIVO o FINALIZADO según el estado del sprint en sprint-plan.json
- CSS estilos para los badges de estado con colores distintivos
- Documentación SKILL.md actualizada con el nuevo formato

## Cambios

- `.claude/dashboard-server.js`: Lectura de campos `sprint_id` y `estado`, renderizado HTML con badges
- `.claude/skills/monitor/SKILL.md`: Documentación actualizada para reflejar el nuevo formato de sprint

## Plan de tests

- [x] Tests unitarios pasan (./gradlew check)
- [x] Build completo sin errores (./gradlew verifyNoLegacyStrings)
- [x] Code review: APROBADO
- [x] Security: APROBADO (XSS protegido con escHtml)

Closes #1355

🤖 Generado con [Claude Code](https://claude.com/claude-code)