### PR TITLE
fix(pipeline): PO-gate contextual + routing con prioridad de dominio

### DIFF
--- a/.pipeline/config.yaml
+++ b/.pipeline/config.yaml
@@ -63,12 +63,25 @@ intake:
 
 # Mapeo de labels de GitHub a skill de desarrollo
 dev_skill_mapping:
+  "area:infra": "backend-dev"    # Infra pura del pipeline/Node.js/hooks → backend-dev (no hay skill infra-dev)
   "area:backend": "backend-dev"
   "app:client": "android-dev"
   "app:business": "android-dev"
   "app:delivery": "android-dev"
   "area:web": "web-dev"
   default: "backend-dev"         # Si no tiene label de área (priority:critical se rutea por área)
+
+# Prioridad de ruteo cuando un issue tiene MÚLTIPLES labels de dominio (ej. area:infra + app:client).
+# Orden de mayor a menor prioridad. El primer label presente en el issue define la ruta.
+# Rationale: si alguien tagueó `area:infra`, esa intención manda — issues del pipeline
+# no deben caer en android-dev sólo porque tienen `app:client` por error (ej. #2328).
+dev_routing_priority:
+  - "area:infra"
+  - "area:backend"
+  - "area:web"
+  - "app:client"
+  - "app:business"
+  - "app:delivery"
 
 # Prioridad de intake (orden de procesamiento)
 prioridad_labels:

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -1794,11 +1794,26 @@ function brazoBarrido(config) {
   }
 }
 
-/** Determinar qué skill de dev corresponde a un issue (por labels de GitHub) */
+/** Determinar qué skill de dev corresponde a un issue (por labels de GitHub).
+ *
+ * Cuando el issue tiene múltiples labels de dominio (ej. `area:infra` + `app:client`),
+ * se usa `dev_routing_priority` del config para elegir determinísticamente. Sin esto,
+ * el orden dependía del orden en que GitHub devolvía los labels, y un `app:client`
+ * mal puesto ruteaba issues 100% de infra del pipeline a android-dev (ej. #2328).
+ */
 function determinarDevSkill(issue, config) {
   const mapping = config.dev_skill_mapping || {};
   const labels = getIssueLabels(issue);
+  const priority = config.dev_routing_priority || [];
 
+  // 1) Prioridad explícita de dominio: `area:*` gana sobre `app:*` cuando coexisten.
+  for (const priorityLabel of priority) {
+    if (labels.includes(priorityLabel) && mapping[priorityLabel]) {
+      return mapping[priorityLabel];
+    }
+  }
+
+  // 2) Fallback: primer match directo (orden de labels de GitHub)
   for (const label of labels) {
     if (mapping[label]) return mapping[label];
   }

--- a/.pipeline/roles/po.md
+++ b/.pipeline/roles/po.md
@@ -16,7 +16,44 @@ Sos el Product Owner del proyecto Intrale. Tu trabajo depende de la fase:
 
 ## En pipeline de desarrollo (fase: aprobacion)
 
+### PASO 0.A — Clasificar scope del issue (determina si aplica la exigencia de video)
+
+Antes de exigir evidencia de video, leé los labels del issue y el `.qa` del agente QA
+para decidir si esta historia requiere QA E2E con video o si un QA structural/api es
+suficiente. La regla la fija CLAUDE.md → "Tipos de issue y criterio QA".
+
+**No requiere video (scope sin UI de usuario — aceptar QA aprobado en modo structural/api):**
+
+Cualquiera de estas condiciones es suficiente:
+- El issue tiene label `area:infra` y NO tiene ningún `app:*` (infra pura del pipeline,
+  hooks, CI/CD, scripts Node.js del `.pipeline/`).
+- El issue tiene label `qa:skipped` con justificación escrita del dev (en el issue,
+  en el YAML del dev, o en el propio `.qa`) explicando por qué no corresponde video.
+- El issue es documentación pura (label `docs` y sólo toca `docs/` o `.md`).
+- El issue es un refactor estructural sin UI nueva (ej. cambios en DI, serialización,
+  deserialización, firmas de servicios) claramente justificado como tal y con
+  `resultado: aprobado` + `modo: structural` en el `.qa`.
+
+**Cómo actuar en estos casos:**
+1. Leer el `.qa` y verificar que tenga `resultado: aprobado` y `modo: structural` o `modo: api`.
+2. Saltear PASO 0 (evidencia de video) y PASO 1 (ver video completo).
+3. Ir directo al PASO 2 (revisión de implementación contra criterios de aceptación por lectura de código y PR).
+4. Si todo cierra, aprobar con motivo explícito indicando por qué no se exigió video.
+   Ejemplo: `"Aprobado: issue de infra pura (.pipeline/), QA structural aprobado, sin requisito de video por política de CLAUDE.md"`.
+5. Si encontrás cualquier inconsistencia (QA no aprobado, modo incorrecto, implementación
+   no cumple criterios, label `app:*` presente sin justificación), **rechazá con motivo específico**
+   — no apruebes a ciegas sólo porque es infra.
+
+**Sí requiere video (continúa con PASO 0 / PASO 1 estrictos):**
+
+- Cualquier label `app:client`, `app:business`, `app:delivery`.
+- Cualquier feature/bug con impacto directo en UI o flujo del usuario.
+- Endpoints backend nuevos o modificados que el usuario percibe (`area:backend` sin `qa:skipped`).
+
 ### PASO 0 — Verificación de evidencia (BLOQUEANTE — sin esto, RECHAZAR)
+
+**Este paso sólo aplica si PASO 0.A concluyó que SÍ requiere video.** Si PASO 0.A
+permitió saltearlo, ir directo al PASO 2.
 
 Antes de hacer CUALQUIER otra cosa, verificá que existe evidencia real del QA:
 
@@ -94,12 +131,14 @@ etapa y qué criterios de aceptación se están verificando.
 
 ## Reglas inquebrantables del PO
 
-- **NUNCA** aprobar sin video con audio narrado — sin excepciones
-- **NUNCA** aprobar basándote solo en lectura de código — eso no demuestra que funciona
-- **NUNCA** aprobar si el video no muestra TODOS los criterios de aceptación
-- **SIEMPRE** ejecutar PASO 0 antes de cualquier revisión
-- **SIEMPRE** ver el video completo con Read antes de decidir
+- **SIEMPRE** ejecutar PASO 0.A primero para clasificar scope del issue
+- **NUNCA** aprobar sin video con audio narrado **cuando el scope del issue requiere video** (UI de usuario, flujos visibles, endpoints percibidos)
+- **NUNCA** aprobar basándote solo en lectura de código **en issues con UI/flujo de usuario** — eso no demuestra que funciona
+- **NUNCA** aprobar si el video no muestra TODOS los criterios de aceptación (cuando aplica video)
+- **SÍ aprobar por lectura de código + QA structural/api** cuando el scope es infra pura, docs pura o refactor estructural sin UI (ver PASO 0.A)
+- **SIEMPRE** ver el video completo con Read antes de decidir, cuando el scope requiere video
 - **SIEMPRE** cruzar cada criterio contra lo que se ve y escucha en el video
+- **SIEMPRE** dejar en el motivo de aprobación explicita la razón por la que se saltea video (si aplica), para trazabilidad
 - Los criterios de aceptación deben ser verificables (no ambiguos)
 - Cada historia debe entregar valor independiente al usuario
 - Las historias grandes se dividen (criterio: si necesita más de 1 PR, es grande)


### PR DESCRIPTION
## Resumen

Tres correcciones sistémicas a la raíz común de los rechazos espurios de hoy (#2159, #2317, #2328): el pipeline aplica reglas rígidas que ignoran el contexto real del issue.

### 1) PO-gate contextual (`roles/po.md`)
Nuevo **PASO 0.A** que clasifica el scope antes de exigir video. Issues con:
- `area:infra` sin `app:*`,
- `qa:skipped` con justificación escrita,
- `docs` pura,
- refactor estructural sin UI con `resultado: aprobado` + `modo: structural` en el `.qa`,

son aprobables por el PO sin video. Se reescriben las \"reglas inquebrantables\" condicionándolas al scope.

Arregla rechazos de **#2159** (refactor DI/deserialización JSON) y **#2317** (infra `.pipeline/*.js` pura) que estaban aprobados por QA structural y rechazados por el PO rígido.

### 2) Routing con prioridad de dominio (`config.yaml` + `pulpo.js`)
Nueva config `dev_routing_priority` y lógica en `determinarDevSkill`:

```
area:infra > area:backend > area:web > app:client/business/delivery
```

Cuando coexisten, gana el de mayor prioridad. Además se agrega `area:infra → backend-dev` explícito al mapping.

Arregla el ruteo incorrecto de **#2328** (dashboard /monitor 100% Node.js del pipeline que con `app:client` caía en android-dev).

### 3) Fix puntual del #2328
Label swap en GitHub: `app:client` → `area:infra` (hecho fuera del PR, ya aplicado).

## Smoke test

Ejecuté un smoke test de `determinarDevSkill` con el config nuevo, 11/11 casos verde:

- `[app:client, area:infra]` → `backend-dev` ✅ (caso #2328)
- `[area:backend, app:client]` → `backend-dev` ✅
- `[area:web, app:business]` → `web-dev` ✅
- `[app:client]` solo → `android-dev` ✅
- `[]` → default `backend-dev` ✅

## Test plan

- [x] \`node --check .pipeline/pulpo.js\` sin errores
- [x] Smoke test de routing: 11/11 casos
- [ ] Post-merge: verificar que /reanudar con #2328 rutea a backend-dev (no android-dev)
- [ ] Post-merge: verificar que #2159 y #2317 pasan el PO-gate si se los vuelve a lanzar

## Labels

- \`area:infra\`, \`tipo:infra\`, \`qa:skipped\` (cambio puro de infra del pipeline V2, sin impacto en UI de usuario)

🤖 Generated with [Claude Code](https://claude.com/claude-code)