### PR TITLE
fix(pipeline): separar estados blocked:dependencies vs needs-human en el Pulpo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,11 +138,13 @@ scripts/planner-plan.json
 .pipeline/definicion/*/listo/*
 .pipeline/definicion/*/procesado/*
 .pipeline/definicion/*/bloqueado-humano/*
+.pipeline/definicion/*/bloqueado-dependencias/*
 .pipeline/desarrollo/*/pendiente/*
 .pipeline/desarrollo/*/trabajando/*
 .pipeline/desarrollo/*/listo/*
 .pipeline/desarrollo/*/procesado/*
 .pipeline/desarrollo/*/bloqueado-humano/*
+.pipeline/desarrollo/*/bloqueado-dependencias/*
 .pipeline/servicios/*/pendiente/*
 .pipeline/servicios/*/trabajando/*
 .pipeline/servicios/*/listo/*

--- a/.pipeline/lib/__tests__/blocked-segregation.test.js
+++ b/.pipeline/lib/__tests__/blocked-segregation.test.js
@@ -1,0 +1,367 @@
+// =============================================================================
+// Tests segregación bloqueado-dependencias/ vs bloqueado-humano/ — issue #3229
+//
+// Cubre los criterios de aceptación del issue:
+//
+//   CA-1 · Carpeta `bloqueado-dependencias/` se crea físicamente y es
+//          distinta de `bloqueado-humano/`.
+//   CA-2 · classifyRebote con `rebote_categoria: dependency_block` clasifica
+//          como dependency_block aunque el motivo no contenga la cadena
+//          literal (puente guru → barrido cerrado).
+//          classifyRebote con `rebote_categoria: human_block` clasifica
+//          como human_block aunque el motivo no matchee patrones.
+//   CA-3 · releaseDependencyBlockToPendiente() mueve archivos de
+//          `bloqueado-dependencias/` a `pendiente/` (rol del brazoDesbloqueo
+//          al destrabar).
+//   CA-4 · reportHumanBlock SIGUE creando markers en `bloqueado-humano/`;
+//          unblockIssue solo destraba esa carpeta (no toca bloqueado-deps/).
+//   CA-5 · E2E con DOS issues hijos: uno dependency_block, otro human_block.
+//          Cada uno cae en SU carpeta y se libera por el flujo correspondiente.
+//
+// =============================================================================
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+// Aislar PIPELINE_DIR a un tmp por test setup
+const TMP_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'v3-blocked-seg-'));
+fs.mkdirSync(path.join(TMP_DIR, '.claude'), { recursive: true });
+fs.mkdirSync(path.join(TMP_DIR, '.pipeline', 'servicios', 'github', 'pendiente'), { recursive: true });
+for (const phase of ['validacion', 'dev']) {
+    for (const state of ['pendiente', 'trabajando', 'listo']) {
+        fs.mkdirSync(path.join(TMP_DIR, '.pipeline', 'desarrollo', phase, state), { recursive: true });
+    }
+}
+process.env.CLAUDE_PROJECT_DIR = TMP_DIR;
+process.env.PIPELINE_REPO_ROOT = TMP_DIR;
+
+delete require.cache[require.resolve('../traceability')];
+delete require.cache[require.resolve('../human-block')];
+delete require.cache[require.resolve('../rebote-classifier')];
+
+const rc = require('../rebote-classifier');
+const hb = require('../human-block');
+
+function clearAll() {
+    const pipelineDir = path.join(TMP_DIR, '.pipeline');
+    for (const pipeline of ['desarrollo', 'definicion']) {
+        const root = path.join(pipelineDir, pipeline);
+        let phases = [];
+        try { phases = fs.readdirSync(root).filter(f => fs.statSync(path.join(root, f)).isDirectory()); }
+        catch { continue; }
+        for (const phase of phases) {
+            for (const state of ['pendiente', 'trabajando', 'listo', 'bloqueado-humano', 'bloqueado-dependencias']) {
+                const dir = path.join(root, phase, state);
+                try {
+                    for (const f of fs.readdirSync(dir)) {
+                        try { fs.unlinkSync(path.join(dir, f)); } catch {}
+                    }
+                } catch {}
+            }
+        }
+    }
+    const ghQueue = path.join(pipelineDir, 'servicios', 'github', 'pendiente');
+    try { for (const f of fs.readdirSync(ghQueue)) fs.unlinkSync(path.join(ghQueue, f)); } catch {}
+}
+
+// =============================================================================
+// CA-2: hint estructural rebote_categoria
+// =============================================================================
+
+test('CA-2: rebote_categoria=dependency_block en opts clasifica como dependency_block sin necesidad de motivo literal', () => {
+    const result = rc.classifyRebote({
+        // Motivo NO contiene la cadena literal "rebote_categoria: dependency_block"
+        // — el agente lo emitió como campo YAML estructurado, no en motivo.
+        motivo: 'Verificado: el merge de la dependencia todavía no aterrizó',
+        rebote_categoria: 'dependency_block',
+        dependsOn: [3220, 3198],
+    });
+    assert.equal(result.category, 'dependency_block');
+    assert.equal(result.label, 'blocked:dependencies');
+    assert.deepEqual(result.dependsOn, [3198, 3220]);
+    assert.equal(result.counts_against_circuit_breaker, false);
+});
+
+test('CA-2: rebote_categoria=dependency_block sin dependsOn → matched=true, assetOnly', () => {
+    const result = rc.classifyRebote({
+        motivo: 'Asset UX todavía no entregado',
+        rebote_categoria: 'dependency_block',
+    });
+    assert.equal(result.category, 'dependency_block');
+    assert.deepEqual(result.dependsOn, []);
+    assert.match(result.reason_summary, /asset|recurso/i);
+});
+
+test('CA-2: rebote_categoria=human_block en opts fuerza human_block aunque motivo no matchee patrón', () => {
+    const result = rc.classifyRebote({
+        motivo: 'Necesito que decidas qué hacer con el flow X (no hay merge ni codeowners involucrados)',
+        rebote_categoria: 'human_block',
+    });
+    assert.equal(result.category, 'human_block');
+    assert.equal(result.label, 'needs-human');
+});
+
+test('CA-2: sin rebote_categoria opt, comportamiento clásico se preserva', () => {
+    // Motivo con patrón clásico → dependency_block igual
+    const r1 = rc.classifyRebote({
+        motivo: 'depende de #1234 que sigue OPEN',
+    });
+    assert.equal(r1.category, 'dependency_block');
+    assert.deepEqual(r1.dependsOn, [1234]);
+
+    // Motivo sin patrón ni hint → code fallback
+    const r2 = rc.classifyRebote({ motivo: 'NullPointer en línea 42' });
+    assert.equal(r2.category, 'code');
+});
+
+// =============================================================================
+// CA-1 + CA-3: filesystem segregación
+// =============================================================================
+
+test('CA-1: writeDependencyBlockMarker crea marker en bloqueado-dependencias/ + .reason.json', () => {
+    clearAll();
+    const result = rc.writeDependencyBlockMarker({
+        issue: 3221,
+        skill: 'guru',
+        phase: 'validacion',
+        pipeline: 'desarrollo',
+        dependsOn: [3220, 3198],
+        reason: 'Verificado: #3220 OPEN',
+    });
+    assert.equal(result.ok, true);
+    assert.match(result.marker_path, /bloqueado-dependencias[\\/]3221\.guru$/);
+    assert.equal(fs.existsSync(result.marker_path), true);
+    assert.equal(fs.existsSync(result.marker_path + '.reason.json'), true);
+
+    const reason = JSON.parse(fs.readFileSync(result.marker_path + '.reason.json', 'utf8'));
+    assert.equal(reason.issue, 3221);
+    assert.equal(reason.skill, 'guru');
+    assert.equal(reason.phase, 'validacion');
+    assert.deepEqual(reason.depends_on, [3198, 3220]);
+});
+
+test('CA-1: la carpeta bloqueado-dependencias/ es física y distinta de bloqueado-humano/', () => {
+    clearAll();
+    rc.writeDependencyBlockMarker({
+        issue: 9001, skill: 'guru', phase: 'validacion',
+        pipeline: 'desarrollo', dependsOn: [1000],
+    });
+    const depDir = path.join(TMP_DIR, '.pipeline', 'desarrollo', 'validacion', 'bloqueado-dependencias');
+    const humanDir = path.join(TMP_DIR, '.pipeline', 'desarrollo', 'validacion', 'bloqueado-humano');
+    assert.equal(fs.statSync(depDir).isDirectory(), true);
+    // bloqueado-humano puede o no existir aún; lo importante es que NO se solapan.
+    assert.ok(depDir !== humanDir);
+    assert.ok(!fs.readdirSync(depDir).some(f => f === '.gitkeep' ? false : !f.startsWith('9001')));
+});
+
+test('CA-2: moveIssueFilesToDependencyBlock saca archivos de pendiente/trabajando/listo a bloqueado-dependencias/', () => {
+    clearAll();
+    const pendDir = path.join(TMP_DIR, '.pipeline', 'desarrollo', 'validacion', 'pendiente');
+    const workDir = path.join(TMP_DIR, '.pipeline', 'desarrollo', 'validacion', 'trabajando');
+    fs.writeFileSync(path.join(pendDir, '3221.guru'), 'issue: 3221\n');
+    fs.writeFileSync(path.join(workDir, '3221.po'), 'issue: 3221\n');
+
+    const result = rc.moveIssueFilesToDependencyBlock({
+        issue: 3221, pipeline: 'desarrollo', phase: 'validacion',
+    });
+    assert.equal(result.moved, 2);
+
+    const depDir = path.join(TMP_DIR, '.pipeline', 'desarrollo', 'validacion', 'bloqueado-dependencias');
+    const moved = fs.readdirSync(depDir).filter(f => f.startsWith('3221.'));
+    assert.equal(moved.length, 2);
+    assert.equal(fs.existsSync(path.join(pendDir, '3221.guru')), false);
+    assert.equal(fs.existsSync(path.join(workDir, '3221.po')), false);
+});
+
+test('CA-3: releaseDependencyBlockToPendiente devuelve archivos a pendiente/ de la fase original', () => {
+    clearAll();
+    // Setup: simular un issue en bloqueado-dependencias/ con su .reason.json
+    rc.writeDependencyBlockMarker({
+        issue: 3221, skill: 'guru', phase: 'validacion',
+        pipeline: 'desarrollo', dependsOn: [3220],
+    });
+
+    const result = rc.releaseDependencyBlockToPendiente({ issue: 3221 });
+    assert.equal(result.moved, 1);
+    assert.equal(result.pipeline, 'desarrollo');
+    assert.equal(result.phase, 'validacion');
+
+    const pendDir = path.join(TMP_DIR, '.pipeline', 'desarrollo', 'validacion', 'pendiente');
+    assert.equal(fs.existsSync(path.join(pendDir, '3221.guru')), true);
+
+    // El marker debe haber salido de bloqueado-dependencias/
+    const depDir = path.join(TMP_DIR, '.pipeline', 'desarrollo', 'validacion', 'bloqueado-dependencias');
+    assert.equal(fs.existsSync(path.join(depDir, '3221.guru')), false);
+    assert.equal(fs.existsSync(path.join(depDir, '3221.guru.reason.json')), false);
+});
+
+test('CA-3: releaseDependencyBlockToPendiente es idempotente cuando no hay markers', () => {
+    clearAll();
+    const result = rc.releaseDependencyBlockToPendiente({ issue: 99999 });
+    assert.equal(result.moved, 0);
+    assert.deepEqual(result.files, []);
+});
+
+test('CA-3: listDependencyBlockedMarkers lista solo markers válidos (excluye .reason.json y .gitkeep)', () => {
+    clearAll();
+    rc.writeDependencyBlockMarker({
+        issue: 3221, skill: 'guru', phase: 'validacion',
+        pipeline: 'desarrollo', dependsOn: [3220],
+    });
+    // Crear un .gitkeep que debería ignorarse
+    fs.writeFileSync(
+        path.join(TMP_DIR, '.pipeline', 'desarrollo', 'validacion', 'bloqueado-dependencias', '.gitkeep'),
+        '',
+    );
+    const list = rc.listDependencyBlockedMarkers();
+    const found = list.find(m => m.issue === 3221);
+    assert.ok(found, 'marker presente');
+    assert.equal(found.skill, 'guru');
+    assert.equal(found.phase, 'validacion');
+    assert.equal(found.pipeline, 'desarrollo');
+    // No debería incluir el .gitkeep ni el .reason.json
+    assert.equal(list.filter(m => m.issue === 3221).length, 1);
+});
+
+// =============================================================================
+// CA-4: bloqueado-humano sigue intacto
+// =============================================================================
+
+test('CA-4: reportHumanBlock NO toca bloqueado-dependencias/ (solo bloqueado-humano/)', () => {
+    clearAll();
+    const srcDir = path.join(TMP_DIR, '.pipeline', 'desarrollo', 'validacion', 'trabajando');
+    fs.writeFileSync(path.join(srcDir, '7777.po'), 'issue: 7777\n');
+
+    hb.reportHumanBlock({
+        issue: 7777, skill: 'po', phase: 'validacion',
+        reason: 'PO necesita decidir entre A y B',
+        question: '¿Cuál preferís?',
+        skipGithubLabel: true,
+    });
+
+    // El marker DEBE estar en bloqueado-humano/, NO en bloqueado-dependencias/
+    const humanDir = path.join(TMP_DIR, '.pipeline', 'desarrollo', 'validacion', 'bloqueado-humano');
+    const depDir = path.join(TMP_DIR, '.pipeline', 'desarrollo', 'validacion', 'bloqueado-dependencias');
+    assert.equal(fs.existsSync(path.join(humanDir, '7777.po')), true, 'marker en bloqueado-humano/');
+    assert.equal(fs.existsSync(path.join(depDir, '7777.po')), false, 'NO debe estar en bloqueado-dependencias/');
+});
+
+test('CA-4: releaseDependencyBlockToPendiente NO libera markers de bloqueado-humano/', () => {
+    clearAll();
+    const srcDir = path.join(TMP_DIR, '.pipeline', 'desarrollo', 'validacion', 'trabajando');
+    fs.writeFileSync(path.join(srcDir, '8888.po'), 'issue: 8888\n');
+    hb.reportHumanBlock({
+        issue: 8888, skill: 'po', phase: 'validacion',
+        reason: 'lo que sea',
+        question: '¿lo que sea?',
+        skipGithubLabel: true,
+    });
+
+    const result = rc.releaseDependencyBlockToPendiente({ issue: 8888 });
+    assert.equal(result.moved, 0, 'no debe mover nada — está en bloqueado-humano/, no bloqueado-dependencias/');
+
+    // El marker humano sigue intacto
+    const humanDir = path.join(TMP_DIR, '.pipeline', 'desarrollo', 'validacion', 'bloqueado-humano');
+    assert.equal(fs.existsSync(path.join(humanDir, '8888.po')), true);
+});
+
+// =============================================================================
+// CA-5: E2E con dos issues hijos
+// =============================================================================
+
+test('CA-5 E2E: dos issues, uno dependency_block y otro human_block, cada uno cae en SU carpeta', () => {
+    clearAll();
+
+    // ----- Issue A (#10001): dependency_block ----------------------------
+    // Simulamos el flujo del barrido del pulpo
+    const motivoA = 'No puedo continuar, el merge de la dep todavía no aterrizó';
+    const classA = rc.classifyRebote({
+        motivo: motivoA,
+        rebote_categoria: 'dependency_block',
+        dependsOn: [10999],
+    });
+    assert.equal(classA.category, 'dependency_block');
+
+    // Setup archivos del agente y aplicar el flujo del barrido
+    const trabajandoA = path.join(TMP_DIR, '.pipeline', 'desarrollo', 'validacion', 'trabajando');
+    fs.writeFileSync(path.join(trabajandoA, '10001.guru'), `issue: 10001\nrechazado: true\n`);
+    rc.writeDependencyBlockMarker({
+        issue: 10001, skill: 'guru', phase: 'validacion',
+        pipeline: 'desarrollo', dependsOn: classA.dependsOn, reason: motivoA,
+    });
+    rc.moveIssueFilesToDependencyBlock({
+        issue: 10001, pipeline: 'desarrollo', phase: 'validacion',
+    });
+
+    // ----- Issue B (#10002): human_block ---------------------------------
+    const motivoB = 'PR #5555 mergeable pero CODEOWNERS requiere review';
+    const classB = rc.classifyRebote({ motivo: motivoB });
+    assert.equal(classB.category, 'human_block');
+
+    const trabajandoB = path.join(TMP_DIR, '.pipeline', 'desarrollo', 'validacion', 'trabajando');
+    fs.writeFileSync(path.join(trabajandoB, '10002.po'), `issue: 10002\nrechazado: true\n`);
+    hb.reportHumanBlock({
+        issue: 10002, skill: 'po', phase: 'validacion',
+        reason: motivoB,
+        question: '¿Podés revisar el PR?',
+        skipGithubLabel: true,
+    });
+
+    // ----- Verificaciones ------------------------------------------------
+    const depDir = path.join(TMP_DIR, '.pipeline', 'desarrollo', 'validacion', 'bloqueado-dependencias');
+    const humanDir = path.join(TMP_DIR, '.pipeline', 'desarrollo', 'validacion', 'bloqueado-humano');
+
+    // Issue A: SOLO en bloqueado-dependencias/
+    assert.equal(fs.existsSync(path.join(depDir, '10001.guru')), true);
+    assert.equal(fs.existsSync(path.join(humanDir, '10001.guru')), false);
+
+    // Issue B: SOLO en bloqueado-humano/
+    assert.equal(fs.existsSync(path.join(humanDir, '10002.po')), true);
+    assert.equal(fs.existsSync(path.join(depDir, '10002.po')), false);
+
+    // ----- Liberación: solo el dependency_block se destrabar automáticamente
+    // (esto es lo que hace el brazoDesbloqueo cuando las deps cierran)
+    const releaseA = rc.releaseDependencyBlockToPendiente({ issue: 10001 });
+    assert.equal(releaseA.moved, 1);
+
+    // Issue A movido a pendiente/
+    assert.equal(fs.existsSync(path.join(depDir, '10001.guru')), false);
+    assert.equal(
+        fs.existsSync(path.join(TMP_DIR, '.pipeline', 'desarrollo', 'validacion', 'pendiente', '10001.guru')),
+        true,
+    );
+
+    // Issue B sigue en bloqueado-humano/ — espera /unblock manual
+    assert.equal(fs.existsSync(path.join(humanDir, '10002.po')), true);
+
+    // ----- /unblock manual sobre el human-blocked -----------------------
+    const unblockB = hb.unblockIssue({ issue: 10002, guidance: 'OK, revisar', unlocker: 'test' });
+    assert.equal(unblockB.ok, true);
+    assert.equal(fs.existsSync(path.join(humanDir, '10002.po')), false);
+    assert.equal(
+        fs.existsSync(path.join(TMP_DIR, '.pipeline', 'desarrollo', 'validacion', 'pendiente', '10002.po')),
+        true,
+    );
+});
+
+test('CA-5 + #3221 (regresión): motivo con rebote_categoria YAML estructurado NO cae en human_block', () => {
+    // Reproducción exacta del bug: el guru clasificó como dependency_block
+    // emitiendo `rebote_categoria` como campo YAML top-level, pero el barrido
+    // pasaba solo `motivo` al classifier → caía a human_block.
+    // Con la fix, el opt `rebote_categoria` hace que clasifique correcto.
+    const result = rc.classifyRebote({
+        // Motivo del agente (texto plano sin la cadena literal del classifier)
+        motivo: '#3220 (multi-provider routing) sigue abierta. Sin ese merge no podemos validar la integración.',
+        rebote_categoria: 'dependency_block',
+        dependsOn: [3220, 3198],
+    });
+    assert.equal(result.category, 'dependency_block', 'el bug #3229 se mantendría reproducido si esto fuera human_block');
+    assert.equal(result.label, 'blocked:dependencies');
+    assert.notEqual(result.label, 'needs-human');
+    assert.deepEqual(result.dependsOn, [3198, 3220]);
+});

--- a/.pipeline/lib/rebote-classifier.js
+++ b/.pipeline/lib/rebote-classifier.js
@@ -65,6 +65,19 @@ const DEPS_LABEL = 'blocked:dependencies';
 const MAX_MOTIVO_LEN = 5000;
 const MAX_DEPS_PER_BLOCK = 20;
 
+// #3229 — Segregación filesystem entre los dos estados conceptualmente distintos:
+//   - bloqueado-humano/         → needs-human, solo libera con /unblock manual
+//   - bloqueado-dependencias/   → blocked:dependencies, libera automático al
+//                                  cerrar todas las deps (brazoDesbloqueo).
+//
+// Antes de #3229, `bloqueado-humano/` recibía AMBOS estados: el barrido del
+// pulpo invocaba reportHumanBlock cuando el motivo no incluía la cadena
+// literal `rebote_categoria: dependency_block` en el texto, aunque el agente
+// emitiese el campo como YAML estructurado. Resultado: dashboards confusos,
+// labels equivocados, tokens desperdiciados en issues que podían destrabarse
+// solos.
+const DEPS_BLOCK_SUBDIR = 'bloqueado-dependencias';
+
 // -----------------------------------------------------------------------------
 // PATRONES DEPENDENCY_BLOCK
 //
@@ -127,6 +140,15 @@ const STRUCTURED_DEPS_LIST = /\b(?:depende_de|depends_on|dependencias)\s*[:=]\s*
  * @param {string} opts.motivo               — texto crudo del rebote
  * @param {number[]} [opts.dependsOn=[]]     — hint estructural de dependencias
  *                                              (si el agente ya las parseó)
+ * @param {string} [opts.rebote_categoria]   — #3229: si el agente ya clasificó
+ *                                              explícitamente como
+ *                                              'dependency_block' o 'human_block'
+ *                                              vía campo YAML top-level, este
+ *                                              hint gana sobre regex sobre el
+ *                                              motivo. Sin esta vía el puente
+ *                                              guru → barrido quedaba roto
+ *                                              cuando la cadena literal no
+ *                                              aparecía en `motivo`.
  * @param {string} [opts.faseDestino]        — fase destino para cross_phase
  * @param {string} [opts.classifyErrorResult] — resultado de precheck.classifyError
  *                                              ('infra' | 'codigo'). Si no se
@@ -161,7 +183,39 @@ function classifyRebote(opts = {}) {
     }
 
     // 2. dependency_block — primer matcher específico
-    //    Prioridad: hint estructural > regex sobre el texto
+    //
+    // Precedencia interna:
+    //   (a) Hint YAML estructurado `rebote_categoria: dependency_block`  [#3229]
+    //   (b) Hint estructural en motivo `rebote_categoria: dependency_block`
+    //   (c) Regex sobre el texto del motivo
+    //
+    // (a) es el camino limpio para agentes que emiten YAML típado; (b) y (c)
+    // siguen vigentes como compat para motivos en texto plano.
+    const explicitCategory = typeof opts.rebote_categoria === 'string'
+        ? opts.rebote_categoria.trim().toLowerCase()
+        : null;
+
+    if (explicitCategory === 'dependency_block') {
+        // Confiamos en el agente — usamos el dependsOn que pasó (sanitizado)
+        // y NO corremos los regex (evitamos falsos negativos por motivos
+        // demasiado cortos o sin patrón estándar).
+        return {
+            category: 'dependency_block',
+            label: DEPS_LABEL,
+            dependsOn: hintDeps,
+            counts_against_circuit_breaker: false,
+            autounlock: {
+                source: 'github-label',
+                mechanism: 'brazo-desbloqueo',
+                label: DEPS_LABEL,
+                note: 'El Pulpo destraba automáticamente cuando todas las dependencias estén CLOSED en GitHub.',
+            },
+            reason_summary: hintDeps.length > 0
+                ? 'Depende de issue(s) abierto(s): ' + hintDeps.map(n => '#' + n).join(', ')
+                : 'Espera asset/recurso no en main (agente declaró dependency_block sin issue numbers)',
+        };
+    }
+
     const depDetect = detectDependencyBlock(motivo, hintDeps);
     if (depDetect.matched) {
         return {
@@ -178,6 +232,21 @@ function classifyRebote(opts = {}) {
             reason_summary: depDetect.assetOnly
                 ? 'Espera asset/recurso no en main'
                 : 'Depende de issue(s) abierto(s): ' + depDetect.dependsOn.map(n => '#' + n).join(', '),
+        };
+    }
+
+    // 2.5 — #3229: si el agente declaró `rebote_categoria: human_block` como
+    // hint YAML explícito, lo respetamos sin pasar por el regex de
+    // isHumanBlockReason. Cubre casos donde el motivo no incluye un patrón
+    // canónico pero el agente sabe que necesita humano (PO ambiguo, etc).
+    if (explicitCategory === 'human_block') {
+        return {
+            category: 'human_block',
+            label: humanBlock.NEEDS_HUMAN_LABEL,
+            dependsOn: [],
+            counts_against_circuit_breaker: false,
+            autounlock: null,
+            reason_summary: 'Bloqueo humano (agente declaró human_block explícitamente)',
         };
     }
 
@@ -385,6 +454,221 @@ function reportDependencyBlock(opts) {
     return { ok: true, issue, label_queued: labelQueued, comment_queued: commentQueued };
 }
 
+// =============================================================================
+// #3229 — Segregación filesystem bloqueado-dependencias/
+// =============================================================================
+//
+// Antes de #3229 el barrido del pulpo movía los archivos del issue a
+// `archivado/` y dejaba al brazoDesbloqueo trabajar solo desde la GitHub-label.
+// El problema: al destrabar, no había forma simple de reingresar el archivo a
+// `pendiente/` (estaba enterrado en archivado/ junto a basura técnica).
+//
+// El nuevo flujo:
+//   1. Barrido detecta dependency_block → mueve archivos a
+//      <pipeline>/<phase>/bloqueado-dependencias/<issue>.<skill>
+//      + .reason.json adyacente con metadata (depende_de, skill, fase, ts).
+//   2. Aplica label `blocked:dependencias` en GitHub (vía reportDependencyBlock).
+//   3. brazoDesbloqueo descubre que todas las deps cerraron → quita label
+//      + escanea `bloqueado-dependencias/` y mueve archivos a `pendiente/`
+//      de la fase original (que está en el .reason.json).
+//
+// `bloqueado-humano/` queda INTACTO — su contrato (release vía /unblock) no
+// cambia. Las dos carpetas son hermanas, mutuamente excluyentes por issue.
+
+/**
+ * Crea/actualiza el marker filesystem para un issue bloqueado por dependencias.
+ * Pareja simétrica de `humanBlock.reportHumanBlock` para el otro estado.
+ *
+ * @param {object} opts
+ * @param {number} opts.issue
+ * @param {string} opts.skill        — skill del agente que detectó la dep
+ * @param {string} opts.phase        — fase donde se detectó (validacion, dev, etc)
+ * @param {string} opts.pipeline     — pipeline (desarrollo/definicion)
+ * @param {number[]} opts.dependsOn  — issue numbers de las dependencias
+ * @param {string} [opts.reason]     — motivo del agente
+ *
+ * @returns {{ ok: boolean, marker_path?: string, error?: string }}
+ */
+function writeDependencyBlockMarker(opts) {
+    const issue = Number(opts.issue);
+    const skill = String(opts.skill || '').trim();
+    const phase = String(opts.phase || '').trim();
+    const pipeline = String(opts.pipeline || 'desarrollo').trim();
+    if (!issue || !skill || !phase) {
+        return { ok: false, error: 'writeDependencyBlockMarker requiere issue, skill, phase' };
+    }
+
+    const targetDir = path.join(PIPELINE_DIR, pipeline, phase, DEPS_BLOCK_SUBDIR);
+    try { fs.mkdirSync(targetDir, { recursive: true }); }
+    catch (e) { return { ok: false, error: 'No se pudo crear ' + DEPS_BLOCK_SUBDIR + ': ' + e.message }; }
+
+    const marker = `${issue}.${skill}`;
+    const targetFile = path.join(targetDir, marker);
+    if (!fs.existsSync(targetFile)) {
+        try { fs.writeFileSync(targetFile, ''); }
+        catch (e) { return { ok: false, error: 'No se pudo crear marker: ' + e.message }; }
+    }
+
+    // Metadata adyacente — el brazoDesbloqueo la lee para saber a qué fase
+    // devolver el archivo cuando destraba.
+    try {
+        fs.writeFileSync(targetFile + '.reason.json', JSON.stringify({
+            issue, skill, phase, pipeline,
+            depends_on: sanitizeDepsList(opts.dependsOn),
+            reason: String(opts.reason || '').slice(0, 1500),
+            blocked_at: new Date().toISOString(),
+        }, null, 2));
+    } catch (e) {
+        // Fail-open: el marker ya está; sin .reason.json el brazo de
+        // desbloqueo cae a defaults (skill='build', phase=BLOCK_SUBDIR padre).
+    }
+
+    return { ok: true, marker_path: targetFile };
+}
+
+/**
+ * Mueve los archivos del issue (desde pendiente/trabajando/listo de la fase
+ * actual) a `bloqueado-dependencias/`. Asociado a `writeDependencyBlockMarker`.
+ *
+ * @param {object} opts
+ * @param {number} opts.issue
+ * @param {string} opts.pipeline
+ * @param {string} opts.phase
+ *
+ * @returns {{ moved: number, target_dir: string }}
+ */
+function moveIssueFilesToDependencyBlock(opts) {
+    const issue = Number(opts.issue);
+    const pipeline = String(opts.pipeline || 'desarrollo').trim();
+    const phase = String(opts.phase || '').trim();
+    if (!issue || !phase) return { moved: 0, target_dir: '' };
+
+    const targetDir = path.join(PIPELINE_DIR, pipeline, phase, DEPS_BLOCK_SUBDIR);
+    try { fs.mkdirSync(targetDir, { recursive: true }); } catch {}
+
+    const prefix = String(issue) + '.';
+    let moved = 0;
+    for (const state of ['pendiente', 'trabajando', 'listo']) {
+        const dir = path.join(PIPELINE_DIR, pipeline, phase, state);
+        let entries = [];
+        try { entries = fs.readdirSync(dir); } catch { continue; }
+        for (const f of entries) {
+            if (!f.startsWith(prefix) || f === '.gitkeep') continue;
+            const src = path.join(dir, f);
+            const dst = path.join(targetDir, f);
+            try {
+                fs.renameSync(src, dst);
+                moved++;
+            } catch {
+                // Si rename falla (cross-device, lock), copiamos+unlink
+                try {
+                    fs.copyFileSync(src, dst);
+                    fs.unlinkSync(src);
+                    moved++;
+                } catch {}
+            }
+        }
+    }
+    return { moved, target_dir: targetDir };
+}
+
+/**
+ * Lista markers presentes en `bloqueado-dependencias/` para todos los
+ * pipelines/fases. Usado por el brazoDesbloqueo para reingresar archivos
+ * cuando las dependencias cierran.
+ *
+ * @returns {Array<{issue, skill, phase, pipeline, file, reason}>}
+ */
+function listDependencyBlockedMarkers() {
+    const PIPELINES = ['desarrollo', 'definicion'];
+    const out = [];
+    for (const pipeline of PIPELINES) {
+        const pipeRoot = path.join(PIPELINE_DIR, pipeline);
+        let phases = [];
+        try {
+            phases = fs.readdirSync(pipeRoot).filter(f => {
+                try { return fs.statSync(path.join(pipeRoot, f)).isDirectory(); }
+                catch { return false; }
+            });
+        } catch { continue; }
+        for (const phase of phases) {
+            const dir = path.join(pipeRoot, phase, DEPS_BLOCK_SUBDIR);
+            let entries = [];
+            try { entries = fs.readdirSync(dir); } catch { continue; }
+            for (const f of entries) {
+                if (f === '.gitkeep' || f.endsWith('.reason.json')) continue;
+                // Markers válidos tienen forma <issue>.<skill> (≤2 segmentos)
+                if (f.split('.').length > 2) continue;
+                const dot = f.indexOf('.');
+                if (dot <= 0) continue;
+                const issue = Number(f.slice(0, dot));
+                const skill = f.slice(dot + 1);
+                if (!Number.isFinite(issue)) continue;
+                let reason = null;
+                try { reason = JSON.parse(fs.readFileSync(path.join(dir, f + '.reason.json'), 'utf8')); }
+                catch {}
+                out.push({
+                    issue, skill, phase, pipeline,
+                    file: path.join(dir, f),
+                    reason,
+                });
+            }
+        }
+    }
+    return out;
+}
+
+/**
+ * Reingresa el archivo de un issue desde `bloqueado-dependencias/` a
+ * `pendiente/` de la fase declarada en `.reason.json` (o `phase` si se pasa).
+ * Idempotente: si el archivo ya no está, devuelve `moved: 0`.
+ *
+ * @param {object} opts
+ * @param {number} opts.issue
+ * @param {string} [opts.targetPhase] — fase explícita; default = lo que dice
+ *                                       el .reason.json del marker.
+ *
+ * @returns {{ moved: number, files: string[], pipeline?: string, phase?: string }}
+ */
+function releaseDependencyBlockToPendiente(opts) {
+    const issue = Number(opts.issue);
+    if (!issue) return { moved: 0, files: [] };
+
+    const markers = listDependencyBlockedMarkers().filter(m => m.issue === issue);
+    if (markers.length === 0) return { moved: 0, files: [] };
+
+    // Agrupar por pipeline+phase (debería ser único, pero defense-in-depth)
+    let pipeline = null;
+    let phase = null;
+    const movedFiles = [];
+
+    for (const m of markers) {
+        const dstPhase = String(opts.targetPhase || m.phase);
+        const dstDir = path.join(PIPELINE_DIR, m.pipeline, dstPhase, 'pendiente');
+        try { fs.mkdirSync(dstDir, { recursive: true }); } catch {}
+        const dst = path.join(dstDir, path.basename(m.file));
+        try {
+            fs.renameSync(m.file, dst);
+            movedFiles.push(dst);
+            pipeline = m.pipeline;
+            phase = dstPhase;
+        } catch {
+            try {
+                fs.copyFileSync(m.file, dst);
+                fs.unlinkSync(m.file);
+                movedFiles.push(dst);
+                pipeline = m.pipeline;
+                phase = dstPhase;
+            } catch {}
+        }
+        // Limpiar el .reason.json adyacente (su info ya está en el archivo
+        // movido o ya no aplica — el agente reentra a pendiente/).
+        try { fs.unlinkSync(m.file + '.reason.json'); } catch {}
+    }
+
+    return { moved: movedFiles.length, files: movedFiles, pipeline, phase };
+}
+
 // -----------------------------------------------------------------------------
 // HELPERS INTERNOS
 // -----------------------------------------------------------------------------
@@ -427,8 +711,14 @@ module.exports = {
     buildDependencyComment,
     reportDependencyBlock,
     sanitizeDepsList,
+    // #3229 — segregación filesystem bloqueado-dependencias/
+    writeDependencyBlockMarker,
+    moveIssueFilesToDependencyBlock,
+    listDependencyBlockedMarkers,
+    releaseDependencyBlockToPendiente,
     DEPENDENCY_PATTERNS,
     DEPENDENCY_ASSET_PATTERNS,
     DEPS_LABEL,
+    DEPS_BLOCK_SUBDIR,
     MAX_DEPS_PER_BLOCK,
 };

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -991,7 +991,9 @@ function issueExistsInPipeline(issueNum, pipelineName) {
       // Solo buscar en estados activos — procesado significa que ya terminó esa fase
       // bloqueado-humano cuenta como activo: el issue está pausado pero ocupando slot conceptual,
       // no debe re-intakearse ni relanzarse hasta que /unblock lo desbloquee (issue #2478)
-      for (const estado of ['pendiente', 'trabajando', 'listo', 'bloqueado-humano']) {
+      // bloqueado-dependencias (issue #3229) idem: el brazoDesbloqueo lo libera cuando
+      // todas las deps cierren — mientras tanto, no debe re-intakearse ni relanzarse.
+      for (const estado of ['pendiente', 'trabajando', 'listo', 'bloqueado-humano', 'bloqueado-dependencias']) {
         const dir = path.join(PIPELINE, pName, fase, estado);
         try {
           for (const f of fs.readdirSync(dir)) {
@@ -2747,10 +2749,19 @@ function brazoBarrido(config) {
           // #2317: clasificar los rechazos por tipo. Si TODOS los motivos
           // apuntan a infra (ENOTFOUND/ETIMEDOUT/etc) marcamos el rebote como
           // `rebote_tipo: infra` para que NO cuente contra el circuit breaker.
+          //
+          // #3229 — pasamos también los campos YAML estructurados que el
+          // agente pudo haber emitido (rebote_categoria, depende_de). Antes
+          // se construía solo con `motivo` y el classifier no veía la
+          // categoría declarativa cuando el agente la emitía como YAML
+          // top-level (resultaba en `human_block` por fallback).
           const motivosClasificados = rechazados.map(r => ({
             skill: skillFromFile(r.file.name),
             motivo: r.motivo || '',
             clasificacion: precheck.classifyError(r.motivo || '') || 'codigo',
+            // Hints estructurados del YAML del agente (pueden ser undefined)
+            rebote_categoria: r.rebote_categoria || null,
+            depende_de: Array.isArray(r.depende_de) ? r.depende_de : null,
           }));
           const esReboteDeInfra = motivosClasificados.length > 0
             && motivosClasificados.every(m => m.clasificacion === 'infra');
@@ -2772,6 +2783,10 @@ function brazoBarrido(config) {
                 motivo: m.motivo,
                 classifyErrorResult: m.clasificacion,
                 isRoutingMismatch: false, // routing se evalúa más abajo, mantener orden
+                // #3229 — hints estructurados del YAML del agente. Cierra el
+                // puente roto entre guru (clasifica) y barrido (consumer).
+                rebote_categoria: m.rebote_categoria,
+                dependsOn: m.depende_de,
               });
               if (result.category !== 'dependency_block') continue;
 
@@ -2827,30 +2842,41 @@ function brazoBarrido(config) {
                 break;
               }
 
-              // Mover archivos de la fase actual a archivado/ — el issue queda
-              // fuera del flujo activo hasta que el brazoDesbloqueo le quite el
-              // label. Mismo patrón que la rama humanBlock más abajo.
-              for (const a of archivos) {
-                const destArch = path.join(fasePath(pipelineName, fase), 'archivado');
-                try { fs.mkdirSync(destArch, { recursive: true }); moveFile(a.path, destArch); } catch {}
+              // #3229 — Mover archivos a `bloqueado-dependencias/` (NO a
+              // `archivado/`). La segregación física hace que:
+              //   - dashboards/auditoría distingan needs-human de blocked-deps,
+              //   - el brazoDesbloqueo pueda reingresar los archivos a
+              //     `pendiente/` cuando cierren todas las deps,
+              //   - los motivos no se confundan ("archivado" implicaba
+              //     descartado/manual).
+              try {
+                reboteClassifier.writeDependencyBlockMarker({
+                  issue: parseInt(issue),
+                  skill: skillDep,
+                  phase: fase,
+                  pipeline: pipelineName,
+                  dependsOn: result.dependsOn,
+                  reason: motivoSanitized,
+                });
+              } catch (e) {
+                log('barrido', `[WARN] #${issue} writeDependencyBlockMarker falló (no bloqueante): ${e.message}`);
               }
-              for (const estado of ['pendiente', 'trabajando']) {
-                const dir = path.join(fasePath(pipelineName, fase), estado);
-                try {
-                  for (const f of fs.readdirSync(dir)) {
-                    if (f.startsWith(issue + '.') && !f.startsWith('.')) {
-                      const archDir = path.join(fasePath(pipelineName, fase), 'archivado');
-                      fs.mkdirSync(archDir, { recursive: true });
-                      try { moveFile(path.join(dir, f), archDir); } catch {}
-                    }
-                  }
-                } catch {}
+
+              try {
+                const movResult = reboteClassifier.moveIssueFilesToDependencyBlock({
+                  issue: parseInt(issue),
+                  pipeline: pipelineName,
+                  phase: fase,
+                });
+                log('barrido', `📦 #${issue} archivos movidos a bloqueado-dependencias/ (count=${movResult.moved})`);
+              } catch (e) {
+                log('barrido', `[WARN] #${issue} moveIssueFilesToDependencyBlock falló: ${e.message}`);
               }
 
               const depsLabel = result.dependsOn.length > 0
                 ? result.dependsOn.map(n => '#' + n).join(',')
                 : '(asset)';
-              log('barrido', `🪢 #${issue} → blocked:dependencies (skill=${skillDep}, deps=${depsLabel}) — sin rebote, sin marker humano, esperando brazoDesbloqueo.`);
+              log('barrido', `🪢 #${issue} → blocked:dependencies (skill=${skillDep}, deps=${depsLabel}) — bloqueado-dependencias/, label blocked:dependencies. Sin needs-human, esperando brazoDesbloqueo.`);
               try {
                 sendTelegram(`🪢 Issue #${issue} bloqueado por dependencias — esperando ${depsLabel}. El pipeline destraba automáticamente al cerrar.`);
               } catch {}
@@ -4006,7 +4032,43 @@ function brazoLanzamiento(config) {
     }
 
     // 0b. BLOCKED: no lanzar issues con blocked:dependencies
+    //
+    // #3229 — Simetría con la rama needs-human de más abajo: si el label se
+    // aplicó DESPUÉS de que el archivo entró a pendiente/ (ej. label puesto
+    // a mano o por servicio-github post-intake), movemos el archivo a
+    // `bloqueado-dependencias/` para que el dashboard lo vea segregado y
+    // el brazoDesbloqueo pueda devolverlo a pendiente/ al destrabar.
     if (issueLbls.includes('blocked:dependencies')) {
+      try {
+        const blockedDepDir = path.join(fasePath(pipelineName, fase), 'bloqueado-dependencias');
+        fs.mkdirSync(blockedDepDir, { recursive: true });
+        const targetFile = path.join(blockedDepDir, archivo.name);
+        if (!fs.existsSync(targetFile)) {
+          try { fs.renameSync(archivo.path, targetFile); }
+          catch {
+            try { fs.copyFileSync(archivo.path, targetFile); fs.unlinkSync(archivo.path); } catch {}
+          }
+          // Dejar .reason.json mínimo si no existía — el brazoDesbloqueo lo
+          // necesita para saber a qué fase devolver el archivo al destrabar.
+          const reasonFile = targetFile + '.reason.json';
+          if (!fs.existsSync(reasonFile)) {
+            try {
+              fs.writeFileSync(reasonFile, JSON.stringify({
+                issue: parseInt(issue),
+                skill: skillFromFile(archivo.name),
+                phase: fase,
+                pipeline: pipelineName,
+                depends_on: [],
+                reason: 'Label blocked:dependencies aplicado en GitHub — pipeline pausa hasta que el brazoDesbloqueo verifique que todas las deps cerraron.',
+                blocked_at: new Date().toISOString(),
+              }, null, 2));
+            } catch {}
+          }
+          log('lanzamiento', `🪢 #${issue} movido a bloqueado-dependencias/ (label blocked:dependencies aplicado post-intake)`);
+        }
+      } catch (e) {
+        log('lanzamiento', `[WARN] #${issue} no se pudo mover a bloqueado-dependencias/: ${e.message}`);
+      }
       log('lanzamiento', `#${issue} omitido — blocked:dependencies`);
       continue;
     }
@@ -8406,6 +8468,24 @@ async function brazoDesbloqueoImpl(config) {
               ['issue', 'edit', String(issue.number), '--remove-label', 'blocked:dependencies', '--repo', 'intrale/platform'],
               10000
             );
+
+            // #3229 — Reingresar archivos del filesystem: si el barrido movió
+            // el issue a `bloqueado-dependencias/` (post-#3229), liberarlo a
+            // `pendiente/` de la fase original. Idempotente: si no hay
+            // marker (caso pre-#3229 o issue label-only sin filesystem move),
+            // moved=0 y seguimos.
+            try {
+              const releaseRes = reboteClassifier.releaseDependencyBlockToPendiente({
+                issue: issue.number,
+              });
+              if (releaseRes.moved > 0) {
+                log('desbloqueo', `🟢 #${issue.number}: ${releaseRes.moved} archivo(s) movido(s) de bloqueado-dependencias/ a ${releaseRes.pipeline}/${releaseRes.phase}/pendiente/`);
+              } else {
+                log('desbloqueo', `🟢 #${issue.number}: sin archivos en bloqueado-dependencias/ (issue label-only, pipeline arrancará via intake)`);
+              }
+            } catch (e) {
+              log('desbloqueo', `[WARN] #${issue.number}: releaseDependencyBlockToPendiente falló (no bloqueante): ${e.message}`);
+            }
 
             // Agregar comentario de desbloqueo
             const unblockComment = `## Dependencias resueltas 🟢\n\nLas siguientes dependencias cerraron: ${depIssueNumbers.map(n => '#' + n).join(', ')}.\n\nEl pipeline reentra a este issue automáticamente.`;


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 5 archivos · +759 -20

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:passed` aplicado por delivery

## Closes

Closes #3229
