### PR TITLE
feat(hooks): liberar slot de concurrencia cuando agente espera CI (#1356)

### DIFF
--- a/.claude/hooks/activity-logger.js
+++ b/.claude/hooks/activity-logger.js
@@ -276,6 +276,27 @@ function detectWaitingState(toolName, toolInput, ts) {
     return null;
 }
 
+// Sincroniza el estado waiting del agente en sprint-plan.json (#1356).
+// Solo actualiza el status — la promoción de cola la maneja post-git-push.js.
+// Es idempotente: si el agente ya está en waiting, no hace nada.
+function syncWaitingToSprintPlan(branch, reason) {
+    try {
+        const planPath = path.join(REPO_ROOT, "scripts", "sprint-plan.json");
+        if (!fs.existsSync(planPath)) return;
+        const plan = JSON.parse(fs.readFileSync(planPath, "utf8"));
+        if (!Array.isArray(plan.agentes)) return;
+        const agent = plan.agentes.find(ag =>
+            branch.includes("/" + String(ag.issue) + "-") ||
+            branch === "agent/" + ag.issue + "-" + (ag.slug || "")
+        );
+        if (!agent || agent.status === "waiting") return;
+        agent.status = "waiting";
+        agent.waiting_since = new Date().toISOString();
+        agent.waiting_reason = reason || "unknown";
+        fs.writeFileSync(planPath, JSON.stringify(plan, null, 2) + "\n", "utf8");
+    } catch(e) { /* no bloquear hook */ }
+}
+
 function updateSession(sessionId, ts, toolName, target, toolInput, usage) {
     try {
         if (!fs.existsSync(SESSIONS_DIR)) fs.mkdirSync(SESSIONS_DIR, { recursive: true });
@@ -442,7 +463,14 @@ function updateSession(sessionId, ts, toolName, target, toolInput, usage) {
         // Detectar y registrar estado de espera legítima
         const waitingState = detectWaitingState(toolName, toolInput, ts);
         if (waitingState) {
+            const wasAlreadyWaiting = !!session.waiting_state;
             session.waiting_state = waitingState;
+            // Si es la primera vez que entra en waiting, sincronizar sprint-plan.json (#1356)
+            // post-git-push.js ya maneja el caso "git push" con promoción de cola.
+            // Aquí cubrimos otros signals (gh pr create, /delivery) — solo actualizamos el estado.
+            if (!wasAlreadyWaiting && session.branch && session.branch.startsWith("agent/")) {
+                syncWaitingToSprintPlan(session.branch, waitingState.reason);
+            }
         } else if (session.waiting_state) {
             // Si hay actividad real (no Bash trivial) después de espera → limpiar
             const clearOnTools = ["Edit", "Write", "NotebookEdit", "TaskCreate"];

--- a/.claude/hooks/agent-concurrency-check.js
+++ b/.claude/hooks/agent-concurrency-check.js
@@ -1,11 +1,12 @@
-// agent-concurrency-check.js — Hook Stop: valida concurrencia de agentes y auto-lanza siguiente (#1277)
+// agent-concurrency-check.js — Hook Stop: valida concurrencia de agentes y auto-lanza siguiente (#1277, #1356)
 // Se ejecuta al finalizar cualquier sesión Claude.
 // Solo actúa si la sesión corresponde a un agente de sprint (rama agent/* en sprint-plan.json).
 //
 // Lógica:
 //   1. Detectar si la sesión que termina es de sprint
 //   2. Remover al agente que terminó del array agentes
-//   3. Comparar agentes activos restantes vs concurrency_limit
+//   3. Comparar agentes ACTIVOS (no-waiting) restantes vs concurrency_limit
+//      Los agentes en status="waiting" no cuentan contra el límite (#1356)
 //   4. Si hay espacio Y hay items en cola: mover primero de cola a agentes + lanzar
 //   5. Si se excede el límite: alerta crítica a Telegram
 //   6. Siempre: log detallado en hook-debug.log
@@ -398,7 +399,11 @@ async function processInput() {
             return;
         }
 
-        log("Agente que finaliza: #" + finishingAgent.issue + " (" + finishingAgent.slug + ")");
+        const wasWaiting = finishingAgent.status === "waiting";
+        log(
+            "Agente que finaliza: #" + finishingAgent.issue + " (" + finishingAgent.slug + ")" +
+            (wasWaiting ? " [estaba en waiting]" : "")
+        );
 
         // ── Construir entrada enriquecida para _completed ────────────────────
         const completedEntry = buildCompletedEntry(finishingAgent, session);
@@ -416,8 +421,15 @@ async function processInput() {
         // Remover al agente que terminó del array agentes
         const prevCount = (plan.agentes || []).length;
         plan.agentes = (plan.agentes || []).filter(ag => ag.issue !== finishingAgent.issue);
-        const afterCount = plan.agentes.length;
-        log("Agentes activos: " + prevCount + " → " + afterCount + " (límite: " + concurrencyLimit + ")");
+
+        // Contar solo agentes no-waiting: los waiting ya liberaron su slot al entrar en espera (#1356)
+        const afterCount = plan.agentes.filter(ag => ag.status !== "waiting").length;
+        const waitingCount = plan.agentes.filter(ag => ag.status === "waiting").length;
+        log(
+            "Agentes activos (no-waiting): " + afterCount + "/" + concurrencyLimit +
+            (waitingCount > 0 ? " (+ " + waitingCount + " en waiting)" : "") +
+            (wasWaiting ? " — terminó desde estado waiting (slot ya estaba liberado)" : "")
+        );
 
         // Bug 3: Agregar agente completado a _completed para mantener historial del sprint (#1345)
         // Antes: el agente se removía de `agentes` sin dejar rastro de que completó
@@ -439,7 +451,7 @@ async function processInput() {
                 "Agente que terminó: #" + finishingAgent.issue + " (" + escHtml(finishingAgent.slug) + ")\n" +
                 "Revisar sprint-plan.json manualmente."
             );
-            log("ANOMALIA: " + afterCount + " agentes > límite " + concurrencyLimit);
+            log("ANOMALIA: " + afterCount + " agentes no-waiting > límite " + concurrencyLimit);
             savePlan(plan);
             await notify(alertMsg);
             return;
@@ -464,14 +476,16 @@ async function processInput() {
             // Lanzar el agente
             const launched = launchAgent(nextAgente);
 
-            const slotsOccupied = plan.agentes.length;
+            const slotsOccupied = plan.agentes.filter(ag => ag.status !== "waiting").length;
             const remainingQueue = newQueue.length;
+            const stillWaiting = plan.agentes.filter(ag => ag.status === "waiting").length;
+            const waitingSuffix = stillWaiting > 0 ? " (+ " + stillWaiting + " en waiting)" : "";
 
             const msg = launched
                 ? (
                     "🚀 <b>Auto-lanzado agente para #" + nextAgente.issue + "</b>\n" +
                     "Slug: " + escHtml(nextAgente.slug) + "\n" +
-                    "Slots activos: <b>" + slotsOccupied + "/" + concurrencyLimit + "</b>\n" +
+                    "Slots activos: <b>" + slotsOccupied + "/" + concurrencyLimit + "</b>" + waitingSuffix + "\n" +
                     "Cola restante: " + remainingQueue + " issue(s)\n" +
                     "<i>Agente finalizado: #" + finishingAgent.issue + " (" + escHtml(finishingAgent.slug) + ")</i>"
                 )
@@ -479,7 +493,7 @@ async function processInput() {
                     "⚠️ <b>Cola: issue #" + nextAgente.issue + " movido pero no pudo lanzarse</b>\n" +
                     "Start-Agente.ps1 no disponible o falló. Lanzar manualmente:\n" +
                     "<code>.\\Start-Agente.ps1 " + nextAgente.numero + "</code>\n" +
-                    "Slots activos: " + slotsOccupied + "/" + concurrencyLimit
+                    "Slots activos: " + slotsOccupied + "/" + concurrencyLimit + waitingSuffix
                 );
 
             await notify(msg);

--- a/.claude/hooks/post-git-push.js
+++ b/.claude/hooks/post-git-push.js
@@ -1,11 +1,122 @@
 // Hook PostToolUse[Bash]: detecta git push y lanza monitoreo CI en background
 // Pure Node.js — sin dependencia de bash ni ci-monitor.sh
 // Polling: consulta GitHub Actions cada 30s hasta que el workflow concluya, luego notifica via Telegram
+// #1356: al detectar git push, marca el agente como "waiting" en sprint-plan.json y promueve siguiente de cola
 const { execSync, spawn } = require("child_process");
 const path = require("path");
 const fs = require("fs");
 
 const PROJECT_DIR = process.env.CLAUDE_PROJECT_DIR || "C:\\Workspaces\\Intrale\\platform";
+const HOOKS_DIR = path.join(PROJECT_DIR, ".claude", "hooks");
+const LOG_FILE = path.join(HOOKS_DIR, "hook-debug.log");
+const PLAN_FILE = path.join(PROJECT_DIR, "scripts", "sprint-plan.json");
+const START_SCRIPT = path.join(PROJECT_DIR, "scripts", "Start-Agente.ps1");
+
+function logHook(msg) {
+    try { fs.appendFileSync(LOG_FILE, "[" + new Date().toISOString() + "] PostGitPush: " + msg + "\n"); } catch(e) {}
+}
+
+function escHtml(str) {
+    return (str || "").replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+async function notifyTelegram(text) {
+    try {
+        const cfg = JSON.parse(fs.readFileSync(path.join(HOOKS_DIR, "telegram-config.json"), "utf8"));
+        const https = require("https");
+        const querystring = require("querystring");
+        const postData = querystring.stringify({ chat_id: cfg.chat_id, text: text, parse_mode: "HTML" });
+        await new Promise((resolve) => {
+            const req = https.request({
+                hostname: "api.telegram.org",
+                path: "/bot" + cfg.bot_token + "/sendMessage",
+                method: "POST",
+                headers: { "Content-Type": "application/x-www-form-urlencoded" },
+                timeout: 6000
+            }, (res) => { res.resume(); resolve(); });
+            req.on("error", resolve);
+            req.on("timeout", () => { req.destroy(); resolve(); });
+            req.write(postData);
+            req.end();
+        });
+    } catch(e) { logHook("notifyTelegram error: " + e.message); }
+}
+
+function launchAgentFromPlan(agente) {
+    try {
+        if (!fs.existsSync(START_SCRIPT)) { logHook("Start-Agente.ps1 no encontrado"); return false; }
+        const ps1 = START_SCRIPT.replace(/\//g, "\\");
+        const child = spawn("powershell.exe", ["-NonInteractive", "-File", ps1, String(agente.numero)], {
+            detached: true, stdio: "ignore", windowsHide: false
+        });
+        child.unref();
+        logHook("Agente " + agente.numero + " (issue #" + agente.issue + ") lanzado desde cola (PID " + child.pid + ")");
+        return true;
+    } catch(e) { logHook("launchAgentFromPlan error: " + e.message); return false; }
+}
+
+// Marca el agente como "waiting" en sprint-plan.json y promueve el siguiente de la cola (#1356)
+async function markAgentWaitingInPlan(branch) {
+    if (!fs.existsSync(PLAN_FILE)) return;
+    let plan;
+    try { plan = JSON.parse(fs.readFileSync(PLAN_FILE, "utf8")); } catch(e) { return; }
+    if (!Array.isArray(plan.agentes)) return;
+
+    // Encontrar el agente por branch
+    const agent = plan.agentes.find(ag =>
+        branch.includes("/" + String(ag.issue) + "-") ||
+        branch === "agent/" + ag.issue + "-" + (ag.slug || "")
+    );
+    if (!agent) { logHook("markAgentWaitingInPlan: sin coincidencia para branch " + branch); return; }
+    if (agent.status === "waiting") { logHook("Agente #" + agent.issue + " ya está en waiting — sin cambios"); return; }
+
+    // Marcar como waiting
+    agent.status = "waiting";
+    agent.waiting_since = new Date().toISOString();
+    agent.waiting_reason = "ci";
+
+    const concurrencyLimit = plan.concurrency_limit || 3;
+    // Contar solo agentes activos (no-waiting): este agente ahora libera su slot
+    const activeCount = plan.agentes.filter(ag => ag.status !== "waiting").length;
+    const queue = Array.isArray(plan._queue) ? plan._queue : (Array.isArray(plan.cola) ? plan.cola : []);
+
+    logHook("Agente #" + agent.issue + " en waiting (CI) — activos no-waiting: " + activeCount + "/" + concurrencyLimit + " — cola: " + queue.length);
+
+    if (activeCount < concurrencyLimit && queue.length > 0) {
+        // Promover siguiente de la cola
+        const nextAgent = queue[0];
+        const newQueue = queue.slice(1);
+        const maxNumero = plan.agentes.reduce((m, ag) => Math.max(m, ag.numero || 0), 0);
+        nextAgent.numero = maxNumero + 1;
+        plan.agentes.push(nextAgent);
+        if (Array.isArray(plan._queue)) plan._queue = newQueue;
+        else plan.cola = newQueue;
+
+        fs.writeFileSync(PLAN_FILE, JSON.stringify(plan, null, 2) + "\n", "utf8");
+        logHook("Agente #" + agent.issue + " en waiting (CI) — slot liberado, promoviendo #" + nextAgent.issue + " de cola");
+
+        const launched = launchAgentFromPlan(nextAgent);
+        const waitingTotal = plan.agentes.filter(ag => ag.status === "waiting").length;
+        const activeNow = plan.agentes.filter(ag => ag.status !== "waiting").length;
+
+        await notifyTelegram(
+            "⏳ <b>Slot liberado — Agente #" + agent.issue + " en espera de CI</b>\n" +
+            (launched
+                ? "🚀 Promovido #" + nextAgent.issue + " (" + escHtml(nextAgent.slug || "") + ") de la cola\n"
+                : "⚠️ Issue #" + nextAgent.issue + " movido a agentes pero sin lanzar automáticamente\n") +
+            "Slots activos: <b>" + activeNow + "/" + concurrencyLimit + "</b>" +
+            (waitingTotal > 0 ? " (+ " + waitingTotal + " en waiting)" : "") + "\n" +
+            "Cola restante: " + newQueue.length + " issue(s)"
+        );
+    } else {
+        fs.writeFileSync(PLAN_FILE, JSON.stringify(plan, null, 2) + "\n", "utf8");
+        if (queue.length === 0) {
+            logHook("Agente #" + agent.issue + " en waiting (CI) — cola vacía, sin promoción");
+        } else {
+            logHook("Agente #" + agent.issue + " en waiting (CI) — slots llenos (" + activeCount + "/" + concurrencyLimit + "), sin promoción");
+        }
+    }
+}
 
 // Leer stdin
 const MAX_READ = 4096;
@@ -60,7 +171,7 @@ function markWaitingCi(branch, sha) {
     return null;
 }
 
-function handleInput() {
+async function handleInput() {
     try {
         const data = JSON.parse(input || "{}");
         const command = (data.tool_input && data.tool_input.command) || "";
@@ -80,6 +191,11 @@ function handleInput() {
 
         // Marcar inicio de espera de CI en la session activa
         const sessionFile = markWaitingCi(branch, sha);
+
+        // Marcar agente como waiting en sprint-plan.json y promover siguiente de cola (#1356)
+        if (branch.startsWith("agent/")) {
+            await markAgentWaitingInPlan(branch);
+        }
 
         // Lanzar monitoreo CI en background (proceso hijo desacoplado)
         const monitorScript = path.join(__dirname, "ci-monitor-bg.js");

--- a/.claude/hooks/tests/test-p22-concurrency-check.js
+++ b/.claude/hooks/tests/test-p22-concurrency-check.js
@@ -201,6 +201,125 @@ describe("P-22: agent-concurrency-check — lógica de concurrencia", () => {
         );
         assert.ok(source.includes("stop_hook_active"), "debe verificar stop_hook_active para evitar recursión");
     });
+
+    // ─── Tests #1356: estado waiting ─────────────────────────────────────────
+
+    it("#1356: hook excluye agentes en waiting del conteo de slots activos", () => {
+        const source = fs.readFileSync(
+            path.join(__dirname, "..", "agent-concurrency-check.js"),
+            "utf8"
+        );
+        assert.ok(
+            source.includes('ag.status !== "waiting"'),
+            "debe filtrar agentes waiting al contar slots activos"
+        );
+        assert.ok(
+            source.includes("afterCount = plan.agentes.filter"),
+            "afterCount debe calcularse filtrando waiting"
+        );
+    });
+
+    it("#1356: hook detecta si el agente que termina estaba en waiting", () => {
+        const source = fs.readFileSync(
+            path.join(__dirname, "..", "agent-concurrency-check.js"),
+            "utf8"
+        );
+        assert.ok(
+            source.includes('finishingAgent.status === "waiting"'),
+            "debe detectar si el agente que termina estaba en waiting"
+        );
+        assert.ok(
+            source.includes("wasWaiting"),
+            "debe usar variable wasWaiting para tracking del estado"
+        );
+    });
+
+    it("#1356: post-git-push.js tiene función markAgentWaitingInPlan", () => {
+        const source = fs.readFileSync(
+            path.join(__dirname, "..", "post-git-push.js"),
+            "utf8"
+        );
+        assert.ok(source.includes("markAgentWaitingInPlan"), "debe tener función markAgentWaitingInPlan");
+        assert.ok(source.includes('status = "waiting"'), "debe marcar status=waiting en el agente");
+        assert.ok(source.includes("waiting_since"), "debe registrar waiting_since timestamp");
+        assert.ok(source.includes("waiting_reason"), "debe registrar waiting_reason");
+    });
+
+    it("#1356: post-git-push.js promueve siguiente de cola al liberar slot", () => {
+        const source = fs.readFileSync(
+            path.join(__dirname, "..", "post-git-push.js"),
+            "utf8"
+        );
+        assert.ok(
+            source.includes("activeCount < concurrencyLimit"),
+            "debe verificar si hay espacio para promover de cola"
+        );
+        assert.ok(source.includes("launchAgentFromPlan"), "debe lanzar el agente promovido");
+        assert.ok(
+            source.includes("slot liberado, promoviendo"),
+            "debe loguear el mensaje de liberación de slot"
+        );
+    });
+
+    it("#1356: post-git-push.js notifica Telegram al liberar slot", () => {
+        const source = fs.readFileSync(
+            path.join(__dirname, "..", "post-git-push.js"),
+            "utf8"
+        );
+        assert.ok(source.includes("notifyTelegram"), "debe notificar a Telegram");
+        assert.ok(source.includes("Slot liberado"), "debe mencionar 'Slot liberado' en la notificación");
+        assert.ok(source.includes("en espera de CI"), "debe indicar que el agente espera CI");
+    });
+
+    it("#1356: post-git-push.js solo actúa en ramas agent/*", () => {
+        const source = fs.readFileSync(
+            path.join(__dirname, "..", "post-git-push.js"),
+            "utf8"
+        );
+        assert.ok(
+            source.includes('branch.startsWith("agent/")'),
+            "debe validar que la rama es agent/* antes de marcar waiting"
+        );
+    });
+
+    it("#1356: activity-logger.js tiene función syncWaitingToSprintPlan", () => {
+        const source = fs.readFileSync(
+            path.join(__dirname, "..", "activity-logger.js"),
+            "utf8"
+        );
+        assert.ok(source.includes("syncWaitingToSprintPlan"), "debe tener función syncWaitingToSprintPlan");
+        assert.ok(
+            source.includes('agent.status === "waiting"'),
+            "syncWaitingToSprintPlan debe ser idempotente (verificar si ya es waiting)"
+        );
+    });
+
+    it("#1356: activity-logger.js sincroniza waiting al detectar por primera vez", () => {
+        const source = fs.readFileSync(
+            path.join(__dirname, "..", "activity-logger.js"),
+            "utf8"
+        );
+        assert.ok(source.includes("wasAlreadyWaiting"), "debe detectar primera vez con wasAlreadyWaiting");
+        assert.ok(
+            source.includes("syncWaitingToSprintPlan(session.branch"),
+            "debe llamar syncWaitingToSprintPlan cuando es primera vez en waiting"
+        );
+    });
+
+    it("#1356: log incluye conteo de agentes en waiting junto con activos", () => {
+        const source = fs.readFileSync(
+            path.join(__dirname, "..", "agent-concurrency-check.js"),
+            "utf8"
+        );
+        assert.ok(
+            source.includes("en waiting"),
+            "debe mostrar agentes en waiting en los logs"
+        );
+        assert.ok(
+            source.includes("waitingCount"),
+            "debe calcular waitingCount separado de afterCount"
+        );
+    });
 });
 
 // ─── Tests para Bug 1345: 4 bugs de concurrencia ────────────────────────────


### PR DESCRIPTION
## Resumen

Implementar estado 'waiting' en sprint-plan.json para agentes esperando CI/PR/merge.

Los agentes en estado `waiting` no cuentan contra el límite de concurrencia, liberando slots para que otros agentes de la cola avancen automáticamente.

## Cambios

- **agent-concurrency-check.js**: Filtrar agentes `status !== "waiting"` al contar slots activos. Detectar si el agente que finaliza estaba en waiting. Agregar log de `waitingCount`.

- **post-git-push.js**: Nueva función `markAgentWaitingInPlan(branch)` que marca agente como waiting en CI, verifica si hay espacio para promover siguiente de cola, lanza automáticamente con PowerShell, notifica Telegram.

- **activity-logger.js**: Nueva función `syncWaitingToSprintPlan(branch, reason)` que sincroniza estado waiting desde actividad de sesión para casos de PR/delivery.

- **test-p22-concurrency-check.js**: 9 nuevos tests para cobertura de #1356 (conteo no-waiting, wasWaiting, marcado waiting, promoción de cola, notificaciones, restricción a agent/*, sincronización, log con waitingCount).

## Plan de tests

- [x] Tests unitarios pasan (26/26 en test-p22)
- [x] Build completo sin errores (BUILD SUCCESSFUL)
- [x] Security scan aprobado (0 críticos, 0 altos)
- [x] Code review aprobado (0 bloqueantes)

Closes #1356

🤖 Generado con [Claude Code](https://claude.ai/claude-code)