### PR TITLE
feat(pipeline): orden manual del Issue Tracker como única fuente de prioridad

### DIFF
--- a/.pipeline/dashboard-v2.js
+++ b/.pipeline/dashboard-v2.js
@@ -1679,10 +1679,12 @@ function generateHTML(state) {
     // syncWith pero por defensa) van al fondo.
     const manualPos = manualOrderIndex.has(String(issueNum)) ? manualOrderIndex.get(String(issueNum)) : 999999;
     const priority = -manualPos;
+    const posLabel = manualPos < 999999 ? `<span class="lc-pos" title="Posición en el orden manual (1 = más prioritario)">#${manualPos + 1}</span>` : '';
     const cardHTML = `<div class="lc-card ${laneCardCls}" data-issue="${issueNum}" data-lane="${lane}" data-status="${complete ? 'completed' : 'active'}" data-subfase="${currentFase}" data-search="${searchKey}" data-retrying-until="${isRetrying ? Number(data.retrying.retryingUntil) : ''}" title="${laneTitle}" aria-live="polite" draggable="${complete ? 'false' : 'true'}" ondragstart="onCardDragStart(event)" ondragover="onCardDragOver(event)" ondragleave="onCardDragLeave(event)" ondrop="onCardDrop(event)" ondragend="onCardDragEnd(event)">
       <div class="lc-card-main">
         <div class="lc-top">
           <div class="lc-top-left">
+            ${posLabel}
             <a class="lc-num" href="${GH(issueNum)}" target="_blank" title="Ver issue en GitHub" onclick="event.stopPropagation()">#${issueNum}</a>
             ${lcBlockIcons}${lcRetryingIcon}
           </div>
@@ -2308,9 +2310,12 @@ function generateHTML(state) {
             <button class="lc-prio-btn lc-prio-down" onclick="event.preventDefault();event.stopPropagation();issueMoveDown(${h.issue})" title="Bajar una posición">▼</button>
           </span>`
         : '';
+      const ahPos = manualOrderIndex.has(String(h.issue)) ? manualOrderIndex.get(String(h.issue)) : null;
+      const ahPosLabel = ahPos !== null ? `<span class="lc-pos" title="Posición en el orden manual (1 = más prioritario)">#${ahPos + 1}</span>` : '';
       return `<a href="${href}" target="_blank" class="ah-card ${statusCls}" title="${tip}">
         <span class="ah-avatar" style="background:${p.color}">${p.icon}</span>
         <span class="ah-skill">${p.name}</span>
+        ${ahPosLabel}
         <span class="ah-issue">#${h.issue}${title}</span>
         <span class="ah-fase">${h.fase}</span>
         <span class="ah-status">${statusIcon} ${statusLabel}</span>
@@ -3762,6 +3767,12 @@ a.skill-recent-item:hover{background:var(--bd2);color:var(--ac)}
 .lc-card-dragging{opacity:0.4;outline:1px dashed var(--ac,#6d8cff)}
 .lc-card.lc-drop-above{box-shadow:0 -3px 0 0 var(--ac,#6d8cff)}
 .lc-card.lc-drop-below{box-shadow:0 3px 0 0 var(--ac,#6d8cff)}
+.lc-pos{
+  display:inline-block;background:var(--sf2,#1a1f2e);color:var(--dim,#9aa6c2);
+  font-size:0.7em;font-weight:700;padding:1px 6px;border-radius:8px;
+  border:1px solid var(--bd,#2a3560);font-variant-numeric:tabular-nums;
+  margin-right:4px;line-height:1.4;
+}
 @keyframes prio-flash-ok-anim{
   0%{box-shadow:0 0 0 0 rgba(63,185,80,0.0);background:transparent}
   30%{box-shadow:0 0 0 3px rgba(63,185,80,0.45);background:rgba(63,185,80,0.10)}

--- a/.pipeline/dashboard-v2.js
+++ b/.pipeline/dashboard-v2.js
@@ -1035,6 +1035,20 @@ function generateHTML(state) {
 
   // KPIs
   const matrixEntries = Object.entries(state.issueMatrix);
+
+  // Orden manual del Issue Tracker: única fuente de prioridad. Issues nuevos
+  // (que aún no tienen entrada) se insertan al tope para que el usuario los vea.
+  let manualOrderState = { version: 1, order: [] };
+  try {
+    const issueOrder = require('./lib/issue-order');
+    manualOrderState = issueOrder.load();
+    const activeIssueNums = matrixEntries
+      .filter(([_, d]) => d.estadoActual)
+      .map(([n]) => String(n));
+    issueOrder.syncWith(manualOrderState, activeIssueNums);
+  } catch (e) {}
+  const manualOrderIndex = new Map(manualOrderState.order.map((n, i) => [String(n), i]));
+
   const activosList = matrixEntries.filter(([_, d]) => d.estadoActual);
   const activos = activosList.length;
   const totalIssues = matrixEntries.length;
@@ -1658,25 +1672,14 @@ function generateHTML(state) {
     const flagSpan = data.staleMin > 60 ? '<span class="lc-flag">🚩</span>' : '';
     // Data atributos para búsqueda client-side
     const searchKey = (issueNum + ' ' + (data.title || '')).toLowerCase().replace(/"/g, '&quot;');
-    // Prioridad para sort (opción B, matchea orden del pulpo):
-    //   Tier 1 (top)    — working: el agente que se está ejecutando
-    //   Tier 2          — pendiente lanzable: próximos según score del pulpo
-    //   Tier 3          — pendiente bloqueado: no lanzables hasta resolver deps
-    //   Tier 4 (fondo)  — stale / failed: hundidos, no son el próximo a lanzar
-    // Dentro de cada tier se desempata por score del pulpo (critical primero).
-    // El sort es `b.priority - a.priority` (desc) → mayor priority = más arriba.
-    const pulpoScore = calcPulpoScore(data.labels);
-    let priority;
-    if (working) {
-      priority = 20000 - pulpoScore;
-    } else if (isStale || hasRejection) {
-      priority = 500 - (data.staleMin || 0);
-    } else if (isBlocked) {
-      priority = 5000 - pulpoScore;
-    } else {
-      priority = 10000 - pulpoScore;
-    }
-    const cardHTML = `<div class="lc-card ${laneCardCls}" data-issue="${issueNum}" data-status="${complete ? 'completed' : 'active'}" data-subfase="${currentFase}" data-search="${searchKey}" data-retrying-until="${isRetrying ? Number(data.retrying.retryingUntil) : ''}" title="${laneTitle}" aria-live="polite">
+    // Prioridad para sort: orden manual del Issue Tracker es la única fuente.
+    // Position 0 = más prioritario; cuanto menor el index, más arriba en la lane.
+    // Sort es `b.priority - a.priority` (desc) → mayor priority = más arriba,
+    // así que invertimos el index. Issues sin entrada (no debería pasar tras
+    // syncWith pero por defensa) van al fondo.
+    const manualPos = manualOrderIndex.has(String(issueNum)) ? manualOrderIndex.get(String(issueNum)) : 999999;
+    const priority = -manualPos;
+    const cardHTML = `<div class="lc-card ${laneCardCls}" data-issue="${issueNum}" data-lane="${lane}" data-status="${complete ? 'completed' : 'active'}" data-subfase="${currentFase}" data-search="${searchKey}" data-retrying-until="${isRetrying ? Number(data.retrying.retryingUntil) : ''}" title="${laneTitle}" aria-live="polite" draggable="${complete ? 'false' : 'true'}" ondragstart="onCardDragStart(event)" ondragover="onCardDragOver(event)" ondragleave="onCardDragLeave(event)" ondrop="onCardDrop(event)" ondragend="onCardDragEnd(event)">
       <div class="lc-card-main">
         <div class="lc-top">
           <div class="lc-top-left">
@@ -1685,8 +1688,8 @@ function generateHTML(state) {
           </div>
           <div class="lc-top-right">
             <span class="lc-prio-actions">
-              <button class="lc-prio-btn lc-prio-up" onclick="event.stopPropagation();issuePrioritize(${issueNum})" title="Priorizar al máximo (priority:critical)">▲</button>
-              <button class="lc-prio-btn lc-prio-down" onclick="event.stopPropagation();issueDeprioritize(${issueNum})" title="Despriorizar al mínimo (priority:low)">▼</button>
+              <button class="lc-prio-btn lc-prio-up" onclick="event.stopPropagation();issueMoveUp(${issueNum})" title="Subir una posición">▲</button>
+              <button class="lc-prio-btn lc-prio-down" onclick="event.stopPropagation();issueMoveDown(${issueNum})" title="Bajar una posición">▼</button>
             </span>
             <span class="lc-elapsed ${laneElapsedCls}">${laneElapsedTxt}</span>
           </div>
@@ -2301,8 +2304,8 @@ function generateHTML(state) {
         : '';
       const prioActions = isRunning
         ? `<span class="ah-prio-actions">
-            <button class="lc-prio-btn lc-prio-up" onclick="event.preventDefault();event.stopPropagation();issuePrioritize(${h.issue})" title="Priorizar al máximo (priority:critical)">▲</button>
-            <button class="lc-prio-btn lc-prio-down" onclick="event.preventDefault();event.stopPropagation();issueDeprioritize(${h.issue})" title="Despriorizar al mínimo (priority:low)">▼</button>
+            <button class="lc-prio-btn lc-prio-up" onclick="event.preventDefault();event.stopPropagation();issueMoveUp(${h.issue})" title="Subir una posición">▲</button>
+            <button class="lc-prio-btn lc-prio-down" onclick="event.preventDefault();event.stopPropagation();issueMoveDown(${h.issue})" title="Bajar una posición">▼</button>
           </span>`
         : '';
       return `<a href="${href}" target="_blank" class="ah-card ${statusCls}" title="${tip}">
@@ -3754,6 +3757,11 @@ a.skill-recent-item:hover{background:var(--bd2);color:var(--ac)}
 .lc-prio-btn:disabled{opacity:0.4;cursor:wait}
 .lc-prio-up:hover{border-color:#3fb950;color:#3fb950}
 .lc-prio-down:hover{border-color:#f85149;color:#f85149}
+.lc-card[draggable="true"]{cursor:grab}
+.lc-card[draggable="true"]:active{cursor:grabbing}
+.lc-card-dragging{opacity:0.4;outline:1px dashed var(--ac,#6d8cff)}
+.lc-card.lc-drop-above{box-shadow:0 -3px 0 0 var(--ac,#6d8cff)}
+.lc-card.lc-drop-below{box-shadow:0 3px 0 0 var(--ac,#6d8cff)}
 @keyframes prio-flash-ok-anim{
   0%{box-shadow:0 0 0 0 rgba(63,185,80,0.0);background:transparent}
   30%{box-shadow:0 0 0 3px rgba(63,185,80,0.45);background:rgba(63,185,80,0.10)}
@@ -5051,7 +5059,7 @@ function _prioCallApi(issueNum, action) {
     .then(r => r.json());
 }
 function _prioFindButtons(issueNum, action) {
-  const fnName = action === 'prioritize' ? 'issuePrioritize' : 'issueDeprioritize';
+  const fnName = (action === 'move-up' || action === 'up') ? 'issueMoveUp' : 'issueMoveDown';
   return Array.from(document.querySelectorAll('button.lc-prio-btn'))
     .filter(b => (b.getAttribute('onclick') || '').includes(fnName + '(' + issueNum + ')'));
 }
@@ -5094,44 +5102,112 @@ function showToast(msg, type) {
     setTimeout(() => t.remove(), 250);
   }, 2200);
 }
-async function issuePrioritize(issueNum) {
-  if (!confirm('Priorizar #' + issueNum + ' al máximo (priority:critical)?')) return;
-  _prioSetLoading(issueNum, 'prioritize', true);
+async function _issueMove(issueNum, direction) {
+  const action = direction === 'up' ? 'move-up' : 'move-down';
+  const arrow = direction === 'up' ? '▲' : '▼';
+  _prioSetLoading(issueNum, action, true);
   try {
-    const j = await _prioCallApi(issueNum, 'prioritize');
+    const r = await fetch('/api/issue/' + issueNum + '/' + action, { method: 'POST' });
+    const j = await r.json();
     if (j.ok) {
       _prioFlashCards(issueNum, true);
-      showToast('▲ #' + issueNum + ' priorizado (priority:critical)', 'ok');
-      setTimeout(() => location.reload(), 700);
+      showToast(arrow + ' #' + issueNum + ' ' + (j.msg || 'movido'), 'ok');
+      setTimeout(() => location.reload(), 500);
     } else {
-      _prioSetLoading(issueNum, 'prioritize', false);
-      _prioFlashCards(issueNum, false);
-      showToast('Error priorizando #' + issueNum + ': ' + (j.msg || 'desconocido'), 'err');
+      _prioSetLoading(issueNum, action, false);
+      if (j.msg === 'already-top' || j.msg === 'already-bottom') {
+        showToast('#' + issueNum + ' ya está en el ' + (j.msg === 'already-top' ? 'tope' : 'fondo'), 'info');
+      } else {
+        _prioFlashCards(issueNum, false);
+        showToast('Error: ' + (j.msg || 'desconocido'), 'err');
+      }
     }
   } catch (e) {
-    _prioSetLoading(issueNum, 'prioritize', false);
+    _prioSetLoading(issueNum, action, false);
     _prioFlashCards(issueNum, false);
-    showToast('Error priorizando #' + issueNum + ': ' + e.message, 'err');
+    showToast('Error moviendo #' + issueNum + ': ' + e.message, 'err');
   }
 }
-async function issueDeprioritize(issueNum) {
-  if (!confirm('Despriorizar #' + issueNum + ' al mínimo (priority:low)?')) return;
-  _prioSetLoading(issueNum, 'deprioritize', true);
+function issueMoveUp(issueNum) { return _issueMove(issueNum, 'up'); }
+function issueMoveDown(issueNum) { return _issueMove(issueNum, 'down'); }
+
+// Drag-and-drop nativo HTML5 sobre las cards del Issue Tracker.
+// Solo dentro de la misma lane: la lane se determina por estado del filesystem,
+// no por decisión del usuario.
+let _draggedCard = null;
+let _draggedLane = null;
+function onCardDragStart(e) {
+  const card = e.currentTarget;
+  if (card.getAttribute('draggable') === 'false') { e.preventDefault(); return; }
+  _draggedCard = card;
+  _draggedLane = card.dataset.lane;
+  card.classList.add('lc-card-dragging');
   try {
-    const j = await _prioCallApi(issueNum, 'deprioritize');
+    e.dataTransfer.effectAllowed = 'move';
+    e.dataTransfer.setData('text/plain', card.dataset.issue);
+  } catch (err) {}
+}
+function onCardDragOver(e) {
+  if (!_draggedCard) return;
+  const card = e.currentTarget;
+  if (card === _draggedCard) return;
+  if (card.dataset.lane !== _draggedLane) return; // solo dentro de la misma lane
+  e.preventDefault();
+  e.dataTransfer.dropEffect = 'move';
+  // Indicador visual: línea arriba o abajo según posición del cursor
+  const rect = card.getBoundingClientRect();
+  const isAbove = (e.clientY - rect.top) < rect.height / 2;
+  card.classList.toggle('lc-drop-above', isAbove);
+  card.classList.toggle('lc-drop-below', !isAbove);
+}
+function onCardDragLeave(e) {
+  e.currentTarget.classList.remove('lc-drop-above', 'lc-drop-below');
+}
+function onCardDrop(e) {
+  if (!_draggedCard) return;
+  const card = e.currentTarget;
+  if (card === _draggedCard) return;
+  if (card.dataset.lane !== _draggedLane) return;
+  e.preventDefault();
+  const rect = card.getBoundingClientRect();
+  const isAbove = (e.clientY - rect.top) < rect.height / 2;
+  card.classList.remove('lc-drop-above', 'lc-drop-below');
+  // Reorder DOM optimista: insertar la draggedCard arriba o abajo del target
+  const parent = card.parentNode;
+  if (isAbove) parent.insertBefore(_draggedCard, card);
+  else parent.insertBefore(_draggedCard, card.nextSibling);
+  // Mandar al server el orden completo de TODAS las cards activas (todas las lanes)
+  _persistDragOrder();
+}
+function onCardDragEnd(e) {
+  if (_draggedCard) _draggedCard.classList.remove('lc-card-dragging');
+  document.querySelectorAll('.lc-drop-above, .lc-drop-below').forEach(c => {
+    c.classList.remove('lc-drop-above', 'lc-drop-below');
+  });
+  _draggedCard = null;
+  _draggedLane = null;
+}
+async function _persistDragOrder() {
+  // Recolectar el orden actual de TODAS las cards activas (ordenadas como están
+  // en el DOM, lane por lane, top→bottom). El server hace setOrder con esto.
+  const allCards = Array.from(document.querySelectorAll('.lc-card[data-status="active"]'));
+  const order = allCards.map(c => c.dataset.issue);
+  try {
+    const r = await fetch('/api/issues/reorder', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ order })
+    });
+    const j = await r.json();
     if (j.ok) {
-      _prioFlashCards(issueNum, true);
-      showToast('▼ #' + issueNum + ' despriorizado (priority:low)', 'ok');
-      setTimeout(() => location.reload(), 700);
+      showToast('✓ Orden actualizado (' + order.length + ' issues)', 'ok');
     } else {
-      _prioSetLoading(issueNum, 'deprioritize', false);
-      _prioFlashCards(issueNum, false);
-      showToast('Error despriorizando #' + issueNum + ': ' + (j.msg || 'desconocido'), 'err');
+      showToast('Error guardando orden: ' + (j.msg || 'desconocido'), 'err');
+      setTimeout(() => location.reload(), 600);
     }
   } catch (e) {
-    _prioSetLoading(issueNum, 'deprioritize', false);
-    _prioFlashCards(issueNum, false);
-    showToast('Error despriorizando #' + issueNum + ': ' + e.message, 'err');
+    showToast('Error guardando orden: ' + e.message, 'err');
+    setTimeout(() => location.reload(), 600);
   }
 }
 
@@ -6863,49 +6939,60 @@ const server = http.createServer((req, res) => {
     return;
   }
 
-  // API issue priority quick actions (cards de Issue Tracker y Equipo en ejecución)
-  const priorityMatch = req.url && req.url.match(/^\/api\/issue\/(\d+)\/(prioritize|deprioritize)$/);
-  if (priorityMatch && req.method === 'POST') {
-    const issueNum = Number(priorityMatch[1]);
-    const action = priorityMatch[2];
-    const targetLabel = action === 'prioritize' ? 'priority:critical' : 'priority:low';
-    const otherLabels = ['priority:critical', 'priority:high', 'priority:medium', 'priority:low']
-      .filter(l => l !== targetLabel);
-    const ghBin = GH_BIN;
-    const repo = 'intrale/platform';
-    const { execFileSync } = require('child_process');
-    const ghTry = (args) => {
-      try {
-        execFileSync(ghBin, args, { stdio: 'ignore', timeout: 15000 });
-        return true;
-      } catch { return false; }
-    };
-    for (const l of otherLabels) {
-      ghTry(['issue', 'edit', String(issueNum), '--repo', repo, '--remove-label', l]);
-    }
-    const added = ghTry(['issue', 'edit', String(issueNum), '--repo', repo, '--add-label', targetLabel]);
-    if (!added) {
-      res.writeHead(500, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ ok: false, msg: `No se pudo agregar label ${targetLabel}` }));
+  // API orden manual de issues (drag-drop + botones ▲/▼ del Issue Tracker)
+  const moveMatch = req.url && req.url.match(/^\/api\/issue\/(\d+)\/(move-up|move-down)$/);
+  if (moveMatch && req.method === 'POST') {
+    const issueNum = String(moveMatch[1]);
+    const action = moveMatch[2];
+    let issueOrder;
+    try { issueOrder = require('./lib/issue-order'); }
+    catch (e) {
+      res.writeHead(503, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ok: false, msg: 'issue-order lib no disponible: ' + e.message }));
       return;
     }
-    // Invalidar/actualizar entrada del title-cache para que el próximo render
-    // ordene la card por la nueva prioridad sin esperar al TTL de 1h.
-    try {
-      const cache = loadIssueTitleCache();
-      const key = String(issueNum);
-      if (cache[key]) {
-        const old = Array.isArray(cache[key].labels) ? cache[key].labels : [];
-        const filtered = old.filter(l => !/^priority:/.test(l));
-        filtered.push(targetLabel);
-        cache[key].labels = filtered;
-        cache[key].fetchedAt = Date.now();
-        saveIssueTitleCache(cache);
+    const state = issueOrder.load();
+    const result = action === 'move-up'
+      ? issueOrder.moveUp(state, issueNum)
+      : issueOrder.moveDown(state, issueNum);
+    log(`order: ${action} #${issueNum} → ${result.ok ? `${result.from}→${result.to}` : result.reason}`);
+    res.writeHead(result.ok ? 200 : 400, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(result.ok
+      ? { ok: true, msg: `Issue #${issueNum} ${action === 'move-up' ? 'subió' : 'bajó'} a posición ${result.to + 1}`, ...result }
+      : { ok: false, msg: result.reason }));
+    return;
+  }
+
+  if (req.url === '/api/issues/reorder' && req.method === 'POST') {
+    let body = '';
+    req.on('data', c => { body += c; if (body.length > 256 * 1024) req.destroy(); });
+    req.on('end', () => {
+      let payload;
+      try { payload = body ? JSON.parse(body) : {}; }
+      catch (e) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ ok: false, msg: 'JSON inválido: ' + e.message }));
+        return;
       }
-    } catch (e) { log(`priority: cache update fallido para #${issueNum}: ${e.message}`); }
-    log(`priority: ${action} #${issueNum} → ${targetLabel}`);
-    res.writeHead(200, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify({ ok: true, msg: `Issue #${issueNum} ${action === 'prioritize' ? 'priorizado' : 'despriorizado'}`, label: targetLabel }));
+      const order = Array.isArray(payload.order) ? payload.order : null;
+      if (!order) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ ok: false, msg: 'Falta payload.order (array de issue numbers)' }));
+        return;
+      }
+      let issueOrder;
+      try { issueOrder = require('./lib/issue-order'); }
+      catch (e) {
+        res.writeHead(503, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ ok: false, msg: 'issue-order lib no disponible: ' + e.message }));
+        return;
+      }
+      const state = issueOrder.load();
+      issueOrder.setOrder(state, order);
+      log(`order: reorder via drag-drop (${order.length} issues, head=${order.slice(0,3).join(',')})`);
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ok: true, msg: `Orden actualizado (${order.length} issues)`, count: order.length }));
+    });
     return;
   }
 

--- a/.pipeline/lib/__tests__/issue-order.test.js
+++ b/.pipeline/lib/__tests__/issue-order.test.js
@@ -1,0 +1,191 @@
+// Tests para .pipeline/lib/issue-order.js — orden manual del Issue Tracker
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const lib = require('../issue-order');
+
+function tmpFile() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'issue-order-'));
+    return path.join(dir, 'order.json');
+}
+
+test('load sin archivo devuelve estado vacío', () => {
+    const f = tmpFile();
+    const s = lib.load(f);
+    assert.equal(s.version, lib.CURRENT_VERSION);
+    assert.deepEqual(s.order, []);
+});
+
+test('save y load son round-trip', () => {
+    const f = tmpFile();
+    const s = { version: 1, order: ['1952', '2510', '2521'] };
+    lib.save(s, f);
+    const loaded = lib.load(f);
+    assert.deepEqual(loaded.order, ['1952', '2510', '2521']);
+});
+
+test('load coerce a strings cuando el JSON guardó números', () => {
+    const f = tmpFile();
+    fs.writeFileSync(f, JSON.stringify({ version: 1, order: [1952, 2510] }));
+    const s = lib.load(f);
+    assert.deepEqual(s.order, ['1952', '2510']);
+});
+
+test('load tolera JSON inválido y devuelve vacío', () => {
+    const f = tmpFile();
+    fs.writeFileSync(f, '{invalid json');
+    const s = lib.load(f);
+    assert.deepEqual(s.order, []);
+});
+
+test('orderOf devuelve el index o null', () => {
+    const s = { version: 1, order: ['1', '2', '3'] };
+    assert.equal(lib.orderOf(s, '1'), 0);
+    assert.equal(lib.orderOf(s, '3'), 2);
+    assert.equal(lib.orderOf(s, 1), 0); // coerce
+    assert.equal(lib.orderOf(s, '99'), null);
+});
+
+test('moveUp swap con el de arriba y persiste', () => {
+    const f = tmpFile();
+    const s = { version: 1, order: ['a', 'b', 'c', 'd'] };
+    const r = lib.moveUp(s, 'c', f);
+    assert.equal(r.ok, true);
+    assert.equal(r.from, 2);
+    assert.equal(r.to, 1);
+    assert.deepEqual(s.order, ['a', 'c', 'b', 'd']);
+    assert.deepEqual(lib.load(f).order, ['a', 'c', 'b', 'd']);
+});
+
+test('moveUp en el tope no hace nada', () => {
+    const s = { version: 1, order: ['a', 'b', 'c'] };
+    const r = lib.moveUp(s, 'a', tmpFile());
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, 'already-top');
+    assert.deepEqual(s.order, ['a', 'b', 'c']);
+});
+
+test('moveUp de issue inexistente devuelve not-found', () => {
+    const s = { version: 1, order: ['a', 'b'] };
+    const r = lib.moveUp(s, 'zzz', tmpFile());
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, 'not-found');
+});
+
+test('moveDown swap con el de abajo y persiste', () => {
+    const f = tmpFile();
+    const s = { version: 1, order: ['a', 'b', 'c', 'd'] };
+    const r = lib.moveDown(s, 'b', f);
+    assert.equal(r.ok, true);
+    assert.equal(r.from, 1);
+    assert.equal(r.to, 2);
+    assert.deepEqual(s.order, ['a', 'c', 'b', 'd']);
+    assert.deepEqual(lib.load(f).order, ['a', 'c', 'b', 'd']);
+});
+
+test('moveDown en el fondo no hace nada', () => {
+    const s = { version: 1, order: ['a', 'b', 'c'] };
+    const r = lib.moveDown(s, 'c', tmpFile());
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, 'already-bottom');
+});
+
+test('setOrder reemplaza la lista respetando el orden recibido', () => {
+    const f = tmpFile();
+    const s = { version: 1, order: ['a', 'b', 'c', 'd'] };
+    lib.setOrder(s, ['c', 'a', 'b', 'd'], f);
+    assert.deepEqual(s.order, ['c', 'a', 'b', 'd']);
+    assert.deepEqual(lib.load(f).order, ['c', 'a', 'b', 'd']);
+});
+
+test('setOrder preserva al final issues no incluidos en newOrder', () => {
+    const s = { version: 1, order: ['a', 'b', 'c', 'd'] };
+    lib.setOrder(s, ['c', 'a'], tmpFile());
+    // c y a primero, luego b y d en orden original
+    assert.deepEqual(s.order, ['c', 'a', 'b', 'd']);
+});
+
+test('insertNew agrega al tope (position 0)', () => {
+    const f = tmpFile();
+    const s = { version: 1, order: ['a', 'b'] };
+    lib.insertNew(s, 'c', f);
+    assert.deepEqual(s.order, ['c', 'a', 'b']);
+    assert.equal(lib.orderOf(s, 'c'), 0);
+});
+
+test('insertNew de issue ya existente no duplica', () => {
+    const s = { version: 1, order: ['a', 'b'] };
+    const r = lib.insertNew(s, 'a', tmpFile());
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, 'already-exists');
+    assert.deepEqual(s.order, ['a', 'b']);
+});
+
+test('removeIssue saca el issue y compacta', () => {
+    const f = tmpFile();
+    const s = { version: 1, order: ['a', 'b', 'c'] };
+    lib.removeIssue(s, 'b', f);
+    assert.deepEqual(s.order, ['a', 'c']);
+    assert.deepEqual(lib.load(f).order, ['a', 'c']);
+});
+
+test('removeIssue idempotente: issue inexistente devuelve not-found sin romper', () => {
+    const s = { version: 1, order: ['a', 'b'] };
+    const r = lib.removeIssue(s, 'zzz', tmpFile());
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, 'not-found');
+    assert.deepEqual(s.order, ['a', 'b']);
+});
+
+test('syncWith inserta issues nuevos al tope (en orden de aparición)', () => {
+    const f = tmpFile();
+    const s = { version: 1, order: ['x', 'y'] };
+    const r = lib.syncWith(s, ['x', 'y', 'a', 'b'], f);
+    assert.equal(r.ok, true);
+    assert.deepEqual(r.added, ['a', 'b']);
+    // Los nuevos al tope, en el orden recibido
+    assert.deepEqual(s.order, ['a', 'b', 'x', 'y']);
+});
+
+test('syncWith no duplica issues que ya existen', () => {
+    const s = { version: 1, order: ['a', 'b', 'c'] };
+    const r = lib.syncWith(s, ['a', 'b', 'c'], tmpFile());
+    assert.deepEqual(r.added, []);
+    assert.deepEqual(s.order, ['a', 'b', 'c']);
+});
+
+test('syncWith preserva issues huérfanos (en state pero no en current)', () => {
+    const s = { version: 1, order: ['a', 'b', 'c'] };
+    lib.syncWith(s, ['a'], tmpFile());
+    // c y b no están en current pero NO se borran (podrían reabrirse)
+    assert.deepEqual(s.order, ['a', 'b', 'c']);
+});
+
+test('syncWith mezcla nuevos al tope y huérfanos preservados al final', () => {
+    const s = { version: 1, order: ['x', 'y'] };
+    lib.syncWith(s, ['z', 'x'], tmpFile());
+    // z es nuevo (al tope), x preserva su posición, y queda al final
+    assert.deepEqual(s.order, ['z', 'x', 'y']);
+});
+
+test('flujo completo: insert nuevo → moveDown → setOrder via drag', () => {
+    const f = tmpFile();
+    const s = lib.load(f);
+    lib.insertNew(s, '100', f);
+    lib.insertNew(s, '101', f);
+    lib.insertNew(s, '102', f);
+    // tope: 102, 101, 100
+    assert.deepEqual(s.order, ['102', '101', '100']);
+    lib.moveDown(s, '102', f);
+    assert.deepEqual(s.order, ['101', '102', '100']);
+    // Drag: usuario arrastra 100 al tope
+    lib.setOrder(s, ['100', '101', '102'], f);
+    assert.deepEqual(s.order, ['100', '101', '102']);
+    // Persistido
+    assert.deepEqual(lib.load(f).order, ['100', '101', '102']);
+});

--- a/.pipeline/lib/issue-order.js
+++ b/.pipeline/lib/issue-order.js
@@ -1,0 +1,145 @@
+// Orden manual de issues en el Issue Tracker del dashboard.
+//
+// Sustituye al sistema de labels priority:critical/high/medium/low + feature_priority
+// como fuente única de orden. El usuario mueve issues vía drag-drop o botones ▲/▼ en
+// el dashboard; el orden se persiste acá y lo respetan tanto el render del dashboard
+// como el sortByPriority del pulpo.
+//
+// Modelo: array ordenado de issue numbers (como strings). El index = position.
+//   { "version": 1, "order": ["1952", "2510", "2521", ...] }
+//
+// Reglas:
+//   - position 0 = más prioritario
+//   - issue desconocido (no en el array) cuando se consulta orderOf → null
+//     (consumidores deben tratarlo como "agregalo al final" o llamar insertNew)
+//   - insertNew agrega al tope (position 0) — issues nuevos van arriba para que el
+//     usuario los vea y decida qué hacer con ellos.
+//
+// Operaciones soportadas: load, save, orderOf, moveUp, moveDown, setOrder,
+// insertNew, removeIssue.
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const PIPELINE_DIR = path.join(REPO_ROOT, '.pipeline');
+const ORDER_FILE = path.join(PIPELINE_DIR, 'issue-manual-order.json');
+
+const CURRENT_VERSION = 1;
+
+function emptyState() {
+    return { version: CURRENT_VERSION, order: [] };
+}
+
+function load(orderFile = ORDER_FILE) {
+    try {
+        const raw = fs.readFileSync(orderFile, 'utf8');
+        const parsed = JSON.parse(raw);
+        if (!parsed || typeof parsed !== 'object') return emptyState();
+        const order = Array.isArray(parsed.order) ? parsed.order.map(String) : [];
+        return { version: CURRENT_VERSION, order };
+    } catch {
+        return emptyState();
+    }
+}
+
+function save(state, orderFile = ORDER_FILE) {
+    try {
+        const safe = {
+            version: CURRENT_VERSION,
+            order: Array.isArray(state.order) ? state.order.map(String) : [],
+        };
+        fs.writeFileSync(orderFile, JSON.stringify(safe, null, 2), 'utf8');
+        return true;
+    } catch { return false; }
+}
+
+function orderOf(state, issue) {
+    const idx = state.order.indexOf(String(issue));
+    return idx === -1 ? null : idx;
+}
+
+// Mueve un issue una posición hacia arriba (más prioritario). Si ya está en el tope
+// o no existe, no-op.
+function moveUp(state, issue, orderFile = ORDER_FILE) {
+    const num = String(issue);
+    const idx = state.order.indexOf(num);
+    if (idx <= 0) return { ok: false, reason: idx === -1 ? 'not-found' : 'already-top' };
+    [state.order[idx - 1], state.order[idx]] = [state.order[idx], state.order[idx - 1]];
+    save(state, orderFile);
+    return { ok: true, from: idx, to: idx - 1 };
+}
+
+// Mueve un issue una posición hacia abajo (menos prioritario). Si ya está en el fondo
+// o no existe, no-op.
+function moveDown(state, issue, orderFile = ORDER_FILE) {
+    const num = String(issue);
+    const idx = state.order.indexOf(num);
+    if (idx === -1) return { ok: false, reason: 'not-found' };
+    if (idx >= state.order.length - 1) return { ok: false, reason: 'already-bottom' };
+    [state.order[idx], state.order[idx + 1]] = [state.order[idx + 1], state.order[idx]];
+    save(state, orderFile);
+    return { ok: true, from: idx, to: idx + 1 };
+}
+
+// Reemplaza la lista entera respetando el array recibido. Cualquier issue conocido
+// que no aparezca en `newOrder` se preserva al final (no se pierden referencias).
+function setOrder(state, newOrder, orderFile = ORDER_FILE) {
+    const cleaned = (Array.isArray(newOrder) ? newOrder : []).map(String);
+    const seen = new Set(cleaned);
+    const tail = state.order.filter(n => !seen.has(n));
+    state.order = cleaned.concat(tail);
+    save(state, orderFile);
+    return { ok: true };
+}
+
+// Inserta un issue nuevo al tope (position 0). Si ya existe, no-op.
+function insertNew(state, issue, orderFile = ORDER_FILE) {
+    const num = String(issue);
+    if (state.order.includes(num)) return { ok: false, reason: 'already-exists' };
+    state.order.unshift(num);
+    save(state, orderFile);
+    return { ok: true };
+}
+
+// Quita un issue del orden (típicamente cuando se cierra). Idempotente.
+function removeIssue(state, issue, orderFile = ORDER_FILE) {
+    const num = String(issue);
+    const idx = state.order.indexOf(num);
+    if (idx === -1) return { ok: false, reason: 'not-found' };
+    state.order.splice(idx, 1);
+    save(state, orderFile);
+    return { ok: true };
+}
+
+// Sincroniza el orden con la lista de issues conocidos:
+//   - issues nuevos (en `currentIssues` pero no en state.order) → insertados al tope
+//   - issues huérfanos (en state.order pero no en `currentIssues`) → preservados
+//     (no se borran porque podrían volver a abrirse o ser de otra fase no visible)
+// Devuelve la lista de issues recién insertados.
+function syncWith(state, currentIssues, orderFile = ORDER_FILE) {
+    const known = new Set(state.order);
+    const incoming = (currentIssues || []).map(String);
+    const newOnes = incoming.filter(n => !known.has(n));
+    if (newOnes.length === 0) return { ok: true, added: [] };
+    state.order = newOnes.concat(state.order);
+    save(state, orderFile);
+    return { ok: true, added: newOnes };
+}
+
+module.exports = {
+    ORDER_FILE,
+    CURRENT_VERSION,
+    load,
+    save,
+    orderOf,
+    moveUp,
+    moveDown,
+    setOrder,
+    insertNew,
+    removeIssue,
+    syncWith,
+    _emptyState: emptyState,
+};

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -3288,12 +3288,27 @@ function calcularPrioridad(issueNum, config) {
   return effectivePrio * 10 + tiebreaker;
 }
 
-/** Ordenar archivos pendientes por prioridad del issue */
+/** Ordenar archivos pendientes por prioridad del issue.
+ *  Fuente única de verdad: orden manual del Issue Tracker
+ *  (.pipeline/issue-manual-order.json). Si un issue no tiene entrada en el orden
+ *  manual, cae al cálculo legacy por labels (calcularPrioridad).
+ */
 function sortByPriority(archivos, config) {
   if (archivos.length <= 1) return archivos;
+  let manualOrderIndex = null;
+  try {
+    const issueOrder = require('./lib/issue-order');
+    const state = issueOrder.load();
+    manualOrderIndex = new Map(state.order.map((n, i) => [String(n), i]));
+  } catch {}
   return archivos.sort((a, b) => {
-    const issueA = issueFromFile(a.name);
-    const issueB = issueFromFile(b.name);
+    const issueA = String(issueFromFile(a.name));
+    const issueB = String(issueFromFile(b.name));
+    if (manualOrderIndex && manualOrderIndex.size > 0) {
+      const ia = manualOrderIndex.has(issueA) ? manualOrderIndex.get(issueA) : Infinity;
+      const ib = manualOrderIndex.has(issueB) ? manualOrderIndex.get(issueB) : Infinity;
+      if (ia !== ib) return ia - ib; // index menor = prioritario primero
+    }
     return calcularPrioridad(issueA, config) - calcularPrioridad(issueB, config);
   });
 }


### PR DESCRIPTION
## Resumen

Reemplaza el sistema de labels `priority:critical/high/medium/low` + `feature_priority` por **orden manual persistido** en `.pipeline/issue-manual-order.json`. El usuario controla el orden con drag-drop o botones ▲/▼ en el dashboard, y el pulpo lo respeta al elegir qué procesar primero.

Resuelve el problema de #1952 reportado por el usuario: la doble priorización (label + feature) hacía que botones del dashboard "no funcionaran" porque `Math.min(prioScore, featureScore)` ignoraba el label cuando la feature era critical.

## Cambios

### Lib nueva — `.pipeline/lib/issue-order.js`
- Estado: `{ version, order: [issue1, issue2, ...] }` — index = position
- Operaciones: `load`, `save`, `orderOf`, `moveUp`, `moveDown`, `setOrder`, `insertNew`, `removeIssue`, `syncWith`
- `syncWith` inserta automáticamente issues nuevos al **tope** (position 0) para que el usuario los vea y decida qué hacer. Issues huérfanos se preservan.
- **21 tests unitarios** cubriendo todas las operaciones y edge cases.

### Dashboard — `.pipeline/dashboard-v2.js`
- Endpoints nuevos:
  - `POST /api/issue/:n/(move-up|move-down)` — swap con vecino
  - `POST /api/issues/reorder` — reemplaza la lista entera (drag-drop)
- `generateHTML` carga el orden manual y syncea con issues activos antes del render
- Botones ▲/▼ existentes ahora llaman a `issueMoveUp`/`issueMoveDown` en vez de aplicar labels `priority:*`
- **Drag-and-drop nativo HTML5** (sin libs):
  - Cards con `draggable=true` y handlers `ondragstart/over/leave/drop/end`
  - Indicador visual: línea arriba o abajo del target según posición del cursor (`.lc-drop-above`/`.lc-drop-below`)
  - Solo dentro de la misma lane (def/dev/qa) — la lane es estado del FS, no decisión UX
  - Persiste el orden completo de cards activas tras cada drop
- **Badge de posición #N** visible en cada card de Issue Tracker y Equipo en ejecución (1-indexed). Útil para ver de un vistazo qué tan arriba está cada issue sin contar las cards.

### Pulpo — `.pipeline/pulpo.js sortByPriority`
- Lee `.pipeline/issue-manual-order.json` y ordena por index
- Si un issue no tiene entrada (cola residual), cae al `calcularPrioridad` legacy. Backwards compat sin migración explícita.

## Decisiones de UX

- **Issues nuevos al tope** (no al fondo): visibilidad para que el usuario decida
- **▲/▼ mueven UNA posición**, no al tope/fondo: control fino, criterio del usuario
- **Drag solo dentro de misma lane**: la lane es estado del FS, no decisión UX
- **`priority:*` labels y `feature_priority` config**: ignorados por pulpo y dashboard. Pueden quedar en GitHub como guía manual sin efecto en el orden.

## Plan de tests

- [x] `node --check` sintaxis OK
- [x] `node .pipeline/lib/__tests__/issue-order.test.js` → 21/21 verde
- [x] Tests existentes de `human-block.test.js` siguen verde (22/22)
- [ ] Probar dashboard local: drag-drop reordena · ▲/▼ swap con vecino · badge de posición correcto · refresh persiste · pulpo respeta el orden en el siguiente tick

🤖 Generado con [Claude Code](https://claude.ai/claude-code)