### PR TITLE
fix(pipeline): hardening post-#2361 (smoke retry global, rollback PPID fallback)

### DIFF
--- a/.pipeline/restart.js
+++ b/.pipeline/restart.js
@@ -193,9 +193,12 @@ function runSmokeTest() {
 
   log('=== SMOKE TEST ===');
   try {
+    // Timeout 60s: smoke-test hace retry de hasta 25s sobre los 3 PID
+    // files + curl 5s + stat checks. 30s previos eran apretados y en
+    // Windows el kill por timeout deja un exit ambiguo (a veces 1).
     const result = spawnSync('bash', [script], {
       cwd: ROOT,
-      timeout: 30000,
+      timeout: 60000,
       encoding: 'utf8',
       windowsHide: true,
     });
@@ -205,8 +208,8 @@ function runSmokeTest() {
       log('Smoke test OK');
       return { ok: true, exitCode, output };
     }
-    log(`Smoke test FAIL (exit ${exitCode})`);
-    if (output) log(output.split('\n').slice(-5).join('\n'));
+    log(`Smoke test FAIL (exit ${exitCode}, signal=${result.signal || 'none'})`);
+    if (output) log(output.split('\n').slice(-12).join('\n'));
     return { ok: false, exitCode, output };
   } catch (e) {
     log(`Smoke test error: ${e.message}`);

--- a/.pipeline/rollback.sh
+++ b/.pipeline/rollback.sh
@@ -39,10 +39,13 @@ log "=== ROLLBACK a ${TARGET} ==="
 
 # --- 1) Matar pipeline ---
 # taskkill //T es tree-kill: si matamos al restart.js padre se lleva
-# puesto a este bash y el rollback muere mid-ejecución. El parent nos
-# pasa su PID en PARENT_RESTART_PID para excluirlo del kill loop.
-PARENT_RESTART_PID="${PARENT_RESTART_PID:-0}"
+# puesto a este bash y el rollback muere mid-ejecución. El parent ideal
+# nos pasa su PID en PARENT_RESTART_PID; si no lo hace (restart.js
+# pre-#2361) caemos a $PPID (el bash siempre tiene el node padre ahí).
+PARENT_RESTART_PID="${PARENT_RESTART_PID:-${PPID:-0}}"
 MY_PID=$$
+# Escribo también a stderr para dejar evidencia aunque tee falle
+echo "[rollback] parent=${PARENT_RESTART_PID} self=${MY_PID}" >&2
 log "1) Matando procesos del pipeline (skip parent=${PARENT_RESTART_PID}, self=${MY_PID})..."
 
 if command -v wmic &>/dev/null; then

--- a/.pipeline/smoke-test.sh
+++ b/.pipeline/smoke-test.sh
@@ -23,11 +23,17 @@ PIPELINE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LOG_FILE="${PIPELINE_DIR}/logs/smoke-test.log"
 mkdir -p "$(dirname "$LOG_FILE")"
 
+# Evidencia a stderr desde el vamos, independiente de tee/LOG_FILE.
+# Si el smoke test falla antes del primer log() (tee roto, CWD raro),
+# restart.js captura esto via spawnSync result.stderr.
+echo "[smoke-test] inicio pid=$$ pipeline_dir=${PIPELINE_DIR}" >&2
+
 log() {
   local msg="$1"
   local ts
   ts="$(date '+%Y-%m-%d %H:%M:%S')"
   echo "[$ts] $msg" | tee -a "$LOG_FILE"
+  echo "[smoke-test] $msg" >&2
 }
 
 fail() {
@@ -36,15 +42,16 @@ fail() {
 }
 
 # --- 1) Procesos críticos ---
-# Retry hasta 30s: singleton.js escribe el .pid DESPUÉS de un wmic scan que
-# se pisa con otros wmic de arranque concurrente y puede tardar varios
-# segundos. Con 6+ servicios arrancando en paralelo justo después de un
-# killAll, el one-shot a los 6s post-launch se volvía carrera.
+# Retry GLOBAL (no por-archivo): chequea los 3 pids en cada iteración;
+# sale apenas los 3 están OK. Total max 25s (cabe en spawnSync timeout
+# de 60s con margen). singleton.js escribe el .pid DESPUÉS de un wmic
+# scan que compite con los otros singletons arrancando en paralelo, así
+# que el one-shot a los 6s post-launch se volvía carrera.
 log "=== SMOKE TEST ==="
 log "1) Verificando procesos críticos..."
 
 CRITICAL=("pulpo.pid" "dashboard.pid" "svc-telegram.pid")
-MAX_WAIT_SECONDS=30
+MAX_WAIT_SECONDS=25
 
 check_pid_alive() {
   local pid="$1"
@@ -55,31 +62,52 @@ check_pid_alive() {
   fi
 }
 
-for pid_file in "${CRITICAL[@]}"; do
-  waited=0
-  last_err=""
-  while [ "$waited" -lt "$MAX_WAIT_SECONDS" ]; do
-    if [ ! -f "${PIPELINE_DIR}/${pid_file}" ]; then
-      last_err="PID file ausente"
-    else
-      pid=$(cat "${PIPELINE_DIR}/${pid_file}" 2>/dev/null | tr -d '[:space:]')
-      if [ -z "$pid" ]; then
-        last_err="PID file vacío"
-      elif check_pid_alive "$pid"; then
-        log "  OK ${pid_file} (PID ${pid})"
-        last_err=""
-        break
-      else
-        last_err="proceso no corre (PID ${pid})"
-      fi
-    fi
-    sleep 1
-    waited=$((waited + 1))
-  done
-  if [ -n "$last_err" ]; then
-    fail "${pid_file}: ${last_err} tras ${MAX_WAIT_SECONDS}s" 1
+# Devuelve 0 si el pid_file está OK (existe, no vacío, proceso vivo).
+# Imprime estado por stdout ("OK PID" | error).
+check_pid_ready() {
+  local pid_file="$1"
+  if [ ! -f "${PIPELINE_DIR}/${pid_file}" ]; then
+    echo "ausente"
+    return 1
   fi
+  local pid
+  pid=$(cat "${PIPELINE_DIR}/${pid_file}" 2>/dev/null | tr -d '[:space:]')
+  if [ -z "$pid" ]; then
+    echo "vacío"
+    return 1
+  fi
+  if check_pid_alive "$pid"; then
+    echo "OK ${pid}"
+    return 0
+  fi
+  echo "muerto(${pid})"
+  return 1
+}
+
+waited=0
+all_ok=0
+pending=""
+while [ "$waited" -lt "$MAX_WAIT_SECONDS" ]; do
+  pending=""
+  declare -a ok_states=()
+  for pid_file in "${CRITICAL[@]}"; do
+    if state=$(check_pid_ready "$pid_file"); then
+      ok_states+=("  ${pid_file}: ${state}")
+    else
+      pending="${pending} ${pid_file}:${state}"
+    fi
+  done
+  if [ -z "$pending" ]; then
+    all_ok=1
+    for line in "${ok_states[@]}"; do log "$line"; done
+    break
+  fi
+  sleep 1
+  waited=$((waited + 1))
 done
+if [ "$all_ok" != 1 ]; then
+  fail "procesos críticos no ready tras ${MAX_WAIT_SECONDS}s:${pending}" 1
+fi
 
 # --- 2) Dashboard responde ---
 log "2) Verificando dashboard HTTP..."


### PR DESCRIPTION
## Summary

Hardening tras segunda falla del restart (2026-04-19 21:40 UTC) con mismo patrón que antes de #2361. La causa raíz: el \`restart.js\` en memoria seguía siendo el viejo hasta que alguien relanza \`node .pipeline/restart.js\`, así que mis fixes del PR anterior no se aplicaban. Este PR endurece los scripts bash (que SÍ se re-leen del disco) para ser defensivos incluso cuando el parent restart.js es pre-#2361.

## Cambios

**1. \`rollback.sh\` — auto-detect del parent PID**
- \`PARENT_RESTART_PID=\"${PARENT_RESTART_PID:-${PPID:-0}}\"\`
- Si el invocador (restart.js viejo) no pasa la env var, usa \`$PPID\` del shell (que en spawnSync es siempre el node padre). Elimina el tree-kill self-inflicted sin depender del restart.js.

**2. \`smoke-test.sh\` — retry global + evidencia en stderr**
- Retry GLOBAL (no por-archivo): chequea los 3 pids en cada iteración, sale apenas los 3 están OK. Total max 25s (antes 30s/file × 3 = 90s, no cabía en spawnSync timeout de 30s).
- \`log()\` ahora también emite a stderr además de \`tee -a LOG_FILE\`. Si tee falla (como pasó a las 18:40 — smoke-test.log no se actualizó pese a exit 1), igual queda evidencia capturada por spawnSync.
- Print de diagnóstico desde la primera línea (\"[smoke-test] inicio pid=...\").

**3. \`restart.js\` — timeout 60s + mejor logging del FAIL**
- Spawn timeout sube 30s → 60s (margen para el retry de 25s + curl 5s + fs checks). En Windows, \`TerminateProcess\` por timeout deja exit ambiguo (a veces 1), que se confundía con fallo real.
- Log del FAIL incluye \`signal\` y toma 12 líneas de output (antes 5).

## Test plan

- [x] Syntax: \`bash -n\` + \`node --check\` OK
- [x] Happy path: 2s, exit 0, signal null via spawnSync
- [x] Retry: PID file retrasado 6s → pasa en 8s (antes fallaba al instante)
- [x] stderr evidence: cada \`log\` call aparece en \`result.stderr\` de spawnSync
- [ ] Próximo restart real con nuevo restart.js en memoria: observar que rollback (si llega a dispararse) no se auto-mate y smoke-test deje log completo

## QA

\`qa:skipped\` — infra del pipeline V2, sin impacto en app/backend de usuario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)