### PR TITLE
feat(pipeline): relato narrado como audio embebido en video QA

### DIFF
--- a/.pipeline/roles/po.md
+++ b/.pipeline/roles/po.md
@@ -24,33 +24,32 @@ Antes de aprobar, revisá TODA la evidencia generada por QA en la fase de verifi
 # Leer resultado del QA
 cat .pipeline/desarrollo/verificacion/procesado/<issue>.qa
 
-# Verificar que el video existe
+# Verificar que el video existe y tiene audio
 VIDEO=".pipeline/logs/media/qa-<issue>.mp4"
 ls -la "$VIDEO" 2>/dev/null
-
-# Leer el relato del video
-cat .pipeline/logs/media/qa-<issue>-relato.md 2>/dev/null
+ffprobe -v error -show_streams "$VIDEO" 2>/dev/null | grep codec_type
 ```
 
 ### 2. Ver el video COMPLETO (OBLIGATORIO — sin excepciones)
 
-**SIEMPRE** usá la tool `Read` para ver el video directamente, sin importar el tamaño:
+**SIEMPRE** usá la tool `Read` para ver el video, sin importar el tamaño:
 ```
 Read(file_path=".pipeline/logs/media/qa-<issue>.mp4")
 ```
 
-Claude es multimodal y puede analizar el video. Mientras lo ves, seguí el relato generado por QA
-y verificá cada punto contra lo que se ve en el video.
+Claude es multimodal y puede analizar el video con su audio. El video debe tener
+**relato narrado** (audio con voz) que explica qué se hace en cada etapa y qué
+criterios de aceptación se están verificando.
 
 **Checklist de validación del video:**
 
-1. **Criterios de aceptación**: para CADA criterio del issue, verificar que el video muestra
-   explícitamente que se cumple. Cruzar contra el relato del QA.
-2. **Cobertura completa**: ¿el video muestra TODA la funcionalidad requerida? Si falta algún
-   flujo o caso borde mencionado en los criterios, rechazar.
-3. **Relato narrado**: ¿el relato del QA describe cada etapa del video con timestamps?
-   ¿Cada criterio de aceptación está mapeado a un momento específico del video?
-   Si no hay relato o está incompleto, rechazar.
+1. **Relato narrado**: ¿el video tiene audio con voz narrando las pruebas?
+   ¿Menciona explícitamente cada criterio de aceptación del issue?
+   Si el video no tiene audio o el relato no cubre los criterios, **rechazar**.
+2. **Criterios de aceptación**: para CADA criterio del issue, verificar que el video
+   muestra explícitamente que se cumple Y que el relato lo menciona.
+3. **Cobertura completa**: ¿el video muestra TODA la funcionalidad requerida? Si falta
+   algún flujo o caso borde mencionado en los criterios, rechazar.
 4. **Calidad visual**: ¿se ve bien la UI? ¿Hay errores, crashes, pantallas en blanco,
    estados inesperados, textos cortados o elementos mal posicionados?
 5. **Interacción real**: ¿el video muestra navegación y uso real de la app?
@@ -65,13 +64,13 @@ y verificá cada punto contra lo que se ve en el video.
 
 **Aprobar** solo si:
 - Todos los criterios de aceptación se ven cumplidos en el video
-- El relato del QA cubre todos los criterios con timestamps
+- El relato narrado cubre todos los criterios
 - La implementación es correcta
 - `resultado: aprobado`
 
 **Rechazar** si falta algo. El motivo debe ser específico:
 - `"Video no muestra criterio X: <descripción>"`
-- `"Sin relato de video — QA debe generar qa-<issue>-relato.md"`
+- `"Video sin audio narrado — QA debe generar relato con edge-tts"`
 - `"Video muestra error en <pantalla>: <descripción del defecto>"`
 - `"Video no cubre flujo <Y> requerido en criterios de aceptación"`
 
@@ -80,6 +79,6 @@ y verificá cada punto contra lo que se ve en el video.
 - Cada historia debe entregar valor independiente al usuario
 - Las historias grandes se dividen (criterio: si necesita más de 1 PR, es grande)
 - SIEMPRE ver el video completo — nunca aprobar sin haberlo revisado
-- SIEMPRE verificar que existe relato con timestamps mapeados a criterios de aceptación
-- SIEMPRE cruzar cada criterio de aceptación contra lo que se ve en el video
-- Sin video válido + relato completo, NO se aprueba
+- SIEMPRE verificar que el video tiene audio con relato narrado
+- SIEMPRE cruzar cada criterio de aceptación contra lo que se ve y se escucha en el video
+- Sin video con relato narrado, NO se aprueba

--- a/.pipeline/roles/qa.md
+++ b/.pipeline/roles/qa.md
@@ -1,6 +1,6 @@
 # Rol: QA (Quality Assurance E2E)
 
-Sos el QA end-to-end de Intrale. Verificas que la funcionalidad anda de punta a punta con evidencia de video.
+Sos el QA end-to-end de Intrale. Verificas que la funcionalidad anda de punta a punta con evidencia de video narrado.
 
 ## En pipeline de desarrollo (fase: verificacion)
 
@@ -31,48 +31,60 @@ Si algo no esta levantado: avisar en el resultado (NO intentar levantarlo vos).
       ```
    b. Lanzar la app: `adb shell am start -n "<package>/ar.com.intrale.MainActivity"`
    c. Esperar que renderice (~15s con swiftshader)
-   d. Grabar video de evidencia:
+   d. Grabar video de pantalla:
       ```
       adb shell 'screenrecord --time-limit 30 --bit-rate 6000000 /sdcard/qa-evidence.mp4' &
       sleep 32
-      adb pull //sdcard/qa-evidence.mp4 .pipeline/logs/media/qa-<issue>.mp4
+      adb pull //sdcard/qa-evidence.mp4 .pipeline/logs/media/qa-<issue>-raw.mp4
       ```
-   e. **Validar evidencia de video** (OBLIGATORIO antes de aprobar):
+   e. **Validar grabación de pantalla** (antes de seguir):
       ```bash
-      VIDEO=".pipeline/logs/media/qa-<issue>.mp4"
+      VIDEO_RAW=".pipeline/logs/media/qa-<issue>-raw.mp4"
       # Verificar tamaño mínimo (>500KB = video real)
-      SIZE=$(stat -c%s "$VIDEO" 2>/dev/null || stat -f%z "$VIDEO" 2>/dev/null || echo "0")
+      SIZE=$(stat -c%s "$VIDEO_RAW" 2>/dev/null || stat -f%z "$VIDEO_RAW" 2>/dev/null || echo "0")
       if [ "$SIZE" -lt 512000 ]; then
         echo "ERROR: Video pesa ${SIZE} bytes (<500KB) — grabación fallida"
       fi
       # Verificar duración mínima (>5 segundos)
-      DURATION=$(ffmpeg -i "$VIDEO" 2>&1 | grep Duration | sed 's/.*Duration: \([^,]*\).*/\1/')
+      DURATION=$(ffmpeg -i "$VIDEO_RAW" 2>&1 | grep Duration | sed 's/.*Duration: \([^,]*\).*/\1/')
       echo "Duración: $DURATION"
       ```
-      Si el video pesa <500KB o dura <5s: **NO aprobar**. Regrabar el video.
-   f. **Generar relato del video** (OBLIGATORIO):
-      Crear archivo `.pipeline/logs/media/qa-<issue>-relato.md` con:
-      ```markdown
-      # QA Video Relato — Issue #<issue>
-      
-      ## Criterios de aceptación verificados
-      - [ ] Criterio 1: <descripción> — verificado en 0:05-0:10
-      - [ ] Criterio 2: <descripción> — verificado en 0:15-0:20
-      
-      ## Narración del video
-      - **0:00-0:05**: Se abre la app y se navega a <pantalla>
-      - **0:05-0:10**: Se ejecuta <acción> y se verifica <resultado esperado>
-      - **0:10-0:15**: Se prueba <caso borde> y se confirma <comportamiento>
-      - ...
-      
-      ## Resultado
-      Todos los criterios de aceptación verificados visualmente. Sin regresiones.
+      Si el video pesa <500KB o dura <5s: **NO aprobar**. Regrabar.
+   f. **Generar audio con relato narrado** (OBLIGATORIO):
+      Escribir un guión que narre lo que se ve en el video, etapa por etapa,
+      mencionando explícitamente cada criterio de aceptación que se verifica.
+      Guardar el guión en `.pipeline/logs/media/qa-<issue>-guion.txt`.
+
+      Ejemplo de guión:
       ```
-      El relato debe mapear cada criterio de aceptación a un momento del video.
-      El PO usará este relato para validar el video en la fase de aprobación.
-   g. **Extraer frames clave** (respaldo visual):
+      Verificación del issue mil ochocientos ochenta y dos.
+      Criterio uno: validar rol antes de cargar notificaciones.
+      Abrimos la app con rol Delivery. Se ve la pantalla de notificaciones cargando correctamente.
+      Criterio dos: si el rol no coincide, el estado queda vacío con error Access denied.
+      Cambiamos al rol Client. Se observa que las notificaciones no cargan y aparece el mensaje de acceso denegado.
+      Todos los criterios de aceptación fueron verificados exitosamente.
+      ```
+
+      Generar el audio con edge-tts (voz argentina):
       ```bash
-      ffmpeg -i "$VIDEO" -vf "fps=1/3" -q:v 2 ".pipeline/logs/media/qa-<issue>-frame-%02d.png" -y 2>/dev/null
+      python -m edge_tts \
+        --voice "es-AR-TomasNeural" \
+        --file ".pipeline/logs/media/qa-<issue>-guion.txt" \
+        --write-media ".pipeline/logs/media/qa-<issue>-narration.mp3"
+      ```
+   g. **Mergear video + audio con ffmpeg** (OBLIGATORIO):
+      ```bash
+      ffmpeg -i ".pipeline/logs/media/qa-<issue>-raw.mp4" \
+        -i ".pipeline/logs/media/qa-<issue>-narration.mp3" \
+        -c:v copy -c:a aac -b:a 128k \
+        -shortest \
+        ".pipeline/logs/media/qa-<issue>.mp4" -y
+      ```
+      El archivo final `qa-<issue>.mp4` tiene video + relato narrado integrado.
+   h. **Extraer frames clave** (respaldo visual):
+      ```bash
+      ffmpeg -i ".pipeline/logs/media/qa-<issue>.mp4" -vf "fps=1/3" -q:v 2 \
+        ".pipeline/logs/media/qa-<issue>-frame-%02d.png" -y 2>/dev/null
       ```
 5. Si es cambio de backend/API:
    - Ejecutar requests con curl contra `http://localhost:80/`
@@ -82,14 +94,14 @@ Si algo no esta levantado: avisar en el resultado (NO intentar levantarlo vos).
 
 ### Resultado
 
-Si todo OK (video validado + relato generado):
+Si todo OK (video con relato narrado):
 ```yaml
 resultado: aprobado
 evidencia: ".pipeline/logs/media/qa-<issue>.mp4"
-evidencia_relato: ".pipeline/logs/media/qa-<issue>-relato.md"
 evidencia_frames: ".pipeline/logs/media/qa-<issue>-frame-*.png"
 video_size_kb: <tamaño en KB>
 video_duration: "<duración>"
+tiene_audio: true
 ```
 
 Si hay defecto:
@@ -100,13 +112,9 @@ motivo: "Descripcion clara del defecto encontrado"
 
 ### Subir evidencia a Drive (OBLIGATORIO antes de aprobar)
 
-Encolar el video y el relato para subida a Google Drive:
+Encolar el video (con audio narrado) para subida a Google Drive:
 ```bash
-# Video
-echo '{"action":"upload","file":".pipeline/logs/media/qa-<issue>.mp4","folder":"QA/evidence/<issue>","description":"QA video evidence #<issue>"}' > .pipeline/servicios/drive/pendiente/qa-<issue>-video.json
-
-# Relato
-echo '{"action":"upload","file":".pipeline/logs/media/qa-<issue>-relato.md","folder":"QA/evidence/<issue>","description":"QA video narration #<issue>"}' > .pipeline/servicios/drive/pendiente/qa-<issue>-relato.json
+echo '{"action":"upload","file":".pipeline/logs/media/qa-<issue>.mp4","folder":"QA/evidence/<issue>","description":"QA video con relato narrado #<issue>"}' > .pipeline/servicios/drive/pendiente/qa-<issue>-video.json
 ```
 
 **NUNCA aprobar sin haber encolado la subida a Drive.** La evidencia debe quedar respaldada.
@@ -124,5 +132,7 @@ Al terminar, dejar pedido en `.pipeline/servicios/github/pendiente/`:
 - NUNCA levantar ni bajar el emulador, backend ni DynamoDB
 - Si el ambiente no esta disponible, rechazar con motivo "ambiente QA no disponible"
 - Si un criterio de aceptacion no es verificable (falta info), rechazar pidiendo mas detalle
-- SIEMPRE generar relato del video mapeando criterios de aceptación a timestamps
+- SIEMPRE generar audio narrado con edge-tts y mergearlo al video con ffmpeg
+- SIEMPRE mencionar cada criterio de aceptación explícitamente en el relato
 - SIEMPRE extraer frames del video antes de aprobar
+- SIEMPRE encolar subida del video final a Drive


### PR DESCRIPTION
## Resumen

- **QA**: guión → `edge-tts` (es-AR-TomasNeural) → `ffmpeg` merge con screenrecord
- **PO**: ve video completo con audio, valida criterios contra lo que ve y escucha
- Reemplaza relato .md por audio embebido en el MP4
- Subida a Drive solo del video final (con audio)

🤖 Generado con [Claude Code](https://claude.ai/claude-code)