### PR TITLE
fix(pipeline): dns.resolve4 → dns.lookup en precheck

### DIFF
--- a/.pipeline/connectivity-precheck.js
+++ b/.pipeline/connectivity-precheck.js
@@ -146,9 +146,15 @@ async function retryWithBackoff(fn, {
 
 /**
  * Resuelve DNS del host con timeout explícito.
+ *
+ * Usa `dns.lookup` (getaddrinfo del OS) en vez de `dns.resolve4` (c-ares).
+ * Why: en Windows/entornos donde los DNS servers de Node quedan en 127.0.0.1
+ * sin resolver local, c-ares devuelve ECONNREFUSED aunque la red funcione.
+ * getaddrinfo respeta la resolución del sistema — misma fuente que curl/nslookup.
+ *
  * @param {string} host
  * @param {number} timeoutMs
- * @returns {Promise<string[]>} lista de IPs
+ * @returns {Promise<string[]>} lista de IPs v4
  */
 function resolveDnsWithTimeout(host, timeoutMs) {
   return new Promise((resolve, reject) => {
@@ -161,11 +167,18 @@ function resolveDnsWithTimeout(host, timeoutMs) {
       reject(e);
     }, timeoutMs);
 
-    dns.resolve4(host)
-      .then((addrs) => {
+    dns.lookup(host, { all: true, family: 4 })
+      .then((entries) => {
         if (settled) return;
         settled = true;
         clearTimeout(timer);
+        const addrs = (entries || []).map((e) => e.address).filter(Boolean);
+        if (addrs.length === 0) {
+          const e = new Error(`DNS lookup returned no A records for ${host}`);
+          e.code = 'ENOTFOUND';
+          reject(e);
+          return;
+        }
         resolve(addrs);
       })
       .catch((err) => {


### PR DESCRIPTION
## Resumen

Desbloquea el pipeline V2 que quedó atrapado rechazando todos los issues en precheck.

### Causa raíz

`connectivity-precheck.js` usa `dns.resolve4()` (c-ares) que consulta contra los servidores DNS configurados en Node.js. En esta máquina, Node estaba apuntado a `127.0.0.1` sin resolver local → **ECONNREFUSED** cada ~40s aunque la red funciona bien.

Verificación: `curl https://api.github.com` → 200 OK, `nslookup api.github.com` → resuelve correctamente a través del DNS del OS.

### Fix

Cambiar a `dns.lookup(host, { all: true, family: 4 })` que usa `getaddrinfo` del sistema operativo. Coincide con el comportamiento de `curl` y el resto del stack.

### Validación

Precheck post-fix:
- ✅ DNS: github (api.github.com), AWS S3, API backend — todos resuelven en ~83ms
- ✅ TLS: handshakes exitosos contra los 3 endpoints → 89ms c/u
- ✅ Duración total: 600ms

El pulpo.log debería dejar de registrar precheck FAIL y lanzar los issues pendientes.

## Plan de tests

- [x] Verificación programática: `precheck.runPrecheck()` retorna `ok: true`
- [x] Verificación CLI: `node .pipeline/connectivity-precheck.js` con salida OK

Closes #2369

🤖 Generado con [Claude Code](https://claude.ai/claude-code)