### PR TITLE
fix(pipeline): TTS roto — helper expone API keys del home secrets

### DIFF
--- a/.pipeline/lib/telegram-secrets.js
+++ b/.pipeline/lib/telegram-secrets.js
@@ -1,13 +1,18 @@
 // =============================================================================
-// telegram-secrets.js — fuente unica de bot_token y chat_id.
+// telegram-secrets.js — fuente unica de credenciales del bot Telegram + claves
+// API (OpenAI, Anthropic, ElevenLabs) usadas por TTS/STT/Vision en multimedia.
 //
 // Prioridad de carga:
-//   1) ENV: TELEGRAM_BOT_TOKEN + TELEGRAM_CHAT_ID
+//   1) ENV: TELEGRAM_BOT_TOKEN + TELEGRAM_CHAT_ID  (+ OPENAI_API_KEY etc.)
 //   2) ~/.claude/secrets/telegram-config.json   (FUERA del repo, recomendado)
 //   3) <repo>/.claude/hooks/telegram-config.json (legacy, fallback con warning)
 //
 // El path (2) es inmune a checkouts/pulls del repo y nunca se sube a github
 // porque vive en el home del usuario. Es la ubicacion oficial post-intrusion.
+//
+// loadTelegramSecrets()  -> {bot_token, chat_id, source}        (criticos, throw si faltan)
+// loadApiKeys()          -> {openai_api_key, anthropic_api_key,
+//                           elevenlabs_api_key, elevenlabs_voice_id}  (best-effort, vacio si falta)
 // =============================================================================
 
 'use strict';
@@ -30,6 +35,13 @@ function isLikelyToken(s) {
 function looksLikePlaceholder(s) {
     if (!s) return true;
     return /(REVOKED|PLACEHOLDER|MOVED|EXAMPLE|REPLACE|CHANGE_ME)/i.test(s);
+}
+
+function pickKey(value) {
+    if (typeof value !== 'string') return '';
+    if (!value.trim()) return '';
+    if (looksLikePlaceholder(value)) return '';
+    return value;
 }
 
 /**
@@ -68,4 +80,35 @@ function loadTelegramSecrets({ legacyConfigPath, log } = {}) {
     throw err;
 }
 
-module.exports = { loadTelegramSecrets, HOME_SECRETS };
+/**
+ * Devuelve las API keys de proveedores externos (TTS/STT/Vision).
+ * Best-effort: nunca lanza, retorna strings vacios para keys faltantes.
+ * Prioridad por key: ENV → home secrets → legacy committed config.
+ * El consumidor decide que hacer cuando una key viene vacia (multimedia
+ * loggea "falta openai_api_key" y degrada).
+ */
+function loadApiKeys({ legacyConfigPath } = {}) {
+    const home = tryRead(HOME_SECRETS) || {};
+    const legacy = legacyConfigPath ? (tryRead(legacyConfigPath) || {}) : {};
+
+    return {
+        openai_api_key:
+            pickKey(process.env.OPENAI_API_KEY) ||
+            pickKey(home.openai_api_key) ||
+            pickKey(legacy.openai_api_key),
+        anthropic_api_key:
+            pickKey(process.env.ANTHROPIC_API_KEY) ||
+            pickKey(home.anthropic_api_key) ||
+            pickKey(legacy.anthropic_api_key),
+        elevenlabs_api_key:
+            pickKey(process.env.ELEVENLABS_API_KEY) ||
+            pickKey(home.elevenlabs_api_key) ||
+            pickKey(legacy.elevenlabs_api_key),
+        elevenlabs_voice_id:
+            pickKey(process.env.ELEVENLABS_VOICE_ID) ||
+            pickKey(home.elevenlabs_voice_id) ||
+            pickKey(legacy.elevenlabs_voice_id),
+    };
+}
+
+module.exports = { loadTelegramSecrets, loadApiKeys, HOME_SECRETS };

--- a/.pipeline/multimedia.js
+++ b/.pipeline/multimedia.js
@@ -10,11 +10,14 @@ const { spawn } = require('child_process');
 
 const ROOT = process.env.PIPELINE_MAIN_ROOT || path.resolve(__dirname, '..');
 const TG_CONFIG_PATH = path.join(ROOT, '.claude', 'hooks', 'telegram-config.json');
-const { loadTelegramSecrets } = require('./lib/telegram-secrets');
+const { loadTelegramSecrets, loadApiKeys } = require('./lib/telegram-secrets');
 
-// Merge: el archivo committed conserva configs no-secretas (elevenlabs key,
-// openai key, etc.); los secrets criticos (bot_token, chat_id) vienen del
-// helper que prioriza ~/.claude/secrets/.
+// Merge en 3 capas para que TTS/STT/Vision nunca se rompa por la migracion
+// del archivo committed a placeholders:
+//   - base = archivo committed (configs no-secretas: voice_id, retries, etc.)
+//   - bot_token + chat_id desde el helper de secrets criticos (home preferido)
+//   - api keys (OpenAI/Anthropic/ElevenLabs) desde loadApiKeys (ENV → home → legacy)
+// Cualquier valor del home pisa el placeholder vacio del archivo committed.
 function loadConfig() {
   let base = {};
   try { base = JSON.parse(fs.readFileSync(TG_CONFIG_PATH, 'utf8')); } catch {}
@@ -23,6 +26,11 @@ function loadConfig() {
     base.bot_token = sec.bot_token;
     base.chat_id = sec.chat_id;
   } catch {}
+  const keys = loadApiKeys({ legacyConfigPath: TG_CONFIG_PATH });
+  if (keys.openai_api_key) base.openai_api_key = keys.openai_api_key;
+  if (keys.anthropic_api_key) base.anthropic_api_key = keys.anthropic_api_key;
+  if (keys.elevenlabs_api_key) base.elevenlabs_api_key = keys.elevenlabs_api_key;
+  if (keys.elevenlabs_voice_id) base.elevenlabs_voice_id = keys.elevenlabs_voice_id;
   return base;
 }
 


### PR DESCRIPTION
## Bug

Tras el PR #2859 (mover bot_token+chat_id a \`~/.claude/secrets/\` y dejar placeholders en el archivo committed), las **API keys** (\`openai_api_key\`, \`anthropic_api_key\`, \`elevenlabs_api_key\`) que \`multimedia.js\` lee del config quedaron en string vacío. El TTS de los rejection reports y el STT de mensajes de voz fallaban con \`"falta openai_api_key"\` porque el merge anterior solo sobrescribía \`bot_token\`+\`chat_id\`.

## Fix

- **\`lib/telegram-secrets.js\`**: nueva función \`loadApiKeys()\` devuelve \`{openai_api_key, anthropic_api_key, elevenlabs_api_key, elevenlabs_voice_id}\` con prioridad ENV → home → legacy. Best-effort, nunca lanza, retorna strings vacíos si la key falta.

- **\`multimedia.js loadConfig()\`** ahora hace 3-way merge: archivo committed (configs no-secretas) + \`loadTelegramSecrets()\` (bot_token+chat_id) + \`loadApiKeys()\` (API keys). El home pisa cualquier placeholder.

## Verificación

\`\`\`
$ node -e "const {loadApiKeys}=require('./.pipeline/lib/telegram-secrets'); console.log(loadApiKeys({legacyConfigPath:'.claude/hooks/telegram-config.json'}))"
{
  openai_api_key: 'sk-proj-Cn...4KcA',     ← desde ~/.claude/secrets/
  anthropic_api_key: '',                    ← no configurado, degrada
  elevenlabs_api_key: '',                   ← no configurado, degrada
  elevenlabs_voice_id: 'pNInz6obpgDQGcFmaJgB'  ← legacy, no es secreto
}
\`\`\`

## Labels

- \`qa:skipped\` — fix urgente de regresión introducida por #2859
- \`area:dashboard\` · \`area:infra\` · \`tipo:fix\`

## Test plan

- [ ] Reiniciar pipeline (pulpo + listener + svc-telegram)
- [ ] Disparar un rejection report (o cualquier flujo que use TTS)
- [ ] Verificar que el audio TTS llega a Telegram con voz natural
- [ ] Probar mensaje de voz al bot → debe transcribir vía OpenAI

🤖 Generated with [Claude Code](https://claude.com/claude-code)