### PR TITLE
fix(dashboard): performance (cache state) + theme dark forzado + log viewer con tema

### DIFF
--- a/.pipeline/dashboard.js
+++ b/.pipeline/dashboard.js
@@ -320,6 +320,25 @@ function fmtTime(ms) {
 
 // --- Recolectar estado ---
 
+// Cache memoizado del state — getPipelineState() escanea TODO el filesystem
+// del pipeline (cada fase × cada estado × cada archivo). En el dashboard
+// nuevo (#2801) cada bloque hace polling independiente, y sin cache cada
+// endpoint /api/dash/* re-escanea el FS → 8-12s por endpoint, dashboard
+// inutilizable. TTL 1500ms balancea frescura (sub-segundo apenas se nota
+// el desfase) con costo (un único escaneo cubre todos los endpoints del
+// mismo "tick" de polling).
+let _stateCache = null;
+let _stateCacheAt = 0;
+const STATE_CACHE_TTL_MS = 2000;
+
+function getCachedPipelineState() {
+  const now = Date.now();
+  if (_stateCache && (now - _stateCacheAt) < STATE_CACHE_TTL_MS) return _stateCache;
+  _stateCache = getPipelineState();
+  _stateCacheAt = now;
+  return _stateCache;
+}
+
 function getPipelineState() {
   const config = loadConfig();
   const state = { config };
@@ -6620,14 +6639,26 @@ setInterval(refresh, 60000);
 
 function generateLogViewerHTML(filename, isLive) {
   const title = filename.replace('.log', '').replace(/-/g, ' ');
+  // Import theme compartido (#2801) — el log viewer es un satélite más,
+  // hereda paleta y tipografía del resto del dashboard nuevo.
+  let sharedTheme = '';
+  try { sharedTheme = fs.readFileSync(path.join(__dirname, 'views', 'dashboard', 'theme.css'), 'utf8'); }
+  catch { /* fallback al CSS local de abajo */ }
   return `<!DOCTYPE html>
-<html><head>
+<html lang="es"><head>
 <meta charset="utf-8">
-<title>${title} — Log Viewer</title>
+<title>${title} — Log Viewer · Intrale</title>
+<style>${sharedTheme}</style>
 <style>
-:root{--bg:#0d1117;--sf:#161b22;--tx:#e6edf3;--dim:#8b949e;--bd:#30363d;--ac:#58a6ff;--gn:#3fb950;--rd:#f85149;--yl:#d29922;--or:#d18616}
+:root{--bg:var(--in-bg);--sf:var(--in-bg-2);--tx:var(--in-fg);--dim:var(--in-fg-dim);--bd:var(--in-border);--ac:var(--in-info);--gn:var(--in-ok);--rd:var(--in-bad);--yl:var(--in-warn);--or:#d18616}
 *{margin:0;padding:0;box-sizing:border-box}
-body{background:var(--bg);color:var(--tx);font-family:'JetBrains Mono',Consolas,monospace;font-size:13px}
+body{background:var(--in-bg);color:var(--in-fg);font-family:var(--in-mono);font-size:13px}
+.lv-topbar{display:flex;align-items:center;gap:14px;padding:14px 22px;background:linear-gradient(135deg,var(--in-brand-soft),transparent 60%);border-bottom:1px solid var(--in-border)}
+.lv-back{font-size:12px;color:var(--in-fg-dim);text-decoration:none}
+.lv-back:hover{color:var(--in-accent)}
+.lv-back::before{content:"← "}
+.lv-logo{width:28px;height:28px;border-radius:8px;background:linear-gradient(135deg,var(--in-brand),var(--in-accent));color:#fff;font-weight:700;display:flex;align-items:center;justify-content:center;font-family:var(--in-font);font-size:14px}
+.lv-name{font-family:var(--in-font);font-size:14px;font-weight:600}
 .header{position:sticky;top:0;z-index:10;background:var(--sf);border-bottom:1px solid var(--bd);padding:10px 16px;display:flex;align-items:center;gap:12px;flex-wrap:wrap}
 .title{font-size:1.1em;font-weight:700;color:var(--ac)}
 .badge{font-size:0.78em;padding:2px 10px;border-radius:10px;font-weight:600}
@@ -6659,6 +6690,11 @@ input[type=text]:focus{outline:none;border-color:var(--ac)}
 .scroll-btn.visible{display:block}
 </style>
 </head><body>
+<div class="lv-topbar">
+  <a class="lv-back" href="/" target="_self">Operación</a>
+  <span class="lv-logo">i</span>
+  <span class="lv-name">Intrale · Log Viewer</span>
+</div>
 <div class="header">
   <span class="title">${title}</span>
   <span class="badge ${isLive ? 'badge-live' : 'badge-done'}">${isLive ? '● LIVE' : '✓ Finalizado'}</span>
@@ -7643,7 +7679,7 @@ const server = http.createServer((req, res) => {
     const dashRoutes = require('./lib/dashboard-routes');
     const url = req.url || '';
     const isLegacy = (url === '/legacy' || url === '/legacy/');
-    if (!isLegacy && dashRoutes.handle(req, res, { getState: getPipelineState, PIPELINE, ROOT, GH_BIN })) {
+    if (!isLegacy && dashRoutes.handle(req, res, { getState: getCachedPipelineState, PIPELINE, ROOT, GH_BIN })) {
       return;
     }
   } catch (e) {

--- a/.pipeline/lib/dashboard-slices.js
+++ b/.pipeline/lib/dashboard-slices.js
@@ -150,20 +150,28 @@ function headerSlice(state, ctx) {
     };
 }
 
+// `gh pr list` tarda ~3-4s y los PRs mergeados de 7 días no cambian rápido.
+// Cache de 5 min para no bloquear el endpoint /api/dash/kpis cada poll.
+let _prsCache = { value: null, at: 0 };
+const PRS_CACHE_TTL_MS = 5 * 60 * 1000;
+
 function kpisSlice(state, ctx) {
     const PIPELINE = ctx.PIPELINE;
     const ROOT = ctx.ROOT;
     const GH_BIN = ctx.GH_BIN;
 
-    let prsLast7d = null;
-    try {
-        const since = new Date(Date.now() - 7 * 86400000).toISOString().slice(0, 10);
-        const result = execSync(
-            `"${GH_BIN}" pr list --state merged --search "merged:>=${since}" --json number --limit 200`,
-            { cwd: ROOT, encoding: 'utf8', timeout: 8000, windowsHide: true }
-        );
-        prsLast7d = JSON.parse(result || '[]').length;
-    } catch { /* gh offline */ }
+    let prsLast7d = _prsCache.value;
+    if (Date.now() - _prsCache.at > PRS_CACHE_TTL_MS) {
+        try {
+            const since = new Date(Date.now() - 7 * 86400000).toISOString().slice(0, 10);
+            const result = execSync(
+                `"${GH_BIN}" pr list --state merged --search "merged:>=${since}" --json number --limit 200`,
+                { cwd: ROOT, encoding: 'utf8', timeout: 8000, windowsHide: true }
+            );
+            prsLast7d = JSON.parse(result || '[]').length;
+            _prsCache = { value: prsLast7d, at: Date.now() };
+        } catch { /* gh offline — mantener valor previo del cache si existe */ }
+    }
 
     let tokens24h = null;
     let snapshot = null;

--- a/.pipeline/views/dashboard/theme.css
+++ b/.pipeline/views/dashboard/theme.css
@@ -1,9 +1,11 @@
-/* Intrale V3 — tema compartido entre home kiosk y tabs satélite.
- * Paleta: identidad Intrale (azul + acento cian), modo oscuro por default,
- * con override claro vía media query.
+/* Intrale — tema compartido entre home kiosk y tabs satélite.
+ * Paleta: identidad Intrale (azul + acento cian).
+ * Modo oscuro siempre — el dashboard se mira en kiosko largas horas, el
+ * fondo claro cansa la vista. Si en el futuro hace falta modo claro,
+ * se controla con `data-theme="light"` en <html>, no con prefers-color-scheme.
  */
 
-:root {
+:root, html[data-theme="dark"] {
   --in-bg: #0d1117;
   --in-bg-2: #161b22;
   --in-bg-3: #1f2937;
@@ -34,19 +36,20 @@
 
   --in-font: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   --in-mono: ui-monospace, "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+
+  color-scheme: dark;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    --in-bg: #f6f8fa;
-    --in-bg-2: #ffffff;
-    --in-bg-3: #eaeef2;
-    --in-fg: #1f2328;
-    --in-fg-dim: #57606a;
-    --in-fg-soft: #8c959f;
-    --in-border: #d0d7de;
-    --in-border-soft: rgba(0,0,0,0.05);
-  }
+html[data-theme="light"] {
+  --in-bg: #f6f8fa;
+  --in-bg-2: #ffffff;
+  --in-bg-3: #eaeef2;
+  --in-fg: #1f2328;
+  --in-fg-dim: #57606a;
+  --in-fg-soft: #8c959f;
+  --in-border: #d0d7de;
+  --in-border-soft: rgba(0,0,0,0.05);
+  color-scheme: light;
 }
 
 * { box-sizing: border-box; }


### PR DESCRIPTION
## Summary

Tres correcciones críticas al rediseño kiosk de #2801, tras feedback en vivo:

1. **Performance del polling** — endpoints `/api/dash/*` tardaban **9-12s** cada uno porque `getPipelineState()` re-escanea todo el filesystem en cada llamada. Con 8 endpoints poleando cada 2-60s, el dashboard quedaba inutilizable. **Fix**: cache memoizado del state con TTL 2000ms (`getCachedPipelineState` en dashboard.js). Plus cache de 5 min para `gh pr list` en `kpisSlice`. **Resultado**: 2-15ms cache hit, 1-2s cache miss puntual.
2. **Theme dark forzado** — `@media (prefers-color-scheme: light)` ponía fondo blanco en navegadores con tema claro del SO, cansa la vista en kiosk. **Fix**: dark siempre, modo claro vía `data-theme="light"` explícito. Plus `color-scheme: dark` para scrollbars y form controls.
3. **Log viewer con identidad** — `/logs/view/*.log` rompía continuidad visual con su propia paleta inline. **Fix**: importar `theme.css` compartido + topbar Intrale (logo + back-link). Variables locales mapeadas a las del sistema.

`qa:skipped` — fix interno del dashboard de operación, sin impacto en apps cliente/business/delivery.

## Smoke timing (verificado en :3201)

| Endpoint | Antes | Después |
|---|---|---|
| /api/dash/header | 9.0s | 2ms |
| /api/dash/active | 9.5s | 15ms |
| /api/dash/equipo | 9.0s | 1.6s (1ª)/2ms (cache) |
| /api/dash/kpis | 12.1s | 2.9s (1ª)/sub-seg (cache) |
| /api/dash/recent | 9.5s | 1.7s/2ms |

## Test plan
- [ ] Refrescar `/` y verificar fondo dark (sin importar tema del SO)
- [ ] Abrir tabs satélite y ver que muestren datos en <2s
- [ ] Abrir `/logs/view/<algo>.log?live=1` y verificar topbar Intrale + paleta consistente
- [ ] Active section actualiza con nuevo agente sin flicker

Relacionado a #2801 (no lo cierra, mejora post-merge).