### PR TITLE
fix(pipeline): TTS no aplica double-summarize en audios (#3512)

### DIFF
--- a/.pipeline/lib/__tests__/text-to-speech-adapter.test.js
+++ b/.pipeline/lib/__tests__/text-to-speech-adapter.test.js
@@ -384,6 +384,45 @@ test('compat: sanitizeForTts con undefined devuelve undefined', () => {
 });
 
 // -----------------------------------------------------------------------------
+// #3512 — sanitizeForTts por default NO debe resumir
+// -----------------------------------------------------------------------------
+
+test('#3512: sanitizeForTts NO resume texto >1500 chars por default', () => {
+    // Construir texto plano sin markdown, >1500 chars y >3800 chars para
+    // emular un chunk del caller (pulpo.js chunkea a 3800).
+    const oracion = 'Esta es una oracion de prueba con datos numericos como 42 y 1234 que ocupa un espacio razonable. ';
+    const input = oracion.repeat(50); // ~5000 chars
+    assert.ok(input.length > 3800, 'fixture debe ser mayor a 3800 chars');
+
+    const out = sanitizeForTts(input);
+
+    // Si se hubiera resumido, el output seria <=1500 chars.
+    assert.ok(
+        out.length > 3000,
+        `sanitizeForTts truncar a ${out.length} chars indica que el resumen sigue activo por default (#3512)`
+    );
+});
+
+test('#3512: sanitizeForTts respeta opt-in summarize:true cuando el caller lo pide', () => {
+    const oracion = 'Otra oracion larga que se repite para forzar resumen heuristico. ';
+    const input = oracion.repeat(40); // ~2600 chars
+    assert.ok(input.length > 1500);
+
+    const out = sanitizeForTts(input, { summarize: true, maxChars: 800 });
+
+    assert.ok(out.length <= 900, 'con summarize:true explicito si debe resumir');
+});
+
+test('#3512: textToSpeechScript mantiene resumen por default (opt-out backward compat)', () => {
+    // textToSpeechScript NO cambia su default — sigue resumiendo si supera maxChars.
+    const oracion = 'Texto largo para probar default de textToSpeechScript. ';
+    const input = oracion.repeat(50);
+    const { script, summarized } = textToSpeechScript(input);
+    assert.equal(summarized, true, 'textToSpeechScript sigue resumiendo por default');
+    assert.ok(script.length <= 1600, 'maxChars default 1500 se respeta');
+});
+
+// -----------------------------------------------------------------------------
 // Fixtures realistas (CA-14: anonimizadas, sin PII real)
 // -----------------------------------------------------------------------------
 

--- a/.pipeline/lib/text-to-speech-adapter.js
+++ b/.pipeline/lib/text-to-speech-adapter.js
@@ -27,10 +27,17 @@
 //   8. Limpieza visual de markdown (headers, listas, code blocks, tablas
 //      a frase natural, emojis decorativos).
 //   9. Resumen heuristico si supera maxChars (default 1500).
+//      OJO (#3512): este resumen NO se aplica desde sanitizeForTts, porque
+//      los callers de TTS chunkean el texto antes (splitTextForTTSChunks a
+//      3800 chars). Si el adapter resumiera cada chunk perderiamos ~60% del
+//      texto en cada audio. El resumen es opt-in via textToSpeechScript({
+//      summarize: true, maxChars: N }) cuando el caller realmente quiere un
+//      digest acotado y no un audio fiel del texto completo.
 //
 // API publica:
 //   textToSpeechScript(text, opts) -> { script, droppedCategories, summarized }
-//   sanitizeForTts(text)          -> string (compat con multimedia.js)
+//   sanitizeForTts(text)          -> string (compat con multimedia.js).
+//                                    Por default summarize=false (#3512).
 //
 // Garantiza idempotencia: adapter(adapter(x).script).script === adapter(x).script.
 // =============================================================================
@@ -457,13 +464,23 @@ function textToSpeechScript(text, opts = {}) {
 
 /**
  * Compat con multimedia.js — devuelve solo el script.
+ *
+ * IMPORTANTE (#3512): por default NO resume. Los callers (multimedia.js,
+ * pulpo.js) ya chunkean el texto a 3800 chars antes de enviarlo al TTS;
+ * si el adapter aplicara summarize=true cada chunk se truncaria a 1500
+ * chars y los audios saldrian recortados al ~40% del texto real.
+ *
+ * Si necesitas un digest, usa textToSpeechScript({ summarize: true, maxChars }).
+ *
  * @param {string} text
  * @param {object} [opts]
+ * @param {boolean} [opts.summarize=false] - opt-in al resumen heuristico.
  * @returns {string}
  */
 function sanitizeForTts(text, opts = {}) {
     if (text == null) return text;
-    return textToSpeechScript(text, opts).script;
+    const effectiveOpts = { summarize: false, ...opts };
+    return textToSpeechScript(text, effectiveOpts).script;
 }
 
 module.exports = {

--- a/docs/audio-ux-guidelines.md
+++ b/docs/audio-ux-guidelines.md
@@ -24,9 +24,9 @@ Opciones:
 
 | Opcion | Default | Que hace |
 |---|---|---|
-| `maxChars` | `1500` | Cap del script. Si se excede, se aplica resumen heuristico. |
+| `maxChars` | `1500` | Cap del script cuando `summarize=true`. Si se excede, se aplica resumen heuristico. |
 | `preserveModelNames` | `true` (desde #3505) | Por default conserva nombres de modelo IA y proveedor (Sonnet, Opus, Claude, Gemini, Cerebras, Codex, GPT-4o, etc.) tal cual — son palabras cortas que el motor TTS pronuncia bien y Whisper transcribe correctamente. Pasar `false` solo si se necesita un audio totalmente generico (uso historico pre-#3505). |
-| `summarize` | `true` | Si `false`, no aplica resumen aunque exceda `maxChars`. |
+| `summarize` | `true` en `textToSpeechScript` · **`false` en `sanitizeForTts`** (desde #3512) | Si `false`, no aplica resumen aunque exceda `maxChars`. `sanitizeForTts` lo desactiva por default porque los callers (`pulpo.js`, `multimedia.js`) ya chunkean el texto a 3800 chars antes de invocar TTS; si el adapter resumiera cada chunk a 1500, perderiamos ~60% del audio en cada mensaje largo. Pasar `summarize: true` explicito cuando se quiera un digest acotado. |
 
 ## Pipeline de transformacion (orden importa)
 
@@ -38,7 +38,7 @@ Opciones:
 6. **Paths** — `C:\...`, `.pipeline/...`, `./foo/bar.js` → `"archivo del pipeline"`.
 7. **Hashes de commit** — 7 a 40 hex aislados → `"commit reciente"`.
 8. **Markdown + emojis + tablas** — headers, listas, code blocks, italicas, negritas, blockquotes, emojis decorativos. Tablas cortas (<= 4 filas x <= 4 columnas) se reformulan a frase natural; tablas grandes caen al fallback CSV.
-9. **Resumen heuristico** — si supera `maxChars`, conserva primer parrafo + primeras oraciones de los siguientes parrafos hasta llenar el cap.
+9. **Resumen heuristico** — opt-in. Solo se aplica si el caller pasa `summarize: true` (default en `textToSpeechScript`) y supera `maxChars`. **No se aplica desde `sanitizeForTts`** (desde #3512) porque los callers reales ya chunkean a 3800 chars y un resumen ah comeria 60% del audio.
 
 ## Catalogo de reglas (con ejemplos antes/despues)
 


### PR DESCRIPTION
## Summary

- `sanitizeForTts` tenía `summarize:true` por default, comprimiendo cada chunk de 3800 chars a ~1500 chars después de que el chunking ya fue hecho
- El adapter resumía cada chunk y los audios narran solo el 40-50% del contenido
- Fix: cambiar default a `summarize: false` — el resumen ahora es opt-in explícito

## Test plan

- [x] Tests 50/50 verde (`text-to-speech-adapter.test.js`)
- [x] Smoke test flujo completo: `splitTextForTTSChunks → sanitizeForTts` preserva 100% del texto
- [x] Callers verificados: ninguno pasa `summarize:true` hardcodeado
- [x] Retrocompatible: API pública sin cambios de firma

## QA

`qa:skipped` — cambio de infra pipeline interno, sin impacto en producto de usuario.

Closes #3512

🤖 Generated with [Claude Code](https://claude.com/claude-code)