### PR TITLE
fix(pipeline): dashboard V3 renderiza la fase linteo

### DIFF
--- a/.pipeline/dashboard-v2.js
+++ b/.pipeline/dashboard-v2.js
@@ -664,7 +664,7 @@ const SKILL_CATEGORY = {
 const FASE_LABEL_SHORT = {
   analisis: 'An', criterios: 'Cr', sizing: 'Si',
   validacion: 'Va', dev: 'Dv', build: 'Bd',
-  verificacion: 'Vf', aprobacion: 'Ap', entrega: 'En',
+  verificacion: 'Vf', linteo: 'Li', aprobacion: 'Ap', entrega: 'En',
 };
 
 const CATEGORY_META = {
@@ -1253,12 +1253,12 @@ function generateHTML(state) {
     const [pipe, fase] = fa.split('/');
     if (pipe === 'definicion') return 'def';
     if (fase === 'validacion' || fase === 'dev' || fase === 'build') return 'dev';
-    return 'qa'; // verificacion, aprobacion, entrega
+    return 'qa'; // verificacion, linteo, aprobacion, entrega
   }
   const laneMeta = {
     def: { label: 'Definición',        color: '#bc8cff', sub: 'análisis · criterios · sizing', subFases: ['analisis', 'criterios', 'sizing'], subLabels: { analisis: 'Análisis', criterios: 'Criterios', sizing: 'Sizing' } },
     dev: { label: 'Desarrollo + Build', color: '#3fb950', sub: 'validación · dev · build',     subFases: ['validacion', 'dev', 'build'],       subLabels: { validacion: 'Validación', dev: 'Dev', build: 'Build' } },
-    qa:  { label: 'QA + Entrega',      color: '#2dd4bf', sub: 'verif · aprob · entrega',      subFases: ['verificacion', 'aprobacion', 'entrega'], subLabels: { verificacion: 'Verif', aprobacion: 'Aprob', entrega: 'Entrega' } },
+    qa:  { label: 'QA + Entrega',      color: '#2dd4bf', sub: 'verif · linteo · aprob · entrega', subFases: ['verificacion', 'linteo', 'aprobacion', 'entrega'], subLabels: { verificacion: 'Verif', linteo: 'Linteo', aprobacion: 'Aprob', entrega: 'Entrega' } },
   };
   const laneCards = { def: [], dev: [], qa: [], done: [] };
   const laneCounts = { def: 0, dev: 0, qa: 0, done: 0 };
@@ -5072,7 +5072,7 @@ function generateMetricsHTML() {
 
   // ETA averages table
   let etaRows = '';
-  const faseOrder = ['analisis', 'criterios', 'sizing', 'validacion', 'dev', 'build', 'verificacion', 'aprobacion', 'entrega'];
+  const faseOrder = ['analisis', 'criterios', 'sizing', 'validacion', 'dev', 'build', 'verificacion', 'linteo', 'aprobacion', 'entrega'];
   for (const fase of faseOrder) {
     const avg = etaAverages[fase];
     if (!avg?.avgMs) continue;


### PR DESCRIPTION
## Contexto

PR #2496 (del 2026-04-23) introdujo la fase \`linteo\` + skill \`linter\` determinístico en \`config.yaml\`, pero olvidó actualizar los mapeos **hardcoded** del dashboard V3. Hoy 2026-04-24 el \`linter:#2407\` corrió, dejó evidencia en filesystem (\`linteo/pendiente/2407.linter\`, \`logs/rejection-2407-linter.pdf\`) y mandó rechazo por Telegram, pero en el dashboard no aparecía por ningún lado.

## Causa

Aunque las fases se leen desde \`config.pipelines.desarrollo.fases\` en varios lugares, hay 4 estructuras con fases hardcoded que no incluían \`linteo\`:

| Línea | Estructura | Faltaba |
|-------|-----------|---------|
| 666 | \`FASE_LABEL_SHORT\` (etiquetas de 2 chars en dots) | \`linteo: 'Li'\` |
| 1256 | Comentario del mapeo fase→lane | mencionaba sólo verif/aprob/entrega |
| 1261 | \`laneMeta.qa.subFases\` + \`subLabels\` + \`sub\` | linteo ausente de la lane QA |
| 5075 | \`faseOrder\` (tabla ETA de la página de métricas) | linteo ausente del orden |

## Cambios

- Agregada \`linteo\` a los 4 mapeos hardcoded.
- Label visible: \"Linteo\" (lane QA + Entrega), abreviación \"Li\", orden natural entre verificacion y aprobacion (mismo orden de \`config.yaml\`).
- Sin cambios en la lógica dinámica ni en estructura de estado.

## Test plan

- [ ] Restart del dashboard y verificar que \`#2407\` aparece con fase linteo en la lane QA.
- [ ] Confirmar que el chip \"Linteo\" en el sub-breakdown de QA+Entrega es clickeable y filtra.
- [ ] Verificar que \`FASE_LABEL_SHORT.linteo\` = 'Li' sale en los dots del timeline del issue.
- [ ] Página de métricas: confirmar que la tabla ETA lista linteo si hay datos.

qa:skipped — cambio de renderer del dashboard V3, sin impacto en producto de usuario.

## Nota aparte

Queda pendiente un bug separado: \`linter:#2407\` murió en 4s con \`code=1\` en modo determinístico. Es issue del \`linter.js\`, no del dashboard.

Nombre de archivo físico \`dashboard-v2.js\` mantenido por convención (V3 es la nomenclatura lógica del pipeline; los archivos conservan el sufijo V2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)