### PR TITLE
fix(pipeline): corregir ventanas de prioridad atascadas y bloqueos incorrectos

### DIFF
--- a/.pipeline/dashboard-v2.js
+++ b/.pipeline/dashboard-v2.js
@@ -672,11 +672,12 @@ function generateHTML(state) {
       }
     }
 
-    const blockedBy = state.blockedIssues.blockedBy[issueNum] || [];
+    const blockedBy = state.blockedIssues.blockedBy[issueNum];
     const blocksOthers = state.blockedIssues.blocks[issueNum] || [];
     let blockIcons = '';
-    if (blockedBy.length > 0) {
-      const depLinks = blockedBy.map(d => '#' + d).join(', ');
+    if (blockedBy != null) {
+      // blockedBy puede ser [] (label sin deps conocidas) o [n1, n2, ...] (con deps)
+      const depLinks = blockedBy.length > 0 ? blockedBy.map(d => '#' + d).join(', ') : 'dependencias no especificadas';
       blockIcons += `<span class="block-icon block-locked">🔒<span class="block-tt">Bloqueado por: ${depLinks}</span></span>`;
     }
     if (blocksOthers.length > 0) {
@@ -799,7 +800,7 @@ function generateHTML(state) {
       cells += `<td class="${isCurrent ? 'cell-current' : ''} ${pipeline === 'definicion' ? 'col-def' : 'col-dev'}">${chips}</td>`;
     }
 
-    const blockedClass = blockedBy.length > 0 ? ' issue-blocked' : '';
+    const blockedClass = blockedBy != null ? ' issue-blocked' : '';
     const rowClass = (data.estadoActual ? `issue-${data.estadoActual}` : 'issue-done') + blockedClass;
     const hiddenClass = rowIndex >= ISSUE_VISIBLE_LIMIT ? ' issue-overflow' : '';
     rows += `<tr class="${rowClass}${hiddenClass}">${issueCell}${cells}</tr>`;

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -1917,14 +1917,15 @@ function brazoLanzamiento(config) {
   // Leer activaciones/desactivaciones manuales del dashboard
   readManualPriorityOverrides();
 
+  // Evaluar Priority Windows ANTES del gate de recursos — para que puedan
+  // desactivarse (cola vacía) incluso cuando el sistema está bajo presión.
+  // Sin esto, una ventana activada durante un pico de carga queda atascada
+  // indefinidamente porque isSystemOverloaded() retorna antes de la evaluación.
+  const qaPriority = evaluateQaPriority(config);
+  const buildPriority = evaluateBuildPriority(config);
+
   // GATE DE RECURSOS: presión graduada (green/yellow/orange/red)
   if (isSystemOverloaded(config)) return;
-
-  // Evaluar QA Priority Window — bloquea dev si QA está acumulado
-  const qaPriority = evaluateQaPriority(config);
-
-  // Evaluar Build Priority Window — bloquea dev si builds están acumulados
-  const buildPriority = evaluateBuildPriority(config);
 
   // Calcular multiplicador de concurrencia según presión actual
   const pressure = getResourcePressure(config);
@@ -4234,7 +4235,11 @@ function brazoDesbloqueo(config) {
       { cwd: ROOT, encoding: 'utf8', timeout: 30000, windowsHide: true }
     );
     const blockedIssues = JSON.parse(result || '[]');
-    if (blockedIssues.length === 0) return;
+    if (blockedIssues.length === 0) {
+      // Limpiar datos stale — si ya no hay bloqueados, el dashboard debe saberlo
+      try { fs.writeFileSync(path.join(PIPELINE, 'blocked-issues.json'), JSON.stringify({ blockedBy: {}, blocks: {} }, null, 2)); } catch {}
+      return;
+    }
 
     log('desbloqueo', `Revisando ${blockedIssues.length} issues bloqueados por dependencias`);
 
@@ -4254,14 +4259,19 @@ function brazoDesbloqueo(config) {
         // Buscar el comentario de dependencias del pipeline
         const depCommentMatch = comments.match(/Dependencias detectadas por el pipeline[\s\S]*?(?=\n\n|\Z)/);
         if (!depCommentMatch) {
-          log('desbloqueo', `#${issue.number}: no se encontró comentario de dependencias — omitido`);
+          // Issue tiene label blocked:dependencies pero sin comentario de dependencias.
+          // Registrarlo con lista vacía para que el dashboard muestre el icono de bloqueo.
+          log('desbloqueo', `#${issue.number}: label blocked:dependencies sin comentario de dependencias — registrado sin deps`);
+          blockedBy[issue.number] = [];
           continue;
         }
 
-        // Extraer números de issues referenciados (#NNN)
-        const depIssueNumbers = [...depCommentMatch[0].matchAll(/#(\d+)/g)].map(m => m[1]);
+        // Extraer números de issues referenciados (#NNN), excluyendo auto-referencia
+        const depIssueNumbers = [...depCommentMatch[0].matchAll(/#(\d+)/g)]
+          .map(m => m[1])
+          .filter(n => n !== String(issue.number));
         if (depIssueNumbers.length === 0) {
-          log('desbloqueo', `#${issue.number}: no se encontraron issues de dependencia — omitido`);
+          log('desbloqueo', `#${issue.number}: no se encontraron issues de dependencia (excluida auto-referencia) — omitido`);
           continue;
         }
 


### PR DESCRIPTION
## Summary
- Mover evaluación de priority windows ANTES del gate de recursos — ventanas se desactivan incluso bajo presión ORANGE/RED (causa raíz de build priority stuck)
- Filtrar auto-referencias en brazoDesbloqueo (#1951 se reportaba bloqueado por sí mismo)
- Escribir `blocked-issues.json` vacío cuando no hay issues bloqueados (limpia datos stale)
- Registrar issues con label `blocked:dependencies` sin comentario de dependencias
- Dashboard: mostrar icono 🔒 para issues con deps vacías o no especificadas

## Test plan
- [ ] Verificar que el pipeline toma issues nuevos (dev no bloqueado por build priority fantasma)
- [ ] Verificar iconos 🔒 visibles en dashboard para issues con `blocked:dependencies`
- [ ] Verificar que `blocked-issues.json` se limpia cuando no hay issues bloqueados
- [ ] Verificar que #1951 no aparece bloqueado por sí mismo

🤖 Generated with [Claude Code](https://claude.com/claude-code)