### PR TITLE
fix(pipeline): capturar logs de agentes en Windows (closeSync en exit)

### DIFF
--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -2673,7 +2673,9 @@ function lanzarAgenteClaude(skill, issue, trabajandoPath, pipeline, fase, config
   });
 
   child.unref();
-  fs.closeSync(agentLogFd);
+  // NO cerrar agentLogFd aquí — en Windows, cerrar el FD en el padre
+  // mata la herencia y el hijo pierde stdout/stderr.
+  // Se cierra en child.on('exit') para que el log capture todo el output.
 
   activeProcesses.set(processKey(skill, issue), {
     pid: child.pid,
@@ -2709,6 +2711,9 @@ function lanzarAgenteClaude(skill, issue, trabajandoPath, pipeline, fase, config
   // Cuando el proceso termina, mover de trabajando → listo
   const launchTime = Date.now();
   child.on('exit', (code) => {
+    // Cerrar el FD del log ahora que el hijo terminó
+    try { fs.closeSync(agentLogFd); } catch {}
+
     const elapsedSec = (Date.now() - launchTime) / 1000;
 
     // Si murió en menos de 15 segundos con error → fallo de infra + COOLDOWN


### PR DESCRIPTION
## Resumen

- Mover `fs.closeSync(agentLogFd)` del spawn inmediato al handler `child.on('exit')` para que el output de los agentes Claude se capture correctamente en Windows
- En Windows, cerrar un FD heredado en el padre invalida la referencia en el hijo — todo el stdout/stderr del agente se perdía

## Contexto

Los logs de agentes en el dashboard mostraban solo la línea de header y nada más. Causa raíz: el FD se cerraba inmediatamente después del `spawn()`, antes de que el hijo pudiera escribir.

## Test plan

- [x] Verificar que después de restart, los logs de agentes muestran output real
- [x] Cambio mínimo (6 líneas), sin riesgo de regresión

QA Validate: omitido — fix de infra/pipeline sin impacto en producto de usuario ⚠️

🤖 Generado con [Claude Code](https://claude.ai/claude-code)