### PR TITLE
fix(pipeline): smoke-test retry + rollback self-kill + parent PID passthrough

### DIFF
--- a/.pipeline/restart.js
+++ b/.pipeline/restart.js
@@ -268,11 +268,15 @@ function runRollback() {
     return false;
   }
   try {
+    // PARENT_RESTART_PID: rollback.sh usa taskkill //T (tree-kill) sobre
+    // todo node.exe del pipeline; sin este hint se mata a sí mismo al
+    // matar a nuestro proceso node.
     const result = spawnSync('bash', [script, 'pipeline-stable'], {
       cwd: ROOT,
       timeout: 180000,
       encoding: 'utf8',
       windowsHide: true,
+      env: { ...process.env, PARENT_RESTART_PID: String(process.pid) },
     });
     const output = `${result.stdout || ''}${result.stderr || ''}`.trim();
     if (output) log(output.split('\n').slice(-8).join('\n'));

--- a/.pipeline/rollback.sh
+++ b/.pipeline/rollback.sh
@@ -38,17 +38,31 @@ fail() {
 log "=== ROLLBACK a ${TARGET} ==="
 
 # --- 1) Matar pipeline ---
-log "1) Matando procesos del pipeline..."
+# taskkill //T es tree-kill: si matamos al restart.js padre se lleva
+# puesto a este bash y el rollback muere mid-ejecución. El parent nos
+# pasa su PID en PARENT_RESTART_PID para excluirlo del kill loop.
+PARENT_RESTART_PID="${PARENT_RESTART_PID:-0}"
+MY_PID=$$
+log "1) Matando procesos del pipeline (skip parent=${PARENT_RESTART_PID}, self=${MY_PID})..."
+
 if command -v wmic &>/dev/null; then
   wmic process where "name='node.exe'" get ProcessId,CommandLine /format:csv 2>/dev/null \
     | grep '\.pipeline' \
     | grep -oE '[0-9]+$' \
     | while read -r pid; do
-        [ -n "$pid" ] && taskkill //PID "$pid" //F //T 2>/dev/null && log "  Killed PID $pid"
+        if [ -z "$pid" ]; then continue; fi
+        if [ "$pid" = "$PARENT_RESTART_PID" ]; then
+          log "  Skip PID $pid (parent restart.js)"
+          continue
+        fi
+        if [ "$pid" = "$MY_PID" ]; then continue; fi
+        taskkill //PID "$pid" //F //T 2>/dev/null && log "  Killed PID $pid"
       done || true
 else
   pgrep -f '\.pipeline' 2>/dev/null | while read -r pid; do
-    [ -n "$pid" ] && kill -9 "$pid" 2>/dev/null && log "  Killed PID $pid"
+    if [ -z "$pid" ]; then continue; fi
+    if [ "$pid" = "$PARENT_RESTART_PID" ] || [ "$pid" = "$MY_PID" ]; then continue; fi
+    kill -9 "$pid" 2>/dev/null && log "  Killed PID $pid"
   done || true
 fi
 

--- a/.pipeline/smoke-test.sh
+++ b/.pipeline/smoke-test.sh
@@ -36,29 +36,49 @@ fail() {
 }
 
 # --- 1) Procesos críticos ---
+# Retry hasta 30s: singleton.js escribe el .pid DESPUÉS de un wmic scan que
+# se pisa con otros wmic de arranque concurrente y puede tardar varios
+# segundos. Con 6+ servicios arrancando en paralelo justo después de un
+# killAll, el one-shot a los 6s post-launch se volvía carrera.
 log "=== SMOKE TEST ==="
 log "1) Verificando procesos críticos..."
 
 CRITICAL=("pulpo.pid" "dashboard.pid" "svc-telegram.pid")
-for pid_file in "${CRITICAL[@]}"; do
-  if [ ! -f "${PIPELINE_DIR}/${pid_file}" ]; then
-    fail "PID file ausente: ${pid_file}" 1
-  fi
-  pid=$(cat "${PIPELINE_DIR}/${pid_file}" 2>/dev/null | tr -d '[:space:]')
-  if [ -z "$pid" ]; then
-    fail "PID file vacío: ${pid_file}" 1
-  fi
-  # Windows/Unix portable process check
+MAX_WAIT_SECONDS=30
+
+check_pid_alive() {
+  local pid="$1"
   if command -v tasklist &>/dev/null; then
-    if ! tasklist //FI "PID eq ${pid}" //NH 2>/dev/null | grep -q "^node"; then
-      fail "Proceso no corre: ${pid_file} (PID ${pid})" 1
-    fi
+    tasklist //FI "PID eq ${pid}" //NH 2>/dev/null | grep -q "^node"
   else
-    if ! ps -p "$pid" &>/dev/null; then
-      fail "Proceso no corre: ${pid_file} (PID ${pid})" 1
-    fi
+    ps -p "$pid" &>/dev/null
   fi
-  log "  OK ${pid_file} (PID ${pid})"
+}
+
+for pid_file in "${CRITICAL[@]}"; do
+  waited=0
+  last_err=""
+  while [ "$waited" -lt "$MAX_WAIT_SECONDS" ]; do
+    if [ ! -f "${PIPELINE_DIR}/${pid_file}" ]; then
+      last_err="PID file ausente"
+    else
+      pid=$(cat "${PIPELINE_DIR}/${pid_file}" 2>/dev/null | tr -d '[:space:]')
+      if [ -z "$pid" ]; then
+        last_err="PID file vacío"
+      elif check_pid_alive "$pid"; then
+        log "  OK ${pid_file} (PID ${pid})"
+        last_err=""
+        break
+      else
+        last_err="proceso no corre (PID ${pid})"
+      fi
+    fi
+    sleep 1
+    waited=$((waited + 1))
+  done
+  if [ -n "$last_err" ]; then
+    fail "${pid_file}: ${last_err} tras ${MAX_WAIT_SECONDS}s" 1
+  fi
 done
 
 # --- 2) Dashboard responde ---


### PR DESCRIPTION
## Summary

Tres bugs en el safety net introducido por #2360, todos expuestos en el primer restart real (2026-04-19 21:11 UTC):

1. **smoke-test.sh race** — chequeo one-shot de PID files a los ~6s post-launch se volvía carrera cuando 6 singletons concurrentes hacían wmic scan tras un killAll. Reemplazado por retry con sleep 1s hasta 30s por archivo.
2. **rollback.sh self-kill** — \`taskkill //T\` (tree-kill) sobre todo \`node.exe\` con \".pipeline\" en el command line incluía al \`restart.js\` padre; el bash rollback.sh moría como hijo del árbol antes del primer \`log\` (por eso no existe \`rollback.log\`). Ahora se excluye el PID del parent y el propio \`$$\` del loop.
3. **restart.js passthrough** — propaga \`process.pid\` como \`PARENT_RESTART_PID\` en el env del \`spawnSync\` de \`rollback.sh\` para que el skip de (2) funcione.

## Contexto del incidente

Al primer restart tras merge de #2360:
- Smoke test exit 1 (process check no encontró uno de los 3 PIDs críticos)
- Auto-rollback disparado
- Rollback.sh se mató a sí mismo vía tree-kill (\`rollback.log\` no existe, alertas enqueued en 425ms)
- Ambas alertas de Telegram (🚨 + ❌) salieron pero el rollback efectivamente no hizo nada (HEAD ya == pipeline-stable, por suerte)

## Test plan

- [x] \`bash -n\` + \`node --check\` OK en los 3 archivos
- [x] Smoke test con PID file retrasado 5s pasa (antes fallaba al instante)
- [x] Smoke test con pipeline actual corriendo pasa (OK pulpo/dashboard/svc-telegram)
- [ ] Observar próximo restart real: smoke-test debería tolerar el startup contention

## QA

\`qa:skipped\` — es un fix del safety net del restart (infra interna del pipeline V2), sin impacto en producto de usuario (app client/business/delivery ni API backend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)