### PR TITLE
feat(sdd): Specs de navegación y UIState para flujos core — closes #1583

### DIFF
--- a/.claude/skills/android-dev/SKILL.md
+++ b/.claude/skills/android-dev/SKILL.md
@@ -67,13 +67,39 @@ Archivos clave:
 - `app/composeApp/src/commonMain/kotlin/ar/com/intrale/DIManager.kt` — DI del app
 - `app/composeApp/build.gradle.kts` — Config de build, flavors, dependencias
 
+## Paso 2.5: Consultar UI Specs (OBLIGATORIO)
+
+Antes de planificar, leer la spec YAML del flujo afectado en `docs/specs/`:
+
+```bash
+ls docs/specs/
+# login.yaml | signup.yaml | profile.yaml | addresses.yaml | README.yaml
+```
+
+```bash
+cat docs/specs/<flow>.yaml
+```
+
+Las specs definen la **fuente de verdad** para:
+- **Rutas** y screen classes existentes
+- **Campos de UIState** con tipos, defaults y validaciones
+- **Transiciones** de navegación (on_success, on_error, links)
+- **Invariantes** que no se pueden violar
+- **Registros DI** esperados
+
+**Reglas:**
+- Si el flujo a implementar tiene spec → respetar campos, validaciones y transiciones definidas
+- Si se agrega un screen/field nuevo → actualizar la spec como parte del mismo PR
+- Si no existe spec para el flujo → consultar `docs/specs/README.yaml` para convenciones y crear una nueva
+
 ## Paso 3: Planificar la solución
 
-1. **Determinar capas afectadas**: ext → asdo → ViewModel → Screen → DIManager
-2. **Verificar** si es Android-only o commonMain (preferir commonMain)
-3. **Diseñar** el UI state como data class: `[Feature]UIState`
-4. **Planificar** validación con Konform si hay formularios
-5. **Identificar** strings necesarias para `resString()` calls
+1. **Contrastar con spec**: verificar que el plan respeta los campos, rutas e invariantes de la spec
+2. **Determinar capas afectadas**: ext → asdo → ViewModel → Screen → DIManager
+3. **Verificar** si es Android-only o commonMain (preferir commonMain)
+4. **Diseñar** el UI state como data class: `[Feature]UIState`
+5. **Planificar** validación con Konform si hay formularios
+6. **Identificar** strings necesarias para `resString()` calls
 
 Si se pasó `--plan`, reportar el plan y detenerse acá.
 
@@ -271,6 +297,7 @@ export JAVA_HOME="/c/Users/Administrator/.jdks/temurin-21.0.7" && \
 - NUNCA importar `kotlin.io.encoding.Base64` en capa UI
 - NUNCA escribir lógica de negocio en la Screen
 - NUNCA commitear — eso lo hace `/delivery`
+- NUNCA ignorar las UI specs de `docs/specs/*.yaml` — si el flujo tiene spec, respetarla
 
 ### Cuándo escalar
 - Cambios en backend → BackendDev

--- a/docs/specs/README.yaml
+++ b/docs/specs/README.yaml
@@ -1,0 +1,94 @@
+# =============================================================================
+# UI Specs — Convenciones y referencia
+# docs/specs/README.yaml
+# =============================================================================
+
+project: intrale-platform
+spec_version: 1
+description: >
+  Especificaciones YAML de navegación y UIState para los flujos core del app.
+  Estas specs son la fuente de verdad para validar implementaciones y planificar
+  cambios en la UI.
+
+# ---------------------------------------------------------------------------
+# Index de specs
+# ---------------------------------------------------------------------------
+specs:
+  - file: login.yaml
+    flow: login
+    screens: [login, force_change_password]
+    description: Autenticación con soporte multi-app, sesión previa, forzado de password
+
+  - file: signup.yaml
+    flow: signup
+    screens: [signup, confirm_signup, select_signup_profile, signup_platform_admin, signup_delivery, register_saler, register_new_business]
+    description: Registro de usuarios por rol y tipo de app
+
+  - file: profile.yaml
+    flow: profile
+    screens: [client_profile, delivery_profile]
+    description: Perfil de usuario (client y delivery) con datos, preferencias y disponibilidad
+
+  - file: addresses.yaml
+    flow: addresses
+    screens: [address_list, address_form]
+    description: CRUD de direcciones del cliente con list-detail pattern
+
+# ---------------------------------------------------------------------------
+# Convenciones de las specs
+# ---------------------------------------------------------------------------
+conventions:
+
+  structure:
+    - Cada spec define un `flow` con `screens`, `invariants` y `di`
+    - Cada screen tiene `route`, `class`, `state`, `viewmodel`, `actions`, `transitions`
+    - State fields incluyen `type`, `default`, y `validation` cuando aplica
+    - Transitions definen `on_success`, `on_error`, `on_load`
+
+  naming:
+    route: "/feature/sub-feature" (lowercase, slash-separated)
+    screen_class: PascalCase + Screen suffix (e.g., AddressListScreen)
+    state_class: PascalCase + UiState/UIState suffix
+    viewmodel_class: PascalCase + ViewModel suffix
+    action_interface: "ToDo" + PascalCase action name
+    action_impl: "Do" + PascalCase action name
+    service_interface: "Comm" + PascalCase service name
+    service_impl: "Client" + PascalCase service name
+
+  validation:
+    framework: Konform DSL
+    common_patterns:
+      email: ".+@.+\\..+"
+      phone: "^[+]?[-0-9 ()]{7,}$"
+      confirmation_code: "^\\d{6}$"
+    error_keys: resString message keys (form_error_*)
+
+  file_paths:
+    note: Relative to app/composeApp/src/commonMain/kotlin/ar/com/intrale/
+    screens: "ui/sc/{feature}/"
+    viewmodels: "ui/sc/{feature}/"
+    actions: "asdo/{feature}/"
+    services: "ext/{feature}/"
+    di: DIManager.kt
+
+# ---------------------------------------------------------------------------
+# Cómo usar estas specs
+# ---------------------------------------------------------------------------
+usage:
+  for_agents: >
+    Los agentes de desarrollo (/android-dev, /web-dev, /backend-dev) DEBEN
+    consultar la spec del flujo relevante antes de implementar cambios.
+    La spec define la fuente de verdad para: rutas, campos de estado,
+    reglas de validación, transiciones de navegación e invariantes.
+
+  for_review: >
+    /review y /qa pueden verificar que la implementación cumple con la spec:
+    campos de state, validaciones, transiciones, y registros de DI.
+
+  for_planning: >
+    /planner y /po pueden usar las specs para entender el estado actual de
+    cada flujo y planificar nuevos features o cambios.
+
+  updating_specs: >
+    Cuando se modifica un flujo, actualizar la spec correspondiente como
+    parte del mismo PR. La spec y el código deben estar siempre en sync.

--- a/docs/specs/addresses.yaml
+++ b/docs/specs/addresses.yaml
@@ -1,0 +1,358 @@
+# =============================================================================
+# UI Spec: Addresses Flow
+# CRUD de direcciones del cliente con list + form pattern
+# =============================================================================
+
+flow: addresses
+version: 1
+description: >
+  Flujo de gestión de direcciones del cliente: listado, creación, edición,
+  eliminación y marcado como predeterminada. Usa patrón list-detail con
+  AddressEditorStore como puente entre pantallas.
+
+# ---------------------------------------------------------------------------
+# Screens
+# ---------------------------------------------------------------------------
+screens:
+
+  # -------------------------------------------------------------------------
+  # Address List
+  # -------------------------------------------------------------------------
+  - id: address_list
+    route: /client/addresses
+    class: AddressListScreen
+    file: ui/sc/client/AddressListScreen.kt
+    title_key: client_profile_addresses_title
+    description: Lista de direcciones guardadas con opciones de editar, eliminar y agregar
+
+    state:
+      class: AddressListUiState
+      file: ui/sc/client/AddressListViewModel.kt
+      fields:
+        - name: status
+          type: AddressListStatus
+          default: Idle
+          options: [Idle, Loading, Loaded, Empty, Error]
+        - name: items
+          type: "List<AddressListItem>"
+          default: "emptyList()"
+        - name: errorMessage
+          type: String?
+          default: null
+        - name: deletingAddressId
+          type: String?
+          default: null
+
+    list_item:
+      class: AddressListItem
+      fields:
+        - name: id
+          type: String
+        - name: label
+          type: String
+        - name: street
+          type: String
+        - name: number
+          type: String
+        - name: reference
+          type: String?
+        - name: city
+          type: String
+        - name: state
+          type: String?
+        - name: postalCode
+          type: String?
+        - name: country
+          type: String?
+        - name: isDefault
+          type: Boolean
+
+    viewmodel:
+      class: AddressListViewModel
+      file: ui/sc/client/AddressListViewModel.kt
+      dependencies:
+        - ToDoGetClientProfile
+        - ToDoManageClientAddress
+      methods:
+        - loadAddresses    # Fetches profile, maps addresses to items
+        - deleteAddress    # suspend (addressId: String) -> Result<Unit>
+        - clearError
+        - toDraft          # Converts AddressListItem -> AddressDraft for editing
+
+    transitions:
+      on_load: loadAddresses
+      on_add:
+        - action: AddressEditorStore.clear()
+        - target: /client/addresses/form
+      on_edit:
+        - action: AddressEditorStore.setDraft(item.toDraft())
+        - target: /client/addresses/form
+      on_delete:
+        - action: show_confirmation_dialog
+        - confirm: viewModel.deleteAddress(id)
+        - on_success: show_snackbar (client_profile_address_deleted)
+        - on_error: show_error_snackbar
+
+    message_keys:
+      - client_profile_add_address
+      - client_addresses_retry
+      - client_profile_addresses_empty
+      - client_addresses_error
+      - client_addresses_delete_confirm_title
+      - client_addresses_delete_confirm_message
+      - client_addresses_delete_confirm_accept
+      - client_addresses_delete_confirm_cancel
+      - client_profile_address_deleted
+      - client_profile_edit_address
+      - client_profile_delete_address
+      - client_profile_default_badge
+      - error_generic
+
+  # -------------------------------------------------------------------------
+  # Address Form
+  # -------------------------------------------------------------------------
+  - id: address_form
+    route: /client/addresses/form
+    class: AddressFormScreen
+    file: ui/sc/client/AddressFormScreen.kt
+    title_key: dynamic  # client_address_form_title_create | client_address_form_title_edit
+    description: Formulario de creación/edición de dirección
+
+    state:
+      class: AddressFormUiState
+      file: ui/sc/client/AddressFormViewModel.kt
+      fields:
+        - name: id
+          type: String?
+          default: null
+          description: null = create mode, present = edit mode
+        - name: label
+          type: String
+          default: ""
+          validation:
+            required: true
+            min_length: 1
+            error_key: form_error_required
+        - name: street
+          type: String
+          default: ""
+          validation:
+            required: true
+            min_length: 1
+            error_key: form_error_required
+        - name: number
+          type: String
+          default: ""
+          validation:
+            required: true
+            min_length: 1
+            error_key: form_error_required
+        - name: reference
+          type: String
+          default: ""
+          validation:
+            required: false
+        - name: city
+          type: String
+          default: ""
+          validation:
+            required: true
+            min_length: 1
+            error_key: form_error_required
+        - name: state
+          type: String
+          default: ""
+          validation:
+            required: false
+        - name: postalCode
+          type: String
+          default: ""
+          validation:
+            required: false
+            min_length: 3
+        - name: country
+          type: String
+          default: ""
+          validation:
+            required: false
+        - name: isDefault
+          type: Boolean
+          default: false
+
+    viewmodel:
+      class: AddressFormViewModel
+      file: ui/sc/client/AddressFormViewModel.kt
+      dependencies:
+        - ToDoManageClientAddress
+      extra_state:
+        - name: loading
+          type: Boolean
+          default: false
+        - name: mode
+          type: AddressFormMode
+          default: Create
+          options: [Create, Edit]
+        - name: errorMessage
+          type: String?
+          default: null
+      methods:
+        - save         # suspend -> Result<ClientAddress>
+        - applyDraft   # (draft: AddressDraft?) -> sets UIState + auto-detects mode
+        - isValid
+        - initInputState
+
+    mode_detection:
+      rule: "id == null -> Create; id != null -> Edit"
+      note: Mode transitions from Create to Edit after successful creation (server assigns id)
+
+    transitions:
+      on_save_success:
+        - action: update_draft_in_store
+        - action: show_snackbar (client_profile_address_saved)
+        - target: /client/addresses (navigate back)
+      on_save_error:
+        - action: show_error_snackbar
+      on_validation_failure:
+        - action: mark_invalid_fields
+        - action: show_error_snackbar
+
+    message_keys:
+      - client_address_form_title_create
+      - client_address_form_title_edit
+      - client_profile_address_label
+      - client_profile_address_line1
+      - client_profile_address_number
+      - client_profile_address_reference
+      - client_profile_address_city
+      - client_profile_address_state
+      - client_profile_address_zip
+      - client_profile_address_country
+      - client_profile_make_default
+      - client_profile_save_address
+      - client_profile_save_address_content_description
+      - client_profile_address_saved
+      - error_generic
+      - form_error_required
+
+# ---------------------------------------------------------------------------
+# Cross-Screen Communication
+# ---------------------------------------------------------------------------
+shared_state:
+
+  address_draft:
+    class: AddressDraft
+    file: ui/sc/client/AddressDraft.kt
+    fields: [id?, label, street, number, reference, city, state, postalCode, country, isDefault]
+
+  address_editor_store:
+    class: AddressEditorStore
+    file: ui/sc/client/AddressEditorStore.kt
+    type: singleton_object
+    state: "StateFlow<AddressDraft?>"
+    methods:
+      - setDraft(draft)   # Set or update draft
+      - update(transform) # Transform current draft
+      - clear()           # Reset to null
+    lifecycle: |
+      1. List screen: clear() on Add, setDraft() on Edit
+      2. Form screen: reads draft via collectAsState()
+      3. Form screen: update() on save success (with server-assigned id)
+      4. List screen: re-reads on resume
+
+# ---------------------------------------------------------------------------
+# Domain Actions
+# ---------------------------------------------------------------------------
+actions:
+
+  manage_address:
+    interface: ToDoManageClientAddress
+    implementation: DoManageClientAddress
+    sealed_actions:
+      - type: Create
+        parameters: [address: ClientAddress]
+        service_call: addressesService.createAddress()
+        post_action: markDefault if isDefault
+      - type: Update
+        parameters: [address: ClientAddress]
+        service_call: addressesService.updateAddress()
+        post_action: markDefault if isDefault
+      - type: Delete
+        parameters: [addressId: String]
+        service_call: addressesService.deleteAddress()
+        post_action: reassign default to next address
+      - type: MarkDefault
+        parameters: [addressId: String]
+        service_call: addressesService.markDefault()
+
+    default_resolution:
+      priority:
+        1: "Updated address ID if marked default"
+        2: "First address marked as default in list"
+        3: "Profile's existing defaultAddressId (if in list)"
+        4: "First address in list"
+        5: "null if no addresses"
+      note: All addresses normalized to match resolved default after every action
+
+# ---------------------------------------------------------------------------
+# API Endpoints
+# ---------------------------------------------------------------------------
+api:
+  base: "/{BUSINESS}/client/addresses"
+  auth: Bearer token
+  endpoints:
+    - method: GET
+      path: /
+      action: listAddresses
+      response: "List<ClientAddressDTO> | ClientAddressResponse"
+    - method: POST
+      path: /
+      action: createAddress
+      request: ClientAddressDTO
+      response: ClientAddressDTO (with server-generated id)
+    - method: PUT
+      path: /{id}
+      action: updateAddress
+      request: ClientAddressDTO
+      response: ClientAddressDTO
+    - method: DELETE
+      path: /{id}
+      action: deleteAddress
+      response: empty
+    - method: PUT
+      path: /{id}/default
+      action: markDefault
+      response: ClientAddressDTO
+
+# ---------------------------------------------------------------------------
+# Navigation Graph
+# ---------------------------------------------------------------------------
+navigation:
+  entry_point: /client/addresses (from client profile)
+  flow:
+    - /client/addresses -> /client/addresses/form (Add or Edit)
+    - /client/addresses/form -> /client/addresses (Save success, navigate back)
+    - /client/addresses (Delete: stays on screen, refreshes list)
+
+# ---------------------------------------------------------------------------
+# Invariants
+# ---------------------------------------------------------------------------
+invariants:
+  - AddressEditorStore is the single source of truth for cross-screen draft state
+  - Form mode (Create/Edit) auto-detected from draft.id presence
+  - Create mode transitions to Edit mode after successful server creation
+  - Delete always shows confirmation dialog before executing
+  - Default address reassignment happens server-side; client normalizes after refresh
+  - Empty optional fields converted to null before API call (trimmed strings)
+  - At least one address should be default when list is non-empty
+  - All API calls require Bearer token from CommKeyValueStorage
+
+# ---------------------------------------------------------------------------
+# DI Registration
+# ---------------------------------------------------------------------------
+di:
+  screens:
+    - tag: CLIENT_ADDRESSES
+      class: AddressListScreen
+    - tag: CLIENT_ADDRESS_FORM
+      class: AddressFormScreen
+  note: Services and actions shared with profile module (clientModule)

--- a/docs/specs/login.yaml
+++ b/docs/specs/login.yaml
@@ -1,0 +1,220 @@
+# =============================================================================
+# UI Spec: Login Flow
+# Flujo de autenticación principal (Client, Business, Delivery)
+# =============================================================================
+
+flow: login
+version: 1
+description: >
+  Flujo de autenticación con soporte para 3 app types, sesión previa,
+  forzado de cambio de contraseña y bloqueo de cuenta.
+
+# ---------------------------------------------------------------------------
+# Screens
+# ---------------------------------------------------------------------------
+screens:
+
+  - id: login
+    route: /login
+    class: Login
+    file: ui/sc/auth/Login.kt
+    title_key: login_appbar_title
+    description: Pantalla principal de login con email y password
+
+    state:
+      class: LoginUIState
+      file: ui/sc/auth/LoginViewModel.kt
+      fields:
+        - name: user
+          type: String
+          default: ""
+          validation:
+            required: true
+            min_length: 1
+            pattern: ".+@.+\\..+"
+            error_key: form_error_invalid_email
+        - name: password
+          type: String
+          default: ""
+          validation:
+            required: true
+            min_length: 8
+            error_key: form_error_min_length_8
+
+    viewmodel:
+      class: LoginViewModel
+      file: ui/sc/auth/LoginViewModel.kt
+      extra_state:
+        - name: loading
+          type: Boolean
+          default: false
+        - name: isCheckingSession
+          type: Boolean
+          default: false
+      methods:
+        - login          # suspend -> Result<DoLoginResult>
+        - previousLogin  # suspend -> Boolean (checks stored token)
+        - onUserChange
+        - onPasswordChange
+        - markCredentialsAsInvalid
+
+    actions:
+      interface: ToDoLogin
+      implementation: DoLogin
+      file: asdo/auth/DoLogin.kt
+      parameters:
+        - user: String
+        - password: String
+        - newPassword: String?    # for forced password change
+        - name: String?           # for forced password change
+        - familyName: String?     # for forced password change
+
+    service:
+      interface: CommLoginService
+      implementations:
+        - class: ClientLoginService
+          endpoint: POST /{BUSINESS}/signin
+          condition: "!isDelivery"
+        - class: DeliveryLoginService
+          endpoint: POST /{DELIVERY}/signin
+          condition: isDelivery
+      request: LoginRequest(email, password, newPassword?, name?, familyName?)
+      response: LoginResponse(statusCode, idToken, accessToken, refreshToken)
+
+    result:
+      success: DoLoginResult(statusCode, accessToken?)
+      exception: DoLoginException(statusCode, message)
+
+    on_launch:
+      - action: check_previous_session
+        via: DoCheckPreviousLogin
+        if_true: trigger_login_with_stored_token
+        if_false: show_login_form
+
+    transitions:
+      on_success:
+        - condition: AppRuntimeConfig.isClient
+          target: /client-home
+          clear_backstack: false
+        - condition: AppRuntimeConfig.isDelivery
+          target: /delivery-dashboard
+          clear_backstack: true
+        - condition: AppRuntimeConfig.isBusiness
+          target: /dashboard
+          clear_backstack: true
+
+      on_error:
+        - status: 401
+          action: mark_credentials_invalid
+          message: invalid_credentials
+        - status: [403, 423]
+          action: show_blocked_message
+          message: user_blocked
+        - status: new_password_required
+          action: store_credentials_and_navigate
+          target: /force-change-password
+        - status: other
+          action: show_generic_error
+
+    links:
+      - label: forgot_password
+        target: /passwordRecovery
+        condition: always
+      - label: no_account_client
+        target: /signup
+        condition: isClient
+      - label: no_account_business
+        target: /selectSignupProfile
+        condition: isBusiness
+      - label: no_account_delivery
+        target: /signupDelivery
+        condition: isDelivery
+      - label: has_recovery_code
+        target: /confirmPasswordRecovery
+        condition: always
+      - label: register_business
+        target: /register-new-business
+        condition: isBusiness
+
+  - id: force_change_password
+    route: /force-change-password
+    class: ForceChangePasswordScreen
+    file: ui/sc/auth/ForceChangePasswordScreen.kt
+    title_key: null
+    description: Pantalla de cambio de contraseña forzado (primer login Cognito)
+
+    state:
+      class: ForceChangePasswordUIState
+      file: ui/sc/auth/ForceChangePasswordViewModel.kt
+      fields:
+        - name: newPassword
+          type: String
+          default: ""
+          validation:
+            required: true
+            min_length: 8
+        - name: name
+          type: String
+          default: ""
+          validation:
+            required: true
+            min_length: 1
+        - name: familyName
+          type: String
+          default: ""
+          validation:
+            required: true
+            min_length: 1
+
+    viewmodel:
+      class: ForceChangePasswordViewModel
+      extra_state:
+        - name: loading
+          type: Boolean
+          default: false
+
+    credential_store:
+      class: ForceChangePasswordCredentialsStore
+      type: singleton_object
+      fields: [user, password]
+      lifecycle: store_on_navigate, clear_on_success
+
+    transitions:
+      on_success:
+        - condition: AppRuntimeConfig.isClient
+          target: /client-home
+        - condition: AppRuntimeConfig.isDelivery
+          target: /delivery-dashboard
+        - condition: AppRuntimeConfig.isBusiness
+          target: /dashboard
+      on_error:
+        - status: 401
+          action: show_invalid_credentials
+
+# ---------------------------------------------------------------------------
+# Invariants
+# ---------------------------------------------------------------------------
+invariants:
+  - Token stored in CommKeyValueStorage on successful login
+  - SessionStore updated with UserRole on successful login
+  - ForceChangePasswordCredentialsStore cleared after successful forced change
+  - Previous session check runs on LaunchedEffect(Unit) at screen init
+  - Service endpoint selected at DI time based on AppRuntimeConfig.isDelivery
+  - All error paths show snackbar; credentials invalid additionally marks fields
+
+# ---------------------------------------------------------------------------
+# DI Registration
+# ---------------------------------------------------------------------------
+di:
+  module: authModule
+  bindings:
+    - type: CommLoginService
+      impl: ClientLoginService | DeliveryLoginService (conditional)
+    - type: ToDoLogin
+      impl: DoLogin
+    - type: ToDoCheckPreviousLogin
+      impl: DoCheckPreviousLogin
+  screens:
+    - tag: init
+      class: Login
+      start_destination: true

--- a/docs/specs/profile.yaml
+++ b/docs/specs/profile.yaml
@@ -1,0 +1,493 @@
+# =============================================================================
+# UI Spec: Profile Flow
+# Perfil de usuario: Client y Delivery con sus particularidades
+# =============================================================================
+
+flow: profile
+version: 1
+description: >
+  Flujo de perfil de usuario con dos variantes: ClientProfile (datos personales,
+  direcciones, preferencias, seguridad) y DeliveryProfile (datos de contacto,
+  vehículo, zonas, disponibilidad horaria).
+
+# ---------------------------------------------------------------------------
+# Screens
+# ---------------------------------------------------------------------------
+screens:
+
+  # -------------------------------------------------------------------------
+  # Client Profile
+  # -------------------------------------------------------------------------
+  - id: client_profile
+    route: /client/profile
+    class: ClientProfileScreen
+    file: ui/sc/client/ClientProfileScreen.kt
+    title_key: client_profile_title
+    description: >
+      Perfil del cliente con secciones: header, datos personales, seguridad,
+      direcciones, preferencias de idioma. Accesible via bottom navigation.
+
+    state:
+      class: ClientProfileUiState
+      file: ui/sc/client/ClientProfileViewModel.kt
+      fields:
+        - name: profileForm
+          type: ClientProfileForm
+          fields:
+            - name: fullName
+              type: String
+              default: ""
+              validation:
+                required: true
+                min_length: 1
+            - name: email
+              type: String
+              default: ""
+              validation:
+                required: true
+                min_length: 1
+                pattern: ".+@.+\\..+"
+            - name: phone
+              type: String
+              default: ""
+              validation:
+                required: false
+                pattern: "^[+]?[-0-9 ()]{7,}$"
+            - name: language
+              type: String
+              default: "es"
+              validation:
+                required: true
+                min_length: 2
+            - name: defaultAddressId
+              type: String?
+              default: null
+        - name: preferences
+          type: ClientPreferences
+          fields:
+            - name: language
+              type: String
+              default: "es"
+        - name: addresses
+          type: "List<ClientAddress>"
+          default: "emptyList()"
+          description: Read-only list displayed in profile; managed via /client/addresses
+        - name: addressForm
+          type: AddressForm
+          description: Legacy inline address form (deprecated in favor of separate flow)
+        - name: loading
+          type: Boolean
+          default: true
+        - name: savingProfile
+          type: Boolean
+          default: false
+        - name: savingAddress
+          type: Boolean
+          default: false
+        - name: error
+          type: String?
+          default: null
+        - name: successKey
+          type: MessageKey?
+          default: null
+
+    viewmodel:
+      class: ClientProfileViewModel
+      file: ui/sc/client/ClientProfileViewModel.kt
+      methods:
+        - loadProfile       # Fetches profile + addresses + preferences
+        - saveProfile       # Validates and updates profile + preferences
+        - saveAddress       # Create or update address (legacy inline)
+        - deleteAddress     # Remove address, reassign default if needed
+        - markDefault       # Set address as default
+        - logout            # Reset cache and clear session
+        - onNameChange
+        - onEmailChange
+        - onPhoneChange
+        - onLanguageChange
+        - startAddressEditing
+        - onAddressChange
+
+    actions:
+      - interface: ToDoGetClientProfile
+        implementation: DoGetClientProfile
+        file: asdo/client/DoClientProfile.kt
+        returns: "Result<ClientProfileData>"
+      - interface: ToDoUpdateClientProfile
+        implementation: DoUpdateClientProfile
+        parameters: [profile: ClientProfile, preferences: ClientPreferences]
+        returns: "Result<ClientProfileData>"
+      - interface: ToDoManageClientAddress
+        implementation: DoManageClientAddress
+        parameters: [action: ManageAddressAction]
+        returns: "Result<ClientProfileData>"
+
+    services:
+      - interface: CommClientProfileService
+        implementation: ClientProfileService
+        endpoints:
+          - method: GET
+            path: /{BUSINESS}/client/profile
+            action: fetchProfile
+          - method: PUT
+            path: /{BUSINESS}/client/profile
+            action: updateProfile
+        auth: Bearer token
+      - interface: CommClientAddressesService
+        implementation: ClientAddressesService
+        endpoints:
+          - method: GET
+            path: /{BUSINESS}/client/addresses
+            action: listAddresses
+          - method: POST
+            path: /{BUSINESS}/client/addresses
+            action: createAddress
+          - method: PUT
+            path: /{BUSINESS}/client/addresses/{id}
+            action: updateAddress
+          - method: DELETE
+            path: /{BUSINESS}/client/addresses/{id}
+            action: deleteAddress
+          - method: PUT
+            path: /{BUSINESS}/client/addresses/{id}/default
+            action: markDefault
+        auth: Bearer token
+
+    sections:
+      - id: header
+        type: display
+        content: avatar_initials, email
+      - id: personal_data
+        type: form
+        fields: [fullName, email, phone]
+        editable: true
+      - id: security
+        type: action_list
+        actions:
+          - label: change_password
+            target: /change-password
+          - label: setup_2fa
+            target: /twoFactorSetup
+          - label: verify_2fa
+            target: /twoFactorVerify
+          - label: logout
+            action: logout
+      - id: addresses
+        type: list
+        items: addresses
+        actions: [view, edit, delete, mark_default, add_new]
+        link: /client/addresses
+      - id: preferences
+        type: form
+        fields: [language]
+        options: ["es", "en"]
+
+    transitions:
+      on_load: loadProfile
+      on_save_success: show_snackbar
+      on_save_error: show_error_snackbar
+      on_logout:
+        - target: /login
+          clear_backstack: true
+
+    navigation:
+      access: bottom_navigation_tab (Home, Orders, Profile)
+
+  # -------------------------------------------------------------------------
+  # Delivery Profile
+  # -------------------------------------------------------------------------
+  - id: delivery_profile
+    route: /delivery/profile
+    class: DeliveryProfileScreen
+    file: ui/sc/delivery/DeliveryProfileScreen.kt
+    title_key: delivery_profile_title
+    description: >
+      Perfil del repartidor con contacto, vehículo, zonas asignadas y
+      configuración de disponibilidad horaria semanal.
+
+    state:
+      class: DeliveryProfileUiState
+      file: ui/sc/delivery/DeliveryProfileViewModel.kt
+      fields:
+        - name: form
+          type: DeliveryProfileForm
+          fields:
+            - name: fullName
+              type: String
+              default: ""
+              validation:
+                required: true
+                min_length: 1
+            - name: email
+              type: String
+              default: ""
+              validation:
+                required: true
+                min_length: 1
+                pattern: ".+@.+\\..+"
+            - name: phone
+              type: String
+              default: ""
+              validation:
+                required: false
+                pattern: "^[+]?[-0-9 ()]{7,}$"
+            - name: vehicleType
+              type: String
+              default: ""
+            - name: vehicleModel
+              type: String
+              default: ""
+            - name: vehiclePlate
+              type: String
+              default: ""
+        - name: zones
+          type: "List<DeliveryZone>"
+          default: "emptyList()"
+          description: Read-only assigned delivery zones
+        - name: availability
+          type: DeliveryAvailabilityForm
+          fields:
+            - name: timezone
+              type: String
+              default: "UTC"
+              validation:
+                required: true
+                min_length: 1
+            - name: slots
+              type: "List<DeliveryAvailabilitySlotForm>"
+              default: "DayOfWeek.entries.map { DeliveryAvailabilitySlotForm(it) }"
+              description: One slot per day of the week (Mon-Sun)
+        - name: loading
+          type: Boolean
+          default: true
+        - name: saving
+          type: Boolean
+          default: false
+        - name: error
+          type: String?
+          default: null
+        - name: successKey
+          type: MessageKey?
+          default: null
+        - name: availabilityErrorKey
+          type: String?
+          default: null
+
+    availability_slot:
+      class: DeliveryAvailabilitySlotForm
+      fields:
+        - name: dayOfWeek
+          type: DayOfWeek
+        - name: enabled
+          type: Boolean
+          default: false
+        - name: mode
+          type: DeliveryAvailabilityMode
+          default: BLOCK
+          options: [BLOCK, CUSTOM]
+        - name: block
+          type: DeliveryAvailabilityBlock
+          default: MORNING
+          options:
+            MORNING: "06:00-12:00"
+            AFTERNOON: "12:00-18:00"
+            NIGHT: "18:00-23:00"
+        - name: start
+          type: String
+          default: "06:00"
+          validation:
+            pattern: "HH:MM"
+            custom: "start < end when mode == CUSTOM"
+        - name: end
+          type: String
+          default: "12:00"
+          validation:
+            pattern: "HH:MM"
+
+    viewmodel:
+      class: DeliveryProfileViewModel
+      file: ui/sc/delivery/DeliveryProfileViewModel.kt
+      methods:
+        - loadProfile       # Load profile + availability concurrently
+        - saveProfile       # Validate both, persist both
+        - logout
+        - onNameChange
+        - onEmailChange
+        - onPhoneChange
+        - onVehicleTypeChange
+        - onVehicleModelChange
+        - onVehiclePlateChange
+        - onTimezoneChange
+        - onToggleDay       # Enable/disable availability for a day
+        - onBlockSelected   # Select predefined block (sets start/end)
+        - onCustomSelected  # Switch to custom time mode
+        - onCustomStartChange
+        - onCustomEndChange
+        - validateProfile
+        - validateAvailability
+
+    actions:
+      - interface: ToDoGetDeliveryProfile
+        implementation: DoGetDeliveryProfile
+        returns: "Result<DeliveryProfileData>"
+      - interface: ToDoUpdateDeliveryProfile
+        implementation: DoUpdateDeliveryProfile
+        parameters: [profile: DeliveryProfile]
+        returns: "Result<DeliveryProfileData>"
+      - interface: ToDoGetDeliveryAvailability
+        implementation: DoGetDeliveryAvailability
+        returns: "Result<DeliveryAvailabilityConfig>"
+      - interface: ToDoUpdateDeliveryAvailability
+        implementation: DoUpdateDeliveryAvailability
+        parameters: [config: DeliveryAvailabilityConfig]
+        returns: "Result<DeliveryAvailabilityConfig>"
+
+    services:
+      - interface: CommDeliveryProfileService
+        implementation: DeliveryProfileService
+        endpoints:
+          - method: GET
+            path: /{DELIVERY}/profile
+            action: fetchProfile
+          - method: PUT
+            path: /{DELIVERY}/profile
+            action: updateProfile
+        auth: Bearer token
+        fallback: demo data on error
+      - interface: CommDeliveryAvailabilityService
+        implementation: DeliveryAvailabilityService
+        endpoints:
+          - method: GET
+            path: /{DELIVERY}/profile/availability
+            action: fetchAvailability
+          - method: PUT
+            path: /{DELIVERY}/profile/availability
+            action: updateAvailability
+        auth: Bearer token
+        fallback: empty UTC config on error
+
+    sections:
+      - id: header
+        type: display
+        content: name, email
+      - id: contact
+        type: form
+        fields: [fullName, email, phone]
+        editable: true
+      - id: vehicle
+        type: form
+        fields: [vehicleType, vehicleModel, vehiclePlate]
+        editable: true
+      - id: zones
+        type: list
+        items: zones
+        read_only: true
+      - id: availability
+        type: complex_form
+        description: Weekly schedule with per-day toggle, block/custom mode
+      - id: actions
+        type: action_list
+        actions:
+          - label: save
+            action: saveProfile
+          - label: logout
+            action: logout
+
+    transitions:
+      on_load: loadProfile (profile + availability concurrent)
+      on_save_success: show_snackbar
+      on_save_error: show_error_snackbar
+      on_logout:
+        - target: /login
+          clear_backstack: true
+
+# ---------------------------------------------------------------------------
+# Domain Models
+# ---------------------------------------------------------------------------
+models:
+
+  ClientProfile:
+    fields: [fullName, email, phone?, defaultAddressId?]
+
+  ClientPreferences:
+    fields: [language]
+
+  ClientProfileData:
+    fields: [profile: ClientProfile, addresses: List<ClientAddress>, preferences: ClientPreferences]
+
+  DeliveryProfile:
+    fields: [fullName, email, phone?, vehicle: DeliveryVehicle]
+
+  DeliveryVehicle:
+    fields: [type, model, plate?]
+
+  DeliveryZone:
+    fields: [id, name, description?]
+
+  DeliveryProfileData:
+    fields: [profile: DeliveryProfile, zones: List<DeliveryZone>]
+
+  DeliveryAvailabilityMode:
+    type: enum
+    values: [BLOCK, CUSTOM]
+
+  DeliveryAvailabilityBlock:
+    type: enum
+    values: [MORNING, AFTERNOON, NIGHT]
+
+  DeliveryAvailabilitySlot:
+    fields: [dayOfWeek, mode, block?, start?, end?]
+
+  DeliveryAvailabilityConfig:
+    fields: [timezone, slots: List<DeliveryAvailabilitySlot>]
+
+# ---------------------------------------------------------------------------
+# Invariants
+# ---------------------------------------------------------------------------
+invariants:
+  - Profile data cached in CommKeyValueStorage after fetch
+  - Client profile and delivery profile are independent flows (different routes, ViewModels, services)
+  - Delivery availability validation requires at least one enabled day
+  - Custom time slots must satisfy start < end
+  - Block selection auto-sets start/end to predefined ranges
+  - Delivery services use fallback/demo data on API errors (graceful degradation)
+  - Client address management in profile delegates to separate /client/addresses flow
+  - Both profiles validate before save (separate validation pipelines for delivery)
+
+# ---------------------------------------------------------------------------
+# DI Registration
+# ---------------------------------------------------------------------------
+di:
+  client_module:
+    bindings:
+      - type: CommClientProfileService
+        impl: ClientProfileService
+      - type: CommClientAddressesService
+        impl: ClientAddressesService
+      - type: ToDoGetClientProfile
+        impl: DoGetClientProfile
+      - type: ToDoUpdateClientProfile
+        impl: DoUpdateClientProfile
+      - type: ToDoManageClientAddress
+        impl: DoManageClientAddress
+    screens:
+      - tag: CLIENT_PROFILE
+        class: ClientProfileScreen
+
+  delivery_module:
+    bindings:
+      - type: CommDeliveryProfileService
+        impl: DeliveryProfileService
+      - type: CommDeliveryAvailabilityService
+        impl: DeliveryAvailabilityService
+      - type: ToDoGetDeliveryProfile
+        impl: DoGetDeliveryProfile
+      - type: ToDoUpdateDeliveryProfile
+        impl: DoUpdateDeliveryProfile
+      - type: ToDoGetDeliveryAvailability
+        impl: DoGetDeliveryAvailability
+      - type: ToDoUpdateDeliveryAvailability
+        impl: DoUpdateDeliveryAvailability
+    screens:
+      - tag: DELIVERY_PROFILE
+        class: DeliveryProfileScreen

--- a/docs/specs/signup.yaml
+++ b/docs/specs/signup.yaml
@@ -1,0 +1,451 @@
+# =============================================================================
+# UI Spec: Signup Flow
+# Registro de usuarios: client, platform admin, delivery, saler, business
+# =============================================================================
+
+flow: signup
+version: 1
+description: >
+  Flujo de registro con múltiples variantes según app type y rol.
+  Incluye confirmación por código de 6 dígitos y registro de negocios.
+
+# ---------------------------------------------------------------------------
+# Screens
+# ---------------------------------------------------------------------------
+screens:
+
+  # -------------------------------------------------------------------------
+  # Generic Signup (Client)
+  # -------------------------------------------------------------------------
+  - id: signup
+    route: /signup
+    class: SignUpScreen
+    file: ui/sc/signup/SignUpScreen.kt
+    title_key: null
+    description: Registro genérico por email (usado en Client app)
+
+    state:
+      class: SignUpUIState
+      file: ui/sc/signup/SignUpViewModel.kt
+      fields:
+        - name: email
+          type: String
+          default: ""
+          validation:
+            required: true
+            pattern: ".+@.+\\..+"
+            error_key: form_error_invalid_email
+
+    viewmodel:
+      class: SignUpViewModel
+      extra_state:
+        - name: loading
+          type: Boolean
+          default: false
+      methods:
+        - signup    # suspend -> Result<DoSignUpResult>
+        - isValid
+
+    actions:
+      interface: ToDoSignUp
+      implementation: DoSignUp
+      file: asdo/signup/DoSignUp.kt
+      parameters:
+        - email: String
+
+    service:
+      interface: CommSignUpService
+      implementation: ClientSignUpService
+      endpoint: POST /{BUSINESS}/signup
+      request: SignUpRequest(email)
+      response: SignUpResponse(statusCode)
+
+    result:
+      success: DoSignUpResult(statusCode)
+      exception: DoSignUpException(statusCode, message)
+
+    transitions:
+      on_success:
+        - target: /confirmSignUp
+          clear_backstack: false
+
+  # -------------------------------------------------------------------------
+  # Confirm Signup (Email verification)
+  # -------------------------------------------------------------------------
+  - id: confirm_signup
+    route: /confirmSignUp
+    class: ConfirmSignUpScreen
+    file: ui/sc/signup/ConfirmSignUpScreen.kt
+    title_key: null
+    description: Verificación de email con código de 6 dígitos
+
+    state:
+      class: ConfirmSignUpUIState
+      file: ui/sc/signup/ConfirmSignUpViewModel.kt
+      fields:
+        - name: email
+          type: String
+          default: ""
+          validation:
+            required: true
+            pattern: ".+@.+\\..+"
+            error_key: form_error_invalid_email
+        - name: code
+          type: String
+          default: ""
+          validation:
+            required: true
+            pattern: "^\\d{6}$"
+            error_key: form_error_invalid_code
+
+    viewmodel:
+      class: ConfirmSignUpViewModel
+      extra_state:
+        - name: loading
+          type: Boolean
+          default: false
+      methods:
+        - confirmSignUp  # suspend -> Result<DoConfirmSignUpResult>
+        - resendCode     # re-invokes ToDoSignUp
+
+    actions:
+      interface: ToDoConfirmSignUp
+      implementation: DoConfirmSignUp
+      file: asdo/signup/DoConfirmSignUp.kt
+      parameters:
+        - email: String
+        - code: String
+
+    service:
+      interface: CommConfirmSignUpService
+      implementation: ClientConfirmSignUpService
+      endpoint: POST /{BUSINESS}/confirmSignUp
+      request: ConfirmSignUpRequest(email, code)
+      response: ConfirmSignUpResponse(statusCode)
+
+    result:
+      success: DoConfirmSignUpResult(statusCode)
+      exception: DoConfirmSignUpException(statusCode, message)
+
+    transitions:
+      on_success:
+        - target: /login
+          clear_backstack: true
+      on_resend_code:
+        - action: show_snackbar
+          message: code_resent
+
+  # -------------------------------------------------------------------------
+  # Select Signup Profile (Business app)
+  # -------------------------------------------------------------------------
+  - id: select_signup_profile
+    route: /selectSignupProfile
+    class: SelectSignUpProfileScreen
+    file: ui/sc/signup/SelectSignUpProfileScreen.kt
+    title_key: null
+    description: Selector de perfil de registro (Platform Admin o Delivery)
+
+    state: null  # No form state — solo navegación
+
+    transitions:
+      cards:
+        - label: platform_admin
+          target: /signupPlatformAdmin
+        - label: delivery_partner
+          target: /signupDelivery
+
+  # -------------------------------------------------------------------------
+  # Signup Platform Admin
+  # -------------------------------------------------------------------------
+  - id: signup_platform_admin
+    route: /signupPlatformAdmin
+    class: SignUpPlatformAdminScreen
+    file: ui/sc/signup/SignUpPlatformAdminScreen.kt
+    title_key: null
+    description: Registro de administrador de plataforma
+
+    state:
+      class: SignUpUIState
+      file: ui/sc/signup/SignUpPlatformAdminViewModel.kt
+      fields:
+        - name: email
+          type: String
+          default: ""
+          validation:
+            required: true
+            pattern: ".+@.+\\..+"
+            error_key: form_error_invalid_email
+
+    viewmodel:
+      class: SignUpPlatformAdminViewModel
+      extra_state:
+        - name: loading
+          type: Boolean
+          default: false
+
+    actions:
+      interface: ToDoSignUpPlatformAdmin
+      implementation: DoSignUpPlatformAdmin
+      file: asdo/signup/DoSignUpPlatformAdmin.kt
+
+    service:
+      interface: CommSignUpPlatformAdminService
+      implementation: ClientSignUpPlatformAdminService
+      endpoint: POST /{BUSINESS}/signupPlatformAdmin
+      request: SignUpRequest(email)
+      response: SignUpResponse(statusCode)
+
+    transitions:
+      on_success:
+        - target: /login
+          clear_backstack: false
+
+  # -------------------------------------------------------------------------
+  # Signup Delivery
+  # -------------------------------------------------------------------------
+  - id: signup_delivery
+    route: /signupDelivery
+    class: SignUpDeliveryScreen
+    file: ui/sc/signup/SignUpDeliveryScreen.kt
+    title_key: null
+    description: Registro de repartidor con selección de negocio
+
+    state:
+      class: SignUpUIState
+      file: ui/sc/signup/SignUpDeliveryViewModel.kt
+      fields:
+        - name: email
+          type: String
+          default: ""
+          validation:
+            required: true
+            pattern: ".+@.+\\..+"
+            error_key: form_error_invalid_email
+        - name: businessPublicId
+          type: String
+          default: ""
+          validation:
+            required: true
+        - name: businessName
+          type: String
+          default: ""
+          description: Display-only, selected from dropdown
+
+    viewmodel:
+      class: SignUpDeliveryViewModel
+      extra_state:
+        - name: loading
+          type: Boolean
+          default: false
+        - name: suggestions
+          type: "List<BusinessView>"
+          default: "emptyList()"
+      methods:
+        - signup
+        - searchBusinesses  # query: String -> populates suggestions
+
+    actions:
+      interface: ToDoSignUpDelivery
+      implementation: DoSignUpDelivery
+      file: asdo/signup/DoSignUpDelivery.kt
+      parameters:
+        - business: String   # publicId
+        - email: String
+
+    service:
+      interface: CommSignUpDeliveryService
+      implementation: ClientSignUpDeliveryService
+      endpoint: POST /{business}/signupDelivery
+      note: business param in URL path is dynamic (not constant BUSINESS)
+      request: SignUpRequest(email)
+      response: SignUpResponse(statusCode)
+
+    ui_components:
+      - type: ExposedDropdownMenuBox
+        purpose: Business search with autocomplete suggestions
+
+    transitions:
+      on_success:
+        - target: /login
+          clear_backstack: false
+
+  # -------------------------------------------------------------------------
+  # Register Saler (requires auth)
+  # -------------------------------------------------------------------------
+  - id: register_saler
+    route: /registerSaler
+    class: RegisterSalerScreen
+    file: ui/sc/signup/RegisterSalerScreen.kt
+    title_key: null
+    description: Registro de vendedor (requiere token de autenticación)
+    requires_auth: true
+
+    state:
+      class: RegisterSalerUIState
+      file: ui/sc/signup/RegisterSalerViewModel.kt
+      fields:
+        - name: email
+          type: String
+          default: ""
+          validation:
+            required: true
+            pattern: ".+@.+\\..+"
+            error_key: register_saler_email_invalid
+
+    viewmodel:
+      class: RegisterSalerViewModel
+
+    actions:
+      interface: ToDoRegisterSaler
+      implementation: DoRegisterSaler
+      file: asdo/signup/DoRegisterSaler.kt
+      note: Retrieves Bearer token from CommKeyValueStorage
+
+    service:
+      interface: CommRegisterSalerService
+      implementation: ClientRegisterSalerService
+      endpoint: POST /{BUSINESS}/registerSaler
+      headers:
+        Authorization: "{token}"
+      request: RegisterSalerRequest(email)
+      response: RegisterSalerResponse(statusCode)
+
+    transitions:
+      on_success:
+        - action: show_snackbar_and_reset_form
+          stays_on_screen: true
+
+  # -------------------------------------------------------------------------
+  # Register New Business
+  # -------------------------------------------------------------------------
+  - id: register_new_business
+    route: /registerNewBusiness
+    class: RegisterNewBusinessScreen
+    file: ui/sc/business/RegisterNewBusinessScreen.kt
+    title_key: null
+    description: Registro de un nuevo negocio
+
+    state:
+      class: UIState
+      file: ui/sc/business/RegisterBusinessViewModel.kt
+      fields:
+        - name: name
+          type: String
+          default: ""
+          validation:
+            required: true
+            min_length: 1
+            error_key: form_error_required
+        - name: email
+          type: String
+          default: ""
+          validation:
+            required: true
+            pattern: ".+@.+\\..+"
+            error_key: form_error_invalid_email
+        - name: description
+          type: String
+          default: ""
+          validation:
+            required: true
+            min_length: 1
+            error_key: form_error_required
+
+    viewmodel:
+      class: RegisterBusinessViewModel
+
+    actions:
+      interface: ToDoRegisterBusiness
+      implementation: DoRegisterBusiness
+      file: asdo/business/DoRegisterBusiness.kt
+      parameters:
+        - name: String
+        - emailAdmin: String
+        - description: String
+
+    service:
+      interface: CommRegisterBusinessService
+      implementation: ClientRegisterBusinessService
+      endpoint: POST /{BUSINESS}/registerBusiness
+      request: RegisterBusinessRequest(name, emailAdmin, description)
+      response: RegisterBusinessResponse(statusCode)
+
+    transitions:
+      on_success:
+        - action: show_snackbar_and_reset_form
+          stays_on_screen: true
+
+# ---------------------------------------------------------------------------
+# Navigation Graph
+# ---------------------------------------------------------------------------
+navigation:
+  entry_points:
+    client: /signup
+    business: /selectSignupProfile
+    delivery: /signupDelivery
+
+  flows:
+    client_signup:
+      - /signup -> /confirmSignUp -> /login
+    business_admin_signup:
+      - /selectSignupProfile -> /signupPlatformAdmin -> /login
+    business_delivery_signup:
+      - /selectSignupProfile -> /signupDelivery -> /login
+    business_register:
+      - /register-new-business (stays on screen)
+    post_auth_saler:
+      - /registerSaler (stays on screen, requires auth)
+
+# ---------------------------------------------------------------------------
+# Invariants
+# ---------------------------------------------------------------------------
+invariants:
+  - All signup endpoints are public except /registerSaler (requires Bearer token)
+  - Email validation pattern ".+@.+\..+" applied uniformly across all signup forms
+  - Confirmation code must be exactly 6 digits
+  - resendCode reuses ToDoSignUp action (same endpoint as initial signup)
+  - Delivery signup uses dynamic business publicId in URL path
+  - Post-auth flows (saler, business) stay on screen after success and reset form
+  - Business search autocomplete via ToGetBusinesses populates suggestions list
+
+# ---------------------------------------------------------------------------
+# DI Registration
+# ---------------------------------------------------------------------------
+di:
+  module: signupModule
+  bindings:
+    - type: CommSignUpService
+      impl: ClientSignUpService
+    - type: CommSignUpPlatformAdminService
+      impl: ClientSignUpPlatformAdminService
+    - type: CommSignUpDeliveryService
+      impl: ClientSignUpDeliveryService
+    - type: CommRegisterSalerService
+      impl: ClientRegisterSalerService
+    - type: CommConfirmSignUpService
+      impl: ClientConfirmSignUpService
+    - type: ToDoSignUp
+      impl: DoSignUp
+    - type: ToDoSignUpPlatformAdmin
+      impl: DoSignUpPlatformAdmin
+    - type: ToDoSignUpDelivery
+      impl: DoSignUpDelivery
+    - type: ToDoRegisterSaler
+      impl: DoRegisterSaler
+    - type: ToDoConfirmSignUp
+      impl: DoConfirmSignUp
+  screens:
+    - tag: SIGNUP
+      class: SignUpScreen
+    - tag: CONFIRM_SIGNUP
+      class: ConfirmSignUpScreen
+    - tag: SELECT_SIGNUP_PROFILE
+      class: SelectSignUpProfileScreen
+    - tag: SIGNUP_PLATFORM_ADMIN
+      class: SignUpPlatformAdminScreen
+    - tag: SIGNUP_DELIVERY
+      class: SignUpDeliveryScreen
+    - tag: REGISTER_SALER
+      class: RegisterSalerScreen
+    - tag: REGISTER_NEW_BUSINESS
+      class: RegisterNewBusinessScreen


### PR DESCRIPTION
## Resumen

Implementa **Spec-Driven Development (SDD) Fase 3**: specs YAML de navegación y UIState para los flujos core de la app.

- `docs/specs/README.yaml` — Índice de specs, convenciones y guía de uso para agentes y QA
- `docs/specs/login.yaml` — Flujo de autenticación: LoginUIState, ForceChangePasswordUIState, transiciones multi-app
- `docs/specs/signup.yaml` — Flujo de registro: SignUpUIState, ConfirmSignUpUIState, SignUpDeliveryUIState, variantes por perfil
- `docs/specs/profile.yaml` — Perfil de usuario: ClientProfileUiState, DeliveryProfileUiState con disponibilidad
- `docs/specs/addresses.yaml` — CRUD de direcciones: AddressListUiState, AddressFormUiState, list-detail pattern
- `.claude/skills/android-dev/SKILL.md` — Paso 2.5 OBLIGATORIO: leer spec antes de implementar ViewModel

## Criterios de aceptación

- [x] Directorio `docs/specs/` creado con specs de navegación y UIState
- [x] Formato YAML con: screens, routes, states, transitions, fields, invariants
- [x] Flujos core especificados: login, signup, profile, addresses
- [x] `/android-dev` lee la spec antes de implementar un ViewModel (Paso 2.5 en SKILL.md)
- [x] Spec de UIState define: tipo, default, validación para cada campo

## Validaciones

- Tests: ✅ backend:test + users:test PASS (sin cambios Kotlin — UP-TO-DATE)
- Build: ✅ backend + users build OK · app build pre-existing iOS variant issue (no relacionado)
- Security: ✅ BAJO RIESGO — solo YAML docs + SKILL.md, sin código compilable
- Review: ✅ APROBADO — 0 bloqueantes, 0 warnings

## Notas técnicas

- Specs reflejan fielmente los ViewModels existentes (validadas contra código fuente)
- Rama rebased sobre `origin/main` antes del push
- Cambios son únicamente YAML/Markdown — sin impacto en build ni tests de Kotlin
- Parte de la iniciativa SDD — reporte de referencia: `docs/ui/reporte-spec-driven-development-2026-03-15.pdf`

Closes #1583

🤖 Generated with [Claude Code](https://claude.com/claude-code)