### PR TITLE
fix(hooks): agent-watcher grace period 15min (#1553)

### DIFF
--- a/.claude/hooks/agent-watcher.js
+++ b/.claude/hooks/agent-watcher.js
@@ -53,6 +53,7 @@ const SESSIONS_DIR = path.join(REPO_ROOT, ".claude", "sessions");
 const WORKTREES_PARENT = path.dirname(REPO_ROOT);
 
 const POLL_INTERVAL_MS = parseInt(process.env.WATCHER_POLL_INTERVAL || "120000", 10); // #1522: 2 min para reconciliación
+const GRACE_PERIOD_MIN = parseInt(process.env.WATCHER_GRACE_PERIOD_MIN || "15", 10); // #1553: grace period antes de evaluar PR
 const LOCK_TIMEOUT_MS = 8000;
 const LOCK_RETRY_MS = 300;
 const DEFAULT_CONCURRENCY_LIMIT = 3;
@@ -562,6 +563,20 @@ async function runCycle() {
             }
 
             if (alive) continue;
+
+            // #1553: Grace period — no evaluar agentes lanzados hace menos de GRACE_PERIOD_MIN minutos.
+            // Evita falsos "failed" cuando el agente aún no tuvo tiempo de crear la PR.
+            if (ag._launched_at) {
+                const launchedAtMs = new Date(ag._launched_at).getTime();
+                if (!isNaN(launchedAtMs)) {
+                    const elapsedMin = (Date.now() - launchedAtMs) / 60000;
+                    if (elapsedMin < GRACE_PERIOD_MIN) {
+                        log("Agente #" + ag.issue + ": PID muerto pero dentro de grace period (" +
+                            Math.round(elapsedMin * 10) / 10 + "/" + GRACE_PERIOD_MIN + " min) — skip");
+                        continue;
+                    }
+                }
+            }
 
             // Agente muerto: verificar PR
             const branch = "agent/" + ag.issue + "-" + ag.slug;

--- a/scripts/Start-Agente.ps1
+++ b/scripts/Start-Agente.ps1
@@ -498,9 +498,31 @@ if ($Numero -eq "all") {
     Write-Host ">> Monitoreo delegado a telegram-commander.js (agent-monitor integrado)." -ForegroundColor Cyan
     Write-Host ">> Reporte post-sprint se generará automáticamente cuando terminen." -ForegroundColor Cyan
 
-    # Agent Watcher DESHABILITADO — destruye agentes al evaluar PRs demasiado rápido (#1551)
-    # TODO: reimplementar con grace period mínimo de 10 min antes de evaluar
-    Write-Host ">> Agent Watcher deshabilitado (bug #1551 — evalúa PRs antes de que los agentes trabajen)" -ForegroundColor DarkGray
+    # Lanzar Agent Watcher en background — reactivado con grace period de 15 min (#1553)
+    $watcherScript = Join-Path $MainRepo ".claude\hooks\agent-watcher.js"
+    if (Test-Path $watcherScript) {
+        $watcherPidFile = Join-Path $MainRepo ".claude\hooks\agent-watcher.pid"
+        $watcherRunning = $false
+        if (Test-Path $watcherPidFile) {
+            try {
+                $existingWatcherPid = [int](Get-Content $watcherPidFile -Raw -ErrorAction SilentlyContinue)
+                $watcherProc = Get-Process -Id $existingWatcherPid -ErrorAction SilentlyContinue
+                if ($watcherProc) { $watcherRunning = $true }
+            } catch {}
+        }
+        if (-not $watcherRunning) {
+            $watcherLog = Join-Path $MainRepo ".claude\hooks\agent-watcher.log"
+            Start-Process node -ArgumentList $watcherScript `
+                -WorkingDirectory $MainRepo `
+                -RedirectStandardOutput $watcherLog `
+                -WindowStyle Hidden
+            Write-Host ">> Agent Watcher iniciado (grace period: 15 min — fix #1553)" -ForegroundColor Green
+        } else {
+            Write-Host ">> Agent Watcher ya activo (PID $existingWatcherPid)" -ForegroundColor Green
+        }
+    } else {
+        Write-Host ">> Agent Watcher no encontrado: $watcherScript" -ForegroundColor Yellow
+    }
 }
 else {
     $num = [int]$Numero


### PR DESCRIPTION
## Resumen

Implementa grace period de 15 minutos para evitar que el agent-watcher marque agentes como \"failed\" cuando sus PIDs mueren durante el desarrollo inicial de la PR.

- ✅ Constante `GRACE_PERIOD_MIN` configurable via env `WATCHER_GRACE_PERIOD_MIN` (default: 15 min)
- ✅ Verifica `_launched_at` antes de evaluar PR — salta si elapsed < grace period
- ✅ Reactivar watcher en `Start-Agente.ps1` (fue deshabilitado por bug #1551)
- ✅ Singleton check via PID file para evitar duplicados
- ✅ Logging descriptivo: `elapsed/total` con precisión a décimas

## Criterios de Aceptación

- [x] Watcher respeta grace period de 15 min
- [x] No marca como failed agentes con PID vivo
- [x] Verificación de PID antes de declarar failed (ya existía, mejorada con grace period)
- [x] Reactivado en Start-Agente.ps1

## Testing

- Tipo: infra/hooks — sin impacto en UI ni tests E2E requeridos
- QA Validate: omitido por tipo:infra (label `qa:skipped`)
- Review: APROBADO ✅
- Security: APROBADO ✅

Closes #1553

🤖 Generado con [Claude Code](https://claude.com/claude-code)