### PR TITLE
fix(pipeline): smoke timeout 60s + wmic lock en singleton

### DIFF
--- a/.pipeline/restart.js
+++ b/.pipeline/restart.js
@@ -193,12 +193,12 @@ function runSmokeTest() {
 
   log('=== SMOKE TEST ===');
   try {
-    // Timeout 60s: smoke-test hace retry de hasta 25s sobre los 3 PID
-    // files + curl 5s + stat checks. 30s previos eran apretados y en
-    // Windows el kill por timeout deja un exit ambiguo (a veces 1).
+    // Timeout 120s: smoke-test hace retry de hasta 60s sobre los 3 PID
+    // files + curl 5s + stat checks. 60s previos se agotaban en Windows
+    // cuando 7 singletons hacían wmic en paralelo post-launchAll.
     const result = spawnSync('bash', [script], {
       cwd: ROOT,
-      timeout: 60000,
+      timeout: 120000,
       encoding: 'utf8',
       windowsHide: true,
     });

--- a/.pipeline/singleton.js
+++ b/.pipeline/singleton.js
@@ -10,12 +10,64 @@ const { spawnSync } = require('child_process');
 
 const PIPELINE = process.env.PIPELINE_STATE_DIR || path.resolve(__dirname);
 
+// Sleep sincrónico reutilizable (mismo patrón que restart.js).
+function sleepMs(ms) {
+  spawnSync(process.execPath, ['-e', `setTimeout(()=>{},${ms})`], { timeout: ms + 1000 });
+}
+
+// Lock file-based para serializar wmic scans en Windows.
+// Cuando restart.js spawnea 7 componentes en paralelo, los 7 singletons
+// ejecutan wmic al mismo tiempo; en Windows eso puede tomar >30s por
+// contención (wmic es lento y no concurrente). Serializamos.
+const WMIC_LOCK_FILE = path.join(PIPELINE, '.wmic-scan.lock');
+const WMIC_LOCK_MAX_WAIT_MS = 45000;
+const WMIC_LOCK_POLL_MS = 200;
+
+function pidAlive(pid) {
+  try { process.kill(pid, 0); return true; } catch (e) { return e.code === 'EPERM'; }
+}
+
+function acquireWmicLock() {
+  const start = Date.now();
+  while (Date.now() - start < WMIC_LOCK_MAX_WAIT_MS) {
+    try {
+      const fd = fs.openSync(WMIC_LOCK_FILE, 'wx');
+      fs.writeSync(fd, String(process.pid));
+      fs.closeSync(fd);
+      return true;
+    } catch (e) {
+      if (e.code !== 'EEXIST') return false;
+      // Si el dueño del lock murió, lo liberamos.
+      try {
+        const ownerPid = parseInt((fs.readFileSync(WMIC_LOCK_FILE, 'utf8') || '').trim(), 10);
+        if (ownerPid && ownerPid !== process.pid && !pidAlive(ownerPid)) {
+          try { fs.unlinkSync(WMIC_LOCK_FILE); } catch {}
+          continue;
+        }
+      } catch {}
+      sleepMs(WMIC_LOCK_POLL_MS);
+    }
+  }
+  // Si no pudimos obtener el lock, seguimos igual — mejor un scan
+  // concurrente que abortar el arranque del componente.
+  return false;
+}
+
+function releaseWmicLock(held) {
+  if (!held) return;
+  try {
+    const ownerPid = parseInt((fs.readFileSync(WMIC_LOCK_FILE, 'utf8') || '').trim(), 10);
+    if (ownerPid === process.pid) fs.unlinkSync(WMIC_LOCK_FILE);
+  } catch {}
+}
+
 /**
  * Busca procesos node.exe que tengan el mismo script en su command line.
  * Retorna array de PIDs (excluyendo el proceso actual).
  */
 function findSiblings(scriptName) {
   if (process.platform === 'win32') {
+    const held = acquireWmicLock();
     try {
       const r = spawnSync('wmic', [
         'process', 'where', "name='node.exe'",
@@ -36,6 +88,7 @@ function findSiblings(scriptName) {
       }
       return pids;
     } catch { return []; }
+    finally { releaseWmicLock(held); }
   }
 
   // Linux/Mac: usar ps

--- a/.pipeline/smoke-test.sh
+++ b/.pipeline/smoke-test.sh
@@ -43,15 +43,16 @@ fail() {
 
 # --- 1) Procesos críticos ---
 # Retry GLOBAL (no por-archivo): chequea los 3 pids en cada iteración;
-# sale apenas los 3 están OK. Total max 25s (cabe en spawnSync timeout
-# de 60s con margen). singleton.js escribe el .pid DESPUÉS de un wmic
-# scan que compite con los otros singletons arrancando en paralelo, así
-# que el one-shot a los 6s post-launch se volvía carrera.
+# sale apenas los 3 están OK. Total max 60s (cabe en spawnSync timeout
+# de 120s con margen). singleton.js escribe el .pid DESPUÉS de un wmic
+# scan que compite con los otros singletons arrancando en paralelo. Con
+# 7 componentes spawneados en paralelo los wmic se apilan y 25s no
+# alcanzan en Windows cuando la caja está cargada.
 log "=== SMOKE TEST ==="
 log "1) Verificando procesos críticos..."
 
 CRITICAL=("pulpo.pid" "dashboard.pid" "svc-telegram.pid")
-MAX_WAIT_SECONDS=25
+MAX_WAIT_SECONDS=60
 
 check_pid_alive() {
   local pid="$1"


### PR DESCRIPTION
## Contexto

Tu `/restart` manual dispara el auto-rollback porque el smoke test falla con *\"procesos críticos no ready tras 25s\"*. Causa raíz: `restart.js` spawnea 7 singletons en paralelo y cada uno hace un `wmic process where name='node.exe' get ProcessId,CommandLine` antes de escribir su `.pid`. Con 7 `wmic` compitiendo, los `.pid` no aparecen dentro de la ventana de 25s del smoke.

## Cambios

- **`.pipeline/smoke-test.sh`** — `MAX_WAIT_SECONDS` 25 → 60.
- **`.pipeline/restart.js`** — `spawnSync` del smoke: timeout 60s → 120s (acomoda el nuevo presupuesto de retry + curl + stat checks).
- **`.pipeline/singleton.js`** — lock `.wmic-scan.lock` (espera activa con poll 200ms, TTL 45s, detección de lock stale por PID muerto). Serializa los `wmic` de los 7 singletons post-launchAll sin bloquear singletons que arrancan en momentos distintos.

## Por qué no rompe

- Lock file stale se limpia solo (detección por `process.kill(pid, 0)`).
- Si no logra el lock en 45s, igual corre el scan (degradación grácil): mejor scan concurrente que abortar el arranque del componente.
- No cambia la semántica de singleton: si hay otra instancia viva, sigue abortando igual.

## Test plan

- [ ] `/restart` desde Telegram → smoke test pasa → tag `pipeline-stable` avanza.
- [ ] Verificar que `.pipeline/.wmic-scan.lock` no quede huérfano tras un restart exitoso.
- [ ] Dashboard HTTP 200 en `:3200` post-restart.

## Labels

`qa:skipped` — cambio 100% en `.pipeline/`, sin impacto en producto de usuario (regla CLAUDE.md § Gate de QA).

Closes #0 (seguimiento del incidente del restart fallido 2026-04-19 19:13 ART)

🤖 Generated with [Claude Code](https://claude.com/claude-code)