### PR TITLE
fix(pipeline): resiliencia de restart — killAll agresivo, retry smoke, singleton marker refresh

### DIFF
--- a/.pipeline/restart.js
+++ b/.pipeline/restart.js
@@ -20,6 +20,7 @@ const {
   findPidByPort,
   pidAlive,
   invalidateCache,
+  SCRIPT_MAP,
 } = require('./pid-discovery');
 const { clearAllMarkers } = require('./lib/ready-marker');
 
@@ -74,9 +75,18 @@ function killAll() {
   invalidateCache();
   const pidsToKill = new Set();
 
+  // Procesos lanzados con `Start-Process -WorkingDirectory .pipeline` tienen
+  // CommandLine = `node pulpo.js` sin `.pipeline` visible — el workdir no
+  // aparece en la CommandLine. Por eso matcheamos por CUALQUIERA de: path
+  // `.pipeline` en la CommandLine, o nombre de script conocido del pipeline.
+  const scriptNames = new Set(Object.values(SCRIPT_MAP));
   for (const p of scanNodeProcesses()) {
-    if (!p.commandLine || !p.commandLine.includes('.pipeline')) continue;
+    if (!p.commandLine) continue;
     if (p.pid === process.pid) continue;
+    const cmd = p.commandLine;
+    const matchByPath = cmd.includes('.pipeline');
+    const matchByScript = [...scriptNames].some(s => cmd.includes(s));
+    if (!matchByPath && !matchByScript) continue;
     pidsToKill.add(p.pid);
   }
 
@@ -340,6 +350,7 @@ const action = process.argv[2] || 'restart';
 const flagPaused = process.argv.includes('--paused');
 const flagNoSmokeTest = process.argv.includes('--no-smoke-test');
 const flagNoRollback = process.argv.includes('--no-rollback');
+const flagNoSync = process.argv.includes('--no-sync');
 
 switch (action) {
   case 'stop':
@@ -351,7 +362,8 @@ switch (action) {
     break;
   default:
     killAll();
-    syncWithMain();
+    if (!flagNoSync) syncWithMain();
+    else log('Saltando sync con origin/main (--no-sync)');
     if (flagPaused) {
       fs.writeFileSync(path.join(PIPELINE, '.paused'), new Date().toISOString());
       log('Modo PAUSADO — solo Telegram + dashboard activos (intake/lanzamiento deshabilitados)');
@@ -367,7 +379,20 @@ switch (action) {
     // Se omite si --paused (no todos los componentes están arriba en modo pausado).
     if (!flagNoSmokeTest && !flagPaused) {
       sleep(3000);
-      const smoke = runSmokeTest();
+      let smoke = runSmokeTest();
+      // Retry antes de disparar rollback destructivo: el smoke-test puede fallar
+      // por bug del singleton (procesos viejos que no fueron matados + respawn
+      // aborta sin escribir marker, ver issue #2450). Reintentamos matando
+      // stragglers y relanzando componentes missing. Solo si el segundo smoke
+      // también falla → rollback.
+      if (!smoke.ok && !flagNoRollback) {
+        log('Primer smoke test FAIL — reintento tras limpieza de stragglers');
+        killAll();
+        launchAll();
+        sleep(5000);
+        smoke = runSmokeTest();
+        if (smoke.ok) log('Segundo smoke test OK tras retry — pipeline recuperado sin rollback');
+      }
       if (smoke.ok) {
         if (!stablePointsToHead()) moveStableTag();
       } else if (flagNoRollback) {
@@ -377,7 +402,7 @@ switch (action) {
         log('Smoke test falló pero no existe tag pipeline-stable — primer deploy, sin rollback');
         enqueueTelegramAlert(`⚠️ *Pipeline restart: smoke test FAIL*\nExit ${smoke.exitCode}\n\nNo existe tag \`pipeline-stable\` (primer deploy). Revisar manualmente.`);
       } else {
-        enqueueTelegramAlert(`🚨 *Pipeline restart FALLÓ — lanzando rollback orphan*\nSmoke test exit ${smoke.exitCode}.\nVolviendo a \`pipeline-stable\`. Progreso en \`logs/rollback.log\`.`);
+        enqueueTelegramAlert(`🚨 *Pipeline restart FALLÓ tras retry — lanzando rollback orphan*\nSmoke test exit ${smoke.exitCode}.\nVolviendo a \`pipeline-stable\`. Progreso en \`logs/rollback.log\`.`);
         // Lanzamos rollback como orphan detached y salimos. El rollback
         // notifica por Telegram cuando termina (OK o FAIL).
         launchRollbackOrphan();

--- a/.pipeline/singleton.js
+++ b/.pipeline/singleton.js
@@ -12,6 +12,7 @@ const path = require('path');
 const { findPidByScript, SCRIPT_MAP, invalidateCache } = require('./pid-discovery');
 
 const PIPELINE = process.env.PIPELINE_STATE_DIR || path.resolve(__dirname);
+const READY_DIR = path.join(PIPELINE, 'ready');
 
 /**
  * Garantiza singleton. Si ya hay una instancia viva del mismo script (según
@@ -31,6 +32,24 @@ module.exports = function singleton(name) {
   const existing = findPidByScript(scriptName);
 
   if (existing && existing.pid !== process.pid) {
+    // Antes de abortar, refrescar el marker ready con el PID de la instancia
+    // viva. Motivo: si el marker no existe o tiene un PID stale, smoke-test
+    // reporta MISSING/STALE a pesar de que el proceso correcto está corriendo
+    // (ver issue #2450). Al abortar silenciosamente, el proceso original
+    // nunca reescribe su marker. Lo hacemos acá en su lugar, usando el PID
+    // que el SO nos reporta como vivo. No-op si falla (best-effort).
+    try {
+      if (!fs.existsSync(READY_DIR)) fs.mkdirSync(READY_DIR, { recursive: true });
+      const markerPath = path.join(READY_DIR, `${name}.ready`);
+      const now = new Date().toISOString();
+      fs.writeFileSync(markerPath, JSON.stringify({
+        name,
+        pid: existing.pid,
+        startedAt: existing.creationDate || now,
+        readyAt: now,
+        meta: { refreshedBy: 'singleton-abort', abortedPid: process.pid },
+      }, null, 2));
+    } catch {}
     console.error(`[FATAL] Ya hay una instancia de ${name} corriendo (PID ${existing.pid}). Abortando.`);
     process.exit(1);
   }


### PR DESCRIPTION
## Summary

Fixea la cadena de 3 bugs que hacía que `restart.js` disparara un rollback destructivo ante cualquier falso positivo del smoke-test, revirtiendo `.pipeline/` al commit \`pipeline-stable\` (típicamente semanas atrás) y perdiendo fixes posteriores.

Incidente que lo destapó: 2026-04-21 ~00:00 UTC-3. Un restart manual disparó rollback → reverso de \`.pipeline/\` al commit \`5c1d08ad\` (PR #2383, de hace ~2 semanas), perdiendo fix config.yaml (#2434) y resiliencia (#2438) en working tree.

## Bug A — killAll no mata procesos lanzados con WorkingDirectory

\`killAll()\` filtraba con \`commandLine.includes('.pipeline')\`. Los procesos lanzados con \`powershell Start-Process -WorkingDirectory .pipeline\` tienen CommandLine sin el path (\`node pulpo.js\`), no matcheaban, sobrevivían. En el incidente se mató 1 proceso en vez de 6-7.

**Fix**: matchear por (a) \`.pipeline\` en CommandLine, O (b) nombre de script en SCRIPT_MAP.

## Bug B — singleton aborta sin refrescar marker (ya documentado en #2450)

Nuevo proceso detecta duplicado → \`exit(1)\`. Instancia viva no recibe notificación → nunca reescribe marker. smoke-test reporta MISSING/STALE para servicios que están funcionando.

**Fix**: antes del \`exit(1)\`, \`singleton.js\` escribe el marker con el PID de la instancia viva (best-effort, no-op si falla).

## Bug C — auto-rollback ante primer FAIL (destructivo)

Primer FAIL → \`rollback.js\` orphan → \`git checkout pipeline-stable -- .pipeline/\`. Revirtió 10 commits en el incidente.

**Fix**: antes del rollback, reintentar kill+launch+smoke una vez. Solo si el SEGUNDO smoke también falla → rollback. Cubre el caso típico de stragglers.

## Cambio adicional

Flag \`--no-sync\` para skippear \`syncWithMain()\`. Útil para diagnóstico local sin que \`git reset --hard FETCH_HEAD\` destruya cambios en curso (bit mordido varias veces en esta misma sesión).

## Test plan

- [x] Sintaxis: \`node -c restart.js\`, \`node -c singleton.js\` — OK
- [x] Local: \`node .pipeline/restart.js --no-sync\` — STOP mata 7 procesos (vs 1 antes), START relanza, STATUS todo OK, smoke-test OK en primer intento sin retry ni rollback
- [ ] Post-merge: monitorear próximos restarts automáticos (watchdog) — no deberían disparar rollbacks por falsos positivos

qa:skipped — cambio interno del pipeline, sin impacto en producto de usuario. Cubre incidente operativo documentado en commit message.

Refs #2450

🤖 Generated with [Claude Code](https://claude.com/claude-code)