### PR TITLE
feat(pipeline): kill dinámico de agentes — elimina dependencia de agent-registry.json (#2486)

### DIFF
--- a/.pipeline/dashboard-v2.js
+++ b/.pipeline/dashboard-v2.js
@@ -6003,19 +6003,25 @@ const server = http.createServer((req, res) => {
           return;
         }
 
-        // Buscar PID del agente en agent-registry
+        // #2486 — descubrimiento dinámico del PID vía pid-discovery.
+        // Reemplaza la lectura de agent-registry.json (fuente duplicada con race conditions
+        // y PIDs stale). pid-discovery cruza scan de procesos vivos por cmdline +
+        // heartbeat reciente, con verificación cruzada antes de matar.
         let killed = false;
+        let pidsKilled = [];
         try {
-          const registry = JSON.parse(fs.readFileSync(path.join(path.dirname(PIPELINE), '.claude', 'hooks', 'agent-registry.json'), 'utf8'));
-          for (const [, agent] of Object.entries(registry.agents || {})) {
-            if (agent.issue === `#${issue}` && agent.pid) {
-              try {
-                execSync(`taskkill /PID ${agent.pid} /F /T`, { timeout: 5000, windowsHide: true, stdio: 'ignore' });
-                killed = true;
-              } catch {}
-            }
+          const { discoverAgentPids } = require('./skills-deterministicos/lib/pid-discovery');
+          const matches = discoverAgentPids({ issue, skill });
+          for (const match of matches) {
+            try {
+              execSync(`taskkill /PID ${match.pid} /F /T`, { timeout: 5000, windowsHide: true, stdio: 'ignore' });
+              killed = true;
+              pidsKilled.push(`${match.pid}(${match.source})`);
+            } catch {}
           }
-        } catch {}
+        } catch (e) {
+          log(`pid-discovery error: ${e.message}`);
+        }
 
         // Mover de trabajando/ a pendiente/ (para que pueda ser relanzado)
         try {
@@ -6028,9 +6034,9 @@ const server = http.createServer((req, res) => {
         }
 
         const msg = killed
-          ? `Agente ${skill} #${issue} cancelado (proceso terminado + devuelto a pendiente)`
-          : `Agente ${skill} #${issue} devuelto a pendiente (proceso no encontrado en registry)`;
-        log(`Kill agent: ${skill} #${issue} en ${pl}/${fase} — ${killed ? 'PID killed' : 'no PID'}`);
+          ? `Agente ${skill} #${issue} cancelado (PIDs ${pidsKilled.join(', ')} + devuelto a pendiente)`
+          : `Agente ${skill} #${issue} devuelto a pendiente (proceso no encontrado — ya terminó o nunca arrancó)`;
+        log(`Kill agent: ${skill} #${issue} en ${pl}/${fase} — ${killed ? `killed ${pidsKilled.join(',')}` : 'no PID'}`);
         res.writeHead(200, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({ ok: true, msg }));
       } catch (e) {

--- a/.pipeline/skills-deterministicos/__tests__/pid-discovery.test.js
+++ b/.pipeline/skills-deterministicos/__tests__/pid-discovery.test.js
@@ -1,0 +1,279 @@
+// Tests unitarios de .pipeline/skills-deterministicos/lib/pid-discovery.js (issue #2486)
+// Reemplaza el uso de agent-registry.json por descubrimiento dinámico.
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const pd = require('../lib/pid-discovery');
+
+// Fixture: salida típica de `Get-CimInstance Win32_Process | Select ProcessId,Name,CommandLine | ConvertTo-Csv`.
+const CSV_FIXTURE = [
+    '"ProcessId","Name","CommandLine"',
+    '"3612","node.exe","""C:\\Program Files\\nodejs\\node.exe"" C:\\Workspaces\\Intrale\\platform\\.pipeline\\listener-telegram.js"',
+    '"18152","node.exe","""C:\\Program Files\\nodejs\\node.exe"" C:\\Workspaces\\Intrale\\platform\\.pipeline\\pulpo.js"',
+    '"24680","node.exe","""C:\\Program Files\\nodejs\\node.exe"" C:\\Workspaces\\Intrale\\platform\\.pipeline\\skills-deterministicos\\builder.js 2486 --trabajando=C:\\foo"',
+    '"24681","node.exe","""C:\\Program Files\\nodejs\\node.exe"" C:\\Workspaces\\Intrale\\platform\\.pipeline\\skills-deterministicos\\tester.js 2488 --trabajando=C:\\bar"',
+    '"14120","claude.exe","C:\\Users\\Administrator\\AppData\\Roaming\\npm\\node_modules\\@anthropic-ai\\claude-code\\bin\\claude.exe -p --output-format stream-json --verbose"',
+    '',
+].join('\n');
+
+function mkRunner(csv = CSV_FIXTURE) {
+    return () => csv;
+}
+
+// ─── parseProcessCsv ────────────────────────────────────────────────────────
+
+test('parseProcessCsv — parsea CSV con cmdline con comillas dobles escapadas', () => {
+    const rows = pd.parseProcessCsv(CSV_FIXTURE);
+    assert.equal(rows.length, 5);
+    const builder = rows.find(r => r.pid === 24680);
+    assert.ok(builder);
+    assert.equal(builder.name, 'node.exe');
+    assert.match(builder.cmdline, /skills-deterministicos\\builder\.js 2486/);
+    const claude = rows.find(r => r.pid === 14120);
+    assert.ok(claude);
+    assert.equal(claude.name, 'claude.exe');
+});
+
+test('parseProcessCsv — CSV vacío → []', () => {
+    assert.deepEqual(pd.parseProcessCsv(''), []);
+    assert.deepEqual(pd.parseProcessCsv(null), []);
+    assert.deepEqual(pd.parseProcessCsv(undefined), []);
+});
+
+test('parseProcessCsv — solo cabecera → []', () => {
+    assert.deepEqual(pd.parseProcessCsv('"ProcessId","Name","CommandLine"'), []);
+});
+
+// ─── splitCsvLine ───────────────────────────────────────────────────────────
+
+test('splitCsvLine — campos con comillas dobles escapadas', () => {
+    const line = '"1","node.exe","""node"" foo.js"';
+    const parts = pd.splitCsvLine(line);
+    assert.deepEqual(parts, ['1', 'node.exe', '"node" foo.js']);
+});
+
+test('splitCsvLine — comas dentro de campo entrecomillado', () => {
+    const line = '"1","node.exe","a, b, c"';
+    const parts = pd.splitCsvLine(line);
+    assert.deepEqual(parts, ['1', 'node.exe', 'a, b, c']);
+});
+
+// ─── matchesDeterministicAgent ──────────────────────────────────────────────
+
+test('matchesDeterministicAgent — builder #2486 → true', () => {
+    const cmd = 'C:\\node.exe .pipeline\\skills-deterministicos\\builder.js 2486 --trabajando=C:\\foo';
+    assert.equal(pd.matchesDeterministicAgent(cmd, 2486, 'builder'), true);
+});
+
+test('matchesDeterministicAgent — skill distinto → false', () => {
+    const cmd = 'node .pipeline\\skills-deterministicos\\tester.js 2486 --trabajando=C:\\foo';
+    assert.equal(pd.matchesDeterministicAgent(cmd, 2486, 'builder'), false);
+});
+
+test('matchesDeterministicAgent — issue distinto → false', () => {
+    const cmd = 'node .pipeline\\skills-deterministicos\\builder.js 9999 --trabajando=C:\\foo';
+    assert.equal(pd.matchesDeterministicAgent(cmd, 2486, 'builder'), false);
+});
+
+test('matchesDeterministicAgent — substring de issue (24860 vs 2486) → false', () => {
+    const cmd = 'node .pipeline\\skills-deterministicos\\builder.js 24860 --trabajando=C:\\foo';
+    assert.equal(pd.matchesDeterministicAgent(cmd, 2486, 'builder'), false);
+});
+
+test('matchesDeterministicAgent — pulpo.js (no es skill) → false', () => {
+    const cmd = 'node .pipeline\\pulpo.js';
+    assert.equal(pd.matchesDeterministicAgent(cmd, 2486, 'builder'), false);
+});
+
+// ─── discoverAgentPids — determinístico (scan por cmdline) ──────────────────
+
+test('discoverAgentPids — builder #2486 detectado por cmdline', () => {
+    const pids = pd.discoverAgentPids({
+        issue: 2486,
+        skill: 'builder',
+        listRunner: mkRunner(),
+        heartbeatDir: fs.mkdtempSync(path.join(os.tmpdir(), 'pd-')),
+    });
+    assert.equal(pids.length, 1);
+    assert.equal(pids[0].pid, 24680);
+    assert.equal(pids[0].source, 'process-scan');
+});
+
+test('discoverAgentPids — tester #2488 detectado por cmdline', () => {
+    const pids = pd.discoverAgentPids({
+        issue: 2488,
+        skill: 'tester',
+        listRunner: mkRunner(),
+        heartbeatDir: fs.mkdtempSync(path.join(os.tmpdir(), 'pd-')),
+    });
+    assert.equal(pids.length, 1);
+    assert.equal(pids[0].pid, 24681);
+});
+
+test('discoverAgentPids — issue inexistente → []', () => {
+    const pids = pd.discoverAgentPids({
+        issue: 9999,
+        skill: 'builder',
+        listRunner: mkRunner(),
+        heartbeatDir: fs.mkdtempSync(path.join(os.tmpdir(), 'pd-')),
+    });
+    assert.equal(pids.length, 0);
+});
+
+test('discoverAgentPids — sin skill y sin heartbeat → []', () => {
+    // Sin skill no se puede scanear por cmdline; sin heartbeat tampoco hay fallback.
+    const pids = pd.discoverAgentPids({
+        issue: 2486,
+        listRunner: mkRunner(),
+        heartbeatDir: fs.mkdtempSync(path.join(os.tmpdir(), 'pd-')),
+    });
+    assert.equal(pids.length, 0);
+});
+
+// ─── discoverAgentPids — LLM por heartbeat ──────────────────────────────────
+
+test('discoverAgentPids — LLM (claude.exe) detectado por heartbeat fresco', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-'));
+    const hbFile = path.join(dir, 'agent-2500.heartbeat');
+    fs.writeFileSync(hbFile, JSON.stringify({
+        issue: 2500,
+        session: 'abc123',
+        ts: new Date().toISOString(),
+        branch: 'agent/2500-algo',
+        pid: 14120,
+    }));
+
+    const pids = pd.discoverAgentPids({
+        issue: 2500,
+        skill: 'po', // skill LLM cualquiera
+        listRunner: mkRunner(),
+        heartbeatDir: dir,
+    });
+    assert.equal(pids.length, 1);
+    assert.equal(pids[0].pid, 14120);
+    assert.equal(pids[0].source, 'heartbeat');
+    assert.equal(pids[0].name, 'claude.exe');
+});
+
+test('discoverAgentPids — heartbeat stale (> 5 min) → ignorado', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-'));
+    const hbFile = path.join(dir, 'agent-2500.heartbeat');
+    fs.writeFileSync(hbFile, JSON.stringify({ issue: 2500, pid: 14120 }));
+    // Retro-envejecemos el mtime 10 minutos
+    const old = Date.now() / 1000 - 10 * 60;
+    fs.utimesSync(hbFile, old, old);
+
+    const pids = pd.discoverAgentPids({
+        issue: 2500,
+        skill: 'po',
+        listRunner: mkRunner(),
+        heartbeatDir: dir,
+    });
+    assert.equal(pids.length, 0);
+});
+
+test('discoverAgentPids — heartbeat apunta a PID muerto → ignorado', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-'));
+    const hbFile = path.join(dir, 'agent-2500.heartbeat');
+    fs.writeFileSync(hbFile, JSON.stringify({
+        issue: 2500,
+        ts: new Date().toISOString(),
+        pid: 777777, // PID que no está en el fixture
+    }));
+
+    const pids = pd.discoverAgentPids({
+        issue: 2500,
+        skill: 'po',
+        listRunner: mkRunner(),
+        heartbeatDir: dir,
+    });
+    assert.equal(pids.length, 0);
+});
+
+test('discoverAgentPids — heartbeat apunta a PID de proceso ajeno (no node/claude) → ignorado', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-'));
+    const hbFile = path.join(dir, 'agent-2500.heartbeat');
+    fs.writeFileSync(hbFile, JSON.stringify({
+        issue: 2500,
+        ts: new Date().toISOString(),
+        pid: 24680, // PID real del fixture, pero es node.exe → válido
+    }));
+
+    // El PID 24680 es node.exe en el fixture → sí es aceptado (defensa en profundidad:
+    // heartbeat + cmdline consistente con un agente de pipeline).
+    const pids = pd.discoverAgentPids({
+        issue: 2500,
+        skill: 'po',
+        listRunner: mkRunner(),
+        heartbeatDir: dir,
+    });
+    assert.equal(pids.length, 1);
+    assert.equal(pids[0].pid, 24680);
+    assert.equal(pids[0].source, 'heartbeat');
+});
+
+// ─── discoverAgentPids — combinación ────────────────────────────────────────
+
+test('discoverAgentPids — scan + heartbeat coinciden → un solo entry (de-dup)', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-'));
+    const hbFile = path.join(dir, 'agent-2486.heartbeat');
+    fs.writeFileSync(hbFile, JSON.stringify({
+        issue: 2486,
+        ts: new Date().toISOString(),
+        pid: 24680,
+    }));
+
+    const pids = pd.discoverAgentPids({
+        issue: 2486,
+        skill: 'builder',
+        listRunner: mkRunner(),
+        heartbeatDir: dir,
+    });
+    assert.equal(pids.length, 1);
+    assert.equal(pids[0].pid, 24680);
+    // La fuente primaria es el scan (se procesa antes que el heartbeat).
+    assert.equal(pids[0].source, 'process-scan');
+});
+
+test('discoverAgentPids — issue sin argumento → []', () => {
+    assert.deepEqual(pd.discoverAgentPids({ listRunner: mkRunner() }), []);
+    assert.deepEqual(pd.discoverAgentPids({}), []);
+});
+
+test('discoverAgentPids — listRunner que tira → [] (no propaga error)', () => {
+    const pids = pd.discoverAgentPids({
+        issue: 2486,
+        skill: 'builder',
+        listRunner: () => { throw new Error('powershell missing'); },
+        heartbeatDir: fs.mkdtempSync(path.join(os.tmpdir(), 'pd-')),
+    });
+    assert.equal(pids.length, 0);
+});
+
+// ─── readHeartbeat ──────────────────────────────────────────────────────────
+
+test('readHeartbeat — archivo válido → objeto parseado + mtimeMs', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-'));
+    const hbFile = path.join(dir, 'agent-7.heartbeat');
+    fs.writeFileSync(hbFile, JSON.stringify({ issue: 7, pid: 1 }));
+    const hb = pd.readHeartbeat(7, { heartbeatDir: dir });
+    assert.equal(hb.issue, 7);
+    assert.equal(hb.pid, 1);
+    assert.ok(typeof hb.mtimeMs === 'number');
+});
+
+test('readHeartbeat — archivo inexistente → null', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-'));
+    assert.equal(pd.readHeartbeat(999, { heartbeatDir: dir }), null);
+});
+
+test('readHeartbeat — JSON inválido → null', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-'));
+    fs.writeFileSync(path.join(dir, 'agent-5.heartbeat'), 'no es json');
+    assert.equal(pd.readHeartbeat(5, { heartbeatDir: dir }), null);
+});

--- a/.pipeline/skills-deterministicos/lib/pid-discovery.js
+++ b/.pipeline/skills-deterministicos/lib/pid-discovery.js
@@ -1,0 +1,231 @@
+'use strict';
+
+// pid-discovery.js — descubrimiento dinámico del PID de un agente en vuelo.
+//
+// Reemplaza la lectura de `.claude/hooks/agent-registry.json` cuando necesitamos
+// matar un agente desde el dashboard. El registry sufría race conditions
+// (stale PIDs reutilizados por el OS, falta de sincronización entre spawn y
+// session:start) y era una fuente de verdad duplicada.
+//
+// Estrategia de descubrimiento:
+//
+//   1) Scan de procesos vivos (PowerShell Get-CimInstance Win32_Process)
+//      filtrando por CommandLine — funciona para agentes determinísticos
+//      (node.exe con skills-deterministicos/<skill>.js y el issue en argv).
+//
+//   2) Heartbeat file (.claude/hooks/agent-<issue>.heartbeat) como fuente
+//      secundaria — aporta el PID de agentes LLM (claude.exe) porque el
+//      CommandLine de claude no contiene el número de issue (viene por env
+//      o por el prompt `-p`). Se valida que el PID esté vivo Y que su
+//      proceso sea claude.exe / node.exe antes de confiar en él.
+//
+// Todos los PIDs retornados están verificados (proceso vivo + cmdline
+// consistente con un agente). Eso previene matar procesos ajenos por
+// PID reuse.
+
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const PROJECT_ROOT = path.resolve(__dirname, '..', '..', '..');
+const HEARTBEAT_DIR = path.join(PROJECT_ROOT, '.claude', 'hooks');
+const HEARTBEAT_MAX_AGE_MS = 5 * 60 * 1000; // 5 min — heartbeat anterior se considera stale
+
+/**
+ * Lista procesos node.exe / claude.exe con su CommandLine.
+ * Retorna [{ pid: number, name: string, cmdline: string }, ...].
+ *
+ * En entornos sin PowerShell (tests), el caller puede inyectar `runner` para
+ * stubear la salida.
+ */
+function listProcesses({ runner } = {}) {
+  const defaultRunner = () => {
+    // PowerShell Get-CimInstance devuelve CSV con ProcessId + CommandLine.
+    // Filtramos por nombre para reducir el volumen de datos parseados.
+    const script = [
+      "Get-CimInstance Win32_Process -Filter \"Name='node.exe' OR Name='claude.exe'\"",
+      '| Select-Object ProcessId,Name,CommandLine',
+      '| ConvertTo-Csv -NoTypeInformation',
+    ].join(' ');
+    return execFileSync('powershell', ['-NoProfile', '-Command', script], {
+      encoding: 'utf8',
+      windowsHide: true,
+      timeout: 10_000,
+    });
+  };
+  const exec = runner || defaultRunner;
+  let csv;
+  try {
+    csv = exec();
+  } catch {
+    return [];
+  }
+  return parseProcessCsv(csv);
+}
+
+/**
+ * Parsea la salida CSV de `Get-CimInstance | ConvertTo-Csv`.
+ *
+ * Cada fila: "PID","Name","CommandLine" (con comillas dobles escapadas
+ * duplicándose: `""` → `"`). Se ignora la cabecera.
+ */
+function parseProcessCsv(csv) {
+  if (!csv || typeof csv !== 'string') return [];
+  const lines = csv.split(/\r?\n/).filter(l => l.trim() !== '');
+  if (lines.length <= 1) return [];
+  const rows = [];
+  for (let i = 1; i < lines.length; i++) {
+    const fields = splitCsvLine(lines[i]);
+    if (fields.length < 2) continue;
+    const pid = parseInt(fields[0], 10);
+    if (!Number.isFinite(pid)) continue;
+    const name = (fields[1] || '').toLowerCase();
+    const cmdline = fields[2] || '';
+    rows.push({ pid, name, cmdline });
+  }
+  return rows;
+}
+
+/**
+ * Split de una línea CSV con comillas dobles escapadas (`""` dentro del campo).
+ */
+function splitCsvLine(line) {
+  const out = [];
+  let i = 0;
+  const n = line.length;
+  while (i < n) {
+    if (line[i] === '"') {
+      // Campo con comillas
+      let buf = '';
+      i++;
+      while (i < n) {
+        if (line[i] === '"') {
+          if (line[i + 1] === '"') {
+            buf += '"';
+            i += 2;
+          } else {
+            i++;
+            break;
+          }
+        } else {
+          buf += line[i];
+          i++;
+        }
+      }
+      out.push(buf);
+      if (line[i] === ',') i++;
+    } else {
+      // Campo sin comillas — leer hasta la próxima coma
+      let buf = '';
+      while (i < n && line[i] !== ',') {
+        buf += line[i];
+        i++;
+      }
+      out.push(buf);
+      if (line[i] === ',') i++;
+    }
+  }
+  return out;
+}
+
+/**
+ * Valida si una línea de comando corresponde a un agente determinístico
+ * para (issue, skill). Match por presencia del archivo del skill Y del issue
+ * como token independiente.
+ */
+function matchesDeterministicAgent(cmdline, issue, skill) {
+  if (!cmdline) return false;
+  const lower = cmdline.toLowerCase();
+  // El script se invoca como `node <path>\skills-deterministicos\<skill>.js`
+  const skillMarker = `skills-deterministicos`;
+  const skillFile = `${String(skill).toLowerCase()}.js`;
+  if (!lower.includes(skillMarker)) return false;
+  if (!lower.includes(skillFile)) return false;
+  // El issue viene como primer argumento posicional: `... <skill>.js 2486 --trabajando=...`.
+  // Usamos una regex con word boundary para evitar falsos positivos (eg. 24860).
+  const issueRe = new RegExp(`\\b${String(issue)}\\b`);
+  return issueRe.test(cmdline);
+}
+
+/**
+ * Lee el heartbeat de un issue. Retorna el objeto parseado o null si no existe
+ * o está malformado.
+ */
+function readHeartbeat(issue, { heartbeatDir = HEARTBEAT_DIR } = {}) {
+  const file = path.join(heartbeatDir, `agent-${issue}.heartbeat`);
+  try {
+    const raw = fs.readFileSync(file, 'utf8');
+    const json = JSON.parse(raw);
+    const stat = fs.statSync(file);
+    return { ...json, file, mtimeMs: stat.mtimeMs };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Descubre los PIDs verificados de un agente en vuelo para (issue [, skill]).
+ *
+ * Retorna un array de candidatos: [{ pid, source, name, cmdline }].
+ *
+ *   - source: 'process-scan' (match por cmdline) o 'heartbeat' (PID leído del
+ *     heartbeat y confirmado vivo con cmdline node.exe / claude.exe).
+ *
+ * Parámetros opcionales para inyección en tests:
+ *   - listRunner: función que devuelve el CSV de Get-CimInstance.
+ *   - heartbeatDir: carpeta alternativa para el heartbeat.
+ *   - now: epoch ms (para test de frescura del heartbeat).
+ */
+function discoverAgentPids({ issue, skill, listRunner, heartbeatDir, now } = {}) {
+  if (!issue) return [];
+  const nowMs = typeof now === 'number' ? now : Date.now();
+  const processes = listProcesses({ runner: listRunner });
+  const byPid = new Map();
+
+  // 1) Scan por cmdline — determinísticos (si se pasó skill).
+  if (skill) {
+    for (const proc of processes) {
+      if (proc.name !== 'node.exe') continue;
+      if (matchesDeterministicAgent(proc.cmdline, issue, skill)) {
+        byPid.set(proc.pid, {
+          pid: proc.pid,
+          source: 'process-scan',
+          name: proc.name,
+          cmdline: proc.cmdline,
+        });
+      }
+    }
+  }
+
+  // 2) Heartbeat — aporta PID de agentes LLM (claude.exe) que no son scanneables
+  // por cmdline. Validación:
+  //   a) Archivo fresco (< 5 min). Un heartbeat viejo indica agente muerto.
+  //   b) El PID declarado aparece en el scan vivo.
+  //   c) El proceso es claude.exe o node.exe (evita matar otro proceso con PID reusado).
+  const hb = readHeartbeat(issue, { heartbeatDir });
+  if (hb && hb.pid && (nowMs - hb.mtimeMs) <= HEARTBEAT_MAX_AGE_MS) {
+    const alive = processes.find(p => p.pid === hb.pid);
+    if (alive && (alive.name === 'claude.exe' || alive.name === 'node.exe')) {
+      if (!byPid.has(alive.pid)) {
+        byPid.set(alive.pid, {
+          pid: alive.pid,
+          source: 'heartbeat',
+          name: alive.name,
+          cmdline: alive.cmdline,
+        });
+      }
+    }
+  }
+
+  return Array.from(byPid.values());
+}
+
+module.exports = {
+  discoverAgentPids,
+  listProcesses,
+  parseProcessCsv,
+  splitCsvLine,
+  matchesDeterministicAgent,
+  readHeartbeat,
+  HEARTBEAT_MAX_AGE_MS,
+};


### PR DESCRIPTION
## Resumen

Reemplaza el kill basado en `agent-registry.json` por descubrimiento dinámico del PID de un agente en vuelo. El registry es una fuente duplicada de verdad con race conditions conocidas (PIDs stale, reuso por el OS, desincronización entre spawn y `session:start`).

**Estrategia de descubrimiento** (archivo nuevo `lib/pid-discovery.js`):

1. **Scan de procesos vivos** vía `Get-CimInstance Win32_Process` (PowerShell) filtrando por `CommandLine` — detecta agentes determinísticos (`node .../skills-deterministicos/<skill>.js <issue> --trabajando=...`) con word-boundary para evitar falsos positivos (ej. `24860` ≠ `2486`).
2. **Heartbeat** (`.claude/hooks/agent-<issue>.heartbeat`) como fuente secundaria — aporta el PID de agentes LLM (`claude.exe`), donde el `CommandLine` no contiene el issue (viene por env). Se valida:
   - Archivo fresco (< 5 min — heartbeat stale = agente muerto).
   - PID declarado aparece en el scan vivo.
   - Proceso es `claude.exe` o `node.exe` (evita matar un proceso con PID reusado por el OS).
3. De-dup cuando ambas fuentes coinciden.

**Refactor del kill:**

`dashboard-v2.js:6006` ya no lee `agent-registry.json`. Usa `discoverAgentPids({ issue, skill })` y reporta los PIDs killeados con su fuente (`process-scan` | `heartbeat`).

## Tests

- `__tests__/pid-discovery.test.js` — 24 tests unitarios con CSV fixture real (`ConvertTo-Csv -NoTypeInformation`): parseo, word-boundary en issue, heartbeat stale, PID muerto, de-dup scan+heartbeat.
- **Total paquete determinístico: 115/115 ✓** (builder + tester + delivery + gradle-parser + kover-parser + git-ops + pid-discovery).

## qa:skipped

Cambio puro de infraestructura del pipeline — no toca producto de usuario final (ni backend, ni app, ni APIs). El contrato externo del `/api/kill-agent` del dashboard se preserva (mismos parámetros, misma respuesta, misma semántica de mover a `pendiente/`).

Closes #2486

🤖 Generated with [Claude Code](https://claude.com/claude-code)