### PR TITLE
fix(telegram): command guard no bloquea respuestas del commander

### DIFF
--- a/.claude/hooks/agent-monitor.js
+++ b/.claude/hooks/agent-monitor.js
@@ -90,6 +90,14 @@ function log(msg) {
 
 async function notify(text, silent) {
     if (!tgClient) return;
+    // No enviar si el commander está procesando un comando del usuario
+    try {
+        const flagFile = path.join(HOOKS_DIR, "command-in-progress.flag");
+        if (fs.existsSync(flagFile)) {
+            const age = Date.now() - fs.statSync(flagFile).mtimeMs;
+            if (age < 180000) return; // 3 min — silenciar
+        }
+    } catch (e) {}
     try { await tgClient.sendMessage(text, { silent: !!silent }); } catch (e) { log("Notify error: " + e.message); }
 }
 

--- a/.claude/hooks/telegram-client.js
+++ b/.claude/hooks/telegram-client.js
@@ -142,11 +142,6 @@ function setCommandInProgress(active) {
 async function sendMessage(text, opts) {
     opts = opts || {};
 
-    // Bloquear mensajes automáticos mientras se procesa un comando del usuario
-    if (isCommandInProgress() && !opts.isResponse) {
-        return null; // Silenciar — no enviar
-    }
-
     const chatId = opts.chatId || getChatId();
     if (!chatId) throw new Error("No chat_id configured");
 
@@ -194,10 +189,6 @@ async function editMessage(messageId, text, opts) {
  */
 function sendPhoto(imageBuffer, caption, opts) {
     opts = opts || {};
-    // Bloquear fotos automáticas mientras se procesa un comando del usuario
-    if (isCommandInProgress() && !opts.isResponse) {
-        return Promise.resolve(null);
-    }
     const chatId = opts.chatId || getChatId();
     const token = getBotToken();
     if (!token || !chatId) return Promise.reject(new Error("No bot_token or chat_id"));


### PR DESCRIPTION
Guard movido de telegram-client.js a hooks externos (stop-notify, agent-monitor).
El commander puede responder sin restricción.

Generado con [Claude Code](https://claude.ai/claude-code)