### PR TITLE
Reintroducir validateCredentialsEnvPresence con awareness de launcher (claude=OAuth, otros=env)

### DIFF
--- a/.pipeline/lib/__tests__/agent-models-validate.test.js
+++ b/.pipeline/lib/__tests__/agent-models-validate.test.js
@@ -682,12 +682,34 @@ test('CA-3 · HARDCODED_SECRET_PATTERNS está congelado (inmutabilidad)', () => 
 // CA-2 (#3080 / S1) · Boot fail-fast por env var faltante
 // =============================================================================
 
-test('CA-2 #3080 · validate con processEnv vacío → falla por ANTHROPIC_API_KEY', () => {
-  const file = tmpFile(baseValid());
+// Helper #3154: baseValid() tiene anthropic con launcher=claude (OAuth bypass).
+// Para testear el camino "exige env var faltante" necesitamos un provider con
+// launcher distinto (codex/gemini/ollama/node) referenciado por algún skill.
+function baseValidWithCodex() {
+  const cfg = baseValid();
+  cfg.providers['openai-codex'] = {
+    launcher: 'codex',
+    model: 'gpt-4o',
+    spawn_args_template: ['-p', '{user_prompt}', '--model', '{model}'],
+    output_parser: 'openai-sse',
+    quota_error_types: [],
+    supports_tool_use: true,
+    prompt_caching: { supported: false },
+    credentials_env: ['OPENAI_API_KEY'],
+  };
+  cfg.skills.qa.provider = 'openai-codex';
+  delete cfg.skills.qa.model_override; // model_override era para anthropic
+  return cfg;
+}
+
+test('CA-2 #3080 · validate con processEnv vacío + provider non-claude → falla por env var', () => {
+  // Antes de #3154: testeaba contra anthropic+ANTHROPIC_API_KEY. Reaimed a
+  // openai-codex+OPENAI_API_KEY porque launcher=claude ahora bypassea el chequeo.
+  const file = tmpFile(baseValidWithCodex());
   try {
     const r = validateMod.validate(file, { processEnv: {} });
     assert.equal(r.ok, false);
-    const e = r.errors.find((er) => er.message.includes('ANTHROPIC_API_KEY'));
+    const e = r.errors.find((er) => er.message.includes('OPENAI_API_KEY'));
     assert.ok(e, `debe fallar por env var faltante: ${JSON.stringify(r.errors)}`);
     assert.match(e.message, /no está presente en process\.env/);
     assert.equal(r.exitCode, 2);
@@ -695,19 +717,21 @@ test('CA-2 #3080 · validate con processEnv vacío → falla por ANTHROPIC_API_K
 });
 
 test('CA-2 #3080 · validate con processEnv válido → ok', () => {
-  const file = tmpFile(baseValid());
+  const file = tmpFile(baseValidWithCodex());
   try {
-    const r = validateMod.validate(file, { processEnv: { ANTHROPIC_API_KEY: 'sk-ant-fake-not-real-1234567890' } });
+    const r = validateMod.validate(file, {
+      processEnv: { OPENAI_API_KEY: 'sk-fake-not-real-1234567890' },
+    });
     assert.equal(r.ok, true, JSON.stringify(r.errors));
   } finally { fs.unlinkSync(file); }
 });
 
 test('CA-2 #3080 · validate con env var presente pero vacía → falla', () => {
-  const file = tmpFile(baseValid());
+  const file = tmpFile(baseValidWithCodex());
   try {
-    const r = validateMod.validate(file, { processEnv: { ANTHROPIC_API_KEY: '' } });
+    const r = validateMod.validate(file, { processEnv: { OPENAI_API_KEY: '' } });
     assert.equal(r.ok, false);
-    const e = r.errors.find((er) => er.message.includes('ANTHROPIC_API_KEY'));
+    const e = r.errors.find((er) => er.message.includes('OPENAI_API_KEY'));
     assert.ok(e, 'env vacía debe fallar igual que ausente');
   } finally { fs.unlinkSync(file); }
 });
@@ -721,8 +745,8 @@ test('CA-2 #3080 · validate sin processEnv → NO valida env vars (backwards co
   } finally { fs.unlinkSync(file); }
 });
 
-test('CA-2 #3080 · validateOrExit con checkEnv:true sin env var → exit 2', () => {
-  const file = tmpFile(baseValid());
+test('CA-2 #3080 · validateOrExit con checkEnv:true sin env var (non-claude) → exit 2', () => {
+  const file = tmpFile(baseValidWithCodex());
   let exitCode = null;
   let stderrMsg = '';
   try {
@@ -734,7 +758,7 @@ test('CA-2 #3080 · validateOrExit con checkEnv:true sin env var → exit 2', ()
       exitFn: (c) => { exitCode = c; },
     });
     assert.equal(exitCode, 2);
-    assert.match(stderrMsg, /ANTHROPIC_API_KEY/);
+    assert.match(stderrMsg, /OPENAI_API_KEY/);
     assert.match(stderrMsg, /no está presente en process\.env/);
   } finally { fs.unlinkSync(file); }
 });
@@ -789,7 +813,8 @@ test('CA-2 #3080 · provider con skill asignado → exige todas sus credentials_
 });
 
 test('CA-2 #3080 · mensaje de fail-fast NO contiene valor del env (anti-leak)', () => {
-  const file = tmpFile(baseValid());
+  // Reaimed post #3154 a un provider non-claude para forzar el path de error.
+  const file = tmpFile(baseValidWithCodex());
   // Setear una env var con un valor que reconoceríamos si filtrara.
   const sentinel = 'SENTINEL-VALUE-1234567890-DO-NOT-LEAK';
   try {
@@ -807,6 +832,7 @@ test('CA-2 #3080 · validateCredentialsEnvPresence función pura, testable sin f
   const cfg = {
     default_provider: 'p1',
     providers: {
+      // Sin launcher → no aplica el bypass de #3154, sigue exigiendo env.
       p1: { credentials_env: ['VAR_A'] },
       p2: { credentials_env: ['VAR_B'] },
     },
@@ -819,6 +845,113 @@ test('CA-2 #3080 · validateCredentialsEnvPresence función pura, testable sin f
   const errs2 = validateMod.validateCredentialsEnvPresence(cfg, {});
   assert.equal(errs2.length, 1);
   assert.match(errs2[0].message, /VAR_A/);
+});
+
+// =============================================================================
+// CA #3154 · Bypass launcher='claude' (auth OAuth vía CLI, no env var)
+// =============================================================================
+
+test('#3154 · launcher=claude con credentials_env declarado → bypass, env vacía es válida', () => {
+  // El setup canónico actual: anthropic con launcher=claude y
+  // credentials_env=['ANTHROPIC_API_KEY']. Claude Max delega la auth al CLI
+  // (OAuth en ~/.claude/.credentials.json), nunca a env vars. La presencia
+  // de ANTHROPIC_API_KEY no debe ser obligatoria al boot.
+  const file = tmpFile(baseValid());
+  try {
+    const r = validateMod.validate(file, { processEnv: {} });
+    assert.equal(r.ok, true, `bypass claude debe pasar con env vacía: ${JSON.stringify(r.errors)}`);
+    // Doble check: ningún error debe nombrar ANTHROPIC_API_KEY.
+    const e = (r.errors || []).find((er) => er.message && er.message.includes('ANTHROPIC_API_KEY'));
+    assert.equal(e, undefined, 'no debe haber error sobre ANTHROPIC_API_KEY');
+  } finally { fs.unlinkSync(file); }
+});
+
+test('#3154 · launcher=codex con env vacía → falla con mensaje accionable (gate openai-codex)', () => {
+  // Espejo del caso anterior: si alguien asigna un skill a openai-codex (que
+  // SÍ usa env var directa OPENAI_API_KEY), el boot fail-fast debe disparar.
+  const file = tmpFile(baseValidWithCodex());
+  try {
+    const r = validateMod.validate(file, { processEnv: {} });
+    assert.equal(r.ok, false);
+    const e = (r.errors || []).find((er) => er.message && er.message.includes('OPENAI_API_KEY'));
+    assert.ok(e, `non-claude debe seguir exigiendo env: ${JSON.stringify(r.errors)}`);
+    assert.match(e.message, /no está presente en process\.env/);
+    assert.match(e.fix, /setear OPENAI_API_KEY/);
+  } finally { fs.unlinkSync(file); }
+});
+
+test('#3154 · bypass por launcher es per-provider, no global (provider claude OK + provider codex falla)', () => {
+  // Mix: skills usando anthropic (launcher=claude, bypass) Y openai-codex
+  // (launcher=codex, exige env). Con env vacía, debe fallar SOLO por codex,
+  // no por anthropic. Esto asegura que el bypass no contamina la decisión
+  // sobre otros providers.
+  const cfg = baseValidWithCodex();
+  // qa ya está en openai-codex por baseValidWithCodex(). backend-dev sigue
+  // en anthropic. Forzamos default_provider a openai-codex para ejercitar
+  // el path de default + el path de skill.
+  cfg.default_provider = 'openai-codex';
+  const file = tmpFile(cfg);
+  try {
+    const r = validateMod.validate(file, { processEnv: {} });
+    assert.equal(r.ok, false);
+    const codexErr = (r.errors || []).find((er) => er.message && er.message.includes('OPENAI_API_KEY'));
+    assert.ok(codexErr, 'codex debe fallar por env faltante');
+    const anthErr = (r.errors || []).find((er) => er.message && er.message.includes('ANTHROPIC_API_KEY'));
+    assert.equal(anthErr, undefined, 'anthropic (launcher=claude) debe seguir bypasseado aunque otro provider falle');
+  } finally { fs.unlinkSync(file); }
+});
+
+test('#3154 · launcher futuro (node) con credentials_env → sigue chequeándose (escenario claude-api SDK)', () => {
+  // Hipótesis: un futuro provider que consuma ANTHROPIC_API_KEY directamente
+  // desde Node (sin pasar por el CLI `claude`) declararía launcher='node'.
+  // El bypass es per-launcher, así que ese caso NO debe escaparse del check.
+  // Este test gatea contra una regresión donde alguien generalizara el bypass.
+  const cfg = baseValid();
+  cfg.providers['anthropic-sdk'] = {
+    launcher: 'node',
+    model: 'deterministic',
+    spawn_args_template: ['{script_path}', '{issue}'],
+    output_parser: 'none',
+    quota_error_types: [],
+    supports_tool_use: false,
+    prompt_caching: { supported: false },
+    credentials_env: ['ANTHROPIC_API_KEY'],
+  };
+  cfg.skills.qa.provider = 'anthropic-sdk';
+  delete cfg.skills.qa.model_override;
+  const file = tmpFile(cfg);
+  try {
+    const r = validateMod.validate(file, { processEnv: {} });
+    assert.equal(r.ok, false);
+    const e = (r.errors || []).find((er) =>
+      er.path && er.path.includes('anthropic-sdk') && er.message.includes('ANTHROPIC_API_KEY')
+    );
+    assert.ok(e, `provider non-claude con credentials_env debe seguir gateado: ${JSON.stringify(r.errors)}`);
+  } finally { fs.unlinkSync(file); }
+});
+
+test('#3154 · validateCredentialsEnvPresence función pura — bypass claude vs check codex', () => {
+  // Mismo shape que el test "función pura" de #3080, ejercitando ambos paths.
+  const cfg = {
+    default_provider: 'anth',
+    providers: {
+      anth: { launcher: 'claude', credentials_env: ['ANTHROPIC_API_KEY'] },
+      codex: { launcher: 'codex', credentials_env: ['OPENAI_API_KEY'] },
+    },
+    skills: {
+      s1: { provider: 'anth' },
+      s2: { provider: 'codex' },
+    },
+  };
+  // Env vacía: claude bypass → no error. codex referenciado → error.
+  const errs = validateMod.validateCredentialsEnvPresence(cfg, {});
+  assert.equal(errs.length, 1, `solo codex debe fallar: ${JSON.stringify(errs)}`);
+  assert.match(errs[0].message, /OPENAI_API_KEY/);
+  assert.match(errs[0].path, /\/providers\/codex\/credentials_env$/);
+
+  // Con OPENAI_API_KEY presente: ambos OK.
+  const errsOk = validateMod.validateCredentialsEnvPresence(cfg, { OPENAI_API_KEY: 'sk-fake' });
+  assert.deepEqual(errsOk, []);
 });
 
 // =============================================================================

--- a/.pipeline/lib/__tests__/agent-models-validate.test.js
+++ b/.pipeline/lib/__tests__/agent-models-validate.test.js
@@ -630,7 +630,32 @@ test('CA-3 · referencia ${ANTHROPIC_API_KEY} en credentials_env → válido (no
 
 test('CA-3 · findHardcodedSecrets aplicado al config canónico no detecta secrets', () => {
   // El archivo canónico en main NO debe tener secrets hardcoded — guardrail.
-  const raw = fs.readFileSync(validateMod.CANONICAL_JSON_PATH, 'utf8');
+  //
+  // Rebote #3154 rev-2: leemos el contenido desde `git show HEAD:.pipeline/agent-models.json`
+  // en vez de `fs.readFileSync(CANONICAL_JSON_PATH)`. Razón: el test
+  // CLI en `.pipeline/tests/validate-agent-models.test.js` usa `withFixture`
+  // para mutar TEMPORALMENTE el archivo canónico durante la ejecución de
+  // sub-procesos. Cuando ambos archivos de test corren en paralelo (default
+  // de `node --test` con múltiples files), este test puede leer el archivo
+  // mientras un fixture con `sk-ant-...` está activo, gatillando un falso
+  // positivo. Leer desde git evita la race: git ve sólo el contenido
+  // committed (HEAD), no las mutaciones temporales del filesystem.
+  //
+  // Fallback a fs.readFileSync si git no está disponible (caso edge, ej.
+  // ejecución desde un tarball sin .git/). El fallback acepta el riesgo de
+  // race en ese contexto poco probable.
+  const { execSync } = require('child_process');
+  const repoRoot = path.resolve(__dirname, '..', '..', '..');
+  let raw;
+  try {
+    raw = execSync('git show HEAD:.pipeline/agent-models.json', {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+  } catch {
+    raw = fs.readFileSync(validateMod.CANONICAL_JSON_PATH, 'utf8');
+  }
   const cfg = JSON.parse(raw);
   const hits = validateMod.findHardcodedSecrets(cfg);
   assert.deepEqual(hits, [], `agent-models.json canónico tiene secrets hardcoded: ${JSON.stringify(hits)}`);

--- a/.pipeline/lib/agent-models-validate.js
+++ b/.pipeline/lib/agent-models-validate.js
@@ -457,6 +457,20 @@ function validateCrossReferences(config) {
  * inyectada al boot. Esto evita rebote falso para el operador que tenga
  * agent-models.json con providers preparados pero no en uso.
  *
+ * Bypass para `launcher: "claude"` (#3154): el CLI `claude` (Claude Max)
+ * autentica vía OAuth — el token persiste en `~/.claude/.credentials.json`
+ * con `subscriptionType: "max"` y nunca pasa por env var. Cualquier
+ * `credentials_env` declarado para un provider con launcher=claude se
+ * ignora a propósito en este chequeo. Para el resto de launchers (`codex`,
+ * `gemini`, `ollama`, `node`) la presencia de la env var sigue siendo
+ * obligatoria al boot.
+ *
+ * NOTA estructural: el bypass acopla launcher='claude' con auth-mode OAuth.
+ * Si en el futuro aparece un launcher='claude' que NO use OAuth (ej. un
+ * SDK que consuma ANTHROPIC_API_KEY directo desde Node) el special case se
+ * invierte. Tracking del refactor a `auth_mode: "oauth" | "env"` declarativo
+ * en provider schema: issue #3205 (no bloqueante).
+ *
  * Devuelve array de errores con shape estándar (path, message, fix).
  *
  * REGLAS DE NO-LEAK:
@@ -482,6 +496,9 @@ function validateCredentialsEnvPresence(config, processEnv) {
     const providerDef = config.providers[providerName];
     if (!providerDef) continue; // ya lo agarra validateCrossReferences
     if (!Array.isArray(providerDef.credentials_env)) continue;
+    // Bypass #3154: launcher=claude autentica vía OAuth del CLI, no por env.
+    // Ver JSDoc arriba para el razonamiento y refactor pendiente (#3205).
+    if (providerDef.launcher === 'claude') continue;
     for (const envVar of providerDef.credentials_env) {
       if (typeof envVar !== 'string' || !envVar) continue;
       // Presencia en processEnv. Una string vacía NO cuenta como "seteada"

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -8896,10 +8896,14 @@ if (process.env.PULPO_SKIP_AGENT_MODELS_VALIDATE !== '1') {
     const agentModelsValidate = require('./lib/agent-models-validate');
     agentModelsValidate.validateOrExit({
       contextLabel: 'boot abortado',
-      // checkEnv quedó en false (default): el setup actual autentica los
-      // skills LLM vía OAuth del CLI `claude` (Claude Max), no por env var.
-      // Activarlo rompe el boot del pulpo. Ver issue de seguimiento para
-      // reintroducirlo con awareness de launcher (claude=OAuth, otros=env).
+      // checkEnv:true (re-activado en #3154 después del fix temporal de #3153).
+      // validateCredentialsEnvPresence hace bypass de providers con
+      // `launcher: "claude"` (auth OAuth vía CLI, no env var). Cualquier
+      // otro launcher (codex/gemini/ollama/node) que declare credentials_env
+      // sigue exigiendo presencia de la env var al boot. Esto gateá la
+      // activación de openai-codex (OPENAI_API_KEY) sin romper el setup
+      // actual donde todos los skills usan launcher=claude.
+      checkEnv: true,
     });
   } catch (err) {
     // Si el módulo de validación mismo crasha (no debería: ajv/loadSchema están

--- a/.pipeline/tests/__fixtures__/validate-agent-models/valid-codex.json
+++ b/.pipeline/tests/__fixtures__/validate-agent-models/valid-codex.json
@@ -1,0 +1,18 @@
+{
+  "default_provider": "openai-codex",
+  "providers": {
+    "openai-codex": {
+      "launcher": "codex",
+      "model": "gpt-5-codex",
+      "spawn_args_template": ["exec", "--full-auto", "--model", "{model}", "{user_prompt}"],
+      "output_parser": "openai-sse",
+      "quota_error_types": ["insufficient_quota"],
+      "supports_tool_use": true,
+      "prompt_caching": { "supported": true, "auto": true },
+      "credentials_env": ["OPENAI_API_KEY"]
+    }
+  },
+  "skills": {
+    "guru": { "provider": "openai-codex" }
+  }
+}

--- a/.pipeline/tests/validate-agent-models.test.js
+++ b/.pipeline/tests/validate-agent-models.test.js
@@ -199,18 +199,39 @@ describe('validate-agent-models (CLI integration)', () => {
     });
   });
 
-  test('fixture válida con env var faltante retorna exit 2 (credencial faltante)', () => {
-    withFixture('valid.json', () => {
+  test('fixture válida (launcher=codex) con env var faltante retorna exit 2 (credencial faltante)', () => {
+    // #3154: El bypass per-launcher hace que `launcher: "claude"` no exija
+    // env var (auth delegada al OAuth del CLI). Para seguir cubriendo el
+    // contrato CA-EXIT-2 ("credencial faltante → exit 2") usamos un fixture
+    // con launcher=codex, que SÍ requiere OPENAI_API_KEY en env.
+    withFixture('valid-codex.json', () => {
       // Borramos la env var del child sin tocar la del padre.
       const env = Object.assign({}, process.env);
-      delete env.ANTHROPIC_API_KEY;
+      delete env.OPENAI_API_KEY;
       const result = spawnSync(process.execPath, [SCRIPT], {
         env: Object.assign(env, { NO_COLOR: '1' }),
         encoding: 'utf8',
       });
       assert.equal(result.status, cli.EXIT.CREDENTIAL_MISSING, `esperaba exit ${cli.EXIT.CREDENTIAL_MISSING}, fue ${result.status}. stderr=${result.stderr}`);
       assert.match(result.stderr, /credencial faltante/i);
-      assert.match(result.stderr, /ANTHROPIC_API_KEY/);
+      assert.match(result.stderr, /OPENAI_API_KEY/);
+    });
+  });
+
+  test('#3154 · fixture válida (launcher=claude) con env var faltante retorna exit 0 (bypass OAuth)', () => {
+    // #3154: launcher=claude delega auth al OAuth del CLI (`~/.claude/.credentials.json`),
+    // por lo que la ausencia de ANTHROPIC_API_KEY NO debe abortar el boot.
+    // Este test documenta el bypass a nivel CLI integration (complementa los
+    // tests unitarios en lib/__tests__/agent-models-validate.test.js).
+    withFixture('valid.json', () => {
+      const env = Object.assign({}, process.env);
+      delete env.ANTHROPIC_API_KEY;
+      const result = spawnSync(process.execPath, [SCRIPT], {
+        env: Object.assign(env, { NO_COLOR: '1' }),
+        encoding: 'utf8',
+      });
+      assert.equal(result.status, cli.EXIT.OK, `esperaba exit 0 (bypass claude), fue ${result.status}. stderr=${result.stderr}`);
+      assert.match(result.stdout, /Validación OK/);
     });
   });
 


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 5 archivos · +239 -21

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:skipped` aplicado por delivery

## Closes

Closes #3154
