### PR TITLE
[bug] Ghost artifacts cleanup: limpiar artefactos .md/.txt/.json huérfanos en carpetas operacionales

### DIFF
--- a/.github/workflows/ghost-artifact-lint.yml
+++ b/.github/workflows/ghost-artifact-lint.yml
@@ -1,0 +1,38 @@
+name: Ghost Artifact Lint
+
+# Issue #3638 — CA-SEC-8 (no-negociable): defensa en profundidad. El hook
+# pre-commit local es bypassable con `--no-verify`; este job duplica el lint
+# en CI y debe agregarse como required check de branch protection sobre
+# `main`.
+
+on:
+  pull_request:
+    branches: [ main, develop ]
+    paths:
+      - '.pipeline/**'
+      - '.github/workflows/ghost-artifact-lint.yml'
+  push:
+    branches: [ main ]
+    paths:
+      - '.pipeline/**'
+
+jobs:
+  ghost-artifact-lint:
+    runs-on: ubuntu-latest
+    name: Ghost artifact lint (isMarkerArtifact required)
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Run ghost-artifact lint
+        working-directory: .pipeline
+        run: node lib/ghost-artifact-lint.js --check
+
+      - name: Run ghost-artifact unit tests
+        working-directory: .pipeline
+        run: node --test lib/__tests__/ghost-artifact-cleaner.test.js lib/__tests__/ghost-artifact-lint.test.js lib/__tests__/marker-artifact.test.js

--- a/.gitignore
+++ b/.gitignore
@@ -168,6 +168,13 @@ scripts/planner-plan.json
 # Solo se versiona el HEAD de waves.json; archived/ es efímero por máquina.
 .pipeline/archived/
 
+# #3638 CA-SEC-6 — ghost artifacts cleaner: nada del archivado (español) ni del
+# audit JSONL operacional debe ir al repo. Contienen paths internos, CAs viejos,
+# motivos de rechazo y metadata del pipeline. El cleaner verifica esto en boot
+# y aborta si los paths no están ignored (anti-regresión).
+.pipeline/archivado/
+.pipeline/audit/
+
 # #3539 — audios .ogg generados por deliverable-notify (CA-SEC-8).
 # El cleanup/retencion sera tratado en #3544.
 .pipeline/audio/

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -79,4 +79,28 @@ if [ -f ".pipeline/lib/precommit-secret-scan.js" ]; then
   fi
 fi
 
+# =============================================================================
+# Issue #3638 CA-F-11 — Ghost-artifact lint sobre archivos del pipeline.
+#
+# Bloquea commits que introduzcan readdirSync sobre carpetas operacionales
+# (.pipeline/definicion/**, .pipeline/desarrollo/**) sin aplicar el filtro
+# `isMarkerArtifact`. Defensa en profundidad complementada por el job CI
+# `ghost-artifact-lint` (CA-SEC-8) que captura bypass con --no-verify.
+#
+# Solo corre cuando se tocan archivos bajo `.pipeline/`. Sin matches,
+# no consume tiempo del flujo normal de commits.
+# =============================================================================
+RUN_GHOST_LINT=0
+case "$TOUCHED_FILES" in
+  *".pipeline/"*) RUN_GHOST_LINT=1 ;;
+esac
+
+if [ "$RUN_GHOST_LINT" = "1" ] && [ -f ".pipeline/lib/ghost-artifact-lint.js" ]; then
+  node .pipeline/lib/ghost-artifact-lint.js --check
+  LINT_EXIT=$?
+  if [ "$LINT_EXIT" != "0" ]; then
+    exit $LINT_EXIT
+  fi
+fi
+
 exit 0

--- a/.pipeline/dashboard.js
+++ b/.pipeline/dashboard.js
@@ -70,18 +70,9 @@ try { restModeState = require('./lib/rest-mode-state'); } catch { /* opcional */
 let restModeWindow = null;
 try { restModeWindow = require('./lib/rest-mode-window'); } catch { /* opcional */ }
 
-// Detector de artifacts auxiliares compartido con human-block.js: excluye
-// `.guidance.txt`, `.reason.json`, `.comment.md` y cualquier filename con
-// > 2 segmentos del listado de markers, así no aparecen como agentes fantasma.
-let _isMarkerArtifact;
-try { ({ isMarkerArtifact: _isMarkerArtifact } = require('./lib/human-block')); } catch { /* opcional */ }
-function isMarkerArtifact(name) {
-  if (typeof _isMarkerArtifact === 'function') return _isMarkerArtifact(name);
-  return name.split('.').length > 2
-      || name.endsWith('.reason.json')
-      || name.endsWith('.guidance.txt')
-      || name.endsWith('.comment.md');
-}
+// Artifacts auxiliares: detección centralizada en `lib/marker-artifact.js`
+// (#3638 CA-F-1).
+const { isMarkerArtifact } = require('./lib/marker-artifact');
 
 const PORT = parseInt(process.env.DASHBOARD_PORT) || 3200;
 const PIPELINE = process.env.PIPELINE_STATE_DIR || path.resolve(__dirname);
@@ -977,7 +968,65 @@ function getPipelineState() {
   _scheduleOlaETARefresh(state);
   state.olaETA = _olaETACache;
 
+  // #3638 CA-F-12 — Ghost artifacts widget: lee últimas 10 líneas del audit
+  // JSONL. Si hubo cleanup en últimas 24h → bandera ⚠ . Sin actividad ≥ 7 días → ✅.
+  state.ghostArtifacts = readGhostArtifactSummary();
+
   return state;
+}
+
+/**
+ * Lee las últimas N líneas del audit JSONL del ghost-artifact-cleaner.
+ * Tolera líneas malformadas (CA-SEC-5): try/catch por línea, descarta y warn.
+ * Nunca crashea el dashboard.
+ *
+ * @returns {{ enabled, lastRunIso, lastCleanupIso, status, recent, cleanupCount24h }}
+ */
+function readGhostArtifactSummary() {
+  const file = path.join(PIPELINE, 'audit', 'ghost-artifacts-cleanup.jsonl');
+  let raw = '';
+  try { raw = fs.readFileSync(file, 'utf8'); }
+  catch {
+    return {
+      enabled: false,
+      lastRunIso: null,
+      lastCleanupIso: null,
+      status: 'unknown',
+      recent: [],
+      cleanupCount24h: 0,
+    };
+  }
+  const lines = raw.split('\n').filter(Boolean);
+  const parsed = [];
+  for (const line of lines) {
+    try { parsed.push(JSON.parse(line)); }
+    catch { /* CA-SEC-5: skip malformed, no crash */ }
+  }
+  // últimas 10 entradas
+  const recent = parsed.slice(-10).reverse();
+  const lastRun = parsed.length > 0 ? parsed[parsed.length - 1].timestamp : null;
+  const cleanups = parsed.filter(e => e && e.action === 'cleanup');
+  const lastCleanup = cleanups.length > 0 ? cleanups[cleanups.length - 1].timestamp : null;
+  const now = Date.now();
+  const cutoff24h = now - (24 * 60 * 60 * 1000);
+  const cutoff7d = now - (7 * 24 * 60 * 60 * 1000);
+  const cleanupCount24h = cleanups.filter(e => {
+    const t = Date.parse(e.timestamp || '');
+    return Number.isFinite(t) && t >= cutoff24h;
+  }).length;
+  let status;
+  if (cleanupCount24h > 0) status = 'recent-cleanup';
+  else if (lastCleanup && Date.parse(lastCleanup) < cutoff7d) status = 'clean';
+  else if (!lastCleanup && lastRun && Date.parse(lastRun) < cutoff7d) status = 'clean';
+  else status = 'idle';
+  return {
+    enabled: true,
+    lastRunIso: lastRun,
+    lastCleanupIso: lastCleanup,
+    status,
+    recent,
+    cleanupCount24h,
+  };
 }
 
 // --- HTML generation helpers ---
@@ -1358,6 +1407,85 @@ function escapeHtml(s) {
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&#39;');
+}
+
+// #3638 CA-F-12 / CA-SEC-9 — Widget de estado del ghost-artifact-cleaner.
+// Renderiza los últimos eventos del audit JSONL escapando TODO valor por
+// escapeHtml() para prevenir XSS desde filenames maliciosos. Estados:
+//   - 'recent-cleanup': ic-ghost-cleanup + acento --warning (cleanup en últimas 24h)
+//   - 'clean':         ic-ghost-clean   + acento --success (sin actividad en 7 días)
+//   - 'idle' / 'unknown': ic-ghost-clean + acento --text-dim (info neutra)
+//
+// Iconografía y paleta tomadas de .pipeline/assets/mockups/narrativa-ghost-artifacts.md
+// (sección "Reglas de iconografia" + "Reglas de paleta"). Prohibido inventar
+// colores o usar emojis del SO: el sprite ya tiene los símbolos diseñados
+// (ic-ghost-clean, ic-ghost-cleanup, ic-archive-box) y design-tokens.css define
+// la familia semántica completa.
+function renderGhostArtifactsWidget(ghost) {
+  if (!ghost || ghost.enabled === false) {
+    return '<details class="collapse-section"><summary>' + ic('ghost-clean', 'Ghost artifacts') + ' Ghost artifacts<span>off</span></summary>'
+      + '<div class="collapse-body" style="padding:8px 12px"><div class="dim">Audit log no inicializado todavía. El cleaner crea <code>.pipeline/audit/ghost-artifacts-cleanup.jsonl</code> en su primer ciclo.</div></div></details>';
+  }
+  const status = ghost.status || 'idle';
+  let banner;
+  if (status === 'recent-cleanup') {
+    banner = `<div class="ga-banner ga-warn">${ic('ghost-cleanup', 'cleanup reciente')}<span>Ghost artifacts: ${ghost.cleanupCount24h} cleanup(s) en las últimas 24h. Revisá el audit log si es inesperado.</span></div>`;
+  } else if (status === 'clean') {
+    banner = `<div class="ga-banner ga-ok">${ic('ghost-clean', 'clean')}<span>Ghost artifacts: clean (sin actividad en últimos 7 días).</span></div>`;
+  } else {
+    banner = `<div class="ga-banner ga-idle">${ic('ghost-clean', 'idle')}<span>Ghost artifacts: idle. Última corrida ${ghost.lastRunIso ? escapeHtml(ghost.lastRunIso) : '—'}.</span></div>`;
+  }
+  const rows = (ghost.recent || []).map(e => {
+    const action = escapeHtml(e.action || '?');
+    const file = escapeHtml(e.file || '');
+    const reason = escapeHtml(e.reason || '');
+    const archivedTo = escapeHtml(e.archived_to || '');
+    const ts = escapeHtml(e.timestamp || '');
+    const context = escapeHtml(e.context || '');
+    const error = escapeHtml(e.error || '');
+    // ic-archive-box como icono auxiliar junto al destino archivado/ghost-*
+    // (convención de la narrativa: caja cerrada = destino del archivo movido).
+    const archivedCell = archivedTo
+      ? `<br><span class="dim ga-archived-to">${ic('archive-box', 'archivado a')} → ${archivedTo}</span>`
+      : '';
+    return `<tr>
+      <td>${ts}</td>
+      <td><span class="ga-action ga-action-${action}">${action}</span></td>
+      <td>${file}${archivedCell}</td>
+      <td>${reason}${error ? `<br><span class="dim">err: ${error}</span>` : ''}${context ? `<br><span class="dim">ctx: ${context}</span>` : ''}</td>
+    </tr>`;
+  }).join('');
+  const auditPath = '.pipeline/audit/ghost-artifacts-cleanup.jsonl';
+  return `<details class="collapse-section"><summary>${ic('ghost-clean', 'Ghost artifacts')} Ghost artifacts<span>${escapeHtml(status)}</span></summary>
+    <div class="collapse-body" style="padding:8px 12px">
+      <style>
+        /* Paleta reusa tokens semánticos de design-tokens.css §3.
+           Prohibido inventar colores; los fallbacks RGB son sólo defensivos. */
+        .ga-banner { padding:8px 12px; border-radius:4px; margin-bottom:8px; font-size:0.9em; display:flex; align-items:center; gap:8px; }
+        .ga-banner > .pl-ic { flex:none; width:16px; height:16px; }
+        .ga-banner.ga-warn { background:var(--warning-bg, rgba(210,153,34,0.18)); border-left:3px solid var(--warning, #D29922); }
+        .ga-banner.ga-warn > .pl-ic { color:var(--warning, #D29922); }
+        .ga-banner.ga-ok   { background:var(--success-bg, rgba(63,185,80,0.15)); border-left:3px solid var(--success, #3FB950); }
+        .ga-banner.ga-ok > .pl-ic { color:var(--success, #3FB950); }
+        .ga-banner.ga-idle { background:var(--deterministic-bg, rgba(110,118,129,0.15)); border-left:3px solid var(--text-dim, #8B949E); }
+        .ga-banner.ga-idle > .pl-ic { color:var(--text-dim, #8B949E); }
+        .ga-audit-table { width:100%; border-collapse:collapse; font-size:0.85em; }
+        .ga-audit-table th, .ga-audit-table td { padding:4px 8px; border-bottom:1px solid var(--border-subtle, rgba(110,118,129,0.2)); text-align:left; vertical-align:top; }
+        /* Chips de action: tokens semánticos por estado.
+           cleanup=success / no-op=neutro / skip=info / error=danger
+           (ver tabla "Chips de action" en narrativa-ghost-artifacts.md). */
+        .ga-action { padding:1px 6px; border-radius:3px; font-size:0.8em; border:1px solid transparent; }
+        .ga-action.ga-action-cleanup { background:var(--success-bg, rgba(63,185,80,0.14)); color:var(--success, #3FB950); border-color:var(--success-dim, #196C2E); }
+        .ga-action.ga-action-no-op   { background:var(--deterministic-bg, rgba(177,186,196,0.10)); color:var(--text-secondary, #B1BAC4); border-color:var(--border-strong, #484F58); }
+        .ga-action.ga-action-skip    { background:var(--info-bg, rgba(88,166,255,0.14)); color:var(--info, #58A6FF); border-color:var(--info-dim, #1F6FEB); }
+        .ga-action.ga-action-error   { background:var(--danger-bg, rgba(248,81,73,0.14)); color:var(--danger, #F85149); border-color:var(--danger-dim, #8B1A14); }
+        .ga-archived-to .pl-ic { width:12px; height:12px; color:var(--text-dim, #8B949E); margin-right:2px; }
+      </style>
+      ${banner}
+      <div style="margin-bottom:8px"><small class="dim">Audit log: <code>${escapeHtml(auditPath)}</code></small></div>
+      ${rows ? `<table class="ga-audit-table"><thead><tr><th>timestamp</th><th>action</th><th>file</th><th>reason / context</th></tr></thead><tbody>${rows}</tbody></table>` : '<div class="dim">Sin entradas en el audit log.</div>'}
+    </div>
+  </details>`;
 }
 
 // --- HTML generation ---
@@ -5372,6 +5500,8 @@ body.standalone .section-collapsed .section-body{display:block !important}
        centerpiece debajo del header de infra para el rediseño V3. -->
 
   ${historyHTML}
+
+  ${renderGhostArtifactsWidget(state.ghostArtifacts)}
 
   ${renderRecommendationsSection()}
 

--- a/.pipeline/lib/__tests__/ghost-artifact-cleaner.test.js
+++ b/.pipeline/lib/__tests__/ghost-artifact-cleaner.test.js
@@ -1,0 +1,313 @@
+'use strict';
+
+// Tests: `lib/ghost-artifact-cleaner` (#3638 CA-F-2..F-8, SEC-1..7, OPS-1..4).
+//
+// Estrategia: cada test arma un tmpdir con una estructura mínima de
+// `.pipeline/` + `.gitignore` + `archivado/` + `audit/` y corre `runOnce`
+// inyectando un `issueStateFn` falso (sin llamar a `gh`).
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const cleaner = require('../ghost-artifact-cleaner');
+const { _internal } = cleaner;
+
+// ─── Helpers de fixture ─────────────────────────────────────────────────────
+
+function makeTmpRepo() {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ghost-test-'));
+    const pipelineRoot = path.join(root, '.pipeline');
+    fs.mkdirSync(pipelineRoot, { recursive: true });
+    // .gitignore tiene que listar los paths protegidos.
+    fs.writeFileSync(
+        path.join(root, '.gitignore'),
+        '.pipeline/archivado/\n.pipeline/audit/\n',
+        'utf8',
+    );
+    return { root, pipelineRoot };
+}
+
+function placeFile(pipelineRoot, relPath, content = 'placeholder') {
+    const full = path.join(pipelineRoot, relPath);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, content, 'utf8');
+    return full;
+}
+
+function silentLogger() {
+    return { info() {}, warn() {}, error() {} };
+}
+
+function readAuditLines(pipelineRoot) {
+    const file = path.join(pipelineRoot, 'audit', 'ghost-artifacts-cleanup.jsonl');
+    try {
+        return fs.readFileSync(file, 'utf8').split('\n').filter(Boolean).map(JSON.parse);
+    } catch { return []; }
+}
+
+// ─── Tests internos puros ───────────────────────────────────────────────────
+
+test('safeIssueFromFilename: acepta markers y artifacts válidos', () => {
+    assert.equal(_internal.safeIssueFromFilename('1732.po.comment.md'), '1732');
+    assert.equal(_internal.safeIssueFromFilename('3638.pipeline-dev.guidance.txt'), '3638');
+    assert.equal(_internal.safeIssueFromFilename('2441.qa.reason.json'), '2441');
+    assert.equal(_internal.safeIssueFromFilename('5000.po'), '5000');
+});
+
+test('safeIssueFromFilename: rechaza filenames maliciosos (anti-injection)', () => {
+    // Punto y coma, espacios, pipes, $(), backticks → null.
+    assert.equal(_internal.safeIssueFromFilename('1732; rm -rf /.po.comment.md'), null);
+    assert.equal(_internal.safeIssueFromFilename('$(curl evil).po.comment.md'), null);
+    assert.equal(_internal.safeIssueFromFilename('1732.PO.comment.md'), null); // mayúsculas no permitidas
+    assert.equal(_internal.safeIssueFromFilename('abc.po.comment.md'), null); // no-numeric issue
+});
+
+test('isCandidateFilename: solo .comment.md / .guidance.txt / .reason.json', () => {
+    assert.equal(_internal.isCandidateFilename('1732.po.comment.md'), true);
+    assert.equal(_internal.isCandidateFilename('1732.po.guidance.txt'), true);
+    assert.equal(_internal.isCandidateFilename('1732.qa.reason.json'), true);
+    assert.equal(_internal.isCandidateFilename('1732.po'), false); // marker válido
+    assert.equal(_internal.isCandidateFilename('foo.bar.baz'), false); // > 2 segmentos pero sin sufijo conocido
+});
+
+test('hasActiveSibling: detecta .work, .build y marker activo', () => {
+    const { pipelineRoot } = makeTmpRepo();
+    const dir = path.join(pipelineRoot, 'definicion', 'criterios', 'pendiente');
+    fs.mkdirSync(dir, { recursive: true });
+    assert.equal(_internal.hasActiveSibling(dir, 1732), false);
+    placeFile(pipelineRoot, 'definicion/criterios/pendiente/1732.po.work', 'x');
+    assert.equal(_internal.hasActiveSibling(dir, 1732), true);
+    fs.unlinkSync(path.join(dir, '1732.po.work'));
+    placeFile(pipelineRoot, 'definicion/criterios/pendiente/1732.po', 'x');
+    assert.equal(_internal.hasActiveSibling(dir, 1732), true);
+});
+
+test('verifyGitignore: aborta si faltan paths protegidos (CA-SEC-6)', () => {
+    const { root } = makeTmpRepo();
+    fs.writeFileSync(path.join(root, '.gitignore'), '# vacío\n', 'utf8');
+    const check = _internal.verifyGitignore(root, silentLogger());
+    assert.equal(check.ok, false);
+    assert.match(check.reason, /gitignore-missing-paths/);
+});
+
+test('verifyGitignore: OK cuando los paths están listados', () => {
+    const { root } = makeTmpRepo();
+    const check = _internal.verifyGitignore(root, silentLogger());
+    assert.equal(check.ok, true);
+});
+
+test('alreadyArchived: encuentra archivo previo en cualquier bucket ghost-*', () => {
+    const { pipelineRoot } = makeTmpRepo();
+    const archivado = path.join(pipelineRoot, 'archivado');
+    const bucket = path.join(archivado, 'ghost-20260101-000000');
+    placeFile(pipelineRoot, 'archivado/ghost-20260101-000000/definicion/criterios/pendiente/3076.po.comment.md', 'old');
+    const found = _internal.alreadyArchived(archivado, 'definicion/criterios/pendiente/3076.po.comment.md');
+    assert.ok(found && found.includes('3076.po.comment.md'), 'debe encontrar el archivo previo');
+});
+
+// ─── Tests de runOnce (integración interna) ─────────────────────────────────
+
+test('runOnce dry-run: lista candidatos, NO toca disco (Gherkin escenario 3)', async () => {
+    const { root, pipelineRoot } = makeTmpRepo();
+    placeFile(pipelineRoot, 'definicion/criterios/pendiente/9999.po.comment.md', 'x');
+    const result = await cleaner.runOnce({
+        mode: 'dry-run',
+        repoRoot: root,
+        pipelineRoot,
+        logger: silentLogger(),
+        issueStateFn: () => ({ ok: true, state: 'CLOSED' }),
+    });
+    assert.equal(result.candidates, 1);
+    assert.equal(result.archived, 0);
+    // Original sigue ahí.
+    assert.ok(fs.existsSync(path.join(pipelineRoot, 'definicion/criterios/pendiente/9999.po.comment.md')));
+    // Audit log NO se escribió (dry-run no audita movimientos).
+    assert.equal(readAuditLines(pipelineRoot).length, 0);
+});
+
+test('runOnce execute: archiva candidato huérfano con issue CLOSED (Gherkin escenario 1)', async () => {
+    const { root, pipelineRoot } = makeTmpRepo();
+    placeFile(pipelineRoot, 'definicion/criterios/pendiente/9999.po.comment.md', 'x');
+    const result = await cleaner.runOnce({
+        mode: 'execute',
+        repoRoot: root,
+        pipelineRoot,
+        logger: silentLogger(),
+        issueStateFn: () => ({ ok: true, state: 'CLOSED' }),
+    });
+    assert.equal(result.archived, 1);
+    assert.equal(fs.existsSync(path.join(pipelineRoot, 'definicion/criterios/pendiente/9999.po.comment.md')), false);
+    // Verificar que se movió a archivado/ghost-*/
+    const buckets = fs.readdirSync(path.join(pipelineRoot, 'archivado'));
+    assert.ok(buckets.some(b => b.startsWith('ghost-')));
+    // Audit log: 1 entrada cleanup.
+    const audit = readAuditLines(pipelineRoot);
+    assert.equal(audit.length, 1);
+    assert.equal(audit[0].action, 'cleanup');
+    assert.match(audit[0].reason, /orphaned/);
+});
+
+test('runOnce: idempotencia — archivo ya archivado → no-op (Gherkin escenario 2)', async () => {
+    const { root, pipelineRoot } = makeTmpRepo();
+    // Archivado previo del mismo path.
+    placeFile(pipelineRoot, 'archivado/ghost-20260101-000000/definicion/criterios/pendiente/3076.po.comment.md', 'old');
+    // Y el archivo "ahora" duplicado en pendiente/ (simula re-aparición patológica).
+    placeFile(pipelineRoot, 'definicion/criterios/pendiente/3076.po.comment.md', 'new');
+    const result = await cleaner.runOnce({
+        mode: 'execute',
+        repoRoot: root,
+        pipelineRoot,
+        logger: silentLogger(),
+        issueStateFn: () => ({ ok: true, state: 'CLOSED' }),
+    });
+    assert.equal(result.archived, 0);
+    assert.equal(result.skipped, 1);
+    // No se creó nueva carpeta ghost-* además de la histórica.
+    const buckets = fs.readdirSync(path.join(pipelineRoot, 'archivado'));
+    assert.equal(buckets.length, 1);
+    // Audit log: 1 entrada con action=no-op.
+    const audit = readAuditLines(pipelineRoot);
+    assert.equal(audit[0].action, 'no-op');
+    assert.match(audit[0].reason, /already archived/);
+});
+
+test('runOnce: skipea si sibling activo en carpeta padre', async () => {
+    const { root, pipelineRoot } = makeTmpRepo();
+    placeFile(pipelineRoot, 'definicion/criterios/pendiente/5000.po.comment.md', 'x');
+    placeFile(pipelineRoot, 'definicion/criterios/pendiente/5000.po.work', 'active');
+    const result = await cleaner.runOnce({
+        mode: 'execute',
+        repoRoot: root,
+        pipelineRoot,
+        logger: silentLogger(),
+        issueStateFn: () => ({ ok: true, state: 'CLOSED' }),
+    });
+    assert.equal(result.archived, 0);
+    assert.equal(result.skipped, 1);
+});
+
+test('runOnce: fail-safe gh down → skip + log (Gherkin escenario 7)', async () => {
+    const { root, pipelineRoot } = makeTmpRepo();
+    placeFile(pipelineRoot, 'definicion/criterios/pendiente/8888.po.comment.md', 'x');
+    const result = await cleaner.runOnce({
+        mode: 'execute',
+        repoRoot: root,
+        pipelineRoot,
+        logger: silentLogger(),
+        issueStateFn: () => ({ ok: false, reason: 'gh-timeout' }),
+    });
+    assert.equal(result.archived, 0);
+    assert.equal(result.skipped, 1);
+    const audit = readAuditLines(pipelineRoot);
+    assert.equal(audit[0].action, 'skip');
+    assert.match(audit[0].reason, /gh unavailable/);
+});
+
+test('runOnce: aborta si .gitignore no protege archivado/audit (CA-SEC-6, Gherkin escenario 6)', async () => {
+    const { root, pipelineRoot } = makeTmpRepo();
+    fs.writeFileSync(path.join(root, '.gitignore'), '# vacío\n', 'utf8');
+    placeFile(pipelineRoot, 'definicion/criterios/pendiente/7777.po.comment.md', 'x');
+    const result = await cleaner.runOnce({
+        mode: 'execute',
+        repoRoot: root,
+        pipelineRoot,
+        logger: silentLogger(),
+        issueStateFn: () => ({ ok: true, state: 'CLOSED' }),
+    });
+    assert.equal(result.aborted, true);
+    assert.equal(result.errors, 1);
+    // Archivo intacto.
+    assert.ok(fs.existsSync(path.join(pipelineRoot, 'definicion/criterios/pendiente/7777.po.comment.md')));
+});
+
+test('runOnce: issue OPEN → NO archiva (preserva trabajo en curso)', async () => {
+    const { root, pipelineRoot } = makeTmpRepo();
+    placeFile(pipelineRoot, 'definicion/criterios/pendiente/4444.po.comment.md', 'x');
+    const result = await cleaner.runOnce({
+        mode: 'execute',
+        repoRoot: root,
+        pipelineRoot,
+        logger: silentLogger(),
+        issueStateFn: () => ({ ok: true, state: 'OPEN' }),
+    });
+    assert.equal(result.archived, 0);
+    assert.equal(result.skipped, 1);
+    assert.ok(fs.existsSync(path.join(pipelineRoot, 'definicion/criterios/pendiente/4444.po.comment.md')));
+});
+
+test('runOnce: ignora markers válidos (.po, .pipeline-dev, etc.)', async () => {
+    const { root, pipelineRoot } = makeTmpRepo();
+    placeFile(pipelineRoot, 'desarrollo/dev/trabajando/3638.pipeline-dev', 'active');
+    const result = await cleaner.runOnce({
+        mode: 'execute',
+        repoRoot: root,
+        pipelineRoot,
+        logger: silentLogger(),
+        issueStateFn: () => ({ ok: true, state: 'CLOSED' }),
+    });
+    // 1 archivo scanned, 0 candidates (no es .comment.md ni similar).
+    assert.equal(result.candidates, 0);
+    assert.equal(result.archived, 0);
+    assert.ok(fs.existsSync(path.join(pipelineRoot, 'desarrollo/dev/trabajando/3638.pipeline-dev')));
+});
+
+test('runOnce: ignora .gitkeep y archivos ocultos por convención', async () => {
+    const { root, pipelineRoot } = makeTmpRepo();
+    placeFile(pipelineRoot, 'definicion/criterios/pendiente/.gitkeep', '');
+    const result = await cleaner.runOnce({
+        mode: 'execute',
+        repoRoot: root,
+        pipelineRoot,
+        logger: silentLogger(),
+        issueStateFn: () => ({ ok: true, state: 'CLOSED' }),
+    });
+    assert.equal(result.candidates, 0);
+    assert.equal(result.archived, 0);
+});
+
+test('runOnce: audit JSONL siempre usa JSON.stringify (CA-SEC-5)', async () => {
+    const { root, pipelineRoot } = makeTmpRepo();
+    placeFile(pipelineRoot, 'definicion/criterios/pendiente/6666.po.comment.md', 'x');
+    await cleaner.runOnce({
+        mode: 'execute',
+        repoRoot: root,
+        pipelineRoot,
+        logger: silentLogger(),
+        issueStateFn: () => ({ ok: true, state: 'CLOSED' }),
+    });
+    const raw = fs.readFileSync(path.join(pipelineRoot, 'audit', 'ghost-artifacts-cleanup.jsonl'), 'utf8');
+    const lines = raw.split('\n').filter(Boolean);
+    for (const line of lines) {
+        // No debe tirar parse error y debe ser un objeto.
+        const obj = JSON.parse(line);
+        assert.equal(typeof obj, 'object');
+        assert.ok(obj.timestamp);
+        assert.ok(obj.action);
+    }
+});
+
+test('walk: maxDepth limita recursión y devuelve symlinks como entry separado', () => {
+    const { pipelineRoot } = makeTmpRepo();
+    placeFile(pipelineRoot, 'definicion/criterios/pendiente/1234.po.comment.md', 'x');
+    const out = _internal.walk(path.join(pipelineRoot, 'definicion'), { maxDepth: 5 });
+    assert.ok(out.some(e => e.kind === 'file' && e.name === '1234.po.comment.md'));
+});
+
+test('runOnce: respeta walk timeout sin colgar el pulpo', async () => {
+    // Simulación: si el walk excede deadline, runOnce marca walkTimedOut y
+    // no archiva nada. Validamos que retorna sin colgarse.
+    const { root, pipelineRoot } = makeTmpRepo();
+    // No-op: el deadline interno es 60s y este test corre en ms.
+    const result = await cleaner.runOnce({
+        mode: 'dry-run',
+        repoRoot: root,
+        pipelineRoot,
+        logger: silentLogger(),
+        issueStateFn: () => ({ ok: true, state: 'CLOSED' }),
+    });
+    assert.equal(result.aborted, false);
+    assert.ok(result.durationMs < 60_000);
+});

--- a/.pipeline/lib/__tests__/ghost-artifact-lint.test.js
+++ b/.pipeline/lib/__tests__/ghost-artifact-lint.test.js
@@ -1,0 +1,150 @@
+'use strict';
+
+// Tests: `lib/ghost-artifact-lint` (#3638 CA-F-9..F-11).
+//
+// Estrategia: armamos tmpdir con archivos sintéticos que reflejen patrones
+// reales (readdir sobre carpetas operacionales, con y sin filtro) y
+// verificamos que el linter los detecte correctamente.
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const lint = require('../ghost-artifact-lint');
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function makeTmpPipeline() {
+    // El linter espera estructura `<pipelineRoot>/lib/foo.js`. Creamos un
+    // mini pipelineRoot sintético.
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ghost-lint-'));
+    fs.mkdirSync(path.join(root, 'lib'), { recursive: true });
+    return root;
+}
+
+function placeJs(root, relPath, source) {
+    const full = path.join(root, relPath);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, source, 'utf8');
+    return full;
+}
+
+function emptyAllowlist() {
+    return { files: new Set(), rules: [] };
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+test('detecta readdir sobre definicion/ sin isMarkerArtifact (Gherkin escenario 4)', () => {
+    const root = makeTmpPipeline();
+    placeJs(root, 'lib/bad.js', `
+        const fs = require('fs');
+        const dir = '.pipeline/definicion/criterios/pendiente';
+        const files = fs.readdirSync(dir);
+        for (const f of files) console.log(f);
+    `);
+    const { violations } = lint.lint({ pipelineRoot: root, allowlist: emptyAllowlist() });
+    assert.equal(violations.length, 1);
+    assert.equal(violations[0].file, 'lib/bad.js');
+});
+
+test('NO emite violation cuando isMarkerArtifact se aplica cerca', () => {
+    const root = makeTmpPipeline();
+    placeJs(root, 'lib/good.js', `
+        const fs = require('fs');
+        const { isMarkerArtifact } = require('./marker-artifact');
+        const dir = '.pipeline/definicion/criterios/pendiente';
+        const files = fs.readdirSync(dir).filter(f => !isMarkerArtifact(f));
+        for (const f of files) console.log(f);
+    `);
+    const { violations } = lint.lint({ pipelineRoot: root, allowlist: emptyAllowlist() });
+    assert.equal(violations.length, 0);
+});
+
+test('acepta variantes de nombre (isMarkerArtifactPulpo) como filtro válido', () => {
+    const root = makeTmpPipeline();
+    placeJs(root, 'lib/pulpo-like.js', `
+        const fs = require('fs');
+        function isMarkerArtifactPulpo(n) { return false; }
+        const dir = '.pipeline/desarrollo/dev/trabajando';
+        const files = fs.readdirSync(dir).filter(f => !isMarkerArtifactPulpo(f));
+    `);
+    const { violations } = lint.lint({ pipelineRoot: root, allowlist: emptyAllowlist() });
+    assert.equal(violations.length, 0);
+});
+
+test('NO emite violation para readdir sobre paths no-operacionales', () => {
+    const root = makeTmpPipeline();
+    placeJs(root, 'lib/config-reader.js', `
+        const fs = require('fs');
+        const files = fs.readdirSync('./node_modules');
+        const more = fs.readdirSync('/tmp');
+    `);
+    const { violations } = lint.lint({ pipelineRoot: root, allowlist: emptyAllowlist() });
+    assert.equal(violations.length, 0);
+});
+
+test('allowlist file entera: skipea todas las violations del archivo', () => {
+    const root = makeTmpPipeline();
+    placeJs(root, 'lib/bad-but-allowed.js', `
+        const fs = require('fs');
+        fs.readdirSync('.pipeline/definicion/criterios/pendiente');
+    `);
+    const allowlist = { files: new Set(['lib/bad-but-allowed.js']), rules: [] };
+    const { violations } = lint.lint({ pipelineRoot: root, allowlist });
+    assert.equal(violations.length, 0);
+});
+
+test('allowlist regla puntual: skipea violation en (file, line) específico', () => {
+    const root = makeTmpPipeline();
+    placeJs(root, 'lib/bad.js', `
+        const fs = require('fs');
+        const files = fs.readdirSync('.pipeline/definicion/criterios/pendiente');
+    `);
+    // Detectar primero la línea real.
+    const baseline = lint.lint({ pipelineRoot: root, allowlist: emptyAllowlist() });
+    assert.equal(baseline.violations.length, 1);
+    const ruled = { files: new Set(), rules: [{ file: 'lib/bad.js', line: baseline.violations[0].line, reason: 'test' }] };
+    const { violations } = lint.lint({ pipelineRoot: root, allowlist: ruled });
+    assert.equal(violations.length, 0);
+});
+
+test('self-exempt: ghost-artifact-cleaner.js no se autoaudita', () => {
+    const root = makeTmpPipeline();
+    // Simular cleaner que sí lee carpetas operacionales con readdir.
+    placeJs(root, 'lib/ghost-artifact-cleaner.js', `
+        const fs = require('fs');
+        fs.readdirSync('.pipeline/definicion/criterios/pendiente');
+    `);
+    const { violations } = lint.lint({ pipelineRoot: root, allowlist: emptyAllowlist() });
+    // El cleaner está exento por construcción.
+    assert.equal(violations.length, 0);
+});
+
+test('skipea directorios excluidos (node_modules, __tests__, archivado)', () => {
+    const root = makeTmpPipeline();
+    placeJs(root, 'lib/__tests__/foo.test.js', `
+        const fs = require('fs');
+        fs.readdirSync('.pipeline/definicion/criterios/pendiente');
+    `);
+    placeJs(root, 'node_modules/bad/index.js', `
+        const fs = require('fs');
+        fs.readdirSync('.pipeline/desarrollo/dev/pendiente');
+    `);
+    const { violations } = lint.lint({ pipelineRoot: root, allowlist: emptyAllowlist() });
+    assert.equal(violations.length, 0);
+});
+
+test('lint del repo real: 0 violations (smoke test post-#3638)', () => {
+    // Smoke: corremos el linter contra el repo real para garantizar que
+    // post-merge el pipeline queda en estado "limpio".
+    const { violations, scanned } = lint.lint();
+    assert.ok(scanned > 0, 'debe escanear archivos del repo');
+    if (violations.length > 0) {
+        // Si esto falla, alguien introdujo un readdir sin filtro durante el dev del propio #3638.
+        const msg = violations.map(v => `${v.file}:${v.line} ${v.snippet}`).join('\n');
+        assert.fail(`smoke test post-#3638: ${violations.length} violations en repo real:\n${msg}`);
+    }
+});

--- a/.pipeline/lib/__tests__/marker-artifact.test.js
+++ b/.pipeline/lib/__tests__/marker-artifact.test.js
@@ -1,0 +1,82 @@
+'use strict';
+
+// Tests: `lib/marker-artifact.isMarkerArtifact` — single source of truth del
+// invariant runtime del pipeline V2 (#3638 CA-F-1).
+//
+// Equivalencia funcional con las 6 duplicaciones previas:
+//   pulpo.js:868, dashboard.js:78, lib/dashboard-slices.js:44,
+//   lib/human-block.js:103, lib/wave-state.js:87 (y eta-markers via import).
+//
+// La lógica histórica era: `name.split('.').length > 2 OR endsWith(
+//   '.reason.json' | '.guidance.txt' | '.comment.md')`.
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { isMarkerArtifact } = require('../marker-artifact');
+
+test('marker válido <issue>.<skill> NO es artifact', () => {
+    assert.equal(isMarkerArtifact('1732.po'), false);
+    assert.equal(isMarkerArtifact('3638.pipeline-dev'), false);
+    assert.equal(isMarkerArtifact('2441.guru'), false);
+    assert.equal(isMarkerArtifact('5000.backend-dev'), false);
+});
+
+test('sufijo .comment.md es artifact', () => {
+    assert.equal(isMarkerArtifact('1732.po.comment.md'), true);
+    assert.equal(isMarkerArtifact('3076.po.comment.md'), true);
+});
+
+test('sufijo .guidance.txt es artifact', () => {
+    assert.equal(isMarkerArtifact('1732.po.guidance.txt'), true);
+    assert.equal(isMarkerArtifact('3073.pipeline-dev.guidance.txt'), true);
+});
+
+test('sufijo .reason.json es artifact', () => {
+    assert.equal(isMarkerArtifact('1732.qa.reason.json'), true);
+    assert.equal(isMarkerArtifact('3638.review.reason.json'), true);
+});
+
+test('cualquier nombre con > 2 segmentos es artifact', () => {
+    assert.equal(isMarkerArtifact('a.b.c'), true);
+    assert.equal(isMarkerArtifact('1.2.3.4'), true);
+    assert.equal(isMarkerArtifact('1732.po.work.tmp'), true);
+});
+
+test('.gitkeep NO es artifact', () => {
+    assert.equal(isMarkerArtifact('.gitkeep'), false);
+});
+
+test('tolera entrada no-string sin crashear', () => {
+    assert.equal(isMarkerArtifact(null), false);
+    assert.equal(isMarkerArtifact(undefined), false);
+    assert.equal(isMarkerArtifact(123), false);
+});
+
+test('equivalencia funcional con la lógica histórica de las 6 duplicaciones', () => {
+    const legacy = (name) => {
+        if (name.split('.').length > 2) return true;
+        return name.endsWith('.reason.json')
+            || name.endsWith('.guidance.txt')
+            || name.endsWith('.comment.md');
+    };
+    const samples = [
+        '1732.po', '3638.pipeline-dev', '2441.guru',
+        '1732.po.comment.md', '1732.po.guidance.txt', '1732.po.reason.json',
+        '5000.qa.reason.json', '8888.review',
+        '.gitkeep', 'a.b.c', '1.2.3.4', '1732.po.work.tmp',
+    ];
+    for (const s of samples) {
+        assert.equal(
+            isMarkerArtifact(s),
+            legacy(s),
+            `desvío de comportamiento legacy en "${s}"`,
+        );
+    }
+});
+
+test('re-export desde human-block sigue funcionando (compat #2854)', () => {
+    const hb = require('../human-block');
+    assert.equal(typeof hb.isMarkerArtifact, 'function');
+    assert.equal(hb.isMarkerArtifact('1732.po.comment.md'), true);
+    assert.equal(hb.isMarkerArtifact('1732.po'), false);
+});

--- a/.pipeline/lib/dashboard-slices.js
+++ b/.pipeline/lib/dashboard-slices.js
@@ -38,14 +38,9 @@ try { partialPause = require('./partial-pause'); } catch { /* opcional */ }
 // y cualquier filename con > 2 segmentos). Compartido con human-block para
 // que ambos listadores excluyan los mismos fantasmas. Fallback defensivo si
 // el módulo no carga.
-let isMarkerArtifact;
-try { ({ isMarkerArtifact } = require('./human-block')); } catch { /* opcional */ }
-if (typeof isMarkerArtifact !== 'function') {
-    isMarkerArtifact = (name) => name.split('.').length > 2
-        || name.endsWith('.reason.json')
-        || name.endsWith('.guidance.txt')
-        || name.endsWith('.comment.md');
-}
+// Artifacts auxiliares: detección centralizada en `lib/marker-artifact.js`
+// (#3638 CA-F-1).
+const { isMarkerArtifact } = require('./marker-artifact');
 
 function isDeterministicSkill(skill) {
     return DETERMINISTIC_SKILLS.has(String(skill || '').trim().toLowerCase());

--- a/.pipeline/lib/eta-markers.js
+++ b/.pipeline/lib/eta-markers.js
@@ -40,7 +40,8 @@
 
 const fs = require('fs');
 const path = require('path');
-const { isMarkerArtifact } = require('./human-block');
+// #3638 CA-F-1: import desde fuente canónica `lib/marker-artifact.js`.
+const { isMarkerArtifact } = require('./marker-artifact');
 
 // ─── Constantes públicas ───────────────────────────────────────────────────
 

--- a/.pipeline/lib/ghost-artifact-cleaner.js
+++ b/.pipeline/lib/ghost-artifact-cleaner.js
@@ -1,0 +1,522 @@
+#!/usr/bin/env node
+'use strict';
+
+// =============================================================================
+// ghost-artifact-cleaner.js — Garbage collector de artifacts huérfanos en
+// carpetas operacionales del pipeline V2 (#3638).
+//
+// Diseño
+// ------
+// Barre `.pipeline/definicion/**` y `.pipeline/desarrollo/**` buscando
+// archivos `.md`/`.txt`/`.json` que sean artifacts auxiliares según
+// `lib/marker-artifact.isMarkerArtifact` (sufijos `.comment.md`,
+// `.guidance.txt`, `.reason.json`) cuyo issue asociado:
+//
+//   (a) está CERRADO en GitHub,
+//   (b) NO tiene `.work`/`.build`/`<issue>.<skill>` (marker activo) en la
+//       carpeta padre.
+//
+// Si ambos se cumplen → archiva el archivo (mueve, NO elimina) a
+// `.pipeline/archivado/ghost-<timestamp>/<path relativo>` y registra una
+// línea JSONL en `.pipeline/audit/ghost-artifacts-cleanup.jsonl`.
+//
+// Modos:
+//   --dry-run   (default fail-safe): lista candidatos, no toca disco.
+//   --execute  : archiva candidatos confirmados.
+//
+// Reglas de seguridad (CA-SEC-1..7):
+//   - path.resolve src debe quedar bajo `.pipeline/definicion/` o
+//     `.pipeline/desarrollo/`. path.resolve dst debe quedar bajo
+//     `.pipeline/archivado/`. Rechazo explícito fuera de scope.
+//   - `fs.lstatSync` rechaza symlinks (anti-attack).
+//   - Filename matchea regex estricta antes de invocar `gh`.
+//   - `gh` se invoca con `spawnSync` array-form, jamás `exec` con string.
+//   - JSONL escrito con `JSON.stringify(obj) + '\n'`.
+//   - `.gitignore` verificado al inicio: aborta si `archivado/` o `audit/`
+//     no están ignored.
+//   - Walk con maxDepth 5 y timeout total 60s.
+//
+// Reglas operativas (CA-OPS-1..4):
+//   - Lock cooperativo vía `lib/file-lock.withLock` sobre
+//     `.pipeline/locks/ghost-cleaner.lock`. Timeout 5s; si no lo agarra,
+//     registra skip y reintenta en próximo tick.
+//   - Fail-safe `gh` down: si `gh issue view` falla o supera 10s, NO archiva.
+//   - Idempotencia: si el archivo ya existe en `archivado/ghost-*/<mismo
+//     path relativo>`, registra `no-op` y skip.
+//   - Logging con prefijo `[ghost-artifact]` en `console.log/error`.
+//
+// API:
+//   await runOnce({ mode, pipelineRoot, repoRoot, now, ghTimeoutMs, logger })
+//     → { scanned, candidates, archived, skipped, errors, durationMs }
+//
+//   CLI:
+//     node .pipeline/lib/ghost-artifact-cleaner.js [--execute|--dry-run]
+// =============================================================================
+
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+const { withLock } = require('./file-lock');
+const { isMarkerArtifact } = require('./marker-artifact');
+
+// ─── Constantes ─────────────────────────────────────────────────────────────
+
+const PIPELINES = ['definicion', 'desarrollo'];
+const ACTIVE_STATES = ['pendiente', 'trabajando', 'listo', 'bloqueado-humano', 'bloqueado-dependencias'];
+const MAX_WALK_DEPTH = 5;
+const WALK_TIMEOUT_MS = 60 * 1000;
+const GH_TIMEOUT_MS_DEFAULT = 10 * 1000;
+const LOCK_TIMEOUT_MS = 5 * 1000;
+const LOG_PREFIX = '[ghost-artifact]';
+
+// Regex estricta para extraer issue de filename: <digits>.<skill>[.suffix]
+// `skill` permite letras, dígitos y guiones. `suffix` es uno de los conocidos.
+// Esto previene command injection en `gh issue view`.
+const FILENAME_REGEX = /^(\d+)\.[a-z][a-z0-9-]*(?:\.(?:comment\.md|guidance\.txt|reason\.json|reason\.resolved(?:-\d+)?\.json))?$/;
+
+// Sólo estos sufijos califican como artifact candidato a limpieza.
+const ARTIFACT_SUFFIXES = ['.comment.md', '.guidance.txt', '.reason.json'];
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function defaultLogger() {
+    return {
+        info: (msg) => console.log(`${LOG_PREFIX} ${msg}`),
+        warn: (msg) => console.warn(`${LOG_PREFIX} ${msg}`),
+        error: (msg) => console.error(`${LOG_PREFIX} ${msg}`),
+    };
+}
+
+function isUnderPrefix(absolutePath, prefix) {
+    const norm = path.resolve(absolutePath) + path.sep;
+    const pre = path.resolve(prefix) + path.sep;
+    return norm.startsWith(pre);
+}
+
+/** Verifica que .pipeline/archivado/ y .pipeline/audit/ estén gitignored. */
+function verifyGitignore(repoRoot, logger) {
+    const giFile = path.join(repoRoot, '.gitignore');
+    let content = '';
+    try { content = fs.readFileSync(giFile, 'utf8'); }
+    catch {
+        logger.error(`.gitignore no encontrado en ${repoRoot}`);
+        return { ok: false, reason: 'gitignore-missing' };
+    }
+    const required = ['.pipeline/archivado/', '.pipeline/audit/'];
+    const missing = required.filter(p => !new RegExp(`(^|\\n)${p.replace(/[.*+?^${}()|[\\]\\\\]/g, '\\$&')}\\s*(\\n|$)`).test(content));
+    if (missing.length > 0) {
+        return { ok: false, reason: `gitignore-missing-paths: ${missing.join(', ')}` };
+    }
+    return { ok: true };
+}
+
+/** Filename matchea regex estricta de issue.skill[.suffix]. */
+function safeIssueFromFilename(filename) {
+    const m = FILENAME_REGEX.exec(filename);
+    if (!m) return null;
+    return m[1];
+}
+
+function isCandidateFilename(name) {
+    // Solo nos interesan archivos que son artifacts auxiliares; los markers
+    // de skill (`<issue>.<skill>`) NO se tocan acá.
+    if (!isMarkerArtifact(name)) return false;
+    return ARTIFACT_SUFFIXES.some(s => name.endsWith(s));
+}
+
+/** ¿Existe marker activo del mismo issue en la carpeta padre? */
+function hasActiveSibling(dir, issue) {
+    const prefix = String(issue) + '.';
+    let entries;
+    try { entries = fs.readdirSync(dir); } catch { return false; }
+    for (const f of entries) {
+        if (!f.startsWith(prefix)) continue;
+        if (f === '.gitkeep') continue;
+        // .work / .build cuentan como actividad
+        if (f.endsWith('.work') || f.endsWith('.build')) return true;
+        // marker de skill (<issue>.<skill>) cuenta como actividad
+        if (!isMarkerArtifact(f)) return true;
+    }
+    return false;
+}
+
+/** Consulta GitHub si el issue está OPEN o CLOSED vía `gh`. Fail-safe. */
+function issueState(issueNumber, opts = {}) {
+    const ghTimeout = opts.ghTimeoutMs || GH_TIMEOUT_MS_DEFAULT;
+    // CA-SEC-4: spawn array-form. issueNumber ya validado por regex.
+    const result = spawnSync('gh', ['issue', 'view', String(issueNumber), '--json', 'state'], {
+        timeout: ghTimeout,
+        encoding: 'utf8',
+        windowsHide: true,
+        shell: false,
+    });
+    if (result.error || result.status !== 0) {
+        return { ok: false, reason: result.error?.code === 'ETIMEDOUT' ? 'gh-timeout' : 'gh-failed' };
+    }
+    try {
+        const json = JSON.parse(result.stdout);
+        return { ok: true, state: json.state };
+    } catch {
+        return { ok: false, reason: 'gh-bad-json' };
+    }
+}
+
+/** Walk recursivo con maxDepth, rechaza symlinks. */
+function walk(rootDir, opts = {}) {
+    const maxDepth = opts.maxDepth || MAX_WALK_DEPTH;
+    const deadline = opts.deadline || (Date.now() + WALK_TIMEOUT_MS);
+    const out = [];
+    function recurse(dir, depth) {
+        if (depth > maxDepth) return;
+        if (Date.now() > deadline) throw new Error('walk-timeout');
+        let entries;
+        try {
+            entries = fs.readdirSync(dir, { withFileTypes: true });
+        } catch {
+            return;
+        }
+        for (const entry of entries) {
+            const full = path.join(dir, entry.name);
+            let lst;
+            try { lst = fs.lstatSync(full); } catch { continue; }
+            // CA-SEC-2: skipear symlinks.
+            if (lst.isSymbolicLink()) {
+                out.push({ kind: 'symlink', path: full, name: entry.name });
+                continue;
+            }
+            if (lst.isDirectory()) {
+                recurse(full, depth + 1);
+            } else if (lst.isFile()) {
+                out.push({ kind: 'file', path: full, name: entry.name });
+            }
+        }
+    }
+    recurse(rootDir, 0);
+    return out;
+}
+
+/** Construye path relativo desde repo root → relPath estilo POSIX. */
+function relFromRoot(repoRoot, absolutePath) {
+    return path.relative(repoRoot, absolutePath).split(path.sep).join('/');
+}
+
+/** Append JSONL al audit log. CA-SEC-5: JSON.stringify exclusivo. */
+function appendAudit(auditFile, entry) {
+    fs.mkdirSync(path.dirname(auditFile), { recursive: true });
+    const line = JSON.stringify(entry) + '\n';
+    fs.appendFileSync(auditFile, line, { encoding: 'utf8' });
+}
+
+// ¿Existe ya el archivo en alguna carpeta `archivado/ghost-<stamp>/<relPath>`?
+function alreadyArchived(archivadoRoot, relFromPipelineRoot) {
+    let buckets;
+    try { buckets = fs.readdirSync(archivadoRoot, { withFileTypes: true }); }
+    catch { return null; }
+    for (const b of buckets) {
+        if (!b.isDirectory()) continue;
+        if (!b.name.startsWith('ghost-')) continue;
+        const candidate = path.join(archivadoRoot, b.name, relFromPipelineRoot);
+        try {
+            const st = fs.lstatSync(candidate);
+            if (st.isFile()) return candidate;
+        } catch { /* sigue */ }
+    }
+    return null;
+}
+
+// ─── Función principal ──────────────────────────────────────────────────────
+
+/**
+ * Ejecuta un ciclo de limpieza.
+ *
+ * @param {object} opts
+ * @param {'dry-run'|'execute'} [opts.mode='dry-run']
+ * @param {string} [opts.pipelineRoot] — default: `<repoRoot>/.pipeline`
+ * @param {string} [opts.repoRoot] — default: cwd
+ * @param {number} [opts.ghTimeoutMs]
+ * @param {function} [opts.issueStateFn] — override para tests (no llamar `gh`)
+ * @param {Date|number} [opts.now]
+ * @param {object} [opts.logger]
+ * @returns {Promise<{scanned, candidates, archived, skipped, errors, durationMs, bucket}>}
+ */
+async function runOnce(opts = {}) {
+    const t0 = Date.now();
+    const mode = opts.mode === 'execute' ? 'execute' : 'dry-run';
+    const logger = opts.logger || defaultLogger();
+    const repoRoot = opts.repoRoot || process.cwd();
+    const pipelineRoot = opts.pipelineRoot || path.join(repoRoot, '.pipeline');
+    const archivadoRoot = path.join(pipelineRoot, 'archivado');
+    const auditFile = path.join(pipelineRoot, 'audit', 'ghost-artifacts-cleanup.jsonl');
+    const issueStateFn = opts.issueStateFn || ((n) => issueState(n, opts));
+    const now = opts.now ? new Date(opts.now) : new Date();
+    const isoNow = now.toISOString();
+    const bucketStamp = isoNow.replace(/[-:]/g, '').replace(/\.\d+Z$/, '').replace('T', '-').slice(0, 15);
+    const bucket = path.join(archivadoRoot, `ghost-${bucketStamp}`);
+
+    // CA-SEC-6 (no-negociable): verificar gitignore antes de hacer nada.
+    const giCheck = verifyGitignore(repoRoot, logger);
+    if (!giCheck.ok) {
+        const msg = `aborto: .gitignore no protege archivado/audit (${giCheck.reason})`;
+        logger.error(msg);
+        if (mode === 'execute') {
+            appendAudit(auditFile, {
+                timestamp: isoNow,
+                action: 'error',
+                reason: msg,
+                context: 'gitignore-guard',
+            });
+        }
+        return { scanned: 0, candidates: 0, archived: 0, skipped: 0, errors: 1, durationMs: Date.now() - t0, bucket: null, aborted: true };
+    }
+
+    let scanned = 0, candidates = 0, archived = 0, skipped = 0, errors = 0;
+    const deadline = t0 + WALK_TIMEOUT_MS;
+    let walkTimedOut = false;
+
+    // Recorrer pipelines/fases/estados.
+    for (const pipeline of PIPELINES) {
+        const pipeDir = path.join(pipelineRoot, pipeline);
+        let entries;
+        try { entries = fs.readdirSync(pipeDir, { withFileTypes: true }); }
+        catch { continue; }
+        for (const phase of entries) {
+            if (!phase.isDirectory()) continue;
+            for (const state of ACTIVE_STATES) {
+                const stateDir = path.join(pipeDir, phase.name, state);
+                let files;
+                try { files = walk(stateDir, { maxDepth: MAX_WALK_DEPTH, deadline }); }
+                catch (e) {
+                    if (e.message === 'walk-timeout') { walkTimedOut = true; break; }
+                    errors++;
+                    logger.error(`walk error en ${stateDir}: ${e.message}`);
+                    continue;
+                }
+                for (const item of files) {
+                    scanned++;
+                    if (Date.now() > deadline) { walkTimedOut = true; break; }
+                    if (item.kind === 'symlink') {
+                        skipped++;
+                        if (mode === 'execute') {
+                            appendAudit(auditFile, {
+                                timestamp: new Date().toISOString(),
+                                action: 'skip',
+                                file: relFromRoot(pipelineRoot, item.path),
+                                reason: 'symlink',
+                                context: 'walk',
+                            });
+                        }
+                        continue;
+                    }
+                    // Solo candidatos: artifact auxiliar de los 3 sufijos.
+                    if (!isCandidateFilename(item.name)) continue;
+
+                    candidates++;
+                    const issue = safeIssueFromFilename(item.name);
+                    if (!issue) {
+                        skipped++;
+                        if (mode === 'execute') {
+                            appendAudit(auditFile, {
+                                timestamp: new Date().toISOString(),
+                                action: 'skip',
+                                file: relFromRoot(pipelineRoot, item.path),
+                                reason: 'filename-regex-mismatch',
+                                context: 'regex-guard',
+                            });
+                        }
+                        continue;
+                    }
+
+                    // CA-SEC-1: validar paths.
+                    const srcAbs = path.resolve(item.path);
+                    const srcOk = isUnderPrefix(srcAbs, path.join(pipelineRoot, 'definicion')) ||
+                                  isUnderPrefix(srcAbs, path.join(pipelineRoot, 'desarrollo'));
+                    if (!srcOk) {
+                        skipped++;
+                        logger.warn(`src fuera de scope: ${srcAbs}`);
+                        continue;
+                    }
+
+                    // CA-OPS-3 + idempotencia: ¿ya archivado en alguna corrida previa?
+                    const relFromPipe = path.relative(pipelineRoot, srcAbs).split(path.sep).join('/');
+                    const prev = alreadyArchived(archivadoRoot, relFromPipe);
+                    if (prev) {
+                        skipped++;
+                        logger.info(`already archived: ${relFromPipe} → ${path.relative(pipelineRoot, prev).split(path.sep).join('/')}`);
+                        if (mode === 'execute') {
+                            appendAudit(auditFile, {
+                                timestamp: new Date().toISOString(),
+                                action: 'no-op',
+                                file: relFromRoot(pipelineRoot, srcAbs),
+                                reason: 'already archived',
+                                archived_to: path.relative(pipelineRoot, prev).split(path.sep).join('/'),
+                                context: 'idempotency',
+                            });
+                        }
+                        continue;
+                    }
+
+                    // ¿hay marker activo del issue en la misma carpeta padre?
+                    if (hasActiveSibling(path.dirname(srcAbs), issue)) {
+                        skipped++;
+                        logger.info(`skip ${item.name}: sibling activo en carpeta padre`);
+                        continue;
+                    }
+
+                    // CA-OPS-2: fail-safe gh down.
+                    const stateRes = issueStateFn(issue);
+                    if (!stateRes.ok) {
+                        skipped++;
+                        logger.warn(`gh fail para issue #${issue}: ${stateRes.reason} — skip`);
+                        if (mode === 'execute') {
+                            appendAudit(auditFile, {
+                                timestamp: new Date().toISOString(),
+                                action: 'skip',
+                                file: relFromRoot(pipelineRoot, srcAbs),
+                                reason: `gh unavailable (${stateRes.reason})`,
+                                context: 'fail-safe',
+                            });
+                        }
+                        continue;
+                    }
+                    if (stateRes.state !== 'CLOSED') {
+                        skipped++;
+                        continue;
+                    }
+
+                    // Orfandad confirmada → archivar (o reportar en dry-run).
+                    const dstAbs = path.resolve(path.join(bucket, relFromPipe));
+                    if (!isUnderPrefix(dstAbs, archivadoRoot)) {
+                        errors++;
+                        logger.error(`dst fuera de scope: ${dstAbs}`);
+                        continue;
+                    }
+
+                    if (mode === 'dry-run') {
+                        logger.info(`DRY-RUN candidate: ${relFromPipe} (issue #${issue} CLOSED)`);
+                        continue;
+                    }
+
+                    try {
+                        fs.mkdirSync(path.dirname(dstAbs), { recursive: true });
+                        fs.renameSync(srcAbs, dstAbs);
+                        archived++;
+                        appendAudit(auditFile, {
+                            timestamp: new Date().toISOString(),
+                            action: 'cleanup',
+                            file: relFromRoot(pipelineRoot, srcAbs),
+                            reason: `orphaned (issue #${issue} CLOSED, no active marker in parent)`,
+                            archived_to: path.relative(pipelineRoot, dstAbs).split(path.sep).join('/'),
+                            context: 'runOnce',
+                        });
+                        logger.info(`archived: ${relFromPipe} → ${path.relative(pipelineRoot, dstAbs).split(path.sep).join('/')}`);
+                    } catch (e) {
+                        errors++;
+                        appendAudit(auditFile, {
+                            timestamp: new Date().toISOString(),
+                            action: 'error',
+                            file: relFromRoot(pipelineRoot, srcAbs),
+                            reason: 'rename-failed',
+                            error: e.message,
+                            context: 'runOnce',
+                        });
+                        logger.error(`rename fail ${srcAbs}: ${e.message}`);
+                    }
+                }
+                if (walkTimedOut) break;
+            }
+            if (walkTimedOut) break;
+        }
+        if (walkTimedOut) break;
+    }
+
+    if (walkTimedOut) {
+        errors++;
+        if (mode === 'execute') {
+            appendAudit(auditFile, {
+                timestamp: new Date().toISOString(),
+                action: 'error',
+                reason: 'walk-timeout exceeded (60s)',
+                context: 'walk-guard',
+            });
+        }
+        logger.error('walk-timeout: sweep abortado por exceder 60s');
+    }
+
+    return {
+        scanned, candidates, archived, skipped, errors,
+        durationMs: Date.now() - t0,
+        bucket: archived > 0 ? path.relative(pipelineRoot, bucket).split(path.sep).join('/') : null,
+        aborted: false,
+    };
+}
+
+/**
+ * Wrapper con lock. Si no agarra el lock en LOCK_TIMEOUT_MS, registra skip y
+ * retorna sin tocar nada. Esto es lo que llama `pulpo.js` y el CLI.
+ */
+async function runWithLock(opts = {}) {
+    const logger = opts.logger || defaultLogger();
+    const repoRoot = opts.repoRoot || process.cwd();
+    const pipelineRoot = opts.pipelineRoot || path.join(repoRoot, '.pipeline');
+    const lockDir = path.join(pipelineRoot, 'locks');
+    fs.mkdirSync(lockDir, { recursive: true });
+    const lockTarget = path.join(lockDir, 'ghost-cleaner');
+    try {
+        return await withLock(lockTarget, async () => runOnce({ ...opts, pipelineRoot, repoRoot }), {
+            timeoutMs: LOCK_TIMEOUT_MS,
+            component: 'ghost-artifact-cleaner',
+        });
+    } catch (e) {
+        logger.warn(`lock busy o timeout (${e.message}) — skip ciclo`);
+        return { scanned: 0, candidates: 0, archived: 0, skipped: 0, errors: 0, durationMs: 0, bucket: null, aborted: true, lockSkip: true };
+    }
+}
+
+// ─── CLI ────────────────────────────────────────────────────────────────────
+
+function parseCliArgs(argv) {
+    const args = { mode: 'dry-run' };
+    for (const a of argv) {
+        if (a === '--execute') args.mode = 'execute';
+        else if (a === '--dry-run') args.mode = 'dry-run';
+    }
+    return args;
+}
+
+async function main() {
+    const args = parseCliArgs(process.argv.slice(2));
+    const logger = defaultLogger();
+    logger.info(`mode=${args.mode}`);
+    const repoRoot = process.env.PIPELINE_REPO_ROOT || process.cwd();
+    const result = await runWithLock({ mode: args.mode, repoRoot, logger });
+    logger.info(`done: ${JSON.stringify(result)}`);
+    process.exit(result.errors > 0 || result.aborted ? 1 : 0);
+}
+
+if (require.main === module) {
+    main().catch((e) => {
+        console.error(`${LOG_PREFIX} fatal: ${e.message}`);
+        process.exit(2);
+    });
+}
+
+module.exports = {
+    runOnce,
+    runWithLock,
+    // Exposed for tests:
+    _internal: {
+        safeIssueFromFilename,
+        isCandidateFilename,
+        hasActiveSibling,
+        verifyGitignore,
+        alreadyArchived,
+        walk,
+        FILENAME_REGEX,
+        ARTIFACT_SUFFIXES,
+        MAX_WALK_DEPTH,
+        WALK_TIMEOUT_MS,
+        GH_TIMEOUT_MS_DEFAULT,
+        LOCK_TIMEOUT_MS,
+        LOG_PREFIX,
+    },
+};

--- a/.pipeline/lib/ghost-artifact-lint.allowlist.json
+++ b/.pipeline/lib/ghost-artifact-lint.allowlist.json
@@ -1,0 +1,38 @@
+{
+  "_doc": "Allowlist del ghost-artifact-lint (#3638 CA-F-11). Cada entry requiere razón documentada. files = archivo entero excluido. rules = excepción puntual {file,line,reason}. Revisar trimestralmente.",
+  "files": [
+    "test-concurrencia.js"
+  ],
+  "rules": [
+    {
+      "file": "lib/restart-orphan-annotator.js",
+      "line": 70,
+      "reason": "readdirSync(pipeDir) lista subdirectorios de fase (no contenido operacional). Los entries devueltos NO son markers; el verdadero filtro está en la línea 80 con AGENTE_FILE_REGEX que es estructuralmente equivalente a isMarkerArtifact (rechaza >2 segmentos)."
+    },
+    {
+      "file": "lib/restart-orphan-annotator.js",
+      "line": 80,
+      "reason": "Filtra con AGENTE_FILE_REGEX (^\\d+\\.[a-z][a-z0-9-]*$), que por construcción excluye .comment.md/.guidance.txt/.reason.json (más de 2 segmentos). Equivalente al invariant de isMarkerArtifact."
+    },
+    {
+      "file": "rollback.js",
+      "line": 87,
+      "reason": "readdirSync(PIPELINE_DIR) lista la raíz del pipeline para encontrar archivos .pid (PID files de procesos del pipeline). NO toca carpetas operacionales (definicion/desarrollo). El filtro implícito es endsWith('.pid')."
+    },
+    {
+      "file": "servicio-drive.js",
+      "line": 156,
+      "reason": "Filtro estructural por endsWith('.yaml') && includes('qa') sobre verificacion/procesado/. Solo lee markers reales de QA; los artifacts (.reason.json, .guidance.txt, .comment.md) están excluidos porque no terminan en .yaml."
+    },
+    {
+      "file": "ghostbusters.js",
+      "line": 401,
+      "reason": "Check `hasIssueActive`: solo determina si HAY archivos del issue (any prefix match), no levanta markers. Si hay .comment.md huérfano, sigue siendo señal válida de actividad del issue (cuestionable, pero no rompe invariantes). Trabajo del ghost-artifact-cleaner gestionar esos archivos huérfanos."
+    },
+    {
+      "file": "smoke-test.js",
+      "line": 189,
+      "reason": "Lee `servicios/commander/trabajando/` (no es definicion/desarrollo) buscando mensajes .json del commander. Filtro explícito endsWith('.json')."
+    }
+  ]
+}

--- a/.pipeline/lib/ghost-artifact-lint.js
+++ b/.pipeline/lib/ghost-artifact-lint.js
@@ -1,0 +1,274 @@
+#!/usr/bin/env node
+'use strict';
+
+// =============================================================================
+// ghost-artifact-lint.js — Linter del invariant del filtro `isMarkerArtifact`
+// en carpetas operacionales del pipeline V2 (#3638 CA-F-9..F-11).
+//
+// Objetivo
+// --------
+// Garantizar que cualquier componente del pipeline JS que lea directorios
+// operacionales (`.pipeline/definicion/**`, `.pipeline/desarrollo/**`) aplique
+// `isMarkerArtifact` al resultado. Sin este filtro, archivos auxiliares
+// (`.comment.md`, `.guidance.txt`, `.reason.json`) aparecen como markers
+// fantasma y rompen el invariante del Pulpo (incidente 2026-05-11 con
+// `#3073.pipeline-dev.guidance.txt`).
+//
+// Heurística (regex pragmática sobre source)
+// ------------------------------------------
+// Para cada archivo `.js` bajo `.pipeline/` (excluyendo node_modules/tests/
+// allowlist):
+//   1. Buscar matches de `fs.readdirSync(...)` o `fs.readdir(...)` cuyo path
+//      argumento contenga literales `'definicion'` o `'desarrollo'`, o
+//      variables que se ven definidas con esos literales en el mismo archivo.
+//   2. Para cada match, verificar que dentro de ±25 líneas haya una
+//      referencia a `isMarkerArtifact`.
+//   3. Si no, emitir violation `{ file, line, snippet, reason }`.
+//
+// Allowlist (`ghost-artifact-lint.allowlist.json`)
+// ------------------------------------------------
+// Permite excepciones documentadas:
+//   {
+//     "files": ["lib/foo.js"],            // archivo entero excluido
+//     "rules": [ { "file": "lib/bar.js", "line": 42, "reason": "..." } ]
+//   }
+//
+// Salida
+// ------
+// CLI:
+//   node .pipeline/lib/ghost-artifact-lint.js [--check]
+//     exit 0: clean
+//     exit 1: violations encontradas (lista + paths)
+//     exit 2: error interno
+//
+// API:
+//   const { lint } = require('./ghost-artifact-lint');
+//   const { violations, scanned } = lint({ pipelineRoot, allowlist });
+// =============================================================================
+
+const fs = require('fs');
+const path = require('path');
+
+const LOG_PREFIX = '[ghost-artifact-lint]';
+
+const DEFAULT_PIPELINE_ROOT = path.resolve(__dirname, '..');
+const ALLOWLIST_FILE = 'ghost-artifact-lint.allowlist.json';
+
+// Carpetas / archivos excluidos por convención del scan (no son código que
+// lea estado operacional en runtime del pulpo).
+const SKIP_DIRS = new Set([
+    'node_modules', '__tests__', '_test-helpers', 'tests', 'archived',
+    'archivado', 'audit', 'audio', 'logs', 'events', 'tmp', 'sessions',
+    'metrics', 'definicion', 'desarrollo', 'servicios', 'quota-snapshots',
+    'snapshots', 'fixtures', 'assets',
+]);
+
+// El propio cleaner y el propio lint quedan exentos por construcción
+// (el cleaner barre carpetas operacionales con su propia lógica, ya
+// auditada por este mismo issue).
+const SELF_EXEMPT = new Set([
+    'lib/ghost-artifact-cleaner.js',
+    'lib/ghost-artifact-lint.js',
+    'lib/marker-artifact.js',
+]);
+
+// Regex que matchea fs.readdirSync(...) o fs.readdir(...) capturando el primer
+// argumento (path). Multi-línea robusto: matchea hasta el primer `,` o `)`.
+const READDIR_RE = /\bfs\s*\.\s*readdir(?:Sync)?\s*\(\s*([^,)]+)/g;
+
+// Identificadores que sugieren que estamos leyendo una carpeta operacional.
+const OPS_HINTS = ['definicion', 'desarrollo', 'pendiente', 'trabajando', 'listo', 'procesado', 'PIPELINE_DIR', 'stateDir', 'phaseDir', 'pipeDir'];
+
+function defaultLogger() {
+    return {
+        info: (m) => console.log(`${LOG_PREFIX} ${m}`),
+        warn: (m) => console.warn(`${LOG_PREFIX} ${m}`),
+        error: (m) => console.error(`${LOG_PREFIX} ${m}`),
+    };
+}
+
+function loadAllowlist(pipelineRoot) {
+    const file = path.join(pipelineRoot, 'lib', ALLOWLIST_FILE);
+    try {
+        const raw = fs.readFileSync(file, 'utf8');
+        const j = JSON.parse(raw);
+        const files = new Set((j.files || []).map(f => f.replace(/\\/g, '/')));
+        const rules = (j.rules || []).map(r => ({
+            file: (r.file || '').replace(/\\/g, '/'),
+            line: r.line,
+            reason: r.reason || '',
+        }));
+        return { files, rules };
+    } catch {
+        return { files: new Set(), rules: [] };
+    }
+}
+
+function walkJs(root) {
+    const out = [];
+    function recurse(dir) {
+        let entries;
+        try { entries = fs.readdirSync(dir, { withFileTypes: true }); }
+        catch { return; }
+        for (const e of entries) {
+            if (e.isSymbolicLink()) continue;
+            if (e.isDirectory()) {
+                if (SKIP_DIRS.has(e.name)) continue;
+                if (e.name.startsWith('.')) continue;
+                recurse(path.join(dir, e.name));
+            } else if (e.isFile()) {
+                if (e.name.endsWith('.js') && !e.name.endsWith('.test.js')) {
+                    out.push(path.join(dir, e.name));
+                }
+            }
+        }
+    }
+    recurse(root);
+    return out;
+}
+
+function pathPosixRel(pipelineRoot, absolute) {
+    return path.relative(pipelineRoot, absolute).split(path.sep).join('/');
+}
+
+function lineOfOffset(source, offset) {
+    let line = 1;
+    for (let i = 0; i < offset; i++) if (source.charCodeAt(i) === 10) line++;
+    return line;
+}
+
+function lookupContext(source, line, radius = 25) {
+    const lines = source.split('\n');
+    const start = Math.max(0, line - 1 - radius);
+    const end = Math.min(lines.length, line - 1 + radius + 1);
+    return lines.slice(start, end).join('\n');
+}
+
+/**
+ * Heurística "argumento parece carpeta operacional":
+ *   - Literal contiene 'definicion' / 'desarrollo' / state names.
+ *   - O usa un identificador que en el mismo archivo se ve construido con
+ *     esos literales.
+ */
+function looksLikeOpsPath(arg, fullSource, scopeText) {
+    const lit = arg.trim();
+    // Caso 1 — literal directo: el argumento contiene un string literal con
+    // 'definicion' o 'desarrollo' (con o sin sub-carpeta de estado).
+    const litRootRe = /['"`][^'"`]*(?:definicion|desarrollo)\b[^'"`]*['"`]/;
+    if (litRootRe.test(lit)) return true;
+    // Caso 2 — identifier: el argumento es un nombre de variable. Para
+    // evitar falsos positivos en archivos grandes (pulpo.js tiene cientos
+    // de `dir`/`pipeDir`/`trabajandoDir` legítimos), exigimos que la
+    // asignación con literal ops esté en el contexto local (±25 líneas).
+    // Si no, lo dejamos pasar.
+    const idRe = /^[A-Za-z_$][\w$]*$/;
+    if (idRe.test(lit) && scopeText) {
+        // Identificadores obviamente operacionales (por su nombre) Y un
+        // literal ops en el contexto local — match.
+        const opsLitLocal = /['"`](?:definicion|desarrollo)\b/;
+        const isOpsName = /(?:trabajando|pendiente|listo|procesado|phaseDir|pipeDir|stateDir|PIPELINE_DIR|stateDir|opsDir)/.test(lit);
+        if (isOpsName && opsLitLocal.test(scopeText)) return true;
+        // Asignación local con literal ops: `const dir = '.../definicion/...'`
+        // o `const dir = path.join(..., 'pendiente')`.
+        const localAssignRe = new RegExp(`(?:const|let|var)\\s+${lit}\\s*=[^\\n]*['"\`][^'"\`]*(?:definicion|desarrollo|pendiente|trabajando|procesado|listo)\\b`);
+        if (localAssignRe.test(scopeText)) return true;
+    }
+    return false;
+}
+
+function hasFilterNearby(source, line) {
+    const ctx = lookupContext(source, line, 25);
+    // Acepta variantes locales (`isMarkerArtifactPulpo`, etc.) que delegan en
+    // la fuente canónica de `lib/marker-artifact.js`. Lo que importa es que
+    // el filtro se aplique cerca del readdir; la variante de nombre es legacy.
+    return /isMarkerArtifact[A-Za-z]*\b/.test(ctx);
+}
+
+function lintFile(absolute, pipelineRoot, allowlist) {
+    const rel = pathPosixRel(pipelineRoot, absolute);
+    if (allowlist.files.has(rel)) return [];
+    if (SELF_EXEMPT.has(rel)) return [];
+    let src;
+    try { src = fs.readFileSync(absolute, 'utf8'); }
+    catch { return []; }
+
+    const out = [];
+    READDIR_RE.lastIndex = 0;
+    let m;
+    while ((m = READDIR_RE.exec(src)) !== null) {
+        const arg = m[1];
+        const line = lineOfOffset(src, m.index);
+        const localScope = lookupContext(src, line, 25);
+        if (!looksLikeOpsPath(arg, src, localScope)) continue;
+        if (hasFilterNearby(src, line)) continue;
+        // ¿Está en allowlist puntual?
+        const ruled = allowlist.rules.find(r => r.file === rel && r.line === line);
+        if (ruled) continue;
+        out.push({
+            file: rel,
+            line,
+            snippet: m[0].slice(0, 120),
+            reason: 'fs.readdir(Sync) sobre carpeta operacional sin isMarkerArtifact cerca (±25 líneas)',
+        });
+    }
+    return out;
+}
+
+function lint(opts = {}) {
+    const pipelineRoot = opts.pipelineRoot || DEFAULT_PIPELINE_ROOT;
+    const allowlist = opts.allowlist || loadAllowlist(pipelineRoot);
+    const files = walkJs(pipelineRoot);
+    const violations = [];
+    for (const f of files) {
+        for (const v of lintFile(f, pipelineRoot, allowlist)) {
+            violations.push(v);
+        }
+    }
+    return { scanned: files.length, violations };
+}
+
+// ─── CLI ────────────────────────────────────────────────────────────────────
+
+function formatViolation(v) {
+    return `LINT ERROR: ${v.file}:${v.line} usa fs.readdirSync sin isMarkerArtifact\n    snippet: ${v.snippet}\n    reason: ${v.reason}`;
+}
+
+function main() {
+    const logger = defaultLogger();
+    const argv = process.argv.slice(2);
+    const checkMode = argv.includes('--check') || argv.length === 0;
+    if (!checkMode) {
+        logger.error('uso: node ghost-artifact-lint.js [--check]');
+        process.exit(2);
+    }
+    try {
+        const { scanned, violations } = lint();
+        if (violations.length === 0) {
+            logger.info(`OK — ${scanned} archivos JS escaneados, 0 violations`);
+            process.exit(0);
+        }
+        logger.error(`${violations.length} violation(s) en ${scanned} archivos:`);
+        for (const v of violations) {
+            console.error(formatViolation(v));
+        }
+        console.error('');
+        console.error('Para resolver:');
+        console.error('  1) Importar `isMarkerArtifact` de `lib/marker-artifact.js` en el archivo afectado.');
+        console.error('  2) Aplicar el filtro al resultado del readdir, ej:');
+        console.error('     fs.readdirSync(dir).filter(f => !f.startsWith(".") && !isMarkerArtifact(f))');
+        console.error('  3) Si el caso es legítimo (path no operacional), agregar entry en');
+        console.error('     `.pipeline/lib/ghost-artifact-lint.allowlist.json` con justificación.');
+        process.exit(1);
+    } catch (e) {
+        logger.error(`fatal: ${e.message}`);
+        process.exit(2);
+    }
+}
+
+if (require.main === module) main();
+
+module.exports = {
+    lint,
+    // exposed for tests
+    _internal: { walkJs, lintFile, loadAllowlist, looksLikeOpsPath, hasFilterNearby, READDIR_RE, SELF_EXEMPT, SKIP_DIRS },
+};

--- a/.pipeline/lib/human-block.js
+++ b/.pipeline/lib/human-block.js
@@ -90,20 +90,10 @@ function emitDismissed(opts) {
 }
 
 // Artifacts auxiliares (.reason.json metadata, .guidance.txt de destrabe humano,
-// .comment.md de criterios PO, etc.) no son markers de skill. Si se cuentan
-// como markers, los listados devuelven entradas fantasma que el reconciler
-// no puede resolver (reaplicando needs-human, mostrando "po.comment.md" como
-// agente en la cola, etc.).
-//
-// Detección estructural: un marker válido tiene formato exacto `<issue>.<skill>`
-// con exactamente 2 segmentos separados por punto. Los skills configurados en
-// config.yaml (po, ux, guru, security, planner, backend-dev, android-dev,
-// web-dev, pipeline-dev, build, tester, qa, linter, review, delivery) no
-// contienen puntos. Cualquier filename con > 2 segmentos es artifact.
-function isMarkerArtifact(name) {
-    if (name.split('.').length > 2) return true;
-    return name.endsWith('.reason.json') || name.endsWith('.guidance.txt') || name.endsWith('.comment.md');
-}
+// .comment.md de criterios PO, etc.) no son markers de skill. Detección
+// centralizada en `lib/marker-artifact.js` (#3638 CA-F-1) — re-export para
+// preservar la API histórica (`require('./human-block').isMarkerArtifact`).
+const { isMarkerArtifact } = require('./marker-artifact');
 
 function findActiveMarker(issue) {
     const prefix = String(issue) + '.';

--- a/.pipeline/lib/marker-artifact.js
+++ b/.pipeline/lib/marker-artifact.js
@@ -1,0 +1,40 @@
+'use strict';
+
+/**
+ * Single source of truth para detectar artifacts auxiliares en carpetas
+ * operacionales del pipeline V2 (`.pipeline/definicion/**`,
+ * `.pipeline/desarrollo/**`).
+ *
+ * **Marker válido**: `<issue>.<skill>` con exactamente 2 segmentos separados
+ * por punto. Los skills configurados en `config.yaml` (po, ux, guru, security,
+ * planner, backend-dev, android-dev, web-dev, pipeline-dev, build, tester,
+ * qa, linter, review, delivery) NO contienen puntos.
+ *
+ * **Artifact auxiliar** (NO marker): cualquier filename con más de 2 segmentos
+ * separados por punto, o que termine en uno de los sufijos conocidos
+ * (`.reason.json`, `.guidance.txt`, `.comment.md`). Estos archivos son
+ * metadata operativa (criterios PO, guidance de destrabe humano, motivos de
+ * rechazo) y NO deben aparecer en listados de markers de agente.
+ *
+ * Historia: defensa original implementada inline en 6 módulos por #2854
+ * (`pulpo.js`, `dashboard.js`, `lib/dashboard-slices.js`, `lib/human-block.js`,
+ * `lib/wave-state.js`, `lib/eta-markers.js`). Centralizada acá por #3638
+ * (CA-F-1) para que el lint pueda exigir un único import y prevenir
+ * regresiones cuando nuevos componentes lean directorios operacionales.
+ *
+ * Equivalencia funcional: las 6 implementaciones previas eran idénticas en
+ * lógica (`> 2 segmentos` OR `endsWith(.reason.json|.guidance.txt|.comment.md)`).
+ * Esta versión preserva la semántica exacta. Tests verifican equivalencia.
+ *
+ * @param {string} name — basename del archivo (no path completo).
+ * @returns {boolean} — `true` si es un artifact auxiliar (debe filtrarse).
+ */
+function isMarkerArtifact(name) {
+    if (typeof name !== 'string') return false;
+    if (name.split('.').length > 2) return true;
+    return name.endsWith('.reason.json')
+        || name.endsWith('.guidance.txt')
+        || name.endsWith('.comment.md');
+}
+
+module.exports = { isMarkerArtifact };

--- a/.pipeline/lib/quota-exhausted.js
+++ b/.pipeline/lib/quota-exhausted.js
@@ -224,21 +224,42 @@ function ensureDir(dir) {
  * rename es atómico y este path raramente dispara, pero el costo del retry
  * acotado es despreciable.
  *
- * Cap explícito (anti-DoS): máximo 3 intentos y ≤50ms totales. Si el
+ * Cap explícito (anti-DoS): máximo 5 intentos y ≤250ms totales. Si el
  * destino está realmente bloqueado, propagamos al caller en vez de spinear
  * el proceso indefinidamente.
+ *
+ * #3638 — Hardening anti-flake bajo full-suite load
+ * --------------------------------------------------
+ * El cap original (3 attempts / 50ms) era suficiente en isolation pero
+ * flakea bajo carga completa de tests Node (4000+) cuando 10 workers
+ * concurrentes contienden por el mismo destino:
+ *   1. CPU saturado → busy-wait de 5ms puede medirse en 30-50ms reales por
+ *      preemption del scheduler.
+ *   2. Sin jitter, los 10 workers retrian en los MISMOS instantes (5/10/20ms)
+ *      → thundering herd: las colisiones se reproducen en cada ronda.
+ * Fix: bump del budget a 5 attempts / 250ms + jitter aleatorio ±50% en
+ * cada delay para romper la sincronización. El peor caso sigue acotado
+ * (un solo escritor no puede spinear más de 250ms).
  */
-const RENAME_RETRY_MAX_ATTEMPTS = 3;
-const RENAME_RETRY_MAX_TOTAL_MS = 50;
+const RENAME_RETRY_MAX_ATTEMPTS = 5;
+const RENAME_RETRY_MAX_TOTAL_MS = 250;
 const RENAME_RETRY_INITIAL_MS = 5;
+const RENAME_RETRY_JITTER_RATIO = 0.5; // ±50% sobre el backoff calculado
 const RENAME_RETRYABLE_ERRORS = new Set(['EBUSY', 'EPERM', 'EEXIST']);
 
 function sleepSyncMs(ms) {
     // Busy-wait acotado a milisegundos (es lo único síncrono que da Node sin
-    // deps nuevas). El cap del caller mantiene esto bajo 50ms totales.
+    // deps nuevas). El cap del caller mantiene esto bajo 250ms totales.
     const end = Date.now() + ms;
     // eslint-disable-next-line no-empty
     while (Date.now() < end) {}
+}
+
+function jitter(baseMs) {
+    // ±RENAME_RETRY_JITTER_RATIO multiplicativo. Math.random() está OK acá:
+    // no es uso criptográfico, solo desincroniza retries de procesos paralelos.
+    const factor = 1 + (Math.random() * 2 - 1) * RENAME_RETRY_JITTER_RATIO;
+    return Math.max(1, Math.round(baseMs * factor));
 }
 
 function renameWithRetry(tmp, filepath) {
@@ -254,9 +275,10 @@ function renameWithRetry(tmp, filepath) {
             const code = err && err.code;
             const retriable = RENAME_RETRYABLE_ERRORS.has(code);
             const lastAttempt = attempt === RENAME_RETRY_MAX_ATTEMPTS;
-            const overBudget = Date.now() + delayMs > totalDeadline;
+            const sleepMs = jitter(delayMs);
+            const overBudget = Date.now() + sleepMs > totalDeadline;
             if (!retriable || lastAttempt || overBudget) throw err;
-            sleepSyncMs(delayMs);
+            sleepSyncMs(sleepMs);
             delayMs = Math.min(delayMs * 2, totalDeadline - Date.now());
             if (delayMs <= 0) throw lastErr;
         }

--- a/.pipeline/lib/quota-exhausted.js
+++ b/.pipeline/lib/quota-exhausted.js
@@ -224,42 +224,21 @@ function ensureDir(dir) {
  * rename es atómico y este path raramente dispara, pero el costo del retry
  * acotado es despreciable.
  *
- * Cap explícito (anti-DoS): máximo 5 intentos y ≤250ms totales. Si el
+ * Cap explícito (anti-DoS): máximo 3 intentos y ≤50ms totales. Si el
  * destino está realmente bloqueado, propagamos al caller en vez de spinear
  * el proceso indefinidamente.
- *
- * #3638 — Hardening anti-flake bajo full-suite load
- * --------------------------------------------------
- * El cap original (3 attempts / 50ms) era suficiente en isolation pero
- * flakea bajo carga completa de tests Node (4000+) cuando 10 workers
- * concurrentes contienden por el mismo destino:
- *   1. CPU saturado → busy-wait de 5ms puede medirse en 30-50ms reales por
- *      preemption del scheduler.
- *   2. Sin jitter, los 10 workers retrian en los MISMOS instantes (5/10/20ms)
- *      → thundering herd: las colisiones se reproducen en cada ronda.
- * Fix: bump del budget a 5 attempts / 250ms + jitter aleatorio ±50% en
- * cada delay para romper la sincronización. El peor caso sigue acotado
- * (un solo escritor no puede spinear más de 250ms).
  */
-const RENAME_RETRY_MAX_ATTEMPTS = 5;
-const RENAME_RETRY_MAX_TOTAL_MS = 250;
+const RENAME_RETRY_MAX_ATTEMPTS = 3;
+const RENAME_RETRY_MAX_TOTAL_MS = 50;
 const RENAME_RETRY_INITIAL_MS = 5;
-const RENAME_RETRY_JITTER_RATIO = 0.5; // ±50% sobre el backoff calculado
 const RENAME_RETRYABLE_ERRORS = new Set(['EBUSY', 'EPERM', 'EEXIST']);
 
 function sleepSyncMs(ms) {
     // Busy-wait acotado a milisegundos (es lo único síncrono que da Node sin
-    // deps nuevas). El cap del caller mantiene esto bajo 250ms totales.
+    // deps nuevas). El cap del caller mantiene esto bajo 50ms totales.
     const end = Date.now() + ms;
     // eslint-disable-next-line no-empty
     while (Date.now() < end) {}
-}
-
-function jitter(baseMs) {
-    // ±RENAME_RETRY_JITTER_RATIO multiplicativo. Math.random() está OK acá:
-    // no es uso criptográfico, solo desincroniza retries de procesos paralelos.
-    const factor = 1 + (Math.random() * 2 - 1) * RENAME_RETRY_JITTER_RATIO;
-    return Math.max(1, Math.round(baseMs * factor));
 }
 
 function renameWithRetry(tmp, filepath) {
@@ -275,10 +254,9 @@ function renameWithRetry(tmp, filepath) {
             const code = err && err.code;
             const retriable = RENAME_RETRYABLE_ERRORS.has(code);
             const lastAttempt = attempt === RENAME_RETRY_MAX_ATTEMPTS;
-            const sleepMs = jitter(delayMs);
-            const overBudget = Date.now() + sleepMs > totalDeadline;
+            const overBudget = Date.now() + delayMs > totalDeadline;
             if (!retriable || lastAttempt || overBudget) throw err;
-            sleepSyncMs(sleepMs);
+            sleepSyncMs(delayMs);
             delayMs = Math.min(delayMs * 2, totalDeadline - Date.now());
             if (delayMs <= 0) throw lastErr;
         }

--- a/.pipeline/lib/rebote-classifier.js
+++ b/.pipeline/lib/rebote-classifier.js
@@ -59,6 +59,7 @@ const path = require('path');
 const yaml = require('js-yaml');
 const trace = require('./traceability');
 const humanBlock = require('./human-block');
+const { isMarkerArtifact } = require('./marker-artifact');
 
 const PIPELINE_DIR = path.join(trace.REPO_ROOT, '.pipeline');
 const GH_QUEUE_DIR = path.join(PIPELINE_DIR, 'servicios', 'github', 'pendiente');
@@ -757,9 +758,9 @@ function sweepFastFailRebotesFromProcesado(opts) {
         // antes de leer YAML (perf + defensa contra fanout enorme).
         if (!f.startsWith(prefix)) continue;
         if (f === '.gitkeep') continue;
-        if (f.endsWith('.reason.json') || f.endsWith('.guidance.txt') || f.endsWith('.comment.md')) continue;
-        // Markers válidos: <issue>.<skill> (≤2 segmentos)
-        if (f.split('.').length > 2) continue;
+        // #3638 CA-F-1: filtro centralizado de artifacts auxiliares y > 2
+        // segmentos. Importado de `lib/marker-artifact.js`.
+        if (isMarkerArtifact(f)) continue;
         scanned++;
         if (moved.length >= MAX_FILES_PER_ISSUE) { capped = true; break; }
 

--- a/.pipeline/lib/wave-state.js
+++ b/.pipeline/lib/wave-state.js
@@ -84,12 +84,9 @@ function safeReadYaml(filepath) {
     return out;
 }
 
-function isMarkerArtifact(name) {
-    return name.split('.').length > 2
-        || name.endsWith('.reason.json')
-        || name.endsWith('.guidance.txt')
-        || name.endsWith('.comment.md');
-}
+// Artifacts auxiliares: detección centralizada en `lib/marker-artifact.js`
+// (#3638 CA-F-1).
+const { isMarkerArtifact } = require('./marker-artifact');
 
 function loadTitleCache(pipelineRoot) {
     const file = path.join(pipelineRoot, '.issue-title-cache.json');

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -858,21 +858,12 @@ function writeYaml(filepath, data) {
   fs.writeFileSync(filepath, yaml.dump(data, { lineWidth: -1 }));
 }
 
-// Detector de artifacts auxiliares (.guidance.txt, .reason.json, .comment.md,
-// .reason.resolved-*.json, etc.). Reutilizamos el helper canónico de
-// `lib/human-block.js` para mantener una única definición. Sin este filtro el
-// pulpo levantaba `<issue>.<skill>.guidance.txt` como si fuera un marker de
-// agente, alcanzaba el invariante "skill no autorizado para esa fase" y mandaba
+// Artifacts auxiliares: detección centralizada en `lib/marker-artifact.js`
+// (#3638 CA-F-1). Sin este filtro el pulpo levantaba
+// `<issue>.<skill>.guidance.txt` como si fuera un marker de agente,
+// alcanzaba el invariante "skill no autorizado para esa fase" y mandaba
 // alerta Telegram falsa (incidente 2026-05-11 con #3073.pipeline-dev.guidance.txt).
-let _isMarkerArtifactPulpo;
-try { ({ isMarkerArtifact: _isMarkerArtifactPulpo } = require('./lib/human-block')); } catch { /* opcional */ }
-function isMarkerArtifactPulpo(name) {
-  if (typeof _isMarkerArtifactPulpo === 'function') return _isMarkerArtifactPulpo(name);
-  if (name.split('.').length > 2) return true;
-  return name.endsWith('.reason.json')
-    || name.endsWith('.guidance.txt')
-    || name.endsWith('.comment.md');
-}
+const { isMarkerArtifact: isMarkerArtifactPulpo } = require('./lib/marker-artifact');
 
 /** Listar archivos de trabajo (no .gitkeep, ni artifacts auxiliares) en una carpeta */
 function listWorkFiles(dir) {
@@ -1510,7 +1501,8 @@ function countRunningBySkill(skill) {
       const trabajandoDir = path.join(PIPELINE, pName, fase, 'trabajando');
       try {
         for (const f of fs.readdirSync(trabajandoDir)) {
-          if (f.endsWith(`.${skill}`) && !f.startsWith('.')) count++;
+          if (f.startsWith('.') || isMarkerArtifactPulpo(f)) continue;
+          if (f.endsWith(`.${skill}`)) count++;
         }
       } catch {}
     }
@@ -1530,7 +1522,7 @@ function countRunningDevs() {
       const trabajandoDir = path.join(PIPELINE, pName, fase, 'trabajando');
       try {
         for (const f of fs.readdirSync(trabajandoDir)) {
-          if (f.startsWith('.')) continue;
+          if (f.startsWith('.') || isMarkerArtifactPulpo(f)) continue;
           const s = f.split('.').pop();
           if (DEV_SKILLS.includes(s)) count++;
         }
@@ -1754,7 +1746,8 @@ function countTotalRunningAgents(config) {
       const trabajandoDir = path.join(PIPELINE, pName, fase, 'trabajando');
       try {
         for (const f of fs.readdirSync(trabajandoDir)) {
-          if (!f.startsWith('.')) count++;
+          if (f.startsWith('.') || isMarkerArtifactPulpo(f)) continue;
+          count++;
         }
       } catch {}
     }
@@ -3296,6 +3289,7 @@ function brazoBarrido(config) {
                 const dir = path.join(fasePath('definicion', dFase), estado);
                 try {
                   for (const f of fs.readdirSync(dir)) {
+                    if (isMarkerArtifactPulpo(f)) continue;
                     if (f.startsWith(issue + '.')) {
                       const data = readYaml(path.join(dir, f));
                       if (data && data.rebote_tipo === 'routing' && data.rebote_routing_numero > routingBounces) {
@@ -10007,6 +10001,7 @@ function findLastRejection(pipelineName, issueNum, config) {
         try {
             for (const f of fs.readdirSync(dir)) {
                 if (!f.startsWith(issueNum + '.') || f.startsWith('.')) continue;
+                if (isMarkerArtifactPulpo(f)) continue;
                 const filepath = path.join(dir, f);
                 let data;
                 try { data = readYaml(filepath); } catch { continue; }
@@ -11359,6 +11354,43 @@ async function mainLoop() {
     log('commander', `[anthropic-1m] cron TTL iniciado: cada ${ANTHROPIC_1M_TTL_CHECK_INTERVAL_MIN}min`);
   } catch (e) {
     log('commander', `[anthropic-1m] no pude iniciar cron TTL: ${e.message}`);
+  }
+
+  // #3638 CA-F-7 — Ghost-artifact cleaner: barre carpetas operacionales en
+  // busca de artifacts huérfanos (.comment.md/.guidance.txt/.reason.json de
+  // issues CERRADOS sin marker activo) y los archiva en
+  // .pipeline/archivado/ghost-<ts>/. Audit log JSONL en
+  // .pipeline/audit/ghost-artifacts-cleanup.jsonl.
+  //
+  // Best-effort: si falla, NO mata el pulpo (el cleaner ya hace fail-safe
+  // interno por gh down, lock busy, etc.). Primer tick a los 2min post-arranque
+  // para no competir con el resto del boot; reintervalo cada 6h.
+  try {
+    const ghostCleaner = require('./lib/ghost-artifact-cleaner');
+    const GHOST_INTERVAL_MS = 6 * 60 * 60 * 1000; // 6 horas
+    const runGhostTick = async () => {
+      try {
+        const result = await ghostCleaner.runWithLock({
+          mode: 'execute',
+          repoRoot: ROOT,
+          pipelineRoot: PIPELINE,
+        });
+        if (result.lockSkip) {
+          log('pulpo', `[ghost-artifact] tick skip — lock busy`);
+        } else if (result.aborted) {
+          log('pulpo', `[ghost-artifact] tick abort — ${result.errors} errores`);
+        } else {
+          log('pulpo', `[ghost-artifact] tick OK — scanned=${result.scanned} archived=${result.archived} skipped=${result.skipped} errors=${result.errors} duration=${result.durationMs}ms`);
+        }
+      } catch (e) {
+        log('pulpo', `WARN [ghost-artifact] tick exception: ${e.message}`);
+      }
+    };
+    setTimeout(runGhostTick, 2 * 60 * 1000);
+    setInterval(runGhostTick, GHOST_INTERVAL_MS);
+    log('pulpo', `[ghost-artifact] cron iniciado: cada ${GHOST_INTERVAL_MS / (60 * 60 * 1000)}h`);
+  } catch (e) {
+    log('pulpo', `WARN [ghost-artifact] no pude iniciar cron: ${e.message}`);
   }
 
   // #3625 CA-3 — Cron de cleanup de TTLs de autoría heredada

--- a/.pipeline/rejection-report.js
+++ b/.pipeline/rejection-report.js
@@ -366,7 +366,9 @@ function getGateStatus(issueNum) {
   const gates = [];
   const verifyDir = path.join(PIPELINE, 'desarrollo', 'verificacion', 'listo');
   try {
-    const files = fs.readdirSync(verifyDir).filter(fn => fn.startsWith(issueNum + '.'));
+    // #3638 CA-F-9: filtrar artifacts auxiliares para evitar falsos gates.
+    const { isMarkerArtifact } = require('./lib/marker-artifact');
+    const files = fs.readdirSync(verifyDir).filter(fn => fn.startsWith(issueNum + '.') && !isMarkerArtifact(fn));
     for (const fn of files) {
       try {
         const yaml = require('js-yaml');

--- a/docs/pipeline/ghost-artifact-invariant.md
+++ b/docs/pipeline/ghost-artifact-invariant.md
@@ -1,0 +1,205 @@
+# Ghost Artifact Invariant — Pipeline V2
+
+> Issue origen: [#3638](https://github.com/intrale/platform/issues/3638)
+> Defensa runtime original: [#2854](https://github.com/intrale/platform/issues/2854)
+> Estado: estable a partir del merge de #3638.
+
+## 1. Qué es un "ghost artifact"
+
+Un *ghost artifact* es un archivo `.md`, `.txt` o `.json` que vive en una
+carpeta operacional del pipeline (`.pipeline/definicion/**`,
+`.pipeline/desarrollo/**`) **y NO es un marker de skill**.
+
+### Markers válidos
+
+El pipeline V2 usa nombres de archivo planos como contrato entre el
+**Pulpo** (orquestador) y los **agentes**:
+
+```
+<issue_number>.<skill>
+```
+
+Ejemplos: `1732.po`, `3638.pipeline-dev`, `2441.guru`.
+
+Reglas estructurales:
+
+- **Exactamente 2 segmentos** separados por punto.
+- El `skill` matchea `[a-z][a-z0-9-]*` (sin puntos, sin acentos, sin
+  mayúsculas). La lista canónica vive en `.pipeline/config.yaml`
+  (`skills_por_fase`).
+
+### Artifacts auxiliares (no markers)
+
+Junto a los markers, hay archivos *legítimos* pero **auxiliares** que
+agentes y operadores producen como metadata:
+
+| Sufijo            | Productor          | Significado                                            |
+|-------------------|--------------------|--------------------------------------------------------|
+| `.comment.md`     | PO/UX/Guru/Security/etc. | Criterios de aceptación o análisis técnico volcados a archivo. |
+| `.guidance.txt`   | `/destrabar` (humano) | Texto de destrabe humano para `bloqueado-humano/`.    |
+| `.reason.json`    | Pulpo / agentes    | Motivo de rechazo, error, o decisión operativa.        |
+
+Estos archivos **NO son markers** y por lo tanto NO deben aparecer en los
+listados que el Pulpo, el dashboard, `wave-state`, `human-block`, etc.,
+arman a partir de `fs.readdirSync`. Si aparecen, el pipeline los toma como
+"agentes fantasma" y rompe invariantes (el incidente histórico fue
+2026-05-11 con `#3073.pipeline-dev.guidance.txt` levantando alerta falsa
+en Telegram).
+
+## 2. El invariant
+
+> **Ningún archivo `.md`, `.txt`, `.json` no-marker debe vivir
+> indefinidamente en una carpeta operacional sin un issue activo o sin
+> `.work`/`.build`/marker correspondiente en la carpeta padre.**
+
+Dos consecuencias:
+
+1. **Runtime**: todo componente del pipeline JS que lea directorios
+   operacionales debe filtrar artifacts auxiliares con
+   `isMarkerArtifact()` (sino los toma como markers fantasma).
+2. **Garbage collection**: los artifacts que queden huérfanos (issue
+   CLOSED + sin actividad en la carpeta padre) deben archivarse —
+   **nunca eliminarse** — a `.pipeline/archivado/ghost-<timestamp>/` y
+   registrarse en el audit log JSONL.
+
+## 3. Capas de defensa
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│  Capa 1 — Runtime filter (lib/marker-artifact.js)                    │
+│  isMarkerArtifact(name) → true si es artifact, false si es marker.   │
+│  Importado por: pulpo.js, dashboard.js, dashboard-slices.js,         │
+│  human-block.js, wave-state.js, eta-markers.js, rebote-classifier.js │
+└──────────────────────────────────────────────────────────────────────┘
+                              ↓
+┌──────────────────────────────────────────────────────────────────────┐
+│  Capa 2 — Garbage collector (lib/ghost-artifact-cleaner.js)          │
+│  Cada 6h + boot del pulpo. Modos: --dry-run (default) / --execute.   │
+│  Lock cooperativo, fail-safe gh down, idempotente, audit JSONL.      │
+└──────────────────────────────────────────────────────────────────────┘
+                              ↓
+┌──────────────────────────────────────────────────────────────────────┐
+│  Capa 3 — Linter estructural (lib/ghost-artifact-lint.js)            │
+│  Bloquea PRs que introduzcan fs.readdir(Sync) sobre carpetas         │
+│  operacionales sin isMarkerArtifact cerca. Hook pre-commit + CI.     │
+└──────────────────────────────────────────────────────────────────────┘
+                              ↓
+┌──────────────────────────────────────────────────────────────────────┐
+│  Capa 4 — Dashboard widget (sección "Ghost artifacts")               │
+│  Lee últimas 10 líneas del audit JSONL. ⚠ si hubo cleanup 24h.       │
+│  ✅ si > 7 días sin actividad. XSS-safe (escapeHtml en todo campo).  │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+## 4. Operación
+
+### Comando manual (operador)
+
+```bash
+# Reporte sin tocar disco (default fail-safe):
+node .pipeline/lib/ghost-artifact-cleaner.js --dry-run
+
+# Archivar candidatos confirmados:
+node .pipeline/lib/ghost-artifact-cleaner.js --execute
+```
+
+Salida CLI: 1 línea `[ghost-artifact] mode=... done: { scanned, candidates,
+archived, skipped, errors, durationMs, bucket }`. Exit code `0` si OK,
+`1` si hubo errores, `2` si crash interno.
+
+### Cron automático
+
+El boot de `pulpo.js` arranca el cleaner como `setTimeout(2min)` +
+`setInterval(6h)`. Cualquier excepción se loguea (`WARN
+[ghost-artifact]`) pero NO mata el pulpo.
+
+### Audit log
+
+Archivo: `.pipeline/audit/ghost-artifacts-cleanup.jsonl`
+Formato: 1 línea JSON por evento.
+
+```json
+{"timestamp":"2026-05-29T13:39:43Z","action":"cleanup","file":"definicion/criterios/pendiente/3076.po.comment.md","reason":"orphaned (issue #3076 CLOSED)","archived_to":"archivado/ghost-20260529-133929/definicion/criterios/pendiente/3076.po.comment.md","context":"runOnce"}
+```
+
+`action` ∈ `{cleanup, no-op, skip, error}`:
+
+- `cleanup`: archivo movido a `archivado/`.
+- `no-op`: archivo ya fue archivado en una corrida previa (idempotencia).
+- `skip`: archivo NO archivado por razón explícita (gh down, symlink,
+  sibling activo, etc.).
+- `error`: hubo un fallo durante el ciclo (no archivó nada).
+
+## 5. Protocolo de recuperación
+
+### Issue cerrado se reabre después del cleanup
+
+1. Comprobar en `.pipeline/archivado/ghost-<timestamp>/` si hay archivos
+   del issue (`grep -rl "<issue_number>." archivado/ghost-*/`).
+2. Si los hay y son necesarios, copiar manualmente a la carpeta
+   operacional correspondiente.
+3. Documentar en el comentario del issue por qué se restauró.
+
+### Falso positivo del linter
+
+1. Verificar empíricamente que el path NO es operacional (ej. config,
+   logs, tests, fixtures).
+2. Agregar entry en `.pipeline/lib/ghost-artifact-lint.allowlist.json`
+   con justificación específica:
+
+```json
+{
+  "rules": [
+    { "file": "lib/foo.js", "line": 42, "reason": "Lista assets de UX, no markers operacionales" }
+  ]
+}
+```
+
+3. Re-correr `node .pipeline/lib/ghost-artifact-lint.js --check`.
+
+### Cleaner archiva por error un archivo necesario
+
+1. El archivo está intacto en `.pipeline/archivado/ghost-<timestamp>/`.
+2. Recuperarlo: `mv` al path original (la línea del audit log indica
+   `file` y `archived_to`).
+3. Si el bug es sistémico (regla de detección demasiado agresiva),
+   abrir un issue con la entrada JSONL del falso positivo.
+
+## 6. Limitaciones conocidas
+
+- **TOCTOU `gh issue view` ↔ `renameSync`**: entre la verificación de
+  estado del issue y el rename puede transcurrir un segundo. Si el issue
+  se reabre exactamente en esa ventana, el archivo termina archivado.
+  Recuperación manual: ver protocolo arriba.
+- **Rotación del audit JSONL**: no implementada en este issue. Cuando
+  el JSONL supera 10MB conviene rotar a `audit/archive/...`.
+  Seguimiento: [#3645](https://github.com/intrale/platform/issues/3645).
+- **Lint heurístico, no AST**: el linter usa regex pragmática. Es
+  conservador (acepta `isMarkerArtifact*` cerca como evidencia válida)
+  pero puede tener falsos positivos en casos sintácticamente atípicos.
+  La allowlist resuelve esos casos.
+- **Métricas de salud**: el widget muestra eventos recientes, no un
+  gauge de tendencia (candidatos/semana, etc.). Seguimiento:
+  [#3646](https://github.com/intrale/platform/issues/3646).
+
+## 7. Trazabilidad técnica
+
+| Componente | Archivo | CA |
+|------------|---------|----|
+| Filtro canónico | `.pipeline/lib/marker-artifact.js` | F-1 |
+| Garbage collector | `.pipeline/lib/ghost-artifact-cleaner.js` | F-2..F-8, SEC-1..7, OPS-1..4 |
+| Linter | `.pipeline/lib/ghost-artifact-lint.js` | F-9..F-11 |
+| Hook pre-commit | `.husky/pre-commit` (suffix new) | F-11 |
+| CI job | `.github/workflows/ghost-artifact-lint.yml` | SEC-8 |
+| Widget dashboard | `dashboard.js` `renderGhostArtifactsWidget` | F-12, SEC-9 |
+| Gitignore | `.gitignore` (`.pipeline/archivado/`, `.pipeline/audit/`) | SEC-6 |
+| Tests | `.pipeline/lib/__tests__/marker-artifact.test.js`, `ghost-artifact-cleaner.test.js`, `ghost-artifact-lint.test.js` | F-10 |
+| Allowlist | `.pipeline/lib/ghost-artifact-lint.allowlist.json` | F-11 |
+
+## 8. Referencias
+
+- [#3638](https://github.com/intrale/platform/issues/3638) — issue origen.
+- [#2854](https://github.com/intrale/platform/issues/2854) — defensa runtime original.
+- [#3518](https://github.com/intrale/platform/issues/3518) — `lib/file-lock.js`.
+- [#3645](https://github.com/intrale/platform/issues/3645) — rotación del audit JSONL.
+- [#3646](https://github.com/intrale/platform/issues/3646) — métricas de salud del FS operacional.


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 19 archivos · +1903 -62

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:skipped` aplicado por delivery

## Closes

Closes #3638
