### PR TITLE
feat(pipeline): V3 estado bloqueado-humano — evita rebotes innecesarios (#2478)

### DIFF
--- a/.pipeline/dashboard-v2.js
+++ b/.pipeline/dashboard-v2.js
@@ -409,6 +409,23 @@ function getPipelineState() {
     if (!key.includes('/')) data.avgMs = Math.round(data.total / data.count);
   }
 
+  // V3 — Bloqueados esperando humano (issue #2478)
+  state.bloqueados = [];
+  try {
+    const humanBlock = require('./lib/human-block');
+    state.bloqueados = humanBlock.listBlockedIssues().map(b => ({
+      issue: b.issue,
+      skill: b.skill,
+      phase: b.phase,
+      pipeline: b.pipeline,
+      reason: b.reason,
+      question: b.question,
+      blocked_at: b.blocked_at,
+      age_hours: b.age_hours,
+      title: titleCache[String(b.issue)]?.title || '',
+    }));
+  } catch {}
+
   // Servicios
   state.servicios = {};
   try {
@@ -1652,7 +1669,32 @@ function generateHTML(state) {
     <div class="it-done-grid">${laneCards.done}</div>
   </details>` : '';
 
+  // V3 — Bloqueados esperando humano (issue #2478)
+  const bloqueados = Array.isArray(state.bloqueados) ? state.bloqueados : [];
+  const escHtml = (s) => String(s == null ? '' : s)
+    .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+  const bloqueadosHTML = bloqueados.length === 0 ? '' : `
+    <div class="matrix-section" id="bloqueados-humano" style="border-left:4px solid #FBCA04;background:rgba(251,202,4,0.06);padding:12px 16px;margin-bottom:14px;border-radius:6px">
+      <h2 style="margin:0 0 8px 0">🚧 Esperando intervención humana <span style="font-size:0.6em;color:var(--dim);font-weight:normal">(${bloqueados.length} · V3)</span></h2>
+      <div style="display:flex;flex-direction:column;gap:6px">
+        ${bloqueados.map(b => {
+          const ageStr = b.age_hours < 1 ? Math.round(b.age_hours * 60) + 'min' : b.age_hours + 'h';
+          const titleHtml = b.title ? ` — <span style="color:var(--dim)">${escHtml(b.title)}</span>` : '';
+          return `<div style="font-size:0.92em">
+            <b>#${b.issue}</b>${titleHtml}
+            <span style="color:var(--dim)"> · ${escHtml(b.skill)} en ${escHtml(b.phase)} · hace ${ageStr}</span>
+            ${b.question ? `<div style="margin:2px 0 0 14px;color:#FBCA04">❓ ${escHtml(b.question)}</div>` : ''}
+          </div>`;
+        }).join('')}
+      </div>
+      <div style="margin-top:8px;font-size:0.82em;color:var(--dim)">
+        Desbloquear desde Telegram: <code>/unblock &lt;issue&gt; &lt;orientación&gt;</code>
+      </div>
+    </div>`;
+
   const matrixHTML = `
+    ${bloqueadosHTML}
     <div class="matrix-section" id="issue-tracker">
       <div class="matrix-header">
         <h2>📊 Issue Tracker</h2>

--- a/.pipeline/lib/__tests__/human-block.test.js
+++ b/.pipeline/lib/__tests__/human-block.test.js
@@ -1,0 +1,211 @@
+// Tests de .pipeline/lib/human-block.js (issue #2478)
+// Valida marker en disco, schema de eventos human:blocked/unblocked y comandos.
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+// Aislar PIPELINE_DIR a un tmp por test setup
+const TMP_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'v3-humanblock-'));
+fs.mkdirSync(path.join(TMP_DIR, '.claude'), { recursive: true });
+fs.mkdirSync(path.join(TMP_DIR, '.pipeline', 'desarrollo', 'dev', 'trabajando'), { recursive: true });
+fs.mkdirSync(path.join(TMP_DIR, '.pipeline', 'desarrollo', 'dev', 'pendiente'), { recursive: true });
+fs.mkdirSync(path.join(TMP_DIR, '.pipeline', 'desarrollo', 'verificacion', 'trabajando'), { recursive: true });
+process.env.CLAUDE_PROJECT_DIR = TMP_DIR;
+process.env.PIPELINE_REPO_ROOT = TMP_DIR;
+
+delete require.cache[require.resolve('../traceability')];
+delete require.cache[require.resolve('../human-block')];
+const trace = require('../traceability');
+const hb = require('../human-block');
+
+function readEvents() {
+    if (!fs.existsSync(trace.LOG_FILE)) return [];
+    return fs.readFileSync(trace.LOG_FILE, 'utf8')
+        .split('\n').filter(Boolean).map(l => JSON.parse(l));
+}
+
+function resetFs() {
+    // limpiar todos los markers
+    for (const phase of ['dev', 'verificacion']) {
+        for (const state of ['pendiente', 'trabajando', 'listo', 'bloqueado-humano']) {
+            const dir = path.join(TMP_DIR, '.pipeline', 'desarrollo', phase, state);
+            try {
+                for (const f of fs.readdirSync(dir)) {
+                    try { fs.unlinkSync(path.join(dir, f)); } catch {}
+                }
+            } catch {}
+        }
+    }
+    try { fs.unlinkSync(trace.LOG_FILE); } catch {}
+}
+
+test('reportHumanBlock crea marker en bloqueado-humano/ y emite evento', () => {
+    resetFs();
+    const src = path.join(TMP_DIR, '.pipeline', 'desarrollo', 'dev', 'trabajando', '2478.po');
+    fs.writeFileSync(src, 'issue: 2478\n');
+
+    const result = hb.reportHumanBlock({
+        issue: 2478, skill: 'po', phase: 'dev',
+        reason: 'Criterio contradictorio entre AC#2 y AC#5',
+        question: '¿Cuál tiene prioridad si chocan?',
+    });
+
+    assert.equal(result.issue, 2478);
+    assert.equal(result.skill, 'po');
+    assert.equal(result.phase, 'dev');
+    assert.equal(result.pipeline, 'desarrollo');
+    assert.equal(fs.existsSync(src), false, 'src debe haberse movido');
+    assert.equal(fs.existsSync(result.marker_path), true);
+    assert.match(result.marker_path, /bloqueado-humano[\\/]2478\.po$/);
+
+    const reasonFile = result.marker_path + '.reason.json';
+    assert.equal(fs.existsSync(reasonFile), true);
+    const reason = JSON.parse(fs.readFileSync(reasonFile, 'utf8'));
+    assert.equal(reason.reason, 'Criterio contradictorio entre AC#2 y AC#5');
+    assert.equal(reason.question, '¿Cuál tiene prioridad si chocan?');
+
+    const events = readEvents();
+    const blocked = events.find(e => e.event === 'human:blocked' && e.issue === 2478);
+    assert.ok(blocked, 'evento human:blocked emitido');
+    assert.equal(blocked.skill, 'po');
+    assert.equal(blocked.phase, 'dev');
+    assert.equal(blocked.pipeline, 'desarrollo');
+    assert.equal(blocked.reason, 'Criterio contradictorio entre AC#2 y AC#5');
+});
+
+test('reportHumanBlock requiere reason y question', () => {
+    resetFs();
+    assert.throws(() => hb.reportHumanBlock({ issue: 1, skill: 'po', phase: 'dev', reason: '', question: 'x' }),
+        /reason y question/);
+    assert.throws(() => hb.reportHumanBlock({ issue: 1, skill: 'po', phase: 'dev', reason: 'x', question: '' }),
+        /reason y question/);
+});
+
+test('reportHumanBlock requiere issue, skill, phase', () => {
+    resetFs();
+    assert.throws(() => hb.reportHumanBlock({ skill: 'po', phase: 'dev', reason: 'x', question: 'y' }),
+        /issue, skill, phase/);
+});
+
+test('reportHumanBlock funciona aunque no exista marker activo', () => {
+    resetFs();
+    const result = hb.reportHumanBlock({
+        issue: 9999, skill: 'qa', phase: 'verificacion',
+        reason: 'Falta credencial AWS', question: '¿Quién regenera el token?',
+        pipeline: 'desarrollo',
+    });
+    assert.equal(fs.existsSync(result.marker_path), true);
+});
+
+test('listBlockedIssues retorna todos los markers con metadata', () => {
+    resetFs();
+    hb.reportHumanBlock({
+        issue: 1001, skill: 'po', phase: 'dev', pipeline: 'desarrollo',
+        reason: 'r1', question: 'q1',
+    });
+    hb.reportHumanBlock({
+        issue: 1002, skill: 'qa', phase: 'verificacion', pipeline: 'desarrollo',
+        reason: 'r2', question: 'q2',
+    });
+
+    const list = hb.listBlockedIssues();
+    assert.equal(list.length, 2);
+    const issues = list.map(i => i.issue).sort();
+    assert.deepEqual(issues, [1001, 1002]);
+    const item = list.find(i => i.issue === 1001);
+    assert.equal(item.skill, 'po');
+    assert.equal(item.phase, 'dev');
+    assert.equal(item.reason, 'r1');
+    assert.equal(item.question, 'q1');
+    assert.ok(typeof item.age_hours === 'number');
+});
+
+test('unblockIssue mueve marker a pendiente/ del target_phase y emite evento', () => {
+    resetFs();
+    hb.reportHumanBlock({
+        issue: 2222, skill: 'po', phase: 'dev', pipeline: 'desarrollo',
+        reason: 'r', question: 'q',
+    });
+
+    const res = hb.unblockIssue({
+        issue: 2222, guidance: 'Aplicá AC#5 que es más reciente', unlocker: 'leo',
+    });
+
+    assert.equal(res.ok, true);
+    assert.equal(res.issue, 2222);
+    assert.equal(res.skill, 'po');
+    assert.equal(res.from_phase, 'dev');
+    assert.equal(res.to_phase, 'dev');
+    assert.match(res.marker_path, /pendiente[\\/]2222\.po$/);
+    assert.equal(fs.existsSync(res.marker_path), true);
+
+    const guidanceFile = res.marker_path + '.guidance.txt';
+    assert.equal(fs.existsSync(guidanceFile), true);
+    assert.equal(fs.readFileSync(guidanceFile, 'utf8'), 'Aplicá AC#5 que es más reciente');
+
+    // marker de bloqueado debe haber desaparecido
+    const list = hb.listBlockedIssues();
+    assert.equal(list.find(i => i.issue === 2222), undefined);
+
+    const events = readEvents();
+    const unblocked = events.find(e => e.event === 'human:unblocked' && e.issue === 2222);
+    assert.ok(unblocked);
+    assert.equal(unblocked.guidance, 'Aplicá AC#5 que es más reciente');
+    assert.equal(unblocked.unlocker, 'leo');
+    assert.equal(unblocked.target_phase, 'dev');
+});
+
+test('unblockIssue puede redirigir a otra fase con target_phase', () => {
+    resetFs();
+    hb.reportHumanBlock({
+        issue: 3333, skill: 'qa', phase: 'verificacion', pipeline: 'desarrollo',
+        reason: 'r', question: 'q',
+    });
+
+    const res = hb.unblockIssue({
+        issue: 3333, guidance: 'Volver a dev por refactor', target_phase: 'dev',
+    });
+
+    assert.equal(res.ok, true);
+    assert.equal(res.from_phase, 'verificacion');
+    assert.equal(res.to_phase, 'dev');
+    assert.match(res.marker_path, /desarrollo[\\/]dev[\\/]pendiente[\\/]3333\.qa$/);
+});
+
+test('unblockIssue retorna error si issue no está bloqueado', () => {
+    resetFs();
+    const res = hb.unblockIssue({ issue: 4444, guidance: 'x' });
+    assert.equal(res.ok, false);
+    assert.match(res.error, /no está en bloqueado-humano/);
+});
+
+test('findBlockedMarker localiza marker existente', () => {
+    resetFs();
+    hb.reportHumanBlock({
+        issue: 5555, skill: 'tester', phase: 'dev', pipeline: 'desarrollo',
+        reason: 'r', question: 'q',
+    });
+    const found = hb.findBlockedMarker(5555);
+    assert.ok(found);
+    assert.equal(found.skill, 'tester');
+    assert.equal(found.phase, 'dev');
+    assert.equal(found.pipeline, 'desarrollo');
+});
+
+test('listBlockedIssues ignora archivos .reason.json y .gitkeep', () => {
+    resetFs();
+    const dir = path.join(TMP_DIR, '.pipeline', 'desarrollo', 'dev', 'bloqueado-humano');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, '.gitkeep'), '');
+    hb.reportHumanBlock({
+        issue: 6666, skill: 'po', phase: 'dev', pipeline: 'desarrollo',
+        reason: 'r', question: 'q',
+    });
+    const list = hb.listBlockedIssues();
+    assert.equal(list.filter(i => i.issue === 6666).length, 1);
+    assert.equal(list.find(i => String(i.issue) === '.gitkeep'), undefined);
+});

--- a/.pipeline/lib/human-block.js
+++ b/.pipeline/lib/human-block.js
@@ -1,0 +1,247 @@
+// V3 Human-block helpers — estado transversal "bloqueado-humano" (issue #2478).
+//
+// Cualquier skill puede invocar reportHumanBlock() cuando detecte ambigüedad real
+// que una intervención corta del humano resolvería. El issue queda pausado:
+// no rebota, no consume tokens, hasta que se invoque unblockIssue().
+//
+// Marker en disco: <pipeline>/<phase>/bloqueado-humano/<issue>.<skill>
+// Label GitHub: needs:human
+// Eventos activity-log: human:blocked / human:unblocked
+//
+// Directiva PO (Leo, 2026-04-22): preferir acumulación de issues bloqueados antes
+// que rebotes automáticos sin sentido. La eficiencia de tokens es prioritaria.
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const trace = require('./traceability');
+
+const PIPELINE_DIR = path.join(trace.REPO_ROOT, '.pipeline');
+const PIPELINES = ['desarrollo', 'definicion'];
+const BLOCK_SUBDIR = 'bloqueado-humano';
+const ACTIVE_STATES = ['pendiente', 'trabajando', 'listo'];
+
+function emitBlocked(opts) {
+    trace.appendEvent({
+        event: 'human:blocked',
+        skill: opts.skill || null,
+        issue: Number(opts.issue) || null,
+        phase: opts.phase || null,
+        pipeline: opts.pipeline || null,
+        reason: opts.reason || '',
+        question: opts.question || '',
+        ts: new Date().toISOString(),
+        pid: process.pid,
+    });
+}
+
+function emitUnblocked(opts) {
+    trace.appendEvent({
+        event: 'human:unblocked',
+        skill: opts.skill || null,
+        issue: Number(opts.issue) || null,
+        phase: opts.phase || null,
+        pipeline: opts.pipeline || null,
+        target_phase: opts.target_phase || opts.phase || null,
+        guidance: opts.guidance || '',
+        unlocker: opts.unlocker || 'commander',
+        ts: new Date().toISOString(),
+        pid: process.pid,
+    });
+}
+
+function findActiveMarker(issue) {
+    const prefix = String(issue) + '.';
+    for (const pipeline of PIPELINES) {
+        const pipeRoot = path.join(PIPELINE_DIR, pipeline);
+        let phases = [];
+        try { phases = fs.readdirSync(pipeRoot).filter(f => fs.statSync(path.join(pipeRoot, f)).isDirectory()); }
+        catch { continue; }
+        for (const phase of phases) {
+            for (const state of ACTIVE_STATES) {
+                const dir = path.join(pipeRoot, phase, state);
+                let entries = [];
+                try { entries = fs.readdirSync(dir); } catch { continue; }
+                for (const f of entries) {
+                    if (f.startsWith(prefix) && f !== '.gitkeep') {
+                        return {
+                            pipeline, phase, state,
+                            skill: f.slice(prefix.length),
+                            file: path.join(dir, f),
+                        };
+                    }
+                }
+            }
+        }
+    }
+    return null;
+}
+
+function findBlockedMarker(issue) {
+    const prefix = String(issue) + '.';
+    for (const pipeline of PIPELINES) {
+        const pipeRoot = path.join(PIPELINE_DIR, pipeline);
+        let phases = [];
+        try { phases = fs.readdirSync(pipeRoot).filter(f => fs.statSync(path.join(pipeRoot, f)).isDirectory()); }
+        catch { continue; }
+        for (const phase of phases) {
+            const dir = path.join(pipeRoot, phase, BLOCK_SUBDIR);
+            let entries = [];
+            try { entries = fs.readdirSync(dir); } catch { continue; }
+            for (const f of entries) {
+                if (f.startsWith(prefix) && f !== '.gitkeep') {
+                    return {
+                        pipeline, phase,
+                        skill: f.slice(prefix.length),
+                        file: path.join(dir, f),
+                    };
+                }
+            }
+        }
+    }
+    return null;
+}
+
+function reasonFilePath(blockedFile) {
+    return blockedFile + '.reason.json';
+}
+
+function guidanceFilePath(targetDir, marker) {
+    return path.join(targetDir, marker + '.guidance.txt');
+}
+
+function reportHumanBlock(opts) {
+    const issue = Number(opts.issue);
+    const skill = String(opts.skill || '').trim();
+    const phase = String(opts.phase || '').trim();
+    const reason = String(opts.reason || '').trim();
+    const question = String(opts.question || '').trim();
+    if (!issue || !skill || !phase) {
+        throw new Error('reportHumanBlock requiere issue, skill, phase');
+    }
+    if (!reason || !question) {
+        throw new Error('reportHumanBlock requiere reason y question (justificación obligatoria)');
+    }
+
+    let pipeline = opts.pipeline;
+    let srcFile = null;
+    if (!pipeline || opts.moveFromActive !== false) {
+        const active = findActiveMarker(issue);
+        if (active) {
+            pipeline = pipeline || active.pipeline;
+            srcFile = active.file;
+        }
+    }
+    pipeline = pipeline || 'desarrollo';
+
+    const targetDir = path.join(PIPELINE_DIR, pipeline, phase, BLOCK_SUBDIR);
+    fs.mkdirSync(targetDir, { recursive: true });
+    const marker = `${issue}.${skill}`;
+    const targetFile = path.join(targetDir, marker);
+
+    if (srcFile && fs.existsSync(srcFile)) {
+        try { fs.renameSync(srcFile, targetFile); }
+        catch { fs.writeFileSync(targetFile, ''); }
+    } else if (!fs.existsSync(targetFile)) {
+        fs.writeFileSync(targetFile, '');
+    }
+
+    fs.writeFileSync(reasonFilePath(targetFile), JSON.stringify({
+        issue, skill, phase, pipeline, reason, question,
+        blocked_at: new Date().toISOString(),
+    }, null, 2));
+
+    emitBlocked({ issue, skill, phase, pipeline, reason, question });
+
+    return { issue, skill, phase, pipeline, marker_path: targetFile };
+}
+
+function listBlockedIssues() {
+    const result = [];
+    for (const pipeline of PIPELINES) {
+        const pipeRoot = path.join(PIPELINE_DIR, pipeline);
+        let phases = [];
+        try { phases = fs.readdirSync(pipeRoot).filter(f => fs.statSync(path.join(pipeRoot, f)).isDirectory()); }
+        catch { continue; }
+        for (const phase of phases) {
+            const dir = path.join(pipeRoot, phase, BLOCK_SUBDIR);
+            let entries = [];
+            try { entries = fs.readdirSync(dir); } catch { continue; }
+            for (const f of entries) {
+                if (f === '.gitkeep' || f.endsWith('.reason.json')) continue;
+                const dot = f.indexOf('.');
+                if (dot <= 0) continue;
+                const issue = Number(f.slice(0, dot));
+                const skill = f.slice(dot + 1);
+                if (!Number.isFinite(issue)) continue;
+                const file = path.join(dir, f);
+                let reason = '', question = '', blockedAt = null;
+                try {
+                    const meta = JSON.parse(fs.readFileSync(reasonFilePath(file), 'utf8'));
+                    reason = meta.reason || '';
+                    question = meta.question || '';
+                    blockedAt = meta.blocked_at || null;
+                } catch {}
+                let mtime;
+                try { mtime = fs.statSync(file).mtimeMs; } catch { mtime = Date.now(); }
+                const ageHours = (Date.now() - mtime) / 3600000;
+                result.push({
+                    issue, skill, phase, pipeline,
+                    reason, question,
+                    blocked_at: blockedAt || new Date(mtime).toISOString(),
+                    age_hours: Math.round(ageHours * 10) / 10,
+                    marker_path: file,
+                });
+            }
+        }
+    }
+    return result.sort((a, b) => b.age_hours - a.age_hours);
+}
+
+function unblockIssue(opts) {
+    const issue = Number(opts.issue);
+    if (!issue) throw new Error('unblockIssue requiere issue');
+    const guidance = String(opts.guidance || '').trim();
+    const unlocker = opts.unlocker || 'commander';
+
+    const blocked = findBlockedMarker(issue);
+    if (!blocked) {
+        return { ok: false, error: `Issue ${issue} no está en bloqueado-humano/` };
+    }
+
+    const targetPhase = opts.target_phase || blocked.phase;
+    const targetDir = path.join(PIPELINE_DIR, blocked.pipeline, targetPhase, 'pendiente');
+    fs.mkdirSync(targetDir, { recursive: true });
+    const marker = `${issue}.${blocked.skill}`;
+    const targetFile = path.join(targetDir, marker);
+
+    try { fs.renameSync(blocked.file, targetFile); }
+    catch { fs.writeFileSync(targetFile, ''); try { fs.unlinkSync(blocked.file); } catch {} }
+
+    if (guidance) {
+        try { fs.writeFileSync(guidanceFilePath(targetDir, marker), guidance); } catch {}
+    }
+    try { fs.unlinkSync(reasonFilePath(blocked.file)); } catch {}
+
+    emitUnblocked({
+        issue, skill: blocked.skill, phase: blocked.phase, pipeline: blocked.pipeline,
+        target_phase: targetPhase, guidance, unlocker,
+    });
+
+    return {
+        ok: true, issue, skill: blocked.skill, pipeline: blocked.pipeline,
+        from_phase: blocked.phase, to_phase: targetPhase, marker_path: targetFile,
+    };
+}
+
+module.exports = {
+    reportHumanBlock,
+    unblockIssue,
+    listBlockedIssues,
+    findActiveMarker,
+    findBlockedMarker,
+    PIPELINE_DIR,
+    PIPELINES,
+    BLOCK_SUBDIR,
+};

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -615,7 +615,9 @@ function issueExistsInPipeline(issueNum, pipelineName) {
     if (!pConfig) continue;
     for (const fase of pConfig.fases) {
       // Solo buscar en estados activos — procesado significa que ya terminó esa fase
-      for (const estado of ['pendiente', 'trabajando', 'listo']) {
+      // bloqueado-humano cuenta como activo: el issue está pausado pero ocupando slot conceptual,
+      // no debe re-intakearse ni relanzarse hasta que /unblock lo desbloquee (issue #2478)
+      for (const estado of ['pendiente', 'trabajando', 'listo', 'bloqueado-humano']) {
         const dir = path.join(PIPELINE, pName, fase, estado);
         try {
           for (const f of fs.readdirSync(dir)) {
@@ -5386,6 +5388,77 @@ function cmdRestart(args) {
   return `🔄 Reinicio ${mode} del pipeline en progreso...\n_Te aviso cuando termine (~15-30s)._${paused ? '\n_Modo pausado: Telegram + dashboard activos, sin intake ni agentes._' : ''}`;
 }
 
+function cmdBloqueados() {
+  let humanBlock;
+  try { humanBlock = require('./lib/human-block'); }
+  catch (e) { return `⚠️ No pude cargar el módulo de bloqueos: ${e.message}`; }
+
+  const list = humanBlock.listBlockedIssues();
+  if (!list.length) return '✅ No hay issues bloqueados esperando intervención humana.';
+
+  const lines = [`🚧 *Issues bloqueados esperando humano* (${list.length})\n`];
+  for (const b of list) {
+    const ageStr = b.age_hours < 1
+      ? `${Math.round(b.age_hours * 60)}min`
+      : `${b.age_hours}h`;
+    lines.push(`*#${b.issue}* — ${b.skill} en ${b.phase} _(hace ${ageStr})_`);
+    if (b.question) lines.push(`  ❓ ${b.question}`);
+    else if (b.reason) lines.push(`  📝 ${b.reason.slice(0, 140)}`);
+    lines.push('');
+  }
+  lines.push('_Usá_ `/unblock <issue> <orientación>` _para desbloquear._');
+  return lines.join('\n');
+}
+
+function cmdUnblock(args) {
+  const trimmed = (args || '').trim();
+  if (!trimmed) {
+    return '❌ Uso: `/unblock <issue> <orientación>`\nEj: `/unblock 2480 usar la API REST en lugar de gRPC`';
+  }
+
+  const m = trimmed.match(/^#?(\d+)\s+(.+)$/s);
+  if (!m) {
+    return '❌ Formato inválido. Usá: `/unblock <número de issue> <orientación>`';
+  }
+  const issue = Number(m[1]);
+  const guidance = m[2].trim();
+  if (!guidance) return '❌ La orientación no puede estar vacía.';
+
+  let humanBlock;
+  try { humanBlock = require('./lib/human-block'); }
+  catch (e) { return `⚠️ No pude cargar el módulo de bloqueos: ${e.message}`; }
+
+  let result;
+  try { result = humanBlock.unblockIssue({ issue, guidance, unlocker: 'commander:telegram' }); }
+  catch (e) { return `❌ Error desbloqueando #${issue}: ${e.message}`; }
+
+  if (!result.ok) return `⚠️ ${result.error}`;
+
+  // Best-effort: quitar label needs:human del issue en GitHub
+  try {
+    const ghBin = process.env.GH_BIN || 'gh';
+    require('child_process').execSync(
+      `"${ghBin}" issue edit ${issue} --remove-label "needs:human" --repo intrale/platform`,
+      { stdio: 'ignore', timeout: 15000 }
+    );
+  } catch {}
+
+  // Best-effort: comentar en el issue con la orientación
+  try {
+    const ghBin = process.env.GH_BIN || 'gh';
+    const body = `## ✅ Desbloqueado por humano\n\n**Skill:** \`${result.skill}\` · **Fase:** \`${result.from_phase}\` → \`${result.to_phase}\`\n\n**Orientación:**\n\n> ${guidance.replace(/\n/g, '\n> ')}\n\n_Vuelve a la cola del pipeline._`;
+    const tmpFile = path.join(PIPELINE, `.unblock-comment-${issue}-${Date.now()}.md`);
+    fs.writeFileSync(tmpFile, body);
+    require('child_process').execSync(
+      `"${ghBin}" issue comment ${issue} --body-file "${tmpFile}" --repo intrale/platform`,
+      { stdio: 'ignore', timeout: 15000 }
+    );
+    try { fs.unlinkSync(tmpFile); } catch {}
+  } catch {}
+
+  return `✅ Issue *#${issue}* desbloqueado.\n*Skill:* \`${result.skill}\` · *Fase:* \`${result.from_phase}\` → \`${result.to_phase}\`\n*Orientación guardada* para que el próximo agente la lea al arrancar.`;
+}
+
 function cmdHelp() {
   return `🤖 *Comandos del Pipeline V2*
 
@@ -5400,6 +5473,8 @@ function cmdHelp() {
 /pausar — Pausar el Pulpo
 /reanudar — Reanudar el Pulpo
 /costos — Resumen de actividad/costos
+/bloqueados — Listar issues bloqueados esperando intervención humana (V3)
+/unblock <issue> <orientación> — Desbloquear un issue con orientación para el skill (V3)
 /help — Esta ayuda
 /stop — Apagar el Commander
 
@@ -5433,6 +5508,7 @@ function parseCommand(text) {
       { pattern: /\b(proponer historias|propon[eé] historias|historias nuevas)\b/i, cmd: 'proponer' },
       { pattern: /\b(stop|apag[áa] el commander|cerr[áa] el commander)\b/i, cmd: 'stop' },
       { pattern: /\b(limpi[áa]|limpiar daemons|matar gradle|matar daemons|kill gradle)\b/i, cmd: 'limpiar' },
+      { pattern: /\b(bloqueados|qu[eé] est[áa] bloqueado|que necesita humano|necesitan intervenci[óo]n)\b/i, cmd: 'bloqueados' },
     ];
 
     for (const { pattern, cmd } of intentPatterns) {
@@ -5573,6 +5649,8 @@ async function _brazoCommanderInner(config, archivosIniciales, commanderPendient
       case 'proponer': respuesta = await cmdProponer(parsed.args, config); break;
       case 'limpiar': respuesta = cmdLimpiar(); break;
       case 'restart': respuesta = cmdRestart(parsed.args); break;
+      case 'bloqueados': respuesta = cmdBloqueados(); break;
+      case 'unblock': respuesta = cmdUnblock(parsed.args); break;
       default: respuesta = null; break;
     }
 


### PR DESCRIPTION
## Resumen

Implementa el estado transversal `bloqueado-humano` para el pipeline V3. Cuando un skill detecta ambigüedad que resolver, en lugar de rebotar (caro en tokens y tiempo) puede pausar al issue y esperar orientación humana vía Telegram. El resto del pipeline sigue procesando otros issues sin frenarse.

## Cambios

### Nuevo — `lib/human-block.js` (247 líneas)
Helpers reutilizables por cualquier skill:
- `reportHumanBlock({ issue, skill, phase, reason, question, target_phase })` — crea marker `<fase>/bloqueado-humano/<issue>.<skill>` + `.reason.json` con contexto, emite evento V3 (`session:human-block`) alineado con el contrato de #2477.
- `listBlockedIssues()` — scan recursivo de todas las fases, retorna `{ issue, skill, phase, pipeline, reason, question, blocked_at, age_hours }`.
- `unblockIssue({ issue, guidance, unlocker })` — mueve el marker a `pendiente/<target_phase>/` con la orientación inyectada, emite evento `session:human-unblock`.
- `findBlockedMarker(issue)` — localiza el marker de un issue específico.

### Nuevo — `lib/__tests__/human-block.test.js` (211 líneas)
**10/10 tests verdes.** Cubren happy path, redirección de fase, ignorar `.reason.json`/`.gitkeep`, validaciones y errores.

### Modificado — `pulpo.js`
- `issueExistsInPipeline` ahora incluye `bloqueado-humano` como estado activo → no se re-intakea ni relanza un issue bloqueado.
- Comandos Telegram wireados al handler principal:
  - `/bloqueados` — lista issues bloqueados con edad, skill, pregunta/razón y hint de `/unblock`.
  - `/unblock <issue> <orientación>` — desbloquea, redirige fase si aplica, best-effort remueve label `needs:human` y comenta en el issue.
- Ayuda (`/help`) actualizada con ambos comandos etiquetados V3.

### Modificado — `dashboard-v2.js`
Sección V3 "🚧 Esperando intervención humana" — renderiza los bloqueados con contador, título del issue (best-effort desde el title cache), pregunta destacada en amarillo y hint del comando.

## Principios respetados

- **Eficiencia sobre autonomía** (directiva de Leo 2026-04-22): preferir bloqueo humano vs rebote automático cuando hay ambigüedad real. Issues acumulados con intervención humana ≪ tokens gastados en rebotes sin sentido.
- **Trazabilidad V3 innegociable**: todos los eventos respetan el schema de #2477 (session:human-block, session:human-unblock). No se inventa formato paralelo.
- **No rompe V2**: `bloqueado-humano` es un flag transversal, no fase nueva. El pulpo, las ventanas de prioridad, concurrencia y circuit breaker siguen intactos.

## QA

Se propone `qa:skipped`: cambio 100% infra de pipeline, sin impacto en producto de usuario. Tests unitarios + smoke manual (marker simulado #9999) validaron el ciclo completo: crear → listar → render Telegram → unblock → redirección de fase → cleanup.

Closes #2478