### PR TITLE
fix(dashboard): popouts por sección rotos por SyntaxError en JS del cliente

### DIFF
--- a/.pipeline/dashboard-v2.js
+++ b/.pipeline/dashboard-v2.js
@@ -5505,7 +5505,7 @@ async function needsHumanDismiss(issueNum) {
     const j = await r.json();
     if (j.ok) {
       if (j.worktree && j.worktree_warning) {
-        const cleanWt = confirm('Issue #' + issueNum + ' desestimado.\n\nEl worktree tiene trabajo en disco:\n  ' + j.worktree + '\n\n¿Limpiar el worktree ahora? (Cancelar = conservar)');
+        const cleanWt = confirm('Issue #' + issueNum + ' desestimado.\\n\\nEl worktree tiene trabajo en disco:\\n  ' + j.worktree + '\\n\\n¿Limpiar el worktree ahora? (Cancelar = conservar)');
         if (cleanWt) {
           try {
             const rw = await fetch('/api/needs-human/' + issueNum + '/dismiss-worktree', { method: 'POST' });


### PR DESCRIPTION
## Resumen

Fix urgente: el PR #2793 introdujo un SyntaxError en el JS del cliente que abortaba `applyStandaloneMode()` y por ende rompía todos los popouts (`?section=needs-human`, `?section=issue-tracker`, `?section=historial`, `?section=equipo`).

## Causa raíz

En `needsHumanDismiss()`, el `confirm()` del aviso de worktree usaba `\n` directo:

```js
const cleanWt = confirm('Issue #' + issueNum + ' desestimado.\n\n...');
```

Como ese JS del cliente vive embebido dentro de un template literal del servidor, el `\n` se procesó como newline literal en el output enviado al navegador, rompiendo el string single-quoted con un salto de línea real:

```js
// Lo que llegaba al navegador (roto):
const cleanWt = confirm('Issue #99 desestimado.

El worktree tiene trabajo en disco:
  ...
```

Eso es un `SyntaxError: Invalid or unexpected token` que aborta el script entero — incluido `applyStandaloneMode()`, lo que hace que los popouts muestren el dashboard total en lugar de la sección aislada.

## Fix

Usar `\n` (doble escape) en el código fuente. El template literal del server emite `\n` literal, que es válido dentro de un string single-quoted del cliente.

## Validación

- `node -c dashboard-v2.js` — sintaxis del archivo OK
- `vm.Script` sobre el HTML servido — JS del cliente OK
- Reproducción manual del template literal con `eval` — string final válido

## Plan de tests

- [x] Sintaxis del archivo Node validada
- [x] Sintaxis del JS cliente simulada via `vm.Script`
- [ ] Tras restart del dashboard: abrir `/?section=needs-human` y confirmar que solo se ve esa sección
- [ ] Idem con `?section=issue-tracker`, `?section=historial`, `?section=equipo`

## QA

`qa:skipped` — Hotfix de regresión en dashboard interno; smoke test manual abriendo cualquier popout.

🤖 Generado con [Claude Code](https://claude.ai/claude-code)