### PR TITLE
fix(hooks): resolver loop infinito de reinicio del commander por conflictos 409

### DIFF
--- a/.claude/hooks/telegram-commander.js
+++ b/.claude/hooks/telegram-commander.js
@@ -144,6 +144,39 @@ function isLockStale(data) {
     return false;
 }
 
+/**
+ * Matar otros procesos telegram-commander.js antes de arrancar.
+ * Esto previene conflictos 409 de Telegram cuando el lockfile se pierde
+ * pero el proceso viejo sigue vivo haciendo polling.
+ */
+function killOtherCommanders() {
+    try {
+        const { execSync } = require("child_process");
+        const wmicOutput = execSync(
+            'wmic process where "name=\'node.exe\' and commandline like \'%telegram-commander.js%\'" get ProcessId /FORMAT:LIST 2>NUL',
+            { encoding: "utf8", timeout: 5000, windowsHide: true }
+        );
+        const pids = [];
+        wmicOutput.split("\n").forEach(line => {
+            const m = line.trim().match(/^ProcessId=(\d+)$/);
+            if (m) pids.push(parseInt(m[1]));
+        });
+        const myPid = process.pid;
+        const others = pids.filter(p => p !== myPid);
+        for (const pid of others) {
+            try {
+                execSync("taskkill /PID " + pid + " /F 2>NUL", { timeout: 3000, windowsHide: true });
+                log("Matado commander previo (PID " + pid + ") para evitar conflicto 409");
+            } catch (e) {}
+        }
+        if (others.length > 0) {
+            log("Eliminados " + others.length + " commander(s) previo(s): " + others.join(", "));
+        }
+    } catch (e) {
+        log("killOtherCommanders error (no crítico): " + e.message);
+    }
+}
+
 function acquireLock() {
     if (fs.existsSync(LOCK_FILE)) {
         let data;
@@ -165,6 +198,10 @@ function acquireLock() {
             }
         }
     }
+
+    // Matar cualquier commander zombie antes de tomar el lock
+    killOtherCommanders();
+
     fs.writeFileSync(LOCK_FILE, JSON.stringify({ pid: process.pid, started: new Date().toISOString() }), "utf8");
     log("Lock adquirido (PID " + process.pid + ")");
 }

--- a/scripts/restart-operational-system.js
+++ b/scripts/restart-operational-system.js
@@ -205,7 +205,15 @@ function cleanStaleProcesses() {
                 if (fs.existsSync(lockFile)) {
                     try {
                         const content = fs.readFileSync(lockFile, "utf8").trim();
-                        const pid = parseInt(content, 10);
+                        // Lockfile puede ser JSON {"pid":NNN,...} o número plano
+                        let pid;
+                        try {
+                            const parsed = JSON.parse(content);
+                            pid = parsed.pid;
+                        } catch (e) {
+                            pid = parseInt(content, 10);
+                        }
+                        if (!pid || isNaN(pid)) continue; // No borrar si no podemos determinar el PID
                         // Verificar si el PID sigue vivo
                         const check = execSafe("tasklist /FI \"PID eq " + pid + "\" /NH 2>&1");
                         if (!check || !check.includes("" + pid)) {
@@ -226,7 +234,14 @@ function cleanStaleProcesses() {
                 if (fs.existsSync(lockFile)) {
                     try {
                         const content = fs.readFileSync(lockFile, "utf8").trim();
-                        const pid = parseInt(content, 10);
+                        let pid;
+                        try {
+                            const parsed = JSON.parse(content);
+                            pid = parsed.pid;
+                        } catch (e) {
+                            pid = parseInt(content, 10);
+                        }
+                        if (!pid || isNaN(pid)) continue;
                         const check = execSafe("kill -0 " + pid + " 2>&1");
                         if (check !== null && check.includes("No such process")) {
                             fs.unlinkSync(lockFile);


### PR DESCRIPTION
## Summary
- **Causa raíz**: `cleanStaleProcesses()` en `restart-operational-system.js` hacía `parseInt(content, 10)` sobre un lockfile JSON (`{"pid":832,...}`) → obtenía `NaN` → concluía "PID muerto" → **borraba el lockfile de un commander VIVO**
- El launcher detectaba "no lockfile" → lanzaba otro commander → conflicto 409 con Telegram → crash → repite cada ~45s indefinidamente

## Changes
- **restart-operational-system.js**: parsear lockfile como JSON antes de `parseInt` fallback; skip si no se puede determinar PID (nunca borrar lockfile válido)
- **telegram-commander.js**: nueva función `killOtherCommanders()` al arrancar — usa `wmic` para encontrar y matar procesos `telegram-commander.js` previos antes de tomar el lock

## Test plan
- [x] Verificar que ops reset NO borra lockfile de commander activo
- [ ] Verificar que commander nuevo mata zombies antes de arrancar
- [ ] Verificar que no hay más alertas "Commander: No hay lockfile" recurrentes

🤖 Generated with [Claude Code](https://claude.com/claude-code)