### PR TITLE
feat(dashboard): icono start.svg para nodo Start del flujo

### DIFF
--- a/.claude/dashboard-server.js
+++ b/.claude/dashboard-server.js
@@ -98,6 +98,7 @@ const AGENT_ICON_MAP = {
   "Config": loadIconDataUri("config.svg"),
   "Done": loadIconDataUri("done.svg"),
   "Error": loadIconDataUri("failure.svg"),
+  "Start": loadIconDataUri("start.svg"),
 };
 const CLAUDE_ICONS = [
   loadIconDataUri("claude-1.svg"),


### PR DESCRIPTION
## Resumen

- Agrega start.svg al mapa de iconos del dashboard
- Nodo Start usa el icono custom en el flujo de agentes

🤖 Generado con [Claude Code](https://claude.ai/claude-code)