### PR TITLE
feat(pipeline): pausa parcial con allowlist de issues (#2490)

### DIFF
--- a/.pipeline/dashboard-v2.js
+++ b/.pipeline/dashboard-v2.js
@@ -920,6 +920,14 @@ function generateHTML(state) {
   try { const lr = JSON.parse(fs.readFileSync(path.join(PIPELINE, 'last-restart.json'), 'utf8')); if (lr.timestamp) { const ms = Date.now() - new Date(lr.timestamp).getTime(); const h = Math.floor(ms / 3600000); const m = Math.floor((ms % 3600000) / 60000); pulpoUptime = h > 0 ? h + 'h ' + m + 'm' : m + 'm'; } } catch {}
   const isPaused = fs.existsSync(path.join(PIPELINE, '.paused'));
 
+  // #2490 — Pausa parcial (allowlist de issues)
+  let partialPauseState = { mode: 'running', allowedIssues: [] };
+  try {
+    const pp = require('./lib/partial-pause');
+    partialPauseState = pp.getPipelineMode();
+  } catch {}
+  const isPartialPause = partialPauseState.mode === 'partial_pause';
+
   // V3 detection: workers determinísticos en .pipeline/workers/*.js
   let v3Workers = [];
   try {
@@ -3713,7 +3721,8 @@ a.skill-recent-item:hover{background:var(--bd2);color:var(--ac)}
       <h1 class="hdr-title">🐙 Pipeline ${v3Active ? 'V2+V3' : 'V2'}</h1>
       ${v3Active ? `<span class="hdr-v3-badge" title="V3 activo · workers determinísticos: ${v3Workers.join(', ')}">⚙ V3 (${v3Workers.length})</span>` : ''}
       <a href="/consumo" class="hdr-v3-badge" style="text-decoration:none;cursor:pointer;" title="V3 · Consumo de tokens / tiempo / TTS por agente, fase e issue (#2477)">📊 Consumo</a>
-      <button class="hdr-status-badge ${isPaused ? 'badge-paused' : 'badge-running'}" onclick="pauseAction('${isPaused ? 'resume' : 'pause'}')" title="${isPaused ? 'Pipeline pausado — click para reanudar' : 'Click para pausar el pipeline'}">${isPaused ? '⏸ PAUSADO' : '▶ RUNNING'}</button>
+      <button class="hdr-status-badge ${isPaused ? 'badge-paused' : isPartialPause ? 'badge-paused' : 'badge-running'}" onclick="pauseAction('${isPaused || isPartialPause ? 'resume' : 'pause'}')" title="${isPaused ? 'Pipeline pausado — click para reanudar' : isPartialPause ? 'Pausa parcial — click para reanudar completo' : 'Click para pausar el pipeline'}">${isPaused ? '⏸ PAUSADO' : isPartialPause ? `⏸ PARCIAL (${partialPauseState.allowedIssues.length})` : '▶ RUNNING'}</button>
+      ${isPartialPause ? `<span class="hdr-v3-badge" title="Pausa parcial — solo estos issues procesan" style="background:rgba(240,165,0,0.15);color:#f0a500;border-color:rgba(240,165,0,0.4);">🎯 ${partialPauseState.allowedIssues.map(i => '#' + i).join(', ')}</span>` : ''}
       <button id="autorefresh-btn" class="badge-autorefresh ar-off" onclick="toggleAutoRefresh()" title="Auto-refresh desactivado — click para activar">↻ AUTO</button>
       <span class="hdr-uptime">UP ${pulpoUptime}</span>
       <span class="hdr-meta">📊 ${dashboardBuild}<span class="hdr-meta-sep">|</span>🐙 ${pulpoBuild}</span>
@@ -3742,6 +3751,10 @@ a.skill-recent-item:hover{background:var(--bd2);color:var(--ac)}
     } else if (isPaused) {
       statusHtml = '<span class="ctrl-bar-status"><span class="ctrl-bar-status-icon">\u23F8\uFE0F</span>Pipeline en pausa</span>'
         + '<button class="ctrl-bar-btn" onclick="pauseAction(\'resume\')" title="Reanudar lanzamientos">\u25B6 Reanudar</button>';
+    } else if (isPartialPause) {
+      const allowedList = partialPauseState.allowedIssues.map(i => '#' + i).join(', ');
+      statusHtml = '<span class="ctrl-bar-status"><span class="ctrl-bar-status-icon">\u{1F3AF}</span>Pausa parcial \u00B7 allowed: ' + allowedList + '</span>'
+        + '<button class="ctrl-bar-btn" onclick="pauseAction(\'resume\')" title="Desactivar pausa parcial y reanudar todo">\u25B6 Reanudar</button>';
     } else if (qaActive) {
       const elapsed = pw.qa.activatedAt ? Math.round((Date.now() - pw.qa.activatedAt) / 60000) : 0;
       statusHtml = '<span class="ctrl-bar-status"><span class="ctrl-bar-status-icon">\u{1F50D}</span>Ventana QA activa \u00B7 ' + elapsed + ' min</span>'
@@ -6101,7 +6114,12 @@ const server = http.createServer((req, res) => {
         const { action } = JSON.parse(body);
         const pauseFile = path.join(PIPELINE, '.paused');
         if (action === 'resume' || action === 'remove') {
+          // #2490 — resume limpia tanto pausa completa como parcial
           try { fs.unlinkSync(pauseFile); } catch {}
+          try {
+            const { resumeAll } = require('./lib/partial-pause');
+            resumeAll();
+          } catch {}
           log(`Pausa eliminada por dashboard (${action})`);
           res.writeHead(200, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ ok: true, msg: 'Pipeline reanudado — lanzamientos activos' }));
@@ -6114,6 +6132,40 @@ const server = http.createServer((req, res) => {
           res.writeHead(400, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ ok: false, msg: `Acción "${action}" no válida` }));
         }
+      } catch (e) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ ok: false, msg: e.message }));
+      }
+    });
+    return;
+  }
+
+  // API: #2490 — Pausa parcial con allowlist de issues
+  if (req.url === '/api/pause-partial' && req.method === 'POST') {
+    let body = '';
+    req.on('data', chunk => { body += chunk; });
+    req.on('end', () => {
+      try {
+        const { issues } = JSON.parse(body || '{}');
+        const { setPartialPause, clearPartialPause, getPipelineMode } = require('./lib/partial-pause');
+        const list = Array.isArray(issues) ? issues : [];
+        if (list.length === 0) {
+          clearPartialPause();
+          log('Pausa parcial eliminada desde dashboard');
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ ok: true, msg: 'Pausa parcial desactivada', mode: 'running' }));
+          return;
+        }
+        const result = setPartialPause(list, { source: 'dashboard' });
+        const state = getPipelineMode();
+        log(`Pausa parcial activada desde dashboard (${result.allowedIssues.join(',')})`);
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          ok: true,
+          msg: result.msg,
+          mode: state.mode,
+          allowedIssues: state.allowedIssues,
+        }));
       } catch (e) {
         res.writeHead(400, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({ ok: false, msg: e.message }));

--- a/.pipeline/lib/__tests__/partial-pause.test.js
+++ b/.pipeline/lib/__tests__/partial-pause.test.js
@@ -1,0 +1,161 @@
+// Tests de .pipeline/lib/partial-pause.js (issue #2490)
+// Valida precedencia paused > partial_pause > running, allowlist, y normalización.
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+// Aislar el módulo a un tmp dir
+const TMP_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'v3-partial-pause-'));
+process.env.PIPELINE_DIR_OVERRIDE = TMP_DIR;
+
+delete require.cache[require.resolve('../partial-pause')];
+const pp = require('../partial-pause');
+
+function resetFs() {
+    const { PARTIAL_FILE, PAUSE_FILE } = pp._paths();
+    try { fs.unlinkSync(PARTIAL_FILE); } catch {}
+    try { fs.unlinkSync(PAUSE_FILE); } catch {}
+}
+
+test('getPipelineMode retorna running cuando no hay ningún marker', () => {
+    resetFs();
+    const state = pp.getPipelineMode();
+    assert.equal(state.mode, 'running');
+    assert.deepEqual(state.allowedIssues, []);
+});
+
+test('isIssueAllowed retorna true para cualquier issue cuando pipeline está running', () => {
+    resetFs();
+    assert.equal(pp.isIssueAllowed(2490), true);
+    assert.equal(pp.isIssueAllowed('2491'), true);
+    assert.equal(pp.isIssueAllowed('#9999'), true);
+});
+
+test('setPartialPause con [2490, 2491] activa partial_pause', () => {
+    resetFs();
+    const result = pp.setPartialPause([2490, 2491], { source: 'telegram' });
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.allowedIssues, [2490, 2491]);
+
+    const state = pp.getPipelineMode();
+    assert.equal(state.mode, 'partial_pause');
+    assert.deepEqual(state.allowedIssues, [2490, 2491]);
+    assert.equal(state.source, 'telegram');
+    assert.ok(state.createdAt);
+});
+
+test('isIssueAllowed respeta allowlist en modo partial_pause', () => {
+    resetFs();
+    pp.setPartialPause([2490, 2491]);
+    assert.equal(pp.isIssueAllowed(2490), true);
+    assert.equal(pp.isIssueAllowed(2491), true);
+    assert.equal(pp.isIssueAllowed(2500), false);
+    assert.equal(pp.isIssueAllowed('#2490'), true);
+    assert.equal(pp.isIssueAllowed('9999'), false);
+});
+
+test('setPartialPause normaliza strings, "#prefix" y descarta valores inválidos', () => {
+    resetFs();
+    const result = pp.setPartialPause(['#2490', '2491', 'abc', 0, -5, null, '  2492 '], { source: 'test' });
+    assert.deepEqual(result.allowedIssues, [2490, 2491, 2492]);
+});
+
+test('setPartialPause deduplica y ordena', () => {
+    resetFs();
+    const result = pp.setPartialPause([2491, 2490, 2491, 2490, 2492]);
+    assert.deepEqual(result.allowedIssues, [2490, 2491, 2492]);
+});
+
+test('setPartialPause con lista vacía elimina el marker', () => {
+    resetFs();
+    pp.setPartialPause([2490]);
+    assert.equal(pp.getPipelineMode().mode, 'partial_pause');
+
+    const result = pp.setPartialPause([]);
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.allowedIssues, []);
+    assert.equal(pp.getPipelineMode().mode, 'running');
+});
+
+test('clearPartialPause elimina el marker y reporta si existía', () => {
+    resetFs();
+    pp.setPartialPause([2490]);
+    const r1 = pp.clearPartialPause();
+    assert.equal(r1.existed, true);
+    assert.equal(pp.getPipelineMode().mode, 'running');
+
+    const r2 = pp.clearPartialPause();
+    assert.equal(r2.existed, false);
+});
+
+test('precedencia: .paused gana sobre .partial-pause.json', () => {
+    resetFs();
+    pp.setPartialPause([2490, 2491]);
+
+    // Simular pausa completa
+    const { PAUSE_FILE } = pp._paths();
+    fs.writeFileSync(PAUSE_FILE, new Date().toISOString());
+
+    const state = pp.getPipelineMode();
+    assert.equal(state.mode, 'paused');
+    assert.equal(pp.isIssueAllowed(2490), false);  // incluso el allowed queda bloqueado
+    assert.equal(pp.isIssueAllowed(2491), false);
+});
+
+test('resumeAll elimina ambos markers', () => {
+    resetFs();
+    pp.setPartialPause([2490]);
+    const { PAUSE_FILE } = pp._paths();
+    fs.writeFileSync(PAUSE_FILE, new Date().toISOString());
+
+    const result = pp.resumeAll();
+    assert.equal(result.removedFull, true);
+    assert.equal(result.removedPartial, true);
+    assert.equal(pp.getPipelineMode().mode, 'running');
+});
+
+test('resumeAll sin markers es no-op', () => {
+    resetFs();
+    const result = pp.resumeAll();
+    assert.equal(result.removedFull, false);
+    assert.equal(result.removedPartial, false);
+});
+
+test('JSON corrupto → modo running (fail-open, no se cuelga)', () => {
+    resetFs();
+    const { PARTIAL_FILE } = pp._paths();
+    fs.writeFileSync(PARTIAL_FILE, '{malformed json');
+
+    const state = pp.getPipelineMode();
+    assert.equal(state.mode, 'running');
+});
+
+test('JSON válido sin allowed_issues → modo running', () => {
+    resetFs();
+    const { PARTIAL_FILE } = pp._paths();
+    fs.writeFileSync(PARTIAL_FILE, JSON.stringify({ other_field: 'x' }));
+
+    const state = pp.getPipelineMode();
+    assert.equal(state.mode, 'running');
+});
+
+test('allowed_issues vacío en el JSON → modo running', () => {
+    resetFs();
+    const { PARTIAL_FILE } = pp._paths();
+    fs.writeFileSync(PARTIAL_FILE, JSON.stringify({ allowed_issues: [] }));
+
+    const state = pp.getPipelineMode();
+    assert.equal(state.mode, 'running');
+});
+
+test('isIssueAllowed(null|undefined|"abc") retorna false sin error', () => {
+    resetFs();
+    pp.setPartialPause([2490]);
+    assert.equal(pp.isIssueAllowed(null), false);
+    assert.equal(pp.isIssueAllowed(undefined), false);
+    assert.equal(pp.isIssueAllowed('abc'), false);
+});

--- a/.pipeline/lib/partial-pause.js
+++ b/.pipeline/lib/partial-pause.js
@@ -1,0 +1,154 @@
+// V3 Partial pause — pausa del pipeline con allowlist explícita de issues (#2490).
+//
+// Tres estados del pipeline:
+//   - running        → procesa todo (sin archivos de control)
+//   - paused         → .pipeline/.paused existe → no procesa nada
+//   - partial_pause  → .pipeline/.partial-pause.json existe → procesa solo issues del allowlist
+//
+// Precedencia: paused > partial_pause > running. Si coexisten .paused y
+// .partial-pause.json, .paused gana (más restrictivo).
+//
+// La tabla de verdad de isIssueAllowed(issue):
+//   running          → true
+//   paused           → false
+//   partial_pause    → issue in allowedIssues
+//
+// El marker JSON tiene el shape:
+//   { allowed_issues: [2490, 2491], created_at: "2026-04-23T19:40:00Z", source: "telegram" }
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+function pipelineDir() {
+    // Permitir override en tests vía env var
+    if (process.env.PIPELINE_DIR_OVERRIDE) return process.env.PIPELINE_DIR_OVERRIDE;
+    return path.join(__dirname, '..');
+}
+
+function partialFile() { return path.join(pipelineDir(), '.partial-pause.json'); }
+function pauseFile() { return path.join(pipelineDir(), '.paused'); }
+
+function normalizeIssue(issue) {
+    const n = Number(String(issue).replace(/^#/, '').trim());
+    return Number.isInteger(n) && n > 0 ? n : null;
+}
+
+function readPartialFile() {
+    try {
+        const raw = fs.readFileSync(partialFile(), 'utf8');
+        const parsed = JSON.parse(raw);
+        const arr = Array.isArray(parsed.allowed_issues) ? parsed.allowed_issues : [];
+        const allowed = arr.map(normalizeIssue).filter(Boolean);
+        return {
+            allowed_issues: allowed,
+            created_at: parsed.created_at || null,
+            source: parsed.source || null,
+        };
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Estado actual del pipeline.
+ * @returns {{mode: 'running'|'paused'|'partial_pause', allowedIssues: number[], createdAt: string|null, source: string|null}}
+ */
+function getPipelineMode() {
+    if (fs.existsSync(pauseFile())) {
+        return { mode: 'paused', allowedIssues: [], createdAt: null, source: null };
+    }
+    const partial = readPartialFile();
+    if (partial && partial.allowed_issues.length > 0) {
+        return {
+            mode: 'partial_pause',
+            allowedIssues: partial.allowed_issues,
+            createdAt: partial.created_at,
+            source: partial.source,
+        };
+    }
+    return { mode: 'running', allowedIssues: [], createdAt: null, source: null };
+}
+
+/**
+ * Determina si un issue puede procesarse según el estado actual.
+ * @param {number|string} issue
+ * @returns {boolean}
+ */
+function isIssueAllowed(issue) {
+    const n = normalizeIssue(issue);
+    if (!n) return false;
+    const state = getPipelineMode();
+    if (state.mode === 'paused') return false;
+    if (state.mode === 'running') return true;
+    return state.allowedIssues.includes(n);
+}
+
+/**
+ * Activa la pausa parcial con un allowlist de issues.
+ * Lista vacía → elimina el marker (equivalente a clear).
+ * @param {Array<number|string>} issues
+ * @param {{source?: string}} [opts]
+ * @returns {{ok: boolean, allowedIssues: number[], msg: string}}
+ */
+function setPartialPause(issues, opts = {}) {
+    const normalized = (Array.isArray(issues) ? issues : [])
+        .map(normalizeIssue)
+        .filter(Boolean);
+    const unique = [...new Set(normalized)].sort((a, b) => a - b);
+
+    if (unique.length === 0) {
+        clearPartialPause();
+        return { ok: true, allowedIssues: [], msg: 'Pausa parcial desactivada (lista vacía)' };
+    }
+
+    const data = {
+        allowed_issues: unique,
+        created_at: new Date().toISOString(),
+        source: opts.source || 'unknown',
+    };
+    fs.writeFileSync(partialFile(), JSON.stringify(data, null, 2));
+    return {
+        ok: true,
+        allowedIssues: unique,
+        msg: `Pausa parcial activa — allowed: ${unique.map(i => `#${i}`).join(', ')}`,
+    };
+}
+
+/**
+ * Desactiva la pausa parcial (elimina marker).
+ * @returns {{ok: boolean, existed: boolean}}
+ */
+function clearPartialPause() {
+    const existed = fs.existsSync(partialFile());
+    if (existed) {
+        try { fs.unlinkSync(partialFile()); } catch {}
+    }
+    return { ok: true, existed };
+}
+
+/**
+ * Desactiva TODO modo de pausa (full + partial). Usado por /resume.
+ * @returns {{removedFull: boolean, removedPartial: boolean}}
+ */
+function resumeAll() {
+    let removedFull = false;
+    let removedPartial = false;
+    if (fs.existsSync(pauseFile())) {
+        try { fs.unlinkSync(pauseFile()); removedFull = true; } catch {}
+    }
+    if (fs.existsSync(partialFile())) {
+        try { fs.unlinkSync(partialFile()); removedPartial = true; } catch {}
+    }
+    return { removedFull, removedPartial };
+}
+
+module.exports = {
+    getPipelineMode,
+    isIssueAllowed,
+    setPartialPause,
+    clearPartialPause,
+    resumeAll,
+    _paths: () => ({ PARTIAL_FILE: partialFile(), PAUSE_FILE: pauseFile() }),
+};

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -28,6 +28,8 @@ const { redact } = require('./redact');
 // y en su lugar re-encola el issue a `build` con YAML limpio.
 const staleness = require('./build-log-staleness');
 const qaEvidenceGate = require('./lib/qa-evidence-gate');
+// #2490 — Pausa parcial con allowlist explícita de issues
+const partialPause = require('./lib/partial-pause');
 // #2334 / CA6: log stream sanitizer para stdout/stderr del agente.
 const { createLogFileWriter } = require('./lib/sanitize-log-stream');
 // #2334 / CA6: patch global de console.* para que nada pase al log de pulpo
@@ -3049,6 +3051,16 @@ function brazoLanzamiento(config) {
     //    Sin este check el siguiente iteration explota al intentar moverlo.
     if (!fs.existsSync(archivo.path)) continue;
 
+    // 0a. PARTIAL PAUSE (#2490): si hay allowlist activa, saltar issues fuera de ella.
+    // El archivo se queda en pendiente/ — no se archiva ni penaliza.
+    if (!partialPause.isIssueAllowed(issue)) {
+      const mode = partialPause.getPipelineMode();
+      if (mode.mode === 'partial_pause') {
+        log('lanzamiento', `#${issue} skipped by partial_pause (allowed: ${mode.allowedIssues.map(i => `#${i}`).join(', ')})`);
+      }
+      continue;
+    }
+
     // 0b. BLOCKED: no lanzar issues con blocked:dependencies
     const issueLbls = getIssueLabels(issue);
     if (issueLbls.includes('blocked:dependencies')) {
@@ -4633,8 +4645,16 @@ async function cmdStatus(config) {
     log('commander', `[status] Error obteniendo PRs del día: ${e.message}`);
   }
 
-  // Estado pausa
-  if (paused) lines.push('\n⏸️ *PULPO PAUSADO*');
+  // Estado pausa (completa o parcial — #2490)
+  if (paused) {
+    lines.push('\n⏸️ *PULPO PAUSADO*');
+  } else {
+    const ppMode = partialPause.getPipelineMode();
+    if (ppMode.mode === 'partial_pause') {
+      const list = ppMode.allowedIssues.map(i => `#${i}`).join(', ');
+      lines.push(`\n⏸️ *PULPO EN PAUSA PARCIAL*\nIssues permitidos: ${list}`);
+    }
+  }
 
   const text = lines.join('\n');
 
@@ -4651,7 +4671,14 @@ async function cmdStatus(config) {
       // Recursos
       const { cpuPercent: cpu, memPercent: mem } = getSystemResourceUsage();
       narration += `CPU al ${cpu} por ciento, RAM al ${mem} por ciento. `;
-      if (paused) narration += 'El pulpo está pausado. ';
+      if (paused) {
+        narration += 'El pulpo está pausado. ';
+      } else {
+        const ppMode = partialPause.getPipelineMode();
+        if (ppMode.mode === 'partial_pause') {
+          narration += `Pipeline en pausa parcial, procesando solo ${ppMode.allowedIssues.length} ${ppMode.allowedIssues.length === 1 ? 'issue' : 'issues'}. `;
+        }
+      }
       // PRs del día
       try {
         const today = new Date().toISOString().slice(0, 10);
@@ -4774,9 +4801,31 @@ function cmdPausar() {
 }
 
 function cmdReanudar() {
-  try { fs.unlinkSync(PAUSE_FILE); } catch {}
+  // #2490 — /reanudar limpia tanto pausa completa como parcial.
+  const { removedFull, removedPartial } = partialPause.resumeAll();
   paused = false;
-  return '▶️ Pulpo REANUDADO. Procesamiento activo.';
+  const parts = [];
+  if (removedFull) parts.push('pausa completa');
+  if (removedPartial) parts.push('pausa parcial');
+  const cleared = parts.length > 0 ? ` (${parts.join(' + ')} eliminada)` : '';
+  return `▶️ Pulpo REANUDADO${cleared}. Procesamiento activo.`;
+}
+
+// #2490 — Pausa parcial con allowlist de issues.
+// Uso: /pause-partial 2490 2491  → procesa solo esos issues, pausa el resto.
+function cmdPausaParcial(args) {
+  const nums = String(args || '').match(/\d+/g) || [];
+  if (nums.length === 0) {
+    const state = partialPause.getPipelineMode();
+    if (state.mode === 'partial_pause') {
+      return `⏸️ *Pausa parcial activa*\nIssues permitidos: ${state.allowedIssues.map(i => `#${i}`).join(', ')}\nDesde: ${state.createdAt || '?'}\n\n_Usar /reanudar para desactivar._`;
+    }
+    return '⚠️ Uso: `/pause-partial 2490 2491`\n\nActiva pausa parcial con los issues indicados. El pipeline sigue corriendo solo para esos números, el resto queda pausado.';
+  }
+  const issues = nums.map(n => parseInt(n, 10));
+  const result = partialPause.setPartialPause(issues, { source: 'telegram' });
+  const list = result.allowedIssues.map(i => `#${i}`).join(', ');
+  return `⏸️ *Pausa parcial activa*\nIssues permitidos: ${list}\n\n_Todo el resto del pipeline queda pausado hasta que hagas /reanudar._`;
 }
 
 function cmdCostos() {
@@ -5494,8 +5543,9 @@ function cmdHelp() {
 /restart pausado — Reiniciar en modo pausado (solo Telegram + dashboard)
 /limpiar — Matar daemons Gradle/Kotlin huérfanos
 /ghostbusters — Matar fantasmas: gradle zombies + worktrees abandonados + emuladores no sincronizados
-/pausar — Pausar el Pulpo
-/reanudar — Reanudar el Pulpo
+/pausar — Pausar el Pulpo (completo)
+/pause-partial 2490 2491 — Pausa parcial: solo esos issues siguen activos
+/reanudar — Reanudar el Pulpo (levanta pausa completa o parcial)
 /costos — Resumen de actividad/costos
 /bloqueados — Listar issues bloqueados esperando intervención humana (V3)
 /unblock <issue> <orientación> — Desbloquear un issue con orientación para el skill (V3)
@@ -5510,8 +5560,8 @@ function parseCommand(text) {
   if (!text || typeof text !== 'string') return null;
   const trimmed = text.trim();
 
-  // Comando explícito /xxx
-  const match = trimmed.match(/^\/(\w+)\s*(.*)?$/s);
+  // Comando explícito /xxx (admite guiones para /pause-partial, /chat-gpt, etc.)
+  const match = trimmed.match(/^\/([\w-]+)\s*(.*)?$/s);
   if (match) return { cmd: match[1].toLowerCase(), args: (match[2] || '').trim() };
 
   // Detección de intención por lenguaje natural (solo para mensajes cortos tipo comando)
@@ -5661,8 +5711,10 @@ async function _brazoCommanderInner(config, archivosIniciales, commanderPendient
       case 'actividad': respuesta = cmdActividad(parsed.args); break;
       case 'ghostbusters': respuesta = cmdGhostbusters(); break;
       case 'intake': respuesta = cmdIntake(parsed.args, config); break;
-      case 'pausar': respuesta = cmdPausar(); break;
-      case 'reanudar': respuesta = cmdReanudar(); break;
+      case 'pausar': case 'pause': respuesta = cmdPausar(); break;
+      case 'reanudar': case 'resume': respuesta = cmdReanudar(); break;
+      case 'pause-partial': case 'pause_partial': case 'pausarparcial':
+        respuesta = cmdPausaParcial(parsed.args); break;
       case 'costos': respuesta = cmdCostos(); break;
       case 'help': case 'start': respuesta = cmdHelp(); break;
       case 'stop':


### PR DESCRIPTION
## 🎯 Resumen

Cierra #2490 — agrega un tercer estado al pipeline V3, `partial_pause`, donde el Pulpo procesa **solo** los issues explícitamente permitidos y saltea todos los demás sin penalizarlos.

### Uso

```
/pause-partial 2490 2491   → procesa SOLO esos dos issues, pausa el resto
/reanudar                  → levanta pausa completa y parcial
/status                    → muestra modo actual (texto + TTS)
```

### Precedencia

`paused > partial_pause > running` — si coexisten `.paused` y `.partial-pause.json`, gana el completo (más restrictivo).

## 📦 Cambios

| Archivo | Líneas | Qué hace |
|---|---|---|
| `.pipeline/lib/partial-pause.js` (nuevo) | 155 | `getPipelineMode`, `isIssueAllowed`, `setPartialPause`, `clearPartialPause`, `resumeAll` con override por `PIPELINE_DIR_OVERRIDE` para tests |
| `.pipeline/pulpo.js` | +64/-8 | Skip en `brazoLanzamiento` de issues fuera del allowlist, comando `/pause-partial`, `/reanudar` limpia ambas pausas, `/status` con texto + TTS, `parseCommand` admite guiones |
| `.pipeline/dashboard-v2.js` | +68/-1 | Badge `⏸ PARCIAL (N)` + pill con los issues permitidos, ctrl-bar con botón Reanudar, endpoint `/api/pause-partial`, `/api/pause` con `action=resume` limpia pausa parcial también |
| `.pipeline/lib/__tests__/partial-pause.test.js` (nuevo) | 161 | 15 tests: modos, precedencia, normalización (`#2490`, whitespace), dedup, JSON corrupto, allowed vacío, null-safe |

**Tests:** 15/15 ✓ (`node --test .pipeline/lib/__tests__/partial-pause.test.js`)

## 🎯 Cambio operativo

Antes: solo existía pausa binaria (todo o nada). Para probar un issue con el pipeline vivo había que modificar el archivo de pendientes manualmente o pausar todo y despausar por cada cambio.

Después: podés dejar corriendo solo los issues que te interesan probar (típicamente el que estás desarrollando más alguno que uses como control), mientras el resto del backlog queda quieto en `pendiente/` sin moverse.

## 🏷️ Labels

- `area:infra`, `tipo:infra` — cambio en pipeline, sin impacto en producto de usuario
- `qa:skipped` — infra interna sin superficie de app, cubierto por tests unitarios

## ✅ Checklist

- [x] Feature funcional end-to-end (Telegram + dashboard)
- [x] Tests unitarios con cobertura de casos edge
- [x] Sintaxis validada (`node -c` en pulpo.js y dashboard-v2.js)
- [x] Precedencia documentada en el código
- [x] `/reanudar` limpia ambos estados (no deja residuos)

Closes #2490

🤖 Generated with [Claude Code](https://claude.com/claude-code)