### PR TITLE
fix(pipeline): agente build genera APK cuando el issue lo requiere

### DIFF
--- a/.pipeline/roles/build.md
+++ b/.pipeline/roles/build.md
@@ -1,6 +1,6 @@
 # Rol: Build (Agente Claude)
 
-Sos el agente de build del pipeline. Tu única tarea es compilar y verificar el código del issue asignado.
+Sos el agente de build del pipeline. Tu tarea es compilar, verificar el código del issue asignado, y generar el APK si el issue lo requiere.
 
 ## Contexto
 
@@ -33,14 +33,61 @@ Las exclusiones son obligatorias:
 - `WasmJs` test compilation causa OOM
 - Targets `iOS` no aplican en CI local
 
-### 3. Reportar resultado
+Si el build falla, saltar directamente al paso 5 (reportar rechazado).
+
+### 3. Determinar si el issue requiere APK
+
+Consultá los labels del issue usando el número de issue del archivo YAML de trabajo:
+
+```bash
+export PATH="/c/Workspaces/gh-cli/bin:$PATH"
+gh issue view <ISSUE_NUMBER> --json labels --jq ".labels[].name"
+```
+
+El issue requiere APK **solo si tiene alguno de estos labels**:
+- `app:client` → flavor `client` → task `assembleClientDebug`
+- `app:business` → flavor `business` → task `assembleBusinessDebug`
+- `app:delivery` → flavor `delivery` → task `assembleDeliveryDebug`
+
+Si el issue **no tiene ningún label `app:*`**, saltar al paso 5 directamente. No se necesita APK.
+
+### 4. Generar y depositar APK
+
+Por cada flavor requerido (según los labels del paso 3):
+
+```bash
+export JAVA_HOME="C:/Users/Administrator/.jdks/temurin-21.0.7"
+export GRADLE_OPTS="-Xmx3g -Dfile.encoding=UTF-8"
+
+./gradlew :app:composeApp:assemble<Flavor>Debug --no-daemon \
+  -x compileTestDevelopmentExecutableKotlinWasmJs \
+  -x compileTestKotlinIosX64 \
+  -x compileKotlinIosSimulatorArm64 \
+  -x compileTestKotlinIosSimulatorArm64
+```
+
+Donde `<Flavor>` es `Client`, `Business` o `Delivery` (primera letra mayúscula).
+
+Después de compilar, copiar el APK al directorio de artefactos QA con la naming convention que el preflight espera:
+
+```bash
+mkdir -p qa/artifacts
+cp app/composeApp/build/outputs/apk/<flavor>/debug/app-<flavor>-debug.apk \
+   qa/artifacts/<ISSUE_NUMBER>-composeApp-<flavor>-debug.apk
+```
+
+Donde `<flavor>` es en minúsculas (`client`, `business`, `delivery`) y `<ISSUE_NUMBER>` es el número del issue.
+
+Si el assemble falla, reportá `resultado: rechazado` con el error.
+
+### 5. Reportar resultado
 
 Escribí el resultado en el archivo YAML de trabajo (path en tu prompt):
 
-- **Si el build pasa (exit 0):** `resultado: aprobado`
+- **Si el build pasa (y el APK se generó si era necesario):** `resultado: aprobado`
 - **Si el build falla:** `resultado: rechazado` con `motivo:` incluyendo las líneas de error relevantes del output
 
-### 4. Matar Gradle daemons
+### 6. Matar Gradle daemons
 
 Después de terminar (pase o falle), matá los daemons de Gradle para liberar RAM:
 


### PR DESCRIPTION
## Resumen

- El agente build solo ejecutaba `./gradlew check` pero nunca generaba el APK que QA espera
- Esto causaba loop infinito verificacion↔build en issue #2019 (16+ rebotes)
- Ahora el build consulta labels del issue y genera APK solo cuando tiene `app:*`

## Cambios

- **Paso 3**: consultar labels via `gh issue view` para determinar si requiere APK
- **Paso 4**: ejecutar `assemble<Flavor>Debug` y copiar APK a `qa/artifacts/` con naming convention correcta

## QA

`qa:skipped` — cambio de infra pura (instrucciones de agente en `.pipeline/roles/build.md`, sin código de producto)

🤖 Generado con [Claude Code](https://claude.ai/claude-code)