### PR TITLE
fix(pipeline): gate de evidencia QA por qaMode autoritativo + APK fresh check (#2351)

### DIFF
--- a/.pipeline/lib/__tests__/apk-freshness.test.js
+++ b/.pipeline/lib/__tests__/apk-freshness.test.js
@@ -1,0 +1,303 @@
+// =============================================================================
+// Tests apk-freshness.js — Issue #2351 (CA-2 + R2, R5)
+//
+// Cobertura:
+//   R5 · extractFailureLines conserva sólo líneas FAILURE:/Task ... FAILED
+//   R5 · matchesApkFailureInFailureLines no matchea en paths/comentarios
+//   R5 · matchesApkFailureInFailureLines SI matchea en líneas de falla real
+//   R2 · checkDebugApksFresh marca fresh=false cuando mtime <= buildStartTime
+//   R2 · checkDebugApksFresh marca fresh=true cuando mtime > buildStartTime
+//   CA-2 · estimateBuildStartTimeMs usa elapsed cuando viene, fallback 30min
+//   CA-2 · buildDismissEvent tiene forma auditable con apkStatus detallado
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+    extractFailureLines,
+    matchesApkFailureInFailureLines,
+    apkPathForFlavor,
+    checkDebugApksFresh,
+    buildDismissEvent,
+    estimateBuildStartTimeMs,
+    APK_PATTERN,
+    DEFAULT_FLAVORS,
+} = require('../apk-freshness');
+
+// ─── Helpers de fakeFs para inyectar statSync sin tocar disco ──────────────
+function fakeFsFromMap(apkMap) {
+    return {
+        statSync(p) {
+            if (!(p in apkMap)) {
+                const err = new Error('ENOENT');
+                err.code = 'ENOENT';
+                throw err;
+            }
+            const entry = apkMap[p];
+            return {
+                isFile: () => true,
+                mtimeMs: entry.mtimeMs,
+                mtime: new Date(entry.mtimeMs),
+                size: entry.size,
+            };
+        },
+    };
+}
+
+// ─── extractFailureLines (R5) ──────────────────────────────────────────────
+test('R5 · extractFailureLines conserva línea FAILURE:', () => {
+    const log = [
+        'some random output',
+        'FAILURE: Execution failed for task \':app:composeApp:assembleClientRelease\'.',
+        '  > Some detail here',
+        'BUILD SUCCESSFUL after 5s',
+    ].join('\n');
+    const out = extractFailureLines(log);
+    assert.match(out, /FAILURE:/);
+    assert.doesNotMatch(out, /random output/);
+    assert.doesNotMatch(out, /BUILD SUCCESSFUL/);
+});
+
+test('R5 · extractFailureLines conserva "> Task :xxx FAILED"', () => {
+    const log = [
+        '> Task :app:composeApp:compileClientDebugKotlinAndroid',
+        '> Task :app:composeApp:bundleBusinessReleaseClassesToRuntimeJar FAILED',
+        '> Task :backend:test',
+    ].join('\n');
+    const out = extractFailureLines(log);
+    assert.match(out, /bundleBusinessReleaseClassesToRuntimeJar FAILED/);
+    // Task ok (sin FAILED) no se conserva
+    assert.doesNotMatch(out, /compileClientDebugKotlinAndroid$/m);
+});
+
+test('R5 · extractFailureLines con input vacío o no-string devuelve string vacío', () => {
+    assert.equal(extractFailureLines(''), '');
+    assert.equal(extractFailureLines(null), '');
+    assert.equal(extractFailureLines(undefined), '');
+    assert.equal(extractFailureLines(42), '');
+});
+
+// ─── matchesApkFailureInFailureLines (R5) ──────────────────────────────────
+test('R5 · NO matchea sobre paths/filenames en buffer crudo', () => {
+    // Regresión del falso positivo: un log con mención literal de "apk-not-found.kt"
+    // en un path no debe disparar el pattern.
+    const log = [
+        'agent wrote file: src/apk-not-found.kt',
+        'BUILD SUCCESSFUL after 2s',
+        '> Task :backend:test',
+    ].join('\n');
+    assert.equal(matchesApkFailureInFailureLines(log), false);
+});
+
+test('R5 · SI matchea cuando FAILURE: habla de assemble', () => {
+    const log = [
+        'random noise',
+        'FAILURE: Execution failed for task \':app:composeApp:assembleBusinessRelease\'.',
+        '  > Querying the mapped value of provider',
+    ].join('\n');
+    assert.equal(matchesApkFailureInFailureLines(log), true);
+});
+
+test('R5 · SI matchea cuando "> Task ... FAILED" contiene assemble/bundle APK', () => {
+    const log = [
+        '> Task :app:composeApp:assembleClientDebug FAILED',
+    ].join('\n');
+    // La línea `> Task ... FAILED` con token "assemble*" → match (co-ocurrencia)
+    assert.equal(matchesApkFailureInFailureLines(log), true);
+});
+
+test('R5 · APK_PATTERN exportado es regex case-insensitive', () => {
+    assert.ok(APK_PATTERN instanceof RegExp);
+    assert.equal(APK_PATTERN.flags.includes('i'), true);
+});
+
+// ─── checkDebugApksFresh (R2) ──────────────────────────────────────────────
+test('R2 · APK con mtime > buildStartTime → fresh=true', () => {
+    const now = 1_700_000_000_000;
+    const buildStart = now - 60_000; // build empezó hace 1 min
+    const apkPath = apkPathForFlavor('/root', 'client');
+    const fakeFs = fakeFsFromMap({
+        [apkPath]: { mtimeMs: now - 30_000, size: 20 * 1024 * 1024 }, // APK de hace 30s
+    });
+    const r = checkDebugApksFresh({
+        rootDir: '/root',
+        buildStartTimeMs: buildStart,
+        flavors: ['client'],
+        fsImpl: fakeFs,
+    });
+    assert.equal(r.checked[0].exists, true);
+    assert.equal(r.checked[0].fresh, true);
+    assert.equal(r.anyFresh, true);
+});
+
+test('R2 · APK con mtime <= buildStartTime → fresh=false (stale)', () => {
+    const now = 1_700_000_000_000;
+    const buildStart = now - 60_000;
+    const apkPath = apkPathForFlavor('/root', 'client');
+    const fakeFs = fakeFsFromMap({
+        [apkPath]: { mtimeMs: now - (3 * 24 * 3600 * 1000), size: 20 * 1024 * 1024 }, // 3 días
+    });
+    const r = checkDebugApksFresh({
+        rootDir: '/root',
+        buildStartTimeMs: buildStart,
+        flavors: ['client'],
+        fsImpl: fakeFs,
+    });
+    assert.equal(r.checked[0].exists, true);
+    assert.equal(r.checked[0].fresh, false);
+    assert.equal(r.anyFresh, false);
+});
+
+test('R2 · APK que no existe → exists=false, fresh=false', () => {
+    const r = checkDebugApksFresh({
+        rootDir: '/root',
+        buildStartTimeMs: Date.now(),
+        flavors: ['client'],
+        fsImpl: fakeFsFromMap({}),
+    });
+    assert.equal(r.checked[0].exists, false);
+    assert.equal(r.checked[0].fresh, false);
+    assert.equal(r.allPresent, false);
+});
+
+test('R2 · anyFresh=true si AL MENOS uno de los 3 flavors es fresco', () => {
+    const now = 1_700_000_000_000;
+    const buildStart = now - 60_000;
+    const clientPath = apkPathForFlavor('/root', 'client');
+    const businessPath = apkPathForFlavor('/root', 'business');
+    const deliveryPath = apkPathForFlavor('/root', 'delivery');
+    const fakeFs = fakeFsFromMap({
+        [clientPath]: { mtimeMs: now - 30_000, size: 1 },       // fresh
+        [businessPath]: { mtimeMs: now - 999_999_000, size: 1 }, // stale
+        [deliveryPath]: { mtimeMs: now - 999_999_000, size: 1 }, // stale
+    });
+    const r = checkDebugApksFresh({
+        rootDir: '/root',
+        buildStartTimeMs: buildStart,
+        fsImpl: fakeFs,
+    });
+    assert.equal(r.anyFresh, true);
+    assert.equal(r.allFresh, false);
+    assert.equal(r.allPresent, true);
+});
+
+test('R2 · DEFAULT_FLAVORS incluye los 3 flavors', () => {
+    assert.deepEqual([...DEFAULT_FLAVORS].sort(), ['business', 'client', 'delivery']);
+});
+
+test('R2 · apkPathForFlavor genera el path canónico', () => {
+    const p = apkPathForFlavor('/repo', 'business');
+    assert.match(p, /app[\\/]composeApp[\\/]build[\\/]outputs[\\/]apk[\\/]business[\\/]debug[\\/]composeApp-business-debug\.apk$/);
+});
+
+// ─── estimateBuildStartTimeMs (CA-2) ───────────────────────────────────────
+test('CA-2 · estimateBuildStartTimeMs usa elapsed + margen de seguridad', () => {
+    const now = 1_700_000_000_000;
+    const r = estimateBuildStartTimeMs({ elapsedSec: 120, nowMs: now });
+    // 120s + 10 min de margen = 720 segundos antes
+    assert.equal(r, now - (120 * 1000) - (10 * 60 * 1000));
+});
+
+test('CA-2 · estimateBuildStartTimeMs sin elapsed usa fallback 30min', () => {
+    const now = 1_700_000_000_000;
+    const r = estimateBuildStartTimeMs({ elapsedSec: null, nowMs: now });
+    assert.equal(r, now - (30 * 60 * 1000));
+});
+
+test('CA-2 · estimateBuildStartTimeMs con elapsed="?" usa fallback 30min', () => {
+    const now = 1_700_000_000_000;
+    const r = estimateBuildStartTimeMs({ elapsedSec: '?', nowMs: now });
+    assert.equal(r, now - (30 * 60 * 1000));
+});
+
+test('CA-2 · estimateBuildStartTimeMs acepta elapsed string numérico', () => {
+    const now = 1_700_000_000_000;
+    const r = estimateBuildStartTimeMs({ elapsedSec: '45', nowMs: now });
+    assert.equal(r, now - (45 * 1000) - (10 * 60 * 1000));
+});
+
+// ─── buildDismissEvent (CA-3/R3) ───────────────────────────────────────────
+test('CA-3 · buildDismissEvent incluye issue, pattern, reason y apkStatus', () => {
+    const apkStatus = {
+        anyFresh: true,
+        allFresh: false,
+        allPresent: true,
+        checked: [
+            { flavor: 'client', exists: true, fresh: true, mtimeMs: Date.now() - 60000, sizeBytes: 20 * 1024 * 1024 },
+            { flavor: 'business', exists: true, fresh: false, mtimeMs: Date.now() - (4 * 24 * 3600 * 1000), sizeBytes: 20 * 1024 * 1024 },
+            { flavor: 'delivery', exists: false, fresh: false, mtimeMs: null, sizeBytes: null },
+        ],
+    };
+    const evt = buildDismissEvent({
+        issue: 2351,
+        pattern: 'apk_not_generated',
+        reason: 'APK debug fresco presente',
+        apkStatus,
+    });
+    assert.equal(evt.event, 'match-dismissed');
+    assert.equal(evt.issue, '2351');
+    assert.equal(evt.pattern, 'apk_not_generated');
+    assert.equal(evt.apkStatus.anyFresh, true);
+    assert.equal(evt.apkStatus.flavors.length, 3);
+    assert.equal(evt.apkStatus.flavors[0].flavor, 'client');
+    assert.equal(evt.apkStatus.flavors[0].fresh, true);
+});
+
+test('CA-3 · buildDismissEvent sin apkStatus pone apkStatus:null (no crash)', () => {
+    const evt = buildDismissEvent({ issue: 1, pattern: 'x', reason: 'y' });
+    assert.equal(evt.apkStatus, null);
+});
+
+// ─── Escenario integrado: falso positivo #2351 ────────────────────────────
+test('#2351 · log de Release FAILED + APKs Debug frescos → match descartado', () => {
+    // Simula el log real que disparó el issue fantasma.
+    const log = [
+        '> Task :app:composeApp:compileBusinessDebugKotlinAndroid',
+        '> Task :app:composeApp:assembleBusinessDebug',
+        'FAILURE: Execution failed for task \':app:composeApp:bundleBusinessReleaseClassesToRuntimeJar\'.',
+        '  > Querying the mapped value of provider(java.util.Set) before task',
+        '    \':app:composeApp:compileBusinessReleaseKotlinAndroid\' has completed is not supported',
+        '> Task :app:composeApp:bundleBusinessReleaseClassesToRuntimeJar FAILED',
+    ].join('\n');
+    // El pattern matchea en líneas de failure real
+    assert.equal(matchesApkFailureInFailureLines(log), true);
+
+    // Pero los APKs Debug SÍ están frescos
+    const now = 1_700_000_000_000;
+    const buildStart = now - 600_000; // build empezó hace 10 min
+    const fakeFs = fakeFsFromMap({
+        [apkPathForFlavor('/repo', 'client')]:   { mtimeMs: now - 120_000, size: 25 * 1024 * 1024 },
+        [apkPathForFlavor('/repo', 'business')]: { mtimeMs: now - 100_000, size: 25 * 1024 * 1024 },
+        [apkPathForFlavor('/repo', 'delivery')]: { mtimeMs: now -  80_000, size: 24 * 1024 * 1024 },
+    });
+    const apkStatus = checkDebugApksFresh({
+        rootDir: '/repo',
+        buildStartTimeMs: buildStart,
+        fsImpl: fakeFs,
+    });
+    // Los 3 debug APKs están frescos → anyFresh y allFresh true
+    assert.equal(apkStatus.anyFresh, true);
+    assert.equal(apkStatus.allFresh, true);
+    // El consumidor (rejection-report.js) decide NO addDep viendo anyFresh=true
+});
+
+test('#2351 · log sin FAILURE real + APKs stale → match no matchea por R5', () => {
+    // Si sólo hay mención en comentarios/paths del log, R5 evita el match
+    const log = 'some log about apk-not-found paths without any FAILURE line';
+    assert.equal(matchesApkFailureInFailureLines(log), false);
+});
+
+test('#2351 · log con Release FAILED real + APKs ausentes → NO descartado', () => {
+    // Caso verdadero: el build actual rompió y no hay APKs frescos
+    const log = 'FAILURE: Execution failed for task \':app:composeApp:assembleClientDebug\'.';
+    assert.equal(matchesApkFailureInFailureLines(log), true);
+    const apkStatus = checkDebugApksFresh({
+        rootDir: '/repo',
+        buildStartTimeMs: Date.now() - 600_000,
+        fsImpl: fakeFsFromMap({}), // ningún APK presente
+    });
+    assert.equal(apkStatus.anyFresh, false);
+    // El consumidor SÍ debería addDep en este caso
+});

--- a/.pipeline/lib/__tests__/qa-evidence-gate.test.js
+++ b/.pipeline/lib/__tests__/qa-evidence-gate.test.js
@@ -1,0 +1,155 @@
+// =============================================================================
+// Tests qa-evidence-gate.js — Issue #2351 (CA-1, CA-3, CA-6 + R1, R3)
+//
+// Cobertura:
+//   CA-1 · qaMode='api' → skip evidence (whitelist explícito)
+//   CA-1 · qaMode='structural' → skip evidence
+//   CA-1 · qaMode='android' / 'ui' / vacío → NO skip (requiere evidencia)
+//   CA-1 · modo autoritativo del preflight gana sobre el YAML del agente
+//   CA-6 · issue UI sin qaMode autoritativo + yamlMode='android' → sigue exigiendo video
+//   R1   · no se infiere skip por ausencia de labels (solo whitelist explícita)
+//   R3   · el evento de bypass tiene la forma esperada para auditar
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+    normalizeMode,
+    resolveQaMode,
+    shouldSkipVisualEvidence,
+    buildBypassEvent,
+    formatBypassLogLine,
+    SKIPPABLE_QA_MODES,
+} = require('../qa-evidence-gate');
+
+// ─── normalizeMode ─────────────────────────────────────────────────────────
+test('normalizeMode · trim + lowercase', () => {
+    assert.equal(normalizeMode('  API '), 'api');
+    assert.equal(normalizeMode('Structural'), 'structural');
+});
+
+test('normalizeMode · null/undefined → cadena vacía', () => {
+    assert.equal(normalizeMode(null), '');
+    assert.equal(normalizeMode(undefined), '');
+    assert.equal(normalizeMode(''), '');
+});
+
+test('normalizeMode · valores no string → string lowercase', () => {
+    assert.equal(normalizeMode(42), '42');
+    assert.equal(normalizeMode(true), 'true');
+});
+
+// ─── resolveQaMode (R1 — whitelist + autoridad) ─────────────────────────────
+test('resolveQaMode · authoritativo del preflight gana sobre YAML', () => {
+    const r = resolveQaMode({ authoritative: 'android', yamlMode: 'api' });
+    assert.equal(r.mode, 'android');
+    assert.equal(r.source, 'preflight');
+});
+
+test('resolveQaMode · sin authoritativo usa el YAML como fallback', () => {
+    const r = resolveQaMode({ authoritative: null, yamlMode: 'structural' });
+    assert.equal(r.mode, 'structural');
+    assert.equal(r.source, 'yaml');
+});
+
+test('resolveQaMode · sin ninguna fuente → source=none', () => {
+    const r = resolveQaMode({ authoritative: null, yamlMode: null });
+    assert.equal(r.mode, '');
+    assert.equal(r.source, 'none');
+});
+
+test('resolveQaMode · default args (sin opts) no crashea', () => {
+    const r = resolveQaMode();
+    assert.equal(r.mode, '');
+    assert.equal(r.source, 'none');
+});
+
+// ─── shouldSkipVisualEvidence (CA-1, CA-6, R1) ──────────────────────────────
+test('CA-1 · qaMode="api" salta evidencia audiovisual', () => {
+    assert.equal(shouldSkipVisualEvidence('api'), true);
+});
+
+test('CA-1 · qaMode="structural" salta evidencia audiovisual', () => {
+    assert.equal(shouldSkipVisualEvidence('structural'), true);
+});
+
+test('CA-6 · qaMode="android" sigue exigiendo evidencia', () => {
+    assert.equal(shouldSkipVisualEvidence('android'), false);
+});
+
+test('CA-6 · qaMode="ui" sigue exigiendo evidencia', () => {
+    // 'ui' no está en la whitelist — defensivo
+    assert.equal(shouldSkipVisualEvidence('ui'), false);
+});
+
+test('R1 · qaMode vacío NUNCA salta (no inferir por ausencia)', () => {
+    assert.equal(shouldSkipVisualEvidence(''), false);
+    assert.equal(shouldSkipVisualEvidence(null), false);
+    assert.equal(shouldSkipVisualEvidence(undefined), false);
+});
+
+test('R1 · qaMode desconocido ("hotfix", "infra") NUNCA salta', () => {
+    assert.equal(shouldSkipVisualEvidence('hotfix'), false);
+    assert.equal(shouldSkipVisualEvidence('infra'), false);
+    assert.equal(shouldSkipVisualEvidence('anything-else'), false);
+});
+
+test('R1 · whitelist es exactamente ["api", "structural"]', () => {
+    assert.deepEqual([...SKIPPABLE_QA_MODES].sort(), ['api', 'structural']);
+});
+
+// ─── buildBypassEvent (R3) ─────────────────────────────────────────────────
+test('R3 · buildBypassEvent tiene forma auditable para api', () => {
+    const evt = buildBypassEvent({
+        issue: 2023,
+        qaMode: 'api',
+        source: 'preflight',
+        labels: ['area:backend'],
+    });
+    assert.equal(evt.event, 'gate-bypass');
+    assert.equal(evt.issue, '2023');
+    assert.equal(evt.qaMode, 'api');
+    assert.equal(evt.source, 'preflight');
+    assert.equal(evt.decision, 'skip-video');
+    assert.match(evt.reason, /QA-API.*evidencia/i);
+    assert.deepEqual(evt.labels, ['area:backend']);
+});
+
+test('R3 · buildBypassEvent tiene forma auditable para structural', () => {
+    const evt = buildBypassEvent({
+        issue: '1507',
+        qaMode: 'structural',
+        source: 'preflight',
+    });
+    assert.equal(evt.qaMode, 'structural');
+    assert.match(evt.reason, /estructural/i);
+    assert.deepEqual(evt.labels, []);
+});
+
+test('R3 · buildBypassEvent normaliza el issue a string', () => {
+    const evt = buildBypassEvent({ issue: 42, qaMode: 'api', source: 'yaml' });
+    assert.equal(typeof evt.issue, 'string');
+    assert.equal(evt.issue, '42');
+});
+
+test('R3 · formatBypassLogLine incluye JSON parseable + prefijo legible', () => {
+    const evt = buildBypassEvent({
+        issue: 2023,
+        qaMode: 'api',
+        source: 'preflight',
+        labels: ['area:backend'],
+    });
+    const line = formatBypassLogLine(evt);
+    // El JSON debe quedar al final y ser parseable
+    const jsonStart = line.indexOf('{');
+    assert.ok(jsonStart > 0, 'line debe tener JSON al final');
+    const parsed = JSON.parse(line.slice(jsonStart));
+    assert.equal(parsed.event, 'gate-bypass');
+    assert.equal(parsed.issue, '2023');
+    // El prefijo legible debe tener gate-bypass, issue y qaMode
+    assert.match(line, /gate-bypass/);
+    assert.match(line, /#2023/);
+    assert.match(line, /qaMode=api/);
+});

--- a/.pipeline/lib/apk-freshness.js
+++ b/.pipeline/lib/apk-freshness.js
@@ -1,0 +1,215 @@
+// =============================================================================
+// apk-freshness.js — Validar existencia + frescura de APKs debug y saneo de
+// matches del rejection-report que disparan "APK no se pudo generar".
+//
+// Issue #2351 — El pattern-match de `rejection-report.js` sobre logs de Gradle
+// matcheaba tasks Release que fallan por un bug conocido de AGP + Kotlin MP
+// (`bundle<Flavor>ReleaseClassesToRuntimeJar`) aunque los APKs Debug sí se
+// generaran correctamente. El reporte creaba entonces un issue fantasma
+// ("El APK no se pudo generar") con `priority:high`.
+//
+// Este módulo implementa R2 y R5 de la auditoría de seguridad:
+//   R2: un APK se considera válido sólo si `mtime > buildStartTime`.
+//       Un APK exitoso de hace 3 días no puede enmascarar un build roto hoy.
+//   R5: restringir el pattern-match a líneas que empiecen con `FAILURE:` o
+//       contengan `> Task ... FAILED`. Nunca buscar en todo el buffer crudo
+//       del log — un path/filename llamado `apk-not-found.kt` haría match
+//       espurio.
+//
+// PURE JS + fs — fácil de testear con `node --test` (inyectamos `rootDir` y
+// `now` para no pisar disco real en los tests).
+// =============================================================================
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const DEFAULT_FLAVORS = Object.freeze(['client', 'business', 'delivery']);
+
+// Pattern original (compat): lo exportamos para tests y regresiones históricas,
+// pero el matcher nuevo lo complementa con detección order-agnostic dentro
+// de cada línea de falla real.
+const APK_PATTERN = /assemble.*fail|build.*apk.*fail|apk.*not\s*(?:found|generated)/i;
+
+// Verbos de falla — una línea de error real típicamente los contiene
+const APK_FAIL_VERBS = /\b(?:fail(?:ed|ure)?|error|exception)\b/i;
+// Targets de falla típicos del pipeline Android: APK, tareas assemble*, bundle*
+// que producen el paquete Android, y el texto genérico "apk not (found|generated)"
+const APK_TARGET_TOKENS = /\bapk\b|\bassemble\w*\b|\bbundle\w*(?:classes|jar|aab|runtime)\w*\b/i;
+
+/**
+ * Extrae únicamente las líneas que representan errores "reales" de Gradle:
+ *   - Comienzan con "FAILURE:" (header del block de error de Gradle)
+ *   - Contienen "> Task :xxx FAILED" (task que falló explícitamente)
+ *
+ * Esto evita falsos positivos cuando paths, filenames o comentarios en el log
+ * contienen palabras como "apk-not-found" o "assemble" sin ser errores.
+ *
+ * @param {string} text
+ * @returns {string}  Texto con sólo líneas de falla real. Cadena vacía si no hay.
+ */
+function extractFailureLines(text) {
+    if (!text || typeof text !== 'string') return '';
+    const keep = [];
+    for (const rawLine of text.split(/\r?\n/)) {
+        const line = rawLine.trimStart();
+        if (line.startsWith('FAILURE:')) { keep.push(rawLine); continue; }
+        // Match `> Task :modulo:task FAILED` (con o sin espacios extra)
+        if (/^\s*>\s*Task\s+[:\w.-]+\s+FAILED\b/i.test(rawLine)) { keep.push(rawLine); continue; }
+    }
+    return keep.join('\n');
+}
+
+/**
+ * Chequea el pattern de APK únicamente sobre las líneas de falla real (R5).
+ *
+ * Motivo de no usar el regex original literal: Gradle escribe "Execution
+ * failed for task ':...:assembleFooRelease'" — el verbo ("failed") viene ANTES
+ * del target ("assemble"), así que `assemble.*fail` no matchea dentro de la
+ * misma línea. Aquí buscamos CO-OCURRENCIA (en la misma línea) de un verbo de
+ * falla + un token de target (apk, assemble*, bundle*Jar/*Aab) sin importar
+ * el orden, más el fallback literal del pattern original.
+ *
+ * @param {string} text
+ * @returns {boolean}
+ */
+function matchesApkFailureInFailureLines(text) {
+    const lines = extractFailureLines(text);
+    if (!lines) return false;
+    for (const line of lines.split(/\r?\n/)) {
+        // Co-ocurrencia en la misma línea: verbo de falla + target de APK/assemble/bundle
+        if (APK_FAIL_VERBS.test(line) && APK_TARGET_TOKENS.test(line)) return true;
+        // Fallback: preservar el match del pattern original por compat con logs
+        // que usen las frases exactas "apk not found / not generated"
+        if (APK_PATTERN.test(line)) return true;
+    }
+    return false;
+}
+
+/**
+ * Resuelve el path esperado del APK debug para un flavor dado.
+ * @param {string} rootDir
+ * @param {string} flavor
+ */
+function apkPathForFlavor(rootDir, flavor) {
+    return path.join(
+        rootDir,
+        'app', 'composeApp', 'build', 'outputs', 'apk',
+        flavor, 'debug',
+        `composeApp-${flavor}-debug.apk`
+    );
+}
+
+/**
+ * Inspecciona los APKs debug de los flavors dados y reporta si existen y son
+ * frescos respecto a un buildStartTime dado (R2).
+ *
+ * @param {object} opts
+ * @param {string} opts.rootDir - raíz del repo (donde cuelga `app/composeApp/...`)
+ * @param {number} opts.buildStartTimeMs - epoch ms; APK con `mtime > este valor` es fresco.
+ * @param {string[]} [opts.flavors] - lista de flavors a chequear (default: los 3).
+ * @param {object} [opts.fsImpl] - override de fs para tests (opcional).
+ * @returns {{
+ *   checked: Array<{flavor:string, path:string, exists:boolean, fresh:boolean, mtimeMs:number|null, sizeBytes:number|null}>,
+ *   anyFresh: boolean,
+ *   allFresh: boolean,
+ *   allPresent: boolean,
+ * }}
+ */
+function checkDebugApksFresh({ rootDir, buildStartTimeMs, flavors = DEFAULT_FLAVORS, fsImpl } = {}) {
+    const FS = fsImpl || fs;
+    const checked = [];
+    let freshCount = 0;
+    let presentCount = 0;
+    for (const flavor of flavors) {
+        const p = apkPathForFlavor(rootDir, flavor);
+        let exists = false;
+        let mtimeMs = null;
+        let sizeBytes = null;
+        try {
+            const st = FS.statSync(p);
+            if (st && st.isFile && st.isFile()) {
+                exists = true;
+                mtimeMs = typeof st.mtimeMs === 'number' ? st.mtimeMs : (st.mtime ? st.mtime.getTime() : 0);
+                sizeBytes = st.size;
+            }
+        } catch (_) { /* not present */ }
+        const fresh = exists && typeof buildStartTimeMs === 'number' && mtimeMs > buildStartTimeMs;
+        if (exists) presentCount++;
+        if (fresh) freshCount++;
+        checked.push({ flavor, path: p, exists, fresh, mtimeMs, sizeBytes });
+    }
+    return {
+        checked,
+        anyFresh: freshCount > 0,
+        allFresh: freshCount === flavors.length,
+        allPresent: presentCount === flavors.length,
+    };
+}
+
+/**
+ * Construye el payload estructurado de un descarte de match (R3/CA-3).
+ * Lo consume `rejection-report.js` para loguear via JSON inline junto al log
+ * textual.
+ *
+ * @param {object} ctx
+ * @param {string|number} ctx.issue
+ * @param {string} ctx.pattern - nombre simbólico del pattern (p. ej. 'apk_not_generated')
+ * @param {string} ctx.reason
+ * @param {object} ctx.apkStatus - objeto devuelto por `checkDebugApksFresh`
+ */
+function buildDismissEvent({ issue, pattern, reason, apkStatus }) {
+    return {
+        event: 'match-dismissed',
+        issue: String(issue),
+        pattern,
+        reason,
+        apkStatus: apkStatus ? {
+            anyFresh: apkStatus.anyFresh,
+            allFresh: apkStatus.allFresh,
+            allPresent: apkStatus.allPresent,
+            flavors: (apkStatus.checked || []).map(c => ({
+                flavor: c.flavor,
+                exists: c.exists,
+                fresh: c.fresh,
+                ageSec: c.mtimeMs ? Math.round((Date.now() - c.mtimeMs) / 1000) : null,
+                sizeKb: c.sizeBytes ? Math.round(c.sizeBytes / 1024) : null,
+            })),
+        } : null,
+    };
+}
+
+/**
+ * Heurística para estimar el inicio del build actual a partir de lo que
+ * `rejection-report.js` conoce: `elapsed` (segundos que duró el agente) +
+ * un margen de seguridad. Si no hay elapsed confiable, usa 30 min atrás por
+ * defecto (suficiente para builds largos sin tragarse APKs verdaderamente
+ * stale).
+ *
+ * @param {object} opts
+ * @param {number|string|null} opts.elapsedSec
+ * @param {number} [opts.safetyMarginMs] - default 10 min.
+ * @param {number} [opts.nowMs] - inyectable para tests.
+ * @param {number} [opts.fallbackWindowMs] - ventana default si no hay elapsed.
+ */
+function estimateBuildStartTimeMs({ elapsedSec, safetyMarginMs = 10 * 60 * 1000, nowMs = Date.now(), fallbackWindowMs = 30 * 60 * 1000 } = {}) {
+    const now = Number.isFinite(nowMs) ? nowMs : Date.now();
+    const parsed = elapsedSec === null || elapsedSec === undefined
+        ? NaN
+        : parseInt(elapsedSec, 10);
+    if (Number.isFinite(parsed) && parsed > 0) {
+        return now - (parsed * 1000) - safetyMarginMs;
+    }
+    return now - fallbackWindowMs;
+}
+
+module.exports = {
+    DEFAULT_FLAVORS,
+    APK_PATTERN,
+    extractFailureLines,
+    matchesApkFailureInFailureLines,
+    apkPathForFlavor,
+    checkDebugApksFresh,
+    buildDismissEvent,
+    estimateBuildStartTimeMs,
+};

--- a/.pipeline/lib/qa-evidence-gate.js
+++ b/.pipeline/lib/qa-evidence-gate.js
@@ -1,0 +1,109 @@
+// =============================================================================
+// qa-evidence-gate.js — Resolución de qaMode y bypass de evidencia audiovisual
+//
+// Issue #2351 — El gate-evidencia-on-exit venía exigiendo video+audio a issues
+// QA-API puros, generando falsos rechazos y disparando el rejection-report con
+// el pattern-match "APK no se pudo generar" como fantasma. La causa real era
+// que `qaMode` se leía sólo del YAML del agente (manipulable por el propio
+// agente QA) en vez de tomarlo del preflight del Pulpo como fuente de verdad.
+//
+// Este módulo implementa R1 de la auditoría de seguridad:
+//   "Detección de qaMode por whitelist explícito, no por ausencia de app:*".
+//
+// Reglas:
+//   - `qaMode === 'api'` o `qaMode === 'structural'` → salta evidencia
+//     audiovisual (la fase QA no produce video ni audio por diseño).
+//   - Cualquier otro valor (`android`, `ui`, undefined, null, '') → exige
+//     evidencia. Nunca inferimos el modo por ausencia de labels.
+//   - El modo autoritativo viene del preflight del Pulpo (parámetro
+//     `authoritativeQaMode`). Si ese valor falta, se cae al YAML del agente
+//     como fallback (no debería pasar en flujo normal porque el Pulpo inyecta
+//     `data.modo = preflightResult.qaMode` antes de lanzar al agente QA).
+//
+// Este archivo es PURE JS — sin dependencias de fs/net — para que sea trivial
+// de testear con `node --test`.
+// =============================================================================
+'use strict';
+
+const SKIPPABLE_QA_MODES = Object.freeze(['api', 'structural']);
+
+/**
+ * Normaliza un valor cualquiera a string lowercase trimado.
+ * Devuelve '' para null/undefined/no-string.
+ */
+function normalizeMode(value) {
+    if (value === null || value === undefined) return '';
+    return String(value).trim().toLowerCase();
+}
+
+/**
+ * Resuelve el qaMode efectivo priorizando la fuente autoritativa del preflight.
+ *
+ * @param {object} opts
+ * @param {string|null} opts.authoritative - qaMode inyectado por el Pulpo (fuente de verdad).
+ * @param {string|null} opts.yamlMode - qaMode leído del YAML del agente (fallback).
+ * @returns {{ mode: string, source: 'preflight'|'yaml'|'none' }}
+ */
+function resolveQaMode({ authoritative, yamlMode } = {}) {
+    const pre = normalizeMode(authoritative);
+    if (pre) return { mode: pre, source: 'preflight' };
+    const yml = normalizeMode(yamlMode);
+    if (yml) return { mode: yml, source: 'yaml' };
+    return { mode: '', source: 'none' };
+}
+
+/**
+ * Devuelve true si el modo resuelto debe saltar la evidencia audiovisual.
+ * Implementa R1: whitelist explícita, nunca inferir por ausencia.
+ *
+ * @param {string} qaMode - valor ya normalizado (lowercase).
+ */
+function shouldSkipVisualEvidence(qaMode) {
+    return SKIPPABLE_QA_MODES.includes(normalizeMode(qaMode));
+}
+
+/**
+ * Construye el payload estructurado de un bypass del gate (R3).
+ * El logger del Pulpo serializa este objeto como JSON inline para auditoría.
+ *
+ * @param {object} ctx
+ * @param {string|number} ctx.issue
+ * @param {string} ctx.qaMode
+ * @param {'preflight'|'yaml'|'none'} ctx.source
+ * @param {string[]} [ctx.labels]
+ * @returns {object}
+ */
+function buildBypassEvent({ issue, qaMode, source, labels = [] }) {
+    const mode = normalizeMode(qaMode);
+    return {
+        event: 'gate-bypass',
+        issue: String(issue),
+        qaMode: mode,
+        source,
+        labels: Array.isArray(labels) ? labels.slice() : [],
+        decision: 'skip-video',
+        reason: mode === 'api'
+            ? 'QA-API no requiere evidencia audiovisual'
+            : mode === 'structural'
+                ? 'QA estructural no requiere evidencia audiovisual'
+                : 'qaMode no requiere evidencia audiovisual',
+    };
+}
+
+/**
+ * Formatea el evento estructurado para imprimir junto al log textual del
+ * Pulpo. Mantiene el prefijo legible del log existente y adjunta un JSON
+ * compacto para que herramientas (monitor, grep) puedan parsearlo.
+ */
+function formatBypassLogLine(event) {
+    return `🟢 gate-bypass #${event.issue} qaMode=${event.qaMode || '?'} source=${event.source} — ${event.reason} ${JSON.stringify(event)}`;
+}
+
+module.exports = {
+    SKIPPABLE_QA_MODES,
+    normalizeMode,
+    resolveQaMode,
+    shouldSkipVisualEvidence,
+    buildBypassEvent,
+    formatBypassLogLine,
+};

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -19,6 +19,7 @@ const connectivityState = require('./connectivity-state'); // #2335
 const { classifyRoutingMismatch } = require('./lib/routing-classifier');
 const cbInfra = require('./circuit-breaker-infra');
 const { redact } = require('./redact');
+const qaEvidenceGate = require('./lib/qa-evidence-gate');
 
 // Crash handlers — loguear y seguir vivo
 process.on('uncaughtException', (err) => {
@@ -880,6 +881,13 @@ function limpiarDaemonsOnDemand() {
 
 const activeProcesses = new Map(); // key: "skill:issue" → { pid, startTime }
 
+// Cache en memoria del qaMode resuelto por el preflight para cada issue.
+// Issue #2351 — R1: el `modo` que emite el agente en el YAML no es fuente de
+// verdad (puede sobrescribirlo). La fuente de verdad es la clasificación del
+// preflight (`preflightQaChecks`). Este cache vive mientras corre el pulpo;
+// si se reinicia, caemos al YAML como fallback (comportamiento antiguo).
+const qaModeByIssue = new Map(); // key: issueNumber → 'android' | 'api' | 'structural'
+
 function processKey(skill, issue) { return `${skill}:${issue}`; }
 
 function isProcessAlive(pid) {
@@ -1178,17 +1186,34 @@ const QA_MIN_FRAME_PNGS = 3;             // Mínimo de frames PNG del agente QA 
  * El campo `video_size_kb` del YAML es solo informativo; si el archivo en disco
  * cumple el umbral, se acepta.
  */
-function validateQaEvidence(issue, qaData) {
+function validateQaEvidence(issue, qaData, authoritativeQaMode = null) {
   // El preflight clasifica cada issue en uno de tres modos (qaMode):
   //   - 'android'    → requiere emulador + APK → debe haber video/frames
   //   - 'api'        → testing via HTTP, sin UI → no produce video
   //   - 'structural' → validación syntax+tests → no produce video
-  // El agente QA escribe `modo: <qaMode>` en el YAML. Solo exigir evidencia
-  // visual cuando realmente aplica — antes este gate rechazaba fantasma
-  // issues de backend/infra cuyo QA estructural había aprobado correctamente,
-  // disparando el loop con el rejection-report.
-  const modo = (qaData.modo || '').toString().toLowerCase();
-  if (modo === 'api' || modo === 'structural') return [];
+  //
+  // R1 (auditoría seguridad #2351): NUNCA inferimos el modo por ausencia de
+  // labels `app:*`. Exigimos whitelist explícita: sólo 'api' o 'structural'
+  // saltean la evidencia. El modo autoritativo viene del preflight del Pulpo
+  // (parámetro `authoritativeQaMode`); si falta, caemos al YAML del agente
+  // como fallback defensivo. Un agente QA no puede bypassear el gate
+  // inventando un `modo` falso si el preflight ya determinó 'android'.
+  //
+  // R3 (CA-3): cada bypass emite un log estructurado para auditoría.
+  const resolution = qaEvidenceGate.resolveQaMode({
+    authoritative: authoritativeQaMode,
+    yamlMode: qaData && qaData.modo,
+  });
+  if (qaEvidenceGate.shouldSkipVisualEvidence(resolution.mode)) {
+    const evt = qaEvidenceGate.buildBypassEvent({
+      issue,
+      qaMode: resolution.mode,
+      source: resolution.source,
+      labels: Array.isArray(qaData && qaData.labels) ? qaData.labels : [],
+    });
+    log('gate-bypass', qaEvidenceGate.formatBypassLogLine(evt));
+    return [];
+  }
 
   const ROOT = path.resolve(PIPELINE, '..');
   const evidenceDir = path.join(ROOT, 'qa', 'evidence', String(issue));
@@ -1892,10 +1917,12 @@ function brazoBarrido(config) {
         // --- GATE DE EVIDENCIA QA (fase verificacion) ---
         // Si el QA dice "aprobado" pero no tiene evidencia real, forzar rechazo automático.
         // Esto evita que issues pasen a aprobación sin video con audio narrado.
+        // R1 (#2351): el qaMode autoritativo viene del cache del preflight, no del YAML.
         if (fase === 'verificacion') {
           const qaResult = resultados.find(r => skillFromFile(r.file.name) === 'qa');
           if (qaResult && qaResult.resultado === 'aprobado') {
-            const issues = validateQaEvidence(issue, qaResult);
+            const authoritativeQaMode = qaModeByIssue.get(String(issue)) || null;
+            const issues = validateQaEvidence(issue, qaResult, authoritativeQaMode);
             if (issues.length > 0) {
               log('barrido', `⛔ #${issue} QA aprobó SIN evidencia válida: ${issues.join(', ')}`);
               qaResult.resultado = 'rechazado';
@@ -3236,6 +3263,13 @@ function preflightQaChecks(issue) {
     : hasBackendLabel ? 'api'
     : 'structural';
 
+  // R1 (#2351): cachear la clasificación autoritativa para que el gate
+  // de evidencia no tenga que depender del `modo` del YAML (manipulable
+  // por el agente). Se setea ni bien determinamos el modo, sin importar
+  // si los checks posteriores pasan o fallan — el modo se conoce desde
+  // el primer momento.
+  qaModeByIssue.set(String(issue), qaMode);
+
   checks.classify = requiresEmulator ? `ui:${flavors.join(',')}` : `no-ui:${qaMode}`;
   log('preflight', `#${issue}: check 1 OK (qaMode=${qaMode}${requiresEmulator ? `, flavors: ${flavors.join(', ')}` : ''})`);
 
@@ -3849,9 +3883,14 @@ function lanzarAgenteClaude(skill, issue, trabajandoPath, pipeline, fase, config
       }
 
       // --- VALIDACIÓN ON-EXIT QA ---
-      // Si el agente QA terminó diciendo "aprobado" pero sin evidencia, forzar rechazo
+      // Si el agente QA terminó diciendo "aprobado" pero sin evidencia, forzar rechazo.
+      // R1 (issue #2351): pasamos `extraEnv.QA_MODE` como fuente de verdad autoritativa
+      // (lo inyectó el preflight del Pulpo antes de lanzar al agente). El agente no
+      // puede bypassear el gate inventando un `modo: api` falso en el YAML si el
+      // preflight había determinado 'android'.
       if (skill === 'qa' && fase === 'verificacion' && data.resultado === 'aprobado') {
-        const evidenceIssues = validateQaEvidence(issue, data);
+        const authoritativeQaMode = extraEnv && extraEnv.QA_MODE ? extraEnv.QA_MODE : null;
+        const evidenceIssues = validateQaEvidence(issue, data, authoritativeQaMode);
         if (evidenceIssues.length > 0) {
           log('lanzamiento', `⛔ QA:#${issue} aprobó sin evidencia válida on-exit: ${evidenceIssues.join(', ')}`);
           data.resultado = 'rechazado';

--- a/.pipeline/rejection-report.js
+++ b/.pipeline/rejection-report.js
@@ -20,6 +20,10 @@ const dedupLib = require('./dedup-lib');
 // reporte con secretos crudos (tokens, JWT, PEM, etc.) que luego viaja a
 // Telegram/Drive.
 const { sanitize: sanitizeReportText } = require('./sanitizer');
+// #2351: el match "APK no se pudo generar" era falso positivo cuando fallaban
+// sólo tasks Release (bug AGP+KMP) mientras los APKs Debug se generaban bien.
+// Este helper nos da extract-failure-lines + checkDebugApksFresh + dismiss log.
+const apkFreshness = require('./lib/apk-freshness');
 
 const ROOT = path.resolve(__dirname, '..');
 const PIPELINE = __dirname;
@@ -871,8 +875,36 @@ function detectExternalDependencies(logTail, motivo) {
     addDep('Problema de red/DNS — no hay conexion a internet', 'El agente no pudo conectarse a internet o a servicios externos. Es un problema de infraestructura, no de codigo. No se evaluo nada.', 'infra', 'normal');
 
   // APK build failure pattern
-  if (combined.match(/assemble.*fail|build.*apk.*fail|apk.*not\s*(?:found|generated)/i))
-    addDep('El APK no se pudo generar', 'El build de Android fallo — el APK no existe. Sin APK no se puede probar en el emulador.', 'pattern-match', 'high');
+  //
+  // #2351 — Historial: este pattern venía disparando el issue fantasma
+  // "El APK no se pudo generar" cuando en realidad fallaba sólo una task
+  // Release (bug conocido de AGP + Kotlin MP en
+  // `bundle<Flavor>ReleaseClassesToRuntimeJar`) y los APKs Debug se generaban
+  // bien. Endurecimos el match con:
+  //   R5 — sólo aplicar el regex a líneas de falla real (FAILURE:/Task FAILED),
+  //        nunca al buffer crudo que incluye paths, comentarios, etc.
+  //   R2 — si el regex matchea, verificar APKs Debug en disco y considerarlos
+  //        válidos sólo cuando `mtime > buildStartTime` (un APK stale de hace
+  //        3 días no puede enmascarar un build actual roto).
+  //   R3 — loguear JSON inline cuando descartamos el match, para auditoría.
+  if (apkFreshness.matchesApkFailureInFailureLines(combined)) {
+    const buildStartTimeMs = apkFreshness.estimateBuildStartTimeMs({ elapsedSec: elapsed });
+    const apkStatus = apkFreshness.checkDebugApksFresh({
+      rootDir: ROOT,
+      buildStartTimeMs,
+    });
+    if (apkStatus.anyFresh) {
+      const dismissEvt = apkFreshness.buildDismissEvent({
+        issue,
+        pattern: 'apk_not_generated',
+        reason: 'APK(s) debug frescos presentes — la falla probable es sólo de tasks Release (bug AGP+KMP)',
+        apkStatus,
+      });
+      try { console.error(`[rejection-report] match-dismissed ${JSON.stringify(dismissEvt)}`); } catch {}
+    } else {
+      addDep('El APK no se pudo generar', 'El build de Android fallo — el APK no existe. Sin APK no se puede probar en el emulador.', 'pattern-match', 'high');
+    }
+  }
 
   // Emulator not running pattern
   //

--- a/docs/qa/qa-mode-gate.md
+++ b/docs/qa/qa-mode-gate.md
@@ -1,0 +1,108 @@
+# Gate de evidencia QA por `qaMode`
+
+_Issue #2351 — Endurecimiento del gate-evidencia-on-exit y del pattern-match de APK en `rejection-report.js`._
+
+## Resumen
+
+El Pulpo clasifica cada issue de QA en uno de tres modos (`qaMode`) durante el
+preflight. El gate de evidencia audiovisual (video + audio narrado) se aplica
+sólo a los modos que realmente producen video. Los otros modos saltan el gate
+de forma **explícita y auditada** — nunca por inferencia ni por ausencia de
+labels.
+
+## Tabla de modos
+
+| `qaMode`     | Cuándo aplica                                                  | Requiere video + audio | Requiere logs API | Criterio del preflight                  |
+|--------------|----------------------------------------------------------------|------------------------|-------------------|-----------------------------------------|
+| `android`    | Issues con label `app:client`, `app:business` o `app:delivery` | **Sí**                 | No                | `requiresEmulator === true`             |
+| `api`        | Backend puro (`area:backend` sin ningún `app:*`)               | No                     | **Sí**            | `hasBackendLabel && !requiresEmulator`  |
+| `structural` | Docs, infra, pipeline (sin `app:*` ni `area:backend`)          | No                     | No                | Ningún label de ruteo QA                |
+
+## Reglas de bypass (R1 — Security)
+
+1. **Whitelist explícita**: sólo `qaMode === 'api'` o `qaMode === 'structural'`
+   saltan la evidencia audiovisual. Cualquier otro valor (`android`, `ui`,
+   vacío, desconocido) **exige** video.
+2. **Autoridad**: el `qaMode` que usa el gate viene del preflight del Pulpo
+   (`preflightQaChecks` en `.pipeline/pulpo.js`), cacheado en memoria. Si
+   falta (ej. tras un restart), se cae al `modo` del YAML del agente — el
+   Pulpo ya inyecta el `modo` en el YAML antes de lanzar al agente QA para
+   que este fallback siga siendo correcto.
+3. **Nunca inferir**: la ausencia de labels `app:*` por sí sola **no** activa
+   el bypass. Un issue UI al que accidentalmente le falten labels sigue
+   exigiendo video.
+
+## Logging auditable (R3 — Security, CA-3)
+
+Cada bypass emite un log estructurado con prefijo legible + JSON inline:
+
+```
+[2026-04-20 21:14:02] [gate-bypass] 🟢 gate-bypass #2023 qaMode=api source=preflight — QA-API no requiere evidencia audiovisual {"event":"gate-bypass","issue":"2023","qaMode":"api","source":"preflight","labels":["area:backend"],"decision":"skip-video","reason":"QA-API no requiere evidencia audiovisual"}
+```
+
+El JSON final es parseable — cualquier herramienta puede consumirlo (monitor,
+auditorías, métricas). Los campos:
+
+| Campo     | Descripción                                                       |
+|-----------|-------------------------------------------------------------------|
+| `event`   | `gate-bypass` (constante)                                         |
+| `issue`   | Número del issue (string)                                         |
+| `qaMode`  | Modo normalizado (`api`, `structural`)                            |
+| `source`  | `preflight` (autoritativo) / `yaml` (fallback) / `none` (sin info)|
+| `labels`  | Labels del issue al momento del check                             |
+| `decision`| `skip-video` (constante)                                          |
+| `reason`  | Frase legible en español                                          |
+
+## Pattern-match de APK en `rejection-report.js` (R2 + R5, CA-2)
+
+El rejection-report usaba un regex laxo sobre el buffer crudo del log para
+detectar "APK no se pudo generar". Eso disparaba falsos positivos cuando:
+
+- Paths/filenames del proyecto contenían palabras como `apk-not-found`
+  (matcheaba sin ser un error real).
+- Tareas Release fallaban por un bug conocido de AGP + Kotlin MP
+  (`bundle<Flavor>ReleaseClassesToRuntimeJar`) mientras los APKs Debug **sí**
+  se generaban bien.
+
+### Nuevo contrato del matcher
+
+1. **R5 — Líneas de falla real**: el regex aplica sólo a líneas que empiezan
+   con `FAILURE:` o contienen `> Task ... FAILED`. Si el texto crudo menciona
+   "apk-not-found" en un path pero no hay líneas de falla real, no se dispara
+   el match.
+2. **R2 — APK fresco**: si el match dispara, se verifica el APK Debug de cada
+   flavor en `app/composeApp/build/outputs/apk/<flavor>/debug/`. Un APK se
+   considera **válido** sólo si `mtime > buildStartTime`. APKs stale (p.ej.
+   de hace 3 días) **no** enmascaran un build actual roto.
+3. **buildStartTime** se estima a partir de `elapsed` (duración del agente)
+   más un margen de seguridad de 10 min. Si no hay `elapsed` confiable, usa
+   una ventana de 30 min hacia atrás.
+4. **Descarte auditado**: cuando el match se descarta porque hay APKs frescos,
+   se emite un log estructurado `match-dismissed` con el detalle de cada
+   flavor (edad, tamaño, fresh/stale).
+
+```
+[rejection-report] match-dismissed {"event":"match-dismissed","issue":"2023","pattern":"apk_not_generated","reason":"APK(s) debug frescos presentes — la falla probable es sólo de tasks Release (bug AGP+KMP)","apkStatus":{"anyFresh":true,"allFresh":true,"allPresent":true,"flavors":[{"flavor":"client","exists":true,"fresh":true,"ageSec":120,"sizeKb":25340},...]}}
+```
+
+## Bypass quirúrgico (R4, CA-4)
+
+Los cambios **no** afectan a:
+
+- El gate de `verifier` (tester/qa/security).
+- La validación de labels requeridos para ruteo.
+- El gate de QA para merge del PR.
+- La detección de otros patrones en `rejection-report.js` (timeouts,
+  crashes, deserialización, etc.).
+
+Sólo se tocan: `validateQaEvidence` + el sitio `gate-evidencia-on-exit` en
+`.pipeline/pulpo.js`, y el pattern-match de APK en `.pipeline/rejection-report.js`.
+
+## Archivos implicados
+
+- `.pipeline/pulpo.js` — gate + cache de `qaMode` autoritativo.
+- `.pipeline/rejection-report.js` — pattern-match + check de frescura.
+- `.pipeline/lib/qa-evidence-gate.js` — resolución de `qaMode` + bypass event.
+- `.pipeline/lib/apk-freshness.js` — extracción de líneas de falla + check APK.
+- `.pipeline/lib/__tests__/qa-evidence-gate.test.js` — tests CA-1, CA-6, R1, R3.
+- `.pipeline/lib/__tests__/apk-freshness.test.js` — tests CA-2, R2, R5.


### PR DESCRIPTION
## Resumen

Desbloquea el pipeline cuando el APK no se regenera: el gate de evidencia QA ahora respeta `qaMode` autoritativo via whitelist (`api` / `structural`), y el rejection-report descarta matches APK falso-positivos cuando existe APK Debug fresco (mtime > buildStartTime).

## Cambios

- **`.pipeline/lib/qa-evidence-gate.js`** — Gate unificado con whitelist explicita de qaMode (R1).
- **`.pipeline/lib/apk-freshness.js`** — Valida APKs Debug existentes con mtime > buildStartTime (R2 + R5).
- **`.pipeline/pulpo.js`** — Integracion del nuevo gate en `gate-evidencia-on-exit`, con logging JSON estructurado (R3) y bypass quirurgico que no afecta verifier/labels/PR gate (R4).
- **`.pipeline/rejection-report.js`** — Pattern-match APK restringido a lineas `FAILURE:` / `Task ... FAILED` (R5).
- **Tests (40 nuevos)** — `qa-evidence-gate` (18/18) + `apk-freshness` (22/22), `node --test` nativo.
- **`docs/qa/qa-mode-gate.md`** — Tabla de modos QA (ui / api / structural) y criterios de bypass.

## Criterios de aceptacion

- [x] CA-1: Gate respeta qaMode por whitelist + cache autoritativo del preflight.
- [x] CA-2: Rejection-report descarta match APK cuando Debug existe y es fresco.
- [x] CA-3: Logs estructurados JSON inline para `gate-bypass` y `match-dismissed`.
- [x] CA-4: Bypass quirurgico — no toca verifier, ruteo ni gate de PR.
- [x] CA-5: #2023 puede reintentarse (qaMode=`api` satura bypass correctamente).
- [x] CA-6: Issues UI siguen exigiendo video (qaMode=`android` sigue pidiendo evidencia).

## Validacion

- 40 tests Node.js OK (`node --test`).
- Smoke test APK client: app abre en welcome, navega a login y vuelve sin errores (video en `qa/evidence/2351/`).
- OWASP Top 10 sin hallazgos (security audit).
- Review + PO + UX aprobados.

## QA

`qa:passed` (infra del pipeline con smoke test APK + 40 tests unitarios).

Closes #2351