### PR TITLE
[bug pipeline] Notificaciones de entregas parciales: adjuntos multimedia no se envían

### DIFF
--- a/.pipeline/lib/__tests__/skill-deliverable-attachments-integration.test.js
+++ b/.pipeline/lib/__tests__/skill-deliverable-attachments-integration.test.js
@@ -1,0 +1,229 @@
+// =============================================================================
+// Integration test — skill-deliverable-attachments + deliverable-notify (#3647)
+//
+// Cubre el flujo end-to-end del CA-2:
+//   1. El helper escanea disco para `ux` y devuelve 2 PNGs.
+//   2. El pulpo (simulado) fusiona el resultado en `yaml.attachments` antes
+//      de invocar `deliverable-notify.notify(...)`.
+//   3. La notify produce dropfiles en telegramQueueDir.
+//   4. Verificamos que los dropfiles incluyen los 2 adjuntos (uno por PNG).
+// =============================================================================
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const helper = require('../skill-deliverable-attachments');
+const dn = require('../deliverable-notify');
+
+// Magic bytes mínimos para que verifyMagicBytes acepte PNG.
+const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]);
+
+function mkTmpRoot() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-attach-int-'));
+    return {
+        root: dir,
+        cleanup: () => { try { fs.rmSync(dir, { recursive: true, force: true }); } catch {} },
+    };
+}
+
+function writePng(absPath, totalBytes) {
+    const total = totalBytes || (PNG_SIGNATURE.length + 64);
+    const padding = Buffer.alloc(Math.max(0, total - PNG_SIGNATURE.length), 0);
+    fs.mkdirSync(path.dirname(absPath), { recursive: true });
+    fs.writeFileSync(absPath, Buffer.concat([PNG_SIGNATURE, padding]));
+}
+
+function defaultCfg() {
+    return {
+        enabled: true,
+        kill_switch: false,
+        skills: ['guru', 'po', 'ux', 'planner'],
+        truncate_chars: 1500,
+        attachment_root: '.pipeline/assets/mockups',
+        attachment_roots: {
+            document:  '.pipeline/assets/docs',
+            image:     '.pipeline/assets/mockups',
+            video:     '.pipeline/assets/videos',
+            animation: '.pipeline/assets/animations',
+        },
+        attachments_per_skill: {
+            ux: { types: ['image', 'video', 'animation'], formats: ['.png', '.jpg', '.jpeg', '.mp4', '.webm', '.gif'] },
+        },
+        attachment_max_count: 5,
+        attachment_max_size_bytes: 50 * 1024 * 1024,
+        attachment_video_max_duration_s: 300,
+        dedup_window_hours: 24,
+        audit_file: '.pipeline/audit/deliverable-notifications.jsonl',
+    };
+}
+
+test('CA-2 integración · ux con 2 PNGs en disco → notify produce dropfiles con attachments', () => {
+    const tmp = mkTmpRoot();
+    try {
+        // Setup: 2 PNGs issue-scoped en el root de mockups (allowlist por default).
+        const issue = 3647;
+        writePng(path.join(tmp.root, '.pipeline/assets/mockups/3647/dashboard-actual-01.png'));
+        writePng(path.join(tmp.root, '.pipeline/assets/mockups/3647/dashboard-esperado-01.png'));
+
+        // Paso 1 — pulpo invoca el helper.
+        const fsAttachments = helper.collectAttachmentsForSkill('ux', issue, 'criterios', {
+            pipelineRoot: tmp.root,
+        });
+        assert.equal(fsAttachments.length, 2, 'helper debe encontrar los 2 PNGs');
+
+        // Paso 2 — pulpo fusiona en r.attachments. YAML simulado mínimo.
+        const yaml = {
+            resultado: 'aprobado',
+            notas: 'Mockups generados con éxito. Ver attachments adjuntos.',
+            attachments: fsAttachments,
+        };
+
+        // Paso 3 — notify produce dropfiles en queue dir.
+        const telegramQueueDir = path.join(tmp.root, '.pipeline/servicios/telegram/pendiente');
+        fs.mkdirSync(telegramQueueDir, { recursive: true });
+
+        const dropfiles = [];
+        const result = dn.notify({
+            issue,
+            skill: 'ux',
+            fase: 'criterios',
+            pipeline: 'definicion',
+            yaml,
+            title: 'Issue de prueba',
+            config: defaultCfg(),
+            pipelineRoot: tmp.root,
+            telegramQueueDir,
+            deps: {
+                writeQueueFile: (p, payload) => {
+                    fs.mkdirSync(path.dirname(p), { recursive: true });
+                    fs.writeFileSync(p, JSON.stringify(payload), 'utf8');
+                    dropfiles.push({ path: p, payload });
+                },
+                now: () => Date.now(),
+            },
+        });
+
+        assert.equal(result.ok, true, `notify falló: ${JSON.stringify(result)}`);
+
+        // Paso 4 — verificación: el flujo multi-attachment emite 1 dropfile
+        // de texto + 1 dropfile por cada adjunto aceptado. Los dropfiles de
+        // adjunto traen el path en el campo `photo:` (CA-UX-EXT-4 + mapping
+        // ATTACHMENT_DROPFILE_FIELD del notifier).
+        const photoDropfiles = dropfiles.filter((d) => d.payload && typeof d.payload.photo === 'string');
+        assert.equal(photoDropfiles.length, 2,
+            `esperaba 2 dropfiles con photo:, hubo ${photoDropfiles.length}. ` +
+            `dropfiles=${JSON.stringify(dropfiles.map((d) => Object.keys(d.payload || {})))}`);
+
+        // Ambos PNGs deben aparecer en los dropfiles (validateAttachmentPath +
+        // verifyMagicBytes pasaron).
+        const photoPaths = photoDropfiles.map((d) => d.payload.photo);
+        assert.ok(photoPaths.some((p) => p.includes('dashboard-actual-01.png')),
+            `falta dashboard-actual-01.png: ${photoPaths.join(', ')}`);
+        assert.ok(photoPaths.some((p) => p.includes('dashboard-esperado-01.png')),
+            `falta dashboard-esperado-01.png: ${photoPaths.join(', ')}`);
+
+        // Y debe haber exactamente 1 dropfile de texto (CA-UX-EXT-4).
+        const textDropfiles = dropfiles.filter((d) => d.payload && typeof d.payload.text === 'string');
+        assert.equal(textDropfiles.length, 1, `esperaba 1 dropfile de texto, hubo ${textDropfiles.length}`);
+    } finally {
+        tmp.cleanup();
+    }
+});
+
+test('CA-6 regresión · sin archivos en disco, helper devuelve [] y notify cae al text-only', () => {
+    const tmp = mkTmpRoot();
+    try {
+        const issue = 9999;
+        // No escribimos PNGs — helper no encuentra nada.
+        const fsAttachments = helper.collectAttachmentsForSkill('ux', issue, 'criterios', {
+            pipelineRoot: tmp.root,
+        });
+        assert.deepEqual(fsAttachments, []);
+
+        // YAML sin attachments declarados.
+        const yaml = {
+            resultado: 'aprobado',
+            notas: 'Sin assets visuales — fase analítica solamente.',
+        };
+
+        const telegramQueueDir = path.join(tmp.root, '.pipeline/servicios/telegram/pendiente');
+        fs.mkdirSync(telegramQueueDir, { recursive: true });
+
+        const dropfiles = [];
+        const result = dn.notify({
+            issue,
+            skill: 'ux',
+            fase: 'criterios',
+            pipeline: 'definicion',
+            yaml,
+            title: 'Issue de prueba sin assets',
+            config: defaultCfg(),
+            pipelineRoot: tmp.root,
+            telegramQueueDir,
+            deps: {
+                writeQueueFile: (p, payload) => {
+                    dropfiles.push({ path: p, payload });
+                },
+                now: () => Date.now(),
+            },
+        });
+
+        assert.equal(result.ok, true, 'notify text-only debe funcionar sin attachments');
+
+        // Sólo el dropfile de texto.
+        assert.equal(dropfiles.length, 1, 'debe haber exactamente 1 dropfile (texto)');
+        const textDropfile = dropfiles[0].payload;
+        assert.ok(typeof textDropfile.text === 'string' && textDropfile.text.length > 0,
+            `dropfile no parece ser texto: ${JSON.stringify(textDropfile)}`);
+    } finally {
+        tmp.cleanup();
+    }
+});
+
+test('CA-FN-4 fallback · si el helper devuelve un path inválido, notify lo descarta sin romper', () => {
+    const tmp = mkTmpRoot();
+    try {
+        const issue = 3647;
+        // Simulamos un YAML con attachment fuera del allowlist (paths fuera del root).
+        // El helper actual NO produce esto, pero el caller podría agregar al merger.
+        const yaml = {
+            resultado: 'aprobado',
+            notas: 'Test fallback.',
+            attachments: [
+                { type: 'image', path: '/etc/passwd' },           // fuera de root
+                { type: 'image', path: '../../escape/foo.png' },  // path traversal
+            ],
+        };
+
+        const telegramQueueDir = path.join(tmp.root, '.pipeline/servicios/telegram/pendiente');
+        fs.mkdirSync(telegramQueueDir, { recursive: true });
+
+        const dropfiles = [];
+        const result = dn.notify({
+            issue,
+            skill: 'ux',
+            fase: 'criterios',
+            pipeline: 'definicion',
+            yaml,
+            title: 'Issue de prueba fallback',
+            config: defaultCfg(),
+            pipelineRoot: tmp.root,
+            telegramQueueDir,
+            deps: {
+                writeQueueFile: (p, payload) => { dropfiles.push({ path: p, payload }); },
+                now: () => Date.now(),
+            },
+        });
+
+        // notify NO debe abortar — debe caer al text-only y devolver ok=true.
+        assert.equal(result.ok, true, `fallback text-only debe ok=true, vino: ${JSON.stringify(result)}`);
+        assert.equal(dropfiles.length, 1, 'sólo el dropfile de texto debe estar presente');
+    } finally {
+        tmp.cleanup();
+    }
+});

--- a/.pipeline/lib/__tests__/skill-deliverable-attachments.test.js
+++ b/.pipeline/lib/__tests__/skill-deliverable-attachments.test.js
@@ -1,0 +1,314 @@
+// =============================================================================
+// Tests skill-deliverable-attachments.js — Helper de adjuntos por skill (#3647)
+//
+// Cubre:
+//   CA-1.1 — vacío => []
+//   CA-1.2 — 2 PNGs ux issue-scoped => 2 paths
+//   CA-1.3 — paths fuera de allowlist son responsabilidad del notifier; el
+//            helper sólo se asegura de no inventar paths
+//   CA-1.4 — issue-scoped estricto: PNGs de issue 3647 y 3648 en disco,
+//            collectAttachmentsForSkill('ux', 3647, ...) devuelve sólo los 3647
+//   CA-6  — regresión gate OFF: sin paths declarados ni archivos en disco,
+//           collect devuelve [] (la notify text-only no rompe upstream)
+// =============================================================================
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const helper = require('../skill-deliverable-attachments');
+
+// -----------------------------------------------------------------------------
+// Fixtures: filesystem temporal con la estructura de directorios esperada
+// -----------------------------------------------------------------------------
+
+function mkTmpRoot() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-attach-test-'));
+    return {
+        root: dir,
+        cleanup: () => { try { fs.rmSync(dir, { recursive: true, force: true }); } catch {} },
+    };
+}
+
+function writeFile(root, relPath, contents) {
+    const abs = path.join(root, relPath);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, contents || 'fixture');
+}
+
+// -----------------------------------------------------------------------------
+// CA-1.1 — input vacío / inexistente
+// -----------------------------------------------------------------------------
+
+test('CA-1.1 — fixture vacío devuelve [] sin error', () => {
+    const tmp = mkTmpRoot();
+    try {
+        const res = helper.collectAttachmentsForSkill('ux', 9999, 'criterios', { pipelineRoot: tmp.root });
+        assert.deepEqual(res, []);
+    } finally {
+        tmp.cleanup();
+    }
+});
+
+test('CA-1.1 — skill desconocido devuelve [] sin error', () => {
+    const tmp = mkTmpRoot();
+    try {
+        writeFile(tmp.root, '.pipeline/assets/mockups/3647/dashboard-actual-01.png', 'PNG');
+        const res = helper.collectAttachmentsForSkill('skill-inexistente', 3647, 'criterios', { pipelineRoot: tmp.root });
+        assert.deepEqual(res, []);
+    } finally {
+        tmp.cleanup();
+    }
+});
+
+test('CA-1.1 — issueNumber inválido devuelve []', () => {
+    const tmp = mkTmpRoot();
+    try {
+        const res1 = helper.collectAttachmentsForSkill('ux', 'abc', 'criterios', { pipelineRoot: tmp.root });
+        const res2 = helper.collectAttachmentsForSkill('ux', null, 'criterios', { pipelineRoot: tmp.root });
+        const res3 = helper.collectAttachmentsForSkill('ux', 0, 'criterios', { pipelineRoot: tmp.root });
+        assert.deepEqual(res1, []);
+        assert.deepEqual(res2, []);
+        assert.deepEqual(res3, []);
+    } finally {
+        tmp.cleanup();
+    }
+});
+
+test('CA-1.1 — skill vacío devuelve []', () => {
+    const tmp = mkTmpRoot();
+    try {
+        const res = helper.collectAttachmentsForSkill('', 3647, 'criterios', { pipelineRoot: tmp.root });
+        assert.deepEqual(res, []);
+    } finally {
+        tmp.cleanup();
+    }
+});
+
+// -----------------------------------------------------------------------------
+// CA-1.2 — 2 PNGs ux issue-scoped en `.pipeline/assets/mockups/<issue>/`
+// -----------------------------------------------------------------------------
+
+test('CA-1.2 — ux con 2 PNGs en mockups/<issue>/ devuelve 2 paths', () => {
+    const tmp = mkTmpRoot();
+    try {
+        writeFile(tmp.root, '.pipeline/assets/mockups/3647/dashboard-actual-01.png', 'PNG-actual');
+        writeFile(tmp.root, '.pipeline/assets/mockups/3647/dashboard-esperado-01.png', 'PNG-esperado');
+
+        const res = helper.collectAttachmentsForSkill('ux', 3647, 'criterios', { pipelineRoot: tmp.root });
+        assert.equal(res.length, 2);
+        assert.equal(res[0].type, 'image');
+        assert.equal(res[1].type, 'image');
+
+        // CA-UX (refinamiento): orden actual → esperado.
+        assert.ok(res[0].path.includes('actual'), `esperaba actual primero, vino ${res[0].path}`);
+        assert.ok(res[1].path.includes('esperado'), `esperaba esperado segundo, vino ${res[1].path}`);
+
+        // Paths relativos al pipelineRoot (normalizados con /).
+        for (const a of res) {
+            assert.equal(typeof a.path, 'string');
+            assert.ok(!path.isAbsolute(a.path), `path debe ser relativo: ${a.path}`);
+            assert.ok(a.path.startsWith('.pipeline/assets/mockups/3647/'),
+                `path debe ser issue-scoped: ${a.path}`);
+        }
+    } finally {
+        tmp.cleanup();
+    }
+});
+
+test('CA-1.2 — descriptors reflejan actual/esperado', () => {
+    const tmp = mkTmpRoot();
+    try {
+        writeFile(tmp.root, '.pipeline/assets/mockups/3647/dashboard-actual-01.png', 'X');
+        writeFile(tmp.root, '.pipeline/assets/mockups/3647/dashboard-esperado-01.png', 'X');
+        const res = helper.collectAttachmentsForSkill('ux', 3647, 'criterios', { pipelineRoot: tmp.root });
+        assert.equal(res[0].descriptor, 'actual');
+        assert.equal(res[1].descriptor, 'esperado');
+    } finally {
+        tmp.cleanup();
+    }
+});
+
+// -----------------------------------------------------------------------------
+// CA-1.4 — Glob scoping issue-scoped obligatorio (defensa #3658)
+// -----------------------------------------------------------------------------
+
+test('CA-1.4 — con PNGs de 3647 y 3648 en disco, ux/3647 sólo devuelve los 3647', () => {
+    const tmp = mkTmpRoot();
+    try {
+        // issue 3647 — los que esperamos
+        writeFile(tmp.root, '.pipeline/assets/mockups/3647/dashboard-actual-01.png', 'a');
+        writeFile(tmp.root, '.pipeline/assets/mockups/3647/dashboard-esperado-01.png', 'b');
+        // issue 3648 — DEBEN ser ignorados
+        writeFile(tmp.root, '.pipeline/assets/mockups/3648/dashboard-actual-01.png', 'c');
+        writeFile(tmp.root, '.pipeline/assets/mockups/3648/dashboard-esperado-01.png', 'd');
+
+        const res = helper.collectAttachmentsForSkill('ux', 3647, 'criterios', { pipelineRoot: tmp.root });
+        assert.equal(res.length, 2);
+        for (const a of res) {
+            assert.ok(a.path.includes('3647'), `cross-contamination detectada: ${a.path}`);
+            assert.ok(!a.path.includes('3648'), `cross-contamination detectada: ${a.path}`);
+        }
+    } finally {
+        tmp.cleanup();
+    }
+});
+
+test('CA-1.4 — convención plana legacy exige {issue} en filename', () => {
+    const tmp = mkTmpRoot();
+    try {
+        // Estos archivos viven en `.pipeline/assets/mockups` (sin subdir issue)
+        // pero el filename incluye 3647 → DEBE matchear.
+        writeFile(tmp.root, '.pipeline/assets/mockups/3647-actual.png', 'a');
+        // Este NO incluye `3647` en el filename → NO debe matchear.
+        writeFile(tmp.root, '.pipeline/assets/mockups/random-other.png', 'b');
+        // 3648 NO debe contaminar.
+        writeFile(tmp.root, '.pipeline/assets/mockups/3648-actual.png', 'c');
+
+        const res = helper.collectAttachmentsForSkill('ux', 3647, 'criterios', { pipelineRoot: tmp.root });
+        assert.equal(res.length, 1);
+        assert.ok(res[0].path.includes('3647-actual.png'));
+    } finally {
+        tmp.cleanup();
+    }
+});
+
+test('CA-1.4 — sourceIsIssueScoped() valida el catálogo completo', () => {
+    const catalog = helper.getSkillSourcesCatalog();
+    for (const [skill, sources] of Object.entries(catalog)) {
+        for (const source of sources) {
+            assert.ok(helper.__internals.sourceIsIssueScoped(source),
+                `source de ${skill} NO está issue-scoped: ${JSON.stringify(source)}`);
+        }
+    }
+});
+
+// -----------------------------------------------------------------------------
+// Otros skills — po / guru / planner
+// -----------------------------------------------------------------------------
+
+test('po recolecta documentos en docs/<issue>/ con extensiones permitidas', () => {
+    const tmp = mkTmpRoot();
+    try {
+        writeFile(tmp.root, '.pipeline/assets/docs/3647/criterios-refinados.md', '# X');
+        writeFile(tmp.root, '.pipeline/assets/docs/3647/diseño-rechazado.exe', 'no');
+
+        const res = helper.collectAttachmentsForSkill('po', 3647, 'criterios', { pipelineRoot: tmp.root });
+        assert.equal(res.length, 1);
+        assert.equal(res[0].type, 'document');
+        assert.ok(res[0].path.endsWith('criterios-refinados.md'));
+    } finally {
+        tmp.cleanup();
+    }
+});
+
+test('guru recolecta análisis en docs/<issue>/', () => {
+    const tmp = mkTmpRoot();
+    try {
+        writeFile(tmp.root, '.pipeline/assets/docs/3647/analisis-tecnico.pdf', '%PDF');
+        const res = helper.collectAttachmentsForSkill('guru', 3647, 'analisis', { pipelineRoot: tmp.root });
+        assert.equal(res.length, 1);
+        assert.equal(res[0].type, 'document');
+        assert.equal(res[0].descriptor, 'analisis');
+    } finally {
+        tmp.cleanup();
+    }
+});
+
+// -----------------------------------------------------------------------------
+// CA-6 — regresión gate OFF: sin nada en disco, devuelve [] (no rompe)
+// -----------------------------------------------------------------------------
+
+test('CA-6 regresión — gate OFF (sin paths declarados ni archivos), devuelve []', () => {
+    const tmp = mkTmpRoot();
+    try {
+        // Simula gate OFF: el agente /ux no generó nada, no hay subdir issue.
+        // Otros archivos completamente unrelated en disco.
+        writeFile(tmp.root, 'docs/unrelated/blob.txt', 'x');
+
+        const res = helper.collectAttachmentsForSkill('ux', 3647, 'criterios', { pipelineRoot: tmp.root });
+        assert.deepEqual(res, []);
+    } finally {
+        tmp.cleanup();
+    }
+});
+
+// -----------------------------------------------------------------------------
+// Cap defensivo HELPER_MAX_PER_INVOCATION
+// -----------------------------------------------------------------------------
+
+test('cap HELPER_MAX_PER_INVOCATION trunca a 12 si hay muchos PNGs', () => {
+    const tmp = mkTmpRoot();
+    try {
+        for (let i = 0; i < 25; i++) {
+            writeFile(tmp.root, `.pipeline/assets/mockups/3647/screen-${String(i).padStart(3, '0')}.png`, 'x');
+        }
+        const res = helper.collectAttachmentsForSkill('ux', 3647, 'criterios', { pipelineRoot: tmp.root });
+        assert.equal(res.length, helper.__internals.HELPER_MAX_PER_INVOCATION);
+    } finally {
+        tmp.cleanup();
+    }
+});
+
+// -----------------------------------------------------------------------------
+// Dedup cross-source: si el mismo archivo matchea varios sources (improbable
+// pero posible si futuras entradas se solapan), no se duplica.
+// -----------------------------------------------------------------------------
+
+test('dedup cross-source: mismo absPath nunca aparece duplicado', () => {
+    const tmp = mkTmpRoot();
+    try {
+        // Este archivo matchea source[0] (dir issue-scoped) y source[2]
+        // (filename incluye 3647). Sin dedup, vendría dos veces.
+        writeFile(tmp.root, '.pipeline/assets/mockups/3647-actual.png', 'a');
+        const res = helper.collectAttachmentsForSkill('ux', 3647, 'criterios', { pipelineRoot: tmp.root });
+        const paths = res.map((a) => a.path);
+        const unique = Array.from(new Set(paths));
+        assert.equal(paths.length, unique.length, `dup paths: ${paths.join(', ')}`);
+    } finally {
+        tmp.cleanup();
+    }
+});
+
+// -----------------------------------------------------------------------------
+// Robustez: directorio existe pero contiene un subdirectorio con mismo nombre
+// que un archivo — debe filtrarse (no es regular file).
+// -----------------------------------------------------------------------------
+
+test('subdirectorios dentro del root issue-scoped son ignorados', () => {
+    const tmp = mkTmpRoot();
+    try {
+        writeFile(tmp.root, '.pipeline/assets/mockups/3647/dashboard-actual-01.png', 'a');
+        // Subdirectorio que NO debe enumerarse como adjunto.
+        fs.mkdirSync(path.join(tmp.root, '.pipeline/assets/mockups/3647/raw'), { recursive: true });
+        fs.writeFileSync(path.join(tmp.root, '.pipeline/assets/mockups/3647/raw/buried.png'), 'no');
+
+        const res = helper.collectAttachmentsForSkill('ux', 3647, 'criterios', { pipelineRoot: tmp.root });
+        assert.equal(res.length, 1);
+        assert.ok(res[0].path.endsWith('dashboard-actual-01.png'));
+    } finally {
+        tmp.cleanup();
+    }
+});
+
+// -----------------------------------------------------------------------------
+// Compat con paths absolutos no-issue-scoped: el caller (pulpo.js) no debe
+// poder romper el helper pasando opts inválidos. El helper devuelve [] sin
+// throwear.
+// -----------------------------------------------------------------------------
+
+test('opts.pipelineRoot inexistente devuelve [] sin throw', () => {
+    const res = helper.collectAttachmentsForSkill('ux', 3647, 'criterios', {
+        pipelineRoot: path.join(os.tmpdir(), 'definitivamente-no-existe-' + Date.now()),
+    });
+    assert.deepEqual(res, []);
+});
+
+test('opts ausente usa process.cwd() — no throw aunque no haya nada', () => {
+    const res = helper.collectAttachmentsForSkill('ux', 99999999, 'criterios');
+    assert.ok(Array.isArray(res));
+});

--- a/.pipeline/lib/skill-deliverable-attachments.js
+++ b/.pipeline/lib/skill-deliverable-attachments.js
@@ -1,0 +1,438 @@
+// =============================================================================
+// skill-deliverable-attachments.js — Helper compartido para recolectar
+// adjuntos por skill al cierre de una fase (issue #3647).
+//
+// Responsabilidad acotada:
+//   - Por skill + issue + fase, escanear los roots conocidos del filesystem y
+//     devolver `[{ type, path, descriptor }]` con paths relativos al repo.
+//   - Estrictamente **issue-scoped** (CA-1.4 / #3658): cada patrón de búsqueda
+//     incluye literalmente `<issueNumber>` en el filename o en un segmento del
+//     path, así PNGs/PDFs del issue vecino no contaminan la entrega.
+//   - Para `ux` aplica orden de lectura visual: actual → esperado → narrativa.
+//   - Si no encuentra nada: array vacío, NO error.
+//
+// Lo que NO hace:
+//   - NO valida path traversal, magic bytes ni allowlist final — eso lo hace
+//     `deliverable-notify.resolveAttachments` downstream. Si este helper
+//     devuelve un path inválido, el notificador lo descarta silenciosamente
+//     con audit y cae al text-only (CA-FN-4).
+//   - NO genera mockups ni captura screenshots — eso lo hace el agente `/ux`
+//     con `ux-mockup-generator.js` + `screenshot-capture.js`.
+//   - NO consulta GitHub.
+//   - NO modifica el YAML del agente. El caller (pulpo.js) decide cómo
+//     fusionar los resultados con `yaml.attachments` ya declarados.
+//
+// Diseño:
+//   - Puro / stateless / sin efectos. Testable con `pipelineRoot` apuntado a
+//     un tmpdir.
+//   - Sin dependencias externas (sin `glob`, sin Anthropic, sin Telegram).
+//   - Determinista: orden estable por skill (CA-UX-7 #3661).
+// =============================================================================
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+// -----------------------------------------------------------------------------
+// Configuración por skill — fuentes a inspeccionar
+// -----------------------------------------------------------------------------
+//
+// Cada entrada describe **un directorio raíz a inspeccionar** y los criterios
+// de match. La búsqueda es **no recursiva** dentro del root (queremos paths
+// predecibles, no descender por accidente en carpetas con contenido de otros
+// issues).
+//
+// `dirTemplate` puede usar `{issue}` para meter el número de issue como segmento
+// del path — esto resulta en directorios issue-scoped en disco (ej:
+// `qa/evidence/3647/`).
+//
+// `nameMustInclude` lista substrings que el filename DEBE contener. Si la lista
+// es no vacía, **se exige siempre que aparezca `{issue}`** (CA-1.4) — si el
+// directorio padre ya es issue-scoped (`{issue}` en `dirTemplate`), el check
+// del filename se relaja a "no exigir {issue} en el name". Sino, exigir
+// `{issue}` en filename es obligatorio.
+//
+// `formats` filtra por extensión (lowercased).
+//
+// `type` declara el `type` que se enviará a `deliverable-notify`. Debe ser
+// uno de document/image/video/animation.
+
+const SKILL_SOURCES = Object.freeze({
+    ux: [
+        // Caso A — dashboard: PNGs en `.pipeline/assets/mockups/<issue>/...`.
+        {
+            dirTemplate: '.pipeline/assets/mockups/{issue}',
+            nameMustInclude: [],          // dir issue-scoped → no exigir {issue} en filename
+            formats: ['.png', '.jpg', '.jpeg', '.gif'],
+            type: 'image',
+            descriptorHint: 'mockup',
+        },
+        // Caso B — Android: PNGs en `qa/evidence/<issue>/`.
+        {
+            dirTemplate: 'qa/evidence/{issue}',
+            nameMustInclude: [],
+            formats: ['.png', '.jpg', '.jpeg', '.gif'],
+            type: 'image',
+            descriptorHint: 'evidence',
+        },
+        // Convención plana legacy — filename DEBE contener `{issue}`.
+        {
+            dirTemplate: '.pipeline/assets/mockups',
+            nameMustInclude: ['{issue}'],
+            formats: ['.png', '.jpg', '.jpeg', '.gif'],
+            type: 'image',
+            descriptorHint: 'mockup',
+        },
+        // Videos cortos (Caso B con grabación opcional) — issue-scoped.
+        {
+            dirTemplate: 'qa/evidence/{issue}',
+            nameMustInclude: [],
+            formats: ['.mp4', '.webm'],
+            type: 'video',
+            descriptorHint: 'video',
+        },
+    ],
+    po: [
+        // Documentos del PO — markdown / PDF con criterios refinados.
+        {
+            dirTemplate: '.pipeline/assets/docs/{issue}',
+            nameMustInclude: [],
+            formats: ['.pdf', '.md'],
+            type: 'document',
+            descriptorHint: 'criterios',
+        },
+        {
+            dirTemplate: '.pipeline/assets/docs',
+            nameMustInclude: ['{issue}'],
+            formats: ['.pdf', '.md'],
+            type: 'document',
+            descriptorHint: 'criterios',
+        },
+    ],
+    guru: [
+        {
+            dirTemplate: '.pipeline/assets/docs/{issue}',
+            nameMustInclude: [],
+            formats: ['.pdf', '.md'],
+            type: 'document',
+            descriptorHint: 'analisis',
+        },
+        {
+            dirTemplate: '.pipeline/assets/docs',
+            nameMustInclude: ['{issue}'],
+            formats: ['.pdf', '.md'],
+            type: 'document',
+            descriptorHint: 'analisis',
+        },
+    ],
+    planner: [
+        {
+            dirTemplate: '.pipeline/assets/docs/{issue}',
+            nameMustInclude: [],
+            formats: ['.pdf', '.md', '.png', '.svg'],
+            type: 'document',
+            descriptorHint: 'planner',
+        },
+        {
+            dirTemplate: '.pipeline/assets/docs',
+            nameMustInclude: ['{issue}'],
+            formats: ['.pdf', '.md'],
+            type: 'document',
+            descriptorHint: 'planner',
+        },
+    ],
+    cua: [
+        {
+            dirTemplate: '.pipeline/cua-outputs/{issue}',
+            nameMustInclude: [],
+            formats: ['.png', '.mp4', '.pdf'],
+            type: null, // inferido por extensión (ver INFER_TYPE_BY_EXT)
+            descriptorHint: 'cua',
+        },
+    ],
+});
+
+// Mapeo extensión → tipo de adjunto. Usado cuando la `source.type` es null
+// (caso CUA donde varios tipos conviven en el mismo root).
+const INFER_TYPE_BY_EXT = Object.freeze({
+    '.pdf':  'document',
+    '.md':   'document',
+    '.png':  'image',
+    '.jpg':  'image',
+    '.jpeg': 'image',
+    '.gif':  'animation',
+    '.mp4':  'video',
+    '.webm': 'video',
+    '.svg':  'image',
+});
+
+// Orden de lectura visual para `ux` (CA-UX-7 refinamiento PO/UX): primero el
+// estado actual, después el esperado, narrativa al final como contexto. Si el
+// filename no matchea ninguna categoría, va al final del grupo de su tipo.
+const UX_ORDER_KEYWORDS = Object.freeze([
+    { rank: 0, regex: /actual|baseline/i },
+    { rank: 1, regex: /esperado|mockup/i },
+    { rank: 2, regex: /narrativa/i },
+]);
+
+// Cap defensivo de adjuntos devueltos por el helper. `deliverable-notify`
+// también aplica su propio cap (default 5), pero corremos el cap acá temprano
+// para no enumerar 200 archivos si un root explota.
+const HELPER_MAX_PER_INVOCATION = 12;
+
+// -----------------------------------------------------------------------------
+// Helpers internos
+// -----------------------------------------------------------------------------
+
+/**
+ * Reemplaza el placeholder `{issue}` en un template por el número de issue
+ * como string. Es defensivo: si el template no tiene el placeholder, lo
+ * devuelve tal cual.
+ *
+ * @param {string} template
+ * @param {string|number} issueNumber
+ * @returns {string}
+ */
+function expandIssue(template, issueNumber) {
+    return String(template).replace(/\{issue\}/g, String(issueNumber));
+}
+
+/**
+ * Determina el `type` final para un archivo dado el `source`.
+ *
+ * @param {object} source
+ * @param {string} ext - extensión lowercased, incluyendo el punto.
+ * @returns {string|null}
+ */
+function resolveType(source, ext) {
+    if (source.type) return source.type;
+    return INFER_TYPE_BY_EXT[ext] || null;
+}
+
+/**
+ * Calcula el rank de orden para un filename `ux`. Más bajo = más arriba.
+ * Mismo rank → tie-break alfabético.
+ *
+ * @param {string} name - basename del archivo (con extensión).
+ * @returns {number}
+ */
+function uxOrderRank(name) {
+    for (const entry of UX_ORDER_KEYWORDS) {
+        if (entry.regex.test(name)) return entry.rank;
+    }
+    return 999;
+}
+
+/**
+ * Construye un `descriptor` legible para `buildAttachmentFilename` del
+ * notifier. Si el filename tiene `actual` o `esperado`, lo usa; sino cae al
+ * hint del source.
+ *
+ * @param {string} name
+ * @param {object} source
+ * @returns {string}
+ */
+function descriptorForFile(name, source) {
+    const lower = name.toLowerCase();
+    if (lower.includes('actual')) return 'actual';
+    if (lower.includes('esperado')) return 'esperado';
+    if (lower.includes('mockup'))  return 'mockup';
+    if (lower.includes('narrativa')) return 'narrativa';
+    if (lower.includes('baseline')) return 'baseline';
+    return source.descriptorHint || 'attach';
+}
+
+/**
+ * Lista archivos regulares del directorio (no recursivo). Si el directorio
+ * no existe, devuelve array vacío sin error.
+ *
+ * @param {string} absDir
+ * @returns {string[]} basenames
+ */
+function listDirSafe(absDir) {
+    try {
+        if (!fs.existsSync(absDir)) return [];
+        const stat = fs.statSync(absDir);
+        if (!stat.isDirectory()) return [];
+        return fs.readdirSync(absDir).filter((name) => {
+            try {
+                const full = path.join(absDir, name);
+                const s = fs.statSync(full);
+                return s.isFile();
+            } catch {
+                return false;
+            }
+        });
+    } catch {
+        return [];
+    }
+}
+
+/**
+ * Aplica filtros del source a un basename (formato + nameMustInclude).
+ *
+ * `nameMustInclude` puede contener placeholders `{issue}`. CA-1.4: si el dir
+ * NO incluye `{issue}` y `nameMustInclude` tampoco, el caller no debería
+ * permitirlo (validateSource). En la práctica, este filtro asume que el
+ * caller ya validó la fuente.
+ *
+ * @param {string} basename
+ * @param {object} source
+ * @param {string|number} issueNumber
+ * @returns {boolean}
+ */
+function matchesSource(basename, source, issueNumber) {
+    const ext = path.extname(basename).toLowerCase();
+    if (!source.formats.includes(ext)) return false;
+    if (Array.isArray(source.nameMustInclude) && source.nameMustInclude.length > 0) {
+        for (const needle of source.nameMustInclude) {
+            const expanded = expandIssue(needle, issueNumber);
+            if (basename.indexOf(expanded) < 0) return false;
+        }
+    }
+    return true;
+}
+
+/**
+ * Verifica que el `source` cumpla la regla CA-1.4: la fuente DEBE ser
+ * issue-scoped (vía `dirTemplate` o vía `nameMustInclude`).
+ *
+ * Si el source no cumple, se ignora silenciosamente (defensa en profundidad
+ * contra modificaciones futuras del catálogo SKILL_SOURCES que omitan el
+ * scoping).
+ *
+ * @param {object} source
+ * @returns {boolean}
+ */
+function sourceIsIssueScoped(source) {
+    const dirHasIssue = String(source.dirTemplate || '').includes('{issue}');
+    const nameHasIssue = Array.isArray(source.nameMustInclude)
+        && source.nameMustInclude.some((n) => String(n).includes('{issue}'));
+    return dirHasIssue || nameHasIssue;
+}
+
+/**
+ * Ordena los resultados de `ux` aplicando `uxOrderRank`. Para otros skills,
+ * orden alfabético estable.
+ *
+ * @param {Array<object>} entries
+ * @param {string} skill
+ * @returns {Array<object>}
+ */
+function sortAttachments(entries, skill) {
+    const copy = entries.slice();
+    if (skill === 'ux') {
+        copy.sort((a, b) => {
+            const ra = uxOrderRank(a._basename);
+            const rb = uxOrderRank(b._basename);
+            if (ra !== rb) return ra - rb;
+            return a._basename.localeCompare(b._basename);
+        });
+    } else {
+        copy.sort((a, b) => a._basename.localeCompare(b._basename));
+    }
+    return copy;
+}
+
+// -----------------------------------------------------------------------------
+// API pública
+// -----------------------------------------------------------------------------
+
+/**
+ * Recolecta los adjuntos disponibles en disco para un skill+issue+fase dados.
+ *
+ * @param {string} skill - 'ux' | 'po' | 'guru' | 'planner' | 'cua' | ...
+ * @param {string|number} issueNumber
+ * @param {string} _phase - reservado para uso futuro (filtrado por fase).
+ *     No se usa hoy: las convenciones de filename de cada skill ya separan
+ *     por fase implícitamente (ej. el mockup vive en criterios; el video QA
+ *     en verificacion). Mantener la firma libera evolución sin romper el
+ *     contrato del caller.
+ * @param {object} [opts]
+ * @param {string} [opts.pipelineRoot] - root del repo (default process.cwd()).
+ * @returns {Array<{type:string, path:string, descriptor:string}>}
+ *     Array vacío si no se encontraron archivos. NUNCA tira excepción.
+ */
+function collectAttachmentsForSkill(skill, issueNumber, _phase, opts) {
+    if (!skill || typeof skill !== 'string') return [];
+    const issueAsNumber = parseInt(issueNumber, 10);
+    if (!Number.isFinite(issueAsNumber) || issueAsNumber <= 0) return [];
+
+    const sources = SKILL_SOURCES[skill];
+    if (!Array.isArray(sources) || sources.length === 0) return [];
+
+    const pipelineRoot = (opts && typeof opts.pipelineRoot === 'string' && opts.pipelineRoot.length > 0)
+        ? opts.pipelineRoot
+        : process.cwd();
+
+    const issueStr = String(issueAsNumber);
+    const collected = [];
+    const seenAbs = new Set();
+
+    for (const source of sources) {
+        // CA-1.4: defensa en profundidad — si el catálogo se modifica y un
+        // source pierde el issue-scoping, lo descartamos en runtime.
+        if (!sourceIsIssueScoped(source)) continue;
+
+        const dirRel = expandIssue(source.dirTemplate, issueStr);
+        const absDir = path.resolve(pipelineRoot, dirRel);
+
+        const names = listDirSafe(absDir);
+        for (const name of names) {
+            if (!matchesSource(name, source, issueStr)) continue;
+
+            const absPath = path.resolve(absDir, name);
+            if (seenAbs.has(absPath)) continue; // dedup cross-source
+
+            const ext = path.extname(name).toLowerCase();
+            const type = resolveType(source, ext);
+            if (!type) continue;
+
+            const relPath = path.relative(pipelineRoot, absPath).replace(/\\/g, '/');
+            collected.push({
+                _basename: name,
+                type,
+                path: relPath,
+                descriptor: descriptorForFile(name, source),
+            });
+            seenAbs.add(absPath);
+
+            if (collected.length >= HELPER_MAX_PER_INVOCATION) break;
+        }
+        if (collected.length >= HELPER_MAX_PER_INVOCATION) break;
+    }
+
+    const sorted = sortAttachments(collected, skill);
+    // Strip campo privado `_basename` antes de devolver.
+    return sorted.map((e) => ({
+        type: e.type,
+        path: e.path,
+        descriptor: e.descriptor,
+    }));
+}
+
+/**
+ * Helper para tests: devuelve el catálogo congelado de sources. Útil para
+ * verificar que cada source cumple CA-1.4 sin ejecutar el filesystem.
+ *
+ * @returns {object}
+ */
+function getSkillSourcesCatalog() {
+    return SKILL_SOURCES;
+}
+
+module.exports = {
+    collectAttachmentsForSkill,
+    getSkillSourcesCatalog,
+    // Exporto helpers internos solo para tests granulares.
+    __internals: {
+        expandIssue,
+        sourceIsIssueScoped,
+        matchesSource,
+        uxOrderRank,
+        descriptorForFile,
+        resolveType,
+        HELPER_MAX_PER_INVOCATION,
+    },
+};

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -122,6 +122,7 @@ const handoff = require('./lib/handoff');
 // opcional). Se invoca desde `brazoBarrido` cuando un skill notificable cierra
 // fase OK. Default OFF (rollout gradual via config.yaml → deliverable_notifications.enabled).
 const deliverableNotify = require('./lib/deliverable-notify');
+const skillDeliverableAttachments = require('./lib/skill-deliverable-attachments');
 // #3481 — Evaluación de completitud de fases paralelas que considera
 // artefactos varados en `procesado/` (con whitelist estricta + anti-race
 // contra pendiente/trabajando). Resuelve el deadlock cuando un skill cerró
@@ -3850,6 +3851,33 @@ function brazoBarrido(config) {
               if (r.resultado !== 'aprobado') continue;
               // skill viene del NOMBRE DEL ARCHIVO, no del YAML editable (CA-SEC-2)
               const notifySkill = skillFromFile(r.file.name);
+
+              // #3647 — CA-2: barrer disco buscando entregables por skill y
+              // fusionarlos en `yaml.attachments` antes de notificar. El helper
+              // es issue-scoped (CA-1.4) y nunca tira; si no encuentra nada
+              // devuelve []. La validación final (path traversal, magic bytes,
+              // allowlist) la hace `deliverable-notify.resolveAttachments`.
+              try {
+                const fsAttachments = skillDeliverableAttachments.collectAttachmentsForSkill(
+                  notifySkill, issue, fase, { pipelineRoot: ROOT },
+                );
+                if (Array.isArray(fsAttachments) && fsAttachments.length > 0) {
+                  const existing = Array.isArray(r.attachments) ? r.attachments.slice() : [];
+                  const seenPaths = new Set(existing.map((a) => (a && a.path) || ''));
+                  for (const a of fsAttachments) {
+                    if (a && !seenPaths.has(a.path)) {
+                      existing.push(a);
+                      seenPaths.add(a.path);
+                    }
+                  }
+                  r.attachments = existing;
+                  log('barrido', `📎 #${issue} attachments por skill ${notifySkill}: ${fsAttachments.length} (helper)`);
+                }
+              } catch (e) {
+                // Nunca bloquear notify por un fallo del helper.
+                log('barrido', `📎 #${issue} helper attachments error (${notifySkill}): ${e.message}`);
+              }
+
               const result = deliverableNotify.notify({
                 issue,
                 skill: notifySkill,

--- a/docs/pipeline-v3-deliverable-notify.md
+++ b/docs/pipeline-v3-deliverable-notify.md
@@ -172,6 +172,115 @@ try {
 El `try/catch` garantiza CA-FN-8: cualquier error del notify NUNCA bloquea el
 `moveFile` que cierra la promoción de fase.
 
+## Attachments por skill (issue #3647)
+
+Hasta Ola N+11, todas las notificaciones salían text-only: el campo
+`yaml.attachments[]` venía sin poblar porque ningún integrador conectaba los
+artefactos generados por cada skill al payload. El issue #3647 cierra ese gap
+agregando un helper compartido.
+
+### Helper `collectAttachmentsForSkill`
+
+Vive en
+[`.pipeline/lib/skill-deliverable-attachments.js`](../.pipeline/lib/skill-deliverable-attachments.js)
+y expone:
+
+```js
+const helper = require('./lib/skill-deliverable-attachments');
+const list = helper.collectAttachmentsForSkill(skill, issueNumber, phase, {
+    pipelineRoot,
+});
+// → [{ type: 'image'|'document'|'video'|'animation', path, descriptor }]
+```
+
+Es **puro / stateless**, escanea disco y devuelve la lista de adjuntos
+issue-scoped que encontró para ese skill. No genera mockups, no valida magic
+bytes ni allowlists — esa validación final la hace
+`deliverable-notify.resolveAttachments` downstream.
+
+### Catálogo de fuentes por skill
+
+| Skill   | Directorios inspeccionados (issue-scoped)           | Formatos         | `type`     |
+|---------|-----------------------------------------------------|------------------|------------|
+| `ux`    | `.pipeline/assets/mockups/<issue>/`                 | `.png .jpg .gif` | `image`    |
+|         | `qa/evidence/<issue>/`                              | `.png .jpg .gif` | `image`    |
+|         | `qa/evidence/<issue>/`                              | `.mp4 .webm`     | `video`    |
+|         | `.pipeline/assets/mockups/` (filename con `<issue>`) | `.png .jpg .gif` | `image`    |
+| `po`    | `.pipeline/assets/docs/<issue>/`                    | `.pdf .md`       | `document` |
+|         | `.pipeline/assets/docs/` (filename con `<issue>`)   | `.pdf .md`       | `document` |
+| `guru`  | `.pipeline/assets/docs/<issue>/`                    | `.pdf .md`       | `document` |
+|         | `.pipeline/assets/docs/` (filename con `<issue>`)   | `.pdf .md`       | `document` |
+| `planner` | `.pipeline/assets/docs/<issue>/`                  | `.pdf .md .png .svg` | `document` |
+|         | `.pipeline/assets/docs/` (filename con `<issue>`)   | `.pdf .md`       | `document` |
+| `cua`   | `.pipeline/cua-outputs/<issue>/`                    | `.png .mp4 .pdf` | (inferido) |
+
+### CA-1.4: glob scoping issue-scoped obligatorio
+
+Cada fuente del catálogo está estrictamente scopeada al issue:
+
+- vía directorio (`.pipeline/assets/mockups/<issue>/`), o
+- vía filename con `<issue>` literal (`.pipeline/assets/mockups/3647-actual.png`).
+
+El helper valida en runtime que ningún source pierda el scoping
+(`sourceIsIssueScoped`). Si una entrada futura del catálogo se modificara y
+perdiera el scoping, se descarta silenciosamente en lugar de contaminar
+notifications entre issues vecinos.
+
+### Orden visual (UX-only)
+
+Para `ux` el orden de los adjuntos es:
+
+1. `actual` / `baseline` — estado actual del producto.
+2. `esperado` / `mockup` — estado propuesto.
+3. `narrativa` — descripción del cambio.
+
+Razón: el operador escanea de izquierda a derecha y espera el contraste
+"antes → después" en ese orden. Para otros skills el orden es alfabético
+estable.
+
+### Integración en `pulpo.js`
+
+```js
+// .pipeline/pulpo.js (~línea 3853, dentro del barrido de notificación)
+const fsAttachments = skillDeliverableAttachments.collectAttachmentsForSkill(
+  notifySkill, issue, fase, { pipelineRoot: ROOT },
+);
+if (Array.isArray(fsAttachments) && fsAttachments.length > 0) {
+  const existing = Array.isArray(r.attachments) ? r.attachments.slice() : [];
+  const seenPaths = new Set(existing.map((a) => (a && a.path) || ''));
+  for (const a of fsAttachments) {
+    if (a && !seenPaths.has(a.path)) {
+      existing.push(a);
+      seenPaths.add(a.path);
+    }
+  }
+  r.attachments = existing;
+}
+// luego deliverable-notify.notify({ ... yaml: r, ... })
+```
+
+El `try/catch` defensivo garantiza que un fallo del helper NUNCA bloquee la
+notificación. Si el helper devuelve `[]`, el notify cae al path text-only sin
+romper (regresión CA-6 cubierta por tests).
+
+### Configurabilidad
+
+Hoy el catálogo `SKILL_SOURCES` está hardcodeado en el helper. Si en el futuro
+se necesita configurar fuentes adicionales por entorno (ej. agregar
+`docs/app-screenshots-reference/<issue>/` para el caso B Android sin
+emulador), se puede agregar un bloque `attachments_per_skill[skill].sources`
+en `config.yaml` y leerlo desde el helper. Por ahora el catálogo refleja la
+convención usada por `screenshot-capture.js`, `ux-mockup-generator.js` y el
+gate `screenshots-mockup-gate.js`.
+
+### Estado del gate `SCREENSHOTS_MOCKUPS_GATE_ENABLED`
+
+El issue #3647 entrega el helper + la integración. La activación del gate
+visual del `/ux` queda **default OFF** (opción b del CA-4): el helper sólo
+adjunta los artefactos que ya estén en disco. Cuando se active el gate full
+en un issue separado (input desde telemetría #3656), las notificaciones de
+`ux` traerán automáticamente los 2 PNGs generados sin más cambios.
+
 ## Out of scope (NO incluido en #3414)
 
 - Comando `/rechazar` y su parser → **#3415** (receiver del envelope).

--- a/docs/pipeline/ux-visual-flow.md
+++ b/docs/pipeline/ux-visual-flow.md
@@ -3,6 +3,8 @@
 > **Issue origen:** [#3381](https://github.com/intrale/platform/issues/3381).
 > **Estado:** rollout gradual, default **OFF** (`SCREENSHOTS_MOCKUPS_GATE_ENABLED=1` para activar el gate).
 > **Audiencia:** `/ux`, `/po`, `/qa`, devs de Android (`/android-dev`) y de pipeline (`/pipeline-dev`).
+>
+> ⚠️ **Tecnología real (clarificación 2026-05-29 · issue #3647):** los mockups se generan con **Anthropic SDK + HTML/CSS + Puppeteer**. **NO se usa Claude Design** (claude.ai/design). Claude Design vive en el bucket Max separado y no tiene endpoint programable que el pipeline pueda integrar — se evaluó en la definición original del #3381 y se descartó. Si una memoria/documentación menciona "Claude Design" como fuente del flujo, está desactualizada respecto a la implementación real entregada.
 
 ## Por qué existe
 


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 6 archivos · +1120 -0

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:skipped` aplicado por delivery

## Closes

Closes #3647
