### PR TITLE
fix(pipeline): detector multi-capa del launcher de Claude Code

### DIFF
--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -27,10 +27,38 @@ const ROOT = path.resolve(__dirname, '..');
 const PIPELINE = path.resolve(__dirname);
 const CONFIG_PATH = path.join(PIPELINE, 'config.yaml');
 const LOG_DIR = path.join(PIPELINE, 'logs');
-// Ejecutar claude via Node directo (evita cmd.exe y ventanas visibles)
-const CLAUDE_CLI_JS = path.join(process.env.APPDATA || '', 'npm', 'node_modules', '@anthropic-ai', 'claude-code', 'cli.js');
-const CLAUDE_BIN = process.env.CLAUDE_BIN || 'claude';
-const USE_NODE_DIRECT = fs.existsSync(CLAUDE_CLI_JS);
+// Detector multi-capa del launcher de Claude Code.
+// La estructura del paquete cambió entre versiones (2.1.114 eliminó cli.js
+// y lo reemplazó con bin/claude.exe nativo + cli-wrapper.cjs fallback).
+// Probamos opciones de más a menos preferida; todas evitan cmd.exe cuando es posible.
+function detectClaudeLauncher() {
+  const pkgDir = path.join(process.env.APPDATA || '', 'npm', 'node_modules', '@anthropic-ai', 'claude-code');
+  const cliJsLegacy = path.join(pkgDir, 'cli.js');
+  const binExe = path.join(pkgDir, 'bin', 'claude.exe');
+  const wrapperCjs = path.join(pkgDir, 'cli-wrapper.cjs');
+  const cmdShim = path.join(process.env.APPDATA || '', 'npm', 'claude.cmd');
+
+  // 1. Legacy cli.js → node directo (compatibilidad con versiones viejas)
+  if (fs.existsSync(cliJsLegacy)) {
+    return { kind: 'node-cli-js', cmd: process.execPath, prefixArgs: [cliJsLegacy], shell: false };
+  }
+  // 2. Binario nativo (Claude Code ≥2.1.114) → ruta absoluta, sin shell
+  if (fs.existsSync(binExe)) {
+    return { kind: 'native-exe', cmd: binExe, prefixArgs: [], shell: false };
+  }
+  // 3. cli-wrapper.cjs → node directo (fallback JS del propio paquete)
+  if (fs.existsSync(wrapperCjs)) {
+    return { kind: 'node-wrapper-cjs', cmd: process.execPath, prefixArgs: [wrapperCjs], shell: false };
+  }
+  // 4. .cmd shim con ruta absoluta → shell:true (shims .cmd requieren shell en spawn)
+  if (fs.existsSync(cmdShim)) {
+    return { kind: 'cmd-shim', cmd: cmdShim, prefixArgs: [], shell: true };
+  }
+  // 5. Último recurso: 'claude' en PATH con shell
+  return { kind: 'path-fallback', cmd: process.env.CLAUDE_BIN || 'claude', prefixArgs: [], shell: true };
+}
+
+const CLAUDE_LAUNCHER = detectClaudeLauncher();
 const GH_BIN = 'C:\\Workspaces\\gh-cli\\bin\\gh.exe';
 
 // Rate limiting para GitHub API (máx 1 call cada 2 segundos)
@@ -2932,15 +2960,15 @@ function lanzarAgenteClaude(skill, issue, trabajandoPath, pipeline, fase, config
     }
   }
 
-  // Usar Node directo para evitar cmd.exe y ventanas visibles
-  const spawnCmd = USE_NODE_DIRECT ? process.execPath : CLAUDE_BIN;
-  const spawnArgs = USE_NODE_DIRECT ? [CLAUDE_CLI_JS, ...args] : args;
+  // Launcher detectado al boot (ver detectClaudeLauncher). Evita cmd.exe cuando es posible.
+  const spawnCmd = CLAUDE_LAUNCHER.cmd;
+  const spawnArgs = [...CLAUDE_LAUNCHER.prefixArgs, ...args];
 
   const child = spawn(spawnCmd, spawnArgs, {
     cwd: (needsWorktree || useExistingWorktree) ? worktreePath : ROOT,
     stdio: ['ignore', agentLogFd, agentLogFd],
     detached: false,
-    shell: false,
+    shell: CLAUDE_LAUNCHER.shell,
     windowsHide: true,
     env: { ...process.env, PIPELINE_ISSUE: issue, PIPELINE_SKILL: skill, PIPELINE_FASE: fase, ...extraEnv }
   });
@@ -3957,14 +3985,14 @@ function ejecutarClaude(prompt, textoOriginal) {
     const cleanEnv = { ...process.env, CLAUDE_PROJECT_DIR: ROOT };
     delete cleanEnv.CLAUDECODE;
 
-    const cmdSpawn = USE_NODE_DIRECT ? process.execPath : CLAUDE_BIN;
-    const cmdArgs = USE_NODE_DIRECT ? [CLAUDE_CLI_JS, ...args] : args;
+    const cmdSpawn = CLAUDE_LAUNCHER.cmd;
+    const cmdArgs = [...CLAUDE_LAUNCHER.prefixArgs, ...args];
 
     const proc = spawn(cmdSpawn, cmdArgs, {
       cwd: ROOT,
       env: cleanEnv,
       stdio: ['pipe', 'pipe', 'pipe'],
-      shell: !USE_NODE_DIRECT,
+      shell: CLAUDE_LAUNCHER.shell,
       windowsHide: true
     });
 
@@ -4947,6 +4975,7 @@ function brazoDesbloqueo(config) {
 async function mainLoop() {
   log('pulpo', `Pulpo V2 iniciado — poll cada ${loadConfig().timeouts?.poll_interval_seconds || 30}s`);
   log('pulpo', `Pipeline: ${PIPELINE}`);
+  log('pulpo', `Claude launcher: ${CLAUDE_LAUNCHER.kind} → ${CLAUDE_LAUNCHER.cmd}`);
 
   // Confirmar restart solicitado desde Telegram. El pulpo anterior murió a
   // mitad del restart.js (cadena: pulpo → cmd → node restart.js, matada por


### PR DESCRIPTION
## Resumen
Claude Code **2.1.114** cambió la estructura del paquete: eliminó `cli.js` y lo reemplazó por `bin/claude.exe` nativo. El pulpo detectaba `USE_NODE_DIRECT` por existencia de `cli.js` y al no encontrarlo caía al fallback `spawn('claude', ..., { shell: false })`, que en Windows **no puede ejecutar shims `.cmd`** → los procesos hijos morían con `ENOENT` antes del primer logline.

**Impacto observado hoy (2026-04-18):** todos los `backend-dev` y `android-dev` lanzados después del auto-update morían en <15s ("muerte prematura"), llegaban a 3 rebotes y eran rechazados. Ejemplos: #2307, #2332, #2333, #2335.

## Solución
Reemplazar `USE_NODE_DIRECT` por `detectClaudeLauncher()` — detector de 5 capas que prueba de más a menos preferida:

| # | Estrategia | Cuándo aplica | `shell` |
|---|------------|----------------|---------|
| 1 | `node cli.js` | Versiones viejas (legacy) | `false` |
| 2 | `bin/claude.exe` directo (ruta absoluta) | Claude Code ≥2.1.114 | `false` |
| 3 | `node cli-wrapper.cjs` | Fallback JS del paquete | `false` |
| 4 | `%APPDATA%/npm/claude.cmd` | Shim npm con ruta absoluta | `true` |
| 5 | `claude` en PATH | Último recurso | `true` |

El launcher se detecta **una vez al boot** y se usa en los dos call sites (`spawn` de agentes y `spawn` de comandos one-shot).

Además, se agrega log al startup indicando qué launcher fue detectado, para facilitar diagnóstico en futuros auto-updates del paquete.

## Smoke test
```
node -e "... detectClaudeLauncher() ..."
→ DETECTED: {"kind":"native-exe","cmd":".../bin/claude.exe","shell":false}

spawn(exe, ['--version'], { shell: false }) 
→ EXIT_CODE: 0, STDOUT: "2.1.114 (Claude Code)"
```

## Test plan
- [ ] Reiniciar el pulpo y verificar en `pulpo.log` la línea `Claude launcher: native-exe → .../claude.exe`
- [ ] Reanudar el pipeline y verificar que al menos un agente lanzado (ej. `backend-dev` del #2023) supera los 15s de "muerte prematura"
- [ ] Verificar que el agent-log contiene output real (no solo header)

## Etiquetas
`qa:skipped` — cambio puro de infra del pipeline, sin impacto en producto de usuario.