### PR TITLE
fix(pipeline): smoke test timeout HTTP de 5s → 30s para evitar rollbacks falsos

### DIFF
--- a/.pipeline/smoke-test.js
+++ b/.pipeline/smoke-test.js
@@ -117,11 +117,15 @@ async function main() {
     fail(`Componentes no-ready tras ${waitedSec}s: ${bad.join(', ')}`, 1);
   }
 
-  // 2) Dashboard HTTP.
+  // 2) Dashboard HTTP. Timeout holgado (30s) porque /api/state lee bastante
+  // estado del filesystem (issueMatrix + servicios + bloqueados-humano +
+  // métricas). Con la cola creciendo se acerca al límite anterior de 5s y
+  // dispara rollbacks falsos positivos. 30s es margen amplio sin retrasar
+  // demasiado el restart cuando hay un problema real.
   if (args.http) {
     log('Verificando dashboard HTTP :3200...');
     const dashPort = parseInt(process.env.DASHBOARD_PORT || '3200', 10);
-    const httpRes = await checkDashboardHttp(dashPort, 5000);
+    const httpRes = await checkDashboardHttp(dashPort, 30000);
     if (!httpRes.ok) {
       fail(`Dashboard no responde en :${dashPort} (status=${httpRes.status})`, 2);
     }


### PR DESCRIPTION
## Resumen

Subir el timeout HTTP del smoke test de 5s a 30s para evitar **rollbacks falsos positivos** cuando `/api/state` se acerca al límite por crecimiento natural del state del pipeline.

## Contexto

El usuario reportó que tras el reinicio del PR #2706 corrió el autorollback. Diagnóstico:

- `restart.js` invoca `smoke-test.js` que hace `GET /api/state` con timeout 5s.
- El sistema venía cerca del límite hace varios runs (4-5s):
  ```
  13:38: HTTP 200 in 5s ⚠ (justo en el límite)
  14:50: HTTP 200 in 4s ⚠ (cerca del límite)
  15:16: TIMEOUT (>5s) ❌ — disparó rollback
  ```
- El cambio del PR #2706 NO toca `getPipelineState` (solo HTML strings). El smoke test NUNCA llegó al render HTML — el rollback fue causado por timing del state, no por el código nuevo.
- Resultado: pipeline revertido a #2705 + dashboard caído (rollback mata procesos pero el relaunch no siempre repara).

## Fix

```diff
- const httpRes = await checkDashboardHttp(dashPort, 5000);
+ const httpRes = await checkDashboardHttp(dashPort, 30000);
```

30s es margen amplio sin retrasar demasiado el restart cuando hay un problema real. La diferencia entre 5s (OK) y 30s (timeout real) es muy informativa: si tarda 30s probablemente sí hay un cuelgue, no carga.

## Plan de tests

- [x] `node --check` syntax OK
- [ ] Reiniciar el dashboard tras este fix: `node .pipeline/restart.js`
- [ ] Verificar que el smoke test pasa con margen
- [ ] Verificar que el código de #2706 (Issue Tracker/Historial colapsados + popout needs-human) está activo

🤖 Generado con [Claude Code](https://claude.ai/claude-code)