### PR TITLE
[Pipeline] Reconciler GitHub re-aplica labels stale después de destrabe manual (race condition)

### DIFF
--- a/.pipeline/__tests__/servicio-github.test.js
+++ b/.pipeline/__tests__/servicio-github.test.js
@@ -1,0 +1,276 @@
+// =============================================================================
+// CA4 (#2994) — E2E test del worker servicio-github.js
+//
+// Reproduce el incidente del 2026-05-05: el reconciler encola una orden de
+// label `needs-human` con metadata (marker_path/snapshot_at/marker_mtime),
+// pero antes de que el worker la procese, el humano destraba el issue
+// moviendo el marker a `pendiente/`. El worker DEBE detectar que la orden
+// está stale y descartarla SIN invocar `gh` — caso contrario re-bloquearía
+// un issue que ya está destrabado.
+//
+// Estrategia para evitar la CLI de `gh` real: stub via `GH_BIN_OVERRIDE`. El
+// stub es un script Node.js cross-platform que registra cada invocación en
+// un archivo plano; los tests luego inspeccionan ese archivo para verificar
+// que el worker invocó (caso happy) o NO invocó (casos stale) a `gh`.
+//
+// El override `PIPELINE_STATE_DIR` hace que todo el FS del worker apunte a
+// un directorio temporal — no toca el `.pipeline/` real.
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+// Setup: directorio temporal aislado + stub de `gh` antes del require del
+// servicio. Las constantes del módulo (PENDIENTE, LISTO, GH_BIN, etc.) se
+// resuelven una sola vez al cargarse, así que es crítico setear el env
+// PRIMERO.
+const TMP_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'svc-gh-e2e-'));
+const PIPELINE = path.join(TMP_DIR, '.pipeline');
+const QUEUE_BASE = path.join(PIPELINE, 'servicios', 'github');
+const PENDIENTE = path.join(QUEUE_BASE, 'pendiente');
+const TRABAJANDO = path.join(QUEUE_BASE, 'trabajando');
+const LISTO = path.join(QUEUE_BASE, 'listo');
+const FALLIDO = path.join(QUEUE_BASE, 'fallido');
+const LOG_DIR = path.join(PIPELINE, 'logs');
+for (const d of [PENDIENTE, TRABAJANDO, LISTO, FALLIDO, LOG_DIR]) {
+    fs.mkdirSync(d, { recursive: true });
+}
+
+// Stub de `gh`: un script Node que escribe argv + cwd a un archivo y sale 0.
+// El worker invoca con `execSync("<GH_BIN>" issue edit ...)` — para que el
+// shell encuentre node.exe interpretando el script lo más portable es
+// usar el shebang nativo en POSIX, pero en Windows execSync usa cmd.exe
+// que NO respeta shebangs. Solución: el override apunta a un .cmd que
+// reenvía a node con un .js helper.
+const STUB_DIR = path.join(TMP_DIR, 'stub-gh');
+fs.mkdirSync(STUB_DIR, { recursive: true });
+const GH_CALLS_LOG = path.join(STUB_DIR, 'gh-calls.log');
+const STUB_JS = path.join(STUB_DIR, 'gh-stub.js');
+fs.writeFileSync(STUB_JS, `
+// Registra cada invocación con argv y exit 0.
+const fs = require('fs');
+const path = require('path');
+const line = JSON.stringify({ ts: Date.now(), argv: process.argv.slice(2) }) + '\\n';
+fs.appendFileSync(${JSON.stringify(GH_CALLS_LOG)}, line);
+process.exit(0);
+`, 'utf8');
+
+// Wrapper .cmd para Windows. En POSIX usaríamos un .sh, pero los tests
+// se ejecutan principalmente en Windows según el entorno del proyecto.
+// execSync usa cmd.exe en Windows así que .cmd funciona; en POSIX caería
+// a sh que no entiende .cmd, así que damos también una variante .sh.
+const STUB_CMD = path.join(STUB_DIR, 'gh.cmd');
+fs.writeFileSync(STUB_CMD,
+    `@echo off\r\nnode "${STUB_JS}" %*\r\n`,
+    'utf8');
+const STUB_SH = path.join(STUB_DIR, 'gh');
+fs.writeFileSync(STUB_SH,
+    `#!/bin/sh\nexec node "${STUB_JS}" "$@"\n`,
+    'utf8');
+try { fs.chmodSync(STUB_SH, 0o755); } catch {}
+
+// El override que lee servicio-github.js es `GH_BIN_OVERRIDE`; en Windows
+// preferimos el .cmd para que execSync(cmd.exe) lo resuelva. El test usa
+// `process.platform` para elegir.
+const STUB_BIN = process.platform === 'win32' ? STUB_CMD : STUB_SH;
+
+process.env.PIPELINE_STATE_DIR = PIPELINE;
+process.env.PIPELINE_MAIN_ROOT = TMP_DIR;
+process.env.GH_BIN_OVERRIDE = STUB_BIN;
+
+// Cargar el servicio DESPUÉS de setear los envs.
+delete require.cache[require.resolve('../servicio-github')];
+const svc = require('../servicio-github');
+
+function clearGhCalls() {
+    try { fs.unlinkSync(GH_CALLS_LOG); } catch {}
+}
+
+function getGhCalls() {
+    try { return fs.readFileSync(GH_CALLS_LOG, 'utf8').split('\n').filter(Boolean).map(l => JSON.parse(l)); }
+    catch { return []; }
+}
+
+function clearQueues() {
+    for (const dir of [PENDIENTE, TRABAJANDO, LISTO, FALLIDO]) {
+        for (const f of fs.readdirSync(dir)) {
+            try { fs.unlinkSync(path.join(dir, f)); } catch {}
+        }
+    }
+}
+
+function clearStaleLog() {
+    try { fs.unlinkSync(path.join(LOG_DIR, 'stale-orders.log')); } catch {}
+}
+
+function readStaleLog() {
+    try {
+        return fs.readFileSync(path.join(LOG_DIR, 'stale-orders.log'), 'utf8')
+            .split('\n').filter(Boolean).map(l => JSON.parse(l));
+    } catch { return []; }
+}
+
+function createMarker(issue, skill, phase = 'dev', pipeline = 'desarrollo') {
+    const dir = path.join(PIPELINE, pipeline, phase, 'bloqueado-humano');
+    fs.mkdirSync(dir, { recursive: true });
+    const file = path.join(dir, `${issue}.${skill}`);
+    fs.writeFileSync(file, '');
+    fs.writeFileSync(file + '.reason.json', JSON.stringify({
+        issue, skill, phase, pipeline,
+        reason: 'test', question: 'test',
+        blocked_at: new Date().toISOString(),
+    }));
+    return file;
+}
+
+function enqueueLabelOrder(issue, label, meta) {
+    const filename = `${issue}-${label}-test-${Date.now()}-${Math.random()}.json`;
+    const filepath = path.join(PENDIENTE, filename);
+    const payload = { action: 'label', issue, label, ...(meta || {}) };
+    fs.writeFileSync(filepath, JSON.stringify(payload));
+    return filename;
+}
+
+function findResultFile(issue, label) {
+    // El servicio mueve el JSON a `listo/` con el mismo nombre original.
+    for (const f of fs.readdirSync(LISTO)) {
+        if (f.startsWith(`${issue}-${label}-`)) {
+            return JSON.parse(fs.readFileSync(path.join(LISTO, f), 'utf8'));
+        }
+    }
+    return null;
+}
+
+// ---------------------------------------------------------------------------
+// CA4: el escenario completo del incidente del 2026-05-05.
+// ---------------------------------------------------------------------------
+test('CA4: orden con marker_path stale (marker movido a pendiente/) NO invoca gh', () => {
+    clearQueues(); clearGhCalls(); clearStaleLog();
+
+    // 1. Crear marker en bloqueado-humano/ (estado inicial)
+    const markerPath = createMarker(2975, 'guru');
+    const markerMtime = fs.statSync(markerPath).mtimeMs;
+
+    // 2. Encolar orden con metadata snapshot
+    enqueueLabelOrder(2975, 'needs-human', {
+        marker_path: markerPath,
+        snapshot_at: new Date().toISOString(),
+        marker_mtime: markerMtime,
+    });
+
+    // 3. Humano destraba: mover marker a pendiente/
+    const pendDir = path.join(PIPELINE, 'desarrollo', 'dev', 'pendiente');
+    fs.mkdirSync(pendDir, { recursive: true });
+    fs.renameSync(markerPath, path.join(pendDir, '2975.guru'));
+
+    // 4. Worker procesa
+    svc.processQueue();
+
+    // 5. Verificar: gh NO fue invocado
+    const calls = getGhCalls();
+    assert.equal(calls.length, 0, `gh NO debe invocarse para órdenes stale (calls=${JSON.stringify(calls)})`);
+
+    // 6. JSON en listo/ con discarded
+    const result = findResultFile(2975, 'needs-human');
+    assert.ok(result, 'orden debe quedar en listo/');
+    assert.equal(result.discarded, 'stale-marker-missing');
+
+    // 7. Log de stale-orders contiene la entrada
+    const log = readStaleLog();
+    assert.equal(log.length, 1, 'una entrada en stale-orders.log');
+    assert.equal(log[0].reason, 'stale-marker-missing');
+    assert.equal(log[0].issue, 2975);
+    assert.equal(log[0].label, 'needs-human');
+});
+
+test('CA1: marker presente con mtime intacto → orden ejecuta normal', () => {
+    clearQueues(); clearGhCalls(); clearStaleLog();
+
+    const markerPath = createMarker(8001, 'po');
+    const markerMtime = fs.statSync(markerPath).mtimeMs;
+    enqueueLabelOrder(8001, 'needs-human', {
+        marker_path: markerPath,
+        snapshot_at: new Date().toISOString(),
+        marker_mtime: markerMtime,
+    });
+
+    svc.processQueue();
+
+    const calls = getGhCalls();
+    // Esperamos al menos 2 invocaciones: `gh label list` (refreshLabelCache)
+    // + `gh issue edit ... --add-label`. Si la cache ya está warm, podría
+    // ser solo 1.
+    const editCall = calls.find(c => c.argv.includes('edit') && c.argv.some(a => a === '--add-label'));
+    assert.ok(editCall, `gh edit debe invocarse con --add-label (calls=${JSON.stringify(calls)})`);
+    assert.ok(editCall.argv.some(a => String(a) === '8001'), 'debe incluir el issue 8001');
+
+    const result = findResultFile(8001, 'needs-human');
+    assert.ok(result, 'orden debe quedar en listo/');
+    assert.equal(result.discarded, undefined, 'no debe estar marcada como descartada');
+});
+
+test('CA2: marker presente pero mtime posterior al snapshot → discarded stale-mtime', () => {
+    clearQueues(); clearGhCalls(); clearStaleLog();
+
+    const markerPath = createMarker(7002, 'ux');
+    // Snapshot ANTES de tocar el marker
+    const snapshotMtime = fs.statSync(markerPath).mtimeMs;
+    enqueueLabelOrder(7002, 'needs-human', {
+        marker_path: markerPath,
+        snapshot_at: new Date().toISOString(),
+        marker_mtime: snapshotMtime,
+    });
+
+    // Humano toca el marker (escribe algo, regenera mtime)
+    const futureMs = Date.now() + 10000;
+    fs.utimesSync(markerPath, new Date(futureMs), new Date(futureMs));
+
+    svc.processQueue();
+
+    const calls = getGhCalls().filter(c => c.argv.includes('edit'));
+    assert.equal(calls.length, 0, 'gh edit NO debe invocarse cuando mtime cambió');
+
+    const result = findResultFile(7002, 'needs-human');
+    assert.equal(result.discarded, 'stale-mtime');
+
+    const log = readStaleLog();
+    const entry = log.find(e => e.issue === 7002);
+    assert.ok(entry, 'log debe tener entrada para 7002');
+    assert.equal(entry.reason, 'stale-mtime');
+    assert.ok(typeof entry.current_mtime === 'number', 'debe persistir current_mtime');
+});
+
+test('Backward-compat: orden sin meta (legacy) ejecuta sin guardia', () => {
+    clearQueues(); clearGhCalls(); clearStaleLog();
+
+    // Orden sin marker_path/marker_mtime — shape clásico pre-#2994
+    const filename = `6500-needs-human-legacy-${Date.now()}.json`;
+    fs.writeFileSync(
+        path.join(PENDIENTE, filename),
+        JSON.stringify({ action: 'label', issue: 6500, label: 'needs-human' }),
+    );
+
+    svc.processQueue();
+
+    const editCall = getGhCalls().find(c => c.argv.includes('edit'));
+    assert.ok(editCall, 'orden legacy SIN meta debe ejecutar normalmente');
+    const result = JSON.parse(fs.readFileSync(path.join(LISTO, filename), 'utf8'));
+    assert.equal(result.discarded, undefined);
+});
+
+test('validateOrderFresh: API directa', () => {
+    // Orden sin meta → null (sin guardia)
+    assert.equal(svc.validateOrderFresh({ action: 'label', issue: 1, label: 'x' }), null);
+    // Orden con meta y marker_path inexistente → stale-marker-missing
+    const r1 = svc.validateOrderFresh({
+        action: 'label', issue: 1, label: 'x',
+        marker_path: path.join(TMP_DIR, 'inexistente-' + Date.now()),
+    });
+    assert.deepEqual(r1, { reason: 'stale-marker-missing', current_mtime: null });
+    // Acción que no es label → null (no aplica guardia)
+    assert.equal(svc.validateOrderFresh({ action: 'comment', issue: 1, body: 'x', marker_path: '/x' }), null);
+});

--- a/.pipeline/lib/__tests__/reconciler-stale-orders-slice.test.js
+++ b/.pipeline/lib/__tests__/reconciler-stale-orders-slice.test.js
@@ -1,0 +1,106 @@
+// =============================================================================
+// CA5 (#2994) — Slice del dashboard que cuenta órdenes stale en últimas 24h.
+//
+// Verifica:
+//   - Sin archivo de log → totales en 0 (no rompe el dashboard).
+//   - Con eventos viejos (>24h) → no se cuentan.
+//   - Con eventos recientes → total + breakdown por reason.
+//   - Líneas inválidas (JSON corrupto) se ignoran sin tirar el slice.
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+// Setup ANTES del require para que el slice resuelva PIPELINE_STATE_DIR.
+const TMP_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'slice-stale-'));
+const PIPELINE = path.join(TMP_DIR, '.pipeline');
+const LOG_DIR = path.join(PIPELINE, 'logs');
+fs.mkdirSync(LOG_DIR, { recursive: true });
+process.env.PIPELINE_STATE_DIR = PIPELINE;
+
+const slices = require('../dashboard-slices');
+
+const LOG_FILE = path.join(LOG_DIR, 'stale-orders.log');
+const STATE = {}; // El slice no usa state, pero la firma lo recibe.
+const CTX = { PIPELINE };
+
+function clearLog() {
+    try { fs.unlinkSync(LOG_FILE); } catch {}
+}
+
+function writeLog(events) {
+    const lines = events.map(e => JSON.stringify(e)).join('\n') + '\n';
+    fs.writeFileSync(LOG_FILE, lines);
+}
+
+function appendLog(events) {
+    const lines = events.map(e => JSON.stringify(e)).join('\n') + '\n';
+    fs.appendFileSync(LOG_FILE, lines);
+}
+
+test('#2994 slice sin archivo → totales en 0', () => {
+    clearLog();
+    const r = slices.reconcilerStaleOrdersSlice(STATE, CTX);
+    assert.equal(r.total_24h, 0);
+    assert.deepEqual(r.by_reason, {});
+    assert.ok(/^\d{4}-/.test(r.updated_at));
+});
+
+test('#2994 slice cuenta eventos recientes y desglosa por reason', () => {
+    clearLog();
+    const now = new Date();
+    writeLog([
+        { ts: now.toISOString(), reason: 'stale-marker-missing', issue: 1, label: 'needs-human' },
+        { ts: now.toISOString(), reason: 'stale-marker-missing', issue: 2, label: 'needs-human' },
+        { ts: now.toISOString(), reason: 'stale-mtime', issue: 3, label: 'needs-human' },
+        { ts: now.toISOString(), reason: 'human-unblock-detected', issue: 4, label: 'needs-human' },
+    ]);
+    const r = slices.reconcilerStaleOrdersSlice(STATE, CTX);
+    assert.equal(r.total_24h, 4);
+    assert.equal(r.by_reason['stale-marker-missing'], 2);
+    assert.equal(r.by_reason['stale-mtime'], 1);
+    assert.equal(r.by_reason['human-unblock-detected'], 1);
+});
+
+test('#2994 slice ignora eventos más viejos que 24h', () => {
+    clearLog();
+    const old = new Date(Date.now() - 25 * 3600 * 1000).toISOString();
+    const now = new Date().toISOString();
+    writeLog([
+        { ts: old, reason: 'stale-marker-missing', issue: 1 },
+        { ts: old, reason: 'stale-mtime', issue: 2 },
+        { ts: now, reason: 'stale-marker-missing', issue: 3 },
+    ]);
+    const r = slices.reconcilerStaleOrdersSlice(STATE, CTX);
+    assert.equal(r.total_24h, 1, 'solo el evento de hoy entra');
+    assert.equal(r.by_reason['stale-marker-missing'], 1);
+});
+
+test('#2994 slice tolera líneas corruptas', () => {
+    clearLog();
+    const now = new Date().toISOString();
+    fs.writeFileSync(LOG_FILE,
+        'esto-no-es-json\n' +
+        JSON.stringify({ ts: now, reason: 'stale-mtime', issue: 1 }) + '\n' +
+        '{partial json\n' +
+        JSON.stringify({ ts: now, reason: 'stale-mtime', issue: 2 }) + '\n'
+    );
+    const r = slices.reconcilerStaleOrdersSlice(STATE, CTX);
+    assert.equal(r.total_24h, 2);
+    assert.equal(r.by_reason['stale-mtime'], 2);
+});
+
+test('#2994 slice ignora eventos sin ts válido', () => {
+    clearLog();
+    writeLog([
+        { reason: 'stale-mtime', issue: 1 }, // sin ts
+        { ts: 'not-a-date', reason: 'stale-mtime', issue: 2 },
+        { ts: new Date().toISOString(), reason: 'stale-mtime', issue: 3 },
+    ]);
+    const r = slices.reconcilerStaleOrdersSlice(STATE, CTX);
+    assert.equal(r.total_24h, 1);
+});

--- a/.pipeline/lib/__tests__/servicio-reconciler.test.js
+++ b/.pipeline/lib/__tests__/servicio-reconciler.test.js
@@ -193,3 +193,154 @@ test('enqueueLabelApply genera JSON con shape correcto', () => {
     const cmd = JSON.parse(fs.readFileSync(path.join(GH_QUEUE, files[0]), 'utf8'));
     assert.deepEqual(cmd, { action: 'label', issue: 1234, label: 'needs-human' });
 });
+
+// =============================================================================
+// #2994 — CA1/CA2: enqueueLabelApply persiste metadata + reconcileMarkerToLabel
+// la pasa para que el worker pueda hacer guardia idempotente.
+// =============================================================================
+
+test('#2994 enqueueLabelApply persiste meta opcional (marker_path/snapshot_at/mtime)', () => {
+    clearGhQueue();
+    const meta = {
+        marker_path: '/tmp/fake-marker',
+        snapshot_at: '2026-05-05T19:30:00Z',
+        marker_mtime: 1714935000000.5,
+    };
+    reconciler.enqueueLabelApply(5555, 'needs-human', meta);
+    const files = fs.readdirSync(GH_QUEUE).filter(f => f.endsWith('.json'));
+    const cmd = JSON.parse(fs.readFileSync(path.join(GH_QUEUE, files[0]), 'utf8'));
+    assert.equal(cmd.marker_path, '/tmp/fake-marker');
+    assert.equal(cmd.snapshot_at, '2026-05-05T19:30:00Z');
+    assert.equal(cmd.marker_mtime, 1714935000000.5);
+});
+
+test('#2994 enqueueLabelApply ignora meta no-objeto (backward-compat)', () => {
+    clearGhQueue();
+    reconciler.enqueueLabelApply(5556, 'needs-human', null);
+    const files = fs.readdirSync(GH_QUEUE).filter(f => f.endsWith('.json'));
+    const cmd = JSON.parse(fs.readFileSync(path.join(GH_QUEUE, files[0]), 'utf8'));
+    // Sin meta → shape clásico exacto, sin campos extra.
+    assert.deepEqual(cmd, { action: 'label', issue: 5556, label: 'needs-human' });
+});
+
+test('#2994 reconcileMarkerToLabel persiste marker_path/mtime de cada marker', () => {
+    clearAllMarkers();
+    clearGhQueue();
+    const dir = path.join(PIPELINE, 'desarrollo', 'validacion', 'bloqueado-humano');
+    const markerFile = path.join(dir, '8800.po');
+    fs.writeFileSync(markerFile, '');
+    fs.writeFileSync(markerFile + '.reason.json', '{}');
+
+    const markers = [{ issue: 8800, skill: 'po', phase: 'validacion', pipeline: 'desarrollo' }];
+    const enqueued = reconciler.reconcileMarkerToLabel(markers, new Set(), () => 'OPEN');
+    assert.equal(enqueued, 1);
+
+    const files = fs.readdirSync(GH_QUEUE).filter(f => f.endsWith('.json'));
+    const cmd = JSON.parse(fs.readFileSync(path.join(GH_QUEUE, files[0]), 'utf8'));
+    assert.equal(cmd.marker_path, markerFile);
+    assert.ok(typeof cmd.marker_mtime === 'number' && cmd.marker_mtime > 0);
+    assert.ok(typeof cmd.snapshot_at === 'string' && /^\d{4}-/.test(cmd.snapshot_at));
+});
+
+// =============================================================================
+// #2994 — CA3: reconcileHumanUnblockDetected detecta destrabe humano y mueve
+// el marker fuera de bloqueado-humano/ siguiendo a GitHub como autoritativo.
+// =============================================================================
+
+test('#2994 CA3 detecta destrabe humano: label ausente + blocked_at viejo + no svc-reconciler', () => {
+    clearAllMarkers();
+    const dir = path.join(PIPELINE, 'desarrollo', 'validacion', 'bloqueado-humano');
+    const pendDir = path.join(PIPELINE, 'desarrollo', 'validacion', 'pendiente');
+    fs.mkdirSync(pendDir, { recursive: true });
+    const markerFile = path.join(dir, '4400.po');
+    fs.writeFileSync(markerFile, '');
+    // blocked_at hace 5 min — bien fuera de la ventana de gracia (60s)
+    const oldTs = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+    fs.writeFileSync(markerFile + '.reason.json', JSON.stringify({
+        issue: 4400, skill: 'po', phase: 'validacion', pipeline: 'desarrollo',
+        blocked_at: oldTs, blocked_by: 'po', // skill original, NO reconciler
+    }));
+
+    const markers = [{ issue: 4400, skill: 'po', phase: 'validacion', pipeline: 'desarrollo' }];
+    const ghIssueSet = new Set([]); // label NO está en GitHub
+    const result = reconciler.reconcileHumanUnblockDetected(markers, ghIssueSet);
+
+    assert.equal(result.detected, 1);
+    assert.equal(result.movedIssues.has(4400), true);
+    assert.equal(fs.existsSync(markerFile), false, 'marker debe haberse movido');
+    assert.equal(fs.existsSync(path.join(pendDir, '4400.po')), true, 'marker debe estar en pendiente/');
+    assert.equal(fs.existsSync(markerFile + '.reason.json'), false, 'reason.json eliminado');
+});
+
+test('#2994 CA3 NO destraba placeholders del propio reconciler (blocked_by=svc-reconciler)', () => {
+    clearAllMarkers();
+    const dir = path.join(PIPELINE, 'desarrollo', 'validacion', 'bloqueado-humano');
+    const markerFile = path.join(dir, '4401.guru');
+    fs.writeFileSync(markerFile, '');
+    const oldTs = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+    fs.writeFileSync(markerFile + '.reason.json', JSON.stringify({
+        issue: 4401, skill: 'guru', phase: 'validacion', pipeline: 'desarrollo',
+        blocked_at: oldTs, blocked_by: 'svc-reconciler',
+    }));
+
+    const markers = [{ issue: 4401, skill: 'guru', phase: 'validacion', pipeline: 'desarrollo' }];
+    const result = reconciler.reconcileHumanUnblockDetected(markers, new Set([]));
+    assert.equal(result.detected, 0);
+    assert.equal(fs.existsSync(markerFile), true, 'placeholder propio NO debe moverse');
+});
+
+test('#2994 CA3 respeta ventana de gracia de 60s (blocked_at reciente)', () => {
+    clearAllMarkers();
+    const dir = path.join(PIPELINE, 'desarrollo', 'validacion', 'bloqueado-humano');
+    const markerFile = path.join(dir, '4402.po');
+    fs.writeFileSync(markerFile, '');
+    const recentTs = new Date(Date.now() - 10 * 1000).toISOString(); // 10s atrás
+    fs.writeFileSync(markerFile + '.reason.json', JSON.stringify({
+        issue: 4402, skill: 'po', phase: 'validacion', pipeline: 'desarrollo',
+        blocked_at: recentTs, blocked_by: 'po',
+    }));
+
+    const markers = [{ issue: 4402, skill: 'po', phase: 'validacion', pipeline: 'desarrollo' }];
+    const result = reconciler.reconcileHumanUnblockDetected(markers, new Set([]));
+    assert.equal(result.detected, 0);
+    assert.equal(fs.existsSync(markerFile), true, 'marker fresco NO debe destrabarse');
+});
+
+test('#2994 CA3 no toca markers cuyo label sí está en GitHub', () => {
+    clearAllMarkers();
+    const dir = path.join(PIPELINE, 'desarrollo', 'validacion', 'bloqueado-humano');
+    const markerFile = path.join(dir, '4403.po');
+    fs.writeFileSync(markerFile, '');
+    fs.writeFileSync(markerFile + '.reason.json', JSON.stringify({
+        issue: 4403, blocked_at: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+        blocked_by: 'po',
+    }));
+    const markers = [{ issue: 4403, skill: 'po', phase: 'validacion', pipeline: 'desarrollo' }];
+    const result = reconciler.reconcileHumanUnblockDetected(markers, new Set([4403]));
+    assert.equal(result.detected, 0);
+});
+
+// =============================================================================
+// #2994 — CA5: appendStaleOrderLog escribe JSONL en logs/stale-orders.log
+// =============================================================================
+
+test('#2994 CA5 appendStaleOrderLog persiste línea JSONL', () => {
+    const logFile = path.join(PIPELINE, 'logs', 'stale-orders.log');
+    try { fs.unlinkSync(logFile); } catch {}
+    reconciler.appendStaleOrderLog({
+        reason: 'stale-mtime',
+        issue: 9999,
+        label: 'needs-human',
+        snapshot_at: '2026-05-05T19:30:00Z',
+        current_mtime: 12345.67,
+        detail: 'test',
+    });
+    const raw = fs.readFileSync(logFile, 'utf8').trim();
+    const ev = JSON.parse(raw);
+    assert.equal(ev.reason, 'stale-mtime');
+    assert.equal(ev.issue, 9999);
+    assert.equal(ev.label, 'needs-human');
+    assert.equal(ev.current_mtime, 12345.67);
+    assert.equal(ev.snapshot_at, '2026-05-05T19:30:00Z');
+    assert.ok(/^\d{4}-/.test(ev.ts));
+});

--- a/.pipeline/lib/dashboard-routes.js
+++ b/.pipeline/lib/dashboard-routes.js
@@ -28,6 +28,8 @@
 //   GET /api/dash/bloqueados          {bloqueados:[]}
 //   GET /api/dash/ops                 {procesos, servicios, ...}
 //   GET /api/dash/historial           {actividad:[]}
+//   GET /api/dash/reconciler-stale-orders        {total_24h, by_reason}
+//   GET /api/diagnostico/reconciler-stale-orders {total_24h, by_reason}  (alias)
 
 'use strict';
 
@@ -76,6 +78,13 @@ const API_ROUTES = {
     // #2976 — banner amarillo de cuota Anthropic agotada (modo determinístico).
     // Polling natural del dashboard cubre aparición/desaparición sin reload.
     '/api/dash/quota-exhausted': (state) => slices.quotaExhaustedSlice(state),
+    // #2994 — Contador de órdenes del reconciler descartadas por stale.
+    // Mismo handler bajo dos paths: el `/api/dash/*` sigue la convención del
+    // dashboard kiosk y `/api/diagnostico/*` es el alias documentado en CA5
+    // para que humanos puedan consultarlo con `curl` sin acordarse del
+    // namespace interno.
+    '/api/dash/reconciler-stale-orders': (state, ctx) => slices.reconcilerStaleOrdersSlice(state, ctx),
+    '/api/diagnostico/reconciler-stale-orders': (state, ctx) => slices.reconcilerStaleOrdersSlice(state, ctx),
 };
 
 function sendJson(res, payload, status = 200) {

--- a/.pipeline/lib/dashboard-slices.js
+++ b/.pipeline/lib/dashboard-slices.js
@@ -713,6 +713,61 @@ function quotaExhaustedSlice(state) {
     };
 }
 
+// =============================================================================
+// #2994 — reconcilerStaleOrdersSlice: contador de órdenes descartadas por stale.
+//
+// El servicio-github.js + servicio-reconciler.js escriben una línea JSONL en
+// `.pipeline/logs/stale-orders.log` cada vez que se descarta una orden por
+// alguno de estos motivos:
+//
+//   - stale-marker-missing   (worker: marker_path ya no existe)
+//   - stale-mtime            (worker: marker_mtime cambió desde snapshot)
+//   - human-unblock-detected (reconciler: detectó destrabe humano y movió marker)
+//
+// Este slice lee el log, filtra eventos de las últimas 24h y devuelve total +
+// breakdown. El dashboard lo muestra en el tab Ops bajo "Reconciler health".
+//
+// Performance: lectura streaming-friendly de un archivo append-only. Cap a
+// las últimas N líneas para no leer un log que crece sin bound. En operación
+// normal el descarte es esporádico (≈ 1-5 por día), así que 5000 líneas
+// cubren ~3 años de log sin problema.
+// =============================================================================
+const STALE_ORDERS_LOG_NAME = 'stale-orders.log';
+const STALE_ORDERS_MAX_LINES = 5000;
+
+function reconcilerStaleOrdersSlice(state, ctx) {
+    const PIPELINE = (ctx && ctx.PIPELINE) || process.env.PIPELINE_STATE_DIR;
+    if (!PIPELINE) {
+        return { total_24h: 0, by_reason: {}, updated_at: new Date().toISOString() };
+    }
+    const logPath = path.join(PIPELINE, 'logs', STALE_ORDERS_LOG_NAME);
+    let raw;
+    try { raw = fs.readFileSync(logPath, 'utf8'); }
+    catch { return { total_24h: 0, by_reason: {}, updated_at: new Date().toISOString() }; }
+
+    const lines = raw.split(/\r?\n/).filter(Boolean);
+    // Tomar solo las últimas N líneas — el archivo es append-only y nunca
+    // queremos parsear más de eso por request del dashboard.
+    const tail = lines.slice(-STALE_ORDERS_MAX_LINES);
+    const cutoff = Date.now() - 24 * 3600 * 1000;
+    const byReason = {};
+    let total = 0;
+    for (const line of tail) {
+        let ev;
+        try { ev = JSON.parse(line); } catch { continue; }
+        const ts = ev.ts ? Date.parse(ev.ts) : NaN;
+        if (!Number.isFinite(ts) || ts < cutoff) continue;
+        const reason = String(ev.reason || 'unknown');
+        byReason[reason] = (byReason[reason] || 0) + 1;
+        total++;
+    }
+    return {
+        total_24h: total,
+        by_reason: byReason,
+        updated_at: new Date().toISOString(),
+    };
+}
+
 module.exports = {
     activeAgents,
     recentlyFinished,
@@ -726,6 +781,7 @@ module.exports = {
     historialSlice,
     quotaSlice,
     quotaExhaustedSlice,
+    reconcilerStaleOrdersSlice,
     // #2894 — exports internos para testing
     _resolveDevSkillFromLabels: resolveDevSkillFromLabels,
     _buildAgentsForActiveFase: buildAgentsForActiveFase,

--- a/.pipeline/servicio-github.js
+++ b/.pipeline/servicio-github.js
@@ -18,7 +18,9 @@ const { sanitize } = require('./sanitizer');
 const { sanitizeGithubPayload } = require('./lib/sanitize-payload');
 
 const ROOT = process.env.PIPELINE_MAIN_ROOT || path.resolve(__dirname, '..');
-const GH_BIN = 'C:\\Workspaces\\gh-cli\\bin\\gh.exe';
+// #2994 — `GH_BIN_OVERRIDE` permite a los tests E2E de la cola apuntar a un
+// stub de `gh` en disco sin tocar el sistema. En producción se ignora.
+const GH_BIN = process.env.GH_BIN_OVERRIDE || 'C:\\Workspaces\\gh-cli\\bin\\gh.exe';
 const PIPELINE = process.env.PIPELINE_STATE_DIR || path.resolve(__dirname);
 const QUEUE_DIR = path.join(PIPELINE, 'servicios', 'github');
 const PENDIENTE = path.join(QUEUE_DIR, 'pendiente');
@@ -27,6 +29,7 @@ const LISTO = path.join(QUEUE_DIR, 'listo');
 const FALLIDO = path.join(QUEUE_DIR, 'fallido');
 const MAX_RETRIES = 3;
 const LOG_DIR = path.join(PIPELINE, 'logs');
+const STALE_ORDERS_LOG = path.join(LOG_DIR, 'stale-orders.log');
 
 function log(msg) {
   const ts = new Date().toISOString().replace('T', ' ').slice(0, 19);
@@ -236,6 +239,62 @@ function ensureLabels(labelsStr) {
   }
 }
 
+// =============================================================================
+// #2994 — Guardia idempotente contra órdenes stale (TOCTOU mitigation)
+// =============================================================================
+//
+// El reconciler encola órdenes basadas en un snapshot del FS. Entre el
+// snapshot y la ejecución, alguien (humano destrabando, /unblock automático)
+// puede haber cambiado el estado. Si re-aplicamos el label sobre un issue
+// que ya fue destrabado, lo re-bloqueamos sin justificación (incidente
+// 2026-05-05 con #2975).
+//
+// La guardia se aplica SOLO a órdenes con metadata. Órdenes legacy sin
+// `marker_path`/`marker_mtime` ejecutan SIN guardia (degradado seguro,
+// comportamiento idéntico al pre-deploy).
+//
+// Devuelve `null` si la orden está fresca (ejecutar normalmente) o un
+// objeto `{reason, current_mtime}` describiendo por qué descartar.
+function validateOrderFresh(data) {
+    if (!data || data.action !== 'label') return null;
+    if (!data.marker_path) return null; // sin metadata = legacy / sin guardia
+
+    if (!fs.existsSync(data.marker_path)) {
+        return { reason: 'stale-marker-missing', current_mtime: null };
+    }
+    if (typeof data.marker_mtime === 'number') {
+        let currentMtime;
+        try { currentMtime = fs.statSync(data.marker_path).mtimeMs; }
+        catch { return { reason: 'stale-marker-missing', current_mtime: null }; }
+        // Tolerancia mínima: NTFS reporta mtimeMs en ms, pero filesystems
+        // remotos pueden tener ruido sub-ms. 5ms es suficientemente grande
+        // para absorber jitter sin enmascarar cambios reales (un destrabe
+        // humano modifica el inode y la diferencia es siempre >> 5ms).
+        if (currentMtime > data.marker_mtime + 5) {
+            return { reason: 'stale-mtime', current_mtime: currentMtime };
+        }
+    }
+    return null;
+}
+
+function logStaleOrder(entry) {
+    try {
+        fs.mkdirSync(LOG_DIR, { recursive: true });
+        const line = JSON.stringify({
+            ts: new Date().toISOString(),
+            reason: entry.reason || 'unknown',
+            issue: entry.issue || null,
+            label: entry.label || null,
+            snapshot_at: entry.snapshot_at || null,
+            current_mtime: entry.current_mtime ?? null,
+            detail: entry.detail || null,
+        }) + '\n';
+        fs.appendFileSync(STALE_ORDERS_LOG, line);
+    } catch {
+        // best-effort — no tirar el worker por un fallo de logging
+    }
+}
+
 // --- Procesamiento de cola ---
 function processQueue() {
   const files = listWorkFiles(PENDIENTE);
@@ -260,13 +319,35 @@ function processQueue() {
           log(`Comentario en #${data.issue}`);
           break;
 
-        case 'label':
+        case 'label': {
+          // #2994 — guardia idempotente: si la orden trae `marker_path`/
+          // `marker_mtime`, validar que el FS sigue justificándola antes
+          // de invocar `gh`. Si está stale, descartar + log + `discarded:`.
+          const stale = validateOrderFresh(data);
+          if (stale) {
+            data.discarded = stale.reason;
+            data.discarded_at = new Date().toISOString();
+            data.current_mtime = stale.current_mtime;
+            logStaleOrder({
+              reason: stale.reason,
+              issue: data.issue,
+              label: data.label,
+              snapshot_at: data.snapshot_at || null,
+              current_mtime: stale.current_mtime,
+              detail: data.marker_path,
+            });
+            log(`Orden stale descartada: #${data.issue} label=${data.label} reason=${stale.reason}`);
+            // Salir del switch sin invocar `gh`. El bloque común de abajo
+            // moverá el JSON a `listo/` con el campo `discarded` ya seteado.
+            break;
+          }
           ensureLabels(data.label);
           execSync(`"${GH_BIN}" issue edit ${data.issue} --add-label "${esc(data.label)}"`, {
             cwd: ROOT, encoding: 'utf8', timeout: 15000, windowsHide: true
           });
           log(`Label "${data.label}" → #${data.issue}`);
           break;
+        }
 
         case 'remove-label':
           execSync(`"${GH_BIN}" issue edit ${data.issue} --remove-label "${esc(data.label)}"`, {
@@ -361,23 +442,47 @@ function main() {
   }, 10000);
 }
 
-fs.writeFileSync(path.join(PIPELINE, 'svc-github.pid'), String(process.pid));
-process.on('SIGINT', () => process.exit(0));
-process.on('SIGTERM', () => process.exit(0));
+// #2994 — Side-effects de arranque (escritura del PID, signal/crash handlers)
+// SOLO cuando este archivo es el entrypoint. Si lo `require()` un test, no
+// queremos tocar el FS real ni registrar handlers contra el process global.
+function installSignalHandlers() {
+  fs.writeFileSync(path.join(PIPELINE, 'svc-github.pid'), String(process.pid));
+  process.on('SIGINT', () => process.exit(0));
+  process.on('SIGTERM', () => process.exit(0));
 
-// Crash handlers
-process.on('uncaughtException', (err) => {
-  // #2334: sanitizar antes de persistir stack a disco.
-  const msg = sanitize(`[${new Date().toISOString()}] [svc-github] CRASH uncaughtException: ${err.stack || err.message}\n`);
-  try { fs.appendFileSync(path.join(LOG_DIR, 'svc-github.log'), msg); } catch {}
-  console.error(msg);
-  process.exit(1);
-});
-process.on('unhandledRejection', (reason) => {
-  const msg = sanitize(`[${new Date().toISOString()}] [svc-github] CRASH unhandledRejection: ${reason?.stack || reason}\n`);
-  try { fs.appendFileSync(path.join(LOG_DIR, 'svc-github.log'), msg); } catch {}
-  console.error(msg);
-  process.exit(1);
-});
+  process.on('uncaughtException', (err) => {
+    // #2334: sanitizar antes de persistir stack a disco.
+    const msg = sanitize(`[${new Date().toISOString()}] [svc-github] CRASH uncaughtException: ${err.stack || err.message}\n`);
+    try { fs.appendFileSync(path.join(LOG_DIR, 'svc-github.log'), msg); } catch {}
+    console.error(msg);
+    process.exit(1);
+  });
+  process.on('unhandledRejection', (reason) => {
+    const msg = sanitize(`[${new Date().toISOString()}] [svc-github] CRASH unhandledRejection: ${reason?.stack || reason}\n`);
+    try { fs.appendFileSync(path.join(LOG_DIR, 'svc-github.log'), msg); } catch {}
+    console.error(msg);
+    process.exit(1);
+  });
+}
 
-main();
+// #2994 — Sólo arrancar el daemon cuando el archivo se ejecuta como entrypoint.
+// `require()` desde tests E2E debe poder llamar a `processQueue()` sin disparar
+// el setInterval/registrar handlers globales contra el FS real.
+if (require.main === module) {
+  installSignalHandlers();
+  main();
+}
+
+module.exports = {
+  processQueue,
+  validateOrderFresh,
+  logStaleOrder,
+  STALE_ORDERS_LOG,
+  // Constantes que los tests necesitan (resueltas a partir de PIPELINE_STATE_DIR
+  // si se setea antes del require).
+  PENDIENTE,
+  TRABAJANDO,
+  LISTO,
+  FALLIDO,
+  LOG_DIR,
+};

--- a/.pipeline/servicio-reconciler.js
+++ b/.pipeline/servicio-reconciler.js
@@ -80,12 +80,34 @@ function getIssueState(issueNum) {
     }
 }
 
-function enqueueLabelApply(issueNum, label) {
+// #2994 — `meta` opcional permite que el worker (servicio-github.js) re-valide
+// que el estado del FS sigue justificando esta orden antes de invocar `gh`.
+//
+// Campos esperados en `meta` (todos opcionales, backward-compat):
+//   - marker_path:  path absoluto del marker que disparó la orden (ej.
+//                   .pipeline/desarrollo/dev/bloqueado-humano/2975.guru).
+//                   El worker hace fs.existsSync() antes del `gh` — si el
+//                   marker ya no está, descarta como `stale-marker-missing`.
+//   - snapshot_at:  ISO timestamp del momento del encolado.
+//   - marker_mtime: mtimeMs del marker en el momento del encolado. El worker
+//                   compara contra el mtime actual; si el marker fue tocado
+//                   después (rename/escritura humana), descarta como
+//                   `stale-mtime`.
+//
+// Si `meta` es null, el JSON queda con shape clásico {action,issue,label} y
+// el worker ejecuta SIN guardia (degradado seguro para órdenes pre-deploy).
+function enqueueLabelApply(issueNum, label, meta = null) {
     fs.mkdirSync(GH_QUEUE, { recursive: true });
     const filename = `${issueNum}-${label}-reconciler-${Date.now()}.json`;
+    const payload = { action: 'label', issue: issueNum, label };
+    if (meta && typeof meta === 'object') {
+        if (meta.marker_path) payload.marker_path = meta.marker_path;
+        if (meta.snapshot_at) payload.snapshot_at = meta.snapshot_at;
+        if (typeof meta.marker_mtime === 'number') payload.marker_mtime = meta.marker_mtime;
+    }
     fs.writeFileSync(
         path.join(GH_QUEUE, filename),
-        JSON.stringify({ action: 'label', issue: issueNum, label }),
+        JSON.stringify(payload),
     );
 }
 
@@ -158,13 +180,44 @@ function reconcileMarkerToLabel(blockedMarkers, ghIssueSet, getStateFn = getIssu
             continue;
         }
         try {
-            enqueueLabelApply(m.issue, RECONCILER_LABEL);
+            // #2994 — Persistir snapshot del marker que justificó la orden.
+            // El worker valida en O(1) que el marker sigue existiendo y no
+            // fue tocado después; si fue tocado (destrabe humano que renombró
+            // el archivo a `pendiente/`), descarta la orden y evita re-aplicar
+            // un label sobre un issue que ya está destrabado.
+            const meta = buildMarkerMeta(m);
+            enqueueLabelApply(m.issue, RECONCILER_LABEL, meta);
             enqueued++;
         } catch (e) {
             log(`Error encolando label #${m.issue}: ${e.message.slice(0, 120)}`);
         }
     }
     return enqueued;
+}
+
+// #2994 — calcula el snapshot del marker justo antes de encolar la orden.
+// El path se reconstruye desde los datos que ya tiene el reconciler en `m`
+// (issue, skill, phase, pipeline) — no requiere I/O extra para descubrirlo.
+//
+// Si por algún motivo el marker no se puede statear (ej. fue movido entre
+// el listBlockedIssues() y este punto), devolvemos `meta` con marker_path
+// pero sin marker_mtime — el worker tratará la ausencia del archivo como
+// `stale-marker-missing` y descartará la orden.
+function buildMarkerMeta(m) {
+    const markerPath = path.join(
+        PIPELINE, m.pipeline, m.phase, humanBlock.BLOCK_SUBDIR, `${m.issue}.${m.skill}`,
+    );
+    const meta = {
+        marker_path: markerPath,
+        snapshot_at: new Date().toISOString(),
+    };
+    try {
+        meta.marker_mtime = fs.statSync(markerPath).mtimeMs;
+    } catch {
+        // marker desapareció entre listado y stat → meta sin mtime; el worker
+        // verá `marker_path` y al fallar existsSync descarta como missing.
+    }
+    return meta;
 }
 
 function reconcileClosedMarkers(blockedMarkers, ghIssueSet, getStateFn = getIssueState) {
@@ -198,6 +251,123 @@ function reconcileClosedMarkers(blockedMarkers, ghIssueSet, getStateFn = getIssu
 }
 
 // -----------------------------------------------------------------------------
+// CA3 (#2994) — Detectar destrabe humano y reconciliar siguiendo a GitHub
+// -----------------------------------------------------------------------------
+//
+// Escenario: humano hace destrabe manual (mueve marker a `pendiente/` + quita
+// label en GitHub vía `gh`). Si por timing el rename del marker falla o la
+// operación queda parcial — o si el humano sólo quitó el label desde la UI
+// de GitHub sin tocar el FS — la próxima corrida ve marker en
+// `bloqueado-humano/` pero label ausente. Hoy el reconciler re-aplica el
+// label, re-bloqueando el issue.
+//
+// Después de operación humana, GitHub pasa a ser autoritativo. La heurística:
+//   marker existe en bloqueado-humano/  ∧  label ausente en GitHub
+//   ∧  blocked_at > 60s  (suficientemente viejo para que un ciclo previo
+//                          ya hubiera tenido tiempo de aplicar el label)
+//   ∧  blocked_by ≠ 'svc-reconciler'  (no deshacer placeholders recién
+//                                        creados por el propio reconciler)
+//   ⇒ asumimos destrabe humano → mover marker a `pendiente/`.
+//
+// Esta regla corre ANTES de `reconcileMarkerToLabel` para evitar encolar la
+// orden que después tendríamos que descartar como stale.
+
+const HUMAN_UNBLOCK_GRACE_MS = 60 * 1000; // 60s
+
+function reconcileHumanUnblockDetected(blockedMarkers, ghIssueSet, opts = {}) {
+    const now = opts.now || Date.now();
+    const logFn = opts.logStaleOrder || appendStaleOrderLog;
+    let detected = 0;
+    const movedIssues = new Set();
+
+    for (const m of blockedMarkers) {
+        if (ghIssueSet.has(m.issue)) continue; // label sigue presente: nada que hacer
+
+        // Leer reason.json para inspeccionar blocked_at y blocked_by.
+        const markerPath = path.join(
+            PIPELINE, m.pipeline, m.phase, humanBlock.BLOCK_SUBDIR, `${m.issue}.${m.skill}`,
+        );
+        const reasonPath = markerPath + '.reason.json';
+        let reason;
+        try { reason = JSON.parse(fs.readFileSync(reasonPath, 'utf8')); }
+        catch { reason = null; }
+
+        if (reason && reason.blocked_by === 'svc-reconciler') continue; // placeholder propio
+
+        // Ventana de gracia: si el bloqueo es muy reciente, asumimos que la
+        // orden de label todavía no se procesó (el ciclo del worker tarda
+        // hasta 10s + el polling normal). Forzar el destrabe acá podría
+        // deshacer un bloqueo legítimo que estaba en flight.
+        const blockedAt = reason && reason.blocked_at ? Date.parse(reason.blocked_at) : NaN;
+        if (Number.isFinite(blockedAt) && (now - blockedAt) < HUMAN_UNBLOCK_GRACE_MS) continue;
+        if (!Number.isFinite(blockedAt)) {
+            // Sin blocked_at confiable, caemos al mtime del marker como proxy.
+            let mtime;
+            try { mtime = fs.statSync(markerPath).mtimeMs; } catch { mtime = NaN; }
+            if (!Number.isFinite(mtime) || (now - mtime) < HUMAN_UNBLOCK_GRACE_MS) continue;
+        }
+
+        // Mover marker a `pendiente/` de la misma fase. Mantenemos el reason.json
+        // como evidencia (renombrado para que no contamine el flow normal).
+        const targetDir = path.join(PIPELINE, m.pipeline, m.phase, 'pendiente');
+        const targetMarker = path.join(targetDir, `${m.issue}.${m.skill}`);
+        try {
+            fs.mkdirSync(targetDir, { recursive: true });
+            fs.renameSync(markerPath, targetMarker);
+            // El reason.json original dejaría rastro innecesario en pendiente/;
+            // lo borramos. La traza del destrabe queda en stale-orders.log.
+            try { fs.unlinkSync(reasonPath); } catch {}
+            detected++;
+            movedIssues.add(m.issue);
+            try {
+                logFn({
+                    reason: 'human-unblock-detected',
+                    issue: m.issue,
+                    label: RECONCILER_LABEL,
+                    snapshot_at: null,
+                    current_mtime: null,
+                    detail: `marker movido a ${m.pipeline}/${m.phase}/pendiente/`,
+                });
+            } catch {}
+            log(`#${m.issue} destrabado por humano detectado — marker → pendiente/`);
+        } catch (e) {
+            log(`Error procesando destrabe humano #${m.issue}: ${e.message.slice(0, 120)}`);
+        }
+    }
+    return { detected, movedIssues };
+}
+
+// -----------------------------------------------------------------------------
+// Telemetría: log append-only de descartes/detecciones (CA5 #2994)
+// -----------------------------------------------------------------------------
+//
+// Línea por evento. Formato JSONL para que el dashboard lo parse barato:
+//   { ts, reason, issue, label, snapshot_at, current_mtime, detail }
+//
+// Reasons posibles:
+//   - stale-marker-missing  (worker: marker_path ya no existe)
+//   - stale-mtime           (worker: marker_mtime cambió desde el snapshot)
+//   - human-unblock-detected (reconciler: detectó destrabe humano y movió marker)
+
+function appendStaleOrderLog(entry) {
+    try {
+        fs.mkdirSync(LOG_DIR, { recursive: true });
+        const line = JSON.stringify({
+            ts: new Date().toISOString(),
+            reason: entry.reason || 'unknown',
+            issue: entry.issue || null,
+            label: entry.label || null,
+            snapshot_at: entry.snapshot_at || null,
+            current_mtime: entry.current_mtime ?? null,
+            detail: entry.detail || null,
+        }) + '\n';
+        fs.appendFileSync(path.join(LOG_DIR, 'stale-orders.log'), line);
+    } catch {
+        // Telemetría es best-effort: si falla, el reconciler no debe morir.
+    }
+}
+
+// -----------------------------------------------------------------------------
 // Loop principal
 // -----------------------------------------------------------------------------
 
@@ -223,13 +393,25 @@ function reconcileOnce() {
     }
 
     const created = reconcileLabelToFilesystem(ghIssues, blockedByIssue);
-    const enqueued = reconcileMarkerToLabel(blockedMarkers, ghIssueSet);
-    const archived = reconcileClosedMarkers(blockedMarkers, ghIssueSet);
+
+    // CA3 (#2994) — primero detectar destrabes humanos: corre ANTES que
+    // reconcileMarkerToLabel para no encolar órdenes que tendríamos que
+    // descartar como stale por GitHub-autoritativo.
+    const unblockResult = reconcileHumanUnblockDetected(blockedMarkers, ghIssueSet);
+    const detected = unblockResult.detected;
+    // Filtrar markers ya movidos para que reconcileMarkerToLabel/Closed
+    // no vuelvan a procesarlos en este mismo ciclo.
+    const remaining = unblockResult.movedIssues.size > 0
+        ? blockedMarkers.filter(m => !unblockResult.movedIssues.has(m.issue))
+        : blockedMarkers;
+
+    const enqueued = reconcileMarkerToLabel(remaining, ghIssueSet);
+    const archived = reconcileClosedMarkers(remaining, ghIssueSet);
 
     const elapsed = Date.now() - t0;
     lastRunAt = Date.now();
-    if (created || enqueued || archived) {
-        log(`Ciclo ${cycleCount} (${elapsed}ms): GH=${ghIssues.length} markers=${blockedMarkers.length} → +${created} placeholders, +${enqueued} labels encolados, +${archived} archivados`);
+    if (created || enqueued || archived || detected) {
+        log(`Ciclo ${cycleCount} (${elapsed}ms): GH=${ghIssues.length} markers=${blockedMarkers.length} → +${created} placeholders, +${enqueued} labels encolados, +${archived} archivados, +${detected} destrabes humanos detectados`);
     } else {
         log(`Ciclo ${cycleCount} (${elapsed}ms): GH=${ghIssues.length} markers=${blockedMarkers.length} — sincronizado`);
     }
@@ -278,8 +460,12 @@ module.exports = {
     reconcileLabelToFilesystem,
     reconcileMarkerToLabel,
     reconcileClosedMarkers,
+    reconcileHumanUnblockDetected,
     decidirFasePlaceholder,
     listGhIssuesWithLabel,
     getIssueState,
     enqueueLabelApply,
+    buildMarkerMeta,
+    appendStaleOrderLog,
+    HUMAN_UNBLOCK_GRACE_MS,
 };

--- a/.pipeline/views/dashboard/satellites.js
+++ b/.pipeline/views/dashboard/satellites.js
@@ -829,6 +829,16 @@ function renderOps() {
   <h2 class="in-section-title"><span class="in-section-title-icon">🛠</span>Procesos del pipeline</h2>
   <div id="ops-procesos" class="ops-grid"></div>
 </section>
+<section class="in-section" aria-label="Métrica de salud del reconciler GitHub">
+  <h2 class="in-section-title"><span class="in-section-title-icon">⏳</span>Reconciler · órdenes descartadas (stale)</h2>
+  <div class="stale-orders-panel" id="stale-orders-panel">
+    <div class="stale-orders-main">
+      <div class="stale-orders-count" id="stale-orders-count">…</div>
+      <div class="stale-orders-caption">últimas 24h</div>
+    </div>
+    <div class="stale-orders-breakdown" id="stale-orders-breakdown"></div>
+  </div>
+</section>
 <section class="in-section">
   <h2 class="in-section-title"><span class="in-section-title-icon">📡</span>QA Environment</h2>
   <pre id="ops-qaenv" class="ops-pre"></pre>
@@ -851,7 +861,19 @@ function renderOps() {
 .ops-banner-hidden { display: none; }
 .ops-banner { display: block; padding: 12px 16px; margin-bottom: 14px; border-radius: var(--in-radius-sm); border: 1px solid var(--in-bad); background: var(--in-bad-soft); color: var(--in-bad); font-weight: 600; }
 .ops-banner-sub { font-weight: 400; font-size: 12px; color: var(--in-fg-dim); margin-top: 4px; font-family: var(--in-mono); }
-.ops-pre { background: var(--in-bg-3); padding: 14px; border-radius: var(--in-radius-sm); font-family: var(--in-mono); font-size: 11px; overflow: auto; max-height: 280px; border: 1px solid var(--in-border); }`;
+.ops-pre { background: var(--in-bg-3); padding: 14px; border-radius: var(--in-radius-sm); font-family: var(--in-mono); font-size: 11px; overflow: auto; max-height: 280px; border: 1px solid var(--in-border); }
+/* #2994 — panel del reconciler stale orders. Reusa --warning/--font-mono.
+   Estado vacío: número 0 en --in-fg-dim para señalar salud sin alarma. */
+.stale-orders-panel { display: flex; flex-direction: column; gap: 12px; padding: 12px 14px; background: var(--in-bg-3); border: 1px solid var(--in-border); border-radius: var(--in-radius-sm); min-width: 260px; }
+.stale-orders-main { display: flex; flex-direction: column; gap: 2px; }
+.stale-orders-count { font-family: var(--in-mono, var(--font-mono, monospace)); font-size: 32px; font-weight: 600; color: var(--warning, var(--in-warn, #D29922)); font-variant-numeric: tabular-nums; line-height: 1.1; }
+.stale-orders-count.is-zero { color: var(--in-fg-dim); }
+.stale-orders-caption { font-size: 12px; color: var(--in-fg-dim); }
+.stale-orders-breakdown { display: flex; flex-direction: column; gap: 4px; }
+.stale-orders-breakdown-row { display: flex; justify-content: space-between; gap: 12px; font-family: var(--in-mono, monospace); font-size: 12px; font-variant-numeric: tabular-nums; padding: 2px 0; }
+.stale-orders-breakdown-reason { color: var(--in-fg-default, var(--in-fg)); }
+.stale-orders-breakdown-value { color: var(--warning, var(--in-warn, #D29922)); font-weight: 600; }
+.stale-orders-empty { color: var(--in-fg-dim); font-size: 12px; }`;
     const script = `
 const PROC_QUEUES = {
     'listener': ['commander', 'telegram'],
@@ -935,7 +957,32 @@ async function tickOps(){
         if(pre.textContent !== txt) pre.textContent = txt;
     }
 }
-const POLLS = [{ fn: tickHeader, ms: 5000 }, { fn: tickOps, ms: 5000 }];
+async function tickStaleOrders(){
+    const d = await fetchJson('/api/dash/reconciler-stale-orders');
+    if(!d) return;
+    const countEl = document.getElementById('stale-orders-count');
+    const breakdownEl = document.getElementById('stale-orders-breakdown');
+    if(!countEl || !breakdownEl) return;
+    const total = Number(d.total_24h) || 0;
+    const txt = String(total);
+    if(countEl.textContent !== txt) countEl.textContent = txt;
+    countEl.className = total === 0 ? 'stale-orders-count is-zero' : 'stale-orders-count';
+    const reasons = d.by_reason || {};
+    let html = '';
+    if(total === 0){
+        html = '<div class="stale-orders-empty">Sin descartes en 24h — saludable</div>';
+    } else {
+        const entries = Object.entries(reasons).sort((a,b) => b[1] - a[1]);
+        for(const [reason, n] of entries){
+            html += '<div class="stale-orders-breakdown-row">'
+                + '<span class="stale-orders-breakdown-reason">— '+escapeHtml(reason)+'</span>'
+                + '<span class="stale-orders-breakdown-value">'+(Number(n)||0)+'</span>'
+                + '</div>';
+        }
+    }
+    if(breakdownEl.innerHTML !== html) breakdownEl.innerHTML = html;
+}
+const POLLS = [{ fn: tickHeader, ms: 5000 }, { fn: tickOps, ms: 5000 }, { fn: tickStaleOrders, ms: 30000 }];
 async function runAll(){ for(const p of POLLS){ try{ await p.fn(); } catch{} } }
 runAll();
 for(const p of POLLS){ setInterval(() => { p.fn().catch(()=>{}); }, p.ms); }`;


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 8 archivos · +966 -30

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:skipped` aplicado por delivery

## Closes

Closes #2994
