### PR TITLE
fix(pipeline): QA role ignora .env.local, siempre backend remoto

### DIFF
--- a/.pipeline/roles/qa.md
+++ b/.pipeline/roles/qa.md
@@ -34,6 +34,10 @@ else (QA_MODE == "android" o vacío):
 
 Backend y DynamoDB/Cognito son **SIEMPRE remotos** (Lambda AWS). NO existe modo local.
 
+**CRITICO: NUNCA leer ni usar `.env.local`, `.env`, ni ningún archivo de configuración local.**
+Estos archivos pueden contener `LOCAL_MODE=true` o endpoints `localhost` que NO aplican a QA.
+Ignoralos completamente — los únicos valores válidos son los de abajo:
+
 - **Backend**: Lambda AWS en `https://mgnr0htbvd.execute-api.us-east-2.amazonaws.com/dev`
 - **DynamoDB/Cognito**: servicios reales de AWS (no local)
 - **Emulador Android**: AVD `virtualAndroid` (sin ventana, sin audio) — solo para QA_MODE=android


### PR DESCRIPTION
## Resumen

- Agregar instrucción explícita en `qa.md` para que el agente QA NUNCA lea `.env.local` ni archivos `.env`
- Borrado `.env.local` huérfano del repo principal que tenía `LOCAL_MODE=true` con endpoints a localhost

## Contexto

QA de #1920 falló porque el agente leyó `.env.local`, encontró `LOCAL_MODE=true` y endpoints `localhost:8000`/`localhost:5050`, y falló al conectar.

QA Validate: omitido — fix de infra/pipeline ⚠️

🤖 Generado con [Claude Code](https://claude.ai/claude-code)