### PR TITLE
fix(pipeline): priority windows respetan paused/partial_pause por diseño

### DIFF
--- a/.pipeline/priority-windows.json
+++ b/.pipeline/priority-windows.json
@@ -1,0 +1,13 @@
+{
+  "qa": {
+    "active": false,
+    "activatedAt": null,
+    "manual": false
+  },
+  "build": {
+    "active": false,
+    "activatedAt": null,
+    "manual": false
+  },
+  "updatedAt": 1777024382604
+}

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -1605,6 +1605,25 @@ function evaluateQaPriority(config) {
   const safetyTimeoutHours = limits.priority_windows_safety_timeout_hours || 2;
   const now = Date.now();
 
+  // Diseño: las ventanas no tienen sentido cuando el pipeline está
+  // detenido (`paused`) o restringido a una allowlist (`partial_pause`).
+  // En esos modos no procesamos despacho normal, así que cualquier ventana
+  // activa quedaría pegada hasta que se libere la pausa. Forzamos cierre.
+  const pipelineMode = partialPause.getPipelineMode().mode;
+  if (pipelineMode === 'paused' || pipelineMode === 'partial_pause') {
+    if (qaPriorityActive) {
+      log('qa-priority', `🟢 QA Priority Window desactivada — pipeline en modo ${pipelineMode}`);
+      qaPriorityActive = false;
+      qaPriorityActivatedAt = 0;
+      qaFirstBlockedAt = 0;
+      qaPriorityManual = false;
+      qaPriorityNotifiedTelegram = false;
+      qaPrioritySafetyNotified = false;
+      persistPriorityWindows();
+    }
+    return false;
+  }
+
   const pendingQa = countPendingVerificacion(config);
 
   // ---- Desactivación ----
@@ -1717,6 +1736,23 @@ function evaluateBuildPriority(config) {
   const threshold = limits.priority_windows_activation_threshold || 3;
   const safetyTimeoutHours = limits.priority_windows_safety_timeout_hours || 2;
   const now = Date.now();
+
+  // Diseño: las ventanas no tienen sentido cuando el pipeline está
+  // detenido (`paused`) o restringido a una allowlist (`partial_pause`).
+  const pipelineMode = partialPause.getPipelineMode().mode;
+  if (pipelineMode === 'paused' || pipelineMode === 'partial_pause') {
+    if (buildPriorityActive) {
+      log('build-priority', `🟢 Build Priority Window desactivada — pipeline en modo ${pipelineMode}`);
+      buildPriorityActive = false;
+      buildPriorityActivatedAt = 0;
+      buildFirstBlockedAt = 0;
+      buildPriorityManual = false;
+      buildPriorityNotifiedTelegram = false;
+      buildPrioritySafetyNotified = false;
+      persistPriorityWindows();
+    }
+    return false;
+  }
 
   const pendingBuild = countPendingBuild(config);
   const runningBuild = countRunningBuild(config);


### PR DESCRIPTION
## Resumen

Las ventanas de prioridad QA y Build ahora se desactivan automáticamente cuando el pipeline está en `paused` o `partial_pause`. Antes quedaban pegadas porque su única forma de desactivarse era vaciar la cola — y en pausa la cola nunca se procesa.

## Caso real reproducido (incidente 2026-04-24)

1. Pausa parcial activa con allowlist `[2450]`.
2. Token huérfano `99999.qa.guidance.txt` en `verificacion/pendiente/` envenena el conteo `pendingQa`.
3. Ventana QA se activa y bloquea fase `validacion` (entre las `QA_BLOCKED_PHASES`).
4. #2450 entra al intake, genera tokens en `validacion/pendiente/` y nunca se despachan: `qaPriority=true` los bloquea.
5. Ventana no se cierra porque `pendingQa > 0` (token huérfano + tokens reales bloqueados por `partial_pause`).
6. Deadlock: 7h+ con #2450 sin avanzar.

## Cambios

- `pulpo.js: evaluateQaPriority` — guard al inicio: si el pipeline está `paused` o `partial_pause`, se fuerza cierre de la ventana (si estaba activa) y retorna `false`.
- `pulpo.js: evaluateBuildPriority` — mismo tratamiento.
- `priority-windows.json` — reset del estado pegado (`qa.active=true`) que quedó del incidente.
- Token huérfano `99999.qa.guidance.txt` borrado del filesystem (no estaba tracked).

## Por qué `qa:skipped`

Cambio puro de pipeline (Node.js), sin impacto en producto de usuario. Tipo `infra`.

## Test plan

- [x] `node --check .pipeline/pulpo.js` — sintaxis OK
- [ ] Reiniciar pipeline → verificar que con `partial_pause` activo la ventana QA queda en `false`
- [ ] Verificar que #2450 avanza por las fases `dev → linteo → review → aprobacion → merge`

Closes #N/A (fix operacional, sin issue dedicado)