### PR TITLE
fix(hooks): auto-aprobar LOW y MEDIUM en permission-gate.js

### DIFF
--- a/.claude/hooks/permission-gate.js
+++ b/.claude/hooks/permission-gate.js
@@ -428,28 +428,22 @@ async function processInput() {
     const severity = classifySeverity(toolName, toolInput, REPO_ROOT);
     log("SEVERITY: " + toolName + " → " + severity);
 
-    // AUTO_ALLOW: acción reversible en directorio seguro → aprobar sin Telegram
-    if (severity === Severity.AUTO_ALLOW) {
-        log("AUTO_ALLOW: " + toolName + " auto-aprobado (directorio seguro / tool interno)");
-        outputAllow("auto: " + toolName + " en directorio seguro");
+    // AUTO_ALLOW, LOW, MEDIUM: auto-aprobar inmediatamente sin Telegram
+    // HIGH sigue requiriendo aprobación manual vía Telegram
+    // git push a main sigue bloqueado por branch-guard.js independientemente
+    if (severity === Severity.AUTO_ALLOW || severity === Severity.LOW || severity === Severity.MEDIUM) {
+        const autoReason = severity === Severity.AUTO_ALLOW ? "AUTO_ALLOW (safe dir)"
+            : severity === Severity.LOW ? "LOW severity"
+            : "MEDIUM severity";
+        log("Auto-aprobando sin Telegram: " + toolName + " (" + autoReason + ")");
+        outputAllow("auto: " + toolName + " (" + autoReason + ")");
         return;
     }
 
-    // Ajustar retry intervals según severidad
-    const severityTimeouts = loadSeverityTimeouts();
-    let effectiveRetryIntervals;
-    if (severity === Severity.LOW) {
-        // LOW: un solo intento con timeout reducido, sin retry
-        effectiveRetryIntervals = [severityTimeouts.low * 60 * 1000];
-    } else if (severity === Severity.HIGH) {
-        // HIGH: usar los retry intervals configurados (flujo completo)
-        effectiveRetryIntervals = RETRY_INTERVALS;
-    } else {
-        // MEDIUM: flujo estándar
-        effectiveRetryIntervals = RETRY_INTERVALS;
-    }
+    // A partir de aquí solo llega HIGH → usar retry intervals completos
+    const effectiveRetryIntervals = RETRY_INTERVALS;
 
-    // ─── Necesita permiso → Enviar a Telegram ────────────────────────────────
+    // ─── HIGH: necesita permiso → Enviar a Telegram ──────────────────────────
     const action = formatAction(toolName, toolInput);
     const sessionId = data.session_id || "";
     const contextLine = formatContext(sessionId, MAIN_REPO_ROOT);


### PR DESCRIPTION
## Problema

El hook `permission-gate.js` (PreToolUse — hook activo) no auto-aprobaba severidades LOW y MEDIUM, causando que herramientas reversibles (Edit, Write, WebFetch, Skill, etc.) pidieran permiso a Telegram innecesariamente.

El auto-approve de LOW/MEDIUM se implementó en el PR #1302, pero **solo en `permission-approver.js`** — un archivo ya inactivo (PermissionRequest no disparaba confiablemente por bugs de Claude Code #12176, #29212).

## Impacto

- ❌ Toda ejecución de Edit/Write fuera de `.claude/` → pregunta Telegram
- ❌ Skill, WebFetch, WebSearch → preguntas innecesarias  
- ❌ Task/Agent (MEDIUM) → preguntas innecesarias
- ✅ HIGH (operaciones destructivas) → sigue pidiendo aprobación correctamente

## Solución

1. Replicar el fast-path de auto-aprobación de LOW+MEDIUM en `permission-gate.js` (líneas 434-441)
2. Limpiar código muerto de retry intervals para LOW/MEDIUM (nunca se alcanzaban)
3. Documentar que solo HIGH requiere aprobación manual

## Testing

Los hooks no tienen test E2E automatizado. Verificar:
- [ ] Edit en `.claude/hooks/` → auto-aprueba sin Telegram ✅ (AUTO_ALLOW)
- [ ] Edit en `src/main/kotlin/` → auto-aprueba sin Telegram ✅ (LOW → auto-approve)
- [ ] WebFetch → auto-aprueba sin Telegram ✅ (LOW)
- [ ] Bash con rm -rf → pide Telegram ✓ (HIGH → espera permiso)

🤖 Generado con [Claude Code](https://claude.com/claude-code)