### PR TITLE
fix(hooks): ops reset rompe telegram-commander por pending-questions.json vacío

### DIFF
--- a/.claude/hooks/pending-questions.js
+++ b/.claude/hooks/pending-questions.js
@@ -33,7 +33,9 @@ function loadQuestions() {
         try {
             const raw = fs.readFileSync(PENDING_FILE, "utf8");
             if (!raw || !raw.trim()) return { questions: [] };
-            return JSON.parse(raw);
+            const parsed = JSON.parse(raw);
+            if (!parsed || !Array.isArray(parsed.questions)) return { questions: [] };
+            return parsed;
         } catch (e) {
             // Si es JSON corrupto (race condition con escritura concurrente), reintentar
             if (e instanceof SyntaxError && attempt < LOAD_RETRY_COUNT - 1) {

--- a/scripts/restart-operational-system.js
+++ b/scripts/restart-operational-system.js
@@ -21,6 +21,10 @@ const CONFIG_FILE = path.join(HOOKS_DIR, "telegram-config.json");
 const RESTART_LOG_FILE = path.join(HOOKS_DIR, "restart-log.jsonl");
 
 // State files a resetear (a JSON vacío {})
+// Algunos archivos requieren estructura específica (no solo {})
+const STATE_FILE_DEFAULTS = {
+    "pending-questions.json": '{"questions":[]}\n',
+};
 const STATE_FILES_TO_RESET = [
     "activity-logger-last.json",
     "health-check-state.json",
@@ -129,7 +133,8 @@ function resetStateFiles() {
                 const stat = fs.statSync(filePath);
                 previousSize = stat.size;
             }
-            fs.writeFileSync(filePath, "{}\n", "utf8");
+            const defaultContent = STATE_FILE_DEFAULTS[fileName] || "{}\n";
+            fs.writeFileSync(filePath, defaultContent, "utf8");
             results.push({ file: fileName, status: "reset", existed, previousSize });
         } catch (e) {
             results.push({ file: fileName, status: "error", error: e.message });


### PR DESCRIPTION
## Summary
- `restart-operational-system.js` reseteaba `pending-questions.json` a `{}` pero `getPendingQuestions()` espera `{questions:[]}`
- Esto causaba: `Cannot read properties of undefined (reading 'filter')` al enviar cualquier mensaje por Telegram
- Fix defensivo en `loadQuestions()` + default correcto en el script de reset

## Test plan
- [x] Enviar mensaje por Telegram después de `/ops reset` → sin error
- [x] `pending-questions.json` se resetea con estructura válida

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>