### PR TITLE
fix(dashboard): gh CLI en background, evitar timeouts del fetch al pausar/desestimar

### DIFF
--- a/.pipeline/dashboard-v2.js
+++ b/.pipeline/dashboard-v2.js
@@ -7118,12 +7118,14 @@ const server = http.createServer((req, res) => {
       }
       const ghBin = GH_BIN;
       const repo = 'intrale/platform';
-      const { execFileSync } = require('child_process');
+      const { execFile } = require('child_process');
+      // Fire-and-forget: el gh CLI puede demorar 5-15s por llamada en Windows.
+      // Si esperáramos sync, el fetch del cliente expira aunque el server haya
+      // procesado la acción. Lanzamos en background y respondemos ya.
       const ghTry = (args) => {
         try {
-          execFileSync(ghBin, args, { stdio: 'ignore', timeout: 15000 });
-          return true;
-        } catch { return false; }
+          execFile(ghBin, args, { timeout: 30000, windowsHide: true }, () => {});
+        } catch {}
       };
 
       if (action === 'reactivate') {
@@ -7229,7 +7231,7 @@ const server = http.createServer((req, res) => {
       ghTry(['issue', 'edit', String(issueNum), '--repo', repo, '--remove-label', 'needs-human']);
       const reasonLine = reason ? `\n\n**Motivo:** ${reason}` : '';
       const closeComment = `## ✕ Desestimado desde el dashboard\n\nIssue cerrado manualmente; no entrará al pipeline.${reasonLine}`;
-      const closed = ghTry(['issue', 'close', String(issueNum), '--repo', repo, '--reason', 'not planned', '--comment', closeComment]);
+      ghTry(['issue', 'close', String(issueNum), '--repo', repo, '--reason', 'not planned', '--comment', closeComment]);
 
       // Detectar worktree asociado para que el frontend pueda ofrecer limpieza opt-in
       let worktreePath = null;
@@ -7242,12 +7244,11 @@ const server = http.createServer((req, res) => {
         if (m) worktreePath = m[1].trim();
       } catch {}
 
-      log(`needs-human: desestimado #${issueNum} (skill=${result.skill}, closed=${closed}, wt=${worktreePath || 'none'})`);
+      log(`needs-human: desestimado #${issueNum} (skill=${result.skill}, wt=${worktreePath || 'none'})`);
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({
         ok: true,
         msg: `Issue #${issueNum} desestimado y cerrado`,
-        closed,
         worktree: worktreePath,
         worktree_warning: worktreePath != null,
         ...result


### PR DESCRIPTION
## Resumen

Fix: las acciones del panel "Necesitan humano" (pausar, reactivar, desestimar) reportaban "error de fetch" en el cliente aunque el server procesaba la acción correctamente.

## Diagnóstico

Logs del dashboard confirman que el server completó todas las acciones del usuario (#1921, #1927, #1931 quedaron con marker `bloqueado-humano` y reason persistido):

```
[2026-04-26 23:46:13] needs-human: pausado #1927 (source=dashboard:issue-tracker)
[2026-04-26 23:48:28] needs-human: pausado #1927 (source=dashboard:issue-tracker)  ← retry del usuario
```

Pero el cliente recibía error porque las llamadas síncronas a `gh CLI` (label + comment) bloqueaban el handler 5-15s en Windows, superando el timeout del fetch del navegador. El usuario veía error → reintentaba → server procesaba dos veces.

## Fix

Cambiar `execFileSync` (bloqueante) por `execFile` async con callback vacío (fire-and-forget):

```js
// Antes — bloquea hasta que gh termine
execFileSync(ghBin, args, { stdio: 'ignore', timeout: 15000 });

// Después — dispara y vuelve enseguida
execFile(ghBin, args, { timeout: 30000, windowsHide: true }, () => {});
```

El handler responde al cliente inmediatamente con el resultado del filesystem (fuente de verdad). Las operaciones de GitHub (label, comment, close) corren en background sin bloquear.

## Trade-off

Si la llamada a `gh CLI` falla (token expirado, rate limit, etc.), el cliente NO se entera. Pero:
- El estado en filesystem (que es lo que el dashboard renderiza) ya está correcto
- El usuario ve el feedback visual inmediato
- En un siguiente refresh el dashboard refleja el estado real

Esto es coherente con la directiva de eficiencia de tokens (memoria): preferir respuesta rápida + best-effort de side effects, antes que bloquear esperando confirmación de cada paso.

## Plan de tests

- [x] Sintaxis OK (`node -c`)
- [ ] Tras restart del dashboard: pausar issue → respuesta < 1s → card desaparece del tracker
- [ ] Verificar que el label `needs-human` aparece en GitHub a los pocos segundos (background)
- [ ] Verificar que reactivar y desestimar también responden rápido

## QA

`qa:skipped` — Hotfix de regresión UX en dashboard interno.

🤖 Generado con [Claude Code](https://claude.ai/claude-code)