### PR TITLE
feat(dashboard): KPI cuota dual con cuenta regresiva + inputs datetime-local en calibración

### DIFF
--- a/.pipeline/dashboard.js
+++ b/.pipeline/dashboard.js
@@ -7791,7 +7791,10 @@ const server = http.createServer((req, res) => {
           realSessionPct: realSession,
           pipelineWeeklyPct: current.pct,
           pipelineSessionPct: current.session ? current.session.pct : 0,
-          // Opcionales — tiempos de reset reportados por el operador
+          // Opcionales — tiempos de reset reportados por el operador.
+          // Acepta ISO absoluto (preferido) o minutos relativos (legacy).
+          sessionResetsAt: payload.session_resets_at || null,
+          weeklyResetsAt: payload.weekly_resets_at || null,
           sessionResetsInMinutes: Number.isFinite(payload.session_resets_in_minutes) ? Number(payload.session_resets_in_minutes) : null,
           weeklyResetsInMinutes: Number.isFinite(payload.weekly_resets_in_minutes) ? Number(payload.weekly_resets_in_minutes) : null,
         });

--- a/.pipeline/lib/weekly-quota.js
+++ b/.pipeline/lib/weekly-quota.js
@@ -130,10 +130,21 @@ function saveCalibration(metricsDir, obs) {
     const newSessionFactor = pipelineSession > 0 ? realSession / pipelineSession : 1;
 
     const now = Date.now();
-    const sessionResetsAt = Number.isFinite(obs.sessionResetsInMinutes) && obs.sessionResetsInMinutes > 0
-        ? new Date(now + obs.sessionResetsInMinutes * 60000).toISOString() : null;
-    const weeklyResetsAt = Number.isFinite(obs.weeklyResetsInMinutes) && obs.weeklyResetsInMinutes > 0
-        ? new Date(now + obs.weeklyResetsInMinutes * 60000).toISOString() : null;
+    // Aceptar tanto "minutos al reset" (legacy) como "timestamp ISO absoluto"
+    // (preferido — más natural cuando el operador pega una hora del datetime
+    // picker o de claude.ai). Si vienen ambos, gana el ISO absoluto.
+    function parseResetAt(directIso, minutesField) {
+        if (directIso) {
+            const ts = new Date(directIso).getTime();
+            if (Number.isFinite(ts) && ts > now) return new Date(ts).toISOString();
+        }
+        if (Number.isFinite(minutesField) && minutesField > 0) {
+            return new Date(now + minutesField * 60000).toISOString();
+        }
+        return null;
+    }
+    const sessionResetsAt = parseResetAt(obs.sessionResetsAt, obs.sessionResetsInMinutes);
+    const weeklyResetsAt = parseResetAt(obs.weeklyResetsAt, obs.weeklyResetsInMinutes);
 
     // Detectar drift del reset semanal: si nuestro cálculo predice X y user
     // reporta Y con > 30 min de diferencia, persistir el offset para corregir

--- a/.pipeline/views/dashboard/home.js
+++ b/.pipeline/views/dashboard/home.js
@@ -70,6 +70,40 @@ function homeStyles() {
 .kpi-card.kpi-ok .kpi-value { color: var(--in-ok); }
 .kpi-bar { margin-top: 6px; }
 
+/* KPI dual de cuota: 2 filas, sin un value gigante */
+.kpi-quota-dual { gap: 6px; }
+.kpi-quota-dual .kpi-icon { font-size: 16px; opacity: 0.7; }
+.kpi-quota-row {
+    display: grid;
+    grid-template-columns: auto 60px 1fr;
+    align-items: baseline;
+    gap: 6px;
+    padding: 4px 0;
+    border-top: 1px solid var(--in-border-soft);
+}
+.kpi-quota-row:first-of-type { border-top: none; }
+.kpi-quota-row-label {
+    font-size: 11px;
+    color: var(--in-fg-dim);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+.kpi-quota-row-value {
+    font-size: 20px;
+    font-weight: 700;
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+}
+.kpi-quota-row-eta {
+    font-size: 10px;
+    color: var(--in-fg-soft);
+    font-family: var(--in-mono);
+    text-align: right;
+}
+.kpi-quota-row.kpi-warn .kpi-quota-row-value { color: var(--in-warn); }
+.kpi-quota-row.kpi-bad .kpi-quota-row-value { color: var(--in-bad); }
+.kpi-quota-row.kpi-ok .kpi-quota-row-value { color: var(--in-ok); }
+
 /* Active section */
 .active-section {
     background: linear-gradient(180deg, rgba(46,230,193,0.05), transparent 80%), var(--in-bg-2);
@@ -486,38 +520,94 @@ async function tickKpis(){
     }
 }
 
-async function tickQuota(){
-    const d = await fetchJson('/api/dash/quota');
-    if(!d) return;
+// Cache del último d para que el tick de cuenta regresiva (cada segundo)
+// pueda actualizar los ETA sin esperar al fetch del polling de 60s.
+let _quotaLastData = null;
+
+function fmtETA(ms){
+    if(ms == null || !Number.isFinite(ms) || ms <= 0) return '·';
+    const totalMin = Math.floor(ms / 60000);
+    if(totalMin < 60) return totalMin+'m';
+    const h = Math.floor(totalMin / 60);
+    const m = totalMin % 60;
+    if(h < 24) return h+'h '+(m>0?m+'m':'');
+    const d = Math.floor(h / 24);
+    const rh = h % 24;
+    return d+'d '+(rh>0?rh+'h':'');
+}
+
+function renderQuotaCard(d){
     const card = document.getElementById('kpi-quota');
-    if(!card) return;
-    // Si hay calibración, usar realPct (factor × pipeline). Si no, pipeline raw.
+    if(!card || !d) return;
     const weekPct = d.realPct != null ? d.realPct : (d.pct || 0);
     const sessPct = d.session && d.session.realPct != null ? d.session.realPct : ((d.session && d.session.pct) || 0);
     const weekStatus = d.realPct != null ? d.realStatus : d.status;
     const sessStatus = d.session && d.session.realPct != null ? d.session.realStatus : (d.session && d.session.status);
-    // Mostrar el peor de los dos — el que sature primero corta antes.
-    const isSession = sessPct > weekPct;
-    const dominantPct = isSession ? sessPct : weekPct;
-    const dominantStatus = isSession ? sessStatus : weekStatus;
-    const calibTag = d.realPct != null ? ' (real)' : '';
-    setText('kpi-quota-value', dominantPct.toFixed(1)+'%');
-    const used = isSession
-        ? ('sesión 5h'+calibTag)
-        : ('semanal'+calibTag);
-    setText('kpi-quota-sub', used);
+
+    setText('kpi-quota-session-pct', sessPct.toFixed(1)+'%');
+    setText('kpi-quota-week-pct', weekPct.toFixed(1)+'%');
+
+    // Cuenta regresiva: si tenemos session_resets_at o weekly_resets_at, usar
+    // diferencia con now. Si no, usar daysToReset del backend (semanal) o
+    // hoursRemaining (sesión, asume rolling 5h sin punto fijo).
+    const now = Date.now();
+    let sessETA;
+    if(d.sessionResetsAt){
+        const ts = new Date(d.sessionResetsAt).getTime();
+        sessETA = ts > now ? fmtETA(ts - now) : '· reseteó';
+    } else if(d.session && d.session.hoursRemaining != null){
+        sessETA = '~'+d.session.hoursRemaining.toFixed(1)+'h al cap';
+    } else {
+        sessETA = '·';
+    }
+    let weekETA;
+    if(d.weeklyResetsAtReported){
+        const ts = new Date(d.weeklyResetsAtReported).getTime();
+        weekETA = ts > now ? fmtETA(ts - now) : '· reseteó';
+    } else if(d.daysToReset != null){
+        weekETA = fmtETA(d.daysToReset * 86400000);
+    } else {
+        weekETA = '·';
+    }
+    setText('kpi-quota-session-eta', sessETA);
+    setText('kpi-quota-week-eta', weekETA);
+
+    const sessRow = document.getElementById('kpi-quota-session');
+    const weekRow = document.getElementById('kpi-quota-week');
+    function setRowStatus(row, status){
+        if(!row) return;
+        row.classList.remove('kpi-ok','kpi-warn','kpi-bad');
+        if(status === 'critical') row.classList.add('kpi-bad');
+        else if(status === 'warning') row.classList.add('kpi-warn');
+        else if(status === 'normal') row.classList.add('kpi-ok');
+    }
+    setRowStatus(sessRow, sessStatus);
+    setRowStatus(weekRow, weekStatus);
+
+    // Color del card = peor de los dos (alerta global)
+    const worst = (sessStatus === 'critical' || weekStatus === 'critical') ? 'critical'
+        : (sessStatus === 'warning' || weekStatus === 'warning') ? 'warning'
+        : (sessStatus === 'normal' || weekStatus === 'normal') ? 'normal' : 'ok';
     card.classList.remove('kpi-ok','kpi-warn','kpi-bad');
-    if(dominantStatus === 'critical') card.classList.add('kpi-bad');
-    else if(dominantStatus === 'warning') card.classList.add('kpi-warn');
-    else if(dominantStatus === 'normal') card.classList.add('kpi-ok');
-    // Tooltip con ambas ventanas + calibración + reset
-    const reset = d.daysToReset != null ? 'Reset semanal en '+d.daysToReset.toFixed(1)+' días.' : '';
-    const adj = d.adjustmentsCount > 0 ? ' '+d.adjustmentsCount+' auto-ajustes.' : '';
-    const realLine = d.realPct != null ? ' Calibrado vs claude.ai (factor ×'+(d.calibration?d.calibration.weekly_factor:'?')+' sem, ×'+(d.calibration?d.calibration.session_factor:'?')+' ses).' : '';
-    const sessLine = 'Sesión 5h: '+sessPct.toFixed(1)+'%'+(d.session && d.session.realPct != null ? ' (real, pipeline '+d.session.pct.toFixed(1)+'%)' : '');
-    const weekLine = 'Semanal: '+weekPct.toFixed(1)+'%'+(d.realPct != null ? ' (real, pipeline '+d.pct.toFixed(1)+'%)' : '');
-    card.title = sessLine+'\\n'+weekLine+'\\n'+reset+adj+realLine;
+    if(worst === 'critical') card.classList.add('kpi-bad');
+    else if(worst === 'warning') card.classList.add('kpi-warn');
+    else if(worst === 'normal') card.classList.add('kpi-ok');
+
+    const realLine = d.realPct != null
+        ? 'Calibrado vs claude.ai (×'+(d.calibration?d.calibration.weekly_factor:'?')+' sem, ×'+(d.calibration?d.calibration.session_factor:'?')+' ses, '+(d.calibration?d.calibration.sample_count:0)+' muestras).'
+        : 'Sin calibrar — pipeline raw. Calibrá en /costos para mejor precisión.';
+    card.title = realLine;
 }
+
+async function tickQuota(){
+    const d = await fetchJson('/api/dash/quota');
+    if(!d) return;
+    _quotaLastData = d;
+    renderQuotaCard(d);
+}
+
+// Cuenta regresiva del ETA actualizada cada segundo sin re-fetch.
+setInterval(() => { if(_quotaLastData) renderQuotaCard(_quotaLastData); }, 1000);
 
 async function tickActive(){
     const d = await fetchJson('/api/dash/active');
@@ -860,11 +950,19 @@ function renderHomeHTML() {
         <span class="kpi-value" id="kpi-bounce-value">…</span>
         <span class="kpi-sub">rechazos / total</span>
       </div>
-      <div class="kpi-card" id="kpi-quota" title="% del límite estimado del Plan Max consumido en los últimos 7 días. Anthropic no expone API; el límite se auto-ajusta observando el uso real.">
+      <div class="kpi-card kpi-quota-dual" id="kpi-quota" title="Cuota Plan Max (sin API pública de Anthropic — calibrado contra valores reales de claude.ai).">
         <span class="kpi-icon">📊</span>
-        <span class="kpi-label">Cuota · 7d</span>
-        <span class="kpi-value" id="kpi-quota-value">…</span>
-        <span class="kpi-sub" id="kpi-quota-sub">plan Max</span>
+        <span class="kpi-label">Cuota Plan Max</span>
+        <div class="kpi-quota-row" id="kpi-quota-session">
+          <span class="kpi-quota-row-label">Sesión 5h</span>
+          <span class="kpi-quota-row-value" id="kpi-quota-session-pct">…</span>
+          <span class="kpi-quota-row-eta" id="kpi-quota-session-eta">·</span>
+        </div>
+        <div class="kpi-quota-row" id="kpi-quota-week">
+          <span class="kpi-quota-row-label">Semanal</span>
+          <span class="kpi-quota-row-value" id="kpi-quota-week-pct">…</span>
+          <span class="kpi-quota-row-eta" id="kpi-quota-week-eta">·</span>
+        </div>
       </div>
     </section>
 

--- a/.pipeline/views/dashboard/satellites.js
+++ b/.pipeline/views/dashboard/satellites.js
@@ -801,12 +801,12 @@ function renderCostos() {
         <input id="calib-session" type="number" step="0.1" min="0" max="100" placeholder="ej: 60" class="in-btn" style="width:100%;background:var(--in-bg-3);font-family:var(--in-mono)">
       </div>
       <div>
-        <label style="font-size:11px;color:var(--in-fg-dim);display:block;margin-bottom:4px">Sesión: minutos al reset (opcional)</label>
-        <input id="calib-session-mins" type="number" step="1" min="0" max="300" placeholder="ej: 165 (= 2h 45m)" class="in-btn" style="width:100%;background:var(--in-bg-3);font-family:var(--in-mono)">
+        <label style="font-size:11px;color:var(--in-fg-dim);display:block;margin-bottom:4px">Sesión: día y hora del reset (opcional)</label>
+        <input id="calib-session-at" type="datetime-local" class="in-btn" style="width:100%;background:var(--in-bg-3);font-family:var(--in-mono)">
       </div>
       <div>
-        <label style="font-size:11px;color:var(--in-fg-dim);display:block;margin-bottom:4px">Semanal: minutos al reset (opcional)</label>
-        <input id="calib-weekly-mins" type="number" step="1" min="0" max="10080" placeholder="ej: 8940 (= 6d 5h)" class="in-btn" style="width:100%;background:var(--in-bg-3);font-family:var(--in-mono)">
+        <label style="font-size:11px;color:var(--in-fg-dim);display:block;margin-bottom:4px">Semanal: día y hora del reset (opcional)</label>
+        <input id="calib-weekly-at" type="datetime-local" class="in-btn" style="width:100%;background:var(--in-bg-3);font-family:var(--in-mono)">
       </div>
     </div>
     <div style="display:flex;gap:8px">
@@ -955,24 +955,29 @@ async function tickQuota(){
         calibBtn.addEventListener('click', async () => {
             const w = parseFloat(document.getElementById('calib-weekly').value);
             const s = parseFloat(document.getElementById('calib-session').value);
-            const sm = parseInt(document.getElementById('calib-session-mins').value, 10);
-            const wm = parseInt(document.getElementById('calib-weekly-mins').value, 10);
+            const sAtRaw = document.getElementById('calib-session-at').value;
+            const wAtRaw = document.getElementById('calib-weekly-at').value;
+            // datetime-local NO incluye TZ — el browser lo interpreta como local.
+            // new Date('2026-04-27T22:00') usa TZ del browser, que para el
+            // operador es ART (lo que queremos). Convertimos a ISO UTC.
+            const sAt = sAtRaw ? new Date(sAtRaw).toISOString() : null;
+            const wAt = wAtRaw ? new Date(wAtRaw).toISOString() : null;
             if(!Number.isFinite(w) || !Number.isFinite(s)){
                 showToast('Ingresá ambos % (semanal y sesión)', false);
                 return;
             }
             try{
                 const body = { real_weekly_pct: w, real_session_pct: s };
-                if(Number.isFinite(sm)) body.session_resets_in_minutes = sm;
-                if(Number.isFinite(wm)) body.weekly_resets_in_minutes = wm;
+                if(sAt) body.session_resets_at = sAt;
+                if(wAt) body.weekly_resets_at = wAt;
                 const r = await fetch('/api/dash/quota/calibrate', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(body)});
                 const j = await r.json();
                 showToast(j.msg || (j.ok?'Calibrado':'Falló'), j.ok);
                 if(j.ok){
                     document.getElementById('calib-weekly').value = '';
                     document.getElementById('calib-session').value = '';
-                    document.getElementById('calib-session-mins').value = '';
-                    document.getElementById('calib-weekly-mins').value = '';
+                    document.getElementById('calib-session-at').value = '';
+                    document.getElementById('calib-weekly-at').value = '';
                 }
                 setTimeout(() => tickQuota().catch(()=>{}), 400);
             } catch(e){ showToast('Error: '+e.message, false); }


### PR DESCRIPTION
Dos UX tweaks del sistema cuota:\n\n1. **KPI dual en home**: card muestra sesión 5h Y semanal con sus % y cuenta regresiva al reset (h/d format, refresh 1s sin re-fetch). Cada fila se colorea independiente. Borde del card = peor status.\n\n2. **datetime-local pickers** en calibración: reemplaza minutos relativos por día y hora directos. Browser convierte usando TZ local (ART). Backend acepta ambos formatos (compat).\n\n`qa:skipped`.