### PR TITLE
fix(commander): /restart y /restart pausado como comandos nativos del pulpo

### DIFF
--- a/.claude/hooks/commander/command-dispatcher.js
+++ b/.claude/hooks/commander/command-dispatcher.js
@@ -109,6 +109,7 @@ function parseCommand(text) {
     if (trimmed === "/limpiar") return { type: "limpiar" };
     if (trimmed === "/detalle" || trimmed === "/mas") return { type: "detalle" };
     if (trimmed === "/restart") return { type: "restart" };
+    if (trimmed === "/restart pausado" || trimmed === "/restart --paused") return { type: "restart", paused: true };
     if (trimmed === "/session") return { type: "session" };
     if (trimmed === "/session clear") return { type: "session_clear" };
 
@@ -469,15 +470,17 @@ async function handleReset(confirmed) {
     }
 }
 
-async function handleRestart() {
-    await _tgApi.sendMessage("🔄 <b>Reinicio completo del pipeline</b> en progreso...\n\n<i>Usando cmd.exe /c restart para que los procesos hijos sobrevivan.</i>");
+async function handleRestart(paused) {
+    const mode = paused ? "pausado" : "completo";
+    const cmd = paused ? "cmd.exe /c restart --paused" : "cmd.exe /c restart";
+    await _tgApi.sendMessage("🔄 <b>Reinicio " + mode + " del pipeline</b> en progreso..." + (paused ? "\n\n<i>Modo pausado: Telegram + dashboard activos, sin intake ni agentes.</i>" : "\n\n<i>Usando cmd.exe /c restart para que los procesos hijos sobrevivan.</i>"));
     try {
         const { exec } = require("child_process");
 
         // Usar cmd.exe /c restart para que los procesos spawneados con detached:true
         // sobrevivan al cierre del padre. Desde Git Bash/hooks el Job Object de Windows
         // mata los hijos — cmd.exe nativo no tiene ese problema.
-        exec("cmd.exe /c restart", {
+        exec(cmd, {
             timeout: 60000,
             cwd: _repoRoot,
             env: { ...process.env, PATH: "C:\\Workspaces\\bin;" + process.env.PATH },

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -3449,6 +3449,39 @@ function cmdLimpiar() {
   return `🧹 *Limpieza de daemons*\n\n${lines}\n\n*Total eliminados:* ${totalKilled}`;
 }
 
+function cmdRestart(args) {
+  const paused = /pausado|--paused/i.test(args || '');
+  const cmd = paused ? 'cmd.exe /c restart --paused' : 'cmd.exe /c restart';
+  const mode = paused ? 'pausado' : 'completo';
+
+  log('commander', `Restart ${mode} solicitado via Telegram`);
+
+  // Registrar timestamp para protección anti-loop
+  try {
+    fs.writeFileSync(path.join(PIPELINE, 'last-restart.json'),
+      JSON.stringify({ timestamp: new Date().toISOString(), mode, source: 'telegram' }));
+  } catch {}
+
+  // Ejecutar con exec async — cmd.exe nativo para que los hijos sobrevivan al Job Object de Windows
+  const { exec } = require('child_process');
+  exec(cmd, {
+    timeout: 60000,
+    cwd: ROOT,
+    env: { ...process.env, PATH: 'C:\\Workspaces\\bin;' + process.env.PATH },
+  }, (error, stdout, stderr) => {
+    if (error) {
+      log('commander', `Error en restart: ${error.message}`);
+      sendTelegram(`❌ Error en reinicio ${mode}:\n\`${error.message.slice(0, 200)}\`\n\nIntentar manualmente: \`cmd.exe /c restart${paused ? ' --paused' : ''}\``);
+      return;
+    }
+    const output = (stdout || '').trim();
+    const tail = output ? output.split('\n').slice(-10).join('\n') : 'Pipeline reiniciado.';
+    sendTelegram(`✅ *Restart ${mode} ejecutado*\n\n\`\`\`\n${tail}\n\`\`\``);
+  });
+
+  return `🔄 Reinicio ${mode} del pipeline en progreso...${paused ? '\n_Modo pausado: Telegram + dashboard activos, sin intake ni agentes._' : ''}`;
+}
+
 function cmdHelp() {
   return `🤖 *Comandos del Pipeline V2*
 
@@ -3456,6 +3489,8 @@ function cmdHelp() {
 /actividad [filtro] — Timeline (ej: /actividad 30m, /actividad #732)
 /intake [issue] — Meter trabajo al pipeline
 /proponer — Proponer historias nuevas (vía Claude)
+/restart — Reiniciar pipeline completo
+/restart pausado — Reiniciar en modo pausado (solo Telegram + dashboard)
 /limpiar — Matar daemons Gradle/Kotlin huérfanos
 /pausar — Pausar el Pulpo
 /reanudar — Reanudar el Pulpo
@@ -3631,6 +3666,7 @@ async function _brazoCommanderInner(config, archivosIniciales, commanderPendient
         break;
       case 'proponer': respuesta = await cmdProponer(parsed.args, config); break;
       case 'limpiar': respuesta = cmdLimpiar(); break;
+      case 'restart': respuesta = cmdRestart(parsed.args); break;
       default: respuesta = null; break;
     }
 


### PR DESCRIPTION
## Resumen

- `/restart` y `/restart pausado` ahora son comandos nativos del pulpo (ejecución directa, sin pasar por Claude)
- Ambos usan `cmd.exe /c restart` para evitar el problema del Job Object de Windows que mata procesos hijos
- `/restart pausado` pasa `--paused` al script, que crea `.pipeline/.paused` (solo levanta Telegram + dashboard)
- Registra `last-restart.json` para protección anti-loop de 120s

## Cambios

- `pulpo.js`: nueva función `cmdRestart(args)` + case en switch + help actualizado
- `command-dispatcher.js`: parsing de `/restart pausado` y `handleRestart(paused)` con `cmd.exe /c restart`

## Plan de tests

- [ ] Enviar `/restart` desde Telegram → pipeline se reinicia completo
- [ ] Enviar `/restart pausado` desde Telegram → pipeline arranca en modo pausado
- [ ] Verificar protección anti-loop (2 restarts < 120s → skip)

QA Validate: omitido — cambio de infra/hooks sin impacto en producto de usuario ⚠️

🤖 Generado con [Claude Code](https://claude.ai/claude-code)