### PR TITLE
refactor(sprint): eliminar fechas de planificación — sizing simple/medio/grande

### DIFF
--- a/.claude/dashboard-server.js
+++ b/.claude/dashboard-server.js
@@ -767,9 +767,8 @@ function mockEjecucionData() {
   const mockSprintPlan = {
     sprint_id: "SPR-013",
     estado: "activo",
-    fecha: new Date().toISOString().split("T")[0],
-    fechaInicio: new Date().toISOString().split("T")[0],
-    fechaFin: new Date(Date.now() + 5 * 86400000).toISOString().split("T")[0],
+    size: "medio",
+    started_at: new Date().toISOString(),
     tema: "Sprint demo — todos los estados de ejecucion",
     agentes: [
       { numero: 1, issue: 1300, slug: "api-pedidos", titulo: "API REST de pedidos", stream: "A", size: "M" },

--- a/.claude/hooks/agent-monitor.js
+++ b/.claude/hooks/agent-monitor.js
@@ -405,7 +405,7 @@ function saveParticipation(data) {
 function recordSprintParticipation() {
     if (!_plan) return null;
 
-    const sprintId = _plan.fechaInicio || _plan.fecha || new Date().toISOString().split("T")[0];
+    const sprintId = _plan.sprint_id || ((_plan.started_at || "").split("T")[0]) || new Date().toISOString().split("T")[0];
 
     // Recopilar skills invocados de todas las sesiones registradas en agent-metrics.json
     const agentsParticipated = new Set();
@@ -429,8 +429,8 @@ function recordSprintParticipation() {
     const existing = participation.sprints.findIndex(s => s.sprint_id === sprintId);
     const record = {
         sprint_id: sprintId,
-        fecha_inicio: _plan.fechaInicio || _plan.fecha,
-        fecha_fin: _plan.fechaFin,
+        fecha_inicio: (_plan.started_at || "").split("T")[0] || null,
+        fecha_fin: (_plan.closed_at || "").split("T")[0] || null,
         recorded_at: new Date().toISOString(),
         agents_participated: agentsList,
         agents_total: ALL_PIPELINE_AGENTS.length,

--- a/.claude/hooks/commander/callback-handler.js
+++ b/.claude/hooks/commander/callback-handler.js
@@ -418,7 +418,7 @@ async function handleAutoPlanCallback(callbackData, callbackQueryId, messageId) 
                 const plan = JSON.parse(fs.readFileSync(_sprintPlanFile, "utf8"));
                 const agentes = plan.agentes || [];
                 const cola = plan.cola || [];
-                planText = `📅 <b>Sprint plan</b> — ${_tgApi.escHtml(plan.fecha || "?")} → ${_tgApi.escHtml(plan.fechaFin || "?")}\n`;
+                planText = `📋 <b>Sprint plan</b> — ${_tgApi.escHtml(plan.sprint_id || "?")} (${_tgApi.escHtml(plan.size || "?")})\n`;
                 planText += `<i>Priorización: ${_tgApi.escHtml(plan.priorization || "N/A")}</i>\n`;
                 planText += `<b>Issues seleccionados:</b> ${plan.total_selected || agentes.length + cola.length}/${plan.max_issues || 5}\n\n`;
                 planText += `🚀 <b>Agentes simultáneos (${agentes.length}):</b>\n`;

--- a/.claude/hooks/commander/sprint-manager.js
+++ b/.claude/hooks/commander/sprint-manager.js
@@ -322,7 +322,7 @@ async function handleSprint(agentNumber) {
     const results = new Array(agentes.length).fill("pending");
 
     let header = "🏃 <b>Sprint iniciado</b> — " + _tgApi.escHtml(plan.titulo) + "\n";
-    header += "📅 " + _tgApi.escHtml(plan.fecha) + " · " + agentes.length + " agente(s)\n";
+    header += "📋 " + _tgApi.escHtml(plan.sprint_id || "Sprint") + " (" + _tgApi.escHtml(plan.size || "?") + ") · " + agentes.length + " agente(s)\n";
     header += "📊 Monitor periódico: cada " + Math.round(sprintMonitorIntervalMs / 60000) + " min\n\n";
     header += formatSprintProgress(agentes, 0, results);
     await _tgApi.sendMessage(header);

--- a/.claude/hooks/health-check-sprint.js
+++ b/.claude/hooks/health-check-sprint.js
@@ -2,7 +2,7 @@
 // Lee sprint-plan.json, verifica estado de issues en GitHub y detecta inconsistencias:
 //   - PR mergeado pero issue abierto
 //   - Historias en "In Progress" > 6h sin actividad (estancadas)
-//   - Sprint pasada fechaFin sin cerrar
+//   - Sprint activo demasiado tiempo sin cerrar (basado en started_at)
 //   - PRs abiertos hace más de 24h sin merge
 // Salida: JSON con diagnóstico detallado
 
@@ -27,7 +27,7 @@ const GH_CLI_CANDIDATES = [
 // Umbrales de detección
 const STALE_IN_PROGRESS_HOURS = 6;   // Historias "In Progress" sin actividad > 6h → estancada
 const STALE_PR_HOURS = 24;           // PRs abiertos sin merge > 24h → alertar
-const SPRINT_OVERDUE_DAYS = 2;       // Sprint pasada fechaFin por > 2 días → cerrar
+const SPRINT_OVERDUE_DAYS = 2;       // Días extra sobre MAX_SPRINT_DAYS para marcar critical
 
 function log(msg) {
     try {
@@ -449,27 +449,28 @@ async function runHealthCheck() {
         issuesDiagnosis.push(issueDiag);
     }
 
-    // ─── Detección 5: Sprint pasada fechaFin sin cerrar ───────────────────────
+    // ─── Detección 5: Sprint overdue (sin fechaFin planificada, basado en started_at + duración) ──
     let sprintStatus = "active";
     let sprintOverdue = null;
-    if (sprintPlan.fechaFin && !sprintPlan.sprint_cerrado) {
-        const fechaFin = new Date(sprintPlan.fechaFin + "T23:59:59Z");
-        const daysOverdue = (now - fechaFin) / (1000 * 60 * 60 * 24);
-        if (daysOverdue > 0) {
-            sprintStatus = daysOverdue > SPRINT_OVERDUE_DAYS ? "overdue_critical" : "overdue";
+    if (sprintPlan.sprint_cerrado) {
+        sprintStatus = "closed";
+    } else if (sprintPlan.started_at) {
+        const startedAt = new Date(sprintPlan.started_at);
+        const daysSinceStart = (now - startedAt) / (1000 * 60 * 60 * 24);
+        // Sprints sin fecha de fin planificada: alertar si lleva más de 7 días activo
+        const MAX_SPRINT_DAYS = 7;
+        if (daysSinceStart > MAX_SPRINT_DAYS) {
+            sprintStatus = daysSinceStart > (MAX_SPRINT_DAYS + SPRINT_OVERDUE_DAYS) ? "overdue_critical" : "overdue";
             sprintOverdue = {
                 type: "sprint_overdue",
-                severity: daysOverdue > SPRINT_OVERDUE_DAYS ? "critical" : "medium",
-                days_overdue: Math.round(daysOverdue),
-                fecha_fin: sprintPlan.fechaFin,
-                message: `Sprint ${sprintPlan.sprint_id} venció hace ${Math.round(daysOverdue)} día(s) sin cerrar`,
-                action: daysOverdue > SPRINT_OVERDUE_DAYS ? "close_sprint" : "alert_sprint_overdue"
+                severity: daysSinceStart > (MAX_SPRINT_DAYS + SPRINT_OVERDUE_DAYS) ? "critical" : "medium",
+                days_active: Math.round(daysSinceStart),
+                message: `Sprint ${sprintPlan.sprint_id} lleva ${Math.round(daysSinceStart)} día(s) activo sin cerrar`,
+                action: sprintStatus === "overdue_critical" ? "close_sprint" : "alert_sprint_overdue"
             };
             inconsistencias.push(sprintOverdue);
             log("Inconsistencia: " + sprintOverdue.message);
         }
-    } else if (sprintPlan.sprint_cerrado) {
-        sprintStatus = "closed";
     }
 
     // ─── Calcular métricas de progreso ────────────────────────────────────────

--- a/.claude/hooks/tests/test-p08-agent-monitor.js
+++ b/.claude/hooks/tests/test-p08-agent-monitor.js
@@ -77,8 +77,9 @@ describe("P-08: Agent monitor", () => {
 
     it("getAgentStatus incluye campo status por agente", () => {
         const plan = {
-            fecha: "2026-03-08",
-            fechaFin: "2026-03-14",
+            sprint_id: "SPR-TEST",
+            size: "medio",
+            started_at: "2026-03-08T10:00:00Z",
             agentes: [{ numero: 1, issue: 9999, slug: "test-slug" }]
         };
         agentMonitor.startAgentMonitor(plan, { guardianOnly: true });
@@ -91,8 +92,9 @@ describe("P-08: Agent monitor", () => {
 
     it("getAgentStatus incluye campos failed y terminal en el resumen", () => {
         const plan = {
-            fecha: "2026-03-08",
-            fechaFin: "2026-03-14",
+            sprint_id: "SPR-TEST",
+            size: "medio",
+            started_at: "2026-03-08T10:00:00Z",
             agentes: [{ numero: 1, issue: 9998, slug: "test-slug-2" }]
         };
         agentMonitor.startAgentMonitor(plan, { guardianOnly: true });

--- a/.claude/hooks/tests/test-p22-concurrency-check.js
+++ b/.claude/hooks/tests/test-p22-concurrency-check.js
@@ -22,8 +22,9 @@ function makeTmpDir() {
 
 function buildPlan(overrides = {}) {
     return Object.assign({
-        fecha: "2026-03-08",
-        fechaFin: "2026-03-15",
+        sprint_id: "SPR-TEST",
+        size: "medio",
+        started_at: "2026-03-08T10:00:00Z",
         concurrency_limit: 3,
         agentes: [
             { numero: 1, issue: 1277, slug: "hooks-validar-concurrencia-agentes" },

--- a/.claude/hooks/tests/test-p24-sprint-health-repair.js
+++ b/.claude/hooks/tests/test-p24-sprint-health-repair.js
@@ -63,10 +63,10 @@ describe("P-24: health-check-sprint.js — existencia y estructura", () => {
         );
     });
 
-    it("detecta sprint pasada fechaFin sin cerrar (sprint_overdue)", () => {
+    it("detecta sprint overdue basado en started_at (sprint_overdue)", () => {
         const src = readSource("health-check-sprint.js");
         assert.ok(src.includes("sprint_overdue"), "debe detectar tipo sprint_overdue");
-        assert.ok(src.includes("fechaFin"), "debe comparar contra fechaFin");
+        assert.ok(src.includes("started_at"), "debe comparar contra started_at");
         assert.ok(src.includes("sprint_cerrado"), "debe verificar campo sprint_cerrado");
     });
 

--- a/.claude/skills/planner/SKILL.md
+++ b/.claude/skills/planner/SKILL.md
@@ -341,11 +341,10 @@ para que `Start-Agente.ps1` pueda lanzar agentes automaticamente:
 ```json
 {
   "sprint_id": "SPR-NNN",
-  "fecha": "2026-02-20",
-  "fechaInicio": "2026-02-20",
-  "fechaFin": "2026-02-26",
+  "size": "medio",
   "tema": "Sprint general — mix de prioridades",
   "estado": "activo",
+  "started_at": "2026-02-20T10:00:00Z",
   "concurrency_limit": 3,
   "pipeline_mode": "scripts",
   "total_stories": 7,
@@ -428,9 +427,9 @@ para que `Start-Agente.ps1` pueda lanzar agentes automaticamente:
 - **NUNCA** poner más de 3 en `agentes[]` aunque el sprint tenga 10 historias.
 
 Reglas de otros campos:
-- `fecha`: fecha de creacion del plan (backward compat, mismo valor que `fechaInicio`)
-- `fechaInicio`: fecha de inicio del sprint (ISO 8601, ej: `"2026-03-03"`) — siempre la fecha actual al momento de planificar
-- `fechaFin`: fecha de fin del sprint (ISO 8601, ej: `"2026-03-07"`) — `fechaInicio` + duracion del sprint (default: 5 dias habiles / 1 semana, excluyendo fines de semana). Si el sprint se planifica un lunes, `fechaFin` es el viernes de esa semana. **OBLIGATORIO** — `Start-Agente.ps1` y `Watch-Agentes.ps1` bloquean la ejecucion si `fechaFin` no existe o ya paso
+- `size`: tamaño del sprint (`"simple"` | `"medio"` | `"grande"`) — Simple: 1-3 stories simples, un solo stream. Medio: 4-6 stories o mix de esfuerzos. Grande: 7+ stories o stories de esfuerzo grande.
+- `started_at`: timestamp ISO 8601 de cuando arranca el sprint (se agrega automáticamente al activar)
+- `closed_at`: timestamp ISO 8601 de cuando se cierra el sprint (se agrega automáticamente al cerrar)
 - `numero`: secuencial empezando en 1 para toda la lista (agentes + _queue juntos)
 - `issue`: numero del issue de GitHub
 - `slug`: identificador corto sin espacios ni caracteres especiales (usado para branch y worktree)

--- a/.claude/skills/scrum/SKILL.md
+++ b/.claude/skills/scrum/SKILL.md
@@ -618,7 +618,7 @@ Ejecutar Paso 0, luego calcular y mostrar métricas:
   Trazabilidad:          N% (sesiones con issue vinculado)
 
 ### Salud del Sprint Actual
-  Sprint:          [sprint_id] ([fechaInicio] → [fechaFin])
+  Sprint:          [sprint_id] (size: [simple|medio|grande])
   Estado:          [active | overdue | closed]
   Inconsistencias: N [🟢 0 | 🟡 1-3 | 🔴 >3]
   ├─ PR mergeado/issue abierto: N
@@ -973,7 +973,7 @@ node /c/Workspaces/Intrale/platform/.claude/skills/scrum/health-report.js 2>/dev
 ## 🏁 Sprint Cerrado — [sprint_id]
 
 ### Resumen del sprint
-- **Período**: [fechaInicio] → [fechaFin]
+- **Tamaño**: [simple|medio|grande]
 - **Historias completadas**: N/M (velocity: N)
 - **Issues redistribuidos**: N
 - **Backup roadmap**: scripts/roadmap.backup.json ✓

--- a/docs/sprint-closing-and-planning.md
+++ b/docs/sprint-closing-and-planning.md
@@ -180,8 +180,8 @@ Un issue bloqueado por una dependencia **no incluida en el plan** es excluido.
 
 ```json
 {
-  "fecha": "2026-03-15",
-  "fechaFin": "2026-03-22",
+  "sprint_id": "SPR-NNN",
+  "size": "medio",
   "generado_por": "auto-plan-sprint.js",
   "priorization": "Técnico → QA → Negocio",
   "max_issues": 5,

--- a/scripts/Start-Agente.ps1
+++ b/scripts/Start-Agente.ps1
@@ -88,28 +88,19 @@ $Plan = Get-Content $PlanFile -Raw | ConvertFrom-Json
 function Test-SprintActivo {
     param([Parameter(Mandatory)] $Plan)
 
-    if (-not $Plan.fechaFin) {
-        Write-Error ("El plan no tiene campo 'fechaFin'. El sprint no es valido.`n" +
+    if (-not $Plan.sprint_id) {
+        Write-Error ("El plan no tiene campo 'sprint_id'. El sprint no es valido.`n" +
                      "Ejecuta /planner sprint para planificar un nuevo sprint antes de lanzar agentes.")
         exit 1
     }
 
-    try {
-        $fechaFin = [DateTime]::ParseExact($Plan.fechaFin, 'yyyy-MM-dd', $null)
-    }
-    catch {
-        Write-Error ("No se pudo parsear fechaFin '{0}'. Formato esperado: yyyy-MM-dd.`n" +
-                     "Ejecuta /planner sprint para generar un plan valido." -f $Plan.fechaFin)
+    if ($Plan.estado -ne 'activo') {
+        Write-Error ("El sprint $($Plan.sprint_id) no esta activo (estado: $($Plan.estado)).`n" +
+                     "Ejecuta /planner sprint para activar el sprint antes de lanzar agentes.")
         exit 1
     }
 
-    if ((Get-Date).Date -gt $fechaFin.Date) {
-        Write-Error ("El sprint del plan actual ha expirado (fechaFin: {0}).`n" +
-                     "Ejecuta /planner sprint para planificar un nuevo sprint antes de lanzar agentes." -f $Plan.fechaFin)
-        exit 1
-    }
-
-    Write-Host ">> Sprint activo (fechaFin: $($Plan.fechaFin))" -ForegroundColor Green
+    Write-Host ">> Sprint activo: $($Plan.sprint_id) (size: $($Plan.size))" -ForegroundColor Green
 }
 
 Test-SprintActivo -Plan $Plan

--- a/scripts/Watch-Agentes.ps1
+++ b/scripts/Watch-Agentes.ps1
@@ -95,28 +95,19 @@ $Plan = Get-Content $PlanFile -Raw | ConvertFrom-Json
 function Test-SprintActivo {
     param([Parameter(Mandatory)] $Plan)
 
-    if (-not $Plan.fechaFin) {
-        Write-Error ("El plan no tiene campo 'fechaFin'. El sprint no es valido.`n" +
+    if (-not $Plan.sprint_id) {
+        Write-Error ("El plan no tiene campo 'sprint_id'. El sprint no es valido.`n" +
                      "Ejecuta /planner sprint para planificar un nuevo sprint antes de lanzar agentes.")
         exit 1
     }
 
-    try {
-        $fechaFin = [DateTime]::ParseExact($Plan.fechaFin, 'yyyy-MM-dd', $null)
-    }
-    catch {
-        Write-Error ("No se pudo parsear fechaFin '{0}'. Formato esperado: yyyy-MM-dd.`n" +
-                     "Ejecuta /planner sprint para generar un plan valido." -f $Plan.fechaFin)
+    if ($Plan.estado -ne 'activo') {
+        Write-Error ("El sprint $($Plan.sprint_id) no esta activo (estado: $($Plan.estado)).`n" +
+                     "Ejecuta /planner sprint para activar el sprint antes de lanzar agentes.")
         exit 1
     }
 
-    if ((Get-Date).Date -gt $fechaFin.Date) {
-        Write-Error ("El sprint del plan actual ha expirado (fechaFin: {0}).`n" +
-                     "Ejecuta /planner sprint para planificar un nuevo sprint antes de lanzar agentes." -f $Plan.fechaFin)
-        exit 1
-    }
-
-    Write-Log ('Sprint activo (fechaFin: {0})' -f $Plan.fechaFin) 'Green'
+    Write-Log ('Sprint activo: {0} (size: {1})' -f $Plan.sprint_id, $Plan.size) 'Green'
 }
 
 Test-SprintActivo -Plan $Plan
@@ -133,7 +124,7 @@ Write-Host '============================================' -ForegroundColor Magen
 Write-Host '  Watch-Agentes -- Ciclo Continuo'            -ForegroundColor Magenta
 Write-Host '============================================' -ForegroundColor Magenta
 Write-Host ''
-Write-Log ('Vigilando {0} agente(s) del sprint {1}' -f $AgentCount, $Plan.fecha) 'Cyan'
+Write-Log ('Vigilando {0} agente(s) del sprint {1}' -f $AgentCount, $Plan.sprint_id) 'Cyan'
 Write-Log ('Intervalo de polling: {0}s' -f $PollInterval) 'Cyan'
 if ($SkipMerge) {
     Write-Log 'SkipMerge activado — PRs sin merge automatico' 'Yellow'
@@ -144,7 +135,7 @@ if ($EffectiveNoAutoPlan) {
 }
 Write-Host ''
 
-$tgMsg = "Watch-Agentes iniciado -- vigilando $AgentCount agente(s) del sprint $($Plan.fecha)"
+$tgMsg = "Watch-Agentes iniciado -- vigilando $AgentCount agente(s) del sprint $($Plan.sprint_id)"
 Send-TelegramMessage $tgMsg
 
 foreach ($a in $Plan.agentes) {

--- a/scripts/ask-next-sprint.js
+++ b/scripts/ask-next-sprint.js
@@ -84,7 +84,7 @@ async function main() {
         if (fs.existsSync(planPath)) {
             const plan = JSON.parse(fs.readFileSync(planPath, "utf8"));
             const count = plan.agentes ? plan.agentes.length : "?";
-            planInfo = "\n\n\uD83D\uDCCB Sprint " + (plan.fecha || "?") + " \u2014 " + count + " agente(s)";
+            planInfo = "\n\n\uD83D\uDCCB Sprint " + (plan.sprint_id || "?") + " \u2014 " + count + " agente(s)";
         }
     } catch(e) {}
 

--- a/scripts/auto-plan-sprint.js
+++ b/scripts/auto-plan-sprint.js
@@ -344,12 +344,6 @@ function generateDefaultPrompt(issue, slug) {
 
 function generateSprintPlan(selectedIssues) {
     const today = new Date();
-    const fechaStr = today.toISOString().split("T")[0];
-
-    // Fecha de fin: 5 días hábiles desde hoy (aprox 1 semana)
-    const fechaFin = new Date(today);
-    fechaFin.setDate(fechaFin.getDate() + 7);
-    const fechaFinStr = fechaFin.toISOString().split("T")[0];
 
     // Construir agentes (máx MAX_AGENTS simultáneos)
     const agentes = selectedIssues.slice(0, MAX_AGENTS).map((issue, i) => ({
@@ -364,8 +358,6 @@ function generateSprintPlan(selectedIssues) {
     }));
 
     const plan = {
-        fecha: fechaStr,
-        fechaFin: fechaFinStr,
         generado_por: "auto-plan-sprint.js",
         generado_at: new Date().toISOString(),
         priorization: "Técnico → QA → Negocio",
@@ -403,7 +395,7 @@ async function notifyTelegram(plan) {
 
     let text = `📅 <b>Plan del siguiente sprint generado</b>\n`;
     text += `<i>Priorización: Técnico → QA → Negocio</i>\n\n`;
-    text += `<b>Sprint:</b> ${plan.fecha} → ${plan.fechaFin}\n`;
+    text += `<b>Sprint:</b> ${plan.sprint_id || "nuevo"} (${plan.size || "?"})\n`;
     text += `<b>Issues seleccionados:</b> ${plan.total_selected}/${plan.max_issues}\n\n`;
 
     text += `🚀 <b>Agentes (primeros 2, simultáneos):</b>\n`;
@@ -504,7 +496,7 @@ async function main() {
 
     // Imprimir resumen siempre
     console.log("=== RESUMEN DEL PLAN ===");
-    console.log(`Sprint: ${plan.fecha} → ${plan.fechaFin}`);
+    console.log(`Sprint: ${plan.sprint_id || "nuevo"} (${plan.size || "?"})`);
     console.log(`Total issues: ${plan.total_selected}`);
     console.log(`\nAgentes simultáneos (${plan.agentes.length}):`);
     for (const a of plan.agentes) {

--- a/scripts/evaluate-and-release.js
+++ b/scripts/evaluate-and-release.js
@@ -279,9 +279,9 @@ async function main() {
         log(`Sprint plan no disponible: ${e.message} — continuando sin él`);
     }
 
-    const sprintDate = plan?.fechaFin || plan?.fecha || new Date().toISOString().split("T")[0];
+    const sprintDate = (plan?.closed_at || plan?.started_at || "").split("T")[0] || new Date().toISOString().split("T")[0];
     const sprintId = plan?.sprint_id || null;
-    const sprintTag = `sprint/${sprintDate}`;
+    const sprintTag = sprintId ? `sprint/${sprintId}` : `sprint/${sprintDate}`;
 
     // Obtener última release
     const lastRelease = getLastRelease();

--- a/scripts/planner-propose-interactive.js
+++ b/scripts/planner-propose-interactive.js
@@ -76,10 +76,10 @@ function loadSprintContext() {
     if (fs.existsSync(SPRINT_PLAN_FILE)) {
         try {
             const plan = JSON.parse(fs.readFileSync(SPRINT_PLAN_FILE, "utf8"));
-            context.fecha = plan.fecha || "?";
+            context.sprintId = plan.sprint_id || "?";
             context.agentes = plan.agentes || [];
             context.issues = (plan.agentes || []).map(a => a.issue).filter(Boolean);
-            log(`Sprint cargado: fecha=${context.fecha}, issues=[${context.issues.join(",")}]`);
+            log(`Sprint cargado: id=${context.sprintId}, issues=[${context.issues.join(",")}]`);
         } catch (e) {
             log("Error leyendo sprint-plan.json: " + e.message);
         }
@@ -214,7 +214,7 @@ function generateProposals(context, debtData, history) {
                 if (!discardedTitles.has(title.toLowerCase().substring(0, 30))) {
                     proposals.push({
                         title,
-                        justification: `Feature implementada en sprint ${context.fecha} sin tests de cobertura`,
+                        justification: `Feature implementada en sprint ${context.sprintId} sin tests de cobertura`,
                         body: buildTestProposalBody(module, description),
                         labels: ["backlog-tecnico", "testing"],
                         effort: "S",
@@ -589,7 +589,7 @@ async function main() {
     const proposalsData = saveProposals(proposals);
 
     // Actualizar historial
-    updateHistory(context.fecha, proposals);
+    updateHistory(context.sprintId, proposals);
 
     // 5. Enviar / mostrar
     if (DRY_RUN) {
@@ -606,7 +606,7 @@ async function main() {
         console.log(`Propuestas guardadas en: ${PROPOSALS_FILE}`);
     } else {
         log("Paso 5/5: Enviando propuestas a Telegram...");
-        const sent = await sendToTelegram(proposalsData, context.fecha);
+        const sent = await sendToTelegram(proposalsData, context.sprintId);
         if (sent) {
             console.log(`\n✅ ${proposals.length} propuesta(s) enviadas a Telegram para aprobación interactiva.\n`);
         } else {

--- a/scripts/roadmap.json
+++ b/scripts/roadmap.json
@@ -1,63 +1,77 @@
 {
-  "updated_ts": "2026-03-16T21:00:00.000Z",
-  "updated_by": "planner",
+  "updated_ts": "2026-03-17T23:00:00Z",
+  "updated_by": "manual — Agent Registry + sprint sizing (#1642, #1643)",
   "horizon_sprints": 5,
   "sprints": [
     {
-      "id": "SPR-035",
-      "tema": "Sprint limpieza + docs pipeline",
-      "status": "done",
-      "stories": [
-        { "issue": 1614, "title": "Limpiar archivos de prueba", "effort": "simple", "stream": "E", "status": "done" },
-        { "issue": 1615, "title": "README para scripts/pipeline", "effort": "simple", "stream": "E", "status": "done" }
-      ]
-    },
-    {
-      "id": "SPR-036",
-      "tema": "Sprint infra — completar pipeline + inicio features negocio",
-      "status": "planned",
-      "stories": [
-        { "issue": 1618, "title": "Propagar GH_TOKEN a auto-delivery", "effort": "simple", "stream": "E", "status": "planned" },
-        { "issue": 603, "title": "Home/dashboard app negocio", "effort": "medio", "stream": "C", "status": "planned" },
-        { "issue": 610, "title": "Dashboard administración negocio", "effort": "medio", "stream": "C", "status": "planned" },
-        { "issue": 613, "title": "Publicación de productos hacia app cliente", "effort": "medio", "stream": "C", "status": "planned" },
-        { "issue": 677, "title": "Config datos básicos del negocio", "effort": "simple", "stream": "C", "status": "planned" }
-      ]
-    },
-    {
       "id": "SPR-037",
-      "tema": "Sprint negocio — pedidos y delivery",
-      "status": "planned",
+      "tema": "Sprint negocio — carry-over dashboard + config + mejoras backend",
+      "status": "done",
+      "size": "medio",
+      "closed_at": "2026-03-17T18:00:00Z",
       "stories": [
-        { "issue": 674, "title": "Detalle de pedido y estado", "effort": "medio", "stream": "C", "status": "planned" },
-        { "issue": 675, "title": "Gestión de repartidores", "effort": "medio", "stream": "C", "status": "planned" },
-        { "issue": 676, "title": "Asignación de pedidos a repartidores", "effort": "medio", "stream": "C", "status": "planned" },
-        { "issue": 678, "title": "Config horarios y zonas de entrega", "effort": "medio", "stream": "C", "status": "planned" },
-        { "issue": 679, "title": "Config medios de pago", "effort": "simple", "stream": "C", "status": "planned" }
+        { "issue": 603, "title": "Home/dashboard app negocio", "effort": "medio", "stream": "C", "status": "done" },
+        { "issue": 677, "title": "Config datos básicos del negocio", "effort": "simple", "stream": "C", "status": "carry-over" },
+        { "issue": 1621, "title": "Sincronizar roadmap.json y sprint-plan.json", "effort": "simple", "stream": "E", "status": "carry-over" },
+        { "issue": 1637, "title": "Sanitización UTF-8 en reportes Telegram", "effort": "simple", "stream": "E", "status": "carry-over" },
+        { "issue": 1635, "title": "Paginación y filtrado para endpoint productos", "effort": "simple", "stream": "E", "status": "carry-over" },
+        { "issue": 1636, "title": "Cache/ETag para endpoint productos", "effort": "simple", "stream": "E", "status": "carry-over" }
       ]
     },
     {
       "id": "SPR-038",
+      "tema": "Sprint negocio — carry-over config/infra + UX dashboard + QA E2E + pedidos",
+      "status": "active",
+      "size": "grande",
+      "started_at": "2026-03-17T18:45:00Z",
+      "stories": [
+        { "issue": 677, "title": "Config datos básicos del negocio", "effort": "simple", "stream": "C", "status": "planned", "moved_from": "SPR-037" },
+        { "issue": 1637, "title": "Sanitización UTF-8 en reportes Telegram", "effort": "simple", "stream": "E", "status": "planned", "moved_from": "SPR-037" },
+        { "issue": 1621, "title": "Sincronizar roadmap.json y sprint-plan.json", "effort": "simple", "stream": "E", "status": "planned", "moved_from": "SPR-037" },
+        { "issue": 1635, "title": "Paginación y filtrado para endpoint productos", "effort": "simple", "stream": "E", "status": "planned", "moved_from": "SPR-037" },
+        { "issue": 1636, "title": "Cache/ETag para endpoint productos", "effort": "simple", "stream": "E", "status": "planned", "moved_from": "SPR-037" },
+        { "issue": 1631, "title": "Empty states y skeleton loading para Home dashboard", "effort": "simple", "stream": "C", "status": "planned" },
+        { "issue": 1632, "title": "Accesibilidad (a11y) para Home dashboard", "effort": "simple", "stream": "C", "status": "planned" },
+        { "issue": 1633, "title": "QA E2E con video — Home dashboard", "effort": "medio", "stream": "E", "status": "planned" },
+        { "issue": 1634, "title": "QA E2E con video — Publicación de productos", "effort": "medio", "stream": "E", "status": "planned" },
+        { "issue": 674, "title": "Detalle de pedido y estado", "effort": "medio", "stream": "C", "status": "planned" }
+      ]
+    },
+    {
+      "id": "SPR-039",
+      "tema": "Sprint infra — Agent Registry + sizing sprints",
+      "status": "active",
+      "size": "medio",
+      "started_at": "2026-03-17T23:30:00Z",
+      "stories": [
+        { "issue": 1642, "title": "Agent Registry único — fuente de verdad centralizada para agentes activos", "effort": "grande", "stream": "E", "status": "planned" },
+        { "issue": 1643, "title": "Eliminar fechas de planificación — sizing simple/medio/grande", "effort": "simple", "stream": "E", "status": "planned" }
+      ]
+    },
+    {
+      "id": "SPR-040",
+      "tema": "Sprint negocio — delivery y configuración",
+      "status": "planned",
+      "size": "grande",
+      "stories": [
+        { "issue": 675, "title": "Gestión de repartidores", "effort": "medio", "stream": "C", "status": "planned" },
+        { "issue": 676, "title": "Asignación de pedidos a repartidores", "effort": "medio", "stream": "C", "status": "planned" },
+        { "issue": 678, "title": "Config horarios y zonas de entrega", "effort": "medio", "stream": "C", "status": "planned" },
+        { "issue": 679, "title": "Config medios de pago", "effort": "simple", "stream": "C", "status": "planned" },
+        { "issue": 680, "title": "Gestión banners y marketing del negocio", "effort": "medio", "stream": "C", "status": "planned" }
+      ]
+    },
+    {
+      "id": "SPR-041",
       "tema": "Sprint cliente — carrito y pedidos",
       "status": "planned",
+      "size": "grande",
       "stories": [
         { "issue": 717, "title": "Visualización del carrito", "effort": "medio", "stream": "B", "status": "planned" },
         { "issue": 718, "title": "Confirmación de pedido y checkout", "effort": "medio", "stream": "B", "status": "planned" },
         { "issue": 720, "title": "Selección medio de pago", "effort": "medio", "stream": "B", "status": "planned" },
         { "issue": 721, "title": "Listado de pedidos del cliente", "effort": "medio", "stream": "B", "status": "planned" },
         { "issue": 722, "title": "Detalle y seguimiento de pedido", "effort": "medio", "stream": "B", "status": "planned" }
-      ]
-    },
-    {
-      "id": "SPR-039",
-      "tema": "Sprint delivery — app repartidores",
-      "status": "planned",
-      "stories": [
-        { "issue": 732, "title": "Listado de pedidos disponibles", "effort": "medio", "stream": "D", "status": "planned" },
-        { "issue": 734, "title": "Flujo estados de entrega", "effort": "medio", "stream": "D", "status": "planned" },
-        { "issue": 735, "title": "Placeholder ubicación y mapa", "effort": "medio", "stream": "D", "status": "planned" },
-        { "issue": 737, "title": "Historial de pedidos", "effort": "medio", "stream": "D", "status": "planned" },
-        { "issue": 740, "title": "Notificaciones de pedidos", "effort": "medio", "stream": "D", "status": "planned" }
       ]
     }
   ]

--- a/scripts/sprint-report.js
+++ b/scripts/sprint-report.js
@@ -250,7 +250,7 @@ const CSS = `
 `;
 
 function buildHtml(plan, issueInfos, agentSummaries, prs, ciRuns, worktrees, sprintDurationMin, problemsData, debtData) {
-    const fecha = plan.fecha || new Date().toISOString().split("T")[0];
+    const fecha = (plan.started_at || "").split("T")[0] || new Date().toISOString().split("T")[0];
     const tema = plan.tema || "";
     const agentes = plan.agentes || [];
     const sprintId = plan.sprint_id || null;
@@ -584,7 +584,7 @@ function buildTimelineEvents(activityLogPath, agentes, plan) {
 
     // Evento de inicio del sprint
     events.push({
-        time: plan.fecha || "Sprint",
+        time: (plan.started_at || "").split("T")[0] || "Sprint",
         title: `Sprint iniciado — ${agentes.length} agentes`,
         detail: `Tema: ${plan.tema || "N/A"}`,
         type: "info"
@@ -668,7 +668,7 @@ async function main() {
         process.exit(0);
     }
 
-    log(`Plan: ${plan.fecha}, ${plan.agentes.length} agentes`);
+    log(`Plan: ${plan.sprint_id || (plan.started_at || "").split("T")[0]}, ${plan.agentes.length} agentes`);
 
     // Snapshot de sesiones (antes de que se limpien)
     const sessions = snapshotSessions();
@@ -746,8 +746,8 @@ async function main() {
     log(`Datos enriquecidos: ${activityProblems.length} problemas en activity, ${prProblems.length} en PRs, ${debtData.length} deuda técnica`);
 
     // Generar HTML
-    const fecha = plan.fecha || new Date().toISOString().split("T")[0];
-    const htmlFileName = `reporte-sprint-${fecha}.html`;
+    const fecha = (plan.started_at || "").split("T")[0] || new Date().toISOString().split("T")[0];
+    const htmlFileName = `reporte-sprint-${plan.sprint_id || fecha}.html`;
     const htmlPath = path.join(QA_DIR, htmlFileName);
     const html = buildHtml(plan, issueInfos, agentSummaries, prs, ciRuns, worktrees, sprintDurationMin, problemsData, debtData);
 

--- a/scripts/sprint-tagger.js
+++ b/scripts/sprint-tagger.js
@@ -161,10 +161,10 @@ async function main() {
         process.exit(0);
     }
 
-    // Fecha de cierre del sprint
-    const sprintDate = plan.fechaFin || plan.fecha || new Date().toISOString().split("T")[0];
-    const tagName = `sprint/${sprintDate}`;
+    // Fecha de cierre del sprint (derivada de closed_at o started_at)
+    const sprintDate = (plan.closed_at || plan.started_at || "").split("T")[0] || new Date().toISOString().split("T")[0];
     const sprintId = plan.sprint_id || null;
+    const tagName = sprintId ? `sprint/${sprintId}` : `sprint/${sprintDate}`;
 
     log(`Sprint: ${sprintId || "sin ID"}, fecha cierre: ${sprintDate}, tag: ${tagName}`);
 


### PR DESCRIPTION
## Summary
- Elimina fechas de planificación (start/end dates) del modelo de sprints
- Adopta sizing simple/medio/grande en lugar de estimaciones temporales
- Timestamps (`started_at`, `closed_at`) solo se usan en ejecución, no en planificación

Closes #1643

🤖 Generated with [Claude Code](https://claude.com/claude-code)