### PR TITLE
fix(infra): guardas de integridad de sprint — lock, forward-sync, pre-flight

### DIFF
--- a/.claude/hooks/pre-launch-validation.js
+++ b/.claude/hooks/pre-launch-validation.js
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+// pre-launch-validation.js — Validación pre-lanzamiento de agentes (#SPR-044-fix)
+// Ejecutado por Start-Agente.ps1 antes de lanzar. Detecta:
+// - Agentes zombie (status=active pero PID muerto)
+// - Sprint en estado inválido
+// - Worktrees huérfanos
+// Exit 0 = OK, Exit 1 = errores bloqueantes
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const { execSync } = require("child_process");
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+const PLAN_FILE = path.join(REPO_ROOT, "scripts", "sprint-plan.json");
+
+function isPidAlive(pid) {
+    if (!pid) return false;
+    try {
+        const out = execSync('tasklist /FI "PID eq ' + parseInt(pid, 10) + '" /NH', {
+            timeout: 3000, windowsHide: true, encoding: "utf8"
+        });
+        return out.indexOf("No tasks") === -1 && out.indexOf("no hay tareas") === -1;
+    } catch (e) { return false; }
+}
+
+function validate() {
+    const errors = [];
+    const warnings = [];
+
+    // 1. Sprint plan existe
+    if (!fs.existsSync(PLAN_FILE)) {
+        errors.push("sprint-plan.json no encontrado");
+        return { ok: false, errors, warnings };
+    }
+
+    let plan;
+    try { plan = JSON.parse(fs.readFileSync(PLAN_FILE, "utf8")); } catch(e) {
+        errors.push("sprint-plan.json no es JSON válido: " + e.message);
+        return { ok: false, errors, warnings };
+    }
+
+    // 2. Sprint activo
+    if (!plan.sprint_id) {
+        errors.push("sprint-plan.json sin sprint_id");
+    }
+
+    // 3. Detectar agentes zombie
+    const zombies = [];
+    for (const ag of (plan.agentes || [])) {
+        if (ag.status === "active" && ag._pid) {
+            if (!isPidAlive(ag._pid)) {
+                zombies.push({ issue: ag.issue, numero: ag.numero, pid: ag._pid, launched: ag._launched_at });
+            }
+        }
+        // Agente "active" sin PID = probablemente plan corrupto
+        if (ag.status === "active" && !ag._pid && ag._launched_at) {
+            warnings.push("Agente " + ag.numero + " #" + ag.issue + ": status=active pero sin _pid (plan posiblemente corrupto)");
+        }
+    }
+
+    if (zombies.length > 0) {
+        warnings.push(zombies.length + " agente(s) zombie detectado(s):");
+        zombies.forEach(z => {
+            warnings.push("  Agente " + z.numero + " #" + z.issue + " PID " + z.pid + " (lanzado " + (z.launched || "?") + ") - MUERTO");
+        });
+    }
+
+    // 4. Verificar worktrees huérfanos
+    try {
+        const wtOut = execSync("git worktree list", { cwd: REPO_ROOT, timeout: 5000, encoding: "utf8" });
+        const lines = wtOut.trim().split("\n").filter(l => l.includes("agent/"));
+        const planIssues = new Set([...(plan.agentes||[]), ...(plan._queue||[])].map(a => String(a.issue)));
+        for (const line of lines) {
+            const m = line.match(/agent\/(\d+)/);
+            if (m && !planIssues.has(m[1])) {
+                warnings.push("Worktree huérfano: " + line.trim().split(/\s+/)[0] + " (issue #" + m[1] + " no está en el plan)");
+            }
+        }
+    } catch(e) {}
+
+    return { ok: errors.length === 0, errors, warnings, zombies: zombies.length > 0 ? zombies : undefined };
+}
+
+// CLI mode
+if (require.main === module) {
+    const result = validate();
+    console.log(JSON.stringify(result));
+    process.exit(result.ok ? 0 : 1);
+}
+
+module.exports = { validate };

--- a/.claude/hooks/sprint-data.js
+++ b/.claude/hooks/sprint-data.js
@@ -242,6 +242,18 @@ function getConcurrencyLimit(sp) {
 // --- Backward-compat: generar sprint-plan.json desde roadmap.json ---
 
 function generateSprintPlanCache(rm) {
+    // Verificar si sprint-plan.json está protegido por _lock_until
+    try {
+        var existing = readJson(SPRINT_PLAN_FILE);
+        if (existing && existing._lock_until) {
+            var lockUntil = new Date(existing._lock_until).getTime();
+            if (!isNaN(lockUntil) && Date.now() < lockUntil) {
+                log("generateSprintPlanCache SKIP: plan protegido hasta " + existing._lock_until);
+                return;
+            }
+        }
+    } catch (e) {}
+
     var sp = getActiveSprint(rm);
     if (!sp) return;
     var stories = sp.stories || [], exec = sp.execution || {};

--- a/.claude/hooks/sprint-sync.js
+++ b/.claude/hooks/sprint-sync.js
@@ -320,6 +320,44 @@ function archiveSprintMetrics(sprintId, velocity) {
     } catch (e) { return { ok: false, message: e.message }; }
 }
 
+// --- Forward-sync: preservar _pid y _launched_at de agentes activos ---
+
+function saveAgentPidState() {
+    var saved = {};
+    try {
+        var plan = JSON.parse(fs.readFileSync(sprintData.SPRINT_PLAN_FILE, "utf8"));
+        if (plan && Array.isArray(plan.agentes)) {
+            plan.agentes.forEach(function(ag) {
+                if (ag._pid || ag._launched_at) {
+                    saved[ag.issue] = { _pid: ag._pid, _launched_at: ag._launched_at, status: ag.status };
+                }
+            });
+        }
+    } catch (e) { /* sprint-plan.json may not exist yet */ }
+    return saved;
+}
+
+function restoreAgentPidState(saved) {
+    if (!saved || Object.keys(saved).length === 0) return;
+    try {
+        var plan = JSON.parse(fs.readFileSync(sprintData.SPRINT_PLAN_FILE, "utf8"));
+        var restored = 0;
+        (plan.agentes || []).forEach(function(ag) {
+            var s = saved[ag.issue];
+            if (s) {
+                if (s._pid) ag._pid = s._pid;
+                if (s._launched_at) ag._launched_at = s._launched_at;
+                if (s.status) ag.status = s.status;
+                restored++;
+            }
+        });
+        if (restored > 0) {
+            fs.writeFileSync(sprintData.SPRINT_PLAN_FILE, JSON.stringify(plan, null, 2));
+            log("Forward-sync: restaurados _pid/_launched_at de " + restored + " agente(s)");
+        }
+    } catch (e) { log("Forward-sync restore error: " + e.message); }
+}
+
 // --- runSync: funcion principal ---
 
 async function runSync(opts) {
@@ -332,6 +370,8 @@ async function runSync(opts) {
     log("Iniciando reconciliacion" + (force ? " (forzada)" : ""));
 
     var allChanges = [];
+    // Forward-sync: capturar _pid/_launched_at ANTES de cualquier regeneracion
+    var savedPidState = saveAgentPidState();
 
     try {
         var ghCmd = getGhCmd();
@@ -389,10 +429,12 @@ async function runSync(opts) {
         var realChanges = allChanges.filter(function(c) { return c.indexOf("roadmap:") === 0; });
         if (realChanges.length > 0) {
             sprintData.writeRoadmap(roadmap, "sprint-sync"); // Esto tambien regenera sprint-plan.json
+            restoreAgentPidState(savedPidState);
             log("roadmap.json actualizado (" + realChanges.length + " cambios)");
         } else {
             // Regenerar sprint-plan.json por si acaso (sin tocar roadmap)
             sprintData.generateSprintPlanCache(roadmap);
+            restoreAgentPidState(savedPidState);
         }
 
         // 4. Actualizar estado
@@ -425,6 +467,7 @@ async function runSync(opts) {
                 freshSprint.closed_at = new Date().toISOString().replace(/\.\d+Z$/, "Z");
                 freshSprint.velocity = doneCount;
                 sprintData.writeRoadmap(roadmap, "sprint-sync (auto-close)");
+                restoreAgentPidState(savedPidState);
 
                 // Generate sprint report PDF + send to Telegram
                 var reportScript = path.join(__dirname, "..", "..", "scripts", "sprint-report.js");
@@ -465,8 +508,12 @@ async function runSync(opts) {
 
 function syncRoadmapOnly(planOverride) {
     try {
+        var saved = saveAgentPidState();
         var roadmap = sprintData.readRoadmap();
-        if (roadmap) sprintData.generateSprintPlanCache(roadmap);
+        if (roadmap) {
+            sprintData.generateSprintPlanCache(roadmap);
+            restoreAgentPidState(saved);
+        }
     } catch (e) { log("syncRoadmapOnly error: " + e.message); }
 }
 

--- a/scripts/Start-Agente.ps1
+++ b/scripts/Start-Agente.ps1
@@ -120,6 +120,28 @@ try {
     Write-Host ">> OPS: Check no disponible (fail-open)" -ForegroundColor DarkGray
 }
 
+# Pre-launch validation: detectar agentes zombie y estado inconsistente
+Write-Host ">> Validando estado pre-lanzamiento..." -ForegroundColor Cyan
+try {
+    $validationJson = & node "$MainRepo\.claude\hooks\pre-launch-validation.js" 2>$null
+    $validation = $validationJson | ConvertFrom-Json
+    if ($validation.warnings) {
+        foreach ($warn in $validation.warnings) {
+            Write-Host ">>   WARN: $warn" -ForegroundColor Yellow
+        }
+    }
+    if (-not $validation.ok) {
+        Write-Host ">> ERRORES CRÍTICOS:" -ForegroundColor Red
+        foreach ($err in $validation.errors) {
+            Write-Host ">>   ERROR: $err" -ForegroundColor Red
+        }
+        exit 1
+    }
+    Write-Host ">> Pre-launch OK" -ForegroundColor Green
+} catch {
+    Write-Host ">> Pre-launch validation no disponible (continuando): $_" -ForegroundColor DarkGray
+}
+
 # --- Pre-sprint cleanup de worktrees huérfanos ---
 # Los worktrees de sprints anteriores se acumulan y saturan git,
 # causando que los agentes no puedan arrancar (SPR-028 incident 2026-03-14)
@@ -540,6 +562,13 @@ function Start-UnAgente {
                 $targetAgent._launched_at = $launchedAt
             } else {
                 $targetAgent | Add-Member -NotePropertyName '_launched_at' -NotePropertyValue $launchedAt -Force
+            }
+            # _lock_until: proteger sprint-plan.json por 10 minutos para que el sync no lo sobreescriba
+            $lockUntil = [datetime]::UtcNow.AddMinutes(10).ToString('yyyy-MM-ddTHH:mm:ss.fffZ')
+            if ($freshPlan.PSObject.Properties.Match('_lock_until').Count) {
+                $freshPlan._lock_until = $lockUntil
+            } else {
+                $freshPlan | Add-Member -NotePropertyName '_lock_until' -NotePropertyValue $lockUntil -Force
             }
             # Verificar integridad antes de escribir: asegurar que no se pierdan agentes
             $originalAgentCount = ((Get-Content $PlanFile -Raw | ConvertFrom-Json).agentes | Measure-Object).Count


### PR DESCRIPTION
## Summary
- `_lock_until` en sprint-plan.json: protege contra sobrescrituras del sync por 10min
- Forward-sync en sprint-sync.js: preserva PIDs de agentes activos al regenerar plan
- pre-launch-validation.js: detecta zombies, plan corrupto y worktrees huérfanos pre-lanzamiento
- Integrado en Start-Agente.ps1 como pre-flight check obligatorio

## Context
En SPR-044, 3 agentes murieron sin delivery porque:
1. Se lanzaron sin Start-Agente.ps1 (sin pipeline)
2. El sprint-sync sobreescribía el plan cada 2min borrando PIDs
3. Nadie detectó que los agentes estaban muertos

## Test plan
- [x] sprint-data.js syntax OK
- [x] sprint-sync.js syntax OK
- [x] pre-launch-validation.js: `{"ok":true,"errors":[],"warnings":[]}`
- [x] Start-Agente.ps1 syntax OK (PSParser)

🤖 Generated with [Claude Code](https://claude.com/claude-code)