### PR TITLE
feat: implementar CRUD productos y categorías #612

### DIFF
--- a/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/catalog/DefaultCatalog_en.kt
+++ b/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/catalog/DefaultCatalog_en.kt
@@ -89,6 +89,7 @@ internal val DefaultCatalog_en: Map<MessageKey, String> = mapOf(
     MessageKey.product_form_available to "Available",
     MessageKey.product_form_out_of_stock to "Out of stock",
     MessageKey.product_form_stock_quantity to "Stock quantity",
+    MessageKey.product_form_stock_helper to "Leave empty for unlimited stock",
     MessageKey.business_products_out_of_stock to "Out of stock",
     MessageKey.client_product_out_of_stock to "Out of stock",
     MessageKey.business_categories_title to "Categories",

--- a/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/catalog/DefaultCatalog_es.kt
+++ b/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/catalog/DefaultCatalog_es.kt
@@ -89,6 +89,7 @@ internal val DefaultCatalog_es: Map<MessageKey, String> = mapOf(
     MessageKey.product_form_available to "Disponible",
     MessageKey.product_form_out_of_stock to "Agotado",
     MessageKey.product_form_stock_quantity to "Cantidad en stock",
+    MessageKey.product_form_stock_helper to "Dejar vacio para stock ilimitado",
     MessageKey.business_products_out_of_stock to "Agotado",
     MessageKey.client_product_out_of_stock to "Agotado",
     MessageKey.business_categories_title to "Categorías",

--- a/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/model/MessageKey.kt
+++ b/app/composeApp/src/commonMain/kotlin/ar/com/intrale/strings/model/MessageKey.kt
@@ -92,6 +92,7 @@ enum class MessageKey {
     product_form_available,
     product_form_out_of_stock,
     product_form_stock_quantity,
+    product_form_stock_helper,
     business_products_out_of_stock,
     client_product_out_of_stock,
     dashboard_menu_request_join_business,

--- a/app/composeApp/src/commonMain/kotlin/ext/business/ClientCategoryService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/business/ClientCategoryService.kt
@@ -83,10 +83,10 @@ class ClientCategoryService(
         }
 
     private fun categoriesUrl(businessId: String): String =
-        "${BuildKonfig.BASE_URL}${BuildKonfig.BUSINESS}/business/$businessId/categories"
+        "${BuildKonfig.BASE_URL}$businessId/business/categories"
 
     private fun categoryUrl(businessId: String, categoryId: String): String =
-        "${categoriesUrl(businessId)}/$categoryId"
+        "${BuildKonfig.BASE_URL}$businessId/business/categories/$categoryId"
 
     private suspend fun HttpResponse.toCategory(): CategoryDTO {
         val bodyText = bodyAsText()

--- a/app/composeApp/src/commonMain/kotlin/ext/business/ClientProductService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/business/ClientProductService.kt
@@ -86,10 +86,10 @@ class ClientProductService(
         }
 
     private fun productsUrl(businessId: String): String =
-        "${BuildKonfig.BASE_URL}${BuildKonfig.BUSINESS}/business/$businessId/products"
+        "${BuildKonfig.BASE_URL}$businessId/business/products"
 
     private fun productUrl(businessId: String, productId: String): String =
-        "${productsUrl(businessId)}/$productId"
+        "${BuildKonfig.BASE_URL}$businessId/business/products/$productId"
 
     private suspend fun HttpResponse.toProduct(): ProductDTO {
         val bodyText = bodyAsText()

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/business/ProductFormScreen.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/business/ProductFormScreen.kt
@@ -14,11 +14,19 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Save
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
@@ -48,6 +56,8 @@ import ui.sc.shared.callService
 import ui.session.SessionStore
 import ui.th.spacing
 
+private val UNIT_OPTIONS = listOf("kg", "g", "unidad", "docena", "litro", "ml", "porcion")
+
 class ProductFormScreen(
     private val editorStore: ProductEditorStore = ProductEditorStore
 ) : Screen(BUSINESS_PRODUCT_FORM_PATH) {
@@ -59,6 +69,7 @@ class ProductFormScreen(
         ScreenContent()
     }
 
+    @OptIn(ExperimentalMaterial3Api::class)
     @Composable
     private fun ScreenContent(viewModel: ProductFormViewModel = viewModel { ProductFormViewModel() }) {
         val sessionState by SessionStore.sessionState.collectAsState()
@@ -66,6 +77,7 @@ class ProductFormScreen(
         val snackbarHostState = remember { SnackbarHostState() }
         val coroutineScope = rememberCoroutineScope()
         var showDeleteDialog by remember { mutableStateOf(false) }
+        var unitExpanded by remember { mutableStateOf(false) }
 
         val businessId = sessionState.selectedBusinessId
         val productSavedMessage = Txt(MessageKey.product_form_saved)
@@ -77,6 +89,7 @@ class ProductFormScreen(
         val deleteConfirmAccept = Txt(MessageKey.product_form_delete_confirm_accept)
         val deleteConfirmCancel = Txt(MessageKey.product_form_delete_confirm_cancel)
         val refreshCategoriesLabel = Txt(MessageKey.business_categories_retry)
+        val stockHelperText = Txt(MessageKey.product_form_stock_helper)
 
         LaunchedEffect(draft) {
             viewModel.applyDraft(draft)
@@ -135,19 +148,54 @@ class ProductFormScreen(
                     onValueChange = { viewModel.uiState = viewModel.uiState.copy(shortDescription = it) }
                 )
 
+                // Precio con prefijo $ para indicar moneda
                 TextField(
                     label = MessageKey.product_form_base_price,
                     value = viewModel.uiState.basePrice,
                     state = viewModel.inputsStates[ProductFormUiState::basePrice.name]!!,
-                    onValueChange = { viewModel.uiState = viewModel.uiState.copy(basePrice = it) }
+                    onValueChange = { viewModel.uiState = viewModel.uiState.copy(basePrice = it) },
+                    leadingIcon = { Text("$", style = MaterialTheme.typography.bodyLarge) }
                 )
 
-                TextField(
-                    label = MessageKey.product_form_unit,
-                    value = viewModel.uiState.unit,
-                    state = viewModel.inputsStates[ProductFormUiState::unit.name]!!,
-                    onValueChange = { viewModel.uiState = viewModel.uiState.copy(unit = it) }
-                )
+                // Unidad como dropdown con opciones predefinidas
+                ExposedDropdownMenuBox(
+                    expanded = unitExpanded,
+                    onExpandedChange = { unitExpanded = it },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    OutlinedTextField(
+                        value = viewModel.uiState.unit,
+                        onValueChange = {},
+                        readOnly = true,
+                        label = {
+                            Text(
+                                Txt(MessageKey.product_form_unit),
+                                style = MaterialTheme.typography.labelMedium
+                            )
+                        },
+                        trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = unitExpanded) },
+                        singleLine = true,
+                        textStyle = MaterialTheme.typography.bodyLarge,
+                        shape = MaterialTheme.shapes.medium,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .menuAnchor(MenuAnchorType.PrimaryNotEditable, enabled = true)
+                    )
+                    ExposedDropdownMenu(
+                        expanded = unitExpanded,
+                        onDismissRequest = { unitExpanded = false }
+                    ) {
+                        UNIT_OPTIONS.forEach { unit ->
+                            DropdownMenuItem(
+                                text = { Text(unit, style = MaterialTheme.typography.bodyLarge) },
+                                onClick = {
+                                    viewModel.uiState = viewModel.uiState.copy(unit = unit)
+                                    unitExpanded = false
+                                }
+                            )
+                        }
+                    }
+                }
 
                 CategorySelector(
                     categories = viewModel.categories,
@@ -171,6 +219,7 @@ class ProductFormScreen(
 
                 StockQuantityField(
                     value = viewModel.uiState.stockQuantity,
+                    helperText = stockHelperText,
                     onValueChange = viewModel::updateStockQuantity
                 )
 
@@ -230,14 +279,24 @@ class ProductFormScreen(
                     }
                 )
 
+                // Botón de eliminar con estilo destructivo (error color)
                 if (viewModel.mode == ProductFormMode.Edit) {
-                    IntralePrimaryButton(
-                        text = Txt(MessageKey.product_form_delete),
-                        leadingIcon = Icons.Default.Delete,
-                        iconContentDescription = Txt(MessageKey.product_form_delete),
+                    Button(
+                        onClick = { showDeleteDialog = true },
                         enabled = !viewModel.loading,
-                        onClick = { showDeleteDialog = true }
-                    )
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = MaterialTheme.colorScheme.error,
+                            contentColor = MaterialTheme.colorScheme.onError
+                        ),
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Delete,
+                            contentDescription = Txt(MessageKey.product_form_delete)
+                        )
+                        Spacer(Modifier.size(ButtonDefaults.IconSpacing))
+                        Text(Txt(MessageKey.product_form_delete))
+                    }
                 }
             }
         }
@@ -248,22 +307,29 @@ class ProductFormScreen(
                 title = { Text(deleteConfirmTitle) },
                 text = { Text(deleteConfirmMessage) },
                 confirmButton = {
-                    TextButton(onClick = {
-                        showDeleteDialog = false
-                        callService(
-                            coroutineScope = coroutineScope,
-                            snackbarHostState = snackbarHostState,
-                            setLoading = { viewModel.loading = it },
-                            serviceCall = { viewModel.delete(businessId) },
-                            onSuccess = {
-                                editorStore.clear()
-                                coroutineScope.launch {
-                                    snackbarHostState.showSnackbar(productDeletedMessage)
+                    // Botón de confirmación de eliminación con estilo destructivo
+                    Button(
+                        onClick = {
+                            showDeleteDialog = false
+                            callService(
+                                coroutineScope = coroutineScope,
+                                snackbarHostState = snackbarHostState,
+                                setLoading = { viewModel.loading = it },
+                                serviceCall = { viewModel.delete(businessId) },
+                                onSuccess = {
+                                    editorStore.clear()
+                                    coroutineScope.launch {
+                                        snackbarHostState.showSnackbar(productDeletedMessage)
+                                    }
+                                    navigate(BUSINESS_PRODUCTS_PATH)
                                 }
-                                navigate(BUSINESS_PRODUCTS_PATH)
-                            }
+                            )
+                        },
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = MaterialTheme.colorScheme.error,
+                            contentColor = MaterialTheme.colorScheme.onError
                         )
-                    }) {
+                    ) {
                         Text(deleteConfirmAccept)
                     }
                 },
@@ -422,6 +488,7 @@ private fun AvailabilitySelector(
 @Composable
 private fun StockQuantityField(
     value: String,
+    helperText: String,
     onValueChange: (String) -> Unit
 ) {
     OutlinedTextField(
@@ -435,6 +502,13 @@ private fun StockQuantityField(
             Text(
                 Txt(MessageKey.product_form_stock_quantity),
                 style = MaterialTheme.typography.labelMedium
+            )
+        },
+        supportingText = {
+            Text(
+                text = helperText,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
             )
         },
         singleLine = true,

--- a/users/src/main/kotlin/ar/com/intrale/BusinessCategories.kt
+++ b/users/src/main/kotlin/ar/com/intrale/BusinessCategories.kt
@@ -1,0 +1,99 @@
+package ar.com.intrale
+
+import aws.sdk.kotlin.services.cognitoidentityprovider.CognitoIdentityProviderClient
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable
+
+class BusinessCategories(
+    override val config: UsersConfig,
+    override val logger: Logger,
+    private val cognito: CognitoIdentityProviderClient,
+    private val tableProfiles: DynamoDbTable<UserBusinessProfile>,
+    private val categoryRepository: CategoryRepository,
+    override val jwtValidator: JwtValidator = CognitoJwtValidator(config)
+) : SecuredFunction(config = config, logger = logger, jwtValidator = jwtValidator) {
+
+    override suspend fun securedExecute(
+        business: String,
+        function: String,
+        headers: Map<String, String>,
+        textBody: String
+    ): Response {
+        logger.debug("Iniciando business/categories para negocio=$business, function=$function")
+
+        val authorized = requireApprovedProfile(cognito, headers, tableProfiles, business, PROFILE_BUSINESS_ADMIN)
+            ?: requireApprovedProfile(cognito, headers, tableProfiles, business, PROFILE_SALER)
+            ?: return UnauthorizedException()
+
+        val method = headers["X-Http-Method"]?.uppercase() ?: HttpMethod.Get.value.uppercase()
+        val categoryId = extractId(function)
+
+        return when (method) {
+            HttpMethod.Get.value.uppercase() -> handleGet(business, categoryId)
+            HttpMethod.Post.value.uppercase() -> handlePost(business, textBody)
+            HttpMethod.Put.value.uppercase() -> handlePut(business, categoryId, textBody)
+            HttpMethod.Delete.value.uppercase() -> handleDelete(business, categoryId)
+            else -> RequestValidationException("Metodo no soportado: $method")
+        }
+    }
+
+    private fun handleGet(business: String, categoryId: String?): Response {
+        if (categoryId != null) {
+            val category = categoryRepository.getCategory(business, categoryId)
+                ?: return ExceptionResponse("Categoria no encontrada", status = HttpStatusCode.NotFound)
+            return CategoryResponse(category = category.toPayload(), status = HttpStatusCode.OK)
+        }
+        val categories = categoryRepository.listCategories(business)
+        return CategoryListResponse(categories = categories.map { it.toPayload() })
+    }
+
+    private fun handlePost(business: String, textBody: String): Response {
+        val body = parseBody<CategoryRequest>(textBody)
+            ?: return RequestValidationException("Request body no encontrado")
+
+        if (body.name.isBlank()) return RequestValidationException("El nombre es requerido")
+
+        val record = CategoryRecord(
+            name = body.name,
+            description = body.description
+        )
+        val saved = categoryRepository.saveCategory(business, record)
+        logger.debug("Categoria creada id=${saved.id} en negocio=$business")
+        return CategoryResponse(category = saved.toPayload(), status = HttpStatusCode.Created)
+    }
+
+    private fun handlePut(business: String, categoryId: String?, textBody: String): Response {
+        if (categoryId == null) return RequestValidationException("ID de categoria requerido")
+
+        val body = parseBody<CategoryRequest>(textBody)
+            ?: return RequestValidationException("Request body no encontrado")
+
+        if (body.name.isBlank()) return RequestValidationException("El nombre es requerido")
+
+        val record = CategoryRecord(
+            name = body.name,
+            description = body.description
+        )
+        val updated = categoryRepository.updateCategory(business, categoryId, record)
+            ?: return ExceptionResponse("Categoria no encontrada", status = HttpStatusCode.NotFound)
+        logger.debug("Categoria actualizada id=$categoryId en negocio=$business")
+        return CategoryResponse(category = updated.toPayload(), status = HttpStatusCode.OK)
+    }
+
+    private fun handleDelete(business: String, categoryId: String?): Response {
+        if (categoryId == null) return RequestValidationException("ID de categoria requerido")
+
+        val deleted = categoryRepository.deleteCategory(business, categoryId)
+        if (!deleted) return ExceptionResponse("Categoria no encontrada", status = HttpStatusCode.NotFound)
+        logger.debug("Categoria eliminada id=$categoryId en negocio=$business")
+        return NoContentResponse()
+    }
+
+    private fun extractId(function: String): String? {
+        val parts = function.split("/")
+        return if (parts.size >= 3) parts[2] else null
+    }
+}

--- a/users/src/main/kotlin/ar/com/intrale/BusinessProducts.kt
+++ b/users/src/main/kotlin/ar/com/intrale/BusinessProducts.kt
@@ -1,0 +1,127 @@
+package ar.com.intrale
+
+import aws.sdk.kotlin.services.cognitoidentityprovider.CognitoIdentityProviderClient
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable
+
+class BusinessProducts(
+    override val config: UsersConfig,
+    override val logger: Logger,
+    private val cognito: CognitoIdentityProviderClient,
+    private val tableProfiles: DynamoDbTable<UserBusinessProfile>,
+    private val productRepository: ProductRepository,
+    private val categoryRepository: CategoryRepository,
+    override val jwtValidator: JwtValidator = CognitoJwtValidator(config)
+) : SecuredFunction(config = config, logger = logger, jwtValidator = jwtValidator) {
+
+    override suspend fun securedExecute(
+        business: String,
+        function: String,
+        headers: Map<String, String>,
+        textBody: String
+    ): Response {
+        logger.debug("Iniciando business/products para negocio=$business, function=$function")
+
+        val authorized = requireApprovedProfile(cognito, headers, tableProfiles, business, PROFILE_BUSINESS_ADMIN)
+            ?: requireApprovedProfile(cognito, headers, tableProfiles, business, PROFILE_SALER)
+            ?: return UnauthorizedException()
+
+        val method = headers["X-Http-Method"]?.uppercase() ?: HttpMethod.Get.value.uppercase()
+        val productId = extractId(function)
+
+        return when (method) {
+            HttpMethod.Get.value.uppercase() -> handleGet(business, productId)
+            HttpMethod.Post.value.uppercase() -> handlePost(business, textBody)
+            HttpMethod.Put.value.uppercase() -> handlePut(business, productId, textBody)
+            HttpMethod.Delete.value.uppercase() -> handleDelete(business, productId)
+            else -> RequestValidationException("Metodo no soportado: $method")
+        }
+    }
+
+    private fun handleGet(business: String, productId: String?): Response {
+        if (productId != null) {
+            val product = productRepository.getProduct(business, productId)
+                ?: return ExceptionResponse("Producto no encontrado", status = HttpStatusCode.NotFound)
+            return ProductResponse(product = product.toPayload(), status = HttpStatusCode.OK)
+        }
+        val products = productRepository.listProducts(business)
+        return ProductListResponse(products = products.map { it.toPayload() })
+    }
+
+    private fun handlePost(business: String, textBody: String): Response {
+        val body = parseBody<ProductRequest>(textBody)
+            ?: return RequestValidationException("Request body no encontrado")
+
+        val validationError = validateProductRequest(body)
+        if (validationError != null) return validationError
+
+        val record = ProductRecord(
+            name = body.name,
+            shortDescription = body.shortDescription,
+            basePrice = body.basePrice,
+            unit = body.unit,
+            categoryId = body.categoryId,
+            status = normalizeStatus(body.status),
+            isAvailable = body.isAvailable,
+            stockQuantity = body.stockQuantity
+        )
+        val saved = productRepository.saveProduct(business, record)
+        logger.debug("Producto creado id=${saved.id} en negocio=$business")
+        return ProductResponse(product = saved.toPayload(), status = HttpStatusCode.Created)
+    }
+
+    private fun handlePut(business: String, productId: String?, textBody: String): Response {
+        if (productId == null) return RequestValidationException("ID de producto requerido")
+
+        val body = parseBody<ProductRequest>(textBody)
+            ?: return RequestValidationException("Request body no encontrado")
+
+        val validationError = validateProductRequest(body)
+        if (validationError != null) return validationError
+
+        val record = ProductRecord(
+            name = body.name,
+            shortDescription = body.shortDescription,
+            basePrice = body.basePrice,
+            unit = body.unit,
+            categoryId = body.categoryId,
+            status = normalizeStatus(body.status),
+            isAvailable = body.isAvailable,
+            stockQuantity = body.stockQuantity
+        )
+        val updated = productRepository.updateProduct(business, productId, record)
+            ?: return ExceptionResponse("Producto no encontrado", status = HttpStatusCode.NotFound)
+        logger.debug("Producto actualizado id=$productId en negocio=$business")
+        return ProductResponse(product = updated.toPayload(), status = HttpStatusCode.OK)
+    }
+
+    private fun handleDelete(business: String, productId: String?): Response {
+        if (productId == null) return RequestValidationException("ID de producto requerido")
+
+        val deleted = productRepository.deleteProduct(business, productId)
+        if (!deleted) return ExceptionResponse("Producto no encontrado", status = HttpStatusCode.NotFound)
+        logger.debug("Producto eliminado id=$productId en negocio=$business")
+        return NoContentResponse()
+    }
+
+    private fun validateProductRequest(body: ProductRequest): Response? {
+        if (body.name.isBlank()) return RequestValidationException("El nombre es requerido")
+        if (body.basePrice <= 0) return RequestValidationException("El precio base debe ser mayor a cero")
+        return null
+    }
+
+    private fun normalizeStatus(status: String?): String {
+        return when (status?.uppercase()) {
+            "PUBLISHED" -> "PUBLISHED"
+            else -> "DRAFT"
+        }
+    }
+
+    private fun extractId(function: String): String? {
+        val parts = function.split("/")
+        return if (parts.size >= 3) parts[2] else null
+    }
+}

--- a/users/src/main/kotlin/ar/com/intrale/CategoryRecord.kt
+++ b/users/src/main/kotlin/ar/com/intrale/CategoryRecord.kt
@@ -1,0 +1,8 @@
+package ar.com.intrale
+
+data class CategoryRecord(
+    val id: String = "",
+    val businessId: String = "",
+    val name: String = "",
+    val description: String? = null
+)

--- a/users/src/main/kotlin/ar/com/intrale/CategoryRepository.kt
+++ b/users/src/main/kotlin/ar/com/intrale/CategoryRepository.kt
@@ -1,0 +1,40 @@
+package ar.com.intrale
+
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+
+class CategoryRepository {
+
+    private val categories = ConcurrentHashMap<String, CategoryRecord>()
+
+    private fun key(business: String, categoryId: String) = "${business.lowercase()}#$categoryId"
+
+    fun listCategories(business: String): List<CategoryRecord> =
+        categories.values.filter { it.businessId == business.lowercase() }.map { it.copy() }
+
+    fun getCategory(business: String, categoryId: String): CategoryRecord? =
+        categories[key(business, categoryId)]?.copy()
+
+    fun saveCategory(business: String, record: CategoryRecord): CategoryRecord {
+        val saved = record.copy(
+            id = record.id.ifBlank { UUID.randomUUID().toString() },
+            businessId = business.lowercase()
+        )
+        categories[key(business, saved.id)] = saved
+        return saved
+    }
+
+    fun updateCategory(business: String, categoryId: String, record: CategoryRecord): CategoryRecord? {
+        val existing = categories[key(business, categoryId)] ?: return null
+        val updated = existing.copy(
+            name = record.name,
+            description = record.description
+        )
+        categories[key(business, categoryId)] = updated
+        return updated
+    }
+
+    fun deleteCategory(business: String, categoryId: String): Boolean {
+        return categories.remove(key(business, categoryId)) != null
+    }
+}

--- a/users/src/main/kotlin/ar/com/intrale/CategoryRequest.kt
+++ b/users/src/main/kotlin/ar/com/intrale/CategoryRequest.kt
@@ -1,0 +1,6 @@
+package ar.com.intrale
+
+data class CategoryRequest(
+    val name: String = "",
+    val description: String? = null
+)

--- a/users/src/main/kotlin/ar/com/intrale/CategoryResponse.kt
+++ b/users/src/main/kotlin/ar/com/intrale/CategoryResponse.kt
@@ -1,0 +1,27 @@
+package ar.com.intrale
+
+import io.ktor.http.HttpStatusCode
+
+data class CategoryPayload(
+    val id: String,
+    val businessId: String,
+    val name: String,
+    val description: String?
+)
+
+class CategoryResponse(
+    val category: CategoryPayload?,
+    status: HttpStatusCode = HttpStatusCode.OK
+) : Response(statusCode = status)
+
+class CategoryListResponse(
+    val categories: List<CategoryPayload>,
+    status: HttpStatusCode = HttpStatusCode.OK
+) : Response(statusCode = status)
+
+fun CategoryRecord.toPayload() = CategoryPayload(
+    id = id,
+    businessId = businessId,
+    name = name,
+    description = description
+)

--- a/users/src/main/kotlin/ar/com/intrale/Modules.kt
+++ b/users/src/main/kotlin/ar/com/intrale/Modules.kt
@@ -240,6 +240,22 @@ val appModule = DI.Module("appModule") {
     bind<Function> (tag="business/fonts") {
         singleton { BusinessFontsFunction(instance(), instance(), instance(), instance(), instance()) }
     }
+
+    bind<ProductRepository> {
+        singleton { ProductRepository() }
+    }
+
+    bind<CategoryRepository> {
+        singleton { CategoryRepository() }
+    }
+
+    bind<Function> (tag="business/products") {
+        singleton { BusinessProducts(instance(), instance(), instance(), instance(), instance(), instance()) }
+    }
+
+    bind<Function> (tag="business/categories") {
+        singleton { BusinessCategories(instance(), instance(), instance(), instance(), instance()) }
+    }
 }
 
 private fun Config.stringValue(path: String): String = getValue(path).unwrapped().toString()

--- a/users/src/main/kotlin/ar/com/intrale/NoContentResponse.kt
+++ b/users/src/main/kotlin/ar/com/intrale/NoContentResponse.kt
@@ -1,0 +1,5 @@
+package ar.com.intrale
+
+import io.ktor.http.HttpStatusCode
+
+class NoContentResponse : Response(statusCode = HttpStatusCode.NoContent)

--- a/users/src/main/kotlin/ar/com/intrale/ProductRecord.kt
+++ b/users/src/main/kotlin/ar/com/intrale/ProductRecord.kt
@@ -1,0 +1,14 @@
+package ar.com.intrale
+
+data class ProductRecord(
+    val id: String = "",
+    val businessId: String = "",
+    val name: String = "",
+    val shortDescription: String? = null,
+    val basePrice: Double = 0.0,
+    val unit: String = "",
+    val categoryId: String = "",
+    val status: String = "DRAFT",
+    val isAvailable: Boolean = true,
+    val stockQuantity: Int? = null
+)

--- a/users/src/main/kotlin/ar/com/intrale/ProductRepository.kt
+++ b/users/src/main/kotlin/ar/com/intrale/ProductRepository.kt
@@ -1,0 +1,46 @@
+package ar.com.intrale
+
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+
+class ProductRepository {
+
+    private val products = ConcurrentHashMap<String, ProductRecord>()
+
+    private fun key(business: String, productId: String) = "${business.lowercase()}#$productId"
+
+    fun listProducts(business: String): List<ProductRecord> =
+        products.values.filter { it.businessId == business.lowercase() }.map { it.copy() }
+
+    fun getProduct(business: String, productId: String): ProductRecord? =
+        products[key(business, productId)]?.copy()
+
+    fun saveProduct(business: String, record: ProductRecord): ProductRecord {
+        val saved = record.copy(
+            id = record.id.ifBlank { UUID.randomUUID().toString() },
+            businessId = business.lowercase()
+        )
+        products[key(business, saved.id)] = saved
+        return saved
+    }
+
+    fun updateProduct(business: String, productId: String, record: ProductRecord): ProductRecord? {
+        val existing = products[key(business, productId)] ?: return null
+        val updated = existing.copy(
+            name = record.name,
+            shortDescription = record.shortDescription,
+            basePrice = record.basePrice,
+            unit = record.unit,
+            categoryId = record.categoryId,
+            status = record.status,
+            isAvailable = record.isAvailable,
+            stockQuantity = record.stockQuantity
+        )
+        products[key(business, productId)] = updated
+        return updated
+    }
+
+    fun deleteProduct(business: String, productId: String): Boolean {
+        return products.remove(key(business, productId)) != null
+    }
+}

--- a/users/src/main/kotlin/ar/com/intrale/ProductRequest.kt
+++ b/users/src/main/kotlin/ar/com/intrale/ProductRequest.kt
@@ -1,0 +1,12 @@
+package ar.com.intrale
+
+data class ProductRequest(
+    val name: String = "",
+    val shortDescription: String? = null,
+    val basePrice: Double = 0.0,
+    val unit: String = "",
+    val categoryId: String = "",
+    val status: String? = null,
+    val isAvailable: Boolean = true,
+    val stockQuantity: Int? = null
+)

--- a/users/src/main/kotlin/ar/com/intrale/ProductResponse.kt
+++ b/users/src/main/kotlin/ar/com/intrale/ProductResponse.kt
@@ -1,0 +1,39 @@
+package ar.com.intrale
+
+import io.ktor.http.HttpStatusCode
+
+data class ProductPayload(
+    val id: String,
+    val businessId: String,
+    val name: String,
+    val shortDescription: String?,
+    val basePrice: Double,
+    val unit: String,
+    val categoryId: String,
+    val status: String,
+    val isAvailable: Boolean,
+    val stockQuantity: Int?
+)
+
+class ProductResponse(
+    val product: ProductPayload?,
+    status: HttpStatusCode = HttpStatusCode.OK
+) : Response(statusCode = status)
+
+class ProductListResponse(
+    val products: List<ProductPayload>,
+    status: HttpStatusCode = HttpStatusCode.OK
+) : Response(statusCode = status)
+
+fun ProductRecord.toPayload() = ProductPayload(
+    id = id,
+    businessId = businessId,
+    name = name,
+    shortDescription = shortDescription,
+    basePrice = basePrice,
+    unit = unit,
+    categoryId = categoryId,
+    status = status,
+    isAvailable = isAvailable,
+    stockQuantity = stockQuantity
+)

--- a/users/src/test/kotlin/ar/com/intrale/BusinessCategoriesTest.kt
+++ b/users/src/test/kotlin/ar/com/intrale/BusinessCategoriesTest.kt
@@ -1,0 +1,237 @@
+package ar.com.intrale
+
+import aws.sdk.kotlin.services.cognitoidentityprovider.CognitoIdentityProviderClient
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.AttributeType
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.GetUserResponse
+import com.google.gson.Gson
+import io.ktor.http.HttpStatusCode
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.slf4j.helpers.NOPLogger
+import software.amazon.awssdk.core.pagination.sync.SdkIterable
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClientExtension
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbIndex
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable
+import software.amazon.awssdk.enhanced.dynamodb.Key
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema
+import software.amazon.awssdk.enhanced.dynamodb.model.Page
+import software.amazon.awssdk.enhanced.dynamodb.model.PageIterable
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+private class StubProfileTableCategories : DynamoDbTable<UserBusinessProfile> {
+    val items = mutableListOf<UserBusinessProfile>()
+    override fun mapperExtension(): DynamoDbEnhancedClientExtension? = null
+    override fun tableSchema(): TableSchema<UserBusinessProfile> =
+        TableSchema.fromBean(UserBusinessProfile::class.java)
+    override fun tableName() = "profiles"
+    override fun keyFrom(item: UserBusinessProfile): Key =
+        Key.builder().partitionValue(item.compositeKey).build()
+    override fun index(indexName: String): DynamoDbIndex<UserBusinessProfile> =
+        throw UnsupportedOperationException()
+    override fun putItem(item: UserBusinessProfile) { items.add(item) }
+    override fun getItem(item: UserBusinessProfile): UserBusinessProfile? =
+        items.firstOrNull { it.compositeKey == item.compositeKey }
+    override fun scan(): PageIterable<UserBusinessProfile> =
+        PageIterable.create(SdkIterable { mutableListOf(Page.create(items)).iterator() })
+}
+
+class BusinessCategoriesTest {
+
+    private val logger = NOPLogger.NOP_LOGGER
+    private val config = testConfig("la-carne")
+    private val cognito = mockk<CognitoIdentityProviderClient>()
+    private val tableProfiles = StubProfileTableCategories()
+    private val categoryRepository = CategoryRepository()
+
+    private val function = BusinessCategories(
+        config = config,
+        logger = logger,
+        cognito = cognito,
+        tableProfiles = tableProfiles,
+        categoryRepository = categoryRepository
+    )
+
+    private fun seedBusinessAdmin(email: String = "admin@lacarne.com") {
+        tableProfiles.items.add(UserBusinessProfile().apply {
+            this.email = email
+            this.business = "la-carne"
+            this.profile = PROFILE_BUSINESS_ADMIN
+            this.state = BusinessState.APPROVED
+        })
+        coEvery { cognito.getUser(any()) } returns GetUserResponse {
+            username = "admin"
+            userAttributes = listOf(AttributeType { name = EMAIL_ATT_NAME; value = email })
+        }
+    }
+
+    private fun categoryRequestJson(
+        name: String = "Carnes",
+        description: String? = null
+    ): String = Gson().toJson(mapOf(
+        "name" to name,
+        "description" to description
+    ))
+
+    @Test
+    fun `GET lista categorias vacia cuando no hay categorias`() = runBlocking {
+        seedBusinessAdmin()
+
+        val response = function.securedExecute(
+            business = "la-carne",
+            function = "business/categories",
+            headers = mapOf("Authorization" to "token", "X-Http-Method" to "GET"),
+            textBody = ""
+        )
+
+        assertTrue(response is CategoryListResponse)
+        assertEquals(HttpStatusCode.OK, response.statusCode)
+        assertTrue(response.categories.isEmpty())
+    }
+
+    @Test
+    fun `POST crea categoria con datos validos`() = runBlocking {
+        seedBusinessAdmin()
+
+        val response = function.securedExecute(
+            business = "la-carne",
+            function = "business/categories",
+            headers = mapOf("Authorization" to "token", "X-Http-Method" to "POST"),
+            textBody = categoryRequestJson()
+        )
+
+        assertTrue(response is CategoryResponse)
+        assertEquals(HttpStatusCode.Created, response.statusCode)
+        assertNotNull(response.category)
+        assertEquals("Carnes", response.category!!.name)
+        assertEquals("la-carne", response.category!!.businessId)
+        assertTrue(response.category!!.id.isNotEmpty())
+    }
+
+    @Test
+    fun `POST categoria aparece en el listado posterior`() = runBlocking {
+        seedBusinessAdmin()
+
+        function.securedExecute(
+            business = "la-carne",
+            function = "business/categories",
+            headers = mapOf("Authorization" to "token", "X-Http-Method" to "POST"),
+            textBody = categoryRequestJson(name = "Bebidas")
+        )
+
+        val listResponse = function.securedExecute(
+            business = "la-carne",
+            function = "business/categories",
+            headers = mapOf("Authorization" to "token", "X-Http-Method" to "GET"),
+            textBody = ""
+        )
+
+        assertTrue(listResponse is CategoryListResponse)
+        assertEquals(1, listResponse.categories.size)
+        assertEquals("Bebidas", listResponse.categories.first().name)
+    }
+
+    @Test
+    fun `PUT actualiza categoria existente`() = runBlocking {
+        seedBusinessAdmin()
+
+        val createResponse = function.securedExecute(
+            business = "la-carne",
+            function = "business/categories",
+            headers = mapOf("Authorization" to "token", "X-Http-Method" to "POST"),
+            textBody = categoryRequestJson(name = "Postres")
+        ) as CategoryResponse
+        val categoryId = createResponse.category!!.id
+
+        val updateResponse = function.securedExecute(
+            business = "la-carne",
+            function = "business/categories/$categoryId",
+            headers = mapOf("Authorization" to "token", "X-Http-Method" to "PUT",
+                "X-Function-Path" to "business/categories/$categoryId"),
+            textBody = categoryRequestJson(name = "Postres y Dulces", description = "Tortas y facturas")
+        )
+
+        assertTrue(updateResponse is CategoryResponse)
+        assertEquals(HttpStatusCode.OK, updateResponse.statusCode)
+        assertEquals("Postres y Dulces", updateResponse.category!!.name)
+        assertEquals("Tortas y facturas", updateResponse.category!!.description)
+    }
+
+    @Test
+    fun `DELETE elimina categoria existente`() = runBlocking {
+        seedBusinessAdmin()
+
+        val createResponse = function.securedExecute(
+            business = "la-carne",
+            function = "business/categories",
+            headers = mapOf("Authorization" to "token", "X-Http-Method" to "POST"),
+            textBody = categoryRequestJson(name = "Categoria a eliminar")
+        ) as CategoryResponse
+        val categoryId = createResponse.category!!.id
+
+        val deleteResponse = function.securedExecute(
+            business = "la-carne",
+            function = "business/categories/$categoryId",
+            headers = mapOf("Authorization" to "token", "X-Http-Method" to "DELETE",
+                "X-Function-Path" to "business/categories/$categoryId"),
+            textBody = ""
+        )
+
+        assertEquals(HttpStatusCode.NoContent, deleteResponse.statusCode)
+
+        val listResponse = function.securedExecute(
+            business = "la-carne",
+            function = "business/categories",
+            headers = mapOf("Authorization" to "token", "X-Http-Method" to "GET"),
+            textBody = ""
+        ) as CategoryListResponse
+        assertTrue(listResponse.categories.isEmpty())
+    }
+
+    @Test
+    fun `POST sin nombre retorna error de validacion`() = runBlocking {
+        seedBusinessAdmin()
+
+        val response = function.securedExecute(
+            business = "la-carne",
+            function = "business/categories",
+            headers = mapOf("Authorization" to "token", "X-Http-Method" to "POST"),
+            textBody = categoryRequestJson(name = "")
+        )
+
+        assertTrue(response is RequestValidationException)
+    }
+
+    @Test
+    fun `usuario sin perfil retorna UnauthorizedException`() = runBlocking {
+        coEvery { cognito.getUser(any()) } throws RuntimeException("Unauthorized")
+
+        val response = function.securedExecute(
+            business = "la-carne",
+            function = "business/categories",
+            headers = mapOf("Authorization" to "token", "X-Http-Method" to "GET"),
+            textBody = ""
+        )
+
+        assertTrue(response is UnauthorizedException)
+    }
+
+    @Test
+    fun `DELETE de categoria inexistente retorna 404`() = runBlocking {
+        seedBusinessAdmin()
+
+        val response = function.securedExecute(
+            business = "la-carne",
+            function = "business/categories/no-existe",
+            headers = mapOf("Authorization" to "token", "X-Http-Method" to "DELETE",
+                "X-Function-Path" to "business/categories/no-existe"),
+            textBody = ""
+        )
+
+        assertTrue(response is ExceptionResponse)
+        assertEquals(HttpStatusCode.NotFound, response.statusCode)
+    }
+}

--- a/users/src/test/kotlin/ar/com/intrale/BusinessProductsTest.kt
+++ b/users/src/test/kotlin/ar/com/intrale/BusinessProductsTest.kt
@@ -1,0 +1,292 @@
+package ar.com.intrale
+
+import aws.sdk.kotlin.services.cognitoidentityprovider.CognitoIdentityProviderClient
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.AttributeType
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.GetUserResponse
+import com.google.gson.Gson
+import io.ktor.http.HttpStatusCode
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.slf4j.helpers.NOPLogger
+import software.amazon.awssdk.core.pagination.sync.SdkIterable
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClientExtension
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbIndex
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable
+import software.amazon.awssdk.enhanced.dynamodb.Key
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema
+import software.amazon.awssdk.enhanced.dynamodb.model.Page
+import software.amazon.awssdk.enhanced.dynamodb.model.PageIterable
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+private class StubProfileTableProducts : DynamoDbTable<UserBusinessProfile> {
+    val items = mutableListOf<UserBusinessProfile>()
+    override fun mapperExtension(): DynamoDbEnhancedClientExtension? = null
+    override fun tableSchema(): TableSchema<UserBusinessProfile> =
+        TableSchema.fromBean(UserBusinessProfile::class.java)
+    override fun tableName() = "profiles"
+    override fun keyFrom(item: UserBusinessProfile): Key =
+        Key.builder().partitionValue(item.compositeKey).build()
+    override fun index(indexName: String): DynamoDbIndex<UserBusinessProfile> =
+        throw UnsupportedOperationException()
+    override fun putItem(item: UserBusinessProfile) { items.add(item) }
+    override fun getItem(item: UserBusinessProfile): UserBusinessProfile? =
+        items.firstOrNull { it.compositeKey == item.compositeKey }
+    override fun scan(): PageIterable<UserBusinessProfile> =
+        PageIterable.create(SdkIterable { mutableListOf(Page.create(items)).iterator() })
+}
+
+class BusinessProductsTest {
+
+    private val logger = NOPLogger.NOP_LOGGER
+    private val config = testConfig("la-carne")
+    private val cognito = mockk<CognitoIdentityProviderClient>()
+    private val tableProfiles = StubProfileTableProducts()
+    private val productRepository = ProductRepository()
+    private val categoryRepository = CategoryRepository()
+
+    private val function = BusinessProducts(
+        config = config,
+        logger = logger,
+        cognito = cognito,
+        tableProfiles = tableProfiles,
+        productRepository = productRepository,
+        categoryRepository = categoryRepository
+    )
+
+    private fun seedBusinessAdmin(email: String = "admin@lacarne.com") {
+        tableProfiles.items.add(UserBusinessProfile().apply {
+            this.email = email
+            this.business = "la-carne"
+            this.profile = PROFILE_BUSINESS_ADMIN
+            this.state = BusinessState.APPROVED
+        })
+        coEvery { cognito.getUser(any()) } returns GetUserResponse {
+            username = "admin"
+            userAttributes = listOf(AttributeType { name = EMAIL_ATT_NAME; value = email })
+        }
+    }
+
+    private fun seedSaler(email: String = "saler@lacarne.com") {
+        tableProfiles.items.add(UserBusinessProfile().apply {
+            this.email = email
+            this.business = "la-carne"
+            this.profile = PROFILE_SALER
+            this.state = BusinessState.APPROVED
+        })
+        coEvery { cognito.getUser(any()) } returns GetUserResponse {
+            username = "saler"
+            userAttributes = listOf(AttributeType { name = EMAIL_ATT_NAME; value = email })
+        }
+    }
+
+    private fun productRequestJson(
+        name: String = "Asado de tira",
+        basePrice: Double = 2500.0,
+        unit: String = "kg",
+        categoryId: String = "cat-1",
+        status: String = "DRAFT",
+        shortDescription: String? = null,
+        isAvailable: Boolean = true
+    ): String = Gson().toJson(mapOf(
+        "name" to name,
+        "basePrice" to basePrice,
+        "unit" to unit,
+        "categoryId" to categoryId,
+        "status" to status,
+        "shortDescription" to shortDescription,
+        "isAvailable" to isAvailable
+    ))
+
+    @Test
+    fun `GET lista productos vacia cuando no hay productos`() = runBlocking {
+        seedBusinessAdmin()
+
+        val response = function.securedExecute(
+            business = "la-carne",
+            function = "business/products",
+            headers = mapOf("Authorization" to "token", "X-Http-Method" to "GET"),
+            textBody = ""
+        )
+
+        assertTrue(response is ProductListResponse)
+        assertEquals(HttpStatusCode.OK, response.statusCode)
+        assertTrue(response.products.isEmpty())
+    }
+
+    @Test
+    fun `POST crea producto con datos validos`() = runBlocking {
+        seedBusinessAdmin()
+
+        val response = function.securedExecute(
+            business = "la-carne",
+            function = "business/products",
+            headers = mapOf("Authorization" to "token", "X-Http-Method" to "POST"),
+            textBody = productRequestJson()
+        )
+
+        assertTrue(response is ProductResponse)
+        assertEquals(HttpStatusCode.Created, response.statusCode)
+        assertNotNull(response.product)
+        assertEquals("Asado de tira", response.product!!.name)
+        assertEquals("la-carne", response.product!!.businessId)
+        assertTrue(response.product!!.id.isNotEmpty())
+    }
+
+    @Test
+    fun `POST producto aparece en el listado posterior`() = runBlocking {
+        seedBusinessAdmin()
+
+        function.securedExecute(
+            business = "la-carne",
+            function = "business/products",
+            headers = mapOf("Authorization" to "token", "X-Http-Method" to "POST"),
+            textBody = productRequestJson(name = "Empanadas x12")
+        )
+
+        val listResponse = function.securedExecute(
+            business = "la-carne",
+            function = "business/products",
+            headers = mapOf("Authorization" to "token", "X-Http-Method" to "GET"),
+            textBody = ""
+        )
+
+        assertTrue(listResponse is ProductListResponse)
+        assertEquals(1, listResponse.products.size)
+        assertEquals("Empanadas x12", listResponse.products.first().name)
+    }
+
+    @Test
+    fun `PUT actualiza producto existente`() = runBlocking {
+        seedBusinessAdmin()
+
+        val createResponse = function.securedExecute(
+            business = "la-carne",
+            function = "business/products",
+            headers = mapOf("Authorization" to "token", "X-Http-Method" to "POST"),
+            textBody = productRequestJson(name = "Chorizo", basePrice = 800.0)
+        ) as ProductResponse
+        val productId = createResponse.product!!.id
+
+        val updateResponse = function.securedExecute(
+            business = "la-carne",
+            function = "business/products/$productId",
+            headers = mapOf("Authorization" to "token", "X-Http-Method" to "PUT",
+                "X-Function-Path" to "business/products/$productId"),
+            textBody = productRequestJson(name = "Chorizo colorado", basePrice = 900.0, status = "PUBLISHED")
+        )
+
+        assertTrue(updateResponse is ProductResponse)
+        assertEquals(HttpStatusCode.OK, updateResponse.statusCode)
+        assertEquals("Chorizo colorado", updateResponse.product!!.name)
+        assertEquals("PUBLISHED", updateResponse.product!!.status)
+        assertEquals(900.0, updateResponse.product!!.basePrice)
+    }
+
+    @Test
+    fun `DELETE elimina producto existente`() = runBlocking {
+        seedBusinessAdmin()
+
+        val createResponse = function.securedExecute(
+            business = "la-carne",
+            function = "business/products",
+            headers = mapOf("Authorization" to "token", "X-Http-Method" to "POST"),
+            textBody = productRequestJson(name = "Producto a eliminar")
+        ) as ProductResponse
+        val productId = createResponse.product!!.id
+
+        val deleteResponse = function.securedExecute(
+            business = "la-carne",
+            function = "business/products/$productId",
+            headers = mapOf("Authorization" to "token", "X-Http-Method" to "DELETE",
+                "X-Function-Path" to "business/products/$productId"),
+            textBody = ""
+        )
+
+        assertEquals(HttpStatusCode.NoContent, deleteResponse.statusCode)
+
+        val listResponse = function.securedExecute(
+            business = "la-carne",
+            function = "business/products",
+            headers = mapOf("Authorization" to "token", "X-Http-Method" to "GET"),
+            textBody = ""
+        ) as ProductListResponse
+        assertTrue(listResponse.products.isEmpty())
+    }
+
+    @Test
+    fun `POST sin nombre retorna error de validacion`() = runBlocking {
+        seedBusinessAdmin()
+
+        val response = function.securedExecute(
+            business = "la-carne",
+            function = "business/products",
+            headers = mapOf("Authorization" to "token", "X-Http-Method" to "POST"),
+            textBody = productRequestJson(name = "")
+        )
+
+        assertTrue(response is RequestValidationException)
+    }
+
+    @Test
+    fun `POST con precio cero retorna error de validacion`() = runBlocking {
+        seedBusinessAdmin()
+
+        val response = function.securedExecute(
+            business = "la-carne",
+            function = "business/products",
+            headers = mapOf("Authorization" to "token", "X-Http-Method" to "POST"),
+            textBody = productRequestJson(basePrice = 0.0)
+        )
+
+        assertTrue(response is RequestValidationException)
+    }
+
+    @Test
+    fun `usuario sin perfil retorna UnauthorizedException`() = runBlocking {
+        coEvery { cognito.getUser(any()) } throws RuntimeException("Unauthorized")
+
+        val response = function.securedExecute(
+            business = "la-carne",
+            function = "business/products",
+            headers = mapOf("Authorization" to "token", "X-Http-Method" to "GET"),
+            textBody = ""
+        )
+
+        assertTrue(response is UnauthorizedException)
+    }
+
+    @Test
+    fun `Saler puede listar y crear productos`() = runBlocking {
+        seedSaler()
+
+        val createResponse = function.securedExecute(
+            business = "la-carne",
+            function = "business/products",
+            headers = mapOf("Authorization" to "token", "X-Http-Method" to "POST"),
+            textBody = productRequestJson(name = "Producto del saler")
+        )
+
+        assertTrue(createResponse is ProductResponse)
+        assertEquals(HttpStatusCode.Created, createResponse.statusCode)
+    }
+
+    @Test
+    fun `DELETE de producto inexistente retorna 404`() = runBlocking {
+        seedBusinessAdmin()
+
+        val response = function.securedExecute(
+            business = "la-carne",
+            function = "business/products/no-existe",
+            headers = mapOf("Authorization" to "token", "X-Http-Method" to "DELETE",
+                "X-Function-Path" to "business/products/no-existe"),
+            textBody = ""
+        )
+
+        assertTrue(response is ExceptionResponse)
+        assertEquals(HttpStatusCode.NotFound, response.statusCode)
+    }
+}


### PR DESCRIPTION
## Resumen

Implementación completa del CRUD de productos y categorías para negociaos (BPROD-002):

- **Backend**: Endpoints `/business/products` y `/business/categories` con autenticación SecuredFunction
- **Repositorios**: In-memory con ConcurrentHashMap siguiendo patrón del proyecto
- **App**: URL fixes + UX improvements en ProductFormScreen (botón delete destructivo, dropdown unidades, prefijo $, helper text)
- **Tests**: 18 tests nuevos (BusinessProductsTest + BusinessCategoriesTest) todos PASSING

## Cambios

### Backend (users/)
- `BusinessProducts.kt` — CRUD completo (GET/POST/PUT/DELETE), tag="business/products"
- `BusinessCategories.kt` — CRUD completo, tag="business/categories"
- `ProductRepository.kt`, `CategoryRepository.kt` — ConcurrentHashMap storage
- Data classes, request DTOs, response payloads
- `NoContentResponse.kt` — respuesta 204 para DELETE exitosos
- Validación: nombre no vacío, precio > 0 (products), solo nombre (categories)
- Autorización: PROFILE_BUSINESS_ADMIN + PROFILE_SALER

### App (URL fixes + UX)
- `ClientProductService.kt`, `ClientCategoryService.kt` — URL fix a patrón dinámico
- `ProductFormScreen.kt` — 4 mejoras UX:
  1. Delete button con estilo destructivo (error color)
  2. Unit field como ExposedDropdownMenuBox (kg, g, unidad, docena, litro, ml, porción)
  3. Price field con leading icon "$"
  4. Stock quantity con helper text "Dejar vacío para stock ilimitado"
- String resources: MessageKey + catálogos ES/EN

### Tests
- `BusinessProductsTest.kt` — 10 tests (CRUD, validación, auth, 404)
- `BusinessCategoriesTest.kt` — 8 tests (CRUD, validación, auth, 404)
- Todas las suites PASSED ✅

## Verificaciones
- ✅ Tests: 18/18 PASSED (BusinessProducts + BusinessCategories)
- ✅ Strings legacy: OK
- ✅ Build: OK (:users:build SUCCESS)
- ⚠️ QA Validate: omitido por decisión del usuario

## Plan de tests
- [x] Tests unitarios pasan (18/18 ✅)
- [x] Módulo users compila sin errores
- [x] Strings legacy verificados
- [x] Build del proyecto OK

Closes #612

QA Validate: omitido por decisión del usuario ⚠️

🤖 Generado con [Claude Code](https://claude.ai/claude-code)