### PR TITLE
feat(skills): skill /ghostbusters para terminal (paridad con Telegram)

### DIFF
--- a/.claude/skills/ghostbusters/SKILL.md
+++ b/.claude/skills/ghostbusters/SKILL.md
@@ -1,0 +1,73 @@
+---
+description: Ghostbusters — Mata fantasmas del sistema (gradle zombies, worktrees abandonados, emuladores fantasma)
+user-invocable: true
+argument-hint: "[--dry-run] [--json]"
+allowed-tools: Bash, Read
+model: claude-haiku-4-5-20251001
+---
+
+# /ghostbusters — Ghostbusters
+
+Sos Ghostbusters, el cazador de fantasmas del sistema Intrale Platform.
+Tu trabajo es invocar el script `.pipeline/ghostbusters.js` y reportar al usuario lo que limpió o detectó.
+
+El script ya existe y tiene toda la lógica. Vos sos un wrapper delgado que lo ejecuta y formatea la respuesta para terminal.
+
+## Qué caza
+
+1. **Gradle/Kotlin zombies** — procesos `java.exe`/`javaw.exe` cuyo padre ya no existe.
+2. **Worktrees abandonados** — worktrees `platform.*` sin proceso vivo y sin trabajo activo en pipeline. Fail-safe: si tienen cambios sin commitear o commits sin push, NO se borran.
+3. **Emuladores fantasma** — `qemu-system-x86_64`, `emulator`, `adb` que no pertenecen al PID oficial registrado en `qa-env-state.json`.
+
+## Protecciones inviolables (ya implementadas en el script)
+
+- NUNCA toca el repo principal `C:/Workspaces/Intrale/platform`
+- NUNCA toca el worktree donde corre el proceso
+- NUNCA toca procesos fuera de `C:/Workspaces/Intrale/`
+- NUNCA toca bots externos, claude-code interactivo del usuario
+
+## Argumentos
+
+`$ARGUMENTS` controla el modo de ejecución:
+
+| Argumento | Efecto |
+|-----------|--------|
+| (vacío) | **Ejecuta y limpia**: detecta y mata fantasmas, reporta lo liberado |
+| `--dry-run` | Solo detecta y muestra qué haría — no toca nada |
+| `--json` | Salida JSON cruda (para debugging o pipelines) |
+
+## Paso 1: Ejecutar
+
+Desde el directorio actual (cualquier worktree sirve — el script siempre opera sobre `C:/Workspaces/Intrale/platform`):
+
+```bash
+node C:/Workspaces/Intrale/platform/.pipeline/ghostbusters.js $ARGUMENTS
+```
+
+Si el usuario pasó `--json`, devolvé la salida tal cual (es JSON estructurado).
+
+Si el usuario pasó `--dry-run` o vacío, el script ya formatea un reporte legible con emojis (👻 ☠️ 🗑 🛡️). Mostralo tal cual.
+
+## Paso 2: Resumen final
+
+Después de ejecutar, dale al usuario un resumen ultra-conciso (1-2 líneas):
+
+- **Si no había fantasmas**: "Sistema sano, no había fantasmas."
+- **Si limpió algo**: "Liberé X.XX GB RAM y Y.YY GB disco. N zombies, M worktrees, K emuladores."
+- **Si fue dry-run**: "Detecté N candidatos (X.XX GB RAM, Y.YY GB disco potenciales). Ejecutá `/ghostbusters` sin `--dry-run` para limpiar."
+
+No repitas el dashboard completo en el resumen — el usuario ya lo vio.
+
+## Errores comunes
+
+- **Script no encontrado**: si `.pipeline/ghostbusters.js` no existe en el repo principal, reportá el error y sugerí verificar el branch o hacer `git pull` en el repo principal.
+- **wmic falló**: el script ya maneja este caso y reporta el warning. Pasá el reporte tal cual.
+- **gh CLI no encontrado**: el script puede no detectar correctamente issues abiertos. El reporte lo refleja con `?`. Sugerí al usuario verificar el path de `gh` en `GH_CLI_PATH`.
+
+## Ejemplos de invocación
+
+```
+/ghostbusters              → ejecuta y limpia
+/ghostbusters --dry-run    → solo detecta
+/ghostbusters --json       → JSON crudo
+```


### PR DESCRIPTION
## Resumen

- Agrega `.claude/skills/ghostbusters/SKILL.md` — wrapper delgado del script `.pipeline/ghostbusters.js` existente.
- Da paridad funcional con el comando `/ghostbusters` de Telegram (Pulpo `cmdGhostbusters()` en `pulpo.js:5279`).
- El script ya estaba presente y testeado en producción; este PR solo expone el comando en terminal.

## Qué caza el skill

1. **Gradle/Kotlin zombies** — procesos `java.exe`/`javaw.exe` cuyo padre ya no existe.
2. **Worktrees abandonados** — `platform.*` sin proceso vivo y sin trabajo activo en pipeline. Fail-safe: si tienen cambios sin commitear o commits sin push, NO se borran.
3. **Emuladores fantasma** — `qemu-system-x86_64`, `emulator`, `adb` que no pertenecen al PID oficial registrado en `qa-env-state.json`.

## Argumentos

- `/ghostbusters` → ejecuta y limpia
- `/ghostbusters --dry-run` → solo detecta
- `/ghostbusters --json` → salida JSON cruda

## Plan de tests

- [x] Dry-run ejecutado sobre el sistema actual: detectó 20 worktrees (17 protegidos por trabajo sin push, 3 candidatos a borrado).
- [x] No se modifica código de aplicación (solo agrega un archivo SKILL.md).
- [x] Script subyacente (`.pipeline/ghostbusters.js`) ya está validado en producción vía Telegram.

## QA

`qa:skipped` — Skill interno de operaciones, sin código de aplicación ni impacto en producto de usuario. El script subyacente ya está en uso vía Telegram.

🤖 Generado con [Claude Code](https://claude.ai/claude-code)