### PR TITLE
fix(builder): heap Gradle, watchdog timeout y build selectivo

### DIFF
--- a/.pipeline/config.yaml
+++ b/.pipeline/config.yaml
@@ -134,6 +134,14 @@ timeouts:
   intake_interval_seconds: 300    # Frecuencia de intake (GitHub API, 5 min)
   orphan_timeout_minutes: 10      # Archivo en trabajando/ sin proceso → vuelve a pendiente
 
+  # Timeout efectivo por agente (watchdog en pulpo.js mata al hijo si lo excede)
+  # Si un skill no está en el override, se usa agent_timeout_default_minutes.
+  agent_timeout_default_minutes: 30
+  agent_timeout_overrides:
+    build: 60                     # Gradle check + assemble puede tardar mucho en primer build
+    qa: 45                        # QA E2E con emulador + video
+    tester: 45                    # Cobertura Kover + suite completa
+
 # GitHub
 github:
   owner: "intrale"

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -2760,13 +2760,38 @@ function lanzarAgenteClaude(skill, issue, trabajandoPath, pipeline, fase, config
   // mata la herencia y el hijo pierde stdout/stderr.
   // Se cierra en child.on('exit') para que el log capture todo el output.
 
+  // Watchdog de timeout por skill: mata al hijo si excede el límite configurado.
+  // Razón: sin enforcement, un /builder con OOM repetido puede quedar 1h+ en loop
+  // (incidente #2218). El tope de 30m del rol no se aplica solo — hay que forzarlo.
+  const timeoutOverrides = config.timeouts?.agent_timeout_overrides || {};
+  const timeoutDefault = config.timeouts?.agent_timeout_default_minutes || 30;
+  const timeoutMin = timeoutOverrides[skill] ?? timeoutDefault;
+  const timeoutMs = timeoutMin * 60 * 1000;
+  const watchdog = setTimeout(() => {
+    if (child.exitCode === null && child.signalCode === null) {
+      log('lanzamiento', `⏱️ ${skill}:#${issue} excedió ${timeoutMin}min — matando (watchdog)`);
+      try { child.kill('SIGTERM'); } catch {}
+      setTimeout(() => { try { child.kill('SIGKILL'); } catch {} }, 10000);
+      try {
+        const data = readYaml(trabajandoPath);
+        data.resultado = 'rechazado';
+        data.motivo = `Timeout de watchdog: excedió ${timeoutMin} minutos sin terminar`;
+        data.rechazado_por = 'watchdog-timeout';
+        writeYaml(trabajandoPath, data);
+      } catch {}
+      sendTelegram(`⏱️ ${skill}:#${issue} matado por watchdog (${timeoutMin}min). Rebote a pendiente.`);
+    }
+  }, timeoutMs);
+  watchdog.unref?.();
+
   activeProcesses.set(processKey(skill, issue), {
     pid: child.pid,
     startTime: Date.now(),
     trabajandoPath,
     pipeline,
     fase,
-    worktreePath: (needsWorktree || useExistingWorktree) ? worktreePath : null
+    worktreePath: (needsWorktree || useExistingWorktree) ? worktreePath : null,
+    watchdog
   });
 
   // Crear canal de contexto para el agente (auto-join)
@@ -2796,6 +2821,8 @@ function lanzarAgenteClaude(skill, issue, trabajandoPath, pipeline, fase, config
   child.on('exit', (code) => {
     // Cerrar el FD del log ahora que el hijo terminó
     try { fs.closeSync(agentLogFd); } catch {}
+    // Cancelar watchdog de timeout (ya terminó, por el motivo que sea)
+    clearTimeout(watchdog);
 
     const elapsedSec = (Date.now() - launchTime) / 1000;
 

--- a/.pipeline/roles/build.md
+++ b/.pipeline/roles/build.md
@@ -18,10 +18,36 @@ Si hay conflictos de merge, reportá `resultado: rechazado` con el detalle de lo
 
 ### 2. Ejecutar build
 
+Primero consultá los labels del issue para decidir si se necesitan targets Android Release:
+
+```bash
+export PATH="/c/Workspaces/gh-cli/bin:$PATH"
+HAS_APP_LABEL=$(gh issue view <ISSUE_NUMBER> --json labels --jq '[.labels[].name] | map(select(startswith("app:"))) | length')
+```
+
+Exportá las variables de entorno (alineadas con `gradle.properties`, no override a la baja):
+
 ```bash
 export JAVA_HOME="C:/Users/Administrator/.jdks/temurin-21.0.7"
-export GRADLE_OPTS="-Xmx3g -Dfile.encoding=UTF-8"
+export GRADLE_OPTS="-Xmx6g -XX:+UseG1GC -Dfile.encoding=UTF-8"
+```
 
+Si el issue **NO tiene ningún label `app:*`** (`HAS_APP_LABEL=0`), corré con exclusiones de Release Android:
+
+```bash
+./gradlew check --no-daemon \
+  -x compileTestDevelopmentExecutableKotlinWasmJs \
+  -x compileTestKotlinIosX64 \
+  -x compileKotlinIosSimulatorArm64 \
+  -x compileTestKotlinIosSimulatorArm64 \
+  -x compileClientReleaseKotlinAndroid \
+  -x compileBusinessReleaseKotlinAndroid \
+  -x compileDeliveryReleaseKotlinAndroid
+```
+
+Si el issue **tiene algún label `app:*`** (`HAS_APP_LABEL>0`), corré sin exclusiones de Release Android (se necesitan para el APK del paso 4):
+
+```bash
 ./gradlew check --no-daemon \
   -x compileTestDevelopmentExecutableKotlinWasmJs \
   -x compileTestKotlinIosX64 \
@@ -29,22 +55,13 @@ export GRADLE_OPTS="-Xmx3g -Dfile.encoding=UTF-8"
   -x compileTestKotlinIosSimulatorArm64
 ```
 
-Las exclusiones son obligatorias:
-- `WasmJs` test compilation causa OOM
-- Targets `iOS` no aplican en CI local
+Las exclusiones permanentes (`WasmJs` test y iOS) son siempre obligatorias. Las de `compile*ReleaseKotlinAndroid` se aplican solo cuando no hay cambios que afecten a Android, para evitar OOM y tiempos de build largos en cambios de backend puros.
 
 Si el build falla, saltar directamente al paso 5 (reportar rechazado).
 
 ### 3. Determinar si el issue requiere APK
 
-Consultá los labels del issue usando el número de issue del archivo YAML de trabajo:
-
-```bash
-export PATH="/c/Workspaces/gh-cli/bin:$PATH"
-gh issue view <ISSUE_NUMBER> --json labels --jq ".labels[].name"
-```
-
-El issue requiere APK **solo si tiene alguno de estos labels**:
+Usando los labels ya consultados en el paso 2, el issue requiere APK **solo si tiene alguno de estos labels**:
 - `app:client` → flavor `client` → task `assembleClientDebug`
 - `app:business` → flavor `business` → task `assembleBusinessDebug`
 - `app:delivery` → flavor `delivery` → task `assembleDeliveryDebug`
@@ -57,7 +74,7 @@ Por cada flavor requerido (según los labels del paso 3):
 
 ```bash
 export JAVA_HOME="C:/Users/Administrator/.jdks/temurin-21.0.7"
-export GRADLE_OPTS="-Xmx3g -Dfile.encoding=UTF-8"
+export GRADLE_OPTS="-Xmx6g -XX:+UseG1GC -Dfile.encoding=UTF-8"
 
 ./gradlew :app:composeApp:assemble<Flavor>Debug --no-daemon \
   -x compileTestDevelopmentExecutableKotlinWasmJs \
@@ -100,7 +117,7 @@ Después de terminar (pase o falle), matá los daemons de Gradle para liberar RA
 - NO modifiques código. Solo compilá y reportá.
 - NO creés worktrees nuevos. Usá el que te asignaron.
 - NO pusheés nada. Solo lectura + build.
-- Timeout máximo: 30 minutos. Si el build no termina, reportá rechazado.
+- Timeout máximo: 60 minutos (enforzado por watchdog en `pulpo.js` vía `agent_timeout_overrides.build` en `config.yaml`). Si te acercás al límite, reportá rechazado con el último error observado.
 - JAVA_HOME debe ser Temurin 21 (no IntelliJ JBR).
 
 ## Modelo

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,14 +3,15 @@ kotlin.version=2.2.21
 kotlin.code.style=official
 
 kotlin.compiler.execution.strategy=in-process
-kotlin.daemon.jvmargs=-Xmx3g
+kotlin.daemon.jvmargs=-Xmx4g -XX:+UseG1GC
 
 #Gradle
 org.gradle.daemon=false
-org.gradle.jvmargs=-Xmx3g -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options\="-Xmx3g"
+org.gradle.jvmargs=-Xmx6g -XX:MaxMetaspaceSize=1g -XX:+UseG1GC -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options\="-Xmx4g"
 org.gradle.java.installations.auto-download=false
 org.gradle.caching=true
 org.gradle.parallel=true
+org.gradle.workers.max=3
 
 #Android
 android.nonTransitiveRClass=true


### PR DESCRIPTION
## Summary

- **gradle.properties**: heap Gradle `-Xmx3g` → `-Xmx6g` con G1GC + `kotlin.daemon.jvmargs -Xmx4g` + `MaxMetaspaceSize=1g`. Ataca la causa raíz del OOM crónico en `compileReleaseKotlinAndroid`.
- **pulpo.js + config.yaml**: watchdog de timeout enforzado. `agent_timeout_default_minutes: 30` con overrides por skill (`build: 60`, `qa: 45`, `tester: 45`). Al exceder dispara `SIGTERM` + `SIGKILL` en 10s, marca el YAML de trabajo como `rechazado` con motivo `watchdog-timeout` y avisa por Telegram.
- **build.md**: build selectivo. Si el issue no tiene labels `app:*`, el paso `check` excluye `compile{Client,Business,Delivery}ReleaseKotlinAndroid` — un fix de backend no debería compilar Release Android (lección de #2159 donde un cambio de 1 línea pegó 1h18m en OOM loop).

Contexto completo y evidencia en #2218.

## Test plan

- [ ] Lanzar build sobre un issue sin `app:*` → verificar que el log muestra las 3 exclusiones `-x compile*ReleaseKotlinAndroid`
- [ ] Lanzar build sobre un issue con `app:delivery` → verificar que las exclusiones NO se aplican y el APK se genera
- [ ] Simular timeout (reducir override temporalmente) → verificar que el watchdog mata, mueve a pendiente y manda Telegram
- [ ] Verificar que un build normal <60min termina limpio y el watchdog se cancela con `clearTimeout`
- [ ] `qa:skipped` aplicable (infra de pipeline, sin impacto en producto de usuario)

Closes #2218

🤖 Generated with [Claude Code](https://claude.com/claude-code)