### PR TITLE
feat(qa): QA_FLAVOR support + Maestro flow filtering para APK business

### DIFF
--- a/qa/regression-suite.json
+++ b/qa/regression-suite.json
@@ -46,6 +46,20 @@
       "tags": ["business", "dashboard"]
     },
     {
+      "id": "REG-06b",
+      "title": "Dashboard de negocio — empty state",
+      "app": "business",
+      "flow": "validate-1633-business-dashboard-empty.yaml",
+      "tags": ["business", "dashboard", "empty-state"]
+    },
+    {
+      "id": "REG-06c",
+      "title": "Dashboard de negocio — error y retry",
+      "app": "business",
+      "flow": "validate-1633-business-dashboard-retry.yaml",
+      "tags": ["business", "dashboard", "error", "retry"]
+    },
+    {
       "id": "REG-07",
       "title": "Navegación principal",
       "app": "client",

--- a/qa/scripts/qa-android.sh
+++ b/qa/scripts/qa-android.sh
@@ -40,6 +40,7 @@ QA_SHARDS=${QA_SHARDS:-1}           # 1 (liviano) o 3 (legacy paralelo)
 QA_AVD_CORES=${QA_AVD_CORES:-2}     # Cores máximos por AVD
 QA_NO_AFFINITY=${QA_NO_AFFINITY:-0} # 0=usar affinity (default), 1=desabilitar
 QA_NARRATION=${QA_NARRATION:-true}  # true=generar narracion TTS (requiere OPENAI_API_KEY), false=solo video mudo
+QA_FLAVOR=${QA_FLAVOR:-client}      # client | business | delivery — flavor del APK a compilar e instalar
 
 # Calcular memoria según modo
 if [ "$QA_SHARDS" = "3" ]; then
@@ -47,6 +48,25 @@ if [ "$QA_SHARDS" = "3" ]; then
 else
     QA_AVD_MEMORY=${QA_AVD_MEMORY:-1536}  # Default liviano: 1536MB
 fi
+
+# Mapear QA_FLAVOR → tarea Gradle, directorio APK y appId filter para flows Maestro
+case "$QA_FLAVOR" in
+  business)
+    GRADLE_APK_TASK=":app:composeApp:assembleBusinessDebug"
+    APK_OUTPUT_DIR="business"
+    APP_ID_FILTER="com.intrale.app.business"
+    ;;
+  delivery)
+    GRADLE_APK_TASK=":app:composeApp:assembleDeliveryDebug"
+    APK_OUTPUT_DIR="delivery"
+    APP_ID_FILTER="com.intrale.app.delivery"
+    ;;
+  *)  # client (default)
+    GRADLE_APK_TASK=":app:composeApp:assembleClientDebug"
+    APK_OUTPUT_DIR="client"
+    APP_ID_FILTER="com.intrale.app.client"
+    ;;
+esac
 
 # Configuración de múltiples AVDs y puertos (soporta 1 a 3 shards)
 declare -A AVD_PORTS=(
@@ -87,6 +107,7 @@ export PATH="${HOME}/.maestro/bin:${ANDROID_SDK}/platform-tools:${PATH}"
 
 echo "=== QA Android — Maestro E2E con Video ==="
 echo "  Modo: $([ "$QA_SHARDS" = "1" ] && echo "LIVIANO (1 shard)" || echo "PARALELO ($QA_SHARDS shards)")"
+echo "  Flavor: ${QA_FLAVOR} (appId: ${APP_ID_FILTER})"
 echo "  Configuración: ${QA_AVD_CORES} cores, ${QA_AVD_MEMORY}MB RAM por AVD"
 if [ "$QA_NO_AFFINITY" = "0" ]; then
     echo "  CPU affinity: ON (cores 4-7 para emulador, 0-3 para agentes)"
@@ -246,14 +267,14 @@ echo "  Maestro $MAESTRO_VER (con soporte --shards)"
 
 # ── 4. Build APK ────────────────────────────────────────────
 echo ""
-echo "[4/9] Compilando APK client debug..."
+echo "[4/9] Compilando APK ${QA_FLAVOR} debug..."
 cd "$PROJECT_ROOT"
-./gradlew :app:composeApp:assembleClientDebug --no-daemon 2>&1 | tail -5
+./gradlew "$GRADLE_APK_TASK" --no-daemon 2>&1 | tail -5
 
 # ── 5. Instalar APK en todos los AVDs ─────────────────────
-APK_PATH=$(find "${PROJECT_ROOT}/app/composeApp/build/outputs/apk/client/debug" -name "*.apk" -type f 2>/dev/null | head -1)
+APK_PATH=$(find "${PROJECT_ROOT}/app/composeApp/build/outputs/apk/${APK_OUTPUT_DIR}/debug" -name "*.apk" -type f 2>/dev/null | head -1)
 if [ -z "$APK_PATH" ]; then
-    echo "ERROR: No se encontro APK en build/outputs/apk/client/debug/"
+    echo "ERROR: No se encontro APK en build/outputs/apk/${APK_OUTPUT_DIR}/debug/"
     exit 1
 fi
 
@@ -272,6 +293,28 @@ echo "  ✓ APK instalado en todos los AVDs"
 
 # ── 6. Crear directorio de recordings ───────────────────────
 mkdir -p "$RECORDINGS_DIR"
+
+# ── 6.5. Filtrar flows Maestro por flavor ───────────────────────
+# Solo ejecuta flows cuyo appId coincide con el flavor compilado,
+# evitando fallos por apps no instaladas en el emulador.
+echo ""
+echo "[6.5/9] Filtrando flows para flavor '${QA_FLAVOR}' (appId: ${APP_ID_FILTER})..."
+FILTERED_FLOWS_DIR="${RECORDINGS_DIR}/flows-${QA_FLAVOR}"
+mkdir -p "$FILTERED_FLOWS_DIR"
+FLOWS_COPIED=0
+for _flow_file in "${MAESTRO_DIR}"/*.yaml; do
+    [ -f "$_flow_file" ] || continue
+    if grep -q "^appId: ${APP_ID_FILTER}" "$_flow_file" 2>/dev/null; then
+        cp "$_flow_file" "$FILTERED_FLOWS_DIR/"
+        FLOWS_COPIED=$((FLOWS_COPIED+1))
+    fi
+done
+if [ "$FLOWS_COPIED" -gt 0 ]; then
+    echo "  ✓ ${FLOWS_COPIED} flows filtrados para ${QA_FLAVOR}"
+    MAESTRO_DIR="$FILTERED_FLOWS_DIR"
+else
+    echo "  ⚠ Sin flows con appId '${APP_ID_FILTER}' — ejecutando todos los flows disponibles"
+fi
 
 # ── 7. Ejecutar Maestro con shards (distribución paralela si QA_SHARDS > 1) ────
 echo ""

--- a/qa/test-cases/1633.json
+++ b/qa/test-cases/1633.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "TC-01",
+    "title": "Carga exitosa del dashboard de negocio (happy path)",
+    "flow": "validate-1633-business-dashboard-load.yaml",
+    "criteria": "El dashboard muestra métricas de productos, pedidos y delivery tras login exitoso"
+  },
+  {
+    "id": "TC-02",
+    "title": "Empty state: negocio sin datos registrados",
+    "flow": "validate-1633-business-dashboard-empty.yaml",
+    "criteria": "Se muestra el estado vacío con CTA cuando el negocio no tiene actividad"
+  },
+  {
+    "id": "TC-03",
+    "title": "Error state y retry del dashboard",
+    "flow": "validate-1633-business-dashboard-retry.yaml",
+    "criteria": "Al ocurrir un error, el botón Reintentar recarga el dashboard sin crash"
+  }
+]


### PR DESCRIPTION
## Resumen

Issue #1633 requería crear tests E2E con video para el dashboard de negocio, pero **qa-android.sh solo compilaba el APK client**. Los flows Maestro para el dashboard usan `appId: com.intrale.app.business`, causando fallos.

### Cambios

#### qa/scripts/qa-android.sh
- ✨ Nueva variable env: `QA_FLAVOR` (client|business|delivery, default: client)
- 🔧 Mapeo automático: flavor → tarea Gradle + directorio APK + appId filter
- 🎯 Filtrado de flows: solo ejecuta flows compatible con el APK compilado
- 🐛 Fix: mensaje de error ahora usa variable `${APK_OUTPUT_DIR}`

#### qa/test-cases/1633.json (NUEVO)
- Test cases JSON para modo guión con 3 escenarios:
  - TC-01: Carga exitosa del dashboard (happy path)
  - TC-02: Empty state sin datos en el negocio
  - TC-03: Error state y retry

#### qa/regression-suite.json
- ➕ REG-06b: Dashboard vacío (empty state)
- ➕ REG-06c: Error y retry del dashboard

### Plan de tests

- [x] Sintaxis bash OK (`bash -n qa-android.sh`)
- [x] JSON válidos (`node -e "JSON.parse(...)"`)
- [x] Compilación QA OK (`:qa:compileTestKotlin`)
- [x] Strings legacy OK (`verifyNoLegacyStrings`)
- [x] Code review OK (ningún bloqueo)
- [x] Security scan OK (sin secrets detectados)
- [x] QA Validate #1633: APROBADO ✅

### Ejecución

Ahora es posible ejecutar:
```bash
QA_FLAVOR=business bash qa/scripts/qa-android.sh
```

Esto compilará el APK business, lo instalará en el emulador, y ejecutará SOLO los 3 flows del dashboard con grabación de video.

Closes #1633

🤖 Generado con [Claude Code](https://claude.com/claude-code)