### PR TITLE
feat(pipeline): rebote-classifier con auto-destrabe de dependencias [Curita C — fix raíz #3086] (#3167)

### DIFF
--- a/.pipeline/lib/__tests__/rebote-classifier.integration.test.js
+++ b/.pipeline/lib/__tests__/rebote-classifier.integration.test.js
@@ -1,0 +1,255 @@
+// =============================================================================
+// Tests de INTEGRACIÓN — rebote-classifier (issue #3167)
+//
+// Diferencia con `rebote-classifier.test.js` (unit):
+// los unit tests cubren cada función aisladamente. Acá ejercitamos el flujo
+// completo end-to-end con stubs livianos:
+//
+//   1) Motivo crudo "agente dijo X" → classifyRebote → reportDependencyBlock
+//      → archivos JSON en `.pipeline/servicios/github/pendiente/` con el
+//      formato exacto que consume `servicio-github.js`.
+//
+//   2) Hint estructurado del agente (rebote_categoria + depende_de) →
+//      classify usa hint → reportDependencyBlock encola las deps del hint.
+//
+//   3) Round-trip comment: el comment generado por buildDependencyComment
+//      → parseDependenciesFromComment recupera los mismos números.
+//
+//   4) Negative case: comment sin marker → parseDependenciesFromComment = [].
+//
+// Aislamiento: `os.tmpdir()/rebote-int-<pid>` con cleanup al final.
+// =============================================================================
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+// Mismo patrón que rebote-classifier.test.js: aislamos PIPELINE_DIR a tmp
+// ANTES de cargar los módulos (traceability resuelve REPO_ROOT al require).
+const TMP_DIR = fs.mkdtempSync(path.join(os.tmpdir(), `rebote-int-${process.pid}-`));
+fs.mkdirSync(path.join(TMP_DIR, '.claude'), { recursive: true });
+fs.mkdirSync(path.join(TMP_DIR, '.pipeline', 'servicios', 'github', 'pendiente'), { recursive: true });
+process.env.CLAUDE_PROJECT_DIR = TMP_DIR;
+process.env.PIPELINE_REPO_ROOT = TMP_DIR;
+
+delete require.cache[require.resolve('../traceability')];
+delete require.cache[require.resolve('../human-block')];
+delete require.cache[require.resolve('../rebote-classifier')];
+delete require.cache[require.resolve('../dep-comment-parser')];
+
+const trace = require('../traceability');
+const rc = require('../rebote-classifier');
+const depParser = require('../dep-comment-parser');
+
+const GH_QUEUE = path.join(TMP_DIR, '.pipeline', 'servicios', 'github', 'pendiente');
+
+function listQueue() {
+    try { return fs.readdirSync(GH_QUEUE); } catch { return []; }
+}
+function readQueueEntries() {
+    return listQueue().map(f => ({
+        name: f,
+        payload: JSON.parse(fs.readFileSync(path.join(GH_QUEUE, f), 'utf8')),
+    }));
+}
+function resetState() {
+    for (const f of listQueue()) {
+        try { fs.unlinkSync(path.join(GH_QUEUE, f)); } catch {}
+    }
+    try { fs.unlinkSync(trace.LOG_FILE); } catch {}
+}
+
+// Cleanup global al final del proceso de tests.
+process.on('exit', () => {
+    try { fs.rmSync(TMP_DIR, { recursive: true, force: true }); } catch {}
+});
+
+// -----------------------------------------------------------------------------
+// 1) Flujo end-to-end con motivo real del incidente #3086
+// -----------------------------------------------------------------------------
+
+test('integration · motivo "#3083 está OPEN" → classify → reportDependencyBlock encola label + comment', () => {
+    resetState();
+
+    const motivo = '#3083 (S5 audit trail) está OPEN — no puedo integrar el audit dual-provider sin que se mergee primero.';
+
+    // Paso 1: clasificar
+    const result = rc.classifyRebote({ motivo, classifyErrorResult: 'codigo' });
+    assert.equal(result.category, 'dependency_block');
+    assert.deepEqual(result.dependsOn, [3083]);
+    assert.equal(result.counts_against_circuit_breaker, false);
+    assert.equal(result.label, 'blocked:dependencies');
+
+    // Paso 2: reportar (encola label + comment)
+    const reported = rc.reportDependencyBlock({
+        issue: 3086,
+        dependsOn: result.dependsOn,
+        reason: motivo,
+        skill: 'guru',
+        phase: 'analisis',
+    });
+    assert.equal(reported.ok, true);
+    assert.equal(reported.label_queued, true);
+    assert.equal(reported.comment_queued, true);
+
+    // Paso 3: verificar archivos JSON encolados con formato del servicio-github
+    const entries = readQueueEntries();
+    assert.equal(entries.length, 2, 'debe haber 2 archivos (label + comment)');
+
+    const label = entries.find(e => e.payload.action === 'label');
+    assert.ok(label, 'falta archivo de label');
+    assert.equal(label.payload.issue, 3086);
+    assert.equal(label.payload.label, 'blocked:dependencies');
+
+    const comment = entries.find(e => e.payload.action === 'comment');
+    assert.ok(comment, 'falta archivo de comment');
+    assert.equal(comment.payload.issue, 3086);
+    assert.match(comment.payload.body, /^## Dependencias detectadas por el pipeline/m);
+    assert.match(comment.payload.body, /- #3083/);
+});
+
+// -----------------------------------------------------------------------------
+// 2) Hint estructurado del agente — formato preferido
+// -----------------------------------------------------------------------------
+
+test('integration · hint estructurado "rebote_categoria + depende_de" → reportDependencyBlock con deps del hint', () => {
+    resetState();
+
+    const motivo = [
+        'rebote_categoria: dependency_block',
+        'depende_de: [3083, 3084]',
+        'motivo: U1 multi-provider necesita el audit trail unificado de #3083.',
+    ].join('\n');
+
+    const result = rc.classifyRebote({ motivo });
+    assert.equal(result.category, 'dependency_block');
+    assert.deepEqual(result.dependsOn, [3083, 3084]);
+
+    const reported = rc.reportDependencyBlock({
+        issue: 3086,
+        dependsOn: result.dependsOn,
+        reason: motivo,
+        skill: 'guru',
+        phase: 'analisis',
+    });
+    assert.equal(reported.ok, true);
+
+    const entries = readQueueEntries();
+    const comment = entries.find(e => e.payload.action === 'comment');
+    assert.ok(comment, 'falta archivo de comment');
+    assert.match(comment.payload.body, /- #3083/);
+    assert.match(comment.payload.body, /- #3084/);
+});
+
+// -----------------------------------------------------------------------------
+// 3) Round-trip: build comment → parseDependenciesFromComment recupera la lista
+// -----------------------------------------------------------------------------
+
+test('integration · round-trip buildDependencyComment → parseDependenciesFromComment recupera deps', () => {
+    const body = rc.buildDependencyComment({
+        dependsOn: [3083, 3084],
+        reason: 'U1 depende de S5 y H6',
+        skill: 'guru',
+    });
+    const parsed = depParser.parseDependenciesFromComment(body);
+    assert.deepEqual(parsed, [3083, 3084]);
+});
+
+test('integration · parseDependenciesFromComment con body sin marker → []', () => {
+    const body = '## Otro heading random\n\n- #100\n- #200\n\nSin el marker correcto.';
+    const parsed = depParser.parseDependenciesFromComment(body);
+    assert.deepEqual(parsed, []);
+});
+
+test('integration · parseDependenciesFromComment con body vacío → []', () => {
+    assert.deepEqual(depParser.parseDependenciesFromComment(''), []);
+    assert.deepEqual(depParser.parseDependenciesFromComment(null), []);
+    assert.deepEqual(depParser.parseDependenciesFromComment(undefined), []);
+});
+
+test('integration · parseDependenciesFromComment dedup + cap a 20', () => {
+    const nums = [];
+    for (let i = 1; i <= 30; i++) nums.push('- #' + i);
+    const body = '## Dependencias detectadas por el pipeline\n\n' + nums.join('\n') + '\n- #5\n- #10';
+    const parsed = depParser.parseDependenciesFromComment(body);
+    assert.equal(parsed.length, 20);
+    assert.deepEqual(parsed.slice(0, 5), [1, 2, 3, 4, 5]);
+    // No debe haber duplicados
+    const set = new Set(parsed);
+    assert.equal(set.size, parsed.length);
+});
+
+// -----------------------------------------------------------------------------
+// 4) Asset-only path (sin issue numbers) — caso UX
+// -----------------------------------------------------------------------------
+
+test('integration · motivo "assets UX no en main" → dependency_block + comment sin bullets numéricos', () => {
+    resetState();
+
+    const motivo = 'No puedo seguir — los assets UX no están en main todavía. Mockups #N pendiente de entrega.';
+    const result = rc.classifyRebote({ motivo });
+    assert.equal(result.category, 'dependency_block');
+    assert.deepEqual(result.dependsOn, []);
+
+    const reported = rc.reportDependencyBlock({
+        issue: 9999,
+        dependsOn: result.dependsOn,
+        reason: motivo,
+        skill: 'android-dev',
+        phase: 'desarrollo',
+    });
+    assert.equal(reported.ok, true);
+
+    const entries = readQueueEntries();
+    const comment = entries.find(e => e.payload.action === 'comment');
+    assert.ok(comment, 'falta archivo de comment');
+    // Sin números en deps, el comment NO debe inyectar bullets `- #N`
+    assert.doesNotMatch(comment.payload.body, /^- #\d+/m);
+    // Sí debe traer la nota de asset/recurso sin número concreto
+    assert.match(comment.payload.body, /asset\/recurso/i);
+});
+
+// -----------------------------------------------------------------------------
+// 5) Event traceability — emit dependency:blocked
+// -----------------------------------------------------------------------------
+
+test('integration · reportDependencyBlock emite evento dependency:blocked en activity-log', () => {
+    resetState();
+
+    rc.reportDependencyBlock({
+        issue: 3086,
+        dependsOn: [3083],
+        reason: 'Test trazabilidad',
+        skill: 'guru',
+        phase: 'analisis',
+    });
+
+    assert.ok(fs.existsSync(trace.LOG_FILE), 'activity-log no se escribió');
+    const lines = fs.readFileSync(trace.LOG_FILE, 'utf8').split('\n').filter(Boolean);
+    const events = lines.map(l => JSON.parse(l));
+    const dep = events.find(e => e.event === 'dependency:blocked' && e.issue === 3086);
+    assert.ok(dep, 'falta evento dependency:blocked para #3086');
+    assert.deepEqual(dep.depends_on, [3083]);
+    assert.equal(dep.skill, 'guru');
+    assert.equal(dep.phase, 'analisis');
+});
+
+// -----------------------------------------------------------------------------
+// 6) Negative case: motivo NO-dependencia NO crea archivos en la cola
+// -----------------------------------------------------------------------------
+
+test('integration · motivo de error de código NO encola label dependency_block', () => {
+    resetState();
+
+    const motivo = 'NullPointerException at LoginViewModel.kt:42 — bug claro en el código.';
+    const result = rc.classifyRebote({ motivo, classifyErrorResult: 'codigo' });
+    assert.equal(result.category, 'code');
+    // Caller NO debe invocar reportDependencyBlock para category=code.
+    // Verificamos que si NO lo invocamos, la cola queda limpia.
+    const entries = readQueueEntries();
+    assert.equal(entries.length, 0);
+});

--- a/.pipeline/lib/__tests__/rebote-classifier.test.js
+++ b/.pipeline/lib/__tests__/rebote-classifier.test.js
@@ -1,0 +1,407 @@
+// =============================================================================
+// Tests rebote-classifier.js — issue #3167
+//
+// Cubre los criterios de aceptación de la Curita C:
+//
+//   CA-1 · classifyRebote devuelve una de las 5 categorías canónicas
+//          (cross_phase, dependency_block, human_block, infra, code).
+//   CA-2 · Precedencia: cross_phase > dependency_block > human_block > infra > code.
+//   CA-3 · detectDependencyBlock extrae issue numbers de patrones realistas.
+//   CA-4 · Hint estructural (rebote_categoria: dependency_block) gana sobre
+//          regex, agrega deps al output.
+//   CA-5 · Patrones de asset/UX matchean sin issue number (assetOnly=true).
+//   CA-6 · buildDependencyComment produce un body parseable por
+//          dep-comment-parser.js (heading exacto + bullets `- #N`).
+//   CA-7 · reportDependencyBlock encola label + comment en la cola GitHub
+//          con formato consumible por servicio-github.js.
+//   CA-8 · reportDependencyBlock emite evento `dependency:blocked` en
+//          el activity-log.
+//   CA-9 · sanitizeDepsList dedup + ordena + acota MAX_DEPS_PER_BLOCK.
+//   CA-10 · NO interfiere con human-block: motivos clásicos de bloqueo
+//           humano siguen clasificándose como human_block.
+//
+// =============================================================================
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+// Aislar PIPELINE_DIR a un tmp por test setup (mismo patrón que
+// human-block.test.js para no contaminar la cola real ni el activity-log)
+const TMP_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'v3-rebote-classifier-'));
+fs.mkdirSync(path.join(TMP_DIR, '.claude'), { recursive: true });
+fs.mkdirSync(path.join(TMP_DIR, '.pipeline', 'servicios', 'github', 'pendiente'), { recursive: true });
+process.env.CLAUDE_PROJECT_DIR = TMP_DIR;
+process.env.PIPELINE_REPO_ROOT = TMP_DIR;
+
+delete require.cache[require.resolve('../traceability')];
+delete require.cache[require.resolve('../human-block')];
+delete require.cache[require.resolve('../rebote-classifier')];
+const trace = require('../traceability');
+const rc = require('../rebote-classifier');
+const depParser = require('../dep-comment-parser');
+
+function readEvents() {
+    if (!fs.existsSync(trace.LOG_FILE)) return [];
+    return fs.readFileSync(trace.LOG_FILE, 'utf8')
+        .split('\n').filter(Boolean).map(l => JSON.parse(l));
+}
+
+function resetState() {
+    const queue = path.join(TMP_DIR, '.pipeline', 'servicios', 'github', 'pendiente');
+    try { for (const f of fs.readdirSync(queue)) fs.unlinkSync(path.join(queue, f)); } catch {}
+    try { fs.unlinkSync(trace.LOG_FILE); } catch {}
+}
+
+// =============================================================================
+// CA-1 + CA-2: clasificación y precedencia
+// =============================================================================
+
+test('CA-1: motivo de timeout con classifyErrorResult=infra → infra', () => {
+    const r = rc.classifyRebote({
+        motivo: 'ETIMEDOUT al conectar con dynamodb.us-east-1.amazonaws.com',
+        classifyErrorResult: 'infra',
+    });
+    assert.equal(r.category, 'infra');
+    assert.equal(r.counts_against_circuit_breaker, false);
+    assert.equal(r.label, null);
+});
+
+test('CA-1: motivo técnico genérico (sin matches) → code', () => {
+    const r = rc.classifyRebote({
+        motivo: 'NullPointerException en LoginService línea 42',
+    });
+    assert.equal(r.category, 'code');
+    assert.equal(r.counts_against_circuit_breaker, true);
+    assert.equal(r.label, null);
+});
+
+test('CA-1: motivo con merge manual / CODEOWNERS → human_block', () => {
+    const r = rc.classifyRebote({
+        motivo: 'PR #2547 mergeable pero CODEOWNERS requiere review humano del backend',
+    });
+    assert.equal(r.category, 'human_block');
+    assert.equal(r.label, 'needs-human');
+});
+
+test('CA-1: motivo con dependencia explícita → dependency_block', () => {
+    const r = rc.classifyRebote({
+        motivo: 'No puedo continuar, depende de #3083 que sigue OPEN',
+    });
+    assert.equal(r.category, 'dependency_block');
+    assert.equal(r.label, 'blocked:dependencies');
+    assert.deepEqual(r.dependsOn, [3083]);
+    assert.equal(r.counts_against_circuit_breaker, false);
+    assert.ok(r.autounlock, 'debe declarar mecanismo de autounlock');
+    assert.equal(r.autounlock.mechanism, 'brazo-desbloqueo');
+});
+
+test('CA-1: isRoutingMismatch=true + faseDestino → cross_phase', () => {
+    const r = rc.classifyRebote({
+        motivo: 'Fuera de alcance: este issue requiere refinamiento de UX',
+        isRoutingMismatch: true,
+        faseDestino: 'definicion/ux',
+    });
+    assert.equal(r.category, 'cross_phase');
+    assert.equal(r.counts_against_circuit_breaker, false);
+});
+
+test('CA-2: cross_phase gana sobre dependency_block', () => {
+    // Si el agente devolvió "depende de #X" PERO el routing-classifier ya
+    // determinó que es out-of-scope, el rebote debe ir a la fase destino,
+    // no quedar como bloqueado por dependencia.
+    const r = rc.classifyRebote({
+        motivo: 'depende de #3083 que está abierta — fuera de alcance de dev',
+        isRoutingMismatch: true,
+        faseDestino: 'definicion/guru',
+    });
+    assert.equal(r.category, 'cross_phase');
+});
+
+test('CA-2: dependency_block gana sobre human_block', () => {
+    // Cuando el motivo menciona BOTH "depende de #N" Y un patrón de
+    // human-block clásico, debe ganar dependency_block (más específico).
+    const r = rc.classifyRebote({
+        motivo: 'depende de #3083 — esto requiere intervención humana también',
+    });
+    assert.equal(r.category, 'dependency_block');
+    assert.deepEqual(r.dependsOn, [3083]);
+});
+
+test('CA-2: human_block gana sobre infra cuando ambos matchean', () => {
+    // Motivo dice "needs-human" Y el caller pre-clasificó como infra. Como
+    // human_block es más específico (catch explícito), gana.
+    const r = rc.classifyRebote({
+        motivo: 'PR pending human review (caída intermitente de gh CLI)',
+        classifyErrorResult: 'infra',
+    });
+    assert.equal(r.category, 'human_block');
+});
+
+// =============================================================================
+// CA-3: detectDependencyBlock — patrones realistas
+// =============================================================================
+
+test('CA-3: "depende de #N" extrae el número', () => {
+    const r = rc.detectDependencyBlock('No puedo continuar, depende de #3083');
+    assert.equal(r.matched, true);
+    assert.deepEqual(r.dependsOn, [3083]);
+    assert.equal(r.assetOnly, false);
+});
+
+test('CA-3: "bloqueado por #N" extrae el número', () => {
+    const r = rc.detectDependencyBlock('Bloqueado por #2734 mientras no se mergee');
+    assert.equal(r.matched, true);
+    assert.deepEqual(r.dependsOn, [2734]);
+});
+
+test('CA-3: "espera merge de #N" extrae el número', () => {
+    const r = rc.detectDependencyBlock('Esperando el merge de #3083 antes de seguir');
+    assert.equal(r.matched, true);
+    assert.deepEqual(r.dependsOn, [3083]);
+});
+
+test('CA-3: "#N está open" extrae el número', () => {
+    const r = rc.detectDependencyBlock('La dependencia #3083 está abierta todavía');
+    assert.equal(r.matched, true);
+    assert.deepEqual(r.dependsOn, [3083]);
+});
+
+test('CA-3: múltiples #N → todos en dependsOn ordenados y dedup', () => {
+    const r = rc.detectDependencyBlock(
+        'Depende de #3083 y de #2734. Adicionalmente #2734 sigue open.',
+    );
+    assert.equal(r.matched, true);
+    assert.deepEqual(r.dependsOn, [2734, 3083]);
+});
+
+test('CA-3: motivo sin ningún patrón → matched=false', () => {
+    const r = rc.detectDependencyBlock('NullPointerException en línea 42');
+    assert.equal(r.matched, false);
+    assert.deepEqual(r.dependsOn, []);
+});
+
+test('CA-3: menciones casuales de #N (sin patrón) → matched=false', () => {
+    // "Mejor que #2547" no es una dependencia formal. No debe matchear.
+    const r = rc.detectDependencyBlock('Decisión: implementar como en #2547 pero con cache');
+    assert.equal(r.matched, false);
+});
+
+// =============================================================================
+// CA-4: Hint estructural
+// =============================================================================
+
+test('CA-4: hint estructural detecta dependency_block sin patrones de texto', () => {
+    const r = rc.detectDependencyBlock(
+        'rebote_categoria: dependency_block; depende_de: [3083, 2734]; reason: ...',
+    );
+    assert.equal(r.matched, true);
+    assert.deepEqual(r.dependsOn, [2734, 3083]);
+});
+
+test('CA-4: hint estructural + dependsOn extra del caller', () => {
+    const r = rc.detectDependencyBlock(
+        'rebote_categoria: "dependency_block"',
+        [3001, 3002],
+    );
+    assert.equal(r.matched, true);
+    assert.deepEqual(r.dependsOn, [3001, 3002]);
+});
+
+test('CA-4: hint con lista en formato YAML works', () => {
+    const r = rc.detectDependencyBlock(
+        'rebote_categoria: dependency_block\ndepende_de: 3083, #2734, 3001',
+    );
+    assert.equal(r.matched, true);
+    assert.deepEqual(r.dependsOn, [2734, 3001, 3083]);
+});
+
+// =============================================================================
+// CA-5: Patrones de asset/UX
+// =============================================================================
+
+test('CA-5: "assets UX no están en main" → matched + assetOnly', () => {
+    const r = rc.detectDependencyBlock('Los assets UX no están en main todavía');
+    assert.equal(r.matched, true);
+    assert.equal(r.assetOnly, true);
+    assert.deepEqual(r.dependsOn, []);
+});
+
+test('CA-5: "recursos UX faltan" → matched + assetOnly', () => {
+    const r = rc.detectDependencyBlock('Recursos UX faltan para implementar el flujo');
+    assert.equal(r.matched, true);
+    assert.equal(r.assetOnly, true);
+});
+
+test('CA-5: classify con assetOnly genera reason_summary apropiado', () => {
+    const r = rc.classifyRebote({
+        motivo: 'Los recursos UX no están en main',
+    });
+    assert.equal(r.category, 'dependency_block');
+    assert.equal(r.label, 'blocked:dependencies');
+    assert.deepEqual(r.dependsOn, []);
+    assert.match(r.reason_summary, /asset|recurso/i);
+});
+
+// =============================================================================
+// CA-6: buildDependencyComment parseable por dep-comment-parser
+// =============================================================================
+
+test('CA-6: comment con deps numéricas es parseable por dep-comment-parser', () => {
+    const body = rc.buildDependencyComment({
+        dependsOn: [3083, 2734],
+        skill: 'guru',
+        reason: 'Test reason',
+    });
+    // Heading EXACTO esperado por dep-comment-parser.js
+    assert.match(body, /^## Dependencias detectadas por el pipeline$/m);
+    assert.match(body, /^- #2734$/m);
+    assert.match(body, /^- #3083$/m);
+
+    // Validamos que el parser real lo procese
+    const parsed = depParser.parseDependencyComment(
+        [{ body, createdAt: new Date().toISOString() }],
+        9999, // selfIssue distinto
+    );
+    assert.ok(Array.isArray(parsed), 'parser debe devolver array');
+    assert.deepEqual(parsed.map(Number).sort((a, b) => a - b), [2734, 3083]);
+});
+
+test('CA-6: comment sin deps numéricas (assetOnly) NO inserta bullets vacíos', () => {
+    const body = rc.buildDependencyComment({
+        dependsOn: [],
+        skill: 'guru',
+        reason: 'Asset UX pendiente',
+    });
+    assert.match(body, /## Dependencias detectadas por el pipeline/);
+    assert.doesNotMatch(body, /^- #/m);
+});
+
+// =============================================================================
+// CA-7 + CA-8: reportDependencyBlock encola artefactos y emite evento
+// =============================================================================
+
+test('CA-7: reportDependencyBlock encola label + comment en cola GitHub', () => {
+    resetState();
+    const result = rc.reportDependencyBlock({
+        issue: 3086,
+        dependsOn: [3083],
+        skill: 'guru',
+        phase: 'analisis',
+        reason: 'Dependencia #3083 todavía OPEN',
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.issue, 3086);
+    assert.equal(result.label_queued, true);
+    assert.equal(result.comment_queued, true);
+
+    const queue = path.join(TMP_DIR, '.pipeline', 'servicios', 'github', 'pendiente');
+    const files = fs.readdirSync(queue).filter(f => f.startsWith('3086-'));
+    assert.equal(files.length, 2, 'debe haber 2 archivos encolados (label + comment)');
+
+    const labelFile = files.find(f => f.includes('blocked-dependencies'));
+    const commentFile = files.find(f => f.includes('deps-comment'));
+    assert.ok(labelFile, 'archivo de label presente');
+    assert.ok(commentFile, 'archivo de comment presente');
+
+    const labelPayload = JSON.parse(fs.readFileSync(path.join(queue, labelFile), 'utf8'));
+    assert.equal(labelPayload.action, 'label');
+    assert.equal(labelPayload.issue, 3086);
+    assert.equal(labelPayload.label, 'blocked:dependencies');
+
+    const commentPayload = JSON.parse(fs.readFileSync(path.join(queue, commentFile), 'utf8'));
+    assert.equal(commentPayload.action, 'comment');
+    assert.equal(commentPayload.issue, 3086);
+    assert.match(commentPayload.body, /## Dependencias detectadas por el pipeline/);
+    assert.match(commentPayload.body, /- #3083/);
+});
+
+test('CA-8: reportDependencyBlock emite evento dependency:blocked', () => {
+    resetState();
+    rc.reportDependencyBlock({
+        issue: 3086,
+        dependsOn: [3083, 2734],
+        skill: 'guru',
+        phase: 'analisis',
+    });
+    const events = readEvents();
+    const ev = events.find(e => e.event === 'dependency:blocked' && e.issue === 3086);
+    assert.ok(ev, 'evento dependency:blocked emitido');
+    assert.deepEqual(ev.depends_on, [2734, 3083]);
+    assert.equal(ev.skill, 'guru');
+    assert.equal(ev.phase, 'analisis');
+});
+
+test('CA-7: reportDependencyBlock rechaza issue inválido', () => {
+    resetState();
+    const result = rc.reportDependencyBlock({ issue: 'not-a-number', dependsOn: [3083] });
+    assert.equal(result.ok, false);
+    assert.match(result.error, /num[eé]rico/);
+});
+
+// =============================================================================
+// CA-9: sanitizeDepsList
+// =============================================================================
+
+test('CA-9: sanitizeDepsList dedup, ordena, descarta inválidos, acepta strings con #', () => {
+    const r = rc.sanitizeDepsList([3083, '#2734', 3083, '#abc', null, 0, -5, '2734']);
+    assert.deepEqual(r, [2734, 3083]);
+});
+
+test('CA-9: sanitizeDepsList acota a MAX_DEPS_PER_BLOCK', () => {
+    const huge = Array.from({ length: 50 }, (_, i) => i + 1);
+    const r = rc.sanitizeDepsList(huge);
+    assert.equal(r.length, rc.MAX_DEPS_PER_BLOCK);
+});
+
+// =============================================================================
+// CA-10: No interfiere con human-block clásico
+// =============================================================================
+
+test('CA-10: motivos clásicos de human-block siguen siendo human_block', () => {
+    const motivos = [
+        'PR #2547 mergeable pero CODEOWNERS requiere review',
+        'Pending human review del feature flag',
+        'merge manual pendiente del backend',
+        'needs-human: revisión de seguridad obligatoria',
+        'aprobación humana pendiente',
+    ];
+    for (const motivo of motivos) {
+        const r = rc.classifyRebote({ motivo });
+        assert.equal(r.category, 'human_block', `"${motivo}" debería ser human_block`);
+        assert.equal(r.label, 'needs-human');
+    }
+});
+
+test('CA-10: motivo vacío → code (fallback) sin romper', () => {
+    const r = rc.classifyRebote({});
+    assert.equal(r.category, 'code');
+});
+
+test('CA-10: motivo undefined → code (fallback) sin romper', () => {
+    const r = rc.classifyRebote({ motivo: undefined });
+    assert.equal(r.category, 'code');
+});
+
+// =============================================================================
+// Smoke: caso real del incidente #3086
+// =============================================================================
+
+test('SMOKE #3086: motivo realístico del guru → dependency_block con #3083', () => {
+    // Motivo aproximado al que el guru emitió en el incidente real:
+    const motivoReal = [
+        'Verificado empíricamente: #3083 (S5 audit trail dinámico) está OPEN.',
+        'Sin él, pulpo.js no emite el campo provider en session:start, y el slice',
+        'dashboard-slices.js no tiene de dónde sacar el dato. Adicionalmente, los',
+        'assets UX no están en main.',
+    ].join('\n');
+
+    const r = rc.classifyRebote({ motivo: motivoReal });
+    assert.equal(r.category, 'dependency_block');
+    assert.ok(r.dependsOn.includes(3083), '#3083 debe estar en dependsOn');
+    assert.equal(r.label, 'blocked:dependencies');
+});

--- a/.pipeline/lib/dep-comment-parser.js
+++ b/.pipeline/lib/dep-comment-parser.js
@@ -239,8 +239,37 @@ function parseDependencyComment(comments, selfIssue) {
     return extractIssueNumbers(block, selfIssue);
 }
 
+/**
+ * #3167 — Wrapper conveniente para callers que tienen UN único body
+ * (no la lista de comments completa) y quieren la lista de números detectados.
+ *
+ * Devuelve siempre un `number[]` (nunca null). Si el body no contiene el
+ * marker, devuelve `[]`. Esto difiere de `parseDependencyComment` que
+ * devuelve `null` para que el caller pueda diferenciar "fail-closed" (no
+ * tocar labels) de "marker presente pero sin numeros". Para el brazo de
+ * desbloqueo se mantiene `parseDependencyComment` con su semántica de null.
+ *
+ * Reglas adicionales del spec del clasificador:
+ *  - Resultado deduplicado y ordenado ascendente.
+ *  - Acotado a 20 elementos (MAX_DEPS_PER_BLOCK).
+ *
+ * @param {string} body — body del comentario.
+ * @returns {number[]}
+ */
+function parseDependenciesFromComment(body) {
+    if (typeof body !== 'string' || body.length === 0) return [];
+    const block = extractDependencyBlock(body);
+    if (block === null) return [];
+    // selfIssue=null → no excluimos nada porque no tenemos contexto del paraguas.
+    const nums = extractIssueNumbers(block, null);
+    // Ordenar ascendente + cap a 20.
+    const sorted = nums.slice().sort((a, b) => a - b);
+    return sorted.slice(0, 20);
+}
+
 module.exports = {
     parseDependencyComment,
+    parseDependenciesFromComment,
     // Helpers exportados para tests unitarios — NO consumir fuera del módulo.
     extractDependencyBlock,
     extractIssueNumbers,

--- a/.pipeline/lib/rebote-classifier.js
+++ b/.pipeline/lib/rebote-classifier.js
@@ -1,0 +1,434 @@
+// =============================================================================
+// rebote-classifier.js — Clasificación unificada de rebotes (issue #3167)
+//
+// CONTEXTO
+// --------
+// Antes de esta capa, el Pulpo decidía qué hacer con un rebote usando una
+// cascada de heurísticas dispersas:
+//
+//   1. precheck.classifyError(motivo) → 'infra' | 'codigo'
+//   2. humanBlock.isHumanBlockReason(motivo) → true | false  (binario)
+//   3. routing-classifier (motivo, faseDestino) → routing mismatch sí/no
+//
+// La capa de bloqueo humano (paso 2) era el "catch-all" cuando un agente
+// detectaba que el issue dependía de otro issue OPEN o de un asset todavía
+// no mergeado a `main`. No había forma de comunicar al Pulpo "esperá una
+// dependencia"; el issue terminaba en `bloqueado-humano/` esperando que
+// un operador lo destrabe manualmente (incidente #3086).
+//
+// Esta capa introduce una clasificación de 5 categorías declarativa y
+// extensible, ordenada por especificidad (más específica gana):
+//
+//   1. cross_phase       — out-of-scope, rebote a otra fase
+//   2. dependency_block  — espera merge/cierre de otro issue o asset
+//   3. human_block       — requiere intervención humana (merge manual, etc)
+//   4. infra             — red/timeout (no cuenta para circuit breaker)
+//   5. code              — fallback técnico (cuenta para circuit breaker)
+//
+// CONTRATO CON EL BRAZO DE DESBLOQUEO
+// -----------------------------------
+// Cuando se detecta `dependency_block`, NO se crea marker en
+// `bloqueado-humano/`. En su lugar:
+//
+//   a) Se aplica label GitHub `blocked:dependencies` (excluye al issue
+//      del intake en pulpo.js:3764-3767 y del recuento de cola en 1883,
+//      2085).
+//   b) Se postea un comentario con el marker exacto
+//      `## Dependencias detectadas por el pipeline` seguido de bullets
+//      `- #N` (formato parseable por `dep-comment-parser.js`).
+//   c) El brazo de desbloqueo (pulpo.js:7838+, intervalo configurable
+//      `desbloqueo.interval_min`) escanea cada N min los issues con ese
+//      label, parsea las deps, y cuando todas están CLOSED quita el
+//      label automáticamente + notifica Telegram.
+//
+// Resultado: cero tokens consumidos mientras espera + cero intervención
+// humana cuando las deps cierren.
+//
+// SEGURIDAD
+// ---------
+// Todos los patrones son regex con quantifiers acotados, sin backtracking
+// exponencial. Parsing line-based donde es posible. Complejidad lineal
+// O(n) sobre el motivo (bounded a 5000 chars en `truncateForClassify`).
+//
+// =============================================================================
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const trace = require('./traceability');
+const humanBlock = require('./human-block');
+
+const PIPELINE_DIR = path.join(trace.REPO_ROOT, '.pipeline');
+const GH_QUEUE_DIR = path.join(PIPELINE_DIR, 'servicios', 'github', 'pendiente');
+const DEPS_LABEL = 'blocked:dependencies';
+const MAX_MOTIVO_LEN = 5000;
+const MAX_DEPS_PER_BLOCK = 20;
+
+// -----------------------------------------------------------------------------
+// PATRONES DEPENDENCY_BLOCK
+//
+// Cada patrón captura el issue number del que se depende. Los patrones son
+// case-insensitive, sin alternaciones anidadas, sin lookbehind variable.
+// El número se captura en el grupo 1 — el caller hace dedup numérico.
+// -----------------------------------------------------------------------------
+const DEPENDENCY_PATTERNS = [
+    // "depende de #N" / "depende del issue #N"
+    /\bdepende(?:n)?\s+(?:de|del)\s+(?:la\s+|el\s+)?(?:issue\s+|PR\s+)?#(\d+)\b/i,
+    // "bloqueado por #N" / "bloqueada por #N"
+    /\bbloqu(?:ead|ad)[oa]s?\s+por\s+(?:la\s+|el\s+)?(?:issue\s+|PR\s+)?#(\d+)\b/i,
+    // "espera/esperando merge de #N"
+    /\bespera(?:ndo)?\s+(?:el\s+)?(?:merge|cierre)\s+(?:de|del)\s+#(\d+)\b/i,
+    // "pendiente de merge #N" / "pendiente del merge de #N"
+    /\bpendiente\s+(?:de\s+|del\s+)?(?:merge|cierre)(?:\s+de)?\s+#(\d+)\b/i,
+    // "#N está open/abierta/sin mergear/todavía abierta" — admite paréntesis
+    // intermedios cortos (ej: "#3083 (S5 audit trail) está OPEN") con bound
+    // estricto para evitar matches cross-párrafo y backtracking exponencial.
+    /#(\d+)(?:\s+\([^)\n]{0,80}\))?\s+(?:est[aá]\s+|todav[ií]a\s+|sigue\s+|continua\s+)?(?:open|abierta|abierto|sin\s+mergear|sin\s+cerrar|sin\s+merge|no\s+mergead[oa])\b/i,
+    // "issue #N (no) está cerrado" / "issue #N OPEN"
+    /\bissue\s+#(\d+)\s+(?:est[aá]\s+|no\s+est[aá]\s+|todav[ií]a\s+)?(?:open|abierta|abierto|pendiente|sin\s+cerrar)\b/i,
+    // "S5/H6/Mx/Ux #N abierta/open"
+    /\b[A-Z]\d{1,2}\s+\(?#?(\d+)\)?\s+.{0,30}\b(?:open|abierta|sin\s+mergear)\b/i,
+    // "dependencia #N" / "dep #N"
+    /\bdependenc(?:ia|y)\s+#(\d+)\b/i,
+    /\bdep\s+#(\d+)\s+(?:open|abierta|pendiente)/i,
+    // "PR #N (mergeable|pendiente|esperando|no mergeado)"  — pre-empt a humanBlock
+    // si claramente es espera-de-merge automático y no merge-manual
+    /\bPR\s+#(\d+)\s+(?:pendiente\s+de\s+merge|todav[ií]a\s+sin\s+mergear|esperando\s+autom?[áa]tico)\b/i,
+];
+
+// Patrones de assets/recursos que están "pendientes" sin un #N explícito.
+// Estos no producen dependsOn numéricas (no hay issue concreto), pero igual
+// son dependency_block — el agente debe especificar manualmente o se rutea
+// a la fase que falta (UX típicamente).
+const DEPENDENCY_ASSET_PATTERNS = [
+    /\basset(?:s)?\s+(?:UX|de\s+UX)\s+(?:no\s+est[aá]n?\s+en\s+main|falta(?:n)?|pendiente(?:s)?)\b/i,
+    /\brecurs(?:o|os)\s+(?:UX|de\s+UX|de\s+dise[ñn]o)\s+(?:no\s+est[aá]n?\s+en\s+main|falta(?:n)?|pendiente(?:s)?)\b/i,
+    /\bdise[ñn]o\s+(?:UX|de\s+UX)\s+todav[ií]a\s+no\s+entregad[oa]\b/i,
+    /\bmockup(?:s)?\s+(?:UX|de\s+UX)\s+(?:falta|pendiente|no\s+est[aá]n?\s+en\s+main)\b/i,
+];
+
+// Hint estructural: el motivo ya viene preformateado por un agente que
+// usa la convención del classifier (campos explícitos en YAML/JSON).
+// Ejemplo de motivo del agente:
+//
+//   "rebote_categoria: dependency_block; depende_de: [3083, 3084]; ..."
+const STRUCTURED_DEPENDENCY_HINT = /\brebote_categoria\s*[:=]\s*['"]?dependency_block\b/i;
+const STRUCTURED_DEPS_LIST = /\b(?:depende_de|depends_on|dependencias)\s*[:=]\s*\[?\s*([\d,\s#]+)\]?/i;
+
+// -----------------------------------------------------------------------------
+// API PÚBLICA
+// -----------------------------------------------------------------------------
+
+/**
+ * Clasifica un motivo de rebote en una de las 5 categorías canónicas.
+ *
+ * @param {object} opts
+ * @param {string} opts.motivo               — texto crudo del rebote
+ * @param {number[]} [opts.dependsOn=[]]     — hint estructural de dependencias
+ *                                              (si el agente ya las parseó)
+ * @param {string} [opts.faseDestino]        — fase destino para cross_phase
+ * @param {string} [opts.classifyErrorResult] — resultado de precheck.classifyError
+ *                                              ('infra' | 'codigo'). Si no se
+ *                                              pasa, este módulo no infiere
+ *                                              infra (lo deja al caller).
+ * @param {boolean} [opts.isRoutingMismatch=false] — flag externo del routing-classifier
+ *
+ * @returns {{
+ *   category: 'cross_phase'|'dependency_block'|'human_block'|'infra'|'code',
+ *   label: string|null,
+ *   dependsOn: number[],
+ *   counts_against_circuit_breaker: boolean,
+ *   autounlock: object|null,
+ *   reason_summary: string,
+ * }}
+ */
+function classifyRebote(opts = {}) {
+    const rawMotivo = String(opts.motivo || '');
+    const motivo = truncateForClassify(rawMotivo);
+    const hintDeps = sanitizeDepsList(opts.dependsOn);
+
+    // 1. cross_phase — hint externo del routing-classifier
+    if (opts.isRoutingMismatch === true && opts.faseDestino) {
+        return {
+            category: 'cross_phase',
+            label: null,
+            dependsOn: [],
+            counts_against_circuit_breaker: false,
+            autounlock: null,
+            reason_summary: 'Rebote routing mismatch → fase destino: ' + String(opts.faseDestino),
+        };
+    }
+
+    // 2. dependency_block — primer matcher específico
+    //    Prioridad: hint estructural > regex sobre el texto
+    const depDetect = detectDependencyBlock(motivo, hintDeps);
+    if (depDetect.matched) {
+        return {
+            category: 'dependency_block',
+            label: DEPS_LABEL,
+            dependsOn: depDetect.dependsOn,
+            counts_against_circuit_breaker: false,
+            autounlock: {
+                source: 'github-label',
+                mechanism: 'brazo-desbloqueo',
+                label: DEPS_LABEL,
+                note: 'El Pulpo destraba automáticamente cuando todas las dependencias estén CLOSED en GitHub.',
+            },
+            reason_summary: depDetect.assetOnly
+                ? 'Espera asset/recurso no en main'
+                : 'Depende de issue(s) abierto(s): ' + depDetect.dependsOn.map(n => '#' + n).join(', '),
+        };
+    }
+
+    // 3. human_block — heurística existente (intacta)
+    if (humanBlock.isHumanBlockReason(motivo)) {
+        return {
+            category: 'human_block',
+            label: humanBlock.NEEDS_HUMAN_LABEL,
+            dependsOn: [],
+            counts_against_circuit_breaker: false,
+            autounlock: null,
+            reason_summary: 'Bloqueo humano (merge manual / CODEOWNERS / decisión)',
+        };
+    }
+
+    // 4. infra — si el caller pre-clasificó como infra
+    if (opts.classifyErrorResult === 'infra') {
+        return {
+            category: 'infra',
+            label: null,
+            dependsOn: [],
+            counts_against_circuit_breaker: false,
+            autounlock: null,
+            reason_summary: 'Error de infra (red/timeout) — reintenta solo',
+        };
+    }
+
+    // 5. code — fallback
+    return {
+        category: 'code',
+        label: null,
+        dependsOn: [],
+        counts_against_circuit_breaker: true,
+        autounlock: null,
+        reason_summary: 'Rechazo técnico — rebota a fase de rechazo',
+    };
+}
+
+/**
+ * Detecta si un motivo describe una dependency_block. Combina hint
+ * estructural (rebote_categoria/depende_de) + pattern matching.
+ *
+ * @returns {{ matched: boolean, dependsOn: number[], assetOnly: boolean }}
+ */
+function detectDependencyBlock(motivo, hintDeps = []) {
+    if (typeof motivo !== 'string' || !motivo.trim()) {
+        return { matched: false, dependsOn: [], assetOnly: false };
+    }
+
+    // 2a. Hint estructural (agente ya clasificó explícitamente)
+    if (STRUCTURED_DEPENDENCY_HINT.test(motivo)) {
+        const deps = new Set(hintDeps);
+        const m = STRUCTURED_DEPS_LIST.exec(motivo);
+        if (m && m[1]) {
+            for (const raw of m[1].split(/[\s,]+/)) {
+                const n = Number(raw.replace(/^#/, ''));
+                if (Number.isFinite(n) && n > 0) deps.add(n);
+            }
+        }
+        const sorted = Array.from(deps).sort((a, b) => a - b).slice(0, MAX_DEPS_PER_BLOCK);
+        // Si solo hubo hint pero no logramos extraer números, igual lo
+        // marcamos como matched: el agente sabe lo que hace.
+        return { matched: true, dependsOn: sorted, assetOnly: sorted.length === 0 };
+    }
+
+    // 2b. Patrones de texto (issue numbers)
+    const found = new Set(hintDeps);
+    for (const pat of DEPENDENCY_PATTERNS) {
+        // Aplicar global manualmente porque algunos patterns no llevan /g
+        const globalPat = new RegExp(pat.source, pat.flags.includes('g') ? pat.flags : pat.flags + 'g');
+        let m;
+        let safetyBudget = 100; // anti-runaway si una regex captura todo
+        while ((m = globalPat.exec(motivo)) !== null && safetyBudget-- > 0) {
+            const n = Number(m[1]);
+            if (Number.isFinite(n) && n > 0) found.add(n);
+            if (m.index === globalPat.lastIndex) globalPat.lastIndex++;
+        }
+    }
+
+    if (found.size > 0) {
+        const sorted = Array.from(found).sort((a, b) => a - b).slice(0, MAX_DEPS_PER_BLOCK);
+        return { matched: true, dependsOn: sorted, assetOnly: false };
+    }
+
+    // 2c. Patrones de assets/recursos (sin issue number explícito)
+    for (const pat of DEPENDENCY_ASSET_PATTERNS) {
+        if (pat.test(motivo)) {
+            return { matched: true, dependsOn: [], assetOnly: true };
+        }
+    }
+
+    return { matched: false, dependsOn: [], assetOnly: false };
+}
+
+/**
+ * Construye el body del comentario GitHub que el brazo de desbloqueo parsea.
+ * Formato compatible con `dep-comment-parser.js` (planner style — heading
+ * limpio + bullets `- #N`).
+ *
+ * @param {object} opts
+ * @param {number[]} opts.dependsOn  — issue numbers (sin #, ya sanitizados)
+ * @param {string}   [opts.reason]   — texto explicativo del agente
+ * @param {string}   [opts.skill]    — agente que detectó la dependencia
+ */
+function buildDependencyComment(opts) {
+    const deps = sanitizeDepsList(opts.dependsOn);
+    const lines = [
+        '## Dependencias detectadas por el pipeline',
+        '',
+    ];
+    if (deps.length === 0) {
+        lines.push('_(El agente detectó dependencia de un asset/recurso sin issue number concreto.)_');
+        lines.push('');
+        lines.push('Este issue queda bloqueado hasta que un operador resuelva la dependencia o agregue el `#N` correspondiente.');
+    } else {
+        for (const n of deps) lines.push('- #' + n);
+        lines.push('');
+        lines.push('Este issue queda bloqueado hasta que se resuelvan las dependencias listadas. El brazo de desbloqueo del Pulpo quita el label automáticamente cuando todas estén CLOSED.');
+    }
+
+    if (opts.reason) {
+        lines.push('');
+        lines.push('### Motivo detectado');
+        lines.push('```');
+        lines.push(String(opts.reason).slice(0, 1500));
+        lines.push('```');
+    }
+    if (opts.skill) {
+        lines.push('');
+        lines.push('_Detectado por agente `' + String(opts.skill) + '` (categoría `dependency_block`)._');
+    }
+
+    return lines.join('\n');
+}
+
+/**
+ * Encola los artefactos GitHub necesarios para que el brazo de desbloqueo
+ * tome al issue:
+ *   1. Aplicar label `blocked:dependencies`
+ *   2. Postear comment con marker parseable
+ *
+ * Side effects: escribe archivos JSON en `.pipeline/servicios/github/pendiente/`.
+ * No invoca gh directamente — el `servicio-github.js` los procesa.
+ *
+ * @param {object} opts
+ * @param {number} opts.issue        — número del issue (obligatorio)
+ * @param {number[]} opts.dependsOn  — lista de issue numbers de las que depende
+ * @param {string} [opts.reason]     — motivo detallado del agente
+ * @param {string} [opts.skill]      — agente que detectó la dependencia
+ * @param {string} [opts.phase]      — fase del agente
+ *
+ * @returns {{ ok: boolean, issue: number, label_queued: boolean, comment_queued: boolean, error?: string }}
+ */
+function reportDependencyBlock(opts) {
+    const issue = Number(opts.issue);
+    if (!Number.isFinite(issue) || issue <= 0) {
+        return { ok: false, issue: 0, label_queued: false, comment_queued: false, error: 'reportDependencyBlock requiere issue numérico' };
+    }
+    const dependsOn = sanitizeDepsList(opts.dependsOn);
+
+    let labelQueued = false;
+    let commentQueued = false;
+
+    try {
+        fs.mkdirSync(GH_QUEUE_DIR, { recursive: true });
+    } catch (e) {
+        return { ok: false, issue, label_queued: false, comment_queued: false, error: 'No se pudo crear cola GitHub: ' + e.message };
+    }
+
+    // 1. Encolar label
+    try {
+        const labelFile = path.join(GH_QUEUE_DIR, `${issue}-${DEPS_LABEL.replace(/:/g, '-')}-block-${Date.now()}.json`);
+        fs.writeFileSync(labelFile, JSON.stringify({
+            action: 'label',
+            issue,
+            label: DEPS_LABEL,
+        }));
+        labelQueued = true;
+    } catch (e) {
+        // Si falla el label NO encolamos comment: sin label, el brazo de
+        // desbloqueo nunca va a barrer este issue (fail-closed).
+        return { ok: false, issue, label_queued: false, comment_queued: false, error: 'No se pudo encolar label: ' + e.message };
+    }
+
+    // 2. Encolar comment con marker
+    try {
+        const body = buildDependencyComment({ dependsOn, reason: opts.reason, skill: opts.skill });
+        const commentFile = path.join(GH_QUEUE_DIR, `${issue}-deps-comment-${Date.now() + 1}.json`);
+        fs.writeFileSync(commentFile, JSON.stringify({
+            action: 'comment',
+            issue,
+            body,
+        }));
+        commentQueued = true;
+    } catch (e) {
+        // Label ya aplicado, comment falló: el brazo lo va a interpretar
+        // como "fail-closed" (no encuentra marker) y dejarlo para revisión.
+        // Eso ya es comportamiento seguro; reportamos error pero ok=true.
+        emitBlocked({ issue, dependsOn, skill: opts.skill, phase: opts.phase, reason: opts.reason });
+        return { ok: true, issue, label_queued: true, comment_queued: false, error: 'Comment falló (label sí aplicado): ' + e.message };
+    }
+
+    emitBlocked({ issue, dependsOn, skill: opts.skill, phase: opts.phase, reason: opts.reason });
+
+    return { ok: true, issue, label_queued: labelQueued, comment_queued: commentQueued };
+}
+
+// -----------------------------------------------------------------------------
+// HELPERS INTERNOS
+// -----------------------------------------------------------------------------
+
+function truncateForClassify(s) {
+    if (typeof s !== 'string') return '';
+    return s.length > MAX_MOTIVO_LEN ? s.slice(0, MAX_MOTIVO_LEN) : s;
+}
+
+function sanitizeDepsList(input) {
+    if (!Array.isArray(input)) return [];
+    const out = new Set();
+    for (const raw of input) {
+        const n = Number(typeof raw === 'string' ? raw.replace(/^#/, '') : raw);
+        if (Number.isFinite(n) && n > 0) out.add(n);
+    }
+    return Array.from(out).sort((a, b) => a - b).slice(0, MAX_DEPS_PER_BLOCK);
+}
+
+function emitBlocked(opts) {
+    try {
+        trace.appendEvent({
+            event: 'dependency:blocked',
+            issue: Number(opts.issue) || null,
+            depends_on: Array.isArray(opts.dependsOn) ? opts.dependsOn : [],
+            skill: opts.skill || null,
+            phase: opts.phase || null,
+            reason: opts.reason || '',
+            ts: new Date().toISOString(),
+            pid: process.pid,
+        });
+    } catch {
+        // appendEvent ya es fail-tolerant; ignoramos
+    }
+}
+
+module.exports = {
+    classifyRebote,
+    detectDependencyBlock,
+    buildDependencyComment,
+    reportDependencyBlock,
+    sanitizeDepsList,
+    DEPENDENCY_PATTERNS,
+    DEPENDENCY_ASSET_PATTERNS,
+    DEPS_LABEL,
+    MAX_DEPS_PER_BLOCK,
+};

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -40,6 +40,12 @@ const quotaExhausted = require('./lib/quota-exhausted'); // #2974
 // #3002 — Parser robusto del marker "Dependencias detectadas por el pipeline".
 // Reemplaza la regex inline rota que extraía deps fantasma del body+comments.
 const { parseDependencyComment } = require('./lib/dep-comment-parser');
+// #3167 — Clasificador unificado de rebotes (cross_phase / dependency_block /
+// human_block / infra / code). El brazo de barrido invoca `classifyRebote`
+// ANTES de la rama de bloqueo humano: si detecta `dependency_block` no se
+// crea marker en `bloqueado-humano/`, se aplica label `blocked:dependencies`
+// y el brazoDesbloqueo (ya existente) destraba cuando todas las deps cierren.
+const reboteClassifier = require('./lib/rebote-classifier');
 // #2893 — Detección de dependencias del allowlist en pausa parcial
 const partialPauseDeps = require('./lib/partial-pause-deps');
 // #2801 — emit session:start/end por cada lanzamiento de agente Claude (LLM)
@@ -2648,6 +2654,81 @@ function brazoBarrido(config) {
           }));
           const esReboteDeInfra = motivosClasificados.length > 0
             && motivosClasificados.every(m => m.clasificacion === 'infra');
+
+          // #3167 — DEPENDENCY_BLOCK: ANTES de evaluar bloqueo humano, le damos al
+          // clasificador unificado la chance de capturar rebotes donde el agente
+          // dice "depende de #N todavía OPEN" o "asset UX no en main". Si calza,
+          // NO creamos marker en `bloqueado-humano/` y NO incrementamos rev:
+          // aplicamos label `blocked:dependencies` y dejamos que el brazoDesbloqueo
+          // (que ya existe — ~línea 7813) destrabe cuando todas las deps cierren
+          // en GitHub. Cero tokens consumidos mientras espera + cero intervención
+          // humana cuando las deps cierren. Defense-in-depth: TODO el resto del
+          // flujo de humanBlock queda intacto abajo (sigue siendo dueño cuando
+          // el motivo no clasifica como dep).
+          let depBlockHandled = false;
+          if (!esReboteDeInfra) {
+            for (const m of motivosClasificados) {
+              const result = reboteClassifier.classifyRebote({
+                motivo: m.motivo,
+                classifyErrorResult: m.clasificacion,
+                isRoutingMismatch: false, // routing se evalúa más abajo, mantener orden
+              });
+              if (result.category !== 'dependency_block') continue;
+
+              const skillDep = m.skill || skillFromFile(rechazados[0].file.name);
+              const motivoSanitized = sanitizePipelineText(m.motivo).slice(0, 1500);
+
+              try {
+                reboteClassifier.reportDependencyBlock({
+                  issue: parseInt(issue),
+                  dependsOn: result.dependsOn,
+                  reason: motivoSanitized,
+                  skill: skillDep,
+                  phase: fase,
+                });
+              } catch (e) {
+                log('barrido', `❌ #${issue} reportDependencyBlock falló: ${e.message}`);
+                // Fail-open: si reportDependencyBlock falla NO caemos a humanBlock
+                // — el motivo SÍ es dep, simplemente la cola GitHub no aceptó el
+                // marker. Mejor dejar el issue en pendiente/ para el próximo ciclo
+                // que crear un marker humano espurio. Rompemos el for sin set de
+                // depBlockHandled para que el flujo siga (rebote_numero, etc).
+                break;
+              }
+
+              // Mover archivos de la fase actual a archivado/ — el issue queda
+              // fuera del flujo activo hasta que el brazoDesbloqueo le quite el
+              // label. Mismo patrón que la rama humanBlock más abajo.
+              for (const a of archivos) {
+                const destArch = path.join(fasePath(pipelineName, fase), 'archivado');
+                try { fs.mkdirSync(destArch, { recursive: true }); moveFile(a.path, destArch); } catch {}
+              }
+              for (const estado of ['pendiente', 'trabajando']) {
+                const dir = path.join(fasePath(pipelineName, fase), estado);
+                try {
+                  for (const f of fs.readdirSync(dir)) {
+                    if (f.startsWith(issue + '.') && !f.startsWith('.')) {
+                      const archDir = path.join(fasePath(pipelineName, fase), 'archivado');
+                      fs.mkdirSync(archDir, { recursive: true });
+                      try { moveFile(path.join(dir, f), archDir); } catch {}
+                    }
+                  }
+                } catch {}
+              }
+
+              const depsLabel = result.dependsOn.length > 0
+                ? result.dependsOn.map(n => '#' + n).join(',')
+                : '(asset)';
+              log('barrido', `🪢 #${issue} → blocked:dependencies (skill=${skillDep}, deps=${depsLabel}) — sin rebote, sin marker humano, esperando brazoDesbloqueo.`);
+              try {
+                sendTelegram(`🪢 Issue #${issue} bloqueado por dependencias — esperando ${depsLabel}. El pipeline destraba automáticamente al cerrar.`);
+              } catch {}
+
+              depBlockHandled = true;
+              break;
+            }
+          }
+          if (depBlockHandled) continue;
 
           // #2549 — BLOQUEO HUMANO: si AL MENOS UN motivo indica que el avance
           // depende de una intervención humana (PR esperando merge, CODEOWNERS,
@@ -7975,7 +8056,7 @@ async function brazoDesbloqueoImpl(config) {
               log('desbloqueo', `Error cerrando paraguas #${issue.number}: ${e.message}`);
             }
           } else {
-            log('desbloqueo', `#${issue.number}: todas las dependencias cerradas (${depIssueNumbers.join(', ')}) → desbloqueando`);
+            log('desbloqueo', `🪢→🟢 #${issue.number} destrabado (deps cerradas: ${depIssueNumbers.map(n => '#' + n).join(',')})`);
 
             // Quitar label blocked:dependencies
             ghThrottle();
@@ -7985,18 +8066,18 @@ async function brazoDesbloqueoImpl(config) {
             );
 
             // Agregar comentario de desbloqueo
-            const unblockComment = `## ✅ Issue desbloqueado automáticamente\n\nTodas las dependencias fueron resueltas (${depIssueNumbers.map(n => '#' + n).join(', ')}). Este issue vuelve a la cola del pipeline para ser procesado.`;
+            const unblockComment = `## Dependencias resueltas 🟢\n\nLas siguientes dependencias cerraron: ${depIssueNumbers.map(n => '#' + n).join(', ')}.\n\nEl pipeline reentra a este issue automáticamente.`;
             ghThrottle();
             await ghDesbloqueoCall(
               ['issue', 'comment', String(issue.number), '--body', unblockComment, '--repo', 'intrale/platform'],
               10000
             );
 
-            sendTelegram(`🔓 Issue #${issue.number} desbloqueado — todas las dependencias resueltas (${depIssueNumbers.map(n => '#' + n).join(', ')}). Vuelve a la cola del pipeline.`);
+            sendTelegram(`🪢→🟢 #${issue.number} destrabado automáticamente (deps cerradas: ${depIssueNumbers.map(n => '#' + n).join(',')})`);
             log('desbloqueo', `#${issue.number} desbloqueado exitosamente`);
           }
         } else {
-          log('desbloqueo', `#${issue.number}: dependencias abiertas: ${openDeps.map(n => '#' + n).join(', ')} — sigue bloqueado`);
+          log('desbloqueo', `🪢⏳ #${issue.number} sigue esperando ${openDeps.map(n => '#' + n).join(',')}`);
         }
       } catch (e) {
         log('desbloqueo', `Error procesando #${issue.number}: ${e.message}`);

--- a/.pipeline/roles/guru.md
+++ b/.pipeline/roles/guru.md
@@ -31,6 +31,45 @@ Sos el investigador técnico del proyecto Intrale.
 - `resultado: aprobado` si es viable
 - `resultado: rechazado` si hay blockers insalvables (con alternativas sugeridas)
 
+## FORMATO DE REBOTES (issue #3167 — clasificador unificado)
+
+Si detectás que el issue **depende de otro issue todavía OPEN** o de un asset
+no mergeado a `main`, **NO escribas un motivo libre**. Usá la convención
+estructurada que el pipeline parsea automáticamente:
+
+```yaml
+resultado: rechazado
+rebote_categoria: dependency_block
+depende_de: [3083, 3084]
+motivo: |
+  Este issue (U1 multi-provider) necesita el audit trail unificado de
+  #3083 (S5) ya mergeado a `main` para registrar las llamadas dual-provider.
+  Hoy #3083 está OPEN y sin merge — no se puede integrar.
+```
+
+**Efecto en el pipeline:**
+
+- El Pulpo aplica label `blocked:dependencies` al issue automáticamente.
+- **NO** se crea marker en `bloqueado-humano/` (cero intervención humana).
+- **NO** se incrementa `rev` (no cuenta contra el circuit breaker).
+- El `brazoDesbloqueo` chequea cada ~5 min si todas las deps están CLOSED;
+  cuando lo están, quita el label y el issue reentra a la cola solo.
+
+**Cuándo aplicar:**
+- Dependencia explícita de otro issue por número (#NNNN).
+- Espera de merge de un PR sin acción humana adicional.
+- Asset/recurso (UX, mockup, design) todavía no mergeado a `main`.
+
+**Cuándo NO aplicar (es `human_block`, no `dependency_block`):**
+- Necesitás que un humano apruebe algo, ejecute un comando, o tome una decisión.
+- El issue depende de credenciales/permisos/aprobaciones administrativas.
+- Hay ambigüedad que requiere clarificación del PO/dueño.
+
+Si dudás entre las dos categorías, usá `human_block` (motivo libre estilo
+"esperando merge manual de PR #NNNN" — el detector lo capta). Es preferible
+fail-safe a fail-open: la diferencia operativa es que `dependency_block`
+destraba solo, `human_block` requiere que alguien actúe.
+
 ## Protocolo de oportunidades de mejora (aplicable en TODAS las fases)
 
 Durante tu análisis técnico (`analisis`, `validacion`), si identificás **deudas técnicas, refactors futuros, optimizaciones de performance, mejoras de arquitectura u oportunidades de investigación** que NO deben frenar la aprobación del issue actual pero vale la pena registrar como trabajo futuro, **NO las dejes sólo como texto en el comentario del issue origen**. Creá un issue independiente por cada una, **marcado como recomendación que requiere aprobación humana** (issue #2653 — el pipeline NO procesa recomendaciones hasta que un humano las apruebe):

--- a/docs/engineering/pipeline-rebote-classifier.md
+++ b/docs/engineering/pipeline-rebote-classifier.md
@@ -1,0 +1,285 @@
+# Sistema de clasificación de rebotes (rebote-classifier)
+
+> **Issue:** [#3167](https://github.com/intrale/platform/issues/3167) — Curita C, Opción A robusta.
+> **Módulo:** [`.pipeline/lib/rebote-classifier.js`](../../.pipeline/lib/rebote-classifier.js)
+> **Tests:** [`.pipeline/lib/__tests__/rebote-classifier.test.js`](../../.pipeline/lib/__tests__/rebote-classifier.test.js) (32 unit) + [`rebote-classifier.integration.test.js`](../../.pipeline/lib/__tests__/rebote-classifier.integration.test.js) (9 integration).
+
+## Por qué existe
+
+El **2026-05-12** el issue #3086 (multi-provider U1) cayó a `bloqueado-humano/`
+cuando en realidad esperaba que se mergeara la dependencia #3083 (S5 audit
+trail). El motivo de rechazo del Guru fue interpretado por `humanBlock` como
+"requiere intervención humana" cuando técnicamente era una espera mecánica:
+"#3083 está OPEN — no puedo integrar sin que mergee primero".
+
+Hasta este sprint, el Pulpo evaluaba rebotes con una cascada dispersa:
+
+1. `precheck.classifyError(motivo) → 'infra' | 'codigo'`
+2. `humanBlock.isHumanBlockReason(motivo) → boolean`
+3. `routing-classifier` (motivo, faseDestino) → mismatch sí/no
+
+`humanBlock` era el catch-all: cualquier motivo que sonara a "espera de algo"
+caía a `bloqueado-humano/` y requería a un operador (Leo, en el caso real)
+para hacer `gh issue edit -N --remove-label needs-human --add-label
+blocked:dependencies`. Cero automatización aunque la dependencia ya cerrara.
+
+El `rebote-classifier` introduce una clasificación declarativa, ordenada por
+especificidad, con cinco categorías canónicas y mecanismos de destrabe
+explícitos por cada una.
+
+## Las 5 categorías
+
+| Categoría | Cuándo aplica | Cuenta CB | Label aplicado | Destrabe |
+|---|---|---|---|---|
+| `cross_phase` | Routing mismatch: agente dice "esto es de otra fase" | No | — | Reroute automático a `definicion/analisis` |
+| `dependency_block` | Espera merge/cierre de otro issue (`#NNNN`) o asset no en `main` | No | `blocked:dependencies` | `brazoDesbloqueo` (5 min) cuando todas las deps están CLOSED |
+| `human_block` | Acción humana: merge manual, CODEOWNERS, decisión, credencial | No | `needs-human` | Humano remueve el label |
+| `infra` | Red/timeout/DNS — error externo recuperable | No | — | Reintento automático (con cap `MAX_REBOTES_INFRA`) |
+| `code` | Fallback técnico — bug del código del issue | **Sí** | — | Re-encola con `rebote_numero+1` hasta `MAX_REBOTES=3` |
+
+**Precedencia (más específica gana):**
+
+```
+cross_phase  >  dependency_block  >  human_block  >  infra  >  code
+```
+
+## Flujo end-to-end
+
+```
+agente claude (skill) emite rejection.yaml con `motivo`
+        │
+        ▼
+.pipeline/<pipe>/<fase>/listo/<N>.<skill>
+        │
+        ▼ (brazoBarrido — pulpo.js:2437)
+clasificación de cada motivo:
+  ├─ precheck.classifyError(motivo) → infra | codigo
+  └─ classifyRebote({motivo, classifyErrorResult, isRoutingMismatch})  ◄── #3167
+        │
+        ▼ result.category
+        │
+        ├── 'dependency_block'
+        │         │
+        │         ▼ (pulpo.js:~2660)
+        │   reportDependencyBlock({issue, dependsOn, reason, skill, phase})
+        │         │
+        │         ▼
+        │   .pipeline/servicios/github/pendiente/
+        │     ├── <N>-blocked-dependencies-block-<ts>.json   (action: 'label')
+        │     └── <N>-deps-comment-<ts>.json                  (action: 'comment')
+        │         │
+        │         ▼ (servicio-github.js polls cola)
+        │   gh issue edit <N> --add-label blocked:dependencies
+        │   gh issue comment <N> --body "## Dependencias detectadas por el pipeline ..."
+        │         │
+        │         ▼ (brazoDesbloqueo cada ~5 min — pulpo.js:7813)
+        │   for each issue con label blocked:dependencies:
+        │     parseDependencyComment(comments, issue)
+        │     for each dep in parsed:
+        │       gh issue view <dep> --json state
+        │     if all CLOSED:
+        │       gh issue edit <N> --remove-label blocked:dependencies
+        │       gh issue comment <N> --body "## Dependencias resueltas 🟢 ..."
+        │
+        ├── 'human_block'  → humanBlock.reportHumanBlock → bloqueado-humano/<N>.marker
+        ├── 'infra'        → re-encola con rebote_tipo=infra (no cuenta CB)
+        ├── 'cross_phase'  → mueve a definicion/analisis con rebote_tipo=routing
+        └── 'code'         → re-encola con rebote_numero+1 hasta MAX_REBOTES
+```
+
+## Convención estructurada para agentes (`rebote_categoria`)
+
+Los agentes Claude pueden **emitir un hint estructurado** en el motivo para
+saltarse el pattern matching y declarar directamente la categoría. Es el
+formato **preferido** cuando el agente tiene certeza:
+
+```yaml
+resultado: rechazado
+rebote_categoria: dependency_block
+depende_de: [3083, 3084]
+motivo: |
+  U1 multi-provider necesita el audit trail unificado de #3083 (S5) y
+  los flags de #3084 (H6) ya mergeados a `main` para poder integrar.
+```
+
+El classifier reconoce el hint en `STRUCTURED_DEPENDENCY_HINT` y `STRUCTURED_DEPS_LIST`
+y lo prioriza sobre la heurística de patrones de texto.
+
+**Skills que actualmente emiten el hint:**
+- `guru` — sección "FORMATO DE REBOTES" en [`.pipeline/roles/guru.md`](../../.pipeline/roles/guru.md)
+- Cualquier skill puede adoptarlo; sólo requiere agregar la nota al prompt.
+
+## Patrones de detección (heurística text-based)
+
+Cuando el agente NO emite el hint estructurado, el classifier intenta detectar
+`dependency_block` con regex acotadas. La lista vive en `DEPENDENCY_PATTERNS`
+(issues con `#N`) y `DEPENDENCY_ASSET_PATTERNS` (assets/recursos sin `#N`).
+
+### Cómo agregar un nuevo patrón
+
+1. Abrí `.pipeline/lib/rebote-classifier.js`, sección "PATRONES DEPENDENCY_BLOCK".
+2. Agregá la regex al array `DEPENDENCY_PATTERNS` **al final** (los patrones
+   más específicos primero — orden importa para minimizar falsos positivos).
+3. Criterios anti-ReDoS:
+   - Sin quantifiers anidados (`(a+)+`).
+   - Sin alternaciones que matcheen el mismo prefijo (`(foo|food)`).
+   - Quantifiers acotados (`{0,80}`, no `*` libre dentro de grupos opcionales).
+   - El número de issue **siempre** captura en `m[1]`.
+4. Agregá un test unitario en `rebote-classifier.test.js` con el motivo real
+   que la regex debe atrapar + un control negativo similar que NO debe matchear.
+5. Corré `node .pipeline/lib/__tests__/rebote-classifier.test.js` (32+1 OK).
+
+## Brazo de desbloqueo automático
+
+El loop ya existe pre-#3167 (`brazoDesbloqueo` en `pulpo.js:7813`, encadenado
+al ciclo principal del Pulpo en `pulpo.js:8430` con sus pares barrido,
+intake, huérfanos). Se hizo `async` en #2801 para no bloquear el event loop
+durante las llamadas a `gh`.
+
+### Ciclo de un tick del brazo
+
+1. **Guard de re-entry** (`_unblockRunning` con watchdog `UNBLOCK_WEDGE_TIMEOUT_MS`).
+2. **Respeta pausa parcial** (`partialPause.getPipelineMode()`): si modo `paused`
+   sale; si `partial_pause` filtra issues fuera del allowlist.
+3. `gh issue list --label "blocked:dependencies" --state open --json number,title,labels --limit 50`.
+4. Por cada issue bloqueado:
+   - `gh issue view <N> --json comments` → `parseDependencyComment(commentsArray, N)`.
+   - Si parser retorna `null` (no marker) → **fail-closed**, skip ciclo, NO toca labels.
+   - Si retorna `[]` (marker vacío) → registra sin deps en mapa.
+   - Si retorna `[deps...]` → consulta `gh issue view <dep> --json state` para
+     cada una; si todas son `CLOSED` → desbloquea.
+5. **Desbloqueo:**
+   - `gh issue edit <N> --remove-label blocked:dependencies`
+   - `gh issue comment <N> --body "## Dependencias resueltas 🟢 ..."`
+   - Telegram: `🪢→🟢 #<N> destrabado automáticamente (deps cerradas: #X,#Y)`
+6. **Auto-cierre del paraguas** (label `split`): si el issue era un paraguas
+   `split` con todas las hijas cerradas, el brazo lo cierra con `gh issue
+   close --reason completed`.
+
+### Intervalo y configuración
+
+- Intervalo del loop principal del Pulpo: configurable en `.pipeline/config.yaml`
+  → `pulpo.tick_interval_ms`. Default: 30 segundos.
+- Intervalo específico del barrido de desbloqueo: `UNBLOCK_INTERVAL_MS`.
+  Default: 5 minutos (cada N ticks, no en cada uno, para no exceder el rate
+  limit de `gh`).
+
+### Idempotencia
+
+- El servicio-github es deduper-aware: si encola dos `label` con la misma
+  combinación issue+label, sólo aplica uno.
+- Si una segunda invocación del brazoBarrido detecta el mismo `dependency_block`
+  ANTES de que el servicio-github procese la cola, ambos archivos se encolan
+  con timestamps distintos pero el resultado es idempotente: GitHub no duplica
+  labels y el comment dedup se hace por la regla del propio servicio.
+
+## Cómo intervenir manualmente
+
+| Necesidad | Comando |
+|---|---|
+| Forzar destrabe de un issue | `gh issue edit <N> --remove-label blocked:dependencies` (el pipeline reentra en próximo intake) |
+| Forzar bloqueo humano (override) | `gh issue edit <N> --add-label needs-human` (precedencia sobre `blocked:dependencies` porque el intake del Pulpo excluye `needs-human`) |
+| Mover entre categorías | Solo cambiar labels — el pipeline se acomoda en el próximo ciclo |
+| Inspeccionar deps detectadas | `cat .pipeline/blocked-issues.json` |
+| Forzar reparseo (después de cambiar el marker) | Eliminar `.pipeline/blocked-issues.json` — el brazo reconstruye en el próximo ciclo |
+
+## Cómo extender el sistema
+
+### Nueva categoría (ej: `quota_block`)
+
+1. Agregar el ramo al switch de `classifyRebote` en `rebote-classifier.js`,
+   respetando la precedencia (más específica primero).
+2. Definir el side effect:
+   - ¿Aplica label? Agregar la constante (`QUOTA_LABEL`).
+   - ¿Tiene autounlock? Definir mecanismo (`source`, `label`, `note`).
+   - ¿Cuenta para el circuit breaker?
+3. Agregar la rama en `pulpo.js:brazoBarrido` (similar al bloque
+   `if (depBlockHandled) continue;` que introdujo #3167).
+4. Si requiere un nuevo loop, modelarlo sobre `brazoDesbloqueo` (re-entry
+   guard, watchdog, async-no-blocking).
+5. Actualizar `agents/*.md` para que los agentes puedan emitir el hint
+   `rebote_categoria: quota_block`.
+6. Tests: unit + integration.
+
+### Nuevo patrón (en una categoría existente)
+
+Ver sección "Cómo agregar un nuevo patrón" arriba.
+
+### Cambiar el intervalo del brazo
+
+Editar `UNBLOCK_INTERVAL_MS` en `pulpo.js` (o exponer en `config.yaml` clave
+`desbloqueo.interval_min` — opción de mejora pendiente).
+
+## Troubleshooting
+
+### "#N tiene label `blocked:dependencies` pero no se destraba"
+
+1. `gh issue view <N> --json comments | jq '.comments[].body' | grep "Dependencias detectadas"` —
+   si no aparece, el marker se perdió. Re-encolar manualmente o quitar el label.
+2. `grep "🪢" .pipeline/logs/pulpo.log | tail -20` — el log del brazo de
+   desbloqueo. Buscar errores de `gh-call-timeout` o `respuesta no parseable`.
+3. `cat .pipeline/blocked-issues.json` — mapa actual del brazo. Si el issue
+   NO está en `blockedBy`, el parser no encontró marker (fail-closed).
+4. `cat .pipeline/logs/desbloqueo.log` (si configurado) — historial reciente.
+
+### "Un agente cayó a `bloqueado-humano/` cuando era una dep"
+
+1. Leer el `reason.json` del marker: `.pipeline/<pipe>/<fase>/bloqueado-humano/<N>.reason.json`.
+2. Identificar el patrón del motivo que NO matcheó. Posibles causas:
+   - Formato nuevo no cubierto por `DEPENDENCY_PATTERNS`.
+   - El agente usó otro idioma o frase ("blocked by ... not merged").
+3. Agregar el patrón siguiendo la sección "Cómo agregar un nuevo patrón".
+4. Escribir test con el motivo real del incidente.
+5. Workaround inmediato: `gh issue edit <N> --remove-label needs-human --add-label blocked:dependencies`
+   y agregar el comment con el formato esperado.
+
+### "Brazo de desbloqueo nunca corre"
+
+1. `grep "brazoDesbloqueo\|desbloqueo" .pipeline/logs/pulpo.log | tail -5` —
+   si NUNCA hay log, el loop no está spawneado.
+2. Verificar línea ~8430 de `pulpo.js`: `brazoDesbloqueo(config).catch(...)` debe
+   estar dentro del setInterval del ciclo principal.
+3. Verificar que el guard `_unblockRunning` no esté wedged (watchdog
+   `_checkAndResetUnblockWedge` lo desbloquea solo cada `UNBLOCK_WEDGE_TIMEOUT_MS`).
+
+### "Demasiados falsos positivos `dependency_block`"
+
+1. Identificar los motivos que matchean por error.
+2. Acotar el patrón problemático (más específico) en `DEPENDENCY_PATTERNS`.
+3. Agregar test negativo: motivo similar que NO debe matchear.
+
+## Tests
+
+| Tipo | Comando | Cobertura |
+|---|---|---|
+| Unit | `node .pipeline/lib/__tests__/rebote-classifier.test.js` | 32 tests — CA-1..CA-10 + SMOKE #3086 |
+| Integration | `node .pipeline/lib/__tests__/rebote-classifier.integration.test.js` | 9 tests — flujo end-to-end con cola GitHub real |
+| Parser | `node .pipeline/lib/__tests__/dep-comment-parser.test.js` | 31 tests — incluye `parseDependenciesFromComment` |
+
+Smoke con motivo real del incidente #3086: incluido en unit tests
+(`SMOKE #3086: motivo realístico del guru → dependency_block con #3083`).
+
+## Archivos clave
+
+| Archivo | Responsabilidad |
+|---|---|
+| [`.pipeline/lib/rebote-classifier.js`](../../.pipeline/lib/rebote-classifier.js) | Núcleo: `classifyRebote`, `detectDependencyBlock`, `buildDependencyComment`, `reportDependencyBlock`, `sanitizeDepsList` |
+| [`.pipeline/lib/dep-comment-parser.js`](../../.pipeline/lib/dep-comment-parser.js) | Parser del marker GitHub (lectura). Expone `parseDependencyComment` (null = fail-closed) y `parseDependenciesFromComment` (siempre `[]` mínimo) |
+| [`.pipeline/lib/human-block.js`](../../.pipeline/lib/human-block.js) | Detección legacy + marker para `bloqueado-humano/`. Se mantiene como segunda red de defensa |
+| [`.pipeline/lib/routing-classifier.js`](../../.pipeline/lib/routing-classifier.js) | Detección de cross_phase. Lo invoca el caller (pulpo.js) antes de `classifyRebote` |
+| [`.pipeline/pulpo.js`](../../.pipeline/pulpo.js) (líneas ~2655–2750) | Wire-up: invoca `classifyRebote` antes de evaluar humanBlock |
+| [`.pipeline/pulpo.js`](../../.pipeline/pulpo.js) (líneas 7813–8015) | `brazoDesbloqueo` — loop que destraba issues con `blocked:dependencies` cuando todas las deps cierran |
+| [`.pipeline/roles/guru.md`](../../.pipeline/roles/guru.md) | Prompt del agente que más emite hints `dependency_block`. Sección "FORMATO DE REBOTES" |
+
+## Glosario
+
+- **CB** (Circuit Breaker): contador `rebote_numero` con cap `MAX_REBOTES=3`. Si
+  un issue alcanza el cap, queda fuera de la cola hasta intervención manual.
+- **Marker GitHub**: el comment con heading exacto `## Dependencias detectadas
+  por el pipeline` seguido de bullets `- #N`. Es la fuente de verdad para el
+  brazo de desbloqueo.
+- **Hint estructurado**: el bloque `rebote_categoria: ... + depende_de: [...]`
+  en el motivo crudo del agente. Atajo al pattern matching.
+- **Fail-closed**: si no se puede confirmar que las deps están realmente
+  cerradas, NO destrabar. Mejor pedir intervención manual que mover el issue
+  con deps reales todavía abiertas.


### PR DESCRIPTION
## Resumen

Curita C — fix raíz del bug arquitectónico que llevó a #3086 a `bloqueado-humano` cuando en realidad era espera de dependencia (#3083 OPEN + assets UX).

Reemplaza la heurística binaria `isHumanBlockReason()` por **5 categorías declarativas** con política propia, agrega **auto-destrabe periódico** y deja al guru capaz de emitir hints estructurados (`rebote_categoria + depende_de`) sin parsing de texto libre.

## Cambios

- **`.pipeline/lib/rebote-classifier.js` (nuevo · 434 líneas)** — `classifyRebote()` con 5 categorías ordenadas por especificidad:
  | Categoría | Cuenta rebote | Label GitHub | Auto-destrabe |
  |---|---|---|---|
  | cross_phase | propio | (ninguno) | rebote a destino |
  | **dependency_block 🆕** | **no** | **blocked:dependencies** | **watcher Pulpo** |
  | human_block | no | needs-human | manual operador |
  | infra | no | (ninguno) | reintenta solo |
  | code | sí | (ninguno) | rebota a fase rechazo |
- **`.pipeline/lib/dep-comment-parser.js`** — `parseDependenciesFromComment()` para round-trip con `buildDependencyComment()`.
- **`.pipeline/pulpo.js` (+89 líneas)** — interceptor en `barridoBloqueos` (líneas 2671-2722) ANTES de `humanBlock` (queda como defense-in-depth). Bucle `desbloqueo` con guard `_unblockRunning`, filtro `partial_pause`, intervalo configurable.
- **`.pipeline/roles/guru.md` (+39 líneas)** — sección de hints estructurados `dependency_block`.
- **`docs/engineering/pipeline-rebote-classifier.md` (nuevo · 285 líneas)** — tabla 5 categorías, flujo end-to-end, mapeo a #3086, runbook intervención manual, referencia cruzada al test SMOKE.

## Comité (review interno cruzado)

| Rol | Resultado |
|---|---|
| **PO** | ✅ resuelve incidente real reciente (#3086); riesgo: prompt guru actualizado pero migración orgánica |
| **QA** | ✅ 32 unit + 9 integración (41/41) + smoke test idéntico al motivo del incidente; observabilidad por evento `dependency:blocked` |
| **Tester** | ✅ casos CA-1..CA-10 cubiertos + sanitización dedup/cap + round-trip parser; fallback `code` cubre motivo vacío/undefined |
| **Dev** | ✅ desacoplado por módulo; humanBlock intacto como defense-in-depth; bucle desbloqueo con watchdog reentrante |

## Test plan

- [x] `node .pipeline/lib/__tests__/rebote-classifier.test.js` → 32/32 ✅
- [x] `node .pipeline/lib/__tests__/rebote-classifier.integration.test.js` → 9/9 ✅
- [x] SMOKE `#3086 motivo guru → dependency_block con #3083` ✅
- [x] Fallback: motivo vacío/undefined → `code` (no rompe) ✅
- [x] humanBlock intacto: motivos clásicos siguen clasificando `human_block` ✅
- [ ] Validación operativa post-merge: primer `dependency_block` real en producción genera label + comment + auto-destrabe al cerrar dep

## Etiquetas

`tipo:infra` `qa:skipped` `priority:high` `size:medium` `area:pipeline` (set en el issue #3167).

Closes #3167

🤖 Generated with [Claude Code](https://claude.com/claude-code)