### PR TITLE
fix(pipeline): health-check valida CLI-OAuth para Claude/Codex, no la API key (#3802)

### DIFF
--- a/.pipeline/lib/__tests__/multi-provider-health-cron.test.js
+++ b/.pipeline/lib/__tests__/multi-provider-health-cron.test.js
@@ -119,6 +119,11 @@ test('runOnce: pingea sólo los providers presentes en secretos', async () => {
         auditDir,
         secretsPath,
         pingImpl: fakePing({ cerebras: { ok: true, reason: 'authenticated', statusCode: 200 } }),
+        // #3802 — probe CLI fijo + sender/dedup aislados: el test no debe
+        // depender del PATH real ni escribir en archivos reales del pipeline.
+        cliProbe: () => false,
+        telegramSender: () => true,
+        dedupFile: path.join(dir, 'dedup.json'),
         skipAudit: true,
     });
     assert.ok(Array.isArray(result.snapshot.providers));
@@ -128,6 +133,89 @@ test('runOnce: pingea sólo los providers presentes en secretos', async () => {
     const gemini = result.snapshot.providers.find(p => p.provider === 'gemini-google');
     assert.equal(gemini.state, 'red');
     assert.equal(gemini.reason_code, 'no_key_configured');
+});
+
+// ─── #3802 — providers CLI-OAuth (Claude Code / Codex): validar CLI, no key.
+test('isBinaryOnPath: encuentra binario en un dir del PATH (fs inyectado)', () => {
+    const fakeFs = { existsSync: (p) => p.includes('claude') };
+    assert.equal(
+        healthCron.isBinaryOnPath('claude', { env: { PATH: '/usr/bin:/usr/local/bin' }, fsImpl: fakeFs }),
+        true,
+    );
+});
+
+test('isBinaryOnPath: false si el binario no está en ningún dir', () => {
+    const fakeFs = { existsSync: () => false };
+    assert.equal(
+        healthCron.isBinaryOnPath('codex', { env: { PATH: '/usr/bin' }, fsImpl: fakeFs }),
+        false,
+    );
+});
+
+test('probeCliProvider: CLI disponible → ok + cli_oauth_ok', () => {
+    const r = healthCron.probeCliProvider(
+        { provider: 'anthropic', cli_binary: 'claude' },
+        { cliProbe: () => true },
+    );
+    assert.equal(r.ok, true);
+    assert.equal(r.reason, 'cli_oauth_ok');
+});
+
+test('probeCliProvider: CLI ausente → !ok + cli_unavailable', () => {
+    const r = healthCron.probeCliProvider(
+        { provider: 'openai', cli_binary: 'codex' },
+        { cliProbe: () => false },
+    );
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, 'cli_unavailable');
+});
+
+test('runOnce: provider OAuth con CLI disponible → green sin pinear la API key', async () => {
+    const dir = tmpDir();
+    const stateDir = path.join(dir, 'state');
+    const auditDir = path.join(dir, 'audit');
+    // Sin keys de anthropic/openai en secretos: igual deben quedar verdes
+    // porque corren por CLI OAuth, no por API key.
+    const secretsPath = makeSecretsFile(dir, {});
+    const result = await healthCron.runOnce({
+        stateDir,
+        auditDir,
+        secretsPath,
+        // pingImpl NO debe ser invocado para providers OAuth.
+        pingImpl: async () => { throw new Error('no debería pinear un provider OAuth'); },
+        cliProbe: () => true, // CLI disponible
+        telegramSender: () => true,
+        dedupFile: path.join(dir, 'dedup.json'),
+        skipAudit: true,
+    });
+    const anthropic = result.snapshot.providers.find(p => p.provider === 'anthropic');
+    assert.equal(anthropic.state, 'green');
+    assert.equal(anthropic.reason_code, 'cli_oauth_ok');
+    assert.equal(anthropic.auth_mode, 'oauth');
+    const openai = result.snapshot.providers.find(p => p.provider === 'openai');
+    assert.equal(openai.state, 'green');
+    assert.equal(openai.reason_code, 'cli_oauth_ok');
+});
+
+test('runOnce: provider OAuth con CLI ausente → red (cli_unavailable)', async () => {
+    const dir = tmpDir();
+    const stateDir = path.join(dir, 'state');
+    const auditDir = path.join(dir, 'audit');
+    const secretsPath = makeSecretsFile(dir, {});
+    const result = await healthCron.runOnce({
+        stateDir,
+        auditDir,
+        secretsPath,
+        pingImpl: fakePing({}),
+        cliProbe: () => false, // CLI no disponible
+        // Aislar efectos de archivo: el rojo de los OAuth dispara el sender.
+        telegramSender: () => true,
+        dedupFile: path.join(dir, 'dedup.json'),
+        skipAudit: true,
+    });
+    const anthropic = result.snapshot.providers.find(p => p.provider === 'anthropic');
+    assert.equal(anthropic.state, 'red');
+    assert.equal(anthropic.reason_code, 'cli_unavailable');
 });
 
 test('runOnce: CA-6 simulación — 2 free providers en rojo simultáneo (free counts)', async () => {
@@ -205,6 +293,11 @@ test('runOnce: el snapshot NO contiene fingerprint, masked ni body excerpt', asy
         auditDir,
         secretsPath,
         pingImpl: fakePing({ cerebras: { ok: false, reason: 'invalid_credentials', statusCode: 401 } }),
+        // #3802 — probe CLI fijo + sender/dedup aislados (sino el rojo de
+        // cerebras dispararía el sender por defecto contra archivos reales).
+        cliProbe: () => false,
+        telegramSender: () => true,
+        dedupFile: path.join(dir, 'dedup.json'),
         skipAudit: true,
     });
     const serialized = JSON.stringify(result.snapshot);
@@ -221,6 +314,13 @@ test('runOnce: persiste snapshot a state/multi-provider-health.json', async () =
         auditDir: path.join(dir, 'audit'),
         secretsPath,
         pingImpl: fakePing({ cerebras: { ok: true, reason: 'authenticated', statusCode: 200 } }),
+        // #3802 — fijar el probe de CLI para no depender del PATH real de la
+        // máquina (sino anthropic/codex darían verde y green_count != 1).
+        cliProbe: () => false,
+        // Aislar efectos: sender en memoria + dedup en tmp (sino escribe en
+        // servicios/telegram/pendiente/ y ~/.claude/secrets/…dedup.json reales).
+        telegramSender: () => true,
+        dedupFile: path.join(dir, 'dedup.json'),
         skipAudit: true,
     });
     const snapshotFile = path.join(stateDir, healthCron.SNAPSHOT_FILENAME);

--- a/.pipeline/lib/multi-provider/health-alerts.js
+++ b/.pipeline/lib/multi-provider/health-alerts.js
@@ -54,6 +54,10 @@ const ALLOWED_REASON_CODES = Object.freeze(new Set([
     'network_error',
     'no_key_configured',
     'unknown_provider',
+    // #3802 — providers CLI-OAuth (Claude Code / Codex): validados por CLI.
+    'cli_oauth_ok',
+    'cli_unavailable',
+    'cli_binary_undeclared',
 ]));
 
 // Estados válidos del provider (espejan los CA-3 / narrativa UX).

--- a/.pipeline/lib/multi-provider/health-cron.js
+++ b/.pipeline/lib/multi-provider/health-cron.js
@@ -67,6 +67,64 @@ function jitterMs(rangeMs = JITTER_RANGE_MS, rng = Math.random) {
     return Math.floor((rng() * 2 - 1) * rangeMs);
 }
 
+// -----------------------------------------------------------------------------
+// CLI-OAuth probe (#3802) — validar el camino que el pipeline realmente usa.
+//
+// Anthropic (Claude Code) y OpenAI/Codex NO se usan por API key: corren por la
+// CLI con OAuth (`claude` MAX login / `codex login`). Pinear su API key da un
+// falso ROJO (la key está ausente o devuelve 403) aunque la CLI funcione bien.
+// Para esos providers validamos que el binario de la CLI esté disponible en el
+// PATH — el camino real— en lugar de la key.
+//
+// Determinístico (scan de PATH, sin red, sin consumir cuota) e inyectable en
+// tests vía `opts.cliProbe`.
+// -----------------------------------------------------------------------------
+
+/**
+ * Resuelve si un binario es invocable buscándolo en el PATH. Windows-aware
+ * (respeta PATHEXT). No spawnea nada — sólo `fs.existsSync` sobre los candidatos.
+ *
+ * @returns {boolean}
+ */
+function isBinaryOnPath(binary, { env = process.env, fsImpl = fs } = {}) {
+    if (!binary || typeof binary !== 'string') return false;
+    const pathVar = env.PATH || env.Path || '';
+    const dirs = pathVar.split(path.delimiter).filter(Boolean);
+    const isWin = process.platform === 'win32';
+    const exts = isWin
+        ? (env.PATHEXT || '.COM;.EXE;.BAT;.CMD').split(';').map(e => e.toLowerCase())
+        : [''];
+    for (const dir of dirs) {
+        // Binario tal cual (sirve para *nix y para .exe ya con extensión en Win).
+        const direct = path.join(dir, binary);
+        try { if (fsImpl.existsSync(direct)) return true; } catch { /* ignore */ }
+        if (isWin) {
+            for (const ext of exts) {
+                try { if (fsImpl.existsSync(direct + ext)) return true; } catch { /* ignore */ }
+            }
+        }
+    }
+    return false;
+}
+
+/**
+ * Probe de salud para un provider CLI-OAuth. Devuelve un objeto con la misma
+ * forma que `live-ping.ping` (`{ ok, reason, ... }`) para que `classifyState`
+ * lo trate igual.
+ */
+function probeCliProvider(spec, { env = process.env, fsImpl = fs, cliProbe } = {}) {
+    const binary = spec.cli_binary || null;
+    if (!binary) {
+        return { ok: false, reason: 'cli_binary_undeclared', provider: spec.provider, cli_oauth: true };
+    }
+    const available = typeof cliProbe === 'function'
+        ? !!cliProbe(binary)
+        : isBinaryOnPath(binary, { env, fsImpl });
+    return available
+        ? { ok: true, reason: 'cli_oauth_ok', provider: spec.provider, cli_oauth: true }
+        : { ok: false, reason: 'cli_unavailable', provider: spec.provider, cli_oauth: true };
+}
+
 function readJson(file, fsImpl = fs) {
     if (!fsImpl.existsSync(file)) return null;
     try { return JSON.parse(fsImpl.readFileSync(file, 'utf8')); }
@@ -205,7 +263,7 @@ function listManagedAndPingable() {
 // Snapshot build + alerts
 // -----------------------------------------------------------------------------
 
-async function pingAllProviders({ providers, prevSnapshot, secretsPath, fsImpl = fs, httpImpl, pingImpl } = {}) {
+async function pingAllProviders({ providers, prevSnapshot, secretsPath, fsImpl = fs, httpImpl, pingImpl, cliProbe } = {}) {
     const prevByProvider = {};
     if (prevSnapshot && Array.isArray(prevSnapshot.providers)) {
         for (const p of prevSnapshot.providers) prevByProvider[p.provider] = p;
@@ -216,7 +274,11 @@ async function pingAllProviders({ providers, prevSnapshot, secretsPath, fsImpl =
         const keyInfo = secretsRw.listKeys({ secretsPath, fsImpl }).find(k => k.provider === spec.provider);
         const prev = prevByProvider[spec.provider] || {};
         let pingResult = null;
-        if (keyInfo && keyInfo.status === 'present') {
+        // #3802 — Providers CLI-OAuth (Claude Code / Codex): validar la CLI, no
+        // la API key. Pinear la key da falso rojo porque el pipeline NO la usa.
+        if (spec.auth_mode === 'oauth') {
+            pingResult = probeCliProvider(spec, { fsImpl, cliProbe });
+        } else if (keyInfo && keyInfo.status === 'present') {
             const _ping = pingImpl || livePing.ping;
             try {
                 pingResult = await _ping({
@@ -252,6 +314,9 @@ async function pingAllProviders({ providers, prevSnapshot, secretsPath, fsImpl =
             last_checked_at: new Date(Date.now()).toISOString(),
             key_status: keyInfo ? keyInfo.status : 'absent',
             free_tier_notes: spec.free_tier_notes || null,
+            // #3802 — el frontend usa esto para mostrar "CLI/OAuth" en vez de
+            // sugerir que falta una API key cuando el provider corre por CLI.
+            auth_mode: spec.auth_mode === 'oauth' ? 'oauth' : 'api_key',
         });
     }
     return results;
@@ -401,6 +466,7 @@ async function runOnce(opts = {}) {
         fsImpl,
         httpImpl: opts.httpImpl,
         pingImpl: opts.pingImpl,
+        cliProbe: opts.cliProbe,
     });
     const snapshot = buildSnapshot({ providers: providerResults, now });
 
@@ -516,6 +582,8 @@ module.exports = {
     classifyState,
     updateRateLimitCounter,
     pingAllProviders,
+    isBinaryOnPath,
+    probeCliProvider,
     buildSnapshot,
     emitAlerts,
     tryAcquireLock,

--- a/.pipeline/lib/multi-provider/secrets-rw.js
+++ b/.pipeline/lib/multi-provider/secrets-rw.js
@@ -65,6 +65,10 @@ const MANAGED_KEYS = Object.freeze([
         reason: 'Claude Code usa OAuth / MAX login; rotar acá puede confundir el child env.',
         canonicalPath: 'providers.anthropic.api_key',
         legacyField: 'anthropic_api_key',
+        // El pipeline lo usa vía Claude Code CLI (OAuth/MAX), NO vía API key.
+        // El health-cron valida la CLI, no pinea la key (sería un falso rojo).
+        auth_mode: 'oauth',
+        cli_binary: 'claude',
     },
     {
         provider: 'openai',
@@ -72,6 +76,10 @@ const MANAGED_KEYS = Object.freeze([
         editable: true,
         canonicalPath: 'providers.openai.api_key',
         legacyField: 'openai_api_key',
+        // Codex CLI autentica vía `codex login` (ChatGPT Plus OAuth), NO por
+        // OPENAI_API_KEY. El health valida la CLI, no la key (falso rojo 403).
+        auth_mode: 'oauth',
+        cli_binary: 'codex',
     },
     {
         provider: 'elevenlabs',


### PR DESCRIPTION
## Problema
El tablero multi-provider mostraba **Anthropic** y **OpenAI/Codex** en 🔴 rojo (key ausente / 403), pero el pipeline NO los usa por API key: corren por **CLI con OAuth** (`claude` MAX login / `codex login`). Pinear la key era validar el camino equivocado → falso rojo.

## Fix
- Providers con `auth_mode='oauth'` ahora se validan chequeando que el **binario de la CLI** esté en el PATH (determinístico, sin red, sin consumir cuota), no pineando la key.
- El snapshot expone `auth_mode` para que el frontend muestre **CLI/OAuth** en vez de sugerir que falta una API key.
- Reason codes nuevos: `cli_oauth_ok` / `cli_unavailable` / `cli_binary_undeclared`.

## Verificación
- `runOnce` real: anthropic + openai → 🟢 verde (`cli_oauth_ok`). Solo ElevenLabs queda rojo (sin key, TTS de pago, rojo legítimo).
- Tests **28/28 verde**. Se fijó `cliProbe` en los runOnce para no depender del PATH real ni escribir en archivos reales del pipeline.

Assignee: leitolarreta

🤖 Generated with [Claude Code](https://claude.com/claude-code)