### PR TITLE
fix: Los 4 puntos finales del multi-provider (#3791)

### DIFF
--- a/.pipeline/lib/__tests__/commander-multi-provider.test.js
+++ b/.pipeline/lib/__tests__/commander-multi-provider.test.js
@@ -374,20 +374,27 @@ test('CA-6 — readCommanderStats agrega entradas por provider efectivo', () => 
 });
 
 // -----------------------------------------------------------------------------
-// SR-2 — safeBuildSpawn captura el throw de los stubs no implementados
+// SR-2 — safeBuildSpawn devuelve spawnDef OK para los adapters reales y captura
+// el throw solo si un handler futuro volviera a ser stub.
 // -----------------------------------------------------------------------------
 
-test('SR-2 — safeBuildSpawn captura _notImplemented del stub openai-codex', () => {
+test('SR-2 — safeBuildSpawn devuelve spawnDef OK con handler openai-codex (real desde PR #3792)', () => {
     const codexHandler = require('../agent-launcher/providers/openai-codex');
-    const r = cmp.safeBuildSpawn({
-        handler: codexHandler,
-        args: ['exec'],
-        cwd: '/tmp',
-        env: {},
-    });
-    assert.equal(r.ok, false);
-    assert.equal(r.reason, 'not_implemented');
-    assert.match(r.message, /openai-codex/);
+    // Forzamos un launcher fake para no depender del binario `codex` real.
+    codexHandler._setLauncherForTesting({ kind: 'test', cmd: '/bin/true', prefixArgs: [], shell: false });
+    try {
+        const r = cmp.safeBuildSpawn({
+            handler: codexHandler,
+            args: ['-p'],
+            cwd: '/tmp',
+            env: {},
+        });
+        assert.equal(r.ok, true);
+        assert.ok(r.spawnDef);
+        assert.equal(r.spawnDef.cmd, '/bin/true');
+    } finally {
+        codexHandler._resetLauncherCacheForTesting();
+    }
 });
 
 test('SR-2 — safeBuildSpawn devuelve spawnDef OK con handler anthropic', () => {
@@ -425,7 +432,9 @@ test('CA-1 / CA-2 — agent-models.json real tiene telegram-commander con orden 
     assert.equal(cmd.provider, 'anthropic');
     const chain = (cmd.fallbacks || []).map(f => f.provider);
     // #3353 — groq removido del orden de fallback del telegram-commander.
-    assert.deepEqual(chain, ['openai-codex', 'gemini-google', 'cerebras']);
+    // 2026-06-02 — nvidia-nim sumado al final de la cadena del Commander
+    // (adapter real, PR #3793) para cerrar el gap multi-provider.
+    assert.deepEqual(chain, ['openai-codex', 'gemini-google', 'cerebras', 'nvidia-nim']);
 });
 
 // -----------------------------------------------------------------------------

--- a/.pipeline/lib/__tests__/sherlock-verifier.test.js
+++ b/.pipeline/lib/__tests__/sherlock-verifier.test.js
@@ -141,6 +141,17 @@ function fakeSpawnAnthropic(responseOrFn) {
     };
 }
 
+// Codex es real desde 2026-06-02 (spawn CLI, PR #3792). Lo inyectamos en los
+// tests con el mismo shape que fakeSpawnAnthropic para evitar spawnear el
+// binario `codex` real en CI.
+function fakeSpawnCodex(responseOrFn) {
+    return async (opts) => {
+        const r = typeof responseOrFn === 'function' ? responseOrFn(opts) : responseOrFn;
+        if (r && typeof r.then === 'function') return await r;
+        return r;
+    };
+}
+
 // =============================================================================
 // T-1 — Escenario "issue bloqueado humano" → Sherlock detecta inconsistencia
 // y devuelve verdict=rechazado con la lista de inconsistencias.
@@ -640,11 +651,12 @@ test('CA-SEC-9 (#3484): sin sherlock_timeout_ms — también devuelve DEFAULT', 
 });
 
 // =============================================================================
-// Extra — resolveSherlockProvider salta providers sin handler implementado
-// (openai-codex sigue siendo stub). #3484: anthropic AHORA tiene handler
-// (spawn), así que no se salta.
+// Extra — resolveSherlockProvider con los 5 providers de la chain con handler.
+// #3484: anthropic tiene handler (spawn). 2026-06-02: openai-codex AHORA es
+// real (spawn CLI, PR #3792), así que tampoco se salta — el resolver devuelve
+// el primero de la chain con su transport.
 // =============================================================================
-test('resolveSherlockProvider salta openai-codex (stub) y devuelve cerebras (HTTP)', () => {
+test('resolveSherlockProvider devuelve openai-codex con transport=spawn (real desde 2026-06-02)', () => {
     const chain = [
         { provider: 'openai-codex', model: 'gpt-5' },
         { provider: 'cerebras', model: 'llama-3.3-70b' },
@@ -657,8 +669,8 @@ test('resolveSherlockProvider salta openai-codex (stub) y devuelve cerebras (HTT
         dispatchModule: fakeDispatcher({ providerChain: chain }),
     });
     assert.ok(r);
-    assert.equal(r.provider, 'cerebras');
-    assert.equal(r.transport, 'http');
+    assert.equal(r.provider, 'openai-codex');
+    assert.equal(r.transport, 'spawn');
 });
 
 test('resolveSherlockProvider devuelve anthropic con transport=spawn (#3484)', () => {
@@ -678,11 +690,13 @@ test('resolveSherlockProvider devuelve anthropic con transport=spawn (#3484)', (
     assert.equal(r.transport, 'spawn');
 });
 
-test('resolveSherlockProvider devuelve null si toda la chain es stub-only (no handler)', () => {
-    // Solo openai-codex en la chain (stub sin handler) — Sherlock no tiene
-    // a quién invocar y devuelve null.
+test('resolveSherlockProvider devuelve null si la chain no tiene provider con handler', () => {
+    // Solo `deterministic` en la chain — no es ni HTTP-completion ni spawn-CLI,
+    // así que Sherlock no tiene a quién invocar y devuelve null. (Antes este
+    // caso se cubría con openai-codex stub; desde 2026-06-02 codex es real, por
+    // eso usamos un provider que genuinamente no tiene handler en Sherlock.)
     const chain = [
-        { provider: 'openai-codex', model: 'gpt-5' },
+        { provider: 'deterministic', model: 'rules-engine' },
     ];
     const r = sherlock._resolveSherlockProvider({
         excludedProvider: null,
@@ -827,14 +841,16 @@ test('#3484 CA-SHERLOCK-5: si toda la chain falla, Sherlock devuelve aborted + F
         configLoader: defaultConfigLoader(),
         completionClient: fakeCompletionClient({ ok: false, error: { type: 'http_error' }, durationMs: 100 }),
         spawnAnthropic: fakeSpawnAnthropic({ ok: false, error: { type: 'spawn_failed' }, durationMs: 0 }),
-        // Solo openai-codex en la chain — stub, sin handler. Sherlock no
-        // tiene a quién invocar → aborted con errorCode=no_provider.
+        // Codex es real desde 2026-06-02: la cascada SÍ lo invoca (spawn). Con el
+        // fake fallando, agota la chain y aborta. El errorCode ahora refleja el
+        // último fallo real del provider (spawn_failed), ya no 'no_provider'.
+        spawnCodex: fakeSpawnCodex({ ok: false, error: { type: 'spawn_failed' }, durationMs: 0 }),
         quotaModule: fakeQuotaAllPass(),
         dispatchModule: fakeDispatcher({ providerChain: [{ provider: 'openai-codex', model: 'gpt-5' }] }),
         residencyModule: fakeResidencyOk(),
     });
     assert.equal(result.verdict, 'aborted');
-    assert.equal(result.errorCode, 'no_provider');
+    assert.equal(result.errorCode, 'spawn_failed');
     assert.equal(result.suggestedDisclaimer, sherlock.DISCLAIMER_TYPES.TIMEOUT_OR_NO_PROVIDER);
 });
 

--- a/.pipeline/lib/commander/multi-provider.js
+++ b/.pipeline/lib/commander/multi-provider.js
@@ -36,17 +36,17 @@
 // pre-spawn solamente el budget efectivo es el HARD_TIMEOUT_MS del spawn
 // único (10 min en pulpo.js). Reservamos la primitiva para que #3275 la use.
 //
-// STUBS DE PROVIDER
-// -----------------
-// Los providers no-Anthropic (`openai-codex`, `gemini-google`, `cerebras`,
-// `nvidia-nim`) hoy son **stubs** que tiran `_notImplemented` en `buildSpawn`
-// (lib/agent-launcher/providers/*.js). El runtime real llega con #3198.
+// ADAPTERS DE PROVIDER (estado 2026-06-02)
+// ----------------------------------------
+// Los 5 providers (`anthropic`, `openai-codex`, `gemini-google`, `cerebras`,
+// `nvidia-nim`) hoy tienen **adapter real** en lib/agent-launcher/providers/*.js
+// (PRs #3792/#3793/#3794 cerraron los últimos stubs del histórico #3198).
+// `buildSpawn` ya NO tira `_notImplemented` para ninguno de ellos.
 //
-// Mientras tanto, la cadena resuelve correctamente al provider (pre-spawn)
-// pero el caller debe `try/catch` el `buildSpawn` y caer al canned response
-// "no implementado todavía". Este módulo expone `safeBuildSpawn(resolution,
-// args, env)` que hace ese catch y devuelve `{ ok: false, reason }` en vez
-// de propagar el throw.
+// `safeBuildSpawn(...)` se mantiene como guardia defensiva: envuelve
+// `handler.buildSpawn` y devuelve `{ ok: false, reason }` en vez de propagar
+// un throw si un provider futuro volviera a ser stub o el handler fallara.
+// El caller decide el canned response sólo en ese caso de borde.
 //
 // COMPATIBILIDAD
 // --------------
@@ -860,7 +860,7 @@ function _selectErrorTypeForFlag(provider, verdict, quotaModule) {
 
 // -----------------------------------------------------------------------------
 // safeBuildSpawn — wrapper defensivo para `handler.buildSpawn` que captura
-// el throw de los stubs no implementados (#3198 pendiente).
+// un eventual throw (guardia residual; hoy los 5 adapters son reales).
 //
 // Devuelve `{ ok: true, spawnDef }` o `{ ok: false, reason }`. El caller
 // (pulpo.js) decide si fallback canned, audit log + Telegram, etc.
@@ -878,15 +878,14 @@ function safeBuildSpawn({ handler, args, cwd, env }) {
 }
 
 // -----------------------------------------------------------------------------
-// cannedFallbackUnavailableResponse — Mensaje al usuario cuando el dispatcher
-// resolvió un fallback pero el `buildSpawn` del provider stub tira
-// `_notImplemented`. Mensaje no técnico, sin paths internos.
+// cannedFallbackUnavailableResponse — Mensaje al usuario para el caso de borde
+// en que el dispatcher resolvió un fallback pero su `buildSpawn` falla (handler
+// roto / binario ausente). Mensaje no técnico, sin paths internos.
 // -----------------------------------------------------------------------------
 function cannedFallbackUnavailableResponse({ provider }) {
     return (
-        `⚠️ Claude no responde y todavía no tengo el provider \`${provider}\` instalado para contestarte. ` +
-        `Lo destrabamos cuando se cierre #3198 (runtime de fallback). ` +
-        `Mientras tanto, podés usar los comandos directos (/status, /listado, /lanzar) que no dependen de LLM.`
+        `⚠️ Claude no responde y el provider de respaldo \`${provider}\` no arrancó (binario o credencial faltante). ` +
+        `Mientras lo reviso, podés usar los comandos directos (/status, /listado, /lanzar) que no dependen de LLM.`
     );
 }
 

--- a/.pipeline/lib/multi-provider/completion-client.js
+++ b/.pipeline/lib/multi-provider/completion-client.js
@@ -6,11 +6,11 @@
 //   - El spawn de CLI (`claude`/`codex`/etc.) agrega 2-5s de overhead de arranque.
 //   - El Sherlock verifier (#3331) requiere latencia <1s → necesita invocar el
 //     provider directamente vía API HTTP, sin pasar por CLI.
-//   - #3198 (adapters runtime) sigue pendiente, así que `safeBuildSpawn` tira
-//     `_notImplemented` para `openai-codex`, `gemini-google`, `cerebras`,
-//     `nvidia-nim`. Este módulo es el **habilitador genérico** para futuras
-//     integraciones in-process (dispatcher Commander cuando se valide latencia,
-//     etc.).
+//   - Los adapters de spawn (`openai-codex`, `gemini-google`, `cerebras`,
+//     `nvidia-nim`, `anthropic`) ya son reales (histórico #3198, cerrado por
+//     PRs #3792/#3793/#3794). Este módulo sigue siendo el camino HTTP
+//     in-process para los providers OpenAI-compat (sin overhead de spawn),
+//     usado por Sherlock; los providers OAuth (anthropic/codex) van por spawn.
 //
 // Providers cubiertos (alineados con FREE_PROVIDERS en health-alerts.js):
 //   - cerebras       (Llama 3.x / Llama 4 scout, OpenAI-compat)

--- a/.pipeline/lib/sherlock-verifier.js
+++ b/.pipeline/lib/sherlock-verifier.js
@@ -33,8 +33,10 @@
 //   1. Se removió el filtro `HTTP_COMPATIBLE_PROVIDERS` que saltaba providers
 //      no-HTTP. Sherlock ahora acepta cualquier provider de la chain
 //      telegram-sherlock. Para Anthropic usa spawn CLI (Opción B) reusando
-//      `agent-launcher/providers/anthropic.js`. Codex sigue siendo stub
-//      (#3076 H3 pendiente) y se salta con gracia hasta que H3 entregue.
+//      `agent-launcher/providers/anthropic.js`. Codex también vía spawn CLI
+//      (`agent-launcher/providers/openai-codex.js`, JSONL → agent_message) —
+//      wireado 2026-06-02 (PR #3792 dejó el adapter real; antes era stub
+//      #3076 H3 y se salteaba con gracia).
 //   2. Se removió el clamp local de timeout (`ABSOLUTE_MAX_TIMEOUT_MS=30s`).
 //      El presupuesto vive en el cliente HTTP (90s default, 180s cap).
 //   3. Se removió la exclusión cross-provider — Sherlock puede usar el mismo
@@ -147,11 +149,18 @@ const HTTP_COMPLETION_PROVIDERS = Object.freeze(new Set([
 ]));
 
 // Providers que Sherlock invoca vía spawn CLI (Opción B de #3484).
-// Anthropic es el único soportado hoy: reusa el launcher detection de
-// `agent-launcher/providers/anthropic.js` y manda el prompt por stdin con
-// `--output-format text`. Codex queda pendiente (#3076 H3).
+//   - anthropic:    reusa `agent-launcher/providers/anthropic.js`, manda el
+//                   prompt por stdin con `--output-format text` y lee el
+//                   stdout como texto plano.
+//   - openai-codex: reusa `agent-launcher/providers/openai-codex.js`, manda el
+//                   prompt como argumento posicional (`-p <prompt>`) con
+//                   `CODEX_MODEL` en el env y parsea el stdout JSONL de
+//                   `codex exec --json` para extraer el `agent_message`
+//                   (transporte agregado 2026-06-02 — antes era stub #3076 H3,
+//                   hoy el adapter es real, PR #3792).
 const SPAWN_COMPLETION_PROVIDERS = Object.freeze(new Set([
     'anthropic',
+    'openai-codex',
 ]));
 
 // Timeout default que Sherlock pasa al completion-client / spawn helper.
@@ -401,7 +410,10 @@ function resolveSherlockProvider({
 }) {
     // #3484: `excludedProvider` se ignora a propósito (back-compat). El
     // único motivo para excluir un provider acá es que NO tengamos handler
-    // implementado todavía (ej. openai-codex es stub).
+    // (HTTP o spawn) implementado en Sherlock para él. Hoy los 5 providers de
+    // la chain telegram-sherlock tienen handler (cerebras/gemini/nvidia HTTP +
+    // anthropic/codex spawn); la rama de exclusión queda como defensa para un
+    // provider futuro sin handler.
     // #3558: `initialExcluded` permite arrancar el resolver con un set
     // pre-poblado, usado por la cascada para saltar providers ya probados
     // sin tocar la semántica original (que sigue ignorando `excludedProvider`).
@@ -448,8 +460,9 @@ function resolveSherlockProvider({
                 : null;
 
         if (!transport) {
-            // Provider sin handler en Sherlock (ej. openai-codex stub #3076) —
-            // excluir y seguir con el próximo de la chain.
+            // Provider sin handler en Sherlock (HTTP ni spawn) — excluir y
+            // seguir con el próximo de la chain. Defensa para providers
+            // futuros; hoy los 5 de telegram-sherlock tienen handler.
             if (typeof log === 'function') {
                 log('sherlock', `provider ${res.provider} no tiene handler en Sherlock — fallback al siguiente`);
             }
@@ -634,6 +647,176 @@ function spawnAnthropicComplete({
 }
 
 // -----------------------------------------------------------------------------
+// spawnCodexComplete — invoca `codex exec --json` con el prompt como argumento
+// posicional y devuelve el shape canónico de completion-client
+// (`{ok, content, ...}`).
+//
+// Diferencias con `spawnAnthropicComplete` (por qué es una función aparte):
+//   - Codex NO acepta el prompt por stdin: el adapter lo manda como argumento
+//     posicional final (`-p <prompt>` → traducido a posicional en
+//     `openai-codex.js::translateClaudeArgsToCodex`). `interactive_supported`
+//     se deja en false → stdin = 'ignore'.
+//   - Codex emite JSONL (`codex exec --json`), NO texto plano. El texto de la
+//     respuesta vive en el evento `{type:'item.completed', item:{type:
+//     'agent_message', text:'...'}}` (shape confirmado por el smoke real
+//     2026-06-01 en tests/smoke/codex-adapter.smoke.js). Nos quedamos con el
+//     ÚLTIMO `agent_message` del stream.
+//   - El modelo se inyecta vía `env.CODEX_MODEL` (lo lee el adapter).
+//
+// Timeout: idéntica semántica a anthropic — `timeoutMs > 0` mata el child con
+// SIGTERM; `timeoutMs === 0` (default post-2026-06-02) corre sin timer.
+//
+// SECURITY:
+//   - El prompt va como argv (limitación del adapter Codex), igual que para
+//     todos los spawns de agentes del pulpo — consistente con el resto del
+//     pipeline. El env del child hereda del parent + CODEX_MODEL.
+//   - stdout truncado a 64KB (mismo cap que anthropic/completion-client).
+// -----------------------------------------------------------------------------
+function spawnCodexComplete({
+    prompt,
+    model,
+    timeoutMs,
+    spawnImpl,
+    codexHandler,
+    cwd,
+    env,
+}) {
+    return new Promise((resolve) => {
+        const startedAt = Date.now();
+        const _spawn = spawnImpl || require('node:child_process').spawn;
+        const handler = codexHandler || require('./agent-launcher/providers/openai-codex');
+        const _cwd = cwd || process.cwd();
+        const _env = Object.assign(
+            {},
+            env || process.env,
+            model ? { CODEX_MODEL: model } : {},
+            { CLAUDE_PROJECT_DIR: _cwd }
+        );
+
+        let spawnSpec;
+        try {
+            spawnSpec = handler.buildSpawn({
+                args: ['-p', String(prompt == null ? '' : prompt)],
+                cwd: _cwd,
+                env: _env,
+                interactive_supported: false,
+            });
+        } catch (e) {
+            return resolve({
+                ok: false,
+                error: { type: 'spawn_unavailable', detail: e && e.message ? e.message : String(e) },
+                provider: 'openai-codex',
+                durationMs: Date.now() - startedAt,
+            });
+        }
+
+        let child;
+        try {
+            child = _spawn(spawnSpec.cmd, spawnSpec.args, spawnSpec.spawnOpts);
+        } catch (e) {
+            return resolve({
+                ok: false,
+                error: { type: 'spawn_failed', detail: e && e.message ? e.message : String(e) },
+                provider: 'openai-codex',
+                durationMs: Date.now() - startedAt,
+            });
+        }
+
+        let stdoutBuf = Buffer.alloc(0);
+        let stderrBuf = Buffer.alloc(0);
+        let truncated = false;
+        let resolved = false;
+
+        const finish = (result) => {
+            if (resolved) return;
+            resolved = true;
+            try { if (timer) clearTimeout(timer); } catch {}
+            resolve(Object.assign({ provider: 'openai-codex', durationMs: Date.now() - startedAt }, result));
+        };
+
+        const timer = Number(timeoutMs) > 0
+            ? setTimeout(() => {
+                try { child.kill('SIGTERM'); } catch {}
+                finish({
+                    ok: false,
+                    error: { type: 'timeout', detail: `spawn codex superó timeoutMs=${timeoutMs}` },
+                });
+            }, Number(timeoutMs))
+            : null;
+
+        if (child.stdout) {
+            child.stdout.on('data', (chunk) => {
+                if (truncated) return;
+                if (stdoutBuf.length + chunk.length > SPAWN_MAX_STDOUT_BYTES) {
+                    truncated = true;
+                    try { child.kill('SIGTERM'); } catch {}
+                    return finish({
+                        ok: false,
+                        error: { type: 'invalid_response', reason: 'body_too_large', detail: `stdout > ${SPAWN_MAX_STDOUT_BYTES} bytes` },
+                    });
+                }
+                stdoutBuf = Buffer.concat([stdoutBuf, chunk]);
+            });
+        }
+        if (child.stderr) {
+            child.stderr.on('data', (chunk) => {
+                if (stderrBuf.length < 2048) {
+                    stderrBuf = Buffer.concat([stderrBuf, chunk.slice(0, 2048 - stderrBuf.length)]);
+                }
+            });
+        }
+
+        child.on('error', (e) => {
+            finish({
+                ok: false,
+                error: { type: 'spawn_error', detail: e && e.message ? e.message : String(e) },
+            });
+        });
+
+        child.on('exit', (code) => {
+            if (resolved) return;
+            const stderr = stderrBuf.toString('utf8').trim();
+            // Parse JSONL: nos quedamos con el último `agent_message`.
+            let agentMessage = null;
+            let inputTokens = 0;
+            let outputTokens = 0;
+            const raw = stdoutBuf.toString('utf8');
+            for (const line of raw.split('\n')) {
+                const t = line.trim();
+                if (!t.startsWith('{')) continue;
+                let obj;
+                try { obj = JSON.parse(t); } catch { continue; }
+                if (obj.type === 'item.completed' && obj.item
+                    && obj.item.type === 'agent_message'
+                    && typeof obj.item.text === 'string') {
+                    agentMessage = obj.item.text;
+                } else if (obj.type === 'turn.completed' && obj.usage && typeof obj.usage === 'object') {
+                    inputTokens += Number(obj.usage.input_tokens || 0);
+                    outputTokens += Number(obj.usage.output_tokens || 0) + Number(obj.usage.reasoning_output_tokens || 0);
+                }
+            }
+            if (code === 0 && agentMessage && agentMessage.trim()) {
+                return finish({
+                    ok: true,
+                    content: agentMessage,
+                    inputTokens,
+                    outputTokens,
+                });
+            }
+            return finish({
+                ok: false,
+                error: {
+                    type: 'spawn_exit',
+                    detail: agentMessage === null
+                        ? `exit=${code}; sin agent_message en el stream JSONL; stderr=${stderr.slice(0, 300)}`
+                        : `exit=${code}; stderr=${stderr.slice(0, 400)}`,
+                },
+            });
+        });
+    });
+}
+
+// -----------------------------------------------------------------------------
 // emitAuditEvent — wrapper sobre commanderMP.auditCommanderRequest para los
 // eventos específicos de Sherlock. Todos los payloads sensibles van como
 // HASH (CA-SEC-8). best-effort: nunca tira al caller.
@@ -746,7 +929,9 @@ async function verify(opts = {}) {
         // inyectables tests
         completionClient,
         spawnAnthropic,
+        spawnCodex,
         anthropicHandler,
+        codexHandler,
         spawnImpl,
         cwd,
         env,
@@ -767,6 +952,7 @@ async function verify(opts = {}) {
     const _now = Number.isFinite(now) ? now : Date.now();
     const _completion = completionClient || require('./multi-provider/completion-client');
     const _spawnAnthropic = typeof spawnAnthropic === 'function' ? spawnAnthropic : spawnAnthropicComplete;
+    const _spawnCodex = typeof spawnCodex === 'function' ? spawnCodex : spawnCodexComplete;
     const _residency = residencyModule || null; // commanderMP.enforceDataResidency lo carga solo
 
     const cfg = loadSherlockConfig({ configLoader });
@@ -832,8 +1018,9 @@ async function verify(opts = {}) {
     // provider corre hasta responder o errorar por su cuenta. La resiliencia
     // ante un provider colgado la da esta cascada, no un corte por reloj.
     //
-    // #3484: NO se excluye al commanderProvider; los providers sin handler
-    // (openai-codex stub) los saltea resolveSherlockProvider internamente.
+    // #3484: NO se excluye al commanderProvider; un provider sin handler en
+    // Sherlock lo saltea resolveSherlockProvider internamente (hoy los 5 de la
+    // chain tienen handler — codex incluido desde 2026-06-02).
     // #3766: sin swap intra-provider — la adversariality nace del rol (prompt
     // fiscal), no del modelo. `commanderModel` se usa solo para el cálculo de
     // `sameModel` que se persiste al JSONL como forensics (sin influir en el
@@ -868,6 +1055,19 @@ async function verify(opts = {}) {
                 timeoutMs: cfg.timeoutMs,
                 spawnImpl,
                 anthropicHandler,
+                cwd,
+                env,
+            });
+            if (r && typeof r === 'object') r.model = resolved.model;
+            return r;
+        }
+        if (resolved.transport === 'spawn' && resolved.provider === 'openai-codex') {
+            const r = await _spawnCodex({
+                prompt,
+                model: resolved.model,
+                timeoutMs: cfg.timeoutMs,
+                spawnImpl,
+                codexHandler,
                 cwd,
                 env,
             });
@@ -1316,4 +1516,5 @@ module.exports = {
     _parseAndValidateSherlockOutput: parseAndValidateSherlockOutput,
     _resolveSherlockProvider: resolveSherlockProvider,
     _spawnAnthropicComplete: spawnAnthropicComplete,
+    _spawnCodexComplete: spawnCodexComplete,
 };


### PR DESCRIPTION
## Resumen

Los 4 puntos finales del multi-provider (#3791):
- Sherlock: Codex wireado real via spawnCodexComplete
- Commander: NVIDIA NIM agregado al final de la chain
- Headers actualizados: completion-client.js, multi-provider.js
- Tests: 123 verdes (sherlock+commander 86/86, completion-client 37/37)

## Cambios

- 5 archivo(s) modificado(s)
- 283 línea(s) agregada(s) (+)
- 58 línea(s) removida(s) (-)

**Refs #3791** — no cierra épico, paso 5/? de la ola multi-provider.

🤖 Generado con [Claude Code](https://claude.ai/claude-code)