### PR TITLE
fix(pipeline): ghostbusters - parser robusto + ignora artefactos build

### DIFF
--- a/.pipeline/ghostbusters.js
+++ b/.pipeline/ghostbusters.js
@@ -282,8 +282,26 @@ function isWorktreeSafeToDelete(wtPath, branch) {
     }).trim();
     const relevantChanges = status.split('\n').filter(l => {
       if (!l.trim()) return false;
-      const filepath = l.substring(3).trim();
-      return !filepath.startsWith('.claude/') && !filepath.startsWith('.claude\\');
+      // git status --porcelain: "XY filename" (2 status chars + space + path).
+      // Parseo robusto: descarta primeros 2 chars y limpia el separador opcional.
+      const filepath = l.length > 2 ? l.slice(2).replace(/^\s+/, '').replace(/^"|"$/g, '') : l.trim();
+      const norm = filepath.replace(/\\/g, '/');
+      // Patrones ignorables: artefactos generados por agentes/build, no son trabajo real.
+      const ignored = [
+        /^\.claude\//,
+        /^\.gradle\//,
+        /^\.gradle-temp\//,
+        /^\.kotlin\//,
+        /^node_modules\//,
+        /(^|\/)build\//,
+        /(^|\/)\.idea\//,
+        /(^|\/)\.DS_Store$/,
+        /(^|\/)Thumbs\.db$/i,
+        /(^|\/)bash\.exe\.stackdump$/i,
+        /\.pyc$/,
+        /\.log$/,
+      ];
+      return !ignored.some(re => re.test(norm));
     });
     if (relevantChanges.length > 0) return { safe: false, reason: `${relevantChanges.length} archivo(s) sin commitear` };
 


### PR DESCRIPTION
## Summary

- Corrige el parser de `git status --porcelain` en `isWorktreeSafeToDelete` (descarte de los 2 chars de status + trim de quoted paths).
- Amplía la lista de patrones ignorables para no proteger worktrees por artefactos generados (`.gradle/`, `.kotlin/`, `node_modules/`, `build/`, `.idea/`, logs, temporales).
- Resultado: ghostbusters `--deep` ahora libera correctamente worktrees abandonados que quedaban falsamente protegidos.

## Contexto

Auditoría manual durante incidente de saturación de disco C: detectó que worktrees como `session-fixsaturacion-20260406` (250 MB) quedaban protegidos por basura de build, no por trabajo real. El fix elimina esos falsos positivos.

## Test plan

- [x] Parse OK (`node -e "require('./.pipeline/ghostbusters.js')"`)
- [ ] Validar en próxima corrida `/ghostbusters --deep` que libera dirs con `.gradle/` pero sin commits ahead

qa:skipped — cambio de tooling interno del pipeline (no afecta producto de usuario, no es UI ni endpoint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)