### PR TITLE
bug(pipeline): pre-flight de emulador se dispara para cualquier skill en fase verificacion (no solo qa)

### DIFF
--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -1179,6 +1179,23 @@ const PROFILE_STALE_HOURS = 24;
 // agente nunca cierran bajo el umbral porque el emulador ya está presente en la baseline).
 const QA_INFRA_SKILLS = new Set(['qa', 'security', 'tester']);
 
+// Skills que DISPARAN el arranque del emulador en el pre-flight de fase `verificacion`.
+// Sólo `qa` necesita realmente el AVD (tests E2E); `tester` y `security` son
+// determinísticos (JVM tests, análisis estático) y no requieren emulador.
+// Esta whitelist evita que el modo descanso levante el emulador innecesariamente
+// cuando solo corren skills determinísticos en la ventana 22:00-07:00 ART.
+// Ver issue #3140.
+const SKILLS_THAT_NEED_EMULATOR = new Set(['qa']);
+
+// Helper único para decidir si un (skill, fase) dispara `preflightQaChecks` y por
+// extensión `requestEmulator`/`reboteVerificacionABuild`. Vive como función pura
+// para tener una sola fuente de verdad — la condición se aplica en el preflight
+// regular del bucle de lanzamiento y también en el deadlock breaker.
+// Ver issue #3140 (whitelist explícita) y CA-4/CA-6 del PO.
+function shouldRunQaPreflight(skill, fase) {
+  return fase === 'verificacion' && SKILLS_THAT_NEED_EMULATOR.has(skill);
+}
+
 function getEstimatedImpact(profile) {
   const DEFAULT_CPU = 12;
   const DEFAULT_MEM = 3;  // Proceso claude.exe real ~ 250-500 MB en 16 GB
@@ -4054,7 +4071,11 @@ function brazoLanzamiento(config) {
     // El preflight y el rebote son barato (no consumen RAM ni CPU significativos),
     // así que tiene sentido ejecutarlos ANTES del gate de recursos.
     let preflightResult = null;
-    if (fase === 'verificacion') {
+    // Filtramos por skill: sólo los skills declarados en SKILLS_THAT_NEED_EMULATOR
+    // disparan el preflight QA (que puede arrancar el emulador). Skills determinísticos
+    // como `tester` y `security` no requieren AVD y no deben pagar el overhead del
+    // preflight ni levantar el emulador (#3140).
+    if (shouldRunQaPreflight(skill, fase)) {
       preflightResult = preflightQaChecks(issue);
       if (!preflightResult.ok) {
         if (preflightResult.result === 'apk_missing') {
@@ -4159,7 +4180,9 @@ function brazoLanzamiento(config) {
         // Si detecta APK faltante, REBOTAR a build (no abandonar) — sin esto, el
         // deadlock breaker se queda atascado para siempre haciendo return ciclo tras
         // ciclo mientras los archivos siguen en verificacion/pendiente/.
-        if (fase === 'verificacion') {
+        // Filtramos por skill por la misma razón que el preflight regular (#3140):
+        // skills determinísticos no deben disparar arranque del emulador.
+        if (shouldRunQaPreflight(skill, fase)) {
           const preflight = preflightQaChecks(issue);
           if (!preflight.ok) {
             if (preflight.result === 'apk_missing') {
@@ -8736,6 +8759,9 @@ if (process.env.PULPO_NO_AUTOSTART === '1') {
     migrateSkillProfilesIfNeeded,
     SKILL_PROFILES_SCHEMA_VERSION,
     QA_INFRA_SKILLS,
+    // #3140 — whitelist de skills que disparan preflight QA / emulador en verificacion.
+    SKILLS_THAT_NEED_EMULATOR,
+    shouldRunQaPreflight,
     MAX_EST_MEM,
     MAX_EST_CPU,
     // #2317 — precheck de conectividad

--- a/.pipeline/tests/preflight-skill-gate.test.js
+++ b/.pipeline/tests/preflight-skill-gate.test.js
@@ -1,0 +1,94 @@
+// Tests del filtro `shouldRunQaPreflight(skill, fase)` y la whitelist
+// `SKILLS_THAT_NEED_EMULATOR` (issue #3140).
+//
+// Bug original: `pulpo.js` disparaba `preflightQaChecks` (y por extensión
+// `requestEmulator`) para CUALQUIER skill en fase `verificacion`. Esto levantaba
+// el emulador Android innecesariamente durante modo descanso cuando solo corrían
+// skills determinísticos (`tester` / `security`).
+//
+// Cubre los CAs:
+// - CA-1 — Existe la whitelist `SKILLS_THAT_NEED_EMULATOR` con contenido `['qa']`.
+// - CA-2/CA-4 — `shouldRunQaPreflight` filtra por skill correctamente.
+// - CA-3 — `qa` en `verificacion` sigue disparando preflight.
+// - CA-5 — Las 3 combinaciones del set `[tester, security, qa]` están testeadas.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+// Levantar pulpo.js en modo test (no inicia singleton ni mainLoop)
+process.env.PULPO_NO_AUTOSTART = '1';
+const pulpo = require('../pulpo.js');
+
+// ----- CA-1: la whitelist existe y contiene solo `qa` ---------------------------
+
+test('SKILLS_THAT_NEED_EMULATOR es un Set y contiene únicamente "qa"', () => {
+    assert.ok(pulpo.SKILLS_THAT_NEED_EMULATOR instanceof Set, 'debe ser un Set');
+    assert.equal(pulpo.SKILLS_THAT_NEED_EMULATOR.size, 1);
+    assert.ok(pulpo.SKILLS_THAT_NEED_EMULATOR.has('qa'));
+});
+
+test('SKILLS_THAT_NEED_EMULATOR NO contiene skills determinísticos', () => {
+    const determ = ['tester', 'security', 'builder', 'review', 'pipeline-dev', 'po', 'planner', 'guru', 'ux'];
+    for (const skill of determ) {
+        assert.ok(
+            !pulpo.SKILLS_THAT_NEED_EMULATOR.has(skill),
+            `'${skill}' no debería disparar emulador en verificacion`,
+        );
+    }
+});
+
+// ----- CA-3: `qa` en `verificacion` SÍ dispara preflight -----------------------
+
+test('shouldRunQaPreflight("qa", "verificacion") === true', () => {
+    assert.equal(pulpo.shouldRunQaPreflight('qa', 'verificacion'), true);
+});
+
+// ----- CA-4: `tester` y `security` en `verificacion` NO disparan preflight -----
+
+test('shouldRunQaPreflight("tester", "verificacion") === false', () => {
+    assert.equal(pulpo.shouldRunQaPreflight('tester', 'verificacion'), false);
+});
+
+test('shouldRunQaPreflight("security", "verificacion") === false', () => {
+    assert.equal(pulpo.shouldRunQaPreflight('security', 'verificacion'), false);
+});
+
+// ----- CA-5: cobertura completa del set actual de verificacion -----------------
+
+test('cobertura de las 3 combinaciones del set [tester, security, qa] en verificacion', () => {
+    const cases = [
+        { skill: 'tester', expected: false },
+        { skill: 'security', expected: false },
+        { skill: 'qa', expected: true },
+    ];
+    for (const { skill, expected } of cases) {
+        assert.equal(
+            pulpo.shouldRunQaPreflight(skill, 'verificacion'),
+            expected,
+            `'${skill}' en verificacion debería retornar ${expected}`,
+        );
+    }
+});
+
+// ----- Casos colaterales: otras fases nunca disparan preflight ------------------
+
+test('shouldRunQaPreflight no dispara en fases distintas de "verificacion" (aunque sea qa)', () => {
+    const otherPhases = ['analisis', 'criterios', 'validacion', 'dev', 'build', 'aprobacion', 'entrega'];
+    for (const fase of otherPhases) {
+        assert.equal(
+            pulpo.shouldRunQaPreflight('qa', fase),
+            false,
+            `qa en fase '${fase}' no debe disparar preflight (solo 'verificacion' aplica)`,
+        );
+    }
+});
+
+test('shouldRunQaPreflight es defensivo ante inputs nulos / vacíos', () => {
+    assert.equal(pulpo.shouldRunQaPreflight(null, 'verificacion'), false);
+    assert.equal(pulpo.shouldRunQaPreflight(undefined, 'verificacion'), false);
+    assert.equal(pulpo.shouldRunQaPreflight('qa', null), false);
+    assert.equal(pulpo.shouldRunQaPreflight('qa', undefined), false);
+    assert.equal(pulpo.shouldRunQaPreflight('', ''), false);
+});


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 2 archivos · +122 -2

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:passed` aplicado por delivery

## Closes

Closes #3140
