### PR TITLE
fix(pipeline): no resetear contador de kill de emergencia en baja temporal de CPU

### DIFF
--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -514,10 +514,12 @@ function isSystemOverloaded(config) {
       sendTelegram(`🔴 Recursos críticos — kill de emergencia: ${killed.join(', ')}\nCPU: ${cpuPercent}% | RAM: ${memPercent}%`);
       lastEmergencyTelegramTs = now;
     }
-    // Re-evaluar
+    // Re-evaluar — NO resetear consecutiveRedCycles acá, porque el kill baja
+    // temporalmente los recursos pero vuelven a subir al siguiente ciclo,
+    // causando un loop infinito de kill + notificación. El counter solo se
+    // resetea cuando el sistema baja naturalmente a GREEN o YELLOW.
     const after = getResourcePressure(config);
     if (after.level !== PRESSURE_LEVELS.RED) {
-      consecutiveRedCycles = 0; // Se recuperó
       return isSystemOverloaded(config);
     }
   }


### PR DESCRIPTION
## Resumen

El kill de emergencia del Pulpo mata Gradle daemons cuando la CPU sube a RED. Eso baja temporalmente la presión, pero luego vuelve a subir al siguiente ciclo, causando un loop infinito de kill + notificación sin nunca alcanzar el tope de 3 intentos.

**Fix:** Solo resetear el contador cuando el sistema baja *naturalmente* a GREEN/YELLOW/ORANGE. Los kills temporales no resetean, así después de 3 kills seguidos sin mejora sostenida, deja de insistir.

## Impacto

- **Área afectada:** Pipeline (infra)
- **Producto:** Sin cambios en código de usuario
- **QA:** No requiere, fix en pipeline automation

## Tipo

- `fix` — corrección de loop infinito en spam de emergencia kill

🤖 Generado con [Claude Code](https://claude.ai/claude-code)