### PR TITLE
feat(ux): separar cambio de contraseña temporal en pantalla dedicada

### DIFF
--- a/app/composeApp/src/commonMain/kotlin/DIManager.kt
+++ b/app/composeApp/src/commonMain/kotlin/DIManager.kt
@@ -168,6 +168,7 @@ import ui.ro.CommonRouter
 import ui.ro.Router
 import ui.sc.auth.ChangePasswordScreen
 import ui.sc.auth.ConfirmPasswordRecoveryScreen
+import ui.sc.auth.ForceChangePasswordScreen
 import ui.sc.auth.Login
 import ui.sc.auth.PasswordRecoveryScreen
 import ui.sc.auth.TwoFactorSetupScreen
@@ -251,6 +252,7 @@ public const val BUSINESS_CATEGORY_FORM = "businessCategoryForm"
 public const val TWO_FACTOR_SETUP = "twoFactorSetup"
 public const val TWO_FACTOR_VERIFY = "twoFactorVerify"
 public const val TYPOGRAPHY_FONTS = "typographyFonts"
+public const val FORCE_CHANGE_PASSWORD = "forceChangePassword"
 
 const val LOGIN_PATH = "/login"
 
@@ -417,6 +419,7 @@ private val screensModule = DI.Module("screens") {
     bindSingleton(tag = TWO_FACTOR_SETUP) { TwoFactorSetupScreen() }
     bindSingleton(tag = TWO_FACTOR_VERIFY) { TwoFactorVerifyScreen() }
     bindSingleton(tag = TYPOGRAPHY_FONTS) { TypographyScreen() }
+    bindSingleton(tag = FORCE_CHANGE_PASSWORD) { ForceChangePasswordScreen() }
 
     bindSingleton(tag = SCREENS) {
         val appType = AppRuntimeConfig.appType
@@ -438,6 +441,7 @@ private val screensModule = DI.Module("screens") {
                     add(instance(tag = SIGNUP))
                     add(instance(tag = CONFIRM_SIGNUP))
                     add(instance(tag = CHANGE_PASSWORD))
+                    add(instance(tag = FORCE_CHANGE_PASSWORD))
                     add(instance(tag = PASSWORD_RECOVERY))
                     add(instance(tag = CONFIRM_PASSWORD_RECOVERY))
                     add(instance(tag = TWO_FACTOR_SETUP))
@@ -453,6 +457,7 @@ private val screensModule = DI.Module("screens") {
                     add(instance(tag = SIGNUP_DELIVERY))
                     add(instance(tag = CONFIRM_SIGNUP))
                     add(instance(tag = CHANGE_PASSWORD))
+                    add(instance(tag = FORCE_CHANGE_PASSWORD))
                     add(instance(tag = PASSWORD_RECOVERY))
                     add(instance(tag = CONFIRM_PASSWORD_RECOVERY))
                     add(instance(tag = TWO_FACTOR_SETUP))
@@ -471,6 +476,7 @@ private val screensModule = DI.Module("screens") {
                     add(instance(tag = SIGNUP_DELIVERY))
                     add(instance(tag = REGISTER_SALER))
                     add(instance(tag = CHANGE_PASSWORD))
+                    add(instance(tag = FORCE_CHANGE_PASSWORD))
                     add(instance(tag = PASSWORD_RECOVERY))
                     add(instance(tag = CONFIRM_PASSWORD_RECOVERY))
                     add(instance(tag = REVIEW_BUSINESS))
@@ -499,6 +505,7 @@ private val screensModule = DI.Module("screens") {
                     add(instance(tag = SIGNUP_DELIVERY))
                     add(instance(tag = REGISTER_SALER))
                     add(instance(tag = CHANGE_PASSWORD))
+                    add(instance(tag = FORCE_CHANGE_PASSWORD))
                     add(instance(tag = PASSWORD_RECOVERY))
                     add(instance(tag = CONFIRM_PASSWORD_RECOVERY))
                     add(instance(tag = REVIEW_BUSINESS))

--- a/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/catalog/DefaultCatalog_en.kt
+++ b/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/catalog/DefaultCatalog_en.kt
@@ -526,4 +526,8 @@ internal val DefaultCatalog_en: Map<MessageKey, String> = mapOf(
     MessageKey.password_match to "Passwords match",
     MessageKey.password_no_match to "Passwords do not match",
     MessageKey.change_password_confirm_new_password to "Confirm new password",
+    MessageKey.force_change_password_appbar_title to "Password Change",
+    MessageKey.force_change_password_welcome_title to "Welcome!",
+    MessageKey.force_change_password_security_message to "For security reasons, you must change your password before continuing.",
+    MessageKey.force_change_password_continue to "Continue",
 )

--- a/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/catalog/DefaultCatalog_es.kt
+++ b/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/catalog/DefaultCatalog_es.kt
@@ -526,4 +526,8 @@ internal val DefaultCatalog_es: Map<MessageKey, String> = mapOf(
     MessageKey.password_match to "Las contrasenas coinciden",
     MessageKey.password_no_match to "Las contrasenas no coinciden",
     MessageKey.change_password_confirm_new_password to "Confirmar nueva contrasena",
+    MessageKey.force_change_password_appbar_title to "Cambio de contrasena",
+    MessageKey.force_change_password_welcome_title to "Bienvenido/a",
+    MessageKey.force_change_password_security_message to "Por seguridad, necesitas cambiar tu contrasena antes de continuar.",
+    MessageKey.force_change_password_continue to "Continuar",
 )

--- a/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/model/MessageKey.kt
+++ b/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/model/MessageKey.kt
@@ -529,4 +529,8 @@ enum class MessageKey {
     password_match,
     password_no_match,
     change_password_confirm_new_password,
+    force_change_password_appbar_title,
+    force_change_password_welcome_title,
+    force_change_password_security_message,
+    force_change_password_continue,
 }

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/auth/ForceChangePasswordScreen.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/auth/ForceChangePasswordScreen.kt
@@ -1,0 +1,229 @@
+package ui.sc.auth
+
+import ar.com.intrale.appconfig.AppRuntimeConfig
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.LockReset
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusDirection
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
+import androidx.lifecycle.viewmodel.compose.viewModel
+import ar.com.intrale.strings.Txt
+import ar.com.intrale.strings.model.MessageKey
+import asdo.auth.DoLoginException
+import org.kodein.log.LoggerFactory
+import org.kodein.log.newLogger
+import ui.cp.buttons.IntralePrimaryButton
+import ui.cp.inputs.PasswordStrengthIndicator
+import ui.cp.inputs.TextField
+import ui.sc.client.CLIENT_HOME_PATH
+import ui.sc.business.DASHBOARD_PATH
+import ui.sc.delivery.DELIVERY_DASHBOARD_PATH
+import ui.sc.shared.Screen
+import ui.sc.shared.callService
+import ui.session.SessionStore
+import ui.session.UserRole
+import ui.th.elevations
+import ui.th.spacing
+
+const val FORCE_CHANGE_PASSWORD_PATH = "/force-change-password"
+
+class ForceChangePasswordScreen : Screen(FORCE_CHANGE_PASSWORD_PATH) {
+
+    override val messageTitle: MessageKey = MessageKey.force_change_password_appbar_title
+
+    private val logger = LoggerFactory.default.newLogger<ForceChangePasswordScreen>()
+
+    @Composable
+    override fun screen() {
+        screenImpl()
+    }
+
+    @Composable
+    private fun screenImpl(viewModel: ForceChangePasswordViewModel = viewModel { ForceChangePasswordViewModel() }) {
+        val snackbarHostState = remember { SnackbarHostState() }
+        val coroutineScope = rememberCoroutineScope()
+        val focusManager = LocalFocusManager.current
+        val scrollState = rememberScrollState()
+
+        val welcomeTitle = Txt(MessageKey.force_change_password_welcome_title)
+        val securityMessage = Txt(MessageKey.force_change_password_security_message)
+        val continueLabel = Txt(MessageKey.force_change_password_continue)
+        val genericError = Txt(MessageKey.login_generic_error)
+        val errorCredentials = Txt(MessageKey.login_error_credentials)
+
+        val isDeliveryApp = AppRuntimeConfig.isDelivery
+        val isBusinessApp = AppRuntimeConfig.isBusiness
+
+        val submitChange: () -> Unit = {
+            focusManager.clearFocus()
+            viewModel.setupValidation()
+            if (viewModel.isValid()) {
+                callService(
+                    coroutineScope = coroutineScope,
+                    snackbarHostState = snackbarHostState,
+                    setLoading = { viewModel.loading = it },
+                    serviceCall = { viewModel.completeLogin() },
+                    onSuccess = {
+                        val destination = when {
+                            AppRuntimeConfig.isClient -> {
+                                SessionStore.updateRole(UserRole.Client)
+                                CLIENT_HOME_PATH
+                            }
+                            isDeliveryApp -> {
+                                SessionStore.updateRole(UserRole.Delivery)
+                                DELIVERY_DASHBOARD_PATH
+                            }
+                            else -> {
+                                SessionStore.updateRole(UserRole.BusinessAdmin)
+                                DASHBOARD_PATH
+                            }
+                        }
+                        logger.info { "Cambio de contraseña completado, navegando a $destination" }
+                        navigateClearingBackStack(destination)
+                    },
+                    onError = { error ->
+                        when (error) {
+                            is DoLoginException -> when {
+                                error.statusCode.value == 401 ->
+                                    snackbarHostState.showSnackbar(errorCredentials)
+                                else -> {
+                                    logger.error { "Error al completar cambio de contraseña: ${error.message}" }
+                                    snackbarHostState.showSnackbar(genericError)
+                                }
+                            }
+                            else -> snackbarHostState.showSnackbar(error.message ?: genericError)
+                        }
+                    }
+                )
+            }
+        }
+
+        Scaffold(snackbarHost = { SnackbarHost(snackbarHostState) }) { padding ->
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .imePadding()
+                    .verticalScroll(scrollState)
+                    .padding(
+                        horizontal = MaterialTheme.spacing.x3,
+                        vertical = MaterialTheme.spacing.x2
+                    ),
+                verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.x4),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.x1)
+                ) {
+                    Text(
+                        text = welcomeTitle,
+                        style = MaterialTheme.typography.headlineMedium,
+                        textAlign = TextAlign.Center
+                    )
+                    Text(
+                        text = securityMessage,
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        textAlign = TextAlign.Center
+                    )
+                }
+
+                Surface(
+                    modifier = Modifier.fillMaxWidth(),
+                    tonalElevation = MaterialTheme.elevations.level2,
+                    shape = MaterialTheme.shapes.large
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(MaterialTheme.spacing.x3),
+                        verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.x2)
+                    ) {
+                        TextField(
+                            label = MessageKey.new_password,
+                            value = viewModel.state.newPassword,
+                            state = viewModel.inputsStates[ForceChangePasswordViewModel.ForceChangePasswordUIState::newPassword.name]!!,
+                            visualTransformation = true,
+                            onValueChange = viewModel::onNewPasswordChange,
+                            modifier = Modifier.fillMaxWidth(),
+                            keyboardOptions = KeyboardOptions.Default.copy(
+                                keyboardType = KeyboardType.Password,
+                                imeAction = ImeAction.Next
+                            ),
+                            keyboardActions = KeyboardActions(onNext = { focusManager.moveFocus(FocusDirection.Down) }),
+                            placeholder = MessageKey.login_new_password_placeholder,
+                            enabled = !viewModel.loading
+                        )
+                        PasswordStrengthIndicator(
+                            password = viewModel.state.newPassword,
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                        TextField(
+                            label = MessageKey.first_name,
+                            value = viewModel.state.name,
+                            state = viewModel.inputsStates[ForceChangePasswordViewModel.ForceChangePasswordUIState::name.name]!!,
+                            onValueChange = viewModel::onNameChange,
+                            modifier = Modifier.fillMaxWidth(),
+                            keyboardOptions = KeyboardOptions.Default.copy(
+                                capitalization = KeyboardCapitalization.Words,
+                                imeAction = ImeAction.Next
+                            ),
+                            keyboardActions = KeyboardActions(onNext = { focusManager.moveFocus(FocusDirection.Down) }),
+                            placeholder = MessageKey.login_name_placeholder,
+                            enabled = !viewModel.loading
+                        )
+                        TextField(
+                            label = MessageKey.family_name,
+                            value = viewModel.state.familyName,
+                            state = viewModel.inputsStates[ForceChangePasswordViewModel.ForceChangePasswordUIState::familyName.name]!!,
+                            onValueChange = viewModel::onFamilyNameChange,
+                            modifier = Modifier.fillMaxWidth(),
+                            keyboardOptions = KeyboardOptions.Default.copy(
+                                capitalization = KeyboardCapitalization.Words,
+                                imeAction = ImeAction.Done
+                            ),
+                            keyboardActions = KeyboardActions(onDone = { submitChange() }),
+                            placeholder = MessageKey.login_family_name_placeholder,
+                            enabled = !viewModel.loading
+                        )
+                    }
+                }
+
+                IntralePrimaryButton(
+                    text = continueLabel,
+                    onClick = submitChange,
+                    modifier = Modifier.fillMaxWidth(),
+                    leadingIcon = Icons.Filled.LockReset,
+                    enabled = !viewModel.loading,
+                    loading = viewModel.loading
+                )
+            }
+        }
+    }
+}

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/auth/ForceChangePasswordViewModel.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/auth/ForceChangePasswordViewModel.kt
@@ -1,0 +1,115 @@
+package ui.sc.auth
+
+import DIManager
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import ar.com.intrale.strings.model.MessageKey
+import ar.com.intrale.strings.resolveMessage
+import asdo.auth.DoLoginResult
+import asdo.auth.ToDoLogin
+import io.konform.validation.Validation
+import io.konform.validation.jsonschema.minLength
+import org.kodein.di.direct
+import org.kodein.di.instance
+import org.kodein.log.LoggerFactory
+import org.kodein.log.newLogger
+import ui.sc.shared.ViewModel
+
+/**
+ * Almacén temporal de credenciales para el flujo de cambio de contraseña obligatorio.
+ * Se limpia automáticamente tras completar el login.
+ */
+internal object ForceChangePasswordCredentialsStore {
+    var user: String = ""
+    var password: String = ""
+
+    fun store(user: String, password: String) {
+        this.user = user
+        this.password = password
+    }
+
+    fun clear() {
+        user = ""
+        password = ""
+    }
+}
+
+class ForceChangePasswordViewModel(
+    private val todoLogin: ToDoLogin = DIManager.di.direct.instance(),
+    loggerFactory: LoggerFactory = LoggerFactory.default
+) : ViewModel() {
+
+    private val logger = loggerFactory.newLogger<ForceChangePasswordViewModel>()
+
+    var state by mutableStateOf(ForceChangePasswordUIState())
+        private set
+    var loading by mutableStateOf(false)
+
+    data class ForceChangePasswordUIState(
+        val newPassword: String = "",
+        val name: String = "",
+        val familyName: String = ""
+    )
+
+    override fun getState(): Any = state
+
+    init {
+        setupValidation()
+        initInputState()
+    }
+
+    fun setupValidation() {
+        validation = Validation<ForceChangePasswordUIState> {
+            ForceChangePasswordUIState::newPassword required {
+                minLength(1) hint resolveMessage(MessageKey.form_error_required)
+                minLength(8) hint resolveMessage(MessageKey.form_error_min_length_8)
+            }
+            ForceChangePasswordUIState::name required {
+                minLength(1) hint resolveMessage(MessageKey.form_error_required)
+            }
+            ForceChangePasswordUIState::familyName required {
+                minLength(1) hint resolveMessage(MessageKey.form_error_required)
+            }
+        } as Validation<Any>
+    }
+
+    override fun initInputState() {
+        inputsStates = mutableMapOf(
+            entry(ForceChangePasswordUIState::newPassword.name),
+            entry(ForceChangePasswordUIState::name.name),
+            entry(ForceChangePasswordUIState::familyName.name),
+        )
+    }
+
+    fun onNewPasswordChange(value: String) {
+        state = state.copy(newPassword = value)
+    }
+
+    fun onNameChange(value: String) {
+        state = state.copy(name = value)
+    }
+
+    fun onFamilyNameChange(value: String) {
+        state = state.copy(familyName = value)
+    }
+
+    suspend fun completeLogin(): Result<DoLoginResult> {
+        logger.debug { "Completando login con cambio de contraseña obligatorio" }
+        val credentials = ForceChangePasswordCredentialsStore
+        val result = todoLogin.execute(
+            user = credentials.user,
+            password = credentials.password,
+            newPassword = state.newPassword,
+            name = state.name,
+            familyName = state.familyName
+        )
+        result.onSuccess {
+            logger.debug { "Login con cambio de contraseña exitoso" }
+            ForceChangePasswordCredentialsStore.clear()
+        }.onFailure { error ->
+            logger.error { "Error al completar el cambio de contraseña: ${error.message}" }
+        }
+        return result
+    }
+}

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/auth/Login.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/auth/Login.kt
@@ -1,7 +1,6 @@
 package ui.sc.auth
 
 import ar.com.intrale.appconfig.AppRuntimeConfig
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -38,7 +37,6 @@ import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -86,7 +84,6 @@ class Login : Screen(LOGIN_PATH) {
         val checkingSessionText = Txt(MessageKey.login_checking_session)
         val loginText = Txt(MessageKey.login_button)
         val errorCredentials = Txt(MessageKey.login_error_credentials)
-        val changePasswordMessage = Txt(MessageKey.login_change_password_required)
         val genericError = Txt(MessageKey.login_generic_error)
         val blockedUserMessage = Txt(MessageKey.login_error_user_blocked)
         val isDeliveryApp = AppRuntimeConfig.isDelivery
@@ -107,8 +104,6 @@ class Login : Screen(LOGIN_PATH) {
         )
         val userIconDescription = Txt(MessageKey.login_user_icon_content_description)
         val passwordIconDescription = Txt(MessageKey.login_password_icon_content_description)
-        val changePasswordTitle = Txt(MessageKey.login_change_password_title)
-        val changePasswordDescription = Txt(MessageKey.login_change_password_description)
         val signupLinkLabel = Txt(MessageKey.signup)
         val requestDeliveryAccessLabel = Txt(MessageKey.delivery_request_access)
         val registerBusinessLinkLabel = Txt(MessageKey.register_business)
@@ -136,11 +131,16 @@ class Login : Screen(LOGIN_PATH) {
                     }
 
                     error.message?.contains("newPassword is required", ignoreCase = true) == true -> {
-                        viewModel.requirePasswordChange()
                         if (isDeliveryApp) {
-                            logger.info { "[Delivery][Login] Se requiere cambio de contraseña" }
+                            logger.info { "[Delivery][Login] Se requiere cambio de contraseña — navegando a pantalla dedicada" }
+                        } else {
+                            logger.info { "Se requiere cambio de contraseña — navegando a pantalla dedicada" }
                         }
-                        snackbarHostState.showSnackbar(changePasswordMessage)
+                        ForceChangePasswordCredentialsStore.store(
+                            user = viewModel.state.user,
+                            password = viewModel.state.password
+                        )
+                        navigate(FORCE_CHANGE_PASSWORD_PATH)
                     }
 
                     else -> {
@@ -316,77 +316,12 @@ class Login : Screen(LOGIN_PATH) {
                             },
                             keyboardOptions = KeyboardOptions.Default.copy(
                                 keyboardType = KeyboardType.Password,
-                                imeAction = if (viewModel.changePasswordRequired) ImeAction.Next else ImeAction.Done
+                                imeAction = ImeAction.Done
                             ),
-                            keyboardActions = if (viewModel.changePasswordRequired) {
-                                KeyboardActions(onNext = { focusManager.moveFocus(FocusDirection.Down) })
-                            } else {
-                                KeyboardActions(onDone = { submitLogin() })
-                            },
+                            keyboardActions = KeyboardActions(onDone = { submitLogin() }),
                             placeholder = MessageKey.login_password_placeholder,
                             enabled = !viewModel.loading
                         )
-
-                        AnimatedVisibility(visible = viewModel.changePasswordRequired) {
-                            Column(
-                                modifier = Modifier.fillMaxWidth(),
-                                verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.x2)
-                            ) {
-                                Divider()
-                                Text(
-                                    text = changePasswordTitle,
-                                    style = MaterialTheme.typography.titleLarge
-                                )
-                                Text(
-                                    text = changePasswordDescription,
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                                )
-                                TextField(
-                                    label = MessageKey.new_password,
-                                    value = viewModel.state.newPassword,
-                                    state = viewModel.inputsStates[LoginViewModel.LoginUIState::newPassword.name]!!,
-                                    visualTransformation = true,
-                                    onValueChange = viewModel::onNewPasswordChange,
-                                    modifier = Modifier.fillMaxWidth(),
-                                    keyboardOptions = KeyboardOptions.Default.copy(
-                                        keyboardType = KeyboardType.Password,
-                                        imeAction = ImeAction.Next
-                                    ),
-                                    keyboardActions = KeyboardActions(onNext = { focusManager.moveFocus(FocusDirection.Down) }),
-                                    placeholder = MessageKey.login_new_password_placeholder,
-                                    enabled = !viewModel.loading
-                                )
-                                TextField(
-                                    label = MessageKey.first_name,
-                                    value = viewModel.state.name,
-                                    state = viewModel.inputsStates[LoginViewModel.LoginUIState::name.name]!!,
-                                    onValueChange = viewModel::onNameChange,
-                                    modifier = Modifier.fillMaxWidth(),
-                                    keyboardOptions = KeyboardOptions.Default.copy(
-                                        capitalization = KeyboardCapitalization.Words,
-                                        imeAction = ImeAction.Next
-                                    ),
-                                    keyboardActions = KeyboardActions(onNext = { focusManager.moveFocus(FocusDirection.Down) }),
-                                    placeholder = MessageKey.login_name_placeholder,
-                                    enabled = !viewModel.loading
-                                )
-                                TextField(
-                                    label = MessageKey.family_name,
-                                    value = viewModel.state.familyName,
-                                    state = viewModel.inputsStates[LoginViewModel.LoginUIState::familyName.name]!!,
-                                    onValueChange = viewModel::onFamilyNameChange,
-                                    modifier = Modifier.fillMaxWidth(),
-                                    keyboardOptions = KeyboardOptions.Default.copy(
-                                        capitalization = KeyboardCapitalization.Words,
-                                        imeAction = ImeAction.Done
-                                    ),
-                                    keyboardActions = KeyboardActions(onDone = { submitLogin() }),
-                                    placeholder = MessageKey.login_family_name_placeholder,
-                                    enabled = !viewModel.loading
-                                )
-                            }
-                        }
                     }
                 }
 

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/auth/LoginViewModel.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/auth/LoginViewModel.kt
@@ -33,43 +33,31 @@ class LoginViewModel(
     var loading by mutableStateOf(false)
     var isCheckingSession by mutableStateOf(false)
         private set
-    var changePasswordRequired by mutableStateOf(false)
-        private set
     private var loginValidation: Validation<LoginUIState> = buildValidation()
 
-    data class LoginUIState (
+    data class LoginUIState(
         val user: String = "",
-        val password: String = "",
-        val newPassword: String = "",
-        val name: String = "",
-        val familyName: String = ""
+        val password: String = ""
     )
-    override fun getState(): Any  = state
+
+    override fun getState(): Any = state
 
     // inputs and validations initialize
     init {
         setupValidation()
         initInputState()
-
-   }
+    }
 
     fun setupValidation() {
         loginValidation = buildValidation()
         validation = loginValidation as Validation<Any>
     }
-   override fun initInputState() {
-       inputsStates = mutableMapOf(
+
+    override fun initInputState() {
+        inputsStates = mutableMapOf(
             entry(LoginUIState::user.name),
             entry(LoginUIState::password.name),
-            entry(LoginUIState::newPassword.name),
-            entry(LoginUIState::name.name),
-            entry(LoginUIState::familyName.name),
-       )
-       /*if (changePasswordRequired) {
-            inputsStates[LoginUIState::newPassword.name] = mutableStateOf(InputState(LoginUIState::newPassword.name))
-            inputsStates[LoginUIState::name.name] = mutableStateOf(InputState(LoginUIState::name.name))
-            inputsStates[LoginUIState::familyName.name] = mutableStateOf(InputState(LoginUIState::familyName.name))
-       }*/
+        )
     }
 
     // Features
@@ -79,10 +67,7 @@ class LoginViewModel(
         validateCurrentState()
         val result = todoLogin.execute(
             user = state.user,
-            password = state.password,
-            newPassword = if (changePasswordRequired) state.newPassword else null,
-            name = if (changePasswordRequired) state.name else null,
-            familyName = if (changePasswordRequired) state.familyName else null
+            password = state.password
         )
         result.onSuccess { logger.debug { "Login exitoso" } }
             .onFailure { error -> logger.error { "Error al iniciar sesión: ${error.message}" } }
@@ -111,35 +96,12 @@ class LoginViewModel(
         validateCurrentState()
     }
 
-    fun onNewPasswordChange(value: String) {
-        state = state.copy(newPassword = value)
-        validateCurrentState()
-    }
-
-    fun onNameChange(value: String) {
-        state = state.copy(name = value)
-        validateCurrentState()
-    }
-
-    fun onFamilyNameChange(value: String) {
-        state = state.copy(familyName = value)
-        validateCurrentState()
-    }
-
     fun markCredentialsAsInvalid(message: String) {
         listOf(LoginUIState::user.name, LoginUIState::password.name).forEach { key ->
             inputsStates[key]?.let {
                 it.value = it.value.copy(isValid = false, details = message)
             }
         }
-    }
-
-    fun requirePasswordChange() {
-        if (!changePasswordRequired) {
-            changePasswordRequired = true
-            setupValidation()
-        }
-        validateCurrentState()
     }
 
     private fun validateCurrentState() {
@@ -165,18 +127,6 @@ class LoginViewModel(
         LoginUIState::password required {
             minLength(1) hint resolveMessage(MessageKey.form_error_required)
             minLength(8) hint resolveMessage(MessageKey.form_error_min_length_8)
-        }
-        if (changePasswordRequired) {
-            LoginUIState::newPassword required {
-                minLength(1) hint resolveMessage(MessageKey.form_error_required)
-                minLength(8) hint resolveMessage(MessageKey.form_error_min_length_8)
-            }
-            LoginUIState::name required {
-                minLength(1) hint resolveMessage(MessageKey.form_error_required)
-            }
-            LoginUIState::familyName required {
-                minLength(1) hint resolveMessage(MessageKey.form_error_required)
-            }
         }
     }
 }

--- a/app/composeApp/src/commonTest/kotlin/ui/sc/auth/AuthViewModelsTest.kt
+++ b/app/composeApp/src/commonTest/kotlin/ui/sc/auth/AuthViewModelsTest.kt
@@ -182,13 +182,6 @@ class LoginViewModelTest {
     }
 
     @Test
-    fun `requirePasswordChange activa campos adicionales`() {
-        val vm = createVm()
-        vm.requirePasswordChange()
-        assertTrue(vm.changePasswordRequired)
-    }
-
-    @Test
     fun `markCredentialsAsInvalid marca campos como invalidos`() {
         val vm = createVm()
         vm.markCredentialsAsInvalid("Credenciales incorrectas")
@@ -430,6 +423,92 @@ class TwoFactorVerifyViewModelTest {
         val vm = TwoFactorVerifyViewModel(FakeTwoFactorVerify(), testLoggerFactory)
         vm.state = TwoFactorVerifyViewModel.TwoFactorVerifyUIState("123")
         assertFalse(vm.isValid())
+    }
+}
+
+// endregion
+
+// region ForceChangePasswordViewModel
+
+class ForceChangePasswordViewModelTest {
+
+    private fun createVm(
+        login: ToDoLogin = FakeLogin()
+    ) = ForceChangePasswordViewModel(login, testLoggerFactory)
+
+    @Test
+    fun `onNewPasswordChange actualiza estado`() {
+        val vm = createVm()
+        vm.onNewPasswordChange("nuevaPass123")
+        assertEquals("nuevaPass123", vm.state.newPassword)
+    }
+
+    @Test
+    fun `onNameChange actualiza estado`() {
+        val vm = createVm()
+        vm.onNameChange("Carlos")
+        assertEquals("Carlos", vm.state.name)
+    }
+
+    @Test
+    fun `onFamilyNameChange actualiza estado`() {
+        val vm = createVm()
+        vm.onFamilyNameChange("Garcia")
+        assertEquals("Garcia", vm.state.familyName)
+    }
+
+    @Test
+    fun `isValid con datos completos retorna true`() {
+        val vm = createVm()
+        vm.onNewPasswordChange("nuevaPass123")
+        vm.onNameChange("Carlos")
+        vm.onFamilyNameChange("Garcia")
+        assertTrue(vm.isValid())
+    }
+
+    @Test
+    fun `isValid con password corta retorna false`() {
+        val vm = createVm()
+        vm.onNewPasswordChange("corta")
+        vm.onNameChange("Carlos")
+        vm.onFamilyNameChange("Garcia")
+        assertFalse(vm.isValid())
+    }
+
+    @Test
+    fun `isValid con nombre vacio retorna false`() {
+        val vm = createVm()
+        vm.onNewPasswordChange("nuevaPass123")
+        vm.onNameChange("")
+        vm.onFamilyNameChange("Garcia")
+        assertFalse(vm.isValid())
+    }
+
+    @Test
+    fun `completeLogin invoca todoLogin con exito`() = runTest {
+        ForceChangePasswordCredentialsStore.store("test@test.com", "oldPass123")
+        val vm = createVm()
+        vm.onNewPasswordChange("nuevaPass123")
+        vm.onNameChange("Carlos")
+        vm.onFamilyNameChange("Garcia")
+
+        val result = vm.completeLogin()
+
+        assertTrue(result.isSuccess)
+    }
+
+    @Test
+    fun `credentialsStore limpia credenciales tras login exitoso`() = runTest {
+        ForceChangePasswordCredentialsStore.store("user@test.com", "pass123")
+        val vm = createVm()
+        vm.onNewPasswordChange("nuevaPass123")
+        vm.onNameChange("Ana")
+        vm.onFamilyNameChange("Lopez")
+
+        vm.completeLogin()
+
+        assertEquals("", ForceChangePasswordCredentialsStore.user)
+        assertEquals("", ForceChangePasswordCredentialsStore.password)
     }
 }
 


### PR DESCRIPTION
## Resumen

Implementación del issue #1145 — wizard de 2 pasos para cambio obligatorio de contraseña en primer login.

## Cambios

- **Nueva pantalla**: `ForceChangePasswordScreen.kt` + `ForceChangePasswordViewModel.kt`
- **Detección de flujo**: En `Login.kt`, cuando se detecta "newPassword is required", almacenar credenciales y navegar a la pantalla dedicada
- **Simplificación de UI**: Eliminar `AnimatedVisibility` del formulario de login
- **Refactor de LoginViewModel**: Remover `changePasswordRequired`, simplificar validación
- **Internacionalización**: Agregar 4 nuevos `MessageKey` para la pantalla (español e inglés)
- **DI Update**: Registrar nueva pantalla en `DIManager.kt` para todos los app types (CLIENT, DELIVERY, BUSINESS)
- **Tests**: Actualizar tests obsoletos, agregar test suite para `ForceChangePasswordViewModel`

## Validaciones pre-delivery

✓ Tests unitarios: APROBADO (testClientDebugUnitTest)
✓ Build: EXITOSO (compileClientDebugKotlinAndroid + compileClientReleaseKotlinAndroid)
✓ Strings legacy: VERIFICADOS (verifyNoLegacyStrings)
✓ ASCII fallbacks: VERIFICADOS (scanNonAsciiFallbacks)
✓ Seguridad: PASS (sin secrets, no password logging, credenciales se limpian post-login)
✓ Code Review: PASS (patrones correctos, logger presente, DI registrado)

## Cómo testear

1. Simular error de "newPassword is required" desde Cognito en primer login
2. Usuario es navegado a la nueva pantalla "Bienvenido/a"
3. Completar formulario (nueva contraseña, nombre, apellido)
4. Validaciones inline funcionan correctamente
5. Al submitear, se ejecuta el login completo y se navega al Home del rol correspondiente

## Impacto

- **UX**: Experiencia mejorada (wizard de 2 pasos > formulario inline expandido)
- **Accesibilidad**: Menos elementos en pantalla inicial (reduces cognitive load)
- **Mantenibilidad**: Lógica de cambio de contraseña aislada en su propio ViewModel

Closes #1145

🤖 Generado con [Claude Code](https://claude.com/claude-code)