### PR TITLE
feat(pipeline): botones de Priority Windows en dashboard

### DIFF
--- a/.pipeline/dashboard-v2.js
+++ b/.pipeline/dashboard-v2.js
@@ -289,6 +289,14 @@ function getPipelineState() {
     }
   } catch {}
 
+  // Priority Windows (estado persistido por el Pulpo)
+  state.priorityWindows = { qa: { active: false }, build: { active: false } };
+  try {
+    const pwData = JSON.parse(fs.readFileSync(path.join(PIPELINE, 'priority-windows.json'), 'utf8'));
+    if (pwData.qa) state.priorityWindows.qa = pwData.qa;
+    if (pwData.build) state.priorityWindows.build = pwData.build;
+  } catch {}
+
   // Rechazos recientes
   state.rechazos = [];
   for (const { pipeline: pName, fase } of allFases) {
@@ -639,6 +647,38 @@ function generateHTML(state) {
     : `<button class="ctl-btn ctl-start ctl-wide" onclick="ctlAction('qa','start')">▶ Levantar QA</button>`;
   qaEnvHTML += `<div class="qa-controls">${qaBtn}</div>`;
 
+  // Priority Windows (QA + Build)
+  const pwQa = state.priorityWindows.qa;
+  const pwBuild = state.priorityWindows.build;
+  const pwQaElapsed = pwQa.active && pwQa.activatedAt ? Math.round((Date.now() - pwQa.activatedAt) / 60000) : 0;
+  const pwBuildElapsed = pwBuild.active && pwBuild.activatedAt ? Math.round((Date.now() - pwBuild.activatedAt) / 60000) : 0;
+
+  const pwQaStatus = pwQa.active
+    ? `<span class="pw-badge pw-active">ACTIVA${pwQaElapsed > 0 ? ` (${pwQaElapsed}min)` : ''}</span>`
+    : `<span class="pw-badge pw-inactive">Inactiva</span>`;
+  const pwBuildStatus = pwBuild.active
+    ? `<span class="pw-badge pw-active">ACTIVA${pwBuildElapsed > 0 ? ` (${pwBuildElapsed}min)` : ''}</span>`
+    : `<span class="pw-badge pw-inactive">Inactiva</span>`;
+
+  const pwQaBtn = pwQa.active
+    ? `<button class="ctl-btn ctl-stop" onclick="pwAction('qa','off')">■ Desactivar</button>`
+    : `<button class="ctl-btn ctl-start" onclick="pwAction('qa','on')">▶ Activar</button>`;
+  const pwBuildBtn = pwBuild.active
+    ? `<button class="ctl-btn ctl-stop" onclick="pwAction('build','off')">■ Desactivar</button>`
+    : `<button class="ctl-btn ctl-start" onclick="pwAction('build','on')">▶ Activar</button>`;
+
+  const priorityWindowsHTML = `
+    <div class="pw-row">
+      <div class="pw-item">
+        <span class="pw-label">🔍 QA Priority</span> ${pwQaStatus} ${pwQaBtn}
+        <span class="pw-desc">Bloquea dev → prioriza verificación</span>
+      </div>
+      <div class="pw-item">
+        <span class="pw-label">🔨 Build Priority</span> ${pwBuildStatus} ${pwBuildBtn}
+        <span class="pw-desc">Bloquea dev → prioriza builds</span>
+      </div>
+    </div>`;
+
   // Rechazos recientes
   let rechazosHTML = '';
   if (state.rechazos.length > 0) {
@@ -880,6 +920,14 @@ h2{color:var(--dim);font-size:0.8em;text-transform:uppercase;letter-spacing:2px;
 .ctl-stop{background:var(--rd2);color:var(--rd)}
 .ctl-wide{padding:4px 12px;font-size:0.78em;margin-top:8px;display:inline-block}
 .qa-controls{margin-top:8px}
+/* Priority Windows */
+.pw-row{display:flex;gap:16px;flex-wrap:wrap}
+.pw-item{display:flex;align-items:center;gap:8px;flex-wrap:wrap;padding:8px 12px;background:var(--sf2);border-radius:var(--radius-sm);border:1px solid var(--bd2);flex:1;min-width:260px}
+.pw-label{font-weight:600;font-size:0.9em;white-space:nowrap}
+.pw-badge{font-size:0.75em;padding:2px 8px;border-radius:10px;font-weight:700;text-transform:uppercase;letter-spacing:0.5px}
+.pw-active{background:var(--yl2);color:var(--yl);border:1px solid var(--yl)}
+.pw-inactive{background:var(--bd2);color:var(--dim);border:1px solid var(--bd)}
+.pw-desc{font-size:0.72em;color:var(--dim);width:100%;margin-top:2px}
 
 /* Toast notification */
 .toast{
@@ -1015,6 +1063,7 @@ h2{color:var(--dim);font-size:0.8em;text-transform:uppercase;letter-spacing:2px;
     <div class="bar-section"><h2>📡 Servicios</h2>${svcsHTML}</div>
     <div class="bar-section"><h2>⚡ Procesos</h2>${procHTML}</div>
     <div class="bar-section"><h2>🧪 QA Environment</h2>${qaEnvHTML}</div>
+    <div class="bar-section"><h2>🚦 Priority Windows</h2>${priorityWindowsHTML}</div>
   </div>
 
   ${matrixHTML}
@@ -1088,6 +1137,22 @@ async function ctlAction(target, action) {
     showToast('Error de conexión: ' + e.message, false);
   }
   btns.forEach(b => b.classList.remove('loading'));
+}
+
+// Priority Window toggle
+async function pwAction(window, action) {
+  try {
+    const resp = await fetch('/api/priority-window', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ window, action })
+    });
+    const result = await resp.json();
+    showToast(result.msg, result.ok);
+    setTimeout(() => location.reload(), 1500);
+  } catch (e) {
+    showToast('Error de conexión: ' + e.message, false);
+  }
 }
 
 function showToast(msg, ok) {
@@ -1175,6 +1240,41 @@ const server = http.createServer((req, res) => {
         log(`Action: ${action} ${target} → ${result.ok ? '✓' : '✗'} ${result.msg}`);
         res.writeHead(200, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify(result));
+      } catch (e) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ ok: false, msg: e.message }));
+      }
+    });
+    return;
+  }
+
+  // API: Priority Windows toggle (on/off manual)
+  if (req.url === '/api/priority-window' && req.method === 'POST') {
+    let body = '';
+    req.on('data', chunk => { body += chunk; });
+    req.on('end', () => {
+      try {
+        const { window: win, action } = JSON.parse(body);
+        if (!['qa', 'build'].includes(win)) {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ ok: false, msg: `Window "${win}" no válida (qa|build)` }));
+          return;
+        }
+        const pwFile = path.join(PIPELINE, 'priority-windows.json');
+        let current = {};
+        try { current = JSON.parse(fs.readFileSync(pwFile, 'utf8')); } catch {}
+        if (!current.qa) current.qa = { active: false };
+        if (!current.build) current.build = { active: false };
+
+        // Escribir manualOverride para que el Pulpo lo consuma en su próximo ciclo
+        current[win].manualOverride = (action === 'on');
+        fs.writeFileSync(pwFile, JSON.stringify(current, null, 2));
+
+        const label = win === 'qa' ? 'QA Priority' : 'Build Priority';
+        const verb = action === 'on' ? 'activada' : 'desactivada';
+        log(`Priority Window: ${label} ${verb} manualmente`);
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ ok: true, msg: `${label} Window ${verb} — surte efecto en el próximo ciclo del Pulpo` }));
       } catch (e) {
         res.writeHead(400, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({ ok: false, msg: e.message }));

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -607,6 +607,80 @@ let buildPriorityActivatedAt = 0;
 let buildFirstBlockedAt = 0;
 let buildPriorityNotifiedTelegram = false;
 
+const PRIORITY_WINDOWS_FILE = path.join(PIPELINE, 'priority-windows.json');
+
+/**
+ * Persistir el estado actual de las priority windows a disco.
+ * El dashboard lee este archivo para mostrar estado y el usuario puede
+ * activar/desactivar ventanas manualmente escribiendo en él.
+ */
+function persistPriorityWindows() {
+  const state = {
+    qa: {
+      active: qaPriorityActive,
+      activatedAt: qaPriorityActivatedAt || null,
+      manual: false // se sobreescribe si fue activación manual
+    },
+    build: {
+      active: buildPriorityActive,
+      activatedAt: buildPriorityActivatedAt || null,
+      manual: false
+    },
+    updatedAt: Date.now()
+  };
+  try { fs.writeFileSync(PRIORITY_WINDOWS_FILE, JSON.stringify(state, null, 2)); } catch {}
+}
+
+/**
+ * Leer activaciones/desactivaciones manuales desde el archivo.
+ * El dashboard escribe { qa: { manualOverride: true/false }, build: { manualOverride: true/false } }
+ * y el Pulpo las consume acá.
+ */
+function readManualPriorityOverrides() {
+  try {
+    const data = JSON.parse(fs.readFileSync(PRIORITY_WINDOWS_FILE, 'utf8'));
+
+    // QA manual override
+    if (data.qa?.manualOverride === true && !qaPriorityActive) {
+      qaPriorityActive = true;
+      qaPriorityActivatedAt = Date.now();
+      qaPriorityNotifiedTelegram = false;
+      log('qa-priority', '🔧 QA Priority Window ACTIVADA MANUALMENTE desde dashboard');
+      sendTelegram('🔧 QA Priority Window activada manualmente desde el dashboard. Dev bloqueado hasta desactivación.');
+      persistPriorityWindows();
+    } else if (data.qa?.manualOverride === false && qaPriorityActive) {
+      qaPriorityActive = false;
+      qaPriorityActivatedAt = 0;
+      qaFirstBlockedAt = 0;
+      log('qa-priority', '🔧 QA Priority Window DESACTIVADA MANUALMENTE desde dashboard');
+      persistPriorityWindows();
+    }
+
+    // Build manual override
+    if (data.build?.manualOverride === true && !buildPriorityActive) {
+      buildPriorityActive = true;
+      buildPriorityActivatedAt = Date.now();
+      buildPriorityNotifiedTelegram = false;
+      log('build-priority', '🔧 Build Priority Window ACTIVADA MANUALMENTE desde dashboard');
+      sendTelegram('🔧 Build Priority Window activada manualmente desde el dashboard. Dev bloqueado hasta desactivación.');
+      persistPriorityWindows();
+    } else if (data.build?.manualOverride === false && buildPriorityActive) {
+      buildPriorityActive = false;
+      buildPriorityActivatedAt = 0;
+      buildFirstBlockedAt = 0;
+      log('build-priority', '🔧 Build Priority Window DESACTIVADA MANUALMENTE desde dashboard');
+      persistPriorityWindows();
+    }
+
+    // Limpiar overrides consumidos
+    if (data.qa?.manualOverride !== undefined || data.build?.manualOverride !== undefined) {
+      delete data.qa?.manualOverride;
+      delete data.build?.manualOverride;
+      fs.writeFileSync(PRIORITY_WINDOWS_FILE, JSON.stringify(data, null, 2));
+    }
+  } catch {}
+}
+
 /**
  * Contar issues pendientes en fase verificación (todas las pipelines).
  */
@@ -658,6 +732,7 @@ function evaluateQaPriority(config) {
       qaPriorityActivatedAt = 0;
       qaFirstBlockedAt = 0;
       qaPriorityNotifiedTelegram = false;
+      persistPriorityWindows();
       return false;
     }
     // Si excedió duración máxima, desactivar para no bloquear dev indefinidamente
@@ -670,6 +745,7 @@ function evaluateQaPriority(config) {
       qaPriorityActivatedAt = 0;
       qaFirstBlockedAt = 0;
       qaPriorityNotifiedTelegram = false;
+      persistPriorityWindows();
       return false;
     }
     return true; // Sigue activa
@@ -689,6 +765,7 @@ function evaluateQaPriority(config) {
       qaPriorityNotifiedTelegram = true;
       log('qa-priority', `🚨 QA PRIORITY WINDOW ACTIVADA — ${pendingQa} issues llevan ${Math.round(waitedMs / 60000)}min sin verificar. Bloqueando lanzamientos dev.`);
       sendTelegram(`🚨 QA Priority Window activada — ${pendingQa} issues llevan ${Math.round(waitedMs / 60000)}min esperando verificación. Bloqueando nuevos lanzamientos de dev para liberar recursos. Duración máxima: ${maxDurationMinutes}min.`);
+      persistPriorityWindows();
       return true;
     }
   } else {
@@ -756,6 +833,7 @@ function evaluateBuildPriority(config) {
       buildPriorityActivatedAt = 0;
       buildFirstBlockedAt = 0;
       buildPriorityNotifiedTelegram = false;
+      persistPriorityWindows();
       return false;
     }
     // Si excedió duración máxima, desactivar para no bloquear dev indefinidamente
@@ -768,6 +846,7 @@ function evaluateBuildPriority(config) {
       buildPriorityActivatedAt = 0;
       buildFirstBlockedAt = 0;
       buildPriorityNotifiedTelegram = false;
+      persistPriorityWindows();
       return false;
     }
     return true; // Sigue activa
@@ -787,6 +866,7 @@ function evaluateBuildPriority(config) {
       buildPriorityNotifiedTelegram = true;
       log('build-priority', `🔨 BUILD PRIORITY WINDOW ACTIVADA — ${pendingBuild} issues llevan ${Math.round(waitedMs / 60000)}min sin buildear. Bloqueando lanzamientos dev.`);
       sendTelegram(`🔨 Build Priority Window activada — ${pendingBuild} issues esperando build hace ${Math.round(waitedMs / 60000)}min. Bloqueando nuevos dev para liberar recursos. Duración máxima: ${maxDurationMinutes}min.`);
+      persistPriorityWindows();
       return true;
     }
   } else {
@@ -1274,6 +1354,9 @@ function sortByPriority(archivos, config) {
 function brazoLanzamiento(config) {
   // Limpieza proactiva periódica (cada N ciclos, sin importar presión)
   proactiveCleanup(config);
+
+  // Leer activaciones/desactivaciones manuales del dashboard
+  readManualPriorityOverrides();
 
   // GATE DE RECURSOS: presión graduada (green/yellow/orange/red)
   if (isSystemOverloaded(config)) return;


### PR DESCRIPTION
## Resumen

- **Dashboard**: nueva sección "🚦 Priority Windows" con estado visual (ACTIVA/Inactiva) y botones de toggle para QA Priority y Build Priority
- **Pulpo**: persiste estado de ambas ventanas a `priority-windows.json` en cada transición
- **API**: nuevo endpoint `POST /api/priority-window` para activar/desactivar manualmente desde el dashboard
- **Comunicación bidireccional**: el dashboard escribe `manualOverride` al archivo, el Pulpo lo consume en el siguiente ciclo y notifica por Telegram

## Flujo

```
Dashboard (botón) → POST /api/priority-window → priority-windows.json (manualOverride)
Pulpo (ciclo) → readManualPriorityOverrides() → activa/desactiva → persistPriorityWindows()
Dashboard (SSE) → lee priority-windows.json → muestra estado actualizado
```

## Plan de tests

- [x] Sintaxis verificada (node -c OK en ambos archivos)
- [x] Botones renderizan en la UI
- [x] API endpoint escribe manualOverride correctamente
- [x] Pulpo consume y limpia overrides

QA Validate: omitido — cambio de infra/pipeline sin impacto en producto de usuario ⚠️

🤖 Generado con [Claude Code](https://claude.ai/claude-code)