### PR TITLE
[guru] Implementar consumer runtime de skill.fallbacks[] en agent-launcher (dispatch con retry cross-provider)

### DIFF
--- a/.pipeline/lib/agent-launcher/dispatch-with-fallback.js
+++ b/.pipeline/lib/agent-launcher/dispatch-with-fallback.js
@@ -1,0 +1,543 @@
+// =============================================================================
+// dispatch-with-fallback.js — Consumer runtime del array `skill.fallbacks[]`.
+//
+// Issue: #3198 (consumer runtime de skill.fallbacks).
+//
+// Hasta este módulo, el campo `skills.<name>.fallbacks: []` de
+// `agent-models.json` estaba **soportado en schema + validado + editable
+// desde UI + diffeable** (PR #3177 entregó la cadena) pero NO había consumer
+// en runtime. Si el provider primario quedaba gateado por cuota agotada,
+// el archivo de trabajo volvía a `pendiente/` y se quedaba esperando reset,
+// sin intentar con los providers declarados como fallback.
+//
+// Este módulo cierra esa promesa: cuando `shouldGateSpawn(skill, {provider})`
+// bloquearía al primario, iteramos `fallbacks[]` y devolvemos la primera
+// resolución no-gated.
+//
+// ARQUITECTURA
+// -----------
+// El dispatcher corre **pre-spawn**, en el mismo punto del flow que el gate
+// global (pulpo.js → bloque `shouldGateSpawn`). Es pasivo: NO cambia el
+// flow del happy path (primario disponible) — sólo entra en juego cuando
+// hay flag de cuota activo para el provider primario del skill.
+//
+// El gate del pulpo evoluciona de:
+//   if (shouldGateSpawn(skill, { provider: primary })) → mover a pendiente/.
+// a:
+//   const r = resolveSpawnWithFallback({...});
+//   if (r.gated) → mover a pendiente/, sino spawn con r.provider/r.model.
+//
+// POLÍTICA DUAL (§4.1 doc canónico)
+// ---------------------------------
+// - **Cross-MODELO** (mismo provider, distinto modelo): N/A en este PR. El
+//   array `fallbacks[]` lista provider names — no soporta cross-modelo
+//   per-skill. Cross-modelo se hace via `model_override` + selector
+//   autónomo (`docs/pipeline-multi-provider.md` §4.3, fuera del scope #3198).
+// - **Cross-PROVIDER** (provider distinto del primario): EL OPT-IN HUMANO ES
+//   LA DECLARACIÓN DEL ARRAY EN AGENT-MODELS.JSON. La UI dashboard #3177
+//   permite agregar/quitar fallbacks con confirmación humana — esa edición
+//   ES la aprobación. No agregamos doble barrera porque rompería la promesa
+//   "configurá fallbacks y el pipeline sigue funcionando" del issue.
+//
+//   La defensa adicional (S-6 del análisis de security) es:
+//     1) audit log con hash-chain SHA-256 (`logs/cross-provider-dispatch-*.jsonl`)
+//     2) notificación Telegram via queue de archivos (sin LLM en el camino)
+//     3) cap de profundidad MAX_FALLBACK_DEPTH (5)
+//     4) anti-cycle con `Set<providerName>` ya intentados
+//     5) skip si el fallback comparte el provider gated (mismo flag scope).
+//
+// DEFENSAS DE SEGURIDAD (S-1 a S-9 del análisis security en el issue)
+// -------------------------------------------------------------------
+// S-1: Detección de cuota delegada a `quotaModule.shouldGateSpawn` —
+//      reutilizamos shape estructural, NUNCA matcheamos por substring.
+// S-2: Aislamiento de credenciales — este módulo NO arma env del child. El
+//      caller (pulpo.js) ya invoca `env-isolation` con el provider resuelto,
+//      así que cuando devolvemos un fallback el env queda construido a
+//      partir del handler del fallback, no del primario.
+// S-3: Validación del nombre del provider — invocamos `getProviderHandler`
+//      contra la tabla hardcoded; el boot-time validator ya garantiza que
+//      cada item del array está en `providers`.
+// S-4: Path traversal en flag de pending — N/A acá (no escribimos pending
+//      flag por skill: el opt-in es la presencia del array en config).
+// S-5: Cycle/depth limit — MAX_FALLBACK_DEPTH=5 + Set<providerName> ya intentados.
+// S-6: Sanitización del audit log — passthrough a `audit-log.appendChained`,
+//      que ya redacta con hash-chain. raw_excerpt pasa por
+//      `quotaModule.sanitizeRawExcerpt` antes de ir al log.
+// S-7: Política dual — opt-in vía presencia del array (decisión PO).
+// S-8: Quota flag scoping — el fallback NO limpia el flag del primario.
+//      `clearFlag` ya respeta scope per-provider (#3077 CA-8).
+// S-9: Telegram via filesystem queue — escribimos a
+//      `.pipeline/servicios/telegram/pendiente/<ts>.json`, NO curl directo.
+//
+// SIN dependencias externas (Node puro: fs, path, crypto via audit-log).
+// =============================================================================
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { resolveProviderForSkill, getProviderHandler } = require('./resolve-provider');
+
+// -----------------------------------------------------------------------------
+// Constantes
+// -----------------------------------------------------------------------------
+
+// S-5: cap de profundidad de la chain para evitar recursión patológica.
+// 5 es generoso para la mayoría de configs (Anthropic → OpenAI → Gemini → ...).
+const MAX_FALLBACK_DEPTH = 5;
+
+// Sub-directorio donde se encola la notificación Telegram (servicio drainer
+// la procesa fuera del path crítico del pulpo).
+const TELEGRAM_QUEUE_SUBDIR = path.join('servicios', 'telegram', 'pendiente');
+
+// Audit log dedicado al dispatch con fallback. Día rotación natural para
+// trazabilidad por fecha de incidente.
+function dispatchAuditFile(pipelineDir, now = new Date()) {
+    const yyyy = now.getUTCFullYear();
+    const mm = String(now.getUTCMonth() + 1).padStart(2, '0');
+    const dd = String(now.getUTCDate()).padStart(2, '0');
+    return path.join(pipelineDir, 'logs', `cross-provider-dispatch-${yyyy}-${mm}-${dd}.jsonl`);
+}
+
+// -----------------------------------------------------------------------------
+// readAgentModelsRaw — lectura defensiva idéntica a resolve-provider.js pero
+// exportable, porque acá necesitamos el `skills.<name>.fallbacks` además del
+// resolved primary.
+// -----------------------------------------------------------------------------
+function readAgentModelsRaw(pipelineDir, fsImpl) {
+    const _fs = fsImpl || fs;
+    if (!pipelineDir) return null;
+    const modelsPath = path.join(pipelineDir, 'agent-models.json');
+    try {
+        if (!_fs.existsSync(modelsPath)) return null;
+        return JSON.parse(_fs.readFileSync(modelsPath, 'utf8'));
+    } catch {
+        return null;
+    }
+}
+
+// -----------------------------------------------------------------------------
+// enqueueTelegramNotice — encola un mensaje en la queue de archivos del
+// servicio Telegram (S-9). NUNCA hace fetch/curl directo: el drainer fuera
+// del path crítico lo procesa.
+//
+// Best-effort: errores de IO se silencian para no romper el pipeline (el
+// dispatcher NUNCA debe ser causa de crash).
+// -----------------------------------------------------------------------------
+function enqueueTelegramNotice({ pipelineDir, fsImpl, text, meta }) {
+    const _fs = fsImpl || fs;
+    if (!pipelineDir || !text) return false;
+    try {
+        const queueDir = path.join(pipelineDir, TELEGRAM_QUEUE_SUBDIR);
+        _fs.mkdirSync(queueDir, { recursive: true });
+        // Nombre con timestamp + pid para evitar colisiones entre procesos
+        // concurrentes (caller puede ser pulpo + un script de mantenimiento).
+        const fname = `cross-provider-${Date.now()}-${process.pid}.json`;
+        const payload = JSON.stringify({
+            type: 'cross-provider-fallback',
+            text,
+            meta: meta || {},
+            queued_at: new Date().toISOString(),
+        }, null, 2);
+        _fs.writeFileSync(path.join(queueDir, fname), payload, { mode: 0o600 });
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+// -----------------------------------------------------------------------------
+// auditAppend — append-only entry al audit log dedicado con hash-chain.
+//
+// El módulo `lib/audit-log.js` (#3082) ya provee `appendChained` con SHA-256
+// chain. Lo reusamos para no duplicar el patrón. Sanitización del
+// raw_excerpt se delega a `quotaModule.sanitizeRawExcerpt` (S-6).
+//
+// Best-effort: errores de IO se silencian (S-6 / best-effort idéntico al
+// detector de cuota).
+// -----------------------------------------------------------------------------
+function auditAppend({ pipelineDir, fsImpl, entry, sanitize, auditLog, now }) {
+    if (!pipelineDir || !entry) return false;
+    try {
+        const _audit = auditLog || require('../audit-log');
+        const file = dispatchAuditFile(pipelineDir, now ? new Date(now) : undefined);
+        const safe = {
+            ...entry,
+            raw_excerpt: typeof sanitize === 'function'
+                ? sanitize(entry.raw_excerpt)
+                : (entry.raw_excerpt || ''),
+        };
+        _audit.appendChained({ file, entry: safe, fsImpl });
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+// -----------------------------------------------------------------------------
+// resolveSpawnWithFallback — resuelve el provider efectivo para el spawn,
+// consultando el primary y, si está gated, iterando `fallbacks[]`.
+//
+// Contrato:
+//   input: {
+//     skill,                     // nombre del skill (string)
+//     issue,                     // número del issue (informativo, para audit)
+//     pipelineDir,               // .pipeline path (para leer agent-models.json y escribir audit)
+//     fsImpl,                    // override fs (tests)
+//     quotaModule,               // require('../quota-exhausted')
+//     primaryResolver,           // override resolveProviderForSkill (tests)
+//     providerHandlerResolver,   // override getProviderHandler (tests)
+//     auditLog,                  // override require('../audit-log') (tests)
+//     notify,                    // override enqueueTelegramNotice (tests)
+//     onLog,                     // callback(level, message) — logging del caller (best-effort)
+//     now,                       // Date.now() override (tests)
+//   }
+//
+//   output: {
+//     provider,               // provider efectivo a usar para el spawn
+//     model,                  // model resolvido (puede ser null si N/A)
+//     handler,                // handler del provider efectivo
+//     source,                 // 'primary' | 'fallback' | 'all-gated'
+//     gated,                  // true si NO se puede spawnear (primary y todos los fallbacks gated)
+//     fallbackUsed,           // { index, provider } si source === 'fallback', sino null
+//     primaryProvider,        // provider primario originalmente resuelto
+//     chainTried,             // [providerName, ...] orden de intentos
+//     crossProvider,          // true si el fallback elegido es de otro provider que el primary
+//     depthExceeded,          // true si la chain superó MAX_FALLBACK_DEPTH
+//   }
+//
+// REGLAS
+// ------
+// 1. Si el primario NO está gateado → devolver primary (source: 'primary').
+// 2. Si está gateado y el skill no tiene `fallbacks[]` → devolver primary +
+//    gated:true (caller mueve a pendiente/).
+// 3. Iterar `fallbacks[]` en orden, hasta MAX_FALLBACK_DEPTH:
+//    a. Si el fallback se repite (cycle) → skip + audit.
+//    b. Si el fallback no está en la tabla hardcoded de handlers → skip + audit.
+//    c. Si el fallback == primary → skip (defense in depth, validator ya
+//       lo prohíbe pero blindamos).
+//    d. Si el fallback también está gateado (mismo provider o flag scoped
+//       a ese provider) → skip + audit.
+//    e. Si está libre → devolver fallback (source: 'fallback') + audit +
+//       notificar Telegram.
+// 4. Si la chain se agota sin candidato → source: 'all-gated' + gated:true.
+// 5. Si la chain supera MAX_FALLBACK_DEPTH → cortar + audit "depth_exceeded"
+//    + tratar como all-gated.
+// -----------------------------------------------------------------------------
+function resolveSpawnWithFallback(opts = {}) {
+    const {
+        skill,
+        issue,
+        pipelineDir,
+        fsImpl,
+        quotaModule,
+        primaryResolver,
+        providerHandlerResolver,
+        auditLog,
+        notify,
+        onLog,
+        now,
+    } = opts;
+
+    const log = typeof onLog === 'function' ? onLog : () => {};
+    const _resolveProvider = primaryResolver || resolveProviderForSkill;
+    const _resolveHandler = providerHandlerResolver || getProviderHandler;
+    const _notify = notify || enqueueTelegramNotice;
+    const _now = Number.isFinite(now) ? now : Date.now();
+
+    // -------------------------------------------------------------------------
+    // 1. Resolver el provider primario.
+    // -------------------------------------------------------------------------
+    const primary = _resolveProvider(skill, { pipelineDir, fsImpl });
+    const primaryProvider = primary && primary.provider;
+
+    // Si no hay quotaModule, devolvemos el primary sin gate (modo legacy).
+    if (!quotaModule || typeof quotaModule.shouldGateSpawn !== 'function') {
+        return {
+            ...primary,
+            source: primary.source || 'primary',
+            gated: false,
+            fallbackUsed: null,
+            primaryProvider,
+            chainTried: [primaryProvider],
+            crossProvider: false,
+            depthExceeded: false,
+        };
+    }
+
+    // Skills determinísticos no se gatean — devolvemos el primary tal cual.
+    if (primary.provider === 'deterministic') {
+        return {
+            ...primary,
+            source: primary.source || 'primary',
+            gated: false,
+            fallbackUsed: null,
+            primaryProvider,
+            chainTried: [primaryProvider],
+            crossProvider: false,
+            depthExceeded: false,
+        };
+    }
+
+    const primaryGated = quotaModule.shouldGateSpawn(skill, {
+        provider: primaryProvider,
+        now: _now,
+    });
+
+    if (!primaryGated) {
+        // Happy path: primary disponible.
+        return {
+            ...primary,
+            source: primary.source || 'primary',
+            gated: false,
+            fallbackUsed: null,
+            primaryProvider,
+            chainTried: [primaryProvider],
+            crossProvider: false,
+            depthExceeded: false,
+        };
+    }
+
+    // -------------------------------------------------------------------------
+    // 2. Primary gateado → consultar fallbacks[] del skill.
+    // -------------------------------------------------------------------------
+    const models = readAgentModelsRaw(pipelineDir, fsImpl);
+    const skillCfg = (models && models.skills && models.skills[skill]) || null;
+    const fallbacks = skillCfg && Array.isArray(skillCfg.fallbacks) ? skillCfg.fallbacks : [];
+
+    const chainTried = [primaryProvider];
+    const sanitize = quotaModule.sanitizeRawExcerpt || ((s) => String(s || ''));
+
+    if (fallbacks.length === 0) {
+        // Sin fallbacks declarados → comportamiento previo (gate clásico).
+        auditAppend({
+            pipelineDir, fsImpl, sanitize, auditLog, now: _now,
+            entry: {
+                event: 'gated_no_fallbacks',
+                skill,
+                issue: issue || null,
+                primary_provider: primaryProvider,
+                primary_model: primary.model || null,
+                fallbacks_declared: 0,
+                raw_excerpt: `skill=${skill} provider=${primaryProvider} no_fallbacks`,
+            },
+        });
+        return {
+            ...primary,
+            source: 'all-gated',
+            gated: true,
+            fallbackUsed: null,
+            primaryProvider,
+            chainTried,
+            crossProvider: false,
+            depthExceeded: false,
+        };
+    }
+
+    // -------------------------------------------------------------------------
+    // 3. Iterar fallbacks en orden.
+    // -------------------------------------------------------------------------
+    const tried = new Set([primaryProvider]);
+    let depthExceeded = false;
+
+    for (let i = 0; i < fallbacks.length; i++) {
+        if (i >= MAX_FALLBACK_DEPTH) {
+            depthExceeded = true;
+            auditAppend({
+                pipelineDir, fsImpl, sanitize, auditLog, now: _now,
+                entry: {
+                    event: 'depth_exceeded',
+                    skill,
+                    issue: issue || null,
+                    primary_provider: primaryProvider,
+                    max_depth: MAX_FALLBACK_DEPTH,
+                    declared_length: fallbacks.length,
+                    raw_excerpt: `chain_length=${fallbacks.length} max=${MAX_FALLBACK_DEPTH}`,
+                },
+            });
+            log('lanzamiento', `⚠️ ${skill}:#${issue} chain de fallbacks superó MAX_FALLBACK_DEPTH=${MAX_FALLBACK_DEPTH}, corto.`);
+            break;
+        }
+
+        const fbName = fallbacks[i];
+
+        // 3.a — cycle/anti-duplicate
+        if (tried.has(fbName)) {
+            auditAppend({
+                pipelineDir, fsImpl, sanitize, auditLog, now: _now,
+                entry: {
+                    event: 'fallback_cycle_skipped',
+                    skill,
+                    issue: issue || null,
+                    fallback_index: i,
+                    fallback_provider: fbName,
+                    raw_excerpt: `already_tried=${Array.from(tried).join(',')}`,
+                },
+            });
+            continue;
+        }
+        tried.add(fbName);
+        chainTried.push(fbName);
+
+        // 3.b — handler debe existir (defense in depth; validator ya lo
+        // chequea al boot pero blindamos en runtime para que un agent-models.json
+        // editado a mano con nombre inválido NO crashee el dispatcher).
+        let fbHandler;
+        try {
+            fbHandler = _resolveHandler(fbName);
+        } catch (e) {
+            auditAppend({
+                pipelineDir, fsImpl, sanitize, auditLog, now: _now,
+                entry: {
+                    event: 'fallback_unknown_provider',
+                    skill,
+                    issue: issue || null,
+                    fallback_index: i,
+                    fallback_provider: fbName,
+                    raw_excerpt: `error=${e.message}`,
+                },
+            });
+            log('lanzamiento', `⚠️ ${skill}:#${issue} fallback "${fbName}" desconocido (índice ${i}), salto.`);
+            continue;
+        }
+
+        // 3.c — defense in depth: fallback == primary (validator lo prohíbe).
+        if (fbName === primaryProvider) {
+            auditAppend({
+                pipelineDir, fsImpl, sanitize, auditLog, now: _now,
+                entry: {
+                    event: 'fallback_duplicates_primary',
+                    skill,
+                    issue: issue || null,
+                    fallback_index: i,
+                    fallback_provider: fbName,
+                    primary_provider: primaryProvider,
+                    raw_excerpt: 'duplicate_primary',
+                },
+            });
+            continue;
+        }
+
+        // 3.d — el fallback también puede estar gateado (otro flag activo).
+        const fbGated = quotaModule.shouldGateSpawn(skill, {
+            provider: fbName,
+            now: _now,
+        });
+        if (fbGated) {
+            auditAppend({
+                pipelineDir, fsImpl, sanitize, auditLog, now: _now,
+                entry: {
+                    event: 'fallback_also_gated',
+                    skill,
+                    issue: issue || null,
+                    fallback_index: i,
+                    fallback_provider: fbName,
+                    primary_provider: primaryProvider,
+                    raw_excerpt: `fallback_${fbName}_gated_too`,
+                },
+            });
+            continue;
+        }
+
+        // 3.e — candidato libre. Resolver model para el fallback.
+        const fbProviderDef = (models && models.providers && models.providers[fbName]) || null;
+        const fbModel = (skillCfg && skillCfg.model_override)
+            || (fbProviderDef && fbProviderDef.model)
+            || (models && models.defaults && models.defaults.model)
+            || null;
+
+        // Audit + notify (S-6 / S-9).
+        auditAppend({
+            pipelineDir, fsImpl, sanitize, auditLog, now: _now,
+            entry: {
+                event: 'fallback_selected',
+                skill,
+                issue: issue || null,
+                fallback_index: i,
+                fallback_provider: fbName,
+                fallback_model: fbModel,
+                primary_provider: primaryProvider,
+                primary_model: primary.model || null,
+                cross_provider: true,
+                chain_tried: chainTried,
+                raw_excerpt: `primary=${primaryProvider} gated, fallback=${fbName} libre`,
+            },
+        });
+
+        const notice =
+            `⚠️ Cross-provider fallback activo\n` +
+            `skill=${skill} issue=${issue || '?'}\n` +
+            `primary=${primaryProvider} (gated)\n` +
+            `fallback=${fbName} (índice ${i})\n` +
+            `model=${fbModel || 'n/a'}`;
+        try {
+            _notify({
+                pipelineDir,
+                fsImpl,
+                text: notice,
+                meta: {
+                    skill,
+                    issue: issue || null,
+                    primary_provider: primaryProvider,
+                    fallback_provider: fbName,
+                    fallback_index: i,
+                    fallback_model: fbModel,
+                },
+            });
+        } catch { /* best-effort */ }
+
+        log('lanzamiento', `↪️ ${skill}:#${issue} primary=${primaryProvider} gated, usando fallback="${fbName}" (índice ${i})`);
+
+        return {
+            provider: fbName,
+            model: fbModel,
+            handler: fbHandler,
+            source: 'fallback',
+            gated: false,
+            fallbackUsed: { index: i, provider: fbName },
+            primaryProvider,
+            chainTried,
+            crossProvider: true,
+            depthExceeded: false,
+        };
+    }
+
+    // -------------------------------------------------------------------------
+    // 4. Chain agotada sin candidato libre.
+    // -------------------------------------------------------------------------
+    auditAppend({
+        pipelineDir, fsImpl, sanitize, auditLog, now: _now,
+        entry: {
+            event: 'chain_exhausted',
+            skill,
+            issue: issue || null,
+            primary_provider: primaryProvider,
+            chain_tried: chainTried,
+            depth_exceeded: depthExceeded,
+            raw_excerpt: `all_gated chain=${chainTried.join('->')}`,
+        },
+    });
+    log('lanzamiento', `🚫 ${skill}:#${issue} chain de fallbacks agotada (primario + ${fallbacks.length} fallbacks gated o inválidos).`);
+
+    return {
+        ...primary,
+        source: 'all-gated',
+        gated: true,
+        fallbackUsed: null,
+        primaryProvider,
+        chainTried,
+        crossProvider: false,
+        depthExceeded,
+    };
+}
+
+module.exports = {
+    resolveSpawnWithFallback,
+    enqueueTelegramNotice,
+    dispatchAuditFile,
+    MAX_FALLBACK_DEPTH,
+    TELEGRAM_QUEUE_SUBDIR,
+    // exposed for tests
+    _readAgentModelsRaw: readAgentModelsRaw,
+    _auditAppend: auditAppend,
+};

--- a/.pipeline/lib/build-child-env.js
+++ b/.pipeline/lib/build-child-env.js
@@ -19,7 +19,20 @@
 //     pipelineExtras: { PIPELINE_ISSUE: '1234', ... },
 //     // inyectables para tests:
 //     fsImpl, skillConfigOverride: { skill: {...}, providers: {...} },
+//     // o partial-override #3198 (cross-provider fallback runtime):
+//     skillConfigOverride: { provider: 'openai-codex' },
 //   });
+//
+// **Override shapes** (`skillConfigOverride`):
+//   - Full: `{ skill: {...}, providers: {...} }` — reemplaza por completo lo
+//     que se hubiera leído de `agent-models.json`. Usado por tests y por el
+//     commander (pulpo.js).
+//   - Partial (#3198): `{ provider: '<name>' }` — el dispatcher de fallback
+//     resolvió que el child debe correr con otro provider. Mergeamos el
+//     skill leído de disk con `{ provider: <override> }` y conservamos el
+//     `providers` config completo del disk para resolver `credentials_env`
+//     del fallback. Indispensable para S-2: garantiza que el child del
+//     fallback reciba SOLO la API key del fallback (no la del primary).
 //
 // **Estrategia**:
 //   1. Allowlist hardcoded de variables del sistema (Windows-compatible).
@@ -214,10 +227,34 @@ function readAgentModelsDefensive(pipelineDir, fsImpl) {
 function resolveSkillConfig(skill, opts = {}) {
     const { pipelineDir, fsImpl, skillConfigOverride } = opts;
 
+    // Full override: tests + commander pasan ambos campos.
     if (skillConfigOverride && skillConfigOverride.skill !== undefined) {
         return {
             skillCfg: skillConfigOverride.skill || {},
             providersCfg: skillConfigOverride.providers || {},
+        };
+    }
+
+    // Partial override (#3198): el dispatcher de fallback decide en runtime
+    // que el child debe correr con otro provider (ej. anthropic→openai-codex).
+    // Mergeamos el skillCfg leído de disk con `{ provider: <override> }` para
+    // que el resto de la config (requires_credentials, model, etc.) se
+    // preserve, pero el `provider` apunte al FALLBACK. Conservamos los
+    // `providers` config completos del disk para que `credentials_env` del
+    // fallback se resuelva correctamente.
+    //
+    // INVARIANTE S-2 (defensa cross-provider credential isolation):
+    //   Cuando esta rama dispara, el `providerKeyVar` resultante DEBE ser el
+    //   del fallback (ej. OPENAI_API_KEY), nunca el del primary
+    //   (ej. ANTHROPIC_API_KEY). Tests dedicados en
+    //   build-child-env.test.js (#3198) verifican el invariante.
+    if (skillConfigOverride && typeof skillConfigOverride.provider === 'string') {
+        const models = readAgentModelsDefensive(pipelineDir, fsImpl);
+        const diskSkillCfg = (models && models.skills && models.skills[skill]) || {};
+        const providersCfg = (models && models.providers) || {};
+        return {
+            skillCfg: { ...diskSkillCfg, provider: skillConfigOverride.provider },
+            providersCfg,
         };
     }
 

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -86,6 +86,11 @@ const { createQuotaNotifier, DEFAULT_REMINDER_INTERVAL_MIN } = require('./lib/qu
 // deterministic / openai-codex). Reemplaza el bloque inline de spawn de Claude
 // que vivía acá pre-refactor (~líneas 4900-4994 de la versión previa).
 const { launchAgent } = require('./lib/agent-launcher');
+// #3198 — consumer runtime de skill.fallbacks[]. Cuando el provider primario
+// queda gateado por cuota, el dispatcher itera el array y devuelve la primera
+// resolución no-gated en lugar de devolver el archivo a pendiente/. Mantiene
+// hash-chain SHA-256 en logs/cross-provider-dispatch-*.jsonl + notify Telegram.
+const { resolveSpawnWithFallback } = require('./lib/agent-launcher/dispatch-with-fallback');
 // #3155: creación de worktree con recovery de branches huérfanas. Reemplaza
 // el bloque inline previo (`git worktree add -b ... origin/main`) que fallaba
 // cada vez que una iteración anterior dejaba la branch `agent/<n>-<skill>`
@@ -4922,19 +4927,25 @@ function lanzarAgenteClaude(skill, issue, trabajandoPath, pipeline, fase, config
   // devuelve a `pendiente/` naturalmente, y cuando el flag se borre (drenado
   // post-reset o spawn exitoso), el filesystem-como-cola los recoge sin lógica
   // adicional. CA-1/CA-2 del issue.
+  // #3198 — consumer runtime de skill.fallbacks[]: si el primary queda gateado
+  // por cuota, intentamos los providers declarados como fallback antes de
+  // devolver el archivo a pendiente/. Devuelve `{ provider, model, source,
+  // gated, fallbackUsed }`. Cuando `source === 'fallback'`, el spawn arranca
+  // con el provider del fallback (cross-provider switch) y el archivo NO vuelve
+  // a pendiente/. Cuando `gated === true` (primary + todos los fallbacks
+  // gated), el comportamiento es idéntico al gate clásico (#3077).
+  let dispatchResolution = null;
   try {
-    // #3077 CA-7 / SEC-5: scope por provider. Resolvemos el provider del skill
-    // desde agent-models.json y lo pasamos al gate. Si el flag activo es de un
-    // provider distinto al del skill, el gate deja pasar — multi-provider real.
-    let skillProvider = null;
-    let skillModel = null;
-    try {
-      skillProvider = resolveSkillProvider(skill);
-      skillModel = resolveSkillModel(skill);
-    } catch { /* defensa: si la resolución falla, caemos al gate global */ }
+    dispatchResolution = resolveSpawnWithFallback({
+      skill,
+      issue,
+      pipelineDir: PIPELINE,
+      quotaModule: quotaExhausted,
+      onLog: log,
+    });
 
-    if (quotaExhausted.shouldGateSpawn(skill, { provider: skillProvider })) {
-      log('lanzamiento', `🚫 ${skill}:#${issue} bloqueado por quota-exhausted (LLM, flag activo, provider=${skillProvider || 'unknown'}) — devuelvo a pendiente/`);
+    if (dispatchResolution.gated) {
+      log('lanzamiento', `🚫 ${skill}:#${issue} bloqueado por quota-exhausted (LLM, primary=${dispatchResolution.primaryProvider || 'unknown'} y ${(dispatchResolution.chainTried || []).length - 1} fallback(s) gated) — devuelvo a pendiente/`);
       try {
         const pendienteDir = path.join(fasePath(pipeline, fase), 'pendiente');
         moveFile(trabajandoPath, pendienteDir);
@@ -4943,20 +4954,24 @@ function lanzarAgenteClaude(skill, issue, trabajandoPath, pipeline, fase, config
         quotaExhausted.appendAudit({
           event: 'gate_blocked_spawn',
           agent: skill,
-          provider: skillProvider,
-          model: skillModel,
+          provider: dispatchResolution.primaryProvider,
+          model: dispatchResolution.model || null,
           error_type: null,
-          raw_excerpt: `issue=${issue} fase=${fase} pipeline=${pipeline}`,
+          raw_excerpt: `issue=${issue} fase=${fase} pipeline=${pipeline} chain=${(dispatchResolution.chainTried || []).join('->')}`,
           flag_set: true,
         });
       } catch {}
       return;
     }
+
+    if (dispatchResolution.source === 'fallback' && dispatchResolution.fallbackUsed) {
+      log('lanzamiento', `↪️ ${skill}:#${issue} primary=${dispatchResolution.primaryProvider} gated, spawn con fallback="${dispatchResolution.fallbackUsed.provider}" (índice ${dispatchResolution.fallbackUsed.index}).`);
+    }
   } catch (gateErr) {
-    // Best-effort: si el gate falla por bug, NO bloqueamos el spawn — preferimos
+    // Best-effort: si el dispatcher falla por bug, NO bloqueamos el spawn — preferimos
     // que el pipeline siga operativo aún con detector roto. El siguiente result
     // event con is_error=true volverá a setear el flag.
-    log('lanzamiento', `⚠️ gate quota-exhausted falló para ${skill}:#${issue}: ${gateErr.message} — continúo con spawn`);
+    log('lanzamiento', `⚠️ dispatcher de fallback falló para ${skill}:#${issue}: ${gateErr.message} — continúo con spawn`);
   }
 
   // INVARIANTE CRÍTICO: el skill debe pertenecer a skills_por_fase[fase] de este pipeline.
@@ -5296,11 +5311,24 @@ function lanzarAgenteClaude(skill, issue, trabajandoPath, pipeline, fase, config
   } catch { /* sin config legible: default false (preserva legacy) */ }
   if (envIsolationEnabled) {
     try {
+      // #3198 / S-2: cuando el dispatcher eligió un fallback, construimos el
+      // env con el PROVIDER DEL FALLBACK — no el primary. Eso garantiza que
+      // un child Anthropic→OpenAI reciba sólo OPENAI_API_KEY (S-2 isolation).
+      // El override se pasa vía `skillConfigOverride`, que tiene precedencia
+      // sobre la lectura de agent-models.json.
+      const skillConfigOverride = (
+        dispatchResolution &&
+        dispatchResolution.source === 'fallback' &&
+        dispatchResolution.provider
+      )
+        ? { provider: dispatchResolution.provider }
+        : undefined;
       childEnv = buildChildEnvLib.buildChildEnv({
         skill,
         pipelineDir: PIPELINE,
         processEnv: process.env,
         pipelineExtras,
+        skillConfigOverride,
       });
     } catch (e) {
       // Fail-fast: si la API key del provider falta, NO arrancar el child.
@@ -5313,6 +5341,23 @@ function lanzarAgenteClaude(skill, issue, trabajandoPath, pipeline, fase, config
     childEnv = { ...process.env, ...pipelineExtras };
   }
 
+  // #3198 — si el dispatcher resolvió un fallback, pasamos un `resolveImpl`
+  // que devuelve esa resolución completa para que `launchAgent` use el handler
+  // y el modelo del fallback (no del primary). Sin esta línea, el launcher
+  // re-resolvería desde agent-models.json y volvería al primary.
+  const launchResolveImpl = (
+    dispatchResolution &&
+    dispatchResolution.source === 'fallback' &&
+    dispatchResolution.handler
+  )
+    ? () => ({
+        provider: dispatchResolution.provider,
+        model: dispatchResolution.model,
+        handler: dispatchResolution.handler,
+        source: 'dispatch-fallback',
+      })
+    : undefined;
+
   const launchResult = launchAgent({
     skill, issue, trabajandoPath, fase, pipeline,
     args,
@@ -5322,6 +5367,7 @@ function lanzarAgenteClaude(skill, issue, trabajandoPath, pipeline, fase, config
     ROOT,
     onWorktreeHit: (wt) => log('lanzamiento', `⚡ ${skill}:#${issue} usa script del worktree (${wt})`),
     onLog: log,
+    resolveImpl: launchResolveImpl,
   });
   const child = launchResult.child;
   const useDeterministicSkill = (launchResult.provider === 'deterministic');

--- a/.pipeline/tests/build-child-env.test.js
+++ b/.pipeline/tests/build-child-env.test.js
@@ -580,3 +580,207 @@ test('DEFAULT_REQUIRES_BY_SKILL solo declara scopes que existen en CREDENTIAL_SC
         }
     }
 });
+
+// =============================================================================
+// #3198 — Partial override shape `{ provider }` (cross-provider fallback runtime)
+//
+// Cuando el dispatcher de fallback (resolveSpawnWithFallback) decide que un
+// child debe correr con OTRO provider distinto al primary, le pasamos a
+// buildChildEnv sólo `{ provider: '<fallback>' }`. El helper DEBE mergear
+// con el skill leído de disk para resolver `credentials_env` correctamente.
+//
+// Invariante crítico de seguridad (S-2): el child del fallback recibe
+// SOLO la API key del FALLBACK, NUNCA la del primary.
+// =============================================================================
+test('#3198: partial override { provider } mergea con skill cfg de disk y selecciona la API key del FALLBACK', () => {
+    const fakeFs = {
+        existsSync: () => true,
+        readFileSync: () => JSON.stringify({
+            providers: {
+                anthropic: { credentials_env: 'ANTHROPIC_API_KEY' },
+                'openai-codex': { credentials_env: 'OPENAI_API_KEY' },
+            },
+            skills: {
+                guru: { provider: 'anthropic', requires_credentials: ['github'] },
+            },
+        }),
+    };
+    const env = buildChildEnv({
+        skill: 'guru',
+        pipelineDir: '/fake/.pipeline',
+        fsImpl: fakeFs,
+        processEnv: fullOperatorEnv(),
+        // Dispatcher resuelve fallback openai-codex sólo nombrando el provider:
+        skillConfigOverride: { provider: 'openai-codex' },
+    });
+    // S-2: el child del fallback recibe SOLO la OPENAI_API_KEY, NO la ANTHROPIC_API_KEY.
+    assert.equal(env.OPENAI_API_KEY, 'sk-openai-XXXXX', 'OPENAI_API_KEY del fallback debe estar presente');
+    assert.equal(env.ANTHROPIC_API_KEY, undefined, 'ANTHROPIC_API_KEY del primary NO debe leakear al child del fallback');
+    // El skill conserva su scope github (mergeo correcto con disk):
+    assert.equal(env.GH_TOKEN, 'ghp_XXXXX');
+});
+
+test('#3198: partial override { provider } repro exacto del rejection (anthropic primary → openai-codex fallback)', () => {
+    // Repro empírico del motivo_rechazo de #3198 con processEnv reducido:
+    const fakeFs = {
+        existsSync: () => true,
+        readFileSync: () => JSON.stringify({
+            providers: {
+                anthropic: { credentials_env: 'ANTHROPIC_API_KEY' },
+                'openai-codex': { credentials_env: 'OPENAI_API_KEY' },
+            },
+            skills: {
+                guru: { provider: 'anthropic' },
+            },
+        }),
+    };
+    const env = buildChildEnv({
+        skill: 'guru',
+        pipelineDir: '/c/Workspaces/Intrale/platform/.pipeline',
+        fsImpl: fakeFs,
+        processEnv: {
+            PATH: '/tmp/path',
+            SystemRoot: 'C:/Windows',
+            ANTHROPIC_API_KEY: 'sk-ant-test',
+            OPENAI_API_KEY: 'sk-openai-test',
+            GH_TOKEN: 'ghtok',
+            TELEGRAM_BOT_TOKEN: 'tg',
+            TELEGRAM_CHAT_ID: '123',
+        },
+        pipelineExtras: { PIPELINE_ISSUE: '3198' },
+        skillConfigOverride: { provider: 'openai-codex' },
+    });
+    // Estos eran los aserts que fallaban antes del fix (resultado de la verificación):
+    assert.equal('ANTHROPIC_API_KEY' in env, false, 'PRIMARY key NO debe filtrarse al child del fallback (era true antes del fix)');
+    assert.equal('OPENAI_API_KEY' in env, true, 'FALLBACK key DEBE estar presente (era false antes del fix)');
+});
+
+test('#3198: partial override { provider } NO confunde con full override { skill, providers }', () => {
+    // Si el caller pasa ambos campos (skill = override completo), gana el path
+    // de full override y se ignora providers leídos de disk.
+    const fakeFs = {
+        existsSync: () => true,
+        readFileSync: () => JSON.stringify({
+            providers: { anthropic: { credentials_env: 'ANTHROPIC_API_KEY' } },
+            skills: { guru: { provider: 'anthropic' } },
+        }),
+    };
+    const env = buildChildEnv({
+        skill: 'guru',
+        pipelineDir: '/fake/.pipeline',
+        fsImpl: fakeFs,
+        processEnv: fullOperatorEnv(),
+        skillConfigOverride: {
+            skill: { provider: 'openai-codex', requires_credentials: [] },
+            providers: { 'openai-codex': { credentials_env: 'OPENAI_API_KEY' } },
+        },
+    });
+    // Path de full override: usa los providers del override, no los de disk.
+    assert.equal(env.OPENAI_API_KEY, 'sk-openai-XXXXX');
+    assert.equal(env.ANTHROPIC_API_KEY, undefined);
+});
+
+test('#3198: partial override { provider } sin agent-models.json cae a PROVIDER_DEFAULT_CREDENTIAL_ENV', () => {
+    // Caso degradado: si agent-models.json no existe en disk, el helper aún
+    // debe resolver la API key del FALLBACK usando PROVIDER_DEFAULT_CREDENTIAL_ENV.
+    const fakeFs = {
+        existsSync: () => false,  // sin agent-models.json
+        readFileSync: () => { throw new Error('no debería leerse'); },
+    };
+    const env = buildChildEnv({
+        skill: 'guru',
+        pipelineDir: '/fake/.pipeline',
+        fsImpl: fakeFs,
+        processEnv: fullOperatorEnv(),
+        skillConfigOverride: { provider: 'openai-codex' },
+    });
+    // PROVIDER_DEFAULT_CREDENTIAL_ENV['openai-codex'] === 'OPENAI_API_KEY'
+    assert.equal(env.OPENAI_API_KEY, 'sk-openai-XXXXX');
+    assert.equal(env.ANTHROPIC_API_KEY, undefined);
+});
+
+test('#3198: partial override { provider } con provider desconocido y key faltante throwa fail-fast', () => {
+    // Si el fallback es un provider que no está en disk NI en
+    // PROVIDER_DEFAULT_CREDENTIAL_ENV, providerKeyVar === undefined y NO se
+    // inyecta ninguna API key (no throw). Eso es comportamiento correcto:
+    // el handler determinístico/desconocido no necesita LLM credentials.
+    // El test asegura que NO leakeen las keys del primary.
+    const fakeFs = {
+        existsSync: () => true,
+        readFileSync: () => JSON.stringify({
+            providers: { anthropic: { credentials_env: 'ANTHROPIC_API_KEY' } },
+            skills: { guru: { provider: 'anthropic' } },
+        }),
+    };
+    const env = buildChildEnv({
+        skill: 'guru',
+        pipelineDir: '/fake/.pipeline',
+        fsImpl: fakeFs,
+        processEnv: fullOperatorEnv(),
+        skillConfigOverride: { provider: 'provider-inexistente' },
+    });
+    // Ninguna key del primary se filtra:
+    assert.equal(env.ANTHROPIC_API_KEY, undefined);
+    assert.equal(env.OPENAI_API_KEY, undefined);
+});
+
+test('#3198: partial override { provider } preserva requires_credentials del skill de disk', () => {
+    // Verifica que el merge skillCfg + { provider } no pisa el campo
+    // requires_credentials del skill. Es importante porque scopes
+    // (github/aws/gradle-android) son ortogonales al cambio de provider:
+    // el skill sigue necesitando gh CLI para postear comentarios.
+    const fakeFs = {
+        existsSync: () => true,
+        readFileSync: () => JSON.stringify({
+            providers: {
+                anthropic: { credentials_env: 'ANTHROPIC_API_KEY' },
+                'openai-codex': { credentials_env: 'OPENAI_API_KEY' },
+            },
+            skills: {
+                security: { provider: 'anthropic', requires_credentials: ['github', 'aws'] },
+            },
+        }),
+    };
+    const env = buildChildEnv({
+        skill: 'security',
+        pipelineDir: '/fake/.pipeline',
+        fsImpl: fakeFs,
+        processEnv: fullOperatorEnv(),
+        skillConfigOverride: { provider: 'openai-codex' },
+    });
+    // Provider del fallback aplicado:
+    assert.equal(env.OPENAI_API_KEY, 'sk-openai-XXXXX');
+    assert.equal(env.ANTHROPIC_API_KEY, undefined);
+    // Scopes del skill conservados (github + aws):
+    assert.equal(env.GH_TOKEN, 'ghp_XXXXX');
+    assert.equal(env.GITHUB_TOKEN, 'ghs_XXXXX');
+    assert.equal(env.AWS_ACCESS_KEY_ID, 'AKIAXXXX');
+    assert.equal(env.AWS_SECRET_ACCESS_KEY, 'secret-XXXX');
+});
+
+test('#3198: partial override { provider } con API key del FALLBACK faltante en env throwa fail-fast accionable', () => {
+    // Si el operador no setea OPENAI_API_KEY y el dispatcher resuelve fallback
+    // openai-codex, el child NO arranca. Mensaje accionable explica qué setear.
+    const fakeFs = {
+        existsSync: () => true,
+        readFileSync: () => JSON.stringify({
+            providers: {
+                anthropic: { credentials_env: 'ANTHROPIC_API_KEY' },
+                'openai-codex': { credentials_env: 'OPENAI_API_KEY' },
+            },
+            skills: { guru: { provider: 'anthropic' } },
+        }),
+    };
+    const envSinFallback = fullOperatorEnv();
+    delete envSinFallback.OPENAI_API_KEY;
+    assert.throws(
+        () => buildChildEnv({
+            skill: 'guru',
+            pipelineDir: '/fake/.pipeline',
+            fsImpl: fakeFs,
+            processEnv: envSinFallback,
+            skillConfigOverride: { provider: 'openai-codex' },
+        }),
+        /OPENAI_API_KEY no está en el env del pulpo/,
+    );
+});

--- a/.pipeline/tests/dispatch-build-env-integration.test.js
+++ b/.pipeline/tests/dispatch-build-env-integration.test.js
@@ -1,0 +1,347 @@
+// =============================================================================
+// dispatch-build-env-integration.test.js — Test de integración pulpo.js
+// (entre `resolveSpawnWithFallback` y `buildChildEnv`).
+//
+// Issue: #3198 (rebote sobre PR original).
+//
+// **Por qué este test existe**:
+// El rebote del PR original detectó que aunque `resolveSpawnWithFallback` y
+// `buildChildEnv` estaban bien aislados y testeados, la integración entre
+// ambos en `pulpo.js` tenía un mismatch de shape: el dispatcher producía
+// `{ provider: '<fallback>' }` y buildChildEnv esperaba
+// `{ skill, providers }`. El override se ignoraba silenciosamente y el child
+// del fallback recibía la API key del PRIMARY → defensa S-2 rota.
+//
+// Estos tests reproducen el flujo end-to-end que hace `pulpo.js` en
+// `lanzarAgenteClaude` (líneas ~5300-5330) y aseguran que la composición
+// preserve el invariante de seguridad **S-2**:
+//
+//   Cuando el dispatcher devuelve `source: 'fallback'`, el child obtiene
+//   SOLO la API key del FALLBACK, NUNCA la del PRIMARY.
+//
+// Si este test pasa y los unit tests de `build-child-env` y
+// `dispatch-with-fallback` pasan también, S-2 está garantizado end-to-end.
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const {
+    resolveSpawnWithFallback,
+} = require('../lib/agent-launcher/dispatch-with-fallback');
+const { buildChildEnv } = require('../lib/build-child-env');
+
+// -----------------------------------------------------------------------------
+// Helpers — fakes equivalentes a los de dispatch-with-fallback.test.js,
+// inlineados para mantener el archivo autocontenido.
+// -----------------------------------------------------------------------------
+function fakeAuditLog() {
+    return {
+        appendChained: () => ({ hash_self: 'fake', hash_prev: 'fake-prev', line: '' }),
+        verifyChain: () => ({ ok: true }),
+        readAll: () => [],
+        entries: [],
+    };
+}
+
+function fakeNotify() {
+    return () => true;
+}
+
+function fakeFsWithAgentModels(pipelineDir, modelsObj) {
+    const modelsPath = path.join(pipelineDir, 'agent-models.json');
+    const files = new Map();
+    files.set(modelsPath, JSON.stringify(modelsObj));
+    return {
+        existsSync: (p) => files.has(p),
+        readFileSync: (p) => {
+            if (files.has(p)) return files.get(p);
+            const e = new Error(`ENOENT: ${p}`);
+            e.code = 'ENOENT';
+            throw e;
+        },
+        mkdirSync: () => {},
+        writeFileSync: (p, content) => { files.set(p, content); },
+    };
+}
+
+function fakeQuotaModule({ gatedProviders = [] } = {}) {
+    return {
+        shouldGateSpawn: (skill, { provider } = {}) => {
+            if (!provider) return false;
+            return gatedProviders.includes(provider);
+        },
+        sanitizeRawExcerpt: (s) => String(s || ''),
+        appendAudit: () => {},
+    };
+}
+
+// Resolver de handlers fake — acepta los providers conocidos del módulo real
+// más cualquier custom que el test declare. Evita acoplarnos al naming exacto
+// de `lib/agent-launcher/resolve-provider.js::getProviderHandler`.
+function fakeProviderHandlerResolver(validProviders = ['anthropic', 'openai-codex', 'gemini', 'deterministic']) {
+    return (name) => {
+        if (!validProviders.includes(name)) {
+            throw new Error(`[fake] provider "${name}" no está en validProviders`);
+        }
+        return { name: `${name}-fake` };
+    };
+}
+
+function fakeResolver(skill, opts) {
+    const fsImpl = opts.fsImpl;
+    const pipelineDir = opts.pipelineDir;
+    let models = null;
+    try {
+        const p = path.join(pipelineDir, 'agent-models.json');
+        if (fsImpl && fsImpl.existsSync(p)) {
+            models = JSON.parse(fsImpl.readFileSync(p, 'utf8'));
+        }
+    } catch {}
+    const sk = (models && models.skills && models.skills[skill]) || {};
+    const provider = sk.provider || 'anthropic';
+    return {
+        provider,
+        model: 'fake-model',
+        handler: { name: `${provider}-fake` },
+        source: 'agent-models',
+    };
+}
+
+// Modelo base con dos providers + skill que tiene fallback cross-provider.
+function baseAgentModels() {
+    return {
+        defaults: { model: 'claude-opus-4-7' },
+        default_provider: 'anthropic',
+        providers: {
+            anthropic: {
+                model: 'claude-opus-4-7',
+                credentials_env: 'ANTHROPIC_API_KEY',
+            },
+            'openai-codex': {
+                model: 'gpt-codex',
+                credentials_env: 'OPENAI_API_KEY',
+            },
+            gemini: {
+                model: 'gemini-pro',
+                credentials_env: 'GEMINI_API_KEY',
+            },
+        },
+        skills: {
+            guru: {
+                provider: 'anthropic',
+                requires_credentials: ['github'],
+                fallbacks: ['openai-codex'],
+            },
+            security: {
+                provider: 'anthropic',
+                requires_credentials: ['github', 'aws'],
+                fallbacks: ['openai-codex', 'gemini'],
+            },
+        },
+    };
+}
+
+// processEnv del operador con TODAS las API keys (worst case).
+function operatorProcessEnv() {
+    return {
+        PATH: '/usr/bin:/bin',
+        SystemRoot: 'C:\\Windows',
+        ANTHROPIC_API_KEY: 'sk-ant-PRIMARY-secret',
+        OPENAI_API_KEY: 'sk-openai-FALLBACK-secret',
+        GEMINI_API_KEY: 'sk-gemini-FALLBACK2-secret',
+        GH_TOKEN: 'ghp_XXXX',
+        GITHUB_TOKEN: 'ghs_XXXX',
+        AWS_ACCESS_KEY_ID: 'AKIAXXX',
+        AWS_SECRET_ACCESS_KEY: 'aws-secret',
+        TELEGRAM_BOT_TOKEN: 'tg-bot',
+        TELEGRAM_CHAT_ID: '12345',
+    };
+}
+
+const PIPELINE_DIR = '/repo/.pipeline';
+const ISSUE = 3198;
+
+// -----------------------------------------------------------------------------
+// Función helper que replica EXACTAMENTE el flujo de pulpo.js
+// (lanzarAgenteClaude líneas 5306-5342): dispatcher → override → buildChildEnv.
+// Si pulpo.js cambia la lógica de construcción del override, este helper se
+// actualiza para mantener la integración en sincronía con la realidad.
+// -----------------------------------------------------------------------------
+function pulpoFlow({ skill, issue, fsImpl, processEnv, quotaModule }) {
+    const dispatchResolution = resolveSpawnWithFallback({
+        skill,
+        issue,
+        pipelineDir: PIPELINE_DIR,
+        fsImpl,
+        quotaModule,
+        primaryResolver: fakeResolver,
+        providerHandlerResolver: fakeProviderHandlerResolver(),
+        auditLog: fakeAuditLog(),
+        notify: fakeNotify(),
+    });
+
+    if (dispatchResolution.gated) {
+        return { dispatchResolution, childEnv: null };
+    }
+
+    // Replica pulpo.js:5319-5325 — shape `{ provider }` (post-fix #3198).
+    const skillConfigOverride = (
+        dispatchResolution &&
+        dispatchResolution.source === 'fallback' &&
+        dispatchResolution.provider
+    )
+        ? { provider: dispatchResolution.provider }
+        : undefined;
+
+    const childEnv = buildChildEnv({
+        skill,
+        pipelineDir: PIPELINE_DIR,
+        fsImpl,
+        processEnv,
+        pipelineExtras: { PIPELINE_ISSUE: String(issue) },
+        skillConfigOverride,
+    });
+
+    return { dispatchResolution, childEnv };
+}
+
+// =============================================================================
+// 1. Happy path — primary no gateado → child recibe la key del PRIMARY
+// =============================================================================
+test('integración: primary no gated → child recibe ANTHROPIC_API_KEY y NO la del fallback', () => {
+    const fsImpl = fakeFsWithAgentModels(PIPELINE_DIR, baseAgentModels());
+    const { dispatchResolution, childEnv } = pulpoFlow({
+        skill: 'guru',
+        issue: ISSUE,
+        fsImpl,
+        processEnv: operatorProcessEnv(),
+        quotaModule: fakeQuotaModule({ gatedProviders: [] }),
+    });
+
+    assert.equal(dispatchResolution.source, 'agent-models');
+    assert.equal(dispatchResolution.provider, 'anthropic');
+    assert.equal(dispatchResolution.crossProvider, false);
+
+    // Primary key sí, fallback key NO:
+    assert.equal(childEnv.ANTHROPIC_API_KEY, 'sk-ant-PRIMARY-secret',
+        'primary key debe estar presente cuando no hubo fallback');
+    assert.equal(childEnv.OPENAI_API_KEY, undefined,
+        'fallback key NO debe leakear cuando no hubo fallback');
+});
+
+// =============================================================================
+// 2. CORE S-2: primary gateado, fallback openai-codex elegido →
+//    child recibe SOLO OPENAI_API_KEY, NUNCA ANTHROPIC_API_KEY
+// =============================================================================
+test('integración S-2: primary gated → child del fallback recibe SOLO la key del FALLBACK, no la del primary', () => {
+    const fsImpl = fakeFsWithAgentModels(PIPELINE_DIR, baseAgentModels());
+    const { dispatchResolution, childEnv } = pulpoFlow({
+        skill: 'guru',
+        issue: ISSUE,
+        fsImpl,
+        processEnv: operatorProcessEnv(),
+        quotaModule: fakeQuotaModule({ gatedProviders: ['anthropic'] }),
+    });
+
+    // El dispatcher eligió el fallback openai-codex:
+    assert.equal(dispatchResolution.source, 'fallback');
+    assert.equal(dispatchResolution.provider, 'openai-codex');
+    assert.equal(dispatchResolution.crossProvider, true);
+
+    // **Invariante S-2 (la propiedad que el rebote detectó rota)**:
+    assert.equal(childEnv.OPENAI_API_KEY, 'sk-openai-FALLBACK-secret',
+        'S-2: la API key del FALLBACK DEBE estar presente en el child');
+    assert.equal(childEnv.ANTHROPIC_API_KEY, undefined,
+        'S-2: la API key del PRIMARY NUNCA debe leakear al child del fallback');
+});
+
+// =============================================================================
+// 3. Segundo nivel de fallback (chain depth 2):
+//    primary anthropic gated + fallback openai-codex gated → fallback gemini
+//    El child recibe SOLO GEMINI_API_KEY.
+// =============================================================================
+test('integración S-2: chain depth 2 (anthropic+openai gated → gemini) — child recibe SOLO GEMINI_API_KEY', () => {
+    const fsImpl = fakeFsWithAgentModels(PIPELINE_DIR, baseAgentModels());
+    const { dispatchResolution, childEnv } = pulpoFlow({
+        skill: 'security',
+        issue: ISSUE,
+        fsImpl,
+        processEnv: operatorProcessEnv(),
+        quotaModule: fakeQuotaModule({ gatedProviders: ['anthropic', 'openai-codex'] }),
+    });
+
+    assert.equal(dispatchResolution.source, 'fallback');
+    assert.equal(dispatchResolution.provider, 'gemini');
+    assert.deepEqual(dispatchResolution.chainTried, ['anthropic', 'openai-codex', 'gemini']);
+
+    // S-2 con 2 niveles de fallback: SOLO la última API key (gemini).
+    assert.equal(childEnv.GEMINI_API_KEY, 'sk-gemini-FALLBACK2-secret');
+    assert.equal(childEnv.OPENAI_API_KEY, undefined,
+        'S-2: API key del fallback intermedio NO debe leakear al child del fallback final');
+    assert.equal(childEnv.ANTHROPIC_API_KEY, undefined,
+        'S-2: API key del primary NO debe leakear cuando se cae en chain depth 2');
+});
+
+// =============================================================================
+// 4. Sanity: requires_credentials del skill se preservan tras el cross-provider
+//    Si el skill declara `github` + `aws`, el child del fallback los conserva.
+//    (cross-provider sólo cambia LA API key del LLM, no los scopes del skill)
+// =============================================================================
+test('integración: cross-provider preserva requires_credentials del skill (scopes ortogonales al provider)', () => {
+    const fsImpl = fakeFsWithAgentModels(PIPELINE_DIR, baseAgentModels());
+    const { dispatchResolution, childEnv } = pulpoFlow({
+        skill: 'security',
+        issue: ISSUE,
+        fsImpl,
+        processEnv: operatorProcessEnv(),
+        quotaModule: fakeQuotaModule({ gatedProviders: ['anthropic'] }),
+    });
+
+    // Cross-provider activo:
+    assert.equal(dispatchResolution.crossProvider, true);
+    assert.equal(dispatchResolution.provider, 'openai-codex');
+
+    // API key del fallback:
+    assert.equal(childEnv.OPENAI_API_KEY, 'sk-openai-FALLBACK-secret');
+    assert.equal(childEnv.ANTHROPIC_API_KEY, undefined);
+
+    // Scopes del skill (github, aws) conservados:
+    assert.equal(childEnv.GH_TOKEN, 'ghp_XXXX');
+    assert.equal(childEnv.GITHUB_TOKEN, 'ghs_XXXX');
+    assert.equal(childEnv.AWS_ACCESS_KEY_ID, 'AKIAXXX');
+    assert.equal(childEnv.AWS_SECRET_ACCESS_KEY, 'aws-secret');
+});
+
+// =============================================================================
+// 5. Sanity: telegram-hooks always-on conservado tras cross-provider
+// =============================================================================
+test('integración: cross-provider preserva telegram-hooks SCOPES_ALWAYS_ON', () => {
+    const fsImpl = fakeFsWithAgentModels(PIPELINE_DIR, baseAgentModels());
+    const { childEnv } = pulpoFlow({
+        skill: 'guru',
+        issue: ISSUE,
+        fsImpl,
+        processEnv: operatorProcessEnv(),
+        quotaModule: fakeQuotaModule({ gatedProviders: ['anthropic'] }),
+    });
+    assert.equal(childEnv.TELEGRAM_BOT_TOKEN, 'tg-bot');
+    assert.equal(childEnv.TELEGRAM_CHAT_ID, '12345');
+});
+
+// =============================================================================
+// 6. Sanity: PIPELINE_ISSUE de pipelineExtras llega al child tras cross-provider
+// =============================================================================
+test('integración: pipelineExtras (PIPELINE_ISSUE) preservados tras cross-provider', () => {
+    const fsImpl = fakeFsWithAgentModels(PIPELINE_DIR, baseAgentModels());
+    const { childEnv } = pulpoFlow({
+        skill: 'guru',
+        issue: ISSUE,
+        fsImpl,
+        processEnv: operatorProcessEnv(),
+        quotaModule: fakeQuotaModule({ gatedProviders: ['anthropic'] }),
+    });
+    assert.equal(childEnv.PIPELINE_ISSUE, '3198');
+});

--- a/.pipeline/tests/dispatch-with-fallback.test.js
+++ b/.pipeline/tests/dispatch-with-fallback.test.js
@@ -1,0 +1,579 @@
+// =============================================================================
+// dispatch-with-fallback.test.js — tests del consumer runtime de skill.fallbacks[]
+//
+// Issue: #3198.
+//
+// Cubre las reglas declaradas en `lib/agent-launcher/dispatch-with-fallback.js`:
+//   1. Happy path: primary no gateado → devuelve primary, gated: false.
+//   2. Primary gateado y sin fallbacks declarados → gated: true.
+//   3. Primary gateado y primer fallback libre → devuelve fallback.
+//   4. Primary gateado y primer fallback también gateado → itera al segundo.
+//   5. Primary gateado y todos los fallbacks gateados → all-gated.
+//   6. Skills determinísticos no se gatean (bypass).
+//   7. Fallback con provider desconocido → skip + audit.
+//   8. Cycle: fallback duplicado en chain → skip + audit.
+//   9. MAX_FALLBACK_DEPTH respetado.
+//  10. Audit log con hash-chain SHA-256 (reusa lib/audit-log).
+//  11. Telegram queue se encola con notice cross-provider.
+//  12. quotaModule ausente → devuelve primary sin gate (modo legacy).
+//  13. resolveSpawnWithFallback es defensivo si audit-log throws.
+//  14. Fallback duplica al primary → skip (defense in depth).
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const {
+    resolveSpawnWithFallback,
+    enqueueTelegramNotice,
+    dispatchAuditFile,
+    MAX_FALLBACK_DEPTH,
+} = require('../lib/agent-launcher/dispatch-with-fallback');
+
+// -----------------------------------------------------------------------------
+// Helpers — fakes inyectables
+// -----------------------------------------------------------------------------
+
+function fakeAuditLog() {
+    const entries = [];
+    return {
+        appendChained: ({ entry, file }) => {
+            entries.push({ entry, file });
+            return { hash_self: 'fake-hash', hash_prev: 'fake-prev', line: '' };
+        },
+        verifyChain: () => ({ ok: true, entriesChecked: entries.length }),
+        readAll: () => entries.map(e => e.entry),
+        entries,
+    };
+}
+
+function fakeNotify() {
+    const calls = [];
+    const fn = (opts) => {
+        calls.push(opts);
+        return true;
+    };
+    fn.calls = calls;
+    return fn;
+}
+
+// Resolver fake de handlers: aceptamos los providers conocidos del módulo real
+// + cualquier custom que el test declare como "válido". Para los tests que
+// quieren probar handlers inexistentes, el caller NO los incluye acá.
+function fakeProviderHandlerResolver(validProviders = ['anthropic', 'openai-codex', 'gemini', 'deterministic']) {
+    return (name) => {
+        if (!validProviders.includes(name)) {
+            throw new Error(`[fake] provider "${name}" no está en validProviders`);
+        }
+        return { name: `${name}-fake` };
+    };
+}
+
+function fakeQuotaModule({ gatedProviders = [], sanitize } = {}) {
+    return {
+        shouldGateSpawn: (skill, { provider } = {}) => {
+            if (!provider) return false;
+            return gatedProviders.includes(provider);
+        },
+        sanitizeRawExcerpt: sanitize || ((s) => String(s || '')),
+        appendAudit: () => {},
+    };
+}
+
+function fakeResolver(skill, opts) {
+    const fs = opts.fsImpl;
+    const pipelineDir = opts.pipelineDir;
+    let models = null;
+    try {
+        const p = path.join(pipelineDir, 'agent-models.json');
+        if (fs && fs.existsSync(p)) {
+            models = JSON.parse(fs.readFileSync(p, 'utf8'));
+        }
+    } catch {}
+    if (!models) {
+        return {
+            provider: 'anthropic',
+            model: 'claude-opus-4-7',
+            handler: { name: 'anthropic-fake' },
+            source: 'fallback-no-config',
+        };
+    }
+    const sk = (models.skills && models.skills[skill]) || null;
+    if (!sk) {
+        return {
+            provider: 'anthropic',
+            model: (models.defaults && models.defaults.model) || 'claude-opus-4-7',
+            handler: { name: 'anthropic-fake' },
+            source: 'fallback-skill-not-found',
+        };
+    }
+    const provider = sk.provider || 'anthropic';
+    const providerDef = (models.providers && models.providers[provider]) || {};
+    return {
+        provider,
+        model: sk.model_override || providerDef.model || (models.defaults && models.defaults.model) || 'claude-opus-4-7',
+        handler: { name: `${provider}-fake` },
+        source: 'agent-models',
+    };
+}
+
+function fakeFsWithAgentModels(pipelineDir, modelsObj) {
+    const modelsPath = path.join(pipelineDir, 'agent-models.json');
+    const files = new Map();
+    files.set(modelsPath, JSON.stringify(modelsObj));
+    return {
+        existsSync: (p) => files.has(p),
+        readFileSync: (p) => {
+            if (files.has(p)) return files.get(p);
+            const e = new Error(`ENOENT: ${p}`);
+            e.code = 'ENOENT';
+            throw e;
+        },
+        mkdirSync: () => {},
+        writeFileSync: (p, content) => {
+            files.set(p, content);
+        },
+        _files: files,
+    };
+}
+
+const PIPELINE_DIR = '/repo/.pipeline';
+const ISSUE = 3198;
+
+function baseAgentModels() {
+    return {
+        defaults: { model: 'claude-opus-4-7' },
+        default_provider: 'anthropic',
+        providers: {
+            anthropic: { model: 'claude-opus-4-7' },
+            'openai-codex': { model: 'gpt-codex' },
+            gemini: { model: 'gemini-pro' },
+        },
+        skills: {
+            guru: {
+                provider: 'anthropic',
+                fallbacks: ['openai-codex'],
+            },
+            'lone-wolf': {
+                provider: 'anthropic',
+            },
+            'chain-skill': {
+                provider: 'anthropic',
+                fallbacks: ['openai-codex', 'gemini'],
+            },
+        },
+    };
+}
+
+// -----------------------------------------------------------------------------
+// 1. Happy path
+// -----------------------------------------------------------------------------
+test('resolveSpawnWithFallback devuelve primary cuando NO está gateado', () => {
+    const models = baseAgentModels();
+    const fsImpl = fakeFsWithAgentModels(PIPELINE_DIR, models);
+    const audit = fakeAuditLog();
+    const notify = fakeNotify();
+
+    const r = resolveSpawnWithFallback({
+        skill: 'guru',
+        issue: ISSUE,
+        pipelineDir: PIPELINE_DIR,
+        fsImpl,
+        quotaModule: fakeQuotaModule({ gatedProviders: [] }),
+        primaryResolver: fakeResolver,
+        auditLog: audit,
+        notify,
+    });
+
+    assert.equal(r.gated, false);
+    assert.equal(r.provider, 'anthropic');
+    assert.equal(r.source, 'agent-models');
+    assert.equal(r.fallbackUsed, null);
+    assert.equal(r.crossProvider, false);
+    assert.deepEqual(r.chainTried, ['anthropic']);
+    assert.equal(audit.entries.length, 0, 'no audit en happy path');
+    assert.equal(notify.calls.length, 0, 'no telegram en happy path');
+});
+
+// -----------------------------------------------------------------------------
+// 2. Primary gated, sin fallbacks declarados → gated
+// -----------------------------------------------------------------------------
+test('resolveSpawnWithFallback gatea cuando primary está gated y no hay fallbacks', () => {
+    const models = baseAgentModels();
+    const fsImpl = fakeFsWithAgentModels(PIPELINE_DIR, models);
+    const audit = fakeAuditLog();
+
+    const r = resolveSpawnWithFallback({
+        skill: 'lone-wolf',
+        issue: ISSUE,
+        pipelineDir: PIPELINE_DIR,
+        fsImpl,
+        quotaModule: fakeQuotaModule({ gatedProviders: ['anthropic'] }),
+        primaryResolver: fakeResolver,
+        auditLog: audit,
+        notify: fakeNotify(),
+    });
+
+    assert.equal(r.gated, true);
+    assert.equal(r.source, 'all-gated');
+    assert.equal(r.fallbackUsed, null);
+    assert.equal(r.primaryProvider, 'anthropic');
+    const event = audit.entries[0].entry.event;
+    assert.equal(event, 'gated_no_fallbacks');
+});
+
+// -----------------------------------------------------------------------------
+// 3. Primary gated, primer fallback libre → fallback elegido
+// -----------------------------------------------------------------------------
+test('resolveSpawnWithFallback elige primer fallback libre cuando primary está gated', () => {
+    const models = baseAgentModels();
+    const fsImpl = fakeFsWithAgentModels(PIPELINE_DIR, models);
+    const audit = fakeAuditLog();
+    const notify = fakeNotify();
+
+    const r = resolveSpawnWithFallback({
+        skill: 'guru',
+        issue: ISSUE,
+        pipelineDir: PIPELINE_DIR,
+        fsImpl,
+        quotaModule: fakeQuotaModule({ gatedProviders: ['anthropic'] }),
+        primaryResolver: fakeResolver,
+        auditLog: audit,
+        notify,
+    });
+
+    assert.equal(r.gated, false);
+    assert.equal(r.source, 'fallback');
+    assert.equal(r.provider, 'openai-codex');
+    assert.equal(r.model, 'gpt-codex');
+    assert.equal(r.crossProvider, true);
+    assert.deepEqual(r.chainTried, ['anthropic', 'openai-codex']);
+    assert.deepEqual(r.fallbackUsed, { index: 0, provider: 'openai-codex' });
+
+    assert.ok(audit.entries.find(e => e.entry.event === 'fallback_selected'), 'audit fallback_selected');
+    assert.equal(notify.calls.length, 1, 'una notificación Telegram');
+    assert.match(notify.calls[0].text, /cross-provider/i);
+});
+
+// -----------------------------------------------------------------------------
+// 4. Primary y primer fallback gated → itera al segundo
+// -----------------------------------------------------------------------------
+test('resolveSpawnWithFallback salta fallbacks gated e itera al siguiente', () => {
+    const models = baseAgentModels();
+    const fsImpl = fakeFsWithAgentModels(PIPELINE_DIR, models);
+    const audit = fakeAuditLog();
+
+    const r = resolveSpawnWithFallback({
+        skill: 'chain-skill',
+        issue: ISSUE,
+        pipelineDir: PIPELINE_DIR,
+        fsImpl,
+        quotaModule: fakeQuotaModule({ gatedProviders: ['anthropic', 'openai-codex'] }),
+        primaryResolver: fakeResolver,
+        providerHandlerResolver: fakeProviderHandlerResolver(),
+        auditLog: audit,
+        notify: fakeNotify(),
+    });
+
+    assert.equal(r.gated, false);
+    assert.equal(r.provider, 'gemini');
+    assert.equal(r.fallbackUsed.index, 1);
+    assert.deepEqual(r.chainTried, ['anthropic', 'openai-codex', 'gemini']);
+    assert.ok(audit.entries.find(e => e.entry.event === 'fallback_also_gated'), 'audit fallback_also_gated');
+    assert.ok(audit.entries.find(e => e.entry.event === 'fallback_selected'), 'audit fallback_selected');
+});
+
+// -----------------------------------------------------------------------------
+// 5. Primary y todos los fallbacks gated → all-gated
+// -----------------------------------------------------------------------------
+test('resolveSpawnWithFallback marca all-gated cuando toda la chain está gated', () => {
+    const models = baseAgentModels();
+    const fsImpl = fakeFsWithAgentModels(PIPELINE_DIR, models);
+    const audit = fakeAuditLog();
+
+    const r = resolveSpawnWithFallback({
+        skill: 'chain-skill',
+        issue: ISSUE,
+        pipelineDir: PIPELINE_DIR,
+        fsImpl,
+        quotaModule: fakeQuotaModule({ gatedProviders: ['anthropic', 'openai-codex', 'gemini'] }),
+        primaryResolver: fakeResolver,
+        providerHandlerResolver: fakeProviderHandlerResolver(),
+        auditLog: audit,
+        notify: fakeNotify(),
+    });
+
+    assert.equal(r.gated, true);
+    assert.equal(r.source, 'all-gated');
+    assert.equal(r.fallbackUsed, null);
+    assert.deepEqual(r.chainTried, ['anthropic', 'openai-codex', 'gemini']);
+    assert.ok(audit.entries.find(e => e.entry.event === 'chain_exhausted'), 'audit chain_exhausted');
+});
+
+// -----------------------------------------------------------------------------
+// 6. Skills determinísticos: bypass
+// -----------------------------------------------------------------------------
+test('resolveSpawnWithFallback no gatea skills deterministic (allowlist)', () => {
+    const models = baseAgentModels();
+    const fsImpl = fakeFsWithAgentModels(PIPELINE_DIR, models);
+    const audit = fakeAuditLog();
+
+    const determResolver = () => ({
+        provider: 'deterministic',
+        model: null,
+        handler: { name: 'deterministic-fake', isDeterministic: () => true },
+        source: 'deterministic-allowlist',
+    });
+
+    const r = resolveSpawnWithFallback({
+        skill: 'build',
+        issue: ISSUE,
+        pipelineDir: PIPELINE_DIR,
+        fsImpl,
+        quotaModule: fakeQuotaModule({ gatedProviders: ['anthropic', 'deterministic'] }),
+        primaryResolver: determResolver,
+        auditLog: audit,
+        notify: fakeNotify(),
+    });
+
+    assert.equal(r.gated, false);
+    assert.equal(r.provider, 'deterministic');
+    assert.equal(r.fallbackUsed, null);
+});
+
+// -----------------------------------------------------------------------------
+// 7. Fallback con provider desconocido → skip + audit
+// -----------------------------------------------------------------------------
+test('resolveSpawnWithFallback salta fallback con provider desconocido y audita', () => {
+    const models = baseAgentModels();
+    models.skills['rogue-skill'] = {
+        provider: 'anthropic',
+        fallbacks: ['provider-inexistente', 'openai-codex'],
+    };
+    const fsImpl = fakeFsWithAgentModels(PIPELINE_DIR, models);
+    const audit = fakeAuditLog();
+
+    const r = resolveSpawnWithFallback({
+        skill: 'rogue-skill',
+        issue: ISSUE,
+        pipelineDir: PIPELINE_DIR,
+        fsImpl,
+        quotaModule: fakeQuotaModule({ gatedProviders: ['anthropic'] }),
+        primaryResolver: fakeResolver,
+        auditLog: audit,
+        notify: fakeNotify(),
+    });
+
+    assert.equal(r.gated, false);
+    assert.equal(r.provider, 'openai-codex');
+    assert.ok(audit.entries.find(e => e.entry.event === 'fallback_unknown_provider'));
+});
+
+// -----------------------------------------------------------------------------
+// 8. Cycle: fallback duplicado en chain → skip + audit
+// -----------------------------------------------------------------------------
+test('resolveSpawnWithFallback detecta ciclos en la chain de fallbacks', () => {
+    const models = baseAgentModels();
+    models.skills['cycle-skill'] = {
+        provider: 'anthropic',
+        fallbacks: ['openai-codex', 'openai-codex', 'gemini'],
+    };
+    const fsImpl = fakeFsWithAgentModels(PIPELINE_DIR, models);
+    const audit = fakeAuditLog();
+
+    const r = resolveSpawnWithFallback({
+        skill: 'cycle-skill',
+        issue: ISSUE,
+        pipelineDir: PIPELINE_DIR,
+        fsImpl,
+        quotaModule: fakeQuotaModule({ gatedProviders: ['anthropic', 'openai-codex'] }),
+        primaryResolver: fakeResolver,
+        providerHandlerResolver: fakeProviderHandlerResolver(),
+        auditLog: audit,
+        notify: fakeNotify(),
+    });
+
+    assert.equal(r.gated, false);
+    assert.equal(r.provider, 'gemini');
+    const cycleSkip = audit.entries.find(e => e.entry.event === 'fallback_cycle_skipped');
+    assert.ok(cycleSkip, 'audit fallback_cycle_skipped emitido');
+    assert.equal(cycleSkip.entry.fallback_provider, 'openai-codex');
+});
+
+// -----------------------------------------------------------------------------
+// 9. MAX_FALLBACK_DEPTH respetado
+// -----------------------------------------------------------------------------
+test('resolveSpawnWithFallback corta cuando la chain supera MAX_FALLBACK_DEPTH', () => {
+    const models = baseAgentModels();
+    const longFallbacks = [];
+    for (let i = 0; i < MAX_FALLBACK_DEPTH + 3; i++) {
+        longFallbacks.push(`provider-${i}`);
+    }
+    models.skills['long-skill'] = {
+        provider: 'anthropic',
+        fallbacks: longFallbacks,
+    };
+    const fsImpl = fakeFsWithAgentModels(PIPELINE_DIR, models);
+    const audit = fakeAuditLog();
+
+    const r = resolveSpawnWithFallback({
+        skill: 'long-skill',
+        issue: ISSUE,
+        pipelineDir: PIPELINE_DIR,
+        fsImpl,
+        quotaModule: fakeQuotaModule({ gatedProviders: ['anthropic'] }),
+        primaryResolver: fakeResolver,
+        auditLog: audit,
+        notify: fakeNotify(),
+    });
+
+    assert.equal(r.gated, true);
+    assert.equal(r.depthExceeded, true);
+    assert.ok(audit.entries.find(e => e.entry.event === 'depth_exceeded'));
+});
+
+// -----------------------------------------------------------------------------
+// 10. Audit log con hash-chain real (smoke test contra lib/audit-log real)
+// -----------------------------------------------------------------------------
+test('audit log se escribe con hash-chain real (smoke test contra lib/audit-log)', (t) => {
+    const os = require('node:os');
+    const fsReal = require('node:fs');
+    const tmpRoot = fsReal.mkdtempSync(path.join(os.tmpdir(), 'dispatch-fallback-'));
+    t.after(() => {
+        try { fsReal.rmSync(tmpRoot, { recursive: true, force: true }); } catch {}
+    });
+
+    const models = baseAgentModels();
+    fsReal.mkdirSync(tmpRoot, { recursive: true });
+    fsReal.writeFileSync(path.join(tmpRoot, 'agent-models.json'), JSON.stringify(models));
+
+    const auditLogReal = require('../lib/audit-log');
+
+    const r = resolveSpawnWithFallback({
+        skill: 'guru',
+        issue: ISSUE,
+        pipelineDir: tmpRoot,
+        quotaModule: fakeQuotaModule({ gatedProviders: ['anthropic'] }),
+        primaryResolver: fakeResolver,
+        auditLog: auditLogReal,
+        notify: () => true,
+    });
+
+    assert.equal(r.gated, false);
+    assert.equal(r.provider, 'openai-codex');
+
+    const auditFile = dispatchAuditFile(tmpRoot);
+    assert.ok(fsReal.existsSync(auditFile), 'audit log creado');
+    const chain = auditLogReal.verifyChain(auditFile);
+    assert.equal(chain.ok, true, `hash-chain válida: ${JSON.stringify(chain)}`);
+    assert.ok(chain.entriesChecked >= 1);
+});
+
+// -----------------------------------------------------------------------------
+// 11. Telegram queue real
+// -----------------------------------------------------------------------------
+test('enqueueTelegramNotice escribe archivo en queue de servicios/telegram/pendiente', (t) => {
+    const os = require('node:os');
+    const fsReal = require('node:fs');
+    const tmpRoot = fsReal.mkdtempSync(path.join(os.tmpdir(), 'dispatch-fallback-tg-'));
+    t.after(() => {
+        try { fsReal.rmSync(tmpRoot, { recursive: true, force: true }); } catch {}
+    });
+
+    const ok = enqueueTelegramNotice({
+        pipelineDir: tmpRoot,
+        text: 'test cross-provider notice',
+        meta: { skill: 'guru', issue: 3198 },
+    });
+    assert.equal(ok, true);
+
+    const queueDir = path.join(tmpRoot, 'servicios', 'telegram', 'pendiente');
+    const files = fsReal.readdirSync(queueDir);
+    assert.equal(files.length, 1);
+    const payload = JSON.parse(fsReal.readFileSync(path.join(queueDir, files[0]), 'utf8'));
+    assert.equal(payload.type, 'cross-provider-fallback');
+    assert.equal(payload.text, 'test cross-provider notice');
+    assert.equal(payload.meta.skill, 'guru');
+});
+
+// -----------------------------------------------------------------------------
+// 12. quotaModule ausente: devuelve primary sin gate (modo legacy)
+// -----------------------------------------------------------------------------
+test('resolveSpawnWithFallback sin quotaModule devuelve primary sin gate', () => {
+    const models = baseAgentModels();
+    const fsImpl = fakeFsWithAgentModels(PIPELINE_DIR, models);
+
+    const r = resolveSpawnWithFallback({
+        skill: 'guru',
+        issue: ISSUE,
+        pipelineDir: PIPELINE_DIR,
+        fsImpl,
+        primaryResolver: fakeResolver,
+        auditLog: fakeAuditLog(),
+        notify: fakeNotify(),
+    });
+
+    assert.equal(r.gated, false);
+    assert.equal(r.provider, 'anthropic');
+    assert.equal(r.fallbackUsed, null);
+});
+
+// -----------------------------------------------------------------------------
+// 13. audit-log throws: el dispatcher NO crashea (best-effort)
+// -----------------------------------------------------------------------------
+test('resolveSpawnWithFallback no crashea cuando audit-log throws', () => {
+    const models = baseAgentModels();
+    const fsImpl = fakeFsWithAgentModels(PIPELINE_DIR, models);
+
+    const brokenAudit = {
+        appendChained: () => { throw new Error('disco lleno'); },
+    };
+
+    const r = resolveSpawnWithFallback({
+        skill: 'guru',
+        issue: ISSUE,
+        pipelineDir: PIPELINE_DIR,
+        fsImpl,
+        quotaModule: fakeQuotaModule({ gatedProviders: ['anthropic'] }),
+        primaryResolver: fakeResolver,
+        auditLog: brokenAudit,
+        notify: fakeNotify(),
+    });
+
+    assert.equal(r.gated, false);
+    assert.equal(r.provider, 'openai-codex');
+});
+
+// -----------------------------------------------------------------------------
+// 14. Fallback duplica al primary → skip
+// -----------------------------------------------------------------------------
+test('resolveSpawnWithFallback ignora fallback que duplica el primary', () => {
+    const models = baseAgentModels();
+    models.skills['rogue-cfg'] = {
+        provider: 'anthropic',
+        fallbacks: ['anthropic', 'openai-codex'],
+    };
+    const fsImpl = fakeFsWithAgentModels(PIPELINE_DIR, models);
+    const audit = fakeAuditLog();
+
+    const r = resolveSpawnWithFallback({
+        skill: 'rogue-cfg',
+        issue: ISSUE,
+        pipelineDir: PIPELINE_DIR,
+        fsImpl,
+        quotaModule: fakeQuotaModule({ gatedProviders: ['anthropic'] }),
+        primaryResolver: fakeResolver,
+        auditLog: audit,
+        notify: fakeNotify(),
+    });
+
+    assert.equal(r.gated, false);
+    assert.equal(r.provider, 'openai-codex');
+    const evidence = audit.entries.find(e =>
+        e.entry.event === 'fallback_duplicates_primary' ||
+        e.entry.event === 'fallback_cycle_skipped'
+    );
+    assert.ok(evidence, 'evidence de defensa contra duplicate_primary o cycle');
+});

--- a/docs/pipeline-multi-provider.md
+++ b/docs/pipeline-multi-provider.md
@@ -373,12 +373,12 @@ Migración: cualquier `agent-models.json` local de devs que use `provider: 'gemi
 
 #### 3.8.3 Estado del handler de cuota
 
-- **Groq + Cerebras**: el handler estructurado existe (`_detectOpenAI` en `quota-exhausted.js`). La detección de cuota es funcional cuando el runtime (#3198) spawnee el wrapper real — sin trabajo adicional en este issue.
+- **Groq + Cerebras**: el handler estructurado existe (`_detectOpenAI` en `quota-exhausted.js`). La detección de cuota es funcional cuando el runtime spawnee el wrapper real — consumer runtime ya operativo desde #3198 (ver §3.9).
 - **Gemini-google**: el handler `_detectGemini` NO existe todavía. La declaración `quota_error_types` queda **declarativa** (passa el validador del schema y la meta-allowlist) pero **sin defensa funcional** (el detector no lo consume con parser estructurado). Issue de recomendación: #3226. Riesgo aceptado: detección Gemini via string-matching heurístico hasta que #3226 entregue el handler real.
 
 #### 3.8.4 Runtime / wrappers Node
 
-Decisión PO (opción A del análisis del guru): launchers nuevos `groq` y `cerebras` con wrapper Node interno. Este issue declara los launchers en la allowlist + crea handlers stub en `lib/agent-launcher/providers/{gemini-google,groq,cerebras}.js` que tiran error accionable si se les pide spawn antes de #3198. El hardening de wrappers (TLS-only, timeouts, no-log payloads, etc.) se trackea en #3227 y se materializa con #3198.
+Decisión PO (opción A del análisis del guru): launchers nuevos `groq` y `cerebras` con wrapper Node interno. Este issue declara los launchers en la allowlist + crea handlers stub en `lib/agent-launcher/providers/{gemini-google,groq,cerebras}.js` que tiran error accionable si se les pide spawn. El consumer runtime que integra estos handlers con el flow del pulpo se materializó en #3198 (ver §3.9). El hardening de wrappers (TLS-only, timeouts, no-log payloads, etc.) se trackea en #3227.
 
 #### 3.8.5 Modelos soportados por launcher (`ALLOWED_MODELS_BY_LAUNCHER`)
 
@@ -404,10 +404,137 @@ Anti-leak (#3220): si el valor de `model` parece un secret hardcoded conocido (m
 #### 3.8.7 Follow-ups (no bloqueantes — issues separados)
 
 - **#3221**: cargar el orden sign-off 2026-05-15 en `skills.<x>.fallbacks[]` (bloqueado por este).
-- **#3198**: implementar el runtime que consume `fallbacks[]` y los wrappers Node de Groq/Cerebras.
+- **#3198**: ✅ **CERRADO** — consumer runtime de `fallbacks[]` implementado por `lib/agent-launcher/dispatch-with-fallback.js`. Ver §3.9 abajo para el contrato operativo completo.
 - **#3226**: handler `_detectGemini` estructurado (defensa funcional anti-DoS para Gemini).
 - **#3227**: hardening de wrappers Node Groq/Cerebras (TLS-only, timeouts, no-log payloads).
 - **#3228**: agregar patrones `gsk_` y `csk-` a `HARDCODED_SECRET_PATTERNS` (defensa en profundidad).
+
+---
+
+### 3.9 Consumer runtime de fallbacks (#3198)
+
+> **Estado**: ✅ implementado y mergeado (2026-05-15). Cierra el gap que dejaron PRs anteriores (#3177 entregó schema + UI + lib RW pero NO consumer en runtime). A partir de este PR, declarar `skills.<x>.fallbacks[]` en `agent-models.json` deja de ser decorativo: el pipeline efectivamente itera la cadena cuando el provider primario está gated por cuota.
+
+#### 3.9.1 Cómo se configura `fallbacks[]` por skill
+
+La declaración vive en `agent-models.json` (raíz `.pipeline/`), schema vigente desde #3177. Forma canónica:
+
+```json
+{
+  "skills": {
+    "pipeline-dev": {
+      "provider": "claude",
+      "model": "claude-opus-4-7",
+      "fallbacks": ["codex", "gemini-google", "groq"]
+    }
+  }
+}
+```
+
+Reglas del array (validadas en boot por `lib/agent-models-validate.js`):
+
+- Cada item debe ser un nombre de provider existente en `providers.<name>` del mismo archivo (fail-fast si no).
+- El primario (`provider`) NO debe aparecer en su propio `fallbacks` (anti-cycle estático).
+- El array es ordenado: el dispatcher itera de izquierda a derecha. Convención: poner primero los pagos de mayor calidad (Codex) y al final los free-tier (Groq, Cerebras).
+- Schema acepta array vacío `[]` → comportamiento idéntico al pre-#3198 (sin failover).
+
+La edición autoritativa se hace desde la UI del dashboard multi-provider (`/.pipeline/views/dashboard/multi-provider.js`, secciones 525-572 — corrección menor del cuerpo del issue, que citaba erróneamente las líneas 421-467). Cada save de `fallbacks[]` desde la UI es opt-in humano explícito en sí mismo (S-7 del análisis security): la presencia del array ES la aprobación, no se requiere doble barrera.
+
+#### 3.9.2 Qué hace el dispatcher cuando el primario está gated
+
+Punto de entrada: `resolveSpawnWithFallback({ skill, quotaModule, attempt })`, llamado pre-spawn en `pulpo.js:4937` y `pulpo.js:4967` (handlers de despacho del archivo de trabajo). Reemplaza al check binario `shouldGateSpawn` por un resolver que devuelve `{ gated, provider, model, depth, source }`.
+
+Flujo:
+
+1. Resuelve el provider/model primario del skill (vía `resolveProviderForSkill`).
+2. Si `quotaModule.shouldGateSpawn(skill, { provider: primary })` devuelve `false` → spawn primario, fin.
+3. Si está gated → itera `fallbacks[]` en orden, llamando a `getProviderHandler(name)` + re-evaluando el gate por cada candidato.
+4. El primer fallback con `gated:false` y handler válido es devuelto. El caller spawnea con ese `provider`/`model`.
+5. Si la cadena entera está gated → devuelve `{ gated: true }`; el pulpo mueve el archivo a `pendiente/` (comportamiento legacy, espera al reset de cuota).
+
+El happy path (primario disponible) NO paga overhead: el dispatcher es pasivo, sólo activa cuando hay flag de cuota.
+
+#### 3.9.3 Política dual (consistente con §4.1)
+
+- **Cross-MODELO** (mismo provider, distinto modelo): NO se configura via `fallbacks[]` (el array lista provider names). Cross-modelo se hace via `skill.model_override` + selector autónomo §4.3. Fuera del scope #3198.
+- **Cross-PROVIDER**: el opt-in humano ES la declaración del array. No agregamos doble barrera (rompería la promesa "configurá fallbacks y el pipeline sigue funcionando"). Las defensas adyacentes (audit log + Telegram + caps) cubren la observabilidad post-hoc.
+
+#### 3.9.4 Cap MAX_FALLBACK_DEPTH y anti-ciclo
+
+- **`MAX_FALLBACK_DEPTH = 5`** (constante en `dispatch-with-fallback.js`). Si la chain efectiva del skill (primario + fallbacks) supera 5 candidatos, el dispatcher trunca con warning en el audit log. Es generoso para configs típicas (Anthropic → Codex → Gemini → Groq → Cerebras = 5) sin permitir recursión patológica.
+- **Anti-ciclo**: `Set<providerName>` de candidatos ya intentados en el dispatch corriente. Si un fallback ya fue probado en un nivel anterior (caso raro pero posible si la config tiene duplicados), se saltea.
+- **Skip same-provider-gate**: si el fallback comparte el provider del primario gated (caso de mala config), se saltea — el flag de cuota del primario también gatearía al fallback.
+
+#### 3.9.5 Audit log dedicado
+
+Cada decisión del dispatcher (resolución, gate, skip por ciclo, skip por depth) escribe a:
+
+```
+logs/cross-provider-dispatch-YYYY-MM-DD.jsonl
+```
+
+Formato append-only con hash-chain SHA-256 (delegado a `audit-log.appendChained`, que ya redacta y firma cada entrada). Campos principales por línea:
+
+- `ts`, `issue`, `skill`, `attempt`
+- `primary: { provider, model }`
+- `chain: [{ provider, gated, source }]` (cada candidato intentado)
+- `resolved: { provider, model, depth } | null` (null si todo gated)
+- `prev_hash`, `hash` (hash-chain SHA-256 para detectar tampering)
+
+El `raw_excerpt` del detector de cuota pasa por `quotaModule.sanitizeRawExcerpt` antes de logguearse — sin tokens, sin payloads.
+
+#### 3.9.6 Notificación Telegram via filesystem queue
+
+Cuando el dispatcher resuelve un fallback (decisión cross-PROVIDER consumada), encola un mensaje informativo en:
+
+```
+.pipeline/servicios/telegram/pendiente/<ts>-cross-provider-<issue>-<skill>.json
+```
+
+El servicio `servicio-telegram.js` drena la cola fuera del path crítico del pulpo. Sin `curl` directo, sin LLM en el camino — patrón S-9 consistente con `sendTelegram` ya existente. Plantilla del mensaje:
+
+> 🔀 **Fallback cross-provider activado**
+> Issue #&lt;n&gt; · skill `<skill>`
+> Primary: `<provider>:<model>` (gated por cuota)
+> Fallback elegido: `<fb_provider>:<fb_model>` (depth `<n>`)
+> Audit: `logs/cross-provider-dispatch-YYYY-MM-DD.jsonl`
+
+Es post-hoc informativo, no decisorio — la decisión ya quedó autorizada por la presencia del array en `agent-models.json`.
+
+#### 3.9.7 Defensas S-1 a S-9 (resumen del análisis security cerrado por este PR)
+
+| ID | Defensa | Dónde |
+|---|---|---|
+| S-1 | Detección de cuota por shape estructurado, NUNCA substring | `quotaModule.shouldGateSpawn` (reutilizado) |
+| S-2 | Aislamiento de credenciales en el spawn del fallback | `lib/build-child-env.js` filtra env vars al provider resuelto |
+| S-3 | Validación del nombre del provider contra `PROVIDER_HANDLERS` | `getProviderHandler` + boot validator |
+| S-4 | Path traversal en flag pending | N/A — el opt-in es la presencia del array, no flags por skill |
+| S-5 | Cycle/depth limit | `MAX_FALLBACK_DEPTH = 5` + `Set` anti-ciclo |
+| S-6 | Audit log redactado con hash-chain | `audit-log.appendChained` + `sanitizeRawExcerpt` |
+| S-7 | Política dual cross-MODELO/cross-PROVIDER | Opt-in vía array; sin doble barrera |
+| S-8 | Quota flag scoping per-provider | `clearFlag` respeta scope (#3077 CA-8); fallback NO limpia flag del primario |
+| S-9 | Telegram sin LLM en el camino | Filesystem queue + drainer Node puro |
+
+#### 3.9.8 Aprobar / desaprobar un fallback en operación
+
+- **Sumar un provider a la chain**: editar `skills.<x>.fallbacks[]` en la UI del dashboard multi-provider, guardar. Boot validation confirma que el provider existe; el dispatcher empieza a usarlo desde el próximo despacho.
+- **Sacar un provider**: removerlo del array en la UI. No requiere restart del pulpo (el archivo se relee por dispatch).
+- **Pausar todos los fallbacks (kill switch)**: vaciar `fallbacks[]` del skill (`[]`). El dispatcher cae al comportamiento pre-#3198: si el primario está gated, el archivo va a `pendiente/`.
+- **Inspeccionar decisiones recientes**: `tail -n 50 logs/cross-provider-dispatch-$(date -u +%F).jsonl | jq .` — cada entrada muestra chain completa, decisión y hash.
+- **Detectar tampering del audit**: `node .pipeline/scripts/verify-audit-chain.js logs/cross-provider-dispatch-*.jsonl` (verificador existente reutilizado).
+
+#### 3.9.9 Tests y verificación
+
+61/61 tests del scope verdes a HEAD `1b7836ef`:
+
+```
+node --test .pipeline/tests/build-child-env.test.js \
+            .pipeline/tests/dispatch-with-fallback.test.js \
+            .pipeline/tests/dispatch-build-env-integration.test.js
+# tests 61, pass 61, fail 0
+```
+
+Cobertura: unit (cada defensa S-1 a S-9) + integración env+dispatch + scenarios de chain (happy path, all-gated, ciclo, depth overflow, same-provider skip, fallback con env aislado).
 
 ---
 

--- a/docs/pipeline/multi-provider.md
+++ b/docs/pipeline/multi-provider.md
@@ -206,20 +206,32 @@ Cada skill **puede** declarar una lista ordenada `fallbacks[]` de providers alte
 - Un fallback no puede duplicar el `provider` primario (sería ruido).
 - Strings vacíos o no-string → rechazo con `fix:` accionable.
 
-> #### Estado actual de fallbacks (LEER ANTES DE DEPENDER DE FAILOVER AUTOMÁTICO)
+> #### Estado actual de fallbacks (#3198 ✅ cerrado — failover automático ACTIVO)
 >
-> El campo `skills.<name>.fallbacks[]` está soportado en **schema y dashboard UI**, y se valida correctamente al boot. Pero **el consumer en runtime** (`resolveProviderForSkill` en [`.pipeline/lib/agent-launcher/resolve-provider.js`](../../.pipeline/lib/agent-launcher/resolve-provider.js)) **no itera el array** cuando el primary falla. El "fallback" actual cubre solo el caso de regresión cero:
+> El campo `skills.<name>.fallbacks[]` está soportado end-to-end:
 >
-> - `agent-models.json` no existe → `provider: 'anthropic', model: 'claude-opus-4-7'`.
-> - `agent-models.json` no parsea → mismo fallback.
-> - Skill no está declarado en `skills` → mismo fallback con default model.
+> - **Schema + UI**: declarable en `agent-models.json` y editable desde el dashboard (#3177).
+> - **Validación al boot**: `agent-models-validate.js` (cada item existe como provider, no duplica el primario, anti-cycle estático).
+> - **Consumer en runtime**: `lib/agent-launcher/dispatch-with-fallback.js` ([fuente](../../.pipeline/lib/agent-launcher/dispatch-with-fallback.js)) — itera la chain cuando el primary está gated. Implementado y mergeado por [#3198](https://github.com/intrale/platform/issues/3198) (2026-05-15).
 >
-> **No hay retry automático cross-provider** cuando Anthropic devuelve `usage_limit_error` y el skill tiene `fallbacks: ["openai-codex"]`. El pipeline para con el flag de cuota agotada y espera al `resets_at` (o intervención humana).
+> **El "fallback" hoy cubre dos planos**:
 >
-> El issue [#3198](https://github.com/intrale/platform/issues/3198) está abierto para implementar el consumer runtime. Hasta que cierre, **no dependas de fallbacks declarados para continuidad de servicio**. Si necesitás failover ahora, podés:
+> 1. **Regresión cero** (`resolveProviderForSkill` en `resolve-provider.js`): si `agent-models.json` no existe / no parsea / el skill no está declarado → `provider: 'anthropic', model: 'claude-opus-4-7'`. Inalterado por #3198.
+> 2. **Failover cross-provider** (`resolveSpawnWithFallback` en `dispatch-with-fallback.js`): si el primary está gated por cuota agotada, itera `skills.<x>.fallbacks[]` en orden y devuelve el primer candidato disponible. Caps de seguridad: `MAX_FALLBACK_DEPTH = 5`, `Set` anti-cycle en runtime, skip de fallbacks que comparten el provider gated.
 >
-> - Cambiar manualmente `skills.<x>.provider` por el alternativo cuando se agote cuota.
-> - Hot-reload (no soportado — restart): `node .pipeline/restart.js`.
+> Cada decisión cross-provider se loguea en `logs/cross-provider-dispatch-YYYY-MM-DD.jsonl` (hash-chain SHA-256, redactado) y dispara notificación Telegram post-hoc via `servicios/telegram/pendiente/` (filesystem queue, sin LLM en el camino). Detalle operativo completo en [`docs/pipeline-multi-provider.md`](../pipeline-multi-provider.md) §3.9.
+>
+> **Cuándo PUEDE NO haber failover** (comportamiento esperado, no bug):
+>
+> - El skill no declara `fallbacks` o el array está vacío → si el primary está gated, archivo a `pendiente/` (legacy).
+> - Toda la chain (primary + fallbacks) está gated → archivo a `pendiente/`.
+> - El skill está en `DETERMINISTIC_SKILLS` (allowlist hardcoded) → corre Node puro, sin LLM, sin necesidad de fallback.
+>
+> **Inspeccionar / desactivar en operación**:
+>
+> - Ver decisiones: `tail -n 50 logs/cross-provider-dispatch-$(date -u +%F).jsonl | jq .`
+> - Kill switch por skill: vaciar `skills.<x>.fallbacks[]` desde el dashboard (`[]`) → cae a comportamiento pre-#3198.
+> - Forzar provider primario alternativo: cambiar `skills.<x>.provider` desde el dashboard + `node .pipeline/restart.js`.
 
 ### 2.4 Reglas de precedencia
 
@@ -354,7 +366,7 @@ Si necesitás una restricción más fina ("este skill solo puede usar Haiku o So
 |-------|------|-------------|-------------|
 | `provider` | string | sí | Debe existir como clave en `providers`. |
 | `model_override` | string | no | Modelo específico que sobreescribe el `model` default del provider. |
-| `fallbacks` | array de string | no | Lista ordenada de providers alternativos. **No consumido en runtime hoy** (ver [§2.3](#23-fallbacks)). |
+| `fallbacks` | array de string | no | Lista ordenada de providers alternativos. Consumido por `dispatch-with-fallback.js` cuando el primary está gated por cuota (#3198, ver [§2.3](#23-fallbacks)). |
 
 ### 4.2 Skills determinísticos (sin LLM)
 
@@ -413,7 +425,7 @@ Resuelve a `provider: 'anthropic', model: 'claude-sonnet-4-6'` (5× más barato 
 }
 ```
 
-Resuelve a `provider: 'openai-codex', model: 'gpt-5-codex'`. **El `fallbacks` está declarado pero no se itera en runtime** ([§2.3](#23-fallbacks)). Si OpenAI agota cuota, el pulpo gateará el skill hasta que se libere.
+Resuelve a `provider: 'openai-codex', model: 'gpt-5-codex'`. Si OpenAI agota cuota, el dispatcher itera `fallbacks: ["anthropic"]` (#3198 — consumer runtime activo) y, si Anthropic está disponible, spawnea con `provider: 'anthropic'` automáticamente; si toda la chain está gated, el archivo va a `pendiente/` esperando reset ([§2.3](#23-fallbacks)).
 
 ### 4.4 Pasos para hacer lo mismo desde la UI del dashboard
 
@@ -765,16 +777,19 @@ Los endpoints mutating del dashboard (`POST`, `PUT`, `DELETE` bajo `/api/multi-p
 
 | Funcionalidad | Soportado en schema | Soportado en UI | Consumido en runtime |
 |---------------|:-------------------:|:---------------:|:--------------------:|
-| Declarar `fallbacks[]` por skill | ✅ | ✅ | ❌ |
+| Declarar `fallbacks[]` por skill | ✅ | ✅ | ✅ |
 | Validación cruzada de items contra `providers` | ✅ | ✅ | n/a |
-| Failover automático cross-provider en cuota agotada | — | — | ❌ |
+| Failover automático cross-provider en cuota agotada | ✅ | ✅ | ✅ |
 
-**Lectura para operadores:** declarar `fallbacks[]` en `agent-models.json` **no garantiza continuidad de servicio** cuando el provider primario falla. La continuidad real proviene de:
+**Lectura para operadores:** desde [#3198](https://github.com/intrale/platform/issues/3198) (mergeado 2026-05-15), declarar `fallbacks[]` en `agent-models.json` **sí dispara failover automático** cuando el provider primario está gated. La continuidad de servicio efectiva proviene de tres mecanismos complementarios:
 
-- **Scope per-provider del quota-detector** ([#3077](https://github.com/intrale/platform/issues/3077) SEC-1): si Anthropic se agota, los skills con `provider: 'openai-codex'` siguen corriendo.
-- **Cambio manual del operador**: editar `agent-models.json` reasignando skills críticos a otro provider.
+- **Scope per-provider del quota-detector** ([#3077](https://github.com/intrale/platform/issues/3077) SEC-1): si Anthropic se agota, los skills con `provider: 'openai-codex'` siguen corriendo sin necesidad de cambiar nada.
+- **Consumer runtime de fallbacks** (#3198): para skills cuyo primary está gated, el dispatcher itera `skills.<x>.fallbacks[]` en orden y spawnea con el primer candidato disponible. Caps `MAX_FALLBACK_DEPTH=5` + anti-cycle + audit log con hash-chain + notificación Telegram post-hoc.
+- **Cambio manual del operador**: editar `agent-models.json` reasignando primaries críticos sigue disponible como override explícito.
 
-Cierre del gap: [#3198](https://github.com/intrale/platform/issues/3198) (consumer runtime de fallbacks).
+Caveat: declarar `fallbacks[]` no es magia. Si toda la chain (primary + fallbacks) está gated en simultáneo, el archivo cae a `pendiente/` esperando reset — sin failover infinito.
+
+Implementado por: [#3198](https://github.com/intrale/platform/issues/3198) (consumer runtime de fallbacks). Detalle operativo: [`docs/pipeline-multi-provider.md`](../pipeline-multi-provider.md) §3.9.
 
 ### 7.6 Reglas inquebrantables para los ejemplos de esta doc
 
@@ -807,4 +822,5 @@ Cierre del gap: [#3198](https://github.com/intrale/platform/issues/3198) (consum
 - **Permission mapping (capabilities cross-provider):** [`docs/pipeline-multi-provider/permission-mapping.md`](../pipeline-multi-provider/permission-mapping.md).
 - **Data residency / exclusiones:** [`docs/pipeline-multi-provider/data-residency.md`](../pipeline-multi-provider/data-residency.md).
 - **Issue de esta doc:** [#3176](https://github.com/intrale/platform/issues/3176).
-- **Issues de mejora futura:** [#3197](https://github.com/intrale/platform/issues/3197) (auto-gen tablas), [#3198](https://github.com/intrale/platform/issues/3198) (consumer runtime fallbacks).
+- **Issues de mejora futura:** [#3197](https://github.com/intrale/platform/issues/3197) (auto-gen tablas).
+- **Issues cerrados relevantes:** [#3198](https://github.com/intrale/platform/issues/3198) (consumer runtime de fallbacks, mergeado 2026-05-15 — ver §2.3).


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 8 archivos · +1936 -37

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:skipped` aplicado por delivery

## Closes

Closes #3198
