### PR TITLE
fix(infra): agentes mueren por file locking — un solo escritor de log

### DIFF
--- a/scripts/Run-AgentStream.ps1
+++ b/scripts/Run-AgentStream.ps1
@@ -101,16 +101,24 @@ try {
         $process.Start() | Out-Null
 
         # Leer output del runner (incluye output de Claude proxied)
+        # NOTA: agent-runner.js ya NO escribe al log (un solo escritor evita FileOpenFailure en Windows)
         while (-not $process.StandardOutput.EndOfStream) {
             $line = $process.StandardOutput.ReadLine()
             if (-not $line) { continue }
-            $line | Out-File -FilePath $LogFile -Encoding utf8 -Append
+            try {
+                $line | Out-File -FilePath $LogFile -Encoding utf8 -Append
+            } catch {
+                # Fail-open: si el archivo esta lockeado, no crashear
+                Write-Host "  [log-write-blocked] $($_.Exception.Message)" -ForegroundColor DarkYellow
+            }
             Write-Host "  $line" -ForegroundColor Gray
         }
 
         $stderrOutput = $process.StandardError.ReadToEnd()
         if ($stderrOutput) {
-            $stderrOutput | Out-File -FilePath $LogFile -Encoding utf8 -Append
+            try {
+                $stderrOutput | Out-File -FilePath $LogFile -Encoding utf8 -Append
+            } catch { }
         }
 
         $process.WaitForExit()

--- a/scripts/pipeline/agent-runner.js
+++ b/scripts/pipeline/agent-runner.js
@@ -47,13 +47,11 @@ function parseArgs() {
 function log(msg) {
     const ts = new Date().toISOString().substring(11, 19);
     const line = "[" + ts + "] " + msg;
+    // Solo escribir a stdout — Run-AgentStream.ps1 es el UNICO escritor del log file.
+    // Escribir desde ambos procesos causa FileOpenFailure en Windows (file locking)
+    // que mata al agente con "proceso_disposed".
     console.log(line);
-    if (logFd) {
-        try { fs.appendFileSync(logFd, line + "\n"); } catch (e) { }
-    }
 }
-
-let logFd = null;
 
 // ─── Pipeline mode detection ─────────────────────────────────────────────────
 
@@ -120,10 +118,8 @@ function runClaude(config) {
         child.stdout.on("data", (chunk) => {
             const lines = chunk.toString().split("\n").filter(l => l.trim());
             for (const line of lines) {
-                // Log raw line
-                if (logFd) {
-                    try { fs.appendFileSync(logFd, line + "\n"); } catch (e) { }
-                }
+                // Raw lines van a stdout — Run-AgentStream.ps1 las escribe al log
+                console.log(line);
 
                 try {
                     const evt = JSON.parse(line);
@@ -148,9 +144,7 @@ function runClaude(config) {
         });
 
         child.stderr.on("data", (chunk) => {
-            if (logFd) {
-                try { fs.appendFileSync(logFd, "STDERR: " + chunk.toString() + "\n"); } catch (e) { }
-            }
+            console.error("STDERR: " + chunk.toString());
         });
 
         child.on("close", (code) => {


### PR DESCRIPTION
## Resumen

Causa raiz de agentes muriendo con "proceso_disposed": escritura simultanea a agente_N.log.
- agent-runner.js elimina toda escritura directa al log (solo stdout)
- Run-AgentStream.ps1 es el unico escritor con try/catch fail-open

QA Validate: omitido - infra

Generado con [Claude Code](https://claude.ai/claude-code)