### PR TITLE
fix(pipeline): watchdog Windows PowerShell 5.1 — encoding y spawn de node

### DIFF
--- a/.pipeline/watchdog.ps1
+++ b/.pipeline/watchdog.ps1
@@ -1,4 +1,4 @@
-# Watchdog V2 — Vigila servicios del pipeline
+﻿# Watchdog V2 — Vigila servicios del pipeline
 # Se ejecuta cada 2 minutos via Windows Task Scheduler
 # Todo corre desde platform/ (repo principal, siempre en main)
 #
@@ -96,6 +96,7 @@ try {
 } catch {}
 
 $NodeModules = "$RepoRoot\node_modules"
+$env:NODE_PATH = $NodeModules
 
 foreach ($svcName in $dead) {
     $script = $ScriptMap[$svcName]
@@ -106,22 +107,19 @@ foreach ($svcName in $dead) {
         continue
     }
 
-    # Double-check justo antes de spawnear: el primer scan podría ser stale
-    # de 1-2s y el servicio puede haber arrancado en ese ínterin (por ejemplo,
-    # restart.js que largó los procesos entre que hicimos el scan y ahora).
+    # Double-check justo antes de spawnear: el primer scan podria ser stale
+    # de 1-2s y el servicio puede haber arrancado en ese interin (por ejemplo,
+    # restart.js que largo los procesos entre que hicimos el scan y ahora).
     if (Test-ServiceAlive $script) {
-        Write-Log "  $svcName : ya arrancó entre el scan y el spawn, skip"
+        Write-Log "  $svcName : ya arranco entre el scan y el spawn, skip"
         continue
     }
 
     try {
-        $cmd = "set `"NODE_PATH=$NodeModules`" && node `"$scriptPath`""
-        $proc = Start-Process -FilePath 'cmd.exe' -ArgumentList '/c', $cmd `
-            -WorkingDirectory $RepoRoot `
-            -WindowStyle Hidden `
-            -PassThru
-        Write-Log "  $svcName : levantado PID $($proc.Id)"
+        $proc = Start-Process -FilePath 'node' -ArgumentList @($scriptPath) -WorkingDirectory $RepoRoot -WindowStyle Hidden -PassThru
+        Write-Log ("  " + $svcName + " : levantado PID " + $proc.Id)
     } catch {
-        Write-Log "  $svcName : ERROR al levantar - $_"
+        $errMsg = $_.Exception.Message
+        Write-Log ("  " + $svcName + " : ERROR al levantar - " + $errMsg)
     }
 }


### PR DESCRIPTION
## Resumen

El watchdog del pipeline V2 (Task Scheduler `Intrale-Pipeline-V2-Watchdog`, cada 2 min) viene fallando con `Último resultado: 1` desde el **19/04/2026 21:09**. Hace 11 días que no escribe en `watchdog.log`.

## Causa raíz

El archivo `.pipeline/watchdog.ps1` estaba guardado como **UTF-8 sin BOM**. Task Scheduler invoca `powershell.exe -NonInteractive -File watchdog.ps1` con PS **5.1**, que sin BOM **interpreta el script como Windows-1252**. Los acentos UTF-8 multibyte de los comentarios (`á`, `é`, `í`, `ó`, `ú`) se leen como dos caracteres rotos, lo que descalibra el conteo de comillas dentro de strings y rompe el parser.

Síntoma reproducible:

```
[118:48] El token '&&' no es un separador de instrucciones válido en esta versión.
[125:55] Falta la cadena en el terminador: ".
[30:42] Falta la llave de cierre "}" en el bloque de instrucciones o la definición de tipo.
[27:33] Falta la llave de cierre "}" en el bloque de instrucciones o la definición de tipo.
```

Los errores en líneas 27/30 son cascada — el parser se cae mucho antes y pierde la cuenta de bloques.

## Cambios

1. **BOM UTF-8 agregado** (`EF BB BF`) al inicio del archivo. PS 5.1 con BOM detecta UTF-8 correctamente. Sin BOM y con multibyte → parser roto.

2. **Eliminado wrapper `cmd.exe /c "set NODE_PATH=... && node ..."`** que requería comillas escapadas frágiles (`` `" ``) y agregaba un proceso intermedio. Ahora:
   - Se setea `$env:NODE_PATH` una sola vez antes del foreach.
   - Se invoca `node` directo vía `Start-Process` con `-ArgumentList @($scriptPath)` (array, sin escapado manual).

3. **Concatenación explícita en `Write-Log`** (`("a" + $b + "c")`) en vez de interpolación (`"a$bc"`) en las líneas con `$_`/`Exception.Message` — reduce superficie de error de parser ante futuros edits que vuelvan a perder el BOM.

## Verificación

```
$ powershell.exe -File watchdog.ps1
EXIT=0

$ schtasks /Run /TN Intrale-Pipeline-V2-Watchdog
CORRECTO: se ha intentado ejecutar la tarea programada

$ schtasks /Query /TN Intrale-Pipeline-V2-Watchdog /V
Ultimo tiempo de ejecucion:  4/30/2026 7:31:13 PM
Ultimo resultado:            0
```

## Test plan

- [x] Parser PS 5.1 acepta el archivo (`ParseFile` sin errores)
- [x] Ejecución manual termina con exit 0
- [x] Task Scheduler reporta `Ultimo resultado: 0` tras forzar `/Run`
- [ ] Confirmar que durante las próximas 2 horas el log se actualiza al menos una vez (ciclo natural de la tarea)

## Closes

Issue del watchdog roto detectado por Leo en sesión Telegram del 30/04/2026 21:41.

🤖 Generated with [Claude Code](https://claude.com/claude-code)