### PR TITLE
feat(hooks): integrar sprint-sync en agent-concurrency-check y post-issue-close

### DIFF
--- a/.claude/hooks/agent-concurrency-check.js
+++ b/.claude/hooks/agent-concurrency-check.js
@@ -18,6 +18,31 @@ const fs = require("fs");
 const path = require("path");
 const { spawn } = require("child_process");
 
+// ─── Sprint sync: actualizar roadmap en puntos clave (#1433) ─────────────────
+
+let _sprintSyncAcc = null;
+function getSprintSyncAcc() {
+    if (_sprintSyncAcc !== null) return _sprintSyncAcc;
+    try {
+        _sprintSyncAcc = require("./sprint-sync");
+    } catch (e) {
+        _sprintSyncAcc = { syncRoadmapOnly: () => {} };
+    }
+    return _sprintSyncAcc;
+}
+
+/**
+ * Llama syncRoadmapOnly(plan) de sprint-sync.js con manejo de errores.
+ * Actualiza roadmap.json a partir del estado actual de sprint-plan.
+ */
+function callSyncRoadmapOnly(plan) {
+    try {
+        getSprintSyncAcc().syncRoadmapOnly(plan);
+    } catch (e) {
+        // No propagar errores del sync para no interrumpir la lógica del hook
+    }
+}
+
 // Bug fix (#1266): Resolver el repo principal desde worktrees.
 // Cuando el hook se ejecuta en un worktree (agent/*), CLAUDE_PROJECT_DIR
 // puede apuntar al worktree vacío. Usamos git worktree list para encontrar
@@ -180,8 +205,6 @@ function releaseLock() {
 }
 
 // ─── Detección de sesiones zombie (#1408) ────────────────────────────────────
-
-const ZOMBIE_THRESHOLD_MS = 20 * 60 * 1000; // 20 minutos (threshold configurable)
 
 // Verifica si un PID de proceso sigue vivo en Windows
 function isPidAlive(pid) {
@@ -630,6 +653,7 @@ async function sweepWaitingAgents(plan) {
             const entry = buildCompletedEntry(ag, null, "ok");
             plan._completed.push(entry);
             log("Sweep: #" + ag.issue + " → _completed (PR mergeada detectada)");
+            callSyncRoadmapOnly(plan); // #1433: actualizar roadmap al completar agente
             freed++;
             await notify(
                 "✅ <b>Agente #" + ag.issue + " completado (sweep periódico)</b>\n" +
@@ -801,6 +825,7 @@ async function processInput() {
                 if (!nextAgente.prompt) nextAgente.prompt = generateDefaultPrompt(nextAgente.issue, nextAgente.slug);
                 plan.agentes = (plan.agentes || []).concat([nextAgente]);
                 setQueue(plan, newQueue);
+                callSyncRoadmapOnly(plan); // #1433: actualizar roadmap al promover
                 savePlan(plan);
                 await updateProjectV2(nextAgente.issue, "In Progress");
                 const launched = launchAgent(nextAgente);
@@ -838,6 +863,7 @@ async function processInput() {
             const completedEntry = buildCompletedEntry(finishingAgent, session, "ok");
             plan._completed.push(completedEntry);
             log("Agente #" + finishingAgent.issue + " → _completed (PR mergeada, duracion=" + completedEntry.duracion_min + "m)");
+            callSyncRoadmapOnly(plan); // #1433: actualizar roadmap al completar agente
             await notify(
                 "✅ <b>Agente #" + finishingAgent.issue + " completado</b>\n" +
                 "PR mergeada · Slug: " + escHtml(finishingAgent.slug) + "\n" +
@@ -932,6 +958,7 @@ async function processInput() {
             // Mover de cola a agentes
             plan.agentes.push(nextAgente);
             setQueue(plan, newQueue);
+            callSyncRoadmapOnly(plan); // #1433: actualizar roadmap al promover de cola
 
             savePlan(plan);
             log("Movido issue #" + nextAgente.issue + " de cola a agentes (número " + nextAgente.numero + ")");

--- a/.claude/hooks/post-issue-close.js
+++ b/.claude/hooks/post-issue-close.js
@@ -11,6 +11,56 @@ const PROJECT_DIR = process.env.CLAUDE_PROJECT_DIR || "C:\\Workspaces\\Intrale\\
 const LOG_FILE = path.join(PROJECT_DIR, ".claude", "hooks", "hook-debug.log");
 const AUDIT_FILE = path.join(PROJECT_DIR, ".claude", "hooks", "delivery-gate-audit.jsonl");
 
+// ─── Sprint sync: reconciliar sprint al cerrar issues (#1433) ────────────────
+
+const SPRINT_PLAN_FILE = path.join(PROJECT_DIR, "scripts", "sprint-plan.json");
+
+let _sprintSyncPic = null;
+function getSprintSyncPic() {
+    if (_sprintSyncPic !== null) return _sprintSyncPic;
+    try {
+        _sprintSyncPic = require("./sprint-sync");
+    } catch (e) {
+        _sprintSyncPic = null;
+    }
+    return _sprintSyncPic;
+}
+
+/**
+ * Verifica si un issue pertenece al sprint activo (agentes[] o _queue[]).
+ */
+function isIssueInSprint(issueNumber) {
+    try {
+        const plan = JSON.parse(fs.readFileSync(SPRINT_PLAN_FILE, "utf8"));
+        const num = Number(issueNumber);
+        const inAgentes = (plan.agentes || []).some(function(a) { return Number(a.issue) === num; });
+        const inQueue = (plan._queue || plan.cola || []).some(function(a) { return Number(a.issue) === num; });
+        return inAgentes || inQueue;
+    } catch (e) {
+        return false;
+    }
+}
+
+/**
+ * Si el issue pertenece al sprint activo, invoca reconcileSprintPlan() via runSync.
+ * Async — no bloquea el flujo principal del hook.
+ */
+function maybeReconcileSprintPlan(issueNumber) {
+    try {
+        if (!isIssueInSprint(issueNumber)) return;
+        const ss = getSprintSyncPic();
+        if (!ss) return;
+        log("Issue #" + issueNumber + " pertenece al sprint activo — iniciando reconciliación");
+        ss.runSync({ force: true, silent: false }).then(function(result) {
+            log("Sprint sync completado: changes=" + ((result && result.changes && result.changes.length) || 0));
+        }).catch(function(e) {
+            log("Sprint sync error: " + e.message);
+        });
+    } catch (e) {
+        log("maybeReconcileSprintPlan error: " + e.message);
+    }
+}
+
 // IDs del Project V2 "Intrale"
 const PROJECT_ID = "PVT_kwDOBTzBoc4AyMGf";
 const FIELD_ID = "PVTSSF_lADOBTzBoc4AyMGfzgoLqjg";
@@ -287,6 +337,9 @@ async function processIssueClose(issueNumber, prNumber) {
         // Notificar por Telegram
         sendTelegram("⚙️ Issue #" + issueNumber + " cerrado sin QA E2E — movido a <b>\"QA Pending\"</b> en lugar de Done");
     }
+
+    // #1433: reconciliar sprint si el issue pertenece al sprint activo
+    maybeReconcileSprintPlan(issueNumber);
 }
 
 // ─── Bug 1 fix: detectar cierre de issues vía PR merge (#1266) ─────────────


### PR DESCRIPTION
## Resumen

Integración de `sprint-sync.js` en dos hooks existentes para mantener sincronizadas sprint-plan.json y roadmap.json en puntos clave del ciclo de vida del agente.

### Cambios realizados

**agent-concurrency-check.js:**
- Al completar agente (PR mergeada) → actualizar roadmap.json con status "done"
- Al promover de cola → actualizar roadmap.json con status "in_progress"
- Se llama `callSyncRoadmapOnly(plan)` en 4 puntos del flujo

**post-issue-close.js:**
- Al cerrar issue del sprint activo → invocar `runSync()` para reconciliar
- Verifica si el issue pertenece al sprint (agentes[] o _queue[])
- Se llama `maybeReconcileSprintPlan(issueNumber)` al finalizar

### Bug fix incluido

- Se corrigió duplicación de `ZOMBIE_THRESHOLD_MS` que causaba SyntaxError

## Plan de verificación

- [x] Tests de hooks pasan (test-p22-concurrency-check.js, test-p20-issue-close-via-pr.js)
- [x] Compilación Kotlin exitosa
- [x] Auditoría de seguridad: APROBADO
- [x] Code review: APROBADO

Closes #1433

🤖 Generado con [Claude Code](https://claude.com/claude-code)