### PR TITLE
feat(monitor): heartbeat Telegram con frecuencia adaptativa (#1396)

### DIFF
--- a/.claude/hooks/reporter-bg.js
+++ b/.claude/hooks/reporter-bg.js
@@ -22,9 +22,16 @@ const LOG_FILE = path.join(REPO_ROOT, "hooks", "hook-debug.log");
 const TG_CONFIG_FILE = path.join(REPO_ROOT, "hooks", "telegram-config.json");
 const DASHBOARD_PORT = 3100;
 const SKIP_ALERT_THRESHOLD = 3; // Alertar a Telegram tras N skips consecutivos
+const HEARTBEAT_STATE_FILE = path.join(REPO_ROOT, "hooks", "heartbeat-state.json");
+const SESSIONS_DIR = path.join(REPO_ROOT, "sessions");
+const ACTIVITY_THRESHOLD_MIN = 15; // Minutos para considerar una sesión como activa
 
 // Contador de heartbeats saltados por fallo de screenshot
 let consecutiveSkipCount = 0;
+
+// Estado del modo actual (se actualiza antes de cada sendPeriodicReport)
+let heartbeatMode = "normal";   // "normal" | "idle"
+let heartbeatIntervalMin = 10;  // Intervalo actual en minutos
 
 function debugLog(msg) {
   try {
@@ -294,8 +301,49 @@ function hasActiveAgents() {
   });
 }
 
+// Detectar sesiones activas leyendo .claude/sessions/*.json directamente
+// Criterio: status === "active" y last_activity_ts < ACTIVITY_THRESHOLD_MIN minutos
+function hasActiveSessions() {
+  try {
+    if (!fs.existsSync(SESSIONS_DIR)) return false;
+    const files = fs.readdirSync(SESSIONS_DIR).filter(function(f) { return f.endsWith(".json"); });
+    const now = Date.now();
+    const threshold = ACTIVITY_THRESHOLD_MIN * 60 * 1000;
+    for (const file of files) {
+      try {
+        const session = JSON.parse(fs.readFileSync(path.join(SESSIONS_DIR, file), "utf8"));
+        if (session.status === "active" && session.last_activity_ts) {
+          const lastActivity = new Date(session.last_activity_ts).getTime();
+          if (now - lastActivity < threshold) return true;
+        }
+      } catch {}
+    }
+    return false;
+  } catch { return false; }
+}
+
+// Cargar estado persistido del heartbeat desde heartbeat-state.json
+function loadHeartbeatState() {
+  try {
+    if (!fs.existsSync(HEARTBEAT_STATE_FILE)) return null;
+    return JSON.parse(fs.readFileSync(HEARTBEAT_STATE_FILE, "utf8"));
+  } catch { return null; }
+}
+
+// Guardar estado del heartbeat en heartbeat-state.json
+function saveHeartbeatState(currentInterval, consecutiveIdle, mode) {
+  try {
+    const state = {
+      currentInterval,
+      consecutiveIdle,
+      lastHeartbeat: new Date().toISOString(),
+      mode
+    };
+    fs.writeFileSync(HEARTBEAT_STATE_FILE, JSON.stringify(state, null, 2), "utf8");
+  } catch (e) { debugLog("Error guardando heartbeat-state.json: " + e.message); }
+}
+
 // Constantes de frecuencia adaptativa
-const INACTIVITY_THRESHOLD_MIN = 5;   // Minutos sin actividad para empezar a escalar
 const INTERVAL_STEP_MIN = 10;         // Minutos extra por cada ciclo inactivo
 const MAX_INTERVAL_MIN = 60;          // Cap máximo del intervalo
 
@@ -322,9 +370,14 @@ async function sendPeriodicReport() {
 
   const dateStr = new Date().toLocaleString("es-AR");
 
+  // Indicador de modo en el caption principal
+  const modeLabel = heartbeatMode === "normal"
+    ? "\ud83d\udc9a <b>Intrale Monitor</b> \u2014 Heartbeat (cada " + heartbeatIntervalMin + " min)"
+    : "\ud83d\udca4 <b>Intrale Monitor</b> \u2014 Heartbeat (cada " + heartbeatIntervalMin + " min \u2014 sin actividad)";
+
   // Mapa de captions descriptivos por section ID
   const SECTION_CAPTIONS = {
-    kpis:            "\ud83d\udcca <b>KPIs</b> \u2014 Intrale Monitor \u2014 " + dateStr,
+    kpis:            "\ud83d\udcca <b>KPIs</b> \u2014 " + modeLabel + " \u2014 " + dateStr,
     ejecucion:       "\u26a1 <b>Ejecuci\u00f3n de agentes</b>",
     sesiones:        "\ud83e\uddd1\u200d\ud83d\udcbb <b>Sesiones activas</b>",
     metricas:        "\ud83d\udcca <b>M\u00e9tricas de uso</b>",
@@ -378,7 +431,7 @@ async function sendPeriodicReport() {
     debugLog("Error con secciones: " + (e.stack || e.message));
   }
 
-  const caption = "\ud83d\udc9a <b>Intrale Monitor</b> \u2014 Heartbeat\n" + dateStr;
+  const caption = modeLabel + "\n" + dateStr;
 
   // 2. Intentar álbum top/bottom (endpoint /screenshots)
   try {
@@ -455,26 +508,47 @@ function start(intervalMin) {
     debugLog("Reporter daemon PID " + process.pid + " base " + intervalMin + " min (adaptativo)");
     console.log("Reporter daemon: PID " + process.pid + ", base " + intervalMin + " min (adaptativo)");
 
-    let inactiveCycles = 0;
+    // Cargar estado persistido al arrancar (sobrevive reinicios)
+    const persistedState = loadHeartbeatState();
+    let consecutiveIdle = persistedState ? (persistedState.consecutiveIdle || 0) : 0;
+    let previousMode = persistedState ? (persistedState.mode || "normal") : "normal";
 
     async function adaptiveLoop() {
-      // Enviar reporte
-      await sendPeriodicReport();
+      // Detectar actividad leyendo sesiones directamente (.claude/sessions/*.json)
+      const active = hasActiveSessions();
+      const wasIdle = previousMode === "idle";
 
-      // Calcular próximo intervalo según actividad
-      const active = await hasActiveAgents();
+      // Actualizar modo y contador
       if (active) {
-        inactiveCycles = 0;
+        if (wasIdle) {
+          // Transición: inactivo → normal — notificar y enviar heartbeat inmediato
+          debugLog("Transicion idle->normal detectada — enviando mensaje de actividad");
+          try {
+            await sendTelegramText(
+              "\ud83d\udd04 <b>Actividad detectada</b> \u2014 volviendo a monitoreo normal (10 min)",
+              false
+            );
+          } catch (e) { debugLog("Error enviando msg transicion: " + e.message); }
+        }
+        consecutiveIdle = 0;
+        heartbeatMode = "normal";
       } else {
-        inactiveCycles++;
+        consecutiveIdle++;
+        heartbeatMode = "idle";
       }
 
-      // Intervalo: base + (ciclos_inactivos * step), con cap máximo
-      const nextInterval = Math.min(
-        intervalMin + (inactiveCycles * INTERVAL_STEP_MIN),
-        MAX_INTERVAL_MIN
-      );
-      debugLog("intervalo adaptativo: " + nextInterval + "min (ciclos_inactivos=" + inactiveCycles + ", agentes_activos=" + active + ")");
+      // Intervalo adaptativo: 10 base, +10 por cada ciclo inactivo, cap 60
+      const nextInterval = active ? intervalMin : Math.min(intervalMin + (consecutiveIdle * INTERVAL_STEP_MIN), MAX_INTERVAL_MIN);
+      heartbeatIntervalMin = nextInterval;
+      previousMode = heartbeatMode;
+
+      debugLog("intervalo adaptativo: " + nextInterval + "min (consecutiveIdle=" + consecutiveIdle + ", modo=" + heartbeatMode + ")");
+
+      // Enviar reporte con el modo actualizado en los captions
+      await sendPeriodicReport();
+
+      // Persistir estado para sobrevivir reinicios
+      saveHeartbeatState(nextInterval, consecutiveIdle, heartbeatMode);
 
       setTimeout(adaptiveLoop, nextInterval * 60 * 1000);
     }

--- a/.claude/hooks/tests/test-p30-heartbeat-adaptativo.js
+++ b/.claude/hooks/tests/test-p30-heartbeat-adaptativo.js
@@ -1,0 +1,210 @@
+// Test P-30: Heartbeat Telegram - frecuencia adaptativa (#1396)
+// Verifica la lógica de intervalo adaptativo en reporter-bg.js:
+// - Detección de actividad por sesiones (.claude/sessions/*.json) con threshold 15 min
+// - Persistencia de estado en heartbeat-state.json
+// - Progresión de intervalos: 10 → 20 → 30 → ... → 60 min
+// - Indicador de modo en captions (💚 normal / 💤 inactivo)
+// - Mensaje de transición al detectar actividad después de inactividad
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const path = require("path");
+
+const REPORTER_FILE = path.join(__dirname, "..", "reporter-bg.js");
+const reporterSrc = fs.readFileSync(REPORTER_FILE, "utf8");
+
+describe("P-30: Heartbeat - frecuencia adaptativa (#1396)", () => {
+
+    describe("Detección de actividad por sesiones", () => {
+        it("define la función hasActiveSessions", () => {
+            assert.ok(reporterSrc.includes("function hasActiveSessions"), "Debe definir hasActiveSessions");
+        });
+        it("lee la carpeta .claude/sessions/ para detectar actividad", () => {
+            assert.ok(reporterSrc.includes("SESSIONS_DIR"), "Debe usar SESSIONS_DIR");
+            assert.ok(reporterSrc.includes("sessions"), "Debe apuntar al directorio sessions");
+        });
+        it("verifica el campo status === active en cada sesión", () => {
+            assert.ok(reporterSrc.includes('session.status === "active"'), 'Debe verificar status === "active"');
+        });
+        it("usa last_activity_ts para calcular tiempo de actividad (no started_ts)", () => {
+            assert.ok(reporterSrc.includes("last_activity_ts"), "Debe usar last_activity_ts");
+        });
+        it("define ACTIVITY_THRESHOLD_MIN como umbral de actividad", () => {
+            assert.ok(reporterSrc.includes("ACTIVITY_THRESHOLD_MIN"), "Debe definir ACTIVITY_THRESHOLD_MIN");
+        });
+        it("el threshold de actividad es 15 minutos", () => {
+            assert.ok(reporterSrc.includes("ACTIVITY_THRESHOLD_MIN = 15"), "El threshold debe ser 15 minutos");
+        });
+        it("solo archivos .json se procesan del directorio de sesiones", () => {
+            assert.ok(reporterSrc.includes('.endsWith(".json")'), "Debe filtrar archivos .json");
+        });
+        it("retorna false si la carpeta sessions no existe", () => {
+            assert.ok(reporterSrc.includes("existsSync(SESSIONS_DIR)"), "Debe verificar si el directorio existe");
+        });
+    });
+
+    describe("Persistencia de estado en heartbeat-state.json", () => {
+        it("define la constante HEARTBEAT_STATE_FILE", () => {
+            assert.ok(reporterSrc.includes("HEARTBEAT_STATE_FILE"), "Debe definir HEARTBEAT_STATE_FILE");
+        });
+        it("el archivo de estado apunta a heartbeat-state.json", () => {
+            assert.ok(reporterSrc.includes("heartbeat-state.json"), "El archivo de estado debe ser heartbeat-state.json");
+        });
+        it("define la función loadHeartbeatState", () => {
+            assert.ok(reporterSrc.includes("function loadHeartbeatState"), "Debe definir loadHeartbeatState");
+        });
+        it("define la función saveHeartbeatState", () => {
+            assert.ok(reporterSrc.includes("function saveHeartbeatState"), "Debe definir saveHeartbeatState");
+        });
+        it("el estado persistido incluye currentInterval", () => {
+            assert.ok(reporterSrc.includes("currentInterval"), "El estado debe incluir currentInterval");
+        });
+        it("el estado persistido incluye consecutiveIdle", () => {
+            assert.ok(reporterSrc.includes("consecutiveIdle"), "El estado debe incluir consecutiveIdle");
+        });
+        it("el estado persistido incluye lastHeartbeat", () => {
+            assert.ok(reporterSrc.includes("lastHeartbeat"), "El estado debe incluir lastHeartbeat");
+        });
+        it("el estado persistido incluye mode (normal/idle)", () => {
+            assert.ok(reporterSrc.includes('"mode"') || reporterSrc.includes("mode:"), "El estado debe incluir mode");
+        });
+        it("carga el estado previo al arrancar (sobrevive reinicios)", () => {
+            assert.ok(reporterSrc.includes("loadHeartbeatState"), "Debe llamar a loadHeartbeatState al arrancar");
+        });
+        it("guarda el estado tras cada ciclo", () => {
+            assert.ok(reporterSrc.includes("saveHeartbeatState"), "Debe llamar a saveHeartbeatState tras cada ciclo");
+        });
+    });
+
+    describe("Progresión de intervalos adaptativos", () => {
+        it("define MAX_INTERVAL_MIN como cap máximo", () => {
+            assert.ok(reporterSrc.includes("MAX_INTERVAL_MIN"), "Debe definir MAX_INTERVAL_MIN");
+        });
+        it("el cap máximo es 60 minutos", () => {
+            assert.ok(reporterSrc.includes("MAX_INTERVAL_MIN = 60"), "El cap máximo debe ser 60 minutos");
+        });
+        it("define INTERVAL_STEP_MIN como incremento por ciclo inactivo", () => {
+            assert.ok(reporterSrc.includes("INTERVAL_STEP_MIN"), "Debe definir INTERVAL_STEP_MIN");
+        });
+        it("el incremento por ciclo inactivo es 10 minutos", () => {
+            assert.ok(reporterSrc.includes("INTERVAL_STEP_MIN = 10"), "El incremento debe ser 10 minutos");
+        });
+        it("usa Math.min para respetar el cap máximo de 60 min", () => {
+            assert.ok(reporterSrc.includes("Math.min("), "Debe usar Math.min para el cap máximo");
+            assert.ok(reporterSrc.includes("MAX_INTERVAL_MIN"), "Debe incluir MAX_INTERVAL_MIN en el Math.min");
+        });
+        it("usa consecutiveIdle para calcular el siguiente intervalo", () => {
+            assert.ok(reporterSrc.includes("consecutiveIdle"), "Debe usar consecutiveIdle en el cálculo");
+        });
+        it("reinicia consecutiveIdle a 0 cuando hay actividad", () => {
+            assert.ok(reporterSrc.includes("consecutiveIdle = 0"), "Debe reiniciar consecutiveIdle a 0 al detectar actividad");
+        });
+        it("incrementa consecutiveIdle cuando no hay actividad", () => {
+            assert.ok(reporterSrc.includes("consecutiveIdle++"), "Debe incrementar consecutiveIdle cuando no hay actividad");
+        });
+        it("con actividad, el intervalo vuelve al base (10 min)", () => {
+            // La formula debe devolver intervalMin cuando active === true
+            assert.ok(
+                reporterSrc.includes("active ? intervalMin :"),
+                "Con actividad debe volver al intervalo base"
+            );
+        });
+    });
+
+    describe("Variables de estado de módulo", () => {
+        it("define heartbeatMode como variable de módulo", () => {
+            assert.ok(reporterSrc.includes('heartbeatMode = "normal"') || reporterSrc.includes("let heartbeatMode"), "Debe definir heartbeatMode");
+        });
+        it("define heartbeatIntervalMin como variable de módulo", () => {
+            assert.ok(reporterSrc.includes("heartbeatIntervalMin"), "Debe definir heartbeatIntervalMin");
+        });
+        it("el modo inicial es normal", () => {
+            assert.ok(reporterSrc.includes('"normal"'), "El modo inicial debe ser normal");
+        });
+        it("el intervalo inicial es 10 minutos", () => {
+            assert.ok(reporterSrc.includes("heartbeatIntervalMin = 10") || reporterSrc.includes("= 10;"), "El intervalo inicial debe ser 10 minutos");
+        });
+    });
+
+    describe("Indicadores de modo en captions", () => {
+        it("el modo normal usa el emoji 💚 en el caption", () => {
+            // 💚 = \uD83D\uDC9A (emoji verde corazón)
+            assert.ok(
+                reporterSrc.includes("\\ud83d\\udc9a") || reporterSrc.includes("\uD83D\uDC9A") || reporterSrc.includes("💚"),
+                "El modo normal debe usar el emoji 💚"
+            );
+        });
+        it("el modo inactivo usa el emoji 💤 en el caption", () => {
+            // 💤 = \uD83D\uDCA4
+            assert.ok(
+                reporterSrc.includes("\\ud83d\\udca4") || reporterSrc.includes("\uD83D\uDCA4") || reporterSrc.includes("💤"),
+                "El modo inactivo debe usar el emoji 💤"
+            );
+        });
+        it("el caption incluye el intervalo actual en minutos", () => {
+            assert.ok(
+                reporterSrc.includes("heartbeatIntervalMin") && reporterSrc.includes("min)"),
+                "El caption debe incluir el intervalo actual"
+            );
+        });
+        it("el caption de inactividad incluye 'sin actividad'", () => {
+            assert.ok(reporterSrc.includes("sin actividad"), "El caption de inactividad debe decir 'sin actividad'");
+        });
+        it("el modeLabel se usa en el caption de secciones (KPIs)", () => {
+            assert.ok(reporterSrc.includes("modeLabel"), "El modeLabel debe usarse en los captions");
+        });
+    });
+
+    describe("Mensaje de transición inactivo → normal", () => {
+        it("envía mensaje de Telegram al detectar transición de idle a normal", () => {
+            assert.ok(reporterSrc.includes("wasIdle"), "Debe detectar la transición usando wasIdle");
+        });
+        it("solo envía el mensaje de transición cuando se pasa de idle a normal (no en normal→normal)", () => {
+            // Debe verificar previousMode === "idle" antes de enviar
+            assert.ok(
+                reporterSrc.includes('previousMode === "idle"') || reporterSrc.includes("wasIdle"),
+                "Debe verificar el modo previo antes de enviar mensaje de transición"
+            );
+        });
+        it("el mensaje de transición menciona volver al monitoreo normal", () => {
+            assert.ok(
+                reporterSrc.includes("monitoreo normal") || reporterSrc.includes("volviendo a monitoreo"),
+                "El mensaje de transición debe mencionar el retorno al monitoreo normal"
+            );
+        });
+        it("el mensaje de transición usa sendTelegramText (no sendTelegramPhoto)", () => {
+            // La transición se notifica como texto, no como screenshot
+            const transitionIdx = reporterSrc.indexOf("wasIdle");
+            assert.ok(transitionIdx !== -1, "Debe existir wasIdle");
+            // Verificar que hay un sendTelegramText cerca del bloque wasIdle
+            const snippet = reporterSrc.substring(transitionIdx, transitionIdx + 500);
+            assert.ok(snippet.includes("sendTelegramText"), "La transición debe usar sendTelegramText");
+        });
+    });
+
+    describe("Función adaptiveLoop — integración general", () => {
+        it("define la función adaptiveLoop dentro del modo daemon", () => {
+            assert.ok(reporterSrc.includes("function adaptiveLoop"), "Debe definir adaptiveLoop");
+        });
+        it("usa hasActiveSessions en lugar de hasActiveAgents para detectar actividad", () => {
+            assert.ok(reporterSrc.includes("hasActiveSessions()"), "Debe usar hasActiveSessions para detectar actividad");
+        });
+        it("actualiza heartbeatMode antes de llamar sendPeriodicReport dentro de adaptiveLoop", () => {
+            // Verificar dentro del cuerpo de adaptiveLoop que heartbeatMode se asigna antes de la llamada
+            const loopIdx = reporterSrc.indexOf("async function adaptiveLoop");
+            assert.ok(loopIdx !== -1, "Debe existir adaptiveLoop");
+            const loopBody = reporterSrc.substring(loopIdx, loopIdx + 3000);
+            const modeSetIdx = loopBody.indexOf("heartbeatMode =");
+            const callIdx = loopBody.indexOf("sendPeriodicReport");
+            assert.ok(modeSetIdx !== -1 && callIdx !== -1, "Ambas referencias deben existir en adaptiveLoop");
+            assert.ok(modeSetIdx < callIdx, "heartbeatMode debe asignarse antes de la llamada a sendPeriodicReport");
+        });
+        it("programa el siguiente ciclo con setTimeout usando el intervalo calculado", () => {
+            assert.ok(reporterSrc.includes("setTimeout(adaptiveLoop"), "Debe programar el siguiente ciclo con setTimeout");
+        });
+        it("el intervalo del setTimeout usa minutos convertidos a milisegundos (* 60 * 1000)", () => {
+            assert.ok(reporterSrc.includes("* 60 * 1000"), "El intervalo debe convertirse a milisegundos");
+        });
+    });
+
+});


### PR DESCRIPTION
## Resumen

Implementar frecuencia adaptativa en el heartbeat de Telegram del monitor:
- **Modo normal**: 10 minutos cuando hay agentes activos (last_activity_ts < 15 min)
- **Modo inactivo**: Incremento progresivo 20 → 30 → 40 → 50 → 60 minutos sin actividad
- **Transición**: Al detectar actividad, volver inmediatamente a 10 minutos + mensaje de transición
- **Persistencia**: Estado guardado en `heartbeat-state.json` para sobrevivir reinicios
- **Indicadores visuales**: 💚 normal / 💤 inactivo en los captions del heartbeat

## Cambios principales

### reporter-bg.js
- Nueva función `hasActiveSessions()`: detecta sesiones activas leyendo `.claude/sessions/*.json`
  - Threshold: `last_activity_ts` dentro de los últimos 15 minutos
  - Únicamente sessiones con `status === "active"`
- Nuevas funciones `loadHeartbeatState()` y `saveHeartbeatState()`: persistencia del estado
  - Archivo: `.claude/hooks/heartbeat-state.json`
  - Contenido: `{ currentInterval, consecutiveIdle, lastHeartbeat, mode }`
- Modificación de `adaptiveLoop()`:
  - Carga estado al arrancar (sobrevive reinicios)
  - Usa `hasActiveSessions()` en lugar de `hasActiveAgents()`
  - Detecta transición idle→normal y envía mensaje por Telegram
  - Calcula intervalo: `active ? 10 : Math.min(10 + (consecutiveIdle * 10), 60)`
  - Envía reporte DESPUÉS de actualizar modo
  - Persiste estado tras cada ciclo
- Indicadores en captions:
  - KPIs section: incluye modeLabel con intervalo actual
  - Fallback caption: usa modeLabel
  - Emojis: 💚 normal, 💤 inactivo

### test-p30-heartbeat-adaptativo.js (NUEVO)
- 45 tests cubriendo:
  - Detección de sesiones con `status === "active"` y `last_activity_ts`
  - Persistencia/carga de estado
  - Progresión de intervalos: 10 → 20 → 30 → ... → 60 (Math.min)
  - Variables de módulo (heartbeatMode, heartbeatIntervalMin)
  - Indicadores en captions (💚 normal, 💤 inactivo)
  - Mensaje de transición (🔄)
  - Integración en adaptiveLoop()

## Verificaciones

- ✅ 556/556 tests pasan (incluyendo P-30 con 45 nuevos tests)
- ✅ Build completo exitoso (12m 4s)
- ✅ Security: aprobado (sin findings críticos/altos)
- ✅ Code review: aprobado sin bloqueantes

## Criterios de aceptación

- [x] Con agentes activos, heartbeat se envía cada 10 minutos
- [x] Sin actividad, el intervalo incrementa en +10 min por ciclo hasta 60 min máximo
- [x] Al detectar nueva actividad, vuelve inmediatamente a 10 minutos
- [x] El mensaje incluye indicador visual del modo actual (💚 normal / 💤 inactivo)
- [x] El estado persiste en `heartbeat-state.json` para sobrevivir reinicios del proceso
- [x] La detección de actividad se basa en `last_activity_ts` de sesiones (no en existencia de archivos)

Closes #1396

🤖 Generado con [Claude Code](https://claude.ai/claude-code)