### PR TITLE
fix(pipeline): pulpo.js wmic sin WHERE - ultimo caller del spam

### DIFF
--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -744,10 +744,11 @@ function limpiarDaemonsOnDemand() {
   // 1. Buscar Gradle daemons
   try {
     const wmicOut = execSync(
-      'wmic process where "name=\'java.exe\'" get ProcessId,ParentProcessId,CommandLine /FORMAT:CSV',
+      'wmic process get Name,ProcessId,ParentProcessId,CommandLine /FORMAT:CSV',
       { encoding: 'utf8', timeout: 10000, windowsHide: true }
     );
     for (const line of wmicOut.split('\n')) {
+      if (!line.includes('java.exe')) continue;
       if (!line.includes('GradleDaemon') && !line.includes('gradle-launcher')) continue;
       const parts = line.split(',');
       const pid = parts[parts.length - 2]?.trim();
@@ -775,10 +776,11 @@ function limpiarDaemonsOnDemand() {
   // 2. Buscar Kotlin compile daemons
   try {
     const wmicOut2 = execSync(
-      'wmic process where "name=\'java.exe\'" get ProcessId,CommandLine /FORMAT:CSV',
+      'wmic process get Name,ProcessId,CommandLine /FORMAT:CSV',
       { encoding: 'utf8', timeout: 10000, windowsHide: true }
     );
     for (const line of wmicOut2.split('\n')) {
+      if (!line.includes('java.exe')) continue;
       if (!line.includes('kotlin-compiler') && !line.includes('KotlinCompileDaemon')) continue;
       const match = line.match(/,(\d+)\s*$/);
       if (!match) continue;


### PR DESCRIPTION
## Resumen

Completa el fix iniciado en #2365/#2366/#2367. Faltaban 2 callers en `pulpo.js`:
- Linea 746-748: busqueda de Gradle daemons
- Linea 777-781: busqueda de Kotlin compile daemons

Ambos usaban `wmic process where "name='java.exe'"` que bajo `cmd.exe /c` pierde el quoting y spamea `"No se reconoce el filtro de busqueda"`.

## Fix

Mismo patron que #2367: sin `WHERE`, filtrar `Name=java.exe` en JS tras parsear CSV.

## Validacion

- \`node -c .pipeline/pulpo.js\` OK
- wmic manual sin WHERE: 194ms, 4 matches java.exe, stderr vacio
- La funcion solo corre on-demand via \`/limpiar\`, fix preventivo

Label: qa:skipped (infra, sin impacto en producto)

Closes spam residual reportado por Leo post-#2367.