### PR TITLE
fix(pipeline): re-agregar svc-reconciler al COMPONENTS array (regresión #2885)

### DIFF
--- a/.pipeline/restart.js
+++ b/.pipeline/restart.js
@@ -50,6 +50,7 @@ const COMPONENTS = [
   { name: 'svc-github', script: 'servicio-github.js', pid: 'svc-github.pid' },
   { name: 'svc-drive', script: 'servicio-drive.js', pid: 'svc-drive.pid' },
   { name: 'svc-emulador', script: 'servicio-emulador.js', pid: 'svc-emulador.pid' },
+  { name: 'svc-reconciler', script: 'servicio-reconciler.js', pid: 'svc-reconciler.pid' },
   { name: 'dashboard', script: 'dashboard.js', pid: 'dashboard.pid' },
 ];
 


### PR DESCRIPTION
Regresión introducida por squash merge de #2885: la línea de svc-reconciler en el array COMPONENTS quedó accidentalmente removida (stash/pop durante desarrollo trajo versión vieja del archivo). Sin esta línea, restart.js no spawnea servicio-reconciler.js → ready marker missing → smoke FAIL → auto-rollback en loop.

Diff: 1 línea agregada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)