### PR TITLE
fix: DeliveryNotificationStore thread-safe updateFromOrders (#1881)

### DIFF
--- a/app/composeApp/src/commonMain/kotlin/ui/sc/client/ClientNotificationStore.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/client/ClientNotificationStore.kt
@@ -18,24 +18,25 @@ object ClientNotificationStore {
         get() = _notifications.value.count { !it.isRead }
 
     fun updateFromOrders(orders: List<ClientOrder>) {
-        val existing = _notifications.value.associateBy { it.id }.toMutableMap()
-        orders.forEach { order ->
-            val notifId = "${order.id}_${order.status.name}"
-            if (!existing.containsKey(notifId)) {
-                existing[notifId] = ClientNotification(
-                    id = notifId,
-                    orderId = order.id,
-                    shortCode = order.shortCode,
-                    businessName = order.businessName,
-                    eventType = order.status.toNotificationEventType(),
-                    message = "",
-                    timestamp = order.createdAt,
-                    isRead = false
-                )
+        _notifications.update { current ->
+            val existing = current.associateBy { it.id }.toMutableMap()
+            orders.forEach { order ->
+                val notifId = "${order.id}_${order.status.name}"
+                if (!existing.containsKey(notifId)) {
+                    existing[notifId] = ClientNotification(
+                        id = notifId,
+                        orderId = order.id,
+                        shortCode = order.shortCode,
+                        businessName = order.businessName,
+                        eventType = order.status.toNotificationEventType(),
+                        message = "",
+                        timestamp = order.createdAt,
+                        isRead = false
+                    )
+                }
             }
+            existing.values.sortedByDescending { it.timestamp }
         }
-        _notifications.value = existing.values
-            .sortedByDescending { it.timestamp }
     }
 
     fun addBusinessMessage(orderId: String, shortCode: String, businessName: String, message: String, timestamp: String) {
@@ -69,6 +70,6 @@ object ClientNotificationStore {
     }
 
     fun clear() {
-        _notifications.value = emptyList()
+        _notifications.update { emptyList() }
     }
 }

--- a/app/composeApp/src/commonMain/kotlin/ui/sc/delivery/DeliveryNotificationStore.kt
+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/delivery/DeliveryNotificationStore.kt
@@ -18,23 +18,24 @@ object DeliveryNotificationStore {
         get() = _notifications.value.count { !it.isRead }
 
     fun updateFromOrders(orders: List<DeliveryOrder>) {
-        val existing = _notifications.value.associateBy { it.id }.toMutableMap()
-        orders.forEach { order ->
-            val notifId = "${order.id}_${order.status.name}"
-            if (!existing.containsKey(notifId)) {
-                existing[notifId] = DeliveryNotification(
-                    id = notifId,
-                    orderId = order.id,
-                    label = order.label,
-                    businessName = order.businessName,
-                    eventType = order.status.toNotificationEventType(),
-                    timestamp = "",
-                    isRead = false
-                )
+        _notifications.update { current ->
+            val existing = current.associateBy { it.id }.toMutableMap()
+            orders.forEach { order ->
+                val notifId = "${order.id}_${order.status.name}"
+                if (!existing.containsKey(notifId)) {
+                    existing[notifId] = DeliveryNotification(
+                        id = notifId,
+                        orderId = order.id,
+                        label = order.label,
+                        businessName = order.businessName,
+                        eventType = order.status.toNotificationEventType(),
+                        timestamp = "",
+                        isRead = false
+                    )
+                }
             }
+            existing.values.sortedByDescending { it.timestamp }
         }
-        _notifications.value = existing.values
-            .sortedByDescending { it.timestamp }
     }
 
     fun markAsRead(id: String) {
@@ -50,6 +51,6 @@ object DeliveryNotificationStore {
     }
 
     fun clear() {
-        _notifications.value = emptyList()
+        _notifications.update { emptyList() }
     }
 }

--- a/app/composeApp/src/commonTest/kotlin/ui/sc/delivery/DeliveryNotificationsViewModelTest.kt
+++ b/app/composeApp/src/commonTest/kotlin/ui/sc/delivery/DeliveryNotificationsViewModelTest.kt
@@ -7,6 +7,8 @@ import asdo.delivery.DeliveryOrderStatus
 import asdo.delivery.ToDoGetDeliveryNotifications
 import asdo.delivery.ToDoMarkAllDeliveryNotificationsRead
 import asdo.delivery.ToDoMarkDeliveryNotificationRead
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.test.runTest
 import org.kodein.log.LoggerFactory
 import org.kodein.log.frontend.simplePrintFrontend
@@ -312,6 +314,39 @@ class DeliveryNotificationStoreTest {
         DeliveryNotificationStore.markAllAsRead()
 
         assertEquals(0, DeliveryNotificationStore.unreadCount)
+    }
+
+    @Test
+    fun `updateFromOrders concurrente no pierde notificaciones`() = runTest {
+        DeliveryNotificationStore.clear()
+
+        // Dos listas de órdenes distintas que se procesan en paralelo
+        val ordersBatch1 = (1..50).map { i ->
+            DeliveryOrder("batch1_$i", "B1-$i", "Negocio Batch1 $i", "Zona A", DeliveryOrderStatus.PENDING, null)
+        }
+        val ordersBatch2 = (1..50).map { i ->
+            DeliveryOrder("batch2_$i", "B2-$i", "Negocio Batch2 $i", "Zona B", DeliveryOrderStatus.IN_PROGRESS, null)
+        }
+
+        // Lanzar ambas actualizaciones en paralelo (simula race condition)
+        val deferred1 = async { DeliveryNotificationStore.updateFromOrders(ordersBatch1) }
+        val deferred2 = async { DeliveryNotificationStore.updateFromOrders(ordersBatch2) }
+        awaitAll(deferred1, deferred2)
+
+        val notifications = DeliveryNotificationStore.notifications.value
+        // Ambos batches deben estar presentes — ninguna notificación se pierde
+        assertEquals(100, notifications.size, "Dos llamadas concurrentes con 50 órdenes cada una deben producir 100 notificaciones")
+
+        val batch1Ids = (1..50).map { "batch1_${it}_PENDING" }
+        val batch2Ids = (1..50).map { "batch2_${it}_IN_PROGRESS" }
+        val allIds = notifications.map { it.id }.toSet()
+
+        batch1Ids.forEach { id ->
+            assertTrue(id in allIds, "Falta notificación $id del batch 1")
+        }
+        batch2Ids.forEach { id ->
+            assertTrue(id in allIds, "Falta notificación $id del batch 2")
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Corrige race condition en `DeliveryNotificationStore.updateFromOrders()` reemplazando assignment directo por `.update {}` (CAS atómico)
- Aplica el mismo fix preventivo a `ClientNotificationStore`
- Agrega test de concurrencia que verifica que dos batches paralelos de 50 notificaciones no pierden datos

Closes #1881

## Archivos modificados
- `DeliveryNotificationStore.kt` — `.update {}` en `updateFromOrders()` y `clear()`
- `ClientNotificationStore.kt` — mismo fix preventivo
- `DeliveryNotificationsViewModelTest.kt` — test de concurrencia

## Validaciones completadas
- ✅ Build & check
- ✅ Security audit (OWASP)
- ✅ QA E2E (`qa:passed`)
- ✅ Code review
- ✅ PO acceptance