### PR TITLE
fix(telegram): silenciar watcher, health-check y notify-telegram

### DIFF
--- a/.claude/hooks/agent-watcher.js
+++ b/.claude/hooks/agent-watcher.js
@@ -220,6 +220,11 @@ try { agentDoctor = require("./agent-doctor"); } catch (e) { log("agent-doctor n
 const { buildCompletedEntry, validateCompletionCriteria, MIN_DURATION_MINUTES } = require("./validation-utils");
 
 async function notify(text) {
+    // Watcher legacy — solo loguea, no envía a Telegram (reemplazado por coordinator)
+    const clean = (text || "").replace(/<[^>]+>/g, "").substring(0, 200);
+    log("(notify→log) " + clean);
+    return;
+    // Dead code below — kept for reference
     if (tgClient) {
         try { await tgClient.sendMessage(text); return; } catch (e) { log("tgClient error: " + e.message); }
     }

--- a/.claude/hooks/health-check.js
+++ b/.claude/hooks/health-check.js
@@ -629,6 +629,12 @@ function checkDeadWorktrees() {
 // ─── Notificación a Telegram ───────────────────────────────────────────────
 
 function sendAlert(text) {
+    // Health check solo loguea — no envía a Telegram.
+    // La info está disponible en el dashboard web y logs.
+    const clean = (text || "").replace(/<[^>]+>/g, "").substring(0, 200);
+    try { fs.appendFileSync(LOG_FILE, "[" + new Date().toISOString() + "] HealthCheck: (alert→log) " + clean + "\n"); } catch(e) {}
+    return Promise.resolve(true);
+    // Dead code below
     return new Promise((resolve) => {
         try {
             const config = JSON.parse(fs.readFileSync(CONFIG_FILE, "utf8"));

--- a/.claude/hooks/notify-telegram.js
+++ b/.claude/hooks/notify-telegram.js
@@ -158,6 +158,11 @@ function classifyNotification(type, message, title) {
 }
 
 function sendTelegram(text, attempt, options) {
+    // Solo loguear — no enviar a Telegram. Las notificaciones automáticas de hooks
+    // no requieren acción del usuario. La info está en dashboard y logs.
+    const clean = (text || "").replace(/<[^>]+>/g, "").substring(0, 200);
+    log("(sendTelegram→log) " + clean);
+    return Promise.resolve({ ok: true, result: { message_id: 0 } });
     const silent = options && options.silent;
     const inlineKeyboard = options && options.inlineKeyboard;
 
@@ -204,6 +209,8 @@ function sendTelegram(text, attempt, options) {
  * Se usa para heartbeat y resumen diario.
  */
 function sendTelegramPhoto(photoBuffer, caption, attempt, options) {
+    log("(sendTelegramPhoto→log) foto omitida — ver dashboard web");
+    return Promise.resolve({ ok: true, result: { message_id: 0 } });
     const silent = options && options.silent;
     const inlineKeyboard = options && options.inlineKeyboard;
 


### PR DESCRIPTION
Todos los hooks que spameaban Telegram ahora solo loguean.

Generado con [Claude Code](https://claude.ai/claude-code)