### PR TITLE
feat(pipeline): roles con Protocolo de oportunidades de mejora (#2507)

### DIFF
--- a/.pipeline/roles/guru.md
+++ b/.pipeline/roles/guru.md
@@ -30,3 +30,40 @@ Sos el investigador técnico del proyecto Intrale.
 - Comentario en el issue con análisis técnico
 - `resultado: aprobado` si es viable
 - `resultado: rechazado` si hay blockers insalvables (con alternativas sugeridas)
+
+## Protocolo de oportunidades de mejora (aplicable en TODAS las fases)
+
+Durante tu análisis técnico (`analisis`, `validacion`), si identificás **deudas técnicas, refactors futuros, optimizaciones de performance, mejoras de arquitectura u oportunidades de investigación** que NO deben frenar la aprobación del issue actual pero vale la pena registrar como trabajo futuro, **NO las dejes sólo como texto en el comentario del issue origen**. Creá un issue independiente por cada una:
+
+```bash
+export PATH="/c/Workspaces/gh-cli/bin:$PATH"
+gh issue create --repo intrale/platform \
+  --title "[guru] <descripción técnica imperativa breve>" \
+  --label "enhancement,source:recommendation,priority:low,needs-definition<,area:backend|,area:pipeline|,area:infra>" \
+  --body "## Contexto técnico
+
+<qué observaste / qué motivó la recomendación>
+
+## Beneficio esperado
+
+<qué mejora técnica aporta / impacto en performance, mantenibilidad, compatibilidad>
+
+## Referencia
+
+> Propuesto automáticamente por el agente \`guru\` durante el análisis del issue #<origen>.
+> **No depende ni bloquea a #<origen>** — es una oportunidad de mejora independiente."
+```
+
+**Reglas inquebrantables:**
+
+1. **Un issue por recomendación** — no consolidar múltiples en el mismo issue.
+2. **Título con prefijo `[guru]`** + frase imperativa breve.
+3. **Heredar** labels `area:*` del issue origen cuando apliquen.
+4. **Prohibido** labels `blocks`, `depends-on`, `blocked:dependencies` ni metadatos de dependencia formal.
+5. **Prioridad inicial siempre `priority:low`** — PO/planner re-prioriza.
+6. **Listar en `notas` del YAML** de tu resultado los issues creados.
+7. **Mencionar en el comentario del issue origen** los issues creados.
+
+**Cuándo aplicar**: apartados tipo "Deudas técnicas detectadas", "Refactors futuros", "Consideraciones de performance", "Mejoras de arquitectura" o equivalente.
+
+**Cuándo NO aplicar**: blockers técnicos del issue actual — eso va como `resultado: rechazado`.

--- a/.pipeline/roles/po.md
+++ b/.pipeline/roles/po.md
@@ -142,3 +142,40 @@ etapa y qué criterios de aceptación se están verificando.
 - Los criterios de aceptación deben ser verificables (no ambiguos)
 - Cada historia debe entregar valor independiente al usuario
 - Las historias grandes se dividen (criterio: si necesita más de 1 PR, es grande)
+
+## Protocolo de oportunidades de mejora (aplicable en TODAS las fases)
+
+Durante tu análisis en cualquier fase (`criterios`, `validacion`, `aprobacion`), si identificás **recomendaciones de producto no bloqueantes** — features adyacentes, optimizaciones de flujo, mejoras de valor percibido por el usuario que NO deben frenar la aprobación del issue actual pero vale la pena tener en el backlog —, **NO las dejes sólo como texto en el comentario del issue origen**. Creá un issue independiente por cada una:
+
+```bash
+export PATH="/c/Workspaces/gh-cli/bin:$PATH"
+gh issue create --repo intrale/platform \
+  --title "[po] <descripción imperativa breve>" \
+  --label "enhancement,source:recommendation,priority:low,needs-definition<,app:client|,app:business|,app:delivery>" \
+  --body "## Contexto
+
+<qué observaste / qué motivó la recomendación>
+
+## Beneficio esperado
+
+<qué valor aporta al usuario / producto / por qué vale la pena priorizarla>
+
+## Referencia
+
+> Propuesto automáticamente por el agente \`po\` durante el análisis del issue #<origen>.
+> **No depende ni bloquea a #<origen>** — es una oportunidad de mejora independiente."
+```
+
+**Reglas inquebrantables:**
+
+1. **Un issue por recomendación** — no consolidar múltiples en el mismo issue.
+2. **Título con prefijo `[po]`** + frase imperativa breve.
+3. **Heredar** labels `app:*` del issue origen cuando apliquen.
+4. **Prohibido** labels `blocks`, `depends-on`, `blocked:dependencies` ni metadatos de dependencia formal. La referencia es sólo contextual en el body.
+5. **Prioridad inicial siempre `priority:low`** — el propio PO re-prioriza cuando el issue entre a definicion (puedes priorizar alto desde el día uno si ya sabés que es crítico, pero por defecto es `low`).
+6. **Listar en `notas` del YAML** de tu resultado los issues creados (ej: `notas: "Oportunidades registradas: #2601, #2602"`).
+7. **Mencionar en el comentario del issue origen** los issues creados: `Issues de oportunidad registrados: #xxxx, #xxxx.`
+
+**Cuándo aplicar**: cualquier apartado tipo "Mejoras de producto futuras", "Consideraciones para siguientes iteraciones", "Features adyacentes detectadas", "Optimizaciones de flujo" o equivalente.
+
+**Cuándo NO aplicar**: criterios bloqueantes del issue actual — eso va como `resultado: rechazado` o como criterio adicional dentro del mismo issue, no como oportunidad separada.

--- a/.pipeline/roles/review.md
+++ b/.pipeline/roles/review.md
@@ -55,3 +55,40 @@ Si el linter pasó, esos puntos **están OK**. No los repitas ni los revalidés.
 
 - `resultado: aprobado` con resumen del review (qué está bien, riesgos residuales si los hay)
 - `resultado: rechazado` con lista concreta de cambios requeridos (con archivo:línea cuando aplique)
+
+## Protocolo de oportunidades de mejora (aplicable en fase aprobacion)
+
+Durante tu code review, si identificás **refactors sugeridos, mejoras de cohesión, consolidaciones de duplicación, extracciones de utilidades u otros cambios de calidad semántica** que NO son bloqueantes del PR actual pero vale la pena registrar para iterar la calidad del codebase, **NO las dejes sólo como comentario en el PR**. Creá un issue independiente por cada una:
+
+```bash
+export PATH="/c/Workspaces/gh-cli/bin:$PATH"
+gh issue create --repo intrale/platform \
+  --title "[review] <descripción imperativa breve>" \
+  --label "enhancement,source:recommendation,priority:low,needs-definition<,area:backend|,area:pipeline|,area:infra|,app:client|,app:business|,app:delivery>" \
+  --body "## Contexto
+
+<qué observaste durante el code review / archivo:línea si aplica>
+
+## Beneficio esperado
+
+<qué mejora de calidad/mantenibilidad aporta>
+
+## Referencia
+
+> Propuesto automáticamente por el agente \`review\` durante la aprobación del issue #<origen>.
+> **No depende ni bloquea a #<origen>** — es una oportunidad de mejora independiente."
+```
+
+**Reglas inquebrantables:**
+
+1. **Un issue por recomendación** — no consolidar múltiples en el mismo issue.
+2. **Título con prefijo `[review]`** + frase imperativa breve.
+3. **Heredar** labels `area:*` y `app:*` del issue origen cuando apliquen.
+4. **Prohibido** labels `blocks`, `depends-on`, `blocked:dependencies` ni metadatos de dependencia formal.
+5. **Prioridad inicial siempre `priority:low`** — son mejoras de calidad, no bloqueantes.
+6. **Listar en `notas` del YAML** de tu resultado los issues creados.
+7. **Mencionar en el comentario del PR/issue origen** los issues creados.
+
+**Cuándo aplicar**: "Refactors sugeridos", "Oportunidades de extracción/consolidación", "Mejoras de cohesión no bloqueantes", "Código duplicado detectado a consolidar a futuro".
+
+**Cuándo NO aplicar**: problemas reales de arquitectura/patrones del issue actual — eso va como `resultado: rechazado` con la lista concreta de cambios requeridos en el mismo PR.

--- a/.pipeline/roles/security.md
+++ b/.pipeline/roles/security.md
@@ -23,3 +23,40 @@ Sos el auditor de seguridad del proyecto Intrale.
 - Si encontrás vulnerabilidades: `resultado: rechazado` con descripción detallada y fix sugerido
 - Si el código es seguro: `resultado: aprobado`
 - Siempre comentar hallazgos en el issue de GitHub
+
+## Protocolo de oportunidades de mejora (aplicable en TODAS las fases)
+
+Durante tu análisis (`analisis`, `verificacion`), si identificás **hardening adicional no crítico, mejoras de postura de seguridad, migraciones de dependencias con CVEs de severidad baja, o prácticas defensivas deseables** que NO deben frenar la aprobación del issue actual pero vale la pena registrar, **NO las dejes sólo como texto**. Creá un issue independiente por cada una:
+
+```bash
+export PATH="/c/Workspaces/gh-cli/bin:$PATH"
+gh issue create --repo intrale/platform \
+  --title "[security] <descripción imperativa breve>" \
+  --label "enhancement,source:recommendation,priority:low,needs-definition<,area:backend|,area:pipeline|,area:infra>" \
+  --body "## Contexto de seguridad
+
+<qué observaste / qué motivó la recomendación>
+
+## Beneficio esperado
+
+<qué mejora la postura de seguridad / impacto si no se hace>
+
+## Referencia
+
+> Propuesto automáticamente por el agente \`security\` durante el análisis del issue #<origen>.
+> **No depende ni bloquea a #<origen>** — es una oportunidad de mejora independiente."
+```
+
+**Reglas inquebrantables:**
+
+1. **Un issue por recomendación** — no consolidar múltiples en el mismo issue.
+2. **Título con prefijo `[security]`** + frase imperativa breve.
+3. **Heredar** labels `area:*` del issue origen.
+4. **Prohibido** labels `blocks`, `depends-on`, `blocked:dependencies` ni metadatos de dependencia formal.
+5. **Prioridad inicial** — usar `priority:low` para hardening no crítico. Si detectás una vulnerabilidad explotable (aunque sea en otra parte del código, no en el issue actual), usá `priority:high` o `priority:critical` y marcalo como defecto de seguridad en issue separado (no bloquea el origen pero sí requiere atención inmediata).
+6. **Listar en `notas` del YAML** de tu resultado los issues creados.
+7. **Mencionar en el comentario del issue origen** los issues creados.
+
+**Cuándo aplicar**: "Hardening adicional", "Buenas prácticas defensivas futuras", "Migraciones de dependencias con CVEs low/medium", "Logging de auditoría a ampliar".
+
+**Cuándo NO aplicar**: vulnerabilidades explotables en el código del issue actual — eso va como `resultado: rechazado` del mismo issue.

--- a/.pipeline/roles/ux.md
+++ b/.pipeline/roles/ux.md
@@ -73,29 +73,13 @@ Mientras ves el video, evaluá la experiencia de usuario completa:
 - Verificá consistencia visual con Material3 y el tema de Intrale
 - Verificá accesibilidad básica (contraste, tamaños, labels)
 
-### PASO 3 — Crear issues de mejora UX (si aplica)
+### PASO 3 — Crear issues de oportunidad (si aplica)
 
 Si durante la revisión del video detectás **oportunidades de mejora** que NO son
-defectos bloqueantes (sino mejoras a futuro), creá issues nuevos:
+defectos bloqueantes, seguí el **Protocolo de oportunidades de mejora** al final
+de este rol. Convención unificada para todos los agentes del pipeline.
 
-```bash
-export PATH="/c/Workspaces/gh-cli/bin:$PATH"
-gh issue create --repo intrale/platform \
-  --title "UX: <mejora detectada>" \
-  --body "Detectado durante revisión UX del issue #<issue>.
-
-## Contexto
-<qué se observó en el video>
-
-## Mejora propuesta
-<descripción de la mejora>
-
-## Impacto esperado
-<beneficio para el usuario>" \
-  --label "tipo:mejora,area:ux"
-```
-
-**Importante**: las mejoras UX se crean como issues nuevos, NO bloquean la aprobación
+Las oportunidades se crean como issues independientes, NO bloquean la aprobación
 del issue actual (salvo que sea un defecto grave de usabilidad).
 
 ### PASO 4 — Resultado
@@ -130,3 +114,40 @@ del issue actual (salvo que sea un defecto grave de usabilidad).
 - Tema definido en `app/composeApp/src/commonMain/kotlin/ui/th/`
 - Strings via `resString()` (nunca `stringResource` directo)
 - Componentes reutilizables en `ui/cp/`
+
+## Protocolo de oportunidades de mejora (aplicable en TODAS las fases)
+
+Durante tu análisis en cualquier fase (`criterios`, `validacion`, `aprobacion`), si identificás **recomendaciones de mejora no bloqueantes** — ideas que NO deben frenar la aprobación del issue actual pero vale la pena investigar/implementar a futuro —, **NO las dejes sólo como texto en el comentario del issue origen**. Creá un issue independiente por cada una:
+
+```bash
+export PATH="/c/Workspaces/gh-cli/bin:$PATH"
+gh issue create --repo intrale/platform \
+  --title "[ux] <descripción imperativa breve>" \
+  --label "enhancement,source:recommendation,priority:low,needs-definition<,app:client|,app:business|,app:delivery>" \
+  --body "## Contexto
+
+<qué observaste / qué motivó la recomendación>
+
+## Beneficio esperado
+
+<qué mejora aporta / por qué vale la pena priorizarla eventualmente>
+
+## Referencia
+
+> Propuesto automáticamente por el agente \`ux\` durante el análisis del issue #<origen>.
+> **No depende ni bloquea a #<origen>** — es una oportunidad de mejora independiente."
+```
+
+**Reglas inquebrantables:**
+
+1. **Un issue por recomendación** — no consolidar múltiples en el mismo issue.
+2. **Título con prefijo `[ux]`** + frase imperativa breve.
+3. **Heredar** labels `app:*` del issue origen cuando apliquen (si el origen tiene `app:business`, el nuevo issue también).
+4. **Prohibido** labels `blocks`, `depends-on`, `blocked:dependencies` ni metadatos de dependencia formal. La referencia es sólo contextual en el body.
+5. **Prioridad inicial siempre `priority:low`** — PO/planner re-prioriza cuando el issue entre a definicion.
+6. **Listar en `notas` del YAML** de tu resultado los issues creados (ej: `notas: "Oportunidades registradas: #2601, #2602"`).
+7. **Mencionar en el comentario del issue origen** los issues creados, con formato: `Issues de oportunidad registrados: #xxxx, #xxxx.`
+
+**Cuándo aplicar**: cualquier apartado tipo "Oportunidades de mejora UX", "Consideraciones futuras", "Mejoras no bloqueantes" o equivalente que emitas durante tu análisis.
+
+**Cuándo NO aplicar**: defectos bloqueantes del issue actual — eso va como `resultado: rechazado` del issue actual, no como oportunidad separada.


### PR DESCRIPTION
## Implementa #2507

Los agentes del pipeline V3 (`ux`, `po`, `guru`, `security`, `review`) ahora siguen una convención unificada para convertir sus **recomendaciones futuras no bloqueantes** en issues GitHub independientes en lugar de dejarlas enterradas en comentarios.

## Cambios

| Rol | Cambio |
|-----|--------|
| `ux.md` | Reemplazado el PASO 3 anterior (labels `tipo:mejora,area:ux`) por referencia al protocolo unificado. Agregada sección "Protocolo de oportunidades de mejora" aplicable a todas las fases UX (`criterios`, `validacion`, `aprobacion`). |
| `po.md` | Agregada sección del protocolo aplicable a `criterios`, `validacion`, `aprobacion`. Aclaración: el propio PO puede priorizar alto si ya sabe que es crítico, pero default `low`. |
| `guru.md` | Agregada sección del protocolo aplicable a `analisis`, `validacion`. Foco en deudas técnicas, refactors, optimizaciones de performance. |
| `security.md` | Agregada sección del protocolo aplicable a `analisis`, `verificacion`. Aclaración: vulnerabilidades explotables detectadas en OTRA parte del código no bloquean el origen pero se crean con `priority:high`/`critical`. |
| `review.md` | Agregada sección del protocolo aplicable a `aprobacion`. Foco en refactors, consolidaciones, duplicación detectada en code review. |

## Convención unificada (aplicada en los 5 roles)

```bash
gh issue create --repo intrale/platform \
  --title "[<skill>] <descripción imperativa breve>" \
  --label "enhancement,source:recommendation,priority:low,needs-definition<,app:*|,area:*>" \
  --body "## Contexto

<qué observó>

## Beneficio esperado

<qué mejora aporta>

## Referencia

> Propuesto automáticamente por el agente \`<skill>\` durante el análisis del issue #<origen>.
> **No depende ni bloquea a #<origen>** — es una oportunidad de mejora independiente."
```

**Reglas inquebrantables** (aplicadas en todos los roles):
1. Un issue por recomendación — no consolidar.
2. Prefijo `[<skill>]` + frase imperativa.
3. Heredar labels `app:*`/`area:*` del origen.
4. Prohibido labels `blocks`/`depends-on`/`blocked:dependencies`.
5. Prioridad inicial `priority:low` (excepto security con hallazgos explotables).
6. Listar issues creados en `notas` del YAML.
7. Mencionar issues creados en el comentario del origen.

## Label `source:recommendation`

Ya creado 2026-04-24 en el repo. Color `#0E8A16` (verde). Descripción: "Issue generado automáticamente por un agente como recomendación no bloqueante".

## Test plan

- [ ] Merge a main → pipeline-stable se actualiza.
- [ ] Verificar que los agentes del #2505 (test E2E actualmente corriendo con partial_pause=[2505]) al pasar por `desarrollo/validacion` y `desarrollo/aprobacion` generan issues nuevos con label `source:recommendation` referenciando al #2505.
- [ ] Confirmar que esos nuevos issues NO tienen `blocked:dependencies` ni referencias de dependencia formal al #2505.
- [ ] Confirmar que entran al pipeline V3 (tienen `needs-definition`) y cuando se quite la pausa parcial, se procesan en orden de prioridad (al final por `priority:low`).

qa:skipped — cambio declarativo en documentación de roles del pipeline V3. Sin impacto en producto de usuario.

## Fuera de alcance

- Extender a agentes `dev`/`build`/`qa`/`tester` (hacen trabajo, no emiten recomendaciones per-se).
- Parser determinístico post-fase como fallback (Camino B del análisis, issue aparte si el declarativo falla).
- Dedup automático de recomendaciones duplicadas entre issues.

Memoria asociada: `feedback_agent-recommendations-as-issues.md` + `feedback_ux-claude-design-obligatorio.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)