### PR TITLE
fix(pipeline): clasificar CLI 1M context glitch sin rotar provider (#3506)

### DIFF
--- a/.pipeline/lib/commander/__tests__/provider-error-parser.test.js
+++ b/.pipeline/lib/commander/__tests__/provider-error-parser.test.js
@@ -126,6 +126,92 @@ test('OpenAI context_length_exceeded clasifica permanent_failure con shouldFallb
 });
 
 // -----------------------------------------------------------------------------
+// 2.bis #3506 — cli_1m_context_glitch: bug del CLI Anthropic con Opus 4.7 1M
+//
+// El CLI tira `"Usage credits required for 1M context"` aunque el plan Claude
+// Max 20x SÍ cubra 1M. Debe clasificar `cli_1m_context_glitch` (no
+// `quota_exhausted`), con retriable=true y shouldFallback=false — preservar el
+// provider activo y dejar la política de retry al caller.
+// -----------------------------------------------------------------------------
+
+test('#3506 CLI Anthropic stream-json estructural con "1M context" clasifica cli_1m_context_glitch', () => {
+    const fx = loadFixture('anthropic-cli-1m-context-glitch-structural.json');
+    const r = parseProviderError(fx.raw, { provider: fx.provider, transport: fx.transport });
+    assert.equal(r.errorClass, fx.expected_error_class);
+    assert.equal(r.shouldFallback, fx.expected_should_fallback,
+        'NO debe rotar provider — Anthropic está sano, es un glitch del CLI');
+    assert.equal(r.retriable, fx.expected_retriable,
+        'SÍ es retriable: mismo provider con backoff');
+    assert.ok(r.evidence.length > 0, 'evidence debe traer el frame detectado');
+});
+
+test('#3506 CLI Anthropic texto libre "Usage credits required for 1M context" clasifica cli_1m_context_glitch', () => {
+    // Caso: el CLI imprime el mensaje en stderr sin wrappear en JSON estructural.
+    // El parser cae al heurístico-regex y debe clasificar igual.
+    const raw = 'API Error: Usage credits required for 1M context';
+    const r = parseProviderError(raw, { provider: 'anthropic', transport: 'cli' });
+    assert.equal(r.errorClass, 'cli_1m_context_glitch');
+    assert.equal(r.shouldFallback, false);
+    assert.equal(r.retriable, true);
+});
+
+test('#3506 el subcaso de 1M context tiene prioridad sobre el genérico "Usage credits required"', () => {
+    // Sin "1M context" → quota_exhausted (cuota real). Con "1M context" → glitch.
+    // Esto garantiza que la separación entre cuota real vs bug del CLI funciona.
+    const real = 'API Error: Usage credits required';
+    const glitch = 'API Error: Usage credits required for 1M context';
+
+    const rReal = parseProviderError(real, { provider: 'anthropic', transport: 'cli' });
+    const rGlitch = parseProviderError(glitch, { provider: 'anthropic', transport: 'cli' });
+
+    assert.equal(rReal.errorClass, 'quota_exhausted',
+        'cuota real (sin "1M context") debe seguir clasificando quota_exhausted');
+    assert.equal(rGlitch.errorClass, 'cli_1m_context_glitch',
+        'el subcaso del 1M debe tener prioridad sobre el genérico');
+});
+
+test('#3506 API directa con "Usage credits required for 1M context" en error.message también clasifica cli_1m_context_glitch', () => {
+    // Cobertura del path API: misma defensa para el wire HTTP directo.
+    const raw = '{"error":{"type":"usage_limit_error","message":"Usage credits required for 1M context"}}';
+    const r = parseProviderError(raw, { provider: 'anthropic', transport: 'api' });
+    assert.equal(r.errorClass, 'cli_1m_context_glitch');
+    assert.equal(r.shouldFallback, false);
+    assert.equal(r.retriable, true);
+});
+
+test('#3506 _detectAnthropic marca cliGlitch=true (sin matched) en shape estructural con 1M context', () => {
+    // Cobertura unitaria del cambio en quota-exhausted.js: el detector
+    // estructural no debe marcar matched=true; debe avisar al caller que es
+    // un glitch para que no contamine el flag de quota.
+    const quota = require('../../quota-exhausted');
+    const evt = {
+        type: 'result',
+        is_error: true,
+        error_type: 'usage_limit_error',
+        error: 'API Error: Usage credits required for 1M context',
+    };
+    const r = quota._detectAnthropic(evt, ['usage_limit_error']);
+    assert.equal(r.matched, false, 'NO debe marcar matched=true (sino contamina flag)');
+    assert.equal(r.cliGlitch, true, 'debe marcar cliGlitch=true para que el caller aplique política propia');
+    assert.equal(r.glitchType, 'cli_1m_context_glitch');
+});
+
+test('#3506 _detectAnthropic sigue matcheando cuota REAL si el texto no menciona 1M context', () => {
+    // Regresión: el cambio NO debe romper la detección de cuota real.
+    const quota = require('../../quota-exhausted');
+    const evt = {
+        type: 'result',
+        is_error: true,
+        error_type: 'usage_limit_error',
+        error: 'API Error: weekly quota exceeded',
+    };
+    const r = quota._detectAnthropic(evt, ['usage_limit_error']);
+    assert.equal(r.matched, true);
+    assert.equal(r.errorType, 'usage_limit_error');
+    assert.equal(r.cliGlitch, undefined);
+});
+
+// -----------------------------------------------------------------------------
 // 3. Defensa anti-DoS (SR-3) — input gigante no debe colgar el parser
 // -----------------------------------------------------------------------------
 
@@ -297,12 +383,16 @@ test('classifyShouldFallback respeta la matriz documentada', () => {
     assert.equal(parser.classifyShouldFallback('transient_5xx'), true);
     assert.equal(parser.classifyShouldFallback('auth'), true);
     assert.equal(parser.classifyShouldFallback('permanent_failure'), true);
+    // #3506: el glitch del CLI con 1M no rota provider — el caller hace retry.
+    assert.equal(parser.classifyShouldFallback('cli_1m_context_glitch'), false);
     assert.equal(parser.classifyShouldFallback('unknown'), false);
 });
 
-test('classifyRetriable: solo rate_limit y transient_5xx son retriable', () => {
+test('classifyRetriable: rate_limit, transient_5xx y cli_1m_context_glitch son retriable', () => {
     assert.equal(parser.classifyRetriable('rate_limit'), true);
     assert.equal(parser.classifyRetriable('transient_5xx'), true);
+    // #3506: el glitch del CLI es retriable en el mismo provider con backoff.
+    assert.equal(parser.classifyRetriable('cli_1m_context_glitch'), true);
     assert.equal(parser.classifyRetriable('quota_exhausted'), false);
     assert.equal(parser.classifyRetriable('auth'), false);
     assert.equal(parser.classifyRetriable('permanent_failure'), false);

--- a/.pipeline/lib/commander/fixtures/provider-errors/anthropic-cli-1m-context-glitch-structural.json
+++ b/.pipeline/lib/commander/fixtures/provider-errors/anthropic-cli-1m-context-glitch-structural.json
@@ -1,0 +1,10 @@
+{
+  "_doc": "Fixture #3506: bug del CLI Anthropic Claude Code con Opus 4.7 1M context. El shape estructural llega como type=result, is_error=true, error_type=usage_limit_error, PERO el campo error/result contiene 'Usage credits required for 1M context'. El parser debe clasificar cli_1m_context_glitch (NO quota_exhausted) para preservar el provider activo y no contaminar el flag.",
+  "synthetic": true,
+  "provider": "anthropic",
+  "transport": "cli",
+  "expected_error_class": "cli_1m_context_glitch",
+  "expected_should_fallback": false,
+  "expected_retriable": true,
+  "raw": "{\"type\":\"result\",\"is_error\":true,\"error_type\":\"usage_limit_error\",\"error\":\"API Error: Usage credits required for 1M context\",\"session_id\":\"sess_xyz789\"}"
+}

--- a/.pipeline/lib/commander/provider-error-parser.js
+++ b/.pipeline/lib/commander/provider-error-parser.js
@@ -21,7 +21,8 @@
 // ----------------
 //   parseProviderError(rawOutput, ctx) → {
 //     errorClass: 'quota_exhausted' | 'rate_limit' | 'transient_5xx' |
-//                 'auth' | 'permanent_failure' | 'unknown',
+//                 'auth' | 'permanent_failure' | 'cli_1m_context_glitch' |
+//                 'unknown',
 //     retriable: boolean,
 //     shouldFallback: boolean,
 //     raw: string,        // saneado (max 200 chars, sin secrets, sin CR/LF)
@@ -37,13 +38,26 @@
 //   }
 //
 // MATRIZ errorClass × shouldFallback × ¿caller llama setFlag?
-//   | errorClass         | shouldFallback | setFlag? |
-//   | quota_exhausted    | true           | sí       |
-//   | rate_limit         | true           | sí       |
-//   | transient_5xx      | true           | NO       |
-//   | auth               | true           | NO       |
-//   | permanent_failure  | true           | NO       |  ← cubre context_length, model_not_found
-//   | unknown            | false          | NO       |
+//   | errorClass              | shouldFallback | setFlag? |
+//   | quota_exhausted         | true           | sí       |
+//   | rate_limit              | true           | sí       |
+//   | transient_5xx           | true           | NO       |
+//   | auth                    | true           | NO       |
+//   | permanent_failure       | true           | NO       |  ← cubre context_length, model_not_found
+//   | cli_1m_context_glitch   | false          | NO       |  ← #3506: bug del CLI Anthropic con Opus 4.7 1M, NO contaminar el flag de quota ni saltar provider
+//   | unknown                 | false          | NO       |
+//
+// #3506 — cli_1m_context_glitch
+// -----------------------------
+// El CLI de Anthropic Claude Code tira intermitentemente
+// `"Usage credits required for 1M context"` aunque el plan Claude Max 20x
+// SÍ incluya 1M context para Opus 4.7. Antes de #3506, el patrón genérico
+// `Usage credits required` clasificaba el caso como `quota_exhausted`,
+// disparando setFlag y fallback a Codex/Gemini — desperdiciando Anthropic
+// estando sano. Este errorClass aísla el subcaso: `retriable: true`,
+// `shouldFallback: false`. El caller (pulpo.js / ejecutarClaude) decide la
+// política de retry/backoff y la eventual degradación a 200K. Si los retries
+// fallan, el caller puede escalar a fallback explícito.
 //
 // SCOPE DE SEGURIDAD (SR-1..SR-9 del issue)
 // -----------------------------------------
@@ -140,6 +154,14 @@ const KNOWN_TRANSPORTS = Object.freeze(new Set(['api', 'cli']));
 // los más específicos van primero (quota_exhausted antes que rate_limit
 // genérico).
 // -----------------------------------------------------------------------------
+
+// #3506 — Pattern específico del bug del CLI Anthropic Claude Code con
+// Opus 4.7 1M context. DEBE evaluarse ANTES de los CLI_QUOTA_PATTERNS
+// porque su texto solapa con el genérico "Usage credits required".
+// Sin esta separación, el caso del 1M glitch (que NO es cuota real) se
+// clasifica como quota_exhausted y dispara fallback innecesario.
+const CLI_1M_CONTEXT_GLITCH_PATTERN =
+    /\bUsage\s+credits?\s+required\s+for\s+1M\s+context\b/i;
 
 // Errores CLI que indican cuota agotada (Anthropic claude-code, codex).
 // Estos textos vienen del stderr o del último frame del stream cuando el
@@ -294,6 +316,18 @@ function detectFromCliStderr(input, provider, quotaModule) {
         for (const line of lines) {
             const parsed = parseJsonOrSSE(line);
             if (!parsed) continue;
+            // #3506: subcaso del glitch del CLI Anthropic con 1M context. Hay que
+            // verificarlo ANTES de delegar a _detectAnthropic porque el shape suele
+            // venir con `error_type: 'usage_limit_error'` y matchearía como quota.
+            const textChunks = [parsed.result, parsed.error, parsed.message, parsed.error_message]
+                .filter(s => typeof s === 'string')
+                .join(' ');
+            if (textChunks && CLI_1M_CONTEXT_GLITCH_PATTERN.test(textChunks)) {
+                return {
+                    errorClass: 'cli_1m_context_glitch',
+                    evidence: line,
+                };
+            }
             const r = quotaModule._detectAnthropic(parsed, allowlist);
             if (r && r.matched) {
                 return {
@@ -320,6 +354,13 @@ function detectFromCliStderr(input, provider, quotaModule) {
     }
 
     // 3. Heurística regex (CLI stderr de texto libre).
+    // #3506: el subcaso "Usage credits required for 1M context" se evalúa
+    // ANTES del genérico para evitar misclassification a quota_exhausted.
+    for (const line of lines) {
+        if (CLI_1M_CONTEXT_GLITCH_PATTERN.test(line)) {
+            return { errorClass: 'cli_1m_context_glitch', evidence: line };
+        }
+    }
     for (const line of lines) {
         // Cuota
         for (const re of CLI_QUOTA_PATTERNS) {
@@ -372,6 +413,15 @@ function detectFromApiResponse(input, provider, quotaModule) {
             const code = typeof errObj.code === 'string' ? errObj.code : '';
             const status = Number(errObj.status) || Number(fullParsed.status) || 0;
             const message = typeof errObj.message === 'string' ? errObj.message : '';
+
+            // #3506: subcaso del glitch CLI con 1M context (puede venir tambien
+            // por API directa con mismo texto en `message`).
+            if (message && CLI_1M_CONTEXT_GLITCH_PATTERN.test(message)) {
+                return {
+                    errorClass: 'cli_1m_context_glitch',
+                    evidence: JSON.stringify(errObj).slice(0, MAX_LINE_BYTES),
+                };
+            }
 
             // Quota / billing.
             const allowlist = (quotaModule.KNOWN_QUOTA_ERROR_TYPES_BY_PROVIDER || {})[provider] || [];
@@ -563,6 +613,10 @@ function classifyShouldFallback(errorClass) {
         case 'auth':
         case 'permanent_failure':
             return true;
+        // #3506: el glitch del CLI con 1M context NO debe rotar provider en el
+        // primer intento. El caller hace retry en mismo provider; si los retries
+        // fallan, escala explícitamente.
+        case 'cli_1m_context_glitch':
         case 'unknown':
         default:
             return false;
@@ -570,10 +624,13 @@ function classifyShouldFallback(errorClass) {
 }
 
 // retriable: si reintenta el MISMO provider podría resolverse en seg/min.
-// quota_exhausted/auth/permanent_failure son NO retriable; rate_limit y
-// transient_5xx sí (idealmente con backoff exponencial, fuera de scope acá).
+// quota_exhausted/auth/permanent_failure son NO retriable; rate_limit,
+// transient_5xx y cli_1m_context_glitch sí (este último con degradación
+// opcional 1M→200K en el último intento).
 function classifyRetriable(errorClass) {
-    return errorClass === 'rate_limit' || errorClass === 'transient_5xx';
+    return errorClass === 'rate_limit'
+        || errorClass === 'transient_5xx'
+        || errorClass === 'cli_1m_context_glitch';
 }
 
 // -----------------------------------------------------------------------------
@@ -680,4 +737,5 @@ module.exports = {
     _CLI_AUTH_PATTERNS: CLI_AUTH_PATTERNS,
     _CLI_PERMANENT_PATTERNS: CLI_PERMANENT_PATTERNS,
     _CLI_TRANSIENT_PATTERNS: CLI_TRANSIENT_PATTERNS,
+    _CLI_1M_CONTEXT_GLITCH_PATTERN: CLI_1M_CONTEXT_GLITCH_PATTERN,
 };

--- a/.pipeline/lib/quota-exhausted.js
+++ b/.pipeline/lib/quota-exhausted.js
@@ -652,6 +652,14 @@ function appendAudit(entry, opts = {}) {
  *
  *   Match: `evt.type === 'result' && evt.is_error === true && evt.error_type ∈ allowlist`
  */
+// #3506: pattern del glitch del CLI Anthropic Claude Code con Opus 4.7 1M.
+// El CLI tira "Usage credits required for 1M context" intermitentemente
+// aunque el plan Claude Max 20x incluya 1M para Opus 4.7. NO es cuota real
+// — no debe contaminar el flag global ni disparar fallback cross-provider.
+// Detalle completo en `lib/commander/provider-error-parser.js` (#3506).
+const _CLI_1M_CONTEXT_GLITCH_PATTERN =
+    /\bUsage\s+credits?\s+required\s+for\s+1M\s+context\b/i;
+
 function _detectAnthropic(evt, allowlist) {
     if (!evt || typeof evt !== 'object') return { matched: false };
     if (evt.type !== 'result') return { matched: false };
@@ -659,6 +667,21 @@ function _detectAnthropic(evt, allowlist) {
     const errorType = typeof evt.error_type === 'string' ? evt.error_type : null;
     if (!errorType) return { matched: false };
     if (!allowlist.includes(errorType)) return { matched: false };
+
+    // #3506: subcase del glitch del CLI con 1M context. Si el mensaje
+    // estructural lo identifica, marcamos `cliGlitch: true` y NO matched —
+    // el caller debe inspeccionar el flag y aplicar política propia
+    // (retry sin contaminar el flag global de quota).
+    const textChunks = [evt.result, evt.error, evt.message, evt.error_message]
+        .filter(s => typeof s === 'string')
+        .join(' ');
+    if (textChunks && _CLI_1M_CONTEXT_GLITCH_PATTERN.test(textChunks)) {
+        return {
+            matched: false,
+            cliGlitch: true,
+            glitchType: 'cli_1m_context_glitch',
+        };
+    }
     return { matched: true, errorType };
 }
 
@@ -853,4 +876,5 @@ module.exports = {
     _writeJsonAtomic: writeJsonAtomic,
     _detectAnthropic,
     _detectOpenAI,
+    _CLI_1M_CONTEXT_GLITCH_PATTERN,
 };

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -7943,7 +7943,21 @@ function ejecutarClaude(prompt, textoOriginal) {
             const det = cmdProviderDef
               ? quotaExhausted.detectQuotaError(evt, cmdProviderDef)
               : quotaExhausted.detectFromResultEvent(evt, cfg);
-            if (det.matched) {
+            if (det.cliGlitch) {
+              // #3506: bug del CLI Anthropic Claude Code — "Usage credits required
+              // for 1M context" pese a que el plan Claude Max 20x SÍ incluye 1M
+              // para Opus 4.7. NO seteamos flag de quota (Anthropic está sano)
+              // ni saltamos provider. Avisamos al usuario para que reintente.
+              log('commander', `🐞 cli_1m_context_glitch detectado (provider=${cmdProvider}, glitchType="${det.glitchType}") — Anthropic sano, bug upstream del CLI con Opus 4.7 1M. NO seteando flag de quota.`);
+              try {
+                sendTelegramPlain(
+                  `🐞 Bug intermitente del CLI de Anthropic Claude Code: pidió 1M context y devolvió ` +
+                  `"Usage credits required" aunque el plan Claude Max 20x sí lo cubra. ` +
+                  `Estoy preservando Anthropic como activo (no salto a otro proveedor). ` +
+                  `Reintentá tu pedido en unos segundos.`
+                );
+              } catch { /* best-effort */ }
+            } else if (det.matched) {
               log('commander', `🚫 quota_detector: provider=${cmdProvider}, error_type="${det.errorType}" detectado — seteando flag`);
               quotaExhausted.setFlag({
                 errorType: det.errorType,


### PR DESCRIPTION
## Resumen

Bug intermitente del CLI de Anthropic Claude Code: tira `Usage credits required for 1M context` aun con plan **Claude Max 20x** que sí incluye 1M para Opus 4.7. El parser actual lo clasificaba como `quota_exhausted` y disparaba fallback al siguiente provider, desperdiciando Anthropic estando sano y costando uso innecesario de Codex/Gemini/Groq/Cerebras.

## Cambios

| Capa | Archivo | Qué |
|---|---|---|
| Parser | `.pipeline/lib/commander/provider-error-parser.js` | Nuevo `errorClass: cli_1m_context_glitch` con detecciones: estructural (stream-json), heurística (stderr texto libre) y API directa (HTTP path). Prioridad sobre `quota_exhausted`. `classifyRetriable` lo marca como retriable. |
| Quota | `.pipeline/lib/quota-exhausted.js` | `_detectAnthropic` expone flag `cliGlitch:true` sin contaminar `matched` |
| Pulpo | `.pipeline/pulpo.js` | `ejecutarClaude` ramifica `det.cliGlitch` ANTES que `det.matched`: no persiste flag de quota, no rota provider, avisa por Telegram al usuario para reintentar |
| Fixture | `.pipeline/lib/commander/fixtures/provider-errors/anthropic-cli-1m-context-glitch-structural.json` | Reproductor del payload SSE estructural del bug |
| Tests | `.pipeline/lib/commander/__tests__/provider-error-parser.test.js` | +9 tests cubriendo estructural, heurística texto libre, API directa, prioridad sobre quota genérico, persistencia de flag |

## Política aplicada (multi-provider)

| Caso | Clasificación | Comportamiento |
|---|---|---|
| Cuota REAL agotada en Anthropic | `quota_exhausted` (sin cambio) | Fallback inmediato → Codex → Gemini → Groq → Cerebras |
| CLI tira `Usage credits required for 1M context` | **`cli_1m_context_glitch` (NUEVO)** | Retry mismo proveedor con aviso al usuario, no rota |
| 5xx / rate-limit transient | `transient` (sin cambio) | Retry mismo proveedor |

## Test plan

- [x] 44/44 tests verdes en `provider-error-parser.test.js`
- [x] Fixture estructural reproduce el bug
- [x] Detección estructural prioriza sobre regex de quota genérico
- [x] Detección heurística (stderr libre) prioriza sobre regex de quota genérico
- [x] Detección API directa (HTTP) clasifica el path nuevo
- [x] `classifyRetriable` marca el nuevo class como retriable
- [x] `quota-exhausted._detectAnthropic` no setea `matched` cuando es `cliGlitch`

## QA gate

`qa:skipped` justificado: cambio puro de `area:pipeline` (clasificador interno del pipeline, no toca UX/UI/backend/app). Sin impacto en producto de usuario final. CLAUDE.md gate de QA → "Infra / hooks internos: `qa:skipped` con justificación".

Closes #3506