### PR TITLE
docs(skills): búsqueda por label de área en detección de duplicados

### DIFF
--- a/.claude/skills/doc/SKILL.md
+++ b/.claude/skills/doc/SKILL.md
@@ -73,14 +73,24 @@ gh pr list --repo intrale/platform --state open --json number,title,url,author
 
 ## Modo: `nueva <descripcion>`
 
-Seguí el flujo completo de `/historia`:
-1. Analizar codebase con Grep/Glob para entender contexto técnico
-2. Redactar issue con estructura estándar (ver `../refinar/issue-template.md`)
-3. Determinar labels (ver `../refinar/labels-guide.md`)
-4. Presentar al usuario para confirmación
-5. Crear en GitHub con `gh issue create`
-6. Agregar al Project V2
-7. Asignar a `leitolarreta`
+Seguí el flujo completo de `/historia`, incluyendo la búsqueda de duplicados:
+
+1. **Buscar duplicados** — antes de crear, buscar issues similares con `gh issue list --search` (cubre título y body):
+   - Extraer palabras clave de la descripción (palabras de 4+ caracteres)
+   - Búsqueda por keywords: `gh issue list --repo intrale/platform --state open --search "KEYWORD1 KEYWORD2" --json number,title,labels,state --limit 10`
+   - Búsqueda por label de área: si la descripción indica el área (cliente/negocio/delivery/infra), ejecutar también `gh issue list --repo intrale/platform --state open --label "AREA_LABEL" --json number,title,labels,state --limit 10`
+   - Combinar y deduplicar resultados por número de issue
+   - Estimar similitud: % de palabras clave del título propuesto que aparecen en cada resultado
+   - Si hay match ≥ 80% en issue OPEN: preguntar si actualizar en vez de crear. Si acepta → invocar `/refinar <N>` y detener. Si no → continuar.
+   - Si hay match ≥ 80% en issue CLOSED: informar y preguntar si reabrirlo o crear nuevo.
+   - Mostrar lista de coincidencias aunque sean medias (50–79%), para contexto del usuario.
+2. Analizar codebase con Grep/Glob para entender contexto técnico
+3. Redactar issue con estructura estándar (ver `../refinar/issue-template.md`)
+4. Determinar labels (ver `../refinar/labels-guide.md`)
+5. Presentar al usuario para confirmación
+6. Crear en GitHub con `gh issue create`
+7. Agregar al Project V2
+8. Asignar a `leitolarreta`
 
 ---
 

--- a/.claude/skills/historia/SKILL.md
+++ b/.claude/skills/historia/SKILL.md
@@ -23,6 +23,69 @@ export PATH="/c/Workspaces/gh-cli/bin:$PATH"
 export GH_TOKEN=$(printf 'protocol=https\nhost=github.com\n' | git credential fill 2>/dev/null | sed -n 's/^password=//p')
 ```
 
+### Paso 1.5: Buscar duplicados
+
+Antes de crear el issue, verificar si ya existe uno similar en GitHub.
+
+**Extraer palabras clave del argumento** (palabras de 4+ caracteres, ignorar artículos/preposiciones):
+
+Por ejemplo, de `"Pantalla de perfil de usuario"` → `pantalla perfil usuario`
+
+**Ejecutar búsqueda en issues abiertos y cerrados:**
+
+Nota: `--search` busca automáticamente en título **y body** de los issues existentes.
+
+```bash
+export PATH="/c/Workspaces/gh-cli/bin:$PATH"
+
+# Búsqueda en issues abiertos por keywords (cubre título y body)
+gh issue list --repo intrale/platform --state open \
+  --search "KEYWORD1 KEYWORD2 KEYWORD3" \
+  --json number,title,labels,state --limit 10
+
+# Búsqueda en issues cerrados (últimos 5)
+gh issue list --repo intrale/platform --state closed \
+  --search "KEYWORD1 KEYWORD2 KEYWORD3" \
+  --json number,title,labels,state --limit 5
+
+# Búsqueda adicional por label de área (si se puede inferir del argumento):
+# - "cliente", "client", "consumidor" → --label "app:client"
+# - "negocio", "business", "comercio" → --label "app:business"
+# - "delivery", "repartidor" → --label "app:delivery"
+# - "área:", "backend", "infra" → --label "area:infra" (o el area:X correspondiente)
+# Ejecutar solo si se detectó un área:
+gh issue list --repo intrale/platform --state open \
+  --label "AREA_LABEL" \
+  --json number,title,labels,state --limit 10 2>/dev/null || true
+```
+
+Combinar y deduplicar los resultados de las tres búsquedas por número de issue antes de continuar.
+
+**Estimar similitud para cada resultado encontrado:**
+
+Contar cuántas palabras clave del título propuesto aparecen en el título del issue encontrado:
+- ≥ 80% de palabras en común → **match alto** (probablemente duplicado)
+- 50–79% de palabras en común → **match medio** (posible duplicado)
+- < 50% de palabras en común → **match bajo** (probablemente distinto)
+
+**Mostrar resultados al usuario:**
+
+```
+Buscando duplicados para: "[descripción propuesta]"
+
+  #892 "Pantalla de perfil — datos personales" (OPEN, app:client) — 85% match
+  #1001 "Editar perfil de usuario" (CLOSED) — 70% match
+  #753 "Vista de usuario registrado" (OPEN, app:client) — 50% match
+
+¿Actualizar #892 en vez de crear una nueva historia? [S/n]
+```
+
+**Decisión:**
+
+- Si hay **match alto (≥ 80%) en issue OPEN**: preguntar al usuario si prefiere actualizar en vez de crear. Si dice **S** → invocar `/refinar <N>` y detener este flujo. Si dice **N** → continuar.
+- Si hay **match alto en issue CLOSED**: informar al usuario ("Existe un issue cerrado similar: #N") y preguntar si desea reabrirlo o crear uno nuevo.
+- Si **no hay matches altos** (o el usuario elige continuar): continuar con el siguiente paso sin interrupciones.
+
 ### Paso 2: Analizar el codebase
 
 Usa Read, Grep y Glob para:


### PR DESCRIPTION
## Resumen

Mejora la detección automática de duplicados en `/historia` y `/doc (modo nueva)`:
- Agregar búsqueda adicional por **labels de área** (app:client, app:business, app:delivery, area:infra, etc.)
- Combinar y deduplicar resultados de búsqueda por keywords + labels
- Documentar que `--search` cubre títulos y body automáticamente

## Plan de validación

- [x] /security: escaneo de diff aprobado (cambios en Markdown, sin código sensible)
- [x] /review: code review aprobado (cambios mínimos, focalizados, sin bloqueantes)
- [x] Criterios de aceptación #1477 completamente cubiertos:
  1. ✅ Búsqueda automática de duplicados (Paso 1.5 en historia/skill.md)
  2. ✅ Mostrar % de similitud estimado (Formato "85% match")
  3. ✅ Ofrecer actualizar vs duplicar ("¿Actualizar #N en vez de crear?")
  4. ✅ Búsqueda por título, labels y keywords del body

Cierra #1477.

🤖 Generado con [Claude Code](https://claude.ai/claude-code)