### PR TITLE
fix(pipeline): incluir area:pipeline y tipo:infra en ROUTING_LABELS (#3076)

### DIFF
--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -4108,7 +4108,7 @@ function brazoLanzamiento(config) {
 
 const APP_LABELS = ['app:client', 'app:business', 'app:delivery'];
 const LABEL_TO_FLAVOR = { 'app:client': 'client', 'app:business': 'business', 'app:delivery': 'delivery' };
-const ROUTING_LABELS = [...APP_LABELS, 'area:backend', 'area:infra', 'docs'];
+const ROUTING_LABELS = [...APP_LABELS, 'area:backend', 'area:infra', 'area:pipeline', 'tipo:infra', 'docs'];
 
 // Keywords para auto-clasificación inteligente de issues sin labels de ruteo
 const AUTO_CLASSIFY_RULES = [


### PR DESCRIPTION
## Summary

Una sola linea de cambio. Sumar `area:pipeline` y `tipo:infra` a `ROUTING_LABELS` del pulpo para que issues de infra/pipeline puros no caigan en el auto-clasificador.

## Causa raiz

Cadena reproducida en `#3076` (6 rebotes APK + 2 circuit breakers en una tarde):

1. Preflight ve labels `tipo:infra, area:pipeline` → ninguna esta en `ROUTING_LABELS`
2. `hasRoutingLabel = false` → llama `autoClassifyIssue(issue)`
3. Auto-clasificador matchea keywords del body (`lista`, `form`, `ui`...) → asigna `app:client`
4. Preflight ve `app:client` → `qaMode = 'android'` → exige `3076-composeApp-client-debug.apk`
5. Smart-build ve diff `area:pipeline` → no genera APK → APK faltante → rebote → circuit breaker

## Solucion

`pulpo.js:4111` antes:
```javascript
const ROUTING_LABELS = [...APP_LABELS, 'area:backend', 'area:infra', 'docs'];
```

Despues:
```javascript
const ROUTING_LABELS = [...APP_LABELS, 'area:backend', 'area:infra', 'area:pipeline', 'tipo:infra', 'docs'];
```

`appLabels` queda vacio → `requiresEmulator = false` → `qaMode = 'structural'` → no exige APK.

## Test plan

- [ ] Verificar que #3076 al re-encolarse no cae en `autoClassifyIssue`
- [ ] Verificar que no se asigna `app:client` zombi
- [ ] Verificar que el preflight rutea a `qaMode = 'structural'`
- [ ] Verificar que ningun issue con `area:backend` (que ya estaba en la lista) cambia comportamiento

Closes #3076

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>