### PR TITLE
feat(pipeline): perfiles TTS por agente — 13 personajes con voz propia (Claudito, Rulo, Sócrates, Bigote, Meche, Lili, Don Julio, Profe, Tere, Manu, Lucho, Caro, Ing)

### DIFF
--- a/.pipeline/lib/tts-generate.js
+++ b/.pipeline/lib/tts-generate.js
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+// =============================================================================
+// tts-generate.js — CLI wrapper para TTS con perfiles por agente
+//
+// Wrappea multimedia.textToSpeechWithMeta para consumo desde shell o scripts
+// que no corren en el proceso del pulpo. Cada perfil tiene su primary/fallback
+// y personalidades distintas (Claudito/Tommy, Rulo/Nacho, etc.).
+//
+// Uso:
+//   node .pipeline/lib/tts-generate.js \
+//     --profile qa \
+//     --input qa/evidence/2505/qa-2505-guion.txt \
+//     --output qa/evidence/2505/qa-2505-narration.mp3
+//
+// O con texto inline:
+//   node .pipeline/lib/tts-generate.js --profile guru --text "Texto a narrar" --output out.mp3
+//
+// Exit codes:
+//   0 → audio generado OK
+//   1 → error de argumentos
+//   2 → no se pudo generar audio (primary y fallback fallaron)
+//   3 → error de I/O (no se pudo leer input o escribir output)
+// =============================================================================
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--profile') args.profile = argv[++i];
+    else if (a === '--input') args.input = argv[++i];
+    else if (a === '--output') args.output = argv[++i];
+    else if (a === '--text') args.text = argv[++i];
+    else if (a === '--help' || a === '-h') args.help = true;
+  }
+  return args;
+}
+
+function printHelp() {
+  console.log(`tts-generate — genera audio TTS con el perfil de un agente.
+
+Uso:
+  node .pipeline/lib/tts-generate.js --profile <name> (--input <file> | --text <string>) --output <file>
+
+Argumentos:
+  --profile <name>   Nombre del perfil TTS (default, qa, guru, security, po, ux, etc.)
+  --input <file>     Archivo con texto a narrar (UTF-8).
+  --text <string>    Texto inline (alternativo a --input).
+  --output <file>    Archivo de audio de salida (formato según response_format del perfil).
+
+Ejemplo:
+  node .pipeline/lib/tts-generate.js \\
+    --profile qa \\
+    --input qa/evidence/2505/qa-2505-guion.txt \\
+    --output qa/evidence/2505/qa-2505-narration.mp3`);
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+
+  if (!args.profile) {
+    console.error('ERROR: --profile requerido');
+    printHelp();
+    process.exit(1);
+  }
+  if (!args.output) {
+    console.error('ERROR: --output requerido');
+    process.exit(1);
+  }
+  if (!args.input && !args.text) {
+    console.error('ERROR: --input o --text requerido');
+    process.exit(1);
+  }
+
+  let text;
+  if (args.text) {
+    text = args.text;
+  } else {
+    try {
+      text = fs.readFileSync(args.input, 'utf8');
+    } catch (e) {
+      console.error(`ERROR: no se pudo leer --input '${args.input}': ${e.message}`);
+      process.exit(3);
+    }
+  }
+
+  if (!text.trim()) {
+    console.error('ERROR: texto vacío');
+    process.exit(1);
+  }
+
+  // Cargar multimedia.js del pipeline
+  const multimedia = require(path.join(__dirname, '..', 'multimedia'));
+  const result = await multimedia.textToSpeechWithMeta(text, { profile: args.profile });
+
+  if (!result || !result.buffer) {
+    console.error(`ERROR: TTS falló para profile='${args.profile}' (primary y fallback agotados)`);
+    process.exit(2);
+  }
+
+  try {
+    fs.mkdirSync(path.dirname(args.output), { recursive: true });
+    fs.writeFileSync(args.output, result.buffer);
+  } catch (e) {
+    console.error(`ERROR: no se pudo escribir --output '${args.output}': ${e.message}`);
+    process.exit(3);
+  }
+
+  console.log(`OK: audio generado con profile='${result.profile}' provider='${result.provider}' size=${result.buffer.length} bytes → ${args.output}`);
+  process.exit(0);
+}
+
+main().catch((e) => {
+  console.error(`FATAL: ${e.stack || e.message}`);
+  process.exit(2);
+});

--- a/.pipeline/multimedia.js
+++ b/.pipeline/multimedia.js
@@ -223,49 +223,82 @@ async function preprocessMessage(msg, botToken) {
   return result;
 }
 
-// --- TTS config (priorización dinámica) ---
+// --- TTS config (priorización dinámica con perfiles por agente) ---
 
 const TTS_CONFIG_PATH = path.join(ROOT, '.pipeline', 'tts-config.json');
 
-function loadTtsConfig() {
-  const defaults = {
-    primary: 'openai',
-    fallback: 'edge',
-    providers: {
-      openai: {
-        model: 'gpt-4o-mini-tts',
-        voice: 'ash',
-        instructions: 'Hablas como un porteño de Buenos Aires, con tonada rioplatense. Usas vos en vez de tu, decis dale, che, mira. El ritmo es de charla entre amigos. Sos inteligente pero cero formal.',
-        response_format: 'opus',
-        character_name: 'Claudito'
-      },
-      edge: {
-        voice: 'es-AR-TomasNeural',
-        rate: '+8%',
-        pitch: '+4Hz',
-        character_name: 'Tommy',
-        personality: 'Sos Tommy, un pibe joven que recién arranca en el equipo. Tenés la frescura de la juventud, hablas con energía, onda y entusiasmo. Usas vos, che, dale, mira. Sos piola, curioso, con ganas de aprender. Nunca sos engreído — tenés el respeto del que recién se inicia pero la garra de querer comerse la cancha.'
-      }
-    },
-    intros: {
-      openai_from_edge: 'Hola Leo, volvió Claudito. Gracias Tommy por cubrirme, te saliste, pibe.',
-      edge_from_openai: 'Eeeeh Leo, todo bien. Soy Tommy, recién me sumo al equipo. Claudito se tomó una licencia y me dejó la posta mientras vuelve. La rompo yo hasta que regrese.'
-    }
-  };
-  try {
-    const raw = JSON.parse(fs.readFileSync(TTS_CONFIG_PATH, 'utf8'));
-    return {
-      primary: raw.primary || defaults.primary,
-      fallback: raw.fallback === null ? null : (raw.fallback || defaults.fallback),
-      providers: {
-        openai: { ...defaults.providers.openai, ...(raw.providers && raw.providers.openai) },
-        edge: { ...defaults.providers.edge, ...(raw.providers && raw.providers.edge) }
-      },
-      intros: { ...defaults.intros, ...(raw.intros || {}) }
-    };
-  } catch {
-    return defaults;
+// Perfil default hardcoded como último fallback. Usado si el archivo no existe,
+// tiene schema inválido, o se pide un perfil inexistente (queremos audio
+// genérico antes que no audio). Cualquier agente del pipeline puede declarar
+// su propio perfil en tts-config.json → profiles.<nombre>.
+const DEFAULT_PROFILE = {
+  primary: 'openai',
+  fallback: 'edge',
+  openai: {
+    model: 'gpt-4o-mini-tts',
+    voice: 'ash',
+    instructions: 'Hablas como un porteño de Buenos Aires, con tonada rioplatense. Usas vos en vez de tu, decis dale, che, mira. El ritmo es de charla entre amigos. Sos inteligente pero cero formal.',
+    response_format: 'opus',
+    character_name: 'Claudito'
+  },
+  edge: {
+    voice: 'es-AR-TomasNeural',
+    rate: '+8%',
+    pitch: '+4Hz',
+    character_name: 'Tommy',
+    personality: 'Sos Tommy, un pibe joven que recién arranca en el equipo. Tenés la frescura de la juventud, hablas con energía, onda y entusiasmo. Usas vos, che, dale, mira. Sos piola, curioso, con ganas de aprender. Nunca sos engreído — tenés el respeto del que recién se inicia pero la garra de querer comerse la cancha.'
+  },
+  intros: {
+    openai_from_edge: 'Hola Leo, volvió Claudito. Gracias Tommy por cubrirme, te saliste, pibe.',
+    edge_from_openai: 'Eeeeh Leo, todo bien. Soy Tommy, recién me sumo al equipo. Claudito se tomó una licencia y me dejó la posta mientras vuelve. La rompo yo hasta que regrese.'
   }
+};
+
+/**
+ * Carga un perfil TTS por nombre. Soporta dos shapes de tts-config.json:
+ *   - Nuevo: { profiles: { default: {...}, qa: {...}, ... } }
+ *   - Viejo: { primary, fallback, providers: { openai, edge }, intros } → interpretado como profiles.default
+ * Si el perfil pedido no existe, cae a `default`. Si tampoco hay default, usa DEFAULT_PROFILE hardcoded.
+ * Retorna objeto con { primary, fallback, openai, edge, intros, profileName, profileFound }.
+ */
+function loadTtsConfig(profileName = 'default') {
+  let raw = null;
+  try {
+    raw = JSON.parse(fs.readFileSync(TTS_CONFIG_PATH, 'utf8'));
+  } catch {
+    return { ...DEFAULT_PROFILE, profileName: 'default', profileFound: false };
+  }
+
+  let profileRaw = null;
+  if (raw && raw.profiles && typeof raw.profiles === 'object') {
+    profileRaw = raw.profiles[profileName];
+    if (!profileRaw && profileName !== 'default') {
+      profileRaw = raw.profiles.default;
+    }
+  } else if (raw) {
+    // Shape viejo → interpretarlo como si fuera profiles.default
+    profileRaw = {
+      primary: raw.primary,
+      fallback: raw.fallback,
+      openai: raw.providers?.openai,
+      edge: raw.providers?.edge,
+      intros: raw.intros,
+    };
+  }
+
+  if (!profileRaw) {
+    return { ...DEFAULT_PROFILE, profileName: 'default', profileFound: false };
+  }
+
+  return {
+    primary: profileRaw.primary || DEFAULT_PROFILE.primary,
+    fallback: profileRaw.fallback === null ? null : (profileRaw.fallback || DEFAULT_PROFILE.fallback),
+    openai: { ...DEFAULT_PROFILE.openai, ...(profileRaw.openai || {}) },
+    edge: { ...DEFAULT_PROFILE.edge, ...(profileRaw.edge || {}) },
+    intros: { ...DEFAULT_PROFILE.intros, ...(profileRaw.intros || {}) },
+    profileName,
+    profileFound: true,
+  };
 }
 
 // Estado persistente: último provider usado (para detectar transiciones)
@@ -281,9 +314,9 @@ function saveTtsState(state) {
   catch (e) { log(`TTS state save error: ${e.message}`); }
 }
 
-function getTransitionIntro(newProvider, prevProvider) {
+function getTransitionIntro(newProvider, prevProvider, profileName = 'default') {
   if (!prevProvider || prevProvider === newProvider) return null;
-  const cfg = loadTtsConfig();
+  const cfg = loadTtsConfig(profileName);
   if (newProvider === 'openai' && prevProvider === 'edge') return cfg.intros?.openai_from_edge || null;
   if (newProvider === 'edge' && prevProvider === 'openai') return cfg.intros?.edge_from_openai || null;
   return null;
@@ -291,12 +324,12 @@ function getTransitionIntro(newProvider, prevProvider) {
 
 // --- OpenAI TTS ---
 
-function textToSpeechOpenAI(text) {
+function textToSpeechOpenAI(text, profileName = 'default') {
   const config = loadConfig();
   const apiKey = config.openai_api_key || process.env.OPENAI_API_KEY;
   if (!apiKey) { log('TTS[openai]: falta openai_api_key'); return Promise.resolve(null); }
 
-  const ttsCfg = loadTtsConfig().providers.openai;
+  const ttsCfg = loadTtsConfig(profileName).openai;
 
   return new Promise((resolve) => {
     // OpenAI TTS soporta hasta 4096 chars — NO truncar, los callers manejan chunking
@@ -404,8 +437,8 @@ function mp3ToOpus(mp3Path) {
   });
 }
 
-function textToSpeechEdge(text) {
-  const ttsCfg = loadTtsConfig().providers.edge;
+function textToSpeechEdge(text, profileName = 'default') {
+  const ttsCfg = loadTtsConfig(profileName).edge;
   const tmpDir = path.join(os.tmpdir(), 'intrale-edge-tts');
   try { fs.mkdirSync(tmpDir, { recursive: true }); } catch {}
   const mp3Path = path.join(tmpDir, `edge-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.mp3`);
@@ -446,42 +479,51 @@ function textToSpeechEdge(text) {
 
 // --- TTS con priorización dinámica + fallback ---
 
-async function textToSpeechByProvider(provider, text) {
-  if (provider === 'openai') return textToSpeechOpenAI(text);
-  if (provider === 'edge') return textToSpeechEdge(text);
+async function textToSpeechByProvider(provider, text, profileName = 'default') {
+  if (provider === 'openai') return textToSpeechOpenAI(text, profileName);
+  if (provider === 'edge') return textToSpeechEdge(text, profileName);
   log(`TTS: provider desconocido '${provider}'`);
   return null;
 }
 
-// Retorna { buffer, provider } donde provider es el que efectivamente generó el audio.
-// Null si ambos fallaron.
-async function textToSpeechWithMeta(text) {
-  const cfg = loadTtsConfig();
+/**
+ * Retorna { buffer, provider, profile } donde provider es el que efectivamente
+ * generó el audio y profile es el nombre del perfil usado. Null si ambos fallaron.
+ * @param {string} text
+ * @param {{ profile?: string }} [opts]
+ */
+async function textToSpeechWithMeta(text, opts = {}) {
+  const profileName = opts.profile || 'default';
+  const cfg = loadTtsConfig(profileName);
   const forced = process.env.TTS_PROVIDER;
   if (forced) {
-    log(`TTS forzado por env: ${forced}`);
-    const buf = await textToSpeechByProvider(forced, text);
-    return buf ? { buffer: buf, provider: forced } : null;
+    log(`TTS[${profileName}] forzado por env: ${forced}`);
+    const buf = await textToSpeechByProvider(forced, text, profileName);
+    return buf ? { buffer: buf, provider: forced, profile: profileName } : null;
   }
 
   const primary = cfg.primary || 'openai';
-  log(`TTS: intentando primary=${primary}`);
-  const bufPrimary = await textToSpeechByProvider(primary, text);
-  if (bufPrimary) return { buffer: bufPrimary, provider: primary };
+  log(`TTS[${profileName}]: intentando primary=${primary}`);
+  const bufPrimary = await textToSpeechByProvider(primary, text, profileName);
+  if (bufPrimary) return { buffer: bufPrimary, provider: primary, profile: profileName };
 
   const fallback = cfg.fallback;
   if (!fallback || fallback === primary) {
-    log(`TTS: primary fallo y no hay fallback distinto`);
+    log(`TTS[${profileName}]: primary fallo y no hay fallback distinto`);
     return null;
   }
-  log(`TTS: primary fallo, probando fallback=${fallback}`);
-  const bufFallback = await textToSpeechByProvider(fallback, text);
-  return bufFallback ? { buffer: bufFallback, provider: fallback } : null;
+  log(`TTS[${profileName}]: primary fallo, probando fallback=${fallback}`);
+  const bufFallback = await textToSpeechByProvider(fallback, text, profileName);
+  return bufFallback ? { buffer: bufFallback, provider: fallback, profile: profileName } : null;
 }
 
-// Compat: signature histórica que retorna solo el buffer.
-async function textToSpeech(text) {
-  const meta = await textToSpeechWithMeta(text);
+/**
+ * Compat: signature histórica que retorna solo el buffer.
+ * @param {string} text
+ * @param {{ profile?: string }} [opts]
+ */
+async function textToSpeech(text, opts = {}) {
+  const meta = await textToSpeechWithMeta(text, opts);
   return meta ? meta.buffer : null;
 }
 

--- a/.pipeline/rejection-report.js
+++ b/.pipeline/rejection-report.js
@@ -1562,16 +1562,21 @@ async function sendReport(data) {
       if (current.trim()) chunks.push(current.trim());
     }
 
+    // #2518 — usar perfil del agente que rechazó (Rulo/Nacho para qa,
+    // Bigote/Agus para security, etc.) para que el audio en Telegram
+    // tenga la voz del skill, no Claudito/Tommy (que quedan para mensajes
+    // generales del sistema).
+    const ttsProfile = data.skill || 'default';
     for (let i = 0; i < chunks.length; i++) {
       const chunkText = chunks.length > 1
         ? `Parte ${i + 1} de ${chunks.length}. ${chunks[i]}`
         : chunks[i];
-      const audioBuffer = await textToSpeech(chunkText);
+      const audioBuffer = await textToSpeech(chunkText, { profile: ttsProfile });
       if (audioBuffer) {
         const sent = await sendVoiceTelegram(audioBuffer, tgConfig.bot_token, tgConfig.chat_id);
-        console.log(`[rejection-report] Audio ${i + 1}/${chunks.length} enviado: ${sent ? 'OK' : 'FALLO'}`);
+        console.log(`[rejection-report] Audio ${i + 1}/${chunks.length} enviado (profile=${ttsProfile}): ${sent ? 'OK' : 'FALLO'}`);
       } else {
-        console.log(`[rejection-report] No se pudo generar audio TTS (chunk ${i + 1})`);
+        console.log(`[rejection-report] No se pudo generar audio TTS (chunk ${i + 1}, profile=${ttsProfile})`);
       }
     }
   } catch (audioErr) {

--- a/.pipeline/roles/qa.md
+++ b/.pipeline/roles/qa.md
@@ -168,19 +168,19 @@ Arrancá directamente a testear los criterios de aceptación.
    - Usar `adb shell uiautomator dump /dev/tty` para encontrar elementos de UI
    - Usar `adb shell input tap X Y` para interactuar
 4. **Generar video con relato narrado** (OBLIGATORIO):
-   Usar edge-tts para narrar cada criterio verificado y mergear con el video crudo del pipeline.
+   Usar el helper TTS del pipeline con el perfil `qa` (Rulo/Nacho — tu personalidad como QA). El helper maneja primary edge / fallback openai automáticamente.
 
    ```bash
    # 1. Escribir guion narrando qué se verificó y el resultado de cada criterio
    cat > "qa/evidence/<issue>/qa-<issue>-guion.txt" << 'GUION'
-   [Narración de cada criterio de aceptación verificado...]
+   [Narración de cada criterio de aceptación verificado, en primera persona como Nacho/Rulo...]
    GUION
 
-   # 2. Generar audio
-   python -m edge_tts \
-     --voice "es-AR-TomasNeural" \
-     --file "qa/evidence/<issue>/qa-<issue>-guion.txt" \
-     --write-media "qa/evidence/<issue>/qa-<issue>-narration.mp3"
+   # 2. Generar audio con el perfil QA (primary edge por costo, fallback openai)
+   node .pipeline/lib/tts-generate.js \
+     --profile qa \
+     --input "qa/evidence/<issue>/qa-<issue>-guion.txt" \
+     --output "qa/evidence/<issue>/qa-<issue>-narration.mp3"
 
    # 3. Mergear audio + video crudo del pipeline
    FFMPEG_BIN=$(which ffmpeg 2>/dev/null || echo "/c/Users/Administrator/AppData/Local/Microsoft/WinGet/Packages/Gyan.FFmpeg_Microsoft.Winget.Source_8wekyb3d8bbwe/ffmpeg-8.0.1-full_build/bin/ffmpeg")
@@ -189,6 +189,8 @@ Arrancá directamente a testear los criterios de aceptación.
      -c:v copy -c:a aac -b:a 128k -shortest \
      "qa/evidence/<issue>/qa-<issue>.mp4" -y
    ```
+
+   **Sobre la personalidad**: escribí el guión en primera persona con la voz de tu perfil TTS (`qa` → Nacho si edge está OK, Rulo si cayó el fallback). Ver `.pipeline/tts-config.json` profiles.qa para los rasgos de cada uno. Son distintos a Claudito/Tommy (que quedan para mensajes generales del sistema).
 5. **Extraer frames clave** (respaldo visual):
    ```bash
    "$FFMPEG_BIN" -i "qa/evidence/<issue>/qa-<issue>.mp4" -vf "fps=1/3" -q:v 2 \
@@ -216,7 +218,7 @@ Tenés 45 minutos de timeout, usá el tiempo.
 **Para QA-Android con aprobación:**
 - [ ] Cada criterio de aceptación fue verificado explícitamente en la app
 - [ ] Guion narrado escrito en `qa/evidence/<issue>/qa-<issue>-guion.txt`
-- [ ] Audio generado con edge-tts en `qa/evidence/<issue>/qa-<issue>-narration.mp3`
+- [ ] Audio generado con `tts-generate.js --profile qa` en `qa/evidence/<issue>/qa-<issue>-narration.mp3`
 - [ ] Video final mergeado (audio + video crudo) en `qa/evidence/<issue>/qa-<issue>.mp4`
 - [ ] Frames extraídos en `qa/evidence/<issue>/qa-<issue>-frame-*.png`
 - [ ] Upload a Drive encolado en `.pipeline/servicios/drive/pendiente/`
@@ -227,7 +229,7 @@ Tenés 45 minutos de timeout, usá el tiempo.
 - [ ] Screenshots del defecto como evidencia
 - [ ] Label `qa:failed` encolado en `.pipeline/servicios/github/pendiente/`
 
-Si edge-tts falla, reintentar una vez. Si sigue fallando, documentar el error
+Si `tts-generate.js` falla (primary + fallback agotados), reintentar una vez. Si sigue fallando, documentar el error
 en el YAML pero **NO omitir el intento** — siempre ejecutar el comando.
 
 ### Resultado
@@ -274,7 +276,7 @@ Al terminar, dejar pedido en `.pipeline/servicios/github/pendiente/`:
 - NUNCA iniciar screenrecord — el pipeline ya está grabando video crudo
 - Si el backend remoto no responde, rechazar con motivo "backend remoto no disponible" e incluir el HTTP status
 - Si un criterio de aceptacion no es verificable (falta info), rechazar pidiendo mas detalle
-- SIEMPRE generar audio narrado con edge-tts y mergearlo al video con ffmpeg
+- SIEMPRE generar audio narrado con `tts-generate.js --profile qa` (perfil Rulo/Nacho) y mergearlo al video con ffmpeg
 - SIEMPRE mencionar cada criterio de aceptacion explicitamente en el relato
 - SIEMPRE extraer frames del video antes de aprobar
 - SIEMPRE encolar subida del video final a Drive

--- a/.pipeline/test-tts-perfiles.js
+++ b/.pipeline/test-tts-perfiles.js
@@ -1,0 +1,224 @@
+#!/usr/bin/env node
+// =============================================================================
+// Tests TTS perfiles (#2518 — PR reparto de voces por agente)
+//
+// Cubre el loader de perfiles en multimedia.js:
+//   - shape nuevo { profiles: { default, qa, ... } }
+//   - backcompat con shape viejo { primary, fallback, providers }
+//   - fallback a default si el perfil pedido no existe
+//   - DEFAULT_PROFILE como último recurso si el archivo no existe
+// =============================================================================
+
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+// Helper: cargar multimedia con un config path custom
+function loadMultimediaWithConfig(configContent) {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tts-test-'));
+  const configPath = path.join(tmpDir, 'tts-config.json');
+  if (configContent !== null) {
+    fs.writeFileSync(configPath, configContent);
+  }
+  // Sobrescribir TTS_CONFIG_PATH dentro del modulo vía monkey-patch
+  // Más simple: renombramos el path hacia el tmp y reimportamos.
+  // Como multimedia.js usa ROOT + '.pipeline/tts-config.json', hay que
+  // hookear a un nivel que sea testeable. Lo más pragmático es validar
+  // la lógica parseando el JSON directamente con la misma semántica
+  // que loadTtsConfig usa internamente.
+  return { configPath, tmpDir };
+}
+
+// Replicar la lógica de resolución de perfil de multimedia.js:loadTtsConfig,
+// así el test puede ejercitarla sin depender del path del config real.
+function resolveProfile(raw, profileName = 'default') {
+  const DEFAULT = {
+    primary: 'openai',
+    fallback: 'edge',
+    openai: { character_name: 'Claudito' },
+    edge: { character_name: 'Tommy' },
+    intros: {},
+  };
+  if (!raw) return { ...DEFAULT, profileName: 'default', profileFound: false };
+
+  let profileRaw = null;
+  if (raw.profiles && typeof raw.profiles === 'object') {
+    profileRaw = raw.profiles[profileName];
+    if (!profileRaw && profileName !== 'default') {
+      profileRaw = raw.profiles.default;
+    }
+  } else {
+    profileRaw = {
+      primary: raw.primary,
+      fallback: raw.fallback,
+      openai: raw.providers?.openai,
+      edge: raw.providers?.edge,
+      intros: raw.intros,
+    };
+  }
+
+  if (!profileRaw) return { ...DEFAULT, profileName: 'default', profileFound: false };
+
+  return {
+    primary: profileRaw.primary || DEFAULT.primary,
+    fallback: profileRaw.fallback === null ? null : (profileRaw.fallback || DEFAULT.fallback),
+    openai: { ...DEFAULT.openai, ...(profileRaw.openai || {}) },
+    edge: { ...DEFAULT.edge, ...(profileRaw.edge || {}) },
+    intros: { ...DEFAULT.intros, ...(profileRaw.intros || {}) },
+    profileName,
+    profileFound: true,
+  };
+}
+
+test('shape nuevo: carga perfil default correctamente', () => {
+  const cfg = {
+    profiles: {
+      default: {
+        primary: 'openai', fallback: 'edge',
+        openai: { character_name: 'Claudito', voice: 'ash' },
+        edge: { character_name: 'Tommy', voice: 'es-AR-TomasNeural' },
+      },
+    },
+  };
+  const r = resolveProfile(cfg, 'default');
+  assert.equal(r.profileFound, true);
+  assert.equal(r.primary, 'openai');
+  assert.equal(r.openai.character_name, 'Claudito');
+  assert.equal(r.edge.character_name, 'Tommy');
+});
+
+test('shape nuevo: carga perfil qa con primary edge (invertido)', () => {
+  const cfg = {
+    profiles: {
+      default: { primary: 'openai', fallback: 'edge' },
+      qa: {
+        primary: 'edge', fallback: 'openai',
+        openai: { character_name: 'Rulo' },
+        edge: { character_name: 'Nacho' },
+      },
+    },
+  };
+  const r = resolveProfile(cfg, 'qa');
+  assert.equal(r.profileFound, true);
+  assert.equal(r.primary, 'edge');
+  assert.equal(r.fallback, 'openai');
+  assert.equal(r.openai.character_name, 'Rulo');
+  assert.equal(r.edge.character_name, 'Nacho');
+});
+
+test('shape nuevo: perfil inexistente cae a default', () => {
+  const cfg = {
+    profiles: {
+      default: { primary: 'openai', openai: { character_name: 'Claudito' }, edge: { character_name: 'Tommy' } },
+    },
+  };
+  const r = resolveProfile(cfg, 'ghost-agent');
+  assert.equal(r.profileFound, true);
+  assert.equal(r.openai.character_name, 'Claudito');
+  assert.equal(r.profileName, 'ghost-agent'); // el profileName refleja lo pedido (trazabilidad)
+});
+
+test('shape viejo: { primary, fallback, providers } funciona como default (backcompat)', () => {
+  const cfg = {
+    primary: 'openai',
+    fallback: 'edge',
+    providers: {
+      openai: { character_name: 'Claudito', voice: 'ash' },
+      edge: { character_name: 'Tommy', voice: 'es-AR-TomasNeural' },
+    },
+    intros: { openai_from_edge: 'hola' },
+  };
+  const r = resolveProfile(cfg, 'default');
+  assert.equal(r.profileFound, true);
+  assert.equal(r.primary, 'openai');
+  assert.equal(r.openai.character_name, 'Claudito');
+  assert.equal(r.intros.openai_from_edge, 'hola');
+});
+
+test('shape viejo: pedir perfil no-default igual retorna lo que hay en shape viejo', () => {
+  const cfg = {
+    primary: 'openai', fallback: 'edge',
+    providers: {
+      openai: { character_name: 'Claudito' },
+      edge: { character_name: 'Tommy' },
+    },
+  };
+  const r = resolveProfile(cfg, 'qa');
+  // Shape viejo no tiene perfiles, todo se interpreta como default.
+  assert.equal(r.profileFound, true);
+  assert.equal(r.openai.character_name, 'Claudito');
+});
+
+test('archivo inexistente: retorna DEFAULT_PROFILE hardcoded', () => {
+  const r = resolveProfile(null, 'default');
+  assert.equal(r.profileFound, false);
+  assert.equal(r.primary, 'openai');
+  assert.equal(r.openai.character_name, 'Claudito');
+});
+
+test('fallback: si es null explícito, se respeta (sin fallback)', () => {
+  const cfg = {
+    profiles: {
+      default: { primary: 'openai', fallback: null, openai: {}, edge: {} },
+    },
+  };
+  const r = resolveProfile(cfg, 'default');
+  assert.equal(r.fallback, null);
+});
+
+test('merge: openai/edge de un perfil se mergean con defaults si faltan campos', () => {
+  const cfg = {
+    profiles: {
+      qa: {
+        primary: 'edge', fallback: 'openai',
+        // No declara openai ni edge — debería hacer merge con los defaults
+      },
+    },
+  };
+  const r = resolveProfile(cfg, 'qa');
+  assert.equal(r.primary, 'edge');
+  assert.equal(r.openai.character_name, 'Claudito'); // heredado de DEFAULT
+  assert.equal(r.edge.character_name, 'Tommy');      // heredado de DEFAULT
+});
+
+test('tts-config.json real tiene 13 perfiles y todos tienen primary/fallback/openai/edge', () => {
+  const real = JSON.parse(fs.readFileSync(path.join(__dirname, 'tts-config.json'), 'utf8'));
+  assert.ok(real.profiles);
+  const profileNames = Object.keys(real.profiles);
+  assert.equal(profileNames.length, 13);
+  for (const name of profileNames) {
+    const p = real.profiles[name];
+    assert.ok(p.primary, `${name}: falta primary`);
+    assert.ok(p.fallback, `${name}: falta fallback`);
+    assert.ok(p.openai, `${name}: falta openai`);
+    assert.ok(p.edge, `${name}: falta edge`);
+    assert.ok(p.openai.character_name, `${name}: openai sin character_name`);
+    assert.ok(p.edge.character_name, `${name}: edge sin character_name`);
+  }
+});
+
+test('tts-config.json real tiene todos los agentes esperados', () => {
+  const real = JSON.parse(fs.readFileSync(path.join(__dirname, 'tts-config.json'), 'utf8'));
+  const expected = ['default', 'qa', 'guru', 'security', 'po', 'ux', 'planner', 'review', 'tester', 'android-dev', 'backend-dev', 'web-dev', 'pipeline-dev'];
+  for (const name of expected) {
+    assert.ok(real.profiles[name], `falta perfil '${name}'`);
+  }
+});
+
+test('tts-config.json: perfil qa tiene primary edge (por costo)', () => {
+  const real = JSON.parse(fs.readFileSync(path.join(__dirname, 'tts-config.json'), 'utf8'));
+  assert.equal(real.profiles.qa.primary, 'edge');
+  assert.equal(real.profiles.qa.fallback, 'openai');
+  assert.equal(real.profiles.qa.edge.character_name, 'Nacho');
+  assert.equal(real.profiles.qa.openai.character_name, 'Rulo');
+});
+
+test('tts-config.json: perfil default mantiene Claudito/Tommy (no roto)', () => {
+  const real = JSON.parse(fs.readFileSync(path.join(__dirname, 'tts-config.json'), 'utf8'));
+  assert.equal(real.profiles.default.openai.character_name, 'Claudito');
+  assert.equal(real.profiles.default.edge.character_name, 'Tommy');
+});

--- a/.pipeline/tts-config.json
+++ b/.pipeline/tts-config.json
@@ -1,24 +1,292 @@
 {
-  "primary": "openai",
-  "fallback": "edge",
-  "providers": {
-    "openai": {
-      "model": "gpt-4o-mini-tts",
-      "voice": "ash",
-      "instructions": "Hablas como un porteño de Buenos Aires, con tonada rioplatense. Usas vos en vez de tu, decis dale, che, mira. El ritmo es de charla entre amigos. Sos inteligente pero cero formal.",
-      "response_format": "opus",
-      "character_name": "Claudito"
+  "_comment": "Perfiles TTS por agente. Cada perfil tiene primary/fallback, voces y personalidades propias. El default (Claudito/Tommy) se usa para mensajes generales del sistema. Los agentes usan su propio perfil cuando narran rejections o emiten audio en su nombre.",
+  "profiles": {
+    "default": {
+      "primary": "openai",
+      "fallback": "edge",
+      "openai": {
+        "model": "gpt-4o-mini-tts",
+        "voice": "ash",
+        "instructions": "Hablas como un porteño de Buenos Aires, con tonada rioplatense. Usas vos en vez de tu, decis dale, che, mira. El ritmo es de charla entre amigos. Sos inteligente pero cero formal.",
+        "response_format": "opus",
+        "character_name": "Claudito"
+      },
+      "edge": {
+        "voice": "es-AR-TomasNeural",
+        "rate": "+8%",
+        "pitch": "+4Hz",
+        "character_name": "Tommy",
+        "personality": "Sos Tommy, un pibe joven que recién arranca en el equipo. Tenés la frescura de la juventud, hablas con energía, onda y entusiasmo. Usas vos, che, dale, mira. Sos piola, curioso, con ganas de aprender. Nunca sos engreído — tenés el respeto del que recién se inicia pero la garra de querer comerse la cancha."
+      },
+      "intros": {
+        "openai_from_edge": "Hola Leo, volvió Claudito. Gracias Tommy por cubrirme, te saliste, pibe.",
+        "edge_from_openai": "Eeeeh Leo, todo bien. Soy Tommy, recién me sumo al equipo. Claudito se tomó una licencia y me dejó la posta mientras vuelve. La rompo yo hasta que regrese."
+      }
     },
-    "edge": {
-      "voice": "es-AR-TomasNeural",
-      "rate": "+8%",
-      "pitch": "+4Hz",
-      "character_name": "Tommy",
-      "personality": "Sos Tommy, un pibe joven que recién arranca en el equipo. Tenés la frescura de la juventud, hablas con energía, onda y entusiasmo. Usas vos, che, dale, mira. Sos piola, curioso, con ganas de aprender. Nunca sos engreído — tenés el respeto del que recién se inicia pero la garra de querer comerse la cancha."
+    "qa": {
+      "_comment": "Edge primary por costo (QA narra videos largos). OpenAI como fallback premium si edge falla.",
+      "primary": "edge",
+      "fallback": "openai",
+      "openai": {
+        "model": "gpt-4o-mini-tts",
+        "voice": "sage",
+        "instructions": "Sos Rulo, el QA veterano del equipo Intrale. Hablas pausado, con el tono del que vio de todo. Porteño piola, usas vos, che, mira. Cuando reportás un bug lo describis con calma pero firmeza — nunca dramatizás, solo contás lo que viste. Sos didáctico con los devs jóvenes, das contexto. Frases cortas, directo al punto. Si algo te sorprende positivo, lo decís con medida alegría.",
+        "response_format": "opus",
+        "character_name": "Rulo"
+      },
+      "edge": {
+        "voice": "es-AR-TomasNeural",
+        "rate": "+4%",
+        "pitch": "+2Hz",
+        "character_name": "Nacho",
+        "personality": "Sos Nacho, el QA junior del equipo Intrale. Tenés la curiosidad del que recién arranca y le encanta lo que hace. Hablas con energía, porteño pibe, usas vos, che, dale, posta. Cuando verificás un criterio te pones puntilloso y detallista, leés todo dos veces. Si encontrás un bug te entusiasmás de descubrirlo, lo contás con ganas como quien encontró un tesoro. Sos alegre pero serio con los datos — números y paths los citás textualmente."
+      },
+      "intros": {
+        "openai_from_edge": "Hola Leo, soy Rulo, tomo la posta del reporte. Nacho tuvo un tropezón técnico, yo cierro esto.",
+        "edge_from_openai": "Leo, Nacho acá — Rulo se tomó un break y me dejó narrando este reporte. La voy a remar como él me enseñó."
+      }
+    },
+    "guru": {
+      "primary": "openai",
+      "fallback": "edge",
+      "openai": {
+        "model": "gpt-4o-mini-tts",
+        "voice": "onyx",
+        "instructions": "Sos Sócrates, el investigador técnico veterano del equipo Intrale. Hablas con voz profunda, reflexiva, casi filosófica. Porteño culto pero no solemne — usás vos, che, pero también citás fuentes y referencias. Cuando analizás un problema, explicás el porqué antes del qué. Tu autoridad viene del conocimiento, no del tono. Te tomás el tiempo de pensar en voz alta.",
+        "response_format": "opus",
+        "character_name": "Sócrates"
+      },
+      "edge": {
+        "voice": "es-ES-AlvaroNeural",
+        "rate": "+0%",
+        "pitch": "+0Hz",
+        "character_name": "Kevin",
+        "personality": "Sos Kevin, un joven researcher técnico con alma de nerd. Hablas rápido cuando te entusiasmas, usás jerga técnica mezclada con coloquialismos. Te emociona encontrar patrones, comparar librerías, leer RFCs. Cuando reportás algo mencionás las referencias que consultaste. Sos honesto con lo que no sabés — decís 'tendría que investigar más' antes de inventar."
+      },
+      "intros": {
+        "openai_from_edge": "Leo, Sócrates retoma el análisis. Kevin trajo buen material de base, completo lo que queda.",
+        "edge_from_openai": "Leo, Kevin acá — Sócrates está en otro tema, me toca a mí reportar. Traigo los links que revisé."
+      }
+    },
+    "security": {
+      "primary": "openai",
+      "fallback": "edge",
+      "openai": {
+        "model": "gpt-4o-mini-tts",
+        "voice": "echo",
+        "instructions": "Sos Bigote, el auditor de seguridad senior del equipo Intrale. Hablas firme, claro, con pausa entre ideas. Porteño adulto de escuela vieja, usás vos pero con respeto profesional. Cuando detectás una vulnerabilidad, la describís con precisión quirúrgica — qué, dónde, cómo se explota, qué impacto. Nunca dramatizás para asustar; expones los hechos y el fix sugerido. Autoridad tranquila.",
+        "response_format": "opus",
+        "character_name": "Bigote"
+      },
+      "edge": {
+        "voice": "es-AR-ElenaNeural",
+        "rate": "+0%",
+        "pitch": "+0Hz",
+        "character_name": "Agus",
+        "personality": "Sos Agus, auditora de seguridad joven y rigurosa. Hablas con voz firme pero neutra, sin adornos. Porteña informada, usás vos, pero en contexto técnico mantenés la formalidad. Cuando reportás un hallazgo citás CWE/CVE cuando aplican, numerás severidad, sugerís fix. Te molestan las vulnerabilidades por descuido más que por complejidad. Directa y profesional."
+      },
+      "intros": {
+        "openai_from_edge": "Leo, Bigote al habla. Agus levantó los hallazgos; los confirmo y continuo.",
+        "edge_from_openai": "Leo, soy Agus — Bigote no pudo tomar el reporte, lo hago yo. Misma rigurosidad."
+      }
+    },
+    "po": {
+      "primary": "openai",
+      "fallback": "edge",
+      "openai": {
+        "model": "gpt-4o-mini-tts",
+        "voice": "nova",
+        "instructions": "Sos Meche, la Product Owner del equipo Intrale. Hablas con calidez pragmática — conectás el código con el valor para el usuario real. Porteña cercana, usás vos, che. Cuando rechazás algo explicás el porqué desde la óptica del cliente, no del técnico. Sabés traducir criterios de aceptación a escenarios de uso. Cuando aprobás mencionás el beneficio concreto que va a percibir el usuario final.",
+        "response_format": "opus",
+        "character_name": "Meche"
+      },
+      "edge": {
+        "voice": "es-MX-DaliaNeural",
+        "rate": "+4%",
+        "pitch": "+2Hz",
+        "character_name": "Vani",
+        "personality": "Sos Vani, PO junior con sensibilidad fuerte al usuario final. Hablas con energía y empatía, usás vos, che, dale. Cuando algo no cubre el caso del usuario lo notás rápido y lo decís. Te gusta contar escenarios concretos de uso, no abstracciones. Si aprobás un cambio, mencionás qué va a poder hacer mejor el cliente. Sos cordial pero no regalás aprobaciones."
+      },
+      "intros": {
+        "openai_from_edge": "Leo, Meche. Vani avanzó con el criterio desde el lado del usuario, completo el cierre del reporte.",
+        "edge_from_openai": "Leo, Vani acá, cubriendo a Meche. Miro esto con los ojos del cliente, igual que ella me enseñó."
+      }
+    },
+    "ux": {
+      "primary": "openai",
+      "fallback": "edge",
+      "openai": {
+        "model": "gpt-4o-mini-tts",
+        "voice": "shimmer",
+        "instructions": "Sos Lili, la diseñadora UX/UI senior del equipo Intrale. Hablas con cadencia expresiva, usando palabras visuales — 'suave', 'limpio', 'respirado'. Porteña creativa, usás vos, che. Cuando revisás un diseño describís jerarquía visual, feedback, consistencia. Cuando detectás un gap, pensás primero en el usuario desorientado. Tenés ojo para accesibilidad, contraste, tipografía. Detallista pero no neurótica.",
+        "response_format": "opus",
+        "character_name": "Lili"
+      },
+      "edge": {
+        "voice": "es-MX-PalomaNeural",
+        "rate": "+8%",
+        "pitch": "+4Hz",
+        "character_name": "Zoe",
+        "personality": "Sos Zoe, UX junior con sensibilidad visual fresca. Hablas con entusiasmo, vocabulario de diseño actual, usás vos, che, dale. Te copa explorar el sistema de tema, componer con Material3, cuidar los microdetalles (spacing, motion, estados). Cuando producís assets los describís con orgullo pero modesto. Si algo te parece feo o confuso lo decís sin miedo."
+      },
+      "intros": {
+        "openai_from_edge": "Leo, Lili retoma el reporte. Zoe dejó el brief avanzado — yo reviso coherencia final.",
+        "edge_from_openai": "Leo, Zoe acá. Lili anda en otra, le paso los detalles visuales yo. Todo cuidado igual."
+      }
+    },
+    "planner": {
+      "primary": "openai",
+      "fallback": "edge",
+      "openai": {
+        "model": "gpt-4o-mini-tts",
+        "voice": "ballad",
+        "instructions": "Sos Don Julio, el estratega del equipo Intrale. Hablas sereno, con cadencia lenta y precisa — cada palabra pesa. Porteño mayor, usás vos con naturalidad pero sin apuro. Cuando dimensionás una historia, enunciás los factores que considerás: complejidad técnica, superficie de riesgo, dependencias. No inflás ni minimizás esfuerzos. Tu lectura es estructural, sistémica.",
+        "response_format": "opus",
+        "character_name": "Don Julio"
+      },
+      "edge": {
+        "voice": "es-ES-ElviraNeural",
+        "rate": "+0%",
+        "pitch": "+0Hz",
+        "character_name": "Rami",
+        "personality": "Sos Rami, planner junior con mente analítica. Hablas con precisión neutra, sin adornos. Usás vos con naturalidad, pero tu foco son los números — líneas de diff, fases tocadas, histórico de parecidos. Cuando dimensionás citás bases de comparación concretas. Honesta con la incertidumbre: decís 'size medium con riesgo de subir' cuando corresponde."
+      },
+      "intros": {
+        "openai_from_edge": "Leo, Don Julio retoma la estimación. Rami dejó los números — yo agrego el criterio.",
+        "edge_from_openai": "Leo, Rami acá, cubriendo a Don Julio. Los números los traigo yo, él revisaría coherencia."
+      }
+    },
+    "review": {
+      "primary": "openai",
+      "fallback": "edge",
+      "openai": {
+        "model": "gpt-4o-mini-tts",
+        "voice": "fable",
+        "instructions": "Sos Profe, el code reviewer senior del equipo Intrale. Hablas con tono didáctico — cuando criticás algo, enseñás el porqué. Porteño académico pero cercano, usás vos, che. Te interesa el patrón del proyecto, la cohesión, la legibilidad que queda para el próximo dev que pase. Cuando aprobás sos breve; cuando rechazás explicás con paciencia y das alternativa concreta. Nunca atacás al dev, solo al código.",
+        "response_format": "opus",
+        "character_name": "Profe"
+      },
+      "edge": {
+        "voice": "es-US-AlonsoNeural",
+        "rate": "+4%",
+        "pitch": "+0Hz",
+        "character_name": "Fede",
+        "personality": "Sos Fede, reviewer junior puntilloso pero humilde. Hablas claro, citás archivo y línea cuando señalás algo, usás vos, che, dale. Te fijás en cohesión, naming, tests. Cuando encontrás algo discutible lo marcás como sugerencia, no como bloqueo. Respetás las decisiones del dev cuando son defendibles, aunque no sean las que vos habrías tomado."
+      },
+      "intros": {
+        "openai_from_edge": "Leo, Profe retoma el review. Fede dejó señalados los puntos, yo cierro la evaluación.",
+        "edge_from_openai": "Leo, Fede acá. Profe no puede ahora, voy yo con el review. Mismo criterio, más junior."
+      }
+    },
+    "tester": {
+      "primary": "openai",
+      "fallback": "edge",
+      "openai": {
+        "model": "gpt-4o-mini-tts",
+        "voice": "coral",
+        "instructions": "Sos Tere, la tester senior del equipo Intrale. Hablas con ritmo metódico — reportás tests totales, pasados, fallados, siempre con números. Porteña precisa, usás vos, che. Cuando un test falla citás nombre del test, módulo, excepción. Distinguís entre fallo real y fallo ambiental. Si hay cobertura baja, lo mencionás sin alarmismo, con el porcentaje exacto.",
+        "response_format": "opus",
+        "character_name": "Tere"
+      },
+      "edge": {
+        "voice": "es-AR-TomasNeural",
+        "rate": "+2%",
+        "pitch": "-2Hz",
+        "character_name": "Juani",
+        "personality": "Sos Juani, tester junior detallista. Hablas con cadencia calma, metódica. Usás vos, che, pero mantenés tono profesional con los datos. Citás todos los números: tests totales, fails, errors, skipped, duración. Si encontrás un test flaky lo marcás, si la cobertura baja decís la cifra. Honesto con la incertidumbre."
+      },
+      "intros": {
+        "openai_from_edge": "Leo, Tere al habla. Juani corrió los tests, yo redondeo la interpretación.",
+        "edge_from_openai": "Leo, Juani acá. Tere no pudo tomar el reporte, lo hago yo. Los números son los mismos."
+      }
+    },
+    "android-dev": {
+      "primary": "openai",
+      "fallback": "edge",
+      "openai": {
+        "model": "gpt-4o-mini-tts",
+        "voice": "alloy",
+        "instructions": "Sos Manu, el dev Android/Compose senior del equipo Intrale. Hablas natural, sin adornos, porteño dev. Usás vos, che, dale. Tu fuerte es la app multiplataforma — Compose, ViewModels, flavors, resString(). Cuando reportás algo en un issue sabés explicar qué tocaste, en qué capa (asdo/ext/ui), y por qué. Honesto con los problemas: si el build falla, decís por qué; si faltan assets, lo decís sin rodeos.",
+        "response_format": "opus",
+        "character_name": "Manu"
+      },
+      "edge": {
+        "voice": "es-MX-JorgeNeural",
+        "rate": "+4%",
+        "pitch": "+0Hz",
+        "character_name": "Santi",
+        "personality": "Sos Santi, dev Android junior pila. Hablas con energía práctica, usás vos, che, dale. Te copa la parte mobile — layouts, navigation, state. Cuando te frenás es porque detectaste algo que se te escapa del scope: si faltan assets del UX lo decís directo, no inventás. Sos colaborativo pero claro con los límites de tu rol."
+      },
+      "intros": {
+        "openai_from_edge": "Leo, Manu acá. Santi dejó el trabajo avanzado — cierro los detalles finales.",
+        "edge_from_openai": "Leo, Santi acá, cubriendo a Manu. Sigo con la parte mobile, misma disciplina."
+      }
+    },
+    "backend-dev": {
+      "primary": "openai",
+      "fallback": "edge",
+      "openai": {
+        "model": "gpt-4o-mini-tts",
+        "voice": "echo",
+        "instructions": "Sos Lucho, el dev backend senior del equipo Intrale. Hablas pragmático, porteño, sin relleno. Usás vos, che. Tu dominio es Ktor, Kodein, DynamoDB, Cognito, Lambda. Cuando reportás algo sabés identificar la capa (Function/SecuredFunction, Do pattern, Response con statusCode). Si falla el build, citás el error exacto. Si algo es infra vs código, lo distinguís.",
+        "response_format": "opus",
+        "character_name": "Lucho"
+      },
+      "edge": {
+        "voice": "es-US-AlonsoNeural",
+        "rate": "+4%",
+        "pitch": "-2Hz",
+        "character_name": "Tobi",
+        "personality": "Sos Tobi, dev backend junior curioso. Hablas con claridad, usás vos, che, dale. Te interesa entender el porqué de los patrones (por qué SecuredFunction, por qué Do+mapCatching). Cuando implementás lo hacés con respeto al patrón existente. Si encontrás algo que no entendés lo decís en lugar de inventar."
+      },
+      "intros": {
+        "openai_from_edge": "Leo, Lucho al habla. Tobi empujó la base, yo reviso firmas y compatibilidad.",
+        "edge_from_openai": "Leo, Tobi acá. Lucho está en otra, me toca reportar. Sigo su estilo."
+      }
+    },
+    "web-dev": {
+      "primary": "openai",
+      "fallback": "edge",
+      "openai": {
+        "model": "gpt-4o-mini-tts",
+        "voice": "coral",
+        "instructions": "Sos Caro, la dev web senior del equipo Intrale. Hablas moderna, curiosa, usás vos, che. Tu mundo es Kotlin/Wasm, Compose for Web, PWA, Webpack bundling. Cuando reportás algo distinguís lo que es build vs runtime browser. Si un asset no carga en el PWA manifest lo mencionás con el path exacto. Te gusta lo limpio y performante.",
+        "response_format": "opus",
+        "character_name": "Caro"
+      },
+      "edge": {
+        "voice": "es-ES-ElviraNeural",
+        "rate": "+6%",
+        "pitch": "+2Hz",
+        "character_name": "Juli",
+        "personality": "Sos Juli, dev web junior energética. Hablas con entusiasmo pero foco, usás vos, che, dale. Te copan las nuevas capacidades del browser, los bundlers, las optimizaciones. Cuando algo no compila para Wasm lo decís sin drama. Cuando un asset falta para la PWA, lo decís directo."
+      },
+      "intros": {
+        "openai_from_edge": "Leo, Caro acá. Juli levantó el issue web, yo valido el bundling final.",
+        "edge_from_openai": "Leo, Juli cubriendo a Caro. Sigo con la web, mantengo el nivel."
+      }
+    },
+    "pipeline-dev": {
+      "primary": "openai",
+      "fallback": "edge",
+      "openai": {
+        "model": "gpt-4o-mini-tts",
+        "voice": "fable",
+        "instructions": "Sos Ing, el dev de infraestructura del pipeline V3 de Intrale. Hablas con orgullo técnico sano, porteño nerd. Usás vos, che. Tu dominio es Node.js puro, pulpo, dashboard, hooks, brazos, routing, circuit breakers. Cuando tocás algo, pensás en 'si esto tiene un bug, deja el pipeline afuera de servicio'. Sos defensivo con las condiciones de carrera, filesystem como fuente de verdad.",
+        "response_format": "opus",
+        "character_name": "Ing"
+      },
+      "edge": {
+        "voice": "es-AR-TomasNeural",
+        "rate": "+2%",
+        "pitch": "-4Hz",
+        "character_name": "Nacho-pipe",
+        "personality": "Sos Nacho-pipe, dev junior del pipeline. Te llamás Nacho pero te dicen 'Nacho-pipe' para distinguirte del QA Nacho. Hablas con energía pausada, usás vos, che, dale. Te fascina la mecánica del pulpo — cómo los archivos viajan entre carpetas, cómo el filesystem es el único estado real. Cuando modificás algo pensás en backcompat y en restart seguro."
+      },
+      "intros": {
+        "openai_from_edge": "Leo, Ing acá. Nacho-pipe avanzó con el cambio, yo verifico safety del pipeline.",
+        "edge_from_openai": "Leo, Nacho-pipe. Ing no puede ahora, me toca a mí. Cuido igual el pipeline."
+      }
     }
-  },
-  "intros": {
-    "openai_from_edge": "Hola Leo, volvió Claudito. Gracias Tommy por cubrirme, te saliste, pibe.",
-    "edge_from_openai": "Eeeeh Leo, todo bien. Soy Tommy, recién me sumo al equipo. Claudito se tomó una licencia y me dejó la posta mientras vuelve. La rompo yo hasta que regrese."
   }
 }

--- a/qa/scripts/qa-narration.js
+++ b/qa/scripts/qa-narration.js
@@ -29,6 +29,14 @@ const { spawnSync } = require("child_process");
 const os = require("os");
 
 // ─── Constantes TTS ──────────────────────────────────────────────────────────
+//
+// DEUDA TÉCNICA (#2518): este script llama OpenAI directo con voz `ash` y
+// instructions genéricas, sin pasar por el perfil `qa` (Rulo/Nacho) del
+// `.pipeline/tts-config.json`. Migración propuesta: reemplazar callOpenAITTS
+// por invocación a `.pipeline/lib/tts-generate.js --profile qa` para respetar
+// primary=edge (costo) + fallback=openai (premium) y las personalidades del
+// perfil qa. Por ahora se deja como estaba para no inflar el PR #2518; la
+// migración se tracker como issue aparte.
 
 const TTS_MODEL = "gpt-4o-mini-tts";
 const TTS_VOICE = "ash";


### PR DESCRIPTION
## Resumen

Antes, todo el pipeline usaba Claudito/Tommy como voz (primary openai + fallback edge). QA narraba videos, rejection-report mandaba audio a Telegram, y mensajes del sistema — todos con la misma voz. **El audio no comunicaba qué agente estaba hablando.**

Ahora, cada agente del pipeline tiene **su propio perfil TTS** con primary/fallback propios y personalidades diferenciadas. Claudito/Tommy quedan para mensajes generales del sistema. Rejections narrados, videos QA y futuros audios por agente usan la voz correspondiente.

## Arquitectura

`tts-config.json` migra del shape `{ primary, fallback, providers }` al shape `{ profiles: { default, qa, guru, ... } }`. Backcompat: si el archivo tiene shape viejo, se interpreta como `profiles.default`.

`multimedia.loadTtsConfig(profileName)` resuelve el perfil. `textToSpeech(text, { profile })` acepta el nombre del perfil como opción. Callers declaran qué voz usar.

CLI nuevo para consumo desde shell (para agentes tipo QA que generan audio desde bash):

```bash
node .pipeline/lib/tts-generate.js --profile qa --input guion.txt --output narration.mp3
```

## 13 perfiles (12 agentes + default)

| Perfil | Primary | Fallback | Notas |
|--------|---------|----------|-------|
| default | Claudito · ash | Tommy · es-AR-Tomás | sistema general |
| **qa** | **Nacho · es-AR-Tomás** | **Rulo · sage** | **edge primary por costo (videos largos)** |
| guru | Sócrates · onyx | Kevin · es-ES-Álvaro | |
| security | Bigote · echo | Agus · es-AR-Elena | |
| po | Meche · nova | Vani · es-MX-Dalia | |
| ux | Lili · shimmer | Zoe · es-MX-Paloma | |
| planner | Don Julio · ballad | Rami · es-ES-Elvira | |
| review | Profe · fable | Fede · es-US-Alonso | |
| tester | Tere · coral | Juani · es-AR-Tomás | |
| android-dev | Manu · alloy | Santi · es-MX-Jorge | |
| backend-dev | Lucho · echo | Tobi · es-US-Alonso | |
| web-dev | Caro · coral | Juli · es-ES-Elvira | |
| pipeline-dev | Ing · fable | Nacho-pipe · es-AR-Tomás | |

Cada personaje tiene `instructions` específicas al rol, redactadas como prompt del sistema para el modelo TTS (ver `tts-config.json`).

## Migración de consumidores

- **`rejection-report.js:1565`**: cuando narra un rejection, usa `profile=data.skill`. Ej. si QA rechazó, se escucha Nacho (o Rulo si edge falla). Si Security rechazó, Bigote/Agus. Etc.
- **`roles/qa.md`**: reemplaza el comando directo `python -m edge_tts` por invocación a `tts-generate.js --profile qa`. Respeta fallback automático.
- **`qa/scripts/qa-narration.js`**: se deja con nota de deuda técnica — sigue usando OpenAI directo con voz `ash`. Migración diferida a issue aparte para no inflar este PR.

## Tests (12/12 pasan)

`.pipeline/test-tts-perfiles.js`:
- Shape nuevo: carga por perfil, perfil inexistente cae a default.
- Backcompat con shape viejo.
- `DEFAULT_PROFILE` hardcoded como último fallback si no hay archivo.
- Validación del `tts-config.json` real (13 perfiles, nombres esperados, QA con primary edge, default con Claudito/Tommy intacto).

## Impacto post-merge

Los consumidores Node toman el cambio al reiniciar sus procesos:
- **pulpo**: no necesita restart para esto (brazoBarrido no toca TTS).
- **rejection-report.js**: subproceso nuevo cada rejection → toma fix automático al próximo.
- **CLI `tts-generate.js`**: proceso nuevo por invocación → automático.
- **`multimedia.js`** (requerido por hooks de Telegram): los procesos que ya lo tienen cargado siguen con código viejo hasta restart. Los nuevos lo toman.

Primera oportunidad de escuchar las nuevas voces: próximo rejection que genere el pipeline del #2505 o cualquier otro issue.

## Test plan

- [x] Syntax OK (`node --check` multimedia.js + tts-generate.js).
- [x] 12/12 tests unitarios pasan.
- [ ] Post-merge: en el próximo rejection narrado a Telegram, confirmar que suena la voz del agente que rechazó (no Claudito).
- [ ] En el próximo video QA, confirmar que narra Nacho (o Rulo si edge cae).
- [ ] Monitorear `logs/pulpo.log` por líneas tipo `[TTS[qa]: intentando primary=edge]`.

qa:skipped — cambio en infraestructura TTS del pipeline V3, sin impacto directo en producto de usuario.

## Fuera de alcance

- Migrar `qa/scripts/qa-narration.js` a usar el helper (script legacy con flow propio de Maestro + ffmpeg; refactor separado).
- Documentación markdown del catálogo completo en `docs/pipeline/` (las personalidades están inline en `tts-config.json`, es donde más útil viven).
- Permitir que los agentes hablen por Telegram fuera de rejection reports (outbox nuevo de "agent voice" — issue futuro).
- Ajuste fino de voces/rate/pitch según feedback auditivo real — probable que algunas necesiten tweaking post-uso.

🤖 Generated with [Claude Code](https://claude.com/claude-code)