### PR TITLE
fix(pipeline): no mover archivos de verificación a build cuando falta APK

### DIFF
--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -1710,15 +1710,46 @@ function brazoLanzamiento(config) {
       preflightResult = preflightQaChecks(issue);
       if (!preflightResult.ok) {
         if (preflightResult.result === 'apk_missing') {
-          // Mover de verificacion/pendiente → build/pendiente — NO penalizar circuit breaker
-          log('lanzamiento', `⏪ #${issue}: APK faltante, moviendo de verificación a cola de build`);
+          // Re-encolar SOLO el build de este issue — NO mover el archivo de verificación.
+          // El archivo de verificación (qa/security/tester) debe permanecer en
+          // verificacion/pendiente/ para que se ejecute cuando el APK esté disponible.
+          // Si lo moviéramos a build/pendiente/, quedaría huérfano porque el builder
+          // solo procesa archivos con skill "build" (#2125).
           try {
             const buildPendDir = path.join(fasePath(pipelineName, 'build'), 'pendiente');
-            moveFile(archivo.path, buildPendDir);
-            ghCommentOnIssue(issue, `⏪ QA requiere APK para este issue. Devuelto al builder automáticamente.`);
-            log('lanzamiento', `✅ #${issue}: movido a build/pendiente OK`);
-          } catch (moveErr) {
-            log('lanzamiento', `⚠️ #${issue}: no se pudo mover a build — ${moveErr.message}`);
+            const buildTrabDir = path.join(fasePath(pipelineName, 'build'), 'trabajando');
+            const buildListoDir = path.join(fasePath(pipelineName, 'build'), 'listo');
+            const buildProcDir = path.join(fasePath(pipelineName, 'build'), 'procesado');
+            const buildFileName = `${issue}.build`;
+
+            // ¿Ya hay un build en vuelo o encolado para este issue? Si sí, no hacer nada.
+            const yaEncolado =
+              fs.existsSync(path.join(buildPendDir, buildFileName)) ||
+              fs.existsSync(path.join(buildTrabDir, buildFileName)) ||
+              fs.existsSync(path.join(buildListoDir, buildFileName));
+
+            if (!yaEncolado) {
+              // Si existe un build procesado anterior, moverlo de vuelta a pendiente
+              // (reaprovecha el rebote_numero si existe). Si no, crear uno nuevo.
+              const procFile = path.join(buildProcDir, buildFileName);
+              if (fs.existsSync(procFile)) {
+                moveFile(procFile, buildPendDir);
+                log('lanzamiento', `⏪ #${issue}: APK faltante — build re-encolado desde procesado`);
+              } else {
+                writeYaml(path.join(buildPendDir, buildFileName), {
+                  issue: parseInt(issue),
+                  fase: 'build',
+                  pipeline: pipelineName,
+                  motivo: 'APK faltante detectado por preflight QA',
+                });
+                log('lanzamiento', `⏪ #${issue}: APK faltante — nuevo build encolado`);
+              }
+              ghCommentOnIssue(issue, `⏪ QA requiere APK para este issue. Re-encolado al builder automáticamente.`);
+            } else {
+              log('lanzamiento', `⏸️ #${issue}: APK faltante — build ya en curso/encolado, esperando`);
+            }
+          } catch (reencolarErr) {
+            log('lanzamiento', `⚠️ #${issue}: no se pudo re-encolar build — ${reencolarErr.message}`);
           }
         } else if (preflightResult.result === 'waiting:emulator') {
           // Señalizar que hay issues esperando emulador — evaluateQaPriority() se encarga


### PR DESCRIPTION
## Problema

El **Issue Tracker** del dashboard mostraba agentes `qa`, `security` y `tester` en la fase **build**, cuando esa fase solo debería contener el agente `build`. Afectaba visualmente a varios issues (#2020, #2019, #2018, #2017, #2043, #2041, #1951, #1920, #1884).

## Causa raíz

En `pulpo.js`, el handler de `apk_missing` en `brazoLanzamiento` movía el archivo de verificación (ej. `2020.qa`) directamente a `desarrollo/build/pendiente/` con `moveFile`. El builder solo procesa archivos con skill `build`, así que los archivos `.qa`/`.security`/`.tester` quedaban huérfanos para siempre en `build/` y el dashboard los mostraba como agentes activos en esa fase. Además, en cada ciclo se comentaba nuevamente el issue en GitHub (spam).

## Fix

Cuando preflight detecta APK faltante, ahora:

- Se re-encola el **build** del issue (movido desde `build/procesado/` si existe, o creado nuevo con `writeYaml`).
- El archivo de verificación **permanece** en `verificacion/pendiente/` para ejecutarse cuando el APK esté disponible.
- Se deduplica: si ya hay un `<issue>.build` en `pendiente`/`trabajando`/`listo`, no se duplica ni se vuelve a comentar en GitHub.
- El archivo de verificación ya no se mueve ni se toca.

## Limpieza de estado

Se limpiaron **35 archivos huérfanos** en `.pipeline/desarrollo/build/` acumulados por el bug:

- `build/pendiente/`: 24 archivos `.qa`/`.security`/`.tester` de 9 issues
- `build/listo/`: `1920.security`
- `build/procesado/`: 9 archivos `.qa`/`.security`/`.tester` de 5 issues
- `verificacion/pendiente/1920.security` duplicado

## QA

`qa:skipped` — cambio de infra interna del pipeline, sin impacto de usuario final. Validado manualmente:

- Pulpo reiniciado con el código corregido.
- `build/{pendiente,trabajando,listo}` quedan limpios (solo `.gitkeep`).
- Log del pulpo ya no emite `moviendo de verificación a cola de build`.

## Test plan

- [x] `node -c .pipeline/pulpo.js` — sintaxis OK
- [x] Filesystem limpio post-fix
- [x] Pulpo reiniciado y procesando ciclos normales
- [ ] Verificar en próximo ciclo con APK faltante real que el build se re-encola correctamente sin tocar el archivo de verificación