### PR TITLE
fix(pipeline): pantalla negra en ventanas standalone tras auto-refresh

### DIFF
--- a/.pipeline/dashboard-v2.js
+++ b/.pipeline/dashboard-v2.js
@@ -4302,6 +4302,14 @@ document.addEventListener('click', function(e) {
 let __softRefreshInFlight = false;
 async function softRefresh() {
   if (__softRefreshInFlight) return;
+  // En modo standalone (?section=X) el soft swap rompe el layout: los
+  // selectores que se reemplazan vienen del server sin la clase
+  // .standalone-target (la agrega applyStandaloneMode al cargar) y CSS
+  // body.standalone > *:not(.standalone-target) los oculta → pantalla negra.
+  // Solución: full reload, que re-ejecuta applyStandaloneMode.
+  if (document.body.classList.contains('standalone')) {
+    return location.reload();
+  }
   // No refrescar si hay log overlay abierto
   const logOv = document.getElementById('log-overlay');
   if (logOv && logOv.classList.contains('open')) return;


### PR DESCRIPTION
## Resumen

**Bug reportado:** las ventanas abiertas con `?section=X` quedan en negro cada cierto tiempo (cada auto-refresh).

**Causa raíz:** `softRefresh()` (intervalo del auto-refresh) reemplaza selectores clave (`#issue-tracker`, `#agent-history`, `.panel-equipo-full`, etc.) con HTML fresco fetcheado del server. En modo standalone, los elementos del server vienen sin la clase `.standalone-target` (esa clase la agrega `applyStandaloneMode()` client-side, solo al cargar). Después del swap, el CSS `body.standalone > *:not(.standalone-target):not(#toast-host) { display: none }` oculta TODO porque el target perdió su clase. Resultado: pantalla en negro.

**Fix:** en modo standalone, `softRefresh()` hace `location.reload()` directo en lugar del swap parcial. Cada refresh re-ejecuta `applyStandaloneMode` y el layout queda intacto. Aceptable porque en standalone solo se muestra una sección (render más liviano).

## Cambios

```js
async function softRefresh() {
  if (__softRefreshInFlight) return;
+ if (document.body.classList.contains('standalone')) {
+   return location.reload();
+ }
  // ... resto del soft swap normal
}
```

## Plan de tests

- [x] `node --check` syntax OK
- [ ] Reiniciar dashboard, abrir `/?section=issue-tracker`, dejar el auto-refresh cada N segundos, verificar que la página no queda en negro

🤖 Generado con [Claude Code](https://claude.ai/claude-code)