### PR TITLE
fix(infra): no marcar agente completed si pipeline/delivery falló (#1800)

### DIFF
--- a/.claude/hooks/agent-monitor.js
+++ b/.claude/hooks/agent-monitor.js
@@ -958,7 +958,7 @@ function moveToCompleted(plan, issueNumber) {
     // Guard contra NaN (#1779)
     if (isNaN(duracion_min) || duracion_min < 0) duracion_min = 0;
 
-    const validation = validateCompletionCriteria(duracion_min, prStatus, branch);
+    const validation = validateCompletionCriteria(duracion_min, prStatus, branch, REPO_ROOT);
     if (validation.suspicious) {
         // Agent Doctor: intentar recovery antes de marcar como _incomplete
         if (agentDoctor) {

--- a/.claude/hooks/validation-utils.js
+++ b/.claude/hooks/validation-utils.js
@@ -199,8 +199,33 @@ function validateCompletionCriteria(duracion_min, prStatus, branch, repoRoot) {
         // null = no determinable → no suma ni resta
     }
 
+    // (#1800) Verificar pipeline-result: si existe y deliveryOk === false, NO es valid
+    let pipelineFailed = false;
+    if (branch) {
+        try {
+            const issueMatch = branch.match(/(\d+)/);
+            if (issueMatch) {
+                const pipelineFile = require("path").join(
+                    repoRoot || process.cwd(), "scripts", "logs",
+                    "agent-" + issueMatch[1] + "-pipeline-result.json"
+                );
+                if (require("fs").existsSync(pipelineFile)) {
+                    const pr = JSON.parse(require("fs").readFileSync(pipelineFile, "utf8"));
+                    if (pr.deliveryOk === false || pr.ok === false) {
+                        pipelineFailed = true;
+                        const gate = pr.failedGate || "delivery";
+                        failedCriteria.push("pipeline falló en " + gate);
+                    } else if (pr.deliveryOk === true) {
+                        criteria.push("pipeline_ok");
+                    }
+                }
+            }
+        } catch (e) { /* fail-open si no se puede leer */ }
+    }
+
     // (#1779) PR mergeada es evidencia definitiva
-    const valid = prMerged || criteria.length >= 2;
+    // (#1800) Pero si pipeline falló explícitamente, NO es valid (aunque tenga PR)
+    const valid = pipelineFailed ? false : (prMerged || criteria.length >= 2);
     return {
         valid,
         suspicious: !valid,


### PR DESCRIPTION
## Resumen

- `validation-utils.js`: Lee `pipeline-result.json` en `validateCompletionCriteria`. Si `deliveryOk === false`, marca como suspicious.
- `agent-monitor.js`: Pasa `REPO_ROOT` al validator.

## Bug corregido
Agente con exit 0 + commits + duración OK se marcaba `_completed` aunque el pipeline post-Claude fallara y no hubiera PR.

Closes #1800

QA Validate: omitido — fix de lógica interna de hooks

🤖 Generado con [Claude Code](https://claude.ai/claude-code)