### PR TITLE
fix(pipeline): deadlock breaker tambien respeta rest-mode (#3790)

### DIFF
--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -4712,6 +4712,30 @@ function brazoLanzamiento(config) {
             return; // No lanzar — el deadlock breaker no puede forzar sin infra
           }
         }
+        // #3790 — El deadlock breaker NO debe agotar Claude durante la ventana
+        // de descanso. Antes bypaseaba el gate del rest-mode (línea 4429) y
+        // forzaba lanzamientos aunque estuviéramos en ventana, lo que rompía
+        // la garantía de Leo de que rebotes/forzados también esperan a que la
+        // ventana cierre. Aplicamos el mismo `isSkillAllowedNow` que el loop
+        // regular — si no permite, no forzamos y el breaker espera al próximo
+        // ciclo (no se incrementa consecutiveAllBlockedCycles porque el "no
+        // lanzar" acá es decisión intencional, no un deadlock real).
+        try {
+          const restCfg = (loadConfig() || {}).rest_mode || {};
+          const issueLbls = getIssueLabels(issue);
+          const verdict = restModeWindow.isSkillAllowedNow(skill, Date.now(), {
+            cfg: restCfg,
+            bypassLabels: issueLbls,
+            pipelineDir: PIPELINE,
+          });
+          if (!verdict.allowed) {
+            log('deadlock', `#${issue}: forzado bloqueado por rest-mode (skill=${skill}, reason=${verdict.reason}) — espera fin de ventana`);
+            return;
+          }
+        } catch (e) {
+          // Fail-open: si el gate falla, no bloqueamos el deadlock breaker.
+          log('deadlock', `rest-mode gate error en deadlock breaker (fail-open): ${e.message}`);
+        }
         const trabajandoPath = moveFile(archivo.path, trabajandoDir);
         lanzarAgenteClaude(skill, issue, trabajandoPath, pipelineName, fase, config);
       } catch (e) {


### PR DESCRIPTION
## Resumen

Cierra el ultimo bypass del gate de descanso. Hasta hoy, el **deadlock breaker** (`pulpo.js:4715`) podia forzar lanzamientos durante la ventana de descanso, mientras que el loop principal de lanzamiento si respetaba el gate desde #2890. Eso rompia la garantia operativa que pidio Leo: durante la ventana, **ningun camino de ejecucion** debe agotar Claude (ni nuevos, ni rebotes, ni forzados).

## Por que esto importa ahora

Tuvimos consumo anomalo el fin de semana 2026-05-31 → 2026-06-01. Causa raiz inicial: `sunday: []` en `rest-mode.json` dejaba el domingo sin ventana, por eso el loop del bug del handler dep-block (#3774) reencolaba toda la noche.

Ya cerramos:
- #3774 — handler dep-block que generaba el loop (mergeado en `f84f0c87`).
- Ventana ampliada en `rest-mode.json` a **18:00 → 12:00 del dia siguiente, todos los dias** (estado runtime, no va en repo).

Falta cerrar la rendija del deadlock breaker, que es lo que entrega este PR.

## Causa raiz

- `restModeWindow.isSkillAllowedNow(skill, ...)` se aplica en `pulpo.js:4429`, dentro del loop sobre archivos de `pendiente/`.
- Si `eligibleForGateCount > 0 && gateBlockedCount === eligibleForGateCount`, el breaker dispara `handleDeadlock(...)` (linea 4685) y, si elige un candidato, lo lanza **sin volver a chequear el gate** (linea 4716).
- Rebotes (infra, cross-phase, dependency_block) si pasan por el gate porque vuelven a `pendiente/` y el loop normal los procesa. Solo el breaker bypaseaba.

## Fix

Antes de `lanzarAgenteClaude` en el breaker, evaluar `isSkillAllowedNow` con la misma config (`loadConfig().rest_mode`) y las labels del issue (incluyendo `bypassLabels` como `priority:critical`). Si el verdict niega, log con motivo y `return` — no se incrementa `consecutiveAllBlockedCycles` porque la decision es intencional, no un deadlock real. Fail-open ante excepcion del gate (igual filosofia que linea 4438).

## Como probar

1. Activar manualmente `rest-mode.json` con ventana abierta `00:00 → 23:59` para todos los dias.
2. Forzar deadlock sintetico (varios archivos en `pendiente/` bloqueados por gate predictivo).
3. Verificar en el log: `#<N>: forzado bloqueado por rest-mode (skill=..., reason=within_window_non_deterministic) — espera fin de ventana`.
4. Confirmar que el breaker **no** llama a `lanzarAgenteClaude`.
5. Desactivar rest-mode → el breaker vuelve a forzar normalmente.

## Test plan

- [x] `node -c .pipeline/pulpo.js` (syntax)
- [ ] Validar en runtime que durante ventana de descanso, el deadlock breaker omite forzado
- [ ] Confirmar que con `priority:critical` el breaker SI fuerza (bypass label vigente)

## qa:skipped — justificacion

Cambio puro de infra del pipeline (`pulpo.js`). No toca producto de usuario, no afecta app:client/business/delivery, no afecta backend API. Mismo criterio que #3774/#3789 mergeado hace 2hs.

Closes #3790

🤖 Generated with [Claude Code](https://claude.com/claude-code)