### PR TITLE
fix(telegram): TTS no responde audio — fallback texto assistant

### DIFF
--- a/.claude/hooks/commander/multimedia-handler.js
+++ b/.claude/hooks/commander/multimedia-handler.js
@@ -245,11 +245,23 @@ async function callTTS(text) {
 // ─── Extracción de respuesta de Claude ───────────────────────────────────────
 
 function extractClaudeResponse(result) {
-    if (!result || result.code !== 0) return null;
+    if (!result || result.code !== 0) {
+        _log("extractClaudeResponse: skip (code=" + (result ? result.code : "null") + ")");
+        return null;
+    }
+    if (!result.stdout) {
+        _log("extractClaudeResponse: stdout vacio — Claude no emitio evento result ni texto");
+        return null;
+    }
     try {
         const json = JSON.parse(result.stdout);
-        return json.result || json.text || json.content || null;
+        const text = json.result || json.text || json.content || null;
+        if (!text) {
+            _log("extractClaudeResponse: JSON parseado pero sin result/text/content: " + result.stdout.substring(0, 200));
+        }
+        return text;
     } catch (e) {
+        // stdout no es JSON — usar como texto plano
         return result.stdout || null;
     }
 }

--- a/.claude/hooks/telegram-commander.js
+++ b/.claude/hooks/telegram-commander.js
@@ -221,6 +221,7 @@ function executeClaude(prompt, extraArgs, options) {
         let stderr = "";
         let _finalResultJson = null;
         let _toolCount = 0;
+        let _lastAssistantText = ""; // Fallback: último texto del assistant (para TTS cuando no hay evento result)
 
         // ─── Procesamiento stream-json en tiempo real ─────────────────────────
         const rl = readline.createInterface({ input: proc.stdout, crlfDelay: Infinity });
@@ -243,6 +244,7 @@ function executeClaude(prompt, extraArgs, options) {
                                 : "  [" + ts + "] [" + _toolCount + "] " + block.name;
                             console.log("\x1b[33m" + tLabel + "\x1b[0m");
                         } else if (block.type === "text" && block.text) {
+                            _lastAssistantText = block.text; // Capturar para TTS fallback
                             let preview = block.text;
                             if (preview.length > 120) preview = preview.substring(0, 120) + "...";
                             console.log("\x1b[90m  [" + ts + "] > " + preview + "\x1b[0m");
@@ -263,7 +265,11 @@ function executeClaude(prompt, extraArgs, options) {
             if (resolved) return;
             resolved = true;
             clearTimeout(timer);
-            const stdout = _finalResultJson ? JSON.stringify(_finalResultJson) : "";
+            // Preferir evento result; fallback al último texto del assistant (para TTS)
+            let stdout = _finalResultJson ? JSON.stringify(_finalResultJson) : "";
+            if (!stdout && _lastAssistantText) {
+                stdout = JSON.stringify({ type: "result", result: _lastAssistantText });
+            }
             log("claude terminó con código " + code + " (stdout: " + stdout.length + " bytes, stderr: " + stderr.length + " bytes)");
             if (stderr) log("STDERR: " + stderr.substring(0, 500));
 


### PR DESCRIPTION
## Resumen

TTS dejó de funcionar el 24-Mar porque Claude no emite evento "result" en stream-json.
Fix: capturar último texto del assistant como fallback + logging diagnóstico.

QA Validate: omitido - infra

Generado con [Claude Code](https://claude.ai/claude-code)