### PR TITLE
feat(pipeline): activar deliverable_notifications por default

### DIFF
--- a/.pipeline/config.yaml
+++ b/.pipeline/config.yaml
@@ -575,9 +575,9 @@ sherlock_max_reelaboraciones: 1
 #   2. Activar con `enabled: true` y observar audit JSONL durante 1-2 días.
 #   3. Si aparecen ruidos no esperados, `kill_switch: true` corta sin reiniciar.
 deliverable_notifications:
-  enabled: false
+  enabled: true
   kill_switch: false
-  skills: [guru, po, ux, planner]
+  skills: [guru, po, ux, planner, architect]
   truncate_chars: 1500
   attachment_root: ".pipeline/assets/mockups"
   dedup_window_hours: 24

--- a/.pipeline/config.yaml
+++ b/.pipeline/config.yaml
@@ -577,7 +577,7 @@ sherlock_max_reelaboraciones: 1
 deliverable_notifications:
   enabled: true
   kill_switch: false
-  skills: [guru, po, ux, planner, architect]
+  skills: [guru, po, ux, planner]
   truncate_chars: 1500
   attachment_root: ".pipeline/assets/mockups"
   dedup_window_hours: 24


### PR DESCRIPTION
## Resumen

Activa por default las notificaciones de entregables parciales del pipeline (épico #3414/#3415/#3416/#3417 mergeado el 20/05 con `enabled: false`).

## Diff

\`\`\`diff
 deliverable_notifications:
-  enabled: false
+  enabled: true
   kill_switch: false
   skills: [guru, po, ux, planner]
\`\`\`

## Por qué

Paso 2 del rollout CA-FN-6: arrancar a notificar. Si aparecen ruidos, `kill_switch: true` corta sin reiniciar (hot-reload cada tick).

## Architect (separado)

El skill `architect` lo sumará el dev del #3507 cuando construya el rol, como parte del entregable de ese issue. Así queda todo en el mismo PR del Arquitecto.

Closes parcialmente paso 2 del rollout del épico #3414.