### PR TITLE
feat(pipeline): Tommy — voz secundaria más joven y fresca

### DIFF
--- a/.pipeline/multimedia.js
+++ b/.pipeline/multimedia.js
@@ -241,14 +241,15 @@ function loadTtsConfig() {
       },
       edge: {
         voice: 'es-AR-TomasNeural',
-        rate: '+0%',
-        pitch: '+0Hz',
-        character_name: 'Tomás'
+        rate: '+8%',
+        pitch: '+4Hz',
+        character_name: 'Tommy',
+        personality: 'Sos Tommy, un pibe joven que recién arranca en el equipo. Tenés la frescura de la juventud, hablas con energía, onda y entusiasmo. Usas vos, che, dale, mira. Sos piola, curioso, con ganas de aprender. Nunca sos engreído — tenés el respeto del que recién se inicia pero la garra de querer comerse la cancha.'
       }
     },
     intros: {
-      openai_from_edge: 'Hola Leo, volvió Claudito. Gracias a Tomás por cubrir mientras me tomé la licencia.',
-      edge_from_openai: 'Hola Leo, soy Tomás. Claudito se tomó una licencia, lo cubro yo mientras vuelve.'
+      openai_from_edge: 'Hola Leo, volvió Claudito. Gracias Tommy por cubrirme, te saliste, pibe.',
+      edge_from_openai: 'Eeeeh Leo, todo bien. Soy Tommy, recién me sumo al equipo. Claudito se tomó una licencia y me dejó la posta mientras vuelve. La rompo yo hasta que regrese.'
     }
   };
   try {

--- a/.pipeline/scripts/test-tts-dual.js
+++ b/.pipeline/scripts/test-tts-dual.js
@@ -11,8 +11,8 @@ const TG_CONFIG_PATH = path.join(ROOT, '.claude', 'hooks', 'telegram-config.json
 const tg = JSON.parse(fs.readFileSync(TG_CONFIG_PATH, 'utf8'));
 
 const TEXTS = {
-  openai: 'Hola Leito, soy el Commander hablando con OpenAI TTS. Esta es la voz premium que usamos por defecto. Si la escuchás bien, queda como primary.',
-  edge:   'Hola Leito, ahora probando Edge TTS, voz es-AR Tomas. Este es el fallback gratis. Si la calidad te cierra, podés switchearlo como primary cuando quieras.'
+  openai: 'Hola Leito, soy Claudito hablando con OpenAI TTS. Esta es la voz premium que usamos por defecto. Si la escuchás bien, queda como primary.',
+  edge:   'Eeeeh Leo, todo bien. Soy Tommy, el pibe nuevo del equipo. Estoy probando la voz de Edge TTS desde es-AR Tomas Neural. Si te cierra como fallback la banco yo cuando Claudito se tome licencia.'
 };
 
 (async () => {

--- a/.pipeline/tts-config.json
+++ b/.pipeline/tts-config.json
@@ -11,13 +11,14 @@
     },
     "edge": {
       "voice": "es-AR-TomasNeural",
-      "rate": "+0%",
-      "pitch": "+0Hz",
-      "character_name": "Tomás"
+      "rate": "+8%",
+      "pitch": "+4Hz",
+      "character_name": "Tommy",
+      "personality": "Sos Tommy, un pibe joven que recién arranca en el equipo. Tenés la frescura de la juventud, hablas con energía, onda y entusiasmo. Usas vos, che, dale, mira. Sos piola, curioso, con ganas de aprender. Nunca sos engreído — tenés el respeto del que recién se inicia pero la garra de querer comerse la cancha."
     }
   },
   "intros": {
-    "openai_from_edge": "Hola Leo, volvió Claudito. Gracias a Tomás por cubrir mientras me tomé la licencia.",
-    "edge_from_openai": "Hola Leo, soy Tomás. Claudito se tomó una licencia, lo cubro yo mientras vuelve."
+    "openai_from_edge": "Hola Leo, volvió Claudito. Gracias Tommy por cubrirme, te saliste, pibe.",
+    "edge_from_openai": "Eeeeh Leo, todo bien. Soy Tommy, recién me sumo al equipo. Claudito se tomó una licencia y me dejó la posta mientras vuelve. La rompo yo hasta que regrese."
   }
 }


### PR DESCRIPTION
## Contexto

Leo escuchó a Tomás (fallback Edge TTS) y pidió:
- Renombrarlo a **Tommy** — más cercano y cariñoso
- Darle **frescura de la juventud** — alguien que recién arranca, con onda

## Cambios

### `.pipeline/tts-config.json` + `.pipeline/multimedia.js`
- `character_name: 'Tomás'` → `'Tommy'`
- `rate: '+0%'` → `'+8%'` (más enérgico)
- `pitch: '+0Hz'` → `'+4Hz'` (más juvenil)
- Nuevo campo `personality` describiendo la onda de Tommy (pibe joven, respetuoso, con ganas de comerse la cancha)

### Intros reescritas
| Transición | Antes | Después |
|---|---|---|
| OpenAI → Edge | *"Hola Leo, soy Tomás. Claudito se tomó una licencia, lo cubro yo mientras vuelve."* | *"Eeeeh Leo, todo bien. Soy Tommy, recién me sumo al equipo. Claudito se tomó una licencia y me dejó la posta mientras vuelve. La rompo yo hasta que regrese."* |
| Edge → OpenAI | *"Hola Leo, volvió Claudito. Gracias a Tomás por cubrir mientras me tomé la licencia."* | *"Hola Leo, volvió Claudito. Gracias Tommy por cubrirme, te saliste, pibe."* |

### `test-tts-dual.js`
- Copy actualizada con la voz de Tommy

## Test plan
- [x] Lint manual (JSON válido, JS sin typos)
- [ ] Escuchar audio Tommy con nueva config (rate/pitch) via `test-tts-dual.js`
- [ ] Verificar que el preámbulo de transición se dispara en cambio de provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)