### PR TITLE
fix(pipeline): variable pipelineName en guard de issue cerrado

### DIFF
--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -2039,7 +2039,7 @@ function brazoLanzamiento(config) {
     // 0c. CLOSED: no lanzar issues cerrados en GitHub — archivar y seguir
     if (isIssueClosed(issue)) {
       log('lanzamiento', `#${issue} omitido — issue cerrado en GitHub, archivando`);
-      const archDir = path.join(fasePath(pipeline, fase), 'archivado');
+      const archDir = path.join(fasePath(pipelineName, fase), 'archivado');
       fs.mkdirSync(archDir, { recursive: true });
       moveFile(archivo.path, archDir);
       continue;


### PR DESCRIPTION
## Summary
- Bug de typo en #2266: `pipeline` (undefined) en vez de `pipelineName` al archivar issues cerrados
- Causaba `pipeline is not defined` en cada ciclo del pulpo, rompiendo el loop principal

## Test plan
- [x] `node -c pulpo.js` pasa
- [x] Error visible en logs del pulpo post-restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)