### PR TITLE
refactor(hooks): consolidar scrum hooks — 4 archivos → 2 puntos de entrada

### DIFF
--- a/.claude/hooks/agent-concurrency-check.js
+++ b/.claude/hooks/agent-concurrency-check.js
@@ -24,7 +24,7 @@ let _sprintSyncAcc = null;
 function getSprintSyncAcc() {
     if (_sprintSyncAcc !== null) return _sprintSyncAcc;
     try {
-        _sprintSyncAcc = require("./sprint-sync");
+        _sprintSyncAcc = require("./sprint-manager");
     } catch (e) {
         _sprintSyncAcc = { syncRoadmapOnly: () => {} };
     }

--- a/.claude/hooks/post-issue-close.js
+++ b/.claude/hooks/post-issue-close.js
@@ -19,7 +19,7 @@ let _sprintSyncPic = null;
 function getSprintSyncPic() {
     if (_sprintSyncPic !== null) return _sprintSyncPic;
     try {
-        _sprintSyncPic = require("./sprint-sync");
+        _sprintSyncPic = require("./sprint-manager");
     } catch (e) {
         _sprintSyncPic = null;
     }

--- a/.claude/hooks/scrum-monitor-bg.js
+++ b/.claude/hooks/scrum-monitor-bg.js
@@ -165,7 +165,7 @@ async function runCheck() {
 
         if (autoRepairInconsistencias.length > 0) {
             try {
-                const { runAutoRepair } = require("./auto-repair-sprint");
+                const { runAutoRepair } = require("./sprint-manager");
                 repairResult = await runAutoRepair(
                     { inconsistencias: autoRepairInconsistencias },
                     { dryRun: false, onlyTypes: AUTO_REPAIR_TYPES }

--- a/.claude/hooks/scrum-validator.js
+++ b/.claude/hooks/scrum-validator.js
@@ -1,0 +1,68 @@
+// scrum-validator.js -- Validacion y correccion unificada del backlog Intrale
+// Consolidacion de scrum-consistency-check.js + scrum-auto-corrections.js (#1511)
+//
+// Este modulo unifica la API publica de ambos scripts de validacion scrum.
+// Los archivos originales se mantienen como implementacion interna.
+//
+// Uso CLI:
+//   node scrum-validator.js consistency [--report] [--alert] [--json]
+//   node scrum-validator.js corrections [--auto] [--report]
+//
+// Uso como modulo:
+//   const { runConsistencyCheck, runAutoCorrections } = require("./scrum-validator");
+
+"use strict";
+
+const consistency = require("./scrum-consistency-check");
+const corrections = require("./scrum-auto-corrections");
+
+// CLI unificado
+if (require.main === module) {
+    const args = process.argv.slice(2);
+    const cmd = args[0] || "";
+    if (cmd === "consistency" || cmd === "consistencia") {
+        consistency.runConsistencyCheck({
+            generateReport: args.includes("--report"),
+            sendAlert: args.includes("--alert")
+        }).then(r => {
+            if (args.includes("--json")) console.log(JSON.stringify(r, null, 2));
+            else {
+                const s = r.summary || {};
+                console.log("Scrum Consistency Check -- " + r.timestamp);
+                console.log("Issues: " + (s.totalIssues || 0) + " | Dup: " + (r.duplicates ? r.duplicates.length : 0));
+                console.log("Contenidas: " + (r.contained ? r.contained.length : 0) + " | Estado: " + (s.health || "?"));
+                if (r.error) console.error("Error:", r.error);
+            }
+        }).catch(e => { console.error("Error:", e.message); process.exit(1); });
+    } else if (cmd === "corrections" || cmd === "correcciones") {
+        corrections.runAutoCorrections({
+            dryRun: !args.includes("--auto"),
+            generateReport: args.includes("--report")
+        }).then(r => {
+            if (r.ok) console.log(corrections.formatAuditSection(r));
+            else { console.error("Error:", r.error); process.exit(1); }
+        }).catch(e => { console.error("Error:", e.message); process.exit(1); });
+    } else {
+        console.log("Uso: node scrum-validator.js <consistency|corrections> [opciones]");
+        console.log("  --report --alert --json --auto");
+    }
+}
+
+module.exports = {
+    runConsistencyCheck: consistency.runConsistencyCheck,
+    detectDuplicates: consistency.detectDuplicates,
+    detectContainedStories: consistency.detectContainedStories,
+    computeSimilarity: consistency.computeSimilarity,
+    extractAcceptanceCriteria: consistency.extractAcceptanceCriteria,
+    jaccardSimilarity: consistency.jaccardSimilarity,
+    tokenize: consistency.tokenize,
+    generateRecommendations: consistency.generateRecommendations,
+    DUPLICATE_THRESHOLD: consistency.DUPLICATE_THRESHOLD,
+    CONTAINED_THRESHOLD: consistency.CONTAINED_THRESHOLD,
+    runAutoCorrections: corrections.runAutoCorrections,
+    formatAuditSection: corrections.formatAuditSection,
+    evaluateCoherenceRules: corrections.evaluateCoherenceRules,
+    COHERENCE_RULES: corrections.COHERENCE_RULES,
+    BACKLOG_COLUMNS: corrections.BACKLOG_COLUMNS,
+    isBacklogColumn: corrections.isBacklogColumn
+};

--- a/.claude/hooks/sprint-manager.js
+++ b/.claude/hooks/sprint-manager.js
@@ -1,0 +1,47 @@
+// sprint-manager.js -- Gestion unificada del sprint: sincronizacion y reparacion
+// Consolidacion de sprint-sync.js + auto-repair-sprint.js (#1511)
+//
+// Este modulo unifica la API publica de ambos scripts de gestion del sprint.
+// Los archivos originales se mantienen como implementacion interna.
+//
+// Uso CLI:
+//   node sprint-manager.js sync [--force]
+//   node sprint-manager.js repair [--auto]
+//
+// Uso como modulo:
+//   const { runSync, syncRoadmapOnly, runAutoRepair } = require("./sprint-manager");
+
+"use strict";
+
+const syncModule = require("./sprint-sync");
+const repairModule = require("./auto-repair-sprint");
+
+// CLI unificado
+if (require.main === module) {
+    const args = process.argv.slice(2);
+    const cmd = args[0] || "";
+    if (cmd === "sync" || cmd === "sincronizar") {
+        syncModule.runSync({ force: args.includes("--force"), silent: false }).then(r => {
+            if (r.skipped) { console.log("Omitido: " + (r.reason || "throttle")); process.exit(0); }
+            if (!r.ok) { console.error("Error:", r.error); process.exit(1); }
+            if (r.changes && r.changes.length > 0) r.changes.forEach(c => console.log("  " + c));
+            else console.log("Sin desincronizaciones.");
+            process.exit(0);
+        }).catch(e => { console.error(e.message); process.exit(1); });
+    } else if (cmd === "repair" || cmd === "reparar") {
+        const { runHealthCheck } = require("./health-check-sprint");
+        runHealthCheck().then(d => repairModule.runAutoRepair(d, { dryRun: !args.includes("--auto") }))
+            .then(r => { console.log(JSON.stringify(r, null, 2)); process.exit(r.ok ? 0 : 1); })
+            .catch(e => { console.error(JSON.stringify({ ok: false, error: e.message })); process.exit(1); });
+    } else {
+        console.log("Uso: node sprint-manager.js <sync|repair> [--force|--auto]");
+    }
+}
+
+module.exports = {
+    runSync: syncModule.runSync,
+    syncRoadmapOnly: syncModule.syncRoadmapOnly,
+    archiveSprintMetrics: syncModule.archiveSprintMetrics,
+    runAutoRepair: repairModule.runAutoRepair,
+    readAuditHistory: repairModule.readAuditHistory
+};

--- a/.claude/hooks/tests/test-p24-sprint-health-repair.js
+++ b/.claude/hooks/tests/test-p24-sprint-health-repair.js
@@ -205,7 +205,7 @@ describe("P-24: auto-repair-sprint.js — existencia y lógica de reparación", 
 
     it("dry-run en runAutoRepair devuelve { ok: true, ok_count: N } con status dry_run", async () => {
         // Test de integración local: crear un diagnóstico mock y correr dry-run
-        const { runAutoRepair } = require(path.join(HOOKS_DIR, "auto-repair-sprint.js"));
+        const { runAutoRepair } = require(path.join(HOOKS_DIR, "sprint-manager.js"));
 
         const fakeDiagnosis = {
             inconsistencias: [

--- a/.claude/skills/delivery/SKILL.md
+++ b/.claude/skills/delivery/SKILL.md
@@ -396,7 +396,7 @@ gh pr merge "$PR_NUMBER" --repo intrale/platform --squash --delete-branch
 
      ```bash
      # Sincronizar roadmap.json con el estado actual del sprint (best-effort)
-     node /c/Workspaces/Intrale/platform/.claude/hooks/sprint-sync.js --force 2>/dev/null
+     node /c/Workspaces/Intrale/platform/.claude/hooks/sprint-manager.js sync --force 2>/dev/null
      ```
 
    - **Merge falla** (conflictos, checks requeridos, etc.):

--- a/.claude/skills/doc/SKILL.md
+++ b/.claude/skills/doc/SKILL.md
@@ -288,7 +288,7 @@ Mostrar:
 ### Paso 13: Sincronizar roadmap.json
 
 ```bash
-node /c/Workspaces/Intrale/platform/.claude/hooks/sprint-sync.js --force 2>/dev/null
+node /c/Workspaces/Intrale/platform/.claude/hooks/sprint-manager.js sync --force 2>/dev/null
 ```
 
 (best-effort: si falla, no interrumpe el flujo)

--- a/.claude/skills/historia/SKILL.md
+++ b/.claude/skills/historia/SKILL.md
@@ -328,7 +328,7 @@ Mostrar:
 Después de crear el issue exitosamente, ejecutar sprint-sync.js para reflejar el nuevo issue en `scripts/roadmap.json`:
 
 ```bash
-node /c/Workspaces/Intrale/platform/.claude/hooks/sprint-sync.js --force 2>/dev/null
+node /c/Workspaces/Intrale/platform/.claude/hooks/sprint-manager.js sync --force 2>/dev/null
 ```
 
 Este paso es best-effort: si falla, no interrumpe el flujo. No reportar al usuario salvo error inesperado.

--- a/.claude/skills/scrum/SKILL.md
+++ b/.claude/skills/scrum/SKILL.md
@@ -190,7 +190,7 @@ Ejecutar Paso 0 completo, luego:
 Ejecutar el script de corrección automática integrado en el audit:
 
 ```bash
-node /c/Workspaces/Intrale/platform/.claude/hooks/scrum-auto-corrections.js --auto --report 2>/dev/null
+node /c/Workspaces/Intrale/platform/.claude/hooks/scrum-validator.js corrections --auto --report 2>/dev/null
 ```
 
 Flags disponibles:
@@ -222,7 +222,7 @@ _Detección automática: [ISO timestamp]_
 
 El script está disponible también como módulo Node.js (`require`):
 ```javascript
-const { runAutoCorrections, formatAuditSection } = require('./scrum-auto-corrections');
+const { runAutoCorrections, formatAuditSection } = require('./scrum-validator');
 const result = await runAutoCorrections({ dryRun: false, generateReport: true });
 ```
 
@@ -445,16 +445,16 @@ Criterios de salud:
 
 ### Sincronización de roadmap.json (al finalizar auditoría)
 
-Después de generar el reporte de auditoría, ejecutar sprint-sync.js para sincronizar `scripts/roadmap.json`:
+Después de generar el reporte de auditoría, ejecutar sprint-manager.js para sincronizar `scripts/roadmap.json`:
 
 ```bash
-node /c/Workspaces/Intrale/platform/.claude/hooks/sprint-sync.js --force 2>/dev/null
+node /c/Workspaces/Intrale/platform/.claude/hooks/sprint-manager.js sync --force 2>/dev/null
 ```
 
 Reportar en el resumen:
 - Si hubo cambios → `✅ roadmap.json actualizado (N cambios)`
 - Si no hubo cambios → `✅ roadmap.json ya sincronizado`
-- Si falló → `⚠️ sprint-sync.js falló (no afecta la auditoría)`
+- Si falló → `⚠️ sprint-manager.js falló (no afecta la auditoría)`
 
 ---
 
@@ -531,16 +531,16 @@ Luego setear el status apropiado según el estado del issue.
 
 ### Sincronización de roadmap.json (al finalizar)
 
-Después de aplicar todas las correcciones al board, ejecutar sprint-sync.js para actualizar `scripts/roadmap.json`:
+Después de aplicar todas las correcciones al board, ejecutar sprint-manager.js para actualizar `scripts/roadmap.json`:
 
 ```bash
-node /c/Workspaces/Intrale/platform/.claude/hooks/sprint-sync.js --force 2>/dev/null
+node /c/Workspaces/Intrale/platform/.claude/hooks/sprint-manager.js sync --force 2>/dev/null
 ```
 
 Reportar el resultado:
 - Si hubo cambios en roadmap.json → `✅ roadmap.json actualizado`
 - Si no hubo cambios → `✅ roadmap.json ya sincronizado`
-- Si falló → `⚠️ sprint-sync.js falló (no bloquea el resultado del sync)`
+- Si falló → `⚠️ sprint-manager.js falló (no bloquea el resultado del sync)`
 
 ---
 
@@ -666,7 +666,7 @@ Mostrar las inconsistencias encontradas con severidad y acción propuesta:
 
 **Con `--auto`**: ejecutar sin confirmación
 ```bash
-node /c/Workspaces/Intrale/platform/.claude/hooks/auto-repair-sprint.js --auto 2>/dev/null
+node /c/Workspaces/Intrale/platform/.claude/hooks/sprint-manager.js repair --auto 2>/dev/null
 ```
 
 **Con `--confirm`** o sin argumentos: mostrar diagnóstico y solicitar confirmación al usuario antes de ejecutar.
@@ -724,7 +724,7 @@ Extraer: `sprint_id`, lista de issues, fechas del sprint.
 
 ```bash
 node /c/Workspaces/Intrale/platform/.claude/hooks/health-check-sprint.js 2>/dev/null
-node /c/Workspaces/Intrale/platform/.claude/hooks/auto-repair-sprint.js --auto 2>/dev/null
+node /c/Workspaces/Intrale/platform/.claude/hooks/sprint-manager.js repair --auto 2>/dev/null
 ```
 
 ### Paso C2b: Backup de roadmap.json ANTES de cualquier modificación
@@ -892,7 +892,7 @@ Archivar las métricas de sesiones del sprint en `.claude/hooks/metrics-archive/
 cat > /tmp/archive-sprint-metrics.js << 'EOF'
 const path = require('path');
 const REPO_ROOT = '/c/Workspaces/Intrale/platform';
-const sprintSync = require(path.join(REPO_ROOT, '.claude', 'hooks', 'sprint-sync.js'));
+const sprintSync = require(path.join(REPO_ROOT, '.claude', 'hooks', 'sprint-manager.js'));
 const fs = require('fs');
 const plan = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, 'scripts', 'sprint-plan.json'), 'utf8'));
 const result = sprintSync.archiveSprintMetrics(plan);
@@ -1055,7 +1055,7 @@ Audita el backlog del Project V2 buscando:
 ### Paso CON1: Ejecutar script de auditoría
 
 ```bash
-node /c/Workspaces/Intrale/platform/.claude/hooks/scrum-consistency-check.js --report --alert 2>/dev/null
+node /c/Workspaces/Intrale/platform/.claude/hooks/scrum-validator.js consistency --report --alert 2>/dev/null
 ```
 
 Flags disponibles:

--- a/.claude/skills/scrum/health-report.js
+++ b/.claude/skills/scrum/health-report.js
@@ -333,7 +333,7 @@ async function generateReport(diagnosis, repairResult) {
 // CLI
 if (require.main === module) {
     const { runHealthCheck } = require(path.join(REPO_ROOT, ".claude", "hooks", "health-check-sprint"));
-    const { runAutoRepair } = require(path.join(REPO_ROOT, ".claude", "hooks", "auto-repair-sprint"));
+    const { runAutoRepair } = require(path.join(REPO_ROOT, ".claude", "hooks", "sprint-manager"));
 
     runHealthCheck().then(async diagnosis => {
         let repairResult = null;

--- a/.claude/skills/scrum/methodology.md
+++ b/.claude/skills/scrum/methodology.md
@@ -82,7 +82,7 @@ Todo → Done             (no se puede completar sin haber trabajado — salvo d
 ### Automáticas (detectadas por auditoría)
 
 Las siguientes reglas son ejecutadas automáticamente por `/scrum audit` mediante
-`scrum-auto-corrections.js`. Las correcciones se aplican sin intervención manual
+`scrum-validator.js`. Las correcciones se aplican sin intervención manual
 y se comentan en cada issue con el patrón:
 `🔄 Scrum Master: movido de [anterior] → [nuevo]. Razón: [razón]. Detectado: [timestamp]`
 
@@ -104,7 +104,7 @@ y se comentan en cada issue con el patrón:
 - Columnas consideradas "Backlog": `Todo`, `Refined`, `Backlog Tecnico`, `Backlog CLIENTE`,
   `Backlog NEGOCIO`, `Backlog DELIVERY`.
 - Patrón de comentario en el issue: `🔄 Scrum Master: movido de [anterior] → [nuevo]. Razón: [razón]. _Detección automática: [timestamp]_`
-- Script de correcciones: `.claude/hooks/scrum-auto-corrections.js`
+- Script de correcciones: `.claude/hooks/scrum-validator.js`
 
 #### Otras reglas (detectadas, corregidas en modo sync)
 
@@ -122,5 +122,5 @@ y se comentan en cada issue con el patrón:
 
 | Fecha | Cambio | Razón |
 |-------|--------|-------|
-| 2026-03-09 | Agregar sección "Reglas de coherencia estado → columna" + alinear con `scrum-auto-corrections.js` | Issue #1301 — auditoría con auto-correcciones |
+| 2026-03-09 | Agregar sección "Reglas de coherencia estado → columna" + alinear con `scrum-validator.js` | Issue #1301 — auditoría con auto-correcciones |
 | 2026-03-02 | Versión inicial | Creación del skill /scrum |

--- a/docs/operativo/hooks-registry.md
+++ b/docs/operativo/hooks-registry.md
@@ -44,7 +44,7 @@
 ### agent-concurrency-check.js ⭐⭐⭐ CRÍTICO
 - **Propósito:** Promocionar siguiente agente de _queue[] si hay capacidad
 - **Scripts invocados:**
-  - sprint-sync.js (sincronizar roadmap con GitHub)
+  - sprint-manager.js (sincronizar roadmap con GitHub)
   - Start-Agente.ps1 (lanzar siguiente agente si hay)
   - notify-telegram.js (notificar promoción)
 - **Estado que toca:**
@@ -66,7 +66,7 @@
 - **Propósito:** Auditar salud del sprint (Project V2 sincronizado, issues correctas)
 - **Scripts invocados:**
   - health-check-sprint.js (ejecutar auditoría)
-  - scrum-auto-corrections.js (auto-reparar inconsistencias menores)
+  - scrum-validator.js (auto-reparar inconsistencias menores)
   - notify-telegram.js (alerta si hay problemas)
 - **Estado que toca:**
   - `scripts/sprint-plan.json` — lectura/escritura de estado
@@ -304,7 +304,7 @@
 
 ```
 agent-concurrency-check.js
-  ├─→ sprint-sync.js (sincronizar roadmap)
+  ├─→ sprint-manager.js (sincronizar roadmap)
   ├─→ Start-Agente.ps1 (lanzar siguiente)
   └─→ notify-telegram.js (notificar)
 
@@ -315,7 +315,7 @@ post-git-push.js
 
 scrum-monitor-bg.js
   ├─→ health-check-sprint.js (ejecutar auditoría)
-  ├─→ scrum-auto-corrections.js (auto-reparar)
+  ├─→ scrum-validator.js (auto-reparar)
   └─→ notify-telegram.js (alerta crítica)
 
 ci-monitor-bg.js

--- a/docs/operativo/troubleshooting.md
+++ b/docs/operativo/troubleshooting.md
@@ -401,7 +401,7 @@
 ├─ Acción F3: Agent "done" en sprint-plan pero "In Progress" en Project V2
 │  │
 │  └─ Causa: Agent terminó pero Project V2 no se actualizó
-│     1. Ejecutar: node .claude/hooks/scrum-auto-corrections.js --repair-status
+│     1. Ejecutar: node .claude/hooks/scrum-validator.js --repair-status
 │     2. Esperar 30s
 │     3. Verificar: /scrum audit
 │     4. Si no se repara: Actualizar manualmente
@@ -414,14 +414,14 @@
 │        - Si plan es correcto: Actualizar Project V2 manualmente
 │        - Si Project V2 es correcto: Actualizar plan
 │     2. Sincronizar:
-│        node .claude/hooks/sprint-sync.js --force-sync
+│        node .claude/hooks/sprint-manager.js --force-sync
 │     3. Verificar: /scrum audit
 │
 └─ Acción F5: Otro tipo de inconsistencia
    │
    └─ Acción:
       1. Leer error completo: /scrum audit
-      2. Ver si es auto-reparable: node .claude/hooks/scrum-auto-corrections.js
+      2. Ver si es auto-reparable: node .claude/hooks/scrum-validator.js
       3. Si no: Invocar /guru (investigar problema específico)
       4. Considerar: Cierre de sprint y replanificación
 ```


### PR DESCRIPTION
## Summary

- Crear `scrum-validator.js` como punto de entrada unificado para consistencia del backlog + correcciones automaticas del board (consolida `scrum-consistency-check.js` + `scrum-auto-corrections.js`)
- Crear `sprint-manager.js` como punto de entrada unificado para sincronizacion del sprint + auto-reparacion (consolida `sprint-sync.js` + `auto-repair-sprint.js`)
- Actualizar todas las referencias externas (`require()`, CLI en SKILL.md, docs) para usar los nuevos modulos

Los 4 archivos originales se mantienen como implementacion interna; los 2 nuevos modulos son la API publica unificada.

## Test plan

- [x] Verificar que `require('./scrum-validator')` exporta las 16 funciones esperadas
- [x] Verificar que `require('./sprint-manager')` exporta las 5 funciones esperadas
- [ ] Ejecutar `/scrum audit` para verificar que la auditoria funciona
- [ ] Ejecutar `/scrum sync` para verificar la sincronizacion
- [ ] Verificar que `scrum-monitor-bg.js` invoca runAutoRepair desde sprint-manager

Closes #1511

Generated with [Claude Code](https://claude.com/claude-code)