### PR TITLE
fix(app): ignoreUnknownKeys en ClientSearchBusinessesService y dashboard (#2158)

### DIFF
--- a/app/composeApp/src/commonMain/kotlin/ext/IntraleJson.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/IntraleJson.kt
@@ -1,0 +1,26 @@
+package ext
+
+import kotlinx.serialization.json.Json
+
+/**
+ * Instancia compartida de [Json] para deserializar respuestas del backend en los
+ * `Client*Service`.
+ *
+ * El backend serializa `Response` con campos extra (por ejemplo `responseHeaders`)
+ * que no estan declarados en los DTO del cliente. Si los servicios usan el `Json`
+ * por defecto (`Json.decodeFromString`) sin `ignoreUnknownKeys = true`, fallan con
+ * `Unexpected JSON token at offset N: Encountered an unknown key 'responseHeaders'`
+ * y el flujo del usuario se rompe (issue #2158).
+ *
+ * Reglas:
+ * - `ignoreUnknownKeys = true`: tolerar campos nuevos del backend sin romper el cliente.
+ * - `isLenient = true`: tolerar JSON con leves desviaciones (comillas simples, claves sin
+ *    comillas, etc.) por compatibilidad con respuestas no estrictas.
+ *
+ * Todo `Client*Service` que haga `bodyAsText() + decodeFromString` manual DEBE usar
+ * esta instancia en lugar de `Json` directamente.
+ */
+val IntraleClientJson: Json = Json {
+    ignoreUnknownKeys = true
+    isLenient = true
+}

--- a/app/composeApp/src/commonMain/kotlin/ext/auth/ClientChangePasswordService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/auth/ClientChangePasswordService.kt
@@ -9,7 +9,7 @@ import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.isSuccess
 import io.ktor.utils.io.InternalAPI
-import kotlinx.serialization.json.Json
+import ext.IntraleClientJson
 import ar.com.intrale.shared.ExceptionResponse
 import ar.com.intrale.shared.StatusCodeDTO
 import ar.com.intrale.shared.toExceptionResponse
@@ -30,7 +30,7 @@ class ClientChangePasswordService(private val httpClient: HttpClient) : CommChan
                 )
             } else {
                 val bodyText = response.bodyAsText()
-                val exception = Json.decodeFromString(ExceptionResponse.serializer(), bodyText)
+                val exception = IntraleClientJson.decodeFromString(ExceptionResponse.serializer(), bodyText)
                 Result.failure(exception)
             }
         } catch (e: Exception) {

--- a/app/composeApp/src/commonMain/kotlin/ext/auth/ClientLoginService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/auth/ClientLoginService.kt
@@ -10,11 +10,11 @@ import org.kodein.log.newLogger
 import io.ktor.client.statement.bodyAsText
 import io.ktor.client.statement.HttpResponse
 import io.ktor.http.isSuccess
-import kotlinx.serialization.json.Json
 import ar.com.intrale.shared.ExceptionResponse
 import ar.com.intrale.shared.toExceptionResponse
 import ar.com.intrale.shared.auth.LoginRequest
 import ar.com.intrale.shared.auth.LoginResponse
+import ext.IntraleClientJson
 
 class ClientLoginService(val httpClient: HttpClient) : CommLoginService {
 
@@ -39,11 +39,11 @@ class ClientLoginService(val httpClient: HttpClient) : CommLoginService {
             val bodyText = response.bodyAsText()
 
             if (response.status.isSuccess()) {
-                val loginResponse = Json.decodeFromString(LoginResponse.serializer(), bodyText)
-                logger.debug { "response body: $loginResponse" }
+                val loginResponse = IntraleClientJson.decodeFromString(LoginResponse.serializer(), bodyText)
+                logger.debug { "login response received with status ${loginResponse.statusCode.value}" }
                 Result.success(loginResponse)
             } else {
-                val exceptionResponse = Json.decodeFromString(ExceptionResponse.serializer(), bodyText)
+                val exceptionResponse = IntraleClientJson.decodeFromString(ExceptionResponse.serializer(), bodyText)
                 logger.debug { "login failed with status: $exceptionResponse" }
                 Result.failure(exceptionResponse)
             }

--- a/app/composeApp/src/commonMain/kotlin/ext/auth/ClientPasswordRecoveryService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/auth/ClientPasswordRecoveryService.kt
@@ -8,7 +8,7 @@ import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.isSuccess
 import io.ktor.utils.io.InternalAPI
-import kotlinx.serialization.json.Json
+import ext.IntraleClientJson
 import ar.com.intrale.shared.ExceptionResponse
 import ar.com.intrale.shared.StatusCodeDTO
 import ar.com.intrale.shared.toExceptionResponse
@@ -29,7 +29,7 @@ class ClientPasswordRecoveryService(private val httpClient: HttpClient) : CommPa
                 )
             } else {
                 val bodyText = response.bodyAsText()
-                val exception = Json.decodeFromString(ExceptionResponse.serializer(), bodyText)
+                val exception = IntraleClientJson.decodeFromString(ExceptionResponse.serializer(), bodyText)
                 Result.failure(exception)
             }
         } catch (e: Exception) {
@@ -49,7 +49,7 @@ class ClientPasswordRecoveryService(private val httpClient: HttpClient) : CommPa
                 )
             } else {
                 val bodyText = response.bodyAsText()
-                val exception = Json.decodeFromString(ExceptionResponse.serializer(), bodyText)
+                val exception = IntraleClientJson.decodeFromString(ExceptionResponse.serializer(), bodyText)
                 Result.failure(exception)
             }
         } catch (e: Exception) {

--- a/app/composeApp/src/commonMain/kotlin/ext/auth/ClientTwoFactorSetupService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/auth/ClientTwoFactorSetupService.kt
@@ -8,7 +8,7 @@ import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.isSuccess
 import io.ktor.utils.io.InternalAPI
-import kotlinx.serialization.json.Json
+import ext.IntraleClientJson
 import ar.com.intrale.shared.ExceptionResponse
 import ar.com.intrale.shared.toExceptionResponse
 import ar.com.intrale.shared.auth.TwoFactorSetupResponse
@@ -22,10 +22,10 @@ class ClientTwoFactorSetupService(private val httpClient: HttpClient) : CommTwoF
             }
             val bodyText = response.bodyAsText()
             if (response.status.isSuccess()) {
-                val twoFactorSetupResponse = Json.decodeFromString(TwoFactorSetupResponse.serializer(), bodyText)
+                val twoFactorSetupResponse = IntraleClientJson.decodeFromString(TwoFactorSetupResponse.serializer(), bodyText)
                 Result.success(twoFactorSetupResponse )
             } else {
-                val exception = Json.decodeFromString(ExceptionResponse.serializer(), bodyText)
+                val exception = IntraleClientJson.decodeFromString(ExceptionResponse.serializer(), bodyText)
                 Result.failure(exception)
             }
         } catch (e: Exception) {

--- a/app/composeApp/src/commonMain/kotlin/ext/auth/ClientTwoFactorVerifyService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/auth/ClientTwoFactorVerifyService.kt
@@ -9,7 +9,7 @@ import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.isSuccess
 import io.ktor.utils.io.InternalAPI
-import kotlinx.serialization.json.Json
+import ext.IntraleClientJson
 import ar.com.intrale.shared.ExceptionResponse
 import ar.com.intrale.shared.StatusCodeDTO
 import ar.com.intrale.shared.toExceptionResponse
@@ -30,7 +30,7 @@ class ClientTwoFactorVerifyService(private val httpClient: HttpClient) : CommTwo
                 )
             } else {
                 val bodyText = response.bodyAsText()
-                val exception = Json.decodeFromString(ExceptionResponse.serializer(), bodyText)
+                val exception = IntraleClientJson.decodeFromString(ExceptionResponse.serializer(), bodyText)
                 Result.failure(exception)
             }
         } catch (e: Exception) {

--- a/app/composeApp/src/commonMain/kotlin/ext/auth/DeliveryLoginService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/auth/DeliveryLoginService.kt
@@ -8,13 +8,13 @@ import io.ktor.client.request.setBody
 import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.isSuccess
-import kotlinx.serialization.json.Json
 import org.kodein.log.LoggerFactory
 import org.kodein.log.newLogger
 import ar.com.intrale.shared.ExceptionResponse
 import ar.com.intrale.shared.toExceptionResponse
 import ar.com.intrale.shared.auth.LoginRequest
 import ar.com.intrale.shared.auth.LoginResponse
+import ext.IntraleClientJson
 
 class DeliveryLoginService(private val httpClient: HttpClient) : CommLoginService {
 
@@ -41,11 +41,11 @@ class DeliveryLoginService(private val httpClient: HttpClient) : CommLoginServic
             val bodyText = response.bodyAsText()
 
             if (response.status.isSuccess()) {
-                val loginResponse = Json.decodeFromString(LoginResponse.serializer(), bodyText)
+                val loginResponse = IntraleClientJson.decodeFromString(LoginResponse.serializer(), bodyText)
                 logger.info { "[Delivery][Login] Respuesta exitosa para ${BuildKonfig.DELIVERY}" }
                 Result.success(loginResponse)
             } else {
-                val exceptionResponse = Json.decodeFromString(ExceptionResponse.serializer(), bodyText)
+                val exceptionResponse = IntraleClientJson.decodeFromString(ExceptionResponse.serializer(), bodyText)
                 logger.warning { "[Delivery][Login] Error ${exceptionResponse.statusCode}: ${exceptionResponse.message}" }
                 Result.failure(exceptionResponse)
             }

--- a/app/composeApp/src/commonMain/kotlin/ext/business/ClientBannerService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/business/ClientBannerService.kt
@@ -19,7 +19,7 @@ import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpHeaders
 import io.ktor.http.isSuccess
 import kotlinx.serialization.builtins.ListSerializer
-import kotlinx.serialization.json.Json
+import ext.IntraleClientJson
 import org.kodein.log.LoggerFactory
 import org.kodein.log.newLogger
 
@@ -90,10 +90,10 @@ class ClientBannerService(
     private suspend fun HttpResponse.toBanner(): BannerDTO {
         val bodyText = bodyAsText()
         if (status.isSuccess()) {
-            runCatching { return Json.decodeFromString(BannerDTO.serializer(), bodyText) }
+            runCatching { return IntraleClientJson.decodeFromString(BannerDTO.serializer(), bodyText) }
             runCatching {
                 val responseWrapper =
-                    Json.decodeFromString(BannerListResponse.serializer(), bodyText)
+                    IntraleClientJson.decodeFromString(BannerListResponse.serializer(), bodyText)
                 responseWrapper.banners.firstOrNull()?.let { return it }
             }
             throw ExceptionResponse(
@@ -108,11 +108,11 @@ class ClientBannerService(
         val bodyText = bodyAsText()
         if (status.isSuccess()) {
             runCatching {
-                return Json.decodeFromString(BannerListResponse.serializer(), bodyText)
+                return IntraleClientJson.decodeFromString(BannerListResponse.serializer(), bodyText)
                     .banners
             }
             runCatching {
-                return Json.decodeFromString(
+                return IntraleClientJson.decodeFromString(
                     ListSerializer(BannerDTO.serializer()),
                     bodyText
                 )
@@ -123,7 +123,7 @@ class ClientBannerService(
     }
 
     private fun String.toBannerException(): ExceptionResponse =
-        runCatching { Json.decodeFromString(ExceptionResponse.serializer(), this) }
+        runCatching { IntraleClientJson.decodeFromString(ExceptionResponse.serializer(), this) }
             .getOrElse {
                 logger.error(it) { "No se pudo parsear la respuesta de error" }
                 ExceptionResponse(

--- a/app/composeApp/src/commonMain/kotlin/ext/business/ClientBusinessConfigService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/business/ClientBusinessConfigService.kt
@@ -17,7 +17,7 @@ import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpHeaders
 import io.ktor.http.isSuccess
-import kotlinx.serialization.json.Json
+import ext.IntraleClientJson
 import org.kodein.log.LoggerFactory
 import org.kodein.log.newLogger
 
@@ -35,10 +35,10 @@ class ClientBusinessConfigService(
             }
             val bodyText = response.bodyAsText()
             if (response.status.isSuccess()) {
-                val result = Json.decodeFromString(GetBusinessConfigResponse.serializer(), bodyText)
+                val result = IntraleClientJson.decodeFromString(GetBusinessConfigResponse.serializer(), bodyText)
                 Result.success(result.config)
             } else {
-                val exception = Json.decodeFromString(ExceptionResponse.serializer(), bodyText)
+                val exception = IntraleClientJson.decodeFromString(ExceptionResponse.serializer(), bodyText)
                 Result.failure(exception)
             }
         } catch (e: Exception) {
@@ -58,10 +58,10 @@ class ClientBusinessConfigService(
             }
             val bodyText = response.bodyAsText()
             if (response.status.isSuccess()) {
-                val result = Json.decodeFromString(UpdateBusinessConfigResponse.serializer(), bodyText)
+                val result = IntraleClientJson.decodeFromString(UpdateBusinessConfigResponse.serializer(), bodyText)
                 Result.success(result.config)
             } else {
-                val exception = Json.decodeFromString(ExceptionResponse.serializer(), bodyText)
+                val exception = IntraleClientJson.decodeFromString(ExceptionResponse.serializer(), bodyText)
                 Result.failure(exception)
             }
         } catch (e: Exception) {

--- a/app/composeApp/src/commonMain/kotlin/ext/business/ClientBusinessDeliveryZoneService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/business/ClientBusinessDeliveryZoneService.kt
@@ -17,7 +17,7 @@ import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpHeaders
 import io.ktor.http.isSuccess
-import kotlinx.serialization.json.Json
+import ext.IntraleClientJson
 import org.kodein.log.LoggerFactory
 import org.kodein.log.newLogger
 
@@ -35,10 +35,10 @@ class ClientBusinessDeliveryZoneService(
             }
             val bodyText = response.bodyAsText()
             if (response.status.isSuccess()) {
-                val result = Json.decodeFromString(GetBusinessDeliveryZoneResponse.serializer(), bodyText)
+                val result = IntraleClientJson.decodeFromString(GetBusinessDeliveryZoneResponse.serializer(), bodyText)
                 Result.success(result.deliveryZone)
             } else {
-                val exception = Json.decodeFromString(ExceptionResponse.serializer(), bodyText)
+                val exception = IntraleClientJson.decodeFromString(ExceptionResponse.serializer(), bodyText)
                 Result.failure(exception)
             }
         } catch (e: Exception) {
@@ -58,10 +58,10 @@ class ClientBusinessDeliveryZoneService(
             }
             val bodyText = response.bodyAsText()
             if (response.status.isSuccess()) {
-                val result = Json.decodeFromString(UpdateBusinessDeliveryZoneResponse.serializer(), bodyText)
+                val result = IntraleClientJson.decodeFromString(UpdateBusinessDeliveryZoneResponse.serializer(), bodyText)
                 Result.success(result.deliveryZone)
             } else {
-                val exception = Json.decodeFromString(ExceptionResponse.serializer(), bodyText)
+                val exception = IntraleClientJson.decodeFromString(ExceptionResponse.serializer(), bodyText)
                 Result.failure(exception)
             }
         } catch (e: Exception) {

--- a/app/composeApp/src/commonMain/kotlin/ext/business/ClientBusinessPaymentMethodsService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/business/ClientBusinessPaymentMethodsService.kt
@@ -17,7 +17,7 @@ import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpHeaders
 import io.ktor.http.isSuccess
-import kotlinx.serialization.json.Json
+import ext.IntraleClientJson
 import org.kodein.log.LoggerFactory
 import org.kodein.log.newLogger
 
@@ -37,10 +37,10 @@ class ClientBusinessPaymentMethodsService(
             }
             val bodyText = response.bodyAsText()
             if (response.status.isSuccess()) {
-                val result = Json.decodeFromString(GetBusinessPaymentMethodsResponse.serializer(), bodyText)
+                val result = IntraleClientJson.decodeFromString(GetBusinessPaymentMethodsResponse.serializer(), bodyText)
                 Result.success(result.paymentMethods)
             } else {
-                val exception = Json.decodeFromString(ExceptionResponse.serializer(), bodyText)
+                val exception = IntraleClientJson.decodeFromString(ExceptionResponse.serializer(), bodyText)
                 Result.failure(exception)
             }
         } catch (e: Exception) {
@@ -62,10 +62,10 @@ class ClientBusinessPaymentMethodsService(
             }
             val bodyText = response.bodyAsText()
             if (response.status.isSuccess()) {
-                val result = Json.decodeFromString(UpdateBusinessPaymentMethodsResponse.serializer(), bodyText)
+                val result = IntraleClientJson.decodeFromString(UpdateBusinessPaymentMethodsResponse.serializer(), bodyText)
                 Result.success(result.paymentMethods)
             } else {
-                val exception = Json.decodeFromString(ExceptionResponse.serializer(), bodyText)
+                val exception = IntraleClientJson.decodeFromString(ExceptionResponse.serializer(), bodyText)
                 Result.failure(exception)
             }
         } catch (e: Exception) {

--- a/app/composeApp/src/commonMain/kotlin/ext/business/ClientBusinessSchedulesService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/business/ClientBusinessSchedulesService.kt
@@ -17,7 +17,7 @@ import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpHeaders
 import io.ktor.http.isSuccess
-import kotlinx.serialization.json.Json
+import ext.IntraleClientJson
 import org.kodein.log.LoggerFactory
 import org.kodein.log.newLogger
 
@@ -35,10 +35,10 @@ class ClientBusinessSchedulesService(
             }
             val bodyText = response.bodyAsText()
             if (response.status.isSuccess()) {
-                val result = Json.decodeFromString(GetBusinessSchedulesResponse.serializer(), bodyText)
+                val result = IntraleClientJson.decodeFromString(GetBusinessSchedulesResponse.serializer(), bodyText)
                 Result.success(result.schedules)
             } else {
-                val exception = Json.decodeFromString(ExceptionResponse.serializer(), bodyText)
+                val exception = IntraleClientJson.decodeFromString(ExceptionResponse.serializer(), bodyText)
                 Result.failure(exception)
             }
         } catch (e: Exception) {
@@ -58,10 +58,10 @@ class ClientBusinessSchedulesService(
             }
             val bodyText = response.bodyAsText()
             if (response.status.isSuccess()) {
-                val result = Json.decodeFromString(UpdateBusinessSchedulesResponse.serializer(), bodyText)
+                val result = IntraleClientJson.decodeFromString(UpdateBusinessSchedulesResponse.serializer(), bodyText)
                 Result.success(result.schedules)
             } else {
-                val exception = Json.decodeFromString(ExceptionResponse.serializer(), bodyText)
+                val exception = IntraleClientJson.decodeFromString(ExceptionResponse.serializer(), bodyText)
                 Result.failure(exception)
             }
         } catch (e: Exception) {

--- a/app/composeApp/src/commonMain/kotlin/ext/business/ClientCategoryService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/business/ClientCategoryService.kt
@@ -21,7 +21,7 @@ import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpHeaders
 import io.ktor.http.isSuccess
 import kotlinx.serialization.builtins.ListSerializer
-import kotlinx.serialization.json.Json
+import ext.IntraleClientJson
 import org.kodein.log.LoggerFactory
 import org.kodein.log.newLogger
 
@@ -94,10 +94,10 @@ class ClientCategoryService(
     private suspend fun HttpResponse.toCategory(): CategoryDTO {
         val bodyText = bodyAsText()
         if (status.isSuccess()) {
-            runCatching { return Json.decodeFromString(CategoryDTO.serializer(), bodyText) }
+            runCatching { return IntraleClientJson.decodeFromString(CategoryDTO.serializer(), bodyText) }
             runCatching {
                 val responseWrapper =
-                    Json.decodeFromString(CategoryListResponse.serializer(), bodyText)
+                    IntraleClientJson.decodeFromString(CategoryListResponse.serializer(), bodyText)
                 responseWrapper.categories.firstOrNull()?.let { return it }
             }
             throw ExceptionResponse(
@@ -112,11 +112,11 @@ class ClientCategoryService(
         val bodyText = bodyAsText()
         if (status.isSuccess()) {
             runCatching {
-                return Json.decodeFromString(CategoryListResponse.serializer(), bodyText)
+                return IntraleClientJson.decodeFromString(CategoryListResponse.serializer(), bodyText)
                     .categories
             }
             runCatching {
-                return Json.decodeFromString(
+                return IntraleClientJson.decodeFromString(
                     ListSerializer(CategoryDTO.serializer()),
                     bodyText
                 )
@@ -127,7 +127,7 @@ class ClientCategoryService(
     }
 
     private fun String.toCategoryException(): ExceptionResponse =
-        runCatching { Json.decodeFromString(ExceptionResponse.serializer(), this) }
+        runCatching { IntraleClientJson.decodeFromString(ExceptionResponse.serializer(), this) }
             .getOrElse {
                 logger.error(it) { "No se pudo parsear la respuesta de error" }
                 ExceptionResponse(

--- a/app/composeApp/src/commonMain/kotlin/ext/business/ClientFontsService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/business/ClientFontsService.kt
@@ -16,7 +16,7 @@ import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpHeaders
 import io.ktor.http.isSuccess
-import kotlinx.serialization.json.Json
+import ext.IntraleClientJson
 import org.kodein.log.LoggerFactory
 import org.kodein.log.newLogger
 
@@ -56,15 +56,15 @@ class ClientFontsService(
         val bodyText = bodyAsText()
         if (status.isSuccess()) {
             runCatching {
-                val wrapper = Json.decodeFromString(FontsResponse.serializer(), bodyText)
+                val wrapper = IntraleClientJson.decodeFromString(FontsResponse.serializer(), bodyText)
                 return FontsDTO(fonts = wrapper.fonts)
             }
             runCatching {
-                return Json.decodeFromString(FontsDTO.serializer(), bodyText)
+                return IntraleClientJson.decodeFromString(FontsDTO.serializer(), bodyText)
             }
             return FontsDTO()
         }
-        throw runCatching { Json.decodeFromString(ExceptionResponse.serializer(), bodyText) }
+        throw runCatching { IntraleClientJson.decodeFromString(ExceptionResponse.serializer(), bodyText) }
             .getOrElse {
                 logger.error(it) { "No se pudo parsear la respuesta de error" }
                 ExceptionResponse(

--- a/app/composeApp/src/commonMain/kotlin/ext/business/ClientGetBusinessDashboardSummaryService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/business/ClientGetBusinessDashboardSummaryService.kt
@@ -12,7 +12,7 @@ import io.ktor.client.request.header
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpHeaders
 import io.ktor.http.isSuccess
-import kotlinx.serialization.json.Json
+import ext.IntraleClientJson
 import org.kodein.log.LoggerFactory
 import org.kodein.log.newLogger
 
@@ -30,10 +30,10 @@ class ClientGetBusinessDashboardSummaryService(
             }
             val bodyText = response.bodyAsText()
             if (response.status.isSuccess()) {
-                val result = Json.decodeFromString(BusinessDashboardSummaryDTO.serializer(), bodyText)
+                val result = IntraleClientJson.decodeFromString(BusinessDashboardSummaryDTO.serializer(), bodyText)
                 Result.success(result)
             } else {
-                val exception = Json.decodeFromString(ExceptionResponse.serializer(), bodyText)
+                val exception = IntraleClientJson.decodeFromString(ExceptionResponse.serializer(), bodyText)
                 Result.failure(exception)
             }
         } catch (e: Exception) {

--- a/app/composeApp/src/commonMain/kotlin/ext/business/ClientGetBusinessOrderDetailService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/business/ClientGetBusinessOrderDetailService.kt
@@ -12,7 +12,7 @@ import io.ktor.client.request.header
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpHeaders
 import io.ktor.http.isSuccess
-import kotlinx.serialization.json.Json
+import ext.IntraleClientJson
 import org.kodein.log.LoggerFactory
 import org.kodein.log.newLogger
 
@@ -34,7 +34,7 @@ class ClientGetBusinessOrderDetailService(
             val bodyText = response.bodyAsText()
             if (response.status.isSuccess()) {
                 val parsed = runCatching {
-                    Json.decodeFromString(BusinessOrderDetailResponseDTO.serializer(), bodyText).order
+                    IntraleClientJson.decodeFromString(BusinessOrderDetailResponseDTO.serializer(), bodyText).order
                 }.getOrNull()
                 if (parsed != null) {
                     Result.success(parsed)
@@ -48,7 +48,7 @@ class ClientGetBusinessOrderDetailService(
                 }
             } else {
                 val exception = runCatching {
-                    Json.decodeFromString(ExceptionResponse.serializer(), bodyText)
+                    IntraleClientJson.decodeFromString(ExceptionResponse.serializer(), bodyText)
                 }.getOrElse {
                     ExceptionResponse(
                         StatusCodeDTO(response.status.value, response.status.description),

--- a/app/composeApp/src/commonMain/kotlin/ext/business/ClientGetBusinessOrdersService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/business/ClientGetBusinessOrdersService.kt
@@ -12,7 +12,7 @@ import io.ktor.client.request.header
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpHeaders
 import io.ktor.http.isSuccess
-import kotlinx.serialization.json.Json
+import ext.IntraleClientJson
 import org.kodein.log.LoggerFactory
 import org.kodein.log.newLogger
 
@@ -32,12 +32,12 @@ class ClientGetBusinessOrdersService(
             val bodyText = response.bodyAsText()
             if (response.status.isSuccess()) {
                 val parsed = runCatching {
-                    Json.decodeFromString(BusinessOrdersListResponseDTO.serializer(), bodyText).orders ?: emptyList()
+                    IntraleClientJson.decodeFromString(BusinessOrdersListResponseDTO.serializer(), bodyText).orders ?: emptyList()
                 }.getOrElse { emptyList() }
                 Result.success(parsed)
             } else {
                 val exception = runCatching {
-                    Json.decodeFromString(ExceptionResponse.serializer(), bodyText)
+                    IntraleClientJson.decodeFromString(ExceptionResponse.serializer(), bodyText)
                 }.getOrElse { ExceptionResponse(StatusCodeDTO(response.status.value, response.status.description), bodyText) }
                 Result.failure(exception)
             }

--- a/app/composeApp/src/commonMain/kotlin/ext/business/ClientGetBusinessProductsService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/business/ClientGetBusinessProductsService.kt
@@ -9,7 +9,7 @@ import io.ktor.client.request.get
 import io.ktor.client.request.parameter
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.isSuccess
-import kotlinx.serialization.json.Json
+import ext.IntraleClientJson
 import org.kodein.log.LoggerFactory
 import org.kodein.log.newLogger
 
@@ -29,11 +29,11 @@ class ClientGetBusinessProductsService(
             }
             val bodyText = response.bodyAsText()
             if (response.status.isSuccess()) {
-                val result = Json.decodeFromString(BusinessProductsResponse.serializer(), bodyText)
+                val result = IntraleClientJson.decodeFromString(BusinessProductsResponse.serializer(), bodyText)
                 logger.debug { "Productos cargados: ${result.products.size}" }
                 Result.success(result)
             } else {
-                val exception = Json.decodeFromString(ExceptionResponse.serializer(), bodyText)
+                val exception = IntraleClientJson.decodeFromString(ExceptionResponse.serializer(), bodyText)
                 Result.failure(exception)
             }
         } catch (e: Exception) {

--- a/app/composeApp/src/commonMain/kotlin/ext/business/ClientGetSalesMetricsService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/business/ClientGetSalesMetricsService.kt
@@ -13,7 +13,7 @@ import io.ktor.client.request.header
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpHeaders
 import io.ktor.http.isSuccess
-import kotlinx.serialization.json.Json
+import ext.IntraleClientJson
 import org.kodein.log.LoggerFactory
 import org.kodein.log.newLogger
 
@@ -31,10 +31,10 @@ class ClientGetSalesMetricsService(
             }
             val bodyText = response.bodyAsText()
             if (response.status.isSuccess()) {
-                val result = Json.decodeFromString(DailySalesMetricsResponseDTO.serializer(), bodyText)
+                val result = IntraleClientJson.decodeFromString(DailySalesMetricsResponseDTO.serializer(), bodyText)
                 Result.success(result.metrics ?: DailySalesMetricsDTO())
             } else {
-                val exception = Json.decodeFromString(ExceptionResponse.serializer(), bodyText)
+                val exception = IntraleClientJson.decodeFromString(ExceptionResponse.serializer(), bodyText)
                 Result.failure(exception)
             }
         } catch (e: Exception) {

--- a/app/composeApp/src/commonMain/kotlin/ext/business/ClientProductService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/business/ClientProductService.kt
@@ -20,7 +20,7 @@ import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpHeaders
 import io.ktor.http.isSuccess
 import kotlinx.serialization.builtins.ListSerializer
-import kotlinx.serialization.json.Json
+import ext.IntraleClientJson
 import org.kodein.log.LoggerFactory
 import org.kodein.log.newLogger
 
@@ -97,10 +97,10 @@ class ClientProductService(
     private suspend fun HttpResponse.toProduct(): ProductDTO {
         val bodyText = bodyAsText()
         if (status.isSuccess()) {
-            runCatching { return Json.decodeFromString(ProductDTO.serializer(), bodyText) }
+            runCatching { return IntraleClientJson.decodeFromString(ProductDTO.serializer(), bodyText) }
             runCatching {
                 val responseWrapper =
-                    Json.decodeFromString(ProductListResponse.serializer(), bodyText)
+                    IntraleClientJson.decodeFromString(ProductListResponse.serializer(), bodyText)
                 responseWrapper.products.firstOrNull()?.let { return it }
             }
             throw ExceptionResponse(
@@ -114,15 +114,15 @@ class ClientProductService(
     private suspend fun HttpResponse.toProducts(): List<ProductDTO> {
         val bodyText = bodyAsText()
         if (status.isSuccess()) {
-            runCatching { return Json.decodeFromString(ProductListResponse.serializer(), bodyText).products }
-            runCatching { return Json.decodeFromString(ListSerializer(ProductDTO.serializer()), bodyText) }
+            runCatching { return IntraleClientJson.decodeFromString(ProductListResponse.serializer(), bodyText).products }
+            runCatching { return IntraleClientJson.decodeFromString(ListSerializer(ProductDTO.serializer()), bodyText) }
             return emptyList()
         }
         throw bodyText.toProductException()
     }
 
     private fun String.toProductException(): ExceptionResponse =
-        runCatching { Json.decodeFromString(ExceptionResponse.serializer(), this) }
+        runCatching { IntraleClientJson.decodeFromString(ExceptionResponse.serializer(), this) }
             .getOrElse {
                 logger.error(it) { "No se pudo parsear la respuesta de error" }
                 ExceptionResponse(

--- a/app/composeApp/src/commonMain/kotlin/ext/business/ClientRegisterBusinessService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/business/ClientRegisterBusinessService.kt
@@ -8,7 +8,7 @@ import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.isSuccess
 import io.ktor.utils.io.InternalAPI
-import kotlinx.serialization.json.Json
+import ext.IntraleClientJson
 import ar.com.intrale.shared.ExceptionResponse
 import ar.com.intrale.shared.StatusCodeDTO
 import ar.com.intrale.shared.toExceptionResponse
@@ -26,7 +26,7 @@ class ClientRegisterBusinessService(private val httpClient: HttpClient) : CommRe
                 Result.success(RegisterBusinessResponse(StatusCodeDTO(response.status.value, response.status.description)))
             } else {
                 val bodyText = response.bodyAsText()
-                val exception = Json.decodeFromString(ExceptionResponse.serializer(), bodyText)
+                val exception = IntraleClientJson.decodeFromString(ExceptionResponse.serializer(), bodyText)
                 Result.failure(exception)
             }
         } catch (e: Exception) {

--- a/app/composeApp/src/commonMain/kotlin/ext/business/ClientRequestJoinBusinessService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/business/ClientRequestJoinBusinessService.kt
@@ -8,7 +8,7 @@ import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.isSuccess
 import io.ktor.utils.io.InternalAPI
-import kotlinx.serialization.json.Json
+import ext.IntraleClientJson
 import ar.com.intrale.shared.ExceptionResponse
 import ar.com.intrale.shared.toExceptionResponse
 import ar.com.intrale.shared.business.RequestJoinBusinessRequest
@@ -23,11 +23,11 @@ class ClientRequestJoinBusinessService(private val httpClient: HttpClient) : Com
             }
             if (response.status.isSuccess()) {
                 val bodyText = response.bodyAsText()
-                val result = Json.decodeFromString(RequestJoinBusinessResponse.serializer(), bodyText)
+                val result = IntraleClientJson.decodeFromString(RequestJoinBusinessResponse.serializer(), bodyText)
                 Result.success(result)
             } else {
                 val bodyText = response.bodyAsText()
-                val exception = Json.decodeFromString(ExceptionResponse.serializer(), bodyText)
+                val exception = IntraleClientJson.decodeFromString(ExceptionResponse.serializer(), bodyText)
                 Result.failure(exception)
             }
         } catch (e: Exception) {

--- a/app/composeApp/src/commonMain/kotlin/ext/business/ClientReviewBusinessRegistrationService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/business/ClientReviewBusinessRegistrationService.kt
@@ -9,7 +9,7 @@ import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.isSuccess
 import io.ktor.utils.io.InternalAPI
-import kotlinx.serialization.json.Json
+import ext.IntraleClientJson
 import ar.com.intrale.shared.ExceptionResponse
 import ar.com.intrale.shared.StatusCodeDTO
 import ar.com.intrale.shared.toExceptionResponse
@@ -33,7 +33,7 @@ class ClientReviewBusinessRegistrationService(private val httpClient: HttpClient
                 Result.success(ReviewBusinessRegistrationResponse(StatusCodeDTO(response.status.value, response.status.description)))
             } else {
                 val bodyText = response.bodyAsText()
-                val exception = Json.decodeFromString(ExceptionResponse.serializer(), bodyText)
+                val exception = IntraleClientJson.decodeFromString(ExceptionResponse.serializer(), bodyText)
                 Result.failure(exception)
             }
         } catch (e: Exception) {

--- a/app/composeApp/src/commonMain/kotlin/ext/business/ClientReviewJoinBusinessService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/business/ClientReviewJoinBusinessService.kt
@@ -8,7 +8,7 @@ import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.isSuccess
 import io.ktor.utils.io.InternalAPI
-import kotlinx.serialization.json.Json
+import ext.IntraleClientJson
 import ar.com.intrale.shared.ExceptionResponse
 import ar.com.intrale.shared.StatusCodeDTO
 import ar.com.intrale.shared.toExceptionResponse
@@ -26,7 +26,7 @@ class ClientReviewJoinBusinessService(private val httpClient: HttpClient) : Comm
                 Result.success(ReviewJoinBusinessResponse(StatusCodeDTO(response.status.value, response.status.description)))
             } else {
                 val bodyText = response.bodyAsText()
-                val exception = Json.decodeFromString(ExceptionResponse.serializer(), bodyText)
+                val exception = IntraleClientJson.decodeFromString(ExceptionResponse.serializer(), bodyText)
                 Result.failure(exception)
             }
         } catch (e: Exception) {

--- a/app/composeApp/src/commonMain/kotlin/ext/business/ClientSearchBusinessesService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/business/ClientSearchBusinessesService.kt
@@ -8,7 +8,7 @@ import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.isSuccess
 import io.ktor.utils.io.InternalAPI
-import kotlinx.serialization.json.Json
+import ext.IntraleClientJson
 import org.kodein.log.LoggerFactory
 import org.kodein.log.newLogger
 import ar.com.intrale.shared.ExceptionResponse
@@ -33,12 +33,12 @@ class ClientSearchBusinessesService(private val httpClient: HttpClient) : CommSe
             }
             if (response.status.isSuccess()) {
                 val bodyText = response.bodyAsText()
-                val result = Json.decodeFromString(SearchBusinessesResponse.serializer(), bodyText)
-                logger.debug { "response body: $result" }
+                val result = IntraleClientJson.decodeFromString(SearchBusinessesResponse.serializer(), bodyText)
+                logger.debug { "search businesses response received with ${result.businesses.size} businesses" }
                 Result.success(result)
             } else {
                 val bodyText = response.bodyAsText()
-                val exception = Json.decodeFromString(ExceptionResponse.serializer(), bodyText)
+                val exception = IntraleClientJson.decodeFromString(ExceptionResponse.serializer(), bodyText)
                 logger.debug { "search business failed with status: $exception" }
                 Result.failure(exception)
             }

--- a/app/composeApp/src/commonMain/kotlin/ext/business/ClientUpdateBusinessOrderStatusService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/business/ClientUpdateBusinessOrderStatusService.kt
@@ -16,6 +16,7 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.contentType
 import io.ktor.http.isSuccess
 import kotlinx.serialization.json.Json
+import ext.IntraleClientJson
 import org.kodein.log.LoggerFactory
 import org.kodein.log.newLogger
 
@@ -52,7 +53,7 @@ class ClientUpdateBusinessOrderStatusService(
             val bodyText = response.bodyAsText()
             if (response.status.isSuccess()) {
                 val parsed = runCatching {
-                    Json.decodeFromString(BusinessOrderStatusUpdateResponseDTO.serializer(), bodyText)
+                    IntraleClientJson.decodeFromString(BusinessOrderStatusUpdateResponseDTO.serializer(), bodyText)
                 }.getOrElse {
                     BusinessOrderStatusUpdateResponseDTO(
                         orderId = orderId,
@@ -63,7 +64,7 @@ class ClientUpdateBusinessOrderStatusService(
                 Result.success(parsed)
             } else {
                 val exception = runCatching {
-                    Json.decodeFromString(ExceptionResponse.serializer(), bodyText)
+                    IntraleClientJson.decodeFromString(ExceptionResponse.serializer(), bodyText)
                 }.getOrElse {
                     ExceptionResponse(
                         StatusCodeDTO(response.status.value, response.status.description),

--- a/app/composeApp/src/commonMain/kotlin/ext/client/ClientOrdersService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/client/ClientOrdersService.kt
@@ -22,6 +22,7 @@ import io.ktor.http.contentType
 import io.ktor.http.isSuccess
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
+import ext.IntraleClientJson
 import org.kodein.log.LoggerFactory
 import org.kodein.log.newLogger
 
@@ -63,12 +64,12 @@ class ClientOrdersService(
         if (status.isSuccess()) {
             if (bodyText.isBlank()) return emptyList()
             val parsedResponse = runCatching {
-                Json.decodeFromString(ClientOrdersResponse.serializer(), bodyText).orders
+                IntraleClientJson.decodeFromString(ClientOrdersResponse.serializer(), bodyText).orders
             }.getOrNull()
             if (parsedResponse != null) {
                 return parsedResponse
             }
-            return Json.decodeFromString(ListSerializer(ClientOrderDTO.serializer()), bodyText)
+            return IntraleClientJson.decodeFromString(ListSerializer(ClientOrderDTO.serializer()), bodyText)
         }
         throw bodyText.toClientException()
     }
@@ -78,12 +79,12 @@ class ClientOrdersService(
         if (status.isSuccess()) {
             if (bodyText.isBlank()) return ClientOrderDetailDTO()
             val parsedResponse = runCatching {
-                Json.decodeFromString(ClientOrderDetailResponse.serializer(), bodyText).order
+                IntraleClientJson.decodeFromString(ClientOrderDetailResponse.serializer(), bodyText).order
             }.getOrNull()
             if (parsedResponse != null) {
                 return parsedResponse
             }
-            return Json.decodeFromString(ClientOrderDetailDTO.serializer(), bodyText)
+            return IntraleClientJson.decodeFromString(ClientOrderDetailDTO.serializer(), bodyText)
         }
         throw bodyText.toClientException()
     }
@@ -98,7 +99,7 @@ class ClientOrdersService(
             }
             val bodyText = response.bodyAsText()
             if (response.status.isSuccess()) {
-                val parsed = Json.decodeFromString(CreateClientOrderResponseDTO.serializer(), bodyText)
+                val parsed = IntraleClientJson.decodeFromString(CreateClientOrderResponseDTO.serializer(), bodyText)
                 Result.success(parsed)
             } else {
                 Result.failure(bodyText.toClientException())
@@ -110,7 +111,7 @@ class ClientOrdersService(
     }
 
     private fun String.toClientException(): ClientExceptionResponse =
-        runCatching { Json.decodeFromString(ClientExceptionResponse.serializer(), this) }
+        runCatching { IntraleClientJson.decodeFromString(ClientExceptionResponse.serializer(), this) }
             .getOrElse { ClientExceptionResponse(message = this) }
 
     private fun io.ktor.client.request.HttpRequestBuilder.authorize() {

--- a/app/composeApp/src/commonMain/kotlin/ext/client/ClientProfileService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/client/ClientProfileService.kt
@@ -20,7 +20,7 @@ import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpHeaders
 import io.ktor.http.isSuccess
 import kotlinx.serialization.builtins.ListSerializer
-import kotlinx.serialization.json.Json
+import ext.IntraleClientJson
 import org.kodein.log.LoggerFactory
 import org.kodein.log.newLogger
 
@@ -72,14 +72,14 @@ class ClientProfileService(
             return if (bodyText.isBlank()) {
                 ClientProfileResponse(profile = ClientProfileDTO())
             } else {
-                Json.decodeFromString(ClientProfileResponse.serializer(), bodyText)
+                IntraleClientJson.decodeFromString(ClientProfileResponse.serializer(), bodyText)
             }
         }
         throw bodyText.toClientException()
     }
 
     private fun String.toClientException(): ClientExceptionResponse =
-        runCatching { Json.decodeFromString(ClientExceptionResponse.serializer(), this) }
+        runCatching { IntraleClientJson.decodeFromString(ClientExceptionResponse.serializer(), this) }
             .getOrElse { ClientExceptionResponse(message = this) }
 
     private fun io.ktor.client.request.HttpRequestBuilder.authorize() {
@@ -172,12 +172,12 @@ class ClientAddressesService(
         if (status.isSuccess()) {
             if (bodyText.isBlank()) return emptyList()
             val parsedResponse = runCatching {
-                Json.decodeFromString(ClientAddressResponse.serializer(), bodyText).addresses
+                IntraleClientJson.decodeFromString(ClientAddressResponse.serializer(), bodyText).addresses
             }.getOrNull()
             if (parsedResponse != null) {
                 return parsedResponse
             }
-            return Json.decodeFromString(ListSerializer(ClientAddressDTO.serializer()), bodyText)
+            return IntraleClientJson.decodeFromString(ListSerializer(ClientAddressDTO.serializer()), bodyText)
         }
         throw bodyText.toClientException()
     }
@@ -186,13 +186,13 @@ class ClientAddressesService(
         val bodyText = bodyAsText()
         if (status.isSuccess()) {
             if (bodyText.isBlank()) return ClientAddressDTO()
-            return Json.decodeFromString(ClientAddressDTO.serializer(), bodyText)
+            return IntraleClientJson.decodeFromString(ClientAddressDTO.serializer(), bodyText)
         }
         throw bodyText.toClientException()
     }
 
     private fun String.toClientException(): ClientExceptionResponse =
-        runCatching { Json.decodeFromString(ClientExceptionResponse.serializer(), this) }
+        runCatching { IntraleClientJson.decodeFromString(ClientExceptionResponse.serializer(), this) }
             .getOrElse { ClientExceptionResponse(message = this) }
 
     private fun io.ktor.client.request.HttpRequestBuilder.authorize() {

--- a/app/composeApp/src/commonMain/kotlin/ext/client/PaymentMethodsService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/client/PaymentMethodsService.kt
@@ -13,7 +13,7 @@ import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpHeaders
 import io.ktor.http.isSuccess
 import kotlinx.serialization.builtins.ListSerializer
-import kotlinx.serialization.json.Json
+import ext.IntraleClientJson
 import org.kodein.log.LoggerFactory
 import org.kodein.log.newLogger
 
@@ -44,18 +44,18 @@ class PaymentMethodsService(
         if (status.isSuccess()) {
             if (bodyText.isBlank()) return emptyList()
             val parsedResponse = runCatching {
-                Json.decodeFromString(PaymentMethodsResponse.serializer(), bodyText).paymentMethods
+                IntraleClientJson.decodeFromString(PaymentMethodsResponse.serializer(), bodyText).paymentMethods
             }.getOrNull()
             if (parsedResponse != null) {
                 return parsedResponse
             }
-            return Json.decodeFromString(ListSerializer(PaymentMethodDTO.serializer()), bodyText)
+            return IntraleClientJson.decodeFromString(ListSerializer(PaymentMethodDTO.serializer()), bodyText)
         }
         throw bodyText.toClientException()
     }
 
     private fun String.toClientException(): ClientExceptionResponse =
-        runCatching { Json.decodeFromString(ClientExceptionResponse.serializer(), this) }
+        runCatching { IntraleClientJson.decodeFromString(ClientExceptionResponse.serializer(), this) }
             .getOrElse { ClientExceptionResponse(message = this) }
 
     private fun io.ktor.client.request.HttpRequestBuilder.authorize() {

--- a/app/composeApp/src/commonMain/kotlin/ext/client/ProductAvailabilityService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/client/ProductAvailabilityService.kt
@@ -15,6 +15,7 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.contentType
 import io.ktor.http.isSuccess
 import kotlinx.serialization.json.Json
+import ext.IntraleClientJson
 import org.kodein.log.LoggerFactory
 import org.kodein.log.newLogger
 
@@ -42,7 +43,7 @@ class ProductAvailabilityService(
             }
             val bodyText = response.bodyAsText()
             if (response.status.isSuccess()) {
-                val parsed = Json.decodeFromString(ProductAvailabilityResponseDTO.serializer(), bodyText)
+                val parsed = IntraleClientJson.decodeFromString(ProductAvailabilityResponseDTO.serializer(), bodyText)
                 Result.success(parsed)
             } else {
                 Result.failure(bodyText.toClientException())
@@ -54,7 +55,7 @@ class ProductAvailabilityService(
     }
 
     private fun String.toClientException(): ClientExceptionResponse =
-        runCatching { Json.decodeFromString(ClientExceptionResponse.serializer(), this) }
+        runCatching { IntraleClientJson.decodeFromString(ClientExceptionResponse.serializer(), this) }
             .getOrElse { ClientExceptionResponse(message = this) }
 
     private fun io.ktor.client.request.HttpRequestBuilder.authorize() {

--- a/app/composeApp/src/commonMain/kotlin/ext/client/PushTokenService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/client/PushTokenService.kt
@@ -13,6 +13,7 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.isSuccess
 import org.kodein.log.LoggerFactory
 import org.kodein.log.newLogger
+import ext.IntraleClientJson
 
 class PushTokenService(
     private val httpClient: HttpClient,
@@ -66,7 +67,7 @@ class PushTokenService(
     }
 
     private fun String.toClientException(): ClientExceptionResponse =
-        runCatching { kotlinx.serialization.json.Json.decodeFromString(ClientExceptionResponse.serializer(), this) }
+        runCatching { IntraleClientJson.decodeFromString(ClientExceptionResponse.serializer(), this) }
             .getOrElse { ClientExceptionResponse(message = this) }
 
     private fun io.ktor.client.request.HttpRequestBuilder.authorize() {

--- a/app/composeApp/src/commonMain/kotlin/ext/delivery/DeliveryExceptions.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/delivery/DeliveryExceptions.kt
@@ -2,7 +2,7 @@ package ext.delivery
 
 import ar.com.intrale.shared.StatusCodeDTO
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.Json
+import ext.IntraleClientJson
 
 @Serializable
 data class DeliveryExceptionResponse(
@@ -16,5 +16,5 @@ fun Throwable.toDeliveryException(): DeliveryExceptionResponse = when (this) {
 }
 
 fun String.toDeliveryException(): DeliveryExceptionResponse =
-    runCatching { Json.decodeFromString(DeliveryExceptionResponse.serializer(), this) }
+    runCatching { IntraleClientJson.decodeFromString(DeliveryExceptionResponse.serializer(), this) }
         .getOrElse { DeliveryExceptionResponse(message = this) }

--- a/app/composeApp/src/commonMain/kotlin/ext/delivery/DeliveryOrdersService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/delivery/DeliveryOrdersService.kt
@@ -18,7 +18,7 @@ import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpHeaders
 import io.ktor.http.isSuccess
 import kotlinx.datetime.LocalDate
-import kotlinx.serialization.json.Json
+import ext.IntraleClientJson
 import org.kodein.log.LoggerFactory
 import org.kodein.log.newLogger
 
@@ -129,7 +129,7 @@ class DeliveryOrdersService(
         if (bodyText.isBlank()) {
             throw DeliveryExceptionResponse(message = "Respuesta vacía del servidor")
         }
-        return Json.decodeFromString(deserializer, bodyText)
+        return IntraleClientJson.decodeFromString(deserializer, bodyText)
     }
 }
 

--- a/app/composeApp/src/commonMain/kotlin/ext/delivery/DeliveryProfileService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/delivery/DeliveryProfileService.kt
@@ -16,7 +16,7 @@ import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpHeaders
 import io.ktor.http.isSuccess
-import kotlinx.serialization.json.Json
+import ext.IntraleClientJson
 import org.kodein.log.LoggerFactory
 import org.kodein.log.newLogger
 
@@ -68,7 +68,7 @@ class DeliveryProfileService(
         val bodyText = bodyAsText()
         if (status.isSuccess()) {
             if (bodyText.isBlank()) return DeliveryProfileResponse(profile = DeliveryProfileDTO())
-            return Json.decodeFromString(DeliveryProfileResponse.serializer(), bodyText)
+            return IntraleClientJson.decodeFromString(DeliveryProfileResponse.serializer(), bodyText)
         }
         throw bodyText.toDeliveryException()
     }
@@ -80,6 +80,6 @@ class DeliveryProfileService(
     }
 
     private fun String.toDeliveryException(): DeliveryExceptionResponse =
-        runCatching { Json.decodeFromString(DeliveryExceptionResponse.serializer(), this) }
+        runCatching { IntraleClientJson.decodeFromString(DeliveryExceptionResponse.serializer(), this) }
             .getOrElse { DeliveryExceptionResponse(message = this) }
 }

--- a/app/composeApp/src/commonMain/kotlin/ext/delivery/DeliveryStateService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/delivery/DeliveryStateService.kt
@@ -13,7 +13,7 @@ import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpHeaders
 import io.ktor.http.isSuccess
-import kotlinx.serialization.json.Json
+import ext.IntraleClientJson
 import org.kodein.log.LoggerFactory
 import org.kodein.log.newLogger
 
@@ -56,6 +56,6 @@ class DeliveryStateService(
         if (bodyText.isBlank()) {
             throw DeliveryExceptionResponse(message = "Respuesta vacía del servidor")
         }
-        return Json.decodeFromString(deserializer, bodyText)
+        return IntraleClientJson.decodeFromString(deserializer, bodyText)
     }
 }

--- a/app/composeApp/src/commonMain/kotlin/ext/signup/ClientConfirmSignUpService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/signup/ClientConfirmSignUpService.kt
@@ -8,7 +8,7 @@ import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.isSuccess
 import io.ktor.utils.io.InternalAPI
-import kotlinx.serialization.json.Json
+import ext.IntraleClientJson
 import ar.com.intrale.shared.ExceptionResponse
 import ar.com.intrale.shared.StatusCodeDTO
 import ar.com.intrale.shared.toExceptionResponse
@@ -29,7 +29,7 @@ class ClientConfirmSignUpService(private val httpClient: HttpClient) : CommConfi
                 )
             } else {
                 val bodyText = response.bodyAsText()
-                val exception = Json.decodeFromString(ExceptionResponse.serializer(), bodyText)
+                val exception = IntraleClientJson.decodeFromString(ExceptionResponse.serializer(), bodyText)
                 Result.failure(exception)
             }
         } catch (e: Exception) {

--- a/app/composeApp/src/commonMain/kotlin/ext/signup/ClientRegisterSalerService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/signup/ClientRegisterSalerService.kt
@@ -9,7 +9,7 @@ import io.ktor.client.statement.bodyAsText
 import io.ktor.client.statement.HttpResponse
 import io.ktor.http.isSuccess
 import io.ktor.utils.io.InternalAPI
-import kotlinx.serialization.json.Json
+import ext.IntraleClientJson
 import ar.com.intrale.shared.ExceptionResponse
 import ar.com.intrale.shared.StatusCodeDTO
 import ar.com.intrale.shared.toExceptionResponse
@@ -30,7 +30,7 @@ class ClientRegisterSalerService(private val httpClient: HttpClient) : CommRegis
                 )
             } else {
                 val bodyText = response.bodyAsText()
-                val exception = Json.decodeFromString(ExceptionResponse.serializer(), bodyText)
+                val exception = IntraleClientJson.decodeFromString(ExceptionResponse.serializer(), bodyText)
                 Result.failure(exception)
             }
         } catch (e: Exception) {

--- a/app/composeApp/src/commonMain/kotlin/ext/signup/ClientSignUpDeliveryService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/signup/ClientSignUpDeliveryService.kt
@@ -8,7 +8,7 @@ import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.isSuccess
 import io.ktor.utils.io.InternalAPI
-import kotlinx.serialization.json.Json
+import ext.IntraleClientJson
 import ar.com.intrale.shared.ExceptionResponse
 import ar.com.intrale.shared.StatusCodeDTO
 import ar.com.intrale.shared.toExceptionResponse
@@ -28,7 +28,7 @@ class ClientSignUpDeliveryService(private val httpClient: HttpClient) : CommSign
                 )
             } else {
                 val bodyText = response.bodyAsText()
-                val exception = Json.decodeFromString(ExceptionResponse.serializer(), bodyText)
+                val exception = IntraleClientJson.decodeFromString(ExceptionResponse.serializer(), bodyText)
                 Result.failure(exception)
             }
         } catch (e: Exception) {

--- a/app/composeApp/src/commonMain/kotlin/ext/signup/ClientSignUpPlatformAdminService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/signup/ClientSignUpPlatformAdminService.kt
@@ -8,7 +8,7 @@ import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.isSuccess
 import io.ktor.utils.io.InternalAPI
-import kotlinx.serialization.json.Json
+import ext.IntraleClientJson
 import ar.com.intrale.shared.ExceptionResponse
 import ar.com.intrale.shared.StatusCodeDTO
 import ar.com.intrale.shared.toExceptionResponse
@@ -28,7 +28,7 @@ class ClientSignUpPlatformAdminService(private val httpClient: HttpClient) : Com
                 )
             } else {
                 val bodyText = response.bodyAsText()
-                val exception = Json.decodeFromString(ExceptionResponse.serializer(), bodyText)
+                val exception = IntraleClientJson.decodeFromString(ExceptionResponse.serializer(), bodyText)
                 Result.failure(exception)
             }
         } catch (e: Exception) {

--- a/app/composeApp/src/commonMain/kotlin/ext/signup/ClientSignUpService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/signup/ClientSignUpService.kt
@@ -8,7 +8,7 @@ import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.isSuccess
 import io.ktor.utils.io.InternalAPI
-import kotlinx.serialization.json.Json
+import ext.IntraleClientJson
 import ar.com.intrale.shared.ExceptionResponse
 import ar.com.intrale.shared.StatusCodeDTO
 import ar.com.intrale.shared.toExceptionResponse
@@ -30,7 +30,7 @@ class ClientSignUpService(private val httpClient: HttpClient) : CommSignUpServic
                 )
             } else {
                 val bodyText = response.bodyAsText()
-                val exception = Json.decodeFromString(ExceptionResponse.serializer(), bodyText)
+                val exception = IntraleClientJson.decodeFromString(ExceptionResponse.serializer(), bodyText)
                 Result.failure(exception)
             }
         } catch (e: Exception) {

--- a/app/composeApp/src/commonMain/kotlin/ext/storage/KeyValueStorageService.kt
+++ b/app/composeApp/src/commonMain/kotlin/ext/storage/KeyValueStorageService.kt
@@ -4,6 +4,7 @@ import com.russhwolf.settings.Settings
 import ext.storage.model.ClientProfileCache
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import ext.IntraleClientJson
 
 class KeyValueStorageService : CommKeyValueStorage {
     private val settings: Settings by lazy { Settings() }
@@ -20,7 +21,7 @@ class KeyValueStorageService : CommKeyValueStorage {
 
     override var profileCache: ClientProfileCache?
         get() = settings.getStringOrNull(StorageKeys.LOGIN_INFO.key)?.let { raw ->
-            runCatching { Json.decodeFromString(ClientProfileCache.serializer(), raw) }.getOrNull()
+            runCatching { IntraleClientJson.decodeFromString(ClientProfileCache.serializer(), raw) }.getOrNull()
         }
         set(value) {
             if (value == null) {

--- a/app/composeApp/src/commonTest/kotlin/ext/auth/ClientAuthServicesTest.kt
+++ b/app/composeApp/src/commonTest/kotlin/ext/auth/ClientAuthServicesTest.kt
@@ -61,6 +61,35 @@ class ClientLoginServiceTest {
         val ex = result.exceptionOrNull() as ExceptionResponse
         assertEquals(401, ex.statusCode.value)
     }
+
+    /**
+     * Regresion #2158: el backend serializa Response con campos extra (responseHeaders).
+     * Sin ignoreUnknownKeys=true el login fallaba con
+     * "Unexpected JSON token at offset N: Encountered an unknown key 'responseHeaders'"
+     * y bloqueaba todo el flujo del usuario hacia el dashboard.
+     */
+    @Test
+    fun `login exitoso tolera campos desconocidos del backend (responseHeaders)`() = runTest {
+        val body = """{"statusCode":{"value":200,"description":"OK"},"responseHeaders":{"x-trace-id":"abc"},"idToken":"id","accessToken":"access","refreshToken":"refresh","extraField":"valor"}"""
+        val service = ClientLoginService(mockClient(HttpStatusCode.OK, body))
+
+        val result = service.execute("user@test.com", "pass123")
+
+        assertTrue(result.isSuccess, "Login debe tolerar campos desconocidos del backend")
+        assertEquals("access", result.getOrThrow().accessToken)
+    }
+
+    @Test
+    fun `login fallido tolera campos desconocidos en ExceptionResponse (responseHeaders)`() = runTest {
+        val body = """{"statusCode":{"value":401,"description":"Unauthorized"},"responseHeaders":{"x-trace-id":"abc"},"message":"Credenciales invalidas"}"""
+        val service = ClientLoginService(mockClient(HttpStatusCode.Unauthorized, body))
+
+        val result = service.execute("user@test.com", "wrong")
+
+        assertTrue(result.isFailure, "Error 401 con campos desconocidos debe deserializar como ExceptionResponse")
+        val ex = result.exceptionOrNull() as ExceptionResponse
+        assertEquals(401, ex.statusCode.value)
+    }
 }
 
 // endregion

--- a/app/composeApp/src/commonTest/kotlin/ext/business/ClientBusinessServicesTest.kt
+++ b/app/composeApp/src/commonTest/kotlin/ext/business/ClientBusinessServicesTest.kt
@@ -145,6 +145,21 @@ class ClientSearchBusinessesServiceTest {
 
         assertTrue(result.isFailure)
     }
+
+    /**
+     * Regresion #2158: el backend serializa Response con campos extra (responseHeaders).
+     * Sin ignoreUnknownKeys=true la busqueda fallaba y el dashboard quedaba vacio.
+     */
+    @Test
+    fun `busqueda exitosa tolera campos desconocidos del backend (responseHeaders)`() = runTest {
+        val body = """{"statusCode":{"value":200,"description":"OK"},"responseHeaders":{"x-trace-id":"abc"},"businesses":[],"lastKey":null,"extraField":"valor"}"""
+        val service = ClientSearchBusinessesService(mockClient(HttpStatusCode.OK, body))
+
+        val result = service.execute("test")
+
+        assertTrue(result.isSuccess, "La busqueda debe tolerar campos desconocidos del backend")
+        assertEquals(0, result.getOrThrow().businesses.size)
+    }
 }
 
 // endregion


### PR DESCRIPTION
## Summary
- Crea `IntraleClientJson` con `ignoreUnknownKeys=true` e `isLenient=true` como instancia compartida de deserialización.
- Reemplaza `Json.decodeFromString` por `IntraleClientJson.decodeFromString` en los 39 `Client/Delivery/PaymentMethods/PushToken/Storage` services del módulo `app/composeApp`.
- Agrega tests de regresión (`ClientAuthServicesTest`, `ClientBusinessServicesTest`) que reproducen el escenario con `responseHeaders` y campos extra.

## Contexto
El backend serializa `Response` con campos extra (`responseHeaders`) que rompían el login y todos los servicios que deserializaban con `Json` por defecto con el error "Unexpected JSON token at offset N: Encountered an unknown key 'responseHeaders'". Bloqueaba el flujo del usuario hacia el dashboard y CA-3 no era verificable end-to-end.

## Gates pipeline
- builder: aprobado
- tester: aprobado
- qa: aprobado (video qa-2158-raw.mp4, 340 KB)
- security: aprobado
- po / review / ux: aprobado

Closes #2158