### PR TITLE
fix(pipeline): elimina WHERE de wmic — filtra node.exe en JS (fix spam log real)

### DIFF
--- a/.pipeline/outbox-drain.js
+++ b/.pipeline/outbox-drain.js
@@ -20,17 +20,19 @@ const { spawnSync } = require("child_process");
 
 function findProcess(scriptName) {
   try {
-    // shell:true preserva comillas del filtro wmic (mismo motivo que pid-discovery.js).
+    // Sin WHERE: cmd.exe /c (shell:true) quita las comillas envolventes y el
+    // filtro "name='node.exe'" llega a wmic sin quoting, tirando "No se
+    // reconoce el filtro de búsqueda" en loop. Filtramos Name=node.exe en JS.
     const r = spawnSync(
-      `wmic process where "name='node.exe'" get ProcessId,CommandLine /format:csv 2>NUL`,
-      { encoding: "utf8", timeout: 10000, windowsHide: true, shell: true }
+      'wmic process get Name,ProcessId,CommandLine /format:csv',
+      { encoding: "utf8", timeout: 15000, windowsHide: true, shell: true }
     );
     const lines = (r.stdout || "").split("\n");
     for (const line of lines) {
-      if (line.includes(scriptName) && !line.includes("wmic")) {
-        const match = line.match(/(\d+)\s*$/);
-        if (match && parseInt(match[1]) !== process.pid) return parseInt(match[1]);
-      }
+      if (!line.toLowerCase().includes('node.exe')) continue;
+      if (!line.includes(scriptName) || line.includes("wmic")) continue;
+      const match = line.match(/(\d+)\s*$/);
+      if (match && parseInt(match[1]) !== process.pid) return parseInt(match[1]);
     }
   } catch {}
   return null;

--- a/.pipeline/pid-discovery.js
+++ b/.pipeline/pid-discovery.js
@@ -38,26 +38,29 @@ function scanNodeProcesses() {
   const processes = [];
   if (process.platform === 'win32') {
     try {
-      // shell:true → cmd.exe preserva las comillas del WHERE; sin esto el
-      // filtro llega a wmic como name=node.exe y tira "No se reconoce
-      // el filtro de búsqueda" en loop, spameando el log del caller.
-      // 2>NUL descarta errores residuales (no queremos forwardear).
+      // Sin WHERE. Cuando el comando se pasa con shell:true, Node lanza
+      // cmd.exe /d /s /c "<cmd>"; cmd.exe /c quita las comillas externas y
+      // el filtro "name='node.exe'" llega a wmic sin comillas (name=node.exe),
+      // disparando "No se reconoce el filtro de búsqueda" en loop.
+      // Solución: traer todos los procesos y filtrar Name=node.exe en JS.
       const r = spawnSync(
-        `wmic process where "name='node.exe'" get ProcessId,CommandLine,CreationDate /format:csv 2>NUL`,
-        { encoding: 'utf8', timeout: 10000, windowsHide: true, shell: true }
+        'wmic process get Name,ProcessId,CommandLine,CreationDate /format:csv',
+        { encoding: 'utf8', timeout: 15000, windowsHide: true, shell: true }
       );
       const lines = (r.stdout || '').split('\n');
       for (const line of lines) {
         const t = line.trim();
         if (!t || !t.includes(',')) continue;
-        // header: Node,CommandLine,CreationDate,ProcessId
+        // header: Node,CommandLine,CreationDate,Name,ProcessId
         if (/^Node,/i.test(t)) continue;
         const parts = t.split(',');
-        if (parts.length < 4) continue;
+        if (parts.length < 5) continue;
         const pid = parseInt(parts[parts.length - 1], 10);
         if (!pid || Number.isNaN(pid)) continue;
-        const creationDate = parts[parts.length - 2] || '';
-        const commandLine = parts.slice(1, -2).join(',');
+        const name = (parts[parts.length - 2] || '').trim();
+        if (name.toLowerCase() !== 'node.exe') continue;
+        const creationDate = parts[parts.length - 3] || '';
+        const commandLine = parts.slice(1, -3).join(',');
         processes.push({ pid, commandLine, creationDate });
       }
     } catch {}


### PR DESCRIPTION
## Contexto

PR #2366 (merge `c8bed2d5`) intentó arreglar el spam `"No se reconoce el filtro de búsqueda"` en `dashboard.log` agregando `shell:true` al `spawnSync` de wmic. **No funcionó en prod** — el dashboard spameó 30+ errores post-restart.

## Causa raíz

- `shell:true` de Node lanza `cmd.exe /d /s /c "<cmd>"` en Windows.
- `cmd.exe /c` **quita las comillas envolventes** del comando.
- El filtro `"name='node.exe'"` llega a wmic **sin quoting** (`name=node.exe`) y dispara el error en loop.
- Bajo git bash el efecto no se reproduce (bash preserva comillas); por eso pasó tests locales pero falló bajo watchdog→dashboard (cmd.exe).

## Solución

- **Sacar `WHERE` de wmic** — filtrar `Name=node.exe` en JS tras parsear CSV.
- Comando robusto en ambos entornos (bash y cmd.exe).
- Ajustar parsing: header ahora tiene `Name` → 5 columnas, `ProcessId` última, `Name` penúltima.
- Mismo patrón aplicado a `outbox-drain.js`.

## Evidencia — 14 casos de prueba locales

| # | Caso | Resultado |
|---|------|-----------|
| 1 | `scanNodeProcesses()` | 9 procs, 144ms |
| 2 | `findPidByPort(3200)` | PID 14608 (dashboard) |
| 3 | `findPidByComponent('dashboard')` | PID + cmdLine + creationDate |
| 4 | `findPidByComponent` × 7 componentes críticos | 7/7 OK |
| 5 | wmic stderr (nuevo código) | 0 líneas |
| 6 | `outbox-drain findProcess` aislado | sin errores |
| 7 | `restart.js status` | 7 componentes + puerto OK |
| 8 | `smoke-test.sh` end-to-end | EXIT 0, HTTP 200 |
| 9 | parsing CSV robusto | 9/9 válidos |
| 10 | `bash -n rollback.sh` | sintaxis OK |
| 11 | `rollback.sh` sin wmic where + usa discovery | 0 refs wmic, 3 refs pid-discovery |
| 12 | `rollback.sh` scan dry via discovery | 7 PIDs pipeline detectados |
| 13 | stderr scan nuevo | 0 líneas (no agrega al log) |
| 14 | ANTES vs DESPUÉS | Fix nuevo funciona bajo cmd.exe; el viejo fallaba |

## Archivos tocados

- `.pipeline/pid-discovery.js` — sin WHERE, filtra Name=node.exe en JS
- `.pipeline/outbox-drain.js` — mismo patrón

## Merge plan

`qa:skipped` — cambio interno de pipeline, sin impacto en producto de usuario. Post-merge: `/restart` para estrenar.

Relacionado: #2366 (intento previo insuficiente), #2365 (pid-discovery original).