### PR TITLE
fix(pipeline): handler dep-block corre siempre — fix loop infinito #3741 (#3774)

### DIFF
--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -2895,9 +2895,22 @@ function brazoBarrido(config) {
           // humana cuando las deps cierren. Defense-in-depth: TODO el resto del
           // flujo de humanBlock queda intacto abajo (sigue siendo dueño cuando
           // el motivo no clasifica como dep).
+          //
+          // #3774 — El handler dep-block corre SIEMPRE (ya no gated por
+          // !esReboteDeInfra). El hint YAML estructurado del agente
+          // (`rebote_categoria: dependency_block`) gana sobre la heurística
+          // textual de `classifyError`, que podía falsamente clasificar como
+          // 'infra' un motivo que mencionaba palabras como "timeout"
+          // (ej: "timeout 15min" describiendo idempotencia del wizard, no un
+          // timeout de red). El loop infinito de #3741 (~$80–100/h) surgía de
+          // este falso positivo: cada ciclo veía `esReboteDeInfra=true`,
+          // salteaba el handler dep-block, y reencolaba con `rebote_numero_infra=1`
+          // (el contador no se persistía en `listo/` así que nunca acumulaba
+          // hacia el cap de 20). El handler ya filtra internamente por
+          // `result.category === 'dependency_block'`; si ningún motivo califica,
+          // `depBlockHandled` queda en false y el flow infra/humano normal sigue.
           let depBlockHandled = false;
-          if (!esReboteDeInfra) {
-            for (const m of motivosClasificados) {
+          for (const m of motivosClasificados) {
               const result = reboteClassifier.classifyRebote({
                 motivo: m.motivo,
                 classifyErrorResult: m.clasificacion,
@@ -3002,7 +3015,6 @@ function brazoBarrido(config) {
 
               depBlockHandled = true;
               break;
-            }
           }
           if (depBlockHandled) continue;
 


### PR DESCRIPTION
## Resumen

Cortar el loop infinito de `dependency_block` que estaba quemando ~$80-100/h en #3741.

## Causa raíz

El motivo del guru sobre #3741 contenía la cadena `"timeout 15min"` (descripción de idempotencia del wizard, **no** un timeout de red). El regex `/timeout/i` de `classifyError` devolvía `'infra'` → `esReboteDeInfra=true` → la guarda `if (!esReboteDeInfra)` salteaba todo el handler de `dependency_block`.

Sin handler dep-block, el flow caía al rebote de infra que leía `rebote_numero_infra` solo de `pendiente|trabajando|procesado` (nunca de `listo/`). Resultado: cada ciclo arrancaba con `counter=0`, persistía `counter=1`, y nunca disparaba el cap de 20. **Reencolado eterno cada ~3 min**.

Evidencia en `activity-log` de hoy: 21 sesiones cerradas del guru sobre #3741 entre 00:00 y 09:30, todas terminadas en `dependency_block`.

## Cambios

`.pipeline/pulpo.js:2895-3018`:
- Saco la guarda `if (!esReboteDeInfra)` que envolvía el handler dep-block
- El handler ahora corre **siempre** — el hint YAML estructurado del agente (`rebote_categoria: dependency_block`) gana sobre la heurística textual de `classifyError`
- El handler ya filtra internamente por `result.category === 'dependency_block'`; si ningún motivo califica, `depBlockHandled` queda `false` y el flow infra/humano normal sigue intacto

## Test plan

- [ ] Pipeline reanudado tras merge — verificar que el guru sobre #3741 ya no se reencola eternamente
- [ ] Confirmar en `activity-log` que el contador de `dependency_block` deja de crecer cuando se reanuda #3741
- [ ] Verificar que rebotes de infra reales (timeout HTTP, OOM, etc.) siguen funcionando como antes
- [ ] Revisar telemetry de costo / iteración por hora vuelve a niveles normales

Closes #3774

🤖 Generated with [Claude Code](https://claude.com/claude-code)