### PR TITLE
fix: actualizar Java 11→21 en composeApp build

### DIFF
--- a/app/composeApp/build.gradle.kts
+++ b/app/composeApp/build.gradle.kts
@@ -373,8 +373,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
     lint {
         disable += "NullSafeMutableLiveData"


### PR DESCRIPTION
## Resumen

- Actualiza `sourceCompatibility` y `targetCompatibility` de `JavaVersion.VERSION_11` a `JavaVersion.VERSION_21` en `app/composeApp/build.gradle.kts`
- Alinea la configuración de compilación del módulo app con el toolchain Java 21 exigido por el proyecto (CLAUDE.md, CI, backend)

## Verificación

- [x] Los 3 flavors Android (client, business, delivery) compilan sin errores
- [x] Tests unitarios pasan (backend, users, app)
- [x] Rebase limpio sobre main (1 commit)
- [x] /tester: APROBADO
- [x] /security: APROBADO — sin findings

## QA

`qa:skipped` — cambio puro de infra/build (versión Java en gradle), sin impacto en producto de usuario

Closes #1782

🤖 Generado con [Claude Code](https://claude.ai/claude-code)