### PR TITLE
fix(telegram): TTS result vacio + doctor spam

### DIFF
--- a/.claude/hooks/agent-coordinator.js
+++ b/.claude/hooks/agent-coordinator.js
@@ -1150,7 +1150,7 @@ async function reconcile() {
                         if (doctorResult.recovery.success && !doctorResult.shouldRelaunch) {
                             plan._completed.push(buildCompletedEntry(ag, null, "completed"));
                             savePlan(plan);
-                            await notify(agentDoctor.buildDiagnosisNotification(ag, doctorResult.diagnosis, doctorResult.recovery));
+                            log("Doctor: recovery exitoso #" + ag.issue + " — no notificar Telegram (anti-spam)");
                             continue;
                         }
                         ag.prompt = agentDoctor.buildDoctorRetryPrompt(ag.prompt || generateDefaultPrompt(ag.issue, ag.slug), ag, doctorResult.diagnosis);

--- a/.claude/hooks/agent-monitor.js
+++ b/.claude/hooks/agent-monitor.js
@@ -1118,7 +1118,7 @@ function moveToCompleted(plan, issueNumber) {
                     finished.motivo = "Recovery por agent-doctor: " + doctorResult.recovery.details;
                     plan._completed.push(finished);
                     log("moveToCompleted: #" + issueNumber + " -> _completed (recovered by doctor)");
-                    notify("\uD83C\uDFE5 <b>Doctor: recovery exitoso #" + issueNumber + "</b>\n" + doctorResult.recovery.details, true);
+                    log("Doctor: recovery exitoso #" + issueNumber + " — " + doctorResult.recovery.details);
                     try { require("./sprint-data.js").saveRoadmapFromPlan(plan, "agent-monitor"); } catch(e2) {}
                     return;
                 }

--- a/.claude/hooks/telegram-commander.js
+++ b/.claude/hooks/telegram-commander.js
@@ -265,7 +265,11 @@ function executeClaude(prompt, extraArgs, options) {
             if (resolved) return;
             resolved = true;
             clearTimeout(timer);
-            // Preferir evento result; fallback al último texto del assistant (para TTS)
+            // Inyectar último texto del assistant si el campo result está vacío
+            // Claude stream-json emite result:"" pero el texto real está en bloques text del assistant
+            if (_finalResultJson && !_finalResultJson.result && _lastAssistantText) {
+                _finalResultJson.result = _lastAssistantText;
+            }
             let stdout = _finalResultJson ? JSON.stringify(_finalResultJson) : "";
             if (!stdout && _lastAssistantText) {
                 stdout = JSON.stringify({ type: "result", result: _lastAssistantText });


### PR DESCRIPTION
## Resumen

- TTS: inyecta texto del assistant cuando result esta vacio
- Doctor: "recovery exitoso" solo va a log, no a Telegram

Generado con [Claude Code](https://claude.ai/claude-code)