### PR TITLE
fix(dashboard): cuota Plan Max — reset domingo 21h ART + sesión rolling 5h + format 24h

### DIFF
--- a/.pipeline/lib/weekly-quota.js
+++ b/.pipeline/lib/weekly-quota.js
@@ -36,9 +36,42 @@ const fs = require('fs');
 const path = require('path');
 
 const DEFAULT_LIMIT_HOURS = 40;
+const DEFAULT_SESSION_LIMIT_HOURS = 5;       // Plan Max: sesión rolling de 5h
 const ADJUSTMENT_BUFFER_HOURS = 5;
 const WEEK_MS = 7 * 24 * 3600 * 1000;
 const DAY_MS = 24 * 3600 * 1000;
+const HOUR_MS = 3600 * 1000;
+// Anthropic resetea la cuota semanal **domingo 21:00 hora local del usuario**
+// (constatado en claude.ai/settings/usage). En Argentina = UTC-3 fijo (sin DST).
+// Configurable vía env por si el operador está en otra TZ.
+const RESET_DAY_LOCAL = 0;  // 0 = Domingo
+const RESET_HOUR_LOCAL = 21;
+const TZ_OFFSET_MIN = Number(process.env.QUOTA_TZ_OFFSET_MIN) || -180; // ART por default
+
+/**
+ * Devuelve el timestamp del último reset semanal (último domingo 21:00 local)
+ * para una marca temporal dada.
+ */
+function getLastWeeklyResetMs(now = Date.now()) {
+    // Convertir now a "hora local" sumando offset (offset es diff de UTC, en min)
+    const localNow = new Date(now + TZ_OFFSET_MIN * 60000);
+    // Construir el "domingo 21:00" más reciente en hora local
+    const localReset = new Date(localNow);
+    localReset.setUTCHours(RESET_HOUR_LOCAL, 0, 0, 0);
+    const dow = localNow.getUTCDay(); // 0=Sun
+    let daysBack = (dow - RESET_DAY_LOCAL + 7) % 7;
+    if (daysBack === 0 && localNow.getUTCHours() < RESET_HOUR_LOCAL) {
+        // Es domingo antes de las 21:00 → el reset fue hace 7 días
+        daysBack = 7;
+    }
+    localReset.setUTCDate(localReset.getUTCDate() - daysBack);
+    // Volver de "hora local fingida" a UTC real
+    return localReset.getTime() - TZ_OFFSET_MIN * 60000;
+}
+
+function getNextWeeklyResetMs(now = Date.now()) {
+    return getLastWeeklyResetMs(now) + WEEK_MS;
+}
 
 function quotaFile(metricsDir) {
     return path.join(metricsDir, 'weekly-quota.json');
@@ -67,18 +100,17 @@ function saveState(metricsDir, state) {
 }
 
 /**
- * Suma duration_ms de session:end en una ventana temporal.
+ * Suma duration_ms de session:end desde un timestamp de inicio hasta now.
  * @param {string} activityLogPath
- * @param {number} windowMs
+ * @param {number} sinceMs - timestamp inicial (ej. último reset semanal)
  * @returns {{hoursUsed: number, sessionsCount: number, hoursLast24h: number}}
  */
-function computeUsage(activityLogPath, windowMs = WEEK_MS) {
+function computeUsageSince(activityLogPath, sinceMs) {
     let raw;
     try { raw = fs.readFileSync(activityLogPath, 'utf8'); }
     catch { return { hoursUsed: 0, sessionsCount: 0, hoursLast24h: 0 }; }
 
     const now = Date.now();
-    const windowStart = now - windowMs;
     const day24Start = now - DAY_MS;
     let totalMs = 0;
     let totalMs24h = 0;
@@ -90,7 +122,7 @@ function computeUsage(activityLogPath, windowMs = WEEK_MS) {
         if (evt.event !== 'session:end') continue;
         if (!evt.ts || !evt.duration_ms) continue;
         const ts = new Date(evt.ts).getTime();
-        if (Number.isNaN(ts) || ts < windowStart) continue;
+        if (Number.isNaN(ts) || ts < sinceMs) continue;
         // Excluir determinísticos (model:'deterministic') porque no consumen
         // cuota del plan Max — solo los agentes Claude reales cuentan.
         if (evt.model === 'deterministic') continue;
@@ -105,10 +137,17 @@ function computeUsage(activityLogPath, windowMs = WEEK_MS) {
     };
 }
 
+// Wrapper de compat para callers viejos que pasaban windowMs deslizante.
+function computeUsage(activityLogPath, windowMs = WEEK_MS) {
+    return computeUsageSince(activityLogPath, Date.now() - windowMs);
+}
+
 /**
  * Calcula la cuota actual con auto-ajuste pasivo.
- * Si las horas usadas exceden el effective_limit (sin bloqueo observado),
- * subimos el límite al observado + buffer.
+ * Ventana semanal = desde el último domingo 21:00 local (Argentina por default).
+ * Sesión = rolling 5h.
+ * Si las horas usadas en la semana exceden el effective_limit (sin bloqueo
+ * observado), subimos el límite al observado + buffer.
  */
 function computeQuota(metricsDir, activityLogPath, opts = {}) {
     const state = loadState(metricsDir);
@@ -119,7 +158,18 @@ function computeQuota(metricsDir, activityLogPath, opts = {}) {
             state.effective_limit_hours = opts.configLimitHours;
         }
     }
-    const usage = computeUsage(activityLogPath);
+    // Reset semanal del observed_max_hours: si pasamos por un reset desde la
+    // última vez que actualizamos, el observado debe limpiarse para que
+    // refleje la semana nueva (no acumular del histórico).
+    const lastReset = getLastWeeklyResetMs();
+    if (state.observed_max_at) {
+        const observedTs = new Date(state.observed_max_at).getTime();
+        if (observedTs < lastReset) {
+            state.observed_max_hours = 0;
+            state.observed_max_at = null;
+        }
+    }
+    const usage = computeUsageSince(activityLogPath, lastReset);
 
     // Auto-ajuste UP: si el uso observado en 7d supera el effective_limit
     // sin bloqueo (asumimos que si Anthropic hubiera cortado, no estaríamos
@@ -150,20 +200,37 @@ function computeQuota(metricsDir, activityLogPath, opts = {}) {
     const hoursRemaining = Math.max(0, state.effective_limit_hours - usage.hoursUsed);
 
     // Burn rate diario: extrapolar últimas 24h. Si no hay datos en 24h,
-    // usar promedio de los 7d.
+    // usar promedio de la semana en curso.
+    const daysSinceReset = Math.max(1, (Date.now() - lastReset) / DAY_MS);
     const burnRatePerDay = usage.hoursLast24h > 0
         ? usage.hoursLast24h
-        : (usage.hoursUsed / 7);
+        : (usage.hoursUsed / daysSinceReset);
     const daysToLimit = burnRatePerDay > 0
         ? hoursRemaining / burnRatePerDay
         : Infinity;
+    const nextReset = getNextWeeklyResetMs();
+    const msToReset = nextReset - Date.now();
+    const daysToReset = msToReset / DAY_MS;
 
     let status = 'ok';
     if (pct >= 90) status = 'critical';
     else if (pct >= 75) status = 'warning';
     else if (pct >= 50) status = 'normal';
 
+    // Sesión rolling 5h — el plan Max define una sesión de 5h que empieza
+    // con el primer mensaje y resetea 5h después. Aproximación pragmática:
+    // sumar duration_ms en las últimas 5h. No es exactamente lo que muestra
+    // claude.ai (que detecta el "primer mensaje" como pivote), pero da una
+    // señal útil de saturación de la sesión actual.
+    const sessionUsage = computeUsageSince(activityLogPath, Date.now() - DEFAULT_SESSION_LIMIT_HOURS * HOUR_MS);
+    const sessionPct = (sessionUsage.hoursUsed / DEFAULT_SESSION_LIMIT_HOURS) * 100;
+    let sessionStatus = 'ok';
+    if (sessionPct >= 90) sessionStatus = 'critical';
+    else if (sessionPct >= 75) sessionStatus = 'warning';
+    else if (sessionPct >= 50) sessionStatus = 'normal';
+
     return {
+        // Semanal (ventana real, reset domingo 21:00 local)
         hoursUsed7d: Math.round(usage.hoursUsed * 10) / 10,
         sessionsCount7d: usage.sessionsCount,
         hoursLast24h: Math.round(usage.hoursLast24h * 10) / 10,
@@ -178,13 +245,30 @@ function computeQuota(metricsDir, activityLogPath, opts = {}) {
         observedMaxHours: Math.round(state.observed_max_hours * 10) / 10,
         observedMaxAt: state.observed_max_at,
         autoAdjusted: adjusted,
+        // Reset semanal real
+        lastResetAt: new Date(lastReset).toISOString(),
+        nextResetAt: new Date(nextReset).toISOString(),
+        daysToReset: Math.round(daysToReset * 10) / 10,
+        // Sesión rolling 5h
+        session: {
+            hoursUsed: Math.round(sessionUsage.hoursUsed * 100) / 100,
+            sessionsCount: sessionUsage.sessionsCount,
+            limitHours: DEFAULT_SESSION_LIMIT_HOURS,
+            pct: Math.round(sessionPct * 10) / 10,
+            hoursRemaining: Math.round(Math.max(0, DEFAULT_SESSION_LIMIT_HOURS - sessionUsage.hoursUsed) * 100) / 100,
+            status: sessionStatus,
+        },
     };
 }
 
 module.exports = {
     computeQuota,
     computeUsage,
+    computeUsageSince,
+    getLastWeeklyResetMs,
+    getNextWeeklyResetMs,
     loadState,
     saveState,
     DEFAULT_LIMIT_HOURS,
+    DEFAULT_SESSION_LIMIT_HOURS,
 };

--- a/.pipeline/views/dashboard/home.js
+++ b/.pipeline/views/dashboard/home.js
@@ -491,18 +491,28 @@ async function tickQuota(){
     if(!d) return;
     const card = document.getElementById('kpi-quota');
     if(!card) return;
-    setText('kpi-quota-value', d.pct != null ? d.pct.toFixed(1)+'%' : '—');
-    const used = d.hoursUsed7d != null ? d.hoursUsed7d.toFixed(1)+'h' : '—';
-    const limit = d.effectiveLimitHours != null ? d.effectiveLimitHours+'h' : '—';
-    setText('kpi-quota-sub', used+' / '+limit+' (Max)');
+    // Mostrar el peor de los dos %: sesión y semanal — el que esté más
+    // saturado es el que va a cortar antes.
+    const weekPct = d.pct || 0;
+    const sessPct = (d.session && d.session.pct) || 0;
+    const isSession = sessPct > weekPct;
+    const dominantPct = isSession ? sessPct : weekPct;
+    const dominantStatus = isSession ? d.session.status : d.status;
+    setText('kpi-quota-value', dominantPct.toFixed(1)+'%');
+    const used = isSession
+        ? (d.session.hoursUsed.toFixed(2)+'h / 5h sesión')
+        : (d.hoursUsed7d.toFixed(1)+'h / '+d.effectiveLimitHours+'h sem');
+    setText('kpi-quota-sub', used);
     card.classList.remove('kpi-ok','kpi-warn','kpi-bad');
-    if(d.status === 'critical') card.classList.add('kpi-bad');
-    else if(d.status === 'warning') card.classList.add('kpi-warn');
-    else if(d.status === 'normal') card.classList.add('kpi-ok');
-    // Tooltip detallado con info de auto-ajuste
-    const adj = d.adjustmentsCount > 0 ? ' · '+d.adjustmentsCount+' auto-ajustes' : '';
-    const days = d.daysToLimit != null ? '~'+d.daysToLimit+'d al límite' : 'sin proyección';
-    card.title = used+' usadas en 7d · '+d.pct.toFixed(1)+'% de '+limit+' estimado'+adj+'. Burn rate '+d.burnRatePerDay+'h/d, '+days+'.';
+    if(dominantStatus === 'critical') card.classList.add('kpi-bad');
+    else if(dominantStatus === 'warning') card.classList.add('kpi-warn');
+    else if(dominantStatus === 'normal') card.classList.add('kpi-ok');
+    // Tooltip con ambas ventanas + reset
+    const reset = d.daysToReset != null ? 'Reset semanal en '+d.daysToReset.toFixed(1)+' días.' : '';
+    const adj = d.adjustmentsCount > 0 ? ' '+d.adjustmentsCount+' auto-ajustes.' : '';
+    card.title = 'Sesión 5h: '+sessPct.toFixed(1)+'% ('+(d.session ? d.session.hoursUsed.toFixed(2) : 0)+'h)\\n' +
+        'Semanal: '+weekPct.toFixed(1)+'% ('+d.hoursUsed7d+'h / '+d.effectiveLimitHours+'h)\\n' +
+        reset + adj + ' Burn rate '+d.burnRatePerDay+'h/d.';
 }
 
 async function tickActive(){

--- a/.pipeline/views/dashboard/satellites.js
+++ b/.pipeline/views/dashboard/satellites.js
@@ -783,8 +783,8 @@ for(const p of POLLS){ setInterval(() => { p.fn().catch(()=>{}); }, p.ms); }`;
 function renderCostos() {
     const body = `
 <section class="in-section">
-  <h2 class="in-section-title"><span class="in-section-title-icon">📊</span>Cuota semanal · Plan Max</h2>
-  <p style="color:var(--in-fg-dim);font-size:12px;margin:0 0 14px 0">Anthropic no expone API; estimación basada en duration_ms del activity-log. Auto-ajuste pasivo: el límite sube si el observado lo supera sin bloqueos.</p>
+  <h2 class="in-section-title"><span class="in-section-title-icon">📊</span>Cuota Plan Max · sesión 5h + semanal (reset domingo 21:00 ART)</h2>
+  <p style="color:var(--in-fg-dim);font-size:12px;margin:0 0 14px 0">Anthropic no expone API. Estimación basada en duration_ms del activity-log (solo agentes Claude del pipeline; tu uso interactivo en claude.ai cuenta aparte). Auto-ajuste pasivo del límite semanal cuando el observado lo supera sin bloqueos.</p>
   <div id="quota-grid" class="kp-grid"></div>
   <div id="quota-bar-wrap" style="margin-top:14px"></div>
   <div id="quota-meta" style="margin-top:10px;font-size:12px;color:var(--in-fg-dim)"></div>
@@ -823,12 +823,18 @@ async function tickQuota(){
         if(grid) grid.innerHTML = '<div class="in-empty">Sin datos de cuota: '+(d && d.error || 'activity-log vacío')+'</div>';
         return;
     }
+    const sess = d.session || { hoursUsed: 0, pct: 0, hoursRemaining: 5, status: 'ok' };
+    const sessCls = sess.status==='critical'?'kp-bad':sess.status==='warning'?'kp-warn':sess.status==='normal'?'':'kp-ok';
+    const weekCls = d.status==='critical'?'kp-bad':d.status==='warning'?'kp-warn':d.status==='normal'?'':'kp-ok';
+    const resetTxt = d.daysToReset != null ? 'Reset en '+d.daysToReset.toFixed(1)+' días' : '';
     const tiles = [
-        { label: 'Horas usadas · 7d', value: d.hoursUsed7d.toFixed(1)+'h', sub: d.sessionsCount7d+' sesiones', cls: '' },
-        { label: 'Cuota consumida', value: d.pct.toFixed(1)+'%', sub: 'de '+d.effectiveLimitHours+'h estimadas', cls: d.status==='critical'?'kp-bad':d.status==='warning'?'kp-warn':'kp-ok' },
-        { label: 'Horas restantes', value: d.hoursRemaining+'h', sub: 'antes del límite estimado', cls: '' },
-        { label: 'Burn rate', value: d.burnRatePerDay+'h/d', sub: 'últimas 24h o promedio 7d', cls: '' },
-        { label: 'Días al límite', value: d.daysToLimit != null ? d.daysToLimit+'d' : '∞', sub: 'al ritmo actual', cls: d.daysToLimit != null && d.daysToLimit < 1 ? 'kp-bad' : d.daysToLimit != null && d.daysToLimit < 2 ? 'kp-warn' : '' },
+        { label: 'Sesión actual · 5h', value: sess.pct.toFixed(1)+'%', sub: sess.hoursUsed.toFixed(2)+'h / 5h', cls: sessCls },
+        { label: 'Sesión · restante', value: sess.hoursRemaining.toFixed(2)+'h', sub: 'reset rolling 5h', cls: '' },
+        { label: 'Semanal · usada', value: d.hoursUsed7d.toFixed(1)+'h', sub: d.sessionsCount7d+' sesiones desde dom 21h', cls: '' },
+        { label: 'Semanal · cuota', value: d.pct.toFixed(1)+'%', sub: 'de '+d.effectiveLimitHours+'h estimadas', cls: weekCls },
+        { label: 'Horas restantes', value: d.hoursRemaining+'h', sub: resetTxt, cls: '' },
+        { label: 'Burn rate', value: d.burnRatePerDay+'h/d', sub: 'últimas 24h o promedio semana', cls: '' },
+        { label: 'Días al límite', value: d.daysToLimit != null ? d.daysToLimit.toFixed(1)+'d' : '∞', sub: 'al ritmo actual', cls: d.daysToLimit != null && d.daysToLimit < 1 ? 'kp-bad' : d.daysToLimit != null && d.daysToLimit < 2 ? 'kp-warn' : '' },
         { label: 'Auto-ajustes', value: d.adjustmentsCount, sub: 'observed: '+d.observedMaxHours+'h', cls: '' },
     ];
     let html = '';
@@ -840,11 +846,15 @@ async function tickQuota(){
         if(barWrap.innerHTML !== barHtml) barWrap.innerHTML = barHtml;
     }
     if(meta){
+        const fmtART = (iso) => new Date(iso).toLocaleString('es-AR', { hour12: false, day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit' });
         const lines = [];
-        if(d.adjustmentsCount > 0) lines.push('🔧 Límite auto-ajustado '+d.adjustmentsCount+' vez/veces (config inicial: '+d.configLimitHours+'h, actual: '+d.effectiveLimitHours+'h).');
-        if(d.daysToLimit != null && d.daysToLimit < 2) lines.push('⚠ Proyección: a este ritmo llegás al límite en ~'+d.daysToLimit+' días.');
-        else if(d.daysToLimit == null || d.daysToLimit > 30) lines.push('Burn rate bajo: la cuota dura más de un mes al ritmo actual.');
-        if(d.observedMaxAt) lines.push('Pico observado: '+d.observedMaxHours+'h (' + new Date(d.observedMaxAt).toLocaleString('es-AR') + ')');
+        if(d.lastResetAt && d.nextResetAt){
+            lines.push('🗓 Semana actual: ' + fmtART(d.lastResetAt) + ' → ' + fmtART(d.nextResetAt));
+        }
+        if(d.adjustmentsCount > 0) lines.push('🔧 Límite auto-ajustado '+d.adjustmentsCount+' vez/veces (config: '+d.configLimitHours+'h → actual: '+d.effectiveLimitHours+'h)');
+        if(d.daysToLimit != null && d.daysToLimit < 2) lines.push('⚠ Llegás al límite en ~'+d.daysToLimit.toFixed(1)+' días al ritmo actual');
+        else if(d.daysToLimit == null || d.daysToLimit > (d.daysToReset || 7)) lines.push('✓ Cuota dura hasta el próximo reset al ritmo actual');
+        if(d.observedMaxAt) lines.push('Pico observado en la semana: '+d.observedMaxHours+'h (' + fmtART(d.observedMaxAt) + ')');
         const txt = lines.join(' · ');
         if(meta.textContent !== txt) meta.textContent = txt;
     }


### PR DESCRIPTION
Mejoras de precisión tras captura del operador (cuota.jpg). Reset semanal real es domingo 21:00 hora local (no 7d deslizante), Plan Max define sesión rolling 5h aparte de la semanal. Plus fix de format 12h sin AM/PM.\n\nDetalle: nuevas funciones `getLastWeeklyResetMs`/`getNextWeeklyResetMs` con TZ configurable (default ART), `computeUsageSince` para ventana arbitraria, bloque `session` en /api/dash/quota con %/hoursUsed/hoursRemaining. Home KPI muestra el peor de los dos. /costos pasa de 6 a 8 tiles separando sesión y semanal.\n\nCaveat: solo cuenta agentes Claude del pipeline. Uso interactivo en claude.ai cuenta aparte.\n\n`qa:skipped`.