### PR TITLE
fix(pipeline): ignorar bloqueado-humano/ — defensa contra git stash -u (#2880 parte 3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,10 +136,12 @@ scripts/planner-plan.json
 .pipeline/definicion/*/trabajando/*
 .pipeline/definicion/*/listo/*
 .pipeline/definicion/*/procesado/*
+.pipeline/definicion/*/bloqueado-humano/*
 .pipeline/desarrollo/*/pendiente/*
 .pipeline/desarrollo/*/trabajando/*
 .pipeline/desarrollo/*/listo/*
 .pipeline/desarrollo/*/procesado/*
+.pipeline/desarrollo/*/bloqueado-humano/*
 .pipeline/servicios/*/pendiente/*
 .pipeline/servicios/*/trabajando/*
 .pipeline/servicios/*/listo/*


### PR DESCRIPTION
## Summary

Agrega 2 patrones al .gitignore para que `.pipeline/{desarrollo,definicion}/*/bloqueado-humano/*` queden ignorados. Eran estado runtime puro pero estaban untracked-no-ignorados — un `git stash -u` los engullía y desaparecían.

Es la **parte 3 (defense-in-depth)** del fix completo descrito en #2880. Las partes 1 (`reportHumanBlock` aplica el label) y 2 (`servicio-reconciler.js`) vienen en PRs siguientes; este PR es independiente y mergeable solo, mejor entregar la protección filesystem inmediatamente.

## Contexto del incidente (2026-04-29)

A las 11:40 corrió `pause-all.js` para pausar todos los issues activos del pipeline. A las 17:07 alguien hizo `git stash push -u` (probablemente delivery o un commit-builder) y se llevó al stash 241 issues bloqueados. Como pulpo siguió corriendo y re-inyectando issues, los markers nunca volvieron al filesystem y `/bloqueados` quedó vacío excepto por #2424 (que sobrevivió porque `**/build/` lo ignoraba accidentalmente).

Recuperación manual ya aplicada hoy (60 labels + 194 markers restaurados desde stash@{3}). Este PR cierra el agujero para que no vuelva a pasar.

## Test plan

- [x] `git check-ignore .pipeline/desarrollo/validacion/bloqueado-humano/2570.po` → ahora matches.
- [x] `git check-ignore .pipeline/definicion/analisis/bloqueado-humano/2538.guru` → ahora matches.
- [x] Markers existentes en filesystem (los 194 restaurados) ya no aparecen en `git status` como untracked.
- [ ] Tras merge: hacer un `git stash push -u` de prueba y confirmar que NO se llevó los markers.

## Riesgo

**Mínimo.** Solo agrega líneas a `.gitignore`. No toca código. No afecta runtime. Si por algún motivo en el futuro hace falta trackear esos archivos, se quitan las líneas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)