### PR TITLE
fix(drive): EISDIR al subir video — credentials path vacío

### DIFF
--- a/qa/scripts/qa-video-share.js
+++ b/qa/scripts/qa-video-share.js
@@ -210,11 +210,13 @@ function driveAvailable() {
     if (OAUTH_REFRESH_TOKEN && OAUTH_CLIENT_ID && OAUTH_CLIENT_SECRET) return true;
     if (!DRIVE_CREDENTIALS_PATH) return false;
     const resolved = path.resolve(DRIVE_CREDENTIALS_PATH);
-    return fs.existsSync(resolved);
+    return fs.existsSync(resolved) && !fs.statSync(resolved).isDirectory();
 }
 
 function loadDriveCredentials() {
+    if (!DRIVE_CREDENTIALS_PATH) return null;
     const resolved = path.resolve(DRIVE_CREDENTIALS_PATH);
+    if (!fs.existsSync(resolved) || fs.statSync(resolved).isDirectory()) return null;
     return JSON.parse(fs.readFileSync(resolved, "utf8"));
 }
 


### PR DESCRIPTION
## Summary
- `DRIVE_CREDENTIALS_PATH` vacío → `path.resolve("")` → directorio del proyecto → EISDIR al leer
- Fix: `loadDriveCredentials` retorna null si path vacío o directorio
- Caso: video QA #2062 (6MB) nunca llegó a Drive

**Nota:** después del fix de EISDIR, el upload falla por OAuth refresh token expirado (`invalid_grant`). Requiere renovación manual del token de Google.

🤖 Generated with [Claude Code](https://claude.com/claude-code)