### PR TITLE
fix(pipeline): rejection-report solo crea qa:dependency para causas EXTERNAS + anti-deadlock en partial_pause

### DIFF
--- a/.pipeline/rejection-report.js
+++ b/.pipeline/rejection-report.js
@@ -1636,6 +1636,26 @@ async function phaseCollect() {
     return;
   }
 
+  // Gate de creación de issue dependiente (v7 — fix del bug del #2505/#2509):
+  // Solo crear issue qa:dependency cuando la causa raíz es EXTERNA al scope
+  // del issue rechazado (infra caída, servicio externo, puerto ocupado, etc.).
+  //
+  // Si el rechazo es INTERNO (el desarrollo no cumple los CA del propio issue,
+  // decisión de producto del PO, etc.), NO crear issue nuevo: el rebote natural
+  // del pulpo ya mueve el archivo de vuelta a dev/pendiente/ y android-dev
+  // vuelve a ejecutar sobre el mismo issue con el contexto del rechazo.
+  //
+  // Crear un issue qa:dependency en rechazos INTERNOS produce redundancia
+  // (el contenido del issue es lo mismo que android-dev ya va a retrabajar)
+  // y genera deadlock si hay pausa parcial sin el nuevo issue en la allowlist.
+  const origen = primaryCause.origen || 'INTERNO';
+  const OPT_IN_INTERNAL = primaryCause.forceCreateDep === true;
+  if (origen !== 'EXTERNO' && !OPT_IN_INTERNAL) {
+    console.log(`[rejection-report] RECHAZO_INTERNO (origen=${origen}) — PDF + rebote natural, sin crear issue qa:dependency.`);
+    await sendReport(data);
+    return;
+  }
+
   // Una causa raíz: armar título canonical
   const summary = primaryCause.summary || '';
   const detail = primaryCause.detail || summary;

--- a/.pipeline/servicio-github.js
+++ b/.pipeline/servicio-github.js
@@ -284,6 +284,29 @@ function processQueue() {
           const urlMatch = output.match(/\/(\d+)\s*$/);
           data.result = { number: urlMatch ? parseInt(urlMatch[1]) : null, url: output };
           log(`Issue creado: #${data.result.number} — ${data.title}`);
+
+          // Defensa anti-deadlock en pausa parcial (fix #2505):
+          // Si el issue creado tiene label qa:dependency Y el body referencia
+          // un issue que está en el allowlist de partial_pause, agregamos
+          // el nuevo número al allowlist. De lo contrario el issue original
+          // queda bloqueado esperando a este nuevo que nunca se procesaría.
+          try {
+            if (data.result?.number && typeof data.labels === 'string' && data.labels.includes('qa:dependency')) {
+              const partialPause = require('./lib/partial-pause');
+              const mode = partialPause.getPipelineMode();
+              if (mode.mode === 'partial_pause') {
+                const refs = [...String(data.body || '').matchAll(/#(\d+)/g)].map(m => parseInt(m[1]));
+                const touchesAllowlist = refs.some(n => mode.allowedIssues.includes(n));
+                if (touchesAllowlist && !mode.allowedIssues.includes(data.result.number)) {
+                  const next = [...mode.allowedIssues, data.result.number];
+                  partialPause.setPartialPause(next, { source: 'auto-deadlock-prevention' });
+                  log(`Partial pause: #${data.result.number} añadido al allowlist (bloquea a issue permitido).`);
+                }
+              }
+            }
+          } catch (e) {
+            log(`Warning: auto-allowlist falló: ${e.message}`);
+          }
           break;
         }
 


### PR DESCRIPTION
## Contexto — incidente test E2E #2505 (2026-04-24)

Durante el test punta-a-punta del #2505 (íconos por flavor) el QA rechazó porque los 3 íconos se mostraban visualmente idénticos — incumplimiento de CA-4/5/6 del **propio issue**. El pipeline reaccionó con dos mecanismos simultáneos:

1. **Rebote natural** (correcto): mueve `2505.android-dev` a `dev/pendiente/` para que android-dev lo corrija.
2. **Rejection report v6** (bug): crea el #2509 con `needs-definition,qa:dependency,priority:high` — contenido idéntico al que android-dev ya va a retrabajar por el rebote.

Consecuencias:
- **Redundancia**: dos "trabajos" para el mismo problema.
- **Deadlock**: con `partial_pause.allowed_issues=[2505]`, el #2509 quedó fuera del allowlist → bloquea a #2505 vía `blocked:dependencies` → #2505 no avanza.

## Diseño original del rejection-report v6 (y cómo se rompió)

La función `classifyRootCause` distinguía `origen: 'EXTERNO'` (infra caída, red, servicios) vs `INTERNO` (código del scope mal). La intención era **solo crear issue dependiente para causas externas** — así un issue con "backend caído" se abre como bloqueante y se resuelve aparte.

Pero `buildAgentVerdict` (agregado después como "fuente de verdad") mapea TODOS los rechazos del YAML del agente a `origen: 'INTERNO'` (salvo PO que es `DECISION-PRODUCTO`). El fallthrough termina creando issue igual, sin respetar el contrato de origen.

## Cambios

### 1) `rejection-report.js` — gate por origen

Después del loop guard y chequeo de `primaryCause`, nuevo gate:

```javascript
const origen = primaryCause.origen || 'INTERNO';
const OPT_IN_INTERNAL = primaryCause.forceCreateDep === true;
if (origen !== 'EXTERNO' && !OPT_IN_INTERNAL) {
  console.log('[rejection-report] RECHAZO_INTERNO — PDF + rebote natural, sin crear issue qa:dependency.');
  await sendReport(data);
  return;
}
```

- **`origen === 'EXTERNO'`** → crea issue qa:dependency (comportamiento original para infra).
- **Otros** (INTERNO, DECISION-PRODUCTO, etc.) → solo PDF de evidencia para el dev; el rebote se encarga.
- **Opt-in `primaryCause.forceCreateDep = true`** para casos excepcionales que un agente quiera forzar creación aunque la causa sea interna.

### 2) `servicio-github.js` — auto-extensión del allowlist

Cuando `action=create-issue` crea un issue con label `qa:dependency` cuyo body referencia un issue que está en `partial_pause.allowed_issues`, el nuevo número se agrega al allowlist automáticamente. Usa `lib/partial-pause` para leer/escribir el marker. Defensa en profundidad: previene deadlocks futuros si algún caso EXTERNO legítimo crea un bloqueante dentro de pausa parcial.

## Test plan

- [x] Diff ambos archivos: rejection-report.js +28, servicio-github.js +23.
- [ ] Remediar #2505/#2509 (post-merge):
  - Cerrar #2509 con comentario "duplicado del rebote del #2505".
  - Quitar label `blocked:dependencies` del #2505 (si lo tiene).
  - Verificar que `2505.android-dev` ya está en `dev/pendiente/` (para que el rebote lo tome).
- [ ] Observar próximo rechazo real del pipeline: confirmar que NO crea issue si origen INTERNO.
- [ ] Simular un rechazo con causa infra (ej. backend caído) y confirmar que SÍ crea issue qa:dependency.
- [ ] Confirmar que si ese issue infra se crea con partial_pause activa, se auto-agrega al allowlist.

qa:skipped — cambio en lógica del pipeline V3 sin impacto directo en producto de usuario. Test de producto lo cubre el próximo rechazo real.

## Fuera de alcance

- Renombrar "v6" → "v7" en los comentarios y mensajes de log del archivo (cosmético).
- Migrar `buildAgentVerdict` para que expose un campo `esScope` explícito (más declarativo que heredar de `origen`). Si después queremos un control más fino, issue aparte.
- Reclasificar retroactivamente los issues `qa:dependency` viejos que nunca deberían haberse creado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)