### PR TITLE
feat(pipeline): cross-phase rebote — agentes pueden pedir re-ejecución de fase upstream

### DIFF
--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -598,6 +598,117 @@ function fasePath(pipelineName, faseName) {
   return path.join(PIPELINE, pipelineName, faseName);
 }
 
+// ---------------------------------------------------------------------------
+// CROSS-PHASE REBOTE — permite a un agente solicitar rebote a otra fase/skill
+// upstream cuando detecta que necesita re-ejecución de trabajo previo.
+//
+// Ejemplo: android-dev detecta que faltan assets del UX → emite YAML con
+//   rebote_destino: { pipeline: desarrollo, fase: validacion, skill: ux }
+// El pulpo rutea el issue a esa fase en vez del default `fase_rechazo`.
+//
+// Escalada automática por cantidad de rebotes cross-phase del mismo issue:
+//   - 1er rebote → destino declarado por el agente.
+//   - 2do rebote → escala a fase previa del mismo skill (ej. validacion/ux → criterios/ux).
+//   - 3er rebote → escalado a humano (label needs-human).
+// ---------------------------------------------------------------------------
+
+const MAX_CROSSPHASE_REBOTES = 2;
+
+/** Orden global de fases considerando todos los pipelines en el orden de config. */
+function getFaseGlobalOrder(config) {
+  const order = [];
+  for (const [pName, pCfg] of Object.entries(config.pipelines || {})) {
+    for (const fase of (pCfg.fases || [])) {
+      order.push({ pipeline: pName, fase });
+    }
+  }
+  return order;
+}
+
+function faseGlobalIndex(pipelineName, fase, config) {
+  const order = getFaseGlobalOrder(config);
+  return order.findIndex(e => e.pipeline === pipelineName && e.fase === fase);
+}
+
+/** Busca la fase anterior (en orden global) donde el skill dado participa. */
+function findPreviousFaseForSkill(skill, fromPipeline, fromFase, config) {
+  const order = getFaseGlobalOrder(config);
+  const currentIdx = order.findIndex(e => e.pipeline === fromPipeline && e.fase === fromFase);
+  if (currentIdx <= 0) return null;
+  for (let i = currentIdx - 1; i >= 0; i--) {
+    const { pipeline: p, fase: f } = order[i];
+    const skills = (config.pipelines?.[p]?.skills_por_fase?.[f]) || [];
+    if (skills.includes(skill)) {
+      return { pipeline: p, fase: f, skill };
+    }
+  }
+  return null;
+}
+
+/** Valida que un rebote_destino declarado por agente sea utilizable. */
+function validateRebotedDestino(destino, faseOriginPipeline, faseOrigin, config) {
+  if (!destino || typeof destino !== 'object') return { ok: false, reason: 'no-destino' };
+  const { pipeline: p, fase: f, skill: s } = destino;
+  if (!p || !f || !s) return { ok: false, reason: 'campos-incompletos' };
+  if (!config.pipelines?.[p]) return { ok: false, reason: `pipeline-no-existe:${p}` };
+  if (!(config.pipelines[p].fases || []).includes(f)) return { ok: false, reason: `fase-no-existe:${p}/${f}` };
+  const skillsFase = (config.pipelines[p].skills_por_fase?.[f]) || [];
+  if (!skillsFase.includes(s)) return { ok: false, reason: `skill-no-en-fase:${s}@${p}/${f}` };
+  const destIdx = faseGlobalIndex(p, f, config);
+  const origIdx = faseGlobalIndex(faseOriginPipeline, faseOrigin, config);
+  if (destIdx < 0 || origIdx < 0) return { ok: false, reason: 'fase-no-resoluble' };
+  if (destIdx >= origIdx) return { ok: false, reason: `destino-no-upstream:${p}/${f}>=${faseOriginPipeline}/${faseOrigin}` };
+  return { ok: true };
+}
+
+/** Cuenta rebotes cross-phase existentes del issue buscando en todos los YAML. */
+function contarCrossPhaseRebotes(issue, config) {
+  let maxCount = 0;
+  for (const pName of Object.keys(config.pipelines || {})) {
+    for (const fase of (config.pipelines[pName].fases || [])) {
+      for (const estado of ['pendiente', 'trabajando', 'procesado']) {
+        const dir = path.join(fasePath(pName, fase), estado);
+        try {
+          for (const f of fs.readdirSync(dir)) {
+            if (!f.startsWith(String(issue) + '.')) continue;
+            const data = readYaml(path.join(dir, f));
+            if (data?.rebote_tipo === 'crossphase' && (data.rebote_numero_crossphase || 0) > maxCount) {
+              maxCount = data.rebote_numero_crossphase;
+            }
+          }
+        } catch {}
+      }
+    }
+  }
+  return maxCount;
+}
+
+/**
+ * Resuelve un cross-phase rebote a partir de los archivos rechazados.
+ * Devuelve null si ningún archivo emitió `rebote_destino` o si el destino es inválido.
+ * Si hay múltiples destinos, elige el MÁS UPSTREAM (menor índice global).
+ */
+function resolveRebotedCrossPhase(resultados, pipelineOrigin, faseOrigin, config) {
+  const candidatos = [];
+  for (const r of resultados) {
+    if (r.resultado !== 'rechazado' || !r.rebote_destino) continue;
+    const validacion = validateRebotedDestino(r.rebote_destino, pipelineOrigin, faseOrigin, config);
+    if (!validacion.ok) {
+      log('barrido', `⚠️ #${r.issue || '?'} rebote_destino inválido (${validacion.reason}) — ignorando, cae a default`);
+      continue;
+    }
+    candidatos.push({
+      destino: r.rebote_destino,
+      skillOrigen: skillFromFile(r.file.name),
+      motivo: r.motivo || '',
+      index: faseGlobalIndex(r.rebote_destino.pipeline, r.rebote_destino.fase, config),
+    });
+  }
+  if (candidatos.length === 0) return null;
+  candidatos.sort((a, b) => a.index - b.index);
+  return candidatos[0];
+}
+
 /** Obtener el mtime de un archivo en minutos */
 function fileAgeMinutes(filepath) {
   try {
@@ -2158,6 +2269,106 @@ function brazoBarrido(config) {
         }
 
         const rechazados = resultados.filter(r => r.resultado === 'rechazado');
+
+        // CROSS-PHASE REBOTE: si algún archivo rechazado declara `rebote_destino`
+        // válido, rutear el issue a esa fase/skill upstream en lugar del default.
+        // Interceptado ANTES del flujo de rebote normal a `fase_rechazo`.
+        if (rechazados.length > 0) {
+          const cross = resolveRebotedCrossPhase(resultados, pipelineName, fase, loadConfig());
+          if (cross) {
+            const cfg = loadConfig();
+            const crossCount = contarCrossPhaseRebotes(issue, cfg);
+            const nuevoCrossCount = crossCount + 1;
+
+            let destinoEfectivo = null;
+            let escalaAHumano = false;
+            if (nuevoCrossCount > MAX_CROSSPHASE_REBOTES) {
+              escalaAHumano = true;
+            } else if (nuevoCrossCount === 1) {
+              destinoEfectivo = cross.destino;
+            } else {
+              // 2do intento: escalar a fase previa del mismo skill.
+              const previa = findPreviousFaseForSkill(
+                cross.destino.skill, cross.destino.pipeline, cross.destino.fase, cfg,
+              );
+              if (!previa) {
+                escalaAHumano = true;
+                log('barrido', `⛔ #${issue} cross-phase rev-${nuevoCrossCount}: sin fase previa para skill ${cross.destino.skill} — escalando a humano`);
+              } else {
+                destinoEfectivo = previa;
+                log('barrido', `↑ #${issue} cross-phase rev-${nuevoCrossCount}: escala a ${previa.pipeline}/${previa.fase}/${previa.skill}`);
+              }
+            }
+
+            if (escalaAHumano) {
+              log('barrido', `⛔ #${issue} CIRCUIT BREAKER CROSSPHASE — ${nuevoCrossCount} rebotes cross-phase (cap ${MAX_CROSSPHASE_REBOTES}). Escalando.`);
+              sendTelegram(`⛔ Issue #${issue} — ${nuevoCrossCount} rebotes cross-phase solicitados por agentes. Requiere intervención manual.`);
+              try {
+                const ghQueueDir = path.join(PIPELINE, 'servicios', 'github', 'pendiente');
+                fs.mkdirSync(ghQueueDir, { recursive: true });
+                const labelFile = path.join(ghQueueDir, `${issue}-needs-human-crossphase-${Date.now()}.json`);
+                fs.writeFileSync(labelFile, JSON.stringify({ action: 'label', issue: parseInt(issue), label: 'needs-human' }));
+              } catch (e) { log('barrido', `error encolando label needs-human: ${e.message}`); }
+              for (const a of archivos) {
+                const dest = path.join(fasePath(pipelineName, fase), 'procesado');
+                try { moveFile(a.path, dest); } catch {}
+              }
+              continue;
+            }
+
+            // Cleanup: mover a procesado/ archivos del issue en todas las fases
+            // entre el destino (inclusivo) y la fase origen (inclusivo), para
+            // que el nuevo ciclo arranque limpio sin conflicto con residuos.
+            const destIdx = faseGlobalIndex(destinoEfectivo.pipeline, destinoEfectivo.fase, cfg);
+            const origIdx = faseGlobalIndex(pipelineName, fase, cfg);
+            const orderGlobal = getFaseGlobalOrder(cfg);
+            for (let i = destIdx; i <= origIdx; i++) {
+              const { pipeline: p, fase: f } = orderGlobal[i];
+              for (const estado of ['pendiente', 'trabajando', 'listo']) {
+                const dir = path.join(fasePath(p, f), estado);
+                try {
+                  for (const fname of fs.readdirSync(dir)) {
+                    if (fname.startsWith('.')) continue;
+                    if (!fname.startsWith(String(issue) + '.')) continue;
+                    const src = path.join(dir, fname);
+                    const dst = path.join(fasePath(p, f), 'procesado', fname);
+                    try {
+                      const prev = readYaml(src) || {};
+                      writeYaml(dst, { ...prev, cancelado_por: 'cross-phase-rebote', cancelado_ts: new Date().toISOString() });
+                      fs.unlinkSync(src);
+                    } catch {}
+                  }
+                } catch {}
+              }
+            }
+
+            // Crear archivo en destino efectivo
+            const destPendiente = path.join(fasePath(destinoEfectivo.pipeline, destinoEfectivo.fase), 'pendiente');
+            try { fs.mkdirSync(destPendiente, { recursive: true }); } catch {}
+            const destFile = path.join(destPendiente, `${issue}.${destinoEfectivo.skill}`);
+            const yamlOut = {
+              issue: parseInt(issue),
+              fase: destinoEfectivo.fase,
+              pipeline: destinoEfectivo.pipeline,
+              rebote: true,
+              rebote_tipo: 'crossphase',
+              rebote_numero_crossphase: nuevoCrossCount,
+              rebote_destino_solicitado: cross.destino,
+              rebote_destino_efectivo: destinoEfectivo,
+              motivo_rechazo: sanitizePipelineText(cross.motivo),
+              rechazado_en_fase: fase,
+              rechazado_por_skill: cross.skillOrigen,
+            };
+            writeYaml(destFile, yamlOut);
+
+            log('barrido', `↪ #${issue} CROSS-PHASE rev-${nuevoCrossCount} — ${pipelineName}/${fase}/${cross.skillOrigen} → ${destinoEfectivo.pipeline}/${destinoEfectivo.fase}/${destinoEfectivo.skill}`);
+            ghCommentOnIssue(
+              issue,
+              `🔁 Pipeline: **${cross.skillOrigen}** (fase \`${pipelineName}/${fase}\`) solicitó re-ejecución de **${destinoEfectivo.skill}** (fase \`${destinoEfectivo.pipeline}/${destinoEfectivo.fase}\`).\n\nCross-phase rebote rev-${nuevoCrossCount}/${MAX_CROSSPHASE_REBOTES}.\n\nMotivo:\n> ${cross.motivo.slice(0, 500)}`
+            );
+            continue;
+          }
+        }
 
         if (rechazados.length > 0 && faseRechazo) {
           // #2317: clasificar los rechazos por tipo. Si TODOS los motivos
@@ -6577,7 +6788,14 @@ if (process.env.PULPO_NO_AUTOSTART === '1') {
     staleness,
     _precheckState: () => ({ lastPrecheckResult, lastPrecheckAt, lastInfraBlockedIssues: Array.from(lastInfraBlockedIssues) }),
     _setPrecheckState: (r) => { lastPrecheckResult = r; lastPrecheckAt = Date.now(); },
-    _resetPrecheckState: () => { lastPrecheckResult = null; lastPrecheckAt = 0; lastPrecheckOkStreak = 0; lastInfraBlockedIssues = new Set(); }
+    _resetPrecheckState: () => { lastPrecheckResult = null; lastPrecheckAt = 0; lastPrecheckOkStreak = 0; lastInfraBlockedIssues = new Set(); },
+    // #2516 — cross-phase rebote: utilidades para tests.
+    MAX_CROSSPHASE_REBOTES,
+    getFaseGlobalOrder,
+    faseGlobalIndex,
+    findPreviousFaseForSkill,
+    validateRebotedDestino,
+    resolveRebotedCrossPhase,
   };
   return; // No arrancar singleton ni mainLoop
 }

--- a/.pipeline/roles/_base.md
+++ b/.pipeline/roles/_base.md
@@ -116,6 +116,52 @@ Usá `gh` para interactuar con GitHub:
 - `gh pr create` — crear PR (solo delivery)
 - Siempre con `export PATH="/c/Workspaces/gh-cli/bin:$PATH"` antes
 
+## Rebote cross-phase (opcional — solicitar re-ejecución de otra fase/skill upstream)
+
+Si durante tu trabajo detectás que **te faltan entregables de otro skill** que vive en una fase anterior (ej. android-dev detecta que UX no entregó los assets esperados), podés solicitar al pipeline que re-ejecute ese skill **en lugar de rebotar al default**.
+
+Para hacerlo, emití en tu resultado:
+
+```yaml
+resultado: rechazado
+motivo: "Explicación detallada + evidencia empírica (output de ls/cat/etc)"
+rebote_destino:
+  pipeline: desarrollo   # o definicion
+  fase: validacion       # fase destino (debe ser upstream de la tuya)
+  skill: ux              # skill que debe re-ejecutar
+```
+
+### Reglas
+
+1. **Destino debe ser upstream** — la fase destino tiene que estar ANTES de la tuya en el orden del pipeline. Declarar un destino no-upstream hace que el pulpo ignore `rebote_destino` y caiga al rebote normal.
+2. **Skill debe existir en la fase destino** — validado contra `skills_por_fase` de `config.yaml`. Si no existe, se ignora.
+3. **Un destino por rechazo** — si varios archivos rechazados emiten destinos distintos para el mismo issue, el pulpo elige el más upstream (más conservador).
+4. **Motivo obligatorio con evidencia empírica** — como cualquier rechazo, debe citar output real de comandos (ver "Protocolo de rebote"). No basta con "me faltan cosas del UX" genérico.
+5. **El motivo viaja al destino** como `motivo_rechazo` + `rechazado_en_fase` + `rechazado_por_skill`. El agente que re-ejecute lee esos campos para saber qué pasó.
+
+### Escalada automática
+
+El pulpo lleva un contador `rebote_numero_crossphase` por issue:
+
+- **1er cross-phase rebote** → destino declarado por el agente.
+- **2do cross-phase rebote** → el pulpo **escala automáticamente** a la fase previa del mismo skill (ej. si pediste `desarrollo/validacion/ux` otra vez, escala a `definicion/criterios/ux`).
+- **3er cross-phase rebote** → circuit breaker, label `needs-human`, escalado manual.
+
+Esto da un gradiente natural: primero intentar cerrar el gap cerca en el flow, después ir más profundo si persiste, y finalmente pedir ayuda humana.
+
+### Cuándo usarlo
+
+- android-dev detecta que faltan assets de UX.
+- Tester detecta que faltan test cases de criterios.
+- QA detecta que el issue requiere re-análisis técnico por cambios no documentados.
+- Review detecta un problema de arquitectura que requiere re-definición.
+
+### Cuándo NO usarlo
+
+- Problemas que vos podés resolver (código, bugs en tu scope).
+- Rechazos por falta de información **en tu propio rol** (pedí al issue, no a otra fase).
+- Disputas con el veredicto de otra fase (eso es rebote normal con argumentación, no cross-phase).
+
 ## Idioma
 
 - Código: inglés

--- a/.pipeline/roles/android-dev.md
+++ b/.pipeline/roles/android-dev.md
@@ -49,17 +49,22 @@ Tu trabajo con assets visuales se limita a:
    md5sum app/composeApp/src/*/res/drawable/ic_intrale_foreground.xml 2>&1
    ```
 2. Leé las `notas` del YAML del UX en `definicion/criterios/procesado/<issue>.ux` para ver qué paths declaró entregados.
-3. **Si los assets faltan o son insuficientes para cubrir los criterios del issue**:
+3. **Si los assets faltan o son insuficientes para cubrir los criterios del issue**, usá **cross-phase rebote** para que UX re-ejecute (ver `_base.md` → "Rebote cross-phase"):
    ```yaml
    resultado: rechazado
    motivo: |
-     Los assets visuales que entregó UX no son suficientes para cumplir con <CA-N>.
-     Paths esperados según criterios del issue: <lista de paths>.
-     Output de `ls`:
-     <output textual real>
-     Requiere que UX genere los assets faltantes antes de que dev pueda ensamblar.
+     UX no entregó assets suficientes para cumplir con <CA-N>.
+     Paths esperados: <lista>.
+     Verificación:
+     $ ls -la app/composeApp/src/{client,delivery}/res 2>&1
+     ls: cannot access 'app/composeApp/src/client/res': No such file or directory
+     ls: cannot access 'app/composeApp/src/delivery/res': No such file or directory
+   rebote_destino:
+     pipeline: desarrollo
+     fase: validacion
+     skill: ux
    ```
-   Esto rebota al ciclo `criterios` (UX re-produce assets) sin que dev tenga que inventar.
+   El pulpo rutea el issue a `desarrollo/validacion/pendiente/<issue>.ux` para que UX regenere los assets sin que vos tengas que inventar. Si UX de validación no resuelve en el primer intento, el pulpo escala automáticamente a `definicion/criterios/ux` en el segundo.
 4. **Si los assets están completos**: tu tarea es ensamblaje puro. Crear estructura, XMLs de config, verificar que cada APK empaqueta sus propios assets (no fallback a `androidMain`):
    ```bash
    ./gradlew :app:composeApp:assembleClientDebug --no-daemon

--- a/.pipeline/roles/backend-dev.md
+++ b/.pipeline/roles/backend-dev.md
@@ -65,6 +65,15 @@ val logger: Logger = LoggerFactory.getLogger("ar.com.intrale")
 
 - Si un endpoint requiere templates HTML estilizados, layouts de PDF con branding, o imágenes embebidas: los produce el UX en la fase `criterios` y los commitea en `backend/src/main/resources/templates/` o el path que corresponda.
 - Vos consumís esos assets desde código: los cargás, parametrizás, servís.
-- Si necesitás assets y el UX no los entregó → `resultado: rechazado, motivo: "Requiere assets visuales que UX debe entregar: <lista>"`.
+- Si necesitás assets y el UX no los entregó, usá **cross-phase rebote** (ver `_base.md` → "Rebote cross-phase"):
+  ```yaml
+  resultado: rechazado
+  motivo: "UX no entregó templates/imágenes requeridos: <lista + output de ls/find>"
+  rebote_destino:
+    pipeline: desarrollo
+    fase: validacion
+    skill: ux
+  ```
+  El pulpo rutea a `desarrollo/validacion/ux` para que regenere. Escalada automática a `definicion/criterios/ux` si persiste.
 
 **No inventes** HTML con CSS tuyo, ni busques imágenes stock, ni improvises branding. Rechazá pidiendo que UX produzca.

--- a/.pipeline/roles/pipeline-dev.md
+++ b/.pipeline/roles/pipeline-dev.md
@@ -101,7 +101,16 @@ El QA E2E del producto (video + emulador) **no aplica** a cambios que solo tocan
 - Paletas, iconografía, branding del dashboard o PDFs: los produce el UX con Claude Design.
 - Estructura funcional del dashboard (endpoints, filtros, routing, performance): eso SÍ es tuyo.
 
-Si el issue tiene impacto visual y el UX no entregó assets/decisiones → `resultado: rechazado, motivo: "Requiere decisiones/assets visuales del UX: <lista>"`. Rebote al UX.
+Si el issue tiene impacto visual y el UX no entregó assets/decisiones, usá **cross-phase rebote** (ver `_base.md` → "Rebote cross-phase"):
+```yaml
+resultado: rechazado
+motivo: "UX no entregó decisiones/assets visuales para: <lista + evidencia>"
+rebote_destino:
+  pipeline: desarrollo
+  fase: validacion
+  skill: ux
+```
+El pulpo rutea a `desarrollo/validacion/ux` para que regenere. Escalada automática a `definicion/criterios/ux` si persiste.
 
 **No improvises CSS/HTML estético, no elijas emojis, no inventes paletas.** Tu dominio es la lógica del pipeline, no la estética.
 

--- a/.pipeline/roles/ux.md
+++ b/.pipeline/roles/ux.md
@@ -46,6 +46,28 @@ El android-dev / backend-dev / web-dev son **ensambladores técnicos**, no dise�
 - El PO no acordó paleta/identidad y el brief técnico es ambiguo (escalar).
 - Imposible producir los assets por limitación de contexto (falta info crítica del issue).
 
+### Cross-phase rebote desde UX
+
+Vos también podés pedir re-ejecución de otra fase si detectás que falta algo upstream. Ver `_base.md` → "Rebote cross-phase".
+
+Ejemplos válidos:
+- **Falta análisis técnico de viabilidad** para saber qué assets producir (ej. no sabés si el target soporta un formato):
+  ```yaml
+  rebote_destino:
+    pipeline: definicion
+    fase: analisis
+    skill: guru
+  ```
+- **PO debe definir alcance visual** que no está claro en el issue (ej. qué flavors requieren ícono distintivo):
+  ```yaml
+  rebote_destino:
+    pipeline: definicion
+    fase: criterios
+    skill: po
+  ```
+
+No abuses: si el problema lo podés resolver vos con la info disponible, no pidas rebote.
+
 ## En pipeline de desarrollo (fase: validacion)
 
 ### Verificación de assets entregados

--- a/.pipeline/roles/web-dev.md
+++ b/.pipeline/roles/web-dev.md
@@ -39,6 +39,15 @@ Tu trabajo con assets visuales en web:
 - Configurar el `manifest.json` de la PWA, referencias desde HTML, bundling via Webpack.
 - Ubicar, servir, verificar que la PWA los carga bien.
 
-Si faltan assets: `resultado: rechazado, motivo: "Assets visuales requeridos por UX no entregados: <lista>"`. Rebote al UX.
+Si faltan assets, usá **cross-phase rebote** (ver `_base.md` → "Rebote cross-phase"):
+```yaml
+resultado: rechazado
+motivo: "UX no entregó assets web requeridos: <lista + output ls/find>"
+rebote_destino:
+  pipeline: desarrollo
+  fase: validacion
+  skill: ux
+```
+El pulpo rutea a `desarrollo/validacion/ux` para que regenere. Escalada automática a `definicion/criterios/ux` si persiste.
 
 **No busques imágenes stock, no improvises favicons genéricos, no elijas paletas vos.** Rechazá pidiendo entrega del UX.

--- a/.pipeline/test-cross-phase-rebote.js
+++ b/.pipeline/test-cross-phase-rebote.js
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+// =============================================================================
+// Tests cross-phase rebote (#2516 — PR del reparto UX↔dev)
+//
+// Cubren los helpers puros de pulpo.js:
+//   - faseGlobalIndex / getFaseGlobalOrder
+//   - findPreviousFaseForSkill
+//   - validateRebotedDestino
+//   - resolveRebotedCrossPhase
+//
+// NO cubren integración con filesystem (cleanup, escribir archivos) — eso queda
+// validado por observación real en el próximo ciclo de #2505 post-merge.
+// =============================================================================
+
+process.env.PULPO_NO_AUTOSTART = '1';
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const pulpo = require('./pulpo.js');
+
+const CONFIG_FAKE = {
+  pipelines: {
+    definicion: {
+      fases: ['analisis', 'criterios', 'sizing'],
+      skills_por_fase: {
+        analisis: ['guru', 'security'],
+        criterios: ['po', 'ux'],
+        sizing: ['planner'],
+      },
+    },
+    desarrollo: {
+      fases: ['validacion', 'dev', 'build', 'verificacion', 'linteo', 'aprobacion', 'entrega'],
+      skills_por_fase: {
+        validacion: ['po', 'ux', 'guru'],
+        dev: ['backend-dev', 'android-dev', 'web-dev', 'pipeline-dev'],
+        build: ['build'],
+        verificacion: ['tester', 'security', 'qa'],
+        linteo: ['linter'],
+        aprobacion: ['review', 'po', 'ux'],
+        entrega: ['delivery'],
+      },
+    },
+  },
+};
+
+test('getFaseGlobalOrder genera orden plano de fases', () => {
+  const order = pulpo.getFaseGlobalOrder(CONFIG_FAKE);
+  assert.equal(order.length, 10);
+  assert.deepEqual(order[0], { pipeline: 'definicion', fase: 'analisis' });
+  assert.deepEqual(order[2], { pipeline: 'definicion', fase: 'sizing' });
+  assert.deepEqual(order[3], { pipeline: 'desarrollo', fase: 'validacion' });
+  assert.deepEqual(order[9], { pipeline: 'desarrollo', fase: 'entrega' });
+});
+
+test('faseGlobalIndex devuelve indice correcto', () => {
+  assert.equal(pulpo.faseGlobalIndex('definicion', 'analisis', CONFIG_FAKE), 0);
+  assert.equal(pulpo.faseGlobalIndex('desarrollo', 'dev', CONFIG_FAKE), 4);
+  assert.equal(pulpo.faseGlobalIndex('desarrollo', 'entrega', CONFIG_FAKE), 9);
+  assert.equal(pulpo.faseGlobalIndex('no-pipe', 'fake', CONFIG_FAKE), -1);
+});
+
+test('findPreviousFaseForSkill: ux desde desarrollo/validacion escala a definicion/criterios', () => {
+  const prev = pulpo.findPreviousFaseForSkill('ux', 'desarrollo', 'validacion', CONFIG_FAKE);
+  assert.deepEqual(prev, { pipeline: 'definicion', fase: 'criterios', skill: 'ux' });
+});
+
+test('findPreviousFaseForSkill: ux desde definicion/criterios no tiene anterior', () => {
+  const prev = pulpo.findPreviousFaseForSkill('ux', 'definicion', 'criterios', CONFIG_FAKE);
+  assert.equal(prev, null);
+});
+
+test('findPreviousFaseForSkill: po desde aprobacion escala a validacion (mismo pipeline)', () => {
+  const prev = pulpo.findPreviousFaseForSkill('po', 'desarrollo', 'aprobacion', CONFIG_FAKE);
+  assert.deepEqual(prev, { pipeline: 'desarrollo', fase: 'validacion', skill: 'po' });
+});
+
+test('validateRebotedDestino: destino upstream valido', () => {
+  const res = pulpo.validateRebotedDestino(
+    { pipeline: 'desarrollo', fase: 'validacion', skill: 'ux' },
+    'desarrollo', 'dev', CONFIG_FAKE
+  );
+  assert.equal(res.ok, true);
+});
+
+test('validateRebotedDestino: destino downstream rechazado', () => {
+  const res = pulpo.validateRebotedDestino(
+    { pipeline: 'desarrollo', fase: 'aprobacion', skill: 'review' },
+    'desarrollo', 'dev', CONFIG_FAKE
+  );
+  assert.equal(res.ok, false);
+  assert.match(res.reason, /destino-no-upstream/);
+});
+
+test('validateRebotedDestino: skill inexistente en la fase', () => {
+  const res = pulpo.validateRebotedDestino(
+    { pipeline: 'desarrollo', fase: 'validacion', skill: 'backend-dev' },
+    'desarrollo', 'dev', CONFIG_FAKE
+  );
+  assert.equal(res.ok, false);
+  assert.match(res.reason, /skill-no-en-fase/);
+});
+
+test('validateRebotedDestino: campos incompletos', () => {
+  assert.equal(pulpo.validateRebotedDestino(null, 'desarrollo', 'dev', CONFIG_FAKE).ok, false);
+  assert.equal(pulpo.validateRebotedDestino({}, 'desarrollo', 'dev', CONFIG_FAKE).ok, false);
+  assert.equal(pulpo.validateRebotedDestino({ pipeline: 'x' }, 'desarrollo', 'dev', CONFIG_FAKE).ok, false);
+});
+
+test('validateRebotedDestino: pipeline inexistente', () => {
+  const res = pulpo.validateRebotedDestino(
+    { pipeline: 'ghost', fase: 'validacion', skill: 'ux' },
+    'desarrollo', 'dev', CONFIG_FAKE
+  );
+  assert.equal(res.ok, false);
+  assert.match(res.reason, /pipeline-no-existe/);
+});
+
+test('resolveRebotedCrossPhase: ignora archivos sin rebote_destino', () => {
+  const resultados = [
+    { resultado: 'rechazado', motivo: 'x', file: { name: '100.android-dev' } },
+  ];
+  assert.equal(pulpo.resolveRebotedCrossPhase(resultados, 'desarrollo', 'dev', CONFIG_FAKE), null);
+});
+
+test('resolveRebotedCrossPhase: elige destino mas upstream entre varios', () => {
+  const resultados = [
+    {
+      resultado: 'rechazado', motivo: 'a',
+      rebote_destino: { pipeline: 'desarrollo', fase: 'validacion', skill: 'ux' },
+      file: { name: '100.android-dev' },
+    },
+    {
+      resultado: 'rechazado', motivo: 'b',
+      rebote_destino: { pipeline: 'definicion', fase: 'criterios', skill: 'ux' },
+      file: { name: '100.backend-dev' },
+    },
+  ];
+  const res = pulpo.resolveRebotedCrossPhase(resultados, 'desarrollo', 'dev', CONFIG_FAKE);
+  assert.ok(res);
+  assert.deepEqual(res.destino, { pipeline: 'definicion', fase: 'criterios', skill: 'ux' });
+});
+
+test('resolveRebotedCrossPhase: ignora destinos invalidos (downstream) y se queda con validos', () => {
+  const resultados = [
+    {
+      resultado: 'rechazado', motivo: 'invalido downstream',
+      rebote_destino: { pipeline: 'desarrollo', fase: 'entrega', skill: 'delivery' },
+      file: { name: '100.android-dev' },
+    },
+    {
+      resultado: 'rechazado', motivo: 'valido',
+      rebote_destino: { pipeline: 'desarrollo', fase: 'validacion', skill: 'ux' },
+      file: { name: '100.backend-dev' },
+    },
+  ];
+  const res = pulpo.resolveRebotedCrossPhase(resultados, 'desarrollo', 'dev', CONFIG_FAKE);
+  assert.ok(res);
+  assert.deepEqual(res.destino, { pipeline: 'desarrollo', fase: 'validacion', skill: 'ux' });
+});
+
+test('MAX_CROSSPHASE_REBOTES es 2 (gradiente: 1 destino declarado, 2 escala, 3 humano)', () => {
+  assert.equal(pulpo.MAX_CROSSPHASE_REBOTES, 2);
+});


### PR DESCRIPTION
## Contexto

Durante el test E2E del #2505 se detectó un gap del mecanismo de rebote: el pulpo solo rebota a la `fase_rechazo` del pipeline (`desarrollo/dev`). Si un agente detecta que necesita re-ejecución de **otro skill upstream** (ej. android-dev pidiendo assets al UX), no había forma de rutear allí. Resultado: loop de rechazos en dev hasta circuit breaker → `needs-human`.

Con el reparto UX↔dev mergeado en PR #2515 (UX produce assets, devs solo ensamblan), este gap se vuelve crítico: android-dev va a rechazar pidiendo UX, pero sin cross-phase rebote el pulpo lo re-encola en dev indefinidamente.

## Diseño

Los agentes declaran en su YAML de rechazo un campo opcional:

```yaml
resultado: rechazado
motivo: "UX no entregó assets. Output ls: ..."
rebote_destino:
  pipeline: desarrollo
  fase: validacion
  skill: ux
```

El pulpo valida que el destino sea upstream y rutea el issue a `desarrollo/validacion/pendiente/<issue>.ux`.

### Gradiente de escalada

Contador `rebote_numero_crossphase` por issue:

- **1er rebote** → destino declarado por el agente.
- **2do rebote** → pulpo escala automáticamente a fase previa del mismo skill (ej. `desarrollo/validacion/ux` → `definicion/criterios/ux`).
- **3er rebote** → circuit breaker, label `needs-human`, escalado manual.

## Implementación

### `pulpo.js` (helpers + `brazoBarrido`)

- `getFaseGlobalOrder`: orden plano de todas las fases de todos los pipelines según config.
- `faseGlobalIndex`: índice en ese orden (para comparar "upstream vs downstream").
- `findPreviousFaseForSkill`: dado un skill, busca la fase anterior donde participa (para escalada).
- `validateRebotedDestino`: pipeline/fase/skill existen + destino es upstream del origen.
- `contarCrossPhaseRebotes`: lee YAMLs del issue para calcular contador.
- `resolveRebotedCrossPhase`: si múltiples rechazados emiten destinos distintos, elige el más upstream.
- Bloque en `brazoBarrido` que intercepta antes del rebote default:
  - Si hay `rebote_destino` válido → rutea a destino efectivo (declarado o escalado).
  - Cleanup: mueve archivos del issue entre fase destino (inclusive) y fase origen a `procesado/` con `cancelado_por: cross-phase-rebote`.
  - Crea archivo nuevo en destino con YAML completo (`rebote_tipo: crossphase`, contador, motivo, skill origen).
  - Comment automático en GitHub para trazabilidad humana.

### Documentación en roles

- `_base.md`: nueva sección "Rebote cross-phase (opcional)" con reglas, validaciones, escalada, casos válidos/inválidos.
- `android-dev.md`, `backend-dev.md`, `web-dev.md`, `pipeline-dev.md`: cada rol actualiza su sección "Delegación al UX" con snippet YAML concreto de `rebote_destino`.
- `ux.md`: caso inverso (UX puede pedir rebote a `guru` o `po` si necesita análisis/criterios faltantes).

### Tests unitarios (14/14 pasan)

`test-cross-phase-rebote.js` cubre helpers puros:
- `getFaseGlobalOrder` genera orden correcto.
- `faseGlobalIndex` para cada fase.
- `findPreviousFaseForSkill` (ux desde validación → criterios, etc.).
- `validateRebotedDestino`: upstream válido, downstream rechazado, skill inexistente, pipeline inexistente, campos incompletos.
- `resolveRebotedCrossPhase`: múltiples destinos → elige más upstream, ignora destinos inválidos.

Ejecutar: `node --test .pipeline/test-cross-phase-rebote.js` (desde worktree principal con node_modules).

## Aplicación al #2505

Cuando el pulpo reiniciado detecte el rechazo del QA rev-N y rebote a dev:

1. **android-dev rev-N** (con rol actualizado del PR #2515) verifica empíricamente con `ls`, encuentra que faltan `src/client/res/` y `src/delivery/res/`.
2. Emite:
   ```yaml
   resultado: rechazado
   motivo: "UX no entregó assets. $ ls -la ...: No such file or directory"
   rebote_destino: { pipeline: desarrollo, fase: validacion, skill: ux }
   ```
3. **pulpo brazoBarrido** con el fix nuevo:
   - Resuelve destino → `desarrollo/validacion/ux`.
   - Contador `rebote_numero_crossphase = 1`.
   - Cleanup de archivos del issue en `validacion`, `dev`, `build`, `verificacion`, `linteo`.
   - Crea `desarrollo/validacion/pendiente/2505.ux` con YAML completo.
   - Comment en GitHub: *"android-dev solicitó re-ejecución de ux. Cross-phase rev-1/2. Motivo: ..."*.
4. **UX rev-N** (con rol del PR #2515, sección PRODUCIR ASSETS) lee motivo, regenera los 3 sets de íconos con Claude Design, commitea, aprueba.
5. barrido promueve a dev → android-dev rev-(N+1) encuentra assets → aprueba.
6. build → verificacion → linteo → aprobacion → entrega. ✅

Si UX rev-N no resuelve (ej. produjo assets insuficientes otra vez), android-dev rev-(N+2) vuelve a emitir `rebote_destino: validacion/ux`. El pulpo ve `rebote_numero_crossphase = 2` → escala a `definicion/criterios/ux`. Si tampoco resuelve → `needs-human`.

## Post-merge

**`pulpo` requiere restart** para que tome la lógica nueva de `brazoBarrido`. Los roles `.md` se leen fresh en cada spawn de agente, no requieren restart.

## Test plan

- [x] `node --check pulpo.js` y `test-cross-phase-rebote.js` passing (14/14).
- [ ] Post-merge: reiniciar pulpo desde PowerShell.
- [ ] Observar rev-N del android-dev:#2505 al spawnearse — verificar que emite `rebote_destino` según rol nuevo.
- [ ] Verificar que el pulpo crea `desarrollo/validacion/pendiente/2505.ux` (no `desarrollo/dev/pendiente/`).
- [ ] Verificar comentario automático en GitHub del #2505.
- [ ] Si UX produce assets correctamente → dev retoma → ciclo termina en entrega.

qa:skipped — cambio en lógica interna del pipeline V3, sin impacto directo en producto de usuario.

## Fuera de alcance

- Dashboard V3 mostrando cross-phase rebotes como badge distinto (cosmético, puede venir después).
- Config `cross_phase_rebote.max_bounces` en config.yaml (queda hardcoded en 2, suficiente por ahora).
- Tests de integración con filesystem real (mover archivos) — validación real pendiente en ciclo #2505.

🤖 Generated with [Claude Code](https://claude.com/claude-code)