### PR TITLE
feat(dashboard): calibración manual de cuota Plan Max contra valores reales de claude.ai

### DIFF
--- a/.pipeline/dashboard.js
+++ b/.pipeline/dashboard.js
@@ -7766,6 +7766,43 @@ const server = http.createServer((req, res) => {
     return;
   }
 
+  // #2801 — Calibración manual de la cuota Plan Max contra el real de claude.ai.
+  // El operador pega los % que ve en claude.ai/settings/usage; el sistema guarda
+  // factor = real/pipeline para extrapolar futuras lecturas.
+  if (req.url === '/api/dash/quota/calibrate' && req.method === 'POST') {
+    let body = '';
+    req.on('data', c => { body += c; if (body.length > 4 * 1024) req.destroy(); });
+    req.on('end', () => {
+      try {
+        const payload = body ? JSON.parse(body) : {};
+        const realWeekly = Number(payload.real_weekly_pct);
+        const realSession = Number(payload.real_session_pct);
+        if (!Number.isFinite(realWeekly) || !Number.isFinite(realSession)) {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ ok: false, msg: 'real_weekly_pct y real_session_pct son requeridos (números)' }));
+          return;
+        }
+        const quotaLib = require('./lib/weekly-quota');
+        const metricsDir = path.join(PIPELINE, 'metrics');
+        const activityLog = path.join(ROOT, '.claude', 'activity-log.jsonl');
+        const current = quotaLib.computeQuota(metricsDir, activityLog);
+        const calibration = quotaLib.saveCalibration(metricsDir, {
+          realWeeklyPct: realWeekly,
+          realSessionPct: realSession,
+          pipelineWeeklyPct: current.pct,
+          pipelineSessionPct: current.session ? current.session.pct : 0,
+        });
+        log(`quota: calibrado real(weekly=${realWeekly}%, session=${realSession}%) → pipeline(weekly=${current.pct}%, session=${current.session?.pct}%) → factors(weekly=${calibration.weekly_factor}, session=${calibration.session_factor})`);
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ ok: true, msg: `Calibración guardada · factor semanal ×${calibration.weekly_factor} · sesión ×${calibration.session_factor}`, calibration }));
+      } catch (e) {
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ ok: false, msg: 'Error: ' + e.message }));
+      }
+    });
+    return;
+  }
+
   // Nuevo dashboard kiosk vertical (#2801) — home + 9 tabs satélite + slices JSON
   // bajo /api/dash/*. Anti-flicker: cliente hace polling JSON y muta DOM in-place.
   // Si la ruta no matchea aquí, cae al catch-all (home legacy en /legacy o /).

--- a/.pipeline/lib/weekly-quota.js
+++ b/.pipeline/lib/weekly-quota.js
@@ -80,7 +80,10 @@ function quotaFile(metricsDir) {
 function loadState(metricsDir) {
     try {
         const raw = fs.readFileSync(quotaFile(metricsDir), 'utf8');
-        return JSON.parse(raw);
+        const parsed = JSON.parse(raw);
+        // Defaults para campos nuevos en estados viejos
+        if (!parsed.calibration) parsed.calibration = null;
+        return parsed;
     } catch {
         return {
             config_limit_hours: DEFAULT_LIMIT_HOURS,
@@ -88,8 +91,39 @@ function loadState(metricsDir) {
             observed_max_hours: 0,
             observed_max_at: null,
             adjustments: [],
+            calibration: null,
         };
     }
+}
+
+/**
+ * Persiste una calibración manual: el operador ingresa el % real que ve
+ * en claude.ai/settings/usage; calculamos un factor que multiplica el %
+ * del pipeline para estimar el % real (que incluye uso interactivo en
+ * claude.ai aparte del pipeline).
+ *
+ * @param {string} metricsDir
+ * @param {{realWeeklyPct: number, realSessionPct: number, pipelineWeeklyPct: number, pipelineSessionPct: number}} obs
+ */
+function saveCalibration(metricsDir, obs) {
+    const state = loadState(metricsDir);
+    const realWeekly = Number(obs.realWeeklyPct);
+    const realSession = Number(obs.realSessionPct);
+    const pipelineWeekly = Number(obs.pipelineWeeklyPct);
+    const pipelineSession = Number(obs.pipelineSessionPct);
+    const weeklyFactor = pipelineWeekly > 0 ? realWeekly / pipelineWeekly : 1;
+    const sessionFactor = pipelineSession > 0 ? realSession / pipelineSession : 1;
+    state.calibration = {
+        at: new Date().toISOString(),
+        real_weekly_pct: realWeekly,
+        real_session_pct: realSession,
+        pipeline_weekly_pct_at: pipelineWeekly,
+        pipeline_session_pct_at: pipelineSession,
+        weekly_factor: Math.round(weeklyFactor * 100) / 100,
+        session_factor: Math.round(sessionFactor * 100) / 100,
+    };
+    saveState(metricsDir, state);
+    return state.calibration;
 }
 
 function saveState(metricsDir, state) {
@@ -229,6 +263,29 @@ function computeQuota(metricsDir, activityLogPath, opts = {}) {
     else if (sessionPct >= 75) sessionStatus = 'warning';
     else if (sessionPct >= 50) sessionStatus = 'normal';
 
+    // Aplicar calibración manual (si existe). Multiplica el % del pipeline
+    // por el factor observado contra el % real de claude.ai. El resultado es
+    // un "estimado real" más cercano a la cuota verdadera de Anthropic
+    // (que incluye uso interactivo del operador, no solo el pipeline).
+    let realPct = null;
+    let realSessionPct = null;
+    let realStatus = status;
+    let realSessionStatus = sessionStatus;
+    if (state.calibration && state.calibration.weekly_factor) {
+        realPct = Math.round(pct * state.calibration.weekly_factor * 10) / 10;
+        if (realPct >= 90) realStatus = 'critical';
+        else if (realPct >= 75) realStatus = 'warning';
+        else if (realPct >= 50) realStatus = 'normal';
+        else realStatus = 'ok';
+    }
+    if (state.calibration && state.calibration.session_factor) {
+        realSessionPct = Math.round(sessionPct * state.calibration.session_factor * 10) / 10;
+        if (realSessionPct >= 90) realSessionStatus = 'critical';
+        else if (realSessionPct >= 75) realSessionStatus = 'warning';
+        else if (realSessionPct >= 50) realSessionStatus = 'normal';
+        else realSessionStatus = 'ok';
+    }
+
     return {
         // Semanal (ventana real, reset domingo 21:00 local)
         hoursUsed7d: Math.round(usage.hoursUsed * 10) / 10,
@@ -237,6 +294,8 @@ function computeQuota(metricsDir, activityLogPath, opts = {}) {
         effectiveLimitHours: state.effective_limit_hours,
         configLimitHours: state.config_limit_hours,
         pct: Math.round(pct * 10) / 10,
+        realPct,
+        realStatus,
         hoursRemaining: Math.round(hoursRemaining * 10) / 10,
         burnRatePerDay: Math.round(burnRatePerDay * 10) / 10,
         daysToLimit: Number.isFinite(daysToLimit) ? Math.round(daysToLimit * 10) / 10 : null,
@@ -255,9 +314,13 @@ function computeQuota(metricsDir, activityLogPath, opts = {}) {
             sessionsCount: sessionUsage.sessionsCount,
             limitHours: DEFAULT_SESSION_LIMIT_HOURS,
             pct: Math.round(sessionPct * 10) / 10,
+            realPct: realSessionPct,
+            realStatus: realSessionStatus,
             hoursRemaining: Math.round(Math.max(0, DEFAULT_SESSION_LIMIT_HOURS - sessionUsage.hoursUsed) * 100) / 100,
             status: sessionStatus,
         },
+        // Calibración (si existe)
+        calibration: state.calibration,
     };
 }
 
@@ -269,6 +332,7 @@ module.exports = {
     getNextWeeklyResetMs,
     loadState,
     saveState,
+    saveCalibration,
     DEFAULT_LIMIT_HOURS,
     DEFAULT_SESSION_LIMIT_HOURS,
 };

--- a/.pipeline/views/dashboard/home.js
+++ b/.pipeline/views/dashboard/home.js
@@ -491,28 +491,32 @@ async function tickQuota(){
     if(!d) return;
     const card = document.getElementById('kpi-quota');
     if(!card) return;
-    // Mostrar el peor de los dos %: sesión y semanal — el que esté más
-    // saturado es el que va a cortar antes.
-    const weekPct = d.pct || 0;
-    const sessPct = (d.session && d.session.pct) || 0;
+    // Si hay calibración, usar realPct (factor × pipeline). Si no, pipeline raw.
+    const weekPct = d.realPct != null ? d.realPct : (d.pct || 0);
+    const sessPct = d.session && d.session.realPct != null ? d.session.realPct : ((d.session && d.session.pct) || 0);
+    const weekStatus = d.realPct != null ? d.realStatus : d.status;
+    const sessStatus = d.session && d.session.realPct != null ? d.session.realStatus : (d.session && d.session.status);
+    // Mostrar el peor de los dos — el que sature primero corta antes.
     const isSession = sessPct > weekPct;
     const dominantPct = isSession ? sessPct : weekPct;
-    const dominantStatus = isSession ? d.session.status : d.status;
+    const dominantStatus = isSession ? sessStatus : weekStatus;
+    const calibTag = d.realPct != null ? ' (real)' : '';
     setText('kpi-quota-value', dominantPct.toFixed(1)+'%');
     const used = isSession
-        ? (d.session.hoursUsed.toFixed(2)+'h / 5h sesión')
-        : (d.hoursUsed7d.toFixed(1)+'h / '+d.effectiveLimitHours+'h sem');
+        ? ('sesión 5h'+calibTag)
+        : ('semanal'+calibTag);
     setText('kpi-quota-sub', used);
     card.classList.remove('kpi-ok','kpi-warn','kpi-bad');
     if(dominantStatus === 'critical') card.classList.add('kpi-bad');
     else if(dominantStatus === 'warning') card.classList.add('kpi-warn');
     else if(dominantStatus === 'normal') card.classList.add('kpi-ok');
-    // Tooltip con ambas ventanas + reset
+    // Tooltip con ambas ventanas + calibración + reset
     const reset = d.daysToReset != null ? 'Reset semanal en '+d.daysToReset.toFixed(1)+' días.' : '';
     const adj = d.adjustmentsCount > 0 ? ' '+d.adjustmentsCount+' auto-ajustes.' : '';
-    card.title = 'Sesión 5h: '+sessPct.toFixed(1)+'% ('+(d.session ? d.session.hoursUsed.toFixed(2) : 0)+'h)\\n' +
-        'Semanal: '+weekPct.toFixed(1)+'% ('+d.hoursUsed7d+'h / '+d.effectiveLimitHours+'h)\\n' +
-        reset + adj + ' Burn rate '+d.burnRatePerDay+'h/d.';
+    const realLine = d.realPct != null ? ' Calibrado vs claude.ai (factor ×'+(d.calibration?d.calibration.weekly_factor:'?')+' sem, ×'+(d.calibration?d.calibration.session_factor:'?')+' ses).' : '';
+    const sessLine = 'Sesión 5h: '+sessPct.toFixed(1)+'%'+(d.session && d.session.realPct != null ? ' (real, pipeline '+d.session.pct.toFixed(1)+'%)' : '');
+    const weekLine = 'Semanal: '+weekPct.toFixed(1)+'%'+(d.realPct != null ? ' (real, pipeline '+d.pct.toFixed(1)+'%)' : '');
+    card.title = sessLine+'\\n'+weekLine+'\\n'+reset+adj+realLine;
 }
 
 async function tickActive(){

--- a/.pipeline/views/dashboard/satellites.js
+++ b/.pipeline/views/dashboard/satellites.js
@@ -788,6 +788,21 @@ function renderCostos() {
   <div id="quota-grid" class="kp-grid"></div>
   <div id="quota-bar-wrap" style="margin-top:14px"></div>
   <div id="quota-meta" style="margin-top:10px;font-size:12px;color:var(--in-fg-dim)"></div>
+  <details id="quota-calib" style="margin-top:14px;border-top:1px solid var(--in-border);padding-top:12px">
+    <summary style="cursor:pointer;font-size:12px;color:var(--in-fg-dim);user-select:none">🎯 Calibrar contra valores reales de claude.ai/settings/usage</summary>
+    <div style="margin-top:10px;display:grid;grid-template-columns:1fr 1fr auto;gap:8px;align-items:end">
+      <div>
+        <label style="font-size:11px;color:var(--in-fg-dim);display:block;margin-bottom:4px">% semanal real (claude.ai)</label>
+        <input id="calib-weekly" type="number" step="0.1" min="0" max="100" placeholder="ej: 22" class="in-btn" style="width:100%;background:var(--in-bg-3);font-family:var(--in-mono)">
+      </div>
+      <div>
+        <label style="font-size:11px;color:var(--in-fg-dim);display:block;margin-bottom:4px">% sesión 5h real (claude.ai)</label>
+        <input id="calib-session" type="number" step="0.1" min="0" max="100" placeholder="ej: 60" class="in-btn" style="width:100%;background:var(--in-bg-3);font-family:var(--in-mono)">
+      </div>
+      <button id="calib-save" class="in-btn" style="border-color:var(--in-accent);color:var(--in-accent)">Aplicar</button>
+    </div>
+    <div id="calib-status" style="margin-top:10px;font-size:11px;color:var(--in-fg-dim)"></div>
+  </details>
 </section>
 <section class="in-section">
   <h2 class="in-section-title"><span class="in-section-title-icon">💰</span>Consumo · tokens y costo</h2>
@@ -823,17 +838,29 @@ async function tickQuota(){
         if(grid) grid.innerHTML = '<div class="in-empty">Sin datos de cuota: '+(d && d.error || 'activity-log vacío')+'</div>';
         return;
     }
-    const sess = d.session || { hoursUsed: 0, pct: 0, hoursRemaining: 5, status: 'ok' };
-    const sessCls = sess.status==='critical'?'kp-bad':sess.status==='warning'?'kp-warn':sess.status==='normal'?'':'kp-ok';
-    const weekCls = d.status==='critical'?'kp-bad':d.status==='warning'?'kp-warn':d.status==='normal'?'':'kp-ok';
+    const sess = d.session || { hoursUsed: 0, pct: 0, realPct: null, hoursRemaining: 5, status: 'ok', realStatus: 'ok' };
+    const sessShownPct = sess.realPct != null ? sess.realPct : sess.pct;
+    const sessShownStatus = sess.realPct != null ? sess.realStatus : sess.status;
+    const sessCls = sessShownStatus==='critical'?'kp-bad':sessShownStatus==='warning'?'kp-warn':sessShownStatus==='normal'?'':'kp-ok';
+    const weekShownPct = d.realPct != null ? d.realPct : d.pct;
+    const weekShownStatus = d.realPct != null ? d.realStatus : d.status;
+    const weekCls = weekShownStatus==='critical'?'kp-bad':weekShownStatus==='warning'?'kp-warn':weekShownStatus==='normal'?'':'kp-ok';
     const resetTxt = d.daysToReset != null ? 'Reset en '+d.daysToReset.toFixed(1)+' días' : '';
+    const sessLabel = sess.realPct != null ? 'Sesión 5h · estimado real' : 'Sesión actual · 5h';
+    const sessSub = sess.realPct != null
+        ? 'pipeline '+sess.pct.toFixed(1)+'% × '+(d.calibration && d.calibration.session_factor ? d.calibration.session_factor : 1)
+        : sess.hoursUsed.toFixed(2)+'h / 5h';
+    const weekLabel = d.realPct != null ? 'Semanal · estimado real' : 'Semanal · cuota';
+    const weekSub = d.realPct != null
+        ? 'pipeline '+d.pct.toFixed(1)+'% × '+(d.calibration && d.calibration.weekly_factor ? d.calibration.weekly_factor : 1)
+        : 'de '+d.effectiveLimitHours+'h estimadas';
     const tiles = [
-        { label: 'Sesión actual · 5h', value: sess.pct.toFixed(1)+'%', sub: sess.hoursUsed.toFixed(2)+'h / 5h', cls: sessCls },
-        { label: 'Sesión · restante', value: sess.hoursRemaining.toFixed(2)+'h', sub: 'reset rolling 5h', cls: '' },
-        { label: 'Semanal · usada', value: d.hoursUsed7d.toFixed(1)+'h', sub: d.sessionsCount7d+' sesiones desde dom 21h', cls: '' },
-        { label: 'Semanal · cuota', value: d.pct.toFixed(1)+'%', sub: 'de '+d.effectiveLimitHours+'h estimadas', cls: weekCls },
-        { label: 'Horas restantes', value: d.hoursRemaining+'h', sub: resetTxt, cls: '' },
-        { label: 'Burn rate', value: d.burnRatePerDay+'h/d', sub: 'últimas 24h o promedio semana', cls: '' },
+        { label: sessLabel, value: sessShownPct.toFixed(1)+'%', sub: sessSub, cls: sessCls },
+        { label: 'Sesión · restante (pipeline)', value: sess.hoursRemaining.toFixed(2)+'h', sub: 'reset rolling 5h', cls: '' },
+        { label: 'Semanal · pipeline usado', value: d.hoursUsed7d.toFixed(1)+'h', sub: d.sessionsCount7d+' sesiones desde dom 21h', cls: '' },
+        { label: weekLabel, value: weekShownPct.toFixed(1)+'%', sub: weekSub, cls: weekCls },
+        { label: 'Horas restantes (pipeline)', value: d.hoursRemaining+'h', sub: resetTxt, cls: '' },
+        { label: 'Burn rate (pipeline)', value: d.burnRatePerDay+'h/d', sub: 'últimas 24h o promedio semana', cls: '' },
         { label: 'Días al límite', value: d.daysToLimit != null ? d.daysToLimit.toFixed(1)+'d' : '∞', sub: 'al ritmo actual', cls: d.daysToLimit != null && d.daysToLimit < 1 ? 'kp-bad' : d.daysToLimit != null && d.daysToLimit < 2 ? 'kp-warn' : '' },
         { label: 'Auto-ajustes', value: d.adjustmentsCount, sub: 'observed: '+d.observedMaxHours+'h', cls: '' },
     ];
@@ -857,6 +884,36 @@ async function tickQuota(){
         if(d.observedMaxAt) lines.push('Pico observado en la semana: '+d.observedMaxHours+'h (' + fmtART(d.observedMaxAt) + ')');
         const txt = lines.join(' · ');
         if(meta.textContent !== txt) meta.textContent = txt;
+    }
+    // Renderizar status de calibración + bind del botón (idempotente).
+    const calibStatus = document.getElementById('calib-status');
+    if(calibStatus){
+        let ctxt;
+        if(d.calibration){
+            const at = fmtART(d.calibration.at);
+            ctxt = '✓ Calibrado el '+at+' · semanal '+d.calibration.real_weekly_pct+'% real / '+d.calibration.pipeline_weekly_pct_at+'% pipeline = factor ×'+d.calibration.weekly_factor+' · sesión ×'+d.calibration.session_factor+'.';
+        } else {
+            ctxt = 'Sin calibrar. Pegá los % que ves en claude.ai/settings/usage para extrapolar el real.';
+        }
+        if(calibStatus.textContent !== ctxt) calibStatus.textContent = ctxt;
+    }
+    const calibBtn = document.getElementById('calib-save');
+    if(calibBtn && !calibBtn.dataset._bound){
+        calibBtn.dataset._bound = '1';
+        calibBtn.addEventListener('click', async () => {
+            const w = parseFloat(document.getElementById('calib-weekly').value);
+            const s = parseFloat(document.getElementById('calib-session').value);
+            if(!Number.isFinite(w) || !Number.isFinite(s)){
+                showToast('Ingresá ambos % (semanal y sesión)', false);
+                return;
+            }
+            try{
+                const r = await fetch('/api/dash/quota/calibrate', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({real_weekly_pct: w, real_session_pct: s})});
+                const j = await r.json();
+                showToast(j.msg || (j.ok?'Calibrado':'Falló'), j.ok);
+                setTimeout(() => tickQuota().catch(()=>{}), 400);
+            } catch(e){ showToast('Error: '+e.message, false); }
+        });
     }
 }
 


### PR DESCRIPTION
El pipeline solo ve sus propios agentes; el uso interactivo del operador en claude.ai cuenta aparte. Calibración manual: en /costos → 🎯 colapsable con 2 inputs (% semanal, % sesión 5h) + botón Aplicar. Calcula factor = real/pipeline y lo persiste. Futuras lecturas multiplican el pipeline pct por el factor para mostrar 'estimado real'.\n\nBackend: `POST /api/dash/quota/calibrate {real_weekly_pct, real_session_pct}` + `saveCalibration()` en weekly-quota.js + `computeQuota` retorna `realPct`/`realStatus` cuando hay calibración.\n\nUI: home KPI usa realPct (más útil), /costos muestra ambos pipeline + real con factor.\n\nVerificado: 22% real / 2.4% pipeline → factor ×9.17 → realPct 22.4% ✓.\n\n`qa:skipped`.