### PR TITLE
fix(security,dashboard): bot Telegram con secrets fuera del repo + visibilidad de fallo

### DIFF
--- a/.claude/hooks/telegram-config.json
+++ b/.claude/hooks/telegram-config.json
@@ -1,6 +1,7 @@
 {
-  "bot_token": "8403197784:AAG07242gOCKwZ-G-DI8eLC6R1HwfhG6Exk",
-  "chat_id": "6529617704",
+  "_secrets_note": "bot_token y chat_id MOVIDOS a ~/.claude/secrets/telegram-config.json (fuera del repo, inmune a checkouts/pulls). NO restaurar credenciales aqui — quedan trackeadas en git. Ver .pipeline/lib/telegram-secrets.js.",
+  "bot_token": "MOVED_TO_HOME_DOT_CLAUDE_SECRETS",
+  "chat_id": "MOVED_TO_HOME_DOT_CLAUDE_SECRETS",
   "permission_timeout_min": 60,
   "task_report_interval_min": 10,
   "retry_intervals_min": [

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,14 @@
+# Secrets — defensa en profundidad. La ubicacion oficial de credenciales es
+# ~/.claude/secrets/ (home del usuario, fuera del repo); estos patrones
+# bloquean cualquier intento accidental de crear esos paths dentro del repo.
+.claude/secrets/
+**/.claude/secrets/
+secrets.json
+**/secrets.json
+.env
+.env.*
+!.env.example
+
 # Build outputs
 build/
 */build/

--- a/.pipeline/dashboard.js
+++ b/.pipeline/dashboard.js
@@ -696,6 +696,18 @@ function getPipelineState() {
     state.infraHealth = { error: 'invalid-json', mtimeMs: Date.now() };
   }
 
+  // Telegram bot health: lo escribe el listener-telegram en cada poll (ok | error
+  // con description). Permite mostrar en /ops cuando el token fue rechazado o
+  // los secrets faltan, en lugar de quedar el bot silenciosamente caido.
+  state.telegramHealth = null;
+  try {
+    const tgHealthPath = path.join(PIPELINE, 'telegram-health.json');
+    if (fs.existsSync(tgHealthPath)) {
+      const raw = fs.readFileSync(tgHealthPath, 'utf8');
+      state.telegramHealth = JSON.parse(raw);
+    }
+  } catch { state.telegramHealth = { ok: false, lastError: { description: 'invalid-json', source: 'dashboard' } }; }
+
   // Recursos del sistema
   const resourceLimits = config.resource_limits || {};
   const sys = getSystemResourceUsage();

--- a/.pipeline/lib/dashboard-slices.js
+++ b/.pipeline/lib/dashboard-slices.js
@@ -405,6 +405,7 @@ function opsSlice(state) {
         qaEnv: state.qaEnv || {},
         qaRemote: state.qaRemote || {},
         resources: state.resources || {},
+        telegramHealth: state.telegramHealth || null,
     };
 }
 

--- a/.pipeline/lib/telegram-health.js
+++ b/.pipeline/lib/telegram-health.js
@@ -1,0 +1,44 @@
+// =============================================================================
+// telegram-health.js — escribe/lee el estado del bot Telegram.
+//
+// El listener actualiza este archivo en cada poll: ok cuando Telegram responde
+// 200, error con descripcion cuando hay 401/403/etc. El dashboard lee este
+// archivo y muestra el fallo en /ops para que un token revocado o secrets
+// faltantes sean visibles inmediatamente, no silenciosos.
+// =============================================================================
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+function healthFile(pipelineDir) {
+    return path.join(pipelineDir, 'telegram-health.json');
+}
+
+function writeHealth(pipelineDir, payload) {
+    try {
+        const file = healthFile(pipelineDir);
+        const data = { ...payload, updatedAt: new Date().toISOString() };
+        fs.writeFileSync(file, JSON.stringify(data, null, 2));
+    } catch {}
+}
+
+function readHealth(pipelineDir) {
+    try {
+        return JSON.parse(fs.readFileSync(healthFile(pipelineDir), 'utf8'));
+    } catch { return null; }
+}
+
+function markOk(pipelineDir, extras = {}) {
+    writeHealth(pipelineDir, { ok: true, lastError: null, ...extras });
+}
+
+function markError(pipelineDir, { code, description, source }) {
+    writeHealth(pipelineDir, {
+        ok: false,
+        lastError: { code: code || null, description: description || 'unknown', source: source || null },
+    });
+}
+
+module.exports = { writeHealth, readHealth, markOk, markError, healthFile };

--- a/.pipeline/lib/telegram-secrets.js
+++ b/.pipeline/lib/telegram-secrets.js
@@ -1,0 +1,71 @@
+// =============================================================================
+// telegram-secrets.js — fuente unica de bot_token y chat_id.
+//
+// Prioridad de carga:
+//   1) ENV: TELEGRAM_BOT_TOKEN + TELEGRAM_CHAT_ID
+//   2) ~/.claude/secrets/telegram-config.json   (FUERA del repo, recomendado)
+//   3) <repo>/.claude/hooks/telegram-config.json (legacy, fallback con warning)
+//
+// El path (2) es inmune a checkouts/pulls del repo y nunca se sube a github
+// porque vive en el home del usuario. Es la ubicacion oficial post-intrusion.
+// =============================================================================
+
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const HOME_SECRETS = path.join(os.homedir(), '.claude', 'secrets', 'telegram-config.json');
+
+function tryRead(file) {
+    try { return JSON.parse(fs.readFileSync(file, 'utf8')); }
+    catch { return null; }
+}
+
+function isLikelyToken(s) {
+    return typeof s === 'string' && /^\d{6,}:[A-Za-z0-9_-]{20,}$/.test(s);
+}
+
+function looksLikePlaceholder(s) {
+    if (!s) return true;
+    return /(REVOKED|PLACEHOLDER|MOVED|EXAMPLE|REPLACE|CHANGE_ME)/i.test(s);
+}
+
+/**
+ * Devuelve { bot_token, chat_id, source }.
+ * Lanza Error si no encuentra credenciales validas en ninguna fuente.
+ */
+function loadTelegramSecrets({ legacyConfigPath, log } = {}) {
+    const logger = typeof log === 'function' ? log : () => {};
+
+    // 1) ENV
+    if (isLikelyToken(process.env.TELEGRAM_BOT_TOKEN) && process.env.TELEGRAM_CHAT_ID) {
+        return {
+            bot_token: process.env.TELEGRAM_BOT_TOKEN,
+            chat_id: String(process.env.TELEGRAM_CHAT_ID),
+            source: 'env',
+        };
+    }
+
+    // 2) Home secrets (oficial)
+    const home = tryRead(HOME_SECRETS);
+    if (home && isLikelyToken(home.bot_token) && home.chat_id) {
+        return { bot_token: home.bot_token, chat_id: String(home.chat_id), source: 'home' };
+    }
+
+    // 3) Legacy fallback
+    if (legacyConfigPath) {
+        const legacy = tryRead(legacyConfigPath);
+        if (legacy && isLikelyToken(legacy.bot_token) && !looksLikePlaceholder(legacy.bot_token)) {
+            logger(`[secrets] WARNING: bot_token leido del archivo committed (${legacyConfigPath}). Mover a ${HOME_SECRETS}.`);
+            return { bot_token: legacy.bot_token, chat_id: String(legacy.chat_id), source: 'legacy' };
+        }
+    }
+
+    const err = new Error(`No se encontraron credenciales Telegram. Crear ${HOME_SECRETS} con {bot_token, chat_id} o setear ENV TELEGRAM_BOT_TOKEN+TELEGRAM_CHAT_ID.`);
+    err.code = 'TELEGRAM_SECRETS_MISSING';
+    throw err;
+}
+
+module.exports = { loadTelegramSecrets, HOME_SECRETS };

--- a/.pipeline/listener-telegram.js
+++ b/.pipeline/listener-telegram.js
@@ -13,23 +13,28 @@ const COMMANDER_QUEUE = path.join(PIPELINE, 'servicios', 'commander', 'pendiente
 const HISTORY_FILE = path.join(PIPELINE, 'commander-history.jsonl');
 const OFFSET_FILE = path.join(PIPELINE, 'listener-offset.json');
 
-// Leer config de Telegram
+// Secrets fuera del repo (ver lib/telegram-secrets.js)
 const MAIN_ROOT = process.env.PIPELINE_MAIN_ROOT || path.resolve(__dirname, '..');
 const TELEGRAM_CONFIG = path.join(MAIN_ROOT, '.claude', 'hooks', 'telegram-config.json');
-let BOT_TOKEN, CHAT_ID;
-
-try {
-  const config = JSON.parse(fs.readFileSync(TELEGRAM_CONFIG, 'utf8'));
-  BOT_TOKEN = config.bot_token;
-  CHAT_ID = config.chat_id;
-} catch (e) {
-  console.error('Error leyendo telegram-config.json:', e.message);
-  process.exit(1);
-}
+const { loadTelegramSecrets } = require('./lib/telegram-secrets');
+const health = require('./lib/telegram-health');
 
 function log(msg) {
   const ts = new Date().toISOString().replace('T', ' ').slice(0, 19);
   console.log(`[${ts}] [listener] ${msg}`);
+}
+
+let BOT_TOKEN, CHAT_ID, SECRETS_SOURCE;
+try {
+  const sec = loadTelegramSecrets({ legacyConfigPath: TELEGRAM_CONFIG, log });
+  BOT_TOKEN = sec.bot_token;
+  CHAT_ID = sec.chat_id;
+  SECRETS_SOURCE = sec.source;
+  log(`Secrets cargados desde: ${SECRETS_SOURCE}`);
+} catch (e) {
+  console.error('FATAL: ' + e.message);
+  health.markError(PIPELINE, { code: e.code || 'NO_SECRETS', description: e.message, source: 'startup' });
+  process.exit(1);
 }
 
 // --- Offset persistence ---
@@ -198,8 +203,27 @@ async function pollLoop() {
   log(`Listener iniciado — offset: ${offset}`);
   log(`Chat ID: ${CHAT_ID}`);
 
+  // Probe inicial: getMe valida que el token siga siendo aceptado por Telegram.
+  // Si no, marcamos health=error con descripcion para que /ops lo muestre y
+  // hacemos backoff hasta que el operador rote el token (no spammear la API).
+  try {
+    const me = await telegramRequest('getMe', {});
+    if (!me.ok) {
+      const desc = me.description || 'unknown';
+      log(`Telegram getMe RECHAZADO (${me.error_code || '-'}): ${desc}`);
+      health.markError(PIPELINE, { code: me.error_code, description: desc, source: 'getMe' });
+    } else {
+      log(`Bot OK: @${me.result?.username} id=${me.result?.id}`);
+      health.markOk(PIPELINE, { bot: me.result?.username, source: SECRETS_SOURCE });
+    }
+  } catch (e) { log(`Error en getMe inicial: ${e.message}`); }
+
   await sendMessage('🐙 *Pipeline V2* — Listener activo');
   try { require('./lib/ready-marker').signalReady('listener', { offset }); } catch {}
+
+  // Backoff exponencial cuando Telegram rechaza el token: empieza 5s, hasta 5min.
+  let backoffMs = 0;
+  let lastErrCode = null;
 
   while (true) {
     try {
@@ -209,21 +233,41 @@ async function pollLoop() {
         allowed_updates: ['message']
       });
 
-      if (result.ok && result.result?.length > 0) {
-        for (const update of result.result) {
-          try {
-            await enqueueMessage(update);
-          } catch (e) {
-            log(`Error procesando update ${update.update_id}: ${e.message}`);
+      if (result.ok) {
+        if (backoffMs > 0) log(`Telegram OK de nuevo, reseteo backoff`);
+        backoffMs = 0;
+        lastErrCode = null;
+        health.markOk(PIPELINE, { bot: 'reachable', source: SECRETS_SOURCE });
+        if (result.result?.length > 0) {
+          for (const update of result.result) {
+            try {
+              await enqueueMessage(update);
+            } catch (e) {
+              log(`Error procesando update ${update.update_id}: ${e.message}`);
+            }
+            offset = update.update_id + 1;
           }
-          offset = update.update_id + 1;
+          saveOffset(offset);
+          log(`Procesados ${result.result.length} update(s), offset → ${offset}`);
         }
-        saveOffset(offset);
-        log(`Procesados ${result.result.length} update(s), offset → ${offset}`);
+      } else {
+        // Telegram respondio JSON con ok:false → token rechazado o config invalido.
+        // El bug previo era ignorar este path silenciosamente y spammear la API.
+        const desc = result.description || 'unknown';
+        const code = result.error_code || null;
+        if (code !== lastErrCode) {
+          log(`Telegram API RECHAZA getUpdates (${code || '-'}): ${desc}`);
+          lastErrCode = code;
+        }
+        health.markError(PIPELINE, { code, description: desc, source: 'getUpdates' });
+        backoffMs = Math.min(Math.max(backoffMs * 2, 5000), 5 * 60 * 1000);
+        await new Promise(r => setTimeout(r, backoffMs));
       }
     } catch (e) {
       log(`Error en polling: ${e.message}`);
-      await new Promise(r => setTimeout(r, 5000));
+      health.markError(PIPELINE, { code: 'NETWORK', description: e.message, source: 'getUpdates' });
+      backoffMs = Math.min(Math.max(backoffMs * 2, 5000), 5 * 60 * 1000);
+      await new Promise(r => setTimeout(r, backoffMs));
     }
   }
 }

--- a/.pipeline/multimedia.js
+++ b/.pipeline/multimedia.js
@@ -10,10 +10,20 @@ const { spawn } = require('child_process');
 
 const ROOT = process.env.PIPELINE_MAIN_ROOT || path.resolve(__dirname, '..');
 const TG_CONFIG_PATH = path.join(ROOT, '.claude', 'hooks', 'telegram-config.json');
+const { loadTelegramSecrets } = require('./lib/telegram-secrets');
 
+// Merge: el archivo committed conserva configs no-secretas (elevenlabs key,
+// openai key, etc.); los secrets criticos (bot_token, chat_id) vienen del
+// helper que prioriza ~/.claude/secrets/.
 function loadConfig() {
-  try { return JSON.parse(fs.readFileSync(TG_CONFIG_PATH, 'utf8')); }
-  catch { return {}; }
+  let base = {};
+  try { base = JSON.parse(fs.readFileSync(TG_CONFIG_PATH, 'utf8')); } catch {}
+  try {
+    const sec = loadTelegramSecrets({ legacyConfigPath: TG_CONFIG_PATH });
+    base.bot_token = sec.bot_token;
+    base.chat_id = sec.chat_id;
+  } catch {}
+  return base;
 }
 
 function log(msg) {

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -6619,17 +6619,17 @@ function sendTelegram(text) {
   }
 }
 
-function getTelegramToken() {
+function _loadTgSecrets() {
   try {
-    return JSON.parse(fs.readFileSync(path.join(ROOT, '.claude', 'hooks', 'telegram-config.json'), 'utf8')).bot_token;
-  } catch { return ''; }
+    const { loadTelegramSecrets } = require('./lib/telegram-secrets');
+    return loadTelegramSecrets({
+      legacyConfigPath: path.join(ROOT, '.claude', 'hooks', 'telegram-config.json'),
+    });
+  } catch { return null; }
 }
 
-function getTelegramChatId() {
-  try {
-    return JSON.parse(fs.readFileSync(path.join(ROOT, '.claude', 'hooks', 'telegram-config.json'), 'utf8')).chat_id;
-  } catch { return ''; }
-}
+function getTelegramToken() { return _loadTgSecrets()?.bot_token || ''; }
+function getTelegramChatId() { return _loadTgSecrets()?.chat_id || ''; }
 
 // =============================================================================
 // BRAZO 4: INTAKE — Lee issues de GitHub y los mete al pipeline

--- a/.pipeline/rejection-report.js
+++ b/.pipeline/rejection-report.js
@@ -1539,7 +1539,14 @@ async function sendReport(data) {
   try {
     const { textToSpeech, sendVoiceTelegram } = require('./multimedia');
     const TG_CONFIG = path.join(ROOT, '.claude', 'hooks', 'telegram-config.json');
-    const tgConfig = JSON.parse(fs.readFileSync(TG_CONFIG, 'utf8'));
+    let tgConfig = {};
+    try { tgConfig = JSON.parse(fs.readFileSync(TG_CONFIG, 'utf8')); } catch {}
+    try {
+      const { loadTelegramSecrets } = require('./lib/telegram-secrets');
+      const sec = loadTelegramSecrets({ legacyConfigPath: TG_CONFIG });
+      tgConfig.bot_token = sec.bot_token;
+      tgConfig.chat_id = sec.chat_id;
+    } catch {}
 
     const narration = generateNarration(data);
     console.log(`[rejection-report] Generando audio TTS (${narration.length} chars)...`);

--- a/.pipeline/servicio-telegram.js
+++ b/.pipeline/servicio-telegram.js
@@ -32,20 +32,24 @@ const LISTO = path.join(QUEUE_DIR, 'listo');
 
 const MAIN_ROOT = process.env.PIPELINE_MAIN_ROOT || path.resolve(__dirname, '..');
 const TELEGRAM_CONFIG = path.join(MAIN_ROOT, '.claude', 'hooks', 'telegram-config.json');
-let BOT_TOKEN, CHAT_ID;
-
-try {
-  const config = JSON.parse(fs.readFileSync(TELEGRAM_CONFIG, 'utf8'));
-  BOT_TOKEN = config.bot_token;
-  CHAT_ID = config.chat_id;
-} catch (e) {
-  console.error('Error leyendo telegram-config.json:', e.message);
-  process.exit(1);
-}
+const { loadTelegramSecrets } = require('./lib/telegram-secrets');
+const health = require('./lib/telegram-health');
 
 function log(msg) {
   const ts = new Date().toISOString().replace('T', ' ').slice(0, 19);
   console.log(`[${ts}] [svc-telegram] ${msg}`);
+}
+
+let BOT_TOKEN, CHAT_ID;
+try {
+  const sec = loadTelegramSecrets({ legacyConfigPath: TELEGRAM_CONFIG, log });
+  BOT_TOKEN = sec.bot_token;
+  CHAT_ID = sec.chat_id;
+  log(`Secrets cargados desde: ${sec.source}`);
+} catch (e) {
+  console.error('FATAL: ' + e.message);
+  health.markError(PIPELINE, { code: e.code || 'NO_SECRETS', description: e.message, source: 'startup' });
+  process.exit(1);
 }
 
 // Tag fijo para logs del http-client — permite filtrar denials del servicio.

--- a/.pipeline/views/dashboard/satellites.js
+++ b/.pipeline/views/dashboard/satellites.js
@@ -652,6 +652,7 @@ for(const p of POLLS){ setInterval(() => { p.fn().catch(()=>{}); }, p.ms); }`;
 // ─────────────────── Ops ───────────────────
 function renderOps() {
     const body = `
+<div id="ops-tg-banner" class="ops-banner-hidden"></div>
 <section class="in-section">
   <h2 class="in-section-title"><span class="in-section-title-icon">🛠</span>Procesos del pipeline</h2>
   <div id="ops-procesos" class="ops-grid"></div>
@@ -665,14 +666,19 @@ function renderOps() {
 .ops-card { background: var(--in-bg-3); padding: 12px 14px; border-radius: var(--in-radius-sm); border: 1px solid var(--in-border); display: flex; flex-direction: column; gap: 4px; }
 .ops-card.alive { border-color: var(--in-ok); }
 .ops-card.dead { border-color: var(--in-bad); opacity: 0.7; }
+.ops-card.bot-down { border-color: var(--in-bad); background: var(--in-bad-soft); }
 .ops-card-name { font-weight: 600; }
 .ops-card-meta { font-size: 11px; color: var(--in-fg-dim); font-family: var(--in-mono); }
+.ops-card-error { font-size: 11px; color: var(--in-bad); font-weight: 600; margin-top: 2px; }
 .ops-queues { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 6px; }
 .ops-queue-group { display: flex; align-items: center; gap: 3px; padding: 2px 6px; border-radius: 999px; background: var(--in-bg-2); border: 1px solid var(--in-border); font-size: 10px; font-family: var(--in-mono); font-variant-numeric: tabular-nums; }
 .ops-queue-group .ops-queue-name { color: var(--in-fg-dim); margin-right: 2px; font-weight: 600; text-transform: lowercase; }
 .ops-chip { display: inline-flex; align-items: center; gap: 2px; padding: 0 4px; border-radius: 6px; color: var(--in-fg-dim); }
 .ops-chip.hot { color: var(--in-warn); font-weight: 600; }
 .ops-chip.work { color: var(--in-info); font-weight: 600; }
+.ops-banner-hidden { display: none; }
+.ops-banner { display: block; padding: 12px 16px; margin-bottom: 14px; border-radius: var(--in-radius-sm); border: 1px solid var(--in-bad); background: var(--in-bad-soft); color: var(--in-bad); font-weight: 600; }
+.ops-banner-sub { font-weight: 400; font-size: 12px; color: var(--in-fg-dim); margin-top: 4px; font-family: var(--in-mono); }
 .ops-pre { background: var(--in-bg-3); padding: 14px; border-radius: var(--in-radius-sm); font-family: var(--in-mono); font-size: 11px; overflow: auto; max-height: 280px; border: 1px solid var(--in-border); }`;
     const script = `
 const PROC_QUEUES = {
@@ -705,18 +711,47 @@ function queuesHTML(name, servicios){
     html += '</div>';
     return html;
 }
+const TG_PROCS = new Set(['listener', 'svc-telegram']);
 async function tickOps(){
     const d = await fetchJson('/api/dash/ops');
     if(!d) return;
+    const tgHealth = d.telegramHealth;
+    const tgDown = tgHealth && tgHealth.ok === false;
+
+    const banner = document.getElementById('ops-tg-banner');
+    if(banner){
+        if(tgDown){
+            const err = tgHealth.lastError || {};
+            const desc = (err.description || 'sin detalle').slice(0, 200);
+            const code = err.code || '—';
+            const src = err.source || '—';
+            const upd = tgHealth.updatedAt ? new Date(tgHealth.updatedAt).toLocaleString('es-AR') : '—';
+            const html = '<div class="ops-banner">⚠ Bot de Telegram caído'
+                + '<div class="ops-banner-sub">'+escapeHtml(desc)+' · code='+escapeHtml(String(code))+' · origen='+escapeHtml(String(src))+' · actualizado '+escapeHtml(upd)+'</div>'
+                + '<div class="ops-banner-sub">Acción: rotar token con BotFather y guardarlo en ~/.claude/secrets/telegram-config.json (fuera del repo). Reiniciar listener.</div>'
+                + '</div>';
+            if(banner.innerHTML !== html){ banner.className = ''; banner.innerHTML = html; }
+        } else if(banner.className !== 'ops-banner-hidden'){
+            banner.className = 'ops-banner-hidden';
+            banner.innerHTML = '';
+        }
+    }
+
     const grid = document.getElementById('ops-procesos');
     if(grid){
         let html = '';
         for(const [name, p] of Object.entries(d.procesos || {})){
-            const cls = p.alive ? 'alive' : 'dead';
+            const isTg = TG_PROCS.has(name);
+            let cls = p.alive ? 'alive' : 'dead';
+            if(isTg && tgDown) cls = (p.alive ? 'alive ' : 'dead ') + 'bot-down';
+            const errLine = (isTg && tgDown)
+                ? '<div class="ops-card-error">⚠ '+escapeHtml((tgHealth.lastError||{}).description || 'API rechazada').slice(0, 80)+'</div>'
+                : '';
             html += '<div class="ops-card '+cls+'">'
                 + '<div class="ops-card-name">'+(p.alive?'\u{1F7E2}':'\u{1F534}')+' '+escapeHtml(name)+'</div>'
                 + '<div class="ops-card-meta">PID '+(p.pid||'—')+'</div>'
                 + '<div class="ops-card-meta">uptime '+fmtDur(p.uptime||0)+'</div>'
+                + errLine
                 + queuesHTML(name, d.servicios)
                 + '</div>';
         }
@@ -724,7 +759,7 @@ async function tickOps(){
     }
     const pre = document.getElementById('ops-qaenv');
     if(pre){
-        const txt = JSON.stringify({ qaEnv: d.qaEnv, qaRemote: d.qaRemote, infraHealth: d.infraHealth }, null, 2);
+        const txt = JSON.stringify({ qaEnv: d.qaEnv, qaRemote: d.qaRemote, infraHealth: d.infraHealth, telegramHealth: d.telegramHealth }, null, 2);
         if(pre.textContent !== txt) pre.textContent = txt;
     }
 }


### PR DESCRIPTION
## Contexto

Tras una intrusión el token del bot fue rotado. El archivo \`.claude/hooks/telegram-config.json\` está committed al repo, así que GitHub secret-scanning notifica a Telegram y este revoca el token. Cualquier \`git checkout\`/\`pull\` repone el token revocado al disco. Encima el listener silenciaba 401/Unauthorized en \`pollLoop()\` y spammeaba la API en un bucle apretado, **sin alerta visible** de que el bot estaba caído.

## Cambios

1. **\`lib/telegram-secrets.js\`** — fuente única de \`bot_token\`+\`chat_id\` con prioridad:
   - \`ENV\` (\`TELEGRAM_BOT_TOKEN\`+\`TELEGRAM_CHAT_ID\`)
   - \`~/.claude/secrets/telegram-config.json\` ← **ubicación oficial** (home del usuario, fuera del repo, inmune a checkouts)
   - archivo committed (legacy, con warning)

2. **\`lib/telegram-health.js\`** — el listener escribe \`.pipeline/telegram-health.json\` en cada poll: \`ok\` cuando Telegram responde 200, error con \`{code, description, source}\` cuando rechaza.

3. **\`listener-telegram.js\`** — probe inicial \`getMe\`; manejo del path \`ok:false\` antes ignorado; backoff exponencial 5s → 5min cuando Telegram rechaza, en lugar del bucle apretado.

4. **Migración al helper** en \`multimedia.js\`, \`pulpo.js\`, \`servicio-telegram.js\`, \`rejection-report.js\` — no quedan lecturas crudas del archivo committed.

5. **\`opsSlice\` expone \`telegramHealth\`**. En \`/ops\`:
   - **banner rojo** arriba con descripción+code+timestamp+acción correctiva cuando \`ok=false\`
   - cards \`listener\` y \`svc-telegram\` con borde rojo y línea de error
   - \`telegramHealth\` también en el JSON debug

6. \`bot_token\` y \`chat_id\` en el archivo committed → placeholder \`MOVED_TO_HOME_DOT_CLAUDE_SECRETS\`. (El token real previo ya estaba revocado por Telegram.)

7. \`.gitignore\` agrega \`.claude/secrets/\` y \`secrets.json\` como defensa en profundidad.

## Labels

- \`qa:skipped\` — security/infra del pipeline interno, sin impacto en app de usuario
- \`area:dashboard\` · \`area:infra\` · \`tipo:security\`

## Test plan

- [ ] Reiniciar listener y svc-telegram
- [ ] Verificar log: \`Secrets cargados desde: home\`
- [ ] Verificar log: \`Bot OK: @<username>\`
- [ ] Enviar un mensaje al bot — debe encolarse en \`commander/pendiente/\`
- [ ] Forzar fallo borrando temporalmente \`~/.claude/secrets/telegram-config.json\` o reescribiendo el token con uno inválido — verificar banner rojo en \`/ops\` y backoff en logs
- [ ] Restaurar y verificar que el banner desaparece

🤖 Generated with [Claude Code](https://claude.com/claude-code)