### PR TITLE
feat(pipeline): adapter real Cerebras con runner Node (multi-provider #3791)

### DIFF
--- a/.pipeline/lib/agent-launcher.js
+++ b/.pipeline/lib/agent-launcher.js
@@ -52,6 +52,7 @@ const PROVIDERS = {
     'openai-codex': require('./agent-launcher/providers/openai-codex'),
     'gemini-google': require('./agent-launcher/providers/gemini-google'),
     'nvidia-nim': require('./agent-launcher/providers/nvidia-nim'),
+    'cerebras': require('./agent-launcher/providers/cerebras'),
 };
 
 // #3082 (CA-S3 / CA-8): cache liviano de required_permissions por skill,

--- a/.pipeline/lib/agent-launcher/providers/cerebras.js
+++ b/.pipeline/lib/agent-launcher/providers/cerebras.js
@@ -1,53 +1,238 @@
 // =============================================================================
-// providers/cerebras.js — Stub del provider Cerebras (#3220).
+// providers/cerebras.js — Handler real del provider Cerebras (#3791)
 //
-// Este archivo existe para que la tabla hardcoded `PROVIDER_HANDLERS` de
-// `resolve-provider.js` pueda resolver el provider `cerebras` sin abrir
-// el vector de path-traversal (require dinámico). El runtime real
-// (wrapper Node que llama al endpoint REST OpenAI-compat de Cerebras)
-// llega con #3198.
+// Cerebras es una API REST drop-in OpenAI-compatible
+// (`https://api.cerebras.ai/v1`) con free tier real (API key `csk-...`). A
+// diferencia de Codex y Gemini NO publica un CLI, así que el "binario" que
+// spawneamos es un runner Node propio (`runners/cerebras-runner.js`) que hace
+// la llamada HTTP y emite UN único objeto JSON a stdout (mismo patrón que el
+// adapter de NVIDIA NIM y que Gemini con `-o json`).
 //
-// API drop-in OpenAI-compatible — el detector estructurado de cuota
-// (`_detectOpenAI` en quota-exhausted.js) ya cubre los shapes SSE que
-// Cerebras emite, por lo que la detección de cuota será automática cuando
-// el wrapper real exista.
+// Wiring acá:
+//   1) detectLauncher — siempre `node <runner.js>` (sin shell, sin binario
+//      externo). El runner vive junto al adapter, ruta hardcoded (sin require
+//      dinámico) para no abrir path-traversal.
+//   2) buildSpawn — traduce los args legacy del pulpo (estilo Claude CLI:
+//      `-p`, `--system-prompt-file`, `--output-format stream-json`) al contrato
+//      del runner (`--model <id> --system-file <path> --prompt <text>`). El
+//      modelo sale de env `CEREBRAS_MODEL` (lo inyecta el pulpo por
+//      env-isolation) o el default del runner (`gpt-oss-120b`; el free tier sólo
+//      sirve `gpt-oss-120b` y `zai-glm-4.7`, ambos modelos de razonamiento).
+//   3) parseTokensFromLog — el runner emite el shape OpenAI chat-completion;
+//      mapeamos `usage.prompt_tokens → input`, `completion_tokens (+ reasoning)
+//      → output`, `prompt_tokens_details.cached_tokens → cache_read`.
+//   4) detectQuotaExhausted — inspecciona el objeto `error` del JSON y matchea
+//      por shape estructural (status/code/type normalizados a lowercase) contra
+//      la allowlist canónica `KNOWN_QUOTA_ERROR_TYPES_BY_PROVIDER['cerebras']`.
 //
-// Si un skill se asigna a este provider antes de #3198, `buildSpawn` tira
-// un error accionable en español. NO crashea el pulpo, NO consume tokens.
+// Auth: API key free-tier en env `CEREBRAS_API_KEY` (la hidrata
+// `lib/credentials.js`). No hay OAuth como Codex/Gemini — Cerebras da créditos
+// free directo con la key.
+//
+// Seguridad:
+//  - Runner con ruta hardcoded (sin require dinámico de provider).
+//  - Args como argv estricto (sin shell concat — shell:false siempre).
+//  - Detección de cuota SOLO por shape estructural sobre campos dedicados de
+//    error (status/code/type). NUNCA substring sobre el contenido del modelo.
 // =============================================================================
 'use strict';
 
-function _notImplemented(operation) {
-    throw new Error(
-        `[agent-launcher/cerebras] Provider "cerebras" no está implementado todavía (operación: ${operation}).\n` +
-        `Issue de entrega: #3198 (runtime fallbacks[] multi-provider).\n` +
-        `Acción inmediata para destrabar: cambiar el provider del skill afectado en .pipeline/agent-models.json a "anthropic" (o al provider que corresponda)\n` +
-        `o esperar a que #3198 entregue el wrapper real.`
-    );
-}
+const fs = require('node:fs');
+const path = require('node:path');
 
+const RUNNER_PATH = path.join(__dirname, '..', 'runners', 'cerebras-runner.js');
+
+// -----------------------------------------------------------------------------
+// detectLauncher — Cerebras no tiene CLI; ejecutamos el runner Node propio.
+// `node <runner.js>` sin shell (cmd = process.execPath, prefixArgs = [runner]).
+// -----------------------------------------------------------------------------
 function detectLauncher() {
-    _notImplemented('detectLauncher');
+    return {
+        kind: 'node-runner',
+        cmd: process.execPath,
+        prefixArgs: [RUNNER_PATH],
+        shell: false,
+    };
 }
 
-function buildSpawn(/* { args, cwd, env } */) {
-    _notImplemented('buildSpawn');
+let cachedLauncher = null;
+function getLauncher() {
+    if (!cachedLauncher) cachedLauncher = detectLauncher();
+    return cachedLauncher;
+}
+function _setLauncherForTesting(launcher) { cachedLauncher = launcher; }
+function _resetLauncherCacheForTesting() { cachedLauncher = null; }
+
+// -----------------------------------------------------------------------------
+// translateClaudeArgsToCerebras — extrae prompt y system file del args estilo
+// Claude CLI y arma el argv del runner. Args desconocidos
+// (`--output-format`, `--verbose`, `--permission-mode`, etc.) se descartan.
+//
+// Contrato de entrada (lo que el pulpo construye, estilo Claude CLI):
+//   ['-p', userPrompt, '--system-prompt-file', systemFile, ...]
+//
+// Contrato de salida (lo que entiende el runner):
+//   ['--model', model?, '--system-file', systemFile?, '--prompt', userPrompt]
+// -----------------------------------------------------------------------------
+function translateClaudeArgsToCerebras(args, env) {
+    let userPrompt = null;
+    let systemFile = null;
+    for (let i = 0; i < args.length; i++) {
+        const a = args[i];
+        if (a === '-p') { userPrompt = args[i + 1]; i++; }
+        else if (a === '--system-prompt-file') { systemFile = args[i + 1]; i++; }
+        // Otros flags no aplican al runner REST; los descartamos.
+    }
+
+    const model = env && env.CEREBRAS_MODEL;
+    const out = [];
+    if (model) out.push('--model', model);
+    if (systemFile && typeof systemFile === 'string') out.push('--system-file', systemFile);
+    out.push('--prompt', typeof userPrompt === 'string' ? userPrompt : '');
+    return out;
 }
 
-function parseTokensFromLog(/* logPath */) {
-    return { input: 0, output: 0, cache_read: 0, cache_create: 0, tool_calls: 0 };
+// -----------------------------------------------------------------------------
+// buildSpawn — { cmd, args, spawnOpts } para child_process.spawn.
+// `args` vienen en formato Claude; los traducimos y prependemos el prefijo del
+// launcher (node + runner.js).
+// -----------------------------------------------------------------------------
+function buildSpawn({ args, cwd, env, interactive_supported }) {
+    const launcher = getLauncher();
+    const cerebrasArgs = translateClaudeArgsToCerebras(args || [], env || {});
+    const stdin = interactive_supported === true ? 'pipe' : 'ignore';
+    return {
+        cmd: launcher.cmd,
+        args: [...launcher.prefixArgs, ...cerebrasArgs],
+        spawnOpts: {
+            cwd,
+            stdio: [stdin, 'pipe', 'pipe'],
+            detached: false,
+            shell: launcher.shell,
+            windowsHide: true,
+            env,
+        },
+    };
 }
 
-function detectQuotaExhausted() {
-    // Detección estructurada: `_detectOpenAI` ya cubre el shape SSE de Cerebras.
-    // Mientras el runtime real (#3198) no spawnee, no aplica.
+// -----------------------------------------------------------------------------
+// _parseCerebrasJson — extrae el objeto JSON del log del runner. Robusto frente
+// a prefijo/sufijo basura (warnings residuales). Mismo enfoque que NVIDIA.
+// -----------------------------------------------------------------------------
+function _parseCerebrasJson(raw) {
+    if (!raw || typeof raw !== 'string') return null;
+    const trimmed = raw.trim();
+    try { return JSON.parse(trimmed); } catch { /* sigue */ }
+    const first = trimmed.indexOf('{');
+    const last = trimmed.lastIndexOf('}');
+    if (first >= 0 && last > first) {
+        try { return JSON.parse(trimmed.slice(first, last + 1)); } catch { /* nada */ }
+    }
+    return null;
+}
+
+// -----------------------------------------------------------------------------
+// parseTokensFromLog — mapea el `usage` OpenAI al shape canónico del pulpo.
+//
+// Shape OpenAI chat-completion que devuelve Cerebras:
+//   { "choices": [...], "usage": {
+//       "prompt_tokens": 17, "completion_tokens": 2, "total_tokens": 19,
+//       "prompt_tokens_details": { "cached_tokens": N } | null } }
+//
+// Mapeo:
+//   prompt_tokens                      → input
+//   completion_tokens + reasoning      → output  (reasoning = thinking, facturable)
+//   prompt_tokens_details.cached_tokens→ cache_read
+//   tool_calls: sin conteo en usage    → 0
+// -----------------------------------------------------------------------------
+function parseTokensFromLog(logPath, fsImpl) {
+    const _fs = fsImpl || fs;
+    const totals = { input: 0, output: 0, cache_read: 0, cache_create: 0, tool_calls: 0 };
+    let raw = '';
+    try { raw = _fs.readFileSync(logPath, 'utf8'); } catch { return totals; }
+    const obj = _parseCerebrasJson(raw);
+    if (!obj || !obj.usage || typeof obj.usage !== 'object') return totals;
+    const u = obj.usage;
+    totals.input = Number(u.prompt_tokens || 0) || 0;
+    const completion = Number(u.completion_tokens || 0) || 0;
+    const reasoning = Number(u.reasoning_tokens || 0) || 0;
+    totals.output = completion + reasoning;
+    const details = u.prompt_tokens_details;
+    if (details && typeof details === 'object') {
+        totals.cache_read = Number(details.cached_tokens || 0) || 0;
+    }
+    return totals;
+}
+
+// -----------------------------------------------------------------------------
+// _extractErrorTokens — candidatos estructurales (lowercased) a matchear contra
+// la allowlist. SOLO campos dedicados de error (status/code/type), nunca el
+// contenido del modelo.
+// -----------------------------------------------------------------------------
+function _extractErrorTokens(err) {
+    if (!err || typeof err !== 'object') return [];
+    const out = [];
+    const push = (v) => { if (typeof v === 'string' && v) out.push(v.toLowerCase()); };
+    push(err.type);
+    push(err.code);
+    push(err.reason);
+    if (typeof err.status === 'string') push(err.status);
+    return out;
+}
+
+// -----------------------------------------------------------------------------
+// detectQuotaExhausted — matchea el objeto `error` del JSON del runner contra la
+// allowlist canónica `KNOWN_QUOTA_ERROR_TYPES_BY_PROVIDER['cerebras']`
+// (= ['rate_limit_exceeded', 'quota_exceeded', ...]).
+// -----------------------------------------------------------------------------
+function detectQuotaExhausted(logPath, cfg, quotaExhaustedModule, fsImpl) {
+    const _fs = fsImpl || fs;
+    if (!quotaExhaustedModule) return { matched: false };
+    const allowlist = (quotaExhaustedModule.KNOWN_QUOTA_ERROR_TYPES_BY_PROVIDER || {})['cerebras']
+        || (cfg && cfg.error_types)
+        || [];
+    if (!allowlist || allowlist.length === 0) return { matched: false };
+
+    let raw = '';
+    try { raw = _fs.readFileSync(logPath, 'utf8'); } catch { return { matched: false }; }
+    if (!raw) return { matched: false };
+
+    const obj = _parseCerebrasJson(raw);
+    if (!obj) return { matched: false };
+
+    // El error puede venir como `error` directo o anidado en `error.error`.
+    const errObj = (obj.error && typeof obj.error === 'object')
+        ? (obj.error.error && typeof obj.error.error === 'object' ? obj.error.error : obj.error)
+        : null;
+    if (!errObj) return { matched: false };
+
+    const candidates = _extractErrorTokens(errObj);
+    for (const cand of candidates) {
+        if (allowlist.includes(cand)) {
+            return {
+                matched: true,
+                errorType: cand,
+                resetsAt: errObj.resets_at || errObj.retry_after || null,
+                rawLine: JSON.stringify(errObj).slice(0, 500),
+                evt: obj,
+            };
+        }
+    }
     return { matched: false };
 }
 
 module.exports = {
     name: 'cerebras',
-    detectLauncher,
+    detectLauncher: getLauncher,
     buildSpawn,
     parseTokensFromLog,
     detectQuotaExhausted,
+    // exports internos para tests
+    _detectLauncherFresh: detectLauncher,
+    _translateClaudeArgsToCerebras: translateClaudeArgsToCerebras,
+    _parseCerebrasJson,
+    _extractErrorTokens,
+    _setLauncherForTesting,
+    _resetLauncherCacheForTesting,
+    RUNNER_PATH,
 };

--- a/.pipeline/lib/agent-launcher/runners/cerebras-runner.js
+++ b/.pipeline/lib/agent-launcher/runners/cerebras-runner.js
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+// =============================================================================
+// runners/cerebras-runner.js — Runner REST del provider Cerebras (#3791)
+//
+// Cerebras es una API REST drop-in OpenAI-compatible
+// (`https://api.cerebras.ai/v1/chat/completions`) con free tier real (API key
+// `csk-...`). A diferencia de Codex y Gemini NO publica un CLI propio, así que
+// este runner ES el "CLI": el adapter `providers/cerebras.js` lo invoca con
+// `node cerebras-runner.js <args>`, hace la llamada HTTP y emite a stdout UN
+// ÚNICO objeto JSON (mismo patrón que el runner de NVIDIA y que Gemini con
+// `-o json`), que `parseTokensFromLog`/`detectQuotaExhausted` del adapter leen
+// del log.
+//
+// Contrato de argv (lo arma `buildSpawn` del adapter, traduciendo los args
+// estilo Claude del pulpo):
+//   --model <id>            modelo Cerebras (ej: gpt-oss-120b)
+//   --system-file <path>    archivo con el system prompt (opcional)
+//   --prompt <text>         prompt del usuario
+//   --max-tokens <n>        cap de salida (opcional, default 4096)
+//
+// Auth: API key free-tier en env `CEREBRAS_API_KEY` (la hidrata
+// `lib/credentials.js` desde ~/.claude/secrets/credentials.json al boot del
+// pulpo y se propaga por el env del spawn). Fallback: si no está en env, el
+// runner intenta cargarla con el loader canónico (robustez en ejecución suelta).
+//
+// Salida stdout (éxito): objeto OpenAI chat-completion tal cual lo devuelve
+// Cerebras (`{ id, model, choices:[...], usage:{...} }`) — el adapter parsea
+// `usage` para los tokens.
+// Salida stdout (error): `{ error: { status, code, type, message } }` y exit 1
+// — el adapter matchea el shape estructural contra la allowlist de cuota.
+//
+// Seguridad: la API key NUNCA se imprime. El endpoint es fijo (sin override por
+// argv) para no abrir SSRF. Sin shell, sin require dinámico.
+// =============================================================================
+'use strict';
+
+const https = require('node:https');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ENDPOINT_HOST = 'api.cerebras.ai';
+const ENDPOINT_PATH = '/v1/chat/completions';
+// El free tier de Cerebras sólo expone modelos de razonamiento; `llama-3.3-70b`
+// NO está disponible (responde 404 "does not exist or you do not have access").
+// Los únicos modelos servibles hoy son `gpt-oss-120b` y `zai-glm-4.7` (verificado
+// contra GET /v1/models). Default `gpt-oss-120b`: más rápido y menor overhead de
+// reasoning que glm-4.7 para el mismo resultado. Override por env `CEREBRAS_MODEL`.
+const DEFAULT_MODEL = 'gpt-oss-120b';
+const DEFAULT_MAX_TOKENS = 4096;
+
+// -----------------------------------------------------------------------------
+// parseArgv — parser minimalista del contrato de argv (sin dependencias).
+// -----------------------------------------------------------------------------
+function parseArgv(argv) {
+    const out = { model: null, systemFile: null, prompt: null, maxTokens: null };
+    for (let i = 0; i < argv.length; i++) {
+        const a = argv[i];
+        if (a === '--model') { out.model = argv[++i]; }
+        else if (a === '--system-file') { out.systemFile = argv[++i]; }
+        else if (a === '--prompt') { out.prompt = argv[++i]; }
+        else if (a === '--max-tokens') { out.maxTokens = parseInt(argv[++i], 10); }
+    }
+    return out;
+}
+
+// -----------------------------------------------------------------------------
+// resolveApiKey — env primero (lo hidrata el pulpo); fallback al loader canónico.
+// -----------------------------------------------------------------------------
+function resolveApiKey() {
+    if (process.env.CEREBRAS_API_KEY && process.env.CEREBRAS_API_KEY.trim()) {
+        return process.env.CEREBRAS_API_KEY.trim();
+    }
+    // Fallback: cargar credentials.json directo (ejecución suelta / smoke local).
+    try {
+        const cred = require(path.join(__dirname, '..', '..', 'credentials.js'));
+        cred.loadIntoEnv({ logger: () => {} });
+        if (process.env.CEREBRAS_API_KEY && process.env.CEREBRAS_API_KEY.trim()) {
+            return process.env.CEREBRAS_API_KEY.trim();
+        }
+    } catch { /* no-op: reportamos abajo */ }
+    return null;
+}
+
+// -----------------------------------------------------------------------------
+// buildMessages — arma el array de mensajes OpenAI a partir del system file y
+// el prompt del usuario. Cerebras SÍ soporta rol `system` nativo (a diferencia
+// de Gemini), así que no hace falta foldear el system al prompt.
+// -----------------------------------------------------------------------------
+function buildMessages(parsed) {
+    const messages = [];
+    if (parsed.systemFile) {
+        let systemText = null;
+        try { systemText = fs.readFileSync(parsed.systemFile, 'utf8'); } catch { systemText = null; }
+        if (systemText && systemText.trim()) {
+            messages.push({ role: 'system', content: systemText.trim() });
+        }
+    }
+    messages.push({ role: 'user', content: typeof parsed.prompt === 'string' ? parsed.prompt : '' });
+    return messages;
+}
+
+// -----------------------------------------------------------------------------
+// callCerebras — POST al endpoint chat/completions. Resuelve con { status, json }.
+// No streaming: queremos el `usage` consolidado en una sola respuesta (igual que
+// el runner de NVIDIA). El timeout protege contra cuelgues de red.
+// -----------------------------------------------------------------------------
+function callCerebras({ apiKey, model, messages, maxTokens }) {
+    return new Promise((resolve, reject) => {
+        const payload = JSON.stringify({
+            model,
+            messages,
+            temperature: 0.2,
+            max_tokens: maxTokens || DEFAULT_MAX_TOKENS,
+            stream: false,
+        });
+        const req = https.request({
+            host: ENDPOINT_HOST,
+            path: ENDPOINT_PATH,
+            method: 'POST',
+            headers: {
+                Authorization: `Bearer ${apiKey}`,
+                'Content-Type': 'application/json',
+                Accept: 'application/json',
+                'Content-Length': Buffer.byteLength(payload),
+            },
+            timeout: 120000,
+        }, (res) => {
+            let data = '';
+            res.on('data', (chunk) => { data += chunk; });
+            res.on('end', () => {
+                let json = null;
+                try { json = JSON.parse(data); } catch { json = { _raw: data.slice(0, 2000) }; }
+                resolve({ status: res.statusCode, json });
+            });
+        });
+        req.on('error', reject);
+        req.on('timeout', () => { req.destroy(new Error('Cerebras request timeout (120s)')); });
+        req.write(payload);
+        req.end();
+    });
+}
+
+// -----------------------------------------------------------------------------
+// normalizeError — homogeneiza el shape de error de Cerebras a campos
+// estructurales que el detector de cuota del adapter sabe matchear. Cerebras
+// puede responder `{ error: {...} }`, `{ message: "..." }`, o un body crudo.
+// -----------------------------------------------------------------------------
+function normalizeError(status, json) {
+    const base = { status };
+    if (json && typeof json === 'object') {
+        if (json.error && typeof json.error === 'object') {
+            return Object.assign(base, json.error);
+        }
+        if (typeof json.message === 'string') {
+            base.message = json.message;
+        } else if (typeof json.detail === 'string') {
+            base.message = json.detail;
+        } else if (json._raw) {
+            base.message = json._raw;
+        }
+    }
+    // Mapear el HTTP code a un `code`/`type` canónico cuando Cerebras no lo da.
+    if (status === 429 && !base.code) { base.code = 'rate_limit_exceeded'; }
+    if (status === 402 && !base.code) { base.code = 'insufficient_quota'; }
+    if (status === 401 && !base.code) { base.code = 'unauthorized'; }
+    return base;
+}
+
+async function main() {
+    const parsed = parseArgv(process.argv.slice(2));
+    const apiKey = resolveApiKey();
+    if (!apiKey) {
+        process.stdout.write(JSON.stringify({
+            error: { status: 0, code: 'no_credentials', message: 'CEREBRAS_API_KEY ausente (env y credentials.json)' },
+        }));
+        process.exit(1);
+        return;
+    }
+
+    const model = parsed.model || process.env.CEREBRAS_MODEL || DEFAULT_MODEL;
+    const messages = buildMessages(parsed);
+
+    try {
+        const { status, json } = await callCerebras({ apiKey, model, messages, maxTokens: parsed.maxTokens });
+        if (status >= 200 && status < 300) {
+            // Éxito: emitimos la respuesta OpenAI tal cual (el adapter parsea `usage`).
+            process.stdout.write(JSON.stringify(json));
+            process.exit(0);
+            return;
+        }
+        // Error HTTP: shape de error normalizado para el detector de cuota.
+        process.stdout.write(JSON.stringify({ error: normalizeError(status, json) }));
+        process.exit(1);
+    } catch (e) {
+        process.stdout.write(JSON.stringify({
+            error: { status: 0, code: 'network_error', message: e && e.message ? e.message : String(e) },
+        }));
+        process.exit(1);
+    }
+}
+
+if (require.main === module) {
+    main();
+}
+
+module.exports = { parseArgv, buildMessages, normalizeError, resolveApiKey };

--- a/.pipeline/tests/agent-launcher.test.js
+++ b/.pipeline/tests/agent-launcher.test.js
@@ -589,3 +589,113 @@ test('nvidia-nim detectQuotaExhausted matchea rate_limit/insufficient_quota por 
     const fsiOk = { readFileSync: () => okPayload };
     assert.equal(nvidia.detectQuotaExhausted(logPath, null, QE, fsiOk).matched, false);
 });
+
+// -----------------------------------------------------------------------------
+// 13a. Provider 'cerebras' real (#3791): launchAgent spawnea el runner Node
+//      (node <runner.js>) traduciendo los args estilo Claude al contrato del
+//      runner (`--model <id> --system-file <path> --prompt <text>`).
+// -----------------------------------------------------------------------------
+test('launchAgent con provider cerebras spawnea el runner Node con args traducidos', () => {
+    const modelsPath = path.join(PIPELINE, 'agent-models.json');
+    const fsi = fakeFs([modelsPath], {
+        [modelsPath]: JSON.stringify({
+            skills: {
+                guru: { provider: 'cerebras', model: 'llama-3.3-70b' },
+            },
+        }),
+    });
+    const spi = fakeSpawn();
+
+    PROVIDERS['cerebras']._setLauncherForTesting({
+        kind: 'node-runner',
+        cmd: '/fake/node',
+        prefixArgs: ['/fake/cerebras-runner.js'],
+        shell: false,
+    });
+    try {
+        launchAgent({
+            skill: 'guru',
+            issue: 1,
+            args: ['-p', 'probe', '--system-prompt-file', '/tmp/sys.md', '--output-format', 'stream-json'],
+            cwd: ROOT,
+            env: { CEREBRAS_MODEL: 'llama-3.3-70b' },
+            PIPELINE,
+            ROOT,
+            fsImpl: fsi,
+            spawnImpl: spi,
+        });
+    } finally {
+        PROVIDERS['cerebras']._resetLauncherCacheForTesting();
+    }
+    assert.equal(spi.calls.length, 1);
+    const call = spi.calls[0];
+    assert.equal(call.cmd, '/fake/node');
+    assert.equal(call.args[0], '/fake/cerebras-runner.js');
+    assert.ok(call.args.includes('--model'));
+    assert.ok(call.args.includes('llama-3.3-70b'));
+    assert.ok(call.args.includes('--system-file'));
+    assert.ok(call.args.includes('/tmp/sys.md'));
+    assert.ok(call.args.includes('--prompt'));
+    assert.ok(call.args.includes('probe'));
+    // El flag --output-format (estilo Claude) se descarta en la traducción.
+    assert.ok(!call.args.includes('--output-format'));
+});
+
+// -----------------------------------------------------------------------------
+// 13b. parseTokensFromLog de cerebras mapea el `usage` OpenAI al shape canónico.
+// -----------------------------------------------------------------------------
+test('cerebras parseTokensFromLog mapea usage OpenAI (prompt/completion/cached/reasoning)', () => {
+    const cerebras = PROVIDERS['cerebras'];
+    const logPath = '/tmp/cerebras.json';
+    const payload = JSON.stringify({
+        id: 'cmpl-1',
+        model: 'llama-3.3-70b',
+        choices: [{ message: { role: 'assistant', content: 'OK' } }],
+        usage: {
+            prompt_tokens: 100,
+            completion_tokens: 8,
+            reasoning_tokens: 2,
+            total_tokens: 110,
+            prompt_tokens_details: { cached_tokens: 30 },
+        },
+    });
+    const fsi = { readFileSync: (p) => (p === logPath ? payload : (() => { const e = new Error('ENOENT'); e.code = 'ENOENT'; throw e; })()) };
+    const tokens = cerebras.parseTokensFromLog(logPath, fsi);
+    assert.equal(tokens.input, 100);
+    assert.equal(tokens.output, 10);          // completion 8 + reasoning 2
+    assert.equal(tokens.cache_read, 30);
+
+    // prompt_tokens_details null (sin cache) no rompe.
+    const noCache = JSON.stringify({ usage: { prompt_tokens: 17, completion_tokens: 2, prompt_tokens_details: null } });
+    const fsi2 = { readFileSync: () => noCache };
+    const t2 = cerebras.parseTokensFromLog(logPath, fsi2);
+    assert.equal(t2.input, 17);
+    assert.equal(t2.output, 2);
+    assert.equal(t2.cache_read, 0);
+});
+
+// -----------------------------------------------------------------------------
+// 13c. detectQuotaExhausted de cerebras matchea por shape estructural.
+// -----------------------------------------------------------------------------
+test('cerebras detectQuotaExhausted matchea rate_limit/quota_exceeded por shape', () => {
+    const cerebras = PROVIDERS['cerebras'];
+    const QE = require('../lib/quota-exhausted');
+    const logPath = '/tmp/cerebras-err.json';
+
+    // 429 normalizado por el runner a code 'rate_limit_exceeded'.
+    const payload = JSON.stringify({ error: { status: 429, code: 'rate_limit_exceeded', message: 'too many requests' } });
+    const fsi = { readFileSync: (p) => (p === logPath ? payload : (() => { const e = new Error('ENOENT'); e.code = 'ENOENT'; throw e; })()) };
+    const res = cerebras.detectQuotaExhausted(logPath, null, QE, fsi);
+    assert.equal(res.matched, true);
+    assert.equal(res.errorType, 'rate_limit_exceeded');
+
+    // quota_exceeded (type) también matchea.
+    const payload2 = JSON.stringify({ error: { type: 'quota_exceeded', message: 'no credits' } });
+    const fsi2 = { readFileSync: () => payload2 };
+    assert.equal(cerebras.detectQuotaExhausted(logPath, null, QE, fsi2).errorType, 'quota_exceeded');
+
+    // Respuesta normal (sin error) → no matchea.
+    const okPayload = JSON.stringify({ choices: [{ message: { content: 'OK' } }], usage: { prompt_tokens: 1 } });
+    const fsiOk = { readFileSync: () => okPayload };
+    assert.equal(cerebras.detectQuotaExhausted(logPath, null, QE, fsiOk).matched, false);
+});

--- a/.pipeline/tests/smoke/cerebras-adapter.smoke.js
+++ b/.pipeline/tests/smoke/cerebras-adapter.smoke.js
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+// =============================================================================
+// cerebras-adapter.smoke.js — Smoke E2E del adapter cerebras
+//
+// Objetivo: invocar el provider real (no mockeado) y verificar que el pipeline
+// buildSpawn → child_process.spawn → parseTokensFromLog cierra el contrato
+// canónico contra el runner REST de Cerebras
+// (`api.cerebras.ai/v1/chat/completions`, free tier con API key).
+//
+// NO toca el pulpo. NO requiere pipeline corriendo. Es un smoke aislado.
+// La API key sale de env CEREBRAS_API_KEY (la hidrata credentials.js); el
+// runner también la resuelve solo si no está en env.
+// =============================================================================
+'use strict';
+
+const { spawn } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const provider = require('../../lib/agent-launcher/providers/cerebras.js');
+const credentials = require('../../lib/credentials.js');
+
+const TIMEOUT_MS = 120_000;
+const PROMPT = 'Responde exactamente con la palabra OK y nada mas. No expliques nada.';
+// El free tier sólo expone modelos de razonamiento; `gpt-oss-120b` es el default
+// del runner (más rápido que `zai-glm-4.7`). `llama-3.3-70b` NO existe en este tier.
+const MODEL = process.env.CEREBRAS_MODEL || 'gpt-oss-120b';
+
+async function main() {
+    // Hidratar la API key como lo hace el pulpo al boot.
+    credentials.loadIntoEnv({ logger: () => {} });
+
+    const t0 = Date.now();
+    const launcher = provider.detectLauncher();
+    console.log(`[smoke] launcher.kind = ${launcher.kind}`);
+    console.log(`[smoke] launcher.cmd  = ${launcher.cmd}`);
+
+    const args = ['-p', PROMPT];
+    const cwd = process.cwd();
+    const env = { ...process.env, CEREBRAS_MODEL: MODEL };
+    const spawnCfg = provider.buildSpawn({ args, cwd, env, interactive_supported: false });
+
+    console.log(`[smoke] model      = ${MODEL}`);
+    console.log(`[smoke] spawn.cmd  = ${spawnCfg.cmd}`);
+    console.log(`[smoke] spawn.args = ${JSON.stringify(spawnCfg.args)}`);
+
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cerebras-smoke-'));
+    const logPath = path.join(tmpDir, 'cerebras.json');
+    const logStream = fs.createWriteStream(logPath, { flags: 'a' });
+
+    const child = spawn(spawnCfg.cmd, spawnCfg.args, spawnCfg.spawnOpts);
+
+    let stdoutBytes = 0;
+    let stderrBytes = 0;
+
+    child.stdout.on('data', (chunk) => { stdoutBytes += chunk.length; logStream.write(chunk); });
+    child.stderr.on('data', (chunk) => { stderrBytes += chunk.length; process.stderr.write(chunk); });
+
+    const timer = setTimeout(() => {
+        console.error('[smoke] TIMEOUT — killing child');
+        child.kill('SIGKILL');
+    }, TIMEOUT_MS);
+
+    const exitCode = await new Promise((resolve) => {
+        child.on('exit', (code) => { clearTimeout(timer); resolve(code); });
+        child.on('error', (err) => { clearTimeout(timer); console.error('[smoke] spawn error:', err); resolve(-1); });
+    });
+
+    logStream.end();
+    await new Promise((r) => logStream.on('finish', r));
+    const dtMs = Date.now() - t0;
+
+    const raw = fs.readFileSync(logPath, 'utf8');
+    const obj = provider._parseCerebrasJson(raw);
+    const responseText = obj && obj.choices && obj.choices[0] && obj.choices[0].message
+        ? obj.choices[0].message.content : null;
+
+    console.log('---');
+    console.log(`[smoke] exit_code      = ${exitCode}`);
+    console.log(`[smoke] duration_ms    = ${dtMs}`);
+    console.log(`[smoke] stdout_bytes   = ${stdoutBytes}`);
+    console.log(`[smoke] stderr_bytes   = ${stderrBytes}`);
+    console.log(`[smoke] json_parsed    = ${obj ? 'yes' : 'no'}`);
+    console.log(`[smoke] response       = ${JSON.stringify(responseText)}`);
+
+    const tokens = provider.parseTokensFromLog(logPath);
+    console.log(`[smoke] parseTokens    = ${JSON.stringify(tokens)}`);
+
+    const QE = require('../../lib/quota-exhausted.js');
+    const qe = provider.detectQuotaExhausted(logPath, null, QE);
+    console.log(`[smoke] detectQuota    = ${JSON.stringify({ matched: qe.matched, errorType: qe.errorType || null })}`);
+
+    const ok =
+        exitCode === 0 &&
+        obj != null &&
+        typeof responseText === 'string' && responseText.length > 0 &&
+        tokens.input > 0 &&
+        qe.matched === false;
+
+    console.log(`[smoke] log_path       = ${logPath}`);
+    console.log(`[smoke] RESULT         = ${ok ? 'PASS' : 'FAIL'}`);
+    process.exit(ok ? 0 : 1);
+}
+
+main().catch((err) => {
+    console.error('[smoke] uncaught:', err);
+    process.exit(2);
+});


### PR DESCRIPTION
Cuarto adapter real de la tanda multi-provider (despues de Codex, Gemini y NVIDIA NIM).

## Que entra
- `runners/cerebras-runner.js` — cliente Node contra el endpoint REST de Cerebras, sin shell
- `providers/cerebras.js` — handler real (adios al stub `_notImplemented`), default `gpt-oss-120b` (free tier)
- registro en `agent-launcher.js`
- 3 tests nuevos del contrato (spawn args, parseTokensFromLog, detectQuotaExhausted) → **20/20 verdes**
- smoke E2E nuevo `tests/smoke/cerebras-adapter.smoke.js` (exit 0, respuesta OK, 83 in / 102 out, quota detection false)

## Mapeo
Usa el shape de usage estilo OpenAI (`prompt/completion/cached/reasoning`). `detectQuotaExhausted` matchea `rate_limit`/`quota_exceeded`.

## Scope
Solo archivos del adapter. Cero estado del pipeline.

Refs #3791