### PR TITLE
fix(pipeline): alias skill 'build' en DETERMINISTIC_SKILLS del modo descanso

### DIFF
--- a/.pipeline/config.yaml
+++ b/.pipeline/config.yaml
@@ -268,7 +268,7 @@ cost_anomaly_alert:
 
 # Modo descanso (#2890 PR-A, parte del épico #2882) — gating horario.
 # Durante la ventana configurada, sólo corren los skills determinísticos
-# (delivery, builder, linter, tester). El resto queda en `pendiente/` sin
+# (delivery, build, linter, tester). El resto queda en `pendiente/` sin
 # penalización (no consume rebote).
 #
 # La configuración funcional (active, start, end, timezone, days, manual)

--- a/.pipeline/lib/__tests__/rest-mode-window.test.js
+++ b/.pipeline/lib/__tests__/rest-mode-window.test.js
@@ -174,7 +174,7 @@ test('isSkillAllowedNow bloquea skill no determinístico dentro de la ventana', 
 
 test('isSkillAllowedNow permite skill determinístico dentro de la ventana', () => {
     const window = { active: true, start: '13:00', end: '17:00', timezone: 'UTC', days: [0, 1, 2, 3, 4, 5, 6] };
-    for (const skill of ['delivery', 'builder', 'linter', 'tester']) {
+    for (const skill of ['delivery', 'build', 'linter', 'tester']) {
         const r = rmw.isSkillAllowedNow(skill, Date.UTC(2026, 0, 5, 14, 0, 0), { window });
         assert.equal(r.allowed, true, `${skill} debería pasar`);
         assert.equal(r.reason, 'deterministic_skill');
@@ -321,7 +321,7 @@ test('DETERMINISTIC_SKILLS coincide con el set documentado', () => {
     // Si pulpo.js cambia su set, este test obliga a actualizar el módulo.
     assert.deepEqual(
         [...rmw.DETERMINISTIC_SKILLS].sort(),
-        ['builder', 'delivery', 'linter', 'tester'].sort()
+        ['build', 'delivery', 'linter', 'tester'].sort()
     );
 });
 

--- a/.pipeline/lib/rest-mode-window.js
+++ b/.pipeline/lib/rest-mode-window.js
@@ -34,7 +34,11 @@ const DEFAULT_PIPELINE_DIR = path.resolve(__dirname, '..');
 // Mismo set que pulpo.js — duplicado a propósito para no introducir un
 // require circular (pulpo → este módulo → pulpo). Si se cambia uno, cambiar
 // el otro. Test de coherencia en `__tests__/rest-mode-window.test.js`.
-const DETERMINISTIC_SKILLS = Object.freeze(['delivery', 'builder', 'linter', 'tester']);
+// El nombre del skill `build` viene de `config.yaml::pipelines.desarrollo.skills_por_fase.build`
+// — no es `builder`, aunque el script en disco se llame `skills-deterministicos/builder.js`.
+// Si esto se desincroniza con el set de pulpo.js, los builds quedan bloqueados durante
+// la ventana de descanso (regresión observada 2026-05-08).
+const DETERMINISTIC_SKILLS = Object.freeze(['delivery', 'build', 'linter', 'tester']);
 
 const DEFAULT_TIMEZONE = 'America/Argentina/Buenos_Aires';
 const DEFAULT_DAYS = Object.freeze([0, 1, 2, 3, 4, 5, 6]);


### PR DESCRIPTION
## Resumen

`DETERMINISTIC_SKILLS` en `rest-mode-window.js` usaba `builder`, mientras que `config.yaml::pipelines.desarrollo.skills_por_fase.build` expone el skill como `build`. El mismatch bloqueaba builds durante la ventana de descanso, contradiciendo el contrato (build es determinístico, debe pasar igual).

## Causa raíz

Detectado tras activar la ventana 22:00 -> 07:00 ART el 2026-05-08 y observar `rest_mode_skip` para `build` en los logs de `pulpo.js`. El nombre venía duplicado a propósito en el módulo (para evitar require circular con `pulpo.js`), pero quedó desincronizado.

## Cambios

- `.pipeline/lib/rest-mode-window.js`: `DETERMINISTIC_SKILLS` ahora contiene `build` (en lugar de `builder`). Se agregó comentario explicando el contrato y por qué duplicamos el set.
- `.pipeline/lib/__tests__/rest-mode-window.test.js`: dos tests actualizados al nuevo nombre — el de skill permitido dentro de la ventana y el de coherencia con el set documentado.
- `.pipeline/config.yaml`: comentario del modo descanso refleja el nombre correcto del skill.

## Validación

- 28/28 tests verde en `node --test .pipeline/lib/__tests__/rest-mode-window.test.js`.

## QA

`qa:skipped` — cambio puro de pipeline interno (gating del modo descanso). Sin impacto en producto de usuario; cubierto por tests del módulo.

## Closes

N/A — fix detectado en operación, sin issue previo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)