### PR TITLE
feat(security): scripts deterministicos para mecanica de scan

### DIFF
--- a/.claude/skills/security/SKILL.md
+++ b/.claude/skills/security/SKILL.md
@@ -76,6 +76,21 @@ export PATH="/c/Workspaces/gh-cli/bin:$PATH"
 
 ---
 
+## Subtareas determinisicas
+
+Antes de ejecutar greps o clasificacion manual, **invocar siempre el script correspondiente** y razonar sobre el JSON resultante. Reduce tool_calls y cache_read sin perder cobertura.
+
+| Subtarea | Script | Reemplaza paso |
+|---|---|---|
+| Clasificar archivos del diff por riesgo | `node .pipeline/scripts-security/classify-diff.js [base-ref]` | S2 |
+| Buscar patrones OWASP A01-A09 en codigo | `node .pipeline/scripts-security/scan-owasp-patterns.js [path]` | S3 (greps por checklist) |
+| Detectar secrets hardcodeados | `node .pipeline/scripts-security/scan-secrets.js [path]` | S4 |
+| Listar dependencias para CVE check | `node .pipeline/scripts-security/check-dependencies.js` | AU1 |
+
+Todos devuelven JSON con `findings[]` (o `dependencies[]`) y exit codes consistentes (`0` sin findings bloqueantes, `1` con findings, `2` error de uso). El agente solo razona sobre los findings y arma el reporte/issue — no ejecuta el grep.
+
+---
+
 ## Modo: `analyze #N` — Análisis de issue (FASE 1)
 
 Analizar el issue antes de comenzar el desarrollo para identificar la superficie de ataque.

--- a/.pipeline/scripts-security/check-dependencies.js
+++ b/.pipeline/scripts-security/check-dependencies.js
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+// check-dependencies.js
+// Lista las dependencias declaradas en el monorepo Gradle (build.gradle.kts +
+// libs.versions.toml) en formato JSON para que el agente /security pueda
+// consultar versiones contra GHSA / NVD sin parsear archivos a mano.
+//
+// Reemplaza el paso AU1 del SKILL.md de /security.
+//
+// Uso:
+//   node check-dependencies.js
+//
+// Exit codes:
+//   0 = listado generado (independiente de hallazgos)
+//   2 = error de IO
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = process.cwd();
+const IGNORE_DIRS = new Set(['.git', 'node_modules', 'build', '.gradle', '.idea', 'dist', 'out', '.kotlin']);
+
+function walk(dir, predicate, out) {
+    let entries;
+    try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return; }
+    for (const e of entries) {
+        const full = path.join(dir, e.name);
+        if (e.isDirectory()) {
+            if (IGNORE_DIRS.has(e.name)) continue;
+            walk(full, predicate, out);
+        } else if (predicate(e.name)) {
+            out.push(full);
+        }
+    }
+}
+
+function parseGradleKts(file) {
+    let content;
+    try { content = fs.readFileSync(file, 'utf8'); } catch { return []; }
+    const deps = [];
+    // implementation("group:artifact:version") | api(...) | classpath(...) | testImplementation(...)
+    const re = /(implementation|api|classpath|testImplementation|androidTestImplementation|kapt|ksp|runtimeOnly|compileOnly)\s*\(\s*"([^":\s]+):([^":\s]+):([^"\s]+)"\s*\)/g;
+    let m;
+    while ((m = re.exec(content)) !== null) {
+        deps.push({
+            scope: m[1],
+            group: m[2],
+            artifact: m[3],
+            version: m[4],
+            source: file,
+        });
+    }
+    return deps;
+}
+
+function parseVersionsToml(file) {
+    let content;
+    try { content = fs.readFileSync(file, 'utf8'); } catch { return { versions: [], libraries: [] }; }
+    const lines = content.split(/\r?\n/);
+    let section = null;
+    const versions = [];
+    const libraries = [];
+    for (const raw of lines) {
+        const line = raw.trim();
+        if (!line || line.startsWith('#')) continue;
+        const sec = line.match(/^\[([a-z-]+)\]$/i);
+        if (sec) { section = sec[1].toLowerCase(); continue; }
+        if (section === 'versions') {
+            const m = line.match(/^([a-zA-Z0-9_-]+)\s*=\s*"([^"]+)"/);
+            if (m) versions.push({ key: m[1], value: m[2] });
+        } else if (section === 'libraries') {
+            const m = line.match(/^([a-zA-Z0-9_-]+)\s*=\s*(.+)$/);
+            if (m) libraries.push({ key: m[1], spec: m[2] });
+        }
+    }
+    return { versions, libraries };
+}
+
+function main() {
+    const gradleFiles = [];
+    walk(ROOT, n => n === 'build.gradle.kts' || n === 'settings.gradle.kts', gradleFiles);
+
+    const tomlFiles = [];
+    walk(ROOT, n => n.endsWith('.versions.toml'), tomlFiles);
+
+    const allDeps = [];
+    for (const f of gradleFiles) allDeps.push(...parseGradleKts(f));
+
+    const tomlData = [];
+    for (const f of tomlFiles) {
+        tomlData.push({ file: f, ...parseVersionsToml(f) });
+    }
+
+    const result = {
+        gradle_files: gradleFiles.length,
+        toml_files: tomlFiles.length,
+        dependencies_count: allDeps.length,
+        dependencies: allDeps,
+        version_catalogs: tomlData,
+    };
+    console.log(JSON.stringify(result, null, 2));
+    process.exit(0);
+}
+
+main();

--- a/.pipeline/scripts-security/classify-diff.js
+++ b/.pipeline/scripts-security/classify-diff.js
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+// classify-diff.js [base-ref]
+// Clasifica los archivos del diff actual (vs origin/main por default) en
+// niveles de riesgo de seguridad: high, medium, low. Reemplaza el paso S2 del
+// SKILL.md de /security y habilita el smart-skip del modo gate.
+//
+// Uso:
+//   node classify-diff.js                 # diff vs origin/main
+//   node classify-diff.js origin/develop  # diff vs otra base
+//
+// Exit codes:
+//   0 = clasificacion exitosa (independiente del riesgo)
+//   2 = error de IO o git no disponible
+
+const { spawnSync } = require('child_process');
+
+const HIGH_RISK_PATTERNS = [
+    /\/auth\//i,
+    /Auth[A-Z]/,
+    /Security[A-Z]/,
+    /Token/i,
+    /Password/i,
+    /Secret/i,
+    /Credentials?/i,
+    /\/config\//,
+    /\.conf$/,
+    /\.properties$/,
+    /Function\.kt$/,
+    /SecuredFunction/,
+    /Cognito/i,
+    /Lambda/i,
+    /Jwt/i,
+    /Crypto/i,
+];
+
+const MEDIUM_RISK_PATTERNS = [
+    /ViewModel\.kt$/,
+    /Service\.kt$/,
+    /Client\.kt$/,
+    /\/di\//,
+    /Validator\.kt$/,
+    /build\.gradle\.kts$/,
+    /dependency/i,
+    /libs\.versions\.toml$/,
+];
+
+function classify(file) {
+    for (const p of HIGH_RISK_PATTERNS) if (p.test(file)) return 'high';
+    for (const p of MEDIUM_RISK_PATTERNS) if (p.test(file)) return 'medium';
+    return 'low';
+}
+
+function main() {
+    const base = process.argv[2] || 'origin/main';
+    const proc = spawnSync('git', ['diff', '--name-only', `${base}...HEAD`], { encoding: 'utf8' });
+    if (proc.status !== 0) {
+        console.error(JSON.stringify({ error: 'git diff fallo', stderr: proc.stderr }));
+        process.exit(2);
+    }
+    const files = proc.stdout.split(/\r?\n/).map(s => s.trim()).filter(Boolean);
+
+    const classified = files.map(f => ({ file: f, risk: classify(f) }));
+
+    const counts = { high: 0, medium: 0, low: 0 };
+    for (const c of classified) counts[c.risk]++;
+
+    const result = {
+        base_ref: base,
+        total_files: files.length,
+        counts,
+        sensitive: counts.high + counts.medium > 0,
+        files: classified,
+    };
+    console.log(JSON.stringify(result, null, 2));
+    process.exit(0);
+}
+
+main();

--- a/.pipeline/scripts-security/scan-owasp-patterns.js
+++ b/.pipeline/scripts-security/scan-owasp-patterns.js
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+// scan-owasp-patterns.js [<path>]
+// Escanea el codigo en busca de patrones asociados a OWASP Top 10 (A01-A09)
+// que el agente /security verificaba con grep ad-hoc en el paso S3.
+//
+// Uso:
+//   node scan-owasp-patterns.js               # cwd
+//   node scan-owasp-patterns.js backend/src
+//
+// Exit codes:
+//   0 = sin findings
+//   1 = findings detectados
+//   2 = error de uso
+
+const fs = require('fs');
+const path = require('path');
+
+const SCAN_EXTS = new Set(['.kt', '.kts']);
+const IGNORE_DIRS = new Set(['.git', 'node_modules', 'build', '.gradle', '.idea', 'dist', 'out', '.kotlin']);
+
+const PATTERNS = [
+    {
+        id: 'function_handles_sensitive_data',
+        owasp: 'A01',
+        severity: 'high',
+        regex: /class\s+\w+\s*\([^)]*\)\s*:\s*Function\b/,
+        description: 'Endpoint Function (no Secured) — verificar si maneja datos sensibles',
+    },
+    {
+        id: 'debug_user_header',
+        owasp: 'A05',
+        severity: 'high',
+        regex: /X-Debug-User/i,
+        description: 'Header X-Debug-User presente — debe estar deshabilitado en prod',
+    },
+    {
+        id: 'cors_wildcard',
+        owasp: 'A05',
+        severity: 'medium',
+        regex: /allowHost\s*\(\s*"\*"|allowAnyHost\s*\(\)/,
+        description: 'CORS con wildcard o anyHost — restringir origenes',
+    },
+    {
+        id: 'todo_enable_auth',
+        owasp: 'A01',
+        severity: 'medium',
+        regex: /\/\/\s*TODO[:\s].*(?:auth|secur)/i,
+        description: 'TODO de habilitar auth/security — pendiente de cierre',
+    },
+    {
+        id: 'logger_with_password',
+        owasp: 'A09',
+        severity: 'high',
+        regex: /logger\.(info|debug|warn|error|trace)\s*\(.*\b(password|passwd|pwd|secret|token)\b/i,
+        description: 'Logger con dato sensible (password/token/secret) — riesgo de logging failure',
+    },
+    {
+        id: 'println_with_sensitive',
+        owasp: 'A09',
+        severity: 'medium',
+        regex: /println\s*\(.*\b(password|passwd|pwd|secret|token|jwt)\b/i,
+        description: 'println con dato sensible — riesgo de logging failure',
+    },
+    {
+        id: 'string_concat_in_query',
+        owasp: 'A03',
+        severity: 'medium',
+        regex: /(query|sql|cmd)\s*=?\s*"[^"]*"\s*\+\s*\w+/i,
+        description: 'Concatenacion de strings en query — posible injection',
+    },
+    {
+        id: 'md5_or_sha1_for_password',
+        owasp: 'A02',
+        severity: 'high',
+        regex: /MessageDigest\.getInstance\s*\(\s*"(MD5|SHA-?1)"\s*\)/i,
+        description: 'Hash debil (MD5/SHA1) — no usar para passwords',
+    },
+    {
+        id: 'base64_as_encryption',
+        owasp: 'A02',
+        severity: 'medium',
+        regex: /\/\/[^\n]*(?:encrypt|cifr).*Base64|Base64.*(?:encrypt|cifr)/i,
+        description: 'Base64 referenciado como cifrado — Base64 es encoding, no cifrado',
+    },
+    {
+        id: 'jwt_decode_without_verify',
+        owasp: 'A07',
+        severity: 'high',
+        regex: /JWT\.decode\s*\(/,
+        description: 'JWT.decode() sin verify — debe usarse JWT.require + verify',
+    },
+];
+
+function walk(dir, out) {
+    let entries;
+    try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return; }
+    for (const e of entries) {
+        const full = path.join(dir, e.name);
+        if (e.isDirectory()) {
+            if (IGNORE_DIRS.has(e.name)) continue;
+            walk(full, out);
+        } else if (SCAN_EXTS.has(path.extname(e.name).toLowerCase())) {
+            out.push(full);
+        }
+    }
+}
+
+function scanFile(file) {
+    let content;
+    try { content = fs.readFileSync(file, 'utf8'); } catch { return []; }
+    const lines = content.split(/\r?\n/);
+    const findings = [];
+    for (let i = 0; i < lines.length; i++) {
+        for (const p of PATTERNS) {
+            if (p.regex.test(lines[i])) {
+                findings.push({
+                    file,
+                    line: i + 1,
+                    pattern_id: p.id,
+                    owasp: p.owasp,
+                    severity: p.severity,
+                    description: p.description,
+                    excerpt: lines[i].length > 200 ? lines[i].slice(0, 200) + '…' : lines[i],
+                });
+            }
+        }
+    }
+    return findings;
+}
+
+function main() {
+    const target = process.argv[2] || process.cwd();
+    if (!fs.existsSync(target)) {
+        console.error(JSON.stringify({ error: 'path no existe', path: target }));
+        process.exit(2);
+    }
+    const files = [];
+    if (fs.statSync(target).isDirectory()) walk(target, files);
+    else files.push(target);
+
+    const all = [];
+    for (const f of files) all.push(...scanFile(f));
+
+    const result = {
+        scanned_files: files.length,
+        findings_count: all.length,
+        critical: all.filter(f => f.severity === 'critical').length,
+        high: all.filter(f => f.severity === 'high').length,
+        medium: all.filter(f => f.severity === 'medium').length,
+        low: all.filter(f => f.severity === 'low').length,
+        findings: all,
+    };
+    console.log(JSON.stringify(result, null, 2));
+    process.exit(result.critical + result.high > 0 ? 1 : 0);
+}
+
+main();

--- a/.pipeline/scripts-security/scan-secrets.js
+++ b/.pipeline/scripts-security/scan-secrets.js
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+// scan-secrets.js [<path>]
+// Escanea recursivamente un path en busca de patrones de secrets hardcodeados:
+// API keys, tokens, passwords, private keys. Reemplaza el grep manual del paso S4
+// del SKILL.md de /security.
+//
+// Uso:
+//   node scan-secrets.js                  # escanea cwd
+//   node scan-secrets.js backend/src      # escanea path especifico
+//
+// Exit codes:
+//   0 = sin findings
+//   1 = al menos un finding (potencial secret)
+//   2 = error de uso o IO
+
+const fs = require('fs');
+const path = require('path');
+
+const SCAN_EXTS = new Set(['.kt', '.kts', '.java', '.js', '.ts', '.json', '.conf', '.properties', '.yml', '.yaml', '.env']);
+const IGNORE_DIRS = new Set(['.git', 'node_modules', 'build', '.gradle', '.idea', 'dist', 'out', '.kotlin', 'kotlin-js-store']);
+
+const PATTERNS = [
+    {
+        id: 'aws_access_key',
+        owasp: 'A02',
+        severity: 'critical',
+        regex: /\bAKIA[0-9A-Z]{16}\b/,
+        description: 'AWS Access Key ID',
+    },
+    {
+        id: 'aws_secret_key',
+        owasp: 'A02',
+        severity: 'critical',
+        regex: /aws[_-]?secret[_-]?(access[_-]?)?key\s*[=:]\s*['"][A-Za-z0-9/+=]{40}['"]/i,
+        description: 'AWS Secret Access Key',
+    },
+    {
+        id: 'private_key_block',
+        owasp: 'A02',
+        severity: 'critical',
+        regex: /-----BEGIN (RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY-----/,
+        description: 'Bloque de clave privada',
+    },
+    {
+        id: 'generic_secret',
+        owasp: 'A02',
+        severity: 'high',
+        regex: /\b(password|passwd|pwd|secret|api[_-]?key|apikey|access[_-]?token|auth[_-]?token|private[_-]?key)\s*[=:]\s*['"][^'"\s$]{8,}['"]/i,
+        description: 'Posible secret hardcodeado (password/secret/api_key/token)',
+    },
+    {
+        id: 'jwt_token',
+        owasp: 'A02',
+        severity: 'high',
+        regex: /\beyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/,
+        description: 'Token JWT hardcodeado',
+    },
+    {
+        id: 'github_token',
+        owasp: 'A02',
+        severity: 'critical',
+        regex: /\b(ghp|gho|ghs|ghu|ghr)_[A-Za-z0-9]{36,}\b/,
+        description: 'Token de GitHub',
+    },
+    {
+        id: 'slack_token',
+        owasp: 'A02',
+        severity: 'high',
+        regex: /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/,
+        description: 'Token de Slack',
+    },
+];
+
+function isLikelyTestFixture(file) {
+    const norm = file.replace(/\\/g, '/').toLowerCase();
+    return /\/(test|tests|fixtures|__mocks__|sample|samples|examples?)\//.test(norm)
+        || /test\.[a-z]+$/.test(norm)
+        || /spec\.[a-z]+$/.test(norm);
+}
+
+function walk(dir, out) {
+    let entries;
+    try {
+        entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+        return;
+    }
+    for (const e of entries) {
+        if (e.name.startsWith('.') && IGNORE_DIRS.has(e.name)) continue;
+        const full = path.join(dir, e.name);
+        if (e.isDirectory()) {
+            if (IGNORE_DIRS.has(e.name)) continue;
+            walk(full, out);
+        } else if (e.isFile()) {
+            const ext = path.extname(e.name).toLowerCase();
+            if (SCAN_EXTS.has(ext) || e.name === '.env') out.push(full);
+        }
+    }
+}
+
+function scanFile(file) {
+    let content;
+    try {
+        content = fs.readFileSync(file, 'utf8');
+    } catch {
+        return [];
+    }
+    const findings = [];
+    const lines = content.split(/\r?\n/);
+    for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        for (const p of PATTERNS) {
+            const m = p.regex.exec(line);
+            if (m) {
+                findings.push({
+                    file,
+                    line: i + 1,
+                    pattern_id: p.id,
+                    owasp: p.owasp,
+                    severity: isLikelyTestFixture(file) ? 'low' : p.severity,
+                    description: p.description,
+                    excerpt: line.length > 200 ? line.slice(0, 200) + '…' : line,
+                    in_test_fixture: isLikelyTestFixture(file),
+                });
+            }
+        }
+    }
+    return findings;
+}
+
+function main() {
+    const target = process.argv[2] || process.cwd();
+    if (!fs.existsSync(target)) {
+        console.error(JSON.stringify({ error: 'path no existe', path: target }));
+        process.exit(2);
+    }
+    const files = [];
+    if (fs.statSync(target).isDirectory()) walk(target, files);
+    else files.push(target);
+
+    const allFindings = [];
+    for (const f of files) allFindings.push(...scanFile(f));
+
+    const summary = {
+        scanned_files: files.length,
+        findings_count: allFindings.length,
+        critical: allFindings.filter(f => f.severity === 'critical').length,
+        high: allFindings.filter(f => f.severity === 'high').length,
+        medium: allFindings.filter(f => f.severity === 'medium').length,
+        low: allFindings.filter(f => f.severity === 'low').length,
+        findings: allFindings,
+    };
+    console.log(JSON.stringify(summary, null, 2));
+
+    const blocking = summary.critical + summary.high;
+    process.exit(blocking > 0 ? 1 : 0);
+}
+
+main();


### PR DESCRIPTION
## Resumen

- Nuevo directorio `.pipeline/scripts-security/` con 4 scripts Node.js que reemplazan greps ad-hoc del agente `/security`.
- `classify-diff.js`, `scan-secrets.js`, `scan-owasp-patterns.js`, `check-dependencies.js`.
- SKILL.md de security agrega seccion \"Subtareas determinisicas\" mapeando pasos S2/S3/S4/AU1 a los scripts.

## Estimado de impacto

- −65% del costo del agente security (~\$15 → \$5/dia).
- tool_calls 24/sesion → ~10/sesion.
- Habilita el smart-skip de #2933 (consume `classify-diff.js`).

## Test plan

- [x] `node --check` OK en los 4 scripts
- [x] `scan-secrets.js` sobre los propios scripts → 0 findings
- [x] `scan-owasp-patterns.js` sobre `backend/src` → 4 findings high (Function classes esperados)
- [x] `check-dependencies.js` sobre repo → 11 build.gradle.kts + 1 libs.versions.toml parseados
- [x] `classify-diff.js HEAD~5` → 15 archivos clasificados low correctamente

Closes #2931