### PR TITLE
chore(pipeline): reducir umbrales de recursos de 80% a 70%

### DIFF
--- a/.pipeline/config.yaml
+++ b/.pipeline/config.yaml
@@ -77,8 +77,8 @@ prioridad_labels:
 
 # Límites de recursos del sistema — bloquea lanzamiento de nuevos agentes si se excede
 resource_limits:
-  max_cpu_percent: 80              # No lanzar si CPU >= 80%
-  max_mem_percent: 80              # No lanzar si RAM >= 80%
+  max_cpu_percent: 70              # No lanzar si CPU >= 70%
+  max_mem_percent: 70              # No lanzar si RAM >= 70%
 
 # Timeouts
 timeouts:


### PR DESCRIPTION
## Resumen

- Reducir `max_cpu_percent` y `max_mem_percent` de 80% a 70% en config.yaml del Pulpo
- Con 16GB RAM y 8 cores, el 80% dejaba poco margen antes de saturación del sistema
- El 70% da headroom para builds Gradle bursty y evita swap en Windows

## Tipo de cambio

Infra/config — sin impacto en código de producto

🤖 Generado con [Claude Code](https://claude.ai/claude-code)