### PR TITLE
fix(pipeline): elimina duplicados en agent_timeout_overrides (YAML crash Pulpo)

### DIFF
--- a/.pipeline/config.yaml
+++ b/.pipeline/config.yaml
@@ -184,12 +184,6 @@ timeouts:
     qa: 45                        # QA E2E con emulador + video
     tester: 45                    # Cobertura Kover + suite completa
     delivery: 90                  # Espera CI completo (OWASP ~28min, check-app ~15min) + gate de review + merge + reporte
-    # Dev agents: features complejas que implementan ToDo/Do/Comm/Client + ViewModel +
-    # pantalla Compose + tests + build de verificación local. 30min es insuficiente
-    # (incidente #1931: android-dev timeout en feature IA con scope grande). Ver #2400.
-    android-dev: 60
-    backend-dev: 60
-    web-dev: 60
 
 # GitHub
 github:


### PR DESCRIPTION
## Summary
- PRs #2418 y #2419 agregaron el mismo override de timeout (backend-dev, android-dev, web-dev) en dos lugares del mismo bloque, dejando `config.yaml` con `duplicated mapping key` en la línea 190.
- Pulpo crashea al parsear: `YAMLException: duplicated mapping key (190:5)`.
- Watchdog hace `git reset --hard FETCH_HEAD` a origin/main cada 2 min → relaunch Pulpo → crash → loop infinito. Pipeline V2 **inoperativo**.

## Cambio
Se eliminan las 6 líneas duplicadas del final del bloque (187-192, agregadas por #2418). Se mantiene el bloque de arriba (agregado por #2419) porque es más completo (incluye `pipeline-dev` y comentarios descriptivos).

## Validación
- \`node -e "require('js-yaml').load(fs.readFileSync('.pipeline/config.yaml','utf8'))"\` → OK
- Pulpo arranca y procesa 156 issues (verificado localmente con fix aplicado)

## Test plan
- [x] YAML parsea sin errores
- [x] Pulpo arranca sin crash
- [x] Dashboard \`/api/state\` reporta \`pulpo: alive\` + issues en \`issueMatrix\`

qa:skipped — cambio de config interno del pipeline, sin impacto en producto de usuario.

Closes ninguno (no había issue abierto; detectado en sesión de diagnóstico 2026-04-21).

🤖 Generated with [Claude Code](https://claude.com/claude-code)