### PR TITLE
feat(infra): build inteligente — compilar solo módulos afectados

### DIFF
--- a/.claude/skills/builder/SKILL.md
+++ b/.claude/skills/builder/SKILL.md
@@ -39,38 +39,50 @@ Verificar que Java 21 esta disponible:
 
 Segun el argumento recibido:
 
-### Todo el proyecto (sin argumento o --clean)
+### Sin argumento — Build inteligente (por defecto)
+
+Usar `scripts/smart-build.sh` para detectar módulos afectados y compilar solo esos:
+
+```bash
+export JAVA_HOME="/c/Users/Administrator/.jdks/temurin-21.0.7" && \
+  chmod +x scripts/smart-build.sh && \
+  bash scripts/smart-build.sh 2>&1 | tail -80
+```
+
+El script detecta automáticamente:
+- Archivos cambiados vs `origin/main`
+- Módulos afectados: `backend`, `users`, `app`, `tools`
+- Transitividad: cambio en `backend/` → recompila también `:users:check`
+- Archivos compartidos (`buildSrc/`, `gradle/`, `*.gradle.kts`) → build completo
+
+### Módulo explícito (argumento `backend`, `users`, `app`, `tools`)
+
+```bash
+export JAVA_HOME="/c/Users/Administrator/.jdks/temurin-21.0.7" && \
+  ./gradlew :<modulo>:check 2>&1 | tail -50
+```
+
+- `backend` → `:backend:check`
+- `users` → `:users:check`
+- `app` → `:app:composeApp:check`
+- `tools` → `:tools:forbidden-strings-processor:check`
+
+### `--clean` (build completo limpio)
 ```bash
 export JAVA_HOME="/c/Users/Administrator/.jdks/temurin-21.0.7" && \
   ./gradlew clean build 2>&1 | tail -80
 ```
 
-### Modulo `backend`
+### `--all` (build completo sin limpiar)
 ```bash
 export JAVA_HOME="/c/Users/Administrator/.jdks/temurin-21.0.7" && \
-  ./gradlew :backend:build 2>&1 | tail -50
+  bash scripts/smart-build.sh --all 2>&1 | tail -80
 ```
 
-### Modulo `users`
+### `--fast` (solo compilación sin checks)
 ```bash
 export JAVA_HOME="/c/Users/Administrator/.jdks/temurin-21.0.7" && \
-  ./gradlew :users:build 2>&1 | tail -50
-```
-
-### Modulo `app`
-```bash
-export JAVA_HOME="/c/Users/Administrator/.jdks/temurin-21.0.7" && \
-  ./gradlew :app:composeApp:build 2>&1 | tail -50
-```
-
-Si se paso `--clean`, anteponer `clean` a la tarea:
-```bash
-./gradlew clean :modulo:build
-```
-
-Si se paso `--fast`, usar solo `compileKotlin` en vez de `build`:
-```bash
-./gradlew :modulo:compileKotlin 2>&1 | tail -50
+  ./gradlew :<modulo>:compileKotlin 2>&1 | tail -50
 ```
 
 ## Paso 3: Verificaciones (si --verify o sin --fast)

--- a/.github/workflows/distribute-android.yml
+++ b/.github/workflows/distribute-android.yml
@@ -20,6 +20,13 @@ name: Distribución Android — Firebase App Distribution (3 Flavors)
 on:
   push:
     branches: [ main ]
+    paths:
+      - 'app/**'
+      - 'buildSrc/**'
+      - 'gradle/**'
+      - '*.gradle.kts'
+      - 'gradle.properties'
+      - 'settings.gradle.kts'
   workflow_dispatch:
     inputs:
       release_notes:

--- a/.github/workflows/distribute-desktop.yml
+++ b/.github/workflows/distribute-desktop.yml
@@ -23,6 +23,13 @@ name: Distribución Desktop — GitHub Releases (MSI + Deb)
 on:
   push:
     branches: [ main ]
+    paths:
+      - 'app/**'
+      - 'buildSrc/**'
+      - 'gradle/**'
+      - '*.gradle.kts'
+      - 'gradle.properties'
+      - 'settings.gradle.kts'
   workflow_dispatch:
     inputs:
       release_notes:

--- a/.github/workflows/distribute-web.yml
+++ b/.github/workflows/distribute-web.yml
@@ -22,6 +22,13 @@ name: Distribución Web — AWS S3 + CloudFront (Wasm)
 on:
   push:
     branches: [ main ]
+    paths:
+      - 'app/**'
+      - 'buildSrc/**'
+      - 'gradle/**'
+      - '*.gradle.kts'
+      - 'gradle.properties'
+      - 'settings.gradle.kts'
   workflow_dispatch:
     inputs:
       release_notes:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,14 @@ name: CI-CD Plataforma
 on:
   push:
     branches: [ main ]
+    paths:
+      - 'backend/**'
+      - 'users/**'
+      - 'buildSrc/**'
+      - 'gradle/**'
+      - '*.gradle.kts'
+      - 'gradle.properties'
+      - 'settings.gradle.kts'
   repository_dispatch:
 jobs:
   deploy-lambda:


### PR DESCRIPTION
## Resumen

Integración de smart-build.sh en el skill /builder con path filtering en workflows de GitHub Actions:

- **Skill /builder**: detecta módulos afectados automáticamente (backend/users/app/tools)
  - Cambios en backend → NO compila app ✅
  - Cambios en app → NO compila backend ✅
  - Archivos compartidos → build completo ✅
  - Transitividad: cambio en backend → recompila users ✅

- **main.yml**: deploy Lambda solo si cambios en backend/, users/ o archivos compartidos
  - Skip si solo app/, docs/, scripts/, .claude/

- **distribute-*.yml**: app distribution solo si cambios en app/** o archivos compartidos
  - distribute-android.yml, distribute-web.yml, distribute-desktop.yml
  - Skip si solo backend/, users/

## Criterios de aceptación

- [x] /builder detecta módulos afectados y compila solo esos
- [x] Backend-only NO compila app
- [x] Archivos compartidos disparan build completo
- [x] Transitividad: backend → users respetada
- [x] main.yml no deploya Lambda si solo app cambió
- [x] distribute-*.yml filtran por app/**
- [x] Tiempo de build reducido en PRs de un solo módulo

## Plan de verificación

- [x] smart-build.sh sintaxis válida ✅
- [x] Path filtering en 4 workflows válido ✅
- [x] Lógica de negocio verificada ✅
- [x] Skill /builder documentado ✅

Closes #1657

🤖 Generado con [Claude Code](https://claude.ai/claude-code)