### PR TITLE
fix(pipeline): logs progresivos con stream-json en dashboard

### DIFF
--- a/.pipeline/dashboard-v2.js
+++ b/.pipeline/dashboard-v2.js
@@ -2024,9 +2024,50 @@ function classifyLine(text) {
   return '';
 }
 
+/** Parsear una línea de stream-json de Claude CLI a texto legible para el log viewer */
+function parseStreamJsonLine(raw) {
+  if (!raw || !raw.startsWith('{')) return raw; // No es JSON, devolver tal cual
+  try {
+    const ev = JSON.parse(raw);
+    switch (ev.type) {
+      case 'system':
+        if (ev.subtype === 'init') return '[init] modelo: ' + (ev.model || '?') + ' | tools: ' + (ev.tools || []).length;
+        return '[system] ' + (ev.subtype || '') + ' ' + (ev.message || '');
+      case 'assistant':
+        if (ev.subtype === 'text') return ev.content || '';
+        if (ev.subtype === 'tool_use') {
+          var name = ev.tool_name || ev.name || '?';
+          var inp = '';
+          try {
+            var input = ev.input || ev.tool_input || {};
+            if (input.command) inp = ': ' + input.command.substring(0, 120);
+            else if (input.pattern) inp = ': ' + input.pattern;
+            else if (input.file_path) inp = ': ' + input.file_path;
+            else if (input.skill) inp = ': ' + input.skill;
+            else if (input.query) inp = ': ' + input.query.substring(0, 80);
+          } catch(_) {}
+          return '[Tool] ' + name + inp;
+        }
+        return ev.content || JSON.stringify(ev).substring(0, 200);
+      case 'result':
+        var cost = ev.cost_usd ? ' ($' + ev.cost_usd.toFixed(4) + ')' : '';
+        var dur = ev.duration_ms ? ' ' + Math.round(ev.duration_ms / 1000) + 's' : '';
+        return '[result] ' + (ev.subtype || 'done') + cost + dur;
+      default:
+        // Otros tipos: mostrar tipo + contenido resumido
+        if (ev.content) return '[' + ev.type + '] ' + (typeof ev.content === 'string' ? ev.content.substring(0, 200) : JSON.stringify(ev.content).substring(0, 200));
+        return raw.substring(0, 200);
+    }
+  } catch(_) {
+    return raw; // Parse falló, devolver raw
+  }
+}
+
 function renderLine(text, idx) {
-  const cls = classifyLine(text);
-  const escaped = text.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+  var display = parseStreamJsonLine(text);
+  if (!display || !display.trim()) return ''; // Skip empty lines
+  var cls = classifyLine(display);
+  var escaped = display.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
   return '<div class="log-line ' + cls + '" data-idx="' + idx + '"><span class="log-line-num">' + (idx + 1) + '</span><span class="log-line-text">' + escaped + '</span></div>';
 }
 

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -2681,7 +2681,7 @@ function lanzarAgenteClaude(skill, issue, trabajandoPath, pipeline, fase, config
     }
   }
 
-  const args = ['-p', userPrompt, '--system-prompt-file', systemFile, '--output-format', 'text', '--verbose', '--permission-mode', 'bypassPermissions'];
+  const args = ['-p', userPrompt, '--system-prompt-file', systemFile, '--output-format', 'stream-json', '--verbose', '--permission-mode', 'bypassPermissions'];
 
   log('lanzamiento', `Lanzando ${skill}:#${issue} (fase: ${fase}, pipeline: ${pipeline})`);
 


### PR DESCRIPTION
## Resumen

- Cambiar `--output-format text` → `stream-json` en lanzamiento de agentes Claude para output progresivo (text solo emite al finalizar)
- Agregar `parseStreamJsonLine()` en dashboard que convierte eventos JSON a texto legible: tool calls, text output, init, result con costo
- `renderLine()` parsea stream-json transparentemente; líneas no-JSON pasan sin cambios

## Contexto

Los logs de agentes en el dashboard estaban vacíos durante la ejecución porque `--output-format text` buferea todo hasta el final. Con `stream-json`, Claude emite cada evento en tiempo real.

## Test plan

- [x] Test local confirmó que stream-json emite progresivamente a FD heredado
- [x] Parser maneja gracefully líneas no-JSON (headers, texto plano)
- [x] Lógica de resultado (aprobado/rechazado) no depende del output format

QA Validate: omitido — fix de infra/pipeline sin impacto en producto de usuario ⚠️

🤖 Generado con [Claude Code](https://claude.ai/claude-code)