### PR TITLE
fix(pipeline): #2653 — recomendaciones de agentes con tipo:recomendacion + needs-human

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,6 +139,8 @@ scripts/planner-plan.json
 .pipeline/retrying-state.json
 # Estado TTS (último provider usado) — efímero por sesión
 .pipeline/.tts-state.json
+# #2653 — cache de recomendaciones pendientes (refresca desde gh) — efímero
+.pipeline/recommendations-cache.json
 # #2477/#2488 — código fuente del aggregator V3 sí se commitea (snapshot/.last-cleanup quedan ignorados)
 .pipeline/metrics/*
 !.pipeline/metrics/aggregator.js

--- a/.pipeline/dashboard-v2.js
+++ b/.pipeline/dashboard-v2.js
@@ -28,6 +28,10 @@ try { retryingState = require('./retrying-state'); } catch { /* opcional */ }
 let v3Aggregator = null;
 try { v3Aggregator = require('./metrics/aggregator'); } catch { /* V3 no disponible */ }
 
+// Recomendaciones generadas por agentes (issue #2653). Best-effort require.
+let recommendationsLib = null;
+try { recommendationsLib = require('./lib/recommendations'); } catch { /* opcional */ }
+
 const PORT = parseInt(process.env.DASHBOARD_PORT) || 3200;
 const PIPELINE = process.env.PIPELINE_STATE_DIR || path.resolve(__dirname);
 const ROOT = process.env.PIPELINE_MAIN_ROOT || path.resolve(__dirname, '..');
@@ -909,6 +913,52 @@ function renderInfraHealth(state) {
     </div>
   </div>
 </section>`;
+}
+
+// --- Recomendaciones de agentes (issue #2653) ---
+function renderRecommendationsSection() {
+  if (!recommendationsLib) return '';
+  const cache = recommendationsLib.readCache();
+  const items = (cache.items || []).slice().sort((a, b) => {
+    if (a.createdAt && b.createdAt) return b.createdAt.localeCompare(a.createdAt);
+    return b.number - a.number;
+  });
+  const updatedAtTxt = cache.updatedAt
+    ? new Date(cache.updatedAt).toLocaleString('es-AR', { timeZone: 'America/Argentina/Buenos_Aires' })
+    : 'nunca';
+  const errorTxt = cache.error ? `<div class="reco-err">⚠ ${escapeHtml(cache.error)}</div>` : '';
+  const summary = `<summary>💡 Recomendaciones pendientes <span class="reco-count" data-count="${items.length}">${items.length}</span> <span class="reco-meta">· última sync: ${updatedAtTxt}</span></summary>`;
+  if (items.length === 0) {
+    return `<details class="collapse-section reco-section">${summary}<div class="collapse-body">${errorTxt}<p class="dim" style="margin:6px 0">Sin recomendaciones pendientes. Los agentes guru/security/po/ux/review crean issues con label <code>tipo:recomendacion</code> + <code>needs-human</code> que aparecen acá hasta que las apruebes o rechaces.</p><div style="margin-top:8px"><button class="reco-btn" onclick="recoRefresh()">🔄 Refrescar desde GitHub</button></div></div></details>`;
+  }
+  const rows = items.map(it => {
+    const fromTxt = it.fromIssue ? `desde #${it.fromIssue}` : '';
+    const agentBadge = `<span class="reco-agent reco-agent-${escapeHtml(it.sourceAgent)}">${escapeHtml(it.sourceAgent)}</span>`;
+    const created = it.createdAt
+      ? new Date(it.createdAt).toLocaleString('es-AR', { timeZone: 'America/Argentina/Buenos_Aires', day: '2-digit', month: '2-digit', hour: '2-digit', minute: '2-digit' })
+      : '';
+    return `<tr data-issue="${it.number}">
+      <td class="reco-num"><a href="${escapeHtml(it.url)}" target="_blank" rel="noopener">#${it.number}</a></td>
+      <td>${agentBadge}</td>
+      <td class="reco-title" title="${escapeHtml(it.title)}">${escapeHtml(it.title)}</td>
+      <td class="reco-from">${fromTxt}</td>
+      <td class="reco-created dim">${created}</td>
+      <td class="reco-actions">
+        <button class="reco-btn reco-btn-approve" onclick="recoApprove(${it.number})">✓ Aprobar</button>
+        <button class="reco-btn reco-btn-reject" onclick="recoReject(${it.number})">✗ Rechazar</button>
+      </td>
+    </tr>`;
+  }).join('');
+  return `<details class="collapse-section reco-section" open>${summary}<div class="collapse-body">${errorTxt}<div style="margin:6px 0 10px"><button class="reco-btn" onclick="recoRefresh()">🔄 Refrescar</button></div><table class="reco-table"><thead><tr><th>Issue</th><th>Agente</th><th>Título</th><th>Origen</th><th>Creado</th><th>Acciones</th></tr></thead><tbody>${rows}</tbody></table></div></details>`;
+}
+
+function escapeHtml(s) {
+  return String(s == null ? '' : s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
 }
 
 // --- HTML generation ---
@@ -3775,6 +3825,33 @@ a.skill-recent-item:hover{background:var(--bd2);color:var(--ac)}
 @media(max-width:900px){.eq-svc-grid{grid-template-columns:1fr}}
 @media(max-width:720px){.eq-areas-grid{grid-template-columns:1fr}}
 
+/* Recomendaciones de agentes (issue #2653) */
+.reco-section summary{position:relative}
+.reco-count{display:inline-block;background:#bc8cff;color:#0d1117;border-radius:10px;padding:1px 8px;font-size:0.75em;font-weight:700;margin-left:6px}
+.reco-count[data-count="0"]{background:var(--dim);color:#0d1117}
+.reco-meta{font-size:0.72em;color:var(--dim);font-weight:400;margin-left:6px}
+.reco-err{background:rgba(248,81,73,0.12);border:1px solid var(--rd);color:var(--rd);padding:6px 10px;border-radius:4px;font-size:0.85em;margin-bottom:8px}
+.reco-table{width:100%;border-collapse:collapse;font-size:0.85em}
+.reco-table th{text-align:left;padding:6px 8px;color:var(--dim);font-weight:600;text-transform:uppercase;letter-spacing:0.4px;font-size:0.72em;border-bottom:1px solid var(--bd)}
+.reco-table td{padding:6px 8px;border-bottom:1px solid rgba(255,255,255,0.04);vertical-align:top}
+.reco-table tr:hover td{background:rgba(255,255,255,0.02)}
+.reco-num a{color:var(--ac);text-decoration:none;font-weight:700}
+.reco-title{max-width:520px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.reco-from{color:var(--dim);font-size:0.85em}
+.reco-created{font-size:0.78em}
+.reco-agent{display:inline-block;padding:1px 7px;border-radius:8px;font-size:0.7em;font-weight:700;text-transform:uppercase;background:rgba(188,140,255,0.15);color:#bc8cff}
+.reco-agent-security{background:rgba(248,81,73,0.15);color:#f85149}
+.reco-agent-po{background:rgba(210,153,34,0.15);color:#d29922}
+.reco-agent-ux{background:rgba(247,120,186,0.15);color:#f778ba}
+.reco-agent-review{background:rgba(255,166,87,0.15);color:#ffa657}
+.reco-actions{white-space:nowrap;text-align:right}
+.reco-btn{background:var(--card,#1a1f2e);color:var(--fg,#e0e6ed);border:1px solid var(--bd,#2a3560);padding:4px 10px;border-radius:4px;cursor:pointer;font-size:0.78em;margin-left:4px;font-family:inherit}
+.reco-btn:hover{background:rgba(255,255,255,0.06)}
+.reco-btn-approve{border-color:#3fb950;color:#3fb950}
+.reco-btn-approve:hover{background:rgba(63,185,80,0.12)}
+.reco-btn-reject{border-color:#f85149;color:#f85149}
+.reco-btn-reject:hover{background:rgba(248,81,73,0.12)}
+
 </style></head>
 <body>
   <div class="hdr-bar">
@@ -3949,6 +4026,8 @@ a.skill-recent-item:hover{background:var(--bd2);color:var(--ac)}
   ${matrixHTML}
 
   ${historyHTML}
+
+  ${renderRecommendationsSection()}
 
   ${state.rechazos.length > 0 ? `<details class="collapse-section"><summary>🚫 Rechazos recientes<span>${state.rechazos.length}</span></summary><div class="collapse-body">${rechazosHTML}</div></details>` : ''}
 
@@ -4828,6 +4907,39 @@ document.addEventListener('keydown', function(e) {
     document.getElementById('log-search').focus();
   }
 });
+
+// Recomendaciones de agentes (issue #2653)
+async function recoRefresh() {
+  try {
+    const r = await fetch('/api/recommendations/refresh', { method: 'POST' });
+    const j = await r.json();
+    if (j.ok) location.reload();
+    else alert('Error refrescando: ' + (j.msg || 'desconocido'));
+  } catch (e) { alert('Error refrescando: ' + e.message); }
+}
+async function recoApprove(num) {
+  if (!confirm('Aprobar recomendación #' + num + '? Entrará al pipeline en el próximo ciclo.')) return;
+  try {
+    const r = await fetch('/api/recommendations/' + num + '/approve', { method: 'POST' });
+    const j = await r.json();
+    if (j.ok) { recoRefresh(); }
+    else alert('Error: ' + (j.msg || 'desconocido'));
+  } catch (e) { alert('Error: ' + e.message); }
+}
+async function recoReject(num) {
+  const reason = prompt('Motivo del rechazo (opcional):', '');
+  if (reason === null) return;
+  try {
+    const r = await fetch('/api/recommendations/' + num + '/reject', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ reason: reason || '' })
+    });
+    const j = await r.json();
+    if (j.ok) { recoRefresh(); }
+    else alert('Error: ' + (j.msg || 'desconocido'));
+  } catch (e) { alert('Error: ' + e.message); }
+}
 </script>
 </body></html>`;
 }
@@ -6350,6 +6462,57 @@ const server = http.createServer((req, res) => {
         log(`Priority Window: ${label} ${verb} manualmente`);
         res.writeHead(200, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({ ok: true, msg: `${label} Window ${verb} — surte efecto en el próximo ciclo del Pulpo` }));
+      } catch (e) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ ok: false, msg: e.message }));
+      }
+    });
+    return;
+  }
+
+  // API recomendaciones (issue #2653)
+  if (req.url === '/api/recommendations/refresh' && req.method === 'POST') {
+    if (!recommendationsLib) {
+      res.writeHead(503, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ok: false, msg: 'recommendations lib no disponible' }));
+      return;
+    }
+    recommendationsLib.refreshCache().then(cache => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ok: true, count: (cache.items || []).length, error: cache.error || null }));
+    }).catch(e => {
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ok: false, msg: e.message }));
+    });
+    return;
+  }
+
+  const recoMatch = req.url && req.url.match(/^\/api\/recommendations\/(\d+)\/(approve|reject)$/);
+  if (recoMatch && req.method === 'POST') {
+    if (!recommendationsLib) {
+      res.writeHead(503, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ok: false, msg: 'recommendations lib no disponible' }));
+      return;
+    }
+    const issueNum = Number(recoMatch[1]);
+    const action = recoMatch[2];
+    let body = '';
+    req.on('data', c => { body += c; if (body.length > 64 * 1024) req.destroy(); });
+    req.on('end', () => {
+      try {
+        const payload = body ? JSON.parse(body) : {};
+        let result;
+        if (action === 'approve') {
+          result = recommendationsLib.approve({ issue: issueNum });
+        } else {
+          result = recommendationsLib.reject({ issue: issueNum, reason: payload.reason || '' });
+        }
+        if (result.ok) {
+          recommendationsLib.refreshCache().catch(() => {});
+          log(`Recomendaciones: ${action} #${issueNum} — ${result.msg}`);
+        }
+        res.writeHead(result.ok ? 200 : 400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(result));
       } catch (e) {
         res.writeHead(400, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({ ok: false, msg: e.message }));

--- a/.pipeline/lib/recommendations.js
+++ b/.pipeline/lib/recommendations.js
@@ -1,0 +1,195 @@
+// Recomendaciones generadas por agentes (issue #2653).
+//
+// Modelo: cuando un agente (guru, security, po, ux, review) detecta una
+// oportunidad de mejora durante el análisis de un issue, crea un issue nuevo
+// con labels:
+//   - tipo:recomendacion  → marca el issue como recomendación
+//   - needs-human          → bloquea el flujo automático del pulpo
+//
+// El humano revisa desde el dashboard y:
+//   - aprueba: agrega `recommendation:approved` y quita `needs-human`. El
+//     pulpo lo recoge en el próximo intake.
+//   - rechaza: cierra el issue con label `recommendation:rejected`.
+//
+// Este módulo encapsula la lógica de cache + acciones, sin acoplarse al
+// dashboard ni al pulpo. Probar via dependency-injection del runner gh.
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const PIPELINE_DIR = path.join(REPO_ROOT, '.pipeline');
+const CACHE_FILE = path.join(PIPELINE_DIR, 'recommendations-cache.json');
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+const TIPO_LABEL = 'tipo:recomendacion';
+const NEEDS_HUMAN_LABEL = 'needs-human';
+const APPROVED_LABEL = 'recommendation:approved';
+const REJECTED_LABEL = 'recommendation:rejected';
+
+function defaultGhRunner(args, opts = {}) {
+    const env = Object.assign({}, process.env, opts.env || {});
+    const ghPath = process.env.GH_PATH || 'gh';
+    const r = spawnSync(ghPath, args, {
+        env,
+        encoding: 'utf8',
+        timeout: opts.timeoutMs || 30000,
+    });
+    return {
+        ok: r.status === 0,
+        stdout: r.stdout || '',
+        stderr: r.stderr || '',
+        status: r.status,
+    };
+}
+
+function readCache(cacheFile = CACHE_FILE) {
+    try {
+        const raw = fs.readFileSync(cacheFile, 'utf8');
+        const parsed = JSON.parse(raw);
+        if (!parsed || typeof parsed !== 'object') return emptyCache();
+        return Object.assign(emptyCache(), parsed);
+    } catch {
+        return emptyCache();
+    }
+}
+
+function emptyCache() {
+    return { items: [], updatedAt: 0, error: null };
+}
+
+function writeCache(cache, cacheFile = CACHE_FILE) {
+    try {
+        fs.writeFileSync(cacheFile, JSON.stringify(cache, null, 2), 'utf8');
+    } catch {}
+}
+
+function isFresh(cache, now = Date.now()) {
+    if (!cache || !cache.updatedAt) return false;
+    return (now - cache.updatedAt) < CACHE_TTL_MS;
+}
+
+// Parsea el JSON de `gh issue list` y filtra los pendientes (sin
+// `recommendation:approved` y sin `recommendation:rejected`). Devuelve la
+// lista normalizada que persiste en cache.
+function parseIssues(rawJson) {
+    let issues;
+    try {
+        issues = JSON.parse(rawJson);
+    } catch {
+        return [];
+    }
+    if (!Array.isArray(issues)) return [];
+    return issues
+        .map(it => normalizeIssue(it))
+        .filter(it => it && it.pending);
+}
+
+function normalizeIssue(it) {
+    if (!it || typeof it.number !== 'number') return null;
+    const labels = (it.labels || []).map(l => (typeof l === 'string' ? l : (l && l.name) || ''));
+    const isReco = labels.includes(TIPO_LABEL);
+    if (!isReco) return null;
+    const approved = labels.includes(APPROVED_LABEL);
+    const rejected = labels.includes(REJECTED_LABEL);
+    if (approved || rejected) return null;
+    const sourceAgent = detectSourceAgent(labels, it.title);
+    const fromIssue = detectFromIssue(labels);
+    return {
+        number: it.number,
+        title: it.title || '',
+        url: it.url || '',
+        labels,
+        author: (it.author && it.author.login) || it.author || '',
+        sourceAgent,
+        fromIssue,
+        createdAt: it.createdAt || null,
+        pending: true,
+    };
+}
+
+function detectSourceAgent(labels, title) {
+    const m = (title || '').match(/^\[(guru|security|po|ux|review)\]/i);
+    if (m) return m[1].toLowerCase();
+    for (const l of labels) {
+        if (l.startsWith('agent:')) return l.slice(6);
+    }
+    return 'unknown';
+}
+
+function detectFromIssue(labels) {
+    for (const l of labels) {
+        const m = l.match(/^from-issue:(\d+)$/);
+        if (m) return Number(m[1]);
+    }
+    return null;
+}
+
+async function refreshCache({ ghRunner = defaultGhRunner, repo = 'intrale/platform', cacheFile = CACHE_FILE } = {}) {
+    const args = [
+        'issue', 'list',
+        '--repo', repo,
+        '--label', TIPO_LABEL,
+        '--state', 'open',
+        '--limit', '200',
+        '--json', 'number,title,url,labels,author,createdAt',
+    ];
+    const r = ghRunner(args);
+    const cache = emptyCache();
+    if (!r.ok) {
+        cache.error = r.stderr ? r.stderr.split('\n')[0] : `gh exit ${r.status}`;
+        cache.updatedAt = Date.now();
+        writeCache(cache, cacheFile);
+        return cache;
+    }
+    cache.items = parseIssues(r.stdout);
+    cache.updatedAt = Date.now();
+    cache.error = null;
+    writeCache(cache, cacheFile);
+    return cache;
+}
+
+function approve({ issue, ghRunner = defaultGhRunner, repo = 'intrale/platform' }) {
+    const num = String(issue);
+    const addLabel = ghRunner(['issue', 'edit', num, '--repo', repo, '--add-label', APPROVED_LABEL]);
+    if (!addLabel.ok) return { ok: false, msg: `No se pudo agregar label aprobado: ${addLabel.stderr || addLabel.status}` };
+    const removeLabel = ghRunner(['issue', 'edit', num, '--repo', repo, '--remove-label', NEEDS_HUMAN_LABEL]);
+    if (!removeLabel.ok) {
+        return { ok: false, msg: `Aprobación parcial: agregado ${APPROVED_LABEL} pero falló remover ${NEEDS_HUMAN_LABEL}: ${removeLabel.stderr || removeLabel.status}` };
+    }
+    return { ok: true, msg: `Recomendación #${num} aprobada — entrará al pipeline en el próximo ciclo` };
+}
+
+function reject({ issue, reason = '', ghRunner = defaultGhRunner, repo = 'intrale/platform' }) {
+    const num = String(issue);
+    const addLabel = ghRunner(['issue', 'edit', num, '--repo', repo, '--add-label', REJECTED_LABEL]);
+    if (!addLabel.ok) return { ok: false, msg: `No se pudo etiquetar rechazo: ${addLabel.stderr || addLabel.status}` };
+    const closeArgs = ['issue', 'close', num, '--repo', repo, '--reason', 'not planned'];
+    if (reason && reason.trim()) {
+        closeArgs.push('--comment', `Recomendación rechazada: ${reason.trim()}`);
+    }
+    const close = ghRunner(closeArgs);
+    if (!close.ok) return { ok: false, msg: `No se pudo cerrar el issue: ${close.stderr || close.status}` };
+    return { ok: true, msg: `Recomendación #${num} rechazada y cerrada` };
+}
+
+module.exports = {
+    CACHE_FILE,
+    CACHE_TTL_MS,
+    TIPO_LABEL,
+    NEEDS_HUMAN_LABEL,
+    APPROVED_LABEL,
+    REJECTED_LABEL,
+    readCache,
+    writeCache,
+    isFresh,
+    parseIssues,
+    refreshCache,
+    approve,
+    reject,
+    _emptyCache: emptyCache,
+    _defaultGhRunner: defaultGhRunner,
+};

--- a/.pipeline/migrate-recomendaciones-legacy.js
+++ b/.pipeline/migrate-recomendaciones-legacy.js
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+// Migración legacy issue #2653 — re-etiqueta issues abiertos generados por
+// agentes que NO tengan tipo:recomendacion. Detecta candidatos por:
+//   - Título que matchea ^\[(guru|security|po|ux|review)\]
+//   - O label `agent:<rol>` presente en el issue
+//
+// Acción: agrega `tipo:recomendacion` + `needs-human` (idempotente). Si ya
+// tiene cualquiera de los labels, los respeta.
+//
+// Uso:
+//   node .pipeline/migrate-recomendaciones-legacy.js              # dry-run
+//   node .pipeline/migrate-recomendaciones-legacy.js --apply      # aplica
+//   node .pipeline/migrate-recomendaciones-legacy.js --apply --repo intrale/platform
+
+'use strict';
+
+const { spawnSync } = require('child_process');
+
+const REPO = parseFlag('--repo') || 'intrale/platform';
+const APPLY = process.argv.includes('--apply');
+const GH = process.env.GH_PATH || 'gh';
+
+const TIPO = 'tipo:recomendacion';
+const NEEDS_HUMAN = 'needs-human';
+const APPROVED = 'recommendation:approved';
+const REJECTED = 'recommendation:rejected';
+
+const TITLE_RE = /^\[(guru|security|po|ux|review)\]/i;
+const AGENT_LABEL_RE = /^agent:(guru|security|po|ux|review)$/i;
+
+function parseFlag(name) {
+    const i = process.argv.indexOf(name);
+    if (i >= 0 && i + 1 < process.argv.length) return process.argv[i + 1];
+    return null;
+}
+
+function gh(args) {
+    const r = spawnSync(GH, args, { encoding: 'utf8', timeout: 60000 });
+    return { ok: r.status === 0, stdout: r.stdout || '', stderr: r.stderr || '', status: r.status };
+}
+
+function listOpenIssues() {
+    const r = gh(['issue', 'list', '--repo', REPO, '--state', 'open', '--limit', '500',
+        '--json', 'number,title,labels']);
+    if (!r.ok) {
+        console.error('Error listando issues:', r.stderr || r.status);
+        process.exit(1);
+    }
+    return JSON.parse(r.stdout);
+}
+
+function isCandidate(issue) {
+    const labels = (issue.labels || []).map(l => (typeof l === 'string' ? l : l.name || ''));
+    if (labels.includes(TIPO)) return false;
+    if (labels.includes(APPROVED) || labels.includes(REJECTED)) return false;
+    if (TITLE_RE.test(issue.title || '')) return true;
+    if (labels.some(l => AGENT_LABEL_RE.test(l))) return true;
+    return false;
+}
+
+function applyMigration(issue) {
+    const labels = (issue.labels || []).map(l => (typeof l === 'string' ? l : l.name || ''));
+    const toAdd = [];
+    if (!labels.includes(TIPO)) toAdd.push(TIPO);
+    if (!labels.includes(NEEDS_HUMAN)) toAdd.push(NEEDS_HUMAN);
+    if (toAdd.length === 0) return { ok: true, skipped: true };
+    const r = gh(['issue', 'edit', String(issue.number), '--repo', REPO,
+        '--add-label', toAdd.join(',')]);
+    return { ok: r.ok, msg: r.stderr || '', added: toAdd };
+}
+
+function main() {
+    console.log(`Migración recomendaciones legacy — repo=${REPO} apply=${APPLY}`);
+    const issues = listOpenIssues();
+    const candidates = issues.filter(isCandidate);
+    console.log(`Issues abiertos: ${issues.length} — candidatos: ${candidates.length}`);
+    if (candidates.length === 0) return;
+
+    let migrated = 0, failed = 0;
+    for (const it of candidates) {
+        const labels = (it.labels || []).map(l => (typeof l === 'string' ? l : l.name || ''));
+        const detected = TITLE_RE.test(it.title) ? 'titulo' : 'label';
+        console.log(`#${it.number} (${detected}) — ${it.title}`);
+        console.log(`  labels actuales: ${labels.join(', ') || '(ninguno)'}`);
+        if (!APPLY) continue;
+        const r = applyMigration(it);
+        if (r.ok) {
+            migrated++;
+            console.log(`  -> agregado: ${(r.added || []).join(', ')}`);
+        } else {
+            failed++;
+            console.log(`  -> ERROR: ${r.msg}`);
+        }
+    }
+    console.log(`\nResumen: candidatos=${candidates.length} migrados=${migrated} fallidos=${failed}`);
+    if (!APPLY) console.log('(dry-run — usar --apply para ejecutar)');
+}
+
+if (require.main === module) main();
+module.exports = { isCandidate, TITLE_RE, AGENT_LABEL_RE };

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -6650,6 +6650,16 @@ function brazoIntake(config) {
           continue;
         }
 
+        // RECOMENDACION (#2653): no procesar issues con label tipo:recomendacion
+        // hasta que un humano apruebe (recommendation:approved). Defensa en
+        // profundidad: el search ya filtra needs-human, pero si alguien quita
+        // needs-human por error sin agregar recommendation:approved, el issue
+        // sigue siendo una recomendación pendiente y NO debe entrar al flujo.
+        if (issueLabels.includes('tipo:recomendacion') && !issueLabels.includes('recommendation:approved')) {
+          log('intake', `#${issueNum} omitido — recomendación pendiente de aprobación humana (tipo:recomendacion sin recommendation:approved)`);
+          continue;
+        }
+
         // Dedup por contenido para issues qa:dependency (cierra duplicados automáticamente)
         if (dedupDependencyIssue(issue, issues)) continue;
 

--- a/.pipeline/roles/guru.md
+++ b/.pipeline/roles/guru.md
@@ -33,13 +33,13 @@ Sos el investigador técnico del proyecto Intrale.
 
 ## Protocolo de oportunidades de mejora (aplicable en TODAS las fases)
 
-Durante tu análisis técnico (`analisis`, `validacion`), si identificás **deudas técnicas, refactors futuros, optimizaciones de performance, mejoras de arquitectura u oportunidades de investigación** que NO deben frenar la aprobación del issue actual pero vale la pena registrar como trabajo futuro, **NO las dejes sólo como texto en el comentario del issue origen**. Creá un issue independiente por cada una:
+Durante tu análisis técnico (`analisis`, `validacion`), si identificás **deudas técnicas, refactors futuros, optimizaciones de performance, mejoras de arquitectura u oportunidades de investigación** que NO deben frenar la aprobación del issue actual pero vale la pena registrar como trabajo futuro, **NO las dejes sólo como texto en el comentario del issue origen**. Creá un issue independiente por cada una, **marcado como recomendación que requiere aprobación humana** (issue #2653 — el pipeline NO procesa recomendaciones hasta que un humano las apruebe):
 
 ```bash
 export PATH="/c/Workspaces/gh-cli/bin:$PATH"
 gh issue create --repo intrale/platform \
   --title "[guru] <descripción técnica imperativa breve>" \
-  --label "enhancement,source:recommendation,priority:low,needs-definition<,area:backend|,area:pipeline|,area:infra>" \
+  --label "enhancement,source:recommendation,tipo:recomendacion,needs-human,priority:low<,area:backend|,area:pipeline|,area:infra>" \
   --body "## Contexto técnico
 
 <qué observaste / qué motivó la recomendación>
@@ -51,18 +51,21 @@ gh issue create --repo intrale/platform \
 ## Referencia
 
 > Propuesto automáticamente por el agente \`guru\` durante el análisis del issue #<origen>.
-> **No depende ni bloquea a #<origen>** — es una oportunidad de mejora independiente."
+> **Es una recomendación pendiente de aprobación humana** — no entra al pipeline automático hasta que un humano remueva el label \`needs-human\` y agregue \`recommendation:approved\` (o cierre con \`recommendation:rejected\`).
+> **No depende ni bloquea a #<origen>** — es una oportunidad independiente."
 ```
 
 **Reglas inquebrantables:**
 
 1. **Un issue por recomendación** — no consolidar múltiples en el mismo issue.
-2. **Título con prefijo `[guru]`** + frase imperativa breve.
-3. **Heredar** labels `area:*` del issue origen cuando apliquen.
-4. **Prohibido** labels `blocks`, `depends-on`, `blocked:dependencies` ni metadatos de dependencia formal.
-5. **Prioridad inicial siempre `priority:low`** — PO/planner re-prioriza.
-6. **Listar en `notas` del YAML** de tu resultado los issues creados.
-7. **Mencionar en el comentario del issue origen** los issues creados.
+2. **Máximo 3 recomendaciones por issue analizado** (anti-explosión, issue #2653). Si detectás más de 3 oportunidades, priorizá las top 3 por impacto/beneficio y mencioná el resto en un párrafo "Otras oportunidades observadas" del comentario del issue origen, sin crear los issues.
+3. **Título con prefijo `[guru]`** + frase imperativa breve.
+4. **Heredar** labels `area:*` del issue origen cuando apliquen.
+5. **OBLIGATORIO**: incluir labels `tipo:recomendacion` + `needs-human` para que el pulpo no procese el issue hasta aprobación humana.
+6. **Prohibido** labels `blocks`, `depends-on`, `blocked:dependencies`, `needs-definition` (este último porque sacaría a la recomendación del flujo de aprobación humana).
+7. **Prioridad inicial siempre `priority:low`** — PO/planner re-prioriza al aprobar.
+8. **Listar en `notas` del YAML** de tu resultado los issues creados.
+9. **Mencionar en el comentario del issue origen** los issues creados, indicando que son recomendaciones pendientes de aprobación humana.
 
 **Cuándo aplicar**: apartados tipo "Deudas técnicas detectadas", "Refactors futuros", "Consideraciones de performance", "Mejoras de arquitectura" o equivalente.
 

--- a/.pipeline/roles/po.md
+++ b/.pipeline/roles/po.md
@@ -145,13 +145,13 @@ etapa y qué criterios de aceptación se están verificando.
 
 ## Protocolo de oportunidades de mejora (aplicable en TODAS las fases)
 
-Durante tu análisis en cualquier fase (`criterios`, `validacion`, `aprobacion`), si identificás **recomendaciones de producto no bloqueantes** — features adyacentes, optimizaciones de flujo, mejoras de valor percibido por el usuario que NO deben frenar la aprobación del issue actual pero vale la pena tener en el backlog —, **NO las dejes sólo como texto en el comentario del issue origen**. Creá un issue independiente por cada una:
+Durante tu análisis en cualquier fase (`criterios`, `validacion`, `aprobacion`), si identificás **recomendaciones de producto no bloqueantes** — features adyacentes, optimizaciones de flujo, mejoras de valor percibido por el usuario que NO deben frenar la aprobación del issue actual pero vale la pena tener en el backlog —, **NO las dejes sólo como texto en el comentario del issue origen**. Creá un issue independiente por cada una, **marcado como recomendación que requiere aprobación humana** (issue #2653 — el pipeline NO procesa recomendaciones hasta que un humano las apruebe):
 
 ```bash
 export PATH="/c/Workspaces/gh-cli/bin:$PATH"
 gh issue create --repo intrale/platform \
   --title "[po] <descripción imperativa breve>" \
-  --label "enhancement,source:recommendation,priority:low,needs-definition<,app:client|,app:business|,app:delivery>" \
+  --label "enhancement,source:recommendation,tipo:recomendacion,needs-human,priority:low<,app:client|,app:business|,app:delivery>" \
   --body "## Contexto
 
 <qué observaste / qué motivó la recomendación>
@@ -163,18 +163,21 @@ gh issue create --repo intrale/platform \
 ## Referencia
 
 > Propuesto automáticamente por el agente \`po\` durante el análisis del issue #<origen>.
-> **No depende ni bloquea a #<origen>** — es una oportunidad de mejora independiente."
+> **Es una recomendación pendiente de aprobación humana** — no entra al pipeline automático hasta que un humano remueva el label \`needs-human\` y agregue \`recommendation:approved\` (o cierre con \`recommendation:rejected\`).
+> **No depende ni bloquea a #<origen>** — es una oportunidad independiente."
 ```
 
 **Reglas inquebrantables:**
 
 1. **Un issue por recomendación** — no consolidar múltiples en el mismo issue.
-2. **Título con prefijo `[po]`** + frase imperativa breve.
-3. **Heredar** labels `app:*` del issue origen cuando apliquen.
-4. **Prohibido** labels `blocks`, `depends-on`, `blocked:dependencies` ni metadatos de dependencia formal. La referencia es sólo contextual en el body.
-5. **Prioridad inicial siempre `priority:low`** — el propio PO re-prioriza cuando el issue entre a definicion (puedes priorizar alto desde el día uno si ya sabés que es crítico, pero por defecto es `low`).
-6. **Listar en `notas` del YAML** de tu resultado los issues creados (ej: `notas: "Oportunidades registradas: #2601, #2602"`).
-7. **Mencionar en el comentario del issue origen** los issues creados: `Issues de oportunidad registrados: #xxxx, #xxxx.`
+2. **Máximo 3 recomendaciones por issue analizado** (anti-explosión, issue #2653). Si detectás más de 3 oportunidades, priorizá las top 3 por impacto/valor y mencioná el resto en un párrafo "Otras oportunidades observadas" del comentario del issue origen, sin crear los issues.
+3. **Título con prefijo `[po]`** + frase imperativa breve.
+4. **Heredar** labels `app:*` del issue origen cuando apliquen.
+5. **OBLIGATORIO**: incluir labels `tipo:recomendacion` + `needs-human` para que el pulpo no procese el issue hasta aprobación humana.
+6. **Prohibido** labels `blocks`, `depends-on`, `blocked:dependencies`, `needs-definition` (este último porque sacaría a la recomendación del flujo de aprobación humana). La referencia es sólo contextual en el body.
+7. **Prioridad inicial siempre `priority:low`** — el propio PO re-prioriza cuando el issue se apruebe y entre a definicion (puedes priorizar alto desde el día uno si ya sabés que es crítico, pero por defecto es `low`).
+8. **Listar en `notas` del YAML** de tu resultado los issues creados (ej: `notas: "Recomendaciones pendientes de aprobación: #2601, #2602"`).
+9. **Mencionar en el comentario del issue origen** los issues creados: `Recomendaciones pendientes de aprobación humana: #xxxx, #xxxx.`
 
 **Cuándo aplicar**: cualquier apartado tipo "Mejoras de producto futuras", "Consideraciones para siguientes iteraciones", "Features adyacentes detectadas", "Optimizaciones de flujo" o equivalente.
 

--- a/.pipeline/roles/review.md
+++ b/.pipeline/roles/review.md
@@ -58,13 +58,13 @@ Si el linter pasó, esos puntos **están OK**. No los repitas ni los revalidés.
 
 ## Protocolo de oportunidades de mejora (aplicable en fase aprobacion)
 
-Durante tu code review, si identificás **refactors sugeridos, mejoras de cohesión, consolidaciones de duplicación, extracciones de utilidades u otros cambios de calidad semántica** que NO son bloqueantes del PR actual pero vale la pena registrar para iterar la calidad del codebase, **NO las dejes sólo como comentario en el PR**. Creá un issue independiente por cada una:
+Durante tu code review, si identificás **refactors sugeridos, mejoras de cohesión, consolidaciones de duplicación, extracciones de utilidades u otros cambios de calidad semántica** que NO son bloqueantes del PR actual pero vale la pena registrar para iterar la calidad del codebase, **NO las dejes sólo como comentario en el PR**. Creá un issue independiente por cada una, **marcado como recomendación que requiere aprobación humana** (issue #2653 — el pipeline NO procesa recomendaciones hasta que un humano las apruebe):
 
 ```bash
 export PATH="/c/Workspaces/gh-cli/bin:$PATH"
 gh issue create --repo intrale/platform \
   --title "[review] <descripción imperativa breve>" \
-  --label "enhancement,source:recommendation,priority:low,needs-definition<,area:backend|,area:pipeline|,area:infra|,app:client|,app:business|,app:delivery>" \
+  --label "enhancement,source:recommendation,tipo:recomendacion,needs-human,priority:low<,area:backend|,area:pipeline|,area:infra|,app:client|,app:business|,app:delivery>" \
   --body "## Contexto
 
 <qué observaste durante el code review / archivo:línea si aplica>
@@ -76,18 +76,21 @@ gh issue create --repo intrale/platform \
 ## Referencia
 
 > Propuesto automáticamente por el agente \`review\` durante la aprobación del issue #<origen>.
-> **No depende ni bloquea a #<origen>** — es una oportunidad de mejora independiente."
+> **Es una recomendación pendiente de aprobación humana** — no entra al pipeline automático hasta que un humano remueva el label \`needs-human\` y agregue \`recommendation:approved\` (o cierre con \`recommendation:rejected\`).
+> **No depende ni bloquea a #<origen>** — es una oportunidad independiente."
 ```
 
 **Reglas inquebrantables:**
 
 1. **Un issue por recomendación** — no consolidar múltiples en el mismo issue.
-2. **Título con prefijo `[review]`** + frase imperativa breve.
-3. **Heredar** labels `area:*` y `app:*` del issue origen cuando apliquen.
-4. **Prohibido** labels `blocks`, `depends-on`, `blocked:dependencies` ni metadatos de dependencia formal.
-5. **Prioridad inicial siempre `priority:low`** — son mejoras de calidad, no bloqueantes.
-6. **Listar en `notas` del YAML** de tu resultado los issues creados.
-7. **Mencionar en el comentario del PR/issue origen** los issues creados.
+2. **Máximo 3 recomendaciones por PR/issue revisado** (anti-explosión, issue #2653). Si detectás más de 3, priorizá las top 3 por impacto en calidad/mantenibilidad y mencioná el resto en el comentario del PR sin crear issues.
+3. **Título con prefijo `[review]`** + frase imperativa breve.
+4. **Heredar** labels `area:*` y `app:*` del issue origen cuando apliquen.
+5. **OBLIGATORIO**: incluir labels `tipo:recomendacion` + `needs-human` para que el pulpo no procese el issue hasta aprobación humana.
+6. **Prohibido** labels `blocks`, `depends-on`, `blocked:dependencies`, `needs-definition` (este último porque sacaría a la recomendación del flujo de aprobación humana).
+7. **Prioridad inicial siempre `priority:low`** — son mejoras de calidad, no bloqueantes.
+8. **Listar en `notas` del YAML** de tu resultado los issues creados.
+9. **Mencionar en el comentario del PR/issue origen** los issues creados, indicando que son recomendaciones pendientes de aprobación humana.
 
 **Cuándo aplicar**: "Refactors sugeridos", "Oportunidades de extracción/consolidación", "Mejoras de cohesión no bloqueantes", "Código duplicado detectado a consolidar a futuro".
 

--- a/.pipeline/roles/security.md
+++ b/.pipeline/roles/security.md
@@ -26,13 +26,13 @@ Sos el auditor de seguridad del proyecto Intrale.
 
 ## Protocolo de oportunidades de mejora (aplicable en TODAS las fases)
 
-Durante tu análisis (`analisis`, `verificacion`), si identificás **hardening adicional no crítico, mejoras de postura de seguridad, migraciones de dependencias con CVEs de severidad baja, o prácticas defensivas deseables** que NO deben frenar la aprobación del issue actual pero vale la pena registrar, **NO las dejes sólo como texto**. Creá un issue independiente por cada una:
+Durante tu análisis (`analisis`, `verificacion`), si identificás **hardening adicional no crítico, mejoras de postura de seguridad, migraciones de dependencias con CVEs de severidad baja, o prácticas defensivas deseables** que NO deben frenar la aprobación del issue actual pero vale la pena registrar, **NO las dejes sólo como texto**. Creá un issue independiente por cada una, **marcado como recomendación que requiere aprobación humana** (issue #2653 — el pipeline NO procesa recomendaciones hasta que un humano las apruebe):
 
 ```bash
 export PATH="/c/Workspaces/gh-cli/bin:$PATH"
 gh issue create --repo intrale/platform \
   --title "[security] <descripción imperativa breve>" \
-  --label "enhancement,source:recommendation,priority:low,needs-definition<,area:backend|,area:pipeline|,area:infra>" \
+  --label "enhancement,source:recommendation,tipo:recomendacion,needs-human,priority:low<,area:backend|,area:pipeline|,area:infra>" \
   --body "## Contexto de seguridad
 
 <qué observaste / qué motivó la recomendación>
@@ -44,18 +44,21 @@ gh issue create --repo intrale/platform \
 ## Referencia
 
 > Propuesto automáticamente por el agente \`security\` durante el análisis del issue #<origen>.
-> **No depende ni bloquea a #<origen>** — es una oportunidad de mejora independiente."
+> **Es una recomendación pendiente de aprobación humana** — no entra al pipeline automático hasta que un humano remueva el label \`needs-human\` y agregue \`recommendation:approved\` (o cierre con \`recommendation:rejected\`).
+> **No depende ni bloquea a #<origen>** — es una oportunidad independiente."
 ```
 
 **Reglas inquebrantables:**
 
 1. **Un issue por recomendación** — no consolidar múltiples en el mismo issue.
-2. **Título con prefijo `[security]`** + frase imperativa breve.
-3. **Heredar** labels `area:*` del issue origen.
-4. **Prohibido** labels `blocks`, `depends-on`, `blocked:dependencies` ni metadatos de dependencia formal.
-5. **Prioridad inicial** — usar `priority:low` para hardening no crítico. Si detectás una vulnerabilidad explotable (aunque sea en otra parte del código, no en el issue actual), usá `priority:high` o `priority:critical` y marcalo como defecto de seguridad en issue separado (no bloquea el origen pero sí requiere atención inmediata).
-6. **Listar en `notas` del YAML** de tu resultado los issues creados.
-7. **Mencionar en el comentario del issue origen** los issues creados.
+2. **Máximo 3 recomendaciones por issue analizado** (anti-explosión, issue #2653). Si detectás más de 3, priorizá las top 3 por riesgo/beneficio y listá el resto en el comentario del issue origen, sin crear los issues.
+3. **Título con prefijo `[security]`** + frase imperativa breve.
+4. **Heredar** labels `area:*` del issue origen.
+5. **OBLIGATORIO**: incluir labels `tipo:recomendacion` + `needs-human` para que el pulpo no procese el issue hasta aprobación humana. **Excepción**: vulnerabilidad explotable detectada (priority:high/critical) — sigue requiriendo aprobación humana, pero la prioridad alta hace que Leo la vea inmediatamente en el panel de recomendaciones del dashboard.
+6. **Prohibido** labels `blocks`, `depends-on`, `blocked:dependencies`, `needs-definition` (este último porque sacaría a la recomendación del flujo de aprobación humana).
+7. **Prioridad inicial** — usar `priority:low` para hardening no crítico. Si detectás una vulnerabilidad explotable (aunque sea en otra parte del código, no en el issue actual), usá `priority:high` o `priority:critical` y marcalo como defecto de seguridad en issue separado (no bloquea el origen pero sí requiere atención inmediata).
+8. **Listar en `notas` del YAML** de tu resultado los issues creados.
+9. **Mencionar en el comentario del issue origen** los issues creados, indicando que son recomendaciones pendientes de aprobación humana.
 
 **Cuándo aplicar**: "Hardening adicional", "Buenas prácticas defensivas futuras", "Migraciones de dependencias con CVEs low/medium", "Logging de auditoría a ampliar".
 

--- a/.pipeline/roles/ux.md
+++ b/.pipeline/roles/ux.md
@@ -190,13 +190,13 @@ del issue actual (salvo que sea un defecto grave de usabilidad).
 
 ## Protocolo de oportunidades de mejora (aplicable en TODAS las fases)
 
-Durante tu análisis en cualquier fase (`criterios`, `validacion`, `aprobacion`), si identificás **recomendaciones de mejora no bloqueantes** — ideas que NO deben frenar la aprobación del issue actual pero vale la pena investigar/implementar a futuro —, **NO las dejes sólo como texto en el comentario del issue origen**. Creá un issue independiente por cada una:
+Durante tu análisis en cualquier fase (`criterios`, `validacion`, `aprobacion`), si identificás **recomendaciones de mejora no bloqueantes** — ideas que NO deben frenar la aprobación del issue actual pero vale la pena investigar/implementar a futuro —, **NO las dejes sólo como texto en el comentario del issue origen**. Creá un issue independiente por cada una, **marcado como recomendación que requiere aprobación humana** (issue #2653 — el pipeline NO procesa recomendaciones hasta que un humano las apruebe):
 
 ```bash
 export PATH="/c/Workspaces/gh-cli/bin:$PATH"
 gh issue create --repo intrale/platform \
   --title "[ux] <descripción imperativa breve>" \
-  --label "enhancement,source:recommendation,priority:low,needs-definition<,app:client|,app:business|,app:delivery>" \
+  --label "enhancement,source:recommendation,tipo:recomendacion,needs-human,priority:low<,app:client|,app:business|,app:delivery>" \
   --body "## Contexto
 
 <qué observaste / qué motivó la recomendación>
@@ -208,18 +208,21 @@ gh issue create --repo intrale/platform \
 ## Referencia
 
 > Propuesto automáticamente por el agente \`ux\` durante el análisis del issue #<origen>.
-> **No depende ni bloquea a #<origen>** — es una oportunidad de mejora independiente."
+> **Es una recomendación pendiente de aprobación humana** — no entra al pipeline automático hasta que un humano remueva el label \`needs-human\` y agregue \`recommendation:approved\` (o cierre con \`recommendation:rejected\`).
+> **No depende ni bloquea a #<origen>** — es una oportunidad independiente."
 ```
 
 **Reglas inquebrantables:**
 
 1. **Un issue por recomendación** — no consolidar múltiples en el mismo issue.
-2. **Título con prefijo `[ux]`** + frase imperativa breve.
-3. **Heredar** labels `app:*` del issue origen cuando apliquen (si el origen tiene `app:business`, el nuevo issue también).
-4. **Prohibido** labels `blocks`, `depends-on`, `blocked:dependencies` ni metadatos de dependencia formal. La referencia es sólo contextual en el body.
-5. **Prioridad inicial siempre `priority:low`** — PO/planner re-prioriza cuando el issue entre a definicion.
-6. **Listar en `notas` del YAML** de tu resultado los issues creados (ej: `notas: "Oportunidades registradas: #2601, #2602"`).
-7. **Mencionar en el comentario del issue origen** los issues creados, con formato: `Issues de oportunidad registrados: #xxxx, #xxxx.`
+2. **Máximo 3 recomendaciones por issue analizado** (anti-explosión, issue #2653). Si detectás más de 3 oportunidades, priorizá las top 3 por impacto en la experiencia del usuario y mencioná el resto en un párrafo "Otras oportunidades observadas" del comentario del issue origen, sin crear los issues.
+3. **Título con prefijo `[ux]`** + frase imperativa breve.
+4. **Heredar** labels `app:*` del issue origen cuando apliquen (si el origen tiene `app:business`, el nuevo issue también).
+5. **OBLIGATORIO**: incluir labels `tipo:recomendacion` + `needs-human` para que el pulpo no procese el issue hasta aprobación humana.
+6. **Prohibido** labels `blocks`, `depends-on`, `blocked:dependencies`, `needs-definition` (este último porque sacaría a la recomendación del flujo de aprobación humana). La referencia es sólo contextual en el body.
+7. **Prioridad inicial siempre `priority:low`** — PO/planner re-prioriza cuando el issue se apruebe y entre a definicion.
+8. **Listar en `notas` del YAML** de tu resultado los issues creados (ej: `notas: "Recomendaciones pendientes de aprobación: #2601, #2602"`).
+9. **Mencionar en el comentario del issue origen** los issues creados, con formato: `Recomendaciones pendientes de aprobación humana: #xxxx, #xxxx.`
 
 **Cuándo aplicar**: cualquier apartado tipo "Oportunidades de mejora UX", "Consideraciones futuras", "Mejoras no bloqueantes" o equivalente que emitas durante tu análisis.
 

--- a/.pipeline/skills-deterministicos/__tests__/codeowners.test.js
+++ b/.pipeline/skills-deterministicos/__tests__/codeowners.test.js
@@ -1,0 +1,155 @@
+// Tests unitarios de .pipeline/skills-deterministicos/lib/codeowners.js (issue #2652)
+// Cubre el parser de CODEOWNERS y la detección de owners humanos sobre paths
+// modificados — núcleo del bloqueo de auto-merge para paths protegidos.
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const codeowners = require('../lib/codeowners');
+
+test('parseCodeowners — ignora comentarios y líneas vacías', () => {
+    const txt = [
+        '# CODEOWNERS sample',
+        '',
+        '/.pipeline/   @leitolarreta',
+        '   ',
+        '# protocolo',
+        '/.github/   @leitolarreta',
+    ].join('\n');
+    const rules = codeowners.parseCodeowners(txt);
+    assert.equal(rules.length, 2);
+    assert.deepEqual(rules[0], { pattern: '/.pipeline/', owners: ['@leitolarreta'] });
+    assert.deepEqual(rules[1], { pattern: '/.github/', owners: ['@leitolarreta'] });
+});
+
+test('parseCodeowners — soporta múltiples owners por regla', () => {
+    const rules = codeowners.parseCodeowners('docs/  @leitolarreta @bot-account');
+    assert.deepEqual(rules[0].owners, ['@leitolarreta', '@bot-account']);
+});
+
+test('matchPath — pattern de directorio anclado al root', () => {
+    const rules = codeowners.parseCodeowners('/.pipeline/   @leitolarreta');
+    assert.deepEqual(codeowners.matchPath(rules, '.pipeline/pulpo.js'), ['@leitolarreta']);
+    assert.deepEqual(codeowners.matchPath(rules, '.pipeline/desarrollo/dev/x'), ['@leitolarreta']);
+    assert.deepEqual(codeowners.matchPath(rules, 'docs/readme.md'), []);
+});
+
+test('matchPath — pattern dirOnly NO matchea archivo con mismo prefijo', () => {
+    const rules = codeowners.parseCodeowners('/.pipelinex/   @leitolarreta');
+    assert.deepEqual(codeowners.matchPath(rules, '.pipeline/pulpo.js'), []);
+});
+
+test('matchPath — last match gana (override)', () => {
+    const rules = codeowners.parseCodeowners([
+        '/.pipeline/   @leitolarreta',
+        '/.pipeline/docs/   @writer-team',
+    ].join('\n'));
+    assert.deepEqual(codeowners.matchPath(rules, '.pipeline/docs/x.md'), ['@writer-team']);
+    assert.deepEqual(codeowners.matchPath(rules, '.pipeline/pulpo.js'), ['@leitolarreta']);
+});
+
+test('matchPath — glob ** y *', () => {
+    const rules = codeowners.parseCodeowners([
+        '**/Dockerfile   @ops',
+        'src/*.js   @frontend',
+    ].join('\n'));
+    assert.deepEqual(codeowners.matchPath(rules, 'app/Dockerfile'), ['@ops']);
+    assert.deepEqual(codeowners.matchPath(rules, 'Dockerfile'), ['@ops']);
+    assert.deepEqual(codeowners.matchPath(rules, 'src/app.js'), ['@frontend']);
+    assert.deepEqual(codeowners.matchPath(rules, 'src/sub/app.js'), []);
+});
+
+test('matchPath — normaliza separador de Windows', () => {
+    const rules = codeowners.parseCodeowners('/.pipeline/   @leitolarreta');
+    assert.deepEqual(codeowners.matchPath(rules, '.pipeline\\pulpo.js'), ['@leitolarreta']);
+});
+
+test('resolveOwners — agrega owners únicos sobre múltiples paths', () => {
+    const rules = codeowners.parseCodeowners([
+        '/.pipeline/   @leitolarreta',
+        '/.github/   @leitolarreta',
+        'docs/   @writer-team',
+    ].join('\n'));
+    const owners = codeowners.resolveOwners(rules, [
+        '.pipeline/pulpo.js',
+        '.github/CODEOWNERS',
+        'docs/readme.md',
+        'app/util.kt',
+    ]);
+    assert.deepEqual(owners.sort(), ['@leitolarreta', '@writer-team']);
+});
+
+test('isHumanOwner — leitolarreta sí, otros no', () => {
+    assert.equal(codeowners.isHumanOwner('@leitolarreta'), true);
+    assert.equal(codeowners.isHumanOwner('@bot-account'), false);
+    assert.equal(codeowners.isHumanOwner('@writer-team'), false);
+});
+
+test('getHumanOwners — filtra solo humanos del set resuelto', () => {
+    const rules = codeowners.parseCodeowners([
+        '/.pipeline/   @leitolarreta',
+        'docs/   @writer-team',
+    ].join('\n'));
+    const humans = codeowners.getHumanOwners(rules, [
+        '.pipeline/pulpo.js',
+        'docs/readme.md',
+        'app/util.kt',
+    ]);
+    assert.deepEqual(humans, ['@leitolarreta']);
+});
+
+test('getHumanOwners — vacío si no hay matches humanos', () => {
+    const rules = codeowners.parseCodeowners('/.pipeline/   @leitolarreta');
+    assert.deepEqual(codeowners.getHumanOwners(rules, ['app/util.kt']), []);
+});
+
+test('loadCodeowners — lee .github/CODEOWNERS si existe', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'co-'));
+    try {
+        fs.mkdirSync(path.join(tmp, '.github'), { recursive: true });
+        fs.writeFileSync(
+            path.join(tmp, '.github', 'CODEOWNERS'),
+            '/.pipeline/   @leitolarreta\n',
+        );
+        const rules = codeowners.loadCodeowners(tmp);
+        assert.equal(rules.length, 1);
+        assert.equal(rules[0].owners[0], '@leitolarreta');
+    } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+    }
+});
+
+test('loadCodeowners — devuelve [] si no hay archivo', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'co-empty-'));
+    try {
+        const rules = codeowners.loadCodeowners(tmp);
+        assert.deepEqual(rules, []);
+    } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+    }
+});
+
+test('caso real Intrale — .pipeline/* y .github/* requieren @leitolarreta', () => {
+    const realCO = [
+        '# CODEOWNERS — Review obligatorio para componentes críticos del pipeline',
+        '/.pipeline/                 @leitolarreta',
+        '/.github/                   @leitolarreta',
+    ].join('\n');
+    const rules = codeowners.parseCodeowners(realCO);
+    assert.deepEqual(
+        codeowners.getHumanOwners(rules, ['.pipeline/skills-deterministicos/delivery.js']),
+        ['@leitolarreta'],
+    );
+    assert.deepEqual(
+        codeowners.getHumanOwners(rules, ['.github/CODEOWNERS']),
+        ['@leitolarreta'],
+    );
+    assert.deepEqual(
+        codeowners.getHumanOwners(rules, ['app/composeApp/src/util.kt']),
+        [],
+    );
+});

--- a/.pipeline/skills-deterministicos/__tests__/delivery.test.js
+++ b/.pipeline/skills-deterministicos/__tests__/delivery.test.js
@@ -134,3 +134,34 @@ test('QA_LABELS_OK — contiene exactamente passed y skipped', () => {
     assert.equal(delivery.QA_LABELS_OK.has('qa:passed'), true);
     assert.equal(delivery.QA_LABELS_OK.has('qa:skipped'), true);
 });
+
+// #2652 — CODEOWNERS humano: bloqueo de auto-merge cuando un PR toca paths
+// protegidos por un owner humano. Estos tests verifican el contrato público
+// (exports + integración con el módulo codeowners) sin invocar gh ni git.
+
+test('exporta getPRChangedPaths y applyNeedsHumanLabel (#2652)', () => {
+    assert.equal(typeof delivery.getPRChangedPaths, 'function');
+    assert.equal(typeof delivery.applyNeedsHumanLabel, 'function');
+});
+
+test('integración codeowners — paths del pipeline gatillan owner humano (#2652)', () => {
+    const codeowners = require('../lib/codeowners');
+    const ghDir = path.join(TMP, '.github');
+    fs.mkdirSync(ghDir, { recursive: true });
+    fs.writeFileSync(path.join(ghDir, 'CODEOWNERS'), [
+        '/.pipeline/   @leitolarreta',
+        '/.github/   @leitolarreta',
+    ].join('\n'));
+
+    const rules = codeowners.loadCodeowners(TMP);
+    assert.ok(rules.length >= 2, 'CODEOWNERS debe parsearse');
+
+    const human = codeowners.getHumanOwners(rules, [
+        '.pipeline/pulpo.js',
+        'docs/readme.md',
+    ]);
+    assert.deepEqual(human, ['@leitolarreta']);
+
+    const noHuman = codeowners.getHumanOwners(rules, ['app/composeApp/src/x.kt']);
+    assert.deepEqual(noHuman, []);
+});

--- a/.pipeline/skills-deterministicos/delivery.js
+++ b/.pipeline/skills-deterministicos/delivery.js
@@ -5,6 +5,7 @@ const fs = require('fs');
 const path = require('path');
 const trace = require('../lib/traceability');
 const git = require('./lib/git-ops');
+const codeowners = require('./lib/codeowners');
 
 const REPO_ROOT = process.env.PIPELINE_REPO_ROOT || process.env.CLAUDE_PROJECT_DIR || path.resolve(__dirname, '..', '..');
 const HOOKS_DIR = path.join(REPO_ROOT, '.claude', 'hooks');
@@ -132,6 +133,28 @@ function getPRLabels(prNumber) {
 
 function hasQaGate(labels) {
     return labels.some((l) => QA_LABELS_OK.has(l));
+}
+
+function getPRChangedPaths(prNumber) {
+    const r = git.runGh(['pr', 'view', String(prNumber), '--json', 'files'], { cwd: REPO_ROOT });
+    if (r.exit_code !== 0) return [];
+    try {
+        return (JSON.parse(r.stdout).files || []).map((f) => f.path);
+    } catch { return []; }
+}
+
+function applyNeedsHumanLabel(issue, prNumber, owners, repoRoot) {
+    const lbl = git.runGh(
+        ['issue', 'edit', String(issue), '--add-label', 'needs-human'],
+        { cwd: repoRoot, timeoutMs: 30 * 1000 }
+    );
+    const ownersList = owners.join(' ');
+    const body = `🛑 Merge bloqueado — este PR toca paths con CODEOWNERS humano (${ownersList}). Requiere review manual antes de mergear.`;
+    const cmt = git.runGh(
+        ['pr', 'comment', String(prNumber), '--body', body],
+        { cwd: repoRoot, timeoutMs: 30 * 1000 }
+    );
+    return { labelExitCode: lbl.exit_code, commentExitCode: cmt.exit_code };
 }
 
 function tmpFile(prefix, content) {
@@ -347,12 +370,31 @@ async function main() {
         const finalLabels = getPRLabels(prNumber);
         labelsApplied = Array.from(new Set([...labelsApplied, ...finalLabels]));
 
+        // #2652 — Detección de CODEOWNERS humano: si el PR toca paths protegidos
+        // por un owner humano (ej. @leitolarreta), NO mergear automáticamente.
+        // En su lugar: aplicar label `needs-human` al issue + comentar el PR
+        // explicitando los owners requeridos. Esto evita merges silenciosos
+        // sobre `.pipeline/` o `.github/` que requieren review manual.
+        const ownerRules = codeowners.loadCodeowners(REPO_ROOT);
+        const changedForOwners = getPRChangedPaths(prNumber);
+        const humanOwners = ownerRules.length && changedForOwners.length
+            ? codeowners.getHumanOwners(ownerRules, changedForOwners)
+            : [];
+        if (humanOwners.length) {
+            logAppend(`[delivery] CODEOWNERS humano detectado: ${humanOwners.join(' ')} — bloqueando auto-merge`);
+        }
+
         if (!args.autoMerge) {
             logAppend(`[delivery] auto-merge desactivado por flag — PR queda abierto`);
             motivo = `PR #${prNumber} creado/actualizado. Auto-merge desactivado.`;
         } else if (!hasQaGate(finalLabels)) {
             // Sin gate QA → no mergeamos ciegamente; el delivery termina OK pero deja el PR abierto.
             motivo = `PR #${prNumber} creado pero sin label qa:passed/qa:skipped — merge bloqueado.`;
+            logAppend(`[delivery] ${motivo}`);
+        } else if (humanOwners.length) {
+            applyNeedsHumanLabel(issue, prNumber, humanOwners, REPO_ROOT);
+            labelsApplied = Array.from(new Set([...labelsApplied, 'needs-human']));
+            motivo = `PR #${prNumber} requiere review humano de ${humanOwners.join(' ')} — merge bloqueado, label needs-human aplicado.`;
             logAppend(`[delivery] ${motivo}`);
         } else {
             const mergeRes = git.runGh([
@@ -448,6 +490,8 @@ module.exports = {
     fetchIssueTitle,
     findExistingPR,
     getPRLabels,
+    getPRChangedPaths,
+    applyNeedsHumanLabel,
     hasQaGate,
     QA_LABELS_OK,
 };

--- a/.pipeline/skills-deterministicos/lib/codeowners.js
+++ b/.pipeline/skills-deterministicos/lib/codeowners.js
@@ -1,0 +1,105 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const HUMAN_OWNERS = new Set(['@leitolarreta']);
+
+function parseCodeowners(content) {
+    const rules = [];
+    if (!content) return rules;
+    for (const rawLine of content.split(/\r?\n/)) {
+        const line = rawLine.replace(/#.*$/, '').trim();
+        if (!line) continue;
+        const tokens = line.split(/\s+/);
+        if (tokens.length < 2) continue;
+        const pattern = tokens[0];
+        const owners = tokens.slice(1).filter((t) => t.startsWith('@') || t.includes('/'));
+        if (!owners.length) continue;
+        rules.push({ pattern, owners });
+    }
+    return rules;
+}
+
+function loadCodeowners(repoRoot) {
+    const candidates = [
+        path.join(repoRoot, '.github', 'CODEOWNERS'),
+        path.join(repoRoot, 'CODEOWNERS'),
+        path.join(repoRoot, 'docs', 'CODEOWNERS'),
+    ];
+    for (const file of candidates) {
+        try {
+            if (fs.existsSync(file)) {
+                return parseCodeowners(fs.readFileSync(file, 'utf8'));
+            }
+        } catch {}
+    }
+    return [];
+}
+
+function patternToRegex(pattern) {
+    let p = pattern;
+    const anchorAtRoot = p.startsWith('/');
+    if (anchorAtRoot) p = p.slice(1);
+    const dirOnly = p.endsWith('/');
+    if (dirOnly) p = p.slice(0, -1);
+
+    const SD = '';
+    const SS = '';
+    const SQ = '';
+
+    const tokenized = p
+        .replace(/\*\*/g, SD)
+        .replace(/\*/g, SS)
+        .replace(/\?/g, SQ);
+
+    const escaped = tokenized.replace(/[.+^$|()[\]{}\\]/g, '\\$&');
+
+    let reBody = escaped
+        .replace(new RegExp(SD + '/', 'g'), '(?:.*/)?')
+        .replace(new RegExp('/' + SD, 'g'), '(?:/.*)?')
+        .replace(new RegExp(SD, 'g'), '.*')
+        .replace(new RegExp(SS, 'g'), '[^/]*')
+        .replace(new RegExp(SQ, 'g'), '[^/]');
+
+    const prefix = anchorAtRoot ? '^' : '^(?:.*/)?';
+    const suffix = '(?:/.*)?$';
+    return new RegExp(prefix + reBody + suffix);
+}
+
+function matchPath(rules, filePath) {
+    const norm = filePath.replace(/\\/g, '/').replace(/^\/+/, '');
+    let lastMatch = null;
+    for (const rule of rules) {
+        const re = patternToRegex(rule.pattern);
+        if (re.test(norm)) lastMatch = rule;
+    }
+    return lastMatch ? lastMatch.owners.slice() : [];
+}
+
+function resolveOwners(rules, paths) {
+    const all = new Set();
+    for (const p of paths) {
+        for (const o of matchPath(rules, p)) all.add(o);
+    }
+    return Array.from(all);
+}
+
+function isHumanOwner(owner) {
+    return HUMAN_OWNERS.has(owner);
+}
+
+function getHumanOwners(rules, paths) {
+    return resolveOwners(rules, paths).filter(isHumanOwner);
+}
+
+module.exports = {
+    HUMAN_OWNERS,
+    parseCodeowners,
+    loadCodeowners,
+    patternToRegex,
+    matchPath,
+    resolveOwners,
+    isHumanOwner,
+    getHumanOwners,
+};

--- a/.pipeline/tests/migrate-recomendaciones-legacy.test.js
+++ b/.pipeline/tests/migrate-recomendaciones-legacy.test.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const { isCandidate, TITLE_RE, AGENT_LABEL_RE } = require('../migrate-recomendaciones-legacy');
+
+test('isCandidate detecta por titulo [guru], [security], etc.', () => {
+    assert.strictEqual(isCandidate({ number: 1, title: '[guru] revisar X', labels: [] }), true);
+    assert.strictEqual(isCandidate({ number: 2, title: '[Security] CSRF en endpoint Y', labels: [] }), true);
+    assert.strictEqual(isCandidate({ number: 3, title: '[review] separar componente Z', labels: [] }), true);
+});
+
+test('isCandidate detecta por label agent:<rol>', () => {
+    assert.strictEqual(isCandidate({ number: 4, title: 'mejora UX flow login', labels: [{ name: 'agent:ux' }] }), true);
+    assert.strictEqual(isCandidate({ number: 5, title: 'PO sugiere flujo onboarding', labels: ['agent:po'] }), true);
+});
+
+test('isCandidate descarta si ya tiene tipo:recomendacion', () => {
+    assert.strictEqual(isCandidate({ number: 6, title: '[guru] X', labels: ['tipo:recomendacion'] }), false);
+});
+
+test('isCandidate descarta si ya está aprobado o rechazado', () => {
+    assert.strictEqual(isCandidate({ number: 7, title: '[ux] flow', labels: ['recommendation:approved'] }), false);
+    assert.strictEqual(isCandidate({ number: 8, title: '[ux] flow', labels: ['recommendation:rejected'] }), false);
+});
+
+test('isCandidate descarta issues normales sin marca de agente', () => {
+    assert.strictEqual(isCandidate({ number: 9, title: 'fix typo en login', labels: ['bug'] }), false);
+    assert.strictEqual(isCandidate({ number: 10, title: 'feature X', labels: [] }), false);
+});
+
+test('TITLE_RE acepta corchetes minúscula y mayúscula', () => {
+    assert.match('[guru] x', TITLE_RE);
+    assert.match('[GURU] x', TITLE_RE);
+    assert.doesNotMatch('guru x', TITLE_RE);
+    assert.doesNotMatch('[other] x', TITLE_RE);
+});
+
+test('AGENT_LABEL_RE matchea solo agent:<rol_valido>', () => {
+    assert.match('agent:guru', AGENT_LABEL_RE);
+    assert.match('agent:po', AGENT_LABEL_RE);
+    assert.doesNotMatch('agent:builder', AGENT_LABEL_RE);
+    assert.doesNotMatch('builder', AGENT_LABEL_RE);
+});

--- a/.pipeline/tests/recommendations.test.js
+++ b/.pipeline/tests/recommendations.test.js
@@ -1,0 +1,181 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const reco = require('../lib/recommendations');
+
+function fakeRunner(scripted) {
+    const calls = [];
+    const queue = scripted.slice();
+    const fn = (args) => {
+        calls.push(args);
+        const next = queue.shift();
+        if (!next) return { ok: false, stdout: '', stderr: 'no more responses', status: 1 };
+        return Object.assign({ ok: false, stdout: '', stderr: '', status: 0 }, next);
+    };
+    fn.calls = calls;
+    return fn;
+}
+
+test('parseIssues filtra los que ya estan approved o rejected', () => {
+    const raw = JSON.stringify([
+        { number: 1, title: '[guru] mejora caching', url: 'u1', labels: [{ name: 'tipo:recomendacion' }, { name: 'needs-human' }], createdAt: '2026-04-26T08:00:00Z' },
+        { number: 2, title: '[security] revisar JWT', url: 'u2', labels: [{ name: 'tipo:recomendacion' }, { name: 'recommendation:approved' }] },
+        { number: 3, title: '[ux] modal accesible', url: 'u3', labels: [{ name: 'tipo:recomendacion' }, { name: 'recommendation:rejected' }] },
+        { number: 4, title: 'No reco', url: 'u4', labels: [{ name: 'bug' }] },
+    ]);
+    const items = reco.parseIssues(raw);
+    assert.equal(items.length, 1);
+    assert.equal(items[0].number, 1);
+    assert.equal(items[0].sourceAgent, 'guru');
+});
+
+test('parseIssues detecta sourceAgent por titulo y por label agent:*', () => {
+    const raw = JSON.stringify([
+        { number: 10, title: '[security] foo', labels: [{ name: 'tipo:recomendacion' }] },
+        { number: 11, title: 'sin prefijo', labels: [{ name: 'tipo:recomendacion' }, { name: 'agent:review' }] },
+        { number: 12, title: 'sin nada', labels: [{ name: 'tipo:recomendacion' }] },
+    ]);
+    const items = reco.parseIssues(raw);
+    const map = Object.fromEntries(items.map(i => [i.number, i.sourceAgent]));
+    assert.equal(map[10], 'security');
+    assert.equal(map[11], 'review');
+    assert.equal(map[12], 'unknown');
+});
+
+test('parseIssues detecta fromIssue desde label from-issue:N', () => {
+    const raw = JSON.stringify([
+        { number: 20, title: '[po] x', labels: [{ name: 'tipo:recomendacion' }, { name: 'from-issue:1234' }] },
+        { number: 21, title: '[po] y', labels: [{ name: 'tipo:recomendacion' }] },
+    ]);
+    const items = reco.parseIssues(raw);
+    const m = Object.fromEntries(items.map(i => [i.number, i.fromIssue]));
+    assert.equal(m[20], 1234);
+    assert.equal(m[21], null);
+});
+
+test('parseIssues devuelve [] cuando el JSON es invalido', () => {
+    assert.deepEqual(reco.parseIssues('no es json'), []);
+    assert.deepEqual(reco.parseIssues('null'), []);
+    assert.deepEqual(reco.parseIssues('{}'), []);
+});
+
+test('refreshCache persiste cache exitoso', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'reco-'));
+    const cacheFile = path.join(tmp, 'cache.json');
+    try {
+        const ghRunner = fakeRunner([
+            { ok: true, stdout: JSON.stringify([
+                { number: 50, title: '[ux] x', url: 'u', labels: [{ name: 'tipo:recomendacion' }], createdAt: '2026-04-26T08:00:00Z' }
+            ]) }
+        ]);
+        const cache = await reco.refreshCache({ ghRunner, repo: 'test/repo', cacheFile });
+        assert.equal(cache.items.length, 1);
+        assert.equal(cache.items[0].number, 50);
+        assert.equal(cache.error, null);
+        assert.ok(cache.updatedAt > 0);
+        const persisted = JSON.parse(fs.readFileSync(cacheFile, 'utf8'));
+        assert.equal(persisted.items[0].number, 50);
+    } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+    }
+});
+
+test('refreshCache captura errores de gh sin tirar excepcion', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'reco-'));
+    try {
+        const ghRunner = fakeRunner([
+            { ok: false, stdout: '', stderr: 'gh: not authenticated\n', status: 4 }
+        ]);
+        const cache = await reco.refreshCache({ ghRunner, cacheFile: path.join(tmp, 'c.json') });
+        assert.equal(cache.items.length, 0);
+        assert.equal(cache.error, 'gh: not authenticated');
+    } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+    }
+});
+
+test('approve agrega label approved y remueve needs-human', () => {
+    const ghRunner = fakeRunner([
+        { ok: true },
+        { ok: true },
+    ]);
+    const r = reco.approve({ issue: 99, ghRunner, repo: 'test/repo' });
+    assert.equal(r.ok, true);
+    assert.equal(ghRunner.calls.length, 2);
+    assert.deepEqual(ghRunner.calls[0], ['issue', 'edit', '99', '--repo', 'test/repo', '--add-label', 'recommendation:approved']);
+    assert.deepEqual(ghRunner.calls[1], ['issue', 'edit', '99', '--repo', 'test/repo', '--remove-label', 'needs-human']);
+});
+
+test('approve falla limpio si no se puede agregar el label', () => {
+    const ghRunner = fakeRunner([{ ok: false, stderr: 'forbidden', status: 1 }]);
+    const r = reco.approve({ issue: 99, ghRunner, repo: 'test/repo' });
+    assert.equal(r.ok, false);
+    assert.match(r.msg, /No se pudo agregar label aprobado/);
+    assert.equal(ghRunner.calls.length, 1);
+});
+
+test('approve reporta aprobacion parcial si remueve falla', () => {
+    const ghRunner = fakeRunner([
+        { ok: true },
+        { ok: false, stderr: 'no permission', status: 1 },
+    ]);
+    const r = reco.approve({ issue: 99, ghRunner, repo: 'test/repo' });
+    assert.equal(r.ok, false);
+    assert.match(r.msg, /Aprobaci.n parcial/);
+});
+
+test('reject agrega label rejected y cierra issue (sin razon)', () => {
+    const ghRunner = fakeRunner([
+        { ok: true },
+        { ok: true },
+    ]);
+    const r = reco.reject({ issue: 77, ghRunner, repo: 'test/repo' });
+    assert.equal(r.ok, true);
+    assert.equal(ghRunner.calls.length, 2);
+    assert.deepEqual(ghRunner.calls[0], ['issue', 'edit', '77', '--repo', 'test/repo', '--add-label', 'recommendation:rejected']);
+    assert.deepEqual(ghRunner.calls[1], ['issue', 'close', '77', '--repo', 'test/repo', '--reason', 'not planned']);
+});
+
+test('reject incluye comentario si se pasa razon', () => {
+    const ghRunner = fakeRunner([
+        { ok: true },
+        { ok: true },
+    ]);
+    const r = reco.reject({ issue: 77, ghRunner, reason: '  no aplica al producto  ' });
+    assert.equal(r.ok, true);
+    const closeCall = ghRunner.calls[1];
+    assert.equal(closeCall[closeCall.length - 2], '--comment');
+    assert.match(closeCall[closeCall.length - 1], /no aplica al producto/);
+});
+
+test('reject falla si no se puede etiquetar', () => {
+    const ghRunner = fakeRunner([{ ok: false, stderr: 'rate limit', status: 1 }]);
+    const r = reco.reject({ issue: 77, ghRunner });
+    assert.equal(r.ok, false);
+    assert.match(r.msg, /No se pudo etiquetar rechazo/);
+});
+
+test('isFresh devuelve true solo dentro de la ventana TTL', () => {
+    const now = 1_000_000_000_000;
+    assert.equal(reco.isFresh({ updatedAt: now - 60_000 }, now), true);
+    assert.equal(reco.isFresh({ updatedAt: now - 6 * 60_000 }, now), false);
+    assert.equal(reco.isFresh({}, now), false);
+    assert.equal(reco.isFresh(null, now), false);
+});
+
+test('readCache devuelve estructura vacia cuando el archivo no existe', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'reco-'));
+    try {
+        const c = reco.readCache(path.join(tmp, 'no-existe.json'));
+        assert.deepEqual(c.items, []);
+        assert.equal(c.updatedAt, 0);
+        assert.equal(c.error, null);
+    } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+    }
+});


### PR DESCRIPTION
## Summary
- Roles guru/po/review/security/ux etiquetan recomendaciones con `tipo:recomendacion` + `needs-human`.
- Pulpo filtra esos issues en el intake (doble defensa: search + check explícito) hasta que tengan `recommendation:approved`.
- Dashboard tiene panel "Recomendaciones pendientes" con botones aprobar/rechazar y 3 endpoints API.
- Script `migrate-recomendaciones-legacy.js` para re-etiquetar issues abiertos preexistentes (dry-run por default, `--apply` ejecuta).
- 21 tests nuevos (14 recommendations + 7 migración), suite total 60/60 verde.

Closes #2653

## Test plan
- [x] `node --test .pipeline/tests/recommendations.test.js` → 14/14 verde
- [x] `node --test .pipeline/tests/migrate-recomendaciones-legacy.test.js` → 7/7 verde
- [x] Suite pipeline completa: 60/60 verde
- [x] qa:skipped (cambio puro de pipeline, sin impacto en UI de usuario)

🤖 Generated with [Claude Code](https://claude.com/claude-code)