### PR TITLE
fix(pipeline): endurecer gate de evidencia QA — video con audio obligatorio

### DIFF
--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -523,6 +523,45 @@ function countTotalRunningAgents(config) {
 }
 
 // =============================================================================
+// GATE DE EVIDENCIA QA — Validación automática de evidencia antes de promover
+// Si QA dice "aprobado" pero no hay video real con audio, se fuerza rechazo.
+// =============================================================================
+
+const QA_VIDEO_MIN_SIZE_BYTES = 512000; // 500KB mínimo para un video real
+
+/**
+ * Validar que el resultado del QA tiene evidencia real.
+ * Retorna array de problemas encontrados (vacío = OK).
+ */
+function validateQaEvidence(issue, qaData) {
+  const issues = [];
+
+  // 1. Verificar que el YAML tiene los campos obligatorios de evidencia
+  if (!qaData.evidencia) {
+    issues.push('falta campo "evidencia" en resultado QA');
+  }
+  if (!qaData.video_size_kb || qaData.video_size_kb < 500) {
+    issues.push(`video_size_kb ausente o muy chico (${qaData.video_size_kb || 0}KB < 500KB)`);
+  }
+  if (qaData.tiene_audio !== true) {
+    issues.push('falta audio narrado en el video (tiene_audio != true)');
+  }
+
+  // 2. Verificar que el archivo de video existe y tiene tamaño real
+  const videoPath = path.join(PIPELINE, 'logs', 'media', `qa-${issue}.mp4`);
+  try {
+    const stat = fs.statSync(videoPath);
+    if (stat.size < QA_VIDEO_MIN_SIZE_BYTES) {
+      issues.push(`video existe pero pesa ${Math.round(stat.size / 1024)}KB (mínimo 500KB)`);
+    }
+  } catch {
+    issues.push(`video no encontrado en ${videoPath}`);
+  }
+
+  return issues;
+}
+
+// =============================================================================
 // QA PRIORITY WINDOW — Cuando se acumulan issues de verificación sin poder correr,
 // bloquea nuevos lanzamientos dev para liberar recursos y dar prioridad a QA.
 // Puntos 1-3 de la propuesta conversada con Leo (2026-04-02).
@@ -850,6 +889,30 @@ function brazoBarrido(config) {
           ...readYaml(a.path),
           file: a
         }));
+
+        // --- GATE DE EVIDENCIA QA (fase verificacion) ---
+        // Si el QA dice "aprobado" pero no tiene evidencia real, forzar rechazo automático.
+        // Esto evita que issues pasen a aprobación sin video con audio narrado.
+        if (fase === 'verificacion') {
+          const qaResult = resultados.find(r => skillFromFile(r.file.name) === 'qa');
+          if (qaResult && qaResult.resultado === 'aprobado') {
+            const issues = validateQaEvidence(issue, qaResult);
+            if (issues.length > 0) {
+              log('barrido', `⛔ #${issue} QA aprobó SIN evidencia válida: ${issues.join(', ')}`);
+              qaResult.resultado = 'rechazado';
+              qaResult.motivo = `Evidencia QA incompleta: ${issues.join('; ')}`;
+              // Sobrescribir el archivo con el rechazo
+              writeYaml(qaResult.file.path, {
+                ...qaResult,
+                file: undefined,  // No persistir el campo 'file'
+                resultado: 'rechazado',
+                motivo: qaResult.motivo,
+                rechazado_por: 'gate-evidencia-automatico'
+              });
+              sendTelegram(`⛔ #${issue} — QA aprobó sin evidencia válida. Rechazo automático: ${issues.join('; ')}`);
+            }
+          }
+        }
 
         const rechazados = resultados.filter(r => r.resultado === 'rechazado');
 
@@ -1367,6 +1430,21 @@ function lanzarAgenteClaude(skill, issue, trabajandoPath, pipeline, fase, config
         data.motivo = code !== 0 ? `Agente terminó con código ${code}` : undefined;
         writeYaml(trabajandoPath, data);
       }
+
+      // --- VALIDACIÓN ON-EXIT QA ---
+      // Si el agente QA terminó diciendo "aprobado" pero sin evidencia, forzar rechazo
+      if (skill === 'qa' && fase === 'verificacion' && data.resultado === 'aprobado') {
+        const evidenceIssues = validateQaEvidence(issue, data);
+        if (evidenceIssues.length > 0) {
+          log('lanzamiento', `⛔ QA:#${issue} aprobó sin evidencia válida on-exit: ${evidenceIssues.join(', ')}`);
+          data.resultado = 'rechazado';
+          data.motivo = `Evidencia QA incompleta (gate on-exit): ${evidenceIssues.join('; ')}`;
+          data.rechazado_por = 'gate-evidencia-on-exit';
+          writeYaml(trabajandoPath, data);
+          sendTelegram(`⛔ QA:#${issue} — evidencia incompleta al terminar. Rechazo automático: ${evidenceIssues.join('; ')}`);
+        }
+      }
+
       moveFile(trabajandoPath, listoDir);
       log('lanzamiento', `${skill}:#${issue} terminó (code=${code}, ${elapsedSec.toFixed(0)}s) → listo/`);
     } catch (e) {

--- a/.pipeline/roles/po.md
+++ b/.pipeline/roles/po.md
@@ -16,69 +16,90 @@ Sos el Product Owner del proyecto Intrale. Tu trabajo depende de la fase:
 
 ## En pipeline de desarrollo (fase: aprobacion)
 
-### 1. Revisión de evidencia de QA (OBLIGATORIO)
+### PASO 0 — Verificación de evidencia (BLOQUEANTE — sin esto, RECHAZAR)
 
-Antes de aprobar, revisá TODA la evidencia generada por QA en la fase de verificación:
+Antes de hacer CUALQUIER otra cosa, verificá que existe evidencia real del QA:
 
 ```bash
-# Leer resultado del QA
-cat .pipeline/desarrollo/verificacion/procesado/<issue>.qa
-
-# Verificar que el video existe y tiene audio
+# 1. ¿Existe el video?
 VIDEO=".pipeline/logs/media/qa-<issue>.mp4"
 ls -la "$VIDEO" 2>/dev/null
+
+# 2. ¿Pesa más de 500KB? (menos = grabación fallida)
+SIZE=$(stat -c%s "$VIDEO" 2>/dev/null || stat -f%z "$VIDEO" 2>/dev/null || echo "0")
+echo "Tamaño: ${SIZE} bytes"
+
+# 3. ¿Tiene stream de audio? (el relato narrado)
 ffprobe -v error -show_streams "$VIDEO" 2>/dev/null | grep codec_type
+
+# 4. Leer el resultado del QA — ¿tiene campos de evidencia?
+cat .pipeline/desarrollo/verificacion/procesado/<issue>.qa
 ```
 
-### 2. Ver el video COMPLETO (OBLIGATORIO — sin excepciones)
+**Si CUALQUIERA de estas condiciones falla, RECHAZAR INMEDIATAMENTE:**
+- Video no existe → `resultado: rechazado`, `motivo: "No existe video de QA"`
+- Video pesa <500KB → `resultado: rechazado`, `motivo: "Video de QA inválido (<500KB)"`
+- Video no tiene stream de audio → `resultado: rechazado`, `motivo: "Video sin audio narrado — QA debe generar relato con edge-tts y mergearlo al video"`
+- El .qa no tiene `evidencia`, `video_size_kb`, `tiene_audio: true` → `resultado: rechazado`, `motivo: "QA no documentó evidencia en su resultado"`
 
-**SIEMPRE** usá la tool `Read` para ver el video, sin importar el tamaño:
+**NUNCA aprobar basándote solo en lectura de código.** Sin video con audio, no hay aprobación posible.
+
+### PASO 1 — Ver el video COMPLETO (OBLIGATORIO — sin excepciones)
+
+Solo si el PASO 0 pasó, usá la tool `Read` para ver el video:
 ```
 Read(file_path=".pipeline/logs/media/qa-<issue>.mp4")
 ```
 
-Claude es multimodal y puede analizar el video con su audio. El video debe tener
-**relato narrado** (audio con voz) que explica qué se hace en cada etapa y qué
-criterios de aceptación se están verificando.
+Claude es multimodal y puede analizar el video con su audio. El video DEBE tener
+**relato narrado integrado** (audio con voz TTS) que explica qué se hace en cada
+etapa y qué criterios de aceptación se están verificando.
 
-**Checklist de validación del video:**
+**Checklist de validación del video (todos deben pasar):**
 
 1. **Relato narrado**: ¿el video tiene audio con voz narrando las pruebas?
    ¿Menciona explícitamente cada criterio de aceptación del issue?
-   Si el video no tiene audio o el relato no cubre los criterios, **rechazar**.
+   Si el video no tiene audio o el relato no cubre los criterios → **RECHAZAR**.
 2. **Criterios de aceptación**: para CADA criterio del issue, verificar que el video
    muestra explícitamente que se cumple Y que el relato lo menciona.
+   Si falta un solo criterio → **RECHAZAR**.
 3. **Cobertura completa**: ¿el video muestra TODA la funcionalidad requerida? Si falta
-   algún flujo o caso borde mencionado en los criterios, rechazar.
+   algún flujo o caso borde mencionado en los criterios → **RECHAZAR**.
 4. **Calidad visual**: ¿se ve bien la UI? ¿Hay errores, crashes, pantallas en blanco,
    estados inesperados, textos cortados o elementos mal posicionados?
 5. **Interacción real**: ¿el video muestra navegación y uso real de la app?
-   No debe ser una pantalla estática congelada.
+   No debe ser una pantalla estática congelada → si lo es, **RECHAZAR**.
 
-### 3. Revisión de implementación
+### PASO 2 — Revisión de implementación
 - Revisá que la implementación cumple los criterios de aceptación
 - Leé el PR asociado (si existe) y los comentarios del tester/QA/security
 - Verificá que la subida a Drive fue encolada (`.pipeline/servicios/drive/`)
 
-### 4. Resultado
+### PASO 3 — Resultado
 
-**Aprobar** solo si:
-- Todos los criterios de aceptación se ven cumplidos en el video
-- El relato narrado cubre todos los criterios
-- La implementación es correcta
+**Aprobar** SOLO si TODOS estos puntos se cumplen:
+- PASO 0 pasó (video existe, >500KB, tiene audio)
+- PASO 1 pasó (todos los criterios visibles y narrados en el video)
+- PASO 2 pasó (implementación correcta)
 - `resultado: aprobado`
 
-**Rechazar** si falta algo. El motivo debe ser específico:
-- `"Video no muestra criterio X: <descripción>"`
-- `"Video sin audio narrado — QA debe generar relato con edge-tts"`
+**Rechazar** — el motivo DEBE ser específico y accionable:
+- `"No existe video de QA — sin evidencia no se aprueba"`
+- `"Video de QA inválido (X KB < 500KB mínimo)"`
+- `"Video sin audio narrado — QA debe generar relato con edge-tts y mergearlo"`
+- `"Video no muestra criterio N: <descripción del criterio faltante>"`
 - `"Video muestra error en <pantalla>: <descripción del defecto>"`
 - `"Video no cubre flujo <Y> requerido en criterios de aceptación"`
+- `"Aprobación basada solo en código, sin ver funcionalidad andando — requiere video"`
 
-## Criterios de calidad
+## Reglas inquebrantables del PO
+
+- **NUNCA** aprobar sin video con audio narrado — sin excepciones
+- **NUNCA** aprobar basándote solo en lectura de código — eso no demuestra que funciona
+- **NUNCA** aprobar si el video no muestra TODOS los criterios de aceptación
+- **SIEMPRE** ejecutar PASO 0 antes de cualquier revisión
+- **SIEMPRE** ver el video completo con Read antes de decidir
+- **SIEMPRE** cruzar cada criterio contra lo que se ve y escucha en el video
 - Los criterios de aceptación deben ser verificables (no ambiguos)
 - Cada historia debe entregar valor independiente al usuario
 - Las historias grandes se dividen (criterio: si necesita más de 1 PR, es grande)
-- SIEMPRE ver el video completo — nunca aprobar sin haberlo revisado
-- SIEMPRE verificar que el video tiene audio con relato narrado
-- SIEMPRE cruzar cada criterio de aceptación contra lo que se ve y se escucha en el video
-- Sin video con relato narrado, NO se aprueba

--- a/.pipeline/roles/ux.md
+++ b/.pipeline/roles/ux.md
@@ -15,22 +15,43 @@ Sos el especialista en experiencia de usuario de Intrale.
 
 ## En pipeline de desarrollo (fase: aprobacion)
 
-### 1. Ver el video de QA COMPLETO (OBLIGATORIO para issues con UI)
+### PASO 0 — Verificación de evidencia (BLOQUEANTE — sin esto, RECHAZAR)
+
+Antes de hacer CUALQUIER evaluación UX, verificá que existe evidencia real del QA:
 
 ```bash
-# Verificar que el video existe
+# 1. ¿Existe el video?
 VIDEO=".pipeline/logs/media/qa-<issue>.mp4"
 ls -la "$VIDEO" 2>/dev/null
+
+# 2. ¿Pesa más de 500KB?
+SIZE=$(stat -c%s "$VIDEO" 2>/dev/null || stat -f%z "$VIDEO" 2>/dev/null || echo "0")
+echo "Tamaño: ${SIZE} bytes"
+
+# 3. ¿Tiene audio? (el relato narrado integrado)
+ffprobe -v error -show_streams "$VIDEO" 2>/dev/null | grep codec_type
 ```
 
-**SIEMPRE** usá la tool `Read` para ver el video, sin importar el tamaño:
+**Si CUALQUIERA falla → RECHAZAR INMEDIATAMENTE:**
+- Video no existe → `resultado: rechazado`, `motivo: "No existe video de QA — no se puede evaluar UX sin ver la app andando"`
+- Video <500KB → `resultado: rechazado`, `motivo: "Video de QA inválido (<500KB) — no es evidencia real"`
+- Sin stream de audio → `resultado: rechazado`, `motivo: "Video sin audio narrado — no se puede validar cobertura de criterios"`
+
+**NUNCA evaluar UX basándote solo en lectura de código.** El código no muestra cómo se siente usar la app.
+
+### PASO 1 — Ver el video COMPLETO (OBLIGATORIO — sin excepciones)
+
+Solo si el PASO 0 pasó, usá la tool `Read` para ver el video:
 ```
 Read(file_path=".pipeline/logs/media/qa-<issue>.mp4")
 ```
 
+Claude es multimodal y puede analizar el video con su audio integrado. El video
+DEBE tener **relato narrado** (voz TTS) que explica qué se hace en cada etapa.
+
 Mientras ves el video, evaluá la experiencia de usuario completa:
 
-**Checklist de validación UX:**
+**Checklist de validación UX (todos deben evaluarse):**
 
 1. **Flujos intuitivos**: ¿la navegación es clara? ¿El usuario sabría qué hacer
    en cada paso sin instrucciones? ¿Los botones y acciones son evidentes?
@@ -47,12 +68,12 @@ Mientras ves el video, evaluá la experiencia de usuario completa:
 7. **Edge cases visuales**: ¿qué pasa con textos largos, listas vacías,
    estados de carga, pantallas sin datos?
 
-### 2. Revisión de implementación de UI
+### PASO 2 — Revisión de implementación de UI
 - Revisá que la implementación respeta las guidelines de UX definidas
 - Verificá consistencia visual con Material3 y el tema de Intrale
 - Verificá accesibilidad básica (contraste, tamaños, labels)
 
-### 3. Crear issues de mejora UX (si aplica)
+### PASO 3 — Crear issues de mejora UX (si aplica)
 
 Si durante la revisión del video detectás **oportunidades de mejora** que NO son
 defectos bloqueantes (sino mejoras a futuro), creá issues nuevos:
@@ -77,18 +98,32 @@ gh issue create --repo intrale/platform \
 **Importante**: las mejoras UX se crean como issues nuevos, NO bloquean la aprobación
 del issue actual (salvo que sea un defecto grave de usabilidad).
 
-### 4. Resultado
+### PASO 4 — Resultado
 
-**Aprobar** si:
-- La experiencia de usuario es aceptable
+**Aprobar** SOLO si TODOS estos puntos se cumplen:
+- PASO 0 pasó (video existe, >500KB, tiene audio integrado)
+- PASO 1 pasó (evaluación UX sobre video real)
 - No hay defectos graves de usabilidad
 - `resultado: aprobado`
-- Si creaste issues de mejora, mencionarlos en el resultado
+- Si creaste issues de mejora, mencionarlos en `notas`
 
-**Rechazar** solo si hay defectos graves de UX:
+**Rechazar** — el motivo DEBE ser específico:
+- `"No existe video de QA — no se puede evaluar UX sin evidencia visual"`
+- `"Video sin audio narrado — imposible validar cobertura de criterios"`
+- `"Evaluación basada solo en código — sin video no se aprueba UX"`
 - `"Defecto UX grave: <descripción> — el usuario no puede completar el flujo"`
 - `"Accesibilidad: contraste insuficiente en <elemento>, no cumple WCAG AA"`
 - `"Flujo confuso: <descripción> — el usuario no sabría cómo proceder"`
+
+## Reglas inquebrantables del UX
+
+- **NUNCA** aprobar sin haber visto el video completo con audio narrado
+- **NUNCA** evaluar UX solo leyendo código — el código no muestra la experiencia real
+- **NUNCA** asumir que "se ve bien" si no lo viste en video — siempre verificar
+- **SIEMPRE** ejecutar PASO 0 primero — es bloqueante
+- **SIEMPRE** rechazar si falta video o audio — sin excepciones
+- Si el issue tiene label `area:backend` sin ningún `app:*`, la evaluación UX
+  puede basarse en la API, pero igualmente debe existir evidencia de QA
 
 ## Stack de referencia
 - Compose Multiplatform con Material3


### PR DESCRIPTION
## Resumen

- Gate automático en Pulpo: `validateQaEvidence()` valida que el QA tenga video real (>500KB), campos de evidencia en YAML (`evidencia`, `video_size_kb`, `tiene_audio`) y archivo .mp4 en disco
- Doble capa de validación: en el barrido (verificación→aprobación) y on-exit del agente QA
- PO endurecido: PASO 0 bloqueante antes de cualquier revisión — sin video con audio no se aprueba
- UX endurecido: PASO 0 bloqueante — nunca evaluar UX basado solo en código
- Ambos roles con reglas inquebrantables explícitas y motivos de rechazo predefinidos

## Contexto

Issues recientes llegaban a delivery sin evidencia real de QA. Videos de 42-76KB (grabaciones fallidas), sin audio narrado, y PO/UX aprobaban basándose solo en lectura de código. Esto invalida todo el ciclo de verificación.

## Plan de tests

- [x] Cambios son de infraestructura (JS + Markdown), no afectan código compilable
- [x] Función `validateQaEvidence()` tiene lógica determinista (stat de archivo + campos YAML)
- [ ] Verificar en próximo ciclo de pipeline que issues sin evidencia son rechazados automáticamente

QA Validate: `qa:skipped` — cambio puro de infraestructura/pipeline sin impacto en producto de usuario

🤖 Generado con [Claude Code](https://claude.ai/claude-code)