### PR TITLE
feat(backend): paginación y filtrado para endpoint de productos publicados

### DIFF
--- a/backend/src/main/kotlin/ar/com/intrale/Application.kt
+++ b/backend/src/main/kotlin/ar/com/intrale/Application.kt
@@ -85,12 +85,16 @@ private fun Route.registerDynamicHandler(httpMethod: HttpMethod) {
                 else -> null
             }
 
+            val queryParams = call.request.queryParameters.entries().associate {
+                "X-Query-${it.key}" to it.value.joinToString(",")
+            }
+
             val headers: Map<String, String> = call.request.headers.entries().associate {
                 it.key to it.value.joinToString(",")
             } + mapOf(
                 "X-Http-Method" to httpMethod.value,
                 "X-Function-Path" to functionPath
-            )
+            ) + queryParams
 
             val functionResponse: Response = when {
                 businessName == null -> RequestValidationException("No business defined on path")

--- a/backend/src/main/kotlin/ar/com/intrale/LambdaRequestHandler.kt
+++ b/backend/src/main/kotlin/ar/com/intrale/LambdaRequestHandler.kt
@@ -111,10 +111,13 @@ abstract class LambdaRequestHandler  : RequestHandler<APIGatewayProxyRequestEven
                                     } else {
                                         logger.info("Request body not found")
                                     }
+                                    val queryParams = (requestEvent.queryStringParameters ?: emptyMap()).map {
+                                        "X-Query-${it.key}" to it.value
+                                    }.toMap()
                                     val headers = (requestEvent.headers ?: emptyMap()) + mapOf(
                                         "X-Http-Method" to httpMethod,
                                         "X-Function-Path" to functionPath
-                                    )
+                                    ) + queryParams
                                     function.execute(
                                         businessName,
                                         functionPath,

--- a/users/src/main/kotlin/ar/com/intrale/ClientProductResponse.kt
+++ b/users/src/main/kotlin/ar/com/intrale/ClientProductResponse.kt
@@ -12,8 +12,16 @@ data class ClientProductPayload(
     val stockQuantity: Int? = null
 )
 
+data class PaginationMetadata(
+    val total: Int,
+    val offset: Int,
+    val limit: Int,
+    val hasMore: Boolean
+)
+
 class ClientProductListResponse(
     val products: List<ClientProductPayload>,
+    val pagination: PaginationMetadata? = null,
     status: HttpStatusCode = HttpStatusCode.OK,
     headers: Map<String, String> = emptyMap()
 ) : Response(statusCode = status, responseHeaders = headers)

--- a/users/src/main/kotlin/ar/com/intrale/ClientProducts.kt
+++ b/users/src/main/kotlin/ar/com/intrale/ClientProducts.kt
@@ -13,6 +13,12 @@ class ClientProducts(
     override val jwtValidator: JwtValidator = CognitoJwtValidator(config)
 ) : SecuredFunction(config = config, logger = logger, jwtValidator = jwtValidator) {
 
+    companion object {
+        const val DEFAULT_OFFSET = 0
+        const val DEFAULT_LIMIT = 20
+        const val MAX_LIMIT = 100
+    }
+
     private val gson = Gson()
 
     override suspend fun securedExecute(
@@ -27,11 +33,24 @@ class ClientProducts(
             return RequestValidationException("Metodo no soportado: $method")
         }
 
-        logger.debug("Consultando productos publicados para negocio=$business")
-        val products = productRepository.listPublishedProducts(business)
-        logger.debug("Productos publicados encontrados: ${products.size} en negocio=$business")
+        val offset = headers["X-Query-offset"]?.toIntOrNull()?.coerceAtLeast(0) ?: DEFAULT_OFFSET
+        val limit = headers["X-Query-limit"]?.toIntOrNull()?.coerceIn(1, MAX_LIMIT) ?: DEFAULT_LIMIT
+        val category = headers["X-Query-category"]
+        val search = headers["X-Query-search"]
 
-        val payloads = products.map { it.toClientPayload() }
+        logger.debug("Consultando productos publicados para negocio=$business offset=$offset limit=$limit category=$category search=$search")
+
+        val result = productRepository.listPublishedProductsPaginated(
+            business = business,
+            offset = offset,
+            limit = limit,
+            category = category,
+            search = search
+        )
+
+        logger.debug("Productos publicados encontrados: ${result.total} en negocio=$business (pagina: ${result.items.size} items)")
+
+        val payloads = result.items.map { it.toClientPayload() }
         val etag = computeETag(payloads)
 
         val ifNoneMatch = headers["If-None-Match"]
@@ -42,6 +61,12 @@ class ClientProducts(
 
         return ClientProductListResponse(
             products = payloads,
+            pagination = PaginationMetadata(
+                total = result.total,
+                offset = result.offset,
+                limit = result.limit,
+                hasMore = result.hasMore
+            ),
             status = HttpStatusCode.OK,
             headers = mapOf("ETag" to etag)
         )
@@ -51,6 +76,6 @@ class ClientProducts(
         val json = gson.toJson(products)
         val digest = MessageDigest.getInstance("MD5")
         val hash = digest.digest(json.toByteArray(Charsets.UTF_8))
-        return "\"${hash.joinToString("") { "%02x".format(it) }}\""
+        return "\"" + hash.joinToString("") { "%02x".format(it) } + "\""
     }
 }

--- a/users/src/main/kotlin/ar/com/intrale/ProductRepository.kt
+++ b/users/src/main/kotlin/ar/com/intrale/ProductRepository.kt
@@ -48,4 +48,47 @@ class ProductRepository {
     fun deleteProduct(business: String, productId: String): Boolean {
         return products.remove(key(business, productId)) != null
     }
+
+    fun listPublishedProductsPaginated(
+        business: String,
+        offset: Int = 0,
+        limit: Int = 20,
+        category: String? = null,
+        search: String? = null
+    ): PaginatedResult<ProductRecord> {
+        var filtered = products.values.filter {
+            it.businessId == business.lowercase() && it.status.uppercase() == "PUBLISHED"
+        }
+
+        if (!category.isNullOrBlank()) {
+            filtered = filtered.filter { it.categoryId.equals(category, ignoreCase = true) }
+        }
+
+        if (!search.isNullOrBlank()) {
+            val searchLower = search.lowercase()
+            filtered = filtered.filter { it.name.lowercase().contains(searchLower) }
+        }
+
+        val total = filtered.size
+        val sortedList = filtered.sortedBy { it.name }
+        val paged = sortedList.drop(offset).take(limit).map { it.copy() }
+        val hasMore = offset + limit < total
+
+        return PaginatedResult(
+            items = paged,
+            total = total,
+            offset = offset,
+            limit = limit,
+            hasMore = hasMore
+        )
+    }
+
 }
+
+data class PaginatedResult<T>(
+    val items: List<T>,
+    val total: Int,
+    val offset: Int,
+    val limit: Int,
+    val hasMore: Boolean
+)

--- a/users/src/test/kotlin/ar/com/intrale/ClientProductsTest.kt
+++ b/users/src/test/kotlin/ar/com/intrale/ClientProductsTest.kt
@@ -6,6 +6,8 @@ import kotlinx.coroutines.runBlocking
 import org.slf4j.helpers.NOPLogger
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class ClientProductsTest {
@@ -27,7 +29,8 @@ class ClientProductsTest {
         business: String = "la-carne",
         name: String,
         status: String = "DRAFT",
-        basePrice: Double = 1000.0
+        basePrice: Double = 1000.0,
+        categoryId: String = "cat-1"
     ): ProductRecord {
         return productRepository.saveProduct(
             business,
@@ -35,7 +38,7 @@ class ClientProductsTest {
                 name = name,
                 basePrice = basePrice,
                 unit = "kg",
-                categoryId = "cat-1",
+                categoryId = categoryId,
                 status = status,
                 isAvailable = true
             )
@@ -56,6 +59,9 @@ class ClientProductsTest {
         assertTrue(response is ClientProductListResponse)
         assertEquals(HttpStatusCode.OK, response.statusCode)
         assertTrue(response.products.isEmpty())
+        assertNotNull(response.pagination)
+        assertEquals(0, response.pagination!!.total)
+        assertFalse(response.pagination!!.hasMore)
     }
 
     @Test
@@ -75,6 +81,7 @@ class ClientProductsTest {
         assertEquals(1, response.products.size)
         assertEquals("Chorizo colorado", response.products.first().name)
         assertEquals("PUBLISHED", response.products.first().status)
+        assertEquals(1, response.pagination!!.total)
     }
 
     @Test
@@ -172,6 +179,8 @@ class ClientProductsTest {
 
         assertTrue(response is RequestValidationException)
     }
+
+    // --- Tests de ETag ---
 
     @Test
     fun `GET retorna header ETag en la respuesta`() = runBlocking {
@@ -289,5 +298,199 @@ class ClientProductsTest {
         val etag1 = function.computeETag(payloads)
         val etag2 = function.computeETag(payloads)
         assertEquals(etag1, etag2, "computeETag debe ser determinista")
+    }
+
+    // --- Tests de paginacion ---
+
+    @Test
+    fun `GET con offset y limit pagina correctamente`() = runBlocking {
+        for (i in 1..5) {
+            seedProduct(name = "Producto $i", status = "PUBLISHED", basePrice = i * 100.0)
+        }
+
+        val response = function.securedExecute(
+            business = "la-carne",
+            function = "products",
+            headers = mapOf(
+                "Authorization" to token,
+                "X-Http-Method" to "GET",
+                "X-Query-offset" to "0",
+                "X-Query-limit" to "2"
+            ),
+            textBody = ""
+        ) as ClientProductListResponse
+
+        assertEquals(2, response.products.size)
+        assertEquals(5, response.pagination!!.total)
+        assertEquals(0, response.pagination!!.offset)
+        assertEquals(2, response.pagination!!.limit)
+        assertTrue(response.pagination!!.hasMore)
+    }
+
+    @Test
+    fun `GET con offset avanzado retorna pagina siguiente`() = runBlocking {
+        for (i in 1..5) {
+            seedProduct(name = "Producto $i", status = "PUBLISHED", basePrice = i * 100.0)
+        }
+
+        val response = function.securedExecute(
+            business = "la-carne",
+            function = "products",
+            headers = mapOf(
+                "Authorization" to token,
+                "X-Http-Method" to "GET",
+                "X-Query-offset" to "3",
+                "X-Query-limit" to "2"
+            ),
+            textBody = ""
+        ) as ClientProductListResponse
+
+        assertEquals(2, response.products.size)
+        assertEquals(5, response.pagination!!.total)
+        assertEquals(3, response.pagination!!.offset)
+        assertFalse(response.pagination!!.hasMore)
+    }
+
+    @Test
+    fun `GET con offset mayor al total retorna lista vacia`() = runBlocking {
+        seedProduct(name = "Unico producto", status = "PUBLISHED")
+
+        val response = function.securedExecute(
+            business = "la-carne",
+            function = "products",
+            headers = mapOf(
+                "Authorization" to token,
+                "X-Http-Method" to "GET",
+                "X-Query-offset" to "100",
+                "X-Query-limit" to "20"
+            ),
+            textBody = ""
+        ) as ClientProductListResponse
+
+        assertTrue(response.products.isEmpty())
+        assertEquals(1, response.pagination!!.total)
+        assertFalse(response.pagination!!.hasMore)
+    }
+
+    // --- Tests de filtro por categoria ---
+
+    @Test
+    fun `GET con filtro de categoria retorna solo productos de esa categoria`() = runBlocking {
+        seedProduct(name = "Asado", status = "PUBLISHED", categoryId = "carnes")
+        seedProduct(name = "Lechuga", status = "PUBLISHED", categoryId = "verduras")
+        seedProduct(name = "Chorizo", status = "PUBLISHED", categoryId = "carnes")
+
+        val response = function.securedExecute(
+            business = "la-carne",
+            function = "products",
+            headers = mapOf(
+                "Authorization" to token,
+                "X-Http-Method" to "GET",
+                "X-Query-category" to "carnes"
+            ),
+            textBody = ""
+        ) as ClientProductListResponse
+
+        assertEquals(2, response.products.size)
+        assertEquals(2, response.pagination!!.total)
+        assertTrue(response.products.all { it.name in listOf("Asado", "Chorizo") })
+    }
+
+    // --- Tests de busqueda por nombre ---
+
+    @Test
+    fun `GET con filtro de busqueda retorna productos que coinciden`() = runBlocking {
+        seedProduct(name = "Asado de tira", status = "PUBLISHED")
+        seedProduct(name = "Chorizo colorado", status = "PUBLISHED")
+        seedProduct(name = "Asado americano", status = "PUBLISHED")
+
+        val response = function.securedExecute(
+            business = "la-carne",
+            function = "products",
+            headers = mapOf(
+                "Authorization" to token,
+                "X-Http-Method" to "GET",
+                "X-Query-search" to "asado"
+            ),
+            textBody = ""
+        ) as ClientProductListResponse
+
+        assertEquals(2, response.products.size)
+        assertEquals(2, response.pagination!!.total)
+        assertTrue(response.products.all { it.name.contains("Asado", ignoreCase = true) })
+    }
+
+    @Test
+    fun `GET con filtros combinados de categoria y busqueda`() = runBlocking {
+        seedProduct(name = "Asado de tira", status = "PUBLISHED", categoryId = "carnes")
+        seedProduct(name = "Asado vegano", status = "PUBLISHED", categoryId = "vegano")
+        seedProduct(name = "Chorizo", status = "PUBLISHED", categoryId = "carnes")
+
+        val response = function.securedExecute(
+            business = "la-carne",
+            function = "products",
+            headers = mapOf(
+                "Authorization" to token,
+                "X-Http-Method" to "GET",
+                "X-Query-category" to "carnes",
+                "X-Query-search" to "asado"
+            ),
+            textBody = ""
+        ) as ClientProductListResponse
+
+        assertEquals(1, response.products.size)
+        assertEquals("Asado de tira", response.products.first().name)
+    }
+
+    @Test
+    fun `GET valores por defecto de paginacion cuando no se especifican`() = runBlocking {
+        seedProduct(name = "Producto test", status = "PUBLISHED")
+
+        val response = function.securedExecute(
+            business = "la-carne",
+            function = "products",
+            headers = mapOf("Authorization" to token, "X-Http-Method" to "GET"),
+            textBody = ""
+        ) as ClientProductListResponse
+
+        assertNotNull(response.pagination)
+        assertEquals(0, response.pagination!!.offset)
+        assertEquals(ClientProducts.DEFAULT_LIMIT, response.pagination!!.limit)
+    }
+
+    @Test
+    fun `GET con limit mayor al maximo se ajusta al maximo`() = runBlocking {
+        seedProduct(name = "Producto test", status = "PUBLISHED")
+
+        val response = function.securedExecute(
+            business = "la-carne",
+            function = "products",
+            headers = mapOf(
+                "Authorization" to token,
+                "X-Http-Method" to "GET",
+                "X-Query-limit" to "500"
+            ),
+            textBody = ""
+        ) as ClientProductListResponse
+
+        assertEquals(ClientProducts.MAX_LIMIT, response.pagination!!.limit)
+    }
+
+    @Test
+    fun `GET con offset negativo se ajusta a cero`() = runBlocking {
+        seedProduct(name = "Producto test", status = "PUBLISHED")
+
+        val response = function.securedExecute(
+            business = "la-carne",
+            function = "products",
+            headers = mapOf(
+                "Authorization" to token,
+                "X-Http-Method" to "GET",
+                "X-Query-offset" to "-5"
+            ),
+            textBody = ""
+        ) as ClientProductListResponse
+
+        assertEquals(0, response.pagination!!.offset)
     }
 }


### PR DESCRIPTION
## Summary
- Paginación con offset/limit (default 0/20, max 100)
- Filtros: por categoría y búsqueda por nombre
- PaginationMetadata en response (total, offset, limit, hasMore)
- Query params propagados vía headers X-Query-* (Ktor + Lambda)
- 16 tests (9 nuevos para paginación/filtros)

Closes #1635

🤖 Generated with [Claude Code](https://claude.com/claude-code)