### PR TITLE
perf(android-dev): bajar modelo de Opus 4.6 a Sonnet 4.6 (#2939)

### DIFF
--- a/.claude/skills/android-dev/SKILL.md
+++ b/.claude/skills/android-dev/SKILL.md
@@ -3,7 +3,7 @@ description: AndroidDev — Desarrollo Android con Compose, flavors, Coil y Mate
 user-invocable: true
 argument-hint: "<issue-o-tarea> [--plan] [--test]"
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, TaskCreate, TaskUpdate, TaskList
-model: claude-opus-4-6
+model: claude-sonnet-4-6
 ---
 
 # /android-dev — AndroidDev


### PR DESCRIPTION
## Summary

- Cambia \`model: claude-opus-4-6\` -> \`model: claude-sonnet-4-6\` en \`.claude/skills/android-dev/SKILL.md\`.
- Alinea con qa, security, pipeline-dev, po, ux, guru, planner que ya estan en Sonnet 4.6.
- Ahorro esperado: ~67% por sesion ($3.64 -> ~$1.20).

## Test plan

- [x] \`grep '^model:' .claude/skills/android-dev/SKILL.md\` retorna \`claude-sonnet-4-6\`
- [ ] Validacion real: proxima sesion de \`/android-dev\` muestra calidad equivalente

\`qa:skipped\` justificacion: solo cambia metadata del agente, no afecta producto.

Closes #2939