### PR TITLE
fix(pipeline): TTS reemplaza # por "número" y descarta emojis

### DIFF
--- a/.pipeline/multimedia.js
+++ b/.pipeline/multimedia.js
@@ -617,6 +617,15 @@ function sanitizeForTts(text) {
   s = s.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '$1');
   // Headers (# ## ### al inicio de línea)
   s = s.replace(/^#{1,6}\s+/gm, '');
+  // Issue/PR refs "#1234" → "número 1234" (el TTS los lee "almohadilla", molesto)
+  s = s.replace(/#(\d+)/g, 'número $1');
+  // Emojis y símbolos visuales: el TTS los narra por nombre Unicode
+  // ("mano hacia la derecha", "casilla de verificación") y arruina el audio.
+  // Drop: pictographs/symbols/dingbats + variation selectors + ZWJ + checkbox-like.
+  s = s.replace(
+    /[\u{1F000}-\u{1FFFF}\u{2600}-\u{27BF}\u{2300}-\u{23FF}\u{2190}-\u{21FF}\u{25A0}-\u{25FF}\u{2460}-\u{24FF}\u{2B00}-\u{2BFF}\u{20D0}-\u{20FF}\u{FE0E}\u{FE0F}\u{200D}]/gu,
+    ''
+  );
   // Blockquotes ">"
   s = s.replace(/^\s*>\s?/gm, '');
   // Tablas: separador --- | --- y filas con |


### PR DESCRIPTION
## Problema
El TTS narra los emojis por su nombre Unicode ("mano hacia la derecha", "casilla de verificación") y lee `#` como "almohadilla", lo que arruina los audios que llegan a Telegram. Leo lo reportó dos veces, la última explícitamente.

## Causa
La función `sanitizeForTts` en `.pipeline/multimedia.js` limpiaba markdown pero no tocaba `#NNNN` ni emojis.

## Cambio
- `#1234` → `número 1234` (cubre todos los issue/PR refs).
- Drop de pictographs, dingbats, símbolos geométricos, keycaps (con `combining enclosing keycap`), variation selectors y ZWJ.

## Verificación
```
"PR #2902 mergeado, cierra #2900 y #2894"
  → "PR número 2902 mergeado, cierra número 2900 y número 2894"

"Estados ☐► trabajando · ☑ completed · ☐ pendiente"
  → "Estados trabajando · completed · pendiente"

"🎤 ✅ 👉 mira aca 👇 ok" → "mira aca ok"

"⚠ Atención: build 1️⃣ falló" → "Atención: build 1 falló"

"identifier_with_underscore se respeta" → idéntico (no rompe identificadores)
```

## Notas
- No toca priorización ni el allowlist de la pausa parcial.
- Aplica solo a TTS — los textos en Telegram siguen mostrando `#NNNN` y emojis normalmente.

qa:skipped (cambio puro de pipeline interno sin impacto en producto).