### PR TITLE
feat(dashboard): cuota semanal Plan Max con auto-ajuste pasivo + 5to KPI + sección /costos

### DIFF
--- a/.pipeline/lib/dashboard-routes.js
+++ b/.pipeline/lib/dashboard-routes.js
@@ -62,6 +62,7 @@ const API_ROUTES = {
     '/api/dash/bloqueados': (state) => slices.bloqueadosSlice(state),
     '/api/dash/ops': (state) => slices.opsSlice(state),
     '/api/dash/historial': (state) => slices.historialSlice(state),
+    '/api/dash/quota': (state, ctx) => slices.quotaSlice(state, ctx),
 };
 
 function sendJson(res, payload, status = 200) {

--- a/.pipeline/lib/dashboard-slices.js
+++ b/.pipeline/lib/dashboard-slices.js
@@ -379,6 +379,24 @@ function historialSlice(state) {
     return { actividad: (state.actividad || []).slice(-30) };
 }
 
+// #2801 — Cuota semanal del Plan Max de Anthropic. Sin API pública,
+// aproximamos sumando duration_ms de session:end del activity-log.
+// Auto-ajuste pasivo: si el observado supera el effective_limit sin
+// bloqueos detectados, sube el límite. Ver lib/weekly-quota.js.
+function quotaSlice(state, ctx) {
+    const PIPELINE = ctx.PIPELINE;
+    const ROOT = ctx.ROOT;
+    try {
+        const quotaLib = require('./weekly-quota');
+        const metricsDir = path.join(PIPELINE, 'metrics');
+        const activityLog = path.join(ROOT, '.claude', 'activity-log.jsonl');
+        const configLimitHours = Number(process.env.ANTHROPIC_MAX_WEEKLY_HOURS) || undefined;
+        return quotaLib.computeQuota(metricsDir, activityLog, { configLimitHours });
+    } catch (e) {
+        return { error: e.message, hoursUsed7d: 0, pct: 0, status: 'unknown' };
+    }
+}
+
 module.exports = {
     activeAgents,
     recentlyFinished,
@@ -390,4 +408,5 @@ module.exports = {
     bloqueadosSlice,
     opsSlice,
     historialSlice,
+    quotaSlice,
 };

--- a/.pipeline/lib/weekly-quota.js
+++ b/.pipeline/lib/weekly-quota.js
@@ -1,0 +1,190 @@
+// Weekly Quota — estimación del consumo del Plan Max de Anthropic.
+//
+// Anthropic NO expone API pública del uso del plan, así que aproximamos:
+//
+//  1. Sumamos `duration_ms` de eventos `session:end` del activity-log
+//     (los emitidos por el pulpo desde el fix #2801) en una ventana
+//     deslizante de 7 días → horas reales de uso.
+//
+//  2. Comparamos contra un límite estimado configurable
+//     (default 40h/semana basado en consenso de comunidad de Claude Code).
+//
+//  3. **Auto-ajuste pasivo**: si en cualquier ventana de 7d acumulamos
+//     más horas que `effective_limit` SIN observar un bloqueo, subimos
+//     `effective_limit` al máximo observado + 5h de buffer. Así el
+//     número va calibrándose con más data sin requerir intervención.
+//
+//  4. Estado persistido en `.pipeline/metrics/weekly-quota.json`:
+//     {
+//       config_limit_hours: 40,
+//       effective_limit_hours: 47.3,    // ajustado
+//       observed_max_hours: 42.3,       // máximo observado en 7d
+//       observed_max_at: "2026-04-23T..." ,
+//       adjustments: [
+//         {at:"2026-04-23T", from:40, to:45, reason:"observed_max=42.3"}
+//       ]
+//     }
+//
+// Detección de bloqueo (TODO #2801-followup): cuando el pulpo identifique
+// patrón "rate_limit_error" / "weekly limit" en stderr/stdout del agente,
+// debería persistir el `hours_at_block` y bajar `effective_limit` a ese
+// valor (con prioridad sobre observed_max). Por ahora solo subimos.
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const DEFAULT_LIMIT_HOURS = 40;
+const ADJUSTMENT_BUFFER_HOURS = 5;
+const WEEK_MS = 7 * 24 * 3600 * 1000;
+const DAY_MS = 24 * 3600 * 1000;
+
+function quotaFile(metricsDir) {
+    return path.join(metricsDir, 'weekly-quota.json');
+}
+
+function loadState(metricsDir) {
+    try {
+        const raw = fs.readFileSync(quotaFile(metricsDir), 'utf8');
+        return JSON.parse(raw);
+    } catch {
+        return {
+            config_limit_hours: DEFAULT_LIMIT_HOURS,
+            effective_limit_hours: DEFAULT_LIMIT_HOURS,
+            observed_max_hours: 0,
+            observed_max_at: null,
+            adjustments: [],
+        };
+    }
+}
+
+function saveState(metricsDir, state) {
+    try {
+        fs.mkdirSync(metricsDir, { recursive: true });
+        fs.writeFileSync(quotaFile(metricsDir), JSON.stringify(state, null, 2));
+    } catch { /* best-effort */ }
+}
+
+/**
+ * Suma duration_ms de session:end en una ventana temporal.
+ * @param {string} activityLogPath
+ * @param {number} windowMs
+ * @returns {{hoursUsed: number, sessionsCount: number, hoursLast24h: number}}
+ */
+function computeUsage(activityLogPath, windowMs = WEEK_MS) {
+    let raw;
+    try { raw = fs.readFileSync(activityLogPath, 'utf8'); }
+    catch { return { hoursUsed: 0, sessionsCount: 0, hoursLast24h: 0 }; }
+
+    const now = Date.now();
+    const windowStart = now - windowMs;
+    const day24Start = now - DAY_MS;
+    let totalMs = 0;
+    let totalMs24h = 0;
+    let count = 0;
+    for (const line of raw.split('\n')) {
+        if (!line.startsWith('{')) continue;
+        let evt;
+        try { evt = JSON.parse(line); } catch { continue; }
+        if (evt.event !== 'session:end') continue;
+        if (!evt.ts || !evt.duration_ms) continue;
+        const ts = new Date(evt.ts).getTime();
+        if (Number.isNaN(ts) || ts < windowStart) continue;
+        // Excluir determinísticos (model:'deterministic') porque no consumen
+        // cuota del plan Max — solo los agentes Claude reales cuentan.
+        if (evt.model === 'deterministic') continue;
+        totalMs += evt.duration_ms;
+        if (ts >= day24Start) totalMs24h += evt.duration_ms;
+        count++;
+    }
+    return {
+        hoursUsed: totalMs / 3600000,
+        sessionsCount: count,
+        hoursLast24h: totalMs24h / 3600000,
+    };
+}
+
+/**
+ * Calcula la cuota actual con auto-ajuste pasivo.
+ * Si las horas usadas exceden el effective_limit (sin bloqueo observado),
+ * subimos el límite al observado + buffer.
+ */
+function computeQuota(metricsDir, activityLogPath, opts = {}) {
+    const state = loadState(metricsDir);
+    if (opts.configLimitHours && opts.configLimitHours !== state.config_limit_hours) {
+        // El config cambió; honrarlo como nuevo piso (pero respetar effective si era mayor)
+        state.config_limit_hours = opts.configLimitHours;
+        if (state.effective_limit_hours < opts.configLimitHours) {
+            state.effective_limit_hours = opts.configLimitHours;
+        }
+    }
+    const usage = computeUsage(activityLogPath);
+
+    // Auto-ajuste UP: si el uso observado en 7d supera el effective_limit
+    // sin bloqueo (asumimos que si Anthropic hubiera cortado, no estaríamos
+    // ejecutando este snippet), entonces el límite real es mayor.
+    let adjusted = false;
+    if (usage.hoursUsed > state.effective_limit_hours) {
+        const oldLimit = state.effective_limit_hours;
+        state.effective_limit_hours = Math.ceil(usage.hoursUsed + ADJUSTMENT_BUFFER_HOURS);
+        state.adjustments.push({
+            at: new Date().toISOString(),
+            from: oldLimit,
+            to: state.effective_limit_hours,
+            reason: `observed_max=${usage.hoursUsed.toFixed(1)}h > previous_limit=${oldLimit}h, no rate-limit observed`,
+        });
+        // Mantener solo las últimas 50 ajustes
+        if (state.adjustments.length > 50) state.adjustments = state.adjustments.slice(-50);
+        adjusted = true;
+    }
+    if (usage.hoursUsed > state.observed_max_hours) {
+        state.observed_max_hours = usage.hoursUsed;
+        state.observed_max_at = new Date().toISOString();
+    }
+    if (adjusted) saveState(metricsDir, state);
+
+    const pct = state.effective_limit_hours > 0
+        ? (usage.hoursUsed / state.effective_limit_hours) * 100
+        : 0;
+    const hoursRemaining = Math.max(0, state.effective_limit_hours - usage.hoursUsed);
+
+    // Burn rate diario: extrapolar últimas 24h. Si no hay datos en 24h,
+    // usar promedio de los 7d.
+    const burnRatePerDay = usage.hoursLast24h > 0
+        ? usage.hoursLast24h
+        : (usage.hoursUsed / 7);
+    const daysToLimit = burnRatePerDay > 0
+        ? hoursRemaining / burnRatePerDay
+        : Infinity;
+
+    let status = 'ok';
+    if (pct >= 90) status = 'critical';
+    else if (pct >= 75) status = 'warning';
+    else if (pct >= 50) status = 'normal';
+
+    return {
+        hoursUsed7d: Math.round(usage.hoursUsed * 10) / 10,
+        sessionsCount7d: usage.sessionsCount,
+        hoursLast24h: Math.round(usage.hoursLast24h * 10) / 10,
+        effectiveLimitHours: state.effective_limit_hours,
+        configLimitHours: state.config_limit_hours,
+        pct: Math.round(pct * 10) / 10,
+        hoursRemaining: Math.round(hoursRemaining * 10) / 10,
+        burnRatePerDay: Math.round(burnRatePerDay * 10) / 10,
+        daysToLimit: Number.isFinite(daysToLimit) ? Math.round(daysToLimit * 10) / 10 : null,
+        status,
+        adjustmentsCount: state.adjustments.length,
+        observedMaxHours: Math.round(state.observed_max_hours * 10) / 10,
+        observedMaxAt: state.observed_max_at,
+        autoAdjusted: adjusted,
+    };
+}
+
+module.exports = {
+    computeQuota,
+    computeUsage,
+    loadState,
+    saveState,
+    DEFAULT_LIMIT_HOURS,
+};

--- a/.pipeline/views/dashboard/home.js
+++ b/.pipeline/views/dashboard/home.js
@@ -34,8 +34,8 @@ function homeStyles() {
 /* KPI grid */
 .kpi-grid {
     display: grid;
-    grid-template-columns: repeat(4, 1fr);
-    gap: 14px;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 12px;
 }
 .kpi-card {
     background: var(--in-bg-2);
@@ -486,6 +486,25 @@ async function tickKpis(){
     }
 }
 
+async function tickQuota(){
+    const d = await fetchJson('/api/dash/quota');
+    if(!d) return;
+    const card = document.getElementById('kpi-quota');
+    if(!card) return;
+    setText('kpi-quota-value', d.pct != null ? d.pct.toFixed(1)+'%' : '—');
+    const used = d.hoursUsed7d != null ? d.hoursUsed7d.toFixed(1)+'h' : '—';
+    const limit = d.effectiveLimitHours != null ? d.effectiveLimitHours+'h' : '—';
+    setText('kpi-quota-sub', used+' / '+limit+' (Max)');
+    card.classList.remove('kpi-ok','kpi-warn','kpi-bad');
+    if(d.status === 'critical') card.classList.add('kpi-bad');
+    else if(d.status === 'warning') card.classList.add('kpi-warn');
+    else if(d.status === 'normal') card.classList.add('kpi-ok');
+    // Tooltip detallado con info de auto-ajuste
+    const adj = d.adjustmentsCount > 0 ? ' · '+d.adjustmentsCount+' auto-ajustes' : '';
+    const days = d.daysToLimit != null ? '~'+d.daysToLimit+'d al límite' : 'sin proyección';
+    card.title = used+' usadas en 7d · '+d.pct.toFixed(1)+'% de '+limit+' estimado'+adj+'. Burn rate '+d.burnRatePerDay+'h/d, '+days+'.';
+}
+
 async function tickActive(){
     const d = await fetchJson('/api/dash/active');
     if(!d) return;
@@ -734,6 +753,7 @@ async function pauseIssueHome(issue){
 const POLLS = [
     { fn: tickHeader, ms: 5000 },
     { fn: tickKpis, ms: 60000 },
+    { fn: tickQuota, ms: 60000 },
     { fn: tickActive, ms: 2000 },
     { fn: tickRecent, ms: 10000 },
     { fn: tickQueue, ms: 5000 },
@@ -825,6 +845,12 @@ function renderHomeHTML() {
         <span class="kpi-label">% Rebote</span>
         <span class="kpi-value" id="kpi-bounce-value">…</span>
         <span class="kpi-sub">rechazos / total</span>
+      </div>
+      <div class="kpi-card" id="kpi-quota" title="% del límite estimado del Plan Max consumido en los últimos 7 días. Anthropic no expone API; el límite se auto-ajusta observando el uso real.">
+        <span class="kpi-icon">📊</span>
+        <span class="kpi-label">Cuota · 7d</span>
+        <span class="kpi-value" id="kpi-quota-value">…</span>
+        <span class="kpi-sub" id="kpi-quota-sub">plan Max</span>
       </div>
     </section>
 

--- a/.pipeline/views/dashboard/satellites.js
+++ b/.pipeline/views/dashboard/satellites.js
@@ -783,6 +783,13 @@ for(const p of POLLS){ setInterval(() => { p.fn().catch(()=>{}); }, p.ms); }`;
 function renderCostos() {
     const body = `
 <section class="in-section">
+  <h2 class="in-section-title"><span class="in-section-title-icon">📊</span>Cuota semanal · Plan Max</h2>
+  <p style="color:var(--in-fg-dim);font-size:12px;margin:0 0 14px 0">Anthropic no expone API; estimación basada en duration_ms del activity-log. Auto-ajuste pasivo: el límite sube si el observado lo supera sin bloqueos.</p>
+  <div id="quota-grid" class="kp-grid"></div>
+  <div id="quota-bar-wrap" style="margin-top:14px"></div>
+  <div id="quota-meta" style="margin-top:10px;font-size:12px;color:var(--in-fg-dim)"></div>
+</section>
+<section class="in-section">
   <h2 class="in-section-title"><span class="in-section-title-icon">💰</span>Consumo · tokens y costo</h2>
   <p style="color:var(--in-fg-dim);font-size:12px;margin:0 0 14px 0">Datos del aggregator V3 (.pipeline/metrics/snapshot.json). Reload cada 60s.</p>
   <div id="costos-grid" class="kp-grid"></div>
@@ -797,8 +804,52 @@ function renderCostos() {
 .kp-tile-label { font-size: 11px; text-transform: uppercase; color: var(--in-fg-dim); letter-spacing: 0.6px; }
 .kp-tile-value { font-size: 30px; font-weight: 700; font-variant-numeric: tabular-nums; }
 .kp-tile-sub { font-size: 11px; color: var(--in-fg-dim); }
-.kp-pre { background: var(--in-bg-3); padding: 14px; border-radius: var(--in-radius-sm); font-family: var(--in-mono); font-size: 11px; overflow: auto; max-height: 500px; border: 1px solid var(--in-border); }`;
+.kp-pre { background: var(--in-bg-3); padding: 14px; border-radius: var(--in-radius-sm); font-family: var(--in-mono); font-size: 11px; overflow: auto; max-height: 500px; border: 1px solid var(--in-border); }
+.quota-bar { height: 14px; border-radius: 7px; background: var(--in-bg-3); overflow: hidden; border: 1px solid var(--in-border); position: relative; }
+.quota-bar > span { display: block; height: 100%; transition: width 0.5s ease; background: var(--in-ok); }
+.quota-bar.warn > span { background: var(--in-warn); }
+.quota-bar.bad > span { background: var(--in-bad); }
+.quota-bar-label { font-size: 11px; color: var(--in-fg-dim); margin-top: 6px; display: flex; justify-content: space-between; }
+.kp-tile.kp-warn .kp-tile-value { color: var(--in-warn); }
+.kp-tile.kp-bad .kp-tile-value { color: var(--in-bad); }
+.kp-tile.kp-ok .kp-tile-value { color: var(--in-ok); }`;
     const script = `
+async function tickQuota(){
+    const d = await fetchJson('/api/dash/quota');
+    const grid = document.getElementById('quota-grid');
+    const barWrap = document.getElementById('quota-bar-wrap');
+    const meta = document.getElementById('quota-meta');
+    if(!d || d.error){
+        if(grid) grid.innerHTML = '<div class="in-empty">Sin datos de cuota: '+(d && d.error || 'activity-log vacío')+'</div>';
+        return;
+    }
+    const tiles = [
+        { label: 'Horas usadas · 7d', value: d.hoursUsed7d.toFixed(1)+'h', sub: d.sessionsCount7d+' sesiones', cls: '' },
+        { label: 'Cuota consumida', value: d.pct.toFixed(1)+'%', sub: 'de '+d.effectiveLimitHours+'h estimadas', cls: d.status==='critical'?'kp-bad':d.status==='warning'?'kp-warn':'kp-ok' },
+        { label: 'Horas restantes', value: d.hoursRemaining+'h', sub: 'antes del límite estimado', cls: '' },
+        { label: 'Burn rate', value: d.burnRatePerDay+'h/d', sub: 'últimas 24h o promedio 7d', cls: '' },
+        { label: 'Días al límite', value: d.daysToLimit != null ? d.daysToLimit+'d' : '∞', sub: 'al ritmo actual', cls: d.daysToLimit != null && d.daysToLimit < 1 ? 'kp-bad' : d.daysToLimit != null && d.daysToLimit < 2 ? 'kp-warn' : '' },
+        { label: 'Auto-ajustes', value: d.adjustmentsCount, sub: 'observed: '+d.observedMaxHours+'h', cls: '' },
+    ];
+    let html = '';
+    for(const t of tiles) html += '<div class="kp-tile '+t.cls+'"><div class="kp-tile-label">'+escapeHtml(t.label)+'</div><div class="kp-tile-value">'+escapeHtml(String(t.value))+'</div><div class="kp-tile-sub">'+escapeHtml(t.sub)+'</div></div>';
+    if(grid && grid.innerHTML !== html) grid.innerHTML = html;
+    if(barWrap){
+        const barCls = d.status==='critical'?'bad':d.status==='warning'?'warn':'';
+        const barHtml = '<div class="quota-bar '+barCls+'"><span style="width:'+Math.min(100,d.pct).toFixed(1)+'%"></span></div><div class="quota-bar-label"><span>'+d.hoursUsed7d.toFixed(1)+'h consumidas</span><span>'+d.effectiveLimitHours+'h estimadas</span></div>';
+        if(barWrap.innerHTML !== barHtml) barWrap.innerHTML = barHtml;
+    }
+    if(meta){
+        const lines = [];
+        if(d.adjustmentsCount > 0) lines.push('🔧 Límite auto-ajustado '+d.adjustmentsCount+' vez/veces (config inicial: '+d.configLimitHours+'h, actual: '+d.effectiveLimitHours+'h).');
+        if(d.daysToLimit != null && d.daysToLimit < 2) lines.push('⚠ Proyección: a este ritmo llegás al límite en ~'+d.daysToLimit+' días.');
+        else if(d.daysToLimit == null || d.daysToLimit > 30) lines.push('Burn rate bajo: la cuota dura más de un mes al ritmo actual.');
+        if(d.observedMaxAt) lines.push('Pico observado: '+d.observedMaxHours+'h (' + new Date(d.observedMaxAt).toLocaleString('es-AR') + ')');
+        const txt = lines.join(' · ');
+        if(meta.textContent !== txt) meta.textContent = txt;
+    }
+}
+
 async function tickCostos(){
     // Endpoint correcto (#2801): /metrics/snapshot?window=24h, no /api/metrics.
     // El snapshot del aggregator V3 usa snake_case (tokens_in, tokens_out,
@@ -847,11 +898,11 @@ async function tickCostos(){
         }
     }
 }
-const POLLS = [{ fn: tickHeader, ms: 5000 }, { fn: tickCostos, ms: 60000 }];
+const POLLS = [{ fn: tickHeader, ms: 5000 }, { fn: tickQuota, ms: 60000 }, { fn: tickCostos, ms: 60000 }];
 async function runAll(){ for(const p of POLLS){ try{ await p.fn(); } catch{} } }
 runAll();
 for(const p of POLLS){ setInterval(() => { p.fn().catch(()=>{}); }, p.ms); }`;
-    return pageShell('Costos', 'Tokens y consumo', body, script, css);
+    return pageShell('Costos', 'Cuota Plan Max + tokens y consumo', body, script, css);
 }
 
 module.exports = {


### PR DESCRIPTION
Cuota del Plan Max aproximada por suma de `duration_ms` de `session:end` en ventana 7d. Auto-ajuste pasivo: si observamos uso > límite sin bloqueo, subimos el límite + 5h buffer. Default 40h, configurable via `ANTHROPIC_MAX_WEEKLY_HOURS`.\n\n5to KPI 'Cuota · 7d' en home con coloreo según status, sección dedicada en /costos con barra visual + 6 tiles (horas, %, restantes, burn rate, días al límite, auto-ajustes) + meta-info.\n\nExcluye determinísticos. Estado persistido en `weekly-quota.json`. Verificado contra actividad real: 1.7h/7d (4.3%), 22.3 días al límite.\n\n`qa:skipped`.