### PR TITLE
fix(pipeline): reorden multi-provider — Cerebras→NVIDIA en devs, correcciones modelo/chain

### DIFF
--- a/.pipeline/agent-models.json
+++ b/.pipeline/agent-models.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./agent-models.schema.json",
-  "_doc": "Configuración multi-proveedor del pipeline V3 — issue #3072 (H1) + #3077 (H5) + #3221 (sign-off Leo 2026-05-15 por agente) + #3258 (skill virtual `telegram-commander`). Documento canónico: docs/pipeline/multi-provider.md. Para agregar/cambiar un provider, primero editar agent-models.schema.json (allowlist de launcher/model) y después este archivo. El boot del pulpo valida con Ajv 2020-12 y aborta si no matchea — ver lib/agent-models-validate.js (#3081 S3). Los strings de 'quota_error_types' se cross-validan contra la meta-allowlist hardcoded en lib/quota-exhausted.js (KNOWN_QUOTA_ERROR_TYPES_BY_PROVIDER) — agregar un valor fuera de esa meta-allowlist hace boot fail-fast (SEC-2 de #3077). Los `fallbacks[]` por skill respetan el orden sign-off Leo 2026-05-15 (memoria project_multi-provider-per-agent-order); los skills con Gemini EXCLUIDO procesan secrets/código fuente sensible (TOS AI Studio entrena con prompts free). El skill virtual `telegram-commander` (#3258) NO está en `skills_por_fase` — es consumido por pulpo.js (commander chat de Telegram) vía lib/commander/multi-provider.js para el dispatch con fallback chain.",
+  "_doc": "Configuración multi-proveedor del pipeline V3 — issue #3072 (H1) + #3077 (H5) + #3221 (sign-off Leo 2026-05-15 por agente) + #3258 (skill virtual `telegram-commander`). Documento canónico: docs/pipeline/multi-provider.md. Para agregar/cambiar un provider, primero editar agent-models.schema.json (allowlist de launcher/model) y después este archivo. El boot del pulpo valida con Ajv 2020-12 y aborta si no matchea — ver lib/agent-models-validate.js (#3081 S3). Los strings de 'quota_error_types' se cross-validan contra la meta-allowlist hardcoded en lib/quota-exhausted.js (KNOWN_QUOTA_ERROR_TYPES_BY_PROVIDER) — agregar un valor fuera de esa meta-allowlist hace boot fail-fast (SEC-2 de #3077). Los `fallbacks[]` por skill respetan el orden sign-off Leo 2026-05-15 (memoria project_multi-provider-per-agent-order); los skills con Gemini EXCLUIDO procesan secrets/código fuente sensible (TOS AI Studio entrena con prompts free). El skill virtual `telegram-commander` (#3258) NO está en `skills_por_fase` — es consumido por pulpo.js (commander chat de Telegram) vía lib/commander/multi-provider.js para el dispatch con fallback chain. Reorden 2026-06-02 (sign-off Leo por voz): (A) devs (backend/pipeline/android/web) + security sacan Cerebras del fallback y meten nvidia-nim — Cerebras no soporta tool_use y no puede editar archivos; NVIDIA es free + tool_use. (B) default global de chain = Claude → Codex → Gemini → Cerebras (Cerebras queda como tail solo en skills de chat/verificación que no requieren tool_use). Corrección de runtime: el modelo Cerebras pasa de `llama-3.3-70b` (muerto, no está en free tier) a `gpt-oss-120b` (verificado GET /v1/models + smoke #3794); alternative_models → `zai-glm-4.7`. telegram-commander suma nvidia-nim al final para alinear el JSON con el código de #3796.",
   "default_provider": "anthropic",
   "providers": {
     "anthropic": {
@@ -95,7 +95,7 @@
     },
     "cerebras": {
       "launcher": "cerebras",
-      "model": "llama-3.3-70b",
+      "model": "gpt-oss-120b",
       "spawn_args_template": [
         "--model",
         "{model}",
@@ -118,7 +118,7 @@
       ],
       "permissions_mode": "bypassPermissions",
       "alternative_models": [
-        "llama-3.1-70b"
+        "zai-glm-4.7"
       ]
     },
     "nvidia-nim": {
@@ -173,8 +173,8 @@
           "model_override": "gpt-5-codex"
         },
         {
-          "provider": "cerebras",
-          "model_override": "llama-3.3-70b"
+          "provider": "nvidia-nim",
+          "model_override": "deepseek-ai/deepseek-v4-pro"
         }
       ]
     },
@@ -187,8 +187,8 @@
           "model_override": "gpt-5-codex"
         },
         {
-          "provider": "cerebras",
-          "model_override": "llama-3.3-70b"
+          "provider": "nvidia-nim",
+          "model_override": "deepseek-ai/deepseek-v4-pro"
         }
       ]
     },
@@ -205,8 +205,8 @@
           "model_override": "gemini-2.0-flash"
         },
         {
-          "provider": "cerebras",
-          "model_override": "llama-3.3-70b"
+          "provider": "nvidia-nim",
+          "model_override": "deepseek-ai/deepseek-v4-pro"
         }
       ]
     },
@@ -223,8 +223,8 @@
           "model_override": "gemini-2.0-flash"
         },
         {
-          "provider": "cerebras",
-          "model_override": "llama-3.3-70b"
+          "provider": "nvidia-nim",
+          "model_override": "deepseek-ai/deepseek-v4-pro"
         }
       ]
     },
@@ -243,8 +243,8 @@
           "model_override": "gpt-5-codex"
         },
         {
-          "provider": "cerebras",
-          "model_override": "llama-3.3-70b"
+          "provider": "nvidia-nim",
+          "model_override": "deepseek-ai/deepseek-v4-pro"
         }
       ]
     },
@@ -262,7 +262,7 @@
         },
         {
           "provider": "cerebras",
-          "model_override": "llama-3.3-70b"
+          "model_override": "gpt-oss-120b"
         }
       ]
     },
@@ -276,7 +276,7 @@
         },
         {
           "provider": "cerebras",
-          "model_override": "llama-3.3-70b"
+          "model_override": "gpt-oss-120b"
         }
       ]
     },
@@ -294,7 +294,7 @@
         },
         {
           "provider": "cerebras",
-          "model_override": "llama-3.3-70b"
+          "model_override": "gpt-oss-120b"
         }
       ]
     },
@@ -312,7 +312,7 @@
         },
         {
           "provider": "cerebras",
-          "model_override": "llama-3.3-70b"
+          "model_override": "gpt-oss-120b"
         }
       ]
     },
@@ -326,7 +326,7 @@
         },
         {
           "provider": "cerebras",
-          "model_override": "llama-3.3-70b"
+          "model_override": "gpt-oss-120b"
         }
       ]
     },
@@ -340,7 +340,7 @@
         },
         {
           "provider": "cerebras",
-          "model_override": "llama-3.3-70b"
+          "model_override": "gpt-oss-120b"
         }
       ]
     },
@@ -354,7 +354,7 @@
         },
         {
           "provider": "cerebras",
-          "model_override": "llama-3.3-70b"
+          "model_override": "gpt-oss-120b"
         },
         {
           "provider": "nvidia-nim",
@@ -376,7 +376,7 @@
         },
         {
           "provider": "cerebras",
-          "model_override": "llama-3.3-70b"
+          "model_override": "gpt-oss-120b"
         }
       ]
     },
@@ -390,7 +390,7 @@
         },
         {
           "provider": "cerebras",
-          "model_override": "llama-3.3-70b"
+          "model_override": "gpt-oss-120b"
         }
       ]
     },
@@ -408,7 +408,7 @@
         },
         {
           "provider": "cerebras",
-          "model_override": "llama-3.3-70b"
+          "model_override": "gpt-oss-120b"
         }
       ]
     },
@@ -422,7 +422,7 @@
         },
         {
           "provider": "cerebras",
-          "model_override": "llama-3.3-70b"
+          "model_override": "gpt-oss-120b"
         }
       ]
     },
@@ -449,7 +449,11 @@
         },
         {
           "provider": "cerebras",
-          "model_override": "llama-3.3-70b"
+          "model_override": "gpt-oss-120b"
+        },
+        {
+          "provider": "nvidia-nim",
+          "model_override": "deepseek-ai/deepseek-v4-pro"
         }
       ]
     },
@@ -467,7 +471,7 @@
         },
         {
           "provider": "cerebras",
-          "model_override": "llama-3.3-70b"
+          "model_override": "gpt-oss-120b"
         },
         {
           "provider": "nvidia-nim",

--- a/.pipeline/lib/agent-models-validate.js
+++ b/.pipeline/lib/agent-models-validate.js
@@ -142,14 +142,14 @@ const ALLOWED_MODELS_BY_LAUNCHER = Object.freeze({
     'gemini-2.0-flash',
     'gemini-1.5-flash',
   ]),
-  // #3501 — `llama-3.1-70b` se agrega como modelo alternativo del provider
-  // cerebras (mismo motivo que arriba). Cerebras Cloud lo expone como modelo
-  // de generación anterior, estable y con el mismo tokenizer base que el
-  // default `llama-3.3-70b` — apto para swap intra-provider sin cambios de
-  // prompt template.
+  // 2026-06-02 — Corrección free tier real: el free tier de Cerebras NO sirve
+  // modelos `llama-*` (verificado contra GET /v1/models). Los únicos servibles
+  // hoy son `gpt-oss-120b` (default, menor overhead de reasoning) y `zai-glm-4.7`
+  // (alternativo para adversariality #3501). El smoke test del adapter (PR #3794)
+  // confirmó `gpt-oss-120b` con la key free real (exit 0, "OK", 83 in / 102 out).
   cerebras: Object.freeze([
-    'llama-3.3-70b',
-    'llama-3.1-70b',
+    'gpt-oss-120b',
+    'zai-glm-4.7',
   ]),
   // #3243 — NVIDIA NIM expone modelos hosted con naming `vendor/model`. La
   // allowlist se inicializa con los 2 modelos sign-off del issue (DeepSeek


### PR DESCRIPTION
## Resumen

Reorden de providers multi-provider tras completar los 4 gaps finales (#3796). Sign-off Leo 2026-06-02 (por voz).

### (A) Devs + security: Cerebras → NVIDIA

Devs (backend-dev, pipeline-dev, android-dev, web-dev) + security sacan Cerebras del fallback porque **no soporta tool_use** (no puede editar archivos):

- **backend-dev / pipeline-dev / security**: Claude → Codex → **NVIDIA**
- **android-dev / web-dev**: Claude → Codex → Gemini → **NVIDIA**

NVIDIA es free tier + tool_use (mejor que Cerebras para el fallback de devs).

### (B) Default global: Claude → Codex → Gemini → Cerebras

Todos los demás skills de chat/verificación (qa, po, ux, perf, tester, review, ops, etc.):

- Chain: **Claude → Codex → Gemini → Cerebras**
- Cerebras como tail **solo en skills sin tool_use** (Gemini excluido en doc/planner/review/ops por TOS)

### Correcciones de runtime

PRs base: #3794 (adapters reales) + #3796 (gaps finales Sherlock/Commander/headers).

1. **Modelo Cerebras**: `llama-3.3-70b` (fuera del free tier) → `gpt-oss-120b` (verificado smoke test #3794)
2. **Alternative models**: `llama-3.1-70b` → `zai-glm-4.7` (para adversariality)
3. **telegram-commander**: suma `nvidia-nim` al final (alinea JSON con código #3796)

## Tests

- ✅ **93/93 verdes** — sherlock 56/56 + completion-client 37/37
- No hay regresiones

## Labels

- `area:pipeline` · `enhancement` · `priority:high` · `size:medium`
- **`qa:skipped`** — cambio de config del pipeline, sin impacto en producto de usuario

🤖 Generado con [Claude Code](https://claude.ai/claude-code)