### PR TITLE
fix(servicio-github): escapado de saltos de línea rompe parsing del detector de dependencias del Pulpo

### DIFF
--- a/.pipeline/__tests__/servicio-github.test.js
+++ b/.pipeline/__tests__/servicio-github.test.js
@@ -467,3 +467,316 @@ test('processQueue() sin args usa defaultGhClient (firma compatible con producci
     // ejecuciones). Aquí no asertamos un destino específico, solo que el
     // dispatch no fue rechazado por la firma.
 });
+
+// ===========================================================================
+// #3303 — Body con saltos de línea reales preservados extremo a extremo.
+//
+// Causa raíz del incidente del 2026-05-17: el `esc()` viejo convertía `\n` a
+// la secuencia literal `\\n` para no romper el quoting del shell de Windows.
+// Resultado: el comentario posteado a GitHub quedaba en una sola línea y el
+// detector de dependencias del Pulpo (`parseDependencyComment`) no matcheaba.
+//
+// El fix migra a `cp.execFileSync` + `--body-file -` con stdin, lo que no
+// requiere escape de newlines. Estos tests cierran la regresión:
+//
+//   CA-4 (dispatch test puro):
+//     - El fake `ghClient` mockea la API. El worker invoca commentIssue con
+//       el body íntegro (con `\n` reales). Si alguien reintrodujera `esc()`
+//       o cualquier transformación de newlines en el path del worker, el
+//       fake lo detectaría comparando `args[1]` contra el string original.
+//
+//   CA-5 (E2E hasta el binario):
+//     - Monkey-patch de `cp.execFileSync` en el módulo de servicio-github.
+//       Captura el argv y `options.input` que llegan al binario `gh`.
+//       Verifica:
+//         (a) que el body se pasa por `--body-file -` (no `-b "..."`).
+//         (b) que el body en stdin tiene los `\n` reales sin transformación.
+//         (c) que NO aparece el patrón `\\n` literal anti-pattern.
+//
+//   CA-6 (integración con el parser real):
+//     - Toma el body que captura CA-5 y lo pasa por `parseDependencyComment`.
+//       Verifica que el parser detecta correctamente el listado `- #NNNN`.
+//       Si el body llegara con `\n` literales (como antes del fix), el
+//       parser devolvería `null` (causa raíz exacta del incidente #3253).
+// ===========================================================================
+
+test('CA-4 #3303: action=comment con body multilínea pasa newlines reales al ghClient', () => {
+    resetState();
+    const ghClient = makeFakeGhClient();
+
+    const bodyMultilinea = '## Dependencias detectadas por el pipeline\n\n- #3257\n\nEste issue queda bloqueado hasta que cierren las dependencias.';
+
+    const filename = enqueueOrder(3253, {
+        action: 'comment', issue: 3253, body: bodyMultilinea,
+    });
+
+    svc.processQueue({ ghClient });
+
+    const call = ghClient.calls.find(c => c.method === 'commentIssue');
+    assert.ok(call, `commentIssue debe haber sido invocado (calls=${JSON.stringify(ghClient.calls)})`);
+    assert.equal(call.args[0], 3253);
+
+    // CA-4 — el body llega IDÉNTICO al string original; ni el dispatcher ni
+    // el `sanitizeGithubPayload` deben transformar `\n` real en `\\n` literal.
+    const receivedBody = call.args[1];
+    assert.equal(receivedBody, bodyMultilinea,
+        'body debe pasarse verbatim — sin transformación de newlines');
+
+    // Doble check: el body contiene saltos de línea reales y NO la secuencia
+    // literal `\n` (dos chars: backslash + n) que producía el bug original.
+    assert.ok(receivedBody.includes('\n'),
+        'body recibido debe contener LF real');
+    assert.ok(!receivedBody.includes('\\n'),
+        'body recibido NO debe contener la secuencia literal \\n (sería el bug previo)');
+
+    // Sanity: el resultado quedó en listo sin descartado.
+    const result = readListoFile(filename);
+    assert.equal(result.discarded, undefined);
+});
+
+test('CA-5 #3303: defaultGhClient.commentIssue invoca execFileSync con --body-file - y body en stdin', () => {
+    resetState();
+
+    // Body que reproduce exactamente el patrón del incidente #3253.
+    const bodyMultilinea = '## Dependencias detectadas por el pipeline\n\n- #3257\n\nEste issue queda bloqueado hasta que cierren las dependencias.';
+
+    // Monkey-patch `cp.execFileSync` a nivel módulo. La producción usa
+    // `cp.execFileSync(GH_BIN, argv, opts)` — capturamos los 3 args, NO
+    // invocamos el binario real. Saneamos al final con `cp.execFileSync = original`.
+    //
+    // Por qué este enfoque y no un stub `.exe` real:
+    //   - Windows requiere `.exe` nativo o `shell: true` para `.bat`/`.cmd`,
+    //     y el punto del fix es justamente NO usar shell. Un stub `.js`
+    //     no es ejecutable directo desde `execFileSync` sin shell.
+    //   - El monkey-patch del módulo `child_process` es el mecanismo
+    //     estándar en Node `node --test` para aislar IO. La invocación
+    //     real ya está cubierta por integration tests en producción
+    //     (el daemon corre miles de veces al día contra `gh.exe` real).
+    const cp = require('node:child_process');
+    const originalExecFileSync = cp.execFileSync;
+
+    let capturedFile = null;
+    let capturedArgs = null;
+    let capturedOptions = null;
+    cp.execFileSync = function spyExecFileSync(file, args, options) {
+        capturedFile = file;
+        capturedArgs = args;
+        capturedOptions = options;
+        // Simulamos un comentario exitoso (gh devuelve la URL en stdout).
+        return 'https://github.com/intrale/platform/issues/3253#issuecomment-fake\n';
+    };
+
+    try {
+        svc.defaultGhClient.commentIssue(3253, bodyMultilinea);
+    } finally {
+        cp.execFileSync = originalExecFileSync;
+    }
+
+    // CA-5 (a) — argv usa --body-file -, NO -b/--body con interpolación.
+    assert.ok(Array.isArray(capturedArgs), 'execFileSync debe recibir argv como array');
+    assert.deepEqual(capturedArgs.slice(0, 3), ['issue', 'comment', '3253']);
+    assert.ok(capturedArgs.includes('--body-file'),
+        `argv debe incluir --body-file (recibido: ${JSON.stringify(capturedArgs)})`);
+    const bodyFileIdx = capturedArgs.indexOf('--body-file');
+    assert.equal(capturedArgs[bodyFileIdx + 1], '-',
+        '--body-file debe apuntar a "-" (stdin)');
+    assert.ok(!capturedArgs.includes('-b'),
+        `argv NO debe usar -b (sería interpolación shell — recibido: ${JSON.stringify(capturedArgs)})`);
+
+    // CA-5 (b) — el body real llega íntegro por stdin (options.input).
+    assert.ok(capturedOptions && typeof capturedOptions.input === 'string',
+        'options.input debe ser string con el body');
+    assert.equal(capturedOptions.input, bodyMultilinea,
+        'options.input debe ser EXACTAMENTE el body original (sin transformación)');
+
+    // CA-5 (c) — anti-pattern: NO debe haber backslash-n literal en el input.
+    assert.ok(capturedOptions.input.includes('\n'),
+        'options.input debe tener LF real');
+    assert.ok(!capturedOptions.input.includes('\\n'),
+        'options.input NO debe tener la secuencia literal \\\\n');
+
+    // Sanity: cwd, encoding, timeout, windowsHide preservados del cliente anterior.
+    assert.equal(capturedOptions.encoding, 'utf8');
+    assert.equal(typeof capturedOptions.timeout, 'number');
+    assert.equal(capturedOptions.windowsHide, true);
+});
+
+test('CA-5 #3303: defaultGhClient.createIssue usa --body-file - y title como argv literal', () => {
+    resetState();
+
+    const titleMultilinea = 'Issue de prueba con "comillas" y %USERPROFILE%';
+    const bodyMultilinea = 'Línea 1\nLínea 2\nLínea 3\n\nCon emojis 🎯 y backticks `cmd`';
+
+    const cp = require('node:child_process');
+    const originalExecFileSync = cp.execFileSync;
+
+    let capturedArgs = null;
+    let capturedOptions = null;
+    cp.execFileSync = function spyExecFileSync(file, args, options) {
+        capturedArgs = args;
+        capturedOptions = options;
+        return 'https://github.com/intrale/platform/issues/9999\n';
+    };
+
+    let result;
+    try {
+        result = svc.defaultGhClient.createIssue({
+            title: titleMultilinea,
+            body: bodyMultilinea,
+            labels: 'bug,needs-definition',
+            repo: 'intrale/platform',
+        });
+    } finally {
+        cp.execFileSync = originalExecFileSync;
+    }
+
+    // Verificar shape: ['issue', 'create', '--title', <title>, '--body-file', '-', '--repo', <repo>, '--label', <labels>]
+    assert.deepEqual(capturedArgs.slice(0, 2), ['issue', 'create']);
+
+    // Title pasa como un solo argv (sin escape, sin expansion de %USERPROFILE%).
+    const titleIdx = capturedArgs.indexOf('--title');
+    assert.equal(capturedArgs[titleIdx + 1], titleMultilinea,
+        'title debe pasarse como un solo argv literal — sin transformación');
+
+    // Body por stdin con --body-file -.
+    const bodyFileIdx = capturedArgs.indexOf('--body-file');
+    assert.equal(capturedArgs[bodyFileIdx + 1], '-');
+    assert.equal(capturedOptions.input, bodyMultilinea,
+        'body de createIssue debe llegar íntegro por stdin');
+    assert.ok(!capturedOptions.input.includes('\\n'),
+        'body NO debe tener secuencia literal \\\\n');
+
+    // Repo y label como argv.
+    const repoIdx = capturedArgs.indexOf('--repo');
+    assert.equal(capturedArgs[repoIdx + 1], 'intrale/platform');
+    const labelIdx = capturedArgs.indexOf('--label');
+    assert.equal(capturedArgs[labelIdx + 1], 'bug,needs-definition');
+
+    // Parse del result (extraer número desde la URL).
+    assert.equal(result.number, 9999);
+});
+
+test('CA-5 #3303: defaultGhClient.editIssue usa argv array (sin shell) para add/remove label', () => {
+    resetState();
+
+    const cp = require('node:child_process');
+    const originalExecFileSync = cp.execFileSync;
+    const calls = [];
+    cp.execFileSync = function spyExecFileSync(file, args, options) {
+        calls.push({ file, args, options });
+        return '';
+    };
+
+    try {
+        svc.defaultGhClient.editIssue(1234, { addLabel: 'needs-definition' });
+        svc.defaultGhClient.editIssue(1234, { removeLabel: 'blocked:dependencies' });
+    } finally {
+        cp.execFileSync = originalExecFileSync;
+    }
+
+    assert.equal(calls.length, 2);
+    assert.deepEqual(calls[0].args, ['issue', 'edit', '1234', '--add-label', 'needs-definition']);
+    assert.deepEqual(calls[1].args, ['issue', 'edit', '1234', '--remove-label', 'blocked:dependencies']);
+    // No hay options.input para edits.
+    assert.equal(calls[0].options.input, undefined);
+});
+
+test('CA-5 #3303: defaultGhClient.createLabel usa argv array y preserva idempotencia "already exists"', () => {
+    resetState();
+
+    const cp = require('node:child_process');
+    const originalExecFileSync = cp.execFileSync;
+
+    let callArgs = null;
+    cp.execFileSync = function spyExecFileSync(file, args, options) {
+        callArgs = args;
+        return '';
+    };
+
+    let result;
+    try {
+        result = svc.defaultGhClient.createLabel('label-nuevo', 'B60205', { repo: 'intrale/platform' });
+    } finally {
+        cp.execFileSync = originalExecFileSync;
+    }
+
+    assert.deepEqual(callArgs, ['label', 'create', 'label-nuevo', '--color', 'B60205', '--repo', 'intrale/platform']);
+    assert.equal(result.created, true);
+    assert.equal(result.alreadyExists, false);
+
+    // Caso idempotencia: el binario falla con "already exists".
+    cp.execFileSync = function spyExecFileSyncFails() {
+        const err = new Error('Error: label already exists');
+        err.stderr = 'label already exists\n';
+        throw err;
+    };
+
+    try {
+        result = svc.defaultGhClient.createLabel('label-existente', 'ededed', { repo: 'intrale/platform' });
+    } finally {
+        cp.execFileSync = originalExecFileSync;
+    }
+
+    assert.equal(result.created, false);
+    assert.equal(result.alreadyExists, true);
+});
+
+test('CA-6 #3303: ciclo end-to-end — body posteado por commentIssue es detectado por parseDependencyComment', () => {
+    resetState();
+
+    // 1. Body que produce el pipeline cuando un issue tiene dependencias.
+    const bodyPipeline = '## Dependencias detectadas por el pipeline\n\n- #3257\n- #3260\n\nEste issue queda bloqueado hasta que cierren las dependencias.';
+
+    // 2. Capturamos el `options.input` que llegaría al binario `gh`.
+    const cp = require('node:child_process');
+    const originalExecFileSync = cp.execFileSync;
+    let stdinCaptured = null;
+    cp.execFileSync = function spyExecFileSync(file, args, options) {
+        stdinCaptured = options.input;
+        return '';
+    };
+
+    try {
+        svc.defaultGhClient.commentIssue(3253, bodyPipeline);
+    } finally {
+        cp.execFileSync = originalExecFileSync;
+    }
+
+    // 3. El body capturado debe ser idéntico al original (lo que GitHub
+    //    recibe y lo que después devuelve por `gh issue view --json comments`).
+    assert.equal(stdinCaptured, bodyPipeline);
+
+    // 4. Pasamos el body capturado por el parser canónico del Pulpo.
+    //    Si la causa raíz del bug se reactivara, el body llegaría sin LF
+    //    reales y el parser devolvería `null`.
+    const { parseDependencyComment } = require('../lib/dep-comment-parser');
+    const deps = parseDependencyComment(
+        [{ body: stdinCaptured, createdAt: new Date().toISOString() }],
+        3253,
+    );
+
+    // 5. El parser debe detectar correctamente AMBAS dependencias.
+    assert.ok(Array.isArray(deps), `parser debe devolver array, recibió: ${deps}`);
+    assert.deepEqual(deps.sort(), [3257, 3260].sort(),
+        'parser debe detectar las dos dependencias #3257 y #3260');
+});
+
+test('CA-6 #3303: regresión cerrada — body con \\n literales (bug previo) NO matchea el parser', () => {
+    // Test de control: si alguien reintroduce el bug (body con `\n` literales
+    // en lugar de LF reales), `parseDependencyComment` debe devolver `null`.
+    // Este test documenta el comportamiento fail-closed del parser y demuestra
+    // que el fix de #3303 (LF reales preservados) es el que habilita la
+    // detección — no un cambio en el parser.
+    const bodyBuggy = '## Dependencias detectadas por el pipeline\\n\\n- #3257\\n\\nEste issue queda bloqueado...';
+
+    const { parseDependencyComment } = require('../lib/dep-comment-parser');
+    const deps = parseDependencyComment(
+        [{ body: bodyBuggy, createdAt: new Date().toISOString() }],
+        3253,
+    );
+
+    // Con `\n` literales (no LF reales), el body es UNA sola línea — el
+    // heading nunca matchea como heading aislado y el parser devuelve null.
+    assert.equal(deps, null,
+        'body con \\\\n literales debe devolver null (fail-closed) — corolario del bug previo');
+});

--- a/.pipeline/servicio-github.js
+++ b/.pipeline/servicio-github.js
@@ -13,7 +13,13 @@
 // producción (el `defaultGhClient` envuelve los `execSync` 1:1).
 // =============================================================================
 
-const { execSync, spawn } = require('child_process');
+// #3303 — Usamos `cp.execFileSync` en lugar de `execSync` con interpolación
+// de string al shell, lo que elimina dependencia de cmd.exe / sh. Mantenemos
+// `spawn` destructured porque lo usa `fireOnComplete` con detached:true (no
+// pasa por shell). `cp` se referencia por módulo para permitir monkey-patch
+// desde los tests (#3303 CA-5).
+const cp = require('child_process');
+const { spawn } = cp;
 const fs = require('fs');
 const path = require('path');
 // #2334: sanitización write-time.
@@ -57,20 +63,36 @@ function listWorkFiles(dir) {
   } catch { return []; }
 }
 
-// --- Escape para shell ---
-function esc(str) {
-  return (str || '')
-    .replace(/\\/g, '\\\\')
-    .replace(/"/g, '\\"')
-    .replace(/\n/g, '\\n')
-    .replace(/\r/g, '');
-}
+// =============================================================================
+// #3303 — `esc()` quedó deprecated y se removió. Era el helper de escapeo
+// para interpolación shell de `execSync(`...${esc(body)}...`)`. Convertía
+// `\n` real a la secuencia literal `\\n` para no romper el quoting de cmd.exe.
+// Efecto colateral: el body posteado a GitHub llegaba con `\n` LITERALES en
+// lugar de saltos de línea reales, y el detector de dependencias del Pulpo
+// (`parseDependencyComment`) no matcheaba el heading porque el comentario
+// quedaba en una sola línea — incidente #3253 (2026-05-17).
+//
+// Reemplazo: `cp.execFileSync(GH_BIN, argv, { input, ... })`. Argv array NO
+// pasa por shell en Windows (CreateProcess directo) ni en Unix (execve), así
+// que no requiere escapeo. Body multilínea se pasa por stdin con
+// `--body-file -`, que es la API soportada por `gh` (validada en gh 2.86.0).
+//
+// Por qué NO se mantiene `esc()` como utilidad opcional:
+//   - No queda ningún caller en este archivo que pase argumentos por shell.
+//   - Si en el futuro un caller necesita shell escape, el patrón canónico
+//     es agregar el caso específico con `cp.execFileSync` + argv y NO
+//     reintroducir el shell. Mantener un helper "por si acaso" reabre el
+//     vector que cerramos.
+//   - Cualquier reintroducción de `execSync` o de `esc()` para body/title
+//     en este archivo debe ser bloqueada en review — el bug es estructural,
+//     no un escape mal escrito.
+// =============================================================================
 
 // =============================================================================
-// #3025 — defaultGhClient: cliente real que envuelve `execSync` 1:1 al binario
-// `gh`. La forma de cada método es la API estable que consume `processQueue`,
-// `refreshLabelCache` y `ensureLabels`. Tests inyectan un mock JS puro con la
-// misma forma; no hay diferencia funcional para producción.
+// #3025 — defaultGhClient: cliente real que envuelve `cp.execFileSync` al
+// binario `gh`. La forma de cada método es la API estable que consume
+// `processQueue`, `refreshLabelCache` y `ensureLabels`. Tests inyectan un
+// mock JS puro con la misma forma; no hay diferencia funcional para producción.
 //
 // Salvaguardas preservadas:
 //   - `GH_BIN_OVERRIDE` sigue resolviendo el binario (futuros smoke tests E2E
@@ -81,33 +103,42 @@ function esc(str) {
 //   - `sanitizeGithubPayload(data)` se sigue invocando ANTES del client en el
 //     call site del worker (no se mueve dentro del client) — defensa explícita
 //     para que cualquier caller del client tenga que sanitizar primero.
+//
+// #3303 — Refactor a `cp.execFileSync` con argv array:
+//   - `commentIssue` y `createIssue` envían el body por stdin con
+//     `--body-file -` (preserva newlines reales, soporta cualquier UTF-8).
+//   - Resto de métodos (`editIssue`, `listLabels`, `createLabel`) pasan args
+//     en argv array — sin shell, sin escape, sin expansión de `%var%`.
 // =============================================================================
 const defaultGhClient = {
   editIssue(issueNumber, { addLabel, removeLabel } = {}) {
     if (addLabel) {
-      execSync(`"${GH_BIN}" issue edit ${issueNumber} --add-label "${esc(addLabel)}"`, {
+      cp.execFileSync(GH_BIN, ['issue', 'edit', String(issueNumber), '--add-label', String(addLabel)], {
         cwd: ROOT, encoding: 'utf8', timeout: 15000, windowsHide: true,
       });
     }
     if (removeLabel) {
-      execSync(`"${GH_BIN}" issue edit ${issueNumber} --remove-label "${esc(removeLabel)}"`, {
+      cp.execFileSync(GH_BIN, ['issue', 'edit', String(issueNumber), '--remove-label', String(removeLabel)], {
         cwd: ROOT, encoding: 'utf8', timeout: 15000, windowsHide: true,
       });
     }
   },
 
   commentIssue(issueNumber, body) {
-    execSync(`"${GH_BIN}" issue comment ${issueNumber} -b "${esc(body)}"`, {
-      cwd: ROOT, encoding: 'utf8', timeout: 15000, windowsHide: true,
+    cp.execFileSync(GH_BIN, ['issue', 'comment', String(issueNumber), '--body-file', '-'], {
+      cwd: ROOT, encoding: 'utf8', input: body == null ? '' : String(body),
+      timeout: 15000, windowsHide: true,
     });
   },
 
   createIssue({ title, body, labels, repo } = {}) {
     const targetRepo = repo || DEFAULT_REPO;
-    const output = execSync(
-      `"${GH_BIN}" issue create --title "${esc(title)}" --body "${esc(body)}" --label "${esc(labels)}" --repo ${targetRepo}`,
-      { cwd: ROOT, encoding: 'utf8', timeout: 20000, windowsHide: true },
-    ).trim();
+    const args = ['issue', 'create', '--title', String(title || ''), '--body-file', '-', '--repo', targetRepo];
+    if (labels) args.push('--label', String(labels));
+    const output = cp.execFileSync(GH_BIN, args, {
+      cwd: ROOT, encoding: 'utf8', input: body == null ? '' : String(body),
+      timeout: 20000, windowsHide: true,
+    }).trim();
     const urlMatch = output.match(/\/(\d+)\s*$/);
     return {
       number: urlMatch ? parseInt(urlMatch[1], 10) : null,
@@ -118,8 +149,9 @@ const defaultGhClient = {
   listLabels({ repo, limit } = {}) {
     const targetRepo = repo || DEFAULT_REPO;
     const targetLimit = limit || 200;
-    const raw = execSync(
-      `"${GH_BIN}" label list --json name --limit ${targetLimit} --repo ${targetRepo}`,
+    const raw = cp.execFileSync(
+      GH_BIN,
+      ['label', 'list', '--json', 'name', '--limit', String(targetLimit), '--repo', targetRepo],
       { cwd: ROOT, encoding: 'utf8', timeout: 15000, windowsHide: true },
     );
     return JSON.parse(raw || '[]');
@@ -128,8 +160,9 @@ const defaultGhClient = {
   createLabel(name, color, { repo } = {}) {
     const targetRepo = repo || DEFAULT_REPO;
     try {
-      execSync(
-        `"${GH_BIN}" label create "${esc(name)}" --color "${color}" --repo ${targetRepo}`,
+      cp.execFileSync(
+        GH_BIN,
+        ['label', 'create', String(name), '--color', String(color), '--repo', targetRepo],
         { cwd: ROOT, encoding: 'utf8', timeout: 10000, windowsHide: true },
       );
       return { created: true, alreadyExists: false };


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 2 archivos · +371 -25

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:skipped` aplicado por delivery

## Closes

Closes #3303
