### PR TITLE
perf(security): smart-skip cuando el diff no toca codigo sensible (#2933)

### DIFF
--- a/.claude/skills/security/SKILL.md
+++ b/.claude/skills/security/SKILL.md
@@ -56,12 +56,15 @@ Antes de ejecutar greps o clasificacion manual, **invocar siempre el script corr
 
 | Subtarea | Script | Reemplaza paso |
 |---|---|---|
+| Smart-skip del modo `gate` (skip determinista si no hay sensibles) | `node .pipeline/scripts-security/security-gate.js [base-ref]` | Modo `gate` (preprocesador) |
 | Clasificar archivos del diff por riesgo | `node .pipeline/scripts-security/classify-diff.js [base-ref]` | S2 |
 | Buscar patrones OWASP A01-A09 en codigo | `node .pipeline/scripts-security/scan-owasp-patterns.js [path]` | S3 (greps por checklist) |
 | Detectar secrets hardcodeados | `node .pipeline/scripts-security/scan-secrets.js [path]` | S4 |
 | Listar dependencias para CVE check | `node .pipeline/scripts-security/check-dependencies.js` | AU1 |
 
 Todos devuelven JSON con `findings[]` (o `dependencies[]`) y exit codes consistentes (`0` sin findings bloqueantes, `1` con findings, `2` error de uso). El agente solo razona sobre los findings y arma el reporte/issue — no ejecuta el grep.
+
+`security-gate.js` es especial: usa exit `0` para skip determinista (status `pass`) y exit `100` para senalizar al caller que debe invocar al LLM. Detalles en la seccion "Modo: `gate`".
 
 ---
 
@@ -212,14 +215,30 @@ Para cada finding `Critical`/`High` crear issue automático (template en `docs/s
 
 ## Modo: `gate` — Gate pre-delivery (FASE 3)
 
-Verificación rápida para `delivery-gate.js`. Salida estructurada:
+Verificación rápida para `delivery-gate.js`. Salida estructurada.
 
-1. Ejecutar `classify-diff.js`. Si `sensitive: false` → emitir pass directo:
-   ```
-   SECURITY_GATE_RESULT: {"gate":"security","status":"pass","critical":0,"high":0,"blockers":[],"reason":"diff sin archivos sensibles"}
-   ```
-2. Si hay archivos sensibles → ejecutar S3 + S4 con foco en A01, A02, A03, A07.
-3. Producir salida JSON al stdout:
+### Smart-skip determinista (preferido)
+
+**El caller del gate (delivery-gate.js, hooks o invocacion manual) DEBE ejecutar primero el wrapper determinista**:
+
+```bash
+node .pipeline/scripts-security/security-gate.js [base-ref]
+```
+
+Comportamiento:
+
+| Exit | Significado | Que hace el caller |
+|---|---|---|
+| `0` | Smart-skip: el diff no toca archivos sensibles. El stdout ya trae el JSON `status:"pass"` final. | Reusar el JSON. **No invocar al LLM.** |
+| `100` | Hay archivos sensibles o falla detectada. El stdout trae `status:"needs_llm"` con la lista de archivos sensibles. | Invocar al agente `/security gate` con el LLM (este SKILL.md). |
+| otro | Error inesperado. | Fail-safe: invocar al LLM igual. |
+
+El wrapper es fail-safe: si `classify-diff.js` falla por cualquier motivo, devuelve exit 100 con `reason:"classify-diff-error"` para que el caller no se saltee la auditoria por error de infra.
+
+### Cuando el wrapper devuelve `needs_llm` (este SKILL toma el control)
+
+1. Ejecutar S3 + S4 con foco en A01, A02, A03, A07 sobre los archivos `sensitive_files` del JSON del wrapper.
+2. Producir salida JSON al stdout:
 
 ```
 SECURITY_GATE_RESULT: {"gate":"security","status":"pass|fail","critical":0,"high":0,"blockers":[]}

--- a/.pipeline/scripts-security/security-gate.js
+++ b/.pipeline/scripts-security/security-gate.js
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+// security-gate.js [base-ref]
+// Wrapper smart-skip para el modo `gate` de /security.
+//
+// Flujo:
+//   1. Invoca classify-diff.js para clasificar archivos del diff por riesgo.
+//   2. Si NO hay archivos sensibles (high/medium) -> emite el JSON de pass al
+//      stdout y termina con exit 0 SIN invocar al LLM. Este es el "skip".
+//   3. Si hay archivos sensibles -> emite un JSON con `needs_llm: true` y la
+//      lista de archivos sensibles, y termina con exit 100 (codigo reservado
+//      para "el caller debe invocar /security gate con LLM").
+//
+// Fail-safe: si classify-diff.js falla por cualquier motivo (git no disponible,
+// repo corrupto, etc), emite `needs_llm: true` con `reason: classify-diff-error`
+// para que el caller no se saltee la auditoria por error de infra.
+//
+// Uso:
+//   node security-gate.js                 # diff vs origin/main
+//   node security-gate.js origin/develop  # diff vs otra base
+//
+// Salida estandar (siempre JSON valido en una linea):
+//   skip:    {"gate":"security","status":"pass","critical":0,"high":0,"blockers":[],"reason":"diff sin archivos sensibles - skip","mode":"deterministic","total_files":N}
+//   needs LLM: {"gate":"security","status":"needs_llm","reason":"diff con archivos sensibles","mode":"llm","sensitive_files":[...],"total_files":N}
+//
+// Exit codes:
+//   0   = skip determinista emitido (status=pass)
+//   100 = el caller debe invocar al LLM (status=needs_llm)
+//   2   = error de uso (no deberia pasar — fail-safe lo convierte en 100)
+
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const EXIT_SKIP = 0;
+const EXIT_NEEDS_LLM = 100;
+
+const CLASSIFY_SCRIPT = path.join(__dirname, 'classify-diff.js');
+
+function emit(obj, code) {
+    process.stdout.write(JSON.stringify(obj) + '\n');
+    process.exit(code);
+}
+
+function main() {
+    const base = process.argv[2] || 'origin/main';
+
+    const proc = spawnSync('node', [CLASSIFY_SCRIPT, base], { encoding: 'utf8' });
+
+    if (proc.status !== 0) {
+        // Fail-safe: si classify-diff falla, NO saltear -> exigir LLM.
+        emit({
+            gate: 'security',
+            status: 'needs_llm',
+            mode: 'llm',
+            reason: 'classify-diff-error: fail-safe a flujo normal',
+            error: (proc.stderr || '').trim().slice(0, 400),
+        }, EXIT_NEEDS_LLM);
+    }
+
+    let parsed;
+    try {
+        parsed = JSON.parse(proc.stdout);
+    } catch (e) {
+        emit({
+            gate: 'security',
+            status: 'needs_llm',
+            mode: 'llm',
+            reason: 'classify-diff-output-invalid: fail-safe a flujo normal',
+            error: e.message,
+        }, EXIT_NEEDS_LLM);
+    }
+
+    const { sensitive, total_files, files = [], counts = {} } = parsed;
+
+    if (!sensitive) {
+        emit({
+            gate: 'security',
+            status: 'pass',
+            critical: 0,
+            high: 0,
+            blockers: [],
+            reason: total_files === 0
+                ? 'diff vacio - skip'
+                : 'diff sin archivos sensibles - skip',
+            mode: 'deterministic',
+            total_files,
+            counts,
+        }, EXIT_SKIP);
+    }
+
+    const sensitiveFiles = files.filter(f => f.risk === 'high' || f.risk === 'medium');
+
+    emit({
+        gate: 'security',
+        status: 'needs_llm',
+        mode: 'llm',
+        reason: 'diff con archivos sensibles - se requiere auditoria LLM',
+        total_files,
+        counts,
+        sensitive_files: sensitiveFiles,
+    }, EXIT_NEEDS_LLM);
+}
+
+main();


### PR DESCRIPTION
## Summary

- Wrapper determinista `.pipeline/scripts-security/security-gate.js` que invoca `classify-diff.js` y emite el JSON de pass del gate cuando el diff no toca archivos sensibles, **sin invocar al LLM**.
- Cuando hay archivos sensibles, el wrapper devuelve `status:"needs_llm"` con la lista de archivos para que el caller invoque al agente.
- Fail-safe: si `classify-diff.js` falla, el wrapper exige LLM (no se saltea auditoria por error de infra).

## Detalle

- Exit codes claros para integracion con cualquier caller:
  - `0` = skip determinista (status `pass`).
  - `100` = el caller debe invocar al LLM.
- SKILL.md actualizado:
  - Tabla de subtareas determinisicas suma `security-gate.js`.
  - Seccion modo `gate` rediseñada: smart-skip primero, LLM solo si hace falta.

## Impacto

Esperado **40-50% de gates de security skip-ables** (PRs que solo tocan `.pipeline/`, `docs/`, hooks, scripts, etc).

Tercero y ultimo issue del trio de optimizacion de `/security`. Sumado a #2931 (scripts deterministicos) y #2932 (split SKILL.md), apunta al objetivo de reducir el agente de \$22 a \$3-4/dia (~85%).

## Test plan

- [x] `node --check security-gate.js` -> sintaxis OK
- [x] Ejecucion contra rama actual sin cambios sensibles -> exit 0, JSON `status:"pass"`, `reason:"diff vacio - skip"`
- [x] Ejecucion contra `origin/main~50` (diff con archivos /auth/, /scripts-security/) -> exit 100, JSON `status:"needs_llm"`, lista 5 archivos high-risk
- [x] Ejecucion con base inexistente (`origin/branch-no-existe-test`) -> exit 100, JSON `reason:"classify-diff-error: fail-safe a flujo normal"` (fail-safe OK)

Closes #2933

🤖 Generated with [Claude Code](https://claude.com/claude-code)