### PR TITLE
fix(pipeline): intake busca 'Ready' (case-sensitive) en lugar de 'ready' — pulpo no lanzaba

### DIFF
--- a/.pipeline/config.yaml
+++ b/.pipeline/config.yaml
@@ -68,7 +68,7 @@ intake:
     label: "needs-definition"
     fase_entrada: analisis
   desarrollo:
-    label: "ready"
+    label: "Ready"
     fase_entrada: validacion
 
 # Mapeo de labels de GitHub a skill de desarrollo


### PR DESCRIPTION
Bug raíz por el que el pipeline no lanzaba nada: `config.yaml` decía `label: "ready"` pero los issues tienen `Ready` (case-sensitive). `gh issue list --label "ready"` retornaba 0; `--label "Ready"` retorna 100+. `qa:skipped`.