### PR TITLE
feat: validación cruzada roadmap vs agent-registry (#1660)

### DIFF
--- a/.claude/hooks/health-check-sprint.js
+++ b/.claude/hooks/health-check-sprint.js
@@ -504,6 +504,15 @@ async function runHealthCheck() {
         inconsistencias
     };
 
+    // Deteccion 6: Validacion cruzada roadmap vs agent-registry (#1660)
+    try {
+        var crossCheckMod=require("./roadmap-registry-check");
+        var crossCheck=crossCheckMod.runCrossValidation({});
+        (crossCheck.zombies||[]).forEach(function(z){inconsistencias.push(z);log("Inconsistencia (zombie): "+z.message);});
+        (crossCheck.orphans||[]).forEach(function(o){inconsistencias.push(o);log("Inconsistencia (orphan): "+o.message);});
+    } catch(e) {
+        log("Validacion cruzada roadmap-registry fallo: "+e.message);
+    }
     log("Health check completado: " + inconsistencias.length + " inconsistencia(s), nivel: " + healthLevel);
     return result;
 }

--- a/.claude/hooks/roadmap-registry-check.js
+++ b/.claude/hooks/roadmap-registry-check.js
@@ -1,0 +1,86 @@
+// roadmap-registry-check.js
+// Validacion cruzada roadmap.json vs agent-registry.json (#1660)
+// ZOMBIE: story in_progress sin agente active en registry
+// ORPHAN: agente active sin story in_progress en roadmap activo
+
+var fs=require("fs");
+var path=require("path");
+
+var HOOKS_DIR=path.dirname(module.filename);
+var REPO_ROOT=process.env.CLAUDE_PROJECT_DIR||path.resolve(HOOKS_DIR,"../..");
+var SCRIPTS_DIR=path.join(REPO_ROOT,"scripts");
+var LOG_FILE=path.join(HOOKS_DIR,"hook-debug.log");
+var ROADMAP_FILE=path.join(SCRIPTS_DIR,"roadmap.json");
+var REGISTRY_FILE=path.join(HOOKS_DIR,"agent-registry.json");
+
+function log(msg){try{fs.appendFileSync(LOG_FILE,"["+new Date().toISOString()+"] roadmap-registry-check: "+msg+String.fromCharCode(10));}catch(e){}}
+
+function readJson(p){try{if(!fs.existsSync(p))return null;return JSON.parse(fs.readFileSync(p,"utf8"));}catch(e){log("Error leyendo "+p+": "+e.message);return null;}}
+
+function normalizeIssueNumber(raw){if(raw==null)return null;var n=parseInt(String(raw).replace(/^#/,"").trim(),10);return isNaN(n)?null:n;}
+
+function getActiveSprint(rm){if(!rm||!Array.isArray(rm.sprints))return null;return rm.sprints.find(function(s){return s.status==="active";})||null;}
+
+function getInProgressStories(sp){if(!sp||!Array.isArray(sp.stories))return[];return sp.stories.filter(function(s){return s.status==="in_progress";});}
+
+function getActiveAgents(reg){if(!reg||typeof reg.agents!=="object")return[];return Object.values(reg.agents).filter(function(a){return a&&a.status==="active";});}
+
+function runCrossValidation(opts){
+  opts=opts||{};
+  var rmp=opts.roadmapPath||ROADMAP_FILE;
+  var rgp=opts.registryPath||REGISTRY_FILE;
+  var roadmap=readJson(rmp);
+  var registry=readJson(rgp);
+  var result={zombies:[],orphans:[],auto_corrected:[],timestamp:new Date().toISOString(),sprint_id:null,ok:true};
+  if(!roadmap){result.ok=false;result.error="roadmap.json no disponible";log(result.error);return result;}
+  var sp=getActiveSprint(roadmap);
+  if(!sp){log("Sin sprint activo");return result;}
+  result.sprint_id=sp.id;
+  var ips=getInProgressStories(sp);
+  var aas=getActiveAgents(registry||{agents:{}});
+  var aabi={};
+  aas.forEach(function(a){var n=normalizeIssueNumber(a.issue);if(n!==null)aabi[n]=a;});
+  var ipbi={};
+  ips.forEach(function(s){var n=normalizeIssueNumber(s.issue);if(n!==null)ipbi[n]=s;});
+  ips.forEach(function(story){
+    var num=normalizeIssueNumber(story.issue);
+    if(num===null)return;
+    if(!aabi[num]){
+      result.zombies.push({type:"roadmap_zombie",severity:"high",issue:num,sprint_id:sp.id,story_title:story.title||"",message:"Issue #"+num+" esta in_progress en roadmap pero no tiene agente activo en agent-registry",action:"correct_to_planned"});
+      log("ZOMBIE detectado: issue #"+num);
+    }
+  });
+  aas.forEach(function(agent){
+    var num=normalizeIssueNumber(agent.issue);
+    if(num===null)return;
+    if(!ipbi[num]){
+      result.orphans.push({type:"roadmap_orphan",severity:"medium",issue:num,sprint_id:sp.id,session_id:agent.session_id||"",agent_status:agent.status,message:"Agente "+(agent.session_id||"?")+" activo para issue #"+num+" sin story in_progress en roadmap sprint "+sp.id,action:"investigate"});
+      log("ORPHAN detectado: issue #"+num);
+    }
+  });
+  if(opts.autoFix&&result.zombies.length>0){
+    var sd=null;
+    try{sd=require("./sprint-data");}catch(e){try{sd=require(path.join(SCRIPTS_DIR,"sprint-data"));}catch(e2){}}
+    if(sd&&sd.updateStoryStatus&&sd.writeRoadmap){
+      result.zombies.forEach(function(z){
+        try{
+          var fr=readJson(rmp);
+          if(!fr)return;
+          var ok=sd.updateStoryStatus(fr,sp.id,z.issue,"planned",null);
+          if(ok){var wr=sd.writeRoadmap(fr,"roadmap-registry-check");if(wr){result.auto_corrected.push({issue:z.issue,from:"in_progress",to:"planned",reason:"zombie_no_active_agent"});log("AUTO-FIX: issue #"+z.issue+" -> planned");}}
+        }catch(e){log("AUTO-FIX ERROR: "+e.message);}
+      });
+    }else{log("AUTO-FIX: sprint-data no disponible");}
+  }
+  result.ok=result.zombies.length===0&&result.orphans.length===0;
+  return result;
+}
+
+if(require.main===module){
+  var af=process.argv.slice(2).indexOf("--auto-fix")>=0;
+  var res=runCrossValidation({autoFix:af});
+  console.log(JSON.stringify(res,null,2));
+  process.exit(res.ok?0:1);
+}
+
+module.exports={runCrossValidation:runCrossValidation,normalizeIssueNumber:normalizeIssueNumber,getActiveSprint:getActiveSprint,getInProgressStories:getInProgressStories,getActiveAgents:getActiveAgents};

--- a/.claude/hooks/scrum-monitor-bg.js
+++ b/.claude/hooks/scrum-monitor-bg.js
@@ -19,7 +19,7 @@ const PID_FILE = path.join(HOOKS_DIR, "scrum-monitor-bg.pid");
 // Intervalo de chequeo: 30 minutos
 const CHECK_INTERVAL_MS = 30 * 60 * 1000;
 // Auto-reparación automática para inconsistencias menores (sin --auto)
-const AUTO_REPAIR_TYPES = ["pr_merged_issue_open", "closed_issue_wrong_status"];
+const AUTO_REPAIR_TYPES = ["pr_merged_issue_open", "closed_issue_wrong_status", "roadmap_zombie"];
 
 function log(msg) {
     try {

--- a/.claude/hooks/tests/test-p35-roadmap-registry-check.js
+++ b/.claude/hooks/tests/test-p35-roadmap-registry-check.js
@@ -1,0 +1,274 @@
+// test-p35-roadmap-registry-check.js
+// Tests para roadmap-registry-check.js (#1660)
+var test=require("node:test");
+var assert=require("node:assert");
+var fs=require("fs");
+var path=require("path");
+var os=require("os");
+
+var MOD_PATH=path.resolve(__dirname,"..","roadmap-registry-check.js");
+var mod=require(MOD_PATH);
+
+function makeTempFiles(rm,reg){
+  var d=fs.mkdtempSync(path.join(os.tmpdir(),"rrc-test-"));
+  fs.writeFileSync(path.join(d,"roadmap.json"),JSON.stringify(rm));
+  fs.writeFileSync(path.join(d,"agent-registry.json"),JSON.stringify(reg));
+  return d;
+}
+
+function mkRm(stories,sprintStatus){
+  sprintStatus=sprintStatus||"active";
+  return {sprints:[{id:"SPR-TEST",status:sprintStatus,stories:stories||[]}]};
+}
+
+function mkReg(agents){
+  var obj={};
+  (agents||[]).forEach(function(a){obj[a.session_id]=a;});
+  return {agents:obj};
+}
+
+test.describe("P-35.1: Estructura del modulo",function(){
+  test.it("el archivo existe",function(){
+    assert.ok(fs.existsSync(MOD_PATH),"No existe "+MOD_PATH);
+  });
+  test.it("exporta runCrossValidation",function(){
+    assert.strictEqual(typeof mod.runCrossValidation,"function");
+  });
+  test.it("exporta normalizeIssueNumber",function(){
+    assert.strictEqual(typeof mod.normalizeIssueNumber,"function");
+  });
+  test.it("exporta getActiveSprint",function(){
+    assert.strictEqual(typeof mod.getActiveSprint,"function");
+  });
+  test.it("exporta getInProgressStories",function(){
+    assert.strictEqual(typeof mod.getInProgressStories,"function");
+  });
+  test.it("exporta getActiveAgents",function(){
+    assert.strictEqual(typeof mod.getActiveAgents,"function");
+  });
+});
+
+test.describe("P-35.2: normalizeIssueNumber",function(){
+  test.it("parsea string con hash",function(){
+    assert.strictEqual(mod.normalizeIssueNumber("#1234"),1234);
+  });
+  test.it("parsea numero entero",function(){
+    assert.strictEqual(mod.normalizeIssueNumber(1234),1234);
+  });
+  test.it("parsea string sin hash",function(){
+    assert.strictEqual(mod.normalizeIssueNumber("1234"),1234);
+  });
+  test.it("retorna null para null",function(){
+    assert.strictEqual(mod.normalizeIssueNumber(null),null);
+  });
+  test.it("retorna null para no numerico",function(){
+    assert.strictEqual(mod.normalizeIssueNumber("abc"),null);
+  });
+});
+
+test.describe("P-35.3: getActiveSprint",function(){
+  test.it("retorna sprint activo",function(){
+    var rm={sprints:[{id:"SPR-A",status:"done"},{id:"SPR-B",status:"active"}]};
+    var s=mod.getActiveSprint(rm);
+    assert.strictEqual(s.id,"SPR-B");
+  });
+  test.it("retorna null si no hay sprint activo",function(){
+    var rm={sprints:[{id:"SPR-A",status:"done"}]};
+    assert.strictEqual(mod.getActiveSprint(rm),null);
+  });
+  test.it("retorna null para roadmap null",function(){
+    assert.strictEqual(mod.getActiveSprint(null),null);
+  });
+});
+
+test.describe("P-35.4: getInProgressStories",function(){
+  test.it("filtra solo in_progress",function(){
+    var sp={stories:[
+      {issue:1,status:"in_progress"},
+      {issue:2,status:"planned"},
+      {issue:3,status:"in_progress"}
+    ]};
+    var res=mod.getInProgressStories(sp);
+    assert.strictEqual(res.length,2);
+    assert.strictEqual(res[0].issue,1);
+    assert.strictEqual(res[1].issue,3);
+  });
+  test.it("retorna array vacio si no hay in_progress",function(){
+    var sp={stories:[{issue:1,status:"planned"}]};
+    assert.strictEqual(mod.getInProgressStories(sp).length,0);
+  });
+  test.it("retorna array vacio para sprint null",function(){
+    assert.strictEqual(mod.getInProgressStories(null).length,0);
+  });
+});
+
+test.describe("P-35.5: getActiveAgents",function(){
+  test.it("filtra solo active",function(){
+    var reg=mkReg([
+      {session_id:"s1",issue:"#10",status:"active"},
+      {session_id:"s2",issue:"#11",status:"zombie"},
+      {session_id:"s3",issue:"#12",status:"idle"}
+    ]);
+    var res=mod.getActiveAgents(reg);
+    assert.strictEqual(res.length,1);
+    assert.strictEqual(res[0].session_id,"s1");
+  });
+  test.it("retorna array vacio para registry null",function(){
+    assert.strictEqual(mod.getActiveAgents(null).length,0);
+  });
+  test.it("retorna array vacio si agents no es objeto",function(){
+    assert.strictEqual(mod.getActiveAgents({agents:[]}).length,0);
+  });
+});
+
+test.describe("P-35.6: runCrossValidation sin sprint activo",function(){
+  test.it("ok true y listas vacias si no hay sprint activo",function(){
+    var rm=mkRm([],"done");
+    var reg=mkReg([]);
+    var d=makeTempFiles(rm,reg);
+    var r=mod.runCrossValidation({roadmapPath:path.join(d,"roadmap.json"),registryPath:path.join(d,"agent-registry.json")});
+    assert.strictEqual(r.ok,true);
+    assert.strictEqual(r.zombies.length,0);
+    assert.strictEqual(r.orphans.length,0);
+    fs.rmSync(d,{recursive:true,force:true});
+  });
+});
+
+test.describe("P-35.7: runCrossValidation deteccion zombies",function(){
+  test.it("detecta 1 zombie cuando story in_progress sin agente activo",function(){
+    var rm=mkRm([{issue:1234,title:"T",status:"in_progress"}]);
+    var reg=mkReg([]);
+    var d=makeTempFiles(rm,reg);
+    var r=mod.runCrossValidation({roadmapPath:path.join(d,"roadmap.json"),registryPath:path.join(d,"agent-registry.json")});
+    assert.strictEqual(r.zombies.length,1);
+    assert.strictEqual(r.zombies[0].issue,1234);
+    assert.strictEqual(r.zombies[0].type,"roadmap_zombie");
+    assert.strictEqual(r.zombies[0].severity,"high");
+    assert.ok(r.zombies[0].action==="correct_to_planned");
+    assert.strictEqual(r.ok,false);
+    fs.rmSync(d,{recursive:true,force:true});
+  });
+  test.it("no detecta zombie si agente activo para el issue",function(){
+    var rm=mkRm([{issue:1234,title:"T",status:"in_progress"}]);
+    var reg=mkReg([{session_id:"s1",issue:"#1234",status:"active"}]);
+    var d=makeTempFiles(rm,reg);
+    var r=mod.runCrossValidation({roadmapPath:path.join(d,"roadmap.json"),registryPath:path.join(d,"agent-registry.json")});
+    assert.strictEqual(r.zombies.length,0);
+    fs.rmSync(d,{recursive:true,force:true});
+  });
+  test.it("normaliza numero en registry con hash prefix",function(){
+    var rm=mkRm([{issue:42,title:"T",status:"in_progress"}]);
+    var reg=mkReg([{session_id:"s1",issue:"#42",status:"active"}]);
+    var d=makeTempFiles(rm,reg);
+    var r=mod.runCrossValidation({roadmapPath:path.join(d,"roadmap.json"),registryPath:path.join(d,"agent-registry.json")});
+    assert.strictEqual(r.zombies.length,0);
+    fs.rmSync(d,{recursive:true,force:true});
+  });
+  test.it("detecta multiples zombies",function(){
+    var rm=mkRm([
+      {issue:10,title:"A",status:"in_progress"},
+      {issue:11,title:"B",status:"in_progress"},
+      {issue:12,title:"C",status:"planned"}
+    ]);
+    var reg=mkReg([{session_id:"s1",issue:"#11",status:"active"}]);
+    var d=makeTempFiles(rm,reg);
+    var r=mod.runCrossValidation({roadmapPath:path.join(d,"roadmap.json"),registryPath:path.join(d,"agent-registry.json")});
+    assert.strictEqual(r.zombies.length,1);
+    assert.strictEqual(r.zombies[0].issue,10);
+    fs.rmSync(d,{recursive:true,force:true});
+  });
+});
+
+test.describe("P-35.8: runCrossValidation deteccion orphans",function(){
+  test.it("detecta 1 orphan cuando agente activo sin story in_progress",function(){
+    var rm=mkRm([{issue:99,title:"T",status:"planned"}]);
+    var reg=mkReg([{session_id:"s1",issue:"#99",status:"active"}]);
+    var d=makeTempFiles(rm,reg);
+    var r=mod.runCrossValidation({roadmapPath:path.join(d,"roadmap.json"),registryPath:path.join(d,"agent-registry.json")});
+    assert.strictEqual(r.orphans.length,1);
+    assert.strictEqual(r.orphans[0].issue,99);
+    assert.strictEqual(r.orphans[0].type,"roadmap_orphan");
+    assert.strictEqual(r.orphans[0].severity,"medium");
+    assert.strictEqual(r.ok,false);
+    fs.rmSync(d,{recursive:true,force:true});
+  });
+  test.it("no detecta orphan si story in_progress en roadmap",function(){
+    var rm=mkRm([{issue:55,title:"T",status:"in_progress"}]);
+    var reg=mkReg([{session_id:"s1",issue:"#55",status:"active"}]);
+    var d=makeTempFiles(rm,reg);
+    var r=mod.runCrossValidation({roadmapPath:path.join(d,"roadmap.json"),registryPath:path.join(d,"agent-registry.json")});
+    assert.strictEqual(r.orphans.length,0);
+    fs.rmSync(d,{recursive:true,force:true});
+  });
+  test.it("ignora agentes zombie e idle",function(){
+    var rm=mkRm([]);
+    var reg=mkReg([
+      {session_id:"s1",issue:"#77",status:"zombie"},
+      {session_id:"s2",issue:"#78",status:"idle"}
+    ]);
+    var d=makeTempFiles(rm,reg);
+    var r=mod.runCrossValidation({roadmapPath:path.join(d,"roadmap.json"),registryPath:path.join(d,"agent-registry.json")});
+    assert.strictEqual(r.orphans.length,0);
+    fs.rmSync(d,{recursive:true,force:true});
+  });
+});
+
+test.describe("P-35.9: runCrossValidation manejo de errores",function(){
+  test.it("retorna ok false si roadmap no existe",function(){
+    var d=fs.mkdtempSync(path.join(os.tmpdir(),"rrc-err-"));
+    var r=mod.runCrossValidation({roadmapPath:path.join(d,"noexiste.json"),registryPath:path.join(d,"reg.json")});
+    assert.strictEqual(r.ok,false);
+    assert.ok(r.error);
+    fs.rmSync(d,{recursive:true,force:true});
+  });
+  test.it("funciona aunque registry no exista",function(){
+    var rm=mkRm([{issue:1,title:"T",status:"in_progress"}]);
+    var d=fs.mkdtempSync(path.join(os.tmpdir(),"rrc-noreg-"));
+    fs.writeFileSync(path.join(d,"roadmap.json"),JSON.stringify(rm));
+    var r=mod.runCrossValidation({roadmapPath:path.join(d,"roadmap.json"),registryPath:path.join(d,"noexiste.json")});
+    assert.strictEqual(r.zombies.length,1);
+    fs.rmSync(d,{recursive:true,force:true});
+  });
+});
+
+test.describe("P-35.10: runCrossValidation sprint_id",function(){
+  test.it("incluye sprint_id del sprint activo",function(){
+    var rm=mkRm([]);
+    var reg=mkReg([]);
+    var d=makeTempFiles(rm,reg);
+    var r=mod.runCrossValidation({roadmapPath:path.join(d,"roadmap.json"),registryPath:path.join(d,"agent-registry.json")});
+    assert.strictEqual(r.sprint_id,"SPR-TEST");
+    fs.rmSync(d,{recursive:true,force:true});
+  });
+});
+
+test.describe("P-35.11: runCrossValidation resultado clean",function(){
+  test.it("ok true cuando no hay zombies ni orphans",function(){
+    var rm=mkRm([{issue:100,title:"T",status:"in_progress"}]);
+    var reg=mkReg([{session_id:"s1",issue:"#100",status:"active"}]);
+    var d=makeTempFiles(rm,reg);
+    var r=mod.runCrossValidation({roadmapPath:path.join(d,"roadmap.json"),registryPath:path.join(d,"agent-registry.json")});
+    assert.strictEqual(r.ok,true);
+    assert.strictEqual(r.zombies.length,0);
+    assert.strictEqual(r.orphans.length,0);
+    fs.rmSync(d,{recursive:true,force:true});
+  });
+  test.it("incluye timestamp en el resultado",function(){
+    var rm=mkRm([]);
+    var reg=mkReg([]);
+    var d=makeTempFiles(rm,reg);
+    var r=mod.runCrossValidation({roadmapPath:path.join(d,"roadmap.json"),registryPath:path.join(d,"agent-registry.json")});
+    assert.ok(r.timestamp);
+    assert.ok(typeof r.timestamp==="string");
+    fs.rmSync(d,{recursive:true,force:true});
+  });
+  test.it("auto_corrected es array vacio sin autoFix",function(){
+    var rm=mkRm([{issue:200,title:"T",status:"in_progress"}]);
+    var reg=mkReg([]);
+    var d=makeTempFiles(rm,reg);
+    var r=mod.runCrossValidation({roadmapPath:path.join(d,"roadmap.json"),registryPath:path.join(d,"agent-registry.json")});
+    assert.ok(Array.isArray(r.auto_corrected));
+    assert.strictEqual(r.auto_corrected.length,0);
+    fs.rmSync(d,{recursive:true,force:true});
+  });
+});


### PR DESCRIPTION
## Resumen

Implementa validación cruzada entre roadmap.json (stories in_progress) y agent-registry.json (agentes activos) para detectar y reportar inconsistencias:

- **Zombies**: stories in_progress sin agente activo registrado → auto-corrección a planned
- **Orphans**: agentes activos sin story in_progress en roadmap → reporte para investigación

## Plan de implementación

- Módulo `roadmap-registry-check.js`: núcleo de validación con exportación de funciones reutilizables
- Integración en `health-check-sprint.js`: "Detección 6" — ejecución durante chequeos de salud
- Auto-repair en `scrum-monitor-bg.js`: `roadmap_zombie` agregado a `AUTO_REPAIR_TYPES`
- Tests P-35: 34 tests (100% pass) cubriendo todos los casos de uso

## Test plan

- ✅ Módulo standalone: `node roadmap-registry-check.js` retorna resultado válido
- ✅ Detección de zombies: 4 escenarios (1 zombie, múltiples, normalización #N)
- ✅ Detección de orphans: 3 escenarios (1 orphan, filtrado de zombie/idle)
- ✅ Manejo de errores: archivos faltantes, registry vacía
- ✅ Resultado con sprint_id y timestamp

## QA

QA Validate: omitido — issue de infra/hooks sin impacto en app de usuario ⚠️

Closes #1660

🤖 Generado con [Claude Code](https://claude.com/claude-code)