### PR TITLE
fix(pipeline): tester no rechaza por gradle exit sin error clasificable + barrido fast-fail

### DIFF
--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -2093,13 +2093,43 @@ function brazoBarrido(config) {
           todosCompletos = skillsRequeridos.every(s => skillsEnListo.includes(s));
         }
 
-        if (!todosCompletos) continue;
-
         // Leer resultados
         const resultados = archivos.map(a => ({
           ...readYaml(a.path),
           file: a
         }));
+
+        // FAST-FAIL: si al menos un skill rechazó, disparar el rebote sin esperar
+        // al resto. Los skills pendientes/en cooldown no cambian el veredicto
+        // (el issue va a rebotear igual) y esperarlos produce deadlocks cuando
+        // algún skill queda atascado. Incidente 2026-04-24: tester:#2505 en
+        // cooldown bloqueaba el rebote de qa:#2505 que ya había rechazado.
+        const hayRechazoConfirmado = resultados.some(r => r.resultado === 'rechazado');
+        if (!todosCompletos && !hayRechazoConfirmado) continue;
+
+        // Si el rebote va a dispararse por fast-fail (todosCompletos=false pero hay rechazo),
+        // cancelar los archivos residuales del mismo issue en pendiente/ y trabajando/
+        // de la fase actual para que no queden huérfanos tras el rebote.
+        if (!todosCompletos && hayRechazoConfirmado) {
+          const procesadoFaseActual = path.join(fasePath(pipelineName, fase), 'procesado');
+          for (const estado of ['pendiente', 'trabajando']) {
+            const dir = path.join(fasePath(pipelineName, fase), estado);
+            try {
+              for (const f of fs.readdirSync(dir)) {
+                if (f.startsWith('.')) continue; // flags internos
+                if (!f.startsWith(issue + '.')) continue;
+                const src = path.join(dir, f);
+                const dst = path.join(procesadoFaseActual, f);
+                try {
+                  const prev = readYaml(src) || {};
+                  writeYaml(dst, { ...prev, cancelado_por: 'fast-fail-rebote', cancelado_ts: new Date().toISOString() });
+                  fs.unlinkSync(src);
+                } catch {}
+              }
+            } catch {}
+          }
+          log('barrido', `⚡ #${issue} fast-fail en ${fase} — rebote temprano, cancelados skills pendientes/en cooldown`);
+        }
 
         // --- GATE DE EVIDENCIA QA (fase verificacion) ---
         // Si el QA dice "aprobado" pero no tiene evidencia real, forzar rechazo automático.

--- a/.pipeline/skills-deterministicos/tester.js
+++ b/.pipeline/skills-deterministicos/tester.js
@@ -328,22 +328,28 @@ async function main() {
         // Decisión de veredicto:
         // 1) tests fallidos o errores → rechazado
         // 2) cobertura < umbral (si se pidió coverage) → rechazado
-        // 3) gradle exit code ≠ 0 → rechazado
+        // 3) gradle exit code ≠ 0 CON bloque de error clasificable → rechazado
+        // 4) gradle exit code ≠ 0 SIN bloque clasificable pero tests OK → APROBADO (los tests son fuente de verdad)
+        // 5) no hay reportes JUnit válidos → rechazado (config rota)
         if (tests.valid && (tests.failures > 0 || tests.errors > 0)) {
             exitCode = 1;
             motivo = `Tests fallidos: ${tests.failures} failures + ${tests.errors} errors sobre ${tests.tests} totales`;
         } else if (args.coverage && koverData.aggregate.valid && koverData.aggregate.total.line.percent < args.threshold) {
             exitCode = 1;
             motivo = `Cobertura de líneas ${koverData.aggregate.total.line.percent}% por debajo del umbral ${args.threshold}%`;
-        } else if (gradleResult.exit_code !== 0) {
+        } else if (gradleResult.exit_code !== 0 && parsedGradle.errors[0]) {
+            // Solo rechazar cuando hay un bloque de error real — el exit code por sí solo
+            // puede venir de warnings o tasks que fallan post-tests sin afectar los resultados.
             exitCode = 1;
             const first = parsedGradle.errors[0];
-            motivo = first
-                ? `Gradle FAILED (${first.classification}): ${(first.message || '').split('\n').slice(0, 3).join(' | ').slice(0, 500)}`
-                : `Gradle exit ${gradleResult.exit_code} sin bloque de error clasificable`;
+            motivo = `Gradle FAILED (${first.classification}): ${(first.message || '').split('\n').slice(0, 3).join(' | ').slice(0, 500)}`;
         } else if (!tests.valid) {
             exitCode = 1;
             motivo = 'No se encontraron reportes JUnit — posible configuración rota o tests omitidos';
+        } else if (gradleResult.exit_code !== 0) {
+            // Tests válidos, sin errores de test, sin bloque de error clasificable de gradle, pero exit != 0.
+            // Aprobar con warning — los tests son la fuente de verdad. Evita rebotes espurios.
+            logAppend(`[tester] WARNING: gradle exit ${gradleResult.exit_code} sin bloque clasificable, pero ${tests.tests} tests pasaron (${tests.failures} fails, ${tests.errors} errors). Aprobando — tests son fuente de verdad.`);
         }
     } catch (e) {
         exitCode = 2;


### PR DESCRIPTION
## Contexto — incidente test E2E #2505 (2026-04-24)

Test punta-a-punta con partial_pause=[2505] quedó colgado tras el rechazo del QA. Dos bugs encadenados:

1. **Tester determinístico rechazaba con falso positivo**: 6658/6660 tests pasaron (0 failures, 0 errors), pero gradle terminó con exit ≠ 0 sin bloque de error clasificable → tester reportó `RECHAZADO` con motivo `"Gradle exit 1 sin bloque de error clasificable"`.

2. **brazoBarrido esperaba fase completa**: el qa:#2505 ya había rechazado (íconos iguales), pero el barrido no podía disparar el rebote hasta que TODOS los skills de `verificacion` terminaran. Tester en cooldown (5 min y subiendo) → deadlock.

## Cambios

### 1) `skills-deterministicos/tester.js` — veredicto correcto cuando los tests son la fuente de verdad

Antes (línea 338-343):
```javascript
} else if (gradleResult.exit_code !== 0) {
    exitCode = 1;
    const first = parsedGradle.errors[0];
    motivo = first
        ? `Gradle FAILED (${first.classification}): ...`
        : `Gradle exit ${gradleResult.exit_code} sin bloque de error clasificable`;
}
```

Ahora:
```javascript
} else if (gradleResult.exit_code !== 0 && parsedGradle.errors[0]) {
    // Solo rechazar cuando hay un bloque de error real
    exitCode = 1;
    motivo = `Gradle FAILED (${first.classification}): ...`;
} else if (!tests.valid) {
    exitCode = 1;
    motivo = 'No se encontraron reportes JUnit — posible configuración rota';
} else if (gradleResult.exit_code !== 0) {
    // Tests OK + gradle exit ≠ 0 sin error clasificable → APROBAR con warning
    logAppend(`[tester] WARNING: gradle exit ${gradleResult.exit_code} sin bloque clasificable, pero ${tests.tests} tests pasaron. Aprobando.`);
}
```

Regla: si los tests se encontraron y todos pasaron, **ellos son la fuente de verdad**. Un exit code sin error concreto (deprecation notices, tasks post-test, warnings) no debería disparar rebote.

### 2) `pulpo.js` — `brazoBarrido` hace fast-fail con rechazo confirmado

Antes: requería `todosCompletos === true` para proceder al evaluar veredictos.

Ahora:
```javascript
const hayRechazoConfirmado = resultados.some(r => r.resultado === 'rechazado');
if (!todosCompletos && !hayRechazoConfirmado) continue;

// Fast-fail: limpiar pendientes/trabajando del mismo issue en la fase actual
if (!todosCompletos && hayRechazoConfirmado) {
  // mover a procesado/ con cancelado_por: 'fast-fail-rebote'
  log('barrido', '⚡ fast-fail en <fase> — rebote temprano, cancelados skills pendientes/en cooldown');
}
```

Beneficios:
- **Elimina deadlocks** por skills en cooldown.
- Rebote se dispara apenas el veredicto es decidido, no horas después.
- Trazabilidad: los skills cancelados quedan en `procesado/` con `cancelado_por: fast-fail-rebote` + timestamp.

## Post-merge — reinicio del pulpo

**Importante**: pulpo.js se carga UNA vez al arrancar el proceso (no por ciclo como los roles). Cambios requieren **restart del proceso pulpo** para tomar efecto. El dashboard y servicios no necesitan restart. Los skills deterministicos (`tester.js`) se ejecutan como subproceso por cada invocación, así que toman el fix automáticamente.

## Test plan

- [x] Syntax OK con `node --check`.
- [ ] Post-merge: restart de `pulpo.js` (`taskkill /F /PID <pulpo-pid>` → pulpo respawnea via watchdog).
- [ ] Confirmar: en el próximo ciclo, brazoBarrido detecta `verificacion/listo/2505.qa` (rechazado) y dispara rebote inmediato → crea `dev/pendiente/2505.android-dev` con `rebote_numero=1, rebote_tipo=codigo`.
- [ ] Confirmar: tester:#2505 al reintentarse (fuera de cooldown) ya NO rechaza por "gradle exit sin bloque clasificable" — ejecuta y aprueba si los tests pasan.
- [ ] android-dev:#2505 retoma, crea `src/client/res/` y `src/delivery/res/` con Claude Design.

qa:skipped — cambio en lógica interna del pipeline V3, sin impacto en producto de usuario.

## Fuera de alcance

- Revisar si otros skills determinísticos (builder, delivery, linter) tienen la misma patología de "exit code sin error clasificable → rechazo". Si sí, issue separado por cada uno.
- Telemetría del fast-fail: contador de cuántas veces se dispara para detectar patrones de skills con cooldowns crónicos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)