### PR TITLE
refactor(pipeline): mover lanzarAgenteClaude a lib/agent-launcher.js con dispatch por provider [H2 multi-provider]

### DIFF
--- a/.pipeline/lib/agent-launcher.js
+++ b/.pipeline/lib/agent-launcher.js
@@ -1,0 +1,152 @@
+// =============================================================================
+// agent-launcher.js — Entry point unificado del lanzamiento de agentes
+// (issue #3074 / H2 multi-provider).
+//
+// Encapsula la decisión "qué binario corre y con qué args para el skill X".
+// Reemplaza el bloque inline de spawn de Claude que vivía en `pulpo.js`
+// (líneas 4900-4994 antes del refactor) por una sola llamada `launchAgent()`.
+//
+// **Contrato público**:
+//   const result = launchAgent({
+//     skill, issue, trabajandoPath, fase, pipeline,
+//     args,            // args ya construidos por pulpo (system-prompt-file, etc.)
+//     cwd,             // worktree path o ROOT
+//     env,             // env completo a pasar al spawn (PIPELINE_*, etc.)
+//     PIPELINE,        // ruta al directorio .pipeline/ (para agent-models.json)
+//     ROOT,            // ruta al repo (para resolveDeterministicScript)
+//     onWorktreeHit,   // callback opcional: invocado si el script determ. viene del worktree
+//     onLog,           // callback opcional para warnings (firma compatible con `log`)
+//     // inyectables (tests):
+//     fsImpl, spawnImpl, execSyncImpl, resolveImpl,
+//   });
+//   // result = { child, provider, model, source, scriptPath?, handler, warning? }
+//
+// **Invariantes preservados** (regresión cero corriendo solo Anthropic — CA-4):
+//   I1: skills determinísticos siempre con shell:false.
+//   I2: env del spawn idéntico al previo (PIPELINE_* + extraEnv).
+//   I3: stdio = ['ignore', 'pipe', 'pipe'], detached:false, windowsHide:true.
+//   I4: defensa de path-traversal — los providers se resuelven contra una
+//       tabla hardcoded (resolve-provider.js), nunca por require dinámico.
+//   I5: el caller (pulpo) sigue siendo dueño del watchdog, child.unref(),
+//       on-exit handler, emit traceability, fast-fail/cooldown, mover archivo.
+//   I6: detector de quota agotada y parseo de tokens delega al `handler`
+//       devuelto, así que cada provider trae su propia implementación.
+//
+// **Rollout reversible**: si un skill determinístico no tiene script en disco
+// (caso "borré builder.js para volver al LLM" #2476), launchAgent cae al
+// provider Anthropic con el `args` original — comportamiento idéntico al del
+// pulpo previo al refactor.
+// =============================================================================
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawn } = require('node:child_process');
+
+const { resolveProviderForSkill } = require('./agent-launcher/resolve-provider');
+const PROVIDERS = {
+    anthropic: require('./agent-launcher/providers/anthropic'),
+    deterministic: require('./agent-launcher/providers/deterministic'),
+    'openai-codex': require('./agent-launcher/providers/openai-codex'),
+};
+
+// -----------------------------------------------------------------------------
+// launchAgent — única función pública. Resuelve provider, arma el spawn y
+// devuelve el handle del proceso + metadata (provider, model, handler).
+//
+// El llamador (pulpo) se queda con `result.child` y conecta watchdog, stdio
+// pipes y el on-exit handler como antes. La metadata (`provider`, `model`,
+// `source`) se usa para logging y trazabilidad (#3072 ya consume `model`).
+// -----------------------------------------------------------------------------
+function launchAgent({
+    skill,
+    issue,
+    trabajandoPath,
+    fase,
+    pipeline,
+    args,
+    cwd,
+    env,
+    PIPELINE,
+    ROOT,
+    onWorktreeHit,
+    onLog,
+    // inyectables para tests
+    fsImpl,
+    spawnImpl,
+    execSyncImpl,
+    resolveImpl,
+} = {}) {
+    if (!skill || typeof skill !== 'string') {
+        throw new Error('[agent-launcher] launchAgent: parámetro "skill" es requerido y debe ser string.');
+    }
+    const _fs = fsImpl || fs;
+    const _spawn = spawnImpl || spawn;
+    const _resolve = resolveImpl || resolveProviderForSkill;
+    const log = (typeof onLog === 'function') ? onLog : () => {};
+
+    // 1. Resolver provider para el skill (usa agent-models.json o default).
+    const resolution = _resolve(skill, { pipelineDir: PIPELINE, fsImpl: _fs });
+    if (resolution.warning) {
+        log('agent-launcher', `⚠️ ${resolution.warning}`);
+    }
+
+    // 2. Provider determinístico: si el script no existe, fallback a Anthropic
+    //    (rollout reversible — invariante histórica del pulpo previo, #2476).
+    let effective = resolution;
+    if (resolution.provider === 'deterministic') {
+        const determ = resolution.handler;
+        const scriptPath = determ.resolveDeterministicScript({
+            skill, issue, ROOT, PIPELINE, onWorktreeHit, execSyncImpl, fsImpl: _fs,
+        });
+        if (!_fs.existsSync(scriptPath)) {
+            log('agent-launcher', `↩️ ${skill}:#${issue} script determinístico no existe (${scriptPath}), fallback a Anthropic LLM.`);
+            effective = {
+                provider: 'anthropic',
+                model: resolution.model || null,
+                handler: PROVIDERS.anthropic,
+                source: 'fallback-deterministic-script-missing',
+            };
+        } else {
+            // El script existe → delegamos al handler determinístico.
+            // `buildSpawn` vuelve a resolver el script internamente (es barato
+            // y mantiene el contrato del handler consistente). El scriptPath
+            // del return permite al caller loggear "ejecutado en modo determinístico".
+            const spawnDef = determ.buildSpawn({
+                skill, issue, trabajandoPath, cwd, env, ROOT, PIPELINE, onWorktreeHit, execSyncImpl, fsImpl: _fs,
+            });
+            const child = _spawn(spawnDef.cmd, spawnDef.args, spawnDef.spawnOpts);
+            return {
+                child,
+                provider: 'deterministic',
+                model: null,
+                source: resolution.source,
+                scriptPath: spawnDef.scriptPath || scriptPath,
+                handler: determ,
+            };
+        }
+    }
+
+    // 3. Provider LLM (anthropic o openai-codex): arma el spawn con el handler.
+    //    Los providers LLM reciben `args` ya construidos por el caller (pulpo
+    //    arma --system-prompt-file, --output-format, etc.).
+    const handler = effective.handler;
+    const spawnDef = handler.buildSpawn({ args, cwd, env });
+    const child = _spawn(spawnDef.cmd, spawnDef.args, spawnDef.spawnOpts);
+    return {
+        child,
+        provider: effective.provider,
+        model: effective.model,
+        source: effective.source,
+        scriptPath: null,
+        handler,
+    };
+}
+
+module.exports = {
+    launchAgent,
+    // re-exports para que el caller pueda parsear tokens / detectar quota
+    // sin tener que volver a resolver el provider.
+    PROVIDERS,
+    resolveProviderForSkill,
+};

--- a/.pipeline/lib/agent-launcher/providers/anthropic.js
+++ b/.pipeline/lib/agent-launcher/providers/anthropic.js
@@ -1,0 +1,177 @@
+// =============================================================================
+// providers/anthropic.js — Handler del provider Anthropic (Claude Code CLI)
+//
+// Encapsula:
+//  - Detección multi-tier del launcher de Claude Code (`detectLauncher`).
+//  - Construcción del comando spawn (`buildSpawn`).
+//  - Parseo de tokens desde el log stream-json del agente (`parseTokensFromLog`).
+//  - Detección de cuota agotada en el log (`detectQuotaExhausted`).
+//
+// Migrado desde `pulpo.js` (issue #3074 / H2 multi-provider) preservando
+// invariantes de seguridad I1, I5, I6 y comportamiento byte-identical del
+// objeto que recibe `child_process.spawn`.
+// =============================================================================
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+// -----------------------------------------------------------------------------
+// detectLauncher — multi-tier detection (preservar orden de precedencia I6)
+//
+// La estructura del paquete @anthropic-ai/claude-code cambió entre versiones
+// (2.1.114 eliminó cli.js y lo reemplazó con bin/claude.exe nativo +
+// cli-wrapper.cjs fallback). Probamos opciones de más a menos preferida; todas
+// evitan cmd.exe cuando es posible.
+//
+// Orden (NO REORDENAR — preservar invariante I6 de seguridad):
+//   1. Legacy cli.js → node directo (compat con versiones viejas, shell:false)
+//   2. Binario nativo bin/claude.exe (≥2.1.114, shell:false)
+//   3. cli-wrapper.cjs → node directo (fallback JS, shell:false)
+//   4. .cmd shim de npm → shell:true (los shims .cmd requieren cmd.exe)
+//   5. PATH fallback → process.env.CLAUDE_BIN o 'claude' (último recurso)
+// -----------------------------------------------------------------------------
+function detectLauncher() {
+    const pkgDir = path.join(process.env.APPDATA || '', 'npm', 'node_modules', '@anthropic-ai', 'claude-code');
+    const cliJsLegacy = path.join(pkgDir, 'cli.js');
+    const binExe = path.join(pkgDir, 'bin', 'claude.exe');
+    const wrapperCjs = path.join(pkgDir, 'cli-wrapper.cjs');
+    const cmdShim = path.join(process.env.APPDATA || '', 'npm', 'claude.cmd');
+
+    // 1. Legacy cli.js → node directo (compatibilidad con versiones viejas)
+    if (fs.existsSync(cliJsLegacy)) {
+        return { kind: 'node-cli-js', cmd: process.execPath, prefixArgs: [cliJsLegacy], shell: false };
+    }
+    // 2. Binario nativo (Claude Code ≥2.1.114) → ruta absoluta, sin shell
+    if (fs.existsSync(binExe)) {
+        return { kind: 'native-exe', cmd: binExe, prefixArgs: [], shell: false };
+    }
+    // 3. cli-wrapper.cjs → node directo (fallback JS del propio paquete)
+    if (fs.existsSync(wrapperCjs)) {
+        return { kind: 'node-wrapper-cjs', cmd: process.execPath, prefixArgs: [wrapperCjs], shell: false };
+    }
+    // 4. .cmd shim con ruta absoluta → shell:true (shims .cmd requieren shell en spawn)
+    if (fs.existsSync(cmdShim)) {
+        return { kind: 'cmd-shim', cmd: cmdShim, prefixArgs: [], shell: true };
+    }
+    // 5. Último recurso: 'claude' en PATH con shell
+    return { kind: 'path-fallback', cmd: process.env.CLAUDE_BIN || 'claude', prefixArgs: [], shell: true };
+}
+
+// Cache del launcher detectado (boot-time). Reusable entre llamadas.
+let cachedLauncher = null;
+function getLauncher() {
+    if (!cachedLauncher) cachedLauncher = detectLauncher();
+    return cachedLauncher;
+}
+// Para tests: permite forzar un launcher específico sin tocar el filesystem.
+function _setLauncherForTesting(launcher) {
+    cachedLauncher = launcher;
+}
+function _resetLauncherCacheForTesting() {
+    cachedLauncher = null;
+}
+
+// -----------------------------------------------------------------------------
+// buildSpawn — devuelve el objeto que el wrapper pasa a child_process.spawn.
+//
+// Contrato:
+//   input:  { args, cwd, env }
+//   output: { cmd, args, spawnOpts }
+//
+// `args` ya viene completo con --system-prompt-file, --output-format, etc.
+// Acá solo prependemos `prefixArgs` del launcher (ej. la ruta a cli.js cuando
+// usamos node directo) y armamos `spawnOpts` con shell del launcher.
+// -----------------------------------------------------------------------------
+function buildSpawn({ args, cwd, env }) {
+    const launcher = getLauncher();
+    return {
+        cmd: launcher.cmd,
+        args: [...launcher.prefixArgs, ...args],
+        spawnOpts: {
+            cwd,
+            stdio: ['ignore', 'pipe', 'pipe'],
+            detached: false,
+            shell: launcher.shell,
+            windowsHide: true,
+            env,
+        },
+    };
+}
+
+// -----------------------------------------------------------------------------
+// parseTokensFromLog — agrega usage de cada turno `assistant` del stream-json.
+//
+// Stream JSON line-por-línea — algunas líneas son truncadas o quedan a mitad
+// por timeouts; el try/catch las descarta sin afectar el resto (invariante I5
+// de seguridad: try/catch POR LÍNEA, no por archivo).
+// -----------------------------------------------------------------------------
+function parseTokensFromLog(logPath, fsImpl) {
+    const _fs = fsImpl || fs;
+    const totals = { input: 0, output: 0, cache_read: 0, cache_create: 0, tool_calls: 0 };
+    try {
+        const raw = _fs.readFileSync(logPath, 'utf8');
+        for (const line of raw.split('\n')) {
+            if (!line.startsWith('{')) continue;
+            let obj;
+            try { obj = JSON.parse(line); } catch { continue; }
+            if (obj.type === 'assistant' && obj.message && obj.message.usage) {
+                const u = obj.message.usage;
+                totals.input += Number(u.input_tokens || 0);
+                totals.output += Number(u.output_tokens || 0);
+                totals.cache_read += Number(u.cache_read_input_tokens || 0);
+                totals.cache_create += Number(u.cache_creation_input_tokens || 0);
+                if (Array.isArray(obj.message.content)) {
+                    totals.tool_calls += obj.message.content.filter((c) => c.type === 'tool_use').length;
+                }
+            }
+        }
+    } catch { /* log no existe o ilegible */ }
+    return totals;
+}
+
+// -----------------------------------------------------------------------------
+// detectQuotaExhausted — busca un result event con shape de cuota agotada
+// (ej. error_type === 'rate_limit_error' || matches del patrón configurado).
+//
+// El detector vive en `lib/quota-exhausted.js` (módulo agnóstico). Acá lo
+// usamos line-by-line sobre el log del agente. Devuelve `{matched, errorType,
+// resetsAt, rawLine}` o `{matched: false}`.
+// -----------------------------------------------------------------------------
+function detectQuotaExhausted(logPath, cfg, quotaExhaustedModule, fsImpl) {
+    const _fs = fsImpl || fs;
+    if (!quotaExhaustedModule || typeof quotaExhaustedModule.detectFromResultEvent !== 'function') {
+        return { matched: false };
+    }
+    let raw = '';
+    try { raw = _fs.readFileSync(logPath, 'utf8'); } catch { return { matched: false }; }
+    if (!raw) return { matched: false };
+    for (const line of raw.split('\n')) {
+        if (!line.startsWith('{')) continue;
+        let evt;
+        try { evt = JSON.parse(line); } catch { continue; }
+        const det = quotaExhaustedModule.detectFromResultEvent(evt, cfg);
+        if (det.matched) {
+            return {
+                matched: true,
+                errorType: det.errorType,
+                resetsAt: evt.resets_at,
+                rawLine: line,
+                evt,
+            };
+        }
+    }
+    return { matched: false };
+}
+
+module.exports = {
+    name: 'anthropic',
+    detectLauncher: getLauncher,
+    buildSpawn,
+    parseTokensFromLog,
+    detectQuotaExhausted,
+    // exports internos para tests
+    _detectLauncherFresh: detectLauncher,
+    _setLauncherForTesting,
+    _resetLauncherCacheForTesting,
+};

--- a/.pipeline/lib/agent-launcher/providers/deterministic.js
+++ b/.pipeline/lib/agent-launcher/providers/deterministic.js
@@ -1,0 +1,118 @@
+// =============================================================================
+// providers/deterministic.js — Handler para skills determinísticos (Node puro).
+//
+// Bypass al LLM: los skills `builder`, `tester`, `delivery`, `linter`
+// implementan su lógica en `.pipeline/skills-deterministicos/<skill>.js` y
+// corren con Node directo, sin gastar tokens. Cada script implementa el mismo
+// contrato (marker, heartbeat, eventos V3, exit 0/1) que el resto del flujo
+// del Pulpo (watchdog, on-exit) entiende sin cambios.
+//
+// Issues: #2476 / #2482 / #2484 (rollout reversible — borrar el archivo del
+// skill devuelve al fallback LLM automáticamente).
+// =============================================================================
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { execSync } = require('node:child_process');
+
+// -----------------------------------------------------------------------------
+// Allowlist hardcoded — invariante de seguridad I4 (path-traversal defense).
+// NUNCA cambiar a require dinámico sobre `skill`: si un atacante con permiso de
+// PR edita esto, podría inyectar un script fuera de skills-deterministicos/.
+// -----------------------------------------------------------------------------
+const DETERMINISTIC_SKILLS = new Set(['builder', 'tester', 'delivery', 'linter']);
+
+function isDeterministic(skill) {
+    return DETERMINISTIC_SKILLS.has(skill);
+}
+
+// -----------------------------------------------------------------------------
+// resolveDeterministicScript — resuelve la ruta absoluta del script Node del
+// skill. Si existe un worktree del issue (platform.agent-<issue>-*), prefiere
+// el script del worktree (puede haber cambios locales del developer).
+//
+// Si el worktree no tiene el script, fallback al de ROOT (el "oficial").
+// -----------------------------------------------------------------------------
+function resolveDeterministicScript({ skill, issue, ROOT, PIPELINE, onWorktreeHit, execSyncImpl, fsImpl } = {}) {
+    const _execSync = execSyncImpl || execSync;
+    const _fs = fsImpl || fs;
+    const rootScript = path.join(PIPELINE, 'skills-deterministicos', `${skill}.js`);
+    if (!issue || !ROOT) return rootScript;
+    let issueWorktree = null;
+    try {
+        const needle = `platform.agent-${issue}-`;
+        const worktrees = _execSync('git worktree list --porcelain', { cwd: ROOT, encoding: 'utf8', timeout: 5000, windowsHide: true });
+        for (const line of String(worktrees).split('\n')) {
+            if (line.startsWith('worktree ') && line.includes(needle)) {
+                issueWorktree = line.replace('worktree ', '').trim();
+                break;
+            }
+        }
+    } catch { /* sin worktree, fallback a ROOT */ }
+    if (issueWorktree) {
+        const wtScript = path.join(issueWorktree, '.pipeline', 'skills-deterministicos', `${skill}.js`);
+        if (_fs.existsSync(wtScript)) {
+            if (typeof onWorktreeHit === 'function') {
+                try { onWorktreeHit(issueWorktree); } catch { /* ignore */ }
+            }
+            return wtScript;
+        }
+    }
+    return rootScript;
+}
+
+// -----------------------------------------------------------------------------
+// buildSpawn — devuelve el objeto spawn para el script determinístico.
+//
+// Contrato igual que el provider Anthropic: {cmd, args, spawnOpts}. Acá la
+// CMD es siempre `process.execPath` (node) y los args incluyen el path del
+// script + el issue + --trabajando=<path>.
+//
+// Defensa I4: el `skill` debe estar en DETERMINISTIC_SKILLS. Si no, throw.
+// -----------------------------------------------------------------------------
+function buildSpawn({ skill, issue, trabajandoPath, cwd, env, ROOT, PIPELINE, onWorktreeHit, execSyncImpl, fsImpl }) {
+    if (!isDeterministic(skill)) {
+        throw new Error(
+            `[agent-launcher/deterministic] skill "${skill}" no está en la allowlist de skills determinísticos.\n` +
+            `Allowlist: ${Array.from(DETERMINISTIC_SKILLS).join(', ')}.\n` +
+            `Esto suele indicar un bug en resolve-provider o un agent-models.json incorrecto.`
+        );
+    }
+    const scriptPath = resolveDeterministicScript({ skill, issue, ROOT, PIPELINE, onWorktreeHit, execSyncImpl, fsImpl });
+    return {
+        cmd: process.execPath,
+        args: [scriptPath, String(issue), `--trabajando=${trabajandoPath}`],
+        spawnOpts: {
+            cwd,
+            stdio: ['ignore', 'pipe', 'pipe'],
+            detached: false,
+            // Defensa I1: shell:false SIEMPRE para skills determinísticos.
+            shell: false,
+            windowsHide: true,
+            env,
+        },
+        scriptPath,
+    };
+}
+
+// Los skills determinísticos no tienen tokens (no van al LLM).
+function parseTokensFromLog(/* logPath */) {
+    return { input: 0, output: 0, cache_read: 0, cache_create: 0, tool_calls: 0 };
+}
+
+// Los skills determinísticos no consumen cuota Anthropic, así que el detector
+// de cuota agotada no aplica.
+function detectQuotaExhausted() {
+    return { matched: false };
+}
+
+module.exports = {
+    name: 'deterministic',
+    DETERMINISTIC_SKILLS,
+    isDeterministic,
+    resolveDeterministicScript,
+    buildSpawn,
+    parseTokensFromLog,
+    detectQuotaExhausted,
+};

--- a/.pipeline/lib/agent-launcher/providers/openai-codex.js
+++ b/.pipeline/lib/agent-launcher/providers/openai-codex.js
@@ -1,0 +1,51 @@
+// =============================================================================
+// providers/openai-codex.js — Stub del provider OpenAI/Codex (issue #3076 / H3).
+//
+// Este archivo existe para cumplir CA-1 del issue #3074 (estructura completa
+// de providers) sin implementar todavía la lógica real, que la entrega H3
+// (issue #3076) cuando agreguemos el binario y los handlers de tokens.
+//
+// Cuando `agent-models.json` apunta un skill a este provider, `buildSpawn`
+// lanza un error accionable en español. NO crashea el pulpo, NO consume
+// tokens — el flujo upstream (resolve-provider o el wrapper de
+// agent-launcher) atrapa el throw y rebota el archivo a `pendiente/` con
+// motivo claro.
+// =============================================================================
+'use strict';
+
+function _notImplemented(operation) {
+    throw new Error(
+        `[agent-launcher/openai-codex] Provider "openai-codex" no está implementado todavía (operación: ${operation}).\n` +
+        `Issue de entrega: #3076 (H3 multi-provider).\n` +
+        `Acción inmediata para destrabar: cambiar el provider del skill afectado en .pipeline/agent-models.json a "anthropic" (o al provider que corresponda)\n` +
+        `o esperar a que H3 entregue el handler real.`
+    );
+}
+
+function detectLauncher() {
+    _notImplemented('detectLauncher');
+}
+
+function buildSpawn(/* { args, cwd, env } */) {
+    _notImplemented('buildSpawn');
+}
+
+// Retornamos zeros — si llegamos a parsear es porque hubo un spawn (que ya
+// debería haber tirado en buildSpawn). Defensivo: no rompemos el on-exit.
+function parseTokensFromLog(/* logPath */) {
+    return { input: 0, output: 0, cache_read: 0, cache_create: 0, tool_calls: 0 };
+}
+
+function detectQuotaExhausted() {
+    // El detector de cuota Anthropic no aplica a OpenAI/Codex. H3 traerá su
+    // propio detector si OpenAI usa un shape de error diferente.
+    return { matched: false };
+}
+
+module.exports = {
+    name: 'openai-codex',
+    detectLauncher,
+    buildSpawn,
+    parseTokensFromLog,
+    detectQuotaExhausted,
+};

--- a/.pipeline/lib/agent-launcher/resolve-provider.js
+++ b/.pipeline/lib/agent-launcher/resolve-provider.js
@@ -1,0 +1,159 @@
+// =============================================================================
+// resolve-provider.js — Resolución skill → provider/handler.
+//
+// CA-2 del issue #3074: el mapeo provider→handler es una **tabla hardcoded**
+// (defensa contra path-traversal en agent-models.json). NO usar
+// `require(\`./providers/\${name}.js\`)` dinámico — un atacante con permiso de
+// PR podría poner `provider: "../../etc/passwd"` y el require lo cargaría.
+//
+// Default defensivo: si `agent-models.json` no existe, no resuelve un skill,
+// o no es JSON válido, defaulteamos a Anthropic con modelo legacy
+// "claude-opus-4-7" para garantizar regresión cero corriendo solo Anthropic
+// (CA-4) hasta que H1 (#3072) deje el archivo en disco.
+//
+// Skills determinísticos (allowlist en providers/deterministic.js) siempre
+// van por el provider deterministic, sin importar lo que diga el JSON.
+// =============================================================================
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+// -----------------------------------------------------------------------------
+// Tabla hardcoded de providers (CA-2 / I-CRÍTICO seguridad).
+// El orden no importa; usamos hasOwnProperty para descartar provider names
+// inexistentes con mensaje accionable.
+// -----------------------------------------------------------------------------
+const PROVIDER_HANDLERS = {
+    'anthropic': require('./providers/anthropic'),
+    'openai-codex': require('./providers/openai-codex'),
+    'deterministic': require('./providers/deterministic'),
+};
+
+const VALID_PROVIDERS = Object.freeze(Object.keys(PROVIDER_HANDLERS));
+
+// Modelo legacy para fallback de regresión cero (idéntico al hardcode previo
+// en pulpo.js:4954 antes de #3072 / H1).
+const LEGACY_ANTHROPIC_MODEL = 'claude-opus-4-7';
+
+// -----------------------------------------------------------------------------
+// getProviderHandler — busca un handler por nombre. Throw si no existe.
+//
+// CA-7 (DX): mensaje accionable que incluye provider recibido, válidos y
+// dónde corregir. NO uses `require` dinámico — la tabla hardcoded ES la
+// validación.
+// -----------------------------------------------------------------------------
+function getProviderHandler(name) {
+    if (typeof name !== 'string' || name.length === 0) {
+        throw new Error(
+            `[agent-launcher] Provider inválido (vacío o no string).\n` +
+            `Providers válidos: ${VALID_PROVIDERS.join(', ')}.\n` +
+            `Verificar .pipeline/agent-models.json (campo "provider" del skill afectado).`
+        );
+    }
+    if (!Object.prototype.hasOwnProperty.call(PROVIDER_HANDLERS, name)) {
+        throw new Error(
+            `[agent-launcher] Provider desconocido "${name}".\n` +
+            `Providers válidos: ${VALID_PROVIDERS.join(', ')}.\n` +
+            `Verificar .pipeline/agent-models.json (campo "provider" del skill afectado).`
+        );
+    }
+    return PROVIDER_HANDLERS[name];
+}
+
+// -----------------------------------------------------------------------------
+// readAgentModels — lee y parsea agent-models.json en pipelineDir/agent-models.json.
+//
+// Defensivo: cualquier error (no existe, JSON inválido, IO error) retorna
+// null SIN tirar. El llamador caerá al default de Anthropic.
+// -----------------------------------------------------------------------------
+function readAgentModels(pipelineDir, fsImpl) {
+    const _fs = fsImpl || fs;
+    if (!pipelineDir) return null;
+    const modelsPath = path.join(pipelineDir, 'agent-models.json');
+    try {
+        if (!_fs.existsSync(modelsPath)) return null;
+        const raw = _fs.readFileSync(modelsPath, 'utf8');
+        return JSON.parse(raw);
+    } catch (e) {
+        // No bloqueamos por JSON inválido. El warning lo reporta el wrapper
+        // que llama a `resolveProviderForSkill` (tiene acceso a `log`).
+        return { __readError: e.message };
+    }
+}
+
+// -----------------------------------------------------------------------------
+// resolveProviderForSkill — devuelve { provider, model, handler, source } para
+// un skill dado.
+//
+// Reglas:
+//  1. Si el skill está en la allowlist determinística → provider 'deterministic'.
+//  2. Si `agent-models.json` no existe / no resuelve el skill → default
+//     'anthropic' con modelo legacy (regresión cero).
+//  3. Si resuelve, valida `provider` contra la tabla hardcoded.
+// -----------------------------------------------------------------------------
+function resolveProviderForSkill(skill, opts = {}) {
+    const { pipelineDir, fsImpl } = opts;
+
+    // 1. Skills determinísticos: allowlist hardcoded del propio handler
+    //    (no consulta agent-models.json, son Node puro y sin tokens).
+    const determHandler = PROVIDER_HANDLERS.deterministic;
+    if (determHandler.isDeterministic(skill)) {
+        return {
+            provider: 'deterministic',
+            model: null,
+            handler: determHandler,
+            source: 'deterministic-allowlist',
+        };
+    }
+
+    // 2. Lectura defensiva de agent-models.json
+    const models = readAgentModels(pipelineDir, fsImpl);
+    if (!models) {
+        return {
+            provider: 'anthropic',
+            model: LEGACY_ANTHROPIC_MODEL,
+            handler: PROVIDER_HANDLERS.anthropic,
+            source: 'fallback-no-config',
+        };
+    }
+    if (models.__readError) {
+        return {
+            provider: 'anthropic',
+            model: LEGACY_ANTHROPIC_MODEL,
+            handler: PROVIDER_HANDLERS.anthropic,
+            source: 'fallback-read-error',
+            warning: `agent-models.json no se pudo parsear: ${models.__readError}`,
+        };
+    }
+
+    const skillCfg = (models.skills && models.skills[skill]) || null;
+    const defaultModel = (models.defaults && models.defaults.model) || LEGACY_ANTHROPIC_MODEL;
+
+    if (!skillCfg) {
+        return {
+            provider: 'anthropic',
+            model: defaultModel,
+            handler: PROVIDER_HANDLERS.anthropic,
+            source: 'fallback-skill-not-found',
+        };
+    }
+
+    const providerName = skillCfg.provider || 'anthropic';
+    const handler = getProviderHandler(providerName); // valida contra tabla hardcoded
+    return {
+        provider: providerName,
+        model: skillCfg.model || defaultModel,
+        handler,
+        source: 'agent-models',
+    };
+}
+
+module.exports = {
+    PROVIDER_HANDLERS,
+    VALID_PROVIDERS,
+    LEGACY_ANTHROPIC_MODEL,
+    getProviderHandler,
+    resolveProviderForSkill,
+    readAgentModels,
+};

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -61,6 +61,10 @@ const restModeWindow = require('./lib/rest-mode-window');
 // inicial + recordatorios A→B→C→D rotando + cierre + canned a texto libre).
 // Depende del flag .pipeline/quota-exhausted.json producido por #2974.
 const { createQuotaNotifier, DEFAULT_REMINDER_INTERVAL_MIN } = require('./lib/quota-notifier');
+// #3074 / H2 multi-provider: dispatcher de spawn por provider (anthropic /
+// deterministic / openai-codex). Reemplaza el bloque inline de spawn de Claude
+// que vivía acá pre-refactor (~líneas 4900-4994 de la versión previa).
+const { launchAgent } = require('./lib/agent-launcher');
 // #2334 / CA6: log stream sanitizer para stdout/stderr del agente.
 const { createLogFileWriter } = require('./lib/sanitize-log-stream');
 // #2334 / CA6: patch global de console.* para que nada pase al log de pulpo
@@ -4893,83 +4897,26 @@ function lanzarAgenteClaude(skill, issue, trabajandoPath, pipeline, fase, config
     }
   }
 
-  // #2476 / #2482 / #2484 — bypass al LLM para skills determinísticos: si el skill
-  // tiene un script Node en `.pipeline/skills-deterministicos/<skill>.js`, lo corremos
-  // con Node puro (cero tokens). El script implementa el mismo contrato (marker,
-  // heartbeat, eventos V3, exit 0=aprobado/1=rebote) por lo que el resto del flujo
-  // (watchdog, on-exit, mover a listo/) funciona sin cambios.
-  // Rollout reversible: borrar el archivo → fallback automático al agente LLM.
-  const DETERMINISTIC_SKILLS = new Set(['builder', 'tester', 'delivery', 'linter']);
-
-  const deterministicScript = DETERMINISTIC_SKILLS.has(skill)
-    ? resolveDeterministicScript({ skill, issue, ROOT, PIPELINE, onWorktreeHit: (wt) => log('lanzamiento', `⚡ ${skill}:#${issue} usa script del worktree (${wt})`) })
-    : path.join(PIPELINE, 'skills-deterministicos', `${skill}.js`);
-  const useDeterministicSkill = (DETERMINISTIC_SKILLS.has(skill) && fs.existsSync(deterministicScript));
-
-  // Launcher detectado al boot (ver detectClaudeLauncher). Evita cmd.exe cuando es posible.
-  const spawnCmd = useDeterministicSkill ? process.execPath : CLAUDE_LAUNCHER.cmd;
-  const spawnArgs = useDeterministicSkill
-    ? [deterministicScript, String(issue), `--trabajando=${trabajandoPath}`]
-    : [...CLAUDE_LAUNCHER.prefixArgs, ...args];
-
-  if (useDeterministicSkill) {
-    log('lanzamiento', `⚡ ${skill}:#${issue} ejecutado en modo determinístico (sin tokens LLM)`);
-  }
-
-  // #2801 — parsea el log stream-json del agente Claude y suma tokens de
-  // cada turno `assistant.usage`. Stream JSON line por línea — algunas
-  // líneas son truncadas o quedan a mitad por timeouts; el try/catch las
-  // descarta sin afectar el resto.
-  function parseTokensFromLog(logPath) {
-    const totals = { input: 0, output: 0, cache_read: 0, cache_create: 0, tool_calls: 0 };
-    try {
-      const raw = fs.readFileSync(logPath, 'utf8');
-      for (const line of raw.split('\n')) {
-        if (!line.startsWith('{')) continue;
-        let obj;
-        try { obj = JSON.parse(line); } catch { continue; }
-        if (obj.type === 'assistant' && obj.message && obj.message.usage) {
-          const u = obj.message.usage;
-          totals.input += Number(u.input_tokens || 0);
-          totals.output += Number(u.output_tokens || 0);
-          totals.cache_read += Number(u.cache_read_input_tokens || 0);
-          totals.cache_create += Number(u.cache_creation_input_tokens || 0);
-          if (Array.isArray(obj.message.content)) {
-            totals.tool_calls += obj.message.content.filter(c => c.type === 'tool_use').length;
-          }
-        }
-      }
-    } catch { /* log no existe o ilegible */ }
-    return totals;
-  }
-
-  // #2801 — emit session:start para agentes Claude (LLM). Los skills
-  // determinísticos emiten su propio par session:start/end internamente,
-  // así que solo cubrimos el path LLM acá. El handle se usa luego en
-  // child.on('exit') para emitir session:end con tokens parseados del log.
-  let traceHandle = null;
-  if (!useDeterministicSkill) {
-    try {
-      traceHandle = trace.emitSessionStart({
-        skill, issue: parseInt(issue), phase: fase, model: 'claude-opus-4-7',
-      });
-    } catch (e) {
-      log('lanzamiento', `traceability emitSessionStart falló: ${e.message}`);
-    }
-  }
-
-  // PIPELINE_WORKTREE: refuerzo defensivo del cwd. Algunos skills
-  // determinísticos (linter.js #2523 rev-1) precomputan rutas absolutas en
-  // tiempo de carga del módulo y no respetan el cwd del spawn salvo que se
-  // les diga explícitamente. Pasarlo como env evita que vuelvan a leer la
-  // rama del checkout principal por accidente.
+  // #3074 / H2 multi-provider — el spawn del agente (LLM o determinístico) se
+  // delega al wrapper `launchAgent` (`lib/agent-launcher.js`). El dispatcher
+  // resuelve el provider según `agent-models.json` (skill → provider+modelo);
+  // si el archivo no existe, defaultea a Anthropic con modelo legacy
+  // ("claude-opus-4-7") preservando regresión cero corriendo solo Anthropic.
+  //
+  // Skills determinísticos (allowlist hardcoded: builder/tester/delivery/linter)
+  // siempre van por provider="deterministic" y corren `skills-deterministicos/<skill>.js`
+  // con Node puro. Si el script fue removido (rollout reversible #2476), el
+  // wrapper cae a Anthropic LLM automáticamente.
+  //
+  // PIPELINE_WORKTREE: refuerzo defensivo del cwd. Algunos skills determinísticos
+  // (linter.js #2523 rev-1) precomputan rutas absolutas en tiempo de carga y no
+  // respetan el cwd del spawn salvo que se les diga explícitamente. Pasarlo como
+  // env evita que vuelvan a leer la rama del checkout principal por accidente.
   const spawnCwd = (needsWorktree || useExistingWorktree) ? worktreePath : ROOT;
-  const child = spawn(spawnCmd, spawnArgs, {
+  const launchResult = launchAgent({
+    skill, issue, trabajandoPath, fase, pipeline,
+    args,
     cwd: spawnCwd,
-    stdio: ['ignore', 'pipe', 'pipe'],
-    detached: false,
-    shell: useDeterministicSkill ? false : CLAUDE_LAUNCHER.shell,
-    windowsHide: true,
     env: {
       ...process.env,
       PIPELINE_ISSUE: issue,
@@ -4991,7 +4938,41 @@ function lanzarAgenteClaude(skill, issue, trabajandoPath, pipeline, fase, config
       })(),
       ...extraEnv,
     },
+    PIPELINE,
+    ROOT,
+    onWorktreeHit: (wt) => log('lanzamiento', `⚡ ${skill}:#${issue} usa script del worktree (${wt})`),
+    onLog: log,
   });
+  const child = launchResult.child;
+  const useDeterministicSkill = (launchResult.provider === 'deterministic');
+  if (useDeterministicSkill) {
+    log('lanzamiento', `⚡ ${skill}:#${issue} ejecutado en modo determinístico (sin tokens LLM)`);
+  }
+
+  // #2801 — parseTokensFromLog delega ahora al handler del provider resuelto
+  // por `launchAgent`. Cada provider trae su propia implementación (Anthropic
+  // parsea stream-json; deterministic devuelve zeros — no consume LLM tokens).
+  function parseTokensFromLog(logPath) {
+    return launchResult.handler.parseTokensFromLog(logPath);
+  }
+
+  // #2801 — emit session:start para agentes Claude (LLM). Los skills
+  // determinísticos emiten su propio par session:start/end internamente,
+  // así que solo cubrimos el path LLM acá. El handle se usa luego en
+  // child.on('exit') para emitir session:end con tokens parseados del log.
+  // #3074 — el `model` ahora viene resuelto del dispatcher (agent-models.json
+  // o fallback legacy), eliminando el hardcode previo.
+  let traceHandle = null;
+  if (!useDeterministicSkill) {
+    try {
+      traceHandle = trace.emitSessionStart({
+        skill, issue: parseInt(issue), phase: fase,
+        model: launchResult.model || 'claude-opus-4-7',
+      });
+    } catch (e) {
+      log('lanzamiento', `traceability emitSessionStart falló: ${e.message}`);
+    }
+  }
 
   // #2334 / CA6: piping stdout/stderr → sanitizeStream → file.
   // Montamos un único writer compartido para preservar el orden

--- a/.pipeline/tests/agent-launcher.test.js
+++ b/.pipeline/tests/agent-launcher.test.js
@@ -1,0 +1,372 @@
+// =============================================================================
+// agent-launcher.test.js — Tests del dispatcher por provider (#3074 / H2).
+//
+// Cubre:
+//   - launchAgent default a Anthropic legacy cuando agent-models.json no existe.
+//   - Skills determinísticos (allowlist) → provider 'deterministic'.
+//   - Fallback a Anthropic si el script determinístico no existe en disco.
+//   - Provider explicito por agent-models.json (anthropic con modelo custom).
+//   - Provider 'openai-codex' devuelve el handler stub (throw en buildSpawn).
+//   - Validación de provider desconocido.
+//   - Inyección de fsImpl/spawnImpl/execSyncImpl funciona (no toca disco/binarios).
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+
+const { launchAgent, PROVIDERS, resolveProviderForSkill } =
+    require('../lib/agent-launcher');
+
+// -----------------------------------------------------------------------------
+// Helpers — fakes inyectables compartidos por todos los tests.
+// -----------------------------------------------------------------------------
+function fakeFs(existingPaths, files = {}) {
+    const set = new Set(existingPaths);
+    return {
+        existsSync: (p) => set.has(p),
+        readFileSync: (p) => {
+            if (files[p] !== undefined) return files[p];
+            const e = new Error(`ENOENT: ${p}`);
+            e.code = 'ENOENT';
+            throw e;
+        },
+    };
+}
+
+function fakeSpawn() {
+    const calls = [];
+    const fake = (cmd, args, opts) => {
+        const handle = { cmd, args, opts, _isFakeChild: true };
+        calls.push(handle);
+        return handle;
+    };
+    fake.calls = calls;
+    return fake;
+}
+
+function fakeExecSync(out) {
+    return () => out;
+}
+
+const ROOT = '/repo/platform';
+const PIPELINE = path.join(ROOT, '.pipeline');
+
+// -----------------------------------------------------------------------------
+// 1. Default: sin agent-models.json → Anthropic legacy.
+// -----------------------------------------------------------------------------
+test('launchAgent defaultea a Anthropic con modelo legacy cuando agent-models.json no existe', () => {
+    const fsi = fakeFs([]);
+    const spi = fakeSpawn();
+    // Inyectamos el launcher de Anthropic para tests (evita detectar binario real).
+    PROVIDERS.anthropic._setLauncherForTesting({
+        kind: 'test', cmd: '/test/claude', prefixArgs: ['--prefix'], shell: false,
+    });
+
+    const result = launchAgent({
+        skill: 'guru',
+        issue: 1234,
+        args: ['-p', '--output-format', 'stream-json'],
+        cwd: ROOT,
+        env: { FOO: 'bar' },
+        PIPELINE,
+        ROOT,
+        fsImpl: fsi,
+        spawnImpl: spi,
+    });
+
+    assert.equal(result.provider, 'anthropic');
+    assert.equal(result.model, 'claude-opus-4-7');
+    assert.equal(result.source, 'fallback-no-config');
+    assert.equal(result.handler, PROVIDERS.anthropic);
+    assert.equal(spi.calls.length, 1);
+    assert.equal(spi.calls[0].cmd, '/test/claude');
+    assert.deepEqual(spi.calls[0].args, ['--prefix', '-p', '--output-format', 'stream-json']);
+    assert.equal(spi.calls[0].opts.cwd, ROOT);
+    assert.equal(spi.calls[0].opts.shell, false);
+    assert.equal(spi.calls[0].opts.windowsHide, true);
+    PROVIDERS.anthropic._resetLauncherCacheForTesting();
+});
+
+// -----------------------------------------------------------------------------
+// 2. Skill determinístico con script presente.
+// -----------------------------------------------------------------------------
+test('launchAgent rutea a deterministic cuando el skill está en allowlist y el script existe', () => {
+    const determScript = path.join(PIPELINE, 'skills-deterministicos', 'tester.js');
+    const fsi = fakeFs([determScript]);
+    const spi = fakeSpawn();
+
+    const result = launchAgent({
+        skill: 'tester',
+        issue: 5678,
+        trabajandoPath: '/work/5678.tester',
+        args: [],
+        cwd: ROOT,
+        env: { PIPELINE_ISSUE: '5678' },
+        PIPELINE,
+        ROOT,
+        execSyncImpl: fakeExecSync('worktree /repo/platform\nHEAD abc\n\n'),
+        fsImpl: fsi,
+        spawnImpl: spi,
+    });
+
+    assert.equal(result.provider, 'deterministic');
+    assert.equal(result.model, null);
+    assert.equal(result.source, 'deterministic-allowlist');
+    assert.equal(result.handler, PROVIDERS.deterministic);
+    assert.ok(result.scriptPath.endsWith(path.join('skills-deterministicos', 'tester.js')));
+    assert.equal(spi.calls.length, 1);
+    assert.equal(spi.calls[0].cmd, process.execPath);
+    assert.deepEqual(spi.calls[0].args, [determScript, '5678', '--trabajando=/work/5678.tester']);
+    // Invariante I1: shell:false SIEMPRE para determinísticos.
+    assert.equal(spi.calls[0].opts.shell, false);
+});
+
+// -----------------------------------------------------------------------------
+// 3. Fallback a Anthropic si el script determinístico no existe (rollout reversible).
+// -----------------------------------------------------------------------------
+test('launchAgent cae a Anthropic si el script determinístico fue removido (rollout reversible)', () => {
+    const fsi = fakeFs([]); // ningún path existe → script no encontrado
+    const spi = fakeSpawn();
+    const warnings = [];
+    PROVIDERS.anthropic._setLauncherForTesting({
+        kind: 'test', cmd: '/test/claude', prefixArgs: [], shell: false,
+    });
+
+    const result = launchAgent({
+        skill: 'builder',
+        issue: 9999,
+        args: ['-p'],
+        cwd: ROOT,
+        env: {},
+        PIPELINE,
+        ROOT,
+        execSyncImpl: fakeExecSync(''),
+        fsImpl: fsi,
+        spawnImpl: spi,
+        onLog: (channel, msg) => warnings.push({ channel, msg }),
+    });
+
+    assert.equal(result.provider, 'anthropic');
+    assert.equal(result.source, 'fallback-deterministic-script-missing');
+    assert.equal(spi.calls[0].cmd, '/test/claude');
+    assert.ok(
+        warnings.some((w) => w.msg.includes('script determinístico no existe')),
+        'esperado warning de fallback'
+    );
+    PROVIDERS.anthropic._resetLauncherCacheForTesting();
+});
+
+// -----------------------------------------------------------------------------
+// 4. agent-models.json define provider y modelo explícitos.
+// -----------------------------------------------------------------------------
+test('launchAgent respeta agent-models.json cuando resuelve provider+modelo del skill', () => {
+    const modelsPath = path.join(PIPELINE, 'agent-models.json');
+    const fsi = fakeFs([modelsPath], {
+        [modelsPath]: JSON.stringify({
+            defaults: { model: 'claude-sonnet-4-5' },
+            skills: {
+                guru: { provider: 'anthropic', model: 'claude-opus-4-7-1m' },
+            },
+        }),
+    });
+    const spi = fakeSpawn();
+    PROVIDERS.anthropic._setLauncherForTesting({
+        kind: 'test', cmd: '/test/claude', prefixArgs: [], shell: false,
+    });
+
+    const result = launchAgent({
+        skill: 'guru',
+        issue: 1,
+        args: ['-p'],
+        cwd: ROOT,
+        env: {},
+        PIPELINE,
+        ROOT,
+        fsImpl: fsi,
+        spawnImpl: spi,
+    });
+
+    assert.equal(result.provider, 'anthropic');
+    assert.equal(result.model, 'claude-opus-4-7-1m');
+    assert.equal(result.source, 'agent-models');
+    PROVIDERS.anthropic._resetLauncherCacheForTesting();
+});
+
+// -----------------------------------------------------------------------------
+// 5. Skill no listado en agent-models.json usa default de defaults.model.
+// -----------------------------------------------------------------------------
+test('launchAgent usa defaults.model cuando el skill no está listado en agent-models.json', () => {
+    const modelsPath = path.join(PIPELINE, 'agent-models.json');
+    const fsi = fakeFs([modelsPath], {
+        [modelsPath]: JSON.stringify({
+            defaults: { model: 'claude-sonnet-4-5' },
+            skills: {},
+        }),
+    });
+    const spi = fakeSpawn();
+    PROVIDERS.anthropic._setLauncherForTesting({
+        kind: 'test', cmd: '/test/claude', prefixArgs: [], shell: false,
+    });
+
+    const result = launchAgent({
+        skill: 'po',
+        issue: 1,
+        args: [],
+        cwd: ROOT,
+        env: {},
+        PIPELINE,
+        ROOT,
+        fsImpl: fsi,
+        spawnImpl: spi,
+    });
+
+    assert.equal(result.provider, 'anthropic');
+    assert.equal(result.model, 'claude-sonnet-4-5');
+    assert.equal(result.source, 'fallback-skill-not-found');
+    PROVIDERS.anthropic._resetLauncherCacheForTesting();
+});
+
+// -----------------------------------------------------------------------------
+// 6. Provider 'openai-codex' (stub) tira error accionable en buildSpawn.
+// -----------------------------------------------------------------------------
+test('launchAgent con provider openai-codex tira error accionable (stub para H3)', () => {
+    const modelsPath = path.join(PIPELINE, 'agent-models.json');
+    const fsi = fakeFs([modelsPath], {
+        [modelsPath]: JSON.stringify({
+            defaults: { model: 'claude-opus-4-7' },
+            skills: {
+                planner: { provider: 'openai-codex', model: 'gpt-5-codex' },
+            },
+        }),
+    });
+    const spi = fakeSpawn();
+
+    assert.throws(
+        () =>
+            launchAgent({
+                skill: 'planner',
+                issue: 1,
+                args: [],
+                cwd: ROOT,
+                env: {},
+                PIPELINE,
+                ROOT,
+                fsImpl: fsi,
+                spawnImpl: spi,
+            }),
+        /openai-codex.*no está implementado/i
+    );
+    // El spawn no debe haberse llamado.
+    assert.equal(spi.calls.length, 0);
+});
+
+// -----------------------------------------------------------------------------
+// 7. Provider desconocido en agent-models.json → error explícito.
+// -----------------------------------------------------------------------------
+test('launchAgent valida provider desconocido con mensaje accionable', () => {
+    const modelsPath = path.join(PIPELINE, 'agent-models.json');
+    const fsi = fakeFs([modelsPath], {
+        [modelsPath]: JSON.stringify({
+            skills: { guru: { provider: 'magic-llm' } },
+        }),
+    });
+    assert.throws(
+        () =>
+            launchAgent({
+                skill: 'guru',
+                issue: 1,
+                args: [],
+                cwd: ROOT,
+                env: {},
+                PIPELINE,
+                ROOT,
+                fsImpl: fsi,
+                spawnImpl: fakeSpawn(),
+            }),
+        /Provider desconocido "magic-llm"/
+    );
+});
+
+// -----------------------------------------------------------------------------
+// 8. Skill ausente o inválido tira error.
+// -----------------------------------------------------------------------------
+test('launchAgent rechaza skill vacío o no string', () => {
+    assert.throws(
+        () =>
+            launchAgent({
+                skill: '',
+                issue: 1,
+                args: [],
+                cwd: ROOT,
+                env: {},
+                PIPELINE,
+                ROOT,
+                fsImpl: fakeFs([]),
+                spawnImpl: fakeSpawn(),
+            }),
+        /skill.*requerido/i
+    );
+});
+
+// -----------------------------------------------------------------------------
+// 9. JSON inválido en agent-models.json → fallback con warning.
+// -----------------------------------------------------------------------------
+test('launchAgent maneja JSON inválido en agent-models.json sin crashear (fallback + warning)', () => {
+    const modelsPath = path.join(PIPELINE, 'agent-models.json');
+    const fsi = fakeFs([modelsPath], { [modelsPath]: '{ broken json' });
+    const spi = fakeSpawn();
+    const warnings = [];
+    PROVIDERS.anthropic._setLauncherForTesting({
+        kind: 'test', cmd: '/test/claude', prefixArgs: [], shell: false,
+    });
+
+    const result = launchAgent({
+        skill: 'guru',
+        issue: 1,
+        args: [],
+        cwd: ROOT,
+        env: {},
+        PIPELINE,
+        ROOT,
+        fsImpl: fsi,
+        spawnImpl: spi,
+        onLog: (channel, msg) => warnings.push(msg),
+    });
+
+    assert.equal(result.provider, 'anthropic');
+    assert.equal(result.model, 'claude-opus-4-7');
+    assert.equal(result.source, 'fallback-read-error');
+    assert.ok(warnings.some((m) => m.includes('agent-models.json no se pudo parsear')));
+    PROVIDERS.anthropic._resetLauncherCacheForTesting();
+});
+
+// -----------------------------------------------------------------------------
+// 10. Test sanity del resolveProviderForSkill (puro, sin spawn).
+// -----------------------------------------------------------------------------
+test('resolveProviderForSkill: builder/tester/delivery/linter siempre son deterministic', () => {
+    const fsi = fakeFs([]);
+    for (const skill of ['builder', 'tester', 'delivery', 'linter']) {
+        const r = resolveProviderForSkill(skill, { pipelineDir: PIPELINE, fsImpl: fsi });
+        assert.equal(r.provider, 'deterministic', `skill ${skill} debería ser deterministic`);
+        assert.equal(r.handler, PROVIDERS.deterministic);
+    }
+});
+
+// -----------------------------------------------------------------------------
+// 11. Cuando agent-models.json existe pero el skill es determinístico,
+//     se ignora la config (allowlist hardcoded gana — invariante I4 seguridad).
+// -----------------------------------------------------------------------------
+test('resolveProviderForSkill: skills determinísticos ignoran agent-models.json (allowlist hardcoded)', () => {
+    const modelsPath = path.join(PIPELINE, 'agent-models.json');
+    const fsi = fakeFs([modelsPath], {
+        [modelsPath]: JSON.stringify({
+            skills: { builder: { provider: 'anthropic', model: 'claude-opus-4-7' } },
+        }),
+    });
+    const r = resolveProviderForSkill('builder', { pipelineDir: PIPELINE, fsImpl: fsi });
+    // builder está en la allowlist → siempre deterministic, agent-models.json ignorado.
+    assert.equal(r.provider, 'deterministic');
+    assert.equal(r.source, 'deterministic-allowlist');
+});


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 7 archivos · +1085 -75

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:skipped` aplicado por delivery

## Closes

Closes #3074
