### PR TITLE
fix(hooks): registrar pr-cleanup.js como hook Stop en settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -35,6 +35,11 @@
             "type": "command",
             "command": "node /c/Workspaces/Intrale/platform/.claude/hooks/scrum-monitor-bg.js",
             "timeout": 60000
+          },
+          {
+            "type": "command",
+            "command": "node /c/Workspaces/Intrale/platform/.claude/hooks/pr-cleanup.js",
+            "timeout": 120000
           }
         ]
       }


### PR DESCRIPTION
## Resumen

Registra `pr-cleanup.js` como hook Stop en `.claude/settings.json`, permitiendo que se ejecute automáticamente al finalizar sesiones de Claude.

- Timeout configurado: 120000ms (suficiente para consultas de CI via gh API)
- Script implementado en #1351 pero no registrado — este PR cierra el gap
- 27/27 tests P-26 pasan ✅

## Cambios

- `.claude/settings.json`: agrega entrada en hooks Stop para `pr-cleanup.js` con timeout 120000ms

## Plan de tests

- [x] Tests P-26 pasan (27/27) — incluyendo los 2 tests de registro que antes fallaban
- [x] Security scan: sin findings (solo config JSON)
- [x] Code review: aprobado — cambio mínimo y correcto

Closes #1376

🤖 Generado con [Claude Code](https://claude.ai/claude-code)