### PR TITLE
fix(pipeline): Grupo B a Sonnet (qa/po/ux) + fix refinar sin modelo

### DIFF
--- a/.pipeline/agent-models.json
+++ b/.pipeline/agent-models.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./agent-models.schema.json",
-  "_doc": "Configuración multi-proveedor del pipeline V3 — issue #3072 (H1) + #3077 (H5) + #3221 (sign-off Leo 2026-05-15 por agente) + #3258 (skill virtual `telegram-commander`). Documento canónico: docs/pipeline/multi-provider.md. Para agregar/cambiar un provider, primero editar agent-models.schema.json (allowlist de launcher/model) y después este archivo. El boot del pulpo valida con Ajv 2020-12 y aborta si no matchea — ver lib/agent-models-validate.js (#3081 S3). Los strings de 'quota_error_types' se cross-validan contra la meta-allowlist hardcoded en lib/quota-exhausted.js (KNOWN_QUOTA_ERROR_TYPES_BY_PROVIDER) — agregar un valor fuera de esa meta-allowlist hace boot fail-fast (SEC-2 de #3077). Los `fallbacks[]` por skill respetan el orden sign-off Leo 2026-05-15 (memoria project_multi-provider-per-agent-order); los skills con Gemini EXCLUIDO procesan secrets/código fuente sensible (TOS AI Studio entrena con prompts free). El skill virtual `telegram-commander` (#3258) NO está en `skills_por_fase` — es consumido por pulpo.js (commander chat de Telegram) vía lib/commander/multi-provider.js para el dispatch con fallback chain. Reorden 2026-06-02 (sign-off Leo por voz): (A) devs (backend/pipeline/android/web) + security sacan Cerebras del fallback y meten nvidia-nim — Cerebras no soporta tool_use y no puede editar archivos; NVIDIA es free + tool_use. (B) default global de chain = Claude → Codex → Gemini → Cerebras (Cerebras queda como tail solo en skills de chat/verificación que no requieren tool_use). Corrección de runtime: el modelo Cerebras pasa de `llama-3.3-70b` (muerto, no está en free tier) a `gpt-oss-120b` (verificado GET /v1/models + smoke #3794); alternative_models → `zai-glm-4.7`. telegram-commander suma nvidia-nim al final para alinear el JSON con el código de #3796. Reorden de modelos 2026-06-02 (sign-off Leo por voz): telegram-commander baja su primario de claude-opus-4-7 → claude-sonnet-4-7 y su fallback Codex de gpt-5-codex → gpt-5 (es el cerebro, conserva calidad pero ahorra ~5x vs Opus sin pérdida relevante en chat/operación). telegram-sherlock MANTIENE claude-haiku-4-5 como primario (es el piso de calidad del verificador y NO se baja — un verificador flojo aprueba cualquier cosa) y baja solo su fallback Codex de gpt-5 → gpt-5-mini (verificación no necesita el tope). gpt-5-mini se agregó a ALLOWED_MODELS_BY_LAUNCHER.codex en lib/agent-models-validate.js.",
+  "_doc": "Configuración multi-proveedor del pipeline V3 — issue #3072 (H1) + #3077 (H5) + #3221 (sign-off Leo 2026-05-15 por agente) + #3258 (skill virtual `telegram-commander`). Documento canónico: docs/pipeline/multi-provider.md. Para agregar/cambiar un provider, primero editar agent-models.schema.json (allowlist de launcher/model) y después este archivo. El boot del pulpo valida con Ajv 2020-12 y aborta si no matchea — ver lib/agent-models-validate.js (#3081 S3). Los strings de 'quota_error_types' se cross-validan contra la meta-allowlist hardcoded en lib/quota-exhausted.js (KNOWN_QUOTA_ERROR_TYPES_BY_PROVIDER) — agregar un valor fuera de esa meta-allowlist hace boot fail-fast (SEC-2 de #3077). Los `fallbacks[]` por skill respetan el orden sign-off Leo 2026-05-15 (memoria project_multi-provider-per-agent-order); los skills con Gemini EXCLUIDO procesan secrets/código fuente sensible (TOS AI Studio entrena con prompts free). El skill virtual `telegram-commander` (#3258) NO está en `skills_por_fase` — es consumido por pulpo.js (commander chat de Telegram) vía lib/commander/multi-provider.js para el dispatch con fallback chain. Reorden 2026-06-02 (sign-off Leo por voz): (A) devs (backend/pipeline/android/web) + security sacan Cerebras del fallback y meten nvidia-nim — Cerebras no soporta tool_use y no puede editar archivos; NVIDIA es free + tool_use. (B) default global de chain = Claude → Codex → Gemini → Cerebras (Cerebras queda como tail solo en skills de chat/verificación que no requieren tool_use). Corrección de runtime: el modelo Cerebras pasa de `llama-3.3-70b` (muerto, no está en free tier) a `gpt-oss-120b` (verificado GET /v1/models + smoke #3794); alternative_models → `zai-glm-4.7`. telegram-commander suma nvidia-nim al final para alinear el JSON con el código de #3796. Reorden de modelos 2026-06-02 (sign-off Leo por voz): telegram-commander baja su primario de claude-opus-4-7 → claude-sonnet-4-7 y su fallback Codex de gpt-5-codex → gpt-5 (es el cerebro, conserva calidad pero ahorra ~5x vs Opus sin pérdida relevante en chat/operación). telegram-sherlock MANTIENE claude-haiku-4-5 como primario (es el piso de calidad del verificador y NO se baja — un verificador flojo aprueba cualquier cosa) y baja solo su fallback Codex de gpt-5 → gpt-5-mini (verificación no necesita el tope). gpt-5-mini se agregó a ALLOWED_MODELS_BY_LAUNCHER.codex en lib/agent-models-validate.js. Reorden Grupo B 2026-06-02 (sign-off Leo por voz): qa/po/ux bajan de claude-opus-4-7 → claude-sonnet-4-7 (no escriben código de producción — evalúan, validan video por frames+capturas y redactan criterios; la capacidad de visión de Sonnet es la misma que Opus, ahorro ~5x sin pérdida relevante). refinar tenía un bug de config: solo declaraba `provider:anthropic` sin model_override → heredaba el default claude-opus-4-7 y SIN fallbacks; ahora explicita claude-sonnet-4-7 + fallbacks [codex gpt-5, cerebras gpt-oss-120b]. Grupo A (backend/pipeline/android/web-dev + security) MANTIENE claude-opus-4-7 — su output va a main y un dev flojo genera rebotes que cuestan más que el ahorro.",
   "default_provider": "anthropic",
   "providers": {
     "anthropic": {
@@ -250,7 +250,7 @@
     },
     "qa": {
       "provider": "anthropic",
-      "model_override": "claude-opus-4-7",
+      "model_override": "claude-sonnet-4-7",
       "fallbacks": [
         {
           "provider": "openai-codex",
@@ -282,7 +282,7 @@
     },
     "po": {
       "provider": "anthropic",
-      "model_override": "claude-opus-4-7",
+      "model_override": "claude-sonnet-4-7",
       "fallbacks": [
         {
           "provider": "openai-codex",
@@ -300,7 +300,7 @@
     },
     "ux": {
       "provider": "anthropic",
-      "model_override": "claude-opus-4-7",
+      "model_override": "claude-sonnet-4-7",
       "fallbacks": [
         {
           "provider": "openai-codex",
@@ -427,7 +427,18 @@
       ]
     },
     "refinar": {
-      "provider": "anthropic"
+      "provider": "anthropic",
+      "model_override": "claude-sonnet-4-7",
+      "fallbacks": [
+        {
+          "provider": "openai-codex",
+          "model_override": "gpt-5"
+        },
+        {
+          "provider": "cerebras",
+          "model_override": "gpt-oss-120b"
+        }
+      ]
     },
     "linter": {
       "provider": "deterministic"


### PR DESCRIPTION
## Qué entra
Reorden de modelos del **Grupo B** (roles de criterio/calidad que NO escriben código de producción) — sign-off Leo por voz 2026-06-02.

| Skill | Antes | Ahora |
|---|---|---|
| qa | claude-opus-4-7 | claude-sonnet-4-7 |
| po | claude-opus-4-7 | claude-sonnet-4-7 |
| ux | claude-opus-4-7 | claude-sonnet-4-7 |
| refinar | (heredaba opus, **sin fallbacks** — bug) | claude-sonnet-4-7 + [codex gpt-5, cerebras gpt-oss-120b] |

**Grupo A** (backend/pipeline/android/web-dev + security) MANTIENE `claude-opus-4-7`: su output va a `main` y un dev flojo genera rebotes que cuestan más que el ahorro.

## Por qué Sonnet aguanta en QA/PO
La validación de video no la hace un modelo "mirando" el stream: el video es evidencia (screenrecord), y el modelo evalúa frames/capturas + logs + criterios. La capacidad de visión de Sonnet es la misma que la de Opus. Ahorro ~5x sin pérdida relevante.

## Validación
- Validador canónico `agent-models-validate`: **OK, exit 0, 0 errores**.

Labels: area:pipeline · enhancement · priority:high · size:simple · qa:skipped