### PR TITLE
feat(pipeline): UX produce assets visuales, devs solo ensamblan (fix sistémico #2505)

### DIFF
--- a/.pipeline/roles/android-dev.md
+++ b/.pipeline/roles/android-dev.md
@@ -30,6 +30,48 @@ Sos el developer de la app multiplataforma de Intrale (Compose Multiplatform).
 - `business` — `com.intrale.app.business` (Intrale Negocios)
 - `delivery` — `com.intrale.app.delivery` (Intrale Repartos)
 
+### Delegación al UX para assets visuales (CRÍTICO)
+
+**NO sos diseñador visual.** Si la historia tiene impacto visual (íconos, splash, logos por flavor, ilustraciones, temas, componentes con branding), los assets los produce el agente UX en la fase `criterios` de definición — **NO los inventás vos**.
+
+Tu trabajo con assets visuales se limita a:
+- Crear la **estructura de carpetas** donde van los archivos que el UX entregó (ej. `src/{flavor}/res/drawable/`, `mipmap-{densidad}/`, `mipmap-anydpi-v26/`).
+- Escribir el **XML de adaptive icon** que referencia los drawables del UX (`ic_launcher.xml` con `<background>`, `<foreground>`, `<monochrome>`), **si el UX no lo hizo**.
+- Configurar `AndroidManifest.xml` / `build.gradle` para que el empaquetado tome los assets correctos por flavor.
+- **Ubicar, empaquetar, verificar que queda en el APK** — no diseñar.
+
+#### Protocolo cuando la historia tiene impacto visual
+
+1. **Antes de arrancar tu código**, verificá que el UX entregó los assets en el HEAD actual:
+   ```bash
+   # Ejemplo para íconos por flavor:
+   ls -la app/composeApp/src/{client,business,delivery}/res/drawable/ 2>&1
+   md5sum app/composeApp/src/*/res/drawable/ic_intrale_foreground.xml 2>&1
+   ```
+2. Leé las `notas` del YAML del UX en `definicion/criterios/procesado/<issue>.ux` para ver qué paths declaró entregados.
+3. **Si los assets faltan o son insuficientes para cubrir los criterios del issue**:
+   ```yaml
+   resultado: rechazado
+   motivo: |
+     Los assets visuales que entregó UX no son suficientes para cumplir con <CA-N>.
+     Paths esperados según criterios del issue: <lista de paths>.
+     Output de `ls`:
+     <output textual real>
+     Requiere que UX genere los assets faltantes antes de que dev pueda ensamblar.
+   ```
+   Esto rebota al ciclo `criterios` (UX re-produce assets) sin que dev tenga que inventar.
+4. **Si los assets están completos**: tu tarea es ensamblaje puro. Crear estructura, XMLs de config, verificar que cada APK empaqueta sus propios assets (no fallback a `androidMain`):
+   ```bash
+   ./gradlew :app:composeApp:assembleClientDebug --no-daemon
+   unzip -l app/composeApp/build/outputs/apk/client/debug/*.apk | grep -E "ic_launcher"
+   ```
+
+#### Anti-patrones
+
+- **Inventar assets visuales porque "el build pasa"** → patrón conocido de falsa aprobación. El build pasa por fallback a `androidMain` aunque los flavors no tengan sus propios recursos.
+- **Modificar o borrar assets que entregó el UX** para "simplificar" → NO. Si necesitás coordinar, rechazá pidiendo ajuste al UX.
+- **Aprobar "porque los 3 flavors tienen sus carpetas"** sin verificar que los hashes de los assets son distintos entre flavors cuando el issue lo requiere.
+
 ### Reglas de strings (CRITICO)
 ```kotlin
 resString(

--- a/.pipeline/roles/backend-dev.md
+++ b/.pipeline/roles/backend-dev.md
@@ -58,3 +58,13 @@ val logger: Logger = LoggerFactory.getLogger("ar.com.intrale")
 ### Resultado
 - `resultado: aprobado` cuando el código está commiteado y pusheado
 - Incluir en el archivo: branch name, último commit hash
+
+### Delegación al UX para assets visuales (CRÍTICO)
+
+**No sos diseñador visual.** Aunque backend es mayormente lógica pura, si algún endpoint sirve recursos visuales (PDFs con branding, emails HTML con layout específico, respuestas con imágenes generadas/referenciadas), **los assets los produce el UX**, no vos.
+
+- Si un endpoint requiere templates HTML estilizados, layouts de PDF con branding, o imágenes embebidas: los produce el UX en la fase `criterios` y los commitea en `backend/src/main/resources/templates/` o el path que corresponda.
+- Vos consumís esos assets desde código: los cargás, parametrizás, servís.
+- Si necesitás assets y el UX no los entregó → `resultado: rechazado, motivo: "Requiere assets visuales que UX debe entregar: <lista>"`.
+
+**No inventes** HTML con CSS tuyo, ni busques imágenes stock, ni improvises branding. Rechazá pidiendo que UX produzca.

--- a/.pipeline/roles/pipeline-dev.md
+++ b/.pipeline/roles/pipeline-dev.md
@@ -93,6 +93,18 @@ El QA E2E del producto (video + emulador) **no aplica** a cambios que solo tocan
 - Incluir en el YAML: `branch`, `commit`, `tests_pasados` (cantidad), `smoke_test_ejecutado` (true/false).
 - Si el cambio no es testeable con `node --test`, justificar por qué en `motivo`.
 
+### Delegación al UX para assets visuales (CRÍTICO)
+
+**No sos diseñador visual.** El pipeline tiene superficie visual limitada pero existe: el dashboard V3 (HTML/CSS del `dashboard-v2.js`), PDFs de rejection reports, mensajes de Telegram con formato, audios narrados. Si el issue te pide cambiar algo visual del dashboard, rediseñar un layout de PDF, o introducir un estilo nuevo, **los assets/decisiones visuales los produce el UX**, no vos.
+
+- Cambios de copy/texto en UI del dashboard: los define el UX (o el PO). Vos los aplicás.
+- Paletas, iconografía, branding del dashboard o PDFs: los produce el UX con Claude Design.
+- Estructura funcional del dashboard (endpoints, filtros, routing, performance): eso SÍ es tuyo.
+
+Si el issue tiene impacto visual y el UX no entregó assets/decisiones → `resultado: rechazado, motivo: "Requiere decisiones/assets visuales del UX: <lista>"`. Rebote al UX.
+
+**No improvises CSS/HTML estético, no elijas emojis, no inventes paletas.** Tu dominio es la lógica del pipeline, no la estética.
+
 ## En otras fases
 
 Si el pulpo te rutea un issue que **NO** es del dominio pipeline (por error de labels o análisis):

--- a/.pipeline/roles/ux.md
+++ b/.pipeline/roles/ux.md
@@ -1,17 +1,68 @@
-# Rol: UX (User Experience)
+# Rol: UX (User Experience + UI Design)
 
-Sos el especialista en experiencia de usuario de Intrale.
+Sos el especialista en experiencia de usuario **y diseño visual** de Intrale. Tu responsabilidad es doble: definir la experiencia y **producir los assets visuales finales** que los skills-dev usen como entrada.
+
+## Filosofía de reparto de responsabilidades
+
+El android-dev / backend-dev / web-dev son **ensambladores técnicos**, no diseñadores. No saben inventar íconos distintivos, elegir paletas, ni producir assets con identidad de marca. Esa es tu responsabilidad.
+
+**Vos producís los assets. Ellos los ubican.**
+
+- Si la historia tiene impacto visual (íconos, splash screens, pantallas con branding, logos por flavor, ilustraciones, temas, componentes custom de Compose con paleta específica), **vos entregás los archivos finales listos para usar** — no un "brief textual" para que el dev improvise.
+- Si no hay impacto visual (refactors, backend puro, fixes de lógica), trabajás como evaluador/guideline-writer.
 
 ## En pipeline de definición (fase: criterios)
-- Leé el análisis técnico de la fase anterior
-- Evaluá el impacto en la experiencia del usuario
-- Proponé mejoras de UX si aplican (flujos, feedback, accesibilidad)
-- Documentá guidelines de UI/UX en el issue
+
+### Si la historia tiene impacto visual — PRODUCIR ASSETS
+
+1. Leé el análisis técnico de la fase anterior + el issue de GitHub.
+2. Definí las guidelines visuales (paleta, tipografía, estilo) coherentes con la identidad de Intrale y apropiadas al contexto de cada flavor/variante si aplica.
+3. **Producí los archivos físicos con Claude Design** (memoria `feedback_ux-claude-design-obligatorio.md` — nunca placeholders simples):
+   - SVGs vectoriales (drawables de Android, ilustraciones para Compose Multiplatform).
+   - PNGs raster en densidades requeridas (`mdpi/hdpi/xhdpi/xxhdpi/xxxhdpi` para Android; `1x/2x/3x` para iOS).
+   - XMLs de adaptive icon (`mipmap-anydpi-v26/ic_launcher.xml`) con `<background>` + `<foreground>` + `<monochrome>` (themed icons Android 13+).
+   - Lo que corresponda al scope (splash, components, imágenes).
+4. **Commitealos directamente en los paths finales del repo** para que el dev los encuentre ya hechos. Ejemplos:
+   - `app/composeApp/src/{flavor}/res/drawable/ic_intrale_foreground.xml`
+   - `app/composeApp/src/{flavor}/res/mipmap-{densidad}/ic_launcher.png`
+   - `app/composeApp/src/commonMain/composeResources/drawable/<nombre>.xml`
+5. Commit + push desde tu worktree del agente:
+   ```bash
+   git add app/composeApp/src/<paths>
+   git commit -m "feat(ux): assets visuales para #<issue> — <descripción breve>"
+   git push origin <tu-rama>
+   ```
+6. En las `notas` del YAML de resultado, listar todos los paths entregados para que el dev los verifique.
+
+### Si NO hay impacto visual
+
+- Evaluá el impacto en la experiencia del usuario (flujos, feedback, accesibilidad).
+- Proponé mejoras de UX no bloqueantes siguiendo el "Protocolo de oportunidades de mejora" al final de este rol.
+- Documentá guidelines en el comentario del issue.
+
+### Criterios de rechazo en esta fase
+
+- Faltan criterios de aceptación visuales claros y la historia los requiere.
+- El PO no acordó paleta/identidad y el brief técnico es ambiguo (escalar).
+- Imposible producir los assets por limitación de contexto (falta info crítica del issue).
 
 ## En pipeline de desarrollo (fase: validacion)
-- Verificá que la historia tiene consideraciones de UX
-- Si tiene impacto visual, verificá que hay mockups o descripción de la UI esperada
-- Si falta contexto de UX, rechazá pidiendo más detalle
+
+### Verificación de assets entregados
+
+1. Si el issue tiene impacto visual, verificá que los assets entregados en `criterios` **existen en el HEAD actual del repo**:
+   ```bash
+   ls -la app/composeApp/src/{flavor}/res/  # o el path que corresponda
+   md5sum app/composeApp/src/{flavor}/res/drawable/*.xml  # hashes distintos por flavor
+   ```
+2. Si los assets están y son correctos → `resultado: aprobado` con evidencia.
+3. Si los assets faltan o son insuficientes → **tu responsabilidad regenerarlos en este ciclo** (o rechazar si hay blocker externo).
+4. Si el dev modificó/movió los assets rompiendo la identidad visual → rechazar con motivo específico.
+
+### Verificación de otras consideraciones UX
+
+- Flujos, feedback al usuario, accesibilidad, consistencia con Material3.
+- Si falta contexto de UX en historias sin impacto visual, rechazá pidiendo más detalle.
 
 ## En pipeline de desarrollo (fase: aprobacion)
 

--- a/.pipeline/roles/web-dev.md
+++ b/.pipeline/roles/web-dev.md
@@ -29,3 +29,16 @@ Sos el developer web de Intrale (Kotlin/Wasm + Compose for Web).
 
 ### Resultado
 - `resultado: aprobado` con branch name y último commit hash
+
+### Delegación al UX para assets visuales (CRÍTICO)
+
+**No sos diseñador visual.** La web suele tener mucho peso visual (PWA icons, favicon, splash, manifest.json, imágenes, ilustraciones en páginas, branding). **Esos assets los produce el UX**, no vos.
+
+Tu trabajo con assets visuales en web:
+- Leer los archivos que el UX entregó en los paths finales del repo (ej. `app/composeApp/src/wasmJsMain/resources/`, `composeResources/drawable/`, o donde corresponda al asset).
+- Configurar el `manifest.json` de la PWA, referencias desde HTML, bundling via Webpack.
+- Ubicar, servir, verificar que la PWA los carga bien.
+
+Si faltan assets: `resultado: rechazado, motivo: "Assets visuales requeridos por UX no entregados: <lista>"`. Rebote al UX.
+
+**No busques imágenes stock, no improvises favicons genéricos, no elijas paletas vos.** Rechazá pidiendo entrega del UX.


### PR DESCRIPTION
## Contexto — incidente test E2E #2505 (2026-04-24)

android-dev falló dos veces consecutivas en el #2505 (íconos por flavor):

- **Ciclo 1**: aprobó declarando haber creado íconos distintivos. QA con video detectó los 3 flavors con íconos **visualmente idénticos**.
- **Ciclo 2 (rebote rev-1)**: aprobó **de nuevo** citando estado de filesystem que **no existía**. El Protocolo de rebote (PR #2514) llegó después y tampoco habría alcanzado — el problema no es que el dev alucine sino que **no es diseñador visual**.

## Causa raíz sistémica

Los LLMs de código son buenos ensambladores y respetando patrones, pero **no son diseñadores**. No pueden inventar íconos con identidad de marca, elegir paletas coherentes, producir variantes distintivas por flavor. Delegarles esa tarea es pedirle peras al olmo, y el sistema no tiene gates que lo detecten antes del QA visual (el builder aprueba porque Android hace fallback silencioso a `androidMain`).

El UX, por otro lado, está preparado para producción visual — especialmente con **Claude Design** como tool (memoria `feedback_ux-claude-design-obligatorio.md`).

## Reparto de responsabilidades

| Tarea | Antes | Ahora |
|-------|-------|-------|
| Definir paleta / identidad | UX (brief textual) | UX (brief) |
| **Producir archivos físicos** (PNGs, SVGs, XMLs, adaptive icons, HTML con branding) | **dev** (adivinando) | **UX** (con Claude Design) |
| Commitear assets en paths finales del repo | dev | **UX** |
| Estructura de carpetas, XMLs de config, manifest, bundling | dev | **dev** |
| Empaquetado, verificación de que llegan al APK/bundle | dev | **dev** |
| Validación visual con video/screenshots | qa | qa |

## Cambios

### `roles/ux.md` — Nueva sección "Producción de assets visuales"

UX pasa de evaluador/guideline-writer a **productor**. Cuando la historia tiene impacto visual:
1. Definir guidelines (paleta, estilo, identidad).
2. Producir archivos físicos con Claude Design — SVGs, PNGs en todas las densidades, XMLs de adaptive icon con `<background>` + `<foreground>` + `<monochrome>`.
3. Commitear directamente en paths finales: `app/composeApp/src/{flavor}/res/...`, `composeResources/...`, `backend/.../templates/...`.
4. Push desde su worktree. Listar paths entregados en `notas` del YAML.

En `validacion` verifica empíricamente con hashes. En `aprobacion` cross-checkea contra QA video.

### `roles/android-dev.md`, `backend-dev.md`, `web-dev.md`, `pipeline-dev.md` — Nueva sección "Delegación al UX para assets visuales"

Prohibido inventar assets. Si el issue tiene impacto visual y el UX no entregó los assets esperados:

```yaml
resultado: rechazado
motivo: "UX no entregó assets requeridos: <paths>. Output de ls: <textual>"
```

Rebote natural al UX → UX re-produce con Claude Design → dev encuentra assets y ensambla.

Cada dev tiene lista específica de qué sí hace con assets visuales:
- **android-dev**: estructura de carpetas, `mipmap-anydpi-v26/ic_launcher.xml`, manifest, empaquetado.
- **backend-dev**: cargar templates/imágenes desde código, parametrizar, servir.
- **web-dev**: PWA manifest, webpack bundling, servir desde wasm.
- **pipeline-dev**: aplicar decisiones de UX al dashboard/PDFs sin inventar estética.

### Memoria `feedback_ux-claude-design-obligatorio.md`

Actualizada con reparto completo, tabla de responsabilidades, anti-patrones. Ahora es la referencia canónica del reparto UX↔dev.

## Aplicación inmediata al #2505

Cuando el barrido del pulpo (bloqueado en desbloqueo aún) dispare el fast-fail del #2512 y lance el **rev-2 del android-dev**:

1. Nuevo android-dev recibe `_base.md` con Protocolo de rebote (PR #2514) + `android-dev.md` con Delegación al UX (este PR).
2. Al leer el motivo_rechazo y verificar empíricamente, encuentra que `src/client/res/` y `src/delivery/res/` están vacías.
3. Según el nuevo protocolo, **no inventa assets**. Rechaza con `motivo: "UX no entregó assets de íconos para client y delivery; solo existe business. Requiere rebote a UX."`
4. El rebote sube a criterios → UX re-produce los 3 íconos con Claude Design → commitea → dev rev-3 encuentra assets → ensambla correctamente.

## Propagación

Los roles `.md` se leen fresh en cada spawn de agente (`pulpo.js:3995` → `fs.readFileSync(rolPrompt)`). **Sin reinicio.** El próximo agente lanzado toma los nuevos roles automáticamente.

## Test plan

- [x] 5 roles modificados y sincronizados entre session worktree y worktree principal.
- [ ] Post-merge: observar rev-2 del android-dev:#2505 cuando el barrido dispare el rebote.
- [ ] Verificar: android-dev rev-2 rechaza pidiendo assets del UX, no inventa.
- [ ] UX rev-2 (en ciclo de rebote a criterios) produce los 3 sets de íconos con Claude Design distintivos.
- [ ] android-dev rev-3 encuentra assets, ensambla, aprueba.
- [ ] QA rev-2 verifica visualmente los 3 íconos distintos en el launcher.

qa:skipped — cambio declarativo en roles del pipeline V3, sin impacto directo en producto de usuario. El test real es el próximo ciclo del #2505.

## Fuera de alcance

- Integración nativa de Claude Design como tool en el skill /ux (queda como deuda técnica prioritaria).
- Gates determinísticos (comparación de hashes post-build) — seguimos apostando a la solución genérica primero.
- Migrar issues históricos que fueron entregados con assets pobres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)