### PR TITLE
fix(infra): dashboard ignora sprint cancelado + reset limpia sesiones

### DIFF
--- a/.claude/dashboard-server.js
+++ b/.claude/dashboard-server.js
@@ -310,8 +310,10 @@ function collectData() {
   try { sprintPlan = readJson(SPRINT_PLAN_FILE); } catch {}
   // sprintIssueSet incluye TODOS los issues del sprint (agentes + _queue + _completed + _incomplete)
   // para retener sesiones activas y evitar que se clasifiquen como zombie.
+  // Si el sprint está cancelado, vaciar el set para que las sesiones huérfanas se descarten normalmente.
+  const sprintCancelled = sprintPlan && (sprintPlan.estado || "").toLowerCase() === "cancelado";
   const sprintIssueSet = new Set(
-    sprintPlan ? [
+    (sprintPlan && !sprintCancelled) ? [
       ...(Array.isArray(sprintPlan.agentes) ? sprintPlan.agentes : []),
       ...(Array.isArray(sprintPlan._queue) ? sprintPlan._queue : []),
       ...(Array.isArray(sprintPlan._completed) ? sprintPlan._completed : []),
@@ -2827,10 +2829,13 @@ function renderHTML(data, theme, section) {
   let sprintPct = 0;
   const completedCount = spCompleted.length;
   const agentesTotal = (data.sprintPlan && data.sprintPlan.total_stories) || allSprintAgentes.length || 1;
-  if (data.sprintPlan && allSprintAgentes.length > 0) {
+  // No mostrar sprint si está cancelado — evitar mostrar datos obsoletos
+  const sprintEstadoCheck = data.sprintPlan ? (data.sprintPlan.estado || "activo").toLowerCase() : "";
+  const isSprintCancelled = sprintEstadoCheck === "cancelado";
+  if (data.sprintPlan && allSprintAgentes.length > 0 && !isSprintCancelled) {
     const spDate = data.sprintPlan.fecha || "";
     const sprintId = data.sprintPlan.sprint_id || null;
-    const sprintEstado = (data.sprintPlan.estado || "activo").toLowerCase();
+    const sprintEstado = sprintEstadoCheck;
     const isFinalizado = sprintEstado === "finalizado";
     // Progreso del sprint: basado en issues completados (fuente de verdad)
     // + progreso parcial de agentes activos basado en tareas o acciones
@@ -3043,7 +3048,7 @@ function renderHTML(data, theme, section) {
 
   // --- UNIFIED AGENT CARDS (combina sprint execution + session info) ---
   let unifiedAgentsHtml = "";
-  if (data.sprintPlan && allSprintAgentes.length > 0) {
+  if (data.sprintPlan && allSprintAgentes.length > 0 && !isSprintCancelled) {
     const sprintId = data.sprintPlan.sprint_id || "Sprint";
     const sprintTema = data.sprintPlan.tema || "";
     const sprintPctColor = sprintPct >= 80 ? "var(--green)" : sprintPct >= 40 ? "#fbbf24" : "var(--text-muted)";

--- a/scripts/reset-operations.js
+++ b/scripts/reset-operations.js
@@ -214,6 +214,33 @@ function cleanWorktrees() {
     return cleaned;
 }
 
+// ─── Step 2.5: Clean orphan sessions ─────────────────────────────────────────
+
+function cleanOrphanSessions() {
+    const cleaned = [];
+    const sessDir = path.join(REPO_ROOT, ".claude", "sessions");
+    try {
+        if (!fs.existsSync(sessDir)) return cleaned;
+        const files = fs.readdirSync(sessDir).filter(f => f.endsWith(".json"));
+        for (const f of files) {
+            try {
+                const fp = path.join(sessDir, f);
+                const s = JSON.parse(fs.readFileSync(fp, "utf8"));
+                // Limpiar sesiones "active" de agentes — son huérfanas si llegamos al reset
+                if (s.status === "active" && s.branch && s.branch.startsWith("agent/")) {
+                    s.status = "done";
+                    s.last_activity_ts = new Date().toISOString();
+                    const tmpPath = fp + ".tmp." + process.pid;
+                    fs.writeFileSync(tmpPath, JSON.stringify(s, null, 2), "utf8");
+                    fs.renameSync(tmpPath, fp);
+                    cleaned.push(f);
+                }
+            } catch (_) {}
+        }
+    } catch (_) {}
+    return cleaned;
+}
+
 // ─── Step 3: Reset state files ──────────────────────────────────────────────
 
 function resetStateFiles() {
@@ -327,6 +354,11 @@ async function main() {
     const worktrees = cleanWorktrees();
     log("  → " + worktrees.length + " worktrees eliminados");
 
+    // Step 2.5
+    log("Paso 2.5/5: Limpiando sesiones huérfanas...");
+    const orphanSessions = cleanOrphanSessions();
+    log("  → " + orphanSessions.length + " sesiones marcadas done");
+
     // Step 3
     log("Paso 3/5: Reseteando state files...");
     const stateFiles = resetStateFiles();
@@ -349,6 +381,7 @@ async function main() {
         elapsed_seconds: parseFloat(elapsed),
         killed: killed.length,
         worktrees_cleaned: worktrees.length,
+        orphan_sessions: orphanSessions.length,
         state_files_reset: stateFiles.length,
         git: gitResult,
         infra_started: infra,


### PR DESCRIPTION
## Resumen

Fix de la causa raíz de los agentes fantasma en /overview:

- Sprint cancelado seguía mostrando agentes porque `sprintIssueSet` retenía sesiones como "sprint sessions" inmortales
- Sesiones con `status: "active"` de agentes muertos nunca se limpiaban
- `/reset` ahora marca sesiones huérfanas de agentes como done

## Test plan

- [x] Sprint cancelado → overview no muestra secciones de sprint
- [x] Sesiones huérfanas descartadas por threshold de 30min
- [x] `/reset` marca sesiones de agentes muertos como done

QA Validate: `qa:skipped` — dashboard interno

🤖 Generado con [Claude Code](https://claude.ai/claude-code)