### PR TITLE
fix(pipeline): crash handler en pulpo.js

### DIFF
--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -10,9 +10,20 @@ const os = require('os');
 const { execSync, spawn } = require('child_process');
 const yaml = require('js-yaml');
 
-// PIPELINE_STATE_DIR y PIPELINE_MAIN_ROOT: seteados por restart.js cuando corre desde platform.ops
-const ROOT = process.env.PIPELINE_MAIN_ROOT || path.resolve(__dirname, '..');
-const PIPELINE = process.env.PIPELINE_STATE_DIR || path.resolve(ROOT, '.pipeline');
+// Crash handlers — loguear y seguir vivo
+process.on('uncaughtException', (err) => {
+  const msg = `[${new Date().toISOString()}] [pulpo] CRASH uncaughtException: ${err.stack || err.message}\n`;
+  try { fs.appendFileSync(path.join(__dirname, 'logs', 'pulpo.log'), msg); } catch {}
+  console.error(msg);
+});
+process.on('unhandledRejection', (reason) => {
+  const msg = `[${new Date().toISOString()}] [pulpo] CRASH unhandledRejection: ${reason}\n`;
+  try { fs.appendFileSync(path.join(__dirname, 'logs', 'pulpo.log'), msg); } catch {}
+  console.error(msg);
+});
+
+const ROOT = path.resolve(__dirname, '..');
+const PIPELINE = path.resolve(__dirname);
 const CONFIG_PATH = path.join(PIPELINE, 'config.yaml');
 const LOG_DIR = path.join(PIPELINE, 'logs');
 // Ejecutar claude via Node directo (evita cmd.exe y ventanas visibles)


### PR DESCRIPTION
## Summary
- Crash handlers (uncaughtException/unhandledRejection) para que el pulpo no muera por errores no capturados
- Simplifica PIPELINE/ROOT a __dirname (elimina refs a ops worktree)

## Test plan
- [x] El watchdog ya cubre restarts, esto es defensa en profundidad

🤖 Generated with [Claude Code](https://claude.com/claude-code)