### PR TITLE
Bug: fast-fail-rebote archiva .po/.ux sin restituir al destrabar

### DIFF
--- a/.pipeline/lib/__tests__/blocked-segregation.test.js
+++ b/.pipeline/lib/__tests__/blocked-segregation.test.js
@@ -33,7 +33,8 @@ const TMP_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'v3-blocked-seg-'));
 fs.mkdirSync(path.join(TMP_DIR, '.claude'), { recursive: true });
 fs.mkdirSync(path.join(TMP_DIR, '.pipeline', 'servicios', 'github', 'pendiente'), { recursive: true });
 for (const phase of ['validacion', 'dev']) {
-    for (const state of ['pendiente', 'trabajando', 'listo']) {
+    // #3373 — agregar 'procesado' para tests del sweep defensivo
+    for (const state of ['pendiente', 'trabajando', 'listo', 'procesado']) {
         fs.mkdirSync(path.join(TMP_DIR, '.pipeline', 'desarrollo', phase, state), { recursive: true });
     }
 }
@@ -55,7 +56,8 @@ function clearAll() {
         try { phases = fs.readdirSync(root).filter(f => fs.statSync(path.join(root, f)).isDirectory()); }
         catch { continue; }
         for (const phase of phases) {
-            for (const state of ['pendiente', 'trabajando', 'listo', 'bloqueado-humano', 'bloqueado-dependencias']) {
+            // #3373 — incluir 'procesado' para limpiar también ese estado entre tests
+            for (const state of ['pendiente', 'trabajando', 'listo', 'procesado', 'bloqueado-humano', 'bloqueado-dependencias']) {
                 const dir = path.join(root, phase, state);
                 try {
                     for (const f of fs.readdirSync(dir)) {
@@ -364,4 +366,243 @@ test('CA-5 + #3221 (regresión): motivo con rebote_categoria YAML estructurado N
     assert.equal(result.label, 'blocked:dependencies');
     assert.notEqual(result.label, 'needs-human');
     assert.deepEqual(result.dependsOn, [3198, 3220]);
+});
+
+// =============================================================================
+// #3373 — Sweep defensivo: recuperar archivos varados en procesado/ por
+//         fast-fail-rebote pre-fix. El issue #3361 sufrió este bug en prod.
+// =============================================================================
+
+const yamlLib = require('js-yaml');
+
+function writeYamlSync(filepath, data) {
+    fs.mkdirSync(path.dirname(filepath), { recursive: true });
+    fs.writeFileSync(filepath, yamlLib.dump(data, { lineWidth: -1 }));
+}
+
+test('#3373 sweep: reingresa archivos con cancelado_por=fast-fail-rebote desde procesado/ a pendiente/', () => {
+    clearAll();
+    const procDir = path.join(TMP_DIR, '.pipeline', 'desarrollo', 'validacion', 'procesado');
+    fs.mkdirSync(procDir, { recursive: true });
+
+    // Simular el estado tras el bug: .po y .ux drenados a procesado/, .guru
+    // en bloqueado-dependencias/ (porque el dep_block handler lo movió bien).
+    writeYamlSync(path.join(procDir, '3361.po'), {
+        issue: 3361, fase: 'validacion', pipeline: 'desarrollo',
+        resultado: 'aprobado', cancelado_por: 'fast-fail-rebote',
+        cancelado_ts: '2026-05-19T00:00:00.000Z',
+    });
+    writeYamlSync(path.join(procDir, '3361.ux'), {
+        issue: 3361, fase: 'validacion', pipeline: 'desarrollo',
+        resultado: 'aprobado', cancelado_por: 'fast-fail-rebote',
+        cancelado_ts: '2026-05-19T00:00:00.000Z',
+    });
+    rc.writeDependencyBlockMarker({
+        issue: 3361, skill: 'guru', phase: 'validacion',
+        pipeline: 'desarrollo', dependsOn: [3353],
+    });
+
+    const result = rc.releaseDependencyBlockToPendiente({ issue: 3361 });
+
+    // 3 archivos: 1 del marker (guru) + 2 del sweep (po, ux)
+    assert.equal(result.moved, 3, 'debe mover 3 archivos: guru + po + ux');
+    assert.equal(result.swept, 2, 'el contador swept debe reportar 2 archivos recuperados');
+
+    const pendDir = path.join(TMP_DIR, '.pipeline', 'desarrollo', 'validacion', 'pendiente');
+    assert.equal(fs.existsSync(path.join(pendDir, '3361.guru')), true, 'guru en pendiente/');
+    assert.equal(fs.existsSync(path.join(pendDir, '3361.po')), true, 'po en pendiente/');
+    assert.equal(fs.existsSync(path.join(pendDir, '3361.ux')), true, 'ux en pendiente/');
+
+    // procesado/ vacío para el issue
+    assert.equal(fs.existsSync(path.join(procDir, '3361.po')), false);
+    assert.equal(fs.existsSync(path.join(procDir, '3361.ux')), false);
+
+    // Los flags cancelado_* deben haberse limpiado del YAML reingresado
+    const reentry = yamlLib.load(fs.readFileSync(path.join(pendDir, '3361.po'), 'utf8'));
+    assert.equal(reentry.cancelado_por, undefined, 'cancelado_por debe limpiarse');
+    assert.equal(reentry.cancelado_ts, undefined, 'cancelado_ts debe limpiarse');
+    assert.equal(reentry.issue, 3361, 'el resto del YAML se preserva');
+});
+
+test('#3373 sweep negativo: NO restituye archivos con cancelado_por=cross-phase-rebote (strict equality)', () => {
+    clearAll();
+    const procDir = path.join(TMP_DIR, '.pipeline', 'desarrollo', 'validacion', 'procesado');
+    fs.mkdirSync(procDir, { recursive: true });
+
+    // Archivos con cross-phase-rebote — semántica distinta, NO se restituye.
+    writeYamlSync(path.join(procDir, '4001.po'), {
+        issue: 4001, fase: 'validacion', pipeline: 'desarrollo',
+        cancelado_por: 'cross-phase-rebote',
+        cancelado_ts: '2026-05-19T00:00:00.000Z',
+    });
+    rc.writeDependencyBlockMarker({
+        issue: 4001, skill: 'guru', phase: 'validacion',
+        pipeline: 'desarrollo', dependsOn: [4999],
+    });
+
+    const result = rc.releaseDependencyBlockToPendiente({ issue: 4001 });
+
+    // Solo 1 movido (el guru del marker), el .po con cross-phase-rebote NO.
+    assert.equal(result.moved, 1, 'solo guru se mueve');
+    assert.equal(result.swept || 0, 0, 'el sweep no recupera cross-phase-rebote');
+
+    // El .po sigue en procesado/ — semántica intacta.
+    assert.equal(fs.existsSync(path.join(procDir, '4001.po')), true);
+});
+
+test('#3373 sweep: aislado por (issue, pipeline, phase) — no escanea otras fases ni otros issues', () => {
+    clearAll();
+    const validProc = path.join(TMP_DIR, '.pipeline', 'desarrollo', 'validacion', 'procesado');
+    const devProc = path.join(TMP_DIR, '.pipeline', 'desarrollo', 'dev', 'procesado');
+    fs.mkdirSync(validProc, { recursive: true });
+    fs.mkdirSync(devProc, { recursive: true });
+
+    // .po del issue 5001 en validacion/procesado/ con cancelado_por (target)
+    writeYamlSync(path.join(validProc, '5001.po'), {
+        issue: 5001, cancelado_por: 'fast-fail-rebote',
+    });
+    // .pipeline-dev del MISMO issue pero en dev/procesado/ con cancelado_por
+    // — no debería tocarse porque el marker está en validacion/, no en dev/.
+    writeYamlSync(path.join(devProc, '5001.pipeline-dev'), {
+        issue: 5001, cancelado_por: 'fast-fail-rebote',
+    });
+    // .po de OTRO issue (5002) en validacion/procesado/ — no debería tocarse.
+    writeYamlSync(path.join(validProc, '5002.po'), {
+        issue: 5002, cancelado_por: 'fast-fail-rebote',
+    });
+    rc.writeDependencyBlockMarker({
+        issue: 5001, skill: 'guru', phase: 'validacion',
+        pipeline: 'desarrollo', dependsOn: [5099],
+    });
+
+    const result = rc.releaseDependencyBlockToPendiente({ issue: 5001 });
+
+    // Movidos: guru (marker) + 5001.po (sweep). NO se toca dev ni issue 5002.
+    assert.equal(result.moved, 2, 'guru + 5001.po (mismo pipeline+phase)');
+    assert.equal(result.swept, 1, 'sweep recupera 1 archivo');
+
+    // El dev/procesado/5001.pipeline-dev sigue ahí — no se escanea.
+    assert.equal(fs.existsSync(path.join(devProc, '5001.pipeline-dev')), true,
+        'el archivo en otra fase no se toca');
+    // El issue 5002 sigue ahí — sweep filtra por issue.
+    assert.equal(fs.existsSync(path.join(validProc, '5002.po')), true,
+        'archivos de otros issues no se tocan');
+});
+
+test('#3373 sweep: cap MAX_FILES_PER_ISSUE=3 (anti-abuso)', () => {
+    clearAll();
+    const procDir = path.join(TMP_DIR, '.pipeline', 'desarrollo', 'validacion', 'procesado');
+    fs.mkdirSync(procDir, { recursive: true });
+
+    // Plantar 5 archivos del mismo issue con cancelado_por (escenario degenerado).
+    for (const skill of ['po', 'ux', 'guru', 'tester', 'review']) {
+        writeYamlSync(path.join(procDir, `6001.${skill}`), {
+            issue: 6001, cancelado_por: 'fast-fail-rebote',
+        });
+    }
+    rc.writeDependencyBlockMarker({
+        issue: 6001, skill: 'guru', phase: 'validacion',
+        pipeline: 'desarrollo', dependsOn: [6099],
+    });
+
+    // El sweep no debe reingresar más de 3 archivos por issue, evitando abuso.
+    const sweepRes = rc.sweepFastFailRebotesFromProcesado({
+        issue: 6001, pipeline: 'desarrollo', phase: 'validacion',
+    });
+    assert.ok(sweepRes.moved <= 3, `cap respetado: moved=${sweepRes.moved} <= 3`);
+    assert.equal(sweepRes.capped, true, 'flag capped=true cuando se llega al límite');
+});
+
+test('#3373 sweep: idempotente — sin markers ni archivos legacy, no hace nada', () => {
+    clearAll();
+    const result = rc.releaseDependencyBlockToPendiente({ issue: 7001 });
+    assert.equal(result.moved, 0);
+    assert.deepEqual(result.files, []);
+});
+
+test('#3373 sweep: idempotente — invocación directa sin archivos coincidentes', () => {
+    clearAll();
+    const result = rc.sweepFastFailRebotesFromProcesado({
+        issue: 7002, pipeline: 'desarrollo', phase: 'validacion',
+    });
+    assert.equal(result.moved, 0);
+    assert.deepEqual(result.files, []);
+});
+
+test('#3373 sweep: validación de input — issue inválido devuelve no-op', () => {
+    const r1 = rc.sweepFastFailRebotesFromProcesado({ issue: 'abc', pipeline: 'desarrollo', phase: 'validacion' });
+    assert.equal(r1.moved, 0);
+    const r2 = rc.sweepFastFailRebotesFromProcesado({ issue: -5, pipeline: 'desarrollo', phase: 'validacion' });
+    assert.equal(r2.moved, 0);
+    const r3 = rc.sweepFastFailRebotesFromProcesado({ issue: 1234, pipeline: '', phase: 'validacion' });
+    assert.equal(r3.moved, 0);
+    const r4 = rc.sweepFastFailRebotesFromProcesado({ issue: 1234, pipeline: 'desarrollo', phase: '' });
+    assert.equal(r4.moved, 0);
+});
+
+test('#3373 sweep: tolera YAML corrupto en procesado/ sin romperse', () => {
+    clearAll();
+    const procDir = path.join(TMP_DIR, '.pipeline', 'desarrollo', 'validacion', 'procesado');
+    fs.mkdirSync(procDir, { recursive: true });
+
+    // YAML válido con flag
+    writeYamlSync(path.join(procDir, '8001.po'), {
+        issue: 8001, cancelado_por: 'fast-fail-rebote',
+    });
+    // YAML corrupto del MISMO issue — el sweep debe skipear, no crashear.
+    fs.writeFileSync(path.join(procDir, '8001.ux'), '!!! no es yaml válido @#$%^&*\n:::\n');
+
+    rc.writeDependencyBlockMarker({
+        issue: 8001, skill: 'guru', phase: 'validacion',
+        pipeline: 'desarrollo', dependsOn: [8099],
+    });
+
+    const result = rc.releaseDependencyBlockToPendiente({ issue: 8001 });
+
+    // El sweep skipea el corrupto pero mueve el válido (.po).
+    assert.equal(result.swept, 1, '.po válido se mueve, .ux corrupto se skipea');
+    const pendDir = path.join(TMP_DIR, '.pipeline', 'desarrollo', 'validacion', 'pendiente');
+    assert.equal(fs.existsSync(path.join(pendDir, '8001.po')), true);
+    // El corrupto sigue en procesado/ (no crasheó, no se movió).
+    assert.equal(fs.existsSync(path.join(procDir, '8001.ux')), true);
+});
+
+test('#3373 reproducción del incidente #3361: destrabe completo sin intervención manual', () => {
+    clearAll();
+    const procDir = path.join(TMP_DIR, '.pipeline', 'desarrollo', 'validacion', 'procesado');
+    fs.mkdirSync(procDir, { recursive: true });
+
+    // Estado pre-fix del incidente real:
+    //   - 3361.guru en bloqueado-dependencias/ (movido bien por dep_block handler)
+    //   - 3361.po y 3361.ux drenados a procesado/ por fast-fail-rebote → varados
+    writeYamlSync(path.join(procDir, '3361.po'), {
+        issue: 3361, fase: 'validacion', pipeline: 'desarrollo',
+        resultado: 'aprobado', skill: 'po',
+        cancelado_por: 'fast-fail-rebote',
+        cancelado_ts: '2026-05-19T12:34:56.000Z',
+    });
+    writeYamlSync(path.join(procDir, '3361.ux'), {
+        issue: 3361, fase: 'validacion', pipeline: 'desarrollo',
+        resultado: 'aprobado', skill: 'ux',
+        cancelado_por: 'fast-fail-rebote',
+        cancelado_ts: '2026-05-19T12:34:56.000Z',
+    });
+    rc.writeDependencyBlockMarker({
+        issue: 3361, skill: 'guru', phase: 'validacion',
+        pipeline: 'desarrollo', dependsOn: [3353],
+        reason: '#3353 (multi-provider) sigue abierta',
+    });
+
+    // Llega el brazoDesbloqueo: la dep cerró, intenta destrabar.
+    const result = rc.releaseDependencyBlockToPendiente({ issue: 3361 });
+
+    // Resultado esperado post-fix: 3 archivos en pendiente/ sin intervención manual.
+    assert.equal(result.moved, 3, 'log [desbloqueo] reporta 3 archivo(s) movido(s)');
+    assert.equal(result.swept, 2, 'log [desbloqueo-sweep] reporta 2 recuperaciones legacy');
+
+    const pendDir = path.join(TMP_DIR, '.pipeline', 'desarrollo', 'validacion', 'pendiente');
+    for (const skill of ['guru', 'po', 'ux']) {
+        assert.equal(fs.existsSync(path.join(pendDir, `3361.${skill}`)), true,
+            `3361.${skill} en pendiente/ post-destrabe`);
+    }
 });

--- a/.pipeline/lib/rebote-classifier.js
+++ b/.pipeline/lib/rebote-classifier.js
@@ -56,6 +56,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const yaml = require('js-yaml');
 const trace = require('./traceability');
 const humanBlock = require('./human-block');
 
@@ -623,19 +624,30 @@ function listDependencyBlockedMarkers() {
  * `pendiente/` de la fase declarada en `.reason.json` (o `phase` si se pasa).
  * Idempotente: si el archivo ya no está, devuelve `moved: 0`.
  *
+ * #3373 — Además de mover desde `bloqueado-dependencias/`, ejecuta un sweep
+ * defensivo sobre `<pipeline>/<phase>/procesado/` buscando archivos del mismo
+ * issue con `cancelado_por === 'fast-fail-rebote'` (strict equality) y los
+ * reingresa a `pendiente/`. Recupera archivos legacy que el fast-fail-rebote
+ * pre-#3373 drenó a procesado/ y dejó varados. NO toca archivos con
+ * `cancelado_por: 'cross-phase-rebote'` (otra semántica).
+ *
  * @param {object} opts
  * @param {number} opts.issue
  * @param {string} [opts.targetPhase] — fase explícita; default = lo que dice
  *                                       el .reason.json del marker.
  *
- * @returns {{ moved: number, files: string[], pipeline?: string, phase?: string }}
+ * @returns {{ moved: number, files: string[], pipeline?: string, phase?: string, swept?: number }}
  */
 function releaseDependencyBlockToPendiente(opts) {
     const issue = Number(opts.issue);
-    if (!issue) return { moved: 0, files: [] };
+    if (!Number.isInteger(issue) || issue <= 0) return { moved: 0, files: [] };
 
     const markers = listDependencyBlockedMarkers().filter(m => m.issue === issue);
-    if (markers.length === 0) return { moved: 0, files: [] };
+    if (markers.length === 0) {
+        // Sin marker no podemos inferir (pipeline, phase). El sweep necesita ese
+        // contexto — sin él no escaneamos a ciegas todo el filesystem.
+        return { moved: 0, files: [] };
+    }
 
     // Agrupar por pipeline+phase (debería ser único, pero defense-in-depth)
     let pipeline = null;
@@ -666,7 +678,122 @@ function releaseDependencyBlockToPendiente(opts) {
         try { fs.unlinkSync(m.file + '.reason.json'); } catch {}
     }
 
-    return { moved: movedFiles.length, files: movedFiles, pipeline, phase };
+    // #3373 — Sweep defensivo: recuperar archivos legacy en procesado/ con
+    // `cancelado_por: fast-fail-rebote` para los (pipeline, phase) donde
+    // encontramos markers. Sin esto, issues que sufrieron el bug pre-#3373
+    // quedan trabados aunque las deps cierren.
+    const sweptFiles = [];
+    const sweepedPhases = new Set();
+    for (const m of markers) {
+        const key = `${m.pipeline}/${m.phase}`;
+        if (sweepedPhases.has(key)) continue;
+        sweepedPhases.add(key);
+        try {
+            const sweepRes = sweepFastFailRebotesFromProcesado({
+                issue,
+                pipeline: m.pipeline,
+                phase: m.phase,
+            });
+            for (const f of sweepRes.files) sweptFiles.push(f);
+        } catch {
+            // sweep defensivo — nunca debe romper el destrabe principal
+        }
+    }
+
+    return {
+        moved: movedFiles.length + sweptFiles.length,
+        files: [...movedFiles, ...sweptFiles],
+        pipeline,
+        phase,
+        swept: sweptFiles.length,
+    };
+}
+
+/**
+ * #3373 — Sweep defensivo: escanea `<pipeline>/<phase>/procesado/` buscando
+ * archivos del mismo issue con flag `cancelado_por === 'fast-fail-rebote'`
+ * (strict equality, NO laxer match) y los reingresa a `pendiente/`. Recupera
+ * archivos legacy varados por el bug pre-#3373.
+ *
+ * Caps de seguridad (recomendación security #3373):
+ *   - Máximo 3 archivos reingresados por issue (anti-abuso).
+ *   - Máximo 100 archivos escaneados por invocación (anti-DOS).
+ *   - Strict equality `=== 'fast-fail-rebote'`: NO restituye 'cross-phase-rebote'
+ *     ni motivos parciales/regex.
+ *   - Filtrado por prefix de filename ANTES de leer YAML (perf + defensa).
+ *   - try/catch envolviendo cada operación de FS (idempotencia + corrupciones).
+ *
+ * @param {object} opts
+ * @param {number} opts.issue
+ * @param {string} opts.pipeline
+ * @param {string} opts.phase
+ *
+ * @returns {{ moved: number, files: string[], scanned: number, capped: boolean }}
+ */
+function sweepFastFailRebotesFromProcesado(opts) {
+    const issue = Number(opts.issue);
+    const pipeline = String(opts.pipeline || '').trim();
+    const phase = String(opts.phase || '').trim();
+    if (!Number.isInteger(issue) || issue <= 0) return { moved: 0, files: [], scanned: 0, capped: false };
+    if (!pipeline || !phase) return { moved: 0, files: [], scanned: 0, capped: false };
+
+    const MAX_FILES_PER_ISSUE = 3;
+    const MAX_FILES_SCANNED = 100;
+
+    const procesadoDir = path.join(PIPELINE_DIR, pipeline, phase, 'procesado');
+    const pendienteDir = path.join(PIPELINE_DIR, pipeline, phase, 'pendiente');
+
+    const prefix = String(issue) + '.';
+    const moved = [];
+    let scanned = 0;
+    let capped = false;
+
+    let entries = [];
+    try { entries = fs.readdirSync(procesadoDir); } catch { return { moved: 0, files: [], scanned: 0, capped: false }; }
+
+    for (const f of entries) {
+        if (scanned >= MAX_FILES_SCANNED) { capped = true; break; }
+        // Early-continue: descarta cualquier archivo que NO sea de este issue
+        // antes de leer YAML (perf + defensa contra fanout enorme).
+        if (!f.startsWith(prefix)) continue;
+        if (f === '.gitkeep') continue;
+        if (f.endsWith('.reason.json') || f.endsWith('.guidance.txt') || f.endsWith('.comment.md')) continue;
+        // Markers válidos: <issue>.<skill> (≤2 segmentos)
+        if (f.split('.').length > 2) continue;
+        scanned++;
+        if (moved.length >= MAX_FILES_PER_ISSUE) { capped = true; break; }
+
+        const src = path.join(procesadoDir, f);
+        let data = null;
+        try {
+            const raw = fs.readFileSync(src, 'utf8');
+            data = yaml.load(raw) || {};
+        } catch {
+            // YAML corrupto o I/O failure: skip silencioso. No relanzar.
+            continue;
+        }
+        // Strict equality — NO 'cross-phase-rebote', NO regex, NO includes.
+        if (data.cancelado_por !== 'fast-fail-rebote') continue;
+
+        try { fs.mkdirSync(pendienteDir, { recursive: true }); } catch {}
+        const dst = path.join(pendienteDir, f);
+
+        // Reescribir YAML limpiando los flags de cancelación — el agente
+        // re-entra a pendiente/ como ciclo nuevo, no como reintento marcado.
+        const clean = { ...data };
+        delete clean.cancelado_por;
+        delete clean.cancelado_ts;
+
+        try {
+            fs.writeFileSync(dst, yaml.dump(clean, { lineWidth: -1 }));
+            fs.unlinkSync(src);
+            moved.push(dst);
+        } catch {
+            // ENOENT u otro race: idempotencia, capturar y seguir.
+        }
+    }
+
+    return { moved: moved.length, files: moved, scanned, capped };
 }
 
 // -----------------------------------------------------------------------------
@@ -716,6 +843,8 @@ module.exports = {
     moveIssueFilesToDependencyBlock,
     listDependencyBlockedMarkers,
     releaseDependencyBlockToPendiente,
+    // #3373 — sweep defensivo de fast-fail-rebote varados en procesado/
+    sweepFastFailRebotesFromProcesado,
     DEPENDENCY_PATTERNS,
     DEPENDENCY_ASSET_PATTERNS,
     DEPS_LABEL,

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -2646,7 +2646,42 @@ function brazoBarrido(config) {
         // Si el rebote va a dispararse por fast-fail (todosCompletos=false pero hay rechazo),
         // cancelar los archivos residuales del mismo issue en pendiente/ y trabajando/
         // de la fase actual para que no queden huérfanos tras el rebote.
+        //
+        // #3373 — EXCEPCIÓN dependency_block: si alguno de los rechazos viene con
+        // `rebote_categoria: dependency_block` (hint YAML del agente) o el classifier
+        // detecta dep_block sobre el motivo, NO drenar. El handler dep-block más abajo
+        // (línea ~2906, moveIssueFilesToDependencyBlock) barre TODOS los archivos del
+        // issue (pendiente + trabajando + listo) a `bloqueado-dependencias/`. Drenar
+        // acá a `procesado/` con `cancelado_por: fast-fail-rebote` rompía el destrabe
+        // automático: el brazoDesbloqueo solo lee `bloqueado-dependencias/` y dejaba
+        // los .po/.ux varados en procesado/. Incidente #3361 — issue trabado ~10h.
+        let hayDepBlockEnRechazos = false;
         if (!todosCompletos && hayRechazoConfirmado) {
+          for (const r of resultados) {
+            if (r.resultado !== 'rechazado') continue;
+            // (a) hint explícito en YAML del agente — gana sobre regex
+            if (r.rebote_categoria === 'dependency_block') {
+              hayDepBlockEnRechazos = true;
+              break;
+            }
+            // (b) fallback: classifier identifica dep_block por motivo
+            try {
+              const cl = reboteClassifier.classifyRebote({
+                motivo: r.motivo || '',
+                rebote_categoria: r.rebote_categoria || null,
+                dependsOn: Array.isArray(r.depende_de) ? r.depende_de : null,
+              });
+              if (cl && cl.category === 'dependency_block') {
+                hayDepBlockEnRechazos = true;
+                break;
+              }
+            } catch {
+              // classifier defensivo — si tira, seguimos con el drain normal
+            }
+          }
+        }
+
+        if (!todosCompletos && hayRechazoConfirmado && !hayDepBlockEnRechazos) {
           const procesadoFaseActual = path.join(fasePath(pipelineName, fase), 'procesado');
           for (const estado of ['pendiente', 'trabajando']) {
             const dir = path.join(fasePath(pipelineName, fase), estado);
@@ -2665,6 +2700,12 @@ function brazoBarrido(config) {
             } catch {}
           }
           log('barrido', `⚡ #${issue} fast-fail en ${fase} — rebote temprano, cancelados skills pendientes/en cooldown`);
+        } else if (!todosCompletos && hayRechazoConfirmado && hayDepBlockEnRechazos) {
+          // #3373 — skip drain. Los archivos pendiente/trabajando se quedan
+          // donde están, el handler dep-block los barre a bloqueado-dependencias/
+          // junto con los de listo/. Así el brazoDesbloqueo encuentra todo
+          // junto y los reingresa cuando las deps cierren.
+          log('barrido', `⚡⏸ #${issue} fast-fail con dependency_block — skip drain. Handler dep-block barre todo a bloqueado-dependencias/.`);
         }
 
         // --- GATE DE EVIDENCIA QA (fase verificacion) ---
@@ -9370,6 +9411,11 @@ async function brazoDesbloqueoImpl(config) {
               });
               if (releaseRes.moved > 0) {
                 log('desbloqueo', `🟢 #${issue.number}: ${releaseRes.moved} archivo(s) movido(s) de bloqueado-dependencias/ a ${releaseRes.pipeline}/${releaseRes.phase}/pendiente/`);
+                // #3373 — sweep defensivo: si recuperó archivos legacy de procesado/,
+                // log explícito con prefijo distintivo para forensics.
+                if (releaseRes.swept && releaseRes.swept > 0) {
+                  log('desbloqueo-sweep', `🧹 #${issue.number}: ${releaseRes.swept} archivo(s) legacy recuperado(s) de procesado/ (cancelado_por: fast-fail-rebote)`);
+                }
               } else {
                 log('desbloqueo', `🟢 #${issue.number}: sin archivos en bloqueado-dependencias/ (issue label-only, pipeline arrancará via intake)`);
               }


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 3 archivos · +422 -6

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:skipped` aplicado por delivery

## Closes

Closes #3373
