### PR TITLE
feat(qa): scripts deterministicos para subtareas mecanicas

### DIFF
--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -48,6 +48,20 @@ Antes de empezar, creá las tareas con `TaskCreate` mapeando los pasos del plan.
 
 **Protocolo de sub-pasos:** Cuando una tarea tiene pasos internos verificables, codificalos en `metadata.steps` al crearla. Al avanzar, actualizá `metadata.current_step` + `metadata.completed_steps` y reflejá el progreso en `activeForm`: `"Ejecutando tests API (paso 2/5 · 40%)…"`.
 
+## Subtareas determinísticas (preferir scripts sobre lógica inline)
+
+Para tareas mecánicas, **invocar estos scripts en lugar de razonar paso a paso**. Reducen tool calls y evitan releer logs/XMLs.
+
+| Tarea | Script | Output |
+|---|---|---|
+| Localizar APK del flavor client | `bash qa/scripts/qa-find-apk.sh` | path absoluto en stdout, exit 1 si no existe |
+| Validar video Maestro (size, integridad básica) | `node qa/scripts/qa-validate-video.js <path>` | JSON `{valid, size_bytes, warnings, errors}` |
+| Localizar reportes JUnit/Maestro/desktop | `node qa/scripts/qa-find-reports.js` | JSON con paths existentes |
+| Extraer issue # del branch actual | `bash qa/scripts/qa-issue-from-branch.sh` | número de issue en stdout |
+| Aplicar label `qa:passed`/`qa:failed`/`qa:skipped` | `bash qa/scripts/qa-apply-verdict-label.sh <verdict> [issue#]` | label aplicado + log |
+
+**Regla:** si el script existe, no reimplementar la lógica con `Read`/`Bash` adhoc.
+
 ## Paso 1: Setup del entorno
 
 ```bash

--- a/qa/scripts/qa-apply-verdict-label.sh
+++ b/qa/scripts/qa-apply-verdict-label.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# qa-apply-verdict-label.sh — Aplica label qa:passed | qa:failed | qa:skipped al issue.
+#
+# Uso:
+#   qa-apply-verdict-label.sh <verdict> [issue-number]
+#
+# Si se omite issue-number, lo extrae con qa-issue-from-branch.sh.
+#
+# Verdicts soportados: passed | failed | skipped
+#
+# Exit codes:
+#   0: label aplicado (o issue no determinable, en cuyo caso emite warning)
+#   1: verdict invalido
+#   2: gh no disponible
+
+set -e
+
+VERDICT="${1:-}"
+ISSUE_NUM="${2:-}"
+
+case "$VERDICT" in
+  passed|failed|skipped) ;;
+  *)
+    echo "ERROR: verdict invalido '$VERDICT' (usar: passed | failed | skipped)" >&2
+    exit 1
+    ;;
+esac
+
+# gh CLI path (Windows)
+export PATH="/c/Workspaces/gh-cli/bin:$PATH"
+if ! command -v gh >/dev/null 2>&1; then
+  echo "ERROR: gh CLI no disponible en PATH" >&2
+  exit 2
+fi
+
+# Resolver issue
+if [ -z "$ISSUE_NUM" ]; then
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  ISSUE_NUM=$(bash "$SCRIPT_DIR/qa-issue-from-branch.sh" 2>/dev/null) || ISSUE_NUM=""
+fi
+
+if [ -z "$ISSUE_NUM" ]; then
+  echo "WARN: no se pudo determinar issue, omitiendo label" >&2
+  exit 0
+fi
+
+LABEL="qa:$VERDICT"
+gh issue edit "$ISSUE_NUM" --repo intrale/platform --add-label "$LABEL" >/dev/null 2>&1 \
+  && echo "Label $LABEL aplicado a issue #$ISSUE_NUM" \
+  || echo "WARN: no se pudo aplicar $LABEL a issue #$ISSUE_NUM" >&2
+
+exit 0

--- a/qa/scripts/qa-find-apk.sh
+++ b/qa/scripts/qa-find-apk.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# qa-find-apk.sh — Busca el APK del flavor client en orden de prioridad.
+#
+# Salida:
+#   stdout: path absoluto al APK (si encontrado)
+#   stderr: razón del fallo (si no se encuentra)
+# Exit codes:
+#   0: APK encontrado, path en stdout
+#   1: APK no encontrado en ninguna ubicación
+
+set -e
+
+CANDIDATES=(
+  "qa/artifacts/composeApp-client-debug.apk"
+  "app/composeApp/build/outputs/apk/client/debug/composeApp-client-debug.apk"
+)
+
+# Glob de fallback (build local con sufijos)
+shopt -s nullglob 2>/dev/null || true
+FALLBACK_GLOB=(app/composeApp/build/outputs/apk/client/debug/*.apk)
+
+for path in "${CANDIDATES[@]}"; do
+  if [ -f "$path" ]; then
+    echo "$(cd "$(dirname "$path")" && pwd)/$(basename "$path")"
+    exit 0
+  fi
+done
+
+for path in "${FALLBACK_GLOB[@]}"; do
+  if [ -f "$path" ]; then
+    echo "$(cd "$(dirname "$path")" && pwd)/$(basename "$path")"
+    exit 0
+  fi
+done
+
+echo "ERROR: APK no encontrado en qa/artifacts/ ni en app/composeApp/build/outputs/apk/client/debug/" >&2
+exit 1

--- a/qa/scripts/qa-find-reports.js
+++ b/qa/scripts/qa-find-reports.js
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+// qa-find-reports.js — Localiza todos los reportes de tests existentes.
+//
+// Uso:
+//   node qa/scripts/qa-find-reports.js
+//
+// Salida JSON:
+//   {
+//     "junit_api": [<paths .xml>],
+//     "junit_desktop": [<paths .xml>],
+//     "maestro": <path | null>,
+//     "html_api": <dir | null>,
+//     "html_desktop": <dir | null>
+//   }
+// Exit code: 0 siempre (reportar ausencia, no fallar).
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+function listXmlIn(dir) {
+  if (!fs.existsSync(dir)) return [];
+  try {
+    return fs
+      .readdirSync(dir)
+      .filter((f) => f.endsWith('.xml'))
+      .map((f) => path.join(dir, f));
+  } catch {
+    return [];
+  }
+}
+
+function existsOrNull(p) {
+  try {
+    fs.statSync(p);
+    return p;
+  } catch {
+    return null;
+  }
+}
+
+const result = {
+  junit_api: listXmlIn('qa/build/test-results/test'),
+  junit_desktop: listXmlIn('app/composeApp/build/test-results/desktopTest'),
+  maestro: existsOrNull('qa/recordings/maestro-results.xml'),
+  html_api: existsOrNull('qa/build/reports/tests/test'),
+  html_desktop: existsOrNull('app/composeApp/build/reports/tests/desktopTest'),
+};
+
+process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+process.exit(0);

--- a/qa/scripts/qa-issue-from-branch.sh
+++ b/qa/scripts/qa-issue-from-branch.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# qa-issue-from-branch.sh — Extrae el número de issue del branch actual.
+#
+# Soporta: agent/<N>-* | feature/<N>-* | bugfix/<N>-*
+#
+# Salida:
+#   stdout: número de issue (sin prefijo)
+# Exit codes:
+#   0: issue encontrado
+#   1: no se pudo determinar
+
+set -e
+
+BRANCH=$(git branch --show-current 2>/dev/null || echo "")
+
+if [ -z "$BRANCH" ]; then
+  echo "ERROR: no hay branch activo" >&2
+  exit 1
+fi
+
+# Formato: <prefix>/<numero>-<slug>
+ISSUE_NUM=$(echo "$BRANCH" | grep -oE '^(agent|feature|bugfix|fix)/[0-9]+-' | grep -oE '[0-9]+')
+
+if [ -z "$ISSUE_NUM" ]; then
+  echo "ERROR: branch '$BRANCH' no contiene un numero de issue (formato esperado: agent/<N>-* | feature/<N>-* | bugfix/<N>-* | fix/<N>-*)" >&2
+  exit 1
+fi
+
+echo "$ISSUE_NUM"
+exit 0

--- a/qa/scripts/qa-validate-video.js
+++ b/qa/scripts/qa-validate-video.js
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+// qa-validate-video.js — Valida un video de evidencia QA.
+//
+// Uso:
+//   node qa/scripts/qa-validate-video.js <path-al-video.mp4>
+//
+// Salida JSON:
+//   { "valid": bool, "size_bytes": n, "warnings": [...], "errors": [...] }
+// Exit codes:
+//   0: válido (puede tener warnings)
+//   1: archivo no existe o demasiado chico (<200KB)
+//   2: argumentos inválidos
+
+'use strict';
+
+const fs = require('fs');
+
+const MIN_VALID_SIZE = 200 * 1024; // 200KB
+const TINY_SIZE = 50 * 1024; // 50KB
+
+function emit(obj, exitCode) {
+  process.stdout.write(JSON.stringify(obj) + '\n');
+  process.exit(exitCode);
+}
+
+const videoPath = process.argv[2];
+if (!videoPath) {
+  emit({ valid: false, errors: ['missing argument: video path'] }, 2);
+}
+
+let stat;
+try {
+  stat = fs.statSync(videoPath);
+} catch (err) {
+  emit({ valid: false, size_bytes: 0, errors: [`file not found: ${videoPath}`] }, 1);
+}
+
+const size = stat.size;
+const warnings = [];
+const errors = [];
+
+if (size < TINY_SIZE) {
+  errors.push(`video too small (${size} bytes < ${TINY_SIZE}) — recording likely failed`);
+} else if (size < MIN_VALID_SIZE) {
+  warnings.push(`video small (${size} bytes < ${MIN_VALID_SIZE}) — may indicate truncated recording`);
+}
+
+const valid = errors.length === 0;
+emit(
+  {
+    valid,
+    size_bytes: size,
+    warnings,
+    errors,
+  },
+  valid ? 0 : 1,
+);


### PR DESCRIPTION
## Resumen

Crea 5 scripts en `qa/scripts/` que reemplazan lógica inline del SKILL.md y reducen tool calls del agente:

| Script | Reemplaza |
|---|---|
| `qa-find-apk.sh` | Búsqueda inline de APK en 2-3 paths |
| `qa-validate-video.js` | Loop de validación de tamaño con stat/ffprobe |
| `qa-find-reports.js` | Múltiples `ls` para localizar reportes JUnit/Maestro |
| `qa-issue-from-branch.sh` | sed inline en cada paso de label |
| `qa-apply-verdict-label.sh` | Bloques duplicados de gh issue edit |

Todos devuelven JSON o exit codes coherentes. SKILL.md gana sección \"Subtareas determinísticas\" con tabla de invocación.

## Ahorro estimado

- Tool calls: 29/sesión → \~18 (−38%).
- cache_read inicial: \-3-5K por SKILL más declarativo.
- Rapidez: ms vs LLM razonando sobre output.

## QA gate

`qa:skipped` — extracción de scripts del skill, sin impacto en producto.

## Test plan

- [x] `bash -n` OK en los 3 .sh.
- [x] `node --check` OK en los 2 .js.
- [x] Ejecución contra filesystem real:
  - `qa-find-apk.sh` localiza el APK existente.
  - `qa-find-reports.js` lista reportes con paths existentes.
  - `qa-validate-video.js` reporta `valid:false` con path inválido.
  - `qa-issue-from-branch.sh` extrae 2924 del branch actual.
  - `qa-apply-verdict-label.sh foo` rechaza verdict inválido con exit 1.
- [ ] Próxima sesión QA del pipeline: comprobar que el agente invoca los scripts.

Closes #2924