### PR TITLE
fix(pipeline): timeout mínimo 60min para todos los agentes dev

### DIFF
--- a/.pipeline/config.yaml
+++ b/.pipeline/config.yaml
@@ -176,6 +176,10 @@ timeouts:
   # Si un skill no está en el override, se usa agent_timeout_default_minutes.
   agent_timeout_default_minutes: 30
   agent_timeout_overrides:
+    backend-dev: 60               # Dev mínimo 60min: historias grandes necesitan tiempo
+    android-dev: 60               # Dev mínimo 60min: historias grandes necesitan tiempo
+    web-dev: 60                   # Dev mínimo 60min: historias grandes necesitan tiempo
+    pipeline-dev: 60              # Dev mínimo 60min: historias grandes necesitan tiempo
     build: 60                     # Gradle check + assemble puede tardar mucho en primer build
     qa: 45                        # QA E2E con emulador + video
     tester: 45                    # Cobertura Kover + suite completa


### PR DESCRIPTION
## Resumen

Eleva el timeout de watchdog de 30 a 60 minutos para todos los agentes dev (`backend-dev`, `android-dev`, `web-dev`, `pipeline-dev`). El default de 30min era insuficiente para historias grandes y cortaba desarrollos en progreso (ej: dev del #1405).

## Cambio

Un solo archivo, sección `timeouts.agent_timeout_overrides` de `.pipeline/config.yaml`:

```yaml
agent_timeout_overrides:
  backend-dev: 60
  android-dev: 60
  web-dev: 60
  pipeline-dev: 60
  build: 60
  qa: 45
  tester: 45
  delivery: 90
```

## Hot-reload

`loadConfig()` se ejecuta en cada ciclo de poll, así que el cambio aplica al próximo spawn sin reiniciar el pulpo.

## QA

`qa:skipped` — cambio puro de configuración del pipeline, sin impacto en producto de usuario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)