### PR TITLE
fix(pipeline): servicio-telegram y servicio-drive recuperan orphans al arrancar

### DIFF
--- a/.pipeline/servicio-drive.js
+++ b/.pipeline/servicio-drive.js
@@ -38,6 +38,32 @@ function listWorkFiles(dir) {
   } catch { return []; }
 }
 
+// Recovery al arrancar: archivos huérfanos en trabajando/ (proceso muerto mid-upload).
+// Recientes (<15 min) → reencolar a pendiente. Viejos → descartar a listo/ con marcador
+// (reintentar un upload de Drive de hace horas puede duplicar videos ya subidos).
+const ORPHAN_MAX_AGE_MS = 15 * 60 * 1000;
+function recoverOrphans() {
+  const orphans = listWorkFiles(TRABAJANDO);
+  if (orphans.length === 0) return;
+  const now = Date.now();
+  let recovered = 0, discarded = 0;
+  for (const file of orphans) {
+    try {
+      const mtime = fs.statSync(file.path).mtimeMs;
+      if (now - mtime < ORPHAN_MAX_AGE_MS) {
+        fs.renameSync(file.path, path.join(PENDIENTE, file.name));
+        recovered++;
+      } else {
+        const destName = file.name.replace(/\.json$/, '-zombie-descartado.json');
+        fs.renameSync(file.path, path.join(LISTO, destName));
+        discarded++;
+      }
+    } catch {}
+  }
+  if (recovered > 0) log(`Recovery: ${recovered} orphans recientes reencolados a pendiente/`);
+  if (discarded > 0) log(`Recovery: ${discarded} zombies viejos (>${ORPHAN_MAX_AGE_MS/60000}min) movidos a listo/ (no se reintentan)`);
+}
+
 // Extraer número de issue desde description o filename
 // Ej: "QA video con relato narrado #2015" → "2015"
 // Ej: "qa-2015-video.json" → "2015"
@@ -258,6 +284,7 @@ function main() {
     process.exit(1);
   }
 
+  recoverOrphans();
   try { require('./lib/ready-marker').signalReady('svc-drive'); } catch {}
   setInterval(() => {
     processQueue().catch(e => log(`Error en processQueue: ${e.message}`));

--- a/.pipeline/servicio-telegram.js
+++ b/.pipeline/servicio-telegram.js
@@ -145,6 +145,33 @@ function listWorkFiles(dir) {
   } catch { return []; }
 }
 
+// Recovery al arrancar: los archivos en trabajando/ son huérfanos de un proceso
+// que murió antes de completar. Si son recientes (<15 min), reencolar a pendiente.
+// Si son viejos (>15 min), descartar a listo/ con marcador — reprocesar un mensaje
+// de Telegram de hace horas/días no tiene sentido (incidente 2026-04-24: zombie de 3 días).
+const ORPHAN_MAX_AGE_MS = 15 * 60 * 1000;
+function recoverOrphans() {
+  const orphans = listWorkFiles(TRABAJANDO);
+  if (orphans.length === 0) return;
+  const now = Date.now();
+  let recovered = 0, discarded = 0;
+  for (const file of orphans) {
+    try {
+      const mtime = fs.statSync(file.path).mtimeMs;
+      if (now - mtime < ORPHAN_MAX_AGE_MS) {
+        fs.renameSync(file.path, path.join(PENDIENTE, file.name));
+        recovered++;
+      } else {
+        const destName = file.name.replace(/\.json$/, '-zombie-descartado.json');
+        fs.renameSync(file.path, path.join(LISTO, destName));
+        discarded++;
+      }
+    } catch {}
+  }
+  if (recovered > 0) log(`Recovery: ${recovered} orphans recientes reencolados a pendiente/`);
+  if (discarded > 0) log(`Recovery: ${discarded} zombies viejos (>${ORPHAN_MAX_AGE_MS/60000}min) movidos a listo/ (no se reintentan)`);
+}
+
 async function processQueue() {
   const files = listWorkFiles(PENDIENTE);
   if (files.length === 0) return;
@@ -190,6 +217,7 @@ async function processQueue() {
 // Main loop
 async function main() {
   log('Servicio Telegram iniciado');
+  recoverOrphans();
   try { require('./lib/ready-marker').signalReady('svc-telegram'); } catch {}
   while (true) {
     try { await processQueue(); } catch (e) { log(`Error: ${e.message}`); }


### PR DESCRIPTION
## Contexto

Descubierto durante el test E2E #2505 (2026-04-24): el dashboard mostraba permanentemente `1 procesando` en el contador de telegram. Investigación: archivo `servicios/telegram/trabajando/1776785981251-cmd.json` con mtime del **Apr 21** (3 días de antigüedad) — mensaje `"🔄 Reinicio completo del pipeline en progreso..."` que había quedado huérfano cuando el proceso murió mid-send y **nunca se recuperó**.

## Causa

`servicio-github.js` (línea 54) y `servicio-emulador.js` (línea 274) tienen `recoverOrphans()` que al arrancar mueve archivos de `trabajando/` a `pendiente/`. **`servicio-telegram.js` y `servicio-drive.js` no la tenían**. Consecuencia: si el proceso muere mid-send/mid-upload, el archivo queda en `trabajando/` para siempre, contaminando el dashboard con "procesando" falso.

## Fix

Agregar `recoverOrphans()` en ambos servicios con **filtro de edad**:

```javascript
const ORPHAN_MAX_AGE_MS = 15 * 60 * 1000;
function recoverOrphans() {
  const orphans = listWorkFiles(TRABAJANDO);
  if (orphans.length === 0) return;
  const now = Date.now();
  let recovered = 0, discarded = 0;
  for (const file of orphans) {
    const mtime = fs.statSync(file.path).mtimeMs;
    if (now - mtime < ORPHAN_MAX_AGE_MS) {
      fs.renameSync(file.path, path.join(PENDIENTE, file.name));
      recovered++;
    } else {
      const destName = file.name.replace(/\.json$/, '-zombie-descartado.json');
      fs.renameSync(file.path, path.join(LISTO, destName));
      discarded++;
    }
  }
  // ... logs
}
```

### Por qué filtro de edad (a diferencia de github)

- **Telegram**: mensajes obsoletos pierden contexto (ej. "reinicio en progreso" cuando el reinicio fue hace 3 días). Reenviarlos es ruido.
- **Drive**: uploads viejos pueden duplicar videos ya subidos manualmente por QA. Reintentarlos es risk de duplicación.
- **Github** (sin filtro, lo dejamos así): labels/comments son idempotentes, no genera efecto visible duplicado.

## Invocación

- `servicio-telegram.js`: `recoverOrphans()` llamado en `main()` antes del while loop.
- `servicio-drive.js`: `recoverOrphans()` llamado en `main()` antes del `setInterval`.

## Test plan

- [x] Syntax OK con `node --check`.
- [x] Zombie del #2505 (de 3 días) ya fue movido manualmente a listo/ antes del merge (no depende del fix para resolverse).
- [ ] Post-merge: reiniciar `svc-telegram` y `svc-drive` en PowerShell para que tomen el fix.
- [ ] Verificar: al reiniciar, si hay algún huérfano reciente se reencola; si es viejo se descarta a listo/ con sufijo `-zombie-descartado.json`.
- [ ] Observar: el contador `procesando` del dashboard NO queda trabado en futuros restarts del pipeline.

qa:skipped — cambio en lógica interna de servicios del pipeline V3, sin impacto en producto de usuario.

## Fuera de alcance

- Replicar filtro de edad en `servicio-github.js` (es idempotente, no hay urgencia).
- Auditar `commander.js` y otros loops de archivos `pendiente/trabajando/` por el mismo patrón. Issue aparte si aparece otro caso concreto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)