### PR TITLE
[guru] Migrar wave-resolver.js a consumir lib/waves.js como fuente canónica

### DIFF
--- a/.pipeline/lib/__tests__/wave-resolver.test.js
+++ b/.pipeline/lib/__tests__/wave-resolver.test.js
@@ -1,10 +1,15 @@
 // =============================================================================
-// wave-resolver.test.js — Tests del resolver de ola activa (#3262).
+// wave-resolver.test.js — Tests del resolver de ola activa.
 //
-// Cubre la cascada de fuentes:
-//   1. active-wave.json (preferido)
-//   2. .partial-pause.json (fallback)
+// Cubre la cascada de fuentes post-#3502:
+//   1. waves.json (vía `lib/waves.js`, source-of-truth canónica)
+//   2. .partial-pause.json (legacy, mientras waves.json no esté poblado)
 //   3. filesystem scan (último recurso, CA-15 fallback grácil)
+//
+// Adicionalmente cubre el normalizador defensivo (CA-4) que tolera AMBOS
+// shapes de issues que aparecen en el wild:
+//   - { number: N }  ← shape canónico que `lib/waves.js` declara.
+//   - N              ← shape "flat" del waves.json real en disco.
 //
 // Ejecutar:  node --test .pipeline/lib/__tests__/wave-resolver.test.js
 // =============================================================================
@@ -17,7 +22,8 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 
-const { resolveActiveWave } = require('../wave-resolver');
+const { resolveActiveWave, _internal } = require('../wave-resolver');
+const waves = require('../waves');
 
 function mkTmpPipeline() {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wave-resolver-'));
@@ -36,29 +42,147 @@ function rmrf(dir) {
     try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
 }
 
-test('resolveActiveWave: prioriza active-wave.json sobre partial-pause', () => {
+function writeWavesJson(dir, active_wave, extra = {}) {
+    const state = {
+        version: '1.0',
+        meta: {
+            created_at: '2026-05-01T00:00:00Z',
+            updated_at: '2026-05-01T00:00:00Z',
+            updated_by: 'test',
+            source: 'manual',
+            note: 'fixture',
+        },
+        active_wave,
+        planned_waves: [],
+        archived_waves: [],
+        dependencies: [],
+        ...extra,
+    };
+    fs.writeFileSync(path.join(dir, 'waves.json'), JSON.stringify(state, null, 2));
+}
+
+// Invalida la cache de waves.js entre tests para evitar que un test arrastre
+// estado al siguiente — el resolver hace invalidate post-call, pero validamos
+// también acá por defensa en profundidad.
+function resetCache() {
+    waves.invalidateCache();
+}
+
+// -----------------------------------------------------------------------------
+// CA-1 — waves.json es source-of-truth primario
+// -----------------------------------------------------------------------------
+
+test('resolveActiveWave: usa waves.json como fuente primaria (CA-1)', () => {
     const dir = mkTmpPipeline();
     try {
-        fs.writeFileSync(path.join(dir, 'active-wave.json'), JSON.stringify({
-            label: 'N+5',
-            issues: [3253, 3257, 3262],
-            opened_at: '2026-05-16T23:48:00Z',
-        }));
+        writeWavesJson(dir, {
+            number: 5,
+            name: 'N+5',
+            started_at: '2026-05-16T23:48:00Z',
+            issues: [
+                { number: 3253 },
+                { number: 3257 },
+                { number: 3262 },
+            ],
+        });
+        // Aunque exista partial-pause con datos distintos, waves.json debe ganar.
         fs.writeFileSync(path.join(dir, '.partial-pause.json'), JSON.stringify({
-            allowed_issues: [9999], // Si gana, falla el assert.
+            allowed_issues: [9999],
             created_at: '2026-05-16T20:00:00Z',
         }));
         const r = resolveActiveWave({ pipelineRoot: dir });
-        assert.equal(r.source, 'active-wave.json');
+        assert.equal(r.source, 'waves.json');
         assert.equal(r.label, 'N+5');
         assert.deepEqual(r.issues, [3253, 3257, 3262]);
+        assert.equal(r.openedAt, '2026-05-16T23:48:00Z');
         assert.equal(r.resolved, true);
-    } finally { rmrf(dir); }
+    } finally { resetCache(); rmrf(dir); }
 });
 
-test('resolveActiveWave: cae a partial-pause cuando no hay active-wave.json', () => {
+test('resolveActiveWave: label cae a "Ola N" si name está ausente', () => {
     const dir = mkTmpPipeline();
     try {
+        writeWavesJson(dir, {
+            number: 7,
+            started_at: '2026-05-20T00:00:00Z',
+            issues: [{ number: 3500 }],
+        });
+        const r = resolveActiveWave({ pipelineRoot: dir });
+        assert.equal(r.source, 'waves.json');
+        assert.equal(r.label, 'Ola 7');
+        assert.deepEqual(r.issues, [3500]);
+    } finally { resetCache(); rmrf(dir); }
+});
+
+// -----------------------------------------------------------------------------
+// CA-4 — Normalizador defensivo (schema drift)
+// -----------------------------------------------------------------------------
+
+test('resolveActiveWave: tolera issues como int planos (CA-4 schema drift)', () => {
+    // Reproduce el shape REAL de .pipeline/waves.json hoy en disco (issues como
+    // enteros planos, key `id` en vez de `number`). Sin el normalizador
+    // defensivo el resolver degradaría silenciosamente al fallback con NaN.
+    const dir = mkTmpPipeline();
+    try {
+        writeWavesJson(dir, {
+            id: 'N+10',
+            name: 'N+10',
+            started_at: '2026-05-22T00:00:00Z',
+            issues: [3501, 3502, 3503, 3504],
+        });
+        const r = resolveActiveWave({ pipelineRoot: dir });
+        assert.equal(r.source, 'waves.json');
+        assert.deepEqual(r.issues, [3501, 3502, 3503, 3504]);
+        assert.equal(r.resolved, true);
+    } finally { resetCache(); rmrf(dir); }
+});
+
+test('resolveActiveWave: tolera mix de shapes (objetos y enteros) y strings con #', () => {
+    const dir = mkTmpPipeline();
+    try {
+        writeWavesJson(dir, {
+            number: 8,
+            name: 'Mix',
+            issues: [
+                { number: 3100 },
+                3200,
+                '3300',
+                '#3400',
+            ],
+        });
+        const r = resolveActiveWave({ pipelineRoot: dir });
+        assert.equal(r.source, 'waves.json');
+        assert.deepEqual(r.issues, [3100, 3200, 3300, 3400]);
+    } finally { resetCache(); rmrf(dir); }
+});
+
+test('normalizeIssueNumber: cubre los shapes esperados y rechaza inválidos', () => {
+    const { normalizeIssueNumber } = _internal;
+    // Válidos
+    assert.equal(normalizeIssueNumber(3501), 3501);
+    assert.equal(normalizeIssueNumber('3501'), 3501);
+    assert.equal(normalizeIssueNumber(' #3501 '), 3501);
+    assert.equal(normalizeIssueNumber({ number: 3501 }), 3501);
+    assert.equal(normalizeIssueNumber({ number: '3501' }), 3501);
+    // Inválidos → null
+    assert.equal(normalizeIssueNumber(null), null);
+    assert.equal(normalizeIssueNumber(undefined), null);
+    assert.equal(normalizeIssueNumber(''), null);
+    assert.equal(normalizeIssueNumber('abc'), null);
+    assert.equal(normalizeIssueNumber(-1), null);
+    assert.equal(normalizeIssueNumber(0), null);
+    assert.equal(normalizeIssueNumber({ number: 'abc' }), null);
+    assert.equal(normalizeIssueNumber({}), null);
+});
+
+// -----------------------------------------------------------------------------
+// CA-2 — Fallback a partial-pause cuando waves.json está vacío
+// -----------------------------------------------------------------------------
+
+test('resolveActiveWave: cae a partial-pause cuando waves.json tiene active_wave=null (CA-2)', () => {
+    const dir = mkTmpPipeline();
+    try {
+        writeWavesJson(dir, null);
         fs.writeFileSync(path.join(dir, '.partial-pause.json'), JSON.stringify({
             allowed_issues: [3253, 3257, '3262', '#3260'],
             created_at: '2026-05-16T20:00:00Z',
@@ -71,13 +195,49 @@ test('resolveActiveWave: cae a partial-pause cuando no hay active-wave.json', ()
         assert.deepEqual(r.issues, [3253, 3257, 3260, 3262]);
         assert.equal(r.resolved, true);
         assert.equal(r.openedAt, '2026-05-16T20:00:00Z');
-    } finally { rmrf(dir); }
+    } finally { resetCache(); rmrf(dir); }
 });
 
-test('resolveActiveWave: fallback FS cuando no hay ningún marker', () => {
+test('resolveActiveWave: cae a partial-pause cuando waves.json no existe', () => {
     const dir = mkTmpPipeline();
     try {
-        // Sin marker files. Creamos archivos de pipeline activos.
+        // Sin waves.json en disco.
+        fs.writeFileSync(path.join(dir, '.partial-pause.json'), JSON.stringify({
+            allowed_issues: [4001, 4002],
+            created_at: '2026-05-26T00:00:00Z',
+        }));
+        const r = resolveActiveWave({ pipelineRoot: dir });
+        assert.equal(r.source, 'partial-pause.json');
+        assert.deepEqual(r.issues, [4001, 4002]);
+    } finally { resetCache(); rmrf(dir); }
+});
+
+test('resolveActiveWave: cae a partial-pause cuando waves.json tiene issues:[]', () => {
+    const dir = mkTmpPipeline();
+    try {
+        writeWavesJson(dir, {
+            number: 5,
+            name: 'Vacía',
+            issues: [],
+        });
+        fs.writeFileSync(path.join(dir, '.partial-pause.json'), JSON.stringify({
+            allowed_issues: [5001],
+            created_at: 'x',
+        }));
+        const r = resolveActiveWave({ pipelineRoot: dir });
+        assert.equal(r.source, 'partial-pause.json');
+        assert.deepEqual(r.issues, [5001]);
+    } finally { resetCache(); rmrf(dir); }
+});
+
+// -----------------------------------------------------------------------------
+// CA-3 — Fallback FS cuando no hay waves.json activa ni partial-pause
+// -----------------------------------------------------------------------------
+
+test('resolveActiveWave: fallback FS cuando no hay ningún marker (CA-3)', () => {
+    const dir = mkTmpPipeline();
+    try {
+        // Sin waves.json, sin partial-pause. Creamos archivos de pipeline activos.
         fs.writeFileSync(path.join(dir, 'desarrollo/dev/trabajando/3262.pipeline-dev'), '');
         fs.writeFileSync(path.join(dir, 'desarrollo/dev/pendiente/3253.android-dev'), '');
         fs.writeFileSync(path.join(dir, 'definicion/analisis/listo/3260.guru'), '');
@@ -86,7 +246,7 @@ test('resolveActiveWave: fallback FS cuando no hay ningún marker', () => {
         assert.equal(r.label, 'Ola actual (sin label)');
         assert.deepEqual(r.issues, [3253, 3260, 3262]);
         assert.equal(r.resolved, true);
-    } finally { rmrf(dir); }
+    } finally { resetCache(); rmrf(dir); }
 });
 
 test('resolveActiveWave: degrada a issues:[] cuando no hay nada', () => {
@@ -96,13 +256,17 @@ test('resolveActiveWave: degrada a issues:[] cuando no hay nada', () => {
         assert.equal(r.source, 'fs-fallback');
         assert.deepEqual(r.issues, []);
         assert.equal(r.resolved, false);
-    } finally { rmrf(dir); }
+    } finally { resetCache(); rmrf(dir); }
 });
 
-test('resolveActiveWave: ignora active-wave.json mal formado y sigue cascada', () => {
+// -----------------------------------------------------------------------------
+// Robustez frente a entrada corrupta
+// -----------------------------------------------------------------------------
+
+test('resolveActiveWave: ignora waves.json mal formado y sigue cascada', () => {
     const dir = mkTmpPipeline();
     try {
-        fs.writeFileSync(path.join(dir, 'active-wave.json'), '{not-json,');
+        fs.writeFileSync(path.join(dir, 'waves.json'), '{not-json,');
         fs.writeFileSync(path.join(dir, '.partial-pause.json'), JSON.stringify({
             allowed_issues: [9999],
             created_at: 'x',
@@ -110,18 +274,7 @@ test('resolveActiveWave: ignora active-wave.json mal formado y sigue cascada', (
         const r = resolveActiveWave({ pipelineRoot: dir });
         assert.equal(r.source, 'partial-pause.json');
         assert.deepEqual(r.issues, [9999]);
-    } finally { rmrf(dir); }
-});
-
-test('resolveActiveWave: active-wave.json sin label o sin issues se descarta', () => {
-    const dir = mkTmpPipeline();
-    try {
-        // Sin label → inválido.
-        fs.writeFileSync(path.join(dir, 'active-wave.json'), JSON.stringify({ issues: [1, 2] }));
-        // Y sin partial-pause → cae a FS fallback.
-        const r = resolveActiveWave({ pipelineRoot: dir });
-        assert.equal(r.source, 'fs-fallback');
-    } finally { rmrf(dir); }
+    } finally { resetCache(); rmrf(dir); }
 });
 
 test('resolveActiveWave: tolera ausencia de directorios de pipeline', () => {
@@ -130,11 +283,50 @@ test('resolveActiveWave: tolera ausencia de directorios de pipeline', () => {
         const r = resolveActiveWave({ pipelineRoot: dir });
         assert.equal(r.source, 'fs-fallback');
         assert.deepEqual(r.issues, []);
-    } finally { rmrf(dir); }
+    } finally { resetCache(); rmrf(dir); }
 });
 
 test('resolveActiveWave: sin pipelineRoot devuelve resultado seguro', () => {
     const r = resolveActiveWave({});
     assert.equal(r.resolved, false);
     assert.deepEqual(r.issues, []);
+    assert.equal(r.source, 'fs-fallback');
+});
+
+// -----------------------------------------------------------------------------
+// CA-5 — `readActiveWaveFile` eliminada
+// -----------------------------------------------------------------------------
+
+test('CA-5: readActiveWaveFile fue eliminada del módulo', () => {
+    // El módulo legacy exportaba `_internal.readActiveWaveFile`. Post-#3502
+    // esa función no debe existir más.
+    assert.equal(typeof _internal.readActiveWaveFile, 'undefined');
+    // Y readFromWavesJson debe existir como su reemplazo.
+    assert.equal(typeof _internal.readFromWavesJson, 'function');
+});
+
+// -----------------------------------------------------------------------------
+// CA-6 — Shape externo preservado para backward compat
+// -----------------------------------------------------------------------------
+
+test('CA-6: shape externo { label, issues, openedAt, source, resolved } preservado', () => {
+    const dir = mkTmpPipeline();
+    try {
+        writeWavesJson(dir, {
+            number: 9,
+            name: 'N+9',
+            started_at: '2026-05-20T00:00:00Z',
+            issues: [{ number: 3500 }],
+        });
+        const r = resolveActiveWave({ pipelineRoot: dir });
+        // Estas son las 5 keys que wave-snapshot.js y wave-renderer.js consumen.
+        assert.ok('label' in r);
+        assert.ok('issues' in r);
+        assert.ok('openedAt' in r);
+        assert.ok('source' in r);
+        assert.ok('resolved' in r);
+        assert.equal(typeof r.label, 'string');
+        assert.ok(Array.isArray(r.issues));
+        assert.equal(typeof r.resolved, 'boolean');
+    } finally { resetCache(); rmrf(dir); }
 });

--- a/.pipeline/lib/commander-deterministic.js
+++ b/.pipeline/lib/commander-deterministic.js
@@ -1466,31 +1466,21 @@ function invalidateKnownIssuesCache(pipelineRoot) {
 
 /**
  * `/wave status [--audio]` — Reusa el snapshot ejecutivo de #3262 (CA-3 DRY).
- * Si `waves.json` tiene `active_wave`, lo usa como source-of-truth; si no,
- * cae al resolver legacy (`.partial-pause.json`) — último bullet de CA-3.
+ *
+ * Post-#3502: el resolver delega internamente en `lib/waves.js` como
+ * source-of-truth única. Ya no necesitamos rama dual acá — la cascada
+ * (waves.json → partial-pause → fs-fallback) vive del lado del resolver.
+ * `usingLegacy` se infiere del `wave.source` para mantener la nota discreta
+ * del template `wave-status` cuando no se está leyendo de `waves.json`.
  */
 async function handleWaveStatus({ pipelineRoot, audio }) {
     const resolver = require('./wave-resolver');
     const snapshotMod = require('./wave-snapshot');
     const rendererMod = require('./wave-renderer');
     const stateMod = require('./wave-state');
-    const waves = require('./waves');
 
-    // Path 1: waves.json poblado → preferir su shape canónico.
-    let wave;
-    let usingLegacy = false;
-    const activeFromWaves = waves.getActiveWave();
-    if (activeFromWaves && Array.isArray(activeFromWaves.issues) && activeFromWaves.issues.length > 0) {
-        wave = {
-            label: activeFromWaves.name || `Ola ${activeFromWaves.number}`,
-            issues: activeFromWaves.issues.map((i) => Number(i.number)).filter(Boolean),
-            number: activeFromWaves.number,
-        };
-    } else {
-        // Path 2: fallback legacy a `.partial-pause.json` (CA-3 último bullet).
-        usingLegacy = true;
-        wave = resolver.resolveActiveWave({ pipelineRoot });
-    }
+    const wave = resolver.resolveActiveWave({ pipelineRoot });
+    const usingLegacy = wave.source !== 'waves.json';
 
     const state = stateMod.getCachedWaveState({ pipelineRoot });
 

--- a/.pipeline/lib/wave-resolver.js
+++ b/.pipeline/lib/wave-resolver.js
@@ -1,35 +1,45 @@
 // =============================================================================
-// wave-resolver.js — Resolver de "ola activa" para el snapshot ejecutivo (#3262).
+// wave-resolver.js — Resolver de "ola activa" para el snapshot ejecutivo.
 //
-// Responde la pregunta "¿qué issues integran la ola actual?" mirando, en orden
-// de prioridad:
+// Responde la pregunta "¿qué issues integran la ola actual?" delegando en la
+// source-of-truth canónica `lib/waves.js` (issue #3502) y degradando con
+// gracia si esa fuente no tiene una ola activa poblada.
 //
-//   1. `.pipeline/active-wave.json`  → fuente canónica (formato preferido).
-//      Schema: { label: "N+5", issues: [3253, 3257, ...], opened_at, source }
+// Cascada de fuentes (en orden de prioridad):
 //
-//   2. `.pipeline/.partial-pause.json`  → fuente actual de hecho. Cuando Leo
-//      arranca una ola edita la allowlist; los issues incluidos son la ola.
+//   1. `lib/waves.js` → `waves.getActiveWave()` lee `.pipeline/waves.json`
+//      con TTL cache 2s. Es la única fuente canónica desde #3489 / H1.
+//      → source: 'waves.json'.
+//
+//   2. `.pipeline/.partial-pause.json` → fuente legacy de hecho mientras
+//      `waves.json` no esté poblado. Migration path heredado del diseño
+//      original; se mantiene para compatibilidad operativa.
 //      Schema: { allowed_issues: [...], created_at, source }
+//      → source: 'partial-pause.json'.
 //
 //   3. Fallback: todos los issues con archivos activos en el pipeline.
 //      Etiqueta "Ola actual (sin label)" — degradación grácil (CA-15).
-//
-// La idea de tener `active-wave.json` como esquema separado viene de la
-// recomendación de guru en el análisis técnico del issue: hoy hay deriva
-// (allowlist, comentarios libres, milestones) y queremos un punto único de
-// verdad para "ola actual". Este módulo lo lee si existe pero NO falla si no.
+//      → source: 'fs-fallback'.
 //
 // Reglas inquebrantables:
 // - Sin red. Sin GitHub API. Solo filesystem propio del pipeline.
 // - Sin throw a callers: cualquier excepción de I/O degrada al siguiente nivel.
 // - Cero acoplamiento con dashboard.js — recibe el state como parámetro cuando
 //   necesita derivar issues activos del filesystem (camino fallback).
+// - Shape externo PRESERVADO: { label, issues, openedAt, source, resolved }.
+//   `wave-snapshot.js` y `wave-renderer.js` consumen este shape sin cambios.
+//
+// Histórico:
+//   - Pre-#3502: la cascada arrancaba con `active-wave.json` (archivo que
+//     NUNCA existió en disco real) y caía a `.partial-pause.json`. Esa función
+//     muerta (`readActiveWaveFile`) fue eliminada en #3502.
 // =============================================================================
 
 'use strict';
 
 const fs = require('fs');
 const path = require('path');
+const waves = require('./waves');
 
 // Constantes de pipeline — replicadas localmente para no acoplar con
 // dashboard.js (que carga config.yaml y arrastra deps innecesarias).
@@ -37,37 +47,100 @@ const PIPELINE_NAMES = ['definicion', 'desarrollo'];
 const ACTIVE_STATES = ['pendiente', 'trabajando', 'listo'];
 
 /**
- * Lee `active-wave.json` si existe y es válido.
+ * Normaliza un identificador de issue tolerando AMBOS shapes que aparecen en
+ * el wild (CA-4 — normalizador defensivo por schema drift de `waves.json`):
+ *
+ *   - { number: 3501 }       ← shape canónico esperado por `lib/waves.js`.
+ *   - 3501                   ← shape "flat" del `waves.json` real en disco hoy.
+ *   - "#3501" / " 3501 "     ← strings con/sin prefijo o whitespace.
+ *
+ * Devuelve int positivo o null si no es válido.
+ *
+ * @param {*} value
+ * @returns {number|null}
+ */
+function normalizeIssueNumber(value) {
+    // Pattern defensivo `i.number ?? i` — flagged por guru en el análisis.
+    const raw = (value && typeof value === 'object') ? value.number : value;
+    if (raw === null || raw === undefined) return null;
+    const n = Number(String(raw).trim().replace(/^#/, ''));
+    return Number.isInteger(n) && n > 0 ? n : null;
+}
+
+/**
+ * Calcula el `pipelineDir` que `lib/waves.js` resolvería internamente.
+ *
+ * `waves.js` usa `PIPELINE_DIR_OVERRIDE` (si está definida) o `__dirname/..`
+ * dentro de `.pipeline/lib/`. Como este resolver vive en el mismo directorio,
+ * `path.resolve(__dirname, '..')` coincide con el cálculo de waves.js cuando
+ * no hay override. Esto nos permite saber si necesitamos hacer override
+ * temporal del env var (caso típico: tests con pipelineRoot en tmp dir).
+ *
+ * @returns {string} path absoluto al directorio `.pipeline`
+ */
+function effectiveWavesPipelineDir() {
+    if (process.env.PIPELINE_DIR_OVERRIDE) return process.env.PIPELINE_DIR_OVERRIDE;
+    return path.resolve(__dirname, '..');
+}
+
+/**
+ * Lee la ola activa delegando en `lib/waves.js` (source-of-truth canónica).
+ *
+ * Si `pipelineRoot` no coincide con el directorio que `lib/waves.js` resolvería
+ * internamente, se hace override temporal de `PIPELINE_DIR_OVERRIDE` para
+ * forzar a `waves.js` a leer el `waves.json` del root pedido (caso típico:
+ * tests con tmp dirs). El override se restaura en `finally` y se invalida la
+ * cache antes y después para no contaminar otros consumers.
+ *
+ * En producción `pipelineRoot` coincide naturalmente con `pipelineDir()` de
+ * waves.js, así que el override es no-op y la cache TTL 2s se hereda (CA-9).
  *
  * @param {string} pipelineRoot
- * @returns {{label: string, issues: number[], openedAt: string|null, source: string}|null}
+ * @returns {{label: string, issues: number[], openedAt: string|null, source: 'waves.json'}|null}
  */
-function readActiveWaveFile(pipelineRoot) {
-    const file = path.join(pipelineRoot, 'active-wave.json');
-    let raw;
+function readFromWavesJson(pipelineRoot) {
+    const wavesDir = effectiveWavesPipelineDir();
+    const needsOverride = path.resolve(pipelineRoot) !== path.resolve(wavesDir);
+    const prevOverride = process.env.PIPELINE_DIR_OVERRIDE;
+
+    if (needsOverride) {
+        process.env.PIPELINE_DIR_OVERRIDE = pipelineRoot;
+        waves.invalidateCache();
+    }
+
+    let active;
     try {
-        raw = fs.readFileSync(file, 'utf8');
+        active = waves.getActiveWave();
     } catch {
+        active = null;
+    } finally {
+        if (needsOverride) {
+            if (prevOverride === undefined) delete process.env.PIPELINE_DIR_OVERRIDE;
+            else process.env.PIPELINE_DIR_OVERRIDE = prevOverride;
+            waves.invalidateCache();
+        }
+    }
+
+    if (!active || !Array.isArray(active.issues) || active.issues.length === 0) {
         return null;
     }
-    let parsed;
-    try {
-        parsed = JSON.parse(raw);
-    } catch {
-        return null;
-    }
-    if (!parsed || typeof parsed !== 'object') return null;
-    const label = typeof parsed.label === 'string' ? parsed.label.trim() : '';
-    const issuesRaw = Array.isArray(parsed.issues) ? parsed.issues : [];
-    const issues = issuesRaw
-        .map((n) => Number(String(n).replace(/^#/, '').trim()))
-        .filter((n) => Number.isInteger(n) && n > 0);
-    if (!label || issues.length === 0) return null;
+
+    // CA-4 — normalizador defensivo: tolera issues como int planos o {number}.
+    const issues = active.issues
+        .map(normalizeIssueNumber)
+        .filter(Boolean);
+    if (issues.length === 0) return null;
+
+    const nameTrim = typeof active.name === 'string' ? active.name.trim() : '';
+    const label = nameTrim
+        || (active.number != null ? `Ola ${active.number}` : 'Ola actual');
+    const openedAt = typeof active.started_at === 'string' ? active.started_at : null;
+
     return {
         label,
         issues: [...new Set(issues)].sort((a, b) => a - b),
-        openedAt: typeof parsed.opened_at === 'string' ? parsed.opened_at : null,
-        source: 'active-wave.json',
+        openedAt,
+        source: 'waves.json',
     };
 }
 
@@ -94,8 +167,8 @@ function readPartialPauseFile(pipelineRoot) {
     if (!parsed || typeof parsed !== 'object') return null;
     const issuesRaw = Array.isArray(parsed.allowed_issues) ? parsed.allowed_issues : [];
     const issues = issuesRaw
-        .map((n) => Number(String(n).replace(/^#/, '').trim()))
-        .filter((n) => Number.isInteger(n) && n > 0);
+        .map(normalizeIssueNumber)
+        .filter(Boolean);
     if (issues.length === 0) return null;
     return {
         label: 'Ola actual',
@@ -154,7 +227,7 @@ function collectActiveIssuesFromFs(pipelineRoot) {
  *   label: string,
  *   issues: number[],
  *   openedAt: string|null,
- *   source: 'active-wave.json'|'partial-pause.json'|'fs-fallback',
+ *   source: 'waves.json'|'partial-pause.json'|'fs-fallback',
  *   resolved: boolean,
  * }}
  */
@@ -164,8 +237,8 @@ function resolveActiveWave(opts) {
         return { label: 'Ola actual (sin label)', issues: [], openedAt: null, source: 'fs-fallback', resolved: false };
     }
 
-    const fromFile = readActiveWaveFile(pipelineRoot);
-    if (fromFile) return { ...fromFile, resolved: true };
+    const fromWaves = readFromWavesJson(pipelineRoot);
+    if (fromWaves) return { ...fromWaves, resolved: true };
 
     const fromPartial = readPartialPauseFile(pipelineRoot);
     if (fromPartial) return { ...fromPartial, resolved: true };
@@ -178,8 +251,10 @@ module.exports = {
     resolveActiveWave,
     // Exports internos para tests
     _internal: {
-        readActiveWaveFile,
+        readFromWavesJson,
         readPartialPauseFile,
         collectActiveIssuesFromFs,
+        normalizeIssueNumber,
+        effectiveWavesPipelineDir,
     },
 };


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 3 archivos · +348 -91

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:skipped` aplicado por delivery

## Closes

Closes #3502
