### PR TITLE
fix(pipeline): timeout 60min + cleanup daemons tras watchdog (#2400)

### DIFF
--- a/.pipeline/config.yaml
+++ b/.pipeline/config.yaml
@@ -180,6 +180,12 @@ timeouts:
     qa: 45                        # QA E2E con emulador + video
     tester: 45                    # Cobertura Kover + suite completa
     delivery: 90                  # Espera CI completo (OWASP ~28min, check-app ~15min) + gate de review + merge + reporte
+    # Dev agents: features complejas que implementan ToDo/Do/Comm/Client + ViewModel +
+    # pantalla Compose + tests + build de verificación local. 30min es insuficiente
+    # (incidente #1931: android-dev timeout en feature IA con scope grande). Ver #2400.
+    android-dev: 60
+    backend-dev: 60
+    web-dev: 60
 
 # GitHub
 github:

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -3859,11 +3859,24 @@ function lanzarAgenteClaude(skill, issue, trabajandoPath, pipeline, fase, config
   const timeoutDefault = config.timeouts?.agent_timeout_default_minutes || 30;
   const timeoutMin = timeoutOverrides[skill] ?? timeoutDefault;
   const timeoutMs = timeoutMin * 60 * 1000;
+  // #2400: log del origen del timeout (override vs default) para debug de DevEx.
+  const timeoutOrigin = (skill in timeoutOverrides) ? 'override' : 'default';
   const watchdog = setTimeout(() => {
     if (child.exitCode === null && child.signalCode === null) {
-      log('lanzamiento', `⏱️ ${skill}:#${issue} excedió ${timeoutMin}min — matando (watchdog)`);
+      log('lanzamiento', `⏱️ ${skill}:#${issue} excedió ${timeoutMin}min (${timeoutOrigin}) — matando (watchdog)`);
       try { child.kill('SIGTERM'); } catch {}
       setTimeout(() => { try { child.kill('SIGKILL'); } catch {} }, 10000);
+      // #2400: paridad con fast-fail — limpiar Gradle daemons huérfanos tras el kill.
+      // Delay 15s para dejar que SIGTERM→SIGKILL cierren el proceso primero.
+      const cleanupCwd = (needsWorktree || useExistingWorktree) ? worktreePath : ROOT;
+      setTimeout(() => {
+        try {
+          const killed = killGradleDaemonsForCwd(cleanupCwd, `${skill}:#${issue} (watchdog)`);
+          log('lanzamiento', `🧹 cleanup post-watchdog ${skill}:#${issue}: ${killed || 0} daemons Gradle terminados`);
+        } catch (e) {
+          log('lanzamiento', `⚠️ cleanup post-watchdog ${skill}:#${issue} falló: ${e.message}`);
+        }
+      }, 15000);
       try {
         const data = readYaml(trabajandoPath);
         data.resultado = 'rechazado';


### PR DESCRIPTION
## Summary

- Extiende timeout watchdog a 60min para agentes de desarrollo (`android-dev`, `backend-dev`, `web-dev`) en `.pipeline/config.yaml`, alineado con el patrón ya aceptado en #2218 para `build: 60`.
- Agrega cleanup de Gradle daemons tras el kill del watchdog en `.pipeline/pulpo.js`, replicando el path de `fast-fail` para evitar daemons huérfanos y locks de archivos en Windows.
- Scope acotado exclusivamente a `.pipeline/*` — sin cambios Kotlin, sin deps nuevas, sin migraciones.

## Contexto

Desbloquea #1931 (feature IA de estimación de delivery en tiempo real) que fue rechazada por watchdog a los 30min. El agente NO estaba en loop — el scope legítimo del feature (ToDo/Do/Comm/Client + ViewModel + Compose + build de verificación) excedía el default de 30min.

## Archivos tocados
- `.pipeline/config.yaml` — 3 overrides nuevos (android-dev, backend-dev, web-dev = 60min)
- `.pipeline/pulpo.js` — invoca `killGradleDaemonsForCwd()` tras SIGKILL del watchdog

## QA
- `qa:skipped` — infra pura del pipeline V2, no hay UI end-user ni flujo de producto. Verificación operativa documentada en CA-8 del issue.
- Análisis de seguridad aprobado (fase verificación): sin vulnerabilidades, cumple los 5 requisitos de seguridad documentados.

## Test plan
- [x] Build `./gradlew check --no-daemon` verificado en fase de build
- [x] Tester + QA + Security aprobaron verificación
- [x] Sin cambios de stack Kotlin (backend/users/app/tools/buildSrc intactos)
- [ ] Tras merge: reabrir #1931 y confirmar que termina dentro de 60min

Closes #2400