### PR TITLE
feat(context): bidirectional context relay + outbox-drain service

### DIFF
--- a/.claude/hooks/activity-logger.js
+++ b/.claude/hooks/activity-logger.js
@@ -112,6 +112,93 @@ function getBranch() {
     return "unknown";
 }
 
+// ─── Context Channel relay ───────────────────────────────────────────────────
+// Post tool activity to context channels when an agent has an open channel
+// Uses in-memory cache (60s TTL) to avoid reading disk on every tool use
+
+let _contextChannelCache = { channelId: null, checkedAt: 0, issueNum: null };
+let _terminalChannelCache = { channelId: null, checkedAt: 0 };
+const CONTEXT_CACHE_TTL_MS = 60 * 1000;
+
+function postToContextChannel(sessionId, toolName, target) {
+    try {
+        if (["Read", "Glob", "Grep", "TaskList", "TaskGet"].includes(toolName)) return;
+        const now = Date.now();
+        let issueNum = _contextChannelCache.issueNum;
+        if (!issueNum || (now - _contextChannelCache.checkedAt) > CONTEXT_CACHE_TTL_MS) {
+            issueNum = null;
+            const branch = getBranch();
+            const branchMatch = (branch || "").match(/(?:agent|feature|bugfix)\/(\d+)/);
+            if (branchMatch) issueNum = branchMatch[1];
+            if (!issueNum && agentRegistry && sessionId) {
+                try {
+                    const agents = agentRegistry.getAllAgents ? agentRegistry.getAllAgents() : [];
+                    const myAgent = agents.find(a => (a.session_id || "").substring(0, 8) === sessionId.substring(0, 8));
+                    if (myAgent && myAgent.issue) issueNum = String(myAgent.issue).replace(/^#/, "");
+                } catch (e) {}
+            }
+            _contextChannelCache.issueNum = issueNum;
+            _contextChannelCache.checkedAt = now;
+        }
+        if (!issueNum) return;
+        let channelId = _contextChannelCache.channelId;
+        if (!channelId || (now - _contextChannelCache.checkedAt) > CONTEXT_CACHE_TTL_MS) {
+            channelId = null;
+            try {
+                const contextManager = require("./context-manager");
+                const channel = contextManager.findChannelByIssue(issueNum);
+                if (channel) channelId = channel.id;
+            } catch (e) {}
+            _contextChannelCache.channelId = channelId;
+        }
+        if (!channelId) return;
+        try {
+            const contextManager = require("./context-manager");
+            const agentLabel = getSprintAgentName(parseInt(issueNum, 10)) || "Agente #" + issueNum;
+            contextManager.postMessage(channelId, {
+                from: "agent-" + sessionId, from_label: agentLabel,
+                type: "activity", content: "[" + toolName + "] " + (target || "--").substring(0, 120),
+            });
+        } catch (e) {}
+    } catch (e) {}
+}
+
+// ─── Terminal Context Channel relay ─────────────────────────────────────────
+function postToTerminalContextChannel(sessionId, toolName, target) {
+    try {
+        if (["Read", "Glob", "Grep", "TaskList", "TaskGet"].includes(toolName)) return;
+        const now = Date.now();
+        const shortSession = (sessionId || "").substring(0, 8) || "local";
+        let channelId = _terminalChannelCache.channelId;
+        if (!channelId || (now - _terminalChannelCache.checkedAt) > CONTEXT_CACHE_TTL_MS) {
+            channelId = null;
+            const candidates = [
+                path.join(REPO_ROOT, ".claude", "hooks", "context-active-" + shortSession + ".json"),
+                path.join(REPO_ROOT, ".claude", "hooks", "context-active-local.json"),
+            ];
+            for (const activeFile of candidates) {
+                try {
+                    const active = JSON.parse(fs.readFileSync(activeFile, "utf8"));
+                    if (active && active.channel_id) { channelId = active.channel_id; break; }
+                } catch (e) {}
+            }
+            _terminalChannelCache.channelId = channelId;
+            _terminalChannelCache.checkedAt = now;
+        }
+        if (!channelId) return;
+        if (_contextChannelCache.channelId === channelId) return;
+        const contextManager = require("./context-manager");
+        contextManager.postMessage(channelId, {
+            from: "terminal-" + shortSession, from_label: "Terminal (" + shortSession + ")",
+            type: "activity", content: "[" + toolName + "] " + (target || "--").substring(0, 120),
+        });
+        try {
+            const bridge = require("./context-bridge");
+            bridge.relayToTelegram(channelId);
+        } catch (e) {}
+    } catch (e) {}
+}
+
 function handleInput() {
     try {
         let data;
@@ -226,6 +313,12 @@ function handleInput() {
         if (sessionId) {
             updateSession(sessionId, ts, toolName, target, ti, data.usage || null);
         }
+
+        // Post actividad a context channels (si el agente tiene canal abierto)
+        postToContextChannel(sessionId, toolName, target);
+
+        // Post actividad al canal activo de la terminal (e.g., telegram)
+        postToTerminalContextChannel(sessionId, toolName, target);
 
         // Detectar sesiones stale periódicamente (cada ~10 invocaciones)
         markStaleSessions();

--- a/.claude/hooks/context-bridge.js
+++ b/.claude/hooks/context-bridge.js
@@ -1,0 +1,243 @@
+// context-bridge.js — Puente entre Context Channels, Pending Questions y Telegram
+// Sincroniza preguntas pendientes de agentes con sus canales de contexto,
+// retransmite respuestas, y envía mensajes nuevos a Telegram
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const contextManager = require("./context-manager");
+const { getPendingQuestions, resolveQuestion, getQuestionsByChannel } = require("./pending-questions");
+
+// Telegram outbox — fire-and-forget via archivo, el Commander drena
+let tgOutbox = null;
+function getTgOutbox() {
+    if (tgOutbox) return tgOutbox;
+    try { tgOutbox = require("./telegram-outbox"); } catch (e) {}
+    return tgOutbox;
+}
+
+// Agent registry — carga lazy
+let agentRegistry = null;
+function getAgentRegistry() {
+    if (agentRegistry) return agentRegistry;
+    try { agentRegistry = require("./agent-registry"); } catch (e) {}
+    return agentRegistry;
+}
+
+// ─── State: track last synced timestamps to avoid re-processing ──────────────
+
+const BRIDGE_STATE_FILE = path.join(__dirname, "context-bridge-state.json");
+
+function loadBridgeState() {
+    try {
+        return JSON.parse(fs.readFileSync(BRIDGE_STATE_FILE, "utf8"));
+    } catch (e) {
+        return { last_question_sync: null, last_telegram_relay: {} };
+    }
+}
+
+function saveBridgeState(state) {
+    try {
+        fs.writeFileSync(BRIDGE_STATE_FILE, JSON.stringify(state, null, 2), "utf8");
+    } catch (e) {}
+}
+
+// ─── Sync: Pending Questions → Context Channels ─────────────────────────────
+// Detecta preguntas nuevas de agentes que tienen un canal de contexto
+// y las postea al canal como mensajes tipo "question"
+
+function syncPendingQuestionsToChannels() {
+    const state = loadBridgeState();
+    const pendingQuestions = getPendingQuestions();
+    const registry = getAgentRegistry();
+    let synced = 0;
+
+    for (const q of pendingQuestions) {
+        // Skip if already has channel_id (already synced)
+        if (q.channel_id) continue;
+
+        // Skip if already processed (check by timestamp)
+        if (state.last_question_sync && q.timestamp <= state.last_question_sync) continue;
+
+        // Try to find a context channel for this question's agent
+        // Use action_data to identify the agent (has session info, tool context)
+        const actionData = q.action_data || {};
+
+        // Try to match by session — find the agent's issue from registry
+        if (!registry) continue;
+        const agents = registry.getAllAgents ? registry.getAllAgents() : [];
+
+        // Look for an agent whose session matches the approver_pid or skill_context
+        let matchedChannel = null;
+
+        for (const agent of agents) {
+            if (agent.status !== "active" && agent.status !== "idle") continue;
+
+            // Check if there's a context channel for this agent
+            const channel = contextManager.findChannelByIssue(agent.issue);
+            if (!channel) continue;
+
+            // Check if this question could belong to this agent
+            // Heuristic: if the question's skill_context matches the agent's skill
+            if (q.skill_context && agent.skill && q.skill_context.includes(agent.skill)) {
+                matchedChannel = channel;
+                break;
+            }
+
+            // Or if any channel has a participant with matching PID
+            if (q.approver_pid && agent.pid === q.approver_pid) {
+                matchedChannel = channel;
+                break;
+            }
+        }
+
+        if (matchedChannel) {
+            // Post the question to the channel
+            const hasTelegramParticipant = matchedChannel.participants.some(p => p.type === "telegram");
+
+            contextManager.postQuestion(
+                matchedChannel.id,
+                { id: "system", label: "Sistema (permiso)" },
+                q.message || "(pregunta de permiso)",
+                q.id // link back to pending question ID
+            );
+
+            synced++;
+        }
+    }
+
+    // Update sync timestamp
+    if (pendingQuestions.length > 0) {
+        state.last_question_sync = new Date().toISOString();
+        saveBridgeState(state);
+    }
+
+    return synced;
+}
+
+// ─── Relay: Context Channel Answer → Pending Questions ───────────────────────
+// When someone answers a question in a context channel, resolve the original
+// pending question so the agent unblocks
+
+function relayAnswerToPendingQuestions(channelId, questionId, answer, answeredBy) {
+    const channel = contextManager.getChannel(channelId);
+    if (!channel) return false;
+
+    // Find the pending question in the channel
+    const pq = (channel.pending_questions || []).find(q => q.question_id === questionId);
+    if (!pq || !pq.pending_question_id) return false;
+
+    // Resolve the original pending question
+    // Map the answer to an action: if it looks like permission response, use that
+    let action = "allow"; // default for permission questions
+    const lower = (answer || "").toLowerCase().trim();
+    if (["no", "deny", "denegar", "n"].includes(lower)) {
+        action = "deny";
+    } else if (["siempre", "always"].includes(lower)) {
+        action = "always";
+    }
+
+    const via = answeredBy === "telegram" ? "telegram" : "context_channel";
+    resolveQuestion(pq.pending_question_id, "answered", via, action);
+
+    return true;
+}
+
+// ─── Relay: Context Channel Messages → Telegram ──────────────────────────────
+// Send new messages from channels with Telegram participants to Telegram
+
+function relayToTelegram(channelId, sinceTimestamp) {
+    const outbox = getTgOutbox();
+    if (!outbox) return 0;
+
+    const channel = contextManager.getChannel(channelId);
+    if (!channel) return 0;
+
+    // Check if Telegram is a participant
+    const hasTg = channel.participants.some(p => p.type === "telegram");
+    if (!hasTg) return 0;
+
+    // Get messages since last relay
+    const state = loadBridgeState();
+    const lastRelay = sinceTimestamp || (state.last_telegram_relay || {})[channelId] || null;
+    const messages = contextManager.getMessages(channelId, lastRelay);
+
+    // Filter out messages FROM telegram (avoid echo)
+    const toRelay = messages.filter(m => m.from !== "telegram" && m.from !== "p-tg");
+
+    let sent = 0;
+    for (const msg of toRelay) {
+        let prefix = "";
+        switch (msg.type) {
+            case "question": prefix = "\u2753 "; break;  // ❓
+            case "answer": prefix = "\u2705 "; break;    // ✅
+            case "activity": prefix = "\ud83d\udd27 "; break;  // 🔧
+            case "system": prefix = "\ud83d\udccb "; break;    // 📋
+            default: prefix = ""; break;
+        }
+
+        const text = "<b>[" + (channel.name || channelId) + "]</b>\n"
+            + "<i>" + (msg.from_label || "?") + ":</i> "
+            + prefix + (msg.content || "").substring(0, 3000);
+
+        try {
+            outbox.enqueue(text, { silent: msg.type === "activity", category: "context-relay" });
+            sent++;
+        } catch (e) {}
+    }
+
+    // Update last relay timestamp
+    if (messages.length > 0) {
+        if (!state.last_telegram_relay) state.last_telegram_relay = {};
+        state.last_telegram_relay[channelId] = messages[messages.length - 1].timestamp;
+        saveBridgeState(state);
+    }
+
+    return sent;
+}
+
+// ─── Tick: Main sync loop ────────────────────────────────────────────────────
+// Called periodically by the commander or via CLI
+
+function tick() {
+    const results = {
+        questions_synced: 0,
+        telegram_relayed: 0,
+        channels_cleaned: 0,
+    };
+
+    try {
+        // 1. Sync pending questions to channels
+        results.questions_synced = syncPendingQuestionsToChannels();
+    } catch (e) {}
+
+    try {
+        // 2. Relay messages to Telegram for all channels with Telegram participants
+        const channels = contextManager.listChannels();
+        for (const ch of channels) {
+            const hasTg = (ch.participants || []).some(p => p.type === "telegram");
+            if (hasTg) {
+                results.telegram_relayed += relayToTelegram(ch.id);
+            }
+        }
+    } catch (e) {}
+
+    try {
+        // 3. Cleanup stale channels (> 24h)
+        const removed = contextManager.cleanupStaleChannels();
+        results.channels_cleaned = removed.length;
+    } catch (e) {}
+
+    return results;
+}
+
+// ─── Exports ─────────────────────────────────────────────────────────────────
+
+module.exports = {
+    syncPendingQuestionsToChannels,
+    relayAnswerToPendingQuestions,
+    relayToTelegram,
+    tick,
+    loadBridgeState,
+    saveBridgeState,
+};

--- a/.claude/hooks/context-cli.js
+++ b/.claude/hooks/context-cli.js
@@ -1,0 +1,539 @@
+#!/usr/bin/env node
+// context-cli.js — CLI entry point para el skill /context
+// Parsea argumentos, ejecuta operaciones via context-manager, imprime JSON a stdout
+//
+// Usage: node context-cli.js <subcommand> [args...]
+// Subcommands: list, join, leave, history, say, answer, create, status
+"use strict";
+
+const path = require("path");
+const fs = require("fs");
+const contextManager = require("./context-manager");
+
+// ─── Agent Registry ──────────────────────────────────────────────────────────
+
+let agentRegistry = null;
+try { agentRegistry = require("./agent-registry"); } catch (e) {}
+
+// ─── Session ID ──────────────────────────────────────────────────────────────
+
+function getSessionId() {
+    return (process.env.CLAUDE_SESSION_ID || "").substring(0, 8) || "local";
+}
+
+// ─── Active context tracking (per-terminal) ──────────────────────────────────
+
+const ACTIVE_CONTEXT_FILE = path.join(__dirname, "context-active-" + getSessionId() + ".json");
+
+function getActiveContext() {
+    try {
+        return JSON.parse(fs.readFileSync(ACTIVE_CONTEXT_FILE, "utf8"));
+    } catch (e) {
+        return null;
+    }
+}
+
+function setActiveContext(channelId, participantId) {
+    const data = { channel_id: channelId, participant_id: participantId, updated_at: new Date().toISOString() };
+    fs.writeFileSync(ACTIVE_CONTEXT_FILE, JSON.stringify(data), "utf8");
+    return data;
+}
+
+function clearActiveContext() {
+    try { fs.unlinkSync(ACTIVE_CONTEXT_FILE); } catch (e) {}
+}
+
+// ─── Activity log import ─────────────────────────────────────────────────────
+
+function importRecentActivity(sessionId, limit) {
+    limit = limit || 15;
+    const logFile = path.join(__dirname, "..", "activity-log.jsonl");
+    try {
+        const content = fs.readFileSync(logFile, "utf8").trim();
+        if (!content) return [];
+        const lines = content.split("\n");
+        const entries = [];
+        const shortId = (sessionId || "").substring(0, 8);
+        for (let i = lines.length - 1; i >= 0 && entries.length < limit; i--) {
+            try {
+                const entry = JSON.parse(lines[i]);
+                if (!shortId || entry.session === shortId) {
+                    entries.unshift(entry);
+                }
+            } catch (e) {}
+        }
+        return entries;
+    } catch (e) {
+        return [];
+    }
+}
+
+// ─── Telegram history import ─────────────────────────────────────────────────
+
+function importTelegramHistory(limit) {
+    limit = limit || 30;
+    const histFile = path.join(__dirname, "..", "..", ".pipeline", "commander-history.jsonl");
+    try {
+        const content = fs.readFileSync(histFile, "utf8").trim();
+        if (!content) return [];
+        const lines = content.split("\n");
+        const entries = [];
+        for (let i = lines.length - 1; i >= 0 && entries.length < limit; i--) {
+            try {
+                entries.unshift(JSON.parse(lines[i]));
+            } catch (e) {}
+        }
+        return entries;
+    } catch (e) {
+        return [];
+    }
+}
+
+// ─── Parse agent reference: "android-dev #1913" or "android-dev 1913" ────────
+
+function parseAgentRef(argsArray) {
+    let skill = null;
+    let issue = null;
+
+    for (const arg of argsArray) {
+        const stripped = arg.replace(/^#/, "");
+        if (/^\d+$/.test(stripped)) {
+            issue = stripped;
+        } else if (!skill) {
+            skill = arg;
+        }
+    }
+
+    return { skill, issue };
+}
+
+// ─── Find agent in registry ─────────────────────────────────────────────────
+
+function findAgent(skill, issue) {
+    if (!agentRegistry) return null;
+    const agents = agentRegistry.getAllAgents ? agentRegistry.getAllAgents() : [];
+
+    return agents.find(a => {
+        const agentIssue = String(a.issue || "").replace(/^#/, "");
+        const matchIssue = issue && agentIssue === issue;
+        const matchSkill = skill && a.skill === skill;
+
+        if (issue && skill) return matchIssue && matchSkill;
+        if (issue) return matchIssue;
+        if (skill) return matchSkill;
+        return false;
+    }) || null;
+}
+
+// ─── Output helpers ──────────────────────────────────────────────────────────
+
+function output(data) {
+    process.stdout.write(JSON.stringify(data, null, 2) + "\n");
+}
+
+function outputError(msg) {
+    output({ ok: false, error: msg });
+    process.exit(1);
+}
+
+// ─── Subcommand: list ────────────────────────────────────────────────────────
+
+function cmdList() {
+    const channels = contextManager.listChannels();
+    output({
+        ok: true,
+        command: "list",
+        channels: channels.map(ch => ({
+            id: ch.id,
+            name: ch.name,
+            origin_type: (ch.origin || {}).type,
+            participants: (ch.participants || []).length,
+            messages: (ch.messages || []).length,
+            pending_questions: (ch.pending_questions || []).filter(q => q.status === "pending").length,
+            updated_at: ch.updated_at,
+        })),
+    });
+}
+
+// ─── Subcommand: join ────────────────────────────────────────────────────────
+
+function cmdJoin(args) {
+    if (args.length === 0) {
+        outputError("Uso: join agent <skill> <issue> | join telegram | join <channel-id>");
+    }
+
+    const firstArg = args[0].toLowerCase();
+
+    // /context join telegram
+    if (firstArg === "telegram") {
+        return cmdJoinTelegram();
+    }
+
+    // /context join agent <skill> <issue>
+    if (firstArg === "agent") {
+        const ref = parseAgentRef(args.slice(1));
+        return cmdJoinAgent(ref.skill, ref.issue);
+    }
+
+    // /context join <skill> #<issue> (shorthand)
+    const ref = parseAgentRef(args);
+    if (ref.issue) {
+        return cmdJoinAgent(ref.skill, ref.issue);
+    }
+
+    // /context join <channel-id>
+    const channel = contextManager.getChannel(firstArg);
+    if (channel) {
+        return joinAndOutput(channel.id);
+    }
+
+    // Try as custom name
+    const customChannel = contextManager.getChannel("custom-" + firstArg);
+    if (customChannel) {
+        return joinAndOutput(customChannel.id);
+    }
+
+    outputError("Canal no encontrado: " + firstArg + ". Usa 'list' para ver canales activos.");
+}
+
+function cmdJoinAgent(skill, issue) {
+    if (!issue && !skill) {
+        outputError("Especifica al menos un skill o issue. Ej: android-dev #1913");
+    }
+
+    // Find agent in registry
+    const agent = findAgent(skill, issue);
+    let channel;
+
+    if (agent) {
+        channel = contextManager.getOrCreateAgentChannel(agent);
+    } else {
+        // Agent not found in registry — create channel anyway for observation
+        const channelId = "agent-" + (issue || skill || "unknown");
+        channel = contextManager.getChannel(channelId);
+        if (!channel) {
+            channel = contextManager.createChannel(channelId, (skill || "agent") + " #" + (issue || "?"), {
+                type: "agent",
+                issue: issue ? "#" + issue : null,
+                skill: skill || null,
+            });
+        }
+    }
+
+    // Import recent activity as retroactive messages
+    if (agent && agent.session_id && channel.messages.length === 0) {
+        const activity = importRecentActivity(agent.session_id, 20);
+        for (const entry of activity) {
+            contextManager.postMessage(channel.id, {
+                from: "system",
+                from_label: agent.agent_name || agent.skill || "Agente",
+                type: "activity",
+                content: "[" + entry.tool + "] " + (entry.target || "--"),
+            });
+        }
+    }
+
+    joinAndOutput(channel.id);
+}
+
+function cmdJoinTelegram() {
+    // Find or create telegram channel
+    let channel = contextManager.findTelegramChannel();
+    const today = new Date().toISOString().substring(0, 10).replace(/-/g, "");
+
+    if (!channel || channel.id !== "telegram-" + today) {
+        channel = contextManager.createChannel("telegram-" + today, "Telegram " + today, {
+            type: "telegram",
+        });
+
+        // Import recent Telegram history
+        const history = importTelegramHistory(30);
+        for (const entry of history) {
+            contextManager.postMessage(channel.id, {
+                from: "telegram",
+                from_label: entry.from || "Telegram",
+                type: "text",
+                content: entry.text || entry.message || "(media)",
+            });
+        }
+    }
+
+    // Auto-unir a Telegram como participante para que el bridge retransmita
+    contextManager.joinChannel(channel.id, { type: "telegram", label: "Telegram" });
+
+    // Auto-start outbox drain si el Pulpo no está corriendo
+    ensureOutboxDrain();
+
+    joinAndOutput(channel.id);
+}
+
+function ensureOutboxDrain() {
+    try {
+        const { spawnSync, spawn } = require("child_process");
+        const drainScript = path.join(__dirname, "..", "..", ".pipeline", "outbox-drain.js");
+        if (!fs.existsSync(drainScript)) return;
+
+        // Check si ya hay un Pulpo o drain corriendo
+        const r = spawnSync("wmic", [
+            "process", "where", "name='node.exe'",
+            "get", "ProcessId,CommandLine", "/format:csv"
+        ], { encoding: "utf8", timeout: 10000, windowsHide: true });
+        const stdout = r.stdout || "";
+        if (stdout.includes("pulpo.js") || stdout.includes("outbox-drain.js")) return;
+
+        // Lanzar drain en background
+        const logPath = path.join(__dirname, "..", "..", ".pipeline", "logs", "outbox-drain.log");
+        const logFd = fs.openSync(logPath, "a");
+        const child = spawn(process.execPath, [drainScript], {
+            detached: true, stdio: ["ignore", logFd, logFd], windowsHide: true
+        });
+        child.unref();
+        fs.closeSync(logFd);
+    } catch (e) {
+        // Silent fail — no bloquear el join
+    }
+}
+
+function joinAndOutput(channelId) {
+    const sessionId = getSessionId();
+    const participant = {
+        type: "terminal",
+        session_id: sessionId,
+        label: "Terminal (" + sessionId + ")",
+    };
+
+    const channel = contextManager.joinChannel(channelId, participant);
+    if (!channel) {
+        outputError("No se pudo unir al canal: " + channelId);
+    }
+
+    // Track active context for this terminal
+    const me = channel.participants.find(p => p.session_id === sessionId && p.type === "terminal");
+    setActiveContext(channelId, me ? me.id : null);
+
+    // Return channel info + recent messages
+    output({
+        ok: true,
+        command: "join",
+        channel: {
+            id: channel.id,
+            name: channel.name,
+            origin: channel.origin,
+            participants: channel.participants,
+            pending_questions: (channel.pending_questions || []).filter(q => q.status === "pending"),
+        },
+        recent_messages: (channel.messages || []).slice(-20),
+    });
+}
+
+// ─── Subcommand: leave ───────────────────────────────────────────────────────
+
+function cmdLeave() {
+    const active = getActiveContext();
+    if (!active) {
+        outputError("No estas en ningun canal. Usa 'list' para ver canales activos.");
+    }
+
+    if (active.participant_id) {
+        contextManager.leaveChannel(active.channel_id, active.participant_id);
+    }
+    clearActiveContext();
+
+    output({ ok: true, command: "leave", channel_id: active.channel_id });
+}
+
+// ─── Subcommand: history ─────────────────────────────────────────────────────
+
+function cmdHistory(args) {
+    const active = getActiveContext();
+    if (!active) {
+        outputError("No estas en ningun canal. Usa 'join' primero.");
+    }
+
+    const limit = parseInt(args[0], 10) || 30;
+    const messages = contextManager.getMessages(active.channel_id, null, limit);
+    const channel = contextManager.getChannel(active.channel_id);
+
+    output({
+        ok: true,
+        command: "history",
+        channel_id: active.channel_id,
+        channel_name: channel ? channel.name : active.channel_id,
+        messages: messages,
+    });
+}
+
+// ─── Subcommand: say ─────────────────────────────────────────────────────────
+
+function cmdSay(args) {
+    const active = getActiveContext();
+    if (!active) {
+        outputError("No estas en ningun canal. Usa 'join' primero.");
+    }
+
+    const text = args.join(" ");
+    if (!text) {
+        outputError("Especifica un mensaje. Ej: say Hola equipo");
+    }
+
+    const msg = contextManager.postMessage(active.channel_id, {
+        from: active.participant_id || "terminal",
+        from_label: "Terminal (" + getSessionId() + ")",
+        type: "text",
+        content: text,
+    });
+
+    // Relay inmediato a Telegram si el canal tiene participante telegram
+    let relayed = false;
+    try {
+        const bridge = require("./context-bridge");
+        const relayCount = bridge.relayToTelegram(active.channel_id);
+        relayed = relayCount > 0;
+    } catch (e) {}
+
+    output({ ok: true, command: "say", message: msg, relayed_to_telegram: relayed });
+}
+
+// ─── Subcommand: answer ──────────────────────────────────────────────────────
+
+function cmdAnswer(args) {
+    const active = getActiveContext();
+    if (!active) {
+        outputError("No estas en ningun canal. Usa 'join' primero.");
+    }
+
+    const text = args.join(" ");
+    if (!text) {
+        outputError("Especifica una respuesta. Ej: answer Usar DynamoDB");
+    }
+
+    // Find the first pending question in the channel
+    const pending = contextManager.getPendingChannelQuestions(active.channel_id);
+    if (pending.length === 0) {
+        outputError("No hay preguntas pendientes en este canal.");
+    }
+
+    const question = pending[0]; // Answer the oldest pending question
+    const result = contextManager.answerQuestion(
+        active.channel_id,
+        question.question_id,
+        { id: active.participant_id || "terminal", label: "Terminal (" + getSessionId() + ")" },
+        text
+    );
+
+    output({
+        ok: true,
+        command: "answer",
+        question_id: question.question_id,
+        pending_question_id: question.pending_question_id,
+        answer: text,
+        result: result,
+    });
+}
+
+// ─── Subcommand: create ──────────────────────────────────────────────────────
+
+function cmdCreate(args) {
+    const name = args.join("-").toLowerCase().replace(/[^a-z0-9-]/g, "") || "channel";
+    const channelId = "custom-" + name;
+
+    const existing = contextManager.getChannel(channelId);
+    if (existing) {
+        // Already exists — just join
+        return joinAndOutput(channelId);
+    }
+
+    contextManager.createChannel(channelId, name, { type: "custom" });
+    joinAndOutput(channelId);
+}
+
+// ─── Subcommand: status ──────────────────────────────────────────────────────
+
+function cmdStatus() {
+    const active = getActiveContext();
+    if (!active) {
+        // Show overview
+        const channels = contextManager.listChannels();
+        output({
+            ok: true,
+            command: "status",
+            active_channel: null,
+            total_channels: channels.length,
+            channels: channels.map(ch => ({
+                id: ch.id,
+                name: ch.name,
+                participants: (ch.participants || []).length,
+                pending_questions: (ch.pending_questions || []).filter(q => q.status === "pending").length,
+            })),
+        });
+        return;
+    }
+
+    const channel = contextManager.getChannel(active.channel_id);
+    if (!channel) {
+        clearActiveContext();
+        outputError("Canal activo ya no existe: " + active.channel_id);
+    }
+
+    const pending = (channel.pending_questions || []).filter(q => q.status === "pending");
+    const recentMsgs = (channel.messages || []).slice(-5);
+
+    output({
+        ok: true,
+        command: "status",
+        active_channel: {
+            id: channel.id,
+            name: channel.name,
+            origin: channel.origin,
+            participants: channel.participants,
+            total_messages: (channel.messages || []).length,
+            pending_questions: pending,
+            recent_messages: recentMsgs,
+        },
+    });
+}
+
+// ─── Subcommand: cleanup ─────────────────────────────────────────────────────
+
+function cmdCleanup() {
+    const removed = contextManager.cleanupStaleChannels();
+    output({ ok: true, command: "cleanup", removed: removed });
+}
+
+// ─── Main dispatch ───────────────────────────────────────────────────────────
+
+function main() {
+    const args = process.argv.slice(2);
+    const sub = (args[0] || "status").toLowerCase();
+    const rest = args.slice(1);
+
+    switch (sub) {
+        case "list":
+            return cmdList();
+        case "join":
+            return cmdJoin(rest);
+        case "leave":
+            return cmdLeave();
+        case "history":
+            return cmdHistory(rest);
+        case "say":
+            return cmdSay(rest);
+        case "answer":
+            return cmdAnswer(rest);
+        case "create":
+            return cmdCreate(rest);
+        case "status":
+            return cmdStatus();
+        case "cleanup":
+            return cmdCleanup();
+        default:
+            // Try to interpret as agent reference: "/context android-dev #1913"
+            const ref = parseAgentRef(args);
+            if (ref.issue || ref.skill) {
+                return cmdJoinAgent(ref.skill, ref.issue);
+            }
+            outputError("Subcomando desconocido: " + sub + ". Usa: list, join, leave, history, say, answer, create, status");
+    }
+}
+
+main();

--- a/.pipeline/dashboard-v2.js
+++ b/.pipeline/dashboard-v2.js
@@ -25,6 +25,7 @@ const COMPONENTS = [
   { name: 'svc-telegram', script: 'servicio-telegram.js', pid: 'svc-telegram.pid' },
   { name: 'svc-github', script: 'servicio-github.js', pid: 'svc-github.pid' },
   { name: 'svc-drive', script: 'servicio-drive.js', pid: 'svc-drive.pid' },
+  { name: 'outbox-drain', script: 'outbox-drain.js', pid: 'outbox-drain.pid' },
 ];
 // Nota: dashboard no se incluye (no puede matarse a sí mismo)
 
@@ -264,7 +265,7 @@ function getPipelineState() {
 
   // Procesos
   state.procesos = {};
-  for (const comp of ['pulpo', 'listener', 'svc-telegram', 'svc-github', 'svc-drive', 'dashboard']) {
+  for (const comp of ['pulpo', 'listener', 'svc-telegram', 'svc-github', 'svc-drive', 'outbox-drain', 'dashboard']) {
     try {
       const pid = fs.readFileSync(path.join(PIPELINE, `${comp}.pid`), 'utf8').trim();
       const alive = isProcessAlive(pid);

--- a/.pipeline/outbox-drain.js
+++ b/.pipeline/outbox-drain.js
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+// outbox-drain.js — Mini-servicio standalone que drena el outbox de Telegram
+// Se auto-mata si detecta que el Pulpo está corriendo (él ya drena)
+// Se levanta automáticamente desde context-cli al unirse a un canal telegram
+//
+// Uso: node .pipeline/outbox-drain.js
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const PIPELINE = path.resolve(__dirname);
+const ROOT = path.resolve(PIPELINE, "..");
+const DRAIN_INTERVAL_MS = 3000;
+const PULPO_CHECK_INTERVAL_MS = 15000;
+const PID_FILE = path.join(PIPELINE, "outbox-drain.pid");
+
+// Singleton: si ya hay otro corriendo, salir silenciosamente
+const { spawnSync } = require("child_process");
+
+function findProcess(scriptName) {
+  try {
+    const r = spawnSync("wmic", [
+      "process", "where", "name='node.exe'",
+      "get", "ProcessId,CommandLine", "/format:csv"
+    ], { encoding: "utf8", timeout: 10000, windowsHide: true });
+    const lines = (r.stdout || "").split("\n");
+    for (const line of lines) {
+      if (line.includes(scriptName) && !line.includes("wmic")) {
+        const match = line.match(/(\d+)\s*$/);
+        if (match && parseInt(match[1]) !== process.pid) return parseInt(match[1]);
+      }
+    }
+  } catch {}
+  return null;
+}
+
+// Si ya hay otro outbox-drain corriendo, salir
+const existing = findProcess("outbox-drain.js");
+if (existing) {
+  process.exit(0);
+}
+
+// Escribir PID
+fs.writeFileSync(PID_FILE, String(process.pid));
+process.on("exit", () => {
+  try {
+    const current = fs.readFileSync(PID_FILE, "utf8").trim();
+    if (current === String(process.pid)) fs.unlinkSync(PID_FILE);
+  } catch {}
+});
+
+function log(msg) {
+  const ts = new Date().toISOString().replace("T", " ").slice(0, 19);
+  console.log(`[${ts}] [outbox-drain] ${msg}`);
+}
+
+log("Iniciado (PID " + process.pid + ") — drain cada " + (DRAIN_INTERVAL_MS / 1000) + "s");
+
+// Drain loop
+const outbox = require(path.join(ROOT, ".claude", "hooks", "telegram-outbox"));
+
+const drainTimer = setInterval(() => {
+  outbox.drainQueue().then(r => {
+    if (r.sent > 0) log("Enviados: " + r.sent + (r.failed > 0 ? ", fallidos: " + r.failed : ""));
+  }).catch(() => {});
+}, DRAIN_INTERVAL_MS);
+
+// Auto-kill si el Pulpo arranca (él tiene su propio drain en mainLoop)
+const pulpoCheckTimer = setInterval(() => {
+  const pulpoPid = findProcess("pulpo.js");
+  if (pulpoPid) {
+    log("Pulpo detectado (PID " + pulpoPid + ") — auto-shutdown");
+    clearInterval(drainTimer);
+    clearInterval(pulpoCheckTimer);
+    process.exit(0);
+  }
+}, PULPO_CHECK_INTERVAL_MS);
+
+// Graceful shutdown
+process.on("SIGINT", () => { log("SIGINT"); process.exit(0); });
+process.on("SIGTERM", () => { log("SIGTERM"); process.exit(0); });

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -654,6 +654,28 @@ function lanzarAgenteClaude(skill, issue, trabajandoPath, pipeline, fase, config
     worktreePath: needsWorktree ? worktreePath : null
   });
 
+  // Crear canal de contexto para el agente (auto-join)
+  let contextChannelId = null;
+  try {
+    const cm = require(path.join(ROOT, '.claude', 'hooks', 'context-manager'));
+    const channelId = 'agent-' + issue;
+    let channel = cm.getChannel(channelId);
+    if (!channel) {
+      channel = cm.createChannel(channelId, skill + ' #' + issue, {
+        type: 'agent', issue: '#' + issue, skill: skill,
+        branch: worktreeBranch || null, worktree: needsWorktree ? worktreePath : null,
+      });
+    }
+    cm.joinChannel(channelId, {
+      type: 'agent', session_id: String(child.pid),
+      label: skill + ' #' + issue,
+    });
+    contextChannelId = channelId;
+    log('lanzamiento', `Canal de contexto creado: ${channelId}`);
+  } catch (e) {
+    log('lanzamiento', `Error creando canal de contexto: ${e.message}`);
+  }
+
   // Cuando el proceso termina, mover de trabajando → listo
   const launchTime = Date.now();
   child.on('exit', (code) => {
@@ -666,6 +688,13 @@ function lanzarAgenteClaude(skill, issue, trabajandoPath, pipeline, fase, config
       const pendienteDir = path.join(fasePath(pipeline, fase), 'pendiente');
       try { moveFile(trabajandoPath, pendienteDir); } catch {}
       activeProcesses.delete(processKey(skill, issue));
+      // Salir del canal de contexto
+      if (contextChannelId) {
+        try {
+          const cm = require(path.join(ROOT, '.claude', 'hooks', 'context-manager'));
+          cm.leaveChannelByType(contextChannelId, 'agent');
+        } catch (e) {}
+      }
       sendTelegram(`⚠️ ${skill}:#${issue} murió en ${elapsedSec.toFixed(0)}s — fallo #${failures}. Cooldown ${delayMin}min antes de reintentar.`);
       return;
     }
@@ -687,6 +716,18 @@ function lanzarAgenteClaude(skill, issue, trabajandoPath, pipeline, fase, config
       log('lanzamiento', `Error post-proceso ${skill}:#${issue}: ${e.message}`);
     }
     activeProcesses.delete(processKey(skill, issue));
+    // Salir del canal de contexto (el canal queda para que otros lo consulten)
+    if (contextChannelId) {
+      try {
+        const cm = require(path.join(ROOT, '.claude', 'hooks', 'context-manager'));
+        cm.leaveChannelByType(contextChannelId, 'agent');
+        cm.postMessage(contextChannelId, {
+          from: 'system', from_label: 'Pipeline',
+          type: 'system',
+          content: skill + ' #' + issue + ' finalizó (code=' + code + ')',
+        });
+      } catch (e) {}
+    }
   });
 
   // stdout/stderr redirigidos al archivo de log via stdio fd
@@ -1620,6 +1661,18 @@ async function mainLoop() {
 
       // Commander SIEMPRE corre (incluso en pausa) — necesario para /reanudar
       await brazoCommander(config);
+
+      // Drain outbox de Telegram (context-relay, notificaciones, etc.)
+      try {
+        const outbox = require(path.join(ROOT, '.claude', 'hooks', 'telegram-outbox'));
+        await outbox.drainQueue();
+      } catch (e) {}
+
+      // Context bridge tick (sync preguntas pendientes, relay, cleanup)
+      try {
+        const bridge = require(path.join(ROOT, '.claude', 'hooks', 'context-bridge'));
+        bridge.tick();
+      } catch (e) {}
 
       if (!paused) {
         rotateHistory();          // Housekeeping: rotar historial > 24hs


### PR DESCRIPTION
## Resumen

Sistema de relay bidireccional entre context channels, Telegram y agentes:

- **Context Relay**: actividad de terminal/agente se postea al canal activo y se retransmite a Telegram automáticamente
- **Outbox Drain**: servicio standalone que drena mensajes a Telegram (singleton, auto-start sin Pulpo, auto-kill cuando Pulpo arranca)
- **Agent Channels**: Pulpo crea canal automáticamente al lanzar agente, leave al terminar
- **Dashboard**: outbox-drain visible como componente gestionable (start/stop desde UI)

## Archivos modificados

| Archivo | Cambio |
|---------|--------|
| `context-cli.js` | Auto-join Telegram, relay inmediato en `say`, auto-start drain |
| `context-bridge.js` | Nuevo — usa outbox.enqueue() para relay seguro |
| `activity-logger.js` | postToContextChannel + postToTerminalContextChannel |
| `pulpo.js` | Auto-crear canal agente, leave on exit, drain + bridge tick en mainLoop |
| `outbox-drain.js` | Nuevo — servicio standalone singleton |
| `dashboard-v2.js` | Agregar outbox-drain como componente |

## Test plan

- [x] `/context telegram` auto-une Telegram como participante
- [x] Actividad de terminal se postea al canal y llega a Telegram vía outbox
- [x] Outbox drain se levanta automáticamente si no hay Pulpo
- [x] Dashboard muestra outbox-drain con botones start/stop

🤖 Generated with [Claude Code](https://claude.ai/claude-code)