### PR TITLE
feat(ux): assets visuales modo descanso + alerta consumo (PR-UX standalone)

### DIFF
--- a/.pipeline/assets/design-tokens.css
+++ b/.pipeline/assets/design-tokens.css
@@ -79,6 +79,27 @@
   --teal-bg:            rgba(45, 212, 191, 0.14);
 
   /* ---------------------------------------------------------------------------
+   * 3.b SEMANTICOS DE OPERACION (estados del pipeline / ventanas)
+   * Reservados para superficies que comunican el estado operativo del
+   * sistema, no del trabajo del agente. Ej: modo descanso, alerta de
+   * consumo anomalo. Coherentes con la paleta existente, distintivos.
+   * #2882 — ventana modo descanso + alerta consumo anomalo.
+   * -------------------------------------------------------------------------- */
+  --rest-mode:          #7C5CFF;   /* indigo nocturno — modo descanso activo */
+  --rest-mode-dim:      #4B36B8;   /* borde/hover del indigo */
+  --rest-mode-bg:       rgba(124, 92, 255, 0.16);
+  --rest-mode-fg:       #C5B7FF;   /* texto sobre rest-mode-bg, contraste 7.4:1 */
+
+  --alert-anomaly:      #FF6B8A;   /* rosa-rojo distinguible del danger puro */
+  --alert-anomaly-dim:  #B8254A;
+  --alert-anomaly-bg:   rgba(255, 107, 138, 0.16);
+  --alert-anomaly-fg:   #FFD2DC;   /* texto sobre alert-anomaly-bg */
+  --alert-anomaly-glow: 0 0 12px rgba(255, 107, 138, 0.50);
+
+  --deterministic:      var(--text-secondary);  /* skill no-LLM (ejecuta sin tokens) */
+  --deterministic-bg:   rgba(177, 186, 196, 0.10);
+
+  /* ---------------------------------------------------------------------------
    * 4. ACENTOS POR LANE (board del dashboard)
    * Cada lane tiene un color distintivo para reforzar la identidad del flujo.
    * -------------------------------------------------------------------------- */

--- a/.pipeline/assets/icons/README.md
+++ b/.pipeline/assets/icons/README.md
@@ -70,6 +70,15 @@ cada icono se referencia via `<svg><use href="#ic-*" /></svg>`:
 | `ic-agents-count`   | Siluetas agrupadas  | KPI: N agentes activos            |
 | `ic-issues-count`   | Layers / pila       | KPI: N issues en curso            |
 
+### Modo descanso y alertas de consumo (#2882)
+
+| ID                    | Nombre                  | Uso                                                           |
+|-----------------------|-------------------------|---------------------------------------------------------------|
+| `ic-rest-mode`        | Luna + estrellas        | Pill del header / banner cuando modo descanso esta activo     |
+| `ic-cost-anomaly`     | Linea con pico          | Banner persistente de alerta de consumo anomalo               |
+| `ic-snooze`           | Campana + Z             | Boton/menu de snooze de alerta (1h/4h/24h)                    |
+| `ic-deterministic`    | Engranaje               | Marca skills que corren durante modo descanso (sin LLM)       |
+
 ## Convenciones de diseno
 
 - **ViewBox**: 24x24 uniforme.

--- a/.pipeline/assets/icons/sprite.svg
+++ b/.pipeline/assets/icons/sprite.svg
@@ -260,4 +260,61 @@
           stroke-linecap="round" stroke-linejoin="round"/>
   </symbol>
 
+  <!-- =========================================================================
+       MODO DESCANSO Y ALERTAS DE CONSUMO (#2882)
+       ========================================================================= -->
+
+  <!-- ic-rest-mode: luna creciente con tres estrellas (modo descanso activo) -->
+  <symbol id="ic-rest-mode" viewBox="0 0 24 24">
+    <!-- Luna creciente: forma con dos arcos (sin <mask> para mantener compatibilidad) -->
+    <path d="M19 14.5 A8.5 8.5 0 1 1 11 4 A6.5 6.5 0 0 0 19 14.5 Z"
+          fill="none" stroke="currentColor" stroke-width="1.75" stroke-linejoin="round"/>
+    <!-- Tres estrellas pequenas (fill=currentColor para distinguir) -->
+    <path d="M16.5 5.5 L17.2 7 L18.7 7.7 L17.2 8.4 L16.5 9.9 L15.8 8.4 L14.3 7.7 L15.8 7 Z"
+          fill="currentColor" stroke="none"/>
+    <circle cx="20.5" cy="10" r="0.7" fill="currentColor"/>
+    <circle cx="14" cy="3.5" r="0.6" fill="currentColor"/>
+  </symbol>
+
+  <!-- ic-cost-anomaly: linea con pico abrupto sobre baseline punteada (alerta de consumo) -->
+  <symbol id="ic-cost-anomaly" viewBox="0 0 24 24">
+    <!-- Eje base sutil -->
+    <path d="M3 19 H21" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" opacity="0.5"/>
+    <!-- Baseline esperado (punteado) -->
+    <path d="M3 14 H21" fill="none" stroke="currentColor" stroke-width="1.2"
+          stroke-linecap="round" stroke-dasharray="2 2.5" opacity="0.55"/>
+    <!-- Linea de consumo con pico hacia arriba -->
+    <path d="M3 14 L7 14 L9 14 L11 13.5 L13 5 L15 13.5 L17 14 L21 14"
+          fill="none" stroke="currentColor" stroke-width="1.85"
+          stroke-linecap="round" stroke-linejoin="round"/>
+    <!-- Punto en la cima del pico para enfatizar -->
+    <circle cx="13" cy="5" r="1.6" fill="currentColor"/>
+  </symbol>
+
+  <!-- ic-snooze: campana con Z (silenciar alerta) -->
+  <symbol id="ic-snooze" viewBox="0 0 24 24">
+    <!-- Campana -->
+    <path d="M6 16 V11 A6 6 0 0 1 18 11 V16 L20 18 H4 Z"
+          fill="none" stroke="currentColor" stroke-width="1.75"
+          stroke-linejoin="round" stroke-linecap="round"/>
+    <!-- Badajo -->
+    <path d="M10.5 21 A1.5 1.5 0 0 0 13.5 21" fill="none" stroke="currentColor"
+          stroke-width="1.75" stroke-linecap="round"/>
+    <!-- Z superpuesta arriba a la derecha -->
+    <path d="M16 3 H22 L16 9 H22" fill="none" stroke="currentColor"
+          stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
+
+  <!-- ic-deterministic: engranaje (skill que ejecuta sin LLM, corre durante modo descanso) -->
+  <symbol id="ic-deterministic" viewBox="0 0 24 24">
+    <!-- Cuerpo del engranaje (8 dientes esquematicos via path simple) -->
+    <path d="M12 2.5 L13.4 4.6 L15.8 4.1 L16.3 6.5 L18.6 7.4 L17.8 9.7 L19.5 11.5
+             L17.8 13.3 L18.6 15.6 L16.3 16.5 L15.8 18.9 L13.4 18.4 L12 20.5
+             L10.6 18.4 L8.2 18.9 L7.7 16.5 L5.4 15.6 L6.2 13.3 L4.5 11.5
+             L6.2 9.7 L5.4 7.4 L7.7 6.5 L8.2 4.1 L10.6 4.6 Z"
+          fill="none" stroke="currentColor" stroke-width="1.55" stroke-linejoin="round"/>
+    <!-- Centro -->
+    <circle cx="12" cy="11.5" r="3" fill="none" stroke="currentColor" stroke-width="1.55"/>
+  </symbol>
+
 </svg>

--- a/.pipeline/assets/mockups/04-rest-mode-active.svg
+++ b/.pipeline/assets/mockups/04-rest-mode-active.svg
@@ -1,0 +1,361 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Mockup 04 — Modo descanso ACTIVO (#2882 PR-A)
+  Resolucion: 1440x900
+  Demuestra:
+    - Pill "Modo descanso 23:00–07:00" en el header (indigo nocturno)
+    - Banner inferior al header con copy explicativo + countdown
+    - Lanes con tarjetas: skills determinísticos en curso (verde), skills LLM en cola (gris/indigo)
+    - Reloj 02:14 — corroborando que la ventana esta activa
+    - KPI "tokens hora" en cero (no hay LLM corriendo)
+  Tokens: design-tokens.css (rest-mode + paleta semantica)
+-->
+<svg xmlns="http://www.w3.org/2000/svg" width="1440" height="900" viewBox="0 0 1440 900"
+     font-family="-apple-system, 'Segoe UI', system-ui, sans-serif">
+
+  <defs>
+    <linearGradient id="brandGrad04" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#00D6FF"/>
+      <stop offset="100%" stop-color="#1890FF"/>
+    </linearGradient>
+    <linearGradient id="restHeaderGrad04" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#1F1645" stop-opacity="0.85"/>
+      <stop offset="100%" stop-color="#161B22" stop-opacity="1"/>
+    </linearGradient>
+    <linearGradient id="restBannerGrad04" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#7C5CFF" stop-opacity="0.18"/>
+      <stop offset="100%" stop-color="#7C5CFF" stop-opacity="0.06"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Fondo -->
+  <rect width="1440" height="900" fill="#0D1117"/>
+
+  <!-- Estrellas decorativas sutiles (refuerzan modo descanso, baja opacidad) -->
+  <g fill="#7C5CFF" opacity="0.18">
+    <circle cx="180" cy="40" r="1"/>
+    <circle cx="540" cy="22" r="0.8"/>
+    <circle cx="780" cy="50" r="1.2"/>
+    <circle cx="1100" cy="18" r="0.9"/>
+    <circle cx="1280" cy="60" r="1"/>
+  </g>
+
+  <!-- =============== HEADER =============== -->
+  <rect x="0" y="0" width="1440" height="92" fill="url(#restHeaderGrad04)"/>
+  <rect x="0" y="91" width="1440" height="1" fill="#30363D"/>
+
+  <!-- Logo + nombre -->
+  <g transform="translate(32, 26)">
+    <rect width="40" height="40" rx="10" fill="#0D274D"/>
+    <path d="M20 8 L6 33 L34 33 Z" fill="none" stroke="url(#brandGrad04)" stroke-width="3"
+          stroke-linejoin="round" stroke-linecap="round"/>
+    <path d="M20 18 L14.5 28 L25.5 28 Z" fill="url(#brandGrad04)"/>
+  </g>
+  <text x="84" y="42" fill="#E6EDF3" font-size="22" font-weight="700">Intrale Pipeline</text>
+  <text x="84" y="62" fill="#8B949E" font-size="11" font-weight="600" letter-spacing="1.5">
+    DASHBOARD V3 · localhost:3200
+  </text>
+
+  <!-- Badge V3 -->
+  <g transform="translate(260, 32)">
+    <rect width="40" height="24" rx="12" fill="#2DD4BF" fill-opacity="0.18" stroke="#2DD4BF" stroke-opacity="0.45"/>
+    <text x="20" y="16" fill="#2DD4BF" font-size="11" font-weight="700" text-anchor="middle" letter-spacing="1.2">V3</text>
+  </g>
+
+  <!-- Pill MODO DESCANSO ACTIVO (luna + texto) -->
+  <g transform="translate(320, 28)">
+    <rect width="246" height="32" rx="16" fill="#7C5CFF" fill-opacity="0.20" stroke="#7C5CFF" stroke-opacity="0.55"/>
+    <!-- Icono luna inline (simplificado del sprite) -->
+    <g transform="translate(11, 6)" fill="none" stroke="#C5B7FF" stroke-width="1.6">
+      <path d="M17 12 A7 7 0 1 1 10 5 A5.5 5.5 0 0 0 17 12 Z" stroke-linejoin="round"/>
+      <circle cx="14.5" cy="4.5" r="0.5" fill="#C5B7FF"/>
+      <circle cx="18.5" cy="8" r="0.4" fill="#C5B7FF"/>
+    </g>
+    <text x="38" y="20" fill="#C5B7FF" font-size="12" font-weight="700" letter-spacing="1.4">
+      MODO DESCANSO · 23:00–07:00
+    </text>
+  </g>
+
+  <!-- Pipeline status (still RUNNING — no esta paused, solo restringido) -->
+  <g transform="translate(580, 32)">
+    <rect width="108" height="24" rx="12" fill="#3FB950" fill-opacity="0.15" stroke="#3FB950" stroke-opacity="0.4"/>
+    <circle cx="14" cy="12" r="3.5" fill="#3FB950"/>
+    <text x="26" y="16" fill="#3FB950" font-size="11" font-weight="700" letter-spacing="1.5">RUNNING</text>
+  </g>
+
+  <!-- KPIs header — agentes y tokens hora (cero porque LLM en pausa) -->
+  <g transform="translate(900, 32)" font-size="13" fill="#B1BAC4">
+    <g>
+      <path d="M4 9 a3 3 0 1 0 6 0 a3 3 0 1 0 -6 0 M0 22 C0 17 3 14 7 14 C11 14 14 17 14 22"
+            fill="none" stroke="#58A6FF" stroke-width="1.75" stroke-linecap="round"/>
+      <text x="22" y="17" fill="#E6EDF3" font-size="14" font-weight="700">2</text>
+      <text x="36" y="17" fill="#8B949E" font-size="11">determinísticos</text>
+    </g>
+    <g transform="translate(155, 0)">
+      <path d="M3 19 H21 M13 19 V6 M13 6 L9 10 M13 6 L17 10" fill="none" stroke="#7C5CFF"
+            stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"/>
+      <text x="29" y="17" fill="#E6EDF3" font-size="14" font-weight="700">5</text>
+      <text x="43" y="17" fill="#8B949E" font-size="11">en cola</text>
+    </g>
+    <g transform="translate(255, 0)">
+      <path d="M3 19 H21 M3 14 H21" fill="none" stroke="#8B949E" stroke-width="1.2"
+            stroke-dasharray="2 2.5" stroke-linecap="round"/>
+      <path d="M3 14 L8 14 L11 13.5 L13 13 L15 13.5 L17 14 L21 14" fill="none"
+            stroke="#3FB950" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+      <text x="29" y="17" fill="#E6EDF3" font-size="14" font-weight="700">$0.00</text>
+      <text x="65" y="17" fill="#8B949E" font-size="11">USD/h</text>
+    </g>
+  </g>
+
+  <!-- Clock — 02:14 (madrugada, dentro de la ventana) -->
+  <g transform="translate(1320, 30)" text-anchor="end" font-family="'SF Mono', Consolas, monospace">
+    <text x="100" y="22" fill="#E6EDF3" font-size="22" font-weight="700" letter-spacing="2">02:14:38</text>
+    <text x="100" y="38" fill="#8B949E" font-size="10" letter-spacing="0.5">Sab 25 abr 2026 · -05h05m</text>
+  </g>
+
+  <!-- =============== BANNER MODO DESCANSO =============== -->
+  <g transform="translate(0, 92)">
+    <rect width="1440" height="64" fill="url(#restBannerGrad04)"/>
+    <rect x="0" y="0" width="3" height="64" fill="#7C5CFF"/>
+
+    <!-- Icono luna grande -->
+    <g transform="translate(32, 18)" fill="none" stroke="#C5B7FF" stroke-width="1.75">
+      <path d="M21 16 A8.5 8.5 0 1 1 13 6 A6.5 6.5 0 0 0 21 16 Z" stroke-linejoin="round"/>
+      <path d="M18.5 7.5 L19.2 9 L20.7 9.7 L19.2 10.4 L18.5 11.9 L17.8 10.4 L16.3 9.7 L17.8 9 Z"
+            fill="#C5B7FF" stroke="none"/>
+      <circle cx="22.5" cy="12" r="0.6" fill="#C5B7FF"/>
+    </g>
+
+    <text x="80" y="36" fill="#E6EDF3" font-size="15" font-weight="600">
+      Pipeline en modo descanso — solo se ejecutan agentes determinísticos
+    </text>
+    <text x="80" y="54" fill="#B1BAC4" font-size="12">
+      Las solicitudes que requieran LLM (po, ux, guru, *-dev, qa, review) quedan en
+      <tspan fill="#C5B7FF" font-weight="600">cola</tspan>
+      hasta el cierre de la ventana. Bypass activo para
+      <tspan fill="#F85149" font-weight="600">priority:critical</tspan>.
+    </text>
+
+    <!-- Countdown a la derecha -->
+    <g transform="translate(1180, 14)">
+      <text x="0" y="14" fill="#8B949E" font-size="10" letter-spacing="1.5">REANUDA EN</text>
+      <text x="0" y="42" fill="#C5B7FF" font-size="22" font-weight="700"
+            font-family="'SF Mono', Consolas, monospace" letter-spacing="1.5">04h 45m 22s</text>
+    </g>
+
+    <!-- Boton "Configurar" -->
+    <g transform="translate(1340, 18)">
+      <rect width="76" height="28" rx="8" fill="none" stroke="#7C5CFF" stroke-opacity="0.55"/>
+      <text x="38" y="18" fill="#C5B7FF" font-size="11" font-weight="600" text-anchor="middle"
+            letter-spacing="0.5">Configurar</text>
+    </g>
+  </g>
+
+  <!-- =============== H2 SECCION =============== -->
+  <text x="32" y="194" fill="#8B949E" font-size="12" font-weight="600" letter-spacing="2">
+    BOARD KANBAN — PIPELINE V3
+  </text>
+
+  <!-- =============== LANES =============== -->
+
+  <!-- === Lane 1: DEFINICION (todos en cola — LLM-only) === -->
+  <g transform="translate(32, 214)">
+    <rect width="445" height="48" rx="10" fill="#161B22" stroke="#30363D"/>
+    <rect width="4" height="48" rx="2" fill="#BC8CFF"/>
+    <text x="22" y="29" fill="#BC8CFF" font-size="13" font-weight="700" letter-spacing="1.2">DEFINICIÓN</text>
+    <text x="155" y="29" fill="#8B949E" font-size="11">3 issues · todos en cola</text>
+    <!-- Pill "EN COLA" -->
+    <g transform="translate(370, 13)">
+      <rect width="60" height="22" rx="11" fill="#7C5CFF" fill-opacity="0.18" stroke="#7C5CFF" stroke-opacity="0.45"/>
+      <text x="30" y="15" fill="#C5B7FF" font-size="10" font-weight="700" text-anchor="middle" letter-spacing="0.8">EN COLA</text>
+    </g>
+
+    <!-- Card 1: po (LLM) -->
+    <g transform="translate(0, 60)">
+      <rect width="445" height="80" rx="10" fill="#161B22" stroke="#30363D" opacity="0.85"/>
+      <rect x="2" width="4" height="80" rx="2" fill="#BC8CFF" opacity="0.4"/>
+      <text x="20" y="24" fill="#E6EDF3" font-size="13" font-weight="700">#2917 — PO</text>
+      <text x="20" y="44" fill="#B1BAC4" font-size="12">Refinar criterios CTA pago carrito</text>
+      <!-- Status "esperando ventana" -->
+      <g transform="translate(280, 13)">
+        <rect width="148" height="22" rx="11" fill="#7C5CFF" fill-opacity="0.16" stroke="#7C5CFF" stroke-opacity="0.4"/>
+        <path d="M286 24 A4 4 0 1 1 282 28 A4 4 0 0 1 286 24 Z" fill="none" stroke="#C5B7FF" stroke-width="1.2" transform="translate(-282,-22)"/>
+        <text x="74" y="15" fill="#C5B7FF" font-size="10" font-weight="600" text-anchor="middle">esperando 04h45m</text>
+      </g>
+      <!-- Skill chip LLM -->
+      <g transform="translate(20, 56)">
+        <rect width="48" height="18" rx="9" fill="#1F6FEB" fill-opacity="0.16" stroke="#1F6FEB" stroke-opacity="0.4"/>
+        <text x="24" y="13" fill="#58A6FF" font-size="9" font-weight="700" text-anchor="middle">LLM</text>
+      </g>
+      <text x="74" y="69" fill="#8B949E" font-size="11">criterios → po · sonnet</text>
+    </g>
+
+    <!-- Card 2: guru (LLM) -->
+    <g transform="translate(0, 152)">
+      <rect width="445" height="80" rx="10" fill="#161B22" stroke="#30363D" opacity="0.85"/>
+      <rect x="2" width="4" height="80" rx="2" fill="#BC8CFF" opacity="0.4"/>
+      <text x="20" y="24" fill="#E6EDF3" font-size="13" font-weight="700">#2920 — GURU</text>
+      <text x="20" y="44" fill="#B1BAC4" font-size="12">Análisis técnico — pre-fetch issue summaries</text>
+      <g transform="translate(280, 13)">
+        <rect width="148" height="22" rx="11" fill="#7C5CFF" fill-opacity="0.16" stroke="#7C5CFF" stroke-opacity="0.4"/>
+        <text x="74" y="15" fill="#C5B7FF" font-size="10" font-weight="600" text-anchor="middle">esperando 04h45m</text>
+      </g>
+      <g transform="translate(20, 56)">
+        <rect width="48" height="18" rx="9" fill="#1F6FEB" fill-opacity="0.16" stroke="#1F6FEB" stroke-opacity="0.4"/>
+        <text x="24" y="13" fill="#58A6FF" font-size="9" font-weight="700" text-anchor="middle">LLM</text>
+      </g>
+      <text x="74" y="69" fill="#8B949E" font-size="11">analisis → guru · sonnet</text>
+    </g>
+  </g>
+
+  <!-- === Lane 2: DESARROLLO (mezcla — builder/tester corriendo, dev en cola) === -->
+  <g transform="translate(497, 214)">
+    <rect width="445" height="48" rx="10" fill="#161B22" stroke="#30363D"/>
+    <rect width="4" height="48" rx="2" fill="#58A6FF"/>
+    <text x="22" y="29" fill="#58A6FF" font-size="13" font-weight="700" letter-spacing="1.2">DESARROLLO</text>
+    <text x="160" y="29" fill="#8B949E" font-size="11">3 issues · 2 corriendo · 1 en cola</text>
+
+    <!-- Card 1: builder (DETERMINISTICO — corriendo) -->
+    <g transform="translate(0, 60)">
+      <rect width="445" height="80" rx="10" fill="#161B22" stroke="#30363D"/>
+      <rect x="2" width="4" height="80" rx="2" fill="#3FB950"/>
+      <text x="20" y="24" fill="#E6EDF3" font-size="13" font-weight="700">#2925 — BUILDER</text>
+      <text x="20" y="44" fill="#B1BAC4" font-size="12">composeApp:assembleClientDebug</text>
+      <!-- Status "corriendo 02:42" -->
+      <g transform="translate(310, 13)">
+        <rect width="118" height="22" rx="11" fill="#3FB950" fill-opacity="0.16" stroke="#3FB950" stroke-opacity="0.45"/>
+        <circle cx="11" cy="11" r="3" fill="#3FB950"/>
+        <text x="59" y="15" fill="#3FB950" font-size="10" font-weight="700" text-anchor="middle" letter-spacing="0.5">CORRIENDO 02:42</text>
+      </g>
+      <!-- Skill chip DETERMINISTICO + engranaje -->
+      <g transform="translate(20, 56)">
+        <rect width="80" height="18" rx="9" fill="rgba(177,186,196,0.10)" stroke="#484F58" stroke-opacity="0.55"/>
+        <g transform="translate(4, 3) scale(0.5)" fill="none" stroke="#B1BAC4" stroke-width="2.2">
+          <path d="M12 2.5 L13.4 4.6 L15.8 4.1 L16.3 6.5 L18.6 7.4 L17.8 9.7 L19.5 11.5
+                   L17.8 13.3 L18.6 15.6 L16.3 16.5 L15.8 18.9 L13.4 18.4 L12 20.5
+                   L10.6 18.4 L8.2 18.9 L7.7 16.5 L5.4 15.6 L6.2 13.3 L4.5 11.5
+                   L6.2 9.7 L5.4 7.4 L7.7 6.5 L8.2 4.1 L10.6 4.6 Z" stroke-linejoin="round"/>
+          <circle cx="12" cy="11.5" r="3"/>
+        </g>
+        <text x="48" y="13" fill="#B1BAC4" font-size="9" font-weight="700" text-anchor="middle">DETERMINÍSTICO</text>
+      </g>
+      <text x="106" y="69" fill="#8B949E" font-size="11">build → builder · 0 tokens</text>
+    </g>
+
+    <!-- Card 2: tester (DETERMINISTICO — corriendo) -->
+    <g transform="translate(0, 152)">
+      <rect width="445" height="80" rx="10" fill="#161B22" stroke="#30363D"/>
+      <rect x="2" width="4" height="80" rx="2" fill="#3FB950"/>
+      <text x="20" y="24" fill="#E6EDF3" font-size="13" font-weight="700">#2918 — TESTER</text>
+      <text x="20" y="44" fill="#B1BAC4" font-size="12">jvmTest cobertura kover</text>
+      <g transform="translate(310, 13)">
+        <rect width="118" height="22" rx="11" fill="#3FB950" fill-opacity="0.16" stroke="#3FB950" stroke-opacity="0.45"/>
+        <circle cx="11" cy="11" r="3" fill="#3FB950"/>
+        <text x="59" y="15" fill="#3FB950" font-size="10" font-weight="700" text-anchor="middle" letter-spacing="0.5">CORRIENDO 00:48</text>
+      </g>
+      <g transform="translate(20, 56)">
+        <rect width="80" height="18" rx="9" fill="rgba(177,186,196,0.10)" stroke="#484F58" stroke-opacity="0.55"/>
+        <g transform="translate(4, 3) scale(0.5)" fill="none" stroke="#B1BAC4" stroke-width="2.2">
+          <path d="M12 2.5 L13.4 4.6 L15.8 4.1 L16.3 6.5 L18.6 7.4 L17.8 9.7 L19.5 11.5
+                   L17.8 13.3 L18.6 15.6 L16.3 16.5 L15.8 18.9 L13.4 18.4 L12 20.5
+                   L10.6 18.4 L8.2 18.9 L7.7 16.5 L5.4 15.6 L6.2 13.3 L4.5 11.5
+                   L6.2 9.7 L5.4 7.4 L7.7 6.5 L8.2 4.1 L10.6 4.6 Z" stroke-linejoin="round"/>
+          <circle cx="12" cy="11.5" r="3"/>
+        </g>
+        <text x="48" y="13" fill="#B1BAC4" font-size="9" font-weight="700" text-anchor="middle">DETERMINÍSTICO</text>
+      </g>
+      <text x="106" y="69" fill="#8B949E" font-size="11">verificacion → tester · 0 tokens</text>
+    </g>
+
+    <!-- Card 3: android-dev (LLM — en cola) -->
+    <g transform="translate(0, 244)">
+      <rect width="445" height="80" rx="10" fill="#161B22" stroke="#30363D" opacity="0.85"/>
+      <rect x="2" width="4" height="80" rx="2" fill="#58A6FF" opacity="0.4"/>
+      <text x="20" y="24" fill="#E6EDF3" font-size="13" font-weight="700">#2912 — ANDROID-DEV</text>
+      <text x="20" y="44" fill="#B1BAC4" font-size="12">Producto Splash con identidad por flavor</text>
+      <g transform="translate(280, 13)">
+        <rect width="148" height="22" rx="11" fill="#7C5CFF" fill-opacity="0.16" stroke="#7C5CFF" stroke-opacity="0.4"/>
+        <text x="74" y="15" fill="#C5B7FF" font-size="10" font-weight="600" text-anchor="middle">esperando 04h45m</text>
+      </g>
+      <g transform="translate(20, 56)">
+        <rect width="48" height="18" rx="9" fill="#1F6FEB" fill-opacity="0.16" stroke="#1F6FEB" stroke-opacity="0.4"/>
+        <text x="24" y="13" fill="#58A6FF" font-size="9" font-weight="700" text-anchor="middle">LLM</text>
+      </g>
+      <text x="74" y="69" fill="#8B949E" font-size="11">dev → android-dev · sonnet</text>
+    </g>
+  </g>
+
+  <!-- === Lane 3: ENTREGA (delivery determinístico — corriendo) === -->
+  <g transform="translate(962, 214)">
+    <rect width="445" height="48" rx="10" fill="#161B22" stroke="#30363D"/>
+    <rect width="4" height="48" rx="2" fill="#3FB950"/>
+    <text x="22" y="29" fill="#3FB950" font-size="13" font-weight="700" letter-spacing="1.2">ENTREGA</text>
+    <text x="120" y="29" fill="#8B949E" font-size="11">1 issue · corriendo</text>
+
+    <!-- Card 1: delivery (DETERMINISTICO) -->
+    <g transform="translate(0, 60)">
+      <rect width="445" height="80" rx="10" fill="#161B22" stroke="#30363D"/>
+      <rect x="2" width="4" height="80" rx="2" fill="#3FB950"/>
+      <text x="20" y="24" fill="#E6EDF3" font-size="13" font-weight="700">#2904 — DELIVERY</text>
+      <text x="20" y="44" fill="#B1BAC4" font-size="12">Commit + push + PR — fix(pipeline) restart re-exec</text>
+      <g transform="translate(310, 13)">
+        <rect width="118" height="22" rx="11" fill="#3FB950" fill-opacity="0.16" stroke="#3FB950" stroke-opacity="0.45"/>
+        <circle cx="11" cy="11" r="3" fill="#3FB950"/>
+        <text x="59" y="15" fill="#3FB950" font-size="10" font-weight="700" text-anchor="middle" letter-spacing="0.5">CORRIENDO 00:12</text>
+      </g>
+      <g transform="translate(20, 56)">
+        <rect width="80" height="18" rx="9" fill="rgba(177,186,196,0.10)" stroke="#484F58" stroke-opacity="0.55"/>
+        <g transform="translate(4, 3) scale(0.5)" fill="none" stroke="#B1BAC4" stroke-width="2.2">
+          <path d="M12 2.5 L13.4 4.6 L15.8 4.1 L16.3 6.5 L18.6 7.4 L17.8 9.7 L19.5 11.5
+                   L17.8 13.3 L18.6 15.6 L16.3 16.5 L15.8 18.9 L13.4 18.4 L12 20.5
+                   L10.6 18.4 L8.2 18.9 L7.7 16.5 L5.4 15.6 L6.2 13.3 L4.5 11.5
+                   L6.2 9.7 L5.4 7.4 L7.7 6.5 L8.2 4.1 L10.6 4.6 Z" stroke-linejoin="round"/>
+          <circle cx="12" cy="11.5" r="3"/>
+        </g>
+        <text x="48" y="13" fill="#B1BAC4" font-size="9" font-weight="700" text-anchor="middle">DETERMINÍSTICO</text>
+      </g>
+      <text x="106" y="69" fill="#8B949E" font-size="11">entrega → delivery · 0 tokens</text>
+    </g>
+
+    <!-- Bypass card (priority:critical override) -->
+    <g transform="translate(0, 152)">
+      <rect width="445" height="80" rx="10" fill="#161B22" stroke="#F85149" stroke-opacity="0.45"/>
+      <rect x="2" width="4" height="80" rx="2" fill="#F85149"/>
+      <text x="20" y="24" fill="#E6EDF3" font-size="13" font-weight="700">#2932 — REVIEW (bypass)</text>
+      <text x="20" y="44" fill="#B1BAC4" font-size="12">Hotfix critico de auth — ejecuta aunque sea LLM</text>
+      <g transform="translate(310, 13)">
+        <rect width="118" height="22" rx="11" fill="#F85149" fill-opacity="0.16" stroke="#F85149" stroke-opacity="0.45"/>
+        <circle cx="11" cy="11" r="3" fill="#F85149"/>
+        <text x="59" y="15" fill="#F85149" font-size="10" font-weight="700" text-anchor="middle" letter-spacing="0.5">CRITICAL · BYPASS</text>
+      </g>
+      <g transform="translate(20, 56)">
+        <rect width="98" height="18" rx="9" fill="#F85149" fill-opacity="0.16" stroke="#F85149" stroke-opacity="0.45"/>
+        <text x="49" y="13" fill="#F85149" font-size="9" font-weight="700" text-anchor="middle" letter-spacing="0.5">priority:critical</text>
+      </g>
+      <text x="124" y="69" fill="#8B949E" font-size="11">aprobacion → review · sonnet</text>
+    </g>
+
+    <!-- Footer info -->
+    <g transform="translate(0, 248)">
+      <text x="0" y="14" fill="#8B949E" font-size="11" font-style="italic">
+        Modo descanso reanudará el procesamiento LLM al cerrar la ventana.
+      </text>
+      <text x="0" y="32" fill="#8B949E" font-size="11" font-style="italic">
+        Concurrencia escalonada al despertar para evitar estampida.
+      </text>
+    </g>
+  </g>
+
+  <!-- =============== FOOTER =============== -->
+  <g transform="translate(0, 858)">
+    <rect width="1440" height="42" fill="#161B22"/>
+    <rect width="1440" height="1" fill="#30363D"/>
+    <text x="32" y="26" fill="#8B949E" font-size="11">
+      Modo descanso · ventana 23:00–07:00 · TZ America/Argentina/Buenos_Aires · días: lun–dom · bypass: priority:critical
+    </text>
+    <text x="1408" y="26" fill="#8B949E" font-size="11" text-anchor="end" font-family="'SF Mono', Consolas, monospace">
+      .pipeline/rest-mode.json
+    </text>
+  </g>
+
+</svg>

--- a/.pipeline/assets/mockups/05-rest-mode-settings.svg
+++ b/.pipeline/assets/mockups/05-rest-mode-settings.svg
@@ -1,0 +1,290 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Mockup 05 — Página de configuración "Modo descanso" (#2882 PR-A / Bloque 3)
+  Resolucion: 1440x900
+  Demuestra:
+    - Tab "Modo descanso" en navegación lateral del dashboard
+    - Form: toggle ON/OFF, hora inicio, hora fin, timezone, días, bypass labels
+    - Sección read-only para "skills determinísticos" + "skills LLM"
+    - Estado actual: ACTIVO con preview del countdown
+    - Banner de confirmación tras guardar (toast persistente abajo)
+  Tokens: design-tokens.css
+-->
+<svg xmlns="http://www.w3.org/2000/svg" width="1440" height="900" viewBox="0 0 1440 900"
+     font-family="-apple-system, 'Segoe UI', system-ui, sans-serif">
+
+  <defs>
+    <linearGradient id="brandGrad05" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#00D6FF"/>
+      <stop offset="100%" stop-color="#1890FF"/>
+    </linearGradient>
+    <linearGradient id="restPanel05" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#1F1645" stop-opacity="0.45"/>
+      <stop offset="100%" stop-color="#161B22" stop-opacity="1"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Fondo -->
+  <rect width="1440" height="900" fill="#0D1117"/>
+
+  <!-- =============== HEADER (compacto, igual al home) =============== -->
+  <rect x="0" y="0" width="1440" height="64" fill="#161B22"/>
+  <rect x="0" y="63" width="1440" height="1" fill="#30363D"/>
+  <g transform="translate(24, 14)">
+    <rect width="36" height="36" rx="9" fill="#0D274D"/>
+    <path d="M18 7 L5 30 L31 30 Z" fill="none" stroke="url(#brandGrad05)" stroke-width="2.5"
+          stroke-linejoin="round"/>
+    <path d="M18 16 L13 26 L23 26 Z" fill="url(#brandGrad05)"/>
+  </g>
+  <text x="72" y="32" fill="#E6EDF3" font-size="17" font-weight="700">Intrale Pipeline</text>
+  <text x="72" y="50" fill="#8B949E" font-size="10" font-weight="600" letter-spacing="1.4">SETTINGS · MODO DESCANSO</text>
+  <!-- Pill estado actual -->
+  <g transform="translate(280, 18)">
+    <rect width="178" height="28" rx="14" fill="#7C5CFF" fill-opacity="0.20" stroke="#7C5CFF" stroke-opacity="0.55"/>
+    <g transform="translate(10, 5)" fill="none" stroke="#C5B7FF" stroke-width="1.6">
+      <path d="M16 11 A6.5 6.5 0 1 1 9.5 5 A5 5 0 0 0 16 11 Z" stroke-linejoin="round"/>
+    </g>
+    <text x="36" y="18" fill="#C5B7FF" font-size="11" font-weight="700" letter-spacing="1.2">ACTIVO · 02:14 LOCAL</text>
+  </g>
+  <text x="1416" y="38" fill="#8B949E" font-size="11" text-anchor="end" font-family="'SF Mono', Consolas, monospace">
+    localhost:3200/settings/rest-mode
+  </text>
+
+  <!-- =============== SIDEBAR =============== -->
+  <rect x="0" y="64" width="220" height="836" fill="#161B22"/>
+  <rect x="220" y="64" width="1" height="836" fill="#30363D"/>
+
+  <!-- Items de navegación -->
+  <g font-size="13" fill="#B1BAC4" font-weight="500">
+    <text x="20" y="100" fill="#8B949E" font-size="10" letter-spacing="1.6">PIPELINE</text>
+    <g transform="translate(20, 116)">
+      <text x="0" y="14">Board</text>
+    </g>
+    <g transform="translate(20, 144)">
+      <text x="0" y="14">Issues</text>
+    </g>
+    <g transform="translate(20, 172)">
+      <text x="0" y="14">Consumo</text>
+    </g>
+
+    <text x="20" y="218" fill="#8B949E" font-size="10" letter-spacing="1.6">OPERACIÓN</text>
+
+    <!-- Item activo: Modo descanso -->
+    <g transform="translate(0, 234)">
+      <rect width="220" height="36" fill="#7C5CFF" fill-opacity="0.12"/>
+      <rect width="3" height="36" fill="#7C5CFF"/>
+      <g transform="translate(20, 8)" fill="none" stroke="#C5B7FF" stroke-width="1.6">
+        <path d="M16 11 A6.5 6.5 0 1 1 9.5 5 A5 5 0 0 0 16 11 Z" stroke-linejoin="round"/>
+        <circle cx="14" cy="4" r="0.5" fill="#C5B7FF"/>
+      </g>
+      <text x="48" y="22" fill="#C5B7FF" font-size="13" font-weight="700">Modo descanso</text>
+    </g>
+
+    <g transform="translate(20, 286)"><text x="0" y="14">Pausa parcial</text></g>
+    <g transform="translate(20, 314)"><text x="0" y="14">Ventanas QA/Build</text></g>
+    <g transform="translate(20, 342)"><text x="0" y="14">Bloqueado humano</text></g>
+
+    <text x="20" y="388" fill="#8B949E" font-size="10" letter-spacing="1.6">SISTEMA</text>
+    <g transform="translate(20, 404)"><text x="0" y="14">Salud</text></g>
+    <g transform="translate(20, 432)"><text x="0" y="14">Logs</text></g>
+  </g>
+
+  <!-- =============== MAIN CONTENT =============== -->
+  <g transform="translate(252, 96)">
+
+    <!-- Title + breadcrumb -->
+    <text x="0" y="0" fill="#8B949E" font-size="11" letter-spacing="1.2">SETTINGS / OPERACIÓN /</text>
+    <text x="0" y="32" fill="#E6EDF3" font-size="26" font-weight="700">Modo descanso</text>
+    <text x="0" y="56" fill="#B1BAC4" font-size="13">
+      Definí una ventana horaria donde el pipeline solo ejecuta agentes determinísticos.
+      Los agentes LLM quedan en cola hasta que la ventana se cierra.
+    </text>
+
+    <!-- =============== CARD 1: TOGGLE + HORARIO =============== -->
+    <g transform="translate(0, 88)">
+      <rect width="780" height="280" rx="12" fill="url(#restPanel05)" stroke="#30363D"/>
+
+      <!-- Header card con toggle ON/OFF -->
+      <text x="24" y="36" fill="#E6EDF3" font-size="16" font-weight="700">Configuración de la ventana</text>
+
+      <!-- Toggle ON -->
+      <g transform="translate(710, 24)">
+        <rect width="46" height="24" rx="12" fill="#7C5CFF"/>
+        <circle cx="34" cy="12" r="9" fill="#FFFFFF"/>
+        <text x="0" y="-6" fill="#C5B7FF" font-size="10" font-weight="700" letter-spacing="1.2">ACTIVO</text>
+      </g>
+      <rect x="0" y="58" width="780" height="1" fill="#30363D"/>
+
+      <!-- Hora inicio + Hora fin -->
+      <g transform="translate(24, 84)">
+        <text x="0" y="0" fill="#B1BAC4" font-size="11" font-weight="600" letter-spacing="0.8">HORA INICIO</text>
+        <rect x="0" y="10" width="120" height="40" rx="8" fill="#0D1117" stroke="#30363D"/>
+        <text x="60" y="36" fill="#E6EDF3" font-size="20" font-weight="700" text-anchor="middle"
+              font-family="'SF Mono', Consolas, monospace" letter-spacing="2">23:00</text>
+      </g>
+      <g transform="translate(170, 84)">
+        <text x="0" y="0" fill="#B1BAC4" font-size="11" font-weight="600" letter-spacing="0.8">HORA FIN</text>
+        <rect x="0" y="10" width="120" height="40" rx="8" fill="#0D1117" stroke="#30363D"/>
+        <text x="60" y="36" fill="#E6EDF3" font-size="20" font-weight="700" text-anchor="middle"
+              font-family="'SF Mono', Consolas, monospace" letter-spacing="2">07:00</text>
+      </g>
+      <g transform="translate(316, 84)">
+        <text x="0" y="0" fill="#B1BAC4" font-size="11" font-weight="600" letter-spacing="0.8">ZONA HORARIA</text>
+        <rect x="0" y="10" width="240" height="40" rx="8" fill="#0D1117" stroke="#30363D"/>
+        <text x="14" y="36" fill="#E6EDF3" font-size="13">America/Argentina/Buenos_Aires</text>
+        <path d="M222 30 L228 36 L234 30" fill="none" stroke="#8B949E" stroke-width="1.5"
+              stroke-linecap="round" stroke-linejoin="round"/>
+      </g>
+
+      <!-- Días aplicables -->
+      <g transform="translate(24, 156)">
+        <text x="0" y="0" fill="#B1BAC4" font-size="11" font-weight="600" letter-spacing="0.8">DÍAS APLICABLES</text>
+        <!-- Day pills (todos activos) -->
+        <g transform="translate(0, 12)">
+          <g transform="translate(0, 0)">
+            <rect width="44" height="36" rx="8" fill="#7C5CFF" fill-opacity="0.20" stroke="#7C5CFF" stroke-opacity="0.5"/>
+            <text x="22" y="22" fill="#C5B7FF" font-size="12" font-weight="700" text-anchor="middle">L</text>
+          </g>
+          <g transform="translate(52, 0)">
+            <rect width="44" height="36" rx="8" fill="#7C5CFF" fill-opacity="0.20" stroke="#7C5CFF" stroke-opacity="0.5"/>
+            <text x="22" y="22" fill="#C5B7FF" font-size="12" font-weight="700" text-anchor="middle">M</text>
+          </g>
+          <g transform="translate(104, 0)">
+            <rect width="44" height="36" rx="8" fill="#7C5CFF" fill-opacity="0.20" stroke="#7C5CFF" stroke-opacity="0.5"/>
+            <text x="22" y="22" fill="#C5B7FF" font-size="12" font-weight="700" text-anchor="middle">M</text>
+          </g>
+          <g transform="translate(156, 0)">
+            <rect width="44" height="36" rx="8" fill="#7C5CFF" fill-opacity="0.20" stroke="#7C5CFF" stroke-opacity="0.5"/>
+            <text x="22" y="22" fill="#C5B7FF" font-size="12" font-weight="700" text-anchor="middle">J</text>
+          </g>
+          <g transform="translate(208, 0)">
+            <rect width="44" height="36" rx="8" fill="#7C5CFF" fill-opacity="0.20" stroke="#7C5CFF" stroke-opacity="0.5"/>
+            <text x="22" y="22" fill="#C5B7FF" font-size="12" font-weight="700" text-anchor="middle">V</text>
+          </g>
+          <g transform="translate(260, 0)">
+            <rect width="44" height="36" rx="8" fill="#7C5CFF" fill-opacity="0.20" stroke="#7C5CFF" stroke-opacity="0.5"/>
+            <text x="22" y="22" fill="#C5B7FF" font-size="12" font-weight="700" text-anchor="middle">S</text>
+          </g>
+          <g transform="translate(312, 0)">
+            <rect width="44" height="36" rx="8" fill="#7C5CFF" fill-opacity="0.20" stroke="#7C5CFF" stroke-opacity="0.5"/>
+            <text x="22" y="22" fill="#C5B7FF" font-size="12" font-weight="700" text-anchor="middle">D</text>
+          </g>
+        </g>
+      </g>
+
+      <!-- Preview del countdown -->
+      <g transform="translate(580, 156)">
+        <rect width="176" height="84" rx="10" fill="#7C5CFF" fill-opacity="0.10" stroke="#7C5CFF" stroke-opacity="0.45"/>
+        <text x="14" y="22" fill="#8B949E" font-size="10" letter-spacing="1.5">REANUDA EN</text>
+        <text x="14" y="56" fill="#C5B7FF" font-size="22" font-weight="700"
+              font-family="'SF Mono', Consolas, monospace" letter-spacing="1.5">04h 45m</text>
+        <text x="14" y="74" fill="#8B949E" font-size="10">basado en hora local actual</text>
+      </g>
+    </g>
+
+    <!-- =============== CARD 2: SKILLS DETERMINÍSTICOS / LLM (read-only) =============== -->
+    <g transform="translate(0, 392)">
+      <rect width="780" height="220" rx="12" fill="#161B22" stroke="#30363D"/>
+      <text x="24" y="36" fill="#E6EDF3" font-size="16" font-weight="700">Skills clasificados</text>
+      <text x="24" y="58" fill="#B1BAC4" font-size="12">
+        Los skills determinísticos siguen ejecutando dentro de la ventana. Los LLM quedan en cola.
+      </text>
+      <text x="755" y="36" fill="#8B949E" font-size="11" text-anchor="end">desde config.yaml · read-only</text>
+
+      <!-- Columna determinísticos -->
+      <g transform="translate(24, 80)">
+        <text x="0" y="0" fill="#3FB950" font-size="11" font-weight="700" letter-spacing="1.2">DETERMINÍSTICOS · CORREN EN VENTANA</text>
+        <g transform="translate(0, 16)" font-size="12">
+          <g><rect width="86" height="26" rx="6" fill="rgba(177,186,196,0.10)" stroke="#484F58" stroke-opacity="0.55"/>
+             <text x="43" y="17" fill="#B1BAC4" text-anchor="middle">delivery</text></g>
+          <g transform="translate(94, 0)"><rect width="86" height="26" rx="6" fill="rgba(177,186,196,0.10)" stroke="#484F58" stroke-opacity="0.55"/>
+             <text x="43" y="17" fill="#B1BAC4" text-anchor="middle">builder</text></g>
+          <g transform="translate(188, 0)"><rect width="86" height="26" rx="6" fill="rgba(177,186,196,0.10)" stroke="#484F58" stroke-opacity="0.55"/>
+             <text x="43" y="17" fill="#B1BAC4" text-anchor="middle">tester</text></g>
+          <g transform="translate(282, 0)"><rect width="86" height="26" rx="6" fill="rgba(177,186,196,0.10)" stroke="#484F58" stroke-opacity="0.55"/>
+             <text x="43" y="17" fill="#B1BAC4" text-anchor="middle">linter</text></g>
+        </g>
+      </g>
+
+      <!-- Columna LLM -->
+      <g transform="translate(24, 144)">
+        <text x="0" y="0" fill="#58A6FF" font-size="11" font-weight="700" letter-spacing="1.2">LLM · QUEDAN EN COLA</text>
+        <g transform="translate(0, 16)" font-size="12">
+          <g><rect width="60" height="24" rx="6" fill="#1F6FEB" fill-opacity="0.12" stroke="#1F6FEB" stroke-opacity="0.4"/>
+             <text x="30" y="16" fill="#58A6FF" text-anchor="middle">po</text></g>
+          <g transform="translate(68, 0)"><rect width="60" height="24" rx="6" fill="#1F6FEB" fill-opacity="0.12" stroke="#1F6FEB" stroke-opacity="0.4"/>
+             <text x="30" y="16" fill="#58A6FF" text-anchor="middle">ux</text></g>
+          <g transform="translate(136, 0)"><rect width="60" height="24" rx="6" fill="#1F6FEB" fill-opacity="0.12" stroke="#1F6FEB" stroke-opacity="0.4"/>
+             <text x="30" y="16" fill="#58A6FF" text-anchor="middle">guru</text></g>
+          <g transform="translate(204, 0)"><rect width="80" height="24" rx="6" fill="#1F6FEB" fill-opacity="0.12" stroke="#1F6FEB" stroke-opacity="0.4"/>
+             <text x="40" y="16" fill="#58A6FF" text-anchor="middle">security</text></g>
+          <g transform="translate(292, 0)"><rect width="80" height="24" rx="6" fill="#1F6FEB" fill-opacity="0.12" stroke="#1F6FEB" stroke-opacity="0.4"/>
+             <text x="40" y="16" fill="#58A6FF" text-anchor="middle">planner</text></g>
+          <g transform="translate(380, 0)"><rect width="100" height="24" rx="6" fill="#1F6FEB" fill-opacity="0.12" stroke="#1F6FEB" stroke-opacity="0.4"/>
+             <text x="50" y="16" fill="#58A6FF" text-anchor="middle">backend-dev</text></g>
+          <g transform="translate(488, 0)"><rect width="100" height="24" rx="6" fill="#1F6FEB" fill-opacity="0.12" stroke="#1F6FEB" stroke-opacity="0.4"/>
+             <text x="50" y="16" fill="#58A6FF" text-anchor="middle">android-dev</text></g>
+          <g transform="translate(596, 0)"><rect width="80" height="24" rx="6" fill="#1F6FEB" fill-opacity="0.12" stroke="#1F6FEB" stroke-opacity="0.4"/>
+             <text x="40" y="16" fill="#58A6FF" text-anchor="middle">web-dev</text></g>
+        </g>
+        <g transform="translate(0, 50)" font-size="12">
+          <g><rect width="100" height="24" rx="6" fill="#1F6FEB" fill-opacity="0.12" stroke="#1F6FEB" stroke-opacity="0.4"/>
+             <text x="50" y="16" fill="#58A6FF" text-anchor="middle">pipeline-dev</text></g>
+          <g transform="translate(108, 0)"><rect width="60" height="24" rx="6" fill="#1F6FEB" fill-opacity="0.12" stroke="#1F6FEB" stroke-opacity="0.4"/>
+             <text x="30" y="16" fill="#58A6FF" text-anchor="middle">qa</text></g>
+          <g transform="translate(176, 0)"><rect width="80" height="24" rx="6" fill="#1F6FEB" fill-opacity="0.12" stroke="#1F6FEB" stroke-opacity="0.4"/>
+             <text x="40" y="16" fill="#58A6FF" text-anchor="middle">review</text></g>
+          <g transform="translate(264, 0)"><rect width="80" height="24" rx="6" fill="#1F6FEB" fill-opacity="0.12" stroke="#1F6FEB" stroke-opacity="0.4"/>
+             <text x="40" y="16" fill="#58A6FF" text-anchor="middle">historia</text></g>
+          <g transform="translate(352, 0)"><rect width="80" height="24" rx="6" fill="#1F6FEB" fill-opacity="0.12" stroke="#1F6FEB" stroke-opacity="0.4"/>
+             <text x="40" y="16" fill="#58A6FF" text-anchor="middle">refinar</text></g>
+        </g>
+      </g>
+    </g>
+
+    <!-- =============== CARD 3: BYPASS LABELS (read-only) =============== -->
+    <g transform="translate(0, 636)">
+      <rect width="780" height="120" rx="12" fill="#161B22" stroke="#30363D"/>
+      <text x="24" y="36" fill="#E6EDF3" font-size="16" font-weight="700">Bypass por label</text>
+      <text x="24" y="58" fill="#B1BAC4" font-size="12">
+        Issues con estos labels se ejecutan aunque la ventana esté activa y el skill sea LLM.
+      </text>
+      <text x="755" y="36" fill="#8B949E" font-size="11" text-anchor="end">solo desde config.yaml</text>
+
+      <g transform="translate(24, 78)">
+        <rect width="142" height="28" rx="14" fill="#F85149" fill-opacity="0.16" stroke="#F85149" stroke-opacity="0.45"/>
+        <text x="71" y="18" fill="#F85149" font-size="11" font-weight="700" text-anchor="middle">priority:critical</text>
+      </g>
+      <g transform="translate(180, 78)">
+        <rect width="80" height="28" rx="14" fill="none" stroke="#30363D" stroke-dasharray="3 3"/>
+        <text x="40" y="18" fill="#6E7681" font-size="11" text-anchor="middle">+ agregar</text>
+      </g>
+    </g>
+
+    <!-- ============== ACCIONES ============== -->
+    <g transform="translate(0, 776)">
+      <g transform="translate(620, 0)">
+        <rect width="76" height="36" rx="8" fill="none" stroke="#30363D"/>
+        <text x="38" y="23" fill="#B1BAC4" font-size="12" text-anchor="middle">Cancelar</text>
+      </g>
+      <g transform="translate(704, 0)">
+        <rect width="76" height="36" rx="8" fill="#7C5CFF"/>
+        <text x="38" y="23" fill="#FFFFFF" font-size="12" font-weight="700" text-anchor="middle">Guardar</text>
+      </g>
+    </g>
+
+  </g>
+
+  <!-- =============== TOAST DE CONFIRMACION =============== -->
+  <g transform="translate(996, 824)">
+    <rect width="412" height="60" rx="10" fill="#161B22" stroke="#3FB950" stroke-opacity="0.5"/>
+    <rect width="3" height="60" fill="#3FB950"/>
+    <g transform="translate(20, 18)" fill="none" stroke="#3FB950" stroke-width="1.75">
+      <circle cx="12" cy="12" r="9"/>
+      <path d="M8 12.5 L11 15.5 L16 9.5" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    <text x="56" y="28" fill="#E6EDF3" font-size="13" font-weight="700">Configuración guardada</text>
+    <text x="56" y="46" fill="#B1BAC4" font-size="11">Hot-reload aplicado · sin reinicio del pipeline</text>
+  </g>
+
+</svg>

--- a/.pipeline/assets/mockups/06-cost-anomaly-alert.svg
+++ b/.pipeline/assets/mockups/06-cost-anomaly-alert.svg
@@ -1,0 +1,321 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Mockup 06 — Banner de alerta de consumo anómalo (#2882 PR-B + PR-C)
+  Resolucion: 1440x900
+  Demuestra:
+    - Banner persistente (rojo) en el header con consumo actual vs esperado
+    - Mini-gráfico inline mostrando el pico
+    - Top 3 skills consumidores
+    - Botón de acuse + selector de snooze (1h/4h/24h)
+    - Mensaje Telegram preview a la derecha (sanitizado por lib/redact.js)
+    - Detalles del baseline horario debajo
+  Tokens: design-tokens.css (alert-anomaly + paleta)
+-->
+<svg xmlns="http://www.w3.org/2000/svg" width="1440" height="900" viewBox="0 0 1440 900"
+     font-family="-apple-system, 'Segoe UI', system-ui, sans-serif">
+
+  <defs>
+    <linearGradient id="brandGrad06" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#00D6FF"/>
+      <stop offset="100%" stop-color="#1890FF"/>
+    </linearGradient>
+    <linearGradient id="alertBannerGrad06" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#FF6B8A" stop-opacity="0.22"/>
+      <stop offset="100%" stop-color="#FF6B8A" stop-opacity="0.06"/>
+    </linearGradient>
+    <linearGradient id="spikeGrad06" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#FF6B8A" stop-opacity="0.50"/>
+      <stop offset="100%" stop-color="#FF6B8A" stop-opacity="0.0"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Fondo -->
+  <rect width="1440" height="900" fill="#0D1117"/>
+
+  <!-- =============== HEADER (compacto) =============== -->
+  <rect x="0" y="0" width="1440" height="64" fill="#161B22"/>
+  <rect x="0" y="63" width="1440" height="1" fill="#30363D"/>
+  <g transform="translate(24, 14)">
+    <rect width="36" height="36" rx="9" fill="#0D274D"/>
+    <path d="M18 7 L5 30 L31 30 Z" fill="none" stroke="url(#brandGrad06)" stroke-width="2.5"
+          stroke-linejoin="round"/>
+    <path d="M18 16 L13 26 L23 26 Z" fill="url(#brandGrad06)"/>
+  </g>
+  <text x="72" y="32" fill="#E6EDF3" font-size="17" font-weight="700">Intrale Pipeline</text>
+  <text x="72" y="50" fill="#8B949E" font-size="10" font-weight="600" letter-spacing="1.4">DASHBOARD V3 · 14:32 LOCAL</text>
+
+  <!-- Status RUNNING -->
+  <g transform="translate(290, 20)">
+    <rect width="100" height="26" rx="13" fill="#3FB950" fill-opacity="0.15" stroke="#3FB950" stroke-opacity="0.4"/>
+    <circle cx="14" cy="13" r="3.5" fill="#3FB950"/>
+    <text x="26" y="17" fill="#3FB950" font-size="11" font-weight="700" letter-spacing="1.4">RUNNING</text>
+  </g>
+
+  <!-- Pill de alerta (entrada al banner persistente) -->
+  <g transform="translate(404, 20)">
+    <rect width="240" height="26" rx="13" fill="#FF6B8A" fill-opacity="0.18" stroke="#FF6B8A" stroke-opacity="0.55"/>
+    <!-- Punto rojo pulsante (representado estatico) -->
+    <circle cx="14" cy="13" r="3.5" fill="#FF6B8A"/>
+    <circle cx="14" cy="13" r="6" fill="#FF6B8A" fill-opacity="0.25"/>
+    <text x="26" y="17" fill="#FFD2DC" font-size="11" font-weight="700" letter-spacing="1.2">CONSUMO ANÓMALO · +213%</text>
+  </g>
+
+  <!-- Reloj -->
+  <g transform="translate(1416, 30)" text-anchor="end" font-family="'SF Mono', Consolas, monospace">
+    <text x="0" y="0" fill="#E6EDF3" font-size="18" font-weight="700" letter-spacing="2">14:32:48</text>
+    <text x="0" y="16" fill="#8B949E" font-size="10">Vie 24 abr 2026</text>
+  </g>
+
+  <!-- =============== BANNER PERSISTENTE DE ALERTA =============== -->
+  <g transform="translate(0, 64)">
+    <rect width="1440" height="148" fill="url(#alertBannerGrad06)"/>
+    <rect width="4" height="148" fill="#FF6B8A"/>
+
+    <!-- Icono pico de consumo grande -->
+    <g transform="translate(32, 28)" fill="none" stroke="#FFD2DC" stroke-width="2">
+      <path d="M3 36 H44" stroke-opacity="0.5"/>
+      <path d="M3 28 H44" stroke-dasharray="3 3" stroke-opacity="0.6"/>
+      <path d="M3 28 L10 28 L14 27 L18 26 L22 8 L26 26 L30 27 L34 28 L44 28"
+            stroke-linecap="round" stroke-linejoin="round" stroke-width="2.4"/>
+      <circle cx="22" cy="8" r="2.5" fill="#FFD2DC" stroke="none"/>
+    </g>
+
+    <!-- Texto principal -->
+    <text x="100" y="48" fill="#E6EDF3" font-size="17" font-weight="700">
+      Pico de consumo detectado — última hora 213% sobre el promedio histórico
+    </text>
+    <text x="100" y="72" fill="#FFD2DC" font-size="13" font-weight="600">
+      $4.72 USD/h consumidos · esperado $1.51 USD/h · franja 14:00–15:00 (rolling 7d)
+    </text>
+    <text x="100" y="92" fill="#B1BAC4" font-size="12">
+      Top 3 consumidores en esta franja:
+      <tspan fill="#E6EDF3" font-weight="600">android-dev</tspan> ($2.10) ·
+      <tspan fill="#E6EDF3" font-weight="600">backend-dev</tspan> ($1.34) ·
+      <tspan fill="#E6EDF3" font-weight="600">guru</tspan> ($0.78)
+    </text>
+    <text x="100" y="112" fill="#8B949E" font-size="11" font-style="italic">
+      Persistente hasta acuse manual o vuelta a baseline (2 chequeos consecutivos).
+    </text>
+
+    <!-- Mini-grafico inline a la derecha -->
+    <g transform="translate(800, 26)">
+      <rect width="220" height="100" rx="8" fill="#0D1117" stroke="#FF6B8A" stroke-opacity="0.35"/>
+      <text x="14" y="20" fill="#8B949E" font-size="10" letter-spacing="1.2">CONSUMO ÚLTIMAS 24H</text>
+      <!-- Eje base -->
+      <path d="M14 86 H206" stroke="#30363D" stroke-width="1"/>
+      <!-- Baseline punteado -->
+      <path d="M14 60 H206" stroke="#8B949E" stroke-width="1" stroke-dasharray="2 2.5" opacity="0.6"/>
+      <!-- Area bajo el pico -->
+      <path d="M14 86 L14 64 L40 62 L60 60 L80 58 L100 60 L120 62 L140 64 L160 60 L180 32 L194 86 Z"
+            fill="url(#spikeGrad06)"/>
+      <!-- Linea principal -->
+      <path d="M14 64 L40 62 L60 60 L80 58 L100 60 L120 62 L140 64 L160 60 L180 32 L194 80"
+            fill="none" stroke="#FF6B8A" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+      <circle cx="180" cy="32" r="3.5" fill="#FF6B8A"/>
+      <text x="180" y="22" fill="#FFD2DC" font-size="10" font-weight="700" text-anchor="middle">+213%</text>
+      <text x="14" y="100" fill="#8B949E" font-size="9">14:30 hace 24h</text>
+      <text x="206" y="100" fill="#8B949E" font-size="9" text-anchor="end">ahora</text>
+    </g>
+
+    <!-- Acciones (acuse + snooze) -->
+    <g transform="translate(1052, 50)">
+      <text x="0" y="-12" fill="#8B949E" font-size="10" letter-spacing="1.4">ACCIONES</text>
+
+      <!-- Botón "Ya lo vi" -->
+      <g transform="translate(0, 0)">
+        <rect width="120" height="36" rx="8" fill="#FF6B8A" fill-opacity="0.18" stroke="#FF6B8A" stroke-opacity="0.55"/>
+        <g transform="translate(12, 8)" fill="none" stroke="#FFD2DC" stroke-width="1.6">
+          <circle cx="10" cy="10" r="8"/>
+          <path d="M6 10.5 L9 13.5 L14 7.5" stroke-linecap="round" stroke-linejoin="round"/>
+        </g>
+        <text x="74" y="23" fill="#FFD2DC" font-size="12" font-weight="700" text-anchor="middle">Ya lo vi</text>
+      </g>
+
+      <!-- Selector snooze -->
+      <g transform="translate(132, 0)">
+        <rect width="240" height="36" rx="8" fill="#161B22" stroke="#30363D"/>
+        <!-- Icono campana + Z -->
+        <g transform="translate(12, 8)" fill="none" stroke="#B1BAC4" stroke-width="1.6">
+          <path d="M5 14 V10 A5 5 0 0 1 15 10 V14 L17 16 H3 Z" stroke-linejoin="round" stroke-linecap="round"/>
+          <path d="M14 2 H19 L14 7 H19" stroke-linecap="round" stroke-linejoin="round"/>
+        </g>
+        <text x="40" y="23" fill="#B1BAC4" font-size="12">Silenciar</text>
+        <!-- Tres opciones -->
+        <g transform="translate(108, 6)">
+          <rect width="36" height="24" rx="6" fill="rgba(177,186,196,0.10)" stroke="#484F58" stroke-opacity="0.55"/>
+          <text x="18" y="16" fill="#B1BAC4" font-size="11" font-weight="600" text-anchor="middle">1h</text>
+        </g>
+        <g transform="translate(150, 6)">
+          <rect width="36" height="24" rx="6" fill="rgba(177,186,196,0.10)" stroke="#484F58" stroke-opacity="0.55"/>
+          <text x="18" y="16" fill="#B1BAC4" font-size="11" font-weight="600" text-anchor="middle">4h</text>
+        </g>
+        <g transform="translate(192, 6)">
+          <rect width="36" height="24" rx="6" fill="#7C5CFF" fill-opacity="0.20" stroke="#7C5CFF" stroke-opacity="0.55"/>
+          <text x="18" y="16" fill="#C5B7FF" font-size="11" font-weight="700" text-anchor="middle">24h</text>
+        </g>
+      </g>
+    </g>
+  </g>
+
+  <!-- =============== H2 SECCION =============== -->
+  <text x="32" y="246" fill="#8B949E" font-size="12" font-weight="600" letter-spacing="2">
+    DETECTOR DE ANOMALÍAS — BASELINE HORARIO (ROLLING 7D)
+  </text>
+
+  <!-- =============== GRAFICO BASELINE 24H =============== -->
+  <g transform="translate(32, 264)">
+    <rect width="900" height="320" rx="12" fill="#161B22" stroke="#30363D"/>
+    <text x="24" y="32" fill="#E6EDF3" font-size="15" font-weight="700">Consumo por hora vs baseline esperado</text>
+    <text x="24" y="52" fill="#8B949E" font-size="11">
+      Línea sólida: hoy · Línea punteada: promedio rolling 7d · Banda: ±50% (umbral default)
+    </text>
+
+    <!-- Y axis labels -->
+    <g font-size="10" fill="#8B949E">
+      <text x="60" y="92" text-anchor="end">$5</text>
+      <text x="60" y="142" text-anchor="end">$4</text>
+      <text x="60" y="192" text-anchor="end">$3</text>
+      <text x="60" y="242" text-anchor="end">$2</text>
+      <text x="60" y="292" text-anchor="end">$1</text>
+    </g>
+
+    <!-- Grid lines -->
+    <g stroke="#21262D" stroke-width="1">
+      <line x1="68" y1="88" x2="876" y2="88"/>
+      <line x1="68" y1="138" x2="876" y2="138"/>
+      <line x1="68" y1="188" x2="876" y2="188"/>
+      <line x1="68" y1="238" x2="876" y2="238"/>
+      <line x1="68" y1="288" x2="876" y2="288"/>
+    </g>
+
+    <!-- Banda de tolerancia (+/-50% sobre baseline) -->
+    <path d="M68 220 L101 218 L134 215 L167 212 L200 208 L233 200 L266 188 L299 180
+             L332 172 L365 168 L398 170 L431 175 L464 180 L497 188 L530 195 L563 205
+             L596 215 L629 220 L662 222 L695 224 L728 222 L761 220 L794 218 L827 218 L876 218
+             L876 270 L827 270 L794 268 L761 270 L728 272 L695 272 L662 274 L629 270
+             L596 264 L563 252 L530 244 L497 236 L464 228 L431 224 L398 222 L365 218 L332 222
+             L299 232 L266 240 L233 250 L200 258 L167 262 L134 264 L101 266 L68 268 Z"
+          fill="#FF6B8A" fill-opacity="0.05" stroke="none"/>
+
+    <!-- Baseline rolling 7d (punteada) -->
+    <path d="M68 245 L101 243 L134 240 L167 237 L200 233 L233 225 L266 213 L299 205
+             L332 197 L365 193 L398 195 L431 200 L464 205 L497 213 L530 220 L563 230
+             L596 240 L629 245 L662 247 L695 249 L728 247 L761 245 L794 243 L827 243 L876 243"
+          fill="none" stroke="#8B949E" stroke-width="1.8" stroke-dasharray="3 3" opacity="0.7"/>
+
+    <!-- Hoy (linea solida con pico) -->
+    <path d="M68 248 L101 245 L134 242 L167 240 L200 235 L233 228 L266 218 L299 210
+             L332 202 L365 198 L398 200 L431 205 L464 210 L497 218 L530 225 L563 234
+             L596 244 L629 250 L662 252 L695 254 L728 250 L761 245 L794 240
+             L827 100 L876 196"
+          fill="none" stroke="#FF6B8A" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/>
+
+    <!-- Pico actual (14:00 = 14h) -->
+    <circle cx="827" cy="100" r="5" fill="#FF6B8A"/>
+    <circle cx="827" cy="100" r="9" fill="#FF6B8A" fill-opacity="0.28"/>
+    <text x="827" y="86" fill="#FFD2DC" font-size="11" font-weight="700" text-anchor="middle">$4.72 · 14:00</text>
+
+    <!-- X axis labels -->
+    <g font-size="10" fill="#8B949E">
+      <text x="68" y="306" text-anchor="middle">00</text>
+      <text x="200" y="306" text-anchor="middle">04</text>
+      <text x="332" y="306" text-anchor="middle">08</text>
+      <text x="464" y="306" text-anchor="middle">12</text>
+      <text x="596" y="306" text-anchor="middle">16</text>
+      <text x="728" y="306" text-anchor="middle">20</text>
+      <text x="876" y="306" text-anchor="middle">23</text>
+    </g>
+
+    <!-- Leyenda -->
+    <g transform="translate(640, 20)" font-size="11">
+      <line x1="0" y1="6" x2="20" y2="6" stroke="#FF6B8A" stroke-width="2.4"/>
+      <text x="26" y="10" fill="#B1BAC4">hoy</text>
+      <line x1="64" y1="6" x2="84" y2="6" stroke="#8B949E" stroke-width="2" stroke-dasharray="3 3"/>
+      <text x="90" y="10" fill="#B1BAC4">baseline 7d</text>
+      <rect x="172" y="0" width="20" height="12" fill="#FF6B8A" fill-opacity="0.15"/>
+      <text x="198" y="10" fill="#B1BAC4">tolerancia ±50%</text>
+    </g>
+  </g>
+
+  <!-- =============== TELEGRAM PREVIEW =============== -->
+  <g transform="translate(956, 264)">
+    <rect width="452" height="320" rx="12" fill="#161B22" stroke="#30363D"/>
+    <text x="24" y="32" fill="#E6EDF3" font-size="15" font-weight="700">Mensaje enviado a Telegram</text>
+    <text x="24" y="52" fill="#8B949E" font-size="11">
+      Sanitizado por
+      <tspan fill="#C5B7FF" font-family="'SF Mono', Consolas, monospace">lib/redact.js</tspan>
+      antes del envío (CA-Sec-A09)
+    </text>
+
+    <!-- Mock burbuja Telegram -->
+    <g transform="translate(24, 76)">
+      <rect width="404" height="218" rx="10" fill="#0D1117" stroke="#30363D"/>
+      <!-- Header burbuja -->
+      <rect x="0" y="0" width="404" height="32" rx="10" fill="#1C2128"/>
+      <rect x="0" y="22" width="404" height="10" fill="#1C2128"/>
+      <text x="14" y="20" fill="#58A6FF" font-size="12" font-weight="700">Intrale Pipeline Bot</text>
+      <text x="390" y="20" fill="#8B949E" font-size="10" text-anchor="end">14:32</text>
+
+      <!-- Cuerpo del mensaje -->
+      <g transform="translate(14, 48)" font-size="12" fill="#E6EDF3">
+        <text x="0" y="0" font-weight="700">⚠ Consumo anómalo detectado</text>
+        <text x="0" y="22" fill="#B1BAC4">Franja 14:00–15:00 · ratio +213%</text>
+        <text x="0" y="46" fill="#B1BAC4">Actual: <tspan fill="#FF6B8A" font-weight="700">$4.72 USD/h</tspan></text>
+        <text x="0" y="64" fill="#B1BAC4">Esperado: <tspan fill="#E6EDF3" font-weight="700">$1.51 USD/h</tspan> (rolling 7d)</text>
+
+        <text x="0" y="92" fill="#8B949E" font-size="11" letter-spacing="1.2">TOP 3 SKILLS</text>
+        <text x="0" y="112" fill="#B1BAC4">
+          1. <tspan fill="#E6EDF3" font-weight="600">android-dev</tspan> — $2.10 (44%)
+        </text>
+        <text x="0" y="130" fill="#B1BAC4">
+          2. <tspan fill="#E6EDF3" font-weight="600">backend-dev</tspan> — $1.34 (28%)
+        </text>
+        <text x="0" y="148" fill="#B1BAC4">
+          3. <tspan fill="#E6EDF3" font-weight="600">guru</tspan> — $0.78 (16%)
+        </text>
+
+        <text x="0" y="172" fill="#8B949E" font-size="11">→ Ver detalle en el dashboard</text>
+      </g>
+    </g>
+  </g>
+
+  <!-- =============== METADATA / AUDIT =============== -->
+  <g transform="translate(32, 612)">
+    <text x="0" y="0" fill="#8B949E" font-size="12" font-weight="600" letter-spacing="2">
+      AUDIT TRAIL — ÚLTIMA EVALUACIÓN
+    </text>
+
+    <g transform="translate(0, 24)" font-size="11" font-family="'SF Mono', Consolas, monospace">
+      <rect width="1376" height="240" rx="10" fill="#161B22" stroke="#30363D"/>
+
+      <g transform="translate(20, 28)" fill="#B1BAC4">
+        <text x="0" y="0" fill="#8B949E">// .pipeline/metrics-history.jsonl — append-only</text>
+        <text x="0" y="22"><tspan fill="#7C5CFF">{</tspan> "ts": <tspan fill="#3FB950">"2026-04-30T14:32:48Z"</tspan>, "hour": <tspan fill="#58A6FF">14</tspan>, "baseline_usd": <tspan fill="#58A6FF">1.51</tspan>, "actual_usd": <tspan fill="#FF6B8A" font-weight="700">4.72</tspan>, "ratio": <tspan fill="#FF6B8A" font-weight="700">2.13</tspan>, "alerted": <tspan fill="#3FB950">true</tspan> <tspan fill="#7C5CFF">}</tspan></text>
+        <text x="0" y="44"><tspan fill="#7C5CFF">{</tspan> "ts": <tspan fill="#3FB950">"2026-04-30T14:22:48Z"</tspan>, "hour": <tspan fill="#58A6FF">14</tspan>, "baseline_usd": <tspan fill="#58A6FF">1.51</tspan>, "actual_usd": <tspan fill="#58A6FF">1.62</tspan>, "ratio": <tspan fill="#58A6FF">1.07</tspan>, "alerted": <tspan fill="#F85149">false</tspan> <tspan fill="#7C5CFF">}</tspan></text>
+        <text x="0" y="66"><tspan fill="#7C5CFF">{</tspan> "ts": <tspan fill="#3FB950">"2026-04-30T14:12:48Z"</tspan>, "hour": <tspan fill="#58A6FF">14</tspan>, "baseline_usd": <tspan fill="#58A6FF">1.51</tspan>, "actual_usd": <tspan fill="#58A6FF">1.48</tspan>, "ratio": <tspan fill="#58A6FF">0.98</tspan>, "alerted": <tspan fill="#F85149">false</tspan> <tspan fill="#7C5CFF">}</tspan></text>
+      </g>
+
+      <rect x="20" y="120" width="1336" height="1" fill="#30363D"/>
+
+      <g transform="translate(20, 144)" fill="#B1BAC4">
+        <text x="0" y="0" fill="#8B949E">// .pipeline/rest-mode-audit.jsonl — append-only (CA-Sec-A08)</text>
+        <text x="0" y="22"><tspan fill="#7C5CFF">{</tspan> "updatedAt": <tspan fill="#3FB950">"2026-04-30T14:32:48Z"</tspan>, "actor": <tspan fill="#3FB950">"cron"</tspan>, "diff": <tspan fill="#3FB950">"alert_triggered: false → true"</tspan> <tspan fill="#7C5CFF">}</tspan></text>
+        <text x="0" y="44"><tspan fill="#7C5CFF">{</tspan> "updatedAt": <tspan fill="#3FB950">"2026-04-29T22:58:12Z"</tspan>, "actor": <tspan fill="#3FB950">"manual"</tspan>, "diff": <tspan fill="#3FB950">"end: 06:30 → 07:00"</tspan> <tspan fill="#7C5CFF">}</tspan></text>
+        <text x="0" y="66"><tspan fill="#7C5CFF">{</tspan> "updatedAt": <tspan fill="#3FB950">"2026-04-25T03:14:00Z"</tspan>, "actor": <tspan fill="#3FB950">"config-reload"</tspan>, "diff": <tspan fill="#3FB950">"days: [1,2,3,4,5] → [0,1,2,3,4,5,6]"</tspan> <tspan fill="#7C5CFF">}</tspan></text>
+      </g>
+    </g>
+  </g>
+
+  <!-- =============== FOOTER =============== -->
+  <g transform="translate(0, 858)">
+    <rect width="1440" height="42" fill="#161B22"/>
+    <rect width="1440" height="1" fill="#30363D"/>
+    <text x="32" y="26" fill="#8B949E" font-size="11">
+      Detector de anomalías · intervalo 10min · umbral +50% · grace period 7d (warmup) · MIN_USD_TO_ALERT $0.50
+    </text>
+    <text x="1408" y="26" fill="#8B949E" font-size="11" text-anchor="end" font-family="'SF Mono', Consolas, monospace">
+      .pipeline/anomaly-detector.js
+    </text>
+  </g>
+
+</svg>

--- a/.pipeline/assets/mockups/README.md
+++ b/.pipeline/assets/mockups/README.md
@@ -7,13 +7,17 @@ no bocetos de baja fidelidad). Cada mockup usa los tokens reales de
 
 ## Inventario
 
-| Archivo                       | Resolucion | Contenido                                      |
-|-------------------------------|------------|------------------------------------------------|
-| `01-home-dashboard.svg`       | 1440x900   | Home con 3 lanes, header de identidad, KPIs, badges diferenciados rebote vs cross-phase |
-| `02-issue-drilldown.svg`      | 1440x900   | Drilldown de issue individual: breadcrumb, KPIs, timeline vertical, panel voz narrando |
-| `03-consumo.svg`              | 1440x900   | Pagina `/consumo` (coordinada con #2520): KPIs, grafico de barras por fase, tabla top 5 |
-| `narrativa-lili.md`           | —          | Script narrado del sistema (texto que Lili dice)     |
-| `narrativa-lili.mp3`          | 4m 42s     | Audio TTS generado con `es-AR-ElenaNeural` (perfil ux — Lili, pitch +10Hz) |
+| Archivo                          | Resolucion | Contenido                                      |
+|----------------------------------|------------|------------------------------------------------|
+| `01-home-dashboard.svg`          | 1440x900   | Home con 3 lanes, header de identidad, KPIs, badges diferenciados rebote vs cross-phase |
+| `02-issue-drilldown.svg`         | 1440x900   | Drilldown de issue individual: breadcrumb, KPIs, timeline vertical, panel voz narrando |
+| `03-consumo.svg`                 | 1440x900   | Pagina `/consumo` (coordinada con #2520): KPIs, grafico de barras por fase, tabla top 5 |
+| `04-rest-mode-active.svg`        | 1440x900   | Modo descanso ACTIVO (#2882): pill header indigo, banner explicativo, lanes con LLM en cola, bypass critical visible |
+| `05-rest-mode-settings.svg`      | 1440x900   | Settings → Operación → Modo descanso: form (toggle, horarios, TZ, días), skills clasificados read-only, bypass labels, toast de confirmación |
+| `06-cost-anomaly-alert.svg`      | 1440x900   | Banner persistente de alerta de consumo anómalo (#2882): pill +213%, mini-gráfico, top 3 skills, acuse + snooze, preview Telegram, audit trail |
+| `narrativa-lili.md`              | —          | Script narrado del sistema visual base (mockups 01-03) |
+| `narrativa-lili.mp3`             | 4m 42s     | Audio TTS de la narrativa base, voz `es-AR-ElenaNeural` |
+| `narrativa-modo-descanso.md`     | —          | Script narrado del modo descanso (#2882, mockups 04-06) — generar mp3 en fase `dev` |
 
 ## Ver los mockups
 

--- a/.pipeline/assets/mockups/narrativa-modo-descanso.md
+++ b/.pipeline/assets/mockups/narrativa-modo-descanso.md
@@ -1,0 +1,117 @@
+# Narrativa Modo descanso — Lili (perfil `ux`)
+
+> Texto que Lili narra acompañando los mockups 04, 05 y 06 del issue
+> [#2882](https://github.com/intrale/platform/issues/2882) — ventana
+> "modo descanso" + alerta de consumo anómalo. El audio se genera con
+> `edge-tts`, voz `es-AR-ElenaNeural`, pitch `+10Hz`, tono amable.
+>
+> Salida sugerida: `.pipeline/assets/mockups/narrativa-modo-descanso.mp3`
+> (lo genera `pipeline-dev` en la fase `dev` del PR-A, junto al video QA).
+
+## Script narrado
+
+Hola equipo, soy Lili. Les paso el sistema visual del modo descanso del
+pipeline, la historia dos mil ochocientos ochenta y dos. Esta historia
+tiene tres mockups, porque la PO recomendó partirla en tres entregas
+independientes: gating horario, detector de anomalías, y canal de alerta.
+Yo entregué el sistema visual de los tres en un único set, así pipeline-dev
+arma cada PR sin volver a esperarme.
+
+Arranquemos por los tokens. Sumé dos colores nuevos al sistema. El primero
+es el indigo nocturno, siete-c-cinco-c-f-f, que comunica modo descanso
+activo. Es violáceo pero más oscuro que el morado de definición, y está
+asociado mentalmente con la noche y el sueño. El segundo es un rosa-rojo,
+f-f-seis-b-ocho-a, distinguible del rojo danger puro, reservado solamente
+para alertas de consumo anómalo. La idea es que cuando el operador ve ese
+tono específico sepa que está mirando un alerta económica, no un fallo de
+ejecución. Los dos colores están saturados en la versión base y atenuados
+en la variante background, manteniendo contraste WCAG doble A en todos los
+pares texto sobre fondo.
+
+Después agregué cuatro íconos nuevos al sprite. La luna creciente con tres
+estrellas, ic guion rest mode, va en la pill del header y en el banner.
+La línea con pico abrupto sobre baseline punteada, ic guion cost anomaly,
+es el ícono del banner persistente y el resumen del problema en una
+imagen. La campana con la zeta, ic guion snooze, es para silenciar la
+alerta. Y el engranaje, ic guion deterministic, marca cada tarjeta del
+board cuya ejecución no depende de un LLM, así el operador entiende a la
+primera por qué siguen corriendo durante la ventana.
+
+Vamos al mockup cuatro, modo descanso activo. Es la home del dashboard a
+las dos y catorce de la madrugada, dentro de la ventana once de la noche
+a siete de la mañana. El header tiene tres cosas distintas a la home
+normal: una pill indigo bien visible que dice modo descanso veintitrés
+cero cero a cero siete cero cero, un banner secundario abajo del header
+que explica con texto qué significa estar en modo descanso, y un
+countdown que muestra cuánto falta para que la ventana cierre. Las
+tarjetas del board respetan dos estilos: las determinísticas, builder,
+tester, delivery, conservan su color verde de corriendo y muestran cero
+tokens consumidos, mientras que las de skill LLM están atenuadas, con un
+chip violeta que dice esperando cuatro horas cuarenta y cinco minutos.
+También dejé visible un caso especial: una tarjeta con borde rojo y label
+priority colon critical que sí se está ejecutando, demostrando que el
+bypass funciona y que el operador puede confiar en que un crítico nunca
+queda dormido.
+
+El mockup cinco es la página de configuración. Vive bajo settings,
+sección operación, ítem modo descanso. El layout sigue el patrón de
+formulario standard del dashboard: tres tarjetas verticales, acciones a
+la derecha abajo. La tarjeta uno tiene el toggle activo slash inactivo,
+los dos campos de hora con tipografía monospace para evitar saltos
+visuales, el selector de zona horaria con default Buenos Aires, y los
+siete pills de días de la semana, todos seleccionables independientemente.
+A la derecha del formulario hay un preview en vivo del countdown, así el
+operador ve el efecto de su configuración sin tener que guardar primero.
+La tarjeta dos es read-only y muestra los skills clasificados como
+determinísticos versus LLM, con la nota de que la lista es fuente de
+verdad desde config.yaml, no editable desde la UI: esto cierra el vector
+de seguridad A04 que pidió el agente security. La tarjeta tres muestra los
+labels de bypass, también read-only. Y abajo, un toast verde de
+confirmación que aparece cuando el operador guarda, dejando claro que la
+configuración aplica con hot-reload, sin reinicio del pipeline.
+
+El mockup seis es el banner persistente de alerta de consumo anómalo. Acá
+hay tres niveles de información, leyéndolos de arriba a abajo. Primero, en
+el header, una pill compacta con el porcentaje del exceso, mas doscientos
+trece por ciento, para que el operador entienda la magnitud al primer
+vistazo. Segundo, el banner persistente debajo del header, ocupando todo
+el ancho, con el ícono del pico, el texto explicativo, los tres skills que
+más consumieron, y un mini gráfico de las últimas veinticuatro horas que
+muestra el pico contra el baseline punteado. Tercero, las acciones a la
+derecha: un botón rosa que dice ya lo vi, para acuse manual; y un selector
+de snooze con opciones una hora, cuatro horas, veinticuatro horas, donde
+veinticuatro horas es el tope máximo, también pedido por security en el
+vector A04.
+
+Debajo del banner, un gráfico grande de consumo horario sobre todo el
+ancho del contenido principal, mostrando la línea sólida de hoy contra la
+punteada del rolling siete días. Una banda rosa atenuada marca la
+tolerancia más menos cincuenta por ciento, que es el umbral default. El
+pico del día pasa por encima de la banda y por eso disparó la alerta. A la
+derecha del gráfico, un preview del mensaje de Telegram tal como llega al
+celular del operador, con la nota explícita de que el contenido pasa por
+lib slash redact punto js antes del envío, cumpliendo el criterio de
+seguridad A09. Y abajo de todo, dos bloques de audit trail mostrando
+exactamente qué se persiste en metrics-history.jsonl y en
+rest-mode-audit.jsonl: el operador puede auditar después qué pasó, quién
+lo cambió, cuándo, y por qué.
+
+Tres decisiones que vale la pena destacar. Primero, el modo descanso usa
+un color propio, no reusa morado de definición ni teal de qa, justamente
+para que el operador sepa al toque cuándo el dashboard está modo descanso
+y cuándo está mirando una lane. Segundo, el banner de alerta usa un rojo
+distinto al danger puro: el danger es para fallos de pipeline, el
+alert-anomaly es para gasto económico anómalo, dos cosas distintas que
+ameritan dos colores distintos. Tercero, el preview del Telegram dentro
+del mockup no es decorativo: muestra exactamente lo que el operador va a
+ver en su celular, sanitizado, así pipeline-dev tiene una referencia
+literal de cómo debe quedar el formato del mensaje.
+
+Lo que viene. Pipeline-dev toma estos tokens, este sprite, y estos tres
+mockups, y aplica el sistema en tres pull requests. El primero, modo
+descanso con gating, persistencia y ui básica, usa los mockups cuatro y
+cinco. El segundo, baseline horario y detector, no toca ui pero comparte
+los tokens. El tercero, telegram más banner más acuse, usa el mockup seis
+completo. Yo vuelvo en validación de cada uno a verificar que los assets
+estén donde los dejé, y vuelvo en aprobación a revisar el video. Cualquier
+duda estoy al pie del cañón.


### PR DESCRIPTION
## Resumen

PR-UX **standalone** que aterriza en `main` los assets visuales necesarios para los issues #2890 (modo descanso) y #2882 (alerta de consumo). Reentrega del commit `04e36c07` originalmente vivido sólo en la rama `refactor/delivery-handoff-integration`.

## Por qué este PR existe

El skill `/pipeline-dev` rebotó la fase `dev` del issue #2890 (rebote cross-phase a UX) porque su rama `agent/2890-pipeline-dev`, basada en `origin/main`, no veía los tokens (`--rest-mode-*`), íconos (`ic-rest-mode`, `ic-cost-anomaly`) ni mockups (04/05/06) que el issue declaraba como "ya entregados". Verificación empírica del rebote (HEAD `405ab121` = `origin/main`):

\`\`\`
$ grep -in "rest-mode" .pipeline/assets/design-tokens.css   # (sin match)
$ grep -in "rest-mode" .pipeline/assets/icons/sprite.svg    # (sin match)
$ ls .pipeline/assets/mockups/                              # sólo 01-03, falta 04-06
$ git merge-base --is-ancestor 04e36c07 origin/main && echo IN || echo NOT  # NOT
\`\`\`

Este PR re-entrega los mismos 8 archivos (1187 inserciones) sobre `main` para que `pipeline-dev` pueda implementar el gating funcional (CA-1.x, CA-Sec-A0x, tests) sin improvisar paleta ni inventar emojis.

## Contenido (idéntico al commit original `04e36c07`)

- `.pipeline/assets/design-tokens.css` — tokens `--rest-mode-*` (indigo nocturno) y `--alert-anomaly-*` (rosa-rojo distinto del danger), con `bg/dim/fg/glow`. Contraste WCAG AA verificado.
- `.pipeline/assets/icons/sprite.svg` — 4 íconos nuevos:
  - `ic-rest-mode` (luna creciente + 3 estrellas)
  - `ic-cost-anomaly` (línea con pico sobre baseline punteada)
  - `ic-snooze` (campana + Z)
  - `ic-deterministic` (engranaje, marca skills sin LLM)
- Mockups SVG 1440x900:
  - `04-rest-mode-active.svg` — home en modo descanso, pill header, banner explicativo, lanes con LLM en cola, bypass `priority:critical`.
  - `05-rest-mode-settings.svg` — form de configuración (toggle, horas, TZ, días), skills clasificados read-only, bypass labels, toast.
  - `06-cost-anomaly-alert.svg` — banner persistente, mini-gráfico, top 3 skills, snooze (cap 24h), preview Telegram redactado, audit trail.
- `narrativa-modo-descanso.md` — script TTS (Lili, edge-tts es-AR).

Sin scripts ni handlers en SVG. Sin CDN externo. Listo para que pipeline-dev consuma vía `var(--rest-mode-*)` y `<use href="#ic-rest-mode">`.

## Verificación post-cherry-pick (rama `agent/2890-ux-rest-mode-assets`)

\`\`\`
$ grep -n "rest-mode" .pipeline/assets/design-tokens.css | head -5
88:  --rest-mode:          #7C5CFF;   /* indigo nocturno — modo descanso activo */
89:  --rest-mode-dim:      #4B36B8;
90:  --rest-mode-bg:       rgba(124, 92, 255, 0.16);
91:  --rest-mode-fg:       #C5B7FF;   /* contraste 7.4:1 */

$ grep -n "ic-rest-mode\|ic-cost-anomaly" .pipeline/assets/icons/sprite.svg
267:  <!-- ic-rest-mode: luna creciente con tres estrellas -->
268:  <symbol id="ic-rest-mode" viewBox="0 0 24 24">
279:  <!-- ic-cost-anomaly: linea con pico abrupto sobre baseline punteada -->
280:  <symbol id="ic-cost-anomaly" viewBox="0 0 24 24">

$ ls .pipeline/assets/mockups/
01-home-dashboard.svg  02-issue-drilldown.svg  03-consumo.svg
04-rest-mode-active.svg  05-rest-mode-settings.svg  06-cost-anomaly-alert.svg
narrativa-lili.md  narrativa-lili.mp3  narrativa-modo-descanso.md  README.md
\`\`\`

## Test plan

- [x] Tokens `--rest-mode-*` y `--alert-anomaly-*` presentes en `design-tokens.css` líneas 88-91+ (verificado por /guru en su review original).
- [x] Símbolos `ic-rest-mode` (línea 268) e `ic-cost-anomaly` (línea 280) presentes en `sprite.svg`.
- [x] Mockups 04, 05, 06 presentes con dimensiones 1440x900 y sin scripts.
- [x] Cherry-pick limpio sobre `origin/main` (parent del commit original ES `405ab121` = HEAD de main).
- [ ] Merge a `main` desbloquea PR-A (#2890), PR-B y PR-C (#2882).

## Coordinación

- **No depende** de `refactor/delivery-handoff-integration`. Aterriza independientemente.
- Una vez mergeado, `pipeline-dev` debe rebasear / refetch su rama `agent/2890-pipeline-dev` y reanudar la fase `dev`.

Closes parcialmente la entrega visual de #2890 y #2882 (los issues siguen abiertos hasta que pipeline-dev complete CA-1.x/CA-Sec).

🤖 Re-entregado por el agente \`/ux\` en respuesta al rebote cross-phase de \`/pipeline-dev\` (rebote_numero_crossphase: 1).