### PR TITLE
perf(web-dev): bajar modelo de Opus 4.6 a Sonnet 4.6 (#2948)

### DIFF
--- a/.claude/skills/web-dev/SKILL.md
+++ b/.claude/skills/web-dev/SKILL.md
@@ -3,7 +3,7 @@ description: WebDev — Desarrollo web con Kotlin/Wasm, PWA, Webpack y browser A
 user-invocable: true
 argument-hint: "<issue-o-tarea> [--plan] [--test]"
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, TaskCreate, TaskUpdate, TaskList
-model: claude-opus-4-6
+model: claude-sonnet-4-6
 ---
 
 # /web-dev — WebDev


### PR DESCRIPTION
## Resumen

Aplica al `/web-dev` la misma palanca ya validada en `/android-dev` (#2940) y `/backend-dev` (#2945) sin regresiones.

**Cambio:** `model: claude-opus-4-6` → `claude-sonnet-4-6` en `.claude/skills/web-dev/SKILL.md`.

## Por qué Sonnet 4.6 alcanza para el dev

1. **Trabajo del dev = 80% mecánica conocida**: scaffolding, copy/paste de patrones, edits chicos sobre arquitectura ya definida.
2. **La decisión arquitectónica fuerte la toma `/refinar`** (Opus 4.6 sigue ahí). El dev recibe el issue con criterios claros, archivos a tocar, patrón a seguir.
3. **Scripts deterministicos** (#2949) sacan otro 20-30% de razonamiento del LLM.
4. **Doctrina larga sale del SKILL** (#2950) — Sonnet 4.6 no se satura intentando absorber 287 líneas de filosofía cada vez.

## Salvaguarda

Si en algún issue concreto Sonnet 4.6 produce código de menor calidad, se puede revertir el modelo solo para ese caso. Telemetría de calidad disponible en `/cost` y `/scrum`.

## Test plan

- [ ] Próximo issue `/web-dev` corre con Sonnet 4.6
- [ ] Cobertura de tests no baja
- [ ] Métrica de tokens/sesión refleja el ahorro esperado (~70%)

Closes #2948

🤖 Generated with [Claude Code](https://claude.com/claude-code)