### PR TITLE
feat(pipeline): rejection report v4.2 — audio TTS + mejoras detalle

### DIFF
--- a/.pipeline/rejection-report.js
+++ b/.pipeline/rejection-report.js
@@ -714,6 +714,69 @@ function analyzeRejection(code, elapsed, motivo, logTail, avgCpu, avgMem, skill)
   return result;
 }
 
+// --- Generar narración en texto plano para TTS ---
+function generateNarration() {
+  const issueCtx = fetchIssueContext(issue);
+  const rootCause = classifyRootCause(motivo, readLastLines(path.join(LOG_DIR, logFile), 80), exitCode);
+  const analysis = analyzeRejection(exitCode, elapsed, motivo, readLastLines(path.join(LOG_DIR, logFile), 80),
+    (() => { const m = getRecentMetrics(10); return m.length > 0 ? Math.round(m.reduce((s, x) => s + x.cpu, 0) / m.length) : 0; })(),
+    (() => { const m = getRecentMetrics(10); return m.length > 0 ? Math.round(m.reduce((s, x) => s + x.mem, 0) / m.length) : 0; })(),
+    skill);
+  const rejectHistory = getRejectHistory(issue);
+  const depIssues = fetchDependencyIssues(issue);
+
+  const parts = [];
+
+  // Intro
+  parts.push(`Reporte de rechazo del issue número ${issue}, que estaba en la fase de ${fase} con el agente ${skill}.`);
+
+  // Qué se estaba haciendo
+  parts.push(`El issue se llama "${issueCtx.title}". ${issueCtx.summary}`);
+
+  // Qué pasó
+  parts.push(`¿Qué pasó? ${rootCause.negocio || rootCause.desc}`);
+
+  // Causa raíz
+  const origenTexto = rootCause.origen === 'EXTERNO'
+    ? 'El problema es externo, no es culpa de este issue.'
+    : rootCause.origen === 'INTERNO'
+    ? 'El problema está en los cambios de este issue, requiere corrección del desarrollador.'
+    : 'No se pudo determinar automáticamente si es un problema interno o externo.';
+  parts.push(`Causa raíz: ${rootCause.desc}. Clasificación: ${rootCause.tipo}. ${origenTexto}`);
+
+  // Historial
+  if (rejectHistory.length > 1) {
+    parts.push(`Este issue ya fue rechazado ${rejectHistory.length} veces. Los rechazos anteriores fueron por: ${rejectHistory.map(h => h.skill + ' en fase ' + h.fase).join(', ')}.`);
+  }
+
+  // Análisis y solución
+  parts.push(`Análisis de la situación: ${analysis.conclusion}`);
+  if (analysis.factors.length > 0) {
+    parts.push(`Factores que contribuyeron: ${analysis.factors.join('. ')}.`);
+  }
+  parts.push(`Para desbloquearlo: ${analysis.suggestion}`);
+  if (analysis.steps.length > 0) {
+    parts.push(`Pasos concretos: ${analysis.steps.map((s, i) => (i + 1) + ', ' + s).join('. ')}.`);
+  }
+
+  // Dependencias
+  if (depIssues.isBlocked || depIssues.linkedDeps.length > 0) {
+    const openDeps = depIssues.linkedDeps.filter(d => d.state === 'OPEN');
+    const closedDeps = depIssues.linkedDeps.filter(d => d.state === 'CLOSED');
+    parts.push(`Este issue está bloqueado por dependencias.`);
+    if (depIssues.linkedDeps.length > 0) {
+      parts.push(`QA creó ${depIssues.linkedDeps.length} issues de dependencia: ${depIssues.linkedDeps.map(d => 'número ' + d.number + ', ' + d.title + ', estado ' + (d.state === 'OPEN' ? 'pendiente' : 'resuelto')).join('. ')}.`);
+    }
+    if (openDeps.length > 0) {
+      parts.push(`Hay ${openDeps.length} dependencias pendientes de resolver. No se debe reintentar hasta que se cierren.`);
+    } else if (closedDeps.length > 0) {
+      parts.push(`Todas las dependencias están resueltas. Se puede reintentar la validación.`);
+    }
+  }
+
+  return parts.join(' ');
+}
+
 // --- Main ---
 async function main() {
   try {
@@ -754,6 +817,51 @@ async function main() {
     try { fs.unlinkSync(path.join(ROOT, 'docs', 'qa', `rejection-${issue}-${skill}.html`)); } catch {}
 
     console.log(`[rejection-report] Reporte enviado a Telegram para #${issue} ${skill}`);
+
+    // --- Audio TTS del reporte ---
+    try {
+      const { textToSpeech, sendVoiceTelegram } = require('./multimedia');
+      const TG_CONFIG = path.join(ROOT, '.claude', 'hooks', 'telegram-config.json');
+      const tgConfig = JSON.parse(fs.readFileSync(TG_CONFIG, 'utf8'));
+
+      const narration = generateNarration();
+      console.log(`[rejection-report] Generando audio TTS (${narration.length} chars)...`);
+
+      // TTS tiene limite de ~4096 chars — partir en chunks si es necesario
+      const MAX_TTS_CHARS = 3800;
+      const chunks = [];
+      if (narration.length <= MAX_TTS_CHARS) {
+        chunks.push(narration);
+      } else {
+        // Partir por oraciones, respetando el limite
+        const sentences = narration.split(/(?<=[.!?])\s+/);
+        let current = '';
+        for (const sentence of sentences) {
+          if ((current + ' ' + sentence).length > MAX_TTS_CHARS && current.length > 0) {
+            chunks.push(current.trim());
+            current = sentence;
+          } else {
+            current = current ? current + ' ' + sentence : sentence;
+          }
+        }
+        if (current.trim()) chunks.push(current.trim());
+      }
+
+      for (let i = 0; i < chunks.length; i++) {
+        const chunkText = chunks.length > 1
+          ? `Parte ${i + 1} de ${chunks.length}. ${chunks[i]}`
+          : chunks[i];
+        const audioBuffer = await textToSpeech(chunkText);
+        if (audioBuffer) {
+          const sent = await sendVoiceTelegram(audioBuffer, tgConfig.bot_token, tgConfig.chat_id);
+          console.log(`[rejection-report] Audio ${i + 1}/${chunks.length} enviado: ${sent ? 'OK' : 'FALLO'}`);
+        } else {
+          console.log(`[rejection-report] No se pudo generar audio TTS (chunk ${i + 1})`);
+        }
+      }
+    } catch (audioErr) {
+      console.error(`[rejection-report] Error generando audio TTS (no fatal): ${audioErr.message}`);
+    }
   } catch (e) {
     console.error(`[rejection-report] Error: ${e.message}`);
     process.exit(1);

--- a/.pipeline/rejection-report.js
+++ b/.pipeline/rejection-report.js
@@ -336,6 +336,9 @@ function generateReport() {
   // 12. Log legible (no JSON crudo)
   const readableLog = extractMeaningfulLog(logTail, 30);
 
+  // 13. Issues de dependencia creados por QA (V9)
+  const depIssues = fetchDependencyIssues(issue);
+
   // --- HTML ---
   return `<!DOCTYPE html>
 <html><head><meta charset="utf-8">
@@ -477,6 +480,23 @@ ${skillProfile ? `
   ${analysis.externalDeps && analysis.externalDeps.length > 0 ? '<h3>Dependencias externas detectadas</h3><ul>' + analysis.externalDeps.map(d => '<li>🔗 ' + escapeHtml(d) + '</li>').join('') + '</ul><p><em>Estas dependencias deberian resolverse en issues separados antes de reintentar la validacion de este issue.</em></p>' : ''}
 </div>
 
+${depIssues.linkedDeps.length > 0 || depIssues.isBlocked ? `
+<h2>Issues de Dependencia Creados</h2>
+<div class="${depIssues.isBlocked ? 'rootcause-box' : 'history-box'}">
+  ${depIssues.isBlocked ? '<p>⛔ <strong>Este issue esta BLOQUEADO</strong> — tiene label <span class="badge badge-red">blocked:dependencies</span>. No se puede avanzar hasta que se resuelvan las dependencias listadas abajo.</p>' : ''}
+  ${depIssues.linkedDeps.length > 0 ? `
+  <p>QA creo los siguientes issues como dependencias que deben resolverse antes de reintentar la validacion:</p>
+  <table>
+    <tr><th>Issue</th><th>Titulo</th><th>Estado</th></tr>
+    ${depIssues.linkedDeps.map(d => {
+      const stateIcon = d.state === 'OPEN' ? '🔴 Pendiente' : d.state === 'CLOSED' ? '✅ Resuelto' : d.state;
+      const stateCls = d.state === 'CLOSED' ? 'gate-approved' : 'gate-rejected';
+      return '<tr><td><strong>#' + d.number + '</strong></td><td>' + escapeHtml(d.title) + '</td><td class="' + stateCls + '">' + stateIcon + '</td></tr>';
+    }).join('')}
+  </table>
+  <p><em>${depIssues.linkedDeps.filter(d => d.state === 'OPEN').length > 0 ? '⚠️ Hay dependencias pendientes de resolver. Este issue no debe reintentarse hasta que se cierren.' : '✅ Todas las dependencias estan resueltas. Se puede reintentar la validacion.'}</em></p>` : '<p>El issue esta marcado como bloqueado pero no se encontraron issues de dependencia vinculados.</p>'}
+</div>` : ''}
+
 <h2>Log del Agente (resumen legible)</h2>
 <pre><code>${escapeHtml(readableLog)}</code></pre>
 
@@ -485,9 +505,70 @@ ${skillProfile ? `
 </details>
 
 <div class="footer">
-  Intrale Platform &mdash; Reporte de Rechazo &mdash; v4.0 &mdash; ${escapeHtml(now.toISOString().slice(0, 10))}
+  Intrale Platform &mdash; Reporte de Rechazo &mdash; v4.1 &mdash; ${escapeHtml(now.toISOString().slice(0, 10))}
 </div>
 </body></html>`;
+}
+
+// --- Buscar issues de dependencia creados en GitHub ---
+function fetchDependencyIssues(issueNum) {
+  try {
+    const ghPath = fs.existsSync(GH_CLI) ? GH_CLI : 'gh';
+    // Buscar issues con label qa:dependency que mencionen este issue
+    const raw = execSync(
+      `"${ghPath}" issue list --label "qa:dependency" --json number,title,state,url --repo intrale/platform --limit 50`,
+      { timeout: 15000, stdio: ['pipe', 'pipe', 'pipe'] }
+    ).toString();
+    const allDeps = JSON.parse(raw || '[]');
+
+    // También buscar si el issue actual tiene label blocked:dependencies
+    let isBlocked = false;
+    try {
+      const issueRaw = execSync(
+        `"${ghPath}" issue view ${issueNum} --json labels --repo intrale/platform`,
+        { timeout: 10000, stdio: ['pipe', 'pipe', 'pipe'] }
+      ).toString();
+      const issueData = JSON.parse(issueRaw);
+      isBlocked = (issueData.labels || []).some(l => l.name === 'blocked:dependencies');
+    } catch {}
+
+    // Buscar en comentarios del issue cuáles fueron vinculados como dependencia
+    let linkedDeps = [];
+    try {
+      const commentsRaw = execSync(
+        `"${ghPath}" issue view ${issueNum} --json comments --repo intrale/platform`,
+        { timeout: 10000, stdio: ['pipe', 'pipe', 'pipe'] }
+      ).toString();
+      const comments = JSON.parse(commentsRaw).comments || [];
+      for (const c of comments) {
+        const body = c.body || '';
+        // Buscar menciones de issues de dependencia (#NNN)
+        const matches = body.match(/#(\d+)/g);
+        if (matches && (body.toLowerCase().includes('dependencia') || body.toLowerCase().includes('bloqueado') || body.toLowerCase().includes('dependency'))) {
+          for (const m of matches) {
+            const num = parseInt(m.slice(1));
+            if (num !== parseInt(issueNum)) {
+              const depInfo = allDeps.find(d => d.number === num);
+              if (depInfo) linkedDeps.push(depInfo);
+              else linkedDeps.push({ number: num, title: `Issue #${num}`, state: 'OPEN', url: '' });
+            }
+          }
+        }
+      }
+    } catch {}
+
+    // Deduplicar
+    const seen = new Set();
+    linkedDeps = linkedDeps.filter(d => {
+      if (seen.has(d.number)) return false;
+      seen.add(d.number);
+      return true;
+    });
+
+    return { isBlocked, linkedDeps };
+  } catch {
+    return { isBlocked: false, linkedDeps: [] };
+  }
 }
 
 // --- Detectar dependencias externas en el log ---


### PR DESCRIPTION
## Summary
- **rejection-report.js v4.2** — Agrega narración TTS automática al reporte de rechazo
- Después de enviar el PDF, genera audio con el contenido del reporte usando OpenAI TTS
- Si el texto es largo (>3800 chars), lo parte automáticamente en múltiples audios consecutivos
- El audio no es un resumen: es el contenido completo narrado

Incluye también los cambios previos:
- v4.1: Sección de issues de dependencia creados por QA
- v3.0: Contexto del issue, historial de rechazos, clasificación de causa raíz

## Test plan
- [ ] Verificar que rejection-report.js pasa syntax check
- [ ] Verificar que el audio se genera correctamente al rechazar un issue
- [ ] Verificar que textos largos se parten en múltiples audios

🤖 Generated with [Claude Code](https://claude.com/claude-code)