### PR TITLE
fix(dashboard): home muestra 10 items en últimos ejecutados y próximos en cola

### DIFF
--- a/.pipeline/views/dashboard/home.js
+++ b/.pipeline/views/dashboard/home.js
@@ -800,7 +800,7 @@ async function tickRecent(){
     if(!d) return;
     const container = document.getElementById('recent-list');
     if(!container) return;
-    const arr = (d.recent || []).slice(0, 5);
+    const arr = (d.recent || []).slice(0, 10);
     if(arr.length === 0){ container.innerHTML = '<div class="in-empty">Sin actividad reciente</div>'; return; }
     const seen = new Set();
     for(const a of arr){
@@ -824,7 +824,7 @@ async function tickQueue(){
     if(!d) return;
     const container = document.getElementById('queue-list');
     if(!container) return;
-    const arr = (d.queue || []).slice(0, 5);
+    const arr = (d.queue || []).slice(0, 10);
     if(arr.length === 0){ container.innerHTML = '<div class="in-empty">Cola vacía</div>'; return; }
     const seen = new Set();
     for(const a of arr){
@@ -1058,7 +1058,7 @@ function renderHomeHTML() {
     <section class="in-section">
       <h2 class="in-section-title">
         <span class="in-section-title-icon">⏪</span>
-        Últimos 5 ejecutados
+        Últimos 10 ejecutados
       </h2>
       <div class="line-list" id="recent-list"></div>
     </section>
@@ -1066,7 +1066,7 @@ function renderHomeHTML() {
     <section class="in-section">
       <h2 class="in-section-title">
         <span class="in-section-title-icon">⏩</span>
-        Próximos 5 en cola
+        Próximos 10 en cola
       </h2>
       <div class="line-list" id="queue-list"></div>
     </section>


### PR DESCRIPTION
## Summary
- `Últimos N ejecutados` y `Próximos N en cola` pasan de 5 a 10 items en la home del dashboard.
- Cambia 3 lugares en `home.js`: dos `slice(0, 10)` en `tickRecent` / `tickQueue` y los dos títulos del HTML.
- La API ya devuelve hasta 10 (`recentlyFinished(state, 10)`, `nextInQueue(state, ctx, 10)`), no hace falta tocar backend.

## Contexto
Leo había pedido este cambio antes (chat Telegram), se aplicó en caliente y nunca quedó committeado. Al mergearse PR #2900 sobre main, el `git reset --hard` del pipeline pisó el archivo con la versión upstream y la home volvió a mostrar 5. Este PR lo deja persistido.

## Test plan
- [x] Reinicio del dashboard y verificación con curl: render muestra "Últimos 10 ejecutados" y "Próximos 10 en cola"
- [ ] Verificar en `localhost:3200` que ambas listas aceptan hasta 10 filas en uso real
- [ ] qa:skipped — UI puramente del dashboard interno, sin impacto en producto de usuario

🤖 Generated with [Claude Code](https://claude.com/claude-code)