### PR TITLE
fix(pipeline): reconciler debe archivar marker bloqueado-humano cuando el guardian re-aprueba

### DIFF
--- a/.pipeline/lib/__tests__/servicio-reconciler.test.js
+++ b/.pipeline/lib/__tests__/servicio-reconciler.test.js
@@ -362,6 +362,318 @@ test('#2994 CA3 no toca markers cuyo label sí está en GitHub', () => {
 });
 
 // =============================================================================
+// #3186 — reconcileResolvedMarkers archiva markers cuando el guardian
+// re-aprueba (listo/ o procesado/ posterior) o aplica TTL como red de seguridad.
+// =============================================================================
+
+function ensurePhaseDirs(pipeline, phase) {
+    const phaseRoot = path.join(PIPELINE, pipeline, phase);
+    fs.mkdirSync(path.join(phaseRoot, 'bloqueado-humano'), { recursive: true });
+    fs.mkdirSync(path.join(phaseRoot, 'pendiente'), { recursive: true });
+    fs.mkdirSync(path.join(phaseRoot, 'listo'), { recursive: true });
+    fs.mkdirSync(path.join(phaseRoot, 'procesado'), { recursive: true });
+    fs.mkdirSync(path.join(phaseRoot, 'archivado'), { recursive: true });
+}
+
+function writeMarker(pipeline, phase, issue, skill, mtimeMs) {
+    const dir = path.join(PIPELINE, pipeline, phase, 'bloqueado-humano');
+    fs.mkdirSync(dir, { recursive: true });
+    const markerPath = path.join(dir, `${issue}.${skill}`);
+    fs.writeFileSync(markerPath, '');
+    fs.writeFileSync(markerPath + '.reason.json', JSON.stringify({
+        issue, skill, phase, pipeline,
+        blocked_at: new Date(mtimeMs || Date.now()).toISOString(),
+        blocked_by: skill,
+    }));
+    if (mtimeMs) {
+        const secs = mtimeMs / 1000;
+        fs.utimesSync(markerPath, secs, secs);
+    }
+    return markerPath;
+}
+
+function writeStateFile(pipeline, phase, state, issue, skill, mtimeMs) {
+    const dir = path.join(PIPELINE, pipeline, phase, state);
+    fs.mkdirSync(dir, { recursive: true });
+    const filePath = path.join(dir, `${issue}.${skill}`);
+    fs.writeFileSync(filePath, '');
+    if (mtimeMs) {
+        const secs = mtimeMs / 1000;
+        fs.utimesSync(filePath, secs, secs);
+    }
+    return filePath;
+}
+
+function clearStateDirs(pipeline, phase) {
+    const phaseRoot = path.join(PIPELINE, pipeline, phase);
+    for (const state of ['listo', 'procesado', 'archivado']) {
+        const dir = path.join(phaseRoot, state);
+        if (!fs.existsSync(dir)) continue;
+        for (const f of fs.readdirSync(dir)) {
+            try { fs.unlinkSync(path.join(dir, f)); } catch {}
+        }
+    }
+}
+
+test('#3186 reconcileResolvedMarkers archiva marker cuando guardian dropea listo/ posterior', () => {
+    clearAllMarkers();
+    clearGhQueue();
+    ensurePhaseDirs('definicion', 'analisis');
+    clearStateDirs('definicion', 'analisis');
+
+    // Marker viejo (5 min atrás)
+    const markerMtime = Date.now() - 5 * 60 * 1000;
+    writeMarker('definicion', 'analisis', 3082, 'guru', markerMtime);
+    // Guardian re-aprobó: listo/ con mtime POSTERIOR al marker
+    writeStateFile('definicion', 'analisis', 'listo', 3082, 'guru', Date.now() - 60 * 1000);
+
+    const markers = [{ issue: 3082, skill: 'guru', phase: 'analisis', pipeline: 'definicion' }];
+    const result = reconciler.reconcileResolvedMarkers(markers);
+
+    assert.equal(result.archived, 1);
+    assert.equal(result.archivedIssues.has(3082), true);
+    assert.equal(result.removeLabelsEnqueued, 1, 'sin otros markers → remove-label encolado');
+
+    // Marker movido a archivado/ con sufijo guardian-resolved
+    const archivedDir = path.join(PIPELINE, 'definicion', 'analisis', 'archivado');
+    const archivedFiles = fs.readdirSync(archivedDir).filter(f => f.startsWith('3082.guru.'));
+    assert.equal(archivedFiles.length, 1);
+    assert.match(archivedFiles[0], /^3082\.guru\.guardian-resolved-/);
+
+    // reason.json eliminado
+    const blockedDir = path.join(PIPELINE, 'definicion', 'analisis', 'bloqueado-humano');
+    assert.equal(fs.existsSync(path.join(blockedDir, '3082.guru.reason.json')), false);
+
+    // Orden remove-label encolada
+    const orders = fs.readdirSync(GH_QUEUE)
+        .filter(f => f.endsWith('.json'))
+        .map(f => JSON.parse(fs.readFileSync(path.join(GH_QUEUE, f), 'utf8')));
+    const removeOrders = orders.filter(o => o.action === 'remove-label');
+    assert.equal(removeOrders.length, 1);
+    assert.equal(removeOrders[0].issue, 3082);
+    assert.equal(removeOrders[0].label, 'needs-human');
+});
+
+test('#3186 reconcileResolvedMarkers también detecta resolución en procesado/ (no solo listo/)', () => {
+    clearAllMarkers();
+    clearGhQueue();
+    ensurePhaseDirs('definicion', 'analisis');
+    clearStateDirs('definicion', 'analisis');
+
+    const markerMtime = Date.now() - 5 * 60 * 1000;
+    writeMarker('definicion', 'analisis', 3083, 'guru', markerMtime);
+    // El pulpo movió listo/ → procesado/ al promover. Reconciler corre tarde.
+    writeStateFile('definicion', 'analisis', 'procesado', 3083, 'guru', Date.now() - 60 * 1000);
+
+    const markers = [{ issue: 3083, skill: 'guru', phase: 'analisis', pipeline: 'definicion' }];
+    const result = reconciler.reconcileResolvedMarkers(markers);
+
+    assert.equal(result.archived, 1, 'también archiva si la resolución está en procesado/');
+});
+
+test('#3186 reconcileResolvedMarkers NO archiva si listo/ no existe', () => {
+    clearAllMarkers();
+    clearGhQueue();
+    ensurePhaseDirs('definicion', 'analisis');
+    clearStateDirs('definicion', 'analisis');
+
+    writeMarker('definicion', 'analisis', 3084, 'guru', Date.now() - 5 * 60 * 1000);
+    // NO escribimos archivo en listo/ ni procesado/
+
+    const markers = [{ issue: 3084, skill: 'guru', phase: 'analisis', pipeline: 'definicion' }];
+    const result = reconciler.reconcileResolvedMarkers(markers, { ttlMs: 30 * 24 * 60 * 60 * 1000 });
+
+    assert.equal(result.archived, 0);
+    assert.equal(result.removeLabelsEnqueued, 0);
+    const blockedDir = path.join(PIPELINE, 'definicion', 'analisis', 'bloqueado-humano');
+    assert.equal(fs.existsSync(path.join(blockedDir, '3084.guru')), true, 'marker intacto');
+});
+
+test('#3186 reconcileResolvedMarkers NO archiva si listo/ existe pero mtime ANTERIOR al marker', () => {
+    clearAllMarkers();
+    clearGhQueue();
+    ensurePhaseDirs('definicion', 'analisis');
+    clearStateDirs('definicion', 'analisis');
+
+    // Caso: el guardian aprobó antes, después rechazó (marker más nuevo que listo/).
+    const oldListoMtime = Date.now() - 10 * 60 * 1000;
+    const newerMarkerMtime = Date.now() - 2 * 60 * 1000;
+    writeStateFile('definicion', 'analisis', 'listo', 3085, 'guru', oldListoMtime);
+    writeMarker('definicion', 'analisis', 3085, 'guru', newerMarkerMtime);
+
+    const markers = [{ issue: 3085, skill: 'guru', phase: 'analisis', pipeline: 'definicion' }];
+    const result = reconciler.reconcileResolvedMarkers(markers, { ttlMs: 30 * 24 * 60 * 60 * 1000 });
+
+    assert.equal(result.archived, 0, 'listo/ más viejo que marker no cuenta como resolución');
+});
+
+test('#3186 reconcileResolvedMarkers aplica TTL como red de seguridad (7d sin movimiento)', () => {
+    clearAllMarkers();
+    clearGhQueue();
+    ensurePhaseDirs('definicion', 'analisis');
+    clearStateDirs('definicion', 'analisis');
+
+    // Marker de hace 10 días, sin archivo en listo/ ni procesado/
+    const tenDaysAgo = Date.now() - 10 * 24 * 60 * 60 * 1000;
+    writeMarker('definicion', 'analisis', 3086, 'guru', tenDaysAgo);
+
+    const markers = [{ issue: 3086, skill: 'guru', phase: 'analisis', pipeline: 'definicion' }];
+    const result = reconciler.reconcileResolvedMarkers(markers); // ttl default 7d
+
+    assert.equal(result.archived, 1, 'marker stale debe archivarse por TTL');
+    assert.equal(result.removeLabelsEnqueued, 1);
+
+    const archivedDir = path.join(PIPELINE, 'definicion', 'analisis', 'archivado');
+    const archivedFiles = fs.readdirSync(archivedDir).filter(f => f.startsWith('3086.guru.'));
+    assert.equal(archivedFiles.length, 1);
+    assert.match(archivedFiles[0], /^3086\.guru\.ttl-expired-/);
+});
+
+test('#3186 reconcileResolvedMarkers NO aplica TTL si está dentro del límite', () => {
+    clearAllMarkers();
+    clearGhQueue();
+    ensurePhaseDirs('definicion', 'analisis');
+    clearStateDirs('definicion', 'analisis');
+
+    // Marker de 3 días — dentro del TTL de 7d
+    const threeDaysAgo = Date.now() - 3 * 24 * 60 * 60 * 1000;
+    writeMarker('definicion', 'analisis', 3087, 'guru', threeDaysAgo);
+
+    const markers = [{ issue: 3087, skill: 'guru', phase: 'analisis', pipeline: 'definicion' }];
+    const result = reconciler.reconcileResolvedMarkers(markers);
+
+    assert.equal(result.archived, 0, 'TTL aún no se cumplió');
+});
+
+test('#3186 reconcileResolvedMarkers solo encola remove-label si NO quedan otros markers cross-fase', () => {
+    clearAllMarkers();
+    clearGhQueue();
+    ensurePhaseDirs('definicion', 'analisis');
+    ensurePhaseDirs('desarrollo', 'dev');
+    clearStateDirs('definicion', 'analisis');
+    clearStateDirs('desarrollo', 'dev');
+
+    // Issue #3088 tiene markers en DOS fases. Resolvemos solo el de definicion.
+    const markerMtime = Date.now() - 5 * 60 * 1000;
+    writeMarker('definicion', 'analisis', 3088, 'guru', markerMtime);
+    writeMarker('desarrollo', 'dev', 3088, 'po', markerMtime); // otro marker activo
+
+    // Resolución del guardian guru en definicion
+    writeStateFile('definicion', 'analisis', 'listo', 3088, 'guru', Date.now() - 60 * 1000);
+
+    const markers = [
+        { issue: 3088, skill: 'guru', phase: 'analisis', pipeline: 'definicion' },
+        { issue: 3088, skill: 'po', phase: 'dev', pipeline: 'desarrollo' },
+    ];
+    const result = reconciler.reconcileResolvedMarkers(markers);
+
+    assert.equal(result.archived, 1, 'archiva solo el resuelto');
+    assert.equal(result.removeLabelsEnqueued, 0, 'NO encola remove-label porque queda el de po');
+
+    // Verificar que no hay orden remove-label en la queue
+    const orders = fs.readdirSync(GH_QUEUE)
+        .filter(f => f.endsWith('.json'))
+        .map(f => JSON.parse(fs.readFileSync(path.join(GH_QUEUE, f), 'utf8')));
+    const removeOrders = orders.filter(o => o.action === 'remove-label');
+    assert.equal(removeOrders.length, 0);
+});
+
+test('#3186 reconcileResolvedMarkers encola remove-label cuando archiva el ÚLTIMO marker del issue', () => {
+    clearAllMarkers();
+    clearGhQueue();
+    ensurePhaseDirs('definicion', 'analisis');
+    ensurePhaseDirs('desarrollo', 'dev');
+    clearStateDirs('definicion', 'analisis');
+    clearStateDirs('desarrollo', 'dev');
+
+    const markerMtime = Date.now() - 5 * 60 * 1000;
+    writeMarker('definicion', 'analisis', 3089, 'guru', markerMtime);
+    writeMarker('desarrollo', 'dev', 3089, 'po', markerMtime);
+
+    // Ambos guardians re-aprobaron
+    writeStateFile('definicion', 'analisis', 'listo', 3089, 'guru', Date.now() - 60 * 1000);
+    writeStateFile('desarrollo', 'dev', 'listo', 3089, 'po', Date.now() - 60 * 1000);
+
+    const markers = [
+        { issue: 3089, skill: 'guru', phase: 'analisis', pipeline: 'definicion' },
+        { issue: 3089, skill: 'po', phase: 'dev', pipeline: 'desarrollo' },
+    ];
+    const result = reconciler.reconcileResolvedMarkers(markers);
+
+    assert.equal(result.archived, 2);
+    assert.equal(result.removeLabelsEnqueued, 1, 'todos archivados → un único remove-label');
+
+    const orders = fs.readdirSync(GH_QUEUE)
+        .filter(f => f.endsWith('.json'))
+        .map(f => JSON.parse(fs.readFileSync(path.join(GH_QUEUE, f), 'utf8')));
+    const removeOrders = orders.filter(o => o.action === 'remove-label');
+    assert.equal(removeOrders.length, 1);
+    assert.equal(removeOrders[0].issue, 3089);
+});
+
+test('#3186 reconcileResolvedMarkers log con reason=guardian-resolved escribe stale-orders.log', () => {
+    clearAllMarkers();
+    clearGhQueue();
+    ensurePhaseDirs('definicion', 'analisis');
+    clearStateDirs('definicion', 'analisis');
+
+    const logFile = path.join(PIPELINE, 'logs', 'stale-orders.log');
+    try { fs.unlinkSync(logFile); } catch {}
+
+    const markerMtime = Date.now() - 5 * 60 * 1000;
+    writeMarker('definicion', 'analisis', 3090, 'guru', markerMtime);
+    writeStateFile('definicion', 'analisis', 'listo', 3090, 'guru', Date.now() - 60 * 1000);
+
+    const markers = [{ issue: 3090, skill: 'guru', phase: 'analisis', pipeline: 'definicion' }];
+    reconciler.reconcileResolvedMarkers(markers);
+
+    const raw = fs.readFileSync(logFile, 'utf8').trim();
+    const lines = raw.split('\n').filter(Boolean);
+    assert.ok(lines.length >= 1);
+    const ev = JSON.parse(lines[lines.length - 1]);
+    assert.equal(ev.reason, 'guardian-resolved');
+    assert.equal(ev.issue, 3090);
+    assert.equal(ev.label, 'needs-human');
+    assert.match(ev.detail, /definicion\/analisis\/listo\/3090\.guru/);
+});
+
+test('#3186 safeTsSuffix produce filename Windows-safe (sin : ni .)', () => {
+    const suffix = reconciler.safeTsSuffix(Date.parse('2026-05-14T22:30:45.123Z'));
+    assert.equal(suffix.includes(':'), false, 'sin dos puntos');
+    assert.equal(suffix.includes('.'), false, 'sin punto');
+    assert.match(suffix, /^2026-05-14T22-30-45-123Z$/);
+});
+
+test('#3186 findGuardianResolution prefiere listo/ sobre procesado/ cuando ambos existen', () => {
+    clearAllMarkers();
+    clearGhQueue();
+    ensurePhaseDirs('definicion', 'analisis');
+    clearStateDirs('definicion', 'analisis');
+
+    const markerMtime = Date.now() - 10 * 60 * 1000;
+    const listoMtime = Date.now() - 5 * 60 * 1000;
+    const procesadoMtime = Date.now() - 3 * 60 * 1000;
+    writeStateFile('definicion', 'analisis', 'listo', 3091, 'guru', listoMtime);
+    writeStateFile('definicion', 'analisis', 'procesado', 3091, 'guru', procesadoMtime);
+
+    const result = reconciler.findGuardianResolution(
+        { issue: 3091, skill: 'guru', phase: 'analisis', pipeline: 'definicion' },
+        markerMtime,
+    );
+    assert.ok(result, 'encuentra resolución');
+    assert.equal(result.state, 'listo', 'primero busca en listo/');
+});
+
+test('#3186 enqueueLabelRemove escribe JSON con shape correcto', () => {
+    clearGhQueue();
+    reconciler.enqueueLabelRemove(7777, 'needs-human');
+    const files = fs.readdirSync(GH_QUEUE).filter(f => f.endsWith('.json'));
+    assert.equal(files.length, 1);
+    const cmd = JSON.parse(fs.readFileSync(path.join(GH_QUEUE, files[0]), 'utf8'));
+    assert.deepEqual(cmd, { action: 'remove-label', issue: 7777, label: 'needs-human' });
+});
+
+// =============================================================================
 // #2994 — CA5: appendStaleOrderLog escribe JSONL en logs/stale-orders.log
 // =============================================================================
 

--- a/.pipeline/servicio-reconciler.js
+++ b/.pipeline/servicio-reconciler.js
@@ -123,6 +123,19 @@ function enqueueLabelApply(issueNum, label, meta = null) {
     );
 }
 
+// #3186 — encola orden `remove-label` para que el servicio-github le quite
+// el label en GitHub. La action `remove-label` ya está soportada por
+// `servicio-github.js` (línea ~451) y es idempotente: si el label ya fue
+// removido, `gh issue edit --remove-label` no falla.
+function enqueueLabelRemove(issueNum, label) {
+    fs.mkdirSync(GH_QUEUE, { recursive: true });
+    const filename = `${issueNum}-rm-${label}-reconciler-${Date.now()}.json`;
+    fs.writeFileSync(
+        path.join(GH_QUEUE, filename),
+        JSON.stringify({ action: 'remove-label', issue: issueNum, label }),
+    );
+}
+
 // -----------------------------------------------------------------------------
 // Decidir fase para placeholder según labels del issue
 // -----------------------------------------------------------------------------
@@ -369,6 +382,175 @@ function reconcileHumanUnblockDetected(blockedMarkers, ghIssueSet, opts = {}) {
 }
 
 // -----------------------------------------------------------------------------
+// #3186 — Reconciliar markers resueltos por el guardian (re-aprobación)
+// -----------------------------------------------------------------------------
+//
+// Asimetría histórica: `reconcileClosedMarkers` archiva markers cuando el
+// issue queda CLOSED en GitHub, pero **no hay equivalente para el caso
+// "guardian re-aprobó"**. Si guru rechaza, deja marker en
+// `bloqueado-humano/3082.guru`. Si en una corrida posterior el mismo skill
+// re-aprueba y dropea `listo/3082.guru`, el marker queda zombie: el reconciler
+// sigue viéndolo y re-aplica `needs-human` cada ciclo (loop label↔reconciler).
+//
+// Esta función detecta dos casos:
+//
+//   A) GUARDIAN-RESOLVED:
+//      Existe `<pipeline>/<phase>/{listo,procesado}/<issue>.<skill>` con
+//      `mtime > marker.mtime`. Esto indica que el mismo skill que generó el
+//      bloqueo emitió un resultado posterior — implícitamente, re-aprobó.
+//
+//      Por qué buscar en `listo/` Y `procesado/`: el pulpo promueve archivos
+//      `listo/` → `procesado/` al instante en que la fase siguiente toma el
+//      issue. Si el reconciler corre tarde (intervalo default 5min), el
+//      archivo ya puede estar en `procesado/`. Sin esta extensión, el bug
+//      original (#3082) se reproduce parcialmente.
+//
+//   B) TTL-EXPIRED:
+//      `now - marker.mtime > RESOLVED_TTL_MS` (default 7 días). Red de
+//      seguridad para markers que nadie tocó en una semana — típicamente
+//      casos donde el archivo `listo/` fue borrado a mano o nunca existió
+//      (humano intervino fuera del pipeline). Sin este TTL los markers
+//      podrían acumularse indefinidamente.
+//
+// Al archivar:
+//   - Marker → `<pipeline>/<phase>/archivado/<issue>.<skill>.<reason>-<ts>`
+//     con timestamp sanitizado para Windows (sin `:` ni `.`).
+//   - `.reason.json` se elimina (mismo patrón que `reconcileClosedMarkers`).
+//   - `appendStaleOrderLog({ reason })` con reasons `guardian-resolved` o
+//     `ttl-expired` para que `reconcilerStaleOrdersSlice` los cuente.
+//
+// Cross-fase remove-label: si después de archivar no quedan otros markers
+// para el mismo issue (un issue puede estar bloqueado por varios skills en
+// fases diferentes), encolar `remove-label needs-human`. Sin esta verificación
+// podríamos quitar el label aunque haya otros bloqueos pendientes.
+
+const RESOLVED_TTL_MS = parseInt(
+    process.env.RECONCILER_RESOLVED_TTL_MS || String(7 * 24 * 60 * 60 * 1000),
+    10,
+); // 7 días default
+
+// Busca resolución del guardian: archivo `<issue>.<skill>` en `listo/` o
+// `procesado/` de la misma fase, con mtime > markerMtime.
+// Devuelve { state, path, mtimeMs } o null.
+function findGuardianResolution(marker, markerMtime) {
+    const base = `${marker.issue}.${marker.skill}`;
+    for (const state of ['listo', 'procesado']) {
+        const candidate = path.join(PIPELINE, marker.pipeline, marker.phase, state, base);
+        let stat;
+        try { stat = fs.statSync(candidate); } catch { continue; }
+        if (stat.mtimeMs > markerMtime) {
+            return { state, path: candidate, mtimeMs: stat.mtimeMs };
+        }
+    }
+    return null;
+}
+
+// Sanitiza un timestamp ISO para usarlo como sufijo de archivo en Windows.
+// `2026-05-14T22:30:45.123Z` → `2026-05-14T22-30-45-123Z`.
+function safeTsSuffix(ms) {
+    return new Date(ms).toISOString().replace(/[:.]/g, '-');
+}
+
+function reconcileResolvedMarkers(blockedMarkers, opts = {}) {
+    const now = opts.now || Date.now();
+    const ttlMs = typeof opts.ttlMs === 'number' ? opts.ttlMs : RESOLVED_TTL_MS;
+    const logFn = opts.logStaleOrder || appendStaleOrderLog;
+    const enqueueRemoveFn = opts.enqueueLabelRemove || enqueueLabelRemove;
+    const findResolutionFn = opts.findGuardianResolution || findGuardianResolution;
+
+    const archivedMarkerKeys = new Set(); // `${issue}.${skill}`
+    const archivedIssues = new Set();
+    const archivedEntries = [];
+
+    for (const m of blockedMarkers) {
+        const markerPath = path.join(
+            PIPELINE, m.pipeline, m.phase, humanBlock.BLOCK_SUBDIR, `${m.issue}.${m.skill}`,
+        );
+        let markerMtime;
+        try { markerMtime = fs.statSync(markerPath).mtimeMs; }
+        catch { continue; } // marker desapareció entre listado y stat — saltar
+
+        let resolved = null;
+        const guardian = findResolutionFn(m, markerMtime);
+        if (guardian) {
+            resolved = {
+                reason: 'guardian-resolved',
+                detail: `${m.pipeline}/${m.phase}/${guardian.state}/${m.issue}.${m.skill}`,
+            };
+        } else if ((now - markerMtime) > ttlMs) {
+            const daysIdle = Math.round((now - markerMtime) / (24 * 3600 * 1000));
+            resolved = {
+                reason: 'ttl-expired',
+                detail: `marker sin movimiento por ${daysIdle}d (TTL=${Math.round(ttlMs / (24 * 3600 * 1000))}d)`,
+            };
+        }
+
+        if (!resolved) continue;
+
+        // Archivar marker en <pipeline>/<phase>/archivado/ con sufijo
+        // `<reason>-<ts>` para que sea evidente por qué se cerró.
+        const archiveDir = path.join(PIPELINE, m.pipeline, m.phase, 'archivado');
+        const base = `${m.issue}.${m.skill}`;
+        const archivedName = `${base}.${resolved.reason}-${safeTsSuffix(now)}`;
+        const dst = path.join(archiveDir, archivedName);
+
+        try {
+            fs.mkdirSync(archiveDir, { recursive: true });
+            fs.renameSync(markerPath, dst);
+        } catch (e) {
+            log(`Error archivando marker resuelto #${m.issue}.${m.skill}: ${e.message.slice(0, 120)}`);
+            continue;
+        }
+        try { fs.unlinkSync(markerPath + '.reason.json'); } catch {}
+
+        archivedMarkerKeys.add(`${m.issue}.${m.skill}`);
+        archivedIssues.add(m.issue);
+        archivedEntries.push({
+            issue: m.issue, skill: m.skill, reason: resolved.reason, archived_as: dst,
+        });
+
+        try {
+            logFn({
+                reason: resolved.reason,
+                issue: m.issue,
+                label: RECONCILER_LABEL,
+                snapshot_at: null,
+                current_mtime: markerMtime,
+                detail: resolved.detail,
+            });
+        } catch {}
+
+        log(`#${m.issue}.${m.skill} resuelto (${resolved.reason}) → archivado/${archivedName}`);
+    }
+
+    // Cross-fase: por cada issue con marker archivado, verificar si quedan
+    // otros markers activos en blockedMarkers (en cualquier fase). Solo si
+    // todos los markers del issue fueron archivados, encolamos remove-label
+    // para que GitHub también quede sin `needs-human`.
+    let removeLabelsEnqueued = 0;
+    for (const issue of archivedIssues) {
+        const stillBlocked = blockedMarkers.some(
+            m => m.issue === issue && !archivedMarkerKeys.has(`${m.issue}.${m.skill}`),
+        );
+        if (stillBlocked) continue;
+        try {
+            enqueueRemoveFn(issue, RECONCILER_LABEL);
+            removeLabelsEnqueued++;
+        } catch (e) {
+            log(`Error encolando remove-label #${issue}: ${e.message.slice(0, 120)}`);
+        }
+    }
+
+    return {
+        archived: archivedEntries.length,
+        archivedIssues,
+        archivedMarkerKeys,
+        removeLabelsEnqueued,
+        entries: archivedEntries,
+    };
+}
+
+// -----------------------------------------------------------------------------
 // Telemetría: log append-only de descartes/detecciones (CA5 #2994)
 // -----------------------------------------------------------------------------
 //
@@ -425,24 +607,38 @@ function reconcileOnce() {
 
     const created = reconcileLabelToFilesystem(ghIssues, blockedByIssue);
 
-    // CA3 (#2994) — primero detectar destrabes humanos: corre ANTES que
+    // #3186 — primero, archivar markers ya resueltos por el guardian (re-aprobó)
+    // o expirados por TTL. Corre ANTES que reconcileMarkerToLabel para no
+    // re-aplicar el label sobre un issue que está funcionalmente destrabado;
+    // ANTES que reconcileHumanUnblockDetected porque el guardian-resolved es
+    // más específico (sabemos exactamente qué skill resolvió) que la detección
+    // por "label ausente" — si ambos disparan, preferimos archivar a `archivado/`
+    // (estado terminal) en vez de mover a `pendiente/` (estado de re-ejecución).
+    const resolvedResult = reconcileResolvedMarkers(blockedMarkers);
+    const resolved = resolvedResult.archived;
+    const resolvedRemovedLabels = resolvedResult.removeLabelsEnqueued;
+    const afterResolved = resolvedResult.archivedMarkerKeys.size > 0
+        ? blockedMarkers.filter(m => !resolvedResult.archivedMarkerKeys.has(`${m.issue}.${m.skill}`))
+        : blockedMarkers;
+
+    // CA3 (#2994) — detectar destrabes humanos: corre ANTES que
     // reconcileMarkerToLabel para no encolar órdenes que tendríamos que
     // descartar como stale por GitHub-autoritativo.
-    const unblockResult = reconcileHumanUnblockDetected(blockedMarkers, ghIssueSet);
+    const unblockResult = reconcileHumanUnblockDetected(afterResolved, ghIssueSet);
     const detected = unblockResult.detected;
     // Filtrar markers ya movidos para que reconcileMarkerToLabel/Closed
     // no vuelvan a procesarlos en este mismo ciclo.
     const remaining = unblockResult.movedIssues.size > 0
-        ? blockedMarkers.filter(m => !unblockResult.movedIssues.has(m.issue))
-        : blockedMarkers;
+        ? afterResolved.filter(m => !unblockResult.movedIssues.has(m.issue))
+        : afterResolved;
 
     const enqueued = reconcileMarkerToLabel(remaining, ghIssueSet);
     const archived = reconcileClosedMarkers(remaining, ghIssueSet);
 
     const elapsed = Date.now() - t0;
     lastRunAt = Date.now();
-    if (created || enqueued || archived || detected) {
-        log(`Ciclo ${cycleCount} (${elapsed}ms): GH=${ghIssues.length} markers=${blockedMarkers.length} → +${created} placeholders, +${enqueued} labels encolados, +${archived} archivados, +${detected} destrabes humanos detectados`);
+    if (created || enqueued || archived || detected || resolved) {
+        log(`Ciclo ${cycleCount} (${elapsed}ms): GH=${ghIssues.length} markers=${blockedMarkers.length} → +${created} placeholders, +${enqueued} labels encolados, +${archived} archivados (closed), +${detected} destrabes humanos, +${resolved} resueltos por guardian/TTL (-${resolvedRemovedLabels} labels removidos)`);
     } else {
         log(`Ciclo ${cycleCount} (${elapsed}ms): GH=${ghIssues.length} markers=${blockedMarkers.length} — sincronizado`);
     }
@@ -492,13 +688,18 @@ module.exports = {
     reconcileMarkerToLabel,
     reconcileClosedMarkers,
     reconcileHumanUnblockDetected,
+    reconcileResolvedMarkers,
+    findGuardianResolution,
+    safeTsSuffix,
     decidirFasePlaceholder,
     isRecommendationIssue,
     RECOMMENDATION_LABELS,
     listGhIssuesWithLabel,
     getIssueState,
     enqueueLabelApply,
+    enqueueLabelRemove,
     buildMarkerMeta,
     appendStaleOrderLog,
     HUMAN_UNBLOCK_GRACE_MS,
+    RESOLVED_TTL_MS,
 };


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 2 archivos · +519 -6

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:skipped` aplicado por delivery

## Closes

Closes #3186
