### PR TITLE
[po] Preferir modelo distinto en same_provider para preservar adversariality

### DIFF
--- a/.pipeline/agent-models.json
+++ b/.pipeline/agent-models.json
@@ -88,7 +88,10 @@
       "credentials_env": [
         "GEMINI_API_KEY"
       ],
-      "permissions_mode": "bypassPermissions"
+      "permissions_mode": "bypassPermissions",
+      "alternative_models": [
+        "gemini-1.5-flash"
+      ]
     },
     "cerebras": {
       "launcher": "cerebras",
@@ -113,7 +116,10 @@
       "credentials_env": [
         "CEREBRAS_API_KEY"
       ],
-      "permissions_mode": "bypassPermissions"
+      "permissions_mode": "bypassPermissions",
+      "alternative_models": [
+        "llama-3.1-70b"
+      ]
     },
     "nvidia-nim": {
       "launcher": "nvidia-nim",

--- a/.pipeline/agent-models.schema.json
+++ b/.pipeline/agent-models.schema.json
@@ -130,6 +130,13 @@
           "type": "string",
           "description": "Cómo se exhibe este provider en la ventana Providers del dashboard. 'live' = se pingea y se muestra el semáforo en vivo. 'not_applicable' = se muestra como 'NO APLICA' (badge informativo, sin semáforo). Default 'live'. #3361 — separa la visualización de la lista canónica para que listConfiguredProviders() siga siendo la fuente de verdad única.",
           "enum": ["live", "not_applicable"]
+        },
+        "alternative_models": {
+          "type": "array",
+          "description": "Modelos alternativos del mismo provider que Sherlock puede usar para preservar adversariality parcial cuando el Commander y Sherlock coinciden en provider (#3501). Lista ordenada por preferencia. Si `commanderProvider === sherlockProvider` y `commanderModel === sherlockModel`, el resolver itera estos modelos antes de saltar al siguiente provider de la chain. Cada entry se cross-valida contra `ALLOWED_MODELS_BY_LAUNCHER` en lib/agent-models-validate.js (defensa anti-supply-chain CA-SEC-SWAP-1). Caps `maxItems: 3` + `uniqueItems: true` evitan cost-amplification (CA-SEC-SWAP-2). Ausencia o lista vacía → política inactiva para este provider, comportamiento idéntico al actual (CA-4 default-safe).",
+          "items": { "type": "string", "minLength": 1 },
+          "maxItems": 3,
+          "uniqueItems": true
         }
       }
     },

--- a/.pipeline/lib/__tests__/agent-models-validate.test.js
+++ b/.pipeline/lib/__tests__/agent-models-validate.test.js
@@ -1060,14 +1060,17 @@ test('#3220 + #3353 · ALLOWED_CREDENTIAL_ENV_VARS incluye CEREBRAS_API_KEY (sin
   assert.ok(!vars.includes('GROQ_API_KEY'), 'GROQ_API_KEY debería estar removida tras #3353');
 });
 
-test('#3220 + #3353 · ALLOWED_MODELS_BY_LAUNCHER declara modelos por providers vivos (sin groq)', () => {
+test('#3220 + #3353 + #3501 · ALLOWED_MODELS_BY_LAUNCHER declara modelos por providers vivos (sin groq, con alternativos #3501)', () => {
   const models = validateMod.ALLOWED_MODELS_BY_LAUNCHER;
   assert.ok(models, 'ALLOWED_MODELS_BY_LAUNCHER debe exportarse');
   assert.ok(Object.isFrozen(models), 'top-level debe estar congelado');
   assert.deepEqual([...models.claude].sort(), ['claude-haiku-4-5', 'claude-opus-4-7', 'claude-sonnet-4-7']);
   assert.deepEqual([...models.codex].sort(), ['gpt-5', 'gpt-5-codex']);
-  assert.deepEqual([...models['gemini-google']], ['gemini-2.0-flash']);
-  assert.deepEqual([...models.cerebras], ['llama-3.3-70b']);
+  // #3501 — gemini-1.5-flash y llama-3.1-70b agregados como modelos alternativos
+  // para preservar adversariality intra-provider en Sherlock (ver
+  // sherlock-verifier.js::resolveSherlockProvider).
+  assert.deepEqual([...models['gemini-google']].sort(), ['gemini-1.5-flash', 'gemini-2.0-flash']);
+  assert.deepEqual([...models.cerebras].sort(), ['llama-3.1-70b', 'llama-3.3-70b']);
   // #3353 — `groq` no debe estar en la allowlist de modelos.
   assert.equal(models.groq, undefined, 'groq debería estar removido tras #3353');
 });

--- a/.pipeline/lib/__tests__/sherlock-verifier.test.js
+++ b/.pipeline/lib/__tests__/sherlock-verifier.test.js
@@ -1369,3 +1369,334 @@ test('#3558: sherlock_verification final incluye attemptCount/fallbackUsed/chain
     // en otros tests). Acá validamos que el audit no rompió por los campos extra.
     assert.equal(typeof verification.same_provider, 'boolean');
 });
+// =============================================================================
+// #3501 — Tests del swap intra-provider para preservar adversariality cuando
+// commander y sherlock coinciden en provider+model. Cobertura CA-14..CA-18.
+//
+// Diseño: los tests escriben un agent-models.json fixture en pipelineDir para
+// que `readAlternativeModelsForProvider` pueda leer la config real. El resto
+// del flow se inyecta con los fakes ya existentes.
+// =============================================================================
+
+function writeAgentModelsFixture(pipelineDir, providersOverride) {
+    const cfg = {
+        $schema: './agent-models.schema.json',
+        default_provider: 'anthropic',
+        providers: Object.assign({
+            anthropic: {
+                launcher: 'claude',
+                model: 'claude-opus-4-7',
+                spawn_args_template: ['-p', '{user_prompt}'],
+                output_parser: 'anthropic-stream-json',
+                quota_error_types: ['usage_limit_error'],
+                supports_tool_use: true,
+                prompt_caching: { supported: true, ttl_seconds_default: 300 },
+                credentials_env: ['ANTHROPIC_API_KEY'],
+                permissions_mode: 'bypassPermissions',
+            },
+            cerebras: {
+                launcher: 'cerebras',
+                model: 'llama-3.3-70b',
+                spawn_args_template: ['--model', '{model}'],
+                output_parser: 'openai-sse',
+                quota_error_types: ['rate_limit_exceeded'],
+                supports_tool_use: false,
+                prompt_caching: { supported: false },
+                credentials_env: ['CEREBRAS_API_KEY'],
+                permissions_mode: 'bypassPermissions',
+                alternative_models: ['llama-3.1-70b'],
+            },
+            'gemini-google': {
+                launcher: 'gemini-google',
+                model: 'gemini-2.0-flash',
+                spawn_args_template: ['--model', '{model}'],
+                output_parser: 'gemini-stream',
+                quota_error_types: ['quota_exceeded'],
+                supports_tool_use: true,
+                prompt_caching: { supported: false },
+                credentials_env: ['GEMINI_API_KEY'],
+                permissions_mode: 'bypassPermissions',
+                alternative_models: ['gemini-1.5-flash'],
+            },
+        }, providersOverride || {}),
+        skills: {
+            'telegram-sherlock': { provider: 'anthropic' },
+        },
+    };
+    fs.writeFileSync(path.join(pipelineDir, 'agent-models.json'), JSON.stringify(cfg, null, 2));
+    return cfg;
+}
+
+// =============================================================================
+// CA-14 — Happy path Anthropic: commander=anthropic/opus, sherlock chain
+// devuelve anthropic/haiku via model_override → same_provider:true,
+// same_model:false. NO debe disparar swap (la diferenciación de modelo ya
+// está resuelta declarativamente por config #3221).
+// =============================================================================
+test('#3501 CA-14: anthropic opus↔haiku via config #3221 NO dispara swap (modelos ya distintos)', async () => {
+    const dir = mkTmpPipelineDir();
+    writeAgentModelsFixture(dir);
+    const okResp = {
+        ok: true,
+        content: JSON.stringify({ verdict: 'ok', reason: 'ok', inconsistencies: [] }),
+        inputTokens: 10, outputTokens: 5, durationMs: 30,
+    };
+    const result = await sherlock.verify({
+        analysis: 'a', originalRequest: '?', systemState: 's',
+        commanderProvider: 'anthropic',
+        commanderModel: 'claude-opus-4-7',
+        pipelineDir: dir,
+        configLoader: defaultConfigLoader(),
+        completionClient: fakeCompletionClient({ ok: false, error: { type: 'should_not_be_called' } }),
+        spawnAnthropic: fakeSpawnAnthropic(okResp),
+        quotaModule: fakeQuotaAllPass(),
+        // Chain devuelve anthropic con modelo haiku (diferente al opus del commander).
+        dispatchModule: fakeDispatcher({ providerChain: [
+            { provider: 'anthropic', model: 'claude-haiku-4-5' },
+        ]}),
+        residencyModule: fakeResidencyOk(),
+    });
+    assert.equal(result.sameProvider, true, 'commander+sherlock=anthropic → same_provider=true');
+    assert.equal(result.sameModel, false, 'opus vs haiku → same_model=false');
+    assert.equal(result.modelSwap.swapped, false, 'modelos ya distintos → NO swap');
+    assert.equal(result.modelSwap.originalModel, null);
+    assert.equal(result.sherlockModel, 'claude-haiku-4-5');
+    // No debería aparecer evento sherlock_model_swap.
+    const entries = readAuditEntries(dir);
+    const swapEvt = entries.find(e => e.event === 'sherlock_model_swap');
+    assert.equal(swapEvt, undefined, 'sin swap → no debe persistirse evento sherlock_model_swap');
+});
+
+// =============================================================================
+// CA-15 — Swap Gemini: commander=gemini-google/gemini-2.0-flash, sherlock
+// chain devuelve gemini-google/gemini-2.0-flash (mismo modelo), agent-models
+// declara alternative_models=['gemini-1.5-flash'] → swap a gemini-1.5-flash,
+// evento sherlock_model_swap emitido con campos diferenciados.
+// =============================================================================
+test('#3501 CA-15: swap intra-provider en gemini-google emite sherlock_model_swap con campos diferenciados', async () => {
+    const dir = mkTmpPipelineDir();
+    writeAgentModelsFixture(dir);
+    const okResp = {
+        ok: true,
+        content: JSON.stringify({ verdict: 'ok', reason: 'ok', inconsistencies: [] }),
+        inputTokens: 10, outputTokens: 5, durationMs: 30,
+    };
+    const result = await sherlock.verify({
+        analysis: 'a', originalRequest: '?', systemState: 's',
+        commanderProvider: 'gemini-google',
+        commanderModel: 'gemini-2.0-flash',
+        pipelineDir: dir,
+        configLoader: defaultConfigLoader(),
+        completionClient: fakeCompletionClient(okResp),
+        quotaModule: fakeQuotaAllPass(),
+        // Chain devuelve gemini-google con el mismo modelo que el commander
+        // — debería disparar el swap.
+        dispatchModule: fakeDispatcher({ providerChain: [
+            { provider: 'gemini-google', model: 'gemini-2.0-flash' },
+        ]}),
+        residencyModule: fakeResidencyOk(),
+    });
+    assert.equal(result.sameProvider, true, 'commander+sherlock=gemini-google → same_provider=true');
+    assert.equal(result.sameModel, false, 'post-swap → sherlock pasa a usar gemini-1.5-flash, distinto del commander');
+    assert.equal(result.modelSwap.swapped, true, 'mismo provider+model → debe disparar swap');
+    assert.equal(result.modelSwap.originalModel, 'gemini-2.0-flash', 'originalModel = modelo del commander/resuelto antes del swap');
+    assert.equal(result.modelSwap.reason, 'same_model_avoidance');
+    assert.equal(result.sherlockModel, 'gemini-1.5-flash', 'sherlock resuelve al modelo alternativo declarado');
+    // Evento sherlock_model_swap debe estar persistido con campos diferenciados.
+    const entries = readAuditEntries(dir);
+    const swapEvt = entries.find(e => e.event === 'sherlock_model_swap');
+    assert.ok(swapEvt, 'evento sherlock_model_swap debe estar persistido');
+    assert.equal(swapEvt.swap_model_origen, 'gemini-2.0-flash');
+    assert.equal(swapEvt.swap_model_destino, 'gemini-1.5-flash');
+    assert.equal(swapEvt.swap_reason, 'same_model_avoidance');
+    assert.equal(swapEvt.same_provider, true);
+    assert.equal(swapEvt.same_model, false, 'post-swap same_model=false (sherlock pasó a alternativo)');
+});
+
+// =============================================================================
+// CA-16 (CA-SEC-SWAP-6) — Test validación schema: fixture con
+// `alternative_models: ['modelo-no-permitido']` → validador del boot rechaza
+// con exit code 2 (anti-regresión de la cross-validation SEC-1).
+// =============================================================================
+test('#3501 CA-16 (CA-SEC-SWAP-6): alternative_models con modelo fuera de ALLOWED_MODELS_BY_LAUNCHER → validate falla con exitCode 2', () => {
+    const validator = require('../agent-models-validate');
+    const cfg = {
+        $schema: './agent-models.schema.json',
+        default_provider: 'cerebras',
+        providers: {
+            cerebras: {
+                launcher: 'cerebras',
+                model: 'llama-3.3-70b',
+                spawn_args_template: ['--model', '{model}'],
+                output_parser: 'openai-sse',
+                quota_error_types: ['rate_limit_exceeded'],
+                supports_tool_use: false,
+                prompt_caching: { supported: false },
+                credentials_env: ['CEREBRAS_API_KEY'],
+                permissions_mode: 'bypassPermissions',
+                // Modelo fuera de ALLOWED_MODELS_BY_LAUNCHER['cerebras'].
+                alternative_models: ['modelo-no-permitido-inventado'],
+            },
+        },
+        skills: {
+            'backend-dev': { provider: 'cerebras' },
+        },
+    };
+    const tmpPath = path.join(os.tmpdir(), `sherlock-3501-swap6-${Date.now()}-${process.pid}.json`);
+    fs.writeFileSync(tmpPath, JSON.stringify(cfg));
+    const result = validator.validate(tmpPath);
+    fs.unlinkSync(tmpPath);
+    assert.equal(result.ok, false, 'validador debe rechazar modelo fuera de allowlist');
+    assert.equal(result.exitCode, 2, 'exit code 2 = INVALID_CONFIG');
+    const swapErr = result.errors.find(e => /alternative_models/.test(e.path));
+    assert.ok(swapErr, 'debe emitir error específico de alternative_models');
+    assert.match(swapErr.message, /ALLOWED_MODELS_BY_LAUNCHER/);
+});
+
+// =============================================================================
+// CA-17 — Invariante reelaboración intacto: ejercitar swap NO afecta el cap
+// hardcoded de reelaboraciones. Comprobamos:
+//   1. La constante HARDCODED_MAX_REELABORACIONES sigue siendo 1.
+//   2. Una verify() que dispara swap devuelve resultado funcionalmente
+//      idéntico al pre-swap (verdict, inconsistencias) — el swap NO se
+//      cuenta como reelaboración (asunto del caller, no del verifier).
+// =============================================================================
+test('#3501 CA-17: invariante cap reelaboración=1 intacto, swap NO consume budget', async () => {
+    // (1) La constante no cambió.
+    assert.equal(sherlock.HARDCODED_MAX_REELABORACIONES, 1,
+        'CA-SEC-9 invariante: cap reelaboración hardcoded sigue siendo 1');
+    // Defense-in-depth: la nueva constante HARDCODED_MAX_MODEL_SWAPS está
+    // separada y NO interfiere con la de reelaboración.
+    assert.equal(sherlock.HARDCODED_MAX_MODEL_SWAPS, 2,
+        'CA-SEC-SWAP-3 invariante: cap swap intra-provider=2 (independiente de reelaboración)');
+
+    // (2) Ejercitar swap y verificar que el resultado es funcional.
+    const dir = mkTmpPipelineDir();
+    writeAgentModelsFixture(dir);
+    const okResp = {
+        ok: true,
+        content: JSON.stringify({
+            verdict: 'rechazado',
+            reason: 'inconsistencia detectada por sherlock con modelo alternativo',
+            inconsistencies: [{ claim: 'X', contradiction: 'Y' }],
+        }),
+        inputTokens: 20, outputTokens: 10, durationMs: 50,
+    };
+    const result = await sherlock.verify({
+        analysis: 'a', originalRequest: '?', systemState: 's',
+        commanderProvider: 'cerebras',
+        commanderModel: 'llama-3.3-70b',
+        pipelineDir: dir,
+        configLoader: defaultConfigLoader({ sherlock_max_reelaboraciones: 99 }), // intento de bypass — clampado a 1.
+        completionClient: fakeCompletionClient(okResp),
+        quotaModule: fakeQuotaAllPass(),
+        dispatchModule: fakeDispatcher({ providerChain: [
+            { provider: 'cerebras', model: 'llama-3.3-70b' },
+        ]}),
+        residencyModule: fakeResidencyOk(),
+    });
+    // Swap se ejerció, NO afectó el flow funcional del verdict.
+    assert.equal(result.modelSwap.swapped, true);
+    assert.equal(result.sherlockModel, 'llama-3.1-70b');
+    assert.equal(result.verdict, 'rechazado');
+    assert.equal(result.inconsistencies.length, 1);
+    // El config loader debió aplicar el clamp a 1 igual que antes del swap.
+    const cfg = sherlock._loadSherlockConfig({
+        configLoader: defaultConfigLoader({ sherlock_max_reelaboraciones: 99 }),
+    });
+    assert.equal(cfg.maxReelaboraciones, 1, 'cap reelaboración clampado a 1 incluso con bypass de config');
+});
+
+// =============================================================================
+// CA-18 — Default-safe: provider SIN alternative_models declarado en
+// agent-models.json → comportamiento idéntico al actual post-#3484 (no swap,
+// se mantiene mismo provider/model — Leo aceptó adversariality reducida
+// 2026-05-22). Garantía de que el cambio es opt-in puro y NO regresiona el
+// flow de #3484 cuando no hay alternativos configurados.
+// =============================================================================
+test('#3501 CA-18: provider sin alternative_models → comportamiento idéntico al post-#3484 (default-safe, opt-in puro)', async () => {
+    const dir = mkTmpPipelineDir();
+    // Fixture override: cerebras SIN alternative_models.
+    writeAgentModelsFixture(dir, {
+        cerebras: {
+            launcher: 'cerebras',
+            model: 'llama-3.3-70b',
+            spawn_args_template: ['--model', '{model}'],
+            output_parser: 'openai-sse',
+            quota_error_types: ['rate_limit_exceeded'],
+            supports_tool_use: false,
+            prompt_caching: { supported: false },
+            credentials_env: ['CEREBRAS_API_KEY'],
+            permissions_mode: 'bypassPermissions',
+            // sin alternative_models → política inactiva
+        },
+    });
+    const okResp = {
+        ok: true,
+        content: JSON.stringify({ verdict: 'ok', reason: 'ok', inconsistencies: [] }),
+        inputTokens: 10, outputTokens: 5, durationMs: 30,
+    };
+    // Chain devuelve cerebras (mismo que commander). Sin alternative_models,
+    // el resolver acepta same_provider tal cual post-#3484 (NO fallback al
+    // siguiente provider — eso sería breaking change del flujo aceptado).
+    const result = await sherlock.verify({
+        analysis: 'a', originalRequest: '?', systemState: 's',
+        commanderProvider: 'cerebras',
+        commanderModel: 'llama-3.3-70b',
+        pipelineDir: dir,
+        configLoader: defaultConfigLoader(),
+        completionClient: fakeCompletionClient(okResp),
+        quotaModule: fakeQuotaAllPass(),
+        dispatchModule: fakeDispatcher({ providerChain: [
+            { provider: 'cerebras', model: 'llama-3.3-70b' },
+            { provider: 'nvidia-nim', model: 'deepseek-ai/deepseek-v4-pro' },
+        ]}),
+        residencyModule: fakeResidencyOk(),
+    });
+    // Sin alternative_models → NO swap, NO fallback al siguiente provider.
+    // El resolver mantiene cerebras+llama-3.3-70b (comportamiento post-#3484).
+    assert.equal(result.modelSwap.swapped, false, 'sin alternative_models → NO swap intra-provider');
+    assert.equal(result.sherlockProvider, 'cerebras', 'default-safe: NO fallback al siguiente provider (post-#3484)');
+    assert.equal(result.sherlockModel, 'llama-3.3-70b');
+    assert.equal(result.sameProvider, true, 'mismo provider preservado');
+    assert.equal(result.sameModel, true, 'mismo modelo preservado (adversariality reducida aceptada)');
+    // Evento sherlock_model_swap NO debe aparecer en este caso.
+    const entries = readAuditEntries(dir);
+    const swapEvt = entries.find(e => e.event === 'sherlock_model_swap');
+    assert.equal(swapEvt, undefined);
+    // CA-11: footer sin sufijo "swap desde".
+    const footer = sherlock.formatVerifiedFooter({
+        sherlockProvider: result.sherlockProvider,
+        sherlockModel: result.sherlockModel,
+        modelSwap: result.modelSwap,
+    });
+    assert.equal(footer, 'Verificado por: cerebras/llama-3.3-70b');
+    assert.ok(!/swap desde/.test(footer));
+});
+
+// =============================================================================
+// #3501 CA-11 — formatVerifiedFooter con swap: incluye sufijo "(swap desde
+// <model-origen>)" cuando aplica. Test del helper directamente (sin verify).
+// =============================================================================
+test('#3501 CA-11: formatVerifiedFooter incluye "(swap desde X)" cuando hubo swap, no agrega emojis ni tono celebratorio', () => {
+    // Caso swap.
+    const withSwap = sherlock.formatVerifiedFooter({
+        sherlockProvider: 'gemini-google',
+        sherlockModel: 'gemini-1.5-flash',
+        modelSwap: { swapped: true, originalModel: 'gemini-2.0-flash', reason: 'same_model_avoidance' },
+    });
+    assert.equal(withSwap, 'Verificado por: gemini-google/gemini-1.5-flash (swap desde gemini-2.0-flash)');
+    // Sin emojis.
+    assert.ok(!/[\u{1F300}-\u{1FAFF}]/u.test(withSwap), 'no debe contener emojis (UX-G1: tono natural, no celebratorio)');
+
+    // Caso sin swap.
+    const noSwap = sherlock.formatVerifiedFooter({
+        sherlockProvider: 'anthropic',
+        sherlockModel: 'claude-haiku-4-5',
+        modelSwap: { swapped: false, originalModel: null, reason: null },
+    });
+    assert.equal(noSwap, 'Verificado por: anthropic/claude-haiku-4-5');
+
+    // Caso degenerado: sin sherlockProvider → string vacío (caller decide no agregar).
+    assert.equal(sherlock.formatVerifiedFooter({ sherlockProvider: null }), '');
+});

--- a/.pipeline/lib/agent-models-validate.js
+++ b/.pipeline/lib/agent-models-validate.js
@@ -133,11 +133,23 @@ const ALLOWED_MODELS_BY_LAUNCHER = Object.freeze({
     'gpt-5-codex',
     'gpt-5',
   ]),
+  // #3501 — `gemini-1.5-flash` se agrega como modelo alternativo del provider
+  // gemini-google para que Sherlock pueda preservar adversariality parcial
+  // cuando coincide en provider con el Commander. La policy de swap intra-provider
+  // vive en lib/sherlock-verifier.js::resolveSherlockProvider (CA-3); la
+  // declaración del modelo como alternative_models vive en agent-models.json.
   'gemini-google': Object.freeze([
     'gemini-2.0-flash',
+    'gemini-1.5-flash',
   ]),
+  // #3501 — `llama-3.1-70b` se agrega como modelo alternativo del provider
+  // cerebras (mismo motivo que arriba). Cerebras Cloud lo expone como modelo
+  // de generación anterior, estable y con el mismo tokenizer base que el
+  // default `llama-3.3-70b` — apto para swap intra-provider sin cambios de
+  // prompt template.
   cerebras: Object.freeze([
     'llama-3.3-70b',
+    'llama-3.1-70b',
   ]),
   // #3243 — NVIDIA NIM expone modelos hosted con naming `vendor/model`. La
   // allowlist se inicializa con los 2 modelos sign-off del issue (DeepSeek
@@ -483,6 +495,54 @@ function validateCrossReferences(config) {
             message: `model "${safeValue}" no está en ALLOWED_MODELS_BY_LAUNCHER["${providerDef.launcher}"] (válidos: [${allowedModels.join(', ')}])`,
             fix: 'usar uno de los modelos soportados por el launcher o agregar el nuevo a ALLOWED_MODELS_BY_LAUNCHER en lib/agent-models-validate.js (decisión de plataforma — requiere review)',
           });
+        }
+      }
+      // #3501 CA-SEC-SWAP-1 — alternative_models[] debe estar en
+      // ALLOWED_MODELS_BY_LAUNCHER del launcher del provider. Defensa
+      // anti-supply-chain idéntica a la de `model` y `model_override`:
+      // un atacante con write-access al config no puede declarar un
+      // modelo arbitrario fuera de la allowlist para swap intra-provider.
+      //
+      // Anti-leak: si el valor matchea un patrón de secret hardcoded
+      // conocido, se redacta con [REDACTED]. Mismo patrón que `model`.
+      //
+      // Defense in depth contra el cap del schema (maxItems: 3): aunque
+      // ajv ya capea por items.maxItems, validamos cada item igual para
+      // que un swap del schema no abra ventana de bypass.
+      if (providerDef && Array.isArray(providerDef.alternative_models)
+          && typeof providerDef.launcher === 'string') {
+        const allowedModels = ALLOWED_MODELS_BY_LAUNCHER[providerDef.launcher];
+        for (let i = 0; i < providerDef.alternative_models.length; i++) {
+          const altModel = providerDef.alternative_models[i];
+          if (typeof altModel !== 'string' || altModel.length === 0) {
+            // Schema ya rechaza, defense in depth.
+            errors.push({
+              path: `#/providers/${key}/alternative_models/${i}`,
+              message: `alternative_models[${i}] debe ser string no vacío`,
+              fix: 'declarar un modelo válido o quitar el item',
+            });
+            continue;
+          }
+          // El default del provider NO debería estar en alternative_models —
+          // sería un no-op (swap a sí mismo). Marcamos para que el operador
+          // limpie la config.
+          if (providerDef.model && altModel === providerDef.model) {
+            errors.push({
+              path: `#/providers/${key}/alternative_models/${i}`,
+              message: `alternative_models[${i}]="${altModel}" duplica el model default del provider — no aporta adversariality`,
+              fix: `quitar "${altModel}" de alternative_models — el swap a sí mismo es no-op`,
+            });
+            continue;
+          }
+          if (Array.isArray(allowedModels) && allowedModels.length > 0
+              && !allowedModels.includes(altModel)) {
+            const safeValue = looksLikeSecret(altModel) ? '[REDACTED]' : altModel;
+            errors.push({
+              path: `#/providers/${key}/alternative_models/${i}`,
+              message: `alternative_models[${i}]="${safeValue}" no está en ALLOWED_MODELS_BY_LAUNCHER["${providerDef.launcher}"] (válidos: [${allowedModels.join(', ')}])`,
+              fix: 'usar uno de los modelos soportados por el launcher o agregar el nuevo a ALLOWED_MODELS_BY_LAUNCHER en lib/agent-models-validate.js (decisión de plataforma — requiere review)',
+            });
+          }
         }
       }
     }

--- a/.pipeline/lib/commander/multi-provider.js
+++ b/.pipeline/lib/commander/multi-provider.js
@@ -398,6 +398,13 @@ function auditCommanderRequest(opts = {}) {
         commanderModel,
         sherlockModel,
         transport,
+        // #3501 CA-5 — Campos específicos del evento `sherlock_model_swap`.
+        // Solo se incluyen cuando el caller (sherlock-verifier) los provee
+        // para que el operador pueda filtrar con jq sin parser ad-hoc:
+        //   jq 'select(.event=="sherlock_model_swap" and .provider_effective=="gemini-google")'
+        swapModelOrigen,
+        swapModelDestino,
+        swapReason,
         // inyectables tests
         fsImpl,
         auditLog,
@@ -433,6 +440,11 @@ function auditCommanderRequest(opts = {}) {
         commander_model: commanderModel || null,
         sherlock_model: sherlockModel || null,
         transport: transport || null,
+        // #3501 CA-5 — Campos del evento de swap. Para eventos que NO sean
+        // `sherlock_model_swap` quedan en null y no afectan el shape canónico.
+        swap_model_origen: swapModelOrigen || null,
+        swap_model_destino: swapModelDestino || null,
+        swap_reason: swapReason || null,
     };
 
     try {

--- a/.pipeline/lib/sherlock-verifier.js
+++ b/.pipeline/lib/sherlock-verifier.js
@@ -110,6 +110,15 @@ const SHERLOCK_CASCADE_MAX_ATTEMPTS_PER_PROVIDER = 2;
 // Invariante CA-SEC-9 — hardcoded, NO depende de config.
 const HARDCODED_MAX_REELABORACIONES = 1;
 
+// #3501 CA-SEC-SWAP-3 — cap runtime de swaps intra-provider dentro de una
+// misma verificación. Defense in depth aunque el schema ya capea
+// `alternative_models` con `maxItems: 3`. Si alguien sube el cap del schema
+// más adelante, esta constante sigue protegiendo al runtime.
+//
+// El swap intra-provider NO consume budget de reelaboración (CA-9): es una
+// elección de modelo dentro de la misma verificación, no un nuevo turn.
+const HARDCODED_MAX_MODEL_SWAPS = 2;
+
 // Cap defensivo de inconsistencias aceptadas en el output del Sherlock
 // (CA-SEC-6). Si el modelo dice "encontré 50 inconsistencias", recortamos
 // a las primeras 5. Más que eso es ruido o intento de DoS de payload.
@@ -326,6 +335,35 @@ function parseAndValidateSherlockOutput(raw) {
 }
 
 // -----------------------------------------------------------------------------
+// readAlternativeModelsForProvider — lee `alternative_models[]` del provider
+// desde `agent-models.json`. Devuelve `[]` si el provider no lo declara o
+// si el archivo no se puede leer (default-safe: política inactiva).
+//
+// #3501 CA-4 — el comportamiento default cuando el provider no declara
+// alternative_models es "caer al siguiente provider" (no-op de la policy).
+//
+// Best-effort: cualquier error de lectura/parse devuelve `[]` para que el
+// resolver no rompa por config inválida (validador ya hace fail-fast al boot).
+// -----------------------------------------------------------------------------
+function readAlternativeModelsForProvider(provider, { pipelineDir, fsImpl }) {
+    if (!provider || !pipelineDir) return [];
+    const _fs = fsImpl || fs;
+    try {
+        const modelsPath = path.join(pipelineDir, 'agent-models.json');
+        if (!_fs.existsSync(modelsPath)) return [];
+        const raw = JSON.parse(_fs.readFileSync(modelsPath, 'utf8'));
+        const providerDef = raw && raw.providers && raw.providers[provider];
+        if (!providerDef || !Array.isArray(providerDef.alternative_models)) return [];
+        // Filtramos defensivamente: solo strings no vacíos.
+        return providerDef.alternative_models.filter(
+            (m) => typeof m === 'string' && m.length > 0
+        );
+    } catch {
+        return [];
+    }
+}
+
+// -----------------------------------------------------------------------------
 // resolveSherlockProvider — encuentra el primer provider de la chain
 // `telegram-sherlock` que tenga handler implementado en Sherlock (HTTP o
 // spawn). Itera agregando providers no-soportados a la lista de excluidos
@@ -335,12 +373,30 @@ function parseAndValidateSherlockOutput(raw) {
 // mismo provider que el Commander — se acepta adversariality reducida y se
 // registra `same_provider` en el audit log (CA-AUDIT-1).
 //
-// Devuelve `{provider, model, transport: 'http'|'spawn'}` o `null` si no
-// hay candidato implementado en toda la chain.
+// #3501 CA-3 — Si el resolved coincide en provider+model con el Commander
+// (same_provider && same_model), antes de excluir el provider entero se
+// intenta swap a un modelo declarado en `alternative_models[]` del mismo
+// provider (orden declarado). Solo si se agotan los alternativos sin éxito
+// se cae al siguiente provider de la chain (CA-4 default-safe).
+//
+// CA-SEC-SWAP-3 — máximo HARDCODED_MAX_MODEL_SWAPS swaps intra-provider
+// dentro de una verificación (defense in depth aunque el schema capea
+// `alternative_models` con maxItems: 3).
+//
+// Devuelve `{provider, model, transport, originalModel?, swapped?, swapReason?}`
+// o `null` si no hay candidato implementado en toda la chain.
+//   - `originalModel`: si hubo swap, el modelo que el resolver hubiera elegido
+//     sin la policy (necesario para el footer Telegram CA-11 y el audit
+//     event CA-5).
+//   - `swapped`: true si se eligió un modelo de alternative_models[].
+//   - `swapReason`: 'same_model_avoidance' (único valor por ahora; futuro
+//     podría agregar 'user_preference' si se implementa #3501 deferred).
 // -----------------------------------------------------------------------------
 function resolveSherlockProvider({
     excludedProvider,  // mantenido en signature por back-compat; ignorado (#3484)
-    initialExcluded,   // #3558 — providers ya intentados por la cascada
+    commanderProvider,  // #3501 — para detectar same_provider+same_model
+    commanderModel,     // #3501 — para detectar same_provider+same_model
+    initialExcluded,    // #3558 — providers ya intentados por la cascada
     pipelineDir,
     log,
     quotaModule,
@@ -391,32 +447,88 @@ function resolveSherlockProvider({
         if (!res || !res.provider || res.gated) {
             return null;
         }
-        if (HTTP_COMPLETION_PROVIDERS.has(res.provider)) {
-            return {
-                provider: res.provider,
-                model: res.model || null,
-                transport: 'http',
-                source: res.source,
-                fallbackUsed: res.fallbackUsed,
-                chainTried: res.chainTried,
-            };
+        const transport = HTTP_COMPLETION_PROVIDERS.has(res.provider)
+            ? 'http'
+            : SPAWN_COMPLETION_PROVIDERS.has(res.provider)
+                ? 'spawn'
+                : null;
+
+        if (!transport) {
+            // Provider sin handler en Sherlock (ej. openai-codex stub #3076) —
+            // excluir y seguir con el próximo de la chain.
+            if (typeof log === 'function') {
+                log('sherlock', `provider ${res.provider} no tiene handler en Sherlock — fallback al siguiente`);
+            }
+            excluded.add(res.provider);
+            continue;
         }
-        if (SPAWN_COMPLETION_PROVIDERS.has(res.provider)) {
-            return {
-                provider: res.provider,
-                model: res.model || null,
-                transport: 'spawn',
-                source: res.source,
-                fallbackUsed: res.fallbackUsed,
-                chainTried: res.chainTried,
-            };
+
+        // #3501 CA-3 — policy de swap intra-provider. Solo dispara cuando
+        // coinciden provider Y model con el Commander. Si solo coincide el
+        // provider (distinto model — caso anthropic opus↔haiku via config
+        // #3221), NO disparamos swap: la diferenciación de modelo ya está
+        // resuelta declarativamente. El comportamiento es "respetar lo que
+        // el resolver de la chain devolvió".
+        const sameProvider = !!(commanderProvider && commanderProvider === res.provider);
+        const sameModel = !!(sameProvider && commanderModel && res.model && commanderModel === res.model);
+
+        if (sameProvider && sameModel) {
+            const alternatives = readAlternativeModelsForProvider(res.provider, { pipelineDir, fsImpl });
+            // Excluimos el modelo que ya tenemos (el del Commander) por si
+            // alguien lo declaró por error en alternative_models — defense in
+            // depth aunque el validator ya lo rechaza.
+            const candidates = alternatives.filter((m) => m !== res.model);
+            // CA-3 — si hay candidatos, swap al primero disponible (los
+            // restantes son tail-options para futuras razones de swap).
+            // CA-SEC-SWAP-3 — el loop iterativo está capado por
+            // HARDCODED_MAX_MODEL_SWAPS aunque por ahora el primer return
+            // siempre dispara con candidates[0].
+            for (let s = 0; s < Math.min(candidates.length, HARDCODED_MAX_MODEL_SWAPS); s++) {
+                const altModel = candidates[s];
+                if (typeof log === 'function') {
+                    log('sherlock', `🔄 swap intra-provider (${res.provider}): ${res.model} → ${altModel} (same_model_avoidance, #3501)`);
+                }
+                return {
+                    provider: res.provider,
+                    model: altModel,
+                    transport,
+                    source: res.source,
+                    fallbackUsed: res.fallbackUsed,
+                    chainTried: res.chainTried,
+                    swapped: true,
+                    originalModel: res.model,
+                    swapReason: 'same_model_avoidance',
+                };
+            }
+            // CA-4 default-safe: si el provider NO declara alternative_models
+            // (o la lista efectiva está vacía después de filtrar el mismo
+            // modelo), se mantiene el mismo provider — comportamiento idéntico
+            // al post-#3484 (Leo aceptó adversariality reducida 2026-05-22).
+            // NO se cae al siguiente provider de la chain: el opt-in puro
+            // significa que un provider sin alternativos sigue funcionando
+            // exactamente como antes del #3501.
+            //
+            // El audit log ya registra `same_provider:true, same_model:true`
+            // via el flujo principal de verify(); la observabilidad existe
+            // para que el operador pueda detectar gaps de cobertura.
+            if (typeof log === 'function') {
+                log('sherlock', `same_provider+same_model con ${res.provider}/${res.model} y sin alternative_models — manteniendo same_provider (default-safe post-#3484)`);
+            }
+            // Fall through al return base (sin swap).
         }
-        // Provider sin handler en Sherlock (ej. openai-codex stub #3076) —
-        // excluir y seguir con el próximo de la chain.
-        if (typeof log === 'function') {
-            log('sherlock', `provider ${res.provider} no tiene handler en Sherlock — fallback al siguiente`);
-        }
-        excluded.add(res.provider);
+
+        // Resolved usable sin swap.
+        return {
+            provider: res.provider,
+            model: res.model || null,
+            transport,
+            source: res.source,
+            fallbackUsed: res.fallbackUsed,
+            chainTried: res.chainTried,
+            swapped: false,
+            originalModel: null,
+            swapReason: null,
+        };
     }
     return null;
 }
@@ -609,6 +721,12 @@ function emitAuditEvent({ pipelineDir, event, payload, fsImpl, auditLog, now }) 
             commanderModel: payload && payload.commanderModel || null,
             sherlockModel: payload && payload.sherlockModel || null,
             transport: payload && payload.transport || null,
+            // #3501 CA-5 — Campos del evento `sherlock_model_swap`. Cuando el
+            // evento NO es de swap, vienen null/undefined y el audit los
+            // registra como null sin afectar el shape canónico.
+            swapModelOrigen: payload && payload.swapModelOrigen || null,
+            swapModelDestino: payload && payload.swapModelDestino || null,
+            swapReason: payload && payload.swapReason || null,
             fsImpl,
             auditLog,
             now,
@@ -757,8 +875,15 @@ async function verify(opts = {}) {
     // Resolución de provider — itera la chain telegram-sherlock. #3484:
     // YA NO se excluye al commanderProvider; solo se saltan providers que
     // no tienen handler implementado en Sherlock.
+    //
+    // #3501 CA-3 — Si el resolved coincide en provider+model con el
+    // Commander, el resolver intenta swap a un modelo de
+    // `alternative_models[]` del provider antes de saltar al siguiente.
+    // Para eso necesita commanderProvider+commanderModel.
     const resolved = resolveSherlockProvider({
         excludedProvider: null,
+        commanderProvider,
+        commanderModel,
         pipelineDir,
         log: _log,
         quotaModule,
@@ -810,6 +935,40 @@ async function verify(opts = {}) {
         _log('sherlock', `🔍 same_provider=true (commander=${commanderProvider}/${commanderModel || '?'}, sherlock=${resolved.provider}/${resolved.model || '?'}) — adversariality reducida (#3484 riesgo aceptado)`);
     }
 
+    // #3501 CA-5 — Evento de audit `sherlock_model_swap` cuando el resolver
+    // ejerció la policy de swap intra-provider. El payload lleva los campos
+    // diferenciados (provider, model_origen, model_destino, razon) que el
+    // operador puede filtrar con `jq` desde el JSONL sin parser ad-hoc.
+    //
+    // CA-10 — los hashes sensibles (analysisHash) se aplican via hashFor() en
+    // emitAuditEvent, igual que el resto de eventos sherlock_*. El swap no
+    // expone el contenido del análisis al log.
+    if (resolved.swapped) {
+        emitAuditEvent({
+            pipelineDir, fsImpl, auditLog, now: _now,
+            event: 'sherlock_model_swap',
+            payload: {
+                analysisHash: hashFor(analysis),
+                commanderProvider,
+                commanderModel,
+                sherlockProvider: resolved.provider,
+                durationMs: Date.now() - startedAt,
+                errorCode: null,
+                // CA-AUDIT-1 (#3484) — campos enriched. sameProvider sigue
+                // siendo true (no cambió el provider); sameModel ahora es
+                // false (porque el swap a otro modelo del provider lo evitó).
+                sameProvider: true,
+                sameModel: false,
+                sherlockModel: resolved.model,
+                transport: resolved.transport,
+                // #3501 CA-5 — campos diferenciados específicos del swap.
+                swapModelOrigen: resolved.originalModel,
+                swapModelDestino: resolved.model,
+                swapReason: resolved.swapReason || 'same_model_avoidance',
+            },
+        });
+    }
+
     // CA-SEC-3 — data-residency fail-closed ANTES del provider call.
     const drCheck = commanderMP.enforceDataResidency({
         pipelineDir,
@@ -858,6 +1017,11 @@ async function verify(opts = {}) {
             outputTokens: 0,
             errorCode: 'residency_blocked',
             suggestedDisclaimer: DISCLAIMER_TYPES.TIMEOUT_OR_NO_PROVIDER,
+            // #3501 — el swap inicial (si lo hubo) sigue siendo informativo
+            // aunque la residency haya bloqueado antes de despachar.
+            modelSwap: resolved.swapped
+                ? { swapped: true, originalModel: resolved.originalModel, reason: resolved.swapReason || 'same_model_avoidance' }
+                : { swapped: false, originalModel: null, reason: null },
         };
     }
 
@@ -1024,6 +1188,15 @@ async function verify(opts = {}) {
 
     const totalMs = Date.now() - startedAt;
 
+    // #3501 — `modelSwap` describe la decisión del resolver inicial (swap
+    // intra-provider via alternative_models[]). Si la cascada (#3558) terminó
+    // cayendo a un provider/modelo distinto del swap inicial, ese swap ya no
+    // refleja lo que el usuario está viendo — se recalibra abajo en el success
+    // path. Para los error paths basta con el snapshot del intento inicial.
+    const initialModelSwap = resolved.swapped
+        ? { swapped: true, originalModel: resolved.originalModel, reason: resolved.swapReason || 'same_model_avoidance' }
+        : { swapped: false, originalModel: null, reason: null };
+
     // 4. Manejar el resultado.
     if (!cascadeResult.ok) {
         // CA-F5 — DISCLAIMER_F6 SOLO cuando la cascada agota o se gatilla el cap.
@@ -1072,6 +1245,10 @@ async function verify(opts = {}) {
             outputTokens: 0,
             errorCode: cascadeResult.errorCode,
             suggestedDisclaimer: DISCLAIMER_TYPES.TIMEOUT_OR_NO_PROVIDER,
+            // #3501 — describe el swap intentado en la resolución inicial,
+            // aunque la cascada haya agotado sin éxito.
+            modelSwap: initialModelSwap,
+            // CA-F4 (#3558) — campos enriched de cascada.
             attemptCount: cascadeResult.attemptsCount,
             fallbackUsed: cascadeResult.fallbackUsed,
             chainTried: cascadeResult.chainTried,
@@ -1087,6 +1264,18 @@ async function verify(opts = {}) {
     const finalTransport = cascadeResult.transportUsed;
     const finalSameProvider = !!(commanderProvider && finalProvider && commanderProvider === finalProvider);
     const finalSameModel = !!(finalSameProvider && commanderModel && finalModel && commanderModel === finalModel);
+
+    // #3501 — Recalibrar `modelSwap` contra el resultado FINAL de la cascada.
+    // El swap intra-provider del resolver inicial solo refleja lo que el usuario
+    // ve si la cascada terminó en el mismo provider+modelo donde el resolver
+    // swapeó. Si cayó a otro modelo (rotación cascade) u otro provider
+    // (fallback), el "(swap desde X)" del footer (CA-11) sería engañoso, así
+    // que reportamos `swapped:false` en esos casos.
+    const finalModelSwap = (initialModelSwap.swapped
+            && finalProvider === resolved.provider
+            && finalModel === resolved.model)
+        ? initialModelSwap
+        : { swapped: false, originalModel: null, reason: null };
 
     // CA-SEC-8 — solo hashes en el audit log (claim/contradiction nunca crudos).
     const claimHashes = parsed.data.inconsistencies.map(it => hashFor(it.claim));
@@ -1136,6 +1325,9 @@ async function verify(opts = {}) {
         suggestedDisclaimer: DISCLAIMER_TYPES.NONE, // el caller decide F-5 vs nada
         claimHashes,
         contradictionHashes,
+        // #3501 — `finalModelSwap` se calculó arriba para reflejar si el swap
+        // intra-provider del resolver inicial se mantuvo en el resultado final.
+        modelSwap: finalModelSwap,
         // CA-F4 (#3558) — campos enriched de cascada disponibles para el caller.
         attemptCount: cascadeResult.attemptsCount,
         fallbackUsed: cascadeResult.fallbackUsed,
@@ -1155,6 +1347,34 @@ function applyDisclaimer(text, disclaimerType) {
         return String(text || '') + DISCLAIMER_F6_VERIFICATION_FAILED;
     }
     return String(text || '');
+}
+
+// -----------------------------------------------------------------------------
+// formatVerifiedFooter — #3501 CA-11. Formato plano para el footer Telegram
+// cuando Sherlock verificó (no es disclaimer, es informativo).
+//
+// Reglas UX (CA-UX-SWAP-1):
+//   - UNA línea, sin emojis, sin tono celebratorio.
+//   - Formato base: "Verificado por: <provider>/<model>"
+//   - Si hubo swap: " (swap desde <model-origen>)" al final
+//   - Si NO hubo swap: el footer se mantiene neutro (mismo formato sin sufijo)
+//
+// Respeta `feedback_telegram-messages-natural.md`: la diferencia (swap vs
+// no-swap) es informativa, no celebratoria. El caller (pulpo.js) decide si
+// agregar el footer al mensaje según política (ej. solo cuando swap, o
+// siempre).
+//
+// Devuelve string vacío si faltan datos mínimos — el caller no agrega línea.
+// -----------------------------------------------------------------------------
+function formatVerifiedFooter({ sherlockProvider, sherlockModel, modelSwap }) {
+    if (!sherlockProvider) return '';
+    const base = sherlockModel
+        ? `Verificado por: ${sherlockProvider}/${sherlockModel}`
+        : `Verificado por: ${sherlockProvider}`;
+    if (modelSwap && modelSwap.swapped && modelSwap.originalModel) {
+        return `${base} (swap desde ${modelSwap.originalModel})`;
+    }
+    return base;
 }
 
 // -----------------------------------------------------------------------------
@@ -1180,9 +1400,13 @@ module.exports = {
     verify,
     applyDisclaimer,
     recordToggleAttempt,
+    // #3501 CA-11 — helper para footer Telegram informativo.
+    formatVerifiedFooter,
 
     // constantes
     HARDCODED_MAX_REELABORACIONES,
+    // #3501 CA-SEC-SWAP-3 — invariante runtime de swaps intra-provider.
+    HARDCODED_MAX_MODEL_SWAPS,
     DEFAULT_TIMEOUT_MS,
     MAX_INCONSISTENCIES,
     HTTP_COMPLETION_PROVIDERS,
@@ -1206,4 +1430,5 @@ module.exports = {
     _parseAndValidateSherlockOutput: parseAndValidateSherlockOutput,
     _resolveSherlockProvider: resolveSherlockProvider,
     _spawnAnthropicComplete: spawnAnthropicComplete,
+    _readAlternativeModelsForProvider: readAlternativeModelsForProvider,
 };

--- a/docs/pipeline/multi-provider.md
+++ b/docs/pipeline/multi-provider.md
@@ -19,7 +19,7 @@
 9. [Modo degradado del Commander (sin LLM)](#9-modo-degradado-del-commander-sin-llm) — `/quota`, cooldown destructivo, gate texto libre.
 10. [Parser robusto de errores in-flight del Commander (#3434)](#10-parser-robusto-de-errores-in-flight-del-commander-3434) — receta para agregar provider, threat model, anti-patterns.
 11. [Fallback in-flight del Commander (#3275)](#11-fallback-in-flight-del-commander-3275) — gate UX, dedupe, tests.
-12. [Sherlock verifier — timeout y providers (#3484)](#12-sherlock-verifier--timeout-y-providers-3484) — opción B spawn-CLI, timeout cap, soft-timeout, audit enriquecido.
+12. [Sherlock verifier — timeout y providers (#3484)](#12-sherlock-verifier--timeout-y-providers-3484) — opción B spawn-CLI, timeout cap, soft-timeout, audit enriquecido. §12.8 cubre swap intra-provider para preservar adversariality (#3501).
 
 > **Convención:** todos los paths `.pipeline/...` son relativos a la raíz del repo (`C:\Workspaces\Intrale\platform\`). Todos los comandos asumen Node.js 21 disponible en PATH.
 
@@ -1743,6 +1743,105 @@ Correr:
 node --test .pipeline/lib/__tests__/sherlock-verifier.test.js
 node --test .pipeline/lib/__tests__/completion-client.test.js
 ```
+
+### 12.8 Swap intra-provider para preservar adversariality (#3501)
+
+Mejora incremental sobre §12.4. Cuando Sherlock termina usando el mismo provider y el mismo modelo que el Commander, la policy de swap intra-provider intenta diferenciar el modelo (dentro del mismo provider) antes de aceptar la coincidencia. Esto recupera adversariality parcial — un blind-spot de `claude-opus-4-7` no necesariamente coincide con el de `claude-haiku-4-5` por diferencias en distillation, training data y temperature defaults.
+
+#### Comportamiento
+
+| Caso | Antes (#3484) | Post-#3501 |
+|---|---|---|
+| `commander=anthropic/opus`, sherlock chain ofrece `anthropic/haiku` (config #3221) | `same_provider:true`, `same_model:false` — sherlock usa haiku, NO dispara swap | Igual — el `model_override` ya diferencia, swap es no-op |
+| `commander=gemini-google/gemini-2.0-flash`, chain ofrece `gemini-google/gemini-2.0-flash` (mismo modelo) | `same_provider:true`, `same_model:true` — adversariality reducida aceptada | El resolver lee `alternative_models[]` del provider y elige `gemini-1.5-flash`; emite `sherlock_model_swap`. Resultado final: `sameModel:false` |
+| `commander=cerebras/llama-3.3-70b`, chain ofrece `cerebras/llama-3.3-70b`, provider SIN `alternative_models` declarado | `same_provider:true`, `same_model:true` — aceptado | Igual — default-safe, política inactiva (opt-in puro) |
+
+#### Cómo configurarlo
+
+En `agent-models.json` se declara `alternative_models: string[]` opcional dentro de `providers.<name>`:
+
+```json
+{
+  "providers": {
+    "gemini-google": {
+      "model": "gemini-2.0-flash",
+      "alternative_models": ["gemini-1.5-flash"]
+    },
+    "cerebras": {
+      "model": "llama-3.3-70b",
+      "alternative_models": ["llama-3.1-70b"]
+    }
+  }
+}
+```
+
+Cada modelo de `alternative_models[]` debe estar en `ALLOWED_MODELS_BY_LAUNCHER` de `lib/agent-models-validate.js`. Si declarás un modelo fuera de la allowlist, el boot del pulpo aborta con exit code 2 (defensa anti-supply-chain, CA-SEC-SWAP-1).
+
+#### Default-safe
+
+- Provider SIN `alternative_models` → la policy es inactiva. El comportamiento es idéntico a §12.4 (acepta `same_provider:true, same_model:true` como riesgo aceptado).
+- Provider CON `alternative_models` vacío después de filtrar el modelo del Commander → idem (la policy no encuentra candidato real, mantiene mismo provider).
+- `anthropic` y `openai-codex` no declaran `alternative_models` porque su diferenciación de modelo ya está resuelta vía `model_override` en `skills.telegram-sherlock` (config #3221). `telegram-commander` apunta a `claude-opus-4-7`, `telegram-sherlock` a `claude-haiku-4-5` — `sameProvider:true`, `sameModel:false` sin necesidad de swap.
+
+#### Caps defensivos
+
+- `maxItems: 3` en el schema sobre `alternative_models[]` — anti-cost-amplification (CA-SEC-SWAP-2).
+- `HARDCODED_MAX_MODEL_SWAPS = 2` en runtime — defense in depth, cap independiente del schema (CA-SEC-SWAP-3).
+- El swap **NO** consume budget de reelaboración (CA-SEC-9 invariante `HARDCODED_MAX_REELABORACIONES=1` intacto). El swap ocurre dentro de la misma verificación, no es un turn nuevo (CA-SEC-SWAP-4).
+
+#### Evento de audit `sherlock_model_swap`
+
+Cuando dispara la policy, emite una entry adicional al JSONL del día:
+
+```json
+{
+  "event": "sherlock_model_swap",
+  "provider_effective": "gemini-google",
+  "swap_model_origen": "gemini-2.0-flash",
+  "swap_model_destino": "gemini-1.5-flash",
+  "swap_reason": "same_model_avoidance",
+  "same_provider": true,
+  "same_model": false,
+  "commander_model": "gemini-2.0-flash",
+  "sherlock_model": "gemini-1.5-flash",
+  "transport": "http"
+}
+```
+
+Filtrado típico para análisis operativo:
+
+```bash
+jq 'select(.event=="sherlock_model_swap")' .pipeline/logs/commander-dispatch-*.jsonl
+
+# Frecuencia de swap por provider (última semana)
+jq -r 'select(.event=="sherlock_model_swap") | .provider_effective' \
+  .pipeline/logs/commander-dispatch-*.jsonl | sort | uniq -c
+```
+
+#### UX en Telegram (CA-11)
+
+`lib/sherlock-verifier.js::formatVerifiedFooter()` produce una línea informativa para el caller (pulpo.js) cuando Sherlock verifica:
+
+- Sin swap: `Verificado por: anthropic/claude-haiku-4-5`
+- Con swap: `Verificado por: gemini-google/gemini-1.5-flash (swap desde gemini-2.0-flash)`
+
+Reglas UX (CA-UX-SWAP-1): UNA línea, sin emojis, sin tono celebratorio. La diferencia es informativa, no celebratoria — respeta `feedback_telegram-messages-natural.md` y `project_v3-efficiency-priority.md`.
+
+#### Métrica de éxito (post-merge, ventana 1-2 semanas)
+
+- `same_provider:true` mantiene el orden de magnitud actual (no se penaliza por el cambio).
+- `same_model:true` cae a < 20 % del subset `same_provider:true` (objetivo del #3501).
+- Evento `sherlock_model_swap` aparece al menos una vez por provider que declare `alternative_models` (prueba de que la policy se ejercita).
+- Cero incidentes de boot abortado por `alternative_models` mal declarado (gracias a CA-SEC-SWAP-1).
+
+#### Tests
+
+- `#3501 CA-14`: anthropic opus↔haiku via config #3221 NO dispara swap (modelos ya distintos).
+- `#3501 CA-15`: swap intra-provider en gemini-google emite `sherlock_model_swap` con campos diferenciados.
+- `#3501 CA-16 (CA-SEC-SWAP-6)`: `alternative_models` con modelo fuera de allowlist → `validate()` exit code 2.
+- `#3501 CA-17`: invariante cap reelaboración=1 intacto, swap NO consume budget.
+- `#3501 CA-18`: provider sin `alternative_models` → comportamiento post-#3484 preservado (default-safe, opt-in puro).
+- `#3501 CA-11`: `formatVerifiedFooter` incluye `(swap desde X)` cuando aplica.
 
 ---
 


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 8 archivos · +776 -33

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:passed` aplicado por delivery

## Closes

Closes #3501
