### PR TITLE
fix(pipeline): restaurar priority windows al reiniciar pulpo

### DIFF
--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -894,6 +894,37 @@ let buildPrioritySafetyNotified = false; // true si ya se envió notificación d
 const PRIORITY_WINDOWS_FILE = path.join(PIPELINE, 'priority-windows.json');
 
 /**
+ * Restaurar el estado de priority windows desde disco al iniciar.
+ * Sin esto, un restart del pulpo pierde la ventana activa y lanza dev
+ * aunque QA/Build estuviera bloqueando.
+ */
+function restorePriorityWindows() {
+  try {
+    if (!fs.existsSync(PRIORITY_WINDOWS_FILE)) return;
+    const data = JSON.parse(fs.readFileSync(PRIORITY_WINDOWS_FILE, 'utf8'));
+    if (data.qa?.active) {
+      qaPriorityActive = true;
+      qaPriorityActivatedAt = data.qa.activatedAt || Date.now();
+      qaPriorityManual = data.qa.manual || false;
+      qaPriorityNotifiedTelegram = true; // Ya se notificó antes del restart
+      log('qa-priority', `♻️ QA Priority Window restaurada desde disco (activada ${new Date(qaPriorityActivatedAt).toISOString()})`);
+    }
+    if (data.build?.active) {
+      buildPriorityActive = true;
+      buildPriorityActivatedAt = data.build.activatedAt || Date.now();
+      buildPriorityManual = data.build.manual || false;
+      buildPriorityNotifiedTelegram = true;
+      log('build-priority', `♻️ Build Priority Window restaurada desde disco (activada ${new Date(buildPriorityActivatedAt).toISOString()})`);
+    }
+  } catch (e) {
+    log('priority', `⚠️ Error restaurando priority windows: ${e.message}`);
+  }
+}
+
+// Restaurar al cargar el módulo
+restorePriorityWindows();
+
+/**
  * Persistir el estado actual de las priority windows a disco.
  * El dashboard lee este archivo para mostrar estado y el usuario puede
  * activar/desactivar ventanas manualmente escribiendo en él.


### PR DESCRIPTION
## Resumen

- Al reiniciar el pulpo, las priority windows (QA/Build) se perdían porque las variables in-memory se inicializaban en `false` sin leer el estado persistido en `priority-windows.json`
- Esto causaba que `dev` se lanzara aunque la ventana QA estuviera activa (ej: backend-dev:#1951 con QA window activa)
- Se agrega `restorePriorityWindows()` que lee el JSON al inicio y restaura el estado completo

## Contexto

Detectado durante diagnóstico de pipeline: tras restart, el pulpo lanzó `backend-dev:#1951` ignorando la ventana QA activa.

## Test plan

- [x] Verificar que tras restart, `qaPriorityActive` se restaura desde disco
- [x] Cambio aditivo (31 líneas), sin riesgo de regresión

QA Validate: omitido — fix de infra/pipeline sin impacto en producto de usuario ⚠️

🤖 Generado con [Claude Code](https://claude.ai/claude-code)