### PR TITLE
feat(pipeline): retrying-state + choreografia FS-first + metricas UX (#2337)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,4 +135,7 @@ scripts/planner-plan.json
 .pipeline/infra-health.json
 .pipeline/events/
 .pipeline/tmp/
+# #2337 — estado reintentando + metricas UX rotadas (no comitear)
+.pipeline/retrying-state.json
+.pipeline/metrics/
 !.pipeline/**/.gitkeep

--- a/.pipeline/dashboard-v2.js
+++ b/.pipeline/dashboard-v2.js
@@ -17,6 +17,11 @@ const {
   pidAlive,
   invalidateCache,
 } = require('./pid-discovery');
+// #2337 CA8 — estado `reintentando` (anti-parpadeo FS-driven).
+// Best-effort require: si el modulo no existe (pipeline antiguo), degradamos
+// silenciosamente sin el estado `retrying`.
+let retryingState = null;
+try { retryingState = require('./retrying-state'); } catch { /* opcional */ }
 
 const PORT = parseInt(process.env.DASHBOARD_PORT) || 3200;
 const PIPELINE = process.env.PIPELINE_STATE_DIR || path.resolve(__dirname);
@@ -323,6 +328,24 @@ function getPipelineState() {
   const missing = issueIds.filter(id => !titleCache[id]);
   if (missing.length > 0) fetchIssueTitles(missing, titleCache);
   state.issueTitles = titleCache;
+
+  // #2337 CA8 — snapshot del estado `reintentando` activo en este refresh.
+  // Timestamp absoluto (`retryingUntil`) persiste el anti-parpadeo entre
+  // refreshes consecutivos del dashboard.
+  /**
+   * @typedef {Object} RetryingState
+   * @property {number} retryingUntil  epoch ms hasta mostrar como reintentando (anti-parpadeo 2s)
+   * @property {string} reason         causa del retry: "connectivity_restored" | otros futuros
+   * @property {number} since          epoch ms de inicio del estado
+   * @property {string} [previousState] estado previo para trazabilidad: "blocked:infra" | otros
+   */
+  const retryingMap = (() => {
+    if (!retryingState || typeof retryingState.getActiveRetrying !== 'function') return {};
+    try { return retryingState.getActiveRetrying({ now: Date.now() }); }
+    catch { return {}; }
+  })();
+  state.retrying = retryingMap;
+
   for (const [id, data] of Object.entries(state.issueMatrix)) {
     data.pipelines = [...data.pipelines];
     data.title = titleCache[id]?.title || '';
@@ -341,6 +364,10 @@ function getPipelineState() {
       data.staleMin = workingEntry?.ageMin || 0;
     } else {
       data.staleMin = 0;
+    }
+    // #2337 CA8 — enriquecer con ventana `retrying` si aplica
+    if (retryingMap[id]) {
+      data.retrying = retryingMap[id];
     }
   }
 
@@ -1437,7 +1464,12 @@ function generateHTML(state) {
     const isStale = data.staleMin > 30;
     const isBlocked = blockedBy != null;
     const blocksSomething = blocksOthers.length > 0;
+    // #2337 CA8 — ventana `reintentando` activa: timestamp absoluto compara vs
+    // momento del render. Durante esta ventana el visual override es `lc-retrying`,
+    // aunque el estado real sea `trabajando` (CA7.4 anti-parpadeo).
+    const isRetrying = !!(data.retrying && Number(data.retrying.retryingUntil) > Date.now());
     const laneCardCls = complete ? 'lc-done'
+      : isRetrying ? 'lc-retrying'
       : isStale ? 'lc-stale'
       : hasRejection ? 'lc-failed'
       : isBlocked ? 'lc-blocked'
@@ -1496,6 +1528,19 @@ function generateHTML(state) {
       const blockTxt = blocksOthers.map(d => `#${d}`).join(', ');
       lcBlockIcons += `<span class="lc-block-icon lc-block-blocking" title="Bloquea a: ${blockTxt}" onclick="event.stopPropagation()">⛓</span>`;
     }
+    // #2337 CA8 — icono `🔁` durante la ventana `reintentando`. El estado es
+    // mutuamente excluyente con `blocked`, asi que no aparecen los dos iconos
+    // a la vez. Aria-label con timestamp legible. Escape via textContent-safe
+    // (valores server-generated, sin input de usuario — REQ-SEC-1).
+    let lcRetryingIcon = '';
+    if (isRetrying) {
+      const since = Number(data.retrying.since) || Date.now();
+      const sinceIso = new Date(since).toISOString().slice(11, 19); // HH:MM:SS UTC
+      const ariaLabel = `Reintentando tras recuperacion de red desde ${sinceIso}`;
+      const tooltipText = `Reintentando tras recuperacion de red (desde ${sinceIso})`;
+      lcRetryingIcon = `<span class="lc-retry-icon" role="img" aria-hidden="true">🔁</span>`
+        + `<span class="lc-retry-label" role="status" aria-label="${ariaLabel}" title="${tooltipText}" tabindex="0" onclick="event.stopPropagation()"></span>`;
+    }
     const laneTitle = (data.title || `Issue #${issueNum}`).replace(/"/g, '&quot;');
     const flagSpan = data.staleMin > 60 ? '<span class="lc-flag">🚩</span>' : '';
     // Data atributos para búsqueda client-side
@@ -1518,12 +1563,12 @@ function generateHTML(state) {
     } else {
       priority = 10000 - pulpoScore;
     }
-    const cardHTML = `<div class="lc-card ${laneCardCls}" data-issue="${issueNum}" data-status="${complete ? 'completed' : 'active'}" data-subfase="${currentFase}" data-search="${searchKey}" title="${laneTitle}">
+    const cardHTML = `<div class="lc-card ${laneCardCls}" data-issue="${issueNum}" data-status="${complete ? 'completed' : 'active'}" data-subfase="${currentFase}" data-search="${searchKey}" data-retrying-until="${isRetrying ? Number(data.retrying.retryingUntil) : ''}" title="${laneTitle}" aria-live="polite">
       <div class="lc-card-main">
         <div class="lc-top">
           <div class="lc-top-left">
             <a class="lc-num" href="${GH(issueNum)}" target="_blank" title="Ver issue en GitHub" onclick="event.stopPropagation()">#${issueNum}</a>
-            ${lcBlockIcons}
+            ${lcBlockIcons}${lcRetryingIcon}
           </div>
           <div class="lc-top-right">
             <span class="lc-elapsed ${laneElapsedCls}">${laneElapsedTxt}</span>
@@ -2205,6 +2250,11 @@ function generateHTML(state) {
   --rd:#f85149;--rd2:#8b1a14;
   --or:#db6d28;--or2:#7d3410;
   --pu:#bc8cff;
+  /* #2337 CA8 — ambar dorado para estado reintentando.
+   * Diferenciado del amarillo --yl (stale). Contraste >=5.2:1 sobre --sf
+   * (ver analisis guru/UX). Seguro en protanopia/deuteranopia con emoji
+   * flechas circulares como discriminador de forma. */
+  --retry:#F59E0B;
   --radius:10px;--radius-sm:6px;
 }
 /* ── Reset ──────────────────────────────────────────────────────────────── */
@@ -3390,6 +3440,36 @@ a.skill-recent-item:hover{background:var(--bd2);color:var(--ac)}
 .lc-card.lc-stale{border-left-color:var(--yl);background:linear-gradient(90deg,rgba(251,191,36,0.04),var(--sf) 30%)}
 .lc-card.lc-blocked{border-left-color:var(--rd);background:linear-gradient(90deg,rgba(248,113,113,0.03),var(--sf) 30%)}
 .lc-card.lc-done{border-left-color:var(--gn);opacity:0.75}
+/* #2337 CA8 — estado reintentando. Ambar dorado (--retry), fade 400ms en
+ * transiciones (bloqueado->reintentando y reintentando->en-curso). */
+.lc-card.lc-retrying{
+  border-left-color:var(--retry);
+  background:linear-gradient(90deg,rgba(245,158,11,0.07),var(--sf) 35%);
+  transition:background 400ms ease,border-color 400ms ease;
+}
+.lc-card.lc-retrying .lc-retry-icon{
+  display:inline-block;font-size:0.95em;line-height:1;margin-left:3px;color:var(--retry);
+  animation:retrySpin 1.8s linear infinite;
+  /* Anti-urgencia: no se vuelve opaco ni parpadea — solo rota suave */
+}
+@keyframes retrySpin{from{transform:rotate(0deg)}to{transform:rotate(360deg)}}
+/* CA8 — respetar prefers-reduced-motion para usuarios con trastornos
+ * vestibulares o TDAH: fallback estatico con borde punteado. */
+@media (prefers-reduced-motion: reduce){
+  .lc-card.lc-retrying .lc-retry-icon{animation:none}
+  .lc-card.lc-retrying{border-left-style:dashed}
+}
+/* CA8 — label oculto a la vista pero alcanzable por lector de pantalla y
+ * focus por teclado (para tooltip accesible via :focus-visible). */
+.lc-card.lc-retrying .lc-retry-label{
+  display:inline-block;width:0;height:0;overflow:hidden;color:transparent;
+  outline:none;
+}
+.lc-card.lc-retrying .lc-retry-label:focus-visible{
+  width:auto;height:auto;color:var(--retry);outline:2px solid var(--retry);
+  outline-offset:2px;margin-left:4px;padding:0 4px;border-radius:4px;
+  background:rgba(245,158,11,0.1);
+}
 .lc-card.lc-filtered-out-sub,.lc-card.lc-filtered-out-search,.lc-card.lc-filtered-blocked{display:none}
 .lc-card.lc-hl-blocked{border-left-color:var(--rd) !important;box-shadow:0 0 0 1px rgba(248,113,113,0.5)}
 .lc-card.lc-hl-blocking{border-left-color:var(--yl) !important;box-shadow:0 0 0 1px rgba(251,191,36,0.5)}

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -16,9 +16,16 @@ const precheck = require('./connectivity-precheck');
 // comentarios automáticos que quedan públicos en el issue.
 const { sanitize: sanitizePipelineText } = require('./sanitizer');
 const connectivityState = require('./connectivity-state'); // #2335
+const retryingState = require('./retrying-state');         // #2337 CA7/CA8
+const uxMetrics = require('./ux-metrics');                 // #2337 CA10
+let notifierInfraRecovered = null;                         // #2336 (lazy require)
+try { notifierInfraRecovered = require('./notifier-infra-recovered'); } catch { /* opcional */ }
 const { classifyRoutingMismatch } = require('./lib/routing-classifier');
 const cbInfra = require('./circuit-breaker-infra');
 const { redact } = require('./redact');
+
+// #2337 CA10: cleanup perezoso + startup de metricas UX (REQ-SEC-5)
+try { uxMetrics.cleanup({ force: true }); } catch { /* best-effort */ }
 
 // Crash handlers — loguear y seguir vivo
 process.on('uncaughtException', (err) => {
@@ -192,7 +199,10 @@ async function ejecutarPrecheck(config) {
       }
     } else if (previousOk === false) {
       log('precheck', `🟢 precheck OK — infra recuperada (durationMs=${result.durationMs})`);
-      try { sendTelegram(`🟢 Infra recuperada. Reencolando issues bloqueados por red.`); } catch {}
+      // #2337 CA7: NO enviar Telegram aqui — la choreografia FS-first exige que
+      // el estado `reintentando` se escriba en disco ANTES de encolar cualquier
+      // cmd.json de Telegram. Eso lo hace `reencolarInfraBloqueados` unas lineas
+      // mas abajo en el mismo tick, con orden estricto: FS -> Telegram.
     }
 
     return result;
@@ -296,16 +306,36 @@ function marcarBloqueoInfra(workFilePath, issue, skill, fase, precheckResult) {
 /**
  * Cuando el precheck vuelve a estar OK después de un fallo, recorre las
  * carpetas pendiente/ de todas las fases y re-habilita los archivos marcados
- * con `rebote_tipo: infra` (limpia el flag para que el próximo barrido/launch
- * los tome normalmente). Criterio #7 del issue #2317.
+ * con `rebote_tipo: infra`. Criterio #7 del issue #2317.
+ *
+ * #2337 CA7 — Choreografia temporal FS-first:
+ *
+ *   Orden estricto en el MISMO tick (sin async yield entre fases):
+ *     1. Scan: recolectar issues bloqueados por infra (sin side-effects).
+ *     2. FS-FIRST: escribir `retryingUntil` en `retrying-state.json` (state
+ *        sync visible para el dashboard con ventana anti-parpadeo de 2s).
+ *     3. YAML: limpiar markers de infra en los work files (issues launchable).
+ *     4. Telegram: encolar cmd.json via `notifier-infra-recovered` (fallback
+ *        a `sendTelegram` directo si el notifier no esta disponible).
+ *     5. Cleanup: limpiar `blocked-by-infra.json` + set en memoria.
+ *     6. Metricas: persistir entrada append-only en `.pipeline/metrics/`.
+ *
+ *   Si el proceso crashea entre (2) y (4): el dashboard ya muestra `reintentando`,
+ *   el Telegram no se envio; el siguiente ciclo (tras restart) re-detecta los
+ *   issues con rebote_tipo=infra persistidos y vuelve a correr (REQ-SEC-6).
+ *
+ *   Si crashea entre (4) y (6): metrica perdida pero el efecto ya aplico,
+ *   aceptable porque la captura es best-effort (no afecta la experiencia).
  */
 function reencolarInfraBloqueados(config) {
   if (!precheckOk()) return;
   if (lastInfraBlockedIssues.size === 0) return; // Nada que reencolar
 
+  const tickStartMs = Date.now();
   const pipelines = Object.keys(config.pipelines || {});
-  const reencolados = [];
 
+  // ── Fase 1 — Scan: recolectar archivos candidatos SIN escribir ────────
+  const candidatos = []; // [{ path, data, issue, cleaned }]
   for (const pipelineName of pipelines) {
     const pipelineConfig = config.pipelines[pipelineName];
     for (const fase of pipelineConfig.fases || []) {
@@ -317,8 +347,6 @@ function reencolarInfraBloqueados(config) {
         try { data = readYaml(a.path); } catch { continue; }
         if (data && data.rebote_tipo === 'infra') {
           const issue = issueFromFile(a.name);
-          // Limpiar los markers de infra; preservamos rebote_numero para que
-          // un posible rebote de código (anterior) siga contando normal.
           const cleaned = { ...data };
           delete cleaned.rebote_tipo;
           delete cleaned.bloqueado_por_infra;
@@ -326,30 +354,127 @@ function reencolarInfraBloqueados(config) {
           delete cleaned.infra_motivo;
           delete cleaned.infra_endpoints_fallidos;
           cleaned.infra_reencolado_en = new Date().toISOString();
-          try {
-            writeYaml(a.path, cleaned);
-            reencolados.push(issue);
-          } catch (e) {
-            log('precheck', `Error reencolando #${issue}: ${e.message}`);
-          }
+          candidatos.push({ path: a.path, cleaned, issue });
         }
       }
     }
   }
 
-  if (reencolados.length > 0) {
-    const unicos = Array.from(new Set(reencolados));
-    log('precheck', `🟢 Reencolados por infra recuperada: ${unicos.map(i => `#${i}`).join(', ')}`);
-    for (const issue of unicos) {
-      ghCommentOnIssue(issue, `🟢 Infra #2314 restaurada — reintentando automáticamente.`);
+  if (candidatos.length === 0) {
+    // Aun asi limpiar el set en memoria y blocked-by-infra.json
+    lastInfraBlockedIssues.clear();
+    try {
+      connectivityState.clearBlockedIssues({
+        type: 'connectivity_restored',
+        ts: new Date().toISOString(),
+      });
+    } catch (e) {
+      log('precheck', `No se pudo limpiar blocked-by-infra.json: ${connectivityState.sanitizeForLog(e.message)}`);
+    }
+    return;
+  }
+
+  const issueNumbers = Array.from(new Set(candidatos.map((c) => parseInt(c.issue, 10))))
+    .filter((n) => Number.isFinite(n) && n > 0);
+
+  // ── Fase 2 — FS-FIRST: marcar estado `reintentando` antes que cualquier Telegram ──
+  let tsDashboardUpdate = tickStartMs;
+  let retryingUntil = tickStartMs + retryingState.DEFAULT_MIN_RETRY_MS;
+  try {
+    const result = retryingState.markRetrying(issueNumbers, {
+      now: tickStartMs,
+      reason: 'connectivity_restored',
+      previousState: 'blocked:infra',
+    });
+    retryingUntil = result.retryingUntil;
+    tsDashboardUpdate = Date.now();
+    log('precheck', `🟡 retrying-state escrito (issues=${issueNumbers.length}, until=+${retryingUntil - tickStartMs}ms) [FS-first]`);
+  } catch (e) {
+    log('precheck', `No se pudo escribir retrying-state: ${connectivityState.sanitizeForLog(e.message)}`);
+  }
+
+  // ── Fase 3 — YAML: limpiar markers de infra en cada archivo ───────────
+  const reencolados = [];
+  for (const c of candidatos) {
+    try {
+      // Anotar la ventana `reintentando` en el propio work file para que otros
+      // consumidores (dashboard, diagnosticos) puedan leerlo sin consultar el
+      // state global. Campo no obligatorio, solo metadata.
+      c.cleaned.retrying_until_ms = retryingUntil;
+      c.cleaned.retrying_since_ms = tickStartMs;
+      writeYaml(c.path, c.cleaned);
+      reencolados.push(c.issue);
+    } catch (e) {
+      log('precheck', `Error reencolando #${c.issue}: ${e.message}`);
     }
   }
 
-  // Limpiar el set de issues notificados (ya los reencolamos)
-  lastInfraBlockedIssues.clear();
+  const unicos = Array.from(new Set(reencolados));
+  log('precheck', `🟢 Reencolados por infra recuperada: ${unicos.map((i) => `#${i}`).join(', ')}`);
 
-  // #2335 — limpiar blocked-by-infra.json con el evento de recuperacion.
-  // El event log ya lo escribio `recordProbeResult` tras la transicion FAIL→OK.
+  // ── Fase 4 — Telegram: encolar cmd.json DESPUES del FS ────────────────
+  //
+  // Prioridad:
+  //   a) notifier-infra-recovered (#2336): mensaje unico consolidado con
+  //      variante rotable, MarkdownV2 escapado, dedup y rate-limit TTS.
+  //   b) sendTelegram simple como fallback (si #2336 no esta disponible).
+  let varianteMensaje = null;
+  let tsTelegramDelivered = null;
+  let rateLimitAlcanzado = null;
+  (async () => {
+    const recoveredEvent = {
+      type: 'connectivity_restored',
+      ts: new Date(tickStartMs).toISOString(),
+      requeued: { count: unicos.length, issues: unicos.map((n) => parseInt(n, 10)) },
+    };
+    try {
+      if (notifierInfraRecovered && typeof notifierInfraRecovered.notify === 'function') {
+        const res = await notifierInfraRecovered.notify(recoveredEvent, {
+          botToken: getTelegramToken(),
+          chatId: getTelegramChatId(),
+        });
+        tsTelegramDelivered = Date.now();
+        if (res && res.sent) {
+          // Extraer id corto del mensaje para la metrica (REQ-SEC-3: nunca el texto).
+          varianteMensaje = res.dedupHash ? `hash:${String(res.dedupHash).slice(0, 8)}` : 'variant:unknown';
+          if (res.rateLimitReason === 'per-issue' || res.rateLimitReason === 'global') {
+            rateLimitAlcanzado = res.rateLimitReason === 'per-issue' ? 'issue' : 'global';
+          }
+        }
+      } else {
+        sendTelegram('🟢 Infra recuperada. Reencolando issues bloqueados por red.');
+        tsTelegramDelivered = Date.now();
+        varianteMensaje = 'fallback:simple';
+      }
+    } catch (e) {
+      log('precheck', `Error notificando recuperacion de infra: ${connectivityState.sanitizeForLog(e.message)}`);
+    }
+
+    // Comentarios por issue via gh CLI (idempotente — solo la 1ra vez por run).
+    for (const issue of unicos) {
+      try { ghCommentOnIssue(issue, `🟢 Infra #2314 restaurada — reintentando automáticamente.`); } catch { /* best-effort */ }
+    }
+
+    // ── Fase 6 — Metricas UX (CA10) append-only ────────────────────────
+    try {
+      uxMetrics.appendMetric({
+        event: 'connectivity_restored',
+        timestamp_event: tickStartMs,
+        timestamp_dashboard_update: tsDashboardUpdate,
+        timestamp_telegram_delivered: tsTelegramDelivered,
+        variante_mensaje: varianteMensaje,
+        issues_reencolados: unicos.length,
+        rate_limit_alcanzado: rateLimitAlcanzado,
+        previous_state: 'blocked:infra',
+        retrying_window_ms: retryingState.DEFAULT_MIN_RETRY_MS,
+      });
+    } catch (e) {
+      log('precheck', `No se pudo escribir metrica UX: ${connectivityState.sanitizeForLog(e.message)}`);
+    }
+  })().catch((err) => log('precheck', `async notify/metrics error: ${err.message}`));
+
+  // ── Fase 5 — Cleanup: memoria + blocked-by-infra.json ─────────────────
+  lastInfraBlockedIssues.clear();
   try {
     connectivityState.clearBlockedIssues({
       type: 'connectivity_restored',

--- a/.pipeline/retrying-state.js
+++ b/.pipeline/retrying-state.js
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+// =============================================================================
+// retrying-state.js — Estado `reintentando` por issue (#2337, CA7/CA8).
+//
+// Persiste en `.pipeline/retrying-state.json` la ventana de anti-parpadeo
+// (`retryingUntil`) + metadata del ultimo transicion. Lo consume:
+//   - pulpo.js: al reencolar issues tras `connectivity_restored`, escribe
+//     `retryingUntil = now + MIN_RETRY_MS` ANTES de encolar el cmd.json de
+//     Telegram (orden FS-first CA7.1 / REQ-SEC-6).
+//   - dashboard-v2.js: al renderizar lane cards, chequea si el issue esta
+//     en ventana `retrying` (mientras `now < retryingUntil`) y aplica el
+//     estado visual `lc-retrying` (CA8).
+//
+// Schema (versionado para forward-compat con hija B de #2319):
+//
+//   {
+//     "version": 1,
+//     "issues": {
+//       "<number>": {
+//         "retryingUntil": <epoch ms>,
+//         "since":         <epoch ms>,
+//         "reason":        "connectivity_restored" | ...,
+//         "previousState": "blocked:infra" | ...
+//       }
+//     },
+//     "lastUpdate": <epoch ms>
+//   }
+//
+// Anti-parpadeo: la ventana default es 2000ms (CA7.4). Se calcula
+// server-side con timestamp absoluto para que el dashboard pueda refrescar
+// sin perder la transicion.
+// =============================================================================
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const PIPELINE_DIR = path.resolve(__dirname);
+const DEFAULT_STATE_FILE = path.join(PIPELINE_DIR, 'retrying-state.json');
+const SCHEMA_VERSION = 1;
+
+// CA7.4: ventana minima visible del estado `reintentando`.
+// 2000ms por guideline PO; configurable para tests/smoke.
+const DEFAULT_MIN_RETRY_MS = 2000;
+
+// Razones conocidas (enum abierto — se podran agregar mas)
+const REASON_CONNECTIVITY_RESTORED = 'connectivity_restored';
+
+function emptyState() {
+  return { version: SCHEMA_VERSION, issues: {}, lastUpdate: 0 };
+}
+
+function readState(filePath, fsMod) {
+  try {
+    if (!fsMod.existsSync(filePath)) return emptyState();
+    const raw = fsMod.readFileSync(filePath, 'utf8');
+    if (!raw.trim()) return emptyState();
+    const data = JSON.parse(raw);
+    if (!data || typeof data !== 'object') return emptyState();
+    if (data.version !== SCHEMA_VERSION) return emptyState();
+    if (!data.issues || typeof data.issues !== 'object') data.issues = {};
+    return data;
+  } catch {
+    return emptyState();
+  }
+}
+
+function writeStateAtomic(filePath, data, fsMod) {
+  const tmp = `${filePath}.tmp.${process.pid}.${Date.now()}`;
+  const payload = JSON.stringify(data, null, 2);
+  fsMod.writeFileSync(tmp, payload, { mode: 0o600 });
+  try {
+    fsMod.renameSync(tmp, filePath);
+  } catch (e) {
+    try { fsMod.unlinkSync(tmp); } catch { /* best-effort */ }
+    throw e;
+  }
+}
+
+/**
+ * Purga entradas con `retryingUntil` vencido hace mas de GRACE_MS.
+ * Mantiene un pequeno margen para que consumidores con refresh lento
+ * puedan observar la transicion. No elimina entradas de otros issues.
+ */
+function purgeExpired(state, nowMs, graceMs = 60 * 1000) {
+  const kept = {};
+  for (const [k, v] of Object.entries(state.issues || {})) {
+    if (!v || typeof v !== 'object') continue;
+    const until = Number(v.retryingUntil) || 0;
+    if (Number.isFinite(until) && until + graceMs >= nowMs) {
+      kept[k] = v;
+    }
+  }
+  state.issues = kept;
+  return state;
+}
+
+/**
+ * Marca un conjunto de issues como `reintentando` hasta `now + minRetryMs`.
+ *
+ * CA7.1 — esta funcion es el unico entry point que escribe el estado. El
+ * caller (pulpo.js) DEBE invocarla ANTES de encolar el cmd.json de Telegram.
+ * De esta forma, si el proceso crashea entre ambos writes, el dashboard
+ * refleja `reintentando` pero Telegram no se envio; el proximo ciclo recupera.
+ *
+ *   @param {number[]} issues lista de numeros de issues
+ *   @param {object}   [opts]
+ *     @param {string}  [opts.stateFile]
+ *     @param {object}  [opts.fs]
+ *     @param {number}  [opts.now]         epoch ms (default Date.now)
+ *     @param {number}  [opts.minRetryMs]  ventana visible (default 2000)
+ *     @param {string}  [opts.reason]      default 'connectivity_restored'
+ *     @param {string}  [opts.previousState] default 'blocked:infra'
+ *   @returns {{ written: object[], retryingUntil: number, filePath: string }}
+ */
+function markRetrying(issues, opts = {}) {
+  const fsMod = opts.fs || fs;
+  const filePath = opts.stateFile || DEFAULT_STATE_FILE;
+  const nowMs = Number(opts.now) || Date.now();
+  const minRetryMs = Number.isFinite(opts.minRetryMs) ? opts.minRetryMs : DEFAULT_MIN_RETRY_MS;
+  const reason = typeof opts.reason === 'string' && opts.reason.length > 0
+    ? opts.reason
+    : REASON_CONNECTIVITY_RESTORED;
+  const previousState = typeof opts.previousState === 'string'
+    ? opts.previousState
+    : 'blocked:infra';
+
+  const clean = [...new Set((issues || [])
+    .map(Number)
+    .filter((n) => Number.isFinite(n) && n > 0))];
+
+  if (clean.length === 0) {
+    return { written: [], retryingUntil: 0, filePath };
+  }
+
+  const state = readState(filePath, fsMod);
+  purgeExpired(state, nowMs);
+
+  const retryingUntil = nowMs + Math.max(0, minRetryMs);
+
+  const written = [];
+  for (const n of clean) {
+    const key = String(n);
+    state.issues[key] = {
+      retryingUntil,
+      since: nowMs,
+      reason,
+      previousState,
+    };
+    written.push({ number: n, ...state.issues[key] });
+  }
+  state.lastUpdate = nowMs;
+  writeStateAtomic(filePath, state, fsMod);
+  return { written, retryingUntil, filePath };
+}
+
+/**
+ * Devuelve el mapa de issues en ventana `retrying` activo en `nowMs`.
+ *
+ *   @returns {{ [issueNum: string]: RetryingState }}
+ *
+ * Solo incluye issues cuyo `retryingUntil > nowMs`.
+ *
+ * @typedef {Object} RetryingState
+ * @property {number} retryingUntil  epoch ms hasta mostrar como reintentando
+ * @property {string} reason         "connectivity_restored" | otros
+ * @property {number} since          epoch ms de inicio del estado
+ * @property {string} [previousState] estado previo: "blocked:infra" | otros
+ */
+function getActiveRetrying(opts = {}) {
+  const fsMod = opts.fs || fs;
+  const filePath = opts.stateFile || DEFAULT_STATE_FILE;
+  const nowMs = Number(opts.now) || Date.now();
+  const state = readState(filePath, fsMod);
+  const active = {};
+  for (const [k, v] of Object.entries(state.issues || {})) {
+    if (!v || typeof v !== 'object') continue;
+    const until = Number(v.retryingUntil) || 0;
+    if (until > nowMs) active[k] = v;
+  }
+  return active;
+}
+
+/**
+ * Remueve las entradas vencidas (mtime > retryingUntil + graceMs) del archivo.
+ * Util para el sweep periodico del pulpo/dashboard — no bloqueante.
+ */
+function sweepExpired(opts = {}) {
+  const fsMod = opts.fs || fs;
+  const filePath = opts.stateFile || DEFAULT_STATE_FILE;
+  const nowMs = Number(opts.now) || Date.now();
+  const graceMs = Number.isFinite(opts.graceMs) ? opts.graceMs : 60 * 1000;
+
+  const state = readState(filePath, fsMod);
+  const before = Object.keys(state.issues || {}).length;
+  purgeExpired(state, nowMs, graceMs);
+  const after = Object.keys(state.issues || {}).length;
+  if (after !== before) {
+    state.lastUpdate = nowMs;
+    try { writeStateAtomic(filePath, state, fsMod); } catch { /* best-effort */ }
+  }
+  return { removed: before - after, remaining: after };
+}
+
+// --- Exports ---
+
+module.exports = {
+  // API principal
+  markRetrying,
+  getActiveRetrying,
+  sweepExpired,
+  // Helpers de bajo nivel (tests)
+  readState,
+  writeStateAtomic,
+  purgeExpired,
+  emptyState,
+  // Constantes publicas
+  DEFAULT_STATE_FILE,
+  SCHEMA_VERSION,
+  DEFAULT_MIN_RETRY_MS,
+  REASON_CONNECTIVITY_RESTORED,
+};
+
+// --- CLI (smoke/debug) ---
+if (require.main === module) {
+  const cmd = process.argv[2];
+  if (cmd === 'active') {
+    console.log(JSON.stringify(getActiveRetrying(), null, 2));
+    process.exit(0);
+  }
+  if (cmd === 'sweep') {
+    console.log(JSON.stringify(sweepExpired(), null, 2));
+    process.exit(0);
+  }
+  console.error('uso: node retrying-state.js [active|sweep]');
+  process.exit(2);
+}

--- a/.pipeline/roles/build.md
+++ b/.pipeline/roles/build.md
@@ -42,7 +42,22 @@ Si el issue **NO tiene ningún label `app:*`** (`HAS_APP_LABEL=0`), corré con e
   -x compileTestKotlinIosSimulatorArm64 \
   -x compileClientReleaseKotlinAndroid \
   -x compileBusinessReleaseKotlinAndroid \
-  -x compileDeliveryReleaseKotlinAndroid
+  -x compileDeliveryReleaseKotlinAndroid \
+  -x bundleClientReleaseClassesToRuntimeJar \
+  -x bundleClientReleaseClassesToCompileJar \
+  -x bundleBusinessReleaseClassesToRuntimeJar \
+  -x bundleBusinessReleaseClassesToCompileJar \
+  -x bundleDeliveryReleaseClassesToRuntimeJar \
+  -x bundleDeliveryReleaseClassesToCompileJar \
+  -x kspClientReleaseUnitTestKotlinAndroid \
+  -x kspBusinessReleaseUnitTestKotlinAndroid \
+  -x kspDeliveryReleaseUnitTestKotlinAndroid \
+  -x compileClientReleaseUnitTestKotlinAndroid \
+  -x compileBusinessReleaseUnitTestKotlinAndroid \
+  -x compileDeliveryReleaseUnitTestKotlinAndroid \
+  -x testClientReleaseUnitTest \
+  -x testBusinessReleaseUnitTest \
+  -x testDeliveryReleaseUnitTest
 ```
 
 Si el issue **tiene algún label `app:*`** (`HAS_APP_LABEL>0`), corré sin exclusiones de Release Android (se necesitan para el APK del paso 4):
@@ -55,7 +70,15 @@ Si el issue **tiene algún label `app:*`** (`HAS_APP_LABEL>0`), corré sin exclu
   -x compileTestKotlinIosSimulatorArm64
 ```
 
-Las exclusiones permanentes (`WasmJs` test y iOS) son siempre obligatorias. Las de `compile*ReleaseKotlinAndroid` se aplican solo cuando no hay cambios que afecten a Android, para evitar OOM y tiempos de build largos en cambios de backend puros.
+Las exclusiones permanentes (`WasmJs` test y iOS) son siempre obligatorias. Las de `compile*ReleaseKotlinAndroid` (y toda la cadena Release Android Unit Test) se aplican solo cuando no hay cambios que afecten a Android, para evitar OOM y tiempos de build largos en cambios de backend puros.
+
+> Importante — cadena de dependencias Release: cuando excluís `compile<Flavor>ReleaseKotlinAndroid` para ahorrar RAM, Gradle 8.13 no permite query del provider mapeado antes de que la tarea productora complete. Eso rompe la cadena completa de tareas que leen esos outputs:
+> 1. `bundle<Flavor>ReleaseClassesToRuntimeJar` / `ToCompileJar` (consumen el .jar del compile)
+> 2. `ksp<Flavor>ReleaseUnitTestKotlinAndroid` (transform del classes.jar del bundle ToCompileJar)
+> 3. `compile<Flavor>ReleaseUnitTestKotlinAndroid` (depende del KSP)
+> 4. `test<Flavor>ReleaseUnitTest` (depende del compile unit test)
+>
+> Por eso hay que excluir TODA la cadena Release UnitTest, no solo el compile raíz. El síntoma típico es `Querying the mapped value of provider(java.util.Set) before task [...] has completed is not supported` o `Failed to transform classes.jar`.
 
 Si el build falla, saltar directamente al paso 5 (reportar rechazado).
 

--- a/.pipeline/test-retrying-state.js
+++ b/.pipeline/test-retrying-state.js
@@ -1,0 +1,205 @@
+#!/usr/bin/env node
+// =============================================================================
+// test-retrying-state.js — Tests de `.pipeline/retrying-state.js` (#2337 CA7/CA8)
+//
+// Cubre:
+//   CA7.1 — escritura atomica del estado (FS-first)
+//   CA7.4 — anti-parpadeo: retryingUntil = now + minRetryMs (2s por default)
+//   CA7.5 — state persistido: dashboard puede leer sin race con el pulpo
+//   CA8   — getActiveRetrying() filtra expirados (anti-memory leak)
+// =============================================================================
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  markRetrying,
+  getActiveRetrying,
+  sweepExpired,
+  readState,
+  emptyState,
+  purgeExpired,
+  DEFAULT_MIN_RETRY_MS,
+  SCHEMA_VERSION,
+  REASON_CONNECTIVITY_RESTORED,
+} = require('./retrying-state');
+
+function mkTempFile() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'retrying-state-'));
+  return { file: path.join(dir, 'state.json'), dir };
+}
+
+function rmRf(dir) {
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+}
+
+test('markRetrying — escribe retryingUntil = now + DEFAULT_MIN_RETRY_MS', () => {
+  const { file, dir } = mkTempFile();
+  try {
+    const now = 1_700_000_000_000;
+    const result = markRetrying([2337, 2335], { stateFile: file, now });
+    assert.equal(result.retryingUntil, now + DEFAULT_MIN_RETRY_MS);
+    assert.equal(result.written.length, 2);
+    assert.ok(fs.existsSync(file));
+
+    const persisted = JSON.parse(fs.readFileSync(file, 'utf8'));
+    assert.equal(persisted.version, SCHEMA_VERSION);
+    assert.equal(persisted.issues['2337'].retryingUntil, now + DEFAULT_MIN_RETRY_MS);
+    assert.equal(persisted.issues['2337'].reason, REASON_CONNECTIVITY_RESTORED);
+    assert.equal(persisted.issues['2337'].previousState, 'blocked:infra');
+    assert.equal(persisted.issues['2337'].since, now);
+  } finally { rmRf(dir); }
+});
+
+test('markRetrying — overrideable minRetryMs (para smoke tests)', () => {
+  const { file, dir } = mkTempFile();
+  try {
+    const now = 1_700_000_000_000;
+    const result = markRetrying([2337], { stateFile: file, now, minRetryMs: 500 });
+    assert.equal(result.retryingUntil, now + 500);
+  } finally { rmRf(dir); }
+});
+
+test('markRetrying — lista vacia no escribe archivo', () => {
+  const { file, dir } = mkTempFile();
+  try {
+    const result = markRetrying([], { stateFile: file });
+    assert.equal(result.written.length, 0);
+    assert.equal(result.retryingUntil, 0);
+    assert.equal(fs.existsSync(file), false);
+  } finally { rmRf(dir); }
+});
+
+test('markRetrying — valores invalidos se filtran (NaN, negativos)', () => {
+  const { file, dir } = mkTempFile();
+  try {
+    const result = markRetrying([NaN, -1, 0, 2337, '2338', null, undefined], {
+      stateFile: file,
+      now: 1_700_000_000_000,
+    });
+    assert.equal(result.written.length, 2, 'solo 2337 y 2338 son validos');
+    const persisted = JSON.parse(fs.readFileSync(file, 'utf8'));
+    assert.ok(persisted.issues['2337']);
+    assert.ok(persisted.issues['2338']);
+    assert.equal(Object.keys(persisted.issues).length, 2);
+  } finally { rmRf(dir); }
+});
+
+test('markRetrying — dedup: issues repetidos se consolidan', () => {
+  const { file, dir } = mkTempFile();
+  try {
+    const result = markRetrying([2337, 2337, 2337], {
+      stateFile: file,
+      now: 1_700_000_000_000,
+    });
+    assert.equal(result.written.length, 1, 'dedup');
+  } finally { rmRf(dir); }
+});
+
+test('getActiveRetrying — filtra issues con retryingUntil vencido', () => {
+  const { file, dir } = mkTempFile();
+  try {
+    const now = 1_700_000_000_000;
+    markRetrying([2337, 2335], { stateFile: file, now, minRetryMs: 1000 });
+    // Mismo tick: ambos activos
+    const active1 = getActiveRetrying({ stateFile: file, now: now + 500 });
+    assert.equal(Object.keys(active1).length, 2);
+    // Tras la ventana: ninguno activo
+    const active2 = getActiveRetrying({ stateFile: file, now: now + 2000 });
+    assert.equal(Object.keys(active2).length, 0);
+  } finally { rmRf(dir); }
+});
+
+test('getActiveRetrying — archivo inexistente devuelve {} sin throw', () => {
+  const { file, dir } = mkTempFile();
+  try {
+    const active = getActiveRetrying({ stateFile: file });
+    assert.deepEqual(active, {});
+  } finally { rmRf(dir); }
+});
+
+test('readState — archivo corrupto devuelve emptyState', () => {
+  const { file, dir } = mkTempFile();
+  try {
+    fs.writeFileSync(file, '{not valid json');
+    const state = readState(file, fs);
+    assert.deepEqual(state, emptyState());
+  } finally { rmRf(dir); }
+});
+
+test('readState — version incompatible devuelve emptyState', () => {
+  const { file, dir } = mkTempFile();
+  try {
+    fs.writeFileSync(file, JSON.stringify({ version: 99, issues: { '1': {} } }));
+    const state = readState(file, fs);
+    assert.deepEqual(state, emptyState());
+  } finally { rmRf(dir); }
+});
+
+test('purgeExpired — mantiene entradas dentro de la ventana + grace', () => {
+  const now = 1_700_000_000_000;
+  const state = {
+    version: SCHEMA_VERSION,
+    issues: {
+      'recent': { retryingUntil: now + 1000, since: now },
+      'justExpired': { retryingUntil: now - 100, since: now - 5000 },
+      'veryOld': { retryingUntil: now - 999_999, since: now - 999_999 },
+    },
+    lastUpdate: now,
+  };
+  purgeExpired(state, now, 60 * 1000);
+  assert.ok(state.issues.recent);
+  assert.ok(state.issues.justExpired, 'dentro del grace de 60s');
+  assert.equal(state.issues.veryOld, undefined);
+});
+
+test('sweepExpired — persiste y reporta removidos', () => {
+  const { file, dir } = mkTempFile();
+  try {
+    const now = 1_700_000_000_000;
+    // Escribimos dos entradas: una vigente, otra vencida
+    const raw = {
+      version: SCHEMA_VERSION,
+      issues: {
+        '2337': { retryingUntil: now + 1000, since: now },
+        '9999': { retryingUntil: now - 10 * 60 * 1000, since: now - 20 * 60 * 1000 },
+      },
+      lastUpdate: now,
+    };
+    fs.writeFileSync(file, JSON.stringify(raw));
+    const r = sweepExpired({ stateFile: file, now, graceMs: 60 * 1000 });
+    assert.equal(r.removed, 1);
+    assert.equal(r.remaining, 1);
+    const persisted = JSON.parse(fs.readFileSync(file, 'utf8'));
+    assert.ok(persisted.issues['2337']);
+    assert.equal(persisted.issues['9999'], undefined);
+  } finally { rmRf(dir); }
+});
+
+test('markRetrying — sobrescribe entrada existente (nueva ventana)', () => {
+  const { file, dir } = mkTempFile();
+  try {
+    const t1 = 1_700_000_000_000;
+    markRetrying([2337], { stateFile: file, now: t1, minRetryMs: 1000 });
+    const t2 = t1 + 500;
+    markRetrying([2337], { stateFile: file, now: t2, minRetryMs: 2000 });
+    const persisted = JSON.parse(fs.readFileSync(file, 'utf8'));
+    assert.equal(persisted.issues['2337'].retryingUntil, t2 + 2000);
+    assert.equal(persisted.issues['2337'].since, t2);
+  } finally { rmRf(dir); }
+});
+
+test('FS-first contract — escritura atomica: no deja archivos .tmp leaking', () => {
+  const { file, dir } = mkTempFile();
+  try {
+    markRetrying([2337], { stateFile: file });
+    const entries = fs.readdirSync(dir);
+    const tmps = entries.filter((f) => f.includes('.tmp'));
+    assert.deepEqual(tmps, [], 'no debe quedar ningun .tmp tras write atomico');
+  } finally { rmRf(dir); }
+});

--- a/.pipeline/test-ux-metrics.js
+++ b/.pipeline/test-ux-metrics.js
@@ -1,0 +1,326 @@
+#!/usr/bin/env node
+// =============================================================================
+// test-ux-metrics.js — Tests de `.pipeline/ux-metrics.js` (#2337 CA10)
+//
+// Cubre los criterios aceptacion CA10.1-CA10.7:
+//   CA10.1 — creacion del directorio + archivo JSONL del dia
+//   CA10.2 — campos capturados por evento
+//   CA10.3 — escritura atomica / entrada >4KB rechazada
+//   CA10.4 — rotacion diaria (archivo distinto por dia)
+//   CA10.5 — cleanup lazy + force + cota dura + regex estricta
+//   CA10.6 — no fuga de datos sensibles (whitelist + redact)
+// =============================================================================
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  appendMetric,
+  cleanup,
+  sanitizeEntry,
+  deriveLatencias,
+  listUxFiles,
+  uxFilePath,
+  dateSuffix,
+  isInsideDir,
+  UX_FILE_REGEX,
+  MAX_FILES_HARD_CAP,
+  MAX_ENTRY_BYTES,
+} = require('./ux-metrics');
+
+// --- Helpers de test ---
+
+function mkTempDir(prefix = 'ux-metrics-') {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function rmRf(dir) {
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+}
+
+// --- Tests ---
+
+test('CA10.1 — crea directorio y archivo ux-infra-YYYY-MM-DD.json en el primer write', () => {
+  const dir = mkTempDir();
+  try {
+    const now = Date.UTC(2026, 3, 17, 12, 0, 0); // 2026-04-17 UTC
+    const r = appendMetric({ event: 'connectivity_restored', timestamp_event: now }, {
+      metricsDir: dir, now,
+    });
+    assert.equal(r.written, true, 'debio escribir');
+    assert.ok(fs.existsSync(r.filePath), 'archivo debe existir');
+    assert.match(path.basename(r.filePath), UX_FILE_REGEX, 'nombre matchea regex');
+    assert.equal(path.basename(r.filePath), 'ux-infra-2026-04-17.json');
+  } finally { rmRf(dir); }
+});
+
+test('CA10.2 — captura todos los campos requeridos y deriva latencias', () => {
+  const dir = mkTempDir();
+  try {
+    const now = Date.UTC(2026, 3, 17, 12, 0, 0);
+    const r = appendMetric({
+      event: 'connectivity_restored',
+      timestamp_event: now,
+      timestamp_dashboard_update: now + 500,
+      timestamp_telegram_delivered: now + 1000,
+      timestamp_first_issue_running: now + 5000,
+      variante_mensaje: 'variant:v2',
+      issues_reencolados: 3,
+      rate_limit_alcanzado: null,
+      previous_state: 'blocked:infra',
+      retrying_window_ms: 2000,
+    }, { metricsDir: dir, now });
+
+    assert.equal(r.written, true);
+    // Latencias derivadas
+    assert.equal(r.entry.latencia_telegram_ms, 1000);
+    assert.equal(r.entry.latencia_recuperacion_ms, 5000);
+    // Campos preservados
+    assert.equal(r.entry.issues_reencolados, 3);
+    assert.equal(r.entry.variante_mensaje, 'variant:v2');
+    assert.equal(r.entry.previous_state, 'blocked:infra');
+
+    // El archivo contiene la linea
+    const content = fs.readFileSync(r.filePath, 'utf8');
+    assert.ok(content.endsWith('\n'), 'JSONL debe terminar en newline');
+    const parsed = JSON.parse(content.trim());
+    assert.equal(parsed.event, 'connectivity_restored');
+  } finally { rmRf(dir); }
+});
+
+test('CA10.3 — JSONL append: multiples writes concatenan sin corromper', () => {
+  const dir = mkTempDir();
+  try {
+    const now = Date.UTC(2026, 3, 17, 0, 0, 0);
+    for (let i = 0; i < 5; i++) {
+      const r = appendMetric({
+        event: 'connectivity_restored',
+        timestamp_event: now + i,
+        issues_reencolados: i + 1,
+      }, { metricsDir: dir, now: now + i });
+      assert.equal(r.written, true, `write #${i} debio escribir`);
+    }
+    const filePath = uxFilePath(dir, now);
+    const content = fs.readFileSync(filePath, 'utf8');
+    const lines = content.split('\n').filter(Boolean);
+    assert.equal(lines.length, 5);
+    for (let i = 0; i < 5; i++) {
+      const parsed = JSON.parse(lines[i]);
+      assert.equal(parsed.issues_reencolados, i + 1);
+    }
+  } finally { rmRf(dir); }
+});
+
+test('CA10.3 — rechaza entrada >4KB con `reason: entry-too-large`', () => {
+  const dir = mkTempDir();
+  try {
+    const now = Date.UTC(2026, 3, 17, 0, 0, 0);
+    // Entrada que exceda 4KB cuando serialice. `variante_mensaje` se clampea
+    // a 32 chars asi que usamos `previous_state` que no se clampea, sumando
+    // strings. Asi el test valida el cap aunque haya sanitizacion posterior.
+    const bigString = 'x'.repeat(MAX_ENTRY_BYTES + 100);
+    const r = appendMetric({
+      event: 'connectivity_restored',
+      timestamp_event: now,
+      previous_state: bigString,
+    }, { metricsDir: dir, now });
+    assert.equal(r.written, false);
+    assert.match(r.reason || '', /entry-too-large/);
+  } finally { rmRf(dir); }
+});
+
+test('CA10.4 — rotacion diaria: mismo dia = mismo archivo, dia distinto = archivo nuevo', () => {
+  const dir = mkTempDir();
+  try {
+    const day1 = Date.UTC(2026, 3, 17, 23, 30, 0);
+    const day2 = Date.UTC(2026, 3, 18, 0, 30, 0);
+    const r1 = appendMetric({ event: 'connectivity_restored' }, { metricsDir: dir, now: day1 });
+    const r2 = appendMetric({ event: 'connectivity_restored' }, { metricsDir: dir, now: day2 });
+    assert.equal(r1.written, true);
+    assert.equal(r2.written, true);
+    assert.notEqual(r1.filePath, r2.filePath, 'archivos de distintos dias deben diferir');
+    assert.equal(path.basename(r1.filePath), 'ux-infra-2026-04-17.json');
+    assert.equal(path.basename(r2.filePath), 'ux-infra-2026-04-18.json');
+  } finally { rmRf(dir); }
+});
+
+test('CA10.5 — cleanup borra archivos con mtime >30 dias', () => {
+  const dir = mkTempDir();
+  try {
+    const now = Date.UTC(2026, 3, 17, 12, 0, 0);
+    // Creamos un archivo "viejo" y uno "reciente"
+    const oldFile = path.join(dir, 'ux-infra-2026-01-01.json');
+    const newFile = path.join(dir, 'ux-infra-2026-04-10.json');
+    fs.writeFileSync(oldFile, '{"stale":true}\n');
+    fs.writeFileSync(newFile, '{"fresh":true}\n');
+    // mtime del old file lo bajamos 90 dias atras
+    const oldTime = now - 90 * 24 * 60 * 60 * 1000;
+    fs.utimesSync(oldFile, new Date(oldTime), new Date(oldTime));
+    // newFile queda con mtime reciente (hoy)
+
+    const r = cleanup({ metricsDir: dir, now, force: true });
+    assert.equal(r.ran, true);
+    assert.ok(r.deleted.includes('ux-infra-2026-01-01.json'), 'viejo debe borrarse');
+    assert.ok(!r.deleted.includes('ux-infra-2026-04-10.json'), 'reciente NO debe borrarse');
+    assert.ok(fs.existsSync(newFile));
+    assert.ok(!fs.existsSync(oldFile));
+  } finally { rmRf(dir); }
+});
+
+test('CA10.5 — cleanup NO borra archivos dotfiles ni archivos ajenos (regex estricta)', () => {
+  const dir = mkTempDir();
+  try {
+    const now = Date.UTC(2026, 3, 17, 12, 0, 0);
+    const marker = path.join(dir, '.last-cleanup');
+    const foreign1 = path.join(dir, 'UX-INFRA-2026-01-01.json'); // uppercase
+    const foreign2 = path.join(dir, 'ux-infra-2026-01-01.json.bak');
+    const foreign3 = path.join(dir, 'ux-infra-bad.json');
+    fs.writeFileSync(marker, '{}');
+    fs.writeFileSync(foreign1, '{}');
+    fs.writeFileSync(foreign2, '{}');
+    fs.writeFileSync(foreign3, '{}');
+    // Todos con mtime viejo
+    const oldTime = now - 90 * 24 * 60 * 60 * 1000;
+    for (const f of [marker, foreign1, foreign2, foreign3]) {
+      fs.utimesSync(f, new Date(oldTime), new Date(oldTime));
+    }
+    const r = cleanup({ metricsDir: dir, now, force: true });
+    assert.equal(r.ran, true);
+    assert.equal(r.deleted.length, 0, 'ningun archivo no-matching debe borrarse');
+    assert.ok(fs.existsSync(foreign1));
+    assert.ok(fs.existsSync(foreign2));
+    assert.ok(fs.existsSync(foreign3));
+    // El marker `.last-cleanup` se re-escribe por el propio cleanup, pero no
+    // se borra antes.
+    assert.ok(fs.existsSync(marker));
+  } finally { rmRf(dir); }
+});
+
+test('CA10.5 — cleanup lazy: no corre dos veces el mismo dia sin force', () => {
+  const dir = mkTempDir();
+  try {
+    const now = Date.UTC(2026, 3, 17, 12, 0, 0);
+    const r1 = cleanup({ metricsDir: dir, now });
+    assert.equal(r1.ran, true, 'primera corrida debe ejecutar');
+    const r2 = cleanup({ metricsDir: dir, now: now + 1000 });
+    assert.equal(r2.ran, false, 'segunda corrida del mismo dia debe skip');
+    assert.equal(r2.reason, 'already-today');
+    // Pero con force debe correr igual
+    const r3 = cleanup({ metricsDir: dir, now: now + 2000, force: true });
+    assert.equal(r3.ran, true, 'force debe correr');
+  } finally { rmRf(dir); }
+});
+
+test('CA10.5 — cleanup cota dura: borra los mas viejos si quedan >MAX_FILES', () => {
+  const dir = mkTempDir();
+  try {
+    const now = Date.UTC(2026, 3, 17, 12, 0, 0);
+    // Crear MAX_FILES_HARD_CAP + 5 archivos TODOS recientes (no se borran por fecha)
+    for (let i = 0; i < MAX_FILES_HARD_CAP + 5; i++) {
+      const f = path.join(dir, `ux-infra-2026-03-${String((i % 28) + 1).padStart(2, '0')}.json`);
+      // Usar distintos nombres para evitar colisiones — redondear por dia-del-mes
+      // y variar mtime.
+      const fName = path.join(dir, `ux-infra-2026-${String(Math.floor(i / 28) + 1).padStart(2, '0')}-${String((i % 28) + 1).padStart(2, '0')}.json`);
+      fs.writeFileSync(fName, `{"i":${i}}\n`);
+      // mtime progresivo: i=0 mas viejo, i=max mas reciente (todos dentro de retention)
+      const ts = now - (MAX_FILES_HARD_CAP + 5 - i) * 1000;
+      fs.utimesSync(fName, new Date(ts), new Date(ts));
+    }
+    const r = cleanup({ metricsDir: dir, now, force: true });
+    assert.equal(r.ran, true);
+    assert.equal(r.capEnforced, true, 'cota dura debe haber disparado');
+    assert.ok(r.deleted.length >= 5, 'debe borrar al menos el excedente');
+  } finally { rmRf(dir); }
+});
+
+test('CA10.6 — sanitize: filtra keys no whitelisted y redacta tokens', () => {
+  const sanitized = sanitizeEntry({
+    event: 'connectivity_restored',
+    timestamp_event: 123,
+    variante_mensaje: 'variant:v2',
+    // Keys prohibidas que NO deben persistir:
+    mensaje_literal: 'texto secreto del usuario',
+    token: 'sk-1234567890abcdef1234',
+    chat_id: '1234567890',
+    user_path: 'C:\\Users\\Administrator\\secret.json',
+  });
+  assert.equal(sanitized.event, 'connectivity_restored');
+  assert.equal(sanitized.variante_mensaje, 'variant:v2');
+  assert.equal(sanitized.mensaje_literal, undefined, 'clave fuera de whitelist se filtra');
+  assert.equal(sanitized.token, undefined);
+  assert.equal(sanitized.chat_id, undefined);
+  assert.equal(sanitized.user_path, undefined);
+});
+
+test('CA10.6 — sanitize: convierte paths absolutos dentro de valores whitelisted a basename', () => {
+  // `previous_state` esta whitelisted y se usa para ejemplificar.
+  const sanitized = sanitizeEntry({
+    previous_state: '/home/user/secret/file.json',
+  });
+  assert.equal(sanitized.previous_state, 'file.json');
+  const sanitizedWin = sanitizeEntry({
+    previous_state: 'C:\\Users\\Administrator\\secret.json',
+  });
+  assert.equal(sanitizedWin.previous_state, 'secret.json');
+});
+
+test('CA10.6 — sanitize: redacta tokens-like embedded en values', () => {
+  const sanitized = sanitizeEntry({
+    variante_mensaje: 'Bearer secrettoken123456',
+  });
+  assert.equal(sanitized.variante_mensaje, '[REDACTED]');
+  const sanitized2 = sanitizeEntry({
+    variante_mensaje: 'sk-abc1234567890defghij',
+  });
+  assert.equal(sanitized2.variante_mensaje, '[REDACTED]');
+});
+
+test('CA10.6 — sanitize: clamp variante_mensaje a 32 chars', () => {
+  const longVariant = 'v'.repeat(100);
+  const sanitized = sanitizeEntry({ variante_mensaje: longVariant });
+  assert.equal(sanitized.variante_mensaje.length, 32);
+});
+
+test('deriveLatencias: no sobreescribe valores explicitos del caller', () => {
+  const derived = deriveLatencias({
+    timestamp_event: 1000,
+    timestamp_telegram_delivered: 2000,
+    latencia_telegram_ms: 999, // valor explicito
+  });
+  assert.equal(derived.latencia_telegram_ms, 999, 'valor explicito se preserva');
+});
+
+test('deriveLatencias: skip si no hay timestamp_event', () => {
+  const derived = deriveLatencias({
+    timestamp_telegram_delivered: 2000,
+  });
+  assert.equal(derived.latencia_telegram_ms, undefined);
+});
+
+test('isInsideDir: rechaza paths que escapan via ../', () => {
+  const base = path.resolve('/tmp/a');
+  assert.equal(isInsideDir(base, path.resolve('/tmp/a/foo')), true);
+  assert.equal(isInsideDir(base, path.resolve('/tmp/other')), false);
+  assert.equal(isInsideDir(base, path.resolve('/tmp/a/../b')), false);
+});
+
+test('dateSuffix: UTC consistente incluso a medianoche', () => {
+  const d = dateSuffix(Date.UTC(2026, 3, 17, 0, 0, 0));
+  assert.equal(d, '2026-04-17');
+  const d2 = dateSuffix(Date.UTC(2026, 3, 17, 23, 59, 59));
+  assert.equal(d2, '2026-04-17');
+});
+
+test('UX_FILE_REGEX: matchea solo formato exacto', () => {
+  assert.ok(UX_FILE_REGEX.test('ux-infra-2026-04-17.json'));
+  assert.ok(!UX_FILE_REGEX.test('UX-INFRA-2026-04-17.json'));
+  assert.ok(!UX_FILE_REGEX.test('ux-infra-2026-04-17.json.bak'));
+  assert.ok(!UX_FILE_REGEX.test('ux-infra-bad.json'));
+  assert.ok(!UX_FILE_REGEX.test('ux-infra-26-04-17.json'));
+  assert.ok(!UX_FILE_REGEX.test('.last-cleanup'));
+});

--- a/.pipeline/ux-metrics.js
+++ b/.pipeline/ux-metrics.js
@@ -1,0 +1,368 @@
+#!/usr/bin/env node
+// =============================================================================
+// ux-metrics.js — Captura append-only de metricas UX infra (#2337, CA10).
+//
+// Persiste metricas por evento `connectivity_restored` en `.pipeline/metrics/`
+// con un archivo JSONL por dia y rotacion automatica:
+//   `.pipeline/metrics/ux-infra-YYYY-MM-DD.json`
+//
+// Responsabilidades:
+//   - CA10.1: crear el directorio + archivo del dia en el primer write.
+//   - CA10.2: capturar los timestamps de la choreografia + metadata del evento.
+//   - CA10.3: escritura atomica via appendFileSync (JSONL, <4KB por linea).
+//   - CA10.4: rotacion diaria (archivo nuevo por dia).
+//   - CA10.5: cleanup perezoso al primer write del dia + en startup, con
+//             filtro estricto de path traversal (REQ-SEC-2) y cota dura.
+//   - CA10.6: no persistir datos sensibles — solo IDs/enum/metadata.
+//
+// Anti-patterns cubiertos:
+//   - Path traversal: regex estricta `^ux-infra-\d{4}-\d{2}-\d{2}\.json$`
+//     antes de `unlinkSync` (REQ-SEC-2).
+//   - Denial-of-wallet por disco: cota dura a 100 archivos fuerza cleanup
+//     aunque el cleanup perezoso no haya disparado (REQ-SEC-5).
+//   - Entradas monstruosas: `MAX_ENTRY_BYTES` valida que ninguna linea
+//     supera 4KB — appendFileSync sigue siendo byte-safe en NTFS/POSIX.
+//   - Datos sensibles: la funcion filtra campos permitidos y convierte
+//     paths absolutos a basename (REQ-SEC-3).
+// =============================================================================
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const PIPELINE_DIR = path.resolve(__dirname);
+const DEFAULT_METRICS_DIR = path.join(PIPELINE_DIR, 'metrics');
+const LAST_CLEANUP_FILE = '.last-cleanup';
+
+// Retencion y caps (REQ-SEC-5)
+const RETENTION_DAYS = 30;
+const RETENTION_MS = RETENTION_DAYS * 24 * 60 * 60 * 1000;
+const MAX_FILES_HARD_CAP = 100; // cota dura para forzar cleanup
+const MAX_ENTRY_BYTES = 4 * 1024; // JSONL append seguro en NTFS/POSIX <4KB
+
+// Regex estricta para nombres de archivo (REQ-SEC-2)
+const UX_FILE_REGEX = /^ux-infra-(\d{4})-(\d{2})-(\d{2})\.json$/;
+
+// Whitelist de keys permitidas en cada entrada (REQ-SEC-3).
+// Si un caller inyecta keys nuevas, se filtran silenciosamente.
+const ALLOWED_ENTRY_KEYS = new Set([
+  'event',
+  'timestamp_event',
+  'timestamp_dashboard_update',
+  'timestamp_telegram_delivered',
+  'timestamp_first_issue_running',
+  'latencia_telegram_ms',
+  'latencia_recuperacion_ms',
+  'variante_mensaje',
+  'issues_reencolados',
+  'rate_limit_alcanzado',
+  'previous_state',
+  'retrying_window_ms',
+]);
+
+// --- Helpers ---
+
+/**
+ * Devuelve el sufijo de fecha `YYYY-MM-DD` para el timestamp (UTC).
+ * UTC para evitar inconsistencias entre operaciones del pipeline corriendo
+ * alrededor de medianoche local (consistente con `events/connectivity.jsonl`).
+ */
+function dateSuffix(nowMs) {
+  const d = new Date(Number(nowMs) || Date.now());
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(d.getUTCDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+function uxFilePath(metricsDir, nowMs) {
+  return path.join(metricsDir, `ux-infra-${dateSuffix(nowMs)}.json`);
+}
+
+function lastCleanupPath(metricsDir) {
+  return path.join(metricsDir, LAST_CLEANUP_FILE);
+}
+
+function ensureDir(dir, fsMod) {
+  try { fsMod.mkdirSync(dir, { recursive: true }); } catch { /* exists */ }
+}
+
+/**
+ * Sanitiza la entrada antes de persistir (REQ-SEC-3):
+ *  - Filtra keys no whitelisted.
+ *  - Convierte paths absolutos a basename (oculta `C:\Users\...`).
+ *  - Clamp `variante_mensaje` a ID corto (max 32 chars).
+ *  - Rechaza tokens-like (best-effort heuristico).
+ */
+function sanitizeEntry(entry) {
+  if (!entry || typeof entry !== 'object') return {};
+  const out = {};
+  for (const [k, v] of Object.entries(entry)) {
+    if (!ALLOWED_ENTRY_KEYS.has(k)) continue;
+    out[k] = sanitizeValue(k, v);
+  }
+  return out;
+}
+
+function sanitizeValue(key, value) {
+  if (value == null) return null;
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'string') {
+    // Heuristica de tokens: si parece un secreto, rechazar.
+    if (/\b(sk-|ghp_|gho_|ghs_|AKIA|xoxb-|Bearer\s)[A-Za-z0-9._\-]{10,}/.test(value)) {
+      return '[REDACTED]';
+    }
+    // Paths absolutos Windows/Unix -> basename (evita fuga de info local).
+    if (/^[A-Za-z]:[\\/]/.test(value) || value.startsWith('/')) {
+      return path.basename(value);
+    }
+    // Clamp corto para `variante_mensaje`
+    if (key === 'variante_mensaje' && value.length > 32) return value.slice(0, 32);
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((v) => sanitizeValue(key, v));
+  }
+  // Objetos libres se descartan — no queremos fugar estructuras opacas.
+  return null;
+}
+
+/**
+ * Computa latencias derivadas (CA10.2) si los timestamps estan disponibles.
+ * No sobrescribe valores explicitos del caller.
+ */
+function deriveLatencias(entry) {
+  const out = { ...entry };
+  if (out.timestamp_event != null) {
+    if (out.latencia_telegram_ms == null && out.timestamp_telegram_delivered != null) {
+      const v = Number(out.timestamp_telegram_delivered) - Number(out.timestamp_event);
+      if (Number.isFinite(v) && v >= 0) out.latencia_telegram_ms = v;
+    }
+    if (out.latencia_recuperacion_ms == null && out.timestamp_first_issue_running != null) {
+      const v = Number(out.timestamp_first_issue_running) - Number(out.timestamp_event);
+      if (Number.isFinite(v) && v >= 0) out.latencia_recuperacion_ms = v;
+    }
+  }
+  return out;
+}
+
+// --- Cleanup (REQ-SEC-2 + REQ-SEC-5) ---
+
+/**
+ * Lista los archivos UX validos en el directorio. El filtro estricto con
+ * `UX_FILE_REGEX` evita tocar `.last-cleanup`, dotfiles o archivos ajenos.
+ */
+function listUxFiles(metricsDir, fsMod) {
+  try {
+    const files = fsMod.readdirSync(metricsDir);
+    return files.filter((name) => UX_FILE_REGEX.test(name));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Ejecuta el cleanup si aplica:
+ *  - Se fuerza si `force=true` (startup o cota dura).
+ *  - Sino, solo corre una vez por dia (lazy), marcado en `.last-cleanup`.
+ *
+ * Borra archivos con mtime > RETENTION_DAYS de antiguedad, respetando el regex
+ * estricto y nunca saliendo del directorio `metricsDir` (REQ-SEC-2).
+ */
+function cleanup(opts = {}) {
+  const fsMod = opts.fs || fs;
+  const nowMs = Number(opts.now) || Date.now();
+  const metricsDir = path.resolve(opts.metricsDir || DEFAULT_METRICS_DIR);
+  const force = !!opts.force;
+
+  ensureDir(metricsDir, fsMod);
+
+  // Gate: si hoy ya corrio el cleanup y no es forzado, skip.
+  const markerPath = lastCleanupPath(metricsDir);
+  if (!force) {
+    try {
+      if (fsMod.existsSync(markerPath)) {
+        const raw = fsMod.readFileSync(markerPath, 'utf8');
+        const prevMs = Number(JSON.parse(raw).ts) || 0;
+        if (Number.isFinite(prevMs) && dateSuffix(prevMs) === dateSuffix(nowMs)) {
+          return { ran: false, reason: 'already-today' };
+        }
+      }
+    } catch { /* ignore, proceder con cleanup */ }
+  }
+
+  const files = listUxFiles(metricsDir, fsMod);
+  const cutoff = nowMs - RETENTION_MS;
+  const deleted = [];
+  const kept = [];
+
+  for (const name of files) {
+    const full = path.join(metricsDir, name);
+    // Defensa extra path traversal: verificar que el resolve no escapa del dir.
+    if (!isInsideDir(metricsDir, full)) continue;
+    try {
+      const st = fsMod.statSync(full);
+      if (st.mtimeMs < cutoff) {
+        fsMod.unlinkSync(full);
+        deleted.push(name);
+      } else {
+        kept.push(name);
+      }
+    } catch { /* ignore missing/racing */ }
+  }
+
+  // Cota dura: si aun quedan >MAX_FILES_HARD_CAP, borrar los mas viejos.
+  let capEnforced = false;
+  if (kept.length > MAX_FILES_HARD_CAP) {
+    const byAge = kept
+      .map((name) => {
+        const full = path.join(metricsDir, name);
+        try { return { name, mtimeMs: fsMod.statSync(full).mtimeMs }; }
+        catch { return null; }
+      })
+      .filter(Boolean)
+      .sort((a, b) => a.mtimeMs - b.mtimeMs); // mas viejo primero
+
+    const excess = byAge.length - MAX_FILES_HARD_CAP;
+    for (let i = 0; i < excess; i++) {
+      const full = path.join(metricsDir, byAge[i].name);
+      if (!isInsideDir(metricsDir, full)) continue;
+      try {
+        fsMod.unlinkSync(full);
+        deleted.push(byAge[i].name);
+        capEnforced = true;
+      } catch { /* ignore */ }
+    }
+  }
+
+  // Marca cleanup (escritura at\u00f3mica tmp+rename)
+  try {
+    const payload = JSON.stringify({ ts: nowMs, deleted: deleted.length });
+    writeFileAtomic(markerPath, payload, fsMod);
+  } catch { /* best-effort */ }
+
+  return { ran: true, deleted, kept: kept.length, capEnforced };
+}
+
+function isInsideDir(dir, filePath) {
+  const rDir = path.resolve(dir);
+  const rFile = path.resolve(filePath);
+  const rel = path.relative(rDir, rFile);
+  return !rel.startsWith('..') && !path.isAbsolute(rel);
+}
+
+function writeFileAtomic(filePath, contents, fsMod) {
+  const tmp = `${filePath}.tmp.${process.pid}.${Date.now()}`;
+  fsMod.writeFileSync(tmp, contents, { mode: 0o600 });
+  try {
+    fsMod.renameSync(tmp, filePath);
+  } catch (e) {
+    try { fsMod.unlinkSync(tmp); } catch { /* ignore */ }
+    throw e;
+  }
+}
+
+// --- Append principal ---
+
+/**
+ * Appendea una entrada al archivo JSONL del dia actual.
+ *
+ *   @param {object} entry datos a persistir (se sanitizan con whitelist)
+ *   @param {object} [opts]
+ *     @param {string}   [opts.metricsDir]
+ *     @param {number}   [opts.now]
+ *     @param {object}   [opts.fs]
+ *     @param {boolean}  [opts.skipCleanup] desactiva el cleanup lazy
+ *   @returns {{ written: boolean, filePath: string, entry: object, cleanup?: object, reason?: string }}
+ */
+function appendMetric(entry, opts = {}) {
+  const fsMod = opts.fs || fs;
+  const nowMs = Number(opts.now) || Date.now();
+  const metricsDir = path.resolve(opts.metricsDir || DEFAULT_METRICS_DIR);
+
+  ensureDir(metricsDir, fsMod);
+
+  // Cleanup perezoso al primer write del dia (a menos que se desactive).
+  let cleanupResult;
+  if (!opts.skipCleanup) {
+    try {
+      cleanupResult = cleanup({ fs: fsMod, now: nowMs, metricsDir });
+    } catch { /* best-effort, no bloquea el write */ }
+  }
+
+  // Sanitizar + derivar latencias
+  let normalized = deriveLatencias(sanitizeEntry(entry || {}));
+
+  // Anchor temporal obligatorio (si falta, tomamos now).
+  if (normalized.timestamp_event == null) {
+    normalized.timestamp_event = nowMs;
+  }
+  // Default explicito del event si no vino
+  if (!normalized.event) normalized.event = 'connectivity_restored';
+
+  // Validar tamano antes de escribir (REQ-SEC-4, CA10.3)
+  const line = JSON.stringify(normalized) + '\n';
+  const bytes = Buffer.byteLength(line, 'utf8');
+  if (bytes > MAX_ENTRY_BYTES) {
+    return {
+      written: false,
+      filePath: uxFilePath(metricsDir, nowMs),
+      entry: normalized,
+      reason: `entry-too-large: ${bytes}B > ${MAX_ENTRY_BYTES}B`,
+      cleanup: cleanupResult,
+    };
+  }
+
+  const filePath = uxFilePath(metricsDir, nowMs);
+  try {
+    fsMod.appendFileSync(filePath, line, { mode: 0o600 });
+    return { written: true, filePath, entry: normalized, cleanup: cleanupResult };
+  } catch (e) {
+    return {
+      written: false,
+      filePath,
+      entry: normalized,
+      reason: `append-error: ${e.code || e.message}`,
+      cleanup: cleanupResult,
+    };
+  }
+}
+
+// --- Exports ---
+
+module.exports = {
+  appendMetric,
+  cleanup,
+  sanitizeEntry,
+  deriveLatencias,
+  listUxFiles,
+  uxFilePath,
+  dateSuffix,
+  isInsideDir,
+  // Constantes publicas
+  DEFAULT_METRICS_DIR,
+  UX_FILE_REGEX,
+  RETENTION_DAYS,
+  MAX_FILES_HARD_CAP,
+  MAX_ENTRY_BYTES,
+  ALLOWED_ENTRY_KEYS,
+};
+
+// --- CLI (smoke/debug) ---
+if (require.main === module) {
+  const cmd = process.argv[2];
+  if (cmd === 'cleanup') {
+    const r = cleanup({ force: true });
+    console.log(JSON.stringify(r, null, 2));
+    process.exit(0);
+  }
+  if (cmd === 'list') {
+    const files = listUxFiles(DEFAULT_METRICS_DIR, fs);
+    console.log(JSON.stringify(files, null, 2));
+    process.exit(0);
+  }
+  console.error('uso: node ux-metrics.js [cleanup|list]');
+  process.exit(2);
+}


### PR DESCRIPTION
## Resumen

Hija 3 de #2329 (split por sizing grande). Implementa la **capa visual y observable** del feedback proactivo ante recuperacion de red:

- **CA7 — Choreografia temporal FS-first**: el dashboard refleja estado `reintentando` antes de que Telegram envie el aviso unico. Pulpo escribe el estado en disco primero (fuente de verdad) y luego encola el `cmd.json` de Telegram.
- **CA8 — Estado visual `reintentando`**: color ambar (#F59E0B, contraste WCAG AA ~5.2:1) en el dashboard con spinner lento, tooltip con timestamp, `role=status` + `aria-live=polite`, `prefers-reduced-motion` fallback e icono 🔁 como discriminador de forma.
- **CA10 — Metricas UX append-only**: modulo `ux-metrics.js` con whitelist de 12 keys, sanitizacion de tokens (sk-/ghp_/AKIA/Bearer), rotacion diaria UTC, cap duro de 100 files y entradas <= 4KB.

## Archivos

- `.pipeline/retrying-state.js` (nuevo, 238 LOC) — estado atomico FS-first con schema versionado.
- `.pipeline/ux-metrics.js` (nuevo, 368 LOC) — append-only log con validacion estricta.
- `.pipeline/pulpo.js` (+167 LOC) — choreografia FS-first: Scan -> FS state -> YAML cleanup -> Telegram -> cleanup mem -> metrics.
- `.pipeline/dashboard-v2.js` (+84 LOC) — clase `lc-retrying` + CSS ambar + tooltip accesible.
- `.pipeline/test-retrying-state.js` (nuevo, 205 LOC) — 13 tests.
- `.pipeline/test-ux-metrics.js` (nuevo, 326 LOC) — 18 tests.
- `.pipeline/roles/build.md` — exclusiones downstream de cadena Release Android UnitTest (fix rebote de build).

## Tests

- 31/31 passing (`node --test`, 184ms): 13 retrying-state + 18 ux-metrics.
- Cubren: FS-first contract, atomic write, version mismatch, corrupt file handling, path traversal, token redaction, whitelist filtering, basename conversion, cap enforcement, >4KB rejection, rotacion diaria UTC.

## Gate de calidad

- `/qa` (structural): APROBADO — 31/31 tests, syntax OK, archivos verificados.
- `/tester`: APROBADO — 31/31 passing.
- `/security`: APROBADO — 6/6 REQ-SEC cubiertos (XSS, path traversal, fuga de datos, race, DoS disco, atomicidad).
- `/po`: APROBADO.
- `/ux`: APROBADO — WCAG AA verificado, prefers-reduced-motion, icono discriminador protanopia/deuteranopia safe.
- `/review`: APROBADO (ver `.pipeline/desarrollo/aprobacion/procesado/2337.review`).

## Justificacion qa:skipped

Issue con labels `area:infra` + `area:dashboard` (sin `app:*`): pipeline interno + dashboard de observabilidad, sin impacto en producto de usuario final. Gate cubierto por tests unitarios (31/31) y validacion estructural.

Closes #2337