### PR TITLE
feat(sdd): /tester genera tests automáticos desde escenarios Gherkin

### DIFF
--- a/.claude/skills/tester/SKILL.md
+++ b/.claude/skills/tester/SKILL.md
@@ -1,8 +1,8 @@
 ---
-description: Tester — Ejecutar tests, verificar cobertura Kover y reportar calidad
+description: Tester — Ejecutar tests, verificar cobertura Kover, generar tests desde Gherkin y reportar calidad
 user-invocable: true
-argument-hint: "[modulo] [--coverage] [--fail-fast]"
-allowed-tools: Bash, Read, Grep, Glob, TaskCreate, TaskUpdate, TaskList
+argument-hint: "[modulo] [--coverage] [--fail-fast] [--from-gherkin <issue>]"
+allowed-tools: Bash, Read, Grep, Glob, TaskCreate, TaskUpdate, TaskList, Write, Edit
 model: claude-haiku-4-5-20251001
 ---
 
@@ -17,6 +17,7 @@ Si algo puede fallar, lo encontrás.
 - `[modulo]` — Módulo a testear: `backend`, `users`, `app`, o vacío para todos
 - `--coverage` — Verificar cobertura Kover además de correr tests
 - `--fail-fast` — Detener al primer fallo
+- `--from-gherkin <issue>` — Generar tests automáticos desde los escenarios Gherkin del issue indicado
 
 ## Pre-flight: Registrar tareas
 
@@ -136,6 +137,157 @@ export JAVA_HOME="/c/Users/Administrator/.jdks/temurin-21.0.7" && \
 [Aprobación para PR | Correcciones requeridas antes de mergear]
 ```
 
+## Modo Gherkin: Generación automática de tests (--from-gherkin)
+
+Cuando se invoca con `--from-gherkin <issue>`, el tester genera tests `@Test fun` a partir de los escenarios Gherkin del issue.
+
+### Paso G1: Obtener escenarios del issue
+
+```bash
+export PATH="/c/Workspaces/gh-cli/bin:$PATH"
+gh issue view <issue> --json body --jq '.body'
+```
+
+Parsear la sección Gherkin del body. Identificar cada bloque `Escenario:` con sus líneas `Dado que`, `Cuando`, `Entonces`, `Y`.
+
+**Palabras clave soportadas (español):**
+- `Escenario:` → delimita un test case
+- `Dado que` / `Dado` → precondiciones (arrange)
+- `Cuando` → acción principal (act)
+- `Entonces` → resultado esperado (assert)
+- `Y` → continúa el bloque anterior (arrange, act o assert según contexto)
+
+**También soportar variantes en inglés** por compatibilidad:
+- `Scenario:` → `Escenario:`
+- `Given` → `Dado que`
+- `When` → `Cuando`
+- `Then` → `Entonces`
+- `And` → `Y`
+
+### Paso G2: Determinar módulo y clase target
+
+Analizar el issue para determinar:
+1. **Módulo target**: inferir de los labels (`area:backend`, `app:client`, etc.) o del contexto del issue
+2. **Clase/feature bajo test**: inferir del título o body (ej: "cancelar orden" → `DoCancelOrder`)
+3. **Directorio de tests**: localizar con Glob el directorio de tests del módulo
+
+```bash
+# Ejemplo: encontrar tests existentes del módulo
+```
+Usar Glob para buscar `**/test/**/*Test.kt` en el módulo correspondiente.
+
+Usar tests existentes como referencia de estilo y imports.
+
+### Paso G3: Mapping Gherkin → Test Kotlin
+
+Cada `Escenario:` genera un `@Test fun`:
+
+```kotlin
+@Test
+fun `[descripción del escenario en español]`() = runTest {
+    // region Arrange — Dado que [precondiciones]
+    // Setup de fakes, mocks y estado inicial derivados del "Dado que"
+    val fakeService = FakeXxxService()
+    // ... más setup según las líneas "Dado que" y "Y" del arrange
+
+    // region Act — Cuando [acción]
+    // Llamada al método/caso de uso derivada del "Cuando"
+    val result = sut.execute(...)
+
+    // region Assert — Entonces [resultado esperado]
+    // Assertions derivadas del "Entonces" y "Y" del assert
+    assertTrue(result.isSuccess)
+    assertEquals(expected, result.getOrNull()?.field)
+}
+```
+
+**Reglas de mapping:**
+
+| Gherkin | Kotlin | Notas |
+|---------|--------|-------|
+| `Dado que el usuario está autenticado` | `val fakeAuth = FakeAuthService(authenticated = true)` | Crear Fake con estado |
+| `Dado que existe una orden en estado PENDING` | `val order = Order(status = PENDING)` | Instanciar entidad |
+| `Cuando presiona "Cancelar orden"` | `val result = doCancel.execute(orderId)` | Llamar al caso de uso |
+| `Cuando intenta [acción] sin permiso` | `val result = doAction.execute(...)` | Ejecutar sin setup de permisos |
+| `Entonces la orden cambia a CANCELLED` | `assertEquals(CANCELLED, result.getOrNull()?.status)` | Assert de estado |
+| `Entonces el sistema responde 403` | `assertTrue(result.isFailure)` + verificar tipo excepción | Assert de error |
+| `Entonces se muestra error "[msg]"` | `assertEquals("[msg]", result.exceptionOrNull()?.message)` | Assert de mensaje |
+| `Y NO se modifica el estado previo` | `assertEquals(originalState, entity.status)` | Assert negativo |
+
+### Paso G4: Generar el archivo de test
+
+**Convenciones obligatorias:**
+- Nombre de archivo: `[Feature]GherkinTest.kt` (ej: `CancelOrderGherkinTest.kt`)
+- Package: mismo que la clase bajo test + `.test`
+- Nombre de test: backtick descriptivo en español, tomado directamente del `Escenario:`
+- `= runTest { ... }` siempre
+- Fakes con prefijo `Fake[Interface]` — reusar existentes si ya existen en el codebase
+- Imports mínimos necesarios
+- Comentarios `// Arrange`, `// Act`, `// Assert` en cada test
+
+**Si un paso Gherkin no puede mapearse directamente a código**, generar un `TODO()` descriptivo:
+
+```kotlin
+@Test
+fun `cancelar orden mientras el negocio la confirma simultáneamente`() = runTest {
+    // Arrange — Dado que la orden está en PENDING y el negocio confirma simultáneamente
+    val fakeService = FakeOrderService()
+    TODO("Arrange: simular confirmación concurrente — requiere definir estrategia de concurrencia")
+
+    // Act — Cuando el cliente cancela
+    // val result = doCancelOrder.execute(orderId)
+
+    // Assert — Entonces prevalece la cancelación
+    // TODO("Assert: verificar resolución de conflicto concurrente")
+}
+```
+
+### Paso G5: Validar tests generados
+
+1. **Compilar** los tests generados:
+```bash
+export JAVA_HOME="/c/Users/Administrator/.jdks/temurin-21.0.7" && \
+  ./gradlew :<modulo>:compileTestKotlin 2>&1
+```
+
+2. **Si hay errores de compilación**: corregir imports, tipos, o marcar con `TODO()` lo que no se pueda resolver
+3. **Ejecutar** los tests:
+```bash
+export JAVA_HOME="/c/Users/Administrator/.jdks/temurin-21.0.7" && \
+  ./gradlew :<modulo>:test --tests "*GherkinTest" --info 2>&1
+```
+
+4. **Reportar** resultado: cuántos tests se generaron, cuántos compilan, cuántos pasan, cuántos tienen TODOs
+
+### Paso G6: Reporte de generación Gherkin
+
+```
+## Reporte de generación Gherkin → Tests
+
+### Issue: #<número> — <título>
+### Archivo generado: `<path>/<Feature>GherkinTest.kt`
+
+### Escenarios procesados
+| # | Escenario | Estado | Notas |
+|---|-----------|--------|-------|
+| 1 | [nombre] | ✅ Compila y pasa | — |
+| 2 | [nombre] | ⚠️ Compila con TODO | Requiere: [detalle] |
+| 3 | [nombre] | ❌ No compila | Error: [detalle] |
+
+### Resumen
+- Total escenarios: N
+- Tests generados: N
+- Compilan y pasan: X
+- Compilan con TODOs: Y
+- Pendientes de resolver: Z
+
+### Fakes creados/reutilizados
+- `FakeXxxService` — [creado nuevo / reutilizado de <path>]
+
+### Próximos pasos
+[Qué falta para que todos los tests pasen sin TODOs]
+```
+
 ## Reglas
 
 - NUNCA saltar tests con `-x test` o `--exclude-task test`
@@ -143,3 +295,6 @@ export JAVA_HOME="/c/Users/Administrator/.jdks/temurin-21.0.7" && \
 - Si el build falla por razón externa (red, credenciales), reportarlo sin falso negativo
 - Workdir: `/c/Workspaces/Intrale/platform` — correr todos los comandos desde ahí
 - Si la cobertura baja del 80%, listar qué código no está cubierto
+- En modo `--from-gherkin`: preferir tests que compilen con TODO a tests que no compilen
+- En modo `--from-gherkin`: reutilizar Fakes existentes del codebase antes de crear nuevos
+- En modo `--from-gherkin`: nunca inventar escenarios — solo generar tests para escenarios explícitos del issue


### PR DESCRIPTION
## Resumen

Actualización del skill `/tester` para implementar la **Fase 2 de Spec-Driven Development (SDD)**.

### Cambios principales

- **Nuevo argumento** `--from-gherkin <issue>`: genera tests `@Test fun` automáticamente desde escenarios Gherkin del issue
- **Parsing de Gherkin** (español e inglés): soporta `Escenario:`, `Dado que`, `Cuando`, `Entonces`, `Y` y sus variantes en inglés
- **Mapping automático**: 
  - `Given` → `arrange` (setup de fakes, estado inicial)
  - `When` → `act` (llamada al caso de uso)
  - `Then` → `assert` (validación de resultado)
- **Convenciones** mantenidas: backtick descriptivo en español, `runTest`, patrón `Fake[Interface]`
- **Tolerancia inteligente**: genera `TODO()` para pasos que no se mapean directamente, manteniendo compilabilidad
- **Validación automática**: compila y ejecuta tests antes de reportar
- **Reporte detallado**: tabla de escenarios procesados con estado de cada test

### Criterios de aceptación cubiertos

- ✅ `/tester` parsea sección Gherkin del issue
- ✅ Cada `Scenario:` genera `@Test fun \`nombre descriptivo\`() = runTest { ... }`
- ✅ `Given` mapean a setup (fakes, mocks, estado)
- ✅ `When` mapean a acciones (llamadas a métodos)
- ✅ `Then` mapean a assertions
- ✅ Tests compilables y ejecutables

### Próximos pasos

Este cambio habilita:
- Generación de tests desde criterios BDD definidos en issues
- Integración con `/po acceptance` (que genera scenarios Gherkin)
- Reducción de interpretación manual de criterios → tests más precisos

Closes #1582

🤖 Generado con [Claude Code](https://claude.ai/claude-code)