### PR TITLE
fix(pipeline): delivery timeout 30->90min (evita rebote infra falso por CI largo)

### DIFF
--- a/.pipeline/config.yaml
+++ b/.pipeline/config.yaml
@@ -178,6 +178,7 @@ timeouts:
     build: 60                     # Gradle check + assemble puede tardar mucho en primer build
     qa: 45                        # QA E2E con emulador + video
     tester: 45                    # Cobertura Kover + suite completa
+    delivery: 90                  # Espera CI completo (OWASP ~28min, check-app ~15min) + gate de review + merge + reporte
 
 # GitHub
 github:


### PR DESCRIPTION
## Resumen

Aumenta el watchdog timeout del skill `delivery` de 30min (default) a 90min. El flujo completo de delivery requiere esperar CI que tarda mucho más que 30min.

## Contexto

**Incidente 2026-04-20:** El delivery de #2159 murió a los 30 min justo cuando OWASP Dependency Check completaba (28m9s). El Pulpo clasificó el rechazo como rebote infra y devolvió el issue a `dev/pendiente/2159.backend-dev`, provocando un re-run innecesario de todo el pipeline de desarrollo. El PR #2372 quedó OPEN con todos los checks pass y nadie hizo el merge.

## Por qué 90 minutos

Desglose de tiempos observados en #2159:
- OWASP Dependency Check: ~28 min
- check-app (Android build): ~15 min
- Semgrep + detect-secrets + verify-strings: <3 min
- Gate de review (con hasta 2 reintentos + dev-skill fix): varios minutos
- Merge + delete-branch + reporte Telegram: ~30 seg

Total en worst case: ~50-60 min + margen de seguridad = 90 min.

## Cambios

- `.pipeline/config.yaml`: agrega `delivery: 90` al `agent_timeout_overrides`

## Relacionado

- **#2374** (fix completo): diferenciar rebote infra vs código, preservar agentes en restart/pause, reintentar misma fase ante timeouts
- **#2159** (incidente): delivery muerto por timeout, re-run innecesario
- **PR #2372** (afectado): quedó OPEN sin merge por este bug

## Plan de tests

- [x] Sintaxis YAML validada
- [ ] Próximo delivery del pipeline debe respetar 90 min de watchdog

## QA

`qa:skipped` — Cambio puro de configuración del pipeline Node.js (1 línea). Sin impacto en backend Kotlin ni apps.

🤖 Generado con [Claude Code](https://claude.ai/claude-code)