### PR TITLE
feat(pipeline): TTS fallback con personalidad — Tomás cubre a Claudito

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,6 +137,8 @@ scripts/planner-plan.json
 .pipeline/tmp/
 # #2337 — estado reintentando + metricas UX rotadas (no comitear)
 .pipeline/retrying-state.json
+# Estado TTS (último provider usado) — efímero por sesión
+.pipeline/.tts-state.json
 # #2477/#2488 — código fuente del aggregator V3 sí se commitea (snapshot/.last-cleanup quedan ignorados)
 .pipeline/metrics/*
 !.pipeline/metrics/aggregator.js

--- a/.pipeline/multimedia.js
+++ b/.pipeline/multimedia.js
@@ -236,13 +236,19 @@ function loadTtsConfig() {
         model: 'gpt-4o-mini-tts',
         voice: 'ash',
         instructions: 'Hablas como un porteño de Buenos Aires, con tonada rioplatense. Usas vos en vez de tu, decis dale, che, mira. El ritmo es de charla entre amigos. Sos inteligente pero cero formal.',
-        response_format: 'opus'
+        response_format: 'opus',
+        character_name: 'Claudito'
       },
       edge: {
         voice: 'es-AR-TomasNeural',
         rate: '+0%',
-        pitch: '+0Hz'
+        pitch: '+0Hz',
+        character_name: 'Tomás'
       }
+    },
+    intros: {
+      openai_from_edge: 'Hola Leo, volvió Claudito. Gracias a Tomás por cubrir mientras me tomé la licencia.',
+      edge_from_openai: 'Hola Leo, soy Tomás. Claudito se tomó una licencia, lo cubro yo mientras vuelve.'
     }
   };
   try {
@@ -253,11 +259,33 @@ function loadTtsConfig() {
       providers: {
         openai: { ...defaults.providers.openai, ...(raw.providers && raw.providers.openai) },
         edge: { ...defaults.providers.edge, ...(raw.providers && raw.providers.edge) }
-      }
+      },
+      intros: { ...defaults.intros, ...(raw.intros || {}) }
     };
   } catch {
     return defaults;
   }
+}
+
+// Estado persistente: último provider usado (para detectar transiciones)
+const TTS_STATE_PATH = path.join(ROOT, '.pipeline', '.tts-state.json');
+
+function loadTtsState() {
+  try { return JSON.parse(fs.readFileSync(TTS_STATE_PATH, 'utf8')); }
+  catch { return { lastProvider: null }; }
+}
+
+function saveTtsState(state) {
+  try { fs.writeFileSync(TTS_STATE_PATH, JSON.stringify(state, null, 2)); }
+  catch (e) { log(`TTS state save error: ${e.message}`); }
+}
+
+function getTransitionIntro(newProvider, prevProvider) {
+  if (!prevProvider || prevProvider === newProvider) return null;
+  const cfg = loadTtsConfig();
+  if (newProvider === 'openai' && prevProvider === 'edge') return cfg.intros?.openai_from_edge || null;
+  if (newProvider === 'edge' && prevProvider === 'openai') return cfg.intros?.edge_from_openai || null;
+  return null;
 }
 
 // --- OpenAI TTS ---
@@ -424,19 +452,21 @@ async function textToSpeechByProvider(provider, text) {
   return null;
 }
 
-async function textToSpeech(text) {
+// Retorna { buffer, provider } donde provider es el que efectivamente generó el audio.
+// Null si ambos fallaron.
+async function textToSpeechWithMeta(text) {
   const cfg = loadTtsConfig();
-  // Forzado opcional por env (útil para tests)
   const forced = process.env.TTS_PROVIDER;
   if (forced) {
     log(`TTS forzado por env: ${forced}`);
-    return await textToSpeechByProvider(forced, text);
+    const buf = await textToSpeechByProvider(forced, text);
+    return buf ? { buffer: buf, provider: forced } : null;
   }
 
   const primary = cfg.primary || 'openai';
   log(`TTS: intentando primary=${primary}`);
-  const buf = await textToSpeechByProvider(primary, text);
-  if (buf) return buf;
+  const bufPrimary = await textToSpeechByProvider(primary, text);
+  if (bufPrimary) return { buffer: bufPrimary, provider: primary };
 
   const fallback = cfg.fallback;
   if (!fallback || fallback === primary) {
@@ -444,7 +474,14 @@ async function textToSpeech(text) {
     return null;
   }
   log(`TTS: primary fallo, probando fallback=${fallback}`);
-  return await textToSpeechByProvider(fallback, text);
+  const bufFallback = await textToSpeechByProvider(fallback, text);
+  return bufFallback ? { buffer: bufFallback, provider: fallback } : null;
+}
+
+// Compat: signature histórica que retorna solo el buffer.
+async function textToSpeech(text) {
+  const meta = await textToSpeechWithMeta(text);
+  return meta ? meta.buffer : null;
 }
 
 // --- Enviar audio por Telegram ---
@@ -523,9 +560,13 @@ module.exports = {
   describeImage,
   downloadTelegramFile,
   textToSpeech,
+  textToSpeechWithMeta,
   textToSpeechOpenAI,
   textToSpeechEdge,
   loadTtsConfig,
+  loadTtsState,
+  saveTtsState,
+  getTransitionIntro,
   sendVoiceTelegram,
   splitTextForTTSChunks
 };

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -4660,7 +4660,7 @@ async function cmdStatus(config) {
 
   // Audio TTS de la narración
   try {
-    const { textToSpeech, sendVoiceTelegram } = require('./multimedia');
+    const { textToSpeechWithMeta, sendVoiceTelegram, loadTtsState, saveTtsState, getTransitionIntro } = require('./multimedia');
     const botToken = getTelegramToken();
     const chatId = getTelegramChatId();
     if (botToken && chatId) {
@@ -4693,14 +4693,29 @@ async function cmdStatus(config) {
       } catch {}
 
       const statusChunks = splitTextForTTSChunks(narration, 3800);
+      let prevProviderStatus = loadTtsState().lastProvider;
       for (let i = 0; i < statusChunks.length; i++) {
-        const chunkText = statusChunks.length > 1
+        let chunkText = statusChunks.length > 1
           ? `Parte ${i + 1} de ${statusChunks.length}. ${statusChunks[i]}`
           : statusChunks[i];
-        const audioBuffer = await textToSpeech(chunkText);
-        if (audioBuffer) {
-          await sendVoiceTelegram(audioBuffer, botToken, chatId);
-          log('commander', `[status] Audio TTS parte ${i + 1}/${statusChunks.length} enviado`);
+        const meta = await textToSpeechWithMeta(chunkText);
+        if (meta && meta.buffer) {
+          const intro = i === 0 ? getTransitionIntro(meta.provider, prevProviderStatus) : null;
+          if (intro) {
+            // Reenviar el primer chunk con el preámbulo de transición
+            const reMeta = await textToSpeechWithMeta(`${intro} ${chunkText}`);
+            if (reMeta && reMeta.buffer) {
+              await sendVoiceTelegram(reMeta.buffer, botToken, chatId);
+              log('commander', `[status] Audio TTS parte 1/${statusChunks.length} enviado con intro (provider=${reMeta.provider})`);
+              saveTtsState({ lastProvider: reMeta.provider });
+              prevProviderStatus = reMeta.provider;
+              continue;
+            }
+          }
+          await sendVoiceTelegram(meta.buffer, botToken, chatId);
+          log('commander', `[status] Audio TTS parte ${i + 1}/${statusChunks.length} enviado (provider=${meta.provider})`);
+          saveTtsState({ lastProvider: meta.provider });
+          prevProviderStatus = meta.provider;
         }
       }
     }
@@ -5674,7 +5689,7 @@ async function _brazoCommanderInner(config, archivosIniciales, commanderPendient
   const chatId = getTelegramChatId();
   log('commander', `Token: ${botToken ? 'OK' : 'FALTA'}, ChatId: ${chatId || 'FALTA'}`);
 
-  const { preprocessMessage, textToSpeech, sendVoiceTelegram } = require('./multimedia');
+  const { preprocessMessage, textToSpeechWithMeta, sendVoiceTelegram, loadTtsState, saveTtsState, getTransitionIntro } = require('./multimedia');
   const session = loadSession();
 
   // --- PREPROCESAR TODOS los mensajes (transcribir audios, etc.) ---
@@ -5872,17 +5887,32 @@ INSTRUCCIÓN: Integrá los complementos del usuario en tu respuesta. Generá UNA
         if (esAudio) {
           try {
             const chatChunks = splitTextForTTSChunks(respuesta, 3800);
+            let prevProvider = loadTtsState().lastProvider;
             for (let i = 0; i < chatChunks.length; i++) {
-              const chunkText = chatChunks.length > 1
+              const baseChunk = chatChunks.length > 1
                 ? `Parte ${i + 1} de ${chatChunks.length}. ${chatChunks[i]}`
                 : chatChunks[i];
-              const audioBuffer = await textToSpeech(chunkText);
-              if (audioBuffer) {
-                const audioPath = path.join(LOG_DIR, 'media', `tts-${Date.now()}-${i}.ogg`);
-                fs.writeFileSync(audioPath, audioBuffer);
-                enviado = await sendVoiceTelegram(audioBuffer, botToken, chatId);
-                if (enviado) log('telegram', `Audio TTS parte ${i + 1}/${chatChunks.length} enviado (${audioBuffer.length} bytes)`);
+              // Primero probamos a ver qué provider gana para este chunk
+              const meta = await textToSpeechWithMeta(baseChunk);
+              if (!meta || !meta.buffer) continue;
+
+              const intro = i === 0 ? getTransitionIntro(meta.provider, prevProvider) : null;
+              let finalBuffer = meta.buffer;
+              let finalProvider = meta.provider;
+              if (intro) {
+                const reMeta = await textToSpeechWithMeta(`${intro} ${baseChunk}`);
+                if (reMeta && reMeta.buffer) {
+                  finalBuffer = reMeta.buffer;
+                  finalProvider = reMeta.provider;
+                }
               }
+
+              const audioPath = path.join(LOG_DIR, 'media', `tts-${Date.now()}-${i}.ogg`);
+              fs.writeFileSync(audioPath, finalBuffer);
+              enviado = await sendVoiceTelegram(finalBuffer, botToken, chatId);
+              if (enviado) log('telegram', `Audio TTS parte ${i + 1}/${chatChunks.length} enviado (${finalBuffer.length} bytes, provider=${finalProvider}${intro ? ', con intro' : ''})`);
+              saveTtsState({ lastProvider: finalProvider });
+              prevProvider = finalProvider;
             }
           } catch (e) {
             log('commander', `TTS error: ${e.message}`);

--- a/.pipeline/tts-config.json
+++ b/.pipeline/tts-config.json
@@ -6,12 +6,18 @@
       "model": "gpt-4o-mini-tts",
       "voice": "ash",
       "instructions": "Hablas como un porteño de Buenos Aires, con tonada rioplatense. Usas vos en vez de tu, decis dale, che, mira. El ritmo es de charla entre amigos. Sos inteligente pero cero formal.",
-      "response_format": "opus"
+      "response_format": "opus",
+      "character_name": "Claudito"
     },
     "edge": {
       "voice": "es-AR-TomasNeural",
       "rate": "+0%",
-      "pitch": "+0Hz"
+      "pitch": "+0Hz",
+      "character_name": "Tomás"
     }
+  },
+  "intros": {
+    "openai_from_edge": "Hola Leo, volvió Claudito. Gracias a Tomás por cubrir mientras me tomé la licencia.",
+    "edge_from_openai": "Hola Leo, soy Tomás. Claudito se tomó una licencia, lo cubro yo mientras vuelve."
   }
 }


### PR DESCRIPTION
## Resumen

Leo eligió **Tomás** como nombre para la voz secundaria (fallback Edge TTS, coincide con `es-AR-TomasNeural`). Cuando falla OpenAI y se activa Edge, el primer audio arranca con un preámbulo natural explicando el cambio de voz, y cuando vuelve OpenAI, Claudito anuncia su regreso.

## Cambios

| Archivo | Qué hace |
|---|---|
| `.pipeline/tts-config.json` | `character_name` por provider + `intros` para las dos transiciones |
| `.pipeline/multimedia.js` | `textToSpeechWithMeta` retorna `{buffer, provider}`, helpers `loadTtsState`/`saveTtsState`/`getTransitionIntro` |
| `.pipeline/pulpo.js` | Detecta transición en `/status` y chat-libre, antepone preámbulo al primer chunk, persiste último provider |
| `.gitignore` | Ignora `.pipeline/.tts-state.json` |

## Flujo

1. Se genera el audio con `textToSpeechWithMeta` → retorna qué provider ganó
2. Si es el primer chunk Y el provider cambió desde la última vez → regenera con el preámbulo anexado
3. Guarda `{ lastProvider }` en `.pipeline/.tts-state.json` para el próximo audio

## Intros configuradas

- **OpenAI → Edge:** _"Hola Leo, soy Tomás. Claudito se tomó una licencia, lo cubro yo mientras vuelve."_
- **Edge → OpenAI:** _"Hola Leo, volvió Claudito. Gracias a Tomás por cubrir mientras me tomé la licencia."_

## Tipo

Infra del pipeline, sin impacto en usuario final. `qa:skipped` justificado.

Closes nada (conversación libre con Leo).