### PR TITLE
fix(pipeline): Sherlock sin timeout + cascada de providers restaurada

### DIFF
--- a/.pipeline/lib/__tests__/completion-client.test.js
+++ b/.pipeline/lib/__tests__/completion-client.test.js
@@ -560,21 +560,23 @@ test('PROVIDER_MODELS_ALLOWLIST incluye los modelos que usa producción (snapsho
 });
 
 // =============================================================================
-// #3484 — Tests del cap defensivo del timeout.
+// 2026-06-02 (Leo) — el timeout se eliminó. El cliente espera lo que tarde el
+// provider; la resiliencia la da la cascada multi-provider del verifier.
 // =============================================================================
 
-test('#3484 CA-CLIENT-3: DEFAULT_TIMEOUT_MS = 90s', () => {
-    assert.equal(completion.DEFAULT_TIMEOUT_MS, 90_000);
+test('CA-CLIENT-3: DEFAULT_TIMEOUT_MS = 0 (sin timeout, 2026-06-02)', () => {
+    assert.equal(completion.DEFAULT_TIMEOUT_MS, 0);
 });
 
-test('#3484 CA-CLIENT-4: ABSOLUTE_MAX_TIMEOUT_MS = 180s exportado', () => {
-    assert.equal(completion.ABSOLUTE_MAX_TIMEOUT_MS, 180_000);
+test('CA-CLIENT-4: el cliente ya no exporta cap absoluto de timeout (2026-06-02)', () => {
+    // El cap absoluto (180s, #3484) se eliminó junto con el timeout.
+    assert.equal(completion.ABSOLUTE_MAX_TIMEOUT_MS, undefined);
 });
 
-test('#3484 CA-CLIENT-4: caller pidiendo timeout > ABSOLUTE_MAX_TIMEOUT_MS se clampea', async () => {
+test('CA-CLIENT-4: caller pidiendo timeout > 0 se respeta sin cap (2026-06-02)', async () => {
     // Estrategia: el fake http NO simula timeout, sino que responde rápido.
-    // Para validar el clamp inspeccionamos que el cliente NO tira aunque le
-    // pasemos 999_999 (lo clampearia a 180_000 internamente).
+    // Validamos que el cliente NO tira aunque le pasemos 999_999 — ya no hay
+    // cap absoluto, el valor se respeta tal cual (opt-in explícito del caller).
     const dir = tmpDir();
     const f = path.join(dir, 'config.json');
     writeKeys(f, { cerebras_api_key: 'csk_test_1234567890abcdef0000' });
@@ -582,7 +584,7 @@ test('#3484 CA-CLIENT-4: caller pidiendo timeout > ABSOLUTE_MAX_TIMEOUT_MS se cl
         provider: 'cerebras',
         model: 'llama-3.3-70b',
         prompt: 'ping',
-        timeoutMs: 999_999, // se clampea a 180_000 internamente
+        timeoutMs: 999_999, // se respeta sin cap (ya no hay ABSOLUTE_MAX)
         secretsPath: f,
         httpImpl: fakeHttp({
             status: 200,

--- a/.pipeline/lib/__tests__/sherlock-verifier.test.js
+++ b/.pipeline/lib/__tests__/sherlock-verifier.test.js
@@ -184,14 +184,14 @@ test('T-1: detecta inconsistencia entre claim del Commander y system_state', asy
 // T-2 — Escenario timeout → respuesta con disclaimer F-6.
 // CA-F-6 + CA-SEC-1 (resilencia ante fallos del provider).
 // =============================================================================
-test('T-2: timeout del completion-client devuelve aborted + disclaimer F-6 (#3668: single-provider)', async () => {
+test('T-2: cuando TODA la chain falla con timeout devuelve aborted + disclaimer F-6 (cascada restaurada 2026-06-02)', async () => {
     const dir = mkTmpPipelineDir();
     const completionTimeout = {
         ok: false,
-        error: { type: 'timeout', detail: 'request superó timeoutMs=10000' },
+        error: { type: 'timeout', detail: 'request sin respuesta del provider' },
         provider: 'cerebras',
         model: 'llama-3.3-70b',
-        durationMs: 10001,
+        durationMs: 1,
     };
     const result = await sherlock.verify({
         analysis: 'cualquier cosa',
@@ -206,14 +206,14 @@ test('T-2: timeout del completion-client devuelve aborted + disclaimer F-6 (#366
         residencyModule: fakeResidencyOk(),
     });
     assert.equal(result.verdict, 'aborted');
-    // #3668 — single-provider: el errorCode canónico es el del error real
-    // (`timeout`), NO `exhausted_cascade` (la cascada fue removida).
+    // Cascada: el errorCode canónico es el del ÚLTIMO error real (`timeout`).
     assert.equal(result.errorCode, 'timeout');
     assert.equal(result.suggestedDisclaimer, sherlock.DISCLAIMER_TYPES.TIMEOUT_OR_NO_PROVIDER);
-    // CA-9 shape stable post-#3668:
-    assert.equal(result.attemptCount, 1, 'attemptCount siempre 1 post-#3668');
-    assert.equal(result.fallbackUsed, false, 'fallbackUsed siempre false post-#3668');
-    assert.ok(Array.isArray(result.chainTried) && result.chainTried.length === 1);
+    // CA-9 shape con cascada: recorrió los 3 providers HTTP de la chain antes
+    // de abortar — fallbackUsed=true porque hubo más de 1 intento.
+    assert.equal(result.attemptCount, 3, 'cascada recorre los 3 providers de CHAIN_HTTP');
+    assert.equal(result.fallbackUsed, true, 'hubo fallback entre providers');
+    assert.ok(Array.isArray(result.chainTried) && result.chainTried.length === 3);
     const final = sherlock.applyDisclaimer('Texto base.', result.suggestedDisclaimer);
     // #3484 — phrasing actualizado por CA-UX-3.
     assert.match(final, /No pude verificar esta respuesta con el verificador adversarial/);
@@ -488,7 +488,7 @@ test('CA-SEC-6: cap inconsistencies <= 5 trunca y marca truncated', () => {
     assert.equal(r.data.inconsistenciesTruncated, true);
 });
 
-test('CA-SEC-6: schema_violation emite evento al audit log y devuelve aborted (#3668: single-provider)', async () => {
+test('CA-SEC-6: schema_violation en TODA la chain emite evento y devuelve aborted (cascada restaurada 2026-06-02)', async () => {
     const dir = mkTmpPipelineDir();
     const badOutput = {
         ok: true,
@@ -505,13 +505,14 @@ test('CA-SEC-6: schema_violation emite evento al audit log y devuelve aborted (#
         residencyModule: fakeResidencyOk(),
     });
     assert.equal(result.verdict, 'aborted');
-    // #3668 — single-provider: el errorCode canónico es `schema_violation`,
-    // NO `exhausted_cascade`. La cascada fue removida.
+    // Cascada restaurada: cada provider devuelve schema inválido, se excluye y
+    // se salta al siguiente. El errorCode canónico es el del ÚLTIMO fallo
+    // (`schema_violation`) y la reason lo cita.
     assert.equal(result.errorCode, 'schema_violation');
     assert.match(result.reason, /schema_violation/);
-    // CA-9 shape stable post-#3668:
-    assert.equal(result.attemptCount, 1);
-    assert.equal(result.fallbackUsed, false);
+    // CA-9 shape con cascada: recorrió los 3 providers HTTP de CHAIN_HTTP.
+    assert.equal(result.attemptCount, 3, 'cascada recorre los 3 providers de CHAIN_HTTP');
+    assert.equal(result.fallbackUsed, true, 'hubo fallback entre providers');
 });
 
 // =============================================================================
@@ -610,12 +611,12 @@ test('CA-SEC-9: sherlock_max_reelaboraciones=99 se clampea a 1', () => {
     assert.equal(cfg.maxReelaboraciones, 1);
 });
 
-// #3484 — el clamp local de timeout fue removido. Sherlock ya NO impone
-// un cap de 30s; el cap defensivo vive en el completion-client (180s).
-// Este test reemplaza el legacy "cap 30s" por la verificación de back-compat:
-// aunque config diga `sherlock_timeout_ms: 999999`, el cargador devuelve
-// el DEFAULT_TIMEOUT_MS del módulo (90s) sin romper.
-test('CA-SEC-9 (#3484): sherlock_timeout_ms en config se ignora — back-compat', () => {
+// 2026-06-02 (Leo) — el timeout se eliminó por completo. Sherlock ya NO impone
+// ningún cap; la resiliencia ante un provider que no responde la da la cascada
+// multi-provider, no un timer. `sherlock_timeout_ms` queda como NO-OP: aunque
+// config diga `999999`, el cargador devuelve DEFAULT_TIMEOUT_MS (0 = sin
+// timeout) sin romper.
+test('CA-SEC-9: sherlock_timeout_ms en config se ignora — sin timeout (2026-06-02)', () => {
     const cfg = sherlock._loadSherlockConfig({
         configLoader: () => ({
             sherlock_enabled: true,
@@ -623,9 +624,9 @@ test('CA-SEC-9 (#3484): sherlock_timeout_ms en config se ignora — back-compat'
             sherlock_max_reelaboraciones: 1,
         }),
     });
-    // El cargador devuelve siempre DEFAULT_TIMEOUT_MS (90s post-#3484).
+    // El cargador devuelve siempre DEFAULT_TIMEOUT_MS (0 = sin timeout).
     assert.equal(cfg.timeoutMs, sherlock.DEFAULT_TIMEOUT_MS);
-    assert.equal(cfg.timeoutMs, 90000);
+    assert.equal(cfg.timeoutMs, 0);
 });
 
 test('CA-SEC-9 (#3484): sin sherlock_timeout_ms — también devuelve DEFAULT', () => {
@@ -988,14 +989,16 @@ test('#3484: spawn helper devuelve content cuando el child termina exitosamente'
     assert.equal(result.provider, 'anthropic');
 });
 
-test('#3484 CA-CLIENT-3: DEFAULT_TIMEOUT_MS del cliente = 90s', () => {
+test('CA-CLIENT-3: DEFAULT_TIMEOUT_MS del cliente = 0 (sin timeout, 2026-06-02)', () => {
     const client = require('../multi-provider/completion-client');
-    assert.equal(client.DEFAULT_TIMEOUT_MS, 90_000);
+    assert.equal(client.DEFAULT_TIMEOUT_MS, 0);
 });
 
-test('#3484 CA-CLIENT-4: ABSOLUTE_MAX_TIMEOUT_MS del cliente = 180s', () => {
+test('CA-CLIENT-4: el cliente ya no exporta cap absoluto de timeout (2026-06-02)', () => {
     const client = require('../multi-provider/completion-client');
-    assert.equal(client.ABSOLUTE_MAX_TIMEOUT_MS, 180_000);
+    // El cap absoluto (180s, #3484) se eliminó junto con el timeout. El cliente
+    // espera lo que tarde el provider; la resiliencia la da la cascada del verifier.
+    assert.equal(client.ABSOLUTE_MAX_TIMEOUT_MS, undefined);
 });
 
 // =============================================================================
@@ -1185,14 +1188,16 @@ test('#3484 CA-AUDIT-1: JSONL persiste campos enriched también en sherlock_abor
 // =============================================================================
 
 // =============================================================================
-// #3668 — Tests post-refactor single-provider. La cascada de #3558 fue removida
-// (lib/sherlock-retry-chain.js eliminado). Sherlock ahora invoca al provider
-// resuelto UNA sola vez; si falla, devuelve aborted + F-6 sin probar otro
-// provider. El shape del retorno preserva attemptCount/fallbackUsed/chainTried
-// (CA-9) para no romper consumers downstream.
+// Cascada restaurada (2026-06-02, Leo) — revierte el single-provider de #3668.
+// Sherlock vuelve a recorrer la chain telegram-sherlock: si un provider falla
+// (error de transporte o schema inválido) lo excluye y salta al siguiente, igual
+// que el probador de agentes. Solo cuando se agota TODA la chain devuelve
+// aborted + F-6. SIN timeout: cada provider corre hasta responder o errorar por
+// su cuenta. El shape del retorno preserva attemptCount/fallbackUsed/chainTried
+// (CA-9) y ahora reflejan el recorrido real de la cascada.
 // =============================================================================
 
-test('#3668: provider único falla → verdict=aborted con shape stable', async () => {
+test('cascada: TODA la chain falla → verdict=aborted con shape stable (cascada restaurada 2026-06-02)', async () => {
     const dir = mkTmpPipelineDir();
     const result = await sherlock.verify({
         analysis: 'a', originalRequest: '?', systemState: 's',
@@ -1201,8 +1206,8 @@ test('#3668: provider único falla → verdict=aborted con shape stable', async 
         configLoader: defaultConfigLoader(),
         completionClient: fakeCompletionClient({
             ok: false,
-            error: { type: 'timeout', detail: 'request superó timeoutMs' },
-            durationMs: 90_000,
+            error: { type: 'timeout', detail: 'request sin respuesta del provider' },
+            durationMs: 1,
         }),
         quotaModule: fakeQuotaAllPass(),
         dispatchModule: fakeDispatcher({ providerChain: CHAIN_HTTP }),
@@ -1211,11 +1216,11 @@ test('#3668: provider único falla → verdict=aborted con shape stable', async 
     assert.equal(result.verdict, 'aborted');
     assert.equal(result.errorCode, 'timeout');
     assert.equal(result.suggestedDisclaimer, sherlock.DISCLAIMER_TYPES.TIMEOUT_OR_NO_PROVIDER);
-    // CA-9 — shape stable post-single-provider.
-    assert.equal(result.fallbackUsed, false, 'fallbackUsed siempre false post-#3668');
-    assert.equal(result.attemptCount, 1, 'attemptCount siempre 1 post-#3668');
+    // CA-9 — shape con cascada: recorre los 3 providers de CHAIN_HTTP antes de abortar.
+    assert.equal(result.fallbackUsed, true, 'hubo fallback entre providers');
+    assert.equal(result.attemptCount, 3, 'cascada recorre los 3 providers de CHAIN_HTTP');
     assert.ok(Array.isArray(result.chainTried));
-    assert.equal(result.chainTried.length, 1, 'chainTried siempre length 1 post-#3668');
+    assert.equal(result.chainTried.length, 3, 'chainTried refleja los 3 providers recorridos');
 });
 
 test('#3668 CA-7: provider no disponible → emite sherlock_skipped_provider_unavailable + F-6', async () => {

--- a/.pipeline/lib/multi-provider/completion-client.js
+++ b/.pipeline/lib/multi-provider/completion-client.js
@@ -44,13 +44,15 @@
 //     provider (sólo `content`/`inputTokens`/`outputTokens`).
 //
 // DoS / resource exhaustion:
-//   - Timeout configurable (default 90s, cap defensivo 180s) en `req.setTimeout`
-//     + handler que destruye con `code: 'ETIMEDOUT'`. El cap absoluto
-//     (`ABSOLUTE_MAX_TIMEOUT_MS`) NO puede ser removido por el caller — protege
-//     al cliente Telegram de quedar bloqueado por una respuesta colgada.
-//     Histórico: el default era 10s + Sherlock clampaba a 30s — insuficiente
-//     para razonamiento adversarial real (issue #3484). Subido a 90s con cap
-//     180s en mayo 2026.
+//   - SIN timeout (decisión Leo 2026-06-02 voz). El cliente espera la respuesta
+//     del provider el tiempo que haga falta — la verificación adversarial nunca
+//     se corta por reloj. Histórico: 10s (default original) → 90s+cap180s (#3484)
+//     → sin timeout (esta versión). La resiliencia ante un provider que no
+//     responde se delega a la **cascada multi-provider** del verifier (Sherlock):
+//     si un provider falla con error, se salta al siguiente de la chain en vez
+//     de cortar por tiempo. `timeoutMs` se mantiene en la signature por
+//     back-compat: si un caller pasa un valor > 0 se respeta (sin cap), pero el
+//     default (0 / inválido / ausente) significa "sin timeout".
 //   - Body cap 64KB (`MAX_BODY_BYTES`). Si el provider devuelve más, abortamos
 //     con `error: {type: 'invalid_response', reason: 'body_too_large'}`.
 //
@@ -157,16 +159,13 @@ const PROVIDER_MODELS_ALLOWLIST = Object.freeze({
     ]),
 });
 
-// Timeout default — 90s. Cubre razonamiento adversarial real de Sherlock
-// (#3484) sin presión de reloj. Histórico: era 10s — insuficiente para
-// providers que tardan 20-40s en razonar sobre análisis largos.
-const DEFAULT_TIMEOUT_MS = 90_000;
-
-// Cap defensivo absoluto del timeout — el caller puede pedir hasta este valor.
-// Más allá de 3 minutos un turno de Telegram empieza a sentirse colgado y
-// arriesga a que el usuario mande mensajes adicionales pensando que el bot
-// murió. NO removible desde caller — protege al chat de bloqueos infinitos.
-const ABSOLUTE_MAX_TIMEOUT_MS = 180_000;
+// Timeout default — 0 = SIN timeout (decisión Leo 2026-06-02 voz). El cliente
+// espera lo que tarde el provider; la resiliencia ante un provider colgado la
+// da la cascada multi-provider del verifier, no un corte por reloj. Histórico:
+// 10s → 90s + cap 180s (#3484) → sin timeout (esta versión). Se mantiene
+// exportado por back-compat; un caller que pase un `timeoutMs > 0` lo conserva
+// (ya NO hay cap), pero el default es no cortar nunca.
+const DEFAULT_TIMEOUT_MS = 0;
 
 const MAX_BODY_BYTES = 64 * 1024; // 64KB — cap defensivo contra DoS.
 
@@ -228,12 +227,13 @@ async function complete({
     const startedAt = Date.now();
     const baseResult = { provider, model };
 
-    // Cap defensivo absoluto — defensa-en-profundidad contra callers que
-    // pasen timeouts excesivos (intencional o por bug). NO se removible.
+    // SIN timeout por default (Leo 2026-06-02). `effectiveTimeoutMs === 0`
+    // significa "no cortar nunca". Si el caller pasa un valor > 0 se respeta
+    // tal cual (ya no hay cap absoluto): es solo un opt-in explícito.
     const rawTimeout = Number(timeoutMs);
     const effectiveTimeoutMs = Number.isFinite(rawTimeout) && rawTimeout > 0
-        ? Math.min(rawTimeout, ABSOLUTE_MAX_TIMEOUT_MS)
-        : DEFAULT_TIMEOUT_MS;
+        ? rawTimeout
+        : 0;
 
     if (!isAllowedProvider(provider)) {
         return {
@@ -425,14 +425,18 @@ function doRequest({ spec, key, body, timeoutMs, httpImpl }) {
         }
 
         const lib = httpImpl || https;
-        const req = lib.request({
+        // timeoutMs === 0 → sin timeout (no seteamos la opción ni el handler).
+        const reqOpts = {
             method: spec.method,
             hostname: url.hostname,
             port: url.port || 443,
             path: url.pathname + url.search,
             headers,
-            timeout: timeoutMs,
-        }, (res) => {
+        };
+        if (Number(timeoutMs) > 0) {
+            reqOpts.timeout = timeoutMs;
+        }
+        const req = lib.request(reqOpts, (res) => {
             const chunks = [];
             let received = 0;
             let truncated = false;
@@ -453,9 +457,12 @@ function doRequest({ spec, key, body, timeoutMs, httpImpl }) {
             });
         });
         req.on('error', reject);
-        req.on('timeout', () => {
-            req.destroy(Object.assign(new Error('Timeout'), { code: 'ETIMEDOUT' }));
-        });
+        // Solo registramos el handler de timeout si hay timeout configurado.
+        if (Number(timeoutMs) > 0) {
+            req.on('timeout', () => {
+                req.destroy(Object.assign(new Error('Timeout'), { code: 'ETIMEDOUT' }));
+            });
+        }
         req.write(body);
         req.end();
     });
@@ -468,6 +475,5 @@ module.exports = {
     PROVIDER_COMPLETION_ENDPOINTS,
     PROVIDER_MODELS_ALLOWLIST,
     DEFAULT_TIMEOUT_MS,
-    ABSOLUTE_MAX_TIMEOUT_MS,
     MAX_BODY_BYTES,
 };

--- a/.pipeline/lib/sherlock-verifier.js
+++ b/.pipeline/lib/sherlock-verifier.js
@@ -9,8 +9,11 @@
 // el estado actual del sistema. Sherlock institucionaliza la contraposición:
 //   - prompt invariante ("fiscal")
 //   - el provider de mejor calidad disponible (orden compartido con Commander)
-//   - timeout delegado al completion-client (90s default, 180s cap)
-//   - disclaimer si falla la verificación
+//   - SIN timeout (Leo 2026-06-02): nunca corta por reloj; la resiliencia la
+//     da la cascada multi-provider, no un timer
+//   - cascada multi-provider: si un provider falla, salta al siguiente de la
+//     chain en vez de abortar (restaurada 2026-06-02, revierte #3668)
+//   - disclaimer F-6 sólo si se agota toda la chain
 //   - cap reelaboración hardcoded = 1
 //
 // Sherlock NO es un skill de agente — corre IN-PROCESS dentro del flujo
@@ -151,11 +154,13 @@ const SPAWN_COMPLETION_PROVIDERS = Object.freeze(new Set([
     'anthropic',
 ]));
 
-// Timeout default que Sherlock pasa al completion-client / spawn helper si
-// no recibe override por config. El cliente HTTP tiene su propio cap absoluto
-// (180s) que es la defensa real; este número es solo conveniencia + back-compat
-// con tests/callers viejos. Histórico: era 10s (clampado a 30s) — insuficiente.
-const DEFAULT_TIMEOUT_MS = 90_000;
+// Timeout default que Sherlock pasa al completion-client / spawn helper.
+// 0 = SIN timeout (decisión Leo 2026-06-02 voz): la verificación adversarial
+// nunca se corta por reloj. La resiliencia ante un provider que no responde la
+// da la cascada multi-provider de `verify()` (si un provider falla con error,
+// salta al siguiente de la chain), no un timeout. Histórico: 10s → 90s (#3484)
+// → sin timeout (esta versión). Se mantiene exportado por back-compat.
+const DEFAULT_TIMEOUT_MS = 0;
 
 // -----------------------------------------------------------------------------
 // Disclaimers (CA-F-5/F-6) — constantes string en español, voseo argentino.
@@ -480,9 +485,10 @@ function resolveSherlockProvider({
 // cli.js legacy, cmd shim, etc.). Pasa `--permission-mode bypassPermissions`
 // + `--output-format text` para obtener la respuesta cruda directamente.
 //
-// Timeout: respeta el `timeoutMs` recibido (clampado por el caller al
-// ABSOLUTE_MAX_TIMEOUT_MS del cliente HTTP). Si no hay respuesta antes,
-// mata el child con SIGTERM y devuelve `error.type === 'timeout'`.
+// Timeout: si `timeoutMs > 0` mata el child con SIGTERM al vencer y devuelve
+// `error.type === 'timeout'`. Con `timeoutMs === 0` (default post-2026-06-02)
+// NO hay timer: el child corre hasta terminar por su cuenta. La cascada de
+// `verify()` cubre el caso de error real del provider.
 //
 // SECURITY:
 //   - El prompt va por stdin (no como arg) → no aparece en `ps aux` ni en
@@ -549,17 +555,21 @@ function spawnAnthropicComplete({
         const finish = (result) => {
             if (resolved) return;
             resolved = true;
-            try { clearTimeout(timer); } catch {}
+            try { if (timer) clearTimeout(timer); } catch {}
             resolve(Object.assign({ provider: 'anthropic', durationMs: Date.now() - startedAt }, result));
         };
 
-        const timer = setTimeout(() => {
-            try { child.kill('SIGTERM'); } catch {}
-            finish({
-                ok: false,
-                error: { type: 'timeout', detail: `spawn anthropic superó timeoutMs=${timeoutMs}` },
-            });
-        }, Math.max(1_000, Number(timeoutMs) || DEFAULT_TIMEOUT_MS));
+        // timeoutMs === 0 → sin timeout: no armamos timer, el child corre hasta
+        // terminar. Solo si el caller pide un timeout > 0 lo respetamos.
+        const timer = Number(timeoutMs) > 0
+            ? setTimeout(() => {
+                try { child.kill('SIGTERM'); } catch {}
+                finish({
+                    ok: false,
+                    error: { type: 'timeout', detail: `spawn anthropic superó timeoutMs=${timeoutMs}` },
+                });
+            }, Number(timeoutMs))
+            : null;
 
         try {
             if (child.stdin && typeof child.stdin.write === 'function') {
@@ -809,162 +819,33 @@ async function verify(opts = {}) {
         _log('sherlock', `🛡️ CA-SEC-1: analysis recortado (injection patterns=${san.hits.join('|')})`);
     }
 
-    // Resolución de provider — itera la chain telegram-sherlock. #3484:
-    // YA NO se excluye al commanderProvider; solo se saltan providers que
-    // no tienen handler implementado en Sherlock.
+    // -------------------------------------------------------------------------
+    // CASCADA MULTI-PROVIDER (restaurada 2026-06-02, revierte #3668).
     //
-    // #3766 — el resolver YA NO hace swap intra-provider por igualdad de
-    // modelo. La adversariality nace del rol (prompt fiscal), no del modelo.
-    // `commanderModel` se sigue pasando solo para el cálculo de `sameModel`
-    // que se persiste al JSONL como forensics (sin influir en veredicto).
-    const resolved = resolveSherlockProvider({
-        excludedProvider: null,
-        commanderProvider,
-        commanderModel,
-        pipelineDir,
-        log: _log,
-        quotaModule,
-        dispatchModule,
-        fsImpl,
-        now: _now,
-    });
+    // Sherlock prueba el primer provider de la chain telegram-sherlock. Si ese
+    // provider falla (error de transporte, timeout explícito que pidiera algún
+    // caller, o output que no respeta el schema), lo excluye y salta al
+    // siguiente de la chain en vez de abortar. Solo cuando se agota TODA la
+    // chain devuelve `verdict: 'aborted'` + disclaimer F-6.
+    //
+    // NO hay timeout (Leo 2026-06-02 voz): `cfg.timeoutMs === 0`, así que cada
+    // provider corre hasta responder o errorar por su cuenta. La resiliencia
+    // ante un provider colgado la da esta cascada, no un corte por reloj.
+    //
+    // #3484: NO se excluye al commanderProvider; los providers sin handler
+    // (openai-codex stub) los saltea resolveSherlockProvider internamente.
+    // #3766: sin swap intra-provider — la adversariality nace del rol (prompt
+    // fiscal), no del modelo. `commanderModel` se usa solo para el cálculo de
+    // `sameModel` que se persiste al JSONL como forensics (sin influir en el
+    // veredicto).
+    //
+    // Shape de retorno (CA-9): `attemptCount` = providers efectivamente
+    // invocados, `fallbackUsed` = true si hubo más de 1 intento, `chainTried`
+    // = lista de providers recorridos (incluye los bloqueados por residency).
+    // -------------------------------------------------------------------------
 
-    if (!resolved) {
-        // CA-7 (#3668) — emitimos DOS eventos: el legacy `sherlock_verification`
-        // (consumido por dashboards históricos) y el nuevo
-        // `sherlock_skipped_provider_unavailable` (PO S-6 / CA-7). El segundo
-        // es la señal canónica de "Sherlock no pudo verificar por falta de
-        // provider" que el monitor de drift de calidad consume.
-        emitAuditEvent({
-            pipelineDir, fsImpl, auditLog, now: _now,
-            event: 'sherlock_verification',
-            payload: {
-                analysisHash: hashFor(analysis),
-                commanderProvider,
-                commanderModel,
-                durationMs: Date.now() - startedAt,
-                errorCode: 'no_provider',
-                sameProvider: false,
-                sameModel: false,
-                sherlockModel: null,
-                transport: null,
-            },
-        });
-        emitAuditEvent({
-            pipelineDir, fsImpl, auditLog, now: _now,
-            event: 'sherlock_skipped_provider_unavailable',
-            payload: {
-                analysisHash: hashFor(analysis),
-                commanderProvider,
-                commanderModel,
-                durationMs: Date.now() - startedAt,
-                errorCode: 'no_provider',
-                sameProvider: false,
-                sameModel: false,
-                sherlockModel: null,
-                transport: null,
-            },
-        });
-        return {
-            verdict: 'aborted',
-            reason: 'no_provider_available',
-            inconsistencies: [],
-            inconsistenciesTruncated: false,
-            sherlockProvider: null,
-            sherlockModel: null,
-            transport: null,
-            sameProvider: false,
-            sameModel: false,
-            commanderProvider,
-            commanderModel,
-            durationMs: Date.now() - startedAt,
-            inputTokens: 0,
-            outputTokens: 0,
-            errorCode: 'no_provider',
-            suggestedDisclaimer: DISCLAIMER_TYPES.TIMEOUT_OR_NO_PROVIDER,
-            // CA-9 (#3668) — shape stable post-single-provider:
-            attemptCount: 0,
-            fallbackUsed: false,
-            chainTried: [],
-        };
-    }
-
-    // CA-AUDIT-1 (#3484) — `sameProvider`/`sameModel` se siguen calculando y
-    // emitiendo al JSONL como forensics (lo lee el monitor de drift y los
-    // análisis ex-post). #3766: NO se usan como input al veredicto ni al
-    // disclaimer — la adversariality nace del rol, no del modelo. `sameModel`
-    // queda en false cuando el caller no pasa `commanderModel` (caso típico
-    // post-#3766 en pulpo.js).
-    const sameProvider = !!(commanderProvider && commanderProvider === resolved.provider);
-    const sameModel = !!(sameProvider && commanderModel && resolved.model && commanderModel === resolved.model);
-    if (sameProvider) {
-        _log('sherlock', `🔍 same_provider=true (commander=${commanderProvider}/${commanderModel || '?'}, sherlock=${resolved.provider}/${resolved.model || '?'}) — adversariality reducida (#3484 riesgo aceptado, #3766 sin swap)`);
-    }
-
-    // #3766 — el evento `sherlock_model_swap` (#3501) se eliminó: ya no hay
-    // policy de swap intra-provider, por lo que no hay nada que emitir aparte
-    // de los eventos canónicos (sherlock_verification, sherlock_skipped_*,
-    // sherlock_aborted_residency, sherlock_schema_violation).
-
-    // CA-SEC-3 — data-residency fail-closed ANTES del provider call.
-    const drCheck = commanderMP.enforceDataResidency({
-        pipelineDir,
-        provider: resolved.provider,
-        paths: [],
-        log: _log,
-        chatId: null,
-        prompt: safeAnalysis,
-        drfModule: _residency,
-        auditLog,
-        fsImpl,
-        now: _now,
-    });
-    if (!drCheck.ok) {
-        emitAuditEvent({
-            pipelineDir, fsImpl, auditLog, now: _now,
-            event: 'sherlock_aborted_residency',
-            payload: {
-                analysisHash: hashFor(analysis),
-                commanderProvider,
-                commanderModel,
-                sherlockProvider: resolved.provider,
-                durationMs: Date.now() - startedAt,
-                errorCode: drCheck.reason,
-                // CA-AUDIT-1 (#3484) — campos enriched a partir del resolved.
-                sameProvider,
-                sameModel,
-                sherlockModel: resolved.model,
-                transport: resolved.transport,
-            },
-        });
-        return {
-            verdict: 'aborted',
-            reason: `residency_${drCheck.reason}`,
-            inconsistencies: [],
-            inconsistenciesTruncated: false,
-            sherlockProvider: resolved.provider,
-            sherlockModel: resolved.model,
-            transport: resolved.transport,
-            sameProvider,
-            sameModel,
-            commanderProvider,
-            commanderModel,
-            durationMs: Date.now() - startedAt,
-            inputTokens: 0,
-            outputTokens: 0,
-            errorCode: 'residency_blocked',
-            suggestedDisclaimer: DISCLAIMER_TYPES.TIMEOUT_OR_NO_PROVIDER,
-            // #3766 — `modelSwap` se mantiene en el shape de retorno (siempre
-            // `swapped:false`) por back-compat con consumers downstream.
-            modelSwap: { swapped: false, originalModel: null, reason: null },
-            // CA-9 (#3668) — shape stable post-single-provider:
-            attemptCount: 0,
-            fallbackUsed: false,
-            chainTried: [resolved.provider],
-        };
-    }
-
-    // CA-SEC-2 — prompt con delimitadores XML.
+    // CA-SEC-2 — prompt con delimitadores XML. Es provider-independiente, así
+    // que se arma una sola vez antes de la cascada.
     const prompt = buildFiscalPrompt({
         analysis: safeAnalysis,
         originalRequest,
@@ -972,24 +853,15 @@ async function verify(opts = {}) {
         lastHourLogs,
     });
 
-    // -------------------------------------------------------------------------
-    // #3668 — Invocación single-provider (sin cascada).
-    //
-    // Reemplaza la cascada de #3558 (lib/sherlock-retry-chain.js, eliminado).
-    // Sherlock invoca 1 sola vez al provider resuelto; si falla, devuelve
-    // `verdict: 'aborted'` + disclaimer F-6 y el caller (pulpo.js) sigue al
-    // contrato `recogerTextoLibre` con el disclaimer aplicado.
-    //
-    // El shape de retorno preserva `attemptCount`/`fallbackUsed`/`chainTried`
-    // (CA-9) para no romper consumers downstream del audit JSONL — colapsan
-    // a `1`/`false`/`[provider]` siempre, pero las keys existen.
-    // -------------------------------------------------------------------------
+    // #3766 — `modelSwap` queda como shape estable (siempre `swapped:false`)
+    // por back-compat con consumers que lo leen (formatVerifiedFooter,
+    // dashboards históricos, JSONL viejo). La policy de swap del #3501 se
+    // eliminó; el field se conserva para no obligar a un breaking change.
+    const modelSwap = { swapped: false, originalModel: null, reason: null };
 
-    // `singleProviderComplete` encapsula la decisión HTTP vs spawn según el
-    // transport del resolved. Lo mantenemos como función local para que el
-    // shape del retorno sea uniforme con lo que esperaban los consumers de la
-    // cascada removida.
-    async function singleProviderComplete() {
+    // `completeWith` encapsula la decisión HTTP vs spawn según el transport del
+    // provider resuelto. Devuelve el shape canónico `{ok, content, ...}`.
+    async function completeWith(resolved) {
         if (resolved.transport === 'spawn' && resolved.provider === 'anthropic') {
             const r = await _spawnAnthropic({
                 prompt,
@@ -1012,97 +884,195 @@ async function verify(opts = {}) {
         });
     }
 
-    let httpResult;
-    try {
-        httpResult = await singleProviderComplete();
-    } catch (e) {
-        // Defensive: el completion-client / spawn helper deberían devolver
-        // siempre `{ok:false, error:{...}}` en lugar de tirar — si tiran,
-        // normalizamos al mismo shape para no romper el flow.
-        httpResult = {
-            ok: false,
-            error: { type: 'provider_exception', detail: e && e.message ? e.message : String(e) },
-            durationMs: 0,
-        };
-    }
+    const excludedProviders = new Set(); // providers ya intentados que fallaron
+    const chainTried = [];               // providers recorridos, en orden
+    let attemptCount = 0;                // providers efectivamente invocados
+    let lastResolved = null;            // último provider resuelto (para shape)
+    let lastSameProvider = false;
+    let lastSameModel = false;
+    let lastErrorCode = 'no_provider';
+    let lastErrorIsTimeout = false;
+    let lastErrorIsResidency = false;
 
-    const totalMs = Date.now() - startedAt;
+    // Cap defensivo del outer loop — la chain telegram-sherlock es chica; este
+    // número solo evita un loop infinito si el resolver devolviera siempre el
+    // mismo provider (no debería: excluimos cada provider tras fallar).
+    const MAX_CASCADE_ITERATIONS = 10;
 
-    // #3766 — `modelSwap` queda como shape estable (siempre `swapped:false`)
-    // por back-compat con consumers que lo leen (formatVerifiedFooter,
-    // dashboards históricos, JSONL viejo). El swap intra-provider del #3501
-    // se eliminó; el field se conserva para no obligar a un breaking change
-    // en downstream.
-    const initialModelSwap = { swapped: false, originalModel: null, reason: null };
-
-    // -------------------------------------------------------------------------
-    // ERROR PATH — provider falló (timeout, http_error, spawn_failed, etc.)
-    // -------------------------------------------------------------------------
-    if (!httpResult || !httpResult.ok) {
-        const lastErr = (httpResult && httpResult.error) || { type: 'unknown' };
-        const errorCode = lastErr.reason || lastErr.type || 'unknown';
-        emitAuditEvent({
-            pipelineDir, fsImpl, auditLog, now: _now,
-            event: 'sherlock_verification',
-            payload: {
-                analysisHash: hashFor(analysis),
-                commanderProvider,
-                commanderModel,
-                sherlockProvider: resolved.provider,
-                durationMs: totalMs,
-                errorCode,
-                sameProvider,
-                sameModel,
-                sherlockModel: resolved.model,
-                transport: resolved.transport,
-            },
-        });
-        return {
-            verdict: 'aborted',
-            reason: lastErr.type === 'timeout' ? 'timeout' : `provider_error:${errorCode}`,
-            inconsistencies: [],
-            inconsistenciesTruncated: false,
-            sherlockProvider: resolved.provider,
-            sherlockModel: resolved.model,
-            transport: resolved.transport,
-            sameProvider,
-            sameModel,
+    for (let iter = 0; iter < MAX_CASCADE_ITERATIONS; iter++) {
+        // Resolución de provider — itera la chain telegram-sherlock arrancando
+        // con los providers ya intentados en `excludedProviders`. #3484: NO se
+        // excluye al commanderProvider; solo se saltan providers sin handler.
+        const resolved = resolveSherlockProvider({
+            excludedProvider: null,
             commanderProvider,
             commanderModel,
-            durationMs: totalMs,
-            inputTokens: 0,
-            outputTokens: 0,
-            errorCode,
-            suggestedDisclaimer: DISCLAIMER_TYPES.TIMEOUT_OR_NO_PROVIDER,
-            modelSwap: initialModelSwap,
-            // CA-9 (#3668) — shape stable post-single-provider:
-            attemptCount: 1,
-            fallbackUsed: false,
-            chainTried: [resolved.provider],
-        };
-    }
-
-    // -------------------------------------------------------------------------
-    // SCHEMA VALIDATION — parsear + validar el output del Sherlock (CA-SEC-6).
-    // -------------------------------------------------------------------------
-    const parsed = parseAndValidateSherlockOutput(httpResult.content);
-    if (!parsed.ok) {
-        emitAuditEvent({
-            pipelineDir, fsImpl, auditLog, now: _now,
-            event: 'sherlock_schema_violation',
-            payload: {
-                analysisHash: hashFor(analysis),
-                commanderProvider,
-                commanderModel,
-                sherlockProvider: resolved.provider,
-                durationMs: totalMs,
-                errorCode: parsed.reason,
-                sameProvider,
-                sameModel,
-                sherlockModel: resolved.model,
-                transport: resolved.transport,
-            },
+            initialExcluded: excludedProviders,
+            pipelineDir,
+            log: _log,
+            quotaModule,
+            dispatchModule,
+            fsImpl,
+            now: _now,
         });
+
+        if (!resolved) break; // chain agotada (o ningún provider disponible)
+
+        lastResolved = resolved;
+
+        // CA-AUDIT-1 (#3484) — `sameProvider`/`sameModel` se calculan por intento
+        // y se persisten al JSONL como forensics (los lee el monitor de drift).
+        // #3766: NO influyen en el veredicto ni en el disclaimer.
+        const sameProvider = !!(commanderProvider && commanderProvider === resolved.provider);
+        const sameModel = !!(sameProvider && commanderModel && resolved.model && commanderModel === resolved.model);
+        lastSameProvider = sameProvider;
+        lastSameModel = sameModel;
+        if (sameProvider) {
+            _log('sherlock', `🔍 same_provider=true (commander=${commanderProvider}/${commanderModel || '?'}, sherlock=${resolved.provider}/${resolved.model || '?'}) — adversariality reducida (#3484 riesgo aceptado, #3766 sin swap)`);
+        }
+
+        // CA-SEC-3 — data-residency fail-closed ANTES del provider call. Si este
+        // provider está bloqueado por residency lo excluimos y la cascada sigue
+        // con el siguiente (otro provider podría estar permitido para este dato).
+        const drCheck = commanderMP.enforceDataResidency({
+            pipelineDir,
+            provider: resolved.provider,
+            paths: [],
+            log: _log,
+            chatId: null,
+            prompt: safeAnalysis,
+            drfModule: _residency,
+            auditLog,
+            fsImpl,
+            now: _now,
+        });
+        if (!drCheck.ok) {
+            emitAuditEvent({
+                pipelineDir, fsImpl, auditLog, now: _now,
+                event: 'sherlock_aborted_residency',
+                payload: {
+                    analysisHash: hashFor(analysis),
+                    commanderProvider,
+                    commanderModel,
+                    sherlockProvider: resolved.provider,
+                    durationMs: Date.now() - startedAt,
+                    errorCode: drCheck.reason,
+                    sameProvider,
+                    sameModel,
+                    sherlockModel: resolved.model,
+                    transport: resolved.transport,
+                },
+            });
+            lastErrorCode = 'residency_blocked';
+            lastErrorIsTimeout = false;
+            lastErrorIsResidency = true;
+            chainTried.push(resolved.provider);
+            excludedProviders.add(resolved.provider);
+            continue;
+        }
+
+        attemptCount++;
+        chainTried.push(resolved.provider);
+
+        let httpResult;
+        try {
+            httpResult = await completeWith(resolved);
+        } catch (e) {
+            // Defensive: el completion-client / spawn helper deberían devolver
+            // siempre `{ok:false, error:{...}}` en lugar de tirar — si tiran,
+            // normalizamos al mismo shape para no romper la cascada.
+            httpResult = {
+                ok: false,
+                error: { type: 'provider_exception', detail: e && e.message ? e.message : String(e) },
+                durationMs: 0,
+            };
+        }
+
+        // ---------------------------------------------------------------------
+        // ERROR PATH — provider falló (timeout, http_error, spawn_failed, etc.)
+        // → excluir y saltar al siguiente de la chain.
+        // ---------------------------------------------------------------------
+        if (!httpResult || !httpResult.ok) {
+            const lastErr = (httpResult && httpResult.error) || { type: 'unknown' };
+            const errorCode = lastErr.reason || lastErr.type || 'unknown';
+            emitAuditEvent({
+                pipelineDir, fsImpl, auditLog, now: _now,
+                event: 'sherlock_verification',
+                payload: {
+                    analysisHash: hashFor(analysis),
+                    commanderProvider,
+                    commanderModel,
+                    sherlockProvider: resolved.provider,
+                    durationMs: Date.now() - startedAt,
+                    errorCode,
+                    sameProvider,
+                    sameModel,
+                    sherlockModel: resolved.model,
+                    transport: resolved.transport,
+                },
+            });
+            lastErrorCode = errorCode;
+            lastErrorIsTimeout = lastErr.type === 'timeout';
+            lastErrorIsResidency = false;
+            _log('sherlock', `provider ${resolved.provider} falló (${errorCode}) — cascada al siguiente`);
+            excludedProviders.add(resolved.provider);
+            continue;
+        }
+
+        // ---------------------------------------------------------------------
+        // SCHEMA VALIDATION — parsear + validar (CA-SEC-6). Si el output no
+        // respeta el schema tratamos al provider como fallido y cascadeamos.
+        // ---------------------------------------------------------------------
+        const parsed = parseAndValidateSherlockOutput(httpResult.content);
+        if (!parsed.ok) {
+            emitAuditEvent({
+                pipelineDir, fsImpl, auditLog, now: _now,
+                event: 'sherlock_schema_violation',
+                payload: {
+                    analysisHash: hashFor(analysis),
+                    commanderProvider,
+                    commanderModel,
+                    sherlockProvider: resolved.provider,
+                    durationMs: Date.now() - startedAt,
+                    errorCode: parsed.reason,
+                    sameProvider,
+                    sameModel,
+                    sherlockModel: resolved.model,
+                    transport: resolved.transport,
+                },
+            });
+            emitAuditEvent({
+                pipelineDir, fsImpl, auditLog, now: _now,
+                event: 'sherlock_verification',
+                payload: {
+                    analysisHash: hashFor(analysis),
+                    commanderProvider,
+                    commanderModel,
+                    sherlockProvider: resolved.provider,
+                    durationMs: Date.now() - startedAt,
+                    errorCode: 'schema_violation',
+                    sameProvider,
+                    sameModel,
+                    sherlockModel: resolved.model,
+                    transport: resolved.transport,
+                },
+            });
+            lastErrorCode = 'schema_violation';
+            lastErrorIsTimeout = false;
+            lastErrorIsResidency = false;
+            _log('sherlock', `provider ${resolved.provider} devolvió schema inválido (${parsed.reason}) — cascada al siguiente`);
+            excludedProviders.add(resolved.provider);
+            continue;
+        }
+
+        // ---------------------------------------------------------------------
+        // SUCCESS PATH — verdict ok o rechazado con schema válido.
+        // ---------------------------------------------------------------------
+        const totalMs = Date.now() - startedAt;
+        // CA-SEC-8 — solo hashes en el audit log (claim/contradiction nunca crudos).
+        const claimHashes = parsed.data.inconsistencies.map(it => hashFor(it.claim));
+        const contradictionHashes = parsed.data.inconsistencies.map(it => hashFor(it.contradiction));
+
         emitAuditEvent({
             pipelineDir, fsImpl, auditLog, now: _now,
             event: 'sherlock_verification',
@@ -1112,18 +1082,21 @@ async function verify(opts = {}) {
                 commanderModel,
                 sherlockProvider: resolved.provider,
                 durationMs: totalMs,
-                errorCode: 'schema_violation',
+                inputTokens: httpResult.inputTokens,
+                outputTokens: httpResult.outputTokens,
+                errorCode: null,
                 sameProvider,
                 sameModel,
                 sherlockModel: resolved.model,
                 transport: resolved.transport,
             },
         });
+
         return {
-            verdict: 'aborted',
-            reason: `schema_violation:${parsed.reason}`,
-            inconsistencies: [],
-            inconsistenciesTruncated: false,
+            verdict: parsed.data.verdict,
+            reason: parsed.data.reason,
+            inconsistencies: parsed.data.inconsistencies,
+            inconsistenciesTruncated: parsed.data.inconsistenciesTruncated,
             sherlockProvider: resolved.provider,
             sherlockModel: resolved.model,
             transport: resolved.transport,
@@ -1134,69 +1107,120 @@ async function verify(opts = {}) {
             durationMs: totalMs,
             inputTokens: httpResult.inputTokens || 0,
             outputTokens: httpResult.outputTokens || 0,
-            errorCode: 'schema_violation',
-            suggestedDisclaimer: DISCLAIMER_TYPES.TIMEOUT_OR_NO_PROVIDER,
-            modelSwap: initialModelSwap,
-            // CA-9 (#3668) — shape stable post-single-provider:
-            attemptCount: 1,
-            fallbackUsed: false,
-            chainTried: [resolved.provider],
+            errorCode: null,
+            suggestedDisclaimer: DISCLAIMER_TYPES.NONE, // el caller decide F-5 vs nada
+            claimHashes,
+            contradictionHashes,
+            modelSwap,
+            // CA-9 — shape stable; con cascada reflejan el recorrido real.
+            attemptCount,
+            fallbackUsed: attemptCount > 1,
+            chainTried: chainTried.slice(),
         };
     }
 
     // -------------------------------------------------------------------------
-    // SUCCESS PATH — verdict ok o rechazado con schema válido.
+    // CHAIN AGOTADA — ningún provider de la chain pudo verificar.
     // -------------------------------------------------------------------------
+    const totalMs = Date.now() - startedAt;
 
-    // CA-SEC-8 — solo hashes en el audit log (claim/contradiction nunca crudos).
-    const claimHashes = parsed.data.inconsistencies.map(it => hashFor(it.claim));
-    const contradictionHashes = parsed.data.inconsistencies.map(it => hashFor(it.contradiction));
-
-    emitAuditEvent({
-        pipelineDir, fsImpl, auditLog, now: _now,
-        event: 'sherlock_verification',
-        payload: {
-            analysisHash: hashFor(analysis),
+    if (!lastResolved) {
+        // No se pudo resolver NINGÚN provider (todos gated / sin handler).
+        // CA-7 (#3668) — emitimos DOS eventos: el legacy `sherlock_verification`
+        // (consumido por dashboards históricos) y el canónico
+        // `sherlock_skipped_provider_unavailable` (PO S-6 / CA-7), que es la
+        // señal de "Sherlock no pudo verificar por falta de provider".
+        emitAuditEvent({
+            pipelineDir, fsImpl, auditLog, now: _now,
+            event: 'sherlock_verification',
+            payload: {
+                analysisHash: hashFor(analysis),
+                commanderProvider,
+                commanderModel,
+                durationMs: totalMs,
+                errorCode: 'no_provider',
+                sameProvider: false,
+                sameModel: false,
+                sherlockModel: null,
+                transport: null,
+            },
+        });
+        emitAuditEvent({
+            pipelineDir, fsImpl, auditLog, now: _now,
+            event: 'sherlock_skipped_provider_unavailable',
+            payload: {
+                analysisHash: hashFor(analysis),
+                commanderProvider,
+                commanderModel,
+                durationMs: totalMs,
+                errorCode: 'no_provider',
+                sameProvider: false,
+                sameModel: false,
+                sherlockModel: null,
+                transport: null,
+            },
+        });
+        return {
+            verdict: 'aborted',
+            reason: 'no_provider_available',
+            inconsistencies: [],
+            inconsistenciesTruncated: false,
+            sherlockProvider: null,
+            sherlockModel: null,
+            transport: null,
+            sameProvider: false,
+            sameModel: false,
             commanderProvider,
             commanderModel,
-            sherlockProvider: resolved.provider,
             durationMs: totalMs,
-            inputTokens: httpResult.inputTokens,
-            outputTokens: httpResult.outputTokens,
-            errorCode: null,
-            sameProvider,
-            sameModel,
-            sherlockModel: resolved.model,
-            transport: resolved.transport,
-        },
-    });
+            inputTokens: 0,
+            outputTokens: 0,
+            errorCode: 'no_provider',
+            suggestedDisclaimer: DISCLAIMER_TYPES.TIMEOUT_OR_NO_PROVIDER,
+            modelSwap,
+            attemptCount: 0,
+            fallbackUsed: false,
+            chainTried: chainTried.slice(),
+        };
+    }
+
+    // Resolvimos uno o más providers pero TODA la chain falló (error, schema o
+    // residency). El errorCode/reason refleja el ÚLTIMO fallo de la cascada.
+    let abortedReason;
+    let abortedErrorCode;
+    if (lastErrorIsResidency) {
+        abortedReason = 'residency_blocked';
+        abortedErrorCode = 'residency_blocked';
+    } else if (lastErrorIsTimeout) {
+        abortedReason = 'timeout';
+        abortedErrorCode = lastErrorCode;
+    } else {
+        abortedReason = `provider_error:${lastErrorCode}`;
+        abortedErrorCode = lastErrorCode;
+    }
 
     return {
-        verdict: parsed.data.verdict,
-        reason: parsed.data.reason,
-        inconsistencies: parsed.data.inconsistencies,
-        inconsistenciesTruncated: parsed.data.inconsistenciesTruncated,
-        sherlockProvider: resolved.provider,
-        sherlockModel: resolved.model,
-        transport: resolved.transport,
-        sameProvider,
-        sameModel,
+        verdict: 'aborted',
+        reason: abortedReason,
+        inconsistencies: [],
+        inconsistenciesTruncated: false,
+        sherlockProvider: lastResolved.provider,
+        sherlockModel: lastResolved.model,
+        transport: lastResolved.transport,
+        sameProvider: lastSameProvider,
+        sameModel: lastSameModel,
         commanderProvider,
         commanderModel,
         durationMs: totalMs,
-        inputTokens: httpResult.inputTokens || 0,
-        outputTokens: httpResult.outputTokens || 0,
-        errorCode: null,
-        suggestedDisclaimer: DISCLAIMER_TYPES.NONE, // el caller decide F-5 vs nada
-        claimHashes,
-        contradictionHashes,
-        // #3766 — `modelSwap` siempre `swapped:false` post-refactor (la
-        // policy #3501 se removió). Field mantenido por back-compat.
-        modelSwap: initialModelSwap,
-        // CA-9 (#3668) — shape stable post-single-provider:
-        attemptCount: 1,
-        fallbackUsed: false,
-        chainTried: [resolved.provider],
+        inputTokens: 0,
+        outputTokens: 0,
+        errorCode: abortedErrorCode,
+        suggestedDisclaimer: DISCLAIMER_TYPES.TIMEOUT_OR_NO_PROVIDER,
+        modelSwap,
+        // CA-9 — shape stable; reflejan el recorrido real de la cascada.
+        attemptCount,
+        fallbackUsed: attemptCount > 1,
+        chainTried: chainTried.slice(),
     };
 }
 


### PR DESCRIPTION
## Que cambia

El verificador adversarial **Sherlock** ya no impone timeout y reintenta en **cascada** entre providers: si uno falla, salta al siguiente de la chain hasta agotarla (misma semantica que el probador de agentes).

### Detalle tecnico
- `DEFAULT_TIMEOUT_MS` = **0** (sin timeout; antes 90s)
- `ABSOLUTE_MAX_TIMEOUT_MS` (cap 180s) **eliminado** — el cliente espera lo que tarde el provider
- `sherlock_timeout_ms` en config queda **NO-OP** (back-compat, no rompe)
- `verify()` reescrito con **cascada provider-a-provider**
- Tests actualizados a la nueva semantica

### Tests
- `sherlock-verifier`: **56/56**
- `completion-client`: **37/37**
- Total **93/93 verdes**

Scope del diff: **solo** `sherlock-verifier.js`, `completion-client.js` y sus tests. Cero estado del pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)