### PR TITLE
feat(dashboard): cuota Plan Max — aprendizaje incremental, reset times reportados, historial, borrar

### DIFF
--- a/.pipeline/dashboard.js
+++ b/.pipeline/dashboard.js
@@ -7791,15 +7791,33 @@ const server = http.createServer((req, res) => {
           realSessionPct: realSession,
           pipelineWeeklyPct: current.pct,
           pipelineSessionPct: current.session ? current.session.pct : 0,
+          // Opcionales — tiempos de reset reportados por el operador
+          sessionResetsInMinutes: Number.isFinite(payload.session_resets_in_minutes) ? Number(payload.session_resets_in_minutes) : null,
+          weeklyResetsInMinutes: Number.isFinite(payload.weekly_resets_in_minutes) ? Number(payload.weekly_resets_in_minutes) : null,
         });
-        log(`quota: calibrado real(weekly=${realWeekly}%, session=${realSession}%) → pipeline(weekly=${current.pct}%, session=${current.session?.pct}%) → factors(weekly=${calibration.weekly_factor}, session=${calibration.session_factor})`);
+        log(`quota: calibrado #${calibration.sample_count} real(w=${realWeekly}%, s=${realSession}%) → pipeline(w=${current.pct}%, s=${current.session?.pct}%) → factor smooth(w=${calibration.weekly_factor}, s=${calibration.session_factor}) raw(w=${calibration.weekly_factor_obs}, s=${calibration.session_factor_obs}) α=${calibration.ema_alpha}`);
         res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ ok: true, msg: `Calibración guardada · factor semanal ×${calibration.weekly_factor} · sesión ×${calibration.session_factor}`, calibration }));
+        res.end(JSON.stringify({ ok: true, msg: `Calibración #${calibration.sample_count} guardada · factor semanal ×${calibration.weekly_factor} · sesión ×${calibration.session_factor} (EMA α=${calibration.ema_alpha})`, calibration }));
       } catch (e) {
         res.writeHead(500, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({ ok: false, msg: 'Error: ' + e.message }));
       }
     });
+    return;
+  }
+
+  if (req.url === '/api/dash/quota/calibrate' && req.method === 'DELETE') {
+    try {
+      const quotaLib = require('./lib/weekly-quota');
+      const metricsDir = path.join(PIPELINE, 'metrics');
+      const result = quotaLib.clearCalibration(metricsDir);
+      log('quota: calibración borrada por operador');
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ok: true, msg: result.msg }));
+    } catch (e) {
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ok: false, msg: 'Error: ' + e.message }));
+    }
     return;
   }
 

--- a/.pipeline/lib/weekly-quota.js
+++ b/.pipeline/lib/weekly-quota.js
@@ -69,8 +69,8 @@ function getLastWeeklyResetMs(now = Date.now()) {
     return localReset.getTime() - TZ_OFFSET_MIN * 60000;
 }
 
-function getNextWeeklyResetMs(now = Date.now()) {
-    return getLastWeeklyResetMs(now) + WEEK_MS;
+function getNextWeeklyResetMs(now = Date.now(), driftMin = 0) {
+    return getLastWeeklyResetMs(now) + WEEK_MS + (driftMin || 0) * 60000;
 }
 
 function quotaFile(metricsDir) {
@@ -83,6 +83,7 @@ function loadState(metricsDir) {
         const parsed = JSON.parse(raw);
         // Defaults para campos nuevos en estados viejos
         if (!parsed.calibration) parsed.calibration = null;
+        if (!parsed.calibrations) parsed.calibrations = [];
         return parsed;
     } catch {
         return {
@@ -92,18 +93,32 @@ function loadState(metricsDir) {
             observed_max_at: null,
             adjustments: [],
             calibration: null,
+            calibrations: [],
         };
     }
 }
 
+const round2 = (n) => Math.round(n * 100) / 100;
+
 /**
- * Persiste una calibración manual: el operador ingresa el % real que ve
- * en claude.ai/settings/usage; calculamos un factor que multiplica el %
- * del pipeline para estimar el % real (que incluye uso interactivo en
- * claude.ai aparte del pipeline).
+ * Persiste una calibración manual con APRENDIZAJE INCREMENTAL:
+ *
+ *   1. Cada calibración se acumula en `calibrations[]` (historial — últimas 20).
+ *   2. Los factores semanal/sesión se calculan por **EMA** (Exponential Moving
+ *      Average) en lugar de reemplazo total: `nuevo = α·obs + (1-α)·viejo`.
+ *      α se ajusta según cantidad de muestras (más muestras → α menor → más
+ *      conservador, menos sensible a outliers individuales).
+ *   3. Si el operador reporta `sessionResetsInMinutes` o `weeklyResetsInMinutes`,
+ *      persistimos esos timestamps absolutos. El cliente los usa para mostrar
+ *      cuenta regresiva precisa, y el server detecta drift de TZ del weekly
+ *      reset (e.g. si reportado != calculado por nuestra fórmula, ajustamos
+ *      el offset persistido).
+ *   4. `weighted_pipeline_pct_at` registra el pipeline pct al momento de
+ *      calibrar — sirve para recalcular factor cuando el pipeline cambia
+ *      mucho entre calibraciones (no implementado aún, queda como hook).
  *
  * @param {string} metricsDir
- * @param {{realWeeklyPct: number, realSessionPct: number, pipelineWeeklyPct: number, pipelineSessionPct: number}} obs
+ * @param {{realWeeklyPct, realSessionPct, pipelineWeeklyPct, pipelineSessionPct, sessionResetsInMinutes?, weeklyResetsInMinutes?}} obs
  */
 function saveCalibration(metricsDir, obs) {
     const state = loadState(metricsDir);
@@ -111,19 +126,79 @@ function saveCalibration(metricsDir, obs) {
     const realSession = Number(obs.realSessionPct);
     const pipelineWeekly = Number(obs.pipelineWeeklyPct);
     const pipelineSession = Number(obs.pipelineSessionPct);
-    const weeklyFactor = pipelineWeekly > 0 ? realWeekly / pipelineWeekly : 1;
-    const sessionFactor = pipelineSession > 0 ? realSession / pipelineSession : 1;
-    state.calibration = {
-        at: new Date().toISOString(),
+    const newWeeklyFactor = pipelineWeekly > 0 ? realWeekly / pipelineWeekly : 1;
+    const newSessionFactor = pipelineSession > 0 ? realSession / pipelineSession : 1;
+
+    const now = Date.now();
+    const sessionResetsAt = Number.isFinite(obs.sessionResetsInMinutes) && obs.sessionResetsInMinutes > 0
+        ? new Date(now + obs.sessionResetsInMinutes * 60000).toISOString() : null;
+    const weeklyResetsAt = Number.isFinite(obs.weeklyResetsInMinutes) && obs.weeklyResetsInMinutes > 0
+        ? new Date(now + obs.weeklyResetsInMinutes * 60000).toISOString() : null;
+
+    // Detectar drift del reset semanal: si nuestro cálculo predice X y user
+    // reporta Y con > 30 min de diferencia, persistir el offset para corregir
+    // próximas invocaciones de getNextWeeklyResetMs().
+    let weeklyResetDriftMin = state.weekly_reset_drift_min || 0;
+    if (weeklyResetsAt) {
+        const ourPredicted = getNextWeeklyResetMs(now);
+        const reportedMs = new Date(weeklyResetsAt).getTime();
+        const driftMs = reportedMs - ourPredicted;
+        if (Math.abs(driftMs) > 30 * 60000) {
+            weeklyResetDriftMin = Math.round(driftMs / 60000);
+        }
+    }
+
+    const entry = {
+        at: new Date(now).toISOString(),
         real_weekly_pct: realWeekly,
         real_session_pct: realSession,
         pipeline_weekly_pct_at: pipelineWeekly,
         pipeline_session_pct_at: pipelineSession,
-        weekly_factor: Math.round(weeklyFactor * 100) / 100,
-        session_factor: Math.round(sessionFactor * 100) / 100,
+        weekly_factor_obs: round2(newWeeklyFactor),
+        session_factor_obs: round2(newSessionFactor),
+        session_resets_at: sessionResetsAt,
+        weekly_resets_at: weeklyResetsAt,
     };
+    state.calibrations.push(entry);
+    if (state.calibrations.length > 20) state.calibrations = state.calibrations.slice(-20);
+
+    // EMA: α decrece con número de muestras. Primera muestra: α=1 (exact).
+    // De ahí en adelante: α = max(0.2, 1 / sqrt(n)) — equilibra respuesta
+    // a cambios reales con resistencia a ruido.
+    const n = state.calibrations.length;
+    const alpha = n === 1 ? 1.0 : Math.max(0.2, 1 / Math.sqrt(n));
+    const prevWeeklyFactor = state.calibration ? state.calibration.weekly_factor : newWeeklyFactor;
+    const prevSessionFactor = state.calibration ? state.calibration.session_factor : newSessionFactor;
+    const smoothWeekly = alpha * newWeeklyFactor + (1 - alpha) * prevWeeklyFactor;
+    const smoothSession = alpha * newSessionFactor + (1 - alpha) * prevSessionFactor;
+
+    state.calibration = {
+        at: new Date(now).toISOString(),
+        real_weekly_pct: realWeekly,
+        real_session_pct: realSession,
+        pipeline_weekly_pct_at: pipelineWeekly,
+        pipeline_session_pct_at: pipelineSession,
+        weekly_factor: round2(smoothWeekly),
+        session_factor: round2(smoothSession),
+        weekly_factor_obs: round2(newWeeklyFactor),
+        session_factor_obs: round2(newSessionFactor),
+        sample_count: n,
+        ema_alpha: round2(alpha),
+        session_resets_at: sessionResetsAt,
+        weekly_resets_at: weeklyResetsAt,
+    };
+    state.weekly_reset_drift_min = weeklyResetDriftMin;
     saveState(metricsDir, state);
     return state.calibration;
+}
+
+function clearCalibration(metricsDir) {
+    const state = loadState(metricsDir);
+    state.calibration = null;
+    state.weekly_reset_drift_min = 0;
+    // calibrations[] (historial) se conserva para auditoría/debug.
+    saveState(metricsDir, state);
+    return { ok: true, msg: 'Calibración borrada — los KPIs vuelven a mostrar el pipeline raw.' };
 }
 
 function saveState(metricsDir, state) {
@@ -242,7 +317,15 @@ function computeQuota(metricsDir, activityLogPath, opts = {}) {
     const daysToLimit = burnRatePerDay > 0
         ? hoursRemaining / burnRatePerDay
         : Infinity;
-    const nextReset = getNextWeeklyResetMs();
+    // Si el operador reportó el reset semanal exacto en una calibración
+    // reciente, lo usamos por encima de nuestro cálculo (que corrige TZ
+    // drift via weekly_reset_drift_min).
+    let nextReset = getNextWeeklyResetMs(Date.now(), state.weekly_reset_drift_min || 0);
+    if (state.calibration && state.calibration.weekly_resets_at) {
+        const reportedReset = new Date(state.calibration.weekly_resets_at).getTime();
+        // Solo respetar si está en el futuro (no expiró). Sino caer al cálculo.
+        if (reportedReset > Date.now()) nextReset = reportedReset;
+    }
     const msToReset = nextReset - Date.now();
     const daysToReset = msToReset / DAY_MS;
 
@@ -319,8 +402,21 @@ function computeQuota(metricsDir, activityLogPath, opts = {}) {
             hoursRemaining: Math.round(Math.max(0, DEFAULT_SESSION_LIMIT_HOURS - sessionUsage.hoursUsed) * 100) / 100,
             status: sessionStatus,
         },
-        // Calibración (si existe)
+        // Calibración (si existe) + historial reciente (últimas 20)
         calibration: state.calibration,
+        calibrations: (state.calibrations || []).slice(-20),
+        weeklyResetDriftMin: state.weekly_reset_drift_min || 0,
+        // Stale: la calibración pierde precisión con el tiempo. Marcamos
+        // stale > 7d para sugerir recalibrar.
+        calibrationAgeDays: state.calibration
+            ? Math.round((Date.now() - new Date(state.calibration.at).getTime()) / DAY_MS * 10) / 10
+            : null,
+        calibrationStale: state.calibration
+            ? (Date.now() - new Date(state.calibration.at).getTime()) > 7 * DAY_MS
+            : false,
+        // Reset times reportados por el operador (si los proveyó en última calib)
+        sessionResetsAt: state.calibration ? state.calibration.session_resets_at : null,
+        weeklyResetsAtReported: state.calibration ? state.calibration.weekly_resets_at : null,
     };
 }
 
@@ -333,6 +429,7 @@ module.exports = {
     loadState,
     saveState,
     saveCalibration,
+    clearCalibration,
     DEFAULT_LIMIT_HOURS,
     DEFAULT_SESSION_LIMIT_HOURS,
 };

--- a/.pipeline/views/dashboard/satellites.js
+++ b/.pipeline/views/dashboard/satellites.js
@@ -789,19 +789,32 @@ function renderCostos() {
   <div id="quota-bar-wrap" style="margin-top:14px"></div>
   <div id="quota-meta" style="margin-top:10px;font-size:12px;color:var(--in-fg-dim)"></div>
   <details id="quota-calib" style="margin-top:14px;border-top:1px solid var(--in-border);padding-top:12px">
-    <summary style="cursor:pointer;font-size:12px;color:var(--in-fg-dim);user-select:none">🎯 Calibrar contra valores reales de claude.ai/settings/usage</summary>
-    <div style="margin-top:10px;display:grid;grid-template-columns:1fr 1fr auto;gap:8px;align-items:end">
+    <summary style="cursor:pointer;font-size:12px;color:var(--in-fg-dim);user-select:none">🎯 Calibrar con valores reales de claude.ai/settings/usage (con aprendizaje)</summary>
+    <p style="font-size:11px;color:var(--in-fg-dim);margin:10px 0 6px 0">Pegá los % que ves y, si querés mejorar la precisión del reset semanal, también el tiempo restante hasta cada reset. Cada calibración entra al historial — los factores se promedian con EMA (más muestras = más estables, menos sensibles a outliers).</p>
+    <div style="display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-bottom:10px">
       <div>
-        <label style="font-size:11px;color:var(--in-fg-dim);display:block;margin-bottom:4px">% semanal real (claude.ai)</label>
+        <label style="font-size:11px;color:var(--in-fg-dim);display:block;margin-bottom:4px">% semanal real</label>
         <input id="calib-weekly" type="number" step="0.1" min="0" max="100" placeholder="ej: 22" class="in-btn" style="width:100%;background:var(--in-bg-3);font-family:var(--in-mono)">
       </div>
       <div>
-        <label style="font-size:11px;color:var(--in-fg-dim);display:block;margin-bottom:4px">% sesión 5h real (claude.ai)</label>
+        <label style="font-size:11px;color:var(--in-fg-dim);display:block;margin-bottom:4px">% sesión 5h real</label>
         <input id="calib-session" type="number" step="0.1" min="0" max="100" placeholder="ej: 60" class="in-btn" style="width:100%;background:var(--in-bg-3);font-family:var(--in-mono)">
       </div>
-      <button id="calib-save" class="in-btn" style="border-color:var(--in-accent);color:var(--in-accent)">Aplicar</button>
+      <div>
+        <label style="font-size:11px;color:var(--in-fg-dim);display:block;margin-bottom:4px">Sesión: minutos al reset (opcional)</label>
+        <input id="calib-session-mins" type="number" step="1" min="0" max="300" placeholder="ej: 165 (= 2h 45m)" class="in-btn" style="width:100%;background:var(--in-bg-3);font-family:var(--in-mono)">
+      </div>
+      <div>
+        <label style="font-size:11px;color:var(--in-fg-dim);display:block;margin-bottom:4px">Semanal: minutos al reset (opcional)</label>
+        <input id="calib-weekly-mins" type="number" step="1" min="0" max="10080" placeholder="ej: 8940 (= 6d 5h)" class="in-btn" style="width:100%;background:var(--in-bg-3);font-family:var(--in-mono)">
+      </div>
+    </div>
+    <div style="display:flex;gap:8px">
+      <button id="calib-save" class="in-btn" style="border-color:var(--in-accent);color:var(--in-accent)">▶ Aplicar y aprender</button>
+      <button id="calib-clear" class="in-btn" style="border-color:var(--in-fg-soft);color:var(--in-fg-dim)">✕ Borrar calibración</button>
     </div>
     <div id="calib-status" style="margin-top:10px;font-size:11px;color:var(--in-fg-dim)"></div>
+    <div id="calib-history" style="margin-top:14px"></div>
   </details>
 </section>
 <section class="in-section">
@@ -894,26 +907,88 @@ async function tickQuota(){
         let ctxt;
         if(d.calibration){
             const at = fmtART(d.calibration.at);
-            ctxt = '✓ Calibrado el '+at+' · semanal '+d.calibration.real_weekly_pct+'% real / '+d.calibration.pipeline_weekly_pct_at+'% pipeline = factor ×'+d.calibration.weekly_factor+' · sesión ×'+d.calibration.session_factor+'.';
+            const stale = d.calibrationStale ? ' ⚠ ' : ' ✓ ';
+            const ageInfo = d.calibrationAgeDays != null ? ' (hace '+d.calibrationAgeDays+'d)' : '';
+            ctxt = stale+'Calibrado #'+d.calibration.sample_count+' · '+at+ageInfo+' · factor smooth(w=×'+d.calibration.weekly_factor+', s=×'+d.calibration.session_factor+') raw esta vez(w=×'+d.calibration.weekly_factor_obs+', s=×'+d.calibration.session_factor_obs+') · α EMA '+d.calibration.ema_alpha;
+            if(d.calibrationStale) ctxt += ' — recomendado recalibrar';
+            if(d.weeklyResetDriftMin) ctxt += ' · drift TZ del reset semanal: '+d.weeklyResetDriftMin+' min';
         } else {
             ctxt = 'Sin calibrar. Pegá los % que ves en claude.ai/settings/usage para extrapolar el real.';
         }
         if(calibStatus.textContent !== ctxt) calibStatus.textContent = ctxt;
     }
+
+    // Historial de calibraciones (tabla compacta)
+    const calibHist = document.getElementById('calib-history');
+    if(calibHist){
+        const arr = (d.calibrations || []).slice().reverse();
+        if(arr.length === 0){
+            calibHist.innerHTML = '';
+        } else {
+            const rows = arr.slice(0, 10).map(c => '<tr>'+
+                '<td style="padding:4px 8px">'+fmtART(c.at)+'</td>'+
+                '<td style="padding:4px 8px;text-align:right">'+c.real_weekly_pct+'%</td>'+
+                '<td style="padding:4px 8px;text-align:right">'+c.real_session_pct+'%</td>'+
+                '<td style="padding:4px 8px;text-align:right;color:var(--in-fg-dim)">'+c.pipeline_weekly_pct_at.toFixed(1)+'%</td>'+
+                '<td style="padding:4px 8px;text-align:right;color:var(--in-fg-dim)">'+c.pipeline_session_pct_at.toFixed(1)+'%</td>'+
+                '<td style="padding:4px 8px;text-align:right">×'+c.weekly_factor_obs+'</td>'+
+                '<td style="padding:4px 8px;text-align:right">×'+c.session_factor_obs+'</td>'+
+                '</tr>').join('');
+            const html = '<details style="margin-top:6px"><summary style="cursor:pointer;font-size:11px;color:var(--in-fg-dim);user-select:none">📜 Historial de '+arr.length+' calibración'+(arr.length===1?'':'es')+'</summary>'+
+                '<table style="width:100%;font-size:11px;font-family:var(--in-mono);margin-top:8px;border-collapse:collapse"><thead><tr style="color:var(--in-fg-dim);border-bottom:1px solid var(--in-border)">'+
+                '<th style="padding:4px 8px;text-align:left">Fecha</th>'+
+                '<th style="padding:4px 8px;text-align:right">Sem real</th>'+
+                '<th style="padding:4px 8px;text-align:right">Ses real</th>'+
+                '<th style="padding:4px 8px;text-align:right">Sem pipe</th>'+
+                '<th style="padding:4px 8px;text-align:right">Ses pipe</th>'+
+                '<th style="padding:4px 8px;text-align:right">×Sem</th>'+
+                '<th style="padding:4px 8px;text-align:right">×Ses</th>'+
+                '</tr></thead><tbody>'+rows+'</tbody></table></details>';
+            if(calibHist.innerHTML !== html) calibHist.innerHTML = html;
+        }
+    }
+
+    // Bind del botón Aplicar
     const calibBtn = document.getElementById('calib-save');
     if(calibBtn && !calibBtn.dataset._bound){
         calibBtn.dataset._bound = '1';
         calibBtn.addEventListener('click', async () => {
             const w = parseFloat(document.getElementById('calib-weekly').value);
             const s = parseFloat(document.getElementById('calib-session').value);
+            const sm = parseInt(document.getElementById('calib-session-mins').value, 10);
+            const wm = parseInt(document.getElementById('calib-weekly-mins').value, 10);
             if(!Number.isFinite(w) || !Number.isFinite(s)){
                 showToast('Ingresá ambos % (semanal y sesión)', false);
                 return;
             }
             try{
-                const r = await fetch('/api/dash/quota/calibrate', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({real_weekly_pct: w, real_session_pct: s})});
+                const body = { real_weekly_pct: w, real_session_pct: s };
+                if(Number.isFinite(sm)) body.session_resets_in_minutes = sm;
+                if(Number.isFinite(wm)) body.weekly_resets_in_minutes = wm;
+                const r = await fetch('/api/dash/quota/calibrate', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(body)});
                 const j = await r.json();
                 showToast(j.msg || (j.ok?'Calibrado':'Falló'), j.ok);
+                if(j.ok){
+                    document.getElementById('calib-weekly').value = '';
+                    document.getElementById('calib-session').value = '';
+                    document.getElementById('calib-session-mins').value = '';
+                    document.getElementById('calib-weekly-mins').value = '';
+                }
+                setTimeout(() => tickQuota().catch(()=>{}), 400);
+            } catch(e){ showToast('Error: '+e.message, false); }
+        });
+    }
+
+    // Bind del botón Borrar
+    const calibClear = document.getElementById('calib-clear');
+    if(calibClear && !calibClear.dataset._bound){
+        calibClear.dataset._bound = '1';
+        calibClear.addEventListener('click', async () => {
+            if(!confirm('¿Borrar la calibración actual? El KPI vuelve a mostrar el pipeline raw. El historial de calibraciones previas se conserva.')) return;
+            try{
+                const r = await fetch('/api/dash/quota/calibrate', {method:'DELETE'});
+                const j = await r.json();
+                showToast(j.msg || (j.ok?'Borrada':'Falló'), j.ok);
                 setTimeout(() => tickQuota().catch(()=>{}), 400);
             } catch(e){ showToast('Error: '+e.message, false); }
         });


### PR DESCRIPTION
Mejora calibración manual con: (1) EMA en factores (más muestras = más estables, α=1/√n), (2) historial 20 calibraciones persistidas con tabla colapsable, (3) inputs opcionales de minutos al reset semanal/sesión que se persisten como timestamps absolutos, (4) drift detection del weekly reset (si reportado != calculado, se ajusta el offset), (5) DELETE para borrar calibración volviendo a pipeline raw.\n\nQuota slice retorna `calibrationAgeDays`, `calibrationStale` (>7d), `weeklyResetDriftMin`, historial completo. UI con form expandido + warning si vieja + tabla compacta de historial + botón Borrar.\n\nVerificado: cal#1 α=1 exact ×6.11; cal#2 EMA α=0.71 smooth ×6.7 (raw ×6.94). Drift +91min. DELETE OK.\n\n`qa:skipped`.