### PR TITLE
feat(ux): assets ghost-artifacts widget #3638 — entrega a main

### DIFF
--- a/.pipeline/assets/icons/sprite.svg
+++ b/.pipeline/assets/icons/sprite.svg
@@ -1112,4 +1112,55 @@
           stroke="currentColor" stroke-width="1" stroke-linejoin="round"/>
   </symbol>
 
+  <!-- =========================================================================
+       GHOST ARTIFACTS (#3638 — widget de salud del filesystem operacional)
+       Trio de iconos para los tres estados del widget:
+         - ic-ghost-clean    : escudo + check + gota fantasma — estado "limpio"
+         - ic-ghost-cleanup  : escoba + chispas — operacion de archivado en curso
+         - ic-archive-box    : caja con tapa cerrada — destino archivado/ghost-*
+       Convenciones: outline 1.75, viewBox 24x24, currentColor.
+       ========================================================================= -->
+
+  <!-- ic-ghost-clean: escudo con check + silueta fantasma sutil dentro.
+       Semantica: el invariant esta protegido + ya no hay huerfanos.
+       Usar con --success cuando no hubo cleanup en 7 dias. -->
+  <symbol id="ic-ghost-clean" viewBox="0 0 24 24">
+    <path d="M12 3 L20 6 V12 C20 16.5 16.5 19.5 12 21 C7.5 19.5 4 16.5 4 12 V6 Z"
+          fill="none" stroke="currentColor" stroke-width="1.75" stroke-linejoin="round"/>
+    <path d="M8.5 12.5 L11 15 L15.5 9.5" fill="none" stroke="currentColor"
+          stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
+
+  <!-- ic-ghost-cleanup: escoba diagonal + tres chispas.
+       Semantica: garbage collector activo, archivado reciente.
+       Usar con --warning cuando hubo cleanup en ultimas 24h. -->
+  <symbol id="ic-ghost-cleanup" viewBox="0 0 24 24">
+    <!-- Mango de la escoba (diagonal arriba-derecha a abajo-izquierda) -->
+    <path d="M20 4 L13 11" fill="none" stroke="currentColor" stroke-width="1.75"
+          stroke-linecap="round"/>
+    <!-- Cabeza de la escoba (trapecio invertido con flecos) -->
+    <path d="M9 15 L15 9 L19 13 L13 19 Z" fill="none" stroke="currentColor"
+          stroke-width="1.75" stroke-linejoin="round"/>
+    <path d="M11 17 L9.5 19 M13 19 L12 21 M15 19.5 L14.5 21.5" stroke="currentColor"
+          stroke-width="1.4" stroke-linecap="round"/>
+    <!-- Chispas (puntos pequenos arriba-derecha) -->
+    <circle cx="6" cy="7" r="0.9" fill="currentColor"/>
+    <circle cx="4.5" cy="11" r="0.7" fill="currentColor"/>
+    <circle cx="7.5" cy="4" r="0.6" fill="currentColor"/>
+  </symbol>
+
+  <!-- ic-archive-box: caja con tapa + label central.
+       Semantica: destino archivado/ghost-*, registro inmutable.
+       Usar con --text-dim como icono auxiliar en links al bucket. -->
+  <symbol id="ic-archive-box" viewBox="0 0 24 24">
+    <!-- Tapa -->
+    <rect x="3" y="5" width="18" height="4.5" rx="1" fill="none" stroke="currentColor"
+          stroke-width="1.75" stroke-linejoin="round"/>
+    <!-- Caja -->
+    <path d="M5 9.5 V19 A1.5 1.5 0 0 0 6.5 20.5 H17.5 A1.5 1.5 0 0 0 19 19 V9.5"
+          fill="none" stroke="currentColor" stroke-width="1.75" stroke-linejoin="round"/>
+    <!-- Tirador central -->
+    <path d="M10 13 H14" stroke="currentColor" stroke-width="1.75" stroke-linecap="round"/>
+  </symbol>
+
 </svg>

--- a/.pipeline/assets/mockups/23-ghost-artifacts-widget.svg
+++ b/.pipeline/assets/mockups/23-ghost-artifacts-widget.svg
@@ -1,0 +1,394 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Mockup 23 — Widget "Ghost artifacts · Filesystem operacional" + estados (#3638)
+  -----------------------------------------------------------------------------
+  Widget que reporta el estado del invariant "ningun archivo no-marker viejo en
+  carpetas operacionales" y que muestra las ultimas operaciones del
+  ghost-artifact-cleaner. Vive en la solapa Pipeline del dashboard V3, al lado
+  del widget de "Audit trail · Allowlist mutations" (mockup 22, #3625).
+
+  Tres estados visuales que el dev DEBE implementar (CA-F-12 de #3638):
+
+    A) CLEAN (no actividad en 7 dias)
+       - Card con borde --success-dim y banner verde
+       - Icono ic-ghost-clean tintado --success
+       - Texto "Ghost artifacts: clean"
+       - KPI "0 cleanups · 7d" en verde
+       - Tabla vacia con mensaje pacifico
+
+    B) RECENT CLEANUP (al menos 1 entrada con action=cleanup en ultimas 24h)
+       - Card con borde --warning y banner ambar
+       - Icono ic-ghost-cleanup tintado --warning
+       - Texto "Cleanup reciente · hace N min"
+       - KPI "N cleanups · 24h" en ambar
+       - Tabla con las ultimas 10 lineas del JSONL, action coloreada por tipo
+       - Boton "Ver archivo de auditoria" lleva al JSONL
+
+    C) WARN/SKIP (gh CLI down o lock busy en ultimas 24h)
+       - Card con borde --info y banner azul informativo
+       - Icono ic-ghost-clean + badge "skip" tintado --info
+       - Texto "Cleanup postergado · gh CLI no disponible" (segun reason)
+       - KPI "M skips · 24h" en azul info
+       - Tabla muestra los skips con razon textual
+
+  Sistema visual: dashboard V3 (design-tokens.css, sprite.svg).
+
+  Convenciones:
+    - Paleta: design-tokens.css (var(--success), var(--warning), var(--info),
+      var(--surface-*), var(--text-*))
+    - Iconos: sprite.svg referenciados con <use href="#ic-*"/>. En este mockup
+      standalone se inlinen como <symbol id="m-*"/> para preview sin sprite.
+    - Tipografia: var(--font-sans) system stack, monospace en hashes/paths.
+    - WCAG AA: contraste >=4.5:1 verificado contra surface-0/1.
+    - Anti-info-solo-por-color: cada estado tiene icono + texto, no solo color.
+    - escapeHtml: TODOS los campos del JSONL (file, reason, archived_to, context,
+      error) se rendean escapados — el mockup los muestra con caracteres seguros
+      pero el dev DEBE aplicar escape entitario en runtime (CA-SEC-9).
+
+  Tamano: 1440x900 (encaja como section card en la solapa Pipeline).
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 900"
+     font-family="-apple-system, 'Segoe UI Variable', 'Segoe UI', Roboto, sans-serif">
+  <defs>
+    <!-- ===== Iconos inline (preview standalone) ===== -->
+    <symbol id="m-ghost-clean" viewBox="0 0 24 24">
+      <path d="M12 3 L20 6 V12 C20 16.5 16.5 19.5 12 21 C7.5 19.5 4 16.5 4 12 V6 Z"
+            fill="none" stroke="currentColor" stroke-width="1.75" stroke-linejoin="round"/>
+      <path d="M8.5 12.5 L11 15 L15.5 9.5" fill="none" stroke="currentColor"
+            stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+    </symbol>
+    <symbol id="m-ghost-cleanup" viewBox="0 0 24 24">
+      <path d="M20 4 L13 11" fill="none" stroke="currentColor" stroke-width="1.75"
+            stroke-linecap="round"/>
+      <path d="M9 15 L15 9 L19 13 L13 19 Z" fill="none" stroke="currentColor"
+            stroke-width="1.75" stroke-linejoin="round"/>
+      <path d="M11 17 L9.5 19 M13 19 L12 21 M15 19.5 L14.5 21.5" stroke="currentColor"
+            stroke-width="1.4" stroke-linecap="round"/>
+      <circle cx="6" cy="7" r="0.9" fill="currentColor"/>
+      <circle cx="4.5" cy="11" r="0.7" fill="currentColor"/>
+      <circle cx="7.5" cy="4" r="0.6" fill="currentColor"/>
+    </symbol>
+    <symbol id="m-archive-box" viewBox="0 0 24 24">
+      <rect x="3" y="5" width="18" height="4.5" rx="1" fill="none" stroke="currentColor"
+            stroke-width="1.75" stroke-linejoin="round"/>
+      <path d="M5 9.5 V19 A1.5 1.5 0 0 0 6.5 20.5 H17.5 A1.5 1.5 0 0 0 19 19 V9.5"
+            fill="none" stroke="currentColor" stroke-width="1.75" stroke-linejoin="round"/>
+      <path d="M10 13 H14" stroke="currentColor" stroke-width="1.75" stroke-linecap="round"/>
+    </symbol>
+    <symbol id="m-info" viewBox="0 0 24 24">
+      <circle cx="12" cy="12" r="9" fill="none" stroke="currentColor" stroke-width="1.6"/>
+      <circle cx="12" cy="8" r="1" fill="currentColor"/>
+      <path d="M12 11 V17" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
+    </symbol>
+    <symbol id="m-link" viewBox="0 0 24 24">
+      <path d="M10 14 L14 10" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
+      <path d="M9 7 H7 A5 5 0 0 0 7 17 H9" fill="none" stroke="currentColor"
+            stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+      <path d="M15 7 H17 A5 5 0 0 1 17 17 H15" fill="none" stroke="currentColor"
+            stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+    </symbol>
+    <symbol id="m-skip" viewBox="0 0 24 24">
+      <circle cx="12" cy="12" r="9" fill="none" stroke="currentColor" stroke-width="1.6"/>
+      <path d="M8 10 L11 13 L8 16 M13 10 L16 13 L13 16" fill="none" stroke="currentColor"
+            stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    </symbol>
+  </defs>
+
+  <!-- ========================================================================= -->
+  <!-- FONDO (surface-0)                                                          -->
+  <!-- ========================================================================= -->
+  <rect width="1440" height="900" fill="#0D1117"/>
+
+  <!-- ========================================================================= -->
+  <!-- BREADCRUMB + TITULO                                                        -->
+  <!-- ========================================================================= -->
+  <text x="24" y="36" fill="#8B949E" font-size="13">Pipeline · Ghost artifacts · Filesystem operacional</text>
+  <text x="24" y="68" fill="#E6EDF3" font-size="24" font-weight="600">Ghost artifacts · Salud del filesystem operacional</text>
+  <text x="24" y="92" fill="#B1BAC4" font-size="13">El garbage collector barre definicion/ y desarrollo/ cada 6h, archiva (no elimina) huerfanos en .pipeline/archivado/ghost-&lt;timestamp&gt;/ y registra cada operacion en JSONL append-only con hash de archivo y razon textual.</text>
+
+  <!-- ========================================================================= -->
+  <!-- ESTADO A — CLEAN (sin actividad 7 dias)                                    -->
+  <!-- ========================================================================= -->
+  <g transform="translate(24,120)">
+    <!-- Card -->
+    <rect width="448" height="240" rx="10" fill="#161B22" stroke="#196C2E" stroke-width="1.5"/>
+    <!-- Header del estado -->
+    <rect x="0" y="0" width="448" height="56" rx="10" fill="rgba(63,185,80,0.10)"/>
+    <rect x="0" y="50" width="448" height="6" fill="rgba(63,185,80,0.10)"/>
+    <g transform="translate(16,16)" color="#3FB950">
+      <svg width="24" height="24" viewBox="0 0 24 24"><use href="#m-ghost-clean"/></svg>
+    </g>
+    <text x="50" y="34" fill="#3FB950" font-size="15" font-weight="600">Ghost artifacts: clean</text>
+    <g transform="translate(376,18)">
+      <rect width="56" height="20" rx="10" fill="#196C2E" opacity="0.4"/>
+      <text x="28" y="14" fill="#E6EDF3" font-size="10" font-weight="600" text-anchor="middle" letter-spacing="0.08em">ESTADO A</text>
+    </g>
+
+    <!-- KPI principal -->
+    <g transform="translate(16,76)">
+      <text x="0" y="14" fill="#8B949E" font-size="11" font-weight="600" letter-spacing="0.08em">CLEANUPS · 7 DIAS</text>
+      <text x="0" y="56" fill="#3FB950" font-size="40" font-weight="600"
+            font-family="'SF Mono', Consolas, monospace">0</text>
+      <text x="80" y="56" fill="#8B949E" font-size="13">sin actividad desde 2026-05-22 13:39Z</text>
+    </g>
+
+    <!-- Mensaje pacifico (estado vacio) -->
+    <g transform="translate(16,164)">
+      <rect width="416" height="60" rx="6" fill="#0D1117" stroke="#21262D" stroke-width="1"/>
+      <g transform="translate(16,18)" color="#8B949E">
+        <svg width="18" height="18" viewBox="0 0 24 24"><use href="#m-info"/></svg>
+      </g>
+      <text x="42" y="26" fill="#B1BAC4" font-size="12">El invariant se mantiene. Proximo barrido en 4h 12m.</text>
+      <text x="42" y="44" fill="#8B949E" font-size="11">Filtro isMarkerArtifact aplicado en 8 componentes.</text>
+    </g>
+  </g>
+
+  <!-- ========================================================================= -->
+  <!-- ESTADO B — RECENT CLEANUP (banner ambar, action en 24h)                    -->
+  <!-- ========================================================================= -->
+  <g transform="translate(496,120)">
+    <!-- Card -->
+    <rect width="448" height="240" rx="10" fill="#161B22" stroke="#D29922" stroke-width="1.5"/>
+    <!-- Header del estado -->
+    <rect x="0" y="0" width="448" height="56" rx="10" fill="rgba(210,153,34,0.12)"/>
+    <rect x="0" y="50" width="448" height="6" fill="rgba(210,153,34,0.12)"/>
+    <g transform="translate(16,16)" color="#D29922">
+      <svg width="24" height="24" viewBox="0 0 24 24"><use href="#m-ghost-cleanup"/></svg>
+    </g>
+    <text x="50" y="34" fill="#D29922" font-size="15" font-weight="600">Cleanup reciente · hace 4 min</text>
+    <g transform="translate(376,18)">
+      <rect width="56" height="20" rx="10" fill="#9E6A03" opacity="0.6"/>
+      <text x="28" y="14" fill="#E6EDF3" font-size="10" font-weight="600" text-anchor="middle" letter-spacing="0.08em">ESTADO B</text>
+    </g>
+
+    <!-- KPI principal -->
+    <g transform="translate(16,76)">
+      <text x="0" y="14" fill="#8B949E" font-size="11" font-weight="600" letter-spacing="0.08em">CLEANUPS · 24 HORAS</text>
+      <text x="0" y="56" fill="#D29922" font-size="40" font-weight="600"
+            font-family="'SF Mono', Consolas, monospace">3</text>
+      <text x="80" y="56" fill="#8B949E" font-size="13">archivados a ghost-20260529-133929</text>
+    </g>
+
+    <!-- Banner con accion -->
+    <g transform="translate(16,164)">
+      <rect width="416" height="60" rx="6" fill="rgba(210,153,34,0.10)" stroke="#9E6A03" stroke-width="1"/>
+      <text x="14" y="22" fill="#D29922" font-size="12" font-weight="600">Operacion reciente · revisar audit log</text>
+      <text x="14" y="40" fill="#B1BAC4" font-size="11">3 archivos huerfanos archivados sin error. Sin perdida de datos.</text>
+      <g transform="translate(280,12)">
+        <rect width="124" height="36" rx="6" fill="#0D1117" stroke="#D29922" stroke-width="1"/>
+        <g transform="translate(10,10)" color="#D29922">
+          <svg width="16" height="16" viewBox="0 0 24 24"><use href="#m-archive-box"/></svg>
+        </g>
+        <text x="62" y="22" fill="#D29922" font-size="11" font-weight="600" text-anchor="middle">Ver auditoria</text>
+      </g>
+    </g>
+  </g>
+
+  <!-- ========================================================================= -->
+  <!-- ESTADO C — WARN/SKIP (gh down, lock busy)                                  -->
+  <!-- ========================================================================= -->
+  <g transform="translate(968,120)">
+    <!-- Card -->
+    <rect width="448" height="240" rx="10" fill="#161B22" stroke="#58A6FF" stroke-width="1.5"/>
+    <!-- Header del estado -->
+    <rect x="0" y="0" width="448" height="56" rx="10" fill="rgba(88,166,255,0.10)"/>
+    <rect x="0" y="50" width="448" height="6" fill="rgba(88,166,255,0.10)"/>
+    <g transform="translate(16,16)" color="#58A6FF">
+      <svg width="24" height="24" viewBox="0 0 24 24"><use href="#m-skip"/></svg>
+    </g>
+    <text x="50" y="34" fill="#58A6FF" font-size="15" font-weight="600">Cleanup postergado · fail-safe</text>
+    <g transform="translate(376,18)">
+      <rect width="56" height="20" rx="10" fill="#1F6FEB" opacity="0.5"/>
+      <text x="28" y="14" fill="#E6EDF3" font-size="10" font-weight="600" text-anchor="middle" letter-spacing="0.08em">ESTADO C</text>
+    </g>
+
+    <!-- KPI principal -->
+    <g transform="translate(16,76)">
+      <text x="0" y="14" fill="#8B949E" font-size="11" font-weight="600" letter-spacing="0.08em">SKIPS · 24 HORAS</text>
+      <text x="0" y="56" fill="#58A6FF" font-size="40" font-weight="600"
+            font-family="'SF Mono', Consolas, monospace">2</text>
+      <text x="80" y="56" fill="#8B949E" font-size="13">archivos NO archivados — invariant preservado</text>
+    </g>
+
+    <!-- Banner con razon -->
+    <g transform="translate(16,164)">
+      <rect width="416" height="60" rx="6" fill="rgba(88,166,255,0.10)" stroke="#1F6FEB" stroke-width="1"/>
+      <text x="14" y="22" fill="#58A6FF" font-size="12" font-weight="600">Razon: gh CLI no disponible &gt;10s timeout</text>
+      <text x="14" y="40" fill="#B1BAC4" font-size="11">Reintento automatico al proximo tick. Nunca archivar en duda.</text>
+    </g>
+  </g>
+
+  <!-- ========================================================================= -->
+  <!-- SECCION — Tabla de ultimas 10 operaciones del JSONL                        -->
+  <!-- ========================================================================= -->
+  <g transform="translate(24,388)">
+    <!-- Titulo + nota -->
+    <g color="#58A6FF">
+      <svg x="0" y="-14" width="20" height="20" viewBox="0 0 24 24"><use href="#m-archive-box"/></svg>
+    </g>
+    <text x="30" y="4" fill="#E6EDF3" font-size="17" font-weight="600">Ultimas operaciones · ghost-artifacts-cleanup.jsonl</text>
+    <text x="430" y="4" fill="#8B949E" font-size="13">append-only, hash de archivo SHA-256, lectura tail -n 10</text>
+    <g transform="translate(1238,-16)">
+      <rect width="154" height="28" rx="6" fill="#161B22" stroke="#30363D" stroke-width="1"/>
+      <g transform="translate(12,6)" color="#B1BAC4">
+        <svg width="14" height="14" viewBox="0 0 24 24"><use href="#m-link"/></svg>
+      </g>
+      <text x="84" y="18" fill="#B1BAC4" font-size="12" font-weight="500" text-anchor="middle">Abrir audit JSONL</text>
+    </g>
+
+    <!-- Card contenedora de la tabla -->
+    <rect x="0" y="24" width="1392" height="464" rx="10" fill="#161B22" stroke="#30363D" stroke-width="1"/>
+
+    <!-- Headers de la tabla -->
+    <g transform="translate(20,52)">
+      <text x="0" y="14" fill="#8B949E" font-size="11" font-weight="600" letter-spacing="0.08em">TIMESTAMP (UTC)</text>
+      <text x="180" y="14" fill="#8B949E" font-size="11" font-weight="600" letter-spacing="0.08em">ACTION</text>
+      <text x="290" y="14" fill="#8B949E" font-size="11" font-weight="600" letter-spacing="0.08em">FILE</text>
+      <text x="700" y="14" fill="#8B949E" font-size="11" font-weight="600" letter-spacing="0.08em">REASON</text>
+      <text x="1100" y="14" fill="#8B949E" font-size="11" font-weight="600" letter-spacing="0.08em">ARCHIVED TO</text>
+      <line x1="-4" y1="22" x2="1356" y2="22" stroke="#21262D" stroke-width="1"/>
+    </g>
+
+    <!-- Row 1 — cleanup OK -->
+    <g transform="translate(20,84)" font-family="'SF Mono', Consolas, monospace" font-size="11">
+      <rect x="-4" y="-12" width="1360" height="32" rx="4" fill="rgba(63,185,80,0.06)"/>
+      <text x="0" y="6" fill="#B1BAC4">2026-05-29 14:21:08Z</text>
+      <g transform="translate(180,-9)">
+        <rect width="84" height="20" rx="10" fill="rgba(63,185,80,0.16)" stroke="#196C2E" stroke-width="1"/>
+        <text x="42" y="14" fill="#3FB950" font-weight="600" text-anchor="middle" font-size="10">cleanup</text>
+      </g>
+      <text x="290" y="6" fill="#E6EDF3">desarrollo/dev/pendiente/3201.guru.comment.md</text>
+      <text x="700" y="6" fill="#B1BAC4">orphaned (issue #3201 CLOSED, no .work/.build in parent)</text>
+      <text x="1100" y="6" fill="#8B949E" font-size="10">archivado/ghost-20260529-142108/...</text>
+    </g>
+
+    <!-- Row 2 — cleanup OK -->
+    <g transform="translate(20,124)" font-family="'SF Mono', Consolas, monospace" font-size="11">
+      <rect x="-4" y="-12" width="1360" height="32" rx="4" fill="rgba(63,185,80,0.06)"/>
+      <text x="0" y="6" fill="#B1BAC4">2026-05-29 14:21:08Z</text>
+      <g transform="translate(180,-9)">
+        <rect width="84" height="20" rx="10" fill="rgba(63,185,80,0.16)" stroke="#196C2E" stroke-width="1"/>
+        <text x="42" y="14" fill="#3FB950" font-weight="600" text-anchor="middle" font-size="10">cleanup</text>
+      </g>
+      <text x="290" y="6" fill="#E6EDF3">desarrollo/build/pendiente/3201.guidance.txt</text>
+      <text x="700" y="6" fill="#B1BAC4">orphaned (issue #3201 CLOSED, no .work/.build in parent)</text>
+      <text x="1100" y="6" fill="#8B949E" font-size="10">archivado/ghost-20260529-142108/...</text>
+    </g>
+
+    <!-- Row 3 — cleanup OK -->
+    <g transform="translate(20,164)" font-family="'SF Mono', Consolas, monospace" font-size="11">
+      <rect x="-4" y="-12" width="1360" height="32" rx="4" fill="rgba(63,185,80,0.06)"/>
+      <text x="0" y="6" fill="#B1BAC4">2026-05-29 14:21:08Z</text>
+      <g transform="translate(180,-9)">
+        <rect width="84" height="20" rx="10" fill="rgba(63,185,80,0.16)" stroke="#196C2E" stroke-width="1"/>
+        <text x="42" y="14" fill="#3FB950" font-weight="600" text-anchor="middle" font-size="10">cleanup</text>
+      </g>
+      <text x="290" y="6" fill="#E6EDF3">definicion/criterios/pendiente/3104.po.reason.json</text>
+      <text x="700" y="6" fill="#B1BAC4">orphaned (issue #3104 CLOSED, no .work/.build in parent)</text>
+      <text x="1100" y="6" fill="#8B949E" font-size="10">archivado/ghost-20260529-142108/...</text>
+    </g>
+
+    <!-- Row 4 — no-op (ya archivado) -->
+    <g transform="translate(20,204)" font-family="'SF Mono', Consolas, monospace" font-size="11">
+      <text x="0" y="6" fill="#B1BAC4">2026-05-29 13:39:43Z</text>
+      <g transform="translate(180,-9)">
+        <rect width="84" height="20" rx="10" fill="rgba(177,186,196,0.10)" stroke="#484F58" stroke-width="1"/>
+        <text x="42" y="14" fill="#B1BAC4" font-weight="600" text-anchor="middle" font-size="10">no-op</text>
+      </g>
+      <text x="290" y="6" fill="#E6EDF3">definicion/criterios/pendiente/3076.po.comment.md</text>
+      <text x="700" y="6" fill="#B1BAC4">already archived (bucket ghost-20260529-133929 existe)</text>
+      <text x="1100" y="6" fill="#8B949E" font-size="10">— sin nuevo bucket</text>
+    </g>
+
+    <!-- Row 5 — skip por gh down -->
+    <g transform="translate(20,244)" font-family="'SF Mono', Consolas, monospace" font-size="11">
+      <rect x="-4" y="-12" width="1360" height="32" rx="4" fill="rgba(88,166,255,0.06)"/>
+      <text x="0" y="6" fill="#B1BAC4">2026-05-29 08:15:02Z</text>
+      <g transform="translate(180,-9)">
+        <rect width="84" height="20" rx="10" fill="rgba(88,166,255,0.16)" stroke="#1F6FEB" stroke-width="1"/>
+        <text x="42" y="14" fill="#58A6FF" font-weight="600" text-anchor="middle" font-size="10">skip</text>
+      </g>
+      <text x="290" y="6" fill="#E6EDF3">desarrollo/dev/pendiente/3555.android-dev.comment.md</text>
+      <text x="700" y="6" fill="#58A6FF">gh unavailable (timeout 10s, exit 1) — fail-safe</text>
+      <text x="1100" y="6" fill="#8B949E" font-size="10">— sin accion (reintento al proximo tick)</text>
+    </g>
+
+    <!-- Row 6 — skip por symlink (CA-SEC-2) -->
+    <g transform="translate(20,284)" font-family="'SF Mono', Consolas, monospace" font-size="11">
+      <text x="0" y="6" fill="#B1BAC4">2026-05-29 02:00:00Z</text>
+      <g transform="translate(180,-9)">
+        <rect width="84" height="20" rx="10" fill="rgba(88,166,255,0.16)" stroke="#1F6FEB" stroke-width="1"/>
+        <text x="42" y="14" fill="#58A6FF" font-weight="600" text-anchor="middle" font-size="10">skip</text>
+      </g>
+      <text x="290" y="6" fill="#E6EDF3">definicion/criterios/pendiente/9999.po.comment.md</text>
+      <text x="700" y="6" fill="#58A6FF">symlink rechazado (lstat.isSymbolicLink === true)</text>
+      <text x="1100" y="6" fill="#8B949E" font-size="10">— sin accion (anti-attack)</text>
+    </g>
+
+    <!-- Row 7 — skip por lock busy -->
+    <g transform="translate(20,324)" font-family="'SF Mono', Consolas, monospace" font-size="11">
+      <rect x="-4" y="-12" width="1360" height="32" rx="4" fill="rgba(88,166,255,0.06)"/>
+      <text x="0" y="6" fill="#B1BAC4">2026-05-28 20:00:00Z</text>
+      <g transform="translate(180,-9)">
+        <rect width="84" height="20" rx="10" fill="rgba(88,166,255,0.16)" stroke="#1F6FEB" stroke-width="1"/>
+        <text x="42" y="14" fill="#58A6FF" font-weight="600" text-anchor="middle" font-size="10">skip</text>
+      </g>
+      <text x="290" y="6" fill="#E6EDF3">— (sweep no inicio)</text>
+      <text x="700" y="6" fill="#58A6FF">lock busy (.pipeline/locks/ghost-cleaner.lock, timeout 5s)</text>
+      <text x="1100" y="6" fill="#8B949E" font-size="10">— sin accion (otro proceso activo)</text>
+    </g>
+
+    <!-- Row 8 — cleanup OK (entrada del bootstrap inicial) -->
+    <g transform="translate(20,364)" font-family="'SF Mono', Consolas, monospace" font-size="11">
+      <text x="0" y="6" fill="#B1BAC4">2026-05-29 13:39:43Z</text>
+      <g transform="translate(180,-9)">
+        <rect width="84" height="20" rx="10" fill="rgba(63,185,80,0.16)" stroke="#196C2E" stroke-width="1"/>
+        <text x="42" y="14" fill="#3FB950" font-weight="600" text-anchor="middle" font-size="10">cleanup</text>
+      </g>
+      <text x="290" y="6" fill="#E6EDF3">definicion/criterios/pendiente/3076.po.comment.md</text>
+      <text x="700" y="6" fill="#B1BAC4">orphaned (issue #3076 CLOSED, manual bootstrap)</text>
+      <text x="1100" y="6" fill="#8B949E" font-size="10">archivado/ghost-20260529-133929/...</text>
+    </g>
+
+    <!-- Footer de la tabla -->
+    <g transform="translate(20,420)">
+      <line x1="-4" y1="0" x2="1356" y2="0" stroke="#21262D" stroke-width="1"/>
+      <text x="0" y="22" fill="#8B949E" font-size="12">8 de 8 entries · archivo 4.2 KB · rotacion pendiente a 10 MB (issue #3645)</text>
+      <g transform="translate(1080,8)">
+        <rect width="124" height="28" rx="6" fill="#161B22" stroke="#30363D" stroke-width="1"/>
+        <text x="62" y="18" fill="#B1BAC4" font-size="12" font-weight="500" text-anchor="middle">Filtrar action</text>
+      </g>
+      <g transform="translate(1216,8)">
+        <rect width="140" height="28" rx="6" fill="#161B22" stroke="#30363D" stroke-width="1"/>
+        <text x="70" y="18" fill="#B1BAC4" font-size="12" font-weight="500" text-anchor="middle">Descargar JSONL</text>
+      </g>
+    </g>
+  </g>
+
+  <!-- ========================================================================= -->
+  <!-- LEYENDA INFERIOR — semantica de action chips                              -->
+  <!-- ========================================================================= -->
+  <g transform="translate(24,876)">
+    <text x="0" y="0" fill="#8B949E" font-size="12">Leyenda:</text>
+    <g transform="translate(72,-10)">
+      <rect width="84" height="20" rx="10" fill="rgba(63,185,80,0.16)" stroke="#196C2E" stroke-width="1"/>
+      <text x="42" y="14" fill="#3FB950" font-weight="600" text-anchor="middle" font-size="10" font-family="'SF Mono', Consolas, monospace">cleanup</text>
+    </g>
+    <text x="166" y="0" fill="#B1BAC4" font-size="11">archivado OK</text>
+    <g transform="translate(260,-10)">
+      <rect width="84" height="20" rx="10" fill="rgba(177,186,196,0.10)" stroke="#484F58" stroke-width="1"/>
+      <text x="42" y="14" fill="#B1BAC4" font-weight="600" text-anchor="middle" font-size="10" font-family="'SF Mono', Consolas, monospace">no-op</text>
+    </g>
+    <text x="354" y="0" fill="#B1BAC4" font-size="11">ya archivado (idempotencia)</text>
+    <g transform="translate(520,-10)">
+      <rect width="84" height="20" rx="10" fill="rgba(88,166,255,0.16)" stroke="#1F6FEB" stroke-width="1"/>
+      <text x="42" y="14" fill="#58A6FF" font-weight="600" text-anchor="middle" font-size="10" font-family="'SF Mono', Consolas, monospace">skip</text>
+    </g>
+    <text x="614" y="0" fill="#B1BAC4" font-size="11">postergado por fail-safe (gh down · symlink · lock busy)</text>
+    <g transform="translate(908,-10)">
+      <rect width="84" height="20" rx="10" fill="rgba(248,81,73,0.16)" stroke="#8B1A14" stroke-width="1"/>
+      <text x="42" y="14" fill="#F85149" font-weight="600" text-anchor="middle" font-size="10" font-family="'SF Mono', Consolas, monospace">error</text>
+    </g>
+    <text x="1002" y="0" fill="#B1BAC4" font-size="11">excepcion no recuperable (sweep abortado)</text>
+  </g>
+</svg>

--- a/.pipeline/assets/mockups/narrativa-ghost-artifacts.md
+++ b/.pipeline/assets/mockups/narrativa-ghost-artifacts.md
@@ -1,0 +1,198 @@
+# Narrativa visual — Widget Ghost artifacts (#3638)
+
+> Sistema visual y comportamiento del widget que reporta la salud del filesystem
+> operacional del pipeline V3. Para el dev que implementa CA-F-12 + CA-SEC-9 +
+> CA-SEC-5 de [#3638](https://github.com/intrale/platform/issues/3638). Soporta
+> los criterios PO en el comentario [#issuecomment-4576057136](https://github.com/intrale/platform/issues/3638#issuecomment-4576057136).
+
+## Contexto
+
+El garbage collector `lib/ghost-artifact-cleaner.js` barre cada 6 horas las
+carpetas operacionales `.pipeline/definicion/**` y `.pipeline/desarrollo/**`,
+detecta artefactos `.md`/`.txt`/`.json` cuyo issue asociado ya fue cerrado y los
+**archiva** (nunca elimina) en `.pipeline/archivado/ghost-<timestamp>/`,
+registrando cada operacion en `.pipeline/audit/ghost-artifacts-cleanup.jsonl`.
+
+El widget en la solapa **Pipeline** del dashboard V3 sirve dos audiencias:
+
+1. **Operador en patrulla** — necesita ver de un vistazo si el invariant esta
+   protegido o si hubo limpieza reciente que pueda explicar un cambio raro en
+   listados.
+2. **Auditor / dev nuevo** — necesita poder bajar al detalle (que se archivo,
+   cuando, con que razon) sin abrir el JSONL a mano.
+
+## Tres estados visuales (cards superiores)
+
+Los tres estados se eligen mirando las **ultimas 7 dias** del JSONL:
+
+| Estado | Condicion | Borde | Acento | Icono |
+|--------|-----------|-------|--------|-------|
+| **A · Clean** | sin `action=cleanup` ni `action=skip` en 7 dias | `--success-dim` | `--success` | `ic-ghost-clean` |
+| **B · Recent cleanup** | al menos 1 `action=cleanup` en 24h | `--warning` | `--warning` | `ic-ghost-cleanup` |
+| **C · Warn/Skip** | al menos 1 `action=skip` en 24h sin cleanup OK | `--info` | `--info` | `ic-skip` + `ic-ghost-clean` |
+
+Cuando se cumplen B **y** C en la misma ventana, gana B (cleanup pesa mas que
+skip — hubo accion efectiva). El estado A es el "verde tranquilo" del CA-F-12:
+"Ghost artifacts: clean".
+
+Los tres estados se renderizan **siempre** como 3 cards lado a lado (no se
+ocultan los otros), porque el operador necesita ver tambien "cuantos skips
+hubo aun cuando hubo cleanups". El borde y el icono comunican cual es el
+estado **dominante** ahora.
+
+### Reglas de iconografia
+
+- `ic-ghost-clean` (escudo + check): el invariant esta protegido. NUNCA aparece
+  solo con color verde — siempre acompanado del texto "Ghost artifacts: clean"
+  para WCAG.
+- `ic-ghost-cleanup` (escoba + chispas): operacion de archivado activa o reciente.
+  Acompana texto "Cleanup reciente · hace N min".
+- `ic-archive-box` (caja cerrada): destino del archivo movido. Aparece como
+  icono auxiliar en el boton "Ver auditoria" y en links al bucket `archivado/`.
+- `ic-skip` (circulo con `>><<`): operacion postergada por fail-safe. Acompana
+  texto "Cleanup postergado · {razon}".
+
+### Reglas de paleta
+
+Las 3 cards reusan tokens existentes del sistema (`design-tokens.css` seccion 3
+SEMANTICOS). **Prohibido inventar colores nuevos** — el sistema ya tiene la
+familia completa.
+
+## Tabla inferior — Ultimas 10 operaciones del JSONL
+
+Lectura `tail -n 10` del archivo `.pipeline/audit/ghost-artifacts-cleanup.jsonl`.
+Si el archivo tiene menos de 10 lineas, mostrar todas las que haya. Si no existe,
+mostrar el estado vacio del card A con mensaje "No hay operaciones registradas".
+
+### Columnas
+
+| Columna | Fuente JSONL | Notas |
+|---------|--------------|-------|
+| TIMESTAMP (UTC) | `timestamp` | Formato `YYYY-MM-DD HH:MM:SSZ`, monospace. |
+| ACTION | `action` ∈ `{cleanup, no-op, skip, error}` | Chip de color (ver leyenda). |
+| FILE | `file` | Path relativo a `.pipeline/`. Monospace. |
+| REASON | `reason` | Texto libre del operador/sistema. |
+| ARCHIVED TO | `archived_to` (opcional) | Truncado con `…` si excede ancho. |
+
+**CA-SEC-9 obligatorio:** TODOS los campos pasan por `escapeHtml(s)` antes de
+renderizarse. El mockup muestra paths con caracteres ASCII seguros, pero el dev
+DEBE asumir que el reason o el file pueden contener `<`, `>`, `&`, `"`, `'`
+(creados por error o por filename pathologico) y escaparlos.
+
+**CA-SEC-5 obligatorio:** cada `JSON.parse(line)` envuelto en try/catch. Si la
+linea es invalida, **descartar + log warning + seguir con la siguiente**. Nunca
+crashear el widget por una entrada corrupta.
+
+### Chips de action
+
+| Action | Color de fondo | Color de texto | Color de borde |
+|--------|----------------|----------------|----------------|
+| `cleanup` | `--success-bg` | `--success` | `--success-dim` |
+| `no-op` | `--deterministic-bg` | `--text-secondary` | `--border-strong` |
+| `skip` | `--info-bg` | `--info` | `--info-dim` |
+| `error` | `--danger-bg` | `--danger` | `--danger-dim` |
+
+El chip se renderiza como `<span class="chip chip-action-{action}">cleanup</span>`
+y la clase mapea al token correspondiente.
+
+### Highlight de fila
+
+La fila completa recibe un fondo MUY tenue del color del action (alpha 6%) para
+permitir scaneo rapido de patrones (3 cleanups seguidos, luego un skip, etc.).
+NO usar color saturado en la fila — el chip ya comunica el estado.
+
+## Banner del estado B — "Operacion reciente"
+
+Cuando hay cleanup en 24h, la card B muestra un sub-banner ambar con:
+
+- Titulo: **"Operacion reciente · revisar audit log"**
+- Cuerpo: **"N archivos huerfanos archivados sin error. Sin perdida de datos."**
+- CTA: **"Ver auditoria"** — boton outline que abre `.pipeline/audit/ghost-artifacts-cleanup.jsonl` (puede ser un `<a href="/api/audit/ghost-artifacts-cleanup.jsonl">` que sirve el contenido en el dashboard, o un `<a download>`).
+
+El texto "Sin perdida de datos" es **importante** — el operador necesita la
+tranquilidad de que el GC archiva, no elimina. Es parte del contrato.
+
+## Banner del estado C — "Razon del skip"
+
+Cuando hay skip en 24h, la card C muestra:
+
+- Titulo: **"Razon: {reason del ultimo skip}"** (escapado).
+- Cuerpo: **"Reintento automatico al proximo tick. Nunca archivar en duda."**
+
+La razon es informacion **critica de auditoria** — si gh esta down, el operador
+necesita saberlo para no confundirlo con un GC roto. El mensaje "Nunca archivar
+en duda" refuerza el fail-safe SEC-E.
+
+## Comportamiento responsive
+
+- Desktop (>=1280px): 3 cards lado a lado, tabla full-width.
+- Tablet (768-1279px): 3 cards apiladas (1 columna), tabla scroll horizontal.
+- Mobile (<768px): widget colapsado a un solo card con el estado dominante y
+  CTA "Ver detalle" que abre el JSONL en pantalla completa.
+
+El dashboard V3 hoy es desktop-first (uso operativo desde escritorio), pero el
+markup debe usar `flex-wrap` y `min-width` para no romper en viewports
+chicos. **Prohibido hardcodear `width: 1440px`.**
+
+## Accesibilidad (WCAG AA)
+
+- Cada `<svg>` con `<use href="#ic-*"/>` lleva `aria-label` descriptivo en el
+  `<svg>` padre (ver convencion del sprite).
+- Cada chip de action tiene texto visible (`cleanup`, `skip`, etc.) ademas del
+  color — anti-info-solo-por-color.
+- Foco visible con `--focus-ring` en los botones "Ver auditoria",
+  "Filtrar action" y "Descargar JSONL".
+- Contraste verificado en design-tokens.css seccion 3: todos los pares
+  texto/fondo cumplen `>=4.5:1` para texto normal y `>=3:1` para texto grande.
+- `prefers-reduced-motion`: si el dev agrega cualquier animacion de pulso al
+  estado B (banner reciente), debe respetar la media query (ya cubierta en
+  design-tokens seccion 12).
+
+## Comportamiento de refresh
+
+- Polling cada 30s del endpoint `/api/audit/ghost-artifacts-cleanup/tail?n=10`.
+- Diff visual: si llega una linea nueva, la tabla scroll-into-view a la primera
+  fila con animacion fade-in de 200ms. Respetar `prefers-reduced-motion`.
+- Si el JSONL no se puede leer (permisos, no existe, parse falla en todas las
+  lineas), mostrar mensaje neutral "No hay operaciones registradas" con el
+  card A en estado clean.
+
+## Ejemplo de entradas JSONL (fixture para tests del widget)
+
+```jsonl
+{"timestamp":"2026-05-29T13:39:43Z","action":"cleanup","file":"definicion/criterios/pendiente/3076.po.comment.md","reason":"orphaned (issue #3076 CLOSED, no .work/.build in parent folder)","archived_to":"archivado/ghost-20260529-133929/3076.po.comment.md","context":"Commander cleanup during issue #3638 definition phase"}
+{"timestamp":"2026-05-29T14:21:08Z","action":"cleanup","file":"desarrollo/dev/pendiente/3201.guru.comment.md","reason":"orphaned (issue #3201 CLOSED, no .work/.build in parent)","archived_to":"archivado/ghost-20260529-142108/desarrollo/dev/pendiente/3201.guru.comment.md","context":"scheduled tick"}
+{"timestamp":"2026-05-29T14:21:08Z","action":"no-op","file":"definicion/criterios/pendiente/3076.po.comment.md","reason":"already archived (bucket ghost-20260529-133929 existe)","archived_to":null,"context":"idempotency check"}
+{"timestamp":"2026-05-29T08:15:02Z","action":"skip","file":"desarrollo/dev/pendiente/3555.android-dev.comment.md","reason":"gh unavailable (timeout 10s, exit 1)","archived_to":null,"context":"fail-safe SEC-OPS-2"}
+{"timestamp":"2026-05-29T02:00:00Z","action":"skip","file":"definicion/criterios/pendiente/9999.po.comment.md","reason":"symlink rechazado (lstat.isSymbolicLink === true)","archived_to":null,"context":"hardening SEC-2"}
+{"timestamp":"2026-05-28T20:00:00Z","action":"skip","file":null,"reason":"lock busy (.pipeline/locks/ghost-cleaner.lock, timeout 5s)","archived_to":null,"context":"concurrency OPS-1"}
+```
+
+El dev puede usar estas 6 lineas como fixture en los tests del widget (CA-F-12)
+para verificar render de los 4 chips, escape HTML de `reason`, truncado de
+`archived_to` y manejo de `null`.
+
+## Lo que el widget NO hace (anti-scope creep)
+
+- **NO** ejecuta el cleaner manualmente. El widget es read-only: muestra lo que
+  el GC del pulpo ya hizo. Un boton "Ejecutar cleaner ahora" estaria fuera de
+  scope y rompe la separacion de responsabilidades (#3638 entrega el cron
+  + comando manual desde terminal).
+- **NO** muestra graficos historicos (timeline, sparkline, gauge). El KPI
+  "X cleanups · 24h" es suficiente para el alcance de este issue. Las metricas
+  agregadas viven en el follow-up [#3646](https://github.com/intrale/platform/issues/3646).
+- **NO** rota el JSONL. La rotacion a 10MB esta en el follow-up
+  [#3645](https://github.com/intrale/platform/issues/3645).
+- **NO** marca entradas como "revisadas" ni mantiene estado del operador. Es
+  solo una vista del JSONL.
+
+## Referencias
+
+- Mockup SVG: `.pipeline/assets/mockups/23-ghost-artifacts-widget.svg`
+- Sprite icons: `.pipeline/assets/icons/sprite.svg` (ids `ic-ghost-clean`,
+  `ic-ghost-cleanup`, `ic-archive-box`).
+- Design tokens: `.pipeline/assets/design-tokens.css` secciones 3 y 11.
+- Patron similar implementado: widget 22 "Audit trail · Allowlist mutations"
+  (#3625, mockup 22) — mismo paradigma de KPI + tabla del JSONL con chips de
+  action.
+- Doc canonica del invariant (a entregar por el dev): `docs/pipeline/ghost-artifact-invariant.md`.


### PR DESCRIPTION
## Resumen

Cherry-pick del commit \`c454cdeb\` (entregado originalmente por UX-criterios en la rama \`local/3518-pipeline-dev-wiring\`) hacia \`origin/main\` para destrabar el pipeline-dev de #3638.

## Contexto del rebote

El agente UX-validacion rechazó #3638 (rebote cross-phase #1 de UX-criterios → UX-criterios) porque los assets visuales del widget ghost artifacts quedaron varados en una rama paralela (\`local/3518-pipeline-dev-wiring\`) y NO accesibles desde \`origin/main\`, que es la base desde donde el \`worktree-launcher.js\` arma los worktrees del pipeline-dev.

## Verificación empírica antes del cherry-pick

\`\`\`
\$ git merge-base --is-ancestor c454cdeb origin/main && echo SI || echo NO
NO esta en origin/main

\$ git branch -a --contains c454cdeb
  local/3518-pipeline-dev-wiring
  remotes/origin/local/3518-pipeline-dev-wiring
\`\`\`

## Archivos modificados (643 inserciones en 3 paths)

- \`.pipeline/assets/icons/sprite.svg\` (+51 lines) — 3 symbols nuevos: \`ic-ghost-clean\`, \`ic-ghost-cleanup\`, \`ic-archive-box\`
- \`.pipeline/assets/mockups/23-ghost-artifacts-widget.svg\` (+394 lines) — mockup 1440x900 con 3 estados (clean / recent cleanup / warn-skip)
- \`.pipeline/assets/mockups/narrativa-ghost-artifacts.md\` (+198 lines) — guía operativa para el dev, fixture JSONL, anti-scope-creep

## QA skip — justificación

Cambio exclusivo en \`.pipeline/assets/\`: assets estáticos SVG + markdown. Ningún Gradle task los procesa, no impactan al producto del usuario final (\`app:*\` ausente). Los assets ya fueron validados por UX en su entrega original (commit \`c454cdeb\`) — este PR solo cambia el canal de entrega.

## Issue

Destraba el ciclo de #3638 (sin cerrarlo — el dev sigue su flujo después de este merge).