### PR TITLE
test: corregir nombres de tests en WcagContrastTest

### DIFF
--- a/app/composeApp/src/commonTest/kotlin/ui/th/WcagContrastTest.kt
+++ b/app/composeApp/src/commonTest/kotlin/ui/th/WcagContrastTest.kt
@@ -37,25 +37,25 @@ class WcagContrastTest {
     // ------------------------------------------------------------------
 
     @Test
-    fun `onSurface sobre surface (light) cumple WCAG AA`() {
+    fun `onSurface sobre surface light cumple WCAG AA`() {
         val ratio = contrastRatio(onSurfaceLight, surfaceLight)
         assertTrue(ratio >= 4.5, "onSurface/surface light: $ratio (esperado >= 4.5:1)")
     }
 
     @Test
-    fun `onBackground sobre background (light) cumple WCAG AA`() {
+    fun `onBackground sobre background light cumple WCAG AA`() {
         val ratio = contrastRatio(onBackgroundLight, backgroundLight)
         assertTrue(ratio >= 4.5, "onBackground/background light: $ratio (esperado >= 4.5:1)")
     }
 
     @Test
-    fun `onSurfaceVariant sobre surface (light) cumple WCAG AA`() {
+    fun `onSurfaceVariant sobre surface light cumple WCAG AA`() {
         val ratio = contrastRatio(onSurfaceVariantLight, surfaceLight)
         assertTrue(ratio >= 4.5, "onSurfaceVariant/surface light: $ratio (esperado >= 4.5:1)")
     }
 
     @Test
-    fun `primary sobre surface (light) cumple WCAG AA`() {
+    fun `primary sobre surface light cumple WCAG AA`() {
         val ratio = contrastRatio(primaryLight, surfaceLight)
         assertTrue(ratio >= 4.5, "primary/surface light: $ratio (esperado >= 4.5:1)")
     }
@@ -65,19 +65,19 @@ class WcagContrastTest {
     // ------------------------------------------------------------------
 
     @Test
-    fun `onSurface sobre surface (dark) cumple WCAG AA`() {
+    fun `onSurface sobre surface dark cumple WCAG AA`() {
         val ratio = contrastRatio(onSurfaceDark, surfaceDark)
         assertTrue(ratio >= 4.5, "onSurface/surface dark: $ratio (esperado >= 4.5:1)")
     }
 
     @Test
-    fun `onSurfaceVariant sobre surface (dark) cumple WCAG AA`() {
+    fun `onSurfaceVariant sobre surface dark cumple WCAG AA`() {
         val ratio = contrastRatio(onSurfaceVariantDark, surfaceDark)
         assertTrue(ratio >= 4.5, "onSurfaceVariant/surface dark: $ratio (esperado >= 4.5:1)")
     }
 
     @Test
-    fun `primary sobre surface (dark) cumple WCAG AA`() {
+    fun `primary sobre surface dark cumple WCAG AA`() {
         val ratio = contrastRatio(primaryDark, surfaceDark)
         assertTrue(ratio >= 4.5, "primary/surface dark: $ratio (esperado >= 4.5:1)")
     }


### PR DESCRIPTION
## Resumen

Se corrigieron los nombres de tests en `WcagContrastTest.kt` que contenían paréntesis `()`, causando errores de compilación en el target iOS Simulator.

- Removidos paréntesis de nombres de tests
- Mantenida la claridad y propósito de cada test
- Build completo ahora exitoso (29m 13s)

## Cambios

- `WcagContrastTest.kt`: 7 nombres de tests modificados para compatibilidad iOS

## Validación

- ✅ Build completo: EXITOSO
- ✅ Tests compilando sin errores
- ✅ Verificaciones lint pasando
- ⚠️ QA E2E: pendiente (feature ya implementada en commits anteriores)

## Contexto

Issue #597 implementa la pantalla de carrito y resumen de pedido. La funcionalidad ya fue desarrollada completamente en commits anteriores. Este PR solo corrige la compilación bloqueada.

Closes #597

🤖 Generado con [Claude Code](https://claude.com/claude-code)