### PR TITLE
fix(dashboard): pausa parcial confirma lista de issues parseados antes de aplicar

### DIFF
--- a/.pipeline/views/dashboard/home.js
+++ b/.pipeline/views/dashboard/home.js
@@ -698,6 +698,12 @@ function bindModeToggle(){
                     if(!raw){ showToast('Ingresá al menos 1 issue (ej: 2505, 2519)', false); return; }
                     const issues = raw.split(/[,\s]+/).map(s => Number(s.replace(/^#/, '').trim())).filter(n => Number.isInteger(n) && n > 0);
                     if(issues.length === 0){ showToast('Ningún número de issue válido en el input', false); return; }
+                    const lista = issues.map(n => '#'+n).join(', ');
+                    const msg = '¿Activar pausa parcial?\n\n' +
+                        'Solo se van a procesar estos ' + issues.length + ' issue' + (issues.length===1?'':'s') + ':\n' +
+                        lista + '\n\n' +
+                        'El resto del pipeline queda pausado hasta que reanudes o cambies la lista.';
+                    if(!confirm(msg)) return;
                     const r = await fetch('/api/pause-partial', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({issues})});
                     const j = await r.json();
                     showToast(j.msg || 'Pausa parcial aplicada', j.ok);


### PR DESCRIPTION
Click en 'Aplicar pausa parcial' ahora muestra confirm() con la lista de issues parseados (`#2505, #2519, ...`) y solo aplica si el usuario acepta. Evita aplicar pausa por error si el input está mal.\n\nqa:skipped — UI.