### PR TITLE
fix(pipeline/multi-provider): groq health-check 400 organization_restricted → forbidden (#3347)

### DIFF
--- a/.pipeline/lib/__tests__/multi-provider-live-ping.test.js
+++ b/.pipeline/lib/__tests__/multi-provider-live-ping.test.js
@@ -170,6 +170,36 @@ test('ping Groq con 429 plain → rate_limited', async () => {
     assert.equal(r.reason, 'rate_limited');
 });
 
+test('ping Groq con 400 organization_restricted → forbidden (#3347)', async () => {
+    const dir = tmpDir();
+    const f = path.join(dir, 'config.json');
+    writeKeys(f, { groq_api_key: 'gsk_test_1234567890abcdef0000' });
+    const r = await livePing.ping({
+        provider: 'groq',
+        secretsPath: f,
+        httpImpl: fakeHttp({
+            status: 400,
+            body: '{"error":{"message":"Organization has been restricted...","type":"invalid_request_error","code":"organization_restricted"}}',
+        }),
+    });
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, 'forbidden');
+    assert.equal(r.statusCode, 400);
+});
+
+test('ping Groq con 400 sin organization_restricted → unknown', async () => {
+    const dir = tmpDir();
+    const f = path.join(dir, 'config.json');
+    writeKeys(f, { groq_api_key: 'gsk_test_1234567890abcdef0000' });
+    const r = await livePing.ping({
+        provider: 'groq',
+        secretsPath: f,
+        httpImpl: fakeHttp({ status: 400, body: '{"error":{"message":"bad request"}}' }),
+    });
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, 'unknown');
+});
+
 test('ping Gemini-Google con status 200 devuelve authenticated', async () => {
     const dir = tmpDir();
     const f = path.join(dir, 'config.json');

--- a/.pipeline/lib/multi-provider/live-ping.js
+++ b/.pipeline/lib/multi-provider/live-ping.js
@@ -97,6 +97,16 @@ const PROVIDER_PING_ENDPOINTS = Object.freeze({
         headers: (key) => ({ 'authorization': `Bearer ${key}` }),
         interpret: (status, bodyExcerpt) => {
             if (status >= 200 && status < 300) return { ok: true, reason: 'authenticated' };
+            if (status === 400) {
+                // Groq devuelve 400 + `organization_restricted` cuando la
+                // organización dueña de la key fue restringida (#3347). El
+                // status es 400 (no 403) porque Groq usa `invalid_request_error`
+                // como wrapper. La key es válida → no es `invalid_credentials`.
+                if (/organization_restricted/i.test(bodyExcerpt)) {
+                    return { ok: false, reason: 'forbidden' };
+                }
+                return { ok: false, reason: 'unknown' };
+            }
             if (status === 401) return { ok: false, reason: 'invalid_credentials' };
             if (status === 403) return { ok: false, reason: 'forbidden' };
             if (status === 429) {


### PR DESCRIPTION
## Resumen

Cuando la organización dueña de la key Groq queda restringida, `/v1/models` devuelve **HTTP 400 + `code: organization_restricted`** (no 403). El handler lo clasificaba como `unknown` → el dashboard mostraba el provider en rojo sin razón legible.

## Diagnóstico (post-fix #3313)

Después de mergear #3346 el cron de health pasó a leer del `credentials.json` canonical. Gemini y Cerebras pasaron a verde, pero Groq cambió de **401 (invalid_credentials)** a **400 (unknown)**. La key es válida — la cuenta está restringida.

Body real:
\`\`\`json
{"error":{"message":"Organization has been restricted...","type":"invalid_request_error","code":"organization_restricted"}}
\`\`\`

## Cambios

- \`.pipeline/lib/multi-provider/live-ping.js\` — handler Groq: rama para status 400, regex sobre \`organization_restricted\` → \`forbidden\`. 400 sin body conocido sigue \`unknown\`.
- \`.pipeline/lib/__tests__/multi-provider-live-ping.test.js\` — 2 tests nuevos.

## Validación

\`\`\`
node --test .pipeline/lib/__tests__/multi-provider-live-ping.test.js
✔ pass 22 / fail 0
\`\`\`

## QA

\`qa:skipped\` justificado: infra pura del pipeline sin impacto en producto de usuario (clasificación de error en cron interno).

Closes #3347.

🤖 Generated with [Claude Code](https://claude.com/claude-code)