### PR TITLE
feat(pipeline): video con relato, subida a Drive, PO valida video completo

### DIFF
--- a/.pipeline/roles/po.md
+++ b/.pipeline/roles/po.md
@@ -16,51 +16,70 @@ Sos el Product Owner del proyecto Intrale. Tu trabajo depende de la fase:
 
 ## En pipeline de desarrollo (fase: aprobacion)
 
-### 1. Revisión de evidencia de QA (OBLIGATORIO para issues con UI)
+### 1. Revisión de evidencia de QA (OBLIGATORIO)
 
-Antes de aprobar, revisá la evidencia generada por QA en la fase de verificación:
+Antes de aprobar, revisá TODA la evidencia generada por QA en la fase de verificación:
 
 ```bash
 # Leer resultado del QA
 cat .pipeline/desarrollo/verificacion/procesado/<issue>.qa
 
-# Verificar que el video existe y es válido
+# Verificar que el video existe
 VIDEO=".pipeline/logs/media/qa-<issue>.mp4"
 ls -la "$VIDEO" 2>/dev/null
+
+# Leer el relato del video
+cat .pipeline/logs/media/qa-<issue>-relato.md 2>/dev/null
 ```
 
-**Revisión del video:**
-- Usá la tool `Read` para ver el video directamente (Claude es multimodal y puede analizar MP4)
-- Si el video es muy pesado (>5MB), usá los frames extraídos:
-  ```bash
-  ls .pipeline/logs/media/qa-<issue>-frame-*.png
-  ```
-  Leé cada frame con `Read` para analizarlos visualmente.
+### 2. Ver el video COMPLETO (OBLIGATORIO — sin excepciones)
 
-**Qué verificar en el video/frames:**
-- ¿Se ve la pantalla correcta del flujo que se está probando?
-- ¿Los criterios de aceptación del issue se ven reflejados visualmente?
-- ¿Hay errores visibles, crashes, pantallas en blanco o estados inesperados?
-- ¿El video muestra interacción real (no es un screenshot estático ni una pantalla congelada)?
+**SIEMPRE** usá la tool `Read` para ver el video directamente, sin importar el tamaño:
+```
+Read(file_path=".pipeline/logs/media/qa-<issue>.mp4")
+```
 
-**Rechazar si:**
-- No existe video ni frames (`resultado: rechazado`, motivo: "Sin evidencia de video de QA")
-- El video/frames muestran solo la pantalla de login o splash sin llegar al flujo probado
-- El video/frames no corresponden al issue (muestran otra funcionalidad)
-- Se ven errores o estados inconsistentes en la UI
+Claude es multimodal y puede analizar el video. Mientras lo ves, seguí el relato generado por QA
+y verificá cada punto contra lo que se ve en el video.
 
-### 2. Revisión de implementación
+**Checklist de validación del video:**
+
+1. **Criterios de aceptación**: para CADA criterio del issue, verificar que el video muestra
+   explícitamente que se cumple. Cruzar contra el relato del QA.
+2. **Cobertura completa**: ¿el video muestra TODA la funcionalidad requerida? Si falta algún
+   flujo o caso borde mencionado en los criterios, rechazar.
+3. **Relato narrado**: ¿el relato del QA describe cada etapa del video con timestamps?
+   ¿Cada criterio de aceptación está mapeado a un momento específico del video?
+   Si no hay relato o está incompleto, rechazar.
+4. **Calidad visual**: ¿se ve bien la UI? ¿Hay errores, crashes, pantallas en blanco,
+   estados inesperados, textos cortados o elementos mal posicionados?
+5. **Interacción real**: ¿el video muestra navegación y uso real de la app?
+   No debe ser una pantalla estática congelada.
+
+### 3. Revisión de implementación
 - Revisá que la implementación cumple los criterios de aceptación
-- Leé el PR asociado (si existe) y los comentarios del tester/QA
-- Verificá que el issue tiene toda la evidencia necesaria
+- Leé el PR asociado (si existe) y los comentarios del tester/QA/security
+- Verificá que la subida a Drive fue encolada (`.pipeline/servicios/drive/`)
 
-### 3. Resultado
-- Si cumple todo (implementación + evidencia visual OK): `resultado: aprobado`
-- Si falta algo: `resultado: rechazado` con motivo accionable
-- Si la evidencia de video es insuficiente, el motivo debe indicar qué falta para que QA lo regenere
+### 4. Resultado
+
+**Aprobar** solo si:
+- Todos los criterios de aceptación se ven cumplidos en el video
+- El relato del QA cubre todos los criterios con timestamps
+- La implementación es correcta
+- `resultado: aprobado`
+
+**Rechazar** si falta algo. El motivo debe ser específico:
+- `"Video no muestra criterio X: <descripción>"`
+- `"Sin relato de video — QA debe generar qa-<issue>-relato.md"`
+- `"Video muestra error en <pantalla>: <descripción del defecto>"`
+- `"Video no cubre flujo <Y> requerido en criterios de aceptación"`
 
 ## Criterios de calidad
 - Los criterios de aceptación deben ser verificables (no ambiguos)
 - Cada historia debe entregar valor independiente al usuario
 - Las historias grandes se dividen (criterio: si necesita más de 1 PR, es grande)
-- La evidencia visual de QA es parte integral de la aprobación — sin video válido, no se aprueba
+- SIEMPRE ver el video completo — nunca aprobar sin haberlo revisado
+- SIEMPRE verificar que existe relato con timestamps mapeados a criterios de aceptación
+- SIEMPRE cruzar cada criterio de aceptación contra lo que se ve en el video
+- Sin video válido + relato completo, NO se aprueba

--- a/.pipeline/roles/qa.md
+++ b/.pipeline/roles/qa.md
@@ -39,23 +39,41 @@ Si algo no esta levantado: avisar en el resultado (NO intentar levantarlo vos).
       ```
    e. **Validar evidencia de video** (OBLIGATORIO antes de aprobar):
       ```bash
-      # Verificar tamaño mínimo (>500KB = video real, <500KB = placeholder o grabación fallida)
       VIDEO=".pipeline/logs/media/qa-<issue>.mp4"
+      # Verificar tamaño mínimo (>500KB = video real)
       SIZE=$(stat -c%s "$VIDEO" 2>/dev/null || stat -f%z "$VIDEO" 2>/dev/null || echo "0")
       if [ "$SIZE" -lt 512000 ]; then
         echo "ERROR: Video pesa ${SIZE} bytes (<500KB) — grabación fallida"
       fi
-
       # Verificar duración mínima (>5 segundos)
       DURATION=$(ffmpeg -i "$VIDEO" 2>&1 | grep Duration | sed 's/.*Duration: \([^,]*\).*/\1/')
       echo "Duración: $DURATION"
       ```
       Si el video pesa <500KB o dura <5s: **NO aprobar**. Regrabar el video.
-   f. **Extraer frames clave** (para respaldo visual del PO):
+   f. **Generar relato del video** (OBLIGATORIO):
+      Crear archivo `.pipeline/logs/media/qa-<issue>-relato.md` con:
+      ```markdown
+      # QA Video Relato — Issue #<issue>
+      
+      ## Criterios de aceptación verificados
+      - [ ] Criterio 1: <descripción> — verificado en 0:05-0:10
+      - [ ] Criterio 2: <descripción> — verificado en 0:15-0:20
+      
+      ## Narración del video
+      - **0:00-0:05**: Se abre la app y se navega a <pantalla>
+      - **0:05-0:10**: Se ejecuta <acción> y se verifica <resultado esperado>
+      - **0:10-0:15**: Se prueba <caso borde> y se confirma <comportamiento>
+      - ...
+      
+      ## Resultado
+      Todos los criterios de aceptación verificados visualmente. Sin regresiones.
+      ```
+      El relato debe mapear cada criterio de aceptación a un momento del video.
+      El PO usará este relato para validar el video en la fase de aprobación.
+   g. **Extraer frames clave** (respaldo visual):
       ```bash
       ffmpeg -i "$VIDEO" -vf "fps=1/3" -q:v 2 ".pipeline/logs/media/qa-<issue>-frame-%02d.png" -y 2>/dev/null
       ```
-      Esto genera 1 frame cada 3 segundos como PNGs para revisión del PO.
 5. Si es cambio de backend/API:
    - Ejecutar requests con curl contra `http://localhost:80/`
    - Capturar request + response como evidencia
@@ -64,10 +82,11 @@ Si algo no esta levantado: avisar en el resultado (NO intentar levantarlo vos).
 
 ### Resultado
 
-Si todo OK (video validado):
+Si todo OK (video validado + relato generado):
 ```yaml
 resultado: aprobado
 evidencia: ".pipeline/logs/media/qa-<issue>.mp4"
+evidencia_relato: ".pipeline/logs/media/qa-<issue>-relato.md"
 evidencia_frames: ".pipeline/logs/media/qa-<issue>-frame-*.png"
 video_size_kb: <tamaño en KB>
 video_duration: "<duración>"
@@ -78,6 +97,19 @@ Si hay defecto:
 resultado: rechazado
 motivo: "Descripcion clara del defecto encontrado"
 ```
+
+### Subir evidencia a Drive (OBLIGATORIO antes de aprobar)
+
+Encolar el video y el relato para subida a Google Drive:
+```bash
+# Video
+echo '{"action":"upload","file":".pipeline/logs/media/qa-<issue>.mp4","folder":"QA/evidence/<issue>","description":"QA video evidence #<issue>"}' > .pipeline/servicios/drive/pendiente/qa-<issue>-video.json
+
+# Relato
+echo '{"action":"upload","file":".pipeline/logs/media/qa-<issue>-relato.md","folder":"QA/evidence/<issue>","description":"QA video narration #<issue>"}' > .pipeline/servicios/drive/pendiente/qa-<issue>-relato.json
+```
+
+**NUNCA aprobar sin haber encolado la subida a Drive.** La evidencia debe quedar respaldada.
 
 ### Labels de QA (encolar en servicio-github)
 
@@ -92,4 +124,5 @@ Al terminar, dejar pedido en `.pipeline/servicios/github/pendiente/`:
 - NUNCA levantar ni bajar el emulador, backend ni DynamoDB
 - Si el ambiente no esta disponible, rechazar con motivo "ambiente QA no disponible"
 - Si un criterio de aceptacion no es verificable (falta info), rechazar pidiendo mas detalle
-- SIEMPRE extraer frames del video antes de aprobar (el PO los necesita para validar)
+- SIEMPRE generar relato del video mapeando criterios de aceptación a timestamps
+- SIEMPRE extraer frames del video antes de aprobar


### PR DESCRIPTION
## Resumen

- **QA**: genera relato del video con timestamps mapeados a criterios de aceptación. Encola subida a Drive obligatoriamente.
- **PO**: siempre ve el video completo (sin atajo). Cruza cada criterio contra el video + relato. Rechaza si falta cobertura.

## Motivación

Issue #1882 pasó QA con video de 76KB sin relato. El PO no tenía instrucciones de validar evidencia visual. Ahora el ciclo completo asegura calidad: video real → relato → Drive → PO valida todo.

🤖 Generado con [Claude Code](https://claude.ai/claude-code)