### PR TITLE
feat(2fa): integración básica con autenticación en dos pasos para cliente

### DIFF
--- a/app/composeApp/build.gradle.kts
+++ b/app/composeApp/build.gradle.kts
@@ -120,6 +120,7 @@ fun sanitizePackageSuffix(raw: String): String {
 val business = providers.gradleProperty("business").orElse("intrale")
 val delivery = providers.gradleProperty("delivery").orElse(business)
 val storeAvailable = providers.gradleProperty("storeAvailable").orElse("true")
+val twoFactorEnabled = providers.gradleProperty("twoFactorEnabled").orElse("true")
 val inferredAppType = providers.provider {
     val taskNames = gradle.startParameter.taskNames.map(String::lowercase)
 
@@ -148,6 +149,7 @@ buildkonfig {
         buildConfigField(FieldSpec.Type.STRING, "DELIVERY", delivery.get())
         buildConfigField(FieldSpec.Type.STRING, "APP_TYPE", appType.get())
         buildConfigField(FieldSpec.Type.BOOLEAN, "STORE_AVAILABLE", storeAvailable.get())
+        buildConfigField(FieldSpec.Type.BOOLEAN, "ENABLE_TWO_FACTOR", twoFactorEnabled.get())
     }
 }
 

--- a/app/composeApp/src/commonMain/kotlin/ar/com/intrale/appconfig/AppType.kt
+++ b/app/composeApp/src/commonMain/kotlin/ar/com/intrale/appconfig/AppType.kt
@@ -30,4 +30,7 @@ object AppRuntimeConfig {
 
     val isDelivery: Boolean
         get() = appType == AppType.DELIVERY
+
+    val twoFactorEnabled: Boolean
+        get() = BuildKonfig.ENABLE_TWO_FACTOR
 }

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/auth/TwoFactorSetupScreen.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/auth/TwoFactorSetupScreen.kt
@@ -6,11 +6,13 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -21,14 +23,16 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontWeight
 import androidx.lifecycle.viewmodel.compose.viewModel
+import ar.com.intrale.strings.Txt
 import ar.com.intrale.strings.model.MessageKey
+import kotlinx.coroutines.launch
 import org.kodein.log.LoggerFactory
 import org.kodein.log.newLogger
-import kotlinx.coroutines.launch
-import ui.th.spacing
 import ui.sc.shared.Screen
 import ui.sc.shared.callService
+import ui.th.spacing
 
 const val TWO_FACTOR_SETUP_PATH = "/twoFactorSetup"
 
@@ -47,6 +51,21 @@ class TwoFactorSetupScreen : Screen(TWO_FACTOR_SETUP_PATH) {
         val snackbarHostState = remember { SnackbarHostState() }
         val uriHandler = LocalUriHandler.current
         val clipboardManager = LocalClipboardManager.current
+
+        val loadingText = Txt(MessageKey.two_factor_setup_loading)
+        val manualTitle = Txt(MessageKey.two_factor_setup_manual_title)
+        val manualInstructions = Txt(MessageKey.two_factor_setup_manual_instructions)
+        val step1 = Txt(MessageKey.two_factor_setup_manual_step1)
+        val step2 = Txt(MessageKey.two_factor_setup_manual_step2)
+        val step3 = Txt(MessageKey.two_factor_setup_manual_step3)
+        val accountLabel = Txt(MessageKey.two_factor_setup_account_label)
+        val secretLabel = Txt(MessageKey.two_factor_setup_secret_label)
+        val copySecretLabel = Txt(MessageKey.two_factor_setup_copy_secret)
+        val copyLinkLabel = Txt(MessageKey.two_factor_setup_copy_link)
+        val findAuthenticatorLabel = Txt(MessageKey.two_factor_setup_find_authenticator)
+        val appOpenedTitle = Txt(MessageKey.two_factor_setup_app_opened_title)
+        val appOpenedInstructions = Txt(MessageKey.two_factor_setup_app_opened_instructions)
+        val goVerifyLabel = Txt(MessageKey.two_factor_setup_go_verify)
 
         LaunchedEffect(Unit) {
             logger.debug { "Invocando setup de 2FA" }
@@ -84,43 +103,96 @@ class TwoFactorSetupScreen : Screen(TWO_FACTOR_SETUP_PATH) {
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.x2)
             ) {
-                if (viewModel.state.showQr) {
-                    Text("QR pendiente")
-                    Text(viewModel.state.issuerAccount)
-                    Text(viewModel.state.secretMasked)
-                    Button(onClick = { clipboardManager.setText(AnnotatedString(viewModel.copySecret())) }) {
-                        Text("Copiar clave")
+                when {
+                    viewModel.loading -> {
+                        CircularProgressIndicator()
+                        Text(loadingText)
                     }
-                    Button(onClick = { clipboardManager.setText(AnnotatedString(viewModel.copyLink())) }) {
-                        Text("Copiar enlace")
-                    }
-                    Button(onClick = {
-                        try {
-                            uriHandler.openUri("https://play.google.com/store/search?q=authenticator")
-                        } catch (e: Throwable) {
-                            logger.error(e) { "No fue posible abrir la aplicación de autenticación" }
-                            coroutine.launch {
-                                snackbarHostState.showSnackbar("No fue posible abrir la aplicación de autenticación")
-                            }
+                    viewModel.state.showQr -> {
+                        Text(
+                            text = manualTitle,
+                            style = MaterialTheme.typography.titleLarge,
+                            fontWeight = FontWeight.Bold
+                        )
+                        Text(
+                            text = manualInstructions,
+                            style = MaterialTheme.typography.bodyMedium
+                        )
+                        Text(
+                            text = step1,
+                            style = MaterialTheme.typography.bodyMedium
+                        )
+                        Text(
+                            text = step2,
+                            style = MaterialTheme.typography.bodyMedium
+                        )
+                        Text(
+                            text = step3,
+                            style = MaterialTheme.typography.bodyMedium
+                        )
+                        Text(
+                            text = "$accountLabel ${viewModel.state.issuerAccount}",
+                            style = MaterialTheme.typography.bodyMedium,
+                            fontWeight = FontWeight.SemiBold
+                        )
+                        Text(
+                            text = "$secretLabel ${viewModel.state.secretMasked}",
+                            style = MaterialTheme.typography.bodyMedium,
+                            fontWeight = FontWeight.SemiBold
+                        )
+                        Button(
+                            onClick = { clipboardManager.setText(AnnotatedString(viewModel.copySecret())) },
+                            modifier = Modifier.fillMaxWidth()
+                        ) {
+                            Text(copySecretLabel)
                         }
-                    }) {
-                        Text("Buscar autenticador")
-                    }
-                    Button(onClick = {
-                        try {
-                            uriHandler.openUri(viewModel.copyLink())
-                        } catch (e: Throwable) {
-                            logger.error(e) { "No se pudo compartir el enlace" }
-                            coroutine.launch {
-                                snackbarHostState.showSnackbar("No se pudo compartir el enlace")
-                            }
+                        OutlinedButton(
+                            onClick = { clipboardManager.setText(AnnotatedString(viewModel.copyLink())) },
+                            modifier = Modifier.fillMaxWidth()
+                        ) {
+                            Text(copyLinkLabel)
                         }
-                    }) {
-                        Text("Compartir")
+                        OutlinedButton(
+                            onClick = {
+                                try {
+                                    uriHandler.openUri("https://play.google.com/store/search?q=authenticator")
+                                } catch (e: Throwable) {
+                                    logger.error(e) { "No fue posible abrir la aplicación de autenticación" }
+                                    coroutine.launch {
+                                        snackbarHostState.showSnackbar(findAuthenticatorLabel)
+                                    }
+                                }
+                            },
+                            modifier = Modifier.fillMaxWidth()
+                        ) {
+                            Text(findAuthenticatorLabel)
+                        }
+                        Button(
+                            onClick = { navigate(TWO_FACTOR_VERIFY_PATH) },
+                            modifier = Modifier.fillMaxWidth()
+                        ) {
+                            Text(goVerifyLabel)
+                        }
+                    }
+                    viewModel.state.deepLinkTried -> {
+                        Text(
+                            text = appOpenedTitle,
+                            style = MaterialTheme.typography.titleLarge,
+                            fontWeight = FontWeight.Bold
+                        )
+                        Text(
+                            text = appOpenedInstructions,
+                            style = MaterialTheme.typography.bodyMedium
+                        )
+                        Button(
+                            onClick = { navigate(TWO_FACTOR_VERIFY_PATH) },
+                            modifier = Modifier.fillMaxWidth()
+                        ) {
+                            Text(goVerifyLabel)
+                        }
                     }
                 }
             }
         }
     }
 }
-

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/auth/TwoFactorVerifyScreen.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/auth/TwoFactorVerifyScreen.kt
@@ -8,9 +8,10 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -19,15 +20,15 @@ import androidx.compose.ui.Modifier
 import androidx.lifecycle.viewmodel.compose.viewModel
 import ar.com.intrale.strings.Txt
 import ar.com.intrale.strings.model.MessageKey
-import org.jetbrains.compose.resources.ExperimentalResourceApi
+import asdo.auth.DoTwoFactorVerifyException
+import kotlinx.coroutines.launch
 import org.kodein.log.LoggerFactory
 import org.kodein.log.newLogger
-import kotlinx.coroutines.launch
 import ui.cp.buttons.Button
 import ui.cp.inputs.TextField
-import ui.th.spacing
 import ui.sc.shared.Screen
 import ui.sc.shared.callService
+import ui.th.spacing
 
 const val TWO_FACTOR_VERIFY_PATH = "/twoFactorVerify"
 
@@ -47,6 +48,8 @@ class TwoFactorVerifyScreen : Screen(TWO_FACTOR_VERIFY_PATH) {
         val verifyLabel = Txt(MessageKey.two_factor_verify_submit)
         val successMessage = Txt(MessageKey.two_factor_verify_success)
         val genericError = Txt(MessageKey.error_generic)
+        val invalidCodeError = Txt(MessageKey.two_factor_verify_error_invalid)
+        val codeHint = Txt(MessageKey.two_factor_verify_code_hint)
 
         Scaffold(snackbarHost = { SnackbarHost(snackbarHostState) }) { padding ->
             Column(
@@ -67,6 +70,11 @@ class TwoFactorVerifyScreen : Screen(TWO_FACTOR_VERIFY_PATH) {
                     state = viewModel.inputsStates[TwoFactorVerifyViewModel.TwoFactorVerifyUIState::code.name]!!,
                     onValueChange = { viewModel.state = viewModel.state.copy(code = it) }
                 )
+                Text(
+                    text = codeHint,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
                 Spacer(modifier = Modifier.size(MaterialTheme.spacing.x1_5))
                 Button(
                     label = verifyLabel,
@@ -84,8 +92,12 @@ class TwoFactorVerifyScreen : Screen(TWO_FACTOR_VERIFY_PATH) {
                                     coroutine.launch { snackbarHostState.showSnackbar(successMessage) }
                                 },
                                 onError = { error ->
-                                    logger.error { "Error al verificar: ${error.message}" }
-                                    snackbarHostState.showSnackbar(error.message ?: genericError)
+                                    logger.error { "Error al verificar código 2FA: ${error.message}" }
+                                    val message = when {
+                                        error is DoTwoFactorVerifyException -> invalidCodeError
+                                        else -> error.message ?: genericError
+                                    }
+                                    snackbarHostState.showSnackbar(message)
                                 }
                             )
                         }
@@ -95,4 +107,3 @@ class TwoFactorVerifyScreen : Screen(TWO_FACTOR_VERIFY_PATH) {
         }
     }
 }
-

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/client/ClientProfileScreen.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/client/ClientProfileScreen.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import ar.com.intrale.appconfig.AppRuntimeConfig
 import ar.com.intrale.strings.Txt
 import ar.com.intrale.strings.model.MessageKey
 import kotlinx.coroutines.launch
@@ -143,6 +144,7 @@ class ClientProfileScreen : Screen(CLIENT_PROFILE_PATH) {
                         onChangePassword = { navigate(CHANGE_PASSWORD_PATH) },
                         onSetupTwoFactor = { navigate(TWO_FACTOR_SETUP_PATH) },
                         onVerifyTwoFactor = { navigate(TWO_FACTOR_VERIFY_PATH) },
+                        twoFactorEnabled = AppRuntimeConfig.twoFactorEnabled,
                         onLogout = {
                             coroutineScope.launch {
                                 viewModel.logout()
@@ -282,6 +284,7 @@ private fun SecurityActionsSection(
     onChangePassword: () -> Unit,
     onSetupTwoFactor: () -> Unit,
     onVerifyTwoFactor: () -> Unit,
+    twoFactorEnabled: Boolean = true,
     onLogout: () -> Unit
 ) {
     val title = Txt(MessageKey.client_profile_security_title)
@@ -310,16 +313,18 @@ private fun SecurityActionsSection(
                 label = changePasswordLabel,
                 onClick = onChangePassword
             )
-            SecurityActionRow(
-                icon = Icons.Default.VerifiedUser,
-                label = setupTwoFactorLabel,
-                onClick = onSetupTwoFactor
-            )
-            SecurityActionRow(
-                icon = Icons.Default.Check,
-                label = verifyTwoFactorLabel,
-                onClick = onVerifyTwoFactor
-            )
+            if (twoFactorEnabled) {
+                SecurityActionRow(
+                    icon = Icons.Default.VerifiedUser,
+                    label = setupTwoFactorLabel,
+                    onClick = onSetupTwoFactor
+                )
+                SecurityActionRow(
+                    icon = Icons.Default.Check,
+                    label = verifyTwoFactorLabel,
+                    onClick = onVerifyTwoFactor
+                )
+            }
             Divider()
             SecurityActionRow(
                 icon = Icons.Default.Logout,

--- a/app/composeApp/src/commonTest/kotlin/ui/sc/TwoFactorSetupViewModelTest.kt
+++ b/app/composeApp/src/commonTest/kotlin/ui/sc/TwoFactorSetupViewModelTest.kt
@@ -37,4 +37,20 @@ class TwoFactorSetupViewModelTest {
         assertEquals("ABCDEF123456", vm.copySecret())
         assertEquals(uri, vm.copyLink())
     }
+
+    @Test
+    fun `deep link exitoso muestra pantalla de app abierta y no QR`() {
+        val vm = TwoFactorSetupViewModel(FakeTwoFactorSetup(), loggerFactory)
+        vm.onDeepLinkResult(true)
+        assertFalse(vm.state.showQr)
+        assertTrue(vm.state.deepLinkTried)
+    }
+
+    @Test
+    fun `deep link fallido muestra configuracion manual`() {
+        val vm = TwoFactorSetupViewModel(FakeTwoFactorSetup(), loggerFactory)
+        vm.onDeepLinkResult(false)
+        assertTrue(vm.state.showQr)
+        assertTrue(vm.state.deepLinkTried)
+    }
 }

--- a/app/composeApp/src/commonTest/kotlin/ui/sc/auth/AuthViewModelsTest.kt
+++ b/app/composeApp/src/commonTest/kotlin/ui/sc/auth/AuthViewModelsTest.kt
@@ -424,6 +424,25 @@ class TwoFactorVerifyViewModelTest {
         vm.state = TwoFactorVerifyViewModel.TwoFactorVerifyUIState("123")
         assertFalse(vm.isValid())
     }
+
+    @Test
+    fun `verify con codigo invalido retorna DoTwoFactorVerifyException`() = runTest {
+        val fakeVerify = FakeTwoFactorVerify(
+            Result.failure(
+                asdo.auth.DoTwoFactorVerifyException(
+                    asdo.auth.TwoFactorVerifyStatusCode(400, "Bad Request"),
+                    "Invalid Two Factor Code"
+                )
+            )
+        )
+        val vm = TwoFactorVerifyViewModel(fakeVerify, testLoggerFactory)
+        vm.state = TwoFactorVerifyViewModel.TwoFactorVerifyUIState("000000")
+
+        val result = vm.verify()
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is asdo.auth.DoTwoFactorVerifyException)
+    }
 }
 
 // endregion


### PR DESCRIPTION
## Resumen

Integración básica de 2FA (Two-Factor Authentication) en la app cliente, reutilizando la infraestructura de TOTP ya implementada en el backend.

- Feature flag `twoFactorEnabled` configurable
- Pantalla de setup con flujo deep link + fallback manual
- Pantalla de verificación con error handling claro
- Validación de código 6 dígitos
- Strings completos en español e inglés

## Cambios principales

- `BuildKonfig.ENABLE_TWO_FACTOR` configurable vía gradle property
- `AppRuntimeConfig.twoFactorEnabled` expuesto en runtime
- `TwoFactorSetupScreen` reescrita (instrucciones paso a paso, copiar secret/link, buscar app autenticadora)
- `TwoFactorVerifyScreen` mejorada (error handling específico para código inválido)
- `ClientProfileScreen` condiciona botones 2FA según feature flag
- 18 nuevas MessageKeys + strings ES/EN
- Tests unitarios para validar comportamiento

## Plan de tests

- ✅ Tests unitarios: setup, verify, deep link, feature flag
- ✅ /tester: todos los tests pasan
- ✅ /po: criterios de aceptación BDD generados y aprobados
- ✅ /security: escaneo OWASP sin hallazgos críticos/altos
- ⚠️ /qa: pendiente (feature flag controlado, sin backend nuevo)

Closes #726

🤖 Generado con [Claude Code](https://claude.ai/claude-code)