### PR TITLE
Fix: reemplazar strings hardcodeados en DeliveryNotificationsScreen

### DIFF
--- a/app/composeApp/src/commonMain/kotlin/ui/sc/delivery/DeliveryNotificationsScreen.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/delivery/DeliveryNotificationsScreen.kt
@@ -248,10 +248,10 @@ private fun DeliveryNotificationCard(
 @Composable
 private fun DeliveryNotificationIcon(eventType: DeliveryNotificationEventType) {
     val eventTypeDescription = when (eventType) {
-        DeliveryNotificationEventType.ORDER_AVAILABLE -> "Pedido disponible"
-        DeliveryNotificationEventType.ORDER_ASSIGNED -> "Pedido asignado"
-        DeliveryNotificationEventType.ORDER_DELIVERED -> "Pedido entregado"
-        DeliveryNotificationEventType.ORDER_NOT_DELIVERED -> "Pedido no entregado"
+        DeliveryNotificationEventType.ORDER_AVAILABLE -> Txt(MessageKey.delivery_notifications_event_new_order)
+        DeliveryNotificationEventType.ORDER_ASSIGNED -> Txt(MessageKey.delivery_notifications_event_assigned)
+        DeliveryNotificationEventType.ORDER_DELIVERED -> Txt(MessageKey.delivery_notifications_event_delivered)
+        DeliveryNotificationEventType.ORDER_NOT_DELIVERED -> Txt(MessageKey.delivery_notifications_event_not_delivered)
     }
 
     val (emoji, bgColor) = when (eventType) {


### PR DESCRIPTION
## Summary
- Reemplaza 4 strings de `contentDescription` hardcodeados en español por `Txt(MessageKey.*)` en `DeliveryNotificationsScreen.kt`
- Cumple con la regla de strings del proyecto (nunca hardcoded, siempre i18n)

Closes #1884

## Cambios
- `DeliveryNotificationsScreen.kt`: 4 líneas modificadas (strings → MessageKey)

## Validaciones completadas
- ✅ Guru: aprobado (fix mecánico, sin riesgos)
- ✅ Security: aprobado (sin impacto de seguridad)
- ✅ QA: passed (`qa:passed` label)

## Test plan
- [x] `verifyNoLegacyStrings` pasa sin warnings
- [x] Strings de `contentDescription` usan `Txt(MessageKey.*)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)