### PR TITLE
feat(web-dev): scripts deterministicos para mecanica de gradle/webpack/wasm (#2949)

### DIFF
--- a/.pipeline/scripts-web/web-build.sh
+++ b/.pipeline/scripts-web/web-build.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Uso: web-build.sh
+# Corre :app:composeApp:wasmJsBrowserDevelopmentWebpack con setup de JAVA_HOME
+# y resume el resultado. Reemplaza la invocacion repetitiva del Paso 6 del
+# SKILL del agente /web-dev (build de target Wasm).
+
+set -uo pipefail
+
+export JAVA_HOME="${JAVA_HOME:-/c/Users/Administrator/.jdks/temurin-21.0.7}"
+
+cd "$(dirname "$0")/../.."
+
+OUT="$(./gradlew :app:composeApp:wasmJsBrowserDevelopmentWebpack --no-daemon 2>&1)"
+RC=$?
+
+echo "$OUT" | tail -50
+echo
+echo "----"
+if (( RC == 0 )); then
+  echo "Resultado: build Wasm OK"
+else
+  echo "Resultado: build Wasm FALLO"
+fi
+echo "Exit: $RC"
+exit $RC

--- a/.pipeline/scripts-web/web-bundle-size.sh
+++ b/.pipeline/scripts-web/web-bundle-size.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Uso: web-bundle-size.sh
+# Reporta el tamanio del bundle Wasm generado (composeApp.js + .wasm).
+# Util para validar performance budgets (Addy Osmani / Alex Russell).
+
+set -uo pipefail
+
+export JAVA_HOME="${JAVA_HOME:-/c/Users/Administrator/.jdks/temurin-21.0.7}"
+
+cd "$(dirname "$0")/../.."
+
+DIST="app/composeApp/build/dist/wasmJs/developmentExecutable"
+
+if [[ ! -d "$DIST" ]]; then
+  echo "Bundle no encontrado en $DIST"
+  echo "Ejecuta primero: .pipeline/scripts-web/web-build.sh"
+  exit 1
+fi
+
+echo "=== Bundle Wasm — $DIST ==="
+echo
+ls -lh "$DIST" | awk 'NR>1 {printf "  %-50s %s\n", $NF, $5}'
+echo
+TOTAL=$(du -sb "$DIST" 2>/dev/null | awk '{print $1}')
+TOTAL_KB=$((TOTAL / 1024))
+TOTAL_MB=$((TOTAL_KB / 1024))
+echo "----"
+echo "Total: ${TOTAL_KB} KB (${TOTAL_MB} MB)"
+echo
+echo "Performance budget orientativo (development build):"
+echo "  - Wasm + JS combinado < 5 MB: aceptable en dev"
+echo "  - Production build con shrinking deberia bajar significativamente"

--- a/.pipeline/scripts-web/web-dev-run.sh
+++ b/.pipeline/scripts-web/web-dev-run.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Uso: web-dev-run.sh
+# Levanta el target Wasm en modo development con webpack-dev-server.
+# Reemplaza la invocacion repetitiva del Paso 6 del SKILL del agente /web-dev
+# (probar localmente en el navegador).
+
+set -uo pipefail
+
+export JAVA_HOME="${JAVA_HOME:-/c/Users/Administrator/.jdks/temurin-21.0.7}"
+
+cd "$(dirname "$0")/../.."
+
+echo "Levantando dev server Wasm en http://localhost:8080 (Ctrl+C para detener)"
+echo "----"
+exec ./gradlew :app:composeApp:wasmJsBrowserDevelopmentRun --no-daemon

--- a/.pipeline/scripts-web/web-env.sh
+++ b/.pipeline/scripts-web/web-env.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Uso: source .pipeline/scripts-web/web-env.sh
+# Setup de JAVA_HOME y PATH para el agente /web-dev.
+# Reemplaza el bloque de exports del Paso 1 del SKILL.
+
+export JAVA_HOME="${JAVA_HOME:-/c/Users/Administrator/.jdks/temurin-21.0.7}"
+export PATH="/c/Workspaces/gh-cli/bin:${PATH}"

--- a/.pipeline/scripts-web/web-test.sh
+++ b/.pipeline/scripts-web/web-test.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Uso: web-test.sh
+# Corre los tests del :app:composeApp (commonTest aplica tambien a Wasm).
+# Reemplaza la invocacion repetitiva del Paso 5 del SKILL del agente /web-dev.
+
+set -uo pipefail
+
+export JAVA_HOME="${JAVA_HOME:-/c/Users/Administrator/.jdks/temurin-21.0.7}"
+
+cd "$(dirname "$0")/../.."
+
+OUT="$(./gradlew :app:composeApp:allTests --no-daemon 2>&1)"
+RC=$?
+
+echo "$OUT" | tail -50
+echo
+echo "----"
+if (( RC == 0 )); then
+  echo "Resultado: tests OK"
+else
+  echo "Resultado: tests FALLARON"
+fi
+echo "Exit: $RC"
+exit $RC

--- a/.pipeline/scripts-web/web-verify.sh
+++ b/.pipeline/scripts-web/web-verify.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Uso: web-verify.sh
+# Ejecuta el ciclo de verificacion del Paso 6 del agente /web-dev:
+# build Wasm, verifyNoLegacyStrings, validateComposeResources y
+# scanNonAsciiFallbacks. Resume cada gate.
+
+set -uo pipefail
+
+export JAVA_HOME="${JAVA_HOME:-/c/Users/Administrator/.jdks/temurin-21.0.7}"
+
+cd "$(dirname "$0")/../.."
+
+run_gate() {
+  local label="$1"
+  local task="$2"
+  echo "=== ${label} ==="
+  if ./gradlew "$task" --no-daemon 2>&1 | tail -30; then
+    echo "[OK] ${label}"
+    return 0
+  else
+    echo "[FAIL] ${label}"
+    return 1
+  fi
+}
+
+declare -i FAILED=0
+declare -i TOTAL=0
+
+TOTAL+=1; run_gate "wasm-webpack"           ":app:composeApp:wasmJsBrowserDevelopmentWebpack" || FAILED+=1
+TOTAL+=1; run_gate "verify-no-legacy-strs"  "verifyNoLegacyStrings"                           || FAILED+=1
+TOTAL+=1; run_gate "validate-resources"     ":app:composeApp:validateComposeResources"        || FAILED+=1
+TOTAL+=1; run_gate "scan-ascii-fallbacks"   ":app:composeApp:scanNonAsciiFallbacks"           || FAILED+=1
+
+echo
+echo "----"
+if (( FAILED == 0 )); then
+  echo "Resultado: ${TOTAL}/${TOTAL} gates OK"
+  exit 0
+else
+  echo "Resultado: ${FAILED}/${TOTAL} gates FALLARON"
+  exit 1
+fi


### PR DESCRIPTION
## Resumen

Reemplaza la mecánica repetitiva de bash que el agente `/web-dev` hacía inline en su SKILL (Pasos 1, 5, 6) por scripts deterministicos en `.pipeline/scripts-web/`.

Mismo patrón aplicado en `/backend-dev` (#2946) y `/android-dev` (#2938).

## Scripts creados

| Script | Reemplaza |
|---|---|
| `web-env.sh` | `export JAVA_HOME=...` + `export PATH=...gh-cli...` (Paso 1) |
| `web-build.sh` | `./gradlew :app:composeApp:wasmJsBrowserDevelopmentWebpack` (Paso 6) |
| `web-test.sh` | `./gradlew :app:composeApp:allTests` (Paso 5) |
| `web-verify.sh` | Ciclo completo: build Wasm + verifyNoLegacyStrings + validateComposeResources + scanNonAsciiFallbacks (Paso 6) |
| `web-dev-run.sh` | `./gradlew :app:composeApp:wasmJsBrowserDevelopmentRun` (Paso 6, prueba local) |
| `web-bundle-size.sh` | Reporte de tamaño del bundle Wasm (validar performance budget — Addy Osmani) |

## Por qué importa

- **Saca razonamiento mecánico del LLM**: Sonnet 4.6 (#2948) puede ahora invocar `bash .pipeline/scripts-web/web-verify.sh` en una línea, en vez de armar exports + gradle wrapper + tail + run-gate logic.
- **Determinismo**: el script siempre hace lo mismo, sin variaciones por interpretación del modelo.
- **Combo con #2950 + #2948**: doctrina afuera + modelo más liviano + scripts deterministicos = ~70% ahorro estimado por sesión.

## Test plan

- [ ] `bash .pipeline/scripts-web/web-env.sh` — exporta variables OK
- [ ] `bash .pipeline/scripts-web/web-build.sh` — build Wasm OK
- [ ] `bash .pipeline/scripts-web/web-verify.sh` — 4/4 gates OK
- [ ] `bash .pipeline/scripts-web/web-bundle-size.sh` — reporta tamaño post-build

Closes #2949

🤖 Generated with [Claude Code](https://claude.com/claude-code)