### PR TITLE
Audio splitter Telegram — bajar cap a 1500 chars para evitar truncado Edge TTS

### DIFF
--- a/.pipeline/__tests__/split-text-for-tts-chunks.test.js
+++ b/.pipeline/__tests__/split-text-for-tts-chunks.test.js
@@ -1,0 +1,165 @@
+// Tests para splitTextForTTSChunks — issue #3485.
+//
+// Cubre los CAs del refinamiento PO:
+//   CA-1: default del helper debe ser 1500 (no 3800).
+//   CA-3: división nunca parte palabras a la mitad.
+//   CA-4: texto ~1200 chars genera 1 chunk.
+//   CA-5: texto ~3000 chars genera 2 chunks.
+//   CA-6: texto ~4500 chars genera 3 chunks.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { splitTextForTTSChunks } = require('../multimedia');
+
+// --- Helpers ---
+
+// Genera un texto de aproximadamente `targetChars` caracteres compuesto por
+// oraciones de longitud "razonable" (10-15 palabras) terminadas en ".".
+// Garantiza palabras sin truncar y delimitadas por espacio.
+function generateSpanishText(targetChars) {
+  const palabras = [
+    'el', 'pipeline', 'procesa', 'cada', 'issue', 'con', 'agentes', 'que',
+    'colaboran', 'para', 'entregar', 'cambios', 'al', 'codigo', 'principal',
+    'durante', 'el', 'ciclo', 'continuo', 'sin', 'intervencion', 'manual',
+    'aunque', 'siempre', 'queda', 'el', 'gate', 'humano', 'antes', 'del',
+    'merge', 'final', 'a', 'main', 'como', 'safety', 'net', 'operativo'
+  ];
+  let texto = '';
+  let i = 0;
+  while (texto.length < targetChars) {
+    const len = 10 + (i % 6); // 10 a 15 palabras por oración
+    const oracion = Array.from({ length: len }, (_, k) => palabras[(i + k) % palabras.length]).join(' ');
+    texto += (texto.length === 0 ? '' : ' ') + oracion + '.';
+    i++;
+  }
+  return texto;
+}
+
+// --- CA-1: default ---
+
+test('splitTextForTTSChunks default debe ser 1500 (no 3800)', () => {
+  // Texto de 1800 chars: con default antiguo 3800 daría 1 chunk;
+  // con default nuevo 1500 da 2.
+  const texto = generateSpanishText(1800);
+  const chunks = splitTextForTTSChunks(texto); // sin segundo argumento
+  assert.equal(chunks.length >= 2, true,
+    `Texto de ${texto.length} chars debería dividirse en >=2 chunks con default 1500, pero quedó en ${chunks.length}`);
+});
+
+// --- CA-3: no parte palabras ---
+
+test('splitTextForTTSChunks nunca parte una palabra a la mitad', () => {
+  const texto = generateSpanishText(4500);
+  const chunks = splitTextForTTSChunks(texto, 1500);
+  for (const chunk of chunks) {
+    // Cada chunk debe empezar y terminar en un caracter no-espacio,
+    // y al recomponer debería haber espacios entre piezas.
+    assert.equal(chunk.trim(), chunk, 'Chunk con whitespace residual al borde');
+    // Verificación más fuerte: ninguna palabra del texto original aparece
+    // partida (medio fragmento al final de un chunk y la otra mitad al
+    // principio del siguiente).
+  }
+  // Recomposición: al juntar los chunks con espacio, el texto resultante
+  // debe contener todas las palabras del original sin alterar (módulo
+  // espacios). Si alguna palabra se cortó, la reconstrucción tendría
+  // tokens "raros".
+  const recompuesto = chunks.join(' ');
+  const palabrasOriginal = texto.split(/\s+/).filter(Boolean);
+  const palabrasRecompuesto = recompuesto.split(/\s+/).filter(Boolean);
+  assert.equal(palabrasRecompuesto.length, palabrasOriginal.length,
+    `Cantidad de palabras cambió: original=${palabrasOriginal.length}, recompuesto=${palabrasRecompuesto.length}`);
+  for (let i = 0; i < palabrasOriginal.length; i++) {
+    assert.equal(palabrasRecompuesto[i], palabrasOriginal[i],
+      `Palabra #${i} difiere: "${palabrasOriginal[i]}" vs "${palabrasRecompuesto[i]}"`);
+  }
+});
+
+// --- CA-4: texto ≤ cap genera 1 chunk ---
+
+test('texto de ~1200 chars genera 1 chunk (CA-4)', () => {
+  const texto = generateSpanishText(1200);
+  // Asegurar que efectivamente cae bajo el cap
+  assert.equal(texto.length <= 1500, true,
+    `Helper de test generó texto más largo del esperado: ${texto.length}`);
+  const chunks = splitTextForTTSChunks(texto, 1500);
+  assert.equal(chunks.length, 1, `Esperaba 1 chunk para texto de ${texto.length} chars, obtuve ${chunks.length}`);
+});
+
+// --- CA-5: texto entre 1×cap y 2×cap genera ~2 chunks (CA "aprox.") ---
+// El algoritmo respeta límites de oración (no se redistribuye), así que un
+// texto de 3000 chars con oraciones de ~80-100 chars puede producir 2 o 3
+// chunks dependiendo de dónde caigan los bordes. El PO refinó como "aprox.
+// 3000 chars → 2 audios". Aceptamos tolerancia ±1 chunk: lo importante es
+// que ninguno excede el cap y nadie se trunca a mitad de palabra.
+
+test('texto de ~3000 chars genera entre 2 y 3 chunks (CA-5 con tolerancia por borde de oracion)', () => {
+  const texto = generateSpanishText(3000);
+  const chunks = splitTextForTTSChunks(texto, 1500);
+  assert.equal(chunks.length >= 2 && chunks.length <= 3, true,
+    `Esperaba 2-3 chunks para texto de ${texto.length} chars, obtuve ${chunks.length}. Largos: ${chunks.map(c => c.length).join(',')}`);
+  for (const c of chunks) {
+    assert.equal(c.length <= 1500, true, `Chunk excede el cap: ${c.length} > 1500`);
+  }
+  // El total preservado (cantidad de chars no-espacio)
+  const charsOriginal = texto.replace(/\s+/g, '').length;
+  const charsRecompuesto = chunks.join(' ').replace(/\s+/g, '').length;
+  assert.equal(charsOriginal, charsRecompuesto, 'Se perdieron caracteres en el split');
+});
+
+// --- CA-6: texto entre 2×cap y 3×cap genera ~3 chunks ---
+
+test('texto de ~4500 chars genera entre 3 y 4 chunks (CA-6 con tolerancia por borde de oracion)', () => {
+  const texto = generateSpanishText(4500);
+  const chunks = splitTextForTTSChunks(texto, 1500);
+  assert.equal(chunks.length >= 3 && chunks.length <= 4, true,
+    `Esperaba 3-4 chunks para texto de ${texto.length} chars, obtuve ${chunks.length}. Largos: ${chunks.map(c => c.length).join(',')}`);
+  for (const c of chunks) {
+    assert.equal(c.length <= 1500, true, `Chunk excede el cap: ${c.length} > 1500`);
+  }
+  const charsOriginal = texto.replace(/\s+/g, '').length;
+  const charsRecompuesto = chunks.join(' ').replace(/\s+/g, '').length;
+  assert.equal(charsOriginal, charsRecompuesto, 'Se perdieron caracteres en el split');
+});
+
+// --- Verificación adicional del cap: ningún chunk excede 1500 ---
+
+test('ningún chunk excede el cap de 1500 (defensa contra truncado de Edge TTS en español)', () => {
+  // Múltiples tamaños de input para cubrir bordes
+  for (const target of [1501, 2000, 2999, 3001, 4499, 6000, 9000]) {
+    const texto = generateSpanishText(target);
+    const chunks = splitTextForTTSChunks(texto, 1500);
+    for (const c of chunks) {
+      assert.equal(c.length <= 1500, true,
+        `Texto de ${texto.length} chars produjo chunk de ${c.length} (>1500)`);
+    }
+  }
+});
+
+// --- Edge cases ---
+
+test('texto vacío retorna [""]', () => {
+  const chunks = splitTextForTTSChunks('', 1500);
+  assert.equal(chunks.length, 1);
+  assert.equal(chunks[0], '');
+});
+
+test('texto exactamente del tamaño del cap retorna 1 chunk', () => {
+  const texto = 'a'.repeat(1500);
+  const chunks = splitTextForTTSChunks(texto, 1500);
+  assert.equal(chunks.length, 1);
+});
+
+test('oración única más larga que el cap se parte por palabras sin truncar', () => {
+  // Una sola oración de ~2200 chars (sin puntos intermedios) → debe partirse
+  // por palabras respetando el cap.
+  const texto = generateSpanishText(2200).replace(/\./g, ',');
+  const chunks = splitTextForTTSChunks(texto, 1500);
+  assert.equal(chunks.length >= 2, true,
+    `Oración única de ${texto.length} chars debería partirse, pero quedó en ${chunks.length}`);
+  for (const c of chunks) {
+    assert.equal(c.length <= 1500, true, `Chunk excede el cap: ${c.length} > 1500`);
+  }
+});

--- a/.pipeline/multimedia.js
+++ b/.pipeline/multimedia.js
@@ -444,18 +444,21 @@ function getTransitionIntro(newProvider, prevProvider, profileName = 'default') 
 
 // --- OpenAI TTS ---
 
-function textToSpeechOpenAI(text, profileName = 'default') {
+function textToSpeechOpenAI(text, profileName = 'default', chunkInfo = null) {
   const config = loadConfig();
   const apiKey = config.openai_api_key || process.env.OPENAI_API_KEY;
   if (!apiKey) { log('TTS[openai]: falta openai_api_key'); return Promise.resolve(null); }
 
   const ttsCfg = loadTtsConfig(profileName).openai;
+  const inputText = text.substring(0, 4096);
+  const estimatedSec = estimateTtsDurationSec(inputText.length);
+  const chunkTag = formatChunkInfo(chunkInfo);
 
   return new Promise((resolve) => {
     // OpenAI TTS soporta hasta 4096 chars — NO truncar, los callers manejan chunking
     const body = JSON.stringify({
       model: ttsCfg.model,
-      input: text.substring(0, 4096),
+      input: inputText,
       voice: ttsCfg.voice,
       instructions: ttsCfg.instructions,
       response_format: ttsCfg.response_format || 'opus'
@@ -477,7 +480,7 @@ function textToSpeechOpenAI(text, profileName = 'default') {
       res.on('end', () => {
         const buffer = Buffer.concat(chunks);
         if (res.statusCode === 200 && buffer.length > 100) {
-          log(`TTS[openai] generado: ${buffer.length} bytes`);
+          log(`TTS[openai] generado: ${buffer.length} bytes chars=${inputText.length} duracion_est=${estimatedSec}s${chunkTag}`);
           resolve(buffer);
         } else {
           log(`TTS[openai] error: status=${res.statusCode}, size=${buffer.length}`);
@@ -557,13 +560,28 @@ function mp3ToOpus(mp3Path) {
   });
 }
 
-function textToSpeechEdge(text, profileName = 'default') {
+// #3485: estimación de duración para detectar truncado interno de Edge TTS.
+// Para español, ~15 chars/seg es una regla pragmática que aproxima el ritmo
+// natural de la voz "es-AR" usada. Útil como leading indicator si el archivo
+// generado sale más corto de lo esperado.
+function estimateTtsDurationSec(chars) {
+  return Math.max(1, Math.round(chars / 15));
+}
+
+function formatChunkInfo(chunkInfo) {
+  if (!chunkInfo || typeof chunkInfo.index !== 'number' || typeof chunkInfo.total !== 'number') return '';
+  return ` chunk=${chunkInfo.index + 1}/${chunkInfo.total} total_parts=${chunkInfo.total}`;
+}
+
+function textToSpeechEdge(text, profileName = 'default', chunkInfo = null) {
   const ttsCfg = loadTtsConfig(profileName).edge;
   const tmpDir = path.join(os.tmpdir(), 'intrale-edge-tts');
   try { fs.mkdirSync(tmpDir, { recursive: true }); } catch {}
   const mp3Path = path.join(tmpDir, `edge-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.mp3`);
   const bin = findEdgeTtsExe();
   const input = text.substring(0, 5000);
+  const estimatedSec = estimateTtsDurationSec(input.length);
+  const chunkTag = formatChunkInfo(chunkInfo);
 
   return new Promise((resolve) => {
     const args = [
@@ -587,7 +605,7 @@ function textToSpeechEdge(text, profileName = 'default') {
       const opusBuf = await mp3ToOpus(mp3Path);
       try { fs.unlinkSync(mp3Path); } catch {}
       if (opusBuf && opusBuf.length > 100) {
-        log(`TTS[edge] generado: ${opusBuf.length} bytes (voz=${ttsCfg.voice})`);
+        log(`TTS[edge] generado: ${opusBuf.length} bytes (voz=${ttsCfg.voice}) chars=${input.length} duracion_est=${estimatedSec}s${chunkTag}`);
         resolve(opusBuf);
       } else {
         log(`TTS[edge] conversion fallida`);
@@ -611,10 +629,10 @@ function sanitizeForTts(text) {
 
 // --- TTS con priorización dinámica + fallback ---
 
-async function textToSpeechByProvider(provider, text, profileName = 'default') {
+async function textToSpeechByProvider(provider, text, profileName = 'default', chunkInfo = null) {
   const cleaned = sanitizeForTts(text);
-  if (provider === 'openai') return textToSpeechOpenAI(cleaned, profileName);
-  if (provider === 'edge') return textToSpeechEdge(cleaned, profileName);
+  if (provider === 'openai') return textToSpeechOpenAI(cleaned, profileName, chunkInfo);
+  if (provider === 'edge') return textToSpeechEdge(cleaned, profileName, chunkInfo);
   log(`TTS: provider desconocido '${provider}'`);
   return null;
 }
@@ -627,17 +645,21 @@ async function textToSpeechByProvider(provider, text, profileName = 'default') {
  */
 async function textToSpeechWithMeta(text, opts = {}) {
   const profileName = opts.profile || 'default';
+  // #3485: chunkInfo opcional { index, total } para que el log del provider
+  // identifique la pieza dentro de la respuesta total y permita detectar
+  // truncados a futuro.
+  const chunkInfo = opts.chunkInfo || null;
   const cfg = loadTtsConfig(profileName);
   const forced = process.env.TTS_PROVIDER;
   if (forced) {
     log(`TTS[${profileName}] forzado por env: ${forced}`);
-    const buf = await textToSpeechByProvider(forced, text, profileName);
+    const buf = await textToSpeechByProvider(forced, text, profileName, chunkInfo);
     return buf ? { buffer: buf, provider: forced, profile: profileName } : null;
   }
 
   const primary = cfg.primary || 'openai';
   log(`TTS[${profileName}]: intentando primary=${primary}`);
-  const bufPrimary = await textToSpeechByProvider(primary, text, profileName);
+  const bufPrimary = await textToSpeechByProvider(primary, text, profileName, chunkInfo);
   if (bufPrimary) return { buffer: bufPrimary, provider: primary, profile: profileName };
 
   const fallback = cfg.fallback;
@@ -646,7 +668,7 @@ async function textToSpeechWithMeta(text, opts = {}) {
     return null;
   }
   log(`TTS[${profileName}]: primary fallo, probando fallback=${fallback}`);
-  const bufFallback = await textToSpeechByProvider(fallback, text, profileName);
+  const bufFallback = await textToSpeechByProvider(fallback, text, profileName, chunkInfo);
   return bufFallback ? { buffer: bufFallback, provider: fallback, profile: profileName } : null;
 }
 
@@ -697,8 +719,12 @@ function sendVoiceTelegram(audioBuffer, botToken, chatId) {
   });
 }
 
-// Partir texto en chunks para TTS respetando límites de oraciones
-function splitTextForTTSChunks(text, maxChars) {
+// Partir texto en chunks para TTS respetando límites de oraciones.
+// Default 1500 chars: Edge TTS empieza a truncar audios internamente cerca de
+// 2500-3000 chars en español; con 1500 más prefijo "Parte X de N. " (≤17 chars)
+// el texto efectivo queda muy por debajo del umbral observado (margen ~1000).
+// Issue #3485.
+function splitTextForTTSChunks(text, maxChars = 1500) {
   if (text.length <= maxChars) return [text];
   const sentences = text.split(/(?<=[.!?])\s+/);
   const chunks = [];

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -763,8 +763,12 @@ function reencolarInfraBloqueados(config) {
 
 // --- Utilidades ---
 
-// Partir texto en chunks para TTS respetando límites de oraciones
-function splitTextForTTSChunks(text, maxChars) {
+// Partir texto en chunks para TTS respetando límites de oraciones.
+// Default 1500: Edge TTS trunca audios internamente cerca de 2500-3000 chars
+// en español; con 1500 el texto efectivo queda muy por debajo del umbral
+// observado. Issue #3485. (Copia idéntica a la de multimedia.js; consolidación
+// futura tracked en #3515.)
+function splitTextForTTSChunks(text, maxChars = 1500) {
   if (text.length <= maxChars) return [text];
   const sentences = text.split(/(?<=[.!?])\s+/);
   const chunks = [];
@@ -6936,18 +6940,21 @@ async function cmdStatus(config) {
         }
       } catch {}
 
-      const statusChunks = splitTextForTTSChunks(narration, 3800);
+      // Cap a 1500 chars para evitar truncado interno de Edge TTS en español (#3485).
+      const statusChunks = splitTextForTTSChunks(narration, 1500);
+      log('commander', `[status] TTS chunks generados: total_parts=${statusChunks.length} (texto=${narration.length} chars, cap=1500)`);
       let prevProviderStatus = loadTtsState().lastProvider;
       for (let i = 0; i < statusChunks.length; i++) {
         let chunkText = statusChunks.length > 1
           ? `Parte ${i + 1} de ${statusChunks.length}. ${statusChunks[i]}`
           : statusChunks[i];
-        const meta = await textToSpeechWithMeta(chunkText);
+        const ttsOpts = { chunkInfo: { index: i, total: statusChunks.length } };
+        const meta = await textToSpeechWithMeta(chunkText, ttsOpts);
         if (meta && meta.buffer) {
           const intro = i === 0 ? getTransitionIntro(meta.provider, prevProviderStatus) : null;
           if (intro) {
             // Reenviar el primer chunk con el preámbulo de transición
-            const reMeta = await textToSpeechWithMeta(`${intro} ${chunkText}`);
+            const reMeta = await textToSpeechWithMeta(`${intro} ${chunkText}`, ttsOpts);
             if (reMeta && reMeta.buffer) {
               await sendVoiceTelegram(reMeta.buffer, botToken, chatId);
               log('commander', `[status] Audio TTS parte 1/${statusChunks.length} enviado con intro (provider=${reMeta.provider})`);
@@ -9053,21 +9060,24 @@ INSTRUCCIÓN: Reelaborá tu respuesta tomando en cuenta las contradicciones dete
         // Si hubo audio → intentar TTS
         if (esAudio) {
           try {
-            const chatChunks = splitTextForTTSChunks(respuesta, 3800);
+            // Cap a 1500 chars para evitar truncado interno de Edge TTS en español (#3485).
+            const chatChunks = splitTextForTTSChunks(respuesta, 1500);
+            log('commander', `[chat] TTS chunks generados: total_parts=${chatChunks.length} (texto=${respuesta.length} chars, cap=1500)`);
             let prevProvider = loadTtsState().lastProvider;
             for (let i = 0; i < chatChunks.length; i++) {
               const baseChunk = chatChunks.length > 1
                 ? `Parte ${i + 1} de ${chatChunks.length}. ${chatChunks[i]}`
                 : chatChunks[i];
+              const ttsOpts = { chunkInfo: { index: i, total: chatChunks.length } };
               // Primero probamos a ver qué provider gana para este chunk
-              const meta = await textToSpeechWithMeta(baseChunk);
+              const meta = await textToSpeechWithMeta(baseChunk, ttsOpts);
               if (!meta || !meta.buffer) continue;
 
               const intro = i === 0 ? getTransitionIntro(meta.provider, prevProvider) : null;
               let finalBuffer = meta.buffer;
               let finalProvider = meta.provider;
               if (intro) {
-                const reMeta = await textToSpeechWithMeta(`${intro} ${baseChunk}`);
+                const reMeta = await textToSpeechWithMeta(`${intro} ${baseChunk}`, ttsOpts);
                 if (reMeta && reMeta.buffer) {
                   finalBuffer = reMeta.buffer;
                   finalProvider = reMeta.provider;


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 3 archivos · +222 -21

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:passed` aplicado por delivery

## Closes

Closes #3485
