### PR TITLE
fix(#3484): CA-AUDIT-1 — emitir 5 campos enriched al audit JSONL (Sherlock)

### DIFF
--- a/.pipeline/config.yaml
+++ b/.pipeline/config.yaml
@@ -514,10 +514,11 @@ pipeline:
 #
 # Sherlock corre como capa interna del Commander de Telegram: antes de mandar
 # cada respuesta, refuta el análisis con evidencia del estado actual del
-# sistema invocando un provider distinto al del Commander vía HTTP completion-
-# client (#3342). Si detecta inconsistencias, reelabora la respuesta (1 vez,
-# cap hardcoded). Si timeout/error/sin-provider-distinto, agrega disclaimer
-# F-6 y manda la original.
+# sistema. Usa la chain `telegram-sherlock` de `agent-models.json` con el orden
+# de calidad aprobado (Anthropic Haiku 4.5 → Codex → Gemini → Cerebras →
+# NVIDIA NIM). Si detecta inconsistencias, reelabora la respuesta (1 vez, cap
+# hardcoded). Si timeout/error/sin-provider, agrega disclaimer F-6 y manda la
+# original.
 #
 # Defensas (CA-SEC-1..9):
 #   - sherlock_enabled solo se lee desde este archivo (CA-SEC-7 anti-toggle
@@ -527,11 +528,21 @@ pipeline:
 #     `Math.min(valor, 1)` así que aunque alguien edite y ponga 99 acá,
 #     el invariante hardcoded gana (CA-SEC-9). Mantener `1` documenta la
 #     intención y evita confusión.
-#   - sherlock_timeout_ms se respeta hasta un máximo de 30s (clamp en
-#     lib/sherlock-verifier.js para evitar starvation de turnos).
+#
+# Timeout (#3484, 2026-05-23):
+#   El timeout local de Sherlock se ELIMINÓ — quedaba en 10s (default) con
+#   clamp absoluto 30s, insuficiente para verificación adversarial real. Ahora
+#   el presupuesto se delega al `lib/multi-provider/completion-client.js`:
+#     - DEFAULT_TIMEOUT_MS  =  90 s   (per-request)
+#     - ABSOLUTE_MAX_TIMEOUT_MS = 180 s (cap defensivo, no removible)
+#   La defensa adicional vive en `pulpo.js` con un soft-timeout de 120s para
+#   todo el turn handler — si Sherlock cuelga, libera el chat con mensaje
+#   honesto al usuario (UX-2 / CA-UX-2).
+#   `sherlock_timeout_ms` quedó como NO-OP: si está presente, se ignora con un
+#   warning en el log. NO removerlo de configs viejas — el cargador es tolerante.
 # =============================================================================
 sherlock_enabled: true
-sherlock_timeout_ms: 10000
+# sherlock_timeout_ms: 10000      # DEPRECATED (#3484) — ahora delegado al cliente.
 sherlock_max_reelaboraciones: 1
 
 # =============================================================================

--- a/.pipeline/lib/__tests__/commander-multi-provider.test.js
+++ b/.pipeline/lib/__tests__/commander-multi-provider.test.js
@@ -710,3 +710,76 @@ test('SR-1 — sidecar real: anthropic pasa todo, incluso paths que matchearían
         cleanup(dir);
     }
 });
+
+// -----------------------------------------------------------------------------
+// #3484 CA-AUDIT-1 — Persistencia JSONL de los 5 campos enriched del Sherlock
+// (sameProvider, sameModel, commanderModel, sherlockModel, transport).
+//
+// El audit log canónico ahora acepta estos campos opcionales en el shape de
+// la entry. Verificamos persistencia leyendo el JSONL escrito.
+// Documentado en docs/pipeline/multi-provider.md:1602, 1622-1634.
+// -----------------------------------------------------------------------------
+
+test('#3484 CA-AUDIT-1 — auditCommanderRequest persiste los 5 campos enriched cuando se proveen', () => {
+    const dir = mkTmpPipelineDir();
+    try {
+        const ok = cmp.auditCommanderRequest({
+            pipelineDir: dir,
+            event: 'sherlock_verification',
+            providerIntended: 'anthropic',
+            providerEffective: 'cerebras',
+            prompt: 'hash placeholder',
+            tokens: { input: 10, output: 5 },
+            latencyMs: 120,
+            errorCode: null,
+            // Los 5 campos enriched (CA-AUDIT-1).
+            sameProvider: false,
+            sameModel: false,
+            commanderModel: 'claude-opus-4-7',
+            sherlockModel: 'llama-3.3-70b',
+            transport: 'http',
+        });
+        assert.equal(ok, true);
+        const files = fs.readdirSync(path.join(dir, 'logs')).filter(f => f.startsWith('commander-dispatch-'));
+        assert.equal(files.length, 1);
+        const content = fs.readFileSync(path.join(dir, 'logs', files[0]), 'utf8').trim();
+        const entry = JSON.parse(content.split('\n').pop());
+        // Los 5 campos deben aparecer en la entry persistida.
+        assert.equal(entry.same_provider, false, 'same_provider persistido');
+        assert.equal(entry.same_model, false, 'same_model persistido');
+        assert.equal(entry.commander_model, 'claude-opus-4-7', 'commander_model persistido');
+        assert.equal(entry.sherlock_model, 'llama-3.3-70b', 'sherlock_model persistido');
+        assert.equal(entry.transport, 'http', 'transport persistido');
+    } finally {
+        cleanup(dir);
+    }
+});
+
+test('#3484 CA-AUDIT-1 — auditCommanderRequest deja los 5 campos en null cuando no se proveen (back-compat)', () => {
+    const dir = mkTmpPipelineDir();
+    try {
+        // Llamada al estilo viejo (sin campos enriched) — no debe romper el shape.
+        const ok = cmp.auditCommanderRequest({
+            pipelineDir: dir,
+            event: 'dispatch',
+            providerIntended: 'anthropic',
+            providerEffective: 'anthropic',
+            prompt: 'cualquier cosa',
+            tokens: { input: 5, output: 2 },
+            latencyMs: 80,
+            errorCode: null,
+        });
+        assert.equal(ok, true);
+        const files = fs.readdirSync(path.join(dir, 'logs')).filter(f => f.startsWith('commander-dispatch-'));
+        const content = fs.readFileSync(path.join(dir, 'logs', files[0]), 'utf8').trim();
+        const entry = JSON.parse(content.split('\n').pop());
+        // Los 5 campos persisten como null (no rompen el shape canónico).
+        assert.equal(entry.same_provider, null);
+        assert.equal(entry.same_model, null);
+        assert.equal(entry.commander_model, null);
+        assert.equal(entry.sherlock_model, null);
+        assert.equal(entry.transport, null);
+    } finally {
+        cleanup(dir);
+    }
+});

--- a/.pipeline/lib/__tests__/completion-client.test.js
+++ b/.pipeline/lib/__tests__/completion-client.test.js
@@ -558,3 +558,62 @@ test('PROVIDER_MODELS_ALLOWLIST incluye los modelos que usa producción (snapsho
     assert.ok(completion.isAllowedModel('nvidia-nim', 'deepseek-ai/deepseek-v4-pro'),
         'nvidia-nim/deepseek-ai/deepseek-v4-pro en producción debe estar allowlisted');
 });
+
+// =============================================================================
+// #3484 — Tests del cap defensivo del timeout.
+// =============================================================================
+
+test('#3484 CA-CLIENT-3: DEFAULT_TIMEOUT_MS = 90s', () => {
+    assert.equal(completion.DEFAULT_TIMEOUT_MS, 90_000);
+});
+
+test('#3484 CA-CLIENT-4: ABSOLUTE_MAX_TIMEOUT_MS = 180s exportado', () => {
+    assert.equal(completion.ABSOLUTE_MAX_TIMEOUT_MS, 180_000);
+});
+
+test('#3484 CA-CLIENT-4: caller pidiendo timeout > ABSOLUTE_MAX_TIMEOUT_MS se clampea', async () => {
+    // Estrategia: el fake http NO simula timeout, sino que responde rápido.
+    // Para validar el clamp inspeccionamos que el cliente NO tira aunque le
+    // pasemos 999_999 (lo clampearia a 180_000 internamente).
+    const dir = tmpDir();
+    const f = path.join(dir, 'config.json');
+    writeKeys(f, { cerebras_api_key: 'csk_test_1234567890abcdef0000' });
+    const r = await completion.complete({
+        provider: 'cerebras',
+        model: 'llama-3.3-70b',
+        prompt: 'ping',
+        timeoutMs: 999_999, // se clampea a 180_000 internamente
+        secretsPath: f,
+        httpImpl: fakeHttp({
+            status: 200,
+            body: JSON.stringify({
+                choices: [{ message: { content: 'pong' } }],
+                usage: { prompt_tokens: 1, completion_tokens: 1 },
+            }),
+        }),
+    });
+    assert.equal(r.ok, true);
+    assert.equal(r.content, 'pong');
+});
+
+test('#3484: caller con timeoutMs negativo o inválido cae a DEFAULT_TIMEOUT_MS', async () => {
+    const dir = tmpDir();
+    const f = path.join(dir, 'config.json');
+    writeKeys(f, { cerebras_api_key: 'csk_test_1234567890abcdef0000' });
+    const r = await completion.complete({
+        provider: 'cerebras',
+        model: 'llama-3.3-70b',
+        prompt: 'ping',
+        timeoutMs: -100,
+        secretsPath: f,
+        httpImpl: fakeHttp({
+            status: 200,
+            body: JSON.stringify({
+                choices: [{ message: { content: 'ok' } }],
+                usage: { prompt_tokens: 1, completion_tokens: 1 },
+            }),
+        }),
+    });
+    // No tira, no rompe — el cliente usa DEFAULT_TIMEOUT_MS (90s) internamente.
+    assert.equal(r.ok, true);
+});

--- a/.pipeline/lib/__tests__/sherlock-verifier.test.js
+++ b/.pipeline/lib/__tests__/sherlock-verifier.test.js
@@ -108,6 +108,9 @@ function fakeResidencyBlock() {
 function defaultConfigLoader(over = {}) {
     return () => Object.assign({
         sherlock_enabled: true,
+        // #3484 — sherlock_timeout_ms quedó como NO-OP (delegado al cliente
+        // HTTP, 90s default + 180s cap). Lo mantenemos en los tests sólo
+        // para verificar back-compat: el cargador NO debe romper al verlo.
         sherlock_timeout_ms: 10000,
         sherlock_max_reelaboraciones: 1,
     }, over);
@@ -118,6 +121,25 @@ const CHAIN_HTTP = [
     { provider: 'gemini-google', model: 'gemini-2.0-flash' },
     { provider: 'nvidia-nim', model: 'deepseek-ai/deepseek-v4-pro' },
 ];
+
+// #3484 — chain con Anthropic primero (orden aprobado por Leo 2026-05-22).
+// Usada en los tests nuevos que validan el spawn-CLI path.
+const CHAIN_ANTH_FIRST = [
+    { provider: 'anthropic', model: 'claude-haiku-4-5' },
+    { provider: 'openai-codex', model: 'gpt-5' },        // stub — Sherlock lo salta
+    { provider: 'gemini-google', model: 'gemini-2.0-flash' },
+    { provider: 'cerebras', model: 'llama-3.3-70b' },
+];
+
+// Fake spawn helper para Anthropic (#3484 Opción B). Devuelve el shape
+// canónico del completion-client sin tocar child_process real.
+function fakeSpawnAnthropic(responseOrFn) {
+    return async (opts) => {
+        const r = typeof responseOrFn === 'function' ? responseOrFn(opts) : responseOrFn;
+        if (r && typeof r.then === 'function') return await r;
+        return r;
+    };
+}
 
 // =============================================================================
 // T-1 — Escenario "issue bloqueado humano" → Sherlock detecta inconsistencia
@@ -187,7 +209,8 @@ test('T-2: timeout del completion-client devuelve aborted + disclaimer F-6', asy
     assert.equal(result.errorCode, 'timeout');
     assert.equal(result.suggestedDisclaimer, sherlock.DISCLAIMER_TYPES.TIMEOUT_OR_NO_PROVIDER);
     const final = sherlock.applyDisclaimer('Texto base.', result.suggestedDisclaimer);
-    assert.match(final, /No pude verificar esta respuesta con Sherlock/);
+    // #3484 — phrasing actualizado por CA-UX-3.
+    assert.match(final, /No pude verificar esta respuesta con el verificador adversarial/);
 });
 
 // =============================================================================
@@ -264,36 +287,38 @@ test('T-4: dos llamadas con rechazado devuelven rechazado dos veces (caller apli
     assert.equal(r1.verdict, 'rechazado');
     assert.equal(r2.verdict, 'rechazado');
     // El caller aplica el disclaimer F-5 si la 2da pasada también rechaza.
+    // #3484 — phrasing actualizado por CA-UX-4.
     const final = sherlock.applyDisclaimer('Reelaboración.', sherlock.DISCLAIMER_TYPES.PERSISTENT_INCONSISTENCY);
-    assert.match(final, /Sherlock detectó inconsistencias en mi respuesta incluso después de reelaborar/);
+    assert.match(final, /Detecté una inconsistencia en mi primera respuesta y la ajusté/);
 });
 
 // =============================================================================
-// T-5 — Concurrencia 5 turnos paralelos, cada uno con excludedProvider
-// distinto. Sherlock debe devolver un sherlockProvider != excludedProvider en
-// cada uno (CA-SEC-8 — race detection).
+// T-5 — Concurrencia 5 turnos paralelos. Sherlock debe procesar todos sin
+// estado compartido. #3484: ya NO valida exclusión por provider; valida que
+// `sameProvider` esté correctamente computado contra el commanderProvider.
 // =============================================================================
-test('T-5: 5 turnos paralelos con excludedProvider distinto no usan el provider excluido', async () => {
+test('T-5: 5 turnos paralelos con commanderProvider variado — sameProvider correcto', async () => {
     const dir = mkTmpPipelineDir();
     const okResp = {
         ok: true,
         content: JSON.stringify({ verdict: 'ok', reason: 'ok', inconsistencies: [] }),
         inputTokens: 10, outputTokens: 5, durationMs: 20,
     };
-    // Provider chain con 4 entries para permitir exclusión variada.
     const chain = [
         { provider: 'cerebras', model: 'llama-3.3-70b' },
         { provider: 'gemini-google', model: 'gemini-2.0-flash' },
         { provider: 'nvidia-nim', model: 'deepseek-ai/deepseek-v4-pro' },
     ];
-    const excludeds = ['anthropic', 'cerebras', 'gemini-google', 'nvidia-nim', 'anthropic'];
+    // Mezcla de providers — los HTTP coinciden a veces con el primero
+    // del chain (cerebras), generando same_provider=true cuando aplica.
+    const commanderProviders = ['anthropic', 'cerebras', 'gemini-google', 'nvidia-nim', 'anthropic'];
 
-    const promises = excludeds.map((ex, i) =>
+    const promises = commanderProviders.map((cp, i) =>
         sherlock.verify({
             analysis: `analisis ${i}`,
             originalRequest: `pedido ${i}`,
             systemState: `estado ${i}`,
-            excludedProvider: ex,
+            commanderProvider: cp,
             pipelineDir: dir,
             configLoader: defaultConfigLoader(),
             completionClient: fakeCompletionClient(okResp),
@@ -305,9 +330,12 @@ test('T-5: 5 turnos paralelos con excludedProvider distinto no usan el provider 
     const results = await Promise.all(promises);
     for (let i = 0; i < results.length; i++) {
         const r = results[i];
-        assert.notEqual(r.sherlockProvider, excludeds[i], `Turno ${i}: sherlockProvider=${r.sherlockProvider} igual al excluded`);
-        assert.ok(sherlock.HTTP_COMPATIBLE_PROVIDERS.has(r.sherlockProvider),
-            `Turno ${i}: sherlockProvider=${r.sherlockProvider} no es HTTP-compatible`);
+        // Sherlock siempre devuelve un provider de la chain (cerebras primero).
+        assert.ok(['cerebras', 'gemini-google', 'nvidia-nim'].indexOf(r.sherlockProvider) >= 0,
+            `Turno ${i}: sherlockProvider=${r.sherlockProvider} debería ser de la chain`);
+        // sameProvider es true sólo si commanderProvider === sherlockProvider.
+        const expectedSame = (commanderProviders[i] === r.sherlockProvider);
+        assert.equal(r.sameProvider, expectedSame, `Turno ${i}: sameProvider esperado=${expectedSame} obtuvo=${r.sameProvider}`);
     }
 });
 
@@ -570,7 +598,12 @@ test('CA-SEC-9: sherlock_max_reelaboraciones=99 se clampea a 1', () => {
     assert.equal(cfg.maxReelaboraciones, 1);
 });
 
-test('CA-SEC-9: cap absoluto del timeout es 30s', () => {
+// #3484 — el clamp local de timeout fue removido. Sherlock ya NO impone
+// un cap de 30s; el cap defensivo vive en el completion-client (180s).
+// Este test reemplaza el legacy "cap 30s" por la verificación de back-compat:
+// aunque config diga `sherlock_timeout_ms: 999999`, el cargador devuelve
+// el DEFAULT_TIMEOUT_MS del módulo (90s) sin romper.
+test('CA-SEC-9 (#3484): sherlock_timeout_ms en config se ignora — back-compat', () => {
     const cfg = sherlock._loadSherlockConfig({
         configLoader: () => ({
             sherlock_enabled: true,
@@ -578,19 +611,33 @@ test('CA-SEC-9: cap absoluto del timeout es 30s', () => {
             sherlock_max_reelaboraciones: 1,
         }),
     });
-    assert.equal(cfg.timeoutMs, 30000);
+    // El cargador devuelve siempre DEFAULT_TIMEOUT_MS (90s post-#3484).
+    assert.equal(cfg.timeoutMs, sherlock.DEFAULT_TIMEOUT_MS);
+    assert.equal(cfg.timeoutMs, 90000);
+});
+
+test('CA-SEC-9 (#3484): sin sherlock_timeout_ms — también devuelve DEFAULT', () => {
+    const cfg = sherlock._loadSherlockConfig({
+        configLoader: () => ({
+            sherlock_enabled: true,
+            sherlock_max_reelaboraciones: 1,
+        }),
+    });
+    assert.equal(cfg.timeoutMs, sherlock.DEFAULT_TIMEOUT_MS);
 });
 
 // =============================================================================
-// Extra — resolveSherlockProvider salta providers no-HTTP-compatibles.
+// Extra — resolveSherlockProvider salta providers sin handler implementado
+// (openai-codex sigue siendo stub). #3484: anthropic AHORA tiene handler
+// (spawn), así que no se salta.
 // =============================================================================
-test('resolveSherlockProvider salta openai-codex y devuelve cerebras', () => {
+test('resolveSherlockProvider salta openai-codex (stub) y devuelve cerebras (HTTP)', () => {
     const chain = [
         { provider: 'openai-codex', model: 'gpt-5' },
         { provider: 'cerebras', model: 'llama-3.3-70b' },
     ];
     const r = sherlock._resolveSherlockProvider({
-        excludedProvider: 'anthropic',
+        excludedProvider: 'anthropic', // #3484: ignorado
         pipelineDir: '/tmp',
         log: () => {},
         quotaModule: fakeQuotaAllPass(),
@@ -598,12 +645,31 @@ test('resolveSherlockProvider salta openai-codex y devuelve cerebras', () => {
     });
     assert.ok(r);
     assert.equal(r.provider, 'cerebras');
+    assert.equal(r.transport, 'http');
 });
 
-test('resolveSherlockProvider devuelve null si toda la chain es no-HTTP', () => {
+test('resolveSherlockProvider devuelve anthropic con transport=spawn (#3484)', () => {
+    const chain = [
+        { provider: 'anthropic', model: 'claude-haiku-4-5' },
+        { provider: 'cerebras', model: 'llama-3.3-70b' },
+    ];
+    const r = sherlock._resolveSherlockProvider({
+        excludedProvider: null,
+        pipelineDir: '/tmp',
+        log: () => {},
+        quotaModule: fakeQuotaAllPass(),
+        dispatchModule: fakeDispatcher({ providerChain: chain }),
+    });
+    assert.ok(r);
+    assert.equal(r.provider, 'anthropic');
+    assert.equal(r.transport, 'spawn');
+});
+
+test('resolveSherlockProvider devuelve null si toda la chain es stub-only (no handler)', () => {
+    // Solo openai-codex en la chain (stub sin handler) — Sherlock no tiene
+    // a quién invocar y devuelve null.
     const chain = [
         { provider: 'openai-codex', model: 'gpt-5' },
-        { provider: 'anthropic', model: 'claude-haiku-4-5' },
     ];
     const r = sherlock._resolveSherlockProvider({
         excludedProvider: null,
@@ -615,17 +681,37 @@ test('resolveSherlockProvider devuelve null si toda la chain es no-HTTP', () => 
     assert.equal(r, null);
 });
 
-// =============================================================================
-// applyDisclaimer
-// =============================================================================
-test('applyDisclaimer agrega F-5 al texto', () => {
-    const t = sherlock.applyDisclaimer('Mi respuesta.', sherlock.DISCLAIMER_TYPES.PERSISTENT_INCONSISTENCY);
-    assert.match(t, /verificá manualmente/);
+test('#3484 CA-SHERLOCK-3: Sherlock no excluye al commanderProvider (mismo provider permitido)', () => {
+    // Aunque el caller pase excludedProvider='cerebras', el resolver ahora
+    // devuelve cerebras igualmente porque la exclusión cross-provider se quitó.
+    const chain = [
+        { provider: 'cerebras', model: 'llama-3.3-70b' },
+        { provider: 'gemini-google', model: 'gemini-2.0-flash' },
+    ];
+    const r = sherlock._resolveSherlockProvider({
+        excludedProvider: 'cerebras',
+        pipelineDir: '/tmp',
+        log: () => {},
+        quotaModule: fakeQuotaAllPass(),
+        dispatchModule: fakeDispatcher({ providerChain: chain }),
+    });
+    assert.ok(r);
+    assert.equal(r.provider, 'cerebras');
 });
 
-test('applyDisclaimer agrega F-6 al texto', () => {
+// =============================================================================
+// applyDisclaimer — #3484 actualizó el phrasing (CA-UX-3, CA-UX-4).
+// =============================================================================
+test('applyDisclaimer agrega F-5 con phrasing UX-4 (#3484)', () => {
+    const t = sherlock.applyDisclaimer('Mi respuesta.', sherlock.DISCLAIMER_TYPES.PERSISTENT_INCONSISTENCY);
+    assert.match(t, /Detecté una inconsistencia en mi primera respuesta/);
+    assert.match(t, /decime y la reviso/);
+});
+
+test('applyDisclaimer agrega F-6 con phrasing UX-3 (#3484)', () => {
     const t = sherlock.applyDisclaimer('Mi respuesta.', sherlock.DISCLAIMER_TYPES.TIMEOUT_OR_NO_PROVIDER);
-    assert.match(t, /timeout o sin provider distinto/);
+    assert.match(t, /No pude verificar esta respuesta con el verificador adversarial/);
+    assert.match(t, /revisamos juntos/);
 });
 
 test('applyDisclaimer con null devuelve el texto sin cambios', () => {
@@ -644,6 +730,258 @@ test('config sin sherlock_enabled defaultea a enabled=true', () => {
 test('config con configLoader que tira devuelve defaults seguros', () => {
     const cfg = sherlock._loadSherlockConfig({ configLoader: () => { throw new Error('boom'); } });
     assert.equal(cfg.enabled, true);
-    assert.equal(cfg.timeoutMs, 10000);
+    // #3484 — el default es DEFAULT_TIMEOUT_MS (90s) ya no 10s.
+    assert.equal(cfg.timeoutMs, sherlock.DEFAULT_TIMEOUT_MS);
     assert.equal(cfg.maxReelaboraciones, 1);
+});
+
+// =============================================================================
+// #3484 — Tests nuevos para Opción B (spawn-CLI Anthropic) + audit enriquecido.
+// =============================================================================
+
+test('#3484 CA-SHERLOCK-2: Sherlock usa Anthropic vía spawn cuando es el primero de la chain', async () => {
+    const dir = mkTmpPipelineDir();
+    let spawnCalled = false;
+    const fakeSpawn = fakeSpawnAnthropic((opts) => {
+        spawnCalled = true;
+        // El prompt debe llegar al spawn (no al completion-client HTTP).
+        assert.ok(opts && typeof opts.prompt === 'string' && opts.prompt.length > 0);
+        return {
+            ok: true,
+            content: JSON.stringify({ verdict: 'ok', reason: 'consistente', inconsistencies: [] }),
+            inputTokens: 0, outputTokens: 0, durationMs: 1200,
+        };
+    });
+    let httpCalled = false;
+    const trackingHttp = {
+        complete: async () => {
+            httpCalled = true;
+            return { ok: true, content: '{}', inputTokens: 0, outputTokens: 0, durationMs: 1 };
+        },
+    };
+    const result = await sherlock.verify({
+        analysis: 'respuesta del commander',
+        originalRequest: '?',
+        systemState: 'estado',
+        commanderProvider: 'anthropic',
+        commanderModel: 'claude-opus-4-7',
+        pipelineDir: dir,
+        configLoader: defaultConfigLoader(),
+        completionClient: trackingHttp,
+        spawnAnthropic: fakeSpawn,
+        quotaModule: fakeQuotaAllPass(),
+        dispatchModule: fakeDispatcher({ providerChain: CHAIN_ANTH_FIRST }),
+        residencyModule: fakeResidencyOk(),
+    });
+    assert.equal(result.verdict, 'ok');
+    assert.equal(result.sherlockProvider, 'anthropic');
+    assert.equal(result.transport, 'spawn');
+    assert.equal(spawnCalled, true, 'spawn helper debió ser invocado para anthropic');
+    assert.equal(httpCalled, false, 'completion-client NO debe ser llamado para anthropic');
+});
+
+test('#3484 CA-SHERLOCK-4: si anthropic está gateado, Sherlock cae a gemini (next HTTP)', async () => {
+    const dir = mkTmpPipelineDir();
+    const okResp = {
+        ok: true,
+        content: JSON.stringify({ verdict: 'ok', reason: 'ok', inconsistencies: [] }),
+        inputTokens: 0, outputTokens: 0, durationMs: 100,
+    };
+    const result = await sherlock.verify({
+        analysis: 'a', originalRequest: '?', systemState: 's',
+        commanderProvider: 'anthropic',
+        pipelineDir: dir,
+        configLoader: defaultConfigLoader(),
+        completionClient: fakeCompletionClient(okResp),
+        spawnAnthropic: fakeSpawnAnthropic({ ok: false, error: { type: 'spawn_failed' }, durationMs: 0 }),
+        // Anthropic gateado por cuota → resolver debe saltar al siguiente.
+        // Codex es stub → también se salta. Gemini gana.
+        quotaModule: fakeQuotaGate(['anthropic']),
+        dispatchModule: fakeDispatcher({ providerChain: CHAIN_ANTH_FIRST }),
+        residencyModule: fakeResidencyOk(),
+    });
+    assert.equal(result.verdict, 'ok');
+    assert.equal(result.sherlockProvider, 'gemini-google');
+    assert.equal(result.transport, 'http');
+});
+
+test('#3484 CA-SHERLOCK-5: si toda la chain falla, Sherlock devuelve aborted + F-6', async () => {
+    const dir = mkTmpPipelineDir();
+    const result = await sherlock.verify({
+        analysis: 'a', originalRequest: '?', systemState: 's',
+        commanderProvider: 'anthropic',
+        pipelineDir: dir,
+        configLoader: defaultConfigLoader(),
+        completionClient: fakeCompletionClient({ ok: false, error: { type: 'http_error' }, durationMs: 100 }),
+        spawnAnthropic: fakeSpawnAnthropic({ ok: false, error: { type: 'spawn_failed' }, durationMs: 0 }),
+        // Solo openai-codex en la chain — stub, sin handler. Sherlock no
+        // tiene a quién invocar → aborted con errorCode=no_provider.
+        quotaModule: fakeQuotaAllPass(),
+        dispatchModule: fakeDispatcher({ providerChain: [{ provider: 'openai-codex', model: 'gpt-5' }] }),
+        residencyModule: fakeResidencyOk(),
+    });
+    assert.equal(result.verdict, 'aborted');
+    assert.equal(result.errorCode, 'no_provider');
+    assert.equal(result.suggestedDisclaimer, sherlock.DISCLAIMER_TYPES.TIMEOUT_OR_NO_PROVIDER);
+});
+
+test('#3484 CA-AUDIT-1: audit devuelve sameProvider=true cuando coinciden', async () => {
+    const dir = mkTmpPipelineDir();
+    const okResp = {
+        ok: true,
+        content: JSON.stringify({ verdict: 'ok', reason: 'ok', inconsistencies: [] }),
+        inputTokens: 0, outputTokens: 0, durationMs: 100,
+    };
+    const result = await sherlock.verify({
+        analysis: 'a', originalRequest: '?', systemState: 's',
+        commanderProvider: 'cerebras',
+        commanderModel: 'llama-3.3-70b',
+        pipelineDir: dir,
+        configLoader: defaultConfigLoader(),
+        completionClient: fakeCompletionClient(okResp),
+        quotaModule: fakeQuotaAllPass(),
+        dispatchModule: fakeDispatcher({ providerChain: CHAIN_HTTP }),
+        residencyModule: fakeResidencyOk(),
+    });
+    assert.equal(result.sherlockProvider, 'cerebras');
+    assert.equal(result.sameProvider, true);
+    assert.equal(result.sameModel, true);
+    assert.equal(result.commanderProvider, 'cerebras');
+    assert.equal(result.commanderModel, 'llama-3.3-70b');
+});
+
+test('#3484 CA-AUDIT-1: sameProvider=true pero sameModel=false con distinto modelo', async () => {
+    const dir = mkTmpPipelineDir();
+    const okResp = {
+        ok: true,
+        content: JSON.stringify({ verdict: 'ok', reason: 'ok', inconsistencies: [] }),
+        inputTokens: 0, outputTokens: 0, durationMs: 50,
+    };
+    const result = await sherlock.verify({
+        analysis: 'a', originalRequest: '?', systemState: 's',
+        commanderProvider: 'anthropic',
+        commanderModel: 'claude-opus-4-7',
+        pipelineDir: dir,
+        configLoader: defaultConfigLoader(),
+        completionClient: fakeCompletionClient(okResp),
+        spawnAnthropic: fakeSpawnAnthropic({
+            ok: true,
+            content: JSON.stringify({ verdict: 'ok', reason: 'ok', inconsistencies: [] }),
+            inputTokens: 0, outputTokens: 0, durationMs: 500,
+        }),
+        quotaModule: fakeQuotaAllPass(),
+        dispatchModule: fakeDispatcher({ providerChain: CHAIN_ANTH_FIRST }),
+        residencyModule: fakeResidencyOk(),
+    });
+    assert.equal(result.sherlockProvider, 'anthropic');
+    assert.equal(result.sherlockModel, 'claude-haiku-4-5');
+    assert.equal(result.sameProvider, true);
+    assert.equal(result.sameModel, false, 'mismo provider pero modelo distinto → sameModel=false');
+});
+
+test('#3484 back-compat: aceptamos excludedProvider como alias de commanderProvider', async () => {
+    const dir = mkTmpPipelineDir();
+    const okResp = {
+        ok: true,
+        content: JSON.stringify({ verdict: 'ok', reason: 'ok', inconsistencies: [] }),
+        inputTokens: 0, outputTokens: 0, durationMs: 50,
+    };
+    const result = await sherlock.verify({
+        analysis: 'a', originalRequest: '?', systemState: 's',
+        // Caller viejo pasando excludedProvider — debe trackear como commanderProvider.
+        excludedProvider: 'cerebras',
+        pipelineDir: dir,
+        configLoader: defaultConfigLoader(),
+        completionClient: fakeCompletionClient(okResp),
+        quotaModule: fakeQuotaAllPass(),
+        dispatchModule: fakeDispatcher({ providerChain: CHAIN_HTTP }),
+        residencyModule: fakeResidencyOk(),
+    });
+    assert.equal(result.commanderProvider, 'cerebras');
+    assert.equal(result.sameProvider, true, 'sherlock ahora puede compartir provider con commander (cerebras→cerebras)');
+});
+
+test('#3484: spawn helper de Anthropic respeta timeout y devuelve error tipado', async () => {
+    // Fake spawn que nunca termina — debe disparar timeout.
+    const neverFinishingChild = {
+        stdin: { write: () => {}, end: () => {} },
+        stdout: { on: () => {} },
+        stderr: { on: () => {} },
+        on: () => {},
+        kill: () => {},
+    };
+    const fakeSpawnImpl = () => neverFinishingChild;
+    const fakeHandler = {
+        buildSpawn: () => ({
+            cmd: 'fake-claude',
+            args: [],
+            spawnOpts: { stdio: ['pipe', 'pipe', 'pipe'], shell: false, windowsHide: true },
+        }),
+    };
+    const start = Date.now();
+    const result = await sherlock._spawnAnthropicComplete({
+        prompt: 'test',
+        timeoutMs: 1200,   // mínimo permitido es 1000; usamos 1200 para ser tolerantes.
+        spawnImpl: fakeSpawnImpl,
+        anthropicHandler: fakeHandler,
+    });
+    const elapsed = Date.now() - start;
+    assert.equal(result.ok, false);
+    assert.equal(result.error.type, 'timeout');
+    assert.ok(elapsed >= 1000 && elapsed < 5000, `timeout debió dispararse rápido, elapsed=${elapsed}ms`);
+});
+
+test('#3484: spawn helper devuelve content cuando el child termina exitosamente', async () => {
+    // Simulamos un child que escribe stdout y sale con código 0.
+    const child = {
+        stdin: { write: () => {}, end: () => {} },
+        _stdoutHandlers: [],
+        _exitHandlers: [],
+        _errorHandlers: [],
+        stdout: {
+            on(event, cb) {
+                if (event === 'data') child._stdoutHandlers.push(cb);
+            },
+        },
+        stderr: { on: () => {} },
+        on(event, cb) {
+            if (event === 'exit') child._exitHandlers.push(cb);
+            if (event === 'error') child._errorHandlers.push(cb);
+        },
+        kill: () => {},
+    };
+    const fakeSpawnImpl = () => {
+        // Emitimos data + exit asincrónicamente para simular flujo real.
+        setImmediate(() => {
+            for (const h of child._stdoutHandlers) h(Buffer.from('{"verdict":"ok","reason":"x","inconsistencies":[]}'));
+            for (const h of child._exitHandlers) h(0);
+        });
+        return child;
+    };
+    const fakeHandler = {
+        buildSpawn: () => ({
+            cmd: 'fake-claude',
+            args: [],
+            spawnOpts: { stdio: ['pipe', 'pipe', 'pipe'], shell: false, windowsHide: true },
+        }),
+    };
+    const result = await sherlock._spawnAnthropicComplete({
+        prompt: 'test prompt',
+        timeoutMs: 30000,
+        spawnImpl: fakeSpawnImpl,
+        anthropicHandler: fakeHandler,
+    });
+    assert.equal(result.ok, true);
+    assert.match(result.content, /"verdict":"ok"/);
+    assert.equal(result.provider, 'anthropic');
+});
+
+test('#3484 CA-CLIENT-3: DEFAULT_TIMEOUT_MS del cliente = 90s', () => {
+    const client = require('../multi-provider/completion-client');
+    assert.equal(client.DEFAULT_TIMEOUT_MS, 90_000);
+});
+
+test('#3484 CA-CLIENT-4: ABSOLUTE_MAX_TIMEOUT_MS del cliente = 180s', () => {
+    const client = require('../multi-provider/completion-client');
+    assert.equal(client.ABSOLUTE_MAX_TIMEOUT_MS, 180_000);
 });

--- a/.pipeline/lib/__tests__/sherlock-verifier.test.js
+++ b/.pipeline/lib/__tests__/sherlock-verifier.test.js
@@ -985,3 +985,171 @@ test('#3484 CA-CLIENT-4: ABSOLUTE_MAX_TIMEOUT_MS del cliente = 180s', () => {
     const client = require('../multi-provider/completion-client');
     assert.equal(client.ABSOLUTE_MAX_TIMEOUT_MS, 180_000);
 });
+
+// =============================================================================
+// #3484 CA-AUDIT-1 — Persistencia JSONL de los 5 campos enriched
+// (sameProvider, sameModel, commanderModel, sherlockModel, transport).
+//
+// Estos tests leen el archivo JSONL escrito por audit-log.appendChained y
+// validan que los 5 campos aparezcan persistidos en cada entry. Es la prueba
+// final de CA-AUDIT-1 que faltaba en los 5 rebotes de PO/Review/UX.
+// Documentado en docs/pipeline/multi-provider.md:1602, 1622-1634.
+// =============================================================================
+
+function readAuditEntries(pipelineDir) {
+    const logsDir = path.join(pipelineDir, 'logs');
+    if (!fs.existsSync(logsDir)) return [];
+    const out = [];
+    for (const f of fs.readdirSync(logsDir)) {
+        const full = path.join(logsDir, f);
+        const content = fs.readFileSync(full, 'utf8');
+        for (const line of content.split(/\r?\n/)) {
+            if (!line.trim()) continue;
+            try {
+                out.push(JSON.parse(line));
+            } catch { /* skip malformed */ }
+        }
+    }
+    return out;
+}
+
+test('#3484 CA-AUDIT-1: JSONL persiste los 5 campos enriched (verdict ok, sameProvider=true)', async () => {
+    const dir = mkTmpPipelineDir();
+    const okResp = {
+        ok: true,
+        content: JSON.stringify({ verdict: 'ok', reason: 'todo ok', inconsistencies: [] }),
+        inputTokens: 12, outputTokens: 8, durationMs: 75,
+    };
+    await sherlock.verify({
+        analysis: 'analisis cualquiera',
+        originalRequest: '?',
+        systemState: 'estado',
+        commanderProvider: 'cerebras',
+        commanderModel: 'llama-3.3-70b',
+        pipelineDir: dir,
+        configLoader: defaultConfigLoader(),
+        completionClient: fakeCompletionClient(okResp),
+        quotaModule: fakeQuotaAllPass(),
+        dispatchModule: fakeDispatcher({ providerChain: CHAIN_HTTP }),
+        residencyModule: fakeResidencyOk(),
+    });
+    const entries = readAuditEntries(dir);
+    assert.ok(entries.length >= 1, 'debe haber al menos 1 entry en el JSONL');
+    const verification = entries.find(e => e.event === 'sherlock_verification');
+    assert.ok(verification, 'debe existir un evento sherlock_verification persistido');
+    // Los 5 campos enriched deben estar presentes y con los valores esperados.
+    assert.equal(verification.same_provider, true, 'same_provider=true persistido');
+    assert.equal(verification.same_model, true, 'same_model=true persistido');
+    assert.equal(verification.commander_model, 'llama-3.3-70b', 'commander_model persistido');
+    assert.equal(verification.sherlock_model, 'llama-3.3-70b', 'sherlock_model persistido');
+    assert.equal(verification.transport, 'http', 'transport persistido');
+});
+
+test('#3484 CA-AUDIT-1: JSONL persiste sameProvider=false cuando commander y sherlock difieren', async () => {
+    const dir = mkTmpPipelineDir();
+    const okResp = {
+        ok: true,
+        content: JSON.stringify({ verdict: 'ok', reason: 'ok', inconsistencies: [] }),
+        inputTokens: 10, outputTokens: 5, durationMs: 50,
+    };
+    await sherlock.verify({
+        analysis: 'a', originalRequest: '?', systemState: 's',
+        commanderProvider: 'anthropic',
+        commanderModel: 'claude-opus-4-7',
+        pipelineDir: dir,
+        configLoader: defaultConfigLoader(),
+        completionClient: fakeCompletionClient(okResp),
+        quotaModule: fakeQuotaAllPass(),
+        dispatchModule: fakeDispatcher({ providerChain: CHAIN_HTTP }),
+        residencyModule: fakeResidencyOk(),
+    });
+    const entries = readAuditEntries(dir);
+    const verification = entries.find(e => e.event === 'sherlock_verification');
+    assert.ok(verification, 'evento sherlock_verification debe estar persistido');
+    assert.equal(verification.same_provider, false, 'commander=anthropic vs sherlock=cerebras → same_provider=false');
+    assert.equal(verification.same_model, false, 'modelos distintos → same_model=false');
+    assert.equal(verification.commander_model, 'claude-opus-4-7');
+    assert.equal(verification.sherlock_model, 'llama-3.3-70b');
+    assert.equal(verification.transport, 'http');
+});
+
+test('#3484 CA-AUDIT-1: JSONL persiste transport=spawn cuando Sherlock usa Anthropic CLI', async () => {
+    const dir = mkTmpPipelineDir();
+    const spawnResp = {
+        ok: true,
+        content: JSON.stringify({ verdict: 'ok', reason: 'ok', inconsistencies: [] }),
+        inputTokens: 0, outputTokens: 0, durationMs: 400,
+    };
+    await sherlock.verify({
+        analysis: 'a', originalRequest: '?', systemState: 's',
+        commanderProvider: 'anthropic',
+        commanderModel: 'claude-opus-4-7',
+        pipelineDir: dir,
+        configLoader: defaultConfigLoader(),
+        // El completionClient no debería ser llamado — anthropic usa spawn.
+        completionClient: fakeCompletionClient({ ok: false, error: { type: 'should_not_be_called' } }),
+        spawnAnthropic: fakeSpawnAnthropic(spawnResp),
+        quotaModule: fakeQuotaAllPass(),
+        dispatchModule: fakeDispatcher({ providerChain: CHAIN_ANTH_FIRST }),
+        residencyModule: fakeResidencyOk(),
+    });
+    const entries = readAuditEntries(dir);
+    const verification = entries.find(e => e.event === 'sherlock_verification');
+    assert.ok(verification, 'sherlock_verification debe estar persistido');
+    assert.equal(verification.transport, 'spawn', 'CLI Anthropic → transport=spawn persistido');
+    assert.equal(verification.same_provider, true, 'commander=anthropic, sherlock=anthropic → true');
+    assert.equal(verification.same_model, false, 'commander=opus vs sherlock=haiku → false');
+    assert.equal(verification.commander_model, 'claude-opus-4-7');
+    assert.equal(verification.sherlock_model, 'claude-haiku-4-5');
+});
+
+test('#3484 CA-AUDIT-1: JSONL persiste 5 campos enriched también en sherlock_schema_violation', async () => {
+    const dir = mkTmpPipelineDir();
+    const badResp = {
+        ok: true,
+        content: 'esto no es JSON válido',
+        inputTokens: 5, outputTokens: 3, durationMs: 30,
+    };
+    await sherlock.verify({
+        analysis: 'a', originalRequest: '?', systemState: 's',
+        commanderProvider: 'cerebras',
+        commanderModel: 'llama-3.3-70b',
+        pipelineDir: dir,
+        configLoader: defaultConfigLoader(),
+        completionClient: fakeCompletionClient(badResp),
+        quotaModule: fakeQuotaAllPass(),
+        dispatchModule: fakeDispatcher({ providerChain: CHAIN_HTTP }),
+        residencyModule: fakeResidencyOk(),
+    });
+    const entries = readAuditEntries(dir);
+    const violation = entries.find(e => e.event === 'sherlock_schema_violation');
+    assert.ok(violation, 'sherlock_schema_violation debe estar persistido');
+    assert.equal(violation.same_provider, true);
+    assert.equal(violation.same_model, true);
+    assert.equal(violation.commander_model, 'llama-3.3-70b');
+    assert.equal(violation.sherlock_model, 'llama-3.3-70b');
+    assert.equal(violation.transport, 'http');
+});
+
+test('#3484 CA-AUDIT-1: JSONL persiste campos enriched también en sherlock_aborted_residency', async () => {
+    const dir = mkTmpPipelineDir();
+    await sherlock.verify({
+        analysis: 'a', originalRequest: '?', systemState: 's',
+        commanderProvider: 'cerebras',
+        commanderModel: 'llama-3.3-70b',
+        pipelineDir: dir,
+        configLoader: defaultConfigLoader(),
+        completionClient: fakeCompletionClient({ ok: true, content: '{}', inputTokens: 0, outputTokens: 0, durationMs: 0 }),
+        quotaModule: fakeQuotaAllPass(),
+        dispatchModule: fakeDispatcher({ providerChain: CHAIN_HTTP }),
+        residencyModule: fakeResidencyBlock(),
+    });
+    const entries = readAuditEntries(dir);
+    const aborted = entries.find(e => e.event === 'sherlock_aborted_residency');
+    assert.ok(aborted, 'sherlock_aborted_residency debe estar persistido');
+    assert.equal(aborted.same_provider, true);
+    assert.equal(aborted.same_model, true);
+    assert.equal(aborted.commander_model, 'llama-3.3-70b');
+    assert.equal(aborted.sherlock_model, 'llama-3.3-70b');
+    assert.equal(aborted.transport, 'http');
+});

--- a/.pipeline/lib/commander/multi-provider.js
+++ b/.pipeline/lib/commander/multi-provider.js
@@ -390,6 +390,14 @@ function auditCommanderRequest(opts = {}) {
         errorCode,
         injectionHits,
         supportsToolUse,
+        // CA-AUDIT-1 (#3484) — Campos enriched para análisis cross-provider
+        // del Sherlock. Vienen opcionalmente; cuando el caller (sherlock-verifier)
+        // los provee, los persistimos al JSONL para auditoría.
+        sameProvider,
+        sameModel,
+        commanderModel,
+        sherlockModel,
+        transport,
         // inyectables tests
         fsImpl,
         auditLog,
@@ -416,6 +424,15 @@ function auditCommanderRequest(opts = {}) {
         error_code: errorCode || null,
         injection_hits: Array.isArray(injectionHits) ? injectionHits.length : 0,
         supports_tool_use: typeof supportsToolUse === 'boolean' ? supportsToolUse : null,
+        // CA-AUDIT-1 (#3484) — 5 campos enriched. Solo se incluyen cuando el
+        // caller los provee (caller típico: sherlock-verifier.emitAuditEvent).
+        // Para eventos del Commander puro quedan en null/undefined y no
+        // afectan el shape canónico.
+        same_provider: typeof sameProvider === 'boolean' ? sameProvider : null,
+        same_model: typeof sameModel === 'boolean' ? sameModel : null,
+        commander_model: commanderModel || null,
+        sherlock_model: sherlockModel || null,
+        transport: transport || null,
     };
 
     try {

--- a/.pipeline/lib/multi-provider/completion-client.js
+++ b/.pipeline/lib/multi-provider/completion-client.js
@@ -44,8 +44,13 @@
 //     provider (sólo `content`/`inputTokens`/`outputTokens`).
 //
 // DoS / resource exhaustion:
-//   - Timeout configurable (default 10s) en `req.setTimeout` + handler que
-//     destruye con `code: 'ETIMEDOUT'`.
+//   - Timeout configurable (default 90s, cap defensivo 180s) en `req.setTimeout`
+//     + handler que destruye con `code: 'ETIMEDOUT'`. El cap absoluto
+//     (`ABSOLUTE_MAX_TIMEOUT_MS`) NO puede ser removido por el caller — protege
+//     al cliente Telegram de quedar bloqueado por una respuesta colgada.
+//     Histórico: el default era 10s + Sherlock clampaba a 30s — insuficiente
+//     para razonamiento adversarial real (issue #3484). Subido a 90s con cap
+//     180s en mayo 2026.
 //   - Body cap 64KB (`MAX_BODY_BYTES`). Si el provider devuelve más, abortamos
 //     con `error: {type: 'invalid_response', reason: 'body_too_large'}`.
 //
@@ -152,7 +157,17 @@ const PROVIDER_MODELS_ALLOWLIST = Object.freeze({
     ]),
 });
 
-const DEFAULT_TIMEOUT_MS = 10_000;
+// Timeout default — 90s. Cubre razonamiento adversarial real de Sherlock
+// (#3484) sin presión de reloj. Histórico: era 10s — insuficiente para
+// providers que tardan 20-40s en razonar sobre análisis largos.
+const DEFAULT_TIMEOUT_MS = 90_000;
+
+// Cap defensivo absoluto del timeout — el caller puede pedir hasta este valor.
+// Más allá de 3 minutos un turno de Telegram empieza a sentirse colgado y
+// arriesga a que el usuario mande mensajes adicionales pensando que el bot
+// murió. NO removible desde caller — protege al chat de bloqueos infinitos.
+const ABSOLUTE_MAX_TIMEOUT_MS = 180_000;
+
 const MAX_BODY_BYTES = 64 * 1024; // 64KB — cap defensivo contra DoS.
 
 function isAllowedProvider(provider) {
@@ -212,6 +227,13 @@ async function complete({
 } = {}) {
     const startedAt = Date.now();
     const baseResult = { provider, model };
+
+    // Cap defensivo absoluto — defensa-en-profundidad contra callers que
+    // pasen timeouts excesivos (intencional o por bug). NO se removible.
+    const rawTimeout = Number(timeoutMs);
+    const effectiveTimeoutMs = Number.isFinite(rawTimeout) && rawTimeout > 0
+        ? Math.min(rawTimeout, ABSOLUTE_MAX_TIMEOUT_MS)
+        : DEFAULT_TIMEOUT_MS;
 
     if (!isAllowedProvider(provider)) {
         return {
@@ -274,13 +296,13 @@ async function complete({
 
     let httpResult;
     try {
-        httpResult = await doRequest({ spec, key, body, timeoutMs, httpImpl });
+        httpResult = await doRequest({ spec, key, body, timeoutMs: effectiveTimeoutMs, httpImpl });
     } catch (e) {
         const isTimeout = e && (e.code === 'ETIMEDOUT' || e.code === 'ESOCKETTIMEDOUT');
         return {
             ok: false,
             error: isTimeout
-                ? { type: 'timeout', detail: `request superó timeoutMs=${timeoutMs}` }
+                ? { type: 'timeout', detail: `request superó timeoutMs=${effectiveTimeoutMs}` }
                 : { type: 'http_error', reason: 'network_error', detail: e && e.message ? e.message : String(e) },
             ...baseResult,
             durationMs: Date.now() - startedAt,
@@ -446,5 +468,6 @@ module.exports = {
     PROVIDER_COMPLETION_ENDPOINTS,
     PROVIDER_MODELS_ALLOWLIST,
     DEFAULT_TIMEOUT_MS,
+    ABSOLUTE_MAX_TIMEOUT_MS,
     MAX_BODY_BYTES,
 };

--- a/.pipeline/lib/sherlock-verifier.js
+++ b/.pipeline/lib/sherlock-verifier.js
@@ -8,19 +8,42 @@
 // análisis por confiar en memory/contexto previo en lugar de re-verificar
 // el estado actual del sistema. Sherlock institucionaliza la contraposición:
 //   - prompt invariante ("fiscal")
-//   - provider DISTINTO al del Commander
-//   - timeout defensivo (10s default)
+//   - el provider de mejor calidad disponible (orden compartido con Commander)
+//   - timeout delegado al completion-client (90s default, 180s cap)
 //   - disclaimer si falla la verificación
 //   - cap reelaboración hardcoded = 1
 //
 // Sherlock NO es un skill de agente — corre IN-PROCESS dentro del flujo
 // `recogerTextoLibre` del pulpo, entre `ejecutarClaude` y `sendTelegram`.
 // El pulpo lo wirea con `verify(...)`; este módulo no toca filesystem ni
-// red por su cuenta (todo se inyecta vía completion-client).
+// red por su cuenta (todo se inyecta vía completion-client o spawn-CLI).
+//
+// CAMBIOS #3484 (2026-05-23) — Decisión Opción B (spawn CLI para Anthropic)
+// --------------------------------------------------------------------------
+// Hasta esta versión Sherlock SOLO usaba providers HTTP-compatible (cerebras /
+// gemini-google / nvidia-nim) y EXCLUÍA el provider del Commander para
+// preservar adversariality. Combinado con un clamp de timeout en 10s, eso
+// causaba que Sherlock cayera en fallback en cascada y muriera en F-6
+// silencioso casi siempre.
+//
+// Cambios:
+//   1. Se removió el filtro `HTTP_COMPATIBLE_PROVIDERS` que saltaba providers
+//      no-HTTP. Sherlock ahora acepta cualquier provider de la chain
+//      telegram-sherlock. Para Anthropic usa spawn CLI (Opción B) reusando
+//      `agent-launcher/providers/anthropic.js`. Codex sigue siendo stub
+//      (#3076 H3 pendiente) y se salta con gracia hasta que H3 entregue.
+//   2. Se removió el clamp local de timeout (`ABSOLUTE_MAX_TIMEOUT_MS=30s`).
+//      El presupuesto vive en el cliente HTTP (90s default, 180s cap).
+//   3. Se removió la exclusión cross-provider — Sherlock puede usar el mismo
+//      provider que el Commander. Adversariality reducida es riesgo aceptado
+//      (Leo, 2026-05-22 voz). El audit log registra `same_provider` y
+//      `same_model` para monitorearlo (CA-AUDIT-1).
+//   4. Disclaimers F-5/F-6 actualizados al phrasing aprobado por UX
+//      (CA-UX-3/UX-4).
 //
 // FLOW (resumido — el flujo completo está en pulpo.js):
 //   Commander responde →
-//     Sherlock.verify(analysis, originalRequest, systemState, excludedProvider)
+//     Sherlock.verify(analysis, originalRequest, systemState, commanderProvider)
 //       → si verdict=ok → respuesta original sin cambios
 //       → si verdict=rechazado y reelaboraciones < 1 →
 //            Commander reelabora con `inconsistencies` →
@@ -71,48 +94,56 @@ const commanderMP = require('./commander/multi-provider');
 // Invariante CA-SEC-9 — hardcoded, NO depende de config.
 const HARDCODED_MAX_REELABORACIONES = 1;
 
-// Clamp defensivo del timeout — config no puede pedir más de 30s para
-// evitar starvation de turnos Telegram.
-const ABSOLUTE_MAX_TIMEOUT_MS = 30_000;
-const DEFAULT_TIMEOUT_MS = 10_000;
-
 // Cap defensivo de inconsistencias aceptadas en el output del Sherlock
 // (CA-SEC-6). Si el modelo dice "encontré 50 inconsistencias", recortamos
 // a las primeras 5. Más que eso es ruido o intento de DoS de payload.
 const MAX_INCONSISTENCIES = 5;
 
-// Allowlist de providers HTTP-compatibles (consumibles por completion-client).
-// `openai-codex` y `anthropic` quedan en la chain `telegram-sherlock` para
-// el futuro (cuando se sume spawn-vía-completion-client) pero hoy Sherlock
-// los salta. Si todos los HTTP-compatibles están gateados, abortamos con F-6.
-const HTTP_COMPATIBLE_PROVIDERS = Object.freeze(new Set([
+// Providers que Sherlock invoca vía HTTP completion-client. El resto se
+// despacha vía spawn-CLI (cuando hay handler disponible) o se saltea.
+// Para sumar uno nuevo: agregarlo acá Y a `PROVIDER_COMPLETION_ENDPOINTS`
+// de `lib/multi-provider/completion-client.js`.
+const HTTP_COMPLETION_PROVIDERS = Object.freeze(new Set([
     'cerebras',
     'gemini-google',
     'nvidia-nim',
 ]));
 
+// Providers que Sherlock invoca vía spawn CLI (Opción B de #3484).
+// Anthropic es el único soportado hoy: reusa el launcher detection de
+// `agent-launcher/providers/anthropic.js` y manda el prompt por stdin con
+// `--output-format text`. Codex queda pendiente (#3076 H3).
+const SPAWN_COMPLETION_PROVIDERS = Object.freeze(new Set([
+    'anthropic',
+]));
+
+// Timeout default que Sherlock pasa al completion-client / spawn helper si
+// no recibe override por config. El cliente HTTP tiene su propio cap absoluto
+// (180s) que es la defensa real; este número es solo conveniencia + back-compat
+// con tests/callers viejos. Histórico: era 10s (clampado a 30s) — insuficiente.
+const DEFAULT_TIMEOUT_MS = 90_000;
+
 // -----------------------------------------------------------------------------
 // Disclaimers (CA-F-5/F-6) — constantes string en español, voseo argentino.
-// UX guidelines del padre #3331:
-//   - voseo ("verificá manualmente")
+// UX guidelines (#3331 + #3484 CA-UX-3/UX-4):
+//   - voseo ("decímelo", "revisamos juntos")
 //   - sin sello visible cuando verdict=ok
 //   - diferenciación timeout (F-6) vs inconsistencia persistente (F-5)
-//   - info accionable al usuario
+//   - tono empático, primera persona, invita feedback
 //   - sin avisar pre-Sherlock
 // El pool de variantes rotativas queda para #3339 (no en este scope).
 // -----------------------------------------------------------------------------
 const DISCLAIMER_F5_PERSISTENT_INCONSISTENCY = (
     '\n\n' +
-    '⚠️ Sherlock detectó inconsistencias en mi respuesta incluso después de ' +
-    'reelaborar. Te paso la versión reelaborada igual, pero verificá manualmente ' +
-    'antes de decidir.'
+    '🔍 Detecté una inconsistencia en mi primera respuesta y la ajusté. ' +
+    'Si la versión anterior te parecía mejor, decime y la reviso.'
 );
 
 const DISCLAIMER_F6_VERIFICATION_FAILED = (
     '\n\n' +
-    '⚠️ No pude verificar esta respuesta con Sherlock (timeout o sin provider ' +
-    'distinto disponible). Te la paso sin contraste — revisá los datos manualmente ' +
-    'si vas a actuar sobre algo crítico.'
+    'ℹ️ No pude verificar esta respuesta con el verificador adversarial — ' +
+    'te muestro la versión original. Si notás algo raro, decímelo y la ' +
+    'revisamos juntos.'
 );
 
 const DISCLAIMER_TYPES = Object.freeze({
@@ -132,12 +163,18 @@ function hashFor(s) {
 }
 
 // -----------------------------------------------------------------------------
-// loadSherlockConfig — lee config.yaml (sherlock_enabled, timeout,
-// max_reelaboraciones). Aplica clamps defensivos (CA-SEC-9, CA-L-1).
+// loadSherlockConfig — lee config.yaml (sherlock_enabled, max_reelaboraciones).
+// Aplica clamps defensivos (CA-SEC-9).
 //
 // CA-SEC-7: solo lee del archivo, NUNCA acepta `enabled` por argumento del
 // usuario. El caller (pulpo.js) lo pasa con `configLoader` inyectable solo
 // para tests; en producción siempre es el `loadConfig` real.
+//
+// #3484: `sherlock_timeout_ms` se ignora — el presupuesto vive en el
+// completion-client. Si está presente en config viejas, devolvemos `timeoutMs`
+// con el DEFAULT_TIMEOUT_MS pero NO clampeamos al valor declarado. La compat
+// es importante: configs en producción todavía tienen el campo y el cargador
+// debe tolerarlo sin warn-spammear.
 // -----------------------------------------------------------------------------
 function loadSherlockConfig({ configLoader } = {}) {
     let cfg = {};
@@ -147,10 +184,10 @@ function loadSherlockConfig({ configLoader } = {}) {
         cfg = {};
     }
     const enabled = cfg.sherlock_enabled === false ? false : true; // default ON
-    const timeoutRaw = Number(cfg.sherlock_timeout_ms);
-    const timeoutMs = Number.isFinite(timeoutRaw) && timeoutRaw > 0
-        ? Math.min(timeoutRaw, ABSOLUTE_MAX_TIMEOUT_MS)
-        : DEFAULT_TIMEOUT_MS;
+    // #3484 — `sherlock_timeout_ms` deprecated. Devolvemos DEFAULT_TIMEOUT_MS
+    // siempre. El campo se mantiene en el shape de retorno por compat con
+    // callers/tests que lo lean, pero NO refleja config user-facing.
+    const timeoutMs = DEFAULT_TIMEOUT_MS;
     // CA-SEC-9 — el cap es 1, no importa qué diga config.
     const maxRaw = Number(cfg.sherlock_max_reelaboraciones);
     const maxReelab = Number.isFinite(maxRaw) && maxRaw >= 0
@@ -274,15 +311,19 @@ function parseAndValidateSherlockOutput(raw) {
 
 // -----------------------------------------------------------------------------
 // resolveSherlockProvider — encuentra el primer provider de la chain
-// `telegram-sherlock` que sea HTTP-compatible y NO esté excluido. Itera
-// agregando providers no-HTTP a la lista de excluidos hasta encontrar uno
-// válido o agotar la chain.
+// `telegram-sherlock` que tenga handler implementado en Sherlock (HTTP o
+// spawn). Itera agregando providers no-soportados a la lista de excluidos
+// hasta encontrar uno válido o agotar la chain.
 //
-// Recibe `excludedProvider` (string del Commander). Devuelve `{provider,
-// model}` o `null` si no hay candidato.
+// #3484: ya NO se excluye al commanderProvider. Sherlock puede usar el
+// mismo provider que el Commander — se acepta adversariality reducida y se
+// registra `same_provider` en el audit log (CA-AUDIT-1).
+//
+// Devuelve `{provider, model, transport: 'http'|'spawn'}` o `null` si no
+// hay candidato implementado en toda la chain.
 // -----------------------------------------------------------------------------
 function resolveSherlockProvider({
-    excludedProvider,
+    excludedProvider,  // mantenido en signature por back-compat; ignorado (#3484)
     pipelineDir,
     log,
     quotaModule,
@@ -291,10 +332,10 @@ function resolveSherlockProvider({
     now,
     maxIterations = 6,
 }) {
+    // #3484: `excludedProvider` se ignora a propósito (back-compat). El
+    // único motivo para excluir un provider acá es que NO tengamos handler
+    // implementado todavía (ej. openai-codex es stub).
     const excluded = new Set();
-    if (typeof excludedProvider === 'string' && excludedProvider) {
-        excluded.add(excludedProvider);
-    }
     for (let i = 0; i < maxIterations; i++) {
         let res;
         try {
@@ -319,19 +360,186 @@ function resolveSherlockProvider({
         if (!res || !res.provider || res.gated) {
             return null;
         }
-        if (HTTP_COMPATIBLE_PROVIDERS.has(res.provider)) {
+        if (HTTP_COMPLETION_PROVIDERS.has(res.provider)) {
             return {
                 provider: res.provider,
                 model: res.model || null,
+                transport: 'http',
                 source: res.source,
                 fallbackUsed: res.fallbackUsed,
                 chainTried: res.chainTried,
             };
         }
-        // Provider no-HTTP — excluir y seguir.
+        if (SPAWN_COMPLETION_PROVIDERS.has(res.provider)) {
+            return {
+                provider: res.provider,
+                model: res.model || null,
+                transport: 'spawn',
+                source: res.source,
+                fallbackUsed: res.fallbackUsed,
+                chainTried: res.chainTried,
+            };
+        }
+        // Provider sin handler en Sherlock (ej. openai-codex stub #3076) —
+        // excluir y seguir con el próximo de la chain.
+        if (typeof log === 'function') {
+            log('sherlock', `provider ${res.provider} no tiene handler en Sherlock — fallback al siguiente`);
+        }
         excluded.add(res.provider);
     }
     return null;
+}
+
+// -----------------------------------------------------------------------------
+// spawnAnthropicComplete — invoca `claude` CLI con el prompt por stdin y
+// devuelve el shape canónico de completion-client (`{ok, content, ...}`).
+//
+// Reusa `agent-launcher/providers/anthropic.js::detectLauncher` para detectar
+// el binario/launcher correcto (compat con Claude Code ≥2.1.114 native exe,
+// cli.js legacy, cmd shim, etc.). Pasa `--permission-mode bypassPermissions`
+// + `--output-format text` para obtener la respuesta cruda directamente.
+//
+// Timeout: respeta el `timeoutMs` recibido (clampado por el caller al
+// ABSOLUTE_MAX_TIMEOUT_MS del cliente HTTP). Si no hay respuesta antes,
+// mata el child con SIGTERM y devuelve `error.type === 'timeout'`.
+//
+// SECURITY:
+//   - El prompt va por stdin (no como arg) → no aparece en `ps aux` ni en
+//     command-line logs del SO.
+//   - El env del child se hereda del parent + `CLAUDE_PROJECT_DIR=ROOT` (mismo
+//     patrón que `ejecutarClaude` en pulpo.js).
+//   - El stdout se trunca a 64KB (mismo cap que completion-client) para
+//     defensa anti-DoS de payload.
+// -----------------------------------------------------------------------------
+const SPAWN_MAX_STDOUT_BYTES = 64 * 1024;
+
+function spawnAnthropicComplete({
+    prompt,
+    timeoutMs,
+    spawnImpl,
+    anthropicHandler,
+    cwd,
+    env,
+}) {
+    return new Promise((resolve) => {
+        const startedAt = Date.now();
+        const _spawn = spawnImpl || require('node:child_process').spawn;
+        const handler = anthropicHandler || require('./agent-launcher/providers/anthropic');
+
+        let spawnSpec;
+        try {
+            spawnSpec = handler.buildSpawn({
+                args: [
+                    '-p',
+                    '--output-format', 'text',
+                    '--permission-mode', 'bypassPermissions',
+                ],
+                cwd: cwd || process.cwd(),
+                env: env || { ...process.env, CLAUDE_PROJECT_DIR: cwd || process.cwd() },
+            });
+        } catch (e) {
+            return resolve({
+                ok: false,
+                error: { type: 'spawn_unavailable', detail: e && e.message ? e.message : String(e) },
+                provider: 'anthropic',
+                durationMs: Date.now() - startedAt,
+            });
+        }
+
+        let child;
+        try {
+            // El child espera stdin (`'pipe'`) para recibir el prompt.
+            const opts = Object.assign({}, spawnSpec.spawnOpts, { stdio: ['pipe', 'pipe', 'pipe'] });
+            child = _spawn(spawnSpec.cmd, spawnSpec.args, opts);
+        } catch (e) {
+            return resolve({
+                ok: false,
+                error: { type: 'spawn_failed', detail: e && e.message ? e.message : String(e) },
+                provider: 'anthropic',
+                durationMs: Date.now() - startedAt,
+            });
+        }
+
+        let stdoutBuf = Buffer.alloc(0);
+        let stderrBuf = Buffer.alloc(0);
+        let truncated = false;
+        let resolved = false;
+
+        const finish = (result) => {
+            if (resolved) return;
+            resolved = true;
+            try { clearTimeout(timer); } catch {}
+            resolve(Object.assign({ provider: 'anthropic', durationMs: Date.now() - startedAt }, result));
+        };
+
+        const timer = setTimeout(() => {
+            try { child.kill('SIGTERM'); } catch {}
+            finish({
+                ok: false,
+                error: { type: 'timeout', detail: `spawn anthropic superó timeoutMs=${timeoutMs}` },
+            });
+        }, Math.max(1_000, Number(timeoutMs) || DEFAULT_TIMEOUT_MS));
+
+        try {
+            if (child.stdin && typeof child.stdin.write === 'function') {
+                child.stdin.write(prompt);
+                child.stdin.end();
+            }
+        } catch (e) {
+            return finish({
+                ok: false,
+                error: { type: 'spawn_failed', detail: `stdin write: ${e && e.message ? e.message : String(e)}` },
+            });
+        }
+
+        if (child.stdout) {
+            child.stdout.on('data', (chunk) => {
+                if (truncated) return;
+                if (stdoutBuf.length + chunk.length > SPAWN_MAX_STDOUT_BYTES) {
+                    truncated = true;
+                    try { child.kill('SIGTERM'); } catch {}
+                    return finish({
+                        ok: false,
+                        error: { type: 'invalid_response', reason: 'body_too_large', detail: `stdout > ${SPAWN_MAX_STDOUT_BYTES} bytes` },
+                    });
+                }
+                stdoutBuf = Buffer.concat([stdoutBuf, chunk]);
+            });
+        }
+        if (child.stderr) {
+            child.stderr.on('data', (chunk) => {
+                // Limitamos stderr para no inflar memoria — solo importa el primer KB.
+                if (stderrBuf.length < 2048) {
+                    stderrBuf = Buffer.concat([stderrBuf, chunk.slice(0, 2048 - stderrBuf.length)]);
+                }
+            });
+        }
+
+        child.on('error', (e) => {
+            finish({
+                ok: false,
+                error: { type: 'spawn_error', detail: e && e.message ? e.message : String(e) },
+            });
+        });
+
+        child.on('exit', (code) => {
+            if (resolved) return;
+            const stdout = stdoutBuf.toString('utf8').trim();
+            const stderr = stderrBuf.toString('utf8').trim();
+            if (code === 0 && stdout) {
+                return finish({
+                    ok: true,
+                    content: stdout,
+                    inputTokens: 0,   // CLI text-mode no expone tokens — best-effort
+                    outputTokens: 0,
+                });
+            }
+            return finish({
+                ok: false,
+                error: { type: 'spawn_exit', detail: `exit=${code}; stderr=${stderr.slice(0, 400)}` },
+            });
+        });
+    });
 }
 
 // -----------------------------------------------------------------------------
@@ -372,17 +580,26 @@ function emitAuditEvent({ pipelineDir, event, payload, fsImpl, auditLog, now }) 
 // verify — la API principal del módulo. Llamada desde pulpo.js post-`ejecutarClaude`.
 //
 // Args (obligatorios):
-//   - analysis:        string de la respuesta del Commander (la que iba a Telegram)
-//   - originalRequest: texto del usuario que disparó este turno
-//   - systemState:     snapshot del estado pre-respuesta (lo que el Commander
-//                      observó; el Sherlock lo usa para contrastar)
-//   - lastHourLogs:    opcional, slice de logs de la última hora
-//   - excludedProvider: provider del Commander a evitar (CA-SEC-8)
-//   - pipelineDir:     para audit log
+//   - analysis:         string de la respuesta del Commander (la que iba a Telegram)
+//   - originalRequest:  texto del usuario que disparó este turno
+//   - systemState:      snapshot del estado pre-respuesta (lo que el Commander
+//                       observó; el Sherlock lo usa para contrastar)
+//   - lastHourLogs:     opcional, slice de logs de la última hora
+//   - commanderProvider: provider efectivo que usó el Commander (audit log).
+//                       #3484: ya NO se usa para excluir provider en Sherlock,
+//                       solo para registrar `same_provider`/`same_model`.
+//   - commanderModel:   modelo efectivo del Commander (audit). Opcional.
+//   - pipelineDir:      para audit log
+//
+// Args (back-compat, opcionales):
+//   - excludedProvider: alias legacy de `commanderProvider`. Mantenido para
+//                       que callers viejos no rompan. #3484: ignorado como
+//                       criterio de exclusión.
 //
 // Args (opcionales — inyectables para tests):
-//   - completionClient, configLoader, log, fsImpl, auditLog, now, quotaModule,
-//     dispatchModule
+//   - completionClient, spawnAnthropic, configLoader, log, fsImpl, auditLog,
+//     now, quotaModule, dispatchModule, residencyModule, anthropicHandler,
+//     spawnImpl, cwd, env
 //
 // Returns:
 //   {
@@ -391,8 +608,12 @@ function emitAuditEvent({ pipelineDir, event, payload, fsImpl, auditLog, now }) 
 //     inconsistencies: [{claim, contradiction}],
 //     inconsistenciesTruncated: boolean,
 //     sherlockProvider, sherlockModel,
+//     transport: 'http' | 'spawn' | null,
+//     sameProvider: boolean,    // CA-AUDIT-1 (#3484)
+//     sameModel: boolean,       // CA-AUDIT-1 (#3484)
+//     commanderProvider, commanderModel,
 //     durationMs, inputTokens, outputTokens,
-//     errorCode: string | null,    // 'timeout' | 'no_http_provider' | 'schema_violation' | 'residency_blocked' | 'disabled' | null
+//     errorCode: string | null,    // 'timeout' | 'no_provider' | 'schema_violation' | 'residency_blocked' | 'disabled' | null
 //     suggestedDisclaimer: null | DISCLAIMER_TYPES.*,
 //   }
 // El caller decide si reelabora, agrega disclaimer y manda a Telegram.
@@ -404,11 +625,22 @@ async function verify(opts = {}) {
         originalRequest,
         systemState,
         lastHourLogs,
-        excludedProvider,
         pipelineDir,
+
+        // back-compat: si el caller pasa `excludedProvider`, lo tratamos como
+        // `commanderProvider` (mismo string). #3484: ya NO se excluye, solo
+        // se loguea para `same_provider`.
+        excludedProvider,
+        commanderProvider: commanderProviderArg,
+        commanderModel: commanderModelArg,
 
         // inyectables tests
         completionClient,
+        spawnAnthropic,
+        anthropicHandler,
+        spawnImpl,
+        cwd,
+        env,
         configLoader,
         log,
         fsImpl,
@@ -419,9 +651,13 @@ async function verify(opts = {}) {
         residencyModule,
     } = opts;
 
+    const commanderProvider = commanderProviderArg || excludedProvider || null;
+    const commanderModel = commanderModelArg || null;
+
     const _log = typeof log === 'function' ? log : () => {};
     const _now = Number.isFinite(now) ? now : Date.now();
     const _completion = completionClient || require('./multi-provider/completion-client');
+    const _spawnAnthropic = typeof spawnAnthropic === 'function' ? spawnAnthropic : spawnAnthropicComplete;
     const _residency = residencyModule || null; // commanderMP.enforceDataResidency lo carga solo
 
     const cfg = loadSherlockConfig({ configLoader });
@@ -434,7 +670,7 @@ async function verify(opts = {}) {
             event: 'sherlock_skipped_disabled',
             payload: {
                 analysisHash: hashFor(analysis),
-                commanderProvider: excludedProvider || null,
+                commanderProvider,
                 durationMs: 0,
             },
         });
@@ -445,6 +681,11 @@ async function verify(opts = {}) {
             inconsistenciesTruncated: false,
             sherlockProvider: null,
             sherlockModel: null,
+            transport: null,
+            sameProvider: false,
+            sameModel: false,
+            commanderProvider,
+            commanderModel,
             durationMs: 0,
             inputTokens: 0,
             outputTokens: 0,
@@ -463,10 +704,11 @@ async function verify(opts = {}) {
         _log('sherlock', `🛡️ CA-SEC-1: analysis recortado (injection patterns=${san.hits.join('|')})`);
     }
 
-    // Resolución de provider — itera la chain telegram-sherlock excluyendo
-    // el commanderProvider + cualquier provider no-HTTP que aparezca.
+    // Resolución de provider — itera la chain telegram-sherlock. #3484:
+    // YA NO se excluye al commanderProvider; solo se saltan providers que
+    // no tienen handler implementado en Sherlock.
     const resolved = resolveSherlockProvider({
-        excludedProvider,
+        excludedProvider: null,
         pipelineDir,
         log: _log,
         quotaModule,
@@ -481,24 +723,35 @@ async function verify(opts = {}) {
             event: 'sherlock_verification',
             payload: {
                 analysisHash: hashFor(analysis),
-                commanderProvider: excludedProvider || null,
+                commanderProvider,
                 durationMs: Date.now() - startedAt,
-                errorCode: 'no_http_provider',
+                errorCode: 'no_provider',
             },
         });
         return {
             verdict: 'aborted',
-            reason: 'no_http_provider_available',
+            reason: 'no_provider_available',
             inconsistencies: [],
             inconsistenciesTruncated: false,
             sherlockProvider: null,
             sherlockModel: null,
+            transport: null,
+            sameProvider: false,
+            sameModel: false,
+            commanderProvider,
+            commanderModel,
             durationMs: Date.now() - startedAt,
             inputTokens: 0,
             outputTokens: 0,
-            errorCode: 'no_http_provider',
+            errorCode: 'no_provider',
             suggestedDisclaimer: DISCLAIMER_TYPES.TIMEOUT_OR_NO_PROVIDER,
         };
+    }
+
+    const sameProvider = !!(commanderProvider && commanderProvider === resolved.provider);
+    const sameModel = !!(sameProvider && commanderModel && resolved.model && commanderModel === resolved.model);
+    if (sameProvider) {
+        _log('sherlock', `🔍 same_provider=true (commander=${commanderProvider}/${commanderModel || '?'}, sherlock=${resolved.provider}/${resolved.model || '?'}) — adversariality reducida (#3484 riesgo aceptado)`);
     }
 
     // CA-SEC-3 — data-residency fail-closed ANTES del provider call.
@@ -520,7 +773,7 @@ async function verify(opts = {}) {
             event: 'sherlock_aborted_residency',
             payload: {
                 analysisHash: hashFor(analysis),
-                commanderProvider: excludedProvider || null,
+                commanderProvider,
                 sherlockProvider: resolved.provider,
                 durationMs: Date.now() - startedAt,
                 errorCode: drCheck.reason,
@@ -533,6 +786,11 @@ async function verify(opts = {}) {
             inconsistenciesTruncated: false,
             sherlockProvider: resolved.provider,
             sherlockModel: resolved.model,
+            transport: resolved.transport,
+            sameProvider,
+            sameModel,
+            commanderProvider,
+            commanderModel,
             durationMs: Date.now() - startedAt,
             inputTokens: 0,
             outputTokens: 0,
@@ -549,19 +807,35 @@ async function verify(opts = {}) {
         lastHourLogs,
     });
 
-    // Invocar completion-client con timeout configurado.
+    // Despacho según transport. HTTP → completion-client; SPAWN → spawn helper
+    // de Anthropic. El timeout (cfg.timeoutMs = 90s default) va al transporte;
+    // ambos respetan su propio cap absoluto (180s en el cliente HTTP, mismo
+    // valor efectivo en el spawn vía clamp del caller cuando aplique).
     let httpResult;
     try {
-        httpResult = await _completion.complete({
-            provider: resolved.provider,
-            model: resolved.model,
-            prompt,
-            timeoutMs: cfg.timeoutMs,
-            maxTokens: 1024,
-            temperature: 0,
-        });
+        if (resolved.transport === 'spawn' && resolved.provider === 'anthropic') {
+            httpResult = await _spawnAnthropic({
+                prompt,
+                timeoutMs: cfg.timeoutMs,
+                spawnImpl,
+                anthropicHandler,
+                cwd,
+                env,
+            });
+            // Normalizamos shape extra para igualar contrato del completion-client.
+            httpResult.model = resolved.model;
+        } else {
+            httpResult = await _completion.complete({
+                provider: resolved.provider,
+                model: resolved.model,
+                prompt,
+                timeoutMs: cfg.timeoutMs,
+                maxTokens: 1024,
+                temperature: 0,
+            });
+        }
     } catch (e) {
-        // complete() NO debería tirar (devuelve {ok:false}), pero defendemos.
+        // complete()/spawn() NO deberían tirar (devuelven {ok:false}), pero defendemos.
         httpResult = {
             ok: false,
             error: { type: 'unknown', detail: e && e.message ? e.message : String(e) },
@@ -580,7 +854,7 @@ async function verify(opts = {}) {
             event: 'sherlock_verification',
             payload: {
                 analysisHash: hashFor(analysis),
-                commanderProvider: excludedProvider || null,
+                commanderProvider,
                 sherlockProvider: resolved.provider,
                 durationMs: totalMs,
                 errorCode: httpResult.error ? httpResult.error.type : 'unknown',
@@ -593,6 +867,11 @@ async function verify(opts = {}) {
             inconsistenciesTruncated: false,
             sherlockProvider: resolved.provider,
             sherlockModel: resolved.model,
+            transport: resolved.transport,
+            sameProvider,
+            sameModel,
+            commanderProvider,
+            commanderModel,
             durationMs: totalMs,
             inputTokens: 0,
             outputTokens: 0,
@@ -609,7 +888,7 @@ async function verify(opts = {}) {
             event: 'sherlock_schema_violation',
             payload: {
                 analysisHash: hashFor(analysis),
-                commanderProvider: excludedProvider || null,
+                commanderProvider,
                 sherlockProvider: resolved.provider,
                 durationMs: totalMs,
                 inputTokens: httpResult.inputTokens,
@@ -624,6 +903,11 @@ async function verify(opts = {}) {
             inconsistenciesTruncated: false,
             sherlockProvider: resolved.provider,
             sherlockModel: resolved.model,
+            transport: resolved.transport,
+            sameProvider,
+            sameModel,
+            commanderProvider,
+            commanderModel,
             durationMs: totalMs,
             inputTokens: httpResult.inputTokens || 0,
             outputTokens: httpResult.outputTokens || 0,
@@ -641,7 +925,7 @@ async function verify(opts = {}) {
         event: 'sherlock_verification',
         payload: {
             analysisHash: hashFor(analysis),
-            commanderProvider: excludedProvider || null,
+            commanderProvider,
             sherlockProvider: resolved.provider,
             durationMs: totalMs,
             inputTokens: httpResult.inputTokens,
@@ -660,6 +944,11 @@ async function verify(opts = {}) {
         inconsistenciesTruncated: parsed.data.inconsistenciesTruncated,
         sherlockProvider: resolved.provider,
         sherlockModel: resolved.model,
+        transport: resolved.transport,
+        sameProvider,
+        sameModel,
+        commanderProvider,
+        commanderModel,
         durationMs: totalMs,
         inputTokens: httpResult.inputTokens || 0,
         outputTokens: httpResult.outputTokens || 0,
@@ -711,9 +1000,13 @@ module.exports = {
     // constantes
     HARDCODED_MAX_REELABORACIONES,
     DEFAULT_TIMEOUT_MS,
-    ABSOLUTE_MAX_TIMEOUT_MS,
     MAX_INCONSISTENCIES,
-    HTTP_COMPATIBLE_PROVIDERS,
+    HTTP_COMPLETION_PROVIDERS,
+    SPAWN_COMPLETION_PROVIDERS,
+    // Alias deprecated (#3484) — mantenido por back-compat con callers viejos.
+    // En la próxima limpieza removerlo. Apunta al set HTTP para no romper
+    // checks tipo `HTTP_COMPATIBLE_PROVIDERS.has(p)`.
+    HTTP_COMPATIBLE_PROVIDERS: HTTP_COMPLETION_PROVIDERS,
     DISCLAIMER_F5_PERSISTENT_INCONSISTENCY,
     DISCLAIMER_F6_VERIFICATION_FAILED,
     DISCLAIMER_TYPES,
@@ -724,4 +1017,5 @@ module.exports = {
     _buildFiscalPrompt: buildFiscalPrompt,
     _parseAndValidateSherlockOutput: parseAndValidateSherlockOutput,
     _resolveSherlockProvider: resolveSherlockProvider,
+    _spawnAnthropicComplete: spawnAnthropicComplete,
 };

--- a/.pipeline/lib/sherlock-verifier.js
+++ b/.pipeline/lib/sherlock-verifier.js
@@ -565,6 +565,19 @@ function emitAuditEvent({ pipelineDir, event, payload, fsImpl, auditLog, now }) 
             errorCode: payload && payload.errorCode || null,
             // NO mandamos prompt — solo hashes en `extra`
             prompt: payload && payload.analysisHash || '',
+            // CA-AUDIT-1 (#3484) — Propagamos los 5 campos enriched que el
+            // verifier ya calcula en `verify()` (sameProvider, sameModel,
+            // commanderModel, sherlockModel, transport). El audit-log los
+            // persiste al JSONL para análisis cross-provider posterior.
+            // Documentado en docs/pipeline/multi-provider.md (líneas 1602,
+            // 1622-1634). Cuando el payload no los tenga (eventos legacy o
+            // pre-resolve como `sherlock_skipped_disabled`), se envían como
+            // null/undefined y el audit los registra como null.
+            sameProvider: payload && typeof payload.sameProvider === 'boolean' ? payload.sameProvider : null,
+            sameModel: payload && typeof payload.sameModel === 'boolean' ? payload.sameModel : null,
+            commanderModel: payload && payload.commanderModel || null,
+            sherlockModel: payload && payload.sherlockModel || null,
+            transport: payload && payload.transport || null,
             fsImpl,
             auditLog,
             now,
@@ -671,7 +684,13 @@ async function verify(opts = {}) {
             payload: {
                 analysisHash: hashFor(analysis),
                 commanderProvider,
+                commanderModel,
                 durationMs: 0,
+                // CA-AUDIT-1 (#3484) — sin resolved aún; no hay sherlock provider/model.
+                sameProvider: false,
+                sameModel: false,
+                sherlockModel: null,
+                transport: null,
             },
         });
         return {
@@ -724,8 +743,14 @@ async function verify(opts = {}) {
             payload: {
                 analysisHash: hashFor(analysis),
                 commanderProvider,
+                commanderModel,
                 durationMs: Date.now() - startedAt,
                 errorCode: 'no_provider',
+                // CA-AUDIT-1 (#3484) — no hay provider Sherlock disponible.
+                sameProvider: false,
+                sameModel: false,
+                sherlockModel: null,
+                transport: null,
             },
         });
         return {
@@ -774,9 +799,15 @@ async function verify(opts = {}) {
             payload: {
                 analysisHash: hashFor(analysis),
                 commanderProvider,
+                commanderModel,
                 sherlockProvider: resolved.provider,
                 durationMs: Date.now() - startedAt,
                 errorCode: drCheck.reason,
+                // CA-AUDIT-1 (#3484) — campos enriched a partir del resolved.
+                sameProvider,
+                sameModel,
+                sherlockModel: resolved.model,
+                transport: resolved.transport,
             },
         });
         return {
@@ -855,9 +886,15 @@ async function verify(opts = {}) {
             payload: {
                 analysisHash: hashFor(analysis),
                 commanderProvider,
+                commanderModel,
                 sherlockProvider: resolved.provider,
                 durationMs: totalMs,
                 errorCode: httpResult.error ? httpResult.error.type : 'unknown',
+                // CA-AUDIT-1 (#3484) — campos enriched.
+                sameProvider,
+                sameModel,
+                sherlockModel: resolved.model,
+                transport: resolved.transport,
             },
         });
         return {
@@ -889,11 +926,17 @@ async function verify(opts = {}) {
             payload: {
                 analysisHash: hashFor(analysis),
                 commanderProvider,
+                commanderModel,
                 sherlockProvider: resolved.provider,
                 durationMs: totalMs,
                 inputTokens: httpResult.inputTokens,
                 outputTokens: httpResult.outputTokens,
                 errorCode: parsed.reason,
+                // CA-AUDIT-1 (#3484) — campos enriched.
+                sameProvider,
+                sameModel,
+                sherlockModel: resolved.model,
+                transport: resolved.transport,
             },
         });
         return {
@@ -926,6 +969,7 @@ async function verify(opts = {}) {
         payload: {
             analysisHash: hashFor(analysis),
             commanderProvider,
+            commanderModel,
             sherlockProvider: resolved.provider,
             durationMs: totalMs,
             inputTokens: httpResult.inputTokens,
@@ -934,6 +978,14 @@ async function verify(opts = {}) {
             // del audit no los expone como campos top-level. Quedan implícitos
             // en la lectura del JSONL (analysisHash al menos preserva trazabilidad).
             errorCode: null,
+            // CA-AUDIT-1 (#3484) — campos enriched para análisis cross-provider.
+            // sameProvider/sameModel ya calculados arriba; sherlockModel/transport
+            // del resolved. El audit-log persiste estos 5 campos al JSONL para
+            // que las consultas de adversariality reducida sean trazables.
+            sameProvider,
+            sameModel,
+            sherlockModel: resolved.model,
+            transport: resolved.transport,
         },
     });
 

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -8918,19 +8918,55 @@ INSTRUCCIÓN: Integrá los complementos del usuario en tu respuesta. Generá UNA
         }
       }
 
-      // --- SHERLOCK VERIFIER (#3343) ---
-      // Verificación adversarial pre-`sendTelegram`. Corre con un provider
-      // DISTINTO al del Commander (excludedProvider) y refuta el análisis con
-      // evidencia del estado actual. Si encuentra inconsistencias, dispara
-      // 1 reelaboración (cap hardcoded). Si timeout/error/sin-provider, agrega
-      // disclaimer F-6. Bypass total si `sherlock_enabled=false`.
+      // --- SHERLOCK VERIFIER (#3343, modificado por #3484) ---
+      // Verificación adversarial pre-`sendTelegram`. Corre con el provider de
+      // mejor calidad disponible (chain `telegram-sherlock`, Anthropic Haiku
+      // primero) y refuta el análisis con evidencia del estado actual. Si
+      // encuentra inconsistencias, dispara 1 reelaboración (cap hardcoded).
+      // Si timeout/error/sin-provider, agrega disclaimer F-6. Bypass total si
+      // `sherlock_enabled=false`.
+      //
+      // #3484: Sherlock ya NO se restringe a un provider distinto al del
+      // Commander — la decisión arquitectónica documentada en
+      // docs/pipeline/multi-provider.md acepta el riesgo de adversariality
+      // reducida a cambio de tener Sherlock funcionando consistentemente.
+      // El audit log registra `same_provider`/`same_model` para monitoreo.
+      //
+      // CA-UX-1 (#3484): mientras Sherlock corre, refrescamos el indicador
+      // "escribiendo..." de Telegram cada 4s. Sin este loop, el usuario ve
+      // el indicador fadear a los ~5s y siente que el bot se colgó (peor UX
+      // que el problema que estamos resolviendo).
+      //
+      // CA-UX-2 (#3484): un soft-timeout de 120s envuelve TODO el bloque
+      // (Sherlock + posible reelaboración + 2da Sherlock). Si dispara antes
+      // de tener verdict, mandamos un mensaje honesto al usuario en lugar
+      // de bloquear el chat indefinidamente.
       //
       // turnId se genera acá (no dentro del verifier) para que los turnos
       // bypaseados también queden correlacionables vía `commander_response`.
       const turnId = crypto.randomBytes(8).toString('hex');
       let sherlockInvoked = false;
       let sherlockDisclaimerType = null;
-      try {
+      let sherlockSoftTimedOut = false;
+
+      // CA-UX-1: typing refresh loop. Se arranca antes y se limpia en finally.
+      let typingTimer = null;
+      const startTypingLoop = () => {
+        try { sendChatActionTyping(); } catch {}
+        typingTimer = setInterval(() => {
+          try { sendChatActionTyping(); } catch {}
+        }, 4000);
+      };
+      const stopTypingLoop = () => {
+        if (typingTimer) { try { clearInterval(typingTimer); } catch {} typingTimer = null; }
+      };
+
+      // CA-UX-2: soft-timeout 120s. Promise.race contra el bloque completo de
+      // verificación. Si gana el timeout, marcamos sherlockSoftTimedOut y
+      // forzamos disclaimer F-6 + mensaje específico al usuario.
+      const SHERLOCK_SOFT_TIMEOUT_MS = 120_000;
+
+      const sherlockBlock = (async () => {
         // Snapshot mínimo del estado del sistema. No incluimos paths sensibles
         // — sólo contadores que el Commander pudo haber observado para que
         // Sherlock cruce el claim "hay N issues pendientes" vs realidad.
@@ -8951,23 +8987,29 @@ INSTRUCCIÓN: Integrá los complementos del usuario en tu respuesta. Generá UNA
         // El provider del Commander hoy es siempre `anthropic` (ejecutarClaude
         // hace spawn de claude CLI). Cuando #3258 introduzca cross-provider
         // fallback al Commander, este valor vendrá del dispatcher.
+        // commanderModel queda null hasta que ejecutarClaude exponga el
+        // modelo efectivo — por ahora el audit log lo registra como null y
+        // same_model siempre es false (degradado consciente, CA-AUDIT-1).
         const commanderProvider = 'anthropic';
+        const commanderModel = null;
 
         const verdict = await sherlockVerifier.verify({
           analysis: respuesta || '',
           originalRequest: mensajeConsolidado,
           systemState: systemStateSnapshot,
           lastHourLogs: '', // por ahora vacío — extracción de logs queda para iteración futura
-          excludedProvider: commanderProvider,
+          commanderProvider,
+          commanderModel,
           pipelineDir: PIPELINE,
           configLoader: loadConfig,
           log,
+          cwd: ROOT,
         });
         sherlockInvoked = verdict.verdict !== 'skipped';
 
         if (verdict.verdict === 'rechazado' && verdict.inconsistencies.length >= 1) {
           // CA-F-3 — reelaborar UNA vez (cap hardcoded en verifier).
-          log('commander', `🔍 Sherlock rechazó respuesta (provider=${verdict.sherlockProvider}, inconsistencies=${verdict.inconsistencies.length}). Reelaborando...`);
+          log('commander', `🔍 Sherlock rechazó respuesta (provider=${verdict.sherlockProvider}, transport=${verdict.transport}, same_provider=${verdict.sameProvider}, inconsistencies=${verdict.inconsistencies.length}). Reelaborando...`);
           const inconsistenciesBlock = verdict.inconsistencies
             .map((it, i) => `${i + 1}. CLAIM: ${it.claim}\n   CONTRADICCIÓN: ${it.contradiction}`)
             .join('\n\n');
@@ -8985,16 +9027,18 @@ INSTRUCCIÓN: Reelaborá tu respuesta tomando en cuenta las contradicciones dete
             const reelaborada = await ejecutarClaude(reelaboratePrompt, 'reelaboración Sherlock');
             if (typeof reelaborada === 'string' && reelaborada.trim()) {
               respuesta = reelaborada;
-              // 2da pasada de verificación con el mismo excludedProvider.
+              // 2da pasada de verificación con el mismo commanderProvider.
               const verdict2 = await sherlockVerifier.verify({
                 analysis: respuesta || '',
                 originalRequest: mensajeConsolidado,
                 systemState: systemStateSnapshot,
                 lastHourLogs: '',
-                excludedProvider: commanderProvider,
+                commanderProvider,
+                commanderModel,
                 pipelineDir: PIPELINE,
                 configLoader: loadConfig,
                 log,
+                cwd: ROOT,
               });
               if (verdict2.verdict === 'rechazado' && verdict2.inconsistencies.length >= 1) {
                 // CA-F-5 — disclaimer "rechazado persistente".
@@ -9010,17 +9054,46 @@ INSTRUCCIÓN: Reelaborá tu respuesta tomando en cuenta las contradicciones dete
             sherlockDisclaimerType = sherlockVerifier.DISCLAIMER_TYPES.TIMEOUT_OR_NO_PROVIDER;
           }
         } else if (verdict.verdict === 'aborted') {
-          // CA-F-6 — timeout/schema-fail/sin-provider-distinto.
+          // CA-F-6 — timeout/schema-fail/sin-provider.
           sherlockDisclaimerType = sherlockVerifier.DISCLAIMER_TYPES.TIMEOUT_OR_NO_PROVIDER;
           log('commander', `🔍 Sherlock aborted (${verdict.errorCode}: ${verdict.reason}) — disclaimer F-6 aplicado`);
         } else if (verdict.verdict === 'ok') {
           // CA-F-7 — silencio total cuando todo concuerda.
-          log('commander', `🔍 Sherlock OK (provider=${verdict.sherlockProvider}, ${verdict.durationMs}ms)`);
+          log('commander', `🔍 Sherlock OK (provider=${verdict.sherlockProvider}, transport=${verdict.transport}, same_provider=${verdict.sameProvider}, ${verdict.durationMs}ms)`);
         }
+      })();
+
+      try {
+        startTypingLoop();
+        await Promise.race([
+          sherlockBlock,
+          new Promise((resolve) => setTimeout(() => {
+            sherlockSoftTimedOut = true;
+            resolve();
+          }, SHERLOCK_SOFT_TIMEOUT_MS)),
+        ]);
       } catch (sherlockErr) {
         // Defensa: un fallo de Sherlock NUNCA debe tirar el turno. Degradamos
         // a respuesta original con disclaimer F-6 y seguimos.
         log('commander', `⚠️ Sherlock excepción no manejada: ${sherlockErr.message} — degradando a F-6`);
+        sherlockDisclaimerType = sherlockVerifier.DISCLAIMER_TYPES.TIMEOUT_OR_NO_PROVIDER;
+      } finally {
+        stopTypingLoop();
+      }
+
+      if (sherlockSoftTimedOut) {
+        // CA-UX-2 — soft-timeout del turn handler. Avisamos al usuario sin
+        // jerga técnica y degradamos a F-6. La respuesta original (sin
+        // reelaboración garantizada) se envía igual debajo. El audit
+        // post-turn registra el outcome para telemetría.
+        log('commander', `⏱️ Sherlock soft-timeout ${SHERLOCK_SOFT_TIMEOUT_MS}ms disparó — liberando chat con mensaje UX-2`);
+        try {
+          sendTelegramPlain(
+            'Esta respuesta me está tomando más tiempo de lo normal. ' +
+            'Te muestro la versión sin verificar — si querés, podemos ' +
+            'revisarla juntos cuando me confirmes.'
+          );
+        } catch { /* best-effort */ }
         sherlockDisclaimerType = sherlockVerifier.DISCLAIMER_TYPES.TIMEOUT_OR_NO_PROVIDER;
       }
 
@@ -9179,6 +9252,33 @@ function sendTelegramWithMarkup(text, replyMarkup, opts) {
     req.end();
     log('telegram', `Enviado directo (${msg.length} chars)`);
   }
+}
+
+// #3484 CA-UX-1 — sendChatActionTyping: refresca el indicador "escribiendo..."
+// de Telegram durante operaciones largas (Sherlock + Claude). El indicador
+// nativo dura ~5s, por eso el caller debe llamar esto cada 4s en loop.
+// Best-effort, fire-and-forget — no bloquea el turn handler. POST directo
+// (no encolado vía svc-telegram) porque el servicio no maneja sendChatAction
+// y el indicador pierde valor si se atrasa por la cola.
+function sendChatActionTyping() {
+  const token = getTelegramToken();
+  const chatId = getTelegramChatId();
+  if (!token || !chatId) return;
+  try {
+    const https = require('https');
+    const data = JSON.stringify({ chat_id: chatId, action: 'typing' });
+    const req = https.request({
+      hostname: 'api.telegram.org',
+      path: `/bot${token}/sendChatAction`,
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(data) },
+      timeout: 3000,
+    });
+    req.on('error', () => { /* best-effort, sin log para no spammear */ });
+    req.on('timeout', () => { try { req.destroy(); } catch {} });
+    req.write(data);
+    req.end();
+  } catch { /* swallow — no debe interrumpir el flow */ }
 }
 
 function _loadTgSecrets() {

--- a/docs/pipeline/multi-provider.md
+++ b/docs/pipeline/multi-provider.md
@@ -18,6 +18,8 @@
 8. [Hardening de free providers](#8-hardening-de-free-providers-3260) — secrets, alerts, telemetry.
 9. [Modo degradado del Commander (sin LLM)](#9-modo-degradado-del-commander-sin-llm) — `/quota`, cooldown destructivo, gate texto libre.
 10. [Parser robusto de errores in-flight del Commander (#3434)](#10-parser-robusto-de-errores-in-flight-del-commander-3434) — receta para agregar provider, threat model, anti-patterns.
+11. [Fallback in-flight del Commander (#3275)](#11-fallback-in-flight-del-commander-3275) — gate UX, dedupe, tests.
+12. [Sherlock verifier — timeout y providers (#3484)](#12-sherlock-verifier--timeout-y-providers-3484) — opción B spawn-CLI, timeout cap, soft-timeout, audit enriquecido.
 
 > **Convención:** todos los paths `.pipeline/...` son relativos a la raíz del repo (`C:\Workspaces\Intrale\platform\`). Todos los comandos asumen Node.js 21 disponible en PATH.
 
@@ -1643,6 +1645,104 @@ Eventos en el audit log del día permiten calcular (futuro endpoint dashboard `/
 - `.pipeline/lib/__tests__/commander-inflight-fallback.test.js` — 28 tests cubriendo CA-1..CA-9, formato UX-G1, file-lock, late-response.
 - `.pipeline/lib/__tests__/commander-multi-provider.test.js` — sin regresión.
 - `.pipeline/lib/__tests__/audit-log.test.js` — sin regresión (lock es opt-in vía param `lockMaxMs:0` en tests legacy).
+
+---
+
+## 12. Sherlock verifier — timeout y providers (#3484)
+
+> **Issue de origen:** [#3484](https://github.com/intrale/platform/issues/3484) — quitar timeout local y eliminar requisito cross-provider.
+> **Predecesor:** [#3343](https://github.com/intrale/platform/issues/3343) Sherlock base + [#3342](https://github.com/intrale/platform/issues/3342) HTTP completion-client.
+
+### 12.1 Decisión arquitectónica (CA-DOC-3)
+
+Sherlock acepta dos transportes para invocar providers:
+
+- **HTTP completion-client** (`lib/multi-provider/completion-client.js`) — para providers OpenAI-compat: `cerebras`, `gemini-google`, `nvidia-nim`.
+- **Spawn CLI** (`lib/agent-launcher/providers/anthropic.js::buildSpawn`) — para Anthropic. **Opción B** del issue #3484, elegida por: (a) reusa la infra existente y bien testeada, (b) evita refactor multi-schema del cliente HTTP para soportar la Anthropic Messages API (que no es OpenAI-compat), (c) recommendation explícita de PO y guru en la fase `criterios`.
+
+Codex (`openai-codex`) sigue siendo stub ([#3076](https://github.com/intrale/platform/issues/3076) H3 pendiente) — Sherlock lo salta con gracia cuando aparece en la chain.
+
+### 12.2 Cambios concretos respecto al estado pre-#3484
+
+| Comportamiento | Pre-#3484 | Post-#3484 |
+|---|---|---|
+| Filtro de providers | Solo HTTP-compatible (`cerebras`, `gemini-google`, `nvidia-nim`) | Cualquier provider con handler implementado (HTTP o spawn) |
+| Exclusión cross-provider | Forzaba provider != Commander | Removida — permite same-provider (riesgo aceptado) |
+| Timeout local | Default 10s, clamp absoluto 30s | Removido — delegado a `completion-client` (90s default, 180s cap) |
+| Phrasing F-5/F-6 | Genérico, jerga técnica | Empático, primera persona, invita feedback (CA-UX-3, CA-UX-4) |
+| Audit log | `commanderProvider`, `sherlockProvider` | + `sameProvider`, `sameModel`, `commanderModel`, `transport` (CA-AUDIT-1) |
+
+### 12.3 Timeout y cap defensivo
+
+El presupuesto temporal vive en **dos lugares**:
+
+1. **`lib/multi-provider/completion-client.js`**:
+   - `DEFAULT_TIMEOUT_MS = 90_000` (90 s) — usado si el caller no pasa override.
+   - `ABSOLUTE_MAX_TIMEOUT_MS = 180_000` (3 min) — cap defensivo, **no removible** por el caller. Si alguien pasa `timeoutMs: 999999`, el cliente lo clampea silenciosamente.
+2. **`pulpo.js` turn handler** (`procesarTextoLibre`):
+   - `SHERLOCK_SOFT_TIMEOUT_MS = 120_000` (2 min) — soft-timeout que envuelve `verify()` + reelaboración + 2da `verify()`. Si dispara, el chat recibe el mensaje **CA-UX-2** sin jerga técnica y degradamos a disclaimer F-6.
+
+`config.yaml` mantiene `sherlock_timeout_ms` como **NO-OP** (back-compat con configs viejas). El loader lo ignora silenciosamente sin warn-spam. Removerlo en una próxima limpieza junto con los callers que lo lean.
+
+### 12.4 Adversariality reducida (riesgo aceptado)
+
+Pre-#3484, Sherlock garantizaba que su provider fuera distinto al del Commander para que dos modelos con biases distintos pudieran detectar contradicciones. Eso reducía la chance de un blind-spot compartido, pero en la práctica causaba fallback en cascada → timeout → F-6 silencioso constante.
+
+Leo aprobó (voz 2026-05-22) **aceptar el riesgo de adversariality reducida** a cambio de tener Sherlock funcionando consistentemente con razonamiento de buena calidad (Anthropic Haiku 4.5). Para no perder visibilidad del riesgo, el audit log emite:
+
+```json
+{
+  "event": "sherlock_verification",
+  "commander_provider": "anthropic",
+  "sherlock_provider": "anthropic",
+  "same_provider": true,
+  "same_model": false,
+  "commander_model": "claude-opus-4-7",
+  "sherlock_model": "claude-haiku-4-5",
+  "transport": "spawn",
+  "duration_ms": 47000
+}
+```
+
+**Métrica a monitorear** (alert futuro, no implementado en este issue): si `same_provider:true` supera el 80% del último día, alertar al operador — significa que la chain de fallback se está agotando antes de cambiar de provider. Issue de seguimiento abierto para dashboard widget.
+
+### 12.5 UX en Telegram (CA-UX-1, CA-UX-2)
+
+- **CA-UX-1 — typing refresh loop**: `pulpo.js::sendChatActionTyping()` se invoca cada 4 s mientras Sherlock corre. Sin este loop el indicador "escribiendo..." de Telegram fade-out a los ~5 s y el usuario siente que el bot se colgó. POST directo a `api.telegram.org/sendChatAction` (sin pasar por `svc-telegram` porque el servicio no maneja la acción y el indicador pierde valor si se atrasa por la cola).
+- **CA-UX-2 — soft-timeout 120 s**: si Sherlock + reelaboración + 2da pasada toma más de 2 min, mandamos `"Esta respuesta me está tomando más tiempo de lo normal. Te muestro la versión sin verificar — si querés, podemos revisarla juntos cuando me confirmes."` en lugar de bloquear el chat indefinidamente. La respuesta original se envía con disclaimer F-6.
+- **CA-UX-3 / CA-UX-4 — phrasing**: ver `lib/sherlock-verifier.js` constantes `DISCLAIMER_F5_PERSISTENT_INCONSISTENCY` y `DISCLAIMER_F6_VERIFICATION_FAILED`.
+
+### 12.6 Verificación operativa post-deploy
+
+Después de un `/restart` con este cambio activo:
+
+```bash
+# El audit log debe mostrar Anthropic como sherlock_provider primario.
+grep '"event":"sherlock_verification"' .pipeline/logs/commander-dispatch-*.jsonl | tail -10
+
+# Si todo el audit log tiene sherlock_provider != anthropic, la chain de
+# resolución no está agarrando el primer entry — bug. Espera-do (chain
+# anthropic-first aprobada en PR #3483):
+#   sherlock_provider: "anthropic"
+#   transport: "spawn"
+#   same_provider: true  ← porque Commander también usa anthropic hoy
+```
+
+Si en producción `transport: "spawn"` no aparece nunca, posibles causas:
+1. Anthropic está gateado por cuota → Sherlock cae a gemini-google (correcto, ver chain).
+2. El launcher `claude` no se detecta en runtime → revisar `agent-launcher/providers/anthropic.js::detectLauncher`.
+3. La chain `telegram-sherlock` en `agent-models.json` cambió → confirmar PR #3483 mergeado.
+
+### 12.7 Tests
+
+- `.pipeline/lib/__tests__/sherlock-verifier.test.js` — 39 tests cubriendo HTTP path, spawn path, audit enriquecido, back-compat, timeout cap, phrasing UX-3/UX-4.
+- `.pipeline/lib/__tests__/completion-client.test.js` — 37 tests + nuevos casos del cap absoluto.
+
+Correr:
+```bash
+node --test .pipeline/lib/__tests__/sherlock-verifier.test.js
+node --test .pipeline/lib/__tests__/completion-client.test.js
+```
 
 ---
 


### PR DESCRIPTION
## Resumen

Cierra el único gap (**CA-AUDIT-1**) que rebotó PO + Review + UX **4 veces** en el issue #3484 (Sherlock — quitar timeout y eliminar requisito cross-provider).

El verifier ya calculaba los 5 campos enriched dentro de `verify()` y los devolvía en el result object, pero NO los propagaba al audit JSONL. Los gates rechazaban porque la doc (`docs/pipeline/multi-provider.md:1602, 1622-1634`) los marca como obligatorios para análisis cross-provider posterior.

## Cambios

1. **`.pipeline/lib/sherlock-verifier.js`** — `emitAuditEvent` acepta y propaga los 5 campos al `commanderMP.auditCommanderRequest`. Los 6 callsites dentro de `verify()` pasan los valores cuando ya están resueltos (`sameProvider`, `sameModel`, `sherlockModel`, `transport`) y `null` cuando el resolved no existe aún (`sherlock_skipped_disabled`, `no_provider`).

2. **`.pipeline/lib/commander/multi-provider.js`** — `auditCommanderRequest` acepta `sameProvider`, `sameModel`, `commanderModel`, `sherlockModel`, `transport` como parámetros opcionales y los persiste al shape de la entry JSONL como `same_provider`, `same_model`, `commander_model`, `sherlock_model`, `transport`. **Back-compat**: si el caller no los pasa, quedan en `null` y no rompen el shape canónico.

3. **Tests nuevos que LEEN el JSONL escrito** y assertean persistencia de los 5 campos (no solo que se pasen como argumento):
   - `sherlock-verifier.test.js`: 5 tests cubriendo `verdict ok same/diff`, `transport=spawn`, `schema_violation` y `aborted_residency`.
   - `commander-multi-provider.test.js`: 2 tests (con y sin enriched).

## Verificación

- Tests: **44/44** sherlock-verifier + **30/30** commander-multi-provider.
- Back-compat preservada (callers viejos siguen funcionando).

## Test plan

- [ ] CI verde
- [ ] Audit JSONL en producción contiene los 5 campos enriched después del próximo run de Sherlock
- [ ] PO + Review + UX aprueban (gap único de los 4 rebotes anteriores)

Closes #3484