### PR TITLE
fix(pipeline): pulpo único dueño del lifecycle del archivo de trabajo

### DIFF
--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -3086,11 +3086,30 @@ function lanzarAgenteClaude(skill, issue, trabajandoPath, pipeline, fase, config
 
     const listoDir = path.join(fasePath(pipeline, fase), 'listo');
     try {
-      const data = readYaml(trabajandoPath);
+      // Single source of truth del lifecycle: el Pulpo es el único que mueve el
+      // archivo de trabajando/ a listo/. Si un agente (contrato viejo o custom)
+      // todavía lo movió él mismo, caemos sobre listo/ para no perder su YAML.
+      // Ese caso dispara la carrera que rechazaba falsamente como
+      // "Evidencia QA incompleta" (el readYaml de trabajando/ devolvía {},
+      // el gate perdía `modo: api/structural` y rebotaba con video faltante).
+      const listoPath = path.join(listoDir, path.basename(trabajandoPath));
+      let workingPath;
+      if (fs.existsSync(trabajandoPath)) {
+        workingPath = trabajandoPath;
+      } else if (fs.existsSync(listoPath)) {
+        workingPath = listoPath;
+        log('lanzamiento', `⚠️ ${skill}:#${issue} movió el archivo a listo/ por su cuenta — leyendo desde allí (contrato viejo, debería solo escribir el YAML)`);
+      } else {
+        log('lanzamiento', `⚠️ ${skill}:#${issue} terminó pero el archivo no está en trabajando/ ni en listo/`);
+        activeProcesses.delete(processKey(skill, issue));
+        return;
+      }
+
+      const data = readYaml(workingPath);
       if (!data.resultado) {
         data.resultado = code === 0 ? 'aprobado' : 'rechazado';
         data.motivo = code !== 0 ? `Agente terminó con código ${code}` : undefined;
-        writeYaml(trabajandoPath, data);
+        writeYaml(workingPath, data);
       }
 
       // --- STOP RECORDING + PULL VIDEO ---
@@ -3137,7 +3156,7 @@ function lanzarAgenteClaude(skill, issue, trabajandoPath, pipeline, fase, config
             data.evidencia = localVideo;
             data.video_size_kb = videoSizeKb;
             // Audio narrado no se genera acá (el agente QA lo hace), pero el video crudo sí
-            writeYaml(trabajandoPath, data);
+            writeYaml(workingPath, data);
           }
         } catch (e) {
           log('lanzamiento', `⚠️ Error bajando recording qa:#${issue}: ${e.message.slice(0, 80)}`);
@@ -3157,12 +3176,16 @@ function lanzarAgenteClaude(skill, issue, trabajandoPath, pipeline, fase, config
           data.resultado = 'rechazado';
           data.motivo = `Evidencia QA incompleta (gate on-exit): ${evidenceIssues.join('; ')}`;
           data.rechazado_por = 'gate-evidencia-on-exit';
-          writeYaml(trabajandoPath, data);
+          writeYaml(workingPath, data);
           sendTelegram(`⛔ QA:#${issue} — evidencia incompleta al terminar. Rechazo automático: ${evidenceIssues.join('; ')}`);
         }
       }
 
-      moveFile(trabajandoPath, listoDir);
+      // Solo movemos si el archivo sigue en trabajando/. Si ya estaba en listo/
+      // (contrato viejo), el move lo completó el agente.
+      if (workingPath === trabajandoPath) {
+        moveFile(trabajandoPath, listoDir);
+      }
       log('lanzamiento', `${skill}:#${issue} terminó (code=${code}, ${elapsedSec.toFixed(0)}s) → listo/`);
 
       // Generar reporte PDF de rechazo y enviar a Telegram (background, no bloquea)

--- a/.pipeline/roles/_base.md
+++ b/.pipeline/roles/_base.md
@@ -25,7 +25,7 @@ Tu archivo de trabajo ya fue movido a `trabajando/` por el Pulpo. El path te lle
 4. **Leer contexto de fases anteriores** — si necesitás saber qué hicieron otros skills, mirá en `procesado/` de la fase anterior
 5. **Verificar pasadas anteriores** — si existen archivos de tu mismo skill en `procesado/` de tu misma fase para el mismo issue, son resultados de una pasada anterior. Leelos para no repetir errores.
 6. **Hacer tu trabajo** — según las instrucciones de tu rol
-6. **Escribir resultado en tu archivo de trabajo**:
+7. **Escribir resultado en tu archivo de trabajo** (que sigue en `trabajando/`):
 
 ```yaml
 issue: 1732
@@ -44,16 +44,14 @@ resultado: rechazado
 motivo: "Descripción clara del problema encontrado"
 ```
 
-7. **Mover tu archivo a `listo/`**:
-```bash
-mv .pipeline/<pipeline>/<fase>/trabajando/<archivo> .pipeline/<pipeline>/<fase>/listo/<archivo>
-```
+8. **Salir con código 0** — el Pulpo detecta tu salida y mueve el archivo de `trabajando/` a `listo/`.
 
 ## Reglas críticas
 
+- **NUNCA** muevas vos el archivo de `trabajando/` a `listo/` — el Pulpo es el único dueño del lifecycle del archivo. Si lo movés, se produce una carrera: el Pulpo on-exit intenta leer `trabajando/` después de que vos ya moviste, encuentra un archivo vacío, pierde tu `resultado` y te rechaza por "evidencia incompleta" aunque hayas aprobado.
 - **NUNCA** modifiques archivos de otros skills o fases
 - **NUNCA** muevas archivos que no son tuyos
-- **SIEMPRE** escribí resultado antes de mover a listo
+- **SIEMPRE** escribí el resultado en `trabajando/` antes de salir
 - Si tu trabajo falla por un error inesperado, escribí `resultado: rechazado` con el motivo
 - El motivo de rechazo debe ser claro y accionable para el developer que lo va a corregir
 


### PR DESCRIPTION
## Problema

Varios backend-dev/android-dev aparecían rechazados con el motivo *"Evidencia QA incompleta (gate on-exit): sin evidencia: no hay .mp4 en qa/evidence/N/ ni qa/recordings/, ni frames PNG suficientes (0/3)"* — incluso cuando el issue era de backend puro, sin UI, y el agente QA había aprobado correctamente con `modo: api`.

Afectados confirmados post-restart del fix del launcher (#2350): #2307, #2159. Históricos: #2040, #2041, #2042, #2043, #2158, #2279, #2296, #2305, #2317, #2318, #2322.

## Causa raíz — carrera entre agente y pulpo

1. El agente ejecuta OK, clasifica `modo: api`, escribe `resultado: aprobado` en `.pipeline/.../trabajando/<issue>.<skill>`.
2. Siguiendo `roles/_base.md:47-50`, el agente hace `mv trabajando/X → listo/X` y sale con código 0.
3. El handler `child.on('exit')` del pulpo (`pulpo.js:3089`) lee `readYaml(trabajandoPath)` — pero el archivo **ya no está ahí**. `readYaml` captura el ENOENT y devuelve `{}`.
4. Con `{}`: se pierde `modo: api`, se pierde el resultado del agente. El gate `validateQaEvidence` no hace early-return para API (porque `modo === ''` no matchea `api|structural`), busca video/frames en el repo principal, no los encuentra (es API sin UI), y **fuerza rechazo**.
5. El pulpo escribe un YAML fantasma de ~208 bytes con `resultado: rechazado` y dispara `rejection-report.js`. Telegram recibe el rechazo fantasma.

## Solución (Opción B — discutida con Leo)

**Single source of truth del lifecycle del archivo = el Pulpo.** El agente solo escribe el YAML con su resultado, nunca mueve el archivo. Esto elimina la carrera por diseño, no por retry/sleep.

### Cambios

- **`roles/_base.md`**: se quita el paso `mv trabajando → listo`. Nuevo paso 8: *salir con código 0; el Pulpo mueve*. Se documenta en *Reglas críticas* por qué el agente no debe mover (incluye explicación de la carrera).

- **`pulpo.js`** (flujo normal de `child.on('exit')`): al inicio del bloque `try`, resuelve `workingPath`:
  - Si `trabajandoPath` existe → usa ese (caso normal con el nuevo contrato).
  - Si no existe pero `listoPath` sí → fallback: lee desde ahí (compat con agentes viejos cacheados que todavía muevan).
  - Si ninguno existe → log + return (antes este caso producía el YAML fantasma).
  
  Todos los `readYaml`/`writeYaml` subsiguientes usan `workingPath`. El `moveFile` final solo se ejecuta cuando `workingPath === trabajandoPath`.

## Smoke test

Ejecutado localmente simulando el escenario exacto del #2307 (agente con contrato viejo que ya movió a `listo/`):

```
workingPath: listo/ (OK fallback)
data.modo: api
data.resultado: aprobado
skip-move: true
gate: early-return OK, NO rechaza
```

`node --check .pipeline/pulpo.js` → SYNTAX_OK.

## Qué NO hace este PR

- No reprocesa los issues ya rechazados falsamente en procesado/. Los que siguen vivos (no cerrados en GitHub) van a requerir relanzarse con `/pausa` + move manual de `listo/` o, mejor, un script aparte (separo en otro PR).

## Labels

`qa:skipped` — cambio puro de infra del pipeline, no impacta feature de usuario. Justificación: modifica comportamiento interno del orquestador y contrato con agentes; validación ya cubierta por smoke test.

Closes #N/A (bug descubierto durante análisis post-#2350 sin issue abierto).

🤖 Generated with [Claude Code](https://claude.com/claude-code)