### PR TITLE
fix: reactivar agent-watcher con grace period de 15 min — #1553

### DIFF
--- a/.claude/hooks/agent-watcher.js
+++ b/.claude/hooks/agent-watcher.js
@@ -53,6 +53,7 @@ const SESSIONS_DIR = path.join(REPO_ROOT, ".claude", "sessions");
 const WORKTREES_PARENT = path.dirname(REPO_ROOT);
 
 const POLL_INTERVAL_MS = parseInt(process.env.WATCHER_POLL_INTERVAL || "120000", 10); // #1522: 2 min para reconciliación
+const GRACE_PERIOD_MIN = parseInt(process.env.WATCHER_GRACE_PERIOD_MIN || "15", 10); // #1553: grace period antes de evaluar PR
 const LOCK_TIMEOUT_MS = 8000;
 const LOCK_RETRY_MS = 300;
 const DEFAULT_CONCURRENCY_LIMIT = 3;
@@ -562,6 +563,20 @@ async function runCycle() {
             }
 
             if (alive) continue;
+
+            // #1553: Grace period — no evaluar agentes lanzados hace menos de GRACE_PERIOD_MIN minutos.
+            // Evita falsos "failed" cuando el agente aún no tuvo tiempo de crear la PR.
+            if (ag._launched_at) {
+                const launchedAtMs = new Date(ag._launched_at).getTime();
+                if (!isNaN(launchedAtMs)) {
+                    const elapsedMin = (Date.now() - launchedAtMs) / 60000;
+                    if (elapsedMin < GRACE_PERIOD_MIN) {
+                        log("Agente #" + ag.issue + ": PID muerto pero dentro de grace period (" +
+                            Math.round(elapsedMin * 10) / 10 + "/" + GRACE_PERIOD_MIN + " min) — skip");
+                        continue;
+                    }
+                }
+            }
 
             // Agente muerto: verificar PR
             const branch = "agent/" + ag.issue + "-" + ag.slug;

--- a/scripts/Start-Agente.ps1
+++ b/scripts/Start-Agente.ps1
@@ -498,9 +498,31 @@ if ($Numero -eq "all") {
     Write-Host ">> Monitoreo delegado a telegram-commander.js (agent-monitor integrado)." -ForegroundColor Cyan
     Write-Host ">> Reporte post-sprint se generará automáticamente cuando terminen." -ForegroundColor Cyan
 
-    # Agent Watcher DESHABILITADO — destruye agentes al evaluar PRs demasiado rápido (#1551)
-    # TODO: reimplementar con grace period mínimo de 10 min antes de evaluar
-    Write-Host ">> Agent Watcher deshabilitado (bug #1551 — evalúa PRs antes de que los agentes trabajen)" -ForegroundColor DarkGray
+    # Lanzar Agent Watcher en background — reactivado con grace period de 15 min (#1553)
+    $watcherScript = Join-Path $MainRepo ".claude\hooks\agent-watcher.js"
+    if (Test-Path $watcherScript) {
+        $watcherPidFile = Join-Path $MainRepo ".claude\hooks\agent-watcher.pid"
+        $watcherRunning = $false
+        if (Test-Path $watcherPidFile) {
+            try {
+                $existingWatcherPid = [int](Get-Content $watcherPidFile -Raw -ErrorAction SilentlyContinue)
+                $watcherProc = Get-Process -Id $existingWatcherPid -ErrorAction SilentlyContinue
+                if ($watcherProc) { $watcherRunning = $true }
+            } catch {}
+        }
+        if (-not $watcherRunning) {
+            $watcherLog = Join-Path $MainRepo ".claude\hooks\agent-watcher.log"
+            Start-Process node -ArgumentList $watcherScript `
+                -WorkingDirectory $MainRepo `
+                -RedirectStandardOutput $watcherLog `
+                -WindowStyle Hidden
+            Write-Host ">> Agent Watcher iniciado (grace period: 15 min — fix #1553)" -ForegroundColor Green
+        } else {
+            Write-Host ">> Agent Watcher ya activo (PID $existingWatcherPid)" -ForegroundColor Green
+        }
+    } else {
+        Write-Host ">> Agent Watcher no encontrado: $watcherScript" -ForegroundColor Yellow
+    }
 }
 else {
     $num = [int]$Numero


### PR DESCRIPTION
## Resumen

Reactivar el `agent-watcher.js` en `Start-Agente.ps1` ahora que tiene grace period implementado.

El watcher estaba deshabilitado por bug #1551 (marcaba agentes como "failed" a los 3-8 segundos).
El commit e4c4395 ya implementó el grace period de 15 minutos en `agent-watcher.js`,
pero `Start-Agente.ps1` seguía deshabilitando el lanzamiento del watcher.

## Cambios

- Reactivar lanzamiento de `agent-watcher.js` en `Start-Agente.ps1 all`
- Verificación de instancia única via PID file
- Fallback a crear nueva instancia si PID no existe o proceso está muerto

## Criterios de aceptación cumplidos

- [x] Watcher respeta grace period de 15 min desde `_launched_at`
- [x] No marca como failed agentes con PID vivo (via `isAgentAlive()`)
- [x] Promoción de `_queue[]` funciona cuando agente termina legítimamente
- [x] Reactivado en `Start-Agente.ps1`

Closes #1553

🤖 Generado con [Claude Code](https://claude.ai/claude-code)