### PR TITLE
fix(hooks): sesiones zombie en worktrees — #1408

### DIFF
--- a/.claude/hooks/activity-logger.js
+++ b/.claude/hooks/activity-logger.js
@@ -192,6 +192,9 @@ function handleInput() {
         // Detectar sesiones stale periódicamente (cada ~10 invocaciones)
         markStaleSessions();
 
+        // Detectar sesiones zombie (PID muerto + >20min inactivas), throttled a 1/min (#1408)
+        checkZombieSessions();
+
         // Auto-iniciar reporter PNG si no esta corriendo
         ensureReporterRunning();
     } catch(e) {}
@@ -202,6 +205,10 @@ function handleInput() {
 const STALE_CHECK_STATE_FILE = path.join(REPO_ROOT, ".claude", "hooks", "activity-logger-stale-check.json");
 const STALE_THRESHOLD_MS = 2 * 60 * 60 * 1000; // 2 horas
 const STALE_CHECK_EVERY_N = 10;
+
+const ZOMBIE_THRESHOLD_MS = 20 * 60 * 1000; // 20 minutos (threshold configurable)
+const ZOMBIE_CHECK_STATE_FILE = path.join(REPO_ROOT, ".claude", "hooks", "activity-logger-zombie-check.json");
+const ZOMBIE_CHECK_THROTTLE_MS = 60 * 1000; // máximo 1 vez por minuto
 
 function markStaleSessions() {
     try {
@@ -242,6 +249,65 @@ function markStaleSessions() {
         if (staleCount > 0) {
             const logFile = path.join(REPO_ROOT, ".claude", "hooks", "hook-debug.log");
             try { fs.appendFileSync(logFile, "[" + new Date().toISOString() + "] activity-logger: " + staleCount + " sesion(es) marcadas stale\n"); } catch(e) {}
+        }
+    } catch(e) { /* no bloquear hook */ }
+}
+
+// Verifica si un PID de proceso sigue vivo en Windows
+function isPidAlive(pid) {
+    if (!pid) return false;
+    try {
+        const output = execSync('tasklist /FI "PID eq ' + parseInt(pid, 10) + '" /NH', {
+            timeout: 3000, windowsHide: true, encoding: "utf8"
+        });
+        // Si el PID existe, la salida contiene una línea con el nombre del proceso
+        // Si no existe: "No tasks are running which match the specified criteria"
+        return output.indexOf("No tasks") === -1 && output.trim().length > 0;
+    } catch (e) {
+        // Fallback: process.kill(pid, 0) solo verifica existencia sin matar
+        try { process.kill(parseInt(pid, 10), 0); return true; } catch (ke) { return ke.code === "EPERM"; }
+    }
+}
+
+// Detecta sesiones zombie: status "active" + last_activity_ts >20min + PID muerto
+// Throttled: corre como máximo 1 vez por minuto (#1408)
+function checkZombieSessions() {
+    try {
+        // Throttle: solo correr cada ZOMBIE_CHECK_THROTTLE_MS
+        try {
+            if (fs.existsSync(ZOMBIE_CHECK_STATE_FILE)) {
+                const s = JSON.parse(fs.readFileSync(ZOMBIE_CHECK_STATE_FILE, "utf8"));
+                if (s.last_check && (Date.now() - s.last_check) < ZOMBIE_CHECK_THROTTLE_MS) return;
+            }
+        } catch(e) { /* si falla leer el state, continuar */ }
+        fs.writeFileSync(ZOMBIE_CHECK_STATE_FILE, JSON.stringify({ last_check: Date.now() }), "utf8");
+
+        if (!fs.existsSync(SESSIONS_DIR)) return;
+        const now = Date.now();
+        const files = fs.readdirSync(SESSIONS_DIR).filter(f => f.endsWith(".json"));
+        let zombieCount = 0;
+        for (const file of files) {
+            try {
+                const filePath = path.join(SESSIONS_DIR, file);
+                const session = JSON.parse(fs.readFileSync(filePath, "utf8"));
+                if (session.status !== "active") continue;
+                const age = now - new Date(session.last_activity_ts || 0).getTime();
+                if (age > ZOMBIE_THRESHOLD_MS && session.pid) {
+                    if (!isPidAlive(session.pid)) {
+                        session.status = "done";
+                        session.completed_at = session.last_activity_ts;
+                        // Escritura atómica: tmp + rename
+                        const tmpPath = filePath + ".tmp";
+                        fs.writeFileSync(tmpPath, JSON.stringify(session, null, 2) + "\n", "utf8");
+                        fs.renameSync(tmpPath, filePath);
+                        zombieCount++;
+                    }
+                }
+            } catch(e) { /* ignorar errores por archivo */ }
+        }
+        if (zombieCount > 0) {
+            const logFile = path.join(REPO_ROOT, ".claude", "hooks", "hook-debug.log");
+            try { fs.appendFileSync(logFile, "[" + new Date().toISOString() + "] activity-logger: " + zombieCount + " sesion(es) zombie marcadas done (PID muerto)\n"); } catch(e) {}
         }
     } catch(e) { /* no bloquear hook */ }
 }

--- a/.claude/hooks/agent-concurrency-check.js
+++ b/.claude/hooks/agent-concurrency-check.js
@@ -138,6 +138,58 @@ function releaseLock() {
     try { fs.unlinkSync(LOCK_FILE); } catch (e) {}
 }
 
+// ─── Detección de sesiones zombie (#1408) ────────────────────────────────────
+
+const ZOMBIE_THRESHOLD_MS = 20 * 60 * 1000; // 20 minutos (threshold configurable)
+
+// Verifica si un PID de proceso sigue vivo en Windows
+function isPidAlive(pid) {
+    if (!pid) return false;
+    try {
+        const { execSync } = require("child_process");
+        const output = execSync('tasklist /FI "PID eq ' + parseInt(pid, 10) + '" /NH', {
+            timeout: 3000, windowsHide: true, encoding: "utf8"
+        });
+        return output.indexOf("No tasks") === -1 && output.trim().length > 0;
+    } catch (e) {
+        try { process.kill(parseInt(pid, 10), 0); return true; } catch (ke) { return ke.code === "EPERM"; }
+    }
+}
+
+/**
+ * Marca sesiones zombie como done y retorna el Set de issue numbers afectados.
+ * Idempotente: ejecutar 2 veces no causa problemas.
+ * Solo actualiza status — NO mata procesos.
+ */
+function markZombieSessions() {
+    const zombieIssues = new Set();
+    try {
+        if (!fs.existsSync(SESSIONS_DIR)) return zombieIssues;
+        const now = Date.now();
+        const files = fs.readdirSync(SESSIONS_DIR).filter(f => f.endsWith(".json"));
+        for (const file of files) {
+            try {
+                const filePath = path.join(SESSIONS_DIR, file);
+                const session = JSON.parse(fs.readFileSync(filePath, "utf8"));
+                if (session.status !== "active") continue;
+                const age = now - new Date(session.last_activity_ts || 0).getTime();
+                if (age > ZOMBIE_THRESHOLD_MS && session.pid) {
+                    if (!isPidAlive(session.pid)) {
+                        session.status = "done";
+                        session.completed_at = session.last_activity_ts;
+                        fs.writeFileSync(filePath, JSON.stringify(session, null, 2) + "\n", "utf8");
+                        // Extraer issue number del branch para excluirlo del conteo de slots
+                        const branchMatch = (session.branch || "").match(/\/(\d+)-/);
+                        if (branchMatch) zombieIssues.add(parseInt(branchMatch[1], 10));
+                        log("Zombie detectado: sesion " + (session.id || file) + " (branch=" + session.branch + ", PID=" + session.pid + " muerto) → done");
+                    }
+                }
+            } catch(e) { /* ignorar errores por archivo */ }
+        }
+    } catch(e) { log("markZombieSessions error: " + e.message); }
+    return zombieIssues;
+}
+
 // ─── Leer/escribir sprint-plan.json ─────────────────────────────────────────
 
 function loadPlan() {
@@ -530,8 +582,16 @@ async function processInput() {
             log("total_stories calculado: " + plan.total_stories);
         }
 
+        // Verificar y marcar sesiones zombie antes de evaluar slots disponibles (#1408)
+        // Garantiza conteo correcto cuando Stop no se disparó en sesiones anteriores
+        const zombieIssues = markZombieSessions();
+        if (zombieIssues.size > 0) {
+            log("Sesiones zombie marcadas: issues " + Array.from(zombieIssues).join(", ") + " → excluidos del conteo de slots");
+        }
+
         // Contar solo agentes no-waiting: los waiting ya liberaron su slot al entrar en espera (#1356)
-        const afterCount = plan.agentes.filter(ag => ag.status !== "waiting").length;
+        // Excluir agentes cuya sesión es zombie (PID muerto, slot ya no está ocupado) (#1408)
+        const afterCount = plan.agentes.filter(ag => ag.status !== "waiting" && !zombieIssues.has(ag.issue)).length;
         const waitingCount = plan.agentes.filter(ag => ag.status === "waiting").length;
         log(
             "Agentes activos (no-waiting): " + afterCount + "/" + concurrencyLimit +

--- a/.claude/hooks/stop-notify.js
+++ b/.claude/hooks/stop-notify.js
@@ -172,20 +172,49 @@ function markSessionDone(sessionId) {
     } catch(e) { log("Error marcando sesion done: " + e.message); }
 }
 
+// Verifica si un PID de proceso sigue vivo en Windows
+function isPidAlive(pid) {
+    if (!pid) return false;
+    try {
+        const { execSync } = require("child_process");
+        const output = execSync('tasklist /FI "PID eq ' + parseInt(pid, 10) + '" /NH', {
+            timeout: 3000, windowsHide: true, encoding: "utf8"
+        });
+        return output.indexOf("No tasks") === -1 && output.trim().length > 0;
+    } catch (e) {
+        try { process.kill(parseInt(pid, 10), 0); return true; } catch (ke) { return ke.code === "EPERM"; }
+    }
+}
+
 function cleanOldSessions() {
     try {
         if (!fs.existsSync(SESSIONS_DIR)) return;
         const files = fs.readdirSync(SESSIONS_DIR).filter(f => f.endsWith(".json"));
         const now = Date.now();
         const MAX_AGE_MS = 2 * 60 * 60 * 1000; // 2 horas (safety net — dashboard ya filtra a 15min)
+        const ZOMBIE_THRESHOLD_MS = 20 * 60 * 1000; // 20 minutos (threshold configurable, #1408)
         let cleaned = 0;
+        let zombies = 0;
 
         for (const file of files) {
             try {
                 const filePath = path.join(SESSIONS_DIR, file);
                 const session = JSON.parse(fs.readFileSync(filePath, "utf8"));
 
-                // Solo limpiar sessions terminadas
+                // GC periódico: marcar sesiones activas con PID muerto como done (#1408)
+                // Solo actualiza el status — NO mata procesos. Idempotente.
+                if (session.status === "active" && session.pid) {
+                    const age = now - new Date(session.last_activity_ts || 0).getTime();
+                    if (age > ZOMBIE_THRESHOLD_MS && !isPidAlive(session.pid)) {
+                        session.status = "done";
+                        session.completed_at = session.last_activity_ts;
+                        fs.writeFileSync(filePath, JSON.stringify(session, null, 2) + "\n", "utf8");
+                        log("GC zombie: sesion " + (session.id || file) + " marcada done (PID=" + session.pid + " muerto, edad=" + Math.round(age / 60000) + "min)");
+                        zombies++;
+                    }
+                }
+
+                // Solo limpiar sessions terminadas con más de 2h de antigüedad
                 if (session.status !== "done") continue;
 
                 const lastActivity = new Date(session.last_activity_ts || 0).getTime();
@@ -199,6 +228,7 @@ function cleanOldSessions() {
             }
         }
 
+        if (zombies > 0) log("GC: " + zombies + " sesion(es) zombie marcadas done");
         if (cleaned > 0) log("Rotacion: " + cleaned + " session(s) antiguas eliminadas");
     } catch(e) { log("Error en rotacion de sessions: " + e.message); }
 }


### PR DESCRIPTION
## Resumen

Implementación de detección automática de sesiones zombie en worktrees de agentes. Resuelve el problema #1394 donde sesiones de agentes completados quedan marcadas como `active` indefinidamente cuando el hook Stop no se dispara.

### Cambios

1. **activity-logger.js** — `checkZombieSessions()`
   - Detecta sesiones con `status: "active"` + `last_activity_ts` > 20 min + PID muerto
   - Throttled a 1 vez por minuto (fail-safe)
   - Marca sesión como `done` sin matar procesos

2. **agent-concurrency-check.js** — `markZombieSessions()`
   - Ejecuta verificación zombie antes de evaluar slots disponibles
   - Retorna Set de issue numbers afectados
   - Excluye agentes zombie del conteo de concurrencia

3. **stop-notify.js** — Extender `cleanOldSessions()`
   - GC periódico: marcar "active" + PID muerto + >20min como `done`
   - Idempotente, fail-open (no mata procesos)

### Verificaciones

- ✅ Tests Gradle + hooks pasan (0 fallos)
- ✅ Build completo exitoso
- ✅ Security: 0 findings críticos (PID sanitizado)
- ✅ Code Review: 0 bloqueantes (aprobado)

Closes #1408

🤖 Generado con [Claude Code](https://claude.ai/claude-code)