### PR TITLE
fix(pipeline): dashboard negative cache — evita loop gh api y fuga de .gh-query-*.graphql

### DIFF
--- a/.pipeline/dashboard-v2.js
+++ b/.pipeline/dashboard-v2.js
@@ -67,24 +67,29 @@ function fetchIssueTitles(issueIds, cache) {
   const batches = [];
   for (let i = 0; i < issueIds.length; i += 50) batches.push(issueIds.slice(i, i + 50));
   for (const batch of batches) {
+    const tmpQuery = path.join(PIPELINE, '.gh-query-' + Date.now() + '.graphql');
     try {
       const fields = batch.map((id, i) => `i${i}: issue(number:${id}) { number title labels(first:10) { nodes { name } } }`).join(' ');
       const query = `{ repository(owner:"intrale",name:"platform") { ${fields} } }`;
       // Write query to temp file to avoid shell escaping issues on Windows
-      const tmpQuery = path.join(PIPELINE, '.gh-query-' + Date.now() + '.graphql');
       fs.writeFileSync(tmpQuery, query);
       const cmd = `${ghPath} api graphql -F query=@${tmpQuery}`;
       const out = execSync(cmd, { encoding: 'utf8', timeout: 30000, windowsHide: true });
-      try { fs.unlinkSync(tmpQuery); } catch {}
       const data = JSON.parse(out)?.data?.repository || {};
-      for (const val of Object.values(data)) {
-        if (!val?.number) continue;
-        cache[String(val.number)] = {
-          title: val.title,
-          labels: (val.labels?.nodes || []).map(l => l.name),
-          fetchedAt: Date.now()
-        };
-      }
+      // Negative cache: issues ausentes/null en la respuesta se marcan como notFound
+      // para que no vuelvan a consultarse en cada refresh (evita loop gh api).
+      batch.forEach((id, i) => {
+        const val = data[`i${i}`];
+        if (val?.number) {
+          cache[String(val.number)] = {
+            title: val.title,
+            labels: (val.labels?.nodes || []).map(l => l.name),
+            fetchedAt: Date.now()
+          };
+        } else {
+          cache[String(id)] = { title: '', labels: [], notFound: true, fetchedAt: Date.now() };
+        }
+      });
     } catch (e) {
       // Fallback: fetch one by one
       for (const id of batch) {
@@ -93,8 +98,14 @@ function fetchIssueTitles(issueIds, cache) {
           const out2 = execSync(cmd2, { encoding: 'utf8', timeout: 10000, windowsHide: true });
           const iss = JSON.parse(out2);
           cache[id] = { title: iss.title, labels: (iss.labels || []).map(l => l.name), fetchedAt: Date.now() };
-        } catch {}
+        } catch {
+          // Issue no resoluble: cachear como notFound para evitar re-consulta en cada refresh
+          cache[String(id)] = { title: '', labels: [], notFound: true, fetchedAt: Date.now() };
+        }
       }
+    } finally {
+      // Garantiza limpieza del tmp aunque execSync falle (evita acumulación .gh-query-*.graphql)
+      try { fs.unlinkSync(tmpQuery); } catch {}
     }
   }
   saveIssueTitleCache(cache);


### PR DESCRIPTION
## Contexto

Incidente 2026-04-24 08:17 ART: CPU al 100% obligó a restart manual. El restart disparó rollback automático porque el dashboard no respondía :3200.

**Causa raíz**: archivo dummy `99999.qa` residual en `desarrollo/verificacion/listo/` → `dashboard-v2.js` lo detectaba, lo agregaba a `issueMatrix`, y en cada refresh llamaba `fetchIssueTitles([99999])`. GitHub responde "Could not resolve to an Issue" pero el cache nunca guardaba el resultado → **consulta infinita** en cada refresh.

Cada llamada escribía un `.gh-query-*.graphql` temporal pero el `unlinkSync` estaba antes del `catch`: si `execSync` fallaba (timeout, gh error), el tmp quedaba huérfano. Resultado: **57.121 archivos acumulados** en `.pipeline/` + CPU saturada spawneando `gh.exe` continuamente.

## Cambios

- **Negative cache** en `fetchIssueTitles` (batch GraphQL + fallback one-by-one): issues que GitHub reporta como ausentes ahora se cachean con `notFound: true` para evitar re-consulta en cada refresh.
- **Cleanup en `finally`**: garantiza borrado de `.gh-query-*.graphql` aún si `execSync` lanza.

## Saneado paralelo

- Borrado `desarrollo/verificacion/listo/99999.qa` residual.
- Purgados los 57.121 `.gh-query-*.graphql` huérfanos.

## Test plan

- [ ] Relanzar pipeline desde PowerShell (`launch-v2.ps1`) — NO desde Git Bash.
- [ ] Verificar que `.issue-title-cache.json` incluye entradas con `notFound: true` para issues que no existen.
- [ ] Confirmar que `.gh-query-*.graphql` no se acumulan en `.pipeline/` tras horas de uptime.
- [ ] Confirmar dashboard responde en :3200 < 5s.

qa:skipped — fix puro de infra del pipeline V3, sin impacto en producto de usuario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)