### PR TITLE
fix: eliminar marcador de conflicto merge en DoDeliveryOrders.kt

### DIFF
--- a/app/composeApp/src/commonMain/kotlin/asdo/delivery/DoDeliveryOrders.kt
+++ b/app/composeApp/src/commonMain/kotlin/asdo/delivery/DoDeliveryOrders.kt
@@ -83,7 +83,6 @@ class DoGetDeliveryOrderDetail(
     }
 }
 
-<<<<<<< HEAD
 class DoGetAvailableDeliveryOrders(
     private val ordersService: CommDeliveryOrdersService
 ) : ToDoGetAvailableDeliveryOrders {


### PR DESCRIPTION
## Resumen

- Elimina marcador `<<<<<<< HEAD` residual en `DoDeliveryOrders.kt:86` que quedó de un merge
- Este marcador rompía **todos** los builds del CI (Android, Desktop, Web)

## Urgencia

HOTFIX — todos los workflows de distribución están rojos desde el último merge a main.

🤖 Generado con [Claude Code](https://claude.ai/claude-code)