### PR TITLE
fix(qa): narración por criterios de aceptación + trim del boot del emulador

### DIFF
--- a/qa/scripts/qa-android.sh
+++ b/qa/scripts/qa-android.sh
@@ -724,10 +724,16 @@ else
         VIDEO_LOCAL="${RECORDINGS_DIR}/maestro-shard-${port}.mp4"
         if [ -f "$VIDEO_LOCAL" ]; then
             echo "  Procesando shard $port..."
+            NARRATION_ARGS=(--video "$VIDEO_LOCAL"
+                --flows-dir "$MAESTRO_DIR"
+                --root "$PROJECT_ROOT"
+                --results-xml "${RECORDINGS_DIR}/maestro-results.xml"
+                --output "${RECORDINGS_DIR}/maestro-shard-${port}-narrated.mp4")
+            if [ -n "${QA_ISSUE:-}" ]; then
+                NARRATION_ARGS+=(--issue "$QA_ISSUE")
+            fi
             QA_NARRATION="$QA_NARRATION" node "$SCRIPT_DIR/qa-narration.js" \
-                --video "$VIDEO_LOCAL" \
-                --flows-dir "$MAESTRO_DIR" \
-                --output "${RECORDINGS_DIR}/maestro-shard-${port}-narrated.mp4" \
+                "${NARRATION_ARGS[@]}" \
                 2>&1 | tail -8 || echo "  Narracion fallida para shard $port (continuando sin audio)"
         fi
     done

--- a/qa/scripts/qa-narration.js
+++ b/qa/scripts/qa-narration.js
@@ -93,12 +93,24 @@ function findFFprobe(ffmpegPath) {
 
 function parseArgs() {
     const args = process.argv.slice(2);
-    const result = { video: "", flowsDir: "", output: "" };
+    const result = {
+        video: "",
+        flowsDir: "",
+        output: "",
+        issue: "",
+        issueTitle: "",
+        resultsXml: "",
+        rootDir: ""
+    };
     for (let i = 0; i < args.length; i++) {
         switch (args[i]) {
             case "--video": result.video = args[++i] || ""; break;
             case "--flows-dir": result.flowsDir = args[++i] || ""; break;
             case "--output": result.output = args[++i] || ""; break;
+            case "--issue": result.issue = args[++i] || ""; break;
+            case "--issue-title": result.issueTitle = args[++i] || ""; break;
+            case "--results-xml": result.resultsXml = args[++i] || ""; break;
+            case "--root": result.rootDir = args[++i] || ""; break;
         }
     }
     return result;
@@ -164,6 +176,69 @@ function getDuration(filePath, ffprobePath) {
     return null;
 }
 
+// ─── Boot trim: detectar pantalla negra inicial y recortarla ────────────────
+// El emulador + splash de Maestro se llevan 1-2 minutos de pantalla negra
+// antes de que aparezca contenido útil. Ese fragmento no aporta evidencia y
+// hace que los videos sean más largos y los audios más caros. Detectamos el
+// primer bloque negro que arranque cerca de t=0 y trimeamos hasta su fin.
+
+function detectBootTrim(videoPath, ffmpegPath) {
+    if (!ffmpegPath) return 0;
+    try {
+        // blackdetect: d=duración mínima, pix_th=umbral por pixel, pic_th=ratio
+        const result = spawnSync(ffmpegPath, [
+            "-i", videoPath,
+            "-vf", "blackdetect=d=0.5:pix_th=0.10:pic_th=0.98",
+            "-an",
+            "-f", "null",
+            "-"
+        ], { stdio: "pipe", timeout: 90000 });
+
+        const stderr = (result.stderr || "").toString();
+        const re = /black_start:(\d+(?:\.\d+)?)\s+black_end:(\d+(?:\.\d+)?)\s+black_duration:(\d+(?:\.\d+)?)/g;
+        let match = re.exec(stderr);
+        if (!match) return 0;
+
+        const start = parseFloat(match[1]);
+        const end = parseFloat(match[2]);
+
+        // Solo trimeamos si el primer bloque arranca cerca del comienzo
+        if (start > 1.5) return 0;
+        // Tope conservador: nunca recortamos más de 60s, aunque blackdetect diga más
+        return Math.min(end, 60);
+    } catch (e) {
+        return 0;
+    }
+}
+
+function trimBootIfNeeded(videoPath, tmpDir, ffmpegPath, ffprobePath) {
+    const trimSec = detectBootTrim(videoPath, ffmpegPath);
+    if (trimSec < 2) return videoPath; // recortes < 2s no valen el reencode
+
+    const trimmedPath = path.join(tmpDir, "video-trimmed.mp4");
+    // Re-encode para garantizar keyframe en el nuevo inicio (copy podría desfasar audio)
+    const result = spawnSync(ffmpegPath, [
+        "-ss", String(trimSec),
+        "-i", videoPath,
+        "-c:v", "libx264",
+        "-preset", "veryfast",
+        "-crf", "23",
+        "-an",
+        "-y",
+        trimmedPath
+    ], { stdio: "pipe", timeout: 180000 });
+
+    if (result.status !== 0 || !fs.existsSync(trimmedPath)) {
+        const stderr = result.stderr ? result.stderr.toString().slice(-300) : "?";
+        console.warn("[qa-narration] Trim de boot falló (" + stderr + ") — usando video original");
+        return videoPath;
+    }
+
+    const newDur = getDuration(trimmedPath, ffprobePath);
+    console.log("[qa-narration] Boot trim: -" + trimSec.toFixed(1) + "s (video ahora " + (newDur || 0).toFixed(1) + "s)");
+    return trimmedPath;
+}
+
 // ─── Narration files discovery ────────────────────────────────────────────────
 
 function findNarrationFiles(flowsDir) {
@@ -185,6 +260,103 @@ function findNarrationFiles(flowsDir) {
         console.error("[qa-narration] Error leyendo flows dir: " + e.message);
     }
     return narrationFiles;
+}
+
+// ─── Generar segmentos a partir de los criterios de aceptación del issue ─────
+// Esta es la vía principal cuando el agente QA conoce el issue. Arma un guion
+// breve: intro con el título del issue, un clip por criterio con su verdicto,
+// y un cierre con el resumen. Los verdictos se leen del JUnit XML de Maestro.
+
+function parseJunitVerdict(resultsXml) {
+    try {
+        const xml = fs.readFileSync(resultsXml, "utf8");
+        const testsMatch = xml.match(/tests="(\d+)"/);
+        const failuresMatch = xml.match(/failures="(\d+)"/);
+        const errorsMatch = xml.match(/errors="(\d+)"/);
+        const tests = testsMatch ? parseInt(testsMatch[1], 10) : 0;
+        const failures = failuresMatch ? parseInt(failuresMatch[1], 10) : 0;
+        const errors = errorsMatch ? parseInt(errorsMatch[1], 10) : 0;
+        return {
+            total: tests,
+            failures: failures + errors,
+            passed: Math.max(0, tests - failures - errors),
+            pass: tests > 0 && (failures + errors) === 0
+        };
+    } catch (e) {
+        return null;
+    }
+}
+
+function getIssueTitle(issueNumber) {
+    if (!issueNumber) return null;
+    try {
+        const ghPath = process.env.GH_PATH || "gh";
+        const result = spawnSync(ghPath, [
+            "issue", "view", String(issueNumber),
+            "--json", "title",
+            "--jq", ".title"
+        ], { stdio: "pipe", timeout: 15000, windowsHide: true });
+        const title = (result.stdout || "").toString().trim();
+        if (title) return title;
+    } catch (e) { /* sin gh, sin título */ }
+    return null;
+}
+
+function loadTestCases(issueNumber, rootDir) {
+    if (!issueNumber) return null;
+    const tcPath = path.join(rootDir, "qa", "test-cases", `${issueNumber}.json`);
+    try {
+        const data = JSON.parse(fs.readFileSync(tcPath, "utf8"));
+        if (Array.isArray(data) && data.length > 0) return data;
+    } catch (e) { /* no test cases */ }
+    return null;
+}
+
+function buildSegmentsFromIssue(issueNumber, issueTitle, resultsXml, rootDir) {
+    const testCases = loadTestCases(issueNumber, rootDir);
+    if (!testCases) return [];
+
+    const verdict = resultsXml && fs.existsSync(resultsXml) ? parseJunitVerdict(resultsXml) : null;
+    const globalPass = verdict ? verdict.pass : null; // null = desconocido
+
+    const titleClean = (issueTitle || "").trim();
+    const segments = [];
+
+    // Intro: explica qué se está validando
+    const intro = titleClean
+        ? `Validamos el issue número ${issueNumber}: ${titleClean}. Revisamos ${testCases.length} criterio${testCases.length === 1 ? "" : "s"} de aceptación.`
+        : `Validamos el issue número ${issueNumber}. Revisamos ${testCases.length} criterio${testCases.length === 1 ? "" : "s"} de aceptación.`;
+    segments.push({ text: intro, delay_ms: 0 });
+
+    // Un clip por criterio, con el verdicto si lo sabemos
+    testCases.forEach((tc, idx) => {
+        const n = idx + 1;
+        const crit = (tc.criteria || tc.title || `Criterio ${n}`).trim();
+        // Tono: enuncia el criterio y, si el QA global pasó, lo declara verificado.
+        // Si falló, lo deja en modo descriptivo sin afirmar OK (no tenemos mapeo por TC).
+        let text;
+        if (globalPass === true) {
+            text = `Criterio ${n}: ${crit}. Verificado.`;
+        } else if (globalPass === false) {
+            text = `Criterio ${n}: ${crit}.`;
+        } else {
+            text = `Criterio ${n}: ${crit}.`;
+        }
+        segments.push({ text, delay_ms: 0 });
+    });
+
+    // Cierre: resume el veredicto global
+    let closing;
+    if (globalPass === true) {
+        closing = `Resultado: los ${testCases.length} criterio${testCases.length === 1 ? "" : "s"} de aceptación se cumplieron. Issue aprobado.`;
+    } else if (globalPass === false) {
+        closing = `Resultado: el flujo se interrumpió antes de validar todos los criterios. Issue rechazado.`;
+    } else {
+        closing = `Fin de la validación del issue ${issueNumber}.`;
+    }
+    segments.push({ text: closing, delay_ms: 0 });
+
+    return segments;
 }
 
 // ─── Generar segmentos de narración a partir de flows ────────────────────────
@@ -354,35 +526,62 @@ async function main() {
 
     // Encontrar archivos de narración o generar desde flows
     const flowsDir = args.flowsDir || path.resolve(__dirname, "../../.maestro/flows");
-    const narrationFiles = findNarrationFiles(flowsDir);
+    const rootDir = args.rootDir || path.resolve(__dirname, "../..");
 
     let allSegments = [];
+    let narrationSource = "";
 
-    if (narrationFiles.length > 0) {
-        for (const nf of narrationFiles) {
-            if (nf.data.segments) {
-                for (const seg of nf.data.segments) {
-                    allSegments.push({ flow: nf.data.flow || "", ...seg });
+    // Prioridad 1: criterios de aceptación del issue (vía principal cuando se conoce el issue)
+    if (args.issue) {
+        const issueTitle = args.issueTitle || getIssueTitle(args.issue);
+        const resultsXml = args.resultsXml || path.join(rootDir, "qa", "recordings", "maestro-results.xml");
+        const issueSegments = buildSegmentsFromIssue(args.issue, issueTitle, resultsXml, rootDir);
+        if (issueSegments.length > 0) {
+            allSegments = issueSegments;
+            narrationSource = "criterios de aceptación del issue #" + args.issue +
+                (issueTitle ? " (" + issueTitle.substring(0, 60) + ")" : "");
+        } else {
+            console.log("[qa-narration] Issue #" + args.issue + " sin test-cases en qa/test-cases/ — cayendo a fallback");
+        }
+    }
+
+    // Prioridad 2: archivos .narration.json por flow
+    if (allSegments.length === 0) {
+        const narrationFiles = findNarrationFiles(flowsDir);
+        if (narrationFiles.length > 0) {
+            for (const nf of narrationFiles) {
+                if (nf.data.segments) {
+                    for (const seg of nf.data.segments) {
+                        allSegments.push({ flow: nf.data.flow || "", ...seg });
+                    }
                 }
             }
+            narrationSource = narrationFiles.length + " archivo(s) .narration.json";
         }
-        console.log("[qa-narration] " + narrationFiles.length + " archivo(s) .narration.json — " + allSegments.length + " segmentos");
-    } else {
-        // Fallback: generar desde nombres de flows YAML
+    }
+
+    // Prioridad 3: fallback genérico desde nombres de flows YAML
+    if (allSegments.length === 0) {
         allSegments = buildSegmentsFromFlows(flowsDir);
         if (allSegments.length === 0) {
             console.log("[qa-narration] No hay segmentos de narración — saltando");
             process.exit(0);
         }
-        console.log("[qa-narration] Narración generada desde " + allSegments.length + " flow(s) YAML");
+        narrationSource = "fallback: " + allSegments.length + " flow(s) YAML";
     }
 
-    // Obtener duración del video
-    const videoDuration = getDuration(args.video, ffprobePath) || 60;
-    console.log("[qa-narration] Duración del video: " + videoDuration.toFixed(1) + "s");
+    console.log("[qa-narration] Guión: " + narrationSource + " — " + allSegments.length + " segmentos");
 
     // Crear directorio temporal
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "qa-narration-"));
+
+    // Trim del boot inicial (pantalla negra del emulador + splash de Maestro).
+    // Devuelve un nuevo path si vale la pena; si no, el original.
+    const sourceVideo = ffmpegPath ? trimBootIfNeeded(args.video, tmpDir, ffmpegPath, ffprobePath) : args.video;
+
+    // Obtener duración del video (ya trimado si correspondió)
+    const videoDuration = getDuration(sourceVideo, ffprobePath) || 60;
+    console.log("[qa-narration] Duración del video: " + videoDuration.toFixed(1) + "s");
 
     try {
         // Generar clips de audio TTS primero (sin asignar timestamps todavía)
@@ -456,7 +655,7 @@ async function main() {
 
             if (audioTrackPath) {
                 try {
-                    mergeVideoAudio(args.video, audioTrackPath, outputPath, ffmpegPath);
+                    mergeVideoAudio(sourceVideo, audioTrackPath, outputPath, ffmpegPath);
                     const stats = fs.statSync(outputPath);
                     const sizeMB = (stats.size / (1024 * 1024)).toFixed(1);
                     console.log("[qa-narration] ✓ Video narrado: " + outputPath + " (" + sizeMB + "MB)");


### PR DESCRIPTION
## Resumen

Encara los 3 problemas que Leo planteó sobre los videos de evidencia QA (audio desincronizado, inicialización eterna, contenido no alineado al issue):

1. **Guion por criterios de aceptación del issue**
   `qa-narration.js` deja de leer `.narration.json` genéricos por flow y arma el guion desde `qa/test-cases/<issue>.json`:
   - Intro con título del issue + cantidad de criterios.
   - Un clip por criterio (texto del campo `criteria`).
   - Cierre con veredicto leído del JUnit XML (`maestro-results.xml`): aprobado / rechazado / inconcluyente.

2. **Trim del boot del emulador**
   Se agrega `detectBootTrim()` con `ffmpeg blackdetect`. Si el video arranca con pantalla negra (emulador booteando + splash de Maestro), se recorta hasta el fin de ese bloque (cap de 60s). Antes se grababan 1-2 minutos de pantalla negra inservibles.

3. **Wiring desde `qa-android.sh`**
   Propaga `--issue`, `--root` y `--results-xml` al narrador.

4. **Fallback prolijo**
   Si no hay `qa/test-cases/<issue>.json`, log explicativo y se cae al camino anterior (.narration.json → flows YAML).

La sincronía secuencial con duraciones reales (PR #2290) se mantiene, así que los criterios entran encadenados y la pista se respeta sobre el video ya trimado.

## Test plan

- [ ] QA E2E sobre el próximo issue → video debe arrancar con contenido real (sin pantalla negra de boot) y la narración debe leer los criterios del test-case.
- [ ] Issue sin `qa/test-cases/<n>.json` → log "sin test-cases" + cae al fallback sin romper la corrida.
- [ ] Issue rechazado → cierre del audio dice "rechazado".

🤖 Generated with [Claude Code](https://claude.com/claude-code)