### PR TITLE
fix(hooks): agent-watcher devuelve a _queue agentes sin trabajo real

### DIFF
--- a/.claude/hooks/agent-watcher.js
+++ b/.claude/hooks/agent-watcher.js
@@ -501,23 +501,45 @@ async function runCycle() {
                     "Estado: pendiente de review · slot liberado"
                 );
             } else {
-                // Sin PR o cerrada sin merge → incompleto
-                const motivo = prStatus.status === "unknown"
-                    ? "No se pudo verificar PR (gh CLI falló)"
-                    : prStatus.status === "closed_no_merge"
-                        ? "PR cerrada sin merge"
-                        : "Sin PR — el agente no completó /delivery";
+                // Sin PR o cerrada sin merge
+                // Fix: si el agente nunca trabajó (sin worktree, sin sesión real),
+                // devolverlo a _queue en vez de _incomplete (#queue-cascade-fix)
+                const worktreePath = path.join(WORKTREES_PARENT, "platform.agent-" + ag.issue + "-" + ag.slug);
+                const hasWorktree = fs.existsSync(worktreePath);
                 const entry = buildCompletedEntry(ag, null, "failed");
-                entry.detectado_por = "agent-watcher";
-                entry.motivo = motivo;
-                freshPlan._incomplete.push(entry);
-                log("Agente #" + ag.issue + " → _incomplete (" + prStatus.status + "): " + motivo);
+                const runtimeMin = entry.duracion_min || 0;
+                const neverWorked = !hasWorktree && runtimeMin < 2;
 
-                await notify(
-                    "⚠️ <b>Agente #" + ag.issue + " terminó sin PR (watcher)</b>\n" +
-                    "Slug: " + escHtml(ag.slug) + " · PR: " + prStatus.status + "\n" +
-                    "Motivo: " + escHtml(motivo)
-                );
+                if (neverWorked) {
+                    // Agente que nunca trabajó → devolver a _queue
+                    const queue = getQueue(freshPlan);
+                    delete ag.status;
+                    delete ag.waiting_since;
+                    delete ag.waiting_reason;
+                    queue.push(ag);
+                    setQueue(freshPlan, queue);
+                    log("Agente #" + ag.issue + " → devuelto a _queue (nunca trabajó: sin worktree, " + runtimeMin + " min)");
+                    await notify(
+                        "🔄 <b>Agente #" + ag.issue + " devuelto a cola (watcher)</b>\n" +
+                        "Sin worktree ni sesión real · Será relanzado cuando haya slot"
+                    );
+                } else {
+                    const motivo = prStatus.status === "unknown"
+                        ? "No se pudo verificar PR (gh CLI falló)"
+                        : prStatus.status === "closed_no_merge"
+                            ? "PR cerrada sin merge"
+                            : "Sin PR — el agente no completó /delivery";
+                    entry.detectado_por = "agent-watcher";
+                    entry.motivo = motivo;
+                    freshPlan._incomplete.push(entry);
+                    log("Agente #" + ag.issue + " → _incomplete (" + prStatus.status + "): " + motivo);
+
+                    await notify(
+                        "⚠️ <b>Agente #" + ag.issue + " terminó sin PR (watcher)</b>\n" +
+                        "Slug: " + escHtml(ag.slug) + " · PR: " + prStatus.status + "\n" +
+                        "Motivo: " + escHtml(motivo)
+                    );
+                }
             }
         }
 


### PR DESCRIPTION
## Resumen

- **agent-watcher.js**: Mismo fix que PR #1488 pero para el watcher externo. Agentes detectados como "muertos" que nunca tuvieron worktree ni runtime significativo (< 2 min) vuelven a `_queue[]` en vez de ir a `_incomplete[]`.

## Contexto

El PR #1488 corrigió `agent-concurrency-check.js` (hook Stop), pero el `agent-watcher.js` (proceso background) tenía la misma lógica sin el fix. El watcher corre cada 60s y era el que seguía vaciando la cola.

## Plan de tests

- [x] Agentes con worktree que fallan → siguen yendo a `_incomplete` (comportamiento correcto)
- [x] Agentes sin worktree y < 2 min → vuelven a `_queue`

🤖 Generado con [Claude Code](https://claude.ai/claude-code)