### PR TITLE
[security] Atomic writes + lock + desync-detector para waves.json (#3518)

### DIFF
--- a/.pipeline/lib/__tests__/desync-detector.test.js
+++ b/.pipeline/lib/__tests__/desync-detector.test.js
@@ -1,0 +1,186 @@
+// =============================================================================
+// desync-detector.test.js — Tests de lib/desync-detector.js (issue #3518 CA-6).
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+function setupTmp() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'desync-test-'));
+    process.env.PIPELINE_DIR_OVERRIDE = dir;
+    delete require.cache[require.resolve('../desync-detector')];
+    delete require.cache[require.resolve('../notify-telegram')];
+    const mod = require('../desync-detector');
+    return { dir, mod };
+}
+
+function teardownTmp(dir) {
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+    delete process.env.PIPELINE_DIR_OVERRIDE;
+}
+
+function writeWaves(dir, activeIssues) {
+    fs.writeFileSync(path.join(dir, 'waves.json'), JSON.stringify({
+        version: '1.0',
+        meta: { updated_at: new Date().toISOString(), updated_by: 't', source: 't' },
+        active_wave: {
+            number: 1,
+            name: 'test',
+            issues: activeIssues,
+        },
+        planned_waves: [],
+        archived_waves: [],
+        dependencies: [],
+    }));
+}
+
+function writePartial(dir, allowedIssues) {
+    fs.writeFileSync(path.join(dir, '.partial-pause.json'), JSON.stringify({
+        allowed_issues: allowedIssues,
+        created_at: new Date().toISOString(),
+        source: 't',
+    }));
+}
+
+test('detectDesync: estado inicial vacío → no desync', () => {
+    const { dir, mod } = setupTmp();
+    try {
+        const res = mod.detectDesync({ skipAlert: true });
+        assert.equal(res.desync, false);
+    } finally { teardownTmp(dir); }
+});
+
+test('detectDesync: solo partial-pause (sin waves.json) → no desync', () => {
+    const { dir, mod } = setupTmp();
+    try {
+        writePartial(dir, [100, 200]);
+        const res = mod.detectDesync({ skipAlert: true });
+        assert.equal(res.desync, false);
+        assert.equal(res.reason, 'no_waves_yet');
+    } finally { teardownTmp(dir); }
+});
+
+test('detectDesync: solo waves.json (sin partial-pause) → no desync', () => {
+    const { dir, mod } = setupTmp();
+    try {
+        writeWaves(dir, [{ number: 100 }, { number: 200 }]);
+        const res = mod.detectDesync({ skipAlert: true });
+        assert.equal(res.desync, false);
+        assert.equal(res.reason, 'no_partial_pause');
+    } finally { teardownTmp(dir); }
+});
+
+test('detectDesync: allowlists iguales → no desync', () => {
+    const { dir, mod } = setupTmp();
+    try {
+        writeWaves(dir, [{ number: 100 }, { number: 200 }]);
+        writePartial(dir, [100, 200]);
+        const res = mod.detectDesync({ skipAlert: true });
+        assert.equal(res.desync, false);
+        assert.deepEqual(res.added, []);
+        assert.deepEqual(res.removed, []);
+    } finally { teardownTmp(dir); }
+});
+
+test('detectDesync: allowlists distintas → desync + flag + alerta', () => {
+    const { dir, mod } = setupTmp();
+    try {
+        writeWaves(dir, [{ number: 100 }, { number: 200 }, { number: 300 }]);
+        writePartial(dir, [100, 999]);
+        const res = mod.detectDesync({ skipAlert: false });
+        assert.equal(res.desync, true);
+        assert.equal(res.reason, 'allowlist_mismatch');
+        assert.deepEqual(res.waves_allowlist.sort((a, b) => a - b), [100, 200, 300]);
+        assert.deepEqual(res.partial_allowlist.sort((a, b) => a - b), [100, 999]);
+        // Flag creado.
+        assert.ok(res.flag_path);
+        assert.equal(fs.existsSync(res.flag_path), true);
+        assert.equal(mod.isDesyncFlagSet(), true);
+        // Alerta disparada (drop en cola Telegram).
+        const alertDir = path.join(dir, 'servicios', 'telegram', 'pendiente');
+        assert.equal(fs.existsSync(alertDir), true);
+        const files = fs.readdirSync(alertDir);
+        assert.ok(files.some((f) => f.startsWith('alert-waves-desync-')), `esperaba alert en ${files.join(',')}`);
+    } finally { teardownTmp(dir); }
+});
+
+test('detectDesync: filtra issues con status=completed en waves.json', () => {
+    const { dir, mod } = setupTmp();
+    try {
+        writeWaves(dir, [
+            { number: 100, status: 'in_progress' },
+            { number: 200, status: 'completed' }, // excluido
+            { number: 300 },
+        ]);
+        writePartial(dir, [100, 300]);
+        const res = mod.detectDesync({ skipAlert: true });
+        assert.equal(res.desync, false, '200 está completed, no debe contar');
+    } finally { teardownTmp(dir); }
+});
+
+test('detectDesync: skipFlag y skipAlert no tocan FS', () => {
+    const { dir, mod } = setupTmp();
+    try {
+        writeWaves(dir, [{ number: 100 }]);
+        writePartial(dir, [999]);
+        const res = mod.detectDesync({ skipFlag: true, skipAlert: true });
+        assert.equal(res.desync, true);
+        assert.equal(res.flag_path, undefined);
+        assert.equal(mod.isDesyncFlagSet(), false);
+        const alertDir = path.join(dir, 'servicios', 'telegram', 'pendiente');
+        assert.equal(fs.existsSync(alertDir), false);
+    } finally { teardownTmp(dir); }
+});
+
+test('clearDesyncFlag elimina el flag de bloqueo', () => {
+    const { dir, mod } = setupTmp();
+    try {
+        writeWaves(dir, [{ number: 100 }]);
+        writePartial(dir, [999]);
+        mod.detectDesync({ skipAlert: true });
+        assert.equal(mod.isDesyncFlagSet(), true);
+        mod.clearDesyncFlag();
+        assert.equal(mod.isDesyncFlagSet(), false);
+    } finally { teardownTmp(dir); }
+});
+
+test('detectDesync NO auto-repara (política security #7)', () => {
+    const { dir, mod } = setupTmp();
+    try {
+        writeWaves(dir, [{ number: 100 }, { number: 200 }]);
+        writePartial(dir, [999]);
+        // Snapshot ANTES.
+        const wavesBefore = fs.readFileSync(path.join(dir, 'waves.json'), 'utf8');
+        const partialBefore = fs.readFileSync(path.join(dir, '.partial-pause.json'), 'utf8');
+        mod.detectDesync({ skipAlert: true });
+        // Los archivos no cambian.
+        assert.equal(fs.readFileSync(path.join(dir, 'waves.json'), 'utf8'), wavesBefore);
+        assert.equal(fs.readFileSync(path.join(dir, '.partial-pause.json'), 'utf8'), partialBefore);
+    } finally { teardownTmp(dir); }
+});
+
+test('diffAllowlists: added/removed correctos', () => {
+    const { dir, mod } = setupTmp();
+    try {
+        const { added, removed } = mod._internal.diffAllowlists([1, 2, 3], [2, 3, 4]);
+        assert.deepEqual(added, [4]);
+        assert.deepEqual(removed, [1]);
+    } finally { teardownTmp(dir); }
+});
+
+test('detectDesync: waves.json corrupto → no es desync (reason no_waves_yet)', () => {
+    const { dir, mod } = setupTmp();
+    try {
+        fs.writeFileSync(path.join(dir, 'waves.json'), '{ corrupto');
+        writePartial(dir, [100]);
+        const res = mod.detectDesync({ skipAlert: true });
+        // El detector no puede leer waves → trata como "no canonical yet"
+        // (no es su rol diagnosticar corrupción; eso lo hace loadStateStrict).
+        assert.equal(res.desync, false);
+        assert.equal(res.reason, 'no_waves_yet');
+    } finally { teardownTmp(dir); }
+});

--- a/.pipeline/lib/__tests__/desync-detector.test.js
+++ b/.pipeline/lib/__tests__/desync-detector.test.js
@@ -172,6 +172,26 @@ test('diffAllowlists: added/removed correctos', () => {
     } finally { teardownTmp(dir); }
 });
 
+test('detectDesync: waves.json con active_wave:null → no_waves_yet (#3518 fix)', () => {
+    const { dir, mod } = setupTmp();
+    try {
+        // Estado inicial/legacy: waves.json existe pero sin ola promovida.
+        // partial-pause tiene allowlist seteado manualmente. NO es desync.
+        fs.writeFileSync(path.join(dir, 'waves.json'), JSON.stringify({
+            version: '1.0',
+            meta: { updated_at: new Date().toISOString() },
+            active_wave: null,
+            planned_waves: [],
+            archived_waves: [],
+        }));
+        writePartial(dir, [3518, 3541, 3577]);
+        const res = mod.detectDesync({ skipAlert: true });
+        assert.equal(res.desync, false, 'active_wave:null debe tratarse como no_waves_yet');
+        assert.equal(res.reason, 'no_waves_yet');
+        assert.equal(mod.isDesyncFlagSet(), false);
+    } finally { teardownTmp(dir); }
+});
+
 test('detectDesync: waves.json corrupto → no es desync (reason no_waves_yet)', () => {
     const { dir, mod } = setupTmp();
     try {

--- a/.pipeline/lib/__tests__/file-lock.test.js
+++ b/.pipeline/lib/__tests__/file-lock.test.js
@@ -1,0 +1,227 @@
+// =============================================================================
+// file-lock.test.js — Tests de lib/file-lock.js (issue #3518 CA-3).
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const lock = require('../file-lock');
+
+function mkTmpFile() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'flock-test-'));
+    return path.join(dir, 'target.json');
+}
+
+function rmrf(p) {
+    try { fs.rmSync(path.dirname(p), { recursive: true, force: true }); } catch {}
+}
+
+// ─── Adquisición básica ─────────────────────────────────────────────────────
+
+test('withLockSync ejecuta fn y libera el lock al salir', () => {
+    const target = mkTmpFile();
+    try {
+        let ran = false;
+        const result = lock.withLockSync(target, () => {
+            ran = true;
+            // El lock debe existir DENTRO de fn.
+            assert.equal(fs.existsSync(target + '.lock'), true);
+            return 42;
+        });
+        assert.equal(ran, true);
+        assert.equal(result, 42);
+        // Tras el return, el lock debe estar liberado.
+        assert.equal(fs.existsSync(target + '.lock'), false);
+    } finally { rmrf(target); }
+});
+
+test('withLockSync libera el lock incluso si fn tira', () => {
+    const target = mkTmpFile();
+    try {
+        assert.throws(() => lock.withLockSync(target, () => { throw new Error('boom'); }), /boom/);
+        assert.equal(fs.existsSync(target + '.lock'), false);
+    } finally { rmrf(target); }
+});
+
+test('withLockSync el lock file contiene metadata enriquecida (pid, startTime, hostname, version)', () => {
+    const target = mkTmpFile();
+    try {
+        let metaSeen = null;
+        lock.withLockSync(target, () => {
+            metaSeen = lock._internal.readLockMeta(target + '.lock');
+        });
+        assert.ok(metaSeen, 'meta debe leerse');
+        assert.equal(metaSeen.pid, process.pid);
+        assert.equal(metaSeen.hostname, os.hostname());
+        assert.equal(metaSeen.version, lock._internal.LOCK_SCHEMA_VERSION);
+        assert.ok(metaSeen.startTime);
+        assert.ok(Number.isFinite(Date.parse(metaSeen.startTime)));
+    } finally { rmrf(target); }
+});
+
+test('withLockSync soporta reentrancia (mismo pid+startTime no deadlockea)', () => {
+    const target = mkTmpFile();
+    try {
+        let inner = false;
+        lock.withLockSync(target, () => {
+            lock.withLockSync(target, () => {
+                inner = true;
+            });
+            // El lock externo todavía existe.
+            assert.equal(fs.existsSync(target + '.lock'), true);
+        });
+        assert.equal(inner, true);
+        assert.equal(fs.existsSync(target + '.lock'), false);
+    } finally { rmrf(target); }
+});
+
+// ─── Stale detection ────────────────────────────────────────────────────────
+
+test('isStale: PID no existe → stale', () => {
+    const fake = { pid: 9999999, startTime: '2026-01-01T00:00:00.000Z' };
+    // PID muy alto — improbable que exista.
+    const stale = lock._internal.isStale(fake, '/nope/inexistent.lock');
+    assert.equal(stale, true);
+});
+
+test('isStale: lock corrupto → stale', () => {
+    const stale = lock._internal.isStale({ _corrupt: true }, '/nope/inexistent.lock');
+    assert.equal(stale, true);
+});
+
+test('isStale: PID vivo + lock reciente → NO stale (conservador)', () => {
+    const target = mkTmpFile();
+    try {
+        // Simular un lock recién creado de OTRO proceso vivo (usamos parent pid).
+        const meta = { pid: process.ppid, startTime: new Date().toISOString(), hostname: os.hostname(), version: '1.0' };
+        fs.writeFileSync(target + '.lock', JSON.stringify(meta));
+        const stale = lock._internal.isStale(meta, target + '.lock');
+        // ppid existe → NO stale (lock es muy nuevo de todas formas).
+        assert.equal(stale, false);
+    } finally { rmrf(target); }
+});
+
+test('acquireLockSync: stale lock se reemplaza automáticamente', () => {
+    const target = mkTmpFile();
+    try {
+        // Plantar un lock huérfano de un PID inexistente.
+        fs.writeFileSync(target + '.lock', JSON.stringify({
+            pid: 9999999,
+            startTime: '2026-01-01T00:00:00.000Z',
+            hostname: 'old-host',
+            version: '1.0',
+        }));
+        // Forzar mtime viejo para que pase el umbral STALE_AGE_MS — aunque
+        // con PID inexistente ya alcanza, esto es defensa.
+        const old = (Date.now() - 5 * 60 * 1000) / 1000;
+        fs.utimesSync(target + '.lock', old, old);
+
+        const res = lock.acquireLockSync(target, { timeoutMs: 1000, maxRetries: 2 });
+        assert.equal(res.acquired, true);
+        // Liberar para no dejar basura.
+        lock.releaseLock(target);
+    } finally { rmrf(target); }
+});
+
+// ─── Timeout + notify ───────────────────────────────────────────────────────
+
+test('acquireLockSync timeout → tira ELOCK_TIMEOUT con holder info', () => {
+    const target = mkTmpFile();
+    try {
+        // Plantar un lock con NUESTRO pid pero startTime distinto — eso debería
+        // contar como reentrancia (mismo pid + start). Para forzar timeout,
+        // simulamos un lock de pid distinto vivo (parent pid) con start reciente.
+        const meta = { pid: process.ppid, startTime: new Date().toISOString(), hostname: 'h', version: '1.0' };
+        fs.writeFileSync(target + '.lock', JSON.stringify(meta));
+        // Timeout MUY corto para no esperar mucho.
+        try {
+            lock.acquireLockSync(target, { timeoutMs: 300, maxRetries: 2 });
+            assert.fail('debería haber tirado timeout');
+        } catch (err) {
+            assert.equal(err.code, 'ELOCK_TIMEOUT');
+            assert.ok(err.lockPath);
+            assert.ok(err.holder);
+            assert.equal(err.holder.pid, process.ppid);
+        }
+        // Limpiar.
+        try { fs.unlinkSync(target + '.lock'); } catch {}
+    } finally { rmrf(target); }
+});
+
+test('withLockSync: en timeout invoca opts.notify con payload estructurado', () => {
+    const target = mkTmpFile();
+    try {
+        const meta = { pid: process.ppid, startTime: new Date().toISOString(), hostname: 'h', version: '1.0' };
+        fs.writeFileSync(target + '.lock', JSON.stringify(meta));
+        let notified = null;
+        try {
+            lock.withLockSync(target, () => {}, {
+                timeoutMs: 300,
+                maxRetries: 2,
+                component: 'test-lock',
+                notify: (payload) => { notified = payload; },
+            });
+            assert.fail('debería haber tirado');
+        } catch (err) {
+            assert.equal(err.code, 'ELOCK_TIMEOUT');
+        }
+        assert.ok(notified, 'notify debe haberse llamado');
+        assert.equal(notified.level, 'error');
+        assert.equal(notified.component, 'test-lock');
+        assert.ok(notified.message.includes('timeout'));
+        try { fs.unlinkSync(target + '.lock'); } catch {}
+    } finally { rmrf(target); }
+});
+
+test('withLockSync: notify que tira NO interrumpe la propagación del error real', () => {
+    const target = mkTmpFile();
+    try {
+        const meta = { pid: process.ppid, startTime: new Date().toISOString(), hostname: 'h', version: '1.0' };
+        fs.writeFileSync(target + '.lock', JSON.stringify(meta));
+        try {
+            lock.withLockSync(target, () => {}, {
+                timeoutMs: 200,
+                maxRetries: 1,
+                notify: () => { throw new Error('notify roto'); },
+            });
+            assert.fail('debería haber tirado timeout');
+        } catch (err) {
+            // Tira ELOCK_TIMEOUT, NO "notify roto".
+            assert.equal(err.code, 'ELOCK_TIMEOUT');
+        }
+        try { fs.unlinkSync(target + '.lock'); } catch {}
+    } finally { rmrf(target); }
+});
+
+// ─── releaseLock ────────────────────────────────────────────────────────────
+
+test('releaseLock: no remueve locks ajenos', () => {
+    const target = mkTmpFile();
+    try {
+        // Plantar lock de otro pid vivo (parent pid).
+        fs.writeFileSync(target + '.lock', JSON.stringify({
+            pid: process.ppid,
+            startTime: new Date().toISOString(),
+            hostname: 'h',
+            version: '1.0',
+        }));
+        const ok = lock.releaseLock(target);
+        assert.equal(ok, false, 'no debe liberar un lock ajeno');
+        assert.equal(fs.existsSync(target + '.lock'), true);
+        fs.unlinkSync(target + '.lock');
+    } finally { rmrf(target); }
+});
+
+test('releaseLock: limpia locks corruptos', () => {
+    const target = mkTmpFile();
+    try {
+        fs.writeFileSync(target + '.lock', 'no es json');
+        const ok = lock.releaseLock(target);
+        assert.equal(ok, true);
+        assert.equal(fs.existsSync(target + '.lock'), false);
+    } finally { rmrf(target); }
+});

--- a/.pipeline/lib/__tests__/fixtures/partial-pause-concurrency-worker.js
+++ b/.pipeline/lib/__tests__/fixtures/partial-pause-concurrency-worker.js
@@ -1,0 +1,32 @@
+// =============================================================================
+// partial-pause-concurrency-worker.js — Worker forkable para tests de
+// concurrencia de partial-pause.js (issue #3518 CA-8).
+//
+// Recibe por env:
+//   PIPELINE_DIR_OVERRIDE   — directorio temporal compartido
+//   WORKER_ISSUES_CSV       — CSV "100,200,300" de issues a setear
+//   WORKER_ID               — identificador para logs
+//
+// Hace setPartialPause con esa lista. Sale 0 si OK, 1 si tira.
+// =============================================================================
+'use strict';
+
+const path = require('path');
+const ppPath = path.join(__dirname, '..', '..', 'partial-pause.js');
+const pp = require(ppPath);
+
+const csv = String(process.env.WORKER_ISSUES_CSV || '').trim();
+const id = process.env.WORKER_ID || `pid-${process.pid}`;
+const issues = csv ? csv.split(',').map((s) => Number(s.trim())).filter(Number.isFinite) : [];
+
+try {
+    const res = pp.setPartialPause(issues, { source: `concurrency-test-${id}` });
+    if (!res.ok) {
+        console.error(`worker(${id}): setPartialPause not ok`);
+        process.exit(1);
+    }
+    process.exit(0);
+} catch (err) {
+    console.error(`worker(${id}): ${err.message}`);
+    process.exit(1);
+}

--- a/.pipeline/lib/__tests__/fixtures/waves-concurrency-worker.js
+++ b/.pipeline/lib/__tests__/fixtures/waves-concurrency-worker.js
@@ -1,0 +1,40 @@
+// =============================================================================
+// waves-concurrency-worker.js — Worker forkable para tests de concurrencia
+// de waves.js (issue #3518 CA-8).
+//
+// Recibe por env:
+//   PIPELINE_DIR_OVERRIDE  — directorio temporal compartido
+//   WORKER_ISSUE           — número de issue a agregar
+//   WORKER_WAVE            — número de ola destino
+//
+// Hace addIssueToWave y sale con código 0 si tuvo éxito, 1 si tiró.
+// Cualquier error se imprime a stderr (capturado por el test padre).
+// =============================================================================
+'use strict';
+
+const path = require('path');
+const wavesPath = path.join(__dirname, '..', '..', 'waves.js');
+const waves = require(wavesPath);
+
+const issue = Number(process.env.WORKER_ISSUE);
+const wave = Number(process.env.WORKER_WAVE);
+
+if (!Number.isInteger(issue) || !Number.isInteger(wave)) {
+    console.error(`worker: WORKER_ISSUE/WORKER_WAVE inválidos (${process.env.WORKER_ISSUE}/${process.env.WORKER_WAVE})`);
+    process.exit(2);
+}
+
+try {
+    waves.addIssueToWave(wave, {
+        number: issue,
+        status: 'pending',
+    }, {
+        updated_by: `worker-${process.pid}`,
+        source: 'concurrency-test',
+        note: `add #${issue}`,
+    });
+    process.exit(0);
+} catch (err) {
+    console.error(`worker(pid=${process.pid}, issue=${issue}): ${err.message}`);
+    process.exit(1);
+}

--- a/.pipeline/lib/__tests__/notify-telegram.test.js
+++ b/.pipeline/lib/__tests__/notify-telegram.test.js
@@ -1,0 +1,124 @@
+// =============================================================================
+// notify-telegram.test.js — Tests de lib/notify-telegram.js (issue #3518 CA-9).
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+function setupTmp() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'notify-tg-test-'));
+    process.env.PIPELINE_DIR_OVERRIDE = dir;
+    delete require.cache[require.resolve('../notify-telegram')];
+    return { dir, mod: require('../notify-telegram') };
+}
+
+function teardownTmp(dir) {
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+    delete process.env.PIPELINE_DIR_OVERRIDE;
+}
+
+test('notifyTelegram rechaza payload sin component/message', () => {
+    const { dir, mod } = setupTmp();
+    try {
+        assert.deepEqual(mod.notifyTelegram(null), { ok: false, reason: 'invalid_payload' });
+        assert.deepEqual(mod.notifyTelegram({}), { ok: false, reason: 'missing_required_fields' });
+        assert.deepEqual(mod.notifyTelegram({ component: 'x' }), { ok: false, reason: 'missing_required_fields' });
+        assert.deepEqual(mod.notifyTelegram({ message: 'x' }), { ok: false, reason: 'missing_required_fields' });
+    } finally { teardownTmp(dir); }
+});
+
+test('notifyTelegram crea drop en servicios/telegram/pendiente/ con shape {text, parse_mode}', () => {
+    const { dir, mod } = setupTmp();
+    try {
+        const res = mod.notifyTelegram({
+            level: 'error',
+            component: 'test-component',
+            message: 'algo falló',
+            action: 'mirá los logs',
+            diag: 'ls -la /tmp',
+        });
+        assert.equal(res.ok, true);
+        assert.ok(res.dropPath);
+        assert.equal(fs.existsSync(res.dropPath), true);
+
+        const parsed = JSON.parse(fs.readFileSync(res.dropPath, 'utf8'));
+        assert.ok(typeof parsed.text === 'string');
+        assert.equal(parsed.parse_mode, 'Markdown');
+        // El texto incluye los pedazos esperables.
+        assert.ok(parsed.text.includes('test-component'));
+        assert.ok(parsed.text.includes('algo falló'));
+        assert.ok(parsed.text.includes('mirá los logs'));
+        assert.ok(parsed.text.includes('(diag: ls -la /tmp)'));
+        // Severidad error → 🚨.
+        assert.ok(parsed.text.startsWith('\u{1F6A8}'));
+    } finally { teardownTmp(dir); }
+});
+
+test('buildMessage incluye contexto, holder, emisor', () => {
+    const { dir, mod } = setupTmp();
+    try {
+        const text = mod._internal.buildMessage({
+            level: 'warn',
+            component: 'waves-lock',
+            message: 'lock timeout',
+            holder: { pid: 12345, hostname: 'host-a', startTime: '2026-05-26T10:00:00Z' },
+            context: { archivo: 'waves.json', retries: 3 },
+            ts: '2026-05-26T13:42:18Z',
+            diag: 'cat waves.json.lock',
+            action: 'Liberá el lock manual',
+        });
+        assert.ok(text.includes('pid=12345'));
+        assert.ok(text.includes('host=host-a'));
+        assert.ok(text.includes('start=2026-05-26T10:00:00Z'));
+        assert.ok(text.includes('archivo: waves.json'));
+        assert.ok(text.includes('retries: 3'));
+        assert.ok(text.includes(`emisor: pid=${process.pid}`));
+        assert.ok(text.includes('host=' + os.hostname()));
+        assert.ok(text.includes('ts=2026-05-26T13:42:18Z'));
+        assert.ok(text.includes('Liberá el lock manual'));
+        assert.ok(text.includes('(diag: cat waves.json.lock)'));
+    } finally { teardownTmp(dir); }
+});
+
+test('emoji por severidad: error 🚨, warn ⚠️, info ℹ️ (default)', () => {
+    const { dir, mod } = setupTmp();
+    try {
+        assert.equal(mod._internal.emojiFor('error'), '\u{1F6A8}');
+        assert.equal(mod._internal.emojiFor('warn'), '\u{26A0}\u{FE0F}');
+        assert.equal(mod._internal.emojiFor('info'), '\u{2139}\u{FE0F}');
+        assert.equal(mod._internal.emojiFor('unknown'), '\u{2139}\u{FE0F}');
+    } finally { teardownTmp(dir); }
+});
+
+test('notifyTelegram no incluye stacktraces (detail trunca a 400 chars)', () => {
+    const { dir, mod } = setupTmp();
+    try {
+        const longDetail = 'a'.repeat(800);
+        const res = mod.notifyTelegram({
+            level: 'error',
+            component: 'x',
+            message: 'y',
+            detail: longDetail,
+        });
+        const parsed = JSON.parse(fs.readFileSync(res.dropPath, 'utf8'));
+        const m = parsed.text.match(/detalle: (.+)/);
+        assert.ok(m);
+        assert.ok(m[1].length <= 400, `detalle truncado, len=${m[1].length}`);
+    } finally { teardownTmp(dir); }
+});
+
+test('notifyTelegram crea el directorio servicios/telegram/pendiente/ si no existe', () => {
+    const { dir, mod } = setupTmp();
+    try {
+        // El directorio no existe al arrancar.
+        const queueDir = path.join(dir, 'servicios', 'telegram', 'pendiente');
+        assert.equal(fs.existsSync(queueDir), false);
+        const res = mod.notifyTelegram({ component: 'a', message: 'b' });
+        assert.equal(res.ok, true);
+        assert.equal(fs.existsSync(queueDir), true);
+    } finally { teardownTmp(dir); }
+});

--- a/.pipeline/lib/__tests__/partial-pause-concurrency.test.js
+++ b/.pipeline/lib/__tests__/partial-pause-concurrency.test.js
@@ -1,0 +1,89 @@
+// =============================================================================
+// partial-pause-concurrency.test.js — Tests de concurrencia con N workers
+// sobre .partial-pause.json. Issue #3518 CA-8.
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { fork } = require('node:child_process');
+
+const WORKER_SCRIPT = path.join(__dirname, 'fixtures', 'partial-pause-concurrency-worker.js');
+
+function setupTmp() {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'pp-conc-test-'));
+}
+
+function rmrf(dir) {
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+}
+
+function forkWorker(dir, issuesCsv, id) {
+    return new Promise((resolve) => {
+        const env = {
+            ...process.env,
+            PIPELINE_DIR_OVERRIDE: dir,
+            WORKER_ISSUES_CSV: issuesCsv,
+            WORKER_ID: id,
+        };
+        const child = fork(WORKER_SCRIPT, [], {
+            env,
+            stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+        });
+        let stderr = '';
+        child.stderr.on('data', (c) => { stderr += c.toString(); });
+        child.on('exit', (code) => resolve({ code, stderr, id }));
+    });
+}
+
+test('CA-8: 10 workers escriben distintas allowlists — JSON final válido + sin tmp/lock residual', async () => {
+    const dir = setupTmp();
+    try {
+        const N = 10;
+        const promises = [];
+        for (let i = 0; i < N; i++) {
+            // Cada worker setea una lista única.
+            const csv = `${1000 + i},${2000 + i}`;
+            promises.push(forkWorker(dir, csv, `w${i}`));
+        }
+        const results = await Promise.all(promises);
+
+        // Al menos un worker debe haber tenido éxito (escribió el archivo final).
+        const successful = results.filter((r) => r.code === 0).length;
+        assert.ok(successful >= 1, `expected at least 1 successful, got ${successful}`);
+
+        // El archivo final debe ser JSON válido (no truncado).
+        const partialPath = path.join(dir, '.partial-pause.json');
+        assert.equal(fs.existsSync(partialPath), true);
+        const raw = fs.readFileSync(partialPath, 'utf8');
+        let parsed;
+        assert.doesNotThrow(() => { parsed = JSON.parse(raw); }, 'JSON parseable');
+        assert.ok(Array.isArray(parsed.allowed_issues));
+        assert.equal(parsed.allowed_issues.length, 2, 'allowlist tiene exactamente los 2 issues del último write');
+
+        // Sin tmp/lock residual.
+        assert.equal(fs.existsSync(partialPath + '.tmp'), false, 'tmp residual');
+        assert.equal(fs.existsSync(partialPath + '.lock'), false, 'lock residual');
+    } finally { rmrf(dir); }
+});
+
+test('CA-8: workers concurrentes con misma allowlist — todos producen el mismo resultado', async () => {
+    const dir = setupTmp();
+    try {
+        const N = 8;
+        const promises = [];
+        for (let i = 0; i < N; i++) {
+            promises.push(forkWorker(dir, '100,200,300', `w${i}`));
+        }
+        const results = await Promise.all(promises);
+        // Todos deben haber tenido éxito (no hay conflict semántico).
+        for (const r of results) {
+            assert.equal(r.code, 0, `worker ${r.id} falló: ${r.stderr}`);
+        }
+        const partial = JSON.parse(fs.readFileSync(path.join(dir, '.partial-pause.json'), 'utf8'));
+        assert.deepEqual(partial.allowed_issues.sort((a, b) => a - b), [100, 200, 300]);
+    } finally { rmrf(dir); }
+});

--- a/.pipeline/lib/__tests__/waves-concurrency.test.js
+++ b/.pipeline/lib/__tests__/waves-concurrency.test.js
@@ -1,0 +1,148 @@
+// =============================================================================
+// waves-concurrency.test.js — Tests de concurrencia con N workers paralelos.
+// Issue #3518 CA-8.
+//
+// Estrategia
+// ----------
+// Forkear N=10 procesos hijos (child_process.fork) que cada uno hace un
+// `addIssueToWave` distinto sobre el MISMO waves.json. Después esperar
+// `Promise.all` de los `exit` events y validar:
+//   (a) JSON sintácticamente válido (JSON.parse no tira).
+//   (b) Schema válido (validateStateStrict no devuelve errores).
+//   (c) Audit log: cada exitoso dejó su entrada (meta.updated_by != 'System').
+//   (d) Idempotencia: los issues aparecen una sola vez (no duplicados).
+//   (e) Sin tmp files residuales (.tmp y .lock liberados).
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { fork } = require('node:child_process');
+
+const WORKER_SCRIPT = path.join(__dirname, 'fixtures', 'waves-concurrency-worker.js');
+
+function setupTmp() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'waves-conc-test-'));
+    return dir;
+}
+
+function rmrf(dir) {
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+}
+
+function writeBaseState(dir) {
+    fs.writeFileSync(path.join(dir, 'waves.json'), JSON.stringify({
+        version: '1.0',
+        meta: {
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+            updated_by: 'test',
+            source: 'fixture',
+        },
+        active_wave: {
+            number: 1,
+            name: 'concurrent',
+            started_at: new Date().toISOString(),
+            issues: [],
+        },
+        planned_waves: [],
+        archived_waves: [],
+        dependencies: [],
+    }, null, 2));
+}
+
+function forkWorker(dir, issue, wave = 1) {
+    return new Promise((resolve) => {
+        const env = {
+            ...process.env,
+            PIPELINE_DIR_OVERRIDE: dir,
+            WORKER_ISSUE: String(issue),
+            WORKER_WAVE: String(wave),
+        };
+        const child = fork(WORKER_SCRIPT, [], {
+            env,
+            stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+        });
+        let stderr = '';
+        child.stderr.on('data', (c) => { stderr += c.toString(); });
+        child.on('exit', (code) => resolve({ code, stderr }));
+    });
+}
+
+test('CA-8: N=10 workers concurrentes — JSON válido + schema válido + N entries + idempotencia', async () => {
+    const dir = setupTmp();
+    try {
+        writeBaseState(dir);
+
+        // 10 issues distintos, forkeados en paralelo.
+        const issues = Array.from({ length: 10 }, (_, i) => 9000 + i);
+        const results = await Promise.all(issues.map((i) => forkWorker(dir, i)));
+
+        // (a) JSON sintácticamente válido.
+        const raw = fs.readFileSync(path.join(dir, 'waves.json'), 'utf8');
+        let parsed;
+        assert.doesNotThrow(() => { parsed = JSON.parse(raw); }, 'JSON debe ser parseable');
+
+        // (b) Schema válido (re-require para tomar override).
+        delete require.cache[require.resolve('../waves')];
+        process.env.PIPELINE_DIR_OVERRIDE = dir;
+        const waves = require('../waves');
+        const errors = waves.validateStateStrict(parsed);
+        assert.equal(errors.length, 0, `schema errors: ${errors.join('; ')}`);
+        delete process.env.PIPELINE_DIR_OVERRIDE;
+
+        // (c) Audit log: el último write quedó registrado. (No podemos verificar
+        //     entrada por entrada porque waves.json mantiene solo el último
+        //     meta — el audit detallado por write es follow-up del security).
+        assert.ok(parsed.meta.updated_by.startsWith('worker-'), 'último writer es un worker');
+
+        // (d) Idempotencia + completitud: todos los issues que reportaron
+        //     éxito están en el wave activo, una sola vez cada uno.
+        const successful = results.filter((r) => r.code === 0).length;
+        const wave = parsed.active_wave;
+        assert.ok(Array.isArray(wave.issues), 'active_wave.issues debe ser array');
+        const seen = new Set();
+        for (const it of wave.issues) {
+            assert.ok(!seen.has(it.number), `issue duplicado: ${it.number}`);
+            seen.add(it.number);
+        }
+        // Todos los workers exitosos dejaron su issue.
+        assert.equal(wave.issues.length, successful, `issues=${wave.issues.length}, exitosos=${successful}`);
+
+        // (e) Sin residuos.
+        assert.equal(fs.existsSync(path.join(dir, 'waves.json.tmp')), false, 'tmp file residual');
+        assert.equal(fs.existsSync(path.join(dir, 'waves.json.lock')), false, 'lock residual');
+
+        // Reportar al menos N/2 deben haber tenido éxito (los demás pueden
+        // haber timeoutado el lock si el sistema está cargado, lo cual es
+        // un escenario válido — pero NO deben haber corrompido el archivo).
+        assert.ok(successful >= issues.length / 2,
+            `solo ${successful}/${issues.length} workers exitosos — posible problema de lock contention`);
+    } finally {
+        delete process.env.PIPELINE_DIR_OVERRIDE;
+        rmrf(dir);
+    }
+});
+
+test('CA-8: workers concurrentes con el MISMO issue — solo uno gana, no duplica', async () => {
+    const dir = setupTmp();
+    try {
+        writeBaseState(dir);
+
+        // 5 workers intentan agregar el MISMO issue.
+        const sameIssue = 8888;
+        const results = await Promise.all(Array.from({ length: 5 }, () => forkWorker(dir, sameIssue)));
+
+        // Al menos uno tuvo éxito.
+        const successful = results.filter((r) => r.code === 0).length;
+        assert.ok(successful >= 1, 'al menos un worker debe haber agregado el issue');
+
+        // El JSON final tiene el issue una sola vez (idempotencia interna de addIssueToWave).
+        const parsed = JSON.parse(fs.readFileSync(path.join(dir, 'waves.json'), 'utf8'));
+        const count = parsed.active_wave.issues.filter((i) => i.number === sameIssue).length;
+        assert.equal(count, 1, `issue ${sameIssue} aparece ${count} veces, debe ser 1`);
+    } finally { rmrf(dir); }
+});

--- a/.pipeline/lib/desync-detector.js
+++ b/.pipeline/lib/desync-detector.js
@@ -83,7 +83,11 @@ function readWavesAllowlist(opts = {}) {
     }
     if (!parsed || typeof parsed !== 'object') return null;
     const active = parsed.active_wave;
-    if (!active || !Array.isArray(active.issues)) return [];
+    // active_wave === null/undefined: no hay ola promovida vía Commander todavía
+    // (estado inicial o legacy con allowlist seteado manualmente). NO es desync,
+    // es ausencia de canónica → mismo trato que "waves.json no existe".
+    if (active === null || active === undefined) return null;
+    if (typeof active !== 'object' || !Array.isArray(active.issues)) return [];
     return active.issues
         .filter((i) => i && i.status !== 'completed')
         .map((i) => normalizeIssue(i && i.number))

--- a/.pipeline/lib/desync-detector.js
+++ b/.pipeline/lib/desync-detector.js
@@ -1,0 +1,242 @@
+// =============================================================================
+// desync-detector.js — Detección de desync entre waves.json y .partial-pause.json
+// Issue #3518 (CA-6).
+//
+// Por qué este detector existe
+// ----------------------------
+// El Commander escribe los DOS archivos secuencialmente al promover una ola
+// (waves.json → setActiveWave, luego .partial-pause.json → setAllowlist).
+// Si el proceso muere entre los dos writes, los archivos quedan inconsistentes:
+//
+//   - waves.json dice "ola N+8 es activa, issues=[A, B, C]"
+//   - .partial-pause.json sigue con allowlist=[X, Y] de la ola previa
+//
+// Resultado: el Pulpo procesa issues del wave VIEJO (los del allowlist) o NO
+// procesa issues que ya deberían estarlo (los del wave nuevo).
+//
+// Política (security req #7 + CA-6)
+// ----------------------------------
+// Al startup del Pulpo, llamamos a `detectDesync()`. Si hay desync:
+//
+//   1. Loggear con detalle exacto de qué difiere.
+//   2. Notificar Telegram con call-to-action y comando de diagnóstico.
+//   3. Marcar `_desync-detected.flag` en .pipeline/ para que el dispatch loop
+//      del Pulpo entre en modo human-block (no procesar nada hasta que un
+//      humano lo destrabe explícitamente).
+//
+// NO AUTO-REPARAR. Auto-reparación bajo asunción de que waves.json es la
+// verdad puede amplificar un compromiso si fue ese archivo el manipulado.
+// La decisión cuál archivo refleja la realidad la toma el humano.
+//
+// API
+// ---
+//   detectDesync(opts?) → { desync: bool, waves_allowlist, partial_allowlist,
+//                           added, removed, flag_path?, alerted? }
+//
+//   isDesyncFlagSet()  → bool  (consulta del flag de bloqueo)
+//   clearDesyncFlag()  → void  (humano destraba)
+//
+// Reglas inquebrantables
+// ----------------------
+//   - Cero side effects en require (safe para tests).
+//   - Tolerante a archivos ausentes (no es desync, es estado inicial).
+//   - El "allowlist" comparable se deriva con normalizeIssue (int positivo).
+//   - El detector NO escribe waves.json ni .partial-pause.json. Solo flag.
+// =============================================================================
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { notifyTelegram } = require('./notify-telegram');
+
+const DESYNC_FLAG_BASENAME = '.desync-detected.flag';
+
+function pipelineDir() {
+    if (process.env.PIPELINE_DIR_OVERRIDE) return process.env.PIPELINE_DIR_OVERRIDE;
+    return path.join(__dirname, '..');
+}
+
+function desyncFlagPath() {
+    return path.join(pipelineDir(), DESYNC_FLAG_BASENAME);
+}
+
+function normalizeIssue(issue) {
+    const n = Number(String(issue).trim().replace(/^#/, ''));
+    return Number.isInteger(n) && n > 0 ? n : null;
+}
+
+/**
+ * Lee la allowlist de waves.json (vía lib/waves.getAllowlist) sin propagar
+ * excepciones de schema (si waves.json está roto, devolvemos null y dejamos
+ * que el caller decida cómo tratarlo). Sin fallback a partial-pause —
+ * acá queremos la canónica del waves.
+ */
+function readWavesAllowlist(opts = {}) {
+    const wavesPath = path.join(pipelineDir(), 'waves.json');
+    if (!fs.existsSync(wavesPath)) return null;
+    let parsed;
+    try {
+        parsed = JSON.parse(fs.readFileSync(wavesPath, 'utf8'));
+    } catch {
+        return null;
+    }
+    if (!parsed || typeof parsed !== 'object') return null;
+    const active = parsed.active_wave;
+    if (!active || !Array.isArray(active.issues)) return [];
+    return active.issues
+        .filter((i) => i && i.status !== 'completed')
+        .map((i) => normalizeIssue(i && i.number))
+        .filter(Boolean);
+}
+
+/**
+ * Lee la allowlist del .partial-pause.json. null si el archivo no existe o
+ * es ilegible. Devuelve array vacío si existe pero está vacío.
+ */
+function readPartialAllowlist() {
+    const partialPath = path.join(pipelineDir(), '.partial-pause.json');
+    if (!fs.existsSync(partialPath)) return null;
+    let parsed;
+    try {
+        parsed = JSON.parse(fs.readFileSync(partialPath, 'utf8'));
+    } catch {
+        return null;
+    }
+    if (!parsed || typeof parsed !== 'object') return null;
+    const arr = Array.isArray(parsed.allowed_issues) ? parsed.allowed_issues : [];
+    return arr.map(normalizeIssue).filter(Boolean);
+}
+
+/**
+ * Calcula la diferencia entre dos arrays de números.
+ * Devuelve { added: en B no en A, removed: en A no en B }.
+ */
+function diffAllowlists(a, b) {
+    const setA = new Set(a);
+    const setB = new Set(b);
+    const added = b.filter((x) => !setA.has(x));
+    const removed = a.filter((x) => !setB.has(x));
+    return { added, removed };
+}
+
+/**
+ * Detecta desync entre waves.json y .partial-pause.json.
+ *
+ * @param {object} [opts]
+ * @param {boolean} [opts.skipFlag=false] — si true, NO crea el flag al detectar.
+ * @param {boolean} [opts.skipAlert=false] — si true, NO envía Telegram.
+ * @returns {{
+ *   desync: boolean,
+ *   reason: string|null,
+ *   waves_allowlist: number[]|null,
+ *   partial_allowlist: number[]|null,
+ *   added: number[],
+ *   removed: number[],
+ *   flag_path?: string,
+ *   alerted?: boolean,
+ * }}
+ */
+function detectDesync(opts = {}) {
+    const wavesAllow = readWavesAllowlist();
+    const partialAllow = readPartialAllowlist();
+
+    // Casos sin desync:
+    //   1. waves.json no existe ni partial-pause → estado inicial limpio.
+    //   2. Solo existe partial-pause (waves.json todavía sin escribir) →
+    //      backward compat con el modo legacy, no es inconsistencia.
+    //   3. Solo existe waves.json (partial-pause se eliminó tras transición) →
+    //      el pulpo usa getAllowlist() que ya cubre este caso.
+    if (wavesAllow === null && partialAllow === null) {
+        return { desync: false, reason: null, waves_allowlist: null, partial_allowlist: null, added: [], removed: [] };
+    }
+    if (wavesAllow === null) {
+        // Sin waves canónica, no podemos comparar. No es desync.
+        return { desync: false, reason: 'no_waves_yet', waves_allowlist: null, partial_allowlist: partialAllow, added: [], removed: [] };
+    }
+    if (partialAllow === null) {
+        // Sin partial-pause, no hay desync (es el estado esperado post-cleanup).
+        return { desync: false, reason: 'no_partial_pause', waves_allowlist: wavesAllow, partial_allowlist: null, added: [], removed: [] };
+    }
+
+    const { added, removed } = diffAllowlists(wavesAllow.sort((a, b) => a - b), partialAllow.sort((a, b) => a - b));
+    if (added.length === 0 && removed.length === 0) {
+        return { desync: false, reason: null, waves_allowlist: wavesAllow, partial_allowlist: partialAllow, added: [], removed: [] };
+    }
+
+    const result = {
+        desync: true,
+        reason: 'allowlist_mismatch',
+        waves_allowlist: wavesAllow,
+        partial_allowlist: partialAllow,
+        added,
+        removed,
+    };
+
+    // Crear flag de bloqueo (humano destraba después de auditar).
+    if (!opts.skipFlag) {
+        const flagPath = desyncFlagPath();
+        try {
+            fs.writeFileSync(flagPath, JSON.stringify({
+                detected_at: new Date().toISOString(),
+                pid: process.pid,
+                waves_allowlist: wavesAllow,
+                partial_allowlist: partialAllow,
+                added,
+                removed,
+            }, null, 2));
+            result.flag_path = flagPath;
+        } catch (err) {
+            console.warn(`[desync-detector] no se pudo crear flag ${flagPath}: ${err.message}`);
+        }
+    }
+
+    if (!opts.skipAlert) {
+        try {
+            notifyTelegram({
+                level: 'warn',
+                component: 'waves-desync',
+                message: 'waves.json y .partial-pause.json desincronizados',
+                context: {
+                    waves_allowlist: wavesAllow,
+                    partial_allowlist: partialAllow,
+                    added_in_waves: added,
+                    removed_from_partial: removed,
+                },
+                action: 'Pipeline en modo human-block. NO se autoreparó (política de seguridad #7). Decidí vos cuál archivo refleja la verdad y arreglalo a mano.',
+                diag: 'diff <(jq \'.active_wave.issues\' .pipeline/waves.json) <(jq \'.allowed_issues\' .pipeline/.partial-pause.json)',
+            });
+            result.alerted = true;
+        } catch (err) {
+            console.warn(`[desync-detector] alerta Telegram falló: ${err.message}`);
+            result.alerted = false;
+        }
+    }
+
+    return result;
+}
+
+function isDesyncFlagSet() {
+    return fs.existsSync(desyncFlagPath());
+}
+
+function clearDesyncFlag() {
+    const p = desyncFlagPath();
+    if (fs.existsSync(p)) {
+        try { fs.unlinkSync(p); } catch {}
+    }
+}
+
+module.exports = {
+    detectDesync,
+    isDesyncFlagSet,
+    clearDesyncFlag,
+    DESYNC_FLAG_BASENAME,
+    _internal: {
+        readWavesAllowlist,
+        readPartialAllowlist,
+        diffAllowlists,
+        normalizeIssue,
+        desyncFlagPath,
+    },
+};

--- a/.pipeline/lib/file-lock.js
+++ b/.pipeline/lib/file-lock.js
@@ -1,0 +1,465 @@
+// =============================================================================
+// file-lock.js — Lock cooperativo basado en filesystem para writes destructivos
+// del control plane (waves.json, .partial-pause.json) — issue #3518.
+//
+// Diseño
+// ------
+// Un lock = un archivo `<target>.lock` cuyo CONTENIDO es JSON enriquecido:
+//
+//   {
+//     "pid": 12847,
+//     "startTime": "2026-05-26T13:42:18.123Z",   // ISO del proceso holder
+//     "hostname": "intrale-host",
+//     "version": "1.0",
+//     "acquired_at": "2026-05-26T13:42:18.999Z"  // ISO de adquisición
+//   }
+//
+// El archivo se crea con `O_CREAT | O_EXCL` (`fs.openSync(path, 'wx')`), atómico
+// en POSIX y Windows. Si dos procesos llegan a la vez, solo uno gana — el otro
+// recibe `EEXIST` y reintenta con backoff.
+//
+// Stale detection (security req #1, requiere las DOS condiciones)
+// ----------------------------------------------------------------
+//   (a) PID no existe (process.kill(pid, 0) tira ESRCH), O
+//   (b) el archivo de lock tiene > 60s de antigüedad Y la heurística
+//       (process.kill(0)+startTime) sugiere que el PID fue reciclado.
+//
+// Política de reintentos (security req #2)
+// -----------------------------------------
+//   timeout: 5000ms total
+//   max retries: 3 (con jitter 50-200ms entre intentos)
+//   en fallo final: notifica Telegram + tira excepción (NUNCA esperar inf).
+//
+// Permisos (security req #6)
+// ---------------------------
+//   POSIX: mode 0o600 explícito al crear (no confiar en umask).
+//   Windows: el mode lo ignora el SO; ACLs del directorio gobiernan acceso.
+//
+// API
+// ---
+//   withLock(filePath, fn, opts?) → Promise<ret> de fn
+//     - filePath: ruta del archivo destino (NO el .lock, ese se deriva)
+//     - fn: función async que se ejecuta con el lock adquirido
+//     - opts: { timeoutMs, maxRetries, notify, lockVersion, onStaleDetected }
+//
+// Reglas inquebrantables
+// ----------------------
+//   - Cero deps npm — solo `fs`, `path`, `os`, `crypto` del core.
+//   - Liberación siempre en `finally`. Si el unlink falla, log + continúa
+//     (otro proceso recuperará el lock por stale-detection eventualmente).
+//   - Idempotente: re-adquirir un lock que ya tenemos NO debe deadlockear
+//     ni romper. La política es: si encuentra un lock con NUESTRO pid+startTime,
+//     entra como reentrancia (sin liberar el lock externo al salir).
+// =============================================================================
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+// Versión interna del schema del lock. Si se rompe el contrato a futuro,
+// procesos con versión vieja deben tratarlo como stale (defensivo).
+const LOCK_SCHEMA_VERSION = '1.0';
+
+const DEFAULT_TIMEOUT_MS = 5000;
+const DEFAULT_MAX_RETRIES = 3;
+const STALE_AGE_MS = 60 * 1000; // 60s — umbral de stale post-PID-reuse
+const POSIX_LOCK_MODE = 0o600;   // -rw-------
+
+// Cache del startTime del proceso actual (estable hasta exit).
+const PROCESS_START_ISO = new Date(Date.now() - Math.round(process.uptime() * 1000)).toISOString();
+
+function logWarn(msg) {
+    console.warn(`[file-lock] ${msg}`);
+}
+
+function logInfo(msg) {
+    console.log(`[file-lock] ${msg}`);
+}
+
+function lockPathOf(filePath) {
+    return filePath + '.lock';
+}
+
+function jitter(min, max) {
+    return min + Math.floor(Math.random() * (max - min + 1));
+}
+
+/**
+ * Intenta leer + parsear el contenido del lock. Devuelve null si:
+ *   - el archivo no existe (ENOENT)
+ *   - el contenido no es JSON válido
+ *   - el shape no matchea (pid faltante, no-objeto, etc.)
+ */
+function readLockMeta(lockPath) {
+    let raw;
+    try {
+        raw = fs.readFileSync(lockPath, 'utf8');
+    } catch (err) {
+        if (err && err.code === 'ENOENT') return null;
+        logWarn(`No se pudo leer lock ${lockPath}: ${err.message}`);
+        return null;
+    }
+    let parsed;
+    try {
+        parsed = JSON.parse(raw);
+    } catch (err) {
+        logWarn(`Lock ${lockPath} corrupto: ${err.message}. Tratando como stale.`);
+        return { _corrupt: true };
+    }
+    if (!parsed || typeof parsed !== 'object' || !Number.isInteger(parsed.pid)) {
+        return { _corrupt: true };
+    }
+    return parsed;
+}
+
+/**
+ * Verifica si un PID está vivo. En POSIX usa `process.kill(pid, 0)`.
+ * En Windows también funciona (Node mapea a OpenProcess + check).
+ * Devuelve true si vive, false si ESRCH, throws (defensivo) si EPERM
+ * (vive pero no podemos señalarlo — lo tratamos como vivo para no romper).
+ */
+function isPidAlive(pid) {
+    if (!Number.isInteger(pid) || pid <= 0) return false;
+    try {
+        process.kill(pid, 0);
+        return true;
+    } catch (err) {
+        if (err && err.code === 'ESRCH') return false;
+        if (err && err.code === 'EPERM') return true; // existe, no podemos firmar
+        return false;
+    }
+}
+
+/**
+ * Devuelve true si el lock referenciado por `meta` se considera stale.
+ *
+ * Requiere ambas condiciones (security req #1):
+ *   - meta._corrupt === true, O
+ *   - (PID no vive), O
+ *   - (PID vive PERO el lock tiene > STALE_AGE_MS Y startTime no matchea
+ *     uno de los procesos activos plausibles — heurística para PID reciclado).
+ *
+ * En la práctica, sin un mecanismo cross-process para enumerar startTime real
+ * por PID (sería platform-specific), aproximamos así: si el lock tiene > 60s
+ * Y la antigüedad del propio proceso vivo con ese PID es MENOR que la
+ * antigüedad del lock, el PID es reciclado → stale.
+ *
+ * Solo aplica el "PID reciclado" cuando el PID del lock ES nuestro proceso
+ * y nuestro startTime difiere. Para PIDs ajenos no tenemos cómo verificar
+ * el startTime sin acceso al /proc — caemos a la heurística temporal pura
+ * (lock > 60s + PID vivo asumimos NO stale, conservador).
+ */
+function isStale(meta, lockPath) {
+    if (!meta) return false;
+    if (meta._corrupt) {
+        // CRÍTICO: distinguir "lock corrupto antiguo" de "lock recién creado
+        // sin contenido todavía". Hay una ventana entre `openSync('wx')` y
+        // `writeSync(meta)` donde otro proceso ve un archivo vacío. Si lo
+        // tratamos como stale + unlink, robamos un lock que está siendo
+        // adquirido legítimamente por otro proceso → ambos pasan, corrupción.
+        //
+        // Heurística: si el lock fue modificado hace < 1s, probablemente es
+        // un race durante la creación → NO stale (esperar y reintentar).
+        let lockMtimeMs;
+        try { lockMtimeMs = fs.statSync(lockPath).mtimeMs; } catch { return true; }
+        const lockAgeMs = Date.now() - lockMtimeMs;
+        if (lockAgeMs < 1000) return false; // race transitoria, no stale
+        return true;
+    }
+    if (!isPidAlive(meta.pid)) return true;
+
+    // PID vive — caso conservador. Solo declarar stale si el lock es VIEJO
+    // (>60s) Y se cumple alguna heurística de PID reciclado.
+    let lockMtimeMs;
+    try {
+        lockMtimeMs = fs.statSync(lockPath).mtimeMs;
+    } catch {
+        return true; // si el lock desapareció, no es ours problem
+    }
+    const lockAgeMs = Date.now() - lockMtimeMs;
+    if (lockAgeMs < STALE_AGE_MS) return false;
+
+    // Si es el mismo PID que el nuestro pero startTime distinto → claramente
+    // un PID nuestro fue reciclado o el lock quedó huérfano de una corrida
+    // anterior.
+    if (meta.pid === process.pid && meta.startTime !== PROCESS_START_ISO) {
+        return true;
+    }
+    return false;
+}
+
+/**
+ * Adquiere atómicamente el lock. Devuelve `{ acquired: true, reentrant: bool }`
+ * o tira excepción si no pudo en el timeout configurado.
+ *
+ * Estrategia:
+ *   1. Intenta `fs.openSync(lockPath, 'wx')`.
+ *   2. Si éxito: escribe meta + cierra fd → lock adquirido.
+ *   3. Si EEXIST: lee meta del holder. Si es ours (mismo pid+startTime),
+ *      retorna reentrant. Si es stale → unlink + reintentar. Si está vivo →
+ *      esperar (jitter) y reintentar hasta agotar.
+ */
+/**
+ * Variante síncrona de acquireLock. Misma lógica que la async pero usando
+ * busy-wait corto para el jitter. Ideal para callsites que históricamente
+ * eran sync (ej. partial-pause.setPartialPause) y romperían contrato al
+ * convertirse en async.
+ *
+ * Costo: el busy-wait ocupa CPU durante la espera. Es aceptable porque:
+ *   - jitter máximo es 200ms por intento, max 3 intentos = 600ms peor caso.
+ *   - los writes de partial-pause son raros (humano por Telegram).
+ *   - alternativas como Atomics.wait requieren SharedArrayBuffer y agregan
+ *     complejidad sin beneficio real a esta escala.
+ */
+function acquireLockSync(filePath, opts) {
+    const lockPath = lockPathOf(filePath);
+    const timeoutMs = opts.timeoutMs != null ? opts.timeoutMs : DEFAULT_TIMEOUT_MS;
+    const maxRetries = opts.maxRetries != null ? opts.maxRetries : DEFAULT_MAX_RETRIES;
+    const startedAt = Date.now();
+    let attempts = 0;
+    let lastErr = null;
+
+    while (attempts <= maxRetries) {
+        if (Date.now() - startedAt > timeoutMs) break;
+        try {
+            const fd = fs.openSync(lockPath, 'wx', POSIX_LOCK_MODE);
+            const meta = {
+                pid: process.pid,
+                startTime: PROCESS_START_ISO,
+                hostname: os.hostname(),
+                version: LOCK_SCHEMA_VERSION,
+                acquired_at: new Date().toISOString(),
+            };
+            try {
+                fs.writeSync(fd, JSON.stringify(meta));
+                fs.fsyncSync(fd);
+            } finally {
+                fs.closeSync(fd);
+            }
+            return { acquired: true, reentrant: false, lockPath };
+        } catch (err) {
+            lastErr = err;
+            if (err && err.code === 'EEXIST') {
+                const holder = readLockMeta(lockPath);
+                if (holder && holder.pid === process.pid && holder.startTime === PROCESS_START_ISO) {
+                    return { acquired: true, reentrant: true, lockPath };
+                }
+                if (isStale(holder, lockPath)) {
+                    try { fs.unlinkSync(lockPath); } catch {}
+                    continue;
+                }
+                attempts++;
+                const wait = jitter(50, 200);
+                const deadline = Date.now() + wait;
+                while (Date.now() < deadline) { /* busy wait */ }
+                continue;
+            }
+            throw err;
+        }
+    }
+
+    const elapsed = Date.now() - startedAt;
+    const errMsg = lastErr ? lastErr.message : 'timeout sin error específico';
+    const meta = readLockMeta(lockPath) || {};
+    const e = new Error(
+        `withLockSync: timeout ${timeoutMs}ms tras ${attempts} reintentos (elapsed=${elapsed}ms) — `
+        + `holder pid=${meta.pid || '?'} host=${meta.hostname || '?'} start=${meta.startTime || '?'}. `
+        + `Último error: ${errMsg}`,
+    );
+    e.code = 'ELOCK_TIMEOUT';
+    e.lockPath = lockPath;
+    e.holder = meta;
+    throw e;
+}
+
+/**
+ * Wrapper sync. Misma semántica que withLock, pero la función `fn` debe ser
+ * síncrona (no Promise). Útil para callsites legacy que históricamente eran
+ * sync.
+ *
+ * @param {string} filePath
+ * @param {() => T} fn — función SÍNCRONA
+ * @param {object} [opts] — mismas opciones que withLock
+ * @returns {T}
+ */
+function withLockSync(filePath, fn, opts = {}) {
+    const component = opts.component || 'file-lock';
+    let acquisition;
+    try {
+        acquisition = acquireLockSync(filePath, opts);
+    } catch (err) {
+        if (typeof opts.notify === 'function') {
+            try {
+                opts.notify({
+                    level: 'error',
+                    component,
+                    message: `timeout adquiriendo lock sobre ${path.basename(filePath)}`,
+                    diag: `cat ${err.lockPath || filePath + '.lock'}`,
+                    detail: err.message,
+                    holder: err.holder || null,
+                });
+            } catch {}
+        }
+        throw err;
+    }
+    try {
+        return fn();
+    } finally {
+        if (!acquisition.reentrant) {
+            releaseLock(filePath);
+        }
+    }
+}
+
+async function acquireLock(filePath, opts) {
+    const lockPath = lockPathOf(filePath);
+    const timeoutMs = opts.timeoutMs != null ? opts.timeoutMs : DEFAULT_TIMEOUT_MS;
+    const maxRetries = opts.maxRetries != null ? opts.maxRetries : DEFAULT_MAX_RETRIES;
+    const startedAt = Date.now();
+    let attempts = 0;
+    let lastErr = null;
+
+    while (attempts <= maxRetries) {
+        if (Date.now() - startedAt > timeoutMs) break;
+        try {
+            const fd = fs.openSync(lockPath, 'wx', POSIX_LOCK_MODE);
+            const meta = {
+                pid: process.pid,
+                startTime: PROCESS_START_ISO,
+                hostname: os.hostname(),
+                version: LOCK_SCHEMA_VERSION,
+                acquired_at: new Date().toISOString(),
+            };
+            try {
+                fs.writeSync(fd, JSON.stringify(meta));
+                fs.fsyncSync(fd);
+            } finally {
+                fs.closeSync(fd);
+            }
+            return { acquired: true, reentrant: false, lockPath };
+        } catch (err) {
+            lastErr = err;
+            if (err && err.code === 'EEXIST') {
+                const holder = readLockMeta(lockPath);
+                if (holder && holder.pid === process.pid && holder.startTime === PROCESS_START_ISO) {
+                    // Reentrancia: ya teníamos el lock. No volvemos a tocarlo.
+                    return { acquired: true, reentrant: true, lockPath };
+                }
+                if (isStale(holder, lockPath)) {
+                    logWarn(`Lock stale detectado en ${lockPath} (holder pid=${holder && holder.pid}). Removiendo.`);
+                    try { fs.unlinkSync(lockPath); } catch {}
+                    continue; // retry inmediato
+                }
+                // Holder vivo — esperar con jitter y reintentar.
+                attempts++;
+                const wait = jitter(50, 200);
+                await new Promise((r) => setTimeout(r, wait));
+                continue;
+            }
+            // Errores no-EEXIST (EPERM, EACCES, ENOSPC, etc.) — abortar.
+            throw err;
+        }
+    }
+
+    const elapsed = Date.now() - startedAt;
+    const errMsg = lastErr ? lastErr.message : 'timeout sin error específico';
+    const meta = readLockMeta(lockPath) || {};
+    const e = new Error(
+        `withLock: timeout ${timeoutMs}ms tras ${attempts} reintentos (elapsed=${elapsed}ms) — `
+        + `holder pid=${meta.pid || '?'} host=${meta.hostname || '?'} start=${meta.startTime || '?'}. `
+        + `Último error: ${errMsg}`,
+    );
+    e.code = 'ELOCK_TIMEOUT';
+    e.lockPath = lockPath;
+    e.holder = meta;
+    throw e;
+}
+
+/**
+ * Libera el lock SI Y SOLO SI somos los dueños. No-op si el lock ya no existe
+ * o pertenece a otro proceso (no robar locks ajenos).
+ */
+function releaseLock(filePath) {
+    const lockPath = lockPathOf(filePath);
+    const meta = readLockMeta(lockPath);
+    if (!meta) return false;
+    if (meta._corrupt) {
+        try { fs.unlinkSync(lockPath); } catch {}
+        return true;
+    }
+    if (meta.pid === process.pid && meta.startTime === PROCESS_START_ISO) {
+        try { fs.unlinkSync(lockPath); return true; } catch (err) {
+            logWarn(`No se pudo liberar lock ${lockPath}: ${err.message}`);
+            return false;
+        }
+    }
+    return false;
+}
+
+/**
+ * Wrapper principal. Ejecuta `fn` bajo el lock asociado a `filePath` y libera
+ * en finally. Si falla la adquisición → llama a `opts.notify` (si está
+ * provisto) y propaga la excepción.
+ *
+ * @param {string} filePath
+ * @param {() => (Promise<T>|T)} fn
+ * @param {object} [opts]
+ * @param {number} [opts.timeoutMs=5000]
+ * @param {number} [opts.maxRetries=3]
+ * @param {(payload: object) => void} [opts.notify] — invoked en fallo final
+ *        con { level, component, message, diag }.
+ * @param {string} [opts.component='file-lock']
+ * @returns {Promise<T>}
+ */
+async function withLock(filePath, fn, opts = {}) {
+    const component = opts.component || 'file-lock';
+    let acquisition;
+    try {
+        acquisition = await acquireLock(filePath, opts);
+    } catch (err) {
+        // Alerta Telegram OBLIGATORIA en fallo final (security req #2).
+        if (typeof opts.notify === 'function') {
+            try {
+                opts.notify({
+                    level: 'error',
+                    component,
+                    message: `timeout adquiriendo lock sobre ${path.basename(filePath)}`,
+                    diag: `cat ${err.lockPath || filePath + '.lock'}`,
+                    detail: err.message,
+                    holder: err.holder || null,
+                });
+            } catch {} // notify NUNCA debe romper la propagación del error real
+        }
+        throw err;
+    }
+
+    try {
+        return await fn();
+    } finally {
+        // En reentrancia, NO liberamos: el frame externo lo hará.
+        if (!acquisition.reentrant) {
+            releaseLock(filePath);
+        }
+    }
+}
+
+module.exports = {
+    withLock,
+    withLockSync,
+    acquireLock,
+    acquireLockSync,
+    releaseLock,
+    // Helpers expuestos para tests:
+    _internal: {
+        readLockMeta,
+        isPidAlive,
+        isStale,
+        lockPathOf,
+        PROCESS_START_ISO,
+        LOCK_SCHEMA_VERSION,
+        STALE_AGE_MS,
+        POSIX_LOCK_MODE,
+    },
+};

--- a/.pipeline/lib/file-lock.js
+++ b/.pipeline/lib/file-lock.js
@@ -26,8 +26,15 @@
 //
 // Política de reintentos (security req #2)
 // -----------------------------------------
-//   timeout: 5000ms total
-//   max retries: 3 (con jitter 50-200ms entre intentos)
+//   timeout: 5000ms total (boundary primaria — el loop termina cuando se
+//            agota este presupuesto, no antes).
+//   max retries: 3 (informativo / soft signal — usado para reporting en el
+//                   mensaje de error; el loop NO termina solo por agotarlo).
+//   jitter: 50-200ms entre intentos. Bajo contención de N workers, varios
+//           reintentos son normales: 10 workers × ~80ms cada uno serializado
+//           = ~800ms bajo lock + jitter. El timeout de 5000ms cubre ~50 retries
+//           en el peor caso, que es lo que necesitamos para que todos converjan
+//           antes de tirar ELOCK_TIMEOUT.
 //   en fallo final: notifica Telegram + tira excepción (NUNCA esperar inf).
 //
 // Permisos (security req #6)
@@ -216,13 +223,16 @@ function isStale(meta, lockPath) {
 function acquireLockSync(filePath, opts) {
     const lockPath = lockPathOf(filePath);
     const timeoutMs = opts.timeoutMs != null ? opts.timeoutMs : DEFAULT_TIMEOUT_MS;
+    // maxRetries es informativo (aparece en el mensaje de error para reporting).
+    // El loop NO termina por agotarlo; solo por agotar el budget de timeoutMs.
+    // Bajo contención de N workers concurrentes, varios reintentos son esperables
+    // y forzar un cap bajo causa lock-starvation espuria (CA-8 regression).
     const maxRetries = opts.maxRetries != null ? opts.maxRetries : DEFAULT_MAX_RETRIES;
     const startedAt = Date.now();
     let attempts = 0;
     let lastErr = null;
 
-    while (attempts <= maxRetries) {
-        if (Date.now() - startedAt > timeoutMs) break;
+    while (Date.now() - startedAt <= timeoutMs) {
         try {
             const fd = fs.openSync(lockPath, 'wx', POSIX_LOCK_MODE);
             const meta = {
@@ -251,7 +261,10 @@ function acquireLockSync(filePath, opts) {
                     continue;
                 }
                 attempts++;
-                const wait = jitter(50, 200);
+                // Bound el wait por lo que reste del timeout para no excederlo.
+                const remaining = timeoutMs - (Date.now() - startedAt);
+                if (remaining <= 0) break;
+                const wait = Math.min(jitter(50, 200), remaining);
                 const deadline = Date.now() + wait;
                 while (Date.now() < deadline) { /* busy wait */ }
                 continue;
@@ -264,7 +277,7 @@ function acquireLockSync(filePath, opts) {
     const errMsg = lastErr ? lastErr.message : 'timeout sin error específico';
     const meta = readLockMeta(lockPath) || {};
     const e = new Error(
-        `withLockSync: timeout ${timeoutMs}ms tras ${attempts} reintentos (elapsed=${elapsed}ms) — `
+        `withLockSync: timeout ${timeoutMs}ms tras ${attempts} reintentos (elapsed=${elapsed}ms, maxRetries=${maxRetries}) — `
         + `holder pid=${meta.pid || '?'} host=${meta.hostname || '?'} start=${meta.startTime || '?'}. `
         + `Último error: ${errMsg}`,
     );
@@ -316,13 +329,14 @@ function withLockSync(filePath, fn, opts = {}) {
 async function acquireLock(filePath, opts) {
     const lockPath = lockPathOf(filePath);
     const timeoutMs = opts.timeoutMs != null ? opts.timeoutMs : DEFAULT_TIMEOUT_MS;
+    // maxRetries informativo (ver acquireLockSync). El loop usa timeoutMs como
+    // boundary primaria; maxRetries solo aparece en el error final para diag.
     const maxRetries = opts.maxRetries != null ? opts.maxRetries : DEFAULT_MAX_RETRIES;
     const startedAt = Date.now();
     let attempts = 0;
     let lastErr = null;
 
-    while (attempts <= maxRetries) {
-        if (Date.now() - startedAt > timeoutMs) break;
+    while (Date.now() - startedAt <= timeoutMs) {
         try {
             const fd = fs.openSync(lockPath, 'wx', POSIX_LOCK_MODE);
             const meta = {
@@ -354,7 +368,9 @@ async function acquireLock(filePath, opts) {
                 }
                 // Holder vivo — esperar con jitter y reintentar.
                 attempts++;
-                const wait = jitter(50, 200);
+                const remaining = timeoutMs - (Date.now() - startedAt);
+                if (remaining <= 0) break;
+                const wait = Math.min(jitter(50, 200), remaining);
                 await new Promise((r) => setTimeout(r, wait));
                 continue;
             }
@@ -367,7 +383,7 @@ async function acquireLock(filePath, opts) {
     const errMsg = lastErr ? lastErr.message : 'timeout sin error específico';
     const meta = readLockMeta(lockPath) || {};
     const e = new Error(
-        `withLock: timeout ${timeoutMs}ms tras ${attempts} reintentos (elapsed=${elapsed}ms) — `
+        `withLock: timeout ${timeoutMs}ms tras ${attempts} reintentos (elapsed=${elapsed}ms, maxRetries=${maxRetries}) — `
         + `holder pid=${meta.pid || '?'} host=${meta.hostname || '?'} start=${meta.startTime || '?'}. `
         + `Último error: ${errMsg}`,
     );

--- a/.pipeline/lib/notify-telegram.js
+++ b/.pipeline/lib/notify-telegram.js
@@ -1,0 +1,201 @@
+// =============================================================================
+// notify-telegram.js — Helper genérico para emitir alertas operacionales
+// del control plane (waves, partial-pause, file-lock) — issue #3518.
+//
+// Por qué este helper existe
+// --------------------------
+// El pipeline ya tiene notifiers específicos (quota-notifier, telegram-notifier,
+// notifier-infra-recovered, etc.), cada uno con su semántica. NO hay un punto
+// canónico para "alerta operacional de bloqueante con call-to-action a Leo"
+// como pide el CA-9 de #3518.
+//
+// Este helper resuelve eso con una firma única:
+//
+//   notifyTelegram({ level, component, message, diag, context? })
+//
+// Y deposita un JSON drop en `.pipeline/servicios/telegram/pendiente/` con
+// el formato que `servicio-telegram.js` ya sabe leer (`{ text, parse_mode }`).
+// Fire-and-forget — si el servicio Telegram está caído, el archivo queda
+// encolado y se procesará al volver.
+//
+// Estructura del mensaje (CA-9 de #3518, guidelines de UX)
+// ---------------------------------------------------------
+//   <emoji severidad> <component>: <resumen 1 línea>
+//
+//   <contexto: PID, host, timestamp ISO>
+//
+//   <call-to-action concreto>
+//
+//   (diag: <comando o path>)
+//
+// Severidades
+// -----------
+//   'error'   → 🚨 (bloqueante, requiere acción inmediata)
+//   'warn'    → ⚠️  (degradado, requiere atención pero no urgente)
+//   'info'    → ℹ️  (informativo, sin acción requerida)
+//
+// Reglas inquebrantables (security + UX)
+// --------------------------------------
+//   - NUNCA stacktraces crudos en el mensaje. El stacktrace va al log file.
+//   - PID + hostname + timestamp ISO SIEMPRE en alertas de lock/concurrencia.
+//   - Idioma: español. Términos técnicos del stack en inglés (lock, fsync, PID).
+//   - Cero deps npm. Cero red directa — usa la cola del servicio-telegram.
+//   - Fail-soft: si el drop falla (FS lleno, permisos), NO propaga — solo
+//     loguea warning. Una alerta perdida no debe romper el caller.
+// =============================================================================
+
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const PIPELINE_DIR_DEFAULT = path.join(__dirname, '..');
+
+function pipelineDir() {
+    if (process.env.PIPELINE_DIR_OVERRIDE) return process.env.PIPELINE_DIR_OVERRIDE;
+    return PIPELINE_DIR_DEFAULT;
+}
+
+function telegramQueueDir() {
+    return path.join(pipelineDir(), 'servicios', 'telegram', 'pendiente');
+}
+
+const EMOJI_BY_LEVEL = Object.freeze({
+    error: '\u{1F6A8}', // 🚨
+    warn: '\u{26A0}\u{FE0F}',  // ⚠️
+    info: '\u{2139}\u{FE0F}',  // ℹ️
+});
+
+function emojiFor(level) {
+    return EMOJI_BY_LEVEL[level] || EMOJI_BY_LEVEL.info;
+}
+
+/**
+ * Construye el texto del mensaje a partir del payload estructurado.
+ * Determinístico — los tests pueden comparar string-equal sobre la salida
+ * (excepto por timestamp si el caller no lo provee).
+ */
+function buildMessage(payload) {
+    const level = payload.level || 'info';
+    const component = String(payload.component || 'pipeline');
+    const summary = String(payload.message || '(sin descripción)');
+    const diag = payload.diag ? String(payload.diag) : null;
+    const ts = payload.ts || new Date().toISOString();
+    const ctx = payload.context && typeof payload.context === 'object' ? payload.context : {};
+
+    const lines = [];
+    lines.push(`${emojiFor(level)} ${component}: ${summary}`);
+    lines.push('');
+
+    // Contexto: holder (PID, host), timestamp, campos custom.
+    const ctxLines = [];
+    if (payload.holder && typeof payload.holder === 'object') {
+        const h = payload.holder;
+        const parts = [];
+        if (h.pid) parts.push(`pid=${h.pid}`);
+        if (h.hostname) parts.push(`host=${h.hostname}`);
+        if (h.startTime) parts.push(`start=${h.startTime}`);
+        if (parts.length > 0) ctxLines.push(`holder: ${parts.join(' ')}`);
+    }
+    for (const key of Object.keys(ctx)) {
+        const val = ctx[key];
+        if (val == null || val === '') continue;
+        ctxLines.push(`${key}: ${typeof val === 'object' ? JSON.stringify(val) : String(val)}`);
+    }
+    ctxLines.push(`emisor: pid=${process.pid} host=${os.hostname()} ts=${ts}`);
+    lines.push(...ctxLines);
+    lines.push('');
+
+    // Acción concreta (recomendable que el caller la inyecte explícitamente).
+    if (payload.action) {
+        lines.push(String(payload.action));
+        lines.push('');
+    }
+
+    // Detalle adicional (1 línea, sin stacktrace). Cap defensivo 400 chars.
+    if (payload.detail) {
+        const det = String(payload.detail).replace(/\s+/g, ' ').slice(0, 400);
+        lines.push(`detalle: ${det}`);
+    }
+
+    if (diag) {
+        lines.push(`(diag: ${diag})`);
+    }
+
+    return lines.join('\n');
+}
+
+/**
+ * Emite una alerta operacional a Telegram. Fire-and-forget.
+ *
+ * @param {object} payload
+ * @param {'error'|'warn'|'info'} [payload.level='info']
+ * @param {string} payload.component   — ej. 'waves-lock', 'waves-schema'
+ * @param {string} payload.message     — resumen 1 línea
+ * @param {string} [payload.diag]      — comando/path de diagnóstico
+ * @param {string} [payload.action]    — call-to-action concreto para Leo
+ * @param {string} [payload.detail]    — info adicional (1 línea, sin stack)
+ * @param {object} [payload.context]   — campos custom k:v
+ * @param {object} [payload.holder]    — { pid, hostname, startTime } del holder
+ *                                       (caso lock timeout)
+ * @returns {{ ok: boolean, dropPath?: string, reason?: string }}
+ */
+function notifyTelegram(payload) {
+    if (!payload || typeof payload !== 'object') {
+        return { ok: false, reason: 'invalid_payload' };
+    }
+    if (!payload.component || !payload.message) {
+        return { ok: false, reason: 'missing_required_fields' };
+    }
+
+    let text;
+    try {
+        text = buildMessage(payload);
+    } catch (err) {
+        console.warn(`[notify-telegram] error construyendo mensaje: ${err.message}`);
+        return { ok: false, reason: 'build_failed' };
+    }
+
+    const dir = telegramQueueDir();
+    try {
+        fs.mkdirSync(dir, { recursive: true });
+    } catch (err) {
+        console.warn(`[notify-telegram] no se pudo crear ${dir}: ${err.message}`);
+        return { ok: false, reason: 'mkdir_failed' };
+    }
+
+    const ts = Date.now();
+    // Identificador único por componente para evitar colisiones cuando dos
+    // alertas del mismo componente caen en el mismo ms.
+    const slug = String(payload.component).replace(/[^a-zA-Z0-9_-]/g, '-').slice(0, 32);
+    const filename = `alert-${slug}-${ts}-${process.pid}.json`;
+    const dropPath = path.join(dir, filename);
+
+    const drop = {
+        text,
+        // El servicio default usa Markdown; nuestro texto no lleva sintaxis MD,
+        // se renderiza igual como texto plano. Pasamos 'Markdown' por consistencia
+        // con el resto del pipeline (no rompe nada — caracteres safe).
+        parse_mode: 'Markdown',
+    };
+
+    try {
+        fs.writeFileSync(dropPath, JSON.stringify(drop, null, 2));
+        return { ok: true, dropPath };
+    } catch (err) {
+        console.warn(`[notify-telegram] no se pudo escribir ${dropPath}: ${err.message}`);
+        return { ok: false, reason: 'write_failed' };
+    }
+}
+
+module.exports = {
+    notifyTelegram,
+    // Helpers exportados para tests
+    _internal: {
+        buildMessage,
+        emojiFor,
+        telegramQueueDir,
+        EMOJI_BY_LEVEL,
+    },
+};

--- a/.pipeline/lib/partial-pause.js
+++ b/.pipeline/lib/partial-pause.js
@@ -29,6 +29,12 @@
 
 const fs = require('fs');
 const path = require('path');
+const { withLockSync } = require('./file-lock');
+const { notifyTelegram } = require('./notify-telegram');
+const { atomicWriteFile } = require('./waves');
+
+const LOCK_TIMEOUT_MS = 5000;
+const LOCK_MAX_RETRIES = 3;
 
 function pipelineDir() {
     // Permitir override en tests vía env var
@@ -174,12 +180,23 @@ function setPartialPause(issues, opts = {}) {
         }
         if (Object.keys(filtered).length > 0) data.dep_sources = filtered;
     }
-    writeAtomic(partialFile(), JSON.stringify(data, null, 2));
-    return {
-        ok: true,
-        allowedIssues: unique,
-        msg: `Pausa parcial activa — allowed: ${unique.map(i => `#${i}`).join(', ')}`,
-    };
+    // CA-2: write atómico (tmp + fsync + rename) bajo lock. Antes era un
+    // writeFileSync directo — si dos /wave promote llegaban a la vez, el
+    // segundo podía pisar al primero o dejar un JSON truncado si moría
+    // a mitad del write.
+    return withLockSync(partialFile(), () => {
+        atomicWriteFile(partialFile(), JSON.stringify(data, null, 2));
+        return {
+            ok: true,
+            allowedIssues: unique,
+            msg: `Pausa parcial activa — allowed: ${unique.map(i => `#${i}`).join(', ')}`,
+        };
+    }, {
+        component: 'partial-pause-lock',
+        timeoutMs: LOCK_TIMEOUT_MS,
+        maxRetries: LOCK_MAX_RETRIES,
+        notify: notifyTelegram,
+    });
 }
 
 /**
@@ -277,14 +294,24 @@ function writeAtomic(targetPath, content) {
 
 /**
  * Desactiva la pausa parcial (elimina marker).
+ *
+ * CA-2: bajo lock para evitar que un unlink pise un write en curso.
+ *
  * @returns {{ok: boolean, existed: boolean}}
  */
 function clearPartialPause() {
-    const existed = fs.existsSync(partialFile());
-    if (existed) {
-        try { fs.unlinkSync(partialFile()); } catch {}
-    }
-    return { ok: true, existed };
+    return withLockSync(partialFile(), () => {
+        const existed = fs.existsSync(partialFile());
+        if (existed) {
+            try { fs.unlinkSync(partialFile()); } catch {}
+        }
+        return { ok: true, existed };
+    }, {
+        component: 'partial-pause-lock',
+        timeoutMs: LOCK_TIMEOUT_MS,
+        maxRetries: LOCK_MAX_RETRIES,
+        notify: notifyTelegram,
+    });
 }
 
 /**

--- a/.pipeline/lib/waves.js
+++ b/.pipeline/lib/waves.js
@@ -35,6 +35,8 @@
 const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
+const { withLockSync } = require('./file-lock');
+const { notifyTelegram } = require('./notify-telegram');
 
 const SCHEMA_VERSION = '1.0';
 const CACHE_TTL_MS = 2000;
@@ -42,6 +44,14 @@ const CACHE_TTL_MS = 2000;
 // #3520 — TTL para considerar un marker `wave-promote.in-progress.json`
 // como stale (rollback automático). Configurable vía env para tests.
 const DEFAULT_PROMOTE_RECOVERY_TTL_MS = 30 * 1000;
+
+// Reintentos para rename en Windows ante EPERM/EBUSY (antivirus, indexer, etc.)
+const RENAME_MAX_RETRIES = 3;
+const RENAME_RETRY_BACKOFF_MS = 50;
+
+// Lock acquisition: 5s timeout, 3 retries con jitter.
+const LOCK_TIMEOUT_MS = 5000;
+const LOCK_MAX_RETRIES = 3;
 
 // Cache por pipelineRoot — mismo shape que wave-state.js.
 const cache = new Map(); // pipelineRoot → { state, ts }
@@ -70,6 +80,63 @@ function listPromoteFailedMarkers() {
             .map((f) => path.join(pipelineDir(), f));
     } catch {
         return [];
+    }
+}
+
+// CA-7: validar que archived/ resuelva dentro de .pipeline/ — defensa en
+// profundidad ante symlink traversal.
+function assertArchivedDirSafe() {
+    const root = path.resolve(pipelineDir());
+    const target = path.resolve(archivedDir());
+    if (target !== root && !target.startsWith(root + path.sep)) {
+        throw new Error(`archived/ resuelve fuera de pipelineDir: ${target} ∉ ${root}`);
+    }
+    if (fs.existsSync(target)) {
+        let real;
+        try { real = fs.realpathSync(target); } catch { real = target; }
+        if (real !== root && !real.startsWith(root + path.sep)) {
+            throw new Error(`archived/ symlink apunta fuera de pipelineDir: ${real} ∉ ${root}`);
+        }
+    }
+}
+
+/**
+ * Write atómico con fsync y reintentos en Windows (CA-1, CA-2 shared helper).
+ * Exportado para que partial-pause.js use la misma implementación (DRY).
+ */
+function atomicWriteFile(targetPath, data) {
+    const tmp = targetPath + '.tmp';
+    let wroteTmp = false;
+    try {
+        fs.writeFileSync(tmp, data);
+        wroteTmp = true;
+        const fd = fs.openSync(tmp, 'r+');
+        try { fs.fsyncSync(fd); } finally { fs.closeSync(fd); }
+
+        let attempt = 0;
+        let lastErr = null;
+        while (attempt < RENAME_MAX_RETRIES) {
+            try {
+                fs.renameSync(tmp, targetPath);
+                wroteTmp = false;
+                return;
+            } catch (err) {
+                lastErr = err;
+                const code = err && err.code;
+                if (code === 'EPERM' || code === 'EBUSY' || code === 'EACCES') {
+                    attempt++;
+                    const deadline = Date.now() + RENAME_RETRY_BACKOFF_MS;
+                    while (Date.now() < deadline) { /* spin defensivo */ }
+                    continue;
+                }
+                throw err;
+            }
+        }
+        throw lastErr || new Error('rename agotó reintentos sin error específico');
+    } finally {
+        if (wroteTmp) {
+            try { fs.unlinkSync(tmp); } catch {}
+        }
     }
 }
 
@@ -275,6 +342,23 @@ function addIssueToWave(waveNumber, issue, meta = {}) {
         throw new Error(`addIssueToWave: issue.number inválido (${issue.number})`);
     }
 
+    // CA-3 + lost-update fix: el read-modify-write completo debe correr bajo
+    // lock, no solo el write. Antes, dos procesos podían loadWaves() del
+    // mismo estado base, mutar en memoria, y el segundo saveState() pisaba
+    // al primero. La reentrancia de withLockSync hace que el saveState
+    // interno comparta este mismo lock sin re-adquirir.
+    return withLockSync(wavesFile(), () => addIssueToWaveLocked(waveNumber, issue, n, meta), {
+        component: 'waves-lock',
+        timeoutMs: LOCK_TIMEOUT_MS,
+        maxRetries: LOCK_MAX_RETRIES,
+        notify: notifyTelegram,
+    });
+}
+
+function addIssueToWaveLocked(waveNumber, issue, n, meta) {
+    // CA-4: invalidar cache ANTES de leer. Garantiza que veamos el último
+    // commit en disco sin depender de que el caller se acordara de hacerlo.
+    invalidateCache();
     const state = loadWaves();
 
     // Verificar conflicto en otras olas.
@@ -330,6 +414,18 @@ function addIssueToWave(waveNumber, issue, meta = {}) {
  * @throws si la ola planificada no existe
  */
 function promoteWaveToActive(waveNumber, metadata = {}) {
+    // Read-modify-write completo bajo lock (mismo fix que addIssueToWave).
+    return withLockSync(wavesFile(), () => promoteWaveToActiveLocked(waveNumber, metadata), {
+        component: 'waves-lock',
+        timeoutMs: LOCK_TIMEOUT_MS,
+        maxRetries: LOCK_MAX_RETRIES,
+        notify: notifyTelegram,
+    });
+}
+
+function promoteWaveToActiveLocked(waveNumber, metadata) {
+    // CA-4: invalidar cache ANTES de leer (idem addIssueToWave).
+    invalidateCache();
     const state = loadWaves();
     const idx = state.planned_waves.findIndex((x) => x.number === waveNumber);
     if (idx < 0) {
@@ -524,8 +620,34 @@ function save(metadata = {}) {
 
 /**
  * Variante interna: persiste un state ya construido (evita re-load).
+ *
+ * Concurrencia: usa `withLock` sobre waves.json para serializar writes
+ * destructivos del Commander. El lock se libera siempre en finally (CA-3).
+ *
+ * Integridad: el merge meta + read-modify-write se hace bajo el lock, con
+ * re-read del disco para evitar last-write-wins basado en TTL cache stale
+ * (security gap #c — Optimistic Concurrency Control vía re-load).
+ *
+ * Atomicidad: tmp + fsync + rename con retry EPERM/EBUSY en Windows (CA-1).
+ *
+ * Schema validation: el state que se persiste pasa por `validateStateStrict`
+ * primero. Un state corrupto NO se escribe nunca (CA-5).
  */
 function saveState(state, metadata = {}) {
+    // CA-3: sync porque los callers existentes (addIssueToWave,
+    // promoteWaveToActive y el commander) no esperan Promise. Cambiar a async
+    // sería breaking. withLockSync usa busy-wait corto durante el jitter, lo
+    // cual es aceptable para la frecuencia de escrituras destructivas (humano
+    // por Telegram, no path caliente).
+    return withLockSync(wavesFile(), () => saveStateLocked(state, metadata), {
+        component: 'waves-lock',
+        timeoutMs: LOCK_TIMEOUT_MS,
+        maxRetries: LOCK_MAX_RETRIES,
+        notify: notifyTelegram,
+    });
+}
+
+function saveStateLocked(state, metadata = {}) {
     if (!state.meta) state.meta = {};
     state.meta.updated_at = nowIso();
     if (metadata.updated_by) state.meta.updated_by = metadata.updated_by;
@@ -533,10 +655,37 @@ function saveState(state, metadata = {}) {
     if (metadata.note) state.meta.note = metadata.note;
     if (!state.meta.created_at) state.meta.created_at = state.meta.updated_at;
 
+    // CA-5: validar shape ANTES de persistir. Un state inválido se rechaza
+    // con excepción + alerta — preferimos perder el write a corromper disco.
+    const validationErrors = validateStateStrict(state, { source: 'pre-write' });
+    if (validationErrors.length > 0) {
+        const msg = `waves.json: shape inválida pre-write — ${validationErrors.join('; ')}`;
+        try {
+            notifyTelegram({
+                level: 'error',
+                component: 'waves-schema',
+                message: 'shape inválida detectada pre-write',
+                detail: validationErrors.join('; '),
+                action: 'Pipeline en modo human-block. Revisá el state antes de re-disparar el write.',
+                diag: `jq . ${wavesFile()}.tmp 2>/dev/null || cat ${wavesFile()}.tmp`,
+            });
+        } catch {}
+        const e = new Error(msg);
+        e.code = 'EWAVES_SCHEMA';
+        throw e;
+    }
+
+    // CA-7: validar archived/ antes de tocarlo (defensa symlink traversal).
+    try { assertArchivedDirSafe(); } catch (err) {
+        logWarn(`assertArchivedDirSafe falló: ${err.message}. Continuando sin backup.`);
+    }
+
     // Backup ANTES de sobreescribir (si existe waves.json previo).
     try {
         if (fs.existsSync(wavesFile())) {
             ensureDir(archivedDir());
+            // ts viene exclusivamente de state.meta.updated_at (derivado de
+            // Date.now() vía nowIso) — security req: nunca de input externo.
             const ts = state.meta.updated_at.replace(/[:.]/g, '-');
             const backup = path.join(archivedDir(), `waves.${ts}.json`);
             try {
@@ -549,20 +698,139 @@ function saveState(state, metadata = {}) {
         logWarn(`Error preparando backup: ${err.message}`);
     }
 
-    // Write atómico: tmp + renameSync.
-    const tmp = wavesFile() + '.tmp';
+    // Write atómico vía helper compartido (CA-1: tmp + fsync + rename + retry).
     try {
-        fs.writeFileSync(tmp, JSON.stringify(state, null, 2));
-        fs.renameSync(tmp, wavesFile());
+        atomicWriteFile(wavesFile(), JSON.stringify(state, null, 2));
     } catch (err) {
         logWarn(`Error escribiendo waves.json: ${err.message}`);
-        try { fs.unlinkSync(tmp); } catch {}
         throw err;
     }
 
     // Invalidar cache post-save.
     invalidateCache();
     logInfo(`waves.json persistido (updated_by=${state.meta.updated_by}, source=${state.meta.source}).`);
+}
+
+/**
+ * Validación estricta de shape (CA-5). Devuelve array de errores.
+ * Si hay 0 errores → state válido. Si hay > 0 → caller decide (excepción
+ * vs degradación). Esta función NUNCA tira ni auto-repara.
+ *
+ * Comparado con `validate()` (legacy boolean + log), esta variante:
+ *   - Es pura (no escribe a console).
+ *   - Devuelve errores detallados accionables.
+ *   - Es la base de la verificación pre-write y post-load strict.
+ */
+function validateStateStrict(raw, opts = {}) {
+    const errors = [];
+    if (!raw || typeof raw !== 'object') {
+        errors.push('state debe ser objeto');
+        return errors;
+    }
+    if (raw.version !== SCHEMA_VERSION) {
+        errors.push(`version esperada ${SCHEMA_VERSION}, recibida ${JSON.stringify(raw.version)}`);
+    }
+    if (!raw.meta || typeof raw.meta !== 'object') {
+        errors.push('meta ausente o no-objeto');
+    } else {
+        // meta.updated_at debe ser ISO parseable.
+        if (typeof raw.meta.updated_at !== 'string' || !Number.isFinite(Date.parse(raw.meta.updated_at))) {
+            errors.push(`meta.updated_at no es ISO string parseable (recibido: ${JSON.stringify(raw.meta.updated_at)})`);
+        }
+    }
+    if (raw.active_wave !== null && raw.active_wave !== undefined && typeof raw.active_wave !== 'object') {
+        errors.push(`active_wave debe ser objeto o null, recibido: ${typeof raw.active_wave}`);
+    }
+    if (raw.active_wave && typeof raw.active_wave === 'object' && raw.active_wave.issues !== undefined && !Array.isArray(raw.active_wave.issues)) {
+        errors.push('active_wave.issues debe ser array');
+    }
+    if (raw.planned_waves !== undefined && !Array.isArray(raw.planned_waves)) {
+        errors.push('planned_waves debe ser array');
+    }
+    if (raw.archived_waves !== undefined && !Array.isArray(raw.archived_waves)) {
+        errors.push('archived_waves debe ser array');
+    }
+    if (raw.dependencies !== undefined && !Array.isArray(raw.dependencies)) {
+        errors.push('dependencies debe ser array');
+    }
+    return errors;
+}
+
+/**
+ * Variante strict de loadWaves (CA-5). Lee el DISCO sin tolerancia: si el
+ * shape no matchea, tira excepción + emite alerta Telegram. NO normaliza
+ * defaults silenciosamente (eso lo hace loadWaves legacy, intencionalmente
+ * permisivo para los consumers existentes).
+ *
+ * Use case: cualquier código nuevo (CA-6 desync detector, futuros consumers)
+ * debería preferir esta variante. El callsite de loadWaves legacy queda
+ * intacto para no romper consumers.
+ *
+ * @throws Error con code='EWAVES_SCHEMA' si el shape es inválido.
+ */
+function loadStateStrict() {
+    const file = wavesFile();
+    if (!fs.existsSync(file)) {
+        // Sin archivo → estado vacío válido. NO alertar (caso normal en startup
+        // fresco, no es corrupción).
+        return emptyState();
+    }
+    let raw;
+    try {
+        raw = fs.readFileSync(file, 'utf8');
+    } catch (err) {
+        const msg = `waves.json: no se pudo leer (${err.message})`;
+        try {
+            notifyTelegram({
+                level: 'error',
+                component: 'waves-schema',
+                message: 'read falló sobre waves.json',
+                detail: err.message,
+                action: 'Verificá permisos/espacio en disco. Pipeline en modo human-block.',
+                diag: `ls -la ${file} && df -h`,
+            });
+        } catch {}
+        const e = new Error(msg);
+        e.code = 'EWAVES_READ';
+        throw e;
+    }
+    let parsed;
+    try {
+        parsed = JSON.parse(raw);
+    } catch (err) {
+        const msg = `waves.json: JSON inválido (${err.message})`;
+        try {
+            notifyTelegram({
+                level: 'error',
+                component: 'waves-schema',
+                message: 'JSON corrupto en waves.json',
+                detail: err.message,
+                action: 'Pipeline en modo human-block. Revisá el archivo o restaurá desde archived/.',
+                diag: `cat ${file}`,
+            });
+        } catch {}
+        const e = new Error(msg);
+        e.code = 'EWAVES_JSON';
+        throw e;
+    }
+    const errors = validateStateStrict(parsed, { source: 'post-load' });
+    if (errors.length > 0) {
+        try {
+            notifyTelegram({
+                level: 'error',
+                component: 'waves-schema',
+                message: 'shape inválida tras load',
+                detail: errors.join('; '),
+                action: 'Pipeline en modo human-block. Revisá el archivo antes de continuar.',
+                diag: `jq . ${file}`,
+            });
+        } catch {}
+        const e = new Error(`waves.json: shape inválida — ${errors.join('; ')}`);
+        e.code = 'EWAVES_SCHEMA';
+        e.errors = errors;
+        throw e;
+    }
+    return parsed;
 }
 
 /**
@@ -1160,9 +1428,16 @@ module.exports = {
     promoteWaveAtomic,
     recoverIncompletePromote,
     isWavePromoteBlocked,
+    // CA-5: variantes strict que tiran si el shape rompe.
+    loadStateStrict,
+    validateStateStrict,
+    // CA-1: helper de write atómico reusable por partial-pause.js.
+    atomicWriteFile,
     // Constantes públicas
     SCHEMA_VERSION,
     CACHE_TTL_MS,
+    LOCK_TIMEOUT_MS,
+    LOCK_MAX_RETRIES,
     // Helpers expuestos para tests
     _paths: () => ({
         WAVES_FILE: wavesFile(),
@@ -1180,5 +1455,6 @@ module.exports = {
         writeMarkerFsync,
         updateMarkerFsync,
         listPromoteFailedMarkers,
+        assertArchivedDirSafe,
     },
 };

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -47,6 +47,8 @@ const visualGate = require('./lib/visual-gate');
 const humanBlock = require('./lib/human-block');
 // #2490 — Pausa parcial con allowlist explícita de issues
 const partialPause = require('./lib/partial-pause');
+// #3518 CA-6 — Detector de desync waves.json ↔ .partial-pause.json
+const desyncDetector = require('./lib/desync-detector');
 
 const quotaExhausted = require('./lib/quota-exhausted'); // #2974
 // #3508 — feature flag + ciclo de vida del workaround Anthropic CLI 1M (#3506).
@@ -10831,6 +10833,21 @@ async function mainLoop() {
     // action='noop' → caso normal, sin log.
   } catch (e) {
     log('pulpo', `WARN [wave-recovery] boot hook falló: ${e.message}`);
+  }
+
+  // #3518 CA-6 — Chequeo de desync al boot: compara waves.json contra
+  // .partial-pause.json. Si hay mismatch, crea flag + alerta Telegram. El
+  // human-block existente lo levanta y pausa los skills hasta intervención.
+  // Si crashea por cualquier razón, NO mata al pulpo (best-effort).
+  try {
+    const desync = desyncDetector.detectDesync();
+    if (desync.desync) {
+      log('pulpo', `WARN desync-detector: ${desync.reason} added=${JSON.stringify(desync.added)} removed=${JSON.stringify(desync.removed)} flag=${desync.flag_path || 'no'}`);
+    } else {
+      log('pulpo', `desync-detector OK (${desync.reason || 'in_sync'})`);
+    }
+  } catch (e) {
+    log('pulpo', `WARN desync-detector falló: ${e.message}`);
   }
 
   // #3508 CA-7 / UX-4 — Log de startup informativo del workaround Anthropic 1M.

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -9952,12 +9952,24 @@ function brazoIntake(config) {
 
 let running = true;
 let paused = false;
+// #3518 CA-6 — bloqueo por desync entre waves.json y .partial-pause.json.
+// El detector crea/borra `.desync-detected.flag`; mientras exista, los brazos
+// que dispatchan trabajo (intake/desbloqueo/barrido/lanzamiento) quedan inertes.
+// Mirror del patrón `paused`: el ciclo igual gira (priority windows, commander,
+// telegram drain, multi-provider health), pero NO arranca agentes nuevos hasta
+// que un humano audite y borre el flag.
+let desyncBlocked = false;
+let desyncBlockedNotifiedTick = 0;
 
 // Archivo de control para pausar/reanudar desde fuera
 const PAUSE_FILE = path.join(PIPELINE, '.paused');
 
 function checkPauseFile() {
   paused = fs.existsSync(PAUSE_FILE);
+}
+
+function checkDesyncFlag() {
+  desyncBlocked = desyncDetector.isDesyncFlagSet();
 }
 
 // =============================================================================
@@ -11105,6 +11117,7 @@ async function mainLoop() {
   while (running) {
     try {
       checkPauseFile();
+      checkDesyncFlag();
 
       const config = loadConfig(); // Reload cada ciclo para hot-reload
 
@@ -11147,7 +11160,7 @@ async function mainLoop() {
         // require puede fallar si el módulo no existe (build viejo); no es fatal.
       }
 
-      if (!paused) {
+      if (!paused && !desyncBlocked) {
         rotateHistory();          // Housekeeping: rotar historial > 24hs
         persistMetricsSnapshot(config); // Métricas históricas para /metrics
 
@@ -11183,8 +11196,15 @@ async function mainLoop() {
         // label `provider-exhaustion-pause` y los destraba si algún provider
         // de su chain se liberó. Fire-and-forget — no bloquea el loop.
         brazoProviderExhaustionRetry(config);
-      } else {
+      } else if (paused) {
         log('pulpo', 'PAUSADO — esperando reanudación (borrar .pipeline/.paused)');
+      } else {
+        // #3518 CA-6 — desync detectado. Loop alive pero NO se dispatcha.
+        // Solo logueamos cada N ticks (1 cada ~5min) para no inundar.
+        desyncBlockedNotifiedTick = (desyncBlockedNotifiedTick + 1) % 10;
+        if (desyncBlockedNotifiedTick === 1) {
+          log('pulpo', 'BLOQUEADO POR DESYNC — dispatch suspendido. Auditar y borrar .pipeline/.desync-detected.flag para reanudar.');
+        }
       }
     } catch (e) {
       log('pulpo', `ERROR en ciclo: ${e.message}`);


### PR DESCRIPTION
## Resumen

Cierre del #3518 — hardening de `waves.json` y `.partial-pause.json` contra corrupción por operaciones destructivas concurrentes del Telegram Commander.

## Cambios incluidos

- **Atomic writes + lock** en `waves.json` y `.partial-pause.json` (commit `52c8b35d`)
- **Wire de `desync-detector` en `pulpo.js`** startup (commit `56e41b45`)
- **Fix CA-6: cortar dispatch loop** cuando `.desync-detected.flag` existe y tratar `active_wave:null` como `no_waves_yet` (commit `260827ad`)
- **Fix CA-8: `timeoutMs` como boundary primaria** del file-lock (commit `67c579ad`)

## Gates

- Tests unitarios `desync-detector.test.js`: 12/12 pass
- `node -c pulpo.js`: syntax OK
- Review semántico: aprobado (marker en `aprobacion/listo/`)
- PO acceptance: aprobado (rechazo #8 corregido con `260827ad`)
- UX: aprobado
- QA: `qa:skipped` — area:pipeline sin app:*, sin impacto user-facing

## Por qué se crea manualmente

El barrido `aprobacion ✓ → entrega` del Pulpo no promovió este issue después del fast-fail de las 14:07 BA — los 3 markers están en `listo/` desde hace 8+ horas sin que el brazo de entrega los tome. Se abre el PR a mano para destrabar la Ola N+10 (último issue pendiente, 21/22 cerrados).

Closes #3518