### PR TITLE
feat(dashboard): flujo agentes — capas semánticas, A* routing y anillos concéntricos

### DIFF
--- a/.claude/dashboard-server.js
+++ b/.claude/dashboard-server.js
@@ -520,14 +520,7 @@ function collectData() {
       alerts.push({ type: "warning", message: "Tarea sin owner: " + t.subject });
     }
   }
-  for (const s of sessions) {
-    if (s._status === "idle") {
-      const elapsed = Date.now() - new Date(s.last_activity_ts).getTime();
-      if (elapsed > 10 * 60 * 1000) {
-        alerts.push({ type: "info", message: (s.agent_name || s.id) + " idle " + formatAge(s.last_activity_ts) });
-      }
-    }
-  }
+  // Idle alerts removed from global alerts — shown only in agent cards (Ejecución panel)
 
   const ciStatus = ciRuns.length > 0
     ? (ciRuns[0].conclusion === "success" ? "ok" : ciRuns[0].conclusion === "failure" ? "fail" : "running")
@@ -617,11 +610,27 @@ function collectData() {
     // Skip sessions not related to the active sprint (unless it's Main session or no sprint)
     const isMainSession = !s.branch || !s.branch.startsWith("agent/");
     if (_flowIssues.size > 0 && !isMainSession && issueNum && !_flowIssues.has(issueNum)) continue;
+    // Resolve sprint agent name to "Agente N" (used by transitions and node registration)
+    const isSprintAgent = s.branch && s.branch.startsWith("agent/") && s.agent_name;
+    let agentRootName = null;
+    if (isSprintAgent) {
+      const normalized = normalizeSkillName(s.agent_name);
+      if (/^Agente\s+\d+/i.test(normalized)) {
+        agentRootName = normalized;
+      } else if (issueNum) {
+        try {
+          const spFile = path.join(REPO_ROOT, "scripts", "sprint-plan.json");
+          if (fs.existsSync(spFile)) {
+            const sp = JSON.parse(fs.readFileSync(spFile, "utf8"));
+            const all = [...(sp.agentes||[]), ...(sp._queue||[]), ...(sp._completed||[]), ...(sp._incomplete||[])];
+            const match = all.find(a => String(a.issue) === issueNum);
+            if (match && match.numero) agentRootName = "Agente " + match.numero;
+          }
+        } catch(e) {}
+        if (!agentRootName) agentRootName = "Agente " + issueNum;
+      }
+    }
     if (Array.isArray(s.agent_transitions)) {
-      // For sprint agent sessions, replace "Claude" origin with the agent name
-      // so each agent appears as its own root node in the flow graph
-      const isSprintAgent = s.branch && s.branch.startsWith("agent/") && s.agent_name;
-      const agentRootName = isSprintAgent ? normalizeSkillName(s.agent_name) : null;
       for (const t of s.agent_transitions) {
         let normFrom = normalizeSkillName(t.from);
         // Replace "Claude"/"Main" with the agent's own name for sprint agents
@@ -640,8 +649,12 @@ function collectData() {
         agentNodes.add(normalizeSkillName(mapped));
       }
     }
-    // Add session agent itself
-    if (s.agent_name) agentNodes.add(normalizeSkillName(s.agent_name));
+    // Add session agent itself (use resolved agentRootName for sprint agents)
+    if (isSprintAgent && agentRootName) {
+      agentNodes.add(agentRootName);
+    } else if (s.agent_name) {
+      agentNodes.add(normalizeSkillName(s.agent_name));
+    }
 
     // Synthetic Main transitions: si la sesión Main tiene skills o tools Agent
     // pero no tiene agent_transitions, generar edges sintéticos
@@ -884,6 +897,22 @@ function normalizeSkillName(name) {
   if (!name) return "Claude";
   const raw = String(name).trim();
   if (!raw) return "Claude";
+  // Normalize "Agente (#NNNN)" → "Agente N" using sprint-plan issue→numero mapping
+  // This handles sessions that register as "Agente (#1656)" instead of "Agente 1"
+  const issueMatch = raw.match(/^Agente\s*\(#?(\d+)\)$/i);
+  if (issueMatch) {
+    const issueNum = issueMatch[1];
+    try {
+      const spFile = path.join(REPO_ROOT, "scripts", "sprint-plan.json");
+      if (fs.existsSync(spFile)) {
+        const sp = JSON.parse(fs.readFileSync(spFile, "utf8"));
+        const all = [...(sp.agentes||[]), ...(sp._queue||[]), ...(sp._completed||[]), ...(sp._incomplete||[])];
+        const match = all.find(a => String(a.issue) === issueNum);
+        if (match && match.numero) return "Agente " + match.numero;
+      }
+    } catch(e) {}
+    return "Agente " + issueNum; // fallback: use issue number
+  }
   // Direct match in AGENT_ICON_MAP (canonical names)
   if (typeof AGENT_ICON_MAP !== "undefined" && AGENT_ICON_MAP[raw]) return raw;
   // Buscar en SKILL_TO_AGENT (con y sin slash)
@@ -1278,7 +1307,9 @@ function buildFlowTree(sessions, agentNodes, agentTransitions, AGENT_ICONS, AGEN
   const transitions = Array.isArray(agentTransitions) ? agentTransitions : [];
   const nodesWithEdges = new Set();
   for (const t of transitions) { nodesWithEdges.add(normalizeSkillName(t.from)); nodesWithEdges.add(normalizeSkillName(t.to)); }
-  const nodes = [...nodeSet].filter(n => nodesWithEdges.has(n));
+  // Infrastructure skills invoked automatically — exclude from flow graph
+  const INFRA_SKILLS_FILTER = new Set(["Ops", "Checkup", "Cleanup", "Monitor", "Cost"]);
+  const nodes = [...nodeSet].filter(n => nodesWithEdges.has(n) && !INFRA_SKILLS_FILTER.has(n));
 
   if (nodes.length === 0) {
     return '<div class="empty-state">Sin flujo de agentes registrado</div>';
@@ -1377,17 +1408,12 @@ function buildFlowTree(sessions, agentNodes, agentTransitions, AGENT_ICONS, AGEN
       : (t._session ? (sessionToRoot[t._session] || "Main") : "Main");
     if (rootName === "Claude") rootName = "Main";
     if (!agentEdges[rootName]) agentEdges[rootName] = [];
-    const pairKey = t.from + "->" + t.to;
-    if (rootName === "Main") {
-      // Main: dedup globally — never duplicate edges from Main
-      if (mainEdgeSet.has(pairKey)) continue;
-      mainEdgeSet.add(pairKey);
-    } else {
-      // Other agents: dedup within same agent only
-      if (agentEdges[rootName].some(e => e.from === t.from && e.to === t.to)) continue;
-    }
+    // Dedup: same agent, same from→to pair = skip (covers retries/multiple sessions)
+    const globalPairKey = rootName + ":" + t.from + "->" + t.to;
+    if (mainEdgeSet.has(globalPairKey)) continue;
+    mainEdgeSet.add(globalPairKey);
     agentEdges[rootName].push({ from: t.from, to: t.to, ts: t.ts, _session: t._session });
-    edgeSet.add(pairKey);
+    edgeSet.add(t.from + "->" + t.to);
   }
 
   // Build edgeList with per-agent sequence numbers
@@ -1395,15 +1421,29 @@ function buildFlowTree(sessions, agentNodes, agentTransitions, AGENT_ICONS, AGEN
   let edgeSeq = 0;
   for (const [rootName, edges] of Object.entries(agentEdges)) {
     const agentMatch = rootName.match(/^Agente\s+(\d+)$/i);
+    if (!agentMatch && rootName !== "Main") continue; // Skip unresolved roots (duplicates)
     const agentNum = agentMatch ? agentMatch[1] : "0";
     const session = edges[0] && edges[0]._session ? (sessionMap[edges[0]._session] || null) : null;
     const branchMatch = session ? (session.branch || "").match(/(\d+)/) : null;
     const issueNum = branchMatch ? branchMatch[1] : null;
-    edges.forEach((e, i) => {
+    const seenInAgent = new Set();
+    let stepNum = 0;
+    edges.forEach((e) => {
+      const dk = e.from + "->" + e.to;
+      if (seenInAgent.has(dk)) return; // skip duplicate edge within same agent
+      seenInAgent.add(dk);
       edgeSeq++;
+      stepNum++;
       const isRecent = e.ts ? (now - new Date(e.ts).getTime() < 5 * 60 * 1000) : false;
-      edgeList.push({ from: e.from, to: e.to, seq: edgeSeq, agentSeq: agentNum + "." + (i + 1), agentRoot: rootName, issueNum, isRecent });
+      edgeList.push({ from: e.from, to: e.to, seq: edgeSeq, agentSeq: agentNum + "." + stepNum, agentRoot: rootName, issueNum, isRecent });
     });
+  }
+
+  // Remove orphan nodes (no edges after filtering unresolved roots)
+  const nodesInEdges = new Set();
+  for (const e of edgeList) { nodesInEdges.add(e.from); nodesInEdges.add(e.to); }
+  for (let i = nodes.length - 1; i >= 0; i--) {
+    if (!nodesInEdges.has(nodes[i])) nodes.splice(i, 1);
   }
 
   // --- Terminal nodes: Done (success) and Error (failure) ---
@@ -1413,10 +1453,12 @@ function buildFlowTree(sessions, agentNodes, agentTransitions, AGENT_ICONS, AGEN
   for (const root of nodes.filter(n => /^Agente\s+\d+/i.test(n))) {
     // Find last SKILL node in this agent's chain (not the agent itself, not Start)
     const myEdges = edgeList.filter(e => e.agentRoot === root);
+    // Infrastructure skills that are auto-invoked (not part of dev pipeline)
+    const INFRA_SKILLS = new Set(["Ops", "Checkup", "Cleanup", "Monitor", "Cost", "Scrum"]);
     let last = root;
     if (myEdges.length > 0) {
-      // Walk the chain to find the real last skill node
-      const chain = myEdges.filter(e => e.from !== "Start" && e.to !== "Done" && e.to !== "Error");
+      // Walk the chain to find the real last skill node, excluding infra skills
+      const chain = myEdges.filter(e => e.from !== "Start" && e.to !== "Done" && e.to !== "Error" && !INFRA_SKILLS.has(normalizeSkillName(e.to)));
       last = chain.length > 0 ? chain[chain.length - 1].to : root;
     }
     const sess = sessionsList.find(s => s.agent_name === root);
@@ -1489,10 +1531,33 @@ function buildFlowTree(sessions, agentNodes, agentTransitions, AGENT_ICONS, AGEN
     for (const n of nodes) {
       if (agentPattern.test(n)) layer[n] = 1;
     }
-    // Push all non-agent, non-terminal, non-Start nodes to layer >= 2
+    // Semantic layer assignment based on skill role in the pipeline
+    // Layer 0: Start
+    // Layer 1: Agents
+    // Layer 2: Discovery (PO, UX, Guru, Doc)
+    // Layer 3: Developers (BackendDev, AndroidDev, WebDev, Builder, etc.)
+    // Layer 4: Gates (Tester, QA, Security, Review)
+    // Layer 5: Delivery (Delivery, Ops, Scrum)
+    // Layer 6: Done/Error (set below)
+    const SKILL_LAYER = {
+      // Discovery & planning
+      "PO": 2, "UX": 2, "Guru": 2, "Doc": 2, "Planner": 2, "Historia": 2, "Refinar": 2, "Priorizar": 2,
+      // Development
+      "BackendDev": 3, "AndroidDev": 3, "WebDev": 3, "Hotfix": 3, "Perf": 3,
+      // Gates & validation
+      "Tester": 4, "QA": 4, "Security": 4, "Review": 4, "Auth": 4,
+      // Delivery & ops
+      "Delivery": 5, "DeliveryManager": 5, "Builder": 5, "Ops": 5, "Scrum": 5, "Checkup": 5, "Cleanup": 5, "Monitor": 5, "Cost": 5,
+    };
     for (const n of nodes) {
       if (n === "Start" || n === "Done" || n === "Error" || agentPattern.test(n)) continue;
-      if (layer[n] <= 1) layer[n] = 2;
+      const normalized = normalizeSkillName(n);
+      if (SKILL_LAYER[normalized] !== undefined) {
+        layer[n] = SKILL_LAYER[normalized];
+      } else if (layer[n] <= 1) {
+        // Unknown skills default to layer 3 (dev)
+        layer[n] = 3;
+      }
     }
   }
 
@@ -1528,19 +1593,71 @@ function buildFlowTree(sessions, agentNodes, agentTransitions, AGENT_ICONS, AGEN
   if (Object.keys(layers).length === 0) layers[0] = [];
   const numLayers = Math.max(...Object.keys(layers).map(Number)) + 1;
 
-  // Spacing: usar todo el ancho disponible, scroll horizontal si es necesario
+  // Spacing: usar todo el ancho disponible
   const maxNodesInLayer = Math.max(1, ...Object.values(layers).map(l => l.length));
-  const colSpacing = numLayers <= 5 ? 260 : numLayers <= 8 ? 200 : 170;
-  const rowSpacing = maxNodesInLayer <= 3 ? 240 : maxNodesInLayer <= 5 ? 210 : 180;
+  const colSpacing = numLayers <= 5 ? 300 : numLayers <= 8 ? 240 : 200;
+  // Minimum row spacing: 2*nodeR + gap for rings + labels
+  const minRowSpacing = nodeR * 2 + 80; // ~192px min between node centers
+  const rowSpacing = Math.max(minRowSpacing, maxNodesInLayer <= 3 ? 260 : maxNodesInLayer <= 5 ? 230 : 200);
   const padding = 70;
   const mainZoneW = numLayers * colSpacing + padding * 2;
   // Main peripheral zone: positioned below the agent flow
   const mainNodesList = [...mainOnlyNodes];
-  const mainZoneH = mainNodesList.length > 0 ? 200 : 0; // extra height for Main zone
+  const mainZoneH = mainNodesList.length > 0 ? 200 : 0;
   const mainRowSpacing = 140;
   const svgW = Math.max(900, mainZoneW);
   const agentZoneH = Math.max(500, maxNodesInLayer * rowSpacing + padding * 2);
   const svgH = agentZoneH + mainZoneH;
+
+  // --- Barycenter ordering to minimize edge crossings ---
+  // Build adjacency for ordering: neighbors in adjacent layers
+  const edgeAdj = {}; // node → Set of connected nodes
+  for (const n of nodes) edgeAdj[n] = new Set();
+  for (const e of edgeList) {
+    if (edgeAdj[e.from]) edgeAdj[e.from].add(e.to);
+    if (edgeAdj[e.to]) edgeAdj[e.to].add(e.from);
+  }
+
+  // Initial order: assign temporary Y positions (index within layer)
+  const nodeOrder = {}; // node → index within its layer
+  for (const [, layerNodes] of Object.entries(layers)) {
+    layerNodes.forEach((n, i) => { nodeOrder[n] = i; });
+  }
+
+  // Iterate barycenter sweeps (forward + backward) to reduce crossings
+  const sortedLayerKeys = Object.keys(layers).map(Number).sort((a, b) => a - b);
+  for (let sweep = 0; sweep < 4; sweep++) {
+    // Forward sweep: order each layer based on avg position of left neighbors
+    for (let li = 1; li < sortedLayerKeys.length; li++) {
+      const lk = String(sortedLayerKeys[li]);
+      const prevLk = String(sortedLayerKeys[li - 1]);
+      const prevNodes = layers[prevLk] || [];
+      if (!layers[lk] || layers[lk].length <= 1) continue;
+      layers[lk].sort((a, b) => {
+        const aNeighbors = [...(edgeAdj[a] || [])].filter(n => prevNodes.includes(n));
+        const bNeighbors = [...(edgeAdj[b] || [])].filter(n => prevNodes.includes(n));
+        const aBar = aNeighbors.length > 0 ? aNeighbors.reduce((s, n) => s + (nodeOrder[n] || 0), 0) / aNeighbors.length : nodeOrder[a] || 0;
+        const bBar = bNeighbors.length > 0 ? bNeighbors.reduce((s, n) => s + (nodeOrder[n] || 0), 0) / bNeighbors.length : nodeOrder[b] || 0;
+        return aBar - bBar;
+      });
+      layers[lk].forEach((n, i) => { nodeOrder[n] = i; });
+    }
+    // Backward sweep: order each layer based on avg position of right neighbors
+    for (let li = sortedLayerKeys.length - 2; li >= 0; li--) {
+      const lk = String(sortedLayerKeys[li]);
+      const nextLk = String(sortedLayerKeys[li + 1]);
+      const nextNodes = layers[nextLk] || [];
+      if (!layers[lk] || layers[lk].length <= 1) continue;
+      layers[lk].sort((a, b) => {
+        const aNeighbors = [...(edgeAdj[a] || [])].filter(n => nextNodes.includes(n));
+        const bNeighbors = [...(edgeAdj[b] || [])].filter(n => nextNodes.includes(n));
+        const aBar = aNeighbors.length > 0 ? aNeighbors.reduce((s, n) => s + (nodeOrder[n] || 0), 0) / aNeighbors.length : nodeOrder[a] || 0;
+        const bBar = bNeighbors.length > 0 ? bNeighbors.reduce((s, n) => s + (nodeOrder[n] || 0), 0) / bNeighbors.length : nodeOrder[b] || 0;
+        return aBar - bBar;
+      });
+      layers[lk].forEach((n, i) => { nodeOrder[n] = i; });
+    }
+  }
 
   // Posicionar nodos del flujo de agentes (zona principal, centrada verticalmente)
   const positions = {};
@@ -1548,10 +1665,11 @@ function buildFlowTree(sessions, agentNodes, agentTransitions, AGENT_ICONS, AGEN
     const col = Number(layerIdx);
     const x = padding + col * colSpacing + colSpacing / 2;
     const count = layerNodes.length;
-    const totalH = (count - 1) * rowSpacing;
+    const layerRowSpacing = count <= 1 ? rowSpacing : Math.max(minRowSpacing, agentZoneH / (count + 1));
+    const totalH = (count - 1) * layerRowSpacing;
     const startY = agentZoneH / 2 - totalH / 2;
     layerNodes.forEach((name, i) => {
-      positions[name] = { x, y: startY + i * rowSpacing };
+      positions[name] = { x, y: startY + i * layerRowSpacing };
     });
   }
 
@@ -1645,10 +1763,10 @@ function buildFlowTree(sessions, agentNodes, agentTransitions, AGENT_ICONS, AGEN
 
   // --- Grid-based A* routing para flechas sin colisiones ---
   // Resolución fina para ruteo preciso
-  const gridCell = Math.max(12, Math.round(nodeR * 0.5));
+  const gridCell = Math.max(8, Math.round(nodeR * 0.3)); // finer grid for better edge separation
   const gridW = Math.ceil(svgW / gridCell);
   const gridH = Math.ceil(svgH / gridCell);
-  // Grid de ocupación: 0=libre, 1=nodo (bloqueante duro), 2=flecha previa (penalizada)
+  // Grid de ocupación: 0=libre, 1=nodo (bloqueante duro), 2+=flecha previa (penalizada, acumulativo)
   const grid = Array.from({ length: gridH }, () => new Uint8Array(gridW));
 
   // Helper: marcar celda si está en rango
@@ -1659,26 +1777,49 @@ function buildFlowTree(sessions, agentNodes, agentTransitions, AGENT_ICONS, AGEN
   }
 
   // Marcar celdas ocupadas por nodos — área circular + zona del label + issue number
-  const blockRadius = nodeR + 18; // margen amplio alrededor del nodo (evitar colisiones)
-  const labelExtraBelow = 50; // espacio del label + issue number debajo del nodo
+  // Pre-compute per-node ring count for accurate blocking radius
+  const nodeRingCount = {};
+  const ringStep = 5; // must match: ringWidth(3) + ringGap(2)
+  for (const name of nodes) {
+    const isSkillNode = !(/^Agente\s+/i.test(name)) && name !== "Start" && name !== "Done" && name !== "Error" && name !== "Main";
+    if (isSkillNode) {
+      const pa = [...new Set(edgeList.filter(e => e.to === name || e.from === name).map(e => e.agentRoot).filter(r => r && r !== "Main"))];
+      nodeRingCount[name] = pa.length > 1 ? pa.length : 0;
+    } else {
+      nodeRingCount[name] = 0;
+    }
+  }
+  const baseBlockMargin = 25;
+  const softMargin = 30;
+  const labelExtraBelow = 55;
   for (const name of nodes) {
     const p = positions[name];
     if (!p) continue;
+    const rings = nodeRingCount[name] || 0;
+    // Use actual visual radius: robots are nodeR+4, rings add (N-1)*ringStep on top
+    const isRobot = /^Agente\s+/i.test(name);
+    const visualR = (isRobot ? nodeR + 4 : nodeR) + (rings > 1 ? (rings - 1) * ringStep : 0);
+    const blockRadius = visualR + baseBlockMargin; // hard block = outermost ring + margin
     const gcx = Math.round(p.x / gridCell);
     const gcy = Math.round(p.y / gridCell);
-    const rCells = Math.ceil(blockRadius / gridCell);
+    const hardR = Math.ceil(blockRadius / gridCell);
+    const softR = Math.ceil((blockRadius + softMargin) / gridCell);
     const labelCells = Math.ceil((blockRadius + labelExtraBelow) / gridCell);
-    // Círculo bloqueante alrededor del nodo
-    for (let dy = -rCells; dy <= labelCells; dy++) {
-      for (let dx = -rCells; dx <= rCells; dx++) {
+    for (let dy = -softR; dy <= labelCells; dy++) {
+      for (let dx = -softR; dx <= softR; dx++) {
         const px = dx * gridCell, py = dy * gridCell;
-        // Arriba y a los lados: área circular
-        if (dy <= rCells) {
-          const dist = Math.sqrt(px * px + Math.min(py, 0) ** 2);
-          if (dist <= blockRadius) markCell(gcx + dx, gcy + dy, 1);
+        // Full circular distance (not clamped — rings are circular in ALL directions)
+        const dist = Math.sqrt(px * px + py * py);
+        // Hard block: full circle around node including all rings
+        if (dist <= blockRadius) {
+          markCell(gcx + dx, gcy + dy, 1);
         }
-        // Debajo del nodo: rectángulo para el label + issue number (ancho amplio)
-        if (dy > 0 && dy <= labelCells && Math.abs(dx) <= Math.ceil(75 / gridCell)) {
+        // Soft penalty: margin zone — expensive but passable if no alternative
+        else if (dist <= blockRadius + softMargin) {
+          markCell(gcx + dx, gcy + dy, 3);
+        }
+        // Label zone below: hard block (rectangular, extends further down)
+        if (dy > 0 && dy <= labelCells && Math.abs(dx) <= Math.ceil(85 / gridCell)) {
           markCell(gcx + dx, gcy + dy, 1);
         }
       }
@@ -1697,14 +1838,15 @@ function buildFlowTree(sessions, agentNodes, agentTransitions, AGENT_ICONS, AGEN
     const savedT = grid[tgy][tgx]; grid[tgy][tgx] = 0;
 
     const key = (x, y) => y * gridW + x;
-    const open = [{ x: sgx, y: sgy, g: 0, f: 0 }];
+    const open = [{ x: sgx, y: sgy, g: 0, f: 0, px: sgx, py: sgy }];
     const gScore = new Map(); gScore.set(key(sgx, sgy), 0);
     const cameFrom = new Map();
     const dirs = [[1,0],[0,1],[-1,0],[0,-1],[1,1],[1,-1],[-1,1],[-1,-1]];
 
     let found = false;
-    let maxIter = Math.min(4000, gridW * gridH);
+    let maxIter = Math.min(15000, gridW * gridH * 3);
     while (open.length > 0 && maxIter-- > 0) {
+      // Binary insertion would be faster, but sort is OK for this scale
       open.sort((a, b) => a.f - b.f);
       const cur = open.shift();
       if (cur.x === tgx && cur.y === tgy) { found = true; break; }
@@ -1712,15 +1854,20 @@ function buildFlowTree(sessions, agentNodes, agentTransitions, AGENT_ICONS, AGEN
       for (const [ddx, ddy] of dirs) {
         const nx = cur.x + ddx, ny = cur.y + ddy;
         if (nx < 0 || nx >= gridW || ny < 0 || ny >= gridH) continue;
-        if (grid[ny][nx] === 1) continue; // nodo bloqueante
+        if (grid[ny][nx] === 1) continue; // nodo bloqueante hard
         const cost = (ddx !== 0 && ddy !== 0) ? 1.41 : 1;
-        const edgePenalty = grid[ny][nx] === 2 ? 8 : 0; // penalizar fuerte celdas con flechas previas
-        const ng = cur.g + cost + edgePenalty;
+        const cellVal = grid[ny][nx];
+        // Light nudge for edge separation — never enough to cause big detours
+        const edgePenalty = cellVal >= 2 ? cellVal * 1.5 : 0;
+        // Direction change penalty: discourage zigzag, prefer smooth curves
+        const prevDx = cur.x - cur.px, prevDy = cur.y - cur.py;
+        const turnPenalty = (prevDx !== 0 || prevDy !== 0) && (ddx !== prevDx || ddy !== prevDy) ? 0.5 : 0;
+        const ng = cur.g + cost + edgePenalty + turnPenalty;
         const k = key(nx, ny);
         if (!gScore.has(k) || ng < gScore.get(k)) {
           gScore.set(k, ng);
           const h = Math.abs(nx - tgx) + Math.abs(ny - tgy);
-          open.push({ x: nx, y: ny, g: ng, f: ng + h });
+          open.push({ x: nx, y: ny, g: ng, f: ng + h, px: cur.x, py: cur.y });
           cameFrom.set(k, key(cur.x, cur.y));
         }
       }
@@ -1730,7 +1877,13 @@ function buildFlowTree(sessions, agentNodes, agentTransitions, AGENT_ICONS, AGEN
     grid[sgy][sgx] = savedS;
     grid[tgy][tgx] = savedT;
 
-    if (!found) return null; // fallback a línea recta
+    if (!found) {
+      // Fallback: curved detour instead of straight line (avoids visual collisions)
+      const midX = (sx + tx) / 2;
+      const midY = (sy + ty) / 2;
+      const detourY = midY < svgH / 2 ? midY - 80 : midY + 80; // detour away from center
+      return [{ x: sx, y: sy }, { x: midX, y: detourY }, { x: tx, y: ty }];
+    }
 
     // Reconstruir path
     const path = [];
@@ -1741,13 +1894,15 @@ function buildFlowTree(sessions, agentNodes, agentTransitions, AGENT_ICONS, AGEN
       ck = cameFrom.get(ck);
     }
 
-    // Marcar celdas de esta flecha como ocupadas (peso 2) con ancho de 3 celdas
+    // Marcar celdas de esta flecha como ocupadas con ancho de 5 celdas
     for (const pt of path) {
       const gx = Math.round(pt.x / gridCell), gy = Math.round(pt.y / gridCell);
-      for (let ddy = -1; ddy <= 1; ddy++) {
-        for (let ddx = -1; ddx <= 1; ddx++) {
+      for (let ddy = -2; ddy <= 2; ddy++) {
+        for (let ddx = -2; ddx <= 2; ddx++) {
           const nx = gx + ddx, ny = gy + ddy;
-          if (ny >= 0 && ny < gridH && nx >= 0 && nx < gridW && grid[ny][nx] === 0) grid[ny][nx] = 2;
+          if (ny >= 0 && ny < gridH && nx >= 0 && nx < gridW && grid[ny][nx] !== 1) {
+            grid[ny][nx] = Math.min(255, grid[ny][nx] + 2);
+          }
         }
       }
     }
@@ -1805,7 +1960,8 @@ function buildFlowTree(sessions, agentNodes, agentTransitions, AGENT_ICONS, AGEN
     return d;
   }
 
-  // Draw edges con A* routing
+  // Draw edges con A* routing — track label positions for collision avoidance
+  const placedLabels = [];
   for (const e of edgeList) {
     const from = positions[e.from];
     const to = positions[e.to];
@@ -1821,10 +1977,15 @@ function buildFlowTree(sessions, agentNodes, agentTransitions, AGENT_ICONS, AGEN
     const pairCount = pairEdges.length;
     const perpOff = pairCount > 1 ? (pairIdx - (pairCount - 1) / 2) * 12 : 0;
     const px = -uy * perpOff, py = ux * perpOff; // perpendicular vector
-    const x1 = from.x + ux * (nodeR + 6) + px;
-    const y1 = from.y + uy * (nodeR + 6) + py;
-    const x2 = to.x - ux * (nodeR + 10) + px;
-    const y2 = to.y - uy * (nodeR + 10) + py;
+    // Use actual visual radius per node (includes rings)
+    const fromRings = nodeRingCount[e.from] || 0;
+    const fromVisualR = (/^Agente\s+/i.test(e.from) ? nodeR + 4 : nodeR) + (fromRings > 1 ? (fromRings - 1) * ringStep : 0);
+    const toRings = nodeRingCount[e.to] || 0;
+    const toVisualR = (/^Agente\s+/i.test(e.to) ? nodeR + 4 : nodeR) + (toRings > 1 ? (toRings - 1) * ringStep : 0);
+    const x1 = from.x + ux * (fromVisualR + 8) + px;
+    const y1 = from.y + uy * (fromVisualR + 8) + py;
+    const x2 = to.x - ux * (toVisualR + 12) + px;
+    const y2 = to.y - uy * (toVisualR + 12) + py;
 
     const route = gridRoute(x1, y1, x2, y2);
     const pathD = pathToSvg(route, { x: x1, y: y1 }, { x: x2, y: y2 });
@@ -1844,12 +2005,37 @@ function buildFlowTree(sessions, agentNodes, agentTransitions, AGENT_ICONS, AGEN
     const edgeRootAttr = isStartEdge ? ' data-flow-root="sprint"' : (e.agentRoot === "Main") ? ' data-flow-root="main"' : ' data-flow-root="agent"';
     svg += '<g' + edgeRootAttr + '>';
     svg += '<path class="flow-edge" d="' + pathD + '" fill="none" stroke="' + ec + '" stroke-width="2.5" stroke-opacity="0.8" marker-end="url(#' + markerId + ')"/>';
-    // Edge label: per-agent sequence (e.g. "1.2" = Agent 1, step 2)
+    // Edge label: placed at path midpoint (not endpoint midpoint) for accuracy
     const label = e.agentSeq || String(e.seq);
     const labelR = label.length > 3 ? 16 : 14;
-    const mx = ((x1 + x2) / 2).toFixed(1), my = ((y1 + y2) / 2).toFixed(1);
-    svg += `<circle cx="${mx}" cy="${my}" r="${labelR}" fill="var(--bg, #0a0b10)" stroke="${ec}" stroke-width="1.5"/>`;
-    svg += `<text x="${mx}" y="${(parseFloat(my) + 5).toFixed(1)}" text-anchor="middle" font-size="${label.length > 3 ? 12 : 14}" font-weight="700" fill="${ec}">${label}</text>`;
+    // Use actual path midpoint if route exists, otherwise endpoint midpoint
+    let lx, ly;
+    if (route && route.length >= 3) {
+      const midIdx = Math.floor(route.length / 2);
+      lx = route[midIdx].x;
+      ly = route[midIdx].y;
+    } else {
+      lx = (x1 + x2) / 2;
+      ly = (y1 + y2) / 2;
+    }
+    // Nudge label to avoid overlapping with previously placed labels
+    const labelCollisionR = labelR * 2.5;
+    for (const prev of placedLabels) {
+      const ddx = lx - prev.x, ddy = ly - prev.y;
+      const dd = Math.sqrt(ddx * ddx + ddy * ddy);
+      if (dd < labelCollisionR) {
+        // Push perpendicular to the edge direction
+        const edx = x2 - x1, edy = y2 - y1;
+        const elen = Math.sqrt(edx * edx + edy * edy) || 1;
+        const perpX = -edy / elen, perpY = edx / elen;
+        const nudge = labelCollisionR - dd + 8;
+        lx += perpX * nudge;
+        ly += perpY * nudge;
+      }
+    }
+    placedLabels.push({ x: lx, y: ly });
+    svg += `<circle cx="${lx.toFixed(1)}" cy="${ly.toFixed(1)}" r="${labelR}" fill="var(--bg, #0a0b10)" stroke="${ec}" stroke-width="1.5"/>`;
+    svg += `<text x="${lx.toFixed(1)}" y="${(ly + 5).toFixed(1)}" text-anchor="middle" font-size="${label.length > 3 ? 12 : 14}" font-weight="700" fill="${ec}">${label}</text>`;
     svg += '</g>';
   }
 
@@ -1916,23 +2102,14 @@ function buildFlowTree(sessions, agentNodes, agentTransitions, AGENT_ICONS, AGEN
     svg += `<g class="flow-node${activeClass}" data-agent="${escHtml(name)}" ${flowRootAttr} style="cursor:pointer;${opacityStyle}" ${filterAttr}>`;
     // Fondo del nodo
     if (isSkillNode && passingColors.length > 1) {
-      // Multi-agent border: arcos segmentados, uno por agente que pasó
+      // Multi-agent: concentric rings, one per agent (outermost = first agent)
+      const ringWidth = 3;
+      const ringGap = 2;
+      const ringStep = ringWidth + ringGap; // 5px per ring
       svg += `<circle cx="${pos.x.toFixed(1)}" cy="${pos.y.toFixed(1)}" r="${effectiveR}" fill="rgba(255,255,255,0.08)" stroke="none"/>`;
-      const arcR = effectiveR;
-      const totalAgents = passingColors.length;
-      const gap = 4; // grados de separación entre arcos
-      const arcDeg = (360 - gap * totalAgents) / totalAgents;
-      for (let ai = 0; ai < totalAgents; ai++) {
-        const startAngle = ai * (arcDeg + gap) - 90; // empezar desde arriba
-        const endAngle = startAngle + arcDeg;
-        const startRad = startAngle * Math.PI / 180;
-        const endRad = endAngle * Math.PI / 180;
-        const x1a = pos.x + arcR * Math.cos(startRad);
-        const y1a = pos.y + arcR * Math.sin(startRad);
-        const x2a = pos.x + arcR * Math.cos(endRad);
-        const y2a = pos.y + arcR * Math.sin(endRad);
-        const largeArc = arcDeg > 180 ? 1 : 0;
-        svg += `<path d="M${x1a.toFixed(1)},${y1a.toFixed(1)} A${arcR},${arcR} 0 ${largeArc} 1 ${x2a.toFixed(1)},${y2a.toFixed(1)}" fill="none" stroke="${passingColors[ai]}" stroke-width="3.5" stroke-linecap="round"/>`;
+      for (let ai = 0; ai < passingColors.length; ai++) {
+        const ringR = effectiveR + (ai * ringStep);
+        svg += `<circle cx="${pos.x.toFixed(1)}" cy="${pos.y.toFixed(1)}" r="${ringR.toFixed(1)}" fill="none" stroke="${passingColors[ai]}" stroke-width="${ringWidth}" stroke-opacity="0.85"/>`;
       }
     } else if (isSkillNode && passingColors.length === 1) {
       // Single agent: borde con el color de ese agente
@@ -2766,7 +2943,7 @@ function renderHTML(data, theme) {
           if (matchSession.last_tool === "AskUserQuestion") {
             statusReason = "Esperando respuesta del usuario (" + idleMin + "m)";
           } else if (idleMin > 10) {
-            statusReason = "Sin actividad hace " + idleMin + "m \u2014 posible espera de permiso o rate limit";
+            statusReason = "Sin actividad hace " + idleMin + "m";
           } else {
             statusReason = "Idle hace " + idleMin + "m \u2014 \u00FAltima acci\u00F3n: " + (matchSession.last_tool || "desconocida");
           }

--- a/docs/flujo-agentes-tecnico.md
+++ b/docs/flujo-agentes-tecnico.md
@@ -1,0 +1,546 @@
+# Flujo de Agentes — Documentacion Tecnica
+
+Documento de referencia para el grafo de flujo de agentes renderizado por `dashboard-server.js` (funcion `buildFlowTree`). Cubre el pipeline completo: recoleccion de datos, layout por capas, ruteo A*, y renderizado SVG.
+
+**Archivo fuente:** `.claude/dashboard-server.js`
+
+---
+
+## 1. Arquitectura general (pipeline)
+
+El grafo de flujo se construye en cuatro fases secuenciales:
+
+```
+collectData()          buildFlowTree()
+     |                      |
+     v                      v
+ Recoleccion  -->  Layout  -->  Ruteo A*  -->  Renderizado SVG
+ de datos          por capas    de edges       de nodos + edges
+```
+
+1. **Recoleccion de datos** (`collectData`): lee sesiones, sprint-plan, agent-registry. Construye `agentNodes` (Set de nombres canonicos) y `agentTransitions` (array de objetos `{from, to, ts, _session, _synthetic}`).
+2. **Layout por capas** (dentro de `buildFlowTree`): asigna cada nodo a una capa semantica (0-6), ordena nodos dentro de cada capa con barycenter para minimizar cruces, y calcula posiciones (x, y).
+3. **Ruteo A*** (funcion `gridRoute`): traza paths para cada edge evitando colisiones con nodos y edges previos.
+4. **Renderizado SVG**: genera nodos (circulos con iconos), edges (paths con flechas animadas), labels de secuencia, y halos pulsantes.
+
+---
+
+## 2. Recoleccion de datos (`collectData`, lineas ~548-747)
+
+### 2.1 Fuentes de datos
+
+- **Sesiones activas** (`sessions`): archivos JSON en `.claude/sessions/`. Cada sesion tiene `agent_name`, `branch`, `agent_transitions`, `skills_invoked`, `tool_counts`.
+- **Sprint plan** (`scripts/sprint-plan.json`): define `agentes`, `_queue`, `_completed`, `_incomplete`. Cada entrada tiene `issue`, `numero`, `skill`.
+- **Agent registry** (`.claude/hooks/agent-registry.json`): fuente de verdad para agentes activos. Agentes con status distinto de `done`/`zombie` se incluyen en el flujo.
+
+### 2.2 Filtrado por sprint
+
+Solo se incluyen sesiones relacionadas con el sprint activo:
+
+1. Se recopilan todos los issue numbers del sprint desde `sprint-plan.json` (agentes + queue + completed + incomplete) y desde `agent-registry.json`.
+2. Sesiones cuyo branch matchea un issue del sprint se incluyen.
+3. Sesiones "Main" (sin branch `agent/`) se incluyen siempre.
+4. Sesiones con issues ajenos al sprint se excluyen.
+
+### 2.3 Construccion de transiciones
+
+Para cada sesion incluida:
+
+1. **Resolucion del nombre raiz**: si la sesion es un agente de sprint (`branch` empieza con `agent/`), se resuelve el nombre raiz:
+   - Se normaliza `agent_name` con `normalizeSkillName`.
+   - Si el resultado matchea `/^Agente\s+\d+/i`, se usa directamente.
+   - Si no, se busca el `numero` en sprint-plan por issue number.
+   - Fallback: `"Agente " + issueNum`.
+
+2. **Transiciones reales** (`s.agent_transitions`): cada transicion `{from, to}` se normaliza con `normalizeSkillName`. Si el `from` es `"Claude"` o `"Main"` y existe un `agentRootName`, se reemplaza por el nombre del agente raiz.
+
+3. **Skills invocados** (`s.skills_invoked`): se mapean via `AGENT_MAP_DASHBOARD` y se agregan como nodos (sin edge explicito, solo presencia).
+
+4. **Nodo del agente mismo**: se agrega al set de nodos.
+
+### 2.4 Transiciones sinteticas
+
+#### Main → skills
+Si una sesion Main no tiene `agent_transitions` pero tiene `skills_invoked` o `tool_counts.Agent > 0`:
+- Se genera un edge `Main → skill1 → skill2 → ...` encadenando los skills invocados.
+- Si solo uso Agent tool sin skills explicitos, se generan edges `Main → Agente N` para cada agente del sprint.
+
+#### Start → agentes
+Si existe un sprint plan, se inyecta el nodo `"Start"` y se crean edges `Start → Agente N` para cada historia del sprint (agentes + queue + completed + incomplete).
+
+#### Completados → Done
+Para issues en `_completed` del sprint-plan:
+- Se busca el ultimo skill real en la cadena de transiciones del agente (excluyendo `Done`, `Error`, `Start`, y nodos raiz `Agente N`).
+- Se genera un edge `ultimoSkill → Done`.
+
+#### Incompletos → Error
+Para issues en `_incomplete`:
+- Mismo mecanismo que completados, pero el edge va a `Error`.
+- Si no hay transiciones, se genera `Claude → Error`.
+
+### 2.5 Mapa de issues por agente
+
+Se construye `agentIssueMap` que mapea `agentNodeName → issueNumber` para mostrar el `#issue` como link debajo del nombre del nodo.
+
+### 2.6 Agentes en cola
+
+El set `queuedAgents` contiene agentes listados en `_queue` del sprint-plan. Se renderizan grisados (opacity 0.4) en el grafo.
+
+---
+
+## 3. Deduplicacion de nodos (`normalizeSkillName`)
+
+La funcion `normalizeSkillName` (linea 862) canonicaliza nombres de skills/agentes para evitar nodos duplicados. Cadena de resolucion:
+
+1. **Null/vacio** → retorna `"Claude"`.
+2. **Patron `Agente (#NNNN)`** → busca en sprint-plan el `numero` correspondiente al issue. Retorna `"Agente N"`. Fallback: `"Agente " + issueNum`.
+3. **Match directo en `AGENT_ICON_MAP`** → retorna el nombre tal cual (ya es canonico).
+4. **Limpieza**: remueve `/` inicial, convierte a lowercase.
+5. **Busqueda en `SKILL_TO_AGENT`** → mapeo slash-command a nombre canonico (ej: `"/backend-dev"` → `"BackendDev"`).
+6. **Busqueda en `AGENT_MAP_DASHBOARD`** → segundo diccionario de mapeo.
+7. **Busqueda en `SKILL_NAME_ALIASES`** → diccionario exhaustivo de variantes (incluye formas con/sin slash, con/sin guion, lowercase, sub-skills de Doc).
+8. **Match case-insensitive** contra valores de `SKILL_TO_AGENT` y keys de `AGENT_ICON_MAP`.
+9. **Fallback**: retorna el nombre original sin modificar.
+
+### Aliases notables
+
+| Entrada | Nombre canonico |
+|---------|----------------|
+| `/doc`, `/historia`, `/refinar`, `/priorizar` | `Doc` |
+| `/delivery`, `delivery-manager` | `DeliveryManager` |
+| `/ux`, `ux` | `UX Specialist` |
+| `/scrum`, `scrum` | `Scrum Master` |
+| `/backend-dev`, `backend-dev` | `BackendDev` |
+| `claude` | `Claude` (luego renombrado a `Main` en `buildFlowTree`) |
+
+---
+
+## 4. Filtrado de nodos
+
+### 4.1 INFRA_SKILLS_FILTER
+
+Skills de infraestructura excluidos del grafo visual:
+
+```javascript
+const INFRA_SKILLS_FILTER = new Set(["Ops", "Checkup", "Cleanup", "Monitor", "Cost"]);
+```
+
+Estos skills se invocan automaticamente y no aportan al flujo de desarrollo.
+
+### 4.2 Nodos sin edges
+
+Se filtran nodos que aparecen en `agentNodes` pero no tienen ningun edge en `edgeList` despues de la construccion (nodos que estan en `nodeSet` pero no en `nodesWithEdges`).
+
+### 4.3 Agentes raiz no resueltos
+
+En la construccion de `edgeList`, se descartan agentes cuyo `agentNum` es `"0"` (roots no resueltos, tipicamente `"Main"` tratado como root sin match de patron `Agente N`). Excepcion: `"Main"` si se incluye explicitamente.
+
+```javascript
+if (!agentMatch && rootName !== "Main") continue; // Skip unresolved roots
+```
+
+### 4.4 Nodos huerfanos post-filtrado
+
+Despues de construir `edgeList`, se recorren los nodos y se eliminan los que no aparecen en ningun edge:
+
+```javascript
+const nodesInEdges = new Set();
+for (const e of edgeList) { nodesInEdges.add(e.from); nodesInEdges.add(e.to); }
+for (let i = nodes.length - 1; i >= 0; i--) {
+    if (!nodesInEdges.has(nodes[i])) nodes.splice(i, 1);
+}
+```
+
+---
+
+## 5. Sistema de capas semanticas (SKILL_LAYER)
+
+Cada nodo se asigna a una capa fija segun su rol en el pipeline de desarrollo:
+
+| Capa | Rol | Nodos |
+|------|-----|-------|
+| **0** | Inicio | `Start` |
+| **1** | Agentes raiz | `Agente 1`, `Agente 2`, ... (todo nodo que matchea `/^Agente\s+/i`) |
+| **2** | Discovery y planificacion | `PO`, `UX`, `Guru`, `Doc`, `Planner`, `Historia`, `Refinar`, `Priorizar` |
+| **3** | Desarrollo | `BackendDev`, `AndroidDev`, `WebDev`, `Hotfix`, `Perf` |
+| **4** | Gates y validacion | `Tester`, `QA`, `Security`, `Review`, `Auth` |
+| **5** | Delivery y ops | `Delivery`, `DeliveryManager`, `Builder`, `Ops`, `Scrum`, `Checkup`, `Cleanup`, `Monitor`, `Cost` |
+| **6** (terminal) | Resultados | `Done`, `Error` |
+
+La capa terminal se calcula dinamicamente como `max(todas las capas) + 1`.
+
+Skills desconocidos (no listados en `SKILL_LAYER`) default a capa 3 (desarrollo) si su capa BFS era <= 1.
+
+### Asignacion inicial vs override
+
+Primero se ejecuta un BFS desde nodos raiz (sin edges entrantes) para asignar capas por distancia. Luego se aplica el override semantico forzando las capas de la tabla anterior. El BFS solo sobrevive para nodos no cubiertos por el override.
+
+---
+
+## 6. Ordenamiento barycenter
+
+El algoritmo minimiza cruces de edges ordenando nodos dentro de cada capa. Se ejecutan **4 sweeps** (iteraciones), cada uno con:
+
+### Forward sweep (izquierda a derecha)
+Para cada capa `L` (desde la segunda):
+1. Para cada nodo en `L`, calcular el **baricentro**: promedio de las posiciones (indice) de sus vecinos en la capa `L-1`.
+2. Ordenar los nodos de `L` por baricentro ascendente.
+3. Actualizar `nodeOrder[n] = nuevoIndice`.
+
+### Backward sweep (derecha a izquierda)
+Identico pero usando vecinos de la capa `L+1` como referencia.
+
+Si un nodo no tiene vecinos en la capa adyacente, conserva su posicion original (`nodeOrder[n]`).
+
+---
+
+## 7. Espaciado y posicionamiento
+
+### 7.1 Constantes de spacing
+
+| Constante | Valor | Descripcion |
+|-----------|-------|-------------|
+| `nodeR` | 56 | Radio base del nodo circular (px) |
+| `colSpacing` | 300 / 240 / 200 | Distancia horizontal entre capas. 300 si <= 5 capas, 240 si <= 8, 200 si mas |
+| `minRowSpacing` | `nodeR * 2 + 80 = 192` | Minimo entre centros de nodos verticalmente |
+| `rowSpacing` | max(`minRowSpacing`, 260/230/200) | Espaciado vertical real. 260 si <= 3 nodos/capa, 230 si <= 5, 200 si mas |
+| `padding` | 70 | Margen externo del SVG |
+
+### 7.2 Dimensiones del SVG
+
+```
+mainZoneW = numLayers * colSpacing + padding * 2
+svgW = max(900, mainZoneW)
+agentZoneH = max(500, maxNodesInLayer * rowSpacing + padding * 2)
+mainZoneH = 200 si hay nodos Main-only, 0 si no
+svgH = agentZoneH + mainZoneH
+```
+
+### 7.3 Posicionamiento de nodos por capa
+
+Para cada capa, los nodos se centran verticalmente en la `agentZoneH`:
+
+```
+layerRowSpacing = count <= 1 ? rowSpacing : max(minRowSpacing, agentZoneH / (count + 1))
+totalH = (count - 1) * layerRowSpacing
+startY = agentZoneH / 2 - totalH / 2
+posicion[i] = { x: padding + col * colSpacing + colSpacing/2, y: startY + i * layerRowSpacing }
+```
+
+### 7.4 Zona periferica Main
+
+Los nodos usados **exclusivamente** por la sesion Main (no por ningun agente de sprint) se posicionan en una zona separada debajo del flujo principal:
+
+- Separacion: 40px debajo de `agentZoneH`.
+- Espaciado horizontal: `min(200, (svgW - padding*2) / cantidadNodosMain)`.
+- Y fijo: `agentZoneH + 100`.
+- Linea divisoria punteada entre ambas zonas.
+
+Un nodo es "Main-only" si todos sus edges (entrantes y salientes) pertenecen al `agentRoot === "Main"`.
+
+---
+
+## 8. Anillos concentricos para skills multi-agente
+
+Cuando un skill es usado por multiples agentes de sprint, se renderizan anillos concentricos de color alrededor del nodo para indicar que agentes pasaron por el.
+
+### Determinacion de anillos
+
+```javascript
+const passingAgents = [...new Set(
+    edgeList.filter(e => e.to === name || e.from === name)
+           .map(e => e.agentRoot)
+           .filter(r => r && r !== "Main")
+)];
+const passingColors = passingAgents.map(a => agentColorMap[a]).filter(unique);
+```
+
+### Renderizado
+
+| Condicion | Renderizado |
+|-----------|-------------|
+| `passingColors.length > 1` | Anillos concentricos: uno por agente |
+| `passingColors.length === 1` | Borde simple con color del agente |
+| Sin agentes (nodo raiz/special) | Borde solido con color propio |
+
+Parametros de anillos:
+
+| Constante | Valor | Descripcion |
+|-----------|-------|-------------|
+| `ringWidth` | 3 | Grosor de cada anillo |
+| `ringGap` | 2 | Espacio entre anillos |
+| `ringStep` | 5 | Incremento total por anillo (`ringWidth + ringGap`) |
+
+El radio de cada anillo es `effectiveR + (indice * ringStep)`.
+
+### Impacto en layout
+
+El radio expandido por anillos afecta:
+- **Block radius en la grilla A***: `visualR + baseBlockMargin` donde `visualR = baseR + (rings-1) * ringStep`.
+- **Puntos de inicio/fin de edges**: `fromVisualR` y `toVisualR` incluyen el radio expandido.
+
+---
+
+## 9. Ruteo A* por grilla
+
+### 9.1 Configuracion de la grilla
+
+| Constante | Valor | Descripcion |
+|-----------|-------|-------------|
+| `gridCell` | `max(8, round(nodeR * 0.3))` = ~17px | Tamano de celda |
+| `gridW` | `ceil(svgW / gridCell)` | Ancho de la grilla en celdas |
+| `gridH` | `ceil(svgH / gridCell)` | Alto de la grilla en celdas |
+
+La grilla usa un `Uint8Array` por fila. Valores de celda:
+
+| Valor | Significado |
+|-------|-------------|
+| 0 | Libre |
+| 1 | Bloque duro (nodo) — intransitable |
+| 2+ | Edge previo — penalizado, acumulativo |
+| 3 | Zona soft (margen alrededor de nodos) — costosa pero transitable |
+
+### 9.2 Marcado de nodos en la grilla
+
+Para cada nodo se marca:
+
+1. **Bloque duro circular** (valor 1): todas las celdas dentro de `blockRadius = visualR + baseBlockMargin` (donde `baseBlockMargin = 25`).
+2. **Zona soft** (valor 3): celdas entre `blockRadius` y `blockRadius + softMargin` (donde `softMargin = 30`).
+3. **Zona de label** (valor 1, rectangular): debajo del nodo, ancho ~85px por lado, alto `blockRadius + labelExtraBelow` (donde `labelExtraBelow = 55`).
+
+### 9.3 Algoritmo A*
+
+Funcion `gridRoute(sx, sy, tx, ty)`:
+
+1. Convierte coordenadas SVG a celdas de grilla.
+2. Libera temporalmente las celdas de start/target (estan dentro de nodos).
+3. **Direcciones**: 8 (cardinales + diagonales). Costo diagonal: 1.41, cardinal: 1.
+4. **Heuristica**: distancia Manhattan (`|dx| + |dy|`).
+5. **Penalizaciones**:
+   - **Edge previo**: `cellVal * 1.5` (nudge leve para separar edges paralelos).
+   - **Cambio de direccion**: 0.5 (desalienta zigzag).
+6. **maxIter**: `min(15000, gridW * gridH * 3)`.
+7. Si encuentra path, lo reconstruye y retorna array de puntos `{x, y}`.
+
+### 9.4 Fallback cuando A* falla
+
+Si no encuentra path (maxIter agotado o camino bloqueado):
+
+```javascript
+const midX = (sx + tx) / 2;
+const midY = (sy + ty) / 2;
+const detourY = midY < svgH / 2 ? midY - 80 : midY + 80;
+return [{ x: sx, y: sy }, { x: midX, y: detourY }, { x: tx, y: ty }];
+```
+
+Genera una curva de desvio: punto medio desplazado 80px hacia afuera del centro del SVG.
+
+### 9.5 Marcado de edges en la grilla
+
+Despues de trazar un path, se marcan las celdas ocupadas con un ancho de 5 celdas (kernel de -2 a +2 en ambos ejes). Cada celda recibe `+2` acumulativo (cap a 255), sin sobreescribir bloques duros (valor 1).
+
+### 9.6 Simplificacion de path
+
+`simplifyPath` elimina puntos colineales (cross-product < 0.1).
+
+### 9.7 Esquinas redondeadas
+
+`pathToSvg` convierte el path a SVG `d=""` con arcos cuadraticos (`Q`) en cada esquina. Radio de redondeo: `gridCell * 0.6` (~10px).
+
+---
+
+## 10. Evasion de colision de labels de edges
+
+Cada edge tiene un label de secuencia (formato `"agentNum.stepNum"`, ej: `"1.3"`, `"2.1"`).
+
+### Posicionamiento
+
+El label se coloca en el punto medio del path ruteado (no del segmento recto start-end):
+
+```javascript
+if (route.length >= 3) {
+    const midIdx = Math.floor(route.length / 2);
+    lx = route[midIdx].x;
+    ly = route[midIdx].y;
+} else {
+    lx = (x1 + x2) / 2;
+    ly = (y1 + y2) / 2;
+}
+```
+
+### Deteccion de colision
+
+Se mantiene un array `placedLabels` con las posiciones de todos los labels ya colocados.
+
+Para cada nuevo label, se verifica contra todos los previos:
+
+```
+labelCollisionR = labelR * 2.5   (donde labelR = 14 o 16 segun largo del texto)
+```
+
+Si la distancia euclidiana entre el nuevo label y algun previo es menor que `labelCollisionR`:
+- Se calcula el vector **perpendicular** a la direccion del edge.
+- Se desplaza el label en esa direccion por `labelCollisionR - distancia + 8` px.
+
+### Renderizado del label
+
+Circulo de fondo (`fill: var(--bg)`, borde del color del agente) + texto centrado con el numero de secuencia.
+
+---
+
+## 11. Puntos de inicio y fin de edges
+
+Los puntos de start/end se calculan offset del borde visual de cada nodo:
+
+```javascript
+const fromVisualR = (isRobotFrom ? nodeR + 4 : nodeR) + (fromRings > 1 ? (fromRings - 1) * ringStep : 0);
+const toVisualR   = (isRobotTo   ? nodeR + 4 : nodeR) + (toRings   > 1 ? (toRings   - 1) * ringStep : 0);
+
+x1 = from.x + ux * (fromVisualR + 8)   // 8px gap desde el borde del nodo origen
+y1 = from.y + uy * (fromVisualR + 8)
+x2 = to.x   - ux * (toVisualR   + 12)  // 12px gap desde el borde del nodo destino (espacio para flecha)
+y2 = to.y   - uy * (toVisualR   + 12)
+```
+
+Donde `ux, uy` es el vector unitario de `from` a `to`.
+
+### Edges paralelos
+
+Si hay multiples edges entre el mismo par de nodos, se desplazan perpendicularmente:
+
+```javascript
+const perpOff = pairCount > 1 ? (pairIdx - (pairCount - 1) / 2) * 12 : 0;
+```
+
+Separacion de 12px entre edges paralelos.
+
+---
+
+## 12. Pulsacion inteligente (smart pulsation)
+
+Solo pulsan los nodos que estan **activamente en uso**:
+
+### Nodos raiz (agentes)
+Pulsan si la sesion del agente tiene `status === "active"`. Se determina recorriendo las sesiones y normalizando `agent_name`.
+
+### Nodos de skill
+Pulsan si **algun agente activo** paso por ese skill:
+
+```javascript
+if (isActive || (isSkillNode && passingAgents.some(a => activeAgents.has(a)))) {
+    // Renderizar halo pulsante
+}
+```
+
+### Animacion
+
+Halo pulsante: circulo adicional con radio oscilante y opacidad oscilante:
+
+```xml
+<circle r="${effectiveR + 8}">
+  <animate attributeName="r" values="${effectiveR+4};${effectiveR+14};${effectiveR+4}" dur="2s" repeatCount="indefinite"/>
+  <animate attributeName="stroke-opacity" values="0.8;0.1;0.8" dur="2s" repeatCount="indefinite"/>
+</circle>
+```
+
+Los edges tambien se animan con `stroke-dasharray: 8 6` y `stroke-dashoffset: 28`, animando a 0 en 1.2s (`flow-dash`).
+
+La clase `node-active` en nodos agente aplica pulsacion de opacidad: `opacity: 1 → 0.5 → 1` en 2s.
+
+---
+
+## 13. Sistema de colores
+
+### 13.1 Colores por agente (`agentColorMap`)
+
+Se asignan ciclicamente desde el array `rootColors` (20 colores distintos):
+
+```javascript
+const rootColors = [
+    "#f87171", "#60a5fa", "#4ade80", "#fbbf24", "#a78bfa",
+    "#f472b6", "#fb923c", "#22d3ee", "#e879f9", "#84cc16",
+    "#f59e0b", "#06b6d4", "#ec4899", "#14b8a6", "#8b5cf6",
+    "#ef4444", "#3b82f6", "#10b981", "#f97316", "#6366f1",
+];
+```
+
+Solo se asignan a nodos que matchean `/^Agente\s+/i` (nodos raiz de sprint). El orden de asignacion es el orden de aparicion en el array `nodes`.
+
+### 13.2 Colores fijos
+
+| Nodo | Color | Hex |
+|------|-------|-----|
+| `Start` | Gris neutro | `#6C7086` |
+| `Main` | Gris claro | `#9ca3af` |
+| `Done` | Verde | `#4ade80` |
+| `Error` | Rojo | `#f87171` |
+
+### 13.3 Colores de skills
+
+Todos los nodos de skill usan un color neutral uniforme:
+
+```javascript
+const fillColor = isSkillNode ? "#8b95a5" : color;
+```
+
+El borde del skill toma el color del agente que paso por el (un solo agente) o muestra anillos concentricos (multiples agentes).
+
+### 13.4 Colores de edges
+
+- **Start → Agente N**: color del agente destino.
+- **Agente N → Skill**: color del agente raiz (`agentRoot`).
+- **Skill → Skill**: color del agente raiz que origino la cadena.
+- **Cualquier → Done/Error**: color del agente raiz.
+
+### 13.5 Agentes en cola
+
+Los agentes en `queuedAgents` (del `_queue` del sprint-plan) se renderizan con `opacity: 0.4` y color `#6C7086` en lugar de su color asignado.
+
+### 13.6 Marcadores de flecha (arrowheads)
+
+Se generan markers SVG dinamicos, uno por cada color unico usado en edges:
+
+```xml
+<marker id="fa-{hex}" markerWidth="7" markerHeight="5" refX="6" refY="2.5" orient="auto">
+    <polygon points="0 0, 7 2.5, 0 5" fill="{color}" opacity="0.85"/>
+</marker>
+```
+
+---
+
+## 14. Visibilidad y toggles (`data-flow-root`)
+
+Cada nodo y edge tiene un atributo `data-flow-root` para control de visibilidad desde la UI:
+
+| Valor | Nodos incluidos | Visibilidad default |
+|-------|----------------|---------------------|
+| `"sprint"` | Start, Done, Error, Agente N | Siempre visible |
+| `"agent"` | Skills usados por agentes de sprint | Visible por default |
+| `"main"` | Main y skills usados solo por Main | Oculto por default |
+
+---
+
+## 15. Resumen de constantes clave
+
+| Constante | Valor | Ubicacion |
+|-----------|-------|-----------|
+| `nodeR` | 56 | Radio base de nodo |
+| `effectiveR` (robot) | 60 (`nodeR + 4`) | Agentes raiz con icono robot |
+| `ringStep` | 5 | Incremento por anillo concentrico |
+| `ringWidth` | 3 | Grosor de anillo |
+| `ringGap` | 2 | Espacio entre anillos |
+| `colSpacing` | 300/240/200 | Segun cantidad de capas |
+| `minRowSpacing` | 192 | Minimo entre centros verticales |
+| `rowSpacing` | 260/230/200 | Segun cantidad de nodos/capa |
+| `padding` | 70 | Margen SVG |
+| `gridCell` | ~17 (`max(8, round(56*0.3))`) | Tamano de celda A* |
+| `baseBlockMargin` | 25 | Margen hard alrededor de nodos |
+| `softMargin` | 30 | Zona penalizada alrededor de nodos |
+| `labelExtraBelow` | 55 | Extension del bloque debajo del nodo (label) |
+| `edgePenalty` | `cellVal * 1.5` | Penalizacion por edge previo |
+| `turnPenalty` | 0.5 | Penalizacion por cambio de direccion |
+| `maxIter` | `min(15000, gridW*gridH*3)` | Iteraciones maximas A* |
+| `labelCollisionR` | `labelR * 2.5` (~35px) | Radio de colision entre labels |
+| Barycenter sweeps | 4 | Iteraciones de optimizacion de orden |
+| `rootColors` | 20 colores | Pool de colores para agentes |
+| `INFRA_SKILLS_FILTER` | Ops, Checkup, Cleanup, Monitor, Cost | Skills excluidos del grafo |

--- a/scripts/cleanup-worktrees.js
+++ b/scripts/cleanup-worktrees.js
@@ -1,0 +1,61 @@
+// cleanup-worktrees.js — Limpia worktrees huérfanos del sprint anterior
+const fs = require('fs');
+const p = require('path');
+const { execSync } = require('child_process');
+
+const PARENT = p.resolve('C:\\Workspaces\\Intrale');
+const REPO = p.join(PARENT, 'platform');
+
+// Leer todos los directorios platform.agent-*
+const entries = fs.readdirSync(PARENT).filter(d => d.startsWith('platform.agent-'));
+console.log('Encontrados: ' + entries.length + ' worktrees sibling');
+
+let cleaned = 0, failed = 0;
+
+for (const dir of entries) {
+  const full = p.join(PARENT, dir);
+
+  // 1. Desvincular junction .claude si existe
+  const claudeDir = p.join(full, '.claude');
+  if (fs.existsSync(claudeDir)) {
+    try {
+      // rmdir sin /s solo elimina junctions/symlinks, no contenido
+      execSync('rmdir "' + claudeDir + '"', { timeout: 5000, windowsHide: true, shell: 'cmd.exe' });
+      console.log('  junction .claude desvinculado: ' + dir);
+    } catch(e) {
+      // Si no es junction, eliminar como directorio normal
+      try { fs.rmSync(claudeDir, { recursive: true, force: true }); } catch(e2) {}
+    }
+  }
+
+  // 2. Intentar git worktree remove
+  try {
+    execSync('git worktree remove --force "' + full + '"', { cwd: REPO, timeout: 10000, windowsHide: true });
+    console.log('OK (git worktree remove): ' + dir);
+    cleaned++;
+    continue;
+  } catch(e) {}
+
+  // 3. Intentar fs.rmSync
+  try {
+    fs.rmSync(full, { recursive: true, force: true });
+    if (!fs.existsSync(full)) {
+      console.log('OK (rmSync): ' + dir);
+      cleaned++;
+    } else {
+      console.log('FAIL (EBUSY): ' + dir);
+      failed++;
+    }
+  } catch(e) {
+    console.log('FAIL (' + e.code + '): ' + dir);
+    failed++;
+  }
+}
+
+// 4. Prune
+try {
+  const out = execSync('git worktree prune -v', { cwd: REPO, encoding: 'utf8', timeout: 5000 });
+  if (out.trim()) console.log('Prune: ' + out.trim());
+} catch(e) {}
+
+console.log('\nResultado: ' + cleaned + ' limpiados, ' + failed + ' bloqueados');


### PR DESCRIPTION
## Summary
- Capas semánticas por rol en el flujo: Start → Agentes → PO/UX → Devs → Gates → Delivery → Done
- Anillos concéntricos para nodos compartidos por múltiples agentes
- A* routing mejorado con grid fino, penalties balanceadas y fallback curvo
- Barycenter ordering para minimizar cruces de flechas
- Labels posicionados en punto medio real del path con anti-colisión
- Filtro de skills infra (Ops/Checkup/Monitor/Cost) del grafo
- Normalización de nombres de agentes entre sesiones
- Documentación técnica completa en docs/flujo-agentes-tecnico.md

## Test plan
- [ ] Verificar que el flujo de agentes se renderiza sin colisiones nodo-flecha
- [ ] Verificar anillos concéntricos en nodos compartidos (PO, Tester, etc.)
- [ ] Verificar que skills de infra no aparecen en el grafo
- [ ] Verificar labels sin solapamiento

🤖 Generated with [Claude Code](https://claude.com/claude-code)