### PR TITLE
feat(dashboard): pipeline ordenado por prioridad + botones top/up/down/bottom/pausar

### DIFF
--- a/.pipeline/dashboard.js
+++ b/.pipeline/dashboard.js
@@ -18,7 +18,7 @@ const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
-const { execSync, spawn } = require('child_process');
+const { execSync, spawn, spawnSync } = require('child_process');
 const yaml = require('js-yaml');
 const {
   findPidByComponent,
@@ -7555,6 +7555,56 @@ const server = http.createServer((req, res) => {
         res.end(JSON.stringify({ ok: false, msg: result.reason }));
       }
     });
+    return;
+  }
+
+  // API mover issue al tope/fondo absoluto del orden manual (#2801).
+  // Distinto de move-before/move-after: no requiere conocer el anchor, el server
+  // resuelve el primer/último issue del state.
+  const moveExtremeMatch = req.url && req.url.match(/^\/api\/issue\/(\d+)\/(move-top|move-bottom)$/);
+  if (moveExtremeMatch && req.method === 'POST') {
+    const issueNum = String(moveExtremeMatch[1]);
+    const action = moveExtremeMatch[2];
+    let issueOrder;
+    try { issueOrder = require('./lib/issue-order'); }
+    catch (e) {
+      res.writeHead(503, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ok: false, msg: 'issue-order lib no disponible: ' + e.message }));
+      return;
+    }
+    const state = issueOrder.load();
+    const order = (state.order || []).filter(x => String(x) !== issueNum);
+    if (action === 'move-top') order.unshift(issueNum);
+    else order.push(issueNum);
+    issueOrder.setOrder(state, order);
+    const newPos = state.order.indexOf(issueNum);
+    log(`order: ${action} #${issueNum} → posición ${newPos + 1}`);
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ ok: true, msg: `Issue #${issueNum} → ${action === 'move-top' ? 'tope' : 'fondo'} (posición ${newPos + 1})`, position: newPos }));
+    return;
+  }
+
+  // API pausar/reanudar issue individual (#2801) — toggle del label
+  // `blocked:dependencies` en GitHub. El pulpo ya respeta ese label en intake
+  // y lanzamiento (líneas 6663, 3534), así que con set/unset alcanza.
+  const pauseIssueMatch = req.url && req.url.match(/^\/api\/issue\/(\d+)\/(pause|resume)$/);
+  if (pauseIssueMatch && req.method === 'POST') {
+    const issueNum = String(pauseIssueMatch[1]);
+    const action = pauseIssueMatch[2];
+    const repo = 'intrale/platform';
+    const flag = action === 'pause' ? '--add-label' : '--remove-label';
+    const result = spawnSync(GH_BIN, ['issue', 'edit', issueNum, '--repo', repo, flag, 'blocked:dependencies'], {
+      encoding: 'utf8', timeout: 15000, windowsHide: true
+    });
+    if (result.status !== 0) {
+      log(`pauseIssue: #${issueNum} ${action} FAIL — ${(result.stderr || '').slice(0, 200)}`);
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ok: false, msg: `gh edit falló: ${(result.stderr || '').trim().slice(0, 200)}` }));
+      return;
+    }
+    log(`pauseIssue: #${issueNum} ${action === 'pause' ? 'pausado (+blocked:dependencies)' : 'reanudado (-blocked:dependencies)'}`);
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ ok: true, msg: `Issue #${issueNum} ${action === 'pause' ? 'pausado' : 'reanudado'}` }));
     return;
   }
 

--- a/.pipeline/lib/dashboard-slices.js
+++ b/.pipeline/lib/dashboard-slices.js
@@ -259,7 +259,7 @@ function equipoSlice(state) {
     return { skills };
 }
 
-function pipelineSlice(state) {
+function pipelineSlice(state, ctx) {
     const matrix = {};
     for (const [issueId, data] of Object.entries(state.issueMatrix || {})) {
         matrix[issueId] = {
@@ -271,7 +271,15 @@ function pipelineSlice(state) {
             staleMin: data.staleMin,
         };
     }
-    return { matrix, fases: state.allFases };
+    // Orden manual de prioridad (#2801) — el cliente lo usa para ordenar
+    // las columnas del kanban. Sin esto cada cliente ordena distinto.
+    let priorityOrder = [];
+    try {
+        const issueOrder = require('./issue-order');
+        const data = issueOrder.load();
+        priorityOrder = (data && Array.isArray(data.order)) ? data.order.map(String) : [];
+    } catch { /* lib no disponible */ }
+    return { matrix, fases: state.allFases, priorityOrder };
 }
 
 function bloqueadosSlice(state) {

--- a/.pipeline/views/dashboard/home.js
+++ b/.pipeline/views/dashboard/home.js
@@ -476,7 +476,13 @@ function renderLineRow(a, isQueue){
     const ghLink = '<a class="line-btn" href="https://github.com/intrale/platform/issues/'+a.issue+'" target="_blank" rel="noopener" title="Abrir issue en GitHub">↗</a>';
     let actions = '';
     if(isQueue){
-        actions = '<button class="line-btn" data-issue="'+a.issue+'" data-action="move-up" title="Subir prioridad">▲</button><button class="line-btn" data-issue="'+a.issue+'" data-action="move-down" title="Bajar prioridad">▼</button>'+ghLink;
+        actions = ''
+          + '<button class="line-btn" data-issue="'+a.issue+'" data-action="move-top" title="Máxima prioridad">⏫</button>'
+          + '<button class="line-btn" data-issue="'+a.issue+'" data-action="move-up" title="Subir prioridad">▲</button>'
+          + '<button class="line-btn" data-issue="'+a.issue+'" data-action="move-down" title="Bajar prioridad">▼</button>'
+          + '<button class="line-btn" data-issue="'+a.issue+'" data-action="move-bottom" title="Mínima prioridad">⏬</button>'
+          + '<button class="line-btn" data-issue="'+a.issue+'" data-action="pause" title="Pausar issue (label blocked:dependencies)">⏸</button>'
+          + ghLink;
     } else {
         const logBtn = a.hasLog ? '<a class="line-btn" href="/logs/view/'+(a.logFile||'')+'" target="_blank" rel="noopener" title="Ver log">📄</a>' : '';
         actions = logBtn+ghLink;
@@ -496,7 +502,11 @@ function bindLineActions(container){
     container.querySelectorAll('.line-btn[data-action]').forEach(b => {
         if(b.dataset._bound) return;
         b.dataset._bound = '1';
-        b.addEventListener('click', () => moveIssue(b.dataset.issue, b.dataset.action));
+        b.addEventListener('click', () => {
+            const action = b.dataset.action;
+            if(action === 'pause') return pauseIssueHome(b.dataset.issue);
+            return moveIssue(b.dataset.issue, action);
+        });
     });
 }
 
@@ -559,6 +569,16 @@ async function moveIssue(issue, direction){
         const j = await r.json();
         showToast(j.msg || (j.ok?'Movido':'Falló'), j.ok);
         setTimeout(() => tickQueue().catch(()=>{}), 400);
+    } catch(e){ showToast('Error: '+e.message, false); }
+}
+
+async function pauseIssueHome(issue){
+    if(!confirm('¿Pausar #'+issue+'? Agrega label blocked:dependencies; el pulpo lo saltea hasta que lo reanudes en /pipeline.')) return;
+    try{
+        const r = await fetch('/api/issue/'+issue+'/pause', {method:'POST'});
+        const j = await r.json();
+        showToast(j.msg || (j.ok?'Pausado':'Falló'), j.ok);
+        setTimeout(() => tickQueue().catch(()=>{}), 600);
     } catch(e){ showToast('Error: '+e.message, false); }
 }
 

--- a/.pipeline/views/dashboard/satellites.js
+++ b/.pipeline/views/dashboard/satellites.js
@@ -127,6 +127,17 @@ async function moveIssue(issue, direction){
     } catch(e){ showToast('Error: '+e.message, false); }
 }
 
+async function pauseIssue(issue, paused){
+    const verb = paused ? 'Reanudar' : 'Pausar';
+    if(!confirm('¿'+verb+' #'+issue+'? '+(paused ? '(quita label blocked:dependencies)' : '(agrega label blocked:dependencies)'))) return;
+    try{
+        const r = await fetch('/api/issue/'+issue+'/'+(paused?'resume':'pause'), {method:'POST'});
+        const j = await r.json();
+        showToast(j.msg || (j.ok?(paused?'Reanudado':'Pausado'):'Falló'), j.ok);
+        if(typeof runAll === 'function') setTimeout(runAll, 600);
+    } catch(e){ showToast('Error: '+e.message, false); }
+}
+
 document.addEventListener('visibilitychange', () => { if(document.visibilityState === 'visible' && typeof runAll === 'function') runAll(); });
 `;
 }
@@ -258,17 +269,41 @@ function renderPipeline() {
 </section>`;
     const css = `
 .pl-board { display: flex; gap: 10px; overflow-x: auto; padding-bottom: 8px; }
-.pl-col { min-width: 180px; flex: 1; background: var(--in-bg-3); border-radius: var(--in-radius-sm); padding: 10px; border: 1px solid var(--in-border); }
+.pl-col { min-width: 220px; flex: 1; background: var(--in-bg-3); border-radius: var(--in-radius-sm); padding: 10px; border: 1px solid var(--in-border); }
 .pl-col-head { display: flex; align-items: center; justify-content: space-between; font-size: 11px; text-transform: uppercase; letter-spacing: 0.6px; color: var(--in-fg-dim); margin-bottom: 8px; padding-bottom: 6px; border-bottom: 1px solid var(--in-border); }
 .pl-col-count { background: var(--in-bg); padding: 1px 8px; border-radius: 9px; font-size: 10px; color: var(--in-fg); }
-.pl-card { display: block; background: var(--in-bg-2); border: 1px solid var(--in-border); border-radius: 6px; padding: 8px 10px; margin-bottom: 6px; font-size: 12px; transition: border-color 0.2s, background 0.2s; color: var(--in-fg); text-decoration: none; }
+.pl-card { background: var(--in-bg-2); border: 1px solid var(--in-border); border-radius: 6px; padding: 8px 10px; margin-bottom: 6px; font-size: 12px; transition: border-color 0.2s, background 0.2s; color: var(--in-fg); }
 .pl-card:hover { border-color: var(--in-accent); background: var(--in-bg-3); }
+.pl-card-head { display: flex; align-items: center; gap: 6px; margin-bottom: 4px; }
 .pl-card-issue { font-weight: 600; color: var(--in-info); }
+.pl-card-issue a { color: inherit; text-decoration: none; }
+.pl-card-issue a:hover { text-decoration: underline; }
+.pl-card-prio { color: var(--in-fg-soft); font-size: 10px; margin-left: auto; font-variant-numeric: tabular-nums; }
 .pl-card-title { font-size: 11px; color: var(--in-fg-dim); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.pl-card-actions { display: flex; gap: 3px; margin-top: 6px; opacity: 0.55; transition: opacity 0.15s; }
+.pl-card:hover .pl-card-actions { opacity: 1; }
+.pl-card-btn { background: transparent; border: 1px solid var(--in-border); color: var(--in-fg-dim); border-radius: 3px; width: 22px; height: 20px; font-size: 10px; cursor: pointer; padding: 0; line-height: 1; transition: background 0.12s, border-color 0.12s, color 0.12s; }
+.pl-card-btn:hover { background: var(--in-bg); border-color: var(--in-accent); color: var(--in-accent); }
+.pl-card-btn.pause:hover { border-color: var(--in-warn); color: var(--in-warn); }
+.pl-card-btn.paused { border-color: var(--in-warn); color: var(--in-warn); }
 .pl-card-state-trabajando { border-color: var(--in-accent); }
 .pl-card-state-listo { border-color: var(--in-ok); }
-.pl-card-state-pendiente { border-color: var(--in-fg-soft); }`;
+.pl-card-state-pendiente { border-color: var(--in-fg-soft); }
+.pl-card-paused-badge { display: inline-block; font-size: 9px; color: var(--in-warn); border: 1px solid var(--in-warn); border-radius: 3px; padding: 0 4px; margin-left: 4px; text-transform: uppercase; letter-spacing: 0.5px; }`;
     const script = `
+function compareByPriority(orderMap){
+    return (a, b) => {
+        const trab = (b.estado==='trabajando'?1:0) - (a.estado==='trabajando'?1:0);
+        if(trab !== 0) return trab;
+        const oa = orderMap.get(String(a.issue));
+        const ob = orderMap.get(String(b.issue));
+        if(oa != null && ob != null) return oa - ob;
+        if(oa != null) return -1;
+        if(ob != null) return 1;
+        return Number(a.issue) - Number(b.issue);
+    };
+}
+
 async function tickPipeline(){
     const d = await fetchJson('/api/dash/pipeline');
     if(!d) return;
@@ -276,6 +311,7 @@ async function tickPipeline(){
     if(!board) return;
     const fases = d.fases || [];
     const matrix = d.matrix || {};
+    const orderMap = new Map((d.priorityOrder || []).map((id, idx) => [String(id), idx]));
     const cols = {};
     for(const { pipeline: p, fase } of fases){
         const key = p+'/'+fase;
@@ -283,16 +319,46 @@ async function tickPipeline(){
     }
     for(const [issue, data] of Object.entries(matrix)){
         if(data.faseActual && cols[data.faseActual]){
-            cols[data.faseActual].items.push({ issue, title: data.title, estado: data.estadoActual, bounces: data.bounces, staleMin: data.staleMin });
+            const labels = data.labels || [];
+            const paused = labels.includes('blocked:dependencies');
+            cols[data.faseActual].items.push({ issue, title: data.title, estado: data.estadoActual, bounces: data.bounces, staleMin: data.staleMin, paused });
         }
     }
+    const cmp = compareByPriority(orderMap);
     let html = '';
     for(const [key, col] of Object.entries(cols)){
-        col.items.sort((a,b) => (b.estado==='trabajando'?1:0) - (a.estado==='trabajando'?1:0));
-        const cards = col.items.slice(0, 12).map(i => '<a href="https://github.com/intrale/platform/issues/'+escapeHtml(i.issue)+'" target="_blank" rel="noopener" class="pl-card pl-card-state-'+escapeHtml(i.estado||'')+'"><div class="pl-card-issue">#'+escapeHtml(i.issue)+'</div><div class="pl-card-title">'+escapeHtml((i.title||'').slice(0,40))+'</div></a>').join('');
+        col.items.sort(cmp);
+        const cards = col.items.slice(0, 12).map(i => {
+            const prio = orderMap.has(String(i.issue)) ? '#' + (orderMap.get(String(i.issue)) + 1) : '';
+            const pausedBadge = i.paused ? '<span class="pl-card-paused-badge">⏸ pausado</span>' : '';
+            const pauseBtn = '<button class="pl-card-btn pause' + (i.paused?' paused':'') + '" data-issue="'+escapeHtml(i.issue)+'" data-action="' + (i.paused?'resume':'pause') + '" title="' + (i.paused?'Reanudar issue':'Pausar issue') + '">' + (i.paused?'▶':'⏸') + '</button>';
+            return '<div class="pl-card pl-card-state-'+escapeHtml(i.estado||'')+'" data-issue="'+escapeHtml(i.issue)+'">'
+              + '<div class="pl-card-head"><span class="pl-card-issue"><a href="https://github.com/intrale/platform/issues/'+escapeHtml(i.issue)+'" target="_blank" rel="noopener">#'+escapeHtml(i.issue)+'</a></span>'+pausedBadge+'<span class="pl-card-prio">'+prio+'</span></div>'
+              + '<div class="pl-card-title" title="'+escapeHtml(i.title||'')+'">'+escapeHtml((i.title||'').slice(0,60))+'</div>'
+              + '<div class="pl-card-actions">'
+              +   '<button class="pl-card-btn" data-issue="'+escapeHtml(i.issue)+'" data-action="move-top" title="Máxima prioridad">⏫</button>'
+              +   '<button class="pl-card-btn" data-issue="'+escapeHtml(i.issue)+'" data-action="move-up" title="Subir">▲</button>'
+              +   '<button class="pl-card-btn" data-issue="'+escapeHtml(i.issue)+'" data-action="move-down" title="Bajar">▼</button>'
+              +   '<button class="pl-card-btn" data-issue="'+escapeHtml(i.issue)+'" data-action="move-bottom" title="Mínima prioridad">⏬</button>'
+              +   pauseBtn
+              + '</div>'
+              + '</div>';
+        }).join('');
         html += '<div class="pl-col"><div class="pl-col-head"><span>'+escapeHtml(key)+'</span><span class="pl-col-count">'+col.items.length+'</span></div>'+(cards || '<div class="in-empty" style="padding:14px 4px;font-size:11px">vacío</div>')+'</div>';
     }
-    if(board.innerHTML !== html) board.innerHTML = html;
+    if(board.innerHTML !== html){
+        board.innerHTML = html;
+        board.querySelectorAll('.pl-card-btn').forEach(b => {
+            const action = b.dataset.action;
+            b.addEventListener('click', (ev) => {
+                ev.preventDefault();
+                ev.stopPropagation();
+                const issue = b.dataset.issue;
+                if(action === 'pause' || action === 'resume') return pauseIssue(issue, action === 'resume');
+                return moveIssue(issue, action);
+            });
+        });
+    }
 }
 const POLLS = [{ fn: tickHeader, ms: 5000 }, { fn: tickPipeline, ms: 5000 }];
 async function runAll(){ for(const p of POLLS){ try{ await p.fn(); } catch{} } }


### PR DESCRIPTION
## Summary

**`/pipeline`**: cada columna se ordena por `priorityOrder` (de `issue-manual-order.json`); issues `trabajando` arriba. Cada card muestra # de prioridad y trae 5 botones al hover:

- ⏫ Máxima (`POST /api/issue/:n/move-top`)
- ▲ Subir (`move-up`)
- ▼ Bajar (`move-down`)
- ⏬ Mínima (`move-bottom`)
- ⏸/▶ Pausar/Reanudar (`pause`/`resume` → toggle label `blocked:dependencies`)

Cards pausadas: borde amarillo + chip "⏸ pausado" + botón cambia a ▶.

**Home `/`**: la cola gana los mismos 5 botones + ↗ GitHub. Antes solo tenía ▲▼↗.

**Endpoints nuevos** en dashboard.js:
- `POST /api/issue/:n/move-top` y `move-bottom` — splice al inicio/final del orden manual.
- `POST /api/issue/:n/pause` y `resume` — toggle del label `blocked:dependencies` vía `gh issue edit`. El pulpo ya respeta ese label en intake (línea 6663) y lanzamiento (3534), no requiere otro cambio.

`pipelineSlice` ahora retorna `priorityOrder` para que el cliente ordene.

`qa:skipped` — UI interna del dashboard de operación, sin impacto en apps cliente/business/delivery.

## Test plan

- [ ] `/pipeline`: ver columnas con cards ordenadas por # prioridad ascendente; trabajando arriba.
- [ ] Hover en una card muestra los 5 botones; click ⏫ lleva al issue al tope.
- [ ] Click ⏸ confirma, agrega label `blocked:dependencies` en GitHub, card cambia a borde amarillo + chip "⏸ pausado", botón se vuelve ▶.
- [ ] Click ▶ en card pausada quita el label y vuelve al estado normal.
- [ ] Home / queue: los 5 botones aparecen en cada item; ⏫⏬ funcionan como en /pipeline.

Relacionado a #2801.