### PR TITLE
fix(pipeline): pre-validar deps CLOSED antes de pegar blocked:dependencies (#3079)

### DIFF
--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -2694,6 +2694,37 @@ function brazoBarrido(config) {
               const skillDep = m.skill || skillFromFile(rechazados[0].file.name);
               const motivoSanitized = sanitizePipelineText(m.motivo).slice(0, 1500);
 
+              // #3079 — Pre-validar deps en GitHub: si todas las dependencias
+              // numéricas que el clasificador identificó ya están CLOSED, NO
+              // pegar `blocked:dependencies` y NO archivar. El agente trabajó
+              // sobre estado stale (worktree viejo o cache de contexto) y el
+              // bloqueo nacería zombi — el brazoDesbloqueo después lo destrabaría
+              // pero entre medio el issue queda pegado al label, el reconciler
+              // lo escalaría con marker fantasma, y el operador ve "needs-human"
+              // sobre una dep ya resuelta. Fail-open: si NO hay deps numéricas
+              // (assets puros) o el state es UNKNOWN, comportamiento previo.
+              if (Array.isArray(result.dependsOn) && result.dependsOn.length > 0) {
+                let todasCerradas = true;
+                const stateLog = [];
+                for (const depNum of result.dependsOn) {
+                  // Invalidar cache antes de chequear: el dep pudo haber cerrado
+                  // hace minutos y el cache de 10min nos daría un estado stale.
+                  issueLabelsCache.delete(depNum);
+                  const info = getIssueInfo(depNum);
+                  stateLog.push(`#${depNum}=${info.state}`);
+                  if (info.state !== 'CLOSED') {
+                    todasCerradas = false;
+                    break;
+                  }
+                }
+                if (todasCerradas) {
+                  log('barrido', `🪢⏭ #${issue} dependency_block IGNORADO — todas las deps ya CLOSED (${stateLog.join(',')}). No se pega label, no se archiva. El motivo era stale.`);
+                  // No archivar, no pegar label. El issue cae al flujo normal
+                  // de rebote (humanBlock → rev++) que lo destraba o lo escala.
+                  continue;
+                }
+              }
+
               try {
                 reboteClassifier.reportDependencyBlock({
                   issue: parseInt(issue),


### PR DESCRIPTION
## Resumen

Agentes con contexto stale generaban rebotes tipo \"depende de #X\" cuando #X ya estaba CLOSED. El pulpo aplicaba label \`blocked:dependencies\` sin verificar primero el estado real en GitHub, creando bloqueos zombi.

Incidente observado hoy (2026-05-13):
- 17:05 — Cleanup manual de labels zombi en #3079, #3082, #3086
- 17:10–17:16 — Los labels reaparecieron porque agentes corriendo con contexto stale (cargado antes del merge de #3072/#3074/#3075) emitían rebotes \"depende de #X\" y el pulpo los aplicaba sin chequear estado real

## Causa raíz

En \`pulpo.js:2685+\` (rama \`dependency_block\` del barrido), la cadena era:

\`\`\`
agente rebota → classifyRebote() → dependency_block + dependsOn=[X]
              → reportDependencyBlock() → encola label blocked:dependencies
              → archiva archivos → espera brazoDesbloqueo
\`\`\`

El \`brazoDesbloqueo\` corre cada 10 min y SÍ quita el label cuando las deps cierran — pero entre medio el issue queda con label zombi, el reconciler escala con marker fantasma, y el operador ve falsos bloqueos.

## Fix

Una sola línea de gate antes de \`reportDependencyBlock\` en \`pulpo.js\`:

\`\`\`javascript
if (Array.isArray(result.dependsOn) && result.dependsOn.length > 0) {
  let todasCerradas = true;
  for (const depNum of result.dependsOn) {
    issueLabelsCache.delete(depNum);  // forzar fetch fresco
    const info = getIssueInfo(depNum);
    if (info.state !== 'CLOSED') { todasCerradas = false; break; }
  }
  if (todasCerradas) {
    log('barrido', '🪢⏭ ... dependency_block IGNORADO — todas las deps ya CLOSED. Motivo stale.');
    continue;  // cae al flujo normal de rebote (humanBlock → rev++)
  }
}
\`\`\`

**Propiedades:**
- ✅ Fail-open: si \`dependsOn\` está vacío (asset puro) o \`state=UNKNOWN\` (network error), comportamiento previo intacto.
- ✅ Invalidamos cache antes de chequear: el cache de 10min daría estado stale si el dep cerró hace minutos.
- ✅ Cero parches: el clasificador y \`reportDependencyBlock\` quedan iguales — toda la lógica del classifier sigue siendo unit-testable sin GH.
- ✅ Sin nuevo state ni configuración: solo aprovecha \`getIssueInfo()\` que ya existe.

## Limpieza paralela

Ya removí manualmente los labels zombi vigentes en #3079, #3082, #3086 con comentario explicativo enlazando este PR.

## Tests

- \`rebote-classifier.test.js\`: 32/32 pass (sin cambios — el classifier es puro)
- \`rebote-classifier.integration.test.js\`: 9/9 pass (sin cambios)
- \`node --check pulpo.js\`: OK

## Cómo se mergea

\`qa:skipped\` justificación: cambio puro de pipeline (rama \`barrido\` del pulpo), sin impacto en UI/backend ni producto del usuario.

Closes #3079

🤖 Generated with [Claude Code](https://claude.com/claude-code)