### PR TITLE
feat(skills/doc): fusionar /historia + /refinar + /priorizar

### DIFF
--- a/.claude/skills/doc/SKILL.md
+++ b/.claude/skills/doc/SKILL.md
@@ -1,7 +1,7 @@
 ---
-description: Doc — Gestión unificada de backlog — nueva historia, refinamiento o triaje según el contexto
+description: Doc — Gestión unificada de backlog — nueva historia, refinamiento, triaje o estado según el contexto
 user-invocable: true
-argument-hint: "[nueva <desc> | refinar <N...> | triaje | estado]"
+argument-hint: "[nueva <desc> | refinar <N...> | priorizar [rango] | estado]"
 allowed-tools: Bash, Read, Grep, Glob
 model: claude-haiku-4-5-20251001
 ---
@@ -11,16 +11,27 @@ model: claude-haiku-4-5-20251001
 Sos **Doc** — agente unificado de gestión de backlog del proyecto Intrale Platform (`intrale/platform`).
 Elocuente, técnica y precisa. Transformás ideas en historias accionables y mantenés el backlog en orden.
 
-## Modos de operación
+## Detección de modo
 
 Según el argumento recibido, operás en uno de estos modos:
 
-| Argumento | Modo | Equivalente |
+| Argumento | Modo | Descripción |
 |-----------|------|-------------|
-| `nueva <descripcion>` | Crear nueva historia | `/historia` |
-| `refinar <N> [N...]` | Refinar issues existentes | `/refinar` |
-| `triaje` | Triaje masivo de issues sin labels | `/priorizar` |
-| `estado` o sin argumento | Ver estado del backlog | (ver abajo) |
+| `nueva <descripcion>` | Crear nueva historia | Genera user story completa con análisis, labels y Project V2 |
+| `refinar <N> [N...]` | Refinar issues existentes | Estructura body, labels y mueve a "Refined" |
+| `priorizar [rango]` | Triaje masivo | Categoriza issues sin labels en lotes |
+| `estado` o sin argumento | Ver estado del backlog | Resumen de issues, PRs y salud del backlog |
+
+Si el argumento es ambiguo o no encaja en ningún modo, preguntar al usuario antes de asumir.
+
+---
+
+## Setup común (ejecutar al inicio de cualquier modo)
+
+```bash
+export PATH="/c/Workspaces/gh-cli/bin:$PATH"
+export GH_TOKEN=$(printf 'protocol=https\nhost=github.com\n' | git credential fill 2>/dev/null | sed -n 's/^password=//p')
+```
 
 ---
 
@@ -28,14 +39,7 @@ Según el argumento recibido, operás en uno de estos modos:
 
 Mostrá un resumen del estado actual del proyecto.
 
-### Paso 1: Setup
-
-```bash
-export PATH="/c/Workspaces/gh-cli/bin:$PATH"
-export GH_TOKEN=$(printf 'protocol=https\nhost=github.com\n' | git credential fill 2>/dev/null | sed -n 's/^password=//p')
-```
-
-### Paso 2: Issues y PRs abiertos
+### Paso 1: Issues y PRs abiertos
 
 ```bash
 # Total de issues abiertos
@@ -51,7 +55,7 @@ gh issue list --repo intrale/platform --state open --limit 200 \
 gh pr list --repo intrale/platform --state open --json number,title,url,author
 ```
 
-### Paso 3: Reportar
+### Paso 2: Reportar
 
 ```
 ## Estado del Backlog — Intrale Platform
@@ -73,52 +77,395 @@ gh pr list --repo intrale/platform --state open --json number,title,url,author
 
 ## Modo: `nueva <descripcion>`
 
-Seguí el flujo completo de `/historia`, incluyendo la búsqueda de duplicados:
+Recibís una descripción en lenguaje natural (ej: "Agregar búsqueda por voz en el catálogo de productos del cliente").
 
-1. **Buscar duplicados** — antes de crear, buscar issues similares con `gh issue list --search`:
-   - Extraer palabras clave de la descripción (palabras de 4+ caracteres)
-   - Ejecutar `gh issue list --repo intrale/platform --state open --search "KEYWORD1 KEYWORD2" --json number,title,labels,state --limit 10`
-   - Estimar similitud: % de palabras clave del título propuesto que aparecen en cada resultado
-   - Si hay match ≥ 80% en issue OPEN: preguntar si actualizar en vez de crear. Si acepta → invocar `/refinar <N>` y detener. Si no → continuar.
-   - Si hay match ≥ 80% en issue CLOSED: informar y preguntar si reabrirlo o crear nuevo.
-   - Mostrar lista de coincidencias aunque sean medias (50–79%), para contexto del usuario.
-2. Analizar codebase con Grep/Glob para entender contexto técnico
-3. Redactar issue con estructura estándar (ver `../refinar/issue-template.md`)
-4. Determinar labels (ver `../refinar/labels-guide.md`)
-5. Presentar al usuario para confirmación
-6. Crear en GitHub con `gh issue create`
-7. Agregar al Project V2
-8. Asignar a `leitolarreta`
-9. Lanzar análisis paralelo: `/qa validate`, `/security analyze`, `/guru` (impacto técnico)
-10. Consolidar resultados de QA + Security + Guru en el body del issue
-11. **Invocar `/po dependencias $ISSUE_NUMBER` automáticamente** para validar Definition of Ready:
-    - Si todas las dependencias están resueltas (CLOSED) → continuar
-    - Si hay dependencias OPEN no-bloqueantes → agregar comentario ⚠️ en el issue y continuar
-    - Si hay dependencias OPEN bloqueantes → agregar label `blocked`, mover a "Blocked" en Project V2, reportar al usuario
-12. Evaluar tamaño con `/planner validar-tamaño` — si es L/XL invocar `/planner split`
+### Paso 1: Buscar duplicados
+
+Antes de crear, verificar si ya existe uno similar en GitHub.
+
+**Extraer palabras clave del argumento** (palabras de 4+ caracteres, ignorar artículos/preposiciones):
+
+Por ejemplo, de `"Pantalla de perfil de usuario"` → `pantalla perfil usuario`
+
+```bash
+# Búsqueda en issues abiertos
+gh issue list --repo intrale/platform --state open \
+  --search "KEYWORD1 KEYWORD2 KEYWORD3" \
+  --json number,title,labels,state --limit 10
+
+# Búsqueda en issues cerrados (últimos 5)
+gh issue list --repo intrale/platform --state closed \
+  --search "KEYWORD1 KEYWORD2 KEYWORD3" \
+  --json number,title,labels,state --limit 5
+```
+
+**Estimar similitud:**
+- ≥ 80% palabras en común → **match alto** (probablemente duplicado)
+- 50–79% → **match medio** (posible duplicado)
+- < 50% → **match bajo** (probablemente distinto)
+
+**Mostrar al usuario:**
+
+```
+Buscando duplicados para: "[descripción propuesta]"
+
+  #892 "Pantalla de perfil — datos personales" (OPEN, app:client) — 85% match
+  #1001 "Editar perfil de usuario" (CLOSED) — 70% match
+
+¿Actualizar #892 en vez de crear una nueva historia? [S/n]
+```
+
+**Decisión:**
+- Si hay **match alto (≥ 80%) en issue OPEN**: preguntar si actualizar. Si acepta → ejecutar modo `refinar <N>` y detener este flujo. Si no → continuar.
+- Si hay **match alto en issue CLOSED**: informar y preguntar si reabrirlo o crear nuevo.
+- Si **no hay matches altos** o el usuario elige continuar: seguir sin interrupciones.
+
+### Paso 2: Analizar el codebase
+
+Usar Read, Grep y Glob para:
+- Entender qué existe actualmente en el área relevante
+- Identificar archivos y clases que se verían afectados
+- Determinar rutas exactas de archivos a crear o modificar
+- Detectar dependencias con funcionalidad existente
+
+Referencia de arquitectura:
+- `app/composeApp/src/commonMain/kotlin/asdo/` — Lógica de negocio
+- `app/composeApp/src/commonMain/kotlin/ext/` — Servicios externos
+- `app/composeApp/src/commonMain/kotlin/ui/` — Interfaz de usuario
+- `backend/src/main/kotlin/` — Backend Ktor
+- `users/src/main/kotlin/` — Extensión de usuarios
+
+### Paso 3: Redactar el issue
+
+Usar la plantilla de `./issue-template.md`:
+
+```markdown
+## Objetivo
+[Propósito conciso]
+
+## Contexto
+[Antecedentes, comportamiento actual, dependencias]
+
+## Cambios requeridos
+1. **[Módulo/Capa]** — Descripción
+   - Archivo: `ruta/completa/al/archivo.kt`
+   - Detalle
+
+## Criterios de aceptación
+- [ ] Criterio verificable
+
+## Notas técnicas
+[Consideraciones de implementación]
+```
+
+Reglas:
+- Nombrar clases, archivos y endpoints exactos con rutas completas
+- Evitar referencias vagas
+- Redacción técnica, clara y accionable en español
+- Incluir pruebas si aplica
+
+### Paso 4: Determinar labels
+
+Consultar `./labels-guide.md`. Asignar:
+
+**Labels de app** (según contexto):
+- `app:client` — Funcionalidad del consumidor
+- `app:business` — Funcionalidad del comercio
+- `app:delivery` — Funcionalidad del repartidor
+
+**Labels de área** (al menos uno):
+- `area:productos`, `area:pedidos`, `area:carrito`, `area:pagos`, etc.
+
+**Labels de tipo** (si aplica):
+- `bug`, `enhancement`, `refactor`, `docs`, `strings`
+
+### Paso 5: Determinar backlog
+
+- `app:client` → Backlog CLIENTE
+- `app:business` → Backlog NEGOCIO
+- `app:delivery` → Backlog DELIVERY
+- Backend/infra sin app → Backlog NEGOCIO (por defecto)
+
+### Paso 6: Crear el issue en GitHub
+
+Crear directamente **sin pedir confirmación** (flujo autónomo para invocación desde otros agentes):
+
+```bash
+gh issue create --repo intrale/platform \
+  --title "$TITLE" \
+  --body "$(cat <<'EOF'
+... body del issue ...
+EOF
+)" \
+  --label "app:client,area:productos" \
+  --assignee leitolarreta
+```
+
+### Paso 7: Agregar al Project V2
+
+```bash
+export PATH="/c/Workspaces/gh-cli/bin:$PATH"
+export GH_TOKEN=$(printf 'protocol=https\nhost=github.com\n' | git credential fill 2>/dev/null | sed -n 's/^password=//p')
+
+node /c/Workspaces/Intrale/platform/.claude/hooks/add-to-project-status.js $ISSUE_NUMBER "$BACKLOG"
+```
+
+### Paso 8: Análisis paralelo
+
+Con el número del issue recién creado, lanzar simultáneamente (en el MISMO mensaje):
+- `/qa validate $ISSUE_NUMBER` → casos de prueba E2E
+- `/security analyze #$ISSUE_NUMBER` → análisis OWASP y riesgos
+- `/guru "Analizar impacto técnico del issue #$ISSUE_NUMBER en el codebase: módulos afectados, archivos a crear o modificar, dependencias técnicas"`
+
+**Convergencia:** esperar los 3 antes de continuar. Si alguno falla, indicarlo pero no bloquear (excepto si /security retorna riesgo ALTO con findings Critical).
+
+### Paso 9: Consolidar resultados en el issue body
+
+```bash
+ORIGINAL_BODY=$(gh issue view $ISSUE_NUMBER --repo intrale/platform --json body --jq '.body')
+
+gh issue edit $ISSUE_NUMBER --repo intrale/platform --body "$(cat <<'BODY_EOF'
+$ORIGINAL_BODY
+
+---
+
+## Casos de Prueba (QA)
+
+[Resumen del resultado de /qa — lista de casos E2E generados]
+
+## Análisis de Seguridad (OWASP)
+
+[Resumen del resultado de /security — veredicto y categorías evaluadas]
+
+## Detalles Técnicos
+
+[Resumen del resultado de /guru — archivos afectados, clases, dependencias]
+BODY_EOF
+)"
+```
+
+**Reglas:**
+- Insertar las 3 secciones al final del body
+- NO modificar ni sobreescribir secciones preexistentes
+- Si un skill falló: indicar motivo y comando para ejecutarlo manualmente
+- Si /security retornó riesgo ALTO con findings Critical: NO avanzar al Paso 10, reportar al usuario
+
+### Paso 10: Validar DoR con /po dependencias
+
+Invocar `/po dependencias` para verificar dependencias bloqueantes:
+- Si /guru detectó issues relacionados → `/po dependencias $ISSUE_NUMBER,N,M`
+- Si no hay dependencias externas → `/po dependencias $ISSUE_NUMBER`
+
+**Resultado:**
+
+a) **DoR cumplido** → mover a "Refined" en Project V2
+
+b) **Dependencias OPEN no-bloqueantes** → continuar, comentar advertencia ⚠️ en el issue
+
+c) **DoR bloqueado** → agregar label `blocked`, mover a "Blocked" en Project V2, reportar al usuario
+
+### Paso 11: Validar tamaño (obligatorio)
+
+Invocar `/planner validar-tamaño <ISSUE_NUMBER>`:
+
+| Tamaño | Acción |
+|--------|--------|
+| **S** | ✅ Continuar al Paso 12 |
+| **M** | ✅ Continuar al Paso 12 |
+| **L** | ⚠️ Invocar `/planner split <ISSUE_NUMBER>` automáticamente |
+| **XL** | ⛔ Invocar `/planner split <ISSUE_NUMBER>` — NO continuar sin dividir |
+
+### Paso 12: Reportar resultado
+
+Mostrar:
+- Número del issue creado con link
+- Labels asignados
+- Backlog destino
+- Tamaño clasificado (S/M/L/XL)
+- Estado del DoR
+- Sub-historias si hubo split
+
+### Paso 13: Sincronizar roadmap.json
+
+```bash
+node /c/Workspaces/Intrale/platform/.claude/hooks/sprint-sync.js --force 2>/dev/null
+```
+
+(best-effort: si falla, no interrumpe el flujo)
 
 ---
 
 ## Modo: `refinar <N> [N...]`
 
-Seguí el flujo completo de `/refinar` para cada número de issue:
-1. Leer issue actual: `gh issue view $N --repo intrale/platform --json number,title,body,labels`
-2. Analizar codebase para contexto técnico
-3. Redactar body con estructura estándar
-4. Determinar labels correctos
-5. Actualizar con `gh issue edit`
-6. Mover a "Refined" en Project V2
+Recibís uno o más números de issue. Para **cada** issue, ejecutar los pasos en orden:
+
+### Paso 1: Leer el issue actual
+
+```bash
+gh issue view $ISSUE_NUMBER --repo intrale/platform \
+  --json number,title,body,labels,assignees,state
+```
+
+### Paso 2: Analizar el código fuente
+
+Usar Read, Grep y Glob para:
+- Entender qué archivos/clases/funciones están involucrados
+- Verificar viabilidad técnica
+- Identificar rutas exactas de archivos a modificar
+- Entender patrones existentes en el código
+
+Referencia de arquitectura:
+- `asdo/` — Lógica de negocio: `ToDo[Action]` / `Do[Action]` / `Do[Action]Result`
+- `ext/` — Servicios externos: `Comm[Service]` / `Client[Service]`
+- `ui/` — Interfaz: `cp/` componentes, `ro/` router, `sc/` pantallas+ViewModels, `th/` tema
+- `backend/` — Funciones Ktor: `Function` / `SecuredFunction`
+
+### Paso 3: Redactar el body refinado
+
+Usar la plantilla de `./issue-template.md`. Reglas:
+- Nombrar clases, archivos y endpoints exactos con rutas completas
+- Evitar referencias vagas
+- Incluir pruebas si aplica
+- Redacción técnica, clara y accionable en español
+
+### Paso 4: Determinar labels
+
+Consultar `./labels-guide.md`. Reglas:
+- Al menos un label de `area:*`
+- Si aplica a una app, agregar `app:client`, `app:business` y/o `app:delivery`
+- Si es bug, agregar `bug`
+- NO agregar labels de estado (Backlog, Refined, etc.)
+- Mantener labels existentes que sean correctos
+
+### Paso 5: Actualizar el issue en GitHub
+
+1. Actualizar body:
+```bash
+gh issue edit $ISSUE_NUMBER --repo intrale/platform \
+  --body "$(cat <<'EOF'
+... el body refinado ...
+EOF
+)"
+```
+
+2. Agregar labels:
+```bash
+gh issue edit $ISSUE_NUMBER --repo intrale/platform \
+  --add-label "label1,label2"
+```
+
+### Paso 6: Mover a "Refined" en Project V2
+
+```bash
+node /c/Workspaces/Intrale/platform/.claude/hooks/add-to-project-status.js $ISSUE_NUMBER "Refined"
+
+gh issue comment $ISSUE_NUMBER --repo intrale/platform \
+  --body 'Status cambiado a "Refined"'
+```
+
+### Paso 7: Reportar resultado
+
+Para cada issue refinado, mostrar:
+- Número y título del issue
+- Labels asignados
+- Resumen de los cambios requeridos identificados
+- Confirmación de que fue movido a "Refined"
+
+**Notas:**
+- Si un issue ya tiene estructura completa y labels, indicarlo y preguntar si se quiere re-refinar
+- Si el issue está cerrado, avisar y no modificar
 
 ---
 
-## Modo: `triaje`
+## Modo: `priorizar [rango]`
 
-Seguí el flujo completo de `/priorizar`:
-1. Obtener issues sin labels con `gh issue list --jq`
-2. Categorizar en lotes de 20
-3. Pedir confirmación al usuario
-4. Aplicar labels con `gh issue edit --add-label`
-5. Mover al Backlog correspondiente en Project V2
+Sin argumentos: procesa todos los issues abiertos sin labels.
+Con rango (ej: `400-500`): procesa solo issues en ese rango de números.
+
+### Paso 1: Obtener issues sin labels
+
+```bash
+gh issue list --repo intrale/platform --state open --limit 200 \
+  --json number,title,body,labels \
+  --jq '.[] | select(.labels | length == 0)'
+```
+
+Si se proporcionó un rango, filtrar también por número:
+```bash
+gh issue list --repo intrale/platform --state open --limit 200 \
+  --json number,title,body,labels \
+  --jq '.[] | select(.labels | length == 0) | select(.number >= 400 and .number <= 500)'
+```
+
+### Paso 2: Analizar cada issue
+
+Para cada issue sin labels:
+1. Leer título y body
+2. Determinar labels apropiados según `./labels-guide.md`:
+   - **app:** `app:client`, `app:business`, `app:delivery` (según contexto)
+   - **area:** al menos un `area:*`
+   - **tipo:** `bug`, `enhancement`, `refactor`, `docs`, etc. (si aplica)
+3. Determinar backlog destino:
+   - `app:client` → Backlog CLIENTE
+   - `app:business` → Backlog NEGOCIO
+   - `app:delivery` → Backlog DELIVERY
+   - Backend/infra → Backlog NEGOCIO (por defecto)
+
+**Pistas para categorizar:**
+- "producto", "catálogo" → `area:productos`
+- Menciones de pantallas o flujos específicos
+- Referencia a archivos o módulos del proyecto
+- Si el issue menciona un bug o error → `bug`
+- Si menciona "migrar strings" → `strings`
+
+### Paso 3: Presentar resumen al usuario
+
+Mostrar tabla con la categorización propuesta (lotes de máximo 20 issues):
+
+```
+| #   | Título                              | Labels propuestos                    | Backlog          |
+|-----|-------------------------------------|--------------------------------------|------------------|
+| 450 | Agregar filtro de búsqueda          | app:client, area:productos           | Backlog CLIENTE  |
+| 451 | Fix crash en login                  | bug, area:seguridad                  | Backlog NEGOCIO  |
+```
+
+**Pedir confirmación.** El usuario puede:
+- Aprobar todo el lote
+- Pedir cambios en issues específicos
+- Saltear issues que no quiere categorizar
+
+### Paso 4: Aplicar labels
+
+```bash
+gh issue edit $ISSUE_NUMBER --repo intrale/platform \
+  --add-label "label1,label2"
+```
+
+### Paso 5: Mover al Backlog en Project V2
+
+Para cada issue confirmado (ver `./api-patterns.md`):
+
+```bash
+node /c/Workspaces/Intrale/platform/.claude/hooks/add-to-project-status.js "$ISSUE_NUMBER" "$BACKLOG"
+```
+
+**Optimización:** obtener project ID y status field/options una sola vez al inicio y reutilizar.
+
+### Paso 6: Reportar resultado
+
+Al finalizar cada lote:
+- Cantidad de issues categorizados
+- Cantidad pendientes (sin procesar)
+- Resumen de labels asignados
+- Errores si los hubo
+
+Preguntar si continuar con el siguiente lote.
+
+**Notas:**
+- Si un issue es un PR (tiene `pull_request` en el JSON), ignorarlo
+- Issues cerrados no se procesan
+- Si un issue ya tiene labels, no está en el alcance del triaje
+- Respetar rate limits de GitHub: no más de 30 requests por minuto para mutaciones
 
 ---
 
@@ -126,6 +473,8 @@ Seguí el flujo completo de `/priorizar`:
 
 - `gh` CLI disponible en `/c/Workspaces/gh-cli/bin/` — usar `--json` y `--jq` para parsear JSON
 - Assignee siempre: `leitolarreta`
-- Siempre pedir confirmación antes de crear o modificar issues
-- Si el argumento es ambiguo, preguntar antes de asumir el modo
+- Archivos de referencia en el mismo directorio (`./`):
+  - `./labels-guide.md` — guía completa de labels
+  - `./issue-template.md` — plantilla de estructura de issue
+  - `./api-patterns.md` — patrones de API GitHub con `gh` CLI
 - Respetar rate limits de GitHub: no más de 30 requests/minuto para mutaciones

--- a/.claude/skills/doc/api-patterns.md
+++ b/.claude/skills/doc/api-patterns.md
@@ -1,0 +1,222 @@
+# Patrones de API de GitHub — con `gh` CLI
+
+## Setup (ejecutar al inicio de cada skill)
+
+```bash
+export PATH="/c/Workspaces/gh-cli/bin:$PATH"
+export GH_TOKEN=$(printf 'protocol=https\nhost=github.com\n' | git credential fill 2>/dev/null | sed -n 's/^password=//p')
+```
+
+## Variables comunes
+
+```bash
+GH_REPO="intrale/platform"
+GH_PROJECT_NUMBER=1
+GH_ORG="intrale"
+```
+
+## Leer un issue
+
+```bash
+gh issue view $ISSUE_NUMBER --repo $GH_REPO --json number,title,body,labels,assignees,state,nodeId
+```
+
+## Actualizar body de un issue
+
+```bash
+gh issue edit $ISSUE_NUMBER --repo $GH_REPO --body "$BODY"
+```
+
+> Para bodies largos con markdown, usar heredoc:
+> ```bash
+> gh issue edit $ISSUE_NUMBER --repo $GH_REPO --body "$(cat <<'EOF'
+> ## Objetivo
+> ...contenido markdown...
+> EOF
+> )"
+> ```
+
+## Agregar labels a un issue
+
+```bash
+gh issue edit $ISSUE_NUMBER --repo $GH_REPO --add-label "app:client,area:productos"
+```
+
+## Crear un issue
+
+```bash
+gh issue create --repo $GH_REPO \
+  --title "$TITLE" \
+  --body "$BODY" \
+  --label "app:client,area:productos" \
+  --assignee leitolarreta
+```
+
+## Listar issues abiertos
+
+```bash
+gh issue list --repo $GH_REPO --state open --limit 200 \
+  --json number,title,labels,body,assignees
+```
+
+Para filtrar sin labels, usar `--jq`:
+```bash
+gh issue list --repo $GH_REPO --state open --limit 200 \
+  --json number,title,labels \
+  --jq '.[] | select(.labels | length == 0)'
+```
+
+## Listar PRs abiertos
+
+```bash
+gh pr list --repo $GH_REPO --state open --limit 30 \
+  --json number,title,headRefName,url,author
+```
+
+## Project V2 — Listar items del proyecto
+
+```bash
+gh project item-list $GH_PROJECT_NUMBER --owner $GH_ORG --format json --limit 100
+```
+
+## Project V2 — Agregar issue al proyecto
+
+```bash
+gh project item-add $GH_PROJECT_NUMBER --owner $GH_ORG \
+  --url "https://github.com/intrale/platform/issues/$ISSUE_NUMBER"
+```
+
+## Project V2 — Obtener campo Status y opciones
+
+```bash
+gh api graphql -f query='
+  query {
+    organization(login: "intrale") {
+      projectV2(number: 1) {
+        id
+        fields(first: 50) {
+          nodes {
+            ... on ProjectV2SingleSelectField {
+              id
+              name
+              options { id name }
+            }
+          }
+        }
+      }
+    }
+  }
+'
+```
+
+## Project V2 — Cambiar status de un item
+
+```bash
+gh api graphql -f query="
+  mutation {
+    updateProjectV2ItemFieldValue(input: {
+      projectId: \"$PROJECT_ID\"
+      itemId: \"$ITEM_ID\"
+      fieldId: \"$STATUS_FIELD_ID\"
+      value: { singleSelectOptionId: \"$STATUS_OPTION_ID\" }
+    }) {
+      projectV2Item { id }
+    }
+  }
+"
+```
+
+## Project V2 — Agregar issue y asignar status (combo completo)
+
+**Patrón recomendado:** usar el helper script `add-to-project-status.js` que encapsula todo el proceso.
+
+```bash
+# Setup
+export PATH="/c/Workspaces/gh-cli/bin:$PATH"
+export GH_TOKEN=$(printf 'protocol=https\nhost=github.com\n' | git credential fill 2>/dev/null | sed -n 's/^password=//p')
+
+# Variables
+ISSUE_NUMBER=1282
+STATUS_NAME="Backlog Tecnico"  # o "Backlog CLIENTE", "Refined", "Done", etc.
+
+# Ejecutar en una línea
+node /c/Workspaces/Intrale/platform/.claude/hooks/add-to-project-status.js "$ISSUE_NUMBER" "$STATUS_NAME"
+
+# Retorna JSON si éxito:
+# {"status":"ok","issueNumber":1282,"statusName":"Backlog Tecnico","itemId":"PVTI_kwDOBTzBoc..."}
+```
+
+**Qué hace `add-to-project-status.js` internamente:**
+
+1. Obtiene token GitHub (`gh auth token` con scope `project`)
+2. Agrega el issue al proyecto: `gh project item-add 1 --owner intrale --url "https://github.com/intrale/platform/issues/$ISSUE_NUMBER"`
+3. Espera 500ms a que GitHub procese
+4. Obtiene `itemId` via GraphQL query `projectItems(...)`
+5. Ejecuta mutación `updateProjectV2ItemFieldValue` con el `optionId` del status destino
+6. Retorna JSON con resultado
+
+**Option IDs disponibles:**
+- `Backlog Tecnico`: `4fef8264`
+- `Backlog CLIENTE`: `74b58f5f`
+- `Backlog NEGOCIO`: `1e51e9ff`
+- `Backlog DELIVERY`: `0fa31c9f`
+- `Refined`: `bac097c6`
+- `Done`: `b30e67ed`
+- (otros: ver `project-utils.js` para lista completa)
+
+**Casos de uso:**
+
+```bash
+# /historia: crear nuevo issue y asignar backlog correcto
+node .claude/hooks/add-to-project-status.js "$NEW_ISSUE_NUMBER" "Backlog CLIENTE"
+
+# /refinar: mover issue a "Refined"
+node .claude/hooks/add-to-project-status.js "$ISSUE_NUMBER" "Refined"
+
+# Script masivo: reparar items sin status
+node .claude/hooks/fix-project-status.js  # reparación automatizada
+```
+
+## Comentar en un issue
+
+```bash
+gh issue comment $ISSUE_NUMBER --repo $GH_REPO \
+  --body 'Status cambiado a "Refined"'
+```
+
+## Verificar si un PR existe para una rama
+
+```bash
+gh pr list --repo $GH_REPO --head "$BRANCH" --state open \
+  --json number,url
+```
+
+## Crear un PR
+
+```bash
+gh pr create --repo $GH_REPO \
+  --title "$TITLE" \
+  --body "$(cat <<'EOF'
+## Resumen
+- Punto 1
+
+## Plan de tests
+- [ ] Tests pasan
+- [ ] Build completo
+
+🤖 Generado con [Claude Code](https://claude.ai/claude-code)
+EOF
+)" \
+  --base main \
+  --head "$BRANCH" \
+  --assignee leitolarreta
+```
+
+## Notas importantes
+
+- `gh` está en `/c/Workspaces/gh-cli/bin/` — siempre agregar al PATH al inicio
+- La autenticación se maneja via `GH_TOKEN` (no usar `gh auth login`)
+- `gh --json` devuelve JSON estructurado — mucho más fiable que parsear con grep/sed
+- `--jq` permite filtrar JSON directamente en el comando gh
+- Para operaciones GraphQL complejas (Project V2 mutations), usar `gh api graphql`
+- Respetar rate limits de GitHub: no más de 30 requests por minuto para mutaciones

--- a/.claude/skills/doc/issue-template.md
+++ b/.claude/skills/doc/issue-template.md
@@ -1,0 +1,44 @@
+# Plantilla de estructura de issue
+
+Usar esta estructura al redactar o refinar cualquier issue:
+
+```markdown
+## Objetivo
+
+Propósito conciso de la historia. Una o dos oraciones que expliquen el "qué" y el "para qué".
+
+## Contexto
+
+- Comportamiento actual (si aplica)
+- Antecedentes relevantes
+- Dependencias con otros issues (si las hay)
+
+## Cambios requeridos
+
+1. **[Módulo/Capa]** — Descripción del cambio
+   - Archivo: `ruta/completa/al/archivo.kt`
+   - Detalle de la modificación
+2. **[Módulo/Capa]** — Siguiente cambio
+   - Archivo: `ruta/completa/al/archivo.kt`
+
+## Criterios de aceptación
+
+- [ ] Criterio verificable 1
+- [ ] Criterio verificable 2
+- [ ] Tests pasan (`./gradlew check`)
+- [ ] Sin regresiones en módulos afectados
+
+## Notas técnicas
+
+- Consideraciones de implementación
+- Patrones a seguir (ej: patrón Do/Comm, sistema de strings)
+- Riesgos o alternativas descartadas
+```
+
+## Reglas de redaccion
+
+- Nombrar clases, archivos y endpoints exactos con rutas completas del workspace
+- Evitar referencias vagas ("el componente", "la pantalla")
+- Incluir pruebas, docs y configuracion si aplica
+- Redaccion clara, sin ambiguedades
+- Lenguaje tecnico y accionable

--- a/.claude/skills/doc/labels-guide.md
+++ b/.claude/skills/doc/labels-guide.md
@@ -1,0 +1,75 @@
+# Guia de labels — intrale/platform
+
+## Labels de app (obligatorio si aplica a una app)
+
+| Label | Cuando usar |
+|-------|-------------|
+| `app:client` | Funcionalidad del usuario final / consumidor |
+| `app:business` | Funcionalidad del comercio / negocio |
+| `app:delivery` | Funcionalidad del repartidor |
+
+> Un issue puede tener multiples labels de app si afecta a varias apps.
+> Si el issue es solo de backend/infra, no lleva label de app.
+
+## Labels de area (obligatorio, al menos uno)
+
+| Label | Cuando usar |
+|-------|-------------|
+| `area:asignacion` | Asignacion de repartidores a pedidos |
+| `area:carrito` | Carrito de compras |
+| `area:checkout` | Proceso de checkout / confirmacion de compra |
+| `area:comunicacion` | Chat, contacto entre usuarios |
+| `area:configuracion` | Configuracion general del negocio |
+| `area:dashboard` | Dashboard / panel principal |
+| `area:delivery` | Logica de delivery / envio |
+| `area:direcciones` | Gestion de direcciones |
+| `area:estado` | Flujo de estados (pedido, entrega) |
+| `area:historial` | Historial de pedidos / actividad |
+| `area:infra` | Infraestructura, CI/CD, AWS, build |
+| `area:marketing` | Promociones, descuentos |
+| `area:notificaciones` | Notificaciones push/in-app |
+| `area:onboarding` | Registro, primer uso |
+| `area:pagos` | Metodos de pago, procesamiento |
+| `area:pedidos` | Gestion de pedidos |
+| `area:perfil` | Perfil de usuario |
+| `area:productos` | Catalogo, CRUD de productos |
+| `area:seguridad` | 2FA, autenticacion, permisos |
+| `area:ubicacion` | Geolocalizacion, mapas |
+
+## Labels de tipo
+
+| Label | Cuando usar |
+|-------|-------------|
+| `bug` | Algo no funciona como se espera |
+| `enhancement` | Mejora a funcionalidad existente |
+| `refactor` | Refactorizacion sin cambio funcional |
+| `docs` | Documentacion |
+| `strings` | Migracion/ajuste de strings |
+| `tipo:infra` | Infraestructura y tooling |
+| `KMP` | Relacionado a Kotlin Multiplatform |
+
+## Labels de estado (no asignar manualmente, gestionadas por flujo)
+
+| Label | Descripcion |
+|-------|-------------|
+| `blocked` | Issue bloqueado |
+| `Backlog` | En backlog sin refinar |
+| `Refined` | Refinado y listo para priorizar |
+| `In Progress` | En desarrollo |
+| `Ready` | Listo para verificar |
+
+## Labels especiales
+
+| Label | Descripcion |
+|-------|-------------|
+| `codex` | Para ejecucion por leitocodexbot |
+| `from-intake` | Creado desde backlog intake |
+| `good first issue` | Adecuado para contribuidores nuevos |
+
+## Reglas de asignacion
+
+1. Todo issue DEBE tener al menos un label de area
+2. Si el issue afecta a una app especifica, agregar el label de app correspondiente
+3. Si es un bug, agregar `bug`; si es feature nueva, no se necesita label de tipo (es el default)
+4. No agregar labels de estado manualmente — se gestionan via Project V2
+5. Usar `codex` solo si el issue sera ejecutado por el bot

--- a/.claude/skills/monitor/SKILL.md
+++ b/.claude/skills/monitor/SKILL.md
@@ -251,7 +251,7 @@ Muestra para cada sprint (últimos 2-3) qué agentes participaron vs. estuvieron
 │  Presentes: /po /tester /security /delivery /ux /guru …          │
 │  Ausentes:  /backend-dev /android-dev /ios-dev /web-dev …        │
 │ Sprint 2026-02-24:  ██████████ 18/21 (86%) 🟢                    │
-│  Presentes: todos excepto /cleanup /priorizar /refinar            │
+│  Presentes: todos excepto /cleanup /doc            │
 └─────────────────────────────────────────────────────────────────┘
 ```
 

--- a/.claude/skills/planner/SKILL.md
+++ b/.claude/skills/planner/SKILL.md
@@ -20,7 +20,7 @@ Sugerís caminos, priorizás trabajo y maximizás la velocidad del equipo.
 | `sprint [N] [foco]` | Qué hacer en los próximos días — top N accionables (default: 7, rango recomendado: 7-10) |
 | `proponer` | Sugerir nuevas historias basadas en gaps del codebase |
 | `validar-tamaño <issue>` | Clasificar una historia como S/M/L/XL con criterios objetivos |
-| `split <issue>` | Dividir una historia L/XL en sub-historias, crearlas con `/historia` y lanzar `/po acceptance` para cada una |
+| `split <issue>` | Dividir una historia L/XL en sub-historias, crearlas con `/doc nueva` y lanzar `/po acceptance` para cada una |
 | `<foco> [N]` | **Atajo** — equivale a `sprint N <foco>` (ver tabla de focos abajo) |
 | sin argumento | Digest rápido: qué bloquea, qué está listo, qué sigue |
 
@@ -640,7 +640,7 @@ Indicar que no se debe continuar sin split.
 ## Modo: `split`
 
 Divide una historia **L o XL** en sub-historias independientes y entregables.
-Crea cada una con `/historia` y lanza `/po acceptance` para cada sub-historia creada.
+Crea cada una con `/doc nueva` y lanza `/po acceptance` para cada sub-historia creada.
 Registra la relación padre→hijo en los issues de GitHub.
 
 Invocación: `/planner split <número-de-issue>`
@@ -696,9 +696,9 @@ Mostrar el plan completo y obtener confirmación antes de crear los issues.
 
 **Si el modo es autónomo** (invocado por otro agente o con flag `--auto`): crear directamente sin confirmación.
 
-### Paso SP4: Crear cada sub-historia con `/historia`
+### Paso SP4: Crear cada sub-historia con `/doc nueva`
 
-Para cada sub-historia propuesta, invocar `/historia` con el body completo.
+Para cada sub-historia propuesta, invocar `/doc nueva` con el body completo.
 
 El body de cada sub-historia DEBE incluir:
 1. La descripción técnica específica de la sub-porción
@@ -706,7 +706,7 @@ El body de cada sub-historia DEBE incluir:
 3. Los criterios de aceptación propios de esta sub-historia
 4. La sección de `## Notas técnicas` con detalles de implementación
 
-**Formato del argumento a `/historia`:**
+**Formato del argumento a `/doc nueva`:**
 
 ```
 <título de la sub-historia>
@@ -812,7 +812,7 @@ Identificar **gaps en el codebase** que aún no tienen issue:
 
 ### Fuentes de análisis
 1. **Arquitectura mapeada** (ver `../../memory/arquitectura.md`): qué módulos existen pero están incompletos
-2. **Issues existentes**: qué áreas del labels-guide no tienen cobertura (`../refinar/labels-guide.md`)
+2. **Issues existentes**: qué áreas del labels-guide no tienen cobertura (`../doc/labels-guide.md`)
 3. **PRs sin labels**: features implementadas por Codex sin issue padre visible
 4. **Patrones del codebase**: pantallas/flows que le faltan tests, endpoints sin implementar
 
@@ -892,9 +892,9 @@ Este script:
 #### Flujo posterior (manejado por telegram-commander.js)
 
 El usuario presiona botones en Telegram:
-- **✅ Crear**: se lanza `/historia` con el contexto completo de la propuesta
+- **✅ Crear**: se lanza `/doc nueva` con el contexto completo de la propuesta
 - **❌ Descartar**: se marca como descartada y se actualiza el mensaje
-- **✅ Crear todas**: se lanzan sesiones `/historia` para todas las pendientes
+- **✅ Crear todas**: se lanzan sesiones `/doc nueva` para todas las pendientes
 
 **No es necesario esperar la respuesta** — el commander maneja los callbacks de forma asíncrona.
 
@@ -909,7 +909,7 @@ gh issue create --repo $GH_REPO \
   --assignee leitolarreta
 ```
 
-Luego agregar al Project V2 siguiendo el patrón de `../refinar/api-patterns.md`.
+Luego agregar al Project V2 siguiendo el patrón de `../doc/api-patterns.md`.
 
 ---
 

--- a/.claude/skills/po/SKILL.md
+++ b/.claude/skills/po/SKILL.md
@@ -452,7 +452,7 @@ Para cada criterio de aceptación del issue, evaluar:
 
 ### Paso RV6: Si REQUIERE CAMBIOS — proponer nuevas historias
 
-Para cada gap identificado (criterio sin evidencia o con falla), proponer una historia usando `/historia`:
+Para cada gap identificado (criterio sin evidencia o con falla), proponer una historia usando `/doc nueva`:
 
 - Si falta evidencia de un criterio: proponer historia de tipo "qa" para cubrir ese escenario
 - Si hay un bug (FAIL): proponer historia de tipo "bug" para corregirlo
@@ -496,8 +496,8 @@ Para cada gap identificado (criterio sin evidencia o con falla), proponer una hi
 
 | Gap | Tipo | Historia propuesta |
 |-----|------|--------------------|
-| [criterio sin evidencia] | Sin QA | `/historia` — Agregar caso de prueba: [descripción] |
-| [escenario FAIL] | Bug | `/historia` — Corregir: [descripción del fallo] |
+| [criterio sin evidencia] | Sin QA | /doc nueva` — Agregar caso de prueba: [descripción] |
+| [escenario FAIL] | Bug | /doc nueva` — Corregir: [descripción del fallo] |
 
 ### Próximos pasos
 1. [Acción concreta para resolver cada gap]

--- a/.claude/skills/scrum/SKILL.md
+++ b/.claude/skills/scrum/SKILL.md
@@ -14,8 +14,8 @@ Sos pragmático, data-driven y facilitador (no bloqueador). Adaptás la metodolo
 
 **NO solapás con otros skills:**
 - `/planner` decide QUÉ hacer → vos no priorizás ni seleccionás sprint
-- `/priorizar` categoriza y etiqueta → vos no agregás labels
-- `/refinar` enriquece issues → vos no editás body ni estructura
+- `/doc priorizar` categoriza y etiqueta → vos no agregás labels
+- `/doc refinar` enriquece issues → vos no editás body ni estructura
 - `/monitor` trackea sesiones Claude → vos no monitoreás agentes
 - `/po` define reglas de negocio → vos no definís acceptance criteria
 
@@ -1121,7 +1121,7 @@ Mostrar resumen en formato:
 Si el usuario pide acción sobre las recomendaciones:
 
 **Para fusionar** — NO es acción automática del Scrum Master, solo informar:
-- El Scrum Master informa cuáles issues fusionar, pero la fusión la ejecuta el agente `/refinar`
+- El Scrum Master informa cuáles issues fusionar, pero la fusión la ejecuta el agente `/doc refinar`
 - Comentar en ambos issues: `🔍 Scrum Master: posible duplicación con #N detectada (similaridad: X%). Revisar para consolidar.`
 
 **Para vincular**:
@@ -1132,7 +1132,7 @@ gh issue comment <NUMBER> --repo $GH_REPO \
 
 **NO hacer automáticamente**:
 - NO cerrar issues (eso es de `/po` o del equipo)
-- NO editar body de issues (eso es de `/refinar`)
+- NO editar body de issues (eso es de `/doc refinar`)
 - Solo informar y vincular vía comentario
 
 ---
@@ -1348,8 +1348,8 @@ node scripts/sprint-report.js scripts/sprint-plan.json 2>&1 || true
 2. **SIEMPRE** descubrir option IDs al inicio (GitHub puede regenerarlos)
 3. **Respetar rate limits**: máx 30 mutations/min
 4. **NO cerrar ni reabrir issues** — solo cambiar su posición en el board
-5. **NO solapar** con `/planner`, `/priorizar`, `/refinar`, `/monitor`, `/po`
-6. **NO editar body** de issues ni agregar labels — eso es de `/refinar` y `/priorizar`
+5. **NO solapar** con `/planner`, `/doc priorizar`, `/doc refinar`, `/monitor`, `/po`
+6. **NO editar body** de issues ni agregar labels — eso es de `/doc refinar` y `/doc priorizar`
 7. **NO crear ni eliminar issues** — solo gestionar su estado en el board
 8. Usar `board-config.json` para IDs estáticos y `methodology.md` para reglas
 9. Siempre responder en español

--- a/.claude/skills/scrum/methodology.md
+++ b/.claude/skills/scrum/methodology.md
@@ -13,7 +13,7 @@ Documento vivo. Actualizable via `/scrum mejoras`.
 
 | Columna | Significado | Quién mueve aquí |
 |---------|------------|-----------------|
-| Todo | Pendiente de inicio, priorizado | `/planner`, `/refinar`, manual |
+| Todo | Pendiente de inicio, priorizado | `/planner`, `/doc refinar`, manual |
 | In Progress | Alguien está trabajando activamente | Desarrollador, agente al iniciar |
 | Ready | Implementado, esperando review/QA | `/delivery` al crear PR |
 | Blocked | Bloqueado por dependencia externa o interna | Desarrollador, `/scrum sync` |

--- a/.claude/skills/ux/SKILL.md
+++ b/.claude/skills/ux/SKILL.md
@@ -485,7 +485,7 @@ Agrupar hallazgos en issues coherentes (no un issue por cada hallazgo):
 
 ### Paso E4: Crear issues
 
-Para cada issue agrupado, usar Skill `/historia` o crear directamente:
+Para cada issue agrupado, usar Skill `/doc nueva` o crear directamente:
 
 ```bash
 export PATH="/c/Workspaces/gh-cli/bin:$PATH"
@@ -553,7 +553,7 @@ El UX specialist trabaja en conjunto con el ecosistema de agentes:
 |--------|------------|
 | `/po` | UX aporta perspectiva de experiencia; PO aporta perspectiva de negocio. UX NO redefine reglas de negocio. |
 | `/qa` | UX define criterios de UX que QA debe verificar (loading, feedback, accesibilidad). |
-| `/historia` | UX puede crear historias de mejora UX via este skill. |
+| /doc nueva` | UX puede crear historias de mejora UX via este skill. |
 | `/review` | UX puede ser consultado en PRs que afecten UI. |
 | `/android-dev`, `/ios-dev`, `/web-dev`, `/desktop-dev` | UX propone, los devs implementan. UX NO escribe codigo. |
 

--- a/docs/agents-model-optimization.md
+++ b/docs/agents-model-optimization.md
@@ -136,9 +136,9 @@ Para verificar que los skills bajados a Haiku no degradan en calidad:
 
 | Check | Descripción |
 |-------|-------------|
-| `/historia "Agregar campo X"` | Debe crear issue con título, body completo (objetivo, contexto, cambios, criterios de aceptación), labels correctos, milestone asignado |
-| `/refinar 1244` | Debe aplicar estructura estándar al issue sin perder información del body original |
-| `/priorizar` | Debe categorizar issues sin labels y asignar `tipo:*` + `area:*` correctamente |
+| `/doc nueva "Agregar campo X"` | Debe crear issue con título, body completo (objetivo, contexto, cambios, criterios de aceptación), labels correctos, milestone asignado |
+| `/doc refinar 1244` | Debe aplicar estructura estándar al issue sin perder información del body original |
+| `/doc priorizar` | Debe categorizar issues sin labels y asignar `tipo:*` + `area:*` correctamente |
 | `/scrum audit` | Debe generar informe de salud del board con métricas cuantitativas |
 | `/doc nueva "descripción"` | Debe delegar correctamente a `/historia` y retornar issue creado |
 

--- a/docs/arquitectura-operativa.md
+++ b/docs/arquitectura-operativa.md
@@ -199,7 +199,7 @@ Mientras los agentes trabajan, **4 sistemas monitorean en background**:
 | Agente A | Invoca a | Agente B | Propósito | Momento |
 |----------|----------|----------|-----------|---------|
 | **Planner** | → | `/po` (dependencias) | Validar orden de ejecución | Pre-sprint |
-| **Planner** | → | `/historia` | Crear nuevas historias si hay gaps | Pre-sprint |
+| **Planner** | → | `/doc nueva` | Crear nuevas historias si hay gaps | Pre-sprint |
 | **Any Agent** | → | `/branch` | Crear rama antes de trabajar | Inicio |
 | **Any Agent** | → | `/po` (acceptance) | Entender criterios del issue | Inicio |
 | **Any Agent** | → | `/guru` | Investigar patrones/libs | Cuando no sabe |

--- a/docs/operativo/flujo-crear-historia.md
+++ b/docs/operativo/flujo-crear-historia.md
@@ -7,10 +7,10 @@
 
 | Color (pizarra) | Rol | Skills/Agentes |
 |------------------|-----|----------------|
-| Naranja | **OPERATOR** | `/ops`, `/scrum`, `/planner`, `/refinar` |
+| Naranja | **OPERATOR** | `/ops`, `/scrum`, `/planner`, `/doc refinar` |
 | Verde | **DEVELOPER** | `/backend-dev`, `/android-dev`, `/guru` |
 | Azul / Rojo (QA) | **QA** | `/qa`, `/tester` |
-| Rojo | **PRODUCT OWNER** | `/po`, `/historia` |
+| Rojo | **PRODUCT OWNER** | `/po`, `/doc nueva` |
 | Verde (Security) | **SECURITY** | `/security` |
 
 ## Diagrama de flujo
@@ -80,13 +80,13 @@ flowchart TD
 ### 2a. Actualizar Historia — OPERATOR (si ya existe)
 - Actualizar el issue existente con nueva información
 - Preservar historial de cambios y comentarios
-- **Agente**: `/refinar`
+- **Agente**: `/doc refinar`
 
 ### 2b. Refinar — PRODUCT OWNER (si no existe, o después de actualizar)
 - Definir criterios de aceptación claros
 - Especificar flujos principales y alternativos
 - Detallar el valor de negocio y el usuario objetivo
-- **Agente**: `/po` + `/historia`
+- **Agente**: `/po` + `/doc nueva`
 
 ### 3. Validar Tamaño — OPERATOR
 - Evaluar si la historia es demasiado grande para un sprint
@@ -98,7 +98,7 @@ flowchart TD
 - Descomponer la historia en sub-historias independientes y entregables
 - Cada sub-historia debe tener valor por sí misma
 - Vuelve a Refinar para cada sub-historia
-- **Agentes**: `/planner` + `/historia`
+- **Agentes**: `/planner` + `/doc nueva`
 
 ### 5. Trabajo paralelo (cuando el tamaño está OK)
 
@@ -131,7 +131,7 @@ Tres actividades se ejecutan **en paralelo**:
 ### 7. Planificar — OPERATOR
 - Asignar la historia al backlog correcto (Técnico, Cliente, Negocio, Delivery)
 - Priorizar según impacto y esfuerzo
-- **Agentes**: `/planner` + `/priorizar`
+- **Agentes**: `/planner` + `/doc priorizar`
 
 ### 8. Actualizar Roadmap — OPERATOR
 - Reflejar la nueva historia en `scripts/roadmap.json`
@@ -151,13 +151,13 @@ Tres actividades se ejecutan **en paralelo**:
 | Paso | Skill principal | Skills de soporte |
 |------|----------------|-------------------|
 | Verificar existencia | `/doc` | — |
-| Actualizar historia | `/refinar` | — |
-| Refinar | `/po` | `/historia` |
+| Actualizar historia | `/doc refinar` | — |
+| Refinar | `/po` | `/doc nueva` |
 | Validar tamaño | `/planner` | — |
-| Partir historias | `/historia` | `/planner` |
+| Partir historias | `/doc nueva` | `/planner` |
 | Generar casos prueba | `/qa` | `/tester` |
 | Recomendaciones seguridad | `/security` | — |
 | Detalles técnicos | `/guru` | developer skills |
 | Validar dependencias | `/po` | — |
-| Planificar | `/planner` | `/priorizar` |
+| Planificar | `/planner` | `/doc priorizar` |
 | Actualizar roadmap | `/scrum` | `/planner` |

--- a/docs/operativo/flujo-lanzar-sprint.md
+++ b/docs/operativo/flujo-lanzar-sprint.md
@@ -10,7 +10,7 @@
 | Naranja | **OPERATOR** | `/ops`, `/scrum`, `/planner` |
 | Verde | **DEVELOPER** | `/backend-dev`, `/android-dev`, `/ios-dev`, `/web-dev`, `/desktop-dev` |
 | Azul | **QA** | `/qa`, `/tester`, `/review` |
-| Rojo | **PRODUCT OWNER** | `/po`, `/historia` |
+| Rojo | **PRODUCT OWNER** | `/po`, `/doc nueva` |
 
 ## Diagrama de flujo
 
@@ -126,12 +126,12 @@ flowchart TD
 ### 11. Proponer Nuevas Historias — PRODUCT OWNER
 - A partir de lo revisado, identificar mejoras o nuevas funcionalidades
 - Crear issues con estructura completa
-- **Agentes**: `/po` + `/historia`
+- **Agentes**: `/po` + `/doc nueva`
 
 ### 12. Planificar — OPERATOR
 - Priorizar las nuevas historias propuestas
 - Asignar al backlog correspondiente (Técnico, Cliente, Negocio, Delivery)
-- **Agentes**: `/planner` + `/priorizar`
+- **Agentes**: `/planner` + `/doc priorizar`
 
 ### 13. Actualizar Roadmap — OPERATOR
 - Actualizar `scripts/roadmap.json` con el nuevo estado
@@ -172,6 +172,6 @@ El developer skill a re-invocar se detecta automáticamente del activity log (ú
 | Ejecutar QA E2E | `/qa` | — |
 | Generar Videos | `/qa` | — |
 | Revisar Videos | `/po` | — |
-| Proponer Historias | `/historia` | `/po` |
-| Planificar | `/planner` | `/priorizar` |
+| Proponer Historias | `/doc nueva` | `/po` |
+| Planificar | `/planner` | `/doc priorizar` |
 | Actualizar Roadmap | `/scrum` | `/planner` |

--- a/docs/pipeline-agentes.md
+++ b/docs/pipeline-agentes.md
@@ -139,10 +139,10 @@ Para cada agente: fase(s) de intervención, trigger, output, veredicto.
 | `/branch` | Pre-F1 | Creación de historia | Crear rama `agent/<issue>-<slug>`, protección de main | **Indispensable** |
 | `/delivery` | Post-F3 | Fin de implementación | Commit + push + PR, merge | **Indispensable** |
 | `/planner` | Pre-sprint | Inicio de sprint | Sprint plan, Gantt, sprint-plan.json para agentes | **Indispensable** |
-| `/historia` | Ad-hoc | Creación de nueva historia | Issue GitHub con estructura completa | **Indispensable** |
-| `/doc` | Ad-hoc | Nuevo issue o refinamiento | Historia de usuario completa, criterios de aceptación | **Fusionable** con `/historia` — ambos crean/refinan issues. Evaluar unificación. |
-| `/refinar` | Ad-hoc | Triaje de issues sin labels | Etiquetar, organizar en backlogs, mover a Project V2 | **Fusionable** con `/priorizar` — ambos categorizan issues |
-| `/priorizar` | Ad-hoc | Triaje masivo | Categorizar, etiquetar y organizar issues en backlogs | **Fusionable** con `/refinar` |
+| `/doc nueva` | Ad-hoc | Creación de nueva historia | Issue GitHub con estructura completa | **Indispensable** |
+| `/doc` | Ad-hoc | Nuevo issue o refinamiento | Historia de usuario completa, criterios de aceptación | **Fusionable** con `/doc nueva` — ambos crean/refinan issues. Evaluar unificación. |
+| `/doc refinar` | Ad-hoc | Triaje de issues sin labels | Etiquetar, organizar en backlogs, mover a Project V2 | **Fusionable** con `/doc priorizar` — ambos categorizan issues |
+| `/doc priorizar` | Ad-hoc | Triaje masivo | Categorizar, etiquetar y organizar issues en backlogs | **Fusionable** con `/doc refinar` |
 | `/auth` | Transversal | PostToolUse automático | Auto-persistir permisos aprobados en approval-history.json | **Indispensable** |
 | `/monitor` | Ad-hoc | Invocación manual | Dashboard de semáforos multi-sesión, actividad en tiempo real | **Indispensable** |
 | `/cleanup` | Ad-hoc | Fin de sprint o mantenimiento | Limpiar logs, sesiones, worktrees, procesos temporales | **Indispensable** |
@@ -155,9 +155,9 @@ Para cada agente: fase(s) de intervención, trigger, output, veredicto.
 
 ### Resumen por veredicto
 
-**Indispensables (17):** `/po`, `/guru`, `/ux`, `/security`, `/tester`, `/review`, `/builder`, `/qa`, `/scrum`, `/ops`, `/branch`, `/delivery`, `/planner`, `/historia`, `/auth`, `/monitor`, `/cleanup`
+**Indispensables (17):** `/po`, `/guru`, `/ux`, `/security`, `/tester`, `/review`, `/builder`, `/qa`, `/scrum`, `/ops`, `/branch`, `/delivery`, `/planner`, `/doc nueva`, `/auth`, `/monitor`, `/cleanup`
 
-**Fusionables (6):** `/doc` + `/refinar` + `/priorizar` (posible unificación en un solo agente de triaje); `/backend-dev` + `/android-dev` + `/ios-dev` + `/web-dev` + `/desktop-dev` (evaluación: unificar como agente developer genérico con contexto de plataforma inyectado vía prompt enrichment del sprint-plan)
+**Fusionables (6):** `/doc` + `/doc refinar` + `/doc priorizar` (posible unificación en un solo agente de triaje); `/backend-dev` + `/android-dev` + `/ios-dev` + `/web-dev` + `/desktop-dev` (evaluación: unificar como agente developer genérico con contexto de plataforma inyectado vía prompt enrichment del sprint-plan)
 
 **Prescindibles (0):** Ningún agente es prescindible — todos tienen función diferenciada.
 

--- a/docs/planificacion-agentes-y-hooks.md
+++ b/docs/planificacion-agentes-y-hooks.md
@@ -63,7 +63,7 @@ Los agentes tienen nombres propios para hacer el trabajo más ameno y distinguir
 **Personalidad**: Elocuente, bilingüe (español/inglés en código), estructurado.
 **Modelo**: `claude-sonnet-4-6` — Escribir bien requiere calidad. Haiku produce texto genérico.
 **Herramientas**: GitHub API, Read, Write.
-**Skills**: `/doc`, `/refinar`, `/historia`, `/priorizar`
+**Skills**: `/doc`, `/doc refinar`, `/doc nueva`, `/doc priorizar`
 
 ---
 
@@ -143,7 +143,7 @@ git push (Bash tool)
 - [x] Agente **Guru** (skill `/guru`)
 - [x] Agente **DeliveryManager** (skill `/delivery`)
 - [x] Agente **Tester** (skill `/tester`)
-- [x] Agente **Doc** (skill `/doc`, unificando `/historia`, `/refinar`, `/priorizar`)
+- [x] Agente **Doc** (skill `/doc`, unificando `/doc nueva`, `/doc refinar`, `/doc priorizar`)
 - [x] Agente **Planner** (skill `/planner` — planificación, sprint, propuestas, digest)
 - [x] Instalar `gh` CLI 2.86.0 y migrar todos los skills de `curl` a `gh`
 - [x] Mejorar MEMORY.md con patrones de arquitectura y debugging (completado con reporte de Guru)

--- a/docs/sprint-closing-and-planning.md
+++ b/docs/sprint-closing-and-planning.md
@@ -94,7 +94,7 @@ Al final de la lista:
 
 | Botón | Efecto |
 |-------|--------|
-| ✅ Crear | Lanza `/historia` para crear el issue en GitHub automáticamente |
+| ✅ Crear | Lanza `/doc nueva` para crear el issue en GitHub automáticamente |
 | ❌ Descartar | Rechaza la propuesta; no se crea issue |
 | ✅ Crear todas | Crea todas las propuestas pendientes en secuencia |
 
@@ -267,7 +267,7 @@ El `telegram-commander.js` procesa estos callbacks del flujo automático:
 
 | callback_data | Acción |
 |--------------|--------|
-| `create_proposal:N` | Lanza `/historia` para crear el issue N |
+| `create_proposal:N` | Lanza `/doc nueva` para crear el issue N |
 | `discard_proposal:N` | Descarta la propuesta N |
 | `create_all_proposals` | Crea todas las propuestas pendientes |
 | `launch_sprint` | Notifica al usuario que ejecute `Start-Agente.ps1 all` |


### PR DESCRIPTION
## Resumen

Unificación de 3 skills de gestión de backlog en `/doc` con modos operacionales.

- `/doc nueva <desc>` → crea user stories (/historia)
- `/doc refinar <N...>` → refina issues existentes (/refinar)
- `/doc priorizar [rango]` → triaje masivo sin labels (/priorizar)
- `/doc estado` → estado del backlog

## Cambios

1. **Archivos de soporte unificados**: `doc/labels-guide.md`, `doc/issue-template.md`, `doc/api-patterns.md`
2. **New skill logic**: `doc/SKILL.md` con 4 modos operacionales + lógica completa migrada
3. **Eliminados**: skills `historia/`, `refinar/`, `priorizar/` (3 skills → 1)
4. **Actualizadas referencias** en 7+ skills (planner, scrum, po, ux, monitor, etc.)
5. **Docs operativas actualizadas**: agents/, docs/operativo/, docs/

## Criterios de aceptación

- [x] `/doc` soporta los 3 modos (nueva, refinar, priorizar)
- [x] /historia, /refinar, /priorizar eliminados
- [x] Templates migrados a /doc
- [x] Documentación actualizada
- [x] Tests verificados (no hay cambios de código)
- [x] Label qa:skipped agregado (tipo:infra)

## Impacto

- **Skills**: 27 → 24 (reducción 11%)
- **UX**: Simplificada (gestión de backlog unificada)
- **Mantenibilidad**: Lógica centralizada, menos código duplicado

Closes #1507

🤖 Generado con [Claude Code](https://claude.com/claude-code)