### PR TITLE
feat(skills): crear skill /cost — Token Cost Tracker

### DIFF
--- a/.claude/skills/cost/SKILL.md
+++ b/.claude/skills/cost/SKILL.md
@@ -1,0 +1,264 @@
+---
+description: Cost — Token Cost Tracker — métricas de consumo por sesión, agente y sprint
+user-invocable: true
+argument-hint: "[sprint|session <id>|agent <name>|report [--telegram]]"
+allowed-tools: Bash, Read, Glob, Grep
+model: claude-haiku-4-5-20251001
+---
+
+# /cost — Token Cost Tracker
+
+Sos Cost, el agente especialista en métricas de consumo de tokens del proyecto Intrale Platform.
+Tu trabajo es consolidar datos de `agent-metrics.json`, estimar tokens (dado que la API no los expone), y generar reportes de consumo desglosados por sesión, agente y sprint.
+
+## Fórmula de estimación de tokens
+
+La API de Claude Code no expone `tokens_input/tokens_output` (siempre `null`). Se usa una estimación por proxy:
+
+```
+tokens_estimados = (duracion_seg * 15) + (tool_calls * 500)
+```
+
+Donde:
+- `duracion_seg` = diferencia en segundos entre `started_ts` y `ended_ts` (o `last_activity_ts`)
+- `tool_calls` = `total_tool_calls` de la sesión
+
+### Costo estimado por sesión
+
+```
+costo_usd = tokens_estimados / 1_000_000 * costo_por_millon_input + tokens_estimados * 0.25 / 1_000_000 * costo_por_millon_output
+```
+
+Simplificado con el approach por acción:
+```
+costo_usd = total_tool_calls * cost_per_action_usd
+```
+
+Donde `cost_per_action_usd` viene de `.claude/hooks/telegram-config.json` → `claude_metrics.cost_per_action_usd` (default: `0.003`).
+
+## NOTA CRITICA: usar heredoc para scripts Node.js
+
+En el entorno bash de Claude Code, el caracter `!` dentro de `node -e "..."` se escapa como `\!`, rompiendo la sintaxis. **SIEMPRE** escribir scripts Node.js a un archivo temporal con heredoc y luego ejecutarlos:
+
+```bash
+cat > /tmp/mi-script.js << 'EOF'
+// codigo Node.js aqui — ! funciona normalmente
+if (!fs.existsSync(dir)) { ... }
+EOF
+node /tmp/mi-script.js
+```
+
+NUNCA usar `node -e "..."` directamente para scripts con `!`.
+
+## Argumentos
+
+`$ARGUMENTS` controla el modo de ejecución:
+
+| Argumento | Efecto |
+|-----------|--------|
+| (vacío) | Resumen global: últimas sesiones + costo acumulado semanal |
+| `sprint` | Desglose del sprint actual (o el último registrado) |
+| `sprint <ID>` | Desglose de un sprint específico (ej: `sprint SPR-025`) |
+| `session <id>` | Detalle de una sesión específica |
+| `agent <name>` | Historial de un agente/skill específico |
+| `report` | Generar reporte HTML completo |
+| `report --telegram` | Generar reporte HTML + PDF y enviar a Telegram |
+
+## Paso 1: Recopilar datos
+
+### Fuentes de datos (leer en paralelo):
+
+1. **agent-metrics.json**: `.claude/hooks/agent-metrics.json` — historial de sesiones con `tool_counts`, `duration_min`, `tokens_estimated`
+2. **telegram-config.json**: `.claude/hooks/telegram-config.json` — `claude_metrics.cost_per_action_usd` y `weekly_budget_usd`
+3. **sprint-plan.json**: `scripts/sprint-plan.json` — plan del sprint actual (puede no existir)
+4. **Sesiones activas**: `.claude/sessions/*.json` — sesiones en curso
+
+### Lectura de agent-metrics.json
+
+```bash
+cat > /tmp/cost-read-metrics.js << 'EOF'
+const fs = require('fs');
+const METRICS_PATH = '/c/Workspaces/Intrale/platform/.claude/hooks/agent-metrics.json';
+const CONFIG_PATH = '/c/Workspaces/Intrale/platform/.claude/hooks/telegram-config.json';
+
+let metrics = { sessions: [] };
+let config = { claude_metrics: { cost_per_action_usd: 0.003, weekly_budget_usd: 50 } };
+
+try { metrics = JSON.parse(fs.readFileSync(METRICS_PATH, 'utf8')); } catch(e) {}
+try {
+    const raw = JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
+    if (raw.claude_metrics) config.claude_metrics = { ...config.claude_metrics, ...raw.claude_metrics };
+} catch(e) {}
+
+const costPerAction = config.claude_metrics.cost_per_action_usd;
+const weeklyBudget = config.claude_metrics.weekly_budget_usd;
+
+const sessions = metrics.sessions || [];
+const enriched = sessions.map(s => {
+    const durationSec = s.duration_min ? s.duration_min * 60 : 0;
+    const toolCalls = s.total_tool_calls || 0;
+    const tokensEst = s.tokens_estimated || (durationSec * 15) + (toolCalls * 500);
+    const costEst = toolCalls * costPerAction;
+    return { ...s, tokens_estimated: tokensEst, cost_estimated_usd: costEst };
+});
+
+console.log(JSON.stringify({ sessions: enriched, costPerAction, weeklyBudget }, null, 2));
+EOF
+node /tmp/cost-read-metrics.js
+```
+
+Parsear el JSON de salida para obtener las sesiones enriquecidas.
+
+## Paso 2: Calcular métricas según modo
+
+### Modo vacío (resumen global)
+
+Calcular:
+- **Total sesiones** registradas
+- **Total tool calls** (suma de `total_tool_calls`)
+- **Total tokens estimados** (suma de `tokens_estimated`)
+- **Costo total estimado** (suma de `cost_estimated_usd`)
+- **Costo semanal** (sesiones de los últimos 7 días)
+- **Presupuesto semanal**: gauge ASCII vs `weekly_budget_usd`
+- **Top 5 sesiones** por costo (más caras primero)
+- **Top skills** por frecuencia de invocación
+
+### Modo `sprint` o `sprint <ID>`
+
+Filtrar sesiones por `sprint_id`. Calcular:
+- **Total del sprint**: tool calls, tokens, costo
+- **Desglose por agente**: cada sesión con issue, duración, calls, tokens, costo
+- **Costo promedio por agente**
+- **Agente más costoso** vs **más eficiente** (costo por tool call)
+
+### Modo `session <id>`
+
+Buscar la sesión por ID (parcial). Mostrar:
+- Todos los campos de la sesión
+- Desglose de `tool_counts` (Bash, Edit, Write, etc.)
+- Tokens estimados y costo
+- Skills invocados
+
+### Modo `agent <name>`
+
+Filtrar sesiones por `agent_name` (match parcial case-insensitive). Mostrar:
+- Historial de sesiones de ese agente
+- Tendencia de costo (creciente/decreciente)
+- Promedio de costo por sesión
+
+## Paso 3: Mostrar dashboard
+
+### Resumen global (modo vacío)
+
+```
+┌─ COST TRACKER ─────────────────────────────────────────────┐
+├─ RESUMEN ──────────────────────────────────────────────────┤
+│ Sesiones totales:  42                                       │
+│ Tool calls:        3,456                                    │
+│ Tokens estimados:  1,234,567                                │
+│ Costo estimado:    $10.37                                   │
+├─ PRESUPUESTO SEMANAL ──────────────────────────────────────┤
+│ ████████░░ 78% ($39.00 / $50.00)                            │
+│ Proyección: $49.12 al ritmo actual                          │
+├─ TOP 5 SESIONES (por costo) ───────────────────────────────┤
+│ Sesión   │ Sprint  │ Agente        │ Calls │ Tokens  │ Costo│
+│──────────┼─────────┼───────────────┼───────┼─────────┼──────│
+│ 012cc827 │ SPR-025 │ Agente 1      │    80 │  76,000 │ $0.24│
+│ 5bc6a2db │ SPR-026 │ Agente (#1463)│    29 │  81,115 │ $0.09│
+│ ...                                                         │
+├─ TOP SKILLS ───────────────────────────────────────────────┤
+│ /ops ×15  /po ×12  /scrum ×10  /planner ×8  /historia ×7   │
+├─ DISTRIBUCIÓN POR HERRAMIENTA ─────────────────────────────┤
+│ Bash  ████████████████ 52%  (1,797)                         │
+│ Edit  ████████░░░░░░░░ 22%  (760)                           │
+│ Write ████░░░░░░░░░░░░  8%  (276)                           │
+│ Skill ███░░░░░░░░░░░░░  7%  (242)                           │
+│ Otros ███░░░░░░░░░░░░░ 11%  (381)                           │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Desglose por sprint
+
+```
+┌─ COST TRACKER — SPR-025 ───────────────────────────────────┐
+├─ RESUMEN DEL SPRINT ───────────────────────────────────────┤
+│ Agentes: 5  │  Duración: 342 min  │  Costo: $4.56           │
+│ Tool calls: 1,520  │  Tokens est.: 890,000                  │
+│ Costo promedio/agente: $0.91                                │
+├─ DESGLOSE POR AGENTE ──────────────────────────────────────┤
+│ #  │ Issue │ Agente          │ Dur. │ Calls│ Tokens │ Costo │
+│────┼───────┼─────────────────┼──────┼──────┼────────┼───────│
+│  1 │ #1463 │ Agente 1        │ 121m │   80 │ 76,000 │ $0.24 │
+│  2 │ #1464 │ Agente (#1464)  │  74m │   29 │ 81,115 │ $0.09 │
+│ ...                                                         │
+├─ EFICIENCIA ───────────────────────────────────────────────┤
+│ Más costoso:   Agente 1 (#1463) — $0.24 (80 calls, 121m)   │
+│ Más eficiente: Agente 2 (#1464) — $0.003/call               │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Iconos por estado:
+- `$` — costo monetario
+- `█` / `░` — barra de progreso/presupuesto
+- Números con separador de miles (ej: `1,234`)
+
+### Reglas del dashboard:
+- Envolver en bloque de código (triple backtick) para monospace
+- Truncar textos largos con `…`
+- Siempre responder en español
+- Si no hay datos: "Sin métricas registradas. Ejecutar agentes para generar datos."
+
+## Paso 4: Modo `report` — Generar HTML + PDF
+
+Si `$ARGUMENTS` contiene `report`:
+
+1. Escribir un script Node.js temporal que genere HTML con los datos consolidados
+2. Usar el mismo CSS que `sprint-report.js` para consistencia visual
+3. Guardar en `docs/qa/reporte-costos-<fecha>.html`
+4. Si `--telegram` fue indicado, enviar via `scripts/report-to-pdf-telegram.js`
+
+```bash
+cat > /tmp/cost-report.js << 'EOF'
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const REPO_ROOT = '/c/Workspaces/Intrale/platform';
+const METRICS_PATH = path.join(REPO_ROOT, '.claude/hooks/agent-metrics.json');
+const CONFIG_PATH = path.join(REPO_ROOT, '.claude/hooks/telegram-config.json');
+const QA_DIR = path.join(REPO_ROOT, 'docs/qa');
+const REPORT_SCRIPT = path.join(REPO_ROOT, 'scripts/report-to-pdf-telegram.js');
+
+// ... (generar HTML con métricas consolidadas)
+// ... (guardar en QA_DIR)
+// ... (si --telegram, ejecutar report-to-pdf-telegram.js)
+EOF
+node /tmp/cost-report.js $EXTRA_FLAGS
+```
+
+El HTML debe incluir:
+- Tabla de resumen general (sesiones, calls, tokens, costo)
+- Tabla de desglose por sprint
+- Tabla de desglose por agente
+- Gráfico de distribución por herramienta (barras CSS)
+- Presupuesto semanal con gauge visual
+- Footer con fecha y modelo
+
+## Integración con sprint-report.js
+
+El skill `/cost` complementa a `sprint-report.js` agregando la dimensión de costos. Para integrar:
+
+1. `sprint-report.js` puede invocar `/cost sprint` al generar el reporte de sprint
+2. Los datos de `tokens_estimated` en `agent-metrics.json` son populados por el hook `activity-logger.js` usando la misma fórmula
+3. El reporte de costos se genera como documento separado en `docs/qa/`
+
+## Reglas generales
+
+- Workdir: `/c/Workspaces/Intrale/platform` — todos los comandos desde ahí
+- **SIEMPRE usar heredoc + archivo temporal** para scripts Node.js (nunca `node -e "..."`)
+- Usar `node` para operaciones de filesystem
+- Paralelizar lecturas independientes con múltiples llamadas Bash/Read simultáneas
+- Siempre responder en español
+- Fail-open: si una fuente de datos no existe, reportar "N/A" y continuar
+- Números con formato legible: separador de miles, 2 decimales para USD
+- Si no hay datos: "Sin métricas registradas."

--- a/scripts/cost-report.js
+++ b/scripts/cost-report.js
@@ -1,0 +1,419 @@
+#!/usr/bin/env node
+// cost-report.js — Genera HTML+PDF de costos estimados y lo envía a Telegram
+// Uso: node cost-report.js [--telegram] [--sprint <ID>]
+// Fail-open: cualquier error queda en scripts/logs/cost-report.log sin interrumpir el flujo
+
+const fs = require("fs");
+const path = require("path");
+const { execSync } = require("child_process");
+
+// --- Config ---
+const REPO_ROOT = path.resolve(__dirname, "..");
+const METRICS_PATH = path.join(REPO_ROOT, ".claude", "hooks", "agent-metrics.json");
+const CONFIG_PATH = path.join(REPO_ROOT, ".claude", "hooks", "telegram-config.json");
+const SPRINT_PLAN_PATH = path.join(__dirname, "sprint-plan.json");
+const LOG_DIR = path.join(__dirname, "logs");
+const LOG_FILE = path.join(LOG_DIR, "cost-report.log");
+const QA_DIR = path.join(REPO_ROOT, "docs", "qa");
+const REPORT_TO_PDF_TELEGRAM = path.join(__dirname, "report-to-pdf-telegram.js");
+
+// --- Args ---
+const args = process.argv.slice(2);
+const sendTelegram = args.includes("--telegram");
+const sprintIdx = args.indexOf("--sprint");
+const sprintFilter = sprintIdx >= 0 && args[sprintIdx + 1] ? args[sprintIdx + 1] : null;
+
+// --- Logging ---
+function ensureDir(dir) {
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+}
+
+function log(msg) {
+    ensureDir(LOG_DIR);
+    const ts = new Date().toISOString();
+    try { fs.appendFileSync(LOG_FILE, `[${ts}] ${msg}\n`); } catch (e) { /* ignore */ }
+}
+
+function readJsonSafe(filePath) {
+    try {
+        if (!fs.existsSync(filePath)) return null;
+        return JSON.parse(fs.readFileSync(filePath, "utf8"));
+    } catch (e) {
+        log(`Error leyendo ${filePath}: ${e.message}`);
+        return null;
+    }
+}
+
+// --- Token estimation ---
+function estimateTokens(session) {
+    if (session.tokens_estimated) return session.tokens_estimated;
+    const durationSec = (session.duration_min || 0) * 60;
+    const toolCalls = session.total_tool_calls || 0;
+    return (durationSec * 15) + (toolCalls * 500);
+}
+
+function estimateCost(session, costPerAction) {
+    const toolCalls = session.total_tool_calls || 0;
+    return toolCalls * costPerAction;
+}
+
+function formatNumber(n) {
+    return n.toLocaleString("es-AR");
+}
+
+function formatUSD(n) {
+    return "$" + n.toFixed(2);
+}
+
+// --- HTML ---
+const CSS = `
+  @page { size: A4; margin: 20mm; }
+  body { font-family: 'Segoe UI', Arial, sans-serif; color: #1a1a2e; background: #fff; margin: 0; padding: 30px; line-height: 1.6; }
+  h1 { color: #16213e; border-bottom: 3px solid #0f3460; padding-bottom: 10px; font-size: 28px; }
+  h2 { color: #0f3460; border-bottom: 2px solid #e2e8f0; padding-bottom: 6px; margin-top: 30px; font-size: 20px; }
+  h3 { color: #533483; margin-top: 20px; font-size: 16px; }
+  table { width: 100%; border-collapse: collapse; margin: 15px 0; font-size: 14px; }
+  th { background: #0f3460; color: #fff; padding: 10px 12px; text-align: left; font-weight: 600; }
+  td { padding: 8px 12px; border-bottom: 1px solid #e2e8f0; }
+  tr:nth-child(even) { background: #f8fafc; }
+  tr:hover { background: #eef2ff; }
+  .metric-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 15px; margin: 20px 0; }
+  .metric-card { background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: #fff; padding: 20px; border-radius: 12px; text-align: center; }
+  .metric-card.green { background: linear-gradient(135deg, #11998e 0%, #38ef7d 100%); }
+  .metric-card.blue { background: linear-gradient(135deg, #4facfe 0%, #00f2fe 100%); }
+  .metric-card.orange { background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%); }
+  .metric-number { font-size: 36px; font-weight: bold; }
+  .metric-label { font-size: 13px; opacity: 0.9; margin-top: 4px; }
+  .bar-container { background: #e2e8f0; border-radius: 8px; height: 24px; margin: 8px 0; overflow: hidden; }
+  .bar-fill { height: 100%; border-radius: 8px; display: flex; align-items: center; padding-left: 8px; color: #fff; font-size: 12px; font-weight: bold; }
+  .bar-bash { background: #3b82f6; }
+  .bar-edit { background: #8b5cf6; }
+  .bar-write { background: #06b6d4; }
+  .bar-skill { background: #f59e0b; }
+  .bar-other { background: #94a3b8; }
+  .section-box { background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 10px; padding: 20px; margin: 15px 0; }
+  .budget-gauge { background: #e2e8f0; border-radius: 12px; height: 32px; margin: 10px 0; position: relative; overflow: hidden; }
+  .budget-fill { height: 100%; border-radius: 12px; display: flex; align-items: center; justify-content: center; color: #fff; font-weight: bold; font-size: 14px; }
+  .budget-green { background: linear-gradient(90deg, #22c55e, #16a34a); }
+  .budget-yellow { background: linear-gradient(90deg, #f59e0b, #d97706); }
+  .budget-red { background: linear-gradient(90deg, #ef4444, #dc2626); }
+  code { background: #f1f5f9; padding: 2px 6px; border-radius: 4px; font-size: 13px; color: #334155; }
+  .footer { margin-top: 40px; padding-top: 15px; border-top: 2px solid #e2e8f0; font-size: 12px; color: #94a3b8; text-align: center; }
+  .formula { background: #f1f5f9; border-left: 4px solid #667eea; padding: 12px 16px; margin: 10px 0; border-radius: 0 8px 8px 0; font-family: monospace; font-size: 13px; }
+`;
+
+function escapeHtml(str) {
+    if (!str) return "";
+    return String(str).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}
+
+function buildHtml(sessions, costPerAction, weeklyBudget, sprintPlan, filterSprintId) {
+    const fecha = new Date().toISOString().split("T")[0];
+
+    // Filtrar por sprint si se especificó
+    let filteredSessions = sessions;
+    if (filterSprintId) {
+        filteredSessions = sessions.filter(s => s.sprint_id === filterSprintId);
+    }
+
+    // Enriquecer sesiones
+    const enriched = filteredSessions.map(s => ({
+        ...s,
+        tokens_estimated: estimateTokens(s),
+        cost_estimated_usd: estimateCost(s, costPerAction),
+    }));
+
+    // Totales
+    const totalSessions = enriched.length;
+    const totalToolCalls = enriched.reduce((sum, s) => sum + (s.total_tool_calls || 0), 0);
+    const totalTokens = enriched.reduce((sum, s) => sum + s.tokens_estimated, 0);
+    const totalCost = enriched.reduce((sum, s) => sum + s.cost_estimated_usd, 0);
+    const totalDurationMin = enriched.reduce((sum, s) => sum + (s.duration_min || 0), 0);
+
+    // Sesiones de últimos 7 días para costo semanal
+    const weekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+    const weeklySessions = sessions.map(s => ({
+        ...s,
+        tokens_estimated: estimateTokens(s),
+        cost_estimated_usd: estimateCost(s, costPerAction),
+    })).filter(s => (s.started_ts || "") >= weekAgo);
+    const weeklyCost = weeklySessions.reduce((sum, s) => sum + s.cost_estimated_usd, 0);
+    const weeklyPct = weeklyBudget > 0 ? Math.min(Math.round(weeklyCost / weeklyBudget * 100), 100) : 0;
+    const budgetClass = weeklyPct >= 90 ? "budget-red" : weeklyPct >= 70 ? "budget-yellow" : "budget-green";
+
+    // Distribución por herramienta
+    const toolTotals = {};
+    for (const s of enriched) {
+        if (!s.tool_counts) continue;
+        for (const [tool, count] of Object.entries(s.tool_counts)) {
+            toolTotals[tool] = (toolTotals[tool] || 0) + count;
+        }
+    }
+    const toolEntries = Object.entries(toolTotals).sort((a, b) => b[1] - a[1]);
+    const toolTotal = toolEntries.reduce((sum, [, n]) => sum + n, 0);
+
+    // Agrupar por sprint
+    const sprintGroups = {};
+    for (const s of enriched) {
+        const sid = s.sprint_id || "Sin sprint";
+        if (!sprintGroups[sid]) sprintGroups[sid] = [];
+        sprintGroups[sid].push(s);
+    }
+
+    // Skills más invocados
+    const skillCounts = {};
+    for (const s of enriched) {
+        if (!s.skills_invoked) continue;
+        for (const skill of s.skills_invoked) {
+            skillCounts[skill] = (skillCounts[skill] || 0) + 1;
+        }
+    }
+    const topSkills = Object.entries(skillCounts).sort((a, b) => b[1] - a[1]).slice(0, 10);
+
+    // Top sesiones por costo
+    const topSessions = [...enriched].sort((a, b) => b.cost_estimated_usd - a.cost_estimated_usd).slice(0, 10);
+
+    const title = filterSprintId
+        ? `Reporte de Costos — ${escapeHtml(filterSprintId)}`
+        : `Reporte de Costos — ${escapeHtml(fecha)}`;
+
+    let html = `<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<title>${title} — Intrale Platform</title>
+<style>${CSS}</style>
+</head>
+<body>
+
+<h1>${title}</h1>
+<p><strong>Proyecto:</strong> Intrale Platform (<code>intrale/platform</code>)<br>
+<strong>Fecha:</strong> ${fecha}<br>
+<strong>Sesiones analizadas:</strong> ${totalSessions}<br>
+<strong>Costo por acción:</strong> ${formatUSD(costPerAction)}</p>
+
+<div class="formula">
+<strong>Fórmula de estimación:</strong> tokens ≈ (duración_seg × 15) + (tool_calls × 500) | costo ≈ tool_calls × ${formatUSD(costPerAction)}
+</div>
+
+<!-- MÉTRICAS GLOBALES -->
+<h2>1. Métricas Globales</h2>
+<div class="metric-grid">
+  <div class="metric-card">
+    <div class="metric-number">${totalSessions}</div>
+    <div class="metric-label">Sesiones</div>
+  </div>
+  <div class="metric-card green">
+    <div class="metric-number">${formatNumber(totalToolCalls)}</div>
+    <div class="metric-label">Tool Calls</div>
+  </div>
+  <div class="metric-card blue">
+    <div class="metric-number">${formatNumber(totalTokens)}</div>
+    <div class="metric-label">Tokens Estimados</div>
+  </div>
+  <div class="metric-card orange">
+    <div class="metric-number">${formatUSD(totalCost)}</div>
+    <div class="metric-label">Costo Estimado</div>
+  </div>
+</div>
+
+<!-- PRESUPUESTO SEMANAL -->
+<h2>2. Presupuesto Semanal</h2>
+<div class="section-box">
+  <p><strong>Costo últimos 7 días:</strong> ${formatUSD(weeklyCost)} / ${formatUSD(weeklyBudget)}</p>
+  <div class="budget-gauge">
+    <div class="budget-fill ${budgetClass}" style="width: ${Math.max(weeklyPct, 5)}%">
+      ${weeklyPct}%
+    </div>
+  </div>
+  <p><strong>Sesiones esta semana:</strong> ${weeklySessions.length} | <strong>Duración total:</strong> ${totalDurationMin} min</p>
+</div>
+
+<!-- DISTRIBUCIÓN POR HERRAMIENTA -->
+<h2>3. Distribución por Herramienta</h2>
+<div class="section-box">`;
+
+    const toolColors = { Bash: "bar-bash", Edit: "bar-edit", Write: "bar-write", Skill: "bar-skill" };
+    for (const [tool, count] of toolEntries.slice(0, 8)) {
+        const pct = toolTotal > 0 ? Math.round(count / toolTotal * 100) : 0;
+        const barClass = toolColors[tool] || "bar-other";
+        html += `
+  <p style="margin: 4px 0; font-size: 13px;"><strong>${escapeHtml(tool)}</strong> — ${formatNumber(count)} (${pct}%)</p>
+  <div class="bar-container">
+    <div class="bar-fill ${barClass}" style="width: ${Math.max(pct, 2)}%">${pct}%</div>
+  </div>`;
+    }
+
+    html += `
+</div>
+
+<!-- TOP SESIONES -->
+<h2>4. Top Sesiones por Costo</h2>
+<table>
+  <thead>
+    <tr><th>Sesión</th><th>Sprint</th><th>Agente</th><th>Dur.</th><th>Calls</th><th>Tokens Est.</th><th>Costo</th></tr>
+  </thead>
+  <tbody>`;
+
+    for (const s of topSessions) {
+        const agentLabel = s.agent_name || (s.branch ? s.branch.replace("agent/", "").substring(0, 20) : "N/A");
+        html += `
+    <tr>
+      <td><code>${escapeHtml(s.id)}</code></td>
+      <td>${escapeHtml(s.sprint_id || "—")}</td>
+      <td>${escapeHtml(agentLabel)}</td>
+      <td>${s.duration_min || 0} min</td>
+      <td>${s.total_tool_calls || 0}</td>
+      <td>${formatNumber(s.tokens_estimated)}</td>
+      <td><strong>${formatUSD(s.cost_estimated_usd)}</strong></td>
+    </tr>`;
+    }
+
+    html += `
+  </tbody>
+</table>
+
+<!-- DESGLOSE POR SPRINT -->
+<h2>5. Desglose por Sprint</h2>`;
+
+    for (const [sprintId, sprintSessions] of Object.entries(sprintGroups)) {
+        const sprintCalls = sprintSessions.reduce((sum, s) => sum + (s.total_tool_calls || 0), 0);
+        const sprintTokens = sprintSessions.reduce((sum, s) => sum + s.tokens_estimated, 0);
+        const sprintCost = sprintSessions.reduce((sum, s) => sum + s.cost_estimated_usd, 0);
+        const sprintDur = sprintSessions.reduce((sum, s) => sum + (s.duration_min || 0), 0);
+
+        html += `
+<div class="section-box">
+  <h3>${escapeHtml(sprintId)}</h3>
+  <p><strong>Sesiones:</strong> ${sprintSessions.length} | <strong>Duración:</strong> ${sprintDur} min | <strong>Calls:</strong> ${formatNumber(sprintCalls)} | <strong>Tokens:</strong> ${formatNumber(sprintTokens)} | <strong>Costo:</strong> ${formatUSD(sprintCost)}</p>
+  <table>
+    <thead>
+      <tr><th>Sesión</th><th>Agente</th><th>Dur.</th><th>Calls</th><th>Tokens</th><th>Costo</th></tr>
+    </thead>
+    <tbody>`;
+
+        for (const s of sprintSessions.sort((a, b) => b.cost_estimated_usd - a.cost_estimated_usd)) {
+            const agentLabel = s.agent_name || (s.branch ? s.branch.replace("agent/", "").substring(0, 25) : "N/A");
+            html += `
+      <tr>
+        <td><code>${escapeHtml(s.id)}</code></td>
+        <td>${escapeHtml(agentLabel)}</td>
+        <td>${s.duration_min || 0}m</td>
+        <td>${s.total_tool_calls || 0}</td>
+        <td>${formatNumber(s.tokens_estimated)}</td>
+        <td>${formatUSD(s.cost_estimated_usd)}</td>
+      </tr>`;
+        }
+
+        html += `
+    </tbody>
+  </table>
+</div>`;
+    }
+
+    // Skills más invocados
+    if (topSkills.length > 0) {
+        html += `
+<!-- TOP SKILLS -->
+<h2>6. Skills más Invocados</h2>
+<table>
+  <thead>
+    <tr><th>Skill</th><th>Invocaciones</th></tr>
+  </thead>
+  <tbody>`;
+
+        for (const [skill, count] of topSkills) {
+            html += `
+    <tr>
+      <td><code>${escapeHtml(skill)}</code></td>
+      <td>${count}</td>
+    </tr>`;
+        }
+
+        html += `
+  </tbody>
+</table>`;
+    }
+
+    // Footer
+    html += `
+<div class="footer">
+  <p>Generado automáticamente el ${fecha} | Intrale Platform | Cost Report</p>
+  <p>Modelo: Claude Haiku 4.5 | Estimación por proxy (duración + tool calls)</p>
+</div>
+
+</body>
+</html>`;
+
+    return html;
+}
+
+// --- PDF + Telegram ---
+function sendReportViaTelegram(htmlPath, caption) {
+    if (!fs.existsSync(REPORT_TO_PDF_TELEGRAM)) {
+        log("report-to-pdf-telegram.js no encontrado: " + REPORT_TO_PDF_TELEGRAM);
+        return false;
+    }
+    try {
+        const result = execSync(
+            `node "${REPORT_TO_PDF_TELEGRAM}" "${htmlPath}" "${caption.replace(/"/g, '\\"')}"`,
+            { encoding: "utf8", timeout: 120000 }
+        ).trim();
+        log("report-to-pdf-telegram.js OK: " + result);
+        return true;
+    } catch (e) {
+        log("report-to-pdf-telegram.js falló: " + e.message);
+        return false;
+    }
+}
+
+// --- Main ---
+function main() {
+    log("=== cost-report.js iniciado ===");
+
+    // Leer métricas
+    const metrics = readJsonSafe(METRICS_PATH);
+    if (!metrics || !metrics.sessions || metrics.sessions.length === 0) {
+        log("Sin sesiones en agent-metrics.json. Abortando.");
+        console.log("Sin métricas registradas.");
+        return;
+    }
+
+    // Leer config
+    const config = readJsonSafe(CONFIG_PATH) || {};
+    const costPerAction = (config.claude_metrics && config.claude_metrics.cost_per_action_usd) || 0.003;
+    const weeklyBudget = (config.claude_metrics && config.claude_metrics.weekly_budget_usd) || 50;
+
+    // Leer sprint plan
+    const sprintPlan = readJsonSafe(SPRINT_PLAN_PATH);
+
+    log(`Métricas: ${metrics.sessions.length} sesiones, costPerAction=${costPerAction}, weeklyBudget=${weeklyBudget}`);
+
+    // Generar HTML
+    const fecha = new Date().toISOString().split("T")[0];
+    const suffix = sprintFilter ? `-${sprintFilter.toLowerCase()}` : "";
+    const htmlFileName = `reporte-costos${suffix}-${fecha}.html`;
+    const htmlPath = path.join(QA_DIR, htmlFileName);
+    const html = buildHtml(metrics.sessions, costPerAction, weeklyBudget, sprintPlan, sprintFilter);
+
+    ensureDir(QA_DIR);
+    fs.writeFileSync(htmlPath, html, "utf8");
+    log(`HTML generado: ${htmlPath}`);
+    console.log(`Reporte generado: ${htmlPath}`);
+
+    // Enviar a Telegram si se solicitó
+    if (sendTelegram) {
+        const sprintLabel = sprintFilter ? ` ${sprintFilter}` : "";
+        const caption = `💰 Reporte de Costos${sprintLabel} — ${fecha} — ${metrics.sessions.length} sesiones`;
+        const sent = sendReportViaTelegram(htmlPath, caption);
+        if (sent) {
+            console.log("Reporte enviado a Telegram.");
+        } else {
+            console.log("No se pudo enviar a Telegram (ver log).");
+        }
+    }
+
+    log("=== cost-report.js completado ===");
+}
+
+main();

--- a/scripts/sprint-report.js
+++ b/scripts/sprint-report.js
@@ -773,6 +773,15 @@ async function main() {
     execSafe(`node "${path.join(__dirname, "evaluate-and-release.js")}" "${planPath}"`, { timeout: 60000 });
     log("--- evaluate-and-release.js completado ---");
 
+    // Paso 3: Generar reporte de costos del sprint (fail-open)
+    const costReportScript = path.join(__dirname, "cost-report.js");
+    if (fs.existsSync(costReportScript)) {
+        log("--- Iniciando cost-report.js ---");
+        const sprintFlag = plan.sprint_id ? `--sprint ${plan.sprint_id}` : "";
+        execSafe(`node "${costReportScript}" --telegram ${sprintFlag}`, { timeout: 120000 });
+        log("--- cost-report.js completado ---");
+    }
+
     const elapsed = Math.round((Date.now() - startTime) / 1000);
     log(`=== sprint-report.js completado en ${elapsed}s ===`);
 }


### PR DESCRIPTION
## Summary
- Nuevo skill `/cost` (Haiku) para trackear y reportar metricas de consumo de tokens
- Estimacion de tokens por proxy: `tokens = (duracion_seg * 15) + (tool_calls * 500)`
- Script `cost-report.js` para generacion de reportes HTML+PDF con envio a Telegram
- Integrado con `sprint-report.js` para ejecutarse automaticamente al cierre de sprint

## Cambios
- `.claude/skills/cost/SKILL.md` -- Definicion completa del skill con modos: resumen global, sprint, session, agent, report
- `scripts/cost-report.js` -- Script Node.js para generar HTML con metricas de costos y enviar PDF via Telegram
- `scripts/sprint-report.js` -- Integrado paso 3 para invocar cost-report.js al finalizar sprint
- `.claude/settings.local.json` -- Permiso `Skill(cost)` registrado

## Criterios de aceptacion
- [x] Skill /cost creado con modelo Haiku
- [x] Estimacion de tokens implementada
- [x] Reporte PDF con desglose por agente/skill
- [x] Integrado con sprint-report.js

Closes #1513

## Test plan
- [ ] Invocar `/cost` sin argumentos y verificar dashboard ASCII
- [ ] Invocar `/cost sprint SPR-027` y verificar desglose
- [ ] Invocar `/cost report --telegram` y verificar PDF en Telegram
- [ ] Ejecutar `node scripts/cost-report.js` y verificar HTML generado en docs/qa/
- [ ] Verificar que sprint-report.js invoca cost-report.js al finalizar

Generated with [Claude Code](https://claude.com/claude-code)