### PR TITLE
fix(pipeline): evitar MSYS path conversion en adb pull del video QA

### DIFF
--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -3057,13 +3057,18 @@ function lanzarAgenteClaude(skill, issue, trabajandoPath, pipeline, fase, config
           const evidenceDir = path.join(ROOT, 'qa', 'evidence', String(issue));
           fs.mkdirSync(evidenceDir, { recursive: true });
           const localVideo = path.join(evidenceDir, `qa-${issue}-raw.mp4`);
+          // Fix #2281: MSYS_NO_PATHCONV evita que Git Bash convierta "/sdcard/..."
+          // a "C:/Program Files/Git/sdcard/..." cuando lo pasa como argumento top-level
+          // a adb.exe. MSYS2_ARG_CONV_EXCL=* desactiva toda conversión de argumentos.
+          // En entornos no-MSYS (Linux/macOS/CI) estas vars se ignoran silenciosamente.
+          const adbEnv = { ...process.env, MSYS_NO_PATHCONV: '1', MSYS2_ARG_CONV_EXCL: '*' };
           execSync(`adb -s ${qaSerial} pull "${qaRecordingPath}" "${localVideo}"`, {
-            encoding: 'utf8', timeout: 30000, windowsHide: true
+            encoding: 'utf8', timeout: 30000, windowsHide: true, env: adbEnv
           });
           // Limpiar del emulador
           try {
             execSync(`adb -s ${qaSerial} shell rm -f "${qaRecordingPath}"`, {
-              encoding: 'utf8', timeout: 5000, windowsHide: true, stdio: 'ignore'
+              encoding: 'utf8', timeout: 5000, windowsHide: true, stdio: 'ignore', env: adbEnv
             });
           } catch {
             // Cleanup best-effort


### PR DESCRIPTION
## Summary

- Fix MSYS path conversion en `adb pull "/sdcard/qa-*.mp4"` dentro de `pulpo.js`: Git Bash mutaba el argumento a `C:/Program Files/Git/sdcard/...` y rompia la descarga del video de evidencia del QA.
- Setea `MSYS_NO_PATHCONV=1` y `MSYS2_ARG_CONV_EXCL=*` en los `execSync` de `adb pull` y el cleanup `adb shell rm -f`. En Linux/macOS/CI las vars son no-op.
- Desbloquea el issue contribuyente #2062 y restaura el gate de QA E2E para cualquier issue con label `app:*`.

## Pipeline gates

- dev (backend-dev): aprobado
- build: aprobado (BUILD SUCCESSFUL, tests + koverVerify + lint + APK)
- verificacion (qa/tester/security): aprobado — video QA 183 KB en `qa/evidence/2281/qa-2281-raw.mp4`
- aprobacion (po/review/ux): aprobado

## Test plan

- [x] Build completo (`./gradlew check --no-daemon`) verde
- [x] QA E2E genera y descarga video desde el emulador sin error de `failed to stat remote object`
- [x] Artefacto APK (`qa/artifacts/2281-composeApp-client-debug.apk`, 22 MB) generado

Closes #2281

🤖 Generated with [Claude Code](https://claude.com/claude-code)