### PR TITLE
fix(pipeline): build sin ventanas visibles (cmd.exe en vez de bash)

### DIFF
--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -609,11 +609,17 @@ function lanzarBuild(issue, trabajandoPath, pipeline, config) {
     }
   }
 
-  const child = spawn('bash', ['-c', `./gradlew check 2>&1`], {
+  // Usar cmd.exe con windowsHide en vez de bash (bash abre ventana visible en Windows)
+  const gradlewCmd = process.platform === 'win32'
+    ? { cmd: 'cmd.exe', args: ['/c', 'gradlew.bat check 2>&1'] }
+    : { cmd: 'bash', args: ['-c', './gradlew check 2>&1'] };
+
+  const child = spawn(gradlewCmd.cmd, gradlewCmd.args, {
     cwd: buildCwd,
     stdio: ['ignore', 'pipe', 'pipe'],
     detached: true,
-    windowsHide: true
+    windowsHide: true,
+    shell: false
   });
 
   child.unref();


### PR DESCRIPTION
## Resumen

- Build usaba `spawn('bash', ...)` que abre ventana visible de mintty en Windows
- Cambiado a `spawn('cmd.exe', ['/c', 'gradlew.bat check'])` con `windowsHide: true` y `shell: false`
- Elimina las ventanas que flashean al ejecutar builds del pipeline

🤖 Generado con [Claude Code](https://claude.ai/claude-code)