### PR TITLE
fix(telegram): audio TTS largo se parte en múltiples mensajes en vez de truncarse

### DIFF
--- a/.claude/hooks/commander/callback-handler.js
+++ b/.claude/hooks/commander/callback-handler.js
@@ -859,10 +859,17 @@ async function routeCallback(cbData, callbackQueryId, message) {
 
         try {
             const multimediaHandler = require("./multimedia-handler");
-            const text = stored.text.substring(0, 2000); // Límite TTS
-            const audioBuffer = await multimediaHandler.callTTS(text);
-            await _tgApi.sendVoiceMessage(audioBuffer);
-            _log("TTS bajo demanda enviado: " + audioBuffer.length + " bytes");
+            const TTS_CHUNK_SIZE = 3800;
+            const chunks = multimediaHandler.splitTextForTTS(stored.text, TTS_CHUNK_SIZE);
+            _log("TTS bajo demanda: " + stored.text.length + " chars, " + chunks.length + " parte(s)");
+            for (let i = 0; i < chunks.length; i++) {
+                const chunkText = chunks.length > 1
+                    ? "Parte " + (i + 1) + " de " + chunks.length + ". " + chunks[i]
+                    : chunks[i];
+                const audioBuffer = await multimediaHandler.callTTS(chunkText);
+                await _tgApi.sendVoiceMessage(audioBuffer);
+                _log("TTS bajo demanda parte " + (i + 1) + "/" + chunks.length + " enviada: " + audioBuffer.length + " bytes");
+            }
         } catch (ttsErr) {
             _log("Error TTS bajo demanda: " + ttsErr.message);
             await _tgApi.sendMessage("❌ Error generando audio: <code>" + _tgApi.escHtml(ttsErr.message) + "</code>");

--- a/.claude/hooks/commander/multimedia-handler.js
+++ b/.claude/hooks/commander/multimedia-handler.js
@@ -140,15 +140,46 @@ function callOpenAITranscription(audioBuffer, filename) {
 
 // ─── OpenAI TTS API ──────────────────────────────────────────────────────────
 
+// Partir texto en chunks para TTS respetando límites de oraciones
+function splitTextForTTS(text, maxChars) {
+    if (text.length <= maxChars) return [text];
+    const sentences = text.split(/(?<=[.!?])\s+/);
+    const chunks = [];
+    let current = '';
+    for (const sentence of sentences) {
+        if ((current + ' ' + sentence).length > maxChars && current.length > 0) {
+            chunks.push(current.trim());
+            current = sentence;
+        } else {
+            current = current ? current + ' ' + sentence : sentence;
+        }
+    }
+    if (current.trim()) chunks.push(current.trim());
+    // Si algún chunk individual sigue siendo más largo (oración gigante), forzar corte por palabras
+    const result = [];
+    for (const chunk of chunks) {
+        if (chunk.length <= maxChars) { result.push(chunk); continue; }
+        const words = chunk.split(/\s+/);
+        let part = '';
+        for (const word of words) {
+            if ((part + ' ' + word).length > maxChars && part.length > 0) {
+                result.push(part.trim());
+                part = word;
+            } else {
+                part = part ? part + ' ' + word : word;
+            }
+        }
+        if (part.trim()) result.push(part.trim());
+    }
+    return result;
+}
+
 function callOpenAITTS(text) {
     return new Promise((resolve, reject) => {
-        const truncated = text.length > 2000
-            ? text.substring(0, 1950) + "... (respuesta truncada para audio)"
-            : text;
-
+        // OpenAI TTS soporta hasta 4096 chars — NO truncar
         const body = JSON.stringify({
             model: _config.ttsModel,
-            input: truncated,
+            input: text.substring(0, 4096),
             voice: _config.ttsVoice,
             instructions: "Hablás como un porteño de Buenos Aires, con tonada rioplatense auténtica. Usás 'vos' en vez de 'tú', decís 'dale', 'che', 'mirá', 'boludo' cuando viene al caso. El ritmo es el de una charla entre amigos en un bar — pausas naturales, énfasis expresivo, te reís si algo es gracioso. Sos inteligente pero cero formal, como un ingeniero argentino joven explicándole algo a un amigo. Nunca sonás como locutor ni como robot — sonás como un pibe real.",
             response_format: "opus"
@@ -187,12 +218,9 @@ function callOpenAITTS(text) {
 
 function callElevenLabsTTS(text) {
     return new Promise((resolve, reject) => {
-        const truncated = text.length > 2000
-            ? text.substring(0, 1950) + "... (respuesta truncada para audio)"
-            : text;
-
+        // ElevenLabs soporta textos largos — NO truncar
         const body = JSON.stringify({
-            text: truncated,
+            text: text,
             model_id: "eleven_multilingual_v2",
             output_format: "opus_48000_32"
         });
@@ -371,10 +399,18 @@ async function handleVoiceOrAudio(msg) {
         // Asumimos que si el usuario envía audio es porque no puede mirar texto.
         if (isVoice && result.code === 0 && claudeResponse && (_config.elevenlabsApiKey || _config.openaiApiKey)) {
             try {
-                _log("Generando TTS para respuesta (" + claudeResponse.length + " chars)");
-                const audioBuffer = await callTTS(claudeResponse);
-                await _tgApi.sendVoiceMessage(audioBuffer);
-                _log("TTS enviado: " + audioBuffer.length + " bytes");
+                const TTS_CHUNK_SIZE = 3800; // Margen bajo el límite de 4096 de OpenAI
+                const chunks = splitTextForTTS(claudeResponse, TTS_CHUNK_SIZE);
+                _log("Generando TTS para respuesta (" + claudeResponse.length + " chars, " + chunks.length + " parte(s))");
+
+                for (let i = 0; i < chunks.length; i++) {
+                    const chunkText = chunks.length > 1
+                        ? "Parte " + (i + 1) + " de " + chunks.length + ". " + chunks[i]
+                        : chunks[i];
+                    const audioBuffer = await callTTS(chunkText);
+                    await _tgApi.sendVoiceMessage(audioBuffer);
+                    _log("TTS parte " + (i + 1) + "/" + chunks.length + " enviada: " + audioBuffer.length + " bytes");
+                }
             } catch (ttsErr) {
                 _log("Error generando TTS, fallback a texto: " + ttsErr.message);
                 await _cmdContext.sendResult("🎤 Voz", result);
@@ -397,6 +433,7 @@ module.exports = {
     callOpenAITTS,
     callElevenLabsTTS,
     callTTS,
+    splitTextForTTS,
     extractClaudeResponse,
     isDocumentImage,
     handlePhoto,

--- a/.pipeline/multimedia.js
+++ b/.pipeline/multimedia.js
@@ -229,11 +229,10 @@ function textToSpeech(text) {
   if (!apiKey) return Promise.resolve(null);
 
   return new Promise((resolve, reject) => {
-    const truncated = text.length > 2000 ? text.substring(0, 1950) + '... (respuesta truncada)' : text;
-
+    // OpenAI TTS soporta hasta 4096 chars — NO truncar, los callers manejan chunking
     const body = JSON.stringify({
       model: 'gpt-4o-mini-tts',
-      input: truncated,
+      input: text.substring(0, 4096),
       voice: 'ash',
       instructions: 'Hablas como un porteño de Buenos Aires, con tonada rioplatense. Usas vos en vez de tu, decis dale, che, mira. El ritmo es de charla entre amigos. Sos inteligente pero cero formal.',
       response_format: 'opus'
@@ -307,4 +306,37 @@ function sendVoiceTelegram(audioBuffer, botToken, chatId) {
   });
 }
 
-module.exports = { preprocessMessage, transcribeAudio, describeImage, downloadTelegramFile, textToSpeech, sendVoiceTelegram };
+// Partir texto en chunks para TTS respetando límites de oraciones
+function splitTextForTTSChunks(text, maxChars) {
+  if (text.length <= maxChars) return [text];
+  const sentences = text.split(/(?<=[.!?])\s+/);
+  const chunks = [];
+  let current = '';
+  for (const sentence of sentences) {
+    if ((current + ' ' + sentence).length > maxChars && current.length > 0) {
+      chunks.push(current.trim());
+      current = sentence;
+    } else {
+      current = current ? current + ' ' + sentence : sentence;
+    }
+  }
+  if (current.trim()) chunks.push(current.trim());
+  const result = [];
+  for (const chunk of chunks) {
+    if (chunk.length <= maxChars) { result.push(chunk); continue; }
+    const words = chunk.split(/\s+/);
+    let part = '';
+    for (const word of words) {
+      if ((part + ' ' + word).length > maxChars && part.length > 0) {
+        result.push(part.trim());
+        part = word;
+      } else {
+        part = part ? part + ' ' + word : word;
+      }
+    }
+    if (part.trim()) result.push(part.trim());
+  }
+  return result;
+}
+
+module.exports = { preprocessMessage, transcribeAudio, describeImage, downloadTelegramFile, textToSpeech, sendVoiceTelegram, splitTextForTTSChunks };

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -63,6 +63,40 @@ function ghCommentOnIssue(issueNumber, body) {
 
 // --- Utilidades ---
 
+// Partir texto en chunks para TTS respetando límites de oraciones
+function splitTextForTTSChunks(text, maxChars) {
+  if (text.length <= maxChars) return [text];
+  const sentences = text.split(/(?<=[.!?])\s+/);
+  const chunks = [];
+  let current = '';
+  for (const sentence of sentences) {
+    if ((current + ' ' + sentence).length > maxChars && current.length > 0) {
+      chunks.push(current.trim());
+      current = sentence;
+    } else {
+      current = current ? current + ' ' + sentence : sentence;
+    }
+  }
+  if (current.trim()) chunks.push(current.trim());
+  // Oraciones individuales más largas que maxChars → corte por palabras
+  const result = [];
+  for (const chunk of chunks) {
+    if (chunk.length <= maxChars) { result.push(chunk); continue; }
+    const words = chunk.split(/\s+/);
+    let part = '';
+    for (const word of words) {
+      if ((part + ' ' + word).length > maxChars && part.length > 0) {
+        result.push(part.trim());
+        part = word;
+      } else {
+        part = part ? part + ' ' + word : word;
+      }
+    }
+    if (part.trim()) result.push(part.trim());
+  }
+  return result;
+}
+
 function log(brazo, msg) {
   const ts = new Date().toISOString().replace('T', ' ').slice(0, 19);
   console.log(`[${ts}] [${brazo}] ${msg}`);
@@ -3077,10 +3111,16 @@ async function cmdStatus(config) {
         }
       } catch {}
 
-      const audioBuffer = await textToSpeech(narration);
-      if (audioBuffer) {
-        await sendVoiceTelegram(audioBuffer, botToken, chatId);
-        log('commander', '[status] Audio TTS enviado');
+      const statusChunks = splitTextForTTSChunks(narration, 3800);
+      for (let i = 0; i < statusChunks.length; i++) {
+        const chunkText = statusChunks.length > 1
+          ? `Parte ${i + 1} de ${statusChunks.length}. ${statusChunks[i]}`
+          : statusChunks[i];
+        const audioBuffer = await textToSpeech(chunkText);
+        if (audioBuffer) {
+          await sendVoiceTelegram(audioBuffer, botToken, chatId);
+          log('commander', `[status] Audio TTS parte ${i + 1}/${statusChunks.length} enviado`);
+        }
       }
     }
   } catch (audioErr) {
@@ -3811,12 +3851,18 @@ INSTRUCCIÓN: Integrá los complementos del usuario en tu respuesta. Generá UNA
         // Si hubo audio → intentar TTS
         if (esAudio) {
           try {
-            const audioBuffer = await textToSpeech(respuesta);
-            if (audioBuffer) {
-              const audioPath = path.join(LOG_DIR, 'media', `tts-${Date.now()}.ogg`);
-              fs.writeFileSync(audioPath, audioBuffer);
-              enviado = await sendVoiceTelegram(audioBuffer, botToken, chatId);
-              if (enviado) log('telegram', `Audio TTS enviado (${audioBuffer.length} bytes)`);
+            const chatChunks = splitTextForTTSChunks(respuesta, 3800);
+            for (let i = 0; i < chatChunks.length; i++) {
+              const chunkText = chatChunks.length > 1
+                ? `Parte ${i + 1} de ${chatChunks.length}. ${chatChunks[i]}`
+                : chatChunks[i];
+              const audioBuffer = await textToSpeech(chunkText);
+              if (audioBuffer) {
+                const audioPath = path.join(LOG_DIR, 'media', `tts-${Date.now()}-${i}.ogg`);
+                fs.writeFileSync(audioPath, audioBuffer);
+                enviado = await sendVoiceTelegram(audioBuffer, botToken, chatId);
+                if (enviado) log('telegram', `Audio TTS parte ${i + 1}/${chatChunks.length} enviado (${audioBuffer.length} bytes)`);
+              }
             }
           } catch (e) {
             log('commander', `TTS error: ${e.message}`);

--- a/qa/scripts/qa-narration.js
+++ b/qa/scripts/qa-narration.js
@@ -108,13 +108,10 @@ function parseArgs() {
 
 function callOpenAITTS(text, apiKey) {
     return new Promise((resolve, reject) => {
-        const truncated = text.length > 2000
-            ? text.substring(0, 1950) + "... (truncado)"
-            : text;
-
+        // OpenAI TTS soporta hasta 4096 chars — NO truncar
         const body = JSON.stringify({
             model: TTS_MODEL,
-            input: truncated,
+            input: text.substring(0, 4096),
             voice: TTS_VOICE,
             instructions: TTS_INSTRUCTIONS,
             response_format: "opus"


### PR DESCRIPTION
## Resumen

Eliminada truncación silenciosa a 2000 caracteres que cortaba audios TTS largos. Ahora se implementa chunking por oraciones (máx 3800 chars/chunk, bajo el límite de 4096 de OpenAI TTS) y se envían múltiples voice messages con numeración "Parte X de Y".

### Cambios
- `multimedia-handler.js`: Nueva función `splitTextForTTS()` + chunking en `handleVoiceOrAudio` y `callOpenAITTS`
- `multimedia.js`: Removida truncación en `textToSpeech()`, agregada `splitTextForTTSChunks()`
- `pulpo.js`: `/status` y chat TTS usan chunking con `splitTextForTTSChunks()`
- `callback-handler.js`: TTS bajo demanda usa chunking en vez de `substring(0, 2000)`
- `qa-narration.js`: Removida truncación (ya segmenta por pasos de video)

### Comportamiento esperado
- Audio corto (<3800 chars): se envía como un único voice message
- Audio largo (>3800 chars): se parte por oraciones, se envía como N voice messages consecutivos con "Parte X de Y"
- Nunca se pierde contenido — la suma de todos los audios representa el texto completo

Closes #1920

QA Validate: omitido — bugfix de infraestructura (hooks Telegram), sin impacto en UI ⚠️

🤖 Generado con [Claude Code](https://claude.ai/claude-code)