### PR TITLE
feat(android-dev): scripts deterministicos (#2938)

### DIFF
--- a/.claude/skills/android-dev/SKILL.md
+++ b/.claude/skills/android-dev/SKILL.md
@@ -178,8 +178,7 @@ class DoMiActionTest {
 ### 4.2 Verificar que los tests FALLAN (Red Phase)
 
 ```bash
-export JAVA_HOME="/c/Users/Administrator/.jdks/temurin-21.0.7" && \
-  ./gradlew :app:composeApp:testDebugUnitTest 2>&1 | tail -30
+.pipeline/scripts-android/android-test.sh
 ```
 
 **Esperado:** los tests deben FALLAR con errores de compilacion o ejecucion (clases no existen aun).
@@ -272,8 +271,7 @@ AsyncImage(
 Despues de implementar el codigo de produccion, verificar que los tests pasan:
 
 ```bash
-export JAVA_HOME="/c/Users/Administrator/.jdks/temurin-21.0.7" && \
-  ./gradlew :app:composeApp:testDebugUnitTest 2>&1 | tail -50
+.pipeline/scripts-android/android-test.sh
 ```
 
 **Esperado:** todos los tests deben PASAR. Si alguno falla, corregir la implementacion (no los tests).
@@ -287,20 +285,16 @@ export JAVA_HOME="/c/Users/Administrator/.jdks/temurin-21.0.7" && \
 ## Paso 7: Verificar build completo
 
 ```bash
-export JAVA_HOME="/c/Users/Administrator/.jdks/temurin-21.0.7" && \
-  ./gradlew :app:composeApp:build 2>&1 | tail -80
+.pipeline/scripts-android/android-build-verify.sh
+```
 
-export JAVA_HOME="/c/Users/Administrator/.jdks/temurin-21.0.7" && \
-  ./gradlew :app:composeApp:testDebugUnitTest 2>&1 | tail -50
+Corre los 5 gates en secuencia (build, tests, no-legacy-strings,
+validate-resources, ascii-fallbacks) y resume cada uno. Exit no-cero si
+alguno falla.
 
-export JAVA_HOME="/c/Users/Administrator/.jdks/temurin-21.0.7" && \
-  ./gradlew verifyNoLegacyStrings 2>&1 | tail -30
-
-export JAVA_HOME="/c/Users/Administrator/.jdks/temurin-21.0.7" && \
-  ./gradlew :app:composeApp:validateComposeResources 2>&1 | tail -30
-
-export JAVA_HOME="/c/Users/Administrator/.jdks/temurin-21.0.7" && \
-  ./gradlew :app:composeApp:scanNonAsciiFallbacks 2>&1 | tail -30
+Para instalar el APK en el emulador conectado:
+```bash
+.pipeline/scripts-android/android-install-apk.sh <client|business|delivery>
 ```
 
 ## Paso 8: Reporte

--- a/.pipeline/scripts-android/android-build-verify.sh
+++ b/.pipeline/scripts-android/android-build-verify.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Uso: android-build-verify.sh
+# Ejecuta el ciclo completo de verificacion del Paso 7 del SKILL del agente
+# /android-dev: build + tests + verifyNoLegacyStrings + validateComposeResources
+# + scanNonAsciiFallbacks. Resume cada gate y exit no-cero si alguno falla.
+
+set -uo pipefail
+
+export JAVA_HOME="${JAVA_HOME:-/c/Users/Administrator/.jdks/temurin-21.0.7}"
+
+cd "$(dirname "$0")/../.."
+
+run_gate() {
+  local label="$1"
+  local task="$2"
+  echo "=== ${label} ==="
+  if ./gradlew "$task" --no-daemon 2>&1 | tail -30; then
+    echo "[OK] ${label}"
+    return 0
+  else
+    echo "[FAIL] ${label}"
+    return 1
+  fi
+}
+
+declare -i FAILED=0
+
+run_gate "build"                ":app:composeApp:build"                  || FAILED+=1
+run_gate "tests"                ":app:composeApp:testDebugUnitTest"      || FAILED+=1
+run_gate "no-legacy-strings"    "verifyNoLegacyStrings"                  || FAILED+=1
+run_gate "validate-resources"   ":app:composeApp:validateComposeResources" || FAILED+=1
+run_gate "ascii-fallbacks"      ":app:composeApp:scanNonAsciiFallbacks"  || FAILED+=1
+
+echo
+echo "----"
+if (( FAILED == 0 )); then
+  echo "Resultado: 5/5 gates OK"
+  exit 0
+else
+  echo "Resultado: ${FAILED}/5 gates FALLARON"
+  exit 1
+fi

--- a/.pipeline/scripts-android/android-install-apk.sh
+++ b/.pipeline/scripts-android/android-install-apk.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Uso: android-install-apk.sh <flavor>   # flavor: client | business | delivery
+# Construye e instala el APK debug del flavor en el emulador/device conectado.
+
+set -euo pipefail
+
+FLAVOR="${1:-}"
+case "$FLAVOR" in
+  client|business|delivery) ;;
+  *) echo "Uso: $0 <client|business|delivery>" >&2; exit 2 ;;
+esac
+
+export JAVA_HOME="${JAVA_HOME:-/c/Users/Administrator/.jdks/temurin-21.0.7}"
+
+cd "$(dirname "$0")/../.."
+
+# Capitaliza primera letra para gradle task: client -> Client
+GRADLE_FLAVOR="$(echo "${FLAVOR:0:1}" | tr '[:lower:]' '[:upper:]')${FLAVOR:1}"
+
+echo "=== assemble${GRADLE_FLAVOR}Debug ==="
+./gradlew ":app:composeApp:assemble${GRADLE_FLAVOR}Debug" --no-daemon 2>&1 | tail -10
+
+APK="$(find app/composeApp/build/outputs/apk/${FLAVOR}/debug -name '*.apk' | head -1)"
+if [[ -z "$APK" ]]; then
+  echo "[FAIL] No se encontro APK en app/composeApp/build/outputs/apk/${FLAVOR}/debug" >&2
+  exit 1
+fi
+
+echo "=== adb install $APK ==="
+adb install -r "$APK"

--- a/.pipeline/scripts-android/android-test.sh
+++ b/.pipeline/scripts-android/android-test.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Uso: android-test.sh
+# Corre los tests unitarios de :app:composeApp:testDebugUnitTest y resume.
+# Reemplaza la invocacion repetitiva en SKILL.md (Pasos 4.2 y 6).
+
+set -uo pipefail
+
+export JAVA_HOME="${JAVA_HOME:-/c/Users/Administrator/.jdks/temurin-21.0.7}"
+
+cd "$(dirname "$0")/../.."
+
+OUT="$(./gradlew :app:composeApp:testDebugUnitTest --no-daemon 2>&1)"
+RC=$?
+
+echo "$OUT" | tail -50
+echo
+echo "----"
+PASSED=$(echo "$OUT" | grep -oE '[0-9]+ tests? completed' | head -1 || echo "")
+FAILED=$(echo "$OUT" | grep -oE '[0-9]+ failed' | head -1 || echo "0 failed")
+echo "Resultado: ${PASSED:-?} | ${FAILED}"
+echo "Exit: $RC"
+exit $RC


### PR DESCRIPTION
## Summary

- Crea \`.pipeline/scripts-android/\` con 3 scripts: \`android-test.sh\`, \`android-build-verify.sh\`, \`android-install-apk.sh\`.
- Reemplaza las invocaciones inline de gradle en \`.claude/skills/android-dev/SKILL.md\` (Pasos 4.2, 6 y 7) por una sola linea por script.
- Reduce cache_read y tool calls Bash del agente \`/android-dev\` por sesion.

## Test plan

- [x] Scripts ejecutables (\`chmod +x\`) y con shebang \`bash\`.
- [x] \`android-build-verify.sh\` exit no-cero si cualquier gate falla.
- [x] SKILL.md sigue siendo coherente con flujo TDD (Red \xe2\x86\x92 Green).
- [ ] Validacion real: proxima sesion de \`/android-dev\` consume el script.

\`qa:skipped\` justificacion: cambio puro de infra del agente, no toca codigo del producto.

Closes #2938