### PR TITLE
fix(ci): pinear binaryen v118 — wasm-opt SIGSEGV en GitHub Actions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,9 @@ import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.gradle.kotlin.dsl.findByType
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+import org.jetbrains.kotlin.gradle.targets.wasm.binaryen.BinaryenPlugin as WasmBinaryenPlugin
+import org.jetbrains.kotlin.gradle.targets.wasm.binaryen.BinaryenEnvSpec as WasmBinaryenEnvSpec
 
 data class LegacyMatch(
     val path: String,
@@ -159,5 +162,13 @@ tasks.matching { it.name == "check" }.configureEach {
 
 tasks.matching { it.name == "build" }.configureEach {
     dependsOn("verifyNoLegacyStrings")
+}
+
+// Pinear binaryen v118 para evitar SIGSEGV en GitHub Actions (binaryen v123 crashea con exit 139)
+// Ver: https://github.com/intrale/platform/issues/1751
+// TODO: volver a versión default cuando binaryen resuelva el crash upstream
+@OptIn(ExperimentalWasmDsl::class)
+plugins.withType<WasmBinaryenPlugin> {
+    extensions.getByType<WasmBinaryenEnvSpec>().version.set("version_118")
 }
 


### PR DESCRIPTION
## Problema

**binaryen v123 crashea con SIGSEGV (exit code 139)** en los runners de GitHub Actions durante `compileProductionExecutableKotlinWasmJsOptimize`.

### Impacto
4 fallos consecutivos en **Distribución Web — AWS S3 + CloudFront (Wasm)** el 2026-03-20.

### Solución
Pinear binaryen a **version_118** (estable) en el build Gradle.

## Testing

- ✅ Tests unitarios: PASSED (backend + app)
- ✅ Verificación de strings: PASSED
- ✅ Build validation: PASSED (config + resources)

## QA E2E

- `qa:skipped` — cambio puro de configuración Gradle (infra/CI), sin lógica de negocio ni impacto en producto de usuario. Label justificado por CLAUDE.md.

## Follow-up

- Monitorear releases de binaryen para volver a versión default cuando se resuelva upstream

Closes #1751

🤖 Generado con [Claude Code](https://claude.ai/claude-code)