### PR TITLE
fix(scripts): eliminar falso positivo de rate limit en Start-Agente.ps1 (#1682)

### DIFF
--- a/scripts/Run-AgentStream.ps1
+++ b/scripts/Run-AgentStream.ps1
@@ -127,13 +127,27 @@ try {
         while (-not $process.StandardOutput.EndOfStream) {
             $line = $process.StandardOutput.ReadLine()
             if (-not $line) { continue }
-            $line | Out-File -FilePath $LogFile -Encoding utf8 -Append
+            # Usar AppendAllText para evitar IOException por file lock cuando otro proceso tiene el log abierto
+            $retries = 3
+            while ($retries -gt 0) {
+                try {
+                    [System.IO.File]::AppendAllText($LogFile, $line + "`n", [System.Text.Encoding]::UTF8)
+                    break
+                } catch {
+                    $retries--
+                    if ($retries -gt 0) { Start-Sleep -Milliseconds 100 }
+                }
+            }
             Write-Host "  $line" -ForegroundColor Gray
         }
 
         $stderrOutput = $process.StandardError.ReadToEnd()
         if ($stderrOutput) {
-            $stderrOutput | Out-File -FilePath $LogFile -Encoding utf8 -Append
+            try {
+                [System.IO.File]::AppendAllText($LogFile, $stderrOutput, [System.Text.Encoding]::UTF8)
+            } catch {
+                Write-Host "  WARN: No se pudo escribir stderr al log: $_" -ForegroundColor DarkYellow
+            }
         }
 
         $process.WaitForExit()

--- a/scripts/Start-Agente.ps1
+++ b/scripts/Start-Agente.ps1
@@ -570,11 +570,38 @@ function Start-UnAgenteConRetry {
         # Proceso termino prematuramente — revisar si fue por rate limit
         $logFile = Join-Path $PSScriptRoot "logs\agente_$($Agente.numero).log"
         $isRateLimit = $false
+        $realCause = "desconocida"
         if (Test-Path $logFile) {
-            $logContent = Get-Content $logFile -Raw -ErrorAction SilentlyContinue
-            if ($logContent -match 'rate.?limit|hit.?your.?limit|You have hit|Claude.ai/api') {
-                $isRateLimit = $true
+            # Parsear JSON line por line para detectar rate limit real (status != "allowed")
+            # Evita falsos positivos: Claude siempre emite rate_limit_event con status="allowed" al inicio
+            foreach ($line in (Get-Content $logFile -ErrorAction SilentlyContinue)) {
+                try {
+                    $evt = $line | ConvertFrom-Json -ErrorAction Stop
+                    if ($evt.type -eq 'rate_limit_event' -and $evt.rate_limit_info.status -ne 'allowed') {
+                        $isRateLimit = $true
+                        $realCause = "rate_limit (status=$($evt.rate_limit_info.status), type=$($evt.rate_limit_info.rateLimitType))"
+                        break
+                    }
+                } catch { }
             }
+            # Fallback: detectar errores HTTP 429 explícitos en texto plano
+            if (-not $isRateLimit) {
+                $logContent = Get-Content $logFile -Raw -ErrorAction SilentlyContinue
+                if ($logContent -match 'HTTP 429|rate limit reached|You have hit your rate limit') {
+                    $isRateLimit = $true
+                    $realCause = "rate_limit (HTTP 429 o mensaje explícito)"
+                }
+            }
+        }
+
+        # Diagnosticar causa real cuando NO es rate limit
+        if (-not $isRateLimit) {
+            $exitCodeInfo = if ($proc.HasExited) { "exit_code=$($proc.ExitCode)" } else { "proceso_vivo" }
+            $lastLines = if (Test-Path $logFile) {
+                (Get-Content $logFile -ErrorAction SilentlyContinue | Select-Object -Last 5) -join " | "
+            } else { "(sin log)" }
+            $realCause = "$exitCodeInfo | ultimas_lineas: $lastLines"
+            Write-Host ">> Causa real de muerte: $realCause" -ForegroundColor DarkYellow
         }
 
         if (-not $isRateLimit) {
@@ -583,11 +610,11 @@ function Start-UnAgenteConRetry {
         }
 
         if ($attempt -ge $MaxRetries) {
-            Write-Host ">> Agente $($Agente.numero) fallo tras $MaxRetries intento(s) por rate limit." -ForegroundColor Red
+            Write-Host ">> Agente $($Agente.numero) fallo tras $MaxRetries intento(s) por rate limit ($realCause)." -ForegroundColor Red
             return $null
         }
 
-        Write-Host ">> Rate limit detectado en agente $($Agente.numero) (intento $attempt/$MaxRetries). Esperando ${RetryDelay}s..." -ForegroundColor Yellow
+        Write-Host ">> Rate limit detectado en agente $($Agente.numero) ($realCause) — intento $attempt/$MaxRetries. Esperando ${RetryDelay}s..." -ForegroundColor Yellow
         Start-Sleep -Seconds $RetryDelay
     }
 


### PR DESCRIPTION
## Resumen

- Corrige regex en Start-UnAgenteConRetry que clasificaba toda muerte prematura como rate limit
- El rate_limit_event informativo ya no dispara el retry de rate limit
- Mejora la detección de errores reales vs eventos informativos

## Archivos
- scripts/Start-Agente.ps1
- scripts/Run-AgentStream.ps1

QA Validate: omitido — cambio en scripts infra sin impacto en app

Closes #1682

🤖 Generado con [Claude Code](https://claude.ai/claude-code)