### PR TITLE
feat(monitor): persistencia y archivado de métricas de agentes entre sprints

### DIFF
--- a/.claude/dashboard-server.js
+++ b/.claude/dashboard-server.js
@@ -1797,8 +1797,9 @@ function renderHTML(data, theme) {
     ciHtml = '<div class="empty-state">Sin datos CI</div>';
   }
 
-  // --- AGENT METRICS TABLE (#1226) ---
+  // --- AGENT METRICS TABLE (#1226, #1419) ---
   let agentMetricsHtml = "";
+  const currentSprintId = (data.sprintPlan && data.sprintPlan.sprint_id) || null;
   const metricsEntries = [];
   const activeSessionIds = new Set();
   for (const s of data.sessions) {
@@ -1813,6 +1814,7 @@ function renderHTML(data, theme) {
     metricsEntries.push({
       agent: s.agent_name || "Claude",
       session: s.id,
+      sprintId: s.sprint_id || currentSprintId || "",
       calls: totalCalls || s.action_count || 0,
       files: Array.isArray(s.modified_files) ? s.modified_files.length : 0,
       tasksCreated: s.tasks_created || 0,
@@ -1827,6 +1829,7 @@ function renderHTML(data, theme) {
       metricsEntries.push({
         agent: ms.agent_name || "Claude",
         session: ms.id,
+        sprintId: ms.sprint_id || "",
         calls: ms.total_tool_calls || 0,
         files: ms.modified_files_count || 0,
         tasksCreated: ms.tasks_created || 0,
@@ -1836,9 +1839,31 @@ function renderHTML(data, theme) {
       });
     }
   }
-  const metricsToShow = metricsEntries.slice(0, 8);
+  const metricsToShow = metricsEntries.slice(0, 12);
+  const totalHistoric = data.agentMetrics && Array.isArray(data.agentMetrics.sessions) ? data.agentMetrics.sessions.length : 0;
+  const sprintSessionCount = currentSprintId
+    ? metricsToShow.filter(m => m.sprintId === currentSprintId).length
+    : 0;
   if (metricsToShow.length > 0) {
-    agentMetricsHtml = '<table style="width:100%;font-size:11px;border-collapse:collapse;">';
+    // Filtro toggle por sprint (#1419): botón que muestra solo el sprint activo
+    const filterToggleId = "agMetricsFilter_" + Date.now();
+    agentMetricsHtml = `<div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:6px;">
+      <span style="font-size:10px;color:var(--text-muted);">${totalHistoric > 0 ? 'Hist&oacute;rico: ' + totalHistoric + ' ses.' : ''}</span>
+      ${currentSprintId ? `<button id="${filterToggleId}" onclick="(function(btn){
+        var tbl=btn.closest('.ag-metrics-wrap').querySelector('.ag-metrics-tbl');
+        var rows=tbl.querySelectorAll('tr[data-sprint]');
+        var isFiltered=btn.dataset.filtered==='1';
+        rows.forEach(function(r){
+          if(isFiltered){r.style.display='';}
+          else{r.style.display=(r.dataset.sprint==='${escHtml(currentSprintId)}')?'':'none';}
+        });
+        btn.dataset.filtered=isFiltered?'0':'1';
+        btn.textContent=isFiltered?'Sprint actual':'Todos';
+        btn.style.background=isFiltered?'var(--surface3)':'var(--blue-dim)';
+        btn.style.color=isFiltered?'var(--text-muted)':'var(--blue)';
+      })(this)" data-filtered="0" style="font-size:10px;padding:2px 8px;border:1px solid var(--border);border-radius:4px;background:var(--surface3);color:var(--text-muted);cursor:pointer;">${escHtml(currentSprintId)}</button>` : ''}
+    </div>`;
+    agentMetricsHtml += '<div class="ag-metrics-wrap"><table class="ag-metrics-tbl" style="width:100%;font-size:11px;border-collapse:collapse;">';
     agentMetricsHtml += '<tr style="color:var(--text-muted);border-bottom:1px solid var(--border);">'
       + '<th style="text-align:left;padding:4px;">Agente</th>'
       + '<th style="text-align:left;padding:4px;">Sesi&oacute;n</th>'
@@ -1850,7 +1875,12 @@ function renderHTML(data, theme) {
       const indicator = m.active ? '<span style="color:var(--green);">&#9679;</span> ' : '';
       const tasksStr = m.tasksCompleted + "/" + m.tasksCreated;
       const durStr = m.durMin < 60 ? m.durMin + "m" : Math.floor(m.durMin / 60) + "h " + (m.durMin % 60) + "m";
-      agentMetricsHtml += '<tr style="border-bottom:1px solid var(--border);">'
+      const sprintAttr = m.sprintId ? ' data-sprint="' + escHtml(m.sprintId) + '"' : '';
+      const isCurrentSprint = currentSprintId && m.sprintId === currentSprintId;
+      const rowStyle = isCurrentSprint
+        ? 'border-bottom:1px solid var(--border);background:var(--blue-dim);'
+        : 'border-bottom:1px solid var(--border);';
+      agentMetricsHtml += `<tr style="${rowStyle}"${sprintAttr}>`
         + '<td style="padding:4px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:120px;">' + indicator + escHtml(m.agent) + '</td>'
         + '<td style="padding:4px;font-family:monospace;font-size:10px;">' + escHtml(m.session) + '</td>'
         + '<td style="text-align:right;padding:4px;font-weight:600;">' + m.calls + '</td>'
@@ -1858,12 +1888,13 @@ function renderHTML(data, theme) {
         + '<td style="text-align:right;padding:4px;">' + tasksStr + '</td>'
         + '<td style="text-align:right;padding:4px;">' + durStr + '</td></tr>';
     }
-    agentMetricsHtml += '</table>';
-    const totalHistoric = data.agentMetrics && Array.isArray(data.agentMetrics.sessions) ? data.agentMetrics.sessions.length : 0;
+    agentMetricsHtml += '</table></div>';
     if (totalHistoric > 0) {
       const lastTs = data.agentMetrics.updated_ts;
-      agentMetricsHtml += '<div style="font-size:10px;color:var(--text-muted);margin-top:6px;">'
-        + 'Hist&oacute;rico: ' + totalHistoric + ' sesiones &mdash; &uacute;ltima: ' + formatAge(lastTs) + '</div>';
+      agentMetricsHtml += '<div style="font-size:10px;color:var(--text-muted);margin-top:4px;">'
+        + '&uacute;ltima: ' + formatAge(lastTs)
+        + (currentSprintId && sprintSessionCount > 0 ? ' &mdash; ' + sprintSessionCount + ' en ' + escHtml(currentSprintId) : '')
+        + '</div>';
     }
   } else {
     agentMetricsHtml = '<div class="empty-state">Sin m&eacute;tricas de agentes</div>';

--- a/.claude/hooks/sprint-sync.js
+++ b/.claude/hooks/sprint-sync.js
@@ -408,6 +408,84 @@ function reconcileRoadmap(plan, roadmap) {
     return changes;
 }
 
+// ─── Archivado de métricas por sprint (#1419) ─────────────────────────────────
+
+const AGENT_METRICS_FILE   = path.join(HOOKS_DIR, "agent-metrics.json");
+const METRICS_ARCHIVE_DIR  = path.join(HOOKS_DIR, "metrics-archive");
+
+/**
+ * Archiva las métricas del sprint cerrado en metrics-archive/agent-metrics-SPR-NNN.json.
+ * Solo crea el archivo si no existe ya (idempotente).
+ * Mantiene el archivo original intacto — el siguiente sprint lo sigue usando.
+ *
+ * @param {object} plan - sprint-plan.json actual
+ * @returns {{ ok: boolean, archiveFile?: string, message?: string }}
+ */
+function archiveSprintMetrics(plan) {
+    if (!plan || !plan.sprint_id) {
+        return { ok: false, message: "sprint_id no disponible en plan" };
+    }
+
+    const sprintId = plan.sprint_id;
+
+    // Crear directorio de archivo si no existe
+    try {
+        if (!fs.existsSync(METRICS_ARCHIVE_DIR)) {
+            fs.mkdirSync(METRICS_ARCHIVE_DIR, { recursive: true });
+            log("metrics-archive: directorio creado en " + METRICS_ARCHIVE_DIR);
+        }
+    } catch (e) {
+        return { ok: false, message: "Error creando metrics-archive/: " + e.message };
+    }
+
+    const archiveFile = path.join(METRICS_ARCHIVE_DIR, "agent-metrics-" + sprintId + ".json");
+
+    // Idempotente: si el archivo ya existe, no sobreescribir
+    if (fs.existsSync(archiveFile)) {
+        log("metrics-archive: " + sprintId + " ya archivado en " + path.basename(archiveFile));
+        return { ok: true, archiveFile, message: "ya archivado (idempotente)" };
+    }
+
+    // Leer métricas actuales
+    let metricsData;
+    try {
+        if (!fs.existsSync(AGENT_METRICS_FILE)) {
+            return { ok: false, message: "agent-metrics.json no existe — sin datos que archivar" };
+        }
+        metricsData = JSON.parse(fs.readFileSync(AGENT_METRICS_FILE, "utf8"));
+    } catch (e) {
+        return { ok: false, message: "Error leyendo agent-metrics.json: " + e.message };
+    }
+
+    if (!metricsData || !Array.isArray(metricsData.sessions)) {
+        return { ok: false, message: "agent-metrics.json sin sesiones" };
+    }
+
+    // Filtrar solo sesiones del sprint actual
+    const sprintSessions = metricsData.sessions.filter(s => s.sprint_id === sprintId);
+
+    // Calcular velocity (stories completadas con resultado "ok")
+    const completedCount = Array.isArray(plan._completed)
+        ? plan._completed.filter(c => c.resultado === "ok").length
+        : 0;
+
+    const archivePayload = {
+        sprint_id:    sprintId,
+        archived_at:  new Date().toISOString().replace(/\.\d+Z$/, "Z"),
+        velocity:     plan.velocity || completedCount,
+        sessions:     sprintSessions
+    };
+
+    try {
+        fs.writeFileSync(archiveFile, JSON.stringify(archivePayload, null, 2) + "\n", "utf8");
+        log("metrics-archive: " + sprintSessions.length + " sesiones de " + sprintId
+            + " archivadas en " + path.basename(archiveFile));
+        return { ok: true, archiveFile, sessionsArchived: sprintSessions.length };
+    } catch (e) {
+        return { ok: false, message: "Error escribiendo archivo de archivo: " + e.message };
+    }
+}
+
 // ─── runSync: función principal exportada ─────────────────────────────────────
 
 /**
@@ -579,4 +657,4 @@ if (require.main === module) {
     }, 2000);
 }
 
-module.exports = { runSync, syncRoadmapOnly };
+module.exports = { runSync, syncRoadmapOnly, archiveSprintMetrics };

--- a/.claude/hooks/stop-notify.js
+++ b/.claude/hooks/stop-notify.js
@@ -76,6 +76,68 @@ setTimeout(() => { if (!done) { done = true; try { process.stdin.destroy(); } ca
 
 const AGENT_METRICS_FILE = path.join(REPO_ROOT, ".claude", "hooks", "agent-metrics.json");
 
+// Detecta si el proceso corre en un worktree sibling (no es el repo principal)
+function detectWorktreeRoot() {
+    try {
+        const { execSync } = require("child_process");
+        const currentDir = process.env.CLAUDE_PROJECT_DIR || __dirname;
+        const output = execSync("git worktree list", {
+            encoding: "utf8",
+            cwd: currentDir,
+            timeout: 5000,
+            windowsHide: true
+        });
+        const lines = output.split("\n").filter(l => l.trim());
+        if (lines.length === 0) return null;
+        const firstLine = lines[0];
+        const match = firstLine.match(/^(.+?)\s+[0-9a-f]{5,}/);
+        if (!match) return null;
+        const mainPath = match[1].trim()
+            .replace(/^\/([a-z])\//, "$1:\\").replace(/\//g, "\\");
+        const currentNorm = (currentDir || "").replace(/\//g, "\\").toLowerCase();
+        const mainNorm = mainPath.toLowerCase();
+        // Si el repo principal difiere del directorio actual, estamos en worktree
+        if (currentNorm && mainNorm && currentNorm !== mainNorm) {
+            return mainPath; // retorna la ruta del repo principal
+        }
+    } catch (e) { /* fall through */ }
+    return null;
+}
+
+// Consolida sesiones del worktree actual al archivo de métricas del repo principal (#1419)
+// Solo fusiona sesiones que no existan aún en el principal (por session id).
+function consolidateWorktreeMetrics(worktreeMetricsFile, mainRepoRoot) {
+    try {
+        if (!fs.existsSync(worktreeMetricsFile)) return;
+        const mainMetricsFile = path.join(mainRepoRoot, ".claude", "hooks", "agent-metrics.json");
+        const wtData = JSON.parse(fs.readFileSync(worktreeMetricsFile, "utf8"));
+        if (!wtData || !Array.isArray(wtData.sessions) || wtData.sessions.length === 0) return;
+
+        let mainData = { updated_ts: new Date().toISOString(), sessions: [] };
+        try {
+            if (fs.existsSync(mainMetricsFile)) {
+                const existing = JSON.parse(fs.readFileSync(mainMetricsFile, "utf8"));
+                if (existing && Array.isArray(existing.sessions)) mainData = existing;
+            }
+        } catch (e) {}
+
+        const existingIds = new Set(mainData.sessions.map(s => s.id));
+        let merged = 0;
+        for (const session of wtData.sessions) {
+            if (!existingIds.has(session.id)) {
+                mainData.sessions.push(session);
+                existingIds.add(session.id);
+                merged++;
+            }
+        }
+        if (merged > 0) {
+            mainData.updated_ts = new Date().toISOString().replace(/\.\d+Z$/, "Z");
+            fs.writeFileSync(mainMetricsFile, JSON.stringify(mainData, null, 2) + "\n", "utf8");
+            log("Worktree consolidation: " + merged + " sesion(es) mergeadas al repo principal");
+        }
+    } catch (e) { log("Error en consolidateWorktreeMetrics: " + e.message); }
+}
+
 // Leer sprint_id activo desde sprint-plan.json para correlación histórica
 function getActiveSprintId() {
     try {
@@ -152,6 +214,12 @@ function flushMetrics(sessionId) {
         metrics.updated_ts = endedTs;
         fs.writeFileSync(AGENT_METRICS_FILE, JSON.stringify(metrics, null, 2) + "\n", "utf8");
         log("Metricas flushed para sesion " + shortId + " (sprint: " + (entry.sprint_id || "unknown") + ")");
+
+        // Consolidar al repo principal si estamos en un worktree (#1419)
+        const mainRepoRoot = detectWorktreeRoot();
+        if (mainRepoRoot) {
+            consolidateWorktreeMetrics(AGENT_METRICS_FILE, mainRepoRoot);
+        }
     } catch(e) { log("Error en flushMetrics: " + e.message); }
 }
 

--- a/.claude/skills/cleanup/SKILL.md
+++ b/.claude/skills/cleanup/SKILL.md
@@ -661,6 +661,10 @@ Reglas:
 - `.claude/hooks/tg-session-store.json`
 - `.claude/hooks/tg-offsets.json`
 - `.claude/session-state.json`
+- `.claude/hooks/agent-metrics.json` (historial de métricas de agentes — append-only, pérdida irreversible)
+- `.claude/hooks/agent-participation.json` (cobertura de agentes por sprint)
+- `.claude/hooks/heartbeat-state.json` (estado de frecuencia adaptativa del heartbeat)
+- `.claude/hooks/scrum-health-history.jsonl` (historial de salud del board — tendencias a largo plazo)
 
 ### NUNCA usar estos comandos (deny rules)
 - `rm -rf` — usar `node fs.rmSync()` o `node fs.unlinkSync()`

--- a/.claude/skills/scrum/SKILL.md
+++ b/.claude/skills/scrum/SKILL.md
@@ -832,6 +832,29 @@ Actualizar `scripts/sprint-plan.json` agregando:
 
 Mover todos los agentes activos a `_completed`.
 
+### Paso C7b: Archivar métricas de agentes del sprint cerrado (#1419)
+
+Archivar las métricas de sesiones del sprint en `.claude/hooks/metrics-archive/`:
+
+```bash
+cat > /tmp/archive-sprint-metrics.js << 'EOF'
+const path = require('path');
+const REPO_ROOT = '/c/Workspaces/Intrale/platform';
+const sprintSync = require(path.join(REPO_ROOT, '.claude', 'hooks', 'sprint-sync.js'));
+const fs = require('fs');
+const plan = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, 'scripts', 'sprint-plan.json'), 'utf8'));
+const result = sprintSync.archiveSprintMetrics(plan);
+console.log(JSON.stringify(result));
+EOF
+node /tmp/archive-sprint-metrics.js
+```
+
+Parsear el JSON de salida. Si `result.ok === true`:
+- Confirmar: `✓ Métricas archivadas: N sesiones → metrics-archive/agent-metrics-SPR-NNN.json`
+
+Si `result.ok === false`:
+- Reportar el `result.message` como advertencia (no bloquea el cierre del sprint)
+
 ### Paso C8: Sincronizar Project V2
 
 Para cada issue completado (CLOSED) del sprint:


### PR DESCRIPTION
## Resumen

Implementa persistencia y archivado de métricas de agentes entre sprints para evitar pérdida de datos históricos con `/cleanup` accidental.

## Cambios

1. **Protección contra borrado** — 4 archivos de métricas agregados a lista de protegidos en `/cleanup`
2. **Sprint ID** — Cada sesión captura `sprint_id` de `sprint-plan.json` para correlación histórica
3. **Consolidación desde worktrees** — Métricas de agentes en worktrees se fusionan al repo principal
4. **Archivado por sprint** — Función `archiveSprintMetrics()` crea `agent-metrics-SPR-NNN.json` al cerrar sprint
5. **Filtro en dashboard** — Panel "Uso de Agentes" incluye toggle "Sprint actual/Todos"

## Criterios de aceptación

- [x] `agent-metrics.json` está en la lista de archivos protegidos de `/cleanup`
- [x] Cada sesión en `agent-metrics.json` tiene campo `sprint_id` poblado
- [x] Las métricas de agentes en worktrees se consolidan al repo principal
- [x] Al cerrar sprint se crea archivo `agent-metrics-SPR-NNN.json`
- [x] El panel "Uso de Agentes" sobrevive `/cleanup --run` sin perder datos
- [x] El dashboard puede mostrar métricas filtradas por sprint

## Archivos modificados

- `.claude/dashboard-server.js` — Filtro toggle por sprint en panel métricas
- `.claude/hooks/stop-notify.js` — Sprint ID, consolidación worktree (68 líneas)
- `.claude/hooks/sprint-sync.js` — `archiveSprintMetrics()` function (80 líneas)
- `.claude/skills/cleanup/SKILL.md` — 4 archivos a lista de protegidos
- `.claude/skills/scrum/SKILL.md` — Paso C7b para archivado al cerrar sprint

## Tecnología de agentes

- ✅ Node.js scripts (stop-notify, sprint-sync, dashboard-server)
- ✅ Idempotencia (archiveSprintMetrics verifica existencia)
- ✅ Error handling (detectWorktreeRoot, consolidateWorktreeMetrics)
- ✅ XSS prevention (escHtml en dashboard inline JS)

Closes #1419

🤖 Generado con [Claude Code](https://claude.ai/claude-code)