### PR TITLE
fix(pipeline): crash handlers en servicios + watchdog reescrito

### DIFF
--- a/.pipeline/dashboard-v2.js
+++ b/.pipeline/dashboard-v2.js
@@ -1204,3 +1204,17 @@ server.listen(PORT, () => {
 fs.writeFileSync(path.join(PIPELINE, 'dashboard.pid'), String(process.pid));
 process.on('SIGINT', () => { server.close(); process.exit(0); });
 process.on('SIGTERM', () => { server.close(); process.exit(0); });
+
+// Crash handlers — loguear antes de morir para diagnóstico
+process.on('uncaughtException', (err) => {
+  const msg = `[${new Date().toISOString()}] [dashboard] CRASH uncaughtException: ${err.stack || err.message}\n`;
+  try { fs.appendFileSync(path.join(LOG_DIR, 'dashboard.log'), msg); } catch {}
+  console.error(msg);
+  process.exit(1);
+});
+process.on('unhandledRejection', (reason) => {
+  const msg = `[${new Date().toISOString()}] [dashboard] CRASH unhandledRejection: ${reason?.stack || reason}\n`;
+  try { fs.appendFileSync(path.join(LOG_DIR, 'dashboard.log'), msg); } catch {}
+  console.error(msg);
+  process.exit(1);
+});

--- a/.pipeline/servicio-drive.js
+++ b/.pipeline/servicio-drive.js
@@ -57,4 +57,20 @@ function main() {
 fs.writeFileSync(path.join(PIPELINE, 'svc-drive.pid'), String(process.pid));
 process.on('SIGINT', () => process.exit(0));
 process.on('SIGTERM', () => process.exit(0));
+
+// Crash handlers — loguear antes de morir para diagnóstico
+const LOG_DIR = path.join(PIPELINE, 'logs');
+process.on('uncaughtException', (err) => {
+  const msg = `[${new Date().toISOString()}] [svc-drive] CRASH uncaughtException: ${err.stack || err.message}\n`;
+  try { fs.appendFileSync(path.join(LOG_DIR, 'svc-drive.log'), msg); } catch {}
+  console.error(msg);
+  process.exit(1);
+});
+process.on('unhandledRejection', (reason) => {
+  const msg = `[${new Date().toISOString()}] [svc-drive] CRASH unhandledRejection: ${reason?.stack || reason}\n`;
+  try { fs.appendFileSync(path.join(LOG_DIR, 'svc-drive.log'), msg); } catch {}
+  console.error(msg);
+  process.exit(1);
+});
+
 main();

--- a/.pipeline/servicio-github.js
+++ b/.pipeline/servicio-github.js
@@ -85,4 +85,20 @@ function main() {
 fs.writeFileSync(path.join(PIPELINE, 'svc-github.pid'), String(process.pid));
 process.on('SIGINT', () => process.exit(0));
 process.on('SIGTERM', () => process.exit(0));
+
+// Crash handlers — loguear antes de morir para diagnóstico
+const LOG_DIR = path.join(PIPELINE, 'logs');
+process.on('uncaughtException', (err) => {
+  const msg = `[${new Date().toISOString()}] [svc-github] CRASH uncaughtException: ${err.stack || err.message}\n`;
+  try { fs.appendFileSync(path.join(LOG_DIR, 'svc-github.log'), msg); } catch {}
+  console.error(msg);
+  process.exit(1);
+});
+process.on('unhandledRejection', (reason) => {
+  const msg = `[${new Date().toISOString()}] [svc-github] CRASH unhandledRejection: ${reason?.stack || reason}\n`;
+  try { fs.appendFileSync(path.join(LOG_DIR, 'svc-github.log'), msg); } catch {}
+  console.error(msg);
+  process.exit(1);
+});
+
 main();

--- a/.pipeline/servicio-telegram.js
+++ b/.pipeline/servicio-telegram.js
@@ -157,6 +157,21 @@ async function main() {
   }
 }
 
+// Crash handlers — loguear antes de morir para diagnóstico
+const LOG_DIR = path.join(PIPELINE, 'logs');
+process.on('uncaughtException', (err) => {
+  const msg = `[${new Date().toISOString()}] [svc-telegram] CRASH uncaughtException: ${err.stack || err.message}\n`;
+  try { fs.appendFileSync(path.join(LOG_DIR, 'svc-telegram.log'), msg); } catch {}
+  console.error(msg);
+  process.exit(1);
+});
+process.on('unhandledRejection', (reason) => {
+  const msg = `[${new Date().toISOString()}] [svc-telegram] CRASH unhandledRejection: ${reason?.stack || reason}\n`;
+  try { fs.appendFileSync(path.join(LOG_DIR, 'svc-telegram.log'), msg); } catch {}
+  console.error(msg);
+  process.exit(1);
+});
+
 // --- SINGLETON ---
 require('./singleton')('svc-telegram');
 main();

--- a/.pipeline/watchdog.ps1
+++ b/.pipeline/watchdog.ps1
@@ -1,46 +1,85 @@
-# Watchdog V2 — Vigila Pulpo + Listener Telegram
+# Watchdog V2 — Vigila todos los servicios del pipeline
 # Se ejecuta cada 2 minutos via Windows Task Scheduler
-# SIEMPRE lanza desde platform.ops (worktree en main) si está disponible
+# Usa platform.ops (worktree ops en main) si esta disponible
 
- = 'C:WorkspacesIntraleplatform.ops'
- = 'C:WorkspacesIntraleplatform'
+$OpsRoot = 'C:\Workspaces\Intrale\platform.ops'
+$FallbackRoot = 'C:\Workspaces\Intrale\platform'
 
-if (Test-Path "\.pipelinepulpo.js") {
-     = "\.pipeline"
-     = } else {
-     = "\.pipeline"
-     = }
-
- = "\.pipeline"
- = "\logswatchdog.log"
-
-function Write-Log() {
-     = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
-    "[] " | Out-File -Append -FilePath  -Encoding utf8
+if (Test-Path "$OpsRoot\.pipeline\pulpo.js") {
+    $PipelineDir = "$OpsRoot\.pipeline"
+    $WorkDir = $OpsRoot
+} else {
+    $PipelineDir = "$FallbackRoot\.pipeline"
+    $WorkDir = $FallbackRoot
 }
 
-function Test-ProcessAlive() {
-    if (-not (Test-Path )) { return  }
-     = [int](Get-Content  -ErrorAction SilentlyContinue)
-    if (-not  -or  -eq 0) { return  }
+$LogDir = "$PipelineDir\logs"
+$LogFile = "$LogDir\watchdog.log"
+
+# Crear directorio de logs si no existe
+if (-not (Test-Path $LogDir)) { New-Item -Path $LogDir -ItemType Directory -Force | Out-Null }
+
+function Write-Log($Message) {
+    $ts = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+    "[$ts] $Message" | Out-File -Append -FilePath $LogFile -Encoding utf8
+}
+
+function Test-ProcessAlive($PidFile) {
+    if (-not (Test-Path $PidFile)) { return $false }
+    $pidStr = Get-Content $PidFile -ErrorAction SilentlyContinue
+    if (-not $pidStr -or $pidStr.Trim() -eq '') { return $false }
+    $pid = [int]$pidStr.Trim()
+    if ($pid -eq 0) { return $false }
     try {
-         = Get-Process -Id  -ErrorAction Stop
-        return (.ProcessName -eq 'node')
+        $proc = Get-Process -Id $pid -ErrorAction Stop
+        return ($proc.ProcessName -eq 'node')
     } catch {
-        return     }
+        return $false
+    }
 }
 
-if ( -eq ) {
+# Servicios criticos que deben estar siempre vivos
+$Services = @(
+    @{ Name = 'pulpo';         Pid = "$PipelineDir\pulpo.pid" },
+    @{ Name = 'listener';      Pid = "$PipelineDir\listener.pid" },
+    @{ Name = 'svc-telegram';  Pid = "$PipelineDir\svc-telegram.pid" },
+    @{ Name = 'svc-github';    Pid = "$PipelineDir\svc-github.pid" },
+    @{ Name = 'svc-drive';     Pid = "$PipelineDir\svc-drive.pid" },
+    @{ Name = 'dashboard';     Pid = "$PipelineDir\dashboard.pid" }
+)
+
+# Sincronizar worktree ops con main (silencioso)
+if ($WorkDir -eq $OpsRoot) {
     try {
-        git -C  fetch origin main 2>        git -C  checkout FETCH_HEAD --force 2>    } catch {}
+        git -C $OpsRoot fetch origin main 2>$null
+        git -C $OpsRoot checkout FETCH_HEAD --force 2>$null
+    } catch {}
 }
 
-if (-not (Test-ProcessAlive "\pulpo.pid")) {
-    Write-Log "Pulpo caido - relanzando desde "
-    Start-Process -FilePath 'cmd.exe' -ArgumentList '/c', "\start-pulpo.bat" -WindowStyle Minimized
+# Verificar cada servicio
+$dead = @()
+foreach ($svc in $Services) {
+    if (-not (Test-ProcessAlive $svc.Pid)) {
+        $dead += $svc.Name
+    }
 }
 
-if (-not (Test-ProcessAlive "\listener.pid")) {
-    Write-Log "Listener caido - relanzando desde "
-    Start-Process -FilePath 'cmd.exe' -ArgumentList '/c', "\start-listener.bat" -WindowStyle Minimized
+if ($dead.Count -eq 0) {
+    # Todo vivo, no loguear para no llenar el log
+    exit 0
+}
+
+# Hay servicios caidos — restart completo
+$deadList = $dead -join ', '
+Write-Log "Servicios caidos detectados: $deadList -- ejecutando restart.js"
+
+try {
+    $restartScript = "$PipelineDir\restart.js"
+    $output = & node $restartScript 2>&1
+    foreach ($line in $output) {
+        Write-Log "  $line"
+    }
+    Write-Log "Restart completado"
+} catch {
+    Write-Log "ERROR en restart: $_"
 }


### PR DESCRIPTION
## Summary
- Agrega `uncaughtException` y `unhandledRejection` handlers a los 4 servicios del pipeline (dashboard-v2, svc-telegram, svc-github, svc-drive) para que logueen el error al archivo antes de morir
- Reescribe `watchdog.ps1` que estaba corrupto (variables PowerShell sin `$`) para vigilar los 6 servicios críticos y ejecutar `restart.js` si alguno cae

## Test plan
- [ ] Verificar que los servicios arrancan correctamente con `node .pipeline/restart.js`
- [ ] Simular crash en un servicio y verificar que el log queda en `.pipeline/logs/`
- [ ] Habilitar tarea programada `Intrale-Pipeline-V2-Watchdog` y verificar que relanza servicios caídos

🤖 Generated with [Claude Code](https://claude.com/claude-code)