### PR TITLE
fix(pipeline): rutear skill 'build' a determinístico (regresión $2.72/h Opus)

### DIFF
--- a/.pipeline/agent-models.json
+++ b/.pipeline/agent-models.json
@@ -81,9 +81,8 @@
     "tester":       { "provider": "deterministic" },
     "qa":           { "provider": "anthropic" },
 
-    "build":        { "provider": "anthropic" },
+    "build":        { "provider": "deterministic" },
     "linter":       { "provider": "deterministic" },
-    "delivery":     { "provider": "deterministic" },
-    "builder":      { "provider": "deterministic" }
+    "delivery":     { "provider": "deterministic" }
   }
 }

--- a/.pipeline/lib/__tests__/dashboard-quota-exhausted.test.js
+++ b/.pipeline/lib/__tests__/dashboard-quota-exhausted.test.js
@@ -82,7 +82,7 @@ test('CA-2: sin flag → slice.active=false con counters en cero', () => {
 // CA-5 — slice cuenta determinísticos corriendo y LLM esperando
 // -----------------------------------------------------------------------------
 
-test('CA-5: con flag activo, contar builder/tester/delivery/linter como determinísticos', () => {
+test('CA-5: con flag activo, contar build/tester/delivery/linter como determinísticos', () => {
     writeFlag({
         exhausted: true,
         resets_at: new Date(Date.now() + 3600000).toISOString(),
@@ -92,7 +92,7 @@ test('CA-5: con flag activo, contar builder/tester/delivery/linter como determin
     try {
         const out = slices.quotaExhaustedSlice(fakeState({
             trabajando: [
-                { skill: 'builder' },
+                { skill: 'build' },
                 { skill: 'tester' },
                 { skill: 'delivery' },
                 { skill: 'linter' },
@@ -102,7 +102,7 @@ test('CA-5: con flag activo, contar builder/tester/delivery/linter como determin
                 { skill: 'guru' },
                 { skill: 'guru' },
                 { skill: 'po' },
-                { skill: 'builder' }, // determinístico en pendiente, no debe contar
+                { skill: 'build' }, // determinístico en pendiente, no debe contar
             ],
         }));
         assert.equal(out.active, true);
@@ -112,9 +112,9 @@ test('CA-5: con flag activo, contar builder/tester/delivery/linter como determin
         const po = out.queuedSkills.find(x => x.skill === 'po');
         assert.ok(guru && guru.count === 2);
         assert.ok(po && po.count === 1);
-        // Builder NO debe estar (es determinístico, no se "encola por
+        // build NO debe estar (es determinístico, no se "encola por
         // falta de cuota").
-        assert.equal(out.queuedSkills.find(x => x.skill === 'builder'), undefined);
+        assert.equal(out.queuedSkills.find(x => x.skill === 'build'), undefined);
         assert.equal(out.queuedCount, 3);
         assert.equal(out.error_type, 'usage_limit_error');
     } finally {

--- a/.pipeline/lib/__tests__/quota-exhausted.test.js
+++ b/.pipeline/lib/__tests__/quota-exhausted.test.js
@@ -337,7 +337,7 @@ test('CA-2 · shouldGateSpawn=false para skills determinísticos aún con flag a
     const now = Date.parse('2026-05-05T00:00:00Z');
     const resetsAt = new Date(now + 24 * 60 * 60 * 1000).toISOString();
     q.setFlag({ errorType: 'usage_limit_error', resetsAt, now });
-    for (const skill of ['builder', 'tester', 'linter', 'delivery']) {
+    for (const skill of ['build', 'tester', 'linter', 'delivery']) {
         assert.equal(q.shouldGateSpawn(skill, { now }), false, `${skill} es determinístico, NO debe gatearse`);
     }
 });
@@ -424,7 +424,7 @@ test('lifecycle · set flag → gate LLM → resets_at expira → drenado', () =
     q.setFlag({ errorType: 'usage_limit_error', resetsAt, now, agent: 'po' });
     assert.equal(q.isQuotaExhausted({ now }), true);
     assert.equal(q.shouldGateSpawn('po', { now }), true);
-    assert.equal(q.shouldGateSpawn('builder', { now }), false);
+    assert.equal(q.shouldGateSpawn('build', { now }), false);
 
     // 2. resets_at expira
     const future = now + 2 * 60 * 60 * 1000; // +2 horas (después del reset)
@@ -699,7 +699,7 @@ test('CA-7 #3077 · skills determinísticos NO se gatean nunca, sin importar pro
     const now = Date.parse('2026-05-05T00:00:00Z');
     const resetsAt = new Date(now + 24 * 60 * 60 * 1000).toISOString();
     q.setFlag({ errorType: 'usage_limit_error', provider: 'anthropic', resetsAt, now });
-    for (const skill of ['builder', 'tester', 'linter', 'delivery']) {
+    for (const skill of ['build', 'tester', 'linter', 'delivery']) {
         assert.equal(q.shouldGateSpawn(skill, { provider: 'anthropic', now }), false);
         assert.equal(q.shouldGateSpawn(skill, { provider: 'openai-codex', now }), false);
         assert.equal(q.shouldGateSpawn(skill, { now }), false);
@@ -1012,7 +1012,7 @@ test('lifecycle multi-provider · flag anthropic + skill openai pasa + skill ant
     assert.equal(q.shouldGateSpawn('qa', { provider: 'openai-codex', now }), false);
 
     // 4. Skill determinístico siempre pasa
-    assert.equal(q.shouldGateSpawn('builder', { provider: 'deterministic', now }), false);
+    assert.equal(q.shouldGateSpawn('build', { provider: 'deterministic', now }), false);
 
     // 5. clearFlag con openai-codex NO limpia
     assert.equal(q.clearFlag({ provider: 'openai-codex' }), false);

--- a/.pipeline/lib/__tests__/rest-mode-window.integration.test.js
+++ b/.pipeline/lib/__tests__/rest-mode-window.integration.test.js
@@ -101,7 +101,7 @@ test('CA-1.5: dentro de la ventana, sólo delivery/builder/linter/tester pasan',
     const cfg = { bypass_labels: ['priority:critical'] };
 
     // Determinísticos pasan.
-    for (const skill of ['delivery', 'builder', 'linter', 'tester']) {
+    for (const skill of ['delivery', 'build', 'linter', 'tester']) {
         const r = simulatePulpoGate(skill, [], now, { cfg, pipelineDir: dir });
         assert.equal(r.advances, true, `${skill} debería pasar`);
     }

--- a/.pipeline/lib/__tests__/rest-mode-window.test.js
+++ b/.pipeline/lib/__tests__/rest-mode-window.test.js
@@ -174,7 +174,7 @@ test('isSkillAllowedNow bloquea skill no determinístico dentro de la ventana', 
 
 test('isSkillAllowedNow permite skill determinístico dentro de la ventana', () => {
     const window = { active: true, start: '13:00', end: '17:00', timezone: 'UTC', days: [0, 1, 2, 3, 4, 5, 6] };
-    for (const skill of ['delivery', 'builder', 'linter', 'tester']) {
+    for (const skill of ['delivery', 'build', 'linter', 'tester']) {
         const r = rmw.isSkillAllowedNow(skill, Date.UTC(2026, 0, 5, 14, 0, 0), { window });
         assert.equal(r.allowed, true, `${skill} debería pasar`);
         assert.equal(r.reason, 'deterministic_skill');
@@ -321,7 +321,7 @@ test('DETERMINISTIC_SKILLS coincide con el set documentado', () => {
     // Si pulpo.js cambia su set, este test obliga a actualizar el módulo.
     assert.deepEqual(
         [...rmw.DETERMINISTIC_SKILLS].sort(),
-        ['builder', 'delivery', 'linter', 'tester'].sort()
+        ['build', 'delivery', 'linter', 'tester'].sort()
     );
 });
 

--- a/.pipeline/lib/agent-launcher/providers/deterministic.js
+++ b/.pipeline/lib/agent-launcher/providers/deterministic.js
@@ -21,7 +21,7 @@ const { execSync } = require('node:child_process');
 // NUNCA cambiar a require dinámico sobre `skill`: si un atacante con permiso de
 // PR edita esto, podría inyectar un script fuera de skills-deterministicos/.
 // -----------------------------------------------------------------------------
-const DETERMINISTIC_SKILLS = new Set(['builder', 'tester', 'delivery', 'linter']);
+const DETERMINISTIC_SKILLS = new Set(['build', 'tester', 'delivery', 'linter']);
 
 function isDeterministic(skill) {
     return DETERMINISTIC_SKILLS.has(skill);

--- a/.pipeline/lib/dashboard-slices.js
+++ b/.pipeline/lib/dashboard-slices.js
@@ -26,7 +26,7 @@ try { quotaExhaustedState = require('./quota-exhausted-state'); } catch { /* opc
 // sincronizado con `DETERMINISTIC_SKILLS` del detector (#2974,
 // `lib/quota-exhausted.js`). Si divergen, el dashboard puede mostrar un
 // conteo distinto al gate real del pulpo.
-const DETERMINISTIC_SKILLS = new Set(['builder', 'tester', 'delivery', 'linter']);
+const DETERMINISTIC_SKILLS = new Set(['build', 'tester', 'delivery', 'linter']);
 
 // #3023 — Filtro de la cola "Próximos 10" por allowlist de pausa parcial.
 // Importación defensiva: si el módulo no está disponible (edge: checkout

--- a/.pipeline/lib/quota-exhausted.js
+++ b/.pipeline/lib/quota-exhausted.js
@@ -745,7 +745,7 @@ function detectFromResultEvent(evt, cfg = null) {
  * corren en Node puro sin tokens LLM.
  */
 const DETERMINISTIC_SKILLS = Object.freeze(
-    new Set(['builder', 'tester', 'delivery', 'linter'])
+    new Set(['build', 'tester', 'delivery', 'linter'])
 );
 
 function isDeterministicSkill(skill) {

--- a/.pipeline/lib/rest-mode-window.js
+++ b/.pipeline/lib/rest-mode-window.js
@@ -34,7 +34,7 @@ const DEFAULT_PIPELINE_DIR = path.resolve(__dirname, '..');
 // Mismo set que pulpo.js — duplicado a propósito para no introducir un
 // require circular (pulpo → este módulo → pulpo). Si se cambia uno, cambiar
 // el otro. Test de coherencia en `__tests__/rest-mode-window.test.js`.
-const DETERMINISTIC_SKILLS = Object.freeze(['delivery', 'builder', 'linter', 'tester']);
+const DETERMINISTIC_SKILLS = Object.freeze(['delivery', 'build', 'linter', 'tester']);
 
 const DEFAULT_TIMEZONE = 'America/Argentina/Buenos_Aires';
 const DEFAULT_DAYS = Object.freeze([0, 1, 2, 3, 4, 5, 6]);

--- a/.pipeline/skills-deterministicos/__tests__/build.test.js
+++ b/.pipeline/skills-deterministicos/__tests__/build.test.js
@@ -1,4 +1,4 @@
-// Tests unitarios de .pipeline/skills-deterministicos/builder.js (issue #2476)
+// Tests unitarios de .pipeline/skills-deterministicos/build.js (issue #2476, rename #3157)
 // No lanzamos gradle real: validamos parseArgs, buildGradleCommand, heartbeat,
 // updateMarker y copyArtifacts con filesystem aislado.
 'use strict';
@@ -10,7 +10,7 @@ const os = require('os');
 const path = require('path');
 
 // Aislar REPO_ROOT a un tmp — el módulo resuelve paths a partir de env vars.
-const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'v3-builder-'));
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'v3-build-'));
 fs.mkdirSync(path.join(TMP, '.claude', 'hooks'), { recursive: true });
 fs.mkdirSync(path.join(TMP, '.pipeline', 'logs'), { recursive: true });
 fs.mkdirSync(path.join(TMP, '.pipeline', 'desarrollo', 'build', 'trabajando'), { recursive: true });
@@ -18,11 +18,11 @@ fs.mkdirSync(path.join(TMP, 'qa', 'artifacts'), { recursive: true });
 process.env.PIPELINE_REPO_ROOT = TMP;
 process.env.CLAUDE_PROJECT_DIR = TMP;
 
-delete require.cache[require.resolve('../builder')];
-const builder = require('../builder');
+delete require.cache[require.resolve('../build')];
+const builder = require('../build');
 
 test('parseArgs — issue posicional + scope por defecto smart', () => {
-    const a = builder.parseArgs(['node', 'builder.js', '2476']);
+    const a = builder.parseArgs(['node', 'build.js', '2476']);
     assert.equal(a.issue, 2476);
     assert.equal(a.scope, 'smart');
     assert.equal(a.module, null);
@@ -85,7 +85,7 @@ test('startHeartbeat — escribe archivo agent-<issue>.heartbeat y lo limpia al 
     assert.equal(fs.existsSync(hbFile), true);
     const content = JSON.parse(fs.readFileSync(hbFile, 'utf8').trim());
     assert.equal(content.issue, 2476);
-    assert.equal(content.skill, 'builder');
+    assert.equal(content.skill, 'build');
     assert.equal(content.model, 'deterministic');
     hb.stop();
     assert.equal(fs.existsSync(hbFile), false);
@@ -98,14 +98,14 @@ test('startHeartbeat — issue null es no-op', () => {
 });
 
 test('updateMarker — escribe resultado y motivo al YAML', () => {
-    const marker = path.join(TMP, '.pipeline', 'desarrollo', 'build', 'trabajando', '2476.builder');
+    const marker = path.join(TMP, '.pipeline', 'desarrollo', 'build', 'trabajando', '2476.build');
     fs.writeFileSync(marker, 'issue: 2476\npipeline: desarrollo\n');
-    builder.updateMarker(marker, { resultado: 'aprobado', motivo: 'Build exitoso', builder_mode: 'deterministic' });
+    builder.updateMarker(marker, { resultado: 'aprobado', motivo: 'Build exitoso', build_mode: 'deterministic' });
     const after = fs.readFileSync(marker, 'utf8');
     assert.ok(after.includes('resultado:'));
     assert.ok(after.includes('"aprobado"'));
     assert.ok(after.includes('"Build exitoso"'));
-    assert.ok(after.includes('builder_mode:'));
+    assert.ok(after.includes('build_mode:'));
     // No duplicó issue/pipeline
     const issueLines = after.split('\n').filter((l) => l.startsWith('issue:'));
     assert.equal(issueLines.length, 1);

--- a/.pipeline/skills-deterministicos/build.js
+++ b/.pipeline/skills-deterministicos/build.js
@@ -1,19 +1,19 @@
 #!/usr/bin/env node
 /**
- * builder.js — Skill determinístico /builder (issue #2476)
+ * build.js — Skill determinístico /build (issue #2476, rename #3157)
  *
- * Reemplaza al skill LLM `builder` dentro del flujo del Pulpo para eliminar
+ * Reemplaza al skill LLM `build` dentro del flujo del Pulpo para eliminar
  * el gasto de tokens en un proceso 100% mecánico: setup JAVA_HOME → correr
  * Gradle → parsear output → generar reporte → copiar artefactos QA.
  *
  * Contrato idéntico al skill LLM:
- *   - Marker en `trabajando/<issue>.builder` (lo lee y actualiza con resultado)
+ *   - Marker en `trabajando/<issue>.build` (lo lee y actualiza con resultado)
  *   - Heartbeat `agent-<issue>.heartbeat` cada 30s
  *   - Eventos `session:start` / `session:end` en activity-log
  *   - Exit code 0 = build OK (marker → aprobado), 1 = build FAIL (rebote)
  *
  * CLI:
- *   node builder.js <issue> [--scope=smart|clean|fast|all] [--module=<name>] [--trabajando=<path>]
+ *   node build.js <issue> [--scope=smart|clean|fast|all] [--module=<name>] [--trabajando=<path>]
  *
  * Env vars (pasadas por el Pulpo):
  *   PIPELINE_ISSUE, PIPELINE_SKILL, PIPELINE_FASE, PIPELINE_TRABAJANDO, PIPELINE_PIPELINE
@@ -64,7 +64,7 @@ function startHeartbeat(issue) {
     const writeHb = () => {
         try {
             fs.writeFileSync(hbFile, JSON.stringify({
-                issue, skill: 'builder', pid: process.pid, model: 'deterministic',
+                issue, skill: 'build', pid: process.pid, model: 'deterministic',
                 ts: new Date().toISOString(),
             }) + '\n');
         } catch {}
@@ -187,7 +187,7 @@ function updateMarker(trabajandoPath, payload) {
         }
         fs.writeFileSync(trabajandoPath, [...kept, ...appended].join('\n') + '\n', 'utf8');
     } catch (e) {
-        process.stderr.write(`[builder] No se pudo actualizar marker: ${e.message}\n`);
+        process.stderr.write(`[build] No se pudo actualizar marker: ${e.message}\n`);
     }
 }
 
@@ -198,17 +198,17 @@ async function main() {
     const scope = args.scope;
 
     if (!issue) {
-        process.stderr.write('[builder] Falta issue (CLI o env PIPELINE_ISSUE).\n');
+        process.stderr.write('[build] Falta issue (CLI o env PIPELINE_ISSUE).\n');
         process.exit(2);
     }
 
     // Log header al agent log
     try { fs.mkdirSync(LOG_DIR, { recursive: true }); } catch {}
-    const agentLog = path.join(LOG_DIR, `${issue}-builder.log`);
+    const agentLog = path.join(LOG_DIR, `${issue}-build.log`);
     const logAppend = (msg) => {
         try { fs.appendFileSync(agentLog, msg + '\n'); } catch {}
     };
-    logAppend(`--- builder:#${issue} (deterministic) scope=${scope} ${new Date().toISOString()} ---`);
+    logAppend(`--- build:#${issue} (deterministic) scope=${scope} ${new Date().toISOString()} ---`);
 
     // Env con JAVA_HOME
     const env = { ...process.env, JAVA_HOME: JAVA_HOME_DEFAULT };
@@ -216,12 +216,12 @@ async function main() {
     env.PATH = `${JAVA_HOME_DEFAULT}/bin${path.delimiter}${env.PATH || ''}`;
 
     const { cmd, args: gArgs, label } = buildGradleCommand(scope, args.module);
-    logAppend(`[builder] scope=${label} cmd="${cmd} ${gArgs.join(' ')}"`);
+    logAppend(`[build] scope=${label} cmd="${cmd} ${gArgs.join(' ')}"`);
 
     // Heartbeat + session:start
     const hb = startHeartbeat(issue);
     const handle = trace.emitSessionStart({
-        skill: 'builder', issue, phase: process.env.PIPELINE_FASE || 'build',
+        skill: 'build', issue, phase: process.env.PIPELINE_FASE || 'build',
         model: 'deterministic',
     });
 
@@ -234,17 +234,17 @@ async function main() {
 
     try {
         gradleResult = await runGradle({ cmd, args: gArgs, cwd: REPO_ROOT, env });
-        logAppend(`[builder] gradle exit_code=${gradleResult.exit_code} wall_ms=${gradleResult.wall_ms}`);
-        logAppend('[builder] --- stdout (último 2000 chars) ---');
+        logAppend(`[build] gradle exit_code=${gradleResult.exit_code} wall_ms=${gradleResult.wall_ms}`);
+        logAppend('[build] --- stdout (último 2000 chars) ---');
         logAppend(gradleResult.stdout.slice(-2000));
-        logAppend('[builder] --- stderr (último 1000 chars) ---');
+        logAppend('[build] --- stderr (último 1000 chars) ---');
         logAppend(gradleResult.stderr.slice(-1000));
 
         parsed = parseGradleOutput(gradleResult.stdout, gradleResult.stderr);
 
         if (parsed.success) {
             artifacts = copyArtifacts(parsed);
-            logAppend(`[builder] artefactos copiados: ${artifacts.join(', ') || '(ninguno)'}`);
+            logAppend(`[build] artefactos copiados: ${artifacts.join(', ') || '(ninguno)'}`);
             exitCode = 0;
         } else {
             exitCode = 1;
@@ -258,24 +258,24 @@ async function main() {
             issue, scope: label, duration_override_ms: gradleResult.wall_ms,
         });
         // Escribir reporte al log + a disco
-        logAppend('[builder] --- REPORTE ---');
+        logAppend('[build] --- REPORTE ---');
         logAppend(report);
         const reportPath = path.join(LOG_DIR, `build-${issue}-report.md`);
         try { fs.writeFileSync(reportPath, report); } catch {}
     } catch (e) {
         exitCode = 2;
-        motivo = `Excepción en builder.js: ${e.message}`;
-        logAppend(`[builder] EXCEPTION: ${e.stack || e.message}`);
+        motivo = `Excepción en build.js: ${e.message}`;
+        logAppend(`[build] EXCEPTION: ${e.stack || e.message}`);
     } finally {
         // Actualizar marker con resultado
         updateMarker(args.trabajando, {
             resultado: exitCode === 0 ? 'aprobado' : 'rechazado',
             motivo: motivo || (exitCode === 0 ? 'Build exitoso' : 'Build fallido'),
-            builder_scope: label,
-            builder_duration_ms: gradleResult ? gradleResult.wall_ms : 0,
-            builder_classification: parsed && parsed.errors[0] ? parsed.errors[0].classification : null,
-            builder_escalate_to: parsed && parsed.errors[0] ? parsed.errors[0].escalate_to : null,
-            builder_mode: 'deterministic',
+            build_scope: label,
+            build_duration_ms: gradleResult ? gradleResult.wall_ms : 0,
+            build_classification: parsed && parsed.errors[0] ? parsed.errors[0].classification : null,
+            build_escalate_to: parsed && parsed.errors[0] ? parsed.errors[0].escalate_to : null,
+            build_mode: 'deterministic',
         });
 
         // session:end
@@ -296,14 +296,14 @@ async function main() {
 if (require.main === module) {
     if (process.argv.includes('--self-check')) {
         const { runSelfCheck } = require('./lib/self-check');
-        runSelfCheck('builder', [
+        runSelfCheck('build', [
             { name: 'parseArgs sin argumentos', fn: () => {
-                const a = parseArgs(['node', 'builder.js']);
+                const a = parseArgs(['node', 'build.js']);
                 if (typeof a !== 'object' || a === null) throw new Error('parseArgs no devuelve objeto');
                 if (a.scope !== 'smart') throw new Error(`scope default esperado 'smart' got '${a.scope}'`);
             }},
             { name: 'parseArgs con --clean', fn: () => {
-                const a = parseArgs(['node', 'builder.js', '1234', '--clean']);
+                const a = parseArgs(['node', 'build.js', '1234', '--clean']);
                 if (a.issue !== 1234) throw new Error(`issue esperado 1234 got ${a.issue}`);
                 if (a.scope !== 'clean') throw new Error(`scope esperado 'clean' got '${a.scope}'`);
             }},
@@ -327,7 +327,7 @@ if (require.main === module) {
         return;
     }
     main().catch((e) => {
-        process.stderr.write(`[builder] fatal: ${e.stack || e.message}\n`);
+        process.stderr.write(`[build] fatal: ${e.stack || e.message}\n`);
         process.exit(2);
     });
 }

--- a/.pipeline/smoke-test.js
+++ b/.pipeline/smoke-test.js
@@ -54,7 +54,7 @@ const DEFAULT_COMPONENTS = [
 // componentes residentes Y skills determinísticos.
 const SELF_CHECK_SKILLS = [
   { name: 'tester',   path: 'skills-deterministicos/tester.js' },
-  { name: 'builder',  path: 'skills-deterministicos/builder.js' },
+  { name: 'build',    path: 'skills-deterministicos/build.js' },
   { name: 'delivery', path: 'skills-deterministicos/delivery.js' },
   { name: 'linter',   path: 'skills-deterministicos/linter.js' },
 ];

--- a/.pipeline/tests/agent-launcher.test.js
+++ b/.pipeline/tests/agent-launcher.test.js
@@ -135,7 +135,7 @@ test('launchAgent cae a Anthropic si el script determinístico fue removido (rol
     });
 
     const result = launchAgent({
-        skill: 'builder',
+        skill: 'build',
         issue: 9999,
         args: ['-p'],
         cwd: ROOT,
@@ -345,9 +345,9 @@ test('launchAgent maneja JSON inválido en agent-models.json sin crashear (fallb
 // -----------------------------------------------------------------------------
 // 10. Test sanity del resolveProviderForSkill (puro, sin spawn).
 // -----------------------------------------------------------------------------
-test('resolveProviderForSkill: builder/tester/delivery/linter siempre son deterministic', () => {
+test('resolveProviderForSkill: build/tester/delivery/linter siempre son deterministic', () => {
     const fsi = fakeFs([]);
-    for (const skill of ['builder', 'tester', 'delivery', 'linter']) {
+    for (const skill of ['build', 'tester', 'delivery', 'linter']) {
         const r = resolveProviderForSkill(skill, { pipelineDir: PIPELINE, fsImpl: fsi });
         assert.equal(r.provider, 'deterministic', `skill ${skill} debería ser deterministic`);
         assert.equal(r.handler, PROVIDERS.deterministic);
@@ -362,11 +362,11 @@ test('resolveProviderForSkill: skills determinísticos ignoran agent-models.json
     const modelsPath = path.join(PIPELINE, 'agent-models.json');
     const fsi = fakeFs([modelsPath], {
         [modelsPath]: JSON.stringify({
-            skills: { builder: { provider: 'anthropic', model: 'claude-opus-4-7' } },
+            skills: { build: { provider: 'anthropic', model: 'claude-opus-4-7' } },
         }),
     });
-    const r = resolveProviderForSkill('builder', { pipelineDir: PIPELINE, fsImpl: fsi });
-    // builder está en la allowlist → siempre deterministic, agent-models.json ignorado.
+    const r = resolveProviderForSkill('build', { pipelineDir: PIPELINE, fsImpl: fsi });
+    // build está en la allowlist → siempre deterministic, agent-models.json ignorado.
     assert.equal(r.provider, 'deterministic');
     assert.equal(r.source, 'deterministic-allowlist');
 });


### PR DESCRIPTION
## Summary

- **Causa raíz**: el Pulpo lanzaba la fase build con `PIPELINE_SKILL=build`, pero la allowlist hardcoded de determinístico en `agent-launcher/providers/deterministic.js` tenía `'builder'` (nombre del archivo, no del skill). Como no matcheaba, caía al fallback Anthropic + Opus 4.7[1m], gastando **~$2.72 USD/h** en lo que tendría que ser un script Node puro de cero tokens (alerta de consumo anómalo en 01:13 UTC).
- **Fix de raíz** (no parche): rename `skills-deterministicos/builder.js` → `build.js`, ajusta las 4 copias del set `DETERMINISTIC_SKILLS` en pulpo/quota/rest-mode/dashboard a `'build'`, y limpia `agent-models.json` (entrada `build` corregida a `deterministic`, entrada duplicada `builder` eliminada).
- **Verificación**: 140 tests OK en los 6 archivos afectados (quota-exhausted, dashboard-quota-exhausted, rest-mode-window unit + integration, agent-launcher, build.test.js).

## Test plan

- [x] `node --test` en los 6 archivos de test afectados → 140/140 verde
- [x] Allowlist hardcoded ahora matchea `PIPELINE_SKILL=build` del Pulpo
- [x] `agent-models.json` consistente (un solo entry para `build`, sin huérfano `builder`)
- [x] Smoke-test path actualizado al archivo renombrado
- [ ] Post-merge `/restart` para que el Pulpo levante con el módulo nuevo cargado

Closes la regresión de consumo del fase build (#3073 + cualquier otro issue cuyo build estaba spawneando sesiones Opus).

qa:skipped — fix puro de infra del pipeline (sin impacto en producto de usuario), determinístico, cubierto por unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)