### PR TITLE
refactor(delivery): /delivery a script determinístico — primeros 2 módulos

### DIFF
--- a/.pipeline/lib/__tests__/change-classifier.test.js
+++ b/.pipeline/lib/__tests__/change-classifier.test.js
@@ -1,0 +1,182 @@
+// =============================================================================
+// Tests change-classifier.js — refactor de /delivery (#2870)
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+    classify,
+    parseConventionalType,
+    isTestFile,
+    isDocFile,
+    isChoreFile,
+} = require('../delivery/change-classifier');
+
+// ---- Detectores de tipo de archivo -----------------------------------------
+
+test('isTestFile matchea __tests__/, *.test.js, Test.kt', () => {
+    assert.equal(isTestFile('.pipeline/lib/__tests__/foo.test.js'), true);
+    assert.equal(isTestFile('app/src/test/kotlin/FooTest.kt'), true);
+    assert.equal(isTestFile('users/src/test/UserTests.kt'), true);
+    assert.equal(isTestFile('lib/foo.spec.ts'), true);
+    assert.equal(isTestFile('app/src/main/MyService.kt'), false);
+});
+
+test('isDocFile matchea docs/, .md, README, CHANGELOG', () => {
+    assert.equal(isDocFile('docs/arquitectura.md'), true);
+    assert.equal(isDocFile('README.md'), true);
+    assert.equal(isDocFile('CHANGELOG'), true);
+    assert.equal(isDocFile('app/src/main/Foo.kt'), false);
+});
+
+test('isChoreFile matchea config/build/CI pero NO tests ni docs', () => {
+    assert.equal(isChoreFile('.github/workflows/ci.yml'), true);
+    assert.equal(isChoreFile('.gitignore'), true);
+    assert.equal(isChoreFile('build.gradle.kts'), true);
+    assert.equal(isChoreFile('package.json'), true);
+    assert.equal(isChoreFile('.claude/skills/foo/SKILL.md'), true);
+    // No clasificar como chore si es test o doc (precedencia)
+    assert.equal(isChoreFile('docs/README.md'), false);
+    assert.equal(isChoreFile('lib/__tests__/foo.test.js'), false);
+});
+
+// ---- parseConventionalType --------------------------------------------------
+
+test('parseConventionalType extrae el tipo de subjects válidos', () => {
+    assert.equal(parseConventionalType('feat: nueva cosa'), 'feat');
+    assert.equal(parseConventionalType('fix(api): bug X'), 'fix');
+    assert.equal(parseConventionalType('refactor(scope): blah'), 'refactor');
+    assert.equal(parseConventionalType('test: agregar tests'), 'test');
+    assert.equal(parseConventionalType('docs(readme): update'), 'docs');
+    assert.equal(parseConventionalType('chore!: breaking'), 'chore');
+});
+
+test('parseConventionalType devuelve null en subjects no convencionales', () => {
+    assert.equal(parseConventionalType('Updated something'), null);
+    assert.equal(parseConventionalType(''), null);
+    assert.equal(parseConventionalType('foo: x'), null);  // foo no es tipo válido
+    assert.equal(parseConventionalType(null), null);
+});
+
+// ---- classify ---------------------------------------------------------------
+
+test('classify devuelve test si TODOS los archivos son tests', () => {
+    const result = classify({
+        files: ['lib/__tests__/a.test.js', 'lib/__tests__/b.test.js'],
+        commits: [],
+        status: [],
+    });
+    assert.equal(result, 'test');
+});
+
+test('classify devuelve docs si TODOS los archivos son docs', () => {
+    const result = classify({
+        files: ['docs/foo.md', 'README.md'],
+        commits: [],
+        status: [],
+    });
+    assert.equal(result, 'docs');
+});
+
+test('classify devuelve chore si TODOS los archivos son chore (build/CI)', () => {
+    const result = classify({
+        files: ['.github/workflows/ci.yml', '.gitignore'],
+        commits: [],
+        status: [],
+    });
+    assert.equal(result, 'chore');
+});
+
+test('classify respeta el subject del primer commit cuando es conventional', () => {
+    // Mix de archivos prod + test, pero el commit dice "fix" → fix.
+    const result = classify({
+        files: ['app/src/main/Foo.kt', 'app/src/test/FooTest.kt'],
+        commits: [
+            { sha: 'abc', subject: 'test: agregar más tests' },          // último commit
+            { sha: 'def', subject: 'fix(api): corregir parsing' },        // primer commit
+        ],
+        status: [],
+    });
+    assert.equal(result, 'fix');
+});
+
+test('classify devuelve feat si hay archivos nuevos (status A) y no hay otra señal', () => {
+    const result = classify({
+        files: [],
+        commits: [],
+        status: [
+            { code: 'A ', path: 'app/src/main/NewService.kt' },
+        ],
+    });
+    assert.equal(result, 'feat');
+});
+
+test('classify devuelve fix si solo hay archivos modificados', () => {
+    const result = classify({
+        files: [],
+        commits: [],
+        status: [
+            { code: ' M', path: 'app/src/main/ExistingService.kt' },
+        ],
+    });
+    assert.equal(result, 'fix');
+});
+
+test('classify devuelve null si no hay señales', () => {
+    const result = classify({ files: [], commits: [], status: [] });
+    assert.equal(result, null);
+});
+
+test('classify usa override cuando se le pasa uno válido', () => {
+    const result = classify({
+        files: ['docs/foo.md'],   // sería docs
+        override: 'feat',
+    });
+    assert.equal(result, 'feat');
+});
+
+test('classify ignora override inválido', () => {
+    const result = classify({
+        files: ['docs/foo.md'],
+        override: 'banana',
+    });
+    assert.equal(result, 'docs');
+});
+
+test('classify NO confunde archivos chore con prod cuando hay test+chore mezclados', () => {
+    // Solo tests + chore: si todos son test → test gana (regla 1 antes que chore).
+    // Pero si hay test + chore mezclado, ya no son TODOS tests ni TODOS chore.
+    // El subject del commit decide, sino caemos en statusBasedType.
+    const result = classify({
+        files: ['lib/__tests__/foo.test.js', 'package.json'],
+        commits: [{ sha: 'a', subject: 'chore(deps): bump foo' }],
+        status: [],
+    });
+    assert.equal(result, 'chore');
+});
+
+test('classify para el caso real del whisper fix (PR #2866)', () => {
+    // El fix que mergeamos hoy: 2 archivos JS modificados, commit fix(pipeline): ...
+    const result = classify({
+        files: ['.pipeline/lib/whisper-local.js', '.pipeline/multimedia.js'],
+        commits: [{ sha: 'abc', subject: 'fix(pipeline): whisper local default model' }],
+        status: [],
+    });
+    assert.equal(result, 'fix');
+});
+
+test('classify para el caso real de los módulos de delivery (PR #2871)', () => {
+    // Archivos nuevos en .pipeline/lib/delivery/ y __tests__ → tests son test pattern,
+    // los .js de delivery no. El subject dice "refactor".
+    const result = classify({
+        files: [
+            '.pipeline/lib/delivery/git-context.js',
+            '.pipeline/lib/__tests__/git-context.test.js',
+        ],
+        commits: [{ sha: 'abc', subject: 'refactor(delivery): git-context determinístico' }],
+        status: [],
+    });
+    assert.equal(result, 'refactor');
+});

--- a/.pipeline/lib/__tests__/git-context.test.js
+++ b/.pipeline/lib/__tests__/git-context.test.js
@@ -1,0 +1,184 @@
+// =============================================================================
+// Tests git-context.js — refactor de /delivery (#2870)
+//
+// Crea un repo git temporal con commits sintéticos y valida que la API
+// extrae el estado correcto. Sin red, sin remote real.
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const ctx = require('../delivery/git-context');
+
+// ---- Helpers ----------------------------------------------------------------
+
+function sh(cwd, args) {
+    const r = spawnSync('git', ['-C', cwd, ...args], { encoding: 'utf8', windowsHide: true });
+    if (r.status !== 0) throw new Error(`git ${args.join(' ')} fail: ${r.stderr}`);
+    return r.stdout.trim();
+}
+
+// Setup: repo con base "main" y nuestro branch "feature" con 2 commits adelante.
+function makeRepo() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-ctx-test-'));
+    sh(dir, ['init', '-q', '-b', 'main']);
+    sh(dir, ['config', 'user.email', 'test@test.test']);
+    sh(dir, ['config', 'user.name', 'Test']);
+    sh(dir, ['config', 'commit.gpgsign', 'false']);
+
+    fs.writeFileSync(path.join(dir, 'README.md'), '# base\n');
+    sh(dir, ['add', 'README.md']);
+    sh(dir, ['commit', '-q', '-m', 'init']);
+
+    // Simular origin/main apuntando al commit base
+    sh(dir, ['update-ref', 'refs/remotes/origin/main', 'HEAD']);
+
+    sh(dir, ['checkout', '-q', '-b', 'feature']);
+
+    fs.writeFileSync(path.join(dir, 'a.js'), 'console.log("a");\n');
+    sh(dir, ['add', 'a.js']);
+    sh(dir, ['commit', '-q', '-m', 'feat: agregar a']);
+
+    fs.writeFileSync(path.join(dir, 'b.js'), 'console.log("b");\n');
+    sh(dir, ['add', 'b.js']);
+    sh(dir, ['commit', '-q', '-m', 'fix: agregar b']);
+
+    return dir;
+}
+
+function cleanup(dir) {
+    try { fs.rmSync(dir, { recursive: true, force: true, maxRetries: 3 }); } catch {}
+}
+
+// ---- Tests ------------------------------------------------------------------
+
+test('currentBranch devuelve el branch actual', () => {
+    const repo = makeRepo();
+    try {
+        assert.equal(ctx.currentBranch(repo), 'feature');
+    } finally { cleanup(repo); }
+});
+
+test('aheadCount cuenta commits adelante de origin/main', () => {
+    const repo = makeRepo();
+    try {
+        assert.equal(ctx.aheadCount(repo, 'origin/main'), 2);
+    } finally { cleanup(repo); }
+});
+
+test('behindCount es 0 cuando origin/main no avanzó', () => {
+    const repo = makeRepo();
+    try {
+        assert.equal(ctx.behindCount(repo, 'origin/main'), 0);
+    } finally { cleanup(repo); }
+});
+
+test('behindCount detecta commits nuevos en origin/main', () => {
+    const repo = makeRepo();
+    try {
+        // Avanzar origin/main con un commit "nuevo" (otra rama, copy ref)
+        sh(repo, ['checkout', '-q', 'main']);
+        fs.writeFileSync(path.join(repo, 'c.js'), 'c\n');
+        sh(repo, ['add', 'c.js']);
+        sh(repo, ['commit', '-q', '-m', 'origin advance']);
+        sh(repo, ['update-ref', 'refs/remotes/origin/main', 'HEAD']);
+        sh(repo, ['checkout', '-q', 'feature']);
+        assert.equal(ctx.behindCount(repo, 'origin/main'), 1);
+    } finally { cleanup(repo); }
+});
+
+test('commitsAhead lista commits con sha y subject', () => {
+    const repo = makeRepo();
+    try {
+        const commits = ctx.commitsAhead(repo, 'origin/main');
+        assert.equal(commits.length, 2);
+        assert.equal(commits[0].subject, 'fix: agregar b');
+        assert.equal(commits[1].subject, 'feat: agregar a');
+        for (const c of commits) {
+            assert.match(c.sha, /^[0-9a-f]{7,}$/);
+        }
+    } finally { cleanup(repo); }
+});
+
+test('filesChanged lista archivos modificados respecto a base', () => {
+    const repo = makeRepo();
+    try {
+        const files = ctx.filesChanged(repo, 'origin/main');
+        assert.deepEqual(files.sort(), ['a.js', 'b.js']);
+    } finally { cleanup(repo); }
+});
+
+test('diffStat retorna files/insertions/deletions parseados', () => {
+    const repo = makeRepo();
+    try {
+        const stat = ctx.diffStat(repo, 'origin/main');
+        assert.equal(stat.files, 2);
+        assert.ok(stat.insertions >= 2, `insertions debe ser >=2, fue ${stat.insertions}`);
+        assert.equal(stat.deletions, 0);
+    } finally { cleanup(repo); }
+});
+
+test('statusPorcelain lista archivos sin commitear', () => {
+    const repo = makeRepo();
+    try {
+        // Tree limpio al inicio
+        assert.equal(ctx.statusPorcelain(repo).length, 0);
+
+        // Crear archivo untracked
+        fs.writeFileSync(path.join(repo, 'untracked.txt'), 'x');
+        // Modificar uno tracked
+        fs.writeFileSync(path.join(repo, 'a.js'), 'modified\n');
+
+        const status = ctx.statusPorcelain(repo);
+        const paths = status.map(s => s.path).sort();
+        assert.deepEqual(paths, ['a.js', 'untracked.txt']);
+
+        const codes = Object.fromEntries(status.map(s => [s.path, s.code]));
+        assert.equal(codes['untracked.txt'], '??');
+        assert.match(codes['a.js'], /M/);
+    } finally { cleanup(repo); }
+});
+
+test('diffText incluye el contenido del diff', () => {
+    const repo = makeRepo();
+    try {
+        const diff = ctx.diffText(repo, 'origin/main');
+        assert.match(diff, /diff --git/);
+        assert.match(diff, /a\.js/);
+        assert.match(diff, /b\.js/);
+        assert.match(diff, /\+console\.log/);
+    } finally { cleanup(repo); }
+});
+
+test('diffText respeta maxBytes y agrega marcador truncated', () => {
+    const repo = makeRepo();
+    try {
+        const diff = ctx.diffText(repo, 'origin/main', 50);
+        assert.ok(diff.length <= 80, `diff truncado a ~50 bytes, fue ${diff.length}`);
+        assert.match(diff, /\[truncated\]/);
+    } finally { cleanup(repo); }
+});
+
+test('snapshot devuelve estructura agregada con todo el contexto', () => {
+    const repo = makeRepo();
+    try {
+        const snap = ctx.snapshot(repo);
+        assert.equal(snap.branch, 'feature');
+        assert.equal(snap.ahead, 2);
+        assert.equal(snap.behind, 0);
+        assert.equal(snap.commits.length, 2);
+        assert.equal(snap.files.length, 2);
+        assert.equal(snap.stat.files, 2);
+    } finally { cleanup(repo); }
+});
+
+test('git() maneja cwd inválido devolviendo ok=false sin tirar', () => {
+    const r = ctx.git(['status'], '/path/que/no/existe');
+    assert.equal(r.ok, false);
+    assert.notEqual(r.status, 0);
+});

--- a/.pipeline/lib/__tests__/worktree-cleanup.test.js
+++ b/.pipeline/lib/__tests__/worktree-cleanup.test.js
@@ -1,0 +1,236 @@
+// =============================================================================
+// Tests worktree-cleanup.js — fix #2867
+//
+// Cubre la detección de "sesión activa" que es el bug crítico que llevó a
+// que /delivery se borrara los skills a sí mismo. Los tests de junction y
+// cleanup completo son integración (requieren git/fsutil) y se hacen aparte.
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+    isActiveSession,
+    isJunction,
+    dismountClaudeJunction,
+    cleanupWorktree,
+} = require('../delivery/worktree-cleanup');
+
+// ---- Helpers ----------------------------------------------------------------
+
+function mkTempWorktree() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wt-cleanup-test-'));
+    return dir;
+}
+
+// ---- isActiveSession --------------------------------------------------------
+
+test('isActiveSession devuelve true cuando cwd === worktree', () => {
+    const wt = mkTempWorktree();
+    try {
+        assert.equal(isActiveSession(wt, wt), true);
+    } finally {
+        fs.rmSync(wt, { recursive: true, force: true });
+    }
+});
+
+test('isActiveSession devuelve true cuando cwd está dentro de worktree', () => {
+    const wt = mkTempWorktree();
+    const sub = path.join(wt, 'subdir');
+    fs.mkdirSync(sub);
+    try {
+        assert.equal(isActiveSession(wt, sub), true);
+    } finally {
+        fs.rmSync(wt, { recursive: true, force: true });
+    }
+});
+
+test('isActiveSession devuelve false cuando cwd está fuera de worktree', () => {
+    const wt = mkTempWorktree();
+    const otherDir = mkTempWorktree();
+    try {
+        assert.equal(isActiveSession(wt, otherDir), false);
+    } finally {
+        fs.rmSync(wt, { recursive: true, force: true });
+        fs.rmSync(otherDir, { recursive: true, force: true });
+    }
+});
+
+test('isActiveSession devuelve false cuando worktree no existe', () => {
+    const cwd = mkTempWorktree();
+    try {
+        assert.equal(isActiveSession('/path/que/no/existe', cwd), false);
+    } finally {
+        fs.rmSync(cwd, { recursive: true, force: true });
+    }
+});
+
+test('isActiveSession devuelve false con args faltantes', () => {
+    assert.equal(isActiveSession(null, '/some/path'), false);
+    assert.equal(isActiveSession('/some/path', null), false);
+    assert.equal(isActiveSession(null, null), false);
+    assert.equal(isActiveSession('', ''), false);
+});
+
+test('isActiveSession es case-insensitive en Windows (no falsos negativos por mayúsculas)', () => {
+    // En Windows el filesystem es case-insensitive. Si el comparador no lo
+    // contempla, paths que difieren solo en casing producirían false.
+    if (process.platform !== 'win32') return; // skip en non-Windows
+    const wt = mkTempWorktree();
+    try {
+        // Construir variantes con casing alterado del path original
+        const upper = wt.toUpperCase();
+        const lower = wt.toLowerCase();
+        // Solo testeable si realpath resuelve a lo mismo
+        try {
+            const realLower = fs.realpathSync(lower);
+            assert.equal(isActiveSession(wt, realLower), true);
+        } catch {
+            // ambiente no soporta el casing alternado; skip
+        }
+        // Mismo path con upper/lower
+        try {
+            assert.equal(isActiveSession(upper, wt), true);
+        } catch {
+            // skip
+        }
+    } finally {
+        fs.rmSync(wt, { recursive: true, force: true });
+    }
+});
+
+test('isActiveSession NO da falso positivo por prefijo de path', () => {
+    // Si un comparador hace startsWith sin tener en cuenta el separador,
+    // /foo/bar startsWith /foo/ba sería true incorrectamente.
+    const root = mkTempWorktree();
+    const wtFoo = path.join(root, 'foo');
+    const wtFooBar = path.join(root, 'foobar');
+    fs.mkdirSync(wtFoo);
+    fs.mkdirSync(wtFooBar);
+    try {
+        // cwd está en /foobar, worktree es /foo — NO debe ser activo.
+        // (Esta es la razón de comparar paths reales con realpath: en general
+        // no produce falsos positivos por casualidad, pero el comparador
+        // con startsWith plano sí. Validamos el comportamiento real.)
+        const result = isActiveSession(wtFoo, wtFooBar);
+        // El comparador actual usa startsWith pero sobre realpath normalizado.
+        // /foobar.startsWith(/foo) es true en string puro, lo cual sería un bug.
+        // Documentamos el caso: si el test falla, hay que agregar separador
+        // al final antes del startsWith.
+        assert.equal(result, false, 'Falso positivo por prefijo: comparar con separador final');
+    } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+    }
+});
+
+// ---- isJunction -------------------------------------------------------------
+
+test('isJunction devuelve false para path inexistente', () => {
+    assert.equal(isJunction('/path/que/no/existe/abcdef'), false);
+});
+
+test('isJunction devuelve false para directorio real', () => {
+    const dir = mkTempWorktree();
+    try {
+        assert.equal(isJunction(dir), false);
+    } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+// Test con junction real solo en Windows con permisos suficientes
+test('isJunction devuelve true para junction Windows', { skip: process.platform !== 'win32' }, () => {
+    const target = mkTempWorktree();
+    const linkDir = mkTempWorktree();
+    const linkPath = path.join(linkDir, 'junction');
+    try {
+        const { spawnSync } = require('node:child_process');
+        const winTarget = target.replace(/\//g, '\\');
+        const winLink = linkPath.replace(/\//g, '\\');
+        const result = spawnSync('cmd', ['/c', 'mklink', '/J', winLink, winTarget], {
+            stdio: 'pipe',
+            windowsHide: true,
+        });
+        if (result.status !== 0) {
+            // No tenemos permisos para crear junction — skip suave
+            return;
+        }
+        assert.equal(isJunction(linkPath), true);
+        // Y un dir real al lado debe seguir siendo false
+        assert.equal(isJunction(target), false);
+    } finally {
+        // Limpiar junction antes que el dir, y con cmd para no seguir el junction
+        try {
+            const { spawnSync } = require('node:child_process');
+            const winLink = linkPath.replace(/\//g, '\\');
+            spawnSync('cmd', ['/c', 'rmdir', winLink], { stdio: 'ignore' });
+        } catch {}
+        fs.rmSync(linkDir, { recursive: true, force: true });
+        fs.rmSync(target, { recursive: true, force: true });
+    }
+});
+
+// ---- dismountClaudeJunction -------------------------------------------------
+
+test('dismountClaudeJunction devuelve not_present cuando .claude no existe', () => {
+    const wt = mkTempWorktree();
+    try {
+        const result = dismountClaudeJunction(wt, () => {});
+        assert.equal(result.dismounted, false);
+        assert.equal(result.reason, 'not_present');
+    } finally {
+        fs.rmSync(wt, { recursive: true, force: true });
+    }
+});
+
+test('dismountClaudeJunction NO toca .claude si es copia real (fix #2867)', () => {
+    const wt = mkTempWorktree();
+    const claude = path.join(wt, '.claude');
+    fs.mkdirSync(claude);
+    fs.writeFileSync(path.join(claude, 'sentinela.txt'), 'no me borres');
+    try {
+        const result = dismountClaudeJunction(wt, () => {});
+        assert.equal(result.dismounted, false);
+        assert.equal(result.reason, 'real_copy');
+        // Lo crítico: el archivo debe seguir ahí
+        assert.equal(fs.existsSync(path.join(claude, 'sentinela.txt')), true);
+    } finally {
+        fs.rmSync(wt, { recursive: true, force: true });
+    }
+});
+
+// ---- cleanupWorktree (smoke) ------------------------------------------------
+
+test('cleanupWorktree skipea cuando es sesión activa (fix #2867)', async () => {
+    const wt = mkTempWorktree();
+    try {
+        const result = await cleanupWorktree({
+            worktreePath: wt,
+            branch: 'agent/fake-branch',
+            mainRepoPath: '/no-importa',
+            sessionCwd: wt,        // activa
+            logger: () => {},
+        });
+        assert.equal(result.ok, true);
+        assert.equal(result.skipped, true);
+        assert.equal(result.reason, 'active_session');
+        // Y el worktree filesystem debe seguir intacto
+        assert.equal(fs.existsSync(wt), true);
+    } finally {
+        fs.rmSync(wt, { recursive: true, force: true });
+    }
+});
+
+test('cleanupWorktree falla sin worktreePath', async () => {
+    const result = await cleanupWorktree({
+        worktreePath: null,
+        branch: 'foo',
+        sessionCwd: '/cwd',
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.error, 'missing_args');
+});

--- a/.pipeline/lib/delivery/change-classifier.js
+++ b/.pipeline/lib/delivery/change-classifier.js
@@ -1,0 +1,145 @@
+// change-classifier.js — Clasifica un cambio en su tipo Conventional Commit.
+//
+// Reemplaza el Paso 3 del SKILL.md ("Basándote en el diff, clasificá:")
+// con reglas determinísticas sobre paths, contenido del diff y subjects
+// de los commits ya hechos en el branch.
+//
+// Output: 'feat' | 'fix' | 'refactor' | 'test' | 'docs' | 'chore' | null
+//
+// Política: si las señales son ambiguas, devolver null y que el caller
+// decida (ej: leer el delivery-payload del issue, o caer a 'chore').
+
+// Reglas en orden de prioridad. Primera que matchea, gana.
+const RULES = [
+  // Si TODO lo cambiado son tests → 'test'
+  {
+    type: 'test',
+    when: ({ files }) => files.length > 0 && files.every(isTestFile),
+  },
+  // Si TODO lo cambiado es docs → 'docs'
+  {
+    type: 'docs',
+    when: ({ files }) => files.length > 0 && files.every(isDocFile),
+  },
+  // Subject del primer commit lo dice explícitamente
+  {
+    type: ({ commits }) => firstSubjectType(commits),
+    when: ({ commits }) => firstSubjectType(commits) != null,
+  },
+  // Cambios solo en config/build/CI/infra → 'chore'
+  {
+    type: 'chore',
+    when: ({ files }) => files.length > 0 && files.every(isChoreFile),
+  },
+  // Cambios que tocan código de producción + tests → probablemente 'feat' o 'fix'.
+  // Si hay archivos NUEVOS de producción → 'feat'. Si solo modifican → 'fix'.
+  // (Heurística simple; el caller puede pisarlo con `--type` o el payload del issue.)
+  {
+    type: ({ status }) => statusBasedType(status),
+    when: ({ status }) => statusBasedType(status) != null,
+  },
+];
+
+const TEST_PATTERNS = [
+  /(^|\/)__tests__\//,
+  /(^|\/)test\//,
+  /\.test\.[jt]sx?$/,
+  /\.spec\.[jt]sx?$/,
+  /Test\.kts?$/,
+  /Tests\.kts?$/,
+];
+
+const DOC_PATTERNS = [
+  /^docs\//,
+  /\.md$/i,
+  /^README/i,
+  /^CHANGELOG/i,
+];
+
+const CHORE_PATTERNS = [
+  /^\.github\//,
+  /^\.gitignore$/,
+  /^\.gitattributes$/,
+  /^\.editorconfig$/,
+  /^\.pipeline\/(config\.yaml|.+\.json)$/,
+  /^\.claude\//,
+  /^buildSrc\//,
+  /(^|\/)build\.gradle(\.kts)?$/,
+  /(^|\/)settings\.gradle(\.kts)?$/,
+  /^gradle\//,
+  /(^|\/)package(-lock)?\.json$/,
+  /^renovate\.json$/,
+];
+
+function isTestFile(filePath) {
+  return TEST_PATTERNS.some((p) => p.test(filePath));
+}
+
+function isDocFile(filePath) {
+  // .claude/ es config del harness, no docs (aunque tenga .md)
+  if (filePath.startsWith('.claude/')) return false;
+  return DOC_PATTERNS.some((p) => p.test(filePath));
+}
+
+function isChoreFile(filePath) {
+  // Tests ganan sobre chore (un .test.js en .github/ sigue siendo test)
+  if (isTestFile(filePath)) return false;
+  // Docs ganan también, pero `isDocFile` ya excluye .claude/, así que un
+  // SKILL.md bajo .claude/ entra como chore correctamente.
+  if (isDocFile(filePath)) return false;
+  return CHORE_PATTERNS.some((p) => p.test(filePath));
+}
+
+// Si el subject del primer commit del branch tiene prefijo conventional,
+// se respeta como source of truth. Es lo que el dev intencionalmente puso.
+function firstSubjectType(commits) {
+  if (!commits || commits.length === 0) return null;
+  // El primer commit cronológicamente del branch (último del array, que viene
+  // ordenado por log con HEAD primero).
+  const first = commits[commits.length - 1];
+  return parseConventionalType(first.subject);
+}
+
+// Parsea "fix(scope): texto" o "feat: texto" → "fix" / "feat" / null.
+function parseConventionalType(subject) {
+  if (!subject) return null;
+  const m = subject.match(/^(feat|fix|refactor|test|docs|chore|perf|style|build|ci)(\([^)]+\))?!?:/i);
+  return m ? m[1].toLowerCase() : null;
+}
+
+// Heurística sobre `git status --porcelain`: si hay archivos NUEVOS (A o ??)
+// que no son chore/doc/test, asumimos 'feat'. Si solo hay modificados, 'fix'.
+function statusBasedType(status) {
+  if (!status || status.length === 0) return null;
+  const productionEntries = status.filter((s) => {
+    const p = s.path;
+    return !isTestFile(p) && !isDocFile(p) && !isChoreFile(p);
+  });
+  if (productionEntries.length === 0) return null;
+  const hasNew = productionEntries.some((s) => /^(A |\?\?)/.test(s.code) || s.code.trim() === 'A');
+  return hasNew ? 'feat' : 'fix';
+}
+
+// API principal. Recibe el snapshot de git-context y devuelve el tipo.
+//
+// Acepta también un override (por ejemplo, viniendo del CLI con --type, o
+// del delivery-payload de un issue).
+function classify({ files = [], commits = [], status = [], override = null } = {}) {
+  if (override && parseConventionalType(`${override}: x`)) return override.toLowerCase();
+  for (const rule of RULES) {
+    if (rule.when({ files, commits, status })) {
+      return typeof rule.type === 'function' ? rule.type({ files, commits, status }) : rule.type;
+    }
+  }
+  return null;
+}
+
+module.exports = {
+  classify,
+  parseConventionalType,
+  isTestFile,
+  isDocFile,
+  isChoreFile,
+  // exports para tests
+  _internals: { firstSubjectType, statusBasedType, RULES },
+};

--- a/.pipeline/lib/delivery/git-context.js
+++ b/.pipeline/lib/delivery/git-context.js
@@ -1,0 +1,133 @@
+// git-context.js — Lectura pura del estado git para el delivery
+//
+// Reemplaza el Paso 2 del SKILL.md (que pedía al LLM correr 4 comandos y
+// parsear los outputs). Acá lo hacemos con spawnSync determinístico.
+//
+// Toda la API devuelve estructuras planas, sin side effects. Si querés
+// que falle algo, lo decide el caller.
+
+const { spawnSync } = require('child_process');
+
+function git(args, cwd, opts = {}) {
+  const result = spawnSync('git', ['-C', cwd, ...args], {
+    stdio: 'pipe',
+    encoding: 'utf8',
+    windowsHide: true,
+    ...opts,
+  });
+  // OJO: solo strippeamos whitespace TRAILING, NO leading. `git status
+  // --porcelain` usa espacios significativos al inicio de cada línea.
+  const trimRight = (s) => (s || '').replace(/\s+$/, '');
+  return {
+    ok: result.status === 0,
+    status: result.status,
+    stdout: trimRight(result.stdout),
+    stderr: trimRight(result.stderr),
+  };
+}
+
+// Branch actual del worktree.
+function currentBranch(cwd) {
+  const r = git(['branch', '--show-current'], cwd);
+  return r.ok ? r.stdout : null;
+}
+
+// Lista de commits que separan HEAD de la base. Devuelve array de
+// { sha, subject } en orden cronológico inverso (HEAD primero).
+function commitsAhead(cwd, base = 'origin/main') {
+  const r = git(['log', `${base}..HEAD`, '--oneline'], cwd);
+  if (!r.ok) return [];
+  return r.stdout.split('\n').filter(Boolean).map((line) => {
+    const idx = line.indexOf(' ');
+    if (idx < 0) return { sha: line, subject: '' };
+    return { sha: line.slice(0, idx), subject: line.slice(idx + 1) };
+  });
+}
+
+// Cantidad de commits adelante del base.
+function aheadCount(cwd, base = 'origin/main') {
+  const r = git(['rev-list', '--count', `${base}..HEAD`], cwd);
+  return r.ok ? Number(r.stdout) || 0 : 0;
+}
+
+// Cantidad de commits que el base está adelante (necesitamos rebase si > 0).
+function behindCount(cwd, base = 'origin/main') {
+  const r = git(['rev-list', '--count', `HEAD..${base}`], cwd);
+  return r.ok ? Number(r.stdout) || 0 : 0;
+}
+
+// `git status --porcelain` parseado. Devuelve array de { code, path }.
+// code es el código de status de 2 caracteres (ej: " M", "??", "A ").
+function statusPorcelain(cwd) {
+  const r = git(['status', '--porcelain'], cwd);
+  if (!r.ok) return [];
+  return r.stdout.split('\n').filter(Boolean).map((line) => ({
+    code: line.slice(0, 2),
+    path: line.slice(3),
+  }));
+}
+
+// Lista de archivos cambiados entre base y HEAD (commits ya hechos).
+function filesChanged(cwd, base = 'origin/main') {
+  const r = git(['diff', '--name-only', `${base}...HEAD`], cwd);
+  return r.ok ? r.stdout.split('\n').filter(Boolean) : [];
+}
+
+// Stat de cambios entre base y HEAD: { files, insertions, deletions }.
+function diffStat(cwd, base = 'origin/main') {
+  const r = git(['diff', '--shortstat', `${base}...HEAD`], cwd);
+  if (!r.ok || !r.stdout) return { files: 0, insertions: 0, deletions: 0 };
+  const m = r.stdout.match(/(\d+) files? changed(?:, (\d+) insertions?\(\+\))?(?:, (\d+) deletions?\(-\))?/);
+  if (!m) return { files: 0, insertions: 0, deletions: 0 };
+  return {
+    files: Number(m[1]) || 0,
+    insertions: Number(m[2]) || 0,
+    deletions: Number(m[3]) || 0,
+  };
+}
+
+// Diff completo (texto) entre base y HEAD. Útil para input al LLM cuando
+// hace falta redactar commit/PR body. La truncación es a nivel de string
+// ya capturado, no a nivel de spawn (sino el proceso falla cuando el diff
+// excede el buffer en lugar de truncar).
+function diffText(cwd, base = 'origin/main', maxBytes = 200000) {
+  // maxBuffer generoso para que el spawn nunca aborte por tamaño.
+  const r = git(['diff', `${base}...HEAD`], cwd, { maxBuffer: 64 * 1024 * 1024 });
+  if (!r.ok) return '';
+  return r.stdout.length > maxBytes ? r.stdout.slice(0, maxBytes) + '\n...[truncated]' : r.stdout;
+}
+
+// Fetch de origen/base. Retorna ok/error.
+function fetchOrigin(cwd, branch = 'main') {
+  const r = git(['fetch', 'origin', branch], cwd);
+  return { ok: r.ok, error: r.ok ? null : r.stderr };
+}
+
+// Snapshot agregado de contexto que necesita el delivery para decidir cosas.
+function snapshot(cwd, base = 'origin/main') {
+  return {
+    cwd,
+    base,
+    branch: currentBranch(cwd),
+    ahead: aheadCount(cwd, base),
+    behind: behindCount(cwd, base),
+    commits: commitsAhead(cwd, base),
+    status: statusPorcelain(cwd),
+    files: filesChanged(cwd, base),
+    stat: diffStat(cwd, base),
+  };
+}
+
+module.exports = {
+  git,
+  currentBranch,
+  commitsAhead,
+  aheadCount,
+  behindCount,
+  statusPorcelain,
+  filesChanged,
+  diffStat,
+  diffText,
+  fetchOrigin,
+  snapshot,
+};

--- a/.pipeline/lib/delivery/worktree-cleanup.js
+++ b/.pipeline/lib/delivery/worktree-cleanup.js
@@ -1,0 +1,164 @@
+// worktree-cleanup.js — Limpieza segura de worktrees post-merge
+//
+// Reemplaza el Paso 6.6 del SKILL.md (markdown interpretado por LLM) con
+// lógica determinística + tests. Incorpora el fix de #2867:
+//
+//   1. Si el worktree a limpiar es donde corre la sesión activa del CLI,
+//      skipea el cleanup completo (solo prune metadata).
+//   2. `.claude/` solo se desmonta con rmdir si es junction. Si es copia
+//      real, se deja que `git worktree remove` se encargue (sino rmdir
+//      borra todo el contenido y voltea los skills).
+
+const path = require('path');
+const fs = require('fs');
+const { execSync, spawnSync } = require('child_process');
+
+const MAIN_REPO_DEFAULT = 'C:/Workspaces/Intrale/platform';
+
+// Compara paths reales (resuelve symlinks/junctions). Si sessionCwd está
+// dentro de worktreePath, este es la sesión activa y NO debe limpiarse.
+function isActiveSession(worktreePath, sessionCwd) {
+  if (!worktreePath || !sessionCwd) return false;
+  let wtReal, cwdReal;
+  try { wtReal = fs.realpathSync(worktreePath); } catch { return false; }
+  try { cwdReal = fs.realpathSync(sessionCwd); } catch { return false; }
+  // Normalizar separadores y casing (Windows es case-insensitive)
+  const norm = (p) => p.replace(/\\/g, '/').toLowerCase();
+  const wt = norm(wtReal);
+  const cwd = norm(cwdReal);
+  // Igualdad exacta o cwd dentro del worktree.
+  // Comparar contra `wt + '/'` evita falsos positivos por prefijo
+  // (ej: cwd=/foobar, wt=/foo — el startsWith plano daría true).
+  return cwd === wt || cwd.startsWith(wt + '/');
+}
+
+// Verifica si un path es un reparse point (junction o symlink) en Windows.
+// Usa `fsutil reparsepoint query` que devuelve exit 0 solo para reparse points.
+function isJunction(targetPath) {
+  if (!fs.existsSync(targetPath)) return false;
+  // En non-Windows también soporta vía lstat
+  if (process.platform !== 'win32') {
+    try { return fs.lstatSync(targetPath).isSymbolicLink(); } catch { return false; }
+  }
+  const winPath = targetPath.replace(/\//g, '\\');
+  const result = spawnSync('cmd', ['/c', 'fsutil', 'reparsepoint', 'query', winPath], {
+    stdio: 'pipe',
+    windowsHide: true,
+  });
+  return result.status === 0;
+}
+
+// Desmonta `.claude/` SOLO si es junction. Si es copia real, no toca.
+function dismountClaudeJunction(worktreePath, logger = () => {}) {
+  const claudePath = path.join(worktreePath, '.claude');
+  if (!fs.existsSync(claudePath)) {
+    logger('  → .claude no existe, skip');
+    return { dismounted: false, reason: 'not_present' };
+  }
+  if (!isJunction(claudePath)) {
+    logger('  → .claude es copia real, no se toca (lo borra git worktree remove)');
+    return { dismounted: false, reason: 'real_copy' };
+  }
+  const winPath = claudePath.replace(/\//g, '\\');
+  const result = spawnSync('cmd', ['/c', 'rmdir', winPath], {
+    stdio: 'pipe',
+    windowsHide: true,
+  });
+  if (result.status === 0) {
+    logger('  → .claude junction desmontado');
+    return { dismounted: true };
+  }
+  logger(`  → falló rmdir (exit ${result.status}): ${result.stderr?.toString().trim()}`);
+  return { dismounted: false, reason: 'rmdir_failed' };
+}
+
+// Ejecuta git desde el repo principal con manejo limpio de errores.
+function gitInMain(args, mainRepo, opts = {}) {
+  const result = spawnSync('git', ['-C', mainRepo, ...args], {
+    stdio: opts.capture ? 'pipe' : 'inherit',
+    encoding: 'utf8',
+    windowsHide: true,
+  });
+  return {
+    ok: result.status === 0,
+    status: result.status,
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+  };
+}
+
+// Limpia un worktree después de merge. Devuelve un resultado estructurado.
+async function cleanupWorktree({
+  worktreePath,
+  branch,
+  mainRepoPath = MAIN_REPO_DEFAULT,
+  sessionCwd = process.cwd(),
+  logger = console.log,
+}) {
+  if (!worktreePath || !branch) {
+    return { ok: false, error: 'missing_args', message: 'worktreePath y branch son obligatorios' };
+  }
+
+  const log = (msg) => logger(msg);
+
+  // 0. Detección de sesión activa (fix #2867)
+  if (isActiveSession(worktreePath, sessionCwd)) {
+    log('⚠️ Skip cleanup: worktree es la sesión activa del CLI');
+    log(`   Worktree: ${worktreePath}`);
+    log(`   Session:  ${sessionCwd}`);
+    log('   Branch local se conserva. Worktree quedará huérfano hasta /cleanup manual.');
+    gitInMain(['worktree', 'prune'], mainRepoPath);
+    return {
+      ok: true,
+      skipped: true,
+      reason: 'active_session',
+      worktreePath,
+      branch,
+    };
+  }
+
+  // 1. Volver al repo principal (cambio de cwd via git -C, no process.chdir)
+  log(`🧹 Limpiando worktree ${worktreePath}`);
+
+  // 2. Desmontar .claude SOLO si es junction
+  const claudeResult = dismountClaudeJunction(worktreePath, log);
+
+  // 3. git worktree remove
+  const wtRemove = gitInMain(['worktree', 'remove', worktreePath, '--force'], mainRepoPath, { capture: true });
+  if (!wtRemove.ok) {
+    log(`  ⚠️ git worktree remove falló: ${wtRemove.stderr.trim()}`);
+  } else {
+    log('  → worktree removido');
+  }
+
+  // 4. Eliminar branch local
+  const branchDel = gitInMain(['branch', '-D', branch], mainRepoPath, { capture: true });
+  if (branchDel.ok) {
+    log(`  → branch local ${branch} eliminada`);
+  } else {
+    log(`  → branch local ${branch} ya no existía`);
+  }
+
+  // 5. Prune
+  gitInMain(['worktree', 'prune'], mainRepoPath);
+  log('  → prune completado');
+
+  return {
+    ok: true,
+    skipped: false,
+    worktreePath,
+    branch,
+    claudeDismounted: claudeResult.dismounted,
+    worktreeRemoved: wtRemove.ok,
+    branchDeleted: branchDel.ok,
+  };
+}
+
+module.exports = {
+  cleanupWorktree,
+  isActiveSession,
+  isJunction,
+  dismountClaudeJunction,
+  // exports para tests
+  _internals: { gitInMain },
+};


### PR DESCRIPTION
## Resumen

Comienzo del refactor de \`/delivery\` (issue #2870). El SKILL.md actual es prosa interpretada por el LLM cada vez (~5-10k tokens, no reproducible, no testeable). Este PR mueve los primeros dos módulos a JS determinístico con tests:

### Módulos entregados

| Módulo | Tests | Función |
|---|---|---|
| \`worktree-cleanup.js\` | 14 ✓ | Cleanup post-merge con fix de #2867 incorporado desde el día 1 |
| \`git-context.js\` | 12 ✓ | Lectura de branch, commits, status, diff |

**Total: 26/26 tests pasan.**

## Bugs reales atrapados por los tests durante este PR

1. **Falso positivo por prefijo en \`isActiveSession\`** — \`/foobar startsWith /foo\` devolvía true. Fix: comparar contra \`wt + '/'\`.
2. **\`git()\` hacía \`trim()\` global** — se comía el espacio leading de \`git status --porcelain\`, parseaba \`.js\` en lugar de \`a.js\`. Fix: trim solo trailing.
3. **\`diffText\` con \`maxBuffer\` chico** — abortaba el spawn en lugar de truncar. Fix: maxBuffer generoso, truncar string capturado.

Estos bugs habrían sido invisibles en el SKILL.md original (todos los pasos se generaban con el LLM al vuelo).

## Próximos módulos

- \`change-classifier.js\` — clasifica diff en feat/fix/refactor/...
- \`commit-builder.js\` / \`pr-builder.js\` — plantillas (LLM solo si hace falta)
- \`rebase-handler.js\` — rebase con resolución auto config / abort código
- \`qa-gate.js\` / \`tester-gate.js\` / \`review-gate.js\` — gates con retries
- \`merge-handler.js\` — gh pr merge con fallbacks
- \`telegram-report.js\` — wrapper sobre script existente
- \`delivery.js\` — entry point que orquesta

Una vez todos los módulos estén, el SKILL.md queda reducido a invocar \`node .pipeline/delivery.js\`.

## Tests

\`\`\`
node --test .pipeline/lib/__tests__/git-context.test.js .pipeline/lib/__tests__/worktree-cleanup.test.js
ℹ pass 26 | fail 0
\`\`\`

Refs #2870

🤖 Generado con [Claude Code](https://claude.ai/claude-code)