### PR TITLE
feat(pipeline): gate validación visual pre-promoción build→verificación (#3383)

### DIFF
--- a/.claude/skills/po/SKILL.md
+++ b/.claude/skills/po/SKILL.md
@@ -879,3 +879,48 @@ Si se detectaron gaps nuevos, actualizar la sección "Gaps conocidos" en `.claud
   ```bash
   export PATH="/c/Workspaces/gh-cli/bin:$PATH"
   ```
+
+## Criterio de aceptación visual en validación post-construcción (#3383)
+
+Para issues con labels `app:client | app:business | app:delivery`, además de
+los criterios de aceptación funcionales, validar visualmente que la entrega
+matchea el mockup esperado adjunto en definición.
+
+**Protocolo de validación**:
+
+1. **Verificar definición visual completa**:
+   - El issue tiene sección `## Screenshots & Mockups` con al menos un mockup
+     esperado + casos borde (vacío, error, datos largos).
+   - El mockup no fue invalidado por un rebote anterior sin re-confirmación de
+     UX (CA-15 — buscar comment `✓ mockup re-confirmado` o `⟳ mockup
+     regenerado` en el último ciclo).
+
+2. **Leer el rejection report visual** si QA emitió uno:
+   - El PDF incluye bloque side-by-side mockup vs entrega (CA-12).
+   - Lista de 3-5 diferencias narradas con título + descripción objetivable +
+     impacto clasificado (CA-13).
+   - Audio narrado (~60s) lee las diferencias + acción sugerida (CA-14).
+
+3. **Aplicar criterio de impacto al veredicto**:
+   - Si todos los hallazgos son **bajo**: el visual es probablemente aceptable.
+     Evaluar `WONTFIX` con razón documentada, no rebote.
+   - Si hay al menos uno **medio**: rebotar al dev — la jerarquía o legibilidad
+     está afectada.
+   - Si hay al menos uno **alto**: rebote bloqueante — afecta la acción
+     principal del usuario.
+
+4. **Validar objetividad de los hallazgos antes de rebotar**:
+   - Si un hallazgo dice "no me gusta" / "queda raro" / "medio feo" sin citar
+     tokens/números/patrones → escalar a UX antes de pasar al dev. No rebotamos
+     al dev con feedback subjetivo.
+   - Si hay duda sobre si el mockup sigue vigente → pedir re-confirmación a UX
+     antes de rebotar.
+
+**Anti-patrones**:
+- Aprobar funcional sin mirar el bloque side-by-side cuando el rejection
+  report visual está presente.
+- Rebotar al dev con feedback de UX que UX nunca validó.
+- Pasar por alto el visual mismatch porque "los tests pasan".
+
+Guía completa: `docs/pipeline/visual-validation.md §6` (checklist UX para PO
+durante validación visual).

--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -442,3 +442,40 @@ gh issue edit "$ISSUE_NUM" --repo intrale/platform --add-label "$LABEL" 2>/dev/n
 - Recordings van a `qa/recordings/` — NO commitear.
 - SIEMPRE reportar veredicto final, incluso sin fallos.
 - Para criterios de cobertura, exploracion abierta o issues ambiguos: consultar `docs/qa-doctrina.md`.
+
+## Validación visual post-construcción (#3383)
+
+Para issues con labels `app:client | app:business | app:delivery` que tengan
+sección `## Screenshots & Mockups` con mockup esperado adjunto:
+
+1. **Capturar la entrega real** en el mismo estado que muestra el mockup
+   (no comparar pantalla feliz vs estado vacío del mockup):
+   - Android: `adb exec-out screencap -p` en flow Maestro.
+   - Dashboard / web: `page.screenshot()` Playwright headless.
+2. **Sanitizar la captura** con `redact()` del módulo `.pipeline/lib/handoff.js`
+   antes de adjuntarla a evidencia o rejection report (CA-9 del issue #3383):
+   - Tokens JWT, AWS keys, emails reales, URLs firmadas, tarjetas de prueba.
+3. **Comparar visual: mockup vs screenshot**. Identificar diferencias
+   objetivables (citando tokens, números, patrones — nunca "no se ve bien").
+4. **Si difiere** — emitir rejection report con bloque side-by-side:
+   - Llamar `rejection-report.js` pasando `data.visualComparison` con
+     `mockup`, `delivery`, `diffs[{title,description,impact}]`,
+     `suggestedAction`.
+   - El PDF resultante (CA-12, CA-13) incluye las 3 secciones obligatorias:
+     mockup esperado, entrega actual, diferencias narradas.
+   - El audio narrado (CA-14, CA-UX-5) lee diferencias + acción sugerida
+     en menos de 60 segundos.
+5. **Aplicar criterio de impacto**:
+   - `alto`: bloquea o degrada la acción principal → rechazo seguro.
+   - `medio`: afecta jerarquía/legibilidad sin bloquear → rechazo justificable.
+   - `bajo`: cosmético → consultar con PO antes de rebote.
+
+Guía completa: `docs/pipeline/visual-validation.md §5` (checklist UX para QA
+durante captura).
+
+**Anti-patrones**:
+- Aprobar visual sin comparar contra el mockup adjunto (cuando existe).
+- Rebotar con feedback subjetivo ("queda raro", "medio feo") sin tokens/números.
+- Capturar con DevTools, Compose layout inspector u overlays de debug visibles.
+- Comparar contra mockup invalidado (rebotado a definición sin re-confirmación
+  de UX — ver CA-15).

--- a/.claude/skills/ux/SKILL.md
+++ b/.claude/skills/ux/SKILL.md
@@ -833,3 +833,47 @@ El UX specialist trabaja en conjunto con el ecosistema de agentes:
   ```bash
   export PATH="/c/Workspaces/gh-cli/bin:$PATH"
   ```
+
+## Rol consultivo en validación visual post-construcción (#3383)
+
+UX no participa por defecto en validación post-construcción — el flujo
+estándar es **QA captura + PO valida**. UX entra **a solicitud** cuando hay
+duda o conflicto.
+
+**Cuándo te invocan a la consulta**:
+
+1. **PO no puede decidir**: los hallazgos visuales del rejection report incluyen
+   ítems clasificados como `medio` pero el contexto del issue sugiere que
+   pueden ser intencionales (ej. una variación de marca aprobada en otro
+   issue). UX revisa y emite veredicto.
+2. **Dev disputa el rebote**: el dev sostiene que la entrega es la versión
+   correcta y el mockup esperado está desactualizado. UX re-confirma el
+   mockup vigente o lo regenera (CA-15 — política de invalidación).
+3. **QA detecta feedback subjetivo**: en el comment del issue alguien dejó
+   "no me gusta" / "queda raro" sin tokens. QA lo escala a UX antes de pasar
+   al dev (no rebotamos al dev con feedback no objetivable).
+4. **El gate `hasVisualReference` rechazó el issue**: el body no tiene sección
+   `## Screenshots & Mockups` con 2+ imágenes. UX adjunta el mockup esperado
+   siguiendo `docs/pipeline/visual-validation.md §2`.
+
+**Qué tenés que hacer**:
+
+- **Aplicar la plantilla** de `## Screenshots & Mockups` (doc §2.1) en el body
+  del issue, con mockup esperado + casos borde + tokens declarados.
+- **Re-confirmar mockups post-rebote** (CA-15): si el issue se rebotó a
+  definición, agregar comment `✓ mockup re-confirmado YYYY-MM-DD` (sin
+  cambios) o `⟳ mockup regenerado YYYY-MM-DD` (con cambios).
+- **Resolver disputas visuales** con argumentos basados en `design-system.md`,
+  tokens existentes, accesibilidad. Si el conflicto es entre estilos
+  intencionados, escalar a PO.
+- **No inventar paleta**: consumir `.pipeline/assets/design-tokens.css`. Cero
+  paleta nueva sin issue dedicado.
+
+**Anti-patrones**:
+- Aprobar visual con "se ve bien" — la justificación debe citar tokens y
+  patrones del design-system.
+- Generar mockups con artefactos (texto "draft", "WIP") — el mockup adjunto
+  al issue debe estar cerrado.
+- Tocar el código de UI: tu output son specs + assets, no commits a la app.
+
+Guía completa: `docs/pipeline/visual-validation.md` (spec end-to-end UX).

--- a/.pipeline/assets/mockups/19-rejection-visual-comparison.svg
+++ b/.pipeline/assets/mockups/19-rejection-visual-comparison.svg
@@ -1,0 +1,236 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Mockup 19 — Bloque side-by-side "Mockup esperado vs Entrega actual" en PDF de rejection report visual.
+  Issue #3383 — Validación visual post-construcción (QA + PO).
+
+  Demuestra:
+    - Header del rejection report (identidad pipeline + veredicto + meta multi-provider)
+    - Bloque comparativo side-by-side con altura igualada y etiquetas claras
+    - Diferencias narradas (texto humano, no diff automatizado en MVP)
+    - Tokens del design system (--surface-*, --semantic-danger, --brand-*)
+    - Accesibilidad: contraste AAA, labels descriptivos, sin depender de color
+  Resolución target: 1240x1754 (A4 a ~150dpi para impresión / PDF lectura cómoda).
+-->
+<svg xmlns="http://www.w3.org/2000/svg" width="1240" height="1754" viewBox="0 0 1240 1754"
+     font-family="-apple-system, 'Segoe UI', system-ui, sans-serif">
+
+  <defs>
+    <linearGradient id="brandGrad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#00D6FF"/>
+      <stop offset="100%" stop-color="#1890FF"/>
+    </linearGradient>
+    <linearGradient id="headerGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0D274D"/>
+      <stop offset="100%" stop-color="#0A1C36"/>
+    </linearGradient>
+    <pattern id="placeholderMockup" patternUnits="userSpaceOnUse" width="32" height="32">
+      <rect width="32" height="32" fill="#1C2128"/>
+      <path d="M0 32 L32 0" stroke="#252B33" stroke-width="1"/>
+    </pattern>
+    <pattern id="placeholderEntrega" patternUnits="userSpaceOnUse" width="32" height="32">
+      <rect width="32" height="32" fill="#1C2128"/>
+      <path d="M0 0 L32 32" stroke="#252B33" stroke-width="1"/>
+    </pattern>
+  </defs>
+
+  <!-- Fondo página -->
+  <rect width="1240" height="1754" fill="#0D1117"/>
+
+  <!-- =================== HEADER =================== -->
+  <rect x="0" y="0" width="1240" height="120" fill="url(#headerGrad)"/>
+  <rect x="0" y="119" width="1240" height="1" fill="#30363D"/>
+
+  <!-- Logo + nombre del reporte -->
+  <g transform="translate(48, 36)">
+    <rect width="48" height="48" rx="12" fill="#0D274D" stroke="#1890FF" stroke-width="1"/>
+    <path d="M24 10 L7 40 L41 40 Z" fill="none" stroke="url(#brandGrad)" stroke-width="3.5"
+          stroke-linejoin="round" stroke-linecap="round"/>
+    <path d="M24 22 L17 34 L31 34 Z" fill="url(#brandGrad)"/>
+  </g>
+  <text x="112" y="58" fill="#E6EDF3" font-size="22" font-weight="700">Intrale Pipeline V3</text>
+  <text x="112" y="80" fill="#8B949E" font-size="11" font-weight="600" letter-spacing="2">REJECTION REPORT · VISUAL VALIDATION</text>
+
+  <!-- Veredicto (top-right) -->
+  <g transform="translate(984, 36)">
+    <rect width="208" height="48" rx="6" fill="#3B1F1B" stroke="#8B1A14"/>
+    <circle cx="22" cy="24" r="6" fill="#F85149"/>
+    <text x="38" y="29" fill="#F85149" font-size="14" font-weight="700">VISUAL MISMATCH</text>
+  </g>
+
+  <!-- ============ Issue title + meta ============ -->
+  <text x="48" y="172" fill="#E6EDF3" font-size="28" font-weight="700">#1842 — Onboarding empresa: paso 2 (datos fiscales)</text>
+
+  <g transform="translate(48, 192)">
+    <rect width="120" height="22" rx="11" fill="#1F2D3F"/>
+    <text x="60" y="16" text-anchor="middle" fill="#58A6FF" font-size="11" font-weight="600">qa · verificacion</text>
+    <rect x="132" width="92" height="22" rx="11" fill="#21262D"/>
+    <text x="178" y="16" text-anchor="middle" fill="#B1BAC4" font-size="11" font-weight="600" font-family="'Cascadia Code', monospace">claude · sonnet-4.6</text>
+    <rect x="236" width="138" height="22" rx="11" fill="#2A1F1C"/>
+    <text x="305" y="16" text-anchor="middle" fill="#F85149" font-size="11" font-weight="600">app:business</text>
+    <text x="404" y="16" fill="#8B949E" font-size="11">2026-05-20 14:32:01 · rebote 1/3</text>
+  </g>
+
+  <!-- =================== BLOQUE COMPARATIVO SIDE-BY-SIDE =================== -->
+  <!-- Encabezado de la sección -->
+  <rect x="48" y="248" width="6" height="32" fill="#F85149"/>
+  <text x="68" y="272" fill="#E6EDF3" font-size="20" font-weight="700">Comparación visual</text>
+  <text x="260" y="272" fill="#8B949E" font-size="12">mockup esperado (definición) · entrega actual (QA capturada)</text>
+
+  <!-- Columna izquierda: Mockup esperado -->
+  <g transform="translate(48, 300)">
+    <rect width="560" height="640" rx="8" fill="#161B22" stroke="#30363D"/>
+
+    <!-- Header de columna -->
+    <rect width="560" height="44" rx="8" fill="#1C2128"/>
+    <rect y="36" width="560" height="8" fill="#1C2128"/>
+    <circle cx="20" cy="22" r="6" fill="#58A6FF"/>
+    <text x="36" y="27" fill="#E6EDF3" font-size="13" font-weight="700">MOCKUP ESPERADO</text>
+    <text x="200" y="27" fill="#8B949E" font-size="11">adjunto en definición · UX · 2026-05-15</text>
+    <rect x="448" y="10" width="104" height="24" rx="4" fill="#0F3D26" stroke="#196C2E"/>
+    <text x="500" y="26" text-anchor="middle" fill="#3FB950" font-size="11" font-weight="600">baseline · v2</text>
+
+    <!-- Marco del frame de la captura -->
+    <rect x="20" y="60" width="520" height="560" rx="6" fill="url(#placeholderMockup)" stroke="#30363D"/>
+
+    <!-- Annotation overlay: pantalla simulada -->
+    <g transform="translate(140, 130)">
+      <rect width="280" height="420" rx="20" fill="#161B22" stroke="#30363D" stroke-width="1.5"/>
+      <!-- Status bar -->
+      <rect width="280" height="24" rx="20" fill="#0D274D"/>
+      <text x="14" y="16" fill="#E6EDF3" font-size="10" font-weight="600">9:41</text>
+      <text x="266" y="16" text-anchor="end" fill="#E6EDF3" font-size="10">100%</text>
+      <!-- Title bar -->
+      <rect y="24" width="280" height="48" fill="#0D274D"/>
+      <text x="14" y="55" fill="#00D6FF" font-size="13" font-weight="700">Onboarding · Paso 2 de 4</text>
+      <text x="266" y="55" text-anchor="end" fill="#B1BAC4" font-size="11">50%</text>
+      <!-- Progress -->
+      <rect y="72" width="140" height="3" fill="#00D6FF"/>
+      <!-- Form -->
+      <text x="20" y="106" fill="#E6EDF3" font-size="13" font-weight="600">Datos fiscales</text>
+      <text x="20" y="124" fill="#8B949E" font-size="10">Necesarios para emitir facturas</text>
+      <!-- CUIT -->
+      <text x="20" y="156" fill="#B1BAC4" font-size="10">CUIT *</text>
+      <rect x="20" y="162" width="240" height="36" rx="6" fill="#1C2128" stroke="#1890FF"/>
+      <text x="32" y="184" fill="#E6EDF3" font-size="12" font-family="monospace">30-71234567-0</text>
+      <!-- Razón social -->
+      <text x="20" y="216" fill="#B1BAC4" font-size="10">Razón social *</text>
+      <rect x="20" y="222" width="240" height="36" rx="6" fill="#1C2128" stroke="#30363D"/>
+      <text x="32" y="244" fill="#6E7681" font-size="12" font-style="italic">Como figura en AFIP</text>
+      <!-- Condición -->
+      <text x="20" y="276" fill="#B1BAC4" font-size="10">Condición IVA *</text>
+      <rect x="20" y="282" width="240" height="36" rx="6" fill="#1C2128" stroke="#30363D"/>
+      <text x="32" y="304" fill="#6E7681" font-size="12">Seleccioná una opción</text>
+      <text x="252" y="304" text-anchor="end" fill="#8B949E" font-size="12">▼</text>
+      <!-- CTA -->
+      <rect x="20" y="356" width="240" height="44" rx="22" fill="url(#brandGrad)"/>
+      <text x="140" y="383" text-anchor="middle" fill="#0A1C36" font-size="13" font-weight="700">Continuar</text>
+    </g>
+  </g>
+
+  <!-- Columna derecha: Entrega actual -->
+  <g transform="translate(632, 300)">
+    <rect width="560" height="640" rx="8" fill="#161B22" stroke="#8B1A14"/>
+
+    <!-- Header de columna -->
+    <rect width="560" height="44" rx="8" fill="#2A1F1C"/>
+    <rect y="36" width="560" height="8" fill="#2A1F1C"/>
+    <circle cx="20" cy="22" r="6" fill="#F85149"/>
+    <text x="36" y="27" fill="#E6EDF3" font-size="13" font-weight="700">ENTREGA ACTUAL</text>
+    <text x="194" y="27" fill="#8B949E" font-size="11">captura QA (emulador) · 2026-05-20 14:31</text>
+    <rect x="448" y="10" width="104" height="24" rx="4" fill="#3B1F1B" stroke="#8B1A14"/>
+    <text x="500" y="26" text-anchor="middle" fill="#F85149" font-size="11" font-weight="600">no matchea</text>
+
+    <!-- Marco del frame de la captura -->
+    <rect x="20" y="60" width="520" height="560" rx="6" fill="url(#placeholderEntrega)" stroke="#30363D"/>
+
+    <!-- Annotation overlay: pantalla actual con defectos -->
+    <g transform="translate(140, 130)">
+      <rect width="280" height="420" rx="20" fill="#161B22" stroke="#30363D" stroke-width="1.5"/>
+      <!-- Status bar (correcta) -->
+      <rect width="280" height="24" rx="20" fill="#0D274D"/>
+      <text x="14" y="16" fill="#E6EDF3" font-size="10" font-weight="600">9:41</text>
+      <text x="266" y="16" text-anchor="end" fill="#E6EDF3" font-size="10">100%</text>
+      <!-- Title bar (DIFF: progreso roto) -->
+      <rect y="24" width="280" height="48" fill="#0D274D"/>
+      <text x="14" y="55" fill="#00D6FF" font-size="13" font-weight="700">Onboarding · Paso 2 de 4</text>
+      <text x="266" y="55" text-anchor="end" fill="#B1BAC4" font-size="11">25%</text>
+      <!-- DIFF marker D1: progress incorrecto -->
+      <rect y="72" width="70" height="3" fill="#F85149"/>
+      <circle cx="74" cy="73.5" r="8" fill="#F85149" stroke="#0D1117" stroke-width="1.5"/>
+      <text x="74" y="77" text-anchor="middle" fill="#0D1117" font-size="9" font-weight="700">1</text>
+      <!-- Form (DIFF: heading sin jerarquía) -->
+      <text x="20" y="106" fill="#B1BAC4" font-size="11">Datos fiscales</text>
+      <circle cx="120" cy="103" r="8" fill="#F85149" stroke="#0D1117" stroke-width="1.5"/>
+      <text x="120" y="107" text-anchor="middle" fill="#0D1117" font-size="9" font-weight="700">2</text>
+      <text x="20" y="124" fill="#8B949E" font-size="10">Necesarios para emitir facturas</text>
+      <!-- CUIT -->
+      <text x="20" y="156" fill="#B1BAC4" font-size="10">CUIT *</text>
+      <rect x="20" y="162" width="240" height="36" rx="6" fill="#1C2128" stroke="#30363D"/>
+      <text x="32" y="184" fill="#E6EDF3" font-size="12" font-family="monospace">30-71234567-0</text>
+      <!-- Razón social -->
+      <text x="20" y="216" fill="#B1BAC4" font-size="10">Razón social *</text>
+      <rect x="20" y="222" width="240" height="36" rx="6" fill="#1C2128" stroke="#30363D"/>
+      <text x="32" y="244" fill="#6E7681" font-size="12" font-style="italic">Como figura en AFIP</text>
+      <!-- Condición -->
+      <text x="20" y="276" fill="#B1BAC4" font-size="10">Condición IVA *</text>
+      <rect x="20" y="282" width="240" height="36" rx="6" fill="#1C2128" stroke="#30363D"/>
+      <text x="32" y="304" fill="#6E7681" font-size="12">Seleccioná una opción</text>
+      <text x="252" y="304" text-anchor="end" fill="#8B949E" font-size="12">▼</text>
+      <!-- DIFF: CTA con color y forma incorrectos -->
+      <rect x="20" y="356" width="240" height="36" rx="6" fill="#1890FF"/>
+      <text x="140" y="379" text-anchor="middle" fill="#FFFFFF" font-size="12" font-weight="600">Continuar</text>
+      <circle cx="270" cy="374" r="10" fill="#F85149" stroke="#0D1117" stroke-width="1.5"/>
+      <text x="270" y="378" text-anchor="middle" fill="#0D1117" font-size="9" font-weight="700">3</text>
+    </g>
+  </g>
+
+  <!-- =================== DIFERENCIAS IDENTIFICADAS (texto humano) =================== -->
+  <rect x="48" y="980" width="6" height="32" fill="#D29922"/>
+  <text x="68" y="1004" fill="#E6EDF3" font-size="20" font-weight="700">Diferencias identificadas</text>
+  <text x="332" y="1004" fill="#8B949E" font-size="12">narradas por QA · 3 hallazgos · sin diff automatizado (MVP)</text>
+
+  <!-- Lista de diferencias -->
+  <g transform="translate(48, 1024)">
+    <!-- Diff 1 -->
+    <rect width="1144" height="100" rx="6" fill="#1C2128" stroke="#30363D"/>
+    <circle cx="32" cy="32" r="14" fill="#F85149"/>
+    <text x="32" y="38" text-anchor="middle" fill="#0D1117" font-size="14" font-weight="700">1</text>
+    <text x="60" y="38" fill="#E6EDF3" font-size="14" font-weight="700">Indicador de progreso muestra 25% en vez de 50%</text>
+    <text x="60" y="62" fill="#B1BAC4" font-size="12">El step 2 de 4 corresponde a 50% del flujo; la entrega calcula como si fueran 8 pasos. Ver mockup paso 72px vs entrega paso 70px.</text>
+    <text x="60" y="84" fill="#8B949E" font-size="11">Impacto · alto · el usuario percibe el flujo más largo de lo real, sube fricción de onboarding.</text>
+
+    <!-- Diff 2 -->
+    <rect y="116" width="1144" height="100" rx="6" fill="#1C2128" stroke="#30363D"/>
+    <circle cx="32" cy="148" r="14" fill="#F85149"/>
+    <text x="32" y="154" text-anchor="middle" fill="#0D1117" font-size="14" font-weight="700">2</text>
+    <text x="60" y="154" fill="#E6EDF3" font-size="14" font-weight="700">Heading "Datos fiscales" pierde jerarquía tipográfica</text>
+    <text x="60" y="178" fill="#B1BAC4" font-size="12">Mockup: 13px / weight 600 / text-primary. Entrega: 11px / weight 400 / text-secondary. Se confunde con el subtítulo.</text>
+    <text x="60" y="200" fill="#8B949E" font-size="11">Impacto · medio · el usuario no identifica el bloque temático del formulario.</text>
+
+    <!-- Diff 3 -->
+    <rect y="232" width="1144" height="100" rx="6" fill="#1C2128" stroke="#30363D"/>
+    <circle cx="32" cy="264" r="14" fill="#F85149"/>
+    <text x="32" y="270" text-anchor="middle" fill="#0D1117" font-size="14" font-weight="700">3</text>
+    <text x="60" y="270" fill="#E6EDF3" font-size="14" font-weight="700">CTA "Continuar" sin gradiente de marca y con radio incorrecto</text>
+    <text x="60" y="294" fill="#B1BAC4" font-size="12">Mockup: radius 22 (pill) + gradient brand-cyan→brand-blue, label en navy-deep. Entrega: radius 6 + brand-blue sólido, label blanco.</text>
+    <text x="60" y="316" fill="#8B949E" font-size="11">Impacto · alto · el CTA pierde identidad y no señala "acción principal" como en el resto de la app.</text>
+  </g>
+
+  <!-- =================== ACCIONES SIGUERIDAS =================== -->
+  <rect x="48" y="1396" width="6" height="32" fill="#3FB950"/>
+  <text x="68" y="1420" fill="#E6EDF3" font-size="20" font-weight="700">Acciones sugeridas</text>
+
+  <g transform="translate(48, 1440)">
+    <rect width="1144" height="140" rx="6" fill="#0F3D26" stroke="#196C2E"/>
+    <text x="24" y="34" fill="#3FB950" font-size="14" font-weight="700">→ Rebote a android-dev</text>
+    <text x="24" y="58" fill="#E6EDF3" font-size="12">Re-implementar respetando tokens de design-system: progress bar 50% step 2/4, heading 13px/600 text-primary, CTA pill 22px con brand gradient.</text>
+    <text x="24" y="82" fill="#E6EDF3" font-size="12">Referencia bloqueante: mockup esperado (definición · UX · 2026-05-15 · baseline v2).</text>
+    <text x="24" y="108" fill="#8B949E" font-size="11">Después de re-implementar, QA captura nuevo screenshot y re-corre comparación. Si el dev modifica el mockup esperado en vez de la entrega, UX debe re-confirmarlo (política de invalidación CA-15).</text>
+    <text x="24" y="128" fill="#8B949E" font-size="11">Si el dev considera que la entrega es la versión correcta y el mockup está desactualizado, abrir comentario en el issue antes de tocar y disputar con UX.</text>
+  </g>
+
+  <!-- =================== FOOTER =================== -->
+  <rect y="1690" width="1240" height="1" fill="#30363D"/>
+  <text x="48" y="1720" fill="#8B949E" font-size="11">Intrale Platform · Visual Validation Report v1 · #3383 · sanitizado (sin JWT/emails/URLs firmadas)</text>
+  <text x="1192" y="1720" text-anchor="end" fill="#8B949E" font-size="11" font-family="'Cascadia Code', monospace">checksum sha256: 4f1c…a7b3</text>
+</svg>

--- a/.pipeline/lib/qa-evidence-gate.js
+++ b/.pipeline/lib/qa-evidence-gate.js
@@ -27,6 +27,155 @@
 
 const SKIPPABLE_QA_MODES = Object.freeze(['api', 'structural']);
 
+// =============================================================================
+// hasVisualReference — Issue #3383 (CA-1, CA-3, CA-7, CA-UX-3)
+//
+// Valida que el body de un issue tenga sección "## Screenshots & Mockups" con
+// al menos 2 attachments markdown antes de que el pulpo promueva a verificación.
+//
+// Reglas de seguridad (CA-7, CA-8):
+//   - Trunca el body a los primeros 100 KB (anti-DOS).
+//   - Regex bounded sin backtracking (negated char classes, sin nested
+//     quantifiers). No usa eval/Function/exec.
+//   - Soft-timeout de 100 ms vía Date.now() — corta el conteo si tarda más,
+//     devuelve `ok: false` con reason 'timeout'. JS no tiene regex timeout
+//     nativo pero los patrones son ReDoS-safe (verificado en tests adversarial).
+//
+// Bypass (CA-3):
+//   - Si labels contiene 'qa:skipped', retorna `ok: true, reason: 'qa-skipped'`
+//     sin parsear el body.
+//
+// CA-UX-3:
+//   - Match case-insensitive del título de sección, variantes 'Screenshots &
+//     Mockups', 'Screenshots y Mockups', 'Screenshots and Mockups'.
+// =============================================================================
+
+const MAX_BODY_BYTES = 100 * 1024; // 100 KB
+const MAX_PARSE_MS = 100; // soft-timeout
+// Header de sección: '##' + 'Screenshots' + separador (&|y|and) + 'Mockups'.
+// Negated char classes y anclas — ReDoS-safe.
+const SECTION_HEADER_RE = /^\s{0,3}#{2,6}\s+screenshots\s+(?:&|y|and)\s+mockups\s*$/im;
+// Header de cualquier otra sección al mismo nivel (para delimitar fin).
+const ANY_HEADER_RE = /^\s{0,3}#{2,6}\s+\S/m;
+// Image markdown: ![alt](url). Negated char classes, sin backtracking peligroso.
+const IMAGE_RE = /!\[[^\]\n]{0,500}\]\([^)\s\n]{1,2000}(?:\s+"[^"\n]{0,500}")?\)/g;
+
+/**
+ * Trunca el body a los primeros MAX_BODY_BYTES (CA-7, anti-DOS).
+ * Usa Buffer.byteLength para contar bytes, no chars (UTF-8 puede inflar).
+ */
+function truncateBody(body) {
+    if (typeof body !== 'string') return '';
+    const buf = Buffer.from(body, 'utf8');
+    if (buf.byteLength <= MAX_BODY_BYTES) return body;
+    return buf.subarray(0, MAX_BODY_BYTES).toString('utf8');
+}
+
+/**
+ * Detecta si labels contiene qa:skipped (CA-3, bypass por whitelist).
+ */
+function hasQaSkippedLabel(labels) {
+    if (!Array.isArray(labels)) return false;
+    return labels.some((l) => {
+        if (typeof l === 'string') return l.toLowerCase() === 'qa:skipped';
+        if (l && typeof l === 'object' && typeof l.name === 'string') {
+            return l.name.toLowerCase() === 'qa:skipped';
+        }
+        return false;
+    });
+}
+
+/**
+ * Extrae la porción del body que está dentro de la sección "## Screenshots &
+ * Mockups", desde su header hasta el siguiente header del mismo nivel o EOF.
+ *
+ * Devuelve null si no encuentra la sección.
+ */
+function extractSectionSlice(truncated) {
+    const headerMatch = SECTION_HEADER_RE.exec(truncated);
+    if (!headerMatch) return null;
+    const start = headerMatch.index + headerMatch[0].length;
+    // Buscar siguiente header DESPUÉS del actual.
+    const rest = truncated.slice(start);
+    const nextHeaderMatch = ANY_HEADER_RE.exec(rest);
+    const end = nextHeaderMatch ? start + nextHeaderMatch.index : truncated.length;
+    return truncated.slice(start, end);
+}
+
+/**
+ * Cuenta attachments markdown (`![alt](url)`) en el slice, con soft-timeout.
+ * Devuelve { count, timedOut }.
+ */
+function countImages(slice) {
+    const start = Date.now();
+    let count = 0;
+    // Regex con flag /g — exec en loop es ReDoS-safe por construcción del patrón.
+    IMAGE_RE.lastIndex = 0;
+    let m;
+    while ((m = IMAGE_RE.exec(slice)) !== null) {
+        count += 1;
+        if (count >= 2 && Date.now() - start <= MAX_PARSE_MS) {
+            // Optimización: con 2 ya alcanza para el CA-1. Seguimos contando hasta 10
+            // para diagnóstico, pero capamos para evitar inputs adversariales.
+            if (count >= 10) break;
+        }
+        if (Date.now() - start > MAX_PARSE_MS) {
+            return { count, timedOut: true };
+        }
+        // Defensa adicional: si el regex no avanza (no debería pasar con este patrón),
+        // forzar avance para evitar loops.
+        if (IMAGE_RE.lastIndex === m.index) IMAGE_RE.lastIndex += 1;
+    }
+    return { count, timedOut: false };
+}
+
+/**
+ * Valida si el body del issue tiene referencia visual obligatoria (CA-1).
+ *
+ * @param {string} body - Body crudo del issue (markdown).
+ * @param {object} [opts]
+ * @param {Array<string|{name:string}>} [opts.labels] - Labels del issue (para bypass qa:skipped).
+ * @returns {{ ok: boolean, reason: string, images?: number }}
+ */
+function hasVisualReference(body, opts = {}) {
+    const labels = opts.labels || [];
+
+    // CA-3: bypass por whitelist qa:skipped.
+    if (hasQaSkippedLabel(labels)) {
+        return { ok: true, reason: 'qa-skipped' };
+    }
+
+    // CA-7: truncar antes de cualquier parse.
+    const truncated = truncateBody(body);
+    if (!truncated) {
+        return { ok: false, reason: 'empty-body' };
+    }
+
+    // Soft-timeout del parse entero.
+    const t0 = Date.now();
+    const slice = extractSectionSlice(truncated);
+    if (Date.now() - t0 > MAX_PARSE_MS) {
+        return { ok: false, reason: 'timeout' };
+    }
+    if (slice === null) {
+        return { ok: false, reason: 'section-missing' };
+    }
+
+    const { count, timedOut } = countImages(slice);
+    if (timedOut) {
+        return { ok: false, reason: 'timeout', images: count };
+    }
+    if (count < 2) {
+        return {
+            ok: false,
+            reason: count === 0 ? 'no-images' : 'needs-at-least-2-images',
+            images: count,
+        };
+    }
+
+    return { ok: true, reason: 'has-visual-reference', images: count };
+}
+
 /**
  * Normaliza un valor cualquiera a string lowercase trimado.
  * Devuelve '' para null/undefined/no-string.
@@ -106,4 +255,11 @@ module.exports = {
     shouldSkipVisualEvidence,
     buildBypassEvent,
     formatBypassLogLine,
+    // Issue #3383
+    hasVisualReference,
+    truncateBody,
+    hasQaSkippedLabel,
+    extractSectionSlice,
+    MAX_BODY_BYTES,
+    MAX_PARSE_MS,
 };

--- a/.pipeline/lib/visual-gate.js
+++ b/.pipeline/lib/visual-gate.js
@@ -1,0 +1,176 @@
+// =============================================================================
+// visual-gate.js — Gate de validación visual pre-promoción build→verificacion
+//                  (Issue #3383)
+//
+// Resumen
+// -------
+// Antes de promover un archivo de `desarrollo/build/listo/` a
+// `desarrollo/verificacion/pendiente/`, el pulpo le pide a este módulo que
+// valide que el body del issue tenga la sección `## Screenshots & Mockups`
+// con al menos 2 attachments markdown.
+//
+// Si el gate falla:
+//   - El archivo NO se promueve.
+//   - Se postea (idempotentemente) un comment de bloqueo en el issue.
+//   - Se aplica el label `needs:visual-baseline`.
+//
+// Reglas operativas
+// -----------------
+//   - Feature flag `PIPELINE_VISUAL_GATE_ENABLED` (default `0`) controla si el
+//     gate corre o no (CA-4, CA-5 — kill-switch sin redeploy).
+//   - El gate sólo aplica al pipeline `desarrollo`, fase origen `build`, fase
+//     destino `verificacion`, y a issues que tengan al menos uno de los
+//     labels `app:client | app:business | app:delivery`.
+//   - Issues con `qa:skipped` legítimo bypassan el gate (la verificación
+//     final la hace `hasVisualReference` reusando la whitelist existente).
+//
+// Idempotencia (CA-UX-2)
+// ----------------------
+// El comment incluye el marker HTML `<!-- visual-gate-block -->` para que el
+// caller (pulpo) pueda detectar si ya fue posteado antes y no duplicarlo. El
+// caller debe llamar a `commentMarkerPresent(comments)` antes de encolar el
+// comentario.
+//
+// Este módulo es JS puro (sin fs/net): la fetch del body y el queueing de
+// acciones lo hace `pulpo.js`. Acá viven sólo: predicado + parser + copy.
+// Esto lo hace testeable con `node --test` y aislado del runtime del pulpo.
+// =============================================================================
+
+'use strict';
+
+const { hasVisualReference } = require('./qa-evidence-gate');
+
+const VISUAL_GATE_ENV = 'PIPELINE_VISUAL_GATE_ENABLED';
+const COMMENT_MARKER = '<!-- visual-gate-block -->';
+const NEEDS_VISUAL_BASELINE_LABEL = 'needs:visual-baseline';
+const VISUAL_GATE_TARGET_LABELS = Object.freeze([
+    'app:client',
+    'app:business',
+    'app:delivery',
+]);
+
+/**
+ * Devuelve true si el flag `PIPELINE_VISUAL_GATE_ENABLED` está activo.
+ * Se puede pasar `env` para testear sin tocar `process.env` real.
+ */
+function isGateEnabled(env = process.env) {
+    return String(env[VISUAL_GATE_ENV] || '0').trim() === '1';
+}
+
+/**
+ * Normaliza un label (string o {name}) a string lowercase.
+ */
+function labelName(l) {
+    if (typeof l === 'string') return l.toLowerCase();
+    if (l && typeof l === 'object' && typeof l.name === 'string') return l.name.toLowerCase();
+    return '';
+}
+
+/**
+ * Devuelve true si labels contiene alguno de los targets visuales (app:*).
+ */
+function hasVisualTargetLabel(labels) {
+    if (!Array.isArray(labels)) return false;
+    const names = labels.map(labelName);
+    return VISUAL_GATE_TARGET_LABELS.some((target) => names.includes(target));
+}
+
+/**
+ * Predicado de aplicabilidad: ¿debe correr el gate para esta transición?
+ *
+ * @param {object} opts
+ * @param {string} opts.pipelineName
+ * @param {string} opts.fromFase
+ * @param {string} opts.toFase
+ * @param {Array<string|{name:string}>} opts.labels
+ * @param {object} [opts.env]
+ * @returns {boolean}
+ */
+function shouldEvaluateVisualGate({ pipelineName, fromFase, toFase, labels, env }) {
+    if (!isGateEnabled(env)) return false;
+    if (pipelineName !== 'desarrollo') return false;
+    if (fromFase !== 'build') return false;
+    if (toFase !== 'verificacion') return false;
+    if (!hasVisualTargetLabel(labels)) return false;
+    return true;
+}
+
+/**
+ * Evalúa el gate visual sobre el body + labels del issue.
+ * Pasa-throw a `hasVisualReference` con la whitelist de qa:skipped intacta.
+ *
+ * @returns {{ ok: boolean, reason: string, images?: number }}
+ */
+function evaluateVisualGate({ body, labels }) {
+    return hasVisualReference(body, { labels });
+}
+
+/**
+ * Construye el body del comment de bloqueo (CA-UX-3.1).
+ * Texto literal acordado con UX (ver docs/pipeline/visual-validation.md §3).
+ */
+function buildBlockComment() {
+    return [
+        '❌ Validación visual bloqueada — falta evidencia en la definición',
+        '',
+        'Este issue tiene labels `app:*` o toca superficies con UI, pero el body no',
+        'incluye la sección **Screenshots & Mockups** con al menos 2 imágenes adjuntas.',
+        '',
+        'QA no puede comparar la entrega contra una referencia que no existe, así que',
+        'el pipeline lo devuelve a definición.',
+        '',
+        '**Cómo desbloquear**:',
+        '1. Volver a refinamiento con `/doc refinar #<issue>` o `/ux #<issue>`.',
+        '2. UX adjunta mockup esperado + estados borde siguiendo',
+        '   [`docs/pipeline/visual-validation.md §2`](../../docs/pipeline/visual-validation.md#2-spec-de-la-sección-screenshots--mockups).',
+        '3. Volver a someter (el label `needs:visual-baseline` se quita automáticamente',
+        '   cuando el gate verifica que ya hay sección + 2 imágenes).',
+        '',
+        'Si este issue NO necesita validación visual (infra pura, docs, refactor sin UI),',
+        'agregá label `qa:skipped` con justificación escrita en un comment.',
+        '',
+        '> _Bloqueado por_ `PIPELINE_VISUAL_GATE_ENABLED=1` · gate `hasVisualReference` · `.pipeline/lib/qa-evidence-gate.js`.',
+        '',
+        COMMENT_MARKER,
+    ].join('\n');
+}
+
+/**
+ * Idempotencia: devuelve true si alguno de los comments ya tiene el marker.
+ *
+ * @param {Array<{body?: string}>} comments
+ * @returns {boolean}
+ */
+function commentMarkerPresent(comments) {
+    if (!Array.isArray(comments)) return false;
+    return comments.some((c) => typeof c?.body === 'string' && c.body.includes(COMMENT_MARKER));
+}
+
+/**
+ * Construye el evento estructurado de bloqueo para auditoría (similar a
+ * buildBypassEvent existente). Útil para logs grepables del pulpo.
+ */
+function buildGateBlockEvent({ issue, reason, images }) {
+    return {
+        event: 'visual-gate-block',
+        issue: String(issue),
+        reason,
+        images: images ?? 0,
+        decision: 'do-not-promote',
+        action: ['label:needs:visual-baseline', 'comment-if-missing'],
+    };
+}
+
+module.exports = {
+    VISUAL_GATE_ENV,
+    COMMENT_MARKER,
+    NEEDS_VISUAL_BASELINE_LABEL,
+    VISUAL_GATE_TARGET_LABELS,
+    isGateEnabled,
+    hasVisualTargetLabel,
+    shouldEvaluateVisualGate,
+    evaluateVisualGate,
+    buildBlockComment,
+    commentMarkerPresent,
+    buildGateBlockEvent,
+};

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -39,6 +39,9 @@ const { redact } = require('./redact');
 // y en su lugar re-encola el issue a `build` con YAML limpio.
 const staleness = require('./build-log-staleness');
 const qaEvidenceGate = require('./lib/qa-evidence-gate');
+// #3383 — Gate visual pre-promoción build→verificacion. Default OFF
+// (PIPELINE_VISUAL_GATE_ENABLED=0). Activación gradual cuando #3381 esté en main.
+const visualGate = require('./lib/visual-gate');
 // #2549 — Detección de bloqueo humano en motivos de rechazo + helpers de marker.
 // Evita relanzar al infinito skills cuyo rechazo es "esperando merge humano".
 const humanBlock = require('./lib/human-block');
@@ -3620,6 +3623,101 @@ function brazoBarrido(config) {
           const siguienteFase = fases[i + 1];
           const siguientePendiente = path.join(fasePath(pipelineName, siguienteFase), 'pendiente');
           const siguienteSkills = pipelineConfig.skills_por_fase[siguienteFase] || [];
+
+          // #3383 — Gate visual pre-promoción build → verificacion.
+          // Si el flag PIPELINE_VISUAL_GATE_ENABLED=1 y el issue tiene labels
+          // app:* sin sección "Screenshots & Mockups" con 2+ imágenes:
+          //   - NO se promueve a verificacion.
+          //   - Se postea (idempotentemente) el comment de bloqueo en GitHub.
+          //   - Se aplica el label needs:visual-baseline.
+          //   - Los archivos de build/listo/ se archivan (no reintenta el loop).
+          // Default OFF: el flag está en 0 mientras #3381 no esté en main.
+          if (visualGate.shouldEvaluateVisualGate({
+            pipelineName,
+            fromFase: fase,
+            toFase: siguienteFase,
+            labels: getIssueInfo(issue).labels,
+          })) {
+            // Refetch body+comments con caller sync. Usamos el helper local
+            // execSync de gh para no acoplar el barrido a callsAsync.
+            let issueBodyVG = '';
+            let issueLabelsVG = getIssueInfo(issue).labels;
+            let issueCommentsVG = [];
+            try {
+              ghThrottle();
+              const rawVG = execSync(
+                `"${GH_BIN}" issue view ${issue} --json body,labels,comments`,
+                { cwd: ROOT, encoding: 'utf8', timeout: 10000, windowsHide: true }
+              );
+              const parsedVG = JSON.parse(rawVG || '{}');
+              issueBodyVG = typeof parsedVG.body === 'string' ? parsedVG.body : '';
+              issueLabelsVG = Array.isArray(parsedVG.labels) ? parsedVG.labels : issueLabelsVG;
+              issueCommentsVG = Array.isArray(parsedVG.comments) ? parsedVG.comments : [];
+            } catch (e) {
+              log('barrido', `#${issue} visual-gate: fetch falló (${e.message}) — fail-OPEN, sigue promoción normal`);
+            }
+            if (issueBodyVG) {
+              const decision = visualGate.evaluateVisualGate({
+                body: issueBodyVG,
+                labels: issueLabelsVG,
+              });
+              if (!decision.ok) {
+                const ev = visualGate.buildGateBlockEvent({
+                  issue,
+                  reason: decision.reason,
+                  images: decision.images,
+                });
+                log('barrido', `🔴 visual-gate-block #${issue} reason=${ev.reason} images=${ev.images} ${JSON.stringify(ev)}`);
+
+                // Idempotencia (CA-UX-2): no duplicar comment si ya está posteado.
+                if (!visualGate.commentMarkerPresent(issueCommentsVG)) {
+                  try {
+                    const ghQueueDir = path.join(PIPELINE, 'servicios', 'github', 'pendiente');
+                    fs.mkdirSync(ghQueueDir, { recursive: true });
+                    fs.writeFileSync(
+                      path.join(ghQueueDir, `${issue}-visual-gate-comment-${Date.now()}.json`),
+                      JSON.stringify({
+                        action: 'comment',
+                        issue: parseInt(issue),
+                        body: visualGate.buildBlockComment(),
+                      }),
+                    );
+                  } catch (e) {
+                    log('barrido', `Error encolando visual-gate comment #${issue}: ${e.message}`);
+                  }
+                } else {
+                  log('barrido', `#${issue} visual-gate-block — marker ya presente, skip duplicado`);
+                }
+
+                // Aplicar label needs:visual-baseline (idempotente desde GH side).
+                try {
+                  const ghQueueDir = path.join(PIPELINE, 'servicios', 'github', 'pendiente');
+                  fs.mkdirSync(ghQueueDir, { recursive: true });
+                  fs.writeFileSync(
+                    path.join(ghQueueDir, `${issue}-visual-gate-label-${Date.now()}.json`),
+                    JSON.stringify({
+                      action: 'label',
+                      issue: parseInt(issue),
+                      label: visualGate.NEEDS_VISUAL_BASELINE_LABEL,
+                    }),
+                  );
+                } catch (e) {
+                  log('barrido', `Error encolando visual-gate label #${issue}: ${e.message}`);
+                }
+
+                // Archivar archivos evaluados (build/listo/<issue>.*) — no se promueve.
+                for (const a of archivos) {
+                  try { moveFile(a.path, procesadoDir); } catch {}
+                }
+                // Skip el resto del bloque de promoción: continuar con el próximo issue.
+                continue;
+              } else if (decision.reason === 'qa-skipped') {
+                log('barrido', `#${issue} visual-gate bypass (qa:skipped)`);
+              } else {
+                log('barrido', `#${issue} visual-gate ✓ images=${decision.images} — promueve a verificacion`);
+              }
+            }
+          }
 
           if (siguienteFase === 'dev' || siguienteFase === 'build' || siguienteFase === 'entrega') {
             // Fase de un solo skill

--- a/.pipeline/rejection-report.js
+++ b/.pipeline/rejection-report.js
@@ -1485,6 +1485,91 @@ function renderSessionMeta(session) {
 }
 
 // =============================================================================
+// renderVisualComparisonBlock(visualComparison) — Issue #3383 (CA-12, CA-13)
+//
+// Renderiza el bloque side-by-side mockup vs entrega cuando la causa del
+// rechazo es un visual mismatch. Layout y tokens descritos en
+// `docs/pipeline/visual-validation.md §4` y referencia visual en
+// `.pipeline/assets/mockups/19-rejection-visual-comparison.svg`.
+//
+// Shape esperado (todos opcionales — si falta, se renderiza placeholder):
+//   {
+//     mockup:   { src, label?, baseline?, timestamp? },
+//     delivery: { src, label?, timestamp? },
+//     diffs:    [ { title, description, impact: 'alto'|'medio'|'bajo' }, ... ],
+//     suggestedAction: { skill, text }
+//   }
+//
+// `src` puede ser:
+//   - data URI (`data:image/png;base64,...`) — ya sanitizado por el caller.
+//   - URL pública absoluta (`https://...`).
+//   - Path absoluto del filesystem (se lee como base64 inline).
+//
+// Si `visualComparison` es null/undefined, retorna cadena vacía (no render).
+// =============================================================================
+function renderVisualComparisonBlock(visualComparison) {
+  if (!visualComparison || typeof visualComparison !== 'object') return '';
+  const v = visualComparison;
+
+  const renderColumn = (col, side) => {
+    const label = escapeHtml(col?.label || (side === 'mockup' ? 'MOCKUP ESPERADO' : 'ENTREGA ACTUAL'));
+    const subtitle = escapeHtml(col?.subtitle ||
+      (side === 'mockup' ? 'adjunto en definición · UX' : 'captura QA · pipeline'));
+    const badge = side === 'mockup'
+      ? `<span class="badge badge-green">${escapeHtml('baseline · ' + (col?.baseline || 'v1'))}</span>`
+      : `<span class="badge badge-red">no matchea</span>`;
+    const borderClass = side === 'mockup' ? 'visual-col-mockup' : 'visual-col-delivery';
+    const imgHtml = col?.src
+      ? `<img src="${escapeHtml(col.src)}" alt="${label}" />`
+      : `<div class="visual-placeholder">⚠ ${label} no disponible</div>`;
+    return `
+      <div class="visual-col ${borderClass}">
+        <div class="visual-col-header">
+          <span class="visual-col-label">${label}</span>
+          ${badge}
+        </div>
+        <div class="visual-col-subtitle">${subtitle}</div>
+        <div class="visual-col-img">${imgHtml}</div>
+      </div>`;
+  };
+
+  const diffs = Array.isArray(v.diffs) ? v.diffs.slice(0, 5) : [];
+  const diffsBlock = diffs.length === 0
+    ? '<p><em>Sin hallazgos narrados disponibles. Revisión humana de QA pendiente.</em></p>'
+    : `<ol class="visual-diffs">
+        ${diffs.map((d, i) => {
+          const impact = (d?.impact || 'medio').toLowerCase();
+          const impactClass = impact === 'alto' ? 'badge-red'
+            : impact === 'medio' ? 'badge-yellow' : 'badge-blue';
+          return `<li>
+            <strong>${escapeHtml(d?.title || `Hallazgo ${i + 1}`)}</strong>
+            <p>${escapeHtml(d?.description || '')}</p>
+            <span class="badge ${impactClass}">impacto: ${escapeHtml(impact)}</span>
+          </li>`;
+        }).join('')}
+       </ol>`;
+
+  const actionBlock = v.suggestedAction
+    ? `<div class="visual-action">
+         <p><strong>→ Rebote a ${escapeHtml(v.suggestedAction.skill || 'dev')}</strong></p>
+         <p>${escapeHtml(v.suggestedAction.text || 'Re-implementar respetando el mockup referenciado.')}</p>
+       </div>`
+    : '';
+
+  return `
+<h2>Comparativo visual — mockup vs entrega</h2>
+<p><span class="badge badge-red">VISUAL MISMATCH</span></p>
+<div class="visual-compare">
+  ${renderColumn(v.mockup, 'mockup')}
+  ${renderColumn(v.delivery, 'delivery')}
+</div>
+<h3>Diferencias identificadas</h3>
+${diffsBlock}
+${actionBlock}
+`;
+}
+
+// =============================================================================
 // renderHtml(data) — reporte estricto v6: veredicto + causa única + evidencia
 // =============================================================================
 function renderHtml(data) {
@@ -1494,6 +1579,8 @@ function renderHtml(data) {
     logTail, readableLog, depIssues, autoCreatedDeps,
     preflight, evidence, primaryCause, verdict, inconclusive,
     sessionCtx,
+    // #3383 — bloque side-by-side opcional (visual mismatch en QA).
+    visualComparison,
   } = data;
   // (#3088 / CA-1) Contexto multi-provider; fallback defensivo si por algún
   // motivo `collectReportData` no lo pobló (tests legacy, callers viejos).
@@ -1576,6 +1663,23 @@ function renderHtml(data) {
   .gate-rejected { color: #c0392b; font-weight: 600; }
   .label-tag { display: inline-block; padding: 1px 6px; border-radius: 8px; font-size: 0.8em; background: #ecf0f1; color: #2c3e50; margin: 1px; }
   .footer { margin-top: 30px; padding-top: 12px; border-top: 1px solid #ddd; font-size: 0.8em; color: #999; text-align: center; }
+  /* #3383 — Bloque side-by-side mockup vs entrega (CA-12, CA-13). Tokens
+     consumidos sin nueva paleta — derivados de design-tokens.css ya en uso
+     en el dashboard. */
+  .visual-compare { display: flex; gap: 24px; margin: 12px 0; align-items: stretch; }
+  .visual-col { flex: 1 1 50%; background: #f8f9fa; border: 1px solid #ddd; border-radius: 6px; padding: 12px; display: flex; flex-direction: column; }
+  .visual-col-mockup { border-color: #ddd; }
+  .visual-col-delivery { border-color: #c0392b; box-shadow: 0 0 0 1px rgba(192,57,43,0.18); }
+  .visual-col-header { display: flex; justify-content: space-between; align-items: center; gap: 8px; margin-bottom: 6px; }
+  .visual-col-label { font-weight: 700; font-size: 0.85em; letter-spacing: 1px; text-transform: uppercase; color: #2c3e50; }
+  .visual-col-subtitle { font-size: 0.78em; color: #7f8c8d; margin-bottom: 8px; }
+  .visual-col-img { flex: 1; background: #ecf0f1; border-radius: 4px; overflow: hidden; min-height: 220px; display: flex; align-items: center; justify-content: center; }
+  .visual-col-img img { max-width: 100%; max-height: 100%; object-fit: contain; display: block; }
+  .visual-placeholder { background: repeating-linear-gradient(45deg, #ecf0f1, #ecf0f1 8px, #dfe6e9 8px, #dfe6e9 16px); color: #c0392b; font-weight: 600; padding: 18px; text-align: center; font-size: 0.85em; width: 100%; }
+  .visual-diffs { padding-left: 20px; }
+  .visual-diffs li { margin-bottom: 10px; }
+  .visual-diffs strong { color: #2c3e50; }
+  .visual-action { background: #d5f5e3; border-left: 4px solid #27ae60; padding: 14px; margin: 12px 0; border-radius: 0 6px 6px 0; }
 </style>
 </head><body>
 
@@ -1586,6 +1690,8 @@ ${renderSessionMeta(session)}
 <div class="context-box">
   <h3>#${escapeHtml(issue)} &mdash; ${escapeHtml(issueCtx.title)}</h3>
 </div>
+
+${renderVisualComparisonBlock(visualComparison)}
 
 <h2>Causa identificada</h2>
 <div class="${inconclusive ? 'history-box' : 'rootcause-box'}">
@@ -1669,11 +1775,25 @@ function providerNarrationSuffix(data) {
 // generateNarration(data) — narración corta para TTS (20-30s, ~300 chars)
 // =============================================================================
 function generateNarration(data) {
-  const { issue, primaryCause, inconclusive, autoCreatedDeps } = data;
+  const { issue, primaryCause, inconclusive, autoCreatedDeps, visualComparison } = data;
 
   // (#3088 / CA-2) Sufijo determinístico opcional con provider+model. Vacío
   // cuando ninguna regla del audio se activa (la mayoría de los casos).
   const provSuffix = providerNarrationSuffix(data);
+
+  // #3383 / CA-UX-5 — audio narrado del rejection report visual: lee
+  // diferencias + acción sugerida, máximo 3 hallazgos, < 60 segundos.
+  // Solo se activa cuando el bloque side-by-side está presente.
+  if (visualComparison && Array.isArray(visualComparison.diffs) && visualComparison.diffs.length > 0) {
+    const diffs = visualComparison.diffs.slice(0, 3);
+    const list = diffs.map((d, i) => {
+      const title = (d?.title || `hallazgo ${i + 1}`).replace(/\.$/, '');
+      const impact = (d?.impact || 'medio').toLowerCase();
+      return `${title} — impacto ${impact}`;
+    }).join('. ');
+    const actionSkill = visualComparison.suggestedAction?.skill || 'el desarrollador del área';
+    return `Issue ${issue}: rechazo visual. ${list}. Acción sugerida: rebotar a ${actionSkill} para re-implementar respetando el mockup adjunto en definición.${provSuffix}`;
+  }
 
   if (inconclusive) {
     return `Issue ${issue}: rechazo inconcluyente. El preflight confirmó emulador disponible pero el agente declaró rechazo. Requiere revisión humana del log.${provSuffix}`;
@@ -2102,6 +2222,8 @@ module.exports = {
   resolveSessionContext,
   // Helpers de bajo nivel — útiles para vectores de injection (SEC-1).
   escapeHtml,
+  // #3383 — bloque side-by-side (CA-12, CA-13).
+  renderVisualComparisonBlock,
   // Acceso a la implementación real de traceability (override en tests).
   _traceability: traceability,
 };

--- a/.pipeline/scripts/backfill-visual-baseline.js
+++ b/.pipeline/scripts/backfill-visual-baseline.js
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+// =============================================================================
+// backfill-visual-baseline.js — Issue #3383 (CA-6)
+//
+// Aplica el label `needs:visual-baseline` y `bloqueado-humano` a todos los
+// issues OPEN con label `app:*` cuyo body NO tiene sección "Screenshots &
+// Mockups" con 2+ imágenes. NO los rechaza ni los saca del pipeline — los
+// marca para que UX agregue retroactivamente el mockup esperado.
+//
+// Diseñado para correr ANTES de activar `PIPELINE_VISUAL_GATE_ENABLED=1` en
+// producción: sin esto, los issues ya refinados se quedarían atascados al
+// promover de build → verificación.
+//
+// Uso:
+//   node .pipeline/scripts/backfill-visual-baseline.js               # dry-run
+//   node .pipeline/scripts/backfill-visual-baseline.js --apply       # ejecuta
+//   node .pipeline/scripts/backfill-visual-baseline.js --apply --limit 50
+//
+// Idempotente:
+//   - No duplica labels (gh edit es idempotente por sí mismo).
+//   - No agrega el label si el body ya tiene visual reference válida.
+//   - Loguea por issue qué decisión tomó.
+// =============================================================================
+
+'use strict';
+
+const { execSync } = require('node:child_process');
+const path = require('node:path');
+const fs = require('node:fs');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const { hasVisualReference } = require(path.join(REPO_ROOT, '.pipeline', 'lib', 'qa-evidence-gate'));
+
+const GH_BIN = process.env.GH_BIN
+    || (process.platform === 'win32' ? 'C:\\Workspaces\\gh-cli\\bin\\gh.exe' : 'gh');
+
+const args = process.argv.slice(2);
+const apply = args.includes('--apply');
+const limitArg = (() => {
+    const idx = args.indexOf('--limit');
+    return idx >= 0 ? parseInt(args[idx + 1], 10) : 200;
+})();
+const repoArg = (() => {
+    const idx = args.indexOf('--repo');
+    return idx >= 0 ? args[idx + 1] : 'intrale/platform';
+})();
+
+const TARGET_LABELS = ['app:client', 'app:business', 'app:delivery'];
+const BACKFILL_LABEL = 'needs:visual-baseline';
+const BLOCKED_LABEL = 'bloqueado-humano';
+
+function ghJson(cmd) {
+    const out = execSync(cmd, { encoding: 'utf8', windowsHide: true, timeout: 30000 });
+    return JSON.parse(out);
+}
+
+function listCandidates() {
+    // Issues OPEN con algún label app:*.
+    // Buscamos en repos y filtramos client-side con --json para tener body completo.
+    const candidates = new Map(); // issue.number → issue (dedup entre labels)
+    for (const label of TARGET_LABELS) {
+        const cmd =
+            `"${GH_BIN}" issue list --repo ${repoArg} --label "${label}" --state open `
+            + `--limit ${limitArg} --json number,title,labels,body`;
+        try {
+            const items = ghJson(cmd);
+            for (const item of items) {
+                if (!candidates.has(item.number)) candidates.set(item.number, item);
+            }
+        } catch (e) {
+            console.error(`[backfill] error listando label=${label}: ${e.message}`);
+        }
+    }
+    return Array.from(candidates.values());
+}
+
+function alreadyHasLabel(issue, name) {
+    return Array.isArray(issue.labels) && issue.labels.some((l) => l?.name === name);
+}
+
+function addLabel(issue, label) {
+    const cmd = `"${GH_BIN}" issue edit ${issue.number} --repo ${repoArg} --add-label "${label}"`;
+    execSync(cmd, { encoding: 'utf8', windowsHide: true, timeout: 20000 });
+}
+
+function summarizeDecision(issue, decision) {
+    const tag = decision.action.padEnd(8, ' ');
+    const reason = decision.reason;
+    const title = (issue.title || '').slice(0, 60);
+    return `#${issue.number}\t${tag}\t${reason}\t${title}`;
+}
+
+function main() {
+    const mode = apply ? 'APPLY' : 'DRY-RUN';
+    console.log(`[backfill-visual-baseline] modo=${mode} repo=${repoArg} limit=${limitArg}`);
+    console.log(`[backfill-visual-baseline] labels objetivo: ${TARGET_LABELS.join(', ')}`);
+    console.log('');
+
+    const candidates = listCandidates();
+    console.log(`[backfill-visual-baseline] candidatos con app:*: ${candidates.length}`);
+
+    const summary = { needs: 0, skipped_qa: 0, ok: 0, already_labeled: 0, errors: 0 };
+
+    for (const issue of candidates) {
+        // qa:skipped legítimo → no aplica gate (CA-3).
+        if (alreadyHasLabel(issue, 'qa:skipped')) {
+            summary.skipped_qa += 1;
+            console.log(summarizeDecision(issue, { action: 'skip', reason: 'qa:skipped' }));
+            continue;
+        }
+
+        // Si ya tiene needs:visual-baseline, idempotente — no re-label.
+        if (alreadyHasLabel(issue, BACKFILL_LABEL)) {
+            summary.already_labeled += 1;
+            console.log(summarizeDecision(issue, { action: 'noop', reason: 'ya tiene needs:visual-baseline' }));
+            continue;
+        }
+
+        // Evaluar gate con body actual.
+        const labelNames = (issue.labels || []).map((l) => l?.name).filter(Boolean);
+        const decision = hasVisualReference(issue.body || '', { labels: labelNames });
+        if (decision.ok) {
+            summary.ok += 1;
+            console.log(summarizeDecision(issue, { action: 'noop', reason: `ok: ${decision.reason}` }));
+            continue;
+        }
+
+        // Falla → aplicar label.
+        summary.needs += 1;
+        console.log(summarizeDecision(issue, { action: 'LABEL', reason: decision.reason }));
+
+        if (apply) {
+            try {
+                addLabel(issue, BACKFILL_LABEL);
+                addLabel(issue, BLOCKED_LABEL);
+            } catch (e) {
+                summary.errors += 1;
+                console.error(`[backfill] error labeling #${issue.number}: ${e.message}`);
+            }
+        }
+    }
+
+    console.log('');
+    console.log(`[backfill-visual-baseline] resumen:`);
+    console.log(`  necesitan baseline: ${summary.needs}`);
+    console.log(`  ya tenían label:    ${summary.already_labeled}`);
+    console.log(`  qa:skipped (skip):  ${summary.skipped_qa}`);
+    console.log(`  ok (con sección):   ${summary.ok}`);
+    console.log(`  errores:            ${summary.errors}`);
+    if (!apply && summary.needs > 0) {
+        console.log('');
+        console.log('  Para aplicar los labels, re-correr con --apply');
+    }
+
+    // Persistir reporte JSON para auditoría (ops puede revisarlo después).
+    try {
+        const outDir = path.join(REPO_ROOT, '.pipeline', 'logs');
+        fs.mkdirSync(outDir, { recursive: true });
+        const reportPath = path.join(outDir, `backfill-visual-baseline-${Date.now()}.json`);
+        fs.writeFileSync(reportPath, JSON.stringify({
+            timestamp: new Date().toISOString(),
+            mode,
+            repo: repoArg,
+            summary,
+            candidates: candidates.length,
+        }, null, 2));
+        console.log(`[backfill-visual-baseline] reporte: ${reportPath}`);
+    } catch (e) {
+        // No es fatal — el log de stdout ya tiene la info.
+        console.error(`[backfill-visual-baseline] no se pudo escribir reporte: ${e.message}`);
+    }
+
+    process.exit(summary.errors > 0 ? 1 : 0);
+}
+
+if (require.main === module) {
+    main();
+}
+
+module.exports = { listCandidates, alreadyHasLabel };

--- a/.pipeline/tests/has-visual-reference.test.js
+++ b/.pipeline/tests/has-visual-reference.test.js
@@ -1,0 +1,255 @@
+// Tests de hasVisualReference (issue #3383, CA-16).
+//
+// Cubre los 7 casos del CA-16 + bordes de seguridad:
+//   1. Sección presente con 2 imágenes → ok:true
+//   2. Sección presente con 1 imagen → ok:false, reason 'needs-at-least-2-images'
+//   3. Sección presente sin imágenes → ok:false, reason 'no-images'
+//   4. Sección ausente → ok:false, reason 'section-missing'
+//   5. Issue con qa:skipped → ok:true bypass independientemente del contenido
+//   6. Body > 100KB → truncado controlado, no cuelga
+//   7. Regex no es ReDoSable (input adversarial documentado)
+//
+// Plus: variantes case-insensitive y separadores '&' / 'y' / 'and' (CA-UX-3).
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+    hasVisualReference,
+    truncateBody,
+    hasQaSkippedLabel,
+    extractSectionSlice,
+    MAX_BODY_BYTES,
+} = require('../lib/qa-evidence-gate');
+
+// ----- CA-1 / CA-16: sección presente con 2 imágenes → ok ------------------
+
+test('CA-16/1 sección con 2 imágenes adjuntas retorna ok:true', () => {
+    const body = [
+        '## Objetivo',
+        'Pantalla onboarding paso 2.',
+        '',
+        '## Screenshots & Mockups',
+        '![mockup esperado](https://user-attachments.githubusercontent.com/1/m.png)',
+        '![entrega actual](https://user-attachments.githubusercontent.com/1/e.png)',
+        '',
+        '## Criterios',
+        '- algo',
+    ].join('\n');
+    const r = hasVisualReference(body);
+    assert.equal(r.ok, true);
+    assert.equal(r.reason, 'has-visual-reference');
+    assert.equal(r.images, 2);
+});
+
+test('CA-16/1b la sección puede tener más de 2 imágenes', () => {
+    const body = [
+        '## Screenshots & Mockups',
+        '![a](x://1.png)',
+        '![b](x://2.png)',
+        '![c](x://3.png)',
+        '![d](x://4.png)',
+    ].join('\n');
+    const r = hasVisualReference(body);
+    assert.equal(r.ok, true);
+    assert.ok(r.images >= 2);
+});
+
+// ----- CA-16/2: sección con 1 imagen → fail --------------------------------
+
+test('CA-16/2 sección con 1 sola imagen retorna ok:false con reason needs-at-least-2-images', () => {
+    const body = [
+        '## Screenshots & Mockups',
+        '![mockup](https://example.com/m.png)',
+    ].join('\n');
+    const r = hasVisualReference(body);
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, 'needs-at-least-2-images');
+    assert.equal(r.images, 1);
+});
+
+// ----- CA-16/3: sección sin imágenes → fail --------------------------------
+
+test('CA-16/3 sección sin imágenes retorna ok:false reason no-images', () => {
+    const body = [
+        '## Screenshots & Mockups',
+        '',
+        'Voy a agregar las imágenes después.',
+    ].join('\n');
+    const r = hasVisualReference(body);
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, 'no-images');
+    assert.equal(r.images, 0);
+});
+
+// ----- CA-16/4: sección ausente → fail -------------------------------------
+
+test('CA-16/4 body sin sección retorna ok:false reason section-missing', () => {
+    const body = [
+        '## Objetivo',
+        '![algo](x://no-importa.png)',
+        '![otro](x://no-importa2.png)',
+        '## Criterios',
+    ].join('\n');
+    const r = hasVisualReference(body);
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, 'section-missing');
+});
+
+test('CA-16/4b body vacío retorna ok:false reason empty-body', () => {
+    assert.deepEqual(hasVisualReference(''), { ok: false, reason: 'empty-body' });
+    assert.deepEqual(hasVisualReference(null), { ok: false, reason: 'empty-body' });
+    assert.deepEqual(hasVisualReference(undefined), { ok: false, reason: 'empty-body' });
+});
+
+// ----- CA-16/5: bypass qa:skipped (CA-3) -----------------------------------
+
+test('CA-16/5 issue con label qa:skipped bypassa el gate', () => {
+    const body = 'no tiene sección ni imágenes';
+    const r = hasVisualReference(body, { labels: ['qa:skipped'] });
+    assert.equal(r.ok, true);
+    assert.equal(r.reason, 'qa-skipped');
+});
+
+test('CA-16/5b qa:skipped funciona también con shape {name}', () => {
+    const r = hasVisualReference('', { labels: [{ name: 'qa:skipped' }, { name: 'app:client' }] });
+    assert.equal(r.ok, true);
+    assert.equal(r.reason, 'qa-skipped');
+});
+
+test('CA-16/5c qa:skipped es case-insensitive', () => {
+    const r = hasVisualReference('', { labels: ['QA:Skipped'] });
+    assert.equal(r.ok, true);
+});
+
+test('hasQaSkippedLabel rechaza labels inválidas sin explotar', () => {
+    assert.equal(hasQaSkippedLabel(null), false);
+    assert.equal(hasQaSkippedLabel(undefined), false);
+    assert.equal(hasQaSkippedLabel('qa:skipped'), false); // no es array
+    assert.equal(hasQaSkippedLabel([null, undefined, 42, {}, { name: 'other' }]), false);
+});
+
+// ----- CA-16/6: body > 100KB truncado controlado ---------------------------
+
+test('CA-16/6 body > 100KB se trunca antes de parsear y no cuelga', () => {
+    // 200KB de relleno + sección al final (queda truncada).
+    const filler = 'a'.repeat(200 * 1024);
+    const body = filler + '\n## Screenshots & Mockups\n![m](x://1.png)\n![e](x://2.png)\n';
+    const t0 = Date.now();
+    const r = hasVisualReference(body);
+    const elapsed = Date.now() - t0;
+    assert.ok(elapsed < 500, `parse tardó ${elapsed}ms — debe ser <500ms incluso con body grande`);
+    // La sección quedó truncada → debe fallar como section-missing.
+    assert.equal(r.ok, false);
+});
+
+test('CA-16/6b body justo en el límite se procesa', () => {
+    const padding = 'x '.repeat(40000); // ~80KB
+    const body = padding + '\n## Screenshots & Mockups\n![m](x://1.png)\n![e](x://2.png)\n';
+    const r = hasVisualReference(body);
+    assert.equal(r.ok, true);
+});
+
+test('truncateBody respeta MAX_BODY_BYTES', () => {
+    const big = 'z'.repeat(MAX_BODY_BYTES + 1000);
+    const out = truncateBody(big);
+    assert.ok(Buffer.byteLength(out, 'utf8') <= MAX_BODY_BYTES);
+});
+
+// ----- CA-16/7: adversarial ReDoS ------------------------------------------
+
+test('CA-16/7 input adversarial ReDoS no cuelga (terminación en <500ms)', () => {
+    // Patrón clásico catastrophic backtracking en regex no-bounded:
+    //   "![" + "a".repeat(N) + "(" sin ")".
+    // Nuestro regex usa [^\]]/[^)] y exec en loop — debe terminar lineal.
+    const adversarial = '## Screenshots & Mockups\n' + '!['.repeat(5000) + 'aaaa';
+    const t0 = Date.now();
+    const r = hasVisualReference(adversarial);
+    const elapsed = Date.now() - t0;
+    assert.ok(elapsed < 500, `parse adversarial tardó ${elapsed}ms — posible ReDoS`);
+    assert.equal(r.ok, false); // no encuentra imágenes válidas
+});
+
+test('CA-16/7b adversarial con muchos brackets anidados no cuelga', () => {
+    const adversarial = '## Screenshots & Mockups\n' + ('![alt'.repeat(2000)) + '\n';
+    const t0 = Date.now();
+    const r = hasVisualReference(adversarial);
+    const elapsed = Date.now() - t0;
+    assert.ok(elapsed < 500, `parse tardó ${elapsed}ms`);
+    assert.equal(r.ok, false);
+});
+
+// ----- CA-UX-3: case-insensitive + variantes de separador ------------------
+
+test('CA-UX-3 acepta variante "Screenshots y Mockups" (español)', () => {
+    const body = [
+        '## Screenshots y Mockups',
+        '![m](x://1.png)',
+        '![e](x://2.png)',
+    ].join('\n');
+    const r = hasVisualReference(body);
+    assert.equal(r.ok, true);
+});
+
+test('CA-UX-3 acepta variante "Screenshots and Mockups"', () => {
+    const body = [
+        '## Screenshots and Mockups',
+        '![m](x://1.png)',
+        '![e](x://2.png)',
+    ].join('\n');
+    const r = hasVisualReference(body);
+    assert.equal(r.ok, true);
+});
+
+test('CA-UX-3 acepta header case-insensitive', () => {
+    const body = [
+        '## SCREENSHOTS & MOCKUPS',
+        '![m](x://1.png)',
+        '![e](x://2.png)',
+    ].join('\n');
+    const r = hasVisualReference(body);
+    assert.equal(r.ok, true);
+});
+
+test('CA-UX-3 acepta header con # adicionales (### o ####)', () => {
+    const body = [
+        '### Screenshots & Mockups',
+        '![m](x://1.png)',
+        '![e](x://2.png)',
+    ].join('\n');
+    const r = hasVisualReference(body);
+    assert.equal(r.ok, true);
+});
+
+test('imágenes después del siguiente header NO cuentan', () => {
+    const body = [
+        '## Screenshots & Mockups',
+        '![solo-una](x://1.png)',
+        '',
+        '## Criterios',
+        '![otra-fuera-de-seccion](x://2.png)',
+        '![otra-mas](x://3.png)',
+    ].join('\n');
+    const r = hasVisualReference(body);
+    assert.equal(r.ok, false);
+    assert.equal(r.images, 1);
+});
+
+// ----- extractSectionSlice helper -----------------------------------------
+
+test('extractSectionSlice corta exactamente entre headers', () => {
+    const body = [
+        '## A',
+        'aa',
+        '## Screenshots & Mockups',
+        'imgs',
+        '![m](x://1.png)',
+        '## B',
+        'bb',
+    ].join('\n');
+    const slice = extractSectionSlice(body);
+    assert.ok(slice.includes('imgs'));
+    assert.ok(slice.includes('![m](x://1.png)'));
+    assert.ok(!slice.includes('bb'));
+});

--- a/.pipeline/tests/rejection-report-visual.test.js
+++ b/.pipeline/tests/rejection-report-visual.test.js
@@ -1,0 +1,223 @@
+// Tests del bloque side-by-side mockup vs entrega en rejection-report.js
+// (Issue #3383, CA-12 / CA-13 / CA-14 / CA-UX-1..6).
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+    renderVisualComparisonBlock,
+    renderHtml,
+    generateNarration,
+    escapeHtml,
+} = require('../rejection-report');
+
+// ----- renderVisualComparisonBlock ----------------------------------------
+
+test('renderVisualComparisonBlock con null retorna vacío (no opt-in, no render)', () => {
+    assert.equal(renderVisualComparisonBlock(null), '');
+    assert.equal(renderVisualComparisonBlock(undefined), '');
+});
+
+test('renderVisualComparisonBlock incluye header VISUAL MISMATCH + ambas columnas (CA-12)', () => {
+    const out = renderVisualComparisonBlock({
+        mockup: { src: 'https://example.com/m.png' },
+        delivery: { src: 'https://example.com/e.png' },
+        diffs: [{ title: 'Botón sin gradiente', description: 'falta linear-gradient(--brand-cyan, --brand-blue)', impact: 'alto' }],
+    });
+    assert.ok(out.includes('VISUAL MISMATCH'));
+    assert.ok(out.includes('MOCKUP ESPERADO'));
+    assert.ok(out.includes('ENTREGA ACTUAL'));
+    assert.ok(out.includes('visual-col-mockup'));
+    assert.ok(out.includes('visual-col-delivery'));
+});
+
+test('renderVisualComparisonBlock muestra placeholder cuando falta src (CA-UX-4)', () => {
+    const out = renderVisualComparisonBlock({
+        mockup: {},
+        delivery: { src: 'x://e.png' },
+        diffs: [],
+    });
+    assert.ok(out.includes('MOCKUP ESPERADO no disponible'));
+    assert.ok(out.includes('visual-placeholder'));
+});
+
+test('renderVisualComparisonBlock renderiza 3 secciones (CA-13)', () => {
+    const out = renderVisualComparisonBlock({
+        mockup: { src: 'x://1.png' },
+        delivery: { src: 'x://2.png' },
+        diffs: [
+            { title: 'A', description: 'a', impact: 'alto' },
+            { title: 'B', description: 'b', impact: 'medio' },
+            { title: 'C', description: 'c', impact: 'bajo' },
+        ],
+        suggestedAction: { skill: 'android-dev', text: 'usar tokens del design-system' },
+    });
+    // (a) mockup esperado, (b) screenshot entrega, (c) diferencias identificadas
+    assert.ok(out.includes('MOCKUP ESPERADO'));
+    assert.ok(out.includes('ENTREGA ACTUAL'));
+    assert.ok(out.includes('Diferencias identificadas'));
+    // suggested action incluida
+    assert.ok(out.includes('Rebote a android-dev'));
+});
+
+test('renderVisualComparisonBlock clasifica impacto en badges (alto/medio/bajo)', () => {
+    const out = renderVisualComparisonBlock({
+        mockup: { src: 'x://1.png' },
+        delivery: { src: 'x://2.png' },
+        diffs: [
+            { title: 'A', description: 'a', impact: 'alto' },
+            { title: 'B', description: 'b', impact: 'medio' },
+            { title: 'C', description: 'c', impact: 'bajo' },
+        ],
+    });
+    // alto → badge-red, medio → badge-yellow, bajo → badge-blue
+    assert.ok(/badge-red[^"]*">impacto: alto/i.test(out));
+    assert.ok(/badge-yellow[^"]*">impacto: medio/i.test(out));
+    assert.ok(/badge-blue[^"]*">impacto: bajo/i.test(out));
+});
+
+test('renderVisualComparisonBlock limita a 5 diffs (CA §4.5 lista max 5)', () => {
+    const tenDiffs = Array.from({ length: 10 }, (_, i) => ({
+        title: `D${i}`,
+        description: `descripción ${i}`,
+        impact: 'medio',
+    }));
+    const out = renderVisualComparisonBlock({
+        mockup: { src: 'x://1.png' },
+        delivery: { src: 'x://2.png' },
+        diffs: tenDiffs,
+    });
+    // Sólo los primeros 5 deben aparecer
+    for (let i = 0; i < 5; i++) assert.ok(out.includes(`D${i}`));
+    assert.ok(!out.includes('D5'));
+    assert.ok(!out.includes('D9'));
+});
+
+test('renderVisualComparisonBlock escapa HTML del title/description (SEC-1)', () => {
+    const out = renderVisualComparisonBlock({
+        mockup: { src: 'x://1.png' },
+        delivery: { src: 'x://2.png' },
+        diffs: [{
+            title: '<script>alert(1)</script>',
+            description: '"><img onerror=foo>',
+            impact: 'alto',
+        }],
+    });
+    assert.ok(!out.includes('<script>alert(1)'));
+    assert.ok(out.includes('&lt;script&gt;'));
+});
+
+test('renderVisualComparisonBlock sin diffs muestra mensaje de revisión humana', () => {
+    const out = renderVisualComparisonBlock({
+        mockup: { src: 'x://1.png' },
+        delivery: { src: 'x://2.png' },
+        diffs: [],
+    });
+    assert.ok(out.toLowerCase().includes('revisión humana'));
+});
+
+// ----- renderHtml integration ---------------------------------------------
+
+const minimalData = {
+    issue: 1234,
+    skill: 'qa',
+    fase: 'verificacion',
+    elapsed: 60,
+    motivo: 'Visual mismatch detectado',
+    timestamp: '2026-05-20',
+    isoDate: '2026-05-20T00:00:00Z',
+    issueCtx: { title: 'Probar onboarding paso 2' },
+    rejectHistory: [],
+    logTail: '',
+    readableLog: '',
+    depIssues: { linkedDeps: [] },
+    autoCreatedDeps: [],
+    preflight: { ok: true, line: 'emulator ok' },
+    evidence: { video: null, frames: 0, logPath: null, videoBytes: 0, logBytes: 0 },
+    primaryCause: { summary: 'Botón sin gradiente', detail: 'falta brand-cyan→brand-blue', priority: 'normal' },
+    inconclusive: false,
+    sessionCtx: { provider: 'anthropic', model: 'opus-4.7', cliVersion: '0.1.0' },
+};
+
+test('renderHtml integra renderVisualComparisonBlock cuando visualComparison está presente', () => {
+    const html = renderHtml({
+        ...minimalData,
+        visualComparison: {
+            mockup: { src: 'https://example.com/m.png' },
+            delivery: { src: 'https://example.com/e.png' },
+            diffs: [{ title: 'Padding incorrecto', description: '24px → 8px', impact: 'medio' }],
+            suggestedAction: { skill: 'android-dev', text: 're-aplicar token de spacing' },
+        },
+    });
+    assert.ok(html.includes('Comparativo visual'));
+    assert.ok(html.includes('VISUAL MISMATCH'));
+    assert.ok(html.includes('Padding incorrecto'));
+});
+
+test('renderHtml omite el bloque si no hay visualComparison (backwards compat)', () => {
+    const html = renderHtml(minimalData);
+    assert.ok(!html.includes('Comparativo visual'));
+    assert.ok(!html.includes('VISUAL MISMATCH'));
+});
+
+// ----- generateNarration con visualComparison (CA-UX-5) -------------------
+
+test('generateNarration usa diffs cuando hay visualComparison (CA-UX-5, audio < 60s)', () => {
+    const text = generateNarration({
+        issue: 1234,
+        primaryCause: null,
+        inconclusive: false,
+        autoCreatedDeps: [],
+        visualComparison: {
+            mockup: { src: 'x://1.png' },
+            delivery: { src: 'x://2.png' },
+            diffs: [
+                { title: 'Botón sin gradiente de marca', description: '', impact: 'alto' },
+                { title: 'Padding 24 vs 8', description: '', impact: 'medio' },
+            ],
+            suggestedAction: { skill: 'android-dev', text: '' },
+        },
+    });
+    assert.ok(text.includes('Issue 1234'));
+    assert.ok(text.toLowerCase().includes('rechazo visual'));
+    assert.ok(text.toLowerCase().includes('botón sin gradiente'));
+    assert.ok(text.toLowerCase().includes('android-dev'));
+    // Audio < 60s ≈ < 900 chars a 150wpm
+    assert.ok(text.length < 900, `narration demasiado larga (${text.length} chars)`);
+});
+
+test('generateNarration limita a 3 diffs en audio', () => {
+    const text = generateNarration({
+        issue: 1234,
+        primaryCause: null,
+        inconclusive: false,
+        autoCreatedDeps: [],
+        visualComparison: {
+            mockup: { src: 'x' },
+            delivery: { src: 'x' },
+            diffs: [
+                { title: 'A1', impact: 'alto' },
+                { title: 'B2', impact: 'medio' },
+                { title: 'C3', impact: 'bajo' },
+                { title: 'D4', impact: 'bajo' },
+                { title: 'E5', impact: 'bajo' },
+            ],
+            suggestedAction: { skill: 'android-dev' },
+        },
+    });
+    assert.ok(text.includes('A1'));
+    assert.ok(text.includes('C3'));
+    assert.ok(!text.includes('D4'));
+    assert.ok(!text.includes('E5'));
+});
+
+test('generateNarration sin visualComparison no menciona visual', () => {
+    const text = generateNarration({
+        issue: 1234,
+        primaryCause: { summary: 'algo' },
+        inconclusive: false,
+        autoCreatedDeps: [],
+    });
+    assert.ok(!text.toLowerCase().includes('rechazo visual'));
+});

--- a/.pipeline/tests/visual-gate.test.js
+++ b/.pipeline/tests/visual-gate.test.js
@@ -1,0 +1,193 @@
+// Tests del módulo visual-gate (issue #3383):
+//   - Feature flag PIPELINE_VISUAL_GATE_ENABLED (CA-4)
+//   - shouldEvaluateVisualGate aplica sólo en desarrollo/build→verificacion con app:*
+//   - bypass qa:skipped (CA-3)
+//   - copy del comment con marker para idempotencia (CA-UX-2)
+//   - commentMarkerPresent detecta posteos previos
+//
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+    VISUAL_GATE_ENV,
+    COMMENT_MARKER,
+    NEEDS_VISUAL_BASELINE_LABEL,
+    isGateEnabled,
+    hasVisualTargetLabel,
+    shouldEvaluateVisualGate,
+    evaluateVisualGate,
+    buildBlockComment,
+    commentMarkerPresent,
+    buildGateBlockEvent,
+} = require('../lib/visual-gate');
+
+// ----- Feature flag (CA-4) -------------------------------------------------
+
+test('isGateEnabled retorna false por default (CA-4 — kill-switch)', () => {
+    assert.equal(isGateEnabled({}), false);
+    assert.equal(isGateEnabled({ [VISUAL_GATE_ENV]: '0' }), false);
+    assert.equal(isGateEnabled({ [VISUAL_GATE_ENV]: '' }), false);
+});
+
+test('isGateEnabled retorna true con flag=1', () => {
+    assert.equal(isGateEnabled({ [VISUAL_GATE_ENV]: '1' }), true);
+});
+
+// ----- hasVisualTargetLabel ------------------------------------------------
+
+test('hasVisualTargetLabel reconoce app:client | app:business | app:delivery', () => {
+    assert.equal(hasVisualTargetLabel(['app:client']), true);
+    assert.equal(hasVisualTargetLabel(['enhancement', 'app:business']), true);
+    assert.equal(hasVisualTargetLabel([{ name: 'app:delivery' }]), true);
+});
+
+test('hasVisualTargetLabel ignora labels no-visuales', () => {
+    assert.equal(hasVisualTargetLabel(['area:infra']), false);
+    assert.equal(hasVisualTargetLabel(['docs', 'area:pipeline']), false);
+    assert.equal(hasVisualTargetLabel([]), false);
+    assert.equal(hasVisualTargetLabel(null), false);
+});
+
+test('hasVisualTargetLabel matchea case-insensitive', () => {
+    assert.equal(hasVisualTargetLabel(['APP:Client']), true);
+});
+
+// ----- shouldEvaluateVisualGate -------------------------------------------
+
+test('shouldEvaluateVisualGate false cuando flag está apagado', () => {
+    assert.equal(
+        shouldEvaluateVisualGate({
+            pipelineName: 'desarrollo',
+            fromFase: 'build',
+            toFase: 'verificacion',
+            labels: ['app:client'],
+            env: {},
+        }),
+        false,
+    );
+});
+
+test('shouldEvaluateVisualGate true cuando todas las condiciones se cumplen', () => {
+    assert.equal(
+        shouldEvaluateVisualGate({
+            pipelineName: 'desarrollo',
+            fromFase: 'build',
+            toFase: 'verificacion',
+            labels: ['app:client'],
+            env: { [VISUAL_GATE_ENV]: '1' },
+        }),
+        true,
+    );
+});
+
+test('shouldEvaluateVisualGate false en pipeline definicion', () => {
+    assert.equal(
+        shouldEvaluateVisualGate({
+            pipelineName: 'definicion',
+            fromFase: 'build',
+            toFase: 'verificacion',
+            labels: ['app:client'],
+            env: { [VISUAL_GATE_ENV]: '1' },
+        }),
+        false,
+    );
+});
+
+test('shouldEvaluateVisualGate false en transición dev→build', () => {
+    assert.equal(
+        shouldEvaluateVisualGate({
+            pipelineName: 'desarrollo',
+            fromFase: 'dev',
+            toFase: 'build',
+            labels: ['app:client'],
+            env: { [VISUAL_GATE_ENV]: '1' },
+        }),
+        false,
+    );
+});
+
+test('shouldEvaluateVisualGate false sin label app:*', () => {
+    assert.equal(
+        shouldEvaluateVisualGate({
+            pipelineName: 'desarrollo',
+            fromFase: 'build',
+            toFase: 'verificacion',
+            labels: ['area:pipeline'],
+            env: { [VISUAL_GATE_ENV]: '1' },
+        }),
+        false,
+    );
+});
+
+// ----- evaluateVisualGate (passthrough a hasVisualReference) ---------------
+
+test('evaluateVisualGate delega a hasVisualReference + retorna su shape', () => {
+    const okBody = '## Screenshots & Mockups\n![m](x://1.png)\n![e](x://2.png)\n';
+    const r = evaluateVisualGate({ body: okBody, labels: ['app:client'] });
+    assert.equal(r.ok, true);
+});
+
+test('evaluateVisualGate bypassa qa:skipped (CA-3)', () => {
+    const r = evaluateVisualGate({ body: '', labels: ['qa:skipped'] });
+    assert.equal(r.ok, true);
+    assert.equal(r.reason, 'qa-skipped');
+});
+
+// ----- buildBlockComment ---------------------------------------------------
+
+test('buildBlockComment incluye el marker para idempotencia (CA-UX-2)', () => {
+    const c = buildBlockComment();
+    assert.ok(c.includes(COMMENT_MARKER));
+});
+
+test('buildBlockComment incluye instrucciones de desbloqueo y qa:skipped', () => {
+    const c = buildBlockComment();
+    assert.ok(c.includes('Screenshots & Mockups'));
+    assert.ok(c.includes('Cómo desbloquear'));
+    assert.ok(c.includes('qa:skipped'));
+    assert.ok(c.includes('needs:visual-baseline'));
+});
+
+test('buildBlockComment no usa tablas (Telegram las rompe — CA-UX §3.2)', () => {
+    const c = buildBlockComment();
+    // Las tablas markdown usan '|' al inicio de líneas y `---|---` separadores.
+    assert.ok(!/^\s*\|/m.test(c), 'no debe haber líneas que empiecen con |');
+    assert.ok(!/\|---/.test(c), 'no debe haber separadores de tabla');
+});
+
+// ----- commentMarkerPresent -----------------------------------------------
+
+test('commentMarkerPresent detecta el marker en cualquier comment previo', () => {
+    assert.equal(
+        commentMarkerPresent([
+            { body: 'sin marker' },
+            { body: `cualquier cosa\n${COMMENT_MARKER}\nmás cosa` },
+        ]),
+        true,
+    );
+});
+
+test('commentMarkerPresent retorna false si no hay marker', () => {
+    assert.equal(commentMarkerPresent([]), false);
+    assert.equal(commentMarkerPresent(null), false);
+    assert.equal(commentMarkerPresent([{ body: 'nada relevante' }]), false);
+});
+
+// ----- buildGateBlockEvent ------------------------------------------------
+
+test('buildGateBlockEvent emite shape estable para audit log', () => {
+    const ev = buildGateBlockEvent({ issue: 1234, reason: 'section-missing', images: 0 });
+    assert.equal(ev.event, 'visual-gate-block');
+    assert.equal(ev.issue, '1234');
+    assert.equal(ev.reason, 'section-missing');
+    assert.equal(ev.images, 0);
+    assert.equal(ev.decision, 'do-not-promote');
+    assert.ok(Array.isArray(ev.action));
+});
+
+test('exports estables del módulo (contrato pulpo)', () => {
+    assert.equal(NEEDS_VISUAL_BASELINE_LABEL, 'needs:visual-baseline');
+    assert.equal(VISUAL_GATE_ENV, 'PIPELINE_VISUAL_GATE_ENABLED');
+    assert.ok(typeof COMMENT_MARKER === 'string' && COMMENT_MARKER.includes('visual-gate-block'));
+});

--- a/docs/pipeline/visual-validation.md
+++ b/docs/pipeline/visual-validation.md
@@ -1,0 +1,427 @@
+# Validación visual post-construcción — Guidelines UX
+
+> **Issue origen**: #3383 (gate + rejection report side-by-side) · #3381 (workflow UX en definición).
+> **Estado**: criterios entregados por UX en fase de definición.
+> **Stack visual**: tokens en `.pipeline/assets/design-tokens.css`, iconografía en `.pipeline/assets/icons/sprite.svg`, mockup de referencia en `.pipeline/assets/mockups/19-rejection-visual-comparison.svg`.
+
+Este documento define **cómo se ve y se siente** la validación visual post-construcción
+en el pipeline V3. Es la fuente UX para que `pipeline-dev` implemente el gate y el
+bloque comparativo del rejection report sin tener que inventar paleta, jerarquía,
+ni tono de los mensajes. **El dev ubica, vos no diseñás**.
+
+Las decisiones de gate, feature flag, backfill y tests viven en los CA del issue
+#3383 (consolidados por PO). Acá vivimos los criterios **visuales y de copy** que
+todavía no están especificados.
+
+## 1. Protocolo end-to-end (vista UX)
+
+```
+┌─────────────┐    ┌─────────────┐    ┌─────────────┐    ┌─────────────┐
+│ Definición  │───▶│  Desarrollo │───▶│     QA      │───▶│  Validación │
+│             │    │             │    │             │    │      PO     │
+│ UX adjunta  │    │ dev imple-  │    │ captura     │    │ aprueba o   │
+│  mockup     │    │  menta      │    │ entrega +   │    │ rebota con  │
+│  esperado   │    │  contra el  │    │ compara vs  │    │ rejection   │
+│  (#3381)    │    │   mockup    │    │   mockup    │    │  report     │
+└─────────────┘    └─────────────┘    └─────────────┘    └─────────────┘
+       │                                      │                  │
+       │  gate hasVisualReference             │  side-by-side    │
+       └──────────────────────────────────────┴──────────────────┘
+                       evidencia visual obligatoria
+```
+
+Tres superficies UX deben quedar resueltas:
+
+| Superficie | Responsable de la spec | Consumido por |
+|---|---|---|
+| **Sección "Screenshots & Mockups" en issue body** | UX (§2 de este doc) | gate `hasVisualReference` |
+| **Comment de bloqueo en GitHub cuando el gate rechaza** | UX (§3 de este doc) | `pulpo.js` al promover |
+| **Bloque side-by-side en rejection report PDF** | UX (§4 de este doc + mockup 19) | `rejection-report.js` |
+
+## 2. Spec de la sección `Screenshots & Mockups`
+
+### 2.1 Plantilla obligatoria
+
+UX adjunta esta sección en el body del issue durante refinamiento. El gate
+valida presencia + 2 imágenes mínimas (CA-1 del issue #3383).
+
+```markdown
+## Screenshots & Mockups
+
+### Mockup esperado
+
+![Mockup esperado — paso N](https://user-attachments.githubusercontent.com/.../mockup-paso-N.png)
+
+> **Fuente**: Claude Design (claude.ai/design) · sesión 2026-MM-DD · v1.
+> **Pantalla cubierta**: <nombre de la pantalla> · flavor <client|business|delivery>.
+> **Tokens aplicados**: `--brand-cyan`, `--brand-blue`, `--text-primary`, `--surface-1`.
+> **Baseline declarado**: sí · cambios futuros requieren re-confirmación UX (CA-15).
+
+### Entrega esperada vs casos borde
+
+![Estado vacío](https://user-attachments.githubusercontent.com/.../estado-vacio.png)
+![Estado con datos largos](https://user-attachments.githubusercontent.com/.../datos-largos.png)
+
+> Casos cubiertos: feliz, vacío, error, carga, datos largos (texto > 60 chars).
+```
+
+### 2.2 Reglas del adjunto
+
+- **Mínimo 2 imágenes** dentro de la sección (CA-1). Si la pantalla tiene 4 estados
+  visuales (feliz, vacío, error, carga), adjuntar las 4 — no asumir que el dev
+  inferirá los estados que faltan.
+- **Formato**: PNG o SVG. Prohibido JPG con artefactos por compresión, gifs.
+- **Tamaño máximo por imagen**: 2 MB (límite de GitHub).
+- **Resolución mínima**: 720×1280 para pantallas mobile, 1280×720 para tablet/desktop.
+- **Densidad declarada**: si el flavor tiene assets en múltiples densidades, declarar
+  cuál se está mostrando (`xhdpi`, `xxhdpi`, etc.).
+- **Sin marcadores temporales**: el mockup no debe tener texto tipo "draft v3",
+  "WIP", "DOC-12". Si el mockup no está cerrado, NO va al issue todavía.
+
+### 2.3 Política de invalidación (CA-15 del issue #3383)
+
+Cuando un issue se rebota desde cualquier fase a definición, el mockup **se
+considera stale automáticamente**. UX debe re-confirmar antes de que el issue
+salga otra vez:
+
+- Re-confirmación sin cambios: agregar comment `✓ mockup re-confirmado YYYY-MM-DD`.
+- Regeneración con cambios: agregar comment `⟳ mockup regenerado YYYY-MM-DD` +
+  reemplazar las imágenes en la sección.
+
+El gate NO valida la frescura — depende del juicio de UX en el rebote. La trazabilidad
+queda en los comments.
+
+### 2.4 Bypass legítimo
+
+Issues marcados con `qa:skipped` (infra pura, docs, refactor sin UI) **bypassan el
+gate por whitelist explícita** (CA-3). UX no necesita adjuntar mockups en esos casos.
+Si dudás si tu issue es `qa:skipped`, lee `CLAUDE.md → "Tipos de issue y criterio QA"`.
+
+## 3. Spec del comment de bloqueo del gate
+
+Cuando `hasVisualReference` retorna `ok: false`, el pulpo postea un comment en el
+issue. La copy es **clave UX**: el dev/UX que lo lea debe entender qué falta y
+cómo desbloquear en menos de 30 segundos.
+
+### 3.1 Comment exacto (case-sensitive con emoji)
+
+```
+❌ Validación visual bloqueada — falta evidencia en la definición
+
+Este issue tiene labels `app:*` o toca superficies con UI, pero el body no
+incluye la sección **Screenshots & Mockups** con al menos 2 imágenes adjuntas.
+
+QA no puede comparar la entrega contra una referencia que no existe, así que
+el pipeline lo devuelve a definición.
+
+**Cómo desbloquear**:
+1. Volver a refinamiento con `/doc refinar #<issue>` o `/ux #<issue>`.
+2. UX adjunta mockup esperado + estados borde siguiendo
+   [`docs/pipeline/visual-validation.md §2`](../../docs/pipeline/visual-validation.md#2-spec-de-la-sección-screenshots--mockups).
+3. Volver a someter (el label `needs:visual-baseline` se quita automáticamente
+   cuando el gate verifica que ya hay sección + 2 imágenes).
+
+Si este issue NO necesita validación visual (infra pura, docs, refactor sin UI),
+agregá label `qa:skipped` con justificación escrita en un comment.
+
+> _Bloqueado por_ `PIPELINE_VISUAL_GATE_ENABLED=1` · gate `hasVisualReference` · `.pipeline/lib/qa-evidence-gate.js`.
+```
+
+### 3.2 Reglas de copy
+
+- **Tono**: directo, sin pasivo-agresivo. "Falta evidencia" — no "te olvidaste".
+- **Acción primero, justificación después**: el "cómo desbloquear" va antes de la
+  letra chica del feature flag.
+- **Sin emojis decorativos en medio del texto**: solo el `❌` del título como
+  semáforo. El resto es texto liso para que sea legible si Telegram lo replica.
+- **Markdown válido**: bullets, negritas y link al doc. NO usar tablas (Telegram
+  las rompe).
+- **Idempotencia**: si el gate vuelve a fallar dos veces seguidas, el bot debe
+  detectar duplicado y NO postear el mismo comment dos veces (sino el issue se
+  contamina). Edición del comment existente con timestamp en lugar de duplicar.
+
+### 3.3 Labels que el gate aplica
+
+- `needs:visual-baseline` (amarillo) — falta sección, esperando UX/dev.
+- `bloqueado-humano` (rojo) — se mantiene hasta que el gate vuelve a pasar.
+
+Cuando el gate vuelve a verificar y pasa, ambos labels se remueven en la misma
+operación API (CA-2 + atomicidad sugerida por security).
+
+## 4. Spec del bloque side-by-side en el rejection report PDF
+
+Implementación visual del bloque comparativo dentro de `rejection-report.js`
+cuando QA detecta visual mismatch. Referencia visual completa en
+`.pipeline/assets/mockups/19-rejection-visual-comparison.svg`.
+
+### 4.1 Layout
+
+| Zona | Posición | Notas |
+|---|---|---|
+| Header del reporte | Top — full width 120px alto | Logo + identidad + veredicto "VISUAL MISMATCH" en danger |
+| Issue title + meta | Bajo el header, padding 48px | Badges: fase, provider/model, app:*, timestamp |
+| Bloque comparativo | Dos columnas 50/50 con gap 24px | Altura igualada, sin scroll interno |
+| Diferencias narradas | Full width, lista vertical | 3-5 items con badge numerado |
+| Acciones sugeridas | Full width, fondo `--success-bg` | A quién rebota + cómo arreglar |
+| Footer | Bottom 1px border | Sanitización confirmada + checksum |
+
+### 4.2 Tokens aplicados (consumir desde `design-tokens.css` ya existente)
+
+```
+Header
+  background: linear-gradient(180deg, --brand-navy → --brand-navy-deep)
+  border-bottom: 1px solid --border
+
+Veredicto VISUAL MISMATCH (top-right)
+  background: rgba(248, 81, 73, 0.14)   /* --danger-bg */
+  border: 1px solid --danger-dim
+  text-color: --semantic-danger          /* #F85149 */
+  font-weight: 700 · font-size: 14px
+
+Columna izquierda (mockup esperado)
+  background: --surface-1
+  border: 1px solid --border
+  header-background: --surface-2
+  header-icon: circle 6px --info        /* #58A6FF */
+
+Columna derecha (entrega actual — la que difiere)
+  background: --surface-1
+  border: 1px solid --danger-dim         /* MARCA distintiva: borde rojo */
+  header-background: rgba(248, 81, 73, 0.14)
+  header-icon: circle 6px --danger
+
+Diff markers (números 1, 2, 3 sobre la entrega)
+  circle radius 14px (ó 8px en overlay denso)
+  fill: --semantic-danger
+  text: --surface-0 (alto contraste sobre rojo)
+  border: 1.5px solid --surface-0 para que se separen del fondo
+```
+
+### 4.3 Etiquetas obligatorias
+
+- Columna izquierda: `MOCKUP ESPERADO` (uppercase, letter-spacing 1px, weight 700)
+  + subtítulo `adjunto en definición · UX · YYYY-MM-DD`.
+- Columna derecha: `ENTREGA ACTUAL` + subtítulo `captura QA (emulador|playwright) · YYYY-MM-DD HH:MM`.
+- Badge en cada columna a la derecha del header:
+  - Izquierda verde: `baseline · v<N>`.
+  - Derecha roja: `no matchea`.
+
+**Nunca** usar solo el color para diferenciar las columnas — la etiqueta textual y
+el icono de status son obligatorios (criterio de accesibilidad: información no
+debe codificarse solo por color, ver design-system.md §1.3).
+
+### 4.4 Altura del bloque comparativo
+
+- Altura fija calculada: el contenido de cada columna debe **rellenar exactamente
+  la misma altura** para que el ojo compare 1:1.
+- Si el mockup esperado tiene aspect-ratio distinto del screenshot capturado
+  (común: mockup 9:16 mobile vs screenshot 16:9 dashboard), se renderiza dentro de
+  un frame de proporción fija con `object-fit: contain` + fondo `--surface-2` para
+  el padding. Sin estirar, sin recortar.
+- Si una columna no tiene imagen (ej. mockup falta o screenshot falló), reemplazar
+  por placeholder pattern (ver mockup 19 — pattern diagonal sobre `--surface-2`) y
+  banda roja explicativa: `⚠ <columna> no disponible: <motivo>`.
+
+### 4.5 Diferencias narradas
+
+Lista vertical, máximo 5 items por reporte (si hay más, agrupar). Cada item:
+
+```
+┌────────────────────────────────────────────────────────────────────┐
+│ ⓞ  Título breve del defecto (max 70 chars · weight 700 · 14px)    │
+│    Descripción objetivable (medible o referenciable a tokens · 12px)│
+│    Impacto · <bajo|medio|alto> · efecto sobre el usuario · 11px    │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+- **Título**: empieza con el componente afectado, no con la corrección. Ej:
+  bien — *"CTA Continuar sin gradiente de marca"*; mal — *"Cambiar el CTA"*.
+- **Descripción**: cita números concretos o tokens. Ej: *"radius 22 (pill) → la
+  entrega usa 6"*. Prohibido *"se ve mal"*, *"queda raro"*, *"medio feo"*.
+- **Impacto**: clasificar en `bajo`/`medio`/`alto` para que el dev priorice.
+  El criterio:
+  - `alto`: bloquea o degrada la acción principal del usuario.
+  - `medio`: afecta jerarquía/legibilidad sin bloquear.
+  - `bajo`: cosmético (ej. shadow ligeramente distinta).
+
+### 4.6 Acciones sugeridas
+
+Bloque verde `--success-bg` al pie del reporte. Estructura:
+
+```
+→ Rebote a <skill>
+
+Re-implementar <descripción acotada> respetando: <tokens|patrones|referencia>.
+Referencia bloqueante: mockup esperado (<fecha>, <baseline vN>).
+
+Después de re-implementar:
+1. QA captura nuevo screenshot.
+2. Re-corre comparación contra el mismo mockup.
+3. Si el dev modifica el mockup esperado en vez de la entrega, UX debe
+   re-confirmar (CA-15).
+4. Si el dev cree que la entrega es la versión correcta, abre comment en el
+   issue antes de tocar y dispute con UX.
+```
+
+La acción sugerida es **no normativa** — es una pista. El veredicto final lo
+toma PO. Pero ahorra 5-10 minutos al dev que recibe el rebote.
+
+## 5. Checklist UX para QA durante la captura
+
+QA, cuando captura el screenshot para comparar:
+
+- [ ] **Misma resolución** que el mockup esperado (o aspect-ratio compatible).
+- [ ] **Mismo estado del flujo** que el mockup muestra (no comparar pantalla feliz
+      vs estado vacío del mockup — si el mockup muestra estado feliz, capturar el
+      mismo estado feliz).
+- [ ] **Sin overlays de debug** activos (no DevTools, no Compose layout inspector,
+      no debug strokes).
+- [ ] **Sin datos sensibles visibles**: JWT en headers, tokens en debug overlay,
+      emails reales del usuario QA. Si aparecen, sanitizar con `redact()` ANTES
+      de adjuntar al rejection report (CA-9 del issue #3383).
+- [ ] **Densidad declarada** en el filename: `screenshot-xxhdpi-2026-05-20.png`.
+- [ ] **Capturar nativo** (no recortar a mano): `adb exec-out screencap` para
+      Android, Playwright `page.screenshot()` para dashboard. Sin tijeras
+      manuales que rompen el aspect ratio.
+
+## 6. Checklist UX para PO durante validación visual
+
+PO, cuando aprueba o rebota el visual:
+
+- [ ] **Los 3-5 hallazgos narrados son objetivables** (cita tokens / números /
+      patrones). Si son *"no me gusta"*, escalar a UX antes de aprobar el rebote
+      al dev — no rebotamos al dev con feedback subjetivo.
+- [ ] **El veredicto matchea con el impacto** declarado: si todos los hallazgos
+      son `bajo`, el visual probablemente es aceptable y la decisión es WONTFIX
+      en lugar de rebote.
+- [ ] **El mockup sigue vigente** (no fue invalidado en un rebote anterior). Si
+      hubo rebote sin re-confirmación de UX, primero pedir re-confirmación.
+- [ ] **No hay duplicados con rebotes anteriores**: si el mismo defecto fue
+      reportado en el rebote previo y "arreglado", evaluar si el dev no entendió
+      o si el mockup es ambiguo. En ese caso UX aclara antes del próximo rebote.
+- [ ] **Audio narrado adjunto** al rejection report PDF (memoria
+      `feedback_rejection-report-audio.md` + CA-14 del issue).
+
+## 7. Criterios de aceptación adicionales que UX adiciona (no duplican PO)
+
+Estos son **suplementarios** a los 20 CA del comment de PO en el issue. No los
+duplican — los profundizan en la dimensión UX. El dev que implemente debe
+satisfacerlos para que UX apruebe en fase de `validacion`.
+
+- [ ] **CA-UX-1** — El bloque side-by-side en el PDF usa tokens del archivo
+      `.pipeline/assets/design-tokens.css` (NO redefine paleta inline). Aceptar
+      que `rejection-report.js` hoy usa CSS inline propio — esta es la oportunidad
+      de migrar los bloques nuevos a tokens. Bloques viejos del reporte que ya
+      están con inline no es responsabilidad de #3383.
+- [ ] **CA-UX-2** — El comment de bloqueo se postea como **edición** del comment
+      previo cuando el gate vuelve a fallar (no como nuevo). Marker en el body
+      `<!-- visual-gate-block -->` para identificar.
+- [ ] **CA-UX-3** — La sección `Screenshots & Mockups` se valida con regex
+      **case-insensitive** del título (`/^##\s+screenshots\s*[&y]\s*mockups/im`)
+      y la regex acepta variantes `Screenshots y Mockups`, `Screenshots & Mockups`.
+- [ ] **CA-UX-4** — Cuando el mockup falta en una columna del PDF (ej. el dev
+      eliminó la imagen original del issue), reemplazar por placeholder pattern
+      diagonal (ver mockup 19) + banda explicativa. NO dejar columna en blanco
+      ni columna a mitad de altura.
+- [ ] **CA-UX-5** — El audio narrado del rejection report (memoria
+      `feedback_rejection-report-audio.md`) debe leer las **diferencias** y la
+      **acción sugerida**, no el rejection report entero. Mantener < 60s.
+- [ ] **CA-UX-6** — Mockup 19 (`.pipeline/assets/mockups/19-rejection-visual-comparison.svg`)
+      es la **referencia visual obligatoria** para implementar el bloque. El dev
+      no inventa proporciones, padding ni colores — sigue el mockup o pregunta a
+      UX si encuentra ambigüedad.
+
+## 8. Anti-patrones a evitar
+
+- **Diff visual automatizado en MVP**: ya argumentado por guru (#3403 lo cubre
+  como fase 2). El mockup viene de Chromium-render, la entrega de Compose-render
+  — el sub-pixel/AA/kerning generaría 30%+ de falsos rebotes. Empezamos con
+  revisión humana.
+- **Mockups en JPG con compresión**: pierde bordes finos, anti-alias, colores
+  exactos. Prohibido en la sección obligatoria.
+- **Mockups generados por el mismo dev que implementa**: conflicto de interés —
+  el dev "ve" el mockup como ya implementado. La memoria
+  `feedback_ux-claude-design-obligatorio.md` exige Claude Design (claude.ai/design)
+  para mockups, no placeholders simples.
+- **Rebotar con "no se ve bien"**: cualquier rebote visual sin 3-5 hallazgos
+  objetivables (con tokens / números) es válido para que el dev escale a UX +
+  PO + Leo. UX no acepta rebotes basados en gusto sin justificación.
+- **Validar contra un mockup invalidado**: si UX no re-confirmó después del último
+  rebote, el mockup está stale (CA-15). PO debe pedir re-confirmación antes de
+  rebotar.
+- **Capturas con datos del usuario QA reales**: el screenshot pasa por GitHub
+  attachments y Telegram. JWT visible, emails reales o números de tarjeta de
+  prueba quedarían públicos. Siempre `redact()` antes de persistir.
+
+## 9. Referencias cruzadas
+
+- `.pipeline/assets/design-tokens.css` — fuente de verdad de paleta + tipografía.
+- `.pipeline/assets/icons/sprite.svg` — iconografía del pipeline (mismo sprite
+  para dashboard, PDF y Telegram-via-PNG).
+- `.pipeline/assets/mockups/19-rejection-visual-comparison.svg` — referencia
+  visual obligatoria del bloque side-by-side de este feature.
+- `docs/pipeline/design-system.md` — guidelines completas del sistema visual
+  (paleta, contraste, tipografía, espaciados, iconos).
+- `.pipeline/lib/qa-evidence-gate.js` — módulo donde el dev incorpora
+  `hasVisualReference` (CA-1 del issue #3383).
+- `.pipeline/rejection-report.js` — módulo donde el dev incorpora el bloque
+  side-by-side (CA-12 del issue #3383).
+- `CLAUDE.md → "Tipos de issue y criterio QA"` — whitelist para bypass por
+  `qa:skipped`.
+- Memorias relacionadas:
+  - `feedback_ux-claude-design-obligatorio.md` — mockups SIEMPRE con Claude Design.
+  - `feedback_rejection-report-audio.md` — audio narrado obligatorio.
+  - `feedback_rejection-reports-detail.md` — detalle no-técnico, contexto del
+    feature, clasificación de causa.
+- Issues recomendación (NO bloquean #3383, aprobación humana):
+  - #3403 — Diff visual automatizado (pixelmatch + tolerancia) como fase 2.
+  - #3404 — Telemetría de fallos visuales por skill.
+  - #3405 — Galería histórica de mockups aprobados como baseline cross-screen.
+
+## 10. Operación del gate — activación, rollback, backfill
+
+### 10.1 Feature flag (CA-4, CA-5)
+
+El gate vive detrás de `PIPELINE_VISUAL_GATE_ENABLED`. Default **OFF** mientras
+#3381 no esté mergeado a `main`. Una vez en main:
+
+- **Activar** (PowerShell del host del pulpo):
+  ```powershell
+  $env:PIPELINE_VISUAL_GATE_ENABLED = '1'
+  node .pipeline/restart.js
+  ```
+- **Desactivar** (kill-switch sin redeploy):
+  ```powershell
+  $env:PIPELINE_VISUAL_GATE_ENABLED = '0'
+  node .pipeline/restart.js
+  ```
+
+El restart del pulpo es no destructivo: los archivos en
+`desarrollo/build/listo/` siguen ahí y se re-evalúan con el nuevo valor del flag
+en el siguiente barrido. Los labels `needs:visual-baseline` ya aplicados NO se
+limpian automáticamente al desactivar (mantienen el contexto del rebote).
+
+### 10.2 Backfill pre-activación (CA-6)
+
+Antes de mover el flag a `1` por primera vez, correr:
+
+```bash
+node .pipeline/scripts/backfill-visual-baseline.js          # dry-run
+node .pipeline/scripts/backfill-visual-baseline.js --apply  # ejecuta
+```
+
+El script lista todos los issues OPEN con label `app:*` cuyo body no tiene
+sección `## Screenshots & Mockups` con 2+ imágenes y les aplica los labels
+`needs:visual-baseline` + `bloqueado-humano`. Es idempotente: si el issue ya
+tiene la sección o el label, no hace nada.
+
+Reporte de auditoría: `.pipeline/logs/backfill-visual-baseline-<ts>.json`.
+
+### 10.3 Criterios de rollback
+
+Activar el kill-switch si:
+- Tasa de falsos rebotes > 30% en una ventana de 50 validaciones (medible vía
+  `#3404` cuando esté implementado, o manualmente).
+- Bug del gate bloquea promoción de issues legítimos (sección y mockups
+  presentes pero gate retorna `ok: false`).
+- Bloqueo cascada por dependencia rota con #3381.


### PR DESCRIPTION
## Resumen

Implementa el gate de validación visual mockup vs entrega que se ejecuta entre build y verificación, con los validadores PO/QA/UX consumiendo evidencia gráfica obligatoria.

## Alcance del cambio

Cambios 100% en pipeline + skills + docs. **No toca código de las apps.**

- `.pipeline/lib/qa-evidence-gate.js` — nuevo gate de evidencia QA
- `.pipeline/lib/visual-gate.js` — gate de comparación visual
- `.pipeline/pulpo.js` — wiring del gate (98 líneas)
- `.pipeline/rejection-report.js` — extiende reporte con sección visual (124 líneas)
- `.pipeline/scripts/backfill-visual-baseline.js` — script de backfill (180 líneas)
- `.pipeline/tests/` — 3 suites Node nuevas (671 líneas)
- `.claude/skills/{po,qa,ux}/SKILL.md` — actualización de instrucciones de validadores
- `docs/pipeline/visual-validation.md` — documentación del flujo (427 líneas)
- `docs/mockups/19-rejection-visual-comparison.svg` — mockup de referencia

**Total:** 13 archivos, +2193 / -1.

## QA

Gate `qa:skipped` aplicado — justificación detallada en el [comentario del issue](https://github.com/intrale/platform/issues/3383#issuecomment-4507483466).

Motivo: el issue lleva labels `app:*` porque el feature objetivo del gate cubre las apps, pero el diff real es 100% pipeline + docs (0 líneas en `app/composeApp/**`). Encaja en el caso explícito "Infra/hooks internos sin impacto en producto" definido en CLAUDE.md.

Validaciones ya aprobadas durante el ciclo Ola N+8:
- Dev: commit `5d254dce` — 53/53 tests
- Build: smart, 234 ms
- UX validator: 16 pasadas consecutivas sin drift
- PO + Guru: aprobados

## Causa raíz del workaround

El issue se trabó 3 veces en el circuit breaker APK porque el clasificador de evidencia consulta labels en vez del diff real. Fix tracked en #3450 (Reclasificador de evidencia QA: priorizar diff real sobre labels) — agendado para próxima ola.

## Test plan

- [x] Build smart: pasa (234 ms, no hay nada que compilar de Kotlin)
- [x] Tests Node nuevos: 53/53 verdes
- [x] UX validator: cero drift visual contra mockup
- [x] PO + Guru: criterios de aceptación verificados
- [ ] Reviewer humano (Leo): verificación final pre-merge

Closes #3383