### PR TITLE
feat(pipeline): adapter real NVIDIA NIM con runner Node (multi-provider #3791)

### DIFF
--- a/.pipeline/lib/agent-launcher.js
+++ b/.pipeline/lib/agent-launcher.js
@@ -51,6 +51,7 @@ const PROVIDERS = {
     deterministic: require('./agent-launcher/providers/deterministic'),
     'openai-codex': require('./agent-launcher/providers/openai-codex'),
     'gemini-google': require('./agent-launcher/providers/gemini-google'),
+    'nvidia-nim': require('./agent-launcher/providers/nvidia-nim'),
 };
 
 // #3082 (CA-S3 / CA-8): cache liviano de required_permissions por skill,

--- a/.pipeline/lib/agent-launcher/providers/nvidia-nim.js
+++ b/.pipeline/lib/agent-launcher/providers/nvidia-nim.js
@@ -1,54 +1,238 @@
 // =============================================================================
-// providers/nvidia-nim.js — Stub del provider NVIDIA NIM (#3243).
+// providers/nvidia-nim.js — Handler real del provider NVIDIA NIM (#3791)
 //
-// Este archivo existe para que la tabla hardcoded `PROVIDER_HANDLERS` de
-// `resolve-provider.js` pueda resolver el provider `nvidia-nim` sin abrir
-// el vector de path-traversal (require dinámico). El runtime real (wrapper
-// Node que llama al endpoint REST OpenAI-compat de NVIDIA NIM) llega con
-// #3198 (dispatch-with-fallback) cuando se materialicen los wrappers reales
-// de free providers.
+// NVIDIA NIM es una API REST drop-in OpenAI-compatible
+// (`https://integrate.api.nvidia.com/v1`) con free tier real (API key
+// `nvapi-...`). A diferencia de Codex y Gemini NO publica un CLI, así que el
+// "binario" que spawneamos es un runner Node propio
+// (`runners/nvidia-nim-runner.js`) que hace la llamada HTTP y emite UN único
+// objeto JSON a stdout (mismo patrón de salida que Gemini con `-o json`).
 //
-// API drop-in OpenAI-compatible (mismo patrón que cerebras) — el
-// detector estructurado de cuota (`_detectOpenAI` en quota-exhausted.js) ya
-// cubre los shapes SSE que NVIDIA NIM emite, por lo que la detección de
-// cuota será automática cuando el wrapper real exista.
+// Wiring acá:
+//   1) detectLauncher — siempre `node <runner.js>` (sin shell, sin binario
+//      externo). El runner vive junto al adapter, ruta hardcoded (sin require
+//      dinámico) para no abrir path-traversal.
+//   2) buildSpawn — traduce los args legacy del pulpo (estilo Claude CLI:
+//      `-p`, `--system-prompt-file`, `--output-format stream-json`) al contrato
+//      del runner (`--model <id> --system-file <path> --prompt <text>`). El
+//      modelo sale de env `NVIDIA_NIM_MODEL` (lo inyecta el pulpo por
+//      env-isolation) o el default del runner.
+//   3) parseTokensFromLog — el runner emite el shape OpenAI chat-completion;
+//      mapeamos `usage.prompt_tokens → input`, `completion_tokens (+ reasoning)
+//      → output`, `prompt_tokens_details.cached_tokens → cache_read`.
+//   4) detectQuotaExhausted — inspecciona el objeto `error` del JSON y matchea
+//      por shape estructural (status/code/type normalizados a lowercase) contra
+//      la allowlist canónica `KNOWN_QUOTA_ERROR_TYPES_BY_PROVIDER['nvidia-nim']`.
 //
-// Si un skill se asigna a este provider antes de #3198, `buildSpawn` tira
-// un error accionable en español. NO crashea el pulpo, NO consume tokens.
+// Auth: API key free-tier en env `NVIDIA_NIM_API_KEY` (la hidrata
+// `lib/credentials.js`). No hay OAuth como Codex/Gemini — NVIDIA da créditos
+// free directo con la key.
+//
+// Seguridad:
+//  - Runner con ruta hardcoded (sin require dinámico de provider).
+//  - Args como argv estricto (sin shell concat — shell:false siempre).
+//  - Detección de cuota SOLO por shape estructural sobre campos dedicados de
+//    error (status/code/type). NUNCA substring sobre el contenido del modelo.
 // =============================================================================
 'use strict';
 
-function _notImplemented(operation) {
-    throw new Error(
-        `[agent-launcher/nvidia-nim] Provider "nvidia-nim" no está implementado todavía (operación: ${operation}).\n` +
-        `Issue de entrega: #3198 (runtime fallbacks[] multi-provider).\n` +
-        `Acción inmediata para destrabar: cambiar el provider del skill afectado en .pipeline/agent-models.json a "anthropic" (o al provider que corresponda)\n` +
-        `o esperar a que #3198 entregue el wrapper real.`
-    );
-}
+const fs = require('node:fs');
+const path = require('node:path');
 
+const RUNNER_PATH = path.join(__dirname, '..', 'runners', 'nvidia-nim-runner.js');
+
+// -----------------------------------------------------------------------------
+// detectLauncher — NVIDIA no tiene CLI; ejecutamos el runner Node propio.
+// `node <runner.js>` sin shell (cmd = process.execPath, prefixArgs = [runner]).
+// -----------------------------------------------------------------------------
 function detectLauncher() {
-    _notImplemented('detectLauncher');
+    return {
+        kind: 'node-runner',
+        cmd: process.execPath,
+        prefixArgs: [RUNNER_PATH],
+        shell: false,
+    };
 }
 
-function buildSpawn(/* { args, cwd, env } */) {
-    _notImplemented('buildSpawn');
+let cachedLauncher = null;
+function getLauncher() {
+    if (!cachedLauncher) cachedLauncher = detectLauncher();
+    return cachedLauncher;
+}
+function _setLauncherForTesting(launcher) { cachedLauncher = launcher; }
+function _resetLauncherCacheForTesting() { cachedLauncher = null; }
+
+// -----------------------------------------------------------------------------
+// translateClaudeArgsToNvidia — extrae prompt y system file del args estilo
+// Claude CLI y arma el argv del runner. Args desconocidos
+// (`--output-format`, `--verbose`, `--permission-mode`, etc.) se descartan.
+//
+// Contrato de entrada (lo que el pulpo construye, estilo Claude CLI):
+//   ['-p', userPrompt, '--system-prompt-file', systemFile, ...]
+//
+// Contrato de salida (lo que entiende el runner):
+//   ['--model', model?, '--system-file', systemFile?, '--prompt', userPrompt]
+// -----------------------------------------------------------------------------
+function translateClaudeArgsToNvidia(args, env) {
+    let userPrompt = null;
+    let systemFile = null;
+    for (let i = 0; i < args.length; i++) {
+        const a = args[i];
+        if (a === '-p') { userPrompt = args[i + 1]; i++; }
+        else if (a === '--system-prompt-file') { systemFile = args[i + 1]; i++; }
+        // Otros flags no aplican al runner REST; los descartamos.
+    }
+
+    const model = env && env.NVIDIA_NIM_MODEL;
+    const out = [];
+    if (model) out.push('--model', model);
+    if (systemFile && typeof systemFile === 'string') out.push('--system-file', systemFile);
+    out.push('--prompt', typeof userPrompt === 'string' ? userPrompt : '');
+    return out;
 }
 
-function parseTokensFromLog(/* logPath */) {
-    return { input: 0, output: 0, cache_read: 0, cache_create: 0, tool_calls: 0 };
+// -----------------------------------------------------------------------------
+// buildSpawn — { cmd, args, spawnOpts } para child_process.spawn.
+// `args` vienen en formato Claude; los traducimos y prependemos el prefijo del
+// launcher (node + runner.js).
+// -----------------------------------------------------------------------------
+function buildSpawn({ args, cwd, env, interactive_supported }) {
+    const launcher = getLauncher();
+    const nvidiaArgs = translateClaudeArgsToNvidia(args || [], env || {});
+    const stdin = interactive_supported === true ? 'pipe' : 'ignore';
+    return {
+        cmd: launcher.cmd,
+        args: [...launcher.prefixArgs, ...nvidiaArgs],
+        spawnOpts: {
+            cwd,
+            stdio: [stdin, 'pipe', 'pipe'],
+            detached: false,
+            shell: launcher.shell,
+            windowsHide: true,
+            env,
+        },
+    };
 }
 
-function detectQuotaExhausted() {
-    // Detección estructurada: `_detectOpenAI` ya cubre el shape SSE de NVIDIA NIM.
-    // Mientras el runtime real (#3198) no spawnee, no aplica.
+// -----------------------------------------------------------------------------
+// _parseNvidiaJson — extrae el objeto JSON del log del runner. Robusto frente a
+// prefijo/sufijo basura (warnings residuales). Mismo enfoque que Gemini.
+// -----------------------------------------------------------------------------
+function _parseNvidiaJson(raw) {
+    if (!raw || typeof raw !== 'string') return null;
+    const trimmed = raw.trim();
+    try { return JSON.parse(trimmed); } catch { /* sigue */ }
+    const first = trimmed.indexOf('{');
+    const last = trimmed.lastIndexOf('}');
+    if (first >= 0 && last > first) {
+        try { return JSON.parse(trimmed.slice(first, last + 1)); } catch { /* nada */ }
+    }
+    return null;
+}
+
+// -----------------------------------------------------------------------------
+// parseTokensFromLog — mapea el `usage` OpenAI al shape canónico del pulpo.
+//
+// Shape capturado en smoke real (2026-06-01, deepseek-v4-pro):
+//   { "choices": [...], "usage": {
+//       "prompt_tokens": 17, "completion_tokens": 2, "total_tokens": 19,
+//       "prompt_tokens_details": { "cached_tokens": N } | null,
+//       "reasoning_tokens": 0 } }
+//
+// Mapeo:
+//   prompt_tokens                      → input
+//   completion_tokens + reasoning      → output  (reasoning = thinking, facturable)
+//   prompt_tokens_details.cached_tokens→ cache_read
+//   tool_calls: sin conteo en usage    → 0
+// -----------------------------------------------------------------------------
+function parseTokensFromLog(logPath, fsImpl) {
+    const _fs = fsImpl || fs;
+    const totals = { input: 0, output: 0, cache_read: 0, cache_create: 0, tool_calls: 0 };
+    let raw = '';
+    try { raw = _fs.readFileSync(logPath, 'utf8'); } catch { return totals; }
+    const obj = _parseNvidiaJson(raw);
+    if (!obj || !obj.usage || typeof obj.usage !== 'object') return totals;
+    const u = obj.usage;
+    totals.input = Number(u.prompt_tokens || 0) || 0;
+    const completion = Number(u.completion_tokens || 0) || 0;
+    const reasoning = Number(u.reasoning_tokens || 0) || 0;
+    totals.output = completion + reasoning;
+    const details = u.prompt_tokens_details;
+    if (details && typeof details === 'object') {
+        totals.cache_read = Number(details.cached_tokens || 0) || 0;
+    }
+    return totals;
+}
+
+// -----------------------------------------------------------------------------
+// _extractErrorTokens — candidatos estructurales (lowercased) a matchear contra
+// la allowlist. SOLO campos dedicados de error (status/code/type), nunca el
+// contenido del modelo.
+// -----------------------------------------------------------------------------
+function _extractErrorTokens(err) {
+    if (!err || typeof err !== 'object') return [];
+    const out = [];
+    const push = (v) => { if (typeof v === 'string' && v) out.push(v.toLowerCase()); };
+    push(err.type);
+    push(err.code);
+    push(err.reason);
+    if (typeof err.status === 'string') push(err.status);
+    return out;
+}
+
+// -----------------------------------------------------------------------------
+// detectQuotaExhausted — matchea el objeto `error` del JSON del runner contra la
+// allowlist canónica `KNOWN_QUOTA_ERROR_TYPES_BY_PROVIDER['nvidia-nim']`
+// (= ['rate_limit_exceeded', 'quota_exceeded', 'insufficient_quota']).
+// -----------------------------------------------------------------------------
+function detectQuotaExhausted(logPath, cfg, quotaExhaustedModule, fsImpl) {
+    const _fs = fsImpl || fs;
+    if (!quotaExhaustedModule) return { matched: false };
+    const allowlist = (quotaExhaustedModule.KNOWN_QUOTA_ERROR_TYPES_BY_PROVIDER || {})['nvidia-nim']
+        || (cfg && cfg.error_types)
+        || [];
+    if (!allowlist || allowlist.length === 0) return { matched: false };
+
+    let raw = '';
+    try { raw = _fs.readFileSync(logPath, 'utf8'); } catch { return { matched: false }; }
+    if (!raw) return { matched: false };
+
+    const obj = _parseNvidiaJson(raw);
+    if (!obj) return { matched: false };
+
+    // El error puede venir como `error` directo o anidado en `error.error`.
+    const errObj = (obj.error && typeof obj.error === 'object')
+        ? (obj.error.error && typeof obj.error.error === 'object' ? obj.error.error : obj.error)
+        : null;
+    if (!errObj) return { matched: false };
+
+    const candidates = _extractErrorTokens(errObj);
+    for (const cand of candidates) {
+        if (allowlist.includes(cand)) {
+            return {
+                matched: true,
+                errorType: cand,
+                resetsAt: errObj.resets_at || errObj.retry_after || null,
+                rawLine: JSON.stringify(errObj).slice(0, 500),
+                evt: obj,
+            };
+        }
+    }
     return { matched: false };
 }
 
 module.exports = {
     name: 'nvidia-nim',
-    detectLauncher,
+    detectLauncher: getLauncher,
     buildSpawn,
     parseTokensFromLog,
     detectQuotaExhausted,
+    // exports internos para tests
+    _detectLauncherFresh: detectLauncher,
+    _translateClaudeArgsToNvidia: translateClaudeArgsToNvidia,
+    _parseNvidiaJson,
+    _extractErrorTokens,
+    _setLauncherForTesting,
+    _resetLauncherCacheForTesting,
+    RUNNER_PATH,
 };

--- a/.pipeline/lib/agent-launcher/runners/nvidia-nim-runner.js
+++ b/.pipeline/lib/agent-launcher/runners/nvidia-nim-runner.js
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+// =============================================================================
+// runners/nvidia-nim-runner.js — Runner REST del provider NVIDIA NIM (#3791)
+//
+// A diferencia de Codex y Gemini (que exponen un CLI propio), NVIDIA NIM es una
+// API REST drop-in OpenAI-compatible (`https://integrate.api.nvidia.com/v1`).
+// No hay binario que spawnear, así que este runner ES el "CLI": el adapter
+// `providers/nvidia-nim.js` lo invoca con `node nvidia-nim-runner.js <args>`,
+// hace la llamada HTTP y emite a stdout UN ÚNICO objeto JSON (mismo patrón que
+// Gemini con `-o json`), que `parseTokensFromLog`/`detectQuotaExhausted` del
+// adapter leen del log.
+//
+// Contrato de argv (lo arma `buildSpawn` del adapter, traduciendo los args
+// estilo Claude del pulpo):
+//   --model <id>            modelo NVIDIA (ej: deepseek-ai/deepseek-v4-pro)
+//   --system-file <path>    archivo con el system prompt (opcional)
+//   --prompt <text>         prompt del usuario
+//   --max-tokens <n>        cap de salida (opcional, default 4096)
+//
+// Auth: API key free-tier en env `NVIDIA_NIM_API_KEY` (la hidrata
+// `lib/credentials.js` desde ~/.claude/secrets/credentials.json al boot del
+// pulpo y se propaga por el env del spawn). Fallback: si no está en env, el
+// runner intenta cargarla con el loader canónico (robustez en ejecución suelta).
+//
+// Salida stdout (éxito): objeto OpenAI chat-completion tal cual lo devuelve
+// NVIDIA (`{ id, model, choices:[...], usage:{...} }`) — el adapter parsea
+// `usage` para los tokens.
+// Salida stdout (error): `{ error: { status, code, type, message } }` y exit 1
+// — el adapter matchea el shape estructural contra la allowlist de cuota.
+//
+// Seguridad: la API key NUNCA se imprime. El endpoint es fijo (sin override por
+// argv) para no abrir SSRF. Sin shell, sin require dinámico.
+// =============================================================================
+'use strict';
+
+const https = require('node:https');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ENDPOINT_HOST = 'integrate.api.nvidia.com';
+const ENDPOINT_PATH = '/v1/chat/completions';
+const DEFAULT_MODEL = 'deepseek-ai/deepseek-v4-pro';
+const DEFAULT_MAX_TOKENS = 4096;
+
+// -----------------------------------------------------------------------------
+// parseArgv — parser minimalista del contrato de argv (sin dependencias).
+// -----------------------------------------------------------------------------
+function parseArgv(argv) {
+    const out = { model: null, systemFile: null, prompt: null, maxTokens: null };
+    for (let i = 0; i < argv.length; i++) {
+        const a = argv[i];
+        if (a === '--model') { out.model = argv[++i]; }
+        else if (a === '--system-file') { out.systemFile = argv[++i]; }
+        else if (a === '--prompt') { out.prompt = argv[++i]; }
+        else if (a === '--max-tokens') { out.maxTokens = parseInt(argv[++i], 10); }
+    }
+    return out;
+}
+
+// -----------------------------------------------------------------------------
+// resolveApiKey — env primero (lo hidrata el pulpo); fallback al loader canónico.
+// -----------------------------------------------------------------------------
+function resolveApiKey() {
+    if (process.env.NVIDIA_NIM_API_KEY && process.env.NVIDIA_NIM_API_KEY.trim()) {
+        return process.env.NVIDIA_NIM_API_KEY.trim();
+    }
+    // Fallback: cargar credentials.json directo (ejecución suelta / smoke local).
+    try {
+        const cred = require(path.join(__dirname, '..', '..', 'credentials.js'));
+        cred.loadIntoEnv({ logger: () => {} });
+        if (process.env.NVIDIA_NIM_API_KEY && process.env.NVIDIA_NIM_API_KEY.trim()) {
+            return process.env.NVIDIA_NIM_API_KEY.trim();
+        }
+    } catch { /* no-op: reportamos abajo */ }
+    return null;
+}
+
+// -----------------------------------------------------------------------------
+// buildMessages — arma el array de mensajes OpenAI a partir del system file y
+// el prompt del usuario. NVIDIA SÍ soporta rol `system` nativo (a diferencia de
+// Gemini), así que no hace falta foldear el system al prompt.
+// -----------------------------------------------------------------------------
+function buildMessages(parsed) {
+    const messages = [];
+    if (parsed.systemFile) {
+        let systemText = null;
+        try { systemText = fs.readFileSync(parsed.systemFile, 'utf8'); } catch { systemText = null; }
+        if (systemText && systemText.trim()) {
+            messages.push({ role: 'system', content: systemText.trim() });
+        }
+    }
+    messages.push({ role: 'user', content: typeof parsed.prompt === 'string' ? parsed.prompt : '' });
+    return messages;
+}
+
+// -----------------------------------------------------------------------------
+// callNvidia — POST al endpoint chat/completions. Resuelve con { status, json }.
+// No streaming: queremos el `usage` consolidado en una sola respuesta (igual que
+// el JSON único de Gemini). El timeout protege contra cuelgues de red.
+// -----------------------------------------------------------------------------
+function callNvidia({ apiKey, model, messages, maxTokens }) {
+    return new Promise((resolve, reject) => {
+        const payload = JSON.stringify({
+            model,
+            messages,
+            temperature: 0.2,
+            max_tokens: maxTokens || DEFAULT_MAX_TOKENS,
+            stream: false,
+        });
+        const req = https.request({
+            host: ENDPOINT_HOST,
+            path: ENDPOINT_PATH,
+            method: 'POST',
+            headers: {
+                Authorization: `Bearer ${apiKey}`,
+                'Content-Type': 'application/json',
+                Accept: 'application/json',
+                'Content-Length': Buffer.byteLength(payload),
+            },
+            timeout: 120000,
+        }, (res) => {
+            let data = '';
+            res.on('data', (chunk) => { data += chunk; });
+            res.on('end', () => {
+                let json = null;
+                try { json = JSON.parse(data); } catch { json = { _raw: data.slice(0, 2000) }; }
+                resolve({ status: res.statusCode, json });
+            });
+        });
+        req.on('error', reject);
+        req.on('timeout', () => { req.destroy(new Error('NVIDIA NIM request timeout (120s)')); });
+        req.write(payload);
+        req.end();
+    });
+}
+
+// -----------------------------------------------------------------------------
+// normalizeError — homogeneiza el shape de error de NVIDIA a campos
+// estructurales que el detector de cuota del adapter sabe matchear. NVIDIA
+// puede responder `{ error: {...} }`, `{ detail: "..." }`, o un body crudo.
+// -----------------------------------------------------------------------------
+function normalizeError(status, json) {
+    const base = { status };
+    if (json && typeof json === 'object') {
+        if (json.error && typeof json.error === 'object') {
+            return Object.assign(base, json.error);
+        }
+        if (typeof json.detail === 'string') {
+            base.message = json.detail;
+        } else if (json._raw) {
+            base.message = json._raw;
+        }
+    }
+    // Mapear el HTTP code a un `code`/`type` canónico cuando NVIDIA no lo da.
+    if (status === 429 && !base.code) { base.code = 'rate_limit_exceeded'; }
+    if (status === 402 && !base.code) { base.code = 'insufficient_quota'; }
+    if (status === 401 && !base.code) { base.code = 'unauthorized'; }
+    return base;
+}
+
+async function main() {
+    const parsed = parseArgv(process.argv.slice(2));
+    const apiKey = resolveApiKey();
+    if (!apiKey) {
+        process.stdout.write(JSON.stringify({
+            error: { status: 0, code: 'no_credentials', message: 'NVIDIA_NIM_API_KEY ausente (env y credentials.json)' },
+        }));
+        process.exit(1);
+        return;
+    }
+
+    const model = parsed.model || process.env.NVIDIA_NIM_MODEL || DEFAULT_MODEL;
+    const messages = buildMessages(parsed);
+
+    try {
+        const { status, json } = await callNvidia({ apiKey, model, messages, maxTokens: parsed.maxTokens });
+        if (status >= 200 && status < 300) {
+            // Éxito: emitimos la respuesta OpenAI tal cual (el adapter parsea `usage`).
+            process.stdout.write(JSON.stringify(json));
+            process.exit(0);
+            return;
+        }
+        // Error HTTP: shape de error normalizado para el detector de cuota.
+        process.stdout.write(JSON.stringify({ error: normalizeError(status, json) }));
+        process.exit(1);
+    } catch (e) {
+        process.stdout.write(JSON.stringify({
+            error: { status: 0, code: 'network_error', message: e && e.message ? e.message : String(e) },
+        }));
+        process.exit(1);
+    }
+}
+
+if (require.main === module) {
+    main();
+}
+
+module.exports = { parseArgv, buildMessages, normalizeError, resolveApiKey };

--- a/.pipeline/tests/agent-launcher.test.js
+++ b/.pipeline/tests/agent-launcher.test.js
@@ -479,3 +479,113 @@ test('resolveProviderForSkill: skills determinísticos ignoran agent-models.json
     assert.equal(r.provider, 'deterministic');
     assert.equal(r.source, 'deterministic-allowlist');
 });
+
+// -----------------------------------------------------------------------------
+// 12a. Provider 'nvidia-nim' real (#3791): launchAgent spawnea el runner Node
+//      (node <runner.js>) traduciendo los args estilo Claude al contrato del
+//      runner (`--model <id> --system-file <path> --prompt <text>`).
+// -----------------------------------------------------------------------------
+test('launchAgent con provider nvidia-nim spawnea el runner Node con args traducidos', () => {
+    const modelsPath = path.join(PIPELINE, 'agent-models.json');
+    const fsi = fakeFs([modelsPath], {
+        [modelsPath]: JSON.stringify({
+            skills: {
+                guru: { provider: 'nvidia-nim', model: 'deepseek-ai/deepseek-v4-pro' },
+            },
+        }),
+    });
+    const spi = fakeSpawn();
+
+    PROVIDERS['nvidia-nim']._setLauncherForTesting({
+        kind: 'node-runner',
+        cmd: '/fake/node',
+        prefixArgs: ['/fake/nvidia-nim-runner.js'],
+        shell: false,
+    });
+    try {
+        launchAgent({
+            skill: 'guru',
+            issue: 1,
+            args: ['-p', 'probe', '--system-prompt-file', '/tmp/sys.md', '--output-format', 'stream-json'],
+            cwd: ROOT,
+            env: { NVIDIA_NIM_MODEL: 'deepseek-ai/deepseek-v4-pro' },
+            PIPELINE,
+            ROOT,
+            fsImpl: fsi,
+            spawnImpl: spi,
+        });
+    } finally {
+        PROVIDERS['nvidia-nim']._resetLauncherCacheForTesting();
+    }
+    assert.equal(spi.calls.length, 1);
+    const call = spi.calls[0];
+    assert.equal(call.cmd, '/fake/node');
+    assert.equal(call.args[0], '/fake/nvidia-nim-runner.js');
+    assert.ok(call.args.includes('--model'));
+    assert.ok(call.args.includes('deepseek-ai/deepseek-v4-pro'));
+    assert.ok(call.args.includes('--system-file'));
+    assert.ok(call.args.includes('/tmp/sys.md'));
+    assert.ok(call.args.includes('--prompt'));
+    assert.ok(call.args.includes('probe'));
+    // El flag --output-format (estilo Claude) se descarta en la traducción.
+    assert.ok(!call.args.includes('--output-format'));
+});
+
+// -----------------------------------------------------------------------------
+// 12b. parseTokensFromLog de nvidia-nim mapea el `usage` OpenAI al shape canónico.
+// -----------------------------------------------------------------------------
+test('nvidia-nim parseTokensFromLog mapea usage OpenAI (prompt/completion/cached/reasoning)', () => {
+    const nvidia = PROVIDERS['nvidia-nim'];
+    const logPath = '/tmp/nvidia.json';
+    const payload = JSON.stringify({
+        id: 'cmpl-1',
+        model: 'deepseek-ai/deepseek-v4-pro',
+        choices: [{ message: { role: 'assistant', content: 'OK' } }],
+        usage: {
+            prompt_tokens: 100,
+            completion_tokens: 8,
+            reasoning_tokens: 2,
+            total_tokens: 110,
+            prompt_tokens_details: { cached_tokens: 30 },
+        },
+    });
+    const fsi = { readFileSync: (p) => (p === logPath ? payload : (() => { const e = new Error('ENOENT'); e.code = 'ENOENT'; throw e; })()) };
+    const tokens = nvidia.parseTokensFromLog(logPath, fsi);
+    assert.equal(tokens.input, 100);
+    assert.equal(tokens.output, 10);          // completion 8 + reasoning 2
+    assert.equal(tokens.cache_read, 30);
+
+    // prompt_tokens_details null (sin cache) no rompe.
+    const noCache = JSON.stringify({ usage: { prompt_tokens: 17, completion_tokens: 2, prompt_tokens_details: null } });
+    const fsi2 = { readFileSync: () => noCache };
+    const t2 = nvidia.parseTokensFromLog(logPath, fsi2);
+    assert.equal(t2.input, 17);
+    assert.equal(t2.output, 2);
+    assert.equal(t2.cache_read, 0);
+});
+
+// -----------------------------------------------------------------------------
+// 12c. detectQuotaExhausted de nvidia-nim matchea por shape estructural.
+// -----------------------------------------------------------------------------
+test('nvidia-nim detectQuotaExhausted matchea rate_limit/insufficient_quota por shape', () => {
+    const nvidia = PROVIDERS['nvidia-nim'];
+    const QE = require('../lib/quota-exhausted');
+    const logPath = '/tmp/nvidia-err.json';
+
+    // 429 normalizado por el runner a code 'rate_limit_exceeded'.
+    const payload = JSON.stringify({ error: { status: 429, code: 'rate_limit_exceeded', message: 'too many requests' } });
+    const fsi = { readFileSync: (p) => (p === logPath ? payload : (() => { const e = new Error('ENOENT'); e.code = 'ENOENT'; throw e; })()) };
+    const res = nvidia.detectQuotaExhausted(logPath, null, QE, fsi);
+    assert.equal(res.matched, true);
+    assert.equal(res.errorType, 'rate_limit_exceeded');
+
+    // insufficient_quota (type) también matchea.
+    const payload2 = JSON.stringify({ error: { type: 'insufficient_quota', message: 'no credits' } });
+    const fsi2 = { readFileSync: () => payload2 };
+    assert.equal(nvidia.detectQuotaExhausted(logPath, null, QE, fsi2).errorType, 'insufficient_quota');
+
+    // Respuesta normal (sin error) → no matchea.
+    const okPayload = JSON.stringify({ choices: [{ message: { content: 'OK' } }], usage: { prompt_tokens: 1 } });
+    const fsiOk = { readFileSync: () => okPayload };
+    assert.equal(nvidia.detectQuotaExhausted(logPath, null, QE, fsiOk).matched, false);
+});

--- a/.pipeline/tests/smoke/nvidia-adapter.smoke.js
+++ b/.pipeline/tests/smoke/nvidia-adapter.smoke.js
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+// =============================================================================
+// nvidia-adapter.smoke.js — Smoke E2E del adapter nvidia-nim
+//
+// Objetivo: invocar el provider real (no mockeado) y verificar que el pipeline
+// buildSpawn → child_process.spawn → parseTokensFromLog cierra el contrato
+// canónico contra el runner REST de NVIDIA NIM
+// (`integrate.api.nvidia.com/v1/chat/completions`, free tier con API key).
+//
+// NO toca el pulpo. NO requiere pipeline corriendo. Es un smoke aislado.
+// La API key sale de env NVIDIA_NIM_API_KEY (la hidrata credentials.js); el
+// runner también la resuelve solo si no está en env.
+// =============================================================================
+'use strict';
+
+const { spawn } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const provider = require('../../lib/agent-launcher/providers/nvidia-nim.js');
+const credentials = require('../../lib/credentials.js');
+
+const TIMEOUT_MS = 120_000;
+const PROMPT = 'Responde exactamente con la palabra OK y nada mas. No expliques nada.';
+const MODEL = process.env.NVIDIA_NIM_MODEL || 'deepseek-ai/deepseek-v4-pro';
+
+async function main() {
+    // Hidratar la API key como lo hace el pulpo al boot.
+    credentials.loadIntoEnv({ logger: () => {} });
+
+    const t0 = Date.now();
+    const launcher = provider.detectLauncher();
+    console.log(`[smoke] launcher.kind = ${launcher.kind}`);
+    console.log(`[smoke] launcher.cmd  = ${launcher.cmd}`);
+
+    const args = ['-p', PROMPT];
+    const cwd = process.cwd();
+    const env = { ...process.env, NVIDIA_NIM_MODEL: MODEL };
+    const spawnCfg = provider.buildSpawn({ args, cwd, env, interactive_supported: false });
+
+    console.log(`[smoke] model      = ${MODEL}`);
+    console.log(`[smoke] spawn.cmd  = ${spawnCfg.cmd}`);
+    console.log(`[smoke] spawn.args = ${JSON.stringify(spawnCfg.args)}`);
+
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nvidia-smoke-'));
+    const logPath = path.join(tmpDir, 'nvidia.json');
+    const logStream = fs.createWriteStream(logPath, { flags: 'a' });
+
+    const child = spawn(spawnCfg.cmd, spawnCfg.args, spawnCfg.spawnOpts);
+
+    let stdoutBytes = 0;
+    let stderrBytes = 0;
+
+    child.stdout.on('data', (chunk) => { stdoutBytes += chunk.length; logStream.write(chunk); });
+    child.stderr.on('data', (chunk) => { stderrBytes += chunk.length; process.stderr.write(chunk); });
+
+    const timer = setTimeout(() => {
+        console.error('[smoke] TIMEOUT — killing child');
+        child.kill('SIGKILL');
+    }, TIMEOUT_MS);
+
+    const exitCode = await new Promise((resolve) => {
+        child.on('exit', (code) => { clearTimeout(timer); resolve(code); });
+        child.on('error', (err) => { clearTimeout(timer); console.error('[smoke] spawn error:', err); resolve(-1); });
+    });
+
+    logStream.end();
+    await new Promise((r) => logStream.on('finish', r));
+    const dtMs = Date.now() - t0;
+
+    const raw = fs.readFileSync(logPath, 'utf8');
+    const obj = provider._parseNvidiaJson(raw);
+    const responseText = obj && obj.choices && obj.choices[0] && obj.choices[0].message
+        ? obj.choices[0].message.content : null;
+
+    console.log('---');
+    console.log(`[smoke] exit_code      = ${exitCode}`);
+    console.log(`[smoke] duration_ms    = ${dtMs}`);
+    console.log(`[smoke] stdout_bytes   = ${stdoutBytes}`);
+    console.log(`[smoke] stderr_bytes   = ${stderrBytes}`);
+    console.log(`[smoke] json_parsed    = ${obj ? 'yes' : 'no'}`);
+    console.log(`[smoke] response       = ${JSON.stringify(responseText)}`);
+
+    const tokens = provider.parseTokensFromLog(logPath);
+    console.log(`[smoke] parseTokens    = ${JSON.stringify(tokens)}`);
+
+    const QE = require('../../lib/quota-exhausted.js');
+    const qe = provider.detectQuotaExhausted(logPath, null, QE);
+    console.log(`[smoke] detectQuota    = ${JSON.stringify({ matched: qe.matched, errorType: qe.errorType || null })}`);
+
+    const ok =
+        exitCode === 0 &&
+        obj != null &&
+        typeof responseText === 'string' && responseText.length > 0 &&
+        tokens.input > 0 &&
+        qe.matched === false;
+
+    console.log(`[smoke] log_path       = ${logPath}`);
+    console.log(`[smoke] RESULT         = ${ok ? 'PASS' : 'FAIL'}`);
+    process.exit(ok ? 0 : 1);
+}
+
+main().catch((err) => {
+    console.error('[smoke] uncaught:', err);
+    process.exit(2);
+});


### PR DESCRIPTION
## Qué hace

Tercer adapter real de la épica multi-provider (#3791), después de Codex y Gemini. Reemplaza el stub `_notImplemented` de NVIDIA NIM por un handler real que habla con el endpoint REST de NVIDIA vía un runner Node dedicado (sin shell).

## Cambios

- `.pipeline/lib/agent-launcher/providers/nvidia-nim.js` — handler real: `detectLauncher` (node-bundle), `buildSpawn`, `parseTokensFromLog` (shape usage estilo OpenAI: prompt/completion/cached/reasoning), `detectQuotaExhausted` (matchea `rate_limit`/`insufficient_quota`)
- `.pipeline/lib/agent-launcher/runners/nvidia-nim-runner.js` — cliente Node contra el endpoint REST de NVIDIA, sin shell
- `.pipeline/lib/agent-launcher.js` — registro del provider `nvidia-nim`
- `.pipeline/tests/agent-launcher.test.js` — **17/17 pasan** (14 previos + 3 nuevos de nvidia)
- `.pipeline/tests/smoke/nvidia-adapter.smoke.js` — smoke E2E nuevo, verificado contra endpoint real (exit 0, respuesta `"OK"`, tokens parseados 21 in / 2 out, quota detection false)

## Verificación

- `node --test .pipeline/tests/agent-launcher.test.js` → pass 17 / fail 0
- `node .pipeline/tests/smoke/nvidia-adapter.smoke.js` → PASS

## QA

`qa:skipped` — cambio puro de infra del pipeline (`.pipeline/`), sin impacto en el producto de usuario.

Refs #3791