### PR TITLE
fix(dashboard): capear realPct de cuota a 100% — factor lineal generaba 211%

### DIFF
--- a/.pipeline/lib/weekly-quota.js
+++ b/.pipeline/lib/weekly-quota.js
@@ -361,19 +361,35 @@ function computeQuota(metricsDir, activityLogPath, opts = {}) {
     // por el factor observado contra el % real de claude.ai. El resultado es
     // un "estimado real" más cercano a la cuota verdadera de Anthropic
     // (que incluye uso interactivo del operador, no solo el pipeline).
+    //
+    // **Cap al 100%**: el factor es lineal y queda fijo desde la calibración,
+    // pero el pipeline pct rolling 5h puede crecer (porque el pipeline procesa
+    // más) sin que necesariamente la cuota real crezca proporcional. Resultado:
+    // sin cap, se llegan a valores absurdos (211%, 300%). Capear refleja la
+    // realidad (la cuota nunca puede pasar 100%) y exponer `*PctRaw` permite
+    // detectar saturación: si pasa >120%, la calibración está obsoleta y
+    // conviene recalibrar.
     let realPct = null;
+    let realPctRaw = null;
+    let realPctCapped = false;
     let realSessionPct = null;
+    let realSessionPctRaw = null;
+    let realSessionPctCapped = false;
     let realStatus = status;
     let realSessionStatus = sessionStatus;
     if (state.calibration && state.calibration.weekly_factor) {
-        realPct = Math.round(pct * state.calibration.weekly_factor * 10) / 10;
+        realPctRaw = Math.round(pct * state.calibration.weekly_factor * 10) / 10;
+        realPct = Math.min(100, realPctRaw);
+        realPctCapped = realPctRaw > 100;
         if (realPct >= 90) realStatus = 'critical';
         else if (realPct >= 75) realStatus = 'warning';
         else if (realPct >= 50) realStatus = 'normal';
         else realStatus = 'ok';
     }
     if (state.calibration && state.calibration.session_factor) {
-        realSessionPct = Math.round(sessionPct * state.calibration.session_factor * 10) / 10;
+        realSessionPctRaw = Math.round(sessionPct * state.calibration.session_factor * 10) / 10;
+        realSessionPct = Math.min(100, realSessionPctRaw);
+        realSessionPctCapped = realSessionPctRaw > 100;
         if (realSessionPct >= 90) realSessionStatus = 'critical';
         else if (realSessionPct >= 75) realSessionStatus = 'warning';
         else if (realSessionPct >= 50) realSessionStatus = 'normal';
@@ -389,6 +405,8 @@ function computeQuota(metricsDir, activityLogPath, opts = {}) {
         configLimitHours: state.config_limit_hours,
         pct: Math.round(pct * 10) / 10,
         realPct,
+        realPctRaw,
+        realPctCapped,
         realStatus,
         hoursRemaining: Math.round(hoursRemaining * 10) / 10,
         burnRatePerDay: Math.round(burnRatePerDay * 10) / 10,
@@ -409,6 +427,8 @@ function computeQuota(metricsDir, activityLogPath, opts = {}) {
             limitHours: DEFAULT_SESSION_LIMIT_HOURS,
             pct: Math.round(sessionPct * 10) / 10,
             realPct: realSessionPct,
+            realPctRaw: realSessionPctRaw,
+            realPctCapped: realSessionPctCapped,
             realStatus: realSessionStatus,
             hoursRemaining: Math.round(Math.max(0, DEFAULT_SESSION_LIMIT_HOURS - sessionUsage.hoursUsed) * 100) / 100,
             status: sessionStatus,

--- a/.pipeline/views/dashboard/home.js
+++ b/.pipeline/views/dashboard/home.js
@@ -648,7 +648,10 @@ function renderQuotaCard(d){
     const realLine = d.realPct != null
         ? 'Calibrado vs claude.ai (×'+(d.calibration?d.calibration.weekly_factor:'?')+' sem, ×'+(d.calibration?d.calibration.session_factor:'?')+' ses, '+(d.calibration?d.calibration.sample_count:0)+' muestras).'
         : 'Sin calibrar — pipeline raw. Calibrá en /costos para mejor precisión.';
-    card.title = realLine;
+    let extraTitle = '';
+    if(d.realPctCapped) extraTitle += ' ⚠ Semanal capeado al 100% (raw '+d.realPctRaw+'%) — recalibrar.';
+    if(d.session && d.session.realPctCapped) extraTitle += ' ⚠ Sesión capeada al 100% (raw '+d.session.realPctRaw+'%) — recalibrar.';
+    card.title = realLine+extraTitle;
 }
 
 async function tickQuota(){

--- a/.pipeline/views/dashboard/satellites.js
+++ b/.pipeline/views/dashboard/satellites.js
@@ -860,12 +860,20 @@ async function tickQuota(){
     const weekCls = weekShownStatus==='critical'?'kp-bad':weekShownStatus==='warning'?'kp-warn':weekShownStatus==='normal'?'':'kp-ok';
     const resetTxt = d.daysToReset != null ? 'Reset en '+d.daysToReset.toFixed(1)+' días' : '';
     const sessLabel = sess.realPct != null ? 'Sesión 5h · estimado real' : 'Sesión actual · 5h';
+    const sessCap = sess.realPctCapped ? ' ⚠ recalibrar' : '';
+    const sessRawTxt = sess.realPctRaw != null && sess.realPctCapped
+        ? ' (raw '+sess.realPctRaw.toFixed(1)+'%)'
+        : '';
     const sessSub = sess.realPct != null
-        ? 'pipeline '+sess.pct.toFixed(1)+'% × '+(d.calibration && d.calibration.session_factor ? d.calibration.session_factor : 1)
+        ? 'pipeline '+sess.pct.toFixed(1)+'% × '+(d.calibration && d.calibration.session_factor ? d.calibration.session_factor : 1)+sessRawTxt+sessCap
         : sess.hoursUsed.toFixed(2)+'h / 5h';
     const weekLabel = d.realPct != null ? 'Semanal · estimado real' : 'Semanal · cuota';
+    const weekCap = d.realPctCapped ? ' ⚠ recalibrar' : '';
+    const weekRawTxt = d.realPctRaw != null && d.realPctCapped
+        ? ' (raw '+d.realPctRaw.toFixed(1)+'%)'
+        : '';
     const weekSub = d.realPct != null
-        ? 'pipeline '+d.pct.toFixed(1)+'% × '+(d.calibration && d.calibration.weekly_factor ? d.calibration.weekly_factor : 1)
+        ? 'pipeline '+d.pct.toFixed(1)+'% × '+(d.calibration && d.calibration.weekly_factor ? d.calibration.weekly_factor : 1)+weekRawTxt+weekCap
         : 'de '+d.effectiveLimitHours+'h estimadas';
     const tiles = [
         { label: sessLabel, value: sessShownPct.toFixed(1)+'%', sub: sessSub, cls: sessCls },


### PR DESCRIPTION
Bug: factor calibración × pipeline pct podía dar valores absurdos (>100%). Cap al 100% + exponer `realPctRaw` y `realPctCapped` para detectar saturación + warning visual '⚠ recalibrar' cuando se capa. Verificado: session raw=137.5% → 100% capped. `qa:skipped`.