### PR TITLE
fix(pulpo): desactivar checkEnv en validateOrExit (regresión #3150 que rompe restart con Claude Max)

### DIFF
--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -8537,11 +8537,10 @@ if (process.env.PULPO_SKIP_AGENT_MODELS_VALIDATE !== '1') {
     const agentModelsValidate = require('./lib/agent-models-validate');
     agentModelsValidate.validateOrExit({
       contextLabel: 'boot abortado',
-      // #3080 / S1 CA-2: fail-fast TOTAL al boot — si algún provider
-      // referenciado por un skill declara `credentials_env` y la env var no
-      // está en process.env, abortar antes de mainLoop. NO loguea valores
-      // (anti-leak): sólo nombres de env vars + paths jsonPointer.
-      checkEnv: true,
+      // checkEnv quedó en false (default): el setup actual autentica los
+      // skills LLM vía OAuth del CLI `claude` (Claude Max), no por env var.
+      // Activarlo rompe el boot del pulpo. Ver issue de seguimiento para
+      // reintroducirlo con awareness de launcher (claude=OAuth, otros=env).
     });
   } catch (err) {
     // Si el módulo de validación mismo crasha (no debería: ajv/loadSchema están


### PR DESCRIPTION
## Síntoma

Después de mergear #3150 hace ~5h, el smoke test del restart empezó a fallar con `STALE pulpo` / `MISSING pulpo` → auto-rollback. Logs:

```
[validate] FATAL agent-models.json inválido — boot abortado
  problema: #/providers/anthropic/credentials_env provider "anthropic"
  requiere env var ANTHROPIC_API_KEY pero no está presente en process.env
```

## Causa raíz

`#3150` (commit `c2f5662e`) agregó `checkEnv: true` al `validateOrExit` del boot en `pulpo.js:8544`. Eso activa `validateCredentialsEnvPresence` que exige que `ANTHROPIC_API_KEY` esté seteada porque `agent-models.json:27` la declara en `providers.anthropic.credentials_env`.

Pero el setup del proyecto autentica los skills LLM vía OAuth del CLI `claude` (Claude Max, `~/.claude/.credentials.json` con `subscriptionType: "max"`), no con API key directa. Esa env var **nunca estuvo persistida** en el sistema y el pipeline siempre funcionó sin ella.

## Fix

Volver al comportamiento pre-#3150: dejar `checkEnv` en su default `false`. La validación estructural sigue activa (schema, secrets hardcoded, allowlist de env vars, cross-references default_provider/skills, denylist de flags, quota_error_types). Lo único que se apaga es el chequeo de **presencia** en `process.env`, que para `launcher: "claude"` no aporta protección porque el CLI no usa la env var.

## Seguimiento

Issue para reintroducir el chequeo con awareness de launcher (claude → OAuth → no chequear, openai-codex → env var requerida) — para hacerlo bien cuando se active `openai-codex` en producción. Lo abro en un comentario.

## QA

`qa:skipped` — cambio puro de infra del pipeline (boot del pulpo), sin impacto en producto de usuario. La verificación es: restart del pipeline corre el smoke test y pasa.

Closes: regresión introducida por #3150.

🤖 Generated with [Claude Code](https://claude.com/claude-code)