### PR TITLE
feat(backend-dev): scripts deterministicos para mecanica de gradle/openapi (#2943)

### DIFF
--- a/.claude/skills/backend-dev/SKILL.md
+++ b/.claude/skills/backend-dev/SKILL.md
@@ -51,6 +51,10 @@ Antes de empezar, creá las tareas con `TaskCreate` mapeando los pasos del plan.
 Antes de escribir una línea de código, leer la spec OpenAPI para identificar el contrato del endpoint a implementar o modificar.
 
 ```bash
+# Endpoint puntual (recomendado, menos tokens):
+bash .pipeline/scripts-backend/openapi-show-endpoint.sh /signin
+
+# Spec completa (cuando el cambio toca varios endpoints):
 cat docs/api/openapi.yaml
 ```
 
@@ -74,8 +78,7 @@ Buscar en la spec:
 ## Paso 1: Setup del entorno
 
 ```bash
-export JAVA_HOME="/c/Users/Administrator/.jdks/temurin-21.0.7"
-export PATH="/c/Workspaces/gh-cli/bin:$PATH"
+source .pipeline/scripts-backend/backend-env.sh
 ```
 
 ## Paso 2: Entender el contexto
@@ -138,8 +141,9 @@ class MiFunctionTest {
 ### 4.2 Verificar que los tests FALLAN (Red Phase)
 
 ```bash
-export JAVA_HOME="/c/Users/Administrator/.jdks/temurin-21.0.7" && \
-  ./gradlew :backend:test 2>&1 | tail -30
+bash .pipeline/scripts-backend/backend-test.sh
+# Si la tarea toca el modulo :users:
+bash .pipeline/scripts-backend/users-test.sh
 ```
 
 **Esperado:** los tests deben FALLAR con errores de compilacion o de ejecucion (clases no existen aun).
@@ -193,8 +197,9 @@ El `statusCode` SIEMPRE debe incluir valor numérico y descripción.
 Despues de implementar el codigo de produccion, verificar que los tests pasan:
 
 ```bash
-export JAVA_HOME="/c/Users/Administrator/.jdks/temurin-21.0.7" && \
-  ./gradlew :backend:test 2>&1 | tail -50
+bash .pipeline/scripts-backend/backend-test.sh
+# Si la tarea toca el modulo :users:
+bash .pipeline/scripts-backend/users-test.sh
 ```
 
 **Esperado:** todos los tests deben PASAR. Si alguno falla, corregir la implementacion (no los tests).
@@ -208,8 +213,14 @@ export JAVA_HOME="/c/Users/Administrator/.jdks/temurin-21.0.7" && \
 ## Paso 7: Verificar build completo
 
 ```bash
-export JAVA_HOME="/c/Users/Administrator/.jdks/temurin-21.0.7" && \
-  ./gradlew :backend:build 2>&1 | tail -50
+# Ciclo completo (tests :backend + tests :users + build :backend):
+bash .pipeline/scripts-backend/backend-verify.sh
+
+# Solo build (cuando los tests ya pasaron en Paso 6):
+bash .pipeline/scripts-backend/backend-build.sh
+
+# Lambda artifact (cuando el cambio se deploya a AWS):
+bash .pipeline/scripts-backend/users-shadow-jar.sh
 ```
 
 Si el build falla, leer el error, corregir y volver a intentar hasta que pase.

--- a/.pipeline/scripts-backend/backend-build.sh
+++ b/.pipeline/scripts-backend/backend-build.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Uso: backend-build.sh
+# Corre :backend:build con setup de JAVA_HOME y resume el resultado.
+# Reemplaza la invocacion repetitiva del SKILL del agente /backend-dev (Paso 7).
+
+set -uo pipefail
+
+export JAVA_HOME="${JAVA_HOME:-/c/Users/Administrator/.jdks/temurin-21.0.7}"
+
+cd "$(dirname "$0")/../.."
+
+OUT="$(./gradlew :backend:build --no-daemon 2>&1)"
+RC=$?
+
+echo "$OUT" | tail -50
+echo
+echo "----"
+if (( RC == 0 )); then
+  echo "Resultado: build OK"
+else
+  echo "Resultado: build FALLO"
+fi
+echo "Exit: $RC"
+exit $RC

--- a/.pipeline/scripts-backend/backend-env.sh
+++ b/.pipeline/scripts-backend/backend-env.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Uso: source .pipeline/scripts-backend/backend-env.sh
+# Setup de JAVA_HOME y PATH para el agente /backend-dev.
+# Reemplaza el bloque de exports del Paso 1 del SKILL.
+
+export JAVA_HOME="${JAVA_HOME:-/c/Users/Administrator/.jdks/temurin-21.0.7}"
+export PATH="/c/Workspaces/gh-cli/bin:${PATH}"

--- a/.pipeline/scripts-backend/backend-test.sh
+++ b/.pipeline/scripts-backend/backend-test.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Uso: backend-test.sh
+# Corre :backend:test con setup de JAVA_HOME y resume el resultado.
+# Reemplaza la invocacion repetitiva del SKILL del agente /backend-dev (Pasos 4.2 y 6).
+
+set -uo pipefail
+
+export JAVA_HOME="${JAVA_HOME:-/c/Users/Administrator/.jdks/temurin-21.0.7}"
+
+cd "$(dirname "$0")/../.."
+
+OUT="$(./gradlew :backend:test --no-daemon 2>&1)"
+RC=$?
+
+echo "$OUT" | tail -50
+echo
+echo "----"
+PASSED=$(echo "$OUT" | grep -oE '[0-9]+ tests? completed' | head -1 || echo "")
+FAILED=$(echo "$OUT" | grep -oE '[0-9]+ failed' | head -1 || echo "0 failed")
+echo "Resultado: ${PASSED:-?} | ${FAILED}"
+echo "Exit: $RC"
+exit $RC

--- a/.pipeline/scripts-backend/backend-verify.sh
+++ b/.pipeline/scripts-backend/backend-verify.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Uso: backend-verify.sh
+# Ejecuta el ciclo de verificacion del Paso 7 del agente /backend-dev:
+# tests de :backend, tests de :users (si existen tests cambiados o el issue
+# toca el modulo) y build completo de :backend. Resume cada gate.
+
+set -uo pipefail
+
+export JAVA_HOME="${JAVA_HOME:-/c/Users/Administrator/.jdks/temurin-21.0.7}"
+
+cd "$(dirname "$0")/../.."
+
+run_gate() {
+  local label="$1"
+  local task="$2"
+  echo "=== ${label} ==="
+  if ./gradlew "$task" --no-daemon 2>&1 | tail -30; then
+    echo "[OK] ${label}"
+    return 0
+  else
+    echo "[FAIL] ${label}"
+    return 1
+  fi
+}
+
+declare -i FAILED=0
+declare -i TOTAL=0
+
+TOTAL+=1; run_gate "backend-tests" ":backend:test"  || FAILED+=1
+TOTAL+=1; run_gate "users-tests"   ":users:test"    || FAILED+=1
+TOTAL+=1; run_gate "backend-build" ":backend:build" || FAILED+=1
+
+echo
+echo "----"
+if (( FAILED == 0 )); then
+  echo "Resultado: ${TOTAL}/${TOTAL} gates OK"
+  exit 0
+else
+  echo "Resultado: ${FAILED}/${TOTAL} gates FALLARON"
+  exit 1
+fi

--- a/.pipeline/scripts-backend/openapi-show-endpoint.sh
+++ b/.pipeline/scripts-backend/openapi-show-endpoint.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Uso: openapi-show-endpoint.sh <path-or-substring>
+# Extrae solo el fragmento del endpoint relevante de docs/api/openapi.yaml en
+# vez de imprimir el archivo completo. Util cuando el issue afecta a un
+# endpoint puntual y el agente solo necesita el contrato de ese path.
+#
+# Ejemplos:
+#   openapi-show-endpoint.sh /signin
+#   openapi-show-endpoint.sh profile
+
+set -uo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "Uso: $0 <path-or-substring>" >&2
+  exit 2
+fi
+
+NEEDLE="$1"
+
+cd "$(dirname "$0")/../.."
+
+SPEC="docs/api/openapi.yaml"
+if [[ ! -f "$SPEC" ]]; then
+  echo "ERROR: spec OpenAPI no encontrada en ${SPEC}" >&2
+  exit 1
+fi
+
+# Encuentra el numero de linea del path que matchea el needle dentro de la
+# seccion paths:. Imprime desde esa linea hasta el siguiente path (o EOF).
+LINE=$(awk -v n="$NEEDLE" '
+  /^paths:/ { in_paths=1; next }
+  in_paths && /^[a-zA-Z]/ && !/^  / { in_paths=0 }
+  in_paths && /^  \// && index($0, n) { print NR; exit }
+' "$SPEC")
+
+if [[ -z "$LINE" ]]; then
+  echo "ERROR: no se encontro endpoint con substring '${NEEDLE}' en ${SPEC}" >&2
+  echo "Endpoints disponibles:"
+  awk '/^paths:/{p=1;next} p && /^[a-zA-Z]/ && !/^  /{p=0} p && /^  \//{print "  "$1}' "$SPEC" | sort -u
+  exit 1
+fi
+
+# Imprime desde la linea encontrada hasta el siguiente endpoint (linea que empieza con dos espacios + slash) o el siguiente top-level.
+awk -v start="$LINE" '
+  NR < start { next }
+  NR == start { print; in_block=1; next }
+  in_block && /^  \// { exit }
+  in_block && /^[a-zA-Z]/ && !/^  / { exit }
+  in_block { print }
+' "$SPEC"

--- a/.pipeline/scripts-backend/users-shadow-jar.sh
+++ b/.pipeline/scripts-backend/users-shadow-jar.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Uso: users-shadow-jar.sh
+# Genera el JAR para AWS Lambda del modulo :users.
+# El artefacto sale en users/build/libs/users-all.jar y CI lo deploya a la Lambda kotlinTest.
+
+set -uo pipefail
+
+export JAVA_HOME="${JAVA_HOME:-/c/Users/Administrator/.jdks/temurin-21.0.7}"
+
+cd "$(dirname "$0")/../.."
+
+OUT="$(./gradlew :users:shadowJar --no-daemon 2>&1)"
+RC=$?
+
+echo "$OUT" | tail -30
+echo
+echo "----"
+JAR="users/build/libs/users-all.jar"
+if [[ -f "$JAR" ]]; then
+  SIZE=$(du -h "$JAR" | awk '{print $1}')
+  echo "Resultado: ${JAR} (${SIZE})"
+else
+  echo "Resultado: shadow jar NO encontrado en ${JAR}"
+fi
+echo "Exit: $RC"
+exit $RC

--- a/.pipeline/scripts-backend/users-test.sh
+++ b/.pipeline/scripts-backend/users-test.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Uso: users-test.sh
+# Corre :users:test con setup de JAVA_HOME y resume el resultado.
+# Cuando el issue toca el modulo :users (autenticacion, perfiles, 2FA).
+
+set -uo pipefail
+
+export JAVA_HOME="${JAVA_HOME:-/c/Users/Administrator/.jdks/temurin-21.0.7}"
+
+cd "$(dirname "$0")/../.."
+
+OUT="$(./gradlew :users:test --no-daemon 2>&1)"
+RC=$?
+
+echo "$OUT" | tail -50
+echo
+echo "----"
+PASSED=$(echo "$OUT" | grep -oE '[0-9]+ tests? completed' | head -1 || echo "")
+FAILED=$(echo "$OUT" | grep -oE '[0-9]+ failed' | head -1 || echo "0 failed")
+echo "Resultado: ${PASSED:-?} | ${FAILED}"
+echo "Exit: $RC"
+exit $RC


### PR DESCRIPTION
## Resumen
- Crea `.pipeline/scripts-backend/` con 7 scripts shell para la mecánica repetitiva del agente `/backend-dev`.
- Reemplaza bloques bash inline del SKILL por invocaciones de una línea.
- Mismo patrón que scripts-pipeline, scripts-qa, scripts-security, scripts-android.

## Scripts creados

| Script | Reemplaza |
|---|---|
| `backend-env.sh` | Setup JAVA_HOME + PATH (Paso 1) |
| `backend-test.sh` | `./gradlew :backend:test` con setup y tail (Pasos 4.2, 6) |
| `users-test.sh` | `./gradlew :users:test` cuando toca módulo `:users` |
| `backend-build.sh` | `./gradlew :backend:build` (Paso 7) |
| `users-shadow-jar.sh` | `./gradlew :users:shadowJar` (Lambda artifact) |
| `openapi-show-endpoint.sh <path>` | Extrae solo el fragmento del endpoint en `docs/api/openapi.yaml` |
| `backend-verify.sh` | Corre los 3 gates (test backend + test users + build) con resumen |

## Cambios en SKILL.md

- Paso 0 (OpenAPI): añade opción de extraer solo el endpoint puntual.
- Paso 1 (Setup): `source .pipeline/scripts-backend/backend-env.sh`.
- Paso 4.2 / Paso 6: `bash backend-test.sh` / `bash users-test.sh`.
- Paso 7: `bash backend-verify.sh` o `backend-build.sh` o `users-shadow-jar.sh`.

## Justificación qa:skipped
Cambio de scripts internos del pipeline + sustitución de bloques bash en SKILL del agente. Sin runtime ni superficie de usuario afectada.

Closes #2943