### PR TITLE
fix(pipeline): self-checks deterministicos + relax CODEOWNERS sobre .pipeline/

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,16 +1,17 @@
-# CODEOWNERS — Review obligatorio para componentes críticos del pipeline
+# CODEOWNERS — Review obligatorio para componentes que el rollback NO cubre
 #
 # Sintaxis: <pattern> <owner-or-team>
 # Último match gana. Los patrones son glob-style (similar a .gitignore).
 #
-# Rationale:
-#   - .pipeline/ es la infraestructura que orquesta todo el trabajo de agentes
-#     (incluye .pipeline/roles/, contrato de cada agente).
-#     Un cambio roto deja el sistema fuera de servicio. Leo revisa cada PR.
-#   - .github/ y CODEOWNERS mismo: proteger el protocolo de protección.
+# Rationale (post acción 3 — issue ciclo rollback/CODEOWNERS):
+#   - .pipeline/ ya NO requiere review humano: el smoke-test del restart corre
+#     self-checks de los skills determinísticos (tester, builder, delivery,
+#     linter) y dispara rollback automático al tag pipeline-stable si alguno
+#     rompe. Auto-merge habilitado.
+#   - .github/workflows/: NO se puede smoke-testear localmente (corren en
+#     GitHub Actions). Único path donde el rollback no nos cubre — sigue
+#     bloqueado a review humano.
+#   - .github/CODEOWNERS: protege el protocolo de protección.
 
-# Pipeline V2 (orquestador, dashboard, hooks, scripts de restart/rollback, roles/)
-/.pipeline/                 @leitolarreta
-
-# Protocolo de protección (workflows y este archivo)
+# Workflows GitHub Actions y este archivo: rollback no aplica
 /.github/                   @leitolarreta

--- a/.pipeline/skills-deterministicos/builder.js
+++ b/.pipeline/skills-deterministicos/builder.js
@@ -294,6 +294,38 @@ async function main() {
 
 // Ejecutar solo si es invocado como CLI (no cuando es require()eado en tests)
 if (require.main === module) {
+    if (process.argv.includes('--self-check')) {
+        const { runSelfCheck } = require('./lib/self-check');
+        runSelfCheck('builder', [
+            { name: 'parseArgs sin argumentos', fn: () => {
+                const a = parseArgs(['node', 'builder.js']);
+                if (typeof a !== 'object' || a === null) throw new Error('parseArgs no devuelve objeto');
+                if (a.scope !== 'smart') throw new Error(`scope default esperado 'smart' got '${a.scope}'`);
+            }},
+            { name: 'parseArgs con --clean', fn: () => {
+                const a = parseArgs(['node', 'builder.js', '1234', '--clean']);
+                if (a.issue !== 1234) throw new Error(`issue esperado 1234 got ${a.issue}`);
+                if (a.scope !== 'clean') throw new Error(`scope esperado 'clean' got '${a.scope}'`);
+            }},
+            { name: 'buildGradleCommand devuelve cmd/args válidos', fn: () => {
+                const r = buildGradleCommand('smart', null);
+                if (!r || typeof r.cmd !== 'string' || !Array.isArray(r.args)) {
+                    throw new Error(`buildGradleCommand devolvió ${JSON.stringify(r)}`);
+                }
+            }},
+            { name: 'buildGradleCommand --clean incluye build task', fn: () => {
+                const r = buildGradleCommand('clean', null);
+                if (!r.args.includes('build') || !r.args.includes('clean')) {
+                    throw new Error(`args sin clean+build: ${JSON.stringify(r.args)}`);
+                }
+            }},
+            { name: 'gradle-parser carga', fn: () => {
+                const gp = require('./lib/gradle-parser');
+                if (!gp || typeof gp !== 'object') throw new Error('gradle-parser no exporta objeto');
+            }},
+        ]);
+        return;
+    }
     main().catch((e) => {
         process.stderr.write(`[builder] fatal: ${e.stack || e.message}\n`);
         process.exit(2);

--- a/.pipeline/skills-deterministicos/delivery.js
+++ b/.pipeline/skills-deterministicos/delivery.js
@@ -543,6 +543,42 @@ async function main() {
 }
 
 if (require.main === module) {
+    if (process.argv.includes('--self-check')) {
+        const { runSelfCheck } = require('./lib/self-check');
+        runSelfCheck('delivery', [
+            { name: 'parseArgs sin argumentos', fn: () => {
+                const a = parseArgs(['node', 'delivery.js']);
+                if (typeof a !== 'object' || a === null) throw new Error('parseArgs no devuelve objeto');
+                if (a.autoMerge !== true) throw new Error('autoMerge default debió ser true');
+            }},
+            { name: 'parseArgs con --no-auto-merge', fn: () => {
+                const a = parseArgs(['node', 'delivery.js', '1234', '--no-auto-merge']);
+                if (a.issue !== 1234) throw new Error(`issue esperado 1234 got ${a.issue}`);
+                if (a.autoMerge !== false) throw new Error('autoMerge debió ser false');
+            }},
+            { name: 'hasQaGate detecta qa:passed', fn: () => {
+                if (!hasQaGate(['foo', 'qa:passed'])) throw new Error('debió aceptar qa:passed');
+                if (!hasQaGate(['qa:skipped'])) throw new Error('debió aceptar qa:skipped');
+                if (hasQaGate(['qa:pending'])) throw new Error('NO debió aceptar qa:pending');
+                if (hasQaGate([])) throw new Error('NO debió aceptar lista vacía');
+            }},
+            { name: 'codeowners lib carga y matchea path', fn: () => {
+                const co = require('./lib/codeowners');
+                const rules = co.parseCodeowners('/.github/   @leitolarreta\n');
+                if (!rules.length) throw new Error('parseCodeowners no devuelve reglas');
+                const owners = co.resolveOwners(rules, ['.github/workflows/build.yml']);
+                if (!owners.includes('@leitolarreta')) throw new Error('debió resolver @leitolarreta para .github/');
+            }},
+            { name: 'codeowners NO matchea .pipeline/ con CODEOWNERS post-acción 3', fn: () => {
+                // Acción 3: solo .github/ requiere humano. .pipeline/ liberado.
+                const co = require('./lib/codeowners');
+                const rules = co.loadCodeowners(REPO_ROOT);
+                const humans = co.getHumanOwners(rules, ['.pipeline/skills-deterministicos/tester.js']);
+                if (humans.length) throw new Error(`.pipeline/ NO debería requerir humano: ${humans.join(',')}`);
+            }},
+        ]);
+        return;
+    }
     main().catch((e) => {
         process.stderr.write(`[delivery] fatal: ${e.stack || e.message}\n`);
         process.exit(2);

--- a/.pipeline/skills-deterministicos/lib/self-check.js
+++ b/.pipeline/skills-deterministicos/lib/self-check.js
@@ -1,0 +1,63 @@
+'use strict';
+
+/**
+ * self-check.js — Helper compartido para validar que un skill determinístico
+ * carga y sus piezas críticas funcionan, sin tocar GitHub, gradle ni el filesystem
+ * de issues.
+ *
+ * Uso típico (al final del entry point del skill, antes del main()):
+ *
+ *   if (process.argv.includes('--self-check')) {
+ *       const { runSelfCheck } = require('./lib/self-check');
+ *       runSelfCheck('tester', [
+ *           { name: 'parseArgs vacío', fn: () => parseArgs(['node', 'tester.js']) },
+ *           { name: 'kover-parser carga', fn: () => require('./lib/kover-parser') },
+ *           // ...
+ *       ]);
+ *       return;
+ *   }
+ *
+ * Cada check es un objeto { name, fn }. fn puede ser sync o async; cualquier
+ * excepción cuenta como falla. Exit 0 si todos pasan, 1 si alguno falla.
+ *
+ * Diseñado para ser invocado por smoke-test.js post-restart: si un PR a
+ * `.pipeline/` rompe la carga de un skill, el self-check falla, smoke-test
+ * falla, restart.js dispara rollback.js al tag pipeline-stable.
+ */
+
+async function runSelfCheck(skillName, checks) {
+    const startedAt = Date.now();
+    let passed = 0;
+    const failed = [];
+
+    process.stdout.write(`[self-check ${skillName}] iniciando ${checks.length} chequeos\n`);
+
+    for (const check of checks) {
+        const checkStart = Date.now();
+        try {
+            const result = check.fn();
+            if (result && typeof result.then === 'function') {
+                await result;
+            }
+            const ms = Date.now() - checkStart;
+            process.stdout.write(`  OK  ${check.name} (${ms}ms)\n`);
+            passed++;
+        } catch (e) {
+            const ms = Date.now() - checkStart;
+            const msg = (e && (e.stack || e.message)) || String(e);
+            process.stdout.write(`  FAIL ${check.name} (${ms}ms)\n    ${msg.split('\n').slice(0, 3).join('\n    ')}\n`);
+            failed.push({ name: check.name, error: msg });
+        }
+    }
+
+    const totalMs = Date.now() - startedAt;
+    if (failed.length === 0) {
+        process.stdout.write(`[self-check ${skillName}] OK · ${passed}/${checks.length} en ${totalMs}ms\n`);
+        process.exit(0);
+    } else {
+        process.stdout.write(`[self-check ${skillName}] FAIL · ${failed.length}/${checks.length} fallidos en ${totalMs}ms\n`);
+        process.exit(1);
+    }
+}
+
+module.exports = { runSelfCheck };

--- a/.pipeline/skills-deterministicos/linter.js
+++ b/.pipeline/skills-deterministicos/linter.js
@@ -265,6 +265,29 @@ async function main() {
 }
 
 if (require.main === module) {
+    if (process.argv.includes('--self-check')) {
+        const { runSelfCheck } = require('./lib/self-check');
+        runSelfCheck('linter', [
+            { name: 'parseArgs sin argumentos', fn: () => {
+                const a = parseArgs(['node', 'linter.js']);
+                if (typeof a !== 'object' || a === null) throw new Error('parseArgs no devuelve objeto');
+                if (a.base !== 'origin/main') throw new Error(`base default esperado 'origin/main' got '${a.base}'`);
+            }},
+            { name: 'parseArgs con --base', fn: () => {
+                const a = parseArgs(['node', 'linter.js', '1234', '--base=origin/develop']);
+                if (a.issue !== 1234) throw new Error(`issue esperado 1234 got ${a.issue}`);
+                if (a.base !== 'origin/develop') throw new Error(`base esperado 'origin/develop' got '${a.base}'`);
+            }},
+            { name: 'static-checks lib carga', fn: () => {
+                const sc = require('./lib/static-checks');
+                if (!sc || typeof sc !== 'object') throw new Error('static-checks no exporta objeto');
+            }},
+            { name: 'runAllChecks es función', fn: () => {
+                if (typeof runAllChecks !== 'function') throw new Error('runAllChecks no es función');
+            }},
+        ]);
+        return;
+    }
     main().catch((e) => {
         process.stderr.write(`[linter] fatal: ${e.stack || e.message}\n`);
         process.exit(2);

--- a/.pipeline/skills-deterministicos/tester.js
+++ b/.pipeline/skills-deterministicos/tester.js
@@ -791,6 +791,49 @@ async function main() {
 }
 
 if (require.main === module) {
+    if (process.argv.includes('--self-check')) {
+        const { runSelfCheck } = require('./lib/self-check');
+        runSelfCheck('tester', [
+            { name: 'parseArgs sin argumentos', fn: () => {
+                const a = parseArgs(['node', 'tester.js']);
+                if (typeof a !== 'object' || a === null) throw new Error('parseArgs no devuelve objeto');
+            }},
+            { name: 'parseArgs con issue', fn: () => {
+                const a = parseArgs(['node', 'tester.js', '1234', '--no-coverage']);
+                if (a.issue !== 1234) throw new Error(`issue esperado 1234 got ${a.issue}`);
+                if (a.coverage !== false) throw new Error('coverage debió quedar false');
+            }},
+            { name: 'gradle-parser carga', fn: () => {
+                const gp = require('./lib/gradle-parser');
+                if (!gp || typeof gp !== 'object') throw new Error('gradle-parser no exporta objeto');
+            }},
+            { name: 'kover-parser carga y parsea testsuite mínimo', fn: () => {
+                const kp = require('./lib/kover-parser');
+                const sample = '<?xml version="1.0"?><testsuite name="x" tests="1" failures="0" errors="0" skipped="0"></testsuite>';
+                const r = kp.parseTestResultsXml(sample);
+                if (!r || !r.valid || r.tests !== 1) throw new Error(`parseTestResultsXml devolvió ${JSON.stringify(r)}`);
+            }},
+            { name: 'kover-parser detecta failures con < y > en stack', fn: () => {
+                const kp = require('./lib/kover-parser');
+                const sample = '<?xml version="1.0"?><testsuite name="x" tests="1" failures="1" errors="0" skipped="0">'
+                    + '<testcase classname="c" name="t" time="0.1">'
+                    + '<failure message="boom" type="Error">at Promise.&lt;anonymous&gt; (foo.js:1:1)</failure>'
+                    + '</testcase></testsuite>';
+                const r = kp.parseTestResultsXml(sample);
+                if (r.failed_tests.length !== 1) throw new Error('debió detectar 1 failed_test');
+                if (r.failed_tests[0].name !== 't') throw new Error(`name esperado 't' got '${r.failed_tests[0].name}'`);
+            }},
+            { name: 'PIPELINE_ONLY_PATTERNS detecta .pipeline/', fn: () => {
+                const isPipelineOnly = isPipelineOnlyChange(['.pipeline/foo.js', 'docs/bar.md']);
+                if (!isPipelineOnly) throw new Error('debió detectar pipeline-only');
+            }},
+            { name: 'PIPELINE_ONLY_PATTERNS NO detecta cambio mixto', fn: () => {
+                const isPipelineOnly = isPipelineOnlyChange(['.pipeline/foo.js', 'app/composeApp/x.kt']);
+                if (isPipelineOnly) throw new Error('NO debió detectar pipeline-only (mixto)');
+            }},
+        ]);
+        return;
+    }
     main().catch((e) => {
         process.stderr.write(`[tester] fatal: ${e.stack || e.message}\n`);
         process.exit(2);

--- a/.pipeline/smoke-test.js
+++ b/.pipeline/smoke-test.js
@@ -28,6 +28,7 @@
 const fs = require('fs');
 const path = require('path');
 const http = require('http');
+const { spawnSync } = require('child_process');
 const { componentState, waitForMarkers } = require('./lib/ready-marker');
 
 const PIPELINE_DIR = __dirname;
@@ -47,8 +48,19 @@ const DEFAULT_COMPONENTS = [
   'dashboard',
 ];
 
+// Skills determinísticos a verificar con --self-check (acción 3 — relax CODEOWNERS).
+// Si alguno falla, el smoke test rebota → restart dispara rollback al tag pipeline-stable.
+// Esto es el reemplazo del bloqueo CODEOWNERS sobre `.pipeline/`: el rollback cubre
+// componentes residentes Y skills determinísticos.
+const SELF_CHECK_SKILLS = [
+  { name: 'tester',   path: 'skills-deterministicos/tester.js' },
+  { name: 'builder',  path: 'skills-deterministicos/builder.js' },
+  { name: 'delivery', path: 'skills-deterministicos/delivery.js' },
+  { name: 'linter',   path: 'skills-deterministicos/linter.js' },
+];
+
 function parseArgs(argv) {
-  const args = { timeoutMs: 60000, components: null, http: true };
+  const args = { timeoutMs: 60000, components: null, http: true, selfCheck: true };
   for (let i = 2; i < argv.length; i++) {
     const a = argv[i];
     if (a === '--timeout' && argv[i + 1]) { args.timeoutMs = parseInt(argv[++i], 10) * 1000; }
@@ -56,8 +68,33 @@ function parseArgs(argv) {
     else if (a === '--components' && argv[i + 1]) { args.components = argv[++i].split(','); }
     else if (a.startsWith('--components=')) { args.components = a.split('=')[1].split(','); }
     else if (a === '--no-http') { args.http = false; }
+    else if (a === '--no-self-check') { args.selfCheck = false; }
   }
   return args;
+}
+
+function runSelfChecks() {
+  const failed = [];
+  for (const skill of SELF_CHECK_SKILLS) {
+    const scriptPath = path.join(PIPELINE_DIR, skill.path);
+    if (!fs.existsSync(scriptPath)) {
+      log(`  SKIP ${skill.name} (script no existe: ${skill.path})`);
+      continue;
+    }
+    const r = spawnSync(process.execPath, [scriptPath, '--self-check'], {
+      cwd: PIPELINE_DIR,
+      timeout: 30000,
+      encoding: 'utf8',
+    });
+    if (r.status === 0) {
+      log(`  OK self-check ${skill.name}`);
+    } else {
+      const tail = ((r.stdout || '') + (r.stderr || '')).split('\n').filter(Boolean).slice(-5).join(' | ');
+      log(`  FAIL self-check ${skill.name} (exit ${r.status}): ${tail.slice(0, 300)}`);
+      failed.push(skill.name);
+    }
+  }
+  return failed;
 }
 
 function log(msg) {
@@ -155,6 +192,16 @@ async function main() {
       }
     }
   } catch {}
+
+  // 5) Self-checks de skills determinísticos. Cobertura post-merge para
+  // cambios en .pipeline/ que el rollback de componentes residentes no toca.
+  if (args.selfCheck) {
+    log('Ejecutando self-checks de skills determinísticos...');
+    const failed = runSelfChecks();
+    if (failed.length > 0) {
+      fail(`Self-checks fallaron: ${failed.join(', ')}`, 4);
+    }
+  }
 
   log('=== SMOKE TEST OK ===');
   process.exit(0);


### PR DESCRIPTION
## Resumen

Cierra el ciclo de bloqueo: cada cambio en `.pipeline/` requeria review humano por CODEOWNERS, generando colas de PRs sin mergear (incidente #2894 anoche). El rollback automatico ya existia en `restart.js` -> `rollback.js` al tag `pipeline-stable`, pero no validaba la salud de los skills determinsticos. Ahora si.

## Cambios

- **skills-deterministicos**: `builder`, `delivery`, `linter`, `tester` exponen `self-check()` con validaciones unitarias internas (**21/21 verde** corriendo a mano).
- **Nuevo** `.pipeline/skills-deterministicos/lib/self-check.js`: orquestador que invoca los 4 skills.
- **smoke-test.js**: nueva fase 5 que ejecuta los self-checks despues de markers, HTTP y last-restart. Flag `--no-self-check` para opt-out en debugging. Si fallan -> exit 4 -> restart dispara rollback automatico.
- **CODEOWNERS**: removido `/.pipeline/` del bloqueo. Solo queda `/.github/` porque los workflows no se pueden smoke-testear localmente. Auto-merge habilitado para PRs que solo tocan `.pipeline/`.

## Test plan

- [x] `node -c .pipeline/smoke-test.js` -> sintaxis OK
- [x] Self-checks corriendo a mano: tester 7/7, builder 5/5, delivery 5/5, linter 4/4 (21/21)
- [ ] Smoke-test completo post-merge en proximo restart

Closes #2882 (parcial - acción 3 del hueco rollback/CODEOWNERS).