### PR TITLE
feat(pipeline): unificar credenciales en credentials.json + cargador (#3311)

### DIFF
--- a/.pipeline/lib/__tests__/credentials.test.js
+++ b/.pipeline/lib/__tests__/credentials.test.js
@@ -1,0 +1,270 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { test } = require('node:test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  loadIntoEnv,
+  ENV_MAPPING,
+  LEGACY_MAPPING,
+  isPlaceholderOrEmpty,
+} = require('../credentials');
+
+// Set total de env vars que el cargador toca. Snapshot para no contaminar
+// otros tests que corran en el mismo proceso.
+const ALL_ENV_VARS = [...new Set([
+  ...Object.values(ENV_MAPPING),
+  ...Object.values(LEGACY_MAPPING),
+])];
+
+function withCleanEnv(fn) {
+  const snapshot = {};
+  for (const v of ALL_ENV_VARS) {
+    snapshot[v] = process.env[v];
+    delete process.env[v];
+  }
+  try { return fn(); }
+  finally {
+    for (const v of ALL_ENV_VARS) {
+      if (snapshot[v] === undefined) delete process.env[v];
+      else process.env[v] = snapshot[v];
+    }
+  }
+}
+
+function withTmpFiles(fn) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'credentials-test-'));
+  const canonical = path.join(dir, 'credentials.json');
+  const legacy = path.join(dir, 'telegram-config.json');
+  try { return fn({ dir, canonical, legacy }); }
+  finally { fs.rmSync(dir, { recursive: true, force: true }); }
+}
+
+function writeJson(p, obj) {
+  fs.writeFileSync(p, JSON.stringify(obj, null, 2), 'utf8');
+}
+
+// ─── canonical: happy path ──────────────────────────────────────────────────
+
+test('loadIntoEnv hidrata todas las vars desde credentials.json canonical', () => {
+  withCleanEnv(() => {
+    withTmpFiles(({ canonical, legacy }) => {
+      writeJson(canonical, {
+        telegram: { bot_token: '12345:botoken-test', chat_id: '99999' },
+        providers: {
+          openai:   { api_key: 'sk-proj-openai-test' },
+          google:   { api_key: 'AIza-gemini-test' },
+          groq:     { api_key: 'gsk_groq-test' },
+          cerebras: { api_key: 'csk-cerebras-test' },
+          nvidia:   { api_key: 'nvapi-nvidia-test' },
+        },
+        multimedia: {
+          elevenlabs_api_key:  'eleven-key-test',
+          elevenlabs_voice_id: 'voice-id-test',
+        },
+      });
+
+      const env = {};
+      const result = loadIntoEnv({ canonicalPath: canonical, legacyPath: legacy, env, logger: () => {} });
+
+      assert.equal(result.source, 'canonical');
+      assert.equal(env.TELEGRAM_BOT_TOKEN, '12345:botoken-test');
+      assert.equal(env.TELEGRAM_CHAT_ID, '99999');
+      assert.equal(env.OPENAI_API_KEY, 'sk-proj-openai-test');
+      assert.equal(env.GEMINI_API_KEY, 'AIza-gemini-test');
+      assert.equal(env.GROQ_API_KEY, 'gsk_groq-test');
+      assert.equal(env.CEREBRAS_API_KEY, 'csk-cerebras-test');
+      assert.equal(env.NVIDIA_NIM_API_KEY, 'nvapi-nvidia-test');
+      assert.equal(env.ELEVENLABS_API_KEY, 'eleven-key-test');
+      assert.equal(env.ELEVENLABS_VOICE_ID, 'voice-id-test');
+      assert.ok(result.hydrated.includes('GROQ_API_KEY'));
+      assert.deepEqual(result.skipped_existing, []);
+    });
+  });
+});
+
+// ─── precedencia env > JSON ─────────────────────────────────────────────────
+
+test('NO sobrescribe env vars que ya estan seteadas (precedencia env > JSON)', () => {
+  withCleanEnv(() => {
+    withTmpFiles(({ canonical, legacy }) => {
+      writeJson(canonical, {
+        providers: { groq: { api_key: 'gsk_from-json' } },
+      });
+      const env = { GROQ_API_KEY: 'gsk_already-set-from-env' };
+      const result = loadIntoEnv({ canonicalPath: canonical, legacyPath: legacy, env, logger: () => {} });
+
+      assert.equal(env.GROQ_API_KEY, 'gsk_already-set-from-env');
+      assert.ok(result.skipped_existing.includes('GROQ_API_KEY'));
+      assert.ok(!result.hydrated.includes('GROQ_API_KEY'));
+    });
+  });
+});
+
+// ─── placeholders y empty ───────────────────────────────────────────────────
+
+test('skipea placeholders conocidos (REVOKED, PLACEHOLDER, MOVED, ...)', () => {
+  withCleanEnv(() => {
+    withTmpFiles(({ canonical, legacy }) => {
+      writeJson(canonical, {
+        telegram: { bot_token: 'MOVED_TO_HOME', chat_id: '' },
+        providers: {
+          openai: { api_key: 'CHANGE_ME' },
+          groq:   { api_key: 'gsk_real-value' },
+        },
+      });
+      const env = {};
+      const result = loadIntoEnv({ canonicalPath: canonical, legacyPath: legacy, env, logger: () => {} });
+
+      assert.equal(env.GROQ_API_KEY, 'gsk_real-value');
+      assert.equal(env.TELEGRAM_BOT_TOKEN, undefined);
+      assert.equal(env.TELEGRAM_CHAT_ID, undefined);
+      assert.equal(env.OPENAI_API_KEY, undefined);
+      assert.ok(result.skipped_empty.includes('TELEGRAM_BOT_TOKEN'));
+      assert.ok(result.skipped_empty.includes('OPENAI_API_KEY'));
+    });
+  });
+});
+
+test('isPlaceholderOrEmpty cubre null/undefined/empty/whitespace/placeholder', () => {
+  assert.equal(isPlaceholderOrEmpty(null), true);
+  assert.equal(isPlaceholderOrEmpty(undefined), true);
+  assert.equal(isPlaceholderOrEmpty(''), true);
+  assert.equal(isPlaceholderOrEmpty('   '), true);
+  assert.equal(isPlaceholderOrEmpty('PLACEHOLDER'), true);
+  assert.equal(isPlaceholderOrEmpty('REVOKED'), true);
+  assert.equal(isPlaceholderOrEmpty('MOVED_TO_HOME'), true);
+  assert.equal(isPlaceholderOrEmpty('change_me'), true);
+  assert.equal(isPlaceholderOrEmpty('sk-proj-real-key-123'), false);
+  assert.equal(isPlaceholderOrEmpty('gsk_real'), false);
+});
+
+// ─── fallback al legacy ─────────────────────────────────────────────────────
+
+test('cuando canonical no existe, hace fallback al legacy con flat keys', () => {
+  withCleanEnv(() => {
+    withTmpFiles(({ canonical, legacy }) => {
+      // canonical NO existe
+      writeJson(legacy, {
+        bot_token: '12345:legacy-token',
+        chat_id: '88888',
+        groq_api_key: 'gsk_from-legacy',
+        openai_api_key: 'sk-proj-legacy',
+      });
+      const env = {};
+      const warnings = [];
+      const result = loadIntoEnv({
+        canonicalPath: canonical,
+        legacyPath: legacy,
+        env,
+        logger: (m) => warnings.push(m),
+      });
+
+      assert.equal(result.source, 'legacy');
+      assert.equal(env.TELEGRAM_BOT_TOKEN, '12345:legacy-token');
+      assert.equal(env.TELEGRAM_CHAT_ID, '88888');
+      assert.equal(env.GROQ_API_KEY, 'gsk_from-legacy');
+      assert.equal(env.OPENAI_API_KEY, 'sk-proj-legacy');
+      assert.ok(warnings.some((m) => /legacy/i.test(m)),
+        'debe emitir warning indicando que usa legacy');
+    });
+  });
+});
+
+test('legacy NO carga providers nuevos (groq/google/cerebras/nvidia se acaban si solo hay legacy)', () => {
+  withCleanEnv(() => {
+    withTmpFiles(({ canonical, legacy }) => {
+      writeJson(legacy, {
+        bot_token: '12345:t',
+        chat_id: '1',
+        // legacy NO conoce el field "google_api_key" ni "cerebras_api_key"
+      });
+      const env = {};
+      const result = loadIntoEnv({ canonicalPath: canonical, legacyPath: legacy, env, logger: () => {} });
+
+      assert.equal(result.source, 'legacy');
+      assert.equal(env.GEMINI_API_KEY, undefined);
+      assert.equal(env.CEREBRAS_API_KEY, undefined);
+      assert.equal(env.NVIDIA_NIM_API_KEY, undefined);
+    });
+  });
+});
+
+// ─── archivo corrupto ───────────────────────────────────────────────────────
+
+test('canonical corrupto cae al legacy con warning', () => {
+  withCleanEnv(() => {
+    withTmpFiles(({ canonical, legacy }) => {
+      fs.writeFileSync(canonical, '{ this is not valid json', 'utf8');
+      writeJson(legacy, { groq_api_key: 'gsk_from-legacy-after-corrupt' });
+
+      const env = {};
+      const warnings = [];
+      const result = loadIntoEnv({
+        canonicalPath: canonical,
+        legacyPath: legacy,
+        env,
+        logger: (m) => warnings.push(m),
+      });
+
+      assert.equal(result.source, 'legacy');
+      assert.equal(env.GROQ_API_KEY, 'gsk_from-legacy-after-corrupt');
+      assert.ok(warnings.some((m) => /invalido/i.test(m)));
+    });
+  });
+});
+
+test('si ambos archivos faltan, source=none y NO lanza', () => {
+  withCleanEnv(() => {
+    withTmpFiles(({ canonical, legacy }) => {
+      const env = {};
+      const warnings = [];
+      const result = loadIntoEnv({
+        canonicalPath: canonical,
+        legacyPath: legacy,
+        env,
+        logger: (m) => warnings.push(m),
+      });
+
+      assert.equal(result.source, 'none');
+      assert.equal(result.hydrated.length, 0);
+      assert.ok(warnings.some((m) => /no se encontro/i.test(m)));
+    });
+  });
+});
+
+// ─── chat_id numerico ───────────────────────────────────────────────────────
+
+test('chat_id numerico se convierte a string', () => {
+  withCleanEnv(() => {
+    withTmpFiles(({ canonical, legacy }) => {
+      writeJson(canonical, {
+        telegram: { bot_token: 'tok', chat_id: 12345 },
+      });
+      const env = {};
+      loadIntoEnv({ canonicalPath: canonical, legacyPath: legacy, env, logger: () => {} });
+
+      assert.equal(env.TELEGRAM_CHAT_ID, '12345');
+      assert.equal(typeof env.TELEGRAM_CHAT_ID, 'string');
+    });
+  });
+});
+
+// ─── mapping coverage ───────────────────────────────────────────────────────
+
+test('ENV_MAPPING cubre los 5 providers IA + telegram + multimedia', () => {
+  const values = new Set(Object.values(ENV_MAPPING));
+  assert.ok(values.has('TELEGRAM_BOT_TOKEN'));
+  assert.ok(values.has('TELEGRAM_CHAT_ID'));
+  assert.ok(values.has('OPENAI_API_KEY'));
+  assert.ok(values.has('ANTHROPIC_API_KEY'));
+  assert.ok(values.has('GEMINI_API_KEY'));
+  assert.ok(values.has('GROQ_API_KEY'));
+  assert.ok(values.has('CEREBRAS_API_KEY'));
+  assert.ok(values.has('NVIDIA_NIM_API_KEY'));
+  assert.ok(values.has('ELEVENLABS_API_KEY'));
+  assert.ok(values.has('ELEVENLABS_VOICE_ID'));
+});

--- a/.pipeline/lib/credentials.js
+++ b/.pipeline/lib/credentials.js
@@ -1,0 +1,172 @@
+// =============================================================================
+// credentials.js — Cargador unificado de credenciales (#3311)
+//
+// Fuente única de verdad: ~/.claude/secrets/credentials.json
+// Lee el archivo al boot del Pulpo/restart.js y popula process.env para que
+// `validateCredentialsEnvPresence` (agent-models-validate.js) encuentre las
+// credenciales sin que el operador tenga que setear setx manualmente por cada
+// provider.
+//
+// Estructura esperada del JSON:
+//   {
+//     "telegram":   { "bot_token": "...", "chat_id": "..." },
+//     "providers":  { "groq": {"api_key": "..."}, "google": {...}, ... },
+//     "multimedia": { "elevenlabs_api_key": "...", "elevenlabs_voice_id": "..." }
+//   }
+//
+// Precedencia (alineada con loadApiKeys de telegram-secrets.js):
+//   1. process.env ya seteado → respetar, no sobrescribir
+//   2. credentials.json (canonical)
+//   3. telegram-config.json (legacy, fallback con warning)
+// =============================================================================
+
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const CANONICAL_PATH = path.join(os.homedir(), '.claude', 'secrets', 'credentials.json');
+const LEGACY_PATH = path.join(os.homedir(), '.claude', 'secrets', 'telegram-config.json');
+
+// Mapeo canónico: dot-path en credentials.json → env var que esperan los CLIs.
+// Mantener ordenado por categoría para facilitar el code-review.
+const ENV_MAPPING = Object.freeze({
+  // Telegram bot
+  'telegram.bot_token':            'TELEGRAM_BOT_TOKEN',
+  'telegram.chat_id':              'TELEGRAM_CHAT_ID',
+  // Providers IA (allowlist en agent-models-validate.js:ALLOWED_CREDENTIAL_ENV_VARS)
+  'providers.openai.api_key':      'OPENAI_API_KEY',
+  'providers.anthropic.api_key':   'ANTHROPIC_API_KEY',
+  'providers.google.api_key':      'GEMINI_API_KEY',
+  'providers.groq.api_key':        'GROQ_API_KEY',
+  'providers.cerebras.api_key':    'CEREBRAS_API_KEY',
+  'providers.nvidia.api_key':      'NVIDIA_NIM_API_KEY',
+  // Multimedia (TTS/STT/Vision)
+  'multimedia.elevenlabs_api_key':  'ELEVENLABS_API_KEY',
+  'multimedia.elevenlabs_voice_id': 'ELEVENLABS_VOICE_ID',
+});
+
+// Mapeo legacy: telegram-config.json usa flat keys (no nested). Solo cubre las
+// que existían en ese formato — providers nuevos (groq/google/cerebras/nvidia)
+// no se cargan del legacy porque no existían cuando ese archivo era canónico.
+const LEGACY_MAPPING = Object.freeze({
+  'bot_token':           'TELEGRAM_BOT_TOKEN',
+  'chat_id':             'TELEGRAM_CHAT_ID',
+  'openai_api_key':      'OPENAI_API_KEY',
+  'anthropic_api_key':   'ANTHROPIC_API_KEY',
+  'groq_api_key':        'GROQ_API_KEY',
+  'elevenlabs_api_key':  'ELEVENLABS_API_KEY',
+  'elevenlabs_voice_id': 'ELEVENLABS_VOICE_ID',
+});
+
+const PLACEHOLDER_RE = /(REVOKED|PLACEHOLDER|MOVED|EXAMPLE|REPLACE|CHANGE_ME)/i;
+
+function isPlaceholderOrEmpty(value) {
+  if (value === null || value === undefined) return true;
+  const s = String(value);
+  if (s.trim().length === 0) return true;
+  return PLACEHOLDER_RE.test(s);
+}
+
+function getNested(obj, dotPath) {
+  return dotPath.split('.').reduce(
+    (acc, k) => (acc && typeof acc === 'object') ? acc[k] : undefined,
+    obj
+  );
+}
+
+function readJsonFile(filePath) {
+  const raw = fs.readFileSync(filePath, 'utf8');
+  return JSON.parse(raw);
+}
+
+/**
+ * Lee credentials.json y popula `env` con las credenciales mapeadas.
+ *
+ * @param {object} [opts]
+ * @param {function} [opts.logger=console.log] Logger para warnings/errors.
+ * @param {string}   [opts.canonicalPath]      Path del archivo canónico (override para tests).
+ * @param {string}   [opts.legacyPath]         Path del archivo legacy (override para tests).
+ * @param {object}   [opts.env=process.env]    Env target (override para tests).
+ * @returns {{source: 'canonical'|'legacy'|'none', hydrated: string[], skipped_existing: string[], skipped_empty: string[]}}
+ */
+function loadIntoEnv(opts = {}) {
+  const logger = typeof opts.logger === 'function' ? opts.logger : console.log;
+  const canonicalPath = opts.canonicalPath || CANONICAL_PATH;
+  const legacyPath = opts.legacyPath || LEGACY_PATH;
+  const env = opts.env || process.env;
+
+  const result = { source: 'none', hydrated: [], skipped_existing: [], skipped_empty: [] };
+
+  let data = null;
+  let usingMapping = null;
+
+  if (fs.existsSync(canonicalPath)) {
+    try {
+      data = readJsonFile(canonicalPath);
+      result.source = 'canonical';
+      usingMapping = ENV_MAPPING;
+    } catch (e) {
+      logger(`[credentials] WARN: ${canonicalPath} es JSON invalido (${e.message}); intentando fallback al legacy`);
+    }
+  }
+
+  if (!data && fs.existsSync(legacyPath)) {
+    try {
+      data = readJsonFile(legacyPath);
+      result.source = 'legacy';
+      usingMapping = LEGACY_MAPPING;
+      logger(`[credentials] WARN: usando archivo legacy ${legacyPath}. Migrar a ${canonicalPath} (ver docs/runbooks/credential-rotation.md)`);
+    } catch (e) {
+      logger(`[credentials] ERROR: legacy ${legacyPath} es JSON invalido (${e.message}); process.env queda como esta`);
+      return result;
+    }
+  }
+
+  if (!data) {
+    logger(`[credentials] WARN: no se encontro ${canonicalPath} ni ${legacyPath}; process.env queda como esta`);
+    return result;
+  }
+
+  for (const [sourceKey, envVar] of Object.entries(usingMapping)) {
+    if (env[envVar] && String(env[envVar]).length > 0) {
+      result.skipped_existing.push(envVar);
+      continue;
+    }
+    const raw = (usingMapping === ENV_MAPPING)
+      ? getNested(data, sourceKey)
+      : data[sourceKey];
+    if (isPlaceholderOrEmpty(raw)) {
+      result.skipped_empty.push(envVar);
+      continue;
+    }
+    env[envVar] = String(raw);
+    result.hydrated.push(envVar);
+  }
+
+  return result;
+}
+
+module.exports = {
+  loadIntoEnv,
+  CANONICAL_PATH,
+  LEGACY_PATH,
+  ENV_MAPPING,
+  LEGACY_MAPPING,
+  isPlaceholderOrEmpty,
+  getNested,
+};
+
+// CLI: dry-run que imprime resumen sin valores. Útil para diagnóstico operativo.
+//   node .pipeline/lib/credentials.js
+if (require.main === module) {
+  const result = loadIntoEnv({ logger: (m) => process.stderr.write(m + '\n') });
+  process.stdout.write(JSON.stringify({
+    source: result.source,
+    hydrated_count: result.hydrated.length,
+    hydrated: result.hydrated,
+    skipped_existing: result.skipped_existing,
+    skipped_empty: result.skipped_empty,
+  }, null, 2) + '\n');
+}

--- a/.pipeline/lib/telegram-secrets.js
+++ b/.pipeline/lib/telegram-secrets.js
@@ -2,17 +2,17 @@
 // telegram-secrets.js — fuente unica de credenciales del bot Telegram + claves
 // API (OpenAI, Anthropic, ElevenLabs) usadas por TTS/STT/Vision en multimedia.
 //
-// Prioridad de carga:
+// Prioridad de carga (#3311 - credentials unificadas):
 //   1) ENV: TELEGRAM_BOT_TOKEN + TELEGRAM_CHAT_ID  (+ OPENAI_API_KEY etc.)
-//   2) ~/.claude/secrets/telegram-config.json   (FUERA del repo, recomendado)
-//   3) <repo>/.claude/hooks/telegram-config.json (legacy, fallback con warning)
+//   2) ~/.claude/secrets/credentials.json   (CANONICAL, nested - estructura unificada)
+//   3) ~/.claude/secrets/telegram-config.json   (home legacy, flat keys, fallback)
+//   4) <repo>/.claude/hooks/telegram-config.json (legacy committed, fallback con warning)
 //
-// El path (2) es inmune a checkouts/pulls del repo y nunca se sube a github
-// porque vive en el home del usuario. Es la ubicacion oficial post-intrusion.
-//
-// loadTelegramSecrets()  -> {bot_token, chat_id, source}        (criticos, throw si faltan)
-// loadApiKeys()          -> {openai_api_key, anthropic_api_key,
-//                           elevenlabs_api_key, elevenlabs_voice_id}  (best-effort, vacio si falta)
+// La API publica (loadTelegramSecrets / loadApiKeys) NO cambia para preservar
+// backward-compat con los 6 consumidores actuales (multimedia.js, pulpo.js,
+// listener-telegram.js, servicio-telegram.js, rejection-report.js,
+// hydrate-provider-env.js). El cargador alternativo
+// `.pipeline/lib/credentials.js#loadIntoEnv()` cubre el path Pulpo multi-provider.
 // =============================================================================
 
 'use strict';
@@ -21,6 +21,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
+const CANONICAL_SECRETS = path.join(os.homedir(), '.claude', 'secrets', 'credentials.json');
 const HOME_SECRETS = path.join(os.homedir(), '.claude', 'secrets', 'telegram-config.json');
 
 function tryRead(file) {
@@ -47,6 +48,9 @@ function pickKey(value) {
 /**
  * Devuelve { bot_token, chat_id, source }.
  * Lanza Error si no encuentra credenciales validas en ninguna fuente.
+ *
+ * Prioridad (#3311):
+ *   env > credentials.json (canonical, nested) > telegram-config.json home (flat) > legacy committed
  */
 function loadTelegramSecrets({ legacyConfigPath, log } = {}) {
     const logger = typeof log === 'function' ? log : () => {};
@@ -60,22 +64,35 @@ function loadTelegramSecrets({ legacyConfigPath, log } = {}) {
         };
     }
 
-    // 2) Home secrets (oficial)
+    // 2) Canonical credentials.json (#3311 - estructura nested unificada)
+    const canonical = tryRead(CANONICAL_SECRETS);
+    if (canonical && canonical.telegram
+        && isLikelyToken(canonical.telegram.bot_token)
+        && canonical.telegram.chat_id) {
+        return {
+            bot_token: canonical.telegram.bot_token,
+            chat_id: String(canonical.telegram.chat_id),
+            source: 'canonical',
+        };
+    }
+
+    // 3) Home telegram-config.json (legacy flat, fallback durante transicion)
     const home = tryRead(HOME_SECRETS);
     if (home && isLikelyToken(home.bot_token) && home.chat_id) {
+        logger(`[secrets] WARNING: bot_token leido de ${HOME_SECRETS} (legacy). Migrar a ${CANONICAL_SECRETS} con estructura nested (#3311).`);
         return { bot_token: home.bot_token, chat_id: String(home.chat_id), source: 'home' };
     }
 
-    // 3) Legacy fallback
+    // 4) Legacy committed fallback
     if (legacyConfigPath) {
         const legacy = tryRead(legacyConfigPath);
         if (legacy && isLikelyToken(legacy.bot_token) && !looksLikePlaceholder(legacy.bot_token)) {
-            logger(`[secrets] WARNING: bot_token leido del archivo committed (${legacyConfigPath}). Mover a ${HOME_SECRETS}.`);
+            logger(`[secrets] WARNING: bot_token leido del archivo committed (${legacyConfigPath}). Mover a ${CANONICAL_SECRETS}.`);
             return { bot_token: legacy.bot_token, chat_id: String(legacy.chat_id), source: 'legacy' };
         }
     }
 
-    const err = new Error(`No se encontraron credenciales Telegram. Crear ${HOME_SECRETS} con {bot_token, chat_id} o setear ENV TELEGRAM_BOT_TOKEN+TELEGRAM_CHAT_ID.`);
+    const err = new Error(`No se encontraron credenciales Telegram. Crear ${CANONICAL_SECRETS} con {telegram:{bot_token, chat_id}} (preferido) o setear ENV TELEGRAM_BOT_TOKEN+TELEGRAM_CHAT_ID.`);
     err.code = 'TELEGRAM_SECRETS_MISSING';
     throw err;
 }
@@ -83,32 +100,44 @@ function loadTelegramSecrets({ legacyConfigPath, log } = {}) {
 /**
  * Devuelve las API keys de proveedores externos (TTS/STT/Vision).
  * Best-effort: nunca lanza, retorna strings vacios para keys faltantes.
- * Prioridad por key: ENV → home secrets → legacy committed config.
+ *
+ * Prioridad por key (#3311):
+ *   ENV > credentials.json canonical (nested) > telegram-config.json home (flat) > legacy committed
+ *
  * El consumidor decide que hacer cuando una key viene vacia (multimedia
  * loggea "falta openai_api_key" y degrada).
  */
 function loadApiKeys({ legacyConfigPath } = {}) {
+    const canonical = tryRead(CANONICAL_SECRETS) || {};
     const home = tryRead(HOME_SECRETS) || {};
     const legacy = legacyConfigPath ? (tryRead(legacyConfigPath) || {}) : {};
+
+    // Helpers para acceso seguro a la estructura nested del canonical.
+    const canonProv = (canonical.providers && typeof canonical.providers === 'object') ? canonical.providers : {};
+    const canonMM = (canonical.multimedia && typeof canonical.multimedia === 'object') ? canonical.multimedia : {};
 
     return {
         openai_api_key:
             pickKey(process.env.OPENAI_API_KEY) ||
+            pickKey(canonProv.openai && canonProv.openai.api_key) ||
             pickKey(home.openai_api_key) ||
             pickKey(legacy.openai_api_key),
         anthropic_api_key:
             pickKey(process.env.ANTHROPIC_API_KEY) ||
+            pickKey(canonProv.anthropic && canonProv.anthropic.api_key) ||
             pickKey(home.anthropic_api_key) ||
             pickKey(legacy.anthropic_api_key),
         elevenlabs_api_key:
             pickKey(process.env.ELEVENLABS_API_KEY) ||
+            pickKey(canonMM.elevenlabs_api_key) ||
             pickKey(home.elevenlabs_api_key) ||
             pickKey(legacy.elevenlabs_api_key),
         elevenlabs_voice_id:
             pickKey(process.env.ELEVENLABS_VOICE_ID) ||
+            pickKey(canonMM.elevenlabs_voice_id) ||
             pickKey(home.elevenlabs_voice_id) ||
             pickKey(legacy.elevenlabs_voice_id),
     };
 }
 
-module.exports = { loadTelegramSecrets, loadApiKeys, HOME_SECRETS };
+module.exports = { loadTelegramSecrets, loadApiKeys, HOME_SECRETS, CANONICAL_SECRETS };

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -10,6 +10,15 @@ const os = require('os');
 const { execSync, spawn, execFile } = require('child_process');
 const { promisify } = require('util');
 const execFileAsync = promisify(execFile);
+
+// #3311 — Hidratar process.env desde ~/.claude/secrets/credentials.json antes
+// de cualquier require que pueda leer credenciales (telegram-secrets,
+// validateOrExit con checkEnv, etc). El cargador degrada silenciosamente si
+// el archivo no existe; sólo loggea warnings al stderr en casos anómalos.
+require('./lib/credentials').loadIntoEnv({
+  logger: (m) => process.stderr.write(m + '\n'),
+});
+
 const yaml = require('js-yaml');
 const dedupLib = require('./dedup-lib');
 const precheck = require('./connectivity-precheck');

--- a/.pipeline/restart.js
+++ b/.pipeline/restart.js
@@ -32,6 +32,16 @@ require('./lib/java-home-normalizer').normalizeJavaHome({
   log: (msg) => console.error(msg),
 });
 
+// #3311 — Hidratar process.env desde ~/.claude/secrets/credentials.json antes
+// de spawnear los hijos del pipeline (pulpo, listener, svc-*). Los procesos
+// hijo heredan el env del padre, así que con una sola invocación acá todos
+// los componentes reciben las API keys de providers + tokens Telegram sin que
+// el operador tenga que setear setx manualmente. Degradación silenciosa si
+// el archivo no existe.
+require('./lib/credentials').loadIntoEnv({
+  logger: (m) => console.error(m),
+});
+
 const PIPELINE = path.resolve(__dirname);
 const ROOT = path.resolve(PIPELINE, '..');
 

--- a/docs/runbooks/credential-rotation.md
+++ b/docs/runbooks/credential-rotation.md
@@ -4,6 +4,60 @@
 > los pasos están numerados, son cortos, y al final hay una checklist de
 > verificación + sección "si algo sale mal".
 
+## Ubicación canónica de credenciales (#3311)
+
+Desde #3311 todas las credenciales del proyecto viven en un **único archivo**:
+
+```
+~/.claude/secrets/credentials.json
+```
+
+**Estructura**:
+
+```json
+{
+  "_note": "...",
+  "_version": 1,
+  "telegram":  { "bot_token": "...", "chat_id": "..." },
+  "providers": {
+    "openai":   { "api_key": "..." },
+    "anthropic":{ "api_key": "..." },
+    "google":   { "api_key": "..." },
+    "groq":     { "api_key": "..." },
+    "cerebras": { "api_key": "..." },
+    "nvidia":   { "api_key": "..." }
+  },
+  "multimedia": {
+    "elevenlabs_api_key":  "...",
+    "elevenlabs_voice_id": "..."
+  }
+}
+```
+
+**Cómo se carga**: `.pipeline/lib/credentials.js#loadIntoEnv()` se invoca al
+boot de `pulpo.js` y `restart.js`, mapea cada path a su env var canónica
+(`providers.groq.api_key` → `GROQ_API_KEY`, etc.) y popula `process.env`.
+`telegram-secrets.js` también lee este archivo para sus consumidores legacy.
+
+**Precedencia**:
+1. `process.env` ya seteado (no se sobrescribe — `setx` sigue funcionando como override manual)
+2. `~/.claude/secrets/credentials.json` (canónico)
+3. `~/.claude/secrets/telegram-config.json` (legacy flat, fallback con warning)
+4. `<repo>/.claude/hooks/telegram-config.json` (legacy committed, último recurso)
+
+**Editar el archivo**: abrir con tu editor preferido y modificar el JSON.
+Después correr `node .pipeline/restart.js` para que el pipeline reinicie con
+las nuevas credenciales hidratadas.
+
+**Verificar qué se hidrata** (sin imprimir valores):
+
+```bash
+node .pipeline/lib/credentials.js
+```
+
+Devuelve `source` (canonical/legacy/none), `hydrated` (nombres de env vars
+hidratadas) y `skipped_*` (las que ya estaban en env o tenían placeholder).
+
 ## Contexto general
 
 - **Por qué rotar**: política `≤ 90 días` por convención (ver
@@ -16,20 +70,20 @@
 
 ## Anthropic
 
+> _Provider opcional — sólo aplica si activaste Vision multimedia directo
+> (no via CLI Claude). Sin `anthropic_api_key` en `credentials.json`, Vision
+> sigue funcionando via OAuth Max del CLI (ver `multimedia.js:213`)._
+
 1. Abrí <https://console.anthropic.com/settings/keys> con la cuenta que figura
    en `account_id` del inventario.
 2. Generá una **nueva key** (botón "Create Key"), nombrá con `intrale-pipeline-v3-YYYYMMDD`.
-3. Actualizá la env var del operador:
-   ```bash
-   # Linux/macOS — editá ~/.zshrc o ~/.bashrc
-   export ANTHROPIC_API_KEY="<nueva-key>"
-   # Windows — Panel de Control → Sistema → Variables de Entorno
-   #   o:  setx ANTHROPIC_API_KEY "<nueva-key>"
+3. Editá `~/.claude/secrets/credentials.json`:
+   ```json
+   { "providers": { "anthropic": { "api_key": "<nueva-key>" } } }
    ```
-   Cerrá y reabrí la terminal donde corre el pulpo (sin reiniciar la terminal,
-   `process.env` queda con el valor viejo).
 4. Revocá la **vieja** key desde la misma consola (botón "Revoke").
-5. Actualizá `last_rotated` en [`docs/secrets-inventory.md`](../secrets-inventory.md)
+5. `node .pipeline/restart.js` para que el pipeline recargue con la key nueva.
+6. Actualizá `last_rotated` en [`docs/secrets-inventory.md`](../secrets-inventory.md)
    con la fecha de hoy en formato ISO `YYYY-MM-DD`. Commiteá.
 
 ### Cómo verificar que rotaste bien (Anthropic)
@@ -51,13 +105,66 @@
 1. Abrí <https://platform.openai.com/api-keys> con la cuenta `account_id`.
 2. Generá una nueva key (botón "Create new secret key"), nombrá con
    `intrale-pipeline-v3-YYYYMMDD`. Limitá scope a `Codex` si corresponde.
-3. Actualizá la env var del operador:
-   ```bash
-   export OPENAI_API_KEY="<nueva-key>"
+3. Editá `~/.claude/secrets/credentials.json`:
+   ```json
+   { "providers": { "openai": { "api_key": "<nueva-key>" } } }
    ```
-   Cerrá y reabrí la terminal del pulpo.
 4. Revocá la vieja key desde la misma consola (botón "Revoke key").
-5. Actualizá `last_rotated` en `docs/secrets-inventory.md`. Commiteá.
+5. `node .pipeline/restart.js`.
+6. Actualizá `last_rotated` en `docs/secrets-inventory.md`. Commiteá.
+
+## Groq (free tier — multi-provider fallback)
+
+> _Free tier, regla `feedback_free-providers-rule`. Nunca pago._
+
+1. Abrí <https://console.groq.com> y andá a "API Keys".
+2. "Create API Key" — nombrá `intrale-pipeline-YYYYMMDD`. Copiar `gsk_...`
+   (se muestra una sola vez).
+3. Editá `~/.claude/secrets/credentials.json`:
+   ```json
+   { "providers": { "groq": { "api_key": "<nueva-key>" } } }
+   ```
+4. Revocá la vieja key en la misma página.
+5. `node .pipeline/restart.js`.
+
+## Gemini (Google AI Studio — free tier)
+
+1. Abrí <https://aistudio.google.com/apikey> con la cuenta GCP del proyecto.
+2. "Create API key" — asociar a un proyecto de Google Cloud existente o nuevo.
+3. Editá `~/.claude/secrets/credentials.json`:
+   ```json
+   { "providers": { "google": { "api_key": "<nueva-key>" } } }
+   ```
+4. Verificar que la **Generative Language API** esté habilitada en el proyecto
+   de GCP (sino tira 403 al primer request).
+5. Revocá la vieja key desde la consola.
+6. `node .pipeline/restart.js`.
+
+## Cerebras (free tier — multi-provider fallback)
+
+1. Abrí <https://cloud.cerebras.ai/platform> y andá a "API Keys".
+2. "Create API Key" — nombrá `intrale-pipeline-YYYYMMDD`. Copiar `csk-...`.
+3. Editá `~/.claude/secrets/credentials.json`:
+   ```json
+   { "providers": { "cerebras": { "api_key": "<nueva-key>" } } }
+   ```
+4. Revocá la vieja key.
+5. `node .pipeline/restart.js`.
+
+## NVIDIA NIM (preparada para #3243 — Ola N+5)
+
+> _Provider declarado pero todavía no consumido. La key vive en `credentials.json`
+> y se hidrata a `NVIDIA_NIM_API_KEY`, pero ningún `agent-models.json` la usa
+> hasta que #3243 entre en producción._
+
+1. Abrí <https://build.nvidia.com> y elegí cualquier modelo (sugerido:
+   DeepSeek V4-Pro o Kimi K2.6). Click "Get API Key".
+2. Editá `~/.claude/secrets/credentials.json`:
+   ```json
+   { "providers": { "nvidia": { "api_key": "<nueva-key>" } } }
+   ```
+3. Revocá la vieja key desde la consola de NVIDIA.
+4. `node .pipeline/restart.js` (no impacta a nada hasta que se implemente #3243).
 
 ### Cómo verificar que rotaste bien (OpenAI)
 

--- a/docs/runbooks/credential-rotation.md
+++ b/docs/runbooks/credential-rotation.md
@@ -113,6 +113,12 @@ hidratadas) y `skipped_*` (las que ya estaban en env o tenían placeholder).
 5. `node .pipeline/restart.js`.
 6. Actualizá `last_rotated` en `docs/secrets-inventory.md`. Commiteá.
 
+### Cómo verificar que rotaste bien (OpenAI)
+
+- [ ] Vieja key revocada falla con `401` (probar con `curl -H "Authorization: Bearer <vieja>" https://api.openai.com/v1/models`).
+- [ ] El pulpo arranca sin `[FATAL]` (CA-2).
+- [ ] Commit pusheado con `last_rotated` actualizado.
+
 ## Groq (free tier — multi-provider fallback)
 
 > _Free tier, regla `feedback_free-providers-rule`. Nunca pago._
@@ -165,12 +171,6 @@ hidratadas) y `skipped_*` (las que ya estaban en env o tenían placeholder).
    ```
 3. Revocá la vieja key desde la consola de NVIDIA.
 4. `node .pipeline/restart.js` (no impacta a nada hasta que se implemente #3243).
-
-### Cómo verificar que rotaste bien (OpenAI)
-
-- [ ] Vieja key revocada falla con `401` (probar con `curl -H "Authorization: Bearer <vieja>" https://api.openai.com/v1/models`).
-- [ ] El pulpo arranca sin `[FATAL]` (CA-2).
-- [ ] Commit pusheado con `last_rotated` actualizado.
 
 ## GitHub (token de gh CLI / `GH_TOKEN`)
 


### PR DESCRIPTION
## Resumen

Una sola fuente de verdad para credenciales del proyecto:
`~/.claude/secrets/credentials.json` con estructura nested (telegram + providers + multimedia). El cargador `.pipeline/lib/credentials.js#loadIntoEnv()` se invoca al boot de `pulpo.js` y `restart.js`, mapea cada `providers.X.api_key` a su env var canónica (`GROQ_API_KEY`, `GEMINI_API_KEY`, etc.) y popula `process.env` para que `validateCredentialsEnvPresence` las encuentre sin que el operador tenga que setear `setx` manualmente por cada provider.

## Cambios

| Archivo | Cambio |
|---|---|
| `.pipeline/lib/credentials.js` *(nuevo)* | Cargador unificado. Expone `loadIntoEnv()`, `ENV_MAPPING`, `LEGACY_MAPPING`, helpers. CLI dry-run con `node .pipeline/lib/credentials.js`. |
| `.pipeline/lib/__tests__/credentials.test.js` *(nuevo)* | 10 tests: happy path, precedencia env>JSON, placeholders, fallback al legacy, archivo corrupto, ambos archivos faltantes, chat_id numérico, mapping coverage. |
| `.pipeline/lib/telegram-secrets.js` | Migrado para leer del nuevo archivo manteniendo API pública (`loadTelegramSecrets`, `loadApiKeys`). Los 6 consumidores legacy (multimedia.js, pulpo.js, listener-telegram.js, servicio-telegram.js, rejection-report.js, hydrate-provider-env.js) siguen funcionando sin cambios. |
| `.pipeline/pulpo.js` | 1 line: `require('./lib/credentials').loadIntoEnv()` al inicio del boot, antes de cualquier otro require que lea credenciales. |
| `.pipeline/restart.js` | Idem, antes de spawnear los hijos (que heredan env). |
| `docs/runbooks/credential-rotation.md` | Nueva sección "Ubicación canónica" + actualización de instrucciones por provider (Anthropic, OpenAI, Groq, Gemini, Cerebras, NVIDIA NIM) — ahora editan el JSON en lugar de hacer setx. |

## Precedencia de carga

1. `process.env` ya seteado (no se sobrescribe, `setx` sigue siendo override válido)
2. `~/.claude/secrets/credentials.json` (canónico, estructura nested)
3. `~/.claude/secrets/telegram-config.json` (legacy flat, fallback con warning)
4. `<repo>/.claude/hooks/telegram-config.json` (legacy committed, último recurso)

## Validación

- ✅ `node .pipeline/lib/agent-models-validate.js` → OK
- ✅ Tests unitarios del cargador: 10/10 pasan
- ✅ Suite completa del pipeline (`node --test .pipeline/lib/__tests__/`): **1770/1770 pasan** — confirmando que la migración de `telegram-secrets.js` no rompió ningún consumidor.
- ✅ Dry-run del cargador en mi máquina: 8 env vars hidratadas (TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID, OPENAI_API_KEY, GEMINI_API_KEY, GROQ_API_KEY, CEREBRAS_API_KEY, NVIDIA_NIM_API_KEY, ELEVENLABS_VOICE_ID).

## QA

**`qa:skipped`** — infra interna del pipeline sin impacto en UI ni producto del usuario. Cubierto por tests unitarios (10 nuevos) + suite completa del pipeline (1770 tests) + validación de boot del Pulpo. CLAUDE.md permite `qa:skipped` para `area:infra`/`area:pipeline` sin `app:*`.

## Test plan

- [x] Tests unitarios del cargador (10/10)
- [x] Suite completa del pipeline (1770/1770)
- [x] Validator `agent-models.json` OK
- [x] Dry-run del cargador con JSON real
- [ ] Post-merge: validar que el Pulpo arranca sin `[FATAL] credentials_env ausente`

## Referencias

- `feedback_credentials-unified` (memory)
- `feedback_api-keys-terminal-only` (memory)
- `project_multimedia-dual-path` (memory)
- #3220 (allowlist de env vars que esto consume)
- #3243 (NVIDIA NIM, consumirá `NVIDIA_NIM_API_KEY` cuando se implemente)

Closes #3311

🤖 Generated with [Claude Code](https://claude.com/claude-code)