### PR TITLE
feat(pipeline): safety net — smoke-test, auto-rollback, rol pipeline-dev

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,16 @@
+# CODEOWNERS — Review obligatorio para componentes críticos del pipeline
+#
+# Sintaxis: <pattern> <owner-or-team>
+# Último match gana. Los patrones son glob-style (similar a .gitignore).
+#
+# Rationale:
+#   - .pipeline/ es la infraestructura que orquesta todo el trabajo de agentes
+#     (incluye .pipeline/roles/, contrato de cada agente).
+#     Un cambio roto deja el sistema fuera de servicio. Leo revisa cada PR.
+#   - .github/ y CODEOWNERS mismo: proteger el protocolo de protección.
+
+# Pipeline V2 (orquestador, dashboard, hooks, scripts de restart/rollback, roles/)
+/.pipeline/                 @leitolarreta
+
+# Protocolo de protección (workflows y este archivo)
+/.github/                   @leitolarreta

--- a/.pipeline/config.yaml
+++ b/.pipeline/config.yaml
@@ -63,7 +63,8 @@ intake:
 
 # Mapeo de labels de GitHub a skill de desarrollo
 dev_skill_mapping:
-  "area:infra": "backend-dev"    # Infra pura del pipeline/Node.js/hooks → backend-dev (no hay skill infra-dev)
+  "area:pipeline": "pipeline-dev" # Scripts Node.js del pipeline (.pipeline/*.js, roles, hooks)
+  "area:infra": "backend-dev"    # Infra kotlin/gradle/ci-cd (NO pipeline — eso es area:pipeline)
   "area:backend": "backend-dev"
   "app:client": "android-dev"
   "app:business": "android-dev"
@@ -73,15 +74,34 @@ dev_skill_mapping:
 
 # Prioridad de ruteo cuando un issue tiene MÚLTIPLES labels de dominio (ej. area:infra + app:client).
 # Orden de mayor a menor prioridad. El primer label presente en el issue define la ruta.
-# Rationale: si alguien tagueó `area:infra`, esa intención manda — issues del pipeline
+# Rationale: si alguien tagueó `area:pipeline` o `area:infra`, esa intención manda — issues del pipeline
 # no deben caer en android-dev sólo porque tienen `app:client` por error (ej. #2328).
 dev_routing_priority:
+  - "area:pipeline"
   - "area:infra"
   - "area:backend"
   - "area:web"
   - "app:client"
   - "app:business"
   - "app:delivery"
+
+# Heurística de override por contenido: issues etiquetados `area:infra` pero con
+# referencias fuertes al pipeline Node.js se re-rutean a `pipeline-dev`. Evita que
+# cambios del pulpo/dashboard caigan en backend-dev (stack Kotlin, no valida JS).
+pipeline_scope_keywords:
+  - ".pipeline/"
+  - "pulpo.js"
+  - "dashboard-v2"
+  - "restart.js"
+  - "rollback.sh"
+  - "smoke-test"
+  - "rejection-report"
+  - "listener-telegram"
+  - "servicio-telegram"
+  - "servicio-github"
+  - "servicio-emulador"
+  - "servicio-drive"
+  - ".pipeline/roles/"
 
 # Prioridad de intake (orden de procesamiento)
 prioridad_labels:

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -2029,13 +2029,26 @@ function brazoBarrido(config) {
  * se usa `dev_routing_priority` del config para elegir determinísticamente. Sin esto,
  * el orden dependía del orden en que GitHub devolvía los labels, y un `app:client`
  * mal puesto ruteaba issues 100% de infra del pipeline a android-dev (ej. #2328).
+ *
+ * Además, issues etiquetados `area:infra` cuyo título/body mencione archivos del
+ * pipeline Node.js se re-rutean a `pipeline-dev` (stack correcto). Así evitamos
+ * que cambios del pulpo/dashboard caigan en backend-dev (Kotlin/Gradle) que no
+ * puede validarlos.
  */
 function determinarDevSkill(issue, config) {
   const mapping = config.dev_skill_mapping || {};
   const labels = getIssueLabels(issue);
   const priority = config.dev_routing_priority || [];
 
-  // 1) Prioridad explícita de dominio: `area:*` gana sobre `app:*` cuando coexisten.
+  // 0) Override por contenido: area:infra + keywords del pipeline → pipeline-dev
+  if (labels.includes('area:infra') && !labels.includes('area:pipeline') && mapping['area:pipeline']) {
+    if (issueMentionsPipelineScope(issue, config)) {
+      log('routing', `#${issue}: area:infra + contenido del pipeline → pipeline-dev (override)`);
+      return mapping['area:pipeline'];
+    }
+  }
+
+  // 1) Prioridad explícita de dominio: `area:pipeline`/`area:*` gana sobre `app:*` cuando coexisten.
   for (const priorityLabel of priority) {
     if (labels.includes(priorityLabel) && mapping[priorityLabel]) {
       return mapping[priorityLabel];
@@ -2048,6 +2061,38 @@ function determinarDevSkill(issue, config) {
   }
 
   return mapping.default || 'backend-dev';
+}
+
+// Cache de títulos/bodies para no golpear GitHub por cada ruteo (TTL corto)
+const issueTextCache = new Map(); // issueNum → { text: string, fetchedAt: timestamp }
+const ISSUE_TEXT_CACHE_TTL_MS = 10 * 60 * 1000;
+
+function getIssueText(issueNum) {
+  const cached = issueTextCache.get(issueNum);
+  if (cached && (Date.now() - cached.fetchedAt) < ISSUE_TEXT_CACHE_TTL_MS) {
+    return cached.text;
+  }
+  try {
+    ghThrottle();
+    const raw = execSync(
+      `"${GH_BIN}" issue view ${issueNum} --json title,body`,
+      { cwd: ROOT, encoding: 'utf8', timeout: 10000, windowsHide: true }
+    );
+    const { title = '', body = '' } = JSON.parse(raw);
+    const text = `${title}\n${body}`.toLowerCase();
+    issueTextCache.set(issueNum, { text, fetchedAt: Date.now() });
+    return text;
+  } catch {
+    return '';
+  }
+}
+
+function issueMentionsPipelineScope(issueNum, config) {
+  const keywords = config.pipeline_scope_keywords || [];
+  if (keywords.length === 0) return false;
+  const text = getIssueText(issueNum);
+  if (!text) return false;
+  return keywords.some(kw => text.includes(kw.toLowerCase()));
 }
 
 // =============================================================================

--- a/.pipeline/restart.js
+++ b/.pipeline/restart.js
@@ -182,6 +182,107 @@ function launchAll() {
   sleep(3000);
 }
 
+// --- SMOKE TEST + TAG pipeline-stable + AUTO-ROLLBACK ---
+
+function runSmokeTest() {
+  const script = path.join(PIPELINE, 'smoke-test.sh');
+  if (!fs.existsSync(script)) {
+    log('Smoke test ausente, se omite');
+    return { ok: true, skipped: true };
+  }
+
+  log('=== SMOKE TEST ===');
+  try {
+    const result = spawnSync('bash', [script], {
+      cwd: ROOT,
+      timeout: 30000,
+      encoding: 'utf8',
+      windowsHide: true,
+    });
+    const output = `${result.stdout || ''}${result.stderr || ''}`.trim();
+    const exitCode = result.status === null ? -1 : result.status;
+    if (exitCode === 0) {
+      log('Smoke test OK');
+      return { ok: true, exitCode, output };
+    }
+    log(`Smoke test FAIL (exit ${exitCode})`);
+    if (output) log(output.split('\n').slice(-5).join('\n'));
+    return { ok: false, exitCode, output };
+  } catch (e) {
+    log(`Smoke test error: ${e.message}`);
+    return { ok: false, exitCode: -1, output: e.message };
+  }
+}
+
+function moveStableTag() {
+  try {
+    execSync('git tag -f pipeline-stable HEAD', { cwd: ROOT, timeout: 5000, windowsHide: true });
+    try {
+      execSync('git push origin --force pipeline-stable', { cwd: ROOT, timeout: 30000, windowsHide: true, stdio: 'ignore' });
+      log('Tag pipeline-stable movido y pusheado');
+    } catch (e) {
+      log(`Tag movido local, push falló: ${e.message.slice(0, 100)}`);
+    }
+  } catch (e) {
+    log(`No se pudo mover tag pipeline-stable: ${e.message.slice(0, 100)}`);
+  }
+}
+
+function stablePointsToHead() {
+  try {
+    const head = execSync('git rev-parse HEAD', { cwd: ROOT, encoding: 'utf8', timeout: 5000 }).trim();
+    const stable = execSync('git rev-parse pipeline-stable', { cwd: ROOT, encoding: 'utf8', timeout: 5000 }).trim();
+    return head === stable;
+  } catch {
+    return false;
+  }
+}
+
+function hasStableTag() {
+  try {
+    execSync('git rev-parse --verify pipeline-stable', { cwd: ROOT, timeout: 5000, stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function enqueueTelegramAlert(text) {
+  const msg = text.length > 4000 ? text.slice(0, 4000) + '...' : text;
+  const svcDir = path.join(PIPELINE, 'servicios', 'telegram', 'pendiente');
+  try {
+    if (!fs.existsSync(svcDir)) fs.mkdirSync(svcDir, { recursive: true });
+    const filename = `${Date.now()}-restart-alert.json`;
+    fs.writeFileSync(path.join(svcDir, filename), JSON.stringify({ text: msg, parse_mode: 'Markdown' }));
+    log(`Alerta Telegram encolada (${msg.length} chars)`);
+  } catch (e) {
+    log(`No se pudo encolar alerta Telegram: ${e.message}`);
+  }
+}
+
+function runRollback() {
+  log('=== AUTO-ROLLBACK ===');
+  const script = path.join(PIPELINE, 'rollback.sh');
+  if (!fs.existsSync(script)) {
+    log('rollback.sh ausente — abortando rollback');
+    return false;
+  }
+  try {
+    const result = spawnSync('bash', [script, 'pipeline-stable'], {
+      cwd: ROOT,
+      timeout: 180000,
+      encoding: 'utf8',
+      windowsHide: true,
+    });
+    const output = `${result.stdout || ''}${result.stderr || ''}`.trim();
+    if (output) log(output.split('\n').slice(-8).join('\n'));
+    return result.status === 0;
+  } catch (e) {
+    log(`Rollback error: ${e.message}`);
+    return false;
+  }
+}
+
 // --- STATUS ---
 
 function status() {
@@ -212,6 +313,8 @@ function status() {
 
 const action = process.argv[2] || 'restart';
 const flagPaused = process.argv.includes('--paused');
+const flagNoSmokeTest = process.argv.includes('--no-smoke-test');
+const flagNoRollback = process.argv.includes('--no-rollback');
 
 switch (action) {
   case 'stop':
@@ -233,4 +336,29 @@ switch (action) {
     launchAll();
     const ok = status();
     log(ok ? '=== Pipeline V2 operativo ===' : '=== Revisar componentes ===');
+
+    // Smoke test + tag pipeline-stable + auto-rollback
+    // Se omite si --no-smoke-test (caso típico: rollback.sh relanza restart.js).
+    // Se omite si --paused (no todos los componentes están arriba en modo pausado).
+    if (!flagNoSmokeTest && !flagPaused) {
+      sleep(3000);
+      const smoke = runSmokeTest();
+      if (smoke.ok) {
+        if (!stablePointsToHead()) moveStableTag();
+      } else if (flagNoRollback) {
+        log('Smoke test falló pero --no-rollback activo (diagnóstico)');
+        enqueueTelegramAlert(`⚠️ *Pipeline restart: smoke test FAIL*\nExit ${smoke.exitCode}\n\nModo diagnóstico (--no-rollback), sin rollback automático.`);
+      } else if (!hasStableTag()) {
+        log('Smoke test falló pero no existe tag pipeline-stable — primer deploy, sin rollback');
+        enqueueTelegramAlert(`⚠️ *Pipeline restart: smoke test FAIL*\nExit ${smoke.exitCode}\n\nNo existe tag \`pipeline-stable\` (primer deploy). Revisar manualmente.`);
+      } else {
+        enqueueTelegramAlert(`🚨 *Pipeline restart FALLÓ — ejecutando rollback automático*\nSmoke test exit ${smoke.exitCode}.\nVolviendo a \`pipeline-stable\`.`);
+        const rollbackOk = runRollback();
+        if (rollbackOk) {
+          enqueueTelegramAlert(`✅ *Rollback completado.*\nPipeline restaurado a \`pipeline-stable\`.`);
+        } else {
+          enqueueTelegramAlert(`❌ *Rollback FALLÓ.* Intervención manual requerida.\n\`\`\`\nbash .pipeline/rollback.sh\n\`\`\``);
+        }
+      }
+    }
 }

--- a/.pipeline/roles/pipeline-dev.md
+++ b/.pipeline/roles/pipeline-dev.md
@@ -1,0 +1,102 @@
+# Rol: Pipeline Developer
+
+Sos el developer dedicado al pipeline V2 de Intrale. Tu dominio es todo el código Node.js que orquesta el sistema (`.pipeline/*.js`, hooks, dashboard, roles).
+
+## Cuándo recibís un issue
+
+Te llegan issues que tocan infraestructura del propio pipeline:
+
+- Bugs o features del pulpo, dashboard V2, rejection-report, hooks, intake/outtake, routing.
+- Cambios en `.pipeline/roles/*.md` (contratos de gates).
+- Scripts de operación: `restart.js`, `rollback.sh`, `smoke-test.sh`, `reset.js`.
+- Evolución de `config.yaml` del pipeline.
+- Nuevos servicios del pipeline (telegram, github, drive, emulador).
+
+Te ruteo el pulpo cuando:
+- El label del issue incluye `area:pipeline`, o
+- El label incluye `area:infra` **y** el análisis técnico o los archivos afectados tocan `.pipeline/*`.
+
+## En pipeline de desarrollo (fase: dev)
+
+### Tu trabajo
+1. Leé el issue completo (criterios de aceptación, análisis técnico).
+2. Si es rebote (`rebote: true`), leé el `motivo_rechazo` y corregí el punto específico.
+3. Creá rama `agent/<issue>-<slug>` si no existe.
+4. Implementá sólo en `.pipeline/` (y docs/ si corresponde).
+5. Escribí tests con `node --test` para la lógica nueva cuando sea viable.
+6. Verificá que nada rompe en caliente — **nunca** dejes el pipeline fuera de servicio.
+7. Commiteá y pusheá.
+
+### Stack
+- **Node.js puro** (sin Gradle, sin Kotlin).
+- **Testing**: `node --test` para unit tests de scripts.
+- **Dependencias**: usar las ya instaladas en `node_modules/` del proyecto. No agregar paquetes nuevos sin justificación.
+- **Shell**: bash puro para scripts de operación (`rollback.sh`, `smoke-test.sh`).
+
+### Reglas inquebrantables
+
+#### 1. El pipeline no puede morir
+Tu código corre en producción continua. Antes de commitear, preguntate: *si este cambio tiene un bug, ¿deja el pipeline fuera de servicio?*
+
+- No introduzcas loops infinitos, writes recursivos sobre archivos que dispare un watcher, o syscalls bloqueantes sin timeout.
+- No asumas que un archivo existe — `try/catch` o `fs.existsSync` defensivo.
+- No cambies formatos de archivo de estado (`agent-registry.json`, `sessions/*.json`) sin migración explícita.
+
+#### 2. Filesystem es la fuente de verdad
+El estado del pipeline vive en el filesystem. **Nunca** pongas estado crítico en memoria de proceso que no se persista inmediatamente.
+
+- Locks: archivo + PID. Liberación idempotente en `try/finally`.
+- Colas: directorios `pendiente/` → `trabajando/` → `listo/`. Mover atómicamente con `rename`.
+- Sesiones: escribir el JSON después de cada cambio, no al final.
+
+#### 3. Contrato de roles es sagrado
+Los YAML que emiten los agentes (`.pipeline/desarrollo/*/listo/*.yaml`) son el contrato entre pulpo y agentes. Un cambio de schema acá rompe TODOS los agentes.
+
+- Si tocás el schema: bumpea versión + compat layer por 1 release.
+- Si agregás un campo: opcional primero, obligatorio después de que todos los roles lo emitan.
+
+#### 4. CODEOWNERS obliga review humana
+Tus PRs SIEMPRE pasan por review de `@leitolarreta` (CODEOWNERS cubre `.pipeline/`). No hay merge automático en este dominio.
+
+#### 5. Tag `pipeline-stable` es el safety net
+Cada `/restart` con smoke test en verde mueve el tag `pipeline-stable`. Es el último commit conocido como operativo.
+
+- Si tu cambio pasa el smoke test → el tag avanza automáticamente.
+- Si falla → `restart.js` dispara `rollback.sh` automático + alerta Telegram.
+- **No dependas** del rollback para "probar en caliente" — rompe la confianza del mecanismo.
+
+### Protocolo de QA para cambios de pipeline
+
+El QA E2E del producto (video + emulador) **no aplica** a cambios que solo tocan `.pipeline/`. En su lugar:
+
+1. **Tests unitarios**: `node --test .pipeline/tests/*.js` para la lógica nueva.
+2. **Smoke test dry-run**: `bash .pipeline/smoke-test.sh` contra un pipeline corriendo.
+3. **Label `qa:skipped`** con justificación: *"Cambio de pipeline infra, validado por smoke test post-restart. Sin UI ni endpoint de producto afectado."*
+4. El PO aprueba por lectura de código + justificación (PO-gate contextual lo permite para `area:pipeline`/`area:infra` sin `app:*`).
+
+### Testing
+
+- Framework: `node --test` (built-in, sin dependencias externas).
+- Ubicación: `.pipeline/tests/*.test.js`.
+- Nombres: descriptivo en español, patrón `test('<qué hace>', ...)`.
+- Fakes: prefijo `fake[Interfaz]` (ej: `fakeGithubClient`).
+
+### Si el issue es `priority:critical` (hotfix del pipeline)
+
+- Branch **desde `origin/main`**, nunca desde rama de feature en curso.
+- Cambio mínimo: sólo lo necesario para desbloquear producción.
+- Test obligatorio: al menos un test que reproduzca el bug si es lógica testeable, o smoke test extendido si es infra.
+- Coordinar `/restart` con Leo explícitamente antes de mergear — un hotfix mal integrado puede agravar la caída.
+
+### Resultado
+- `resultado: aprobado` cuando el código está commiteado, pusheado, y el smoke test local pasa.
+- Incluir en el YAML: `branch`, `commit`, `tests_pasados` (cantidad), `smoke_test_ejecutado` (true/false).
+- Si el cambio no es testeable con `node --test`, justificar por qué en `motivo`.
+
+## En otras fases
+
+Si el pulpo te rutea un issue que **NO** es del dominio pipeline (por error de labels o análisis):
+
+- Rechazá con `resultado: rechazado` y `motivo: routing incorrecto, issue no toca .pipeline/*`.
+- Sugerí el rol correcto en el motivo: `backend-dev` (Kotlin), `android-dev` (Compose), `web-dev` (Wasm).
+- No intentes arreglarlo: vos sos Node.js, no Kotlin.

--- a/.pipeline/rollback.sh
+++ b/.pipeline/rollback.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# rollback.sh — Rollback de emergencia del pipeline V2
+#
+# Diseño: bash puro, ejecutable aunque el pipeline esté muerto o corrupto.
+# Requisitos mínimos: bash, git, node.
+# NO depende de ningún script .js del pipeline.
+#
+# Flujo:
+#   1. Mata todo proceso del pipeline (wmic/ps)
+#   2. git fetch origin pipeline-stable
+#   3. git reset --hard pipeline-stable (solo .pipeline/* y roles/*)
+#   4. Relanza el pipeline con node restart.js
+#
+# Uso:
+#   bash .pipeline/rollback.sh             → rollback a pipeline-stable
+#   bash .pipeline/rollback.sh <sha|tag>   → rollback a commit específico
+
+set -u
+
+PIPELINE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "${PIPELINE_DIR}/.." && pwd)"
+TARGET="${1:-pipeline-stable}"
+LOG_FILE="${PIPELINE_DIR}/logs/rollback.log"
+mkdir -p "$(dirname "$LOG_FILE")"
+
+log() {
+  local msg="$1"
+  local ts
+  ts="$(date '+%Y-%m-%d %H:%M:%S')"
+  echo "[$ts] $msg" | tee -a "$LOG_FILE"
+}
+
+fail() {
+  log "FAIL: $1"
+  exit "${2:-1}"
+}
+
+log "=== ROLLBACK a ${TARGET} ==="
+
+# --- 1) Matar pipeline ---
+log "1) Matando procesos del pipeline..."
+if command -v wmic &>/dev/null; then
+  wmic process where "name='node.exe'" get ProcessId,CommandLine /format:csv 2>/dev/null \
+    | grep '\.pipeline' \
+    | grep -oE '[0-9]+$' \
+    | while read -r pid; do
+        [ -n "$pid" ] && taskkill //PID "$pid" //F //T 2>/dev/null && log "  Killed PID $pid"
+      done || true
+else
+  pgrep -f '\.pipeline' 2>/dev/null | while read -r pid; do
+    [ -n "$pid" ] && kill -9 "$pid" 2>/dev/null && log "  Killed PID $pid"
+  done || true
+fi
+
+# Limpiar PIDs
+for pid_file in "${PIPELINE_DIR}"/*.pid; do
+  [ -f "$pid_file" ] && rm -f "$pid_file"
+done
+
+sleep 2
+
+# --- 2) Verificar target existe ---
+log "2) Verificando target ${TARGET}..."
+cd "$ROOT" || fail "No se pudo entrar a $ROOT" 2
+
+if ! git rev-parse --verify "$TARGET" &>/dev/null; then
+  log "  Target local no existe, haciendo fetch..."
+  git fetch origin "refs/tags/${TARGET}:refs/tags/${TARGET}" 2>/dev/null \
+    || git fetch origin "${TARGET}" 2>/dev/null \
+    || fail "No se pudo fetch ${TARGET}" 2
+fi
+
+TARGET_SHA="$(git rev-parse "${TARGET}")"
+log "  Target SHA: ${TARGET_SHA}"
+
+# --- 3) Reset quirúrgico: solo .pipeline/ (incluye .pipeline/roles/) ---
+log "3) Revirtiendo .pipeline/ al target..."
+git checkout "${TARGET}" -- .pipeline/ 2>/dev/null \
+  || fail "git checkout falló" 3
+
+# --- 4) Relanzar ---
+log "4) Relanzando pipeline..."
+cd "$ROOT" || fail "No se pudo entrar a $ROOT" 4
+node "${PIPELINE_DIR}/restart.js" --no-smoke-test 2>&1 | tee -a "$LOG_FILE"
+restart_rc=${PIPESTATUS[0]}
+
+if [ "$restart_rc" -ne 0 ]; then
+  fail "restart.js retornó ${restart_rc}" 4
+fi
+
+log "=== ROLLBACK COMPLETADO ==="
+log "Pipeline restaurado a ${TARGET} (${TARGET_SHA:0:8})"
+exit 0

--- a/.pipeline/smoke-test.sh
+++ b/.pipeline/smoke-test.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# smoke-test.sh — Verificación post-restart del pipeline V2
+#
+# Diseñado para correr SIN depender del pipeline vivo. Solo requiere:
+#   - bash, node, curl, taskkill/ps (según OS)
+#   - Acceso al filesystem del proyecto
+#
+# Chequeos:
+#   1. Procesos críticos corren (pulpo, dashboard, servicio-telegram)
+#   2. Dashboard responde en :3200
+#   3. No hay lock files huérfanos bloqueando el pipeline
+#   4. El archivo de último restart es reciente (< 120s)
+#
+# Exit codes:
+#   0 → pipeline sano
+#   1 → fallo crítico (componente caído)
+#   2 → fallo de conectividad (dashboard no responde)
+#   3 → fallo de estado (archivos corruptos o stale)
+
+set -u
+
+PIPELINE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOG_FILE="${PIPELINE_DIR}/logs/smoke-test.log"
+mkdir -p "$(dirname "$LOG_FILE")"
+
+log() {
+  local msg="$1"
+  local ts
+  ts="$(date '+%Y-%m-%d %H:%M:%S')"
+  echo "[$ts] $msg" | tee -a "$LOG_FILE"
+}
+
+fail() {
+  log "FAIL: $1"
+  exit "${2:-1}"
+}
+
+# --- 1) Procesos críticos ---
+log "=== SMOKE TEST ==="
+log "1) Verificando procesos críticos..."
+
+CRITICAL=("pulpo.pid" "dashboard.pid" "svc-telegram.pid")
+for pid_file in "${CRITICAL[@]}"; do
+  if [ ! -f "${PIPELINE_DIR}/${pid_file}" ]; then
+    fail "PID file ausente: ${pid_file}" 1
+  fi
+  pid=$(cat "${PIPELINE_DIR}/${pid_file}" 2>/dev/null | tr -d '[:space:]')
+  if [ -z "$pid" ]; then
+    fail "PID file vacío: ${pid_file}" 1
+  fi
+  # Windows/Unix portable process check
+  if command -v tasklist &>/dev/null; then
+    if ! tasklist //FI "PID eq ${pid}" //NH 2>/dev/null | grep -q "^node"; then
+      fail "Proceso no corre: ${pid_file} (PID ${pid})" 1
+    fi
+  else
+    if ! ps -p "$pid" &>/dev/null; then
+      fail "Proceso no corre: ${pid_file} (PID ${pid})" 1
+    fi
+  fi
+  log "  OK ${pid_file} (PID ${pid})"
+done
+
+# --- 2) Dashboard responde ---
+log "2) Verificando dashboard HTTP..."
+if command -v curl &>/dev/null; then
+  # Dashboard en :3200 — endpoint /api/state es cheap
+  http_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 "http://127.0.0.1:3200/api/state" 2>/dev/null || echo "000")
+  if [ "$http_code" != "200" ]; then
+    fail "Dashboard no responde en :3200 (HTTP ${http_code})" 2
+  fi
+  log "  OK dashboard HTTP 200"
+else
+  log "  SKIP curl no disponible"
+fi
+
+# --- 3) Estado del filesystem ---
+log "3) Verificando estado del filesystem..."
+
+# last-restart.json debe existir y ser reciente (< 5 min)
+LAST_RESTART="${PIPELINE_DIR}/last-restart.json"
+if [ ! -f "$LAST_RESTART" ]; then
+  fail "last-restart.json ausente" 3
+fi
+
+# Portable file mtime (GNU stat / BSD stat / fallback)
+if stat --version &>/dev/null 2>&1; then
+  mtime=$(stat -c %Y "$LAST_RESTART" 2>/dev/null)
+else
+  mtime=$(stat -f %m "$LAST_RESTART" 2>/dev/null)
+fi
+now=$(date +%s)
+age=$((now - mtime))
+if [ "$age" -gt 300 ]; then
+  log "  WARN last-restart.json tiene ${age}s (esperado < 300)"
+else
+  log "  OK last-restart.json (${age}s)"
+fi
+
+# Archivos de commander/trabajando huérfanos (>10 min)
+ORPHAN_DIR="${PIPELINE_DIR}/servicios/commander/trabajando"
+if [ -d "$ORPHAN_DIR" ]; then
+  orphan_count=$(find "$ORPHAN_DIR" -name "*.json" -type f 2>/dev/null | wc -l | tr -d '[:space:]')
+  if [ "${orphan_count:-0}" -gt 0 ]; then
+    log "  WARN ${orphan_count} mensajes en commander/trabajando/ (esperado 0 post-restart)"
+  fi
+fi
+
+log "=== SMOKE TEST OK ==="
+exit 0

--- a/docs/pipeline-safety.md
+++ b/docs/pipeline-safety.md
@@ -1,0 +1,77 @@
+# Protocolo de seguridad del pipeline V2
+
+Este documento describe los 5 mecanismos que protegen al pipeline de quedar fuera de servicio por un cambio defectuoso. Están pensados para sostener la evolución del pipeline por agentes (futuro rol `pipeline-dev`) sin que un error pueda dejar el sistema caído.
+
+## 1. Tag automático `pipeline-stable`
+
+Cada vez que un `/restart` termina con el smoke test en verde, el tag `pipeline-stable` se mueve al HEAD actual (local y push a `origin`). Es la última versión verificada como operativa.
+
+- Se mueve únicamente cuando el smoke test pasa (exit 0).
+- Queda disponible como target de rollback desde cualquier rama.
+- No requiere intervención manual.
+
+## 2. Smoke test post-restart (`.pipeline/smoke-test.sh`)
+
+Bash puro. No depende de Node ni del pipeline vivo — solo de `bash`, `git`, `curl` y acceso al filesystem. Se corre automáticamente al final de `restart.js`.
+
+Chequeos:
+1. Procesos críticos (`pulpo`, `dashboard`, `svc-telegram`) tienen PID file y proceso vivo.
+2. Dashboard responde HTTP 200 en `:3200/api/state`.
+3. `last-restart.json` existe y es reciente (< 5 min).
+4. Warnings sobre mensajes huérfanos en `commander/trabajando/`.
+
+Exit codes:
+- `0` — pipeline sano → mueve tag `pipeline-stable`
+- `1` — fallo crítico (componente caído) → auto-rollback
+- `2` — fallo de conectividad (dashboard no responde) → auto-rollback
+- `3` — fallo de estado (archivos corruptos o stale) → auto-rollback
+
+## 3. Rollback de emergencia (`.pipeline/rollback.sh`)
+
+Bash puro, ejecutable aunque el pipeline esté muerto o corrupto.
+
+Flujo:
+1. Mata todo proceso del pipeline.
+2. `git fetch` del target (default `pipeline-stable`).
+3. `git checkout <target> -- .pipeline/` (reset quirúrgico, no afecta otros archivos — incluye `.pipeline/roles/`).
+4. Relanza el pipeline con `node restart.js --no-smoke-test`.
+
+Uso manual:
+```bash
+bash .pipeline/rollback.sh                  # → pipeline-stable
+bash .pipeline/rollback.sh <sha|tag>        # → commit específico
+```
+
+Requisitos mínimos: `bash`, `git`, `node`. No depende de ningún `.js` del pipeline.
+
+## 4. Auto-rollback en `restart.js`
+
+Si el smoke test falla después del `/restart`, `restart.js` ejecuta `rollback.sh pipeline-stable` automáticamente y envía una notificación por Telegram describiendo la causa. Las banderas relevantes:
+
+- `--no-smoke-test` → deshabilita el smoke test (para el propio rollback y casos especiales).
+- `--no-rollback` → corre smoke test pero no dispara rollback (diagnóstico).
+
+La condición para auto-rollback es: smoke test exit ≠ 0 **y** existe el tag `pipeline-stable` (si no existe, es el primer deploy y no hay a dónde volver).
+
+## 5. CODEOWNERS: review obligatorio de cambios críticos
+
+`.github/CODEOWNERS` obliga a que cada PR que toque `.pipeline/` (incluido `.pipeline/roles/`) o `.github/` tenga review explícito de `@leitolarreta` antes de mergear. Esto es la última línea: aunque los agentes se automaticen, un humano revisa cualquier cambio que pueda romper la orquestación.
+
+> Requiere que branch protection esté activado en GitHub con "Require review from Code Owners" marcado. Si no lo está, CODEOWNERS aún sirve como asignación automática de reviewers.
+
+## Flujo de evolución esperado
+
+1. `pipeline-dev` (o cualquier agente/humano) abre un PR tocando `.pipeline/` (incluye `.pipeline/roles/`).
+2. CODEOWNERS asigna review a `@leitolarreta`.
+3. Leo aprueba y mergea.
+4. Alguien dispara `/restart` (manual o desde Telegram).
+5. `restart.js` sincroniza con `main`, relanza procesos, corre smoke test.
+6. Si OK → tag `pipeline-stable` avanza al nuevo HEAD.
+7. Si FAIL → auto-rollback al `pipeline-stable` anterior + alerta Telegram.
+
+En el peor caso (todo se rompió y el pipeline no responde):
+
+```bash
+# Desde cualquier terminal, sin pipeline vivo:
+bash C:/Workspaces/Intrale/platform/.pipeline/rollback.sh
+```


### PR DESCRIPTION
## Contexto

Tras los incidentes de esta mañana (#2159, #2317, #2328 mal ruteados y rechazos en cascada), surgió el pedido de crear un rol dedicado `pipeline-dev` (Node.js) para que los propios agentes puedan evolucionar el pipeline. La inquietud principal de Leo: **un cambio defectuoso no puede dejar el pipeline fuera de servicio**. Este PR implementa los 5 mecanismos de protección acordados.

## Resumen

1. **Smoke test post-restart** (`.pipeline/smoke-test.sh`, bash puro): valida procesos, dashboard HTTP `:3200` y estado de filesystem.
2. **Tag automático `pipeline-stable`**: `restart.js` lo mueve al HEAD cuando el smoke test pasa, y lo pushea a `origin`. Es el último commit conocido como operativo.
3. **Auto-rollback**: si el smoke test falla, `restart.js` ejecuta `rollback.sh pipeline-stable` automáticamente + envía alerta por Telegram.
4. **Rollback de emergencia** (`.pipeline/rollback.sh`, bash puro): ejecutable aunque el pipeline esté muerto o corrupto. Solo requiere `bash`, `git` y `node` — no depende de ningún `.js` del pipeline.
5. **CODEOWNERS**: cada PR que toque `.pipeline/` o `.github/` requiere review explícita de `@leitolarreta`.

Además, se crea el **rol `pipeline-dev`** y se integra al routing:
- `.pipeline/roles/pipeline-dev.md`: contrato completo (dominio, stack Node.js, gates con `node --test`, QA exento con `qa:skipped`, reglas inquebrantables).
- `config.yaml`: nuevo label `area:pipeline` mapeado a `pipeline-dev`, agregado al tope de `dev_routing_priority`.
- `pulpo.js`: heurística de override — si un issue tiene `area:infra` y su título/body menciona `.pipeline/`, `pulpo.js`, `dashboard-v2`, etc. → re-rutea a `pipeline-dev` (evita que cambios del pulpo caigan en `backend-dev`, que no valida JS).

Documentación completa en `docs/pipeline-safety.md`.

## Flags nuevos en restart.js

- `--no-smoke-test`: omite el smoke test (usado por el propio `rollback.sh` al relanzar, para evitar recursión).
- `--no-rollback`: corre smoke test pero no dispara rollback automático (modo diagnóstico).

## Flujo esperado

```
/restart → kill + sync main + launch → status → smoke test
  OK   → git tag -f pipeline-stable HEAD + push
  FAIL → rollback.sh pipeline-stable + alerta Telegram
```

Si todo se rompe y el pipeline no responde, desde cualquier terminal:
```bash
bash C:/Workspaces/Intrale/platform/.pipeline/rollback.sh
```

## Test plan

- [x] `node --check` pasa en `restart.js` y `pulpo.js`.
- [x] `bash -n` pasa en `smoke-test.sh` y `rollback.sh`.
- [ ] Post-merge: ejecutar `/restart` y verificar que el smoke test corre, pasa, y el tag `pipeline-stable` apunta al commit de merge.
- [ ] Post-merge: verificar manualmente que `area:pipeline` rutea a `pipeline-dev` (se puede forzar con un issue de prueba).
- [ ] Post-merge: verificar que issue con `area:infra` + menciones de `.pipeline/` se re-rutea a `pipeline-dev`.

qa:skipped — este PR solo toca `.pipeline/`, scripts bash de operación y CODEOWNERS. No impacta producto de usuario. El smoke test post-restart es la validación.

Closes #2328 (al establecer el rol correcto y la heurística de routing, el issue del dashboard queda correctamente ruteado).

🤖 Generated with [Claude Code](https://claude.com/claude-code)