### PR TITLE
fix(agents): watcher idle timeout + diagnostico de muerte

### DIFF
--- a/.claude/hooks/agent-watcher.js
+++ b/.claude/hooks/agent-watcher.js
@@ -858,6 +858,29 @@ async function runCycle() {
             process.exit(0);
         }
 
+        // Auto-shutdown si solo quedan agentes en "waiting" (PR abierta) sin trabajo real
+        // Evita que el watcher corra indefinidamente esperando reviews manuales
+        if (remainingActive === 0 && remainingQueue === 0 && waitingCount > 0) {
+            if (!global._idleSince) {
+                global._idleSince = Date.now();
+                log("Watcher idle: solo quedan " + waitingCount + " agente(s) en waiting (PR abierta). Timer de 15 min iniciado.");
+            }
+            const IDLE_TIMEOUT_MS = 15 * 60 * 1000; // 15 minutos
+            const idleMin = Math.round((Date.now() - global._idleSince) / 60000);
+            if (Date.now() - global._idleSince > IDLE_TIMEOUT_MS) {
+                log("Watcher idle timeout: " + idleMin + " min sin trabajo real. Auto-terminando.");
+                await notify(
+                    "⏹️ <b>Agent Watcher auto-shutdown (idle " + idleMin + " min)</b>\n" +
+                    waitingCount + " agente(s) en waiting (PR abierta) — requieren review manual.\n" +
+                    "<i>Watcher se detiene. Mergear PRs manualmente o relanzar sprint.</i>"
+                );
+                process.exit(0);
+            }
+        } else {
+            // Reset idle timer si hay trabajo activo
+            global._idleSince = null;
+        }
+
     } finally {
         if (locked) releaseLock();
     }

--- a/scripts/Run-AgentStream.ps1
+++ b/scripts/Run-AgentStream.ps1
@@ -157,8 +157,23 @@ try {
     $process.WaitForExit()
     $exitCode = $process.ExitCode
 
+    # Diagnostico de muerte: registrar causa en el log
+    $deathDiag = @{
+        timestamp = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ss.fffZ')
+        agent = $AgentNum
+        issue = $Issue
+        slug = $Slug
+        model = $Model
+        exitCode = $exitCode
+        toolCalls = $toolCount
+        messages = $msgCount
+        hasStderr = [bool]$stderrOutput
+    }
+    $diagJson = $deathDiag | ConvertTo-Json -Compress
+    "DEATH_DIAG: $diagJson" | Out-File -FilePath $LogFile -Encoding utf8 -Append
+
     Write-Host ""
-    Write-Host "  Resumen: $toolCount tool calls, $msgCount mensajes" -ForegroundColor Cyan
+    Write-Host "  Resumen: $toolCount tool calls, $msgCount mensajes, modelo: $Model" -ForegroundColor Cyan
 
     if ($exitCode -ne 0) {
         Write-Host "  ERROR: claude finalizo con exit code $exitCode" -ForegroundColor Red
@@ -171,6 +186,15 @@ try {
     }
 }
 catch {
+    # Diagnostico de excepcion
+    $errorDiag = @{
+        timestamp = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ss.fffZ')
+        agent = $AgentNum
+        issue = $Issue
+        type = "EXCEPTION"
+        message = $_.Exception.Message
+    }
+    ($errorDiag | ConvertTo-Json -Compress) | Out-File -FilePath $LogFile -Encoding utf8 -Append
     $_ | Out-String | Out-File -FilePath $LogFile -Encoding utf8 -Append
     Write-Host "  EXCEPTION: $($_.Exception.Message)" -ForegroundColor Red
     Write-Host "  La terminal se cerrara en 30 segundos..." -ForegroundColor Yellow


### PR DESCRIPTION
## Resumen

- **agent-watcher.js**: auto-shutdown tras 15 min idle cuando solo quedan agentes en "waiting" (PR abierta sin review). Antes el watcher corría indefinidamente.
- **Run-AgentStream.ps1**: registra `DEATH_DIAG` JSON al terminar cada agente con exit code, modelo, tool calls y mensajes. Facilita post-mortem.

## Contexto

Hallazgo de autopsia SPR-033: el watcher seguía corriendo 20+ min con 0 agentes activos porque había PRs abiertas en estado "waiting". Los agentes morían sin dejar diagnóstico.

## Plan de tests

- [x] Watcher se auto-termina cuando idle
- [x] Cada agente deja DEATH_DIAG en su log

QA Validate: omitido — label area:infra

🤖 Generado con [Claude Code](https://claude.ai/claude-code)