### PR TITLE
feat(hooks): sanitización UTF-8 en envío de reportes a Telegram

### DIFF
--- a/.claude/hooks/commander/telegram-api.js
+++ b/.claude/hooks/commander/telegram-api.js
@@ -5,6 +5,7 @@
 
 const https = require("https");
 const { registerMessage } = require("../telegram-message-registry");
+const { sanitizeHtml } = require("../telegram-sanitizer");
 
 // ─── Constantes ──────────────────────────────────────────────────────────────
 const TG_MSG_MAX = 4096;
@@ -58,9 +59,10 @@ function escHtml(s) {
 }
 
 async function sendMessage(text, parseMode) {
+    const sanitizedText = (parseMode || "HTML") === "HTML" ? sanitizeHtml(text) : text;
     const result = await telegramPost("sendMessage", {
         chat_id: _chatId,
-        text: text,
+        text: sanitizedText,
         parse_mode: parseMode || "HTML"
     }, 8000);
     if (result && result.message_id) {

--- a/.claude/hooks/notify-telegram.js
+++ b/.claude/hooks/notify-telegram.js
@@ -15,6 +15,7 @@ const path = require("path");
 const { readSessionContext } = require("./context-reader");
 const { resolveMainRepoRoot } = require("./permission-utils");
 const { registerMessage } = require("./telegram-message-registry");
+const { sanitizeHtml } = require("./telegram-sanitizer");
 
 const _tgCfg = JSON.parse(require("fs").readFileSync(require("path").join(__dirname, "telegram-config.json"), "utf8"));
 const BOT_TOKEN = _tgCfg.bot_token;
@@ -163,7 +164,7 @@ function sendTelegram(text, attempt, options) {
     return new Promise((resolve, reject) => {
         const params = {
             chat_id: CHAT_ID,
-            text: text,
+            text: sanitizeHtml(text),
             parse_mode: "HTML",
             disable_web_page_preview: true
         };
@@ -352,6 +353,7 @@ async function processInput() {
         if (screenshot && screenshot.length > 1000) {
             let caption = classification.emoji + " <b>" + escHtml(agent) + " \u2014 " + escHtml(displayTitle) + "</b>";
             if (contextLine) caption += "\n" + contextLine;
+            caption = sanitizeHtml(caption);
 
             for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
                 try {

--- a/.claude/hooks/telegram-client.js
+++ b/.claude/hooks/telegram-client.js
@@ -6,6 +6,7 @@
 const https = require("https");
 const fs = require("fs");
 const path = require("path");
+const { sanitizeHtml } = require("./telegram-sanitizer");
 
 const HOOKS_DIR = __dirname;
 const CONFIG_FILE = path.join(HOOKS_DIR, "telegram-config.json");
@@ -114,8 +115,9 @@ async function sendMessage(text, opts) {
     const chatId = opts.chatId || getChatId();
     if (!chatId) throw new Error("No chat_id configured");
 
-    // Truncar si excede límite de Telegram
-    const safeText = text.length > TG_MSG_MAX ? text.substring(0, TG_MSG_MAX - 20) + "\n\n…(truncado)" : text;
+    // Sanitizar UTF-8 y truncar si excede límite de Telegram
+    const sanitized = sanitizeHtml(text);
+    const safeText = sanitized.length > TG_MSG_MAX ? sanitized.substring(0, TG_MSG_MAX - 20) + "\n\n…(truncado)" : sanitized;
 
     const params = {
         chat_id: chatId,
@@ -141,7 +143,7 @@ async function editMessage(messageId, text, opts) {
     const params = {
         chat_id: chatId,
         message_id: messageId,
-        text: text,
+        text: sanitizeHtml(text),
         parse_mode: "HTML"
     };
     if (opts.replyMarkup) params.reply_markup = opts.replyMarkup;
@@ -160,15 +162,16 @@ function sendPhoto(imageBuffer, caption, opts) {
     const chatId = opts.chatId || getChatId();
     const token = getBotToken();
     if (!token || !chatId) return Promise.reject(new Error("No bot_token or chat_id"));
+    const safeCaption = caption ? sanitizeHtml(caption) : caption;
 
     return new Promise((resolve, reject) => {
         const boundary = "----TgClient" + Date.now();
         let body = "";
         body += "--" + boundary + "\r\n";
         body += "Content-Disposition: form-data; name=\"chat_id\"\r\n\r\n" + chatId + "\r\n";
-        if (caption) {
+        if (safeCaption) {
             body += "--" + boundary + "\r\n";
-            body += "Content-Disposition: form-data; name=\"caption\"\r\n\r\n" + caption + "\r\n";
+            body += "Content-Disposition: form-data; name=\"caption\"\r\n\r\n" + safeCaption + "\r\n";
             body += "--" + boundary + "\r\n";
             body += "Content-Disposition: form-data; name=\"parse_mode\"\r\n\r\nHTML\r\n";
         }
@@ -221,15 +224,16 @@ function sendDocument(fileBuffer, filename, caption, opts) {
     const chatId = opts.chatId || getChatId();
     const token = getBotToken();
     if (!token || !chatId) return Promise.reject(new Error("No bot_token or chat_id"));
+    const safeCaption = caption ? sanitizeHtml(caption) : caption;
 
     return new Promise((resolve, reject) => {
         const boundary = "----TgClient" + Date.now();
         let body = "";
         body += "--" + boundary + "\r\n";
         body += "Content-Disposition: form-data; name=\"chat_id\"\r\n\r\n" + chatId + "\r\n";
-        if (caption) {
+        if (safeCaption) {
             body += "--" + boundary + "\r\n";
-            body += "Content-Disposition: form-data; name=\"caption\"\r\n\r\n" + caption + "\r\n";
+            body += "Content-Disposition: form-data; name=\"caption\"\r\n\r\n" + safeCaption + "\r\n";
         }
         body += "--" + boundary + "\r\n";
         body += "Content-Disposition: form-data; name=\"document\"; filename=\"" + filename + "\"\r\nContent-Type: application/octet-stream\r\n\r\n";

--- a/.claude/hooks/telegram-sanitizer.js
+++ b/.claude/hooks/telegram-sanitizer.js
@@ -1,0 +1,175 @@
+// telegram-sanitizer.js — Sanitización UTF-8 para envío a la API de Telegram (#1637)
+// Limpia caracteres problemáticos que causan errores de encoding en la API
+// Pure Node.js — sin dependencias externas
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const LOG_FILE = path.join(__dirname, "hook-debug.log");
+
+function log(msg) {
+    try { fs.appendFileSync(LOG_FILE, "[" + new Date().toISOString() + "] TgSanitizer: " + msg + "\n"); } catch (e) {}
+}
+
+// ─── Caracteres problemáticos ────────────────────────────────────────────────
+
+// Surrogate halves sueltos — inválidos en UTF-8
+// High surrogate sin low surrogate, o low surrogate sin high surrogate
+const LONE_HIGH_SURROGATE_RE = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])/g;
+const LONE_LOW_SURROGATE_RE = /(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g;
+
+// Caracteres de control C0 (excepto \n \r \t que son válidos en Telegram)
+const CONTROL_CHARS_RE = /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g;
+
+// Caracteres de control C1 (U+0080..U+009F) — raramente intencionales
+const C1_CONTROL_RE = /[\u0080-\u009F]/g;
+
+// BOM (Byte Order Mark) y otros invisibles problemáticos
+const BOM_AND_SPECIALS_RE = /[\uFEFF\uFFFE\uFFFF]/g;
+
+// Zero-width characters que pueden corromper markdown de Telegram
+// (zero-width space, zero-width non-joiner, zero-width joiner, word joiner,
+//  left-to-right/right-to-left marks)
+const ZERO_WIDTH_RE = /[\u200B\u200C\u200D\u2060\u200E\u200F]/g;
+
+// Variation selectors (U+FE00..U+FE0F) — pueden causar rendering issues
+// pero son legítimos con emojis, así que solo los removemos si están sueltos
+// (no precedidos por un emoji base)
+const VARIATION_SELECTOR_RE = /(?<![^\u0000-\u00FF\u2000-\u3300\uD800-\uDBFF])[\uFE00-\uFE0F]/g;
+
+// ─── Función principal ──────────────────────────────────────────────────────
+
+/**
+ * Sanitiza un texto para envío seguro a la API de Telegram.
+ * Remueve caracteres que causan errores de encoding UTF-8 y otros problemas.
+ *
+ * @param {string} text - Texto a sanitizar
+ * @param {object} [opts] - Opciones: { logWarnings: boolean }
+ * @returns {string} Texto sanitizado
+ */
+function sanitize(text, opts) {
+    if (!text || typeof text !== "string") return text || "";
+
+    opts = opts || {};
+    const logWarnings = opts.logWarnings !== false; // default: true
+
+    let result = text;
+    let warnings = [];
+
+    // 1. Remover surrogates sueltos (causa principal de errores UTF-8)
+    const highMatches = result.match(LONE_HIGH_SURROGATE_RE);
+    const lowMatches = result.match(LONE_LOW_SURROGATE_RE);
+    if (highMatches || lowMatches) {
+        const count = (highMatches ? highMatches.length : 0) + (lowMatches ? lowMatches.length : 0);
+        warnings.push("surrogates sueltos: " + count);
+        result = result.replace(LONE_HIGH_SURROGATE_RE, "\uFFFD");
+        result = result.replace(LONE_LOW_SURROGATE_RE, "\uFFFD");
+    }
+
+    // 2. Remover caracteres de control C0 (excepto \n, \r, \t)
+    const controlMatches = result.match(CONTROL_CHARS_RE);
+    if (controlMatches) {
+        warnings.push("chars control C0: " + controlMatches.length);
+        result = result.replace(CONTROL_CHARS_RE, "");
+    }
+
+    // 3. Remover caracteres de control C1
+    const c1Matches = result.match(C1_CONTROL_RE);
+    if (c1Matches) {
+        warnings.push("chars control C1: " + c1Matches.length);
+        result = result.replace(C1_CONTROL_RE, "");
+    }
+
+    // 4. Remover BOM y caracteres especiales inválidos
+    const bomMatches = result.match(BOM_AND_SPECIALS_RE);
+    if (bomMatches) {
+        warnings.push("BOM/specials: " + bomMatches.length);
+        result = result.replace(BOM_AND_SPECIALS_RE, "");
+    }
+
+    // 5. Remover zero-width characters problemáticos
+    const zwMatches = result.match(ZERO_WIDTH_RE);
+    if (zwMatches) {
+        warnings.push("zero-width chars: " + zwMatches.length);
+        result = result.replace(ZERO_WIDTH_RE, "");
+    }
+
+    // 6. Normalizar line endings (CRLF → LF)
+    if (result.includes("\r\n")) {
+        result = result.replace(/\r\n/g, "\n");
+    }
+    // Remover \r sueltos (sin \n)
+    if (result.includes("\r")) {
+        result = result.replace(/\r/g, "\n");
+    }
+
+    // 7. Colapsar líneas vacías excesivas (más de 2 seguidas)
+    result = result.replace(/\n{4,}/g, "\n\n\n");
+
+    // Log warnings si se detectaron problemas
+    if (logWarnings && warnings.length > 0) {
+        log("WARNING sanitización requerida — " + warnings.join(", ") +
+            " — primeros 100 chars del input: " + text.substring(0, 100).replace(/[\n\r]/g, "\\n"));
+    }
+
+    return result;
+}
+
+/**
+ * Sanitiza texto HTML para Telegram.
+ * Además de la sanitización base, asegura que los tags HTML estén balanceados.
+ *
+ * @param {string} html - Texto HTML a sanitizar
+ * @param {object} [opts] - Opciones: { logWarnings: boolean }
+ * @returns {string} HTML sanitizado
+ */
+function sanitizeHtml(html, opts) {
+    if (!html || typeof html !== "string") return html || "";
+
+    // Primero sanitizar caracteres problemáticos
+    let result = sanitize(html, opts);
+
+    // Reparar tags HTML rotos por la sanitización
+    // Telegram soporta: b, strong, i, em, u, ins, s, strike, del, a, code, pre
+    const supportedTags = ["b", "strong", "i", "em", "u", "ins", "s", "strike", "del", "a", "code", "pre"];
+
+    // Verificar tags abiertos sin cerrar
+    for (const tag of supportedTags) {
+        const openRe = new RegExp("<" + tag + "(\\s[^>]*)?>", "gi");
+        const closeRe = new RegExp("</" + tag + ">", "gi");
+        const opens = (result.match(openRe) || []).length;
+        const closes = (result.match(closeRe) || []).length;
+
+        if (opens > closes) {
+            // Agregar tags de cierre faltantes al final
+            for (let i = 0; i < opens - closes; i++) {
+                result += "</" + tag + ">";
+            }
+        }
+    }
+
+    return result;
+}
+
+/**
+ * Verifica si un texto necesita sanitización (sin modificarlo).
+ *
+ * @param {string} text - Texto a verificar
+ * @returns {boolean} true si el texto contiene caracteres problemáticos
+ */
+function needsSanitization(text) {
+    if (!text || typeof text !== "string") return false;
+    return LONE_HIGH_SURROGATE_RE.test(text) ||
+           LONE_LOW_SURROGATE_RE.test(text) ||
+           CONTROL_CHARS_RE.test(text) ||
+           C1_CONTROL_RE.test(text) ||
+           BOM_AND_SPECIALS_RE.test(text) ||
+           ZERO_WIDTH_RE.test(text);
+}
+
+module.exports = {
+    sanitize,
+    sanitizeHtml,
+    needsSanitization
+};

--- a/.claude/hooks/tests/test-telegram-sanitizer.js
+++ b/.claude/hooks/tests/test-telegram-sanitizer.js
@@ -1,0 +1,212 @@
+// Test: telegram-sanitizer.js — Sanitización UTF-8 para Telegram (#1637)
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+
+const { sanitize, sanitizeHtml, needsSanitization } = require("../telegram-sanitizer");
+
+describe("telegram-sanitizer: sanitize()", () => {
+    it("retorna string vacío para null/undefined", () => {
+        assert.equal(sanitize(null), "");
+        assert.equal(sanitize(undefined), "");
+        assert.equal(sanitize(""), "");
+    });
+
+    it("no modifica texto limpio ASCII", () => {
+        const text = "Hello world! This is a test 123.";
+        assert.equal(sanitize(text), text);
+    });
+
+    it("no modifica texto con emojis válidos", () => {
+        const text = "Estado: \u2705 OK \ud83d\ude80 Deploy exitoso \ud83d\udcca";
+        assert.equal(sanitize(text), text);
+    });
+
+    it("no modifica texto con caracteres españoles válidos", () => {
+        const text = "Implementación exitosa — configuración actualizada ñ á é í ó ú";
+        assert.equal(sanitize(text), text);
+    });
+
+    it("preserva \\n, \\r\\n y \\t", () => {
+        const text = "Línea 1\nLínea 2\tcon tab";
+        assert.equal(sanitize(text), text);
+    });
+
+    it("remueve caracteres de control C0 (excepto \\n, \\r, \\t)", () => {
+        const text = "Hola\x00mundo\x01test\x07bell";
+        const result = sanitize(text, { logWarnings: false });
+        assert.equal(result, "Holamundotestbell");
+    });
+
+    it("remueve NULL byte (\\u0000)", () => {
+        const text = "texto\u0000con\u0000nulls";
+        const result = sanitize(text, { logWarnings: false });
+        assert.equal(result, "textoconnulls");
+    });
+
+    it("remueve caracteres de control C1", () => {
+        const text = "texto\u0085con\u008Dcontrol\u009F";
+        const result = sanitize(text, { logWarnings: false });
+        assert.equal(result, "textoconcontrol");
+    });
+
+    it("remueve BOM (U+FEFF)", () => {
+        const text = "\uFEFFtexto con BOM";
+        const result = sanitize(text, { logWarnings: false });
+        assert.equal(result, "texto con BOM");
+    });
+
+    it("remueve U+FFFE y U+FFFF", () => {
+        const text = "texto\uFFFE\uFFFFfin";
+        const result = sanitize(text, { logWarnings: false });
+        assert.equal(result, "textofin");
+    });
+
+    it("remueve zero-width spaces", () => {
+        const text = "texto\u200Bcon\u200Czero\u200Dwidth";
+        const result = sanitize(text, { logWarnings: false });
+        assert.equal(result, "textoconzerowidth");
+    });
+
+    it("remueve word joiner (U+2060)", () => {
+        const text = "texto\u2060junto";
+        const result = sanitize(text, { logWarnings: false });
+        assert.equal(result, "textojunto");
+    });
+
+    it("remueve LTR/RTL marks", () => {
+        const text = "texto\u200Econ\u200Fmarks";
+        const result = sanitize(text, { logWarnings: false });
+        assert.equal(result, "textoconmarks");
+    });
+
+    it("normaliza CRLF a LF", () => {
+        const text = "línea 1\r\nlínea 2\r\nlínea 3";
+        const result = sanitize(text, { logWarnings: false });
+        assert.equal(result, "línea 1\nlínea 2\nlínea 3");
+    });
+
+    it("normaliza \\r sueltos a \\n", () => {
+        const text = "línea 1\rlínea 2";
+        const result = sanitize(text, { logWarnings: false });
+        assert.equal(result, "línea 1\nlínea 2");
+    });
+
+    it("colapsa más de 3 líneas vacías consecutivas", () => {
+        const text = "párrafo 1\n\n\n\n\n\npárrafo 2";
+        const result = sanitize(text, { logWarnings: false });
+        assert.equal(result, "párrafo 1\n\n\npárrafo 2");
+    });
+
+    it("maneja múltiples problemas combinados", () => {
+        const text = "\uFEFF\x00Hola\u200B\u0085mundo\r\ntest";
+        const result = sanitize(text, { logWarnings: false });
+        assert.equal(result, "Holamundo\ntest");
+    });
+
+    it("no modifica markdown de Telegram válido", () => {
+        const text = "<b>negrita</b> <i>cursiva</i> <code>código</code>";
+        assert.equal(sanitize(text), text);
+    });
+});
+
+describe("telegram-sanitizer: sanitizeHtml()", () => {
+    it("sanitiza caracteres problemáticos en HTML", () => {
+        const html = "<b>Hola\x00mundo</b>";
+        const result = sanitizeHtml(html, { logWarnings: false });
+        assert.equal(result, "<b>Holamundo</b>");
+    });
+
+    it("cierra tags HTML huérfanos", () => {
+        const html = "<b>texto sin cerrar";
+        const result = sanitizeHtml(html, { logWarnings: false });
+        assert.ok(result.includes("</b>"), "Debería cerrar el tag <b>");
+    });
+
+    it("cierra múltiples tags huérfanos", () => {
+        const html = "<b><i>texto";
+        const result = sanitizeHtml(html, { logWarnings: false });
+        assert.ok(result.includes("</b>"), "Debería cerrar <b>");
+        assert.ok(result.includes("</i>"), "Debería cerrar <i>");
+    });
+
+    it("no agrega tags extra si ya están balanceados", () => {
+        const html = "<b>ok</b> <i>ok</i>";
+        const result = sanitizeHtml(html, { logWarnings: false });
+        assert.equal(result, html);
+    });
+
+    it("maneja tags con atributos (ej: <a href>)", () => {
+        const html = '<a href="https://example.com">link';
+        const result = sanitizeHtml(html, { logWarnings: false });
+        assert.ok(result.includes("</a>"), "Debería cerrar <a>");
+    });
+
+    it("retorna string vacío para null", () => {
+        assert.equal(sanitizeHtml(null), "");
+        assert.equal(sanitizeHtml(undefined), "");
+    });
+
+    it("maneja HTML con emojis y caracteres especiales", () => {
+        const html = "<b>\u2705 Deploy exitoso</b>\n\ud83d\udcca <i>Métricas</i>";
+        const result = sanitizeHtml(html, { logWarnings: false });
+        assert.equal(result, html);
+    });
+});
+
+describe("telegram-sanitizer: needsSanitization()", () => {
+    it("retorna false para texto limpio", () => {
+        assert.equal(needsSanitization("Hello world"), false);
+    });
+
+    it("retorna false para null/undefined", () => {
+        assert.equal(needsSanitization(null), false);
+        assert.equal(needsSanitization(undefined), false);
+    });
+
+    it("retorna true para texto con NULL byte", () => {
+        assert.equal(needsSanitization("hola\x00mundo"), true);
+    });
+
+    it("retorna true para texto con BOM", () => {
+        assert.equal(needsSanitization("\uFEFFtexto"), true);
+    });
+
+    it("retorna true para texto con zero-width chars", () => {
+        assert.equal(needsSanitization("texto\u200Btest"), true);
+    });
+
+    it("retorna true para texto con control C1", () => {
+        assert.equal(needsSanitization("texto\u0085test"), true);
+    });
+
+    it("retorna false para texto con emojis válidos", () => {
+        assert.equal(needsSanitization("\u2705 OK \ud83d\ude80"), false);
+    });
+
+    it("retorna false para texto con acentos españoles", () => {
+        assert.equal(needsSanitization("Implementación exitosa ñ á é"), false);
+    });
+});
+
+describe("telegram-sanitizer: integración con telegram-client", () => {
+    it("telegram-client.js importa telegram-sanitizer", () => {
+        const fs = require("fs");
+        const path = require("path");
+        const src = fs.readFileSync(path.join(__dirname, "..", "telegram-client.js"), "utf8");
+        assert.ok(src.includes('require("./telegram-sanitizer")'), "telegram-client debería importar telegram-sanitizer");
+    });
+
+    it("commander/telegram-api.js importa telegram-sanitizer", () => {
+        const fs = require("fs");
+        const path = require("path");
+        const src = fs.readFileSync(path.join(__dirname, "..", "commander", "telegram-api.js"), "utf8");
+        assert.ok(src.includes('require("../telegram-sanitizer")'), "telegram-api debería importar telegram-sanitizer");
+    });
+
+    it("notify-telegram.js importa telegram-sanitizer", () => {
+        const fs = require("fs");
+        const path = require("path");
+        const src = fs.readFileSync(path.join(__dirname, "..", "notify-telegram.js"), "utf8");
+        assert.ok(src.includes('require("./telegram-sanitizer")'), "notify-telegram debería importar telegram-sanitizer");
+    });
+});


### PR DESCRIPTION
## Summary
- Módulo `telegram-sanitizer.js` reutilizable con sanitize/sanitizeHtml/needsSanitization
- Integrado en los 3 puntos de envío: telegram-client.js, commander/telegram-api.js, notify-telegram.js
- Limpia surrogates huérfanos, caracteres de control, BOM, zero-width chars, normaliza line endings
- 36 tests unitarios cubriendo todos los edge cases

Closes #1637

🤖 Generated with [Claude Code](https://claude.com/claude-code)