### PR TITLE
feat(dashboard): home — botonera de áreas debajo de KPIs, sin título

### DIFF
--- a/.pipeline/views/dashboard/home.js
+++ b/.pipeline/views/dashboard/home.js
@@ -644,6 +644,10 @@ function renderHomeHTML() {
       </div>
     </section>
 
+    <nav class="areas-bar" aria-label="Áreas">
+      ${areasHtml}
+    </nav>
+
     <section class="active-section">
       <h2 class="in-section-title">
         <span class="in-section-title-icon">🟢</span>
@@ -660,7 +664,7 @@ function renderHomeHTML() {
     <section class="in-section">
       <h2 class="in-section-title">
         <span class="in-section-title-icon">⏪</span>
-        Últimos 3 ejecutados
+        Últimos 5 ejecutados
       </h2>
       <div class="line-list" id="recent-list"></div>
     </section>
@@ -668,19 +672,9 @@ function renderHomeHTML() {
     <section class="in-section">
       <h2 class="in-section-title">
         <span class="in-section-title-icon">⏩</span>
-        Próximos 3 en cola
+        Próximos 5 en cola
       </h2>
       <div class="line-list" id="queue-list"></div>
-    </section>
-
-    <section class="in-section">
-      <h2 class="in-section-title">
-        <span class="in-section-title-icon">🗂</span>
-        Áreas
-      </h2>
-      <div class="areas-bar">
-        ${areasHtml}
-      </div>
     </section>
 
   </main>


### PR DESCRIPTION
Mueve la botonera de áreas a justo debajo de los KPIs y elimina el título "🗂 Áreas" (la botonera se entiende sola). Plus titulos "Últimos 3/Próximos 3" → "Últimos 5/Próximos 5" para alinear con #2807. qa:skipped — UI interna del dashboard.