### PR TITLE
fix(pipeline): normalizar JAVA_HOME stale al arrancar pulpo/servicios

### DIFF
--- a/.pipeline/lib/java-home-normalizer.js
+++ b/.pipeline/lib/java-home-normalizer.js
@@ -1,0 +1,104 @@
+// =============================================================================
+// java-home-normalizer.js — Saneado global de JAVA_HOME para el pipeline
+//
+// Incidente 2026-04-21: varios agentes builder fallaron porque heredaban
+// JAVA_HOME=C:\Program Files\JetBrains\IntelliJ IDEA 2024.3.1\jbr — una ruta
+// stale que dejaba de existir al reinstalar/actualizar IntelliJ. El gradlew
+// aborta antes de compilar y el log del build queda vacío/sin timestamp
+// nuevo, haciendo parecer que el dev "no trabajó".
+//
+// Este módulo corre una sola vez al arranque de cada proceso raíz del
+// pipeline (pulpo, restart, smoke-test, cualquier helper que spawnee gradle).
+// Sobrescribe `process.env.JAVA_HOME` a un Temurin 21 válido del sistema si
+// la variable apunta a algo inexistente o sin `bin/java`. Todos los hijos
+// que spawnee el proceso heredan el valor corregido.
+// =============================================================================
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+function isValidJavaHome(candidate) {
+    if (!candidate || typeof candidate !== 'string') return false;
+    try {
+        const exe = process.platform === 'win32' ? 'java.exe' : 'java';
+        return fs.existsSync(path.join(candidate, 'bin', exe));
+    } catch {
+        return false;
+    }
+}
+
+function pickTemurin21() {
+    const candidates = [];
+
+    // Preferencia #1: variable explícita para el pipeline (permite override fácil).
+    if (process.env.PIPELINE_JAVA_HOME) candidates.push(process.env.PIPELINE_JAVA_HOME);
+    if (process.env.JAVA_HOME_21) candidates.push(process.env.JAVA_HOME_21);
+
+    // #2: carpeta .jdks del usuario (IntelliJ coloca acá los toolchains descargados).
+    const home = os.homedir();
+    if (home) {
+        const jdksDir = path.join(home, '.jdks');
+        try {
+            if (fs.existsSync(jdksDir)) {
+                const entries = fs.readdirSync(jdksDir).filter((n) => /^temurin-21/i.test(n));
+                entries.sort().reverse(); // más nuevo primero (string sort alcanza para 21.x.y)
+                for (const name of entries) candidates.push(path.join(jdksDir, name));
+            }
+        } catch { /* best-effort */ }
+    }
+
+    // #3: Temurin instalado vía MSI en Program Files.
+    const pf = process.env['ProgramFiles'] || 'C:\\Program Files';
+    const temurinRoot = path.join(pf, 'Eclipse Adoptium');
+    try {
+        if (fs.existsSync(temurinRoot)) {
+            const entries = fs.readdirSync(temurinRoot).filter((n) => /jdk-21/i.test(n));
+            entries.sort().reverse();
+            for (const name of entries) candidates.push(path.join(temurinRoot, name));
+        }
+    } catch { /* best-effort */ }
+
+    return candidates.find(isValidJavaHome) || null;
+}
+
+/**
+ * Normaliza process.env.JAVA_HOME al arranque del proceso.
+ *
+ * @param {object} [opts]
+ * @param {(msg: string) => void} [opts.log] — función de logging opcional
+ * @returns {{changed: boolean, previous: string|null, current: string|null, reason: string}}
+ */
+function normalizeJavaHome(opts = {}) {
+    const log = typeof opts.log === 'function' ? opts.log : () => {};
+    const previous = process.env.JAVA_HOME || null;
+    const previousOk = isValidJavaHome(previous);
+
+    if (previousOk) {
+        return { changed: false, previous, current: previous, reason: 'valid' };
+    }
+
+    const chosen = pickTemurin21();
+    if (!chosen) {
+        log(`[java-home-normalizer] JAVA_HOME inválido (${previous || 'unset'}) y no se encontró Temurin 21 en el sistema`);
+        return { changed: false, previous, current: previous, reason: 'no-temurin-found' };
+    }
+
+    process.env.JAVA_HOME = chosen;
+
+    // Reforzar el PATH para que `java`/`javac` también resuelvan al nuevo JDK.
+    // Agregamos el bin/ al FRENTE del PATH (idempotente — no duplicamos si ya estaba).
+    const binDir = path.join(chosen, 'bin');
+    const sep = process.platform === 'win32' ? ';' : ':';
+    const pathParts = (process.env.PATH || '').split(sep).filter(Boolean);
+    if (!pathParts.some((p) => path.resolve(p).toLowerCase() === path.resolve(binDir).toLowerCase())) {
+        process.env.PATH = [binDir, ...pathParts].join(sep);
+    }
+
+    const reason = previous ? 'stale-path' : 'unset';
+    log(`[java-home-normalizer] JAVA_HOME ${reason}: "${previous || ''}" → "${chosen}"`);
+    return { changed: true, previous, current: chosen, reason };
+}
+
+module.exports = { normalizeJavaHome, isValidJavaHome, pickTemurin21 };

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -29,6 +29,18 @@ const { createLogFileWriter } = require('./lib/sanitize-log-stream');
 // #2334 / CA6: patch global de console.* para que nada pase al log de pulpo
 // (archivo `logs/pulpo.log` que hereda stdout/stderr vía fd).
 require('./lib/sanitize-console').install();
+// Saneado global de JAVA_HOME — si el pulpo heredó una ruta stale (ej. JBR de
+// una versión vieja de IntelliJ), la corregimos acá antes de spawnear agentes,
+// así todos los hijos (builder, tester, qa, etc.) reciben un JDK válido.
+// Incidente 2026-04-21: gradlew abortaba con "JAVA_HOME is set to an invalid
+// directory" y el log quedaba sin error real, confundiendo al rebote como si
+// fuera falla de código.
+require('./lib/java-home-normalizer').normalizeJavaHome({
+  log: (msg) => {
+    try { fs.appendFileSync(path.join(__dirname, 'logs', 'pulpo.log'), `[${new Date().toISOString()}] ${msg}\n`); } catch {}
+    console.error(msg);
+  },
+});
 
 // #2337 CA10: cleanup perezoso + startup de metricas UX (REQ-SEC-5)
 try { uxMetrics.cleanup({ force: true }); } catch { /* best-effort */ }

--- a/.pipeline/qa-environment.js
+++ b/.pipeline/qa-environment.js
@@ -14,6 +14,13 @@ const { execSync, spawn } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 
+// Saneado global de JAVA_HOME — qa-environment se ejecuta standalone y como
+// hijo de svc-emulador; en ambos casos hay que asegurar JDK válido para los
+// scripts de QA Android que disparan gradle. Incidente 2026-04-21.
+require('./lib/java-home-normalizer').normalizeJavaHome({
+  log: (msg) => console.error(msg),
+});
+
 const PIPELINE = process.env.PIPELINE_STATE_DIR || path.resolve(__dirname);
 const ROOT = process.env.PIPELINE_MAIN_ROOT || path.resolve(PIPELINE, '..');
 const STATE_FILE = path.join(PIPELINE, 'qa-env-state.json');

--- a/.pipeline/restart.js
+++ b/.pipeline/restart.js
@@ -23,6 +23,13 @@ const {
 } = require('./pid-discovery');
 const { clearAllMarkers } = require('./lib/ready-marker');
 
+// Saneado global de JAVA_HOME — si restart.js heredó una ruta stale (ej. JBR
+// de IntelliJ obsoleto), la corregimos antes de spawnear pulpo/servicios, así
+// todos los hijos reciben un JDK válido. Incidente 2026-04-21.
+require('./lib/java-home-normalizer').normalizeJavaHome({
+  log: (msg) => console.error(msg),
+});
+
 const PIPELINE = path.resolve(__dirname);
 const ROOT = path.resolve(PIPELINE, '..');
 

--- a/.pipeline/servicio-emulador.js
+++ b/.pipeline/servicio-emulador.js
@@ -14,6 +14,12 @@ const { execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 
+// Saneado global de JAVA_HOME — propaga un JDK válido a qa-environment y a
+// los builds QA que corren contra el emulador. Incidente 2026-04-21.
+require('./lib/java-home-normalizer').normalizeJavaHome({
+  log: (msg) => console.error(msg),
+});
+
 const PIPELINE = process.env.PIPELINE_STATE_DIR || path.resolve(__dirname);
 const ROOT = process.env.PIPELINE_MAIN_ROOT || path.resolve(__dirname, '..');
 const LOG_DIR = path.join(PIPELINE, 'logs');

--- a/.pipeline/servicio-github.js
+++ b/.pipeline/servicio-github.js
@@ -9,6 +9,11 @@ const fs = require('fs');
 const path = require('path');
 // #2334: sanitización write-time.
 require('./lib/sanitize-console').install();
+// Saneado global de JAVA_HOME — este servicio spawnea agentes Claude que
+// pueden invocar gradle; hereda y propaga el valor a sus hijos.
+require('./lib/java-home-normalizer').normalizeJavaHome({
+  log: (msg) => console.error(msg),
+});
 const { sanitize } = require('./sanitizer');
 const { sanitizeGithubPayload } = require('./lib/sanitize-payload');
 


### PR DESCRIPTION
## Summary

- Nuevo `lib/java-home-normalizer.js` que detecta `JAVA_HOME` apuntando a rutas inválidas y lo reemplaza por el primer Temurin 21 válido del sistema.
- Cableado en los 5 puntos del pipeline que spawnean gradle vía hijos: `pulpo.js`, `restart.js`, `qa-environment.js`, `servicio-emulador.js`, `servicio-github.js`.
- Todos los hijos (builder, agentes, QA) heredan un `JAVA_HOME` saneado.

## Contexto del incidente (2026-04-21)

7 issues (#1923, #1931, #1934, #1947, #1952, #1953, #1954) quedaron rechazados con rama `agent/<issue>-android-dev` vacía (0 commits), haciendo parecer que el android-dev no trabajó. La causa real: el pulpo heredó `JAVA_HOME` apuntando a `IntelliJ IDEA 2024.3.1/jbr` (instalación de IntelliJ ya removida). El gradlew abortaba con `JAVA_HOME is set to an invalid directory` antes de compilar nada, y el rebote genérico lo clasificaba como falla de código.

El fix actúa al arranque de cada proceso del pipeline — no requiere tocar configuración del agente ni del OS.

## Test plan

- [x] `node -e "require('./.pipeline/lib/java-home-normalizer').normalizeJavaHome({log: console.error})"` con `JAVA_HOME` válido → no lo toca.
- [ ] Reanudar pipeline (pausado desde 10:50 AM) y validar que los próximos agentes android-dev producen commits.
- [ ] Confirmar que `build.log` ya no contiene "JAVA_HOME is set to an invalid directory".

🤖 Generated with [Claude Code](https://claude.com/claude-code)