### PR TITLE
fix(monitor): ocultar tarjeta y panel CI/CD cuando no hay datos

### DIFF
--- a/.claude/dashboard-server.js
+++ b/.claude/dashboard-server.js
@@ -2038,11 +2038,11 @@ function renderHTML(data, theme) {
         <div class="kl">Permisos</div>
         <div class="kt" style="color:${permStats.pending > 0 ? 'var(--yellow)' : 'var(--green)'}">${permStats.pending > 0 ? permStats.pending + ' pendiente(s)' : permStats.auto + ' auto'}</div>
       </div>
-      <div class="kpi ${data.ciStatus === 'ok' ? 'kpi-green' : data.ciStatus === 'fail' ? 'kpi-red' : 'kpi-orange'}">
+      ${data.ciStatus !== 'unknown' ? `<div class="kpi ${data.ciStatus === 'ok' ? 'kpi-green' : data.ciStatus === 'fail' ? 'kpi-red' : 'kpi-orange'}">
         <div class="kv" style="color:${data.ciStatus === 'ok' ? 'var(--green)' : data.ciStatus === 'fail' ? 'var(--red)' : 'var(--yellow)'}">${data.ciStatus === 'ok' ? '&#10003;' : data.ciStatus === 'fail' ? '&#10007;' : '&#9203;'}</div>
         <div class="kl">CI / CD</div>
-        <div class="kt" style="color:${data.ciStatus === 'ok' ? 'var(--green)' : data.ciStatus === 'fail' ? 'var(--red)' : 'var(--yellow)'}">${data.ciStatus === 'ok' ? 'Build OK' : data.ciStatus === 'fail' ? 'Build FAIL' : data.ciStatus === 'running' ? 'En curso...' : 'Sin datos'}</div>
-      </div>
+        <div class="kt" style="color:${data.ciStatus === 'ok' ? 'var(--green)' : data.ciStatus === 'fail' ? 'var(--red)' : 'var(--yellow)'}">${data.ciStatus === 'ok' ? 'Build OK' : data.ciStatus === 'fail' ? 'Build FAIL' : 'En curso...'}</div>
+      </div>` : ''}
       <div class="kpi kpi-orange">
         <div class="kv" style="color:var(--orange)">${data.totalActions}</div>
         <div class="kl">Acciones hoy</div>
@@ -2110,11 +2110,11 @@ function renderHTML(data, theme) {
       </div>
     </div>
 
-    <!-- CI -->
-    <div class="panel" style="margin-bottom:16px;" data-panel="ci">
+    <!-- CI (solo si hay datos) -->
+    ${data.ciRuns.length > 0 ? `<div class="panel" style="margin-bottom:16px;" data-panel="ci">
       <div class="panel-title">CI / CD</div>
       ${ciHtml}
-    </div>
+    </div>` : ''}
 
   </div>
 

--- a/scripts/roadmap.json
+++ b/scripts/roadmap.json
@@ -1,44 +1,233 @@
 {
-  "updated_ts": "2026-03-10T22:32:58.717Z",
-  "updated_by": "scrum-close",
+  "updated_ts": "2026-03-11T16:36:59.117Z",
+  "updated_by": "scrum close",
   "horizon_sprints": 7,
   "sprints": [
     {
       "id": "SPR-021",
-      "start": "2026-03-24",
-      "end": "2026-03-28",
-      "tema": "Continuar UX contraseñas + Dashboard screenshots",
+      "start": "2026-03-10",
+      "end": "2026-03-14",
+      "tema": "Sprint técnico — infra crítica: sesiones, scrum, dashboard sync, UX contraseñas, heartbeat",
+      "status": "done",
+      "closed_at": "2026-03-11T15:14:27Z",
+      "velocity": 11,
       "issues": [
         {
-          "number": 1390,
-          "title": "fix(monitor): sincronizar dashboard y Project V2...",
+          "number": 1394,
+          "title": "fix(hooks): sesiones GC lifecycle",
           "size": "M",
           "stream": "E",
-          "status": "planned"
-        },
-        {
-          "number": 1380,
-          "title": "bug(monitor): heartbeat Telegram screenshots",
-          "size": "M",
-          "stream": "E",
-          "status": "planned"
+          "status": "done",
+          "pr": 1397
         },
         {
           "number": 1148,
-          "title": "[UX] Agregar indicador de fortaleza contraseña",
+          "title": "[UX] Indicador fortaleza contraseñas",
           "size": "S",
           "stream": "B",
-          "status": "planned"
+          "status": "done",
+          "pr": 1398
+        },
+        {
+          "number": 1395,
+          "title": "feat(scrum): replanificación sprint close",
+          "size": "M",
+          "stream": "E",
+          "status": "done",
+          "pr": 1401
+        },
+        {
+          "number": 1390,
+          "title": "fix(monitor): sync dashboard Project V2",
+          "size": "M",
+          "stream": "E",
+          "status": "done",
+          "pr": 1400
+        },
+        {
+          "number": 1399,
+          "title": "fix(hooks): agent-concurrency launch fix",
+          "size": "M",
+          "stream": "E",
+          "status": "done",
+          "pr": 1402
+        },
+        {
+          "number": 1403,
+          "title": "bug(monitor): heartbeat fallback ASCII",
+          "size": "M",
+          "stream": "E",
+          "status": "done",
+          "pr": 1407
+        },
+        {
+          "number": 1404,
+          "title": "bug(monitor): permisos panel sync",
+          "size": "S",
+          "stream": "E",
+          "status": "done",
+          "pr": 1405
+        },
+        {
+          "number": 1383,
+          "title": "fix(monitor): activity-logger TodoWrite",
+          "size": "S",
+          "stream": "E",
+          "status": "done",
+          "pr": 1406
+        },
+        {
+          "number": 1380,
+          "title": "bug(monitor): heartbeat screenshots",
+          "size": "M",
+          "stream": "E",
+          "status": "done",
+          "pr": 1409
         },
         {
           "number": 1145,
-          "title": "[UX] Separar cambio contraseña temporal",
+          "title": "[UX] Pantalla dedicada cambio contraseña",
           "size": "M",
           "stream": "B",
+          "status": "done",
+          "pr": 1410
+        },
+        {
+          "number": 1396,
+          "title": "feat(monitor): heartbeat frecuencia adaptativa",
+          "size": "S",
+          "stream": "E",
+          "status": "done"
+        }
+      ]
+    },
+    {
+      "id": "SPR-022",
+      "start": "2026-03-17",
+      "end": "2026-03-21",
+      "tema": "Pendiente de planificación",
+      "status": "planned",
+      "issues": [
+        {
+          "number": 1412,
+          "title": "bug(monitor): dashboard-server zombie heartbeats",
+          "size": "M",
+          "stream": "E",
+          "status": "planned"
+        },
+        {
+          "number": 1408,
+          "title": "bug(hooks): sesiones zombie en worktrees PID check",
+          "size": "M",
+          "stream": "E",
+          "status": "planned"
+        },
+        {
+          "number": 1413,
+          "title": "fix(monitor): ocultar CI/CD sin datos",
+          "size": "S",
+          "stream": "E",
+          "status": "planned"
+        },
+        {
+          "number": 1415,
+          "title": "fix(monitor): prevenir instancias zombie dashboard-server",
+          "size": "M",
+          "stream": "E",
+          "status": "planned"
+        },
+        {
+          "number": 1414,
+          "title": "fix(monitor): frecuencia adaptativa en dashboard-server",
+          "size": "M",
+          "stream": "E",
+          "status": "planned"
+        },
+        {
+          "number": 1416,
+          "title": "refactor(monitor): unificar heartbeat reporter",
+          "size": "L",
+          "stream": "E",
+          "status": "planned"
+        },
+        {
+          "number": 1417,
+          "title": "feat(monitor): sincronización automática sprint ↔ roadmap ↔ dashboard ↔ Telegram",
+          "size": "L",
+          "stream": "E",
+          "status": "planned"
+        },
+        {
+          "number": 1418,
+          "title": "fix(monitor): mejorar panel Flujo de Agentes — flechas enumeradas, layout, iconos",
+          "size": "M",
+          "stream": "E",
+          "status": "planned"
+        },
+        {
+          "number": 1419,
+          "title": "feat(monitor): persistencia y archivado de métricas de agentes entre sprints",
+          "size": "M",
+          "stream": "E",
+          "status": "planned"
+        },
+        {
+          "number": 1420,
+          "title": "feat(scrum): mantener roadmap 7-10 sprints planificados — proponer historias si faltan",
+          "size": "L",
+          "stream": "E",
           "status": "planned"
         }
       ]
+    },
+    {
+      "id": "SPR-023",
+      "start": "2026-03-24",
+      "end": "2026-03-28",
+      "tema": "Pendiente de planificación",
+      "status": "planned",
+      "issues": []
+    },
+    {
+      "id": "SPR-024",
+      "start": "2026-03-31",
+      "end": "2026-04-04",
+      "tema": "Pendiente de planificación",
+      "status": "planned",
+      "issues": []
+    },
+    {
+      "id": "SPR-025",
+      "start": "2026-04-07",
+      "end": "2026-04-11",
+      "tema": "Pendiente de planificación",
+      "status": "planned",
+      "issues": []
+    },
+    {
+      "id": "SPR-026",
+      "start": "2026-04-14",
+      "end": "2026-04-18",
+      "tema": "Pendiente de planificación",
+      "status": "planned",
+      "issues": []
+    },
+    {
+      "id": "SPR-027",
+      "start": "2026-04-21",
+      "end": "2026-04-25",
+      "tema": "Pendiente de planificación",
+      "status": "planned",
+      "issues": []
+    },
+    {
+      "id": "SPR-028",
+      "start": "2026-04-28",
+      "end": "2026-05-02",
+      "tema": "Pendiente de planificación",
+      "status": "planned",
+      "issues": []
     }
   ],
-  "migration_note": "4 issues del sprint anterior (SPR-020) trasladados a SPR-021 (pendientes). Revisar con /planner para agregar nuevas historias del backlog"
+  "deferred": []
 }


### PR DESCRIPTION
## Resumen

Ocultar completamente la tarjeta KPI y panel CI/CD del dashboard web cuando no hay datos de ejecuciones de GitHub Actions.

## Cambios

- Tarjeta CI/CD (KPI superior): renderiza solo si `data.ciStatus !== 'unknown'`
- Panel CI/CD completo: renderiza solo si `data.ciRuns.length > 0`
- Elimina el ruido visual "Sin datos" que aparecía constantemente

## Tests

- [ ] Dashboard sin GitHub Actions activos: no aparece tarjeta ni panel CI/CD
- [ ] Dashboard con GitHub Actions: tarjeta y panel aparecen normalmente
- [ ] Cambio es solo renderizado, no afecta lógica de recolección

Closes #1413

🤖 Generado con [Claude Code](https://claude.ai/claude-code)