### PR TITLE
feat(sprint-report): propuesta de nuevas historias en pipeline de fin de sprint

### DIFF
--- a/scripts/sprint-report.js
+++ b/scripts/sprint-report.js
@@ -797,6 +797,23 @@ async function main() {
         log("--- cost-report.js completado ---");
     }
 
+    // Paso 4: Propuesta de nuevas historias (lanzar sesión claude en background)
+    // /planner proponer analiza gaps del codebase y genera propuestas + botones Telegram
+    log("--- Iniciando propuesta de nuevas historias ---");
+    try {
+        const claudeCmd = process.platform === "win32" ? "claude" : "claude";
+        const propPrompt = "Ejecutar /planner proponer — analizar gaps del codebase tras el sprint " +
+            (plan.sprint_id || "") + " y proponer nuevas historias. Generar planner-proposals.json y enviar botones a Telegram.";
+        const { spawn } = require("child_process");
+        const child = spawn(claudeCmd, ["--model", "sonnet", "-p", propPrompt], {
+            cwd: REPO_ROOT, detached: true, stdio: "ignore", windowsHide: true
+        });
+        child.unref();
+        log("Propuesta de historias lanzada en background (PID " + child.pid + ")");
+    } catch (e) {
+        log("Error lanzando propuesta de historias: " + e.message + " (no bloquea)");
+    }
+
     const elapsed = Math.round((Date.now() - startTime) / 1000);
     log(`=== sprint-report.js completado en ${elapsed}s ===`);
 }


### PR DESCRIPTION
## Resumen

- Agrega paso 4 al pipeline de sprint-report.js
- Lanza /planner proponer en background (sesión claude detached)
- Genera planner-proposals.json + botones Telegram
- Fail-open: no bloquea si falla

Pipeline completo: reporte PDF → tag → release → costos → propuestas

🤖 Generado con [Claude Code](https://claude.ai/claude-code)