### PR TITLE
fix(pipeline): brazoIntake y brazoDesbloqueo respetan partial_pause (closes #2506)

### DIFF
--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -6329,6 +6329,14 @@ function brazoIntake(config) {
   if (Date.now() - lastIntakeTime < intakeInterval) return;
   lastIntakeTime = Date.now();
 
+  // #2506: respetar pausa parcial — si está activa, solo procesar issues del allowlist.
+  // Si es pausa completa, no hacer intake.
+  const pipelineMode = partialPause.getPipelineMode();
+  if (pipelineMode.mode === 'paused') return;
+  const allowlistSet = pipelineMode.mode === 'partial_pause'
+    ? new Set(pipelineMode.allowedIssues.map(String))
+    : null;
+
   const intakeConfig = config.intake || {};
 
   for (const [pipelineName, pipeIntake] of Object.entries(intakeConfig)) {
@@ -6346,9 +6354,22 @@ function brazoIntake(config) {
         `"${GH_BIN}" issue list --label "${label}" --state open --json number,title,labels --limit 50 --search "-label:needs-human"`,
         { cwd: ROOT, encoding: 'utf8', timeout: 30000, windowsHide: true }
       );
-      const issues = JSON.parse(result || '[]');
+      let issues = JSON.parse(result || '[]');
 
       if (issues.length === 0) continue;
+
+      // #2506: si partial_pause, filtrar antes del loop principal para no hacer trabajo inútil.
+      if (allowlistSet) {
+        const before = issues.length;
+        issues = issues.filter(i => allowlistSet.has(String(i.number)));
+        if (issues.length === 0) {
+          log('intake', `${pipelineName}: partial_pause filtró ${before} issues fuera del allowlist — sin candidatos`);
+          continue;
+        }
+        if (before > issues.length) {
+          log('intake', `${pipelineName}: partial_pause filtró ${before - issues.length} issues fuera del allowlist (${issues.length} candidatos restantes)`);
+        }
+      }
 
       // Cachear labels+estado de los issues recién traídos de GitHub
       for (const issue of issues) {
@@ -6518,6 +6539,16 @@ function brazoDesbloqueo(config) {
   if (Date.now() - lastUnblockTime < UNBLOCK_INTERVAL_MS) return;
   lastUnblockTime = Date.now();
 
+  // #2506: respetar pausa parcial — los bloqueados fuera del allowlist no se van
+  // a ejecutar aunque se desbloqueen ahora, así que no tiene sentido gastar el
+  // ciclo consultando sus dependencias en GitHub (cada issue toma 20-30s por
+  // los múltiples gh issue view; con 25 issues bloqueados típicos, ~8 min/ciclo).
+  const pipelineMode = partialPause.getPipelineMode();
+  if (pipelineMode.mode === 'paused') return;
+  const allowlistSet = pipelineMode.mode === 'partial_pause'
+    ? new Set(pipelineMode.allowedIssues.map(String))
+    : null;
+
   try {
     // 1. Buscar issues abiertos con label blocked:dependencies
     ghThrottle();
@@ -6525,11 +6556,22 @@ function brazoDesbloqueo(config) {
       `"${GH_BIN}" issue list --label "blocked:dependencies" --state open --json number,title,labels --limit 50`,
       { cwd: ROOT, encoding: 'utf8', timeout: 30000, windowsHide: true }
     );
-    const blockedIssues = JSON.parse(result || '[]');
+    let blockedIssues = JSON.parse(result || '[]');
     if (blockedIssues.length === 0) {
       // Limpiar datos stale — si ya no hay bloqueados, el dashboard debe saberlo
       try { fs.writeFileSync(path.join(PIPELINE, 'blocked-issues.json'), JSON.stringify({ blockedBy: {}, blocks: {} }, null, 2)); } catch {}
       return;
+    }
+
+    // #2506: filtrar por allowlist si pausa parcial activa.
+    if (allowlistSet) {
+      const before = blockedIssues.length;
+      blockedIssues = blockedIssues.filter(i => allowlistSet.has(String(i.number)));
+      if (blockedIssues.length === 0) {
+        log('desbloqueo', `partial_pause: ninguno de los ${before} issues bloqueados está en el allowlist — skip ciclo`);
+        return;
+      }
+      log('desbloqueo', `partial_pause: filtrados ${before - blockedIssues.length} issues fuera del allowlist (${blockedIssues.length} candidatos)`);
     }
 
     log('desbloqueo', `Revisando ${blockedIssues.length} issues bloqueados por dependencias`);


### PR DESCRIPTION
## Cierra #2506

Durante el test E2E del #2505 vimos que el pulpo en pausa parcial (allowed_issues=[2505]) gastaba **5-8 minutos por ciclo** en el `brazoDesbloqueo`, consultando GitHub por issues bloqueados que nunca iba a procesar (ninguno en el allowlist).

El `brazoIntake` sufría del mismo patrón en menor escala: levantaba todos los Ready/needs-definition y los skipeaba uno por uno con log ruidoso.

## Fix

### brazoIntake (`pulpo.js:6327`)

Early check de `pipelineMode` ANTES de consultar GitHub. Filtrar issues recibidos por allowlist antes del loop principal si partial_pause está activa.

```javascript
const pipelineMode = partialPause.getPipelineMode();
if (pipelineMode.mode === 'paused') return;
const allowlistSet = pipelineMode.mode === 'partial_pause'
  ? new Set(pipelineMode.allowedIssues.map(String))
  : null;

// ...después del gh issue list:
if (allowlistSet) {
  issues = issues.filter(i => allowlistSet.has(String(i.number)));
  if (issues.length === 0) continue;
}
```

### brazoDesbloqueo (`pulpo.js:6538`)

Mismo patrón pero con mayor impacto: filtrar `blockedIssues` por allowlist **antes** de hacer el costoso `gh issue view` por cada dependencia.

```javascript
if (allowlistSet) {
  blockedIssues = blockedIssues.filter(i => allowlistSet.has(String(i.number)));
  if (blockedIssues.length === 0) {
    log('desbloqueo', `partial_pause: ninguno ... — skip ciclo`);
    return;
  }
}
```

## Impacto

| Escenario | Antes | Ahora |
|-----------|-------|-------|
| `partial_pause=[2505]`, 25 issues con `blocked:dependencies`, ninguno en allowlist | ~8 min/ciclo | ~0s |
| `partial_pause=[X]`, X bloqueado por deps | ~8 min | ~20-30s (solo procesa X) |
| `paused` | brazos hacían trabajo inútil | early return |
| `running` (sin pausa) | sin cambio | sin cambio |

Para el #2505 en curso: las transiciones de fase (build terminado → verificacion lanzada → qa rechaza → fast-fail → rebote → dev → cross-phase rebote a ux → ...) pasan de ~8-10 min de latencia por ciclo a **~30s**.

## Post-merge

Pulpo requiere restart para tomar el fix (los brazos viven en el proceso long-running).

## Test plan

- [x] Syntax OK con `node --check`.
- [x] Tests existentes (`test-cross-phase-rebote.js`) siguen pasando 14/14.
- [ ] Post-merge + restart pulpo: observar log del `brazoDesbloqueo` con `allowlist=[2505]`. Debería imprimir `partial_pause: ninguno de los N issues bloqueados está en el allowlist — skip ciclo` y retornar en <1s.
- [ ] Observar transiciones de fase del #2505 mucho más rápidas.

qa:skipped — optimización del pipeline V3. Sin impacto en producto.

## Fuera de alcance

- Tests unitarios con mocks del pipelineMode — los helpers filtrables están ya cubiertos por `partial-pause.test.js` del PR #2490. Este fix es composición de primitivas existentes.
- Reducir el `UNBLOCK_INTERVAL_MS = 30 min` para que brazoDesbloqueo corra más frecuente — decisión aparte.
- Implementar que `gh issue list --search "<numeros>"` traiga solo issues del allowlist desde GitHub (más eficiente aún, pero requiere construir la query correctamente — dejado como optimización futura).

🤖 Generated with [Claude Code](https://claude.com/claude-code)