### PR TITLE
fix(pipeline): filtrar .guidance.txt en listadores de bloqueado-humano

### DIFF
--- a/.pipeline/lib/__tests__/human-block.test.js
+++ b/.pipeline/lib/__tests__/human-block.test.js
@@ -246,6 +246,49 @@ test('listBlockedIssues ignora archivos .reason.json y .gitkeep', () => {
     assert.equal(list.find(i => String(i.issue) === '.gitkeep'), undefined);
 });
 
+// Regresión: cuando un humano deja un `.guidance.txt` al lado de un marker
+// bloqueado, el listador NO debe tratarlo como un segundo marker fantasma.
+// Si lo hacía, el reconciler veía dos entradas para el mismo issue, no
+// encontraba reason.json válido para la guidance, y terminaba re-aplicando
+// el label needs-human aunque el humano lo hubiera quitado en GitHub.
+test('listBlockedIssues ignora .guidance.txt como marker fantasma', () => {
+    resetFs();
+    hb.reportHumanBlock({
+        issue: 3075, skill: 'pipeline-dev', phase: 'dev', pipeline: 'desarrollo',
+        reason: 'Bloqueante mergeado, requiere relanzar',
+        question: '¿Volvemos a encolar a dev?',
+    });
+    // Simula el archivo de guidance que cargo manualmente al destrabar.
+    const dir = path.join(TMP_DIR, '.pipeline', 'desarrollo', 'dev', 'bloqueado-humano');
+    fs.writeFileSync(path.join(dir, '3075.pipeline-dev.guidance.txt'), 'Encoda al toque');
+
+    const list = hb.listBlockedIssues();
+    const matches = list.filter(i => i.issue === 3075);
+    assert.equal(matches.length, 1, 'solo un marker real, no debe incluir guidance.txt');
+    assert.equal(matches[0].skill, 'pipeline-dev');
+});
+
+test('findBlockedMarker ignora .guidance.txt y .reason.json al buscar', () => {
+    resetFs();
+    const dir = path.join(TMP_DIR, '.pipeline', 'desarrollo', 'dev', 'bloqueado-humano');
+    fs.mkdirSync(dir, { recursive: true });
+    // Crear solo artifacts, sin marker real.
+    fs.writeFileSync(path.join(dir, '7777.po.guidance.txt'), 'g');
+    fs.writeFileSync(path.join(dir, '7777.po.reason.json'), '{}');
+    assert.equal(hb.findBlockedMarker(7777), null, 'sin marker real, debe devolver null');
+});
+
+test('findActiveMarker ignora .guidance.txt en estados activos', () => {
+    resetFs();
+    const dir = path.join(TMP_DIR, '.pipeline', 'desarrollo', 'dev', 'pendiente');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, '8888.po'), '');
+    fs.writeFileSync(path.join(dir, '8888.po.guidance.txt'), 'g');
+    const found = hb.findActiveMarker(8888);
+    assert.ok(found);
+    assert.equal(found.skill, 'po', 'debe devolver el marker real, no el guidance');
+});
+
 // =============================================================================
 // #2549 — isHumanBlockReason: detección de motivos de bloqueo humano en rechazos
 // =============================================================================

--- a/.pipeline/lib/human-block.js
+++ b/.pipeline/lib/human-block.js
@@ -89,6 +89,14 @@ function emitDismissed(opts) {
     });
 }
 
+// Artifacts auxiliares (.reason.json metadata, .guidance.txt de destrabe humano)
+// no son markers de skill. Si se cuentan como markers, el listado devuelve dos
+// entradas por issue (la real y la fantasma), el reconciler no encuentra
+// reason válido para la fantasma, y termina re-aplicando el label needs-human.
+function isMarkerArtifact(name) {
+    return name.endsWith('.reason.json') || name.endsWith('.guidance.txt');
+}
+
 function findActiveMarker(issue) {
     const prefix = String(issue) + '.';
     for (const pipeline of PIPELINES) {
@@ -102,7 +110,7 @@ function findActiveMarker(issue) {
                 let entries = [];
                 try { entries = fs.readdirSync(dir); } catch { continue; }
                 for (const f of entries) {
-                    if (f.startsWith(prefix) && f !== '.gitkeep') {
+                    if (f.startsWith(prefix) && f !== '.gitkeep' && !isMarkerArtifact(f)) {
                         return {
                             pipeline, phase, state,
                             skill: f.slice(prefix.length),
@@ -128,7 +136,7 @@ function findBlockedMarker(issue) {
             let entries = [];
             try { entries = fs.readdirSync(dir); } catch { continue; }
             for (const f of entries) {
-                if (f.startsWith(prefix) && f !== '.gitkeep') {
+                if (f.startsWith(prefix) && f !== '.gitkeep' && !isMarkerArtifact(f)) {
                     return {
                         pipeline, phase,
                         skill: f.slice(prefix.length),
@@ -214,7 +222,7 @@ function listBlockedIssues() {
             let entries = [];
             try { entries = fs.readdirSync(dir); } catch { continue; }
             for (const f of entries) {
-                if (f === '.gitkeep' || f.endsWith('.reason.json')) continue;
+                if (f === '.gitkeep' || isMarkerArtifact(f)) continue;
                 const dot = f.indexOf('.');
                 if (dot <= 0) continue;
                 const issue = Number(f.slice(0, dot));


### PR DESCRIPTION
## Summary
- Bug: `listBlockedIssues`, `findBlockedMarker` y `findActiveMarker` en `.pipeline/lib/human-block.js` ignoraban solo `.reason.json` y `.gitkeep` como markers, tratando los archivos `.guidance.txt` (cargados al lado del marker para dar contexto al destrabe) como un skill bloqueado adicional.
- Impacto reproducido: #3075 entraba en loop `guidance` → `bloqueado-humano` cada ~10 min porque el listador veía dos markers (skill real `pipeline-dev` + el `.guidance.txt`) y el reconciler reaplicaba el label `needs-human` en GitHub apenas se removía manualmente.
- Fix: helper `isMarkerArtifact()` centralizado que excluye `.reason.json`, `.gitkeep` y `.guidance.txt`, aplicado en los 3 listadores.

## Test plan
- [x] Tests existentes: 22/22 verde
- [x] +3 tests de regresión específicos para `.guidance.txt`:
  - `listBlockedIssues ignora .guidance.txt como marker fantasma`
  - `findBlockedMarker ignora .guidance.txt y .reason.json al buscar`
  - `findActiveMarker ignora .guidance.txt en estados activos`
- [x] Total: 25/25 verde

## QA
`qa:skipped` — cambio puro de pipeline interno (`tipo:infra` / `area:pipeline`), sin impacto en producto de usuario final. Cubierto por tests unitarios de regresión.

🤖 Generated with [Claude Code](https://claude.com/claude-code)