### PR TITLE
docs(skills): Búsqueda proactiva de duplicados al crear historia

### DIFF
--- a/.claude/skills/doc/SKILL.md
+++ b/.claude/skills/doc/SKILL.md
@@ -73,14 +73,22 @@ gh pr list --repo intrale/platform --state open --json number,title,url,author
 
 ## Modo: `nueva <descripcion>`
 
-Seguí el flujo completo de `/historia`:
-1. Analizar codebase con Grep/Glob para entender contexto técnico
-2. Redactar issue con estructura estándar (ver `../refinar/issue-template.md`)
-3. Determinar labels (ver `../refinar/labels-guide.md`)
-4. Presentar al usuario para confirmación
-5. Crear en GitHub con `gh issue create`
-6. Agregar al Project V2
-7. Asignar a `leitolarreta`
+Seguí el flujo completo de `/historia`, incluyendo la búsqueda de duplicados:
+
+1. **Buscar duplicados** — antes de crear, buscar issues similares con `gh issue list --search`:
+   - Extraer palabras clave de la descripción (palabras de 4+ caracteres)
+   - Ejecutar `gh issue list --repo intrale/platform --state open --search "KEYWORD1 KEYWORD2" --json number,title,labels,state --limit 10`
+   - Estimar similitud: % de palabras clave del título propuesto que aparecen en cada resultado
+   - Si hay match ≥ 80% en issue OPEN: preguntar si actualizar en vez de crear. Si acepta → invocar `/refinar <N>` y detener. Si no → continuar.
+   - Si hay match ≥ 80% en issue CLOSED: informar y preguntar si reabrirlo o crear nuevo.
+   - Mostrar lista de coincidencias aunque sean medias (50–79%), para contexto del usuario.
+2. Analizar codebase con Grep/Glob para entender contexto técnico
+3. Redactar issue con estructura estándar (ver `../refinar/issue-template.md`)
+4. Determinar labels (ver `../refinar/labels-guide.md`)
+5. Presentar al usuario para confirmación
+6. Crear en GitHub con `gh issue create`
+7. Agregar al Project V2
+8. Asignar a `leitolarreta`
 
 ---
 

--- a/.claude/skills/historia/SKILL.md
+++ b/.claude/skills/historia/SKILL.md
@@ -23,6 +23,55 @@ export PATH="/c/Workspaces/gh-cli/bin:$PATH"
 export GH_TOKEN=$(printf 'protocol=https\nhost=github.com\n' | git credential fill 2>/dev/null | sed -n 's/^password=//p')
 ```
 
+### Paso 1.5: Buscar duplicados
+
+Antes de crear el issue, verificar si ya existe uno similar en GitHub.
+
+**Extraer palabras clave del argumento** (palabras de 4+ caracteres, ignorar artículos/preposiciones):
+
+Por ejemplo, de `"Pantalla de perfil de usuario"` → `pantalla perfil usuario`
+
+**Ejecutar búsqueda en issues abiertos y cerrados:**
+
+```bash
+export PATH="/c/Workspaces/gh-cli/bin:$PATH"
+
+# Búsqueda en issues abiertos
+gh issue list --repo intrale/platform --state open \
+  --search "KEYWORD1 KEYWORD2 KEYWORD3" \
+  --json number,title,labels,state --limit 10
+
+# Búsqueda en issues cerrados (últimos 5)
+gh issue list --repo intrale/platform --state closed \
+  --search "KEYWORD1 KEYWORD2 KEYWORD3" \
+  --json number,title,labels,state --limit 5
+```
+
+**Estimar similitud para cada resultado encontrado:**
+
+Contar cuántas palabras clave del título propuesto aparecen en el título del issue encontrado:
+- ≥ 80% de palabras en común → **match alto** (probablemente duplicado)
+- 50–79% de palabras en común → **match medio** (posible duplicado)
+- < 50% de palabras en común → **match bajo** (probablemente distinto)
+
+**Mostrar resultados al usuario:**
+
+```
+Buscando duplicados para: "[descripción propuesta]"
+
+  #892 "Pantalla de perfil — datos personales" (OPEN, app:client) — 85% match
+  #1001 "Editar perfil de usuario" (CLOSED) — 70% match
+  #753 "Vista de usuario registrado" (OPEN, app:client) — 50% match
+
+¿Actualizar #892 en vez de crear una nueva historia? [S/n]
+```
+
+**Decisión:**
+
+- Si hay **match alto (≥ 80%) en issue OPEN**: preguntar al usuario si prefiere actualizar en vez de crear. Si dice **S** → invocar `/refinar <N>` y detener este flujo. Si dice **N** → continuar.
+- Si hay **match alto en issue CLOSED**: informar al usuario ("Existe un issue cerrado similar: #N") y preguntar si desea reabrirlo o crear uno nuevo.
+- Si **no hay matches altos** (o el usuario elige continuar): continuar con el siguiente paso sin interrupciones.
+
 ### Paso 2: Analizar el codebase
 
 Usa Read, Grep y Glob para:


### PR DESCRIPTION
## Resumen

Implementa búsqueda proactiva de duplicados en los skills `/historia` y `/doc` (modo nueva) al crear un issue, para evitar la creación accidental de historias duplicadas.

### Cambios

- **Paso 1.5 en `/historia`**: Buscar issues similares por palabras clave antes de crear
- **Modo `nueva` en `/doc`**: Integrar búsqueda de duplicados en el flujo unificado
- Cálculo de similitud estimada: % de palabras clave del título propuesto
- Si match ≥ 80% en issue OPEN: preguntar si actualizar en vez de crear
- Si match ≥ 80% en issue CLOSED: ofrecer reabrir
- Mostrar lista de coincidencias para contexto del usuario

### Flujo de uso

```
/historia Pantalla de perfil de usuario

Buscando duplicados para: "Pantalla de perfil de usuario"

  #892 "Pantalla de perfil — datos personales" (OPEN, app:client) — 85% match
  #753 "Vista de usuario registrado" (OPEN, app:client) — 50% match

¿Actualizar #892 en vez de crear una nueva historia? [S/n]
→ Si S: invocar /refinar 892
→ Si N: continuar con creación normal
```

### Validación

- ✅ Tester: sin tests afectados (cambios en .md de skills)
- ✅ Builder: build sin cambios (solo documentación)
- ✅ Security: sin vulnerabilidades (búsqueda via gh CLI flags seguros)
- ✅ Review: convenciones OK (skills documentation)

Closes #1477.

🤖 Generado con [Claude Code](https://claude.com/claude-code)