### PR TITLE
chore(skills): congelar ios-dev y desktop-dev en _frozen/

### DIFF
--- a/.claude/hooks/agent-monitor.js
+++ b/.claude/hooks/agent-monitor.js
@@ -42,9 +42,11 @@ const METRICS_FILE = path.join(HOOKS_DIR, "agent-metrics.json");
 const PARTICIPATION_FILE = path.join(HOOKS_DIR, "agent-participation.json");
 
 // Lista canónica de todos los agentes que deben participar proactivamente en el pipeline
+// NOTA: /ios-dev y /desktop-dev están congelados en .claude/skills/_frozen/ (issue #1519)
+// Para reactivarlos: mover la carpeta de _frozen/ a .claude/skills/ y agregar al array.
 const ALL_PIPELINE_AGENTS = [
     "/ops", "/po", "/ux", "/guru",
-    "/backend-dev", "/android-dev", "/ios-dev", "/web-dev", "/desktop-dev",
+    "/backend-dev", "/android-dev", "/web-dev",
     "/tester", "/builder", "/security", "/qa", "/review",
     "/delivery", "/scrum", "/cleanup",
     "/planner", "/refinar", "/priorizar", "/historia"

--- a/.claude/skills/_frozen/desktop-dev/SKILL.md
+++ b/.claude/skills/_frozen/desktop-dev/SKILL.md
@@ -4,6 +4,19 @@ user-invocable: true
 argument-hint: "<issue-o-tarea> [--plan] [--test]"
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, TaskCreate, TaskUpdate, TaskList
 model: claude-sonnet-4-6
+frozen: true
+frozen-since: 2026-03-13
+frozen-reason: Sin issues Desktop asignados en sprints recientes (SPR-025). Reactivar cuando haya trabajo Desktop específico.
+---
+
+> ⚠️ **SKILL CONGELADO** — Este skill está inactivo para reducir costos operativos.
+>
+> **Para reactivar:** mover este archivo a `.claude/skills/desktop-dev/SKILL.md`
+> (es decir, mover la carpeta `_frozen/desktop-dev/` de vuelta a `.claude/skills/desktop-dev/`)
+>
+> **Motivo de congelamiento:** Sin issues Desktop en sprints recientes (detectado en SPR-025).
+> **Congelado el:** 2026-03-13 · **Issue:** #1519
+
 ---
 
 # /desktop-dev — DesktopDev

--- a/.claude/skills/_frozen/ios-dev/SKILL.md
+++ b/.claude/skills/_frozen/ios-dev/SKILL.md
@@ -4,6 +4,19 @@ user-invocable: true
 argument-hint: "<issue-o-tarea> [--plan] [--test]"
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, TaskCreate, TaskUpdate, TaskList
 model: claude-sonnet-4-6
+frozen: true
+frozen-since: 2026-03-13
+frozen-reason: Sin issues iOS asignados en sprints recientes (SPR-025). Reactivar cuando haya trabajo iOS específico.
+---
+
+> ⚠️ **SKILL CONGELADO** — Este skill está inactivo para reducir costos operativos.
+>
+> **Para reactivar:** mover este archivo a `.claude/skills/ios-dev/SKILL.md`
+> (es decir, mover la carpeta `_frozen/ios-dev/` de vuelta a `.claude/skills/ios-dev/`)
+>
+> **Motivo de congelamiento:** Sin issues iOS en sprints recientes (detectado en SPR-025).
+> **Congelado el:** 2026-03-13 · **Issue:** #1519
+
 ---
 
 # /ios-dev — iOSDev


### PR DESCRIPTION
## Resumen

- Congelamiento de skills /ios-dev y /desktop-dev por falta de issues asignados
- Archivos movidos a `.claude/skills/_frozen/` para limpieza de catálogo
- Actualización de agent-monitor.js para remover del pipeline de monitoreo
- Documentación de reactivación en notas y MEMORY.md

## Plan de tests

- [x] Tests backend/users: BUILD SUCCESSFUL ✅
- [x] Escaneo de seguridad: APROBADO ✅
- [x] Code review: APROBADO ✅
- [x] Label qa:skipped: agregado ✅

## Justificación

Identificado en **Análisis Operativo SPR-025** (Sección 11). Ambos skills:
- Usan Sonnet (modelo caro)
- No tienen issues asignados en sprints recientes
- Ocupan espacio en el catálogo de agentes

Solución: congelamiento reversible con fácil reactivación.

Closes #1519

🤖 Generado con [Claude Code](https://claude.com/claude-code)