### PR TITLE
feat(telegram): boton Escuchar para TTS bajo demanda en cada respuesta

### DIFF
--- a/.claude/hooks/commander/callback-handler.js
+++ b/.claude/hooks/commander/callback-handler.js
@@ -832,6 +832,46 @@ async function routeCallback(cbData, callbackQueryId, message) {
     }
 
     // Detalle bajo demanda (#1681)
+    if (cbData === "tts_listen") {
+        _log("Callback tts_listen recibido — generando audio de la respuesta");
+        try {
+            await _tgApi.telegramPost("answerCallbackQuery", {
+                callback_query_id: callbackQueryId,
+                text: "Generando audio...",
+                show_alert: false
+            }, 5000);
+        } catch (e) {}
+
+        const stored = lastFullResponse.load();
+        if (!stored || !stored.text) {
+            await _tgApi.sendMessage("⏱ La respuesta expiró (TTL: 10 min). Ejecutá el comando nuevamente.");
+            return true;
+        }
+
+        // Activar command-in-progress para silenciar otros mensajes
+        try { require("../telegram-client").setCommandInProgress(true); } catch (e) {}
+
+        // Escribir voice flag para que stop-notify no envíe imagen
+        try {
+            const flagPath = path.join(_hooksDir || __dirname + "/..", "voice-response-active.flag");
+            require("fs").writeFileSync(flagPath, String(Date.now()), "utf8");
+        } catch (e) {}
+
+        try {
+            const multimediaHandler = require("./multimedia-handler");
+            const text = stored.text.substring(0, 2000); // Límite TTS
+            const audioBuffer = await multimediaHandler.callTTS(text);
+            await _tgApi.sendVoiceMessage(audioBuffer);
+            _log("TTS bajo demanda enviado: " + audioBuffer.length + " bytes");
+        } catch (ttsErr) {
+            _log("Error TTS bajo demanda: " + ttsErr.message);
+            await _tgApi.sendMessage("❌ Error generando audio: <code>" + _tgApi.escHtml(ttsErr.message) + "</code>");
+        } finally {
+            try { require("../telegram-client").setCommandInProgress(false); } catch (e) {}
+        }
+        return true;
+    }
+
     if (cbData === "show_detail") {
         _log("Callback show_detail recibido");
         try {

--- a/.claude/hooks/telegram-commander.js
+++ b/.claude/hooks/telegram-commander.js
@@ -371,9 +371,14 @@ async function sendResult(label, result) {
         rawText = result.stdout || "(sin output)";
     }
 
+    // Guardar respuesta completa para TTS bajo demanda
+    lastFullResponse.save(rawText, label);
+
+    // Botón "Escuchar" siempre disponible para pedir audio de la respuesta
+    const listenBtn = { text: "🔊 Escuchar", callback_data: "tts_listen" };
+
     // Resumen inteligente (#1681): si la respuesta es larga, resumir y ofrecer detalle
     if (!responseSummarizer.isShort(rawText)) {
-        lastFullResponse.save(rawText, label);
         const summary = responseSummarizer.summarize(rawText);
         output = cmdPrefix + "✅ <b>" + tgApi.escHtml(label) + "</b>\n\n" + tgApi.escHtml(summary);
         try {
@@ -382,7 +387,7 @@ async function sendResult(label, result) {
                 chat_id: tgApi.getChatId(),
                 text: output,
                 parse_mode: "HTML",
-                reply_markup: { inline_keyboard: [[{ text: "📋 Ver detalle", callback_data: "show_detail" }]] }
+                reply_markup: { inline_keyboard: [[{ text: "📋 Ver detalle", callback_data: "show_detail" }, listenBtn]] }
             }, 8000);
             if (r && r.message_id) registerMessage(r.message_id, "command");
         } catch (e) {
@@ -391,7 +396,18 @@ async function sendResult(label, result) {
         }
     } else {
         output = cmdPrefix + "✅ <b>" + tgApi.escHtml(label) + "</b>\n\n" + tgApi.escHtml(rawText);
-        await tgApi.sendLongMessage(output);
+        try {
+            const { registerMessage } = require("./telegram-message-registry");
+            const r = await tgApi.telegramPost("sendMessage", {
+                chat_id: tgApi.getChatId(),
+                text: output,
+                parse_mode: "HTML",
+                reply_markup: { inline_keyboard: [[listenBtn]] }
+            }, 8000);
+            if (r && r.message_id) registerMessage(r.message_id, "command");
+        } catch (e) {
+            await tgApi.sendLongMessage(output);
+        }
     }
 }
 


### PR DESCRIPTION
## Resumen

- Boton "Escuchar" en cada respuesta de texto de Telegram
- Genera TTS y envia solo audio, sin otros mensajes
- Silencia notificaciones automaticas durante generacion

Generado con [Claude Code](https://claude.ai/claude-code)