### PR TITLE
fix(pipeline/multi-provider): secrets-rw lee/escribe credentials.json canonical (#3313)

### DIFF
--- a/.pipeline/lib/__tests__/multi-provider-secrets-rw.test.js
+++ b/.pipeline/lib/__tests__/multi-provider-secrets-rw.test.js
@@ -1,5 +1,8 @@
 // =============================================================================
-// multi-provider-secrets-rw.test.js — Tests del módulo secrets-rw (#3177).
+// multi-provider-secrets-rw.test.js — Tests del módulo secrets-rw (#3177 / #3313).
+//
+// Cubre tanto el formato canónico (credentials.json nested, #3311) como el
+// fallback de lectura del legacy (telegram-config.json flat).
 // =============================================================================
 'use strict';
 
@@ -13,6 +16,22 @@ const secrets = require('../multi-provider/secrets-rw');
 
 function tmpDir() {
     return fs.mkdtempSync(path.join(os.tmpdir(), 'mp-secrets-test-'));
+}
+
+function writeCanonical(file, overrides = {}) {
+    const data = {
+        telegram: { bot_token: 'x', chat_id: 'y' },
+        providers: {},
+        multimedia: {},
+        ...overrides,
+    };
+    fs.writeFileSync(file, JSON.stringify(data, null, 2));
+    return file;
+}
+
+function writeLegacy(file, data) {
+    fs.writeFileSync(file, JSON.stringify(data));
+    return file;
 }
 
 test('maskValue oculta el medio de una key, dejando 6+****+4', () => {
@@ -43,13 +62,37 @@ test('isPlaceholder detecta marcadores comunes', () => {
     assert.equal(secrets.isPlaceholder(null), true);
 });
 
-test('listKeys devuelve metadata correcta sin la key cruda', () => {
+test('detectFormat distingue canonical de legacy', () => {
+    assert.equal(secrets.detectFormat({ providers: {} }), 'canonical');
+    assert.equal(secrets.detectFormat({ multimedia: {} }), 'canonical');
+    assert.equal(secrets.detectFormat({ telegram: {} }), 'canonical');
+    assert.equal(secrets.detectFormat({ openai_api_key: 'sk-xxx' }), 'legacy');
+    assert.equal(secrets.detectFormat({ groq_api_key: 'gsk_xxx' }), 'legacy');
+    assert.equal(secrets.detectFormat({}), 'canonical');
+});
+
+test('setNested crea estructura intermedia y asigna el valor', () => {
+    const obj = {};
+    secrets.setNested(obj, 'providers.groq.api_key', 'gsk_real');
+    assert.deepEqual(obj, { providers: { groq: { api_key: 'gsk_real' } } });
+
+    secrets.setNested(obj, 'providers.openai.api_key', 'sk-real');
+    assert.equal(obj.providers.openai.api_key, 'sk-real');
+    assert.equal(obj.providers.groq.api_key, 'gsk_real', 'no debe pisar siblings');
+});
+
+test('listKeys lee del formato CANONICAL nested', () => {
     const dir = tmpDir();
-    const file = path.join(dir, 'config.json');
+    const file = path.join(dir, 'credentials.json');
     fs.writeFileSync(file, JSON.stringify({
-        openai_api_key: 'sk-actual-key-1234567890abcdef',
-        anthropic_api_key: 'PLACEHOLDER',
-        elevenlabs_api_key: '',
+        providers: {
+            openai:   { api_key: 'sk-actual-key-1234567890abcdef' },
+            anthropic: { api_key: 'PLACEHOLDER' },
+            groq:     { api_key: 'gsk_real_key_1234567890abcdef' },
+            google:   { api_key: 'AIza_real_key_1234567890abc' },
+            cerebras: { api_key: 'csk_real_key_1234567890abcdef' },
+        },
+        multimedia: { elevenlabs_api_key: '' },
     }));
     const out = secrets.listKeys({ secretsPath: file });
     const byProvider = Object.fromEntries(out.map(k => [k.provider, k]));
@@ -57,21 +100,45 @@ test('listKeys devuelve metadata correcta sin la key cruda', () => {
     assert.equal(byProvider.openai.status, 'present');
     assert.ok(byProvider.openai.masked.startsWith('sk-act'));
     assert.equal(byProvider.openai.masked.endsWith('cdef'), true);
-    assert.ok(!String(byProvider.openai.masked).includes('actual-key-1234567890'));
     assert.equal(byProvider.openai.editable, true);
 
     assert.equal(byProvider.anthropic.status, 'placeholder');
     assert.equal(byProvider.anthropic.editable, false);
-    assert.ok(byProvider.anthropic.reason);
 
     assert.equal(byProvider.elevenlabs.status, 'absent');
     assert.equal(byProvider.elevenlabs.masked, null);
+
+    // Los 3 free providers DEBEN aparecer como present con la estructura nested
+    // — éste es exactamente el caso que rompía el dashboard antes de #3313.
+    assert.equal(byProvider.groq.status, 'present');
+    assert.equal(byProvider['gemini-google'].status, 'present');
+    assert.equal(byProvider.cerebras.status, 'present');
+});
+
+test('listKeys lee del formato LEGACY flat (fallback)', () => {
+    const dir = tmpDir();
+    const file = path.join(dir, 'telegram-config.json');
+    fs.writeFileSync(file, JSON.stringify({
+        openai_api_key: 'sk-legacy-1234567890abcdef',
+        anthropic_api_key: 'PLACEHOLDER',
+        elevenlabs_api_key: '',
+        groq_api_key: 'gsk_legacy_1234567890abcdef',
+    }));
+    const out = secrets.listKeys({ secretsPath: file });
+    const byProvider = Object.fromEntries(out.map(k => [k.provider, k]));
+
+    assert.equal(byProvider.openai.status, 'present');
+    assert.equal(byProvider.anthropic.status, 'placeholder');
+    assert.equal(byProvider.elevenlabs.status, 'absent');
+    assert.equal(byProvider.groq.status, 'present');
+    // El legacy no incluye cerebras ni gemini-google → absent.
+    assert.equal(byProvider.cerebras.status, 'absent');
+    assert.equal(byProvider['gemini-google'].status, 'absent');
 });
 
 test('rotateKey rechaza provider no gestionado', () => {
     const dir = tmpDir();
-    const file = path.join(dir, 'config.json');
-    fs.writeFileSync(file, JSON.stringify({}));
+    const file = writeCanonical(path.join(dir, 'credentials.json'));
     assert.throws(
         () => secrets.rotateKey({ provider: 'unknown-provider', newValue: 'x'.repeat(40), secretsPath: file, backupDir: path.join(dir, 'bak') }),
         /no está gestionado/
@@ -80,8 +147,9 @@ test('rotateKey rechaza provider no gestionado', () => {
 
 test('rotateKey rechaza Anthropic (no editable)', () => {
     const dir = tmpDir();
-    const file = path.join(dir, 'config.json');
-    fs.writeFileSync(file, JSON.stringify({ anthropic_api_key: 'sk-ant-xxxxxxxxxxxx' }));
+    const file = writeCanonical(path.join(dir, 'credentials.json'), {
+        providers: { anthropic: { api_key: 'sk-ant-xxxxxxxxxxxx' } },
+    });
     assert.throws(
         () => secrets.rotateKey({ provider: 'anthropic', newValue: 'sk-ant-new'.padEnd(40, 'x'), secretsPath: file, backupDir: path.join(dir, 'bak') }),
         /no es editable/
@@ -90,8 +158,7 @@ test('rotateKey rechaza Anthropic (no editable)', () => {
 
 test('rotateKey rechaza newValue vacío, corto, placeholder o con control chars', () => {
     const dir = tmpDir();
-    const file = path.join(dir, 'config.json');
-    fs.writeFileSync(file, JSON.stringify({}));
+    const file = writeCanonical(path.join(dir, 'credentials.json'));
     const common = { provider: 'openai', secretsPath: file, backupDir: path.join(dir, 'bak') };
     assert.throws(() => secrets.rotateKey({ ...common, newValue: '' }), /newValue.*requerido/);
     assert.throws(() => secrets.rotateKey({ ...common, newValue: 'short' }), /demasiado corto/);
@@ -99,11 +166,15 @@ test('rotateKey rechaza newValue vacío, corto, placeholder o con control chars'
     assert.throws(() => secrets.rotateKey({ ...common, newValue: 'sk-with-newline\nbad-aaaaaaaaaa' }), /control/);
 });
 
-test('rotateKey escribe atómicamente y crea backup pre-save', () => {
+test('rotateKey escribe atómicamente sobre formato CANONICAL preservando estructura nested', () => {
     const dir = tmpDir();
-    const file = path.join(dir, 'config.json');
+    const file = path.join(dir, 'credentials.json');
     const bakDir = path.join(dir, 'bak');
-    fs.writeFileSync(file, JSON.stringify({ openai_api_key: 'sk-old-12345678901234567890', other: 'preserved' }));
+    fs.writeFileSync(file, JSON.stringify({
+        telegram: { bot_token: 'preserved' },
+        providers: { openai: { api_key: 'sk-old-12345678901234567890' } },
+        multimedia: { elevenlabs_voice_id: 'preserved-voice' },
+    }));
     const result = secrets.rotateKey({
         provider: 'openai',
         newValue: 'sk-new-aaaaaaaaaaaaaaaaaaaa',
@@ -113,20 +184,62 @@ test('rotateKey escribe atómicamente y crea backup pre-save', () => {
     });
     assert.equal(result.ok, true);
     assert.equal(result.provider, 'openai');
+    assert.equal(result.format, 'canonical');
+    assert.equal(result.canonicalPath, 'providers.openai.api_key');
     assert.ok(result.fingerprint);
     assert.ok(result.backupPath);
     assert.ok(fs.existsSync(result.backupPath));
 
     const updated = JSON.parse(fs.readFileSync(file, 'utf8'));
-    assert.equal(updated.openai_api_key, 'sk-new-aaaaaaaaaaaaaaaaaaaa');
-    assert.equal(updated.other, 'preserved', 'campos no tocados deben preservarse');
+    assert.equal(updated.providers.openai.api_key, 'sk-new-aaaaaaaaaaaaaaaaaaaa');
+    assert.equal(updated.telegram.bot_token, 'preserved', 'top-level no tocado debe preservarse');
+    assert.equal(updated.multimedia.elevenlabs_voice_id, 'preserved-voice', 'siblings preservados');
 });
 
-test('rotateKey respeta la retention policy en backups', () => {
+test('rotateKey crea archivo CANONICAL si no existe (estructura nested)', () => {
     const dir = tmpDir();
-    const file = path.join(dir, 'config.json');
+    const file = path.join(dir, 'credentials.json');
     const bakDir = path.join(dir, 'bak');
-    fs.writeFileSync(file, JSON.stringify({ openai_api_key: 'sk-init-1234567890abcdef0000' }));
+    const result = secrets.rotateKey({
+        provider: 'groq',
+        newValue: 'gsk_fresh_aaaaaaaaaaaaaaaaaaaa',
+        secretsPath: file,
+        backupDir: bakDir,
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.format, 'canonical');
+    assert.equal(result.canonicalPath, 'providers.groq.api_key');
+    const updated = JSON.parse(fs.readFileSync(file, 'utf8'));
+    assert.equal(updated.providers.groq.api_key, 'gsk_fresh_aaaaaaaaaaaaaaaaaaaa');
+});
+
+test('rotateKey sobre archivo LEGACY preserva formato flat (compat hacia atrás)', () => {
+    const dir = tmpDir();
+    const file = path.join(dir, 'telegram-config.json');
+    const bakDir = path.join(dir, 'bak');
+    fs.writeFileSync(file, JSON.stringify({
+        openai_api_key: 'sk-old-12345678901234567890',
+        groq_api_key: 'gsk_old_aaaaaaaaaaaaaaaaaaaaa',
+    }));
+    const result = secrets.rotateKey({
+        provider: 'groq',
+        newValue: 'gsk_new_bbbbbbbbbbbbbbbbbbbbb',
+        secretsPath: file,
+        backupDir: bakDir,
+    });
+    assert.equal(result.format, 'legacy');
+    const updated = JSON.parse(fs.readFileSync(file, 'utf8'));
+    assert.equal(updated.groq_api_key, 'gsk_new_bbbbbbbbbbbbbbbbbbbbb');
+    assert.equal(updated.openai_api_key, 'sk-old-12345678901234567890', 'flat siblings preservados');
+});
+
+test('rotateKey respeta la retention policy en backups (canonical)', () => {
+    const dir = tmpDir();
+    const file = path.join(dir, 'credentials.json');
+    const bakDir = path.join(dir, 'bak');
+    fs.writeFileSync(file, JSON.stringify({
+        providers: { openai: { api_key: 'sk-init-1234567890abcdef0000' } },
+    }));
     for (let i = 0; i < 5; i++) {
         secrets.rotateKey({
             provider: 'openai',
@@ -137,29 +250,52 @@ test('rotateKey respeta la retention policy en backups', () => {
             now: 1000 + i,
         });
     }
-    const files = fs.readdirSync(bakDir);
-    assert.equal(files.length, 2, 'retention=2 mantiene solo 2 backups');
+    const backups = fs.readdirSync(bakDir).filter(f => f.startsWith('credentials.'));
+    assert.equal(backups.length, 2, 'retention=2 mantiene solo 2 backups del archivo canonical');
 });
 
-test('getRawKey devuelve la key real o null si ausente/placeholder', () => {
+test('getRawKey lee la key real del CANONICAL nested', () => {
     const dir = tmpDir();
-    const file = path.join(dir, 'config.json');
+    const file = path.join(dir, 'credentials.json');
     fs.writeFileSync(file, JSON.stringify({
-        openai_api_key: 'sk-real-1234567890abcdef0000',
-        elevenlabs_api_key: 'PLACEHOLDER',
+        providers: {
+            openai:   { api_key: 'sk-real-1234567890abcdef0000' },
+            google:   { api_key: 'AIza-real-1234567890abcdef' },
+            cerebras: { api_key: 'csk-real-1234567890abcdef' },
+        },
+        multimedia: { elevenlabs_api_key: 'PLACEHOLDER' },
     }));
     assert.equal(secrets.getRawKey({ provider: 'openai', secretsPath: file }), 'sk-real-1234567890abcdef0000');
-    assert.equal(secrets.getRawKey({ provider: 'elevenlabs', secretsPath: file }), null);
-    assert.equal(secrets.getRawKey({ provider: 'anthropic', secretsPath: file }), null);
+    // 'gemini-google' (UI) mapea a 'providers.google.api_key' en canonical.
+    assert.equal(secrets.getRawKey({ provider: 'gemini-google', secretsPath: file }), 'AIza-real-1234567890abcdef');
+    assert.equal(secrets.getRawKey({ provider: 'cerebras', secretsPath: file }), 'csk-real-1234567890abcdef');
+    assert.equal(secrets.getRawKey({ provider: 'elevenlabs', secretsPath: file }), null, 'PLACEHOLDER → null');
+    assert.equal(secrets.getRawKey({ provider: 'anthropic', secretsPath: file }), null, 'absent → null');
 });
 
-// ─── Free providers (#3260) ─────────────────────────────────────────────────
+test('getRawKey lee del LEGACY flat cuando el canonical no existe', () => {
+    const dir = tmpDir();
+    const legacyFile = path.join(dir, 'telegram-config.json');
+    fs.writeFileSync(legacyFile, JSON.stringify({
+        openai_api_key: 'sk-legacy-1234567890abcdef',
+        groq_api_key: 'gsk_legacy_1234567890abcdef',
+    }));
+    assert.equal(secrets.getRawKey({ provider: 'openai', secretsPath: legacyFile }), 'sk-legacy-1234567890abcdef');
+    assert.equal(secrets.getRawKey({ provider: 'groq', secretsPath: legacyFile }), 'gsk_legacy_1234567890abcdef');
+});
 
-test('MANAGED_KEYS incluye los 3 free providers de #3260', () => {
+// ─── Free providers (#3260 + #3313) ─────────────────────────────────────────
+
+test('MANAGED_KEYS incluye los 3 free providers de #3260 con canonicalPath', () => {
     const providers = secrets.MANAGED_KEYS.map(k => k.provider);
     assert.ok(providers.includes('groq'), 'groq presente');
     assert.ok(providers.includes('gemini-google'), 'gemini-google presente');
     assert.ok(providers.includes('cerebras'), 'cerebras presente');
+
+    const byP = Object.fromEntries(secrets.MANAGED_KEYS.map(k => [k.provider, k]));
+    assert.equal(byP.groq.canonicalPath, 'providers.groq.api_key');
+    assert.equal(byP['gemini-google'].canonicalPath, 'providers.google.api_key');
+    assert.equal(byP.cerebras.canonicalPath, 'providers.cerebras.api_key');
 });
 
 test('free providers son editable=true (rotables vía UI)', () => {
@@ -170,11 +306,13 @@ test('free providers son editable=true (rotables vía UI)', () => {
     }
 });
 
-test('rotateKey de free provider crea backup + write atómico 0600 (SR-1)', () => {
+test('rotateKey de free provider sobre CANONICAL crea backup + write atómico 0600 (SR-1)', () => {
     const dir = tmpDir();
-    const file = path.join(dir, 'config.json');
+    const file = path.join(dir, 'credentials.json');
     const bakDir = path.join(dir, 'bak');
-    fs.writeFileSync(file, JSON.stringify({ groq_api_key: 'gsk_old_aaaaaaaaaaaaaaaaaaaaa' }));
+    fs.writeFileSync(file, JSON.stringify({
+        providers: { groq: { api_key: 'gsk_old_aaaaaaaaaaaaaaaaaaaaa' } },
+    }));
     const result = secrets.rotateKey({
         provider: 'groq',
         newValue: 'gsk_new_bbbbbbbbbbbbbbbbbbbbb',
@@ -184,19 +322,21 @@ test('rotateKey de free provider crea backup + write atómico 0600 (SR-1)', () =
     });
     assert.equal(result.ok, true);
     assert.equal(result.provider, 'groq');
+    assert.equal(result.format, 'canonical');
     assert.ok(result.fingerprint, 'fingerprint generado');
     assert.equal(result.fingerprint.length, 16);
     const persisted = JSON.parse(fs.readFileSync(file, 'utf8'));
-    assert.equal(persisted.groq_api_key, 'gsk_new_bbbbbbbbbbbbbbbbbbbbb');
-    // Backup existe
-    const backups = fs.readdirSync(bakDir);
+    assert.equal(persisted.providers.groq.api_key, 'gsk_new_bbbbbbbbbbbbbbbbbbbbb');
+    const backups = fs.readdirSync(bakDir).filter(f => f.startsWith('credentials.'));
     assert.equal(backups.length, 1);
 });
 
 test('listKeys de free provider incluye free_tier_notes en metadata', () => {
     const dir = tmpDir();
-    const file = path.join(dir, 'config.json');
-    fs.writeFileSync(file, JSON.stringify({ groq_api_key: 'gsk_aaaaaaaaaaaaaaaaaaaaaa' }));
+    const file = path.join(dir, 'credentials.json');
+    fs.writeFileSync(file, JSON.stringify({
+        providers: { groq: { api_key: 'gsk_aaaaaaaaaaaaaaaaaaaaaa' } },
+    }));
     const out = secrets.listKeys({ secretsPath: file });
     const groq = out.find(k => k.provider === 'groq');
     assert.equal(groq.status, 'present');

--- a/.pipeline/lib/multi-provider/secrets-rw.js
+++ b/.pipeline/lib/multi-provider/secrets-rw.js
@@ -1,6 +1,10 @@
 // =============================================================================
-// secrets-rw.js — Lectura/escritura segura de API keys en
-// `~/.claude/secrets/telegram-config.json` desde la UI del dashboard (#3177).
+// secrets-rw.js — Lectura/escritura segura de API keys (#3177 / #3313).
+//
+// Fuente única de verdad: `~/.claude/secrets/credentials.json` (canonical,
+// estructura nested introducida por #3311). Fallback de SOLO LECTURA a
+// `~/.claude/secrets/telegram-config.json` (legacy, flat keys) para casos
+// donde el canonical todavía no fue creado.
 //
 // Reglas de seguridad (OWASP A02 — Cryptographic Failures + A07):
 //   - GET nunca devuelve la key completa. Sólo metadata: provider, status
@@ -11,6 +15,23 @@
 //     La API la lista pero con flag `editable: false`.
 //   - El archivo en disco tiene permisos 0600 después de cada write (best-effort
 //     en Windows: setFileSecurity no es trivial sin nativos, en POSIX usa chmod).
+//
+// Estructura canonical esperada (alineada con .pipeline/lib/credentials.js):
+//   {
+//     "telegram":   { "bot_token": "...", "chat_id": "..." },
+//     "providers":  {
+//       "anthropic": { "api_key": "..." },
+//       "openai":    { "api_key": "..." },
+//       "groq":      { "api_key": "..." },
+//       "google":    { "api_key": "..." },        // mapea al provider 'gemini-google'
+//       "cerebras":  { "api_key": "..." },
+//       "nvidia":    { "api_key": "..." }
+//     },
+//     "multimedia": { "elevenlabs_api_key": "..." }
+//   }
+//
+// Estructura legacy (solo lectura, deprecada):
+//   { "openai_api_key": "...", "groq_api_key": "...", ... }  // flat
 // =============================================================================
 'use strict';
 
@@ -19,55 +40,64 @@ const path = require('node:path');
 const os = require('node:os');
 const crypto = require('node:crypto');
 
-const HOME_SECRETS = path.join(os.homedir(), '.claude', 'secrets', 'telegram-config.json');
+const HOME_CANONICAL = path.join(os.homedir(), '.claude', 'secrets', 'credentials.json');
+const HOME_LEGACY = path.join(os.homedir(), '.claude', 'secrets', 'telegram-config.json');
 const DEFAULT_BACKUP_DIR = path.join(os.homedir(), '.claude', 'secrets', 'backups');
 const DEFAULT_BACKUP_RETENTION = 30;
 
 // Lista canónica de keys gestionables vía UI. Anthropic está pero `editable:false`.
 //
-// Los 3 free providers (#3260 — hardening de free providers, ola N+5) entran al
-// mismo flujo de masking + fingerprint SHA-256 + atomic write 0600 + backup
-// 30d + audit chain (SR-1 de security). NVIDIA-NIM se sumará cuando mergee
-// #3243 — la lista crece editando este array, sin código nuevo.
+// `canonicalPath` = dot-path en credentials.json (estructura nested).
+// `legacyField`   = flat key en telegram-config.json (solo lectura, para
+// compat hacia atrás mientras el canonical todavía no existe).
 const MANAGED_KEYS = Object.freeze([
     {
-        jsonField: 'anthropic_api_key',
         provider: 'anthropic',
         label: 'Anthropic',
         editable: false,
         reason: 'Claude Code usa OAuth / MAX login; rotar acá puede confundir el child env.',
+        canonicalPath: 'providers.anthropic.api_key',
+        legacyField: 'anthropic_api_key',
     },
     {
-        jsonField: 'openai_api_key',
         provider: 'openai',
         label: 'OpenAI / Codex',
         editable: true,
+        canonicalPath: 'providers.openai.api_key',
+        legacyField: 'openai_api_key',
     },
     {
-        jsonField: 'elevenlabs_api_key',
         provider: 'elevenlabs',
         label: 'ElevenLabs',
         editable: true,
+        canonicalPath: 'multimedia.elevenlabs_api_key',
+        legacyField: 'elevenlabs_api_key',
     },
     {
-        jsonField: 'groq_api_key',
         provider: 'groq',
         label: 'Groq',
         editable: true,
+        canonicalPath: 'providers.groq.api_key',
+        legacyField: 'groq_api_key',
         free_tier_notes: 'RPM 30 / RPD 14400 (free) — ver docs/pipeline/multi-provider.md §8.',
     },
     {
-        jsonField: 'gemini_google_api_key',
         provider: 'gemini-google',
         label: 'Gemini (Google AI Studio)',
         editable: true,
+        // En el credentials.json canónico vive bajo `providers.google` (alineado
+        // con credentials.js → GEMINI_API_KEY). En la UI seguimos llamándolo
+        // 'gemini-google' para diferenciarlo de Vertex AI.
+        canonicalPath: 'providers.google.api_key',
+        legacyField: 'gemini_google_api_key',
         free_tier_notes: 'RPM 15 / RPD 1500 / TPM 1M (free) — ver docs/pipeline/multi-provider.md §8.',
     },
     {
-        jsonField: 'cerebras_api_key',
         provider: 'cerebras',
         label: 'Cerebras',
         editable: true,
+        canonicalPath: 'providers.cerebras.api_key',
+        legacyField: 'cerebras_api_key',
         free_tier_notes: 'RPM 30 / TPM 60K (free) — ver docs/pipeline/multi-provider.md §8.',
     },
 ]);
@@ -100,10 +130,72 @@ function tryReadJson(file, fsImpl = fs) {
     }
 }
 
-function listKeys({ secretsPath = HOME_SECRETS, fsImpl = fs } = {}) {
-    const json = tryReadJson(secretsPath, fsImpl) || {};
+function getNested(obj, dotPath) {
+    return dotPath.split('.').reduce(
+        (acc, k) => (acc && typeof acc === 'object') ? acc[k] : undefined,
+        obj
+    );
+}
+
+function setNested(obj, dotPath, value) {
+    const parts = dotPath.split('.');
+    const last = parts.pop();
+    let cur = obj;
+    for (const p of parts) {
+        if (cur[p] === null || cur[p] === undefined || typeof cur[p] !== 'object') {
+            cur[p] = {};
+        }
+        cur = cur[p];
+    }
+    cur[last] = value;
+    return obj;
+}
+
+// Detecta el formato del JSON cargado. Si tiene alguna de las claves canónicas
+// top-level → 'canonical'; en cualquier otro caso → 'legacy' (incluso si está
+// vacío o no tiene ninguna key conocida, asumimos legacy por defensa, porque
+// si está vacío sin tener providers/multimedia no podemos asumir intent).
+function detectFormat(data) {
+    if (!data || typeof data !== 'object') return 'canonical';
+    if (data.providers !== undefined || data.multimedia !== undefined || data.telegram !== undefined) {
+        return 'canonical';
+    }
+    // Si tiene alguna flat key conocida → legacy.
+    for (const spec of MANAGED_KEYS) {
+        if (Object.prototype.hasOwnProperty.call(data, spec.legacyField)) return 'legacy';
+    }
+    // Vacío o desconocido: asumimos canonical (caso de archivo recién creado).
+    return 'canonical';
+}
+
+function readKeyFromData(spec, data, format) {
+    if (!data) return undefined;
+    if (format === 'legacy') return data[spec.legacyField];
+    return getNested(data, spec.canonicalPath);
+}
+
+// Resuelve qué archivo abrir y devuelve {data, format, path}. Si `secretsPath`
+// es explícito, usa ese; sino, intenta canonical y luego legacy.
+function loadSource({ secretsPath, fsImpl = fs } = {}) {
+    if (secretsPath) {
+        const data = tryReadJson(secretsPath, fsImpl);
+        return { data, format: detectFormat(data), path: secretsPath };
+    }
+    if (fsImpl.existsSync(HOME_CANONICAL)) {
+        const data = tryReadJson(HOME_CANONICAL, fsImpl);
+        return { data: data || {}, format: 'canonical', path: HOME_CANONICAL };
+    }
+    if (fsImpl.existsSync(HOME_LEGACY)) {
+        const data = tryReadJson(HOME_LEGACY, fsImpl);
+        return { data: data || {}, format: 'legacy', path: HOME_LEGACY };
+    }
+    return { data: null, format: 'canonical', path: HOME_CANONICAL };
+}
+
+function listKeys({ secretsPath, fsImpl = fs } = {}) {
+    const { data, format } = loadSource({ secretsPath, fsImpl });
     return MANAGED_KEYS.map(spec => {
-        const raw = json[spec.jsonField];
+        const raw = readKeyFromData(spec, data, format);
         let status;
         if (typeof raw !== 'string' || !raw.trim()) status = 'absent';
         else if (isPlaceholder(raw)) status = 'placeholder';
@@ -111,7 +203,8 @@ function listKeys({ secretsPath = HOME_SECRETS, fsImpl = fs } = {}) {
 
         return {
             provider: spec.provider,
-            jsonField: spec.jsonField,
+            jsonField: spec.legacyField, // Compat: la UI/log ya consumen `jsonField`. Mantenemos el alias.
+            canonicalPath: spec.canonicalPath,
             label: spec.label,
             editable: spec.editable,
             reason: spec.reason || null,
@@ -126,7 +219,7 @@ function listKeys({ secretsPath = HOME_SECRETS, fsImpl = fs } = {}) {
 function rotateKey({
     provider,
     newValue,
-    secretsPath = HOME_SECRETS,
+    secretsPath,
     backupDir = DEFAULT_BACKUP_DIR,
     retention = DEFAULT_BACKUP_RETENTION,
     fsImpl = fs,
@@ -152,40 +245,64 @@ function rotateKey({
         throw new Error('[secrets-rw] rotateKey: "newValue" demasiado corto (< 20 chars). Sospechoso.');
     }
 
-    const dir = path.dirname(secretsPath);
+    // Escritura: por defecto el archivo destino es el canonical. Si el caller
+    // pasa `secretsPath`, se respeta. El formato escrito preserva el formato
+    // detectado del archivo existente (si es legacy y existe, mantenemos flat
+    // para no romper consumidores legacy; si no existe o es canonical,
+    // escribimos canonical nested).
+    const targetPath = secretsPath || HOME_CANONICAL;
+    const dir = path.dirname(targetPath);
     if (!fsImpl.existsSync(dir)) fsImpl.mkdirSync(dir, { recursive: true });
-    const current = tryReadJson(secretsPath, fsImpl) || {};
+
+    let current = {};
+    let format = 'canonical';
+    if (fsImpl.existsSync(targetPath)) {
+        current = tryReadJson(targetPath, fsImpl) || {};
+        format = detectFormat(current);
+    }
 
     let backupPath = null;
-    if (fsImpl.existsSync(secretsPath)) {
+    if (fsImpl.existsSync(targetPath)) {
         if (!fsImpl.existsSync(backupDir)) fsImpl.mkdirSync(backupDir, { recursive: true });
         const ts = new Date(now).toISOString().replace(/[:.]/g, '-');
-        backupPath = path.join(backupDir, `telegram-config.${ts}.json`);
-        fsImpl.copyFileSync(secretsPath, backupPath);
+        const basename = path.basename(targetPath, '.json');
+        backupPath = path.join(backupDir, `${basename}.${ts}.json`);
+        fsImpl.copyFileSync(targetPath, backupPath);
         try { fsImpl.chmodSync(backupPath, 0o600); } catch { /* Windows: best-effort */ }
     }
 
-    const updated = { ...current, [spec.jsonField]: newValue.trim() };
-    const tmpPath = `${secretsPath}.tmp.${process.pid}.${now}`;
-    fsImpl.writeFileSync(tmpPath, JSON.stringify(updated, null, 2) + '\n', { mode: 0o600 });
-    fsImpl.renameSync(tmpPath, secretsPath);
-    try { fsImpl.chmodSync(secretsPath, 0o600); } catch { /* Windows: best-effort */ }
+    const trimmed = newValue.trim();
+    const updated = JSON.parse(JSON.stringify(current));
+    if (format === 'legacy') {
+        updated[spec.legacyField] = trimmed;
+    } else {
+        setNested(updated, spec.canonicalPath, trimmed);
+    }
 
-    applyBackupRetention({ backupDir, retention, fsImpl });
+    const tmpPath = `${targetPath}.tmp.${process.pid}.${now}`;
+    fsImpl.writeFileSync(tmpPath, JSON.stringify(updated, null, 2) + '\n', { mode: 0o600 });
+    fsImpl.renameSync(tmpPath, targetPath);
+    try { fsImpl.chmodSync(targetPath, 0o600); } catch { /* Windows: best-effort */ }
+
+    applyBackupRetention({ backupDir, retention, fsImpl, basename: path.basename(targetPath, '.json') });
 
     return {
         ok: true,
-        jsonField: spec.jsonField,
+        jsonField: spec.legacyField,
+        canonicalPath: spec.canonicalPath,
         provider: spec.provider,
-        fingerprint: fingerprint(newValue.trim()),
+        format,
+        targetPath,
+        fingerprint: fingerprint(trimmed),
         backupPath,
     };
 }
 
-function applyBackupRetention({ backupDir, retention, fsImpl }) {
+function applyBackupRetention({ backupDir, retention, fsImpl, basename }) {
     if (!fsImpl.existsSync(backupDir)) return;
+    const prefix = `${basename}.`;
     const files = fsImpl.readdirSync(backupDir)
-        .filter(f => f.startsWith('telegram-config.') && f.endsWith('.json'))
+        .filter(f => f.startsWith(prefix) && f.endsWith('.json'))
         .sort();
     while (files.length > retention) {
         const oldest = files.shift();
@@ -193,17 +310,21 @@ function applyBackupRetention({ backupDir, retention, fsImpl }) {
     }
 }
 
-function getRawKey({ provider, secretsPath = HOME_SECRETS, fsImpl = fs } = {}) {
+function getRawKey({ provider, secretsPath, fsImpl = fs } = {}) {
     const spec = MANAGED_KEYS.find(k => k.provider === provider);
     if (!spec) return null;
-    const json = tryReadJson(secretsPath, fsImpl) || {};
-    const raw = json[spec.jsonField];
+    const { data, format } = loadSource({ secretsPath, fsImpl });
+    const raw = readKeyFromData(spec, data, format);
     if (!raw || typeof raw !== 'string' || !raw.trim() || isPlaceholder(raw)) return null;
     return raw;
 }
 
 module.exports = {
-    HOME_SECRETS,
+    HOME_CANONICAL,
+    HOME_LEGACY,
+    // Compat hacia atrás: módulos que importaban `HOME_SECRETS` siguen funcionando
+    // — apunta al canonical, que es el nuevo destino.
+    HOME_SECRETS: HOME_CANONICAL,
     DEFAULT_BACKUP_DIR,
     DEFAULT_BACKUP_RETENTION,
     MANAGED_KEYS,
@@ -213,4 +334,8 @@ module.exports = {
     maskValue,
     fingerprint,
     isPlaceholder,
+    // Helpers expuestos para tests y consumidores internos:
+    detectFormat,
+    getNested,
+    setNested,
 };


### PR DESCRIPTION
## Resumen

Migra `.pipeline/lib/multi-provider/secrets-rw.js` a la estructura **nested** del `credentials.json` canonical introducida por #3311. Antes hardcodeaba `telegram-config.json` con flat keys, lo que dejaba a Cerebras y Gemini como `no_key_configured` (esas keys nunca existieron en el legacy) y a Groq como `invalid_credentials` (key vieja del legacy).

## Causa raíz

`secrets-rw.js:22` apuntaba a `~/.claude/secrets/telegram-config.json` con campos planos (`groq_api_key`, `gemini_google_api_key`, `cerebras_api_key`). El PR #3311 unificó las credenciales en `credentials.json` con estructura nested (`providers.<name>.api_key` y `multimedia.elevenlabs_api_key`) pero no se actualizó este módulo. Como consecuencia, **todo el panel \"Providers\" del dashboard + el cron de health + el botón de \"Probar\" leían del archivo equivocado**.

## Cambios

- `MANAGED_KEYS` ahora incluye `canonicalPath` (dot-path nested) además de `legacyField` para fallback de lectura.
- `listKeys` / `getRawKey` autodetectan el formato del archivo (canonical vs legacy) y leen lo correspondiente.
- `rotateKey` **escribe siempre al canonical** preservando estructura nested. Si el archivo destino ya es legacy flat, mantiene ese formato (compat hacia atrás).
- `gemini-google` (UI) mapea a `providers.google.api_key` (alineado con la convención de `.pipeline/lib/credentials.js` → `GEMINI_API_KEY`).
- Backups se llaman `credentials.<ts>.json` cuando el origen es canonical.
- Tests actualizados para cubrir ambos formatos + fallback + free providers.

## Validación E2E

Ejecuté `health-cron.runOnce()` contra el `credentials.json` real:

| Provider | Antes (legacy) | Después (canonical) |
|---|---|---|
| **groq** | 🔴 invalid_credentials (401) | 🟢 authenticated (200, 274ms) |
| **gemini-google** | 🔴 no_key_configured | 🟢 authenticated (200, 523ms) |
| **cerebras** | 🔴 no_key_configured | 🟢 authenticated (200, 1293ms) |

La alerta \"Multi-Down: 3 free providers en rojo\" desaparece con este fix.

## Tests

```
ℹ tests 21
ℹ pass 21
ℹ fail 0
ℹ duration_ms 121.7357
```

## Test plan

- [x] Tests unitarios pasan (21/21).
- [x] `listKeys()` contra `credentials.json` real reporta groq/gemini-google/cerebras como `present`.
- [x] `health-cron.runOnce()` real muestra los 3 free providers en 🟢 con auth contra los endpoints de cada provider.
- [ ] Post-merge: reiniciar pipeline (`node .pipeline/restart.js`) para que los procesos vivos recarguen el módulo.
- [ ] Confirmar visualmente en el dashboard (ventana \"Providers\") que los 3 quedan en verde.

## QA

`qa:skipped` — cambio puro de infra del pipeline. No hay UI de usuario impactada (la ventana \"Providers\" es de operación interna).

Closes #3313

🤖 Generated with [Claude Code](https://claude.com/claude-code)