### PR TITLE
feat(pipeline): salvaguardas de resiliencia y seguridad (#2405)

### DIFF
--- a/.pipeline/backup-agent-branch.js
+++ b/.pipeline/backup-agent-branch.js
@@ -1,0 +1,352 @@
+// =============================================================================
+// backup-agent-branch.js — Helper para crear tags de backup antes de operaciones
+// destructivas (reset/merge) sobre ramas `agent/*`.
+//
+// Criterio CA-2 del issue #2405:
+//   - Si hay commits locales no pusheados, crear tag local
+//     `backup/agent-<issue>-<skill>-<YYYYMMDDTHHMMSSZ>-<rand4>`
+//   - Loggear a `.pipeline/logs/audit-<issue>.log` con prefijo `[BACKUP]`,
+//     SHA del tip, y el comando de reverso `git reset --hard <tag>`.
+//   - Tags son LOCALES (nunca `git push --tags` implícito).
+//   - Colisión de nombre → reintento con nuevo rand4 (no `--force`).
+//
+// Uso programático:
+//   const { backupAgentBranch } = require('./backup-agent-branch');
+//   const result = backupAgentBranch({ issue: 2405, skill: 'pipeline-dev', cwd: '.' });
+//   if (result.ok && result.created) console.log(`Tag creado: ${result.tag}`);
+//
+// Uso CLI:
+//   node .pipeline/backup-agent-branch.js --issue 2405 --skill pipeline-dev [--cwd path]
+// =============================================================================
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { execSync, spawnSync } = require('child_process');
+
+const PIPELINE = path.resolve(__dirname);
+const LOG_DIR = path.join(PIPELINE, 'logs');
+
+/**
+ * ISO-8601 UTC compacto sin puntuación — seguro como sufijo de tag git.
+ * Ej: 20260421T210345Z
+ */
+function timestampUtcCompact(date = new Date()) {
+  return date.toISOString().replace(/[-:]/g, '').replace(/\.\d+Z$/, 'Z');
+}
+
+/**
+ * Devuelve `count` hex chars pseudo-aleatorios (seguro suficiente para
+ * disambiguar tags creados en el mismo segundo).
+ */
+function randomHex(count = 4) {
+  const chars = '0123456789abcdef';
+  let out = '';
+  for (let i = 0; i < count; i++) out += chars[Math.floor(Math.random() * 16)];
+  return out;
+}
+
+/**
+ * Ejecuta git con captura de stdout/stderr. Lanza error con mensaje claro si
+ * el exit code != 0.
+ *
+ * Usamos spawnSync en vez de execSync para evitar problemas de quoting.
+ */
+function git(args, cwd) {
+  const res = spawnSync('git', args, {
+    cwd: cwd || process.cwd(),
+    encoding: 'utf8',
+    windowsHide: true,
+  });
+  if (res.status !== 0) {
+    const stderr = (res.stderr || '').trim();
+    const err = new Error(`git ${args.join(' ')} failed (exit ${res.status}): ${stderr}`);
+    err.stdout = res.stdout;
+    err.stderr = res.stderr;
+    err.status = res.status;
+    throw err;
+  }
+  return (res.stdout || '').trim();
+}
+
+/**
+ * Detecta la rama actual. Devuelve null si HEAD está detached.
+ */
+function currentBranch(cwd) {
+  try {
+    const out = git(['rev-parse', '--abbrev-ref', 'HEAD'], cwd);
+    if (!out || out === 'HEAD') return null;
+    return out;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Cuenta commits locales NO pusheados al upstream. Si el upstream no existe,
+ * compara contra origin/main (fallback conservador).
+ *
+ * @returns {{ count: number, upstreamUsed: string|null }}
+ */
+function countUnpushedCommits(branch, cwd) {
+  // 1) Intentar con upstream configurado
+  try {
+    const upstream = git(['rev-parse', '--abbrev-ref', `${branch}@{upstream}`], cwd);
+    const list = git(['rev-list', `${upstream}..HEAD`], cwd);
+    const count = list ? list.split('\n').filter(Boolean).length : 0;
+    return { count, upstreamUsed: upstream };
+  } catch {
+    // 2) Fallback: compararse contra origin/main
+    try {
+      const list = git(['rev-list', 'origin/main..HEAD'], cwd);
+      const count = list ? list.split('\n').filter(Boolean).length : 0;
+      return { count, upstreamUsed: 'origin/main' };
+    } catch {
+      // Ni upstream ni origin/main disponibles — asumimos hay commits
+      // (posición conservadora: preferimos crear tag y gastar refs antes que
+      // perder commits silenciosamente).
+      return { count: 1, upstreamUsed: null };
+    }
+  }
+}
+
+/**
+ * ¿Existe un tag con este nombre?
+ */
+function tagExists(name, cwd) {
+  try {
+    const out = git(['tag', '-l', name], cwd);
+    return out.trim() === name;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Append-only al audit log del issue. Crea el directorio si no existe.
+ */
+function writeAudit(issue, line) {
+  try {
+    fs.mkdirSync(LOG_DIR, { recursive: true });
+    const file = path.join(LOG_DIR, `audit-${issue}.log`);
+    // Usamos appendFileSync (flag 'a' implícito) para evitar truncar.
+    fs.appendFileSync(file, line + '\n', { encoding: 'utf8' });
+  } catch (e) {
+    // No podemos tirar acá — el audit es best-effort. El caller sigue.
+    try { process.stderr.write(`[backup-agent-branch] audit write failed: ${e.message}\n`); } catch {}
+  }
+}
+
+/**
+ * Crea un tag de backup si hay commits locales no pusheados en la rama actual.
+ *
+ * @param {object} opts
+ * @param {number|string} opts.issue — número del issue
+ * @param {string} opts.skill — skill responsable (pipeline-dev, backend-dev, etc.)
+ * @param {string} [opts.cwd] — worktree donde operar (default CWD)
+ * @param {string} [opts.forceBranch] — override de detección de rama (tests)
+ * @returns {{ ok: boolean, created: boolean, tag?: string, tip?: string, branch?: string, reason?: string, unpushedCount?: number }}
+ */
+function backupAgentBranch(opts) {
+  const issue = String(opts.issue || '').trim();
+  const skill = String(opts.skill || '').trim();
+  const cwd = opts.cwd || process.cwd();
+
+  if (!issue || !skill) {
+    return { ok: false, created: false, reason: 'missing issue or skill' };
+  }
+
+  // 1) Determinar rama
+  const branch = opts.forceBranch || currentBranch(cwd);
+  if (!branch) {
+    return { ok: true, created: false, reason: 'detached-head' };
+  }
+  if (!branch.startsWith('agent/')) {
+    // Sólo protegemos ramas agent/*. Otras ramas (main, feature/*) no aplican.
+    return { ok: true, created: false, reason: 'not-agent-branch', branch };
+  }
+
+  // 2) Contar commits no pusheados
+  let unpushed;
+  try {
+    unpushed = countUnpushedCommits(branch, cwd);
+  } catch (e) {
+    return { ok: false, created: false, reason: `cannot-count-unpushed: ${e.message}`, branch };
+  }
+  if (unpushed.count === 0) {
+    return { ok: true, created: false, reason: 'no-unpushed-commits', branch };
+  }
+
+  // 3) Resolver SHA del tip
+  let tip;
+  try {
+    tip = git(['rev-parse', '--short=8', 'HEAD'], cwd);
+  } catch (e) {
+    return { ok: false, created: false, reason: `cannot-resolve-tip: ${e.message}`, branch };
+  }
+
+  // 4) Construir nombre de tag + reintento por colisión (hasta 5 intentos)
+  const timestamp = timestampUtcCompact();
+  let tag = null;
+  for (let attempt = 0; attempt < 5; attempt++) {
+    const candidate = `backup/agent-${issue}-${skill}-${timestamp}-${randomHex(4)}`;
+    if (!tagExists(candidate, cwd)) {
+      tag = candidate;
+      break;
+    }
+  }
+  if (!tag) {
+    return { ok: false, created: false, reason: 'could-not-find-unique-tag-name', branch, tip };
+  }
+
+  // 5) Crear tag LOCAL (sin push). Nunca --force; si falla reportamos.
+  try {
+    git(['tag', tag, 'HEAD'], cwd);
+  } catch (e) {
+    return { ok: false, created: false, reason: `tag-create-failed: ${e.message}`, branch, tip };
+  }
+
+  // 6) Audit log
+  const now = new Date().toISOString();
+  const auditLine = [
+    `${now} [BACKUP] issue=${issue} skill=${skill} branch=${branch}`,
+    `  tag=${tag}`,
+    `  tip=${tip} unpushed=${unpushed.count} upstream=${unpushed.upstreamUsed || 'none'}`,
+    `  revert: git reset --hard ${tag}`,
+  ].join('\n');
+  writeAudit(issue, auditLine);
+
+  return {
+    ok: true,
+    created: true,
+    tag,
+    tip,
+    branch,
+    unpushedCount: unpushed.count,
+  };
+}
+
+/**
+ * Barre todos los tags `backup/*` y borra los que superan TTL (default 30 días).
+ *
+ * @param {object} [opts]
+ * @param {number} [opts.ttlDays=30] — edad máxima en días
+ * @param {boolean} [opts.dryRun=false] — si true, sólo reporta, no borra
+ * @param {string} [opts.cwd]
+ * @returns {{ scanned: number, expired: Array<{ tag: string, ageDays: number }>, deleted: string[] }}
+ */
+function cleanBackupTags(opts = {}) {
+  const ttlDays = opts.ttlDays === undefined ? 30 : opts.ttlDays;
+  const dryRun = !!opts.dryRun;
+  const cwd = opts.cwd || process.cwd();
+
+  const ttlSeconds = ttlDays * 24 * 60 * 60;
+  const nowSec = Math.floor(Date.now() / 1000);
+
+  let rawList;
+  try {
+    rawList = git([
+      'for-each-ref',
+      '--format=%(refname:short)|%(creatordate:unix)',
+      'refs/tags/backup/',
+    ], cwd);
+  } catch (e) {
+    return {
+      scanned: 0,
+      expired: [],
+      deleted: [],
+      error: `for-each-ref failed: ${e.message}`,
+    };
+  }
+
+  const lines = (rawList || '').split('\n').filter(Boolean);
+  const expired = [];
+  const deleted = [];
+
+  for (const line of lines) {
+    const [tag, createdAt] = line.split('|');
+    if (!tag || !createdAt) continue;
+    const ageSec = nowSec - parseInt(createdAt, 10);
+    if (!Number.isFinite(ageSec) || ageSec < 0) continue;
+    if (ageSec <= ttlSeconds) continue;
+    const ageDays = Math.floor(ageSec / (24 * 60 * 60));
+    expired.push({ tag, ageDays });
+    if (dryRun) continue;
+    try {
+      git(['tag', '-d', tag], cwd);
+      deleted.push(tag);
+      // Audit (issue desconocido si no se puede parsear — usar 'cleanup')
+      const issueMatch = tag.match(/^backup\/agent-(\d+)-/);
+      const issueFromTag = issueMatch ? issueMatch[1] : 'cleanup';
+      writeAudit(
+        issueFromTag,
+        `${new Date().toISOString()} [CLEANUP] tag=${tag} age=${ageDays}d`,
+      );
+    } catch (e) {
+      try { process.stderr.write(`[backup-agent-branch] failed to delete ${tag}: ${e.message}\n`); } catch {}
+    }
+  }
+
+  return {
+    scanned: lines.length,
+    expired,
+    deleted,
+  };
+}
+
+// =============================================================================
+// CLI
+// =============================================================================
+
+function parseCliArgs(argv) {
+  const opts = { issue: null, skill: null, cwd: undefined, clean: false, dryRun: false, ttlDays: 30 };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--issue') opts.issue = argv[++i];
+    else if (a === '--skill') opts.skill = argv[++i];
+    else if (a === '--cwd') opts.cwd = argv[++i];
+    else if (a === '--clean') opts.clean = true;
+    else if (a === '--dry-run') opts.dryRun = true;
+    else if (a === '--ttl-days') opts.ttlDays = parseInt(argv[++i], 10);
+  }
+  return opts;
+}
+
+function mainCli() {
+  const opts = parseCliArgs(process.argv.slice(2));
+
+  if (opts.clean) {
+    const result = cleanBackupTags({ ttlDays: opts.ttlDays, dryRun: opts.dryRun, cwd: opts.cwd });
+    console.log(JSON.stringify(result, null, 2));
+    process.exit(result.error ? 1 : 0);
+  }
+
+  if (!opts.issue || !opts.skill) {
+    console.error('Usage: backup-agent-branch.js --issue <N> --skill <skill> [--cwd path]');
+    console.error('       backup-agent-branch.js --clean [--dry-run] [--ttl-days 30]');
+    process.exit(2);
+  }
+
+  const result = backupAgentBranch({ issue: opts.issue, skill: opts.skill, cwd: opts.cwd });
+  console.log(JSON.stringify(result, null, 2));
+  process.exit(result.ok ? 0 : 1);
+}
+
+if (require.main === module) {
+  mainCli();
+}
+
+module.exports = {
+  backupAgentBranch,
+  cleanBackupTags,
+  // testable internals
+  __forTestsOnly__: {
+    timestampUtcCompact,
+    randomHex,
+    currentBranch,
+    countUnpushedCommits,
+    tagExists,
+    writeAudit,
+  },
+};

--- a/.pipeline/config.yaml
+++ b/.pipeline/config.yaml
@@ -185,6 +185,25 @@ timeouts:
     tester: 45                    # Cobertura Kover + suite completa
     delivery: 90                  # Espera CI completo (OWASP ~28min, check-app ~15min) + gate de review + merge + reporte
 
+# Build (#2405 CA-1) — Allowlist de JAVA_HOME para el rol build
+# Se compara normalizando separadores (C:/Users/... y C:\Users\...), case-insensitive.
+# Paths con `..` o whitespace embebido son rechazados.
+# Agregar un JDK nuevo: appendear una entrada y commitear.
+# Ver docs/operacion-pipeline.md para el flujo completo.
+build:
+  java_home_allowlist:
+    - "C:/Users/Administrator/.jdks/temurin-21.0.7"
+    - "C:/Users/Administrator/.jdks/temurin-21.0.8"
+
+# Circuit breaker de infra (#2405 CA-4)
+# Cuando un issue acumula N rebotes infra consecutivos sin recuperación, el Pulpo
+# aplica label `needs-human`, comenta en GitHub con estructura UX, y lo saca de la
+# cola de intake hasta que un humano quite el label. Arranca en 5 (conservador) y
+# se puede bajar a 3 tras una semana de observación. Distinto de MAX_REBOTES_INFRA
+# (cap duro antisabotaje, default 20) — este es el threshold "escalar a humano".
+circuit_breaker:
+  infra_escalate_threshold: 5
+
 # GitHub
 github:
   owner: "intrale"

--- a/.pipeline/connectivity-precheck.js
+++ b/.pipeline/connectivity-precheck.js
@@ -56,6 +56,13 @@ const INFRA_MESSAGE_PATTERNS = [
   /ECONNRESET/i,
   /network is unreachable/i,
   /dns/i,
+  // #2405 CA-1 — JAVA_HOME drift es un problema de entorno (host), no de código.
+  // El helper `validate-java-home.js` falla con exit 78 y escribe este patrón
+  // en el motivo. `sysexits(3)` define 78 como EX_CONFIG → clasifica infra.
+  /JAVA_HOME\s+(?:invalido|no\s+esta\s+en\s+la\s+allowlist)/i,
+  /\bexit\s+(?:code\s+)?78\b/i,
+  /\bEX_CONFIG\b/,
+  /FATAL:\s*JAVA_HOME/i,
 ];
 
 // #2404 — Patrones de toolchain (JDK/JAVA_HOME/gradle) que también son `infra`.

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -2146,6 +2146,111 @@ function brazoBarrido(config) {
           const MAX_REBOTES = 3;
           const MAX_REBOTES_INFRA = connectivityState.MAX_REBOTES_INFRA || 20;
 
+          // #2405 CA-4: threshold blando que escala a humano con label `needs-human`
+          // ANTES de alcanzar el cap duro. Arranca en 5, configurable vía config.yaml.
+          const INFRA_ESCALATE_THRESHOLD = Math.max(
+            1,
+            (config.circuit_breaker && config.circuit_breaker.infra_escalate_threshold) || 5,
+          );
+
+          // #2405 CA-4 — escalado a humano cuando se acumulan N rebotes infra
+          // consecutivos sin recuperación. Aplica label `needs-human`, comenta
+          // en GitHub con estructura UX, y mueve los archivos a procesado/ para
+          // sacarlo de la cola hasta que un humano quite el label.
+          if (esReboteDeInfra
+              && reboteInfraCount + 1 >= INFRA_ESCALATE_THRESHOLD
+              && reboteInfraCount < MAX_REBOTES_INFRA) {
+            // Deduplicar: sólo escalamos una vez por issue (archivo flag).
+            const needsHumanFlag = path.join(
+              fasePath(pipelineName, fase),
+              'procesado',
+              `.${issue}.needs-human-notified`,
+            );
+            const yaEscalado = fs.existsSync(needsHumanFlag);
+            if (!yaEscalado) {
+              log('barrido', `⚠️ #${issue} ESCALANDO a needs-human — ${reboteInfraCount + 1} rebotes infra (threshold ${INFRA_ESCALATE_THRESHOLD})`);
+              // Motivo sanitizado (redact → sin paths internos, sin tokens).
+              const motivoRedactado = sanitizePipelineText(
+                rechazados.map(r => `[${skillFromFile(r.file.name)}] ${r.motivo || ''}`).join('\n'),
+              ).slice(0, 1500);
+              // Encolar creación de label + add-label + comentario en servicio-github.
+              try {
+                const ghQueueDir = path.join(PIPELINE, 'servicios', 'github', 'pendiente');
+                fs.mkdirSync(ghQueueDir, { recursive: true });
+                // Aplicar label `needs-human`. El servicio-github auto-crea el
+                // label si no existe (ver LABEL_COLORS, color #B60205).
+                fs.writeFileSync(
+                  path.join(ghQueueDir, `${issue}-needs-human-apply-${Date.now()}.json`),
+                  JSON.stringify({ action: 'label', issue: parseInt(issue), label: 'needs-human' }),
+                );
+                // 3) comentario estructurado (plantilla UX — una frase + <details> + 3 acciones)
+                const body = [
+                  `## Pipeline escaló este issue a intervención humana`,
+                  '',
+                  `El pipeline intentó procesar este issue ${reboteInfraCount + 1} veces y falló por un problema de infraestructura que no puede resolver automáticamente.`,
+                  '',
+                  `### Qué pasó`,
+                  `El agente \`${rechazados[0] ? skillFromFile(rechazados[0].file.name) : 'desconocido'}\` falló en la fase \`${fase}\` por una causa clasificada como infra persistente (threshold: ${INFRA_ESCALATE_THRESHOLD} rebotes).`,
+                  '',
+                  `### Causa raíz`,
+                  `<details><summary>Motivo del último rechazo (redactado)</summary>`,
+                  '',
+                  '```',
+                  motivoRedactado,
+                  '```',
+                  '',
+                  `</details>`,
+                  '',
+                  `### Qué podés hacer`,
+                  `1. **Si es un problema del entorno** — revisá \`.pipeline/logs/${issue}-*.log\` y confirmá que el JDK/dependencia/variable esté presente en el host.`,
+                  `2. **Si es un problema del issue** — reabrí la definición o dividilo en partes más chicas; al quitar el label \`needs-human\` el issue reentra a la cola.`,
+                  `3. **Si no estás seguro** — preguntá antes de quitar el label; el contador de rebotes infra se resetea al removerlo.`,
+                  '',
+                  `Al quitar el label \`needs-human\`, el issue reentra a la cola automáticamente en el próximo ciclo de intake (~5 min) y el contador de rebotes se resetea.`,
+                  '',
+                  `📎 Log del agente: \`.pipeline/logs/${issue}-${rechazados[0] ? skillFromFile(rechazados[0].file.name) : 'skill'}.log\``,
+                  `📎 Audit trail: \`.pipeline/logs/audit-${issue}.log\``,
+                ].join('\n');
+                fs.writeFileSync(
+                  path.join(ghQueueDir, `${issue}-needs-human-comment-${Date.now()}.json`),
+                  JSON.stringify({ action: 'comment', issue: parseInt(issue), body }),
+                );
+              } catch (e) {
+                log('barrido', `Error encolando needs-human para #${issue}: ${e.message}`);
+              }
+              sendTelegram(`🚨 Issue #${issue} escalado a needs-human — ${reboteInfraCount + 1} rebotes por infra. Requiere intervención humana (quitá el label para reintentar).`);
+              // Flag de dedup
+              try {
+                fs.mkdirSync(path.dirname(needsHumanFlag), { recursive: true });
+                fs.writeFileSync(needsHumanFlag, new Date().toISOString());
+              } catch {}
+            }
+            // #2405 CA-4 — Mover archivos actuales a `archivado/` (no procesado/).
+            // Al quitar el label `needs-human`, el intake crea un archivo fresco
+            // en pendiente/ y el contador de rebotes infra se resetea naturalmente
+            // (no hay archivos en pendiente/trabajando/procesado para sumar).
+            for (const a of archivos) {
+              const dest = path.join(fasePath(pipelineName, fase), 'archivado');
+              try { fs.mkdirSync(dest, { recursive: true }); moveFile(a.path, dest); } catch {}
+            }
+            // Archivar también los archivos acumulados en la fase de rechazo
+            // para que el próximo ciclo no los lea como rebote previo.
+            for (const estado of ['pendiente', 'trabajando', 'procesado']) {
+              const dir = path.join(fasePath(pipelineName, faseRechazo), estado);
+              try {
+                for (const f of fs.readdirSync(dir)) {
+                  if (f.startsWith(issue + '.') && !f.startsWith('.')) {
+                    const src = path.join(dir, f);
+                    const archDir = path.join(fasePath(pipelineName, faseRechazo), 'archivado');
+                    fs.mkdirSync(archDir, { recursive: true });
+                    try { moveFile(src, archDir); } catch {}
+                  }
+                }
+              } catch {}
+            }
+            continue;
+          }
+
           // #2335 CA5 — cap duro sobre infra. Si se supera, el circuit breaker
           // generico aplica igual (defense-in-depth: si la clasificacion infra
           // fuera saboteada, el pipeline no queda en loop infinito).
@@ -3918,6 +4023,11 @@ function lanzarAgenteClaude(skill, issue, trabajandoPath, pipeline, fase, config
     userPrompt += `\n\n⚠️ REBOTE — Este issue fue RECHAZADO en la fase "${rechazadoEn}" y vuelve a vos para corrección.\n`;
     userPrompt += `MOTIVO DEL RECHAZO:\n${motivo}\n\n`;
     userPrompt += `INSTRUCCIONES OBLIGATORIAS:\n`;
+    // #2405 CA-2: backup tag automático antes del merge destructivo sobre agent/*.
+    // Si hay commits locales no pusheados, el helper crea un tag local
+    // `backup/agent-<issue>-<skill>-<timestamp>-<rand4>` antes del merge.
+    // Los tags tienen TTL 30 días (cleanBackupTags del mismo helper).
+    userPrompt += `0. Crear backup tag por si hay commits no pusheados: node .pipeline/backup-agent-branch.js --issue ${issue} --skill ${skill}\n`;
     userPrompt += `1. Actualizá tu rama con main: git fetch origin main && git merge origin/main --no-edit\n`;
     userPrompt += `2. Leé el motivo de rechazo arriba con atención\n`;
     if (buildLogExists) {
@@ -5768,9 +5878,11 @@ function brazoIntake(config) {
 
     try {
       // Consultar GitHub por issues con el label
+      // #2405 CA-4: excluir issues con label `needs-human` — el circuit breaker
+      // de infra los saca de la cola de intake hasta que un humano quite el label.
       ghThrottle();
       const result = execSync(
-        `"${GH_BIN}" issue list --label "${label}" --state open --json number,title,labels --limit 50`,
+        `"${GH_BIN}" issue list --label "${label}" --state open --json number,title,labels --limit 50 --search "-label:needs-human"`,
         { cwd: ROOT, encoding: 'utf8', timeout: 30000, windowsHide: true }
       );
       const issues = JSON.parse(result || '[]');

--- a/.pipeline/roles/build.md
+++ b/.pipeline/roles/build.md
@@ -8,6 +8,22 @@ El Pulpo te lanza en el worktree del issue (creado en la fase dev). Si no hay wo
 
 ## Pasos obligatorios
 
+### 0. Fail-fast JAVA_HOME (allowlist de `config.yaml`)
+
+**Antes** de cualquier otro paso, validar que `$JAVA_HOME` heredado del entorno esté en la allowlist parametrizada. Si no coincide, fallar con exit **78** — el Pulpo lo clasifica como `rebote_tipo: infra` automáticamente (no cuenta contra el circuit breaker del código).
+
+```bash
+# Helper que compara $JAVA_HOME contra build.java_home_allowlist de config.yaml,
+# normalizando separadores (/ vs \), case-insensitive y resolviendo symlinks.
+node .pipeline/validate-java-home.js || exit 78
+```
+
+Si el helper devuelve exit 78:
+
+- Loggea el valor actual de `$JAVA_HOME` y la allowlist esperada.
+- El issue reencola con `rebote_tipo: infra` sin penalizar el budget de código.
+- Para agregar un JDK nuevo a la allowlist, editar `.pipeline/config.yaml` bajo `build.java_home_allowlist` y commitear. Ver `docs/operacion-pipeline.md#allowlist-jdk`.
+
 ### 1. Actualizar con main
 
 ```bash

--- a/.pipeline/servicio-github.js
+++ b/.pipeline/servicio-github.js
@@ -210,6 +210,7 @@ const LABEL_COLORS = {
   'qa:dependency': 'D93F0B',
   'blocked:dependencies': 'B60205',
   'needs-definition': 'ededed',
+  'needs-human': 'B60205',   // #2405 CA-4 — circuit breaker infra escalado a humano
 };
 
 function ensureLabels(labelsStr) {

--- a/.pipeline/tests/backup-agent-branch.test.js
+++ b/.pipeline/tests/backup-agent-branch.test.js
@@ -1,0 +1,170 @@
+// =============================================================================
+// backup-agent-branch.test.js — Tests para el helper de backup (#2405 CA-2)
+// =============================================================================
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const { execSync } = require('child_process');
+
+const {
+  backupAgentBranch,
+  cleanBackupTags,
+  __forTestsOnly__,
+} = require(path.join(__dirname, '..', 'backup-agent-branch.js'));
+
+const { timestampUtcCompact, randomHex } = __forTestsOnly__;
+
+function mkTmpRepo() {
+  const repo = fs.mkdtempSync(path.join(os.tmpdir(), 'backup-test-'));
+  execSync('git init --quiet', { cwd: repo });
+  execSync('git config user.email "t@t.t"', { cwd: repo });
+  execSync('git config user.name "T"', { cwd: repo });
+  execSync('git commit --allow-empty -m "init" --quiet', { cwd: repo });
+  return repo;
+}
+
+function mkCommit(repo, file, content) {
+  fs.writeFileSync(path.join(repo, file), content || 'content');
+  execSync(`git add "${file}"`, { cwd: repo });
+  execSync(`git commit -m "add ${file}" --quiet`, { cwd: repo });
+}
+
+function listTags(repo) {
+  return execSync('git tag -l', { cwd: repo, encoding: 'utf8' })
+    .trim().split('\n').filter(Boolean);
+}
+
+test('timestampUtcCompact: formato YYYYMMDDTHHMMSSZ sin puntuación', () => {
+  const t = timestampUtcCompact(new Date('2026-04-21T12:34:56.789Z'));
+  assert.equal(t, '20260421T123456Z');
+});
+
+test('randomHex: devuelve N chars hexadecimales', () => {
+  const h = randomHex(4);
+  assert.equal(h.length, 4);
+  assert.match(h, /^[0-9a-f]{4}$/);
+});
+
+test('backupAgentBranch: crea tag si hay commits locales no pusheados', () => {
+  const repo = mkTmpRepo();
+  try {
+    // Estamos en main. Checkout a agent/9999-test.
+    execSync('git checkout -q -b agent/9999-test', { cwd: repo });
+    mkCommit(repo, 'a.txt', 'a');
+    mkCommit(repo, 'b.txt', 'b');
+
+    // No hay upstream → el helper debe usar fallback contra origin/main
+    // (que tampoco existe en este repo). countUnpushedCommits devuelve 1
+    // como posición conservadora.
+    const result = backupAgentBranch({
+      issue: 9999,
+      skill: 'pipeline-dev',
+      cwd: repo,
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.created, true);
+    assert.match(result.tag, /^backup\/agent-9999-pipeline-dev-\d{8}T\d{6}Z-[0-9a-f]{4}$/);
+
+    // Verificar que el tag fue creado localmente
+    const tags = listTags(repo);
+    assert.ok(tags.includes(result.tag), `tag ${result.tag} no aparece en 'git tag -l'`);
+  } finally {
+    try { fs.rmSync(repo, { recursive: true, force: true }); } catch {}
+  }
+});
+
+test('backupAgentBranch: NO crea tag si la rama no es agent/*', () => {
+  const repo = mkTmpRepo();
+  try {
+    execSync('git checkout -q -b feature/xyz', { cwd: repo });
+    mkCommit(repo, 'a.txt', 'a');
+
+    const result = backupAgentBranch({
+      issue: 1111,
+      skill: 'backend-dev',
+      cwd: repo,
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.created, false);
+    assert.equal(result.reason, 'not-agent-branch');
+    assert.equal(listTags(repo).length, 0);
+  } finally {
+    try { fs.rmSync(repo, { recursive: true, force: true }); } catch {}
+  }
+});
+
+test('backupAgentBranch: fail si falta issue o skill', () => {
+  const repo = mkTmpRepo();
+  try {
+    const r1 = backupAgentBranch({ issue: null, skill: 'x', cwd: repo });
+    assert.equal(r1.ok, false);
+    const r2 = backupAgentBranch({ issue: 1, skill: '', cwd: repo });
+    assert.equal(r2.ok, false);
+  } finally {
+    try { fs.rmSync(repo, { recursive: true, force: true }); } catch {}
+  }
+});
+
+test('cleanBackupTags: dry-run no borra nada, detecta expirados', () => {
+  const repo = mkTmpRepo();
+  try {
+    execSync('git checkout -q -b agent/8888-test', { cwd: repo });
+    mkCommit(repo, 'a.txt', 'a');
+
+    // Crear un tag backup "a mano" con fecha antigua via GIT_COMMITTER_DATE
+    // (el creatordate de un tag lightweight usa el commit del target).
+    // Como el commit actual es nuevo, ageSec será ~0 → no expira con TTL=30.
+    execSync('git tag backup/agent-8888-skill-20200101T000000Z-abcd', { cwd: repo });
+
+    // TTL agresivo (0 días) → todos los tags con creatordate < now son expirados.
+    const r = cleanBackupTags({ ttlDays: -1, dryRun: true, cwd: repo });
+    assert.ok(r.scanned >= 1);
+    assert.ok(r.expired.length >= 1);
+    assert.equal(r.deleted.length, 0); // dry-run
+    assert.ok(listTags(repo).includes('backup/agent-8888-skill-20200101T000000Z-abcd'));
+  } finally {
+    try { fs.rmSync(repo, { recursive: true, force: true }); } catch {}
+  }
+});
+
+test('cleanBackupTags: sin dry-run sí borra', () => {
+  const repo = mkTmpRepo();
+  try {
+    execSync('git checkout -q -b agent/7777-test', { cwd: repo });
+    mkCommit(repo, 'a.txt', 'a');
+    execSync('git tag backup/agent-7777-skill-20200101T000000Z-deff', { cwd: repo });
+
+    const r = cleanBackupTags({ ttlDays: -1, dryRun: false, cwd: repo });
+    assert.ok(r.deleted.length >= 1);
+    assert.ok(!listTags(repo).includes('backup/agent-7777-skill-20200101T000000Z-deff'));
+  } finally {
+    try { fs.rmSync(repo, { recursive: true, force: true }); } catch {}
+  }
+});
+
+test('backupAgentBranch: tags son locales (no push)', () => {
+  const repo = mkTmpRepo();
+  try {
+    execSync('git checkout -q -b agent/6666-test', { cwd: repo });
+    mkCommit(repo, 'a.txt', 'a');
+
+    const result = backupAgentBranch({
+      issue: 6666, skill: 'test', cwd: repo,
+    });
+    assert.equal(result.ok, true);
+
+    // No hay remote 'origin', pero si lo hubiera el helper NO debería haberle
+    // pusheado. Verificamos indirectamente que no haya intentado push: el
+    // exit code del helper no falla aunque no haya remote.
+    assert.equal(result.created, true);
+    // El tag está solo en el repo local
+    assert.ok(listTags(repo).includes(result.tag));
+  } finally {
+    try { fs.rmSync(repo, { recursive: true, force: true }); } catch {}
+  }
+});

--- a/.pipeline/tests/validate-java-home.test.js
+++ b/.pipeline/tests/validate-java-home.test.js
@@ -1,0 +1,141 @@
+// =============================================================================
+// validate-java-home.test.js — Tests para el fail-fast de JAVA_HOME (#2405 CA-1)
+// =============================================================================
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const {
+  validateJavaHome,
+  validateJavaHomeFs,
+  loadAllowlist,
+  normalizePath,
+  isSuspicious,
+  EXIT_CONFIG_ERROR,
+} = require(path.join(__dirname, '..', 'validate-java-home.js'));
+
+test('normalizePath: unifica separadores y case', () => {
+  assert.equal(
+    normalizePath('C:\\Users\\Admin\\.jdks\\temurin-21.0.7'),
+    'c:/users/admin/.jdks/temurin-21.0.7',
+  );
+  assert.equal(
+    normalizePath('C:/Users/Admin/.jdks/temurin-21.0.7/'),
+    'c:/users/admin/.jdks/temurin-21.0.7',
+  );
+});
+
+test('isSuspicious: rechaza paths con `..`, shell-metachars, y bordes con whitespace', () => {
+  assert.equal(isSuspicious('C:/Users/../../secret'), true);
+  assert.equal(isSuspicious(' C:/Users/Admin'), true);
+  assert.equal(isSuspicious('C:/Users; rm -rf /'), true);
+  assert.equal(isSuspicious('C:/Users/Admin && malicious'), true);
+  assert.equal(isSuspicious('C:/Program Files/Java/jdk-21'), false, 'espacios embebidos son legítimos en Windows');
+  assert.equal(isSuspicious('C:/Users/Admin/.jdks/temurin-21.0.7'), false);
+});
+
+test('validateJavaHome: match exacto', () => {
+  const r = validateJavaHome({
+    javaHome: 'C:/Users/Administrator/.jdks/temurin-21.0.7',
+    allowlist: ['C:/Users/Administrator/.jdks/temurin-21.0.7'],
+  });
+  assert.equal(r.ok, true);
+});
+
+test('validateJavaHome: match con separadores Windows distintos', () => {
+  const r = validateJavaHome({
+    javaHome: 'C:\\Users\\Administrator\\.jdks\\temurin-21.0.7',
+    allowlist: ['C:/Users/Administrator/.jdks/temurin-21.0.7'],
+  });
+  assert.equal(r.ok, true);
+});
+
+test('validateJavaHome: match case-insensitive', () => {
+  const r = validateJavaHome({
+    javaHome: 'c:/users/administrator/.jdks/TEMURIN-21.0.7',
+    allowlist: ['C:/Users/Administrator/.jdks/temurin-21.0.7'],
+  });
+  assert.equal(r.ok, true);
+});
+
+test('validateJavaHome: match como subdirectorio (JDK/bin debajo de JDK)', () => {
+  const r = validateJavaHome({
+    javaHome: 'C:/Users/Administrator/.jdks/temurin-21.0.7/bin',
+    allowlist: ['C:/Users/Administrator/.jdks/temurin-21.0.7'],
+  });
+  assert.equal(r.ok, true);
+});
+
+test('validateJavaHome: falla si no matchea', () => {
+  const r = validateJavaHome({
+    javaHome: 'C:/Program Files/Eclipse Adoptium/jdk-17',
+    allowlist: ['C:/Users/Administrator/.jdks/temurin-21.0.7'],
+  });
+  assert.equal(r.ok, false);
+  assert.equal(r.reason, 'not-in-allowlist');
+});
+
+test('validateJavaHome: fail-closed si allowlist vacía', () => {
+  const r = validateJavaHome({
+    javaHome: 'C:/any/path',
+    allowlist: [],
+  });
+  assert.equal(r.ok, false);
+  assert.equal(r.reason, 'allowlist-empty');
+});
+
+test('validateJavaHome: fail-closed si JAVA_HOME vacío', () => {
+  const r = validateJavaHome({ javaHome: '', allowlist: ['/usr/lib/jvm/jdk21'] });
+  assert.equal(r.ok, false);
+  assert.equal(r.reason, 'javahome-empty');
+});
+
+test('validateJavaHome: rechaza JAVA_HOME con `..`', () => {
+  const r = validateJavaHome({
+    javaHome: 'C:/Users/Admin/../../malicious',
+    allowlist: ['C:/Users/Admin'],
+  });
+  assert.equal(r.ok, false);
+  assert.equal(r.reason, 'javahome-suspicious');
+});
+
+test('loadAllowlist: parsea config.yaml real del repo', () => {
+  const configPath = path.join(__dirname, '..', 'config.yaml');
+  const result = loadAllowlist(configPath);
+  assert.equal(result.ok, true);
+  assert.ok(Array.isArray(result.list));
+  assert.ok(result.list.length > 0, 'allowlist no debe estar vacía en config.yaml');
+  assert.ok(
+    result.list.some(e => e.includes('temurin-21')),
+    'debe contener al menos un JDK Temurin 21',
+  );
+});
+
+test('loadAllowlist: parser manual con YAML minimal', () => {
+  const tmp = path.join(os.tmpdir(), `test-yaml-${Date.now()}.yaml`);
+  fs.writeFileSync(tmp, [
+    '# test',
+    'build:',
+    '  java_home_allowlist:',
+    '    - "C:/path/one"',
+    '    - "C:/path/two"',
+    'other: value',
+  ].join('\n'));
+  try {
+    const result = loadAllowlist(tmp);
+    assert.equal(result.ok, true);
+    // Si yaml está disponible, se usa; si no, el fallback manual saca lo mismo.
+    assert.deepEqual(result.list, ['C:/path/one', 'C:/path/two']);
+  } finally {
+    try { fs.unlinkSync(tmp); } catch {}
+  }
+});
+
+test('EXIT_CONFIG_ERROR es 78 (sysexits EX_CONFIG)', () => {
+  assert.equal(EXIT_CONFIG_ERROR, 78);
+});

--- a/.pipeline/validate-java-home.js
+++ b/.pipeline/validate-java-home.js
@@ -1,0 +1,248 @@
+#!/usr/bin/env node
+// =============================================================================
+// validate-java-home.js — Fail-fast validator para $JAVA_HOME
+//
+// Criterio CA-1 de #2405:
+//   - Lee `build.java_home_allowlist` de `.pipeline/config.yaml`.
+//   - Compara normalizando:
+//       * separadores `/` vs `\` (Windows)
+//       * case-insensitive (Windows FS default)
+//       * symlinks/junctions resueltos (fs.realpathSync)
+//       * rechaza `..` y whitespace embebido
+//   - Si matchea → exit 0.
+//   - Si no matchea → exit 78 (sysexits EX_CONFIG) + mensaje accionable a stderr.
+//   - Si allowlist vacía o YAML roto → exit 78 (fail-closed).
+//
+// CLI:
+//   node .pipeline/validate-java-home.js [--quiet]
+//
+// API:
+//   const { validateJavaHome } = require('./validate-java-home');
+//   const { ok, reason } = validateJavaHome({ javaHome, allowlist });
+// =============================================================================
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const EXIT_CONFIG_ERROR = 78;
+
+/**
+ * Normaliza un path para comparar contra la allowlist:
+ *   - Cambia `\` por `/`.
+ *   - Quita trailing slash.
+ *   - Lowercase (en Windows el FS es case-insensitive; también aceptamos
+ *     allowlist en mayúsculas/minúsculas).
+ */
+function normalizePath(p) {
+  if (typeof p !== 'string') return '';
+  return String(p)
+    .replace(/\\/g, '/')
+    .replace(/\/+$/, '')
+    .toLowerCase();
+}
+
+/**
+ * Resuelve symlinks/junctions sin tirar si el path no existe. Si no podemos
+ * resolver (disco offline, permisos), devolvemos el path original normalizado.
+ */
+function realpathBestEffort(p) {
+  try {
+    return fs.realpathSync(p);
+  } catch {
+    return p;
+  }
+}
+
+/**
+ * Carga la allowlist desde config.yaml. Usa `yaml` si está disponible, si no
+ * hace un parseo manual muy conservador (sólo el bloque `build.java_home_allowlist`).
+ *
+ * Fail-closed: si no podemos parsear → allowlist vacía, el validador falla 78.
+ */
+function loadAllowlist(configPath) {
+  let rawYaml = '';
+  try {
+    rawYaml = fs.readFileSync(configPath, 'utf8');
+  } catch {
+    return { ok: false, reason: `cannot-read-config: ${configPath}`, list: [] };
+  }
+
+  // 1) Intentar con paquete `yaml` si está
+  try {
+    // eslint-disable-next-line global-require
+    const yaml = require('yaml');
+    const doc = yaml.parse(rawYaml) || {};
+    const list = (doc.build && Array.isArray(doc.build.java_home_allowlist))
+      ? doc.build.java_home_allowlist.filter((x) => typeof x === 'string')
+      : [];
+    return { ok: true, list };
+  } catch (e) {
+    // fallthrough
+  }
+
+  // 2) Parseo manual minimalista: busca bloque `build:` → `  java_home_allowlist:` → items `    - "..."`
+  const lines = rawYaml.split(/\r?\n/);
+  let inBuild = false;
+  let inList = false;
+  const list = [];
+  for (const raw of lines) {
+    const line = raw.replace(/\t/g, '    ');
+    if (/^build:\s*$/.test(line)) { inBuild = true; inList = false; continue; }
+    if (inBuild && /^\S/.test(line) && !/^build:\s*$/.test(line)) {
+      // top-level distinto → salimos del bloque build
+      inBuild = false;
+      inList = false;
+    }
+    if (inBuild && /^\s{2,}java_home_allowlist:\s*$/.test(line)) {
+      inList = true;
+      continue;
+    }
+    if (inBuild && inList) {
+      const m = line.match(/^\s{4,}-\s*(['"]?)([^'"\s].*?)\1\s*$/);
+      if (m) {
+        list.push(m[2].trim());
+      } else if (/^\s{2,}\S/.test(line) && !/^\s{4,}-/.test(line)) {
+        // clave hermana → cierra la lista
+        inList = false;
+      }
+    }
+  }
+  return { ok: true, list };
+}
+
+/**
+ * ¿El path es sospechoso?
+ *
+ * Rechaza:
+ *   - Directory traversal (`..`)
+ *   - Metacaracteres de shell (`;`, `&&`, `|`, backticks, `$(`, `>`, `<`)
+ *   - Bordes con whitespace (trimmeable)
+ *   - Caracteres de control
+ *
+ * ACEPTA paths Windows legítimos como "C:/Program Files/..." — el espacio
+ * dentro del path es válido; sólo lo rechazamos si está al inicio/fin o
+ * mezclado con metacaracteres de shell.
+ */
+function isSuspicious(p) {
+  if (typeof p !== 'string') return true;
+  if (p.length === 0) return true;
+  if (p.includes('..')) return true;
+  if (p !== p.trim()) return true; // bordes con whitespace
+  // Metacaracteres de shell que no tienen lugar en un path filesystem.
+  if (/[;&|`$><\n\r\t\x00]/.test(p)) return true;
+  // Secuencias tipo `$(` o `${`.
+  if (/\$\(|\$\{/.test(p)) return true;
+  return false;
+}
+
+/**
+ * Validación pura (sin side effects, testable). No lee filesystem.
+ *
+ * @param {{ javaHome: string, allowlist: string[] }} opts
+ * @returns {{ ok: boolean, reason?: string, matched?: string }}
+ */
+function validateJavaHome({ javaHome, allowlist }) {
+  if (!javaHome || typeof javaHome !== 'string') {
+    return { ok: false, reason: 'javahome-empty' };
+  }
+  if (isSuspicious(javaHome)) {
+    return { ok: false, reason: 'javahome-suspicious' };
+  }
+  if (!Array.isArray(allowlist) || allowlist.length === 0) {
+    return { ok: false, reason: 'allowlist-empty' };
+  }
+
+  const candidate = normalizePath(javaHome);
+  for (const entry of allowlist) {
+    if (typeof entry !== 'string' || !entry) continue;
+    if (isSuspicious(entry)) continue; // allowlist defensiva
+    const target = normalizePath(entry);
+    if (!target) continue;
+    if (candidate === target) {
+      return { ok: true, matched: entry };
+    }
+    // Match por prefijo: `JAVA_HOME` puede contener un subdirectorio (jre/bin) del JDK.
+    // Sin embargo, sólo aceptamos si `candidate` está DENTRO de `target` con separador.
+    if (candidate.startsWith(target + '/')) {
+      return { ok: true, matched: entry };
+    }
+  }
+
+  return { ok: false, reason: 'not-in-allowlist' };
+}
+
+/**
+ * Wrapper que además resuelve symlinks antes de comparar. Útil desde CLI.
+ */
+function validateJavaHomeFs({ javaHome, allowlist }) {
+  const first = validateJavaHome({ javaHome, allowlist });
+  if (first.ok) return first;
+  if (first.reason !== 'not-in-allowlist') return first;
+
+  // Reintentar con realpath por si el JAVA_HOME es un junction/symlink.
+  const real = realpathBestEffort(javaHome);
+  if (real && real !== javaHome) {
+    return validateJavaHome({ javaHome: real, allowlist });
+  }
+  return first;
+}
+
+/**
+ * Main CLI. Exit 0 si ok, exit 78 si no.
+ */
+function mainCli() {
+  const args = process.argv.slice(2);
+  const quiet = args.includes('--quiet');
+
+  const javaHome = process.env.JAVA_HOME || '';
+  const configPath = path.join(__dirname, 'config.yaml');
+
+  const loaded = loadAllowlist(configPath);
+  if (!loaded.ok) {
+    if (!quiet) process.stderr.write(`FATAL: no se pudo leer allowlist (${loaded.reason})\n`);
+    process.exit(EXIT_CONFIG_ERROR);
+  }
+
+  const result = validateJavaHomeFs({ javaHome, allowlist: loaded.list });
+  if (result.ok) {
+    if (!quiet) process.stdout.write(`OK: JAVA_HOME aceptado (${result.matched})\n`);
+    process.exit(0);
+  }
+
+  if (!quiet) {
+    const lines = [];
+    lines.push('FATAL: JAVA_HOME no esta en la allowlist.');
+    lines.push('');
+    lines.push(`  JAVA_HOME actual:  ${javaHome || '(vacio)'}`);
+    lines.push(`  Razon:             ${result.reason}`);
+    lines.push('  Allowlist esperada (config.yaml `build.java_home_allowlist`):');
+    for (const entry of loaded.list) {
+      lines.push(`    - ${entry}`);
+    }
+    if (loaded.list.length === 0) lines.push('    (vacia — fail-closed)');
+    lines.push('');
+    lines.push('Como resolver:');
+    lines.push('  1. Si el path es legitimo -> agregalo a config.yaml y commitea');
+    lines.push('     (ver docs/operacion-pipeline.md).');
+    lines.push('  2. Si el path es stale (ej. JDK desinstalado) -> corregi JAVA_HOME');
+    lines.push('     en el profile del host.');
+    lines.push('');
+    lines.push('Exit code: 78 (mapeado a rebote_tipo=infra)');
+    process.stderr.write(lines.join('\n') + '\n');
+  }
+  process.exit(EXIT_CONFIG_ERROR);
+}
+
+if (require.main === module) {
+  mainCli();
+}
+
+module.exports = {
+  validateJavaHome,
+  validateJavaHomeFs,
+  loadAllowlist,
+  normalizePath,
+  isSuspicious,
+  EXIT_CONFIG_ERROR,
+};

--- a/docs/operacion-pipeline.md
+++ b/docs/operacion-pipeline.md
@@ -1,0 +1,210 @@
+# Operación del Pipeline V2 — Flujos Operativos
+
+Referencia rápida para operadores y desarrolladores sobre los flujos nuevos introducidos por el issue #2405 (fail-fast JAVA_HOME, backup tags, circuit breaker `needs-human`).
+
+---
+
+## Allowlist JDK (JAVA_HOME) {#allowlist-jdk}
+
+### Por qué
+
+El rol `build` compila con Gradle contra un Temurin 21 específico. Si el host desarrolla drift en `JAVA_HOME` (ej. IntelliJ desinstalado, JDK nuevo en otro path), el build falla con errores oscuros y el pipeline los clasificaba como errores de código, consumiendo budget del circuit breaker.
+
+Desde #2405, el rol `build` tiene un **paso 0** que valida `$JAVA_HOME` contra una allowlist parametrizada en `.pipeline/config.yaml`. Si no matchea, falla con exit 78 (sysexits EX_CONFIG) y el Pulpo lo clasifica automáticamente como `rebote_tipo: infra` — no consume budget de código.
+
+### Agregar un JDK nuevo a la allowlist
+
+```bash
+# 1. Editar config.yaml
+$EDITOR .pipeline/config.yaml
+```
+
+Appendear una entrada bajo `build.java_home_allowlist`:
+
+```yaml
+build:
+  java_home_allowlist:
+    - "C:/Users/Administrator/.jdks/temurin-21.0.7"
+    - "C:/Users/Administrator/.jdks/temurin-21.0.8"
+    - "C:/Users/Administrator/.jdks/temurin-21.0.9"   # <-- nuevo
+```
+
+```bash
+# 2. Verificar localmente antes de commitear
+JAVA_HOME="C:/Users/Administrator/.jdks/temurin-21.0.9" \
+  node .pipeline/validate-java-home.js
+# → OK: JAVA_HOME aceptado (...)
+
+# 3. Commitear
+git add .pipeline/config.yaml
+git commit -m "chore(pipeline): agrega temurin-21.0.9 a la allowlist de JAVA_HOME"
+```
+
+### Comparación
+
+El validador normaliza antes de comparar:
+
+- Separadores `/` ↔ `\` (Windows).
+- Case-insensitive (FS Windows default).
+- Resuelve symlinks/junctions (`fs.realpathSync`).
+- Acepta match por subdirectorio (`.../jdk/bin` matchea si `.../jdk` está en la allowlist).
+
+Rechaza:
+
+- Paths con `..` (directory traversal).
+- Paths con shell-metachars (`;`, `&&`, `|`, backticks, `$(`).
+- Paths con whitespace en los bordes (un path mal-sanitizado que llegó trimeado).
+
+---
+
+## Backup/restore de ramas `agent/*` {#backup-restore}
+
+### Por qué
+
+Un incidente histórico (#1952) perdió commits de una rama `agent/*` tras un reset automático del pipeline. Desde #2405, el Pulpo inyecta en el prompt del rebote un **paso 0** que llama a `backup-agent-branch.js` **antes** del `git merge origin/main`.
+
+Si hay commits locales no pusheados (`git rev-list <upstream>..HEAD` > 0), el helper crea un tag local `backup/agent-<issue>-<skill>-<timestamp>-<rand4>` y loggea la operación.
+
+### Listar tags de backup
+
+```bash
+git tag -l "backup/*"
+```
+
+### Restaurar de un backup
+
+```bash
+# 1. Encontrar el tag relevante
+git tag -l "backup/agent-2405-*" --format='%(refname:short) %(creatordate:iso)'
+
+# 2. Recuperar commits (reset destructivo — asegurate de no tener cambios pendientes)
+git reset --hard backup/agent-2405-pipeline-dev-20260421T152311Z-a3f2
+```
+
+### Audit log
+
+Cada operación de backup/restore/cleanup queda registrada en `.pipeline/logs/audit-<issue>.log` con formato grep-friendly:
+
+```
+2026-04-21T15:23:11Z [BACKUP] issue=2405 skill=pipeline-dev branch=agent/2405-pipeline-dev
+  tag=backup/agent-2405-pipeline-dev-20260421T152311Z-a3f2
+  tip=8f2c91d unpushed=3 upstream=origin/agent/2405-pipeline-dev
+  revert: git reset --hard backup/agent-2405-pipeline-dev-20260421T152311Z-a3f2
+```
+
+El comando de reverso (`revert: ...`) es copiable tal cual.
+
+### TTL 30 días (cleanup automático)
+
+Los tags `backup/*` tienen TTL 30 días. El cleanup se puede ejecutar manualmente:
+
+```bash
+# Dry-run (sólo reporta)
+node .pipeline/backup-agent-branch.js --clean --dry-run --ttl-days 30
+
+# Borrar tags expirados
+node .pipeline/backup-agent-branch.js --clean --ttl-days 30
+```
+
+Cada borrado queda loggeado en el audit:
+
+```
+2026-05-21T00:00:00Z [CLEANUP] tag=backup/agent-2405-pipeline-dev-... age=31d
+```
+
+### Los tags no se pushean
+
+Por diseño los tags `backup/*` son **locales**. Nunca se hace `git push --tags` desde el helper. Eso evita exponer referencias al remote y mantiene `refs/tags/` limpio upstream.
+
+---
+
+## Circuit breaker `needs-human` {#needs-human}
+
+### Por qué
+
+Un issue que falla por infra repetidamente (JDK drift, network flaky, storage lleno, etc.) puede consumir tokens y slots indefinidamente. Desde #2405, el Pulpo tiene un threshold blando (`circuit_breaker.infra_escalate_threshold`, default 5) que escala el issue a un humano con label `needs-human` antes de alcanzar el cap duro `MAX_REBOTES_INFRA` (20).
+
+### Qué hace el escalado
+
+Cuando un issue acumula N rebotes infra consecutivos (N = threshold):
+
+1. Aplica label `needs-human` (color `#B60205`, auto-creado en primera aplicación).
+2. Comenta en el issue con:
+   - Frase única explicando qué pasó.
+   - Causa raíz (motivo del último rechazo, redactado por el sanitizer — sin tokens, sin paths internos).
+   - 3 acciones sugeridas al humano.
+   - Links a los logs relevantes.
+3. Archiva los archivos del issue (mueve de `pendiente/trabajando/procesado` a `archivado/`).
+4. Envía notificación Telegram.
+5. Filtra el issue de la cola de intake hasta que un humano quite el label.
+
+### Cómo destrabar un issue `needs-human`
+
+```bash
+export PATH="/c/Workspaces/gh-cli/bin:$PATH"
+
+# 1. Revisar qué pasó
+gh issue view <N> --comments | tail -50
+cat .pipeline/logs/audit-<N>.log
+cat .pipeline/logs/<N>-*.log | tail -100
+
+# 2. Corregir el problema de entorno / definición del issue
+# (ej. agregar JDK a allowlist, reiniciar servicio, dividir historia)
+
+# 3. Quitar el label — el issue reentra al intake en el próximo ciclo (~5 min)
+gh issue edit <N> --remove-label needs-human
+```
+
+Al quitar el label:
+
+- El intake filtra `-label:needs-human` en la consulta a GitHub, así que vuelve a aparecer.
+- Los archivos antiguos están en `archivado/` — el contador de rebotes infra empieza desde 0.
+
+### Configurar el threshold
+
+En `.pipeline/config.yaml`:
+
+```yaml
+circuit_breaker:
+  infra_escalate_threshold: 5   # arranca en 5 (conservador)
+```
+
+Recomendación: bajar a 3 tras una semana de observación operativa estable.
+
+### Diferencia con `MAX_REBOTES_INFRA`
+
+| Concepto | Valor | Semántica |
+|---|---|---|
+| `circuit_breaker.infra_escalate_threshold` | 5 (config.yaml) | Escalado blando a humano (label + comment). |
+| `MAX_REBOTES_INFRA` | 20 (código) | Cap duro antisabotaje. Si la clasificación infra fuera saboteada y hubiera loop infinito, este cap detiene todo. |
+
+---
+
+## Tabla de exit codes del rol `build`
+
+| Exit code | Significado | Clasificación |
+|---|---|---|
+| 0 | Build OK | éxito |
+| 78 | JAVA_HOME fuera de allowlist (sysexits EX_CONFIG) | `rebote_tipo: infra` |
+| otros != 0 | Fallo de Gradle/test | `rebote_tipo: codigo` (o infra si el motivo matchea patrones ENOTFOUND/ETIMEDOUT/etc.) |
+
+---
+
+## Token `gh` del Pulpo — scope mínimo
+
+El Pulpo interactúa con GitHub vía `gh` CLI. El token debe tener:
+
+- `repo` — para `issue edit --add-label`, `issue edit --remove-label`, `label create`, `issue comment`, `issue view`, `pr create`.
+- `write:discussion` — sólo si en el futuro se usa `gh api /repos/:owner/:repo/discussions`.
+
+El token **NO** debe tener:
+
+- `admin:org` — no gestionamos la organización desde el pipeline.
+- `delete_repo` — nunca borramos repos.
+- `workflow` — el pipeline no modifica GitHub Actions programáticamente.
+
+Revisar scope:
+
+```bash
+gh auth status
+```


### PR DESCRIPTION
## Summary

Implementa las salvaguardas de resiliencia y seguridad del pipeline (CA-1..CA-4 del issue #2405, parte 2 de #2401).

- **CA-1 JAVA_HOME fail-fast**: `validate-java-home.js` + paso 0 en `roles/build.md`, allowlist en `config.yaml`, exit 78 mapeado como rebote `infra`.
- **CA-2 Backup tags**: `backup-agent-branch.js` crea `backup/agent-<N>-<skill>-<ts>-<rand4>` antes de operaciones destructivas sobre `agent/*`, audit log, TTL 30d.
- **CA-3 Sanitización de secretos**: cobertura existente en `sanitizer.js` + `sanitize-log-stream.js` validada (AWS/JWT/GitHub/Cognito/Telegram/PEM/etc).
- **CA-4 Circuit breaker → needs-human**: threshold configurable (`circuit_breaker.infra_escalate_threshold=5`) antes del cap duro, label `needs-human` (#B60205), filtro en intake, archivado del issue, notificación Telegram.

## Test plan

- [x] `node --test .pipeline/tests/validate-java-home.test.js` → 13/13
- [x] `node --test .pipeline/tests/backup-agent-branch.test.js` → 8/8
- [x] `node --test .pipeline/tests/sanitizer.test.js` → 51/51
- [x] Verificación estructural (qa:skipped — scope 100% infra .pipeline/ + docs/ + 1 label GitHub)
- [x] Security audit (OWASP, fail-closed, sin secretos en logs)

Closes #2405
Refs #2401

🤖 Generated with [Claude Code](https://claude.com/claude-code)