### PR TITLE
feat(pipeline): métricas V3 extendidas — LLM vs determinístico, TTS por issue y proyecciones

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,5 +137,11 @@ scripts/planner-plan.json
 .pipeline/tmp/
 # #2337 — estado reintentando + metricas UX rotadas (no comitear)
 .pipeline/retrying-state.json
-.pipeline/metrics/
+# #2477/#2488 — código fuente del aggregator V3 sí se commitea (snapshot/.last-cleanup quedan ignorados)
+.pipeline/metrics/*
+!.pipeline/metrics/aggregator.js
+!.pipeline/metrics/projections.js
+!.pipeline/metrics/report-daily.js
+!.pipeline/metrics/__tests__/
+!.pipeline/metrics/__tests__/**
 !.pipeline/**/.gitkeep

--- a/.pipeline/dashboard-v2.js
+++ b/.pipeline/dashboard-v2.js
@@ -5381,6 +5381,9 @@ function renderConsumoHtml() {
     <button class="tab active" data-panel="agents">Por agente</button>
     <button class="tab" data-panel="phases">Por fase</button>
     <button class="tab" data-panel="issues">Por issue</button>
+    <button class="tab" data-panel="projections">Proyecciones</button>
+    <button class="tab" data-panel="llmvsdet">LLM vs Determinístico</button>
+    <button class="tab" data-panel="ttsissues">TTS por issue</button>
   </div>
 
   <div class="panel active" id="panel-agents">
@@ -5408,9 +5411,37 @@ function renderConsumoHtml() {
     </div>
   </div>
 
+  <div class="panel" id="panel-projections">
+    <div id="proj-cards"><div class="empty">Cargando…</div></div>
+  </div>
+
+  <div class="panel" id="panel-llmvsdet">
+    <div class="card-sub" style="color:var(--dim);font-size:12px;margin-bottom:8px;">
+      Comparativa por skill entre ejecución LLM (Claude) y determinística (Node puro). "Ahorro estimado" = sesiones_det × costo_promedio_llm.
+    </div>
+    <table>
+      <thead><tr><th>Skill</th><th class="num">LLM sesiones</th><th class="num">LLM costo</th><th class="num">LLM prom/sesión</th><th class="num">Det sesiones</th><th class="num">Det costo</th><th class="num">Ahorro estimado</th><th>Estado</th></tr></thead>
+      <tbody id="tbody-llmvsdet"><tr><td colspan="8" class="empty">Cargando…</td></tr></tbody>
+    </table>
+  </div>
+
+  <div class="panel" id="panel-ttsissues">
+    <div class="card-sub" style="color:var(--dim);font-size:12px;margin-bottom:8px;">
+      Consumo de TTS (caracteres, audio, costo) desglosado por issue. Click en una fila para ver los providers usados.
+    </div>
+    <table>
+      <thead><tr><th>Issue</th><th class="num">TTS count</th><th class="num">Caracteres</th><th class="num">Audio</th><th class="num">Costo</th></tr></thead>
+      <tbody id="tbody-ttsissues"><tr><td colspan="5" class="empty">Cargando…</td></tr></tbody>
+    </table>
+    <div class="drilldown" id="tts-drilldown">
+      <h3 id="tts-dd-title">Providers</h3>
+      <div id="tts-dd-body"></div>
+    </div>
+  </div>
+
   <div class="footer">
-    Schema V3 definido en <a href="https://github.com/intrale/platform/issues/2477" target="_blank">#2477</a>.
-    Endpoints JSON: <a href="/metrics/agents">/metrics/agents</a> · <a href="/metrics/phases">/metrics/phases</a> · <a href="/metrics/issues">/metrics/issues</a> · <a href="/metrics/tts">/metrics/tts</a> · <a href="/metrics/snapshot">/metrics/snapshot</a>
+    Schema V3 definido en <a href="https://github.com/intrale/platform/issues/2477" target="_blank">#2477</a> · Extensiones en <a href="https://github.com/intrale/platform/issues/2488" target="_blank">#2488</a>.<br>
+    Endpoints JSON: <a href="/metrics/agents">/agents</a> · <a href="/metrics/phases">/phases</a> · <a href="/metrics/issues">/issues</a> · <a href="/metrics/tts">/tts</a> · <a href="/metrics/projections">/projections</a> · <a href="/metrics/llm-vs-deterministic">/llm-vs-deterministic</a> · <a href="/metrics/daily">/daily</a> · <a href="/metrics/snapshot">/snapshot</a>
   </div>
 
 <script>
@@ -5493,6 +5524,110 @@ function renderIssues(rows) {
   ).join('');
 }
 
+function projCard(title, dim) {
+  if (!dim) return '';
+  const q = dim.quota || {};
+  const status = q.status || 'ok';
+  const color = status === 'over' ? 'var(--rd, #f85149)' : (status === 'warning' ? 'var(--yl, #d29922)' : 'var(--gn, #3fb950)');
+  const ratioPct = q.ratio != null ? Math.round(q.ratio * 100) + '%' : '—';
+  const alert = q.alert ? '<div style="margin-top:8px;padding:8px;background:rgba(248,81,73,0.10);border-left:3px solid '+color+';font-size:12px;">⚠️ '+q.alert+'</div>' : '';
+  const secondary = [];
+  if (dim.dimension === 'tts') {
+    if (dim.tts_chars_monthly_projection != null) secondary.push(['Caracteres/mes (proyectado)', fmtNum(dim.tts_chars_monthly_projection)]);
+    if (dim.tts_audio_seconds_monthly_projection != null) secondary.push(['Audio/mes (proyectado)', fmtAudio(dim.tts_audio_seconds_monthly_projection)]);
+    if (dim.tts_chars_month_to_date != null) secondary.push(['Caracteres MTD', fmtNum(dim.tts_chars_month_to_date)]);
+  } else {
+    if (dim.sessions_monthly_projection != null) secondary.push(['Sesiones/mes (proyectado)', fmtNum(dim.sessions_monthly_projection)]);
+    if (dim.sessions_month_to_date != null) secondary.push(['Sesiones MTD', fmtNum(dim.sessions_month_to_date)]);
+  }
+  const secHtml = secondary.length ? '<div style="margin-top:10px;display:grid;grid-template-columns:1fr 1fr;gap:6px;font-size:12px;color:var(--dim);">'
+    + secondary.map(([l,v]) => '<div>'+l+': <span style="color:var(--fg);font-weight:600;">'+v+'</span></div>').join('') + '</div>' : '';
+  return '<div class="kpi" style="border-left:3px solid '+color+';padding:14px;">'
+    +'<div class="label" style="font-size:14px;font-weight:700;text-transform:uppercase;letter-spacing:0.05em;">'+title+'</div>'
+    +'<div style="margin-top:10px;display:grid;grid-template-columns:1fr 1fr;gap:8px;font-size:13px;">'
+      +'<div><div style="color:var(--dim);font-size:11px;">Promedio diario</div><div style="font-weight:600;">'+fmtUsd(dim.daily_avg_usd)+'</div></div>'
+      +'<div><div style="color:var(--dim);font-size:11px;">Proyección semanal</div><div style="font-weight:600;">'+fmtUsd(dim.weekly_projection_usd)+'</div></div>'
+      +'<div><div style="color:var(--dim);font-size:11px;">Mes hasta hoy</div><div style="font-weight:600;">'+fmtUsd(dim.month_to_date_usd)+'</div></div>'
+      +'<div><div style="color:var(--dim);font-size:11px;">Proyección fin de mes</div><div style="font-weight:600;color:'+color+';">'+fmtUsd(dim.monthly_forecast_usd)+'</div></div>'
+      +'<div><div style="color:var(--dim);font-size:11px;">Cuota mensual</div><div style="font-weight:600;">'+fmtUsd(q.monthly_usd)+'</div></div>'
+      +'<div><div style="color:var(--dim);font-size:11px;">% de cuota</div><div style="font-weight:600;color:'+color+';">'+ratioPct+'</div></div>'
+    +'</div>'
+    + secHtml
+    + alert
+    +'<div style="margin-top:8px;font-size:11px;color:var(--dim);">Basado en últimos '+(dim.samples||0)+' días · '+dim.days_remaining_this_month+' días restantes del mes</div>'
+  +'</div>';
+}
+
+function renderProjections(projections) {
+  const el = document.getElementById('proj-cards');
+  if (!projections || (!projections.tokens && !projections.tts)) {
+    el.innerHTML = '<div class="empty">Sin datos suficientes para proyectar.</div>';
+    return;
+  }
+  el.innerHTML = '<div style="display:grid;grid-template-columns:1fr 1fr;gap:14px;">'
+    + projCard('Tokens (LLM)', projections.tokens)
+    + projCard('TTS (audio)', projections.tts)
+    + '</div>';
+}
+
+function renderLlmVsDet(rows) {
+  const body = document.getElementById('tbody-llmvsdet');
+  if (!rows || !rows.length) { body.innerHTML = '<tr><td colspan="8" class="empty">Sin sesiones registradas para comparar</td></tr>'; return; }
+  body.innerHTML = rows.map(r => {
+    const status = r.migrated
+      ? '<span style="color:var(--gn, #3fb950);">✓ Migrado</span>'
+      : '<span style="color:var(--dim);">— Solo LLM</span>';
+    const savings = r.estimated_savings_usd > 0
+      ? '<span style="color:var(--gn, #3fb950);font-weight:600;">'+fmtUsd(r.estimated_savings_usd)+'</span>'
+      : fmtUsd(r.estimated_savings_usd);
+    return '<tr><td class="skill">'+(r.skill||'—')+'</td>'
+      +'<td class="num">'+fmtNum(r.llm_sessions)+'</td>'
+      +'<td class="usd">'+fmtUsd(r.llm_cost_usd)+'</td>'
+      +'<td class="usd">'+fmtUsd(r.llm_avg_cost_per_session)+'</td>'
+      +'<td class="num">'+fmtNum(r.deterministic_sessions)+'</td>'
+      +'<td class="usd">'+fmtUsd(r.deterministic_cost_usd)+'</td>'
+      +'<td class="usd">'+savings+'</td>'
+      +'<td>'+status+'</td></tr>';
+  }).join('');
+}
+
+function renderTtsByIssue(rows) {
+  const body = document.getElementById('tbody-ttsissues');
+  if (!rows || !rows.length) { body.innerHTML = '<tr><td colspan="5" class="empty">Sin TTS registrado en la ventana</td></tr>'; return; }
+  body.innerHTML = rows.map(r =>
+    '<tr onclick="showTtsProviders('+r.issue+')"><td class="issue">#'+r.issue+'</td>'
+    +'<td class="num">'+fmtNum(r.tts_count)+'</td>'
+    +'<td class="num">'+fmtNum(r.tts_chars)+'</td>'
+    +'<td class="num">'+fmtAudio(r.tts_audio_seconds)+'</td>'
+    +'<td class="usd">'+fmtUsd(r.tts_cost_usd)+'</td></tr>'
+  ).join('');
+}
+
+function showTtsProviders(issueNumber) {
+  const list = (lastSnapshot && lastSnapshot.tts && lastSnapshot.tts.by_issue) || [];
+  const issue = list.find(i => Number(i.issue) === Number(issueNumber));
+  const dd = document.getElementById('tts-drilldown');
+  const title = document.getElementById('tts-dd-title');
+  const body = document.getElementById('tts-dd-body');
+  if (!issue || !issue.by_provider || !issue.by_provider.length) {
+    title.textContent = 'Providers TTS de #' + issueNumber;
+    body.innerHTML = '<div class="empty">Sin breakdown por provider para este issue.</div>';
+  } else {
+    title.textContent = 'Providers TTS de #' + issue.issue + ' · ' + fmtNum(issue.tts_count) + ' generaciones · ' + fmtUsd(issue.tts_cost_usd);
+    body.innerHTML = '<table style="width:100%;margin-top:6px;"><thead><tr><th>Provider</th><th class="num">Eventos</th><th class="num">Caracteres</th><th class="num">Audio</th><th class="usd">Costo</th></tr></thead><tbody>'
+      + issue.by_provider.map(p =>
+        '<tr><td>'+(p.provider||'—')+'</td>'
+        +'<td class="num">'+fmtNum(p.tts_count)+'</td>'
+        +'<td class="num">'+fmtNum(p.tts_chars)+'</td>'
+        +'<td class="num">'+fmtAudio(p.tts_audio_seconds)+'</td>'
+        +'<td class="usd">'+fmtUsd(p.tts_cost_usd)+'</td></tr>'
+      ).join('')
+      + '</tbody></table>';
+  }
+  dd.classList.add('open');
+  dd.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+}
+
 let lastSnapshot = null;
 
 async function refresh() {
@@ -5505,6 +5640,9 @@ async function refresh() {
     renderAgents(snap.agents || []);
     renderPhases(snap.phases || []);
     renderIssues(snap.issues || []);
+    renderProjections(snap.projections || null);
+    renderLlmVsDet(snap.llm_vs_deterministic || []);
+    renderTtsByIssue((snap.tts && snap.tts.by_issue) || []);
     document.getElementById('last-refresh').textContent = 'Actualizado: ' + new Date().toLocaleTimeString('es-AR');
   } catch (e) {
     document.getElementById('last-refresh').textContent = 'Error: ' + e.message;
@@ -6126,15 +6264,15 @@ const server = http.createServer((req, res) => {
   // ===========================================================================
   // V3 — Endpoints de métricas extendidas (issue #2477)
   // ===========================================================================
-  if (req.url.startsWith('/metrics/') || req.url === '/consumo') {
+  if (req.url.startsWith('/metrics/') || req.url === '/consumo' || req.url === '/metrics-v3' || req.url === '/metrics-v3/') {
     if (!v3Aggregator) {
       res.writeHead(503, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ error: 'V3 aggregator no disponible. Verificar .pipeline/metrics/aggregator.js' }));
       return;
     }
 
-    // /consumo → página HTML con las 3 tabs
-    if (req.url === '/consumo') {
+    // /consumo o /metrics-v3 → página HTML con tabs (#2488: alias /metrics-v3 más descriptivo)
+    if (req.url === '/consumo' || req.url === '/metrics-v3' || req.url === '/metrics-v3/') {
       res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
       res.end(renderConsumoHtml());
       return;
@@ -6161,6 +6299,10 @@ const server = http.createServer((req, res) => {
       if (u.pathname === '/metrics/tts')    return respond(Object.assign({}, baseMeta, { tts: snap.tts || {} }));
       if (u.pathname === '/metrics/snapshot') return respond(snap);
       if (u.pathname === '/metrics/totals')  return respond(Object.assign({}, baseMeta, { totals: snap.totals || {} }));
+      // #2488 — nuevos endpoints
+      if (u.pathname === '/metrics/projections') return respond(Object.assign({}, baseMeta, { projections: snap.projections || {} }));
+      if (u.pathname === '/metrics/llm-vs-deterministic') return respond(Object.assign({}, baseMeta, { llm_vs_deterministic: snap.llm_vs_deterministic || [] }));
+      if (u.pathname === '/metrics/daily') return respond(Object.assign({}, baseMeta, { daily: snap.daily || [] }));
 
       const issueMatch = u.pathname.match(/^\/metrics\/issues\/(\d+)\/?$/);
       if (issueMatch) {
@@ -6174,7 +6316,7 @@ const server = http.createServer((req, res) => {
       }
 
       res.writeHead(404, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ error: 'endpoint no reconocido', valid: ['/metrics/agents', '/metrics/phases', '/metrics/issues', '/metrics/issues/:n', '/metrics/tts', '/metrics/totals', '/metrics/snapshot', '/consumo'] }));
+      res.end(JSON.stringify({ error: 'endpoint no reconocido', valid: ['/metrics/agents', '/metrics/phases', '/metrics/issues', '/metrics/issues/:n', '/metrics/tts', '/metrics/totals', '/metrics/snapshot', '/metrics/projections', '/metrics/llm-vs-deterministic', '/metrics/daily', '/consumo', '/metrics-v3'] }));
     }).catch(fail);
     return;
   }

--- a/.pipeline/metrics/__tests__/aggregator.test.js
+++ b/.pipeline/metrics/__tests__/aggregator.test.js
@@ -1,0 +1,182 @@
+// Tests de .pipeline/metrics/aggregator.js (#2488)
+// Verifica agregación extendida: execution_mode, TTS por issue, LLM vs det, daily series.
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const TMP_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'v3-agg-'));
+fs.mkdirSync(path.join(TMP_DIR, '.claude'), { recursive: true });
+fs.mkdirSync(path.join(TMP_DIR, '.pipeline', 'metrics'), { recursive: true });
+process.env.CLAUDE_PROJECT_DIR = TMP_DIR;
+process.env.PIPELINE_REPO_ROOT = TMP_DIR;
+
+delete require.cache[require.resolve('../../lib/traceability')];
+delete require.cache[require.resolve('../projections')];
+delete require.cache[require.resolve('../aggregator')];
+
+const trace = require('../../lib/traceability');
+const aggregator = require('../aggregator');
+
+function writeLog(events) {
+    const lines = events.map(e => JSON.stringify(e)).join('\n') + '\n';
+    fs.writeFileSync(trace.LOG_FILE, lines, 'utf8');
+}
+
+function sessionEnd({ skill, issue, phase, model, tokens_in, tokens_out, cache_read, cache_write, duration_ms, ts }) {
+    return {
+        event: 'session:end',
+        skill, issue, phase, model,
+        tokens_in: tokens_in || 0,
+        tokens_out: tokens_out || 0,
+        cache_read: cache_read || 0,
+        cache_write: cache_write || 0,
+        duration_ms: duration_ms || 1000,
+        tool_calls: 0,
+        ts: ts || new Date().toISOString(),
+    };
+}
+
+function ttsGen({ skill, issue, phase, provider, chars, audio_seconds, cost, ts }) {
+    return {
+        event: 'tts:generated',
+        skill, issue, phase, provider,
+        chars: chars || 0,
+        audio_seconds: audio_seconds || 0,
+        cost_estimate_usd: cost || 0,
+        ts: ts || new Date().toISOString(),
+    };
+}
+
+test('classifyExecutionMode distingue deterministic vs llm', () => {
+    assert.equal(aggregator.classifyExecutionMode('deterministic'), 'deterministic');
+    assert.equal(aggregator.classifyExecutionMode('DETERMINISTIC'), 'deterministic');
+    assert.equal(aggregator.classifyExecutionMode('claude-opus-4-7'), 'llm');
+    assert.equal(aggregator.classifyExecutionMode('claude-sonnet-4-6'), 'llm');
+    assert.equal(aggregator.classifyExecutionMode(null), 'llm');
+    assert.equal(aggregator.classifyExecutionMode(''), 'llm');
+});
+
+test('buildSnapshot genera llm_vs_deterministic con ahorro estimado', async () => {
+    writeLog([
+        sessionEnd({ skill: 'builder', issue: 2476, phase: 'build', model: 'claude-opus-4-7', tokens_in: 10000, tokens_out: 2000, ts: '2026-04-22T10:00:00Z' }),
+        sessionEnd({ skill: 'builder', issue: 2476, phase: 'build', model: 'claude-opus-4-7', tokens_in: 8000, tokens_out: 1500, ts: '2026-04-22T11:00:00Z' }),
+        sessionEnd({ skill: 'builder', issue: 2484, phase: 'build', model: 'deterministic', ts: '2026-04-22T12:00:00Z' }),
+        sessionEnd({ skill: 'builder', issue: 2485, phase: 'build', model: 'deterministic', ts: '2026-04-22T13:00:00Z' }),
+        sessionEnd({ skill: 'builder', issue: 2486, phase: 'build', model: 'deterministic', ts: '2026-04-22T14:00:00Z' }),
+    ]);
+    const snap = await aggregator.buildSnapshot({});
+    assert.ok(Array.isArray(snap.llm_vs_deterministic));
+    const builder = snap.llm_vs_deterministic.find(r => r.skill === 'builder');
+    assert.ok(builder, 'builder debe existir en llm_vs_deterministic');
+    assert.equal(builder.llm_sessions, 2);
+    assert.equal(builder.deterministic_sessions, 3);
+    assert.ok(builder.llm_avg_cost_per_session > 0);
+    assert.ok(builder.estimated_savings_usd > 0);
+    assert.equal(builder.migrated, true);
+});
+
+test('buildSnapshot expone TTS por issue con break-down por provider', async () => {
+    writeLog([
+        sessionEnd({ skill: 'qa', issue: 2477, phase: 'qa', model: 'claude-opus-4-7', tokens_in: 5000, ts: '2026-04-22T10:00:00Z' }),
+        ttsGen({ skill: 'qa', issue: 2477, phase: 'qa', provider: 'openai', chars: 500, audio_seconds: 35, cost: 0.01, ts: '2026-04-22T10:05:00Z' }),
+        ttsGen({ skill: 'qa', issue: 2477, phase: 'qa', provider: 'edge-tts', chars: 300, audio_seconds: 20, cost: 0, ts: '2026-04-22T10:06:00Z' }),
+        ttsGen({ skill: 'qa', issue: 2488, phase: 'qa', provider: 'openai', chars: 1000, audio_seconds: 70, cost: 0.02, ts: '2026-04-22T11:00:00Z' }),
+    ]);
+    const snap = await aggregator.buildSnapshot({});
+    assert.ok(Array.isArray(snap.tts.by_issue));
+    assert.equal(snap.tts.by_issue.length, 2);
+
+    // Ranking por cost_usd desc — 2488 tiene cost=0.02, 2477 tiene 0.01
+    assert.equal(snap.tts.by_issue[0].issue, 2488);
+    assert.equal(snap.tts.by_issue[0].tts_chars, 1000);
+    assert.equal(snap.tts.by_issue[0].tts_audio_seconds, 70);
+
+    const issue2477 = snap.tts.by_issue.find(i => i.issue === 2477);
+    assert.equal(issue2477.tts_chars, 800); // 500 + 300
+    assert.equal(issue2477.by_provider.length, 2);
+    const byProv = Object.fromEntries(issue2477.by_provider.map(p => [p.provider, p]));
+    assert.equal(byProv.openai.tts_chars, 500);
+    assert.equal(byProv['edge-tts'].tts_chars, 300);
+});
+
+test('buildSnapshot expone by_skill dentro de cada issue', async () => {
+    writeLog([
+        sessionEnd({ skill: 'builder',  issue: 2500, phase: 'build', model: 'deterministic',  ts: '2026-04-22T10:00:00Z' }),
+        sessionEnd({ skill: 'tester',   issue: 2500, phase: 'test',  model: 'deterministic',  ts: '2026-04-22T10:05:00Z' }),
+        sessionEnd({ skill: 'delivery', issue: 2500, phase: 'deliver', model: 'deterministic', ts: '2026-04-22T10:10:00Z' }),
+    ]);
+    const snap = await aggregator.buildSnapshot({});
+    const issue = snap.issues.find(i => i.issue === 2500);
+    assert.ok(issue);
+    assert.ok(Array.isArray(issue.by_skill));
+    assert.equal(issue.by_skill.length, 3);
+    const skills = issue.by_skill.map(s => s.skill).sort();
+    assert.deepEqual(skills, ['builder', 'delivery', 'tester']);
+});
+
+test('buildSnapshot incluye daily series para proyecciones', async () => {
+    writeLog([
+        sessionEnd({ skill: 'qa', issue: 2600, phase: 'qa', model: 'claude-opus-4-7', tokens_in: 1000000, ts: '2026-04-20T10:00:00Z' }),
+        sessionEnd({ skill: 'qa', issue: 2600, phase: 'qa', model: 'claude-opus-4-7', tokens_in: 500000,  ts: '2026-04-21T10:00:00Z' }),
+        sessionEnd({ skill: 'qa', issue: 2600, phase: 'qa', model: 'claude-opus-4-7', tokens_in: 2000000, ts: '2026-04-22T10:00:00Z' }),
+    ]);
+    const snap = await aggregator.buildSnapshot({});
+    assert.ok(Array.isArray(snap.daily));
+    assert.equal(snap.daily.length, 3);
+    assert.equal(snap.daily[0].day, '2026-04-20');
+    assert.equal(snap.daily[2].day, '2026-04-22');
+    // Orden ascendente
+    assert.ok(snap.daily[0].day < snap.daily[2].day);
+});
+
+test('buildSnapshot genera projections con tokens y tts', async () => {
+    writeLog([
+        sessionEnd({ skill: 'qa', issue: 2700, phase: 'qa', model: 'claude-opus-4-7', tokens_in: 100000, tokens_out: 50000, ts: '2026-04-22T10:00:00Z' }),
+        ttsGen({ skill: 'qa', issue: 2700, phase: 'qa', provider: 'openai', chars: 5000, audio_seconds: 350, cost: 0.0875, ts: '2026-04-22T10:30:00Z' }),
+    ]);
+    const snap = await aggregator.buildSnapshot({});
+    assert.ok(snap.projections);
+    assert.ok(snap.projections.tokens);
+    assert.ok(snap.projections.tts);
+    assert.ok(snap.projections.tokens.dimension === 'tokens');
+    assert.ok(snap.projections.tts.dimension === 'tts');
+});
+
+test('buildSnapshot con log vacío no explota', async () => {
+    // Sobrescribir con archivo vacío
+    fs.writeFileSync(trace.LOG_FILE, '', 'utf8');
+    const snap = await aggregator.buildSnapshot({});
+    assert.equal(snap.totals.sessions, 0);
+    assert.deepEqual(snap.llm_vs_deterministic, []);
+    assert.deepEqual(snap.tts.by_issue, []);
+    assert.ok(snap.projections);
+});
+
+test('buildSnapshot respeta ventana temporal', async () => {
+    const now = Date.now();
+    const old = new Date(now - 8 * 86400e3).toISOString();
+    const recent = new Date(now - 1 * 86400e3).toISOString();
+    writeLog([
+        sessionEnd({ skill: 'qa', issue: 2800, phase: 'qa', model: 'claude-opus-4-7', tokens_in: 10000, ts: old }),
+        sessionEnd({ skill: 'qa', issue: 2801, phase: 'qa', model: 'claude-opus-4-7', tokens_in: 20000, ts: recent }),
+    ]);
+    const snapAll = await aggregator.buildSnapshot({ window: 'all' });
+    const snap7d = await aggregator.buildSnapshot({ window: '7d' });
+    // Ventana 7d excluye el de hace 8 días
+    assert.equal(snapAll.totals.sessions, 2);
+    assert.equal(snap7d.totals.sessions, 1);
+});
+
+test('by_issue queda vacío cuando no hay TTS (pero sí hay sesiones)', async () => {
+    writeLog([
+        sessionEnd({ skill: 'builder', issue: 2900, phase: 'build', model: 'deterministic', ts: '2026-04-22T10:00:00Z' }),
+    ]);
+    const snap = await aggregator.buildSnapshot({});
+    assert.equal(snap.tts.by_issue.length, 0);
+    // Pero el issue sí existe en snap.issues
+    assert.ok(snap.issues.find(i => i.issue === 2900));
+});

--- a/.pipeline/metrics/__tests__/projections.test.js
+++ b/.pipeline/metrics/__tests__/projections.test.js
@@ -1,0 +1,176 @@
+// Tests de .pipeline/metrics/projections.js (#2488)
+// Verifica promedios diarios, proyecciones mensuales/semanales y detección de desvío.
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+    computeProjections,
+    dailyAverage,
+    daysInMonth,
+    daysRemainingThisMonth,
+    daysRemainingThisWeek,
+    monthToDate,
+} = require('../projections');
+
+function mkDay(day, cost, tts, sessions, chars, audio) {
+    return {
+        day,
+        cost_usd: cost,
+        tts_cost_usd: tts || 0,
+        sessions: sessions || 0,
+        tts_chars: chars || 0,
+        tts_audio_seconds: audio || 0,
+    };
+}
+
+test('dailyAverage respeta ventana de N días', () => {
+    const series = [
+        mkDay('2026-04-15', 1),
+        mkDay('2026-04-16', 2),
+        mkDay('2026-04-17', 3),
+        mkDay('2026-04-18', 4),
+        mkDay('2026-04-19', 5),
+        mkDay('2026-04-20', 6),
+        mkDay('2026-04-21', 7),
+        mkDay('2026-04-22', 14), // solo este debería dominar si ventana=1
+    ];
+    // ventana 7 días → toma los últimos 7 = 2+3+4+5+6+7+14 = 41 / 7
+    assert.equal(dailyAverage(series, 'cost_usd', 7), 41 / 7);
+    // ventana 1 → último día
+    assert.equal(dailyAverage(series, 'cost_usd', 1), 14);
+});
+
+test('dailyAverage con serie más corta que ventana divide por días disponibles', () => {
+    const series = [mkDay('2026-04-21', 2), mkDay('2026-04-22', 4)];
+    // No divide por 7 — divide por 2 (lo que hay)
+    assert.equal(dailyAverage(series, 'cost_usd', 7), 3);
+});
+
+test('dailyAverage devuelve 0 con serie vacía', () => {
+    assert.equal(dailyAverage([], 'cost_usd', 7), 0);
+});
+
+test('daysInMonth para abril 2026', () => {
+    assert.equal(daysInMonth(new Date(2026, 3, 22)), 30); // mes 0-indexed → abril
+});
+
+test('daysInMonth para febrero 2024 (bisiesto)', () => {
+    assert.equal(daysInMonth(new Date(2024, 1, 10)), 29);
+});
+
+test('daysRemainingThisMonth calcula lo que falta', () => {
+    assert.equal(daysRemainingThisMonth(new Date(2026, 3, 22)), 8); // 30 - 22
+    assert.equal(daysRemainingThisMonth(new Date(2026, 3, 30)), 0);
+});
+
+test('daysRemainingThisWeek 0 domingo, 6 lunes', () => {
+    // 2026-04-19 = domingo (constructor local, no UTC)
+    assert.equal(daysRemainingThisWeek(new Date(2026, 3, 19)), 0);
+    // 2026-04-20 = lunes → 6 días hasta fin de semana
+    assert.equal(daysRemainingThisWeek(new Date(2026, 3, 20)), 6);
+});
+
+test('monthToDate suma solo días del mes corriente', () => {
+    const series = [
+        mkDay('2026-03-30', 100),  // mes anterior
+        mkDay('2026-04-01', 5),
+        mkDay('2026-04-15', 10),
+        mkDay('2026-04-22', 20),
+    ];
+    assert.equal(monthToDate(series, 'cost_usd', new Date('2026-04-22')), 35);
+});
+
+test('computeProjections devuelve tokens y tts', () => {
+    const series = [
+        mkDay('2026-04-20', 1.5, 0.1, 10, 1000, 70),
+        mkDay('2026-04-21', 2.0, 0.2, 15, 2000, 140),
+        mkDay('2026-04-22', 2.5, 0.15, 12, 1500, 100),
+    ];
+    const proj = computeProjections({ daily: series, now: new Date('2026-04-22T20:00:00Z') });
+    assert.ok(proj.tokens);
+    assert.ok(proj.tts);
+    assert.equal(proj.tokens.dimension, 'tokens');
+    assert.equal(proj.tts.dimension, 'tts');
+    assert.ok(proj.tokens.daily_avg_usd > 0);
+    assert.ok(proj.tts.daily_avg_usd > 0);
+    // Proyección mensual = avg × daysInMonth
+    const expectedTokensMonthly = ((1.5 + 2.0 + 2.5) / 3) * 30;
+    // redondeo a 4 decimales
+    assert.equal(proj.tokens.monthly_projection_usd, Math.round(expectedTokensMonthly * 10000) / 10000);
+});
+
+test('computeProjections detecta desvío cuando forecast > cuota', () => {
+    const series = [
+        mkDay('2026-04-22', 10), // $10/día → proyección mensual ~$300
+    ];
+    const proj = computeProjections({
+        daily: series,
+        now: new Date('2026-04-22T20:00:00Z'),
+        quotas: { monthly_token_usd: 50, monthly_tts_usd: 5 },
+    });
+    assert.equal(proj.tokens.quota.status, 'over');
+    assert.ok(proj.tokens.quota.alert);
+    assert.ok(proj.tokens.quota.delta_usd > 0);
+    assert.ok(proj.tokens.quota.ratio > 1);
+});
+
+test('computeProjections status ok cuando forecast < 90% cuota', () => {
+    const series = [mkDay('2026-04-22', 1)]; // $1/día
+    const proj = computeProjections({
+        daily: series,
+        now: new Date('2026-04-22T20:00:00Z'),
+        quotas: { monthly_token_usd: 500, monthly_tts_usd: 100 },
+    });
+    assert.equal(proj.tokens.quota.status, 'ok');
+    assert.equal(proj.tokens.quota.alert, null);
+});
+
+test('computeProjections status warning cuando forecast entre 90-100% cuota', () => {
+    // 1 día con $1.5 → avg=1.5, forecast = mtd(1.5) + avg*daysLeft(8) = 1.5 + 12 = 13.5
+    // cuota 14 → ratio = 0.964 → warning
+    const series = [mkDay('2026-04-22', 1.5)];
+    const proj = computeProjections({
+        daily: series,
+        now: new Date('2026-04-22T20:00:00Z'),
+        quotas: { monthly_token_usd: 14, monthly_tts_usd: 100 },
+    });
+    assert.equal(proj.tokens.quota.status, 'warning');
+    assert.equal(proj.tokens.quota.alert, null); // warning no dispara alert
+});
+
+test('computeProjections con serie vacía devuelve ceros', () => {
+    const proj = computeProjections({ daily: [], now: new Date('2026-04-22T20:00:00Z') });
+    assert.equal(proj.tokens.daily_avg_usd, 0);
+    assert.equal(proj.tokens.monthly_projection_usd, 0);
+    assert.equal(proj.tts.daily_avg_usd, 0);
+});
+
+test('computeProjections incluye campos secundarios (sessions, tts_chars)', () => {
+    const series = [
+        mkDay('2026-04-22', 5, 0.2, 10, 1400, 100),
+    ];
+    const proj = computeProjections({ daily: series, now: new Date('2026-04-22T20:00:00Z') });
+    assert.equal(proj.tokens.sessions_daily_avg, 10);
+    assert.equal(proj.tts.tts_chars_daily_avg, 1400);
+    assert.equal(proj.tts.tts_audio_seconds_daily_avg, 100);
+});
+
+test('computeProjections forecast = mtd + avg × diasRestantes', () => {
+    // Serie con 3 días del mes: 1, 2, 3 → mtd = 6, avg = 2
+    // now = 2026-04-22 → daysLeft = 8
+    // forecast esperado = 6 + 2*8 = 22
+    const series = [
+        mkDay('2026-04-20', 1),
+        mkDay('2026-04-21', 2),
+        mkDay('2026-04-22', 3),
+    ];
+    const proj = computeProjections({
+        daily: series,
+        now: new Date('2026-04-22T20:00:00Z'),
+        quotas: { monthly_token_usd: 100, monthly_tts_usd: 100 },
+    });
+    assert.equal(proj.tokens.month_to_date_usd, 6);
+    assert.equal(proj.tokens.monthly_forecast_usd, 22);
+});

--- a/.pipeline/metrics/aggregator.js
+++ b/.pipeline/metrics/aggregator.js
@@ -1,0 +1,382 @@
+#!/usr/bin/env node
+// V3 Metrics Aggregator — lee activity-log.jsonl, indexa eventos V3 y persiste snapshots
+// Contrato definido en issue #2477.
+//
+// Modos:
+//   node aggregator.js                 → modo daemon, refresh cada 60s
+//   node aggregator.js --once          → snapshot único y exit
+//   node aggregator.js --window 24h    → aplicar ventana temporal al snapshot (1h|24h|7d|all)
+//
+// Output: .pipeline/metrics/snapshot.json (ver schema abajo).
+// Consumido por dashboard-v2.js y report-daily.js.
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const readline = require('readline');
+const { LOG_FILE, REPO_ROOT, estimateCostUsd, MODEL_PRICING } = require('../lib/traceability');
+const { computeProjections } = require('./projections');
+
+const METRICS_DIR = path.join(REPO_ROOT, '.pipeline', 'metrics');
+const SNAPSHOT_FILE = path.join(METRICS_DIR, 'snapshot.json');
+const DEFAULT_REFRESH_MS = 60000;
+
+// Normaliza el modelo a "deterministic" | "llm" para comparativa (#2488)
+function classifyExecutionMode(model) {
+    const m = String(model || '').toLowerCase().trim();
+    return m === 'deterministic' ? 'deterministic' : 'llm';
+}
+
+function ensureDir(dir) {
+    try { fs.mkdirSync(dir, { recursive: true }); } catch (e) { /* ignore */ }
+}
+
+function parseWindow(s) {
+    if (!s || s === 'all') return null;
+    const m = String(s).match(/^(\d+)([hd])$/i);
+    if (!m) return null;
+    const n = parseInt(m[1], 10);
+    const mult = m[2].toLowerCase() === 'h' ? 3600e3 : 86400e3;
+    return n * mult;
+}
+
+function emptyBucket() {
+    return {
+        sessions: 0,
+        tokens_in: 0,
+        tokens_out: 0,
+        cache_read: 0,
+        cache_write: 0,
+        duration_ms: 0,
+        tool_calls: 0,
+        cost_usd: 0,
+        tts_chars: 0,
+        tts_audio_seconds: 0,
+        tts_cost_usd: 0,
+        tts_count: 0,
+    };
+}
+
+function addToBucket(b, evt) {
+    if (evt.event === 'session:end') {
+        b.sessions += 1;
+        b.tokens_in += Number(evt.tokens_in || 0);
+        b.tokens_out += Number(evt.tokens_out || 0);
+        b.cache_read += Number(evt.cache_read || 0);
+        b.cache_write += Number(evt.cache_write || 0);
+        b.duration_ms += Number(evt.duration_ms || 0);
+        b.tool_calls += Number(evt.tool_calls || 0);
+        b.cost_usd += estimateCostUsd(evt.model, evt);
+    } else if (evt.event === 'tts:generated') {
+        b.tts_chars += Number(evt.chars || 0);
+        b.tts_audio_seconds += Number(evt.audio_seconds || 0);
+        b.tts_cost_usd += Number(evt.cost_estimate_usd || 0);
+        b.tts_count += 1;
+    }
+}
+
+function withAvg(bucket) {
+    const avg_tokens = bucket.sessions > 0 ? Math.round((bucket.tokens_in + bucket.tokens_out + bucket.cache_read + bucket.cache_write) / bucket.sessions) : 0;
+    const avg_duration_ms = bucket.sessions > 0 ? Math.round(bucket.duration_ms / bucket.sessions) : 0;
+    return Object.assign({}, bucket, {
+        avg_tokens_per_session: avg_tokens,
+        avg_duration_ms,
+        cost_usd: Math.round(bucket.cost_usd * 10000) / 10000,
+        tts_cost_usd: Math.round(bucket.tts_cost_usd * 10000) / 10000,
+    });
+}
+
+async function buildSnapshot(options) {
+    options = options || {};
+    const windowMs = parseWindow(options.window);
+    const nowMs = Date.now();
+    const cutoffMs = windowMs ? nowMs - windowMs : null;
+
+    const byAgent = new Map();        // skill → bucket
+    const byPhase = new Map();        // phase → bucket
+    const byIssue = new Map();        // issue → { total: bucket, timeline, by_skill, tts_by_provider } (#2488)
+    const byProvider = new Map();     // provider → bucket (TTS)
+    const byAgentProvider = new Map();// `${skill}|${provider}` → bucket (TTS)
+    const byAgentMode = new Map();    // `${skill}|${mode}` → bucket (#2488 — LLM vs determinístico)
+    const dailySeries = new Map();    // YYYY-MM-DD → { cost_usd, tts_cost_usd, sessions } (para proyecciones)
+
+    let totalEvents = 0;
+    let v3Events = 0;
+
+    if (!fs.existsSync(LOG_FILE)) {
+        return emitEmptySnapshot(options);
+    }
+
+    const stream = fs.createReadStream(LOG_FILE, { encoding: 'utf8' });
+    const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+
+    for await (const line of rl) {
+        if (!line) continue;
+        totalEvents += 1;
+        let evt;
+        try { evt = JSON.parse(line); } catch (_) { continue; }
+        if (!evt || !evt.event) continue; // línea vieja (shape {ts, session, tool, target}) — ignorar
+        if (evt.event !== 'session:end' && evt.event !== 'tts:generated') continue;
+        v3Events += 1;
+
+        if (cutoffMs && evt.ts) {
+            const tsMs = Date.parse(evt.ts);
+            if (Number.isFinite(tsMs) && tsMs < cutoffMs) continue;
+        }
+
+        const skill = evt.skill || 'unknown';
+        const phase = evt.phase || 'unknown';
+        const issue = evt.issue || null;
+        const provider = evt.provider || null;
+        const mode = evt.event === 'session:end' ? classifyExecutionMode(evt.model) : null;
+
+        if (!byAgent.has(skill)) byAgent.set(skill, emptyBucket());
+        addToBucket(byAgent.get(skill), evt);
+
+        if (!byPhase.has(phase)) byPhase.set(phase, emptyBucket());
+        addToBucket(byPhase.get(phase), evt);
+
+        if (issue) {
+            if (!byIssue.has(issue)) byIssue.set(issue, {
+                total: emptyBucket(),
+                timeline: [],
+                by_skill: new Map(),        // skill → bucket (tokens/costo por skill dentro del issue)
+                tts_by_provider: new Map(), // provider → bucket (TTS por issue y provider)
+            });
+            const entry = byIssue.get(issue);
+            addToBucket(entry.total, evt);
+
+            if (!entry.by_skill.has(skill)) entry.by_skill.set(skill, emptyBucket());
+            addToBucket(entry.by_skill.get(skill), evt);
+
+            if (evt.event === 'tts:generated' && provider) {
+                if (!entry.tts_by_provider.has(provider)) entry.tts_by_provider.set(provider, emptyBucket());
+                addToBucket(entry.tts_by_provider.get(provider), evt);
+            }
+
+            entry.timeline.push({
+                event: evt.event,
+                skill,
+                phase,
+                ts: evt.ts,
+                tokens: evt.event === 'session:end' ? (Number(evt.tokens_in || 0) + Number(evt.tokens_out || 0)) : null,
+                cache: evt.event === 'session:end' ? (Number(evt.cache_read || 0) + Number(evt.cache_write || 0)) : null,
+                duration_ms: evt.event === 'session:end' ? Number(evt.duration_ms || 0) : null,
+                cost_usd: evt.event === 'session:end' ? estimateCostUsd(evt.model, evt) : Number(evt.cost_estimate_usd || 0),
+                tts_chars: evt.event === 'tts:generated' ? Number(evt.chars || 0) : null,
+                tts_audio_seconds: evt.event === 'tts:generated' ? Number(evt.audio_seconds || 0) : null,
+                model: evt.model || provider || null,
+                execution_mode: mode,
+            });
+        }
+
+        if (evt.event === 'tts:generated' && provider) {
+            if (!byProvider.has(provider)) byProvider.set(provider, emptyBucket());
+            addToBucket(byProvider.get(provider), evt);
+
+            const key = `${skill}|${provider}`;
+            if (!byAgentProvider.has(key)) byAgentProvider.set(key, emptyBucket());
+            addToBucket(byAgentProvider.get(key), evt);
+        }
+
+        if (evt.event === 'session:end' && mode) {
+            const key = `${skill}|${mode}`;
+            if (!byAgentMode.has(key)) byAgentMode.set(key, emptyBucket());
+            addToBucket(byAgentMode.get(key), evt);
+        }
+
+        // Serie temporal diaria para proyecciones (#2488)
+        if (evt.ts) {
+            const day = String(evt.ts).substring(0, 10); // YYYY-MM-DD
+            if (!dailySeries.has(day)) dailySeries.set(day, { cost_usd: 0, tts_cost_usd: 0, sessions: 0, tts_chars: 0, tts_audio_seconds: 0 });
+            const d = dailySeries.get(day);
+            if (evt.event === 'session:end') {
+                d.cost_usd += estimateCostUsd(evt.model, evt);
+                d.sessions += 1;
+            } else if (evt.event === 'tts:generated') {
+                d.tts_cost_usd += Number(evt.cost_estimate_usd || 0);
+                d.tts_chars += Number(evt.chars || 0);
+                d.tts_audio_seconds += Number(evt.audio_seconds || 0);
+            }
+        }
+    }
+
+    const agents = [...byAgent.entries()].map(([k, v]) => Object.assign({ skill: k }, withAvg(v)));
+    const phases = [...byPhase.entries()].map(([k, v]) => Object.assign({ phase: k }, withAvg(v)));
+
+    const issues = [...byIssue.entries()].map(([k, v]) => {
+        v.timeline.sort((a, b) => String(a.ts).localeCompare(String(b.ts)));
+        const bySkill = [...v.by_skill.entries()].map(([s, b]) => Object.assign({ skill: s }, withAvg(b)));
+        const ttsByProvider = [...v.tts_by_provider.entries()].map(([p, b]) => Object.assign({ provider: p }, withAvg(b)));
+        bySkill.sort((a, b) => b.cost_usd - a.cost_usd);
+        ttsByProvider.sort((a, b) => b.tts_cost_usd - a.tts_cost_usd);
+        return Object.assign({
+            issue: k,
+            timeline: v.timeline,
+            by_skill: bySkill,
+            tts_by_provider: ttsByProvider,
+        }, withAvg(v.total));
+    });
+
+    const tts = {
+        by_provider: [...byProvider.entries()].map(([k, v]) => Object.assign({ provider: k }, withAvg(v))),
+        by_agent: [...byAgentProvider.entries()].map(([k, v]) => {
+            const [skill, provider] = k.split('|');
+            return Object.assign({ skill, provider }, withAvg(v));
+        }),
+        // TTS por issue — ranking completo (#2488)
+        by_issue: issues
+            .filter(i => i.tts_chars > 0 || i.tts_audio_seconds > 0)
+            .map(i => ({
+                issue: i.issue,
+                tts_chars: i.tts_chars,
+                tts_audio_seconds: i.tts_audio_seconds,
+                tts_cost_usd: i.tts_cost_usd,
+                tts_count: i.tts_count,
+                by_provider: i.tts_by_provider,
+            }))
+            .sort((a, b) => b.tts_cost_usd - a.tts_cost_usd),
+    };
+
+    // Comparativa LLM vs determinístico (#2488)
+    const modeComparison = [...byAgentMode.entries()].map(([k, v]) => {
+        const [skill, execution_mode] = k.split('|');
+        return Object.assign({ skill, execution_mode }, withAvg(v));
+    });
+    // Para cada skill que tiene ambos modos, calcular % de ahorro cuando det > 0
+    const modeBySkill = {};
+    for (const row of modeComparison) {
+        modeBySkill[row.skill] = modeBySkill[row.skill] || {};
+        modeBySkill[row.skill][row.execution_mode] = row;
+    }
+    const llmVsDeterministic = Object.entries(modeBySkill).map(([skill, byMode]) => {
+        const llm = byMode.llm || null;
+        const det = byMode.deterministic || null;
+        const llmAvgCost = llm && llm.sessions > 0 ? llm.cost_usd / llm.sessions : 0;
+        const detSessions = det ? det.sessions : 0;
+        const savingsUsd = Math.round(detSessions * llmAvgCost * 10000) / 10000;
+        return {
+            skill,
+            llm_sessions: llm ? llm.sessions : 0,
+            llm_cost_usd: llm ? llm.cost_usd : 0,
+            llm_avg_cost_per_session: Math.round(llmAvgCost * 10000) / 10000,
+            deterministic_sessions: detSessions,
+            deterministic_cost_usd: det ? det.cost_usd : 0,
+            estimated_savings_usd: savingsUsd,
+            migrated: !!det && detSessions > 0,
+        };
+    }).sort((a, b) => b.estimated_savings_usd - a.estimated_savings_usd);
+
+    // Rankings
+    agents.sort((a, b) => b.cost_usd - a.cost_usd);
+    phases.sort((a, b) => b.cost_usd - a.cost_usd);
+    issues.sort((a, b) => b.cost_usd - a.cost_usd);
+    tts.by_provider.sort((a, b) => b.tts_cost_usd - a.tts_cost_usd);
+    tts.by_agent.sort((a, b) => b.tts_cost_usd - a.tts_cost_usd);
+
+    // Serie diaria ordenada (para proyecciones)
+    const daily = [...dailySeries.entries()]
+        .map(([day, d]) => ({ day, ...d, cost_usd: Math.round(d.cost_usd * 10000) / 10000, tts_cost_usd: Math.round(d.tts_cost_usd * 10000) / 10000 }))
+        .sort((a, b) => a.day.localeCompare(b.day));
+
+    const projections = computeProjections({ daily, now: new Date(nowMs) });
+
+    return {
+        generated_at: new Date().toISOString(),
+        window: options.window || 'all',
+        cutoff_ts: cutoffMs ? new Date(cutoffMs).toISOString() : null,
+        totals: {
+            sessions: agents.reduce((s, a) => s + a.sessions, 0),
+            tokens_in: agents.reduce((s, a) => s + a.tokens_in, 0),
+            tokens_out: agents.reduce((s, a) => s + a.tokens_out, 0),
+            cache_read: agents.reduce((s, a) => s + a.cache_read, 0),
+            cache_write: agents.reduce((s, a) => s + a.cache_write, 0),
+            cost_usd: Math.round(agents.reduce((s, a) => s + a.cost_usd, 0) * 10000) / 10000,
+            tts_chars: agents.reduce((s, a) => s + a.tts_chars, 0),
+            tts_audio_seconds: Math.round(agents.reduce((s, a) => s + a.tts_audio_seconds, 0) * 10) / 10,
+            tts_cost_usd: Math.round(agents.reduce((s, a) => s + a.tts_cost_usd, 0) * 10000) / 10000,
+            v3_events: v3Events,
+            total_log_lines: totalEvents,
+        },
+        agents,
+        phases,
+        issues,
+        tts,
+        llm_vs_deterministic: llmVsDeterministic,
+        daily,
+        projections,
+        pricing: MODEL_PRICING,
+    };
+}
+
+function emitEmptySnapshot(options) {
+    return {
+        generated_at: new Date().toISOString(),
+        window: (options && options.window) || 'all',
+        cutoff_ts: null,
+        totals: emptyBucket(),
+        agents: [], phases: [], issues: [],
+        tts: { by_provider: [], by_agent: [], by_issue: [] },
+        llm_vs_deterministic: [],
+        daily: [],
+        projections: computeProjections({ daily: [], now: new Date() }),
+        pricing: MODEL_PRICING,
+    };
+}
+
+function writeSnapshot(snap) {
+    ensureDir(METRICS_DIR);
+    const tmp = SNAPSHOT_FILE + '.tmp';
+    fs.writeFileSync(tmp, JSON.stringify(snap, null, 2), 'utf8');
+    fs.renameSync(tmp, SNAPSHOT_FILE);
+}
+
+async function runOnce(options) {
+    const snap = await buildSnapshot(options);
+    writeSnapshot(snap);
+    return snap;
+}
+
+function parseArgs(argv) {
+    const args = { once: false, window: 'all', refreshMs: DEFAULT_REFRESH_MS };
+    for (let i = 2; i < argv.length; i++) {
+        const a = argv[i];
+        if (a === '--once') args.once = true;
+        else if (a === '--window' && argv[i + 1]) { args.window = argv[++i]; }
+        else if (a === '--refresh' && argv[i + 1]) { args.refreshMs = Math.max(5000, parseInt(argv[++i], 10) || DEFAULT_REFRESH_MS); }
+        else if (a === '--help' || a === '-h') {
+            process.stdout.write('Uso: aggregator.js [--once] [--window 1h|24h|7d|all] [--refresh ms]\n');
+            process.exit(0);
+        }
+    }
+    return args;
+}
+
+async function main() {
+    const args = parseArgs(process.argv);
+    if (args.once) {
+        const snap = await runOnce(args);
+        process.stdout.write(`[aggregator] snapshot window=${args.window} sessions=${snap.totals.sessions || 0} cost=$${(snap.totals.cost_usd || 0).toFixed(4)} tts=$${(snap.totals.tts_cost_usd || 0).toFixed(4)}\n`);
+        return;
+    }
+    let busy = false;
+    async function tick() {
+        if (busy) return;
+        busy = true;
+        try {
+            const snap = await runOnce(args);
+            process.stdout.write(`[aggregator] ${new Date().toISOString()} ventana=${args.window} sesiones=${snap.totals.sessions || 0} costo=$${(snap.totals.cost_usd || 0).toFixed(4)}\n`);
+        } catch (e) {
+            process.stderr.write(`[aggregator] error: ${e.message}\n`);
+        } finally { busy = false; }
+    }
+    await tick();
+    setInterval(tick, args.refreshMs);
+}
+
+if (require.main === module) {
+    main().catch(e => { process.stderr.write(e.stack + '\n'); process.exit(1); });
+}
+
+module.exports = { buildSnapshot, runOnce, writeSnapshot, classifyExecutionMode, SNAPSHOT_FILE, METRICS_DIR };

--- a/.pipeline/metrics/projections.js
+++ b/.pipeline/metrics/projections.js
@@ -1,0 +1,150 @@
+// V3 Metrics — Proyecciones de consumo (tokens + TTS) (#2488)
+// Calcula promedios diarios, proyecciones semanales/mensuales y detección de desvío vs cuota.
+//
+// Input: serie temporal diaria ordenada [{ day: 'YYYY-MM-DD', cost_usd, tts_cost_usd, sessions, tts_chars, tts_audio_seconds }]
+// Output: objeto con proyecciones y alertas por dimensión (tokens/TTS).
+
+'use strict';
+
+// Cuotas por defecto — override con env vars si el usuario maneja plan Max/etc.
+const DEFAULT_MONTHLY_TOKEN_USD = Number(process.env.METRICS_QUOTA_MONTHLY_USD || 100);
+const DEFAULT_MONTHLY_TTS_USD   = Number(process.env.METRICS_QUOTA_TTS_MONTHLY_USD || 10);
+
+// Cuántos días recientes se usan para el promedio (ignora días muy viejos para reflejar tendencia actual)
+const DEFAULT_WINDOW_DAYS = 7;
+
+function daysInMonth(date) {
+    return new Date(date.getFullYear(), date.getMonth() + 1, 0).getDate();
+}
+
+function startOfMonth(date) {
+    return new Date(date.getFullYear(), date.getMonth(), 1);
+}
+
+function daysElapsedThisMonth(date) {
+    return date.getDate();
+}
+
+function daysRemainingThisMonth(date) {
+    return daysInMonth(date) - daysElapsedThisMonth(date);
+}
+
+function daysRemainingThisWeek(date) {
+    // 0 = domingo, 6 = sábado. Queremos días restantes hasta fin de semana (lunes a domingo).
+    const dow = date.getDay();
+    return dow === 0 ? 0 : 7 - dow;
+}
+
+function round(n, d) {
+    const mult = Math.pow(10, d || 4);
+    return Math.round(n * mult) / mult;
+}
+
+// Promedio diario usando los últimos N días que efectivamente aparecen en la serie.
+// Si la serie es más corta que windowDays, divide por los días que haya (no subestima).
+function dailyAverage(series, field, windowDays) {
+    if (!series || series.length === 0) return 0;
+    const take = Math.min(windowDays, series.length);
+    const recent = series.slice(-take);
+    const sum = recent.reduce((s, d) => s + Number(d[field] || 0), 0);
+    return sum / take;
+}
+
+// Suma del mes actual (para saber cuánto llevamos gastado)
+function monthToDate(series, field, now) {
+    if (!series || series.length === 0) return 0;
+    const mStart = startOfMonth(now).toISOString().substring(0, 10);
+    return series
+        .filter(d => d.day >= mStart)
+        .reduce((s, d) => s + Number(d[field] || 0), 0);
+}
+
+function buildDimension({ series, costField, quotaUsd, now, label, secondaryFields }) {
+    const avgDaily = dailyAverage(series, costField, DEFAULT_WINDOW_DAYS);
+    const weeklyProj = avgDaily * 7;
+    const monthlyProj = avgDaily * daysInMonth(now);
+
+    const monthToDateUsd = monthToDate(series, costField, now);
+    const daysLeftMonth = daysRemainingThisMonth(now);
+    // Proyección del cierre de mes = gastado hoy + (promedio_diario × días_que_quedan)
+    const monthlyForecast = monthToDateUsd + (avgDaily * daysLeftMonth);
+
+    const overQuota = monthlyForecast > quotaUsd;
+    const quotaDeltaUsd = round(monthlyForecast - quotaUsd, 4);
+    const quotaRatio = quotaUsd > 0 ? round(monthlyForecast / quotaUsd, 3) : null;
+
+    const secondary = {};
+    if (Array.isArray(secondaryFields)) {
+        for (const f of secondaryFields) {
+            secondary[f + '_daily_avg'] = round(dailyAverage(series, f, DEFAULT_WINDOW_DAYS), 2);
+            secondary[f + '_weekly_projection'] = round(dailyAverage(series, f, DEFAULT_WINDOW_DAYS) * 7, 2);
+            secondary[f + '_monthly_projection'] = round(dailyAverage(series, f, DEFAULT_WINDOW_DAYS) * daysInMonth(now), 2);
+            secondary[f + '_month_to_date'] = round(monthToDate(series, f, now), 2);
+        }
+    }
+
+    return Object.assign({
+        dimension: label,
+        window_days: DEFAULT_WINDOW_DAYS,
+        samples: Math.min(series.length, DEFAULT_WINDOW_DAYS),
+        daily_avg_usd: round(avgDaily, 4),
+        weekly_projection_usd: round(weeklyProj, 4),
+        monthly_projection_usd: round(monthlyProj, 4),
+        month_to_date_usd: round(monthToDateUsd, 4),
+        monthly_forecast_usd: round(monthlyForecast, 4),
+        days_elapsed_this_month: daysElapsedThisMonth(now),
+        days_remaining_this_month: daysLeftMonth,
+        days_remaining_this_week: daysRemainingThisWeek(now),
+        quota: {
+            monthly_usd: quotaUsd,
+            forecast_usd: round(monthlyForecast, 4),
+            delta_usd: quotaDeltaUsd,
+            ratio: quotaRatio,
+            status: overQuota ? 'over' : (quotaRatio !== null && quotaRatio > 0.9 ? 'warning' : 'ok'),
+            alert: overQuota
+                ? `Proyección supera la cuota por $${Math.abs(quotaDeltaUsd).toFixed(2)} USD (${Math.round((quotaRatio || 0) * 100)}% de la cuota mensual)`
+                : null,
+        },
+    }, secondary);
+}
+
+function computeProjections(opts) {
+    opts = opts || {};
+    const series = Array.isArray(opts.daily) ? opts.daily : [];
+    const now = opts.now instanceof Date ? opts.now : new Date();
+    const quotas = opts.quotas || {};
+    const monthlyTokenQuota = Number(quotas.monthly_token_usd !== undefined ? quotas.monthly_token_usd : DEFAULT_MONTHLY_TOKEN_USD);
+    const monthlyTtsQuota   = Number(quotas.monthly_tts_usd   !== undefined ? quotas.monthly_tts_usd   : DEFAULT_MONTHLY_TTS_USD);
+
+    return {
+        generated_at: now.toISOString(),
+        tokens: buildDimension({
+            series,
+            costField: 'cost_usd',
+            quotaUsd: monthlyTokenQuota,
+            now,
+            label: 'tokens',
+            secondaryFields: ['sessions'],
+        }),
+        tts: buildDimension({
+            series,
+            costField: 'tts_cost_usd',
+            quotaUsd: monthlyTtsQuota,
+            now,
+            label: 'tts',
+            secondaryFields: ['tts_chars', 'tts_audio_seconds'],
+        }),
+    };
+}
+
+module.exports = {
+    computeProjections,
+    dailyAverage,
+    daysInMonth,
+    daysRemainingThisMonth,
+    daysRemainingThisWeek,
+    monthToDate,
+    DEFAULT_MONTHLY_TOKEN_USD,
+    DEFAULT_MONTHLY_TTS_USD,
+    DEFAULT_WINDOW_DAYS,
+};

--- a/.pipeline/metrics/report-daily.js
+++ b/.pipeline/metrics/report-daily.js
@@ -1,0 +1,210 @@
+#!/usr/bin/env node
+// V3 Metrics Daily Report — genera PDF con top consumos del día y lo envía por Telegram.
+// Contrato definido en issue #2477.
+//
+// Uso:
+//   node .pipeline/metrics/report-daily.js                 → ventana 24h, envía a Telegram
+//   node .pipeline/metrics/report-daily.js --dry           → genera HTML+PDF sin enviar
+//   node .pipeline/metrics/report-daily.js --window 7d     → ventana custom
+//
+// Dependencias: reutiliza scripts/report-to-pdf-telegram.js (pipeline unificado HTML→PDF→Telegram).
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+const { buildSnapshot } = require('./aggregator');
+const { REPO_ROOT } = require('../lib/traceability');
+
+const DOCS_QA_DIR = path.join(REPO_ROOT, 'docs', 'qa');
+const REPORT_SCRIPT = path.join(REPO_ROOT, 'scripts', 'report-to-pdf-telegram.js');
+
+function parseArgs(argv) {
+    const args = { window: '24h', prevWindow: '24h', dry: false };
+    for (let i = 2; i < argv.length; i++) {
+        const a = argv[i];
+        if (a === '--dry' || a === '--dry-run') args.dry = true;
+        else if (a === '--window' && argv[i + 1]) args.window = argv[++i];
+        else if (a === '--help' || a === '-h') {
+            process.stdout.write('Uso: report-daily.js [--window 24h|7d|all] [--dry]\n');
+            process.exit(0);
+        }
+    }
+    return args;
+}
+
+function fmtUsd(n) {
+    const v = Number(n || 0);
+    return '$' + v.toFixed(4);
+}
+function fmtNum(n) {
+    const v = Number(n || 0);
+    if (v >= 1e6) return (v / 1e6).toFixed(2) + 'M';
+    if (v >= 1e3) return (v / 1e3).toFixed(1) + 'K';
+    return String(Math.round(v));
+}
+function fmtDur(ms) {
+    const s = Math.round((ms || 0) / 1000);
+    if (s < 60) return s + 's';
+    const m = Math.floor(s / 60);
+    const rem = s % 60;
+    if (m < 60) return m + 'm ' + rem + 's';
+    const h = Math.floor(m / 60);
+    return h + 'h ' + (m % 60) + 'm';
+}
+function esc(s) { return String(s == null ? '' : s).replace(/[&<>]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' }[c])); }
+
+function trendArrow(current, previous) {
+    if (!previous || previous === 0) return '—';
+    const delta = (current - previous) / previous * 100;
+    if (Math.abs(delta) < 1) return '→ 0%';
+    const sign = delta > 0 ? '▲' : '▼';
+    return `${sign} ${Math.abs(delta).toFixed(0)}%`;
+}
+
+function renderHtml({ snapshot, prev, window, generatedAt }) {
+    const top5Agents = (snapshot.agents || []).slice(0, 5);
+    const top5Issues = (snapshot.issues || []).slice(0, 5);
+    const ttsByProvider = (snapshot.tts && snapshot.tts.by_provider) || [];
+
+    const t = snapshot.totals || {};
+    const pt = (prev && prev.totals) || {};
+
+    const rowsAgents = top5Agents.map(a => `
+        <tr>
+            <td class="skill">${esc(a.skill)}</td>
+            <td class="num">${fmtNum(a.sessions)}</td>
+            <td class="num">${fmtNum(a.tokens_in + a.tokens_out)}</td>
+            <td class="num">${fmtNum(a.cache_read + a.cache_write)}</td>
+            <td class="num">${fmtDur(a.avg_duration_ms)}</td>
+            <td class="usd">${fmtUsd(a.cost_usd)}</td>
+        </tr>`).join('');
+
+    const rowsIssues = top5Issues.map(i => `
+        <tr>
+            <td class="issue">#${esc(i.issue)}</td>
+            <td class="num">${fmtNum(i.sessions)}</td>
+            <td class="num">${fmtNum(i.tokens_in + i.tokens_out)}</td>
+            <td class="num">${fmtDur(i.duration_ms)}</td>
+            <td class="usd">${fmtUsd(i.cost_usd)}</td>
+        </tr>`).join('');
+
+    const rowsTts = ttsByProvider.map(p => `
+        <tr>
+            <td class="skill">${esc(p.provider)}</td>
+            <td class="num">${fmtNum(p.tts_count)}</td>
+            <td class="num">${fmtNum(p.tts_chars)}</td>
+            <td class="num">${(p.tts_audio_seconds / 60).toFixed(1)} min</td>
+            <td class="usd">${fmtUsd(p.tts_cost_usd)}</td>
+        </tr>`).join('');
+
+    return `<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<title>Reporte diario V3 — Consumo Pipeline</title>
+<style>
+    body { font-family: -apple-system, 'Segoe UI', sans-serif; color: #1a1a2e; padding: 24px; max-width: 900px; margin: 0 auto; }
+    h1 { color: #16213e; border-bottom: 3px solid #0f3460; padding-bottom: 8px; margin-bottom: 4px; }
+    .subtitle { color: #666; font-size: 13px; margin-bottom: 24px; }
+    h2 { color: #0f3460; margin-top: 28px; border-left: 4px solid #0f3460; padding-left: 10px; }
+    .totals { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; margin: 16px 0; }
+    .kpi { background: #f4f6fb; padding: 12px; border-radius: 6px; }
+    .kpi .label { font-size: 11px; color: #666; text-transform: uppercase; letter-spacing: 0.5px; }
+    .kpi .value { font-size: 20px; font-weight: 700; color: #0f3460; margin-top: 4px; }
+    .kpi .trend { font-size: 12px; margin-top: 4px; color: #888; }
+    table { width: 100%; border-collapse: collapse; margin: 10px 0; font-size: 13px; }
+    th { background: #0f3460; color: white; text-align: left; padding: 8px 10px; }
+    td { padding: 8px 10px; border-bottom: 1px solid #eee; }
+    td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
+    td.usd { text-align: right; font-weight: 600; color: #0f3460; font-variant-numeric: tabular-nums; }
+    td.skill, td.issue { font-weight: 600; }
+    tr:nth-child(even) { background: #fafbfd; }
+    .footer { margin-top: 32px; padding-top: 12px; border-top: 1px solid #ddd; font-size: 11px; color: #888; }
+</style>
+</head>
+<body>
+    <h1>Reporte diario V3 — Consumo del pipeline</h1>
+    <div class="subtitle">Ventana: <b>${esc(window)}</b> · Generado: ${esc(generatedAt)}</div>
+
+    <div class="totals">
+        <div class="kpi"><div class="label">Sesiones</div><div class="value">${fmtNum(t.sessions)}</div><div class="trend">vs previo: ${trendArrow(t.sessions, pt.sessions)}</div></div>
+        <div class="kpi"><div class="label">Tokens in+out</div><div class="value">${fmtNum((t.tokens_in || 0) + (t.tokens_out || 0))}</div><div class="trend">vs previo: ${trendArrow((t.tokens_in||0)+(t.tokens_out||0), (pt.tokens_in||0)+(pt.tokens_out||0))}</div></div>
+        <div class="kpi"><div class="label">Costo estimado</div><div class="value">${fmtUsd(t.cost_usd)}</div><div class="trend">vs previo: ${trendArrow(t.cost_usd, pt.cost_usd)}</div></div>
+        <div class="kpi"><div class="label">TTS (costo)</div><div class="value">${fmtUsd(t.tts_cost_usd)}</div><div class="trend">${fmtNum(t.tts_chars)} chars · ${((t.tts_audio_seconds||0)/60).toFixed(1)}min</div></div>
+    </div>
+
+    <h2>Top 5 agentes por costo</h2>
+    <table>
+        <thead><tr><th>Skill</th><th class="num">Sesiones</th><th class="num">Tokens</th><th class="num">Cache</th><th class="num">Dur. prom</th><th class="num">Costo</th></tr></thead>
+        <tbody>${rowsAgents || '<tr><td colspan="6" style="text-align:center; color:#888;">Sin datos en la ventana</td></tr>'}</tbody>
+    </table>
+
+    <h2>Top 5 issues más caros</h2>
+    <table>
+        <thead><tr><th>Issue</th><th class="num">Sesiones</th><th class="num">Tokens</th><th class="num">Duración total</th><th class="num">Costo</th></tr></thead>
+        <tbody>${rowsIssues || '<tr><td colspan="5" style="text-align:center; color:#888;">Sin datos en la ventana</td></tr>'}</tbody>
+    </table>
+
+    <h2>TTS por provider</h2>
+    <table>
+        <thead><tr><th>Provider</th><th class="num">Invocaciones</th><th class="num">Chars</th><th class="num">Audio</th><th class="num">Costo</th></tr></thead>
+        <tbody>${rowsTts || '<tr><td colspan="5" style="text-align:center; color:#888;">Sin TTS registrado</td></tr>'}</tbody>
+    </table>
+
+    <div class="footer">
+        Generado por <code>.pipeline/metrics/report-daily.js</code> · Schema V3 definido en issue #2477.<br>
+        Costos: estimaciones basadas en pricing público por modelo (ver <code>lib/traceability.js</code> → MODEL_PRICING).
+    </div>
+</body>
+</html>`;
+}
+
+function sendToTelegram(htmlPath, caption) {
+    if (!fs.existsSync(REPORT_SCRIPT)) {
+        process.stderr.write(`[report-daily] script de envío no encontrado: ${REPORT_SCRIPT}\n`);
+        return false;
+    }
+    const html = fs.readFileSync(htmlPath, 'utf8');
+    const r = spawnSync('node', [REPORT_SCRIPT, '--stdin', caption], {
+        input: html,
+        encoding: 'utf8',
+        cwd: REPO_ROOT,
+        windowsHide: true,
+    });
+    if (r.stdout) process.stdout.write(r.stdout);
+    if (r.stderr) process.stderr.write(r.stderr);
+    return r.status === 0;
+}
+
+async function main() {
+    const args = parseArgs(process.argv);
+
+    const snapshot = await buildSnapshot({ window: args.window });
+    const prev = null; // TODO futuro: calcular ventana previa equivalente. Hoy trendArrow cae a '—' sin pt.
+
+    const generatedAt = new Date().toISOString();
+    const html = renderHtml({ snapshot, prev, window: args.window, generatedAt });
+
+    const dateTag = generatedAt.slice(0, 10);
+    try { fs.mkdirSync(DOCS_QA_DIR, { recursive: true }); } catch (_) {}
+    const htmlPath = path.join(DOCS_QA_DIR, `reporte-consumo-v3-${dateTag}.html`);
+    fs.writeFileSync(htmlPath, html, 'utf8');
+    process.stdout.write(`[report-daily] HTML: ${htmlPath}\n`);
+    process.stdout.write(`[report-daily] Totales ${args.window}: sesiones=${snapshot.totals.sessions || 0} costo=${fmtUsd(snapshot.totals.cost_usd)} tts=${fmtUsd(snapshot.totals.tts_cost_usd)}\n`);
+
+    if (args.dry) {
+        process.stdout.write('[report-daily] --dry: no se envía a Telegram\n');
+        return 0;
+    }
+
+    const ok = sendToTelegram(htmlPath, `📊 Reporte diario V3 — Consumo ${args.window} (${dateTag})`);
+    return ok ? 0 : 1;
+}
+
+if (require.main === module) {
+    main().then(code => process.exit(code || 0)).catch(e => { process.stderr.write(e.stack + '\n'); process.exit(1); });
+}
+
+module.exports = { renderHtml };


### PR DESCRIPTION
## Resumen

Extiende el endpoint de métricas V3 con tres tabs nuevas en `/metrics-v3` (alias `/consumo`):

- **LLM vs Determinístico** — duración media/p95 y % de ahorro de tokens por skill
- **TTS por issue** — caracteres y segundos sintetizados con breakdown por provider
- **Proyecciones** — forecast tokens/TTS semanal y mensual, cuotas y alertas de desvío

## Cambios

- `.pipeline/metrics/aggregator.js` — extiende snapshot V3 con `llm_vs_deterministic`, `tts.by_issue` (por provider) y `daily` series
- `.pipeline/metrics/projections.js` — nuevo módulo: `dailyAverage`, `monthToDate`, `computeProjections` con status `ok` / `warning` / `over`
- `.pipeline/metrics/report-daily.js` — script standalone de reporte diario
- `.pipeline/dashboard-v2.js` — 3 tabs nuevas, 3 endpoints JSON (`/projections`, `/llm-vs-deterministic`, `/daily`) + alias `/metrics-v3`
- `.gitignore` — commitea el código fuente del aggregator, mantiene ignorados `snapshot.json` y `.last-cleanup`

## Tests

24 tests determinísticos — todos pasan:

- 9 tests aggregator (LLM vs determinístico, daily series, TTS por issue/provider)
- 15 tests projections (forecast, cuotas OK/warning/over, ventanas, edge cases)

## Test plan

- [x] `node --test .pipeline/metrics/__tests__/aggregator.test.js` → 9/9
- [x] `node --test .pipeline/metrics/__tests__/projections.test.js` → 15/15
- [ ] Verificación manual del endpoint `/metrics-v3` en el dashboard tras merge

Closes #2488

🤖 Generated with [Claude Code](https://claude.com/claude-code)