### PR TITLE
fix(pipeline): /restart Telegram spawn fallaba silenciosamente

### DIFF
--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -4104,20 +4104,35 @@ function cmdRestart(args) {
   // Lanzar restart.js como proceso COMPLETAMENTE desvinculado del árbol del
   // pulpo. En Windows, taskkill /T sigue la jerarquía de PPID — un spawn
   // normal queda como descendiente y muere cuando el pulpo se mata a sí mismo.
-  // `cmd.exe /c start ""` reasigna el parent a conhost.exe, rompiendo la
-  // cadena. Así el restart.js sobrevive al kill del pulpo y completa launchAll.
+  // `start` reasigna el parent a conhost.exe, rompiendo la cadena PPID. Así
+  // el restart.js sobrevive al kill del pulpo y completa launchAll.
+  //
+  // Iteración: el intento previo con `spawn('cmd.exe', ['/c', cadena])` falló
+  // silenciosamente porque cmd.exe trata `""` (título vacío de `start`) como
+  // fin prematuro del string cuando está dentro del `/c`. Ahora:
+  //   - shell:true → Node arma `cmd.exe /d /s /c "..."` escapando bien.
+  //   - Título "restart-bg" (no vacío) → evita el edge case de `""`.
+  //   - stdio redirigido a archivo → si el spawn vuelve a fallar, hay
+  //     evidencia en logs/restart-spawn.log en vez de silencio.
   const { spawn } = require('child_process');
+  const fsMod = require('fs');
   const pausedArg = paused ? ' --paused' : '';
-  const cmdLine = `start "" /MIN cmd.exe /c restart${pausedArg}`;
+  const spawnLogPath = path.join(PIPELINE, 'logs', 'restart-spawn.log');
   try {
-    const child = spawn('cmd.exe', ['/c', cmdLine], {
+    fsMod.writeFileSync(spawnLogPath,
+      `--- restart spawn ${new Date().toISOString()} mode=${mode} ---\n`);
+    const logFd = fsMod.openSync(spawnLogPath, 'a');
+    const child = spawn(`start "restart-bg" /MIN cmd.exe /c restart${pausedArg}`, [], {
       cwd: ROOT,
       detached: true,
-      stdio: 'ignore',
+      stdio: ['ignore', logFd, logFd],
+      shell: true,
       windowsHide: true,
       env: { ...process.env, PATH: 'C:\\Workspaces\\bin;' + process.env.PATH },
     });
     child.unref();
+    try { fsMod.closeSync(logFd); } catch {}
+    log('commander', `restart spawneado (cmd.exe /d /s /c ... start restart-bg)`);
   } catch (e) {
     log('commander', `Error lanzando restart: ${e.message}`);
     return `❌ No pude lanzar el restart: ${e.message.slice(0, 200)}`;


### PR DESCRIPTION
## Contexto

Fix del fix del PR #2348. Leo reportó que `/restart` sigue sin funcionar: el pulpo escribe `last-restart.json` pero nunca se reinicia.

## Diagnóstico

PID 18088 creado ayer 16:47 local, recibió `/restart` a las 16:53 (escribió el marker), siguió vivo y pausado 22h después. El log solo muestra:

```
[16:53:24] [commander] Restart completo solicitado via Telegram
```

Y nada más. El try/catch no saltó. El spawn reportó éxito.

## Causa

El código del PR #2348:
```js
spawn('cmd.exe', ['/c', 'start "" /MIN cmd /c restart'])
```

Pasa `""` (título vacío) a `start`. Cuando cmd.exe procesa `/c` + cadena entera, las `""` internas se tratan como fin prematuro del string — el comando queda malformado. Pero cmd.exe exitea con código 0, el spawn retorna OK, el pulpo nunca se entera.

## Fix

Tres cambios complementarios:

1. **`shell: true`** — Node arma `cmd.exe /d /s /c \"comando\"` escapando correctamente las comillas anidadas.

2. **Título no vacío** — `start \"restart-bg\" /MIN ...` evita el edge case de `\"\"`.

3. **stdio redirigido a `logs/restart-spawn.log`** — antes era `'ignore'` → fallaba en silencio. Ahora si el spawn vuelve a fallar por cualquier razón, queda evidencia en disco.

Extra: el commander loggea `\"restart spawneado (...)\"` después de escribir el marker para confirmar que `cmdRestart` llegó al final sin throw.

## Test

El test end-to-end requiere ejecutar `/restart` desde Telegram una vez mergeado y el pulpo recargado con el código nuevo. Si vuelve a fallar, el log `restart-spawn.log` nos da la evidencia que antes no teníamos.

## QA

Cambio puro de pipeline (`.pipeline/pulpo.js`). Sin impacto en producto.

✅ `qa:skipped` — infra

🤖 Generado con [Claude Code](https://claude.ai/claude-code)