### PR TITLE
fix(pipeline): routing-mismatch recovery — rechazos por 'fuera de alcance' vuelven a definicion

### DIFF
--- a/.pipeline/config.yaml
+++ b/.pipeline/config.yaml
@@ -52,6 +52,13 @@ concurrencia:
 # evitando que el backlog de desarrollo bloquee el avance de issues ya codificados.
 # Orden efectivo: entrega → aprobacion → verificacion → build → dev → validacion
 
+# Routing mismatch: cuántas veces puede un issue volver a definición por
+# "fuera de alcance" antes de escalar a humano. Evita bucles en casos raros
+# donde ningún agente encuentra su alcance. Al superar el budget se aplica
+# label `blocked:routing-manual` y se notifica por Telegram.
+routing:
+  max_bounces: 2
+
 # Intake: qué labels de GitHub disparan la entrada a cada pipeline
 intake:
   definicion:

--- a/.pipeline/lib/__tests__/routing-classifier.test.js
+++ b/.pipeline/lib/__tests__/routing-classifier.test.js
@@ -1,0 +1,80 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { classifyRoutingMismatch } = require('../routing-classifier');
+
+// Motivo real extraído del rechazo de #2334 por backend-dev (2026-04-20).
+const MOTIVO_2334 = `[backend-dev] Issue fuera de alcance de backend-dev. El alcance 100% declarado en el issue es Node.js del pipeline (.pipeline/servicio-telegram.js, .pipeline/servicio-drive.js, .pipeline/servicio-github.js, stream-filter sobre .pipeline/logs/, tests con node --test), que es dominio exclusivo del rol pipeline-dev segun .pipeline/roles/pipeline-dev.md. backend-dev solo implementa Ktor/Kotlin (./gradlew :backend:build, :users:build) y el issue no toca ningun archivo .kt. Accion correcta: agregar label "area:pipeline" al issue #2334 para que el Pulpo lo rutee a pipeline-dev.`;
+
+test('detecta "fuera de alcance" en motivo real de #2334', () => {
+  const r = classifyRoutingMismatch(MOTIVO_2334);
+  assert.equal(r.isRouting, true);
+  assert.equal(r.skillSugerido, 'pipeline-dev');
+  assert.equal(r.labelSugerido, 'area:pipeline');
+});
+
+test('detecta "out of scope" en inglés', () => {
+  const r = classifyRoutingMismatch('[android-dev] Out of scope — should route to backend-dev.');
+  assert.equal(r.isRouting, true);
+  assert.equal(r.skillSugerido, 'backend-dev');
+});
+
+test('detecta "corresponde a" con skill explícito', () => {
+  const r = classifyRoutingMismatch('Este issue corresponde a web-dev, no a backend-dev.');
+  assert.equal(r.isRouting, true);
+  assert.equal(r.skillSugerido, 'web-dev');
+});
+
+test('detecta "dominio exclusivo de X"', () => {
+  const r = classifyRoutingMismatch('Es dominio exclusivo del rol pipeline-dev según .pipeline/roles/.');
+  assert.equal(r.isRouting, true);
+  assert.equal(r.skillSugerido, 'pipeline-dev');
+});
+
+test('detecta sugerencia de label "agregar area:X"', () => {
+  const r = classifyRoutingMismatch('Agregar label "area:pipeline" al issue para que el Pulpo lo rutee correctamente.');
+  assert.equal(r.isRouting, true);
+  assert.equal(r.labelSugerido, 'area:pipeline');
+});
+
+test('NO es routing: motivo de infra (ECONNREFUSED)', () => {
+  const r = classifyRoutingMismatch('[backend-dev] ECONNREFUSED contra api.github.com — no puedo leer el issue.');
+  assert.equal(r.isRouting, false);
+  assert.equal(r.skillSugerido, null);
+  assert.equal(r.labelSugerido, null);
+});
+
+test('NO es routing: motivo de defecto de código real', () => {
+  const r = classifyRoutingMismatch('[tester] Test unitario fallido: expected true, got false en AuthServiceTest.kt:42.');
+  assert.equal(r.isRouting, false);
+});
+
+test('NO es routing: motivo de QA con screenshot faltante', () => {
+  const r = classifyRoutingMismatch('[ux] No se encontró video de QA en qa-2371.mp4 — no puedo evaluar la experiencia.');
+  assert.equal(r.isRouting, false);
+});
+
+test('robusto a input vacío o no-string', () => {
+  assert.equal(classifyRoutingMismatch('').isRouting, false);
+  assert.equal(classifyRoutingMismatch(null).isRouting, false);
+  assert.equal(classifyRoutingMismatch(undefined).isRouting, false);
+  assert.equal(classifyRoutingMismatch(123).isRouting, false);
+});
+
+test('isRouting=true pero sin skill extraíble (routing genérico)', () => {
+  const r = classifyRoutingMismatch('Fuera de alcance — no corresponde a este agente.');
+  assert.equal(r.isRouting, true);
+  assert.equal(r.skillSugerido, null);
+});
+
+test('skill extraído solo si es skill conocido (no falso positivo)', () => {
+  const r = classifyRoutingMismatch('Corresponde a un-skill-inventado-xyz.');
+  assert.equal(r.isRouting, true);
+  assert.equal(r.skillSugerido, null, 'no debería extraer skills desconocidos');
+});
+
+test('label extraído solo si es área conocida', () => {
+  const r = classifyRoutingMismatch('Fuera de alcance — agregar area:inventada.');
+  assert.equal(r.isRouting, true);
+  assert.equal(r.labelSugerido, null);
+});

--- a/.pipeline/lib/routing-classifier.js
+++ b/.pipeline/lib/routing-classifier.js
@@ -1,0 +1,114 @@
+// =============================================================================
+// routing-classifier.js — Clasificación de rechazos por routing mismatch
+//
+// Cuando un dev rechaza un issue por "fuera de alcance" (el issue no pertenece
+// a su dominio), el pulpo debe devolver el issue a definición en vez de
+// reencolarlo en el mismo dev → evita bucles hasta circuit breaker y consume
+// el motivo como feedback para re-clasificar correctamente.
+//
+// Este módulo detecta esos motivos y extrae, cuando el agente lo indica, el
+// skill/label sugeridos. No toma decisiones — solo extrae información.
+// =============================================================================
+
+// Patrones que indican que el agente considera el issue fuera de su alcance.
+// Listado ampliable: agregar patrones cuando aparezcan formas nuevas en logs.
+const ROUTING_PATTERNS = [
+  /fuera de alcance/i,
+  /fuera del alcance/i,
+  /out\s+of\s+scope/i,
+  /no\s+(es|son)\s+(de\s+)?(mi|nuestro)\s+(alcance|dominio|scope)/i,
+  /no\s+soy\s+el\s+agente\s+correcto/i,
+  /dominio\s+exclusivo\s+(del?\s+)?(rol\s+)?[\w-]+/i,
+  /corresponde\s+a\s+[\w-]+/i,
+  /(debe|debería|deberia)\s+ir\s+a\s+[\w-]+/i,
+  /(rutear|enrutar|re?direccionar)\s+(a|hacia)\s+[\w-]+/i,
+  /(este|el)\s+issue\s+(es|pertenece)\s+(al|del)?\s*(rol|dominio|skill|agente)?\s*[\w-]+/i,
+  /agregar\s+label\s+['"]?area:[\w-]+/i,
+];
+
+// Skills conocidos del pipeline (debe coincidir con config.yaml dev_skill_mapping).
+// Usado para validar que lo extraído es un skill real, no un falso positivo.
+const KNOWN_DEV_SKILLS = new Set([
+  'backend-dev',
+  'android-dev',
+  'web-dev',
+  'pipeline-dev',
+  'ios-dev',
+  'desktop-dev',
+]);
+
+// Áreas conocidas (labels area:*). Sincronizar con dev_skill_mapping del config.
+const KNOWN_AREAS = new Set([
+  'pipeline',
+  'infra',
+  'backend',
+  'web',
+  'productos',
+  'pedidos',
+  'carrito',
+  'pagos',
+  'seguridad',
+]);
+
+// Extrae el primer skill conocido mencionado en el texto.
+function extractSkillSugerido(motivo) {
+  if (!motivo || typeof motivo !== 'string') return null;
+  // Buscar patrones "corresponde a X", "rutear a X", "dominio exclusivo del rol X",
+  // "rol X", "agente X", o simplemente el skill mencionado directamente.
+  const re = /(?:corresponde\s+a|rutear\s+(?:a|hacia)|enrutar\s+(?:a|hacia)|dominio\s+exclusivo(?:\s+del?\s+rol)?|rol|agente|skill)\s+([a-z][\w-]+)/gi;
+  let m;
+  while ((m = re.exec(motivo)) !== null) {
+    const candidate = m[1].toLowerCase();
+    if (KNOWN_DEV_SKILLS.has(candidate)) return candidate;
+  }
+  // Fallback: buscar cualquier mención directa a un skill conocido en el texto.
+  for (const skill of KNOWN_DEV_SKILLS) {
+    const skillRe = new RegExp(`\\b${skill}\\b`, 'i');
+    if (skillRe.test(motivo)) return skill;
+  }
+  return null;
+}
+
+// Extrae el primer label area:X conocido mencionado en el texto.
+function extractLabelSugerido(motivo) {
+  if (!motivo || typeof motivo !== 'string') return null;
+  const re = /area:([\w-]+)/gi;
+  let m;
+  while ((m = re.exec(motivo)) !== null) {
+    const area = m[1].toLowerCase();
+    if (KNOWN_AREAS.has(area)) return `area:${area}`;
+  }
+  return null;
+}
+
+/**
+ * Clasifica un motivo de rechazo como routing-mismatch o no.
+ *
+ * @param {string} motivo Texto del motivo de rechazo escrito por el agente.
+ * @returns {{isRouting: boolean, skillSugerido: string|null, labelSugerido: string|null, pattern: string|null}}
+ */
+function classifyRoutingMismatch(motivo) {
+  const result = { isRouting: false, skillSugerido: null, labelSugerido: null, pattern: null };
+  if (!motivo || typeof motivo !== 'string') return result;
+
+  for (const pattern of ROUTING_PATTERNS) {
+    if (pattern.test(motivo)) {
+      result.isRouting = true;
+      result.pattern = pattern.source;
+      break;
+    }
+  }
+
+  if (result.isRouting) {
+    result.skillSugerido = extractSkillSugerido(motivo);
+    result.labelSugerido = extractLabelSugerido(motivo);
+  }
+
+  return result;
+}
+
+module.exports = {
+  classifyRoutingMismatch,
+  KNOWN_DEV_SKILLS,
+  KNOWN_AREAS,
+};

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -11,6 +11,7 @@ const { execSync, spawn } = require('child_process');
 const yaml = require('js-yaml');
 const dedupLib = require('./dedup-lib');
 const precheck = require('./connectivity-precheck');
+const { classifyRoutingMismatch } = require('./lib/routing-classifier');
 
 // Crash handlers — loguear y seguir vivo
 process.on('uncaughtException', (err) => {
@@ -1856,6 +1857,16 @@ function brazoBarrido(config) {
           const esReboteDeInfra = motivosClasificados.length > 0
             && motivosClasificados.every(m => m.clasificacion === 'infra');
 
+          // Routing mismatch: si el agente rechazó por "fuera de alcance",
+          // devolver el issue a definición con observaciones — el ruteo se
+          // reevalúa allá (Guru/PO/UX clasifican y aplican labels). NO consume
+          // budget del circuit breaker de dev (el defecto está en la clasificación
+          // inicial, no en el código). Usa budget separado `max_routing_bounces`.
+          const routingAnalisis = motivosClasificados
+            .map(m => ({ skill: m.skill, motivo: m.motivo, ...classifyRoutingMismatch(m.motivo) }))
+            .filter(m => m.isRouting);
+          const esRoutingMismatch = !esReboteDeInfra && routingAnalisis.length > 0;
+
           // Circuit breaker: leer rebote_numero del archivo que originó este ciclo
           // (puede estar en trabajando/ o pendiente/ de la fase de rechazo, o en el propio resultado)
           // Buscar el máximo rebote_numero entre los archivos del issue en dev
@@ -1887,6 +1898,119 @@ function brazoBarrido(config) {
               const dest = path.join(fasePath(pipelineName, fase), 'procesado');
               try { moveFile(a.path, dest); } catch {}
             }
+            continue;
+          }
+
+          // --- ROUTING MISMATCH: devolver a definición en vez de reencolar aquí ---
+          if (esRoutingMismatch) {
+            // Contar rebotes previos de routing (separados del contador de código)
+            let routingBounces = 0;
+            const defFases = (config.pipelines && config.pipelines.definicion && config.pipelines.definicion.fases) || [];
+            for (const dFase of defFases) {
+              for (const estado of ['pendiente', 'trabajando', 'procesado']) {
+                const dir = path.join(fasePath('definicion', dFase), estado);
+                try {
+                  for (const f of fs.readdirSync(dir)) {
+                    if (f.startsWith(issue + '.')) {
+                      const data = readYaml(path.join(dir, f));
+                      if (data && data.rebote_tipo === 'routing' && data.rebote_routing_numero > routingBounces) {
+                        routingBounces = data.rebote_routing_numero;
+                      }
+                    }
+                  }
+                } catch {}
+              }
+            }
+
+            const MAX_ROUTING_BOUNCES = (config.routing && config.routing.max_bounces) || 2;
+            const nuevoRoutingBounces = routingBounces + 1;
+
+            // Consolidar motivo + sugerencias del agente
+            const motivosRouting = routingAnalisis.map(m => `[${m.skill}] ${m.motivo}`).join('\n');
+            const skillSugerido = routingAnalisis.find(m => m.skillSugerido)?.skillSugerido || null;
+            const labelSugerido = routingAnalisis.find(m => m.labelSugerido)?.labelSugerido || null;
+
+            if (nuevoRoutingBounces > MAX_ROUTING_BOUNCES) {
+              log('routing', `⛔ #${issue} BUDGET AGOTADO — ${nuevoRoutingBounces}/${MAX_ROUTING_BOUNCES} rebotes por routing. Escalando a humano.`);
+              sendTelegram(`⛔ Issue #${issue} — ${nuevoRoutingBounces} rebotes por routing mismatch. Ningún agente encuentra su alcance. Requiere reclasificación manual.\n\nÚltimo motivo:\n${motivosRouting.slice(0, 500)}`);
+              // Encolar en servicio-github: label blocked:routing-manual
+              try {
+                const ghQueueDir = path.join(PIPELINE, 'servicios', 'github', 'pendiente');
+                fs.mkdirSync(ghQueueDir, { recursive: true });
+                const labelFile = path.join(ghQueueDir, `${issue}-blocked-routing-${Date.now()}.json`);
+                fs.writeFileSync(labelFile, JSON.stringify({ action: 'label', issue: parseInt(issue), label: 'blocked:routing-manual' }));
+              } catch (e) {
+                log('routing', `Error encolando label blocked:routing-manual: ${e.message}`);
+              }
+              // Archivos actuales se mueven a procesado/ al cerrar el loop — no continuar en pipeline
+              continue;
+            }
+
+            // Mover issue a definicion/analisis/pendiente para que Guru/Security reanalicen.
+            // Los skills de la fase `analisis` los define config.yaml.
+            const analisisPendiente = path.join(fasePath('definicion', 'analisis'), 'pendiente');
+            fs.mkdirSync(analisisPendiente, { recursive: true });
+            const analisisSkills = (config.pipelines.definicion.skills_por_fase || {}).analisis || ['guru'];
+            for (const skill of analisisSkills) {
+              const dst = path.join(analisisPendiente, `${issue}.${skill}`);
+              writeYaml(dst, {
+                issue: parseInt(issue),
+                fase: 'analisis',
+                pipeline: 'definicion',
+                rebote: true,
+                rebote_tipo: 'routing',
+                rebote_routing_numero: nuevoRoutingBounces,
+                motivo_rechazo: motivosRouting,
+                skill_sugerido: skillSugerido,
+                label_sugerido: labelSugerido,
+                rechazado_desde_pipeline: pipelineName,
+                rechazado_desde_fase: fase,
+                rechazado_por: routingAnalisis.map(m => m.skill).join(','),
+              });
+            }
+
+            log('routing', `#${issue} RECHAZO por routing mismatch en ${pipelineName}/${fase} → devuelto a definicion/analisis (bounce ${nuevoRoutingBounces}/${MAX_ROUTING_BOUNCES}${skillSugerido ? `, skill sugerido: ${skillSugerido}` : ''}${labelSugerido ? `, label sugerido: ${labelSugerido}` : ''})`);
+
+            // Cleanup: archivar archivos del issue en TODAS las fases del pipeline origen
+            // (no solo las posteriores — también las anteriores, porque el issue ya no pertenece a este pipeline).
+            for (const otraFase of fases) {
+              if (otraFase === fase) continue; // los de la fase actual los mueve el loop al final
+              for (const estado of ['pendiente', 'trabajando', 'listo']) {
+                const dir = path.join(fasePath(pipelineName, otraFase), estado);
+                try {
+                  for (const f of fs.readdirSync(dir)) {
+                    if (f.startsWith(issue + '.') && !f.startsWith('.')) {
+                      const src = path.join(dir, f);
+                      const archDir = path.join(fasePath(pipelineName, otraFase), 'archivado');
+                      fs.mkdirSync(archDir, { recursive: true });
+                      moveFile(src, archDir);
+                      log('routing', `#${issue} cleanup: ${otraFase}/${estado}/${f} → archivado/`);
+                    }
+                  }
+                } catch {}
+              }
+            }
+
+            // Comentario en GitHub para auditoría
+            const bodyAuditoria = [
+              `🔀 **Reclasificación automática** — ${routingAnalisis[0].skill} en \`${pipelineName}/${fase}\` reportó que este issue está fuera de su alcance.`,
+              '',
+              `Se devolvió a \`definicion/analisis\` para re-triaje por Guru${analisisSkills.includes('security') ? '/Security' : ''} (bounce ${nuevoRoutingBounces}/${MAX_ROUTING_BOUNCES}).`,
+              '',
+              skillSugerido ? `**Skill sugerido por el agente:** \`${skillSugerido}\`` : null,
+              labelSugerido ? `**Label sugerido:** \`${labelSugerido}\`` : null,
+              '',
+              '<details><summary>Motivo completo del rechazo</summary>',
+              '',
+              '```',
+              motivosRouting.slice(0, 1500),
+              '```',
+              '</details>',
+              '',
+              `_Este rebote NO consume budget del circuit breaker de código._`,
+            ].filter(x => x !== null).join('\n');
+            ghCommentOnIssue(issue, bodyAuditoria);
+
             continue;
           }
 


### PR DESCRIPTION
## Resumen

Agrega detección y recuperación automática de **routing mismatches**: cuando un dev rechaza un issue por estar fuera de su alcance (ej: backend-dev recibe issue de pipeline Node.js), el Pulpo devuelve el issue a `definicion/analisis` con metadata de sugerencia, en lugar de reencolarlo hasta agotar el circuit breaker.

### Contexto

Issue #2334 fue rechazado por backend-dev con motivo "fuera de alcance — corresponde a pipeline-dev". Sin este fix, el issue rebota contra el mismo dev 3 veces y queda bloqueado sin que Guru/PO/UX tengan chance de re-clasificarlo.

### Cambios

- **`lib/routing-classifier.js` (nuevo)**: módulo puro que clasifica motivos contra 10+ patrones de "out of scope" (ES/EN). Extrae skill y label sugeridos validados contra listas conocidas.
- **`lib/__tests__/routing-classifier.test.js` (nuevo)**: 12 tests con `node --test`, incluye el motivo real de #2334 como fixture.
- **`pulpo.js`**: agrega rama de recuperación routing-mismatch antes del circuit breaker de código. Cuenta rebotes de routing por separado, respeta `config.routing.max_bounces` (default 2), devuelve a definición con metadata rica (skill_sugerido, label_sugerido, rechazado_desde_pipeline/fase/por), limpia archivos de todas las fases origen y comenta en GitHub con audit trail. Superar budget → label `blocked:routing-manual` + alerta Telegram.
- **`config.yaml`**: sección `routing: { max_bounces: 2 }`.

## Plan de tests

- [x] Tests unitarios pasan (`node --test .pipeline/lib/__tests__/routing-classifier.test.js` → 12/12)
- [x] Sintaxis de `pulpo.js` OK (`node -c`)
- [ ] Validación en runtime: próximo ciclo del Pulpo debería detectar rebotes routing y devolver a definición

## QA

`qa:skipped` — Cambio puro de infra del pipeline Node.js (sin impacto en backend Kotlin ni apps). No hay flujo de usuario que validar con video. El comportamiento se valida con tests unitarios + observación del pipeline en producción.

🤖 Generado con [Claude Code](https://claude.ai/claude-code)