### PR TITLE
fix(pipeline): planner registra deps al splittear + auto-close paraguas

### DIFF
--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -5745,7 +5745,7 @@ function brazoDesbloqueo(config) {
     // 1. Buscar issues abiertos con label blocked:dependencies
     ghThrottle();
     const result = execSync(
-      `"${GH_BIN}" issue list --label "blocked:dependencies" --state open --json number,title --limit 50`,
+      `"${GH_BIN}" issue list --label "blocked:dependencies" --state open --json number,title,labels --limit 50`,
       { cwd: ROOT, encoding: 'utf8', timeout: 30000, windowsHide: true }
     );
     const blockedIssues = JSON.parse(result || '[]');
@@ -5829,8 +5829,9 @@ function brazoDesbloqueo(config) {
         }
 
         if (allClosed) {
-          // 4. Todas cerradas → desbloquear
-          log('desbloqueo', `#${issue.number}: todas las dependencias cerradas (${depIssueNumbers.join(', ')}) → desbloqueando`);
+          // 4. Todas cerradas → desbloquear (o auto-cerrar si es paraguas `split`)
+          const issueLabelNames = (issue.labels || []).map(l => l.name);
+          const isSplitParent = issueLabelNames.includes('split');
 
           // Quitar de los mapeos (ya no está bloqueado)
           delete blockedBy[issue.number];
@@ -5839,23 +5840,42 @@ function brazoDesbloqueo(config) {
             if (blocks[dep] && blocks[dep].length === 0) delete blocks[dep];
           }
 
-          // Quitar label blocked:dependencies
-          ghThrottle();
-          execSync(
-            `"${GH_BIN}" issue edit ${issue.number} --remove-label "blocked:dependencies" --repo intrale/platform`,
-            { cwd: ROOT, timeout: 10000, windowsHide: true }
-          );
+          if (isSplitParent) {
+            // Paraguas: las hijas cubren el scope, se cierra el padre sin reingresar al pipeline
+            log('desbloqueo', `#${issue.number}: paraguas split con todas las hijas cerradas (${depIssueNumbers.join(', ')}) → auto-cerrando`);
+            const closeComment = `## ✅ Paraguas resuelto\n\nEste issue era un paraguas (label \`split\`) y todas sus historias hijas fueron cerradas (${depIssueNumbers.map(n => '#' + n).join(', ')}). El scope queda cubierto por las hijas, no requiere desarrollo adicional.\n\n_Cerrado automáticamente por el brazo de desbloqueo del pipeline._`;
+            ghThrottle();
+            try {
+              execSync(
+                `"${GH_BIN}" issue close ${issue.number} --reason completed --comment "${closeComment.replace(/"/g, '\\"')}" --repo intrale/platform`,
+                { cwd: ROOT, timeout: 10000, windowsHide: true }
+              );
+              sendTelegram(`🟢 Paraguas #${issue.number} cerrado automáticamente — todas las hijas del split (${depIssueNumbers.map(n => '#' + n).join(', ')}) resueltas.`);
+              log('desbloqueo', `#${issue.number} paraguas cerrado exitosamente`);
+            } catch (e) {
+              log('desbloqueo', `Error cerrando paraguas #${issue.number}: ${e.message}`);
+            }
+          } else {
+            log('desbloqueo', `#${issue.number}: todas las dependencias cerradas (${depIssueNumbers.join(', ')}) → desbloqueando`);
 
-          // Agregar comentario de desbloqueo
-          const unblockComment = `## ✅ Issue desbloqueado automáticamente\n\nTodas las dependencias fueron resueltas (${depIssueNumbers.map(n => '#' + n).join(', ')}). Este issue vuelve a la cola del pipeline para ser procesado.`;
-          ghThrottle();
-          execSync(
-            `"${GH_BIN}" issue comment ${issue.number} --body "${unblockComment.replace(/"/g, '\\"')}" --repo intrale/platform`,
-            { cwd: ROOT, timeout: 10000, windowsHide: true }
-          );
+            // Quitar label blocked:dependencies
+            ghThrottle();
+            execSync(
+              `"${GH_BIN}" issue edit ${issue.number} --remove-label "blocked:dependencies" --repo intrale/platform`,
+              { cwd: ROOT, timeout: 10000, windowsHide: true }
+            );
 
-          sendTelegram(`🔓 Issue #${issue.number} desbloqueado — todas las dependencias resueltas (${depIssueNumbers.map(n => '#' + n).join(', ')}). Vuelve a la cola del pipeline.`);
-          log('desbloqueo', `#${issue.number} desbloqueado exitosamente`);
+            // Agregar comentario de desbloqueo
+            const unblockComment = `## ✅ Issue desbloqueado automáticamente\n\nTodas las dependencias fueron resueltas (${depIssueNumbers.map(n => '#' + n).join(', ')}). Este issue vuelve a la cola del pipeline para ser procesado.`;
+            ghThrottle();
+            execSync(
+              `"${GH_BIN}" issue comment ${issue.number} --body "${unblockComment.replace(/"/g, '\\"')}" --repo intrale/platform`,
+              { cwd: ROOT, timeout: 10000, windowsHide: true }
+            );
+
+            sendTelegram(`🔓 Issue #${issue.number} desbloqueado — todas las dependencias resueltas (${depIssueNumbers.map(n => '#' + n).join(', ')}). Vuelve a la cola del pipeline.`);
+            log('desbloqueo', `#${issue.number} desbloqueado exitosamente`);
+          }
         } else {
           log('desbloqueo', `#${issue.number}: dependencias abiertas: ${openDeps.map(n => '#' + n).join(', ')} — sigue bloqueado`);
         }

--- a/.pipeline/roles/planner.md
+++ b/.pipeline/roles/planner.md
@@ -17,8 +17,13 @@ Sos el dimensionador de historias de Intrale.
    - Título: `[Split de #<parent>] <descripción>`
    - Body: referencia a la historia madre + criterios específicos de la parte
    - Labels: mismos que la historia madre + `needs-definition`
-3. Marcá la historia original como "dividida" (comentario + label `split`)
+3. Marcá la historia original como "dividida":
+   - Label `split` (indica que es un paraguas)
+   - Label `blocked:dependencies` (bloquea el intake hasta que cierren las hijas)
+   - Comentario con encabezado EXACTO **`## Dependencias detectadas por el pipeline`** listando `#NNNN` de cada hija (el brazo de desbloqueo parsea este formato)
+   - El label `Ready` se mantiene — es el `blocked:dependencies` el que impide el intake, no hace falta quitarlo
 4. Las historias hijas entran al pipeline de definición en fase `criterios` (no desde cero)
+5. Cuando las hijas cierren, el brazo de desbloqueo quita `blocked:dependencies` automáticamente y el paraguas vuelve a la cola; el Guru/PO lo cerrará si detecta que el scope ya fue cubierto
 
 ### Resultado
 - Si simple o medio: `resultado: aprobado` + agregar label `size:simple` o `size:medium` al issue


### PR DESCRIPTION
## Contexto

Causa raíz del loop de rechazos del #2401 (y cualquier futuro paraguas `split`): el Planner dividía historias grandes en hijas pero **no registraba la relación de dependencia** en un formato que el intake del pulpo pudiera respetar. Resultado: el intake re-encolaba el paraguas, el Guru lo rechazaba ("scope cubierto por hijas"), vuelta a empezar.

Diseño acordado con Leo (2026-04-21):
- Planner splitea → hijas registradas como `blocked:dependencies` del padre.
- Intake respeta el label → padre queda bloqueado hasta que cierren las hijas.
- Cuando cierran todas, el pipeline **auto-cierra el paraguas** (no requiere re-intake ni intervención del Guru).

## Cambios

### `.pipeline/roles/planner.md`
Protocolo de split actualizado. Al marcar el paraguas, ahora exige:
- Label `split` (meta-issue).
- Label `blocked:dependencies` (bloquea intake).
- Comentario con encabezado exacto `## Dependencias detectadas por el pipeline` listando las `#NNNN` de cada hija. Es el formato que ya parsea `brazoDesbloqueo`.
- El label `Ready` se mantiene — `blocked:dependencies` es el que impide el intake.

### `.pipeline/pulpo.js` (brazoDesbloqueo)
Cuando todas las hijas cierran:
- Si el padre tiene label `split` → **auto-close** con `reason=completed` + comentario explicativo + notificación Telegram.
- Si no es paraguas → comportamiento previo (quita `blocked:dependencies`, re-encola).

## Fix manual aplicado al #2401

Como el pipeline está pausado, apliqué en paralelo el fix al issue actual (no borra trabajo, solo arregla los labels):
- `#2401` ahora tiene `blocked:dependencies` + comentario con deps `#2404`, `#2405`, `#2406`.
- `#2406` tenía `split` espurio (es hija, no padre) — removido.

## QA

Cambio puro de infra del pipeline (`.pipeline/roles/` y `.pipeline/pulpo.js`), sin impacto en producto de usuario → `qa:skipped` según CLAUDE.md.

Closes #2401 cuando mergeen las hijas.