### PR TITLE
feat(ux): mejorar flujo password recovery — email pre-cargado, teclado numérico, reenviar código

### DIFF
--- a/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/catalog/DefaultCatalog_en.kt
+++ b/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/catalog/DefaultCatalog_en.kt
@@ -336,6 +336,7 @@ internal val DefaultCatalog_en: Map<MessageKey, String> = mapOf(
     MessageKey.password_recovery_send_code to "Send code",
     MessageKey.password_recovery_have_code to "I already have a recovery code",
     MessageKey.password_recovery_email_sent to "We sent you an email with instructions to continue",
+    MessageKey.password_recovery_resend_code to "Resend code",
     MessageKey.business to "Business",
     MessageKey.request_join_business to "Request to join",
     MessageKey.request_join_business_sent to "Request sent",

--- a/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/catalog/DefaultCatalog_es.kt
+++ b/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/catalog/DefaultCatalog_es.kt
@@ -336,6 +336,7 @@ internal val DefaultCatalog_es: Map<MessageKey, String> = mapOf(
     MessageKey.password_recovery_send_code to "Enviar codigo",
     MessageKey.password_recovery_have_code to "Ya tengo un código de recuperación",
     MessageKey.password_recovery_email_sent to "Te enviamos un correo con las instrucciones para continuar",
+    MessageKey.password_recovery_resend_code to "Reenviar codigo",
     MessageKey.business to "Negocio",
     MessageKey.request_join_business to "Solicitar unión",
     MessageKey.request_join_business_sent to "Solicitud enviada",

--- a/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/model/MessageKey.kt
+++ b/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/model/MessageKey.kt
@@ -339,6 +339,7 @@ enum class MessageKey {
     password_recovery_send_code,
     password_recovery_have_code,
     password_recovery_email_sent,
+    password_recovery_resend_code,
     business,
     request_join_business,
     request_join_business_sent,

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/auth/ConfirmPasswordRecoveryScreen.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/auth/ConfirmPasswordRecoveryScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -68,6 +69,7 @@ class ConfirmPasswordRecoveryScreen : Screen(CONFIRM_PASSWORD_RECOVERY_PATH) {
         val genericErrorMessage = Txt(MessageKey.error_generic)
         val userIconDescription = Txt(MessageKey.login_user_icon_content_description)
         val passwordIconDescription = Txt(MessageKey.login_password_icon_content_description)
+        val resendCodeText = Txt(MessageKey.password_recovery_resend_code)
 
         val submitForm: () -> Unit = {
             focusManager.clearFocus()
@@ -155,7 +157,7 @@ class ConfirmPasswordRecoveryScreen : Screen(CONFIRM_PASSWORD_RECOVERY_PATH) {
                                 imeAction = ImeAction.Next
                             ),
                             keyboardActions = KeyboardActions(onNext = { focusManager.moveFocus(FocusDirection.Down) }),
-                            enabled = !viewModel.loading
+                            enabled = false
                         )
 
                         TextField(
@@ -171,6 +173,7 @@ class ConfirmPasswordRecoveryScreen : Screen(CONFIRM_PASSWORD_RECOVERY_PATH) {
                                 )
                             },
                             keyboardOptions = KeyboardOptions.Default.copy(
+                                keyboardType = KeyboardType.NumberPassword,
                                 imeAction = ImeAction.Next
                             ),
                             keyboardActions = KeyboardActions(onNext = { focusManager.moveFocus(FocusDirection.Down) }),
@@ -217,6 +220,13 @@ class ConfirmPasswordRecoveryScreen : Screen(CONFIRM_PASSWORD_RECOVERY_PATH) {
                     enabled = !viewModel.loading,
                     onClick = submitForm
                 )
+
+                TextButton(
+                    onClick = { navigate(PASSWORD_RECOVERY_PATH) },
+                    enabled = !viewModel.loading
+                ) {
+                    Text(text = resendCodeText)
+                }
             }
         }
     }

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/auth/ConfirmPasswordRecoveryViewModel.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/auth/ConfirmPasswordRecoveryViewModel.kt
@@ -23,7 +23,9 @@ class ConfirmPasswordRecoveryViewModel(
 ) : ViewModel() {
     private val logger = loggerFactory.newLogger<ConfirmPasswordRecoveryViewModel>()
 
-    var state by mutableStateOf(ConfirmPasswordRecoveryUIState())
+    var state by mutableStateOf(
+        ConfirmPasswordRecoveryUIState(email = PasswordRecoveryArgs.email.also { PasswordRecoveryArgs.email = "" })
+    )
     var loading by mutableStateOf(false)
 
     data class ConfirmPasswordRecoveryUIState(

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/auth/PasswordRecoveryArgs.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/auth/PasswordRecoveryArgs.kt
@@ -1,0 +1,9 @@
+package ui.sc.auth
+
+/**
+ * Almacena argumentos de navegación entre PasswordRecoveryScreen y ConfirmPasswordRecoveryScreen.
+ * Se limpia automáticamente al leer el email en ConfirmPasswordRecoveryViewModel.
+ */
+object PasswordRecoveryArgs {
+    var email: String = ""
+}

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/auth/PasswordRecoveryScreen.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/auth/PasswordRecoveryScreen.kt
@@ -152,6 +152,7 @@ class PasswordRecoveryScreen : Screen(PASSWORD_RECOVERY_PATH) {
                                     coroutine.launch {
                                         snackbarHostState.showSnackbar(passwordRecoverySuccessMessage)
                                     }
+                                    PasswordRecoveryArgs.email = viewModel.state.email
                                     navigate(CONFIRM_PASSWORD_RECOVERY_PATH)
                                 },
                                 onError = { error ->

--- a/app/composeApp/src/commonTest/kotlin/ui/sc/auth/AuthViewModelsTest.kt
+++ b/app/composeApp/src/commonTest/kotlin/ui/sc/auth/AuthViewModelsTest.kt
@@ -343,6 +343,21 @@ class ConfirmPasswordRecoveryViewModelTest {
         assertFalse(confirmState.isValid)
         assertEquals(resolveMessage(MessageKey.form_error_passwords_mismatch), confirmState.details)
     }
+
+    @Test
+    fun `email se precarga desde PasswordRecoveryArgs al inicializar`() {
+        PasswordRecoveryArgs.email = "prefilled@test.com"
+        val vm = ConfirmPasswordRecoveryViewModel(FakeConfirmPasswordRecovery(), testLoggerFactory)
+        assertEquals("prefilled@test.com", vm.state.email)
+        assertEquals("", PasswordRecoveryArgs.email)
+    }
+
+    @Test
+    fun `PasswordRecoveryArgs se limpia al crear el ViewModel`() {
+        PasswordRecoveryArgs.email = "otro@test.com"
+        ConfirmPasswordRecoveryViewModel(FakeConfirmPasswordRecovery(), testLoggerFactory)
+        assertEquals("", PasswordRecoveryArgs.email)
+    }
 }
 
 // endregion


### PR DESCRIPTION
## Resumen

Mejora de UX del flujo de recuperación de contraseña (issue #1144). Resuelve 3 friction points detectados en auditoría UX:

### FP-1: Email pre-cargado (heurística #6 — Reconocimiento > recuerdo)
- Email escrito en PasswordRecoveryScreen se pasa automáticamente a ConfirmPasswordRecoveryScreen
- Campo email es read-only (`enabled = false`)
- Se usa singleton temporal `PasswordRecoveryArgs` que se auto-limpia

### FP-2: Teclado numérico (heurística #5 — Prevención de errores)
- Campo "código" en ConfirmPasswordRecoveryScreen ahora usa `KeyboardType.NumberPassword`
- Cognito envía código de 6 dígitos → teclado numérico evita errores de tipeo

### FP-3: Botón reenviar código (heurística #3 — Control y libertad)
- Nuevo `TextButton` "Reenviar código" visible en ConfirmPasswordRecoveryScreen
- Navega de vuelta a PasswordRecoveryScreen sin perder contexto

## Archivos modificados

- `MessageKey.kt` — +1 enum: `password_recovery_resend_code`
- `DefaultCatalog_es.kt` — +1 string: "Reenviar codigo"
- `DefaultCatalog_en.kt` — +1 string: "Resend code"
- `PasswordRecoveryScreen.kt` — Pasar email a `PasswordRecoveryArgs` antes de navegar
- `ConfirmPasswordRecoveryScreen.kt` — Email read-only, teclado numérico, botón reenviar
- `ConfirmPasswordRecoveryViewModel.kt` — Pre-cargar email desde `PasswordRecoveryArgs`
- `PasswordRecoveryArgs.kt` (NEW) — Singleton temporal para navegación sin Nav args
- `AuthViewModelsTest.kt` — +2 tests para validar pre-carga de email

## Validación

- ✅ **Build**: exitoso (`assemble` sin errores)
- ✅ **Tests**: todos pasan (client flavor, users, verifyNoLegacyStrings)
- ✅ **Seguridad**: análisis OWASP completado — 0 críticos, 0 altos, 0 medios
- ✅ **Code Review**: aprobado sin bloqueantes
- ✅ **Convenciones**: strings via `Txt(MessageKey)`, loggers presentes, patrones seguidos

## Plan de testing

- [ ] Email pre-cargado en pantalla ConfirmPasswordRecovery (visual)
- [ ] Campo código abre teclado numérico (mobile)
- [ ] Botón reenviar código navega correctamente
- [ ] Flujo funciona en Android, iOS, Desktop, Web

Closes #1144

🤖 Generado con [Claude Code](https://claude.ai/claude-code)