### PR TITLE
fix(pipeline): propagar contexto del último rechazo en re-intake

### DIFF
--- a/.pipeline/dashboard.js
+++ b/.pipeline/dashboard.js
@@ -382,6 +382,20 @@ function getPipelineState() {
           entry.motivo = yamlData.motivo;
         }
 
+        // #2801 — Si el archivo en pendiente/trabajando tiene contexto de
+        // rebote (sea por flujo normal o por re-intake), exponerlo a la UI
+        // para que el operador sepa por qué este issue volvió a esta fase.
+        if (estado === 'pendiente' || estado === 'trabajando') {
+          const yamlData = readYamlSafe(filepath);
+          if (yamlData && (yamlData.rebote || yamlData.motivo_rechazo)) {
+            entry.rebote = true;
+            entry.rebote_tipo = yamlData.rebote_tipo || null;
+            entry.motivo_rechazo = yamlData.motivo_rechazo || null;
+            entry.rechazado_en_fase = yamlData.rechazado_en_fase || null;
+            entry.rechazado_skill_previo = yamlData.rechazado_skill_previo || null;
+          }
+        }
+
         // Log disponible? Buscar {issue}-{skill}.log o build-{issue}.log
         let logFile = `${issue}-${skill}.log`;
         if (!fs.existsSync(path.join(LOG_DIR, logFile)) && skill === 'build') {
@@ -443,6 +457,20 @@ function getPipelineState() {
       bounces += rejected.length;
     }
     data.bounces = bounces;
+    // #2801 — surface info de rebote del archivo activo (pendiente/trabajando)
+    // si el agente lo recibió con motivo_rechazo del intake o del barrido.
+    data.rebote = false;
+    for (const entries of Object.values(data.fases)) {
+      const reboteEntry = entries.find(e => (e.estado === 'pendiente' || e.estado === 'trabajando') && e.rebote);
+      if (reboteEntry) {
+        data.rebote = true;
+        data.rebote_tipo = reboteEntry.rebote_tipo || null;
+        data.motivo_rechazo = reboteEntry.motivo_rechazo || null;
+        data.rechazado_en_fase = reboteEntry.rechazado_en_fase || null;
+        data.rechazado_skill_previo = reboteEntry.rechazado_skill_previo || null;
+        break;
+      }
+    }
     // Calcular stale: minutos desde última actividad en fase activa
     if (data.estadoActual === 'trabajando') {
       const currentEntries = data.fases[data.faseActual] || [];

--- a/.pipeline/lib/dashboard-slices.js
+++ b/.pipeline/lib/dashboard-slices.js
@@ -269,6 +269,11 @@ function pipelineSlice(state, ctx) {
             estadoActual: data.estadoActual,
             bounces: data.bounces,
             staleMin: data.staleMin,
+            rebote: !!data.rebote,
+            rebote_tipo: data.rebote_tipo || null,
+            motivo_rechazo: data.motivo_rechazo || null,
+            rechazado_en_fase: data.rechazado_en_fase || null,
+            rechazado_skill_previo: data.rechazado_skill_previo || null,
         };
     }
     // Orden manual de prioridad (#2801) — el cliente lo usa para ordenar

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -6605,6 +6605,47 @@ function closeDuplicateIssue(dupNum, existingNum, dupTitle) {
   }
 }
 
+/**
+ * Busca el último rechazo del issue en `<pipeline>/<fase>/procesado/<issue>.*`.
+ * Devuelve `{motivo, fase, skill, at}` del archivo más reciente con
+ * `resultado: rechazado` o `null` si no encuentra ninguno.
+ *
+ * Caso de uso (#2801): el intake re-toma un issue que ya pasó por el pipeline
+ * (post circuit breaker o cleanup downstream). El agente que reciba el
+ * re-intake necesita saber por qué falló la corrida anterior — sin eso,
+ * arranca a ciegas y vuelve a fallar por la misma razón.
+ */
+function findLastRejection(pipelineName, issueNum, config) {
+    const pipelineConfig = (config.pipelines || {})[pipelineName];
+    if (!pipelineConfig) return null;
+    const fases = pipelineConfig.fases || [];
+    let best = null;
+    for (const fase of fases) {
+        const dir = path.join(fasePath(pipelineName, fase), 'procesado');
+        try {
+            for (const f of fs.readdirSync(dir)) {
+                if (!f.startsWith(issueNum + '.') || f.startsWith('.')) continue;
+                const filepath = path.join(dir, f);
+                let data;
+                try { data = readYaml(filepath); } catch { continue; }
+                if (!data || data.resultado !== 'rechazado') continue;
+                let at = 0;
+                try { at = fs.statSync(filepath).mtimeMs; } catch {}
+                if (!best || at > best.at) {
+                    const skill = f.split('.').slice(1).join('.');
+                    best = {
+                        motivo: data.motivo || data.motivo_rechazo || 'sin motivo registrado',
+                        fase,
+                        skill,
+                        at: at ? new Date(at).toISOString() : null,
+                    };
+                }
+            }
+        } catch { /* dir no existe */ }
+    }
+    return best;
+}
+
 function brazoIntake(config) {
   const intakeInterval = (config.timeouts?.intake_interval_seconds || 300) * 1000;
   if (Date.now() - lastIntakeTime < intakeInterval) return;
@@ -6693,13 +6734,30 @@ function brazoIntake(config) {
         const skills = pipelineConfig.skills_por_fase[faseEntrada] || [];
         const pendienteDir = path.join(fasePath(pipelineName, faseEntrada), 'pendiente');
 
+        // #2801 — Si el issue ya pasó por el pipeline antes (circuit breaker
+        // o intake repetido), buscamos el último rechazo en `*/procesado/`
+        // para propagar el contexto al nuevo archivo. Sin esto, el agente
+        // que recibe el re-intake arranca a ciegas y vuelve a fallar igual.
+        const previousRejection = findLastRejection(pipelineName, issueNum, config);
+        const baseYaml = { issue: parseInt(issueNum), fase: faseEntrada, pipeline: pipelineName };
+        if (previousRejection) {
+          baseYaml.rebote = true;
+          baseYaml.rebote_tipo = 're-intake';
+          baseYaml.rebote_re_intake = true;
+          baseYaml.motivo_rechazo = previousRejection.motivo;
+          baseYaml.rechazado_en_fase = previousRejection.fase;
+          baseYaml.rechazado_skill_previo = previousRejection.skill;
+          baseYaml.rechazado_at = previousRejection.at;
+        }
+
         if (faseEntrada === 'dev') {
           // Fase dev: un solo skill según labels
           const devSkill = determinarDevSkill(issueNum, config);
           const filePath = path.join(pendienteDir, `${issueNum}.${devSkill}`);
           if (!fs.existsSync(filePath)) {
-            writeYaml(filePath, { issue: parseInt(issueNum), fase: faseEntrada, pipeline: pipelineName });
-            log('intake', `#${issueNum} "${issue.title}" → ${pipelineName}/${faseEntrada} (${devSkill})`);
+            writeYaml(filePath, baseYaml);
+            const tag = previousRejection ? ` ↩ con contexto de rechazo previo (${previousRejection.fase}/${previousRejection.skill})` : '';
+            log('intake', `#${issueNum} "${issue.title}" → ${pipelineName}/${faseEntrada} (${devSkill})${tag}`);
           }
         } else {
           // Fase paralela: un archivo por skill
@@ -6707,12 +6765,13 @@ function brazoIntake(config) {
           for (const skill of skills) {
             const filePath = path.join(pendienteDir, `${issueNum}.${skill}`);
             if (!fs.existsSync(filePath)) {
-              writeYaml(filePath, { issue: parseInt(issueNum), fase: faseEntrada, pipeline: pipelineName });
+              writeYaml(filePath, baseYaml);
               created = true;
             }
           }
           if (created) {
-            log('intake', `#${issueNum} "${issue.title}" → ${pipelineName}/${faseEntrada} (${skills.join(', ')})`);
+            const tag = previousRejection ? ` ↩ con contexto de rechazo previo (${previousRejection.fase}/${previousRejection.skill})` : '';
+            log('intake', `#${issueNum} "${issue.title}" → ${pipelineName}/${faseEntrada} (${skills.join(', ')})${tag}`);
           }
         }
       }

--- a/.pipeline/views/dashboard/satellites.js
+++ b/.pipeline/views/dashboard/satellites.js
@@ -289,7 +289,8 @@ function renderPipeline() {
 .pl-card-state-trabajando { border-color: var(--in-accent); }
 .pl-card-state-listo { border-color: var(--in-ok); }
 .pl-card-state-pendiente { border-color: var(--in-fg-soft); }
-.pl-card-paused-badge { display: inline-block; font-size: 9px; color: var(--in-warn); border: 1px solid var(--in-warn); border-radius: 3px; padding: 0 4px; margin-left: 4px; text-transform: uppercase; letter-spacing: 0.5px; }`;
+.pl-card-paused-badge { display: inline-block; font-size: 9px; color: var(--in-warn); border: 1px solid var(--in-warn); border-radius: 3px; padding: 0 4px; margin-left: 4px; text-transform: uppercase; letter-spacing: 0.5px; }
+.pl-card-rebote { display: inline-block; font-size: 9px; font-weight: 600; color: var(--in-bad); border: 1px solid var(--in-bad); background: var(--in-bad-soft); border-radius: 3px; padding: 0 4px; margin-top: 4px; cursor: help; }`;
     const script = `
 function compareByPriority(orderMap){
     return (a, b) => {
@@ -321,7 +322,14 @@ async function tickPipeline(){
         if(data.faseActual && cols[data.faseActual]){
             const labels = data.labels || [];
             const paused = labels.includes('blocked:dependencies');
-            cols[data.faseActual].items.push({ issue, title: data.title, estado: data.estadoActual, bounces: data.bounces, staleMin: data.staleMin, paused });
+            cols[data.faseActual].items.push({
+                issue, title: data.title, estado: data.estadoActual,
+                bounces: data.bounces, staleMin: data.staleMin, paused,
+                rebote: data.rebote, rebote_tipo: data.rebote_tipo,
+                motivo_rechazo: data.motivo_rechazo,
+                rechazado_en_fase: data.rechazado_en_fase,
+                rechazado_skill_previo: data.rechazado_skill_previo,
+            });
         }
     }
     const cmp = compareByPriority(orderMap);
@@ -331,10 +339,14 @@ async function tickPipeline(){
         const cards = col.items.slice(0, 12).map(i => {
             const prio = orderMap.has(String(i.issue)) ? '#' + (orderMap.get(String(i.issue)) + 1) : '';
             const pausedBadge = i.paused ? '<span class="pl-card-paused-badge">⏸ pausado</span>' : '';
+            const reboteBadge = i.rebote
+              ? '<div class="pl-card-rebote" title="Rechazado en ' + escapeHtml(i.rechazado_en_fase||'?') + (i.rechazado_skill_previo?'/'+escapeHtml(i.rechazado_skill_previo):'') + ': ' + escapeHtml((i.motivo_rechazo||'').replace(/"/g,"\\u0027").slice(0,400)) + '">↩ rebote' + (i.rebote_tipo?' · '+escapeHtml(i.rebote_tipo):'') + '</div>'
+              : '';
             const pauseBtn = '<button class="pl-card-btn pause' + (i.paused?' paused':'') + '" data-issue="'+escapeHtml(i.issue)+'" data-action="' + (i.paused?'resume':'pause') + '" title="' + (i.paused?'Reanudar issue':'Pausar issue') + '">' + (i.paused?'▶':'⏸') + '</button>';
             return '<div class="pl-card pl-card-state-'+escapeHtml(i.estado||'')+'" data-issue="'+escapeHtml(i.issue)+'">'
               + '<div class="pl-card-head"><span class="pl-card-issue"><a href="https://github.com/intrale/platform/issues/'+escapeHtml(i.issue)+'" target="_blank" rel="noopener">#'+escapeHtml(i.issue)+'</a></span>'+pausedBadge+'<span class="pl-card-prio">'+prio+'</span></div>'
               + '<div class="pl-card-title" title="'+escapeHtml(i.title||'')+'">'+escapeHtml((i.title||'').slice(0,60))+'</div>'
+              + reboteBadge
               + '<div class="pl-card-actions">'
               +   '<button class="pl-card-btn" data-issue="'+escapeHtml(i.issue)+'" data-action="move-top" title="Máxima prioridad">⏫</button>'
               +   '<button class="pl-card-btn" data-issue="'+escapeHtml(i.issue)+'" data-action="move-up" title="Subir">▲</button>'
@@ -459,6 +471,7 @@ function renderIssues() {
 .iss-issue a:hover { text-decoration: underline; }
 .iss-title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--in-fg-dim); }
 .iss-title.paused::before { content: "⏸ "; color: var(--in-warn); font-weight: 600; }
+.iss-rebote { display: inline-block; font-size: 10px; font-weight: 600; color: var(--in-bad); border: 1px solid var(--in-bad); background: var(--in-bad-soft); border-radius: 3px; padding: 0 5px; margin-right: 6px; cursor: help; }
 .iss-fase { font-size: 11px; text-transform: uppercase; color: var(--in-fg-dim); }
 .iss-state { font-size: 11px; }
 .iss-state.trabajando { color: var(--in-accent); }
@@ -500,11 +513,14 @@ function renderIssuesTable(filter){
         const pauseIcon = paused ? '▶' : '⏸';
         const pauseTitle = paused ? 'Reanudar issue' : 'Pausar issue';
         const titleClass = paused ? 'iss-title paused' : 'iss-title';
+        const reboteChip = data.rebote
+          ? '<span class="iss-rebote" title="Rechazado en '+escapeHtml(data.rechazado_en_fase||'?')+(data.rechazado_skill_previo?'/'+escapeHtml(data.rechazado_skill_previo):'')+': '+escapeHtml((data.motivo_rechazo||'').replace(/"/g,"'").slice(0,300))+'">↩ rechazo</span>'
+          : '';
         html += ''
           + '<div class="iss-row" data-issue="'+escapeHtml(id)+'">'
           +   '<div class="'+prioClass+'">'+escapeHtml(prio)+'</div>'
           +   '<div class="iss-issue"><a href="https://github.com/intrale/platform/issues/'+escapeHtml(id)+'" target="_blank" rel="noopener">#'+escapeHtml(id)+'</a></div>'
-          +   '<div class="'+titleClass+'" title="'+escapeHtml(data.title||'')+'">'+escapeHtml(data.title||'')+'</div>'
+          +   '<div class="'+titleClass+'" title="'+escapeHtml(data.title||'')+'">'+reboteChip+escapeHtml(data.title||'')+'</div>'
           +   '<div class="iss-fase">'+escapeHtml(data.faseActual||'—')+'</div>'
           +   '<div class="iss-state '+escapeHtml(data.estadoActual||'')+'">'+escapeHtml(data.estadoActual||'')+'</div>'
           +   '<div class="iss-bounces '+(data.bounces>2?'warn':'')+'">'+(data.bounces||0)+'×</div>'


### PR DESCRIPTION
## Problema (caso #2505)

#2505 fue rechazado en delivery con motivo \`Rebase conflict: untracked file bash.exe.stackdump\`. El barrido escaló a manual por circuit breaker (3 rebotes), todos los archivos pasaron a \`procesado/\`. Después el intake — que solo chequea \`pendiente/trabajando/listo/bloqueado-humano\` con \`issueExistsInPipeline\` — vio el label \`Ready\` en GitHub y re-tomó el issue como nuevo.

**Resultado**: los archivos creados en \`validacion/pendiente/2505.{po,ux,guru}\` solo tenían \`{issue, fase, pipeline}\` — el guru/po/ux arrancaban a ciegas, sin saber que la corrida anterior falló por un conflicto de rebase. **Probabilidad alta de fallar igual.**

## Fix en 3 capas

**1. Backend (`pulpo.js`)**:
- Nueva función `findLastRejection(pipeline, issue, config)` busca el último \`*/procesado/<issue>.*\` con \`resultado: rechazado\` y devuelve \`{motivo, fase, skill, at}\`.
- Intake enriquece cada YAML que crea con \`rebote: true\`, \`rebote_tipo: 're-intake'\`, \`motivo_rechazo\`, \`rechazado_en_fase\`, \`rechazado_skill_previo\`, \`rechazado_at\`.

**2. Prompt del agente** (sin cambios — ya soporta):
- El prompt en línea 4549 detecta \`workData.rebote === true\` y arma un bloque \"⚠️ REBOTE — Este issue fue RECHAZADO en la fase X y vuelve a vos para corrección. MOTIVO: ...\". Con esto el agente ahora tiene la info para actuar.

**3. Dashboard** (`/pipeline` y `/issues`):
- \`getPipelineState\` lee \`motivo_rechazo\` también de archivos en pendiente/trabajando.
- \`pipelineSlice\` retorna 5 campos nuevos del rebote.
- Cards de \`/pipeline\`: chip rojo \"↩ rebote · re-intake\" con tooltip del motivo (300 chars).
- Rows de \`/issues\`: chip rojo \"↩ rechazo\" antes del título.

\`qa:skipped\` — fix del flujo interno del pipeline + UI del dashboard.

## Test plan
- [ ] Issue que rechace + escale a circuit breaker + re-intake automático: el archivo nuevo en \`pendiente/\` debe contener \`motivo_rechazo\` del último rechazo
- [ ] \`/pipeline\` muestra chip \"↩ rebote\" en la card; hover revela motivo completo
- [ ] \`/issues\` muestra chip \"↩ rechazo\" antes del título
- [ ] Al lanzar un agente sobre un issue re-intakeado, el prompt incluye el bloque \"⚠️ REBOTE\" con motivo y instrucciones

## Pendiente (issue futuro)
Routing inteligente: un \`Rebase conflict\` no es responsabilidad de guru/po/ux. Idealmente el barrido debería rutear al skill apto (pipeline-dev) según el tipo de motivo. Hoy va al pipeline default.

Relacionado a #2801.