### PR TITLE
fix(pipeline): validateQaEvidence respeta qaMode (structural/api no requieren video)

### DIFF
--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -881,6 +881,17 @@ const QA_MIN_FRAME_PNGS = 3;             // Mínimo de frames PNG del agente QA 
  * cumple el umbral, se acepta.
  */
 function validateQaEvidence(issue, qaData) {
+  // El preflight clasifica cada issue en uno de tres modos (qaMode):
+  //   - 'android'    → requiere emulador + APK → debe haber video/frames
+  //   - 'api'        → testing via HTTP, sin UI → no produce video
+  //   - 'structural' → validación syntax+tests → no produce video
+  // El agente QA escribe `modo: <qaMode>` en el YAML. Solo exigir evidencia
+  // visual cuando realmente aplica — antes este gate rechazaba fantasma
+  // issues de backend/infra cuyo QA estructural había aprobado correctamente,
+  // disparando el loop con el rejection-report.
+  const modo = (qaData.modo || '').toString().toLowerCase();
+  if (modo === 'api' || modo === 'structural') return [];
+
   const ROOT = path.resolve(PIPELINE, '..');
   const evidenceDir = path.join(ROOT, 'qa', 'evidence', String(issue));
   const recordingsDir = path.join(ROOT, 'qa', 'recordings');


### PR DESCRIPTION
## Causa raíz de la hemorragia

Entre los PRs #2343 y #2344 arreglamos los síntomas del rejection-report (dedup laxo, regex emulador, loop recursivo, config-dump). Este PR arregla la **causa raíz** de por qué el rejection-report estaba siendo invocado en primer lugar: un gate de evidencia que rechazaba issues backend/infra cuyo QA había corrido y aprobado correctamente.

## El bug

`validateQaEvidence()` (pulpo.js:883) exige video `.mp4` o N frames PNG, **sin mirar `qaData.modo`**. El sistema tiene tres modos de QA (pulpo.js:2499):

| Modo | Descripción | ¿Produce video? |
|---|---|---|
| `android` | Requiere emulador + APK | ✅ Sí (screenrecord) |
| `api` | Testing via HTTP, sin UI | ❌ No |
| `structural` | Validación syntax + tests unitarios | ❌ No |

El preflight clasifica correctamente (pulpo.js:2171) y setea `QA_MODE=<qaMode>` en el entorno del agente, que lo escribe en el YAML como `modo: <qaMode>`. Pero el gate on-exit ignoraba ese campo y rechazaba igual.

## Ejemplo real — #2317

Log `2317-qa.log` línea 80 muestra al agente QA aprobando correctamente:

```yaml
issue: 2317
modo: structural
resultado: aprobado
evidencia: |
  - node --check .pipeline/connectivity-precheck.js → OK
  - node --check .pipeline/pulpo.js → OK
  - YAML config válido, con sección 'precheck'
  - Unit tests: 13/13 pasaron
```

El `gate-evidencia-on-exit` pisó el archivo:
```yaml
resultado: rechazado
motivo: 'Evidencia QA incompleta (gate on-exit): sin evidencia: no hay .mp4...'
rechazado_por: gate-evidencia-on-exit
```

Después el rejection-report analizó el falso rechazo, el log decía \"modo structural, sin emulador\", el regex matcheaba \"emulator\"/\"device\" → creaba issue fantasma \"Emulador no corriendo\" → loop con PRs #2343 y #2344 como síntomas.

## Fix

Al inicio de `validateQaEvidence`, si `modo === 'api' || modo === 'structural'`, retornar `[]` (sin issues). Solo exigir evidencia visual cuando realmente corresponde.

Dos gates usan esta función — ambos arreglados con el mismo cambio:
- `gate-evidencia-on-exit` (pulpo.js:3098) — al terminar el agente
- `gate-evidencia-automatico` (pulpo.js:1586) — durante el barrido

## Tests manuales

| Caso | Antes | Después |
|---|---|---|
| `modo: structural`, sin video | rechazado (falso+) | **aprobado** ✓ |
| `modo: api`, sin video | rechazado (falso+) | **aprobado** ✓ |
| `modo: android`, sin video | rechazado | rechazado ✓ (intacto) |
| `modo: qa` (legacy), sin video | rechazado | rechazado ✓ |
| Sin modo (legacy), sin video | rechazado | rechazado ✓ |
| `modo: STRUCTURAL` (case-insensitive) | rechazado | **aprobado** ✓ |

6/6 casos pasan.

## Relación con PRs previos

- #2343 — dedup unificado + causa desde motivo real (síntomas)
- #2344 — loop guard + regex emulador estricto + filtro config-dump (síntomas)
- **#2345 (este)** — causa raíz: el gate que estaba creando los falsos rechazos

Los 3 PRs son complementarios. Sin este último, backend/infra seguirían teniendo rechazos fantasma aunque el rejection-report ya no amplificara el ruido.

## QA

Cambio puro de pipeline (`.pipeline/pulpo.js`). Sin impacto en producto.

✅ `qa:skipped` — infra

🤖 Generado con [Claude Code](https://claude.ai/claude-code)