### PR TITLE
fix(pipeline): excluir bloqueados del conteo de ventanas de prioridad

### DIFF
--- a/.pipeline/dashboard-v2.js
+++ b/.pipeline/dashboard-v2.js
@@ -1299,6 +1299,10 @@ h2{color:var(--dim);font-size:0.8em;text-transform:uppercase;letter-spacing:2px;
 .cell-current{background:rgba(88,166,255,0.07);border-left:3px solid var(--ac)}
 .issue-done{opacity:0.38}
 .issue-listo{opacity:0.65}
+.issue-blocked{background:rgba(248,81,73,0.08)}
+.block-icon{position:relative;margin-left:4px;cursor:help;font-size:0.85em}
+.block-icon .block-tt{display:none;position:absolute;left:50%;transform:translateX(-50%);bottom:120%;background:var(--sf);color:var(--fg);padding:4px 8px;border-radius:4px;font-size:0.8em;white-space:nowrap;z-index:10;border:1px solid var(--bd)}
+.block-icon:hover .block-tt{display:block}
 
 /* ── Chips ──────────────────────────────────────────────────────────────── */
 .chip{

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -1064,7 +1064,12 @@ function countPendingVerificacion(config) {
   for (const [pName, pConfig] of Object.entries(config.pipelines)) {
     if (!pConfig.fases.includes('verificacion')) continue;
     const pendDir = path.join(PIPELINE, pName, 'verificacion', 'pendiente');
-    count += listWorkFiles(pendDir).length;
+    const files = listWorkFiles(pendDir);
+    for (const f of files) {
+      const issue = issueFromFile(f.name);
+      const labels = getIssueLabels(issue);
+      if (!labels.includes('blocked:dependencies')) count++;
+    }
   }
   return count;
 }
@@ -1172,7 +1177,12 @@ function countPendingBuild(config) {
   for (const [pName, pConfig] of Object.entries(config.pipelines)) {
     if (!pConfig.fases.includes('build')) continue;
     const pendDir = path.join(PIPELINE, pName, 'build', 'pendiente');
-    count += listWorkFiles(pendDir).length;
+    const files = listWorkFiles(pendDir);
+    for (const f of files) {
+      const issue = issueFromFile(f.name);
+      const labels = getIssueLabels(issue);
+      if (!labels.includes('blocked:dependencies')) count++;
+    }
   }
   return count;
 }
@@ -4228,6 +4238,10 @@ function brazoDesbloqueo(config) {
 
     log('desbloqueo', `Revisando ${blockedIssues.length} issues bloqueados por dependencias`);
 
+    // Mapeos bidireccionales para el dashboard
+    const blockedBy = {};  // issue → [dependencias]
+    const blocks = {};     // dependencia → [issues que bloquea]
+
     for (const issue of blockedIssues) {
       try {
         // 2. Leer comentarios del issue para encontrar dependencias creadas por el pipeline
@@ -4249,6 +4263,13 @@ function brazoDesbloqueo(config) {
         if (depIssueNumbers.length === 0) {
           log('desbloqueo', `#${issue.number}: no se encontraron issues de dependencia — omitido`);
           continue;
+        }
+
+        // Registrar mapeos bidireccionales
+        blockedBy[issue.number] = depIssueNumbers;
+        for (const dep of depIssueNumbers) {
+          if (!blocks[dep]) blocks[dep] = [];
+          if (!blocks[dep].includes(String(issue.number))) blocks[dep].push(String(issue.number));
         }
 
         // 3. Verificar si todas las dependencias están cerradas
@@ -4276,6 +4297,13 @@ function brazoDesbloqueo(config) {
           // 4. Todas cerradas → desbloquear
           log('desbloqueo', `#${issue.number}: todas las dependencias cerradas (${depIssueNumbers.join(', ')}) → desbloqueando`);
 
+          // Quitar de los mapeos (ya no está bloqueado)
+          delete blockedBy[issue.number];
+          for (const dep of depIssueNumbers) {
+            if (blocks[dep]) blocks[dep] = blocks[dep].filter(n => n !== String(issue.number));
+            if (blocks[dep] && blocks[dep].length === 0) delete blocks[dep];
+          }
+
           // Quitar label blocked:dependencies
           ghThrottle();
           execSync(
@@ -4299,6 +4327,13 @@ function brazoDesbloqueo(config) {
       } catch (e) {
         log('desbloqueo', `Error procesando #${issue.number}: ${e.message}`);
       }
+    }
+
+    // Persistir mapeos para el dashboard
+    try {
+      fs.writeFileSync(path.join(PIPELINE, 'blocked-issues.json'), JSON.stringify({ blockedBy, blocks }, null, 2));
+    } catch (e) {
+      log('desbloqueo', `Error persistiendo blocked-issues.json: ${e.message}`);
     }
   } catch (e) {
     log('desbloqueo', `Error en brazo de desbloqueo: ${e.message}`);


### PR DESCRIPTION
## Summary
- `countPendingBuild()` y `countPendingVerificacion()` excluyen issues con `blocked:dependencies` del conteo, evitando deadlock donde la Build Priority Window se activa por builds que nunca van a correr
- Brazo desbloqueo del pulpo persiste `blocked-issues.json` con mapeos bidireccionales para alimentar indicadores visuales del dashboard (#2170)
- CSS faltante para `.issue-blocked`, `.block-icon` y tooltips de bloqueo

## Causa raíz
La Build Priority Window se activaba contando 2 builds pendientes (#1920 y #2017), pero ambos tenían `blocked:dependencies`. La ventana bloqueaba dev y validación, y los builds nunca arrancaban → deadlock total, 0 agentes lanzados.

Closes #2170

🤖 Generated with [Claude Code](https://claude.com/claude-code)