### PR TITLE
feat(pipeline): protocolo de rebote genérico — verificación empírica obligatoria en _base.md

### DIFF
--- a/.pipeline/roles/_base.md
+++ b/.pipeline/roles/_base.md
@@ -15,12 +15,7 @@ Tu archivo de trabajo ya fue movido a `trabajando/` por el Pulpo. El path te lle
 ## Tu ciclo de trabajo
 
 1. **Leer el archivo de trabajo** — contiene `issue`, `fase`, `pipeline` y posiblemente `rebote` con `motivo_rechazo`
-2. **Si es un REBOTE** (`rebote: true` en tu archivo de trabajo):
-   - Leé el `motivo_rechazo` — contiene exactamente por qué la fase posterior rechazó tu trabajo
-   - Si el rechazo viene de `build`, leé el log completo: `cat .pipeline/logs/build-<issue>.log | tail -100`
-   - Si el rechazo viene de `verificacion`, leé los archivos en `verificacion/procesado/<issue>.*` para ver qué encontraron tester/qa/security
-   - **Tu único objetivo es corregir los errores del rechazo**, no reimplementar desde cero
-   - Verificá que compila localmente (`./gradlew check --no-daemon`) antes de marcar como aprobado
+2. **Si es un REBOTE** (`rebote: true` en tu archivo de trabajo): seguí el **Protocolo de rebote** más abajo ANTES de cualquier otro paso.
 3. **Leer el issue de GitHub** — `gh issue view <issue> --json title,body,labels,comments`
 4. **Leer contexto de fases anteriores** — si necesitás saber qué hicieron otros skills, mirá en `procesado/` de la fase anterior
 5. **Verificar pasadas anteriores** — si existen archivos de tu mismo skill en `procesado/` de tu misma fase para el mismo issue, son resultados de una pasada anterior. Leelos para no repetir errores.
@@ -45,6 +40,58 @@ motivo: "Descripción clara del problema encontrado"
 ```
 
 8. **Salir con código 0** — el Pulpo detecta tu salida y mueve el archivo de `trabajando/` a `listo/`.
+
+## Protocolo de rebote (CRÍTICO)
+
+Si tu archivo de trabajo tiene `rebote: true` (o cualquier campo `motivo_rechazo`, `rechazado_en_fase`, `rebote_numero`), **NO estás arrancando desde cero** — alguien ya intentó antes y una fase posterior rechazó con motivo específico. Tratá el rechazo como input **al mismo nivel de autoridad que los criterios de aceptación del issue**.
+
+Tres reglas inquebrantables:
+
+### 1. El `motivo_rechazo` NO es una sugerencia, es la única observación que importa
+
+- Leé el `motivo_rechazo` **completo**, hasta el final. Ignorar partes del texto es una forma común de fallar de nuevo por lo mismo.
+- Identificá **cada claim específico** que hace el rechazo. Ejemplos reales:
+  - "El archivo X no existe" → claim verificable con `ls` / `test -f` / `stat`.
+  - "Los íconos son visualmente idénticos" → claim verificable con `md5sum` / `diff` / inspección del recurso.
+  - "La función Y no respeta el patrón Z" → claim verificable leyendo el código y comparándolo con el patrón.
+  - "Tests del módulo M fallan" → claim verificable con `./gradlew :M:test`.
+
+### 2. Verificás cada claim empíricamente en ESTE ciclo (no citar estado sin comprobar)
+
+- Prohibido aprobar citando archivos, paths, hashes o comandos sin haberlos ejecutado y observado su salida real en esta misma pasada.
+- Por cada claim del rechazo, ejecutás el comando concreto de verificación y **pegás el output textual** en las `notas` del resultado. Ejemplos:
+  ```
+  ## Verificación del rechazo rev-<N>
+
+  CA-1 ("carpetas X y Y no existen"):
+  $ ls -la app/composeApp/src/{X,Y}/res 2>&1
+  <output REAL>
+
+  CA-4 ("íconos visualmente idénticos"):
+  $ md5sum app/composeApp/src/*/res/mipmap-mdpi/ic_launcher.png
+  <hashes REALES>
+  ```
+- Si el rechazo menciona varios claims, los verificás **todos**. Un solo claim sin verificar arruina la aprobación.
+
+### 3. El veredicto depende del resultado empírico, no de lo que creés
+
+- Si la verificación confirma que el claim sigue siendo válido (el problema persiste) → `resultado: rechazado` con motivo explícito. NO aprobás "porque igual lo arreglé en otro lado".
+- Si la verificación muestra que el claim ya no aplica (el problema se resolvió), aprobás **adjuntando la evidencia** que lo demuestra.
+- Si no podés verificar un claim porque te falta contexto, información o herramienta, **rechazá pidiendo ese contexto** — no asumas.
+- Si encontrás un desacuerdo con el rechazo (creés que el reviewer se equivocó), argumentalo con evidencia concreta de archivos/líneas/outputs, no con interpretación.
+
+### Anti-patrones a evitar
+
+- "Ya estaba resuelto en un commit anterior / en otra rama / en el worktree del agente" → no sirve. **Lo que importa es el estado del HEAD que va a evaluar la siguiente fase**.
+- "El build compila exitosamente" → insuficiente. Un build OK no prueba que los assets/recursos/configuración por flavor/perfil estén bien diferenciados.
+- "Hice merge con main y ya está" → verificá empíricamente qué quedó en el merge. El merge no arregla claims del rechazo por sí solo.
+- "Los tests pasan" → los tests unitarios rara vez cubren assets visuales, configs por flavor, recursos. Verificá específicamente lo que pide el rechazo.
+
+### Si el rebote viene de una fase posterior específica
+
+- **Rechazo de `build`**: leé el log completo: `cat .pipeline/logs/build-<issue>.log | tail -200`. Verificá compilación real con `./gradlew <tarea> --no-daemon`.
+- **Rechazo de `verificacion`**: leé los YAMLs en `.pipeline/desarrollo/verificacion/procesado/<issue>.*` y el PDF en `logs/rejection-<issue>-<skill>.pdf` si existe. Si hay video QA, mirá el frame donde se evidencia el defecto (`qa/evidence/<issue>/screenshot-*.png`).
+- **Rechazo de `aprobacion`** (review): leé la review en el PR con `gh pr view <N> --json reviews`.
 
 ## Reglas críticas
 


### PR DESCRIPTION
## Contexto — incidente test E2E #2505 (2026-04-24)

Android-dev del #2505 falló **dos veces por la misma causa**, auto-aprobando con claims no verificados:

**Ciclo 1** — android-dev aprobó diciendo "creé los 3 sets de íconos por flavor". QA con video detectó que los 3 íconos en el launcher eran visualmente idénticos (fallback a `androidMain`). Rechazo con motivo específico apuntando a `src/client/res/` y `src/delivery/res/` inexistentes.

**Ciclo 2 (rebote rev-1)** — android-dev aprobó **otra vez**, citando: *"1. CA-1 (folders client/ y delivery/ NO EXISTEN) -> RESUELTO — ls app/composeApp/src/ muestra client/, business/ y delivery/ con res/ pobladas"*.

Verificación empírica con `ls` contra el HEAD real post-merge:
```
business/res/    ← poblado
client/          ← sin res/
delivery/        ← sin res/
```

El YAML mintió (o alucinó) el estado del filesystem. Ningún gate del pipeline lo detectó porque todos los agentes se basan en self-reporting.

## Decisión de diseño

En lugar de gates determinísticos específicos (comparación de hashes por flavor, verificación de paths citados, etc. — propuestos y rechazados), fix **genérico** en el rol base: obligar a que cualquier agente en un rebote **verifique empíricamente** cada claim del rechazo anterior, con comando concreto y output pegado en las notas.

La regla aplica a cualquier skill que pueda ser objeto de rechazo (dev, builder, reviewer, cualquiera). No hay lógica específica de Android, íconos, ni flavors — la convención es genérica.

## Cambios

`_base.md` (se concatena con cada rol al lanzar agente) recibe nueva sección **"Protocolo de rebote (CRÍTICO)"** con tres reglas inquebrantables:

1. **El `motivo_rechazo` tiene autoridad**: identificar cada claim específico, no ignorar partes del texto.
2. **Verificar empíricamente cada claim en este ciclo**: prohibido citar estado sin comprobarlo con comando concreto, pegar output en notas.
3. **Veredicto dictado por resultado empírico**: si el problema persiste → rechazar con motivo; si se resolvió → aprobar adjuntando evidencia; si no se puede verificar → rechazar pidiendo contexto.

Anti-patrones explicitados:
- "Ya estaba resuelto en otro commit/worktree" → no vale.
- "El build compila" → insuficiente para assets/configs por flavor.
- "Hice merge con main" → verificar qué quedó en el merge.
- "Los tests pasan" → raramente cubren assets visuales.

## Propagación

Los archivos `.md` de los roles se leen **fresh en cada lanzamiento** (`pulpo.js:3995-4001` → `fs.readFileSync(rolPrompt)` en cada spawn). No hace falta reiniciar pulpo. El próximo agente lanzado toma el protocolo automáticamente.

## Test plan

- [x] `_base.md` sincronizado entre session worktree y worktree principal.
- [ ] Post-merge: observar el próximo rebote (sea del #2505 o cualquier otro issue). Verificar que:
  - El YAML del agente cita **output textual** de comandos de verificación en las notas.
  - Si el claim del rechazo persiste, el agente rechaza con motivo, no aprueba.
  - Si aprueba, las notas contienen hashes/listados/diffs como evidencia.
- [ ] Si el próximo rebote sigue mostrando alucinación (dev aprueba con claims no verificados), escalar a gates determinísticos específicos como segundo nivel de defensa.

qa:skipped — cambio en documentación de rol base del pipeline V3, sin impacto en producto de usuario.

## Fuera de alcance

- Gates determinísticos específicos (hashes por flavor, comparación de recursos) — descartados por preferir solución genérica primero.
- Telemetría automática de agentes que ignoran el protocolo (para medir compliance).
- Replicar el protocolo en documentación de agentes humanos / runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)