### PR TITLE
fix(build): binaryen v118 pin alcanza subprojects (fix SIGSEGV wasm-opt)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -179,4 +179,10 @@ tasks.matching { it.name == "build" }.configureEach {
 plugins.withType<WasmBinaryenPlugin> {
     extensions.getByType<WasmBinaryenEnvSpec>().version.set("version_118")
 }
+@OptIn(ExperimentalWasmDsl::class)
+allprojects {
+    plugins.withType<WasmBinaryenPlugin> {
+        extensions.getByType<WasmBinaryenEnvSpec>().version.set("version_118")
+    }
+}
 


### PR DESCRIPTION
## Resumen

- El pin de binaryen v118 estaba en `plugins.withType` del root, pero el target `wasmJs` vive en `:app:composeApp`
- Resultado: binaryen v123 se seguía usando → `wasm-opt` crasheaba con SIGSEGV (exit 139) en CI
- Fix: agregar `allprojects { plugins.withType<WasmBinaryenPlugin> { ... } }` para que el pin alcance a todos los subprojects

## Urgencia

HOTFIX — Distribución Web/Wasm está rota en CI.

🤖 Generado con [Claude Code](https://claude.ai/claude-code)