### PR TITLE
feat(pipeline): hidratar OPENAI_API_KEY desde JSON único al boot del pulpo [H3 multi-provider]

### DIFF
--- a/.pipeline/lib/__tests__/hydrate-provider-env.test.js
+++ b/.pipeline/lib/__tests__/hydrate-provider-env.test.js
@@ -1,0 +1,133 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { test } = require('node:test');
+
+const { hydrateProviderEnv, ENV_MAPPING } = require('../hydrate-provider-env');
+
+// Loader factory: replica el contrato de loadApiKeys (precedencia env > JSON,
+// ignora placeholders). En los tests reemplaza loadApiKeys real para que NO
+// dependan del ~/.claude/secrets/telegram-config.json del usuario corriendo CI.
+function fakeLoaderFor(jsonBody) {
+    return () => ({
+        openai_api_key: pick(process.env.OPENAI_API_KEY) || pick(jsonBody.openai_api_key),
+        anthropic_api_key: pick(process.env.ANTHROPIC_API_KEY) || pick(jsonBody.anthropic_api_key),
+        elevenlabs_api_key: pick(process.env.ELEVENLABS_API_KEY) || pick(jsonBody.elevenlabs_api_key),
+        elevenlabs_voice_id: pick(process.env.ELEVENLABS_VOICE_ID) || pick(jsonBody.elevenlabs_voice_id),
+    });
+}
+
+function pick(v) {
+    if (typeof v !== 'string' || !v.trim()) return '';
+    if (/(REVOKED|PLACEHOLDER|MOVED|EXAMPLE|REPLACE|CHANGE_ME)/i.test(v)) return '';
+    return v;
+}
+
+const ALL_VARS = Object.values(ENV_MAPPING);
+
+function withCleanEnv(fn) {
+    const snapshot = {};
+    for (const v of ALL_VARS) {
+        snapshot[v] = process.env[v];
+        delete process.env[v];
+    }
+    try { return fn(); }
+    finally {
+        for (const v of ALL_VARS) {
+            if (snapshot[v] === undefined) delete process.env[v];
+            else process.env[v] = snapshot[v];
+        }
+    }
+}
+
+test('hidrata OPENAI_API_KEY desde el JSON cuando no estaba en env', () => {
+    withCleanEnv(() => {
+        const result = hydrateProviderEnv({
+            loadKeysFn: fakeLoaderFor({ openai_api_key: 'sk-proj-test-123' }),
+        });
+        assert.equal(process.env.OPENAI_API_KEY, 'sk-proj-test-123');
+        assert.deepEqual(result.hydrated, ['OPENAI_API_KEY']);
+    });
+});
+
+test('no sobreescribe si la env var ya estaba seteada', () => {
+    withCleanEnv(() => {
+        process.env.OPENAI_API_KEY = 'sk-existing';
+        const result = hydrateProviderEnv({
+            loadKeysFn: fakeLoaderFor({ openai_api_key: 'sk-proj-test-overwrite' }),
+        });
+        assert.equal(process.env.OPENAI_API_KEY, 'sk-existing');
+        assert.deepEqual(result.alreadySet, ['OPENAI_API_KEY']);
+        assert.equal(result.hydrated.length, 0);
+    });
+});
+
+test('reporta como missing cuando ni env ni JSON traen la key', () => {
+    withCleanEnv(() => {
+        const result = hydrateProviderEnv({ loadKeysFn: fakeLoaderFor({}) });
+        assert.ok(result.missing.includes('OPENAI_API_KEY'));
+        assert.equal(process.env.OPENAI_API_KEY, undefined);
+    });
+});
+
+test('hidrata también ELEVENLABS_API_KEY y ELEVENLABS_VOICE_ID', () => {
+    withCleanEnv(() => {
+        const result = hydrateProviderEnv({
+            loadKeysFn: fakeLoaderFor({
+                elevenlabs_api_key: 'eleven-key',
+                elevenlabs_voice_id: 'voice-id-abc',
+            }),
+        });
+        assert.equal(process.env.ELEVENLABS_API_KEY, 'eleven-key');
+        assert.equal(process.env.ELEVENLABS_VOICE_ID, 'voice-id-abc');
+        assert.ok(result.hydrated.includes('ELEVENLABS_API_KEY'));
+        assert.ok(result.hydrated.includes('ELEVENLABS_VOICE_ID'));
+    });
+});
+
+test('es idempotente — segunda llamada no rehidrata ni rompe', () => {
+    withCleanEnv(() => {
+        const loader = fakeLoaderFor({ openai_api_key: 'sk-idempotent' });
+        const r1 = hydrateProviderEnv({ loadKeysFn: loader });
+        const r2 = hydrateProviderEnv({ loadKeysFn: loader });
+        assert.deepEqual(r1.hydrated, ['OPENAI_API_KEY']);
+        assert.deepEqual(r2.hydrated, []);
+        assert.deepEqual(r2.alreadySet, ['OPENAI_API_KEY']);
+        assert.equal(process.env.OPENAI_API_KEY, 'sk-idempotent');
+    });
+});
+
+test('placeholders del JSON se ignoran (no se hidrata con valor sucio)', () => {
+    withCleanEnv(() => {
+        const result = hydrateProviderEnv({
+            loadKeysFn: fakeLoaderFor({ openai_api_key: 'REVOKED_PLACEHOLDER' }),
+        });
+        assert.ok(result.missing.includes('OPENAI_API_KEY'));
+        assert.equal(process.env.OPENAI_API_KEY, undefined);
+    });
+});
+
+test('logger recibe líneas legibles para auditoría', () => {
+    withCleanEnv(() => {
+        const lines = [];
+        hydrateProviderEnv({
+            loadKeysFn: fakeLoaderFor({ openai_api_key: 'sk-log-check' }),
+            log: (m) => lines.push(m),
+        });
+        assert.ok(lines.some((l) => /hidratadas desde JSON.*OPENAI_API_KEY/.test(l)));
+    });
+});
+
+test('no loguea el valor crudo de la key (sólo el nombre del env var)', () => {
+    withCleanEnv(() => {
+        const lines = [];
+        const secret = 'sk-proj-SHOULDNOTLEAK-abcdef123';
+        hydrateProviderEnv({
+            loadKeysFn: fakeLoaderFor({ openai_api_key: secret }),
+            log: (m) => lines.push(m),
+        });
+        for (const line of lines) {
+            assert.equal(line.includes(secret), false, `Línea filtra el secret: ${line}`);
+        }
+    });
+});

--- a/.pipeline/lib/hydrate-provider-env.js
+++ b/.pipeline/lib/hydrate-provider-env.js
@@ -1,0 +1,73 @@
+// =============================================================================
+// hydrate-provider-env.js — Hidrata `process.env` con las API keys de proveedores
+// LLM/TTS guardadas en `~/.claude/secrets/telegram-config.json`.
+//
+// CONTEXTO (#3075 multi-provider H3 — desbloqueo openai-codex)
+// -----------------------------------------------------------------------------
+// El pulpo lee `telegram-config.json` para TTS (OpenAI) y Whisper local. La key
+// `openai_api_key` ya vive ahí. El dispatcher `build-child-env.js` filtra el env
+// del padre con allowlist mínima — para que el child de `openai-codex` reciba
+// `OPENAI_API_KEY`, el **padre** (pulpo) tiene que tenerla en `process.env`.
+//
+// Antes de esta hidratación, el operador tenía que setear `OPENAI_API_KEY` como
+// env var del SO (User/Machine), creando una segunda fuente de verdad. Rotar la
+// key requería cambiarla en dos lados. Ahora la fuente única es el JSON.
+//
+// REGLA DE PRECEDENCIA
+// -----------------------------------------------------------------------------
+// 1. Si el env var ya existe en `process.env` (ej. seteado por el operador o por
+//    un test), NO se sobreescribe — el llamador manda.
+// 2. Si está vacío y el JSON tiene la key correspondiente, se hidrata.
+// 3. Si ni env ni JSON la traen, se loguea WARN y se sigue (degradación grácil).
+//
+// Esta función es idempotente: ejecutarla varias veces no cambia el resultado
+// salvo que el JSON cambie y reiniciemos el pulpo.
+// =============================================================================
+
+'use strict';
+
+const { loadApiKeys } = require('./telegram-secrets');
+
+// Mapeo: campo del JSON → env var que esperan los CLIs externos.
+// `anthropic_api_key` queda fuera del default a propósito: Claude Code ya tiene
+// auth propia vía OAuth/MAX login, sobre-hidratar puede confundirlo. El operador
+// puede pasarla explícitamente si la necesita seteando la env var del SO.
+const ENV_MAPPING = Object.freeze({
+    openai_api_key: 'OPENAI_API_KEY',
+    elevenlabs_api_key: 'ELEVENLABS_API_KEY',
+    elevenlabs_voice_id: 'ELEVENLABS_VOICE_ID',
+});
+
+function hydrateProviderEnv({ legacyConfigPath, log, loadKeysFn } = {}) {
+    const logger = typeof log === 'function' ? log : () => {};
+    const loader = typeof loadKeysFn === 'function' ? loadKeysFn : loadApiKeys;
+    const keys = loader({ legacyConfigPath });
+
+    const hydrated = [];
+    const alreadySet = [];
+    const missing = [];
+
+    for (const [jsonField, envVar] of Object.entries(ENV_MAPPING)) {
+        const fromJson = keys[jsonField];
+        const fromEnv = process.env[envVar];
+
+        if (fromEnv && fromEnv.trim()) {
+            alreadySet.push(envVar);
+            continue;
+        }
+        if (fromJson && fromJson.trim()) {
+            process.env[envVar] = fromJson;
+            hydrated.push(envVar);
+            continue;
+        }
+        missing.push(envVar);
+    }
+
+    if (hydrated.length) logger(`[pulpo] env hydration: hidratadas desde JSON → ${hydrated.join(', ')}`);
+    if (alreadySet.length) logger(`[pulpo] env hydration: ya estaban en env (no se tocaron) → ${alreadySet.join(', ')}`);
+    if (missing.length) logger(`[pulpo] env hydration: faltantes (no hay valor en env ni JSON) → ${missing.join(', ')}`);
+
+    return { hydrated, alreadySet, missing };
+}
+
+module.exports = { hydrateProviderEnv, ENV_MAPPING };

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -110,6 +110,22 @@ require('./lib/java-home-normalizer').normalizeJavaHome({
   },
 });
 
+// #3075 — Hidratación de API keys de providers desde el JSON único de secretos.
+// El dispatcher de child procesos (`lib/build-child-env.js`) filtra `process.env`
+// con allowlist mínima: para que el child de `openai-codex` reciba
+// `OPENAI_API_KEY`, el padre tiene que tenerla en `process.env`. La fuente única
+// de verdad es `~/.claude/secrets/telegram-config.json` (la misma key que ya usan
+// TTS/Whisper vía `multimedia.js`). Mantener una sola fuente evita divergencias
+// al rotar la key. Idempotente y no sobreescribe si el operador setea la var
+// explícitamente en el SO.
+require('./lib/hydrate-provider-env').hydrateProviderEnv({
+  legacyConfigPath: path.join(__dirname, '..', '.claude', 'hooks', 'telegram-config.json'),
+  log: (msg) => {
+    try { fs.appendFileSync(path.join(__dirname, 'logs', 'pulpo.log'), `[${new Date().toISOString()}] ${msg}\n`); } catch {}
+    console.error(msg);
+  },
+});
+
 // #2337 CA10: cleanup perezoso + startup de metricas UX (REQ-SEC-5)
 try { uxMetrics.cleanup({ force: true }); } catch { /* best-effort */ }
 


### PR DESCRIPTION
## Resumen

Desbloquea **#3075** moviendo la inyección de `OPENAI_API_KEY` al **único punto** que ya leen los servicios multimedia: `~/.claude/secrets/telegram-config.json`.

Antes: el operador tenía que setear `OPENAI_API_KEY` como env var del SO (User/Machine) para que el child de `openai-codex` la recibiera. Dos fuentes de verdad (JSON + Windows env). Rotar la key requería tocar dos lugares.

Después: una sola fuente. El pulpo lee el JSON al boot e hidrata `process.env`. El dispatcher `build-child-env` ya estaba listo para propagarla al child (#3074 wired el mapeo `'openai-codex' → 'OPENAI_API_KEY'`).

## Cambios

| Archivo | Tipo | Resumen |
|---|---|---|
| `.pipeline/lib/hydrate-provider-env.js` | nuevo (73 líneas) | `hydrateProviderEnv()` con precedencia env > JSON > missing, idempotente, ignora placeholders, no filtra valores crudos |
| `.pipeline/lib/__tests__/hydrate-provider-env.test.js` | nuevo (133 líneas) | 8 tests unit cubriendo: hidratación happy-path, no sobreescribir env existente, placeholders, ELEVENLABS opcional, idempotencia, logger sin leak de secret |
| `.pipeline/pulpo.js` | mod (+16 líneas) | Wire-up post `normalizeJavaHome`, antes del crash handler |

## Invariantes preservadas

- **I-S2** (build-child-env auditable, sin valores crudos): el logger del módulo nuevo loguea solo nombres de env vars (`OPENAI_API_KEY`), nunca el valor. Test dedicado verifica esto.
- **#3072/3081 agent-models schema**: no se toca `agent-models.json`. El dispatcher #3074 sigue mapeando `'openai-codex' → 'OPENAI_API_KEY'` igual.
- **Precedencia**: si el operador setea la env var del SO explícitamente, ese valor gana (override del JSON). Útil para tests/CI.

## Tests

- Suite nueva: **8/8** ✅
- `build-child-env.test.js` regresión: **34/34** ✅ (total combinado 42/42 en 140ms)

## Smoke local

```
[pulpo] env hydration: hidratadas desde JSON → OPENAI_API_KEY
[pulpo] env hydration: faltantes (no hay valor en env ni JSON) → ELEVENLABS_API_KEY, ELEVENLABS_VOICE_ID
OPENAI_API_KEY set: true len: 164
```

## Test plan

- [x] `node --test .pipeline/lib/__tests__/hydrate-provider-env.test.js` → 8/8
- [x] `node --check .pipeline/pulpo.js` → sintaxis OK
- [x] Smoke local: `OPENAI_API_KEY` hidratada con la key real del JSON (sk-proj, 164 chars)
- [ ] Post-merge: restart pipeline + verificar línea `[pulpo] env hydration` en `pulpo.log`
- [ ] Post-merge: quitar label `needs-human` de #3075 con comentario explicativo

Closes #3075