### PR TITLE
fix(pipeline): whisper local default model + mensaje de fallo preciso

### DIFF
--- a/.pipeline/lib/whisper-local.js
+++ b/.pipeline/lib/whisper-local.js
@@ -12,10 +12,12 @@ const path = require('path');
 const crypto = require('crypto');
 const { spawn } = require('child_process');
 
-// Modelo por defecto: large-v3-turbo — calidad casi igual a large-v3 pero ~5x
-// más rápido y con buen reconocimiento de español rioplatense. Se puede pisar
-// con WHISPER_LOCAL_MODEL (small/medium/large-v3-turbo/large-v3).
-const DEFAULT_MODEL = process.env.WHISPER_LOCAL_MODEL || 'large-v3-turbo';
+// Modelo por defecto: medium — balance entre calidad y memoria. El large-v3-turbo
+// pide ~6-10 GB de RAM y crashea con ACCESS_VIOLATION (exit 0xC0000005) cuando la
+// máquina ya está cargada (CPU/RAM altos + audio largo). medium usa ~5 GB y
+// transcribe español rioplatense con buena calidad. Se puede pisar con
+// WHISPER_LOCAL_MODEL (small/medium/large-v3-turbo/large-v3).
+const DEFAULT_MODEL = process.env.WHISPER_LOCAL_MODEL || 'medium';
 const DEFAULT_LANGUAGE = process.env.WHISPER_LOCAL_LANGUAGE || 'Spanish';
 const DEFAULT_THREADS = Number(process.env.WHISPER_LOCAL_THREADS || 4);
 const DEFAULT_TIMEOUT_MS = Number(process.env.WHISPER_LOCAL_TIMEOUT_MS || 300000); // 5 min

--- a/.pipeline/multimedia.js
+++ b/.pipeline/multimedia.js
@@ -178,7 +178,22 @@ async function transcribeAudioWithFallback(audioBuffer, audioPath, filename) {
 
 // Mensaje human-friendly que va a Telegram cuando whisper no pudo transcribir.
 // Es lo que va a leer Leo, así que tiene que ser breve y accionable.
-function transcriptionFailureMessage(errorKind) {
+// Cuando ambos engines (API + local) fallan, el mensaje refleja eso —
+// no podemos echarle la culpa solo a la cuota de OpenAI si el local crasheó.
+function transcriptionFailureMessage(errorKind, localErrorKind = null) {
+  if (localErrorKind) {
+    const apiPart = errorKind === 'quota' ? 'cuota OpenAI agotada'
+                  : errorKind === 'auth'  ? 'key OpenAI inválida'
+                  : errorKind === 'rate_limit' ? 'rate-limit OpenAI'
+                  : errorKind === 'network' ? 'no llegué a OpenAI'
+                  : errorKind === 'timeout' ? 'timeout OpenAI'
+                  : `OpenAI ${errorKind}`;
+    const localHint = localErrorKind === 'cli_error' ? 'crasheó (probable OOM con audio largo)'
+                    : localErrorKind === 'timeout'  ? 'tardó demasiado'
+                    : localErrorKind === 'no_binary' ? 'no está instalado'
+                    : `falló (${localErrorKind})`;
+    return `🎤 Audio recibido. Falló API (${apiPart}) y también whisper local — ${localHint}. Repetímelo por texto cuando puedas. Si el local sigue crasheando: bajar \`WHISPER_LOCAL_MODEL\` a \`small\` o reiniciar la máquina.`;
+  }
   switch (errorKind) {
     case 'no_key':     return '🎤 Audio recibido. No tengo `openai_api_key` cargada — repetímelo por texto cuando puedas.';
     case 'quota':      return '🎤 Audio recibido. La cuota de OpenAI está agotada (Whisper no responde) — repetímelo por texto cuando puedas. Para volver a habilitar la transcripción: subir cuota o rotar la key en `~/.claude/secrets/telegram-config.json`.';
@@ -280,7 +295,7 @@ async function preprocessMessage(msg, botToken) {
         log(`Transcripcion FALLO (${tx.errorKind}): ${tx.raw}${tx.localErrorKind ? ` | local=${tx.localErrorKind}: ${tx.localRaw}` : ''}`);
         // No metemos el error como texto del mensaje — el caller decide qué hacer.
         result.text = '';
-        result.audio = { ok: false, errorKind: tx.errorKind, raw: tx.raw, fallbackMessage: transcriptionFailureMessage(tx.errorKind) };
+        result.audio = { ok: false, errorKind: tx.errorKind, raw: tx.raw, localErrorKind: tx.localErrorKind || null, fallbackMessage: transcriptionFailureMessage(tx.errorKind, tx.localErrorKind || null) };
         result.extras.push(`(audio sin transcribir: ${tx.errorKind})`);
       }
     } else {


### PR DESCRIPTION
## Resumen

- Cambiar DEFAULT_MODEL de `large-v3-turbo` a `medium` (~5GB en lugar de ~10GB)
  para evitar ACCESS_VIOLATION (exit 0xC0000005) cuando máquina está cargada
  (CPU/RAM altos + audio largo). El modelo `medium` transcribe español con buena calidad.

- `transcriptionFailureMessage()` ahora acepta `localErrorKind`: cuando ambos engines
  (API + local) fallan, el mensaje refleja eso en lugar de echarle la culpa solo a "cuota OpenAI".
  Hint accionable: bajar a `WHISPER_LOCAL_MODEL=small` o reiniciar la máquina.

## Contexto

Usuario reportaba mensaje "La cuota de OpenAI está agotada" cuando el problema real fue crash
del whisper local por OOM con audio de 749 KB. El modelo `large-v3-turbo` pide ~6-10 GB de RAM,
pero con CPU/RAM ya cargados (59% RAM, 86% CPU) no alcanza la memoria disponible.

## Testing

- Cambio es infra/operativo sin impacto visible en producto
- No requiere QA E2E
- Scripts de pipeline: sin tests automáticos

🤖 Generado con [Claude Code](https://claude.ai/claude-code)