### PR TITLE
refactor(pipeline): rediseño smoke/rollback en Node puro con ready-markers

### DIFF
--- a/.pipeline/dashboard-v2.js
+++ b/.pipeline/dashboard-v2.js
@@ -5741,6 +5741,7 @@ const server = http.createServer((req, res) => {
 server.listen(PORT, () => {
   log(`Dashboard V2 en http://localhost:${PORT}`);
   log(`API: /api/state | Logs: /logs/{file} | SSE: /events`);
+  try { require('./lib/ready-marker').signalReady('dashboard', { port: PORT }); } catch {}
 });
 
 // dashboard.pid se mantiene como hint informativo (útil para mtime →

--- a/.pipeline/lib/ready-marker.js
+++ b/.pipeline/lib/ready-marker.js
@@ -1,0 +1,136 @@
+// ready-marker.js — marcadores de "componente listo"
+//
+// Diseño: cada componente del pipeline (pulpo, dashboard, listener,
+// servicios) escribe un archivo `.ready` cuando termina su fase de
+// inicialización y entra en loop principal. El smoke-test y el restart
+// leen esos marcadores en vez de escanear el SO con wmic.
+//
+// Ventajas vs. el modelo anterior (scan de OS + match por commandLine):
+//   - No depende de wmic (quoting frágil en cmd.exe/bash).
+//   - Cada componente declara explícitamente su estado "ready" desde
+//     adentro, no se infiere desde afuera.
+//   - Distingue "arrancando" (sin marker) de "vivo" (marker + pid alive).
+//   - El marker incluye pid, timestamp y metadata útil para debugging.
+//
+// Estructura de un marker:
+//   .pipeline/ready/<name>.ready → JSON
+//     { name, pid, startedAt, readyAt, meta }
+
+const fs = require('fs');
+const path = require('path');
+
+const PIPELINE_DIR = path.resolve(__dirname, '..');
+const READY_DIR = path.join(PIPELINE_DIR, 'ready');
+
+function ensureDir() {
+  if (!fs.existsSync(READY_DIR)) fs.mkdirSync(READY_DIR, { recursive: true });
+}
+
+function markerPath(name) {
+  return path.join(READY_DIR, `${name}.ready`);
+}
+
+// Llamado desde cada componente cuando completó init.
+// `name` debe coincidir con el name usado en restart.js COMPONENTS.
+function signalReady(name, meta = {}) {
+  try {
+    ensureDir();
+    const data = {
+      name,
+      pid: process.pid,
+      startedAt: process.env.__INTRALE_PROCESS_START || new Date().toISOString(),
+      readyAt: new Date().toISOString(),
+      meta,
+    };
+    fs.writeFileSync(markerPath(name), JSON.stringify(data, null, 2));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Lee marker si existe. Retorna null si no existe o es inválido.
+function readMarker(name) {
+  try {
+    const raw = fs.readFileSync(markerPath(name), 'utf8');
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+// Verifica si un PID está vivo (portable).
+function pidAlive(pid) {
+  if (!pid || pid < 1) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e) {
+    return e.code === 'EPERM';
+  }
+}
+
+// Borra todos los markers. Llamado por restart.js antes del launchAll
+// para evitar leer markers viejos del ciclo anterior.
+function clearAllMarkers() {
+  try {
+    if (!fs.existsSync(READY_DIR)) return 0;
+    let n = 0;
+    for (const f of fs.readdirSync(READY_DIR)) {
+      if (f.endsWith('.ready')) {
+        try { fs.unlinkSync(path.join(READY_DIR, f)); n++; } catch {}
+      }
+    }
+    return n;
+  } catch {
+    return 0;
+  }
+}
+
+// Borra el marker de un componente puntual.
+function clearMarker(name) {
+  try { fs.unlinkSync(markerPath(name)); return true; } catch { return false; }
+}
+
+// Estado por componente: ready/booting/stale/missing.
+//   ready    → marker existe y PID está vivo
+//   stale    → marker existe pero el PID murió (crash o no-arrancó)
+//   missing  → no hay marker (aún no señalizó ready)
+function componentState(name) {
+  const m = readMarker(name);
+  if (!m) return { state: 'missing', marker: null };
+  if (!pidAlive(m.pid)) return { state: 'stale', marker: m };
+  return { state: 'ready', marker: m };
+}
+
+// Polling helper: espera hasta que todos los componentes estén ready,
+// o hasta que se agote el timeout. Retorna detalle por componente.
+// Si `timeoutMs` se agota con alguno aún en `missing`, ese se reporta
+// como tal (no como fail duro) — el caller decide qué hacer.
+async function waitForMarkers(names, timeoutMs = 60000, pollMs = 1000) {
+  const deadline = Date.now() + timeoutMs;
+  let last = {};
+  while (Date.now() < deadline) {
+    last = {};
+    let allReady = true;
+    for (const name of names) {
+      const st = componentState(name);
+      last[name] = st;
+      if (st.state !== 'ready') allReady = false;
+    }
+    if (allReady) return { ok: true, waitedMs: timeoutMs - (deadline - Date.now()), results: last };
+    await new Promise(r => setTimeout(r, pollMs));
+  }
+  return { ok: false, waitedMs: timeoutMs, results: last };
+}
+
+module.exports = {
+  signalReady,
+  readMarker,
+  clearAllMarkers,
+  clearMarker,
+  componentState,
+  waitForMarkers,
+  pidAlive,
+  READY_DIR,
+};

--- a/.pipeline/listener-telegram.js
+++ b/.pipeline/listener-telegram.js
@@ -199,6 +199,7 @@ async function pollLoop() {
   log(`Chat ID: ${CHAT_ID}`);
 
   await sendMessage('🐙 *Pipeline V2* — Listener activo');
+  try { require('./lib/ready-marker').signalReady('listener', { offset }); } catch {}
 
   while (true) {
     try {

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -5413,6 +5413,9 @@ if (process.env.PULPO_NO_AUTOSTART === '1') {
 // --- SINGLETON ---
 require('./singleton')('pulpo');
 
+// Signal ready — singleton adquirido, mainLoop arranca
+try { require('./lib/ready-marker').signalReady('pulpo'); } catch {}
+
 mainLoop().then(() => {
   log('pulpo', 'Pulpo finalizado');
   process.exit(0);

--- a/.pipeline/restart.js
+++ b/.pipeline/restart.js
@@ -21,6 +21,7 @@ const {
   pidAlive,
   invalidateCache,
 } = require('./pid-discovery');
+const { clearAllMarkers } = require('./lib/ready-marker');
 
 const PIPELINE = path.resolve(__dirname);
 const ROOT = path.resolve(PIPELINE, '..');
@@ -95,6 +96,12 @@ function killAll() {
   for (const comp of COMPONENTS) {
     try { fs.unlinkSync(path.join(PIPELINE, comp.pid)); } catch {}
   }
+
+  // Limpiar ready markers — cada componente debe reescribir el suyo
+  // al completar su init tras el relaunch. Si no aparecen, el smoke
+  // los reporta como "missing" (booting o crasheado).
+  const cleared = clearAllMarkers();
+  if (cleared > 0) log(`  ${cleared} ready marker(s) limpiados`);
 
   // Mover archivos de trabajando/ Y pendiente/ a listo/ en commander
   // IMPORTANTE: limpiar AMBAS colas — si hay un mensaje de restart pendiente
@@ -177,7 +184,7 @@ function launchAll() {
 // --- SMOKE TEST + TAG pipeline-stable + AUTO-ROLLBACK ---
 
 function runSmokeTest() {
-  const script = path.join(PIPELINE, 'smoke-test.sh');
+  const script = path.join(PIPELINE, 'smoke-test.js');
   if (!fs.existsSync(script)) {
     log('Smoke test ausente, se omite');
     return { ok: true, skipped: true };
@@ -185,12 +192,13 @@ function runSmokeTest() {
 
   log('=== SMOKE TEST ===');
   try {
-    // Timeout 120s: smoke-test hace retry de hasta 60s sobre los 3 PID
-    // files + curl 5s + stat checks. 60s previos se agotaban en Windows
-    // cuando 7 singletons hacían wmic en paralelo post-launchAll.
-    const result = spawnSync('bash', [script], {
+    // smoke-test.js es Node puro: lee ready markers + chequea HTTP en
+    // :3200. No usa wmic ni bash. Timeout holgado (90s) porque el smoke
+    // internamente hace polling hasta 60s a que los 7 componentes
+    // escriban sus markers.
+    const result = spawnSync(process.execPath, [script], {
       cwd: ROOT,
-      timeout: 120000,
+      timeout: 90000,
       encoding: 'utf8',
       windowsHide: true,
     });
@@ -255,31 +263,40 @@ function enqueueTelegramAlert(text) {
   }
 }
 
-function runRollback() {
-  log('=== AUTO-ROLLBACK ===');
-  const script = path.join(PIPELINE, 'rollback.sh');
+function launchRollbackOrphan() {
+  // Estrategia detached-orphan: el rollback corre independiente de restart.js.
+  // Problema anterior: cuando rollback.sh hacía `taskkill /T` sobre procesos
+  // del pipeline, se comía a restart.js (su parent) y moría mid-ejecución.
+  //
+  // Solución: restart.js spawnea rollback.js con detached+stdio:ignore+unref,
+  // sale de inmediato, y el rollback orphan es libre de matar lo que
+  // quiera — nuestro proceso ya no existe. No hay loop de self-kill.
+  log('=== AUTO-ROLLBACK (orphan detached) ===');
+  const script = path.join(PIPELINE, 'rollback.js');
   if (!fs.existsSync(script)) {
-    log('rollback.sh ausente — abortando rollback');
+    log('rollback.js ausente — no se puede ejecutar rollback');
     return false;
   }
-  try {
-    // PARENT_RESTART_PID: rollback.sh usa taskkill //T (tree-kill) sobre
-    // todo node.exe del pipeline; sin este hint se mata a sí mismo al
-    // matar a nuestro proceso node.
-    const result = spawnSync('bash', [script, 'pipeline-stable'], {
-      cwd: ROOT,
-      timeout: 180000,
-      encoding: 'utf8',
-      windowsHide: true,
-      env: { ...process.env, PARENT_RESTART_PID: String(process.pid) },
-    });
-    const output = `${result.stdout || ''}${result.stderr || ''}`.trim();
-    if (output) log(output.split('\n').slice(-8).join('\n'));
-    return result.status === 0;
-  } catch (e) {
-    log(`Rollback error: ${e.message}`);
-    return false;
-  }
+
+  const logsDir = path.join(PIPELINE, 'logs');
+  if (!fs.existsSync(logsDir)) fs.mkdirSync(logsDir, { recursive: true });
+  const logPath = path.join(logsDir, 'rollback.log');
+  const logFd = fs.openSync(logPath, 'a');
+  try { fs.writeSync(logFd, `\n--- orphan rollback launch ${new Date().toISOString()} ---\n`); } catch {}
+
+  const child = spawn(process.execPath, [script, 'pipeline-stable'], {
+    cwd: ROOT,
+    stdio: ['ignore', logFd, logFd],
+    detached: true,
+    windowsHide: true,
+    env: { ...process.env, NODE_PATH: path.join(ROOT, 'node_modules') },
+  });
+  child.unref();
+  fs.closeSync(logFd);
+
+  log(`  Rollback lanzado como orphan PID ${child.pid}`);
+  log(`  Seguir progreso: tail -f .pipeline/logs/rollback.log`);
+  return true;
 }
 
 // --- STATUS ---
@@ -353,13 +370,10 @@ switch (action) {
         log('Smoke test falló pero no existe tag pipeline-stable — primer deploy, sin rollback');
         enqueueTelegramAlert(`⚠️ *Pipeline restart: smoke test FAIL*\nExit ${smoke.exitCode}\n\nNo existe tag \`pipeline-stable\` (primer deploy). Revisar manualmente.`);
       } else {
-        enqueueTelegramAlert(`🚨 *Pipeline restart FALLÓ — ejecutando rollback automático*\nSmoke test exit ${smoke.exitCode}.\nVolviendo a \`pipeline-stable\`.`);
-        const rollbackOk = runRollback();
-        if (rollbackOk) {
-          enqueueTelegramAlert(`✅ *Rollback completado.*\nPipeline restaurado a \`pipeline-stable\`.`);
-        } else {
-          enqueueTelegramAlert(`❌ *Rollback FALLÓ.* Intervención manual requerida.\n\`\`\`\nbash .pipeline/rollback.sh\n\`\`\``);
-        }
+        enqueueTelegramAlert(`🚨 *Pipeline restart FALLÓ — lanzando rollback orphan*\nSmoke test exit ${smoke.exitCode}.\nVolviendo a \`pipeline-stable\`. Progreso en \`logs/rollback.log\`.`);
+        // Lanzamos rollback como orphan detached y salimos. El rollback
+        // notifica por Telegram cuando termina (OK o FAIL).
+        launchRollbackOrphan();
       }
     }
 }

--- a/.pipeline/rollback.js
+++ b/.pipeline/rollback.js
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+// rollback.js — Rollback del pipeline V2 (Node puro, detached-safe)
+//
+// Reemplazo de rollback.sh. Los problemas del script bash anterior:
+//   - taskkill //T (tree-kill) se comía al parent restart.js si no lo
+//     salteaba con PARENT_RESTART_PID → el rollback moría mid-ejecución.
+//   - Bash + wmic + quoting frágil → misma cadena que el smoke-test
+//     rompió 4 veces.
+//
+// Este script corre COMO ORPHAN: cuando restart.js detecta que el smoke
+// falló, lanza rollback.js con { detached: true, stdio: 'ignore' } y
+// unref + process.exit(0). Así el rollback queda corriendo por su
+// cuenta y es libre de matar a TODO proceso del pipeline incluyendo
+// al restart.js original (que ya murió) sin matarse a sí mismo.
+//
+// Flujo:
+//   1. Matar todos los node.exe del pipeline (saltando self).
+//   2. git fetch origin pipeline-stable + checkout solo de .pipeline/.
+//   3. Relanzar: node restart.js --no-smoke-test --no-rollback.
+//   4. Notificar resultado por Telegram (via outbox).
+//
+// Uso:
+//   node .pipeline/rollback.js              → rollback a pipeline-stable
+//   node .pipeline/rollback.js <sha|tag>    → rollback a commit/tag puntual
+
+const { execSync, spawn, spawnSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const { scanNodeProcesses, invalidateCache } = require('./pid-discovery');
+
+const PIPELINE_DIR = __dirname;
+const ROOT = path.resolve(PIPELINE_DIR, '..');
+const LOG_FILE = path.join(PIPELINE_DIR, 'logs', 'rollback.log');
+const TARGET = process.argv[2] || 'pipeline-stable';
+
+function log(msg) {
+  const ts = new Date().toISOString().replace('T', ' ').slice(0, 19);
+  const line = `[${ts}] ${msg}`;
+  try { fs.mkdirSync(path.dirname(LOG_FILE), { recursive: true }); } catch {}
+  try { fs.appendFileSync(LOG_FILE, line + '\n'); } catch {}
+  console.log(line);
+}
+
+function fail(msg, code = 1) {
+  log(`FAIL: ${msg}`);
+  enqueueTelegramAlert(`❌ *Rollback FALLÓ.* Intervención manual requerida.\n\`\`\`\nnode .pipeline/rollback.js\n\`\`\`\n${msg}`);
+  process.exit(code);
+}
+
+function enqueueTelegramAlert(text) {
+  const msg = text.length > 4000 ? text.slice(0, 4000) + '...' : text;
+  const svcDir = path.join(PIPELINE_DIR, 'servicios', 'telegram', 'pendiente');
+  try {
+    if (!fs.existsSync(svcDir)) fs.mkdirSync(svcDir, { recursive: true });
+    const filename = `${Date.now()}-rollback-alert.json`;
+    fs.writeFileSync(path.join(svcDir, filename), JSON.stringify({ text: msg, parse_mode: 'Markdown' }));
+  } catch (e) {
+    log(`No se pudo encolar alerta Telegram: ${e.message}`);
+  }
+}
+
+function sleep(ms) {
+  spawnSync(process.execPath, ['-e', `setTimeout(()=>{},${ms})`], { timeout: ms + 2000 });
+}
+
+// --- 1) Matar todo proceso del pipeline, salteando self ---
+
+function killPipelineProcesses() {
+  log(`=== ROLLBACK a ${TARGET} ===`);
+  log(`1) Matando procesos del pipeline (self=${process.pid})...`);
+
+  invalidateCache();
+  let killed = 0;
+  for (const p of scanNodeProcesses()) {
+    if (!p.commandLine || !p.commandLine.includes('.pipeline')) continue;
+    if (p.pid === process.pid) continue;
+    try {
+      execSync(`taskkill /PID ${p.pid} /F /T`, { timeout: 5000, stdio: 'ignore' });
+      log(`  Killed PID ${p.pid}`);
+      killed++;
+    } catch {}
+  }
+  if (killed === 0) log('  No había procesos del pipeline corriendo');
+
+  // Limpiar PID files.
+  try {
+    for (const f of fs.readdirSync(PIPELINE_DIR)) {
+      if (f.endsWith('.pid')) { try { fs.unlinkSync(path.join(PIPELINE_DIR, f)); } catch {} }
+    }
+  } catch {}
+
+  sleep(2000);
+}
+
+// --- 2) Verificar target + checkout quirúrgico ---
+
+function resetPipelineDir() {
+  log(`2) Verificando target ${TARGET}...`);
+
+  // Si el target no existe localmente, intentar fetch.
+  try {
+    execSync(`git rev-parse --verify ${TARGET}`, { cwd: ROOT, timeout: 5000, stdio: 'ignore' });
+  } catch {
+    log('  Target local no existe, haciendo fetch...');
+    let fetched = false;
+    for (const ref of [`refs/tags/${TARGET}:refs/tags/${TARGET}`, TARGET]) {
+      try {
+        execSync(`git fetch origin ${ref}`, { cwd: ROOT, timeout: 30000, stdio: 'ignore' });
+        fetched = true;
+        break;
+      } catch {}
+    }
+    if (!fetched) fail(`No se pudo fetch ${TARGET}`, 2);
+  }
+
+  let sha = '';
+  try {
+    sha = execSync(`git rev-parse ${TARGET}`, { cwd: ROOT, encoding: 'utf8', timeout: 5000 }).trim();
+    log(`  Target SHA: ${sha}`);
+  } catch (e) {
+    fail(`No se pudo resolver SHA de ${TARGET}: ${e.message}`, 2);
+  }
+
+  log(`3) Revirtiendo .pipeline/ al target...`);
+  try {
+    execSync(`git checkout ${TARGET} -- .pipeline/`, { cwd: ROOT, timeout: 30000 });
+  } catch (e) {
+    fail(`git checkout falló: ${e.message}`, 3);
+  }
+
+  return sha;
+}
+
+// --- 3) Relanzar pipeline (sin smoke + sin rollback recursivo) ---
+
+function relaunchPipeline() {
+  log(`4) Relanzando pipeline...`);
+  const restartScript = path.join(PIPELINE_DIR, 'restart.js');
+  const result = spawnSync(process.execPath, [restartScript, '--no-smoke-test', '--no-rollback'], {
+    cwd: ROOT,
+    timeout: 120000,
+    encoding: 'utf8',
+    windowsHide: true,
+  });
+  const output = `${result.stdout || ''}${result.stderr || ''}`.trim();
+  if (output) log(output.split('\n').slice(-12).join('\n'));
+  if (result.status !== 0) fail(`restart.js retornó ${result.status}`, 4);
+}
+
+// --- Main ---
+
+(function main() {
+  killPipelineProcesses();
+  const sha = resetPipelineDir();
+  relaunchPipeline();
+  log('=== ROLLBACK COMPLETADO ===');
+  log(`Pipeline restaurado a ${TARGET} (${sha.slice(0, 8)})`);
+  enqueueTelegramAlert(`✅ *Rollback completado.*\nPipeline restaurado a \`${TARGET}\` (${sha.slice(0, 8)}).`);
+  process.exit(0);
+})();

--- a/.pipeline/servicio-drive.js
+++ b/.pipeline/servicio-drive.js
@@ -224,6 +224,7 @@ function main() {
     process.exit(1);
   }
 
+  try { require('./lib/ready-marker').signalReady('svc-drive'); } catch {}
   setInterval(() => {
     processQueue().catch(e => log(`Error en processQueue: ${e.message}`));
   }, 10000);

--- a/.pipeline/servicio-emulador.js
+++ b/.pipeline/servicio-emulador.js
@@ -273,6 +273,8 @@ async function main() {
     }
   }
 
+  try { require('./lib/ready-marker').signalReady('svc-emulador'); } catch {}
+
   while (true) {
     try {
       await processQueue();

--- a/.pipeline/servicio-github.js
+++ b/.pipeline/servicio-github.js
@@ -319,6 +319,7 @@ function main() {
   retryFailedOnCompletes();
 
   log('Servicio GitHub iniciado');
+  try { require('./lib/ready-marker').signalReady('svc-github'); } catch {}
   setInterval(() => {
     try { processQueue(); } catch (e) { log(`Error: ${e.message}`); }
   }, 10000);

--- a/.pipeline/servicio-telegram.js
+++ b/.pipeline/servicio-telegram.js
@@ -151,6 +151,7 @@ async function processQueue() {
 // Main loop
 async function main() {
   log('Servicio Telegram iniciado');
+  try { require('./lib/ready-marker').signalReady('svc-telegram'); } catch {}
   while (true) {
     try { await processQueue(); } catch (e) { log(`Error: ${e.message}`); }
     await new Promise(r => setTimeout(r, 5000)); // Poll cada 5 seg

--- a/.pipeline/smoke-test.js
+++ b/.pipeline/smoke-test.js
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+// smoke-test.js — Verificación post-restart del pipeline V2 (Node puro)
+//
+// Reemplazo de smoke-test.sh. Eliminamos la cadena bash + wmic + node
+// anidada que se rompía por el quoting bajo cmd.exe. Este script usa
+// únicamente el fs + el módulo ready-marker (cada componente del
+// pipeline escribe su propio marker al terminar de inicializar).
+//
+// Chequeos:
+//   1. Todos los componentes del pipeline escribieron su .ready marker
+//      y su PID sigue vivo.
+//   2. Dashboard responde HTTP 200 en :3200 (/api/state).
+//   3. last-restart.json existe y es reciente.
+//   4. No quedaron mensajes huérfanos en commander/trabajando/ (warn).
+//
+// Exit codes:
+//   0 → pipeline sano (todos los componentes ready + dashboard responde)
+//   1 → componente no llegó a "ready" en el timeout, o su PID murió (stale)
+//   2 → dashboard no responde en :3200
+//   3 → last-restart.json ausente
+//
+// Uso:
+//   node .pipeline/smoke-test.js                       → chequeo estándar
+//   node .pipeline/smoke-test.js --timeout 90          → espera hasta 90s
+//   node .pipeline/smoke-test.js --components=a,b,c    → solo esos
+//   node .pipeline/smoke-test.js --no-http             → salta chequeo HTTP
+
+const fs = require('fs');
+const path = require('path');
+const http = require('http');
+const { componentState, waitForMarkers } = require('./lib/ready-marker');
+
+const PIPELINE_DIR = __dirname;
+const LOG_FILE = path.join(PIPELINE_DIR, 'logs', 'smoke-test.log');
+
+// Componentes que deben escribir marker tras initialize.
+// Debe estar sincronizado con restart.js COMPONENTS y con las llamadas
+// signalReady() inyectadas en cada componente.
+const DEFAULT_COMPONENTS = [
+  'pulpo',
+  'listener',
+  'svc-telegram',
+  'svc-github',
+  'svc-drive',
+  'svc-emulador',
+  'dashboard',
+];
+
+function parseArgs(argv) {
+  const args = { timeoutMs: 60000, components: null, http: true };
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--timeout' && argv[i + 1]) { args.timeoutMs = parseInt(argv[++i], 10) * 1000; }
+    else if (a.startsWith('--timeout=')) { args.timeoutMs = parseInt(a.split('=')[1], 10) * 1000; }
+    else if (a === '--components' && argv[i + 1]) { args.components = argv[++i].split(','); }
+    else if (a.startsWith('--components=')) { args.components = a.split('=')[1].split(','); }
+    else if (a === '--no-http') { args.http = false; }
+  }
+  return args;
+}
+
+function log(msg) {
+  const ts = new Date().toISOString().replace('T', ' ').slice(0, 19);
+  const line = `[${ts}] ${msg}`;
+  try { fs.mkdirSync(path.dirname(LOG_FILE), { recursive: true }); } catch {}
+  try { fs.appendFileSync(LOG_FILE, line + '\n'); } catch {}
+  console.log(line);
+}
+
+function fail(msg, code = 1) {
+  log(`FAIL: ${msg}`);
+  process.exit(code);
+}
+
+async function checkDashboardHttp(port, timeoutMs = 5000) {
+  return new Promise(resolve => {
+    const req = http.get({
+      host: '127.0.0.1',
+      port,
+      path: '/api/state',
+      timeout: timeoutMs,
+    }, res => {
+      res.resume();
+      resolve({ ok: res.statusCode === 200, status: res.statusCode });
+    });
+    req.on('timeout', () => { req.destroy(); resolve({ ok: false, status: 'timeout' }); });
+    req.on('error', e => resolve({ ok: false, status: e.code || 'error' }));
+  });
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const components = args.components || DEFAULT_COMPONENTS;
+
+  log('=== SMOKE TEST ===');
+  log(`Esperando marker ready de: ${components.join(', ')} (timeout ${args.timeoutMs / 1000}s)`);
+
+  // 1) Componentes listos — polling sobre los markers.
+  const start = Date.now();
+  const res = await waitForMarkers(components, args.timeoutMs, 1000);
+  const waitedSec = Math.round((Date.now() - start) / 1000);
+
+  // Log del estado final componente por componente.
+  for (const name of components) {
+    const st = res.results[name] || { state: 'missing' };
+    if (st.state === 'ready') {
+      log(`  OK ${name} (PID ${st.marker.pid}, ready en ${new Date(st.marker.readyAt).toTimeString().slice(0, 8)})`);
+    } else if (st.state === 'stale') {
+      log(`  STALE ${name} (PID ${st.marker?.pid || '?'} muerto — crash post-ready o no-arrancó)`);
+    } else {
+      log(`  MISSING ${name} (sin marker ready tras ${waitedSec}s — no completó init)`);
+    }
+  }
+
+  if (!res.ok) {
+    const bad = components.filter(n => res.results[n]?.state !== 'ready');
+    fail(`Componentes no-ready tras ${waitedSec}s: ${bad.join(', ')}`, 1);
+  }
+
+  // 2) Dashboard HTTP.
+  if (args.http) {
+    log('Verificando dashboard HTTP :3200...');
+    const dashPort = parseInt(process.env.DASHBOARD_PORT || '3200', 10);
+    const httpRes = await checkDashboardHttp(dashPort, 5000);
+    if (!httpRes.ok) {
+      fail(`Dashboard no responde en :${dashPort} (status=${httpRes.status})`, 2);
+    }
+    log(`  OK dashboard HTTP 200`);
+  }
+
+  // 3) last-restart.json.
+  const lastRestart = path.join(PIPELINE_DIR, 'last-restart.json');
+  if (!fs.existsSync(lastRestart)) {
+    fail('last-restart.json ausente', 3);
+  }
+  const ageSec = Math.round((Date.now() - fs.statSync(lastRestart).mtimeMs) / 1000);
+  if (ageSec > 300) {
+    log(`  WARN last-restart.json tiene ${ageSec}s (esperado < 300)`);
+  } else {
+    log(`  OK last-restart.json (${ageSec}s)`);
+  }
+
+  // 4) Huérfanos en commander/trabajando/ (solo warn).
+  const orphanDir = path.join(PIPELINE_DIR, 'servicios', 'commander', 'trabajando');
+  try {
+    if (fs.existsSync(orphanDir)) {
+      const orphans = fs.readdirSync(orphanDir).filter(f => f.endsWith('.json')).length;
+      if (orphans > 0) {
+        log(`  WARN ${orphans} mensaje(s) en commander/trabajando/ (esperado 0 post-restart)`);
+      }
+    }
+  } catch {}
+
+  log('=== SMOKE TEST OK ===');
+  process.exit(0);
+}
+
+main().catch(e => {
+  log(`Smoke test error: ${e.stack || e.message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Contexto

Cadena de fallos en restarts (últimos días): `smoke-test.sh` → exit 1 → `rollback.sh` → también falla. Los parches #2362/#2364/#2365/#2366/#2367 mitigaron síntomas pero no la causa raíz.

## Diagnóstico raíz

1. **Suicidio del parent**: `restart.js` queda vivo como parent de todo. Cuando `rollback.sh` ejecuta `taskkill //T` (tree-kill), se come a su propio parent y muere mid-ejecución. El hack `PARENT_RESTART_PID` es un parche del parche.
2. **Quoting wmic bajo `cmd.exe /c`**: toda la cadena bash+wmic+node depende de que las comillas sobrevivan a cmd.exe, lo cual es frágil. 4 PRs lo confirman.
3. **Discovery desde afuera**: smoke scanneaba el OS para ver si algo estaba vivo, en vez de que el componente reporte `ready`.
4. **Cobertura parcial**: smoke chequeaba 3 de 7 componentes.

## Rediseño

- `smoke-test.js` (161 líneas) — smoke en Node puro, chequea los 7 componentes vía ready-markers + HTTP 200.
- `rollback.js` (160 líneas) — rollback en Node puro, sin `taskkill //T` sobre el propio parent.
- `lib/ready-marker.js` (136 líneas) — cada componente escribe `ready/<nombre>.ready` cuando terminó warm-up. Discovery pasa a ser **pull**, no **scan**.
- `restart.js` refactorizado — invoca smoke/rollback en Node, no más bash+wmic+node nested.
- Los 7 servicios (pulpo, dashboard, listener, svc-telegram, svc-github, svc-drive, svc-emulador) instrumentados con `markReady()` al terminar su arranque.

## Validación

- `node -c` pasa en los 4 archivos nuevos/refactorizados.
- Smoke nuevo contra procesos vivos actuales → FAIL esperado (los procesos corriendo fueron lanzados con código viejo, sin ready-markers). Se estrenará en el próximo restart.

## Label

`qa:skipped` — cambio de infra del pipeline, sin impacto en producto de usuario final.

## Test plan

- [ ] Tras merge, ejecutar `/restart` y verificar que smoke pasa con los 7 componentes.
- [ ] Si smoke falla, rollback nuevo no debe matar a su propio parent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)