### PR TITLE
fix(infra): agentes Minimized en vez de Hidden — Hidden causa SIGINT

### DIFF
--- a/scripts/Start-Agente.ps1
+++ b/scripts/Start-Agente.ps1
@@ -641,6 +641,9 @@ function Start-UnAgente {
     $agentModel = if ($Agente.PSObject.Properties["model"] -and $Agente.model) { $Agente.model } else { "sonnet" }
 
     Write-Host ">> Lanzando agente en background (modelo: $agentModel)..."
+    # Lanzar con -WindowStyle Minimized (NO Hidden).
+    # Hidden causa SIGINT (0xC000013A) que mata al proceso claude hijo.
+    # Minimized: ventana minimizada en taskbar, no ocupa pantalla pero consola estable.
     $proc = Start-Process powershell -ArgumentList (
         "-ExecutionPolicy", "Bypass",
         "-File", $streamScript,
@@ -652,7 +655,7 @@ function Start-UnAgente {
         "-Slug", $slug,
         "-Branch", $branch,
         "-Model", $agentModel
-    ) -WindowStyle Hidden -PassThru
+    ) -WindowStyle Minimized -PassThru
 
     # Extraer PID de forma segura — $proc.Id puede fallar si el proceso terminó inmediatamente
     $procId = $null


### PR DESCRIPTION
## Resumen

Root cause de por qué los agentes morían inmediatamente: `-WindowStyle Hidden` en Windows causa que el proceso hijo claude reciba SIGINT (exit code 0xC000013A).

Fix: `-WindowStyle Minimized` — consola minimizada en taskbar, no visible pero estable.

## Evidencia

- Exit code 3221225786 = 0xC000013A = STATUS_CONTROL_C_EXIT
- Los 3 agentes murieron con este exit code
- El watcher los encontró muertos (no los mató)
- Sin DEATH_DIAG = murieron antes del cleanup

QA Validate: `qa:skipped`

🤖 Generado con [Claude Code](https://claude.ai/claude-code)