### PR TITLE
fix(pipeline): QA recording perdido en Windows por sintaxis bash en pkill

### DIFF
--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -3037,11 +3037,17 @@ function lanzarAgenteClaude(skill, issue, trabajandoPath, pipeline, fase, config
       // --- STOP RECORDING + PULL VIDEO ---
       // Parar screenrecord del pipeline y bajar el video al evidence dir
       if (skill === 'qa' && fase === 'verificacion' && qaRecordingPath && qaSerial) {
+        // pkill puede fallar si screenrecord ya autoterminó por --time-limit;
+        // no debe abortar el pull. Sin sintaxis bash (2>/dev/null || true)
+        // porque execSync usa cmd.exe en Windows.
         try {
-          // Matar screenrecord en el emulador (produce el mp4 final)
-          execSync(`adb -s ${qaSerial} shell "pkill -f screenrecord" 2>/dev/null || true`, {
-            encoding: 'utf8', timeout: 5000, windowsHide: true
+          execSync(`adb -s ${qaSerial} shell pkill -f screenrecord`, {
+            encoding: 'utf8', timeout: 5000, windowsHide: true, stdio: 'ignore'
           });
+        } catch {
+          // Sin proceso vivo: screenrecord ya cerró el mp4 por timeout. OK.
+        }
+        try {
           // Esperar a que el archivo se cierre (screenrecord tarda ~1s en flush)
           execSync('ping -n 3 127.0.0.1 > NUL', { timeout: 5000, windowsHide: true });
           // Pull del video
@@ -3052,9 +3058,13 @@ function lanzarAgenteClaude(skill, issue, trabajandoPath, pipeline, fase, config
             encoding: 'utf8', timeout: 30000, windowsHide: true
           });
           // Limpiar del emulador
-          execSync(`adb -s ${qaSerial} shell rm -f "${qaRecordingPath}"`, {
-            encoding: 'utf8', timeout: 5000, windowsHide: true
-          });
+          try {
+            execSync(`adb -s ${qaSerial} shell rm -f "${qaRecordingPath}"`, {
+              encoding: 'utf8', timeout: 5000, windowsHide: true, stdio: 'ignore'
+            });
+          } catch {
+            // Cleanup best-effort
+          }
           const videoStat = fs.statSync(localVideo);
           const videoSizeKb = Math.round(videoStat.size / 1024);
           log('lanzamiento', `🎬 Recording parado para qa:#${issue} — video: ${videoSizeKb}KB → ${localVideo}`);
@@ -3066,7 +3076,7 @@ function lanzarAgenteClaude(skill, issue, trabajandoPath, pipeline, fase, config
             writeYaml(trabajandoPath, data);
           }
         } catch (e) {
-          log('lanzamiento', `⚠️ Error parando/bajando recording qa:#${issue}: ${e.message.slice(0, 80)}`);
+          log('lanzamiento', `⚠️ Error bajando recording qa:#${issue}: ${e.message.slice(0, 80)}`);
         }
         // Matar el proceso local si sigue vivo
         if (qaRecordingProc && qaRecordingProc.exitCode === null) {


### PR DESCRIPTION
## Resumen

Bug en `pulpo.js`: el QA del #2062 (y potencialmente todos los QA en Windows) terminaba con video de 0KB aunque la grabación funcionara correctamente.

## Causa raíz

En el bloque que para el `screenrecord` y baja el mp4 al `evidence dir`:

\`\`\`js
execSync(\`adb -s \${qaSerial} shell "pkill -f screenrecord" 2>/dev/null || true\`, ...)
\`\`\`

Usa sintaxis bash (\`2>/dev/null\`, \`|| true\`), pero \`execSync\` corre por \`cmd.exe\` en Windows. La línea tira \`Command failed\`, el \`catch\` envuelve también el \`adb pull\`, y el video **nunca** se descarga.

Resultado: el YAML del QA queda sin \`evidencia\` ni \`video_size_kb\`, el gate \`gate-evidencia-on-exit\` rechaza con \"video 0KB < 200KB\" aunque el mp4 esté completo en \`/sdcard\`.

## Evidencia

- Pulpo log: \`🎬 Recording iniciado para qa:#2062\` → 11 min después \`⚠️ Error parando/bajando recording qa:#2062: Command failed: adb -s emulator-5554 shell \"pkill -f screenrecord\" 2>/dev/null |\`
- Verificado en el emulador: \`/sdcard/qa-2062-pipeline.mp4\` = **654 KB** (bien por encima del threshold de 200 KB)
- Recording autoterminó a los 180s por \`--time-limit\`, así que \`pkill\` siempre va a fallar para QA que corren > 3 min

## Fix

1. Separar el \`try/catch\` del \`pkill\` del de \`pull\`. Si pkill falla porque screenrecord ya autoterminó, el pull debe seguir.
2. Eliminar sintaxis bash, usar \`stdio:'ignore'\` + \`try/catch\` Node nativo.

## QA

- \`qa:skipped\` — cambio de infra del pipeline (.pipeline/pulpo.js), sin impacto en producto de usuario. La validación es operativa: reencolar QA #2062 y confirmar que ahora produce video.

## Test plan

- [ ] Reencolar QA #2062 → verificar que se baja el mp4 al evidence dir y se inyecta \`video_size_kb\` en el YAML
- [ ] Confirmar que el gate \`gate-evidencia-on-exit\` no rechaza

🤖 Generated with [Claude Code](https://claude.com/claude-code)