### PR TITLE
fix(reconciler): no crear placeholders fantasma para issues con source:recommendation

### DIFF
--- a/.pipeline/cleanup-recommendation-placeholders.js
+++ b/.pipeline/cleanup-recommendation-placeholders.js
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+// Cleanup retroactivo de placeholders fantasma creados por svc-reconciler para
+// issues con labels `source:recommendation` o `tipo:recomendacion`.
+//
+// Estos issues son recomendaciones auto-generadas (security/guru/planner) que
+// tienen `needs-human` para triaje humano futuro, pero NO son agentes reales
+// bloqueados. El reconciler los venía inventando como markers en
+// `bloqueado-humano/`, lo que generaba alertas Telegram falsas y los mostraba
+// en `/bloqueados` como si fueran agentes esperando destrabe.
+//
+// Este script:
+//   1. Lee los issues con labels de recomendación desde GitHub
+//   2. Recorre todos los markers en `*/bloqueado-humano/` con
+//      `blocked_by:svc-reconciler` cuyo número de issue está en el set
+//   3. Mueve marker + reason.json a `archivado/` con sufijo `.cleaned-recommendation`
+//
+// Es one-shot: corre una vez, después del fix del reconciler que ya no los crea.
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const PIPELINE = path.resolve(__dirname);
+const GH_BIN = process.env.GH_BIN || 'C:\\Workspaces\\gh-cli\\bin\\gh.exe';
+
+function listRecommendationIssues() {
+    const a = JSON.parse(execSync(
+        `"${GH_BIN}" issue list --label "source:recommendation" --state open --json number --limit 500`,
+        { encoding: 'utf8', windowsHide: true },
+    ));
+    const b = JSON.parse(execSync(
+        `"${GH_BIN}" issue list --label "tipo:recomendacion" --state open --json number --limit 500`,
+        { encoding: 'utf8', windowsHide: true },
+    ));
+    return new Set([...a.map(i => i.number), ...b.map(i => i.number)]);
+}
+
+function walkBlockedDirs() {
+    const matches = [];
+    for (const pipeline of ['definicion', 'desarrollo']) {
+        const root = path.join(PIPELINE, pipeline);
+        if (!fs.existsSync(root)) continue;
+        for (const phase of fs.readdirSync(root)) {
+            const blockedDir = path.join(root, phase, 'bloqueado-humano');
+            if (!fs.existsSync(blockedDir)) continue;
+            for (const f of fs.readdirSync(blockedDir)) {
+                if (f.startsWith('.')) continue;
+                if (f.endsWith('.reason.json')) continue;
+                if (f.endsWith('.guidance.txt')) continue;
+                matches.push({ pipeline, phase, fileName: f, dir: blockedDir });
+            }
+        }
+    }
+    return matches;
+}
+
+function cleanup() {
+    const recSet = listRecommendationIssues();
+    console.log(`Issues con labels de recomendación: ${recSet.size}`);
+
+    const markers = walkBlockedDirs();
+    console.log(`Markers encontrados en bloqueado-humano/: ${markers.length}`);
+
+    let cleaned = 0;
+    let skippedNoReason = 0;
+    let skippedNotReconciler = 0;
+    let skippedNotRecommendation = 0;
+
+    for (const m of markers) {
+        const issueNum = parseInt(m.fileName.split('.')[0], 10);
+        if (!Number.isFinite(issueNum)) continue;
+        if (!recSet.has(issueNum)) { skippedNotRecommendation++; continue; }
+
+        const markerPath = path.join(m.dir, m.fileName);
+        const reasonPath = markerPath + '.reason.json';
+
+        let reason;
+        try { reason = JSON.parse(fs.readFileSync(reasonPath, 'utf8')); }
+        catch { reason = null; }
+
+        if (!reason) { skippedNoReason++; continue; }
+        if (reason.blocked_by !== 'svc-reconciler') { skippedNotReconciler++; continue; }
+
+        const archiveDir = path.join(PIPELINE, m.pipeline, m.phase, 'archivado');
+        fs.mkdirSync(archiveDir, { recursive: true });
+        const stamp = new Date().toISOString().slice(0, 10);
+        const dstMarker = path.join(archiveDir, `${m.fileName}.cleaned-recommendation-${stamp}`);
+        const dstReason = path.join(archiveDir, `${m.fileName}.reason.cleaned-recommendation-${stamp}.json`);
+        fs.renameSync(markerPath, dstMarker);
+        fs.renameSync(reasonPath, dstReason);
+        cleaned++;
+        console.log(`  cleaned: ${m.pipeline}/${m.phase}/${m.fileName} (issue #${issueNum})`);
+    }
+
+    console.log('');
+    console.log(`Resumen:`);
+    console.log(`  cleaned: ${cleaned}`);
+    console.log(`  skipped (no reason.json): ${skippedNoReason}`);
+    console.log(`  skipped (no reconciler-created): ${skippedNotReconciler}`);
+    console.log(`  skipped (not in recommendation set): ${skippedNotRecommendation}`);
+}
+
+if (require.main === module) cleanup();
+module.exports = { cleanup, listRecommendationIssues, walkBlockedDirs };

--- a/.pipeline/lib/__tests__/servicio-reconciler.test.js
+++ b/.pipeline/lib/__tests__/servicio-reconciler.test.js
@@ -92,6 +92,47 @@ test('reconcileLabelToFilesystem crea placeholder cuando label sin marker', () =
     assert.match(reason.reason, /placeholder/i);
 });
 
+test('reconcileLabelToFilesystem NO crea placeholder para issues con source:recommendation', () => {
+    clearAllMarkers();
+    clearGhQueue();
+    const ghIssues = [
+        { number: 3146, labels: ['enhancement', 'source:recommendation', 'needs-human', 'tipo:recomendacion'] },
+        { number: 3147, labels: ['ready', 'source:recommendation', 'needs-human'] },
+        { number: 9999, labels: ['ready', 'needs-human'] }, // este sí debería crearse
+    ];
+    const created = reconciler.reconcileLabelToFilesystem(ghIssues, new Map());
+
+    assert.equal(created, 1, 'solo el issue sin label de recomendación crea placeholder');
+    const m3146 = path.join(PIPELINE, 'definicion', 'analisis', 'bloqueado-humano', '3146.guru');
+    const m3147 = path.join(PIPELINE, 'desarrollo', 'dev', 'bloqueado-humano', '3147.guru');
+    const m9999 = path.join(PIPELINE, 'desarrollo', 'dev', 'bloqueado-humano', '9999.guru');
+    assert.equal(fs.existsSync(m3146), false, '#3146 no debe tener marker fantasma (es recomendación)');
+    assert.equal(fs.existsSync(m3147), false, '#3147 no debe tener marker fantasma (es recomendación)');
+    assert.equal(fs.existsSync(m9999), true, '#9999 sí debe tener placeholder (agente real bloqueado)');
+});
+
+test('reconcileLabelToFilesystem también skipea tipo:recomendacion (alias en español)', () => {
+    clearAllMarkers();
+    clearGhQueue();
+    const ghIssues = [
+        { number: 4242, labels: ['tipo:recomendacion', 'needs-human'] },
+    ];
+    const created = reconciler.reconcileLabelToFilesystem(ghIssues, new Map());
+    assert.equal(created, 0);
+    const m = path.join(PIPELINE, 'definicion', 'analisis', 'bloqueado-humano', '4242.guru');
+    assert.equal(fs.existsSync(m), false);
+});
+
+test('isRecommendationIssue detecta los dos labels de recomendación', () => {
+    assert.equal(reconciler.isRecommendationIssue(['source:recommendation']), true);
+    assert.equal(reconciler.isRecommendationIssue(['tipo:recomendacion']), true);
+    assert.equal(reconciler.isRecommendationIssue(['enhancement', 'source:recommendation']), true);
+    assert.equal(reconciler.isRecommendationIssue(['ready', 'app:client']), false);
+    assert.equal(reconciler.isRecommendationIssue([]), false);
+    assert.equal(reconciler.isRecommendationIssue(undefined), false);
+    assert.equal(reconciler.isRecommendationIssue(null), false);
+});
+
 test('reconcileLabelToFilesystem omite issues que ya tienen marker', () => {
     clearAllMarkers();
     clearGhQueue();

--- a/.pipeline/servicio-reconciler.js
+++ b/.pipeline/servicio-reconciler.js
@@ -42,6 +42,18 @@ const GH_QUEUE = path.join(PIPELINE, 'servicios', 'github', 'pendiente');
 const RECONCILE_INTERVAL_MS = parseInt(process.env.RECONCILER_INTERVAL_MS || '300000', 10); // 5 min default
 const RECONCILER_LABEL = 'needs-human';
 
+// Labels que indican que `needs-human` está pegado por origen de recomendación
+// (security/guru/planner generan issues auto y los marcan así para triaje humano
+// futuro). NO hay un agente real bloqueado trabajando esos issues — son backlog
+// pendiente de decisión. El reconciler NO debe inventar placeholders en
+// bloqueado-humano/ para estos casos: el placeholder dispara alerta Telegram y
+// los muestra en `/bloqueados` como si fueran agentes fantasma esperando
+// destrabe, cuando en realidad son sugerencias que esperan triaje.
+//
+// Mantenemos el label `needs-human` en GitHub (visibilidad para `/doc priorizar`).
+// Solo cortamos la creación automática de markers en filesystem.
+const RECOMMENDATION_LABELS = new Set(['source:recommendation', 'tipo:recomendacion']);
+
 function log(msg) {
     const ts = new Date().toISOString().replace('T', ' ').slice(0, 19);
     console.log(`[${ts}] [svc-reconciler] ${msg}`);
@@ -135,10 +147,26 @@ function decidirFasePlaceholder(labels) {
 // Reconciliación: las 3 reglas
 // -----------------------------------------------------------------------------
 
+function isRecommendationIssue(labels) {
+    if (!Array.isArray(labels)) return false;
+    for (const l of labels) {
+        if (RECOMMENDATION_LABELS.has(l)) return true;
+    }
+    return false;
+}
+
 function reconcileLabelToFilesystem(ghIssues, blockedByIssue) {
     let created = 0;
+    let skippedRecommendations = 0;
     for (const issue of ghIssues) {
         if (blockedByIssue.has(issue.number)) continue;
+        // Skip: recomendaciones auto-generadas (security/guru/planner) que
+        // tienen `needs-human` para triaje futuro pero no son agentes bloqueados.
+        // Inventar marker fantasma confunde al dashboard y dispara alerta Telegram.
+        if (isRecommendationIssue(issue.labels)) {
+            skippedRecommendations++;
+            continue;
+        }
         // Issue tiene label `needs-human` pero no hay marker físico → crear placeholder
         const { pipeline, phase, skill } = decidirFasePlaceholder(issue.labels);
         const targetDir = path.join(PIPELINE, pipeline, phase, humanBlock.BLOCK_SUBDIR);
@@ -161,6 +189,9 @@ function reconcileLabelToFilesystem(ghIssues, blockedByIssue) {
         } catch (e) {
             log(`Error creando placeholder #${issue.number}: ${e.message.slice(0, 120)}`);
         }
+    }
+    if (skippedRecommendations > 0) {
+        log(`Skipped ${skippedRecommendations} issues con labels de recomendación (no se crean placeholders)`);
     }
     return created;
 }
@@ -462,6 +493,8 @@ module.exports = {
     reconcileClosedMarkers,
     reconcileHumanUnblockDetected,
     decidirFasePlaceholder,
+    isRecommendationIssue,
+    RECOMMENDATION_LABELS,
     listGhIssuesWithLabel,
     getIssueState,
     enqueueLabelApply,


### PR DESCRIPTION
## Bug raíz

El `svc-reconciler` venía creando markers en `bloqueado-humano/` para cualquier issue con label `needs-human` que no tuviera marker físico. El problema: agentes como `security`, `guru` y `planner` generan automáticamente issues como "recomendaciones de defensa-en-profundidad / mejora futura" y les pegan `needs-human + source:recommendation + tipo:recomendacion` para triaje humano posterior.

El reconciler trataba esos labels como si fueran agentes bloqueados → inventaba `3146.guru` (y similares) en `definicion/analisis/bloqueado-humano/`, lo que disparaba alertas Telegram fantasma y los mostraba en `/bloqueados` como agentes esperando destrabe.

**Impacto medido:** 251 placeholders fantasma acumulados, alertas Telegram falsas en cada ciclo del reconciler.

## Fix (approach whitelist por origen, propuesto por Leo)

- `reconcileLabelToFilesystem` ahora skipea issues con `source:recommendation` o `tipo:recomendacion`.
- El label `needs-human` se **mantiene en GitHub** para que `/doc priorizar` los vea como backlog pendiente de triaje.
- Helper `isRecommendationIssue()` centraliza la lógica y queda exportado.
- Script one-shot `cleanup-recommendation-placeholders.js` archivó los 251 placeholders fantasma ya existentes en `<fase>/archivado/` con sufijo `.cleaned-recommendation-<date>`.

## Tests

22/22 verde, con 3 de regresión específicos:
- `reconcileLabelToFilesystem NO crea placeholder para issues con source:recommendation`
- `reconcileLabelToFilesystem también skipea tipo:recomendacion (alias en español)`
- `isRecommendationIssue detecta los dos labels de recomendación`

## qa:skipped justificación

Cambio puro de pipeline interno (svc-reconciler), sin impacto en producto de usuario final, cubierto por tests unitarios de regresión. Cumple criterio CLAUDE.md (infra/hooks internos → qa:skipped con justificación).

## Test plan

- [x] Tests unitarios 22/22 verde
- [x] Cleanup retroactivo ejecutado: 251 fantasmas archivados, 95 agentes reales conservados intactos
- [x] Verificar que `/bloqueados` ya no muestra `3146.guru` ni similares post-merge