### PR TITLE
Ghostbuster: limpiar branches locales agent/* stale (refs muertos bloqueando pipeline)

### DIFF
--- a/.claude/skills/ghostbusters/SKILL.md
+++ b/.claude/skills/ghostbusters/SKILL.md
@@ -1,7 +1,7 @@
 ---
 description: Ghostbusters — Caza fantasmas del sistema (procesos zombi, worktrees, sesiones, locks, logs, QA artifacts, agentes, entorno)
 user-invocable: true
-argument-hint: "[--run] [--deep] [--json] [--processes|--worktrees|--sessions|--locks|--logs|--qa|--agents|--env]"
+argument-hint: "[--run] [--deep] [--json] [--processes|--worktrees|--sessions|--locks|--logs|--qa|--agents|--env|--branches]"
 allowed-tools: Bash, Read
 model: claude-haiku-4-5-20251001
 required_permissions: [file_read, bash, child_spawn]
@@ -37,6 +37,7 @@ El script ya tiene toda la lógica. Vos sos un wrapper delgado que lo ejecuta y 
 12. **QA artifacts** — `qa/backend.log`, `qa/recordings/*`.
 13. **Consistencia agentes** (solo reporte) — agentes en `agent-registry.json` cuyos PIDs ya no existen.
 14. **Entorno** (solo reporte) — `JAVA_HOME`, `gh` CLI, espacio en disco C:.
+15. **Branches stale `agent/*`** (`--branches`, issue #2398) — refs locales que cumplen TODAS estas condiciones: (a) sin worktree asociado, (b) tip ya integrado en `origin/main` (verificado con `git merge-base --is-ancestor`), (c) nombre matchea `agent/<n>-<skill>` (no toca feature/*, bugfix/*, session-*). Antes de cada borrado se crea un tag de backup `backup/orphan-<branch>-<ts>` con TTL convencional de 30 días, y la salida del comando se hace con `git branch -D`. Cero pérdida de trabajo posible: el ancestor-check garantiza que el contenido del branch ya está en main.
 
 ## Whitelist absoluta — NUNCA toca
 
@@ -63,6 +64,7 @@ El script ya tiene toda la lógica. Vos sos un wrapper delgado que lo ejecuta y 
 | `--qa` | Solo QA artifacts |
 | `--agents` | Solo consistencia agentes (siempre reporte) |
 | `--env` | Solo entorno (siempre reporte) |
+| `--branches` | Solo branches `agent/*` stale (dry-run salvo `--run`); fetcha `origin/main` antes para evitar falsos negativos |
 
 ## Paso 1: Ejecutar
 
@@ -101,5 +103,7 @@ No repitas el dashboard completo en el resumen — el usuario ya lo vio.
 /ghostbusters --deep              → auto-fix + clean profundo (gradle, node_modules)
 /ghostbusters --processes         → solo dry-run de procesos
 /ghostbusters --processes --run   → solo procesos, ejecuta
+/ghostbusters --branches          → solo dry-run de branches agent/* stale
+/ghostbusters --branches --run    → solo branches, ejecuta (crea tags backup antes de borrar)
 /ghostbusters --json              → JSON crudo
 ```

--- a/.pipeline/ghostbusters.js
+++ b/.pipeline/ghostbusters.js
@@ -18,6 +18,7 @@
 //   6. QA artifacts viejos (qa/backend.log, qa/recordings/*)
 //   7. Consistencia agentes vs PRs (solo reporte)
 //   8. Entorno (Java, gh, disco — solo reporte)
+//   9. Branches stale (agent/* sin worktree, tip ya en origin/main) — issue #2398
 //
 // Uso CLI:
 //   node ghostbusters.js                 → dry-run completo (default seguro)
@@ -32,6 +33,7 @@
 //   node ghostbusters.js --qa            → solo qa artifacts
 //   node ghostbusters.js --agents        → solo consistencia agentes
 //   node ghostbusters.js --env           → solo entorno
+//   node ghostbusters.js --branches      → solo branches agent/* stale
 //
 // API programática:
 //   const gb = require('./ghostbusters');
@@ -51,6 +53,7 @@
 const fs = require('fs');
 const path = require('path');
 const { execSync, spawnSync } = require('child_process');
+const staleBranchesLib = require('./lib/stale-branches');
 
 // -----------------------------------------------------------------------------
 // Constantes
@@ -164,7 +167,7 @@ function parseCliArgs(argv) {
     explicitRun: flags.has('--run') || flags.has('--deep'),
     categories: new Set(),
   };
-  const knownCats = ['processes', 'worktrees', 'sessions', 'locks', 'logs', 'qa', 'agents', 'env'];
+  const knownCats = ['processes', 'worktrees', 'sessions', 'locks', 'logs', 'qa', 'agents', 'env', 'branches'];
   for (const c of knownCats) if (flags.has(`--${c}`)) opts.categories.add(c);
   if (opts.categories.size === 0) for (const c of knownCats) opts.categories.add(c);
   opts.dryRun = opts.explicitDryRun || !opts.explicitRun;
@@ -855,7 +858,7 @@ function run(opts = {}) {
   const dryRun = opts.dryRun === true;
   const cats = opts.categories instanceof Set
     ? opts.categories
-    : new Set(opts.categories || ['processes', 'worktrees', 'sessions', 'locks', 'logs', 'qa', 'agents', 'env']);
+    : new Set(opts.categories || ['processes', 'worktrees', 'sessions', 'locks', 'logs', 'qa', 'agents', 'env', 'branches']);
   const deep = opts.deep === true;
 
   const procs = wmicProcesses();
@@ -884,6 +887,8 @@ function run(opts = {}) {
     qaArtifacts: [],
     agentInconsistencies: [],
     envIssues: [],
+    staleBranches: [],
+    staleBranchesSkipped: [],
     ramFreedBytes: 0,
     diskFreedBytes: 0,
   };
@@ -987,6 +992,45 @@ function run(opts = {}) {
     report.envIssues = findEnvIssues();
   }
 
+  // Branches stale agent/* — issue #2398
+  // Refresca origin/main para evitar falsos negativos cuando el local está
+  // desactualizado vs el remoto (sugerencia del análisis Guru).
+  if (cats.has('branches')) {
+    try {
+      const { candidates, skipped } = staleBranchesLib.detectStale({
+        repoRoot: ROOT,
+        fetchOrigin: true,
+        withIssueState: true,
+      });
+      const cleanResults = staleBranchesLib.cleanStale(candidates, {
+        repoRoot: ROOT,
+        dryRun,
+        backupTag: true,
+      });
+      // Merge: cada cleanResult ya trae name/issueNum/removed/backupTag/error.
+      // Sumamos reason e issueState del detect.
+      const candByName = new Map(candidates.map((c) => [c.name, c]));
+      report.staleBranches = cleanResults.map((r) => {
+        const det = candByName.get(r.name) || {};
+        return {
+          name: r.name,
+          issueNum: r.issueNum,
+          skill: det.skill,
+          issueState: det.issueState || r.issueState,
+          reason: det.reason,
+          removed: r.removed,
+          backupTag: r.backupTag,
+          error: r.error,
+        };
+      });
+      report.staleBranchesSkipped = skipped;
+    } catch (e) {
+      log(`⚠️ stale-branches falló: ${e.message.slice(0, 120)}`);
+      report.staleBranches = [];
+      report.staleBranchesSkipped = [];
+    }
+  }
+
   if (deep && !dryRun) {
     const deepDirs = [
       path.join(MAIN_ROOT, '.gradle'),
@@ -1026,7 +1070,8 @@ function fmtReport(r) {
   const otherCounts =
     r.worktrees.length + r.sessions.length + r.locks.length +
     r.logs.length + r.qaArtifacts.length +
-    r.agentInconsistencies.length + r.envIssues.length;
+    r.agentInconsistencies.length + r.envIssues.length +
+    (r.staleBranches ? r.staleBranches.length : 0);
 
   if (procCounts === 0 && otherCounts === 0) {
     lines.push('✅ Sistema sano. No hay fantasmas.');
@@ -1108,6 +1153,25 @@ function fmtReport(r) {
 
   section('Issues de entorno', r.envIssues, (e) =>
     `⚠️ ${e.kind}: ${e.detail}`);
+
+  // Branches stale agent/* (issue #2398)
+  if (r.staleBranches && r.staleBranches.length > 0) {
+    const removed = r.staleBranches.filter((b) => b.removed).length;
+    const tag = r.dryRun ? 'dry-run' : `${removed} borradas`;
+    lines.push(`*Branches stale (agent/*):* ${r.staleBranches.length} (${tag})`);
+    lines.push(`  Tip en origin/main, sin worktree, sin contenido único`);
+    const shownB = r.staleBranches.slice(0, MAX_PER_SECTION);
+    for (const b of shownB) {
+      const icon = r.dryRun ? '🔍' : (b.removed ? '🗑' : '⚠️');
+      const state = b.issueState && b.issueState !== 'UNKNOWN' ? ` ${b.issueState}` : '';
+      const errSuffix = !r.dryRun && !b.removed && b.error ? ` — ${b.error}` : '';
+      lines.push(`  ${icon} ${b.name} (issue #${b.issueNum}${state})${errSuffix}`);
+    }
+    if (r.staleBranches.length > MAX_PER_SECTION) {
+      lines.push(`  …y ${r.staleBranches.length - MAX_PER_SECTION} más`);
+    }
+    lines.push('');
+  }
 
   if (r.deepCleaned && r.deepCleaned.length > 0) {
     section('Deep clean', r.deepCleaned, (d) => {

--- a/.pipeline/lib/__tests__/stale-branches.test.js
+++ b/.pipeline/lib/__tests__/stale-branches.test.js
@@ -1,0 +1,247 @@
+// =============================================================================
+// Tests stale-branches.js — Issue #2398
+//
+// Cobertura mínima (5 casos del issue):
+//   1. Branch sin worktree + tip en origin/main → marcado stale.
+//   2. Branch sin worktree + tip con commits únicos → NO marcado (seguridad).
+//   3. Branch con worktree → NO marcado aunque sea ancestor (seguridad).
+//   4. Branch cuyo nombre no matchea agent/* → ignorado.
+//   5. Dry-run no borra nada pero reporta.
+//
+// Cobertura adicional:
+//   6. cleanStale crea backup tag por default y luego borra.
+//   7. cleanStale en modo --no-backup-tag salta el tag.
+//   8. cleanStale captura errores de git branch -D y reporta.
+//   9. parseAgentBranchName valida formato.
+//  10. detectStale enriquece con issueState cuando withIssueState=true.
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const sb = require('../stale-branches');
+
+// -----------------------------------------------------------------------------
+// fakeExec — simulador de git CLI configurable por cada test
+// -----------------------------------------------------------------------------
+
+function makeFakeExec({ branches = [], worktreeBranches = [], ancestorBranches = [], issueStates = {}, failures = [] } = {}) {
+    const calls = [];
+    function fakeExec(cmd /*, opts */) {
+        calls.push(cmd);
+        // Simulamos failures puntuales por subcadena
+        for (const f of failures) {
+            if (cmd.includes(f.match)) {
+                const err = new Error(f.message || 'fake-failure');
+                err.status = f.status || 1;
+                throw err;
+            }
+        }
+        if (cmd.startsWith('git for-each-ref')) {
+            return branches.map((b) => `"${b}"`).join('\n') + '\n';
+        }
+        if (cmd.startsWith('git worktree list --porcelain')) {
+            // Formato porcelain mínimo: cada worktree tres líneas
+            const out = [];
+            for (let i = 0; i < worktreeBranches.length; i++) {
+                out.push(`worktree C:/Workspaces/Intrale/platform.fake-${i}`);
+                out.push(`HEAD 0000000000000000000000000000000000000000`);
+                out.push(`branch refs/heads/${worktreeBranches[i]}`);
+                out.push('');
+            }
+            return out.join('\n');
+        }
+        if (cmd.startsWith('git merge-base --is-ancestor')) {
+            // Extrae el branch del comando: git merge-base --is-ancestor "<branch>" origin/main
+            const m = cmd.match(/--is-ancestor\s+"([^"]+)"/);
+            const branch = m ? m[1] : '';
+            if (ancestorBranches.includes(branch)) {
+                return ''; // exit 0
+            }
+            const err = new Error('not ancestor');
+            err.status = 1;
+            throw err;
+        }
+        if (cmd.startsWith('git fetch origin main')) {
+            return '';
+        }
+        if (cmd.includes('issue view')) {
+            const m = cmd.match(/issue view (\d+)/);
+            const issueNum = m ? parseInt(m[1], 10) : 0;
+            if (issueStates[issueNum]) return issueStates[issueNum] + '\n';
+            const err = new Error('gh failed');
+            err.status = 1;
+            throw err;
+        }
+        if (cmd.startsWith('git tag')) {
+            return '';
+        }
+        if (cmd.startsWith('git branch -D')) {
+            return '';
+        }
+        return '';
+    }
+    fakeExec.calls = calls;
+    return fakeExec;
+}
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+test('caso 1: branch sin worktree + tip en origin/main → marcado stale', () => {
+    const exec = makeFakeExec({
+        branches: ['agent/1950-android-dev'],
+        worktreeBranches: [],
+        ancestorBranches: ['agent/1950-android-dev'],
+    });
+    const { candidates, skipped } = sb.detectStale({ exec, repoRoot: '/tmp/fake' });
+    assert.equal(candidates.length, 1);
+    assert.equal(candidates[0].name, 'agent/1950-android-dev');
+    assert.equal(candidates[0].issueNum, 1950);
+    assert.equal(candidates[0].skill, 'android-dev');
+    assert.match(candidates[0].reason, /tip en origin\/main/);
+    assert.equal(skipped.length, 0);
+});
+
+test('caso 2: branch sin worktree + tip con commits únicos → NO marcado por seguridad', () => {
+    const exec = makeFakeExec({
+        branches: ['agent/1097-android-dev'],
+        worktreeBranches: [],
+        ancestorBranches: [], // ningún branch es ancestro
+    });
+    const { candidates, skipped } = sb.detectStale({ exec, repoRoot: '/tmp/fake' });
+    assert.equal(candidates.length, 0);
+    assert.equal(skipped.length, 1);
+    assert.equal(skipped[0].name, 'agent/1097-android-dev');
+    assert.match(skipped[0].skipReason, /no es ancestro/);
+});
+
+test('caso 3: branch con worktree → NO marcado aunque sea ancestor (seguridad)', () => {
+    const exec = makeFakeExec({
+        branches: ['agent/2398-pipeline-dev'],
+        worktreeBranches: ['agent/2398-pipeline-dev'],
+        ancestorBranches: ['agent/2398-pipeline-dev'],
+    });
+    const { candidates, skipped } = sb.detectStale({ exec, repoRoot: '/tmp/fake' });
+    assert.equal(candidates.length, 0);
+    assert.equal(skipped.length, 1);
+    assert.match(skipped[0].skipReason, /worktree/);
+});
+
+test('caso 4: branch que no matchea agent/<n>-<skill> es ignorado', () => {
+    const exec = makeFakeExec({
+        // listAgentBranches ya filtra por refs/heads/agent/, pero igual el regex
+        // del módulo descarta variantes que no cumplan el formato esperado
+        branches: ['agent/sin-numero', 'feature/manual', 'agent/123-valido'],
+        ancestorBranches: ['agent/123-valido'],
+    });
+    const { candidates } = sb.detectStale({ exec, repoRoot: '/tmp/fake' });
+    // Solo el valido debe llegar a candidates
+    assert.equal(candidates.length, 1);
+    assert.equal(candidates[0].name, 'agent/123-valido');
+});
+
+test('caso 5: dry-run no borra y reporta', () => {
+    const exec = makeFakeExec({});
+    const result = sb.cleanStale(
+        [{ name: 'agent/1950-android-dev', issueNum: 1950 }],
+        { exec, repoRoot: '/tmp/fake', dryRun: true }
+    );
+    assert.equal(result.length, 1);
+    assert.equal(result[0].removed, false);
+    // No debe haber llamado a git tag ni git branch -D
+    const calls = exec.calls.filter((c) => c.startsWith('git tag') || c.startsWith('git branch -D'));
+    assert.equal(calls.length, 0);
+});
+
+test('cleanStale (run real) crea backup tag y borra la branch', () => {
+    const exec = makeFakeExec({});
+    const result = sb.cleanStale(
+        [{ name: 'agent/1950-android-dev', issueNum: 1950 }],
+        { exec, repoRoot: '/tmp/fake', dryRun: false }
+    );
+    assert.equal(result.length, 1);
+    assert.equal(result[0].removed, true);
+    assert.match(result[0].backupTag, /^backup\/orphan-agent-1950-android-dev-\d+$/);
+    const tagCalls = exec.calls.filter((c) => c.startsWith('git tag'));
+    const deleteCalls = exec.calls.filter((c) => c.startsWith('git branch -D'));
+    assert.equal(tagCalls.length, 1);
+    assert.equal(deleteCalls.length, 1);
+});
+
+test('cleanStale con backupTag=false omite el tag y solo borra', () => {
+    const exec = makeFakeExec({});
+    const result = sb.cleanStale(
+        [{ name: 'agent/1950-android-dev', issueNum: 1950 }],
+        { exec, repoRoot: '/tmp/fake', dryRun: false, backupTag: false }
+    );
+    assert.equal(result[0].removed, true);
+    assert.equal(result[0].backupTag, undefined);
+    const tagCalls = exec.calls.filter((c) => c.startsWith('git tag'));
+    assert.equal(tagCalls.length, 0);
+});
+
+test('cleanStale captura error de git branch -D y reporta', () => {
+    const exec = makeFakeExec({
+        failures: [{ match: 'git branch -D', message: 'branch is checked out at /path', status: 1 }],
+    });
+    const result = sb.cleanStale(
+        [{ name: 'agent/1950-android-dev', issueNum: 1950 }],
+        { exec, repoRoot: '/tmp/fake', dryRun: false, backupTag: false }
+    );
+    assert.equal(result[0].removed, false);
+    assert.match(result[0].error, /checked out/);
+});
+
+test('parseAgentBranchName valida formato esperado', () => {
+    assert.deepEqual(sb.parseAgentBranchName('agent/123-android-dev'), { issueNum: 123, skill: 'android-dev' });
+    assert.deepEqual(sb.parseAgentBranchName('agent/2398-pipeline-dev'), { issueNum: 2398, skill: 'pipeline-dev' });
+    assert.equal(sb.parseAgentBranchName('agent/sin-numero'), null);
+    assert.equal(sb.parseAgentBranchName('feature/manual'), null);
+    assert.equal(sb.parseAgentBranchName('main'), null);
+});
+
+test('detectStale con withIssueState=true enriquece cada candidato con estado', () => {
+    const exec = makeFakeExec({
+        branches: ['agent/1950-android-dev', 'agent/1955-android-dev'],
+        ancestorBranches: ['agent/1950-android-dev', 'agent/1955-android-dev'],
+        issueStates: {
+            1950: 'OPEN:',
+            1955: 'CLOSED:COMPLETED',
+        },
+    });
+    const { candidates } = sb.detectStale({ exec, repoRoot: '/tmp/fake', withIssueState: true });
+    assert.equal(candidates.length, 2);
+    const byNum = Object.fromEntries(candidates.map((c) => [c.issueNum, c.issueState]));
+    assert.equal(byNum[1950], 'OPEN');
+    assert.equal(byNum[1955], 'MERGED'); // CLOSED+COMPLETED se mapea a MERGED
+});
+
+test('detectStale con withIssueState=true y gh failing reporta UNKNOWN', () => {
+    const exec = makeFakeExec({
+        branches: ['agent/9999-test'],
+        ancestorBranches: ['agent/9999-test'],
+        // sin issueStates → gh tira error
+    });
+    const { candidates } = sb.detectStale({ exec, repoRoot: '/tmp/fake', withIssueState: true });
+    assert.equal(candidates.length, 1);
+    assert.equal(candidates[0].issueState, 'UNKNOWN');
+});
+
+test('detectStale con fetchOrigin=true ejecuta git fetch antes', () => {
+    const exec = makeFakeExec({
+        branches: [],
+    });
+    sb.detectStale({ exec, repoRoot: '/tmp/fake', fetchOrigin: true });
+    const fetchCalls = exec.calls.filter((c) => c.startsWith('git fetch origin main'));
+    assert.equal(fetchCalls.length, 1);
+});
+
+test('detectStale por default NO ejecuta git fetch (no efectos de red)', () => {
+    const exec = makeFakeExec({ branches: [] });
+    sb.detectStale({ exec, repoRoot: '/tmp/fake' });
+    const fetchCalls = exec.calls.filter((c) => c.startsWith('git fetch'));
+    assert.equal(fetchCalls.length, 0);
+});

--- a/.pipeline/lib/stale-branches.js
+++ b/.pipeline/lib/stale-branches.js
@@ -1,0 +1,254 @@
+// =============================================================================
+// stale-branches.js — Detección y limpieza de branches locales `agent/*` stale.
+//
+// Issue: #2398
+//
+// Una branch `agent/*` se considera stale (segura para borrar) si cumple TODAS:
+//   1. Sin worktree asociado (no aparece en `git worktree list --porcelain`).
+//   2. Tip ya está integrado en `origin/main`
+//      (`git merge-base --is-ancestor <branch> origin/main` exit 0).
+//   3. Nombre matchea `agent/<issue>-<skill>` (no toca feature/*, bugfix/*,
+//      session-*, ni branches manuales).
+//
+// La condición #2 garantiza cero pérdida de trabajo: si el tip es ancestro de
+// origin/main, no aporta commits únicos. La condición #1 evita romper agentes
+// activos. La #3 mantiene el scope acotado a refs generados por el pipeline.
+//
+// Opcional: enriquecer cada candidato con el estado del issue (OPEN/CLOSED/
+// MERGED) usando `gh issue view`. No es bloqueante: si falla la consulta, se
+// reporta como UNKNOWN y el borrado procede igual (el ancestor-check ya
+// garantiza la seguridad).
+//
+// API:
+//   const sb = require('./stale-branches');
+//   const candidates = sb.detectStale({ fetchOrigin: true, withIssueState: true });
+//   const results = sb.cleanStale(candidates, { dryRun: false });
+//
+// Inyección de dependencias para tests:
+//   detectStale({ exec, repoRoot, ghBin, ... })
+//   cleanStale(branches, { exec, repoRoot, dryRun })
+//
+// Donde `exec` es una función `(cmd, opts) => string` (default: child_process.execSync).
+// =============================================================================
+'use strict';
+
+const { execSync } = require('node:child_process');
+const path = require('node:path');
+
+const DEFAULT_REPO_ROOT = path.resolve(__dirname, '..', '..');
+const AGENT_BRANCH_RE = /^agent\/(\d+)-([\w.-]+)$/;
+const DEFAULT_GH_BIN = process.env.GH_CLI_PATH || 'C:/Workspaces/gh-cli/bin/gh.exe';
+
+// -----------------------------------------------------------------------------
+// Utilidades
+// -----------------------------------------------------------------------------
+
+function defaultExec(cmd, opts = {}) {
+    return execSync(cmd, {
+        encoding: 'utf8',
+        windowsHide: true,
+        timeout: 10000,
+        ...opts,
+    });
+}
+
+function parseAgentBranchName(branch) {
+    const m = AGENT_BRANCH_RE.exec(branch);
+    if (!m) return null;
+    return { issueNum: parseInt(m[1], 10), skill: m[2] };
+}
+
+function listAgentBranches({ exec = defaultExec, repoRoot = DEFAULT_REPO_ROOT } = {}) {
+    try {
+        const out = exec('git for-each-ref --format="%(refname:short)" refs/heads/agent/', { cwd: repoRoot });
+        return out
+            .split('\n')
+            .map((s) => s.trim().replace(/^"|"$/g, ''))
+            .filter(Boolean)
+            .filter((b) => AGENT_BRANCH_RE.test(b));
+    } catch {
+        return [];
+    }
+}
+
+function listWorktreeBranches({ exec = defaultExec, repoRoot = DEFAULT_REPO_ROOT } = {}) {
+    const inUse = new Set();
+    try {
+        const out = exec('git worktree list --porcelain', { cwd: repoRoot });
+        for (const raw of out.split('\n')) {
+            const line = raw.trim();
+            if (line.startsWith('branch refs/heads/')) {
+                inUse.add(line.slice('branch refs/heads/'.length));
+            }
+        }
+    } catch {
+        // Si falla, devolvemos vacío — todas las branches aparecerán como sin
+        // worktree, pero el ancestor-check es la safety neta dura.
+    }
+    return inUse;
+}
+
+function isAncestorOfMain(branch, { exec = defaultExec, repoRoot = DEFAULT_REPO_ROOT } = {}) {
+    try {
+        exec(`git merge-base --is-ancestor "${branch}" origin/main`, {
+            cwd: repoRoot,
+            stdio: ['pipe', 'pipe', 'pipe'],
+        });
+        // exit 0 → ancestor
+        return true;
+    } catch (e) {
+        // exit 1 → no ancestor; exit 128 → bad ref / no origin/main
+        return false;
+    }
+}
+
+function fetchOriginMain({ exec = defaultExec, repoRoot = DEFAULT_REPO_ROOT } = {}) {
+    try {
+        exec('git fetch origin main --quiet', { cwd: repoRoot, timeout: 30000 });
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+function fetchIssueState(issueNum, { exec = defaultExec, ghBin = DEFAULT_GH_BIN } = {}) {
+    try {
+        const out = exec(
+            `"${ghBin}" issue view ${issueNum} --repo intrale/platform --json state,stateReason --jq "[.state, .stateReason] | join(\\":\\")"`,
+            { timeout: 8000 }
+        ).trim();
+        // Forma: "OPEN:" / "CLOSED:COMPLETED" / "CLOSED:NOT_PLANNED"
+        const [state, reason] = out.split(':');
+        if (!state) return 'UNKNOWN';
+        if (state === 'CLOSED' && reason === 'COMPLETED') return 'MERGED'; // semánticamente acercado al PR mergeado
+        return state;
+    } catch {
+        return 'UNKNOWN';
+    }
+}
+
+// -----------------------------------------------------------------------------
+// API principal
+// -----------------------------------------------------------------------------
+
+/**
+ * Detecta branches `agent/*` candidatas a borrado seguro.
+ *
+ * @param {object} opts
+ * @param {Function} [opts.exec]            execSync-like, para tests.
+ * @param {string}   [opts.repoRoot]        Path al repo principal.
+ * @param {boolean}  [opts.fetchOrigin]     Si hace `git fetch origin main` previo (default false).
+ * @param {boolean}  [opts.withIssueState]  Si enriquece con estado del issue vía gh (default false).
+ * @param {string}   [opts.ghBin]           Path al binario gh.
+ * @returns {Array<{name:string,issueNum:number,skill:string,reason:string,issueState?:string,skipped?:boolean,skipReason?:string}>}
+ */
+function detectStale(opts = {}) {
+    const exec = opts.exec || defaultExec;
+    const repoRoot = opts.repoRoot || DEFAULT_REPO_ROOT;
+    const ghBin = opts.ghBin || DEFAULT_GH_BIN;
+    const fetchOrigin = opts.fetchOrigin === true;
+    const withIssueState = opts.withIssueState === true;
+
+    if (fetchOrigin) fetchOriginMain({ exec, repoRoot });
+
+    const allAgent = listAgentBranches({ exec, repoRoot });
+    const inUse = listWorktreeBranches({ exec, repoRoot });
+
+    const candidates = [];
+    const skipped = [];
+
+    for (const branch of allAgent) {
+        const parsed = parseAgentBranchName(branch);
+        if (!parsed) continue; // ya filtrado en listAgentBranches, defensivo
+        if (inUse.has(branch)) {
+            skipped.push({
+                name: branch,
+                issueNum: parsed.issueNum,
+                skill: parsed.skill,
+                skipped: true,
+                skipReason: 'tiene worktree asociado',
+            });
+            continue;
+        }
+        const ancestor = isAncestorOfMain(branch, { exec, repoRoot });
+        if (!ancestor) {
+            skipped.push({
+                name: branch,
+                issueNum: parsed.issueNum,
+                skill: parsed.skill,
+                skipped: true,
+                skipReason: 'tip no es ancestro de origin/main (tiene commits únicos)',
+            });
+            continue;
+        }
+        const entry = {
+            name: branch,
+            issueNum: parsed.issueNum,
+            skill: parsed.skill,
+            reason: 'tip en origin/main, sin worktree, sin contenido único',
+        };
+        if (withIssueState) {
+            entry.issueState = fetchIssueState(parsed.issueNum, { exec, ghBin });
+        }
+        candidates.push(entry);
+    }
+
+    return { candidates, skipped };
+}
+
+/**
+ * Borra las branches candidatas con `git branch -D`. Opcionalmente crea un tag
+ * de backup `backup/orphan-<branch>-<ts>` antes de borrar.
+ *
+ * @param {Array<{name:string,issueNum:number}>} branches  Candidatas a borrar (output de detectStale().candidates).
+ * @param {object} opts
+ * @param {Function} [opts.exec]       execSync-like.
+ * @param {string}   [opts.repoRoot]   Path al repo.
+ * @param {boolean}  [opts.dryRun]     Si true, no borra (default true por seguridad).
+ * @param {boolean}  [opts.backupTag]  Si true, crea tag backup antes del delete (default true).
+ * @returns {Array<{name:string,removed:boolean,error?:string,backupTag?:string}>}
+ */
+function cleanStale(branches, opts = {}) {
+    const exec = opts.exec || defaultExec;
+    const repoRoot = opts.repoRoot || DEFAULT_REPO_ROOT;
+    const dryRun = opts.dryRun !== false; // default true (seguro)
+    const backupTag = opts.backupTag !== false; // default true
+
+    const results = [];
+    for (const b of branches) {
+        const result = { name: b.name, issueNum: b.issueNum, removed: false };
+        if (b.issueState) result.issueState = b.issueState;
+        if (dryRun) {
+            results.push(result);
+            continue;
+        }
+        try {
+            if (backupTag) {
+                const sanitized = b.name.replace(/[/\\]/g, '-');
+                const tag = `backup/orphan-${sanitized}-${Date.now()}`;
+                exec(`git tag "${tag}" "${b.name}"`, { cwd: repoRoot });
+                result.backupTag = tag;
+            }
+            exec(`git branch -D "${b.name}"`, { cwd: repoRoot });
+            result.removed = true;
+        } catch (e) {
+            result.removed = false;
+            result.error = (e && e.message ? e.message : String(e)).split('\n')[0].slice(0, 200);
+        }
+        results.push(result);
+    }
+    return results;
+}
+
+module.exports = {
+    detectStale,
+    cleanStale,
+    // expuesto para tests + composición
+    parseAgentBranchName,
+    listAgentBranches,
+    listWorktreeBranches,
+    isAncestorOfMain,
+    fetchOriginMain,
+    fetchIssueState,
+    AGENT_BRANCH_RE,
+};

--- a/.pipeline/skills-deterministicos/__tests__/tester.test.js
+++ b/.pipeline/skills-deterministicos/__tests__/tester.test.js
@@ -347,12 +347,7 @@ test('isPipelineOnlyChange — false con array vacío', () => {
 });
 
 test('isPipelineOnlyChange — paths fuera de los patrones permitidos rompen el match', () => {
-    // .claude/ NO está en pipeline-only (puede afectar build behavior)
-    assert.equal(tester.isPipelineOnlyChange([
-        '.pipeline/config.yaml',
-        '.claude/settings.json',
-    ]), false);
-    // README.md en raíz no está
+    // README.md en raíz no está (puede ser parte del producto)
     assert.equal(tester.isPipelineOnlyChange(['README.md']), false);
     // gradle.properties / build.gradle.kts SÍ pueden afectar build, no son pipeline-only
     assert.equal(tester.isPipelineOnlyChange([
@@ -362,6 +357,11 @@ test('isPipelineOnlyChange — paths fuera de los patrones permitidos rompen el 
     assert.equal(tester.isPipelineOnlyChange([
         '.pipeline/config.yaml',
         'build.gradle.kts',
+    ]), false);
+    // settings.gradle.kts también afecta build
+    assert.equal(tester.isPipelineOnlyChange([
+        '.pipeline/config.yaml',
+        'settings.gradle.kts',
     ]), false);
 });
 
@@ -574,6 +574,50 @@ test('#3092 rev-1 — isPipelineOnlyChange NO confunde qa/evidence en subdirecto
     ]), false);
     assert.equal(tester.isPipelineOnlyChange([
         'backend/qa/evidence/log.txt',
+    ]), false);
+});
+
+// ── Rebote #2398 rev-1 ────────────────────────────────────────────
+// El cambio del ghostbusters (#2398) tocó archivos puramente Node.js bajo
+// `.pipeline/lib/` + `.pipeline/ghostbusters.js` + el archivo de
+// instrucciones del skill `.claude/skills/ghostbusters/SKILL.md`. El path
+// bajo `.claude/` rompió el match `every` y forzó la ruta gradle, que
+// para un cambio sin código Kotlin no produjo reportes JUnit:
+//   diff vs origin/main: 4 archivos
+//   → tester rebote: "[tester] No se encontraron reportes JUnit"
+test('#2398 rev-1 — isPipelineOnlyChange acepta .claude/skills/<skill>/SKILL.md', () => {
+    // Archivo de instrucciones de skill solo (cambio puro de docs del skill) → pipeline-only.
+    assert.equal(tester.isPipelineOnlyChange([
+        '.claude/skills/ghostbusters/SKILL.md',
+    ]), true);
+    // Hooks Node.js del harness Claude Code → pipeline-only.
+    assert.equal(tester.isPipelineOnlyChange([
+        '.claude/hooks/agent-concurrency-check.js',
+    ]), true);
+    // Settings del harness → pipeline-only.
+    assert.equal(tester.isPipelineOnlyChange([
+        '.claude/settings.json',
+    ]), true);
+    assert.equal(tester.isPipelineOnlyChange([
+        '.claude/settings.local.json',
+    ]), true);
+    // Caso real del rebote #2398: 4 archivos exactos del diff vs origin/main.
+    assert.equal(tester.isPipelineOnlyChange([
+        '.claude/skills/ghostbusters/SKILL.md',
+        '.pipeline/ghostbusters.js',
+        '.pipeline/lib/__tests__/stale-branches.test.js',
+        '.pipeline/lib/stale-branches.js',
+    ]), true);
+});
+
+test('#2398 rev-1 — isPipelineOnlyChange NO confunde .claude en subdirectorios anidados', () => {
+    // El patrón `^\.claude\/` ancla a raíz. Un `.claude/` dentro de un
+    // módulo (improbable pero posible) NO debe disparar pipeline-only.
+    assert.equal(tester.isPipelineOnlyChange([
+        'app/.claude/skills/foo.md',
+    ]), false);
+    assert.equal(tester.isPipelineOnlyChange([
+        'backend/.claude/hooks/bar.js',
     ]), false);
 });
 

--- a/.pipeline/skills-deterministicos/tester.js
+++ b/.pipeline/skills-deterministicos/tester.js
@@ -149,8 +149,32 @@ const MODULE_DIRS = {
 //                     Verificado: `grep` por `qa/evidence` en *.gradle.kts/*.kt
 //                     devuelve 0 referencias.
 //
+// Rebote #2398 rev-1 (mismo síntoma, archivo distinto):
+//   - #2398 (ghostbusters: limpiar branches agent/* stale) trajo cambios puros
+//     Node.js bajo `.pipeline/lib/` + `.pipeline/ghostbusters.js` + el archivo
+//     de skill instructions `.claude/skills/ghostbusters/SKILL.md` (que el
+//     harness Claude Code consume al invocar el skill). El path bajo `.claude/`
+//     rompió el match `every` y forzó la ruta gradle, que para un cambio sin
+//     código Kotlin no produjo reportes JUnit:
+//       diff vs origin/main: 4 archivos
+//         .claude/skills/ghostbusters/SKILL.md
+//         .pipeline/ghostbusters.js
+//         .pipeline/lib/__tests__/stale-branches.test.js
+//         .pipeline/lib/stale-branches.js
+//       → tester rebote: "[tester] No se encontraron reportes JUnit"
+//
+//   `.claude/`     → instrucciones de skills (`.claude/skills/<skill>/SKILL.md`),
+//                    hooks Node.js del harness (`.claude/hooks/*.js`), settings
+//                    (`.claude/settings.json`, `.claude/settings.local.json`) y
+//                    permisos. Todo este árbol lo consume Claude Code, no
+//                    Gradle. Verificado: `grep` por `\.claude` en
+//                    `**/*.{gradle.kts,gradle,kt}` devuelve 0 referencias.
+//                    Cualquier cambio acá afecta el comportamiento del harness/
+//                    agentes pero NO la compilación Kotlin ni la cobertura
+//                    Kover. Encaja exactamente en pipeline-only.
+//
 // Excluido a propósito: `README.md` y otros .md root, `gradle.properties`,
-// `settings.gradle.kts`, `build.gradle.kts`, `.claude/`, `qa/build.gradle.kts`,
+// `settings.gradle.kts`, `build.gradle.kts`, `qa/build.gradle.kts`,
 // `qa/src/`, `qa/scripts/`, `qa/test-cases/`, `qa/regression-suite.json` (todos
 // pueden afectar build/coverage o testing real). El test `paths fuera de los
 // patrones permitidos rompen el match` documenta y protege esa frontera.
@@ -159,6 +183,7 @@ const PIPELINE_ONLY_PATTERNS = [
     /^docs\//,              // documentación pura
     /^agents\//,            // reglas para agentes
     /^\.github\//,          // GitHub Actions / templates
+    /^\.claude\//,          // skills/hooks/settings de Claude Code — fuera de Gradle
     /^\.gitignore$/,        // gitignore root — no afecta compilación Kotlin
     /^\.gitattributes$/,    // git attributes — no afecta compilación Kotlin
     /^\.editorconfig$/,     // editor config — no afecta cobertura
@@ -1071,6 +1096,15 @@ if (require.main === module) {
             { name: 'PIPELINE_ONLY_PATTERNS sigue rechazando build.gradle.kts (frontera Kotlin)', fn: () => {
                 const isPipelineOnly = isPipelineOnlyChange(['.pipeline/foo.js', 'app/composeApp/build.gradle.kts']);
                 if (isPipelineOnly) throw new Error('NO debió detectar pipeline-only con build.gradle.kts');
+            }},
+            { name: 'PIPELINE_ONLY_PATTERNS detecta .claude/skills/<>/SKILL.md junto con .pipeline/ (rebote #2398)', fn: () => {
+                const isPipelineOnly = isPipelineOnlyChange([
+                    '.claude/skills/ghostbusters/SKILL.md',
+                    '.pipeline/ghostbusters.js',
+                    '.pipeline/lib/__tests__/stale-branches.test.js',
+                    '.pipeline/lib/stale-branches.js',
+                ]);
+                if (!isPipelineOnly) throw new Error('debió detectar pipeline-only con .claude/skills/<>/SKILL.md');
             }},
         ]);
         return;


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 6 archivos · +658 -11

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:skipped` aplicado por delivery

## Closes

Closes #2398
