### PR TITLE
fix(telegram): sanitización UTF-8 centralizada en reportes Telegram (#1639)

### DIFF
--- a/.claude/hooks/delivery-report.js
+++ b/.claude/hooks/delivery-report.js
@@ -43,43 +43,9 @@ try {
 }
 
 const TMP_DIR = path.join(__dirname, "..", "tmp");
-// --- UTF-8 sanitization ---
 
-/**
- * Sanitiza texto para envío a Telegram: elimina lone surrogates, bytes nulos
- * y caracteres de control no-printable. Preserva emojis, tildes, eñes y
- * cualquier carácter Unicode válido.
- * @param {string} text
- * @returns {string}
- */
-function sanitizeUtf8(text) {
-    if (typeof text !== 'string' || !text) return text || '';
-    let sanitized = '';
-    for (let i = 0; i < text.length; i++) {
-        const code = text.charCodeAt(i);
-        if (code >= 0xD800 && code <= 0xDBFF) {
-            const next = text.charCodeAt(i + 1);
-            if (next >= 0xDC00 && next <= 0xDFFF) {
-                sanitized += text[i] + text[i + 1];
-                i++;
-            }
-        } else if (code >= 0xDC00 && code <= 0xDFFF) {
-            // lone low surrogate -> descartar
-        } else if (
-            (code < 0x20 && code !== 0x09 && code !== 0x0A && code !== 0x0D) ||
-            code === 0x7F ||
-            (code >= 0x80 && code <= 0x9F)
-        ) {
-            // caracteres de control -> descartar
-        } else {
-            sanitized += text[i];
-        }
-    }
-    if (sanitized !== text) {
-        console.warn('[delivery-report] [sanitizeUtf8] ' + (text.length - sanitized.length) + ' caracteres problemáticos eliminados para Telegram');
-    }
-    return sanitized;
-}
+// Reutilizar sanitizador centralizado (#1637/#1639)
+const { sanitize: sanitizeUtf8 } = require("./telegram-sanitizer");
 
 const MAX_RETRIES = 2;
 const RETRY_DELAY_MS = 1500;

--- a/scripts/report-to-pdf-telegram.js
+++ b/scripts/report-to-pdf-telegram.js
@@ -28,45 +28,8 @@ const filteredArgs = args.filter(a => a !== '--stdin' && a !== '--md');
 const inputArg = filteredArgs[0];
 const caption = filteredArgs[1] || filteredArgs[0] || 'Reporte Intrale';
 
-// --- UTF-8 sanitization ---
-
-/**
- * Sanitiza texto para envío a Telegram: elimina lone surrogates, bytes nulos
- * y caracteres de control no-printable. Preserva emojis, tildes, eñes y
- * cualquier carácter Unicode válido.
- * @param {string} text
- * @returns {string}
- */
-function sanitizeUtf8(text) {
-  if (typeof text !== 'string' || !text) return text || '';
-  let sanitized = '';
-  for (let i = 0; i < text.length; i++) {
-    const code = text.charCodeAt(i);
-    if (code >= 0xD800 && code <= 0xDBFF) {
-      // High surrogate: válido solo si va seguido de low surrogate
-      const next = text.charCodeAt(i + 1);
-      if (next >= 0xDC00 && next <= 0xDFFF) {
-        sanitized += text[i] + text[i + 1];
-        i++;
-      }
-      // si no, lone surrogate → descartar
-    } else if (code >= 0xDC00 && code <= 0xDFFF) {
-      // Lone low surrogate → descartar
-    } else if (
-      (code < 0x20 && code !== 0x09 && code !== 0x0A && code !== 0x0D) ||
-      code === 0x7F ||
-      (code >= 0x80 && code <= 0x9F)
-    ) {
-      // Caracteres de control no deseados → descartar
-    } else {
-      sanitized += text[i];
-    }
-  }
-  if (sanitized !== text) {
-    console.warn(`[sanitizeUtf8] ${text.length - sanitized.length} caracteres problemáticos eliminados del texto para Telegram`);
-  }
-  return sanitized;
-}
+// Reutilizar sanitizador centralizado (#1637/#1639)
+const { sanitize: sanitizeUtf8 } = require(path.join(__dirname, '..', '.claude', 'hooks', 'telegram-sanitizer'));
 
 async function readStdin() {
   return new Promise((resolve) => {

--- a/scripts/sprint-report.js
+++ b/scripts/sprint-report.js
@@ -36,43 +36,8 @@ function execSafe(cmd, opts = {}) {
     }
 }
 
-// --- UTF-8 sanitization ---
-
-/**
- * Sanitiza texto para envío a Telegram: elimina lone surrogates, bytes nulos
- * y caracteres de control no-printable. Preserva emojis, tildes, eñes y
- * cualquier carácter Unicode válido.
- * @param {string} text
- * @returns {string}
- */
-function sanitizeUtf8(text) {
-    if (typeof text !== 'string' || !text) return text || '';
-    let sanitized = '';
-    for (let i = 0; i < text.length; i++) {
-        const code = text.charCodeAt(i);
-        if (code >= 0xD800 && code <= 0xDBFF) {
-            const next = text.charCodeAt(i + 1);
-            if (next >= 0xDC00 && next <= 0xDFFF) {
-                sanitized += text[i] + text[i + 1];
-                i++;
-            }
-        } else if (code >= 0xDC00 && code <= 0xDFFF) {
-            // lone low surrogate → descartar
-        } else if (
-            (code < 0x20 && code !== 0x09 && code !== 0x0A && code !== 0x0D) ||
-            code === 0x7F ||
-            (code >= 0x80 && code <= 0x9F)
-        ) {
-            // caracteres de control → descartar
-        } else {
-            sanitized += text[i];
-        }
-    }
-    if (sanitized !== text) {
-        log(`[sanitizeUtf8] ${text.length - sanitized.length} caracteres problemáticos eliminados del caption para Telegram`);
-    }
-    return sanitized;
-}
+// Reutilizar sanitizador centralizado (#1637/#1639)
+const { sanitize: sanitizeUtf8 } = require(path.join(__dirname, '..', '.claude', 'hooks', 'telegram-sanitizer'));
 
 // --- PDF + Telegram via script unificado ---
 function sendReportViaTelegram(htmlPath, caption) {


### PR DESCRIPTION
## Resumen

- Crea telegram-sanitizer.js centralizado para sanitización UTF-8
- Reutiliza el sanitizer en delivery-report.js, sprint-report.js y report-to-pdf-telegram.js
- Elimina funciones inline duplicadas de sanitización

## Archivos
- .claude/hooks/delivery-report.js
- scripts/report-to-pdf-telegram.js
- scripts/sprint-report.js

QA Validate: omitido — cambio en scripts infra sin impacto en app

Closes #1639

🤖 Generado con [Claude Code](https://claude.ai/claude-code)