### PR TITLE
fix(telegram): stop-notify no envia imagen en respuestas de audio

### DIFF
--- a/.claude/hooks/commander/multimedia-handler.js
+++ b/.claude/hooks/commander/multimedia-handler.js
@@ -355,6 +355,15 @@ async function handleVoiceOrAudio(msg) {
             return;
         }
 
+        // Marcar flag de voz ANTES de ejecutar Claude para que stop-notify no envíe imagen
+        const voiceFlagFile = require("path").join(
+            process.env.CLAUDE_PROJECT_DIR || "C:\\Workspaces\\Intrale\\platform",
+            ".claude", "hooks", "voice-response-active.flag"
+        );
+        if (isVoice) {
+            try { require("fs").writeFileSync(voiceFlagFile, String(Date.now()), "utf8"); } catch (e) {}
+        }
+
         const result = await _cmdContext.executeClaudeQueued(transcription, [], { useSession: true, skill: null });
         const claudeResponse = extractClaudeResponse(result);
 

--- a/.claude/hooks/stop-notify.js
+++ b/.claude/hooks/stop-notify.js
@@ -477,6 +477,20 @@ async function processInput() {
     // Rotacion: limpiar sessions "done" con mas de 2h de antiguedad
     cleanOldSessions();
 
+    // Detectar si es respuesta de voz del commander (TTS ya enviado — no duplicar)
+    try {
+        const voiceFlagFile = path.join(HOOKS_DIR, "voice-response-active.flag");
+        if (fs.existsSync(voiceFlagFile)) {
+            const flagAge = Date.now() - fs.statSync(voiceFlagFile).mtimeMs;
+            if (flagAge < 120000) { // 2 min
+                log("Respuesta de voz activa — omitiendo stop-notify (TTS ya enviado)");
+                try { fs.unlinkSync(voiceFlagFile); } catch (e) {}
+                return;
+            }
+            try { fs.unlinkSync(voiceFlagFile); } catch (e) {}
+        }
+    } catch (e) {}
+
     // Detectar si es ejecución de sprint
     const isSprint = isSprintSession(sessionId);
 


### PR DESCRIPTION
## Resumen

- Flag file voice-response-active.flag evita que stop-notify duplique
- Audio: solo TTS, sin imagen ni texto redundante

Generado con [Claude Code](https://claude.ai/claude-code)