### PR TITLE
perf(backend-dev): bajar modelo de Opus 4.6 a Sonnet 4.6 (#2942)

### DIFF
--- a/.claude/skills/backend-dev/SKILL.md
+++ b/.claude/skills/backend-dev/SKILL.md
@@ -3,7 +3,7 @@ description: BackendDev — Desarrollo backend Ktor, microservicios, DynamoDB, C
 user-invocable: true
 argument-hint: "<issue-o-tarea> [--plan] [--test]"
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, TaskCreate, TaskUpdate, TaskList
-model: claude-opus-4-6
+model: claude-sonnet-4-6
 ---
 
 # /backend-dev — BackendDev


### PR DESCRIPTION
## Resumen
- Cambia el modelo de `/backend-dev` de `claude-opus-4-6` a `claude-sonnet-4-6`.
- Alineado con qa, security, pipeline-dev, android-dev, po, ux, guru, planner.

## Cambios técnicos
- `.claude/skills/backend-dev/SKILL.md` línea 6: frontmatter `model` actualizado.

## Justificación qa:skipped
Cambio de configuración interna del agente, sin runtime ni superficie de usuario afectada. Mismo patrón que #2940 (android-dev).

Closes #2942