### PR TITLE
chore(pipeline): reordenar providers de telegram-sherlock priorizando calidad y consistencia

### DIFF
--- a/.pipeline/agent-models.json
+++ b/.pipeline/agent-models.json
@@ -430,24 +430,24 @@
       ]
     },
     "telegram-sherlock": {
-      "provider": "cerebras",
-      "model_override": "llama-3.3-70b",
+      "provider": "anthropic",
+      "model_override": "claude-haiku-4-5",
       "fallbacks": [
-        {
-          "provider": "gemini-google",
-          "model_override": "gemini-2.0-flash"
-        },
-        {
-          "provider": "nvidia-nim",
-          "model_override": "deepseek-ai/deepseek-v4-pro"
-        },
         {
           "provider": "openai-codex",
           "model_override": "gpt-5"
         },
         {
-          "provider": "anthropic",
-          "model_override": "claude-haiku-4-5"
+          "provider": "gemini-google",
+          "model_override": "gemini-2.0-flash"
+        },
+        {
+          "provider": "cerebras",
+          "model_override": "llama-3.3-70b"
+        },
+        {
+          "provider": "nvidia-nim",
+          "model_override": "deepseek-ai/deepseek-v4-pro"
         }
       ]
     }


### PR DESCRIPTION
## Resumen

Reordena la cadena de providers de `telegram-sherlock` en `.pipeline/agent-models.json` para priorizar **calidad y consistencia** sobre velocidad/costo cero.

## Nuevo orden

| # | Provider | Modelo | Tipo |
|---|---|---|---|
| **1** | anthropic | claude-haiku-4-5 | Pagado barato (primario) |
| **2** | openai-codex | gpt-5 | Pagado (fallback equivalente) |
| **3** | gemini-google | gemini-2.0-flash | Free |
| **4** | cerebras | llama-3.3-70b | Free + rápido |
| **5** | nvidia-nim | deepseek-v4-pro | Free experimental |

## Motivación

Decidido por Leo via Telegram el 2026-05-22.

- El orden anterior `cerebras → gemini → nvidia-nim → codex → anthropic` optimizaba latencia + free tier, pero generaba **timeouts y "sin provider" recurrentes** y verificaciones inconsistentes.
- Haiku 4.5 da el **mejor ratio calidad/costo** del stack (~$1/M input) con razonamiento sólido y, al ser misma familia que el Commander (Opus 4.7), aplica criterios consistentes para detectar contradicciones.
- Los free providers quedan como red de seguridad — siguen entrando si los pagos caen, pero no son la fuente primaria de juicio.

## qa:skipped

Cambio puro de configuración (un JSON del pipeline). Sin código nuevo, sin impacto en producto de usuario.

## Test plan

- [x] JSON parsea OK
- [x] Cadena correcta (validada por script)
- [ ] Post-merge: restart del pipeline para tomar el cambio
- [ ] Observar al próximo Sherlock pegando a Anthropic primero en logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)