### PR TITLE
fix(dashboard): pause/resume refresca title-cache al instante

### DIFF
--- a/.pipeline/dashboard.js
+++ b/.pipeline/dashboard.js
@@ -7646,6 +7646,15 @@ const server = http.createServer((req, res) => {
       res.end(JSON.stringify({ ok: false, msg: `gh edit falló: ${(result.stderr || '').trim().slice(0, 200)}` }));
       return;
     }
+    // El title-cache (TTL 1h) tapa el label recién editado: refrescar el issue
+    // puntual + invalidar el state cache memoizado para que el próximo poll del
+    // dashboard vea el cambio.
+    try {
+      const titleCache = loadIssueTitleCache();
+      delete titleCache[issueNum];
+      fetchIssueTitles([issueNum], titleCache);
+    } catch (e) { log(`pauseIssue: cache refresh failed for #${issueNum}: ${e.message}`); }
+    _stateCache = null; _stateCacheAt = 0;
     log(`pauseIssue: #${issueNum} ${action === 'pause' ? 'pausado (+blocked:dependencies)' : 'reanudado (-blocked:dependencies)'}`);
     res.writeHead(200, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify({ ok: true, msg: `Issue #${issueNum} ${action === 'pause' ? 'pausado' : 'reanudado'}` }));


### PR DESCRIPTION
## Summary

- El handler \`POST /api/issue/<n>/pause|resume\` aplicaba el label en GitHub via \`gh issue edit\` pero **no invalidaba el title-cache local** (TTL 1h).
- Resultado: el dashboard confirmaba "pausado" via toast pero el badge ⏸ no aparecía hasta que expirara el cache (1h) o se reiniciara el proceso.
- Fix: tras el \`gh edit\` OK, refetcheamos el issue puntual vía GraphQL (\`fetchIssueTitles\`) y forzamos \`_stateCache=null\` para que el próximo poll lea labels frescos.

## Labels

- \`qa:skipped\` — fix de UX puro del dashboard interno (sin impacto en app de usuario)
- \`area:dashboard\` · \`tipo:fix\`

## Test plan

- [ ] Reiniciar dashboard
- [ ] En \`/pipeline\`, pausar un issue
- [ ] Verificar que en el siguiente poll (≤5s) aparece el badge ⏸ pausado y el botón cambia a ▶
- [ ] Reanudar y verificar que el badge desaparece igual de rápido

🤖 Generated with [Claude Code](https://claude.com/claude-code)