### PR TITLE
fix(telegram): silenciar mensajes automaticos durante comando del usuario

### DIFF
--- a/.claude/hooks/stop-notify.js
+++ b/.claude/hooks/stop-notify.js
@@ -479,7 +479,7 @@ async function processInput() {
 
     // Detectar si es respuesta de voz del commander (TTS ya enviado — no duplicar)
     try {
-        const voiceFlagFile = path.join(HOOKS_DIR, "voice-response-active.flag");
+        const voiceFlagFile = path.join(__dirname, "voice-response-active.flag");
         if (fs.existsSync(voiceFlagFile)) {
             const flagAge = Date.now() - fs.statSync(voiceFlagFile).mtimeMs;
             if (flagAge < 120000) { // 2 min

--- a/.claude/hooks/telegram-client.js
+++ b/.claude/hooks/telegram-client.js
@@ -110,8 +110,43 @@ async function telegramPostRetry(method, params, timeoutMs) {
  * @param {object} [opts] - Opciones: { silent, replyMarkup, chatId }
  * @returns {Promise<object>} Mensaje enviado
  */
+// ─── Command-in-progress guard ───────────────────────────────────────────────
+// Cuando el usuario envía un mensaje (texto o audio), se activa un flag que
+// bloquea mensajes automáticos de otros hooks hasta que la respuesta se envíe.
+// Solo mensajes marcados con opts.isResponse=true pasan durante el bloqueo.
+
+const COMMAND_FLAG = path.join(HOOKS_DIR, "command-in-progress.flag");
+
+function isCommandInProgress() {
+    try {
+        if (!fs.existsSync(COMMAND_FLAG)) return false;
+        const age = Date.now() - fs.statSync(COMMAND_FLAG).mtimeMs;
+        if (age > 180000) { // 3 min max — cleanup stale flags
+            try { fs.unlinkSync(COMMAND_FLAG); } catch (e) {}
+            return false;
+        }
+        return true;
+    } catch (e) { return false; }
+}
+
+function setCommandInProgress(active) {
+    try {
+        if (active) {
+            fs.writeFileSync(COMMAND_FLAG, String(Date.now()), "utf8");
+        } else {
+            if (fs.existsSync(COMMAND_FLAG)) fs.unlinkSync(COMMAND_FLAG);
+        }
+    } catch (e) {}
+}
+
 async function sendMessage(text, opts) {
     opts = opts || {};
+
+    // Bloquear mensajes automáticos mientras se procesa un comando del usuario
+    if (isCommandInProgress() && !opts.isResponse) {
+        return null; // Silenciar — no enviar
+    }
+
     const chatId = opts.chatId || getChatId();
     if (!chatId) throw new Error("No chat_id configured");
 
@@ -159,6 +194,10 @@ async function editMessage(messageId, text, opts) {
  */
 function sendPhoto(imageBuffer, caption, opts) {
     opts = opts || {};
+    // Bloquear fotos automáticas mientras se procesa un comando del usuario
+    if (isCommandInProgress() && !opts.isResponse) {
+        return Promise.resolve(null);
+    }
     const chatId = opts.chatId || getChatId();
     const token = getBotToken();
     if (!token || !chatId) return Promise.reject(new Error("No bot_token or chat_id"));
@@ -279,5 +318,7 @@ module.exports = {
     getConfig,
     getBotToken,
     getChatId,
-    TG_MSG_MAX
+    TG_MSG_MAX,
+    setCommandInProgress,
+    isCommandInProgress
 };

--- a/.claude/hooks/telegram-commander.js
+++ b/.claude/hooks/telegram-commander.js
@@ -156,6 +156,9 @@ async function executeClaudeQueued(prompt, extraArgs, options) {
     activeCommands.set(cmdId, { label, sessionId: null, startTime: Date.now() });
     log("Comando [Cmd #" + cmdId + "] registrado: " + label + " (activos: " + activeCommands.size + ")");
 
+    // Silenciar mensajes automáticos de otros hooks mientras se procesa el comando
+    try { require("./telegram-client").setCommandInProgress(true); } catch (e) {}
+
     // ─── Traza de inicio en terminal ─────────────────────────────────────────
     const _ts0 = new Date().toISOString().substring(11, 19);
     const _displayLabel = _qOpts.cmdLabel || (_qOpts.skill ? "/" + _qOpts.skill : label.substring(0, 60));
@@ -179,6 +182,7 @@ async function executeClaudeQueued(prompt, extraArgs, options) {
         return result;
     } finally {
         activeCommands.delete(cmdId);
+        try { require("./telegram-client").setCommandInProgress(false); } catch (e) {}
         log("Comando [Cmd #" + cmdId + "] finalizado (activos: " + activeCommands.size + ")");
     }
 }


### PR DESCRIPTION
## Resumen

- Flag command-in-progress bloquea sendMessage/sendPhoto automaticos
- Solo mensajes con isResponse=true pasan durante procesamiento
- Aplica a texto y audio por igual

Generado con [Claude Code](https://claude.ai/claude-code)