### PR TITLE
feat(dashboard): pills de Priority Windows (QA/Build) + salud CPU/RAM en header del home

### DIFF
--- a/.pipeline/lib/dashboard-slices.js
+++ b/.pipeline/lib/dashboard-slices.js
@@ -154,6 +154,37 @@ function headerSlice(state, ctx) {
     const bloqueadosCount = (state.bloqueados || []).length;
     const historialCount = (state.actividad || []).length;
 
+    // Priority windows (QA/Build) — bloquean dev/build cuando la cola QA
+    // o Build se acumula. El operador necesita verlas en el header del home
+    // para saber por qué no se lanzan agentes y poder desactivarlas con un click.
+    const pw = state.priorityWindows || {};
+    const priorityWindows = {
+        qa: {
+            active: !!pw.qa?.active,
+            activatedAt: pw.qa?.activatedAt || null,
+            cooldownUntil: pw.qa?.cooldownUntil || null,
+            manual: !!pw.qa?.manual,
+        },
+        build: {
+            active: !!pw.build?.active,
+            activatedAt: pw.build?.activatedAt || null,
+            manual: !!pw.build?.manual,
+        },
+    };
+
+    // Salud del sistema (CPU/RAM) — antes vivía en una sección /ops, pero el
+    // operador la quiere a la vista en el home (sin tener que ir a otra tab).
+    const r = state.resources || {};
+    const resources = {
+        cpuPercent: r.cpuPercent ?? null,
+        memPercent: r.memPercent ?? null,
+        memUsedGB: r.memUsedGB ?? null,
+        memTotalGB: r.memTotalGB ?? null,
+        cpuCores: r.cpuCores ?? null,
+        maxCpu: r.maxCpu ?? 70,
+        maxMem: r.maxMem ?? 70,
+    };
+
     return {
         mode,
         allowedIssues,
@@ -167,6 +198,8 @@ function headerSlice(state, ctx) {
             matriz: pipelineActive,
             historial: historialCount,
         },
+        priorityWindows,
+        resources,
         timestamp: Date.now(),
     };
 }

--- a/.pipeline/views/dashboard/home.js
+++ b/.pipeline/views/dashboard/home.js
@@ -503,6 +503,58 @@ async function tickHeader(){
         if(count === 0) badge.classList.add('area-pill-badge-zero');
         else if(area === 'bloqueados' && count > 0) badge.classList.add('area-pill-badge-bad');
     }
+    // Priority Windows: pills clickeables solo visibles si están active.
+    const pw = d.priorityWindows || {};
+    function setWindowPill(id, win, label){
+        const pill = document.getElementById(id);
+        if(!pill) return;
+        if(!win || !win.active){
+            pill.style.display = 'none';
+            return;
+        }
+        pill.style.display = '';
+        pill.classList.remove('in-pill-ok','in-pill-bad');
+        pill.classList.add('in-pill-warn');
+        const tag = win.manual ? '🔒' : '⚡';
+        let elapsed = '';
+        if(win.activatedAt){
+            const ms = Date.now() - win.activatedAt;
+            const min = Math.floor(ms/60000);
+            elapsed = min < 60 ? ' · '+min+'m' : ' · '+Math.floor(min/60)+'h '+(min%60)+'m';
+        }
+        pill.textContent = tag+' '+label+' window'+elapsed;
+        if(!pill.dataset._bound){
+            pill.dataset._bound = '1';
+            pill.style.cursor = 'pointer';
+            pill.addEventListener('click', async () => {
+                if(!confirm('¿Desactivar la '+label+' Priority Window? El pipeline va a poder lanzar dev/build de nuevo.')) return;
+                try{
+                    const r = await fetch('/api/priority-window', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({window: id.replace('hdr-window-',''), action:'deactivate'})});
+                    const j = await r.json();
+                    showToast(j.msg || (j.ok?label+' desactivada':'Falló'), j.ok);
+                    setTimeout(() => tickHeader().catch(()=>{}), 600);
+                } catch(e){ showToast('Error: '+e.message, false); }
+            });
+        }
+    }
+    setWindowPill('hdr-window-qa', pw.qa, 'QA');
+    setWindowPill('hdr-window-build', pw.build, 'Build');
+    // Recursos: CPU/RAM con coloreo según umbrales.
+    const res = d.resources;
+    const resPill = document.getElementById('hdr-resources');
+    if(resPill && res){
+        const cpu = res.cpuPercent != null ? res.cpuPercent : '?';
+        const mem = res.memPercent != null ? res.memPercent : '?';
+        resPill.textContent = '🖥 CPU '+cpu+'% · RAM '+mem+'%';
+        resPill.classList.remove('in-pill-ok','in-pill-warn','in-pill-bad');
+        const worst = Math.max(Number(cpu)||0, Number(mem)||0);
+        const maxCpu = res.maxCpu || 70;
+        const maxMem = res.maxMem || 70;
+        if((Number(cpu)||0) > maxCpu || (Number(mem)||0) > maxMem) resPill.classList.add('in-pill-bad');
+        else if(worst > 50) resPill.classList.add('in-pill-warn');
+        else resPill.classList.add('in-pill-ok');
+        resPill.title = 'CPU '+cpu+'% (cap '+maxCpu+'%) · RAM '+mem+'% ('+(res.memUsedGB||'?')+'GB / '+(res.memTotalGB||'?')+'GB · cap '+maxMem+'%) · '+(res.cpuCores||'?')+' cores';
+    }
 }
 
 async function tickKpis(){
@@ -918,6 +970,9 @@ function renderHomeHTML() {
           </div>
         </div>
       </span>
+      <span class="in-pill" id="hdr-window-qa" style="display:none" title="Click para desactivar la QA Priority Window">…</span>
+      <span class="in-pill" id="hdr-window-build" style="display:none" title="Click para desactivar la Build Priority Window">…</span>
+      <span class="in-pill" id="hdr-resources" title="CPU y RAM del sistema">…</span>
       <span class="in-pill" id="hdr-pulpo">…</span>
       <span class="in-clock" id="hdr-clock">…</span>
     </div>


### PR DESCRIPTION
Dos cosas faltaban en el header tras el rediseño:\n\n1. **Priority Windows visibles + clickeables**: pills al lado de Mode/Pulpo que aparecen solo si la ventana QA o Build está activa. Click → confirm → desactivar. Antes el operador no veía que el pipeline estaba bloqueado por una window.\n\n2. **Salud CPU/RAM**: pill compacta con coloreo según umbrales (<50% verde, 50-70% warn, >70% bad). Tooltip con GB y cores.\n\nBackend: `headerSlice` retorna `priorityWindows` y `resources` (datos ya existían en state, solo no se exponían).\n\n`qa:skipped`.