### PR TITLE
feat(pipeline): botones ⏫ ⏬ para mover al tope/fondo de la columna sin swap

### DIFF
--- a/.pipeline/dashboard-v2.js
+++ b/.pipeline/dashboard-v2.js
@@ -1690,8 +1690,10 @@ function generateHTML(state) {
           </div>
           <div class="lc-top-right">
             <span class="lc-prio-actions">
+              <button class="lc-prio-btn lc-prio-top" onclick="event.stopPropagation();issueMoveToTop(${issueNum})" title="Mover al tope de la columna">⏫</button>
               <button class="lc-prio-btn lc-prio-up" onclick="event.stopPropagation();issueMoveUp(${issueNum})" title="Subir una posición">▲</button>
               <button class="lc-prio-btn lc-prio-down" onclick="event.stopPropagation();issueMoveDown(${issueNum})" title="Bajar una posición">▼</button>
+              <button class="lc-prio-btn lc-prio-bottom" onclick="event.stopPropagation();issueMoveToBottom(${issueNum})" title="Mover al fondo de la columna">⏬</button>
             </span>
             <span class="lc-elapsed ${laneElapsedCls}">${laneElapsedTxt}</span>
           </div>
@@ -2312,8 +2314,10 @@ function generateHTML(state) {
         : '';
       const prioActions = isRunning
         ? `<span class="ah-prio-actions">
+            <button class="lc-prio-btn lc-prio-top" onclick="event.preventDefault();event.stopPropagation();issueMoveToTop(${h.issue})" title="Mover al tope de la columna">⏫</button>
             <button class="lc-prio-btn lc-prio-up" onclick="event.preventDefault();event.stopPropagation();issueMoveUp(${h.issue})" title="Subir una posición">▲</button>
             <button class="lc-prio-btn lc-prio-down" onclick="event.preventDefault();event.stopPropagation();issueMoveDown(${h.issue})" title="Bajar una posición">▼</button>
+            <button class="lc-prio-btn lc-prio-bottom" onclick="event.preventDefault();event.stopPropagation();issueMoveToBottom(${h.issue})" title="Mover al fondo de la columna">⏬</button>
           </span>`
         : '';
       const ahPos = manualOrderIndex.has(String(h.issue)) ? manualOrderIndex.get(String(h.issue)) : null;
@@ -3773,6 +3777,8 @@ a.skill-recent-item:hover{background:var(--bd2);color:var(--ac)}
 .lc-prio-btn:disabled{opacity:0.4;cursor:wait}
 .lc-prio-up:hover{border-color:#3fb950;color:#3fb950}
 .lc-prio-down:hover{border-color:#f85149;color:#f85149}
+.lc-prio-top:hover{border-color:#3fb950;color:#3fb950;background:rgba(63,185,80,0.10)}
+.lc-prio-bottom:hover{border-color:#f85149;color:#f85149;background:rgba(248,81,73,0.10)}
 .lc-card[draggable="true"]{cursor:grab}
 .lc-card[draggable="true"]:active{cursor:grabbing}
 .lc-card-dragging{opacity:0.4;outline:1px dashed var(--ac,#6d8cff)}
@@ -5220,6 +5226,70 @@ async function _issueMove(issueNum, direction) {
 }
 function issueMoveUp(issueNum) { return _issueMove(issueNum, 'up'); }
 function issueMoveDown(issueNum) { return _issueMove(issueNum, 'down'); }
+
+// Mover al tope/fondo de la columna: encuentra el primero/último visible en la
+// misma lane y manda anchor al endpoint move-before/move-after (splice sin swap).
+function _findLaneEnds(issueNum) {
+  const target = document.querySelector('.lc-card[data-issue="' + issueNum + '"][data-status="active"]');
+  if (!target) return { error: 'card-not-visible' };
+  const lane = target.dataset.lane;
+  const peers = Array.from(document.querySelectorAll(
+    '.lc-card[data-lane="' + lane + '"][data-status="active"]'
+  ));
+  if (peers.length === 0) return { error: 'no-peers' };
+  return { first: peers[0].dataset.issue, last: peers[peers.length - 1].dataset.issue, count: peers.length };
+}
+async function _issueMoveRelative(issueNum, direction) {
+  const ends = _findLaneEnds(issueNum);
+  if (ends.error) {
+    showToast('No se pudo localizar la columna del #' + issueNum, 'err');
+    return;
+  }
+  const anchor = direction === 'top' ? ends.first : ends.last;
+  if (anchor === String(issueNum)) {
+    showToast('#' + issueNum + ' ya está en el ' + (direction === 'top' ? 'tope' : 'fondo') + ' de la columna', 'info');
+    return;
+  }
+  const action = direction === 'top' ? 'move-before' : 'move-after';
+  const arrow = direction === 'top' ? '⏫' : '⏬';
+  const fnName = direction === 'top' ? 'issueMoveToTop' : 'issueMoveToBottom';
+  // Loading state en los botones afectados
+  document.querySelectorAll('button.lc-prio-btn[onclick*="' + fnName + '(' + issueNum + ')"]').forEach(b => {
+    b.dataset.origText = b.textContent;
+    b.textContent = '⋯';
+    b.disabled = true;
+  });
+  try {
+    const r = await fetch('/api/issue/' + issueNum + '/' + action, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ anchor })
+    });
+    const j = await r.json();
+    if (j.ok) {
+      _prioFlashCards(issueNum, true);
+      showToast(arrow + ' #' + issueNum + ' ' + (j.msg || 'movido'), 'ok');
+      setTimeout(() => location.reload(), 500);
+    } else {
+      _prioFlashCards(issueNum, false);
+      showToast('Error: ' + (j.msg || 'desconocido'), 'err');
+      // Restaurar botones
+      document.querySelectorAll('button.lc-prio-btn[onclick*="' + fnName + '(' + issueNum + ')"]').forEach(b => {
+        if (b.dataset.origText) b.textContent = b.dataset.origText;
+        b.disabled = false;
+      });
+    }
+  } catch (e) {
+    _prioFlashCards(issueNum, false);
+    showToast('Error moviendo #' + issueNum + ': ' + e.message, 'err');
+    document.querySelectorAll('button.lc-prio-btn[onclick*="' + fnName + '(' + issueNum + ')"]').forEach(b => {
+      if (b.dataset.origText) b.textContent = b.dataset.origText;
+      b.disabled = false;
+    });
+  }
+}
+function issueMoveToTop(issueNum) { return _issueMoveRelative(issueNum, 'top'); }
+function issueMoveToBottom(issueNum) { return _issueMoveRelative(issueNum, 'bottom'); }
 
 // Drag-and-drop nativo HTML5 sobre las cards del Issue Tracker.
 // Solo dentro de la misma lane: la lane se determina por estado del filesystem,
@@ -7112,6 +7182,52 @@ const server = http.createServer((req, res) => {
       if (result.ok) {
         const newPos = state.order.indexOf(issueNum);
         res.end(JSON.stringify({ ok: true, msg: `Issue #${issueNum} ${action === 'move-up' ? 'subió' : 'bajó'} a posición ${newPos + 1}`, ...result, position: newPos }));
+      } else {
+        res.end(JSON.stringify({ ok: false, msg: result.reason }));
+      }
+    });
+    return;
+  }
+
+  // API mover issue al tope/fondo de su columna (splice sin swap).
+  // Body: { "anchor": "<issue-num>" } — el primer/último issue de la columna.
+  const moveRelativeMatch = req.url && req.url.match(/^\/api\/issue\/(\d+)\/(move-before|move-after)$/);
+  if (moveRelativeMatch && req.method === 'POST') {
+    const issueNum = String(moveRelativeMatch[1]);
+    const action = moveRelativeMatch[2];
+    let body = '';
+    req.on('data', c => { body += c; if (body.length > 16 * 1024) req.destroy(); });
+    req.on('end', () => {
+      let payload = {};
+      try { payload = body ? JSON.parse(body) : {}; }
+      catch (e) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ ok: false, msg: 'JSON inválido: ' + e.message }));
+        return;
+      }
+      const anchor = payload.anchor != null ? String(payload.anchor) : null;
+      if (!anchor) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ ok: false, msg: 'Falta anchor en el body' }));
+        return;
+      }
+      let issueOrder;
+      try { issueOrder = require('./lib/issue-order'); }
+      catch (e) {
+        res.writeHead(503, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ ok: false, msg: 'issue-order lib no disponible: ' + e.message }));
+        return;
+      }
+      const state = issueOrder.load();
+      const result = action === 'move-before'
+        ? issueOrder.moveBefore(state, issueNum, anchor)
+        : issueOrder.moveAfter(state, issueNum, anchor);
+      log(`order: ${action} #${issueNum} ${action === 'move-before' ? '←' : '→'} #${anchor} → ${result.ok ? `${result.from}→${result.to}` : result.reason}`);
+      res.writeHead(result.ok ? 200 : 400, { 'Content-Type': 'application/json' });
+      if (result.ok) {
+        const newPos = state.order.indexOf(issueNum);
+        const verbo = action === 'move-before' ? 'al tope' : 'al fondo';
+        res.end(JSON.stringify({ ok: true, msg: `Issue #${issueNum} movido ${verbo} (posición ${newPos + 1})`, ...result, position: newPos }));
       } else {
         res.end(JSON.stringify({ ok: false, msg: result.reason }));
       }

--- a/.pipeline/lib/__tests__/issue-order.test.js
+++ b/.pipeline/lib/__tests__/issue-order.test.js
@@ -127,6 +127,77 @@ test('swap con el mismo issue retorna error same-issue', () => {
     assert.equal(r.reason, 'same-issue');
 });
 
+test('moveBefore inserta el issue justo antes del anchor sin swappear', () => {
+    const f = tmpFile();
+    const s = { version: 1, order: ['a', 'b', 'c', 'd', 'e'] };
+    // Mover 'd' antes de 'b'
+    const r = lib.moveBefore(s, 'd', 'b', f);
+    assert.equal(r.ok, true);
+    // Resultado esperado: a, d, b, c, e (b/c mantuvieron orden relativo)
+    assert.deepEqual(s.order, ['a', 'd', 'b', 'c', 'e']);
+});
+
+test('moveBefore funciona para llevar al tope de un bloque (anchor=primero)', () => {
+    const s = { version: 1, order: ['a', 'b', 'c', 'd', 'e'] };
+    // Tope: mover 'd' antes de 'a'
+    lib.moveBefore(s, 'd', 'a', tmpFile());
+    assert.deepEqual(s.order, ['d', 'a', 'b', 'c', 'e']);
+});
+
+test('moveBefore con anchor inexistente restaura el array original', () => {
+    const s = { version: 1, order: ['a', 'b', 'c'] };
+    const r = lib.moveBefore(s, 'a', 'zzz', tmpFile());
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, 'anchor-not-found');
+    assert.deepEqual(s.order, ['a', 'b', 'c']);
+});
+
+test('moveBefore con issue inexistente devuelve not-found', () => {
+    const s = { version: 1, order: ['a', 'b'] };
+    const r = lib.moveBefore(s, 'zzz', 'a', tmpFile());
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, 'not-found');
+});
+
+test('moveBefore con mismo issue y anchor devuelve same-issue', () => {
+    const s = { version: 1, order: ['a', 'b'] };
+    const r = lib.moveBefore(s, 'a', 'a', tmpFile());
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, 'same-issue');
+});
+
+test('moveAfter inserta el issue justo después del anchor sin swappear', () => {
+    const f = tmpFile();
+    const s = { version: 1, order: ['a', 'b', 'c', 'd', 'e'] };
+    // Mover 'b' después de 'd'
+    const r = lib.moveAfter(s, 'b', 'd', f);
+    assert.equal(r.ok, true);
+    // Resultado: a, c, d, b, e (c mantuvo posición relativa, b al fondo del bloque)
+    assert.deepEqual(s.order, ['a', 'c', 'd', 'b', 'e']);
+});
+
+test('moveAfter funciona para llevar al fondo de un bloque (anchor=último)', () => {
+    const s = { version: 1, order: ['a', 'b', 'c', 'd', 'e'] };
+    // Fondo: mover 'b' después de 'e'
+    lib.moveAfter(s, 'b', 'e', tmpFile());
+    assert.deepEqual(s.order, ['a', 'c', 'd', 'e', 'b']);
+});
+
+test('moveAfter con anchor inexistente restaura el array original', () => {
+    const s = { version: 1, order: ['a', 'b', 'c'] };
+    const r = lib.moveAfter(s, 'a', 'zzz', tmpFile());
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, 'anchor-not-found');
+    assert.deepEqual(s.order, ['a', 'b', 'c']);
+});
+
+test('moveBefore preserva orden relativo del resto del array', () => {
+    const s = { version: 1, order: ['x', 'a', 'y', 'b', 'z', 'c'] };
+    // Mover 'c' antes de 'a' — el orden relativo entre x, y, b, z se preserva
+    lib.moveBefore(s, 'c', 'a', tmpFile());
+    assert.deepEqual(s.order, ['x', 'c', 'a', 'y', 'b', 'z']);
+});
+
 test('setOrder reemplaza la lista respetando el orden recibido', () => {
     const f = tmpFile();
     const s = { version: 1, order: ['a', 'b', 'c', 'd'] };

--- a/.pipeline/lib/issue-order.js
+++ b/.pipeline/lib/issue-order.js
@@ -100,6 +100,45 @@ function swap(state, issueA, issueB, orderFile = ORDER_FILE) {
     return { ok: true, from: ia, to: ib };
 }
 
+// Mueve un issue justo antes del anchor (splice sin swap). El resto del array
+// preserva su orden relativo. Útil para "tope de columna" desde el dashboard:
+// pasar como anchor el primer issue de la columna.
+function moveBefore(state, issue, anchor, orderFile = ORDER_FILE) {
+    const num = String(issue);
+    const anc = String(anchor);
+    if (num === anc) return { ok: false, reason: 'same-issue' };
+    const fromIdx = state.order.indexOf(num);
+    if (fromIdx === -1) return { ok: false, reason: 'not-found' };
+    state.order.splice(fromIdx, 1);
+    const ancIdx = state.order.indexOf(anc);
+    if (ancIdx === -1) {
+        state.order.splice(fromIdx, 0, num);
+        return { ok: false, reason: 'anchor-not-found' };
+    }
+    state.order.splice(ancIdx, 0, num);
+    save(state, orderFile);
+    return { ok: true, from: fromIdx, to: ancIdx };
+}
+
+// Mueve un issue justo después del anchor (splice sin swap). Útil para "fondo
+// de columna": pasar como anchor el último issue de la columna.
+function moveAfter(state, issue, anchor, orderFile = ORDER_FILE) {
+    const num = String(issue);
+    const anc = String(anchor);
+    if (num === anc) return { ok: false, reason: 'same-issue' };
+    const fromIdx = state.order.indexOf(num);
+    if (fromIdx === -1) return { ok: false, reason: 'not-found' };
+    state.order.splice(fromIdx, 1);
+    const ancIdx = state.order.indexOf(anc);
+    if (ancIdx === -1) {
+        state.order.splice(fromIdx, 0, num);
+        return { ok: false, reason: 'anchor-not-found' };
+    }
+    state.order.splice(ancIdx + 1, 0, num);
+    save(state, orderFile);
+    return { ok: true, from: fromIdx, to: ancIdx + 1 };
+}
+
 // Reemplaza la lista entera respetando el array recibido. Cualquier issue conocido
 // que no aparezca en `newOrder` se preserva al final (no se pierden referencias).
 function setOrder(state, newOrder, orderFile = ORDER_FILE) {
@@ -154,6 +193,8 @@ module.exports = {
     moveUp,
     moveDown,
     swap,
+    moveBefore,
+    moveAfter,
     setOrder,
     insertNew,
     removeIssue,


### PR DESCRIPTION
## Resumen

Agrega dos botones más a cada card del Issue Tracker y Equipo en ejecución:

- **⏫ Mover al tope de la columna**: el issue va al primer lugar de su lane. El resto de la columna se desplaza hacia abajo manteniendo el orden relativo entre ellos (splice, NO swap).
- **⏬ Mover al fondo de la columna**: análogo, va al último lugar.

## Diferencia con ▲/▼ existentes

Si #2019 (pos 53) y los anteriores en su lane son #1921 (pos 17), #1927 (pos 20), #2019 (pos 53):

- `▲` click → swap con #1927 → orden: #1921, #2019, #1927
- `⏫` click → splice antes de #1921 → orden: #2019, #1921, #1927 (resto preserva orden)

## Cambios

### Lib — `.pipeline/lib/issue-order.js`
- `moveBefore(state, issue, anchor)` y `moveAfter(state, issue, anchor)` con splice + restore en error.
- 9 tests nuevos cubriendo splice, anchor inexistente, mismo issue, preservación del orden relativo del resto. Total ahora: 34 tests verde.

### Endpoint — `dashboard-v2.js`
- `POST /api/issue/:n/(move-before|move-after)` con body `{ anchor: <issue-num> }`. La lib hace el splice y persiste.

### Frontend
- `_findLaneEnds(issueNum)` determina first/last visibles de la lane via DOM query.
- `_issueMoveRelative(num, 'top'|'bottom')` invoca el endpoint con el anchor correspondiente. Toast si el issue ya está en tope/fondo.
- Botones `⏫`/`⏬` al lado de `▲`/`▼` con tinted hover (verde/rojo).

## Plan de tests

- [x] `node --check` syntax OK
- [x] `issue-order.test.js` 34/34 verde
- [ ] Probar dashboard local: clic en ⏫ desde una card al fondo de su columna → 1 click la lleva al tope · clic en ⏬ análogo · resto de la columna preserva orden relativo

🤖 Generado con [Claude Code](https://claude.ai/claude-code)