### PR TITLE
fix(pipeline): tester muestra archivo de test fallido en lugar de '(sin nombre)'

### DIFF
--- a/.pipeline/skills-deterministicos/__tests__/tester.test.js
+++ b/.pipeline/skills-deterministicos/__tests__/tester.test.js
@@ -364,6 +364,33 @@ AssertionError: expected 1 to equal 2
     assert.ok(r.failed_tests[0].message.includes('expected 1 to equal 2'));
 });
 
+test('parseNodeTestJunit — atributo name con `>` literal no rompe el parser (regresión #2892)', () => {
+    // node --test escribe el name del test sin escapar `>` (XML lo permite
+    // dentro de values de atributos). Antes del fix, el regex `[^>]*?`
+    // truncaba el match al primer `>` y los testcases siguientes perdían
+    // name/classname → el reporte mostraba "(sin nombre) > test failed"
+    // y el dev no podía saber qué archivo abrir.
+    const xml = `<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+\t<testcase name="conserva &amp;quot;> Task :xxx FAILED&amp;quot;" time="0.001" classname="test" file="apk.test.js"/>
+\t<testcase name="C:\\\\repo\\\\.pipeline\\\\tests\\\\sanitizer.test.js" time="0.7" classname="test" file="C:\\\\repo\\\\.pipeline\\\\tests\\\\sanitizer.test.js" failure="test failed">
+\t\t<failure type="testCodeFailure" message="test failed">
+[Error: test failed] { code: 'ERR_TEST_FAILURE' }
+\t\t</failure>
+\t</testcase>
+\t<!-- tests 2 -->
+\t<!-- fail 1 -->
+</testsuites>`;
+    const r = tester.parseNodeTestJunit(xml);
+    assert.equal(r.failures, 1);
+    assert.equal(r.failed_tests.length, 1);
+    assert.ok(r.failed_tests[0].name.endsWith('sanitizer.test.js'),
+        `name debería contener sanitizer.test.js, fue: ${r.failed_tests[0].name}`);
+    assert.equal(r.failed_tests[0].classname, 'test');
+    assert.equal(r.failed_tests[0].message, 'test failed');
+    assert.ok(r.failed_tests[0].stack_snippet.includes('ERR_TEST_FAILURE'));
+});
+
 test('parseNodeTestJunit — XML vacío o malformado devuelve valid:false', () => {
     assert.equal(tester.parseNodeTestJunit('').valid, false);
     assert.equal(tester.parseNodeTestJunit(null).valid, false);

--- a/.pipeline/skills-deterministicos/lib/kover-parser.js
+++ b/.pipeline/skills-deterministicos/lib/kover-parser.js
@@ -352,10 +352,17 @@ function renderTestsSection(tests) {
     lines.push(`- Tiempo total: ${tests.time_seconds.toFixed(1)}s  ·  Suites: ${tests.suites}`);
     if (tests.failed_tests.length > 0) {
         lines.push('- Tests fallidos:');
+        const path = require('path');
         for (const ft of tests.failed_tests.slice(0, 10)) {
-            const loc = `${ft.classname} > ${ft.name}`;
+            // node --test reporta a veces el archivo entero como un testcase
+            // con name = ruta absoluta cuando el archivo falla a nivel global.
+            // Mostrar basename para que sea legible en el rejection report.
+            const isFileLevel = typeof ft.name === 'string' && /[\\/]/.test(ft.name);
+            const displayName = isFileLevel ? `${path.basename(ft.name)} (archivo entero)` : ft.name;
+            const loc = `${ft.classname} > ${displayName}`;
             lines.push(`  - **${loc}**`);
             if (ft.message) lines.push(`    - ${ft.message.split('\n')[0].slice(0, 200)}`);
+            if (ft.stack_snippet) lines.push(`    - \`${ft.stack_snippet.slice(0, 300)}\``);
         }
         if (tests.failed_tests.length > 10) {
             lines.push(`  - _(…${tests.failed_tests.length - 10} más)_`);

--- a/.pipeline/skills-deterministicos/tester.js
+++ b/.pipeline/skills-deterministicos/tester.js
@@ -197,14 +197,23 @@ function parseNodeTestJunit(xml) {
     if (dm) out.time_seconds = parseFloat(dm[1]) / 1000;
     out.valid = !!tm;
 
-    // Recolectar testcases con <failure>/<error> para detalle del rebote
-    const tcRe = /<testcase\b([^>]*?)(?:\/>|>([\s\S]*?)<\/testcase>)/g;
+    // Recolectar testcases con <failure>/<error> para detalle del rebote.
+    // Los atributos pueden contener `>` literal dentro de un valor quoted
+    // (p. ej. `name="conserva &amp;quot;> Task ... FAILED&amp;quot;"`), así
+    // que NO se puede usar `[^>]*?` para los atributos: trunca al primer `>`,
+    // los matches subsiguientes pierden alineación y el reporte termina con
+    // `name=(sin nombre)`. Permitimos cualquier secuencia de strings quoted
+    // o caracteres no-`>` fuera de comillas.
+    const ATTRS = `(?:"[^"]*"|'[^']*'|[^>"'])*?`;
+    const tcRe = new RegExp(`<testcase\\b(${ATTRS})(?:\\/>|>([\\s\\S]*?)<\\/testcase>)`, 'g');
+    const failRe = new RegExp(`<failure\\b(${ATTRS})(?:\\/>|>([\\s\\S]*?)<\\/failure>)`);
+    const errRe = new RegExp(`<error\\b(${ATTRS})(?:\\/>|>([\\s\\S]*?)<\\/error>)`);
     let m;
     while ((m = tcRe.exec(xml)) !== null) {
         const attrs = m[1] || '';
         const body = m[2] || '';
-        const failMatch = body.match(/<failure\b([^>]*?)(?:\/>|>([\s\S]*?)<\/failure>)/);
-        const errMatch = body.match(/<error\b([^>]*?)(?:\/>|>([\s\S]*?)<\/error>)/);
+        const failMatch = body.match(failRe);
+        const errMatch = body.match(errRe);
         if (!failMatch && !errMatch) continue;
         const nameMatch = attrs.match(/\bname="([^"]*)"/);
         const cnameMatch = attrs.match(/\bclassname="([^"]*)"/);


### PR DESCRIPTION
## Problema

Cuando el tester rebotaba a `pipeline-dev` con tests Node fallidos, el rejection report decía:

\`\`\`
- Tests fallidos:
  - **node-test > (sin nombre)**
    - test failed
\`\`\`

El dev no podía saber qué archivo abrir ni qué test arreglar de los 665 ejecutados (ejemplo concreto: rebote del #2892).

## Causa raíz

El parser \`parseNodeTestJunit\` usa \`<testcase\b([^>]*?)(?:\/>|>...)\` para extraer atributos. \`[^>]*?\` no permite \`>\` literal, pero \`node --test\` escribe el name del test sin escapar \`>\` (la spec XML lo permite dentro de values quoted):

\`\`\`xml
<testcase name="conserva &amp;quot;> Task :xxx FAILED&amp;quot;" ...
\`\`\`

El regex truncaba al primer \`>\`, los atributos siguientes (\`classname\`, \`file\`) quedaban fuera y el body del testcase capturaba 145 KB hasta el siguiente \`</testcase>\` que apareciera. El \`<failure>\` real (del file-level fail de \`sanitizer.test.js\`) caía en ese body, pero \`name\`/\`classname\` ya no se podían recuperar.

## Cambios

1. **\`tester.js\` (parseNodeTestJunit)**: regex de atributos ahora permite \`>\` dentro de strings quoted (\`(?:"[^"]*"|'[^']*'|[^>"'])*?\`).
2. **\`kover-parser.js\` (renderTestsSection)**: si el name es una ruta absoluta (file-level failure de node-test), muestra el basename + indicador \"(archivo entero)\". Agrega también \`stack_snippet\` con el detalle del error.
3. **Test de regresión** con un XML que reproduce el bug original.

## Resultado

Antes:
\`\`\`
- **node-test > (sin nombre)**
  - test failed
\`\`\`

Después:
\`\`\`
- **test > sanitizer.test.js (archivo entero)**
  - test failed
  - \`[Error: test failed] { code: 'ERR_TEST_FAILURE', ... }\`
\`\`\`

## Verificación

- \`node --test\` sobre el XML real del rebote del #2892: ahora extrae \`name=sanitizer.test.js\` y \`classname=test\`.
- Suite completa de tests del tester + kover-parser: 51/51 verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)