### PR TITLE
fix(pipeline): watchdog restarts en loop + scripts corruptos

### DIFF
--- a/.pipeline/config.yaml
+++ b/.pipeline/config.yaml
@@ -106,7 +106,7 @@ resource_limits:
   max_mem_percent: 70              # No lanzar si RAM >= 70%
   qa_env_max_cpu_percent: 60       # QA env (3 servicios pesados) necesita más margen
   qa_env_max_mem_percent: 60       # QA env: DynamoDB + Gradle + emulador consumen mucha RAM
-  max_concurrent_devs: 2           # Máximo de desarrolladores simultáneos (android+backend+web combinados)
+  max_concurrent_devs: 1           # Máximo de desarrolladores simultáneos (limitado hasta estabilizar pipeline)
   saturation_streak_threshold: 3   # Ciclos consecutivos de sobrecarga antes de buscar zombies
   zombie_hunt_cooldown_minutes: 5  # Cooldown entre búsquedas de zombies
   gradle_kill_streak: 4            # Forzar kill de Gradle daemons aunque haya agentes

--- a/.pipeline/start-listener.bat
+++ b/.pipeline/start-listener.bat
@@ -1,8 +1,7 @@
 @echo off
 REM Worktree ops: siempre ejecutar desde platform.ops (main)
 set PIPELINE_STATE_DIR=C:\Workspaces\Intrale\platform\.pipeline
-set NODE_PATH=C:WorkspacesIntraleplatform
-ode_modules
+set "NODE_PATH=C:\Workspaces\Intrale\platform\node_modules"
 set PIPELINE_MAIN_ROOT=C:\Workspaces\Intrale\platform
 if exist C:\Workspaces\Intrale\platform.ops\.pipeline\listener-telegram.js (
     cd /d C:\Workspaces\Intrale\platform.ops

--- a/.pipeline/start-pulpo.bat
+++ b/.pipeline/start-pulpo.bat
@@ -1,8 +1,7 @@
 @echo off
 REM Worktree ops: siempre ejecutar desde platform.ops (main)
 set PIPELINE_STATE_DIR=C:\Workspaces\Intrale\platform\.pipeline
-set NODE_PATH=C:WorkspacesIntraleplatform
-ode_modules
+set "NODE_PATH=C:\Workspaces\Intrale\platform\node_modules"
 set PIPELINE_MAIN_ROOT=C:\Workspaces\Intrale\platform
 if exist C:\Workspaces\Intrale\platform.ops\.pipeline\pulpo.js (
     cd /d C:\Workspaces\Intrale\platform.ops

--- a/.pipeline/watchdog.ps1
+++ b/.pipeline/watchdog.ps1
@@ -28,24 +28,27 @@ function Test-ProcessAlive($PidFile) {
     if (-not (Test-Path $PidFile)) { return $false }
     $pidStr = Get-Content $PidFile -ErrorAction SilentlyContinue
     if (-not $pidStr -or $pidStr.Trim() -eq '') { return $false }
-    $pid = [int]$pidStr.Trim()
-    if ($pid -eq 0) { return $false }
+    $procId = [int]$pidStr.Trim()
+    if ($procId -eq 0) { return $false }
     try {
-        $proc = Get-Process -Id $pid -ErrorAction Stop
+        $proc = Get-Process -Id $procId -ErrorAction Stop
         return ($proc.ProcessName -eq 'node')
     } catch {
         return $false
     }
 }
 
+# PIDs siempre se escriben en el repo principal (PIPELINE_STATE_DIR de restart.js)
+$PidDir = "$FallbackRoot\.pipeline"
+
 # Servicios criticos que deben estar siempre vivos
 $Services = @(
-    @{ Name = 'pulpo';         Pid = "$PipelineDir\pulpo.pid" },
-    @{ Name = 'listener';      Pid = "$PipelineDir\listener.pid" },
-    @{ Name = 'svc-telegram';  Pid = "$PipelineDir\svc-telegram.pid" },
-    @{ Name = 'svc-github';    Pid = "$PipelineDir\svc-github.pid" },
-    @{ Name = 'svc-drive';     Pid = "$PipelineDir\svc-drive.pid" },
-    @{ Name = 'dashboard';     Pid = "$PipelineDir\dashboard.pid" }
+    @{ Name = 'pulpo';         Pid = "$PidDir\pulpo.pid" },
+    @{ Name = 'listener';      Pid = "$PidDir\listener.pid" },
+    @{ Name = 'svc-telegram';  Pid = "$PidDir\svc-telegram.pid" },
+    @{ Name = 'svc-github';    Pid = "$PidDir\svc-github.pid" },
+    @{ Name = 'svc-drive';     Pid = "$PidDir\svc-drive.pid" },
+    @{ Name = 'dashboard';     Pid = "$PidDir\dashboard.pid" }
 )
 
 # Sincronizar worktree ops con main (silencioso)


### PR DESCRIPTION
## Summary
- **watchdog.ps1**: `$pid` es variable reservada read-only de PowerShell → renombrada a `$procId`
- **watchdog.ps1**: buscaba PIDs en `platform.ops\.pipeline` pero restart.js los escribe en `platform\.pipeline` → corregido, eliminando restarts en loop cada 2 min
- **start-pulpo.bat / start-listener.bat**: `NODE_PATH` corrupto (`\n` interpretado como newline) → `Cannot find module 'js-yaml'` al arrancar
- **config.yaml**: `max_concurrent_devs` de 2 a 1 hasta estabilizar pipeline

## Test plan
- [x] Watchdog ejecuta sin errores PowerShell
- [x] Watchdog sale con exit 0 cuando todos los servicios están vivos (no dispara restart falso)
- [x] Pipeline levanta correctamente con `restart.js`
- [ ] Verificar que el scheduled task no provoca restarts innecesarios en los próximos ciclos

🤖 Generated with [Claude Code](https://claude.com/claude-code)