### PR TITLE
[guru] Derivar KNOWN_HINTS_BY_PROVIDER de agent-models.json#quota_error_types

### DIFF
--- a/.pipeline/lib/__tests__/provider-exhaustion-pause.test.js
+++ b/.pipeline/lib/__tests__/provider-exhaustion-pause.test.js
@@ -1,0 +1,379 @@
+// =============================================================================
+// Tests provider-exhaustion-pause.js — Issue #3498
+//
+// Cobertura de los CA consolidados por po (#3498 c-4549199606):
+//   CA-1  · Provider conocido → join(' / ') de quota_error_types.
+//   CA-2  · Provider inexistente → fallback 'quota_exhausted'.
+//   CA-3  · quota_error_types vacío o ausente → fallback.
+//   CA-4  · loadAndValidate corrupto → fallback degraded + warning UNA vez.
+//   CA-5  · opts.agentModels inyectado tiene precedencia sobre cache.
+//   CA-6  · Memoización: una sola invocación a loadAndValidate por proceso.
+//   CA-7  · formatExhaustionMessage usa getQuotaHint, no la constante vieja.
+//   CA-9  · Cap defensivo slice(0, 5) antes del join (anti-DoS).
+//   CA-10 · Sanitización por elemento contra Markdown injection.
+//   CA-13 · Fallback informativo "config indisponible" sólo en degraded mode.
+//   CA-14 · Wording del mensaje Telegram NO cambia (snapshot anti-regresión).
+//   CA-15 · Suite completa (10 tests obligatorios).
+// =============================================================================
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const mod = require('../provider-exhaustion-pause');
+const { getQuotaHint, sanitizeHintElement, formatExhaustionMessage, _resetQuotaHintsCache } = mod;
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function fixtureConfig() {
+    // Sub-set fiel del agent-models.json en HEAD (#3498 análisis).
+    return {
+        providers: {
+            anthropic: {
+                quota_error_types: ['usage_limit_error', 'weekly_quota_exhausted', 'snapshot_threshold_90'],
+            },
+            'openai-codex': {
+                quota_error_types: ['insufficient_quota', 'billing_hard_limit_reached'],
+            },
+            'gemini-google': {
+                quota_error_types: ['quota_exceeded', 'resource_exhausted'],
+            },
+            cerebras: {
+                quota_error_types: ['rate_limit_exceeded', 'quota_exceeded'],
+            },
+            'nvidia-nim': {
+                quota_error_types: ['rate_limit_exceeded', 'quota_exceeded', 'insufficient_quota'],
+            },
+            deterministic: {
+                quota_error_types: [],
+            },
+        },
+    };
+}
+
+function silentLogger() {
+    const warnings = [];
+    return {
+        warnings,
+        warn(...args) { warnings.push(args.join(' ')); },
+    };
+}
+
+// Asegurar cache limpio antes de cada test para predecir warnings/loads.
+test.beforeEach(() => { _resetQuotaHintsCache(); });
+
+// ─── CA-1 · Provider conocido ────────────────────────────────────────────────
+
+test('CA-1 — getQuotaHint devuelve los strings unidos por " / " para provider conocido', () => {
+    const cfg = fixtureConfig();
+    const hint = getQuotaHint('openai-codex', { agentModels: cfg });
+    assert.equal(hint, 'insufficient_quota / billing_hard_limit_reached');
+});
+
+test('CA-1b — anthropic refleja el JSON actual (incluye snapshot_threshold_90)', () => {
+    // Verifica explícitamente que el drift está cerrado: el hint Telegram
+    // ahora refleja TODO el contenido de quota_error_types de anthropic, no
+    // una constante hardcoded desactualizada.
+    const hint = getQuotaHint('anthropic', { agentModels: fixtureConfig() });
+    assert.equal(hint, 'usage_limit_error / weekly_quota_exhausted / snapshot_threshold_90');
+});
+
+// ─── CA-2 · Provider inexistente ─────────────────────────────────────────────
+
+test('CA-2 — provider inexistente devuelve fallback plano', () => {
+    const hint = getQuotaHint('foo-bar', { agentModels: fixtureConfig() });
+    assert.equal(hint, 'quota_exhausted');
+});
+
+// ─── CA-3 · quota_error_types vacío o ausente ────────────────────────────────
+
+test('CA-3a — quota_error_types vacío devuelve fallback plano (caso deterministic)', () => {
+    const hint = getQuotaHint('deterministic', { agentModels: fixtureConfig() });
+    assert.equal(hint, 'quota_exhausted');
+});
+
+test('CA-3b — quota_error_types ausente devuelve fallback plano', () => {
+    const cfg = { providers: { someprov: { /* sin quota_error_types */ } } };
+    const hint = getQuotaHint('someprov', { agentModels: cfg });
+    assert.equal(hint, 'quota_exhausted');
+});
+
+// ─── CA-4 · loadAndValidate corrupto → fallback degraded + warning UNA vez ────
+
+test('CA-4 — config sin loader → fallback degraded "config indisponible" + warning UNA vez', () => {
+    // Forzamos el path "sin inyección" → el helper intenta el loader real.
+    // Como en este worktree el loader carga OK normalmente, simulamos el modo
+    // degraded inyectando un cache vacío manualmente vía falso loader.
+    // Truco: pasamos un agentModels sin `providers` → el helper devuelve
+    // fallback PLANO (no degraded) porque no hubo fallo de carga.
+    //
+    // Para forzar el path degraded de verdad, monkey-patcheamos
+    // `loadAndValidate` del cache interno reimportando el módulo con un
+    // require fresh + agent-models stub roto. Lo más limpio en Node test es
+    // verificar el comportamiento via cache reset + mock del require interno.
+    //
+    // Workaround: probamos el path inyectando logger y forzando un objeto
+    // que dispare la rama degraded a través del setter `_resetQuotaHintsCache`
+    // tras un primer call que rompe.
+    //
+    // Estrategia: usamos `require.cache` para reemplazar transitoriamente
+    // `agent-models` por un stub que tira al cargar.
+
+    const path = require('path');
+    const agentModelsPath = require.resolve('../agent-models');
+    const originalModule = require.cache[agentModelsPath];
+
+    // Stub loader que retorna { ok: false }.
+    require.cache[agentModelsPath] = {
+        id: agentModelsPath,
+        filename: agentModelsPath,
+        loaded: true,
+        exports: {
+            loadAndValidate() { return { ok: false, errors: [{ msg: 'corrupt' }] }; },
+        },
+    };
+
+    // Recargar el módulo bajo test con el stub en place.
+    const fresh = (() => {
+        const p = require.resolve('../provider-exhaustion-pause');
+        delete require.cache[p];
+        return require('../provider-exhaustion-pause');
+    })();
+
+    try {
+        const logger = silentLogger();
+        const hint1 = fresh.getQuotaHint('anthropic', { logger });
+        assert.equal(hint1, 'quota_exhausted (config indisponible)');
+        assert.equal(logger.warnings.length, 1);
+
+        // Segunda invocación: ya no debe loggear de nuevo (CA-4: warning UNA vez).
+        const hint2 = fresh.getQuotaHint('cerebras', { logger });
+        assert.equal(hint2, 'quota_exhausted (config indisponible)');
+        assert.equal(logger.warnings.length, 1, 'warning emitido una sola vez por vida del proceso');
+    } finally {
+        // Restaurar el módulo original para no contaminar tests siguientes.
+        if (originalModule) {
+            require.cache[agentModelsPath] = originalModule;
+        } else {
+            delete require.cache[agentModelsPath];
+        }
+        delete require.cache[require.resolve('../provider-exhaustion-pause')];
+    }
+});
+
+test('CA-4b — loadAndValidate que lanza excepción cae a fallback degraded', () => {
+    const agentModelsPath = require.resolve('../agent-models');
+    const originalModule = require.cache[agentModelsPath];
+
+    require.cache[agentModelsPath] = {
+        id: agentModelsPath,
+        filename: agentModelsPath,
+        loaded: true,
+        exports: {
+            loadAndValidate() { throw new Error('explota'); },
+        },
+    };
+
+    const fresh = (() => {
+        const p = require.resolve('../provider-exhaustion-pause');
+        delete require.cache[p];
+        return require('../provider-exhaustion-pause');
+    })();
+
+    try {
+        const logger = silentLogger();
+        const hint = fresh.getQuotaHint('anthropic', { logger });
+        assert.equal(hint, 'quota_exhausted (config indisponible)');
+        assert.equal(logger.warnings.length, 1);
+    } finally {
+        if (originalModule) {
+            require.cache[agentModelsPath] = originalModule;
+        } else {
+            delete require.cache[agentModelsPath];
+        }
+        delete require.cache[require.resolve('../provider-exhaustion-pause')];
+    }
+});
+
+// ─── CA-5 · Inyección precedente sobre cache ─────────────────────────────────
+
+test('CA-5 — opts.agentModels inyectado tiene precedencia sobre el cache lazy', () => {
+    // Primer call: poblar cache implícito con el config real (no inyectado).
+    const realHint = getQuotaHint('anthropic');
+    assert.ok(realHint.includes('usage_limit_error'),
+        `el config real debería traer usage_limit_error, vino: ${realHint}`);
+
+    // Segundo call con inyección: debe ganar el inject, no la cache.
+    const injected = {
+        providers: { anthropic: { quota_error_types: ['INJECTED_TYPE'] } },
+    };
+    const hint = getQuotaHint('anthropic', { agentModels: injected });
+    assert.equal(hint, 'INJECTED_TYPE');
+});
+
+// ─── CA-6 · Memoización ──────────────────────────────────────────────────────
+
+test('CA-6 — loadAndValidate se invoca UNA sola vez para múltiples invocaciones (memoización)', () => {
+    const agentModelsPath = require.resolve('../agent-models');
+    const originalModule = require.cache[agentModelsPath];
+
+    let calls = 0;
+    require.cache[agentModelsPath] = {
+        id: agentModelsPath,
+        filename: agentModelsPath,
+        loaded: true,
+        exports: {
+            loadAndValidate() {
+                calls += 1;
+                return { ok: true, config: fixtureConfig() };
+            },
+        },
+    };
+
+    const fresh = (() => {
+        const p = require.resolve('../provider-exhaustion-pause');
+        delete require.cache[p];
+        return require('../provider-exhaustion-pause');
+    })();
+
+    try {
+        fresh.getQuotaHint('anthropic');
+        fresh.getQuotaHint('openai-codex');
+        fresh.getQuotaHint('foo-bar');
+        fresh.getQuotaHint('cerebras');
+        assert.equal(calls, 1, `loadAndValidate llamado 1 vez, fueron ${calls}`);
+    } finally {
+        if (originalModule) {
+            require.cache[agentModelsPath] = originalModule;
+        } else {
+            delete require.cache[agentModelsPath];
+        }
+        delete require.cache[require.resolve('../provider-exhaustion-pause')];
+    }
+});
+
+// ─── CA-9 · Cap defensivo ─────────────────────────────────────────────────────
+
+test('CA-9 — provider con 10 elementos → exactamente 5 en el output (anti-DoS)', () => {
+    const cfg = {
+        providers: {
+            bigprov: {
+                quota_error_types: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'],
+            },
+        },
+    };
+    const hint = getQuotaHint('bigprov', { agentModels: cfg });
+    assert.equal(hint, 'a / b / c / d / e');
+    // Sanity check: exactamente 5 elementos separados por ' / '.
+    assert.equal(hint.split(' / ').length, 5);
+});
+
+// ─── CA-10 · Sanitización por elemento ───────────────────────────────────────
+
+test('CA-10 — input con caracteres Markdown maliciosos queda sanitizado', () => {
+    const cfg = {
+        providers: {
+            evilprov: {
+                quota_error_types: ['*[evil](http://x)*', 'normal_string', '`backtick`'],
+            },
+        },
+    };
+    const hint = getQuotaHint('evilprov', { agentModels: cfg });
+    // Caracteres `*`, `[`, `]`, `(`, `)`, backtick removidos. El underscore
+    // se preserva intencionalmente (ver JSDoc de sanitizeHintElement — CA-14
+    // prevalece sobre injection italic, que no abre vector real).
+    assert.equal(hint, 'evilhttp://x / normal_string / backtick');
+    // Garantía explícita: ninguno de los chars realmente peligrosos sobrevive.
+    for (const ch of ['*', '[', ']', '(', ')', '`']) {
+        assert.ok(!hint.includes(ch), `el char "${ch}" debe estar eliminado`);
+    }
+    // Y el underscore se preserva para no destruir identificadores legítimos.
+    assert.ok(hint.includes('normal_string'), 'underscore en identificadores preservado');
+});
+
+test('CA-10b — sanitizeHintElement maneja null/undefined sin throw', () => {
+    assert.equal(sanitizeHintElement(null), '');
+    assert.equal(sanitizeHintElement(undefined), '');
+    assert.equal(sanitizeHintElement(42), '42');
+});
+
+// ─── CA-7 + CA-14 · Snapshot del mensaje Telegram ────────────────────────────
+
+test('CA-7 + CA-14 — snapshot de formatExhaustionMessage para los 5 providers reales', () => {
+    const cfg = fixtureConfig();
+    const baseChain = ['anthropic', 'openai-codex'];
+
+    for (const primary of ['anthropic', 'openai-codex', 'gemini-google', 'cerebras', 'nvidia-nim']) {
+        const text = formatExhaustionMessage({
+            skill: 'guru',
+            issue: 9999,
+            title: 'test',
+            primary_provider: primary,
+            chain_tried: baseChain,
+            retry_interval_ms: 5 * 60 * 1000,
+        }, { agentModels: cfg });
+
+        // El wording alrededor del hint NO cambia (líneas estables del template).
+        assert.ok(text.includes('🟧 *Pipeline pausado — cuota agotada*'), `header presente para ${primary}`);
+        assert.ok(text.includes('Issue: [#9999 — test]'), `link al issue presente para ${primary}`);
+        assert.ok(text.includes('Skill: `guru`'), `skill line presente para ${primary}`);
+        assert.ok(text.includes(`Primary: \`${primary}\``), `primary line presente para ${primary}`);
+        assert.ok(text.includes('Cadena intentada: `anthropic -> openai-codex`'), `chain line presente para ${primary}`);
+        assert.ok(text.includes('provider-exhaustion-pause'), `label name presente para ${primary}`);
+        assert.ok(text.includes('reintentar cada ~300s'), `ETA presente para ${primary}`);
+
+        // El hint corresponde a la derivación de quota_error_types (CA-7).
+        const expected = cfg.providers[primary].quota_error_types.slice(0, 5).join(' / ');
+        assert.ok(text.includes(`(${expected})`),
+            `hint derivado de agent-models.json para ${primary} = "(${expected})", body=${text}`);
+    }
+});
+
+test('CA-13 — formatExhaustionMessage en modo degraded propaga el sufijo informativo', () => {
+    const agentModelsPath = require.resolve('../agent-models');
+    const originalModule = require.cache[agentModelsPath];
+
+    require.cache[agentModelsPath] = {
+        id: agentModelsPath,
+        filename: agentModelsPath,
+        loaded: true,
+        exports: {
+            loadAndValidate() { return { ok: false }; },
+        },
+    };
+
+    const fresh = (() => {
+        const p = require.resolve('../provider-exhaustion-pause');
+        delete require.cache[p];
+        return require('../provider-exhaustion-pause');
+    })();
+
+    try {
+        const text = fresh.formatExhaustionMessage({
+            skill: 'guru',
+            issue: 1,
+            primary_provider: 'anthropic',
+            chain_tried: ['anthropic'],
+            retry_interval_ms: 60000,
+        }, { logger: silentLogger() });
+        assert.ok(
+            text.includes('(quota_exhausted (config indisponible))'),
+            `el sufijo degraded debe aparecer en el mensaje Telegram, vino: ${text}`,
+        );
+    } finally {
+        if (originalModule) {
+            require.cache[agentModelsPath] = originalModule;
+        } else {
+            delete require.cache[agentModelsPath];
+        }
+        delete require.cache[require.resolve('../provider-exhaustion-pause')];
+    }
+});
+
+// ─── Cleanup: confirmar que la constante vieja ya no está exportada ──────────
+
+test('CA-8 — KNOWN_HINTS_BY_PROVIDER ya no se exporta (cleanup)', () => {
+    assert.equal(typeof mod.KNOWN_HINTS_BY_PROVIDER, 'undefined',
+        'KNOWN_HINTS_BY_PROVIDER debe quedar removido del module.exports');
+});

--- a/.pipeline/lib/http-error-classifier.js
+++ b/.pipeline/lib/http-error-classifier.js
@@ -31,10 +31,10 @@
 // - NO reemplaza `quota_error_types` en `agent-models.json`: esa allowlist
 //   cubre el canal CLI (claude-code/codex via stream-json o stderr), donde NO
 //   hay HTTP status visible al wrapper. Este clasificador cubre el canal API.
-// - NO reemplaza `KNOWN_HINTS_BY_PROVIDER` en `provider-exhaustion-pause.js`:
-//   esos hints son texto humanizado para mensajes Telegram, no clasificación.
-//   El consumer puede combinar la `category` de acá con el hint humano de
-//   allá.
+// - NO reemplaza `getQuotaHint(provider)` en `provider-exhaustion-pause.js`:
+//   ese helper humaniza el detalle del mensaje Telegram derivando de
+//   `agent-models.json#quota_error_types` (#3498) — no es clasificación. El
+//   consumer puede combinar la `category` de acá con el hint humano de allá.
 //
 // MATRIZ
 // ------

--- a/.pipeline/lib/provider-exhaustion-pause.js
+++ b/.pipeline/lib/provider-exhaustion-pause.js
@@ -80,6 +80,12 @@ try { auditLogLib = require('./audit-log'); } catch { /* opcional */ }
 let quotaModule = null;
 try { quotaModule = require('./quota-exhausted'); } catch { /* opcional */ }
 
+// Loader de `agent-models.json` (#3498). Fuente única para humanizar los hints
+// de quota en el mensaje Telegram. Si no carga, `getQuotaHint` degrada a
+// fallback genérico — el barrido nunca se cae por un loader opcional.
+let agentModelsLib = null;
+try { agentModelsLib = require('./agent-models'); } catch { /* opcional */ }
+
 // -----------------------------------------------------------------------------
 // Constantes (todas configurables vía opts del caller para tests + flex)
 // -----------------------------------------------------------------------------
@@ -109,16 +115,23 @@ const TELEGRAM_QUEUE_SUBDIR = path.join('servicios', 'telegram', 'pendiente');
 // Subdir de markers de notificación. Una entrada por issue.
 const NOTIFY_MARKER_SUBDIR = path.join('state', 'exhaustion-notified');
 
-// Tipos de error esperables por provider — para humanizar el detalle del
-// Telegram. Si el caller no pasa `error_types`, mostramos `unknown`.
-const KNOWN_HINTS_BY_PROVIDER = Object.freeze({
-    anthropic: 'usage_limit_error / weekly_quota_exhausted',
-    'openai-codex': 'insufficient_quota / billing_hard_limit_reached',
-    'gemini-google': 'quota_exceeded / resource_exhausted',
-    // Groq descontinuado en #3353 — sin hint hardcoded para el provider.
-    cerebras: 'rate_limit_exceeded / quota_exceeded',
-    'nvidia-nim': 'rate_limit_exceeded / quota_exceeded / insufficient_quota',
-});
+// Hints humanizados por provider (#3498).
+//
+// Fuente única de verdad: `agent-models.json#providers.<id>.quota_error_types`.
+// Antes (rebote 0 de #3259) esto era una tabla `KNOWN_HINTS_BY_PROVIDER`
+// hardcoded — quedaba en drift con `agent-models.json` (incidente Ola N+10
+// 2026-05-26: el hint Telegram no reflejaba `snapshot_threshold_90` aunque
+// estaba en el JSON). #3498 cierra esa deuda derivando el hint del JSON con
+// `getQuotaHint(provider, opts)`.
+//
+// Constantes del helper:
+const QUOTA_HINT_FALLBACK = 'quota_exhausted';
+const QUOTA_HINT_FALLBACK_DEGRADED = 'quota_exhausted (config indisponible)';
+// Cap defensivo — invariante de seguridad (CA-9 / SEC-1):
+//   1) Previene DoS por mensaje > 4096 bytes (límite Telegram).
+//   2) Mantiene legibilidad de la línea del operador (UX-1).
+// Cap aplicado ANTES del `.join(' / ')`.
+const QUOTA_HINT_MAX_ELEMENTS = 5;
 
 // -----------------------------------------------------------------------------
 // Path helpers
@@ -180,6 +193,142 @@ function sanitizeForTelegram(text) {
         str = str.slice(0, TELEGRAM_MAX_BYTES - 32) + '\n[... truncado]';
     }
     return str;
+}
+
+// -----------------------------------------------------------------------------
+// Quota hint helper (#3498) — derivado de agent-models.json#quota_error_types
+// -----------------------------------------------------------------------------
+
+// Cache memoizado lazy del config validado.
+//   `null` = todavía no se intentó cargar (estado virgen del proceso).
+//   Objeto literal `{}` = se intentó cargar y falló — modo degradado.
+//   Objeto con `providers` = cargado OK.
+// Pulpo se reinicia con `restart.js` y no hace hot-reload, así que una sola
+// carga por vida de proceso es coherente (CA-6).
+let _quotaHintsCache = null;
+let _quotaHintsLoadFailed = false;
+let _quotaHintsWarningEmitted = false;
+
+/**
+ * Sanitiza un elemento individual de `quota_error_types` antes del join.
+ * Defense in depth sobre `sanitizeForTelegram` (que se aplica al mensaje
+ * completo aguas abajo). Elimina caracteres Markdown que podrían romper
+ * el render Telegram o inyectar links (CA-10 / SEC-2 / UX-4).
+ *
+ * Nota deliberada de diseño: el underscore (`_`) NO se elimina aunque sea
+ * el marcador de italic en Markdown. Los identificadores en
+ * `quota_error_types` son snake_case (`usage_limit_error`,
+ * `weekly_quota_exhausted`, etc.) y eliminarlo destruiría el contenido que
+ * el operador necesita leer — esto pisaría CA-14 (anti-regresión del
+ * wording vs el hardcoded previo). El render italic ocasional no abre
+ * vector de injection (no inyecta links, no levanta scripts) y la baseline
+ * del módulo lo viene tolerando desde #3259. Los chars realmente
+ * peligrosos (`*`, backtick, `[`, `]`, `(`, `)`) sí se filtran.
+ */
+function sanitizeHintElement(s) {
+    return String(s == null ? '' : s).replace(/[*`\[\]()]/g, '');
+}
+
+function _logQuotaHintWarning(opts) {
+    if (_quotaHintsWarningEmitted) return;
+    _quotaHintsWarningEmitted = true;
+    const logger = (opts && opts.logger) || console;
+    try {
+        if (logger && typeof logger.warn === 'function') {
+            logger.warn('[provider-exhaustion-pause] agent-models.json no disponible o corrupto — getQuotaHint cae a fallback genérico');
+        }
+    } catch { /* logger inválido — silenciar */ }
+}
+
+/**
+ * Devuelve el hint humanizado del provider para el mensaje Telegram al
+ * operador. Fuente única de verdad: `agent-models.json#providers.<id>.quota_error_types`.
+ *
+ * Comportamiento:
+ *   - Provider con `quota_error_types` poblado → strings sanitizados unidos por `' / '`
+ *     (hasta {@link QUOTA_HINT_MAX_ELEMENTS} elementos).
+ *   - Provider con `quota_error_types: []` o ausente → `'quota_exhausted'`.
+ *   - Provider inexistente en el config → `'quota_exhausted'`.
+ *   - `agent-models.json` corrupto / no cargable → `'quota_exhausted (config indisponible)'`
+ *     + warning loggeado una sola vez (no spam por invocación).
+ *
+ * Defensas (invariantes documentadas):
+ *   - Cap `slice(0, 5)` ANTES del join (CA-9 / SEC-1).
+ *   - Sanitización por elemento previa al join (CA-10 / SEC-2 / UX-4).
+ *
+ * @param {string} provider — identificador del provider (ej. `'anthropic'`).
+ * @param {object} [opts]
+ * @param {object} [opts.agentModels] — config inyectado para tests; tiene
+ *   precedencia sobre la cache memoizada (CA-5).
+ * @param {object} [opts.logger] — logger custom para el warning del caso
+ *   corrupto; default `console`.
+ * @returns {string} hint humanizado.
+ */
+function getQuotaHint(provider, opts = {}) {
+    let config = null;
+    let degraded = false;
+
+    // 1) Inyección explícita (testeable, prioritaria). NO toca el cache global.
+    if (opts.agentModels && typeof opts.agentModels === 'object') {
+        config = opts.agentModels;
+    } else {
+        // 2) Cache lazy — cargar una sola vez por vida del proceso.
+        if (_quotaHintsCache === null) {
+            try {
+                if (!agentModelsLib || typeof agentModelsLib.loadAndValidate !== 'function') {
+                    throw new Error('agent-models loader unavailable');
+                }
+                const result = agentModelsLib.loadAndValidate();
+                if (result && result.ok && result.config && typeof result.config === 'object') {
+                    _quotaHintsCache = result.config;
+                    _quotaHintsLoadFailed = false;
+                } else {
+                    _quotaHintsCache = {};
+                    _quotaHintsLoadFailed = true;
+                    _logQuotaHintWarning(opts);
+                }
+            } catch {
+                _quotaHintsCache = {};
+                _quotaHintsLoadFailed = true;
+                _logQuotaHintWarning(opts);
+            }
+        }
+        config = _quotaHintsCache;
+        degraded = _quotaHintsLoadFailed;
+    }
+
+    // 3) Extraer `quota_error_types` defensivamente.
+    let types = null;
+    try {
+        const providerNode = config && config.providers && config.providers[provider];
+        if (providerNode && Array.isArray(providerNode.quota_error_types)) {
+            types = providerNode.quota_error_types;
+        }
+    } catch { /* defensive — caemos a fallback abajo */ }
+
+    if (Array.isArray(types) && types.length > 0) {
+        const joined = types
+            .slice(0, QUOTA_HINT_MAX_ELEMENTS)
+            .map(sanitizeHintElement)
+            .filter(s => s.length > 0)
+            .join(' / ');
+        if (joined.length > 0) return joined;
+        // Todos los elementos quedaron vacíos tras la sanitización → fallback.
+    }
+
+    return degraded ? QUOTA_HINT_FALLBACK_DEGRADED : QUOTA_HINT_FALLBACK;
+}
+
+/**
+ * Resetea el cache memoizado del helper. Pensado únicamente para tests
+ * (entre casos). NO usar desde producción — el cache es lazy y consistente
+ * durante la vida del proceso (Pulpo se reinicia con `restart.js`, sin
+ * hot-reload).
+ */
+function _resetQuotaHintsCache() {
+    _quotaHintsCache = null;
+    _quotaHintsLoadFailed = false;
+    _quotaHintsWarningEmitted = false;
 }
 
 // -----------------------------------------------------------------------------
@@ -374,8 +523,12 @@ function shouldNotify(issue, payload, opts = {}) {
  * NO Markdown porque el body puede traer chain con guiones; el servicio
  * Telegram lo encola con `parse_mode: 'Markdown'` por defecto pero el
  * caller puede pedir plain.
+ *
+ * @param {object} payload — datos del evento de exhaustion.
+ * @param {object} [opts] — overrides (propagados a `getQuotaHint`). Permite
+ *   inyectar `agentModels` para tests sin tocar el cache global (#3498 CA-5).
  */
-function formatExhaustionMessage(payload) {
+function formatExhaustionMessage(payload, opts = {}) {
     const skill = String(payload.skill || 'unknown');
     const issue = isValidIssue(payload.issue) ? Number(payload.issue) : null;
     const title = payload.title ? String(payload.title) : '';
@@ -383,7 +536,10 @@ function formatExhaustionMessage(payload) {
     const chain = Array.isArray(payload.chain_tried) && payload.chain_tried.length
         ? payload.chain_tried.join(' -> ')
         : primary;
-    const hint = KNOWN_HINTS_BY_PROVIDER[primary] || 'quota_exhausted';
+    // #3498: hint derivado de `agent-models.json#quota_error_types`; el helper
+    // mantiene fallback genérico si el provider no está en el config o si el
+    // JSON no carga. Nunca tira.
+    const hint = getQuotaHint(primary, opts);
     const retrySec = Math.max(60, Math.round(Number(payload.retry_interval_ms || DEFAULT_RETRY_INTERVAL_MS) / 1000));
     const issueLink = issue
         ? `[#${issue}${title ? ' — ' + title.slice(0, 80) : ''}](https://github.com/${GH_REPO}/issues/${issue})`
@@ -556,7 +712,7 @@ function reportExhaustion(payload, opts = {}) {
     const decision = shouldNotify(issue, payload, opts);
     out.notify_reason = decision.reason;
     if (decision.notify) {
-        const text = formatExhaustionMessage(payload);
+        const text = formatExhaustionMessage(payload, opts);
         const tg = enqueueTelegram(text, { ...opts, filenameTag: 'exhaustion-pause' });
         out.notified = tg.ok;
         if (tg.file) out.telegram_file = tg.file;
@@ -715,6 +871,11 @@ module.exports = {
     telegramQueueDir,
     exhaustionAuditFile,
 
+    // #3498: helper memoizado del hint humanizado + reset para tests.
+    getQuotaHint,
+    sanitizeHintElement,
+    _resetQuotaHintsCache,
+
     // Constantes
     EXHAUSTION_LABEL,
     GH_REPO,
@@ -724,5 +885,8 @@ module.exports = {
     DEFAULT_RETRY_INTERVAL_MS,
     TELEGRAM_QUEUE_SUBDIR,
     NOTIFY_MARKER_SUBDIR,
-    KNOWN_HINTS_BY_PROVIDER,
+    // #3498: constantes nuevas del helper.
+    QUOTA_HINT_FALLBACK,
+    QUOTA_HINT_FALLBACK_DEGRADED,
+    QUOTA_HINT_MAX_ELEMENTS,
 };

--- a/docs/pipeline/multi-provider.md
+++ b/docs/pipeline/multi-provider.md
@@ -406,7 +406,7 @@ classifyHttpError(statusCode, responseBody, provider) → {
 #### Lo que el clasificador NO reemplaza
 
 - **`quota_error_types` en `agent-models.json`** sigue siendo `required` en el schema y cubre el **canal CLI** (claude-code/codex via stream-json o stderr donde no hay HTTP status visible al wrapper). Cross-validado contra `KNOWN_QUOTA_ERROR_TYPES_BY_PROVIDER` en `quota-exhausted.js` (defensa SEC-2 de [#3077](https://github.com/intrale/platform/issues/3077) contra adulteración de `agent-models.json`).
-- **`KNOWN_HINTS_BY_PROVIDER` en `provider-exhaustion-pause.js`** sigue siendo texto humanizado para mensajes Telegram. El clasificador da la `category` (operativa); el hint humano se compone aparte.
+- **El hint humanizado del mensaje Telegram** se compone aparte vía `getQuotaHint(provider)` en `provider-exhaustion-pause.js` ([#3498](https://github.com/intrale/platform/issues/3498)). Desde el refactor de #3498 ese helper se **deriva automáticamente** de `agent-models.json#providers.<id>.quota_error_types` con cap defensivo de 5 elementos, sanitización por elemento y fallback `'quota_exhausted'` (o `'quota_exhausted (config indisponible)'` si el JSON no carga). **Agregar un patrón nuevo es ahora un PR de un solo archivo (`agent-models.json`)**; el mensaje Telegram refleja el cambio al próximo restart del Pulpo, sin tocar la tabla manual `KNOWN_HINTS_BY_PROVIDER` (eliminada). El clasificador HTTP da la `category` operativa; el hint humano se compone aparte y vive en el panel del operador.
 
 #### Consumidores actuales
 


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 4 archivos · +562 -19

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:skipped` aplicado por delivery

## Closes

Closes #3498
