### PR TITLE
feat(pipeline): bloqueo y desbloqueo automático de issues por dependencias

### DIFF
--- a/.claude/skills/guru/SKILL.md
+++ b/.claude/skills/guru/SKILL.md
@@ -84,6 +84,72 @@ de la tecnología relevante para el proyecto:
 Si encontraste una URL relevante (docs oficiales, GitHub, etc.), fetcheala
 para obtener información más detallada.
 
+## Detección de dependencias funcionales (cuando se analiza un issue)
+
+Cuando Guru se ejecuta en la fase de **análisis** del pipeline (el argumento es un número de issue o el contexto indica que se está analizando un issue para el pipeline), agregar este paso DESPUÉS del protocolo de búsqueda:
+
+### Paso 5: Verificar dependencias funcionales
+
+Del body del issue, extraer las funcionalidades que el issue **asume como existentes** (pantallas, endpoints, servicios, componentes). Para cada una:
+
+1. **Buscar en el codebase** si la funcionalidad existe:
+   - Pantallas: Glob `**/sc/**Screen.kt` + Grep por nombre de pantalla
+   - Endpoints: Grep por tag en Kodein / `Function` / `SecuredFunction`
+   - Servicios: Grep por `Comm*` / `Client*` / `ToDo*` / `Do*`
+   - Componentes UI: Glob `**/cp/**` + Grep
+
+2. **Buscar en GitHub** si ya hay un issue abierto que cubra esa funcionalidad:
+   ```bash
+   export PATH="/c/Workspaces/gh-cli/bin:$PATH"
+   gh issue list --repo intrale/platform --search "<keyword de la funcionalidad>" --state open --json number,title --limit 5
+   ```
+
+3. **Si la funcionalidad NO existe en el codebase Y no hay issue abierto** → crear un issue de dependencia:
+   ```bash
+   export PATH="/c/Workspaces/gh-cli/bin:$PATH"
+   gh issue create --repo intrale/platform \
+     --title "dep: <descripción corta de la funcionalidad faltante>" \
+     --body "## Contexto
+   Detectado por Guru durante análisis técnico del issue #<N>.
+
+   ## Funcionalidad requerida
+   <descripción no-técnica de lo que falta>
+
+   ## Por qué es necesario
+   El issue #<N> asume que esta funcionalidad existe pero no está implementada.
+
+   ## Criterio de aceptación
+   - [ ] <criterio verificable>" \
+     --label "needs-definition,qa:dependency" \
+     --assignee leitolarreta
+   ```
+
+4. **Vincular al issue original** con un comentario que referencie la dependencia detectada y el número de issue creado:
+   ```bash
+   gh issue comment <N> --repo intrale/platform --body "🔗 **Dependencia detectada por Guru (análisis técnico):** #<nuevo-issue> — <descripción corta>. Este issue requiere que la funcionalidad anterior exista antes de poder desarrollarse."
+   ```
+
+5. **Si se crearon dependencias**, agregar label `blocked:dependencies` al issue original:
+   ```bash
+   gh issue edit <N> --repo intrale/platform --add-label "blocked:dependencies"
+   ```
+
+### Reporte de dependencias (agregar al final del reporte normal)
+
+Si se detectaron dependencias, agregar esta sección al reporte:
+
+```
+## ⚠️ Dependencias funcionales detectadas
+
+| # | Funcionalidad faltante | Issue creado | Estado |
+|---|----------------------|--------------|--------|
+| 1 | <descripción> | #<nuevo> | 🔴 Pendiente |
+
+**Impacto:** Este issue queda BLOQUEADO (`blocked:dependencies`) hasta que se resuelvan las dependencias.
+**Recomendación:** Priorizar los issues de dependencia antes de iniciar el desarrollo de #<N>.
+```
+
+
 ## Formato de respuesta
 
 Estructurá siempre el reporte así:

--- a/.claude/skills/po/SKILL.md
+++ b/.claude/skills/po/SKILL.md
@@ -67,6 +67,77 @@ Al iniciar, parsear el primer argumento:
 
 ---
 
+## Verificación de dependencias funcionales (en análisis de issues)
+
+Cuando PO se ejecuta como parte del análisis de un issue del pipeline (modos `validar`, `acceptance`, o el argumento contiene un número de issue), agregar este paso **antes** de emitir el veredicto:
+
+### Paso PRE1: Identificar funcionalidades asumidas
+
+Del body del issue, extraer las funcionalidades que el issue **asume como existentes** desde la perspectiva de producto:
+- Flujos de negocio previos que deben estar implementados (ej: "el usuario ya tiene cuenta" → ¿existe registro?)
+- Endpoints o servicios backend que el issue consume pero que podrían no existir
+- Reglas de negocio referenciadas en `business-rules.md` que requieren implementación previa
+- Roles o permisos que el issue asume pero que podrían no estar desarrollados
+
+### Paso PRE2: Verificar existencia en el codebase
+
+```bash
+# Buscar endpoints/funciones mencionadas
+# Grep por Function/SecuredFunction + tag en Kodein
+# Buscar servicios backend: Comm*, Client*, ToDo*, Do*
+# Buscar pantallas: *Screen.kt en sc/
+```
+
+### Paso PRE3: Buscar issues abiertos que cubran la funcionalidad faltante
+
+```bash
+export PATH="/c/Workspaces/gh-cli/bin:$PATH"
+gh issue list --repo intrale/platform --search "<keyword de la funcionalidad>" --state open --json number,title --limit 5
+```
+
+### Paso PRE4: Crear issue de dependencia si la funcionalidad NO existe
+
+```bash
+export PATH="/c/Workspaces/gh-cli/bin:$PATH"
+gh issue create --repo intrale/platform \
+  --title "dep(producto): <descripción de la funcionalidad faltante>" \
+  --body "## Contexto
+Detectado por PO durante validación de producto del issue #<N>.
+
+## Funcionalidad requerida
+<descripción no-técnica de lo que falta — en términos de negocio>
+
+## Por qué es necesario
+El issue #<N> asume que esta funcionalidad existe, pero no hay evidencia de implementación ni issue abierto que la cubra.
+
+## Impacto en el producto
+<qué pasa si se desarrolla #<N> sin esta funcionalidad — flujo incompleto, regla de negocio violada, etc.>
+
+## Criterio de aceptación
+- [ ] <criterio verificable>" \
+  --label "needs-definition,qa:dependency" \
+  --assignee leitolarreta
+```
+
+### Paso PRE5: Vincular y bloquear el issue original
+
+```bash
+gh issue comment <N> --repo intrale/platform --body "📋 **Dependencia de producto detectada por PO:** #<nuevo-issue> — <descripción>. Este issue NO debe desarrollarse hasta que la funcionalidad requerida esté disponible."
+gh issue edit <N> --repo intrale/platform --add-label "blocked:dependencies"
+```
+
+> **Reporte de dependencias de producto:** Si se detectaron dependencias, incluir en el veredicto:
+> ```
+> ### ⚠️ Dependencias de producto detectadas
+> | # | Funcionalidad faltante | Issue creado | Impacto en negocio |
+> |---|----------------------|--------------|-------------------|
+> | 1 | <descripción> | #<nuevo> | <flujo afectado> |
+>
+> **Veredicto automático: REQUIERE CAMBIOS** — El issue tiene dependencias funcionales no resueltas.
+> ```
+
+---
+
 ## Modo: Definir (`/po definir <area>`)
 
 Define los flujos detallados para un área de negocio.

--- a/.claude/skills/security/SKILL.md
+++ b/.claude/skills/security/SKILL.md
@@ -133,7 +133,71 @@ Para cada componente afectado, verificar contra OWASP Top 10:
 [Explicación y recomendaciones priorizadas]
 ```
 
-### Paso A5: Generar issue automático si riesgo es ALTO
+### Paso A5b: Verificar dependencias funcionales (seguridad)
+
+Además del análisis de superficie de ataque, verificar si el issue **asume funcionalidades de seguridad que no existen aún** (middleware de auth, validaciones, controles de acceso, cifrado):
+
+1. **Identificar dependencias de seguridad implícitas** del body del issue:
+   - ¿Requiere `SecuredFunction` en endpoints que hoy son `Function`?
+   - ¿Asume que existe validación de roles/permisos que no está implementada?
+   - ¿Necesita cifrado de datos o tokens que no existe?
+   - ¿Depende de un flujo de auth (2FA, recovery, etc.) que no está desarrollado?
+
+2. **Buscar en el codebase** si la funcionalidad de seguridad existe:
+   ```bash
+   # Buscar SecuredFunction existentes
+   grep -rn "SecuredFunction" backend/src/ users/src/ --include="*.kt" | head -20
+   # Buscar validaciones de roles/permisos
+   grep -rn "role\|permission\|authorize" backend/src/ users/src/ --include="*.kt" | head -20
+   ```
+
+3. **Buscar en GitHub** si ya hay un issue abierto para la funcionalidad faltante:
+   ```bash
+   export PATH="/c/Workspaces/gh-cli/bin:$PATH"
+   gh issue list --repo intrale/platform --search "<keyword>" --state open --json number,title --limit 5
+   ```
+
+4. **Si la funcionalidad de seguridad NO existe y no hay issue** → crear issue de dependencia:
+   ```bash
+   export PATH="/c/Workspaces/gh-cli/bin:$PATH"
+   gh issue create --repo intrale/platform \
+     --title "dep(security): <descripción del control faltante>" \
+     --body "## Contexto
+   Detectado por Security durante análisis de seguridad del issue #<N>.
+
+   ## Control de seguridad requerido
+   <descripción del control que falta — entendible por PO>
+
+   ## Riesgo si no se implementa
+   <qué puede pasar si se desarrolla #<N> sin este control>
+
+   ## Criterio de aceptación
+   - [ ] <criterio verificable>" \
+     --label "needs-definition,qa:dependency,area:seguridad" \
+     --assignee leitolarreta
+   ```
+
+5. **Vincular y bloquear** el issue original:
+   ```bash
+   gh issue comment <N> --repo intrale/platform --body "🔒 **Dependencia de seguridad detectada:** #<nuevo-issue> — <descripción>. Este issue NO debe desarrollarse sin este control de seguridad."
+   gh issue edit <N> --repo intrale/platform --add-label "blocked:dependencies"
+   ```
+
+### Reporte de dependencias de seguridad (agregar al reporte de análisis)
+
+Si se detectaron dependencias de seguridad, agregar al reporte:
+
+```
+### ⚠️ Dependencias de seguridad detectadas
+
+| # | Control faltante | Issue creado | Riesgo sin control |
+|---|-----------------|--------------|-------------------|
+| 1 | <descripción> | #<nuevo> | Alto/Medio/Bajo |
+
+**Impacto:** Este issue queda BLOQUEADO hasta que se implementen los controles de seguridad requeridos.
+```
+
+### Paso A5b: Generar issue automático si riesgo es ALTO
 
 Si el análisis detecta riesgo alto, crear un issue de seguridad automáticamente:
 

--- a/.claude/skills/ux/SKILL.md
+++ b/.claude/skills/ux/SKILL.md
@@ -93,6 +93,74 @@ Al iniciar, parsear el primer argumento:
 
 ---
 
+## Verificación de dependencias funcionales (en análisis de issues)
+
+Cuando UX se ejecuta como parte del análisis de un issue del pipeline (el argumento contiene un número de issue), agregar este paso **antes** de cualquier auditoría o propuesta:
+
+### Paso D1: Identificar dependencias de UX implícitas
+
+Del body del issue, extraer las funcionalidades de UI que el issue **asume como existentes**:
+- Pantallas referenciadas que deben existir previamente
+- Componentes UI compartidos que se mencionan pero podrían no existir
+- Flujos de navegación que asumen pantallas intermedias
+- Estados de UI (loading, empty, error) en pantallas de las que depende
+
+### Paso D2: Verificar existencia en el codebase
+
+```bash
+# Buscar pantallas mencionadas
+# Glob: **/sc/**Screen.kt + Grep por nombre
+# Buscar componentes UI mencionados
+# Glob: **/cp/** + Grep por nombre de componente
+# Buscar rutas de navegación
+# Grep en **/ro/** por rutas referenciadas
+```
+
+### Paso D3: Buscar issues abiertos que cubran la funcionalidad faltante
+
+```bash
+export PATH="/c/Workspaces/gh-cli/bin:$PATH"
+gh issue list --repo intrale/platform --search "<keyword de la pantalla o componente>" --state open --json number,title --limit 5
+```
+
+### Paso D4: Crear issue de dependencia si la funcionalidad NO existe
+
+```bash
+export PATH="/c/Workspaces/gh-cli/bin:$PATH"
+gh issue create --repo intrale/platform \
+  --title "dep(ux): <descripción del componente/pantalla faltante>" \
+  --body "## Contexto
+Detectado por UX durante análisis de experiencia del issue #<N>.
+
+## Componente/Pantalla requerida
+<descripción de lo que falta — entendible por PO y dev>
+
+## Impacto en la experiencia
+<qué pasa si se desarrolla #<N> sin este componente — flujo roto, navegación incompleta, etc.>
+
+## Criterio de aceptación
+- [ ] <criterio verificable>" \
+  --label "needs-definition,qa:dependency,ux" \
+  --assignee leitolarreta
+```
+
+### Paso D5: Vincular y bloquear el issue original
+
+```bash
+gh issue comment <N> --repo intrale/platform --body "🎨 **Dependencia de UX detectada:** #<nuevo-issue> — <descripción>. El issue #<N> asume que este componente/pantalla existe pero no está implementado."
+gh issue edit <N> --repo intrale/platform --add-label "blocked:dependencies"
+```
+
+> **Reporte de dependencias UX:** Si se detectaron dependencias, incluir en el reporte:
+> ```
+> ### ⚠️ Dependencias de UX detectadas
+> | # | Componente/Pantalla faltante | Issue creado | Impacto en flujo |
+> |---|----------------------------|--------------|-----------------|
+> | 1 | <descripción> | #<nuevo> | <flujo afectado> |
+> ```
+
+---
+
 ## Modo: Auditar (`/ux auditar <flujo>`)
 
 Auditoria UX profunda de un flujo completo de usuario (no solo una pantalla — el journey entero).

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // =============================================================================
 // Pulpo V2 — Proceso central del pipeline
-// Brazos: barrido, lanzamiento, huérfanos (+ intake en F5)
+// Brazos: barrido, lanzamiento, huérfanos, desbloqueo (+ intake en F5)
 // =============================================================================
 
 const fs = require('fs');
@@ -1955,6 +1955,13 @@ function brazoLanzamiento(config) {
     //    Sin este check el siguiente iteration explota al intentar moverlo.
     if (!fs.existsSync(archivo.path)) continue;
 
+    // 0b. BLOCKED: no lanzar issues con blocked:dependencies
+    const issueLbls = getIssueLabels(issue);
+    if (issueLbls.includes('blocked:dependencies')) {
+      log('lanzamiento', `#${issue} omitido — blocked:dependencies`);
+      continue;
+    }
+
     // 1. DEDUP: ¿ya hay un agente activo para este ISSUE (cualquier skill) en trabajando/?
     const issueAlreadyWorking = listWorkFiles(trabajandoDir).some(f => issueFromFile(f.name) === issue);
     if (issueAlreadyWorking) continue;
@@ -3827,6 +3834,13 @@ function brazoIntake(config) {
       for (const issue of issues) {
         const issueNum = String(issue.number);
 
+        // BLOCKED: no procesar issues con label blocked:dependencies
+        const issueLabels = (issue.labels || []).map(l => l.name);
+        if (issueLabels.includes('blocked:dependencies')) {
+          log('intake', `#${issueNum} omitido — tiene label blocked:dependencies`);
+          continue;
+        }
+
         // Deduplicación: verificar que el issue no esté ya activo en este pipeline
         if (issueExistsInPipeline(issueNum, pipelineName)) continue;
 
@@ -3957,6 +3971,107 @@ function persistMetricsSnapshot(config) {
   } catch {}
 }
 
+// =============================================================================
+// BRAZO DESBLOQUEO — Revisa issues con blocked:dependencies y desbloquea
+// cuando todas sus dependencias están cerradas.
+// Frecuencia: cada 10 minutos (no necesita ser frecuente).
+// =============================================================================
+let lastUnblockTime = 0;
+const UNBLOCK_INTERVAL_MS = 10 * 60 * 1000; // 10 minutos
+
+function brazoDesbloqueo(config) {
+  if (Date.now() - lastUnblockTime < UNBLOCK_INTERVAL_MS) return;
+  lastUnblockTime = Date.now();
+
+  try {
+    // 1. Buscar issues abiertos con label blocked:dependencies
+    ghThrottle();
+    const result = execSync(
+      `"${GH_BIN}" issue list --label "blocked:dependencies" --state open --json number,title --limit 50`,
+      { cwd: ROOT, encoding: 'utf8', timeout: 30000, windowsHide: true }
+    );
+    const blockedIssues = JSON.parse(result || '[]');
+    if (blockedIssues.length === 0) return;
+
+    log('desbloqueo', `Revisando ${blockedIssues.length} issues bloqueados por dependencias`);
+
+    for (const issue of blockedIssues) {
+      try {
+        // 2. Leer comentarios del issue para encontrar dependencias creadas por el pipeline
+        ghThrottle();
+        const comments = execSync(
+          `"${GH_BIN}" issue view ${issue.number} --json comments --jq ".comments[].body" --repo intrale/platform`,
+          { cwd: ROOT, encoding: 'utf8', timeout: 15000, windowsHide: true }
+        );
+
+        // Buscar el comentario de dependencias del pipeline
+        const depCommentMatch = comments.match(/Dependencias detectadas por el pipeline[\s\S]*?(?=\n\n|\Z)/);
+        if (!depCommentMatch) {
+          log('desbloqueo', `#${issue.number}: no se encontró comentario de dependencias — omitido`);
+          continue;
+        }
+
+        // Extraer números de issues referenciados (#NNN)
+        const depIssueNumbers = [...depCommentMatch[0].matchAll(/#(\d+)/g)].map(m => m[1]);
+        if (depIssueNumbers.length === 0) {
+          log('desbloqueo', `#${issue.number}: no se encontraron issues de dependencia — omitido`);
+          continue;
+        }
+
+        // 3. Verificar si todas las dependencias están cerradas
+        let allClosed = true;
+        const openDeps = [];
+        for (const depNum of depIssueNumbers) {
+          ghThrottle();
+          try {
+            const depState = execSync(
+              `"${GH_BIN}" issue view ${depNum} --json state --jq ".state" --repo intrale/platform`,
+              { cwd: ROOT, encoding: 'utf8', timeout: 10000, windowsHide: true }
+            ).trim();
+            if (depState !== 'CLOSED') {
+              allClosed = false;
+              openDeps.push(depNum);
+            }
+          } catch (e) {
+            // Si no se puede leer el estado, asumir que está abierto
+            allClosed = false;
+            openDeps.push(depNum);
+          }
+        }
+
+        if (allClosed) {
+          // 4. Todas cerradas → desbloquear
+          log('desbloqueo', `#${issue.number}: todas las dependencias cerradas (${depIssueNumbers.join(', ')}) → desbloqueando`);
+
+          // Quitar label blocked:dependencies
+          ghThrottle();
+          execSync(
+            `"${GH_BIN}" issue edit ${issue.number} --remove-label "blocked:dependencies" --repo intrale/platform`,
+            { cwd: ROOT, timeout: 10000, windowsHide: true }
+          );
+
+          // Agregar comentario de desbloqueo
+          const unblockComment = `## ✅ Issue desbloqueado automáticamente\n\nTodas las dependencias fueron resueltas (${depIssueNumbers.map(n => '#' + n).join(', ')}). Este issue vuelve a la cola del pipeline para ser procesado.`;
+          ghThrottle();
+          execSync(
+            `"${GH_BIN}" issue comment ${issue.number} --body "${unblockComment.replace(/"/g, '\\"')}" --repo intrale/platform`,
+            { cwd: ROOT, timeout: 10000, windowsHide: true }
+          );
+
+          sendTelegram(`🔓 Issue #${issue.number} desbloqueado — todas las dependencias resueltas (${depIssueNumbers.map(n => '#' + n).join(', ')}). Vuelve a la cola del pipeline.`);
+          log('desbloqueo', `#${issue.number} desbloqueado exitosamente`);
+        } else {
+          log('desbloqueo', `#${issue.number}: dependencias abiertas: ${openDeps.map(n => '#' + n).join(', ')} — sigue bloqueado`);
+        }
+      } catch (e) {
+        log('desbloqueo', `Error procesando #${issue.number}: ${e.message}`);
+      }
+    }
+  } catch (e) {
+    log('desbloqueo', `Error en brazo de desbloqueo: ${e.message}`);
+  }
+}
+
 async function mainLoop() {
   log('pulpo', `Pulpo V2 iniciado — poll cada ${loadConfig().timeouts?.poll_interval_seconds || 30}s`);
   log('pulpo', `Pipeline: ${PIPELINE}`);
@@ -3989,10 +4104,11 @@ async function mainLoop() {
       if (!paused) {
         rotateHistory();          // Housekeeping: rotar historial > 24hs
         persistMetricsSnapshot(config); // Métricas históricas para /metrics
-        brazoIntake(config);    // Segundo: traer trabajo nuevo de GitHub
-        brazoBarrido(config);   // Tercero: promover entre fases
-        brazoLanzamiento(config); // Cuarto: asignar trabajo a agentes
-        brazoHuerfanos(config); // Quinto: recuperar trabajo trabado
+        brazoIntake(config);      // Segundo: traer trabajo nuevo de GitHub
+        brazoDesbloqueo(config);  // Tercero: desbloquear issues cuyas dependencias se resolvieron
+        brazoBarrido(config);     // Cuarto: promover entre fases
+        brazoLanzamiento(config); // Quinto: asignar trabajo a agentes
+        brazoHuerfanos(config);   // Sexto: recuperar trabajo trabado
       } else {
         log('pulpo', 'PAUSADO — esperando reanudación (borrar .pipeline/.paused)');
       }

--- a/.pipeline/rejection-report.js
+++ b/.pipeline/rejection-report.js
@@ -19,6 +19,9 @@ const PROFILES_FILE = path.join(PIPELINE, 'skill-profiles.json');
 const REPORT_SCRIPT = path.join(ROOT, 'scripts', 'report-to-pdf-telegram.js');
 const GH_CLI = process.env.GH_CLI_PATH || '/c/Workspaces/gh-cli/bin/gh';
 
+// Shared state: issues de dependencia creados por generateReport(), leídos por generateNarration()
+let _autoCreatedDeps = [];
+
 // --- Parse args ---
 const args = process.argv.slice(2);
 function getArg(name) {
@@ -339,6 +342,10 @@ function generateReport() {
   // 13. Issues de dependencia creados por QA (V9)
   const depIssues = fetchDependencyIssues(issue);
 
+  // 14. Crear issues de dependencia automáticamente si se detectaron y no existen
+  const autoCreatedDeps = createDependencyIssues(issue, analysis.externalDeps, issueCtx.title);
+  _autoCreatedDeps = autoCreatedDeps; // Compartir con generateNarration()
+
   // --- HTML ---
   return `<!DOCTYPE html>
 <html><head><meta charset="utf-8">
@@ -477,15 +484,16 @@ ${skillProfile ? `
   <h3>${rootCause.origen === 'EXTERNO' ? '⚠️ Este issue NO necesita cambios — el bloqueo es externo' : '🔧 Acciones requeridas en este issue'}</h3>
   <p>${escapeHtml(analysis.suggestion)}</p>
   ${analysis.steps.length > 0 ? '<h3>Pasos concretos</h3><ol>' + analysis.steps.map(s => '<li>' + escapeHtml(s) + '</li>').join('') + '</ol>' : ''}
-  ${analysis.externalDeps && analysis.externalDeps.length > 0 ? '<h3>Dependencias externas detectadas</h3><ul>' + analysis.externalDeps.map(d => '<li>🔗 ' + escapeHtml(d) + '</li>').join('') + '</ul><p><em>Estas dependencias deberian resolverse en issues separados antes de reintentar la validacion de este issue.</em></p>' : ''}
+  ${autoCreatedDeps.length > 0 ? '<h3>Issues de Dependencia Creados Automaticamente</h3><table><tr><th>Issue</th><th>Titulo</th><th>Estado</th></tr>' + autoCreatedDeps.map(d => '<tr><td><strong>#' + d.number + '</strong></td><td>' + escapeHtml(d.title) + '</td><td>' + (d.alreadyExisted ? '<span class="badge badge-yellow">Ya existia</span>' : '<span class="badge badge-blue">Creado ahora</span>') + '</td></tr>').join('') + '</table><p><em>Este issue queda bloqueado (blocked:dependencies) hasta que se resuelvan estos issues.</em></p>' : ''}
+  ${analysis.externalDeps && analysis.externalDeps.length > 0 && autoCreatedDeps.length === 0 ? '<h3>Dependencias externas detectadas</h3><ul>' + analysis.externalDeps.map(d => '<li>🔗 ' + escapeHtml(d) + '</li>').join('') + '</ul><p><em>No se pudieron crear issues automaticamente. Crear manualmente antes de reintentar.</em></p>' : ''}
 </div>
 
-${depIssues.linkedDeps.length > 0 || depIssues.isBlocked ? `
-<h2>Issues de Dependencia Creados</h2>
+${(depIssues.linkedDeps.length > 0 || depIssues.isBlocked) && autoCreatedDeps.length === 0 ? `
+<h2>Issues de Dependencia Previos</h2>
 <div class="${depIssues.isBlocked ? 'rootcause-box' : 'history-box'}">
   ${depIssues.isBlocked ? '<p>⛔ <strong>Este issue esta BLOQUEADO</strong> — tiene label <span class="badge badge-red">blocked:dependencies</span>. No se puede avanzar hasta que se resuelvan las dependencias listadas abajo.</p>' : ''}
   ${depIssues.linkedDeps.length > 0 ? `
-  <p>QA creo los siguientes issues como dependencias que deben resolverse antes de reintentar la validacion:</p>
+  <p>Issues de dependencia vinculados previamente:</p>
   <table>
     <tr><th>Issue</th><th>Titulo</th><th>Estado</th></tr>
     ${depIssues.linkedDeps.map(d => {
@@ -505,7 +513,7 @@ ${depIssues.linkedDeps.length > 0 || depIssues.isBlocked ? `
 </details>
 
 <div class="footer">
-  Intrale Platform &mdash; Reporte de Rechazo &mdash; v4.1 &mdash; ${escapeHtml(now.toISOString().slice(0, 10))}
+  Intrale Platform &mdash; Reporte de Rechazo &mdash; v4.2 &mdash; ${escapeHtml(now.toISOString().slice(0, 10))}
 </div>
 </body></html>`;
 }
@@ -602,6 +610,113 @@ function detectExternalDependencies(logTail, motivo) {
   }
 
   return deps;
+}
+
+// --- Crear issues de dependencia en GitHub automáticamente ---
+// Recibe las dependencias detectadas, crea issues con label qa:dependency,
+// vincula al issue original y devuelve los issues creados con sus números.
+function createDependencyIssues(issueNum, externalDeps, issueTitle) {
+  if (!externalDeps || externalDeps.length === 0) return [];
+
+  const ghPath = fs.existsSync(GH_CLI) ? GH_CLI : 'gh';
+  const created = [];
+
+  for (const dep of externalDeps) {
+    try {
+      // 1. Buscar si ya existe un issue abierto para esta dependencia (evitar duplicados)
+      const searchQuery = dep.length > 60 ? dep.substring(0, 60) : dep;
+      let alreadyExists = false;
+      try {
+        const searchRaw = execSync(
+          `"${ghPath}" issue list --label "qa:dependency" --search "${searchQuery.replace(/"/g, '\\"')}" --json number,title,state --repo intrale/platform --limit 5`,
+          { timeout: 15000, stdio: ['pipe', 'pipe', 'pipe'] }
+        ).toString();
+        const existing = JSON.parse(searchRaw || '[]');
+        const openMatch = existing.find(e => e.state === 'OPEN');
+        if (openMatch) {
+          created.push({ number: openMatch.number, title: openMatch.title, state: 'OPEN', alreadyExisted: true });
+          alreadyExists = true;
+        }
+      } catch {}
+
+      if (alreadyExists) continue;
+
+      // 2. Crear el issue de dependencia
+      const depTitle = `dep: ${dep.length > 80 ? dep.substring(0, 80) + '...' : dep}`;
+      const depBody = [
+        '## Contexto',
+        '',
+        `Dependencia detectada automáticamente durante el rechazo del issue #${issueNum} (${issueTitle || ''}).`,
+        '',
+        '## Problema',
+        '',
+        dep,
+        '',
+        '## Origen',
+        '',
+        `El issue #${issueNum} fue rechazado porque depende de una funcionalidad que no existe o tiene un bug que bloquea la ejecución.`,
+        '',
+        '## Criterios de aceptación',
+        '',
+        '- [ ] La funcionalidad descrita arriba está implementada y funcionando',
+        `- [ ] El issue #${issueNum} puede reintentarse sin este bloqueo`,
+        '',
+        '---',
+        `_Issue creado automáticamente por el rejection report del pipeline._`,
+      ].join('\n');
+
+      const createRaw = execSync(
+        `"${ghPath}" issue create --title "${depTitle.replace(/"/g, '\\"')}" --body "${depBody.replace(/"/g, '\\"')}" --label "needs-definition,qa:dependency" --repo intrale/platform`,
+        { timeout: 20000, stdio: ['pipe', 'pipe', 'pipe'] }
+      ).toString().trim();
+
+      // gh issue create devuelve la URL del issue, extraer el número
+      const urlMatch = createRaw.match(/\/(\d+)\s*$/);
+      const newNumber = urlMatch ? parseInt(urlMatch[1]) : null;
+
+      if (newNumber) {
+        created.push({ number: newNumber, title: depTitle, state: 'OPEN', alreadyExisted: false });
+        console.log(`[rejection-report] Issue de dependencia creado: #${newNumber} — ${depTitle}`);
+      }
+    } catch (err) {
+      console.error(`[rejection-report] Error creando issue de dependencia: ${err.message}`);
+    }
+  }
+
+  // 3. Si se crearon issues, vincular al issue original con un comentario y agregar label blocked:dependencies
+  if (created.length > 0) {
+    try {
+      const newIssues = created.filter(c => !c.alreadyExisted);
+      const existingIssues = created.filter(c => c.alreadyExisted);
+      const commentParts = ['## 🔗 Dependencias detectadas por el pipeline\n'];
+      if (newIssues.length > 0) {
+        commentParts.push('**Issues creados automáticamente:**');
+        for (const c of newIssues) commentParts.push(`- #${c.number} — ${c.title}`);
+      }
+      if (existingIssues.length > 0) {
+        commentParts.push('\n**Issues existentes vinculados:**');
+        for (const c of existingIssues) commentParts.push(`- #${c.number} — ${c.title}`);
+      }
+      commentParts.push(`\nEste issue queda bloqueado hasta que se resuelvan las dependencias listadas.`);
+
+      const comment = commentParts.join('\n');
+      execSync(
+        `"${ghPath}" issue comment ${issueNum} --body "${comment.replace(/"/g, '\\"')}" --repo intrale/platform`,
+        { timeout: 15000, stdio: ['pipe', 'pipe', 'pipe'] }
+      );
+
+      // Agregar label blocked:dependencies al issue original
+      execSync(
+        `"${ghPath}" issue edit ${issueNum} --add-label "blocked:dependencies" --repo intrale/platform`,
+        { timeout: 10000, stdio: ['pipe', 'pipe', 'pipe'] }
+      );
+      console.log(`[rejection-report] Issue #${issueNum} marcado como blocked:dependencies con ${created.length} dependencias`);
+    } catch (err) {
+      console.error(`[rejection-report] Error vinculando dependencias al issue #${issueNum}: ${err.message}`);
+    }
+  }
+
+  return created;
 }
 
 // --- Análisis automático basado en patrones ---
@@ -759,13 +874,24 @@ function generateNarration() {
     parts.push(`Pasos concretos: ${analysis.steps.map((s, i) => (i + 1) + ', ' + s).join('. ')}.`);
   }
 
-  // Dependencias
-  if (depIssues.isBlocked || depIssues.linkedDeps.length > 0) {
+  // Dependencias creadas automáticamente por este reporte
+  if (_autoCreatedDeps.length > 0) {
+    const newOnes = _autoCreatedDeps.filter(d => !d.alreadyExisted);
+    const existingOnes = _autoCreatedDeps.filter(d => d.alreadyExisted);
+    if (newOnes.length > 0) {
+      parts.push(`Se crearon automáticamente ${newOnes.length} issues de dependencia: ${newOnes.map(d => 'número ' + d.number + ', ' + d.title.replace(/^dep:\s*/i, '')).join('. ')}.`);
+    }
+    if (existingOnes.length > 0) {
+      parts.push(`Se vincularon ${existingOnes.length} issues de dependencia que ya existían: ${existingOnes.map(d => 'número ' + d.number).join(', ')}.`);
+    }
+    parts.push(`El issue queda bloqueado hasta que se resuelvan estas dependencias.`);
+  } else if (depIssues.isBlocked || depIssues.linkedDeps.length > 0) {
+    // Dependencias previas (ya existían antes de este reporte)
     const openDeps = depIssues.linkedDeps.filter(d => d.state === 'OPEN');
     const closedDeps = depIssues.linkedDeps.filter(d => d.state === 'CLOSED');
     parts.push(`Este issue está bloqueado por dependencias.`);
     if (depIssues.linkedDeps.length > 0) {
-      parts.push(`QA creó ${depIssues.linkedDeps.length} issues de dependencia: ${depIssues.linkedDeps.map(d => 'número ' + d.number + ', ' + d.title + ', estado ' + (d.state === 'OPEN' ? 'pendiente' : 'resuelto')).join('. ')}.`);
+      parts.push(`Hay ${depIssues.linkedDeps.length} issues de dependencia vinculados: ${depIssues.linkedDeps.map(d => 'número ' + d.number + ', ' + d.title + ', estado ' + (d.state === 'OPEN' ? 'pendiente' : 'resuelto')).join('. ')}.`);
     }
     if (openDeps.length > 0) {
       parts.push(`Hay ${openDeps.length} dependencias pendientes de resolver. No se debe reintentar hasta que se cierren.`);


### PR DESCRIPTION
## Summary
- El pipeline ahora **no procesa** issues que tengan label `blocked:dependencies` (ni en intake ni en lanzamiento)
- Nuevo **brazo de desbloqueo**: cada 10 minutos revisa issues bloqueados, verifica si todas sus dependencias (issues referenciados en el comentario del pipeline) están cerradas, y si lo están → quita el label, comenta en el issue y notifica por Telegram
- Esto cierra el circuito completo: QA/skills detectan dependencia → crean issue → bloquean → pipeline espera → dependencias se resuelven → pipeline desbloquea automáticamente

## Cambios
- **Intake**: filtra issues con `blocked:dependencies` antes de ingestarlos
- **Lanzamiento**: verifica labels antes de lanzar agente, omite bloqueados
- **Desbloqueo** (nuevo brazo): consulta GitHub cada 10min, parsea comentarios de dependencias, verifica estado de cada dependencia

## Test plan
- [ ] Verificar que un issue con `blocked:dependencies` no se ingesta al pipeline
- [ ] Verificar que un issue bloqueado en `pendiente/` no se lanza
- [ ] Crear un issue de dependencia, cerrarlo, y verificar que el brazo de desbloqueo quita el label y notifica

🤖 Generated with [Claude Code](https://claude.com/claude-code)