### PR TITLE
chore(agentes): optimización de modelos - Haiku puro para /tester, estimar tokens

### DIFF
--- a/.claude/hooks/activity-logger.js
+++ b/.claude/hooks/activity-logger.js
@@ -660,6 +660,16 @@ function updateSession(sessionId, ts, toolName, target, toolInput, usage) {
             session.tokens_output = (session.tokens_output || 0) + (Number(usage.output_tokens) || 0);
         }
 
+        // Estimación de tokens por proxy (#1518): tokens_estimated = (duracion_seg * 15) + (tool_count * 500)
+        // Calibrar contra dashboard de Anthropic. Se usa cuando tokens reales no están disponibles.
+        try {
+            const startedMs = new Date(session.started_ts || ts).getTime();
+            const nowMs = new Date(ts).getTime();
+            const duracionSeg = Math.max(0, Math.round((nowMs - startedMs) / 1000));
+            const toolCount = session.action_count || 0;
+            session.tokens_estimated = (duracionSeg * 15) + (toolCount * 500);
+        } catch(e) { /* no bloquear hook */ }
+
         fs.writeFileSync(sessionFile, JSON.stringify(session, null, 2) + "\n", "utf8");
     } catch(e) { /* no bloquear hook por error de sesion */ }
 }

--- a/.claude/hooks/stop-notify.js
+++ b/.claude/hooks/stop-notify.js
@@ -172,6 +172,11 @@ function flushMetrics(sessionId) {
             ? (tokensInput || 0) + (tokensOutput || 0)
             : null;
 
+        // Estimación de tokens por proxy (#1518): tokens_estimated = (duracion_seg * 15) + (tool_count * 500)
+        // Calibrar contra dashboard de Anthropic. Se usa cuando tokens reales no están disponibles.
+        const duracionSeg = Math.max(0, Math.round((endMs - startMs) / 1000));
+        const tokensEstimated = (duracionSeg * 15) + (totalToolCalls * 500);
+
         const entry = {
             id: shortId,
             sprint_id: getActiveSprintId(),
@@ -189,6 +194,7 @@ function flushMetrics(sessionId) {
             tokens_input: tokensInput,
             tokens_output: tokensOutput,
             tokens_total: tokensTotal,
+            tokens_estimated: tokensEstimated,
         };
 
         // Append-only: leer el archivo existente y agregar el nuevo registro.

--- a/.claude/skills/tester/SKILL.md
+++ b/.claude/skills/tester/SKILL.md
@@ -88,7 +88,7 @@ Reportar:
 - Cobertura si fue solicitada (líneas, branches)
 - Módulos verificados
 
-### Si hay fallos (escalar modelo mentalmente a Sonnet para análisis)
+### Si hay fallos
 
 Para cada test fallido:
 1. Leer el stack trace completo


### PR DESCRIPTION
## Resumen

### Recomendaciones de Análisis Operativo SPR-025

- **R9**: `/tester` bajado a Haiku puro — análisis de fallos es formulaico (leer output → identificar línea → sugerir fix)
- **R10**: `/ux` mantiene Sonnet — 4/5 modos creativos (auditar, benchmark, tendencias, mejorar requieren WebSearch + diseño)  
- **R11**: Estimación de tokens por proxy — fórmula `tokens_estimated = (duracion_seg * 15) + (tool_count * 500)` para calibración futura

### Archivos modificados

- `.claude/skills/tester/SKILL.md` — eliminada instrucción de escalado a Sonnet
- `.claude/hooks/activity-logger.js` — cálculo de tokens_estimated en updateSession()  
- `.claude/hooks/stop-notify.js` — persistencia de tokens_estimated en agent-metrics.json

## Evaluación

- **QA**: omitido intencionalmente — cambios infra-only (sin código Kotlin ni endpoints)
- **Build**: compileKotlin exitosa en 2s (sin cambios en código de producción)
- **Security**: 0 findings — no hay secrets, no hay endpoints nuevos, sin vulnerabilidades
- **Review**: aprobado — 0 bloqueantes, sintaxis JS correcta

## Plan de tests

- [x] Sintaxis de archivos .js verificada con `node -c`
- [x] Build Kotlin compila exitosamente sin cambios
- [x] Security audit sin findings
- [x] Code review aprobado

Closes #1518

🤖 Generado con [Claude Code](https://claude.ai/claude-code)