### PR TITLE
docs(skills): Invocar /po dependencias automáticamente en flujo de crear historia

### DIFF
--- a/.claude/skills/doc/SKILL.md
+++ b/.claude/skills/doc/SKILL.md
@@ -89,6 +89,13 @@ Seguí el flujo completo de `/historia`, incluyendo la búsqueda de duplicados:
 6. Crear en GitHub con `gh issue create`
 7. Agregar al Project V2
 8. Asignar a `leitolarreta`
+9. Lanzar análisis paralelo: `/qa validate`, `/security analyze`, `/guru` (impacto técnico)
+10. Consolidar resultados de QA + Security + Guru en el body del issue
+11. **Invocar `/po dependencias $ISSUE_NUMBER` automáticamente** para validar Definition of Ready:
+    - Si todas las dependencias están resueltas (CLOSED) → continuar
+    - Si hay dependencias OPEN no-bloqueantes → agregar comentario ⚠️ en el issue y continuar
+    - Si hay dependencias OPEN bloqueantes → agregar label `blocked`, mover a "Blocked" en Project V2, reportar al usuario
+12. Evaluar tamaño con `/planner validar-tamaño` — si es L/XL invocar `/planner split`
 
 ---
 

--- a/.claude/skills/historia/SKILL.md
+++ b/.claude/skills/historia/SKILL.md
@@ -237,10 +237,56 @@ Invocar `/po dependencias` para verificar dependencias bloqueantes:
 - Si /guru detectó issues o módulos que este issue depende técnicamente → invocar como `/po dependencias $ISSUE_NUMBER,N,M` (incluyendo los issues relacionados)
 - Si no hay dependencias externas detectadas → invocar como `/po dependencias $ISSUE_NUMBER`
 
-**Resultado:**
-- DoR cumplido (sin bloqueos) → mover issue a status "Refined" en Project V2 (si no fue movido ya)
-- DoR bloqueado (dependencia OPEN fuera del sprint) → agregar label `blocked`, mover a status "Blocked" en Project V2, reportar al usuario las dependencias bloqueantes
-- DoR bloqueado por seguridad → ya manejado en Paso 9
+**Resultado según el análisis de dependencias:**
+
+**a) DoR cumplido (sin bloqueos):**
+- Mover issue a status "Refined" en Project V2 (si no fue movido ya)
+
+**b) DoR con dependencias OPEN no-bloqueantes:**
+- Continuar al Paso 11 (no se bloquea la planificación)
+- Agregar comentario de advertencia en el issue:
+```bash
+export PATH="/c/Workspaces/gh-cli/bin:$PATH"
+gh issue comment $ISSUE_NUMBER --repo intrale/platform \
+  --body "$(cat <<'EOF'
+⚠️ **Dependencias OPEN detectadas (no bloqueantes)**
+
+Las siguientes dependencias están abiertas pero no bloquean el desarrollo:
+
+[lista de dependencias OPEN no-bloqueantes con #número y título]
+
+La historia puede planificarse. Se recomienda revisar estas dependencias antes de iniciar el sprint.
+EOF
+)"
+```
+
+**c) DoR bloqueado (dependencia OPEN bloqueante fuera del sprint):**
+- Agregar label `blocked` al issue
+- Mover a status "Blocked" en Project V2
+- Reportar al usuario las dependencias bloqueantes
+```bash
+export PATH="/c/Workspaces/gh-cli/bin:$PATH"
+gh issue edit $ISSUE_NUMBER --repo intrale/platform --add-label "blocked"
+node /c/Workspaces/Intrale/platform/.claude/hooks/add-to-project-status.js $ISSUE_NUMBER "Blocked"
+gh issue comment $ISSUE_NUMBER --repo intrale/platform \
+  --body "$(cat <<'EOF'
+⛔ **Historia bloqueada — dependencias sin resolver**
+
+Las siguientes dependencias están abiertas y bloquean el desarrollo:
+
+[lista de dependencias bloqueantes con #número y título]
+
+La historia NO puede planificarse hasta que estas dependencias estén resueltas (CLOSED).
+Opciones:
+- (a) Incluir las dependencias en el mismo sprint
+- (b) Mover esta historia al siguiente sprint
+- (c) Implementar con stub y aceptar deuda técnica (documentar decisión)
+EOF
+)"
+```
+
+**d) DoR bloqueado por seguridad:**
+- Ya manejado en Paso 9 — no continuar si /security retornó riesgo ALTO con findings Critical
 
 ### Paso 11: Evaluar tamaño y split obligatorio (gate)
 
@@ -277,7 +323,7 @@ Mostrar:
 - Sub-historias creadas por el split (si aplica): lista de `#NNN — título` con estado de `/po acceptance`
 - Si fue split: indicar que el issue padre queda como épica
 
-### Paso 10: Sincronizar roadmap.json
+### Paso 13: Sincronizar roadmap.json
 
 Después de crear el issue exitosamente, ejecutar sprint-sync.js para reflejar el nuevo issue en `scripts/roadmap.json`:
 


### PR DESCRIPTION
## Resumen

Integra la invocación automática de `/po dependencias` en los skills `/doc` y `/historia` para validar Definition of Ready antes de planificar historias. Implementa el paso 6 del flujo operativo de creación de historias.

## Cambios

### `.claude/skills/doc/SKILL.md`
- Agrega pasos 9-12 al flujo "Modo: nueva"
- Paso 11: Invoca `/po dependencias $ISSUE_NUMBER` automáticamente
- Paso 12: Evalúa tamaño con `/planner validar-tamaño`

### `.claude/skills/historia/SKILL.md`
- **Mejora Paso 10: Validar Definition of Ready con /po dependencias**
  - **a) DoR cumplido (sin bloqueos)** → Mover a status "Refined"
  - **b) Deps OPEN no-bloqueantes** → Agregar ⚠️ warning en issue, continuar
  - **c) Deps OPEN bloqueantes** → Marcar como "Blocked", reportar usuario
  - **d) DoR bloqueado por seguridad** → No continuar (ya manejado en Paso 9)
- Corrige numeración: Paso 10 (roadmap.json) → **Paso 13**

## Criterios de aceptación

- [x] Al crear una historia, se invoca `/po dependencias` automáticamente
- [x] Dependencias bloqueantes impiden que la historia se planifique (label `blocked` + status "Blocked")
- [x] Dependencias OPEN no-bloqueantes se reflejan como warning en el issue (comentario ⚠️)
- [x] El issue se marca como "Blocked" en el board si hay dependencias sin resolver

## Testing

- [x] Tests de sintaxis pasan (build completo OK)
- [x] Code review aprobado (sin bloqueantes)
- [x] Seguridad auditada (BAJO RIESGO — solo documentación)

Closes #1481

🤖 Generado con [Claude Code](https://claude.ai/claude-code)