### PR TITLE
fix(pipeline): endpoints del dashboard fallaban silenciosos por gh fallback incorrecto

### DIFF
--- a/.pipeline/dashboard-v2.js
+++ b/.pipeline/dashboard-v2.js
@@ -50,6 +50,11 @@ const COMPONENTS = [
 ];
 // Nota: dashboard no se incluye (no puede matarse a sí mismo)
 
+// gh CLI: el proceso del dashboard no necesariamente tiene gh en PATH.
+// Usamos un fallback hardcoded al binario en la instalación local.
+const GH_BIN_DEFAULT = 'C:/Workspaces/gh-cli/bin/gh';
+const GH_BIN = process.env.GH_BIN || process.env.GH_PATH || GH_BIN_DEFAULT;
+
 // --- Issue title/label cache (persisted to disk, refreshed via gh CLI) ---
 const TITLE_CACHE_FILE = path.join(PIPELINE, '.issue-title-cache.json');
 const TITLE_CACHE_TTL = 3600000; // 1 hour
@@ -66,7 +71,7 @@ function saveIssueTitleCache(cache) {
 }
 
 function fetchIssueTitles(issueIds, cache) {
-  const ghPath = process.env.GH_PATH || 'C:/Workspaces/gh-cli/bin/gh';
+  const ghPath = GH_BIN;
   // GraphQL batch: up to 50 issues per query
   const batches = [];
   for (let i = 0; i < issueIds.length; i += 50) batches.push(issueIds.slice(i, i + 50));
@@ -6801,7 +6806,7 @@ const server = http.createServer((req, res) => {
         res.end(JSON.stringify({ ok: false, msg: 'human-block lib no disponible: ' + e.message }));
         return;
       }
-      const ghBin = process.env.GH_BIN || process.env.GH_PATH || 'gh';
+      const ghBin = GH_BIN;
       const repo = 'intrale/platform';
       const { execFileSync } = require('child_process');
       const ghTry = (args) => {
@@ -6866,7 +6871,7 @@ const server = http.createServer((req, res) => {
     const targetLabel = action === 'prioritize' ? 'priority:critical' : 'priority:low';
     const otherLabels = ['priority:critical', 'priority:high', 'priority:medium', 'priority:low']
       .filter(l => l !== targetLabel);
-    const ghBin = process.env.GH_BIN || process.env.GH_PATH || 'gh';
+    const ghBin = GH_BIN;
     const repo = 'intrale/platform';
     const { execFileSync } = require('child_process');
     const ghTry = (args) => {


### PR DESCRIPTION
## Resumen

Los endpoints `/api/issue/:n/(prioritize|deprioritize)` (PR #2670) y `/api/needs-human/:n/(reactivate|dismiss)` (PR #2666) usaban como fallback `'gh'`. Como el proceso del dashboard se lanza sin `gh` en `PATH` y sin `GH_BIN`/`GH_PATH` exportadas, `execFileSync('gh', ...)` tiraba `ENOENT`. El helper `ghTry` lo capturaba en `catch {}` y retornaba `false` silenciosamente. Resultado: el toast decía "✓ priorizado" pero el label nunca se aplicaba en GitHub y la card no se reordenaba.

`fetchIssueTitles` (línea 69) ya tenía el fallback correcto hardcoded a `'C:/Workspaces/gh-cli/bin/gh'` — por eso ese código sí funcionaba. Unifiqué las 3 referencias bajo una constante `GH_BIN` al top-level del archivo.

## Cambios

```diff
+ const GH_BIN_DEFAULT = 'C:/Workspaces/gh-cli/bin/gh';
+ const GH_BIN = process.env.GH_BIN || process.env.GH_PATH || GH_BIN_DEFAULT;
```

- `fetchIssueTitles`: `process.env.GH_PATH || 'C:/...'` → `GH_BIN`
- Endpoint priority: `process.env.GH_BIN || process.env.GH_PATH || 'gh'` → `GH_BIN`
- Endpoint needs-human: igual

## Repro detectada por el usuario

1. Dashboard corriendo sin `GH_BIN`/`GH_PATH` en env
2. Click en ▼ Despriorizar #1952
3. Toast "▼ #1952 despriorizado" aparece (200 OK)
4. Label sigue siendo `priority:high` en GitHub
5. Card no se reordena al refrescar

Después del fix manual de #1952 (gh issue edit + cache update) la card baja al fondo correctamente.

## Plan de tests

- [x] `node --check` syntax OK
- [ ] Reiniciar dashboard y probar ▲/▼ en otra issue: label aplicado en GitHub + card reordenada
- [ ] Probar ▶ Reactivar y ✕ Desestimar en panel needs-human (mismo fix aplica)

🤖 Generado con [Claude Code](https://claude.ai/claude-code)