### PR TITLE
feat(pipeline): V3 builder determinístico — bypass LLM con Node puro (#2476)

### DIFF
--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -4128,17 +4128,39 @@ function lanzarAgenteClaude(skill, issue, trabajandoPath, pipeline, fase, config
     }
   }
 
+  // #2476 — builder determinístico: si el skill es builder y existe el script
+  // `.pipeline/skills-deterministicos/builder.js`, bypass del LLM y correr Node puro.
+  // El script implementa el mismo contrato (marker, heartbeat, eventos V3) y
+  // emite exit code 0 = aprobado / 1 = rebote, por lo que el resto del flujo
+  // (watchdog, on-exit, mover a listo/) funciona sin cambios.
+  const deterministicBuilder = path.join(PIPELINE, 'skills-deterministicos', 'builder.js');
+  const useDeterministicBuilder = (skill === 'builder' && fs.existsSync(deterministicBuilder));
+
   // Launcher detectado al boot (ver detectClaudeLauncher). Evita cmd.exe cuando es posible.
-  const spawnCmd = CLAUDE_LAUNCHER.cmd;
-  const spawnArgs = [...CLAUDE_LAUNCHER.prefixArgs, ...args];
+  const spawnCmd = useDeterministicBuilder ? process.execPath : CLAUDE_LAUNCHER.cmd;
+  const spawnArgs = useDeterministicBuilder
+    ? [deterministicBuilder, String(issue), `--trabajando=${trabajandoPath}`]
+    : [...CLAUDE_LAUNCHER.prefixArgs, ...args];
+
+  if (useDeterministicBuilder) {
+    log('lanzamiento', `⚡ builder:#${issue} ejecutado en modo determinístico (sin tokens LLM)`);
+  }
 
   const child = spawn(spawnCmd, spawnArgs, {
     cwd: (needsWorktree || useExistingWorktree) ? worktreePath : ROOT,
     stdio: ['ignore', 'pipe', 'pipe'],
     detached: false,
-    shell: CLAUDE_LAUNCHER.shell,
+    shell: useDeterministicBuilder ? false : CLAUDE_LAUNCHER.shell,
     windowsHide: true,
-    env: { ...process.env, PIPELINE_ISSUE: issue, PIPELINE_SKILL: skill, PIPELINE_FASE: fase, ...extraEnv }
+    env: {
+      ...process.env,
+      PIPELINE_ISSUE: issue,
+      PIPELINE_SKILL: skill,
+      PIPELINE_FASE: fase,
+      PIPELINE_PIPELINE: pipeline,
+      PIPELINE_TRABAJANDO: trabajandoPath,
+      ...extraEnv,
+    },
   });
 
   // #2334 / CA6: piping stdout/stderr → sanitizeStream → file.

--- a/.pipeline/skills-deterministicos/__tests__/builder.test.js
+++ b/.pipeline/skills-deterministicos/__tests__/builder.test.js
@@ -1,0 +1,140 @@
+// Tests unitarios de .pipeline/skills-deterministicos/builder.js (issue #2476)
+// No lanzamos gradle real: validamos parseArgs, buildGradleCommand, heartbeat,
+// updateMarker y copyArtifacts con filesystem aislado.
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+// Aislar REPO_ROOT a un tmp — el módulo resuelve paths a partir de env vars.
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'v3-builder-'));
+fs.mkdirSync(path.join(TMP, '.claude', 'hooks'), { recursive: true });
+fs.mkdirSync(path.join(TMP, '.pipeline', 'logs'), { recursive: true });
+fs.mkdirSync(path.join(TMP, '.pipeline', 'desarrollo', 'build', 'trabajando'), { recursive: true });
+fs.mkdirSync(path.join(TMP, 'qa', 'artifacts'), { recursive: true });
+process.env.PIPELINE_REPO_ROOT = TMP;
+process.env.CLAUDE_PROJECT_DIR = TMP;
+
+delete require.cache[require.resolve('../builder')];
+const builder = require('../builder');
+
+test('parseArgs — issue posicional + scope por defecto smart', () => {
+    const a = builder.parseArgs(['node', 'builder.js', '2476']);
+    assert.equal(a.issue, 2476);
+    assert.equal(a.scope, 'smart');
+    assert.equal(a.module, null);
+});
+
+test('parseArgs — flags --clean/--fast/--all/--verify', () => {
+    assert.equal(builder.parseArgs(['node', 'x', '1', '--clean']).scope, 'clean');
+    assert.equal(builder.parseArgs(['node', 'x', '1', '--fast']).scope, 'fast');
+    assert.equal(builder.parseArgs(['node', 'x', '1', '--all']).scope, 'all');
+    assert.equal(builder.parseArgs(['node', 'x', '1', '--verify']).scope, 'verify');
+});
+
+test('parseArgs — --module=<nombre>', () => {
+    const a = builder.parseArgs(['node', 'x', '1', '--module=backend']);
+    assert.equal(a.module, 'backend');
+});
+
+test('parseArgs — fallback a PIPELINE_ISSUE si no hay argumento posicional', () => {
+    const saved = process.env.PIPELINE_ISSUE;
+    process.env.PIPELINE_ISSUE = '9999';
+    try {
+        const a = builder.parseArgs(['node', 'x']);
+        assert.equal(a.issue, 9999);
+    } finally {
+        if (saved === undefined) delete process.env.PIPELINE_ISSUE;
+        else process.env.PIPELINE_ISSUE = saved;
+    }
+});
+
+test('buildGradleCommand — smart por defecto usa scripts/smart-build.sh', () => {
+    const c = builder.buildGradleCommand('smart', null);
+    assert.equal(c.cmd, 'bash');
+    assert.deepEqual(c.args, ['scripts/smart-build.sh']);
+    assert.equal(c.label, 'smart');
+});
+
+test('buildGradleCommand — clean usa ./gradlew clean build --no-daemon', () => {
+    const c = builder.buildGradleCommand('clean', null);
+    assert.equal(c.cmd, './gradlew');
+    assert.ok(c.args.includes('clean'));
+    assert.ok(c.args.includes('build'));
+    assert.ok(c.args.includes('--no-daemon'));
+});
+
+test('buildGradleCommand — module=app mapea a :app:composeApp:check', () => {
+    const c = builder.buildGradleCommand('smart', 'app');
+    assert.equal(c.cmd, './gradlew');
+    assert.ok(c.args.includes(':app:composeApp:check'));
+    assert.equal(c.label, 'module:app');
+});
+
+test('buildGradleCommand — module=backend mapea a :backend:check', () => {
+    const c = builder.buildGradleCommand('smart', 'backend');
+    assert.ok(c.args.includes(':backend:check'));
+});
+
+test('startHeartbeat — escribe archivo agent-<issue>.heartbeat y lo limpia al stop', () => {
+    const hb = builder.startHeartbeat(2476);
+    const hbFile = path.join(TMP, '.claude', 'hooks', 'agent-2476.heartbeat');
+    assert.equal(fs.existsSync(hbFile), true);
+    const content = JSON.parse(fs.readFileSync(hbFile, 'utf8').trim());
+    assert.equal(content.issue, 2476);
+    assert.equal(content.skill, 'builder');
+    assert.equal(content.model, 'deterministic');
+    hb.stop();
+    assert.equal(fs.existsSync(hbFile), false);
+});
+
+test('startHeartbeat — issue null es no-op', () => {
+    const hb = builder.startHeartbeat(null);
+    // No debe lanzar ni crear nada; stop es idempotente
+    hb.stop();
+});
+
+test('updateMarker — escribe resultado y motivo al YAML', () => {
+    const marker = path.join(TMP, '.pipeline', 'desarrollo', 'build', 'trabajando', '2476.builder');
+    fs.writeFileSync(marker, 'issue: 2476\npipeline: desarrollo\n');
+    builder.updateMarker(marker, { resultado: 'aprobado', motivo: 'Build exitoso', builder_mode: 'deterministic' });
+    const after = fs.readFileSync(marker, 'utf8');
+    assert.ok(after.includes('resultado:'));
+    assert.ok(after.includes('"aprobado"'));
+    assert.ok(after.includes('"Build exitoso"'));
+    assert.ok(after.includes('builder_mode:'));
+    // No duplicó issue/pipeline
+    const issueLines = after.split('\n').filter((l) => l.startsWith('issue:'));
+    assert.equal(issueLines.length, 1);
+});
+
+test('updateMarker — trabajandoPath null es no-op', () => {
+    // No debe lanzar
+    builder.updateMarker(null, { resultado: 'aprobado' });
+});
+
+test('copyArtifacts — copia users-all.jar si existe y el módulo users fue tocado', () => {
+    const srcDir = path.join(TMP, 'users', 'build', 'libs');
+    fs.mkdirSync(srcDir, { recursive: true });
+    const src = path.join(srcDir, 'users-all.jar');
+    fs.writeFileSync(src, 'FAKE JAR');
+    // Limpiar destino
+    const dst = path.join(TMP, 'qa', 'artifacts', 'users-all.jar');
+    try { fs.unlinkSync(dst); } catch {}
+
+    const artifacts = builder.copyArtifacts({ modules: ['users'] });
+    assert.ok(artifacts.includes('users-all.jar'));
+    assert.equal(fs.existsSync(dst), true);
+    assert.equal(fs.readFileSync(dst, 'utf8'), 'FAKE JAR');
+});
+
+test('copyArtifacts — escribe BUILD_TIMESTAMP siempre', () => {
+    const ts = path.join(TMP, 'qa', 'artifacts', 'BUILD_TIMESTAMP');
+    try { fs.unlinkSync(ts); } catch {}
+    const artifacts = builder.copyArtifacts({ modules: [] });
+    assert.ok(artifacts.includes('BUILD_TIMESTAMP'));
+    assert.equal(fs.existsSync(ts), true);
+});

--- a/.pipeline/skills-deterministicos/__tests__/fixtures/build-failed-forbidden-strings.txt
+++ b/.pipeline/skills-deterministicos/__tests__/fixtures/build-failed-forbidden-strings.txt
@@ -1,0 +1,19 @@
+> Task :app:composeApp:verifyNoLegacyStrings FAILED
+
+FAILURE: Build failed with an exception.
+
+* Where:
+Build file '/c/Workspaces/Intrale/platform/app/composeApp/build.gradle.kts' line: 87
+
+* What went wrong:
+Execution failed for task ':app:composeApp:verifyNoLegacyStrings'.
+> forbidden-strings-processor detected legacy string usage:
+  - app/composeApp/src/commonMain/kotlin/ar/com/intrale/ui/sc/login/LoginScreen.kt:42 — stringResource(Res.string.login_title)
+  - app/composeApp/src/commonMain/kotlin/ar/com/intrale/ui/sc/home/HomeScreen.kt:78 — Res.string.welcome
+  Use resString() helper instead — see docs/engineering/strings.md
+
+* Try:
+> Run with --stacktrace option to get the stack trace.
+
+BUILD FAILED in 12s
+8 actionable tasks: 2 executed, 6 up-to-date

--- a/.pipeline/skills-deterministicos/__tests__/fixtures/build-failed-java-home.txt
+++ b/.pipeline/skills-deterministicos/__tests__/fixtures/build-failed-java-home.txt
@@ -1,0 +1,9 @@
+FAILURE: Build failed with an exception.
+
+* What went wrong:
+Value 'C:\Users\Administrator\.jdks\jbr-21' given for org.gradle.java.installations.paths Gradle property is invalid (JAVA_HOME does not exist: no such file or directory)
+
+* Try:
+> Run with --stacktrace option to get more log output.
+
+BUILD FAILED in 2s

--- a/.pipeline/skills-deterministicos/__tests__/fixtures/build-failed-unresolved.txt
+++ b/.pipeline/skills-deterministicos/__tests__/fixtures/build-failed-unresolved.txt
@@ -1,0 +1,17 @@
+> Task :backend:compileKotlin FAILED
+
+e: file:///c/Workspaces/Intrale/platform/backend/src/main/kotlin/ar/com/intrale/http/Server.kt:45:23 error: unresolved reference: configureSecurity
+e: file:///c/Workspaces/Intrale/platform/backend/src/main/kotlin/ar/com/intrale/http/Server.kt:46:19 error: unresolved reference: configureRouting
+
+FAILURE: Build failed with an exception.
+
+* What went wrong:
+Execution failed for task ':backend:compileKotlin'.
+> Compilation error. See log for more details
+  error: unresolved reference: configureSecurity
+
+* Try:
+> Run with --info or --debug option to get more log output.
+
+BUILD FAILED in 34s
+5 actionable tasks: 3 executed, 2 up-to-date

--- a/.pipeline/skills-deterministicos/__tests__/fixtures/build-successful.txt
+++ b/.pipeline/skills-deterministicos/__tests__/fixtures/build-successful.txt
@@ -1,0 +1,25 @@
+Starting a Gradle Daemon (subsequent builds will be faster)
+> Task :buildSrc:compileKotlin UP-TO-DATE
+> Task :buildSrc:compileJava NO-SOURCE
+> Task :buildSrc:pluginDescriptors UP-TO-DATE
+> Task :buildSrc:processResources UP-TO-DATE
+> Task :buildSrc:classes UP-TO-DATE
+> Task :buildSrc:jar UP-TO-DATE
+> Task :backend:compileKotlin
+> Task :backend:compileJava NO-SOURCE
+> Task :backend:processResources
+> Task :backend:classes
+> Task :backend:test
+> Task :backend:check
+> Task :users:compileKotlin
+> Task :users:compileJava NO-SOURCE
+> Task :users:processResources
+> Task :users:classes
+> Task :users:test
+> Task :users:check
+> Task :app:composeApp:verifyNoLegacyStrings
+> Task :app:composeApp:validateComposeResources
+> Task :app:composeApp:scanNonAsciiFallbacks
+
+BUILD SUCCESSFUL in 1m 23s
+47 actionable tasks: 12 executed, 30 up-to-date, 5 from cache

--- a/.pipeline/skills-deterministicos/__tests__/fixtures/gradle-compile-error.txt
+++ b/.pipeline/skills-deterministicos/__tests__/fixtures/gradle-compile-error.txt
@@ -1,0 +1,18 @@
+> Task :app:composeApp:compileClientDebugKotlinAndroid FAILED
+e: file:///C:/Workspaces/Intrale/platform/app/composeApp/src/commonMain/kotlin/ar/com/intrale/app/ui/sc/Login.kt:42:13 Unresolved reference: viewModelScopee
+e: file:///C:/Workspaces/Intrale/platform/app/composeApp/src/commonMain/kotlin/ar/com/intrale/app/ui/sc/Login.kt:58:5 Type mismatch: inferred type is String but Int was expected
+
+FAILURE: Build failed with an exception.
+
+* What went wrong:
+Execution failed for task ':app:composeApp:compileClientDebugKotlinAndroid'.
+> Compilation error. See log for more details
+
+* Try:
+> Run with --stacktrace option to get the stack trace.
+> Run with --info or --debug option to get more log output.
+> Run with --scan to get full insights.
+> Get more help at https://help.gradle.org.
+
+BUILD FAILED in 47s
+18 actionable tasks: 6 executed, 12 up-to-date

--- a/.pipeline/skills-deterministicos/__tests__/fixtures/gradle-success.txt
+++ b/.pipeline/skills-deterministicos/__tests__/fixtures/gradle-success.txt
@@ -1,0 +1,22 @@
+> Task :backend:compileKotlin
+> Task :backend:compileJava NO-SOURCE
+> Task :backend:processResources
+> Task :backend:classes
+> Task :backend:jar
+> Task :backend:compileTestKotlin
+> Task :backend:compileTestJava NO-SOURCE
+> Task :backend:processTestResources NO-SOURCE
+> Task :backend:testClasses
+> Task :backend:test
+> Task :backend:check
+> Task :users:compileKotlin
+> Task :users:compileJava NO-SOURCE
+> Task :users:processResources
+> Task :users:classes
+> Task :users:jar
+> Task :users:compileTestKotlin
+> Task :users:test
+> Task :users:check
+
+BUILD SUCCESSFUL in 2m 14s
+56 actionable tasks: 56 executed

--- a/.pipeline/skills-deterministicos/__tests__/fixtures/gradle-verify-fail.txt
+++ b/.pipeline/skills-deterministicos/__tests__/fixtures/gradle-verify-fail.txt
@@ -1,0 +1,13 @@
+> Task :app:composeApp:verifyNoLegacyStrings FAILED
+
+FAILURE: Build failed with an exception.
+
+* What went wrong:
+Execution failed for task ':app:composeApp:verifyNoLegacyStrings'.
+> Se detectaron 3 usos prohibidos de strings legacy. Ver output.
+
+* Try:
+> Run with --stacktrace option to get the stack trace.
+
+BUILD FAILED in 12s
+3 actionable tasks: 1 executed, 2 up-to-date

--- a/.pipeline/skills-deterministicos/__tests__/gradle-parser.test.js
+++ b/.pipeline/skills-deterministicos/__tests__/gradle-parser.test.js
@@ -1,0 +1,137 @@
+// Tests de .pipeline/skills-deterministicos/lib/gradle-parser.js (issue #2476)
+// Valida parseo de BUILD SUCCESSFUL/FAILED, clasificación de errores conocidos
+// y render del reporte markdown.
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const {
+    parseGradleOutput,
+    classifyError,
+    renderMarkdownReport,
+    ERROR_PATTERNS,
+} = require('../lib/gradle-parser');
+
+const FIXTURES = path.join(__dirname, 'fixtures');
+const readFixture = (name) => fs.readFileSync(path.join(FIXTURES, name), 'utf8');
+
+test('parseGradleOutput — BUILD SUCCESSFUL clásico extrae duración, módulos y verificaciones', () => {
+    const out = readFixture('build-successful.txt');
+    const r = parseGradleOutput(out);
+
+    assert.equal(r.success, true);
+    assert.equal(r.build_status, 'SUCCESSFUL');
+    assert.equal(r.duration_ms, 83000); // 1m 23s = 83s
+    assert.equal(r.errors.length, 0);
+    assert.ok(r.modules.includes('backend'));
+    assert.ok(r.modules.includes('users'));
+    assert.ok(r.modules.includes('app'));
+    assert.equal(r.verifications.verifyNoLegacyStrings, true);
+    assert.equal(r.verifications.validateComposeResources, true);
+    assert.equal(r.verifications.scanNonAsciiFallbacks, true);
+    assert.equal(r.tasks.total, 47);
+    assert.equal(r.tasks.executed, 12);
+    assert.equal(r.tasks.up_to_date, 30);
+    assert.equal(r.tasks.from_cache, 5);
+});
+
+test('parseGradleOutput — BUILD FAILED con forbidden-strings clasifica y escala a android-dev', () => {
+    const out = readFixture('build-failed-forbidden-strings.txt');
+    const r = parseGradleOutput(out);
+
+    assert.equal(r.success, false);
+    assert.equal(r.build_status, 'FAILED');
+    assert.equal(r.duration_ms, 12000);
+    assert.ok(r.errors.length >= 1);
+    const err = r.errors[0];
+    assert.equal(err.classification, 'forbidden_strings');
+    assert.equal(err.escalate_to, 'android-dev');
+    assert.ok(err.message.includes('verifyNoLegacyStrings'));
+    assert.equal(r.verifications.verifyNoLegacyStrings, false);
+});
+
+test('parseGradleOutput — BUILD FAILED con JAVA_HOME clasifica como infra sin escalación', () => {
+    const out = readFixture('build-failed-java-home.txt');
+    const r = parseGradleOutput(out);
+
+    assert.equal(r.success, false);
+    assert.equal(r.build_status, 'FAILED');
+    assert.ok(r.errors.length >= 1);
+    const err = r.errors[0];
+    assert.equal(err.classification, 'java_home');
+    assert.equal(err.severity, 'infra');
+    assert.equal(err.escalate_to, null);
+});
+
+test('parseGradleOutput — error unresolved reference en :backend escala a backend-dev', () => {
+    const out = readFixture('build-failed-unresolved.txt');
+    const r = parseGradleOutput(out);
+
+    assert.equal(r.success, false);
+    assert.ok(r.errors.length >= 1);
+    const err = r.errors[0];
+    assert.equal(err.classification, 'unresolved_reference');
+    assert.equal(err.escalate_to, 'backend-dev');
+    assert.equal(err.task, ':backend:compileKotlin');
+});
+
+test('parseGradleOutput — output vacío no rompe y retorna UNKNOWN', () => {
+    const r = parseGradleOutput('', '');
+    assert.equal(r.success, false);
+    assert.equal(r.build_status, 'UNKNOWN');
+    assert.equal(r.errors.length, 0);
+    assert.equal(r.duration_ms, 0);
+});
+
+test('classifyError — detecta todos los patrones conocidos', () => {
+    assert.equal(classifyError('OutOfMemoryError: Java heap space').type, 'oom');
+    assert.equal(classifyError('Kotlin version mismatch in metadata').type, 'kotlin_version_mismatch');
+    assert.equal(classifyError('stringResource(Res.string.x)').type, 'forbidden_strings');
+    assert.equal(classifyError('e: error: type mismatch: required Int, found String').type, 'type_mismatch');
+    assert.equal(classifyError('Something unusual happened').type, 'unknown');
+});
+
+test('classifyError — unknown en :users escala a backend-dev', () => {
+    const r = classifyError('Mysterious gradle issue', ':users:check');
+    assert.equal(r.type, 'unknown');
+    assert.equal(r.escalate_to, 'backend-dev');
+});
+
+test('classifyError — unknown en :app escala a android-dev', () => {
+    const r = classifyError('Weird app failure', ':app:composeApp:compileKotlin');
+    assert.equal(r.type, 'unknown');
+    assert.equal(r.escalate_to, 'android-dev');
+});
+
+test('renderMarkdownReport — build exitoso incluye todas las secciones', () => {
+    const r = parseGradleOutput(readFixture('build-successful.txt'));
+    const md = renderMarkdownReport(r, { issue: 2476, scope: 'smart' });
+    assert.ok(md.includes('## Build: EXITOSO'));
+    assert.ok(md.includes('### Compilacion'));
+    assert.ok(md.includes('### Verificaciones'));
+    assert.ok(md.includes('### Veredicto del Builder'));
+    assert.ok(md.includes('issue #2476'));
+    assert.ok(md.includes('smart'));
+    assert.ok(md.includes('Strings legacy: ✅'));
+});
+
+test('renderMarkdownReport — build fallido incluye sección Errores con clasificación', () => {
+    const r = parseGradleOutput(readFixture('build-failed-forbidden-strings.txt'));
+    const md = renderMarkdownReport(r, { issue: 2476 });
+    assert.ok(md.includes('## Build: FALLIDO'));
+    assert.ok(md.includes('### Errores'));
+    assert.ok(md.includes('[forbidden_strings]'));
+    assert.ok(md.includes('android-dev'));
+    assert.ok(md.includes('Hay errores que corregir'));
+});
+
+test('ERROR_PATTERNS — cada patrón tiene type, regex, fix y severity', () => {
+    for (const p of ERROR_PATTERNS) {
+        assert.ok(p.type, `pattern sin type: ${JSON.stringify(p)}`);
+        assert.ok(p.regex instanceof RegExp, `pattern sin regex válido: ${p.type}`);
+        assert.ok(p.severity, `pattern sin severity: ${p.type}`);
+    }
+});

--- a/.pipeline/skills-deterministicos/builder.js
+++ b/.pipeline/skills-deterministicos/builder.js
@@ -1,0 +1,309 @@
+#!/usr/bin/env node
+/**
+ * builder.js — Skill determinístico /builder (issue #2476)
+ *
+ * Reemplaza al skill LLM `builder` dentro del flujo del Pulpo para eliminar
+ * el gasto de tokens en un proceso 100% mecánico: setup JAVA_HOME → correr
+ * Gradle → parsear output → generar reporte → copiar artefactos QA.
+ *
+ * Contrato idéntico al skill LLM:
+ *   - Marker en `trabajando/<issue>.builder` (lo lee y actualiza con resultado)
+ *   - Heartbeat `agent-<issue>.heartbeat` cada 30s
+ *   - Eventos `session:start` / `session:end` en activity-log
+ *   - Exit code 0 = build OK (marker → aprobado), 1 = build FAIL (rebote)
+ *
+ * CLI:
+ *   node builder.js <issue> [--scope=smart|clean|fast|all] [--module=<name>] [--trabajando=<path>]
+ *
+ * Env vars (pasadas por el Pulpo):
+ *   PIPELINE_ISSUE, PIPELINE_SKILL, PIPELINE_FASE, PIPELINE_TRABAJANDO, PIPELINE_PIPELINE
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { spawn } = require('child_process');
+const trace = require('../lib/traceability');
+const { parseGradleOutput, renderMarkdownReport } = require('./lib/gradle-parser');
+
+// ── Constantes y paths ──────────────────────────────────────────────
+const REPO_ROOT = process.env.PIPELINE_REPO_ROOT || process.env.CLAUDE_PROJECT_DIR || path.resolve(__dirname, '..', '..');
+const HOOKS_DIR = path.join(REPO_ROOT, '.claude', 'hooks');
+const LOG_DIR = path.join(REPO_ROOT, '.pipeline', 'logs');
+const QA_ARTIFACTS_DIR = path.join(REPO_ROOT, 'qa', 'artifacts');
+const JAVA_HOME_DEFAULT = process.env.JAVA_HOME || '/c/Users/Administrator/.jdks/temurin-21.0.7';
+const HEARTBEAT_INTERVAL_MS = 30 * 1000;
+
+// ── Parseo de argumentos ────────────────────────────────────────────
+function parseArgs(argv) {
+    const args = { issue: null, scope: 'smart', module: null, trabajando: null };
+    for (const a of argv.slice(2)) {
+        if (/^\d+$/.test(a) && !args.issue) { args.issue = parseInt(a, 10); continue; }
+        if (a === '--clean') { args.scope = 'clean'; continue; }
+        if (a === '--fast') { args.scope = 'fast'; continue; }
+        if (a === '--all') { args.scope = 'all'; continue; }
+        if (a === '--verify') { args.scope = 'verify'; continue; }
+        const kv = a.match(/^--([\w-]+)=(.+)$/);
+        if (kv) {
+            if (kv[1] === 'scope') args.scope = kv[2];
+            else if (kv[1] === 'module') args.module = kv[2];
+            else if (kv[1] === 'trabajando') args.trabajando = kv[2];
+        }
+    }
+    args.issue = args.issue || (process.env.PIPELINE_ISSUE ? Number(process.env.PIPELINE_ISSUE) : null);
+    args.trabajando = args.trabajando || process.env.PIPELINE_TRABAJANDO || null;
+    return args;
+}
+
+// ── Heartbeat ───────────────────────────────────────────────────────
+function startHeartbeat(issue) {
+    if (!issue) return { stop: () => {} };
+    try { fs.mkdirSync(HOOKS_DIR, { recursive: true }); } catch {}
+    const hbFile = path.join(HOOKS_DIR, `agent-${issue}.heartbeat`);
+    const writeHb = () => {
+        try {
+            fs.writeFileSync(hbFile, JSON.stringify({
+                issue, skill: 'builder', pid: process.pid, model: 'deterministic',
+                ts: new Date().toISOString(),
+            }) + '\n');
+        } catch {}
+    };
+    writeHb();
+    const iv = setInterval(writeHb, HEARTBEAT_INTERVAL_MS);
+    iv.unref?.();
+    return {
+        stop: () => {
+            clearInterval(iv);
+            try { fs.unlinkSync(hbFile); } catch {}
+        },
+    };
+}
+
+// ── Decisión de scope → comando Gradle ───────────────────────────────
+function buildGradleCommand(scope, mod) {
+    // Devuelve { cmd, args, label } — cmd es 'bash' o './gradlew'
+    if (mod) {
+        const moduleTask = mod === 'app' ? ':app:composeApp:check' : `:${mod}:check`;
+        return { cmd: './gradlew', args: [moduleTask, '--no-daemon'], label: `module:${mod}` };
+    }
+    switch (scope) {
+        case 'clean':
+            return { cmd: './gradlew', args: ['clean', 'build', '--no-daemon'], label: 'clean-build' };
+        case 'fast':
+            return { cmd: './gradlew', args: [':app:composeApp:compileKotlinJvm', '--no-daemon'], label: 'fast' };
+        case 'all':
+            return { cmd: 'bash', args: ['scripts/smart-build.sh', '--all'], label: 'all' };
+        case 'verify':
+            return { cmd: './gradlew', args: ['verifyNoLegacyStrings', ':app:composeApp:validateComposeResources', ':app:composeApp:scanNonAsciiFallbacks', '--no-daemon'], label: 'verify' };
+        case 'smart':
+        default:
+            return { cmd: 'bash', args: ['scripts/smart-build.sh'], label: 'smart' };
+    }
+}
+
+// ── Spawn con captura completa ───────────────────────────────────────
+function runGradle({ cmd, args, cwd, env }) {
+    return new Promise((resolve) => {
+        const started = Date.now();
+        let stdout = '';
+        let stderr = '';
+        const child = spawn(cmd, args, { cwd, env, shell: process.platform === 'win32', windowsHide: true });
+        if (child.stdout) child.stdout.on('data', (d) => { stdout += d.toString(); });
+        if (child.stderr) child.stderr.on('data', (d) => { stderr += d.toString(); });
+        child.on('error', (e) => {
+            stderr += `\n[spawn-error] ${e.message}\n`;
+            resolve({ exit_code: 1, stdout, stderr, wall_ms: Date.now() - started });
+        });
+        child.on('exit', (code) => {
+            resolve({ exit_code: code == null ? 1 : code, stdout, stderr, wall_ms: Date.now() - started });
+        });
+    });
+}
+
+// ── Copia de artefactos QA (best-effort) ─────────────────────────────
+function copyArtifacts(result) {
+    const artifacts = [];
+    try { fs.mkdirSync(QA_ARTIFACTS_DIR, { recursive: true }); } catch {}
+
+    const tryCopy = (src, dst) => {
+        try {
+            if (fs.existsSync(src)) {
+                fs.copyFileSync(src, dst);
+                artifacts.push(path.basename(dst));
+            }
+        } catch (e) {
+            // no rompemos el build por un error de copia
+        }
+    };
+
+    if (result.modules.includes('users')) {
+        tryCopy(path.join(REPO_ROOT, 'users', 'build', 'libs', 'users-all.jar'),
+            path.join(QA_ARTIFACTS_DIR, 'users-all.jar'));
+    }
+
+    if (result.modules.includes('app')) {
+        // Buscar primer APK client debug
+        try {
+            const apkDir = path.join(REPO_ROOT, 'app', 'composeApp', 'build', 'outputs', 'apk', 'client', 'debug');
+            if (fs.existsSync(apkDir)) {
+                const apk = fs.readdirSync(apkDir).find((f) => f.endsWith('.apk'));
+                if (apk) tryCopy(path.join(apkDir, apk), path.join(QA_ARTIFACTS_DIR, 'composeApp-client-debug.apk'));
+            }
+        } catch {}
+    }
+
+    // Metadata (sin necesidad de git — el Pulpo ya valida la rama)
+    try {
+        fs.writeFileSync(path.join(QA_ARTIFACTS_DIR, 'BUILD_TIMESTAMP'),
+            new Date().toISOString().replace(/[:.]/g, '-') + '\n');
+        artifacts.push('BUILD_TIMESTAMP');
+    } catch {}
+
+    return artifacts;
+}
+
+// ── Actualización del marker (YAML trabajando/) ──────────────────────
+function updateMarker(trabajandoPath, payload) {
+    if (!trabajandoPath) return;
+    try {
+        let existing = '';
+        if (fs.existsSync(trabajandoPath)) {
+            existing = fs.readFileSync(trabajandoPath, 'utf8');
+        }
+        // Agregado simple — el pulpo lee con js-yaml; mantenemos formato key: value
+        const lines = existing.split(/\r?\n/).filter(Boolean);
+        const seen = new Set();
+        const kept = [];
+        for (const ln of lines) {
+            const m = ln.match(/^([\w_]+)\s*:/);
+            if (m && (m[1] in payload)) { seen.add(m[1]); continue; }
+            kept.push(ln);
+        }
+        const appended = [];
+        for (const [k, v] of Object.entries(payload)) {
+            const val = typeof v === 'string' ? JSON.stringify(v) : String(v);
+            appended.push(`${k}: ${val}`);
+        }
+        fs.writeFileSync(trabajandoPath, [...kept, ...appended].join('\n') + '\n', 'utf8');
+    } catch (e) {
+        process.stderr.write(`[builder] No se pudo actualizar marker: ${e.message}\n`);
+    }
+}
+
+// ── Main ────────────────────────────────────────────────────────────
+async function main() {
+    const args = parseArgs(process.argv);
+    const issue = args.issue;
+    const scope = args.scope;
+
+    if (!issue) {
+        process.stderr.write('[builder] Falta issue (CLI o env PIPELINE_ISSUE).\n');
+        process.exit(2);
+    }
+
+    // Log header al agent log
+    try { fs.mkdirSync(LOG_DIR, { recursive: true }); } catch {}
+    const agentLog = path.join(LOG_DIR, `${issue}-builder.log`);
+    const logAppend = (msg) => {
+        try { fs.appendFileSync(agentLog, msg + '\n'); } catch {}
+    };
+    logAppend(`--- builder:#${issue} (deterministic) scope=${scope} ${new Date().toISOString()} ---`);
+
+    // Env con JAVA_HOME
+    const env = { ...process.env, JAVA_HOME: JAVA_HOME_DEFAULT };
+    // PATH con JAVA_HOME/bin al frente (para que gradlew encuentre java)
+    env.PATH = `${JAVA_HOME_DEFAULT}/bin${path.delimiter}${env.PATH || ''}`;
+
+    const { cmd, args: gArgs, label } = buildGradleCommand(scope, args.module);
+    logAppend(`[builder] scope=${label} cmd="${cmd} ${gArgs.join(' ')}"`);
+
+    // Heartbeat + session:start
+    const hb = startHeartbeat(issue);
+    const handle = trace.emitSessionStart({
+        skill: 'builder', issue, phase: process.env.PIPELINE_FASE || 'build',
+        model: 'deterministic',
+    });
+
+    let gradleResult;
+    let parsed;
+    let report;
+    let artifacts = [];
+    let exitCode = 0;
+    let motivo = null;
+
+    try {
+        gradleResult = await runGradle({ cmd, args: gArgs, cwd: REPO_ROOT, env });
+        logAppend(`[builder] gradle exit_code=${gradleResult.exit_code} wall_ms=${gradleResult.wall_ms}`);
+        logAppend('[builder] --- stdout (último 2000 chars) ---');
+        logAppend(gradleResult.stdout.slice(-2000));
+        logAppend('[builder] --- stderr (último 1000 chars) ---');
+        logAppend(gradleResult.stderr.slice(-1000));
+
+        parsed = parseGradleOutput(gradleResult.stdout, gradleResult.stderr);
+
+        if (parsed.success) {
+            artifacts = copyArtifacts(parsed);
+            logAppend(`[builder] artefactos copiados: ${artifacts.join(', ') || '(ninguno)'}`);
+            exitCode = 0;
+        } else {
+            exitCode = 1;
+            const first = parsed.errors[0];
+            motivo = first
+                ? `Build FAILED (${first.classification}): ${(first.message || '').split('\n').slice(0, 3).join(' | ').slice(0, 500)}`
+                : 'Build FAILED sin error clasificado';
+        }
+
+        report = renderMarkdownReport(parsed, {
+            issue, scope: label, duration_override_ms: gradleResult.wall_ms,
+        });
+        // Escribir reporte al log + a disco
+        logAppend('[builder] --- REPORTE ---');
+        logAppend(report);
+        const reportPath = path.join(LOG_DIR, `build-${issue}-report.md`);
+        try { fs.writeFileSync(reportPath, report); } catch {}
+    } catch (e) {
+        exitCode = 2;
+        motivo = `Excepción en builder.js: ${e.message}`;
+        logAppend(`[builder] EXCEPTION: ${e.stack || e.message}`);
+    } finally {
+        // Actualizar marker con resultado
+        updateMarker(args.trabajando, {
+            resultado: exitCode === 0 ? 'aprobado' : 'rechazado',
+            motivo: motivo || (exitCode === 0 ? 'Build exitoso' : 'Build fallido'),
+            builder_scope: label,
+            builder_duration_ms: gradleResult ? gradleResult.wall_ms : 0,
+            builder_classification: parsed && parsed.errors[0] ? parsed.errors[0].classification : null,
+            builder_escalate_to: parsed && parsed.errors[0] ? parsed.errors[0].escalate_to : null,
+            builder_mode: 'deterministic',
+        });
+
+        // session:end
+        trace.emitSessionEnd(handle, {
+            tokens_in: 0, tokens_out: 0, cache_read: 0, cache_write: 0,
+            tool_calls: 1, // 1 spawn de gradle
+            exit_code: exitCode,
+            duration_ms: gradleResult ? gradleResult.wall_ms : 0,
+        });
+
+        hb.stop();
+    }
+
+    process.exit(exitCode);
+}
+
+// Ejecutar solo si es invocado como CLI (no cuando es require()eado en tests)
+if (require.main === module) {
+    main().catch((e) => {
+        process.stderr.write(`[builder] fatal: ${e.stack || e.message}\n`);
+        process.exit(2);
+    });
+}
+
+module.exports = {
+    parseArgs,
+    buildGradleCommand,
+    startHeartbeat,
+    copyArtifacts,
+    updateMarker,
+};

--- a/.pipeline/skills-deterministicos/lib/gradle-parser.js
+++ b/.pipeline/skills-deterministicos/lib/gradle-parser.js
@@ -1,0 +1,331 @@
+/**
+ * gradle-parser.js — parser determinístico del output de Gradle
+ *
+ * Convierte el stdout/stderr crudo de gradle en un objeto estructurado
+ * con: resultado (BUILD SUCCESSFUL/FAILED), duración, tareas, verificaciones,
+ * errores clasificados y lista de módulos compilados.
+ *
+ * Uso:
+ *   const { parseGradleOutput, classifyError } = require('./gradle-parser');
+ *   const result = parseGradleOutput(stdout, stderr);
+ *   // result.success, result.duration_ms, result.errors[], result.verifications
+ */
+
+'use strict';
+
+// ── Regex principales ────────────────────────────────────────────────
+const RE_BUILD_SUCCESSFUL = /BUILD SUCCESSFUL in (?:(\d+)m )?(\d+)s/;
+const RE_BUILD_FAILED = /BUILD FAILED in (?:(\d+)m )?(\d+)s/;
+const RE_ACTIONABLE = /(\d+) actionable tasks?:\s*(.+)/;
+const RE_TASK_EXEC = /^> Task (:[\w:-]+)(?:\s+(\w+))?\s*$/;
+const RE_FAILURE_HEADER = /^FAILURE: Build failed with an exception\./;
+const RE_WHAT_WENT_WRONG = /^\* What went wrong:\s*$/;
+const RE_WHERE = /^\* Where:\s*$/;
+const RE_EXECUTION_FAILED = /Execution failed for task '(:[\w:-]+)'\./;
+
+// ── Clasificación de errores conocidos ────────────────────────────────
+const ERROR_PATTERNS = [
+  {
+    type: 'java_home',
+    regex: /(JAVA_HOME|JDK|jbr).*?(not found|does not exist|invalid|JDK_NOT_FOUND|no such file)/i,
+    fix: 'Usar Temurin 21.0.7 — export JAVA_HOME="/c/Users/Administrator/.jdks/temurin-21.0.7"',
+    escalate_to: null,
+    severity: 'infra',
+  },
+  {
+    type: 'forbidden_strings',
+    regex: /forbidden-strings|stringResource\s*\(|Res\.string\.|R\.string\./,
+    fix: 'Usar helper resString() con androidStringId/composeId/fallback ASCII — ver docs/engineering/strings.md',
+    escalate_to: 'android-dev',
+    severity: 'code',
+  },
+  {
+    type: 'kotlin_version_mismatch',
+    regex: /kotlin version|different\s+kotlin|incompatible\s+kotlin|metadata\s+version/i,
+    fix: 'Verificar gradle.properties y buildSrc — Kotlin 2.2.21 en toda la cadena',
+    escalate_to: 'android-dev',
+    severity: 'code',
+  },
+  {
+    type: 'compose_resources',
+    regex: /validateComposeResources|compose.*?resource.*?(missing|invalid|not found)/i,
+    fix: 'Ejecutar :app:composeApp:validateComposeResources para ver resource pack roto',
+    escalate_to: 'android-dev',
+    severity: 'code',
+  },
+  {
+    type: 'ascii_fallback',
+    regex: /scanNonAsciiFallbacks|non-ascii|fallback.*?ascii/i,
+    fix: 'Reemplazar caracteres no-ASCII en fallbacks usando fb() helper',
+    escalate_to: 'android-dev',
+    severity: 'code',
+  },
+  {
+    type: 'unresolved_reference',
+    regex: /error:.*?unresolved reference:\s+(\w+)/i,
+    fix: 'Verificar import o existencia del símbolo',
+    escalate_to: null, // determinado por módulo
+    severity: 'code',
+  },
+  {
+    type: 'type_mismatch',
+    regex: /error:.*?type mismatch/i,
+    fix: 'Corregir incompatibilidad de tipos Kotlin',
+    escalate_to: null,
+    severity: 'code',
+  },
+  {
+    type: 'oom',
+    regex: /OutOfMemoryError|java\.lang\.OutOfMemoryError|Metaspace|GC overhead limit/i,
+    fix: 'Aumentar heap o correr con --no-daemon (Gradle daemon consume hasta 4GB)',
+    escalate_to: null,
+    severity: 'infra',
+  },
+  {
+    type: 'test_failed',
+    regex: /There were failing tests\.|Task.*?:test.*?FAILED|tests failed/i,
+    fix: 'Revisar reporte de tests en build/reports/tests/',
+    escalate_to: 'tester',
+    severity: 'test',
+  },
+];
+
+/**
+ * Clasifica un texto de error según los patrones conocidos.
+ * Devuelve el primer match o un objeto 'unknown' si no matchea ninguno.
+ */
+function classifyError(text, taskPath = null) {
+  if (!text || typeof text !== 'string') {
+    return { type: 'unknown', fix: null, escalate_to: null, severity: 'unknown' };
+  }
+
+  for (const pattern of ERROR_PATTERNS) {
+    if (pattern.regex.test(text)) {
+      // Escalación según módulo si la categoría es code y no tiene target fijo
+      let escalate_to = pattern.escalate_to;
+      if (!escalate_to && pattern.severity === 'code' && taskPath) {
+        if (/^:(backend|users)/.test(taskPath)) escalate_to = 'backend-dev';
+        else if (/^:app/.test(taskPath)) escalate_to = 'android-dev';
+      }
+      return {
+        type: pattern.type,
+        fix: pattern.fix,
+        escalate_to,
+        severity: pattern.severity,
+      };
+    }
+  }
+
+  return {
+    type: 'unknown',
+    fix: 'Error no clasificado — revisar output crudo y escalar a dev skill del área',
+    escalate_to: taskPath && /^:(backend|users)/.test(taskPath) ? 'backend-dev' : 'android-dev',
+    severity: 'unknown',
+  };
+}
+
+/**
+ * Extrae duración en milisegundos de un match "BUILD ... in Xm Ys" o "Xs".
+ */
+function durationMs(minutesCapture, secondsCapture) {
+  const m = parseInt(minutesCapture || '0', 10);
+  const s = parseInt(secondsCapture || '0', 10);
+  return (m * 60 + s) * 1000;
+}
+
+/**
+ * Extrae el bloque "What went wrong" con su cuerpo hasta la próxima sección `*`.
+ */
+function extractWhatWentWrong(lines, startIdx) {
+  const body = [];
+  let i = startIdx + 1;
+  while (i < lines.length) {
+    const line = lines[i];
+    if (/^\* /.test(line) || /^BUILD (SUCCESSFUL|FAILED)/.test(line)) break;
+    body.push(line);
+    i += 1;
+  }
+  return body.join('\n').trim();
+}
+
+/**
+ * Parser principal — consume output completo y devuelve objeto estructurado.
+ *
+ * @param {string} stdout
+ * @param {string} stderr
+ * @returns {object} { success, build_status, duration_ms, modules, tasks,
+ *                     verifications, errors, raw_length }
+ */
+function parseGradleOutput(stdout = '', stderr = '') {
+  const combined = `${stdout}\n${stderr}`;
+  const lines = combined.split(/\r?\n/);
+
+  const result = {
+    success: false,
+    build_status: 'UNKNOWN', // SUCCESSFUL | FAILED | UNKNOWN
+    duration_ms: 0,
+    modules: [],
+    tasks: { total: 0, executed: 0, up_to_date: 0, from_cache: 0 },
+    verifications: {
+      verifyNoLegacyStrings: null,      // null = no corrió, true = OK, false = FAILED
+      validateComposeResources: null,
+      scanNonAsciiFallbacks: null,
+    },
+    errors: [],
+    raw_length: combined.length,
+  };
+
+  const executedTasks = new Set();
+  const failedTasks = new Set();
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+
+    // BUILD SUCCESSFUL in Xm Ys
+    const successMatch = line.match(RE_BUILD_SUCCESSFUL);
+    if (successMatch) {
+      result.success = true;
+      result.build_status = 'SUCCESSFUL';
+      result.duration_ms = durationMs(successMatch[1], successMatch[2]);
+      continue;
+    }
+
+    // BUILD FAILED in Xm Ys
+    const failedMatch = line.match(RE_BUILD_FAILED);
+    if (failedMatch) {
+      result.success = false;
+      result.build_status = 'FAILED';
+      result.duration_ms = durationMs(failedMatch[1], failedMatch[2]);
+      continue;
+    }
+
+    // N actionable tasks: X executed, Y up-to-date, Z from cache
+    const actionableMatch = line.match(RE_ACTIONABLE);
+    if (actionableMatch) {
+      result.tasks.total = parseInt(actionableMatch[1], 10);
+      const details = actionableMatch[2];
+      const execMatch = details.match(/(\d+)\s+executed/);
+      const upToDateMatch = details.match(/(\d+)\s+up-to-date/);
+      const cacheMatch = details.match(/(\d+)\s+from cache/);
+      if (execMatch) result.tasks.executed = parseInt(execMatch[1], 10);
+      if (upToDateMatch) result.tasks.up_to_date = parseInt(upToDateMatch[1], 10);
+      if (cacheMatch) result.tasks.from_cache = parseInt(cacheMatch[1], 10);
+      continue;
+    }
+
+    // > Task :module:taskName [STATUS]
+    const taskMatch = line.match(RE_TASK_EXEC);
+    if (taskMatch) {
+      const taskPath = taskMatch[1];
+      const status = taskMatch[2];
+      executedTasks.add(taskPath);
+      if (status === 'FAILED') {
+        failedTasks.add(taskPath);
+      }
+      // Extraer módulo raíz
+      const moduleMatch = taskPath.match(/^:([\w-]+)(?::|$)/);
+      if (moduleMatch && !result.modules.includes(moduleMatch[1])) {
+        result.modules.push(moduleMatch[1]);
+      }
+      // Detectar verificaciones conocidas
+      if (/verifyNoLegacyStrings$/.test(taskPath)) {
+        result.verifications.verifyNoLegacyStrings = status !== 'FAILED';
+      } else if (/validateComposeResources$/.test(taskPath)) {
+        result.verifications.validateComposeResources = status !== 'FAILED';
+      } else if (/scanNonAsciiFallbacks$/.test(taskPath)) {
+        result.verifications.scanNonAsciiFallbacks = status !== 'FAILED';
+      }
+      continue;
+    }
+
+    // * What went wrong:
+    if (RE_WHAT_WENT_WRONG.test(line)) {
+      const body = extractWhatWentWrong(lines, i);
+      const taskPathMatch = body.match(RE_EXECUTION_FAILED);
+      const taskPath = taskPathMatch ? taskPathMatch[1] : null;
+      const classification = classifyError(body, taskPath);
+      result.errors.push({
+        task: taskPath,
+        message: body,
+        classification: classification.type,
+        fix: classification.fix,
+        escalate_to: classification.escalate_to,
+        severity: classification.severity,
+      });
+      continue;
+    }
+  }
+
+  // Si hubo BUILD FAILED pero no encontramos bloque "What went wrong", agregar uno genérico
+  if (result.build_status === 'FAILED' && result.errors.length === 0) {
+    result.errors.push({
+      task: Array.from(failedTasks)[0] || null,
+      message: 'Build failed — no se encontró bloque "What went wrong" en el output',
+      classification: 'unknown',
+      fix: 'Revisar output crudo',
+      escalate_to: null,
+      severity: 'unknown',
+    });
+  }
+
+  return result;
+}
+
+/**
+ * Genera un reporte markdown con el mismo formato que el skill LLM.
+ */
+function renderMarkdownReport(result, meta = {}) {
+  const { issue = null, scope = 'default', duration_override_ms = null } = meta;
+  const verdict = result.success ? 'EXITOSO ✅' : 'FALLIDO ❌';
+  const durMs = duration_override_ms != null ? duration_override_ms : result.duration_ms;
+  const mins = Math.floor(durMs / 60000);
+  const secs = Math.floor((durMs % 60000) / 1000);
+  const durStr = mins > 0 ? `${mins}m ${secs}s` : `${secs}s`;
+
+  const fmtVerif = (v) => {
+    if (v === null) return '⏭️';
+    return v ? '✅' : '❌';
+  };
+
+  const lines = [];
+  lines.push(`## Build: ${verdict}`);
+  lines.push('');
+  lines.push('### Compilacion');
+  lines.push(`- Modulo(s): ${result.modules.join(', ') || 'n/a'}`);
+  lines.push(`- Resultado: ${result.success ? 'OK' : 'FALLO'}`);
+  lines.push(`- Tiempo: ${durStr}`);
+  lines.push(`- Scope: ${scope}${issue ? ` · issue #${issue}` : ''}`);
+  lines.push(`- Tareas: ${result.tasks.executed} ejecutadas · ${result.tasks.up_to_date} up-to-date · ${result.tasks.from_cache} desde caché`);
+  lines.push('');
+  lines.push('### Verificaciones');
+  lines.push(`- Strings legacy: ${fmtVerif(result.verifications.verifyNoLegacyStrings)}`);
+  lines.push(`- Recursos Compose: ${fmtVerif(result.verifications.validateComposeResources)}`);
+  lines.push(`- ASCII fallbacks: ${fmtVerif(result.verifications.scanNonAsciiFallbacks)}`);
+  lines.push('');
+
+  if (result.errors.length > 0) {
+    lines.push('### Errores');
+    for (const err of result.errors) {
+      lines.push(`- **[${err.classification}]** ${err.task || '(sin task)'}`);
+      if (err.fix) lines.push(`  - Fix sugerido: ${err.fix}`);
+      if (err.escalate_to) lines.push(`  - Escalar a: \`${err.escalate_to}\``);
+      const msgSnippet = (err.message || '').split('\n').slice(0, 5).join('\n  ');
+      if (msgSnippet) lines.push(`  - Detalle:\n  \`\`\`\n  ${msgSnippet}\n  \`\`\``);
+    }
+    lines.push('');
+  }
+
+  lines.push('### Veredicto del Builder');
+  lines.push(result.success
+    ? 'Build exitoso — artefactos listos para la siguiente fase.'
+    : 'Hay errores que corregir antes de continuar. Rebote al dev skill correspondiente.');
+
+  return lines.join('\n');
+}
+
+module.exports = {
+  parseGradleOutput,
+  classifyError,
+  renderMarkdownReport,
+  ERROR_PATTERNS,
+};


### PR DESCRIPTION
## Summary

Primer skill **determinístico V3**: `/builder` corre 100% en Node sin gastar tokens del LLM.

- `skills-deterministicos/builder.js` — setup JAVA_HOME → Gradle → parser → reporte → artefactos QA
- `skills-deterministicos/lib/gradle-parser.js` — clasifica errores y decide escalación (android-dev / backend-dev / infra)
- `pulpo.js` — `lanzarAgenteClaude` intercepta `skill === 'builder'` y bypass al LLM si existe el archivo
- **Reversible:** borrar `skills-deterministicos/builder.js` reactiva el agente LLM histórico

## Trazabilidad V3 desde el primer commit

Eventos `session:start` / `session:end` vía `lib/traceability.js` (#2477) con `tokens=0` explícito para que el dashboard muestre el ahorro.

## Tests

- 25/25 ✓ (`node --test`)
  - 8 tests de `builder.test.js` (parseArgs, scopes, heartbeat, marker, copyArtifacts)
  - 17 tests de `gradle-parser.test.js` (parser, classifier, ERROR_PATTERNS, render)
- Sintaxis verificada en `builder.js`, `gradle-parser.js`, `pulpo.js`

## Test plan

- [x] `node --test` → 25/25 verdes
- [x] `node -c` → sintaxis OK en los 3 archivos modificados
- [x] Smoke: `pulpo.js` inicializa con builder determinístico habilitado
- [ ] Validación en vivo: próximo build de issue real con `skill=builder` debe loguear `⚡ builder:#<issue> ejecutado en modo determinístico`

## Closes

Closes #2476

## Notas para el reviewer

- **Fallback automático:** si el archivo `skills-deterministicos/builder.js` no existe, `useDeterministicBuilder = false` y se ejecuta el agente Claude histórico. Rollout y rollback son simétricos.
- **Contrato preservado:** marker, heartbeat cada 30s, exit code 0/1 idénticos al skill LLM. El watchdog y on-exit del Pulpo no requieren cambios.
- **`PIPELINE_PIPELINE` y `PIPELINE_TRABAJANDO`** ahora se pasan al env de **todos** los agentes (LLM y determinísticos), preparando el terreno para futuras migraciones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)