### PR TITLE
fix(dashboard): filtrar artifacts auxiliares en cola y conteos (próximos 10 + listWorkFiles)

### DIFF
--- a/.pipeline/dashboard.js
+++ b/.pipeline/dashboard.js
@@ -55,6 +55,19 @@ try { restModeState = require('./lib/rest-mode-state'); } catch { /* opcional */
 let restModeWindow = null;
 try { restModeWindow = require('./lib/rest-mode-window'); } catch { /* opcional */ }
 
+// Detector de artifacts auxiliares compartido con human-block.js: excluye
+// `.guidance.txt`, `.reason.json`, `.comment.md` y cualquier filename con
+// > 2 segmentos del listado de markers, así no aparecen como agentes fantasma.
+let _isMarkerArtifact;
+try { ({ isMarkerArtifact: _isMarkerArtifact } = require('./lib/human-block')); } catch { /* opcional */ }
+function isMarkerArtifact(name) {
+  if (typeof _isMarkerArtifact === 'function') return _isMarkerArtifact(name);
+  return name.split('.').length > 2
+      || name.endsWith('.reason.json')
+      || name.endsWith('.guidance.txt')
+      || name.endsWith('.comment.md');
+}
+
 const PORT = parseInt(process.env.DASHBOARD_PORT) || 3200;
 const PIPELINE = process.env.PIPELINE_STATE_DIR || path.resolve(__dirname);
 const ROOT = process.env.PIPELINE_MAIN_ROOT || path.resolve(__dirname, '..');
@@ -304,8 +317,15 @@ function loadConfig() {
 }
 
 function listWorkFiles(dir) {
-  try { return fs.readdirSync(dir).filter(f => !f.startsWith('.') && !f.endsWith('.gitkeep')); }
-  catch { return []; }
+  try {
+    return fs.readdirSync(dir).filter(f => {
+      if (f.startsWith('.') || f.endsWith('.gitkeep')) return false;
+      // Excluir artifacts (.guidance.txt, .reason.json, .comment.md, etc.)
+      // que no son markers de skill — evita que aparezcan como agentes fantasma
+      // en issueMatrix y en los conteos del dashboard.
+      return !isMarkerArtifact(f);
+    });
+  } catch { return []; }
 }
 
 function readYamlSafe(filepath) {

--- a/.pipeline/lib/__tests__/dashboard-slices-next-in-queue.test.js
+++ b/.pipeline/lib/__tests__/dashboard-slices-next-in-queue.test.js
@@ -194,6 +194,111 @@ test('nextInQueue: limit recorta despues del filtrado por allowlist', () => {
     }
 });
 
+// =============================================================================
+// Regresión #3145 — Artifacts auxiliares no son markers de skill.
+//
+// `nextInQueue` listaba `3076.po.comment.md` como agente "po.comment.md" en
+// la cola (caso real visto el 2026-05-11). El listador filtra ahora cualquier
+// archivo con > 2 segmentos, además de los sufijos típicos.
+// =============================================================================
+test('nextInQueue: ignora .comment.md como marker fantasma', () => {
+    clearPause();
+    const PIPELINE = fs.mkdtempSync(path.join(os.tmpdir(), 'v3-niq-artifact-'));
+    try {
+        const sub = path.join(PIPELINE, 'definicion', 'criterios', 'pendiente');
+        fs.mkdirSync(sub, { recursive: true });
+        // Marker real + artifact con > 2 segmentos
+        fs.writeFileSync(path.join(sub, '3076.pipeline-dev'), '');
+        fs.writeFileSync(path.join(sub, '3076.po.comment.md'), 'criterios');
+        const state = {
+            config: { concurrencia: { 'pipeline-dev': 2 } },
+            allFases: [{ pipeline: 'definicion', fase: 'criterios' }],
+            issueMatrix: { '3076': { title: 'x', bounces: 0, fases: {} } },
+            etaAverages: {},
+        };
+        const out = slices.nextInQueue(state, { PIPELINE }, 10);
+        assert.equal(out.length, 1, 'solo el marker real debe aparecer');
+        assert.equal(out[0].skill, 'pipeline-dev');
+        assert.equal(out.find(o => o.skill === 'po.comment.md'), undefined);
+    } finally {
+        try { fs.rmSync(PIPELINE, { recursive: true, force: true }); } catch {}
+    }
+});
+
+test('nextInQueue: ignora .guidance.txt y .reason.json como markers fantasma', () => {
+    clearPause();
+    const PIPELINE = fs.mkdtempSync(path.join(os.tmpdir(), 'v3-niq-artifact2-'));
+    try {
+        const sub = path.join(PIPELINE, 'desarrollo', 'dev', 'pendiente');
+        fs.mkdirSync(sub, { recursive: true });
+        fs.writeFileSync(path.join(sub, '3075.pipeline-dev'), '');
+        fs.writeFileSync(path.join(sub, '3075.pipeline-dev.guidance.txt'), 'pista');
+        fs.writeFileSync(path.join(sub, '3075.pipeline-dev.reason.json'), '{}');
+        const state = {
+            config: { concurrencia: { 'pipeline-dev': 2 } },
+            allFases: [{ pipeline: 'desarrollo', fase: 'dev' }],
+            issueMatrix: { '3075': { title: 'x', bounces: 0, fases: {} } },
+            etaAverages: {},
+        };
+        const out = slices.nextInQueue(state, { PIPELINE }, 10);
+        assert.equal(out.length, 1, 'solo el marker real debe aparecer');
+        assert.equal(out[0].skill, 'pipeline-dev');
+    } finally {
+        try { fs.rmSync(PIPELINE, { recursive: true, force: true }); } catch {}
+    }
+});
+
+// =============================================================================
+// Regresión #3145 (Bug 2) — Early-break no se consume con items fuera de allowlist.
+//
+// Antes del fix: `if (out.length >= limit * 4) break;` se evaluaba ANTES de
+// filtrar por allowlist. Una fase con >= limit*4 items legacy fuera de
+// allowlist comía el early-break y ocultaba items reales de fases posteriores.
+//
+// Ahora el filtro de allowlist está dentro del loop, así que items
+// descartados ni se cuentan para el early-break.
+// =============================================================================
+test('nextInQueue: backlog legacy fuera de allowlist no oculta items reales de otras fases', () => {
+    clearPause();
+    // limit=2 → early-break en out.length >= 8
+    // Simulamos 12 items legacy en validacion/pendiente (todos fuera de allowlist)
+    // + 1 item real en desarrollo/dev/pendiente (dentro de allowlist)
+    const PIPELINE = fs.mkdtempSync(path.join(os.tmpdir(), 'v3-niq-earlybreak-'));
+    try {
+        const legacyDir = path.join(PIPELINE, 'desarrollo', 'validacion', 'pendiente');
+        fs.mkdirSync(legacyDir, { recursive: true });
+        for (let i = 1; i <= 12; i++) {
+            fs.writeFileSync(path.join(legacyDir, `${1000 + i}.ux`), '');
+        }
+        const devDir = path.join(PIPELINE, 'desarrollo', 'dev', 'pendiente');
+        fs.mkdirSync(devDir, { recursive: true });
+        fs.writeFileSync(path.join(devDir, '3075.pipeline-dev'), '');
+
+        pp.setPartialPause([3075], { source: 'test' });
+
+        const issueMatrix = { '3075': { title: 'real', bounces: 0, fases: {} } };
+        for (let i = 1; i <= 12; i++) {
+            issueMatrix[String(1000 + i)] = { title: `legacy ${i}`, bounces: 0, fases: {} };
+        }
+        const state = {
+            config: { concurrencia: { 'pipeline-dev': 2, ux: 1 } },
+            // OJO: orden importa — validacion se procesa ANTES que dev
+            allFases: [
+                { pipeline: 'desarrollo', fase: 'validacion' },
+                { pipeline: 'desarrollo', fase: 'dev' },
+            ],
+            issueMatrix,
+            etaAverages: {},
+        };
+        const out = slices.nextInQueue(state, { PIPELINE }, 2);
+        assert.equal(out.length, 1, 'el item real de la fase posterior debe aparecer');
+        assert.equal(out[0].issue, '3075');
+    } finally {
+        clearPause();
+        try { fs.rmSync(PIPELINE, { recursive: true, force: true }); } catch {}
+    }
+});
+
 // Cleanup: evita dejar el TMP_DIR colgando en /tmp después de los tests.
 test.after(() => {
     try { fs.rmSync(TMP_DIR, { recursive: true, force: true }); } catch {}

--- a/.pipeline/lib/dashboard-slices.js
+++ b/.pipeline/lib/dashboard-slices.js
@@ -34,6 +34,19 @@ const DETERMINISTIC_SKILLS = new Set(['builder', 'tester', 'delivery', 'linter']
 let partialPause = null;
 try { partialPause = require('./partial-pause'); } catch { /* opcional */ }
 
+// Detector de artifacts auxiliares (.guidance.txt, .reason.json, .comment.md,
+// y cualquier filename con > 2 segmentos). Compartido con human-block para
+// que ambos listadores excluyan los mismos fantasmas. Fallback defensivo si
+// el módulo no carga.
+let isMarkerArtifact;
+try { ({ isMarkerArtifact } = require('./human-block')); } catch { /* opcional */ }
+if (typeof isMarkerArtifact !== 'function') {
+    isMarkerArtifact = (name) => name.split('.').length > 2
+        || name.endsWith('.reason.json')
+        || name.endsWith('.guidance.txt')
+        || name.endsWith('.comment.md');
+}
+
 function isDeterministicSkill(skill) {
     return DETERMINISTIC_SKILLS.has(String(skill || '').trim().toLowerCase());
 }
@@ -101,22 +114,6 @@ function recentlyFinished(state, limit = 3, opts = {}) {
     return out.slice(0, limit);
 }
 
-// #3023 — Si está en pausa parcial, filtra `items` dejando sólo los que
-// están en la allowlist; otros estados (running/paused) NO filtran (la
-// pausa total se renderiza con el banner global, fuera de alcance).
-//
-// Usa `isIssueAllowedInState` para evitar la trampa string↔number: los
-// items de cola exponen `item.issue` como string (`f.split('.')[0]`) pero
-// `allowedIssues` viene como `number[]`. La función helper hace
-// `normalizeIssue()` por dentro y resuelve la coerción correctamente.
-function applyPartialPauseFilter(items, ppState) {
-    if (!ppState || ppState.mode !== 'partial_pause') return items;
-    if (!partialPause || typeof partialPause.isIssueAllowedInState !== 'function') {
-        return items;
-    }
-    return items.filter(item => partialPause.isIssueAllowedInState(item.issue, ppState));
-}
-
 function nextInQueue(state, ctx, limit = 3, opts = {}) {
     const PIPELINE = ctx.PIPELINE;
     const out = [];
@@ -135,17 +132,43 @@ function nextInQueue(state, ctx, limit = 3, opts = {}) {
         }
     }
 
+    // Resolver pipelineMode UNA vez antes del loop. Necesario para filtrar
+    // inline contra la allowlist (ver más abajo) y evitar que el early-break
+    // de `out.length >= limit * 4` se consuma con items que después van a
+    // descartarse por pausa parcial.
+    //
+    // `opts.pipelineMode` permite a callers (route handler, tests) inyectar
+    // el modo ya leído. Si no se pasa, se lee del filesystem vía el módulo
+    // `partial-pause` (lectura barata, dos `existsSync` + un `readFileSync`).
+    let ppState = opts.pipelineMode || null;
+    if (!ppState && partialPause && typeof partialPause.getPipelineMode === 'function') {
+        try { ppState = partialPause.getPipelineMode(); } catch { ppState = null; }
+    }
+    const ppActive = !!(ppState && ppState.mode === 'partial_pause'
+        && partialPause && typeof partialPause.isIssueAllowedInState === 'function');
+
     const seen = new Set();
     for (const { pipeline: pName, fase } of state.allFases || []) {
         const dir = path.join(PIPELINE, pName, fase, 'pendiente');
         let files = [];
-        try { files = fs.readdirSync(dir).filter(f => !f.startsWith('.')); } catch { continue; }
+        // Filtrar artifacts (.guidance.txt, .reason.json, .comment.md, etc.)
+        // para que no se traten como markers fantasma (ej: `3076.po.comment.md`
+        // aparecía como agente "po.comment.md" en la cola).
+        try { files = fs.readdirSync(dir).filter(f => !f.startsWith('.') && !isMarkerArtifact(f)); } catch { continue; }
         for (const f of files) {
             const issue = f.split('.')[0];
             const skill = f.split('.').slice(1).join('.');
             const key = `${issue}.${skill}`;
             if (seen.has(key)) continue;
             seen.add(key);
+
+            // Si hay pausa parcial, filtrar inline ANTES del push. Si no
+            // filtramos acá, una fase con muchos items fuera de allowlist
+            // (típico: `validacion/pendiente/` con backlog histórico de
+            // ~40 issues legacy) consume el early-break y oculta items
+            // reales de fases posteriores (dev, aprobación, etc.).
+            if (ppActive && !partialPause.isIssueAllowedInState(issue, ppState)) continue;
+
             const data = state.issueMatrix?.[issue];
             const load = skillLoad[skill] || { running: 0, max: 0 };
             const slotFree = load.running < load.max;
@@ -166,24 +189,11 @@ function nextInQueue(state, ctx, limit = 3, opts = {}) {
         if (out.length >= limit * 4) break;
     }
 
-    // #3023 — Filtrar por allowlist ANTES del sort para no descartar items
-    // priorizados. En la práctica el sort es estable y da el mismo resultado,
-    // pero conceptualmente: filtrar primero, sortear después.
-    //
-    // `opts.pipelineMode` permite a callers (route handler, tests) inyectar
-    // el modo ya leído. Si no se pasa, se lee del filesystem vía el módulo
-    // `partial-pause` (lectura barata, dos `existsSync` + un `readFileSync`).
-    let ppState = opts.pipelineMode || null;
-    if (!ppState && partialPause && typeof partialPause.getPipelineMode === 'function') {
-        try { ppState = partialPause.getPipelineMode(); } catch { ppState = null; }
-    }
-    const filtered = applyPartialPauseFilter(out, ppState);
-
-    filtered.sort((a, b) => {
+    out.sort((a, b) => {
         if (a.slotFree !== b.slotFree) return a.slotFree ? -1 : 1;
         return (b.bounces || 0) - (a.bounces || 0);
     });
-    return filtered.slice(0, limit);
+    return out.slice(0, limit);
 }
 
 function headerSlice(state, ctx) {

--- a/.pipeline/lib/human-block.js
+++ b/.pipeline/lib/human-block.js
@@ -89,12 +89,20 @@ function emitDismissed(opts) {
     });
 }
 
-// Artifacts auxiliares (.reason.json metadata, .guidance.txt de destrabe humano)
-// no son markers de skill. Si se cuentan como markers, el listado devuelve dos
-// entradas por issue (la real y la fantasma), el reconciler no encuentra
-// reason válido para la fantasma, y termina re-aplicando el label needs-human.
+// Artifacts auxiliares (.reason.json metadata, .guidance.txt de destrabe humano,
+// .comment.md de criterios PO, etc.) no son markers de skill. Si se cuentan
+// como markers, los listados devuelven entradas fantasma que el reconciler
+// no puede resolver (reaplicando needs-human, mostrando "po.comment.md" como
+// agente en la cola, etc.).
+//
+// Detección estructural: un marker válido tiene formato exacto `<issue>.<skill>`
+// con exactamente 2 segmentos separados por punto. Los skills configurados en
+// config.yaml (po, ux, guru, security, planner, backend-dev, android-dev,
+// web-dev, pipeline-dev, build, tester, qa, linter, review, delivery) no
+// contienen puntos. Cualquier filename con > 2 segmentos es artifact.
 function isMarkerArtifact(name) {
-    return name.endsWith('.reason.json') || name.endsWith('.guidance.txt');
+    if (name.split('.').length > 2) return true;
+    return name.endsWith('.reason.json') || name.endsWith('.guidance.txt') || name.endsWith('.comment.md');
 }
 
 function findActiveMarker(issue) {
@@ -427,4 +435,5 @@ module.exports = {
     PIPELINES,
     BLOCK_SUBDIR,
     NEEDS_HUMAN_LABEL,
+    isMarkerArtifact,
 };


### PR DESCRIPTION
## Resumen

Dos bugs del dashboard reportados desde Telegram al despausar la pausa parcial de la ola multi-provider:

1. **\`3076.po.comment.md\` aparecía como agente fantasma** \`skill=\"po.comment.md\"\` en "próximos 10 en cola".
2. **Solo 1 item visible** cuando la allowlist tiene 21 issues (early-break consumido por backlog legacy).

## Causa raíz

### Bug 1 — artifacts no filtrados
\`nextInQueue\` (lib/dashboard-slices.js) y \`listWorkFiles\` (dashboard.js) filtraban \`.\` y \`.gitkeep\` pero no \`.comment.md\`/\`.guidance.txt\`/\`.reason.json\`. El split por puntos convertía \`3076.po.comment.md\` en \`issue=3076, skill=\"po.comment.md\"\`.

Mismo patrón que el bug ya fixeado ayer en human-block.js (#3144) — el fix anterior fue parcial, no incluía los listadores del dashboard.

### Bug 2 — early-break envenenado por allowlist
En pausa parcial, \`applyPartialPauseFilter\` se aplicaba DESPUÉS del loop sobre fases. El early-break \`out.length >= limit * 4\` se consumía con items legacy de \`validacion/pendiente/\` que después se descartaban por allowlist, dejando la cola visible casi vacía aunque la allowlist tuviera items reales pendientes en fases posteriores.

## Cambios

- **lib/human-block.js**: extender \`isMarkerArtifact()\` con detección estructural (>2 segmentos) + sufijo \`.comment.md\`. Exportar el helper.
- **lib/dashboard-slices.js**: importar \`isMarkerArtifact\` (con fallback defensivo). Mover lectura de \`pipelineMode\` antes del loop y filtrar inline por allowlist **antes** del push — así el early-break solo cuenta items que sí van a ir a la cola.
- **dashboard.js**: aplicar \`isMarkerArtifact\` en \`listWorkFiles()\` para limpiar también issueMatrix y conteos.

## Tests

- **+3 tests de regresión** en dashboard-slices-next-in-queue.test.js:
  - \`nextInQueue: ignora .comment.md como marker fantasma\`
  - \`nextInQueue: ignora .guidance.txt y .reason.json como markers fantasma\`
  - \`nextInQueue: backlog legacy fuera de allowlist no oculta items reales de otras fases\`
- **Suite completa verde**: 10/10 dashboard-slices, 25/25 human-block.

## qa:skipped — justificación

Cambio puro de pipeline interno (dashboard de operación), sin impacto en producto de usuario final. Cubierto por tests unitarios de regresión específicos para ambos bugs. Cumple el criterio del CLAUDE.md (infra/hooks internos → \`qa:skipped\` con justificación).

Closes #3145

## Test plan
- [ ] CI verde
- [ ] Tests pipeline: \`node --test .pipeline/lib/__tests__/dashboard-slices-next-in-queue.test.js\`
- [ ] Verificación visual: despausar parcial → "próximos 10 en cola" muestra issues reales sin \`.comment.md\` fantasmas

🤖 Generated with [Claude Code](https://claude.com/claude-code)