### PR TITLE
fix(pulpo): filtrar artifacts auxiliares en listWorkFiles

### DIFF
--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -716,11 +716,27 @@ function writeYaml(filepath, data) {
   fs.writeFileSync(filepath, yaml.dump(data, { lineWidth: -1 }));
 }
 
-/** Listar archivos de trabajo (no .gitkeep) en una carpeta */
+// Detector de artifacts auxiliares (.guidance.txt, .reason.json, .comment.md,
+// .reason.resolved-*.json, etc.). Reutilizamos el helper canónico de
+// `lib/human-block.js` para mantener una única definición. Sin este filtro el
+// pulpo levantaba `<issue>.<skill>.guidance.txt` como si fuera un marker de
+// agente, alcanzaba el invariante "skill no autorizado para esa fase" y mandaba
+// alerta Telegram falsa (incidente 2026-05-11 con #3073.pipeline-dev.guidance.txt).
+let _isMarkerArtifactPulpo;
+try { ({ isMarkerArtifact: _isMarkerArtifactPulpo } = require('./lib/human-block')); } catch { /* opcional */ }
+function isMarkerArtifactPulpo(name) {
+  if (typeof _isMarkerArtifactPulpo === 'function') return _isMarkerArtifactPulpo(name);
+  if (name.split('.').length > 2) return true;
+  return name.endsWith('.reason.json')
+    || name.endsWith('.guidance.txt')
+    || name.endsWith('.comment.md');
+}
+
+/** Listar archivos de trabajo (no .gitkeep, ni artifacts auxiliares) en una carpeta */
 function listWorkFiles(dir) {
   try {
     return fs.readdirSync(dir)
-      .filter(f => !f.startsWith('.') && !f.endsWith('.gitkeep'))
+      .filter(f => !f.startsWith('.') && !f.endsWith('.gitkeep') && !isMarkerArtifactPulpo(f))
       .map(f => ({ name: f, path: path.join(dir, f) }));
   } catch { return []; }
 }
@@ -7468,7 +7484,7 @@ function countQueuedLlmAgents() {
   for (const fase of llmFases) {
     const dir = path.join(PIPELINE, 'desarrollo', fase, 'pendiente');
     try {
-      const files = fs.readdirSync(dir).filter(f => !f.startsWith('.') && !f.endsWith('.gitkeep'));
+      const files = fs.readdirSync(dir).filter(f => !f.startsWith('.') && !f.endsWith('.gitkeep') && !isMarkerArtifactPulpo(f));
       total += files.length;
     } catch { /* dir no existe — sumar 0 */ }
   }


### PR DESCRIPTION
## Resumen

Tercera (y final) copia del bug de los **agentes fantasma** que ya fixeamos hoy en #3144 (`human-block.js`) y #3145 (`dashboard-slices.js`): el listador central del Pulpo `listWorkFiles()` no filtraba los artifacts auxiliares (`.guidance.txt`, `.reason.json`, `.comment.md`), entonces el Pulpo levantaba `<issue>.<skill>.guidance.txt` como si fuera un marker de agente.

## Incidente reproducible (2026-05-11 21:58 UTC)

```
[lanzamiento] ⛔ INVARIANTE: skill "pipeline-dev.guidance.txt" no pertenece
a fase "dev" (permitidos: backend-dev, android-dev, web-dev, pipeline-dev).
Archivo: 3073.pipeline-dev.guidance.txt
```

Y el `sendTelegram` adyacente generaba spam cada ciclo del barrido:
> ⛔ Pipeline bloqueó lanzamiento de pipeline-dev.guidance.txt:#3073 en fase "dev" — skill no autorizado para esa fase. Revisar inmediatamente.

## Causa raíz

`listWorkFiles()` en `pulpo.js:720` y `countQueuedLlmAgents()` en `pulpo.js:7471` filtraban sólo `.gitkeep` y archivos que arrancan con `.`, pero no extensiones como `.guidance.txt` / `.reason.json` / `.comment.md`. Misma falla que ya corregimos en otros dos listadores hoy.

## Fix

Reutilizar el helper canónico `isMarkerArtifact()` de `lib/human-block.js`. Una sola fuente de verdad para todos los listadores del pipeline.

## Verificación

```
3073.pipeline-dev                        → marker=false  (agente real)
3073.pipeline-dev.guidance.txt           → marker=true   (artifact)
3076.po.comment.md                       → marker=true   (artifact)
3075.pipeline-dev.reason.json            → marker=true   (artifact)
2019.android-dev.guidance.txt            → marker=true   (artifact)
741.android-dev                          → marker=false  (agente real)
.gitkeep                                 → marker=false  (filtrado aparte)
```

## Notas

- `node -c pulpo.js` → sintaxis OK.
- No invento branch ni tocamos `main`: este es el patrón estándar #3144/#3145/#3148.
- Después del merge, basta con `/restart` para que el pulpo levante el código nuevo y paren las alertas.

Closes #N/A (no había issue formal — diagnóstico en sesión Commander a partir del reporte de Leo).