### PR TITLE
fix(pipeline): pausa parcial filtra cola QA/Build por allowlist (#2957)

### DIFF
--- a/.pipeline/lib/__tests__/partial-pause.test.js
+++ b/.pipeline/lib/__tests__/partial-pause.test.js
@@ -159,3 +159,47 @@ test('isIssueAllowed(null|undefined|"abc") retorna false sin error', () => {
     assert.equal(pp.isIssueAllowed(undefined), false);
     assert.equal(pp.isIssueAllowed('abc'), false);
 });
+
+// ----- isIssueAllowedInState (#2957) ------------------------------------------
+//
+// La variante "in state" no toca filesystem: recibe el estado ya leído. Permite
+// a callers que iteran muchos issues en un mismo tick (counters de cola)
+// reutilizar la misma decisión sin pagar IO por elemento.
+
+test('isIssueAllowedInState — modo running deja pasar todo', () => {
+    const state = { mode: 'running', allowedIssues: [] };
+    assert.equal(pp.isIssueAllowedInState(2490, state), true);
+    assert.equal(pp.isIssueAllowedInState('#9999', state), true);
+});
+
+test('isIssueAllowedInState — modo paused bloquea todo', () => {
+    const state = { mode: 'paused', allowedIssues: [] };
+    assert.equal(pp.isIssueAllowedInState(2490, state), false);
+    assert.equal(pp.isIssueAllowedInState('#9999', state), false);
+});
+
+test('isIssueAllowedInState — modo partial_pause respeta allowlist', () => {
+    const state = { mode: 'partial_pause', allowedIssues: [2891] };
+    assert.equal(pp.isIssueAllowedInState(2891, state), true);
+    assert.equal(pp.isIssueAllowedInState('2891', state), true);
+    assert.equal(pp.isIssueAllowedInState('#2891', state), true);
+    // Issues fuera del allowlist (caso del bug #2957: contadores incluían estos)
+    assert.equal(pp.isIssueAllowedInState(2892, state), false);
+    assert.equal(pp.isIssueAllowedInState(2893, state), false);
+    assert.equal(pp.isIssueAllowedInState(2914, state), false);
+});
+
+test('isIssueAllowedInState — entradas inválidas no rompen', () => {
+    const state = { mode: 'partial_pause', allowedIssues: [2891] };
+    assert.equal(pp.isIssueAllowedInState(null, state), false);
+    assert.equal(pp.isIssueAllowedInState(undefined, state), false);
+    assert.equal(pp.isIssueAllowedInState('abc', state), false);
+    // state inválido también es seguro
+    assert.equal(pp.isIssueAllowedInState(2891, null), false);
+    assert.equal(pp.isIssueAllowedInState(2891, {}), false);
+});
+
+test('isIssueAllowedInState — partial_pause con allowedIssues no-array es seguro', () => {
+    const state = { mode: 'partial_pause' };
+    assert.equal(pp.isIssueAllowedInState(2891, state), false);
+});

--- a/.pipeline/lib/partial-pause.js
+++ b/.pipeline/lib/partial-pause.js
@@ -108,12 +108,26 @@ function getPipelineMode() {
  * @returns {boolean}
  */
 function isIssueAllowed(issue) {
+    return isIssueAllowedInState(issue, getPipelineMode());
+}
+
+/**
+ * Variante pura de `isIssueAllowed` que recibe el estado ya leído (#2957).
+ *
+ * Pensada para callers que iteran muchos issues en un mismo tick (counters
+ * de cola, reconciler) y no quieren pagar el costo de releer el filesystem
+ * por cada uno. La política es la misma que `isIssueAllowed`.
+ *
+ * @param {number|string} issue
+ * @param {ReturnType<typeof getPipelineMode>} state
+ * @returns {boolean}
+ */
+function isIssueAllowedInState(issue, state) {
     const n = normalizeIssue(issue);
     if (!n) return false;
-    const state = getPipelineMode();
-    if (state.mode === 'paused') return false;
+    if (!state || state.mode === 'paused') return false;
     if (state.mode === 'running') return true;
-    return state.allowedIssues.includes(n);
+    return Array.isArray(state.allowedIssues) && state.allowedIssues.includes(n);
 }
 
 /**
@@ -194,6 +208,7 @@ function resumeAll() {
 module.exports = {
     getPipelineMode,
     isIssueAllowed,
+    isIssueAllowedInState,
     setPartialPause,
     clearPartialPause,
     resumeAll,

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -1763,8 +1763,14 @@ function readManualPriorityOverrides() {
 
 /**
  * Contar issues pendientes en fase verificación (todas las pipelines).
+ *
+ * En modo `partial_pause`, filtra los issues fuera del allowlist: la cola
+ * "lógica" excluye lo que la pausa parcial nunca va a dejar lanzar (#2957).
+ * Acepta `pipelineState` por override para tests.
  */
-function countPendingVerificacion(config) {
+function countPendingVerificacion(config, overrides = {}) {
+  const state = overrides.pipelineState || partialPause.getPipelineMode();
+  const filterByAllowlist = state && state.mode === 'partial_pause';
   let count = 0;
   for (const [pName, pConfig] of Object.entries(config.pipelines)) {
     if (!pConfig.fases.includes('verificacion')) continue;
@@ -1772,6 +1778,7 @@ function countPendingVerificacion(config) {
     const files = listWorkFiles(pendDir);
     for (const f of files) {
       const issue = issueFromFile(f.name);
+      if (filterByAllowlist && !partialPause.isIssueAllowedInState(issue, state)) continue;
       const labels = getIssueLabels(issue);
       if (!labels.includes('blocked:dependencies')) count++;
     }
@@ -1959,8 +1966,13 @@ function evaluateQaPriority(config, overrides = {}) {
 
 /**
  * Contar issues pendientes en fase build (todas las pipelines).
+ *
+ * En modo `partial_pause`, filtra los issues fuera del allowlist (#2957).
+ * Acepta `pipelineState` por override para tests.
  */
-function countPendingBuild(config) {
+function countPendingBuild(config, overrides = {}) {
+  const state = overrides.pipelineState || partialPause.getPipelineMode();
+  const filterByAllowlist = state && state.mode === 'partial_pause';
   let count = 0;
   for (const [pName, pConfig] of Object.entries(config.pipelines)) {
     if (!pConfig.fases.includes('build')) continue;
@@ -1968,6 +1980,7 @@ function countPendingBuild(config) {
     const files = listWorkFiles(pendDir);
     for (const f of files) {
       const issue = issueFromFile(f.name);
+      if (filterByAllowlist && !partialPause.isIssueAllowedInState(issue, state)) continue;
       const labels = getIssueLabels(issue);
       if (!labels.includes('blocked:dependencies')) count++;
     }
@@ -7635,6 +7648,8 @@ if (process.env.PULPO_NO_AUTOSTART === '1') {
     _setBuildPriorityState: (active, manual) => { buildPriorityActive = active; buildPriorityManual = manual || false; },
     // #2893 — resolver de script determinístico (preferencia worktree-first).
     resolveDeterministicScript,
+    // #2957 — counter de fase build expuesto para tests del filtro por allowlist.
+    countPendingBuild,
   };
   return; // No arrancar singleton ni mainLoop
 }


### PR DESCRIPTION
## Resumen

Fix del bug reportado el 2026-05-04: durante el arranque progresivo de la cola con `partial_pause` allowlist `[2891]`, el pipeline notificó por Telegram "3 en cola esperando QA" pese a que ningún issue del allowlist podía estar en esa fase. El contador estaba incluyendo issues que la pausa parcial filtra antes de lanzar.

Mismo bug aplicaba a `countPendingBuild` (gemelo de QA).

## Cambios

- **`lib/partial-pause.js`** — nuevo helper puro `isIssueAllowedInState(issue, state)`. La variante "in state" no toca filesystem: recibe el estado ya leído. Permite a callers que iteran muchos issues en un mismo tick (counters de cola, reconciler) reutilizar la misma decisión sin pagar IO por elemento.
- **`pulpo.js`** — `countPendingVerificacion` y `countPendingBuild` ahora consultan ese helper para excluir issues fuera del allowlist cuando estamos en `partial_pause`. La guardia ya existente en `evaluateQaPriority`/`evaluateBuildPriority` queda como cinturón + tirantes.
- **Tests** — 5 casos nuevos en `partial-pause.test.js` cubren modos `running`/`paused`/`partial_pause`, allowlist `[2891]` con issues fuera (caso del bug), y defensas contra entradas inválidas (null, allowedIssues no-array, state vacío).

## Verificación

```
node --test .pipeline/lib/__tests__/partial-pause.test.js     → 20 pass / 0 fail
node --test .pipeline/tests/qa-priority-window.test.js        → 17 pass / 0 fail
node --test .pipeline/tests/partial-pause-deps.test.js        → 28 pass / 0 fail
```

## Por qué `qa:skipped`

Cambio puro de infra del pipeline (`area:infra` en el issue). No toca producto de usuario, no afecta runtime de Android/Backend. La validación funcional natural es despausar el pipeline con el fix activo y observar que los contadores ya no notifican "N en cola" cuando los pendings están fuera del allowlist.

Closes #2957