### PR TITLE
feat: diagnóstico automático y retry inteligente para agentes (#1749)

### DIFF
--- a/.claude/hooks/agent-concurrency-check.js
+++ b/.claude/hooks/agent-concurrency-check.js
@@ -1,4 +1,4 @@
-// agent-concurrency-check.js — Hook Stop: valida concurrencia de agentes y auto-lanza siguiente (#1277, #1356)
+﻿// agent-concurrency-check.js — Hook Stop: valida concurrencia de agentes y auto-lanza siguiente (#1277, #1356)
 // Se ejecuta al finalizar cualquier sesión Claude.
 // Solo actúa si la sesión corresponde a un agente de sprint (rama agent/* en sprint-plan.json).
 //
@@ -154,6 +154,10 @@ function isPidAlive(pid) {
 
 let tgClient = null;
 try { tgClient = require("./telegram-client"); } catch (e) { tgClient = null; }
+
+// Diagnostico de causa de muerte de agentes (#1749)
+let retryDiagnostics = null;
+try { retryDiagnostics = require("./agent-retry-diagnostics"); } catch (e) { log("agent-retry-diagnostics no disponible: " + e.message); }
 
 async function notify(text) {
     if (tgClient) {
@@ -944,6 +948,20 @@ async function processInput() {
 
             if (neverWorked) {
                 // Agente que nunca trabajó → devolver a _queue (no penalizar)
+                // Enriquecer prompt con contexto del fallo (#1749)
+                if (retryDiagnostics) {
+                    try {
+                        const retCount = (finishingAgent._retry_count || 0) + 1;
+                        finishingAgent._retry_count = retCount;
+                        const diag = retryDiagnostics.analyzeDeath(finishingAgent, REPO_ROOT, HOOKS_DIR);
+                        const basePrompt = finishingAgent.prompt || generateDefaultPrompt(finishingAgent.issue, finishingAgent.slug);
+                        finishingAgent.prompt = retryDiagnostics.buildRetryPrompt(basePrompt, finishingAgent, diag);
+                        const diagEntry = retryDiagnostics.buildDiagnosticsEntry(finishingAgent, diag);
+                        if (!Array.isArray(finishingAgent._retry_diagnostics)) finishingAgent._retry_diagnostics = [];
+                        finishingAgent._retry_diagnostics.push(diagEntry);
+                        log("Diagnostico concurrency #" + finishingAgent.issue + ": " + diag.cause);
+                    } catch (e) { log("WARN: retryDiagnostics error: " + e.message); }
+                }
                 const queue = getQueue(plan);
                 queue.push(finishingAgent);
                 setQueue(plan, queue);

--- a/.claude/hooks/agent-retry-diagnostics.js
+++ b/.claude/hooks/agent-retry-diagnostics.js
@@ -1,0 +1,240 @@
+﻿// agent-retry-diagnostics.js (#1749)
+// Diagnostico automatico de causa de muerte de agentes.
+//
+// Causas detectadas:
+//   zero_tool_calls   agente arranco pero no hizo ningun tool call
+//   explored_no_code  mas de 5 tool calls pero 0 commits
+//   build_failed      Claude termino OK pero build-check fallo
+//   delivery_failed   build OK pero push/PR fallo
+//   short_session     sesion corta sin commits
+//   unknown           sin datos suficientes
+"use strict";
+
+const fs   = require("fs");
+const path = require("path");
+const { execSync } = require("child_process");
+
+const CAUSES = {
+    ZERO_TOOL_CALLS:  "zero_tool_calls",
+    EXPLORED_NO_CODE: "explored_no_code",
+    BUILD_FAILED:     "build_failed",
+    DELIVERY_FAILED:  "delivery_failed",
+    SHORT_SESSION:    "short_session",
+    UNKNOWN:          "unknown",
+};
+
+function readPipelineResult(issue, logsDir) {
+    const filePath = path.join(logsDir, "agent-" + issue + "-pipeline-result.json");
+    try {
+        if (!fs.existsSync(filePath)) return null;
+        return JSON.parse(fs.readFileSync(filePath, "utf8"));
+    } catch (e) { return null; }
+}
+
+function getLocalCommitCount(agente, worktreeDir) {
+    try {
+        if (worktreeDir && fs.existsSync(worktreeDir)) {
+            const out = execSync(
+                "git log origin/main..HEAD --oneline 2>NUL",
+                { cwd: worktreeDir, encoding: "utf8", timeout: 10000, windowsHide: true }
+            );
+            return out.trim().split("\n").filter(Boolean).length;
+        }
+    } catch (e) {}
+    return 0;
+}
+
+function hasRemoteBranch(agente, repoRoot) {
+    const branch = "agent/" + agente.issue + "-" + agente.slug;
+    try {
+        const out = execSync(
+            "git ls-remote --heads origin " + branch + " 2>NUL",
+            { cwd: repoRoot, encoding: "utf8", timeout: 10000, windowsHide: true }
+        );
+        return out.trim().length > 0;
+    } catch (e) { return false; }
+}
+
+function getWorktreeDir(agente, repoRoot) {
+    return path.join(path.dirname(repoRoot),
+        path.basename(repoRoot) + ".agent-" + agente.issue + "-" + agente.slug);
+}
+
+/**
+ * Analiza la causa de muerte de un agente.
+ * @param {object} agente    Objeto del agente del sprint-plan
+ * @param {string} repoRoot  Path al repo principal
+ * @param {string} hooksDir  Path a .claude/hooks/
+ * @returns {object} diagnosis
+ */
+function analyzeDeath(agente, repoRoot, hooksDir) {
+    const logsDir     = path.join(repoRoot, "scripts", "logs");
+    const worktreeDir = getWorktreeDir(agente, repoRoot);
+    const wtExists    = fs.existsSync(path.join(worktreeDir, ".git"));
+
+    const pipelineResult   = readPipelineResult(agente.issue, logsDir);
+    const localCommitCount = getLocalCommitCount(agente, worktreeDir);
+    const hasLocal         = localCommitCount > 0;
+    const hasRemote        = hasRemoteBranch(agente, repoRoot);
+
+    const toolCallCount  = pipelineResult ? (pipelineResult.toolCalls || 0) : (agente._last_tool_calls || 0);
+    const buildFailed    = pipelineResult ? (pipelineResult.buildOk === false) : false;
+    const deliveryFailed = pipelineResult ? (pipelineResult.deliveryOk === false) : false;
+    const buildError     = buildFailed ? (pipelineResult.buildError || "") : null;
+
+    let cause = CAUSES.UNKNOWN;
+    if (pipelineResult) {
+        if (deliveryFailed && !buildFailed && (hasLocal || hasRemote)) {
+            cause = CAUSES.DELIVERY_FAILED;
+        } else if (buildFailed) {
+            cause = CAUSES.BUILD_FAILED;
+        } else if (toolCallCount === 0) {
+            cause = CAUSES.ZERO_TOOL_CALLS;
+        } else if (toolCallCount > 5 && !hasLocal) {
+            cause = CAUSES.EXPLORED_NO_CODE;
+        } else if (!hasLocal) {
+            cause = CAUSES.SHORT_SESSION;
+        } else {
+            cause = CAUSES.DELIVERY_FAILED;
+        }
+    } else {
+        if (hasLocal || hasRemote) {
+            cause = CAUSES.DELIVERY_FAILED;
+        } else if (wtExists && toolCallCount > 5) {
+            cause = CAUSES.EXPLORED_NO_CODE;
+        } else if (wtExists) {
+            cause = CAUSES.SHORT_SESSION;
+        } else {
+            cause = CAUSES.ZERO_TOOL_CALLS;
+        }
+    }
+
+    return {
+        cause,
+        hasLocalCommits:   hasLocal,
+        localCommitCount,
+        hasRemoteBranch:   hasRemote,
+        buildError,
+        toolCallCount,
+        deliveryFailed,
+        buildFailed,
+        pipelineResult,
+        worktreeExists:    wtExists,
+    };
+}
+
+/**
+ * Construye el prompt enriquecido para el reintento.
+ * @param {string} originalPrompt Prompt base
+ * @param {object} agente         Objeto del agente
+ * @param {object} diagnosis      Resultado de analyzeDeath()
+ * @returns {string} Prompt enriquecido
+ */
+function buildRetryPrompt(originalPrompt, agente, diagnosis) {
+    const branch     = "agent/" + agente.issue + "-" + agente.slug;
+    const retryCount = agente._retry_count || 0;
+    const retryLabel = "REINTENTO " + retryCount + "/3";
+    let context = "";
+
+    switch (diagnosis.cause) {
+        case CAUSES.ZERO_TOOL_CALLS:
+            context = "[" + retryLabel + "] El intento anterior fallo sin ejecutar ningun tool call. " +
+                "Problema de arranque o entorno. Verificar con /ops antes de comenzar la implementacion.";
+            break;
+        case CAUSES.EXPLORED_NO_CODE:
+            context = "[" + retryLabel + "] El intento anterior exploro el codebase (" +
+                diagnosis.toolCallCount + " tool calls) pero no produjo codigo ni commits. " +
+                "Ir directamente a implementar los cambios del issue sin exploracion extensa.";
+            break;
+        case CAUSES.BUILD_FAILED:
+            context = "[" + retryLabel + "] El intento anterior implemento el codigo pero fallo el build. " +
+                "La rama " + branch + " tiene los cambios. " +
+                "IMPORTANTE: NO reimplementar desde cero. Continuar desde la rama existente y corregir solo el build." +
+                (diagnosis.buildError ? "\nError de build:\n" + diagnosis.buildError.substring(0, 400) : "");
+            break;
+        case CAUSES.DELIVERY_FAILED:
+            if (diagnosis.hasLocalCommits) {
+                context = "[" + retryLabel + "] El codigo esta implementado en la rama " + branch + " (" +
+                    diagnosis.localCommitCount + " commit(s)). " +
+                    "El intento anterior fallo en delivery (push/PR). " +
+                    "IMPORTANTE: NO reimplementar. Solo hacer /delivery desde la rama existente.";
+            } else if (diagnosis.hasRemoteBranch) {
+                context = "[" + retryLabel + "] El codigo fue pusheado a origin/" + branch + " pero falta la PR. " +
+                    "IMPORTANTE: NO reimplementar. Solo crear la PR con /delivery.";
+            } else {
+                context = "[" + retryLabel + "] El intento anterior completo la implementacion pero fallo el delivery. " +
+                    "Verificar el estado de la rama " + branch + " y completar el delivery.";
+            }
+            break;
+        case CAUSES.SHORT_SESSION:
+            context = "[" + retryLabel + "] El intento anterior duro muy poco sin producir resultados. " +
+                "Posible problema de arranque. Verificar entorno con /ops e implementar directamente.";
+            break;
+        default:
+            context = "[" + retryLabel + "] Reintento automatico, causa no determinada. " +
+                "Verificar estado de la rama " + branch + " antes de implementar.";
+    }
+    return context + "\n" + originalPrompt;
+}
+
+/**
+ * Determina si el worktree debe reutilizarse (hay commits que no deben perderse).
+ */
+function shouldReuseWorktree(diagnosis) {
+    return diagnosis.hasLocalCommits && diagnosis.localCommitCount > 0;
+}
+
+/**
+ * Construye el objeto de diagnostico para persistir en plan._retry_diagnostics.
+ */
+function buildDiagnosticsEntry(agente, diagnosis) {
+    return {
+        retry:            agente._retry_count || 0,
+        timestamp:        new Date().toISOString(),
+        cause:            diagnosis.cause,
+        hasLocalCommits:  diagnosis.hasLocalCommits,
+        localCommitCount: diagnosis.localCommitCount,
+        hasRemoteBranch:  diagnosis.hasRemoteBranch,
+        buildError:       diagnosis.buildError,
+        toolCallCount:    diagnosis.toolCallCount,
+        deliveryFailed:   diagnosis.deliveryFailed,
+        buildFailed:      diagnosis.buildFailed,
+        worktreeExists:   diagnosis.worktreeExists,
+    };
+}
+
+/**
+ * Construye resumen en HTML para notificacion Telegram cuando se agotan reintentos.
+ */
+function buildExhaustedSummary(agente, diagnosticsHistory) {
+    const branch = "agent/" + agente.issue + "-" + agente.slug;
+    const CAUSE_LABELS = {
+        [CAUSES.ZERO_TOOL_CALLS]:  "Sin tool calls (problema de entorno)",
+        [CAUSES.EXPLORED_NO_CODE]: "Exploro sin producir codigo",
+        [CAUSES.BUILD_FAILED]:     "Build fallo",
+        [CAUSES.DELIVERY_FAILED]:  "Delivery/push fallo",
+        [CAUSES.SHORT_SESSION]:    "Sesion demasiado corta",
+        [CAUSES.UNKNOWN]:          "Causa desconocida",
+    };
+    const lines = [
+        "🚫 <b>Agente #" + agente.issue + " agoto reintentos</b>",
+        "Slug: " + branch, "",
+        "<b>Historial de causas:</b>",
+    ];
+    for (const entry of (diagnosticsHistory || [])) {
+        const label = CAUSE_LABELS[entry.cause] || entry.cause;
+        lines.push("  Intento " + entry.retry + ": " + label +
+            (entry.buildError ? " -- " + entry.buildError.substring(0, 100) : ""));
+    }
+    lines.push("", "<i>Accion: revisar issue manualmente y relanzar si es necesario</i>");
+    return lines.join("\n");
+}
+
+module.exports = {
+    CAUSES,
+    analyzeDeath,
+    buildRetryPrompt,
+    shouldReuseWorktree,
+    buildDiagnosticsEntry,
+    buildExhaustedSummary,
+};

--- a/.claude/hooks/agent-watcher.js
+++ b/.claude/hooks/agent-watcher.js
@@ -1,4 +1,4 @@
-// agent-watcher.js — Watcher externo para promoción automática de agentes
+﻿// agent-watcher.js — Watcher externo para promoción automática de agentes
 // desde _queue[] cuando agentes en worktrees terminan (#1441, #1522)
 //
 // Problema que resuelve:
@@ -207,6 +207,10 @@ function escHtml(str) {
 
 let tgClient = null;
 try { tgClient = require("./telegram-client"); } catch (e) {}
+
+// Diagnostico de causa de muerte de agentes (#1749)
+let retryDiagnostics = null;
+try { retryDiagnostics = require("./agent-retry-diagnostics"); } catch (e) { log("agent-retry-diagnostics no disponible: " + e.message); }
 
 // Validación centralizada de completación (#1458)
 const { buildCompletedEntry, validateCompletionCriteria, MIN_DURATION_MINUTES } = require("./validation-utils");
@@ -475,13 +479,24 @@ function launchAgent(agente) {
             agente.prompt = generateDefaultPrompt(agente.issue, agente.slug);
         }
 
-        // Paso 1: Setup worktree
+        // Paso 1: Setup worktree (o reusar existente si _reuse_worktree=true, #1749)
         let wtDir;
-        try {
-            wtDir = setupWorktree(agente);
-        } catch (e) {
-            log("launchAgent: setupWorktree falló para #" + agente.issue + ": " + e.message);
-            return false;
+        if (agente._reuse_worktree) {
+            wtDir = getExpectedWorktreePath(agente);
+            if (!fs.existsSync(path.join(wtDir, ".git"))) {
+                log("launchAgent: _reuse_worktree=true pero worktree no existe en " + wtDir + " -- recreando");
+                agente._reuse_worktree = false;
+            } else {
+                log("launchAgent: reutilizando worktree existente " + path.basename(wtDir));
+            }
+        }
+        if (!agente._reuse_worktree) {
+            try {
+                wtDir = setupWorktree(agente);
+            } catch (e) {
+                log("launchAgent: setupWorktree fallo para #" + agente.issue + ": " + e.message);
+                return false;
+            }
         }
 
         // Paso 2: Escribir prompt
@@ -963,6 +978,24 @@ async function runCycle() {
                     const retryCount = ag._retry_count || 0;
 
                     if (retryCount < MAX_RETRIES) {
+                        // Diagnosticar causa de muerte antes de relanzar (#1749)
+                        if (retryDiagnostics) {
+                            try {
+                                const diagnosis = retryDiagnostics.analyzeDeath(ag, REPO_ROOT, HOOKS_DIR);
+                                log("Diagnostico #" + ag.issue + ": causa=" + diagnosis.cause + " localCommits=" + diagnosis.localCommitCount + " remoteBranch=" + diagnosis.hasRemoteBranch);
+                                const basePrompt = ag.prompt || generateDefaultPrompt(ag.issue, ag.slug);
+                                ag.prompt = retryDiagnostics.buildRetryPrompt(basePrompt, ag, diagnosis);
+                                if (retryDiagnostics.shouldReuseWorktree(diagnosis)) {
+                                    ag._reuse_worktree = true;
+                                    log("Diagnostico #" + ag.issue + ": se reutilizara worktree (" + diagnosis.localCommitCount + " commits)");
+                                }
+                                const diagEntry = retryDiagnostics.buildDiagnosticsEntry(ag, diagnosis);
+                                if (!Array.isArray(ag._retry_diagnostics)) ag._retry_diagnostics = [];
+                                ag._retry_diagnostics.push(diagEntry);
+                            } catch (e) {
+                                log("WARN: agent-retry-diagnostics error: " + e.message);
+                            }
+                        }
                         // Relanzar: re-agregar al plan como "promoted" con contador actualizado
                         ag._retry_count = retryCount + 1;
                         ag.status = "promoted";
@@ -981,11 +1014,16 @@ async function runCycle() {
                         // Persistir el _pid asignado por launchAgent
                         if (ag._pid) savePlan(freshPlan);
 
+                        const diagCause = (ag._retry_diagnostics && ag._retry_diagnostics.length > 0)
+                            ? ag._retry_diagnostics[ag._retry_diagnostics.length - 1].cause
+                            : "unknown";
                         await notify(
                             "🔄 <b>Agente #" + ag.issue + " relanzado (intento " + ag._retry_count + "/" + MAX_RETRIES + ")</b>\n" +
                             "Sin PR detectada · Slug: " + escHtml(ag.slug) + "\n" +
-                            "Resultado: " + (relaunchResult ? "spawn exitoso" : "spawn fallido")
-                        );
+                            "Causa: " + escHtml(diagCause) + "\n" +
+                            "Resultado: " + (relaunchResult ? "spawn exitoso" : "spawn fallido") +
+                            (ag._reuse_worktree ? " · Worktree reutilizado" : "")
+                        )
                     } else {
                         // Excedió reintentos: verificar si el issue fue cerrado en GitHub
                         let issueAlreadyClosed = false;
@@ -1022,14 +1060,16 @@ async function runCycle() {
                                     : "Sin PR tras " + MAX_RETRIES + " reintentos — el agente no completó /delivery";
                             entry.detectado_por = "agent-watcher";
                             entry.motivo = motivo;
+                            if (ag._retry_diagnostics) entry._retry_diagnostics = ag._retry_diagnostics;
                             freshPlan._incomplete.push(entry);
                             log("Agente #" + ag.issue + " → _incomplete (" + prStatus.status + "): " + motivo);
 
-                            await notify(
-                                "⚠️ <b>Agente #" + ag.issue + " terminó sin PR (watcher)</b>\n" +
-                                "Slug: " + escHtml(ag.slug) + " · PR: " + prStatus.status + "\n" +
-                                "Motivo: " + escHtml(motivo)
-                            );
+                            const exhaustedMsg = (retryDiagnostics && ag._retry_diagnostics && ag._retry_diagnostics.length > 0)
+                                ? retryDiagnostics.buildExhaustedSummary(ag, ag._retry_diagnostics)
+                                : "&#x26A0;&#xFE0F; <b>Agente #" + ag.issue + " termino sin PR (watcher)</b>\n" +
+                                  "Slug: " + escHtml(ag.slug) + " · PR: " + prStatus.status + "\n" +
+                                  "Motivo: " + escHtml(motivo);
+                            await notify(exhaustedMsg)
                         }
                     }
                 }


### PR DESCRIPTION
## Resumen

Implementa análisis automático de causa de muerte cuando un agente sale sin completar el delivery, permitiendo reintentos inteligentes que preservan el trabajo realizado y enriquecen el prompt con contexto específico del fallo.

### Problema
- Agentes que pierden slot de ejecución mueren sin hacer delivery
- Los reintentos reciben el mismo prompt original, causando loops de muerte
- Se pierde el contexto del fallo (¿build roto? ¿delivery fallido? ¿sesión corta?)
- No hay visibilidad de por qué falló el agente

### Solución
**Módulo `agent-retry-diagnostics.js`** (247 líneas):
- Detecta 6 causas de muerte:
  * `zero_tool_calls` — agente arrancó pero no hizo ningún tool call
  * `explored_no_code` — exploración sin commits (>5 tool calls, 0 commits)
  * `build_failed` — build roto tras implementación
  * `delivery_failed` — push/PR fallido
  * `short_session` — sesión muy corta sin resultados
  * `unknown` — causa no determinada
- Enriquece el prompt de reintento con contexto específico
- Reutiliza worktree si hay commits locales (preserva trabajo)

**Integración en `agent-watcher.js`**:
- Antes de relanzar agente muerto: analiza causa
- Enriquece prompt con "[REINTENTO N/3]" + contexto específico
- Limita reintentos a máximo 3 veces
- Persiste historial de diagnósticos en `ag._retry_diagnostics`
- Telegram notifica cuando se agotan reintentos con resumen de causas

**Integración en `agent-concurrency-check.js`**:
- Cuando agente vuelve a la cola tras timeout: diagnóstico + enriquecimiento

## Plan de tests
- [x] /tester — Tests pass
- [x] /builder — Build successful
- [x] /security — Security scan PASS
- [x] /review — Code review APPROVED

## Integración
- `agent-runner.js` (ya implementado) escribe `agent-{issue}-pipeline-result.json` con datos de diagnóstico
- Los hooks `Start-Agente.ps1` y `Run-AgentStream.ps1` usan este resultado
- El sistema de queue de agentes (`agent-concurrency-check.js`) consume los diagnósticos

Closes #1749

🤖 Generado con Claude Code