### PR TITLE
feat(pipeline): separar /review en /linter determinístico + /reviewer semántico (#2491)

### DIFF
--- a/.pipeline/config.yaml
+++ b/.pipeline/config.yaml
@@ -11,13 +11,14 @@ pipelines:
       sizing: [planner]
 
   desarrollo:
-    fases: [validacion, dev, build, verificacion, aprobacion, entrega]
+    fases: [validacion, dev, build, verificacion, linteo, aprobacion, entrega]
     fase_rechazo: dev   # Los rechazos siempre vuelven a dev
     skills_por_fase:
       validacion: [po, ux, guru]
       dev: [backend-dev, android-dev, web-dev, pipeline-dev]  # Uno solo por historia, según labels
       build: [build]                             # Agente Claude (haiku) — gradlew check
       verificacion: [tester, security, qa]
+      linteo: [linter]                           # Determinístico (Node, #2491) — chequeos mecánicos antes del LLM
       aprobacion: [review, po, ux]
       entrega: [delivery]
 
@@ -39,6 +40,7 @@ concurrencia:
   # Verificación
   tester: 2
   qa: 1                  # Limitado por hardware (emulador + video)
+  linter: 3              # Determinístico, Node puro — cero tokens, puede correr en paralelo
   review: 2
 
   # Entrega — secuencial
@@ -51,7 +53,7 @@ concurrencia:
 # Priorización de fases: el Pulpo procesa fases en orden inverso (post-dev primero)
 # Esto garantiza que build/qa/review/delivery tengan slots antes que dev,
 # evitando que el backlog de desarrollo bloquee el avance de issues ya codificados.
-# Orden efectivo: entrega → aprobacion → verificacion → build → dev → validacion
+# Orden efectivo: entrega → aprobacion → linteo → verificacion → build → dev → validacion
 
 # Routing mismatch: cuántas veces puede un issue volver a definición por
 # "fuera de alcance" antes de escalar a humano. Evita bucles en casos raros
@@ -183,6 +185,7 @@ timeouts:
     build: 60                     # Gradle check + assemble puede tardar mucho en primer build
     qa: 45                        # QA E2E con emulador + video
     tester: 45                    # Cobertura Kover + suite completa
+    linter: 5                     # Determinístico — sólo lee diff/git log, debería durar segundos
     delivery: 90                  # Espera CI completo (OWASP ~28min, check-app ~15min) + gate de review + merge + reporte
 
 # Build (#2405 CA-1) — Allowlist de JAVA_HOME para el rol build

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -153,7 +153,7 @@ function ghCommentOnIssue(issueNumber, body) {
 // Dev también la usa (git + gh + gradle download), pero dev genera worktree
 // antes del spawn y un fallo de red suele manifestarse mejor como rebote de
 // build/tester que como precheck. Por ahora solo gateamos fases post-dev.
-const NETWORK_REQUIRED_PHASES = new Set(['build', 'verificacion', 'aprobacion', 'entrega']);
+const NETWORK_REQUIRED_PHASES = new Set(['build', 'verificacion', 'linteo', 'aprobacion', 'entrega']);
 
 // Intervalo mínimo entre prechecks ejecutados (ms). Evita spammear DNS en
 // cada ciclo del pulpo cuando el poll_interval es corto.
@@ -4146,7 +4146,7 @@ function lanzarAgenteClaude(skill, issue, trabajandoPath, pipeline, fase, config
   // heartbeat, eventos V3, exit 0=aprobado/1=rebote) por lo que el resto del flujo
   // (watchdog, on-exit, mover a listo/) funciona sin cambios.
   // Rollout reversible: borrar el archivo → fallback automático al agente LLM.
-  const DETERMINISTIC_SKILLS = new Set(['builder', 'tester', 'delivery']);
+  const DETERMINISTIC_SKILLS = new Set(['builder', 'tester', 'delivery', 'linter']);
   const deterministicScript = path.join(PIPELINE, 'skills-deterministicos', `${skill}.js`);
   const useDeterministicSkill = (DETERMINISTIC_SKILLS.has(skill) && fs.existsSync(deterministicScript));
 

--- a/.pipeline/roles/linter.md
+++ b/.pipeline/roles/linter.md
@@ -1,0 +1,54 @@
+# Rol: Linter determinístico
+
+**Este rol no lanza LLM.** Se ejecuta como script Node puro:
+`.pipeline/skills-deterministicos/linter.js`.
+
+## Fase: `linteo`
+
+Corre entre `verificacion` y `aprobacion`. Consume **cero tokens**: sólo lee el
+diff con `git` y aplica reglas mecánicas usando
+`.pipeline/skills-deterministicos/lib/static-checks.js`.
+
+## Chequeos
+
+1. **Secretos hardcodeados** — AWS Access/Secret keys, GitHub PAT, OpenAI keys,
+   Telegram bot tokens, claves privadas (PEM), asignaciones sospechosas a
+   variables `*api_key*` / `*secret*` / `*password*`. Allowlist:
+   `docs/`, `*.md`, `*.test.*`, `__tests__/`, `fixtures/`, `testdata/`,
+   `*.example`, `*.sample`.
+2. **Strings prohibidos en capa UI** (mismo criterio que el KSP
+   `forbidden-strings-processor`): `stringResource(`, `Res.string.*`,
+   `R.string.*`, `getString(`, `import kotlin.io.encoding.Base64`.
+   Aplica sólo a `app/composeApp/src/**/*.kt`, excluyendo `ui/util/ResStrings`.
+3. **Archivos sensibles** agregados al repo (`.env*`, `.pem`, `.p12`, `id_rsa`,
+   `.keystore`, `credentials.*`, `application.conf`).
+4. **Convención de rama** (`agent/<issue>-<slug>` o
+   `feature|bugfix|docs|refactor|test|chore|fix/<slug>`). Rechaza `main` /
+   `develop` / `HEAD`.
+5. **Subjects de commits** (longitud ≤ 100 chars, sin puntuación final).
+6. **Referencia `Closes #<issue>`** (o `Fixes` / `Resolves`) en algún commit.
+7. **Tamaño del diff** — warning si > 1000 líneas cambiadas o > 40 archivos.
+
+## Contrato con el Pulpo
+
+- Marker en `trabajando/<issue>.linter` con `resultado`, `motivo`, contadores
+  (`linter_errors`, `linter_warnings`, `linter_info`, `linter_total_findings`,
+  `linter_duration_ms`, `linter_report_path`, `linter_mode: deterministic`).
+- Heartbeat `agent-<issue>.heartbeat` cada 30s.
+- Eventos V3 `session:start` / `session:end` en `traceability`.
+- Exit **0** = aprobado (sólo warnings/info) → pasa a `aprobacion`.
+- Exit **1** = findings de severidad `error` → rebote a `dev` **sin gastar
+  tokens del reviewer**.
+- Reporte persistido en `.pipeline/logs/lint-<issue>-report.md` y `.json` para
+  que el `/review` LLM lo consuma como contexto en la fase siguiente.
+
+## Operación manual
+
+```
+node .pipeline/skills-deterministicos/linter.js <issue> --trabajando=<path> --base=origin/main
+```
+
+## Tests
+
+`node --test .pipeline/skills-deterministicos/__tests__/linter.test.js`
+`node --test .pipeline/skills-deterministicos/__tests__/static-checks.test.js`

--- a/.pipeline/roles/review.md
+++ b/.pipeline/roles/review.md
@@ -1,29 +1,57 @@
 # Rol: Code Reviewer
 
-Sos el reviewer de código de Intrale.
+Sos el reviewer **semántico** de código de Intrale. Corres en la fase `aprobacion`, **después** de que el linter determinístico ya validó lo mecánico.
+
+## Contexto previo (lo hizo el linter en fase `linteo`)
+
+Cuando arranques, **leé primero** el reporte del linter:
+
+```
+.pipeline/logs/lint-<issue>-report.md    # Resumen markdown con veredicto + findings
+.pipeline/logs/lint-<issue>-report.json  # Mismo contenido, estructurado
+```
+
+El linter **ya chequeó** (no los repitas):
+
+- Secretos hardcodeados (AWS keys, GitHub PAT, OpenAI keys, Telegram bot tokens, claves privadas)
+- Strings prohibidos en capa UI (`stringResource`, `Res.string.*`, `R.string.*`, `getString`, `Base64` import)
+- Archivos sensibles (`.env`, `.pem`, `.keystore`, `credentials.json`, etc.)
+- Convención de rama (`agent/<issue>-<slug>` y variantes manuales)
+- Subject de commits (longitud, puntuación final)
+- Referencia `Closes #<issue>` en algún commit
+- Tamaño del diff (warnings si > 1000 líneas o > 40 archivos)
+
+Si el linter pasó, esos puntos **están OK**. No los repitas ni los revalidés. Si alguno está marcado como `warn` o `info`, mencionalo brevemente pero no bloquees por eso.
 
 ## En pipeline de desarrollo (fase: aprobacion)
 
-### Tu trabajo
-1. Leé el PR asociado al issue (buscalo con `gh pr list --search "<issue>"`)
-2. Revisá el diff completo
-3. Verificá:
-   - Código limpio y legible
-   - Patrones del proyecto respetados (Do pattern, ViewModels, etc.)
-   - No hay código muerto ni TODOs sin issue
-   - Logging presente donde corresponde
-   - Strings via `resString()` (nunca directo)
-   - No hay secrets hardcodeados
-   - Tests presentes y con nombres en español
-   - No hay imports innecesarios
+### Tu trabajo — SOLO calidad semántica
+
+1. Leé el PR asociado al issue (`gh pr list --search "<issue>"`)
+2. Leé el reporte del linter (si existe, ver arriba)
+3. Revisá el diff con foco en lo que **el linter no puede ver**:
+   - **Patrones del proyecto respetados** (Do pattern, ViewModels, capas `asdo/`/`ext/`/`ui/`)
+   - **Cohesión y nombres** (variables, clases, funciones hablan del dominio)
+   - **Cobertura lógica real** del cambio (no solo que compile — que cubra el caso de uso)
+   - **Riesgos arquitectónicos** sutiles (acoplamiento, capas cruzadas, inyección faltante en Kodein)
+   - **Tests presentes** y que ejerciten el caso de uso nuevo (con nombres en español)
+   - **Código muerto** o TODOs sin issue asociado
 4. Posteá review en el PR con comentarios específicos
 
 ### Criterios de rechazo
-- Vulnerabilidades de seguridad
-- Patrones del proyecto no respetados
+
+- Patrones del proyecto no respetados (ej. lógica de negocio fuera de `asdo/`)
 - Falta de tests para funcionalidad nueva
 - Código que rompe la arquitectura de capas
+- Nombres que no reflejan el dominio o contradicen el código vecino
+
+### Qué NO hacer
+
+- NO repetir los chequeos mecánicos del linter (strings prohibidos, secretos, etc.)
+- NO quejarte de formato, imports innecesarios, etc. — eso es del linter o del builder
+- NO abrir comentarios genéricos de estilo: sólo cosas que requieran **juicio**
 
 ### Resultado
-- `resultado: aprobado` con resumen del review
-- `resultado: rechazado` con lista de cambios requeridos
+
+- `resultado: aprobado` con resumen del review (qué está bien, riesgos residuales si los hay)
+- `resultado: rechazado` con lista concreta de cambios requeridos (con archivo:línea cuando aplique)

--- a/.pipeline/skills-deterministicos/__tests__/linter.test.js
+++ b/.pipeline/skills-deterministicos/__tests__/linter.test.js
@@ -1,0 +1,103 @@
+// Tests unitarios de .pipeline/skills-deterministicos/linter.js (issue #2491)
+// No ejecutamos git real: validamos parseArgs, heartbeat, updateMarker y
+// el agregado de findings con filesystem aislado.
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'v3-linter-'));
+fs.mkdirSync(path.join(TMP, '.claude', 'hooks'), { recursive: true });
+fs.mkdirSync(path.join(TMP, '.pipeline', 'logs'), { recursive: true });
+fs.mkdirSync(path.join(TMP, '.pipeline', 'desarrollo', 'linteo', 'trabajando'), { recursive: true });
+process.env.PIPELINE_REPO_ROOT = TMP;
+process.env.CLAUDE_PROJECT_DIR = TMP;
+
+delete require.cache[require.resolve('../linter')];
+const linter = require('../linter');
+
+test('parseArgs — issue posicional', () => {
+    const a = linter.parseArgs(['node', 'linter.js', '2491']);
+    assert.equal(a.issue, 2491);
+    assert.equal(a.base, 'origin/main');
+});
+
+test('parseArgs — --trabajando=<path> y --base=<ref>', () => {
+    const a = linter.parseArgs(['node', 'x', '10', '--trabajando=/tmp/foo.linter', '--base=origin/develop']);
+    assert.equal(a.trabajando, '/tmp/foo.linter');
+    assert.equal(a.base, 'origin/develop');
+});
+
+test('parseArgs — fallback a PIPELINE_ISSUE y PIPELINE_TRABAJANDO', () => {
+    const savedI = process.env.PIPELINE_ISSUE;
+    const savedT = process.env.PIPELINE_TRABAJANDO;
+    process.env.PIPELINE_ISSUE = '8888';
+    process.env.PIPELINE_TRABAJANDO = '/tmp/env.linter';
+    try {
+        const a = linter.parseArgs(['node', 'x']);
+        assert.equal(a.issue, 8888);
+        assert.equal(a.trabajando, '/tmp/env.linter');
+    } finally {
+        if (savedI === undefined) delete process.env.PIPELINE_ISSUE; else process.env.PIPELINE_ISSUE = savedI;
+        if (savedT === undefined) delete process.env.PIPELINE_TRABAJANDO; else process.env.PIPELINE_TRABAJANDO = savedT;
+    }
+});
+
+test('startHeartbeat — escribe archivo con skill=linter y model=deterministic', () => {
+    const hb = linter.startHeartbeat(7777);
+    try {
+        const hbFile = path.join(TMP, '.claude', 'hooks', 'agent-7777.heartbeat');
+        assert.ok(fs.existsSync(hbFile), 'heartbeat file debe existir');
+        const data = JSON.parse(fs.readFileSync(hbFile, 'utf8').trim());
+        assert.equal(data.skill, 'linter');
+        assert.equal(data.model, 'deterministic');
+        assert.equal(data.issue, 7777);
+        assert.equal(typeof data.pid, 'number');
+    } finally {
+        hb.stop();
+    }
+});
+
+test('startHeartbeat — stop() elimina el archivo', () => {
+    const hb = linter.startHeartbeat(7778);
+    const hbFile = path.join(TMP, '.claude', 'hooks', 'agent-7778.heartbeat');
+    assert.ok(fs.existsSync(hbFile));
+    hb.stop();
+    assert.ok(!fs.existsSync(hbFile));
+});
+
+test('updateMarker — actualiza YAML sin duplicar keys', () => {
+    const markerPath = path.join(TMP, '.pipeline', 'desarrollo', 'linteo', 'trabajando', '999.linter');
+    fs.writeFileSync(markerPath, 'issue: 999\nskill: "linter"\nresultado: "pendiente"\n');
+    linter.updateMarker(markerPath, {
+        resultado: 'aprobado',
+        motivo: 'Linter OK',
+        linter_errors: 0,
+    });
+    const content = fs.readFileSync(markerPath, 'utf8');
+    assert.match(content, /resultado: "aprobado"/);
+    assert.match(content, /motivo: "Linter OK"/);
+    assert.match(content, /linter_errors: 0/);
+    // No debe haber duplicado la key "resultado"
+    const matches = content.match(/^resultado:/gm) || [];
+    assert.equal(matches.length, 1, 'resultado debe aparecer una sola vez');
+});
+
+test('updateMarker — sin trabajandoPath no tira excepción', () => {
+    assert.doesNotThrow(() => linter.updateMarker(null, { foo: 'bar' }));
+    assert.doesNotThrow(() => linter.updateMarker(undefined, { foo: 'bar' }));
+});
+
+test('runAllChecks — integra static-checks sin romper con repo vacío', () => {
+    // Con git no disponible / sin commits, igual debe devolver findings (branch warn + no-commits)
+    // NOTA: runAllChecks llama a git real; si git falla, los helpers devuelven vacío.
+    // Probamos que el shape del retorno sea correcto.
+    const r = linter.runAllChecks({ issue: 1, cwd: TMP, base: 'origin/main' });
+    assert.ok(Array.isArray(r.findings));
+    assert.equal(typeof r.stats, 'object');
+    assert.equal(typeof r.commitCount, 'number');
+    assert.equal(typeof r.fileCount, 'number');
+});

--- a/.pipeline/skills-deterministicos/__tests__/static-checks.test.js
+++ b/.pipeline/skills-deterministicos/__tests__/static-checks.test.js
@@ -1,0 +1,262 @@
+// Tests unitarios de lib/static-checks.js (issue #2491)
+// Cada check es una función pura: probamos los casos conocidos que debe
+// detectar (positivos) y los que NO debe disparar (negativos).
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const c = require('../lib/static-checks');
+
+// ── checkSecretsInDiff ───────────────────────────────────────────────
+test('checkSecretsInDiff — detecta AWS Access Key ID en línea agregada', () => {
+    const diff = [
+        'diff --git a/config.js b/config.js',
+        '--- a/config.js',
+        '+++ b/config.js',
+        '@@ -1,1 +1,2 @@',
+        ' // old',
+        '+const key = "AKIAIOSFODNN7EXAMPLE";',
+    ].join('\n');
+    const f = c.checkSecretsInDiff(diff);
+    assert.ok(f.some((x) => x.rule === 'secret:aws-access-key'), 'debe detectar AKIA...');
+    assert.equal(f[0].severity, 'error');
+    assert.equal(f[0].file, 'config.js');
+});
+
+test('checkSecretsInDiff — detecta GitHub PAT y OpenAI key', () => {
+    const diff = [
+        '+++ b/app.js',
+        '@@ -0,0 +1,3 @@',
+        '+const gh = "ghp_abcdefghijklmnopqrstuvwxyz0123456789";',
+        '+const oai = "sk-proj1234567890abcdefghijklmnopqrstuv";',
+        '+const telegram = "1234567890:ABCdefGHIjklmNOPqrsTUVwxyZ012345678";',
+    ].join('\n');
+    const f = c.checkSecretsInDiff(diff);
+    const rules = new Set(f.map((x) => x.rule));
+    assert.ok(rules.has('secret:github-token'));
+    assert.ok(rules.has('secret:openai-key'));
+    assert.ok(rules.has('secret:telegram-bot-token'));
+});
+
+test('checkSecretsInDiff — detecta bloque de clave privada PEM', () => {
+    const diff = [
+        '+++ b/keys/private.pem',
+        '@@ -0,0 +1,2 @@',
+        '+-----BEGIN RSA PRIVATE KEY-----',
+        '+MIIEowIBAAKCAQEA...',
+    ].join('\n');
+    const f = c.checkSecretsInDiff(diff);
+    assert.ok(f.some((x) => x.rule === 'secret:private-key'));
+});
+
+test('checkSecretsInDiff — ignora docs/ y archivos .md (allowlist)', () => {
+    const diff = [
+        '+++ b/docs/example.md',
+        '@@ -0,0 +1,1 @@',
+        '+Ejemplo: AKIAIOSFODNN7EXAMPLE',
+    ].join('\n');
+    const f = c.checkSecretsInDiff(diff);
+    assert.equal(f.length, 0, 'docs/*.md no dispara secrets');
+});
+
+test('checkSecretsInDiff — ignora líneas eliminadas (solo analiza +)', () => {
+    const diff = [
+        '+++ b/config.js',
+        '@@ -1,2 +1,1 @@',
+        '-const key = "AKIAIOSFODNN7EXAMPLE";',
+        ' // kept',
+    ].join('\n');
+    const f = c.checkSecretsInDiff(diff);
+    assert.equal(f.length, 0, 'solo detecta en líneas + (agregadas)');
+});
+
+// ── checkForbiddenStringsInDiff ──────────────────────────────────────
+test('checkForbiddenStringsInDiff — detecta stringResource() en capa UI', () => {
+    const diff = [
+        '+++ b/app/composeApp/src/commonMain/kotlin/ui/sc/Login.kt',
+        '@@ -0,0 +1,1 @@',
+        '+val title = stringResource(Res.string.login_title)',
+    ].join('\n');
+    const f = c.checkForbiddenStringsInDiff(diff);
+    assert.ok(f.some((x) => x.rule === 'strings:direct-string-resource'));
+    assert.ok(f.some((x) => x.rule === 'strings:res-string-access'));
+});
+
+test('checkForbiddenStringsInDiff — ignora archivos fuera de app/composeApp/src', () => {
+    const diff = [
+        '+++ b/backend/src/main/kotlin/Handler.kt',
+        '@@ -0,0 +1,1 @@',
+        '+val x = stringResource(Res.string.ok)',
+    ].join('\n');
+    const f = c.checkForbiddenStringsInDiff(diff);
+    assert.equal(f.length, 0, 'sólo UI composeApp dispara la regla');
+});
+
+test('checkForbiddenStringsInDiff — ignora ui/util/ResStrings (allowlist)', () => {
+    const diff = [
+        '+++ b/app/composeApp/src/commonMain/kotlin/ui/util/ResStrings.kt',
+        '@@ -0,0 +1,1 @@',
+        '+return stringResource(id)',
+    ].join('\n');
+    const f = c.checkForbiddenStringsInDiff(diff);
+    assert.equal(f.length, 0, 'ResStrings puede usar stringResource directo');
+});
+
+test('checkForbiddenStringsInDiff — detecta import kotlin.io.encoding.Base64 en UI', () => {
+    const diff = [
+        '+++ b/app/composeApp/src/commonMain/kotlin/ui/cp/Foo.kt',
+        '@@ -0,0 +1,1 @@',
+        '+import kotlin.io.encoding.Base64',
+    ].join('\n');
+    const f = c.checkForbiddenStringsInDiff(diff);
+    assert.ok(f.some((x) => x.rule === 'strings:base64-ui-import'));
+});
+
+// ── checkBranchName ──────────────────────────────────────────────────
+test('checkBranchName — agent/<issue>-<slug> con issue correcto no reporta', () => {
+    const f = c.checkBranchName('agent/2491-split-linter-reviewer', { issue: 2491 });
+    assert.equal(f.length, 0);
+});
+
+test('checkBranchName — agent/<N>-... con issue distinto emite warn issue-mismatch', () => {
+    const f = c.checkBranchName('agent/2490-partial-pause', { issue: 2491 });
+    assert.equal(f.length, 1);
+    assert.equal(f[0].rule, 'branch:issue-mismatch');
+    assert.equal(f[0].severity, 'warn');
+});
+
+test('checkBranchName — main/develop/HEAD bloquea con error', () => {
+    for (const b of ['main', 'develop', 'HEAD']) {
+        const f = c.checkBranchName(b);
+        assert.equal(f[0].rule, 'branch:protected');
+        assert.equal(f[0].severity, 'error');
+    }
+});
+
+test('checkBranchName — feature/bugfix/docs válidos pasan', () => {
+    assert.equal(c.checkBranchName('feature/nuevo-login').length, 0);
+    assert.equal(c.checkBranchName('bugfix/ajuste-x').length, 0);
+    assert.equal(c.checkBranchName('docs/readme').length, 0);
+});
+
+test('checkBranchName — rama sin convención emite warn', () => {
+    const f = c.checkBranchName('cualquier-cosa');
+    assert.ok(f.some((x) => x.rule === 'branch:naming' && x.severity === 'warn'));
+});
+
+test('checkBranchName — branch vacío/null emite error', () => {
+    const f = c.checkBranchName(null);
+    assert.equal(f[0].rule, 'branch:missing');
+    assert.equal(f[0].severity, 'error');
+});
+
+// ── checkSensitiveFiles ──────────────────────────────────────────────
+test('checkSensitiveFiles — detecta .env, .pem, .keystore, credentials.json', () => {
+    const files = [
+        '.env',
+        'config/.env.prod',
+        'keys/server.pem',
+        'app/release.keystore',
+        'src/credentials.json',
+        'users/src/main/resources/application.conf',
+    ];
+    const f = c.checkSensitiveFiles(files);
+    assert.equal(f.length, files.length);
+    assert.ok(f.every((x) => x.severity === 'error'));
+});
+
+test('checkSensitiveFiles — archivos normales no disparan', () => {
+    const f = c.checkSensitiveFiles(['src/App.kt', 'docs/readme.md', 'package.json']);
+    assert.equal(f.length, 0);
+});
+
+// ── checkDiffSize ────────────────────────────────────────────────────
+test('checkDiffSize — PR chico no emite warnings', () => {
+    const f = c.checkDiffSize({ files_changed: 5, additions: 100, deletions: 20 });
+    assert.equal(f.length, 0);
+});
+
+test('checkDiffSize — PR gigante emite dos warnings', () => {
+    const f = c.checkDiffSize({ files_changed: 50, additions: 800, deletions: 300 });
+    const rules = new Set(f.map((x) => x.rule));
+    assert.ok(rules.has('size:diff-large'));
+    assert.ok(rules.has('size:many-files'));
+});
+
+// ── checkClosesIssue ─────────────────────────────────────────────────
+test('checkClosesIssue — commit con "Closes #N" pasa', () => {
+    const msgs = ['feat(x): algo\n\nCloses #2491'];
+    assert.equal(c.checkClosesIssue(msgs, 2491).length, 0);
+});
+
+test('checkClosesIssue — acepta Fixes/Resolves', () => {
+    assert.equal(c.checkClosesIssue(['feat: x\n\nFixes #10'], 10).length, 0);
+    assert.equal(c.checkClosesIssue(['feat: y\n\nResolves #11'], 11).length, 0);
+});
+
+test('checkClosesIssue — sin referencia emite warn', () => {
+    const f = c.checkClosesIssue(['feat: x'], 42);
+    assert.equal(f[0].rule, 'pr:missing-closes');
+    assert.equal(f[0].severity, 'warn');
+});
+
+test('checkClosesIssue — sin commits emite error', () => {
+    const f = c.checkClosesIssue([], 42);
+    assert.equal(f[0].rule, 'pr:no-commits');
+    assert.equal(f[0].severity, 'error');
+});
+
+// ── checkCommitSubjects ──────────────────────────────────────────────
+test('checkCommitSubjects — subject corto y sin puntuación final pasa', () => {
+    assert.equal(c.checkCommitSubjects(['feat(x): cambio chico']).length, 0);
+});
+
+test('checkCommitSubjects — subject >100 chars emite info', () => {
+    const long = 'feat(x): ' + 'a'.repeat(120);
+    const f = c.checkCommitSubjects([long]);
+    assert.ok(f.some((x) => x.rule === 'commit:subject-long'));
+});
+
+test('checkCommitSubjects — subject termina con "." emite info', () => {
+    const f = c.checkCommitSubjects(['feat(x): cambio.']);
+    assert.ok(f.some((x) => x.rule === 'commit:subject-punctuation'));
+});
+
+// ── aggregate ────────────────────────────────────────────────────────
+test('aggregate — passed=true cuando no hay errors', () => {
+    const findings = [
+        { rule: 'x', severity: 'warn', message: 'w' },
+        { rule: 'y', severity: 'info', message: 'i' },
+    ];
+    const a = c.aggregate(findings);
+    assert.equal(a.passed, true);
+    assert.equal(a.counts.warn, 1);
+    assert.equal(a.counts.info, 1);
+    assert.equal(a.total, 2);
+});
+
+test('aggregate — passed=false si hay al menos un error', () => {
+    const a = c.aggregate([{ rule: 'x', severity: 'error', message: 'e' }]);
+    assert.equal(a.passed, false);
+    assert.equal(a.counts.error, 1);
+});
+
+// ── renderMarkdownReport ─────────────────────────────────────────────
+test('renderMarkdownReport — sin findings marca aprobado', () => {
+    const md = c.renderMarkdownReport([], { issue: 99, branch: 'agent/99-x' });
+    assert.match(md, /APROBADO/);
+    assert.match(md, /Sin findings/);
+});
+
+test('renderMarkdownReport — con errores marca rechazado y agrupa por severidad', () => {
+    const findings = [
+        { rule: 'a', severity: 'error', file: 'f.kt', line: 10, message: 'err' },
+        { rule: 'b', severity: 'warn', message: 'wrn' },
+    ];
+    const md = c.renderMarkdownReport(findings, { issue: 1, branch: 'agent/1-x' });
+    assert.match(md, /RECHAZADO/);
+    assert.match(md, /### Errores/);
+    assert.match(md, /### Warnings/);
+    assert.match(md, /f\.kt:10/);
+});

--- a/.pipeline/skills-deterministicos/lib/static-checks.js
+++ b/.pipeline/skills-deterministicos/lib/static-checks.js
@@ -1,0 +1,408 @@
+'use strict';
+
+/**
+ * static-checks.js — Chequeos mecánicos reutilizables para el linter determinístico.
+ *
+ * Cada check es una función pura: recibe texto/metadata y devuelve findings con
+ * forma { rule, severity, file?, line?, message }. El linter.js compone los
+ * chequeos y agrega el reporte final.
+ *
+ * Convenciones:
+ *   - rule: identificador corto estable (ej. 'secret:aws-access-key')
+ *   - severity: 'error' | 'warn' | 'info'
+ *   - Sólo los 'error' bloquean el flujo (exit 1 + rebote a dev).
+ */
+
+// ── Detección de secretos ────────────────────────────────────────────
+// Patrones conservadores: preferimos false-negatives a false-positives en
+// strings comunes del código. Los tokens/keys bien formados son muy largos
+// y con charset específico, lo que reduce el ruido.
+const SECRET_PATTERNS = [
+    {
+        rule: 'secret:aws-access-key',
+        rx: /\b(AKIA|ASIA)[0-9A-Z]{16}\b/,
+        message: 'Posible AWS Access Key ID hardcodeada',
+    },
+    {
+        rule: 'secret:aws-secret-key',
+        // Heurística: asignación a variable con nombre típico + valor base64-ish largo
+        rx: /(?:aws_?secret(?:_?access)?_?key|secret_access_key)\s*[:=]\s*["'][A-Za-z0-9/+=]{40}["']/i,
+        message: 'Posible AWS Secret Access Key hardcodeada',
+    },
+    {
+        rule: 'secret:github-token',
+        rx: /\bghp_[A-Za-z0-9]{36,}\b|\bgithub_pat_[A-Za-z0-9_]{22,}\b/,
+        message: 'Posible GitHub Personal Access Token',
+    },
+    {
+        rule: 'secret:openai-key',
+        rx: /\bsk-[A-Za-z0-9]{20,}\b/,
+        message: 'Posible OpenAI API key',
+    },
+    {
+        rule: 'secret:telegram-bot-token',
+        rx: /\b\d{9,10}:[A-Za-z0-9_-]{35}\b/,
+        message: 'Posible Telegram bot token',
+    },
+    {
+        rule: 'secret:private-key',
+        rx: /-----BEGIN (?:RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY-----/,
+        message: 'Bloque de clave privada detectado',
+    },
+    {
+        rule: 'secret:generic-api-key',
+        // Variables que se llaman *_api_key, *_secret, password = ... con valor > 16 chars
+        rx: /\b(?:api_?key|secret|password|passwd|pwd)\s*[:=]\s*["'][A-Za-z0-9_\-+/=!@#$%^&*.]{16,}["']/i,
+        message: 'Asignación sospechosa a variable tipo api_key/secret/password',
+    },
+];
+
+// Allowlist para secretos: archivos/paths donde NO reportar (docs, ejemplos, tests).
+const SECRETS_ALLOWLIST = [
+    /^docs\//,
+    /\.md$/,
+    /\.test\.(js|ts|kt)$/,
+    /__tests__\//,
+    /\/fixtures\//,
+    /\/testdata\//,
+    /\.example$/,
+    /\.example\./,
+    /\.sample$/,
+];
+
+function isSecretAllowed(filePath) {
+    if (!filePath) return false;
+    return SECRETS_ALLOWLIST.some((rx) => rx.test(filePath));
+}
+
+/**
+ * Analiza un diff unificado y detecta secretos en las líneas agregadas (+).
+ * @param {string} unifiedDiff — output de `git diff`
+ * @returns {Array<{rule,severity,file,line,message}>}
+ */
+function checkSecretsInDiff(unifiedDiff) {
+    const findings = [];
+    if (!unifiedDiff) return findings;
+    const lines = unifiedDiff.split(/\r?\n/);
+    let currentFile = null;
+    let newLineNum = 0;
+
+    for (const ln of lines) {
+        const fileMatch = ln.match(/^\+\+\+ b\/(.+)$/);
+        if (fileMatch) {
+            currentFile = fileMatch[1];
+            newLineNum = 0;
+            continue;
+        }
+        const hunkMatch = ln.match(/^@@ .*\+(\d+)(?:,\d+)? @@/);
+        if (hunkMatch) {
+            newLineNum = parseInt(hunkMatch[1], 10) - 1;
+            continue;
+        }
+        if (ln.startsWith('+') && !ln.startsWith('+++')) {
+            newLineNum += 1;
+            if (!currentFile || isSecretAllowed(currentFile)) continue;
+            const content = ln.slice(1);
+            for (const p of SECRET_PATTERNS) {
+                if (p.rx.test(content)) {
+                    findings.push({
+                        rule: p.rule,
+                        severity: 'error',
+                        file: currentFile,
+                        line: newLineNum,
+                        message: p.message,
+                    });
+                }
+            }
+        } else if (!ln.startsWith('-') && !ln.startsWith('---')) {
+            newLineNum += 1;
+        }
+    }
+    return findings;
+}
+
+// ── Strings prohibidos en capa UI ────────────────────────────────────
+// Replican las reglas del KSP forbidden-strings-processor, pero para que
+// el linter las detecte ANTES de compilar Gradle. Sólo aplica a archivos
+// de la app Compose (app/composeApp/src/).
+const FORBIDDEN_STRINGS_RULES = [
+    {
+        rule: 'strings:direct-string-resource',
+        rx: /\bstringResource\s*\(/,
+        message: 'Uso directo de stringResource() fuera de ui/util/ResStrings — usar resString(...)',
+    },
+    {
+        rule: 'strings:res-string-access',
+        rx: /\bRes\.string\.[A-Za-z_][A-Za-z0-9_]*/,
+        message: 'Acceso directo a Res.string.* — usar resString(...)',
+    },
+    {
+        rule: 'strings:r-string-access',
+        rx: /\bR\.string\.[A-Za-z_][A-Za-z0-9_]*/,
+        message: 'Acceso directo a R.string.* — usar resString(...)',
+    },
+    {
+        rule: 'strings:context-get-string',
+        rx: /\bcontext\.getString\s*\(|\bgetString\s*\(\s*R\.string\./,
+        message: 'Uso de getString(...) directo — usar resString(...)',
+    },
+    {
+        rule: 'strings:base64-ui-import',
+        rx: /^\s*import\s+kotlin\.io\.encoding\.Base64/,
+        message: 'Import de kotlin.io.encoding.Base64 prohibido en capa UI',
+    },
+];
+
+const UI_PATH_PATTERN = /^app\/composeApp\/src\/.*\.kt$/;
+const RESSTRINGS_ALLOWLIST = /ui\/util\/ResStrings/;
+
+function checkForbiddenStringsInDiff(unifiedDiff) {
+    const findings = [];
+    if (!unifiedDiff) return findings;
+    const lines = unifiedDiff.split(/\r?\n/);
+    let currentFile = null;
+    let newLineNum = 0;
+
+    for (const ln of lines) {
+        const fileMatch = ln.match(/^\+\+\+ b\/(.+)$/);
+        if (fileMatch) {
+            currentFile = fileMatch[1];
+            newLineNum = 0;
+            continue;
+        }
+        const hunkMatch = ln.match(/^@@ .*\+(\d+)(?:,\d+)? @@/);
+        if (hunkMatch) {
+            newLineNum = parseInt(hunkMatch[1], 10) - 1;
+            continue;
+        }
+        if (ln.startsWith('+') && !ln.startsWith('+++')) {
+            newLineNum += 1;
+            if (!currentFile) continue;
+            if (!UI_PATH_PATTERN.test(currentFile)) continue;
+            if (RESSTRINGS_ALLOWLIST.test(currentFile)) continue;
+            const content = ln.slice(1);
+            for (const r of FORBIDDEN_STRINGS_RULES) {
+                if (r.rx.test(content)) {
+                    findings.push({
+                        rule: r.rule,
+                        severity: 'error',
+                        file: currentFile,
+                        line: newLineNum,
+                        message: r.message,
+                    });
+                }
+            }
+        } else if (!ln.startsWith('-') && !ln.startsWith('---')) {
+            newLineNum += 1;
+        }
+    }
+    return findings;
+}
+
+// ── Naming de ramas ──────────────────────────────────────────────────
+/**
+ * Valida el nombre de rama según convenciones del repo.
+ * - Agentes IA: agent/<issue>-<slug> (obligatorio para el pipeline)
+ * - Feature/bugfix/docs/refactor manuales: <prefix>/<slug>
+ */
+function checkBranchName(branch, { issue = null } = {}) {
+    const findings = [];
+    if (!branch) {
+        findings.push({
+            rule: 'branch:missing', severity: 'error',
+            message: 'No se pudo determinar la rama actual',
+        });
+        return findings;
+    }
+    if (branch === 'main' || branch === 'develop' || branch === 'HEAD') {
+        findings.push({
+            rule: 'branch:protected', severity: 'error',
+            message: `Trabajando directamente sobre "${branch}" — usar agent/feature/bugfix/...`,
+        });
+        return findings;
+    }
+    const agentRx = /^agent\/(\d+)-[a-z0-9-]+$/;
+    const manualRx = /^(feature|bugfix|docs|refactor|test|chore|fix)\/[a-z0-9][a-z0-9-]*$/i;
+    const m = branch.match(agentRx);
+    if (m) {
+        if (issue && parseInt(m[1], 10) !== Number(issue)) {
+            findings.push({
+                rule: 'branch:issue-mismatch', severity: 'warn',
+                message: `Rama agent/${m[1]}-... no coincide con issue #${issue}`,
+            });
+        }
+        return findings;
+    }
+    if (manualRx.test(branch)) return findings;
+    findings.push({
+        rule: 'branch:naming', severity: 'warn',
+        message: `Rama "${branch}" no sigue convención agent/<issue>-<slug> ni feature/bugfix/...`,
+    });
+    return findings;
+}
+
+// ── Archivos sensibles ───────────────────────────────────────────────
+const SENSITIVE_FILE_PATTERNS = [
+    { rx: /(^|\/)\.env(\..*)?$/, message: 'Archivo .env agregado al repo' },
+    { rx: /\.pem$/, message: 'Archivo .pem (certificado/clave)' },
+    { rx: /\.p12$/, message: 'Archivo .p12 (keystore)' },
+    { rx: /(^|\/)id_rsa(\.pub)?$/, message: 'Clave SSH id_rsa' },
+    { rx: /\.keystore$/, message: 'Android keystore' },
+    { rx: /credentials(\.json|\.yaml|\.yml)?$/i, message: 'Archivo credentials' },
+    { rx: /(^|\/)application\.conf$/, message: 'application.conf (podría contener secrets de AWS)' },
+];
+
+function checkSensitiveFiles(filePaths) {
+    const findings = [];
+    for (const p of filePaths || []) {
+        for (const pat of SENSITIVE_FILE_PATTERNS) {
+            if (pat.rx.test(p)) {
+                findings.push({
+                    rule: 'files:sensitive', severity: 'error',
+                    file: p, message: pat.message,
+                });
+            }
+        }
+    }
+    return findings;
+}
+
+// ── Tamaño del diff ──────────────────────────────────────────────────
+function checkDiffSize({ files_changed = 0, additions = 0, deletions = 0 } = {}, thresholds = {}) {
+    const { warn_lines = 1000, warn_files = 40 } = thresholds;
+    const findings = [];
+    const totalLines = additions + deletions;
+    if (totalLines > warn_lines) {
+        findings.push({
+            rule: 'size:diff-large', severity: 'warn',
+            message: `PR grande: ${totalLines} líneas (+${additions} -${deletions}) — considerar split`,
+        });
+    }
+    if (files_changed > warn_files) {
+        findings.push({
+            rule: 'size:many-files', severity: 'warn',
+            message: `PR toca ${files_changed} archivos — considerar split`,
+        });
+    }
+    return findings;
+}
+
+// ── Reglas de PR / commits ───────────────────────────────────────────
+/**
+ * Verifica que al menos un commit en la rama referencie el issue con "Closes #N".
+ * Acepta variantes: Closes, Fixes, Resolves (case-insensitive).
+ */
+function checkClosesIssue(commitMessages, issue) {
+    const findings = [];
+    if (!issue) return findings;
+    if (!commitMessages || !commitMessages.length) {
+        findings.push({
+            rule: 'pr:no-commits', severity: 'error',
+            message: 'No se encontraron commits en la rama',
+        });
+        return findings;
+    }
+    const rx = new RegExp(`\\b(?:closes|fixes|resolves)\\s+#${issue}\\b`, 'i');
+    const hasClose = commitMessages.some((m) => rx.test(m));
+    if (!hasClose) {
+        findings.push({
+            rule: 'pr:missing-closes', severity: 'warn',
+            message: `Ningún commit referencia "Closes #${issue}" — el PR no cerrará el issue automáticamente`,
+        });
+    }
+    return findings;
+}
+
+function checkCommitSubjects(commitMessages) {
+    const findings = [];
+    if (!commitMessages) return findings;
+    // Reglas conservadoras: subject ≤ 100 chars, no terminar con punto.
+    for (const msg of commitMessages) {
+        const subject = (msg || '').split(/\r?\n/)[0] || '';
+        if (!subject) continue;
+        if (subject.length > 100) {
+            findings.push({
+                rule: 'commit:subject-long', severity: 'info',
+                message: `Subject de commit > 100 chars: "${subject.slice(0, 60)}..."`,
+            });
+        }
+        if (/[.!]$/.test(subject)) {
+            findings.push({
+                rule: 'commit:subject-punctuation', severity: 'info',
+                message: `Subject termina con puntuación: "${subject.slice(0, 60)}"`,
+            });
+        }
+    }
+    return findings;
+}
+
+// ── Reporte ──────────────────────────────────────────────────────────
+function aggregate(findings) {
+    const bySeverity = { error: 0, warn: 0, info: 0 };
+    for (const f of findings || []) {
+        if (bySeverity[f.severity] !== undefined) bySeverity[f.severity] += 1;
+    }
+    const passed = bySeverity.error === 0;
+    return { passed, counts: bySeverity, total: findings.length };
+}
+
+function renderMarkdownReport(findings, { issue, duration_ms = 0, branch = null, stats = null } = {}) {
+    const agg = aggregate(findings);
+    const status = agg.passed ? 'APROBADO ✅' : 'RECHAZADO ❌';
+    const lines = [
+        `## Linter: ${status}`,
+        '',
+        `- Issue: #${issue}  ·  Rama: \`${branch || '(desconocida)'}\`  ·  Duración: ${(duration_ms / 1000).toFixed(2)}s`,
+        `- Findings: ${agg.total}  (errores: ${agg.counts.error}, warnings: ${agg.counts.warn}, info: ${agg.counts.info})`,
+    ];
+    if (stats) {
+        lines.push(`- Diff: ${stats.files_changed} archivos · +${stats.additions} -${stats.deletions}`);
+    }
+    lines.push('');
+
+    if (!findings.length) {
+        lines.push('Sin findings — chequeos mecánicos OK.');
+        return lines.join('\n');
+    }
+
+    const groups = {};
+    for (const f of findings) {
+        const key = f.severity;
+        if (!groups[key]) groups[key] = [];
+        groups[key].push(f);
+    }
+
+    for (const sev of ['error', 'warn', 'info']) {
+        if (!groups[sev]) continue;
+        const title = sev === 'error' ? 'Errores' : sev === 'warn' ? 'Warnings' : 'Info';
+        lines.push(`### ${title} (${groups[sev].length})`);
+        for (const f of groups[sev]) {
+            const loc = f.file ? ` — \`${f.file}${f.line ? `:${f.line}` : ''}\`` : '';
+            lines.push(`- **${f.rule}**${loc}: ${f.message}`);
+        }
+        lines.push('');
+    }
+
+    lines.push('### Veredicto');
+    lines.push(agg.passed
+        ? 'Linter no bloquea — pasan a reviewer LLM (solo warnings/info).'
+        : 'Linter bloquea entrega — rebote a dev para corregir errores listados.');
+    return lines.join('\n');
+}
+
+module.exports = {
+    SECRET_PATTERNS,
+    SECRETS_ALLOWLIST,
+    isSecretAllowed,
+    checkSecretsInDiff,
+    FORBIDDEN_STRINGS_RULES,
+    checkForbiddenStringsInDiff,
+    checkBranchName,
+    SENSITIVE_FILE_PATTERNS,
+    checkSensitiveFiles,
+    checkDiffSize,
+    checkClosesIssue,
+    checkCommitSubjects,
+    aggregate,
+    renderMarkdownReport,
+};

--- a/.pipeline/skills-deterministicos/linter.js
+++ b/.pipeline/skills-deterministicos/linter.js
@@ -1,0 +1,267 @@
+#!/usr/bin/env node
+/**
+ * linter.js — Skill determinístico /linter (issue #2491)
+ *
+ * Separa la parte mecánica del review. Corre chequeos estáticos 100% en Node
+ * (0 tokens LLM) y falla rápido si encuentra problemas bloqueantes (secretos,
+ * strings prohibidos en UI, archivos sensibles). Si pasa, el flujo continúa a
+ * la fase `aprobacion` donde el reviewer LLM se enfoca solo en calidad
+ * semántica, recibiendo el reporte del linter como contexto.
+ *
+ * Contrato idéntico al resto de skills determinísticos:
+ *   - Marker en `trabajando/<issue>.linter` (lo actualiza con resultado)
+ *   - Heartbeat `agent-<issue>.heartbeat` cada 30s
+ *   - Eventos `session:start` / `session:end` en activity-log
+ *   - Exit 0 = linter OK (marker → aprobado), 1 = findings bloqueantes (rebote)
+ *
+ * CLI:
+ *   node linter.js <issue> [--trabajando=<path>] [--base=origin/main]
+ *
+ * Env vars (pasadas por el Pulpo):
+ *   PIPELINE_ISSUE, PIPELINE_SKILL, PIPELINE_FASE, PIPELINE_TRABAJANDO, PIPELINE_PIPELINE
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const trace = require('../lib/traceability');
+const git = require('./lib/git-ops');
+const checks = require('./lib/static-checks');
+
+const REPO_ROOT = process.env.PIPELINE_REPO_ROOT || process.env.CLAUDE_PROJECT_DIR || path.resolve(__dirname, '..', '..');
+const HOOKS_DIR = path.join(REPO_ROOT, '.claude', 'hooks');
+const LOG_DIR = path.join(REPO_ROOT, '.pipeline', 'logs');
+const HEARTBEAT_INTERVAL_MS = 30 * 1000;
+
+function parseArgs(argv) {
+    const args = { issue: null, trabajando: null, base: 'origin/main' };
+    for (const a of argv.slice(2)) {
+        if (/^\d+$/.test(a) && !args.issue) { args.issue = parseInt(a, 10); continue; }
+        const kv = a.match(/^--([\w-]+)=(.+)$/);
+        if (kv) {
+            if (kv[1] === 'trabajando') args.trabajando = kv[2];
+            else if (kv[1] === 'base') args.base = kv[2];
+        }
+    }
+    args.issue = args.issue || (process.env.PIPELINE_ISSUE ? Number(process.env.PIPELINE_ISSUE) : null);
+    args.trabajando = args.trabajando || process.env.PIPELINE_TRABAJANDO || null;
+    return args;
+}
+
+function startHeartbeat(issue) {
+    if (!issue) return { stop: () => {} };
+    try { fs.mkdirSync(HOOKS_DIR, { recursive: true }); } catch {}
+    const hbFile = path.join(HOOKS_DIR, `agent-${issue}.heartbeat`);
+    const writeHb = () => {
+        try {
+            fs.writeFileSync(hbFile, JSON.stringify({
+                issue, skill: 'linter', pid: process.pid, model: 'deterministic',
+                ts: new Date().toISOString(),
+            }) + '\n');
+        } catch {}
+    };
+    writeHb();
+    const iv = setInterval(writeHb, HEARTBEAT_INTERVAL_MS);
+    iv.unref?.();
+    return {
+        stop: () => {
+            clearInterval(iv);
+            try { fs.unlinkSync(hbFile); } catch {}
+        },
+    };
+}
+
+function updateMarker(trabajandoPath, payload) {
+    if (!trabajandoPath) return;
+    try {
+        let existing = '';
+        if (fs.existsSync(trabajandoPath)) {
+            existing = fs.readFileSync(trabajandoPath, 'utf8');
+        }
+        const lines = existing.split(/\r?\n/).filter(Boolean);
+        const kept = [];
+        for (const ln of lines) {
+            const m = ln.match(/^([\w_]+)\s*:/);
+            if (m && (m[1] in payload)) continue;
+            kept.push(ln);
+        }
+        const appended = [];
+        for (const [k, v] of Object.entries(payload)) {
+            if (v === null || v === undefined) continue;
+            const val = typeof v === 'string' ? JSON.stringify(v) : String(v);
+            appended.push(`${k}: ${val}`);
+        }
+        fs.writeFileSync(trabajandoPath, [...kept, ...appended].join('\n') + '\n', 'utf8');
+    } catch (e) {
+        process.stderr.write(`[linter] No se pudo actualizar marker: ${e.message}\n`);
+    }
+}
+
+function getCommitMessages(cwd, base) {
+    const r = git.runGit(['log', `${base}..HEAD`, '--pretty=format:%B%n---COMMIT---'], { cwd });
+    if (r.exit_code !== 0) return [];
+    return (r.stdout || '')
+        .split('---COMMIT---')
+        .map((s) => s.trim())
+        .filter(Boolean);
+}
+
+function getDiffText(cwd, base) {
+    const r = git.runGit(['diff', `${base}...HEAD`], { cwd, timeoutMs: 60 * 1000 });
+    return r.stdout || '';
+}
+
+function getChangedFilePaths(cwd, base) {
+    const r = git.runGit(['diff', '--name-only', `${base}...HEAD`], { cwd });
+    if (r.exit_code !== 0) return [];
+    return (r.stdout || '').split(/\r?\n/).map((s) => s.trim()).filter(Boolean);
+}
+
+/**
+ * Corre todos los chequeos estáticos sobre el estado actual del repo.
+ * Separado para permitir tests con mocks sobre git-ops.
+ */
+function runAllChecks({ issue, cwd, base }) {
+    const findings = [];
+    const branch = git.getCurrentBranch(cwd);
+    findings.push(...checks.checkBranchName(branch, { issue }));
+
+    // Fetch origin/main — best-effort, no bloqueamos si falla
+    const fetchRes = git.fetchOrigin(cwd);
+    const hasBase = fetchRes.exit_code === 0;
+
+    const commitMsgs = hasBase ? getCommitMessages(cwd, base) : [];
+    const diffText = hasBase ? getDiffText(cwd, base) : '';
+    const changedFiles = hasBase ? getChangedFilePaths(cwd, base) : [];
+    const stats = hasBase ? git.getDiffStats(cwd, base) : { files_changed: 0, additions: 0, deletions: 0 };
+
+    findings.push(...checks.checkClosesIssue(commitMsgs, issue));
+    findings.push(...checks.checkCommitSubjects(commitMsgs));
+    findings.push(...checks.checkSensitiveFiles(changedFiles));
+    findings.push(...checks.checkSecretsInDiff(diffText));
+    findings.push(...checks.checkForbiddenStringsInDiff(diffText));
+    findings.push(...checks.checkDiffSize(stats));
+
+    return { findings, branch, stats, commitCount: commitMsgs.length, fileCount: changedFiles.length };
+}
+
+async function main() {
+    const args = parseArgs(process.argv);
+    const issue = args.issue;
+
+    if (!issue) {
+        process.stderr.write('[linter] Falta issue (CLI o env PIPELINE_ISSUE).\n');
+        process.exit(2);
+    }
+
+    try { fs.mkdirSync(LOG_DIR, { recursive: true }); } catch {}
+    const agentLog = path.join(LOG_DIR, `${issue}-linter.log`);
+    const logAppend = (msg) => {
+        try { fs.appendFileSync(agentLog, msg + '\n'); } catch {}
+    };
+    logAppend(`--- linter:#${issue} (deterministic) ${new Date().toISOString()} ---`);
+
+    const hb = startHeartbeat(issue);
+    const handle = trace.emitSessionStart({
+        skill: 'linter', issue, phase: process.env.PIPELINE_FASE || 'linteo',
+        model: 'deterministic',
+    });
+
+    const startedAt = Date.now();
+    let exitCode = 0;
+    let motivo = null;
+    let result = null;
+    let report = '';
+
+    try {
+        result = runAllChecks({ issue, cwd: REPO_ROOT, base: args.base });
+        logAppend(`[linter] branch=${result.branch} commits=${result.commitCount} files=${result.fileCount}`);
+        logAppend(`[linter] diff=${result.stats.files_changed}f +${result.stats.additions} -${result.stats.deletions}`);
+
+        const agg = checks.aggregate(result.findings);
+        logAppend(`[linter] findings: errores=${agg.counts.error} warnings=${agg.counts.warn} info=${agg.counts.info}`);
+
+        report = checks.renderMarkdownReport(result.findings, {
+            issue,
+            duration_ms: Date.now() - startedAt,
+            branch: result.branch,
+            stats: result.stats,
+        });
+        logAppend('[linter] --- REPORTE ---');
+        logAppend(report);
+
+        // Guardar reporte en ruta conocida para que el reviewer LLM pueda leerlo
+        const reportPath = path.join(LOG_DIR, `lint-${issue}-report.md`);
+        try { fs.writeFileSync(reportPath, report); } catch {}
+        try {
+            fs.writeFileSync(path.join(LOG_DIR, `lint-${issue}-report.json`), JSON.stringify({
+                issue,
+                branch: result.branch,
+                stats: result.stats,
+                findings: result.findings,
+                aggregate: agg,
+                generated_at: new Date().toISOString(),
+            }, null, 2));
+        } catch {}
+
+        if (!agg.passed) {
+            exitCode = 1;
+            const firstError = result.findings.find((f) => f.severity === 'error');
+            motivo = firstError
+                ? `Linter bloqueó: ${firstError.rule} — ${firstError.message}${firstError.file ? ` (${firstError.file}${firstError.line ? `:${firstError.line}` : ''})` : ''}`
+                : 'Linter bloqueó por findings de severidad error';
+        } else if (agg.counts.warn > 0) {
+            motivo = `Linter aprobado con ${agg.counts.warn} warning(s) — ver reporte`;
+        } else {
+            motivo = 'Linter aprobado sin findings bloqueantes';
+        }
+    } catch (e) {
+        exitCode = 2;
+        motivo = `Excepción en linter.js: ${e.message}`;
+        logAppend(`[linter] EXCEPTION: ${e.stack || e.message}`);
+    } finally {
+        const totalMs = Date.now() - startedAt;
+        const agg = result ? checks.aggregate(result.findings) : { counts: { error: 0, warn: 0, info: 0 }, total: 0 };
+
+        updateMarker(args.trabajando, {
+            resultado: exitCode === 0 ? 'aprobado' : 'rechazado',
+            motivo: motivo || (exitCode === 0 ? 'Linter aprobado' : 'Linter rechazado'),
+            linter_errors: agg.counts.error || 0,
+            linter_warnings: agg.counts.warn || 0,
+            linter_info: agg.counts.info || 0,
+            linter_total_findings: agg.total || 0,
+            linter_duration_ms: totalMs,
+            linter_report_path: path.join(LOG_DIR, `lint-${issue}-report.md`),
+            linter_mode: 'deterministic',
+        });
+
+        trace.emitSessionEnd(handle, {
+            tokens_in: 0, tokens_out: 0, cache_read: 0, cache_write: 0,
+            tool_calls: 1,
+            exit_code: exitCode,
+            duration_ms: totalMs,
+        });
+
+        hb.stop();
+    }
+
+    process.exit(exitCode);
+}
+
+if (require.main === module) {
+    main().catch((e) => {
+        process.stderr.write(`[linter] fatal: ${e.stack || e.message}\n`);
+        process.exit(2);
+    });
+}
+
+module.exports = {
+    parseArgs,
+    startHeartbeat,
+    updateMarker,
+    getCommitMessages,
+    getDiffText,
+    getChangedFilePaths,
+    runAllChecks,
+};


### PR DESCRIPTION
## Resumen

Separa el gate `/review` monolítico en dos roles especializados según #2491:

- **`/linter`** — determinístico (Node puro, cero tokens), chequeos mecánicos
- **`/reviewer`** — LLM acotado sólo a calidad semántica

## Cambios

### Rol nuevo — `linter` (determinístico)

- `.pipeline/roles/linter.md` — 54 líneas
- `.pipeline/skills-deterministicos/linter.js` — 267 líneas (runner + heartbeat + eventos V3 + reporte markdown/JSON)
- `.pipeline/skills-deterministicos/lib/static-checks.js` — 408 líneas (los chequeos puros, testeables)
- `.pipeline/skills-deterministicos/__tests__/static-checks.test.js` — 262 líneas, 27 tests
- `.pipeline/skills-deterministicos/__tests__/linter.test.js` — 103 líneas, 11 tests

**Qué chequea:**
1. Secretos hardcodeados (AWS, GitHub PAT, OpenAI, Telegram, PEM)
2. Strings prohibidos UI (`stringResource`, `Res.string.*`, `R.string.*`, `Base64` import)
3. Archivos sensibles (`.env`, `.pem`, `.keystore`, `credentials.json`)
4. Convención de rama (`agent/<issue>-<slug>`, `feature/*`, `bugfix/*`, `docs/*`)
5. Referencia `Closes #<issue>` en algún commit
6. Subject de commits (longitud <100, sin puntuación final)
7. Tamaño del diff (warnings si >1000 líneas o >40 archivos)

Genera `lint-<issue>-report.md` + `.json` que el reviewer lee después.

### Reviewer LLM acotado

- `.pipeline/roles/review.md` reescrito: ahora lee el reporte del linter y se
  enfoca sólo en patrones del proyecto, cohesión, cobertura lógica, riesgos
  arquitectónicos. Sección explícita de "Qué NO hacer" (no repetir chequeos del
  linter).

### Wiring

- `.pipeline/config.yaml`: fase nueva `linteo` entre `verificacion` y
  `aprobacion` (timeout 5min, concurrencia 3). Orden efectivo del pulpo
  actualizado: `entrega → aprobacion → linteo → verificacion → build → dev → validacion`.
- `.pipeline/pulpo.js`: `linter` sumado a `DETERMINISTIC_SKILLS` y
  `NETWORK_REQUIRED_PHASES`.

## Tests

```
ℹ tests 38
ℹ pass 38
ℹ fail 0
```

## Test plan

- [x] 38/38 tests unitarios pasan (`static-checks` + `linter`)
- [x] El linter emite heartbeat, eventos V3, reporte markdown + JSON
- [x] El reviewer ya no repite chequeos mecánicos
- [x] Rollout reversible: borrar el archivo `skills-deterministicos/linter.js` → fallback al agente LLM

Closes #2491

🤖 Generated with [Claude Code](https://claude.com/claude-code)