### PR TITLE
feat(scrum): roadmap-planner.js — distribuir backlog en sprints vacíos

### DIFF
--- a/.claude/hooks/roadmap-planner.js
+++ b/.claude/hooks/roadmap-planner.js
@@ -1,0 +1,430 @@
+// roadmap-planner.js — Distribuir issues del backlog en sprints futuros vacíos
+// Sub-tarea de #1420. Llena automáticamente sprints vacíos con issues del backlog.
+//
+// Lógica:
+//   1. Leer scripts/roadmap.json → contar sprints futuros con status !== "done"
+//   2. Si sprints_futuros < 7:
+//      a. Fetch issues abiertos de GitHub (gh issue list --state open --limit 200)
+//      b. Excluir issues ya asignados a algún sprint del roadmap
+//      c. Clasificar por prioridad y stream (bugs primero, balance de streams)
+//      d. Distribuir en sprints vacíos (7-10 issues por sprint)
+//      e. Escribir roadmap.json actualizado
+//
+// Reglas de distribución:
+//   - Bugs y bloqueantes → sprint más cercano
+//   - Balance: no más del 60% de un stream por sprint
+//   - Máximo 2 issues L/XL por sprint
+//   - Issues con label "Refined" tienen prioridad
+//
+// Idempotente: ejecutar N veces = mismo resultado
+//   - Solo toca sprints vacíos (sin issues), nunca sprints con issues ya asignados
+//
+// Uso standalone: node roadmap-planner.js [--dry-run]
+// Uso como módulo: const { planRoadmap } = require('./roadmap-planner')
+//
+// Pure Node.js — sin dependencias externas
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const { execSync } = require("child_process");
+
+// ─── Paths ────────────────────────────────────────────────────────────────────
+
+function resolveMainRepoRoot() {
+    const envRoot = process.env.CLAUDE_PROJECT_DIR || "C:\\Workspaces\\Intrale\\platform";
+    try {
+        const out = execSync("git worktree list", {
+            encoding: "utf8", cwd: envRoot, timeout: 5000, windowsHide: true
+        });
+        const firstLine = out.split("\n")[0] || "";
+        const match = firstLine.match(/^(.+?)\s+[0-9a-f]{5,}/);
+        if (match) return match[1].trim().replace(/\\/g, "/");
+    } catch (e) {}
+    return envRoot.replace(/\\/g, "/");
+}
+
+const REPO_ROOT    = resolveMainRepoRoot();
+const HOOKS_DIR    = path.join(REPO_ROOT, ".claude", "hooks");
+const SCRIPTS_DIR  = path.join(REPO_ROOT, "scripts");
+const ROADMAP_FILE = path.join(SCRIPTS_DIR, "roadmap.json");
+const LOG_FILE     = path.join(HOOKS_DIR, "hook-debug.log");
+const GH_PATH      = "C:\\Workspaces\\gh-cli\\bin\\gh.exe";
+
+// ─── Constantes de distribución ───────────────────────────────────────────────
+
+const MIN_HORIZON    = 7;   // Mínimo de sprints futuros (status !== "done") para no planificar
+const MIN_ISSUES_PER_SPRINT = 7;   // Mínimo de issues a colocar por sprint vacío
+const MAX_ISSUES_PER_SPRINT = 10;  // Máximo de issues por sprint
+const MAX_LARGE_PER_SPRINT  = 2;   // Máximo de issues L/XL por sprint
+const MAX_STREAM_RATIO      = 0.6; // Máximo 60% de un stream por sprint
+
+// ─── Logging ──────────────────────────────────────────────────────────────────
+
+function log(msg) {
+    try {
+        fs.appendFileSync(LOG_FILE, "[" + new Date().toISOString() + "] roadmap-planner: " + msg + "\n");
+    } catch (e) {}
+    console.log("[roadmap-planner] " + msg);
+}
+
+// ─── JSON utils ───────────────────────────────────────────────────────────────
+
+function readJson(filePath) {
+    try {
+        return JSON.parse(fs.readFileSync(filePath, "utf8"));
+    } catch (e) {
+        return null;
+    }
+}
+
+function writeJson(filePath, obj) {
+    fs.writeFileSync(filePath, JSON.stringify(obj, null, 2) + "\n", "utf8");
+}
+
+// ─── Clasificación de issues ──────────────────────────────────────────────────
+
+/**
+ * Determina el stream de un issue basado en sus labels.
+ * Streams: E=Engineering/Infra, B=Business, C=Client, D=Delivery
+ */
+function getStream(labels) {
+    if (labels.includes("app:business") || labels.includes("backlog-negocio"))  return "B";
+    if (labels.includes("app:client")   || labels.includes("backlog-cliente"))  return "C";
+    if (labels.includes("app:delivery") || labels.includes("backlog-delivery")) return "D";
+    // Default: Engineering (backlog-tecnico, tipo:infra, area:*)
+    return "E";
+}
+
+/**
+ * Determina el tamaño de un issue basado en sus labels.
+ */
+function getSize(labels) {
+    if (labels.includes("tamaño:XS") || labels.includes("size:XS")) return "XS";
+    if (labels.includes("tamaño:S")  || labels.includes("size:S"))  return "S";
+    if (labels.includes("tamaño:M")  || labels.includes("size:M"))  return "M";
+    if (labels.includes("tamaño:L")  || labels.includes("size:L"))  return "L";
+    if (labels.includes("tamaño:XL") || labels.includes("size:XL")) return "XL";
+    return "M"; // Default M
+}
+
+function isLargeSize(size) {
+    return size === "L" || size === "XL";
+}
+
+function isBugOrBlocker(labels) {
+    return labels.includes("bug")         ||
+           labels.includes("blocker")     ||
+           labels.includes("tipo:bug")    ||
+           labels.includes("tipo:blocker");
+}
+
+function isRefined(labels) {
+    return labels.includes("Refined") || labels.includes("refined");
+}
+
+/**
+ * Scoring de prioridad. Mayor score = mayor prioridad.
+ * - Bloqueantes: 50 pts
+ * - Bugs: 40 pts
+ * - Backlog técnico: +30 pts (se suma, no reemplaza)
+ * - Issues refinados: +20 pts
+ * - Tamaño preferido (S/M antes que L/XL): hasta 10 pts
+ */
+function scoreIssue(issue) {
+    const labels = issue.labels || [];
+    let score = 0;
+
+    // Tipo de impacto
+    if (labels.includes("blocker"))    score += 50;
+    else if (isBugOrBlocker(labels))   score += 40;
+    else if (isRefined(labels))        score += 20;
+    else                               score += 5;
+
+    // Backlog técnico tiene bonus (siempre va primero)
+    if (labels.includes("backlog-tecnico") || labels.includes("tipo:infra") ||
+        labels.includes("area:infra")      || labels.includes("area:scrum") ||
+        labels.includes("area:monitor"))   score += 30;
+
+    // Tamaño preferido (más fácil de colocar = más útil)
+    const size = getSize(labels);
+    if (size === "XS" || size === "S") score += 10;
+    else if (size === "M")             score += 7;
+    else if (size === "L")             score += 4;
+    else if (size === "XL")            score += 2;
+
+    return score;
+}
+
+// ─── Fetch issues de GitHub ───────────────────────────────────────────────────
+
+/**
+ * Obtiene issues abiertos del repositorio intrale/platform.
+ * Retorna array de { number, title, labels[] }
+ */
+function fetchOpenIssues(limit) {
+    if (!fs.existsSync(GH_PATH)) {
+        log("WARN: gh CLI no encontrado en " + GH_PATH);
+        return [];
+    }
+
+    let raw = null;
+    try {
+        raw = execSync(
+            `"${GH_PATH}" issue list --repo intrale/platform --state open ` +
+            `--limit ${limit} --json number,title,labels`,
+            { encoding: "utf8", timeout: 30000, windowsHide: true }
+        ).trim();
+    } catch (e) {
+        log("ERROR fetching issues de GitHub: " + e.message);
+        return [];
+    }
+
+    try {
+        const issues = JSON.parse(raw);
+        return issues.map(issue => ({
+            number: issue.number,
+            title:  issue.title,
+            labels: (issue.labels || []).map(l => l.name)
+        }));
+    } catch (e) {
+        log("ERROR parseando JSON de issues: " + e.message);
+        return [];
+    }
+}
+
+// ─── Distribución de issues en un sprint ─────────────────────────────────────
+
+/**
+ * Distribuye issues del pool de candidatos en un sprint.
+ *
+ * Reglas aplicadas:
+ *   1. Bugs y bloqueantes van primero (sprint más cercano)
+ *   2. No más del 60% de un stream por sprint
+ *   3. Máximo MAX_LARGE_PER_SPRINT issues L/XL por sprint
+ *   4. Entre MIN_ISSUES_PER_SPRINT y MAX_ISSUES_PER_SPRINT issues por sprint
+ *
+ * @param {object[]} candidates - Issues candidatos, ya ordenados por prioridad
+ * @param {number} targetMin - Mínimo de issues a asignar
+ * @param {number} targetMax - Máximo de issues a asignar
+ * @returns {[object[], object[]]} [asignados, restantes]
+ */
+function distributeIntoSprint(candidates, targetMin, targetMax) {
+    const assigned = [];
+    const rejected = []; // rechazados por restricciones
+
+    // Límite de issues de un mismo stream: floor(targetMax * 60%)
+    const maxStreamIssues = Math.floor(targetMax * MAX_STREAM_RATIO);
+
+    const streamCounts = {};
+    let largeCount = 0;
+
+    // Primer pase: bugs/bloqueantes primero (ya ordenados por score), luego otros
+    const bugs    = candidates.filter(i => isBugOrBlocker(i.labels));
+    const nonBugs = candidates.filter(i => !isBugOrBlocker(i.labels));
+    const ordered = [...bugs, ...nonBugs];
+
+    for (const issue of ordered) {
+        if (assigned.length >= targetMax) break;
+
+        const stream      = getStream(issue.labels);
+        const size        = getSize(issue.labels);
+        const streamCount = streamCounts[stream] || 0;
+
+        // Restricción de stream (max 60%)
+        if (streamCount >= maxStreamIssues) {
+            rejected.push(issue);
+            continue;
+        }
+
+        // Restricción de tamaño L/XL (máx 2 por sprint)
+        if (isLargeSize(size) && largeCount >= MAX_LARGE_PER_SPRINT) {
+            rejected.push(issue);
+            continue;
+        }
+
+        assigned.push(issue);
+        streamCounts[stream] = streamCount + 1;
+        if (isLargeSize(size)) largeCount++;
+    }
+
+    // Segundo pase: si quedamos por debajo del mínimo, agregar rechazados por stream
+    // (es mejor llenar el sprint que dejarlo muy vacío)
+    if (assigned.length < targetMin) {
+        for (const issue of rejected) {
+            if (assigned.length >= targetMin) break;
+            const size = getSize(issue.labels);
+            if (isLargeSize(size) && largeCount >= MAX_LARGE_PER_SPRINT) continue;
+            assigned.push(issue);
+            if (isLargeSize(size)) largeCount++;
+        }
+    }
+
+    // Calcular restantes (los no asignados)
+    const assignedNumbers = new Set(assigned.map(i => i.number));
+    const remaining = candidates.filter(i => !assignedNumbers.has(i.number));
+
+    return [assigned, remaining];
+}
+
+// ─── Función principal ────────────────────────────────────────────────────────
+
+/**
+ * planRoadmap() — Distribuye issues del backlog en sprints futuros vacíos.
+ *
+ * Idempotente: solo modifica sprints completamente vacíos (sin issues).
+ * No altera sprints que ya tienen issues asignados.
+ *
+ * Condición de activación: sprints futuros (status !== "done") < MIN_HORIZON (7).
+ *
+ * @param {object} opts
+ * @param {boolean} [opts.dryRun=false] - Si true, no escribe roadmap.json
+ * @param {number}  [opts.limit=200]    - Límite de issues a pedir a GitHub
+ * @returns {{ filled: number, skipped: number, remaining: number, message: string }}
+ */
+function planRoadmap(opts) {
+    opts = opts || {};
+    const dryRun = opts.dryRun === true;
+    const limit  = parseInt(opts.limit, 10) || 200;
+
+    log("Iniciando planRoadmap()" + (dryRun ? " [dry-run]" : ""));
+
+    // 1. Leer roadmap.json
+    const roadmap = readJson(ROADMAP_FILE);
+    if (!roadmap || !Array.isArray(roadmap.sprints)) {
+        const msg = "ERROR: No se pudo leer roadmap.json o no tiene sprints";
+        log(msg);
+        return { filled: 0, skipped: 0, remaining: 0, message: msg };
+    }
+
+    // 2. Contar sprints futuros (status !== "done")
+    const futureSprints = roadmap.sprints.filter(s => s.status !== "done");
+    log("Sprints futuros: " + futureSprints.length + " (horizon mínimo: " + MIN_HORIZON + ")");
+
+    if (futureSprints.length >= MIN_HORIZON) {
+        const msg = "OK: " + futureSprints.length + " sprints futuros — no se necesita replanificación (mínimo: " + MIN_HORIZON + ")";
+        log(msg);
+        return { filled: 0, skipped: futureSprints.length, remaining: 0, message: msg };
+    }
+
+    // 3. Colectar todos los issue numbers ya asignados en algún sprint
+    const assignedNumbers = new Set();
+    for (const sprint of roadmap.sprints) {
+        for (const issue of (sprint.issues || [])) {
+            assignedNumbers.add(issue.number);
+        }
+    }
+    log("Issues ya asignados en roadmap: " + assignedNumbers.size);
+
+    // 4. Fetch backlog de GitHub
+    const openIssues = fetchOpenIssues(limit);
+    log("Issues abiertos en GitHub: " + openIssues.length);
+
+    // 5. Filtrar candidatos: no asignados
+    const candidates = openIssues.filter(i => !assignedNumbers.has(i.number));
+    log("Candidatos disponibles: " + candidates.length);
+
+    if (candidates.length === 0) {
+        const msg = "WARN: No hay issues disponibles en el backlog para distribuir";
+        log(msg);
+        return { filled: 0, skipped: 0, remaining: 0, message: msg };
+    }
+
+    // 6. Ordenar candidatos por prioridad (mayor score = primero)
+    candidates.sort((a, b) => scoreIssue(b) - scoreIssue(a));
+
+    // 7. Identificar sprints vacíos (sin issues) entre los futuros
+    const emptySprints = futureSprints.filter(s =>
+        !s.issues || s.issues.length === 0
+    );
+    log("Sprints vacíos a llenar: " + emptySprints.length);
+
+    if (emptySprints.length === 0) {
+        const msg = "INFO: No hay sprints vacíos — todos los sprints futuros ya tienen issues";
+        log(msg);
+        return { filled: 0, skipped: futureSprints.length, remaining: candidates.length, message: msg };
+    }
+
+    // 8. Distribuir candidatos en sprints vacíos (más cercano primero)
+    let pool = [...candidates];
+    let filledCount = 0;
+
+    for (const targetSprint of emptySprints) {
+        if (pool.length === 0) {
+            log("Sprint " + targetSprint.id + ": sin candidatos restantes en el backlog");
+            break;
+        }
+
+        const [assigned, leftover] = distributeIntoSprint(
+            pool, MIN_ISSUES_PER_SPRINT, MAX_ISSUES_PER_SPRINT
+        );
+        pool = leftover;
+
+        if (assigned.length === 0) {
+            log("Sprint " + targetSprint.id + ": ningún issue pudo asignarse (restricciones)");
+            continue;
+        }
+
+        // Convertir al formato de roadmap.json
+        const roadmapIssues = assigned.map(issue => ({
+            number: issue.number,
+            title:  issue.title,
+            size:   getSize(issue.labels),
+            stream: getStream(issue.labels),
+            status: "planned"
+        }));
+
+        // Actualizar el sprint en el roadmap (buscar por id)
+        const sprintIdx = roadmap.sprints.findIndex(s => s.id === targetSprint.id);
+        if (sprintIdx !== -1) {
+            roadmap.sprints[sprintIdx].issues = roadmapIssues;
+        }
+
+        const streamSummary = roadmapIssues.reduce((acc, i) => {
+            acc[i.stream] = (acc[i.stream] || 0) + 1;
+            return acc;
+        }, {});
+
+        log("Sprint " + targetSprint.id + ": " + assigned.length + " issues — " +
+            Object.entries(streamSummary).map(([k, v]) => k + ":" + v).join(", "));
+
+        filledCount++;
+    }
+
+    // 9. Actualizar metadata del roadmap
+    roadmap.updated_ts = new Date().toISOString();
+    roadmap.updated_by = "roadmap-planner";
+
+    // 10. Escribir roadmap.json
+    if (!dryRun) {
+        writeJson(ROADMAP_FILE, roadmap);
+        log("roadmap.json actualizado: " + filledCount + " sprint(s) llenados");
+    } else {
+        log("[dry-run] Se hubieran llenado " + filledCount + " sprint(s)");
+    }
+
+    const msg = "Distribución completa: " + filledCount + " sprints llenados, " +
+                pool.length + " issues restantes en backlog";
+    log(msg);
+
+    return {
+        filled:    filledCount,
+        skipped:   emptySprints.length - filledCount,
+        remaining: pool.length,
+        message:   msg
+    };
+}
+
+// ─── Exportar como módulo ─────────────────────────────────────────────────────
+
+module.exports = { planRoadmap };
+
+// ─── Invocable standalone ─────────────────────────────────────────────────────
+
+if (require.main === module) {
+    const dryRun = process.argv.includes("--dry-run");
+    const result = planRoadmap({ dryRun });
+    console.log("\n[roadmap-planner] " + result.message);
+    process.exit(0);
+}

--- a/.claude/hooks/tests/test-roadmap-planner.js
+++ b/.claude/hooks/tests/test-roadmap-planner.js
@@ -1,0 +1,72 @@
+// test-roadmap-planner.js — Tests unitarios de roadmap-planner.js
+// Issue #1435: verifica exportación de módulo, retorno esperado y propiedades del resultado
+"use strict";
+
+const path = require("path");
+const assert = require("assert");
+
+const HOOKS_DIR = path.join(__dirname, "..");
+const { planRoadmap } = require(path.join(HOOKS_DIR, "roadmap-planner"));
+
+let passed = 0;
+let failed = 0;
+
+function test(label, fn) {
+    try {
+        fn();
+        console.log("  PASS: " + label);
+        passed++;
+    } catch (e) {
+        console.log("  FAIL: " + label + " — " + e.message);
+        failed++;
+    }
+}
+
+console.log("=== roadmap-planner.js — tests unitarios ===\n");
+
+// 1. Exporta planRoadmap como función
+test("exporta planRoadmap como función", () => {
+    assert.strictEqual(typeof planRoadmap, "function");
+});
+
+// 2. Con roadmap actual (7 sprints futuros), no dispara la distribución
+test("no rellenar si sprints futuros >= 7", () => {
+    const result = planRoadmap({ dryRun: true });
+    assert.strictEqual(result.filled, 0, "filled debe ser 0");
+    assert.strictEqual(result.skipped, 7, "skipped debe ser 7");
+    assert.ok(typeof result.message === "string", "message debe ser string");
+});
+
+// 3. El resultado siempre tiene las 4 propiedades esperadas
+test("resultado tiene propiedades filled, skipped, remaining, message", () => {
+    const result = planRoadmap({ dryRun: true });
+    assert.ok("filled"    in result, "falta 'filled'");
+    assert.ok("skipped"   in result, "falta 'skipped'");
+    assert.ok("remaining" in result, "falta 'remaining'");
+    assert.ok("message"   in result, "falta 'message'");
+});
+
+// 4. dryRun: no modifica roadmap.json
+test("dryRun: no modifica roadmap.json", () => {
+    const fs = require("fs");
+    const roadmapPath = path.join(__dirname, "../../../scripts/roadmap.json");
+    const before = fs.readFileSync(roadmapPath, "utf8");
+    planRoadmap({ dryRun: true });
+    const after = fs.readFileSync(roadmapPath, "utf8");
+    assert.strictEqual(before, after, "roadmap.json no debe modificarse en dry-run");
+});
+
+// 5. Idempotencia: dos llamadas con dryRun producen el mismo resultado
+test("idempotente: dos llamadas producen el mismo mensaje", () => {
+    const r1 = planRoadmap({ dryRun: true });
+    const r2 = planRoadmap({ dryRun: true });
+    assert.strictEqual(r1.message, r2.message, "mensajes deben coincidir");
+    assert.strictEqual(r1.filled,  r2.filled,  "filled debe coincidir");
+});
+
+console.log("\n=== Resultado: " + passed + "/" + (passed + failed) + " tests OK ===");
+if (failed > 0) {
+    console.log("FALLARON " + failed + " tests");
+    process.exit(1);
+}
+process.exit(0);


### PR DESCRIPTION
## Resumen

Implementa `roadmap-planner.js` que distribuye automáticamente issues del backlog abierto en sprints futuros vacíos del roadmap.

## Cambios

- Nuevo archivo: `.claude/hooks/roadmap-planner.js` (+431 líneas)
  - Función principal: `planRoadmap(opts?)` — distribuye issues del backlog
  - Exportable como módulo: `const { planRoadmap } = require('./roadmap-planner')`
  - Invocable standalone: `node roadmap-planner.js [--dry-run]`
  - Idempotente: solo modifica sprints vacíos

- Tests: `.claude/hooks/tests/test-roadmap-planner.js` (+73 líneas)
  - 5 tests unitarios — todos pasan

## Reglas de distribución implementadas

✓ Bugs y bloqueantes → sprint más cercano  
✓ Balance: máximo 60% de un stream por sprint  
✓ Máximo 2 issues L/XL por sprint  
✓ Issues refinados tienen prioridad  
✓ Distribución de 7-10 issues por sprint vacío  

## Verificaciones

✓ **Tests**: 5/5 pasan  
✓ **Sintaxis**: válida  
✓ **Seguridad**: APROBADO  
✓ **Code Review**: APROBADO  

## Plan de validación

- [x] Tests unitarios pasan
- [x] Módulo es invocable

Sub-tarea de #1420.

Closes #1435

🤖 Generado con [Claude Code](https://claude.ai/claude-code)