### PR TITLE
fix(build): deshabilitar Gradle daemon globalmente

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,7 @@ kotlin.compiler.execution.strategy=in-process
 kotlin.daemon.jvmargs=-Xmx2g
 
 #Gradle
+org.gradle.daemon=false
 org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options\="-Xmx4g"
 org.gradle.java.installations.auto-download=false
 org.gradle.caching=true


### PR DESCRIPTION
## Resumen

- Agrega `org.gradle.daemon=false` en `gradle.properties`
- Complementa PR #2000: ahora ningún build (ni pipeline ni agentes) crea daemons residentes
- Trade-off: cada build arranca JVM de cero (~segundos extra) pero nunca más quedan zombies consumiendo RAM

## Contexto

El PR #2000 agregó cleanup post-agente, pero los daemons se creaban igual durante la ejecución. Esta config los previene de raíz.

## Plan de tests

- [x] Build local funciona con `--no-daemon` implícito
- [x] RAM se mantiene estable después de múltiples builds

QA Validate: omitido — cambio de config/infra sin impacto en producto de usuario ⚠️

🤖 Generado con [Claude Code](https://claude.ai/claude-code)