### PR TITLE
fix(pipeline): gating real de boot del emulador + retry portable

### DIFF
--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -1153,18 +1153,28 @@ function tryFreeResources(mode = 'soft') {
  * Delega al servicio-emulador via cola (no ejecuta directamente).
  * Retorna true si encoló el pedido de stop.
  */
+// Grace period: después de levantar el emulador (boot_completed), no apagarlo
+// durante este tiempo. Evita el loop preflight→start→idle→stop→preflight que
+// corrompía el quickboot. Anclado a qa-env-state.lastStartedAt, que qa-environment.js
+// escribe recién DESPUÉS de confirmar sys.boot_completed=1.
+const EMULATOR_IDLE_GRACE_MS = 3 * 60 * 1000; // 3 minutos de warm-up protegido
+
 function shutdownIdleEmulator(config) {
   try {
-    // ¿Hay algo en verificacion/trabajando?
+    // ¿Hay algo en verificacion/trabajando O pendiente?
+    // Si hay QA pendiente encolada, el emulador va a ser necesario inmediatamente.
     for (const [pName, pConfig] of Object.entries(config.pipelines)) {
       if (!pConfig.fases.includes('verificacion')) continue;
-      const trabajandoDir = path.join(fasePath(pName, 'verificacion'), 'trabajando');
-      const archivos = listWorkFiles(trabajandoDir);
-      if (archivos.length > 0) return false; // Hay agentes de QA corriendo, no tocar
+      const verifDir = fasePath(pName, 'verificacion');
+      const trabajando = listWorkFiles(path.join(verifDir, 'trabajando'));
+      if (trabajando.length > 0) return false; // Hay agentes QA corriendo
+      const pendiente = listWorkFiles(path.join(verifDir, 'pendiente'));
+      if (pendiente.length > 0) return false; // Hay QA pendiente en cola
     }
 
     // ¿Está corriendo el emulador? Verificar state file Y por nombre de proceso
     let emulatorRunning = false;
+    let lastStartedAt = 0;
 
     // Check 1: state file
     const stateFile = path.join(PIPELINE, 'qa-env-state.json');
@@ -1173,6 +1183,7 @@ function shutdownIdleEmulator(config) {
         const state = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
         const emulatorPid = state.emulator || state.emulador;
         if (emulatorPid && isProcessAlive(emulatorPid)) emulatorRunning = true;
+        lastStartedAt = state.lastStartedAt || 0;
       } catch {}
     }
 
@@ -1186,6 +1197,15 @@ function shutdownIdleEmulator(config) {
     }
 
     if (!emulatorRunning) return false;
+
+    // Grace period: no apagar si estamos dentro de la ventana post-boot.
+    // lastStartedAt se actualiza en qa-environment.js DESPUÉS de boot_completed.
+    const ageMs = Date.now() - lastStartedAt;
+    if (lastStartedAt > 0 && ageMs < EMULATOR_IDLE_GRACE_MS) {
+      const remaining = Math.round((EMULATOR_IDLE_GRACE_MS - ageMs) / 1000);
+      log('recursos', `⏳ Emulador dentro de grace period post-boot (${remaining}s restantes) — no apagar`);
+      return false;
+    }
 
     // Encolar stop al servicio-emulador (no ejecutar directo)
     log('recursos', '🔌 Encolando stop de emulador idle para liberar ~2.5GB RAM');
@@ -2332,32 +2352,25 @@ function preflightQaChecks(issue) {
     return { ok: false, result: 'waiting:emulator', reason: 'Emulador no disponible — requiere activación de ventana QA', flavors, requiresEmulator: true, qaMode: 'android' };
   }
 
-  // Blindaje 2: Mini screenrecord de prueba (2s) para verificar que ADB puede grabar
-  // Si falla, reintentar hasta 3 veces con espera progresiva
+  // Blindaje 2: Mini screenrecord de prueba (2s) para verificar que ADB puede grabar.
+  // Con el gating de boot real en qa-environment.waitBootCompleted(), el framework
+  // ya está listo antes de llegar acá, así que un solo intento es suficiente.
+  // Si falla, es ADB realmente inestable y conviene abortar el preflight rápido.
   let screenrecordOk = false;
-  const maxRetries = 3;
-  for (let attempt = 1; attempt <= maxRetries; attempt++) {
-    try {
-      // Grabar 2 segundos de prueba
-      execSync(
-        `adb -s ${emulatorSerial} shell "screenrecord --time-limit 2 /sdcard/qa-preflight-test.mp4 && ls -l /sdcard/qa-preflight-test.mp4 && rm -f /sdcard/qa-preflight-test.mp4"`,
-        { encoding: 'utf8', timeout: 15000, windowsHide: true }
-      );
-      screenrecordOk = true;
-      log('preflight', `#${issue}: check 4b OK — screenrecord test passed (intento ${attempt}/${maxRetries})`);
-      break;
-    } catch (e) {
-      log('preflight', `#${issue}: check 4b — screenrecord test FAIL intento ${attempt}/${maxRetries}: ${e.message.slice(0, 60)}`);
-      if (attempt < maxRetries) {
-        // Espera progresiva: 3s, 6s
-        execSync(`sleep ${attempt * 3}`, { windowsHide: true });
-      }
-    }
+  try {
+    execSync(
+      `adb -s ${emulatorSerial} shell "screenrecord --time-limit 2 /sdcard/qa-preflight-test.mp4 && ls -l /sdcard/qa-preflight-test.mp4 && rm -f /sdcard/qa-preflight-test.mp4"`,
+      { encoding: 'utf8', timeout: 15000, windowsHide: true }
+    );
+    screenrecordOk = true;
+    log('preflight', `#${issue}: check 4b OK — screenrecord test passed`);
+  } catch (e) {
+    log('preflight', `#${issue}: check 4b FAIL — screenrecord: ${e.message.slice(0, 80)}`);
   }
 
   if (!screenrecordOk) {
     checks.emulator = 'screenrecord-fail';
-    log('preflight', `#${issue}: check 4b FAIL — screenrecord no funciona despues de ${maxRetries} intentos → blocked:infra`);
+    log('preflight', `#${issue}: check 4b FAIL — screenrecord no funciona → blocked:infra`);
     logPreflight(issue, checks, 'blocked:infra', startMs);
     sendBlockedInfraNotif(issue, `⚠️ Pre-flight QA #${issue}: emulador disponible pero screenrecord no funciona. Posible ADB inestable — reintentando en proxima ventana.`);
     return { ok: false, result: 'blocked:infra', reason: 'Screenrecord no funciona — ADB inestable', flavors, requiresEmulator: true, qaMode: 'android' };

--- a/.pipeline/qa-environment.js
+++ b/.pipeline/qa-environment.js
@@ -21,8 +21,89 @@ const STATE_FILE = path.join(PIPELINE, 'qa-env-state.json');
 const ADB = 'C:\\Users\\Administrator\\AppData\\Local\\Android\\Sdk\\platform-tools\\adb.exe';
 const EMULATOR = 'C:\\Users\\Administrator\\AppData\\Local\\Android\\Sdk\\emulator\\emulator.exe';
 
+// Snapshot conocido-bueno (docs/qa/android-emulator, memoria android-emulator.md).
+// Usamos -snapshot + -no-snapshot-save para arrancar desde un estado estable
+// y NO reescribir el quickboot en cada stop (los ciclos rápidos lo corrompían).
+const EMULATOR_ARGS = [
+  '-avd', 'virtualAndroid',
+  '-no-window', '-no-audio',
+  '-gpu', 'swiftshader_indirect',
+  '-snapshot', 'qa-ready',
+  '-no-snapshot-save',
+];
+
+// Timeouts del gating de boot
+const BOOT_TIMEOUT_MS = 180000;  // 3 minutos de margen total para boot
+const BOOT_POLL_MS = 1000;       // poll cada segundo
+
 function log(msg) {
   console.log(`[${new Date().toISOString().replace('T',' ').slice(0,19)}] [qa-env] ${msg}`);
+}
+
+// Sleep sincrónico portable a Windows (no usa el comando shell `sleep`,
+// que no existe en cmd.exe — ver pulpo.js:2067 para el patrón).
+function sleepSync(ms) {
+  try {
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+  } catch {
+    // Fallback si SharedArrayBuffer no está disponible
+    const end = Date.now() + ms;
+    while (Date.now() < end) { /* spin */ }
+  }
+}
+
+// Espera que el framework de Android esté REALMENTE listo:
+//   1. adbd escuchando (wait-for-device)
+//   2. sys.boot_completed == 1
+//   3. init.svc.bootanim == stopped
+//   4. el service manager tiene `settings` (evita race con `settings put`)
+// En laboratorio (fresh boot desde snapshot) esto tarda ~13-30s.
+function waitBootCompleted(timeoutMs = BOOT_TIMEOUT_MS) {
+  const t0 = Date.now();
+  execSync(`"${ADB}" wait-for-device`, { timeout: timeoutMs, windowsHide: true });
+
+  const deadline = t0 + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const bc = execSync(`"${ADB}" shell getprop sys.boot_completed`,
+        { encoding: 'utf8', timeout: 5000, windowsHide: true }).trim();
+      const anim = execSync(`"${ADB}" shell getprop init.svc.bootanim`,
+        { encoding: 'utf8', timeout: 5000, windowsHide: true }).trim();
+      if (bc === '1' && anim === 'stopped') {
+        const svc = execSync(`"${ADB}" shell service check settings`,
+          { encoding: 'utf8', timeout: 5000, windowsHide: true });
+        if (svc.includes('found')) {
+          const elapsed = Math.round((Date.now() - t0) / 1000);
+          log(`  Boot completo confirmado en ${elapsed}s (boot_completed=1, bootanim=stopped, service settings=found)`);
+          return true;
+        }
+      }
+    } catch { /* retry */ }
+    sleepSync(BOOT_POLL_MS);
+  }
+  throw new Error(`Boot del emulador no completado dentro de ${Math.round(timeoutMs/1000)}s`);
+}
+
+// Devuelve el PID real del proceso QEMU del emulador (o null si no corre).
+// Lo usamos después del boot para reemplazar el PID del wrapper emulator.exe
+// por el del worker real de QEMU, que es el que persiste.
+function detectQemuPid() {
+  try {
+    const out = execSync(
+      'tasklist /FI "IMAGENAME eq qemu-system-x86_64-headless.exe" /NH /FO CSV',
+      { encoding: 'utf8', timeout: 5000, windowsHide: true, stdio: ['pipe', 'pipe', 'ignore'] }
+    );
+    // Formato CSV: "qemu-system-x86_64-headless.exe","1234","Console","1","234,567 KB"
+    // Campo [0] = imagen, [1] = PID, [2] = session, [3] = session#, [4] = mem.
+    const line = out.split('\n').find(l => l.toLowerCase().includes('qemu-system'));
+    if (!line) return null;
+    const fields = line.match(/"([^"]*)"/g);
+    if (fields && fields.length >= 2) {
+      const pid = parseInt(fields[1].replace(/"/g, ''), 10);
+      if (!isNaN(pid) && pid > 0) return pid;
+    }
+  } catch { /* fallthrough */ }
+  return null;
 }
 
 function saveState(state) {
@@ -51,29 +132,33 @@ function startAll() {
 
   // Emulador Android (único componente local)
   if (!isAlive(state.emulator)) {
-    log('Levantando emulador Android (virtualAndroid)...');
-    const emu = spawn(EMULATOR, [
-      '-avd', 'virtualAndroid', '-no-window', '-no-audio', '-gpu', 'swiftshader_indirect'
-    ], {
+    log('Levantando emulador Android (virtualAndroid, snapshot qa-ready)...');
+    const emu = spawn(EMULATOR, EMULATOR_ARGS, {
       stdio: 'ignore', detached: true, windowsHide: true
     });
     emu.unref();
-    state.emulator = emu.pid;
-    log(`  Emulador PID: ${emu.pid}`);
+    log(`  Wrapper PID: ${emu.pid} — esperando boot completo...`);
 
-    // Desactivar animaciones después de boot (~60s)
-    log('  Esperando boot del emulador (60s)...');
-    setTimeout(() => {
-      try {
-        execSync(`"${ADB}" wait-for-device`, { timeout: 120000, windowsHide: true });
-        execSync(`"${ADB}" shell settings put global window_animation_scale 0`, { windowsHide: true });
-        execSync(`"${ADB}" shell settings put global transition_animation_scale 0`, { windowsHide: true });
-        execSync(`"${ADB}" shell settings put global animator_duration_scale 0`, { windowsHide: true });
-        log('  Animaciones desactivadas');
-      } catch (e) {
-        log(`  Error configurando emulador: ${e.message}`);
-      }
-    }, 5000); // adb wait-for-device maneja el timing
+    // Gating REAL: esperar a que el framework esté listo antes de terminar.
+    // Si esto falla, el catch re-lanza para que el servicio lo sepa.
+    try {
+      waitBootCompleted();
+      execSync(`"${ADB}" shell settings put global window_animation_scale 0`, { windowsHide: true });
+      execSync(`"${ADB}" shell settings put global transition_animation_scale 0`, { windowsHide: true });
+      execSync(`"${ADB}" shell settings put global animator_duration_scale 0`, { windowsHide: true });
+      log('  Animaciones desactivadas');
+    } catch (e) {
+      log(`  Error esperando boot del emulador: ${e.message}`);
+      throw e; // propagar al servicio emulador
+    }
+
+    // Tras boot completo, persistir el PID REAL del worker QEMU
+    // (el wrapper emulator.exe puede terminar después del spawn).
+    const qemuPid = detectQemuPid();
+    state.emulator = qemuPid || emu.pid;
+    // Anchor del grace period post-boot (leído por pulpo.shutdownIdleEmulator)
+    state.lastStartedAt = Date.now();
+    log(`  Emulador PID real (QEMU): ${state.emulator}`);
   } else {
     log(`Emulador ya corriendo (PID ${state.emulator})`);
   }
@@ -96,7 +181,21 @@ function stopAll() {
     }
   }
 
-  saveState({ emulator: null });
+  // Fallback: matar QEMU por nombre si quedó huérfano (state.emulator stale,
+  // wrapper muerto pero QEMU vivo, etc). Mismo patrón que servicio-emulador.doStop.
+  try {
+    const check = execSync(
+      'tasklist /FI "IMAGENAME eq qemu-system-x86_64-headless.exe" /NH /FO CSV',
+      { encoding: 'utf8', timeout: 5000, windowsHide: true, stdio: ['pipe', 'pipe', 'ignore'] }
+    );
+    if (check.includes('qemu-system')) {
+      execSync('taskkill /IM qemu-system-x86_64-headless.exe /F /T',
+        { timeout: 10000, windowsHide: true, stdio: 'ignore' });
+      log('QEMU matado por nombre (fallback)');
+    }
+  } catch { /* no qemu running — ok */ }
+
+  saveState({ emulator: null, lastStartedAt: 0 });
   log('QA Environment detenido');
 }
 
@@ -134,22 +233,26 @@ function startOne(component) {
   }
 
   if (component === 'emulator' && !isAlive(state.emulator)) {
-    log('Levantando emulador Android (virtualAndroid)...');
-    const emu = spawn(EMULATOR, [
-      '-avd', 'virtualAndroid', '-no-window', '-no-audio', '-gpu', 'swiftshader_indirect'
-    ], { stdio: 'ignore', detached: true, windowsHide: true });
+    log('Levantando emulador Android (virtualAndroid, snapshot qa-ready)...');
+    const emu = spawn(EMULATOR, EMULATOR_ARGS, {
+      stdio: 'ignore', detached: true, windowsHide: true
+    });
     emu.unref();
-    state.emulator = emu.pid;
-    log(`  Emulador PID: ${emu.pid}`);
-    setTimeout(() => {
-      try {
-        execSync(`"${ADB}" wait-for-device`, { timeout: 120000, windowsHide: true });
-        execSync(`"${ADB}" shell settings put global window_animation_scale 0`, { windowsHide: true });
-        execSync(`"${ADB}" shell settings put global transition_animation_scale 0`, { windowsHide: true });
-        execSync(`"${ADB}" shell settings put global animator_duration_scale 0`, { windowsHide: true });
-        log('  Animaciones desactivadas');
-      } catch (e) { log(`  Error configurando emulador: ${e.message}`); }
-    }, 5000);
+    log(`  Wrapper PID: ${emu.pid} — esperando boot completo...`);
+    try {
+      waitBootCompleted();
+      execSync(`"${ADB}" shell settings put global window_animation_scale 0`, { windowsHide: true });
+      execSync(`"${ADB}" shell settings put global transition_animation_scale 0`, { windowsHide: true });
+      execSync(`"${ADB}" shell settings put global animator_duration_scale 0`, { windowsHide: true });
+      log('  Animaciones desactivadas');
+    } catch (e) {
+      log(`  Error esperando boot del emulador: ${e.message}`);
+      throw e;
+    }
+    const qemuPid = detectQemuPid();
+    state.emulator = qemuPid || emu.pid;
+    state.lastStartedAt = Date.now();
+    log(`  Emulador PID real (QEMU): ${state.emulator}`);
   } else {
     log(`${component} ya corriendo o no reconocido`);
   }


### PR DESCRIPTION
## Contexto

Después del restart con los cambios de #2128 (servicio-emulador microservicio), el pipeline quedó sin lanzar agentes. Pulpo rompía en loop con `[pulpo] ERROR en ciclo: Command failed: sleep 3` y el emulador entraba en ciclo perverso start/stop cada ~1 min.

## Diagnóstico (reproducido en laboratorio)

Levantando un emulador con los mismos flags que `qa-environment.js` y corriendo el **mismo comando** que ejecuta `pulpo.js:2342`:

| Estado del framework | `sys.boot_completed` | `bootanim` | Resultado del check 4b |
|---|---|---|---|
| Post `adb wait-for-device` | *(vacío)* | `running` | ❌ `Unable to open '/sdcard/qa-preflight-test.mp4': No such file or directory` |
| Post `sys.boot_completed=1` (13s después) | `1` | `stopped` | ✅ MP4 de 208 KB generado, exit 0 |
| Post `sys.boot_completed=1` (repetición) | `1` | `stopped` | ✅ MP4 de 67 KB, exit 0 |

**Causa raíz**: `wait-for-device` solo verifica `adbd`, no el framework. Por eso `settings put` mostraba `cmd: Can't find service: settings` en cada arranque y `screenrecord` corría antes de que el storage daemon tuviera `/sdcard` listo.

**Causas amplificadoras**:
- `execSync(\`sleep N\`)` en `pulpo.js:2353` — el retry del check 4b crasheaba pulpo porque `sleep` no existe en `cmd.exe` de Windows.
- `pulpo-idle` apagaba el emulador durante el warm-up → `saveOnExit=true` persistía un quickboot corrupto → siguiente arranque degradado → ETIMEDOUT a los 2 min.
- El PID persistido era el del wrapper `emulator.exe`, no el del worker `qemu-system-x86_64-headless.exe`.
- El snapshot `qa-ready` existía pero el pipeline nunca lo usaba.

## Cambios

### `qa-environment.js`
- `waitBootCompleted()` espera las tres señales reales: `sys.boot_completed=1`, `init.svc.bootanim=stopped` y `service check settings → found`.
- Spawn usa `-snapshot qa-ready -no-snapshot-save` → arranque rápido y estable, sin ensuciar el quickboot.
- `settings put` corre sincrónico DESPUÉS del boot real (no desde un `setTimeout` en background).
- `detectQemuPid()` persiste el PID real del proceso QEMU en `qa-env-state.json` (parser CSV de `tasklist` corregido).
- `state.lastStartedAt` anchor para el grace period.
- `stopAll()` fallback `taskkill /IM` por nombre de imagen cuando el PID está stale.
- `sleepSync()` portable con `Atomics.wait` (sin shell hacks).

### `pulpo.js`
- Retry del screenrecord ya no usa `execSync('sleep N')`. Con gating real, un único intento es suficiente.
- `shutdownIdleEmulator()` respeta `EMULATOR_IDLE_GRACE_MS = 3 min` desde `state.lastStartedAt`, y no apaga si hay algo en `verificacion/pendiente` (no sólo `trabajando`).

## Evidencia (post-fix, corrida en vivo)

### 1. `qa-environment.js start` con los fixes
\`\`\`
[qa-env] Levantando emulador Android (virtualAndroid, snapshot qa-ready)...
[qa-env]   Wrapper PID: 11224 — esperando boot completo...
[qa-env]   Boot completo confirmado en 5s (boot_completed=1, bootanim=stopped, service settings=found)
[qa-env]   Animaciones desactivadas
[qa-env]   Emulador PID real (QEMU): 16016
[qa-env] QA Environment listo
\`\`\`
Ya **no aparece** `cmd: Can't find service: settings`. Boot en 5 s desde el snapshot.

### 2. `qa-env-state.json`
\`\`\`json
{ "emulator": 16016, "lastStartedAt": 1775955116606 }
\`\`\`
Coincide con `tasklist`: `"qemu-system-x86_64-headless.exe","16016","Console","1","2,752,332 KB"`

### 3. Screenrecord — mismo comando que `pulpo.js:2342`
\`\`\`
$ adb shell "screenrecord --time-limit 2 /sdcard/qa-preflight-test.mp4 && ls -l ..."
-rw-rw---- 1 u0_a192 media_rw 56575 2026-04-12 00:52 /sdcard/qa-preflight-test.mp4
exit=0

$ adb shell 'getprop sys.boot_completed; getprop init.svc.bootanim; service check settings'
1
stopped
Service settings: found
\`\`\`

### 4. Grace period (unit test de la lógica)
\`\`\`
recién arrancado (0s)     → {"shutdown":false,"remainingSec":180}
1 min atrás               → {"shutdown":false,"remainingSec":120}
2 min atrás               → {"shutdown":false,"remainingSec":60}
3 min atrás (borde)       → {"shutdown":true}
5 min atrás               → {"shutdown":true}
sin state (0)             → {"shutdown":true}
\`\`\`

### 5. Stop limpio + fallback kill-by-name
\`\`\`
[qa-env] Stopped emulator (PID 16016)
[qa-env] QA Environment detenido
$ tasklist | grep qemu-system → (vacío)
\`\`\`

## Deploy

Los fixes están en el repo principal pero el `svc-emulador` y `pulpo` actualmente corriendo tienen el código viejo en memoria. **Al mergear hay que reiniciar los servicios** para que carguen el código nuevo:

\`\`\`
node .pipeline/restart.js
\`\`\`

> Recordatorio (memoria `no-restart-from-bash.md`): no ejecutar `restart.js` desde Git Bash — los hijos mueren con el padre. Usar `cmd.exe` / PowerShell.

## QA gate

Etiquetado `qa:skipped` con justificación: cambio puro de infraestructura del pipeline (gating de boot y retry portable), sin impacto en producto de usuario ni en módulos build/app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)