### PR TITLE
feat(pipeline): TTS con fallback dinámico OpenAI ↔ Edge

### DIFF
--- a/.pipeline/multimedia.js
+++ b/.pipeline/multimedia.js
@@ -5,6 +5,8 @@
 const https = require('https');
 const fs = require('fs');
 const path = require('path');
+const os = require('os');
+const { spawn } = require('child_process');
 
 const ROOT = process.env.PIPELINE_MAIN_ROOT || path.resolve(__dirname, '..');
 const TG_CONFIG_PATH = path.join(ROOT, '.claude', 'hooks', 'telegram-config.json');
@@ -221,21 +223,60 @@ async function preprocessMessage(msg, botToken) {
   return result;
 }
 
+// --- TTS config (priorización dinámica) ---
+
+const TTS_CONFIG_PATH = path.join(ROOT, '.pipeline', 'tts-config.json');
+
+function loadTtsConfig() {
+  const defaults = {
+    primary: 'openai',
+    fallback: 'edge',
+    providers: {
+      openai: {
+        model: 'gpt-4o-mini-tts',
+        voice: 'ash',
+        instructions: 'Hablas como un porteño de Buenos Aires, con tonada rioplatense. Usas vos en vez de tu, decis dale, che, mira. El ritmo es de charla entre amigos. Sos inteligente pero cero formal.',
+        response_format: 'opus'
+      },
+      edge: {
+        voice: 'es-AR-TomasNeural',
+        rate: '+0%',
+        pitch: '+0Hz'
+      }
+    }
+  };
+  try {
+    const raw = JSON.parse(fs.readFileSync(TTS_CONFIG_PATH, 'utf8'));
+    return {
+      primary: raw.primary || defaults.primary,
+      fallback: raw.fallback === null ? null : (raw.fallback || defaults.fallback),
+      providers: {
+        openai: { ...defaults.providers.openai, ...(raw.providers && raw.providers.openai) },
+        edge: { ...defaults.providers.edge, ...(raw.providers && raw.providers.edge) }
+      }
+    };
+  } catch {
+    return defaults;
+  }
+}
+
 // --- OpenAI TTS ---
 
-function textToSpeech(text) {
+function textToSpeechOpenAI(text) {
   const config = loadConfig();
   const apiKey = config.openai_api_key || process.env.OPENAI_API_KEY;
-  if (!apiKey) return Promise.resolve(null);
+  if (!apiKey) { log('TTS[openai]: falta openai_api_key'); return Promise.resolve(null); }
 
-  return new Promise((resolve, reject) => {
+  const ttsCfg = loadTtsConfig().providers.openai;
+
+  return new Promise((resolve) => {
     // OpenAI TTS soporta hasta 4096 chars — NO truncar, los callers manejan chunking
     const body = JSON.stringify({
-      model: 'gpt-4o-mini-tts',
+      model: ttsCfg.model,
       input: text.substring(0, 4096),
-      voice: 'ash',
-      instructions: 'Hablas como un porteño de Buenos Aires, con tonada rioplatense. Usas vos en vez de tu, decis dale, che, mira. El ritmo es de charla entre amigos. Sos inteligente pero cero formal.',
-      response_format: 'opus'
+      voice: ttsCfg.voice,
+      instructions: ttsCfg.instructions,
+      response_format: ttsCfg.response_format || 'opus'
     });
 
     const req = https.request({
@@ -254,19 +295,156 @@ function textToSpeech(text) {
       res.on('end', () => {
         const buffer = Buffer.concat(chunks);
         if (res.statusCode === 200 && buffer.length > 100) {
-          log(`TTS generado: ${buffer.length} bytes`);
+          log(`TTS[openai] generado: ${buffer.length} bytes`);
           resolve(buffer);
         } else {
-          log(`TTS error: status=${res.statusCode}, size=${buffer.length}`);
+          log(`TTS[openai] error: status=${res.statusCode}, size=${buffer.length}`);
           resolve(null);
         }
       });
     });
-    req.on('error', (e) => { log(`TTS error: ${e.message}`); resolve(null); });
-    req.on('timeout', () => { req.destroy(); resolve(null); });
+    req.on('error', (e) => { log(`TTS[openai] error: ${e.message}`); resolve(null); });
+    req.on('timeout', () => { req.destroy(); log('TTS[openai] timeout'); resolve(null); });
     req.write(body);
     req.end();
   });
+}
+
+// --- Edge TTS (Microsoft, gratis) ---
+
+function findEdgeTtsExe() {
+  // Permite override por env
+  if (process.env.EDGE_TTS_BIN && fs.existsSync(process.env.EDGE_TTS_BIN)) return process.env.EDGE_TTS_BIN;
+  const candidates = [];
+  if (process.platform === 'win32') {
+    const appData = process.env.APPDATA || path.join(os.homedir(), 'AppData', 'Roaming');
+    for (const v of ['Python314', 'Python313', 'Python312', 'Python311', 'Python310']) {
+      candidates.push(path.join(appData, 'Python', v, 'Scripts', 'edge-tts.exe'));
+    }
+    candidates.push('C:\\Python314\\Scripts\\edge-tts.exe');
+    candidates.push('C:\\Python313\\Scripts\\edge-tts.exe');
+    candidates.push('C:\\Python312\\Scripts\\edge-tts.exe');
+  } else {
+    candidates.push('/usr/local/bin/edge-tts', '/usr/bin/edge-tts');
+  }
+  for (const c of candidates) { if (fs.existsSync(c)) return c; }
+  return 'edge-tts'; // último recurso: que lo busque en PATH
+}
+
+function findFfmpegExe() {
+  if (process.env.FFMPEG_BIN && fs.existsSync(process.env.FFMPEG_BIN)) return process.env.FFMPEG_BIN;
+  // En Windows el which puede ser lento, probamos comunes primero
+  if (process.platform === 'win32') {
+    const wingetBase = path.join(os.homedir(), 'AppData', 'Local', 'Microsoft', 'WinGet', 'Packages');
+    try {
+      if (fs.existsSync(wingetBase)) {
+        const entries = fs.readdirSync(wingetBase);
+        const ff = entries.find(e => e.toLowerCase().startsWith('gyan.ffmpeg'));
+        if (ff) {
+          const pkgDir = path.join(wingetBase, ff);
+          const sub = fs.readdirSync(pkgDir).find(e => e.toLowerCase().startsWith('ffmpeg-'));
+          if (sub) {
+            const bin = path.join(pkgDir, sub, 'bin', 'ffmpeg.exe');
+            if (fs.existsSync(bin)) return bin;
+          }
+        }
+      }
+    } catch {}
+  }
+  return 'ffmpeg'; // lo busca en PATH
+}
+
+function mp3ToOpus(mp3Path) {
+  return new Promise((resolve) => {
+    const oggPath = mp3Path.replace(/\.mp3$/i, '.ogg');
+    const ff = findFfmpegExe();
+    const args = ['-y', '-loglevel', 'error', '-i', mp3Path, '-c:a', 'libopus', '-b:a', '48k', '-vbr', 'on', oggPath];
+    const proc = spawn(ff, args, { windowsHide: true });
+    let stderr = '';
+    proc.stderr.on('data', d => stderr += d.toString());
+    proc.on('error', (e) => { log(`TTS[edge] ffmpeg error: ${e.message}`); resolve(null); });
+    proc.on('close', (code) => {
+      if (code === 0 && fs.existsSync(oggPath)) {
+        try { const buf = fs.readFileSync(oggPath); fs.unlinkSync(oggPath); resolve(buf); }
+        catch { resolve(null); }
+      } else {
+        log(`TTS[edge] ffmpeg exit=${code} ${stderr.slice(0, 200)}`);
+        resolve(null);
+      }
+    });
+  });
+}
+
+function textToSpeechEdge(text) {
+  const ttsCfg = loadTtsConfig().providers.edge;
+  const tmpDir = path.join(os.tmpdir(), 'intrale-edge-tts');
+  try { fs.mkdirSync(tmpDir, { recursive: true }); } catch {}
+  const mp3Path = path.join(tmpDir, `edge-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.mp3`);
+  const bin = findEdgeTtsExe();
+  const input = text.substring(0, 5000);
+
+  return new Promise((resolve) => {
+    const args = [
+      '--voice', ttsCfg.voice,
+      '--rate', ttsCfg.rate || '+0%',
+      '--pitch', ttsCfg.pitch || '+0Hz',
+      '--text', input,
+      '--write-media', mp3Path
+    ];
+    const proc = spawn(bin, args, { windowsHide: true });
+    let stderr = '';
+    proc.stderr.on('data', d => stderr += d.toString());
+    proc.on('error', (e) => { log(`TTS[edge] error spawn: ${e.message}`); resolve(null); });
+    proc.on('close', async (code) => {
+      if (code !== 0 || !fs.existsSync(mp3Path)) {
+        log(`TTS[edge] exit=${code} ${stderr.slice(0, 200)}`);
+        resolve(null);
+        return;
+      }
+      // Convertir mp3 → opus ogg (Telegram voice message)
+      const opusBuf = await mp3ToOpus(mp3Path);
+      try { fs.unlinkSync(mp3Path); } catch {}
+      if (opusBuf && opusBuf.length > 100) {
+        log(`TTS[edge] generado: ${opusBuf.length} bytes (voz=${ttsCfg.voice})`);
+        resolve(opusBuf);
+      } else {
+        log(`TTS[edge] conversion fallida`);
+        resolve(null);
+      }
+    });
+  });
+}
+
+// --- TTS con priorización dinámica + fallback ---
+
+async function textToSpeechByProvider(provider, text) {
+  if (provider === 'openai') return textToSpeechOpenAI(text);
+  if (provider === 'edge') return textToSpeechEdge(text);
+  log(`TTS: provider desconocido '${provider}'`);
+  return null;
+}
+
+async function textToSpeech(text) {
+  const cfg = loadTtsConfig();
+  // Forzado opcional por env (útil para tests)
+  const forced = process.env.TTS_PROVIDER;
+  if (forced) {
+    log(`TTS forzado por env: ${forced}`);
+    return await textToSpeechByProvider(forced, text);
+  }
+
+  const primary = cfg.primary || 'openai';
+  log(`TTS: intentando primary=${primary}`);
+  const buf = await textToSpeechByProvider(primary, text);
+  if (buf) return buf;
+
+  const fallback = cfg.fallback;
+  if (!fallback || fallback === primary) {
+    log(`TTS: primary fallo y no hay fallback distinto`);
+    return null;
+  }
+  log(`TTS: primary fallo, probando fallback=${fallback}`);
+  return await textToSpeechByProvider(fallback, text);
 }
 
 // --- Enviar audio por Telegram ---
@@ -339,4 +517,15 @@ function splitTextForTTSChunks(text, maxChars) {
   return result;
 }
 
-module.exports = { preprocessMessage, transcribeAudio, describeImage, downloadTelegramFile, textToSpeech, sendVoiceTelegram, splitTextForTTSChunks };
+module.exports = {
+  preprocessMessage,
+  transcribeAudio,
+  describeImage,
+  downloadTelegramFile,
+  textToSpeech,
+  textToSpeechOpenAI,
+  textToSpeechEdge,
+  loadTtsConfig,
+  sendVoiceTelegram,
+  splitTextForTTSChunks
+};

--- a/.pipeline/scripts/test-tts-dual.js
+++ b/.pipeline/scripts/test-tts-dual.js
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+// Script de prueba: genera audio con OpenAI TTS y Edge TTS y los manda a Telegram
+// Uso:  node .pipeline/scripts/test-tts-dual.js
+
+const path = require('path');
+const fs = require('fs');
+const { textToSpeechOpenAI, textToSpeechEdge, sendVoiceTelegram } = require(path.resolve(__dirname, '..', 'multimedia.js'));
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const TG_CONFIG_PATH = path.join(ROOT, '.claude', 'hooks', 'telegram-config.json');
+const tg = JSON.parse(fs.readFileSync(TG_CONFIG_PATH, 'utf8'));
+
+const TEXTS = {
+  openai: 'Hola Leito, soy el Commander hablando con OpenAI TTS. Esta es la voz premium que usamos por defecto. Si la escuchás bien, queda como primary.',
+  edge:   'Hola Leito, ahora probando Edge TTS, voz es-AR Tomas. Este es el fallback gratis. Si la calidad te cierra, podés switchearlo como primary cuando quieras.'
+};
+
+(async () => {
+  console.log('=== Test TTS dual: OpenAI + Edge ===');
+
+  console.log('\n[1/2] Generando con OpenAI...');
+  const openaiBuf = await textToSpeechOpenAI(TEXTS.openai);
+  if (openaiBuf) {
+    console.log(`  OpenAI OK: ${openaiBuf.length} bytes — enviando a Telegram...`);
+    const ok = await sendVoiceTelegram(openaiBuf, tg.bot_token, tg.chat_id);
+    console.log(`  Telegram sendVoice(openai): ${ok}`);
+  } else {
+    console.log('  OpenAI FALLÓ (null). No envío.');
+  }
+
+  console.log('\n[2/2] Generando con Edge...');
+  const edgeBuf = await textToSpeechEdge(TEXTS.edge);
+  if (edgeBuf) {
+    console.log(`  Edge OK: ${edgeBuf.length} bytes — enviando a Telegram...`);
+    const ok = await sendVoiceTelegram(edgeBuf, tg.bot_token, tg.chat_id);
+    console.log(`  Telegram sendVoice(edge): ${ok}`);
+  } else {
+    console.log('  Edge FALLÓ (null). No envío.');
+  }
+
+  console.log('\n=== Done ===');
+})().catch(e => { console.error('FATAL:', e); process.exit(1); });

--- a/.pipeline/tts-config.json
+++ b/.pipeline/tts-config.json
@@ -1,0 +1,17 @@
+{
+  "primary": "openai",
+  "fallback": "edge",
+  "providers": {
+    "openai": {
+      "model": "gpt-4o-mini-tts",
+      "voice": "ash",
+      "instructions": "Hablas como un porteño de Buenos Aires, con tonada rioplatense. Usas vos en vez de tu, decis dale, che, mira. El ritmo es de charla entre amigos. Sos inteligente pero cero formal.",
+      "response_format": "opus"
+    },
+    "edge": {
+      "voice": "es-AR-TomasNeural",
+      "rate": "+0%",
+      "pitch": "+0Hz"
+    }
+  }
+}


### PR DESCRIPTION
## Resumen

Agrega **Edge TTS** (Microsoft, gratuito) como segundo proveedor de texto-a-voz junto a OpenAI TTS, con priorización dinámica y fallback automático.

### Motivación

En la sesión del 2026-04-23 el endpoint \`/v1/audio/speech\` de OpenAI tiró \`socket hang up\` durante varias horas y dejó al commander sin voz. Tener un único proveedor = single point of failure.

## Diseño

### Configuración dinámica — \`.pipeline/tts-config.json\`
\`\`\`json
{
  \"primary\": \"openai\",
  \"fallback\": \"edge\",
  \"providers\": {
    \"openai\": { \"model\": \"gpt-4o-mini-tts\", \"voice\": \"ash\", ... },
    \"edge\":   { \"voice\": \"es-AR-TomasNeural\", \"rate\": \"+0%\", \"pitch\": \"+0Hz\" }
  }
}
\`\`\`

Para migrar primary→edge (ahorro OpenAI) alcanza con editar el JSON, sin redeploy de código.

### Flujo runtime

\`textToSpeech(text)\`:
1. Lee \`primary\` desde config
2. Intenta generar; si retorna buffer válido → éxito
3. Si devuelve \`null\` (error de red, 401, socket hang up, etc.) → intenta \`fallback\`
4. \`TTS_PROVIDER=edge|openai\` como override por env (tests)

### Edge TTS

- Usa \`edge-tts\` CLI (ya instalado en la máquina)
- Genera MP3 → convierte a **Opus/OGG** con ffmpeg para que Telegram lo muestre como \"voice message\" (no audio file)
- Voz por defecto: \`es-AR-TomasNeural\` (masculina argentina)

## Tests de humo (ejecutados)

\`\`\`
[1/2] Generando con OpenAI...
  OpenAI OK: 107580 bytes — Telegram sendVoice: true  ✅
[2/2] Generando con Edge...
  Edge OK: 63209 bytes — Telegram sendVoice: true     ✅
\`\`\`

Script reutilizable: \`node .pipeline/scripts/test-tts-dual.js\`

## Archivos

| Archivo | Qué cambia |
|---|---|
| \`.pipeline/multimedia.js\` | Split \`textToSpeech\` → \`textToSpeechOpenAI\` + \`textToSpeechEdge\` + orquestador con fallback |
| \`.pipeline/tts-config.json\` | Nueva config dinámica (primary/fallback/providers) |
| \`.pipeline/scripts/test-tts-dual.js\` | Script de prueba reutilizable |

## QA

\`qa:skipped\` — cambio interno del pipeline/hooks sin impacto en producto de usuario (confirmado con Leo vía Telegram).

Closes relacionado con la observación del 2026-04-23 sobre fallos de OpenAI TTS.