### PR TITLE
feat(pipeline): servicio-reconciler + reportHumanBlock auto-aplica label (#2880)

### DIFF
--- a/.pipeline/dashboard.js
+++ b/.pipeline/dashboard.js
@@ -88,6 +88,7 @@ const COMPONENTS = [
   { name: 'svc-github', script: 'servicio-github.js', pid: 'svc-github.pid' },
   { name: 'svc-drive', script: 'servicio-drive.js', pid: 'svc-drive.pid' },
   { name: 'svc-emulador', script: 'servicio-emulador.js', pid: 'svc-emulador.pid' },
+  { name: 'svc-reconciler', script: 'servicio-reconciler.js', pid: 'svc-reconciler.pid' },
   { name: 'outbox-drain', script: 'outbox-drain.js', pid: 'outbox-drain.pid' },
 ];
 // Nota: dashboard no se incluye (no puede matarse a sí mismo)
@@ -628,7 +629,7 @@ function getPipelineState() {
   // Procesos — descubiertos al vuelo desde el SO, no desde archivos .pid.
   state.procesos = {};
   invalidateCache();
-  for (const comp of ['pulpo', 'listener', 'svc-telegram', 'svc-github', 'svc-drive', 'outbox-drain', 'dashboard']) {
+  for (const comp of ['pulpo', 'listener', 'svc-telegram', 'svc-github', 'svc-drive', 'svc-reconciler', 'outbox-drain', 'dashboard']) {
     const found = findPidByComponent(comp);
     if (found && pidAlive(found.pid)) {
       const uptime = getProcessUptime(comp);

--- a/.pipeline/lib/__tests__/servicio-reconciler.test.js
+++ b/.pipeline/lib/__tests__/servicio-reconciler.test.js
@@ -1,0 +1,195 @@
+// Tests de .pipeline/servicio-reconciler.js (issue #2880)
+// Valida las 3 reglas de reconciliación + heurística de fase para placeholders.
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const TMP_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'v3-reconciler-'));
+fs.mkdirSync(path.join(TMP_DIR, '.claude'), { recursive: true });
+fs.mkdirSync(path.join(TMP_DIR, '.pipeline', 'desarrollo', 'dev', 'pendiente'), { recursive: true });
+fs.mkdirSync(path.join(TMP_DIR, '.pipeline', 'desarrollo', 'validacion', 'bloqueado-humano'), { recursive: true });
+fs.mkdirSync(path.join(TMP_DIR, '.pipeline', 'definicion', 'analisis', 'bloqueado-humano'), { recursive: true });
+fs.mkdirSync(path.join(TMP_DIR, '.pipeline', 'servicios', 'github', 'pendiente'), { recursive: true });
+
+process.env.CLAUDE_PROJECT_DIR = TMP_DIR;
+process.env.PIPELINE_REPO_ROOT = TMP_DIR;
+process.env.PIPELINE_STATE_DIR = path.join(TMP_DIR, '.pipeline');
+process.env.PIPELINE_MAIN_ROOT = TMP_DIR;
+
+delete require.cache[require.resolve('../traceability')];
+delete require.cache[require.resolve('../human-block')];
+delete require.cache[require.resolve('../../servicio-reconciler')];
+
+const humanBlock = require('../human-block');
+const reconciler = require('../../servicio-reconciler');
+
+const PIPELINE = path.join(TMP_DIR, '.pipeline');
+const GH_QUEUE = path.join(PIPELINE, 'servicios', 'github', 'pendiente');
+
+function clearGhQueue() {
+    for (const f of fs.readdirSync(GH_QUEUE)) {
+        if (f.endsWith('.json')) try { fs.unlinkSync(path.join(GH_QUEUE, f)); } catch {}
+    }
+}
+
+function clearAllMarkers() {
+    for (const pipeline of ['desarrollo', 'definicion']) {
+        const root = path.join(PIPELINE, pipeline);
+        for (const phase of fs.readdirSync(root)) {
+            const blockedDir = path.join(root, phase, 'bloqueado-humano');
+            if (!fs.existsSync(blockedDir)) continue;
+            for (const f of fs.readdirSync(blockedDir)) {
+                try { fs.unlinkSync(path.join(blockedDir, f)); } catch {}
+            }
+        }
+    }
+}
+
+function listGhQueueLabels() {
+    return fs.readdirSync(GH_QUEUE)
+        .filter(f => f.endsWith('.json'))
+        .map(f => JSON.parse(fs.readFileSync(path.join(GH_QUEUE, f), 'utf8')))
+        .filter(c => c.action === 'label');
+}
+
+test('decidirFasePlaceholder mapea ready → desarrollo/dev', () => {
+    const r = reconciler.decidirFasePlaceholder(['ready', 'app:client']);
+    assert.equal(r.pipeline, 'desarrollo');
+    assert.equal(r.phase, 'dev');
+});
+
+test('decidirFasePlaceholder default → definicion/analisis', () => {
+    const r = reconciler.decidirFasePlaceholder(['needs-definition']);
+    assert.equal(r.pipeline, 'definicion');
+    assert.equal(r.phase, 'analisis');
+    const r2 = reconciler.decidirFasePlaceholder([]);
+    assert.equal(r2.pipeline, 'definicion');
+    assert.equal(r2.phase, 'analisis');
+});
+
+test('reconcileLabelToFilesystem crea placeholder cuando label sin marker', () => {
+    clearAllMarkers();
+    clearGhQueue();
+    const ghIssues = [
+        { number: 9001, labels: ['ready'] },
+        { number: 9002, labels: ['needs-definition'] },
+    ];
+    const created = reconciler.reconcileLabelToFilesystem(ghIssues, new Map());
+
+    assert.equal(created, 2);
+    const m1 = path.join(PIPELINE, 'desarrollo', 'dev', 'bloqueado-humano', '9001.guru');
+    const m2 = path.join(PIPELINE, 'definicion', 'analisis', 'bloqueado-humano', '9002.guru');
+    assert.equal(fs.existsSync(m1), true, 'marker 9001 creado');
+    assert.equal(fs.existsSync(m1 + '.reason.json'), true, 'reason.json creado');
+    assert.equal(fs.existsSync(m2), true, 'marker 9002 creado');
+
+    const reason = JSON.parse(fs.readFileSync(m1 + '.reason.json', 'utf8'));
+    assert.equal(reason.blocked_by, 'svc-reconciler');
+    assert.match(reason.reason, /placeholder/i);
+});
+
+test('reconcileLabelToFilesystem omite issues que ya tienen marker', () => {
+    clearAllMarkers();
+    clearGhQueue();
+    const blockedByIssue = new Map([[8500, [{ issue: 8500, skill: 'po', phase: 'validacion', pipeline: 'desarrollo' }]]]);
+    const ghIssues = [{ number: 8500, labels: ['ready'] }];
+    const created = reconciler.reconcileLabelToFilesystem(ghIssues, blockedByIssue);
+    assert.equal(created, 0);
+});
+
+test('reconcileMarkerToLabel encolar label cuando marker sin label en GitHub', () => {
+    clearAllMarkers();
+    clearGhQueue();
+    const markers = [
+        { issue: 7001, skill: 'po', phase: 'validacion', pipeline: 'desarrollo' },
+        { issue: 7002, skill: 'guru', phase: 'analisis', pipeline: 'definicion' },
+    ];
+    const ghSet = new Set([]); // ningún issue tiene el label
+    const stateFn = () => 'OPEN';
+    const enqueued = reconciler.reconcileMarkerToLabel(markers, ghSet, stateFn);
+
+    assert.equal(enqueued, 2);
+    const labels = listGhQueueLabels();
+    assert.equal(labels.length, 2);
+    assert.equal(labels.every(l => l.label === 'needs-human'), true);
+    assert.deepEqual(labels.map(l => l.issue).sort(), [7001, 7002]);
+});
+
+test('reconcileMarkerToLabel deduplica markers del mismo issue (1 enqueue por issue)', () => {
+    clearAllMarkers();
+    clearGhQueue();
+    const markers = [
+        { issue: 6500, skill: 'po', phase: 'validacion', pipeline: 'desarrollo' },
+        { issue: 6500, skill: 'ux', phase: 'validacion', pipeline: 'desarrollo' },
+        { issue: 6500, skill: 'guru', phase: 'validacion', pipeline: 'desarrollo' },
+    ];
+    const enqueued = reconciler.reconcileMarkerToLabel(markers, new Set(), () => 'OPEN');
+    assert.equal(enqueued, 1);
+});
+
+test('reconcileMarkerToLabel no encola si issue ya tiene label en GitHub', () => {
+    clearAllMarkers();
+    clearGhQueue();
+    const markers = [{ issue: 5500, skill: 'po', phase: 'validacion', pipeline: 'desarrollo' }];
+    const enqueued = reconciler.reconcileMarkerToLabel(markers, new Set([5500]), () => 'OPEN');
+    assert.equal(enqueued, 0);
+});
+
+test('reconcileMarkerToLabel skip CLOSED y UNKNOWN', () => {
+    clearAllMarkers();
+    clearGhQueue();
+    const markers = [
+        { issue: 4001, skill: 'po', phase: 'validacion', pipeline: 'desarrollo' },
+        { issue: 4002, skill: 'po', phase: 'validacion', pipeline: 'desarrollo' },
+        { issue: 4003, skill: 'po', phase: 'validacion', pipeline: 'desarrollo' },
+    ];
+    const states = { 4001: 'OPEN', 4002: 'CLOSED', 4003: 'UNKNOWN' };
+    const enqueued = reconciler.reconcileMarkerToLabel(markers, new Set(), n => states[n]);
+    assert.equal(enqueued, 1, 'solo el OPEN encola');
+});
+
+test('reconcileClosedMarkers archiva markers de issues cerrados', () => {
+    clearAllMarkers();
+    clearGhQueue();
+    const blockedDir = path.join(PIPELINE, 'desarrollo', 'validacion', 'bloqueado-humano');
+    const archDir = path.join(PIPELINE, 'desarrollo', 'validacion', 'archivado');
+    const markerFile = path.join(blockedDir, '3001.po');
+    const reasonFile = markerFile + '.reason.json';
+    fs.writeFileSync(markerFile, '');
+    fs.writeFileSync(reasonFile, '{}');
+
+    const markers = [{ issue: 3001, skill: 'po', phase: 'validacion', pipeline: 'desarrollo' }];
+    const archived = reconciler.reconcileClosedMarkers(markers, new Set(), () => 'CLOSED');
+
+    assert.equal(archived, 1);
+    assert.equal(fs.existsSync(markerFile), false, 'marker movido fuera de bloqueado-humano/');
+    assert.equal(fs.existsSync(reasonFile), false, 'reason borrado');
+    assert.equal(fs.existsSync(path.join(archDir, '3001.po')), true, 'archivo movido a archivado/');
+});
+
+test('reconcileClosedMarkers omite markers de issues abiertos', () => {
+    clearAllMarkers();
+    clearGhQueue();
+    const blockedDir = path.join(PIPELINE, 'desarrollo', 'validacion', 'bloqueado-humano');
+    const markerFile = path.join(blockedDir, '2001.po');
+    fs.writeFileSync(markerFile, '');
+    fs.writeFileSync(markerFile + '.reason.json', '{}');
+
+    const markers = [{ issue: 2001, skill: 'po', phase: 'validacion', pipeline: 'desarrollo' }];
+    const archived = reconciler.reconcileClosedMarkers(markers, new Set(), () => 'OPEN');
+    assert.equal(archived, 0);
+    assert.equal(fs.existsSync(markerFile), true, 'marker no se movió');
+});
+
+test('enqueueLabelApply genera JSON con shape correcto', () => {
+    clearGhQueue();
+    reconciler.enqueueLabelApply(1234, 'needs-human');
+    const files = fs.readdirSync(GH_QUEUE).filter(f => f.endsWith('.json'));
+    assert.equal(files.length, 1);
+    const cmd = JSON.parse(fs.readFileSync(path.join(GH_QUEUE, files[0]), 'utf8'));
+    assert.deepEqual(cmd, { action: 'label', issue: 1234, label: 'needs-human' });
+});

--- a/.pipeline/lib/human-block.js
+++ b/.pipeline/lib/human-block.js
@@ -26,6 +26,25 @@ const PIPELINE_DIR = path.join(trace.REPO_ROOT, '.pipeline');
 const PIPELINES = ['desarrollo', 'definicion'];
 const BLOCK_SUBDIR = 'bloqueado-humano';
 const ACTIVE_STATES = ['pendiente', 'trabajando', 'listo'];
+const GH_QUEUE_DIR = path.join(PIPELINE_DIR, 'servicios', 'github', 'pendiente');
+const NEEDS_HUMAN_LABEL = 'needs-human';
+
+// #2880 — encolar comando de label en la cola del servicio-github. Centralizar
+// acá la aplicación del label evita que cada caller (pause-all, scripts manuales,
+// pulpo en barrido) tenga que duplicar la lógica y olvide aplicarlo.
+function enqueueNeedsHumanLabel(issue) {
+    try {
+        fs.mkdirSync(GH_QUEUE_DIR, { recursive: true });
+        const filename = `${issue}-${NEEDS_HUMAN_LABEL}-block-${Date.now()}.json`;
+        fs.writeFileSync(
+            path.join(GH_QUEUE_DIR, filename),
+            JSON.stringify({ action: 'label', issue: Number(issue), label: NEEDS_HUMAN_LABEL }),
+        );
+        return true;
+    } catch {
+        return false;
+    }
+}
 
 function emitBlocked(opts) {
     trace.appendEvent({
@@ -172,6 +191,13 @@ function reportHumanBlock(opts) {
     }, null, 2));
 
     emitBlocked({ issue, skill, phase, pipeline, reason, question });
+
+    // #2880 — aplicar label `needs-human` en GitHub. Sin esto el intake del
+    // pulpo no excluye al issue y vuelve a inyectarlo en pendiente/, dejando
+    // el bloqueo inconsistente entre filesystem y GitHub.
+    if (opts.skipGithubLabel !== true) {
+        enqueueNeedsHumanLabel(issue);
+    }
 
     return { issue, skill, phase, pipeline, marker_path: targetFile };
 }
@@ -387,8 +413,10 @@ module.exports = {
     isHumanBlockReason,
     inferHumanBlockQuestion,
     buildBlockedSummaryMarkdown,
+    enqueueNeedsHumanLabel,
     HUMAN_BLOCK_PATTERNS,
     PIPELINE_DIR,
     PIPELINES,
     BLOCK_SUBDIR,
+    NEEDS_HUMAN_LABEL,
 };

--- a/.pipeline/pid-discovery.js
+++ b/.pipeline/pid-discovery.js
@@ -23,6 +23,7 @@ const SCRIPT_MAP = {
   'svc-github': 'servicio-github.js',
   'svc-drive': 'servicio-drive.js',
   'svc-emulador': 'servicio-emulador.js',
+  'svc-reconciler': 'servicio-reconciler.js',
   'dashboard': 'dashboard.js',
   'outbox-drain': 'outbox-drain.js',
 };

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -2521,14 +2521,11 @@ function brazoBarrido(config) {
                 log('barrido', `❌ #${issue} reportHumanBlock falló: ${e.message}`);
               }
 
-              // Aplicar label needs-human en GitHub (servicio-github auto-crea el label).
+              // #2880 — Label needs-human: lo encola humanBlock.reportHumanBlock() arriba.
+              // Acá solo encolamos el comentario explicativo en el issue.
               try {
                 const ghQueueDir = path.join(PIPELINE, 'servicios', 'github', 'pendiente');
                 fs.mkdirSync(ghQueueDir, { recursive: true });
-                fs.writeFileSync(
-                  path.join(ghQueueDir, `${issue}-needs-human-blockreason-${Date.now()}.json`),
-                  JSON.stringify({ action: 'label', issue: parseInt(issue), label: 'needs-human' }),
-                );
                 const body = [
                   `## Pipeline pausó este issue: requiere intervención humana`,
                   '',
@@ -2551,7 +2548,7 @@ function brazoBarrido(config) {
                   JSON.stringify({ action: 'comment', issue: parseInt(issue), body }),
                 );
               } catch (e) {
-                log('barrido', `Error encolando needs-human para #${issue}: ${e.message}`);
+                log('barrido', `Error encolando comentario needs-human para #${issue}: ${e.message}`);
               }
 
               // Notificación Telegram con listado completo de incidentes.

--- a/.pipeline/restart.js
+++ b/.pipeline/restart.js
@@ -41,6 +41,7 @@ const COMPONENTS = [
   { name: 'svc-github', script: 'servicio-github.js', pid: 'svc-github.pid' },
   { name: 'svc-drive', script: 'servicio-drive.js', pid: 'svc-drive.pid' },
   { name: 'svc-emulador', script: 'servicio-emulador.js', pid: 'svc-emulador.pid' },
+  { name: 'svc-reconciler', script: 'servicio-reconciler.js', pid: 'svc-reconciler.pid' },
   { name: 'dashboard', script: 'dashboard.js', pid: 'dashboard.pid' },
 ];
 

--- a/.pipeline/servicio-reconciler.js
+++ b/.pipeline/servicio-reconciler.js
@@ -1,0 +1,285 @@
+#!/usr/bin/env node
+// =============================================================================
+// Servicio Reconciler — Sincroniza label needs-human ↔ marker bloqueado-humano
+// =============================================================================
+//
+// Contexto: hay tres fuentes de verdad de "issue bloqueado por humano":
+//   1. Label `needs-human` en GitHub
+//   2. Archivo en `<pipeline>/<fase>/bloqueado-humano/<issue>.<skill>`
+//   3. Lo que muestra el dashboard /bloqueados (lee solo filesystem)
+//
+// Cualquier vía alternativa de bloquear (pause-all, label aplicado a mano desde
+// GitHub UI, /unblock parcial, git stash -u accidental) rompe la sincronía y
+// deja issues invisibles en el dashboard. Incidente 2026-04-29: 241 issues
+// fantasma por un git stash -u que se llevó los markers untracked.
+//
+// Este servicio corre como proceso separado (no bloquea al pulpo) y cada
+// RECONCILE_INTERVAL_MS:
+//   1. Lista issues con label `needs-human` en GitHub (open).
+//   2. Para cada uno sin marker físico → crea placeholder en la fase apropiada.
+//   3. Lista markers en bloqueado-humano/.
+//   4. Para cada marker cuyo issue NO tenga el label en GitHub → encola apply.
+//   5. Para cada marker cuyo issue esté CLOSED → archiva el marker.
+//
+// Issue: #2880
+
+'use strict';
+
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+require('./lib/sanitize-console').install();
+const { sanitize } = require('./sanitizer');
+const humanBlock = require('./lib/human-block');
+
+const ROOT = process.env.PIPELINE_MAIN_ROOT || path.resolve(__dirname, '..');
+const PIPELINE = process.env.PIPELINE_STATE_DIR || path.resolve(__dirname);
+const GH_BIN = process.env.GH_BIN || 'C:\\Workspaces\\gh-cli\\bin\\gh.exe';
+const LOG_DIR = path.join(PIPELINE, 'logs');
+const GH_QUEUE = path.join(PIPELINE, 'servicios', 'github', 'pendiente');
+
+const RECONCILE_INTERVAL_MS = parseInt(process.env.RECONCILER_INTERVAL_MS || '300000', 10); // 5 min default
+const RECONCILER_LABEL = 'needs-human';
+
+function log(msg) {
+    const ts = new Date().toISOString().replace('T', ' ').slice(0, 19);
+    console.log(`[${ts}] [svc-reconciler] ${msg}`);
+}
+
+// -----------------------------------------------------------------------------
+// GitHub helpers
+// -----------------------------------------------------------------------------
+
+function listGhIssuesWithLabel(label) {
+    try {
+        const raw = execSync(
+            `"${GH_BIN}" issue list --label "${label}" --state open --json number,labels --limit 500`,
+            { cwd: ROOT, encoding: 'utf8', timeout: 30000, windowsHide: true }
+        );
+        const issues = JSON.parse(raw || '[]');
+        return issues.map(i => ({
+            number: i.number,
+            labels: (i.labels || []).map(l => l.name),
+        }));
+    } catch (e) {
+        log(`Error consultando GitHub: ${e.message.slice(0, 120)}`);
+        return null;
+    }
+}
+
+function getIssueState(issueNum) {
+    try {
+        const raw = execSync(
+            `"${GH_BIN}" issue view ${issueNum} --json state`,
+            { cwd: ROOT, encoding: 'utf8', timeout: 10000, windowsHide: true }
+        );
+        return (JSON.parse(raw).state || 'UNKNOWN').toUpperCase();
+    } catch {
+        return 'UNKNOWN';
+    }
+}
+
+function enqueueLabelApply(issueNum, label) {
+    fs.mkdirSync(GH_QUEUE, { recursive: true });
+    const filename = `${issueNum}-${label}-reconciler-${Date.now()}.json`;
+    fs.writeFileSync(
+        path.join(GH_QUEUE, filename),
+        JSON.stringify({ action: 'label', issue: issueNum, label }),
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Decidir fase para placeholder según labels del issue
+// -----------------------------------------------------------------------------
+//
+// Heurística simple: leer labels y mapear a la fase de entrada de cada pipeline.
+// Si no hay match claro, default a `definicion/analisis` (entrada del pipeline
+// de definición — fase más permisiva, el siguiente reconcile puede ajustarla
+// si el issue obtiene labels más específicos).
+//
+// El reason del marker indica que es un placeholder, así que el humano que
+// /unblock-ee sabe que la fase puede no ser la "real" del issue.
+
+function decidirFasePlaceholder(labels) {
+    const labelSet = new Set(labels);
+    if (labelSet.has('ready')) {
+        return { pipeline: 'desarrollo', phase: 'dev', skill: 'guru' };
+    }
+    return { pipeline: 'definicion', phase: 'analisis', skill: 'guru' };
+}
+
+// -----------------------------------------------------------------------------
+// Reconciliación: las 3 reglas
+// -----------------------------------------------------------------------------
+
+function reconcileLabelToFilesystem(ghIssues, blockedByIssue) {
+    let created = 0;
+    for (const issue of ghIssues) {
+        if (blockedByIssue.has(issue.number)) continue;
+        // Issue tiene label `needs-human` pero no hay marker físico → crear placeholder
+        const { pipeline, phase, skill } = decidirFasePlaceholder(issue.labels);
+        const targetDir = path.join(PIPELINE, pipeline, phase, humanBlock.BLOCK_SUBDIR);
+        const targetFile = path.join(targetDir, `${issue.number}.${skill}`);
+        if (fs.existsSync(targetFile)) continue;
+        try {
+            fs.mkdirSync(targetDir, { recursive: true });
+            fs.writeFileSync(targetFile, '');
+            fs.writeFileSync(targetFile + '.reason.json', JSON.stringify({
+                issue: issue.number,
+                skill,
+                phase,
+                pipeline,
+                reason: 'Reconciler: issue tiene label needs-human en GitHub pero no había marker físico. Placeholder creado para mantener visibilidad en /bloqueados.',
+                question: '[reconciler] Marker placeholder. Verificá la fase con criterio humano antes de /unblock; el reconciler eligió la fase por heurística sobre labels.',
+                blocked_at: new Date().toISOString(),
+                blocked_by: 'svc-reconciler',
+            }, null, 2));
+            created++;
+        } catch (e) {
+            log(`Error creando placeholder #${issue.number}: ${e.message.slice(0, 120)}`);
+        }
+    }
+    return created;
+}
+
+function reconcileMarkerToLabel(blockedMarkers, ghIssueSet, getStateFn = getIssueState) {
+    let enqueued = 0;
+    const seenIssue = new Set();
+    for (const m of blockedMarkers) {
+        if (ghIssueSet.has(m.issue)) continue;
+        if (seenIssue.has(m.issue)) continue; // un solo encolado por issue (no por skill)
+        seenIssue.add(m.issue);
+
+        const state = getStateFn(m.issue);
+        if (state === 'CLOSED' || state === 'UNKNOWN') {
+            // No encolar label; el archivado de issues cerrados se hace en
+            // reconcileClosedMarkers() para mantener responsabilidades separadas.
+            continue;
+        }
+        try {
+            enqueueLabelApply(m.issue, RECONCILER_LABEL);
+            enqueued++;
+        } catch (e) {
+            log(`Error encolando label #${m.issue}: ${e.message.slice(0, 120)}`);
+        }
+    }
+    return enqueued;
+}
+
+function reconcileClosedMarkers(blockedMarkers, ghIssueSet, getStateFn = getIssueState) {
+    let archived = 0;
+    const seenIssue = new Set();
+    for (const m of blockedMarkers) {
+        if (ghIssueSet.has(m.issue)) continue;
+        if (seenIssue.has(m.issue)) continue;
+        seenIssue.add(m.issue);
+
+        const state = getStateFn(m.issue);
+        if (state !== 'CLOSED') continue;
+
+        // Mover marker (y reason.json) a archivado/ de la misma fase
+        const archiveDir = path.join(PIPELINE, m.pipeline, m.phase, 'archivado');
+        try {
+            fs.mkdirSync(archiveDir, { recursive: true });
+            const baseName = `${m.issue}.${m.skill}`;
+            const srcMarker = path.join(PIPELINE, m.pipeline, m.phase, humanBlock.BLOCK_SUBDIR, baseName);
+            const dstMarker = path.join(archiveDir, baseName);
+            if (fs.existsSync(srcMarker)) {
+                fs.renameSync(srcMarker, dstMarker);
+            }
+            try { fs.unlinkSync(srcMarker + '.reason.json'); } catch {}
+            archived++;
+        } catch (e) {
+            log(`Error archivando #${m.issue}: ${e.message.slice(0, 120)}`);
+        }
+    }
+    return archived;
+}
+
+// -----------------------------------------------------------------------------
+// Loop principal
+// -----------------------------------------------------------------------------
+
+let lastRunAt = 0;
+let cycleCount = 0;
+
+function reconcileOnce() {
+    const t0 = Date.now();
+    cycleCount++;
+
+    const ghIssues = listGhIssuesWithLabel(RECONCILER_LABEL);
+    if (ghIssues === null) {
+        log(`Ciclo ${cycleCount}: SKIP — GitHub no respondió`);
+        return;
+    }
+
+    const ghIssueSet = new Set(ghIssues.map(i => i.number));
+    const blockedMarkers = humanBlock.listBlockedIssues();
+    const blockedByIssue = new Map();
+    for (const m of blockedMarkers) {
+        if (!blockedByIssue.has(m.issue)) blockedByIssue.set(m.issue, []);
+        blockedByIssue.get(m.issue).push(m);
+    }
+
+    const created = reconcileLabelToFilesystem(ghIssues, blockedByIssue);
+    const enqueued = reconcileMarkerToLabel(blockedMarkers, ghIssueSet);
+    const archived = reconcileClosedMarkers(blockedMarkers, ghIssueSet);
+
+    const elapsed = Date.now() - t0;
+    lastRunAt = Date.now();
+    if (created || enqueued || archived) {
+        log(`Ciclo ${cycleCount} (${elapsed}ms): GH=${ghIssues.length} markers=${blockedMarkers.length} → +${created} placeholders, +${enqueued} labels encolados, +${archived} archivados`);
+    } else {
+        log(`Ciclo ${cycleCount} (${elapsed}ms): GH=${ghIssues.length} markers=${blockedMarkers.length} — sincronizado`);
+    }
+}
+
+function main() {
+    fs.mkdirSync(LOG_DIR, { recursive: true });
+    fs.mkdirSync(GH_QUEUE, { recursive: true });
+
+    log(`Iniciado — intervalo ${Math.round(RECONCILE_INTERVAL_MS / 1000)}s`);
+    try { require('./lib/ready-marker').signalReady('svc-reconciler'); } catch {}
+
+    // Primer ciclo en 30s para que el resto del pipeline arranque sin contienda.
+    setTimeout(() => {
+        try { reconcileOnce(); } catch (e) { log(`Error: ${e.message}`); }
+        setInterval(() => {
+            try { reconcileOnce(); } catch (e) { log(`Error: ${e.message}`); }
+        }, RECONCILE_INTERVAL_MS);
+    }, 30000);
+}
+
+fs.writeFileSync(path.join(PIPELINE, 'svc-reconciler.pid'), String(process.pid));
+process.on('SIGINT', () => process.exit(0));
+process.on('SIGTERM', () => process.exit(0));
+
+process.on('uncaughtException', (err) => {
+    const msg = sanitize(`[${new Date().toISOString()}] [svc-reconciler] CRASH uncaughtException: ${err.stack || err.message}\n`);
+    try { fs.appendFileSync(path.join(LOG_DIR, 'svc-reconciler.log'), msg); } catch {}
+    console.error(msg);
+    process.exit(1);
+});
+process.on('unhandledRejection', (reason) => {
+    const msg = sanitize(`[${new Date().toISOString()}] [svc-reconciler] CRASH unhandledRejection: ${reason?.stack || reason}\n`);
+    try { fs.appendFileSync(path.join(LOG_DIR, 'svc-reconciler.log'), msg); } catch {}
+    console.error(msg);
+    process.exit(1);
+});
+
+// Exportar para tests unitarios (no se ejecuta main si se require como módulo)
+if (require.main === module) {
+    main();
+}
+
+module.exports = {
+    reconcileOnce,
+    reconcileLabelToFilesystem,
+    reconcileMarkerToLabel,
+    reconcileClosedMarkers,
+    decidirFasePlaceholder,
+    listGhIssuesWithLabel,
+    getIssueState,
+    enqueueLabelApply,
+};

--- a/.pipeline/smoke-test.js
+++ b/.pipeline/smoke-test.js
@@ -43,6 +43,7 @@ const DEFAULT_COMPONENTS = [
   'svc-github',
   'svc-drive',
   'svc-emulador',
+  'svc-reconciler',
   'dashboard',
 ];
 


### PR DESCRIPTION
## Summary

Cierra el agujero de sincronización entre **label `needs-human` en GitHub** y **marker en `bloqueado-humano/` filesystem** que dejó 241 issues fantasma el 2026-04-29.

- **`lib/human-block.js`**: `reportHumanBlock()` encola el apply del label automáticamente. Cualquier vía oficial de bloqueo (incluido pause-all/scripts manuales) hereda el contrato correcto.
- **`servicio-reconciler.js`** (nuevo): proceso Node separado, corre cada 5 min en paralelo a Pulpo. Implementa las 3 reglas:
  1. Issue con label `needs-human` pero sin marker → crea placeholder
  2. Marker pero sin label → encola apply label
  3. Marker de issue closed → archiva el marker
- **`pulpo.js`**: deja de duplicar el encolado de label en su barrido (ahora vive en `reportHumanBlock`).
- **`restart.js` + `dashboard.js` + `pid-discovery.js` + `smoke-test.js`**: registran svc-reconciler como componente regular.
- **Tests** (11/11 verde): cubren las 3 reglas + heurística de fase + dedup + skip CLOSED/UNKNOWN.

## Diseño del reconciler

- Proceso aparte (no bloquea ni se bloquea con Pulpo).
- Primer ciclo a 30s del arranque (deja que el resto del pipeline se inicialice).
- Si `gh` falla, salta el ciclo sin tocar filesystem (defensivo).
- Heurística de fase para placeholders: `ready` → `desarrollo/dev`, default → `definicion/analisis`. El reason del placeholder dice claramente que la fase es estimada — el humano que /unblock-ee la ajusta si es necesario.
- Funciones de regla parametrizables (`getStateFn` injectable) para que los tests no necesiten mockear `gh`.

## Test plan

- [x] `node --test lib/__tests__/servicio-reconciler.test.js` — 11/11 pass
- [x] `node --test lib/__tests__/human-block.test.js` — 22/22 pass (no rompe tests existentes)
- [x] Syntax check de los 5 archivos modificados (`node -c`)
- [ ] Tras merge: levantar pipeline, esperar primer ciclo del reconciler (30s), verificar que loguea estado consistente
- [ ] Tras merge: forzar desincronía (label sin marker) y confirmar que el reconciler la cura en el siguiente ciclo

## Riesgo

- **Reconciler**: si `gh` cuelga, el ciclo entero del reconciler se cuelga (timeout de 30s). Mitigación: el resto del pipeline no se entera porque es proceso separado.
- **Cambio en `reportHumanBlock`**: ahora encola un comando extra. Si la cola del servicio-github está saturada el label puede tardar minutos. Mitigación: el escalado del pulpo no es time-critical (de todas formas pulpo no relanza el skill bloqueado).
- **Backwards-compat**: tests existentes pasan. El nuevo `skipGithubLabel: true` permite opt-out si algún caller no quería el label (ningún caller actual lo necesita).

## Relacionado

- Issue: #2880
- PR complementario (parte 3): #2883 — `.gitignore` para `bloqueado-humano/*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)