### PR TITLE
feat(a11y): accesibilidad WCAG AA para Home dashboard (#1632)

### DIFF
--- a/app/composeApp/src/androidInstrumentedTest/kotlin/ui/sc/business/DashboardA11yTest.kt
+++ b/app/composeApp/src/androidInstrumentedTest/kotlin/ui/sc/business/DashboardA11yTest.kt
@@ -1,0 +1,61 @@
+package ui.sc.business
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.test.assertTrue
+import ui.util.RES_ERROR_PREFIX
+
+/**
+ * Verifica la semántica de accesibilidad (a11y) del Dashboard de negocio:
+ * headings marcados, live regions, sin textos de fallback visibles.
+ */
+@RunWith(AndroidJUnit4::class)
+class DashboardA11yTest {
+
+    @get:Rule
+    val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun `dashboard tiene al menos un nodo marcado como heading`() {
+        composeRule.setContent {
+            DashboardScreen().screen()
+        }
+
+        composeRule.waitForIdle()
+
+        val headingNodes = composeRule.onAllNodes(
+            SemanticsMatcher.keyIsDefined(SemanticsProperties.Heading)
+        ).fetchSemanticsNodes()
+
+        assertTrue(
+            headingNodes.isNotEmpty(),
+            "El Dashboard no tiene ningun nodo marcado como heading para lectores de pantalla."
+        )
+    }
+
+    @Test
+    fun `dashboard no expone textos de fallback a lectores de pantalla`() {
+        composeRule.setContent {
+            DashboardScreen().screen()
+        }
+
+        composeRule.waitForIdle()
+
+        val fallbackNodes = composeRule
+            .onAllNodesWithText(RES_ERROR_PREFIX, substring = true)
+            .fetchSemanticsNodes()
+
+        assertTrue(
+            fallbackNodes.isEmpty(),
+            "Se detectaron ${fallbackNodes.size} nodos con prefijo de fallback " +
+                "visibles para lectores de pantalla en el Dashboard."
+        )
+    }
+}

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/business/DashboardScreen.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/business/DashboardScreen.kt
@@ -29,6 +29,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
 import androidx.lifecycle.viewmodel.compose.viewModel
 import kotlinx.coroutines.launch
 import org.kodein.log.LoggerFactory
@@ -81,11 +85,13 @@ class DashboardScreen : Screen(DASHBOARD_PATH) {
             // Encabezado: nombre del negocio + subtítulo + descripción
             Text(
                 text = businessName,
-                style = MaterialTheme.typography.headlineMedium
+                style = MaterialTheme.typography.headlineMedium,
+                modifier = Modifier.semantics { heading() }
             )
             Text(
                 text = Txt(MessageKey.dashboard_admin_subtitle),
-                style = MaterialTheme.typography.titleMedium
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.semantics { heading() }
             )
             Text(
                 text = Txt(MessageKey.dashboard_manage_intro),
@@ -93,9 +99,15 @@ class DashboardScreen : Screen(DASHBOARD_PATH) {
             )
 
             if (uiState.isBusinessLoading) {
-                Text(text = Txt(MessageKey.dashboard_business_loading))
+                Text(
+                    text = Txt(MessageKey.dashboard_business_loading),
+                    modifier = Modifier.semantics { liveRegion = LiveRegionMode.Polite }
+                )
             } else if (uiState.businessError != null) {
-                Text(text = Txt(MessageKey.dashboard_business_error))
+                Text(
+                    text = Txt(MessageKey.dashboard_business_error),
+                    modifier = Modifier.semantics { liveRegion = LiveRegionMode.Polite }
+                )
             } else if (uiState.businesses.size > 1) {
                 var expanded by remember { mutableStateOf(false) }
                 val inputState = remember { mutableStateOf(InputState("businessSelector")) }
@@ -140,14 +152,23 @@ class DashboardScreen : Screen(DASHBOARD_PATH) {
     ) {
         when (state) {
             BusinessDashboardSummaryState.Loading -> {
-                Text(text = Txt(MessageKey.dashboard_summary_loading))
+                Text(
+                    text = Txt(MessageKey.dashboard_summary_loading),
+                    modifier = Modifier.semantics { liveRegion = LiveRegionMode.Polite }
+                )
             }
             BusinessDashboardSummaryState.MissingBusiness -> {
-                Text(text = Txt(MessageKey.dashboard_business_missing))
+                Text(
+                    text = Txt(MessageKey.dashboard_business_missing),
+                    modifier = Modifier.semantics { liveRegion = LiveRegionMode.Polite }
+                )
             }
             is BusinessDashboardSummaryState.Error -> {
                 Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.x1)) {
-                    Text(text = Txt(MessageKey.dashboard_summary_error))
+                    Text(
+                        text = Txt(MessageKey.dashboard_summary_error),
+                        modifier = Modifier.semantics { liveRegion = LiveRegionMode.Polite }
+                    )
                     TextButton(onClick = onRetry) {
                         Text(text = Txt(MessageKey.dashboard_summary_retry))
                     }
@@ -230,13 +251,24 @@ class DashboardScreen : Screen(DASHBOARD_PATH) {
                     .padding(MaterialTheme.spacing.x2),
                 verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.x1)
             ) {
-                Text(text = title, style = MaterialTheme.typography.titleMedium)
-                Text(
-                    text = description,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-                Text(text = metric, style = MaterialTheme.typography.bodySmall)
+                // Sección de información: título + descripción + métrica se fusionan para
+                // lectores de pantalla (TalkBack/VoiceOver), anunciándose como una sola unidad.
+                Column(
+                    modifier = Modifier.semantics(mergeDescendants = true) { },
+                    verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.x1)
+                ) {
+                    Text(
+                        text = title,
+                        style = MaterialTheme.typography.titleMedium,
+                        modifier = Modifier.semantics { heading() }
+                    )
+                    Text(
+                        text = description,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Text(text = metric, style = MaterialTheme.typography.bodySmall)
+                }
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.End

--- a/app/composeApp/src/commonTest/kotlin/ui/th/WcagContrastTest.kt
+++ b/app/composeApp/src/commonTest/kotlin/ui/th/WcagContrastTest.kt
@@ -1,0 +1,117 @@
+package ui.th
+
+import kotlin.math.pow
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Verifica que los pares de colores del tema Intrale usados en el Dashboard
+ * cumplan el ratio de contraste WCAG AA (mínimo 4.5:1 para texto normal).
+ *
+ * Referencia: https://www.w3.org/TR/WCAG21/#contrast-minimum
+ */
+class WcagContrastTest {
+
+    // ------------------------------------------------------------------
+    // Colores del tema (hexadecimal 0xAARRGGBB → solo tomamos RGB)
+    // ------------------------------------------------------------------
+
+    // Fondos
+    private val surfaceLight         = 0xFFF9F9FFL
+    private val backgroundLight      = 0xFFF9F9FFL
+
+    // Textos sobre superficie/fondo (light)
+    private val onSurfaceLight       = 0xFF191C20L
+    private val onSurfaceVariantLight = 0xFF44474EL
+    private val primaryLight         = 0xFF415F91L
+    private val onBackgroundLight    = 0xFF191C20L
+
+    // Textos sobre superficie (dark)
+    private val surfaceDark          = 0xFF111318L
+    private val onSurfaceDark        = 0xFFE2E2E9L
+    private val onSurfaceVariantDark  = 0xFFC4C6D0L
+    private val primaryDark          = 0xFFAAC7FFL
+
+    // ------------------------------------------------------------------
+    // Tests light theme
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `onSurface sobre surface (light) cumple WCAG AA`() {
+        val ratio = contrastRatio(onSurfaceLight, surfaceLight)
+        assertTrue(ratio >= 4.5, "onSurface/surface light: $ratio (esperado >= 4.5:1)")
+    }
+
+    @Test
+    fun `onBackground sobre background (light) cumple WCAG AA`() {
+        val ratio = contrastRatio(onBackgroundLight, backgroundLight)
+        assertTrue(ratio >= 4.5, "onBackground/background light: $ratio (esperado >= 4.5:1)")
+    }
+
+    @Test
+    fun `onSurfaceVariant sobre surface (light) cumple WCAG AA`() {
+        val ratio = contrastRatio(onSurfaceVariantLight, surfaceLight)
+        assertTrue(ratio >= 4.5, "onSurfaceVariant/surface light: $ratio (esperado >= 4.5:1)")
+    }
+
+    @Test
+    fun `primary sobre surface (light) cumple WCAG AA`() {
+        val ratio = contrastRatio(primaryLight, surfaceLight)
+        assertTrue(ratio >= 4.5, "primary/surface light: $ratio (esperado >= 4.5:1)")
+    }
+
+    // ------------------------------------------------------------------
+    // Tests dark theme
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `onSurface sobre surface (dark) cumple WCAG AA`() {
+        val ratio = contrastRatio(onSurfaceDark, surfaceDark)
+        assertTrue(ratio >= 4.5, "onSurface/surface dark: $ratio (esperado >= 4.5:1)")
+    }
+
+    @Test
+    fun `onSurfaceVariant sobre surface (dark) cumple WCAG AA`() {
+        val ratio = contrastRatio(onSurfaceVariantDark, surfaceDark)
+        assertTrue(ratio >= 4.5, "onSurfaceVariant/surface dark: $ratio (esperado >= 4.5:1)")
+    }
+
+    @Test
+    fun `primary sobre surface (dark) cumple WCAG AA`() {
+        val ratio = contrastRatio(primaryDark, surfaceDark)
+        assertTrue(ratio >= 4.5, "primary/surface dark: $ratio (esperado >= 4.5:1)")
+    }
+
+    // ------------------------------------------------------------------
+    // Utilidades WCAG
+    // ------------------------------------------------------------------
+
+    /**
+     * Calcula el ratio de contraste entre dos colores (foreground / background).
+     * Fórmula: (L1 + 0.05) / (L2 + 0.05) donde L1 >= L2.
+     */
+    private fun contrastRatio(fg: Long, bg: Long): Double {
+        val l1 = relativeLuminance(fg)
+        val l2 = relativeLuminance(bg)
+        val lighter = maxOf(l1, l2) + 0.05
+        val darker  = minOf(l1, l2) + 0.05
+        return lighter / darker
+    }
+
+    /**
+     * Luminancia relativa según WCAG 2.1.
+     * Extrae R, G, B del color en formato 0xFFRRGGBB.
+     */
+    private fun relativeLuminance(colorLong: Long): Double {
+        val r = ((colorLong shr 16) and 0xFF).toDouble() / 255.0
+        val g = ((colorLong shr 8)  and 0xFF).toDouble() / 255.0
+        val b = (colorLong          and 0xFF).toDouble() / 255.0
+        return 0.2126 * linearize(r) + 0.7152 * linearize(g) + 0.0722 * linearize(b)
+    }
+
+    /**
+     * Convierte canal sRGB a lineal según IEC 61966-2-1.
+     */
+    private fun linearize(c: Double): Double =
+        if (c <= 0.04045) c / 12.92 else ((c + 0.055) / 1.055).pow(2.4)
+}

--- a/scripts/Run-AgentStream.ps1
+++ b/scripts/Run-AgentStream.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Ejecuta claude en modo stream-json y muestra actividad en tiempo real.
 .DESCRIPTION
@@ -245,6 +245,8 @@ try {
     }
 
     # Diagnostico de muerte: registrar causa en el log
+    $diagToolCalls = $(if ($useRunner) { -1 } else { $toolCount })
+    $diagMessages = $(if ($useRunner) { -1 } else { $msgCount })
     $deathDiag = @{
         timestamp = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ss.fffZ')
         agent = $AgentNum
@@ -253,8 +255,8 @@ try {
         model = $Model
         exitCode = $exitCode
         pipelineMode = $pipelineMode
-        toolCalls = if ($useRunner) { -1 } else { $toolCount }
-        messages = if ($useRunner) { -1 } else { $msgCount }
+        toolCalls = $diagToolCalls
+        messages = $diagMessages
         hasStderr = [bool]$stderrOutput
     }
     $diagJson = $deathDiag | ConvertTo-Json -Compress


### PR DESCRIPTION
## Summary
- Headings semanticos en nombre del negocio, subtitulo y titulos de cards
- Live regions para estados de carga, error y ausencia de datos
- mergeDescendants en secciones info de DashboardActionCard
- Test de contraste WCAG AA (ratio >= 4.5:1) light/dark
- Test instrumentado de a11y

Closes #1632