### PR TITLE
feat(infra): script validate-env.sh y detección dinámica de JAVA_HOME

### DIFF
--- a/docs/entorno-local.md
+++ b/docs/entorno-local.md
@@ -170,6 +170,87 @@ El script `scripts/init-local-aws.sh` crea automáticamente:
 
 ## Troubleshooting
 
+### Verificar prerequisitos antes de empezar
+
+Antes de levantar el ambiente, ejecutá:
+
+```bash
+./scripts/validate-env.sh
+```
+
+El script verifica Java 21, Docker daemon, ADB y AVDs configurados. Muestra errores críticos (bloquean el ambiente) y advertencias (solo afectan funcionalidad Android).
+
+### Java 21 no encontrado o versión incorrecta
+
+Si `validate-env.sh` reporta error de Java:
+
+1. **Instalar Temurin 21** (recomendado):
+   - Descargar desde [adoptium.net](https://adoptium.net/)
+   - En Windows: el instalador lo ubica en `C:\Program Files\Eclipse Adoptium\jdk-21.x.x`
+
+2. **Setear JAVA_HOME manualmente** si hay múltiples JDKs:
+
+   ```bash
+   # Linux/macOS
+   export JAVA_HOME="/usr/lib/jvm/temurin-21"
+
+   # Windows (Git Bash / MSYS2)
+   export JAVA_HOME="/c/Program Files/Eclipse Adoptium/jdk-21.x.x"
+   ```
+
+3. **En Windows con IntelliJ/Android Studio**: los JDKs descargados por el IDE suelen estar en
+   `~/.jdks/`. `local-up.sh` los detecta automáticamente.
+
+4. Verificar la versión activa:
+
+   ```bash
+   java -version
+   # Debe mostrar: openjdk version "21.x.x" ...
+   ```
+
+### Docker daemon no está corriendo
+
+Si `validate-env.sh` reporta que el daemon no responde:
+
+- **Windows/macOS**: abrí Docker Desktop y esperá a que el ícono en la barra de tareas deje de girar.
+- **Linux**: `sudo systemctl start docker` (o `sudo service docker start`).
+- Verificar estado: `docker info` — debe responder sin errores.
+
+### ADB no encontrado
+
+Si necesitás probar la app Android:
+
+1. Instalá **Android Studio** o descargá solo **Platform-Tools**:
+   - [developer.android.com/tools/releases/platform-tools](https://developer.android.com/tools/releases/platform-tools)
+
+2. Agregá al PATH:
+
+   ```bash
+   # En ~/.bashrc o ~/.zshrc
+   export ANDROID_HOME="$HOME/Android/Sdk"          # Linux/macOS
+   export ANDROID_HOME="/c/Users/$USER/AppData/Local/Android/Sdk"  # Windows
+   export PATH="$ANDROID_HOME/platform-tools:$PATH"
+   ```
+
+3. Reiniciá la terminal y verificá: `adb version`
+
+### AVD no configurado o 'virtualAndroid' no encontrado
+
+Los scripts `local-app.sh` y `qa-android.sh` buscan un AVD llamado **`virtualAndroid`** por defecto.
+
+Para crearlo:
+
+1. Abrí **Android Studio > Device Manager > Create Device**
+2. Seleccioná: **Pixel 6**, API **34** (Android 14), x86_64
+3. Nombralo exactamente `virtualAndroid`
+4. En "Advanced Settings" → "Cold Boot" (opcional, mejora reproducibilidad en CI)
+
+Verificar AVDs existentes:
+
+```bash
+emulator -list-avds
+```
+
 ### `aws-init` falla o no termina
 
 ```bash

--- a/scripts/local-up.sh
+++ b/scripts/local-up.sh
@@ -116,13 +116,52 @@ set -a
 source "$ENV_FILE"
 set +a
 
-# JAVA_HOME — usar Temurin 21 si existe
-if [ -d "/c/Users/Administrator/.jdks/temurin-21.0.7" ]; then
-  export JAVA_HOME="/c/Users/Administrator/.jdks/temurin-21.0.7"
+# JAVA_HOME — detección dinámica en orden de preferencia
+detect_java_home() {
+  # 1. Buscar Temurin 21 en ubicaciones estándar (varias versiones patch)
+  for candidate in \
+    /c/Users/Administrator/.jdks/temurin-21* \
+    /c/Program\ Files/Eclipse\ Adoptium/jdk-21* \
+    /usr/lib/jvm/temurin-21* \
+    /usr/lib/jvm/java-21*; do
+    if [ -x "$candidate/bin/java" ]; then
+      echo "$candidate"
+      return
+    fi
+  done
+
+  # 2. Usar JAVA_HOME ya seteado si es Java 21
+  if [ -n "${JAVA_HOME:-}" ] && [ -x "$JAVA_HOME/bin/java" ]; then
+    local ver
+    ver=$("$JAVA_HOME/bin/java" -version 2>&1 | head -1 | sed 's/.*version "\([0-9]*\).*/\1/')
+    if [ "$ver" = "21" ]; then
+      echo "$JAVA_HOME"
+      return
+    fi
+  fi
+
+  # 3. Usar java del PATH si es Java 21
+  if command -v java &>/dev/null; then
+    local ver
+    ver=$(java -version 2>&1 | head -1 | sed 's/.*version "\([0-9]*\).*/\1/')
+    if [ "$ver" = "21" ]; then
+      # Devolver directorio del JDK (dos niveles sobre el binario)
+      local java_bin
+      java_bin=$(command -v java)
+      echo "$(cd "$(dirname "$java_bin")/.." && pwd)"
+      return
+    fi
+  fi
+}
+
+DETECTED_JAVA_HOME="$(detect_java_home)"
+if [ -n "$DETECTED_JAVA_HOME" ]; then
+  export JAVA_HOME="$DETECTED_JAVA_HOME"
+  echo "Usando JAVA_HOME: $JAVA_HOME"
 elif [ -n "${JAVA_HOME:-}" ]; then
-  echo "Usando JAVA_HOME existente: $JAVA_HOME"
+  echo "WARN: JAVA_HOME configurado pero no es Java 21 — Gradle puede fallar: $JAVA_HOME"
 else
-  echo "WARN: JAVA_HOME no configurado — Gradle usará el JDK del PATH"
+  echo "WARN: Java 21 no encontrado — Gradle usará el JDK del PATH (puede fallar)"
 fi
 
 # No usar exec — mantener el script vivo para el trap

--- a/scripts/validate-env.sh
+++ b/scripts/validate-env.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Verifica que el entorno local tenga todos los prerequisitos para levantar el ambiente.
+# Uso: ./scripts/validate-env.sh
+# Salida: 0 si todo está OK, 1 si hay algún prerequisito faltante o inválido.
+set -uo pipefail
+
+ERRORS=0
+WARNINGS=0
+
+pass() { echo "  [OK]  $1"; }
+fail() { echo "  [ERR] $1"; ERRORS=$((ERRORS + 1)); }
+warn() { echo "  [WARN] $1"; WARNINGS=$((WARNINGS + 1)); }
+section() { echo ""; echo "=== $1 ==="; }
+
+# ── 1. Java 21 ────────────────────────────────────────────
+section "Java"
+
+# Detectar java en PATH o JAVA_HOME
+JAVA_BIN=""
+if [ -n "${JAVA_HOME:-}" ] && [ -x "$JAVA_HOME/bin/java" ]; then
+  JAVA_BIN="$JAVA_HOME/bin/java"
+elif command -v java &>/dev/null; then
+  JAVA_BIN="$(command -v java)"
+fi
+
+if [ -z "$JAVA_BIN" ]; then
+  fail "Java no encontrado (ni en PATH ni en JAVA_HOME)"
+  echo "       Instala Temurin 21: https://adoptium.net/"
+else
+  JAVA_VERSION=$("$JAVA_BIN" -version 2>&1 | head -1 | sed 's/.*version "\([^"]*\)".*/\1/')
+  JAVA_MAJOR=$(echo "$JAVA_VERSION" | sed 's/^\([0-9]*\).*/\1/')
+  if [ "$JAVA_MAJOR" = "21" ]; then
+    pass "Java $JAVA_VERSION encontrado en $JAVA_BIN"
+  else
+    fail "Se requiere Java 21, encontrado: $JAVA_VERSION (en $JAVA_BIN)"
+    echo "       Instala Temurin 21: https://adoptium.net/"
+    echo "       O setea JAVA_HOME apuntando a un JDK 21"
+  fi
+fi
+
+# ── 2. Docker daemon ──────────────────────────────────────
+section "Docker"
+
+if ! command -v docker &>/dev/null; then
+  fail "'docker' no encontrado en PATH"
+  echo "       Instala Docker Desktop: https://www.docker.com/products/docker-desktop/"
+else
+  DOCKER_VERSION=$(docker --version 2>/dev/null | sed 's/Docker version //')
+  if docker info &>/dev/null; then
+    pass "Docker $DOCKER_VERSION — daemon activo"
+  else
+    fail "Docker está instalado ($DOCKER_VERSION) pero el daemon no está corriendo"
+    echo "       Abrí Docker Desktop y esperá a que arranque."
+  fi
+fi
+
+# ── 3. ADB ────────────────────────────────────────────────
+section "Android (ADB)"
+
+if ! command -v adb &>/dev/null; then
+  warn "adb no encontrado en PATH (requerido solo para pruebas Android)"
+  echo "       Instala Android SDK Platform-Tools o Android Studio."
+  echo "       Agrega \$ANDROID_HOME/platform-tools al PATH."
+else
+  ADB_VERSION=$(adb version 2>/dev/null | head -1)
+  pass "$ADB_VERSION"
+
+  # Verificar que adb server está activo
+  if ! adb devices &>/dev/null; then
+    warn "adb encontrado pero el servidor no responde — intentá 'adb start-server'"
+  fi
+fi
+
+# ── 4. Emulador AVD ───────────────────────────────────────
+section "Android AVD (emulador)"
+
+EMULATOR_BIN=""
+if command -v emulator &>/dev/null; then
+  EMULATOR_BIN="$(command -v emulator)"
+elif [ -n "${ANDROID_HOME:-}" ] && [ -x "$ANDROID_HOME/emulator/emulator" ]; then
+  EMULATOR_BIN="$ANDROID_HOME/emulator/emulator"
+fi
+
+if [ -z "$EMULATOR_BIN" ]; then
+  warn "emulator no encontrado (requerido solo para pruebas Android)"
+  echo "       Instala Android SDK Emulator desde Android Studio > SDK Manager."
+else
+  AVD_LIST=$("$EMULATOR_BIN" -list-avds 2>/dev/null || true)
+  if [ -z "$AVD_LIST" ]; then
+    warn "No se encontraron AVDs configurados"
+    echo "       Creá un AVD desde Android Studio > Device Manager."
+    echo "       Recomendado: Pixel 6, API 34 (Android 14), nombre 'virtualAndroid'"
+  else
+    AVD_COUNT=$(echo "$AVD_LIST" | grep -c . || true)
+    pass "$AVD_COUNT AVD(s) encontrado(s):"
+    echo "$AVD_LIST" | while read -r avd; do echo "         • $avd"; done
+
+    # Avisar si no existe el AVD canónico del proyecto
+    if ! echo "$AVD_LIST" | grep -q "virtualAndroid"; then
+      warn "AVD 'virtualAndroid' no encontrado (nombre canónico del proyecto)"
+      echo "       El script qa-android.sh y local-app.sh buscan este AVD por defecto."
+    fi
+  fi
+fi
+
+# ── Resumen ───────────────────────────────────────────────
+echo ""
+echo "======================================="
+if [ $ERRORS -gt 0 ]; then
+  echo "RESULTADO: $ERRORS error(es) crítico(s), $WARNINGS advertencia(s)"
+  echo "Corregí los errores antes de levantar el ambiente local."
+  echo "Consultá docs/entorno-local.md para guía de troubleshooting."
+  exit 1
+elif [ $WARNINGS -gt 0 ]; then
+  echo "RESULTADO: OK con $WARNINGS advertencia(s)"
+  echo "El ambiente puede levantarse, pero algunas funciones Android no estarán disponibles."
+  exit 0
+else
+  echo "RESULTADO: Todo OK — el ambiente está listo"
+  exit 0
+fi


### PR DESCRIPTION
## Resumen

- Nuevo `scripts/validate-env.sh`: verifica prerequisitos del ambiente (Java 21, Docker daemon, ADB, emulador AVD) con reporte claro de errores vs advertencias
- `scripts/local-up.sh`: reemplaza JAVA_HOME hardcodeado por detección dinámica en múltiples ubicaciones (`.jdks/`, `Program Files`, PATH)
- `docs/entorno-local.md`: sección de troubleshooting ampliada con guías para Java, Docker, ADB y AVD

## Plan de tests

- [x] Sintaxis bash válida (`bash -n`) en ambos scripts
- [x] `verifyNoLegacyStrings` pasa
- [x] Sin cambios en código Kotlin — no requiere tests unitarios

QA Validate: `qa:skipped` — cambio puro de infra/scripts sin impacto en producto de usuario

Closes #1783

🤖 Generado con [Claude Code](https://claude.ai/claude-code)