### PR TITLE
fix(dashboard): UI optimista en botón ⏸ Pausar

### DIFF
--- a/.pipeline/dashboard-v2.js
+++ b/.pipeline/dashboard-v2.js
@@ -5462,8 +5462,10 @@ function nhDisableButtons(issueNum) {
 async function needsHumanBlock(issueNum) {
   const reason = prompt('Pausar #' + issueNum + ' — motivo (opcional, Enter para omitir):', '');
   if (reason === null) return;
-  const btn = document.querySelector('.lc-card[data-issue="' + issueNum + '"] .lc-pause-btn');
-  if (btn) btn.disabled = true;
+  // Feedback visual optimista: ocultar la card inmediatamente.
+  // El server puede tardar 3-5s; sin feedback el usuario clickea de nuevo.
+  const cards = document.querySelectorAll('.lc-card[data-issue="' + issueNum + '"]');
+  cards.forEach(c => { c.style.transition = 'opacity 0.2s'; c.style.opacity = '0.3'; c.style.pointerEvents = 'none'; });
   try {
     const r = await fetch('/api/needs-human/' + issueNum + '/block', {
       method: 'POST',
@@ -5471,9 +5473,16 @@ async function needsHumanBlock(issueNum) {
       body: JSON.stringify({ reason: reason || '', source: 'dashboard:issue-tracker' })
     });
     const j = await r.json();
-    if (j.ok) location.reload();
-    else { alert('Error pausando: ' + (j.msg || 'desconocido')); if (btn) btn.disabled = false; }
-  } catch (e) { alert('Error pausando: ' + e.message); if (btn) btn.disabled = false; }
+    if (j.ok) {
+      cards.forEach(c => { c.style.display = 'none'; });
+    } else {
+      alert('Error pausando: ' + (j.msg || 'desconocido'));
+      cards.forEach(c => { c.style.opacity = ''; c.style.pointerEvents = ''; });
+    }
+  } catch (e) {
+    alert('Error pausando: ' + e.message);
+    cards.forEach(c => { c.style.opacity = ''; c.style.pointerEvents = ''; });
+  }
 }
 async function needsHumanReactivate(issueNum) {
   if (!confirm('Reactivar #' + issueNum + '? Volverá a la cola del pipeline sin orientación adicional.')) return;


### PR DESCRIPTION
## Resumen

Mejora UX del botón ⏸ Pausar: feedback visual inmediato para que el usuario no perciba "error de fetch" cuando el server tarda en responder.

## Diagnóstico

Bench del dashboard actual:
- `/api/state` → 4.88s
- `/api/needs-human/.../block` → 3-6s
- `/api/needs-human/.../reactivate` → 3.27s

El problema NO era el `gh CLI` (ya está async desde #2796). Es un cuello más grande, probablemente `getPipelineState()` reconstruyendo todo el state desde filesystem en cada request.

Resultado: el usuario hace clic, no ve respuesta, hace clic otra vez. A veces el primer fetch eventualmente completa pero el cliente percibe "error de fetch" antes (timeout del navegador, cancelación, etc.).

## Fix

UI optimista: al hacer clic en ⏸:

1. La card se oscurece (`opacity: 0.3`) y desactiva (`pointer-events: none`) **inmediatamente**
2. El fetch corre en background
3. Si OK: la card se oculta (`display: none`) definitivamente
4. Si error: el opacity se restaura y aparece el alert

El usuario tiene respuesta visual instantánea aunque el server tarde unos segundos. No hay incentivo para clickear de nuevo.

## Tech debt pendiente

La lentitud general del dashboard (3-5s por request) merece investigación dedicada. Probable culpable: `getPipelineState()` reconstruyendo el state desde filesystem en cada request (cientos de archivos, sin cache).

## Plan de tests

- [x] Sintaxis validada
- [ ] Tras restart del dashboard: clic en ⏸ → la card se oscurece inmediatamente → desaparece tras la respuesta
- [ ] Verificar que con error, la card vuelve a su estado original

## QA

`qa:skipped` — Mejora UX en dashboard interno, sin impacto en producto de usuario.

🤖 Generado con [Claude Code](https://claude.ai/claude-code)