### PR TITLE
fix(pipeline): mejorar detección de dependencias en issues bloqueados

### DIFF
--- a/.pipeline/dashboard-v2.js
+++ b/.pipeline/dashboard-v2.js
@@ -800,7 +800,7 @@ function generateHTML(state) {
       if (blockedBy.length > 0) {
         depText = blockedBy.map(d => `#${d}`).join(', ');
       } else {
-        depText = '—';
+        depText = 'sin dependencias especificadas';
       }
       blockIcons += `<span class="block-icon block-locked" title="Bloqueado">🚫<span class="block-tt">Bloqueado por: ${depText}</span></span>`;
     }

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -4258,20 +4258,31 @@ function brazoDesbloqueo(config) {
 
         // Buscar el comentario de dependencias del pipeline
         const depCommentMatch = comments.match(/Dependencias detectadas por el pipeline[\s\S]*?(?=\n\n|\Z)/);
-        if (!depCommentMatch) {
-          // Issue tiene label blocked:dependencies pero sin comentario de dependencias.
-          // Registrarlo con lista vacía para que el dashboard muestre el icono de bloqueo.
-          log('desbloqueo', `#${issue.number}: label blocked:dependencies sin comentario de dependencias — registrado sin deps`);
-          blockedBy[issue.number] = [];
-          continue;
+        let depIssueNumbers = [];
+        if (depCommentMatch) {
+          depIssueNumbers = [...depCommentMatch[0].matchAll(/#(\d+)/g)]
+            .map(m => m[1])
+            .filter(n => n !== String(issue.number));
         }
 
-        // Extraer números de issues referenciados (#NNN), excluyendo auto-referencia
-        const depIssueNumbers = [...depCommentMatch[0].matchAll(/#(\d+)/g)]
-          .map(m => m[1])
-          .filter(n => n !== String(issue.number));
+        // Fallback: si no hay deps en el comentario del pipeline, buscar en body + todos los comentarios
         if (depIssueNumbers.length === 0) {
-          log('desbloqueo', `#${issue.number}: no se encontraron issues de dependencia (excluida auto-referencia) — omitido`);
+          try {
+            ghThrottle();
+            const fullData = execSync(
+              `"${GH_BIN}" issue view ${issue.number} --json body,comments --jq "[.body, .comments[].body] | join(\\"\\\\n\\")" --repo intrale/platform`,
+              { cwd: ROOT, encoding: 'utf8', timeout: 15000, windowsHide: true }
+            );
+            const allRefs = [...fullData.matchAll(/#(\d+)/g)]
+              .map(m => m[1])
+              .filter(n => n !== String(issue.number));
+            depIssueNumbers = [...new Set(allRefs)]; // dedup
+          } catch {}
+        }
+
+        if (depIssueNumbers.length === 0) {
+          log('desbloqueo', `#${issue.number}: label blocked:dependencies sin dependencias detectables — registrado sin deps`);
+          blockedBy[issue.number] = [];
           continue;
         }
 


### PR DESCRIPTION
## Resumen

- Dashboard: tooltip de bloqueo muestra "sin dependencias especificadas" cuando no hay deps (antes mostraba "—")
- Pulpo: fallback busca refs `#NNN` en body + todos los comentarios del issue, no solo en el comentario específico del pipeline

## Contexto

Los issues #1913, #2019, #2021 tienen label `blocked:dependencies` pero el comentario del pipeline está vacío (solo header sin issues). El tooltip de bloqueo no mostraba información útil.

## Test plan

- [ ] Verificar tooltip en dashboard muestra "sin dependencias especificadas" para issues sin deps
- [ ] Verificar que el pulpo detecta refs en body/comentarios como fallback

🤖 Generado con [Claude Code](https://claude.ai/claude-code)