### PR TITLE
bug(pipeline): preservar agentes en vuelo (restart/pause) + diferenciar rebote infra vs codigo

### DIFF
--- a/.pipeline/lib/__tests__/rebote-destino.test.js
+++ b/.pipeline/lib/__tests__/rebote-destino.test.js
@@ -1,0 +1,273 @@
+// .pipeline/lib/__tests__/rebote-destino.test.js
+// =============================================================================
+// Tests de lib/rebote-destino.js — issue #2374.
+//
+// Asegura el contrato del rebote:
+//   - rebote código  → faseRechazo (dev)
+//   - rebote infra   → MISMA fase (mono-skill: un solo skill; paralela: todos)
+//
+// Sin estos tests, una regresión silenciosa devolvería issues a dev cuando el
+// código no falló (timeout/watchdog/crash), causando ciclos de cómputo
+// duplicado — el incidente que motivó este issue (#2159: delivery #2159 muerto
+// por timeout de CI, rebotado erróneamente a backend-dev).
+// =============================================================================
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { resolveReboteDestino, FASES_MONO_SKILL } = require('../rebote-destino');
+
+// Configuración estándar de skills_por_fase (espejo del config.yaml).
+const SKILLS_POR_FASE = {
+  validacion: ['po', 'ux', 'guru'],
+  dev: ['backend-dev', 'android-dev', 'web-dev', 'pipeline-dev'],
+  build: ['build'],
+  verificacion: ['tester', 'security', 'qa'],
+  linteo: ['linter'],
+  aprobacion: ['review', 'po', 'ux'],
+  entrega: ['delivery'],
+};
+
+// Stub determinístico de determinarDevSkill — siempre devuelve el mismo skill
+// para evitar dependencia de labels reales.
+function fakeDetermineDevSkill(_issue, _config) {
+  return 'pipeline-dev';
+}
+
+// Stub determinístico de skillFromFile — extrae el sufijo después del primer punto.
+function fakeSkillFromFile(name) {
+  if (!name || typeof name !== 'string') return '';
+  const dot = name.indexOf('.');
+  return dot === -1 ? '' : name.slice(dot + 1);
+}
+
+// =============================================================================
+// REBOTE CÓDIGO — comportamiento histórico (preservar): destino = faseRechazo
+// =============================================================================
+
+test('rebote código en fase verificacion → faseRechazo (dev) con devSkill', () => {
+  const r = resolveReboteDestino({
+    esReboteDeInfra: false,
+    fase: 'verificacion',
+    faseRechazo: 'dev',
+    skillsPorFase: SKILLS_POR_FASE,
+    determinarDevSkill: fakeDetermineDevSkill,
+    rechazados: [{ file: { name: '1234.qa' }, motivo: 'tests fallan' }],
+    issue: 1234,
+    config: {},
+    skillFromFile: fakeSkillFromFile,
+  });
+  assert.equal(r.faseDestino, 'dev');
+  assert.deepEqual(r.skillsDestino, ['pipeline-dev']);
+});
+
+test('rebote código en fase aprobacion → faseRechazo (dev) con devSkill', () => {
+  const r = resolveReboteDestino({
+    esReboteDeInfra: false,
+    fase: 'aprobacion',
+    faseRechazo: 'dev',
+    skillsPorFase: SKILLS_POR_FASE,
+    determinarDevSkill: fakeDetermineDevSkill,
+    rechazados: [{ file: { name: '2000.review' }, motivo: 'review bloqueado' }],
+    issue: 2000,
+    config: {},
+    skillFromFile: fakeSkillFromFile,
+  });
+  assert.equal(r.faseDestino, 'dev');
+  assert.deepEqual(r.skillsDestino, ['pipeline-dev']);
+});
+
+test('rebote código en fase dev → faseRechazo (dev) — mismo destino (no regresión)', () => {
+  const r = resolveReboteDestino({
+    esReboteDeInfra: false,
+    fase: 'dev',
+    faseRechazo: 'dev',
+    skillsPorFase: SKILLS_POR_FASE,
+    determinarDevSkill: fakeDetermineDevSkill,
+    rechazados: [{ file: { name: '5.pipeline-dev' }, motivo: 'tests rotos' }],
+    issue: 5,
+    config: {},
+    skillFromFile: fakeSkillFromFile,
+  });
+  assert.equal(r.faseDestino, 'dev');
+  assert.deepEqual(r.skillsDestino, ['pipeline-dev']);
+});
+
+// =============================================================================
+// REBOTE INFRA — CAMBIO NUEVO #2374: destino = MISMA fase
+// =============================================================================
+
+test('rebote INFRA en fase entrega → MISMA fase entrega con skill delivery', () => {
+  // Caso canónico del issue #2374: delivery #2159 murió por timeout esperando
+  // CI. PR estaba creado con checks pass. Antes: rebotaba a dev/backend-dev.
+  // Ahora: re-encola en entrega/delivery.
+  const r = resolveReboteDestino({
+    esReboteDeInfra: true,
+    fase: 'entrega',
+    faseRechazo: 'dev',
+    skillsPorFase: SKILLS_POR_FASE,
+    determinarDevSkill: fakeDetermineDevSkill,
+    rechazados: [{ file: { name: '2159.delivery' }, motivo: 'watchdog timeout 90min' }],
+    issue: 2159,
+    config: {},
+    skillFromFile: fakeSkillFromFile,
+  });
+  assert.equal(r.faseDestino, 'entrega', 'destino debe ser entrega, NO dev');
+  assert.deepEqual(r.skillsDestino, ['delivery'], 'skill debe ser delivery, NO backend-dev');
+});
+
+test('rebote INFRA en fase build → MISMA fase build con skill build', () => {
+  const r = resolveReboteDestino({
+    esReboteDeInfra: true,
+    fase: 'build',
+    faseRechazo: 'dev',
+    skillsPorFase: SKILLS_POR_FASE,
+    determinarDevSkill: fakeDetermineDevSkill,
+    rechazados: [{ file: { name: '500.build' }, motivo: 'gradle crash OOM' }],
+    issue: 500,
+    config: {},
+    skillFromFile: fakeSkillFromFile,
+  });
+  assert.equal(r.faseDestino, 'build');
+  assert.deepEqual(r.skillsDestino, ['build']);
+});
+
+test('rebote INFRA en fase verificacion (paralela) → MISMA fase con TODOS los skills', () => {
+  // Multi-skill: si solo re-encoláramos qa, las próximas evaluaciones
+  // quedarían incompletas para siempre (tester+security en procesado).
+  const r = resolveReboteDestino({
+    esReboteDeInfra: true,
+    fase: 'verificacion',
+    faseRechazo: 'dev',
+    skillsPorFase: SKILLS_POR_FASE,
+    determinarDevSkill: fakeDetermineDevSkill,
+    rechazados: [{ file: { name: '777.qa' }, motivo: 'emulador timeout' }],
+    issue: 777,
+    config: {},
+    skillFromFile: fakeSkillFromFile,
+  });
+  assert.equal(r.faseDestino, 'verificacion');
+  assert.deepEqual(r.skillsDestino.sort(), ['qa', 'security', 'tester']);
+});
+
+test('rebote INFRA en fase aprobacion (paralela) → MISMA fase con TODOS los skills', () => {
+  const r = resolveReboteDestino({
+    esReboteDeInfra: true,
+    fase: 'aprobacion',
+    faseRechazo: 'dev',
+    skillsPorFase: SKILLS_POR_FASE,
+    determinarDevSkill: fakeDetermineDevSkill,
+    rechazados: [{ file: { name: '900.review' }, motivo: 'gh api timeout' }],
+    issue: 900,
+    config: {},
+    skillFromFile: fakeSkillFromFile,
+  });
+  assert.equal(r.faseDestino, 'aprobacion');
+  assert.deepEqual(r.skillsDestino.sort(), ['po', 'review', 'ux']);
+});
+
+test('rebote INFRA en fase dev → MISMA fase dev con devSkill resuelto por labels', () => {
+  // dev es mono-skill funcional (varios skills declarados pero solo 1 corre
+  // por issue, según labels). Re-encolar usando determinarDevSkill.
+  const r = resolveReboteDestino({
+    esReboteDeInfra: true,
+    fase: 'dev',
+    faseRechazo: 'dev',
+    skillsPorFase: SKILLS_POR_FASE,
+    determinarDevSkill: fakeDetermineDevSkill,
+    rechazados: [{ file: { name: '42.pipeline-dev' }, motivo: 'crash de claude.exe' }],
+    issue: 42,
+    config: {},
+    skillFromFile: fakeSkillFromFile,
+  });
+  assert.equal(r.faseDestino, 'dev');
+  assert.deepEqual(r.skillsDestino, ['pipeline-dev']);
+});
+
+// =============================================================================
+// FALLBACKS DEFENSIVOS — config rota / fase no declarada
+// =============================================================================
+
+test('fallback: rebote infra con fase no declarada en skills_por_fase → usa skills de rechazados', () => {
+  const r = resolveReboteDestino({
+    esReboteDeInfra: true,
+    fase: 'fase-fantasma',
+    faseRechazo: 'dev',
+    skillsPorFase: SKILLS_POR_FASE, // no contiene 'fase-fantasma'
+    determinarDevSkill: fakeDetermineDevSkill,
+    rechazados: [
+      { file: { name: '1.skillA' }, motivo: 'x' },
+      { file: { name: '1.skillB' }, motivo: 'y' },
+    ],
+    issue: 1,
+    config: {},
+    skillFromFile: fakeSkillFromFile,
+  });
+  assert.equal(r.faseDestino, 'fase-fantasma');
+  assert.deepEqual(r.skillsDestino.sort(), ['skillA', 'skillB']);
+});
+
+test('fallback: rebote infra con skills_por_fase vacío en la fase → usa skills de rechazados', () => {
+  const r = resolveReboteDestino({
+    esReboteDeInfra: true,
+    fase: 'verificacion',
+    faseRechazo: 'dev',
+    skillsPorFase: { verificacion: [] },
+    determinarDevSkill: fakeDetermineDevSkill,
+    rechazados: [{ file: { name: '3.qa' }, motivo: 'timeout' }],
+    issue: 3,
+    config: {},
+    skillFromFile: fakeSkillFromFile,
+  });
+  assert.equal(r.faseDestino, 'verificacion');
+  assert.deepEqual(r.skillsDestino, ['qa']);
+});
+
+test('fallback: rebote infra sin determinarDevSkill (dev) → fallback a rechazados', () => {
+  const r = resolveReboteDestino({
+    esReboteDeInfra: true,
+    fase: 'dev',
+    faseRechazo: 'dev',
+    skillsPorFase: SKILLS_POR_FASE,
+    determinarDevSkill: null,
+    rechazados: [{ file: { name: '7.backend-dev' }, motivo: 'x' }],
+    issue: 7,
+    config: {},
+    skillFromFile: fakeSkillFromFile,
+  });
+  assert.equal(r.faseDestino, 'dev');
+  assert.deepEqual(r.skillsDestino, ['backend-dev']);
+});
+
+test('fallback: rebote código sin determinarDevSkill → skillsDestino vacío (caller debe loggear)', () => {
+  const r = resolveReboteDestino({
+    esReboteDeInfra: false,
+    fase: 'verificacion',
+    faseRechazo: 'dev',
+    skillsPorFase: SKILLS_POR_FASE,
+    determinarDevSkill: null,
+    rechazados: [{ file: { name: '8.qa' }, motivo: 'x' }],
+    issue: 8,
+    config: {},
+    skillFromFile: fakeSkillFromFile,
+  });
+  // Comportamiento conservador: no inventamos un skill — el caller debe
+  // detectar destino vacío y escalar (no perder rebote silenciosamente).
+  assert.equal(r.faseDestino, 'dev');
+  assert.deepEqual(r.skillsDestino, []);
+});
+
+// =============================================================================
+// EXPORTS
+// =============================================================================
+
+test('FASES_MONO_SKILL exporta el set canónico', () => {
+  assert.ok(FASES_MONO_SKILL.has('dev'));
+  assert.ok(FASES_MONO_SKILL.has('build'));
+  assert.ok(FASES_MONO_SKILL.has('entrega'));
+  assert.ok(!FASES_MONO_SKILL.has('verificacion'));
+  assert.ok(!FASES_MONO_SKILL.has('validacion'));
+  assert.ok(!FASES_MONO_SKILL.has('aprobacion'));
+});

--- a/.pipeline/lib/__tests__/restart-orphan-annotator.test.js
+++ b/.pipeline/lib/__tests__/restart-orphan-annotator.test.js
@@ -1,0 +1,301 @@
+// .pipeline/lib/__tests__/restart-orphan-annotator.test.js
+// =============================================================================
+// Tests del helper `restart-orphan-annotator.js` — issue #2374 Parte 1.
+//
+// Asegura que cuando un restart interrumpe agentes en vuelo:
+//   - Sus YAMLs en `trabajando/` se mueven a `pendiente/`.
+//   - El contenido del YAML SE PRESERVA íntegro (no perdemos `rebote_numero`,
+//     `motivo_rechazo`, etc).
+//   - Se anota `restart_interrupted: true` y `restart_at: <ISO>` para que el
+//     agente re-lanzado sepa que fue un corte por restart.
+//   - Es idempotente: dos restarts consecutivos sin que el agente arranque no
+//     duplican las claves.
+//   - Defensive: archivos no-YAML caen al rename atómico clásico (preserva
+//     comportamiento histórico).
+// =============================================================================
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  annotateAndMoveOrphans,
+  annotateContent,
+  AGENTE_FILE_REGEX,
+} = require('../restart-orphan-annotator');
+
+function freshTmpDir(prefix = 'v3-restart-annot-') {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function setupPipelineRoot(tmpRoot, pipeline, fase, files) {
+  const trabajando = path.join(tmpRoot, pipeline, fase, 'trabajando');
+  const pendiente = path.join(tmpRoot, pipeline, fase, 'pendiente');
+  fs.mkdirSync(trabajando, { recursive: true });
+  fs.mkdirSync(pendiente, { recursive: true });
+  for (const [name, content] of Object.entries(files)) {
+    fs.writeFileSync(path.join(trabajando, name), content);
+  }
+  return { trabajando, pendiente };
+}
+
+// =============================================================================
+// CONTENIDO ANOTADO
+// =============================================================================
+
+test('annotateContent agrega las claves al final de un YAML', () => {
+  const raw = 'issue: 2159\nfase: entrega\npipeline: desarrollo';
+  const out = annotateContent(raw, '2026-05-15T00:00:00Z');
+  assert.match(out, /restart_interrupted: true/);
+  assert.match(out, /restart_at: '2026-05-15T00:00:00Z'/);
+  // El contenido original sigue presente íntegro
+  assert.match(out, /issue: 2159/);
+  assert.match(out, /fase: entrega/);
+  assert.match(out, /pipeline: desarrollo/);
+});
+
+test('annotateContent es idempotente (no duplica si ya tiene la marca)', () => {
+  const raw = "issue: 1\nrestart_interrupted: true\nrestart_at: '2026-01-01T00:00:00Z'\n";
+  const out = annotateContent(raw, '2026-05-15T00:00:00Z');
+  assert.equal(out, raw, 'segundo restart no debe agregar otra marca');
+  const occurrences = (out.match(/restart_interrupted:/g) || []).length;
+  assert.equal(occurrences, 1, 'restart_interrupted debe aparecer una sola vez');
+});
+
+test('annotateContent maneja YAML con trailing newlines sin duplicarlas', () => {
+  const raw = 'issue: 2159\n\n\n';
+  const out = annotateContent(raw, '2026-05-15T00:00:00Z');
+  // No queremos `\n\n\nrestart_...` — recortamos el whitespace final.
+  assert.match(out, /issue: 2159\nrestart_interrupted/);
+});
+
+// =============================================================================
+// AGENTE_FILE_REGEX — filtro de archivos válidos
+// =============================================================================
+
+test('AGENTE_FILE_REGEX acepta nombres canónicos issue.skill', () => {
+  assert.ok(AGENTE_FILE_REGEX.test('1915.qa'));
+  assert.ok(AGENTE_FILE_REGEX.test('2441.guru'));
+  assert.ok(AGENTE_FILE_REGEX.test('2159.delivery'));
+  assert.ok(AGENTE_FILE_REGEX.test('5.pipeline-dev'));
+});
+
+test('AGENTE_FILE_REGEX rechaza .gitkeep, README y otros no-agentes', () => {
+  assert.ok(!AGENTE_FILE_REGEX.test('.gitkeep'));
+  assert.ok(!AGENTE_FILE_REGEX.test('README.md'));
+  assert.ok(!AGENTE_FILE_REGEX.test('1915'));
+  assert.ok(!AGENTE_FILE_REGEX.test('.hidden'));
+  assert.ok(!AGENTE_FILE_REGEX.test('a.b.c'));
+  assert.ok(!AGENTE_FILE_REGEX.test('1234.QA')); // case-sensitive: skills son lowercase
+});
+
+// =============================================================================
+// FLUJO COMPLETO — mover + anotar
+// =============================================================================
+
+test('mueve archivos de trabajando/ a pendiente/ con marca de restart', () => {
+  const root = freshTmpDir();
+  setupPipelineRoot(root, 'desarrollo', 'entrega', {
+    '2159.delivery': 'issue: 2159\nfase: entrega\npipeline: desarrollo\n',
+  });
+
+  const result = annotateAndMoveOrphans({
+    pipelineRoot: root,
+    pipelinesScan: ['desarrollo'],
+    restartAt: '2026-05-15T12:00:00Z',
+  });
+
+  assert.equal(result.movedCount, 1);
+  const trabajando = path.join(root, 'desarrollo', 'entrega', 'trabajando', '2159.delivery');
+  const pendiente = path.join(root, 'desarrollo', 'entrega', 'pendiente', '2159.delivery');
+  assert.ok(!fs.existsSync(trabajando), 'archivo origen debe haberse borrado');
+  assert.ok(fs.existsSync(pendiente), 'archivo destino debe existir en pendiente');
+
+  const content = fs.readFileSync(pendiente, 'utf8');
+  assert.match(content, /issue: 2159/);
+  assert.match(content, /restart_interrupted: true/);
+  assert.match(content, /restart_at: '2026-05-15T12:00:00Z'/);
+});
+
+test('preserva contenido original íntegro (rebote_numero, motivo_rechazo, etc)', () => {
+  const root = freshTmpDir();
+  const original = [
+    'issue: 2159',
+    'fase: entrega',
+    'pipeline: desarrollo',
+    'rebote: true',
+    'rebote_numero: 2',
+    'rebote_tipo: infra',
+    "motivo_rechazo: 'watchdog timeout 90min'",
+    'rechazado_en_fase: entrega',
+    '',
+  ].join('\n');
+  setupPipelineRoot(root, 'desarrollo', 'entrega', {
+    '2159.delivery': original,
+  });
+
+  annotateAndMoveOrphans({
+    pipelineRoot: root,
+    pipelinesScan: ['desarrollo'],
+    restartAt: '2026-05-15T12:00:00Z',
+  });
+
+  const content = fs.readFileSync(
+    path.join(root, 'desarrollo', 'entrega', 'pendiente', '2159.delivery'),
+    'utf8',
+  );
+  // Cada clave original debe estar presente.
+  for (const key of ['rebote: true', 'rebote_numero: 2', 'rebote_tipo: infra', 'rechazado_en_fase: entrega']) {
+    assert.ok(content.includes(key), `falta la clave preservada "${key}"`);
+  }
+});
+
+test('idempotencia: dos restarts consecutivos no duplican la marca', () => {
+  const root = freshTmpDir();
+  setupPipelineRoot(root, 'desarrollo', 'dev', {
+    '42.backend-dev': 'issue: 42\nfase: dev\npipeline: desarrollo\n',
+  });
+
+  // Primer restart
+  annotateAndMoveOrphans({
+    pipelineRoot: root,
+    pipelinesScan: ['desarrollo'],
+    restartAt: '2026-05-15T10:00:00Z',
+  });
+
+  // Simulación: el agente no arrancó todavía, restart segundo lo agarra en pendiente.
+  // Para reproducir un escenario válido del helper movemos manualmente al trabajando
+  // de nuevo (como si el pulpo hubiera empezado y matado al child sin que el agente
+  // llegara a hacer trabajo real).
+  const pendientePath = path.join(root, 'desarrollo', 'dev', 'pendiente', '42.backend-dev');
+  const trabajandoPath = path.join(root, 'desarrollo', 'dev', 'trabajando', '42.backend-dev');
+  fs.renameSync(pendientePath, trabajandoPath);
+
+  // Segundo restart
+  annotateAndMoveOrphans({
+    pipelineRoot: root,
+    pipelinesScan: ['desarrollo'],
+    restartAt: '2026-05-15T11:00:00Z',
+  });
+
+  const content = fs.readFileSync(pendientePath, 'utf8');
+  const occurrences = (content.match(/restart_interrupted:/g) || []).length;
+  assert.equal(occurrences, 1, 'restart_interrupted no debe duplicarse en restarts consecutivos');
+});
+
+test('archivos no-YAML caen al rename clásico (preserva comportamiento histórico)', () => {
+  const root = freshTmpDir();
+  setupPipelineRoot(root, 'desarrollo', 'entrega', {
+    '2159.delivery': '!@#binary garbage no es yaml!@#',
+  });
+
+  const result = annotateAndMoveOrphans({
+    pipelineRoot: root,
+    pipelinesScan: ['desarrollo'],
+    restartAt: '2026-05-15T12:00:00Z',
+  });
+
+  assert.equal(result.movedCount, 1);
+  const pendiente = path.join(root, 'desarrollo', 'entrega', 'pendiente', '2159.delivery');
+  assert.ok(fs.existsSync(pendiente), 'el archivo debe moverse igualmente para no perderse');
+  const content = fs.readFileSync(pendiente, 'utf8');
+  // No anota porque no parece YAML; el contenido se preserva tal cual.
+  assert.equal(content, '!@#binary garbage no es yaml!@#');
+});
+
+test('filtra .gitkeep y archivos no-agente', () => {
+  const root = freshTmpDir();
+  setupPipelineRoot(root, 'desarrollo', 'entrega', {
+    '2159.delivery': 'issue: 2159\n',
+    '.gitkeep': '',
+    'README.md': 'docs',
+  });
+
+  const result = annotateAndMoveOrphans({
+    pipelineRoot: root,
+    pipelinesScan: ['desarrollo'],
+    restartAt: '2026-05-15T12:00:00Z',
+  });
+
+  assert.equal(result.movedCount, 1, 'sólo el archivo de agente debe contar');
+  const trabajando = path.join(root, 'desarrollo', 'entrega', 'trabajando');
+  assert.ok(fs.existsSync(path.join(trabajando, '.gitkeep')));
+  assert.ok(fs.existsSync(path.join(trabajando, 'README.md')));
+});
+
+test('barre múltiples pipelines (desarrollo + definicion) sin colisión', () => {
+  const root = freshTmpDir();
+  setupPipelineRoot(root, 'desarrollo', 'entrega', {
+    '2159.delivery': 'issue: 2159\nfase: entrega\n',
+  });
+  setupPipelineRoot(root, 'definicion', 'analisis', {
+    '3000.guru': 'issue: 3000\nfase: analisis\n',
+  });
+
+  const result = annotateAndMoveOrphans({
+    pipelineRoot: root,
+    pipelinesScan: ['desarrollo', 'definicion'],
+    restartAt: '2026-05-15T12:00:00Z',
+  });
+
+  assert.equal(result.movedCount, 2);
+  assert.ok(fs.existsSync(path.join(root, 'desarrollo', 'entrega', 'pendiente', '2159.delivery')));
+  assert.ok(fs.existsSync(path.join(root, 'definicion', 'analisis', 'pendiente', '3000.guru')));
+});
+
+test('no-op cuando trabajando/ está vacío', () => {
+  const root = freshTmpDir();
+  setupPipelineRoot(root, 'desarrollo', 'entrega', {});
+
+  const result = annotateAndMoveOrphans({
+    pipelineRoot: root,
+    pipelinesScan: ['desarrollo'],
+    restartAt: '2026-05-15T12:00:00Z',
+  });
+
+  assert.equal(result.movedCount, 0);
+});
+
+test('no falla si el pipeline scaneado no existe en disco', () => {
+  const root = freshTmpDir();
+  // No creamos `definicion/`.
+  setupPipelineRoot(root, 'desarrollo', 'entrega', {
+    '2159.delivery': 'issue: 2159\n',
+  });
+
+  const result = annotateAndMoveOrphans({
+    pipelineRoot: root,
+    pipelinesScan: ['desarrollo', 'definicion'],
+    restartAt: '2026-05-15T12:00:00Z',
+  });
+
+  assert.equal(result.movedCount, 1);
+});
+
+test('throws si falta pipelineRoot', () => {
+  assert.throws(
+    () => annotateAndMoveOrphans({}),
+    /pipelineRoot/,
+  );
+});
+
+test('default scan desarrollo+definicion cuando no se especifica pipelinesScan', () => {
+  const root = freshTmpDir();
+  setupPipelineRoot(root, 'desarrollo', 'entrega', {
+    '2159.delivery': 'issue: 2159\n',
+  });
+  setupPipelineRoot(root, 'definicion', 'analisis', {
+    '3000.guru': 'issue: 3000\n',
+  });
+
+  const result = annotateAndMoveOrphans({
+    pipelineRoot: root,
+    restartAt: '2026-05-15T12:00:00Z',
+  });
+
+  assert.equal(result.movedCount, 2);
+});

--- a/.pipeline/lib/rebote-destino.js
+++ b/.pipeline/lib/rebote-destino.js
@@ -1,0 +1,110 @@
+// .pipeline/lib/rebote-destino.js
+// =============================================================================
+// Resolución del destino de un rebote — fase + skills a re-encolar.
+//
+// Issue #2374: diferenciar rebote infra vs código.
+//
+// Contrato (puro, sin side-effects):
+//   resolveReboteDestino({
+//     esReboteDeInfra,   // boolean — true si la clasificación dio infra
+//     fase,              // string — fase actual donde ocurrió el rechazo
+//     faseRechazo,       // string|null — fase configurada para rebote código (ej. 'dev')
+//     skillsPorFase,     // object — pipelineConfig.skills_por_fase
+//     determinarDevSkill,// function(issue, config) → skill (sólo se usa para dev/codigo)
+//     rechazados,        // array de { file: {name}, motivo? } — para fallback defensivo
+//     issue,             // string|number — id del issue
+//     config,            // object — config completo (sólo se pasa a determinarDevSkill)
+//     skillFromFile,     // function(filename) → skill — para fallback defensivo
+//   }) → { faseDestino, skillsDestino }
+//
+// Reglas:
+//   - rebote código → faseDestino = faseRechazo, skillsDestino = [determinarDevSkill(issue, config)]
+//     Razón: el dev tiene que corregir el código. El skill se elige por labels
+//     del issue (mismo criterio que el promotor a dev).
+//
+//   - rebote infra → faseDestino = fase (misma), skillsDestino dependen del shape de la fase:
+//       * fases mono-skill (dev/build/entrega): re-encolar el único skill.
+//         Para `dev`, determinarDevSkill resuelve por labels.
+//       * fases paralelas (validación/verificación/aprobación): re-encolar TODOS
+//         los skills_por_fase. No basta con re-encolar sólo el skill que falló,
+//         porque los archivos en listo/ de skills que aprobaron se mueven a
+//         procesado/ al final del barrido y la próxima evaluación quedaría
+//         incompleta para siempre (faltan resultados de los demás).
+//
+//   - Fallback defensivo: si por config rota o fase desconocida no resolvimos
+//     skills, caemos a los skills de los archivos rechazados — para no perder
+//     el rebote silenciosamente.
+//
+// El módulo es puro: NO toca filesystem. El caller (pulpo.js) lee el resultado
+// y escribe los YAMLs en `<faseDestino>/pendiente/`.
+// =============================================================================
+
+'use strict';
+
+// Fases de "un solo skill" — el resto se asume paralelo multi-skill.
+// Sincronizado con pulpo.js:3463-3473 (lógica de promoción entre fases).
+const FASES_MONO_SKILL = new Set(['dev', 'build', 'entrega']);
+
+function resolveReboteDestino(opts) {
+  const {
+    esReboteDeInfra,
+    fase,
+    faseRechazo,
+    skillsPorFase = {},
+    determinarDevSkill,
+    rechazados = [],
+    issue,
+    config = {},
+    skillFromFile,
+  } = opts;
+
+  // Rebote código → comportamiento histórico (a faseRechazo, dev).
+  if (!esReboteDeInfra) {
+    const devSkill = typeof determinarDevSkill === 'function'
+      ? determinarDevSkill(issue, config)
+      : null;
+    return {
+      faseDestino: faseRechazo,
+      skillsDestino: devSkill ? [devSkill] : [],
+    };
+  }
+
+  // Rebote infra → misma fase. Skills dependen del shape de la fase.
+  let skillsDestino;
+  if (FASES_MONO_SKILL.has(fase)) {
+    if (fase === 'dev') {
+      const devSkill = typeof determinarDevSkill === 'function'
+        ? determinarDevSkill(issue, config)
+        : null;
+      skillsDestino = devSkill ? [devSkill] : [];
+    } else {
+      const skillsArr = skillsPorFase[fase] || [];
+      skillsDestino = skillsArr.length > 0 ? [skillsArr[0]] : [];
+    }
+  } else {
+    // Fase paralela: re-encolar TODOS los skills declarados.
+    skillsDestino = (skillsPorFase[fase] || []).slice();
+  }
+
+  // Fallback defensivo: si no resolvimos nada, usar los skills de los archivos
+  // rechazados. Esto evita que un rebote infra se pierda silenciosamente si la
+  // config tiene una fase no declarada o `skills_por_fase` está corrupto.
+  if (skillsDestino.length === 0 && typeof skillFromFile === 'function') {
+    const fallback = [...new Set(
+      rechazados
+        .map(r => skillFromFile((r.file && r.file.name) || ''))
+        .filter(Boolean)
+    )];
+    skillsDestino = fallback;
+  }
+
+  return {
+    faseDestino: fase,
+    skillsDestino,
+  };
+}
+
+module.exports = {
+  resolveReboteDestino,
+  FASES_MONO_SKILL,
+};

--- a/.pipeline/lib/restart-orphan-annotator.js
+++ b/.pipeline/lib/restart-orphan-annotator.js
@@ -1,0 +1,111 @@
+// .pipeline/lib/restart-orphan-annotator.js
+// =============================================================================
+// Mueve archivos huérfanos de `trabajando/` → `pendiente/` durante un restart,
+// anotando trazabilidad sobre la interrupción.
+//
+// Issue #2374 Parte 1 — preservación de trabajo interrumpido por restart.
+//
+// Contrato:
+//   annotateAndMoveOrphans({ pipelineRoot, pipelinesScan, restartAt }) → { movedCount }
+//
+//   - pipelineRoot:   absoluto, raíz del `.pipeline/` (donde viven los dirs
+//                     `desarrollo/` y `definicion/`).
+//   - pipelinesScan:  array de nombres de subcarpetas de pipelines a barrer
+//                     (default: ['desarrollo', 'definicion']).
+//   - restartAt:      ISO string del timestamp del restart.
+//
+//   Por cada archivo `<issue>.<skill>` en `<pipeline>/<fase>/trabajando/`:
+//     1. Lee el contenido.
+//     2. Si parece YAML estructurado y NO tiene ya `restart_interrupted:`,
+//        agrega las claves `restart_interrupted: true` y `restart_at: <ISO>`.
+//     3. Escribe el resultado en `<pipeline>/<fase>/pendiente/<f>`.
+//     4. Borra el origen.
+//
+//   Idempotente: si el archivo ya tiene la marca (caso patológico de dos
+//   restarts consecutivos sin que el agente arranque) no la duplica.
+//
+//   Defensivo: si la lectura/parseo falla, hace un rename clásico para no
+//   perder el archivo (comportamiento histórico pre-#2374).
+//
+// El módulo es side-effect heavy (toca el filesystem) pero está acotado a
+// `pipelineRoot` para test con un tmpdir.
+// =============================================================================
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+// `<issueId>.<skill>` — ej. `1915.qa`, `2441.guru`. Filtra `.gitkeep` y otros.
+const AGENTE_FILE_REGEX = /^\d+\.[a-z][a-z0-9-]*$/;
+
+// Heurística simple para detectar YAML estructurado: empieza con una clave
+// de identificador seguido de `:`.
+const YAML_LIKE_RE = /^\s*[a-zA-Z_][a-zA-Z0-9_-]*\s*:/;
+
+function annotateContent(raw, restartAt) {
+  if (raw.includes('restart_interrupted:')) return raw; // idempotente
+  const trimmed = raw.replace(/\s*$/, '');
+  return `${trimmed}\nrestart_interrupted: true\nrestart_at: '${restartAt}'\n`;
+}
+
+function annotateAndMoveOrphans(opts) {
+  const {
+    pipelineRoot,
+    pipelinesScan = ['desarrollo', 'definicion'],
+    restartAt,
+  } = opts;
+
+  if (!pipelineRoot || typeof pipelineRoot !== 'string') {
+    throw new Error('annotateAndMoveOrphans: pipelineRoot requerido');
+  }
+  const stamp = restartAt || new Date().toISOString();
+
+  let movedCount = 0;
+
+  for (const pipeline of pipelinesScan) {
+    const pipeDir = path.join(pipelineRoot, pipeline);
+    if (!fs.existsSync(pipeDir)) continue;
+    let fases;
+    try { fases = fs.readdirSync(pipeDir); } catch { continue; }
+    for (const fase of fases) {
+      const trabajando = path.join(pipeDir, fase, 'trabajando');
+      const pendiente = path.join(pipeDir, fase, 'pendiente');
+      if (!fs.existsSync(trabajando)) continue;
+      try {
+        if (!fs.existsSync(pendiente)) fs.mkdirSync(pendiente, { recursive: true });
+      } catch { continue; }
+
+      let entries;
+      try { entries = fs.readdirSync(trabajando); } catch { continue; }
+      for (const f of entries) {
+        if (!AGENTE_FILE_REGEX.test(f)) continue;
+        const srcPath = path.join(trabajando, f);
+        const dstPath = path.join(pendiente, f);
+        let annotated = false;
+        try {
+          const raw = fs.readFileSync(srcPath, 'utf8');
+          if (raw && YAML_LIKE_RE.test(raw)) {
+            fs.writeFileSync(dstPath, annotateContent(raw, stamp));
+            try { fs.unlinkSync(srcPath); } catch {}
+            annotated = true;
+          }
+        } catch {
+          // I/O falló — caemos al rename clásico abajo.
+        }
+        if (!annotated) {
+          try { fs.renameSync(srcPath, dstPath); } catch {}
+        }
+        movedCount++;
+      }
+    }
+  }
+
+  return { movedCount };
+}
+
+module.exports = {
+  annotateAndMoveOrphans,
+  annotateContent,
+  AGENTE_FILE_REGEX,
+};

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -51,6 +51,8 @@ const {
 // crea marker en `bloqueado-humano/`, se aplica label `blocked:dependencies`
 // y el brazoDesbloqueo (ya existente) destraba cuando todas las deps cierren.
 const reboteClassifier = require('./lib/rebote-classifier');
+// #2374 — Destino del rebote (faseRechazo para código, misma fase para infra)
+const { resolveReboteDestino } = require('./lib/rebote-destino');
 // #2893 — Detección de dependencias del allowlist en pausa parcial
 const partialPauseDeps = require('./lib/partial-pause-deps');
 // #2801 — emit session:start/end por cada lanzamiento de agente Claude (LLM)
@@ -3382,12 +3384,6 @@ function brazoBarrido(config) {
             }
           }
 
-          const devPendiente = path.join(fasePath(pipelineName, faseRechazo), 'pendiente');
-
-          // Determinar qué skill de dev corresponde
-          const devSkill = determinarDevSkill(issue, config);
-          const devFile = path.join(devPendiente, `${issue}.${devSkill}`);
-
           // #2317: clasificar el rebote. Si el motivo apunta a infra,
           // marcarlo como `rebote_tipo: infra` y NO incrementar el contador
           // efectivo del circuit breaker (se preserva el reboteCount anterior).
@@ -3400,6 +3396,41 @@ function brazoBarrido(config) {
           const nuevoReboteNumero = esReboteDeInfra ? reboteCount : (reboteCount + 1);
           const nuevoReboteInfraNumero = esReboteDeInfra ? (reboteInfraCount + 1) : reboteInfraCount;
 
+          // #2374 — diferenciar destino del rebote según tipo:
+          //   - codigo:  faseRechazo (dev) — el dev tiene que corregir el código.
+          //   - infra:   MISMA fase — el watchdog/timeout/crash es transitorio,
+          //              no hay defecto de código que corregir, sólo reintentar.
+          //
+          // Incidente que motivó esta separación: delivery de #2159 murió por
+          // timeout esperando CI (OWASP ~28min). PR ya estaba creado con
+          // checks pass, pero el pipeline devolvió el issue a dev como si
+          // backend-dev hubiera fallado → re-run completo (horas de cómputo
+          // duplicado: backend-dev + builder + tester + qa + review + delivery).
+          //
+          // Estrategia de skills destino (ver .pipeline/lib/rebote-destino.js
+          // para el contrato puro testeable):
+          //   - dev/build/entrega: fases mono-skill. Re-encolamos ese único skill.
+          //     Para `dev`, determinarDevSkill resuelve por labels del issue.
+          //   - validación/verificación/aprobación: fases paralelas multi-skill.
+          //     Re-encolamos TODOS los skills_por_fase porque los archivos en
+          //     listo/ de skills que aprobaron se mueven a procesado/ al final
+          //     del barrido (línea 3547). Si re-encoláramos solo el skill que
+          //     falló por infra, la próxima evaluación quedaría incompleta para
+          //     siempre (faltarían los listo/ de los demás skills_requeridos).
+          const { faseDestino, skillsDestino } = resolveReboteDestino({
+            esReboteDeInfra,
+            fase,
+            faseRechazo,
+            skillsPorFase: pipelineConfig.skills_por_fase || {},
+            determinarDevSkill,
+            rechazados,
+            issue,
+            config,
+            skillFromFile,
+          });
+
+          const destinoPendiente = path.join(fasePath(pipelineName, faseDestino), 'pendiente');
+
           // #2333: sanitizar el motivo de rechazo antes de persistirlo en
           // el YAML del archivo de trabajo. Esto evita que un log con
           // tokens/JWT/PEM termine en el próximo archivo que se lee y
@@ -3408,7 +3439,7 @@ function brazoBarrido(config) {
           // cuando hubo al menos un rebote infra clasificado.
           const yamlOut = {
             issue: parseInt(issue),
-            fase: faseRechazo,
+            fase: faseDestino,
             pipeline: pipelineName,
             rebote: true,
             rebote_numero: nuevoReboteNumero,
@@ -3419,16 +3450,20 @@ function brazoBarrido(config) {
           if (nuevoReboteInfraNumero > 0) {
             yamlOut.rebote_numero_infra = nuevoReboteInfraNumero;
           }
-          writeYaml(devFile, yamlOut);
+          for (const skill of skillsDestino) {
+            const destinoFile = path.join(destinoPendiente, `${issue}.${skill}`);
+            writeYaml(destinoFile, yamlOut);
+          }
 
           if (esReboteDeInfra) {
-            log('barrido', `#${issue} RECHAZADO en ${fase} por INFRA → devuelto a ${faseRechazo} (rebote_numero_infra=${nuevoReboteInfraNumero}/${MAX_REBOTES_INFRA} — NO cuenta contra circuit breaker generico)`);
+            const skillsStr = skillsDestino.join(',') || '(ninguno)';
+            log('barrido', `#${issue} RECHAZADO en ${fase} por INFRA → REENCOLADO en MISMA fase '${faseDestino}' [${skillsStr}] (rebote_numero_infra=${nuevoReboteInfraNumero}/${MAX_REBOTES_INFRA} — NO cuenta contra circuit breaker generico, NO devuelto a dev)`);
             ghCommentOnIssue(
               issue,
-              `🚫 Bloqueado por infra #2314 — rebote clasificado como infra (no cuenta contra el circuit breaker). Se reintentará al restaurar conectividad.`,
+              `🚫 Rebote clasificado como infra (#2374) — reintentando en \`${faseDestino}\` sin devolver a \`dev\` (el código no falló, sólo timeout/crash/watchdog). No cuenta contra el circuit breaker de código.`,
             );
           } else {
-            log('barrido', `#${issue} RECHAZADO en ${fase} → devuelto a ${faseRechazo} (rebote ${nuevoReboteNumero}/${MAX_REBOTES})`);
+            log('barrido', `#${issue} RECHAZADO en ${fase} → devuelto a ${faseDestino} (rebote ${nuevoReboteNumero}/${MAX_REBOTES})`);
           }
 
           // CLEANUP DOWNSTREAM: limpiar archivos residuales del issue en fases posteriores.

--- a/.pipeline/restart.js
+++ b/.pipeline/restart.js
@@ -23,6 +23,7 @@ const {
   SCRIPT_MAP,
 } = require('./pid-discovery');
 const { clearAllMarkers } = require('./lib/ready-marker');
+const { annotateAndMoveOrphans } = require('./lib/restart-orphan-annotator');
 
 // Saneado global de JAVA_HOME — si restart.js heredó una ruta stale (ej. JBR
 // de IntelliJ obsoleto), la corregimos antes de spawnear pulpo/servicios, así
@@ -181,28 +182,31 @@ function killAll() {
   // dueño; sin esta limpieza, el mecanismo [huerfanos] del Pulpo tarda hasta
   // `orphan_timeout_minutes` (10min default) en moverlos — dejando el
   // dashboard mostrando "activos" agentes que ya no existen.
-  // Formato de archivo de agente: `<issueId>.<skill>` (ej. 1915.qa, 2441.guru).
-  // Filtramos `.gitkeep` y cualquier otro archivo sin ese patrón.
-  const agenteFileRegex = /^\d+\.[a-z][a-z0-9-]*$/;
-  let orphansMoved = 0;
-  for (const pipeline of ['desarrollo', 'definicion']) {
-    const pipeDir = path.join(PIPELINE, pipeline);
-    if (!fs.existsSync(pipeDir)) continue;
-    for (const fase of fs.readdirSync(pipeDir)) {
-      const trabajando = path.join(pipeDir, fase, 'trabajando');
-      const pendiente = path.join(pipeDir, fase, 'pendiente');
-      if (!fs.existsSync(trabajando)) continue;
-      try {
-        if (!fs.existsSync(pendiente)) fs.mkdirSync(pendiente, { recursive: true });
-        for (const f of fs.readdirSync(trabajando)) {
-          if (!agenteFileRegex.test(f)) continue;
-          fs.renameSync(path.join(trabajando, f), path.join(pendiente, f));
-          orphansMoved++;
-        }
-      } catch {}
-    }
-  }
-  if (orphansMoved > 0) log(`  ${orphansMoved} agente(s) huérfano(s) de fases → pendiente/`);
+  //
+  // #2374 Parte 1 — preservación de trabajo interrumpido por restart:
+  //   Hoy `killAll()` mata claude.exe (spawn no-detached), por lo que el
+  //   trabajo en memoria del agente se pierde. El YAML del archivo SE PRESERVA
+  //   (el helper lo escribe íntegro en `pendiente/`), pero el agente re-lanzado
+  //   parte de cero. Para dejar trazabilidad del corte el helper agrega al
+  //   YAML las claves `restart_interrupted: true` y `restart_at: <ISO>` — el
+  //   agente que re-tome el archivo verá explícitamente que es un re-run
+  //   post-restart y puede decidir comportamiento defensivo (por ejemplo,
+  //   builder puede limpiar daemons stale antes de empezar).
+  //
+  //   Hot-restart real (preservar el proceso del agente vivo, sin matarlo,
+  //   y que el nuevo pulpo lo reattach) requiere `detached:true` en
+  //   `lib/agent-launcher.js`, persistencia de PID + heartbeat, y handler de
+  //   reattach en pulpo.js. Esa entrega queda como follow-up por el riesgo
+  //   regresivo en el spawn.
+  //
+  //   El helper `annotateAndMoveOrphans` está testeado en
+  //   `lib/__tests__/restart-orphan-annotator.test.js`.
+  const { movedCount: orphansMoved } = annotateAndMoveOrphans({
+    pipelineRoot: PIPELINE,
+    pipelinesScan: ['desarrollo', 'definicion'],
+    restartAt: new Date().toISOString(),
+  });
+  if (orphansMoved > 0) log(`  ${orphansMoved} agente(s) interrumpido(s) por restart → pendiente/ (marcados con restart_interrupted: true)`);
 
   // Escribir timestamp de último restart para evitar restarts encadenados
   try {

--- a/.pipeline/tests/pause-contract-docs.test.js
+++ b/.pipeline/tests/pause-contract-docs.test.js
@@ -1,0 +1,90 @@
+// .pipeline/tests/pause-contract-docs.test.js
+// =============================================================================
+// Tests de contrato del documento `docs/pipeline-v3-pause-rebote.md`
+// — issue #2374, Parte 2.
+//
+// El documento es el contrato escrito de qué hace `.paused` y dónde re-encola
+// un rebote según tipo. Estos tests aseguran que:
+//   1. El doc existe.
+//   2. Cubre las superficies clave (intake, lanzamiento, barrido, huérfanos,
+//      agentes en vuelo, exit handler).
+//   3. Cubre la diferencia infra vs código.
+//   4. Apunta a los tests que congelan cada parte del contrato.
+//
+// Si alguien borra o vacía el doc, este test falla y obliga a actualizar el
+// contrato en otro lado antes de poder cerrar el cambio.
+// =============================================================================
+
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const DOC_PATH = path.join(ROOT, 'docs', 'pipeline-v3-pause-rebote.md');
+
+function readDoc() {
+  return fs.readFileSync(DOC_PATH, 'utf8');
+}
+
+test('doc del contrato pause+rebote existe', () => {
+  assert.ok(fs.existsSync(DOC_PATH), `falta archivo: ${DOC_PATH}`);
+  const stat = fs.statSync(DOC_PATH);
+  assert.ok(stat.size > 1000, 'doc del contrato es sospechosamente corto');
+});
+
+test('doc cubre superficies del .paused (intake, lanzamiento, barrido, huérfanos)', () => {
+  const doc = readDoc();
+  for (const surface of ['Intake', 'Lanzamiento', 'Barrido', 'brazoHuerfanos']) {
+    assert.ok(
+      new RegExp(`\\b${surface}`, 'i').test(doc),
+      `doc no menciona la superficie "${surface}" del contrato de pausa`
+    );
+  }
+});
+
+test('doc aclara qué pasa con agentes en vuelo y exit handler', () => {
+  const doc = readDoc();
+  assert.ok(/[Aa]gentes en vuelo/.test(doc), 'doc no aclara comportamiento de agentes en vuelo');
+  assert.ok(/[Ee]xit handler/.test(doc) || /child\.on\('exit'/.test(doc),
+    'doc no aclara que el exit handler corre durante la pausa');
+});
+
+test('doc declara la precedencia paused > partial_pause > running', () => {
+  const doc = readDoc();
+  assert.ok(/paused > partial_pause > running/.test(doc),
+    'doc no documenta la precedencia explícita del estado');
+});
+
+test('doc cubre clasificación infra vs código (Parte 3 #2374)', () => {
+  const doc = readDoc();
+  assert.ok(/\binfra\b/i.test(doc), 'doc no menciona la categoría infra');
+  assert.ok(/\bc[oó]digo\b/i.test(doc) || /\bcode\b/i.test(doc), 'doc no menciona la categoría código/code');
+  assert.ok(/faseRechazo/.test(doc), 'doc no menciona la variable faseRechazo (destino código)');
+  assert.ok(/MISMA fase/i.test(doc) || /misma fase/i.test(doc),
+    'doc no menciona "misma fase" como destino para rebote infra');
+});
+
+test('doc apunta a los tests que congelan el contrato', () => {
+  const doc = readDoc();
+  assert.ok(/rebote-destino\.test\.js/.test(doc),
+    'doc no referencia el test de destino de rebote');
+  assert.ok(/partial-pause\.test\.js/.test(doc),
+    'doc no referencia el test de la tabla de pausa');
+});
+
+test('doc cita el incidente #2159 (motivación histórica)', () => {
+  const doc = readDoc();
+  assert.ok(/#?2159/.test(doc),
+    'doc no cita #2159 (delivery muerto por timeout de CI, origen de la historia)');
+});
+
+test('doc cita el circuit breaker separado de infra (MAX_REBOTES_INFRA, infra_escalate_threshold)', () => {
+  const doc = readDoc();
+  assert.ok(/MAX_REBOTES_INFRA/.test(doc),
+    'doc no cita MAX_REBOTES_INFRA (cap duro independiente del de código)');
+  assert.ok(/infra_escalate_threshold/.test(doc),
+    'doc no cita infra_escalate_threshold (escala blanda a needs-human)');
+});

--- a/docs/pipeline-v3-pause-rebote.md
+++ b/docs/pipeline-v3-pause-rebote.md
@@ -1,0 +1,148 @@
+# Pipeline V3 — Contrato de Pausa + Rebote infra vs código
+
+Issue de referencia: [#2374](https://github.com/intrale/platform/issues/2374).
+
+Este documento congela el contrato de dos mecanismos del pulpo cuya semántica
+era ambigua hasta esta historia:
+
+1. **`.paused`** — el archivo marker que detiene el procesamiento del pipeline.
+2. **`rebote_tipo` (infra vs código)** — dónde se re-encola un issue cuando el
+   pipeline detecta un rechazo según la naturaleza del fallo.
+
+---
+
+## 1. Contrato del archivo `.paused`
+
+### Activación / desactivación
+
+- Crear: `touch .pipeline/.paused` (o bien `node .pipeline/restart.js --paused`).
+- Borrar: `rm .pipeline/.paused` (o bien `node .pipeline/restart.js`, que parte
+  el lifecycle nuevo sin el marker, salvo `--paused`).
+- Coexistencia con `.partial-pause.json`: **`.paused` tiene precedencia** sobre
+  cualquier allowlist. La tabla de verdad vive en `.pipeline/lib/partial-pause.js`.
+
+### Qué hace el pulpo cuando `.paused` está presente
+
+| Subsistema | Comportamiento | Implementación |
+|------------|----------------|----------------|
+| **Intake (GitHub → pipeline)** | **Bloqueado.** No se lee `gh issue list`, no se crean archivos en `*/pendiente/`. | `pulpo.js` `brazoIntake`, gate explícito al inicio del brazo. |
+| **Lanzamiento de nuevos agentes** | **Bloqueado.** No se llama a `lanzarAgenteClaude` ni se promueven worktrees. | `pulpo.js` loop principal: `if (!paused) { brazoLanzamiento(...) }`. |
+| **Barrido / promoción entre fases** | **Bloqueado.** Archivos en `listo/` NO se promueven a la siguiente fase mientras dura la pausa — se acumulan. Al despausar, el barrido drena lo acumulado en orden. | `pulpo.js` loop principal: `if (!paused) { brazoBarrido(...) }`. |
+| **Watchdog / brazoHuerfanos** | **Bloqueado.** Archivos en `trabajando/` no se marcan como huérfanos por timeout durante la pausa. | `pulpo.js` loop principal: `if (!paused) { brazoHuerfanos(...) }`. |
+| **Agentes en vuelo** | **Siguen corriendo.** No se les manda señal de kill. La pausa NO mata trabajo en progreso. | El loop pausado no toca procesos. |
+| **Exit handler de agente que termina** | **Se ejecuta.** Cuando un agente termina mientras `.paused` está activo, su `child.on('exit')` corre en memoria del pulpo (sigue vivo) y mueve `trabajando/<N>.<skill>` → `listo/<N>.<skill>`. | `pulpo.js` `child.on('exit', ...)` ~línea 5501. |
+| **Servicios auxiliares (telegram, dashboard, github, drive, emulador, reconciler)** | **Siguen corriendo.** Cada servicio tiene su propio gate de pausa si decidió respetarla; la mayoría sirve estado y no inyecta trabajo. | Procesos hijos del `restart.js`, independientes del loop del pulpo. |
+| **Detector de cuota Anthropic** | **Corre siempre.** `pollQuotaFlag()` no respeta la pausa porque su objetivo es liberar el gate cuando se restaura la cuota, y eso debe pasar también en estado pausado. | `pulpo.js` loop principal, fuera del `if (!paused)`. |
+
+### Lo que NO hace el `.paused`
+
+- **NO mata agentes en vuelo.** Si querés frenar todo en caliente (incluido el
+  trabajo en progreso), `node .pipeline/restart.js stop` mata el árbol entero.
+- **NO bloquea el dashboard ni Telegram.** Esas superficies son de lectura;
+  bloquearlas dejaría operativamente ciego al operador.
+- **NO afecta el routing-mismatch ni el cross-phase rebote.** Esos flujos pasan
+  por barrido — y barrido está bloqueado — así que efectivamente no corren,
+  pero no porque tengan gate propio: porque viven dentro de un brazo bloqueado.
+
+### Modos futuros (opcionales — NO implementados en esta historia)
+
+El issue #2374 contempla evolucionar el contrato a tres modos:
+
+- `.paused` (actual) → bloqueado todo el lifecycle salvo telemetría.
+- `.paused-hard` → además congela exit handlers (drenaje cero).
+- `.paused-drain` → no lanza nuevos, espera a que todos los `trabajando/` migren a `listo/`.
+
+Si llegan a implementarse, el archivo será reemplazado por un JSON con `mode`
+explícito (mismo patrón que `.partial-pause.json`), preservando el archivo
+desnudo `.paused` como alias de `mode: full` por compatibilidad.
+
+---
+
+## 2. Contrato del rebote — infra vs código
+
+### Clasificación
+
+La clasificación se hace en `pulpo.js` (fuente de verdad: `lib/rebote-classifier.js`)
+sobre el conjunto de motivos de los archivos en `listo/` que reportaron
+`resultado: rechazado`. La precedencia de categorías es:
+
+```
+cross_phase > dependency_block > human_block > infra > code
+```
+
+Para los tipos de rebote que afectan el destino (este documento):
+
+- **`infra`** — la causa raíz es de infraestructura: timeout de watchdog, crash
+  del child, error de red/DNS/TLS, pérdida transitoria de capacidad del LLM.
+  El código del issue no tiene defecto que corregir.
+- **`code`** — la causa raíz es código que el dev escribió: tests fallan, review
+  bloquea por arquitectura, QA detecta defecto funcional, linter rechaza.
+
+### Destino del rebote
+
+Implementación pura en `.pipeline/lib/rebote-destino.js` (función
+`resolveReboteDestino`).
+
+| Tipo | `faseDestino` | `skillsDestino` | Por qué |
+|------|---------------|-----------------|---------|
+| `code` | `faseRechazo` (config — para `desarrollo` es `dev`) | `[determinarDevSkill(issue, config)]` | El dev tiene que corregir el código. El skill se elige por labels del issue (backend-dev, android-dev, web-dev, pipeline-dev). |
+| `infra` en fase mono-skill (`dev` / `build` / `entrega`) | Misma fase | `[único skill]`. Para `dev`, `determinarDevSkill(...)`. | Reintento puro — no hay nada que el dev corrija. |
+| `infra` en fase paralela (`validacion` / `verificacion` / `aprobacion`) | Misma fase | **TODOS** los `skills_por_fase[fase]` | Los archivos en `listo/` de skills que aprobaron se mueven a `procesado/` al final del barrido. Si re-encoláramos sólo el skill que falló por infra, la próxima evaluación quedaría incompleta para siempre (faltan los resultados de los demás skills_requeridos). |
+
+### Circuit breaker independiente
+
+- `MAX_REBOTES = 3` — rebotes de código consecutivos antes de escalar (label
+  `needs-human`, alerta Telegram).
+- `MAX_REBOTES_INFRA = 20` (cap duro) — contador separado `rebote_numero_infra`
+  que **no consume** el budget de código.
+- `infra_escalate_threshold = 5` (config.yaml `circuit_breaker.*`) —
+  threshold blando: a partir de N rebotes infra consecutivos, se aplica
+  `needs-human` y se notifica, aunque no se haya alcanzado el cap duro.
+
+Esto evita el bucle histórico: timeouts de CI en delivery devolvían el issue a
+backend-dev, que rebotaba 3 veces sin tocar nada, y se escalaba a humano por un
+problema que no tenía solución de código.
+
+### Ejemplo canónico (incidente #2159)
+
+```
+1. desarrollo/entrega/trabajando/2159.delivery        ← agente delivery corriendo
+2. watchdog timeout 90min (CI tarda 28m por OWASP)    ← clasificación: infra
+3. ANTES (regresión #2374): desarrollo/dev/pendiente/2159.backend-dev
+   → re-run de backend-dev + builder + tester + qa + review + delivery (horas)
+4. AHORA: desarrollo/entrega/pendiente/2159.delivery
+   → re-run de delivery únicamente. rebote_numero_infra=1, rebote_numero=0.
+```
+
+---
+
+## 3. Diagnóstico operativo
+
+### Verificar el estado de pausa
+```bash
+ls -la .pipeline/.paused .pipeline/.partial-pause.json 2>/dev/null
+node -e "console.log(JSON.stringify(require('./.pipeline/lib/partial-pause').getPipelineMode(), null, 2))"
+```
+
+### Ver clasificación reciente de rebotes
+```bash
+grep -E "rebote_tipo|RECHAZADO en .* (por INFRA|→ devuelto)" .pipeline/logs/pulpo.log | tail -50
+```
+
+### Forzar despausa total
+```bash
+node -e "require('./.pipeline/lib/partial-pause').resumeAll()"
+```
+
+---
+
+## 4. Tests que congelan el contrato
+
+- `.pipeline/lib/__tests__/rebote-destino.test.js` — destino del rebote para
+  cada combinación tipo × fase, fallbacks defensivos.
+- `.pipeline/lib/__tests__/partial-pause.test.js` — tabla de verdad de
+  precedencia `paused > partial_pause > running`.
+- `.pipeline/lib/__tests__/rebote-classifier.test.js` — categorías canónicas
+  con precedencia y patrones de detección.
+
+Cualquier cambio que rompa estos tests viene a este documento primero.


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 8 archivos · +1105 -33

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:skipped` aplicado por delivery

## Closes

Closes #2374
