### PR TITLE
fix(wasm): pinear binaryen v118 para evitar SIGSEGV en CI

### DIFF
--- a/app/composeApp/build.gradle.kts
+++ b/app/composeApp/build.gradle.kts
@@ -198,6 +198,11 @@ kotlin {
             }
         }
         binaries.executable()
+        // binaryen v123 crashea con SIGSEGV en GitHub Actions runners.
+        // Pinear a v118 (estable) hasta que upstream lo resuelva.
+        applyBinaryen {
+            binaryenVersion.set("version_118")
+        }
     }
     
     sourceSets {


### PR DESCRIPTION
## Problema
**binaryen v123 crashea con SIGSEGV (exit code 139)** en los runners de GitHub Actions.

### Impacto
4 fallos consecutivos en **Distribución Web — AWS S3 + CloudFront (Wasm)**:
- 2026-03-20 14:10:10Z
- 2026-03-20 14:15:36Z
- 2026-03-20 15:01:57Z
- 2026-03-20 16:33:47Z

El task `compileProductionExecutableKotlinWasmJsOptimize` invoca `wasm-opt` (binaryen) que crashea sin logs útiles. Exit code 139 = SIGSEGV (segmentation fault).

### Solución
Pinear binaryen a **version_118** (versión estable conocida) en el target `wasmJs` del Gradle build.

```kotlin
applyBinaryen {
    binaryenVersion.set("version_118")
}
```

Esto fuerza a Kotlin/Wasm a usar binaryen v118 en lugar de v123 (la versión por defecto en Kotlin 2.2.21).

### Testing
- [ ] Build Wasm debe pasar en CI sin crashear
- [ ] Tamaño del binario web es aceptable (puede variar levemente vs v123)

### Referencias
- Kotlin/Wasm: https://youtrack.jetbrains.com/issues/KT (buscar binaryen crashes)