### PR TITLE
feat(metrics): contabilidad multi-bot + proyección quota + budget gap (#2854)

### DIFF
--- a/.claude/hooks/telegram-config.example.json
+++ b/.claude/hooks/telegram-config.example.json
@@ -1,6 +1,6 @@
 {
-  "bot_token": "8403197784:AAG07242gOCKwZ-G-DI8eLC6R1HwfhG6Exk",
-  "chat_id": "6529617704",
+  "bot_token": "YOUR_BOT_TOKEN_HERE",
+  "chat_id": "YOUR_CHAT_ID_HERE",
   "permission_timeout_min": 60,
   "task_report_interval_min": 10,
   "retry_intervals_min": [
@@ -47,6 +47,11 @@
     "weekly_budget_usd": 50
   },
   "elevenlabs_api_key": "",
-  "elevenlabs_voice_id": "pNInz6obpgDQGcFmaJgB",
-  "openai_api_key": ""
+  "elevenlabs_voice_id": "",
+  "openai_api_key": "",
+  "google_oauth_client_id": "",
+  "google_oauth_client_secret": "",
+  "google_oauth_refresh_token": "",
+  "google_drive_folder_id": "",
+  "google_credentials_path": ""
 }

--- a/.gitignore
+++ b/.gitignore
@@ -150,6 +150,8 @@ scripts/planner-plan.json
 !.pipeline/metrics/aggregator.js
 !.pipeline/metrics/projections.js
 !.pipeline/metrics/report-daily.js
+!.pipeline/metrics/multi-bot-aggregator.js
+!.pipeline/metrics/multi-bot-config.json
 !.pipeline/metrics/__tests__/
 !.pipeline/metrics/__tests__/**
 !.pipeline/**/.gitkeep

--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,6 @@ scripts/planner-plan.json
 !.pipeline/metrics/__tests__/
 !.pipeline/metrics/__tests__/**
 !.pipeline/**/.gitkeep
+
+# Telegram bot config con secretos (token, chat_id, OAuth refresh tokens, API keys) — usar telegram-config.example.json como referencia
+.claude/hooks/telegram-config.json

--- a/.pipeline/assets/mockups/2748/01-team-list-full.svg
+++ b/.pipeline/assets/mockups/2748/01-team-list-full.svg
@@ -1,0 +1,174 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Mockup 01 — Pantalla "Equipo" estado lleno (LazyColumn con empleados)
+  Issue: #2748 (split de #2441 → #2426 → #1949)
+  Flavor: business
+  Audience: android-dev (referencia visual para implementar)
+
+  Decisiones UX clave documentadas:
+  - TopAppBar M3 con título "Equipo" + ícono de menú a la izquierda + acción "Negocio activo" (BusinessSelector) a la derecha.
+  - LazyColumn con cards M3 elevation=1, padding 16dp, gap 12dp.
+  - Cada item: avatar/iniciales (40dp) + nombre + email + chip de rol + chip de estado + ⋮.
+  - Chip de rol: SuggestionChip M3 con leadingIcon (drawable correspondiente) y container tonal (paleta del tema).
+  - Chip de estado: AssistChip pequeño con leadingIcon y outline.
+  - FAB extendido (Extended FAB) "+ Invitar" anclado bottom-end (visible para OWNER/MANAGER, regla RequireRole).
+  - Touch target ≥ 48dp en FAB y ⋮.
+  - El último OWNER NO tiene ⋮ visible (anti-error de revocación).
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 412 892" width="412" height="892" font-family="Roboto, Inter, system-ui, sans-serif">
+
+  <!-- ====== background = surface light ====== -->
+  <rect width="412" height="892" fill="#F9F9FF"/>
+
+  <!-- ====== Status bar ====== -->
+  <rect width="412" height="32" fill="#F9F9FF"/>
+  <text x="20" y="22" font-size="13" fill="#191C20" font-weight="500">9:41</text>
+  <circle cx="380" cy="16" r="4" fill="#191C20"/>
+  <rect x="350" y="12" width="20" height="8" rx="2" fill="#191C20"/>
+
+  <!-- ====== TopAppBar ====== -->
+  <rect x="0" y="32" width="412" height="64" fill="#EDEDF4"/>
+  <!-- Hamburguesa -->
+  <rect x="20" y="60" width="20" height="2" fill="#191C20"/>
+  <rect x="20" y="66" width="20" height="2" fill="#191C20"/>
+  <rect x="20" y="72" width="20" height="2" fill="#191C20"/>
+  <text x="60" y="71" font-size="20" font-weight="500" fill="#191C20">Equipo</text>
+  <!-- BusinessSelector dropdown right-side -->
+  <rect x="280" y="50" width="118" height="28" rx="14" fill="#DAE2F9"/>
+  <text x="294" y="69" font-size="12" fill="#131C2B" font-weight="500">Mi Almacen</text>
+  <path d="M380 64 L386 70 L392 64" stroke="#131C2B" stroke-width="2" fill="none" stroke-linecap="round"/>
+
+  <!-- ====== Header section ====== -->
+  <text x="20" y="130" font-size="14" fill="#44474E">3 personas en tu equipo</text>
+
+  <!-- ====== Card 1 — OWNER ACTIVO (último OWNER → SIN ⋮) ====== -->
+  <g transform="translate(16, 152)">
+    <rect width="380" height="100" rx="16" fill="#FFFFFF" stroke="#E2E2E9" stroke-width="1"/>
+    <!-- Avatar iniciales -->
+    <circle cx="40" cy="50" r="22" fill="#D6E3FF"/>
+    <text x="40" y="56" font-size="16" font-weight="600" fill="#001B3E" text-anchor="middle">LL</text>
+    <!-- Nombre -->
+    <text x="76" y="42" font-size="16" font-weight="500" fill="#191C20">Leonardo Larreta</text>
+    <text x="76" y="60" font-size="13" fill="#44474E">leitolarreta@gmail.com</text>
+    <!-- Chip rol OWNER (primaryContainer) -->
+    <g transform="translate(76, 70)">
+      <rect width="76" height="24" rx="8" fill="#D6E3FF"/>
+      <!-- ícono corona -->
+      <path d="M12 18 L11 13 L14 14.5 L17 11 L20 14.5 L23 13 L22 18 Z" fill="#001B3E"/>
+      <text x="32" y="16" font-size="11" font-weight="600" fill="#001B3E">OWNER</text>
+    </g>
+    <!-- Chip estado ACTIVO -->
+    <g transform="translate(160, 70)">
+      <rect width="68" height="24" rx="8" fill="none" stroke="#74777F" stroke-width="1"/>
+      <circle cx="14" cy="12" r="3" fill="#37BF6E"/>
+      <text x="22" y="16" font-size="11" font-weight="500" fill="#191C20">ACTIVO</text>
+    </g>
+    <!-- (intencionalmente sin ⋮ — último OWNER no admite revocación ni cambio de rol) -->
+    <!-- annotation para devs -->
+    <text x="295" y="56" font-size="10" fill="#BA1A1A" font-style="italic">(sin ⋮: último OWNER)</text>
+  </g>
+
+  <!-- ====== Card 2 — MANAGER ACTIVO ====== -->
+  <g transform="translate(16, 264)">
+    <rect width="380" height="100" rx="16" fill="#FFFFFF" stroke="#E2E2E9" stroke-width="1"/>
+    <circle cx="40" cy="50" r="22" fill="#FAD8FD"/>
+    <text x="40" y="56" font-size="16" font-weight="600" fill="#28132E" text-anchor="middle">MR</text>
+    <text x="76" y="42" font-size="16" font-weight="500" fill="#191C20">Maria Rodriguez</text>
+    <text x="76" y="60" font-size="13" fill="#44474E">maria.r@example.com</text>
+    <!-- Chip rol MANAGER (tertiaryContainer) -->
+    <g transform="translate(76, 70)">
+      <rect width="92" height="24" rx="8" fill="#FAD8FD"/>
+      <path d="M16 6 L10 8 V12 C10 15 13 18 16 19 C19 18 22 15 22 12 V8 Z M14 13 L13 12 L12 13 L14 15 L19 10 L18 9 Z" fill="#28132E" transform="scale(0.6) translate(8 6)"/>
+      <text x="32" y="16" font-size="11" font-weight="600" fill="#28132E">MANAGER</text>
+    </g>
+    <!-- Chip estado ACTIVO -->
+    <g transform="translate(176, 70)">
+      <rect width="68" height="24" rx="8" fill="none" stroke="#74777F" stroke-width="1"/>
+      <circle cx="14" cy="12" r="3" fill="#37BF6E"/>
+      <text x="22" y="16" font-size="11" font-weight="500" fill="#191C20">ACTIVO</text>
+    </g>
+    <!-- ⋮ menú contextual -->
+    <g transform="translate(340, 38)">
+      <rect width="24" height="24" rx="12" fill="none"/>
+      <circle cx="12" cy="6" r="2" fill="#44474E"/>
+      <circle cx="12" cy="12" r="2" fill="#44474E"/>
+      <circle cx="12" cy="18" r="2" fill="#44474E"/>
+    </g>
+  </g>
+
+  <!-- ====== Card 3 — CASHIER PENDIENTE ====== -->
+  <g transform="translate(16, 376)">
+    <rect width="380" height="100" rx="16" fill="#FFFFFF" stroke="#E2E2E9" stroke-width="1"/>
+    <circle cx="40" cy="50" r="22" fill="#DAE2F9"/>
+    <text x="40" y="56" font-size="16" font-weight="600" fill="#131C2B" text-anchor="middle">JG</text>
+    <text x="76" y="42" font-size="16" font-weight="500" fill="#191C20">Juan Gomez</text>
+    <text x="76" y="60" font-size="13" fill="#44474E">j***@***.com</text>
+    <!-- Chip rol CASHIER (secondaryContainer) -->
+    <g transform="translate(76, 70)">
+      <rect width="86" height="24" rx="8" fill="#DAE2F9"/>
+      <rect x="9" y="9" width="14" height="8" rx="1" fill="none" stroke="#131C2B" stroke-width="1.4"/>
+      <text x="32" y="16" font-size="11" font-weight="600" fill="#131C2B">CASHIER</text>
+    </g>
+    <!-- Chip estado PENDIENTE (tertiaryContainer) -->
+    <g transform="translate(170, 70)">
+      <rect width="84" height="24" rx="8" fill="#FAD8FD"/>
+      <circle cx="13" cy="12" r="5" fill="none" stroke="#28132E" stroke-width="1.4"/>
+      <line x1="13" y1="12" x2="13" y2="9" stroke="#28132E" stroke-width="1.4" stroke-linecap="round"/>
+      <line x1="13" y1="12" x2="15.5" y2="13" stroke="#28132E" stroke-width="1.4" stroke-linecap="round"/>
+      <text x="24" y="16" font-size="11" font-weight="600" fill="#28132E">PENDIENTE</text>
+    </g>
+    <!-- ⋮ -->
+    <g transform="translate(340, 38)">
+      <circle cx="12" cy="6" r="2" fill="#44474E"/>
+      <circle cx="12" cy="12" r="2" fill="#44474E"/>
+      <circle cx="12" cy="18" r="2" fill="#44474E"/>
+    </g>
+  </g>
+
+  <!-- ====== Card 4 — EMPLOYEE REVOCADO ====== -->
+  <g transform="translate(16, 488)" opacity="0.65">
+    <rect width="380" height="100" rx="16" fill="#FFFFFF" stroke="#E2E2E9" stroke-width="1"/>
+    <circle cx="40" cy="50" r="22" fill="#E7E8EE"/>
+    <text x="40" y="56" font-size="16" font-weight="600" fill="#191C20" text-anchor="middle">PS</text>
+    <text x="76" y="42" font-size="16" font-weight="500" fill="#191C20">Pedro Suarez</text>
+    <text x="76" y="60" font-size="13" fill="#44474E">p***@***.com</text>
+    <!-- Chip rol EMPLOYEE (surfaceContainerHigh) -->
+    <g transform="translate(76, 70)">
+      <rect width="100" height="24" rx="8" fill="#E7E8EE"/>
+      <circle cx="14" cy="10" r="3" fill="none" stroke="#191C20" stroke-width="1.4"/>
+      <path d="M9 18 Q14 14 19 18" fill="none" stroke="#191C20" stroke-width="1.4"/>
+      <text x="32" y="16" font-size="11" font-weight="600" fill="#191C20">EMPLOYEE</text>
+    </g>
+    <!-- Chip estado REVOCADO (errorContainer) -->
+    <g transform="translate(184, 70)">
+      <rect width="92" height="24" rx="8" fill="#FFDAD6"/>
+      <line x1="9" y1="8" x2="17" y2="16" stroke="#410002" stroke-width="2" stroke-linecap="round"/>
+      <line x1="17" y1="8" x2="9" y2="16" stroke="#410002" stroke-width="2" stroke-linecap="round"/>
+      <text x="24" y="16" font-size="11" font-weight="600" fill="#410002">REVOCADO</text>
+    </g>
+    <!-- (sin ⋮ — revocado no permite acciones) -->
+  </g>
+
+  <!-- ====== Extended FAB "+ Invitar" ====== -->
+  <g transform="translate(252, 808)">
+    <rect width="144" height="56" rx="16" fill="#415F91"/>
+    <line x1="22" y1="28" x2="34" y2="28" stroke="#FFFFFF" stroke-width="2.5" stroke-linecap="round"/>
+    <line x1="28" y1="22" x2="28" y2="34" stroke="#FFFFFF" stroke-width="2.5" stroke-linecap="round"/>
+    <text x="46" y="34" font-size="14" font-weight="600" fill="#FFFFFF">Invitar</text>
+  </g>
+
+  <!-- ====== Notas para devs ====== -->
+  <g transform="translate(16, 620)" opacity="0.85">
+    <rect width="380" height="160" rx="12" fill="#EDEDF4" stroke="#C4C6D0" stroke-width="1" stroke-dasharray="4 4"/>
+    <text x="16" y="24" font-size="11" font-weight="700" fill="#191C20">NOTAS DEV (no se renderiza en runtime)</text>
+    <text x="16" y="44" font-size="10" fill="#44474E">• TopAppBar M3 (CenterAligned o Small) con título "Equipo" + BusinessSelector</text>
+    <text x="16" y="60" font-size="10" fill="#44474E">• LazyColumn padding 16dp, items con elevation=1, gap 12dp</text>
+    <text x="16" y="76" font-size="10" fill="#44474E">• Avatar 40dp (Image o Box con iniciales). ContentDescription: "Avatar de [nombre]"</text>
+    <text x="16" y="92" font-size="10" fill="#44474E">• Chips: SuggestionChip de M3, leadingIcon=ic_team_role_*.xml, container tonal del tema</text>
+    <text x="16" y="108" font-size="10" fill="#44474E">• ⋮ IconButton 48dp touch target. ContentDescription: "Acciones de [nombre]"</text>
+    <text x="16" y="124" font-size="10" fill="#44474E">• ÚLTIMO OWNER: el ViewModel devuelve 0 acciones — NO renderizar el ⋮ (visibilidad, no disabled)</text>
+    <text x="16" y="140" font-size="10" fill="#44474E">• Email enmascarado para invitaciones pendientes/revocadas: "j***@***.com" en UI observable</text>
+    <text x="16" y="156" font-size="10" fill="#BA1A1A">• RequireRole(setOf(OWNER, MANAGER)) wrap obligatorio</text>
+  </g>
+
+</svg>

--- a/.pipeline/assets/mockups/2748/02-team-empty-murble.svg
+++ b/.pipeline/assets/mockups/2748/02-team-empty-murble.svg
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Mockup 02 — Estado EMPTY de la pantalla "Equipo" con Murble companion
+  Issue: #2748
+  Audience: android-dev
+
+  Decisiones UX clave:
+  - Murble centrado verticalmente, 200dp, tinte = MaterialTheme.colorScheme.tertiary (#705575).
+  - Copy primario: "Sumá gente a tu equipo" (titleLarge, fontWeight=600).
+  - Copy secundario: explica el beneficio ("Invitá a tus compañeros con un mail. Eligen rol, aceptan y empiezan a operar el negocio con vos.").
+  - CTA primario "Invitar a alguien" (FilledButton M3, container=primary).
+  - Sin FAB en este estado (el CTA inline lo reemplaza por jerarquía clara).
+  - El TopAppBar y BusinessSelector permanecen iguales que en estado lleno.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 412 892" width="412" height="892" font-family="Roboto, Inter, system-ui, sans-serif">
+
+  <rect width="412" height="892" fill="#F9F9FF"/>
+
+  <!-- Status bar -->
+  <rect width="412" height="32" fill="#F9F9FF"/>
+  <text x="20" y="22" font-size="13" fill="#191C20" font-weight="500">9:41</text>
+  <rect x="350" y="12" width="20" height="8" rx="2" fill="#191C20"/>
+
+  <!-- TopAppBar -->
+  <rect x="0" y="32" width="412" height="64" fill="#EDEDF4"/>
+  <rect x="20" y="60" width="20" height="2" fill="#191C20"/>
+  <rect x="20" y="66" width="20" height="2" fill="#191C20"/>
+  <rect x="20" y="72" width="20" height="2" fill="#191C20"/>
+  <text x="60" y="71" font-size="20" font-weight="500" fill="#191C20">Equipo</text>
+  <rect x="280" y="50" width="118" height="28" rx="14" fill="#DAE2F9"/>
+  <text x="294" y="69" font-size="12" fill="#131C2B" font-weight="500">Mi Almacen</text>
+  <path d="M380 64 L386 70 L392 64" stroke="#131C2B" stroke-width="2" fill="none" stroke-linecap="round"/>
+
+  <!-- ====== Murble centrado ====== -->
+  <g transform="translate(106, 200)" opacity="0.9">
+    <!-- Cuerpo blob -->
+    <path d="M100,40 C140,38 165,62 168,98 C170,124 162,148 140,160 C120,170 100,168 90,165 C70,160 55,148 48,128 C42,108 45,82 60,62 C72,48 86,42 100,40 Z" fill="#705575"/>
+    <!-- Brazo saludando -->
+    <path d="M55,90 C42,82 32,72 28,60 C26,52 30,46 38,46 C46,46 54,54 62,68 C66,76 64,86 60,92 C58,94 56,93 55,90 Z" fill="#705575"/>
+    <!-- Ojo izq -->
+    <ellipse cx="82" cy="90" rx="10" ry="12" fill="#FFFFFF"/>
+    <ellipse cx="84" cy="93" rx="4" ry="5" fill="#28132E"/>
+    <ellipse cx="86" cy="89" rx="1.5" ry="1.8" fill="#FFFFFF"/>
+    <!-- Ojo der -->
+    <ellipse cx="126" cy="90" rx="10" ry="12" fill="#FFFFFF"/>
+    <ellipse cx="128" cy="93" rx="4" ry="5" fill="#28132E"/>
+    <ellipse cx="130" cy="89" rx="1.5" ry="1.8" fill="#FFFFFF"/>
+    <!-- Sonrisa -->
+    <path d="M85,120 Q105,138 125,120 Q120,134 105,136 Q90,134 85,120 Z" fill="#FFFFFF"/>
+    <path d="M85,120 Q105,140 125,120" stroke="#28132E" stroke-width="2" fill="none" stroke-linecap="round"/>
+    <!-- Estrellitas -->
+    <path d="M170,55 L173,62 L180,62 L174,67 L176,74 L170,70 L164,74 L166,67 L160,62 L167,62 Z" fill="#705575"/>
+    <path d="M30,130 L32,135 L37,135 L33,138 L34,143 L30,140 L26,143 L27,138 L23,135 L28,135 Z" fill="#705575"/>
+    <path d="M155,150 L156.5,153.5 L160,153.5 L157.2,156 L158,160 L155,158 L152,160 L152.8,156 L150,153.5 L153.5,153.5 Z" fill="#705575"/>
+  </g>
+
+  <!-- ====== Copy primario ====== -->
+  <text x="206" y="500" font-size="22" font-weight="600" fill="#191C20" text-anchor="middle">Sumá gente a tu equipo</text>
+
+  <!-- ====== Copy secundario ====== -->
+  <text x="206" y="538" font-size="14" fill="#44474E" text-anchor="middle">
+    <tspan x="206" dy="0">Invitá a tus compañeros con un mail. Eligen rol,</tspan>
+    <tspan x="206" dy="20">aceptan y empiezan a operar el negocio con vos.</tspan>
+  </text>
+
+  <!-- ====== CTA primario ====== -->
+  <g transform="translate(106, 600)">
+    <rect width="200" height="56" rx="16" fill="#415F91"/>
+    <line x1="68" y1="28" x2="80" y2="28" stroke="#FFFFFF" stroke-width="2.5" stroke-linecap="round"/>
+    <line x1="74" y1="22" x2="74" y2="34" stroke="#FFFFFF" stroke-width="2.5" stroke-linecap="round"/>
+    <text x="118" y="34" font-size="15" font-weight="600" fill="#FFFFFF">Invitar a alguien</text>
+  </g>
+
+  <!-- ====== Notas DEV ====== -->
+  <g transform="translate(16, 720)">
+    <rect width="380" height="140" rx="12" fill="#EDEDF4" stroke="#C4C6D0" stroke-width="1" stroke-dasharray="4 4"/>
+    <text x="16" y="24" font-size="11" font-weight="700" fill="#191C20">NOTAS DEV — estado EMPTY</text>
+    <text x="16" y="44" font-size="10" fill="#44474E">• Asset: team_murble_friendly.xml a 200dp, tint = MaterialTheme.colorScheme.tertiary</text>
+    <text x="16" y="60" font-size="10" fill="#44474E">• ContentDescription Murble: "Murble, el ayudante de Intrale, te da la bienvenida"</text>
+    <text x="16" y="76" font-size="10" fill="#44474E">• Copy con resString() + fb() ASCII-safe (TODOS los strings)</text>
+    <text x="16" y="92" font-size="10" fill="#44474E">• CTA: FilledButton M3, mismo destino que el FAB del estado lleno (BottomSheet de invitar)</text>
+    <text x="16" y="108" font-size="10" fill="#44474E">• En este estado NO se muestra FAB — el CTA inline ES el CTA primario</text>
+    <text x="16" y="124" font-size="10" fill="#BA1A1A">• Si CASHIER llega aquí (no debería por RequireRole), igual mostrar empty + CTA disabled</text>
+  </g>
+</svg>

--- a/.pipeline/assets/mockups/2748/03-invite-bottomsheet.svg
+++ b/.pipeline/assets/mockups/2748/03-invite-bottomsheet.svg
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Mockup 03 — BottomSheet "Invitar empleado"
+  Issue: #2748
+  Audience: android-dev
+
+  Decisiones UX:
+  - ModalBottomSheet M3, drag handle visible, padding 24dp.
+  - Título "Invitar empleado" + subtítulo (titleLarge + bodyMedium).
+  - Campo email TextField outlined, validación en vivo Konform.
+  - Selector de rol: 4 SuggestionChip seleccionables (single-select), grid 2x2.
+  - Cada chip tiene leadingIcon + nombre + descripción corta debajo.
+  - CTA "Enviar invitación" full-width, deshabilitado hasta validar email + rol.
+  - Botón "Cancelar" texto secundario arriba a la derecha.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 412 892" width="412" height="892" font-family="Roboto, Inter, system-ui, sans-serif">
+
+  <!-- Scrim oscuro detrás -->
+  <rect width="412" height="892" fill="#191C20" opacity="0.5"/>
+
+  <!-- ====== BottomSheet ====== -->
+  <g transform="translate(0, 240)">
+    <path d="M0,28 Q0,0 28,0 L384,0 Q412,0 412,28 L412,652 L0,652 Z" fill="#F3F3FA"/>
+
+    <!-- Drag handle -->
+    <rect x="186" y="12" width="40" height="4" rx="2" fill="#74777F"/>
+
+    <!-- Header -->
+    <text x="24" y="56" font-size="22" font-weight="600" fill="#191C20">Invitar empleado</text>
+    <text x="372" y="56" font-size="14" fill="#415F91" text-anchor="end">Cancelar</text>
+    <text x="24" y="86" font-size="14" fill="#44474E">Le mandamos un mail con un link para que se sume.</text>
+
+    <!-- TextField email -->
+    <text x="24" y="124" font-size="12" fill="#44474E">Email</text>
+    <rect x="24" y="132" width="364" height="56" rx="8" fill="none" stroke="#415F91" stroke-width="2"/>
+    <text x="40" y="166" font-size="15" fill="#191C20">maria.rodriguez@miempresa.com</text>
+    <!-- helper text -->
+    <text x="40" y="206" font-size="11" fill="#37BF6E">✓ Email válido</text>
+
+    <!-- Selector rol header -->
+    <text x="24" y="240" font-size="12" fill="#44474E">Elegí un rol</text>
+
+    <!-- Chip OWNER (sin selección por defecto) -->
+    <g transform="translate(24, 256)">
+      <rect width="174" height="80" rx="12" fill="#FFFFFF" stroke="#C4C6D0" stroke-width="1.5"/>
+      <g transform="translate(12, 12)">
+        <rect width="28" height="28" rx="14" fill="#D6E3FF"/>
+        <path d="M14 22 L13 17 L16 18.5 L19 15 L22 18.5 L25 17 L24 22 Z" fill="#001B3E" transform="translate(-4 -2)"/>
+      </g>
+      <text x="48" y="28" font-size="14" font-weight="600" fill="#191C20">Owner</text>
+      <text x="12" y="58" font-size="11" fill="#44474E">Control total del negocio</text>
+      <text x="12" y="72" font-size="11" fill="#44474E">y del equipo.</text>
+    </g>
+
+    <!-- Chip MANAGER seleccionado -->
+    <g transform="translate(214, 256)">
+      <rect width="174" height="80" rx="12" fill="#D6E3FF" stroke="#415F91" stroke-width="2.5"/>
+      <g transform="translate(12, 12)">
+        <rect width="28" height="28" rx="14" fill="#FAD8FD"/>
+        <path d="M16 8 L10 10 V14 C10 17 13 20 16 21 C19 20 22 17 22 14 V10 Z" fill="none" stroke="#28132E" stroke-width="1.5"/>
+        <path d="M14 14 L13 13 L12 14 L14 16 L19 11 L18 10 Z" fill="#28132E"/>
+      </g>
+      <text x="48" y="28" font-size="14" font-weight="600" fill="#001B3E">Manager</text>
+      <!-- Check de selección -->
+      <circle cx="156" cy="22" r="10" fill="#415F91"/>
+      <path d="M152 22 L155 25 L161 19" stroke="#FFFFFF" stroke-width="2" fill="none" stroke-linecap="round"/>
+      <text x="12" y="58" font-size="11" fill="#001B3E">Administra equipo</text>
+      <text x="12" y="72" font-size="11" fill="#001B3E">sin tocar facturación.</text>
+    </g>
+
+    <!-- Chip CASHIER -->
+    <g transform="translate(24, 348)">
+      <rect width="174" height="80" rx="12" fill="#FFFFFF" stroke="#C4C6D0" stroke-width="1.5"/>
+      <g transform="translate(12, 12)">
+        <rect width="28" height="28" rx="14" fill="#DAE2F9"/>
+        <rect x="9" y="10" width="14" height="8" rx="1" fill="none" stroke="#131C2B" stroke-width="1.4" transform="translate(-2 0)"/>
+      </g>
+      <text x="48" y="28" font-size="14" font-weight="600" fill="#191C20">Cashier</text>
+      <text x="12" y="58" font-size="11" fill="#44474E">Opera caja, ve sus</text>
+      <text x="12" y="72" font-size="11" fill="#44474E">propias ventas.</text>
+    </g>
+
+    <!-- Chip EMPLOYEE -->
+    <g transform="translate(214, 348)">
+      <rect width="174" height="80" rx="12" fill="#FFFFFF" stroke="#C4C6D0" stroke-width="1.5"/>
+      <g transform="translate(12, 12)">
+        <rect width="28" height="28" rx="14" fill="#E7E8EE"/>
+        <circle cx="14" cy="11" r="3.5" fill="none" stroke="#191C20" stroke-width="1.4"/>
+        <path d="M9 21 Q14 16 19 21" fill="none" stroke="#191C20" stroke-width="1.4"/>
+      </g>
+      <text x="48" y="28" font-size="14" font-weight="600" fill="#191C20">Employee</text>
+      <text x="12" y="58" font-size="11" fill="#44474E">Acceso básico, sin</text>
+      <text x="12" y="72" font-size="11" fill="#44474E">acciones administrativas.</text>
+    </g>
+
+    <!-- CTA enviar (habilitado porque email + rol válidos) -->
+    <g transform="translate(24, 460)">
+      <rect width="364" height="56" rx="16" fill="#415F91"/>
+      <text x="182" y="34" font-size="15" font-weight="600" fill="#FFFFFF" text-anchor="middle">Enviar invitación</text>
+    </g>
+
+    <!-- Anti-escalada hint -->
+    <g transform="translate(24, 540)">
+      <rect width="364" height="64" rx="12" fill="#FAD8FD" opacity="0.5"/>
+      <text x="16" y="22" font-size="11" font-weight="600" fill="#28132E">Sobre los roles</text>
+      <text x="16" y="40" font-size="10" fill="#28132E">No podés asignar un rol con más permisos que los tuyos.</text>
+      <text x="16" y="56" font-size="10" fill="#28132E">Si sos MANAGER, no vas a ver "Owner" como opción.</text>
+    </g>
+  </g>
+
+  <!-- Notas DEV (al fondo) -->
+  <g transform="translate(16, 894)" opacity="0">
+    <text>placeholder</text>
+  </g>
+</svg>

--- a/.pipeline/assets/mockups/2748/04-invitation-accept.svg
+++ b/.pipeline/assets/mockups/2748/04-invitation-accept.svg
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Mockup 04 — Pantalla "Aceptación de invitación" (deep link válido)
+  Issue: #2748
+  Audience: android-dev
+
+  Decisiones UX:
+  - Hero icon: ic_invitation_envelope.xml a 96dp, color = primary.
+  - Título: "Te invitan a [Nombre del Negocio]" (headlineMedium, fontWeight=600).
+  - Body: explica el contexto en 1-2 líneas.
+  - Chip M3 grande mostrando el rol asignado, leadingIcon del rol.
+  - Dos CTAs apilados:
+    - Primario "Aceptar" (FilledButton M3, container=primary).
+    - Secundario "Rechazar" (OutlinedButton M3).
+  - Si NO hay sesión: redirigir a login PRIMERO, luego mostrar esta pantalla.
+  - Si email distinto: ver mockup 05 (estado de error).
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 412 892" width="412" height="892" font-family="Roboto, Inter, system-ui, sans-serif">
+
+  <rect width="412" height="892" fill="#F9F9FF"/>
+
+  <!-- Status bar -->
+  <rect width="412" height="32" fill="#F9F9FF"/>
+  <text x="20" y="22" font-size="13" fill="#191C20" font-weight="500">9:41</text>
+  <rect x="350" y="12" width="20" height="8" rx="2" fill="#191C20"/>
+
+  <!-- TopAppBar minimal con back -->
+  <rect x="0" y="32" width="412" height="64" fill="#F9F9FF"/>
+  <path d="M28 64 L36 56 M28 64 L36 72 M28 64 L48 64" stroke="#191C20" stroke-width="2" stroke-linecap="round" fill="none"/>
+
+  <!-- Hero icon: sobre con check -->
+  <g transform="translate(158, 144)">
+    <rect width="96" height="96" rx="48" fill="#D6E3FF"/>
+    <g transform="translate(20, 20)">
+      <!-- envelope body -->
+      <path d="M48 12 L8 12 L8 44 L48 44 Z" fill="#415F91"/>
+      <!-- envelope flap -->
+      <path d="M8 12 L28 28 L48 12" fill="none" stroke="#415F91" stroke-width="2"/>
+      <!-- check -->
+      <circle cx="44" cy="42" r="14" fill="#37BF6E"/>
+      <path d="M38 42 L42 46 L50 38" stroke="#FFFFFF" stroke-width="2.5" stroke-linecap="round" fill="none"/>
+    </g>
+  </g>
+
+  <!-- Título -->
+  <text x="206" y="280" font-size="13" fill="#44474E" text-anchor="middle">Te invitan a</text>
+  <text x="206" y="316" font-size="26" font-weight="600" fill="#191C20" text-anchor="middle">Mi Almacen</text>
+
+  <!-- Body -->
+  <text x="206" y="350" font-size="14" fill="#44474E" text-anchor="middle">
+    <tspan x="206" dy="0">Vas a poder operar el negocio según el rol</tspan>
+    <tspan x="206" dy="20">que te asignó el dueño.</tspan>
+  </text>
+
+  <!-- Chip de rol (grande) -->
+  <g transform="translate(126, 392)">
+    <rect width="160" height="48" rx="16" fill="#FAD8FD"/>
+    <g transform="translate(16, 12)">
+      <path d="M16 8 L10 10 V14 C10 17 13 20 16 21 C19 20 22 17 22 14 V10 Z" fill="none" stroke="#28132E" stroke-width="1.5"/>
+      <path d="M14 14 L13 13 L12 14 L14 16 L19 11 L18 10 Z" fill="#28132E"/>
+    </g>
+    <text x="60" y="30" font-size="15" font-weight="600" fill="#28132E">Tu rol: Manager</text>
+  </g>
+
+  <!-- Description del rol -->
+  <text x="206" y="476" font-size="12" fill="#44474E" text-anchor="middle">
+    <tspan x="206" dy="0">Administra el equipo del negocio sin tocar</tspan>
+    <tspan x="206" dy="18">facturación. Acepta para empezar.</tspan>
+  </text>
+
+  <!-- CTAs apilados -->
+  <g transform="translate(40, 550)">
+    <rect width="332" height="56" rx="16" fill="#415F91"/>
+    <text x="166" y="34" font-size="15" font-weight="600" fill="#FFFFFF" text-anchor="middle">Aceptar invitación</text>
+  </g>
+
+  <g transform="translate(40, 622)">
+    <rect width="332" height="56" rx="16" fill="none" stroke="#415F91" stroke-width="1.5"/>
+    <text x="166" y="34" font-size="15" font-weight="500" fill="#415F91" text-anchor="middle">Rechazar</text>
+  </g>
+
+  <!-- Hint de privacidad -->
+  <g transform="translate(40, 712)">
+    <rect width="332" height="60" rx="12" fill="#EDEDF4"/>
+    <circle cx="20" cy="30" r="10" fill="none" stroke="#44474E" stroke-width="1.5"/>
+    <text x="20" y="34" font-size="12" font-weight="700" fill="#44474E" text-anchor="middle">i</text>
+    <text x="36" y="26" font-size="11" fill="#44474E">Si rechazás, no se notifica a nadie.</text>
+    <text x="36" y="42" font-size="11" fill="#44474E">El link queda inválido para futuros usos.</text>
+  </g>
+
+  <!-- Notas DEV -->
+  <g transform="translate(16, 800)">
+    <rect width="380" height="80" rx="12" fill="#EDEDF4" stroke="#C4C6D0" stroke-width="1" stroke-dasharray="4 4"/>
+    <text x="16" y="22" font-size="11" font-weight="700" fill="#191C20">NOTAS DEV — InvitationScreen</text>
+    <text x="16" y="40" font-size="10" fill="#44474E">• Si no hay sesión: redirigir a login con returnTo, NO mostrar nombre del negocio</text>
+    <text x="16" y="56" font-size="10" fill="#44474E">• Token NUNCA en logs. Tras consumo, borrar de InvitationDeepLinkStore</text>
+    <text x="16" y="72" font-size="10" fill="#BA1A1A">• Tras Aceptar: refresh del BusinessSelector + nav al home del negocio nuevo</text>
+  </g>
+</svg>

--- a/.pipeline/assets/mockups/2748/05-invitation-error-states.svg
+++ b/.pipeline/assets/mockups/2748/05-invitation-error-states.svg
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Mockup 05 — Estados de error de "Aceptación de invitación" (deep link inválido)
+  Issue: #2748
+  Audience: android-dev
+
+  Tres estados representados lado a lado:
+    A) Token expirado
+    B) Token reutilizado (ya consumido)
+    C) Email distinto al logueado
+
+  Decisiones UX:
+  - Mismo layout base que la pantalla feliz, cambia el hero icon + título + body + CTAs.
+  - Hero icon = ícono de error con halo errorContainer (no rojo agresivo, dignidad).
+  - Cada estado tiene un CTA secundario para que el usuario tenga salida clara.
+  - Token NUNCA aparece en pantalla.
+  - Email distinto: enmascarar el email correcto ("Iniciá sesión con j***@***.com").
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 720" width="1280" height="720" font-family="Roboto, Inter, system-ui, sans-serif">
+
+  <rect width="1280" height="720" fill="#F0F0F7"/>
+
+  <text x="640" y="40" font-size="22" font-weight="700" fill="#191C20" text-anchor="middle">Aceptación de invitación — Estados de error</text>
+
+  <!-- ====== A) Token expirado ====== -->
+  <g transform="translate(40, 80)">
+    <rect width="380" height="600" rx="32" fill="#F9F9FF" stroke="#C4C6D0" stroke-width="1"/>
+
+    <text x="190" y="36" font-size="14" font-weight="600" fill="#44474E" text-anchor="middle">A) Token expirado</text>
+
+    <!-- Hero -->
+    <g transform="translate(142, 80)">
+      <rect width="96" height="96" rx="48" fill="#FAD8FD"/>
+      <g transform="translate(28, 24)">
+        <circle cx="20" cy="24" r="18" fill="none" stroke="#28132E" stroke-width="2.5"/>
+        <line x1="20" y1="14" x2="20" y2="22" stroke="#28132E" stroke-width="2.5" stroke-linecap="round"/>
+        <line x1="20" y1="22" x2="26" y2="26" stroke="#28132E" stroke-width="2.5" stroke-linecap="round"/>
+      </g>
+    </g>
+
+    <text x="190" y="220" font-size="20" font-weight="600" fill="#191C20" text-anchor="middle">La invitación expiró</text>
+    <text x="190" y="252" font-size="13" fill="#44474E" text-anchor="middle">
+      <tspan x="190" dy="0">Pasaron más de 72 horas desde que te</tspan>
+      <tspan x="190" dy="18">la enviaron. Pedile a quien te invitó</tspan>
+      <tspan x="190" dy="18">que la mande de nuevo.</tspan>
+    </text>
+
+    <!-- CTA primario -->
+    <g transform="translate(40, 390)">
+      <rect width="300" height="56" rx="16" fill="#415F91"/>
+      <text x="150" y="34" font-size="14" font-weight="600" fill="#FFFFFF" text-anchor="middle">Volver al inicio</text>
+    </g>
+
+    <!-- CTA secundario -->
+    <g transform="translate(40, 460)">
+      <rect width="300" height="56" rx="16" fill="none" stroke="#415F91" stroke-width="1.5"/>
+      <text x="150" y="34" font-size="14" font-weight="500" fill="#415F91" text-anchor="middle">Pedir nueva invitación</text>
+    </g>
+  </g>
+
+  <!-- ====== B) Token reutilizado ====== -->
+  <g transform="translate(450, 80)">
+    <rect width="380" height="600" rx="32" fill="#F9F9FF" stroke="#C4C6D0" stroke-width="1"/>
+
+    <text x="190" y="36" font-size="14" font-weight="600" fill="#44474E" text-anchor="middle">B) Ya fue usada</text>
+
+    <g transform="translate(142, 80)">
+      <rect width="96" height="96" rx="48" fill="#DAE2F9"/>
+      <!-- check + barra "ya usado" -->
+      <g transform="translate(20, 20)">
+        <circle cx="28" cy="28" r="22" fill="none" stroke="#131C2B" stroke-width="2.5"/>
+        <path d="M18 28 L24 34 L38 20" stroke="#131C2B" stroke-width="2.5" stroke-linecap="round" fill="none"/>
+      </g>
+    </g>
+
+    <text x="190" y="220" font-size="20" font-weight="600" fill="#191C20" text-anchor="middle">Ya aceptaste esta invitación</text>
+    <text x="190" y="252" font-size="13" fill="#44474E" text-anchor="middle">
+      <tspan x="190" dy="0">Esta invitación ya fue usada antes.</tspan>
+      <tspan x="190" dy="18">El negocio aparece en tu selector,</tspan>
+      <tspan x="190" dy="18">podés cambiar a él cuando quieras.</tspan>
+    </text>
+
+    <g transform="translate(40, 390)">
+      <rect width="300" height="56" rx="16" fill="#415F91"/>
+      <text x="150" y="34" font-size="14" font-weight="600" fill="#FFFFFF" text-anchor="middle">Ir al negocio</text>
+    </g>
+
+    <g transform="translate(40, 460)">
+      <rect width="300" height="56" rx="16" fill="none" stroke="#415F91" stroke-width="1.5"/>
+      <text x="150" y="34" font-size="14" font-weight="500" fill="#415F91" text-anchor="middle">Volver al inicio</text>
+    </g>
+  </g>
+
+  <!-- ====== C) Email distinto ====== -->
+  <g transform="translate(860, 80)">
+    <rect width="380" height="600" rx="32" fill="#F9F9FF" stroke="#C4C6D0" stroke-width="1"/>
+
+    <text x="190" y="36" font-size="14" font-weight="600" fill="#44474E" text-anchor="middle">C) Email distinto al logueado</text>
+
+    <g transform="translate(142, 80)">
+      <rect width="96" height="96" rx="48" fill="#FFDAD6"/>
+      <g transform="translate(24, 24)">
+        <!-- person + lock -->
+        <circle cx="24" cy="20" r="8" fill="none" stroke="#410002" stroke-width="2"/>
+        <path d="M10 44 Q24 30 38 44" fill="none" stroke="#410002" stroke-width="2"/>
+        <rect x="32" y="32" width="14" height="12" rx="2" fill="#FFDAD6" stroke="#410002" stroke-width="2"/>
+        <path d="M36 32 V28 Q36 24 39 24 Q42 24 42 28 V32" fill="none" stroke="#410002" stroke-width="2"/>
+      </g>
+    </g>
+
+    <text x="190" y="220" font-size="20" font-weight="600" fill="#191C20" text-anchor="middle">Esta invitación es para</text>
+    <text x="190" y="244" font-size="20" font-weight="600" fill="#191C20" text-anchor="middle">otra cuenta</text>
+    <text x="190" y="280" font-size="13" fill="#44474E" text-anchor="middle">
+      <tspan x="190" dy="0">Iniciá sesión con</tspan>
+      <tspan x="190" dy="22" font-weight="600" font-family="monospace" fill="#191C20">j***@***.com</tspan>
+      <tspan x="190" dy="22">para aceptar la invitación.</tspan>
+    </text>
+
+    <g transform="translate(40, 410)">
+      <rect width="300" height="56" rx="16" fill="#415F91"/>
+      <text x="150" y="34" font-size="14" font-weight="600" fill="#FFFFFF" text-anchor="middle">Cambiar de cuenta</text>
+    </g>
+
+    <g transform="translate(40, 480)">
+      <rect width="300" height="56" rx="16" fill="none" stroke="#415F91" stroke-width="1.5"/>
+      <text x="150" y="34" font-size="14" font-weight="500" fill="#415F91" text-anchor="middle">Volver al inicio</text>
+    </g>
+  </g>
+</svg>

--- a/.pipeline/assets/mockups/2748/06-revoke-confirmation-dialog.svg
+++ b/.pipeline/assets/mockups/2748/06-revoke-confirmation-dialog.svg
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Mockup 06 — Dialog destructivo de "Revocar acceso"
+  Issue: #2748
+  Audience: android-dev
+
+  Decisiones UX:
+  - AlertDialog M3 con container = surfaceContainerHigh, borderRadius=28dp.
+  - Icon: ic_warning circular, tinte = error (no errorContainer — comunicar gravedad).
+  - Headline: "¿Revocar acceso?" — pregunta directa, no afirmación.
+  - SupportingText: nombra a la persona + explica el efecto inmediato + tono.
+  - Action principal "Revocar": container=error, label=onError. Touch target 48dp.
+  - Action secundaria "Cancelar": text button. Foco inicial en Cancelar (anti-error tap).
+  - Si la operación falla en backend (ej. race con último OWNER): mantener dialog abierto + mostrar error inline.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 412 892" width="412" height="892" font-family="Roboto, Inter, system-ui, sans-serif">
+
+  <!-- Pantalla de fondo (lista de equipo difuminada) -->
+  <rect width="412" height="892" fill="#F9F9FF"/>
+  <rect width="412" height="32" fill="#F9F9FF"/>
+  <text x="20" y="22" font-size="13" fill="#191C20" font-weight="500">9:41</text>
+  <rect x="0" y="32" width="412" height="64" fill="#EDEDF4" opacity="0.6"/>
+  <text x="60" y="71" font-size="20" font-weight="500" fill="#191C20" opacity="0.5">Equipo</text>
+
+  <!-- Cards difuminadas -->
+  <g opacity="0.3">
+    <rect x="16" y="120" width="380" height="100" rx="16" fill="#FFFFFF" stroke="#E2E2E9"/>
+    <rect x="16" y="232" width="380" height="100" rx="16" fill="#FFFFFF" stroke="#E2E2E9"/>
+    <rect x="16" y="344" width="380" height="100" rx="16" fill="#FFFFFF" stroke="#E2E2E9"/>
+  </g>
+
+  <!-- Scrim -->
+  <rect width="412" height="892" fill="#000000" opacity="0.45"/>
+
+  <!-- ====== Dialog ====== -->
+  <g transform="translate(36, 220)">
+    <rect width="340" height="396" rx="28" fill="#E7E8EE"/>
+
+    <!-- Icon circular -->
+    <g transform="translate(146, 32)">
+      <rect width="48" height="48" rx="24" fill="#FFDAD6"/>
+      <g transform="translate(8, 8)">
+        <!-- triangle warning -->
+        <path d="M16 4 L28 28 L4 28 Z" fill="none" stroke="#BA1A1A" stroke-width="2.5" stroke-linejoin="round"/>
+        <line x1="16" y1="14" x2="16" y2="20" stroke="#BA1A1A" stroke-width="2.5" stroke-linecap="round"/>
+        <circle cx="16" cy="24" r="1.4" fill="#BA1A1A"/>
+      </g>
+    </g>
+
+    <!-- Headline -->
+    <text x="170" y="120" font-size="22" font-weight="600" fill="#191C20" text-anchor="middle">¿Revocar acceso?</text>
+
+    <!-- Supporting text -->
+    <text x="24" y="166" font-size="14" fill="#44474E">
+      <tspan x="24" dy="0" font-weight="500">Maria Rodriguez</tspan>
+      <tspan x="24" dy="22">va a perder acceso a Mi Almacen</tspan>
+      <tspan x="24" dy="22">inmediatamente. Si querés que vuelva,</tspan>
+      <tspan x="24" dy="22">vas a tener que invitarla de nuevo.</tspan>
+    </text>
+
+    <!-- Hint contextual -->
+    <g transform="translate(24, 280)">
+      <rect width="292" height="44" rx="8" fill="#FAD8FD"/>
+      <text x="16" y="20" font-size="11" font-weight="600" fill="#28132E">Esta acción se registra en el</text>
+      <text x="16" y="36" font-size="11" font-weight="600" fill="#28132E">historial del negocio.</text>
+    </g>
+
+    <!-- Acciones -->
+    <g transform="translate(24, 348)">
+      <!-- Cancelar (text button, foco inicial) -->
+      <rect width="100" height="40" rx="20" fill="none"/>
+      <text x="50" y="26" font-size="14" font-weight="600" fill="#415F91" text-anchor="middle">Cancelar</text>
+
+      <!-- Revocar (container error) -->
+      <rect x="120" y="0" width="172" height="40" rx="20" fill="#BA1A1A"/>
+      <text x="206" y="26" font-size="14" font-weight="600" fill="#FFFFFF" text-anchor="middle">Revocar acceso</text>
+    </g>
+  </g>
+
+  <!-- Notas DEV -->
+  <g transform="translate(16, 720)">
+    <rect width="380" height="140" rx="12" fill="#FFFFFF" stroke="#C4C6D0" stroke-width="1" stroke-dasharray="4 4" opacity="0.95"/>
+    <text x="16" y="24" font-size="11" font-weight="700" fill="#191C20">NOTAS DEV — Dialog destructivo</text>
+    <text x="16" y="44" font-size="10" fill="#44474E">• AlertDialog de M3, NO Dialog custom — accesibilidad gratis (focus trap, escape, etc)</text>
+    <text x="16" y="60" font-size="10" fill="#44474E">• Foco inicial en Cancelar (anti-error tap accidental)</text>
+    <text x="16" y="76" font-size="10" fill="#44474E">• Container del action destructivo = MaterialTheme.colorScheme.error (#BA1A1A)</text>
+    <text x="16" y="92" font-size="10" fill="#44474E">• Touch target 48dp en ambas acciones (Material guideline)</text>
+    <text x="16" y="108" font-size="10" fill="#44474E">• Si backend rechaza (race condition último OWNER): mantener dialog + mostrar SnackbarHost</text>
+    <text x="16" y="124" font-size="10" fill="#BA1A1A">• ContentDescription icon: "Advertencia: acción destructiva"</text>
+  </g>
+</svg>

--- a/.pipeline/assets/mockups/2748/07-role-chips-system.svg
+++ b/.pipeline/assets/mockups/2748/07-role-chips-system.svg
@@ -1,0 +1,217 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Mockup 07 — Sistema de chips de rol y de estado con paleta WCAG AA
+  Issue: #2748
+  Audience: android-dev + reviewers (UX/accesibilidad)
+
+  Documentación visual de:
+    1. Cuatro chips de rol (OWNER, MANAGER, CASHIER, EMPLOYEE) con tokens del tema Intrale.
+    2. Tres chips de estado (ACTIVO, PENDIENTE, REVOCADO).
+    3. Tabla de contraste WCAG AA.
+    4. Variantes (selected / disabled / outlined-only).
+
+  Decisiones críticas (BLOQUEANTES):
+  - Cero colores ad-hoc. TODO sale del tema en `ui/th/Color.kt`.
+  - Container y onContainer del mismo tono → contraste WCAG AA garantizado.
+  - El bloque "anti-escalada" en el header explica por qué son 4 y por qué sólo OWNER/MANAGER ven todos.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 980" width="1280" height="980" font-family="Roboto, Inter, system-ui, sans-serif">
+
+  <rect width="1280" height="980" fill="#F0F0F7"/>
+
+  <!-- Header -->
+  <text x="40" y="48" font-size="24" font-weight="700" fill="#191C20">Sistema de chips de rol y estado — Equipo (#2748)</text>
+  <text x="40" y="76" font-size="13" fill="#44474E">Paleta tomada del tema en ui/th/Color.kt — WCAG AA (≥4.5:1) verificado para texto y leading icon en cada chip.</text>
+
+  <!-- ====== Sección 1: Chips de rol ====== -->
+  <text x="40" y="124" font-size="16" font-weight="600" fill="#191C20">1) Chips de rol — SuggestionChip M3 con leadingIcon</text>
+
+  <!-- OWNER -->
+  <g transform="translate(40, 152)">
+    <rect width="280" height="156" rx="16" fill="#FFFFFF" stroke="#C4C6D0"/>
+    <text x="16" y="28" font-size="13" font-weight="700" fill="#191C20">OWNER</text>
+    <text x="16" y="46" font-size="11" fill="#44474E">primaryContainer + onPrimaryContainer</text>
+    <!-- chip -->
+    <g transform="translate(16, 60)">
+      <rect width="100" height="32" rx="8" fill="#D6E3FF"/>
+      <g transform="translate(8, 4)"><path d="M14 22 L13 17 L16 18.5 L19 15 L22 18.5 L25 17 L24 22 Z" fill="#001B3E"/></g>
+      <text x="38" y="22" font-size="12" font-weight="600" fill="#001B3E">OWNER</text>
+    </g>
+    <text x="16" y="118" font-size="10" fill="#44474E">Hex container: #D6E3FF</text>
+    <text x="16" y="132" font-size="10" fill="#44474E">Hex onContainer: #001B3E</text>
+    <text x="16" y="146" font-size="10" font-weight="600" fill="#37BF6E">Contrast 12.4:1 ✓ AAA</text>
+  </g>
+
+  <!-- MANAGER -->
+  <g transform="translate(336, 152)">
+    <rect width="280" height="156" rx="16" fill="#FFFFFF" stroke="#C4C6D0"/>
+    <text x="16" y="28" font-size="13" font-weight="700" fill="#191C20">MANAGER</text>
+    <text x="16" y="46" font-size="11" fill="#44474E">tertiaryContainer + onTertiaryContainer</text>
+    <g transform="translate(16, 60)">
+      <rect width="116" height="32" rx="8" fill="#FAD8FD"/>
+      <g transform="translate(8, 4)">
+        <path d="M16 8 L10 10 V14 C10 17 13 20 16 21 C19 20 22 17 22 14 V10 Z" fill="none" stroke="#28132E" stroke-width="1.5"/>
+        <path d="M14 14 L13 13 L12 14 L14 16 L19 11 L18 10 Z" fill="#28132E"/>
+      </g>
+      <text x="38" y="22" font-size="12" font-weight="600" fill="#28132E">MANAGER</text>
+    </g>
+    <text x="16" y="118" font-size="10" fill="#44474E">Hex container: #FAD8FD</text>
+    <text x="16" y="132" font-size="10" fill="#44474E">Hex onContainer: #28132E</text>
+    <text x="16" y="146" font-size="10" font-weight="600" fill="#37BF6E">Contrast 13.1:1 ✓ AAA</text>
+  </g>
+
+  <!-- CASHIER -->
+  <g transform="translate(632, 152)">
+    <rect width="280" height="156" rx="16" fill="#FFFFFF" stroke="#C4C6D0"/>
+    <text x="16" y="28" font-size="13" font-weight="700" fill="#191C20">CASHIER</text>
+    <text x="16" y="46" font-size="11" fill="#44474E">secondaryContainer + onSecondaryContainer</text>
+    <g transform="translate(16, 60)">
+      <rect width="108" height="32" rx="8" fill="#DAE2F9"/>
+      <rect x="9" y="12" width="14" height="8" rx="1" fill="none" stroke="#131C2B" stroke-width="1.4"/>
+      <text x="38" y="22" font-size="12" font-weight="600" fill="#131C2B">CASHIER</text>
+    </g>
+    <text x="16" y="118" font-size="10" fill="#44474E">Hex container: #DAE2F9</text>
+    <text x="16" y="132" font-size="10" fill="#44474E">Hex onContainer: #131C2B</text>
+    <text x="16" y="146" font-size="10" font-weight="600" fill="#37BF6E">Contrast 12.8:1 ✓ AAA</text>
+  </g>
+
+  <!-- EMPLOYEE -->
+  <g transform="translate(928, 152)">
+    <rect width="280" height="156" rx="16" fill="#FFFFFF" stroke="#C4C6D0"/>
+    <text x="16" y="28" font-size="13" font-weight="700" fill="#191C20">EMPLOYEE</text>
+    <text x="16" y="46" font-size="11" fill="#44474E">surfaceContainerHigh + onSurface</text>
+    <g transform="translate(16, 60)">
+      <rect width="120" height="32" rx="8" fill="#E7E8EE"/>
+      <circle cx="22" cy="14" r="3.5" fill="none" stroke="#191C20" stroke-width="1.4"/>
+      <path d="M16 26 Q22 20 28 26" fill="none" stroke="#191C20" stroke-width="1.4"/>
+      <text x="38" y="22" font-size="12" font-weight="600" fill="#191C20">EMPLOYEE</text>
+    </g>
+    <text x="16" y="118" font-size="10" fill="#44474E">Hex container: #E7E8EE</text>
+    <text x="16" y="132" font-size="10" fill="#44474E">Hex onContainer: #191C20</text>
+    <text x="16" y="146" font-size="10" font-weight="600" fill="#37BF6E">Contrast 12.0:1 ✓ AAA</text>
+  </g>
+
+  <!-- ====== Sección 2: Chips de estado ====== -->
+  <text x="40" y="356" font-size="16" font-weight="600" fill="#191C20">2) Chips de estado — AssistChip M3</text>
+
+  <!-- ACTIVO -->
+  <g transform="translate(40, 380)">
+    <rect width="280" height="120" rx="16" fill="#FFFFFF" stroke="#C4C6D0"/>
+    <text x="16" y="28" font-size="13" font-weight="700" fill="#191C20">ACTIVO</text>
+    <text x="16" y="46" font-size="11" fill="#44474E">outlined + dot indicador</text>
+    <g transform="translate(16, 60)">
+      <rect width="84" height="32" rx="8" fill="none" stroke="#74777F" stroke-width="1"/>
+      <circle cx="16" cy="16" r="4" fill="#37BF6E"/>
+      <text x="28" y="22" font-size="12" font-weight="500" fill="#191C20">ACTIVO</text>
+    </g>
+    <text x="16" y="110" font-size="10" fill="#44474E">Outline + dot semántico (#37BF6E success)</text>
+  </g>
+
+  <!-- PENDIENTE -->
+  <g transform="translate(336, 380)">
+    <rect width="280" height="120" rx="16" fill="#FFFFFF" stroke="#C4C6D0"/>
+    <text x="16" y="28" font-size="13" font-weight="700" fill="#191C20">PENDIENTE</text>
+    <text x="16" y="46" font-size="11" fill="#44474E">tertiaryContainer + ic_team_status_pending</text>
+    <g transform="translate(16, 60)">
+      <rect width="108" height="32" rx="8" fill="#FAD8FD"/>
+      <circle cx="16" cy="16" r="6" fill="none" stroke="#28132E" stroke-width="1.4"/>
+      <line x1="16" y1="16" x2="16" y2="12" stroke="#28132E" stroke-width="1.4" stroke-linecap="round"/>
+      <line x1="16" y1="16" x2="19" y2="17.5" stroke="#28132E" stroke-width="1.4" stroke-linecap="round"/>
+      <text x="28" y="22" font-size="12" font-weight="600" fill="#28132E">PENDIENTE</text>
+    </g>
+    <text x="16" y="110" font-size="10" font-weight="600" fill="#37BF6E">Contrast 13.1:1 ✓ AAA</text>
+  </g>
+
+  <!-- REVOCADO -->
+  <g transform="translate(632, 380)">
+    <rect width="280" height="120" rx="16" fill="#FFFFFF" stroke="#C4C6D0"/>
+    <text x="16" y="28" font-size="13" font-weight="700" fill="#191C20">REVOCADO</text>
+    <text x="16" y="46" font-size="11" fill="#44474E">errorContainer + onErrorContainer</text>
+    <g transform="translate(16, 60)">
+      <rect width="116" height="32" rx="8" fill="#FFDAD6"/>
+      <line x1="9" y1="10" x2="17" y2="22" stroke="#410002" stroke-width="2" stroke-linecap="round"/>
+      <line x1="17" y1="10" x2="9" y2="22" stroke="#410002" stroke-width="2" stroke-linecap="round"/>
+      <text x="26" y="22" font-size="12" font-weight="600" fill="#410002">REVOCADO</text>
+    </g>
+    <text x="16" y="110" font-size="10" font-weight="600" fill="#37BF6E">Contrast 11.6:1 ✓ AAA</text>
+  </g>
+
+  <!-- ====== Sección 3: Variantes selected ====== -->
+  <text x="40" y="544" font-size="16" font-weight="600" fill="#191C20">3) Variantes en BottomSheet de invitación — selected vs unselected</text>
+
+  <g transform="translate(40, 568)">
+    <text x="0" y="20" font-size="12" font-weight="600" fill="#44474E">Unselected (default)</text>
+    <g transform="translate(0, 36)">
+      <rect width="200" height="76" rx="12" fill="#FFFFFF" stroke="#C4C6D0" stroke-width="1.5"/>
+      <text x="14" y="28" font-size="14" font-weight="600" fill="#191C20">Manager</text>
+      <text x="14" y="50" font-size="11" fill="#44474E">Administra equipo</text>
+      <text x="14" y="64" font-size="11" fill="#44474E">sin tocar facturación.</text>
+    </g>
+  </g>
+
+  <g transform="translate(264, 568)">
+    <text x="0" y="20" font-size="12" font-weight="600" fill="#44474E">Selected (acción primaria)</text>
+    <g transform="translate(0, 36)">
+      <rect width="200" height="76" rx="12" fill="#D6E3FF" stroke="#415F91" stroke-width="2.5"/>
+      <text x="14" y="28" font-size="14" font-weight="600" fill="#001B3E">Manager</text>
+      <circle cx="180" cy="22" r="10" fill="#415F91"/>
+      <path d="M176 22 L179 25 L185 19" stroke="#FFFFFF" stroke-width="2" fill="none" stroke-linecap="round"/>
+      <text x="14" y="50" font-size="11" fill="#001B3E">Administra equipo</text>
+      <text x="14" y="64" font-size="11" fill="#001B3E">sin tocar facturación.</text>
+    </g>
+  </g>
+
+  <g transform="translate(488, 568)">
+    <text x="0" y="20" font-size="12" font-weight="600" fill="#44474E">Disabled (anti-escalada — NO se renderiza)</text>
+    <g transform="translate(0, 36)" opacity="0.4">
+      <rect width="200" height="76" rx="12" fill="#FFFFFF" stroke="#C4C6D0" stroke-width="1.5" stroke-dasharray="4 4"/>
+      <text x="14" y="28" font-size="14" font-weight="600" fill="#191C20">Owner</text>
+      <text x="14" y="50" font-size="11" fill="#44474E">Control total del negocio</text>
+      <text x="14" y="64" font-size="11" fill="#44474E">y del equipo.</text>
+    </g>
+    <text x="0" y="128" font-size="10" font-weight="600" fill="#BA1A1A">Si el invitador es MANAGER, esta opción NO se filtra como disabled — se OMITE del set.</text>
+  </g>
+
+  <!-- ====== Sección 4: Mapeo ícono → drawable ====== -->
+  <text x="40" y="752" font-size="16" font-weight="600" fill="#191C20">4) Mapeo de drawables (ya commiteados por UX en commonMain/composeResources/drawable/)</text>
+
+  <g transform="translate(40, 776)">
+    <rect width="1200" height="160" rx="12" fill="#FFFFFF" stroke="#C4C6D0"/>
+    <text x="20" y="28" font-size="11" font-weight="700" fill="#191C20">Rol / estado</text>
+    <text x="220" y="28" font-size="11" font-weight="700" fill="#191C20">Drawable XML</text>
+    <text x="600" y="28" font-size="11" font-weight="700" fill="#191C20">Container token</text>
+    <text x="880" y="28" font-size="11" font-weight="700" fill="#191C20">Tint token</text>
+
+    <line x1="0" y1="40" x2="1200" y2="40" stroke="#C4C6D0"/>
+
+    <text x="20" y="60" font-size="11" fill="#191C20">OWNER</text>
+    <text x="220" y="60" font-size="11" font-family="monospace" fill="#44474E">ic_team_role_owner.xml</text>
+    <text x="600" y="60" font-size="11" font-family="monospace" fill="#44474E">primaryContainer</text>
+    <text x="880" y="60" font-size="11" font-family="monospace" fill="#44474E">onPrimaryContainer</text>
+
+    <text x="20" y="78" font-size="11" fill="#191C20">MANAGER</text>
+    <text x="220" y="78" font-size="11" font-family="monospace" fill="#44474E">ic_team_role_manager.xml</text>
+    <text x="600" y="78" font-size="11" font-family="monospace" fill="#44474E">tertiaryContainer</text>
+    <text x="880" y="78" font-size="11" font-family="monospace" fill="#44474E">onTertiaryContainer</text>
+
+    <text x="20" y="96" font-size="11" fill="#191C20">CASHIER</text>
+    <text x="220" y="96" font-size="11" font-family="monospace" fill="#44474E">ic_team_role_cashier.xml</text>
+    <text x="600" y="96" font-size="11" font-family="monospace" fill="#44474E">secondaryContainer</text>
+    <text x="880" y="96" font-size="11" font-family="monospace" fill="#44474E">onSecondaryContainer</text>
+
+    <text x="20" y="114" font-size="11" fill="#191C20">EMPLOYEE</text>
+    <text x="220" y="114" font-size="11" font-family="monospace" fill="#44474E">ic_team_role_employee.xml</text>
+    <text x="600" y="114" font-size="11" font-family="monospace" fill="#44474E">surfaceContainerHigh</text>
+    <text x="880" y="114" font-size="11" font-family="monospace" fill="#44474E">onSurface</text>
+
+    <text x="20" y="132" font-size="11" fill="#191C20">PENDIENTE</text>
+    <text x="220" y="132" font-size="11" font-family="monospace" fill="#44474E">ic_team_status_pending.xml</text>
+    <text x="600" y="132" font-size="11" font-family="monospace" fill="#44474E">tertiaryContainer</text>
+    <text x="880" y="132" font-size="11" font-family="monospace" fill="#44474E">onTertiaryContainer</text>
+
+    <text x="20" y="150" font-size="11" fill="#191C20">REVOCADO</text>
+    <text x="220" y="150" font-size="11" font-family="monospace" fill="#44474E">(close icon inline, sin drawable)</text>
+    <text x="600" y="150" font-size="11" font-family="monospace" fill="#44474E">errorContainer</text>
+    <text x="880" y="150" font-size="11" font-family="monospace" fill="#44474E">onErrorContainer</text>
+  </g>
+</svg>

--- a/.pipeline/assets/mockups/2820/README.md
+++ b/.pipeline/assets/mockups/2820/README.md
@@ -1,0 +1,71 @@
+# Mockups UX — #2820 (split de #2748)
+
+#2820 entrega **únicamente la pantalla "Equipo" + CRUD de empleados** del flavor
+`business`. El flujo de aceptación por deep link queda fuera de scope (lo entrega
+la historia hermana c.2.b — #2821).
+
+## Mockups en scope (referencia desde `.pipeline/assets/mockups/2748/`)
+
+Los siguientes mockups producidos para el padre #2748 aplican 1:1 a este split y
+**no se duplican acá** para evitar deriva entre fuentes:
+
+| Mockup | Path | Cubre criterio (issue #2820) |
+|---|---|---|
+| Lista completa de equipo | `.pipeline/assets/mockups/2748/01-team-list-full.svg` | E2 (listado), E5 (menú contextual), E7 (último OWNER sin opciones) |
+| Estado vacío con Murble | `.pipeline/assets/mockups/2748/02-team-empty-murble.svg` | E3 (empty state + CTA inline al BottomSheet) |
+| BottomSheet de invitación | `.pipeline/assets/mockups/2748/03-invite-bottomsheet.svg` | E4 (campo email + 4 chips de rol + CTA validado) |
+| Dialog destructivo de revocación | `.pipeline/assets/mockups/2748/06-revoke-confirmation-dialog.svg` | E6 (confirmación M3 destructiva) |
+| Sistema de chips de rol | `.pipeline/assets/mockups/2748/07-role-chips-system.svg` | E2 chip M3 + paleta WCAG AA + tokens |
+
+## Mockups fuera de scope (NO usar en #2820)
+
+Pertenecen a la historia hermana #2821 (c.2.b — flujo deep link de aceptación) y
+**no se renderizan ni navegan** en #2820:
+
+- `04-invitation-accept.svg` — pantalla de aceptación con deep link.
+- `05-invitation-error-states.svg` — errores de deep link (expirado, reutilizado,
+  email distinto).
+
+## Drawables entregados (paths finales del repo)
+
+Todos en `app/composeApp/src/commonMain/composeResources/drawable/` (commit
+`7387e424` mergeado a `feature/dashboard-v3-kanban-protagonist-2800`):
+
+- `ic_team_role_owner.xml` — corona (chip rol OWNER, container=primaryContainer).
+- `ic_team_role_manager.xml` — escudo+check (chip rol MANAGER, container=tertiaryContainer).
+- `ic_team_role_cashier.xml` — caja registradora (chip rol CASHIER, container=secondaryContainer).
+- `ic_team_role_employee.xml` — persona (chip rol EMPLOYEE, container=surfaceContainerHigh).
+- `ic_team_menu.xml` — entrada "Equipo" del home (24dp).
+- `ic_team_status_pending.xml` — reloj (badge estado PENDIENTE).
+- `team_murble_friendly.xml` — companion blob 200dp (estado EMPTY, tinte=tertiary).
+
+> `ic_invitation_envelope.xml` también está commiteado pero su uso pertenece a
+> #2821 (hero icon de InvitationScreen), no a #2820.
+
+## Decisiones bloqueantes (heredadas del padre #2748)
+
+1. **Visibilidad — no deshabilitado**: las opciones del menú contextual `⋮` que
+   un rol no puede ejecutar **no se renderizan**. No aparecen en gris.
+2. **Email enmascarado**: snackbar de éxito + dialog destructivo + mensajes de
+   error muestran `j***@***.com`. El email completo solo aparece en el ítem
+   propio del listado.
+3. **Token nunca en pantalla ni en logs**: el cliente no debe loguear ni mostrar
+   el token de invitación que devuelva el backend.
+4. **Bloqueo del último OWNER**: la opción "Revocar" no se renderiza en el menú
+   del único OWNER. El backend (#2440) es autoritativo y rechaza con código de
+   error mapeable a copy.
+5. **Foco inicial en "Cancelar"** del dialog destructivo (Material3 best
+   practice — el foco no apunta a la acción peligrosa).
+6. **CTA inline en estado vacío**: además del FAB, el empty state tiene un
+   botón inline que abre el BottomSheet de invitación directamente.
+
+## Tema y accesibilidad
+
+- Cero colores ad-hoc — todos los chips usan tokens del tema en `ui/th/Color.kt`
+  (`primaryContainer`, `secondaryContainer`, `tertiaryContainer`,
+  `surfaceContainerHigh`).
+- Contraste verificado ≥ 12:1 (AAA, supera AA por amplio margen).
+- Touch targets ≥ 48dp en FAB, menú contextual, chips, CTA del dialog.
+- `contentDescription` obligatorio en avatar, FAB, menú `⋮`, dialog destructivo.
+- Estados (PENDIENTE / ACTIVO / REVOCADO) **no dependen solo del color** — siempre
+  combinan icono + chip + texto.

--- a/.pipeline/dashboard.js
+++ b/.pipeline/dashboard.js
@@ -37,6 +37,11 @@ try { retryingState = require('./retrying-state'); } catch { /* opcional */ }
 let v3Aggregator = null;
 try { v3Aggregator = require('./metrics/aggregator'); } catch { /* V3 no disponible */ }
 
+// Multi-bot accounting (issue #2854). Consolida snapshots de varios bots
+// que comparten cuenta Anthropic. Best-effort.
+let multiBotAggregator = null;
+try { multiBotAggregator = require('./metrics/multi-bot-aggregator'); } catch { /* opcional */ }
+
 // Recomendaciones generadas por agentes (issue #2653). Best-effort require.
 let recommendationsLib = null;
 try { recommendationsLib = require('./lib/recommendations'); } catch { /* opcional */ }
@@ -7708,8 +7713,9 @@ const server = http.createServer((req, res) => {
 
   // ===========================================================================
   // V3 — Endpoints de métricas extendidas (issue #2477)
+  // El check excluye /metrics/multi-bot (handler propio en #2854 más abajo).
   // ===========================================================================
-  if (req.url.startsWith('/metrics/') || req.url === '/consumo' || req.url === '/metrics-v3' || req.url === '/metrics-v3/') {
+  if ((req.url.startsWith('/metrics/') && !req.url.startsWith('/metrics/multi-bot')) || req.url === '/consumo' || req.url === '/metrics-v3' || req.url === '/metrics-v3/') {
     if (!v3Aggregator) {
       res.writeHead(503, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ error: 'V3 aggregator no disponible. Verificar .pipeline/metrics/aggregator.js' }));
@@ -7746,6 +7752,8 @@ const server = http.createServer((req, res) => {
       if (u.pathname === '/metrics/totals')  return respond(Object.assign({}, baseMeta, { totals: snap.totals || {} }));
       // #2488 — nuevos endpoints
       if (u.pathname === '/metrics/projections') return respond(Object.assign({}, baseMeta, { projections: snap.projections || {} }));
+      // #2854 — Burn rate y budget gap (proyección semanal en USD)
+      if (u.pathname === '/metrics/burn') return respond(Object.assign({}, baseMeta, { burn: (snap.projections && snap.projections.burn) || {} }));
       if (u.pathname === '/metrics/llm-vs-deterministic') return respond(Object.assign({}, baseMeta, { llm_vs_deterministic: snap.llm_vs_deterministic || [] }));
       if (u.pathname === '/metrics/daily') return respond(Object.assign({}, baseMeta, { daily: snap.daily || [] }));
 
@@ -7761,8 +7769,53 @@ const server = http.createServer((req, res) => {
       }
 
       res.writeHead(404, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ error: 'endpoint no reconocido', valid: ['/metrics/agents', '/metrics/phases', '/metrics/issues', '/metrics/issues/:n', '/metrics/tts', '/metrics/totals', '/metrics/snapshot', '/metrics/projections', '/metrics/llm-vs-deterministic', '/metrics/daily', '/consumo', '/metrics-v3'] }));
+      res.end(JSON.stringify({ error: 'endpoint no reconocido', valid: ['/metrics/agents', '/metrics/phases', '/metrics/issues', '/metrics/issues/:n', '/metrics/tts', '/metrics/totals', '/metrics/snapshot', '/metrics/projections', '/metrics/burn', '/metrics/llm-vs-deterministic', '/metrics/daily', '/metrics/multi-bot/snapshot', '/metrics/multi-bot/by-bot', '/metrics/multi-bot/by-skill', '/metrics/multi-bot/by-issue', '/metrics/multi-bot/totals', '/consumo', '/metrics-v3'] }));
     }).catch(fail);
+    return;
+  }
+
+  // ===========================================================================
+  // #2854 — Multi-bot accounting endpoints
+  // Consolida snapshots de Intrale + Alina + libro + club + Néstor.
+  // ===========================================================================
+  if (req.url.startsWith('/metrics/multi-bot')) {
+    if (!multiBotAggregator) {
+      res.writeHead(503, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'multi-bot aggregator no disponible' }));
+      return;
+    }
+    try {
+      const snap = multiBotAggregator.consolidate();
+      const u = new URL(req.url, 'http://localhost');
+      const pathname = u.pathname;
+      const respond = (data) => {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(data, null, 2));
+      };
+      const baseMeta = { generated_at: snap.generated_at, bots_available: snap.bots_available };
+      if (pathname === '/metrics/multi-bot' || pathname === '/metrics/multi-bot/' || pathname === '/metrics/multi-bot/snapshot') {
+        return respond(snap);
+      }
+      if (pathname === '/metrics/multi-bot/by-bot') {
+        return respond(Object.assign({}, baseMeta, { by_bot: snap.by_bot }));
+      }
+      if (pathname === '/metrics/multi-bot/by-skill') {
+        return respond(Object.assign({}, baseMeta, { by_skill: snap.by_skill }));
+      }
+      if (pathname === '/metrics/multi-bot/by-issue') {
+        const botFilter = u.searchParams.get('bot');
+        const list = botFilter ? snap.by_issue.filter(i => i.bot_id === botFilter) : snap.by_issue;
+        return respond(Object.assign({}, baseMeta, { by_issue: list, filtered_by_bot: botFilter || null }));
+      }
+      if (pathname === '/metrics/multi-bot/totals') {
+        return respond(Object.assign({}, baseMeta, { totals: snap.totals, bots_unavailable: snap.bots_unavailable }));
+      }
+      res.writeHead(404, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'endpoint multi-bot no reconocido', valid: ['/metrics/multi-bot/snapshot', '/metrics/multi-bot/by-bot', '/metrics/multi-bot/by-skill', '/metrics/multi-bot/by-issue?bot=<id>', '/metrics/multi-bot/totals'] }));
+    } catch (e) {
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: e.message || String(e) }));
+    }
     return;
   }
 

--- a/.pipeline/lib/__tests__/weekly-quota-calibration.test.js
+++ b/.pipeline/lib/__tests__/weekly-quota-calibration.test.js
@@ -1,0 +1,223 @@
+// Tests de calibración multi-semana de weekly-quota (#2854).
+// Valida:
+//   - Mediana ponderada por recencia (vs EMA legacy)
+//   - Histórico cap a 50 (no 20)
+//   - weekly_profiles[] se snapshotea al cruzar reset semanal
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const TMP_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'v3-quota-calib-'));
+fs.mkdirSync(path.join(TMP_DIR, 'metrics'), { recursive: true });
+const METRICS_DIR = path.join(TMP_DIR, 'metrics');
+
+const wq = require('../weekly-quota');
+
+const DAY_MS = 24 * 3600 * 1000;
+
+function freshState() {
+    const file = path.join(METRICS_DIR, 'weekly-quota.json');
+    try { fs.unlinkSync(file); } catch { /* noop */ }
+}
+
+test('weightedRecencyMedian: muestra única devuelve ese valor', () => {
+    const now = Date.now();
+    const samples = [{ at: new Date(now).toISOString(), value: 5.2 }];
+    assert.equal(wq.weightedRecencyMedian(samples, now), 5.2);
+});
+
+test('weightedRecencyMedian: dos muestras devuelve promedio simple', () => {
+    const now = Date.now();
+    const samples = [
+        { at: new Date(now - DAY_MS).toISOString(), value: 4.0 },
+        { at: new Date(now).toISOString(), value: 6.0 },
+    ];
+    assert.equal(wq.weightedRecencyMedian(samples, now), 5.0);
+});
+
+test('weightedRecencyMedian: con outlier extremo, mediana lo ignora', () => {
+    const now = Date.now();
+    const samples = [
+        { at: new Date(now - 1 * DAY_MS).toISOString(), value: 5.0 },
+        { at: new Date(now - 2 * DAY_MS).toISOString(), value: 5.5 },
+        { at: new Date(now - 3 * DAY_MS).toISOString(), value: 6.0 },
+        { at: new Date(now - 4 * DAY_MS).toISOString(), value: 5.2 },
+        { at: new Date(now - 5 * DAY_MS).toISOString(), value: 50.0 }, // outlier
+    ];
+    const result = wq.weightedRecencyMedian(samples, now);
+    // Una EMA o promedio se iría a ~14, la mediana ponderada se queda cerca de 5-6
+    assert.ok(result >= 5.0 && result <= 6.5,
+        `mediana ponderada debe ignorar outlier (resultado=${result})`);
+});
+
+test('weightedRecencyMedian: descarta muestras viejas (>28d)', () => {
+    const now = Date.now();
+    const samples = [
+        { at: new Date(now - 60 * DAY_MS).toISOString(), value: 100.0 }, // vieja, descartar
+        { at: new Date(now - 1 * DAY_MS).toISOString(), value: 5.0 },
+    ];
+    assert.equal(wq.weightedRecencyMedian(samples, now), 5.0);
+});
+
+test('weightedRecencyMedian: muestras frescas pesan más por half-life 14d', () => {
+    const now = Date.now();
+    // Dos grupos: 3 muestras viejas (~21d) en valor 10, 3 frescas (~1d) en valor 4
+    // El factor 0.5^(21/14) ≈ 0.35, el factor 0.5^(1/14) ≈ 0.95
+    // Pesos totales: viejas ~1.05, frescas ~2.85 → mediana ponderada cae sobre las frescas
+    const samples = [
+        { at: new Date(now - 21 * DAY_MS).toISOString(), value: 10.0 },
+        { at: new Date(now - 20 * DAY_MS).toISOString(), value: 10.0 },
+        { at: new Date(now - 19 * DAY_MS).toISOString(), value: 10.0 },
+        { at: new Date(now - 1 * DAY_MS).toISOString(), value: 4.0 },
+        { at: new Date(now - 1 * DAY_MS).toISOString(), value: 4.0 },
+        { at: new Date(now - 2 * DAY_MS).toISOString(), value: 4.0 },
+    ];
+    const result = wq.weightedRecencyMedian(samples, now);
+    assert.ok(result >= 4.0 && result <= 5.0,
+        `recency bias debe favorecer las frescas (resultado=${result})`);
+});
+
+test('saveCalibration: histórico crece hasta CALIBRATION_HISTORY_MAX (50)', () => {
+    freshState();
+    for (let i = 0; i < 60; i++) {
+        wq.saveCalibration(METRICS_DIR, {
+            realWeeklyPct: 30,
+            realSessionPct: 50,
+            pipelineWeeklyPct: 10,
+            pipelineSessionPct: 25,
+        });
+    }
+    const state = wq.loadState(METRICS_DIR);
+    assert.equal(state.calibrations.length, 50,
+        `histórico debe estar capeado a 50, no a 20 (legacy)`);
+    assert.ok(wq.CALIBRATION_HISTORY_MAX === 50);
+});
+
+test('saveCalibration: usa mediana ponderada (method registrado)', () => {
+    freshState();
+    wq.saveCalibration(METRICS_DIR, {
+        realWeeklyPct: 30,
+        realSessionPct: 50,
+        pipelineWeeklyPct: 10,
+        pipelineSessionPct: 25,
+    });
+    const state = wq.loadState(METRICS_DIR);
+    assert.equal(state.calibration.method, 'weighted_recency_median_28d');
+    assert.equal(state.calibration.half_life_days, 14);
+    assert.ok(state.calibration.fresh_sample_count >= 1);
+    // Sin método EMA legacy en el output
+    assert.equal(state.calibration.ema_alpha, undefined);
+});
+
+test('saveCalibration: outlier fuerte no arrastra el factor (robustez)', () => {
+    freshState();
+    // Cargar 5 calibraciones razonables en factor ~5.0
+    for (let i = 0; i < 5; i++) {
+        wq.saveCalibration(METRICS_DIR, {
+            realWeeklyPct: 50,
+            realSessionPct: 50,
+            pipelineWeeklyPct: 10,    // → factor 5.0
+            pipelineSessionPct: 25,   // → factor 2.0
+        });
+    }
+    const stateBeforeOutlier = wq.loadState(METRICS_DIR);
+    const factorBefore = stateBeforeOutlier.calibration.weekly_factor;
+    assert.ok(factorBefore >= 4.5 && factorBefore <= 5.5,
+        `factor estable en ~5.0 antes del outlier (${factorBefore})`);
+
+    // Cargar UN outlier extremo (factor 50)
+    wq.saveCalibration(METRICS_DIR, {
+        realWeeklyPct: 100,
+        realSessionPct: 50,
+        pipelineWeeklyPct: 2,   // → factor 50
+        pipelineSessionPct: 25,
+    });
+    const stateAfter = wq.loadState(METRICS_DIR);
+    const factorAfter = stateAfter.calibration.weekly_factor;
+    // Mediana resiste el outlier; con EMA legacy hubiera saltado a >15.
+    assert.ok(factorAfter < 10,
+        `mediana resiste outlier — factor debe quedar <10 (resultado: ${factorAfter})`);
+});
+
+test('weekly_profiles: snapshot de semana anterior cuando se calibra en semana nueva', () => {
+    freshState();
+    const eightDaysAgo = Date.now() - 8 * DAY_MS;
+    // Manualmente plantar un state con calibración de hace 8 días (semana anterior)
+    const state = wq.loadState(METRICS_DIR);
+    state.calibration = {
+        at: new Date(eightDaysAgo).toISOString(),
+        weekly_factor: 5.0,
+        session_factor: 2.0,
+    };
+    state.calibrations = [{
+        at: new Date(eightDaysAgo).toISOString(),
+        real_weekly_pct: 40,
+        real_session_pct: 50,
+        pipeline_weekly_pct_at: 8,
+        pipeline_session_pct_at: 25,
+        weekly_factor_obs: 5.0,
+        session_factor_obs: 2.0,
+        session_resets_at: null,
+        weekly_resets_at: null,
+    }];
+    wq.saveState(METRICS_DIR, state);
+
+    // Calibrar HOY → debería snapshotear la semana anterior antes de actualizar
+    wq.saveCalibration(METRICS_DIR, {
+        realWeeklyPct: 20,
+        realSessionPct: 30,
+        pipelineWeeklyPct: 5,
+        pipelineSessionPct: 15,
+    });
+    const finalState = wq.loadState(METRICS_DIR);
+    assert.ok(Array.isArray(finalState.weekly_profiles));
+    assert.ok(finalState.weekly_profiles.length >= 1,
+        `debe haber al menos 1 perfil de semana cerrada`);
+    const profile = finalState.weekly_profiles[0];
+    assert.equal(profile.final_factor_weekly, 5.0,
+        `el perfil debe preservar el factor de la semana cerrada`);
+    assert.ok(profile.week_start_iso);
+    assert.ok(profile.week_end_iso);
+});
+
+test('weekly_profiles: idempotencia — calibrar 2 veces en la misma semana no duplica perfil', () => {
+    freshState();
+    const eightDaysAgo = Date.now() - 8 * DAY_MS;
+    const state = wq.loadState(METRICS_DIR);
+    state.calibration = {
+        at: new Date(eightDaysAgo).toISOString(),
+        weekly_factor: 4.5,
+        session_factor: 1.5,
+    };
+    state.calibrations = [{
+        at: new Date(eightDaysAgo).toISOString(),
+        real_weekly_pct: 30,
+        real_session_pct: 40,
+        pipeline_weekly_pct_at: 7,
+        pipeline_session_pct_at: 27,
+        weekly_factor_obs: 4.5,
+        session_factor_obs: 1.5,
+        session_resets_at: null,
+        weekly_resets_at: null,
+    }];
+    wq.saveState(METRICS_DIR, state);
+
+    // Dos calibraciones consecutivas en la misma semana actual
+    wq.saveCalibration(METRICS_DIR, {
+        realWeeklyPct: 20, realSessionPct: 30,
+        pipelineWeeklyPct: 5, pipelineSessionPct: 15,
+    });
+    wq.saveCalibration(METRICS_DIR, {
+        realWeeklyPct: 25, realSessionPct: 35,
+        pipelineWeeklyPct: 5, pipelineSessionPct: 17,
+    });
+
+    const finalState = wq.loadState(METRICS_DIR);
+    // Sólo debe haberse creado UN perfil para la semana anterior
+    assert.equal(finalState.weekly_profiles.length, 1,
+        `idempotente: solo 1 perfil aunque se calibre varias veces`);
+});

--- a/.pipeline/lib/weekly-quota.js
+++ b/.pipeline/lib/weekly-quota.js
@@ -41,6 +41,16 @@ const ADJUSTMENT_BUFFER_HOURS = 5;
 const WEEK_MS = 7 * 24 * 3600 * 1000;
 const DAY_MS = 24 * 3600 * 1000;
 const HOUR_MS = 3600 * 1000;
+// #2854 — Aprendizaje multi-semana. Histórico extendido a 50 muestras
+// (~4-8 semanas). El factor se refina con mediana ponderada por recencia
+// sobre las últimas 28 días. Half-life del peso = 14 días.
+const CALIBRATION_HISTORY_MAX = 50;
+const CALIBRATION_FRESH_WINDOW_MS = 28 * DAY_MS;
+const CALIBRATION_HALF_LIFE_DAYS = 14;
+// `weekly_profiles[]` persiste el factor "estable" de cada semana cerrada
+// para tener referencia comparativa semana a semana. Hasta 12 semanas
+// (~3 meses) — útil para detectar tendencias estacionales.
+const WEEKLY_PROFILES_MAX = 12;
 // Anthropic resetea la cuota semanal **domingo 21:00 hora local del usuario**
 // (constatado en claude.ai/settings/usage). En Argentina = UTC-3 fijo (sin DST).
 // Configurable vía env por si el operador está en otra TZ.
@@ -84,6 +94,7 @@ function loadState(metricsDir) {
         // Defaults para campos nuevos en estados viejos
         if (!parsed.calibration) parsed.calibration = null;
         if (!parsed.calibrations) parsed.calibrations = [];
+        if (!parsed.weekly_profiles) parsed.weekly_profiles = [];
         return parsed;
     } catch {
         return {
@@ -94,28 +105,77 @@ function loadState(metricsDir) {
             adjustments: [],
             calibration: null,
             calibrations: [],
+            weekly_profiles: [],
         };
     }
+}
+
+/**
+ * Mediana ponderada por recencia. Cada observación tiene un peso
+ * exponencialmente decreciente con la edad (half-life 14 días).
+ *
+ *   peso(age_days) = 0.5 ^ (age_days / 14)
+ *
+ * Ventajas vs EMA simple:
+ *  - **Robusta a outliers**: la mediana ignora picos extremos. Cuando Leo
+ *    carga varios % seguidos para experimentar, los outliers no arrastran
+ *    el factor.
+ *  - **Multi-semana**: usa hasta 28 días de historial en lugar de chatarse
+ *    a una EMA con peso fijo.
+ *  - **Tendencia**: muestras más recientes pesan más (recency bias suave).
+ *
+ * Si hay menos de 3 muestras frescas, fallback al promedio simple.
+ *
+ * @param {Array<{at:string, value:number}>} samples - observaciones con timestamp
+ * @param {number} now - timestamp actual (ms)
+ * @returns {number} factor calibrado
+ */
+function weightedRecencyMedian(samples, now) {
+    const fresh = (samples || []).filter(s => {
+        const age = now - new Date(s.at).getTime();
+        return age >= 0 && age <= CALIBRATION_FRESH_WINDOW_MS && Number.isFinite(s.value) && s.value > 0;
+    });
+    if (fresh.length === 0) return null;
+    if (fresh.length < 3) {
+        // Promedio simple para n<3 — la mediana no es estable con pocas muestras
+        const sum = fresh.reduce((s, x) => s + x.value, 0);
+        return sum / fresh.length;
+    }
+    // Calcular peso por edad
+    const weighted = fresh.map(s => {
+        const ageDays = (now - new Date(s.at).getTime()) / DAY_MS;
+        const w = Math.pow(0.5, ageDays / CALIBRATION_HALF_LIFE_DAYS);
+        return { value: s.value, weight: w };
+    });
+    // Ordenar por valor y encontrar el punto donde la suma de pesos cruza el 50%
+    weighted.sort((a, b) => a.value - b.value);
+    const totalWeight = weighted.reduce((s, x) => s + x.weight, 0);
+    let cumulative = 0;
+    for (const item of weighted) {
+        cumulative += item.weight;
+        if (cumulative >= totalWeight / 2) return item.value;
+    }
+    return weighted[weighted.length - 1].value;
 }
 
 const round2 = (n) => Math.round(n * 100) / 100;
 
 /**
- * Persiste una calibración manual con APRENDIZAJE INCREMENTAL:
+ * Persiste una calibración manual con APRENDIZAJE MULTI-SEMANA (#2854).
  *
- *   1. Cada calibración se acumula en `calibrations[]` (historial — últimas 20).
- *   2. Los factores semanal/sesión se calculan por **EMA** (Exponential Moving
- *      Average) en lugar de reemplazo total: `nuevo = α·obs + (1-α)·viejo`.
- *      α se ajusta según cantidad de muestras (más muestras → α menor → más
- *      conservador, menos sensible a outliers individuales).
- *   3. Si el operador reporta `sessionResetsInMinutes` o `weeklyResetsInMinutes`,
- *      persistimos esos timestamps absolutos. El cliente los usa para mostrar
- *      cuenta regresiva precisa, y el server detecta drift de TZ del weekly
- *      reset (e.g. si reportado != calculado por nuestra fórmula, ajustamos
- *      el offset persistido).
- *   4. `weighted_pipeline_pct_at` registra el pipeline pct al momento de
- *      calibrar — sirve para recalcular factor cuando el pipeline cambia
- *      mucho entre calibraciones (no implementado aún, queda como hook).
+ *   1. Histórico extendido a 50 calibraciones (~4-8 semanas).
+ *   2. El factor se refina con **mediana ponderada por recencia** sobre las
+ *      últimas 28 días (half-life 14d). Razón: la mediana es robusta a
+ *      outliers (Leo a veces carga varios % seguidos para experimentar),
+ *      y considerar 4 semanas permite que la calibración mejore con cada
+ *      semana en lugar de chatarse a una EMA simple.
+ *   3. Si la calibración cruza un reset semanal vs la calibración previa,
+ *      snapshoteamos el factor "estable" de la semana cerrada en
+ *      `weekly_profiles[]` (max 12 entradas). Esto preserva el factor
+ *      característico de cada semana para análisis comparativo.
+ *   4. Persiste `session_resets_at` / `weekly_resets_at` absolutos cuando
+ *      el operador los reporta — el cliente muestra cuenta regresiva
+ *      precisa y el server detecta drift de TZ del weekly reset.
  *
  * @param {string} metricsDir
  * @param {{realWeeklyPct, realSessionPct, pipelineWeeklyPct, pipelineSessionPct, sessionResetsInMinutes?, weeklyResetsInMinutes?}} obs
@@ -130,6 +190,9 @@ function saveCalibration(metricsDir, obs) {
     const newSessionFactor = pipelineSession > 0 ? realSession / pipelineSession : 1;
 
     const now = Date.now();
+    // Snapshot de la semana cerrada: si la calibración previa pertenecía a
+    // una semana anterior, congelar el factor final como perfil de esa semana.
+    maybeSnapshotPreviousWeek(state, now);
     // Aceptar tanto "minutos al reset" (legacy) como "timestamp ISO absoluto"
     // (preferido — más natural cuando el operador pega una hora del datetime
     // picker o de claude.ai). Si vienen ambos, gana el ISO absoluto.
@@ -171,17 +234,23 @@ function saveCalibration(metricsDir, obs) {
         weekly_resets_at: weeklyResetsAt,
     };
     state.calibrations.push(entry);
-    if (state.calibrations.length > 20) state.calibrations = state.calibrations.slice(-20);
+    if (state.calibrations.length > CALIBRATION_HISTORY_MAX) {
+        state.calibrations = state.calibrations.slice(-CALIBRATION_HISTORY_MAX);
+    }
 
-    // EMA: α decrece con número de muestras. Primera muestra: α=1 (exact).
-    // De ahí en adelante: α = max(0.2, 1 / sqrt(n)) — equilibra respuesta
-    // a cambios reales con resistencia a ruido.
-    const n = state.calibrations.length;
-    const alpha = n === 1 ? 1.0 : Math.max(0.2, 1 / Math.sqrt(n));
-    const prevWeeklyFactor = state.calibration ? state.calibration.weekly_factor : newWeeklyFactor;
-    const prevSessionFactor = state.calibration ? state.calibration.session_factor : newSessionFactor;
-    const smoothWeekly = alpha * newWeeklyFactor + (1 - alpha) * prevWeeklyFactor;
-    const smoothSession = alpha * newSessionFactor + (1 - alpha) * prevSessionFactor;
+    // Mediana ponderada por recencia sobre los obs frescos (≤28d).
+    // Si hay muy pocas muestras (<3 frescas), `weightedRecencyMedian` cae
+    // a promedio simple — y si tampoco hay frescas, usamos el obs actual.
+    const weeklySamples = state.calibrations.map(c => ({ at: c.at, value: Number(c.weekly_factor_obs) }));
+    const sessionSamples = state.calibrations.map(c => ({ at: c.at, value: Number(c.session_factor_obs) }));
+    const refinedWeekly = weightedRecencyMedian(weeklySamples, now);
+    const refinedSession = weightedRecencyMedian(sessionSamples, now);
+    const finalWeekly = Number.isFinite(refinedWeekly) && refinedWeekly > 0 ? refinedWeekly : newWeeklyFactor;
+    const finalSession = Number.isFinite(refinedSession) && refinedSession > 0 ? refinedSession : newSessionFactor;
+    // Conteo de muestras frescas (las que efectivamente entraron al cálculo).
+    const freshCount = state.calibrations.filter(c =>
+        (now - new Date(c.at).getTime()) <= CALIBRATION_FRESH_WINDOW_MS
+    ).length;
 
     state.calibration = {
         at: new Date(now).toISOString(),
@@ -189,18 +258,63 @@ function saveCalibration(metricsDir, obs) {
         real_session_pct: realSession,
         pipeline_weekly_pct_at: pipelineWeekly,
         pipeline_session_pct_at: pipelineSession,
-        weekly_factor: round2(smoothWeekly),
-        session_factor: round2(smoothSession),
+        weekly_factor: round2(finalWeekly),
+        session_factor: round2(finalSession),
         weekly_factor_obs: round2(newWeeklyFactor),
         session_factor_obs: round2(newSessionFactor),
-        sample_count: n,
-        ema_alpha: round2(alpha),
+        sample_count: state.calibrations.length,
+        fresh_sample_count: freshCount,
+        method: 'weighted_recency_median_28d',
+        half_life_days: CALIBRATION_HALF_LIFE_DAYS,
         session_resets_at: sessionResetsAt,
         weekly_resets_at: weeklyResetsAt,
     };
     state.weekly_reset_drift_min = weeklyResetDriftMin;
     saveState(metricsDir, state);
     return state.calibration;
+}
+
+/**
+ * Si la calibración previa (state.calibration) pertenece a una semana
+ * anterior al `now`, snapshotea el perfil de esa semana en `weekly_profiles[]`.
+ * Idempotente: si ya hay perfil para esa misma semana, no duplica.
+ *
+ * Estructura del perfil:
+ *  - `week_start_iso`, `week_end_iso`: límites de la semana cerrada
+ *  - `final_factor_weekly`, `final_factor_session`: último factor refinado
+ *  - `samples_in_week`: cantidad de calibraciones cargadas en esa semana
+ *  - `max_real_weekly_pct`: pico de %real reportado en la semana (para
+ *    detectar semanas más intensas)
+ */
+function maybeSnapshotPreviousWeek(state, now) {
+    if (!state.calibration || !state.calibration.at) return;
+    const prevAt = new Date(state.calibration.at).getTime();
+    const prevResetEnd = getNextWeeklyResetMs(prevAt);
+    // Si el siguiente reset semanal de la calib previa ya pasó vs `now`,
+    // entonces la calibración previa pertenece a una semana cerrada.
+    if (prevResetEnd > now) return;
+    const weekStart = getLastWeeklyResetMs(prevAt);
+    const weekStartIso = new Date(weekStart).toISOString();
+    if (!state.weekly_profiles) state.weekly_profiles = [];
+    if (state.weekly_profiles.some(p => p.week_start_iso === weekStartIso)) return;
+    // Filtrar calibraciones que cayeron dentro de esa semana
+    const inWeek = (state.calibrations || []).filter(c => {
+        const t = new Date(c.at).getTime();
+        return t >= weekStart && t < prevResetEnd;
+    });
+    const maxRealWeekly = inWeek.reduce((m, c) => Math.max(m, Number(c.real_weekly_pct) || 0), 0);
+    state.weekly_profiles.push({
+        week_start_iso: weekStartIso,
+        week_end_iso: new Date(prevResetEnd).toISOString(),
+        final_factor_weekly: state.calibration.weekly_factor,
+        final_factor_session: state.calibration.session_factor,
+        samples_in_week: inWeek.length,
+        max_real_weekly_pct: maxRealWeekly,
+        snapshotted_at: new Date(now).toISOString(),
+    });
+    if (state.weekly_profiles.length > WEEKLY_PROFILES_MAX) {
+        state.weekly_profiles = state.weekly_profiles.slice(-WEEKLY_PROFILES_MAX);
+    }
 }
 
 function clearCalibration(metricsDir) {
@@ -433,9 +547,12 @@ function computeQuota(metricsDir, activityLogPath, opts = {}) {
             hoursRemaining: Math.round(Math.max(0, DEFAULT_SESSION_LIMIT_HOURS - sessionUsage.hoursUsed) * 100) / 100,
             status: sessionStatus,
         },
-        // Calibración (si existe) + historial reciente (últimas 20)
+        // Calibración (si existe) + historial reciente (últimas 50, multi-semana)
         calibration: state.calibration,
-        calibrations: (state.calibrations || []).slice(-20),
+        calibrations: (state.calibrations || []).slice(-CALIBRATION_HISTORY_MAX),
+        // Perfiles de semanas cerradas (factor estable de cada semana, hasta 12)
+        // Permite a Leo / al dashboard comparar tendencia semana a semana.
+        weeklyProfiles: state.weekly_profiles || [],
         weeklyResetDriftMin: state.weekly_reset_drift_min || 0,
         // Stale: la calibración pierde precisión con el tiempo. Marcamos
         // stale > 7d para sugerir recalibrar.
@@ -461,6 +578,11 @@ module.exports = {
     saveState,
     saveCalibration,
     clearCalibration,
+    weightedRecencyMedian,
     DEFAULT_LIMIT_HOURS,
     DEFAULT_SESSION_LIMIT_HOURS,
+    CALIBRATION_HISTORY_MAX,
+    CALIBRATION_FRESH_WINDOW_MS,
+    CALIBRATION_HALF_LIFE_DAYS,
+    WEEKLY_PROFILES_MAX,
 };

--- a/.pipeline/metrics/aggregator.js
+++ b/.pipeline/metrics/aggregator.js
@@ -22,6 +22,12 @@ const METRICS_DIR = path.join(REPO_ROOT, '.pipeline', 'metrics');
 const SNAPSHOT_FILE = path.join(METRICS_DIR, 'snapshot.json');
 const DEFAULT_REFRESH_MS = 60000;
 
+// #2854 — Identificador del bot dueño de este snapshot. Permite consolidar
+// el costo de varios bots que comparten cuenta Anthropic (Intrale, Alina,
+// libro, club, Néstor) sin perder discriminación. Override por env.
+const BOT_ID = process.env.INTRALE_BOT_ID || 'intrale';
+const BOT_LABEL = process.env.INTRALE_BOT_LABEL || 'Intrale';
+
 // Normaliza el modelo a "deterministic" | "llm" para comparativa (#2488)
 function classifyExecutionMode(model) {
     const m = String(model || '').toLowerCase().trim();
@@ -284,6 +290,8 @@ async function buildSnapshot(options) {
 
     return {
         generated_at: new Date().toISOString(),
+        bot_id: BOT_ID,
+        bot_label: BOT_LABEL,
         window: options.window || 'all',
         cutoff_ts: cutoffMs ? new Date(cutoffMs).toISOString() : null,
         totals: {
@@ -313,6 +321,8 @@ async function buildSnapshot(options) {
 function emitEmptySnapshot(options) {
     return {
         generated_at: new Date().toISOString(),
+        bot_id: BOT_ID,
+        bot_label: BOT_LABEL,
         window: (options && options.window) || 'all',
         cutoff_ts: null,
         totals: emptyBucket(),

--- a/.pipeline/metrics/multi-bot-aggregator.js
+++ b/.pipeline/metrics/multi-bot-aggregator.js
@@ -1,0 +1,270 @@
+#!/usr/bin/env node
+// Multi-Bot Aggregator (#2854) — consolida snapshots de varios bots que
+// comparten la misma cuenta Anthropic en un único `multi-bot-snapshot.json`.
+//
+// Funcionamiento:
+//   1. Lee la lista de bots de `metrics/multi-bot-config.json`.
+//   2. Por cada bot habilitado intenta abrir su `snapshot_path`.
+//      - Si no existe / está corrupto → lo registra en `bots_unavailable`
+//        sin abortar (fail-open).
+//   3. Suma totales globales y mantiene un breakdown por bot, por
+//      bot×skill (agente), por bot×issue.
+//   4. Drill-down completo: bot → agente → issue (re-expone los issues
+//      de cada bot con el bot_id pegado para filtrar en UI).
+//
+// Output: `metrics/multi-bot-snapshot.json` con:
+//   {
+//     generated_at, window, bots_count, bots_available, bots_unavailable[],
+//     totals: { cost_usd, sessions, tokens_in, tokens_out, cache_read,
+//               cache_write, tts_cost_usd },
+//     by_bot: [{ bot_id, label, totals, agents[], issues[] }],
+//     by_skill: [{ skill, total_cost_usd, by_bot: [{bot_id, cost_usd}] }],
+//     by_issue: [{ issue, bot_id, cost_usd, by_skill[] }],
+//   }
+//
+// Modos:
+//   node multi-bot-aggregator.js               → daemon, refresh cada 60s
+//   node multi-bot-aggregator.js --once        → consolida y exit
+//
+// El consumidor principal es el dashboard `/metrics/multi-bot/*`.
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const PIPELINE_DIR = path.join(REPO_ROOT, '.pipeline');
+const METRICS_DIR = path.join(PIPELINE_DIR, 'metrics');
+const CONFIG_FILE = path.join(METRICS_DIR, 'multi-bot-config.json');
+const OUTPUT_FILE = path.join(METRICS_DIR, 'multi-bot-snapshot.json');
+const DEFAULT_REFRESH_MS = 60000;
+
+function readJsonSafe(filePath) {
+    try {
+        return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    } catch {
+        return null;
+    }
+}
+
+function loadConfig() {
+    const cfg = readJsonSafe(CONFIG_FILE);
+    if (!cfg || !Array.isArray(cfg.bots)) {
+        return { bots: [] };
+    }
+    return cfg;
+}
+
+// Resuelve un path del config — si es relativo, lo ancla al REPO_ROOT
+// del proyecto Intrale (porque los otros bots viven en repos hermanos).
+function resolveSnapshotPath(rawPath) {
+    if (path.isAbsolute(rawPath)) return rawPath;
+    return path.resolve(REPO_ROOT, rawPath);
+}
+
+function emptyTotals() {
+    return {
+        sessions: 0,
+        tokens_in: 0,
+        tokens_out: 0,
+        cache_read: 0,
+        cache_write: 0,
+        cost_usd: 0,
+        tts_cost_usd: 0,
+    };
+}
+
+function addInto(target, source) {
+    if (!source) return;
+    target.sessions += Number(source.sessions || 0);
+    target.tokens_in += Number(source.tokens_in || 0);
+    target.tokens_out += Number(source.tokens_out || 0);
+    target.cache_read += Number(source.cache_read || 0);
+    target.cache_write += Number(source.cache_write || 0);
+    target.cost_usd += Number(source.cost_usd || 0);
+    target.tts_cost_usd += Number(source.tts_cost_usd || 0);
+}
+
+function round4(n) { return Math.round(Number(n || 0) * 10000) / 10000; }
+
+function consolidate() {
+    const cfg = loadConfig();
+    const enabledBots = (cfg.bots || []).filter(b => b.enabled !== false);
+
+    const totals = emptyTotals();
+    const byBot = [];
+    const bySkillMap = new Map();    // skill → { skill, total_cost_usd, by_bot: Map<bot_id, cost> }
+    const byIssue = [];               // [{ issue, bot_id, label, ... }]
+    const botsUnavailable = [];
+
+    for (const botCfg of enabledBots) {
+        const snapPath = resolveSnapshotPath(botCfg.snapshot_path || '');
+        const snap = readJsonSafe(snapPath);
+        if (!snap) {
+            botsUnavailable.push({
+                bot_id: botCfg.bot_id,
+                label: botCfg.label || botCfg.bot_id,
+                snapshot_path: snapPath,
+                reason: fs.existsSync(snapPath) ? 'invalid_json' : 'not_found',
+            });
+            continue;
+        }
+
+        // Tolerancia: el snapshot puede no traer bot_id (bots que aún no
+        // se actualizaron). Caer al config.
+        const botId = snap.bot_id || botCfg.bot_id;
+        const label = snap.bot_label || botCfg.label || botId;
+
+        const botTotals = emptyTotals();
+        addInto(botTotals, snap.totals || {});
+        addInto(totals, botTotals);
+
+        const agents = Array.isArray(snap.agents) ? snap.agents : [];
+        const issues = Array.isArray(snap.issues) ? snap.issues : [];
+
+        // Agentes — agregar al breakdown global por skill
+        for (const a of agents) {
+            const skill = a.skill || 'unknown';
+            if (!bySkillMap.has(skill)) {
+                bySkillMap.set(skill, {
+                    skill,
+                    total_cost_usd: 0,
+                    sessions: 0,
+                    by_bot: new Map(),
+                });
+            }
+            const entry = bySkillMap.get(skill);
+            entry.total_cost_usd += Number(a.cost_usd || 0);
+            entry.sessions += Number(a.sessions || 0);
+            const prev = entry.by_bot.get(botId) || { bot_id: botId, label, cost_usd: 0, sessions: 0 };
+            prev.cost_usd += Number(a.cost_usd || 0);
+            prev.sessions += Number(a.sessions || 0);
+            entry.by_bot.set(botId, prev);
+        }
+
+        // Issues — pegar bot_id para filtrar en UI sin perder identidad
+        for (const i of issues) {
+            byIssue.push({
+                bot_id: botId,
+                bot_label: label,
+                issue: i.issue,
+                sessions: i.sessions || 0,
+                cost_usd: Number(i.cost_usd || 0),
+                tokens_in: i.tokens_in || 0,
+                tokens_out: i.tokens_out || 0,
+                cache_read: i.cache_read || 0,
+                cache_write: i.cache_write || 0,
+                tts_cost_usd: Number(i.tts_cost_usd || 0),
+                by_skill: Array.isArray(i.by_skill) ? i.by_skill : [],
+            });
+        }
+
+        byBot.push({
+            bot_id: botId,
+            label,
+            owner: botCfg.owner || null,
+            generated_at: snap.generated_at || null,
+            window: snap.window || 'all',
+            totals: {
+                sessions: botTotals.sessions,
+                tokens_in: botTotals.tokens_in,
+                tokens_out: botTotals.tokens_out,
+                cache_read: botTotals.cache_read,
+                cache_write: botTotals.cache_write,
+                cost_usd: round4(botTotals.cost_usd),
+                tts_cost_usd: round4(botTotals.tts_cost_usd),
+            },
+            agents,
+            issues_count: issues.length,
+            agents_count: agents.length,
+            // Top-3 issues por costo para vista rápida
+            top_issues: issues.slice(0, 3).map(i => ({
+                issue: i.issue,
+                cost_usd: round4(i.cost_usd || 0),
+                sessions: i.sessions || 0,
+            })),
+        });
+    }
+
+    const bySkill = [...bySkillMap.values()]
+        .map(e => ({
+            skill: e.skill,
+            total_cost_usd: round4(e.total_cost_usd),
+            sessions: e.sessions,
+            by_bot: [...e.by_bot.values()]
+                .map(b => ({ ...b, cost_usd: round4(b.cost_usd) }))
+                .sort((a, b) => b.cost_usd - a.cost_usd),
+        }))
+        .sort((a, b) => b.total_cost_usd - a.total_cost_usd);
+
+    byIssue.sort((a, b) => b.cost_usd - a.cost_usd);
+    byBot.sort((a, b) => b.totals.cost_usd - a.totals.cost_usd);
+
+    return {
+        generated_at: new Date().toISOString(),
+        bots_configured: enabledBots.length,
+        bots_available: byBot.length,
+        bots_unavailable: botsUnavailable,
+        totals: {
+            sessions: totals.sessions,
+            tokens_in: totals.tokens_in,
+            tokens_out: totals.tokens_out,
+            cache_read: totals.cache_read,
+            cache_write: totals.cache_write,
+            cost_usd: round4(totals.cost_usd),
+            tts_cost_usd: round4(totals.tts_cost_usd),
+        },
+        by_bot: byBot,
+        by_skill: bySkill,
+        by_issue: byIssue,
+    };
+}
+
+function writeSnapshot(snap) {
+    fs.mkdirSync(METRICS_DIR, { recursive: true });
+    const tmp = OUTPUT_FILE + '.tmp';
+    fs.writeFileSync(tmp, JSON.stringify(snap, null, 2), 'utf8');
+    fs.renameSync(tmp, OUTPUT_FILE);
+}
+
+function runOnce() {
+    const snap = consolidate();
+    writeSnapshot(snap);
+    return snap;
+}
+
+function parseArgs(argv) {
+    const args = { once: false, refreshMs: DEFAULT_REFRESH_MS };
+    for (let i = 2; i < argv.length; i++) {
+        const a = argv[i];
+        if (a === '--once') args.once = true;
+        else if (a === '--refresh' && argv[i + 1]) {
+            args.refreshMs = Math.max(5000, parseInt(argv[++i], 10) || DEFAULT_REFRESH_MS);
+        } else if (a === '--help' || a === '-h') {
+            process.stdout.write('Uso: multi-bot-aggregator.js [--once] [--refresh ms]\n');
+            process.exit(0);
+        }
+    }
+    return args;
+}
+
+function main() {
+    const args = parseArgs(process.argv);
+    const tick = () => {
+        try {
+            const snap = runOnce();
+            process.stdout.write(`[multi-bot] ${new Date().toISOString()} bots=${snap.bots_available}/${snap.bots_configured} costo=$${snap.totals.cost_usd.toFixed(4)}\n`);
+        } catch (e) {
+            process.stderr.write(`[multi-bot] error: ${e.message}\n`);
+        }
+    };
+    tick();
+    if (!args.once) setInterval(tick, args.refreshMs);
+}
+
+if (require.main === module) {
+    main();
+}
+
+module.exports = { consolidate, runOnce, writeSnapshot, OUTPUT_FILE, CONFIG_FILE };

--- a/.pipeline/metrics/multi-bot-config.json
+++ b/.pipeline/metrics/multi-bot-config.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "./multi-bot-config.schema.md",
+  "comment": "Lista de bots que comparten la misma cuenta Anthropic. El multi-bot-aggregator lee el snapshot de cada uno y consolida en multi-bot-snapshot.json. Cada bot debe publicar un snapshot con el mismo schema que .pipeline/metrics/snapshot.json (mínimo: bot_id, bot_label, totals.cost_usd, agents[], issues[]). Para bots externos (Alina, libro, club, Néstor) configurar el path absoluto que apunta a su snapshot.json. Los bots ausentes (path inexistente) se ignoran sin romper.",
+  "bots": [
+    {
+      "bot_id": "intrale",
+      "label": "Intrale",
+      "snapshot_path": ".pipeline/metrics/snapshot.json",
+      "owner": "Leo",
+      "enabled": true
+    },
+    {
+      "bot_id": "alina",
+      "label": "Alina",
+      "snapshot_path": "../alina/.pipeline/metrics/snapshot.json",
+      "owner": "Alina",
+      "enabled": false,
+      "note": "Pendiente: Alina debe alinear el formato del snapshot y habilitar."
+    },
+    {
+      "bot_id": "libro",
+      "label": "Libro",
+      "snapshot_path": "../libro/.pipeline/metrics/snapshot.json",
+      "owner": "Leo",
+      "enabled": false,
+      "note": "Pendiente: instrumentar el bot del libro para emitir snapshot."
+    },
+    {
+      "bot_id": "club",
+      "label": "Club",
+      "snapshot_path": "../club/.pipeline/metrics/snapshot.json",
+      "owner": "Leo",
+      "enabled": false,
+      "note": "Pendiente: instrumentar el bot del club para emitir snapshot."
+    },
+    {
+      "bot_id": "nestor",
+      "label": "Néstor",
+      "snapshot_path": "../nestor/.pipeline/metrics/snapshot.json",
+      "owner": "Leo",
+      "enabled": false,
+      "note": "Pendiente: instrumentar el bot Néstor para emitir snapshot."
+    }
+  ]
+}

--- a/.pipeline/metrics/projections.js
+++ b/.pipeline/metrics/projections.js
@@ -9,9 +9,13 @@
 // Cuotas por defecto — override con env vars si el usuario maneja plan Max/etc.
 const DEFAULT_MONTHLY_TOKEN_USD = Number(process.env.METRICS_QUOTA_MONTHLY_USD || 100);
 const DEFAULT_MONTHLY_TTS_USD   = Number(process.env.METRICS_QUOTA_TTS_MONTHLY_USD || 10);
+// #2854 — Cuota semanal (USD). Permite proyectar agotamiento dentro de la
+// semana corriente (Plan API o presupuesto operativo). Override con env.
+const DEFAULT_WEEKLY_TOKEN_USD = Number(process.env.METRICS_QUOTA_WEEKLY_USD || 25);
 
 // Cuántos días recientes se usan para el promedio (ignora días muy viejos para reflejar tendencia actual)
 const DEFAULT_WINDOW_DAYS = 7;
+const DEFAULT_BURN_WINDOW_DAYS = 7;
 
 function daysInMonth(date) {
     return new Date(date.getFullYear(), date.getMonth() + 1, 0).getDate();
@@ -115,6 +119,7 @@ function computeProjections(opts) {
     const quotas = opts.quotas || {};
     const monthlyTokenQuota = Number(quotas.monthly_token_usd !== undefined ? quotas.monthly_token_usd : DEFAULT_MONTHLY_TOKEN_USD);
     const monthlyTtsQuota   = Number(quotas.monthly_tts_usd   !== undefined ? quotas.monthly_tts_usd   : DEFAULT_MONTHLY_TTS_USD);
+    const weeklyTokenQuota  = Number(quotas.weekly_token_usd  !== undefined ? quotas.weekly_token_usd  : DEFAULT_WEEKLY_TOKEN_USD);
 
     return {
         generated_at: now.toISOString(),
@@ -134,17 +139,142 @@ function computeProjections(opts) {
             label: 'tts',
             secondaryFields: ['tts_chars', 'tts_audio_seconds'],
         }),
+        // #2854 — Burn rate y budget gap por costo USD (semanal). Permite
+        // contestar: "te quedás sin cuota el [día]" y "necesitás +US$ X
+        // para llegar al domingo a este ritmo".
+        burn: computeBurnAndGap({ series, weeklyTokenQuota, monthlyTokenQuota, now }),
+    };
+}
+
+// Día de la semana en que reseta la cuota semanal (Anthropic Plan Max:
+// domingo 21:00 hora local). Override por env si la cuenta es API/distinta.
+const WEEK_RESET_DOW = Number(process.env.METRICS_WEEK_RESET_DOW); // 0=Dom, 6=Sáb
+const WEEK_RESET_DEFAULT = 0; // Domingo
+
+function nextWeeklyResetIso(now) {
+    const targetDow = Number.isFinite(WEEK_RESET_DOW) ? WEEK_RESET_DOW : WEEK_RESET_DEFAULT;
+    const d = new Date(now.getTime());
+    const dow = d.getDay();
+    let daysAhead = (targetDow - dow + 7) % 7;
+    if (daysAhead === 0) daysAhead = 7; // si hoy es el día de reset, apuntar al próximo
+    d.setDate(d.getDate() + daysAhead);
+    d.setHours(21, 0, 0, 0); // 21:00 local
+    return d;
+}
+
+function startOfCurrentWeek(now) {
+    const targetDow = Number.isFinite(WEEK_RESET_DOW) ? WEEK_RESET_DOW : WEEK_RESET_DEFAULT;
+    const next = nextWeeklyResetIso(now);
+    const start = new Date(next.getTime());
+    start.setDate(start.getDate() - 7);
+    return start;
+}
+
+function sumSeriesSince(series, startIso, field) {
+    return series
+        .filter(d => d.day >= startIso)
+        .reduce((s, d) => s + Number(d[field] || 0), 0);
+}
+
+function computeBurnAndGap({ series, weeklyTokenQuota, monthlyTokenQuota, now }) {
+    if (!series || series.length === 0) {
+        return {
+            burn_rate_usd_per_day_24h: 0,
+            burn_rate_usd_per_day_7d: 0,
+            week_to_date_usd: 0,
+            week_remaining_quota_usd: weeklyTokenQuota,
+            weekly_quota_usd: weeklyTokenQuota,
+            forecast_week_end_usd: 0,
+            week_gap_usd: 0,
+            days_to_quota_exhaustion: null,
+            quota_exhaustion_at: null,
+            week_resets_at: nextWeeklyResetIso(now).toISOString(),
+            human_message: null,
+            status: 'ok',
+        };
+    }
+    // Burn rate 24h = costo del último día de la serie (proxy).
+    const last = series[series.length - 1];
+    const burn24h = Number(last && last.cost_usd || 0);
+    // Burn rate 7d promedio.
+    const burn7dAvg = dailyAverage(series, 'cost_usd', DEFAULT_BURN_WINDOW_DAYS);
+    // Burn rate efectivo: máximo entre 24h reciente y promedio 7d para ser
+    // conservador con picos. Si 24h > 7d → estamos acelerando.
+    const burnEffective = Math.max(burn24h, burn7dAvg);
+
+    const weekStartIso = startOfCurrentWeek(now).toISOString().substring(0, 10);
+    const weekToDate = sumSeriesSince(series, weekStartIso, 'cost_usd');
+    const weekRemainingQuota = Math.max(0, weeklyTokenQuota - weekToDate);
+    const weekResetMs = nextWeeklyResetIso(now).getTime();
+    const daysToWeekReset = Math.max(0, (weekResetMs - now.getTime()) / 86400000);
+
+    const forecastWeekEnd = weekToDate + (burnEffective * daysToWeekReset);
+    const weekGap = forecastWeekEnd - weeklyTokenQuota;
+
+    let daysToExhaustion = null;
+    let exhaustionAt = null;
+    if (burnEffective > 0 && weekRemainingQuota > 0) {
+        daysToExhaustion = weekRemainingQuota / burnEffective;
+        exhaustionAt = new Date(now.getTime() + daysToExhaustion * 86400000).toISOString();
+    } else if (weekRemainingQuota <= 0) {
+        daysToExhaustion = 0;
+        exhaustionAt = now.toISOString();
+    }
+
+    let status = 'ok';
+    if (weekRemainingQuota <= 0) status = 'over';
+    else if (forecastWeekEnd > weeklyTokenQuota) status = 'projected_over';
+    else if (forecastWeekEnd > weeklyTokenQuota * 0.9) status = 'warning';
+
+    let humanMessage = null;
+    const dayNames = ['domingo', 'lunes', 'martes', 'miércoles', 'jueves', 'viernes', 'sábado'];
+    if (status === 'over') {
+        humanMessage = `Te quedaste sin cuota semanal. Llevás US$${weekToDate.toFixed(2)} de US$${weeklyTokenQuota.toFixed(2)}.`;
+    } else if (daysToExhaustion !== null && Number.isFinite(daysToExhaustion) && daysToExhaustion < daysToWeekReset) {
+        const exhaustDate = new Date(exhaustionAt);
+        const dayName = dayNames[exhaustDate.getDay()];
+        const hh = String(exhaustDate.getHours()).padStart(2, '0');
+        const mm = String(exhaustDate.getMinutes()).padStart(2, '0');
+        humanMessage = `A este ritmo te quedás sin cuota el ${dayName} a las ${hh}:${mm}. Necesitás +US$${weekGap.toFixed(2)} de presupuesto extra para llegar al fin de semana.`;
+    } else if (status === 'warning') {
+        humanMessage = `Atención: la proyección al fin de semana (US$${forecastWeekEnd.toFixed(2)}) está cerca del límite (US$${weeklyTokenQuota.toFixed(2)}).`;
+    } else {
+        humanMessage = `OK. Proyección al fin de semana: US$${forecastWeekEnd.toFixed(2)} de US$${weeklyTokenQuota.toFixed(2)}.`;
+    }
+
+    return {
+        burn_rate_usd_per_day_24h: round(burn24h, 4),
+        burn_rate_usd_per_day_7d: round(burn7dAvg, 4),
+        burn_rate_usd_per_day_effective: round(burnEffective, 4),
+        week_to_date_usd: round(weekToDate, 4),
+        week_remaining_quota_usd: round(weekRemainingQuota, 4),
+        weekly_quota_usd: weeklyTokenQuota,
+        monthly_quota_usd: monthlyTokenQuota,
+        forecast_week_end_usd: round(forecastWeekEnd, 4),
+        week_gap_usd: round(weekGap, 4),
+        days_to_quota_exhaustion: daysToExhaustion !== null && Number.isFinite(daysToExhaustion)
+            ? round(daysToExhaustion, 2)
+            : null,
+        quota_exhaustion_at: exhaustionAt,
+        week_resets_at: new Date(weekResetMs).toISOString(),
+        days_to_week_reset: round(daysToWeekReset, 2),
+        human_message: humanMessage,
+        status,
     };
 }
 
 module.exports = {
     computeProjections,
+    computeBurnAndGap,
     dailyAverage,
     daysInMonth,
     daysRemainingThisMonth,
     daysRemainingThisWeek,
-    monthToDate,
+    nextWeeklyResetIso,
+    startOfCurrentWeek,
     DEFAULT_MONTHLY_TOKEN_USD,
     DEFAULT_MONTHLY_TTS_USD,
+    DEFAULT_WEEKLY_TOKEN_USD,
     DEFAULT_WINDOW_DAYS,
+    monthToDate,
 };

--- a/.pipeline/views/dashboard/satellites.js
+++ b/.pipeline/views/dashboard/satellites.js
@@ -823,6 +823,17 @@ function renderCostos() {
   <div id="costos-grid" class="kp-grid"></div>
 </section>
 <section class="in-section">
+  <h2 class="in-section-title"><span class="in-section-title-icon">📈</span>Proyección de cuota · burn rate y budget gap</h2>
+  <p id="burn-summary" style="color:var(--in-fg-dim);font-size:12px;margin:0 0 14px 0">Calculando proyección…</p>
+  <div id="burn-grid" class="kp-grid"></div>
+</section>
+<section class="in-section">
+  <h2 class="in-section-title"><span class="in-section-title-icon">🛰</span>Multi-bot accounting · Plan Max compartido</h2>
+  <p style="color:var(--in-fg-dim);font-size:12px;margin:0 0 14px 0">Consolidado de todos los bots que usan la misma cuenta Anthropic (Intrale + Alina + libro + club + Néstor). Drill-down: bot → skill → issue.</p>
+  <div id="multibot-grid" class="kp-grid"></div>
+  <div id="multibot-detail" style="margin-top:14px"></div>
+</section>
+<section class="in-section">
   <h2 class="in-section-title"><span class="in-section-title-icon">📋</span>Por skill</h2>
   <pre id="costos-detail" class="kp-pre"></pre>
 </section>`;
@@ -917,7 +928,11 @@ async function tickQuota(){
             const at = fmtART(d.calibration.at);
             const stale = d.calibrationStale ? ' ⚠ ' : ' ✓ ';
             const ageInfo = d.calibrationAgeDays != null ? ' (hace '+d.calibrationAgeDays+'d)' : '';
-            ctxt = stale+'Calibrado #'+d.calibration.sample_count+' · '+at+ageInfo+' · factor smooth(w=×'+d.calibration.weekly_factor+', s=×'+d.calibration.session_factor+') raw esta vez(w=×'+d.calibration.weekly_factor_obs+', s=×'+d.calibration.session_factor_obs+') · α EMA '+d.calibration.ema_alpha;
+            const fresh = d.calibration.fresh_sample_count != null ? d.calibration.fresh_sample_count+'/' : '';
+            const method = d.calibration.method === 'weighted_recency_median_28d'
+                ? 'mediana ponderada 28d (½-life '+(d.calibration.half_life_days||14)+'d)'
+                : (d.calibration.ema_alpha != null ? 'α EMA '+d.calibration.ema_alpha : 'EMA');
+            ctxt = stale+'Calibrado '+fresh+'#'+d.calibration.sample_count+' · '+at+ageInfo+' · factor refinado(w=×'+d.calibration.weekly_factor+', s=×'+d.calibration.session_factor+') raw esta vez(w=×'+d.calibration.weekly_factor_obs+', s=×'+d.calibration.session_factor_obs+') · '+method;
             if(d.calibrationStale) ctxt += ' — recomendado recalibrar';
             if(d.weeklyResetDriftMin) ctxt += ' · drift TZ del reset semanal: '+d.weeklyResetDriftMin+' min';
         } else {
@@ -1056,7 +1071,101 @@ async function tickCostos(){
         }
     }
 }
-const POLLS = [{ fn: tickHeader, ms: 5000 }, { fn: tickQuota, ms: 60000 }, { fn: tickCostos, ms: 60000 }];
+async function tickBurn(){
+    // #2854 — Burn rate + budget gap (proyección semanal en US$).
+    const data = await fetchJson('/metrics/burn');
+    const grid = document.getElementById('burn-grid');
+    const summary = document.getElementById('burn-summary');
+    const b = data && data.burn || null;
+    if(!b || b.weekly_quota_usd == null){
+        if(grid) grid.innerHTML = '<div class="in-empty">Sin datos de burn rate. Esperá a que termine algún agente.</div>';
+        if(summary) summary.textContent = '—';
+        return;
+    }
+    const fmtUsd = (n) => '$'+Number(n||0).toFixed(2);
+    const fmtDate = (iso) => { try{ return new Date(iso).toLocaleString('es-AR', {hour12:false, day:'2-digit', month:'2-digit', hour:'2-digit', minute:'2-digit'}); } catch{ return '—'; } };
+    const statusCls = b.status==='over'?'kp-bad':b.status==='projected_over'?'kp-bad':b.status==='warning'?'kp-warn':'kp-ok';
+    const exhaustValue = b.days_to_quota_exhaustion != null
+        ? (b.days_to_quota_exhaustion < 1 ? fmtDate(b.quota_exhaustion_at) : b.days_to_quota_exhaustion.toFixed(1)+' días')
+        : '∞';
+    const tiles = [
+        { label: 'Burn rate · 24h', value: fmtUsd(b.burn_rate_usd_per_day_24h), sub: 'costo del último día', cls: '' },
+        { label: 'Burn rate · 7d prom', value: fmtUsd(b.burn_rate_usd_per_day_7d), sub: 'media diaria 7 días', cls: '' },
+        { label: 'Semana en curso', value: fmtUsd(b.week_to_date_usd), sub: 'desde último reset · ' + fmtUsd(b.weekly_quota_usd) + ' cuota', cls: statusCls },
+        { label: 'Forecast fin de semana', value: fmtUsd(b.forecast_week_end_usd), sub: 'al ritmo actual · reset ' + fmtDate(b.week_resets_at), cls: statusCls },
+        { label: 'Budget gap', value: (b.week_gap_usd > 0 ? '+' : '') + fmtUsd(b.week_gap_usd), sub: b.week_gap_usd > 0 ? 'extra necesario para llegar al reset' : 'dentro del presupuesto', cls: b.week_gap_usd > 0 ? 'kp-bad' : 'kp-ok' },
+        { label: 'Te quedás sin cuota', value: exhaustValue, sub: b.status === 'over' ? 'ya agotada' : 'al ritmo efectivo', cls: b.status === 'over' || (b.days_to_quota_exhaustion != null && b.days_to_quota_exhaustion < 1) ? 'kp-bad' : '' },
+    ];
+    let html = '';
+    for(const t of tiles) html += '<div class="kp-tile '+t.cls+'"><div class="kp-tile-label">'+escapeHtml(t.label)+'</div><div class="kp-tile-value">'+escapeHtml(String(t.value))+'</div><div class="kp-tile-sub">'+escapeHtml(t.sub)+'</div></div>';
+    if(grid && grid.innerHTML !== html) grid.innerHTML = html;
+    if(summary){
+        const txt = b.human_message || '—';
+        if(summary.textContent !== txt) summary.textContent = txt;
+    }
+}
+
+async function tickMultiBot(){
+    // #2854 — Multi-bot accounting (Intrale + bots externos en misma cuenta).
+    const snap = await fetchJson('/metrics/multi-bot/snapshot');
+    const grid = document.getElementById('multibot-grid');
+    const detail = document.getElementById('multibot-detail');
+    if(!snap || !snap.totals){
+        if(grid) grid.innerHTML = '<div class="in-empty">Multi-bot aggregator sin datos. Solo se contabiliza Intrale por ahora.</div>';
+        if(detail) detail.innerHTML = '';
+        return;
+    }
+    const t = snap.totals;
+    const fmtUsd = (n) => '$'+Number(n||0).toFixed(2);
+    const totalUsd = Number(t.cost_usd || 0);
+    const tiles = [
+        { label: 'Total bots · costo', value: fmtUsd(totalUsd), sub: snap.bots_available + ' bot(s) disponibles', cls: '' },
+        { label: 'Total · sesiones', value: fmtNum(t.sessions || 0), sub: 'todas las cuentas combinadas', cls: '' },
+        { label: 'Total · tokens', value: fmtNum((t.tokens_in||0) + (t.tokens_out||0) + (t.cache_read||0) + (t.cache_write||0)), sub: 'in + out + cache', cls: '' },
+        { label: 'Bots inactivos', value: (snap.bots_unavailable && snap.bots_unavailable.length) || 0, sub: 'sin snapshot reciente', cls: '' },
+    ];
+    let html = '';
+    for(const ti of tiles) html += '<div class="kp-tile '+ti.cls+'"><div class="kp-tile-label">'+escapeHtml(ti.label)+'</div><div class="kp-tile-value">'+escapeHtml(String(ti.value))+'</div><div class="kp-tile-sub">'+escapeHtml(ti.sub)+'</div></div>';
+    if(grid && grid.innerHTML !== html) grid.innerHTML = html;
+
+    if(detail){
+        const byBot = snap.by_bot || [];
+        const bySkill = snap.by_skill || [];
+        const byIssue = snap.by_issue || [];
+        const pct = (v) => totalUsd > 0 ? ((Number(v||0) / totalUsd) * 100).toFixed(1) + '%' : '—';
+        let block = '';
+        if(byBot.length){
+            block += '<details open style="margin-bottom:12px"><summary style="cursor:pointer;font-weight:600;font-size:12px;padding:6px 0">Por bot (' + byBot.length + ')</summary>';
+            block += '<table style="width:100%;border-collapse:collapse;font-size:11px;margin-top:6px"><thead><tr style="border-bottom:1px solid var(--in-border);text-align:left"><th style="padding:4px 8px">bot</th><th style="padding:4px 8px;text-align:right">sesiones</th><th style="padding:4px 8px;text-align:right">tokens</th><th style="padding:4px 8px;text-align:right">costo USD</th><th style="padding:4px 8px;text-align:right">% del total</th></tr></thead><tbody>';
+            for(const b of byBot){
+                const tot = (b.tokens_in||0) + (b.tokens_out||0) + (b.cache_read||0) + (b.cache_write||0);
+                block += '<tr><td style="padding:4px 8px">'+escapeHtml(b.bot_id||b.bot_name||'?')+'</td><td style="padding:4px 8px;text-align:right">'+fmtNum(b.sessions||0)+'</td><td style="padding:4px 8px;text-align:right">'+fmtNum(tot)+'</td><td style="padding:4px 8px;text-align:right">'+fmtUsd(b.cost_usd||0)+'</td><td style="padding:4px 8px;text-align:right">'+pct(b.cost_usd)+'</td></tr>';
+            }
+            block += '</tbody></table></details>';
+        }
+        if(bySkill.length){
+            block += '<details style="margin-bottom:12px"><summary style="cursor:pointer;font-weight:600;font-size:12px;padding:6px 0">Por skill (' + bySkill.length + ')</summary>';
+            block += '<table style="width:100%;border-collapse:collapse;font-size:11px;margin-top:6px"><thead><tr style="border-bottom:1px solid var(--in-border);text-align:left"><th style="padding:4px 8px">bot · skill</th><th style="padding:4px 8px;text-align:right">sesiones</th><th style="padding:4px 8px;text-align:right">costo USD</th><th style="padding:4px 8px;text-align:right">% del total</th></tr></thead><tbody>';
+            for(const s of bySkill){
+                block += '<tr><td style="padding:4px 8px">'+escapeHtml((s.bot_id||'?')+' · '+(s.skill||'?'))+'</td><td style="padding:4px 8px;text-align:right">'+fmtNum(s.sessions||0)+'</td><td style="padding:4px 8px;text-align:right">'+fmtUsd(s.cost_usd||0)+'</td><td style="padding:4px 8px;text-align:right">'+pct(s.cost_usd)+'</td></tr>';
+            }
+            block += '</tbody></table></details>';
+        }
+        if(byIssue.length){
+            const top = byIssue.slice(0, 20);
+            block += '<details style="margin-bottom:12px"><summary style="cursor:pointer;font-weight:600;font-size:12px;padding:6px 0">Por issue · top 20 (' + byIssue.length + ' total)</summary>';
+            block += '<table style="width:100%;border-collapse:collapse;font-size:11px;margin-top:6px"><thead><tr style="border-bottom:1px solid var(--in-border);text-align:left"><th style="padding:4px 8px">bot · issue</th><th style="padding:4px 8px;text-align:right">sesiones</th><th style="padding:4px 8px;text-align:right">costo USD</th><th style="padding:4px 8px;text-align:right">% del total</th></tr></thead><tbody>';
+            for(const i of top){
+                const issueLbl = (i.bot_id||'?') + ' · #' + (i.issue||'?');
+                block += '<tr><td style="padding:4px 8px">'+escapeHtml(issueLbl)+'</td><td style="padding:4px 8px;text-align:right">'+fmtNum(i.sessions||0)+'</td><td style="padding:4px 8px;text-align:right">'+fmtUsd(i.cost_usd||0)+'</td><td style="padding:4px 8px;text-align:right">'+pct(i.cost_usd)+'</td></tr>';
+            }
+            block += '</tbody></table></details>';
+        }
+        if(detail.innerHTML !== block) detail.innerHTML = block;
+    }
+}
+
+const POLLS = [{ fn: tickHeader, ms: 5000 }, { fn: tickQuota, ms: 60000 }, { fn: tickCostos, ms: 60000 }, { fn: tickBurn, ms: 60000 }, { fn: tickMultiBot, ms: 60000 }];
 async function runAll(){ for(const p of POLLS){ try{ await p.fn(); } catch{} } }
 runAll();
 for(const p of POLLS){ setInterval(() => { p.fn().catch(()=>{}); }, p.ms); }`;

--- a/app/composeApp/src/commonMain/composeResources/drawable/ic_invitation_envelope.xml
+++ b/app/composeApp/src/commonMain/composeResources/drawable/ic_invitation_envelope.xml
@@ -1,0 +1,18 @@
+<!--
+  ic_invitation_envelope — Ícono ilustrativo de la pantalla "Aceptación de invitación".
+  Diseño: sobre cerrado con marca de check superpuesta (símbolo "invitación verificada").
+  Uso: hero icon central de InvitationScreen tras validar el token.
+  Tamaño objetivo: 96-128dp (escala 24dp viewport).
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M20,4H4C2.9,4 2,4.9 2,6V18C2,19.1 2.9,20 4,20H13.09C13.03,19.67 13,19.34 13,19C13,18.45 13.08,17.92 13.21,17.41L12,18.17L4,13V6L12,11L20,6V11.08C20.71,11.18 21.38,11.39 22,11.68V6C22,4.9 21.1,4 20,4ZM12,9L4,4H20L12,9Z"
+      android:fillColor="#FF000000"/>
+  <path
+      android:pathData="M17.75,22L14,18.25L15.41,16.84L17.75,19.17L22.59,14.34L24,15.75L17.75,22Z"
+      android:fillColor="#FF000000"/>
+</vector>

--- a/app/composeApp/src/commonMain/composeResources/drawable/ic_team_menu.xml
+++ b/app/composeApp/src/commonMain/composeResources/drawable/ic_team_menu.xml
@@ -1,0 +1,24 @@
+<!--
+  ic_team_menu — Ícono para la entrada "Equipo" del home del flavor business.
+  Diseño: tres siluetas de personas agrupadas (Material Symbols outlined "groups").
+  Uso: leadingIcon de NavigationBar/NavigationDrawer/MenuItem en HomeScreen.
+  Tamaño objetivo: 24dp.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M4,13C5.1,13 6,12.1 6,11C6,9.9 5.1,9 4,9C2.9,9 2,9.9 2,11C2,12.1 2.9,13 4,13ZM5.13,14.1C4.76,14.04 4.39,14 4,14C3.01,14 2.07,14.21 1.22,14.58C0.48,14.9 0,15.62 0,16.43V18H4.5V16.39C4.5,15.56 4.73,14.78 5.13,14.1Z"
+      android:fillColor="#FF000000"/>
+  <path
+      android:pathData="M20,13C21.1,13 22,12.1 22,11C22,9.9 21.1,9 20,9C18.9,9 18,9.9 18,11C18,12.1 18.9,13 20,13ZM24,16.43C24,15.62 23.52,14.9 22.78,14.58C21.93,14.21 20.99,14 20,14C19.61,14 19.24,14.04 18.87,14.1C19.27,14.78 19.5,15.56 19.5,16.39V18H24V16.43Z"
+      android:fillColor="#FF000000"/>
+  <path
+      android:pathData="M16.24,13.65C15.07,13.13 13.63,12.75 12,12.75C10.37,12.75 8.93,13.13 7.76,13.65C6.68,14.13 6,15.21 6,16.39V18H18V16.39C18,15.21 17.32,14.13 16.24,13.65ZM8.07,16C8.16,15.77 8.2,15.61 8.98,15.31C9.95,14.93 10.97,14.75 12,14.75C13.03,14.75 14.05,14.93 15.02,15.31C15.79,15.61 15.83,15.77 15.93,16H8.07Z"
+      android:fillColor="#FF000000"/>
+  <path
+      android:pathData="M12,6C13.1,6 14,6.9 14,8C14,9.1 13.1,10 12,10C10.9,10 10,9.1 10,8C10,6.9 10.9,6 12,6ZM12,4C9.79,4 8,5.79 8,8C8,10.21 9.79,12 12,12C14.21,12 16,10.21 16,8C16,5.79 14.21,4 12,4Z"
+      android:fillColor="#FF000000"/>
+</vector>

--- a/app/composeApp/src/commonMain/composeResources/drawable/ic_team_role_cashier.xml
+++ b/app/composeApp/src/commonMain/composeResources/drawable/ic_team_role_cashier.xml
@@ -1,0 +1,18 @@
+<!--
+  ic_team_role_cashier — Chip ícono para el rol CASHIER (operativo de caja).
+  Diseño: caja registradora estilizada (Material Symbols outlined "point_of_sale").
+  Uso: leading icon del SuggestionChip/AssistChip con container=secondaryContainer y tint=onSecondaryContainer.
+  Tamaño objetivo: 18dp (chip leading icon).
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M21,16V19H3V16H21ZM5,15V12H19V15H5ZM5,11V4H19V11H5Z M7,6V9H17V6H7Z M7,13V14H9V13H7Z M11,13V14H13V13H11Z M15,13V14H17V13H15Z"
+      android:fillColor="#FF000000"/>
+  <path
+      android:pathData="M4,21V20H20V21H4Z"
+      android:fillColor="#FF000000"/>
+</vector>

--- a/app/composeApp/src/commonMain/composeResources/drawable/ic_team_role_employee.xml
+++ b/app/composeApp/src/commonMain/composeResources/drawable/ic_team_role_employee.xml
@@ -1,0 +1,18 @@
+<!--
+  ic_team_role_employee — Chip ícono para el rol EMPLOYEE (genérico, sin permisos administrativos).
+  Diseño: silueta de persona simple (Material Symbols outlined "person").
+  Uso: leading icon del SuggestionChip/AssistChip con container=surfaceContainerHigh y tint=onSurface.
+  Tamaño objetivo: 18dp (chip leading icon).
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M12,12C14.21,12 16,10.21 16,8C16,5.79 14.21,4 12,4C9.79,4 8,5.79 8,8C8,10.21 9.79,12 12,12ZM12,6C13.1,6 14,6.9 14,8C14,9.1 13.1,10 12,10C10.9,10 10,9.1 10,8C10,6.9 10.9,6 12,6Z"
+      android:fillColor="#FF000000"/>
+  <path
+      android:pathData="M12,13C9.33,13 4,14.34 4,17V20H20V17C20,14.34 14.67,13 12,13ZM18,18H6V17.01C6.2,16.29 9.3,15 12,15C14.7,15 17.8,16.29 18,17V18Z"
+      android:fillColor="#FF000000"/>
+</vector>

--- a/app/composeApp/src/commonMain/composeResources/drawable/ic_team_role_manager.xml
+++ b/app/composeApp/src/commonMain/composeResources/drawable/ic_team_role_manager.xml
@@ -1,0 +1,18 @@
+<!--
+  ic_team_role_manager — Chip ícono para el rol MANAGER (autoridad delegada).
+  Diseño: escudo con check (símbolo de "verificado/autorizado").
+  Uso: leading icon del SuggestionChip/AssistChip con container=tertiaryContainer y tint=onTertiaryContainer.
+  Tamaño objetivo: 18dp (chip leading icon).
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M12,2L4,5V11C4,15.55 6.84,19.74 11,21C11.33,21.1 11.66,21.16 12,21.16C12.34,21.16 12.67,21.1 13,21C17.16,19.74 20,15.55 20,11V5L12,2ZM18,11C18,14.55 15.84,17.83 12.5,18.93C12.17,19.04 11.83,19.04 11.5,18.93C8.16,17.83 6,14.55 6,11V6.39L12,4.14L18,6.39V11Z"
+      android:fillColor="#FF000000"/>
+  <path
+      android:pathData="M10.5,13.59L8.41,11.5L7,12.91L10.5,16.41L16.5,10.41L15.09,9L10.5,13.59Z"
+      android:fillColor="#FF000000"/>
+</vector>

--- a/app/composeApp/src/commonMain/composeResources/drawable/ic_team_role_owner.xml
+++ b/app/composeApp/src/commonMain/composeResources/drawable/ic_team_role_owner.xml
@@ -1,0 +1,19 @@
+<!--
+  ic_team_role_owner — Chip ícono para el rol OWNER (autoridad máxima).
+  Diseño: corona estilizada con tres puntas (estilo Material Symbols outlined).
+  Uso: leading icon del SuggestionChip/AssistChip con container=primaryContainer y tint=onPrimaryContainer.
+  Tamaño objetivo: 18dp (chip leading icon).
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M5,16L3.5,8.5L8,11.5L12,5L16,11.5L20.5,8.5L19,16H5ZM5,18H19V20H5V18Z"
+      android:fillColor="#FF000000"/>
+  <path
+      android:pathData="M12,7.5L9,12.25L5.6,10.05L6.7,15H17.3L18.4,10.05L15,12.25L12,7.5Z"
+      android:fillColor="#FF000000"
+      android:fillAlpha="0.25"/>
+</vector>

--- a/app/composeApp/src/commonMain/composeResources/drawable/ic_team_status_pending.xml
+++ b/app/composeApp/src/commonMain/composeResources/drawable/ic_team_status_pending.xml
@@ -1,0 +1,18 @@
+<!--
+  ic_team_status_pending — Ícono para badge de estado PENDIENTE en items de empleados.
+  Diseño: reloj minimalista (Material Symbols outlined "schedule") — comunica "esperando aceptación".
+  Uso: leading icon en chip de estado dentro del item del LazyColumn.
+  Tamaño objetivo: 16dp (status badge).
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M12,2C6.48,2 2,6.48 2,12C2,17.52 6.48,22 12,22C17.52,22 22,17.52 22,12C22,6.48 17.52,2 12,2ZM12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20,12C20,16.41 16.41,20 12,20Z"
+      android:fillColor="#FF000000"/>
+  <path
+      android:pathData="M12.5,7H11V13L16.25,16.15L17,14.92L12.5,12.25V7Z"
+      android:fillColor="#FF000000"/>
+</vector>

--- a/app/composeApp/src/commonMain/composeResources/drawable/team_murble_friendly.xml
+++ b/app/composeApp/src/commonMain/composeResources/drawable/team_murble_friendly.xml
@@ -1,0 +1,92 @@
+<!--
+  team_murble_friendly — Companion blob "Murble" en pose amistosa con un saludo de bienvenida.
+  Identidad: blob orgánico de color secundario con dos ojos grandes expresivos, sonrisa cálida y
+  un brazo levantado saludando. Pensado para el estado EMPTY de la pantalla "Equipo" del flavor
+  business: invita al OWNER a sumar a sus primeros empleados.
+
+  Composición:
+    - Cuerpo principal: silueta blob asimétrica con curva orgánica (no círculo perfecto, identidad).
+    - Brazo izquierdo: extendido saludando (gesto inclusivo).
+    - Ojos: dos óvalos grandes con highlight blanco (lifelike).
+    - Boca: sonrisa amplia con gesto cálido.
+    - Pequeñas estrellitas alrededor: sensación de bienvenida activa.
+
+  Color: usa android:fillColor placeholder "#FF000000" para que el dev lo tinte con
+  ColorFilter del tema Material3 (`MaterialTheme.colorScheme.tertiary` recomendado, contraste AA).
+  El blanco de highlights va literal porque tiene que verse contra cualquier tint.
+
+  Tamaño objetivo: 160-200dp en el estado EMPTY (gran presencia).
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="200dp"
+    android:height="200dp"
+    android:viewportWidth="200"
+    android:viewportHeight="200">
+
+  <!-- Cuerpo principal: blob orgánico asimétrico (la "personalidad" de Murble) -->
+  <path
+      android:pathData="M100,40 C140,38 165,62 168,98 C170,124 162,148 140,160 C120,170 100,168 90,165 C70,160 55,148 48,128 C42,108 45,82 60,62 C72,48 86,42 100,40 Z"
+      android:fillColor="#FF000000"/>
+
+  <!-- Brazo izquierdo levantado saludando -->
+  <path
+      android:pathData="M55,90 C42,82 32,72 28,60 C26,52 30,46 38,46 C46,46 54,54 62,68 C66,76 64,86 60,92 C58,94 56,93 55,90 Z"
+      android:fillColor="#FF000000"/>
+
+  <!-- Ojo izquierdo (óvalo grande) -->
+  <path
+      android:pathData="M82,90 m-10,0 a10,12 0 1,0 20,0 a10,12 0 1,0 -20,0"
+      android:fillColor="#FFFFFFFF"/>
+
+  <!-- Pupila izquierda -->
+  <path
+      android:pathData="M84,93 m-4,0 a4,5 0 1,0 8,0 a4,5 0 1,0 -8,0"
+      android:fillColor="#FF1A1A1A"/>
+
+  <!-- Highlight ojo izquierdo -->
+  <path
+      android:pathData="M86,89 m-1.5,0 a1.5,1.8 0 1,0 3,0 a1.5,1.8 0 1,0 -3,0"
+      android:fillColor="#FFFFFFFF"/>
+
+  <!-- Ojo derecho (óvalo grande) -->
+  <path
+      android:pathData="M126,90 m-10,0 a10,12 0 1,0 20,0 a10,12 0 1,0 -20,0"
+      android:fillColor="#FFFFFFFF"/>
+
+  <!-- Pupila derecha -->
+  <path
+      android:pathData="M128,93 m-4,0 a4,5 0 1,0 8,0 a4,5 0 1,0 -8,0"
+      android:fillColor="#FF1A1A1A"/>
+
+  <!-- Highlight ojo derecho -->
+  <path
+      android:pathData="M130,89 m-1.5,0 a1.5,1.8 0 1,0 3,0 a1.5,1.8 0 1,0 -3,0"
+      android:fillColor="#FFFFFFFF"/>
+
+  <!-- Sonrisa cálida (boca curva amplia) -->
+  <path
+      android:pathData="M85,120 Q105,138 125,120 Q120,134 105,136 Q90,134 85,120 Z"
+      android:fillColor="#FFFFFFFF"/>
+
+  <!-- Línea inferior de sonrisa para reforzar el gesto -->
+  <path
+      android:pathData="M85,120 Q105,140 125,120"
+      android:strokeColor="#FF1A1A1A"
+      android:strokeWidth="2"
+      android:strokeLineCap="round"
+      android:fillColor="#00000000"/>
+
+  <!-- Estrellitas de bienvenida — invitación a interactuar -->
+  <path
+      android:pathData="M170,55 L173,62 L180,62 L174,67 L176,74 L170,70 L164,74 L166,67 L160,62 L167,62 Z"
+      android:fillColor="#FF000000"/>
+
+  <path
+      android:pathData="M30,130 L32,135 L37,135 L33,138 L34,143 L30,140 L26,143 L27,138 L23,135 L28,135 Z"
+      android:fillColor="#FF000000"/>
+
+  <path
+      android:pathData="M155,150 L156.5,153.5 L160,153.5 L157.2,156 L158,160 L155,158 L152,160 L152.8,156 L150,153.5 L153.5,153.5 Z"
+      android:fillColor="#FF000000"/>
+
+</vector>

--- a/scripts/cost-report.js
+++ b/scripts/cost-report.js
@@ -10,6 +10,7 @@ const { execSync } = require("child_process");
 // --- Config ---
 const REPO_ROOT = path.resolve(__dirname, "..");
 const METRICS_PATH = path.join(REPO_ROOT, ".claude", "hooks", "agent-metrics.json");
+const SNAPSHOT_PATH = path.join(REPO_ROOT, ".pipeline", "metrics", "snapshot.json");
 const CONFIG_PATH = path.join(REPO_ROOT, ".claude", "hooks", "telegram-config.json");
 const SPRINT_PLAN_PATH = path.join(__dirname, "sprint-plan.json");
 const LOG_DIR = path.join(__dirname, "logs");
@@ -44,15 +45,55 @@ function readJsonSafe(filePath) {
     }
 }
 
-// --- Token estimation ---
-function estimateTokens(session) {
+// --- Snapshot real (.pipeline/metrics/snapshot.json) ---
+// Devuelve un mapa por skill con tokens/cost reales y tool_calls totales,
+// para prorratear costos a sesiones individuales del agent-metrics.json.
+// Si el snapshot no existe → null y se usa la heurística como fallback.
+function loadSnapshotIndex() {
+    const snap = readJsonSafe(SNAPSHOT_PATH);
+    if (!snap || !snap.agents) return null;
+    const bySkill = {};
+    for (const a of snap.agents) {
+        if (!a.skill) continue;
+        const tokensTotal = (a.tokens_in || 0) + (a.tokens_out || 0) + (a.cache_read || 0) + (a.cache_write || 0);
+        bySkill[a.skill] = {
+            sessions: a.sessions || 0,
+            tool_calls: a.tool_calls || 0,
+            tokens_total: tokensTotal,
+            cost_usd: a.cost_usd || 0,
+        };
+    }
+    return {
+        totals: snap.totals || null,
+        bySkill,
+        generated_at: snap.generated_at || null,
+    };
+}
+
+// Prorratea tokens reales de la skill a esta sesión según su % de tool_calls.
+// Si no hay datos del snapshot para la skill → fallback heurístico.
+function estimateTokens(session, snapshotIndex) {
     if (session.tokens_estimated) return session.tokens_estimated;
+    const skill = session.agent_name || session.skill;
+    if (snapshotIndex && skill && snapshotIndex.bySkill[skill] && snapshotIndex.bySkill[skill].tool_calls > 0) {
+        const sk = snapshotIndex.bySkill[skill];
+        const sessionCalls = session.total_tool_calls || 0;
+        const ratio = sessionCalls / sk.tool_calls;
+        return Math.round(sk.tokens_total * ratio);
+    }
     const durationSec = (session.duration_min || 0) * 60;
     const toolCalls = session.total_tool_calls || 0;
     return (durationSec * 15) + (toolCalls * 500);
 }
 
-function estimateCost(session, costPerAction) {
+function estimateCost(session, costPerAction, snapshotIndex) {
+    const skill = session.agent_name || session.skill;
+    if (snapshotIndex && skill && snapshotIndex.bySkill[skill] && snapshotIndex.bySkill[skill].tool_calls > 0) {
+        const sk = snapshotIndex.bySkill[skill];
+        const sessionCalls = session.total_tool_calls || 0;
+        const ratio = sessionCalls / sk.tool_calls;
+        return sk.cost_usd * ratio;
+    }
     const toolCalls = session.total_tool_calls || 0;
     return toolCalls * costPerAction;
 }
@@ -109,6 +150,8 @@ function escapeHtml(str) {
 
 function buildHtml(sessions, costPerAction, weeklyBudget, sprintPlan, filterSprintId) {
     const fecha = new Date().toISOString().split("T")[0];
+    const snapshotIndex = loadSnapshotIndex();
+    const usingRealMetrics = !!(snapshotIndex && snapshotIndex.totals);
 
     // Filtrar por sprint si se especificó
     let filteredSessions = sessions;
@@ -116,26 +159,33 @@ function buildHtml(sessions, costPerAction, weeklyBudget, sprintPlan, filterSpri
         filteredSessions = sessions.filter(s => s.sprint_id === filterSprintId);
     }
 
-    // Enriquecer sesiones
+    // Enriquecer sesiones (prorrateo desde snapshot real cuando hay match por skill)
     const enriched = filteredSessions.map(s => ({
         ...s,
-        tokens_estimated: estimateTokens(s),
-        cost_estimated_usd: estimateCost(s, costPerAction),
+        tokens_estimated: estimateTokens(s, snapshotIndex),
+        cost_estimated_usd: estimateCost(s, costPerAction, snapshotIndex),
     }));
 
-    // Totales
+    // Totales: si hay snapshot real y NO hay filtro de sprint, usamos el snapshot
+    // como ground truth (es la realidad agregada por el Pulpo).
+    // Si hay filtro o no hay snapshot, sumamos por sesión.
     const totalSessions = enriched.length;
     const totalToolCalls = enriched.reduce((sum, s) => sum + (s.total_tool_calls || 0), 0);
-    const totalTokens = enriched.reduce((sum, s) => sum + s.tokens_estimated, 0);
-    const totalCost = enriched.reduce((sum, s) => sum + s.cost_estimated_usd, 0);
     const totalDurationMin = enriched.reduce((sum, s) => sum + (s.duration_min || 0), 0);
+    const useGlobalSnapshot = usingRealMetrics && !filterSprintId;
+    const totalTokens = useGlobalSnapshot
+        ? ((snapshotIndex.totals.tokens_in || 0) + (snapshotIndex.totals.tokens_out || 0) + (snapshotIndex.totals.cache_read || 0) + (snapshotIndex.totals.cache_write || 0))
+        : enriched.reduce((sum, s) => sum + s.tokens_estimated, 0);
+    const totalCost = useGlobalSnapshot
+        ? (snapshotIndex.totals.cost_usd || 0)
+        : enriched.reduce((sum, s) => sum + s.cost_estimated_usd, 0);
 
     // Sesiones de últimos 7 días para costo semanal
     const weekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
     const weeklySessions = sessions.map(s => ({
         ...s,
-        tokens_estimated: estimateTokens(s),
-        cost_estimated_usd: estimateCost(s, costPerAction),
+        tokens_estimated: estimateTokens(s, snapshotIndex),
+        cost_estimated_usd: estimateCost(s, costPerAction, snapshotIndex),
     })).filter(s => (s.started_ts || "") >= weekAgo);
     const weeklyCost = weeklySessions.reduce((sum, s) => sum + s.cost_estimated_usd, 0);
     const weeklyPct = weeklyBudget > 0 ? Math.min(Math.round(weeklyCost / weeklyBudget * 100), 100) : 0;
@@ -190,10 +240,14 @@ function buildHtml(sessions, costPerAction, weeklyBudget, sprintPlan, filterSpri
 <p><strong>Proyecto:</strong> Intrale Platform (<code>intrale/platform</code>)<br>
 <strong>Fecha:</strong> ${fecha}<br>
 <strong>Sesiones analizadas:</strong> ${totalSessions}<br>
-<strong>Costo por acción:</strong> ${formatUSD(costPerAction)}</p>
+<strong>Fuente de datos:</strong> ${usingRealMetrics
+    ? `tokens y costos reales del snapshot del Pulpo (<code>.pipeline/metrics/snapshot.json</code>${snapshotIndex.generated_at ? `, generado ${escapeHtml(snapshotIndex.generated_at)}` : ""})`
+    : `estimación heurística (snapshot no disponible)`}</p>
 
 <div class="formula">
-<strong>Fórmula de estimación:</strong> tokens ≈ (duración_seg × 15) + (tool_calls × 500) | costo ≈ tool_calls × ${formatUSD(costPerAction)}
+${usingRealMetrics
+    ? `<strong>Cálculo:</strong> totales globales = snapshot real (Anthropic API). Per-sesión = prorrateo del costo de la skill por % de tool_calls de cada sesión.`
+    : `<strong>Fórmula heurística (fallback):</strong> tokens ≈ (duración_seg × 15) + (tool_calls × 500) | costo ≈ tool_calls × ${formatUSD(costPerAction)}`}
 </div>
 
 <!-- MÉTRICAS GLOBALES -->
@@ -339,7 +393,9 @@ function buildHtml(sessions, costPerAction, weeklyBudget, sprintPlan, filterSpri
     html += `
 <div class="footer">
   <p>Generado automáticamente el ${fecha} | Intrale Platform | Cost Report</p>
-  <p>Modelo: Claude Haiku 4.5 | Estimación por proxy (duración + tool calls)</p>
+  <p>${usingRealMetrics
+    ? `Datos reales del snapshot del Pulpo (.pipeline/metrics/snapshot.json) — precios oficiales de Anthropic`
+    : `Snapshot real no disponible — usando estimación heurística por tool_calls + duración`}</p>
 </div>
 
 </body>


### PR DESCRIPTION
## Summary

Issue #2854 — contabilidad consolidada del Plan Max compartido entre Intrale + Alina + libro + club + Néstor, proyección de cuota y budget gap.

## Cambios

### 1. `scripts/cost-report.js` — fix de la heurística divergente
- Antes: estimaba tokens por `duration × 15 + tool_calls × 500` y costo por `tool_calls × $0.003`. Resultado: ~US$ 1 cuando en realidad iban US$ 137 (~115× off).
- Ahora: lee `.pipeline/metrics/snapshot.json` (tokens reales × precios oficiales Anthropic) y prorratea por sesión usando `% tool_calls`. Header del PDF declara la fuente (`snapshot` vs `heurística-fallback`).

### 2. Multi-bot accounting
- `.pipeline/metrics/multi-bot-aggregator.js` — combina snapshots estandarizados de los 5 bots con jerarquía `bot → skill → issue → sesión`.
- `.pipeline/metrics/multi-bot-config.json` — registro de bots (Intrale + 4 stubs para Alina/libro/club/Néstor pendientes de alinear con sus owners).
- `dashboard.js`: endpoints `/metrics/multi-bot/{snapshot,by-bot,by-skill,by-issue,totals}`.
- `views/dashboard/satellites.js`: bloque "Multi-bot accounting · Plan Max compartido" con tiles + drill-down plegable (bot, skill, top 20 issues).

### 3. Proyección de quota + budget gap
- `.pipeline/metrics/projections.js`: `burn_rate_usd_per_day_24h`, `_7d`, `_effective` (max), `week_to_date_usd`, `forecast_week_end_usd`, `week_gap_usd`, `quota_exhaustion_at`, `human_message`.
- Reset semanal configurable (`METRICS_WEEK_RESET_DOW` / `_HOUR` / `_TZ`), default domingo 00 UTC.
- Endpoint `/metrics/burn` + bloque "Proyección de cuota" en `/costos` con tiles (burn 24h, burn 7d, semana en curso, forecast, gap, fecha de agotamiento).

### 4. Calibración refinable determinística (sin IA)
- Histórico extendido **20 → 50 muestras** (~4-8 semanas). Sobrevive resets.
- Factor con **mediana ponderada por recencia** (ventana 28d, half-life 14d) en vez de EMA. Robusta a outliers.
- `weekly_profiles[]` snapshotea factor estable de cada semana cerrada (12 últimas) → permite refinar fórmula multi-semana cuando Leo carga nuevos % del console.

## Test plan

- [x] `node --test .pipeline/lib/__tests__/weekly-quota-calibration.test.js` — 10 verde (mediana ponderada, descarta >28d, half-life, snapshot semanal, idempotencia)
- [x] `node --test .pipeline/metrics/__tests__/projections.test.js` + `aggregator.test.js` — 24 verde, 0 regresiones
- [x] Smoke `curl http://localhost:3200/metrics/burn` — devuelve burn rate, week_to_date, forecast, gap, status
- [x] Smoke `curl http://localhost:3200/metrics/multi-bot/snapshot` — devuelve totales + by_bot + skill + issue
- [ ] QA E2E con video del dashboard `/costos` mostrando los 3 bloques nuevos
- [ ] PO acceptance — Leo valida números contra console Anthropic

## Notas

- Otros bots (Alina/libro/club/Néstor) aparecen en `multi-bot-config.json` con `enabled: false` hasta alinear formato de snapshot con sus owners.
- Modelo confirmado por Leo: cuenta única (Plan Max), todos los bots son "clientes" de la misma billetera. La calibración usa el % del console como ground truth, no hay tarifa US$/semana.

Closes #2854

🤖 Generated with [Claude Code](https://claude.com/claude-code)