### PR TITLE
fix(qa): evidencia Drive unica por issue + nombres descriptivos + audio sincronizado

### DIFF
--- a/qa/scripts/qa-narration.js
+++ b/qa/scripts/qa-narration.js
@@ -381,27 +381,18 @@ async function main() {
     const videoDuration = getDuration(args.video, ffprobePath) || 60;
     console.log("[qa-narration] Duración del video: " + videoDuration.toFixed(1) + "s");
 
-    // Calcular timestamps: distribuir uniformemente si no hay delay_ms explícito
-    const segmentInterval = videoDuration / (allSegments.length + 1);
-    const timedSegments = allSegments.map((seg, idx) => ({
-        ...seg,
-        startTime: typeof seg.start_ms === "number"
-            ? seg.start_ms / 1000
-            : segmentInterval * (idx + 1) + (seg.delay_ms || 0) / 1000
-    }));
-
     // Crear directorio temporal
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "qa-narration-"));
 
     try {
-        // Generar clips de audio TTS para cada segmento
-        console.log("[qa-narration] Generando " + timedSegments.length + " clip(s) TTS con OpenAI...");
+        // Generar clips de audio TTS primero (sin asignar timestamps todavía)
+        console.log("[qa-narration] Generando " + allSegments.length + " clip(s) TTS con OpenAI...");
         const clipFiles = [];
 
-        for (let i = 0; i < timedSegments.length; i++) {
-            const seg = timedSegments[i];
+        for (let i = 0; i < allSegments.length; i++) {
+            const seg = allSegments[i];
             const clipPath = path.join(tmpDir, "paso_" + (i + 1) + ".opus");
-            const progressLabel = "  Paso " + (i + 1) + "/" + timedSegments.length;
+            const progressLabel = "  Paso " + (i + 1) + "/" + allSegments.length;
 
             try {
                 const audioBuffer = await callOpenAITTS(seg.text, openaiApiKey);
@@ -409,13 +400,46 @@ async function main() {
                 const clipDuration = getDuration(clipPath, ffprobePath) || 3;
                 clipFiles.push({
                     path: clipPath,
-                    startTime: seg.startTime,
-                    duration: clipDuration
+                    duration: clipDuration,
+                    // startTime se asigna abajo en base a la duración acumulada real
+                    explicitStart: typeof seg.start_ms === "number" ? seg.start_ms / 1000 : null,
+                    delayMs: seg.delay_ms || 0
                 });
                 process.stdout.write(progressLabel + " OK (" + clipDuration.toFixed(1) + "s) → " + seg.text.substring(0, 60) + "\n");
             } catch (e) {
                 console.error(progressLabel + " FALLÓ: " + e.message);
                 // Continuar con el siguiente clip
+            }
+        }
+
+        // Asignar startTime SINCRÓNICO con la acción real:
+        // 1) Si el segmento trae start_ms explícito → se usa tal cual.
+        // 2) Si no → se encadena secuencialmente desde el inicio del video,
+        //    acumulando duraciones reales de los clips + una pausa breve.
+        //    Esto evita el desfasaje que producía la distribución uniforme,
+        //    donde la narración quedaba desalineada respecto a lo mostrado.
+        const INTER_CLIP_PAUSE = 0.35; // 350ms entre clips consecutivos
+        let cursor = 0;
+        for (const clip of clipFiles) {
+            if (clip.explicitStart !== null) {
+                clip.startTime = clip.explicitStart + clip.delayMs / 1000;
+                cursor = Math.max(cursor, clip.startTime + clip.duration + INTER_CLIP_PAUSE);
+            } else {
+                clip.startTime = cursor + clip.delayMs / 1000;
+                cursor = clip.startTime + clip.duration + INTER_CLIP_PAUSE;
+            }
+        }
+
+        // Si la narración total excede la duración del video, avisar.
+        // El filtro amix respeta duration=first, por lo que recortará naturalmente,
+        // pero un buffer menor a 2s suele indicar que conviene guiones más cortos.
+        const last = clipFiles[clipFiles.length - 1];
+        if (last) {
+            const end = last.startTime + last.duration;
+            if (end > videoDuration) {
+                console.warn("[qa-narration] Narración (" + end.toFixed(1) + "s) excede video (" + videoDuration.toFixed(1) + "s) — final queda truncado");
+            } else {
+                console.log("[qa-narration] Narración termina a " + end.toFixed(1) + "s / video " + videoDuration.toFixed(1) + "s (buffer " + (videoDuration - end).toFixed(1) + "s)");
             }
         }
 

--- a/qa/scripts/qa-video-share.js
+++ b/qa/scripts/qa-video-share.js
@@ -499,15 +499,12 @@ async function uploadToDrive(videoBuffer, filename, issueNumber, issueTitle, spr
     // Carpeta raíz configurada (ej. ID de "Intrale QA" en Drive)
     const rootFolderId = DRIVE_FOLDER_ID;
 
-    // Estructura: rootFolderId / SPR-XXXX / #issue-titulo /
-    const sprintFolder = sprintId || "QA";
-    const issueFolder = issueTitle
-        ? "#" + issueNumber + "-" + issueTitle.replace(/[/\\?%*:|"<>]/g, "-").slice(0, 40)
-        : "#" + issueNumber;
+    // Estructura: rootFolderId / #issueNumber /
+    // Una sola carpeta unívoca por issue (sin sprint, sin título, sin doble nivel).
+    const issueFolder = "#" + issueNumber;
 
-    console.log("[qa-video-share] Drive: creando estructura " + sprintFolder + " / " + issueFolder);
-    const sprintFolderId = await driveGetOrCreateFolder(accessToken, sprintFolder, rootFolderId);
-    const issueFolderId = await driveGetOrCreateFolder(accessToken, issueFolder, sprintFolderId);
+    console.log("[qa-video-share] Drive: creando/usando carpeta " + issueFolder);
+    const issueFolderId = await driveGetOrCreateFolder(accessToken, issueFolder, rootFolderId);
 
     console.log("[qa-video-share] Drive: subiendo " + filename + " (" + formatSize(videoBuffer.length) + ")...");
     const uploaded = await driveUploadFile(accessToken, videoBuffer, filename, issueFolderId);
@@ -686,6 +683,24 @@ function formatSize(bytes) {
     return (bytes / (1024 * 1024)).toFixed(1) + "MB";
 }
 
+// Nombre descriptivo para el video subido a Drive.
+// Formato: qa-<issue>-<YYYYMMDD>-<HHMM>-<verdict>[-narrated].mp4
+// Ejemplo: qa-2062-20260416-2311-rechazado-narrated.mp4
+function buildDriveFilename(issueNumber, verdict, hasNarration) {
+    const now = new Date();
+    const pad = (n) => String(n).padStart(2, "0");
+    const date = now.getFullYear() + pad(now.getMonth() + 1) + pad(now.getDate());
+    const time = pad(now.getHours()) + pad(now.getMinutes());
+    const normalized = String(verdict || "DESCONOCIDO")
+        .toLowerCase()
+        .normalize("NFD").replace(/[\u0300-\u036f]/g, "")
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-|-$/g, "");
+    const verdictTag = normalized || "desconocido";
+    const suffix = hasNarration ? "-narrated" : "";
+    return "qa-" + issueNumber + "-" + date + "-" + time + "-" + verdictTag + suffix + ".mp4";
+}
+
 // --- Leer sprint activo desde roadmap.json (fallback si no se pasa --sprint) ---
 
 function readActiveSprint() {
@@ -764,12 +779,14 @@ async function main() {
 
         // ── Nivel 1: Google Drive ──────────────────────────────────────────
         if (driveAvailable()) {
-            console.log("[qa-video-share] " + filename + " (" + sizeStr + ") -> Google Drive");
+            // Renombrar para que sea identificable: qa-<issue>-<fecha>-<hora>-<verdict>[-narrated].mp4
+            const driveFilename = buildDriveFilename(data.issue, data.verdict, hasNarration);
+            console.log("[qa-video-share] " + filename + " (" + sizeStr + ") -> Google Drive como " + driveFilename);
             try {
                 const videoBuffer = fs.readFileSync(fullPath);
                 const driveLink = await withRetry(
-                    () => uploadToDrive(videoBuffer, filename, data.issue, data.title, sprintId),
-                    "Drive upload " + filename
+                    () => uploadToDrive(videoBuffer, driveFilename, data.issue, data.title, sprintId),
+                    "Drive upload " + driveFilename
                 );
 
                 // Guardar primer link de Drive para qa-report.json
@@ -790,17 +807,17 @@ async function main() {
                     "\uD83D\uDCCB Reporte: `" + repoReportPath + "`\n" +
                     "\uD83D\uDD52 " + timestamp;
 
-                await withRetry(() => sendTelegramMessage(message), "sendMessage Drive link " + filename);
-                console.log("[qa-video-share] " + filename + " subido a Drive, link enviado OK");
+                await withRetry(() => sendTelegramMessage(message), "sendMessage Drive link " + driveFilename);
+                console.log("[qa-video-share] " + driveFilename + " subido a Drive, link enviado OK");
                 sent++;
             } catch (e) {
-                console.error("[qa-video-share] Drive fallo para " + filename + ": " + e.message);
+                console.error("[qa-video-share] Drive fallo para " + driveFilename + ": " + e.message);
                 console.error("[qa-video-share] ERROR: No se pudo subir evidencia a Drive. Pipeline fallido.");
                 // Notificar el fallo a Telegram
                 try {
                     await sendTelegramMessage(
                         "❌ *Drive Upload FALLIDO* — Issue #" + data.issue + "\n" +
-                        "Video: `" + filename + "` (" + sizeStr + ")\n" +
+                        "Video: `" + driveFilename + "` (" + sizeStr + ")\n" +
                         "Error: " + e.message.substring(0, 200)
                     );
                 } catch (e2) {}


### PR DESCRIPTION
## Summary

Aplica los tres ajustes pedidos sobre la evidencia QA:

- **Drive — una sola carpeta por issue.** Antes: `Intrale QA / SPR-XXXX / #issue-titulo/` (doble nivel). Ahora: `<root> / #<issue>/`. Una carpeta unívoca por issue, sin sprint ni título.
- **Nombres de videos descriptivos.** Formato: `qa-<issue>-<YYYYMMDD>-<HHMM>-<verdict>[-narrated].mp4`. Ejemplo: `qa-2062-20260416-2311-rechazado-narrated.mp4`. Identifica issue, fecha/hora de la corrida y resultado.
- **Audio narrado sincronizado.** Los clips TTS ya no se distribuyen uniformemente sobre la duración del video (que causaba desfasaje con la acción mostrada). Se encadenan secuencialmente desde el inicio usando la duración real medida de cada clip + pausa breve entre clips. Si un segmento trae `start_ms` explícito, se respeta.

## Test plan

- [x] Node sintaxis OK en ambos scripts
- [ ] Próxima corrida de QA real sube a `<root>/#<issue>/` con el nombre nuevo
- [ ] Audio del video narrado va sincronizado con los pasos mostrados

Closes nada (ajuste directo a guideline de Leo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)