### PR TITLE
feat(dashboard): Normalizar nombres de agentes en sesiones, registry y dashboard

### DIFF
--- a/.claude/dashboard-server.js
+++ b/.claude/dashboard-server.js
@@ -526,6 +526,22 @@ function collectData() {
     ? (ciRuns[0].conclusion === "success" ? "ok" : ciRuns[0].conclusion === "failure" ? "fail" : "running")
     : "unknown";
 
+  // Helper para resolver nombre de agente desde issue en el registry (#1733)
+  function resolveRegistryAgentName(issueStr) {
+    try {
+      const issueNum = parseInt(String(issueStr).replace(/^#/, ""), 10);
+      if (isNaN(issueNum)) return "Agente (?)";
+      if (sprintPlan) {
+        const all = [
+          ...(sprintPlan.agentes || []), ...(sprintPlan._queue || []),
+          ...(sprintPlan._completed || []), ...(sprintPlan._incomplete || []),
+        ];
+        const match = all.find(a => a.issue === issueNum);
+        if (match && match.numero) return "Agente " + match.numero;
+      }
+      return "Agente " + issueNum; // fallback: usar número de issue como aproximación
+    } catch(e) { return "Agente (?)"; }
+  }
   // Normalizar nombres de agentes: "Agente (#NNNN)" → "Agente N" usando sprint plan
   // Esto evita nodos duplicados en el flujo cuando sesiones/registry usan formatos diferentes
   if (sprintPlan) {
@@ -556,6 +572,32 @@ function collectData() {
           const toMatch = t.to.match(/Agente\s*\(#(\d+)\)/i);
           if (toMatch && issueToAgentNum[toMatch[1]]) t.to = "Agente " + issueToAgentNum[toMatch[1]];
         }
+      }
+    }
+  }
+
+    // Normalizar también agentes del registry: usar agent_name o resolver desde issue (#1733)
+  if (sprintPlan && registryAgents) {
+    const issueToAgentNum = {};
+    [...(sprintPlan.agentes || []), ...(sprintPlan._queue || []),
+     ...(sprintPlan._completed || []), ...(sprintPlan._incomplete || [])].forEach(a => {
+      if (a.issue && a.numero) issueToAgentNum[String(a.issue)] = a.numero;
+    });
+    for (const ra of registryAgents) {
+      // Normalizar skill si tiene formato "Agente (#N)"
+      if (ra.skill && /#d+/.test(ra.skill)) {
+        const m = ra.skill.match(/#(d+)/);
+        if (m && issueToAgentNum[m[1]]) ra.skill = "Agente " + issueToAgentNum[m[1]];
+      }
+      // Normalizar agent_name si tiene formato "Agente (#N)"
+      if (ra.agent_name && /#d+/.test(ra.agent_name)) {
+        const m = ra.agent_name.match(/#(d+)/);
+        if (m && issueToAgentNum[m[1]]) ra.agent_name = "Agente " + issueToAgentNum[m[1]];
+      }
+      // Si no tiene agent_name pero tiene issue del sprint, asignarlo
+      if (!ra.agent_name && ra.issue) {
+        const issueNum = String(ra.issue).replace(/^#/, "");
+        if (issueToAgentNum[issueNum]) ra.agent_name = "Agente " + issueToAgentNum[issueNum];
       }
     }
   }
@@ -4024,7 +4066,7 @@ function handleRequest(req, res) {
           .filter(a => a.status === "active" && !sessionIds.has(a.session_id))
           .map(a => ({
             id: a.session_id,
-            agent: a.skill || "Agente (#" + (a.issue || "?") + ")",
+            agent: a.agent_name || a.skill || (a.issue ? resolveRegistryAgentName(a.issue) : "Agente (?)"),
             lastTool: null,
             lastTarget: a.branch || "",
             actions: 0,

--- a/.claude/hooks/activity-logger.js
+++ b/.claude/hooks/activity-logger.js
@@ -49,12 +49,18 @@ const AGENT_MAP = {
 };
 
 // Mapeo de issue number a "Agente N" desde sprint-plan.json
+// Busca en todas las listas: agentes activos, cola, completados e incompletos (#1733)
 function getSprintAgentName(issueNum) {
     try {
         const planPath = path.join(REPO_ROOT, "scripts", "sprint-plan.json");
         const plan = JSON.parse(fs.readFileSync(planPath, "utf8"));
-        if (!Array.isArray(plan.agentes)) return null;
-        const entry = plan.agentes.find(a => a.issue === issueNum);
+        const all = [
+            ...(Array.isArray(plan.agentes) ? plan.agentes : []),
+            ...(Array.isArray(plan._queue) ? plan._queue : []),
+            ...(Array.isArray(plan._completed) ? plan._completed : []),
+            ...(Array.isArray(plan._incomplete) ? plan._incomplete : []),
+        ];
+        const entry = all.find(a => a.issue === issueNum);
         return entry ? "Agente " + entry.numero : null;
     } catch(e) { return null; }
 }
@@ -501,6 +507,14 @@ function updateSession(sessionId, ts, toolName, target, toolInput, usage) {
                 current_task: null,
                 current_tasks: [],
             };
+            // Resolver agent_name al crear la sesión: usar número del plan (#1733)
+            if (!session.agent_name && session.branch) {
+                const branchM = session.branch.match(/^agent\/(\d+)/);
+                if (branchM) {
+                    const n = parseInt(branchM[1], 10);
+                    session.agent_name = getSprintAgentName(n) || ("Agente " + n);
+                }
+            }
         }
 
         session.last_activity_ts = ts;
@@ -555,7 +569,7 @@ function updateSession(sessionId, ts, toolName, target, toolInput, usage) {
             if (branchMatch) {
                 const issueNum = parseInt(branchMatch[1], 10);
                 const sprintName = getSprintAgentName(issueNum);
-                session.agent_name = sprintName || ("Agente (#" + issueNum + ")");
+                session.agent_name = sprintName || ("Agente " + issueNum); // formato consistente sin "(#)" (#1733)
             } else if (session.branch !== "main" && session.branch !== "develop" && session.branch !== "unknown") {
                 const slug = session.branch.replace(/^[^/]+\//, "").substring(0, 20);
                 session.agent_name = "Agente (" + slug + ")";
@@ -711,6 +725,7 @@ function updateSession(sessionId, ts, toolName, target, toolInput, usage) {
                         agentRegistry.registerAgent({
                             session_id: sid,
                             issue: issueNum ? "#" + issueNum : null,
+                            agent_name: session.agent_name || null,
                             skill: session.agent_name || null,
                             branch: session.branch,
                             worktree: WORKTREE_ROOT !== REPO_ROOT ? WORKTREE_ROOT : null,

--- a/.claude/hooks/agent-registry.js
+++ b/.claude/hooks/agent-registry.js
@@ -96,6 +96,46 @@ function saveRegistry(registry) {
     }
 }
 
+
+// Resuelve el nombre canónico del agente desde sprint-plan.json dado un issue string (#1733)
+// Retorna "Agente N" (posición en el sprint) o null si no se encuentra.
+function resolveAgentName(issueStr) {
+    try {
+        const issueNum = parseInt(String(issueStr).replace(/^#/, ""), 10);
+        if (isNaN(issueNum)) return null;
+        // Resolver el repo root (main repo, no worktree)
+        let repoRoot = null;
+        try {
+            const { execSync } = require("child_process");
+            const gitCommon = execSync("git rev-parse --git-common-dir", { timeout: 3000, windowsHide: true })
+                .toString().trim().split(String.fromCharCode(92)).join("/");
+            if (gitCommon === ".git") {
+                repoRoot = process.cwd();
+            } else {
+                const gitIdx = gitCommon.indexOf("/.git");
+                if (gitIdx !== -1) repoRoot = gitCommon.substring(0, gitIdx);
+            }
+        } catch(e) {}
+        const sprintPlanPaths = [
+            repoRoot ? path.join(repoRoot, "scripts", "sprint-plan.json") : null,
+            path.join(__dirname, "..", "..", "scripts", "sprint-plan.json"),
+            "C:/Workspaces/Intrale/platform/scripts/sprint-plan.json",
+        ].filter(Boolean);
+        for (const p of sprintPlanPaths) {
+            if (!fs.existsSync(p)) continue;
+            const plan = JSON.parse(fs.readFileSync(p, "utf8"));
+            const all = [
+                ...(Array.isArray(plan.agentes) ? plan.agentes : []),
+                ...(Array.isArray(plan._queue) ? plan._queue : []),
+                ...(Array.isArray(plan._completed) ? plan._completed : []),
+                ...(Array.isArray(plan._incomplete) ? plan._incomplete : []),
+            ];
+            const match = all.find(a => a.issue === issueNum);
+            if (match && match.numero) return "Agente " + match.numero;
+        }
+        return null;
+    } catch(e) { return null; }
+}
 // ─── CRUD ────────────────────────────────────────────────────────────────────
 
 /**
@@ -118,6 +158,7 @@ function registerAgent(entry) {
             session_id: entry.session_id,
             issue: entry.issue || null,
             skill: entry.skill || null,
+            agent_name: entry.agent_name || (entry.issue ? resolveAgentName(entry.issue) : null) || null,
             branch: entry.branch || null,
             worktree: entry.worktree || null,
             pid: entry.pid || null,
@@ -267,6 +308,7 @@ function sweepRegistry() {
 // ─── Exports ─────────────────────────────────────────────────────────────────
 
 module.exports = {
+    resolveAgentName,
     REGISTRY_FILE,
     ZOMBIE_THRESHOLD_MS,
     IDLE_THRESHOLD_MS,


### PR DESCRIPTION
## Resumen

Normalizar a `Agente N` en todos los puntos de escritura:
- **activity-logger.js**: expandir `getSprintAgentName()` para buscar en `_queue`, `_completed`, `_incomplete`
- **activity-logger.js**: resolver `agent_name` al crear sesión (no esperar >2 acciones)
- **activity-logger.js**: cambiar fallback `"Agente (#N)"` → `"Agente N"` (formato consistente)
- **agent-registry.js**: agregar `resolveAgentName()` para mapear issue→número desde sprint-plan.json
- **agent-registry.js**: incluir `agent_name` en entrada nueva del registry
- **dashboard-server.js**: normalizar agents del registry al cargar datos
- **dashboard-server.js**: remover fallback `"Agente (#N)"` en mapper de registro

## Problema resuelto

Los agentes se registraban con nombres inconsistentes:
- `"Agente 1"` (plan)
- `"Agente (#1658)"` (registry)
- `"Agente (#1093)"` (sesión promovida)
- `null` (sesión sin agent_name)

Esto causaba nodos duplicados en el flujo del dashboard y checklists que no se asociaban.

## Plan de tests

- ✅ Sintaxis JS verificada en 3 archivos
- ✅ Paths en resolveAgentName con fallbacks robustos
- ✅ Securitygate: APROBADO (sin secrets, sin inyecciones)
- ✅ Code review: APROBADO (cambios consistentes)

## Gates completados

- ✅ /tester — N/A (archivos de infra)
- ✅ /security — APROBADO
- ✅ /review — APROBADO

Closes #1733

🤖 Generado con [Claude Code](https://claude.ai/claude-code)