### PR TITLE
feat(dashboard): reactivar issues con orientación humana inyectada al prompt del agente

### DIFF
--- a/.pipeline/dashboard.js
+++ b/.pipeline/dashboard.js
@@ -7374,8 +7374,12 @@ const server = http.createServer((req, res) => {
       };
 
       if (action === 'reactivate') {
+        // #2801 — guidance opcional desde el dashboard. Si viene, se persiste
+        // en `<marker>.guidance.txt` (vía humanBlock) y el pulpo la inyecta
+        // al prompt del agente cuando lo lance.
+        const guidance = String(payload.guidance || '').trim();
         let result;
-        try { result = humanBlock.unblockIssue({ issue: issueNum, guidance: '', unlocker: 'commander:dashboard' }); }
+        try { result = humanBlock.unblockIssue({ issue: issueNum, guidance, unlocker: 'commander:dashboard' }); }
         catch (e) {
           res.writeHead(500, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ ok: false, msg: 'Error desbloqueando: ' + e.message }));
@@ -7387,11 +7391,14 @@ const server = http.createServer((req, res) => {
           return;
         }
         ghTry(['issue', 'edit', String(issueNum), '--repo', repo, '--remove-label', 'needs-human']);
-        const comment = `## ▶ Reactivado desde el dashboard\n\n**Skill:** \`${result.skill}\` · **Fase:** \`${result.from_phase}\` → \`${result.to_phase}\`\n\nVuelve a la cola del pipeline sin orientación adicional.`;
+        const guidanceBlock = guidance
+          ? `\n\n**Orientación del operador:**\n\n> ${guidance.replace(/\n/g, '\n> ')}`
+          : '\n\nVuelve a la cola del pipeline sin orientación adicional.';
+        const comment = `## ▶ Reactivado desde el dashboard\n\n**Skill:** \`${result.skill}\` · **Fase:** \`${result.from_phase}\` → \`${result.to_phase}\`${guidanceBlock}`;
         ghTry(['issue', 'comment', String(issueNum), '--repo', repo, '--body', comment]);
-        log(`needs-human: reactivado #${issueNum} (skill=${result.skill}, ${result.from_phase}→${result.to_phase})`);
+        log(`needs-human: reactivado #${issueNum} (skill=${result.skill}, ${result.from_phase}→${result.to_phase})${guidance ? ` con orientación (${guidance.length} chars)` : ''}`);
         res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ ok: true, msg: `Issue #${issueNum} reactivado`, ...result }));
+        res.end(JSON.stringify({ ok: true, msg: `Issue #${issueNum} reactivado${guidance ? ' con orientación' : ''}`, ...result }));
         return;
       }
 

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -4486,6 +4486,22 @@ function lanzarAgenteClaude(skill, issue, trabajandoPath, pipeline, fase, config
   // Construir user prompt — enriquecer si es un rebote con contexto del rechazo
   let userPrompt = `Archivo de trabajo: ${path.basename(trabajandoPath)}\nPath: ${trabajandoPath}\nContenido:\n${yaml.dump(workData, { lineWidth: -1 })}`;
 
+  // #2801 — Si el issue fue desbloqueado manualmente con orientación humana,
+  // human-block deja un archivo `<marker>.guidance.txt` junto al archivo de
+  // trabajo. Lo inyectamos al prompt como bloque destacado para que el
+  // agente sepa qué hacer ANTES de retomar el flujo normal. El archivo se
+  // borra después de leerlo (one-shot) para no contaminar reintentos.
+  try {
+    const guidancePath = trabajandoPath + '.guidance.txt';
+    if (fs.existsSync(guidancePath)) {
+      const guidance = fs.readFileSync(guidancePath, 'utf8').trim();
+      if (guidance) {
+        userPrompt += `\n\n📋 INDICACIONES HUMANAS — Este issue venía bloqueado y fue reactivado por un operador con guía explícita. Tenelo en cuenta antes de actuar:\n\n${guidance}\n\nUsá esta orientación para informar tus decisiones — NO la ignores.`;
+      }
+      try { fs.unlinkSync(guidancePath); } catch {}
+    }
+  } catch (e) { log('lanzamiento', `⚠️ ${skill}:#${issue} no se pudo leer guidance: ${e.message}`); }
+
   if (workData.rebote) {
     const rechazadoEn = workData.rechazado_en_fase || 'desconocida';
     const motivo = workData.motivo_rechazo || 'sin motivo especificado';

--- a/.pipeline/views/dashboard/satellites.js
+++ b/.pipeline/views/dashboard/satellites.js
@@ -98,9 +98,22 @@ async function killSkillGroup(skill, agents){
 }
 
 async function nhReactivate(issue){
-    if(!confirm('¿Reactivar #'+issue+' (quitar label needs-human)?')) return;
+    // Pedir indicaciones para el agente. prompt() permite multi-línea pegando texto.
+    // Si el operador acepta sin texto, sigue (compat con el flujo viejo).
+    // Si cancela (null), abortar.
+    const guidance = prompt(
+        '¿Reactivar #'+issue+'?\\n\\n' +
+        'Indicaciones para el agente (opcional — se pasan como contexto al prompt y se postean en el issue):\\n' +
+        'Ej: "Usar la API REST en vez de gh CLI", "Ignorar el rebase conflict, ya está limpio", etc.',
+        ''
+    );
+    if(guidance === null) return; // cancel
     try{
-        const r = await fetch('/api/needs-human/'+issue+'/reactivate', {method:'POST'});
+        const r = await fetch('/api/needs-human/'+issue+'/reactivate', {
+            method: 'POST',
+            headers: {'Content-Type':'application/json'},
+            body: JSON.stringify({ guidance: guidance.trim() }),
+        });
         const j = await r.json();
         showToast(j.msg || (j.ok?'Reactivado':'Falló'), j.ok);
         if(typeof runAll === 'function') setTimeout(runAll, 600);


### PR DESCRIPTION
Click ▶ Reactivar en /bloqueados ahora abre un prompt() que pide indicaciones para el agente. Si el operador escribe algo, se persiste como `<marker>.guidance.txt` y el pulpo la inyecta al prompt del agente como bloque '📋 INDICACIONES HUMANAS' antes del próximo lanzamiento. También aparece en el comentario del issue como blockquote.\n\nWiring completo en 3 capas: cliente (satellites.js), backend (dashboard.js /api/needs-human/:n/reactivate), pulpo (pulpo.js construyendo el prompt). El archivo de guidance es one-shot (se borra al leerlo, no contamina reintentos).\n\n`qa:skipped`.