### PR TITLE
feat: agregar sección Gherkin obligatoria en issues y validación en /po

### DIFF
--- a/.claude/skills/doc/SKILL.md
+++ b/.claude/skills/doc/SKILL.md
@@ -163,6 +163,7 @@ Reglas:
 - Evitar referencias vagas
 - Redacción técnica, clara y accionable en español
 - Incluir pruebas si aplica
+- **Escenarios Gherkin obligatorios:** mínimo 2 (happy path + caso de error). Usar la sección "Escenarios Gherkin" de `./issue-template.md`. Agregar más según complejidad (permisos, edge cases, transiciones de estado).
 
 ### Paso 4: Determinar labels
 
@@ -337,6 +338,7 @@ Usar la plantilla de `./issue-template.md`. Reglas:
 - Evitar referencias vagas
 - Incluir pruebas si aplica
 - Redacción técnica, clara y accionable en español
+- **Escenarios Gherkin obligatorios:** si el issue no tiene sección "Escenarios Gherkin", agregarla con mínimo 2 escenarios (happy path + caso de error). Usar la plantilla de `./issue-template.md`.
 
 ### Paso 4: Determinar labels
 

--- a/.claude/skills/doc/issue-template.md
+++ b/.claude/skills/doc/issue-template.md
@@ -28,6 +28,31 @@ Propósito conciso de la historia. Una o dos oraciones que expliquen el "qué" y
 - [ ] Tests pasan (`./gradlew check`)
 - [ ] Sin regresiones en módulos afectados
 
+## Escenarios Gherkin
+
+> Obligatorio: mínimo 2 escenarios (happy path + caso de error).
+> Usar formato Given/When/Then en español (Dado/Cuando/Entonces).
+
+```gherkin
+Escenario: [Happy path — flujo principal exitoso]
+  Dado que [precondición: usuario autenticado, datos existentes, estado previo]
+  Cuando [acción principal del usuario]
+  Entonces [resultado esperado visible para el usuario]
+  Y [efecto secundario: datos persistidos, estado cambiado]
+
+Escenario: [Caso de error — validación, permisos o estado inválido]
+  Dado que [precondición que genera el error]
+  Cuando [acción del usuario]
+  Entonces el sistema muestra error "[mensaje específico]"
+  Y NO se modifica el estado previo
+```
+
+**Reglas:**
+- Cada escenario debe ser autocontenido (precondiciones explícitas)
+- Usar datos realistas (nombres argentinos, direcciones reales, montos en ARS)
+- Los mensajes de error deben ser específicos (no "Error genérico")
+- Agregar más escenarios según complejidad: permisos, edge cases, transiciones de estado
+
 ## Notas técnicas
 
 - Consideraciones de implementación

--- a/.claude/skills/po/SKILL.md
+++ b/.claude/skills/po/SKILL.md
@@ -158,6 +158,7 @@ Leer los archivos modificados con Read tool. Para cada cambio, evaluar:
 3. **¿Los permisos están verificados?** — ¿Quién puede hacer qué?
 4. **¿Las transiciones de estado son válidas?** — ¿Se validan las ilegales?
 5. **¿Los edge cases están cubiertos?** — Duplicados, vacíos, concurrencia
+6. **¿Tiene escenarios Gherkin?** — El issue DEBE tener sección "Escenarios Gherkin" con mínimo 2 escenarios (happy path + caso de error). Si falta → **REQUIERE CAMBIOS** automáticamente.
 
 ### Paso V4: Generar test cases para QA
 
@@ -188,6 +189,16 @@ Para cada criterio de aceptación, generar un test case concreto que QA pueda ej
 | Regla | Cumple | Nota |
 |-------|--------|------|
 | [regla de business-rules.md] | ✅/❌ | [detalle] |
+
+### Escenarios Gherkin
+| Verificación | Estado | Detalle |
+|-------------|--------|---------|
+| Sección "Escenarios Gherkin" presente | ✅/❌ | [existe o falta en el issue] |
+| Mínimo 2 escenarios (happy path + error) | ✅/❌ | [cantidad encontrada] |
+| Escenarios autocontenidos y con datos reales | ✅/⚠️/❌ | [calidad de los escenarios] |
+
+> **Si falta la sección o tiene menos de 2 escenarios → veredicto automático: REQUIERE CAMBIOS.**
+> Indicar al usuario que ejecute `/doc refinar <N>` para agregar los escenarios faltantes.
 
 ### Test cases para QA
 [Lista de test cases generados]


### PR DESCRIPTION
## Resumen

- Actualizar `/doc skill` para requerir mínimo 2 escenarios Gherkin (happy path + error) en modos "nueva" y "refinar"
- Actualizar `/po skill` para validar existencia de escenarios Gherkin antes de aprobar (Modo Validar)
- Actualizar `issue-template.md` con sección "Escenarios Gherkin" obligatoria con ejemplo en español (Dado/Cuando/Entonces)
- Agregar tabla de verificación en `/po validar` con 3 criterios: existencia de sección, cantidad mínima (2), calidad de escenarios
- Si faltan escenarios → veredicto automático "REQUIERE CAMBIOS" → recomendar ejecutar `/doc refinar <N>`

## Criterios de aceptación

- [x] `/doc nueva` valida que los escenarios Gherkin se incluyan antes de crear el issue
- [x] `/doc refinar` agrega sección Gherkin si falta
- [x] `/po validar` valida presencia de escenarios y bloquea sin ellos
- [x] issue-template.md tiene plantilla clara con formato Gherkin (Given/When/Then)

Closes #1581

🤖 Generado con [Claude Code](https://claude.com/claude-code)