### PR TITLE
feat(infra): persistencia histórica de métricas de agentes y API

### DIFF
--- a/.claude/dashboard-server.js
+++ b/.claude/dashboard-server.js
@@ -3942,6 +3942,75 @@ function handleRequest(req, res) {
     const client = { res, alive: true };
     sseClients.add(client);
     req.on("close", () => { client.alive = false; sseClients.delete(client); });
+  } else if (pathname === "/api/history") {
+    // Endpoint de historial de métricas (#1716)
+    const SESSIONS_HISTORY_FILE = path.join(REPO_ROOT, ".claude", "hooks", "sessions-history.jsonl");
+    const sprintFilter = url.searchParams.get("sprint");
+    
+    try {
+      let sessions = [];
+      if (fs.existsSync(SESSIONS_HISTORY_FILE)) {
+        const lines = fs.readFileSync(SESSIONS_HISTORY_FILE, "utf8").split("\n").filter(l => l.trim());
+        sessions = lines.map(line => {
+          try { return JSON.parse(line); } catch(e) { return null; }
+        }).filter(s => s !== null);
+      }
+      
+      // Filtrar por sprint si se especifica
+      if (sprintFilter) {
+        sessions = sessions.filter(s => s.sprint_id === sprintFilter);
+      }
+      
+      // Agrupar por sprint y agregar metrics
+      const bySprintId = {};
+      sessions.forEach(s => {
+        const sid = s.sprint_id || "unknown";
+        if (!bySprintId[sid]) {
+          bySprintId[sid] = {
+            sprint_id: sid,
+            sessions: [],
+            summary: {
+              total_sessions: 0,
+              total_duration_min: 0,
+              total_tokens_input: 0,
+              total_tokens_output: 0,
+              total_cost_usd: 0,
+              total_tool_calls: 0,
+              agents: {}
+            }
+          };
+        }
+        bySprintId[sid].sessions.push(s);
+        bySprintId[sid].summary.total_sessions++;
+        bySprintId[sid].summary.total_duration_min += (s.duration_min || 0);
+        bySprintId[sid].summary.total_tokens_input += (s.tokens.input || 0);
+        bySprintId[sid].summary.total_tokens_output += (s.tokens.output || 0);
+        bySprintId[sid].summary.total_cost_usd += parseFloat(s.cost_usd || 0);
+        bySprintId[sid].summary.total_tool_calls += (s.model_usage && s.model_usage.tool_calls || 0);
+        
+        const agent = s.agent_name || "Unknown";
+        if (!bySprintId[sid].summary.agents[agent]) {
+          bySprintId[sid].summary.agents[agent] = { count: 0, duration_min: 0, cost_usd: 0 };
+        }
+        bySprintId[sid].summary.agents[agent].count++;
+        bySprintId[sid].summary.agents[agent].duration_min += (s.duration_min || 0);
+        bySprintId[sid].summary.agents[agent].cost_usd += parseFloat(s.cost_usd || 0);
+      });
+      
+      const result = sprintFilter && bySprintId[sprintFilter] 
+        ? bySprintId[sprintFilter]
+        : { sprints: Object.values(bySprintId), total_sprints: Object.keys(bySprintId).length };
+      
+      const json = JSON.stringify({
+        timestamp: new Date().toISOString(),
+        data: result
+      });
+      res.writeHead(200, { "Content-Type": "application/json", "Cache-Control": "no-cache" });
+      res.end(json);
+    } catch(e) {
+      res.writeHead(500, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: e.message }));
+    }
   } else if (pathname === "/api/status") {
     const data = collectData();
     const json = JSON.stringify({

--- a/.claude/hooks/sprint-sync.js
+++ b/.claude/hooks/sprint-sync.js
@@ -316,6 +316,65 @@ function archiveSprintMetrics(sprintId, velocity) {
         var sprintSessions = metricsData.sessions.filter(function(s) { return s.sprint_id === sprintId; });
         var payload = { sprint_id: sprintId, archived_at: new Date().toISOString(), velocity: velocity || 0, sessions: sprintSessions };
         sprintData.writeJson(archiveFile, payload);
+        
+        // Generar snapshot de sprint con métricas agregadas (#1716)
+        var aggregated = {
+            sprint_id: sprintId,
+            snapshot_at: new Date().toISOString(),
+            total_sessions: sprintSessions.length,
+            summary: {
+                total_duration_min: 0,
+                total_tokens_input: 0,
+                total_tokens_output: 0,
+                total_cost_usd: 0.0,
+                total_tool_calls: 0,
+                total_modified_files: 0,
+                total_tasks_created: 0,
+                total_tasks_completed: 0,
+                success_rate: 0.0
+            },
+            sessions_by_agent: {},
+            skills_breakdown: {}
+        };
+        
+        // Agregar métricas desde sesiones
+        sprintSessions.forEach(function(s) {
+            aggregated.summary.total_duration_min += (s.duration_min || 0);
+            aggregated.summary.total_tokens_input += (s.tokens_input || 0);
+            aggregated.summary.total_tokens_output += (s.tokens_output || 0);
+            aggregated.summary.total_tool_calls += (s.total_tool_calls || 0);
+            aggregated.summary.total_modified_files += (s.modified_files_count || 0);
+            aggregated.summary.total_tasks_created += (s.tasks_created || 0);
+            aggregated.summary.total_tasks_completed += (s.tasks_completed || 0);
+            var agentName = s.agent_name || "Unknown";
+            if (!aggregated.sessions_by_agent[agentName]) {
+                aggregated.sessions_by_agent[agentName] = { count: 0, duration_min: 0, tokens_input: 0, tokens_output: 0, tool_calls: 0, skills: [] };
+            }
+            aggregated.sessions_by_agent[agentName].count++;
+            aggregated.sessions_by_agent[agentName].duration_min += (s.duration_min || 0);
+            aggregated.sessions_by_agent[agentName].tokens_input += (s.tokens_input || 0);
+            aggregated.sessions_by_agent[agentName].tokens_output += (s.tokens_output || 0);
+            aggregated.sessions_by_agent[agentName].tool_calls += (s.total_tool_calls || 0);
+            if (Array.isArray(s.skills_invoked)) {
+                s.skills_invoked.forEach(function(sk) {
+                    if (!aggregated.skills_breakdown[sk]) aggregated.skills_breakdown[sk] = { count: 0, duration_min: 0 };
+                    aggregated.skills_breakdown[sk].count++;
+                    aggregated.skills_breakdown[sk].duration_min += (s.duration_min || 0);
+                });
+            }
+        });
+        if (aggregated.summary.total_sessions > 0) {
+            var successCount = sprintSessions.filter(function(s) { return (s.tasks_created || 0) > 0 && s.tasks_created === s.tasks_completed; }).length;
+            aggregated.summary.success_rate = (successCount / aggregated.summary.total_sessions * 100).toFixed(1);
+        }
+        
+        // Guardar snapshot a docs/sprints/SPR-NNN-metrics.json
+        try {
+            var snapshotDir = path.join(REPO_ROOT, "docs", "sprints");
+            if (!fs.existsSync(snapshotDir)) fs.mkdirSync(snapshotDir, { recursive: true });
+            var snapshotFile = path.join(snapshotDir, sprintId + "-metrics.json");
+            fs.writeFileSync(snapshotFile, JSON.stringify(aggregated, null, 2) + "\n", "utf8");
+        } catch (sse) { /* ignorar errores al guardar snapshot */ }
         return { ok: true, archiveFile: archiveFile, sessionsArchived: sprintSessions.length };
     } catch (e) { return { ok: false, message: e.message }; }
 }

--- a/.claude/hooks/stop-notify.js
+++ b/.claude/hooks/stop-notify.js
@@ -79,6 +79,7 @@ process.stdin.on("error", () => { if (!done) { done = true; processInput(); } })
 setTimeout(() => { if (!done) { done = true; try { process.stdin.destroy(); } catch(e) {} processInput(); } }, 3000);
 
 const AGENT_METRICS_FILE = path.join(REPO_ROOT, ".claude", "hooks", "agent-metrics.json");
+const SESSIONS_HISTORY_FILE = path.join(REPO_ROOT, ".claude", "hooks", "sessions-history.jsonl");
 
 // Detecta si el proceso corre en un worktree sibling (no es el repo principal)
 function detectWorktreeRoot() {
@@ -224,6 +225,41 @@ function flushMetrics(sessionId) {
         metrics.updated_ts = endedTs;
         fs.writeFileSync(AGENT_METRICS_FILE, JSON.stringify(metrics, null, 2) + "\n", "utf8");
         log("Metricas flushed para sesion " + shortId + " (sprint: " + (entry.sprint_id || "unknown") + ")");
+
+
+        // Persistir sesión en historial inmutable sessions-history.jsonl (#1716)
+        try {
+            const historyRecord = {
+                session_id: shortId,
+                sprint_id: entry.sprint_id || null,
+                agent_name: entry.agent_name || null,
+                issue: (() => {
+                    const m = (entry.branch || "").match(/^agent\/(\d+)/);
+                    return m ? parseInt(m[1], 10) : null;
+                })(),
+                branch: entry.branch || null,
+                started_at: entry.started_ts || endedTs,
+                completed_at: endedTs,
+                duration_min: entry.duration_min || 0,
+                result: entry.tasks_created > 0 && entry.tasks_created === entry.tasks_completed ? "ok" : (entry.tasks_created === 0 ? "ok" : "partial"),
+                pr: null,  // TODO: extract from session or sprint-plan
+                transitions: session.agent_transitions || [],
+                skills_invoked: entry.skills_invoked || [],
+                tokens: {
+                    input: entry.tokens_input || 0,
+                    output: entry.tokens_output || 0,
+                    cache_read: 0  // Not tracked yet
+                },
+                cost_usd: (() => {
+                    const total = (entry.tokens_input || 0) + (entry.tokens_output || 0);
+                    // Claude API pricing estimate: ~$3 per 1M input tokens, ~$15 per 1M output tokens
+                    return (total > 0 ? ((entry.tokens_input || 0) * 0.000003 + (entry.tokens_output || 0) * 0.000015) : (entry.tokens_estimated || 0) * 0.000001).toFixed(4);
+                })(),
+                model_usage: { tool_calls: entry.total_tool_calls, modified_files: entry.modified_files_count }
+            };
+            fs.appendFileSync(SESSIONS_HISTORY_FILE, JSON.stringify(historyRecord) + "\n", "utf8");
+            log("Session " + shortId + " persistida a sessions-history.jsonl");
+        } catch (e) { log("Error persistiendo sesión a history: " + e.message); }
 
         // Consolidar al repo principal si estamos en un worktree (#1419)
         const mainRepoRoot = detectWorktreeRoot();


### PR DESCRIPTION
## Resumen

Implementa el issue #1716 para preservar datos de sesiones de agentes que de otro modo se perderían al limpiar sesiones stale o borrar worktrees.

## Cambios

- **stop-notify.js**: Append a `sessions-history.jsonl` con cada sesión completada (transiciones, tokens, costos estimados)
- **sprint-sync.js**: Genera snapshots en `docs/sprints/SPR-NNN-metrics.json` con métricas agregadas por agente y skill
- **dashboard-server.js**: Nuevo endpoint `/api/history` para consultar historial filtrable por sprint

## Plan de tests

- [x] Sintaxis JavaScript validada (node -c)
- [x] Build Gradle sin regresiones (verifyNoLegacyStrings pasa)
- [x] Security scan: 0 findings críticos/altos
- [x] Code review: aprobado

## Impacto

Antes: Al ejecutar `session-gc.js` o borrar worktrees, se perdía toda la información de transiciones, tiempos y costos de agentes.
Después: Histórico inmutable en `.claude/hooks/sessions-history.jsonl` + snapshots por sprint en `docs/sprints/` + API consultable.

Cierra #1716

🤖 Generado con [Claude Code](https://claude.com/claude-code)