### PR TITLE
fix(pipeline): pulpo inyecta modo al YAML de QA antes del launch

### DIFF
--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -2189,6 +2189,22 @@ function brazoLanzamiento(config) {
         if (preflightResult.emulatorSerial) {
           extraEnv.QA_EMULATOR_SERIAL = preflightResult.emulatorSerial;
         }
+
+        // Inyectar `modo` al archivo YAML para que gate-evidencia-on-exit lo
+        // respete sin depender de que el agente lo escriba. El preflight ya
+        // sabe el qaMode correcto — esa es la fuente de verdad. Si el agente
+        // QA aprueba pero omite el campo (ocurrió con #2159 structural y
+        // disparó falso rechazo aunque el fix #2345 estuviera activo), el
+        // gate igual lee `modo: structural` desde acá.
+        if (skill === 'qa') {
+          try {
+            const data = readYaml(trabajandoPath) || {};
+            data.modo = preflightResult.qaMode;
+            writeYaml(trabajandoPath, data);
+          } catch (e) {
+            log('lanzamiento', `⚠️ No pude inyectar modo al YAML de ${archivo.name}: ${e.message.slice(0, 80)}`);
+          }
+        }
       }
       lanzarAgenteClaude(skill, issue, trabajandoPath, pipelineName, fase, config, extraEnv);
       anyLaunched = true;


### PR DESCRIPTION
## Complemento al PR #2345

El fix #2345 arregló `validateQaEvidence` para respetar `qaData.modo === 'structural'|'api'`, pero asumía que el agente QA escribía el campo al aprobar. Cuando el agente era conciso y escribía solo `resultado: aprobado` sin el `modo`, el gate leía `modo = undefined`, caía a la política vieja y rechazaba issues `structural`/`api` fantasma.

## Caso real — #2159 post-fix #2345

| Timestamp | Evento |
|---|---|
| 18:25:02 | Pulpo lanza `qa:#2159` con `QA_MODE=structural` (fix activo) |
| 18:37:55 | ⛔ Gate on-exit rechaza: *\"sin evidencia, no hay .mp4\"* |
| 18:37:55 | PDF de rechazo enviado a Telegram |

El archivo YAML final en `listo/2159.qa`:
```yaml
resultado: rechazado
motivo: 'Evidencia QA incompleta (gate on-exit)...'
rechazado_por: gate-evidencia-on-exit
```
(sin campo `modo` — el agente no lo escribió)

## Comparación con #2317 (mismo día)

```yaml
issue: 2317
modo: structural         ← agente lo escribió explícitamente
resultado: aprobado
evidencia: |
  - node --check OK
  - 13/13 tests
```

El agente del #2317 fue meticuloso. El del #2159 no. **El fix no puede depender del comportamiento consistente del agente.**

## Fix

Cuando el pulpo lanza el skill QA (pulpo.js:2175, justo después de mover a `trabajando/`), leer el YAML, setear `modo: <preflightResult.qaMode>` y escribirlo. Así queda garantizado desde el nacimiento del archivo, independiente de lo que haga el agente.

El preflight ya sabe el `qaMode` correcto — esa es la fuente autoritativa del sistema. Si el agente luego sobreescribe el campo (caso raro), lo hará con el mismo valor.

## Tests manuales

| Paso | Resultado |
|---|---|
| Archivo inicial: `issue/fase/pipeline` | + inyección → agrega `modo: structural` |
| Agente aprueba con `writeYaml` | preserva `modo` + agrega `resultado: aprobado` |
| `validateQaEvidence` lee `modo: structural` | retorna `[]` (no exige video) ✓ |

## Cadena de fixes

| PR | Capa | Arregla |
|---|---|---|
| #2343 | rejection-report (dedup+causa) | Síntoma |
| #2344 | rejection-report (regex+loop+config) | Síntoma |
| #2345 | gate-evidencia (respeta `modo`) | Parcial — depende del agente |
| **#2346 (este)** | pulpo (inyecta `modo`) | Robusto — garantizado desde el lanzamiento |

## QA

Cambio puro de pipeline (`.pipeline/pulpo.js`). Sin impacto en producto.

✅ `qa:skipped` — infra

🤖 Generado con [Claude Code](https://claude.ai/claude-code)