### PR TITLE
feat: Gate TDD — validar que tests se escribieron antes del código

### DIFF
--- a/.claude/skills/android-dev/SKILL.md
+++ b/.claude/skills/android-dev/SKILL.md
@@ -77,7 +77,47 @@ Archivos clave:
 
 Si se pasó `--plan`, reportar el plan y detenerse acá.
 
-## Paso 4: Implementar
+## Paso 4: Escribir tests primero (TDD — Red Phase)
+
+**OBLIGATORIO antes de escribir codigo de produccion.**
+
+### 4.1 Crear los archivos de test
+
+Con base en el plan del Paso 3, escribir los tests en `app/composeApp/src/commonTest/kotlin/`:
+
+```kotlin
+class DoMiActionTest {
+    @Test
+    fun `execute retorna resultado exitoso con datos validos`() = runTest {
+        val fakeService = FakeCommMiService(Result.success(miResponse))
+        val action = DoMiAction(fakeService)
+        val result = action.execute(miParams)
+        assertTrue(result.isSuccess)
+    }
+
+    @Test
+    fun `execute retorna fallo cuando el servicio falla`() = runTest {
+        val fakeService = FakeCommMiService(Result.failure(RuntimeException("error")))
+        val action = DoMiAction(fakeService)
+        val result = action.execute(miParams)
+        assertTrue(result.isFailure)
+    }
+}
+```
+
+### 4.2 Verificar que los tests FALLAN (Red Phase)
+
+```bash
+export JAVA_HOME="/c/Users/Administrator/.jdks/temurin-21.0.7" && \
+  ./gradlew :app:composeApp:testDebugUnitTest 2>&1 | tail -30
+```
+
+**Esperado:** los tests deben FALLAR con errores de compilacion o ejecucion (clases no existen aun).
+Si los tests pasan en este punto, revisar que esten probando la logica correcta (no son triviales).
+
+> Este paso garantiza que los tests son utiles: si ya pasaran sin implementacion, no prueban nada.
+
+## Paso 5: Implementar
 
 ### Capas del app (orden de implementación)
 
@@ -157,26 +197,24 @@ AsyncImage(
 )
 ```
 
-## Paso 5: Tests
+## Paso 6: Verificar que los tests PASAN (TDD — Green Phase)
 
-```kotlin
-class DoMiActionTest {
-    @Test
-    fun `execute retorna resultado exitoso con datos válidos`() = runTest {
-        val fakeService = FakeCommMiService(Result.success(miResponse))
-        val action = DoMiAction(fakeService)
-        val result = action.execute(miParams)
-        assertTrue(result.isSuccess)
-    }
-}
+Despues de implementar el codigo de produccion, verificar que los tests pasan:
+
+```bash
+export JAVA_HOME="/c/Users/Administrator/.jdks/temurin-21.0.7" && \
+  ./gradlew :app:composeApp:testDebugUnitTest 2>&1 | tail -50
 ```
 
+**Esperado:** todos los tests deben PASAR. Si alguno falla, corregir la implementacion (no los tests).
+
+### Convenciones de tests
 - Framework: kotlin-test + MockK + `runTest`
-- Ubicación: `app/composeApp/src/commonTest/kotlin/`
-- Nombres: backtick descriptivo en español
+- Ubicacion: `app/composeApp/src/commonTest/kotlin/`
+- Nombres: backtick descriptivo en espanol
 - Fakes: `Fake[Interface]`
 
-## Paso 6: Verificar
+## Paso 7: Verificar build completo
 
 ```bash
 export JAVA_HOME="/c/Users/Administrator/.jdks/temurin-21.0.7" && \
@@ -195,7 +233,7 @@ export JAVA_HOME="/c/Users/Administrator/.jdks/temurin-21.0.7" && \
   ./gradlew :app:composeApp:scanNonAsciiFallbacks 2>&1 | tail -30
 ```
 
-## Paso 7: Reporte
+## Paso 8: Reporte
 
 ```
 ## AndroidDev — Reporte de implementación

--- a/.claude/skills/backend-dev/SKILL.md
+++ b/.claude/skills/backend-dev/SKILL.md
@@ -66,7 +66,46 @@ Antes de escribir código, diseñá la solución:
 
 Si se pasó `--plan`, reportar el plan y detenerse acá.
 
-## Paso 4: Implementar
+## Paso 4: Escribir tests primero (TDD — Red Phase)
+
+**OBLIGATORIO antes de escribir codigo de produccion.**
+
+### 4.1 Crear los archivos de test
+
+Con base en el plan del Paso 3, escribir los tests en `src/test/kotlin/ar/com/intrale/`:
+
+```kotlin
+class MiFunctionTest {
+
+    @Test
+    fun `execute retorna respuesta exitosa con datos validos`() = runBlocking {
+        val dynamoDB = mockk<DynamoDbClient>()
+        coEvery { dynamoDB.getItem(any()) } returns mockResponse
+        val function = MiFunction(dynamoDB)
+        val result = function.execute(miRequest)
+        assertEquals(HttpStatusCode.OK, result.statusCode)
+    }
+
+    @Test
+    fun `execute retorna error cuando datos son invalidos`() = runBlocking {
+        // test del caso de error
+    }
+}
+```
+
+### 4.2 Verificar que los tests FALLAN (Red Phase)
+
+```bash
+export JAVA_HOME="/c/Users/Administrator/.jdks/temurin-21.0.7" && \
+  ./gradlew :backend:test 2>&1 | tail -30
+```
+
+**Esperado:** los tests deben FALLAR con errores de compilacion o de ejecucion (clases no existen aun).
+Si los tests pasan en este punto, revisar que esten probando la logica correcta (no son triviales).
+
+> Este paso garantiza que los tests son utiles: si ya pasaran sin implementacion, no prueban nada.
+
+## Paso 5: Implementar
 
 ### Arquitectura obligatoria
 
@@ -107,43 +146,33 @@ El `statusCode` SIEMPRE debe incluir valor numérico y descripción.
 - Cognito: `CognitoIdentityProviderClient` (SDK Kotlin 1.2.28)
 - Lambda: `LambdaRequestHandler`, deploy via `:users:shadowJar`
 
-## Paso 5: Tests
+## Paso 6: Verificar que los tests PASAN (TDD — Green Phase)
 
-Si se pasó `--test` o la tarea lo requiere:
-
-```kotlin
-class MiFunctionTest {
-
-    @Test
-    fun `execute retorna respuesta exitosa con datos válidos`() = runBlocking {
-        val dynamoDB = mockk<DynamoDbClient>()
-        coEvery { dynamoDB.getItem(any()) } returns mockResponse
-        val function = MiFunction(dynamoDB)
-        val result = function.execute(miRequest)
-        assertEquals(HttpStatusCode.OK, result.statusCode)
-    }
-}
-```
-
-### Convenciones
-- Framework: kotlin-test + MockK + `runBlocking`
-- Ubicación: `src/test/kotlin/ar/com/intrale/`
-- Nombres: backtick descriptivo en español
-- Fakes: `Fake[Interface]`
-
-## Paso 6: Verificar
+Despues de implementar el codigo de produccion, verificar que los tests pasan:
 
 ```bash
-export JAVA_HOME="/c/Users/Administrator/.jdks/temurin-21.0.7" && \
-  ./gradlew :backend:build 2>&1 | tail -50
-
 export JAVA_HOME="/c/Users/Administrator/.jdks/temurin-21.0.7" && \
   ./gradlew :backend:test 2>&1 | tail -50
 ```
 
+**Esperado:** todos los tests deben PASAR. Si alguno falla, corregir la implementacion (no los tests).
+
+### Convenciones de tests
+- Framework: kotlin-test + MockK + `runBlocking`
+- Ubicacion: `src/test/kotlin/ar/com/intrale/`
+- Nombres: backtick descriptivo en espanol
+- Fakes: `Fake[Interface]`
+
+## Paso 7: Verificar build completo
+
+```bash
+export JAVA_HOME="/c/Users/Administrator/.jdks/temurin-21.0.7" && \
+  ./gradlew :backend:build 2>&1 | tail -50
+```
+
 Si el build falla, leer el error, corregir y volver a intentar hasta que pase.
 
-## Paso 7: Reporte
+## Paso 8: Reporte
 
 ```
 ## BackendDev — Reporte de implementación

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -109,6 +109,41 @@ Si se agrego una nueva Function en backend:
 Si se agrego un nuevo servicio en app:
 - Verificar que esta registrado en `DIManager`
 
+### 4.9 Verificar TDD Compliance
+
+Analizar el historial de commits del branch para verificar que se siguio el patron TDD:
+
+```bash
+# Listar commits del branch con sus archivos (excluye merge commits)
+git log origin/main..HEAD --no-merges --name-only --pretty=format:"COMMIT:%H %s"
+```
+
+Para cada commit, clasificar los archivos en:
+- **Solo tests**: todos los archivos son `*Test.kt`, `*Tests.kt` o estan en carpetas `test/`
+- **Solo produccion**: ningun archivo es test
+- **Mixto**: mezcla de tests y produccion (anti-patron TDD)
+
+**Reglas de evaluacion:**
+
+1. Si el primer commit del branch contiene SOLO archivos de test → TDD seguido correctamente ✅
+2. Si el primer commit mezcla tests + produccion → advertencia TDD ⚠️
+3. Si no hay archivos de test en ningun commit → advertencia TDD ⚠️
+4. Si todos los commits son de produccion (sin ningun test) → advertencia TDD ⚠️
+
+**Incluir en el reporte:**
+
+```
+### TDD Compliance
+- [ ] Primer commit contiene solo archivos de test
+- [ ] Tests fueron escritos antes del codigo de produccion
+- [ ] Existe al menos un commit con solo archivos *Test.kt
+```
+
+Clasificar como:
+- ✅ **TDD OK** — primer commit es solo tests
+- ⚠️ **TDD WARNING** — tests y produccion mezclados o codigo primero (no impide merge salvo `--strict`)
+- ❌ **TDD FAIL** — no hay tests en ningun commit (reportar como BLOQUEANTE en `--strict`, WARNING en modo normal)
+
 ## Paso 5: Verificar tests existentes
 
 ```bash


### PR DESCRIPTION
## Resumen

Implementar validación obligatoria del patrón TDD (Test-Driven Development) en los developer skills del proyecto:

- **`/review`**: checklist TDD Compliance (sección 4.9) que analiza el historial de commits del branch
- **`/backend-dev`**: Paso 4 "Escribir tests primero (Red Phase)" + Paso 6 "Verificar Green Phase"
- **`/android-dev`**: Paso 4 "Escribir tests primero (Red Phase)" + Paso 6 "Verificar Green Phase"

## Plan de tests

- [ ] Tests unitarios pasan (backend, users, app/client)
- [ ] Build completo sin errores
- [ ] No hay violaciones de convenciones de strings

Closes #1478

🤖 Generado con [Claude Code](https://claude.com/claude-code)