### PR TITLE
[Split de #3382] Hook QA post-ejecución que promueve screenshots a librería app-screenshots-reference

### DIFF
--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -356,6 +356,32 @@ Generar `qa/evidence/<issue>/qa-report.json` siguiendo el template de `docs/qa-t
 
 Usar `Write` tool para escribir el `qa-report.json`.
 
+## Paso V7c: Promoción de screenshots a librería (issue #3409)
+
+Después de escribir `qa-report.json`, si el `verdict` quedó `APROBADO` y el branch corresponde a un issue con label `app:client | app:business | app:delivery`, invocar el hook de promoción:
+
+```bash
+node qa/scripts/promote-screenshots.js \
+  --issue "$ISSUE_NUM" \
+  2>&1 | tail -20
+```
+
+El hook es **idempotente** y **fail-safe**:
+
+- Detecta PNGs en `qa/evidence/<issue>/`, los mapea a pantalla canónica + flavor, y copia atómicamente a `docs/app-screenshots-reference/<pantalla>/<pantalla>-<flavor>-<YYYY-MM-DD>.png`.
+- Si la política PII de #3385 no está disponible (módulo `qa/lib/pii-policy.js` ausente, contrato roto, o lanza al cargar), **NO promueve nada** y registra `PII policy unavailable — promotion skipped`. El repo es público — default seguro.
+- Si la librería `docs/app-screenshots-reference/` no existe en `main`, el hook falla con `screenshots-reference library missing — depends on #3407`. **NO crea la estructura on-demand** (eso es scope de #3407).
+- Re-ejecutar sobre el mismo run no duplica archivos: el hook compara hashes y emite `promoted 0 screenshots (already in library)`.
+- Logs accionables esperados:
+  - `promoted N screenshots to library` — happy path.
+  - `promoted 0 screenshots (already in library)` — idempotencia.
+  - `overwritten same-day screenshot <pantalla>/<flavor>` — versión nueva sobre la misma fecha.
+  - `PII detected — promotion skipped: <filename>` — flags PII activos.
+  - `PII policy unavailable — promotion skipped` — política no importable.
+  - `unmapped: <filename>` — el filename no mapeó a pantalla canónica (no aborta).
+
+El hook **no aborta** el QA: cualquier skip queda registrado para trazabilidad y el exit code sigue 0. Ver `docs/qa/screenshot-promotion.md` para el detalle operativo y la lista de heurísticas filename → pantalla canónica.
+
 ## Paso V7b: Enviar videos a Telegram
 
 Best-effort, no aborta el reporte:

--- a/.pipeline/skills-deterministicos/__tests__/tester.test.js
+++ b/.pipeline/skills-deterministicos/__tests__/tester.test.js
@@ -561,9 +561,14 @@ test('#3092 rev-1 — isPipelineOnlyChange NO acepta otros subdirectorios de qa/
     // deben caer en pipeline-only:
     //   qa/build.gradle.kts         → módulo Gradle real (afecta build)
     //   qa/src/test/                → código Kotlin/JS de test
-    //   qa/scripts/                 → scripts de QA ejecutados por gradlew
+    //   qa/scripts/*.sh             → scripts shell de QA (pueden orquestar gradle)
     //   qa/test-cases/<id>.json     → casos consumidos por scripts QA
     //   qa/regression-suite.json    → catálogo de regresión
+    //
+    // Frontera afinada por rebote #3409: los archivos .js/.mjs/.cjs bajo
+    // `qa/scripts/` ahora SÍ caen en pipeline-only (son hooks Node.js
+    // puros que no consume Gradle), pero el resto sigue forzando ruta
+    // gradle. El test `#3409 rev-1` documenta el nuevo branch positivo.
     assert.equal(tester.isPipelineOnlyChange([
         '.pipeline/config.yaml',
         'qa/build.gradle.kts',
@@ -583,6 +588,67 @@ test('#3092 rev-1 — isPipelineOnlyChange NO acepta otros subdirectorios de qa/
     assert.equal(tester.isPipelineOnlyChange([
         '.pipeline/config.yaml',
         'qa/regression-suite.json',
+    ]), false);
+});
+
+// ── Rebote #3409 rev-1 ────────────────────────────────────────────────
+// El hook `qa/scripts/promote-screenshots.js` (Node.js puro, 434 líneas)
+// + sus 18 tests bajo `qa/scripts/__tests__/promote-screenshots.test.js`
+// + `.claude/skills/qa/SKILL.md` modificado + `docs/qa/screenshot-promotion.md`
+// + `package.json` formaron un cambio puramente pipeline-only que el
+// tester clasificó como mixto porque los .js bajo `qa/scripts/` no
+// matcheaban ningún pattern. Resultado: ruta gradle, 0 JUnit reports,
+// rebote por "No se encontraron reportes JUnit".
+//
+// Verificación de seguridad: `grep` por `qa/scripts` en `**/*.gradle*`
+// devuelve 0 referencias — Gradle no consume estos scripts; los invoca
+// el skill /qa (Node.js).
+test('#3409 rev-1 — isPipelineOnlyChange acepta qa/scripts/*.js y __tests__/*.test.js', () => {
+    // Hook Node.js bajo qa/scripts/ → pipeline-only.
+    assert.equal(tester.isPipelineOnlyChange([
+        'qa/scripts/promote-screenshots.js',
+    ]), true);
+    // Test del hook bajo qa/scripts/__tests__/ → pipeline-only.
+    assert.equal(tester.isPipelineOnlyChange([
+        'qa/scripts/__tests__/promote-screenshots.test.js',
+    ]), true);
+    // Variantes .mjs / .cjs también caen en pipeline-only.
+    assert.equal(tester.isPipelineOnlyChange([
+        'qa/scripts/some-hook.mjs',
+    ]), true);
+    assert.equal(tester.isPipelineOnlyChange([
+        'qa/scripts/legacy-hook.cjs',
+    ]), true);
+    // Caso real del rebote #3409: 5 archivos exactos del diff vs origin/main.
+    assert.equal(tester.isPipelineOnlyChange([
+        '.claude/skills/qa/SKILL.md',
+        'docs/qa/screenshot-promotion.md',
+        'package.json',
+        'qa/scripts/__tests__/promote-screenshots.test.js',
+        'qa/scripts/promote-screenshots.js',
+    ]), true);
+});
+
+test('#3409 rev-1 — isPipelineOnlyChange mantiene la frontera #3092 para shells/configs/casos QA', () => {
+    // Los .sh bajo qa/scripts/ siguen forzando ruta gradle: pueden orquestar
+    // ejecuciones gradle/emulador y un cambio ahí debe verificarse en flujo
+    // QA real, no por tests Node aislados.
+    assert.equal(tester.isPipelineOnlyChange([
+        'qa/scripts/qa-android.sh',
+    ]), false);
+    assert.equal(tester.isPipelineOnlyChange([
+        'qa/scripts/promote-screenshots.js',
+        'qa/scripts/qa-android.sh',
+    ]), false);
+    // Subdirectorios anidados que NO son __tests__/ y archivos sin extensión
+    // .js/.mjs/.cjs no califican (defensa contra typos / archivos opacos).
+    assert.equal(tester.isPipelineOnlyChange([
+        'qa/scripts/promote-screenshots',  // sin extensión
+    ]), false);
+    // qa/scripts/ anidado dentro de un módulo NO debe disparar pipeline-only
+    // (mismo ancla a raíz que el resto de patrones #3092/#2398).
+    assert.equal(tester.isPipelineOnlyChange([
+        'app/qa/scripts/foo.js',
     ]), false);
 });
 
@@ -733,6 +799,65 @@ test('findNodeTestFiles — encuentra *.test.js dentro de .pipeline/ y excluye n
     assert.ok(found.includes('.pipeline/metrics/__tests__/b.test.js'));
     assert.ok(!found.some((f) => f.includes('node_modules')), 'node_modules debe estar excluido');
     assert.ok(!found.some((f) => f.includes('desarrollo')), 'desarrollo/ debe estar excluido');
+});
+
+// Rebote #3409 rev-1: el tester corre `node --test` sobre los archivos que
+// findNodeTestFiles le devuelve. Sin esta extensión, los 18 tests del hook
+// `qa/scripts/promote-screenshots.js` no se ejecutaban en la ruta
+// pipeline-only y el tester aprobaba como qa:skipped sin haber corrido tests
+// reales. Acá validamos que el segundo root (`qa/scripts/__tests__/`) se
+// escanea de forma simétrica a `.pipeline/`.
+test('#3409 rev-1 — findNodeTestFiles escanea también qa/scripts/__tests__/', () => {
+    // Crear un repo fresco para no contaminar con tests de los otros casos.
+    const fresh = fs.mkdtempSync(path.join(os.tmpdir(), 'v3-tester-3409-'));
+    // .pipeline/ test
+    fs.mkdirSync(path.join(fresh, '.pipeline', 'tests'), { recursive: true });
+    fs.writeFileSync(path.join(fresh, '.pipeline', 'tests', 'pipe.test.js'), '// pipeline test');
+    // qa/scripts/__tests__/ test (objetivo del rebote)
+    fs.mkdirSync(path.join(fresh, 'qa', 'scripts', '__tests__'), { recursive: true });
+    fs.writeFileSync(
+        path.join(fresh, 'qa', 'scripts', '__tests__', 'promote-screenshots.test.js'),
+        '// qa script test'
+    );
+    // Archivos no-test bajo qa/scripts/__tests__/ → ignorados (no terminan en .test.js)
+    fs.writeFileSync(
+        path.join(fresh, 'qa', 'scripts', '__tests__', 'helpers.js'),
+        '// helper, sin sufijo .test.js'
+    );
+    // qa/scripts/promote-screenshots.js (NO está en __tests__/) → ignorado
+    fs.writeFileSync(
+        path.join(fresh, 'qa', 'scripts', 'promote-screenshots.js'),
+        '// hook implementation, no tests'
+    );
+    // qa/evidence/ no debe contar como root de tests (no es escaneado).
+    fs.mkdirSync(path.join(fresh, 'qa', 'evidence', '3409'), { recursive: true });
+    fs.writeFileSync(
+        path.join(fresh, 'qa', 'evidence', '3409', 'stray.test.js'),
+        '// no debe levantarse'
+    );
+
+    const found = tester.findNodeTestFiles(fresh).map((f) => path.relative(fresh, f).replace(/\\/g, '/'));
+    assert.ok(found.includes('.pipeline/tests/pipe.test.js'),
+        `esperaba .pipeline/tests/pipe.test.js, fue: ${JSON.stringify(found)}`);
+    assert.ok(found.includes('qa/scripts/__tests__/promote-screenshots.test.js'),
+        `esperaba qa/scripts/__tests__/promote-screenshots.test.js, fue: ${JSON.stringify(found)}`);
+    assert.ok(!found.some((f) => f.includes('helpers.js')), 'helpers.js no debe contarse como test');
+    assert.ok(!found.some((f) => f.endsWith('promote-screenshots.js') && !f.endsWith('.test.js')),
+        'el hook (no-test) no debe contarse');
+    assert.ok(!found.some((f) => f.includes('qa/evidence')),
+        'qa/evidence/ no debe escanearse aunque tenga *.test.js sueltos');
+});
+
+// Defensa: si qa/scripts/__tests__/ no existe en el repo, findNodeTestFiles
+// no debe romper. Esto cubre repos que no usan el patrón QA Node aún (ej.
+// worktrees viejos o forks limpios).
+test('#3409 rev-1 — findNodeTestFiles tolera ausencia de qa/scripts/__tests__/', () => {
+    const fresh = fs.mkdtempSync(path.join(os.tmpdir(), 'v3-tester-3409-empty-'));
+    fs.mkdirSync(path.join(fresh, '.pipeline', 'tests'), { recursive: true });
+    fs.writeFileSync(path.join(fresh, '.pipeline', 'tests', 'only-pipe.test.js'), '// solo pipeline');
+    // qa/ NO existe.
+    const found = tester.findNodeTestFiles(fresh).map((f) => path.relative(fresh, f).replace(/\\/g, '/'));
+    assert.deepEqual(found, ['.pipeline/tests/only-pipe.test.js']);
 });
 
 test('runNodeTests — sin tests detectados devuelve no_tests:true y exit_code:0', async () => {

--- a/.pipeline/skills-deterministicos/tester.js
+++ b/.pipeline/skills-deterministicos/tester.js
@@ -186,24 +186,53 @@ const MODULE_DIRS = {
 //                    agentes pero NO la compilación Kotlin ni la cobertura
 //                    Kover. Encaja exactamente en pipeline-only.
 //
+// Rebote #3409 rev-1 (mismo síntoma, archivos distintos):
+//   - #3409 (hook `qa/scripts/promote-screenshots.js` para promover
+//     screenshots a la librería de referencia visual) entregó un cambio
+//     puramente Node.js bajo `qa/scripts/` + `qa/scripts/__tests__/` +
+//     `.claude/skills/qa/SKILL.md` + `docs/qa/screenshot-promotion.md` +
+//     `package.json`. Tres de los cinco archivos matcheaban patterns
+//     existentes, pero los dos archivos bajo `qa/scripts/*.js` rompían el
+//     match `every`. El tester cayó a la ruta gradle, corrió todas las
+//     tasks UP-TO-DATE (sin código Kotlin tocado) y produjo 0 JUnit
+//     reports → rebote "[tester] No se encontraron reportes JUnit".
+//     Verificación empírica en `.pipeline/logs/3409-tester.log`:
+//       [tester] git diff vs main: 5 archivos · pipeline_only=false
+//       [tester] gradle exit_code=0 wall_ms=56911 (BUILD SUCCESSFUL,
+//                tareas UP-TO-DATE)
+//       - No se encontraron reportes JUnit
+//
+//   El pattern agregado abajo (`/^qa\/scripts\/.*\.(js|mjs|cjs)$/`) es
+//   deliberadamente narrow: solo matchea archivos Node.js bajo qa/scripts/,
+//   NO archivos .sh, .kt, .gradle.kts. Esto mantiene la frontera del rebote
+//   #3092: `qa/scripts/qa-android.sh` y compañía siguen forzando ruta
+//   gradle (su modificación puede afectar el comportamiento del QA real),
+//   pero los hooks Node.js puros (`promote-screenshots.js`, `qa-narration.js`,
+//   `qa-summarize-results.js`, etc.) ahora caen en pipeline-only.
+//   Verificación de seguridad: `grep` por `qa/scripts` en
+//   `**/*.{kts,gradle,kt,properties}` devuelve 0 referencias, así que
+//   Gradle no consume estos scripts.
+//
 // Excluido a propósito: `README.md` y otros .md root, `gradle.properties`,
 // `settings.gradle.kts`, `build.gradle.kts`, `qa/build.gradle.kts`,
-// `qa/src/`, `qa/scripts/`, `qa/test-cases/`, `qa/regression-suite.json` (todos
-// pueden afectar build/coverage o testing real). El test `paths fuera de los
-// patrones permitidos rompen el match` documenta y protege esa frontera.
+// `qa/src/`, `qa/scripts/*.sh` (scripts shell que pueden orquestar gradle),
+// `qa/test-cases/`, `qa/regression-suite.json` (todos pueden afectar
+// build/coverage o testing real). El test `paths fuera de los patrones
+// permitidos rompen el match` documenta y protege esa frontera.
 const PIPELINE_ONLY_PATTERNS = [
-    /^\.pipeline\//,        // pipeline V3 (Node.js)
-    /^docs\//,              // documentación pura
-    /^agents\//,            // reglas para agentes
-    /^\.github\//,          // GitHub Actions / templates
-    /^\.claude\//,          // skills/hooks/settings de Claude Code — fuera de Gradle
-    /^\.gitignore$/,        // gitignore root — no afecta compilación Kotlin
-    /^\.gitattributes$/,    // git attributes — no afecta compilación Kotlin
-    /^\.editorconfig$/,     // editor config — no afecta cobertura
-    /^\.husky\//,           // husky git hooks (Node.js) — fuera de classpath Gradle
-    /^package\.json$/,      // npm manifest — usado solo por `.pipeline/` Node.js
-    /^package-lock\.json$/, // npm lockfile — usado solo por `.pipeline/` Node.js
-    /^qa\/evidence\//,      // QA artifacts (video/screenshots/reports) — fuera de Gradle
+    /^\.pipeline\//,                       // pipeline V3 (Node.js)
+    /^docs\//,                             // documentación pura
+    /^agents\//,                           // reglas para agentes
+    /^\.github\//,                         // GitHub Actions / templates
+    /^\.claude\//,                         // skills/hooks/settings de Claude Code — fuera de Gradle
+    /^\.gitignore$/,                       // gitignore root — no afecta compilación Kotlin
+    /^\.gitattributes$/,                   // git attributes — no afecta compilación Kotlin
+    /^\.editorconfig$/,                    // editor config — no afecta cobertura
+    /^\.husky\//,                          // husky git hooks (Node.js) — fuera de classpath Gradle
+    /^package\.json$/,                     // npm manifest — usado solo por `.pipeline/` Node.js
+    /^package-lock\.json$/,                // npm lockfile — usado solo por `.pipeline/` Node.js
+    /^qa\/evidence\//,                     // QA artifacts (video/screenshots/reports) — fuera de Gradle
+    /^qa\/scripts\/.*\.(js|mjs|cjs)$/,     // Node.js scripts/hooks QA — fuera de Gradle (rebote #3409)
 ];
 
 /**
@@ -324,27 +353,42 @@ function isPipelineOnlyChange(files) {
 }
 
 /**
- * Encuentra recursivamente los archivos *.test.js dentro de `.pipeline/`,
- * excluyendo `node_modules` y directorios ocultos.
+ * Encuentra recursivamente los archivos *.test.js para la ruta pipeline-only.
+ *
+ * Roots escaneados:
+ *   - `.pipeline/` — tests del propio pipeline (V3, hooks, lib, etc.).
+ *   - `qa/scripts/__tests__/` — tests Node de hooks/scripts QA. Agregado
+ *     en el rebote #3409: el hook `promote-screenshots.js` y sus 18 tests
+ *     viven acá; sin escanear este root, los pipeline-only sin tests bajo
+ *     `.pipeline/` daban `no_tests:true` y aprobaban como qa:skipped en
+ *     vez de validar los tests reales que SI existen.
+ *
+ * Excluye `node_modules`, directorios ocultos, y backlogs/estado del
+ * pipeline (`desarrollo/`, `definicion/`, `logs/`).
  */
 function findNodeTestFiles(repoRoot) {
     const out = [];
-    const root = path.join(repoRoot, '.pipeline');
-    if (!fs.existsSync(root)) return out;
-    const stack = [root];
-    while (stack.length > 0) {
-        const cur = stack.pop();
-        let entries;
-        try { entries = fs.readdirSync(cur, { withFileTypes: true }); } catch { continue; }
-        for (const ent of entries) {
-            const full = path.join(cur, ent.name);
-            if (ent.isDirectory()) {
-                if (ent.name === 'node_modules' || ent.name.startsWith('.')) continue;
-                // Excluir backlogs/estado del pipeline (no contienen tests)
-                if (ent.name === 'desarrollo' || ent.name === 'definicion' || ent.name === 'logs') continue;
-                stack.push(full);
-            } else if (ent.isFile() && /\.test\.js$/i.test(ent.name)) {
-                out.push(full);
+    const roots = [
+        path.join(repoRoot, '.pipeline'),
+        path.join(repoRoot, 'qa', 'scripts', '__tests__'),
+    ];
+    for (const root of roots) {
+        if (!fs.existsSync(root)) continue;
+        const stack = [root];
+        while (stack.length > 0) {
+            const cur = stack.pop();
+            let entries;
+            try { entries = fs.readdirSync(cur, { withFileTypes: true }); } catch { continue; }
+            for (const ent of entries) {
+                const full = path.join(cur, ent.name);
+                if (ent.isDirectory()) {
+                    if (ent.name === 'node_modules' || ent.name.startsWith('.')) continue;
+                    // Excluir backlogs/estado del pipeline (no contienen tests)
+                    if (ent.name === 'desarrollo' || ent.name === 'definicion' || ent.name === 'logs') continue;
+                    stack.push(full);
+                } else if (ent.isFile() && /\.test\.js$/i.test(ent.name)) {
+                    out.push(full);
+                }
             }
         }
     }
@@ -1210,6 +1254,23 @@ if (require.main === module) {
                     '.pipeline/lib/stale-branches.js',
                 ]);
                 if (!isPipelineOnly) throw new Error('debió detectar pipeline-only con .claude/skills/<>/SKILL.md');
+            }},
+            { name: 'PIPELINE_ONLY_PATTERNS detecta qa/scripts/*.js + qa/scripts/__tests__/ (rebote #3409)', fn: () => {
+                const isPipelineOnly = isPipelineOnlyChange([
+                    '.claude/skills/qa/SKILL.md',
+                    'docs/qa/screenshot-promotion.md',
+                    'package.json',
+                    'qa/scripts/__tests__/promote-screenshots.test.js',
+                    'qa/scripts/promote-screenshots.js',
+                ]);
+                if (!isPipelineOnly) throw new Error('debió detectar pipeline-only con qa/scripts/*.js (#3409)');
+            }},
+            { name: 'PIPELINE_ONLY_PATTERNS sigue rechazando qa/scripts/*.sh (frontera #3092)', fn: () => {
+                const isPipelineOnly = isPipelineOnlyChange([
+                    '.pipeline/config.yaml',
+                    'qa/scripts/qa-android.sh',
+                ]);
+                if (isPipelineOnly) throw new Error('NO debió detectar pipeline-only con qa/scripts/qa-android.sh');
             }},
         ]);
         return;

--- a/docs/qa/screenshot-promotion.md
+++ b/docs/qa/screenshot-promotion.md
@@ -1,0 +1,235 @@
+# Hook QA — Promoción de screenshots a librería curada
+
+> **Issue origen**: [#3409](https://github.com/intrale/platform/issues/3409) (split 3/3 de [#3382](https://github.com/intrale/platform/issues/3382)).
+> **Implementación**: [`qa/scripts/promote-screenshots.js`](../../qa/scripts/promote-screenshots.js).
+> **Skill que lo invoca**: [`.claude/skills/qa/SKILL.md`](../../.claude/skills/qa/SKILL.md) — Paso V7c.
+> **Librería destino**: [`docs/app-screenshots-reference/`](../app-screenshots-reference/) (entregada por [#3407](https://github.com/intrale/platform/issues/3407)).
+> **Doc operativa del flujo paraguas**: [`docs/pipeline/ux-android-visual-flow.md`](../pipeline/ux-android-visual-flow.md).
+
+Este documento describe el hook QA que, al cierre de un `/qa validate <issue>`
+con veredicto APROBADO, promueve los screenshots representativos a la librería
+canónica para uso cross-agente (UX en definición, dev en implementación, QA
+en validación visual post-build).
+
+## 1. Cuándo se ejecuta
+
+El hook corre como **Paso V7c** del skill `/qa` (`flujo de validacion`),
+después de:
+
+1. `Paso V7` — generación de `qa/evidence/<issue>/qa-report.json`.
+2. Verificar que `qa-report.verdict === "APROBADO"`.
+3. El issue tiene al menos un label `app:client | app:business | app:delivery`.
+
+Si alguna condición falla, el hook NO se invoca. El propio hook re-verifica el
+verdict del report como guarda defensiva.
+
+## 2. Contrato CLI
+
+```bash
+node qa/scripts/promote-screenshots.js \
+  --issue <N> \
+  [--evidence-dir <path>] \
+  [--library-dir <path>] \
+  [--report <path>] \
+  [--flavor <client|business|delivery>] \
+  [--date <YYYY-MM-DD>] \
+  [--dry-run]
+```
+
+| Flag             | Default                                          | Notas                                    |
+|------------------|--------------------------------------------------|------------------------------------------|
+| `--issue`        | (obligatorio)                                    | Número de issue del run QA              |
+| `--evidence-dir` | `qa/evidence/<issue>/`                           | Directorio con los PNGs a evaluar       |
+| `--library-dir`  | `docs/app-screenshots-reference/`                | Librería destino                        |
+| `--report`       | `<evidence-dir>/qa-report.json`                  | Para leer verdict/flavor/labels         |
+| `--flavor`       | (inferido de report)                             | Override explícito si el report no lo expone |
+| `--date`         | UTC hoy `YYYY-MM-DD`                             | Para la fecha del filename canónico     |
+| `--dry-run`      | `false`                                          | Loguea acciones, no copia archivos      |
+
+**Importante**: el path del módulo PII (`qa/lib/pii-policy.js`) **NO es
+configurable** ni por CLI ni por env. Es fijo por diseño (CA-7.8) para que un
+dev distraído no pueda bypassear el fail-safe.
+
+## 3. Lógica de promoción
+
+```
+┌──────────────────────────────────────────────────────────────────────────┐
+│ 1. ensureLibraryPresent(libraryDir)                                      │
+│    └─ si NO existe → exit 1 con "screenshots-reference library missing"  │
+│ 2. readQaReport(reportPath)                                              │
+│    └─ si verdict ≠ APROBADO → exit 0 con skip                            │
+│ 3. loadPIIPolicy(qa/lib/pii-policy.js)                                   │
+│    └─ si no disponible → exit 0 con "PII policy unavailable"             │
+│ 4. resolveFlavor(--flavor || report.flavor || único label app:*)         │
+│    └─ si no se resuelve → exit 0 con "flavor not resolved"               │
+│ 5. listEvidencePngs(evidenceDir)                                         │
+│ 6. Para cada PNG:                                                        │
+│      a. inferScreen(filename) — heurística de mapeo                      │
+│      b. policy.hasPII(file, {issue, flavor, screen})                     │
+│      c. if pii.flagged → log "PII detected" + skip                       │
+│      d. computeTargetPath(<pantalla>/<pantalla>-<flavor>-<fecha>.png)    │
+│      e. if existsSync(target) && sha256(target) === sha256(src)          │
+│           → log "already in library" + skip (idempotencia)               │
+│      f. atomicCopy(src, target) — tmp+rename para no dejar parciales     │
+│      g. if willOverwrite → log "overwritten same-day screenshot"         │
+│ 7. Resumen final accionable: "promoted N screenshots to library"         │
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+## 4. Comportamiento fail-safe (CA-7.7 + CA-7.8)
+
+El repo `intrale/platform` es **público**. La política por defecto es:
+**si no se puede confirmar que un screenshot está libre de PII → NO se
+promueve**.
+
+| Situación                                                | Acción                                          |
+|----------------------------------------------------------|-------------------------------------------------|
+| `qa/lib/pii-policy.js` no existe                         | Exit 0, log `PII policy unavailable`           |
+| `qa/lib/pii-policy.js` lanza al cargar                   | Exit 0, log `PII policy unavailable`           |
+| `qa/lib/pii-policy.js` no exporta `hasPII`               | Exit 0, log `PII policy unavailable`           |
+| `policy.hasPII()` lanza para un PNG específico           | Skip ese PNG, log con error message            |
+| `policy.hasPII()` devuelve `{ flagged: true, flags: [] }`| Skip ese PNG, log `PII detected — skipped`     |
+
+Notas operativas:
+
+- Hasta que [#3385](https://github.com/intrale/platform/issues/3385) entregue
+  el módulo `qa/lib/pii-policy.js` con su política formal, el hook **no
+  promueve nada en producción** y solo loguea la causa.
+- En tests, los fixtures escriben un `qa/lib/pii-policy.js` sintético dentro
+  del directorio temp del test (no toca el repo real).
+
+## 5. Contrato esperado del módulo PII (`qa/lib/pii-policy.js`)
+
+A entregar por [#3385](https://github.com/intrale/platform/issues/3385):
+
+```js
+// qa/lib/pii-policy.js
+module.exports = {
+    /**
+     * Determina si un screenshot contiene PII visible.
+     *
+     * @param {string} filePath - Path absoluto al PNG.
+     * @param {{issue: string|number, flavor: string, screen: string}} context
+     * @returns {{ flagged: boolean, flags?: string[] }}
+     */
+    hasPII(filePath, context) {
+        // implementación: OCR + regex contra patrones sensibles,
+        // o consulta a un manifest declarativo.
+        return { flagged: false, flags: [] };
+    },
+};
+```
+
+Reglas:
+
+- **Síncrono**. El hook QA no maneja promesas.
+- **Defensivo**: si lanza, el hook trata el PNG como "PII no determinable" y
+  lo skippea (no promueve).
+- **Idempotente**: la respuesta no puede depender del orden de llamada.
+
+## 6. Heurística filename → pantalla canónica
+
+Alineada con [`docs/pipeline/ux-android-visual-flow.md`](../pipeline/ux-android-visual-flow.md) §7.
+El orden de chequeo importa: reglas más específicas primero.
+
+| Substring (case-insensitive)            | Pantalla canónica   |
+|-----------------------------------------|---------------------|
+| `password-recovery`, `recovery`         | `login`             |
+| `signin`, `login`                       | `login`             |
+| `signup`, `register`, `registro`        | `signup`            |
+| `welcome`                               | `welcome`           |
+| `business-home`, `home`, `^main`, `-main` | `home`            |
+| `drawer-search`, `busqueda`, `búsqueda`, `search` | `busqueda` |
+| `detalle-producto`, `product-detail`, `producto`, `detalle`, `product` | `detalle-producto` |
+| `carrito`, `cart`                       | `carrito`           |
+| `checkout`                              | `checkout`          |
+| `profile-selector`, `perfil`, `profile` | `perfil`            |
+| `pedidos`, `pedido`, `orders`, `order`  | `pedidos`           |
+
+Si **ningún** patrón matchea, el PNG queda como `skipped_unmapped` y el hook
+loguea `unmapped: <filename>` pero continúa con el resto. La recomendación
+[#3466](https://github.com/intrale/platform/issues/3466) propone un schema
+declarativo `qa/screenshot-mapping.yaml` que reemplaza esta heurística
+implícita.
+
+## 7. Resolución de flavor
+
+Orden de precedencia:
+
+1. `--flavor <client|business|delivery>` (CLI explícito).
+2. `qa-report.flavor` si el report lo expone (a entregar por [#3468](https://github.com/intrale/platform/issues/3468)).
+3. Si `qa-report.labels` tiene **exactamente un** label `app:*` → ese flavor.
+4. Si hay varios `app:*` y no hay override → skip con log `flavor not resolved`.
+
+Hasta que #3468 cierre, lo más probable es que el hook deba recibir
+`--flavor` explícito desde el invocador (skill `/qa`).
+
+## 8. Idempotencia
+
+El hook compara sha256 del PNG origen contra el destino existente (mismo
+filename canónico). Tres escenarios:
+
+| Estado destino                    | Acción                                |
+|-----------------------------------|---------------------------------------|
+| No existe                         | Copia atómica (tmp + rename)          |
+| Existe con **mismo** hash         | Skip (`already in library`)           |
+| Existe con **distinto** hash      | Sobreescribe (`overwritten same-day…`)|
+
+La copia se hace con `tmp+rename` para no dejar archivos parcialmente
+escritos si el proceso muere a mitad. La recomendación
+[#3467](https://github.com/intrale/platform/issues/3467) trackea formalizar
+esta atomicidad como un helper reusable.
+
+## 9. Códigos de salida
+
+| Exit code | Significado                                                           |
+|-----------|-----------------------------------------------------------------------|
+| 0         | Ejecución concluida (incluye fail-safe sin promoción)                |
+| 1         | Error duro (librería ausente, qa-report ilegible, copia fallida)     |
+| 2         | Argumentos inválidos                                                  |
+
+El hook **no aborta** el QA aunque skippee toda la promoción: el QA sigue su
+flujo normal después de V7c.
+
+## 10. Tests
+
+Cobertura en [`qa/scripts/__tests__/promote-screenshots.test.js`](../../qa/scripts/__tests__/promote-screenshots.test.js):
+
+1. **Escenario 1 (Gherkin PO)** — QA exitoso promueve login + carrito.
+2. **Escenario 2 (Gherkin PO)** — Idempotente (no duplica al re-ejecutar).
+3. **Escenario 3 (Gherkin PO)** — Sobreescribe versión anterior del mismo día.
+4. **Escenario 4 (Gherkin PO)** — PII detectada → skip con log.
+5. **Escenario 5 (Gherkin PO)** — Política PII no disponible → fail-safe.
+6. **Escenario 6 (Gherkin PO)** — Librería ausente → error claro con ref a #3407.
+
+Más escenarios defensivos (módulo PII con contrato roto, `hasPII` lanza,
+RECHAZADO no promueve, flavor irresoluble, heurística de mapeo, etc.).
+
+Ejecutar localmente:
+
+```bash
+node --test qa/scripts/__tests__/promote-screenshots.test.js
+```
+
+O via npm (junto al resto de tests del pipeline):
+
+```bash
+npm run test:pipeline
+```
+
+## 11. Limitaciones conocidas / issues relacionados
+
+| Issue                                                            | Relación                                                |
+|------------------------------------------------------------------|---------------------------------------------------------|
+| [#3385](https://github.com/intrale/platform/issues/3385)         | Política PII formal — el hook no promueve sin ella     |
+| [#3407](https://github.com/intrale/platform/issues/3407)         | Estructura `docs/app-screenshots-reference/` (mergeado)|
+| [#3408](https://github.com/intrale/platform/issues/3408)         | Helpers UX para consumir la librería desde definición  |
+| [#3459](https://github.com/intrale/platform/issues/3459)         | Path sanitization adicional (recomendación)            |
+| [#3460](https://github.com/intrale/platform/issues/3460)         | EXIF/metadata stripping antes de promover              |
+| [#3461](https://github.com/intrale/platform/issues/3461)         | Caps de tamaño/cantidad por run                        |
+| [#3466](https://github.com/intrale/platform/issues/3466)         | Schema declarativo `qa/screenshot-mapping.yaml`        |
+| [#3467](https://github.com/intrale/platform/issues/3467)         | Atomicidad (tmp+rename) como helper reusable           |
+| [#3468](https://github.com/intrale/platform/issues/3468)         | Exponer flavor en `qa-report.json`                     |
+
+Ninguna bloquea la operatividad actual: el hook es funcional hoy con
+comportamiento fail-safe ante cualquier ausencia.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "prepare": "husky || true",
     "validate:agent-models": "node .pipeline/lib/agent-models-validate.js",
-    "test:pipeline": "node --test .pipeline/lib/__tests__ .pipeline/tests",
+    "test:pipeline": "node --test .pipeline/lib/__tests__ .pipeline/tests qa/scripts/__tests__",
     "smoke:commander": "node .pipeline/tests/smoke/commander-degraded.smoke.js"
   },
   "dependencies": {

--- a/qa/scripts/__tests__/promote-screenshots.test.js
+++ b/qa/scripts/__tests__/promote-screenshots.test.js
@@ -1,0 +1,448 @@
+// =============================================================================
+// Tests promote-screenshots.js — Issue #3409 (CA-7.1 a CA-7.9)
+//
+// Cubre los 6 escenarios Gherkin del PO (#3409#issuecomment-4509799939):
+//   1. QA exitoso promueve screenshots a la librería
+//   2. Hook idempotente (no duplica al re-ejecutar)
+//   3. Sobreescribe el más reciente del día
+//   4. Fail-safe ante PII detectada (política PII disponible)
+//   5. Fail-safe ante política PII NO disponible (default seguro)
+//   6. Falla clara si la estructura de librería no existe
+//
+// + cobertura adicional:
+//   - Heurística filename → pantalla canónica
+//   - Inferencia de flavor desde qa-report.labels
+//   - Unmapped PNGs no abortan el run
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const crypto = require('crypto');
+
+const {
+    promoteScreenshots,
+    inferScreen,
+    inferFlavorFromReport,
+    loadPIIPolicy,
+} = require('../promote-screenshots');
+
+// ─── Helpers de fixture ──────────────────────────────────────────────────
+function makeTmpRoot() {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'promote-screenshots-'));
+}
+
+function rmTmpRoot(root) {
+    try { fs.rmSync(root, { recursive: true, force: true }); } catch { /* noop */ }
+}
+
+function writePng(filePath, content = 'fake-png-content') {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, content);
+}
+
+function buildLibrary(libraryDir, screens = ['login', 'carrito', 'checkout', 'home', 'perfil']) {
+    fs.mkdirSync(libraryDir, { recursive: true });
+    fs.writeFileSync(path.join(libraryDir, 'README.md'), '# library\n');
+    for (const s of screens) {
+        fs.mkdirSync(path.join(libraryDir, s), { recursive: true });
+    }
+}
+
+function writeReport(reportPath, partial = {}) {
+    const report = {
+        issue_number: 3382,
+        verdict: 'APROBADO',
+        flavor: 'client',
+        ...partial,
+    };
+    fs.mkdirSync(path.dirname(reportPath), { recursive: true });
+    fs.writeFileSync(reportPath, JSON.stringify(report, null, 2));
+}
+
+// Fake PII policy module — escribimos un .js real en disco porque el hook
+// hace `require()` con path absoluto (fail-safe es real, no mock-friendly).
+function writePiiPolicyModule(targetPath, behavior = 'safe') {
+    fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+    let body;
+    switch (behavior) {
+        case 'safe':
+            body = `module.exports = { hasPII: () => ({ flagged: false, flags: [] }) };\n`;
+            break;
+        case 'flagged':
+            body = `module.exports = { hasPII: () => ({ flagged: true, flags: ['contiene_email_usuario'] }) };\n`;
+            break;
+        case 'flagged-only-checkout':
+            body = `module.exports = { hasPII: (f) => /checkout/i.test(String(f)) ? ({ flagged: true, flags: ['contiene_email_usuario'] }) : ({ flagged: false, flags: [] }) };\n`;
+            break;
+        case 'throws':
+            body = `module.exports = { hasPII: () => { throw new Error('boom'); } };\n`;
+            break;
+        case 'broken-contract':
+            body = `module.exports = { foo: 1 };\n`;
+            break;
+        case 'load-throws':
+            body = `throw new Error('cannot load');\n`;
+            break;
+        default:
+            throw new Error('unknown behavior: ' + behavior);
+    }
+    fs.writeFileSync(targetPath, body);
+}
+
+function setupFixture({ piiBehavior = 'safe', verdict = 'APROBADO', flavor = 'client', screenshots = [], extraReport = {} } = {}) {
+    const root = makeTmpRoot();
+    const evidenceDir = path.join(root, 'qa', 'evidence', '3382-test');
+    const libraryDir = path.join(root, 'docs', 'app-screenshots-reference');
+    const piiPolicyPath = path.join(root, 'qa', 'lib', 'pii-policy.js');
+    const reportPath = path.join(evidenceDir, 'qa-report.json');
+
+    buildLibrary(libraryDir);
+    if (piiBehavior !== 'missing') {
+        writePiiPolicyModule(piiPolicyPath, piiBehavior);
+    }
+    writeReport(reportPath, { verdict, flavor, ...extraReport });
+    for (const s of screenshots) {
+        writePng(path.join(evidenceDir, s.name), s.content || `content-${s.name}`);
+    }
+
+    return { root, evidenceDir, libraryDir, piiPolicyPath, reportPath };
+}
+
+// ─── Escenario 1: QA exitoso promueve screenshots a la librería ──────────
+test('escenario 1 — QA exitoso promueve login y carrito a la librería', () => {
+    const { root, evidenceDir, libraryDir, piiPolicyPath } = setupFixture({
+        screenshots: [
+            { name: '01-login.png', content: 'login-png-bytes' },
+            { name: '02-carrito.png', content: 'carrito-png-bytes' },
+        ],
+    });
+    try {
+        const result = promoteScreenshots({
+            issue: '3382-test',
+            evidenceDir,
+            libraryDir,
+            piiPolicyPath,
+            date: '2026-05-20',
+        });
+
+        assert.equal(result.ok, true);
+        assert.equal(result.exitCode, 0);
+        assert.equal(result.promoted, 2);
+        assert.equal(result.already_in_library, 0);
+
+        assert.ok(fs.existsSync(path.join(libraryDir, 'login', 'login-client-2026-05-20.png')));
+        assert.ok(fs.existsSync(path.join(libraryDir, 'carrito', 'carrito-client-2026-05-20.png')));
+
+        assert.ok(
+            result.log.some((l) => l === 'promoted 2 screenshots to library'),
+            `expected summary log; got: ${JSON.stringify(result.log)}`
+        );
+    } finally {
+        rmTmpRoot(root);
+    }
+});
+
+// ─── Escenario 2: Hook idempotente ───────────────────────────────────────
+test('escenario 2 — hook idempotente (segunda corrida no duplica)', () => {
+    const { root, evidenceDir, libraryDir, piiPolicyPath } = setupFixture({
+        screenshots: [
+            { name: '01-login.png', content: 'login-bytes' },
+            { name: '02-carrito.png', content: 'carrito-bytes' },
+        ],
+    });
+    try {
+        const first = promoteScreenshots({ issue: '3382-test', evidenceDir, libraryDir, piiPolicyPath, date: '2026-05-20' });
+        assert.equal(first.promoted, 2);
+
+        const second = promoteScreenshots({ issue: '3382-test', evidenceDir, libraryDir, piiPolicyPath, date: '2026-05-20' });
+        assert.equal(second.promoted, 0);
+        assert.equal(second.already_in_library, 2);
+        assert.ok(
+            second.log.some((l) => l === 'promoted 0 screenshots (already in library)'),
+            `expected idempotent summary; got: ${JSON.stringify(second.log)}`
+        );
+
+        // Verificación física: solo un archivo por destino, no duplicados.
+        const loginFiles = fs.readdirSync(path.join(libraryDir, 'login'));
+        assert.deepEqual(loginFiles, ['login-client-2026-05-20.png']);
+    } finally {
+        rmTmpRoot(root);
+    }
+});
+
+// ─── Escenario 3: Sobreescribe el más reciente del día ──────────────────
+test('escenario 3 — sobreescribe versión anterior del mismo día/pantalla/flavor', () => {
+    const { root, evidenceDir, libraryDir, piiPolicyPath } = setupFixture({
+        screenshots: [{ name: '01-login.png', content: 'login-v2-bytes' }],
+    });
+    try {
+        // Pre-poblar la librería con una versión "vieja" del mismo día.
+        const targetPath = path.join(libraryDir, 'login', 'login-client-2026-05-20.png');
+        fs.writeFileSync(targetPath, 'login-v1-bytes');
+
+        const result = promoteScreenshots({ issue: '3382-test', evidenceDir, libraryDir, piiPolicyPath, date: '2026-05-20' });
+        assert.equal(result.promoted, 1);
+        assert.equal(result.already_in_library, 0);
+
+        const after = fs.readFileSync(targetPath, 'utf8');
+        assert.equal(after, 'login-v2-bytes', 'expected overwrite with new content');
+
+        assert.ok(
+            result.log.some((l) => l === 'overwritten same-day screenshot login/client'),
+            `expected overwrite log entry; got: ${JSON.stringify(result.log)}`
+        );
+    } finally {
+        rmTmpRoot(root);
+    }
+});
+
+// ─── Escenario 4: Fail-safe ante PII detectada ──────────────────────────
+test('escenario 4 — PII detectada (política disponible) → promotion skipped', () => {
+    const { root, evidenceDir, libraryDir, piiPolicyPath } = setupFixture({
+        piiBehavior: 'flagged-only-checkout',
+        screenshots: [{ name: 'checkout.png', content: 'checkout-bytes' }],
+    });
+    try {
+        const result = promoteScreenshots({ issue: '3382-test', evidenceDir, libraryDir, piiPolicyPath, date: '2026-05-20' });
+        assert.equal(result.ok, true);
+        assert.equal(result.exitCode, 0);
+        assert.equal(result.promoted, 0);
+        assert.equal(result.skipped_pii, 1);
+
+        const targetPath = path.join(libraryDir, 'checkout', 'checkout-client-2026-05-20.png');
+        assert.equal(fs.existsSync(targetPath), false, 'expected no file promoted');
+
+        assert.ok(
+            result.log.some((l) => /PII detected — promotion skipped: checkout\.png/.test(l)),
+            `expected PII skipped log; got: ${JSON.stringify(result.log)}`
+        );
+    } finally {
+        rmTmpRoot(root);
+    }
+});
+
+// ─── Escenario 5: Fail-safe ante política PII NO disponible ─────────────
+test('escenario 5 — política PII NO disponible → fail-safe, no promueve nada', () => {
+    const { root, evidenceDir, libraryDir, piiPolicyPath } = setupFixture({
+        piiBehavior: 'missing',
+        screenshots: [{ name: '01-login.png', content: 'login-bytes' }],
+    });
+    try {
+        const result = promoteScreenshots({ issue: '3382-test', evidenceDir, libraryDir, piiPolicyPath, date: '2026-05-20' });
+        assert.equal(result.ok, true);
+        assert.equal(result.exitCode, 0, 'fail-safe debe salir 0 (no falla el QA)');
+        assert.equal(result.promoted, 0);
+
+        assert.ok(
+            result.log.some((l) => /PII policy unavailable — promotion skipped/.test(l)),
+            `expected fail-safe log; got: ${JSON.stringify(result.log)}`
+        );
+
+        const targetPath = path.join(libraryDir, 'login', 'login-client-2026-05-20.png');
+        assert.equal(fs.existsSync(targetPath), false);
+    } finally {
+        rmTmpRoot(root);
+    }
+});
+
+test('escenario 5b — módulo PII existe pero contrato roto → fail-safe', () => {
+    const { root, evidenceDir, libraryDir, piiPolicyPath } = setupFixture({
+        piiBehavior: 'broken-contract',
+        screenshots: [{ name: '01-login.png' }],
+    });
+    try {
+        const result = promoteScreenshots({ issue: '3382-test', evidenceDir, libraryDir, piiPolicyPath });
+        assert.equal(result.exitCode, 0);
+        assert.equal(result.promoted, 0);
+        assert.ok(
+            result.log.some((l) => /PII policy unavailable — promotion skipped.*hasPII/.test(l)),
+            `expected broken-contract fail-safe; got: ${JSON.stringify(result.log)}`
+        );
+    } finally {
+        rmTmpRoot(root);
+    }
+});
+
+test('escenario 5c — módulo PII falla al cargar → fail-safe', () => {
+    const { root, evidenceDir, libraryDir, piiPolicyPath } = setupFixture({
+        piiBehavior: 'load-throws',
+        screenshots: [{ name: '01-login.png' }],
+    });
+    try {
+        const result = promoteScreenshots({ issue: '3382-test', evidenceDir, libraryDir, piiPolicyPath });
+        assert.equal(result.exitCode, 0);
+        assert.equal(result.promoted, 0);
+        assert.ok(
+            result.log.some((l) => /PII policy unavailable — promotion skipped.*failed to load/.test(l)),
+            `expected load-throws fail-safe; got: ${JSON.stringify(result.log)}`
+        );
+    } finally {
+        rmTmpRoot(root);
+    }
+});
+
+test('escenario 5d — hasPII lanza por screenshot → skip individual (no aborta)', () => {
+    const { root, evidenceDir, libraryDir, piiPolicyPath } = setupFixture({
+        piiBehavior: 'throws',
+        screenshots: [{ name: '01-login.png' }, { name: '02-carrito.png' }],
+    });
+    try {
+        const result = promoteScreenshots({ issue: '3382-test', evidenceDir, libraryDir, piiPolicyPath });
+        assert.equal(result.exitCode, 0);
+        assert.equal(result.promoted, 0);
+        assert.equal(result.skipped_pii, 2);
+    } finally {
+        rmTmpRoot(root);
+    }
+});
+
+// ─── Escenario 6: Falla clara si la estructura de librería no existe ────
+test('escenario 6 — librería ausente → error claro con referencia a #3407', () => {
+    const root = makeTmpRoot();
+    const evidenceDir = path.join(root, 'qa', 'evidence', '3382-test');
+    const libraryDir = path.join(root, 'docs', 'app-screenshots-reference');
+    const piiPolicyPath = path.join(root, 'qa', 'lib', 'pii-policy.js');
+    const reportPath = path.join(evidenceDir, 'qa-report.json');
+
+    writePiiPolicyModule(piiPolicyPath, 'safe');
+    writeReport(reportPath);
+    writePng(path.join(evidenceDir, '01-login.png'));
+
+    try {
+        const result = promoteScreenshots({ issue: '3382-test', evidenceDir, libraryDir, piiPolicyPath });
+        assert.equal(result.ok, false);
+        assert.equal(result.exitCode, 1);
+        assert.ok(
+            result.errors.some((e) => /screenshots-reference library missing — depends on #3407/.test(e)),
+            `expected error mencioning #3407; got: ${JSON.stringify(result.errors)}`
+        );
+    } finally {
+        rmTmpRoot(root);
+    }
+});
+
+// ─── Tests adicionales: heurística filename → pantalla canónica ──────────
+test('inferScreen — mapea nombres legacy a pantallas canónicas', () => {
+    assert.equal(inferScreen('01-login.png'), 'login');
+    assert.equal(inferScreen('b06-login-with-links.png'), 'login');
+    assert.equal(inferScreen('password-recovery-step3.png'), 'login'); // sub-flow
+    assert.equal(inferScreen('signup-validation.png'), 'signup');
+    assert.equal(inferScreen('register.png'), 'signup');
+    assert.equal(inferScreen('welcome.png'), 'welcome');
+    assert.equal(inferScreen('business-home.png'), 'home');
+    assert.equal(inferScreen('home-screen.png'), 'home');
+    assert.equal(inferScreen('main-dashboard.png'), 'home');
+    assert.equal(inferScreen('drawer-search.png'), 'busqueda');
+    assert.equal(inferScreen('búsqueda-resultados.png'), 'busqueda');
+    assert.equal(inferScreen('detalle-producto-banana.png'), 'detalle-producto');
+    assert.equal(inferScreen('product-detail.png'), 'detalle-producto');
+    assert.equal(inferScreen('carrito-vacio.png'), 'carrito');
+    assert.equal(inferScreen('cart.png'), 'carrito');
+    assert.equal(inferScreen('checkout-step2.png'), 'checkout');
+    assert.equal(inferScreen('profile-selector.png'), 'perfil');
+    assert.equal(inferScreen('perfil.png'), 'perfil');
+    assert.equal(inferScreen('pedidos-list.png'), 'pedidos');
+    assert.equal(inferScreen('orders.png'), 'pedidos');
+
+    // No match → null (no se promueve).
+    assert.equal(inferScreen('check2.png'), null);
+    assert.equal(inferScreen('random-debug-overlay.png'), null);
+});
+
+// ─── Inferencia de flavor desde report ───────────────────────────────────
+test('inferFlavorFromReport — respeta flavor explícito si presente', () => {
+    assert.equal(inferFlavorFromReport({ flavor: 'business' }), 'business');
+});
+
+test('inferFlavorFromReport — usa label app:* si hay solo uno', () => {
+    assert.equal(inferFlavorFromReport({ labels: ['app:client', 'enhancement'] }), 'client');
+    assert.equal(inferFlavorFromReport({ labels: ['app:delivery'] }), 'delivery');
+});
+
+test('inferFlavorFromReport — devuelve null si hay múltiples app:*', () => {
+    assert.equal(inferFlavorFromReport({ labels: ['app:client', 'app:business'] }), null);
+});
+
+test('inferFlavorFromReport — devuelve null si no hay flavor ni labels', () => {
+    assert.equal(inferFlavorFromReport({}), null);
+    assert.equal(inferFlavorFromReport(null), null);
+});
+
+// ─── Unmapped PNG no aborta ──────────────────────────────────────────────
+test('unmapped PNG queda registrado como skipped_unmapped, sin abortar', () => {
+    const { root, evidenceDir, libraryDir, piiPolicyPath } = setupFixture({
+        screenshots: [
+            { name: '01-login.png', content: 'login-bytes' },
+            { name: 'random-debug.png', content: 'random-bytes' },
+        ],
+    });
+    try {
+        const result = promoteScreenshots({ issue: '3382-test', evidenceDir, libraryDir, piiPolicyPath, date: '2026-05-20' });
+        assert.equal(result.exitCode, 0);
+        assert.equal(result.promoted, 1);
+        assert.equal(result.skipped_unmapped, 1);
+        assert.ok(
+            result.log.some((l) => /unmapped: random-debug\.png/.test(l)),
+            `expected unmapped log; got: ${JSON.stringify(result.log)}`
+        );
+    } finally {
+        rmTmpRoot(root);
+    }
+});
+
+// ─── qa-report con verdict RECHAZADO no promueve ─────────────────────────
+test('qa-report con verdict RECHAZADO no promueve', () => {
+    const { root, evidenceDir, libraryDir, piiPolicyPath } = setupFixture({
+        verdict: 'RECHAZADO',
+        screenshots: [{ name: '01-login.png' }],
+    });
+    try {
+        const result = promoteScreenshots({ issue: '3382-test', evidenceDir, libraryDir, piiPolicyPath });
+        assert.equal(result.exitCode, 0);
+        assert.equal(result.promoted, 0);
+        assert.ok(
+            result.log.some((l) => /verdict is RECHAZADO — promotion skipped/.test(l)),
+            `expected verdict skip log; got: ${JSON.stringify(result.log)}`
+        );
+    } finally {
+        rmTmpRoot(root);
+    }
+});
+
+// ─── missing --issue ─────────────────────────────────────────────────────
+test('falta --issue → exit code 2', () => {
+    const result = promoteScreenshots({ issue: null });
+    assert.equal(result.exitCode, 2);
+    assert.ok(result.errors.some((e) => /missing --issue/.test(e)));
+});
+
+// ─── Flavor no resoluble → skip con log ──────────────────────────────────
+test('si no hay flavor ni en CLI ni en report ni en labels → skip', () => {
+    const { root, evidenceDir, libraryDir, piiPolicyPath } = setupFixture({
+        flavor: null,
+        screenshots: [{ name: '01-login.png' }],
+        extraReport: { flavor: null, labels: ['app:client', 'app:business'] },
+    });
+    // Patch del report para borrar flavor manualmente
+    const reportPath = path.join(evidenceDir, 'qa-report.json');
+    const report = JSON.parse(fs.readFileSync(reportPath, 'utf8'));
+    delete report.flavor;
+    report.labels = ['app:client', 'app:business'];
+    fs.writeFileSync(reportPath, JSON.stringify(report, null, 2));
+
+    try {
+        const result = promoteScreenshots({ issue: '3382-test', evidenceDir, libraryDir, piiPolicyPath, date: '2026-05-20' });
+        assert.equal(result.exitCode, 0);
+        assert.equal(result.promoted, 0);
+        assert.ok(
+            result.log.some((l) => /flavor not resolved/.test(l)),
+            `expected flavor skip log; got: ${JSON.stringify(result.log)}`
+        );
+    } finally {
+        rmTmpRoot(root);
+    }
+});

--- a/qa/scripts/promote-screenshots.js
+++ b/qa/scripts/promote-screenshots.js
@@ -1,0 +1,434 @@
+#!/usr/bin/env node
+// =============================================================================
+// promote-screenshots.js — Hook QA post-ejecución exitosa que promueve PNGs
+// de `qa/evidence/<issue>/` a la librería curada
+// `docs/app-screenshots-reference/<pantalla>/<pantalla>-<flavor>-<YYYY-MM-DD>.png`.
+//
+// Issue #3409 (split 3/3 de #3382) · CA-7.1 a CA-7.9.
+//
+// Contrato CLI:
+//   node qa/scripts/promote-screenshots.js \
+//     --issue <N> \
+//     [--evidence-dir <path>] \
+//     [--library-dir <path>] \
+//     [--report <path>] \
+//     [--flavor <client|business|delivery>] \
+//     [--date <YYYY-MM-DD>] \
+//     [--dry-run]
+//
+// Salida JSON por stdout:
+//   {
+//     "promoted": <N>,
+//     "already_in_library": <N>,
+//     "skipped_pii": <N>,
+//     "skipped_unmapped": <N>,
+//     "log": [ ...mensajes accionables... ],
+//     "errors": [ ... ]
+//   }
+//
+// Exit codes:
+//   0 → ejecución concluida (incluye fail-safe sin promoción)
+//   1 → error duro (librería ausente, qa-report ilegible, etc.)
+//   2 → argumentos inválidos
+//
+// Comportamiento fail-safe (CA-7.7/7.8):
+//   El módulo de política PII se importa con `require('qa/lib/pii-policy.js')`
+//   (path fijo, NO configurable por CLI/env para que un dev distraído no pueda
+//   bypassear). Si el módulo no existe, no expone `hasPII`, o lanza al cargar,
+//   se asume política NO disponible → exit 0 sin promover y log explícito.
+//
+// El repo `intrale/platform` es PÚBLICO: el default es siempre fail-safe.
+// =============================================================================
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const PII_POLICY_PATH = path.join(REPO_ROOT, 'qa', 'lib', 'pii-policy.js');
+
+// ─── Heurística de mapeo PNG → pantalla canónica ──────────────────────────
+// Alineada con docs/pipeline/ux-android-visual-flow.md §7.
+// Orden importa: las reglas más específicas van primero.
+const SCREEN_HEURISTICS = Object.freeze([
+    { canonical: 'login',            patterns: [/password-recovery/i, /recovery/i, /signin/i, /login/i] },
+    { canonical: 'signup',           patterns: [/signup/i, /register/i, /registro/i] },
+    { canonical: 'welcome',          patterns: [/welcome/i] },
+    { canonical: 'home',             patterns: [/business-home/i, /home/i, /^main/i, /-main/i] },
+    { canonical: 'busqueda',         patterns: [/drawer-search/i, /busqueda/i, /b[uú]squeda/i, /search/i] },
+    { canonical: 'detalle-producto', patterns: [/detalle-producto/i, /product-detail/i, /producto/i, /detalle/i, /product/i] },
+    { canonical: 'carrito',          patterns: [/carrito/i, /cart/i] },
+    { canonical: 'checkout',         patterns: [/checkout/i] },
+    { canonical: 'perfil',           patterns: [/profile-selector/i, /perfil/i, /profile/i] },
+    { canonical: 'pedidos',          patterns: [/pedidos/i, /pedido/i, /orders/i, /order/i] },
+]);
+
+const VALID_FLAVORS = Object.freeze(['client', 'business', 'delivery']);
+
+// ─── Util: parsing de argumentos ──────────────────────────────────────────
+function parseArgs(argv) {
+    const args = {
+        issue: null,
+        evidenceDir: null,
+        libraryDir: null,
+        report: null,
+        flavor: null,
+        date: null,
+        dryRun: false,
+    };
+    for (let i = 2; i < argv.length; i++) {
+        const a = argv[i];
+        switch (a) {
+            case '--issue':         args.issue = argv[++i]; break;
+            case '--evidence-dir':  args.evidenceDir = argv[++i]; break;
+            case '--library-dir':   args.libraryDir = argv[++i]; break;
+            case '--report':        args.report = argv[++i]; break;
+            case '--flavor':        args.flavor = argv[++i]; break;
+            case '--date':          args.date = argv[++i]; break;
+            case '--dry-run':       args.dryRun = true; break;
+            default:
+                throw new Error(`unknown argument: ${a}`);
+        }
+    }
+    return args;
+}
+
+// ─── Util: mapeo filename → pantalla canónica ─────────────────────────────
+function inferScreen(filename) {
+    const lower = filename.toLowerCase();
+    for (const rule of SCREEN_HEURISTICS) {
+        for (const pat of rule.patterns) {
+            if (pat.test(lower)) return rule.canonical;
+        }
+    }
+    return null;
+}
+
+// ─── Util: validar flavor ─────────────────────────────────────────────────
+function validateFlavor(flavor) {
+    if (!flavor) return null;
+    if (VALID_FLAVORS.includes(flavor)) return flavor;
+    return null;
+}
+
+// ─── Util: inferir flavor desde qa-report.json o labels ───────────────────
+// Política: si el report incluye `flavor` (top-level) lo respeta. Si no, si
+// el report incluye `labels` con UN SOLO `app:*` → ese flavor. Si hay varios
+// app:* y no hay flavor explícito → retorna null (no promueve, registra).
+function inferFlavorFromReport(report) {
+    if (!report) return null;
+    if (report.flavor && VALID_FLAVORS.includes(report.flavor)) return report.flavor;
+
+    const labels = Array.isArray(report.labels) ? report.labels : null;
+    if (!labels) return null;
+    const appLabels = labels
+        .filter((l) => typeof l === 'string' && l.startsWith('app:'))
+        .map((l) => l.slice('app:'.length));
+    const candidates = appLabels.filter((f) => VALID_FLAVORS.includes(f));
+    if (candidates.length === 1) return candidates[0];
+    return null;
+}
+
+// ─── Util: validar fecha YYYY-MM-DD ───────────────────────────────────────
+function validateDate(dateStr) {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(dateStr)) return null;
+    return dateStr;
+}
+
+function todayIso(now = new Date()) {
+    const y = now.getUTCFullYear();
+    const m = String(now.getUTCMonth() + 1).padStart(2, '0');
+    const d = String(now.getUTCDate()).padStart(2, '0');
+    return `${y}-${m}-${d}`;
+}
+
+// ─── Util: sha256 hash de un archivo ──────────────────────────────────────
+function sha256File(filePath) {
+    const buf = fs.readFileSync(filePath);
+    return crypto.createHash('sha256').update(buf).digest('hex');
+}
+
+// ─── Carga del módulo PII (fail-safe) ─────────────────────────────────────
+// CA-7.7 + CA-7.8: import explícito; cualquier ausencia/error → política NO
+// disponible → NO promover. Nunca se acepta CLI/env override.
+function loadPIIPolicy({ piiPolicyPath = PII_POLICY_PATH, requireFn = require } = {}) {
+    if (!fs.existsSync(piiPolicyPath)) {
+        return { available: false, reason: 'pii-policy module missing' };
+    }
+    try {
+        // Bust de cache para que reload en tests funcione (delete del cache).
+        try { delete requireFn.cache[piiPolicyPath]; } catch { /* noop */ }
+        const mod = requireFn(piiPolicyPath);
+        if (!mod || typeof mod.hasPII !== 'function') {
+            return { available: false, reason: 'pii-policy module missing hasPII()' };
+        }
+        return { available: true, policy: mod };
+    } catch (err) {
+        return { available: false, reason: `pii-policy module failed to load: ${err.message}` };
+    }
+}
+
+// ─── Lectura del qa-report.json ──────────────────────────────────────────
+function readQaReport(reportPath) {
+    if (!fs.existsSync(reportPath)) {
+        return { ok: false, reason: `qa-report.json not found at ${reportPath}` };
+    }
+    let raw;
+    try { raw = fs.readFileSync(reportPath, 'utf8'); }
+    catch (err) { return { ok: false, reason: `qa-report.json unreadable: ${err.message}` }; }
+    let json;
+    try { json = JSON.parse(raw); }
+    catch (err) { return { ok: false, reason: `qa-report.json invalid JSON: ${err.message}` }; }
+    return { ok: true, report: json };
+}
+
+// ─── Listado de PNGs en evidence dir ─────────────────────────────────────
+function listEvidencePngs(evidenceDir) {
+    if (!fs.existsSync(evidenceDir)) return [];
+    let entries;
+    try { entries = fs.readdirSync(evidenceDir); }
+    catch { return []; }
+    return entries
+        .filter((f) => f.toLowerCase().endsWith('.png'))
+        .map((f) => path.join(evidenceDir, f))
+        .sort();
+}
+
+// ─── Copia atómica (tmp + rename) ────────────────────────────────────────
+function atomicCopy(src, dest) {
+    const dir = path.dirname(dest);
+    fs.mkdirSync(dir, { recursive: true });
+    const tmp = `${dest}.tmp-${process.pid}-${Date.now()}`;
+    fs.copyFileSync(src, tmp);
+    fs.renameSync(tmp, dest);
+}
+
+// ─── Verificación de estructura de librería (CA-7.9) ─────────────────────
+function ensureLibraryPresent(libraryDir) {
+    const readmePath = path.join(libraryDir, 'README.md');
+    if (!fs.existsSync(libraryDir) || !fs.existsSync(readmePath)) {
+        return {
+            ok: false,
+            error: 'screenshots-reference library missing — depends on #3407',
+        };
+    }
+    return { ok: true };
+}
+
+// ─── Lógica principal (exportada para tests) ─────────────────────────────
+function promoteScreenshots(opts) {
+    const log = [];
+    const errors = [];
+    const stats = {
+        promoted: 0,
+        already_in_library: 0,
+        skipped_pii: 0,
+        skipped_unmapped: 0,
+    };
+
+    const issue = opts.issue;
+    if (!issue) {
+        errors.push('missing --issue');
+        return { ok: false, exitCode: 2, log, errors, ...stats };
+    }
+
+    const repoRoot = opts.repoRoot || REPO_ROOT;
+    const evidenceDir = opts.evidenceDir
+        || path.join(repoRoot, 'qa', 'evidence', String(issue));
+    const libraryDir = opts.libraryDir
+        || path.join(repoRoot, 'docs', 'app-screenshots-reference');
+    const reportPath = opts.report
+        || path.join(evidenceDir, 'qa-report.json');
+    const date = validateDate(opts.date || '') || todayIso(opts.now || new Date());
+    const requireFn = opts.requireFn || require;
+    const piiPolicyPath = opts.piiPolicyPath || PII_POLICY_PATH;
+
+    // CA-7.9 — Librería debe existir (responsabilidad de #3407).
+    const libCheck = ensureLibraryPresent(libraryDir);
+    if (!libCheck.ok) {
+        errors.push(libCheck.error);
+        return { ok: false, exitCode: 1, log, errors, ...stats };
+    }
+
+    // Leer qa-report para verdict + metadata.
+    const reportRead = readQaReport(reportPath);
+    if (!reportRead.ok) {
+        errors.push(reportRead.reason);
+        return { ok: false, exitCode: 1, log, errors, ...stats };
+    }
+    const report = reportRead.report;
+
+    if (report.verdict && String(report.verdict).toUpperCase() !== 'APROBADO') {
+        log.push(`qa-report verdict is ${report.verdict} — promotion skipped`);
+        return { ok: true, exitCode: 0, log, errors, ...stats };
+    }
+
+    // CA-7.7/7.8 — Fail-safe ante ausencia de política PII.
+    const pii = loadPIIPolicy({ piiPolicyPath, requireFn });
+    if (!pii.available) {
+        log.push(`PII policy unavailable — promotion skipped (${pii.reason})`);
+        return { ok: true, exitCode: 0, log, errors, ...stats };
+    }
+
+    // Flavor: CLI > qa-report.flavor > labels (si un solo app:*).
+    const flavorCli = validateFlavor(opts.flavor);
+    const flavor = flavorCli || inferFlavorFromReport(report);
+    if (!flavor) {
+        log.push('flavor not resolved (no --flavor, no qa-report.flavor, no single app:* label) — promotion skipped');
+        return { ok: true, exitCode: 0, log, errors, ...stats };
+    }
+
+    // Listar PNGs.
+    const pngs = listEvidencePngs(evidenceDir);
+    if (pngs.length === 0) {
+        log.push(`no PNGs found in ${evidenceDir} — nothing to promote`);
+        log.push('promoted 0 screenshots to library');
+        return { ok: true, exitCode: 0, log, errors, ...stats };
+    }
+
+    // Procesar cada PNG.
+    for (const png of pngs) {
+        const filename = path.basename(png);
+
+        // Mapeo pantalla canónica.
+        const screen = inferScreen(filename);
+        if (!screen) {
+            stats.skipped_unmapped++;
+            log.push(`unmapped: ${filename} — no canonical screen matched, skipped`);
+            continue;
+        }
+
+        // Consulta PII (import explícito ya validado arriba).
+        let piiCheck;
+        try {
+            piiCheck = pii.policy.hasPII(png, { issue, flavor, screen });
+        } catch (err) {
+            // CA-7.7 refuerzo defensivo: si hasPII lanza, fail-safe.
+            stats.skipped_pii++;
+            log.push(`PII check threw on ${filename} — skipped (${err.message})`);
+            continue;
+        }
+        if (piiCheck && piiCheck.flagged) {
+            stats.skipped_pii++;
+            const flagsDesc = Array.isArray(piiCheck.flags) && piiCheck.flags.length > 0
+                ? ` [${piiCheck.flags.join(', ')}]`
+                : '';
+            log.push(`PII detected — promotion skipped: ${filename}${flagsDesc}`);
+            continue;
+        }
+
+        // Path canónico destino.
+        const targetName = `${screen}-${flavor}-${date}.png`;
+        const targetPath = path.join(libraryDir, screen, targetName);
+
+        // Idempotencia: si destino existe y tiene mismo hash → no-op.
+        let isSameContent = false;
+        if (fs.existsSync(targetPath)) {
+            try {
+                isSameContent = sha256File(png) === sha256File(targetPath);
+            } catch { isSameContent = false; }
+        }
+
+        if (isSameContent) {
+            stats.already_in_library++;
+            log.push(`already in library: ${screen}/${targetName} (same content)`);
+            continue;
+        }
+
+        // Sobreescritura misma fecha (último QA del día gana — CA-7.3).
+        const willOverwrite = fs.existsSync(targetPath);
+
+        if (opts.dryRun) {
+            stats.promoted++;
+            log.push(`[dry-run] would promote ${filename} → ${screen}/${targetName}`);
+            if (willOverwrite) log.push(`[dry-run] overwritten same-day screenshot ${screen}/${flavor}`);
+            continue;
+        }
+
+        try {
+            atomicCopy(png, targetPath);
+        } catch (err) {
+            errors.push(`failed to promote ${filename}: ${err.message}`);
+            continue;
+        }
+        stats.promoted++;
+        log.push(`promoted ${filename} → ${screen}/${targetName}`);
+        if (willOverwrite) {
+            log.push(`overwritten same-day screenshot ${screen}/${flavor}`);
+        }
+    }
+
+    // Resumen final accionable (CA-7.4 / CA-7.5).
+    if (stats.promoted === 0 && stats.already_in_library > 0 && stats.skipped_pii === 0 && stats.skipped_unmapped === 0) {
+        log.push(`promoted 0 screenshots (already in library)`);
+    } else {
+        log.push(`promoted ${stats.promoted} screenshots to library`);
+    }
+
+    return {
+        ok: errors.length === 0,
+        exitCode: errors.length === 0 ? 0 : 1,
+        log,
+        errors,
+        ...stats,
+    };
+}
+
+// ─── CLI entrypoint ──────────────────────────────────────────────────────
+function main() {
+    let args;
+    try {
+        args = parseArgs(process.argv);
+    } catch (err) {
+        process.stdout.write(JSON.stringify({
+            ok: false,
+            errors: [err.message],
+            log: [],
+            promoted: 0,
+            already_in_library: 0,
+            skipped_pii: 0,
+            skipped_unmapped: 0,
+        }, null, 2) + '\n');
+        process.exit(2);
+    }
+
+    const result = promoteScreenshots({
+        issue: args.issue,
+        evidenceDir: args.evidenceDir,
+        libraryDir: args.libraryDir,
+        report: args.report,
+        flavor: args.flavor,
+        date: args.date,
+        dryRun: args.dryRun,
+    });
+
+    process.stdout.write(JSON.stringify({
+        ok: result.ok,
+        promoted: result.promoted,
+        already_in_library: result.already_in_library,
+        skipped_pii: result.skipped_pii,
+        skipped_unmapped: result.skipped_unmapped,
+        log: result.log,
+        errors: result.errors,
+    }, null, 2) + '\n');
+
+    process.exit(result.exitCode);
+}
+
+if (require.main === module) {
+    main();
+}
+
+module.exports = {
+    promoteScreenshots,
+    inferScreen,
+    inferFlavorFromReport,
+    loadPIIPolicy,
+    ensureLibraryPresent,
+    todayIso,
+    sha256File,
+    SCREEN_HEURISTICS,
+    VALID_FLAVORS,
+    PII_POLICY_PATH,
+};


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 7 archivos · +1364 -35

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:skipped` aplicado por delivery

## Closes

Closes #3409
