### PR TITLE
fix(pipeline-dev): bajar modelo de Opus 4.6 a Sonnet 4.6

### DIFF
--- a/.claude/skills/pipeline-dev/SKILL.md
+++ b/.claude/skills/pipeline-dev/SKILL.md
@@ -3,7 +3,7 @@ description: PipelineDev — Desarrollo del pipeline V2 (Pulpo, dashboard, hooks
 user-invocable: true
 argument-hint: "<issue-o-tarea> [--plan] [--test]"
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, TaskCreate, TaskUpdate, TaskList
-model: claude-opus-4-6
+model: claude-sonnet-4-6
 ---
 
 # /pipeline-dev — PipelineDev


### PR DESCRIPTION
## Resumen

`pipeline-dev` fue el agente más caro del 1 may: **\$37.41 / 34% del gasto total** en 4 sesiones. El driver del costo es **cache_read** (17.0M tokens), no la generación. El skill resuelve Node.js defensivo, hooks y scripts del pipeline — Opus es overkill para ese trabajo.

## Cambio

```diff
-model: claude-opus-4-6
+model: claude-sonnet-4-6
```

Una línea en `.claude/skills/pipeline-dev/SKILL.md`.

## Pricing comparativo

| Modelo | cache_read | output |
|---|---|---|
| Opus 4.6 | \$1.50/MT | \$75/MT |
| Sonnet 4.6 | \$0.30/MT | \$15/MT |

Sonnet 4.6 es **5x más barato**.

## Estimación

**−80% gasto del agente: \$37 → \$7.5**

Reservar Opus solo para invocaciones manuales de diseño arquitectural complejo (no automáticas del pipeline).

## QA

`qa:skipped` — cambio puro de configuración de skill, sin impacto en producto de usuario. Validación post-merge: verificar en `metrics/snapshot.json` después de la próxima sesión de pipeline-dev que el modelo activo es `claude-sonnet-4-6`.

Closes #2915

🤖 Generated with [Claude Code](https://claude.com/claude-code)