### PR TITLE
fix(pipeline): corregir sintaxis PowerShell en launch-v2.ps1

### DIFF
--- a/.pipeline/launch-v2.ps1
+++ b/.pipeline/launch-v2.ps1
@@ -53,7 +53,7 @@ Write-Host "  Servicios: telegram, github, drive"
 Write-Host "  Watchdog:  cada 2 min"
 Write-Host ""
 Write-Host "Comandos utiles:"
-Write-Host "  Estado:   ls .pipeline/desarrollo/*/pendiente/"
-Write-Host "  Pausar:   touch .pipeline/.paused"
-Write-Host "  Reanudar: rm .pipeline/.paused"
-Write-Host "  Detener:  taskkill /F /PID (cat .pipeline/pulpo.pid)"
+Write-Host '  Estado:   ls .pipeline\desarrollo\*\pendiente\'
+Write-Host '  Pausar:   New-Item .pipeline\.paused'
+Write-Host '  Reanudar: Remove-Item .pipeline\.paused'
+Write-Host '  Detener:  taskkill /F /PID $((Get-Content .pipeline\pulpo.pid))'


### PR DESCRIPTION
## Summary
- Paréntesis en Write-Host causaban error de parsing en PowerShell línea 59
- Cambiado a comillas simples para evitar interpolación

🤖 Generated with [Claude Code](https://claude.com/claude-code)