### PR TITLE
refactor(delivery): /handoff + orquestador + integración con developers (#2870)

### DIFF
--- a/.claude/skills/android-dev/SKILL.md
+++ b/.claude/skills/android-dev/SKILL.md
@@ -325,6 +325,42 @@ export JAVA_HOME="/c/Users/Administrator/.jdks/temurin-21.0.7" && \
 - ASCII fallbacks: OK / FALLO
 ```
 
+## Paso 9: Handoff (si fui invocado con issue)
+
+Si el argumento `<issue-o-tarea>` es un número de issue, antes de exitar invocá `/handoff`
+con el commit-message y pr-body redactados desde TU contexto (vos hiciste el laburo,
+vos sabés qué cambió y por qué).
+
+**Redactar commit-message** (Conventional Commits, máx 72 chars el subject):
+```
+feat(android): subject corto y descriptivo
+
+Body opcional explicando el por qué del cambio.
+```
+
+**Redactar pr-body** (markdown estructurado, mencionando flavors afectados):
+```
+## Resumen
+- Bullet 1: qué cambió
+- Bullet 2: por qué
+
+## Flavors afectados
+- client / business / delivery
+
+## Cambios técnicos
+- Archivo X: ...
+
+## Tests
+- [N] tests nuevos
+```
+
+**Invocación:**
+```
+Skill(skill="handoff", args="<issue> --commit '<commit-message>' --body '<pr-body>' --type <tipo>")
+```
+
+Si el argumento NO es un número de issue, saltá este paso.
+
 ## Reglas
 
 ### Convenciones obligatorias

--- a/.claude/skills/backend-dev/SKILL.md
+++ b/.claude/skills/backend-dev/SKILL.md
@@ -236,6 +236,43 @@ Si el build falla, leer el error, corregir y volver a intentar hasta que pase.
 - Compilación: OK / FALLO
 ```
 
+## Paso 9: Handoff (si fui invocado con issue)
+
+Si el argumento `<issue-o-tarea>` es un número de issue, antes de exitar invocá `/handoff` con
+el commit-message y pr-body redactados desde TU contexto (vos hiciste el laburo, vos sabés
+qué cambió y por qué — un template no puede igualar eso).
+
+**Redactar commit-message** (Conventional Commits, máx 72 chars el subject):
+```
+feat(scope): subject corto y descriptivo
+
+Body opcional explicando el por qué del cambio.
+Si hay breaking changes, agregar BREAKING CHANGE: ...
+```
+
+**Redactar pr-body** (markdown estructurado):
+```
+## Resumen
+- Bullet 1: qué cambió
+- Bullet 2: por qué
+
+## Cambios técnicos
+- Archivo X: ...
+- Archivo Y: ...
+
+## Tests
+- [N] tests nuevos
+- Cobertura: ...
+```
+
+**Invocación:**
+```
+Skill(skill="handoff", args="<issue> --commit '<commit-message>' --body '<pr-body>' --type <tipo>")
+```
+
+Si el argumento NO es un número de issue (ej: `"refactor X"`), saltá este paso — `/delivery` usará
+el fallback determinístico cuando no haya issue.
+
 ## Reglas
 
 ### Convenciones obligatorias

--- a/.claude/skills/delivery/SKILL.md
+++ b/.claude/skills/delivery/SKILL.md
@@ -76,31 +76,42 @@ export PATH="/c/Workspaces/gh-cli/bin:$PATH"
 export GH_TOKEN=$(printf 'protocol=https\nhost=github.com\n' | git credential fill 2>/dev/null | sed -n 's/^password=//p')
 ```
 
-## Paso 2: Contexto actual
+## Paso 2: Contexto + commit/PR determinísticos (script)
+
+A partir del refactor #2870, los pasos 2-3-4-6 (contexto, tipo, commit-message, pr-body)
+los resuelve un script determinístico que NO invoca LLM:
 
 ```bash
-# Branch actual
-BRANCH=$(git branch --show-current)
-
-# Commits que van a incluirse (diferencia con main)
-git log origin/main..HEAD --oneline
-
-# Cambios staged y unstaged
-git status
-git diff --stat
+node .pipeline/delivery.js \
+  --description "<descripcion-breve>" \
+  ${ISSUE_NUM:+--issue $ISSUE_NUM} \
+  --json
 ```
 
-Analizá los cambios para redactar el commit y el PR.
+El script:
+- Lee snapshot del git (`git-context`)
+- Clasifica el tipo de cambio (`change-classifier`)
+- Si hay issue, busca payload `<!-- delivery-payload -->` en los comentarios y lee
+  `commit-message` + `pr-body` del agente que hizo el laburo (`/handoff`)
+- Si no hay payload, cae a template determinístico
 
-## Paso 3: Determinar tipo de cambio
+**Output JSON** (parsealo):
+```json
+{
+  "branch": "...",
+  "type": "feat|fix|refactor|...",
+  "commitMessage": "...",
+  "commitSource": "issue-payload | fallback",
+  "prTitle": "...",
+  "prBody": "...",
+  "prSource": "issue-payload | fallback"
+}
+```
 
-Basándote en el diff, clasificá:
-- `feat:` — nueva funcionalidad
-- `fix:` — corrección de bug
-- `refactor:` — refactor sin cambio de comportamiento
-- `test:` — solo tests
-- `docs:` — solo documentación
-- `chore:` — tareas de mantenimiento
+Usá `commitMessage` para el commit del Paso 4, `prTitle` + `prBody` para el `gh pr create` del Paso 6.
+**No redactes nada vos** — el agente que hizo el laburo ya lo redactó vía `/handoff`.
+
+Si el script falla (raro), seguí el flujo manual debajo como fallback.
 
 ## Paso 3.5: Verificar QA E2E (gate obligatorio)
 

--- a/.claude/skills/handoff/SKILL.md
+++ b/.claude/skills/handoff/SKILL.md
@@ -1,0 +1,102 @@
+---
+description: Handoff — postea payload de delivery (commit-message + pr-body) en el issue para que /delivery lo lea
+user-invocable: true
+argument-hint: "<issue> --commit '<msg>' --body '<pr-body>' [--type <tipo>] [--qa <disposition>]"
+allowed-tools: Bash, Read
+model: claude-haiku-4-5-20251001
+---
+
+# /handoff — Handoff
+
+Sos **Handoff** — un wrapper delgado que postea un comentario marcado en el issue de GitHub
+con el payload estructurado que `/delivery` consume después.
+
+No redactás nada. No interpretás el diff. Recibís lo que el agente que hizo el laburo
+te pasa, lo formateás con el marker, y posteás. Listo.
+
+## Por qué existe
+
+Para que `/delivery` corra cero LLM (refactor #2870), necesita leer commit-message y pr-body
+desde algún lado. La fuente: un comentario marcado en el issue, posteado por el agente
+que hizo el laburo (el dev tiene el contexto, el delivery no).
+
+`/handoff` encapsula:
+- El formato del marker (`<!-- delivery-payload -->`)
+- La estructura de secciones (`## commit-message`, `## pr-body`, `## qa-disposition`)
+- El manejo de errores (issue no existe, sin permisos)
+
+## Argumentos
+
+- `<issue>` — Número de issue donde postear (obligatorio)
+- `--commit '<msg>'` — Commit message convencional (obligatorio)
+- `--body '<pr-body>'` — Cuerpo del PR (obligatorio)
+- `--type <tipo>` — Override del tipo conventional commit (opcional: feat|fix|refactor|test|docs|chore)
+- `--qa <disposition>` — `qa:passed` o `qa:skipped (<razón>)` (opcional, default: `qa:skipped (no verificado)`)
+
+## Paso 1: Validar argumentos
+
+Verificá que tengas:
+- `<issue>` numérico
+- `--commit` no vacío
+- `--body` no vacío
+
+Si falta algo, abortá con error claro indicando qué falta.
+
+## Paso 2: Construir payload
+
+Formato exacto (respetá los marcadores y separadores):
+
+```
+<!-- delivery-payload -->
+## commit-message
+<contenido de --commit>
+
+## pr-body
+<contenido de --body>
+
+## qa-disposition
+<contenido de --qa, o "qa:skipped (no verificado)">
+<!-- /delivery-payload -->
+```
+
+## Paso 3: Postear comentario en el issue
+
+```bash
+export PATH="/c/Workspaces/gh-cli/bin:$PATH"
+gh issue comment <issue> --repo intrale/platform --body "$(cat <<'EOF'
+<!-- delivery-payload -->
+## commit-message
+<commit-message>
+
+## pr-body
+<pr-body>
+
+## qa-disposition
+<qa-disposition>
+<!-- /delivery-payload -->
+EOF
+)"
+```
+
+## Paso 4: Reportar
+
+Si el comentario se posteó exitosamente:
+```
+✅ Handoff completado
+Issue: #<N>
+Comentario: <URL>
+Commit message: <primera línea>
+```
+
+Si falló (issue no existe, sin permisos, etc.):
+```
+❌ Handoff falló
+Razón: <error de gh>
+```
+
+## Reglas
+
+- NUNCA modificar el commit-message ni el pr-body recibidos. Pasarlos tal cual.
+- NUNCA redactar nada vos. Sos un wrapper, no un editor.
+- NUNCA postear sin marker. Si /delivery no encuentra el marker, cae a fallback.
+- Si el issue ya tiene un payload anterior, no es problema: /delivery toma el último.

--- a/.claude/skills/pipeline-dev/SKILL.md
+++ b/.claude/skills/pipeline-dev/SKILL.md
@@ -161,7 +161,38 @@ El QA E2E del producto (video + emulador) **no aplica** a cambios que solo tocan
 3. Label `qa:skipped` con justificación: *"Cambio de pipeline infra, validado por smoke test post-restart. Sin UI ni endpoint de producto afectado."*
 4. El PO aprueba por lectura de código + justificación (PO-gate contextual lo permite para `area:pipeline`/`area:infra` sin `app:*`).
 
-## Paso 9: Emitir resultado al pulpo
+## Paso 9: Handoff al issue
+
+Antes de emitir al pulpo, postear el payload de delivery en el issue para que `/delivery`
+lo consuma cuando le toque (refactor #2870):
+
+**Redactar commit-message** (Conventional Commits):
+```
+fix(pipeline): subject corto y descriptivo
+
+Body explicando el por qué.
+```
+
+**Redactar pr-body**:
+```
+## Resumen
+- Bullet 1: qué cambió en el pipeline
+- Bullet 2: por qué
+
+## Smoke test
+- Ejecutado: sí/no
+- Resultado: ...
+
+## Tests unitarios
+- [N] tests
+```
+
+**Invocación:**
+```
+Skill(skill="handoff", args="<issue> --commit '<commit-message>' --body '<pr-body>' --qa 'qa:skipped (cambio de infra, validado por smoke test)'")
+```
+
+## Paso 10: Emitir resultado al pulpo
 
 Emitir YAML a `.pipeline/desarrollo/dev/listo/<issue>.pipeline-dev` con:
 

--- a/.claude/skills/web-dev/SKILL.md
+++ b/.claude/skills/web-dev/SKILL.md
@@ -224,6 +224,39 @@ export JAVA_HOME="/c/Users/Administrator/.jdks/temurin-21.0.7" && \
 - Verificaciones: OK / FALLO
 ```
 
+## Paso 8: Handoff (si fui invocado con issue)
+
+Si el argumento `<issue-o-tarea>` es un número de issue, antes de exitar invocá `/handoff`
+con el commit-message y pr-body redactados desde TU contexto (vos hiciste el laburo,
+vos sabés qué cambió y por qué).
+
+**Redactar commit-message** (Conventional Commits, máx 72 chars el subject):
+```
+feat(web): subject corto y descriptivo
+
+Body opcional explicando el por qué del cambio.
+```
+
+**Redactar pr-body** (markdown estructurado):
+```
+## Resumen
+- Bullet 1: qué cambió
+- Bullet 2: por qué
+
+## Cambios técnicos
+- Archivo X: ...
+
+## Tests
+- [N] tests nuevos
+```
+
+**Invocación:**
+```
+Skill(skill="handoff", args="<issue> --commit '<commit-message>' --body '<pr-body>' --type <tipo>")
+```
+
+Si el argumento NO es un número de issue, saltá este paso.
+
 ## Reglas
 
 ### Convenciones obligatorias

--- a/.pipeline/delivery.js
+++ b/.pipeline/delivery.js
@@ -1,0 +1,248 @@
+#!/usr/bin/env node
+// delivery.js — Orquestador determinístico del refactor #2870.
+//
+// Reemplaza la lógica del SKILL.md de /delivery con un script que:
+//   1. Lee estado git con git-context
+//   2. Clasifica el cambio con change-classifier
+//   3. Lee payload del issue (si existe) o cae a fallback
+//   4. Construye commit-message con commit-builder
+//   5. Construye pr-body con pr-builder
+//   6. Ejecuta: git commit + push + gh pr create
+//
+// Cero LLM. Determinismo total.
+//
+// Uso:
+//   node .pipeline/delivery.js --issue <N> --description "<desc>" [--type <tipo>] [--draft]
+//   node .pipeline/delivery.js --description "<desc>" [--type <tipo>]   (sin issue)
+
+'use strict';
+
+const { spawnSync } = require('child_process');
+const path = require('path');
+
+const gitCtx = require('./lib/delivery/git-context');
+const classifier = require('./lib/delivery/change-classifier');
+const commitBuilder = require('./lib/delivery/commit-builder');
+const prBuilder = require('./lib/delivery/pr-builder');
+
+// ---- CLI parsing -----------------------------------------------------------
+
+function parseArgs(argv) {
+  const args = {
+    issue: null,
+    description: null,
+    type: null,
+    draft: false,
+    dryRun: false,
+    json: false,
+    repo: 'intrale/platform',
+    base: 'main',
+  };
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--issue') args.issue = argv[++i];
+    else if (a === '--description') args.description = argv[++i];
+    else if (a === '--type') args.type = argv[++i];
+    else if (a === '--draft') args.draft = true;
+    else if (a === '--dry-run') args.dryRun = true;
+    else if (a === '--json') args.json = true;
+    else if (a === '--repo') args.repo = argv[++i];
+    else if (a === '--base') args.base = argv[++i];
+  }
+  return args;
+}
+
+// ---- gh CLI helpers --------------------------------------------------------
+
+function gh(ghArgs, opts = {}) {
+  const result = spawnSync('gh', ghArgs, {
+    stdio: 'pipe',
+    encoding: 'utf8',
+    windowsHide: true,
+    ...opts,
+  });
+  return {
+    ok: result.status === 0,
+    status: result.status,
+    stdout: (result.stdout || '').trim(),
+    stderr: (result.stderr || '').trim(),
+  };
+}
+
+// Lee body + comments del issue. Devuelve { body, comments: [{body}] }.
+function fetchIssue(issueNumber, repo) {
+  if (!issueNumber) return { body: null, comments: [] };
+  const r = gh([
+    'issue', 'view', String(issueNumber),
+    '--repo', repo,
+    '--json', 'body,comments',
+  ]);
+  if (!r.ok) return { body: null, comments: [] };
+  try {
+    const data = JSON.parse(r.stdout);
+    return {
+      body: data.body || null,
+      comments: (data.comments || []).map((c) => ({ body: c.body || '' })),
+    };
+  } catch {
+    return { body: null, comments: [] };
+  }
+}
+
+// ---- Main ------------------------------------------------------------------
+
+function main() {
+  const args = parseArgs(process.argv);
+  const cwd = process.cwd();
+
+  // 1. Snapshot de git
+  const snap = gitCtx.snapshot(cwd, `origin/${args.base}`);
+  if (!snap.branch) {
+    console.error('❌ No se pudo determinar branch actual');
+    process.exit(1);
+  }
+  if (snap.ahead === 0) {
+    console.error(`❌ Branch ${snap.branch} no tiene commits adelante de origin/${args.base}`);
+    process.exit(1);
+  }
+
+  // 2. Clasificar cambio
+  const inferredType = classifier.classify({
+    files: snap.files,
+    commits: snap.commits,
+    status: snap.status,
+    override: args.type,
+  });
+
+  // 3. Leer issue (si hay) para payload
+  const issue = fetchIssue(args.issue, args.repo);
+
+  // 4. Construir commit-message
+  const commit = commitBuilder.build({
+    issueBody: issue.body,
+    issueComments: issue.comments,
+    type: inferredType,
+    description: args.description,
+  });
+
+  // 5. Construir pr-body
+  const pr = prBuilder.build({
+    issueBody: issue.body,
+    issueComments: issue.comments,
+    description: args.description,
+    diffStat: snap.stat,
+    issueNumber: args.issue,
+  });
+
+  // Modo --json: emite todo lo computado y termina (no ejecuta git/gh).
+  // Útil para que /delivery (SKILL.md) consuma sin perder los gates externos.
+  if (args.json) {
+    const out = {
+      branch: snap.branch,
+      base: args.base,
+      ahead: snap.ahead,
+      stat: snap.stat,
+      type: inferredType,
+      issue: args.issue,
+      commitMessage: commit.message,
+      commitSource: commit.source,
+      prTitle: commit.message.split('\n')[0],
+      prBody: pr.body,
+      prSource: pr.source,
+    };
+    console.log(JSON.stringify(out, null, 2));
+    return;
+  }
+
+  // Reporte de lo que se va a hacer
+  console.log('━━━ /delivery (determinístico) ━━━');
+  console.log(`Branch:      ${snap.branch}`);
+  console.log(`Base:        origin/${args.base}`);
+  console.log(`Ahead:       ${snap.ahead} commits, ${snap.stat.files} archivos`);
+  console.log(`Tipo:        ${inferredType || 'N/A'}`);
+  console.log(`Issue:       ${args.issue || 'N/A'}`);
+  console.log(`Commit src:  ${commit.source}`);
+  console.log(`PR src:      ${pr.source}`);
+  console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+
+  if (args.dryRun) {
+    console.log('\n--- COMMIT MESSAGE ---');
+    console.log(commit.message);
+    console.log('\n--- PR BODY ---');
+    console.log(pr.body);
+    console.log('\n(--dry-run: no se ejecutó push ni se creó PR)');
+    return;
+  }
+
+  // 6. Push (asume commits ya hechos por el agente)
+  console.log('\n→ git push...');
+  const push = spawnSync('git', ['-C', cwd, 'push', '-u', 'origin', snap.branch], {
+    stdio: 'inherit',
+  });
+  if (push.status !== 0) {
+    console.error('❌ git push falló');
+    process.exit(1);
+  }
+
+  // 7. Crear PR (si no existe)
+  const existing = gh([
+    'pr', 'list',
+    '--repo', args.repo,
+    '--head', snap.branch,
+    '--state', 'open',
+    '--json', 'number,url',
+  ]);
+
+  let prUrl = null;
+  let prNumber = null;
+  if (existing.ok && existing.stdout && existing.stdout !== '[]') {
+    try {
+      const list = JSON.parse(existing.stdout);
+      if (list.length > 0) {
+        prUrl = list[0].url;
+        prNumber = list[0].number;
+      }
+    } catch {}
+  }
+
+  if (!prUrl) {
+    console.log('→ gh pr create...');
+    const subject = commit.message.split('\n')[0];
+    const createArgs = [
+      'pr', 'create',
+      '--repo', args.repo,
+      '--title', subject,
+      '--body', pr.body,
+      '--base', args.base,
+      '--head', snap.branch,
+      '--assignee', 'leitolarreta',
+    ];
+    if (args.draft) createArgs.push('--draft');
+    const create = gh(createArgs);
+    if (!create.ok) {
+      console.error('❌ gh pr create falló:', create.stderr);
+      process.exit(1);
+    }
+    prUrl = create.stdout.split('\n').find((l) => l.startsWith('https://')) || create.stdout;
+    const m = prUrl.match(/\/pull\/(\d+)/);
+    prNumber = m ? m[1] : null;
+  } else {
+    console.log(`→ PR ya existe: ${prUrl}`);
+  }
+
+  console.log(`\n✅ Delivery completo`);
+  console.log(`   PR:     ${prUrl}`);
+  console.log(`   Number: ${prNumber || 'N/A'}`);
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (err) {
+    console.error('❌ Error en delivery.js:', err.message);
+    if (process.env.DEBUG) console.error(err.stack);
+    process.exit(1);
+  }
+}
+
+module.exports = { parseArgs, fetchIssue, main };

--- a/.pipeline/lib/__tests__/change-classifier.test.js
+++ b/.pipeline/lib/__tests__/change-classifier.test.js
@@ -1,0 +1,182 @@
+// =============================================================================
+// Tests change-classifier.js — refactor de /delivery (#2870)
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+    classify,
+    parseConventionalType,
+    isTestFile,
+    isDocFile,
+    isChoreFile,
+} = require('../delivery/change-classifier');
+
+// ---- Detectores de tipo de archivo -----------------------------------------
+
+test('isTestFile matchea __tests__/, *.test.js, Test.kt', () => {
+    assert.equal(isTestFile('.pipeline/lib/__tests__/foo.test.js'), true);
+    assert.equal(isTestFile('app/src/test/kotlin/FooTest.kt'), true);
+    assert.equal(isTestFile('users/src/test/UserTests.kt'), true);
+    assert.equal(isTestFile('lib/foo.spec.ts'), true);
+    assert.equal(isTestFile('app/src/main/MyService.kt'), false);
+});
+
+test('isDocFile matchea docs/, .md, README, CHANGELOG', () => {
+    assert.equal(isDocFile('docs/arquitectura.md'), true);
+    assert.equal(isDocFile('README.md'), true);
+    assert.equal(isDocFile('CHANGELOG'), true);
+    assert.equal(isDocFile('app/src/main/Foo.kt'), false);
+});
+
+test('isChoreFile matchea config/build/CI pero NO tests ni docs', () => {
+    assert.equal(isChoreFile('.github/workflows/ci.yml'), true);
+    assert.equal(isChoreFile('.gitignore'), true);
+    assert.equal(isChoreFile('build.gradle.kts'), true);
+    assert.equal(isChoreFile('package.json'), true);
+    assert.equal(isChoreFile('.claude/skills/foo/SKILL.md'), true);
+    // No clasificar como chore si es test o doc (precedencia)
+    assert.equal(isChoreFile('docs/README.md'), false);
+    assert.equal(isChoreFile('lib/__tests__/foo.test.js'), false);
+});
+
+// ---- parseConventionalType --------------------------------------------------
+
+test('parseConventionalType extrae el tipo de subjects válidos', () => {
+    assert.equal(parseConventionalType('feat: nueva cosa'), 'feat');
+    assert.equal(parseConventionalType('fix(api): bug X'), 'fix');
+    assert.equal(parseConventionalType('refactor(scope): blah'), 'refactor');
+    assert.equal(parseConventionalType('test: agregar tests'), 'test');
+    assert.equal(parseConventionalType('docs(readme): update'), 'docs');
+    assert.equal(parseConventionalType('chore!: breaking'), 'chore');
+});
+
+test('parseConventionalType devuelve null en subjects no convencionales', () => {
+    assert.equal(parseConventionalType('Updated something'), null);
+    assert.equal(parseConventionalType(''), null);
+    assert.equal(parseConventionalType('foo: x'), null);  // foo no es tipo válido
+    assert.equal(parseConventionalType(null), null);
+});
+
+// ---- classify ---------------------------------------------------------------
+
+test('classify devuelve test si TODOS los archivos son tests', () => {
+    const result = classify({
+        files: ['lib/__tests__/a.test.js', 'lib/__tests__/b.test.js'],
+        commits: [],
+        status: [],
+    });
+    assert.equal(result, 'test');
+});
+
+test('classify devuelve docs si TODOS los archivos son docs', () => {
+    const result = classify({
+        files: ['docs/foo.md', 'README.md'],
+        commits: [],
+        status: [],
+    });
+    assert.equal(result, 'docs');
+});
+
+test('classify devuelve chore si TODOS los archivos son chore (build/CI)', () => {
+    const result = classify({
+        files: ['.github/workflows/ci.yml', '.gitignore'],
+        commits: [],
+        status: [],
+    });
+    assert.equal(result, 'chore');
+});
+
+test('classify respeta el subject del primer commit cuando es conventional', () => {
+    // Mix de archivos prod + test, pero el commit dice "fix" → fix.
+    const result = classify({
+        files: ['app/src/main/Foo.kt', 'app/src/test/FooTest.kt'],
+        commits: [
+            { sha: 'abc', subject: 'test: agregar más tests' },          // último commit
+            { sha: 'def', subject: 'fix(api): corregir parsing' },        // primer commit
+        ],
+        status: [],
+    });
+    assert.equal(result, 'fix');
+});
+
+test('classify devuelve feat si hay archivos nuevos (status A) y no hay otra señal', () => {
+    const result = classify({
+        files: [],
+        commits: [],
+        status: [
+            { code: 'A ', path: 'app/src/main/NewService.kt' },
+        ],
+    });
+    assert.equal(result, 'feat');
+});
+
+test('classify devuelve fix si solo hay archivos modificados', () => {
+    const result = classify({
+        files: [],
+        commits: [],
+        status: [
+            { code: ' M', path: 'app/src/main/ExistingService.kt' },
+        ],
+    });
+    assert.equal(result, 'fix');
+});
+
+test('classify devuelve null si no hay señales', () => {
+    const result = classify({ files: [], commits: [], status: [] });
+    assert.equal(result, null);
+});
+
+test('classify usa override cuando se le pasa uno válido', () => {
+    const result = classify({
+        files: ['docs/foo.md'],   // sería docs
+        override: 'feat',
+    });
+    assert.equal(result, 'feat');
+});
+
+test('classify ignora override inválido', () => {
+    const result = classify({
+        files: ['docs/foo.md'],
+        override: 'banana',
+    });
+    assert.equal(result, 'docs');
+});
+
+test('classify NO confunde archivos chore con prod cuando hay test+chore mezclados', () => {
+    // Solo tests + chore: si todos son test → test gana (regla 1 antes que chore).
+    // Pero si hay test + chore mezclado, ya no son TODOS tests ni TODOS chore.
+    // El subject del commit decide, sino caemos en statusBasedType.
+    const result = classify({
+        files: ['lib/__tests__/foo.test.js', 'package.json'],
+        commits: [{ sha: 'a', subject: 'chore(deps): bump foo' }],
+        status: [],
+    });
+    assert.equal(result, 'chore');
+});
+
+test('classify para el caso real del whisper fix (PR #2866)', () => {
+    // El fix que mergeamos hoy: 2 archivos JS modificados, commit fix(pipeline): ...
+    const result = classify({
+        files: ['.pipeline/lib/whisper-local.js', '.pipeline/multimedia.js'],
+        commits: [{ sha: 'abc', subject: 'fix(pipeline): whisper local default model' }],
+        status: [],
+    });
+    assert.equal(result, 'fix');
+});
+
+test('classify para el caso real de los módulos de delivery (PR #2871)', () => {
+    // Archivos nuevos en .pipeline/lib/delivery/ y __tests__ → tests son test pattern,
+    // los .js de delivery no. El subject dice "refactor".
+    const result = classify({
+        files: [
+            '.pipeline/lib/delivery/git-context.js',
+            '.pipeline/lib/__tests__/git-context.test.js',
+        ],
+        commits: [{ sha: 'abc', subject: 'refactor(delivery): git-context determinístico' }],
+        status: [],
+    });
+    assert.equal(result, 'refactor');
+});

--- a/.pipeline/lib/__tests__/commit-builder.test.js
+++ b/.pipeline/lib/__tests__/commit-builder.test.js
@@ -1,0 +1,155 @@
+// =============================================================================
+// Tests commit-builder.js — refactor de /delivery (#2870)
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+    build,
+    parseDeliveryPayload,
+    buildFallbackMessage,
+} = require('../delivery/commit-builder');
+
+// ---- parseDeliveryPayload --------------------------------------------------
+
+test('parseDeliveryPayload extrae la sección commit-message del payload', () => {
+    const issue = `
+<!-- delivery-payload -->
+## commit-message
+fix(api): corregir parsing JSON
+
+Body adicional del commit.
+
+## pr-body
+- Punto 1
+- Punto 2
+
+## qa-disposition
+qa:passed
+<!-- /delivery-payload -->
+`;
+    const result = parseDeliveryPayload(issue);
+    assert.equal(result, 'fix(api): corregir parsing JSON\n\nBody adicional del commit.');
+});
+
+test('parseDeliveryPayload devuelve null si no hay payload', () => {
+    const issue = 'Este es solo un comentario sin payload';
+    const result = parseDeliveryPayload(issue);
+    assert.equal(result, null);
+});
+
+test('parseDeliveryPayload maneja espacios y saltos de línea alrededor del marker', () => {
+    const issue = `
+<!--  delivery-payload  -->
+## commit-message
+feat: nueva característica
+
+## pr-body
+Descripción
+
+<!--  /delivery-payload  -->
+`;
+    const result = parseDeliveryPayload(issue);
+    assert.match(result, /feat: nueva característica/);
+});
+
+// ---- buildFallbackMessage --------------------------------------------------
+
+test('buildFallbackMessage construye mensaje convencional simple', () => {
+    const msg = buildFallbackMessage('feat', 'nueva funcionalidad X');
+    assert.equal(msg, 'feat: nueva funcionalidad X');
+});
+
+test('buildFallbackMessage trunca subject a 72 caracteres', () => {
+    const longSubject = 'a'.repeat(100);
+    const msg = buildFallbackMessage('fix', longSubject);
+    const lines = msg.split('\n');
+    assert.ok(lines[0].length <= 72);
+});
+
+test('buildFallbackMessage incluye body multilinea', () => {
+    const description = `Sujeto corto
+Primer párrafo del body.
+Segundo párrafo.`;
+    const msg = buildFallbackMessage('refactor', description);
+    assert.match(msg, /Primer párrafo del body/);
+    assert.match(msg, /Segundo párrafo/);
+});
+
+test('buildFallbackMessage normaliza tipo a minúsculas', () => {
+    const msg = buildFallbackMessage('FIX', 'algo');
+    assert.match(msg, /^fix:/);
+});
+
+test('buildFallbackMessage rechaza tipo inválido, usa chore', () => {
+    const msg = buildFallbackMessage('invalid', 'algo');
+    assert.match(msg, /^chore:/);
+});
+
+test('buildFallbackMessage con null type y description devuelve default', () => {
+    const msg = buildFallbackMessage(null, null);
+    assert.equal(msg, 'chore: actualizar estado del delivery');
+});
+
+// ---- build principal -------------------------------------------------------
+
+test('build lee payload del último comentario del issue', () => {
+    const result = build({
+        issueComments: [
+            { body: 'Comentario 1' },
+            { body: '<!-- delivery-payload -->\n## commit-message\nfeat: x\n## pr-body\n...\n<!-- /delivery-payload -->' },
+            { body: 'Comentario 3 sin payload' },
+        ],
+    });
+    // El comentario más nuevo (índice 2) no tiene payload, pero hay uno en el índice 1
+    assert.equal(result.source, 'issue-payload');
+    assert.match(result.message, /feat: x/);
+});
+
+test('build gana último payload cuando hay múltiples comentarios con payload', () => {
+    const result = build({
+        issueComments: [
+            { body: '<!-- delivery-payload -->\n## commit-message\nfeat: primera\n## pr-body\n...\n<!-- /delivery-payload -->' },
+            { body: '<!-- delivery-payload -->\n## commit-message\nfeat: segunda\n## pr-body\n...\n<!-- /delivery-payload -->' },
+        ],
+    });
+    assert.match(result.message, /feat: segunda/);
+});
+
+test('build cae a fallback si no hay payload en comments', () => {
+    const result = build({
+        issueComments: [
+            { body: 'Comentario sin payload' },
+        ],
+        type: 'fix',
+        description: 'algún bug',
+    });
+    assert.equal(result.source, 'fallback');
+    assert.match(result.message, /^fix:/);
+});
+
+test('build lee payload del issue body si no hay en comments', () => {
+    const result = build({
+        issueBody: '<!-- delivery-payload -->\n## commit-message\nfeat: body payload\n## pr-body\n...\n<!-- /delivery-payload -->',
+        issueComments: [
+            { body: 'Comentario sin payload' },
+        ],
+    });
+    assert.equal(result.source, 'issue-payload');
+    assert.match(result.message, /feat: body payload/);
+});
+
+test('build sin issue retorna fallback con defaults', () => {
+    const result = build({});
+    assert.equal(result.source, 'fallback');
+    assert.equal(result.message, 'chore: actualizar estado del delivery');
+});
+
+test('build estructura retornada siempre contiene message y source', () => {
+    const r1 = build({ issueComments: [], type: 'feat', description: 'x' });
+    assert.ok('message' in r1);
+    assert.ok('source' in r1);
+    assert.match(r1.source, /^(issue-payload|fallback)$/);
+});

--- a/.pipeline/lib/__tests__/delivery-orchestrator.test.js
+++ b/.pipeline/lib/__tests__/delivery-orchestrator.test.js
@@ -1,0 +1,72 @@
+// =============================================================================
+// Tests delivery.js (orquestador) — refactor #2870
+//
+// Solo testea las funciones puras (parseArgs, fetchIssue parsing).
+// El flujo end-to-end (main) requiere repo git + gh CLI mockeado, lo cubre
+// el smoke test manual.
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const { parseArgs } = require('../../delivery');
+
+// ---- parseArgs --------------------------------------------------------------
+
+test('parseArgs lee --issue y --description', () => {
+    const args = parseArgs(['node', 'delivery.js', '--issue', '123', '--description', 'hola mundo']);
+    assert.equal(args.issue, '123');
+    assert.equal(args.description, 'hola mundo');
+});
+
+test('parseArgs lee --type override', () => {
+    const args = parseArgs(['node', 'delivery.js', '--type', 'feat']);
+    assert.equal(args.type, 'feat');
+});
+
+test('parseArgs lee --draft como boolean', () => {
+    const args = parseArgs(['node', 'delivery.js', '--draft']);
+    assert.equal(args.draft, true);
+});
+
+test('parseArgs lee --dry-run como boolean', () => {
+    const args = parseArgs(['node', 'delivery.js', '--dry-run']);
+    assert.equal(args.dryRun, true);
+});
+
+test('parseArgs defaults sensatos cuando no hay args', () => {
+    const args = parseArgs(['node', 'delivery.js']);
+    assert.equal(args.issue, null);
+    assert.equal(args.description, null);
+    assert.equal(args.type, null);
+    assert.equal(args.draft, false);
+    assert.equal(args.dryRun, false);
+    assert.equal(args.repo, 'intrale/platform');
+    assert.equal(args.base, 'main');
+});
+
+test('parseArgs permite override de --repo y --base', () => {
+    const args = parseArgs([
+        'node', 'delivery.js',
+        '--repo', 'foo/bar',
+        '--base', 'develop',
+    ]);
+    assert.equal(args.repo, 'foo/bar');
+    assert.equal(args.base, 'develop');
+});
+
+test('parseArgs combina múltiples flags', () => {
+    const args = parseArgs([
+        'node', 'delivery.js',
+        '--issue', '456',
+        '--description', 'fix bug',
+        '--type', 'fix',
+        '--draft',
+    ]);
+    assert.equal(args.issue, '456');
+    assert.equal(args.description, 'fix bug');
+    assert.equal(args.type, 'fix');
+    assert.equal(args.draft, true);
+});

--- a/.pipeline/lib/__tests__/git-context.test.js
+++ b/.pipeline/lib/__tests__/git-context.test.js
@@ -1,0 +1,184 @@
+// =============================================================================
+// Tests git-context.js — refactor de /delivery (#2870)
+//
+// Crea un repo git temporal con commits sintéticos y valida que la API
+// extrae el estado correcto. Sin red, sin remote real.
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const ctx = require('../delivery/git-context');
+
+// ---- Helpers ----------------------------------------------------------------
+
+function sh(cwd, args) {
+    const r = spawnSync('git', ['-C', cwd, ...args], { encoding: 'utf8', windowsHide: true });
+    if (r.status !== 0) throw new Error(`git ${args.join(' ')} fail: ${r.stderr}`);
+    return r.stdout.trim();
+}
+
+// Setup: repo con base "main" y nuestro branch "feature" con 2 commits adelante.
+function makeRepo() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-ctx-test-'));
+    sh(dir, ['init', '-q', '-b', 'main']);
+    sh(dir, ['config', 'user.email', 'test@test.test']);
+    sh(dir, ['config', 'user.name', 'Test']);
+    sh(dir, ['config', 'commit.gpgsign', 'false']);
+
+    fs.writeFileSync(path.join(dir, 'README.md'), '# base\n');
+    sh(dir, ['add', 'README.md']);
+    sh(dir, ['commit', '-q', '-m', 'init']);
+
+    // Simular origin/main apuntando al commit base
+    sh(dir, ['update-ref', 'refs/remotes/origin/main', 'HEAD']);
+
+    sh(dir, ['checkout', '-q', '-b', 'feature']);
+
+    fs.writeFileSync(path.join(dir, 'a.js'), 'console.log("a");\n');
+    sh(dir, ['add', 'a.js']);
+    sh(dir, ['commit', '-q', '-m', 'feat: agregar a']);
+
+    fs.writeFileSync(path.join(dir, 'b.js'), 'console.log("b");\n');
+    sh(dir, ['add', 'b.js']);
+    sh(dir, ['commit', '-q', '-m', 'fix: agregar b']);
+
+    return dir;
+}
+
+function cleanup(dir) {
+    try { fs.rmSync(dir, { recursive: true, force: true, maxRetries: 3 }); } catch {}
+}
+
+// ---- Tests ------------------------------------------------------------------
+
+test('currentBranch devuelve el branch actual', () => {
+    const repo = makeRepo();
+    try {
+        assert.equal(ctx.currentBranch(repo), 'feature');
+    } finally { cleanup(repo); }
+});
+
+test('aheadCount cuenta commits adelante de origin/main', () => {
+    const repo = makeRepo();
+    try {
+        assert.equal(ctx.aheadCount(repo, 'origin/main'), 2);
+    } finally { cleanup(repo); }
+});
+
+test('behindCount es 0 cuando origin/main no avanzó', () => {
+    const repo = makeRepo();
+    try {
+        assert.equal(ctx.behindCount(repo, 'origin/main'), 0);
+    } finally { cleanup(repo); }
+});
+
+test('behindCount detecta commits nuevos en origin/main', () => {
+    const repo = makeRepo();
+    try {
+        // Avanzar origin/main con un commit "nuevo" (otra rama, copy ref)
+        sh(repo, ['checkout', '-q', 'main']);
+        fs.writeFileSync(path.join(repo, 'c.js'), 'c\n');
+        sh(repo, ['add', 'c.js']);
+        sh(repo, ['commit', '-q', '-m', 'origin advance']);
+        sh(repo, ['update-ref', 'refs/remotes/origin/main', 'HEAD']);
+        sh(repo, ['checkout', '-q', 'feature']);
+        assert.equal(ctx.behindCount(repo, 'origin/main'), 1);
+    } finally { cleanup(repo); }
+});
+
+test('commitsAhead lista commits con sha y subject', () => {
+    const repo = makeRepo();
+    try {
+        const commits = ctx.commitsAhead(repo, 'origin/main');
+        assert.equal(commits.length, 2);
+        assert.equal(commits[0].subject, 'fix: agregar b');
+        assert.equal(commits[1].subject, 'feat: agregar a');
+        for (const c of commits) {
+            assert.match(c.sha, /^[0-9a-f]{7,}$/);
+        }
+    } finally { cleanup(repo); }
+});
+
+test('filesChanged lista archivos modificados respecto a base', () => {
+    const repo = makeRepo();
+    try {
+        const files = ctx.filesChanged(repo, 'origin/main');
+        assert.deepEqual(files.sort(), ['a.js', 'b.js']);
+    } finally { cleanup(repo); }
+});
+
+test('diffStat retorna files/insertions/deletions parseados', () => {
+    const repo = makeRepo();
+    try {
+        const stat = ctx.diffStat(repo, 'origin/main');
+        assert.equal(stat.files, 2);
+        assert.ok(stat.insertions >= 2, `insertions debe ser >=2, fue ${stat.insertions}`);
+        assert.equal(stat.deletions, 0);
+    } finally { cleanup(repo); }
+});
+
+test('statusPorcelain lista archivos sin commitear', () => {
+    const repo = makeRepo();
+    try {
+        // Tree limpio al inicio
+        assert.equal(ctx.statusPorcelain(repo).length, 0);
+
+        // Crear archivo untracked
+        fs.writeFileSync(path.join(repo, 'untracked.txt'), 'x');
+        // Modificar uno tracked
+        fs.writeFileSync(path.join(repo, 'a.js'), 'modified\n');
+
+        const status = ctx.statusPorcelain(repo);
+        const paths = status.map(s => s.path).sort();
+        assert.deepEqual(paths, ['a.js', 'untracked.txt']);
+
+        const codes = Object.fromEntries(status.map(s => [s.path, s.code]));
+        assert.equal(codes['untracked.txt'], '??');
+        assert.match(codes['a.js'], /M/);
+    } finally { cleanup(repo); }
+});
+
+test('diffText incluye el contenido del diff', () => {
+    const repo = makeRepo();
+    try {
+        const diff = ctx.diffText(repo, 'origin/main');
+        assert.match(diff, /diff --git/);
+        assert.match(diff, /a\.js/);
+        assert.match(diff, /b\.js/);
+        assert.match(diff, /\+console\.log/);
+    } finally { cleanup(repo); }
+});
+
+test('diffText respeta maxBytes y agrega marcador truncated', () => {
+    const repo = makeRepo();
+    try {
+        const diff = ctx.diffText(repo, 'origin/main', 50);
+        assert.ok(diff.length <= 80, `diff truncado a ~50 bytes, fue ${diff.length}`);
+        assert.match(diff, /\[truncated\]/);
+    } finally { cleanup(repo); }
+});
+
+test('snapshot devuelve estructura agregada con todo el contexto', () => {
+    const repo = makeRepo();
+    try {
+        const snap = ctx.snapshot(repo);
+        assert.equal(snap.branch, 'feature');
+        assert.equal(snap.ahead, 2);
+        assert.equal(snap.behind, 0);
+        assert.equal(snap.commits.length, 2);
+        assert.equal(snap.files.length, 2);
+        assert.equal(snap.stat.files, 2);
+    } finally { cleanup(repo); }
+});
+
+test('git() maneja cwd inválido devolviendo ok=false sin tirar', () => {
+    const r = ctx.git(['status'], '/path/que/no/existe');
+    assert.equal(r.ok, false);
+    assert.notEqual(r.status, 0);
+});

--- a/.pipeline/lib/__tests__/pr-builder.test.js
+++ b/.pipeline/lib/__tests__/pr-builder.test.js
@@ -1,0 +1,172 @@
+// =============================================================================
+// Tests pr-builder.js — refactor de /delivery (#2870)
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+    build,
+    parseDeliveryPayload,
+    buildFallbackBody,
+} = require('../delivery/pr-builder');
+
+// ---- parseDeliveryPayload --------------------------------------------------
+
+test('parseDeliveryPayload extrae la sección pr-body del payload', () => {
+    const issue = `
+<!-- delivery-payload -->
+## commit-message
+fix(api): corregir parsing JSON
+
+## pr-body
+- Punto 1 del PR
+- Punto 2 del PR
+
+Descripción larga del PR.
+
+## qa-disposition
+qa:passed
+<!-- /delivery-payload -->
+`;
+    const result = parseDeliveryPayload(issue);
+    assert.match(result, /Punto 1 del PR/);
+    assert.match(result, /Descripción larga del PR/);
+});
+
+test('parseDeliveryPayload devuelve null si no hay payload', () => {
+    const issue = 'Este es solo un comentario sin payload';
+    const result = parseDeliveryPayload(issue);
+    assert.equal(result, null);
+});
+
+test('parseDeliveryPayload maneja espacios alrededor del marker', () => {
+    const issue = `
+<!--  delivery-payload  -->
+## commit-message
+feat: x
+
+##  pr-body
+Contenido del PR
+
+##  qa-disposition
+qa:passed
+<!--  /delivery-payload  -->
+`;
+    const result = parseDeliveryPayload(issue);
+    assert.match(result, /Contenido del PR/);
+});
+
+// ---- buildFallbackBody --------------------------------------------------
+
+test('buildFallbackBody genera body simple sin contenido', () => {
+    const body = buildFallbackBody({});
+    assert.match(body, /## Resumen/);
+    assert.match(body, /Actualización del sistema de entrega/);
+    assert.match(body, /Claude Code/);
+});
+
+test('buildFallbackBody incluye descripción cuando existe', () => {
+    const body = buildFallbackBody({
+        description: 'Implementar nueva API de usuarios',
+    });
+    assert.match(body, /Implementar nueva API de usuarios/);
+});
+
+test('buildFallbackBody incluye estadísticas de diff', () => {
+    const body = buildFallbackBody({
+        filesChanged: 5,
+        insertions: 120,
+        deletions: 30,
+    });
+    assert.match(body, /5 archivo/);
+    assert.match(body, /120 línea.*agregada/);
+    assert.match(body, /30 línea.*removida/);
+});
+
+test('buildFallbackBody incluye Closes cuando hay issue number', () => {
+    const body = buildFallbackBody({
+        issueNumber: 123,
+    });
+    assert.match(body, /Closes #123/);
+});
+
+test('buildFallbackBody incluye footer con Claude Code', () => {
+    const body = buildFallbackBody({});
+    assert.match(body, /🤖 Generado con/);
+    assert.match(body, /claude-code/i);
+});
+
+// ---- build principal -------------------------------------------------------
+
+test('build lee payload del último comentario del issue', () => {
+    const result = build({
+        issueComments: [
+            { body: 'Comentario 1' },
+            { body: '<!-- delivery-payload -->\n## commit-message\nfeat: x\n## pr-body\nPayload PR\n## qa-disposition\n...\n<!-- /delivery-payload -->' },
+            { body: 'Comentario 3 sin payload' },
+        ],
+    });
+    assert.equal(result.source, 'issue-payload');
+    assert.match(result.body, /Payload PR/);
+});
+
+test('build gana último payload cuando hay múltiples comentarios con payload', () => {
+    const result = build({
+        issueComments: [
+            { body: '<!-- delivery-payload -->\n## commit-message\nfeat: x\n## pr-body\nPrimera\n## qa-disposition\nqa:passed\n<!-- /delivery-payload -->' },
+            { body: '<!-- delivery-payload -->\n## commit-message\nfeat: y\n## pr-body\nSegunda\n## qa-disposition\nqa:passed\n<!-- /delivery-payload -->' },
+        ],
+    });
+    assert.match(result.body, /Segunda/);
+});
+
+test('build cae a fallback si no hay payload en comments', () => {
+    const result = build({
+        issueComments: [
+            { body: 'Comentario sin payload' },
+        ],
+        description: 'Nueva feature',
+        diffStat: { files: 2, insertions: 50, deletions: 10 },
+    });
+    assert.equal(result.source, 'fallback');
+    assert.match(result.body, /Nueva feature/);
+    assert.match(result.body, /2 archivo/);
+});
+
+test('build lee payload del issue body si no hay en comments', () => {
+    const result = build({
+        issueBody: '<!-- delivery-payload -->\n## commit-message\nfeat: x\n## pr-body\nPayload body\n## qa-disposition\nqa:passed\n<!-- /delivery-payload -->',
+        issueComments: [
+            { body: 'Comentario sin payload' },
+        ],
+    });
+    assert.equal(result.source, 'issue-payload');
+    assert.match(result.body, /Payload body/);
+});
+
+test('build sin issue retorna fallback con defaults', () => {
+    const result = build({});
+    assert.equal(result.source, 'fallback');
+    assert.match(result.body, /Actualización del sistema de entrega/);
+});
+
+test('build estructura retornada siempre contiene body y source', () => {
+    const r1 = build({ issueComments: [] });
+    assert.ok('body' in r1);
+    assert.ok('source' in r1);
+    assert.match(r1.source, /^(issue-payload|fallback)$/);
+});
+
+test('build combina descripción + diff stat + issue number en fallback', () => {
+    const result = build({
+        description: 'Arreglar bug crítico',
+        diffStat: { files: 3, insertions: 75, deletions: 20 },
+        issueNumber: 456,
+    });
+    assert.match(result.body, /Arreglar bug crítico/);
+    assert.match(result.body, /3 archivo/);
+    assert.match(result.body, /75 línea.*agregada/);
+    assert.match(result.body, /Closes #456/);
+});

--- a/.pipeline/lib/__tests__/worktree-cleanup.test.js
+++ b/.pipeline/lib/__tests__/worktree-cleanup.test.js
@@ -1,0 +1,236 @@
+// =============================================================================
+// Tests worktree-cleanup.js — fix #2867
+//
+// Cubre la detección de "sesión activa" que es el bug crítico que llevó a
+// que /delivery se borrara los skills a sí mismo. Los tests de junction y
+// cleanup completo son integración (requieren git/fsutil) y se hacen aparte.
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+    isActiveSession,
+    isJunction,
+    dismountClaudeJunction,
+    cleanupWorktree,
+} = require('../delivery/worktree-cleanup');
+
+// ---- Helpers ----------------------------------------------------------------
+
+function mkTempWorktree() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wt-cleanup-test-'));
+    return dir;
+}
+
+// ---- isActiveSession --------------------------------------------------------
+
+test('isActiveSession devuelve true cuando cwd === worktree', () => {
+    const wt = mkTempWorktree();
+    try {
+        assert.equal(isActiveSession(wt, wt), true);
+    } finally {
+        fs.rmSync(wt, { recursive: true, force: true });
+    }
+});
+
+test('isActiveSession devuelve true cuando cwd está dentro de worktree', () => {
+    const wt = mkTempWorktree();
+    const sub = path.join(wt, 'subdir');
+    fs.mkdirSync(sub);
+    try {
+        assert.equal(isActiveSession(wt, sub), true);
+    } finally {
+        fs.rmSync(wt, { recursive: true, force: true });
+    }
+});
+
+test('isActiveSession devuelve false cuando cwd está fuera de worktree', () => {
+    const wt = mkTempWorktree();
+    const otherDir = mkTempWorktree();
+    try {
+        assert.equal(isActiveSession(wt, otherDir), false);
+    } finally {
+        fs.rmSync(wt, { recursive: true, force: true });
+        fs.rmSync(otherDir, { recursive: true, force: true });
+    }
+});
+
+test('isActiveSession devuelve false cuando worktree no existe', () => {
+    const cwd = mkTempWorktree();
+    try {
+        assert.equal(isActiveSession('/path/que/no/existe', cwd), false);
+    } finally {
+        fs.rmSync(cwd, { recursive: true, force: true });
+    }
+});
+
+test('isActiveSession devuelve false con args faltantes', () => {
+    assert.equal(isActiveSession(null, '/some/path'), false);
+    assert.equal(isActiveSession('/some/path', null), false);
+    assert.equal(isActiveSession(null, null), false);
+    assert.equal(isActiveSession('', ''), false);
+});
+
+test('isActiveSession es case-insensitive en Windows (no falsos negativos por mayúsculas)', () => {
+    // En Windows el filesystem es case-insensitive. Si el comparador no lo
+    // contempla, paths que difieren solo en casing producirían false.
+    if (process.platform !== 'win32') return; // skip en non-Windows
+    const wt = mkTempWorktree();
+    try {
+        // Construir variantes con casing alterado del path original
+        const upper = wt.toUpperCase();
+        const lower = wt.toLowerCase();
+        // Solo testeable si realpath resuelve a lo mismo
+        try {
+            const realLower = fs.realpathSync(lower);
+            assert.equal(isActiveSession(wt, realLower), true);
+        } catch {
+            // ambiente no soporta el casing alternado; skip
+        }
+        // Mismo path con upper/lower
+        try {
+            assert.equal(isActiveSession(upper, wt), true);
+        } catch {
+            // skip
+        }
+    } finally {
+        fs.rmSync(wt, { recursive: true, force: true });
+    }
+});
+
+test('isActiveSession NO da falso positivo por prefijo de path', () => {
+    // Si un comparador hace startsWith sin tener en cuenta el separador,
+    // /foo/bar startsWith /foo/ba sería true incorrectamente.
+    const root = mkTempWorktree();
+    const wtFoo = path.join(root, 'foo');
+    const wtFooBar = path.join(root, 'foobar');
+    fs.mkdirSync(wtFoo);
+    fs.mkdirSync(wtFooBar);
+    try {
+        // cwd está en /foobar, worktree es /foo — NO debe ser activo.
+        // (Esta es la razón de comparar paths reales con realpath: en general
+        // no produce falsos positivos por casualidad, pero el comparador
+        // con startsWith plano sí. Validamos el comportamiento real.)
+        const result = isActiveSession(wtFoo, wtFooBar);
+        // El comparador actual usa startsWith pero sobre realpath normalizado.
+        // /foobar.startsWith(/foo) es true en string puro, lo cual sería un bug.
+        // Documentamos el caso: si el test falla, hay que agregar separador
+        // al final antes del startsWith.
+        assert.equal(result, false, 'Falso positivo por prefijo: comparar con separador final');
+    } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+    }
+});
+
+// ---- isJunction -------------------------------------------------------------
+
+test('isJunction devuelve false para path inexistente', () => {
+    assert.equal(isJunction('/path/que/no/existe/abcdef'), false);
+});
+
+test('isJunction devuelve false para directorio real', () => {
+    const dir = mkTempWorktree();
+    try {
+        assert.equal(isJunction(dir), false);
+    } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+// Test con junction real solo en Windows con permisos suficientes
+test('isJunction devuelve true para junction Windows', { skip: process.platform !== 'win32' }, () => {
+    const target = mkTempWorktree();
+    const linkDir = mkTempWorktree();
+    const linkPath = path.join(linkDir, 'junction');
+    try {
+        const { spawnSync } = require('node:child_process');
+        const winTarget = target.replace(/\//g, '\\');
+        const winLink = linkPath.replace(/\//g, '\\');
+        const result = spawnSync('cmd', ['/c', 'mklink', '/J', winLink, winTarget], {
+            stdio: 'pipe',
+            windowsHide: true,
+        });
+        if (result.status !== 0) {
+            // No tenemos permisos para crear junction — skip suave
+            return;
+        }
+        assert.equal(isJunction(linkPath), true);
+        // Y un dir real al lado debe seguir siendo false
+        assert.equal(isJunction(target), false);
+    } finally {
+        // Limpiar junction antes que el dir, y con cmd para no seguir el junction
+        try {
+            const { spawnSync } = require('node:child_process');
+            const winLink = linkPath.replace(/\//g, '\\');
+            spawnSync('cmd', ['/c', 'rmdir', winLink], { stdio: 'ignore' });
+        } catch {}
+        fs.rmSync(linkDir, { recursive: true, force: true });
+        fs.rmSync(target, { recursive: true, force: true });
+    }
+});
+
+// ---- dismountClaudeJunction -------------------------------------------------
+
+test('dismountClaudeJunction devuelve not_present cuando .claude no existe', () => {
+    const wt = mkTempWorktree();
+    try {
+        const result = dismountClaudeJunction(wt, () => {});
+        assert.equal(result.dismounted, false);
+        assert.equal(result.reason, 'not_present');
+    } finally {
+        fs.rmSync(wt, { recursive: true, force: true });
+    }
+});
+
+test('dismountClaudeJunction NO toca .claude si es copia real (fix #2867)', () => {
+    const wt = mkTempWorktree();
+    const claude = path.join(wt, '.claude');
+    fs.mkdirSync(claude);
+    fs.writeFileSync(path.join(claude, 'sentinela.txt'), 'no me borres');
+    try {
+        const result = dismountClaudeJunction(wt, () => {});
+        assert.equal(result.dismounted, false);
+        assert.equal(result.reason, 'real_copy');
+        // Lo crítico: el archivo debe seguir ahí
+        assert.equal(fs.existsSync(path.join(claude, 'sentinela.txt')), true);
+    } finally {
+        fs.rmSync(wt, { recursive: true, force: true });
+    }
+});
+
+// ---- cleanupWorktree (smoke) ------------------------------------------------
+
+test('cleanupWorktree skipea cuando es sesión activa (fix #2867)', async () => {
+    const wt = mkTempWorktree();
+    try {
+        const result = await cleanupWorktree({
+            worktreePath: wt,
+            branch: 'agent/fake-branch',
+            mainRepoPath: '/no-importa',
+            sessionCwd: wt,        // activa
+            logger: () => {},
+        });
+        assert.equal(result.ok, true);
+        assert.equal(result.skipped, true);
+        assert.equal(result.reason, 'active_session');
+        // Y el worktree filesystem debe seguir intacto
+        assert.equal(fs.existsSync(wt), true);
+    } finally {
+        fs.rmSync(wt, { recursive: true, force: true });
+    }
+});
+
+test('cleanupWorktree falla sin worktreePath', async () => {
+    const result = await cleanupWorktree({
+        worktreePath: null,
+        branch: 'foo',
+        sessionCwd: '/cwd',
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.error, 'missing_args');
+});

--- a/.pipeline/lib/delivery/change-classifier.js
+++ b/.pipeline/lib/delivery/change-classifier.js
@@ -1,0 +1,145 @@
+// change-classifier.js — Clasifica un cambio en su tipo Conventional Commit.
+//
+// Reemplaza el Paso 3 del SKILL.md ("Basándote en el diff, clasificá:")
+// con reglas determinísticas sobre paths, contenido del diff y subjects
+// de los commits ya hechos en el branch.
+//
+// Output: 'feat' | 'fix' | 'refactor' | 'test' | 'docs' | 'chore' | null
+//
+// Política: si las señales son ambiguas, devolver null y que el caller
+// decida (ej: leer el delivery-payload del issue, o caer a 'chore').
+
+// Reglas en orden de prioridad. Primera que matchea, gana.
+const RULES = [
+  // Si TODO lo cambiado son tests → 'test'
+  {
+    type: 'test',
+    when: ({ files }) => files.length > 0 && files.every(isTestFile),
+  },
+  // Si TODO lo cambiado es docs → 'docs'
+  {
+    type: 'docs',
+    when: ({ files }) => files.length > 0 && files.every(isDocFile),
+  },
+  // Subject del primer commit lo dice explícitamente
+  {
+    type: ({ commits }) => firstSubjectType(commits),
+    when: ({ commits }) => firstSubjectType(commits) != null,
+  },
+  // Cambios solo en config/build/CI/infra → 'chore'
+  {
+    type: 'chore',
+    when: ({ files }) => files.length > 0 && files.every(isChoreFile),
+  },
+  // Cambios que tocan código de producción + tests → probablemente 'feat' o 'fix'.
+  // Si hay archivos NUEVOS de producción → 'feat'. Si solo modifican → 'fix'.
+  // (Heurística simple; el caller puede pisarlo con `--type` o el payload del issue.)
+  {
+    type: ({ status }) => statusBasedType(status),
+    when: ({ status }) => statusBasedType(status) != null,
+  },
+];
+
+const TEST_PATTERNS = [
+  /(^|\/)__tests__\//,
+  /(^|\/)test\//,
+  /\.test\.[jt]sx?$/,
+  /\.spec\.[jt]sx?$/,
+  /Test\.kts?$/,
+  /Tests\.kts?$/,
+];
+
+const DOC_PATTERNS = [
+  /^docs\//,
+  /\.md$/i,
+  /^README/i,
+  /^CHANGELOG/i,
+];
+
+const CHORE_PATTERNS = [
+  /^\.github\//,
+  /^\.gitignore$/,
+  /^\.gitattributes$/,
+  /^\.editorconfig$/,
+  /^\.pipeline\/(config\.yaml|.+\.json)$/,
+  /^\.claude\//,
+  /^buildSrc\//,
+  /(^|\/)build\.gradle(\.kts)?$/,
+  /(^|\/)settings\.gradle(\.kts)?$/,
+  /^gradle\//,
+  /(^|\/)package(-lock)?\.json$/,
+  /^renovate\.json$/,
+];
+
+function isTestFile(filePath) {
+  return TEST_PATTERNS.some((p) => p.test(filePath));
+}
+
+function isDocFile(filePath) {
+  // .claude/ es config del harness, no docs (aunque tenga .md)
+  if (filePath.startsWith('.claude/')) return false;
+  return DOC_PATTERNS.some((p) => p.test(filePath));
+}
+
+function isChoreFile(filePath) {
+  // Tests ganan sobre chore (un .test.js en .github/ sigue siendo test)
+  if (isTestFile(filePath)) return false;
+  // Docs ganan también, pero `isDocFile` ya excluye .claude/, así que un
+  // SKILL.md bajo .claude/ entra como chore correctamente.
+  if (isDocFile(filePath)) return false;
+  return CHORE_PATTERNS.some((p) => p.test(filePath));
+}
+
+// Si el subject del primer commit del branch tiene prefijo conventional,
+// se respeta como source of truth. Es lo que el dev intencionalmente puso.
+function firstSubjectType(commits) {
+  if (!commits || commits.length === 0) return null;
+  // El primer commit cronológicamente del branch (último del array, que viene
+  // ordenado por log con HEAD primero).
+  const first = commits[commits.length - 1];
+  return parseConventionalType(first.subject);
+}
+
+// Parsea "fix(scope): texto" o "feat: texto" → "fix" / "feat" / null.
+function parseConventionalType(subject) {
+  if (!subject) return null;
+  const m = subject.match(/^(feat|fix|refactor|test|docs|chore|perf|style|build|ci)(\([^)]+\))?!?:/i);
+  return m ? m[1].toLowerCase() : null;
+}
+
+// Heurística sobre `git status --porcelain`: si hay archivos NUEVOS (A o ??)
+// que no son chore/doc/test, asumimos 'feat'. Si solo hay modificados, 'fix'.
+function statusBasedType(status) {
+  if (!status || status.length === 0) return null;
+  const productionEntries = status.filter((s) => {
+    const p = s.path;
+    return !isTestFile(p) && !isDocFile(p) && !isChoreFile(p);
+  });
+  if (productionEntries.length === 0) return null;
+  const hasNew = productionEntries.some((s) => /^(A |\?\?)/.test(s.code) || s.code.trim() === 'A');
+  return hasNew ? 'feat' : 'fix';
+}
+
+// API principal. Recibe el snapshot de git-context y devuelve el tipo.
+//
+// Acepta también un override (por ejemplo, viniendo del CLI con --type, o
+// del delivery-payload de un issue).
+function classify({ files = [], commits = [], status = [], override = null } = {}) {
+  if (override && parseConventionalType(`${override}: x`)) return override.toLowerCase();
+  for (const rule of RULES) {
+    if (rule.when({ files, commits, status })) {
+      return typeof rule.type === 'function' ? rule.type({ files, commits, status }) : rule.type;
+    }
+  }
+  return null;
+}
+
+module.exports = {
+  classify,
+  parseConventionalType,
+  isTestFile,
+  isDocFile,
+  isChoreFile,
+  // exports para tests
+  _internals: { firstSubjectType, statusBasedType, RULES },
+};

--- a/.pipeline/lib/delivery/commit-builder.js
+++ b/.pipeline/lib/delivery/commit-builder.js
@@ -1,0 +1,94 @@
+// commit-builder.js — Construye el mensaje de commit desde el payload del issue.
+//
+// Lee el comentario marcado en el issue (delivery-payload) y extrae la sección
+// commit-message. Si no existe, cae a un template determinístico.
+//
+// Output: { message, source }
+// source: 'issue-payload' | 'fallback'
+
+function parseDeliveryPayload(issueBodyOrComment) {
+  if (!issueBodyOrComment) return null;
+  const match = issueBodyOrComment.match(
+    /<!--\s*delivery-payload\s*-->[\s\S]*?##\s*commit-message\s*\n([\s\S]*?)\n##\s/
+  );
+  if (!match) return null;
+  return match[1].trim();
+}
+
+// Template fallback cuando no hay payload de issue.
+// Usa el tipo inferido y la descripción para construir un commit convencional.
+function buildFallbackMessage(type, description) {
+  if (!type || !description) {
+    return 'chore: actualizar estado del delivery';
+  }
+  // Garantizar que el type es válido y esté en minúsculas
+  const validTypes = ['feat', 'fix', 'refactor', 'test', 'docs', 'chore', 'perf', 'style', 'build', 'ci'];
+  const normalizedType = validTypes.includes(type.toLowerCase()) ? type.toLowerCase() : 'chore';
+
+  // Primer párrafo como subject.
+  // El total "type: subject" debe ser <= 72 caracteres.
+  const lines = description.split('\n');
+  const prefix = `${normalizedType}: `;
+  const maxSubjectLen = Math.max(20, 72 - prefix.length); // mínimo 20 chars para el subject
+  const subject = lines[0].slice(0, maxSubjectLen);
+  const body = lines.slice(1).filter(l => l.trim()).join('\n');
+
+  let message = `${prefix}${subject}`;
+  if (body) {
+    message += `\n\n${body}`;
+  }
+  return message;
+}
+
+// API principal. Lee el issue, extrae el payload o cae a fallback.
+//
+// `issue` puede ser:
+// - null/undefined: usa fallback
+// - { body, comments: [{ body, ... }, ...] }: búsqueda en comments
+//
+// Retorna { message, source }
+function build({
+  issueBody = null,
+  issueComments = [],
+  type = null,
+  description = null,
+} = {}) {
+  // Buscar payload en comments (orden reverso: el último gana)
+  for (let i = issueComments.length - 1; i >= 0; i--) {
+    const commentText = typeof issueComments[i] === 'string'
+      ? issueComments[i]
+      : issueComments[i]?.body;
+    const payload = parseDeliveryPayload(commentText);
+    if (payload) {
+      return {
+        message: payload,
+        source: 'issue-payload',
+      };
+    }
+  }
+
+  // Fallback: buscar en el body del issue
+  if (issueBody) {
+    const payload = parseDeliveryPayload(issueBody);
+    if (payload) {
+      return {
+        message: payload,
+        source: 'issue-payload',
+      };
+    }
+  }
+
+  // Template fallback
+  return {
+    message: buildFallbackMessage(type, description),
+    source: 'fallback',
+  };
+}
+
+module.exports = {
+  build,
+  parseDeliveryPayload,
+  buildFallbackMessage,
+  // exports para tests
+  _internals: { parseDeliveryPayload, buildFallbackMessage },
+};

--- a/.pipeline/lib/delivery/git-context.js
+++ b/.pipeline/lib/delivery/git-context.js
@@ -1,0 +1,133 @@
+// git-context.js — Lectura pura del estado git para el delivery
+//
+// Reemplaza el Paso 2 del SKILL.md (que pedía al LLM correr 4 comandos y
+// parsear los outputs). Acá lo hacemos con spawnSync determinístico.
+//
+// Toda la API devuelve estructuras planas, sin side effects. Si querés
+// que falle algo, lo decide el caller.
+
+const { spawnSync } = require('child_process');
+
+function git(args, cwd, opts = {}) {
+  const result = spawnSync('git', ['-C', cwd, ...args], {
+    stdio: 'pipe',
+    encoding: 'utf8',
+    windowsHide: true,
+    ...opts,
+  });
+  // OJO: solo strippeamos whitespace TRAILING, NO leading. `git status
+  // --porcelain` usa espacios significativos al inicio de cada línea.
+  const trimRight = (s) => (s || '').replace(/\s+$/, '');
+  return {
+    ok: result.status === 0,
+    status: result.status,
+    stdout: trimRight(result.stdout),
+    stderr: trimRight(result.stderr),
+  };
+}
+
+// Branch actual del worktree.
+function currentBranch(cwd) {
+  const r = git(['branch', '--show-current'], cwd);
+  return r.ok ? r.stdout : null;
+}
+
+// Lista de commits que separan HEAD de la base. Devuelve array de
+// { sha, subject } en orden cronológico inverso (HEAD primero).
+function commitsAhead(cwd, base = 'origin/main') {
+  const r = git(['log', `${base}..HEAD`, '--oneline'], cwd);
+  if (!r.ok) return [];
+  return r.stdout.split('\n').filter(Boolean).map((line) => {
+    const idx = line.indexOf(' ');
+    if (idx < 0) return { sha: line, subject: '' };
+    return { sha: line.slice(0, idx), subject: line.slice(idx + 1) };
+  });
+}
+
+// Cantidad de commits adelante del base.
+function aheadCount(cwd, base = 'origin/main') {
+  const r = git(['rev-list', '--count', `${base}..HEAD`], cwd);
+  return r.ok ? Number(r.stdout) || 0 : 0;
+}
+
+// Cantidad de commits que el base está adelante (necesitamos rebase si > 0).
+function behindCount(cwd, base = 'origin/main') {
+  const r = git(['rev-list', '--count', `HEAD..${base}`], cwd);
+  return r.ok ? Number(r.stdout) || 0 : 0;
+}
+
+// `git status --porcelain` parseado. Devuelve array de { code, path }.
+// code es el código de status de 2 caracteres (ej: " M", "??", "A ").
+function statusPorcelain(cwd) {
+  const r = git(['status', '--porcelain'], cwd);
+  if (!r.ok) return [];
+  return r.stdout.split('\n').filter(Boolean).map((line) => ({
+    code: line.slice(0, 2),
+    path: line.slice(3),
+  }));
+}
+
+// Lista de archivos cambiados entre base y HEAD (commits ya hechos).
+function filesChanged(cwd, base = 'origin/main') {
+  const r = git(['diff', '--name-only', `${base}...HEAD`], cwd);
+  return r.ok ? r.stdout.split('\n').filter(Boolean) : [];
+}
+
+// Stat de cambios entre base y HEAD: { files, insertions, deletions }.
+function diffStat(cwd, base = 'origin/main') {
+  const r = git(['diff', '--shortstat', `${base}...HEAD`], cwd);
+  if (!r.ok || !r.stdout) return { files: 0, insertions: 0, deletions: 0 };
+  const m = r.stdout.match(/(\d+) files? changed(?:, (\d+) insertions?\(\+\))?(?:, (\d+) deletions?\(-\))?/);
+  if (!m) return { files: 0, insertions: 0, deletions: 0 };
+  return {
+    files: Number(m[1]) || 0,
+    insertions: Number(m[2]) || 0,
+    deletions: Number(m[3]) || 0,
+  };
+}
+
+// Diff completo (texto) entre base y HEAD. Útil para input al LLM cuando
+// hace falta redactar commit/PR body. La truncación es a nivel de string
+// ya capturado, no a nivel de spawn (sino el proceso falla cuando el diff
+// excede el buffer en lugar de truncar).
+function diffText(cwd, base = 'origin/main', maxBytes = 200000) {
+  // maxBuffer generoso para que el spawn nunca aborte por tamaño.
+  const r = git(['diff', `${base}...HEAD`], cwd, { maxBuffer: 64 * 1024 * 1024 });
+  if (!r.ok) return '';
+  return r.stdout.length > maxBytes ? r.stdout.slice(0, maxBytes) + '\n...[truncated]' : r.stdout;
+}
+
+// Fetch de origen/base. Retorna ok/error.
+function fetchOrigin(cwd, branch = 'main') {
+  const r = git(['fetch', 'origin', branch], cwd);
+  return { ok: r.ok, error: r.ok ? null : r.stderr };
+}
+
+// Snapshot agregado de contexto que necesita el delivery para decidir cosas.
+function snapshot(cwd, base = 'origin/main') {
+  return {
+    cwd,
+    base,
+    branch: currentBranch(cwd),
+    ahead: aheadCount(cwd, base),
+    behind: behindCount(cwd, base),
+    commits: commitsAhead(cwd, base),
+    status: statusPorcelain(cwd),
+    files: filesChanged(cwd, base),
+    stat: diffStat(cwd, base),
+  };
+}
+
+module.exports = {
+  git,
+  currentBranch,
+  commitsAhead,
+  aheadCount,
+  behindCount,
+  statusPorcelain,
+  filesChanged,
+  diffStat,
+  diffText,
+  fetchOrigin,
+  snapshot,
+};

--- a/.pipeline/lib/delivery/pr-builder.js
+++ b/.pipeline/lib/delivery/pr-builder.js
@@ -1,0 +1,108 @@
+// pr-builder.js — Construye el body del PR desde el payload del issue.
+//
+// Lee el comentario marcado en el issue (delivery-payload) y extrae la sección
+// pr-body. Si no existe, cae a un template determinístico.
+//
+// Output: { body, source }
+// source: 'issue-payload' | 'fallback'
+
+function parseDeliveryPayload(issueBodyOrComment) {
+  if (!issueBodyOrComment) return null;
+  const match = issueBodyOrComment.match(
+    /<!--\s*delivery-payload\s*-->[\s\S]*?##\s*pr-body\s*\n([\s\S]*?)\n##\s/
+  );
+  if (!match) return null;
+  return match[1].trim();
+}
+
+// Template fallback cuando no hay payload de issue.
+// Usa los cambios (diff stat) y la descripción para construir un body estructurado.
+function buildFallbackBody({
+  description = null,
+  filesChanged = 0,
+  insertions = 0,
+  deletions = 0,
+  issueNumber = null,
+} = {}) {
+  let body = '## Resumen\n\n';
+
+  if (description) {
+    body += `${description}\n\n`;
+  } else {
+    body += 'Actualización del sistema de entrega.\n\n';
+  }
+
+  if (filesChanged > 0) {
+    body += '## Cambios\n\n';
+    body += `- ${filesChanged} archivo(s) modificado(s)\n`;
+    body += `- ${insertions} línea(s) agregada(s) (+)\n`;
+    body += `- ${deletions} línea(s) removida(s) (-)\n\n`;
+  }
+
+  // Footer estándar
+  body += '---\n\n';
+  body += '🤖 Generado con [Claude Code](https://claude.ai/claude-code)\n';
+
+  // Agregar Closes si hay issue
+  if (issueNumber) {
+    body += `\nCloses #${issueNumber}\n`;
+  }
+
+  return body;
+}
+
+// API principal. Lee el issue, extrae el payload o cae a fallback.
+//
+// Retorna { body, source }
+function build({
+  issueBody = null,
+  issueComments = [],
+  description = null,
+  diffStat = { files: 0, insertions: 0, deletions: 0 },
+  issueNumber = null,
+} = {}) {
+  // Buscar payload en comments (orden reverso: el último gana)
+  for (let i = issueComments.length - 1; i >= 0; i--) {
+    const commentText = typeof issueComments[i] === 'string'
+      ? issueComments[i]
+      : issueComments[i]?.body;
+    const payload = parseDeliveryPayload(commentText);
+    if (payload) {
+      return {
+        body: payload,
+        source: 'issue-payload',
+      };
+    }
+  }
+
+  // Fallback: buscar en el body del issue
+  if (issueBody) {
+    const payload = parseDeliveryPayload(issueBody);
+    if (payload) {
+      return {
+        body: payload,
+        source: 'issue-payload',
+      };
+    }
+  }
+
+  // Template fallback
+  return {
+    body: buildFallbackBody({
+      description,
+      filesChanged: diffStat.files,
+      insertions: diffStat.insertions,
+      deletions: diffStat.deletions,
+      issueNumber,
+    }),
+    source: 'fallback',
+  };
+}
+
+module.exports = {
+  build,
+  parseDeliveryPayload,
+  buildFallbackBody,
+  // exports para tests
+  _internals: { parseDeliveryPayload, buildFallbackBody },
+};

--- a/.pipeline/lib/delivery/worktree-cleanup.js
+++ b/.pipeline/lib/delivery/worktree-cleanup.js
@@ -1,0 +1,164 @@
+// worktree-cleanup.js — Limpieza segura de worktrees post-merge
+//
+// Reemplaza el Paso 6.6 del SKILL.md (markdown interpretado por LLM) con
+// lógica determinística + tests. Incorpora el fix de #2867:
+//
+//   1. Si el worktree a limpiar es donde corre la sesión activa del CLI,
+//      skipea el cleanup completo (solo prune metadata).
+//   2. `.claude/` solo se desmonta con rmdir si es junction. Si es copia
+//      real, se deja que `git worktree remove` se encargue (sino rmdir
+//      borra todo el contenido y voltea los skills).
+
+const path = require('path');
+const fs = require('fs');
+const { execSync, spawnSync } = require('child_process');
+
+const MAIN_REPO_DEFAULT = 'C:/Workspaces/Intrale/platform';
+
+// Compara paths reales (resuelve symlinks/junctions). Si sessionCwd está
+// dentro de worktreePath, este es la sesión activa y NO debe limpiarse.
+function isActiveSession(worktreePath, sessionCwd) {
+  if (!worktreePath || !sessionCwd) return false;
+  let wtReal, cwdReal;
+  try { wtReal = fs.realpathSync(worktreePath); } catch { return false; }
+  try { cwdReal = fs.realpathSync(sessionCwd); } catch { return false; }
+  // Normalizar separadores y casing (Windows es case-insensitive)
+  const norm = (p) => p.replace(/\\/g, '/').toLowerCase();
+  const wt = norm(wtReal);
+  const cwd = norm(cwdReal);
+  // Igualdad exacta o cwd dentro del worktree.
+  // Comparar contra `wt + '/'` evita falsos positivos por prefijo
+  // (ej: cwd=/foobar, wt=/foo — el startsWith plano daría true).
+  return cwd === wt || cwd.startsWith(wt + '/');
+}
+
+// Verifica si un path es un reparse point (junction o symlink) en Windows.
+// Usa `fsutil reparsepoint query` que devuelve exit 0 solo para reparse points.
+function isJunction(targetPath) {
+  if (!fs.existsSync(targetPath)) return false;
+  // En non-Windows también soporta vía lstat
+  if (process.platform !== 'win32') {
+    try { return fs.lstatSync(targetPath).isSymbolicLink(); } catch { return false; }
+  }
+  const winPath = targetPath.replace(/\//g, '\\');
+  const result = spawnSync('cmd', ['/c', 'fsutil', 'reparsepoint', 'query', winPath], {
+    stdio: 'pipe',
+    windowsHide: true,
+  });
+  return result.status === 0;
+}
+
+// Desmonta `.claude/` SOLO si es junction. Si es copia real, no toca.
+function dismountClaudeJunction(worktreePath, logger = () => {}) {
+  const claudePath = path.join(worktreePath, '.claude');
+  if (!fs.existsSync(claudePath)) {
+    logger('  → .claude no existe, skip');
+    return { dismounted: false, reason: 'not_present' };
+  }
+  if (!isJunction(claudePath)) {
+    logger('  → .claude es copia real, no se toca (lo borra git worktree remove)');
+    return { dismounted: false, reason: 'real_copy' };
+  }
+  const winPath = claudePath.replace(/\//g, '\\');
+  const result = spawnSync('cmd', ['/c', 'rmdir', winPath], {
+    stdio: 'pipe',
+    windowsHide: true,
+  });
+  if (result.status === 0) {
+    logger('  → .claude junction desmontado');
+    return { dismounted: true };
+  }
+  logger(`  → falló rmdir (exit ${result.status}): ${result.stderr?.toString().trim()}`);
+  return { dismounted: false, reason: 'rmdir_failed' };
+}
+
+// Ejecuta git desde el repo principal con manejo limpio de errores.
+function gitInMain(args, mainRepo, opts = {}) {
+  const result = spawnSync('git', ['-C', mainRepo, ...args], {
+    stdio: opts.capture ? 'pipe' : 'inherit',
+    encoding: 'utf8',
+    windowsHide: true,
+  });
+  return {
+    ok: result.status === 0,
+    status: result.status,
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+  };
+}
+
+// Limpia un worktree después de merge. Devuelve un resultado estructurado.
+async function cleanupWorktree({
+  worktreePath,
+  branch,
+  mainRepoPath = MAIN_REPO_DEFAULT,
+  sessionCwd = process.cwd(),
+  logger = console.log,
+}) {
+  if (!worktreePath || !branch) {
+    return { ok: false, error: 'missing_args', message: 'worktreePath y branch son obligatorios' };
+  }
+
+  const log = (msg) => logger(msg);
+
+  // 0. Detección de sesión activa (fix #2867)
+  if (isActiveSession(worktreePath, sessionCwd)) {
+    log('⚠️ Skip cleanup: worktree es la sesión activa del CLI');
+    log(`   Worktree: ${worktreePath}`);
+    log(`   Session:  ${sessionCwd}`);
+    log('   Branch local se conserva. Worktree quedará huérfano hasta /cleanup manual.');
+    gitInMain(['worktree', 'prune'], mainRepoPath);
+    return {
+      ok: true,
+      skipped: true,
+      reason: 'active_session',
+      worktreePath,
+      branch,
+    };
+  }
+
+  // 1. Volver al repo principal (cambio de cwd via git -C, no process.chdir)
+  log(`🧹 Limpiando worktree ${worktreePath}`);
+
+  // 2. Desmontar .claude SOLO si es junction
+  const claudeResult = dismountClaudeJunction(worktreePath, log);
+
+  // 3. git worktree remove
+  const wtRemove = gitInMain(['worktree', 'remove', worktreePath, '--force'], mainRepoPath, { capture: true });
+  if (!wtRemove.ok) {
+    log(`  ⚠️ git worktree remove falló: ${wtRemove.stderr.trim()}`);
+  } else {
+    log('  → worktree removido');
+  }
+
+  // 4. Eliminar branch local
+  const branchDel = gitInMain(['branch', '-D', branch], mainRepoPath, { capture: true });
+  if (branchDel.ok) {
+    log(`  → branch local ${branch} eliminada`);
+  } else {
+    log(`  → branch local ${branch} ya no existía`);
+  }
+
+  // 5. Prune
+  gitInMain(['worktree', 'prune'], mainRepoPath);
+  log('  → prune completado');
+
+  return {
+    ok: true,
+    skipped: false,
+    worktreePath,
+    branch,
+    claudeDismounted: claudeResult.dismounted,
+    worktreeRemoved: wtRemove.ok,
+    branchDeleted: branchDel.ok,
+  };
+}
+
+module.exports = {
+  cleanupWorktree,
+  isActiveSession,
+  isJunction,
+  dismountClaudeJunction,
+  // exports para tests
+  _internals: { gitInMain },
+};

--- a/.pipeline/lib/whisper-local.js
+++ b/.pipeline/lib/whisper-local.js
@@ -12,10 +12,12 @@ const path = require('path');
 const crypto = require('crypto');
 const { spawn } = require('child_process');
 
-// Modelo por defecto: large-v3-turbo — calidad casi igual a large-v3 pero ~5x
-// más rápido y con buen reconocimiento de español rioplatense. Se puede pisar
-// con WHISPER_LOCAL_MODEL (small/medium/large-v3-turbo/large-v3).
-const DEFAULT_MODEL = process.env.WHISPER_LOCAL_MODEL || 'large-v3-turbo';
+// Modelo por defecto: medium — balance entre calidad y memoria. El large-v3-turbo
+// pide ~6-10 GB de RAM y crashea con ACCESS_VIOLATION (exit 0xC0000005) cuando la
+// máquina ya está cargada (CPU/RAM altos + audio largo). medium usa ~5 GB y
+// transcribe español rioplatense con buena calidad. Se puede pisar con
+// WHISPER_LOCAL_MODEL (small/medium/large-v3-turbo/large-v3).
+const DEFAULT_MODEL = process.env.WHISPER_LOCAL_MODEL || 'medium';
 const DEFAULT_LANGUAGE = process.env.WHISPER_LOCAL_LANGUAGE || 'Spanish';
 const DEFAULT_THREADS = Number(process.env.WHISPER_LOCAL_THREADS || 4);
 const DEFAULT_TIMEOUT_MS = Number(process.env.WHISPER_LOCAL_TIMEOUT_MS || 300000); // 5 min

--- a/.pipeline/multimedia.js
+++ b/.pipeline/multimedia.js
@@ -178,7 +178,22 @@ async function transcribeAudioWithFallback(audioBuffer, audioPath, filename) {
 
 // Mensaje human-friendly que va a Telegram cuando whisper no pudo transcribir.
 // Es lo que va a leer Leo, así que tiene que ser breve y accionable.
-function transcriptionFailureMessage(errorKind) {
+// Cuando ambos engines (API + local) fallan, el mensaje refleja eso —
+// no podemos echarle la culpa solo a la cuota de OpenAI si el local crasheó.
+function transcriptionFailureMessage(errorKind, localErrorKind = null) {
+  if (localErrorKind) {
+    const apiPart = errorKind === 'quota' ? 'cuota OpenAI agotada'
+                  : errorKind === 'auth'  ? 'key OpenAI inválida'
+                  : errorKind === 'rate_limit' ? 'rate-limit OpenAI'
+                  : errorKind === 'network' ? 'no llegué a OpenAI'
+                  : errorKind === 'timeout' ? 'timeout OpenAI'
+                  : `OpenAI ${errorKind}`;
+    const localHint = localErrorKind === 'cli_error' ? 'crasheó (probable OOM con audio largo)'
+                    : localErrorKind === 'timeout'  ? 'tardó demasiado'
+                    : localErrorKind === 'no_binary' ? 'no está instalado'
+                    : `falló (${localErrorKind})`;
+    return `🎤 Audio recibido. Falló API (${apiPart}) y también whisper local — ${localHint}. Repetímelo por texto cuando puedas. Si el local sigue crasheando: bajar \`WHISPER_LOCAL_MODEL\` a \`small\` o reiniciar la máquina.`;
+  }
   switch (errorKind) {
     case 'no_key':     return '🎤 Audio recibido. No tengo `openai_api_key` cargada — repetímelo por texto cuando puedas.';
     case 'quota':      return '🎤 Audio recibido. La cuota de OpenAI está agotada (Whisper no responde) — repetímelo por texto cuando puedas. Para volver a habilitar la transcripción: subir cuota o rotar la key en `~/.claude/secrets/telegram-config.json`.';
@@ -280,7 +295,7 @@ async function preprocessMessage(msg, botToken) {
         log(`Transcripcion FALLO (${tx.errorKind}): ${tx.raw}${tx.localErrorKind ? ` | local=${tx.localErrorKind}: ${tx.localRaw}` : ''}`);
         // No metemos el error como texto del mensaje — el caller decide qué hacer.
         result.text = '';
-        result.audio = { ok: false, errorKind: tx.errorKind, raw: tx.raw, fallbackMessage: transcriptionFailureMessage(tx.errorKind) };
+        result.audio = { ok: false, errorKind: tx.errorKind, raw: tx.raw, localErrorKind: tx.localErrorKind || null, fallbackMessage: transcriptionFailureMessage(tx.errorKind, tx.localErrorKind || null) };
         result.extras.push(`(audio sin transcribir: ${tx.errorKind})`);
       }
     } else {

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -1087,10 +1087,11 @@ function limpiarDaemonsOnDemand() {
   // 1. Buscar Gradle daemons
   try {
     const wmicOut = execSync(
-      'wmic process where "name=\'java.exe\'" get ProcessId,ParentProcessId,CommandLine /FORMAT:CSV',
+      'wmic process get Name,ProcessId,ParentProcessId,CommandLine /FORMAT:CSV',
       { encoding: 'utf8', timeout: 10000, windowsHide: true }
     );
     for (const line of wmicOut.split('\n')) {
+      if (!line.includes('java.exe')) continue;
       if (!line.includes('GradleDaemon') && !line.includes('gradle-launcher')) continue;
       const parts = line.split(',');
       const pid = parts[parts.length - 2]?.trim();
@@ -1118,10 +1119,11 @@ function limpiarDaemonsOnDemand() {
   // 2. Buscar Kotlin compile daemons
   try {
     const wmicOut2 = execSync(
-      'wmic process where "name=\'java.exe\'" get ProcessId,CommandLine /FORMAT:CSV',
+      'wmic process get Name,ProcessId,CommandLine /FORMAT:CSV',
       { encoding: 'utf8', timeout: 10000, windowsHide: true }
     );
     for (const line of wmicOut2.split('\n')) {
+      if (!line.includes('java.exe')) continue;
       if (!line.includes('kotlin-compiler') && !line.includes('KotlinCompileDaemon')) continue;
       const match = line.match(/,(\d+)\s*$/);
       if (!match) continue;


### PR DESCRIPTION
## Resumen

Cierra el ciclo del refactor determinístico de `/delivery`. Después de este PR, `/delivery` no invoca LLM para redactar commit/PR — los lee del payload posteado por el agente que hizo el laburo.

## Cambios

### 1. Nuevo skill `/handoff`
Wrapper delgado que postea payload marcado en el issue:
```
<!-- delivery-payload -->
## commit-message
fix(api): ...

## pr-body
...

## qa-disposition
qa:passed
<!-- /delivery-payload -->
```
`/delivery` lo consume después. Cero redacción, solo formato + post.

### 2. Nuevo orquestador `.pipeline/delivery.js`
Script determinístico que orquesta los 5 módulos del refactor:
- `git-context.snapshot()` → estado del repo
- `change-classifier.classify()` → tipo conventional commit
- `commit-builder.build()` → commit-message (issue payload o fallback)
- `pr-builder.build()` → pr-body (issue payload o fallback)

Modo `--json` para que `/delivery` SKILL.md lo consuma sin perder los gates de QA/tester/review existentes.

### 3. Developers migrados
Cada developer skill agrega un paso final que invoca `/handoff` cuando recibe issue:
- ✅ backend-dev (Paso 9)
- ✅ android-dev (Paso 9)
- ✅ web-dev (Paso 8)
- ✅ pipeline-dev (Paso 9)
- ⏸ ios-dev, desktop-dev (frozen, no se migran)

El dev redacta commit-message y pr-body desde **su contexto** (vio el diff, sabe el por qué). Mejor que template determinístico o LLM analizando solo el diff.

### 4. `/delivery` SKILL.md actualizado
Paso 2 ahora invoca `delivery.js --json` para strings determinísticos. Resto del flujo (gates, merge, cleanup, --all, --clean) intacto.

## Flujo end-to-end

```
Pipeline → /backend-dev (issue 1234)
  └→ codea, tests, commitea local
  └→ /handoff 1234 --commit '...' --body '...'
       └→ postea payload en issue #1234

Pipeline → /delivery
  └→ delivery.js --issue 1234 --json
       └→ lee payload del issue → commitMessage + prBody
  └→ git push + gh pr create con esos strings
  └→ gates + merge automático
```

## Tests

- 7 nuevos (`parseArgs` del orquestador)
- Suite total delivery: **37 passing** (commit-builder + pr-builder + orchestrator)
- Smoke test manual: `delivery.js --json` ejecutado en este branch (✅)

## Issues relacionados

Closes #2870 (refactor master)
Closes #2872 (handoff design)

🤖 Generado con [Claude Code](https://claude.ai/claude-code)