### PR TITLE
fix(hooks): reactivar agent-watcher con grace period de 15 min (#1553)

### DIFF
--- a/scripts/Start-Agente.ps1
+++ b/scripts/Start-Agente.ps1
@@ -611,9 +611,28 @@ if ($Numero -eq "all") {
     Write-Host ">> Monitoreo delegado a telegram-commander.js (agent-monitor integrado)." -ForegroundColor Cyan
     Write-Host ">> Reporte post-sprint se generara automaticamente cuando terminen." -ForegroundColor Cyan
 
-    # Agent Watcher DESHABILITADO — destruye agentes al evaluar PRs demasiado rápido (#1551)
-    # TODO: reimplementar con grace period mínimo de 10 min antes de evaluar
-    Write-Host ">> Agent Watcher deshabilitado (bug #1551 — evalua PRs antes de que los agentes trabajen)" -ForegroundColor DarkGray
+    # Agent Watcher — reactivado con grace period de 15 min (#1553)
+    $watcherScript  = Join-Path $MainRepo ".claude\hooks\agent-watcher.js"
+    $watcherPidFile = Join-Path $MainRepo ".claude\hooks\agent-watcher.pid"
+
+    $watcherRunning = $false
+    if (Test-Path $watcherPidFile) {
+        $existingWatcherPid = Get-Content $watcherPidFile -ErrorAction SilentlyContinue
+        if ($existingWatcherPid) {
+            $watcherProc = Get-Process -Id ([int]$existingWatcherPid) -ErrorAction SilentlyContinue
+            if ($watcherProc) { $watcherRunning = $true }
+        }
+    }
+
+    if ($watcherRunning) {
+        Write-Host ">> Agent Watcher ya activo (PID $existingWatcherPid)" -ForegroundColor Cyan
+    } else {
+        $watcher = Start-Process -FilePath "node" `
+            -ArgumentList $watcherScript `
+            -WindowStyle Hidden -PassThru `
+            -WorkingDirectory $MainRepo
+        Write-Host ">> Agent Watcher iniciado (PID $($watcher.Id), grace period 15 min) — fix #1553" -ForegroundColor Green
+    }
 }
 else {
     $num = [int]$Numero


### PR DESCRIPTION
## Resumen

Reactiva el hook `agent-watcher.js` que estaba deshabilitado por el bug #1551. 

Los hooks `sprint-sync.js` y `agent-concurrency-check.js` ya fueron corregidos en main con:
- Grace period de 15 minutos antes de evaluar si un agente completó
- Verificación de PID vivo antes de mover a `_incomplete`

Esta rama agrega la reactivación del watcher con idempotencia correcta.

## Cambios

- **scripts/Start-Agente.ps1** — Reactiva agent-watcher al lanzar el sprint
  - Verifica si watcher ya está corriendo (por PID)
  - Solo lanza si no hay proceso activo
  - Información de traza con PID y referencia al fix

## Verificaciones

- ✅ Tests: backend, users, app (client) pasan
- ✅ Build: backend, users, app compilaron sin errores
- ✅ Security: sin findings críticos/altos
- ✅ Code Review: APROBADO
- ✅ QA: omitido (tipo:infra, sin impacto en producto de usuario)

## Criterios de aceptación

- [x] Agentes con PID vivo nunca se mueven a `_incomplete` (verificado en sprint-sync.js + agent-concurrency-check.js)
- [x] Grace period de 15 min respetado (verificado en agent-watcher.js)
- [x] Watcher reactivo con idempotencia (esta rama)

Closes #1552

🤖 Generado con [Claude Code](https://claude.ai/claude-code)