### PR TITLE
fix(hooks): health-check defensivo y commander resiliente a errores aislados

### DIFF
--- a/.claude/hooks/health-check.js
+++ b/.claude/hooks/health-check.js
@@ -730,7 +730,7 @@ async function main() {
     if (shouldRunCheck(componentState, "worktrees", now)) {
         checks.worktrees = checkDeadWorktrees();
     } else {
-        checks.worktrees = { ok: true, dead: [] };
+        checks.worktrees = { ok: true, dead: [], cleaned: [], strategies: {} };
     }
 
     // P-07: Actualizar estado por componente
@@ -742,15 +742,15 @@ async function main() {
     saveComponentState(componentState);
 
     const checkDetails = {
-        commander: checks.commander.detail,
-        approvers: checks.approvers.detail,
-        telegram: checks.telegram.detail,
-        settings: checks.settings.details.join(", "),
-        hooks: checks.hooks.missing.length > 0 ? "Faltantes: " + checks.hooks.missing.join(", ") : "Todos presentes",
-        worktrees: checks.worktrees.dead.length > 0
+        commander: checks.commander.detail || "",
+        approvers: checks.approvers.detail || "",
+        telegram: checks.telegram.detail || "",
+        settings: (checks.settings.details || []).join(", "),
+        hooks: (checks.hooks.missing || []).length > 0 ? "Faltantes: " + checks.hooks.missing.join(", ") : "Todos presentes",
+        worktrees: (checks.worktrees.dead || []).length > 0
             ? checks.worktrees.dead.length + " muertos [" + checks.worktrees.dead.join(", ") + "]"
-                + (checks.worktrees.cleaned.length > 0 ? " (" + checks.worktrees.cleaned.length + " limpiados)" : "")
-            : checks.worktrees.cleaned.length > 0
+                + ((checks.worktrees.cleaned || []).length > 0 ? " (" + checks.worktrees.cleaned.length + " limpiados)" : "")
+            : (checks.worktrees.cleaned || []).length > 0
                 ? checks.worktrees.cleaned.length + " limpiados ✅"
                     + (Object.keys(checks.worktrees.strategies || {}).length > 0
                         ? " (" + Object.values(checks.worktrees.strategies).join(", ") + ")"
@@ -798,8 +798,8 @@ async function main() {
     if (!checks.approvers.ok) rawIssues.push({ msg: "🟡 Approvers: " + checks.approvers.detail, check: "approvers" });
     if (!checks.telegram.ok) rawIssues.push({ msg: "🔴 Telegram Bot: " + checks.telegram.detail, check: "telegram" });
     if (!checks.settings.ok) rawIssues.push({ msg: "🔴 Settings: " + checks.settings.details.join(", "), check: "settings" });
-    if (!checks.hooks.ok) rawIssues.push({ msg: "🔴 Hooks faltantes: " + checks.hooks.missing.join(", "), check: "hooks" });
-    if (!checks.worktrees.ok) rawIssues.push({ msg: "🟡 Worktrees muertos: " + checks.worktrees.dead.length, check: "worktrees" });
+    if (!checks.hooks.ok) rawIssues.push({ msg: "🔴 Hooks faltantes: " + (checks.hooks.missing || []).join(", "), check: "hooks" });
+    if (!checks.worktrees.ok) rawIssues.push({ msg: "🟡 Worktrees muertos: " + (checks.worktrees.dead || []).length, check: "worktrees" });
 
     for (const ri of rawIssues) {
         const results = allResults[ri.check] || [];
@@ -886,4 +886,4 @@ async function main() {
     }
 }
 
-main().catch(e => log("Error en health-check: " + e.message));
+main().catch(e => log("Error en health-check: " + e.message + (e.stack ? "\n" + e.stack : "")));

--- a/.claude/hooks/telegram-commander.js
+++ b/.claude/hooks/telegram-commander.js
@@ -3357,16 +3357,33 @@ async function shutdown(signal) {
 process.on("SIGINT", () => shutdown("SIGINT"));
 process.on("SIGTERM", () => shutdown("SIGTERM"));
 
-// Capturar errores no manejados para limpiar lockfile siempre
+// Capturar errores no manejados — tolerar errores aislados, crash solo si son persistentes
+let _uncaughtErrorCount = 0;
+const UNCAUGHT_THRESHOLD = 3;
+const UNCAUGHT_RESET_MS = 60000;
+let _uncaughtResetTimer = null;
+
 process.on("uncaughtException", (e) => {
-    log("uncaughtException: " + e.message);
-    releaseLock();
-    process.exit(1);
+    _uncaughtErrorCount++;
+    log("uncaughtException (" + _uncaughtErrorCount + "/" + UNCAUGHT_THRESHOLD + "): " + e.message + (e.stack ? "\n" + e.stack : ""));
+    if (_uncaughtErrorCount >= UNCAUGHT_THRESHOLD) {
+        log("Demasiados errores no manejados — cerrando commander");
+        releaseLock();
+        process.exit(1);
+    }
+    clearTimeout(_uncaughtResetTimer);
+    _uncaughtResetTimer = setTimeout(() => { _uncaughtErrorCount = 0; }, UNCAUGHT_RESET_MS);
 });
 process.on("unhandledRejection", (reason) => {
-    log("unhandledRejection: " + String(reason));
-    releaseLock();
-    process.exit(1);
+    _uncaughtErrorCount++;
+    log("unhandledRejection (" + _uncaughtErrorCount + "/" + UNCAUGHT_THRESHOLD + "): " + String(reason));
+    if (_uncaughtErrorCount >= UNCAUGHT_THRESHOLD) {
+        log("Demasiados rejections no manejadas — cerrando commander");
+        releaseLock();
+        process.exit(1);
+    }
+    clearTimeout(_uncaughtResetTimer);
+    _uncaughtResetTimer = setTimeout(() => { _uncaughtErrorCount = 0; }, UNCAUGHT_RESET_MS);
 });
 
 // ─── Main ────────────────────────────────────────────────────────────────────

--- a/scripts/restart-operational-system.js
+++ b/scripts/restart-operational-system.js
@@ -24,6 +24,8 @@ const RESTART_LOG_FILE = path.join(HOOKS_DIR, "restart-log.jsonl");
 // Algunos archivos requieren estructura específica (no solo {})
 const STATE_FILE_DEFAULTS = {
     "pending-questions.json": '{"questions":[]}\n',
+    "health-check-history.json": '{"problems":[]}\n',
+    "telegram-messages.json": '{"messages":[]}\n',
 };
 const STATE_FILES_TO_RESET = [
     "activity-logger-last.json",


### PR DESCRIPTION
## Summary
- **health-check.js**: guards defensivos `(|| [])` en todos los accesos `.length` para evitar crash cuando state files están vacíos tras ops reset. Agrega `cleaned`/`strategies` al default de worktrees skip. Stack trace completo en catch.
- **telegram-commander.js**: `uncaughtException`/`unhandledRejection` ahora toleran hasta 3 errores en 60s antes de crashear (antes el primer error aislado mataba todo el commander).
- **restart-operational-system.js**: defaults correctos para `health-check-history.json` (`{problems:[]}`) y `telegram-messages.json` (`{messages:[]}`).

## Context
Tras un `/ops reset`, todos los state files se resetean a `{}`. Esto causaba:
1. health-check.js crasheaba con `Cannot read properties of undefined (reading 'length')` en cada invocación
2. El crash repetido (sin cooldown porque el state nunca se escribía) generaba ruido masivo en logs
3. Un solo error no manejado crasheaba el commander completo vía `process.exit(1)`

## Test plan
- [x] Tests P-07 health-backoff pasan (8/8)
- [x] Tests pre-existentes no afectados
- [ ] Ejecutar `/ops reset` y verificar que no hay crashes en health-check
- [ ] Verificar que commander sobrevive errores aislados sin crashear

🤖 Generated with [Claude Code](https://claude.com/claude-code)