### PR TITLE
fix(pipeline): cleanup downstream al rechazar — evita delivery sin QA

### DIFF
--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -1653,6 +1653,28 @@ function brazoBarrido(config) {
           });
 
           log('barrido', `#${issue} RECHAZADO en ${fase} → devuelto a ${faseRechazo} (rebote ${reboteCount + 1}/${MAX_REBOTES})`);
+
+          // CLEANUP DOWNSTREAM: limpiar archivos residuales del issue en fases posteriores.
+          // Sin esto, archivos de aprobacion/listo/ de un ciclo anterior sobreviven al rechazo
+          // y el barrido los promueve a entrega — el issue sale a delivery sin QA pasado.
+          // (Incidente #2043: delivery se lanzó con QA rechazado.)
+          for (let downstream = i + 1; downstream < fases.length; downstream++) {
+            const downFase = fases[downstream];
+            for (const estado of ['pendiente', 'trabajando', 'listo']) {
+              const dir = path.join(fasePath(pipelineName, downFase), estado);
+              try {
+                for (const f of fs.readdirSync(dir)) {
+                  if (f.startsWith(issue + '.') && !f.startsWith('.')) {
+                    const src = path.join(dir, f);
+                    const archDir = path.join(fasePath(pipelineName, downFase), 'archivado');
+                    fs.mkdirSync(archDir, { recursive: true });
+                    moveFile(src, archDir);
+                    log('barrido', `#${issue} cleanup downstream: ${downFase}/${estado}/${f} → archivado/`);
+                  }
+                }
+              } catch {}
+            }
+          }
         } else if (i < fases.length - 1) {
           // Todos aprobaron → promover a siguiente fase
           const siguienteFase = fases[i + 1];


### PR DESCRIPTION
## Summary
- Al rechazar un issue en verificación, no se limpiaban archivos de fases downstream (aprobación, entrega)
- Archivos residuales de ciclos anteriores en `aprobacion/listo/` causaban que el barrido promoviera a entrega sin QA
- Incidente: #2043 llegó a delivery con QA rechazado

## Cambio
- Al rechazar, barrer fases downstream y mover archivos del issue a `archivado/`
- Se limpian `pendiente/`, `trabajando/` y `listo/` de cada fase posterior

## Test plan
- [x] `node -c pulpo.js`
- [x] Lógica insertada después del rebote a dev, antes del else de promoción

🤖 Generated with [Claude Code](https://claude.com/claude-code)