### PR TITLE
fix(dashboard): escapar \n en msg de pausa parcial — rompía parse del JS cliente

### DIFF
--- a/.pipeline/views/dashboard/home.js
+++ b/.pipeline/views/dashboard/home.js
@@ -699,9 +699,11 @@ function bindModeToggle(){
                     const issues = raw.split(/[,\s]+/).map(s => Number(s.replace(/^#/, '').trim())).filter(n => Number.isInteger(n) && n > 0);
                     if(issues.length === 0){ showToast('Ningún número de issue válido en el input', false); return; }
                     const lista = issues.map(n => '#'+n).join(', ');
-                    const msg = '¿Activar pausa parcial?\n\n' +
-                        'Solo se van a procesar estos ' + issues.length + ' issue' + (issues.length===1?'':'s') + ':\n' +
-                        lista + '\n\n' +
+                    // \\n para que el template literal de Node escriba "\\n" literal al HTML;
+                    // el cliente al ejecutar el string los interpreta como saltos de línea.
+                    const msg = '¿Activar pausa parcial?\\n\\n' +
+                        'Solo se van a procesar estos ' + issues.length + ' issue' + (issues.length===1?'':'s') + ':\\n' +
+                        lista + '\\n\\n' +
                         'El resto del pipeline queda pausado hasta que reanudes o cambies la lista.';
                     if(!confirm(msg)) return;
                     const r = await fetch('/api/pause-partial', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({issues})});


### PR DESCRIPTION
Regresión del PR #2815. Los \n del confirm() estaban dentro de un template literal de Node y se convertían en newlines reales rompiendo las comillas simples del cliente → JS no parseaba → home en blanco. Fix: escapar como \\n para que queden \n literales y el cliente los interprete en runtime.\n\nVerificado: `node --check` del JS embebido pasa.\n\nqa:skipped — UI.