### PR TITLE
fix(hooks): prevenir cascada de _queue a _incomplete

### DIFF
--- a/.claude/dashboard-server.js
+++ b/.claude/dashboard-server.js
@@ -1394,9 +1394,11 @@ function renderHTML(data, theme) {
     const tasksDone = tasks.filter(t => t.status === "completed").length;
     const actionCount = matchSession ? (matchSession.action_count || 0) : 0;
     let tasksPct;
-    if (tasks.length > 0) {
+    if (forcedStatus === "done") {
+      tasksPct = 100;
+    } else if (tasks.length > 0) {
       tasksPct = Math.round((tasksDone / tasks.length) * 100);
-    } else if (agStatus === "done" || agStatus === "stale" || forcedStatus === "done") {
+    } else if (agStatus === "done" || agStatus === "stale") {
       tasksPct = 100;
     } else if (actionCount > 0) {
       const sizeExpected = { S: 40, M: 80, L: 160, XL: 300 };

--- a/.claude/hooks/agent-concurrency-check.js
+++ b/.claude/hooks/agent-concurrency-check.js
@@ -901,20 +901,42 @@ async function processInput() {
                 "Estado: pendiente de review · slot liberado"
             );
         } else {
-            // Sin PR (none, closed_no_merge, unknown) → _incomplete con resultado "failed"
-            const motivo = prStatus.status === "unknown"
-                ? "No se pudo verificar PR (gh CLI falló)"
-                : "Sin PR — el agente no completó /delivery";
-            const incompleteEntry = buildCompletedEntry(finishingAgent, session, "failed");
-            incompleteEntry.motivo = motivo;
-            plan._incomplete.push(incompleteEntry);
-            log("Agente #" + finishingAgent.issue + " → _incomplete (sin PR): " + motivo);
-            await notify(
-                "⚠️ <b>Agente #" + finishingAgent.issue + " FALLIDO</b>\n" +
-                "Rama: " + escHtml(agentBranch) + "\n" +
-                "Motivo: " + escHtml(motivo) + "\n" +
-                "<i>Acción: revisar worktree y relanzar si es necesario</i>"
-            );
+            // Sin PR (none, closed_no_merge, unknown)
+            // Fix: si el agente nunca trabajó realmente (0 acciones, duración < 2 min),
+            // devolverlo a _queue en vez de mandarlo a _incomplete (#queue-cascade-fix)
+            const actionCount = session ? (session.action_count || 0) : 0;
+            const startedTs = session ? session.started_ts : null;
+            const runtimeMin = startedTs ? (Date.now() - startedTs) / 60000 : 0;
+            const neverWorked = actionCount < 5 && runtimeMin < 2;
+
+            if (neverWorked) {
+                // Agente que nunca trabajó → devolver a _queue (no penalizar)
+                const queue = getQueue(plan);
+                queue.push(finishingAgent);
+                setQueue(plan, queue);
+                log("Agente #" + finishingAgent.issue + " → devuelto a _queue (nunca trabajó: " + actionCount + " acciones, " + Math.round(runtimeMin) + " min)");
+                await notify(
+                    "🔄 <b>Agente #" + finishingAgent.issue + " devuelto a cola</b>\n" +
+                    "Rama: " + escHtml(agentBranch) + "\n" +
+                    "Motivo: sesión terminó sin trabajo real (" + actionCount + " acciones)\n" +
+                    "<i>Será relanzado cuando haya un slot disponible</i>"
+                );
+            } else {
+                const motivo = prStatus.status === "unknown"
+                    ? "No se pudo verificar PR (gh CLI falló)"
+                    : "Sin PR — el agente no completó /delivery";
+                const incompleteEntry = buildCompletedEntry(finishingAgent, session, "failed");
+                incompleteEntry.motivo = motivo;
+                if (!Array.isArray(plan._incomplete)) plan._incomplete = [];
+                plan._incomplete.push(incompleteEntry);
+                log("Agente #" + finishingAgent.issue + " → _incomplete (sin PR, " + actionCount + " acciones, " + Math.round(runtimeMin) + " min): " + motivo);
+                await notify(
+                    "⚠️ <b>Agente #" + finishingAgent.issue + " FALLIDO</b>\n" +
+                    "Rama: " + escHtml(agentBranch) + "\n" +
+                    "Motivo: " + escHtml(motivo) + "\n" +
+                    "<i>Acción: revisar worktree y relanzar si es necesario</i>"
+                );
+            }
         }
 
         // Actualizar Project V2: issue completado → Done


### PR DESCRIPTION
## Resumen

- **agent-concurrency-check.js**: Si un agente termina sin PR pero nunca trabajó realmente (`action_count < 5` y `runtime < 2 min`), se devuelve a `_queue[]` en vez de ir a `_incomplete[]`. Esto previene el efecto cascada que vaciaba toda la cola.
- **dashboard-server.js**: Issues en `_completed` siempre muestran 100% en el monitor, sin importar el estado de tasks de la sesión vieja.

## Contexto

Bug detectado en SPR-023: al terminar los 3 primeros agentes, el watcher promovía agentes de la cola, pero si la sesión fallaba rápidamente (lanzamiento fallido), el hook los movía a `_incomplete` y al liberar el slot promovía el siguiente — cascada hasta vaciar `_queue[]` y `agentes[]` completos.

## Plan de tests

- [x] Verificar que el fix no rompe el flujo normal (agentes que SÍ trabajaron y fallaron siguen yendo a `_incomplete`)
- [x] Verificar que agentes con < 5 acciones y < 2 min vuelven a `_queue`

🤖 Generado con [Claude Code](https://claude.ai/claude-code)