### PR TITLE
fix: propagar GH_TOKEN a auto-delivery.js desde Run-AgentStream.ps1 (#1618)

### DIFF
--- a/agent-done.json
+++ b/agent-done.json
@@ -1,7 +1,7 @@
 {
-  "summary": "README para scripts/pipeline",
-  "pr_title": "docs: README para scripts/pipeline",
-  "pr_body": "Documenta el pipeline de eficiencia. Closes #1615",
-  "commit_type": "docs",
-  "files_changed": ["scripts/pipeline/README.md"]
+  "summary": "propagar GH_TOKEN a auto-delivery.js desde Run-AgentStream.ps1",
+  "pr_title": "fix: propagar GH_TOKEN a auto-delivery.js desde Run-AgentStream.ps1",
+  "pr_body": "## Problema\n\n`auto-delivery.js` no podía crear PRs porque `git credential fill` no funciona en el subprocess de node. El `GH_TOKEN` no se propagaba desde la sesión PowerShell al `agent-runner.js`.\n\n## Solución\n\nEn `Run-AgentStream.ps1`, antes de lanzar el proceso node, se obtiene el `GH_TOKEN` con tres métodos en cascada:\n1. `$env:GH_TOKEN` si ya está seteado\n2. `git credential fill` (funciona en el contexto PS1)\n3. `gh auth token` como fallback\n\nEl token se pasa al proceso node via `$process.StartInfo.EnvironmentVariables[\"GH_TOKEN\"]`. Desde ahí, `agent-runner.js` lo propaga a `auto-delivery.js` a través de `...process.env` en el env del subprocess post-Claude.\n\n## Archivos modificados\n\n- `scripts/Run-AgentStream.ps1` — agrega bloque de obtención y propagación de GH_TOKEN\n\nCloses #1618\n\n---\nGenerated with [Claude Code](https://claude.ai/claude-code)",
+  "commit_type": "fix",
+  "files_changed": ["scripts/Run-AgentStream.ps1"]
 }

--- a/scripts/Run-AgentStream.ps1
+++ b/scripts/Run-AgentStream.ps1
@@ -98,6 +98,29 @@ try {
         $process.StartInfo.CreateNoWindow = $false
         $process.StartInfo.WorkingDirectory = $WorkDir
         $process.StartInfo.EnvironmentVariables["CLAUDE_PROJECT_DIR"] = $WorkDir
+
+        # Propagar GH_TOKEN para que auto-delivery.js pueda crear/mergear PRs
+        $ghToken = $env:GH_TOKEN
+        if (-not $ghToken -or $ghToken.Length -lt 10) {
+            try {
+                $credInput = "protocol=https`nhost=github.com`n"
+                $credLines = ($credInput | & git credential fill 2>$null)
+                $pwdLine = @($credLines) | Where-Object { $_ -match '^password=' }
+                if ($pwdLine) { $ghToken = (($pwdLine | Select-Object -First 1) -replace '^password=', '').Trim() }
+            } catch { }
+        }
+        if (-not $ghToken -or $ghToken.Length -lt 10) {
+            try {
+                $ghToken = (& "C:\Workspaces\gh-cli\bin\gh.exe" auth token 2>$null | Out-String).Trim()
+            } catch { }
+        }
+        if ($ghToken -and $ghToken.Length -gt 10) {
+            $process.StartInfo.EnvironmentVariables["GH_TOKEN"] = $ghToken
+            Write-Host "  GH_TOKEN obtenido y propagado al runner" -ForegroundColor DarkGreen
+        } else {
+            Write-Host "  WARN: No se pudo obtener GH_TOKEN — auto-delivery puede fallar" -ForegroundColor DarkYellow
+        }
+
         $process.Start() | Out-Null
 
         # Leer output del runner (incluye output de Claude proxied)


### PR DESCRIPTION
## Problema

auto-delivery.js no podia crear PRs porque git credential fill no funciona en el subprocess de node. El GH_TOKEN no se propagaba desde la sesion PowerShell al agent-runner.js.

## Solucion

En Run-AgentStream.ps1, antes de lanzar el proceso node, se obtiene el GH_TOKEN con tres metodos en cascada:
1. $env:GH_TOKEN si ya esta seteado
2. git credential fill (funciona en el contexto PS1)
3. gh auth token como fallback

El token se pasa al proceso node via $process.StartInfo.EnvironmentVariables["GH_TOKEN"].

Closes #1618

Generated with [Claude Code](https://claude.ai/claude-code)