### PR TITLE
feat(backend): endpoint de productos publicados para app cliente (#613)

### DIFF
--- a/agent-done.json
+++ b/agent-done.json
@@ -1,7 +1,14 @@
 {
-  "summary": "propagar GH_TOKEN a auto-delivery.js desde Run-AgentStream.ps1",
-  "pr_title": "fix: propagar GH_TOKEN a auto-delivery.js desde Run-AgentStream.ps1",
-  "pr_body": "## Problema\n\n`auto-delivery.js` no podía crear PRs porque `git credential fill` no funciona en el subprocess de node. El `GH_TOKEN` no se propagaba desde la sesión PowerShell al `agent-runner.js`.\n\n## Solución\n\nEn `Run-AgentStream.ps1`, antes de lanzar el proceso node, se obtiene el `GH_TOKEN` con tres métodos en cascada:\n1. `$env:GH_TOKEN` si ya está seteado\n2. `git credential fill` (funciona en el contexto PS1)\n3. `gh auth token` como fallback\n\nEl token se pasa al proceso node via `$process.StartInfo.EnvironmentVariables[\"GH_TOKEN\"]`. Desde ahí, `agent-runner.js` lo propaga a `auto-delivery.js` a través de `...process.env` en el env del subprocess post-Claude.\n\n## Archivos modificados\n\n- `scripts/Run-AgentStream.ps1` — agrega bloque de obtención y propagación de GH_TOKEN\n\nCloses #1618\n\n---\nGenerated with [Claude Code](https://claude.ai/claude-code)",
-  "commit_type": "fix",
-  "files_changed": ["scripts/Run-AgentStream.ps1"]
+  "summary": "Implementado endpoint backend GET /{business}/products que devuelve solo productos PUBLISHED para la app cliente. Se creó la función ClientProducts (SecuredFunction), la respuesta ClientProductListResponse con payload compatible con BusinessProductsResponse del cliente, y se agregó listPublishedProducts al ProductRepository. Registrado en DI (Modules.kt y E2ETestBase.kt) con 6 tests unitarios completos.",
+  "pr_title": "feat(backend): endpoint de productos publicados para app cliente (#613)",
+  "pr_body": "## Cambios\n\n- Nuevo endpoint `GET /{business}/products` que retorna solo productos en estado `PUBLISHED`\n- Nueva clase `ClientProducts` (SecuredFunction) registrada con tag `products`\n- Nuevo `ClientProductListResponse` + `ClientProductPayload` (compatible con `BusinessProductsResponse` del cliente)\n- `ProductRepository.listPublishedProducts()` — filtro por estado PUBLISHED\n- Registrado en `Modules.kt` y `E2ETestBase.kt`\n- 6 tests unitarios en `ClientProductsTest` cubriendo todos los criterios de aceptación\n\n## Criterios de aceptación cubiertos\n\n- ✅ Producto en DRAFT no aparece en la app cliente\n- ✅ Producto en PUBLISHED sí aparece en la app cliente\n- ✅ Cambio DRAFT→PUBLISHED hace visible el producto sin reinstalar\n- ✅ Cambio PUBLISHED→DRAFT oculta el producto\n- ✅ Lista vacía cuando no hay productos publicados (estado vacío ya manejado por `ClientProductsState.Empty`)\n\nCloses #613",
+  "commit_type": "feat",
+  "files_changed": [
+    "users/src/main/kotlin/ar/com/intrale/ClientProducts.kt",
+    "users/src/main/kotlin/ar/com/intrale/ClientProductResponse.kt",
+    "users/src/main/kotlin/ar/com/intrale/ProductRepository.kt",
+    "users/src/main/kotlin/ar/com/intrale/Modules.kt",
+    "users/src/test/kotlin/ar/com/intrale/E2ETestBase.kt",
+    "users/src/test/kotlin/ar/com/intrale/ClientProductsTest.kt"
+  ]
 }

--- a/users/src/main/kotlin/ar/com/intrale/ClientProductResponse.kt
+++ b/users/src/main/kotlin/ar/com/intrale/ClientProductResponse.kt
@@ -1,0 +1,27 @@
+package ar.com.intrale
+
+import io.ktor.http.HttpStatusCode
+
+data class ClientProductPayload(
+    val id: String,
+    val name: String,
+    val basePrice: Double,
+    val status: String,
+    val emoji: String? = null,
+    val isAvailable: Boolean,
+    val stockQuantity: Int? = null
+)
+
+class ClientProductListResponse(
+    val products: List<ClientProductPayload>,
+    status: HttpStatusCode = HttpStatusCode.OK
+) : Response(statusCode = status)
+
+fun ProductRecord.toClientPayload() = ClientProductPayload(
+    id = id,
+    name = name,
+    basePrice = basePrice,
+    status = status,
+    isAvailable = isAvailable,
+    stockQuantity = stockQuantity
+)

--- a/users/src/main/kotlin/ar/com/intrale/ClientProducts.kt
+++ b/users/src/main/kotlin/ar/com/intrale/ClientProducts.kt
@@ -1,0 +1,34 @@
+package ar.com.intrale
+
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import org.slf4j.Logger
+
+class ClientProducts(
+    override val config: UsersConfig,
+    override val logger: Logger,
+    private val productRepository: ProductRepository,
+    override val jwtValidator: JwtValidator = CognitoJwtValidator(config)
+) : SecuredFunction(config = config, logger = logger, jwtValidator = jwtValidator) {
+
+    override suspend fun securedExecute(
+        business: String,
+        function: String,
+        headers: Map<String, String>,
+        textBody: String
+    ): Response {
+        val method = headers["X-Http-Method"]?.uppercase() ?: HttpMethod.Get.value.uppercase()
+
+        if (method != HttpMethod.Get.value.uppercase()) {
+            return RequestValidationException("Metodo no soportado: $method")
+        }
+
+        logger.debug("Consultando productos publicados para negocio=$business")
+        val products = productRepository.listPublishedProducts(business)
+        logger.debug("Productos publicados encontrados: ${products.size} en negocio=$business")
+        return ClientProductListResponse(
+            products = products.map { it.toClientPayload() },
+            status = HttpStatusCode.OK
+        )
+    }
+}

--- a/users/src/main/kotlin/ar/com/intrale/Modules.kt
+++ b/users/src/main/kotlin/ar/com/intrale/Modules.kt
@@ -253,6 +253,10 @@ val appModule = DI.Module("appModule") {
         singleton { BusinessProducts(instance(), instance(), instance(), instance(), instance(), instance()) }
     }
 
+    bind<Function> (tag="products") {
+        singleton { ClientProducts(instance(), instance(), instance()) }
+    }
+
     bind<Function> (tag="business/categories") {
         singleton { BusinessCategories(instance(), instance(), instance(), instance(), instance()) }
     }

--- a/users/src/main/kotlin/ar/com/intrale/ProductRepository.kt
+++ b/users/src/main/kotlin/ar/com/intrale/ProductRepository.kt
@@ -12,6 +12,11 @@ class ProductRepository {
     fun listProducts(business: String): List<ProductRecord> =
         products.values.filter { it.businessId == business.lowercase() }.map { it.copy() }
 
+    fun listPublishedProducts(business: String): List<ProductRecord> =
+        products.values.filter {
+            it.businessId == business.lowercase() && it.status.uppercase() == "PUBLISHED"
+        }.map { it.copy() }
+
     fun getProduct(business: String, productId: String): ProductRecord? =
         products[key(business, productId)]?.copy()
 

--- a/users/src/test/kotlin/ar/com/intrale/ClientProductsTest.kt
+++ b/users/src/test/kotlin/ar/com/intrale/ClientProductsTest.kt
@@ -1,0 +1,175 @@
+package ar.com.intrale
+
+import com.google.gson.Gson
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.runBlocking
+import org.slf4j.helpers.NOPLogger
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ClientProductsTest {
+
+    private val logger = NOPLogger.NOP_LOGGER
+    private val config = testConfig("la-carne")
+    private val productRepository = ProductRepository()
+    private val jwtValidator = LocalJwtValidator()
+    private val token = jwtValidator.generateToken("cliente@lacarne.com")
+
+    private val function = ClientProducts(
+        config = config,
+        logger = logger,
+        productRepository = productRepository,
+        jwtValidator = jwtValidator
+    )
+
+    private fun seedProduct(
+        business: String = "la-carne",
+        name: String,
+        status: String = "DRAFT",
+        basePrice: Double = 1000.0
+    ): ProductRecord {
+        return productRepository.saveProduct(
+            business,
+            ProductRecord(
+                name = name,
+                basePrice = basePrice,
+                unit = "kg",
+                categoryId = "cat-1",
+                status = status,
+                isAvailable = true
+            )
+        )
+    }
+
+    @Test
+    fun `GET retorna lista vacia cuando no hay productos publicados`() = runBlocking {
+        seedProduct(name = "Asado en borrador", status = "DRAFT")
+
+        val response = function.securedExecute(
+            business = "la-carne",
+            function = "products",
+            headers = mapOf("Authorization" to token, "X-Http-Method" to "GET"),
+            textBody = ""
+        )
+
+        assertTrue(response is ClientProductListResponse)
+        assertEquals(HttpStatusCode.OK, response.statusCode)
+        assertTrue(response.products.isEmpty())
+    }
+
+    @Test
+    fun `GET retorna solo productos publicados`() = runBlocking {
+        seedProduct(name = "Chorizo colorado", status = "PUBLISHED", basePrice = 800.0)
+        seedProduct(name = "Asado borrador", status = "DRAFT", basePrice = 2500.0)
+
+        val response = function.securedExecute(
+            business = "la-carne",
+            function = "products",
+            headers = mapOf("Authorization" to token, "X-Http-Method" to "GET"),
+            textBody = ""
+        )
+
+        assertTrue(response is ClientProductListResponse)
+        assertEquals(HttpStatusCode.OK, response.statusCode)
+        assertEquals(1, response.products.size)
+        assertEquals("Chorizo colorado", response.products.first().name)
+        assertEquals("PUBLISHED", response.products.first().status)
+    }
+
+    @Test
+    fun `GET no devuelve productos de otro negocio`() = runBlocking {
+        seedProduct(business = "otro-negocio", name = "Producto ajeno", status = "PUBLISHED")
+        seedProduct(business = "la-carne", name = "Producto propio", status = "PUBLISHED")
+
+        val response = function.securedExecute(
+            business = "la-carne",
+            function = "products",
+            headers = mapOf("Authorization" to token, "X-Http-Method" to "GET"),
+            textBody = ""
+        )
+
+        assertTrue(response is ClientProductListResponse)
+        assertEquals(1, response.products.size)
+        assertEquals("Producto propio", response.products.first().name)
+    }
+
+    @Test
+    fun `cambio de DRAFT a PUBLISHED hace visible el producto`() = runBlocking {
+        val product = seedProduct(name = "Empanadas x12", status = "DRAFT")
+
+        val beforeResponse = function.securedExecute(
+            business = "la-carne",
+            function = "products",
+            headers = mapOf("Authorization" to token, "X-Http-Method" to "GET"),
+            textBody = ""
+        ) as ClientProductListResponse
+        assertTrue(beforeResponse.products.isEmpty())
+
+        productRepository.updateProduct(
+            "la-carne",
+            product.id,
+            product.copy(status = "PUBLISHED")
+        )
+
+        val afterResponse = function.securedExecute(
+            business = "la-carne",
+            function = "products",
+            headers = mapOf("Authorization" to token, "X-Http-Method" to "GET"),
+            textBody = ""
+        ) as ClientProductListResponse
+        assertEquals(1, afterResponse.products.size)
+        assertEquals("Empanadas x12", afterResponse.products.first().name)
+    }
+
+    @Test
+    fun `cambio de PUBLISHED a DRAFT oculta el producto`() = runBlocking {
+        val product = seedProduct(name = "Milanesa de pollo", status = "PUBLISHED")
+
+        val beforeResponse = function.securedExecute(
+            business = "la-carne",
+            function = "products",
+            headers = mapOf("Authorization" to token, "X-Http-Method" to "GET"),
+            textBody = ""
+        ) as ClientProductListResponse
+        assertEquals(1, beforeResponse.products.size)
+
+        productRepository.updateProduct(
+            "la-carne",
+            product.id,
+            product.copy(status = "DRAFT")
+        )
+
+        val afterResponse = function.securedExecute(
+            business = "la-carne",
+            function = "products",
+            headers = mapOf("Authorization" to token, "X-Http-Method" to "GET"),
+            textBody = ""
+        ) as ClientProductListResponse
+        assertTrue(afterResponse.products.isEmpty())
+    }
+
+    @Test
+    fun `GET sin token retorna UnauthorizedException`() = runBlocking {
+        val response = function.execute(
+            business = "la-carne",
+            function = "products",
+            headers = mapOf("X-Http-Method" to "GET"),
+            textBody = ""
+        )
+
+        assertTrue(response is UnauthorizedException)
+    }
+
+    @Test
+    fun `metodo no soportado retorna error`() = runBlocking {
+        val response = function.securedExecute(
+            business = "la-carne",
+            function = "products",
+            headers = mapOf("Authorization" to token, "X-Http-Method" to "POST"),
+            textBody = Gson().toJson(mapOf("name" to "test"))
+        )
+
+        assertTrue(response is RequestValidationException)
+    }
+}

--- a/users/src/test/kotlin/ar/com/intrale/E2ETestBase.kt
+++ b/users/src/test/kotlin/ar/com/intrale/E2ETestBase.kt
@@ -46,6 +46,7 @@ abstract class E2ETestBase {
             bind<Faker>() { singleton { Faker() } }
             bind<ClientProfileRepository>() { singleton { ClientProfileRepository() } }
             bind<ClientOrderRepository>() { singleton { ClientOrderRepository() } }
+            bind<ProductRepository>() { singleton { ProductRepository() } }
 
             // Funciones no seguras
             bind<Function>(tag = "signup") {
@@ -127,6 +128,9 @@ abstract class E2ETestBase {
             }
             bind<Function>(tag = "business/orders") {
                 singleton { BusinessOrdersFunction(instance(), instance(), instance(), instance()) }
+            }
+            bind<Function>(tag = "products") {
+                singleton { ClientProducts(instance(), instance(), instance(), instance()) }
             }
         }
     }


### PR DESCRIPTION
## Cambios

- Nuevo endpoint GET /{business}/products que retorna solo productos en estado PUBLISHED
- Nueva clase ClientProducts (SecuredFunction) registrada con tag products
- Nuevo ClientProductListResponse + ClientProductPayload
- ProductRepository.listPublishedProducts() con filtro por estado PUBLISHED
- Registrado en Modules.kt y E2ETestBase.kt
- 6 tests unitarios en ClientProductsTest cubriendo todos los criterios de aceptacion

## Criterios de aceptacion cubiertos

- Producto en DRAFT no aparece en la app cliente
- Producto en PUBLISHED si aparece en la app cliente
- Cambio DRAFT->PUBLISHED hace visible el producto sin reinstalar
- Cambio PUBLISHED->DRAFT oculta el producto
- Lista vacia cuando no hay productos publicados

Closes #613

Generated with [Claude Code](https://claude.ai/claude-code)