### PR TITLE
fix(pipeline): MP-01/MP-02 — fin del "no pude verificar" espurio (soft-timeout vs presupuesto Sherlock) (#3803)

### DIFF
--- a/.pipeline/lib/__tests__/completion-client.test.js
+++ b/.pipeline/lib/__tests__/completion-client.test.js
@@ -619,3 +619,156 @@ test('#3484: caller con timeoutMs negativo o inválido cae a DEFAULT_TIMEOUT_MS'
     // No tira, no rompe — el cliente usa DEFAULT_TIMEOUT_MS (90s) internamente.
     assert.equal(r.ok, true);
 });
+
+// ─── MP-04 (#3803) · allowlist config-aware ─────────────────────────────────
+// Un modelo declarado en agent-models.json pero ausente de la allowlist
+// hardcoded ANTES fallaba con invalid_model y mataba un eslabón sano de la
+// cascada (caso real: cerebras=gpt-oss-120b). Ahora se acepta.
+
+function writeAgentModels(pipelineDir, json) {
+    fs.writeFileSync(path.join(pipelineDir, 'agent-models.json'), JSON.stringify(json));
+}
+
+test('MP-04 · modelo configurado en agent-models.json pero NO en allowlist hardcoded → aceptado', async () => {
+    const pipelineDir = tmpDir();
+    writeAgentModels(pipelineDir, {
+        providers: { cerebras: { model: 'gpt-oss-120b' } },
+        skills: {},
+    });
+    const f = path.join(pipelineDir, 'config.json');
+    writeKeys(f, { cerebras_api_key: 'csk_test_1234567890abcdef0000' });
+    const r = await completion.complete({
+        provider: 'cerebras',
+        model: 'gpt-oss-120b', // NO está en PROVIDER_MODELS_ALLOWLIST
+        prompt: 'ping',
+        pipelineDir,
+        secretsPath: f,
+        httpImpl: fakeHttp({
+            status: 200,
+            body: JSON.stringify({ choices: [{ message: { content: 'pong oss' } }] }),
+        }),
+    });
+    assert.equal(r.ok, true, 'el modelo configurado debe pasar la allowlist config-aware');
+    assert.equal(r.content, 'pong oss');
+});
+
+test('MP-04 · modelo declarado como model_override de un fallback también se acepta', async () => {
+    const pipelineDir = tmpDir();
+    writeAgentModels(pipelineDir, {
+        providers: { cerebras: { model: 'llama-3.3-70b' } },
+        skills: { qa: { provider: 'anthropic', fallbacks: [{ provider: 'cerebras', model_override: 'gpt-oss-120b' }] } },
+    });
+    const f = path.join(pipelineDir, 'config.json');
+    writeKeys(f, { cerebras_api_key: 'csk_test_1234567890abcdef0000' });
+    const r = await completion.complete({
+        provider: 'cerebras',
+        model: 'gpt-oss-120b',
+        prompt: 'ping',
+        pipelineDir,
+        secretsPath: f,
+        httpImpl: fakeHttp({ status: 200, body: JSON.stringify({ choices: [{ message: { content: 'ok' } }] }) }),
+    });
+    assert.equal(r.ok, true, 'model_override declarado por humano debe aceptarse');
+});
+
+test('MP-04 · modelo NI en allowlist NI configurado sigue siendo invalid_model (defensa intacta)', async () => {
+    const pipelineDir = tmpDir();
+    writeAgentModels(pipelineDir, { providers: { cerebras: { model: 'llama-3.3-70b' } }, skills: {} });
+    const r = await completion.complete({
+        provider: 'cerebras',
+        model: 'modelo-arbitrario-no-declarado',
+        prompt: 'hi',
+        pipelineDir,
+    });
+    assert.equal(r.ok, false);
+    assert.equal(r.error.type, 'invalid_model', 'la defensa anti-modelo-arbitrario sigue activa');
+});
+
+// ─── MP-12 (#3803) · retry único ante schema_drift en 2xx ────────────────────
+
+// fakeHttp con secuencia de respuestas: una por cada request (para ejercer el
+// retry). La N-ésima request usa responses[N-1] (la última se repite si faltan).
+function fakeHttpSequence(responses) {
+    let call = 0;
+    return {
+        request(opts, cb) {
+            const idx = Math.min(call, responses.length - 1);
+            call += 1;
+            const { status = 200, body = '' } = responses[idx] || {};
+            const req = {
+                on(ev, fn) { this[`_${ev}`] = fn; return this; },
+                write() {},
+                end() {
+                    process.nextTick(() => {
+                        const res = {
+                            statusCode: status,
+                            on(ev, fn) {
+                                if (ev === 'data') fn(Buffer.from(body, 'utf8'));
+                                if (ev === 'end') fn();
+                            },
+                        };
+                        cb(res);
+                    });
+                },
+                destroy() {},
+            };
+            return req;
+        },
+        _calls() { return call; },
+    };
+}
+
+test('MP-12 · 2xx con schema_drift en el 1er intento → reintenta y devuelve éxito en el 2do', async () => {
+    const dir = tmpDir();
+    const f = path.join(dir, 'config.json');
+    writeKeys(f, { cerebras_api_key: 'csk_test_1234567890abcdef0000' });
+    const http = fakeHttpSequence([
+        { status: 200, body: '<html>blip</html>' }, // malformado
+        { status: 200, body: JSON.stringify({ choices: [{ message: { content: 'recuperado' } }] }) },
+    ]);
+    const r = await completion.complete({
+        provider: 'cerebras',
+        model: 'llama-3.3-70b',
+        prompt: 'ping',
+        secretsPath: f,
+        httpImpl: http,
+    });
+    assert.equal(r.ok, true, 'el retry debe recuperar el blip transitorio');
+    assert.equal(r.content, 'recuperado');
+    assert.equal(http._calls(), 2, 'debe haber reintentado exactamente una vez');
+});
+
+test('MP-12 · schema_drift persistente en ambos intentos → invalid_response (sin retry infinito)', async () => {
+    const dir = tmpDir();
+    const f = path.join(dir, 'config.json');
+    writeKeys(f, { cerebras_api_key: 'csk_test_1234567890abcdef0000' });
+    const http = fakeHttpSequence([{ status: 200, body: '<html>roto</html>' }]);
+    const r = await completion.complete({
+        provider: 'cerebras',
+        model: 'llama-3.3-70b',
+        prompt: 'ping',
+        secretsPath: f,
+        httpImpl: http,
+    });
+    assert.equal(r.ok, false);
+    assert.equal(r.error.type, 'invalid_response');
+    assert.equal(r.error.reason, 'schema_drift');
+    assert.equal(http._calls(), 2, 'tope de 2 intentos, no más');
+});
+
+test('MP-12 · error NO-2xx (5xx) NO consume retry — cascada inmediata', async () => {
+    const dir = tmpDir();
+    const f = path.join(dir, 'config.json');
+    writeKeys(f, { cerebras_api_key: 'csk_test_1234567890abcdef0000' });
+    const http = fakeHttpSequence([{ status: 503, body: 'down' }]);
+    const r = await completion.complete({
+        provider: 'cerebras',
+        model: 'llama-3.3-70b',
+        prompt: 'ping',
+        secretsPath: f,
+        httpImpl: http,
+    });
+    assert.equal(r.ok, false);
+    assert.equal(r.error.type, 'http_error');
+    assert.equal(http._calls(), 1, 'un 5xx no debe reintentar (solo schema_drift 2xx reintenta)');
+});

--- a/.pipeline/lib/__tests__/dispatch-mp05-credentials.test.js
+++ b/.pipeline/lib/__tests__/dispatch-mp05-credentials.test.js
@@ -1,0 +1,174 @@
+// =============================================================================
+// dispatch-mp05-credentials.test.js — MP-05 (#3803)
+//
+// Pre-check de credenciales del fallback en `resolveSpawnWithFallback`. Antes
+// sólo el Commander validaba credenciales pre-spawn; en los skills genéricos,
+// un fallback sin key se intentaba igual y fallaba recién en runtime como
+// `no_key_configured` (indistinguible de un error de red). MP-05 lo detecta
+// ANTES de seleccionarlo y salta limpio al siguiente candidato, dejando rastro
+// en el audit como `fallback_no_credentials`.
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const dispatch = require('../agent-launcher/dispatch-with-fallback');
+
+// -----------------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------------
+
+// pipelineDir temporal con un agent-models.json donde:
+//   - primary  = anthropic (launcher claude → OAuth, sin env)
+//   - fallback1 = cerebras (requiere CEREBRAS_API_KEY)
+//   - fallback2 = openai-codex (requiere OPENAI_API_KEY)
+function mkTmpPipelineDir() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mp05-'));
+    const models = {
+        default_provider: 'anthropic',
+        providers: {
+            anthropic: {
+                launcher: 'claude',
+                model: 'claude-opus-4-7',
+                credentials_env: ['ANTHROPIC_API_KEY'],
+            },
+            cerebras: {
+                launcher: 'cerebras',
+                model: 'llama-3.3-70b',
+                credentials_env: ['CEREBRAS_API_KEY'],
+            },
+            'openai-codex': {
+                launcher: 'codex',
+                model: 'gpt-5-codex',
+                credentials_env: ['OPENAI_API_KEY'],
+            },
+        },
+        skills: {
+            'backend-dev': {
+                provider: 'anthropic',
+                fallbacks: [
+                    { provider: 'cerebras' },
+                    { provider: 'openai-codex' },
+                ],
+            },
+        },
+    };
+    fs.writeFileSync(path.join(dir, 'agent-models.json'), JSON.stringify(models, null, 2));
+    fs.mkdirSync(path.join(dir, 'logs'), { recursive: true });
+    return dir;
+}
+
+function cleanup(dir) {
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+}
+
+function readAuditLines(pipelineDir) {
+    const file = dispatch.dispatchAuditFile(pipelineDir);
+    if (!fs.existsSync(file)) return [];
+    return fs.readFileSync(file, 'utf8')
+        .split('\n')
+        .filter(l => l.trim().length > 0)
+        .map(l => JSON.parse(l));
+}
+
+// quotaModule fake: el primario siempre gateado, los fallbacks libres (el corte
+// de MP-05 es por credencial, no por cuota).
+function makeQuotaModule() {
+    return {
+        shouldGateSpawn(skill, { provider }) {
+            return provider === 'anthropic'; // sólo el primario gateado
+        },
+        sanitizeRawExcerpt: (s) => String(s || ''),
+    };
+}
+
+const primaryResolver = () => ({ provider: 'anthropic', model: 'claude-opus-4-7', source: 'primary' });
+const providerHandlerResolver = (name) => ({ name, providerDef: { launcher: name } });
+const silentNotify = () => {};
+
+// -----------------------------------------------------------------------------
+// MP-05
+// -----------------------------------------------------------------------------
+
+test('MP-05 · fallback sin credencial se saltea y se elige el siguiente con key', () => {
+    const dir = mkTmpPipelineDir();
+    try {
+        const r = dispatch.resolveSpawnWithFallback({
+            skill: 'backend-dev',
+            issue: 4242,
+            pipelineDir: dir,
+            quotaModule: makeQuotaModule(),
+            primaryResolver,
+            providerHandlerResolver,
+            notify: silentNotify,
+            // cerebras SIN key → debe saltarse; openai-codex CON key → se elige.
+            processEnv: { OPENAI_API_KEY: 'real-oai-key' },
+        });
+
+        assert.equal(r.source, 'fallback');
+        assert.equal(r.provider, 'openai-codex');
+        assert.equal(r.gated, false);
+        // La cadena pasó por cerebras (saltado) antes de openai-codex.
+        assert.deepEqual(r.chainTried, ['anthropic', 'cerebras', 'openai-codex']);
+
+        const audit = readAuditLines(dir);
+        const skipEv = audit.find(e => e.event === 'fallback_no_credentials');
+        assert.ok(skipEv, 'falta evento fallback_no_credentials');
+        assert.equal(skipEv.fallback_provider, 'cerebras');
+        assert.match(skipEv.raw_excerpt, /CEREBRAS_API_KEY/);
+        // El que sí tenía credencial quedó seleccionado.
+        assert.ok(audit.some(e => e.event === 'fallback_selected' && e.fallback_provider === 'openai-codex'));
+    } finally { cleanup(dir); }
+});
+
+test('MP-05 · todos los fallbacks sin credencial → chain agotada (all-gated)', () => {
+    const dir = mkTmpPipelineDir();
+    try {
+        const r = dispatch.resolveSpawnWithFallback({
+            skill: 'backend-dev',
+            issue: 4243,
+            pipelineDir: dir,
+            quotaModule: makeQuotaModule(),
+            primaryResolver,
+            providerHandlerResolver,
+            notify: silentNotify,
+            // ninguna key presente → ambos fallbacks se saltan por credencial.
+            processEnv: {},
+        });
+
+        assert.equal(r.gated, true);
+        assert.equal(r.source, 'all-gated');
+
+        const audit = readAuditLines(dir);
+        const skipped = audit.filter(e => e.event === 'fallback_no_credentials').map(e => e.fallback_provider);
+        assert.deepEqual(skipped.sort(), ['cerebras', 'openai-codex']);
+        assert.ok(audit.some(e => e.event === 'chain_exhausted'));
+        // Defensa: ningún provider sin credencial pudo ser seleccionado.
+        assert.ok(!audit.some(e => e.event === 'fallback_selected'));
+    } finally { cleanup(dir); }
+});
+
+test('MP-05 · placeholder REVOKED cuenta como credencial ausente', () => {
+    const dir = mkTmpPipelineDir();
+    try {
+        const r = dispatch.resolveSpawnWithFallback({
+            skill: 'backend-dev',
+            issue: 4244,
+            pipelineDir: dir,
+            quotaModule: makeQuotaModule(),
+            primaryResolver,
+            providerHandlerResolver,
+            notify: silentNotify,
+            // cerebras con placeholder → saltado; openai-codex con key real → elegido.
+            processEnv: { CEREBRAS_API_KEY: 'REVOKED', OPENAI_API_KEY: 'real-oai-key' },
+        });
+
+        assert.equal(r.provider, 'openai-codex');
+        const audit = readAuditLines(dir);
+        assert.ok(audit.some(e => e.event === 'fallback_no_credentials' && e.fallback_provider === 'cerebras'));
+    } finally { cleanup(dir); }
+});

--- a/.pipeline/lib/__tests__/sherlock-soft-timeout-mp01.test.js
+++ b/.pipeline/lib/__tests__/sherlock-soft-timeout-mp01.test.js
@@ -1,0 +1,44 @@
+// =============================================================================
+// sherlock-soft-timeout-mp01.test.js — MP-01/MP-02 (#3803)
+//
+// El orquestador del Commander corre el bloque Sherlock contra un reloj de
+// release (Promise.race). El bug raíz del "no pude verificar" recurrente era
+// que el reloj (antes 120s, MENOR que el presupuesto del cliente de 180s+
+// reelaboración) podía ganar la carrera y disparar un F-6 espurio aunque
+// Sherlock ya hubiese resuelto con OK.
+//
+// `shouldEmitSoftTimeoutDisclaimer(softTimedOut, resolved)` centraliza la
+// decisión: el disclaimer SOLO se emite cuando el reloj ganó SIN verdict.
+// Si Sherlock resolvió, se honra su resultado real (nunca se pisa un OK).
+// =============================================================================
+'use strict';
+
+process.env.PULPO_NO_AUTOSTART = '1';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const pulpo = require('../../pulpo.js');
+const { shouldEmitSoftTimeoutDisclaimer } = pulpo;
+
+test('emite F-6 cuando el soft-timeout gana SIN verdict (cuelgue genuino)', () => {
+  assert.equal(shouldEmitSoftTimeoutDisclaimer(true, false), true);
+});
+
+test('NO emite F-6 espurio cuando el reloj gana pero Sherlock ya resolvió', () => {
+  // Causa raíz del "no pude verificar": el verdict real manda, no el reloj.
+  assert.equal(shouldEmitSoftTimeoutDisclaimer(true, true), false);
+});
+
+test('NO emite F-6 cuando no hubo soft-timeout (flujo normal con verdict)', () => {
+  assert.equal(shouldEmitSoftTimeoutDisclaimer(false, true), false);
+});
+
+test('NO emite F-6 cuando no hubo soft-timeout ni verdict (sin carrera)', () => {
+  assert.equal(shouldEmitSoftTimeoutDisclaimer(false, false), false);
+});
+
+test('coerce de valores falsy/undefined → trata como sin timeout', () => {
+  assert.equal(shouldEmitSoftTimeoutDisclaimer(undefined, undefined), false);
+  assert.equal(shouldEmitSoftTimeoutDisclaimer(null, false), false);
+});

--- a/.pipeline/lib/agent-launcher/dispatch-with-fallback.js
+++ b/.pipeline/lib/agent-launcher/dispatch-with-fallback.js
@@ -77,6 +77,10 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 const { resolveProviderForSkill, getProviderHandler } = require('./resolve-provider');
+// MP-05 (#3803) — reutilizamos la validación de credenciales del precheck del
+// Commander para hacer pre-check de credenciales también en los skills antes de
+// elegir un fallback (no solo el Commander la tenía).
+const { _validateProviderCredentials: validateProviderCredentials } = require('../commander/credentials-precheck');
 
 // -----------------------------------------------------------------------------
 // Constantes
@@ -537,9 +541,11 @@ function resolveSpawnWithFallback(opts = {}) {
         notify,
         onLog,
         now,
+        processEnv,
     } = opts;
 
     const log = typeof onLog === 'function' ? onLog : () => {};
+    const _env = processEnv || process.env;
     const _resolveProvider = primaryResolver || resolveProviderForSkill;
     const _resolveHandler = providerHandlerResolver || getProviderHandler;
     const _notify = notify || enqueueTelegramNotice;
@@ -874,6 +880,30 @@ function resolveSpawnWithFallback(opts = {}) {
                     raw_excerpt: `fallback_${fbName}_gated_too`,
                 },
             });
+            continue;
+        }
+
+        // 3.d.bis — MP-05: pre-check de credenciales del fallback. Antes solo el
+        // Commander validaba credenciales pre-spawn; en los skills, un fallback
+        // sin key se intentaba igual y fallaba recién en runtime como
+        // `no_key_configured` (indistinguible de un error de red). Acá lo
+        // detectamos antes y saltamos limpio al siguiente candidato.
+        const fbDefForCreds = (models && models.providers && models.providers[fbName]) || null;
+        const credCheck = validateProviderCredentials(fbName, fbDefForCreds, _env);
+        if (!credCheck.ok) {
+            auditAppend({
+                pipelineDir, fsImpl, sanitize, auditLog, now: _now,
+                entry: {
+                    event: 'fallback_no_credentials',
+                    skill,
+                    issue: issue || null,
+                    fallback_index: i,
+                    fallback_provider: fbName,
+                    primary_provider: primaryProvider,
+                    raw_excerpt: `fallback_${fbName}_${credCheck.reason || 'no_credentials'}`,
+                },
+            });
+            log('lanzamiento', `↪️ ${skill}:#${issue || '?'} fallback="${fbName}" sin credencial (${credCheck.reason || 'no_credentials'}) — salto al siguiente.`);
             continue;
         }
 

--- a/.pipeline/lib/multi-provider/completion-client.js
+++ b/.pipeline/lib/multi-provider/completion-client.js
@@ -81,6 +81,8 @@
 
 const https = require('node:https');
 const { URL } = require('node:url');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const secretsRw = require('./secrets-rw');
 // #3486: clasificador HTTP universal. Delegamos la matriz statusCode→reason
@@ -169,14 +171,78 @@ const DEFAULT_TIMEOUT_MS = 0;
 
 const MAX_BODY_BYTES = 64 * 1024; // 64KB — cap defensivo contra DoS.
 
+// ---------------------------------------------------------------------------
+// MP-04 (#3803) — allowlist config-aware. La allowlist hardcoded de arriba es
+// la línea de base de defensa, pero quedaba ESTÁTICA: un modelo configurado en
+// `agent-models.json` (p.ej. cerebras=gpt-oss-120b) que no figurara como string
+// literal acá hacía fallar al provider con `invalid_model` ANTES del request
+// HTTP → cortaba la cascada en un eslabón sano. Ahora derivamos también los
+// modelos efectivamente declarados en la config (provider.model default +
+// todos los `model_override` por skill) y los unimos a la allowlist. Así un
+// modelo legítimamente configurado nunca se rechaza por drift de la lista, sin
+// abrir la puerta a `model` arbitrario (solo lo que un humano puso en config).
+//
+// Caché por mtime para no leer el JSON en cada `complete()`.
+let _configuredModelsCache = { mtimeMs: -1, pipelineDir: null, byProvider: null };
+
+function defaultPipelineDir() {
+    // completion-client.js vive en .pipeline/lib/multi-provider/
+    return path.join(__dirname, '..', '..');
+}
+
+function getConfiguredModels(pipelineDir, fsImpl) {
+    const _fs = fsImpl || fs;
+    const dir = pipelineDir || defaultPipelineDir();
+    const modelsPath = path.join(dir, 'agent-models.json');
+    let mtimeMs;
+    try {
+        mtimeMs = _fs.statSync(modelsPath).mtimeMs;
+    } catch {
+        return Object.create(null);
+    }
+    if (_configuredModelsCache.byProvider
+        && _configuredModelsCache.pipelineDir === dir
+        && _configuredModelsCache.mtimeMs === mtimeMs) {
+        return _configuredModelsCache.byProvider;
+    }
+    const byProvider = Object.create(null);
+    const add = (prov, model) => {
+        if (typeof prov !== 'string' || typeof model !== 'string' || !model) return;
+        (byProvider[prov] || (byProvider[prov] = new Set())).add(model);
+    };
+    try {
+        const models = JSON.parse(_fs.readFileSync(modelsPath, 'utf8'));
+        const providers = (models && models.providers) || {};
+        for (const [prov, def] of Object.entries(providers)) {
+            if (def && typeof def.model === 'string') add(prov, def.model);
+        }
+        const skills = (models && models.skills) || {};
+        for (const cfg of Object.values(skills)) {
+            const fbs = Array.isArray(cfg && cfg.fallbacks) ? cfg.fallbacks : [];
+            for (const fb of fbs) {
+                if (fb && typeof fb === 'object' && typeof fb.provider === 'string') {
+                    if (typeof fb.model_override === 'string') add(fb.provider, fb.model_override);
+                }
+            }
+        }
+    } catch {
+        return Object.create(null);
+    }
+    _configuredModelsCache = { mtimeMs, pipelineDir: dir, byProvider };
+    return byProvider;
+}
+
 function isAllowedProvider(provider) {
     return Object.prototype.hasOwnProperty.call(PROVIDER_COMPLETION_ENDPOINTS, provider);
 }
 
-function isAllowedModel(provider, model) {
+function isAllowedModel(provider, model, configuredByProvider) {
     const list = PROVIDER_MODELS_ALLOWLIST[provider];
-    if (!list) return false;
-    return list.indexOf(model) >= 0;
+    if (list && list.indexOf(model) >= 0) return true;
+    // Config-aware: aceptar modelos declarados por un humano en agent-models.json.
+    const cfgSet = configuredByProvider && configuredByProvider[provider];
+    if (cfgSet && cfgSet.has(model)) return true;
+    return false;
 }
 
 // ---------------------------------------------------------------------------
@@ -221,6 +287,7 @@ async function complete({
     temperature = 0,
     timeoutMs = DEFAULT_TIMEOUT_MS,
     secretsPath,
+    pipelineDir,
     fsImpl,
     httpImpl,
 } = {}) {
@@ -251,10 +318,11 @@ async function complete({
             durationMs: Date.now() - startedAt,
         };
     }
-    if (!isAllowedModel(provider, model)) {
+    const configuredByProvider = getConfiguredModels(pipelineDir, fsImpl);
+    if (!isAllowedModel(provider, model, configuredByProvider)) {
         return {
             ok: false,
-            error: { type: 'invalid_model', detail: `model '${model}' no está en allowlist de '${provider}'` },
+            error: { type: 'invalid_model', detail: `model '${model}' no está en allowlist ni configurado para '${provider}'` },
             ...baseResult,
             durationMs: Date.now() - startedAt,
         };
@@ -294,6 +362,17 @@ async function complete({
         temperature,
     });
 
+    // MP-12 (#3803) — retry único ante schema_drift en respuestas 2xx. Un
+    // provider que responde 200 con un body malformado (JSON roto o
+    // `choices[0].message.content` ausente) mataba el intento sin reintentar,
+    // y combinado con la cascada degradaba un eslabón por un blip transitorio
+    // del shim OpenAI-compat. Ahora reintentamos UNA vez la misma request
+    // (misma key/body) antes de declarar `invalid_response`. Solo el 2xx
+    // malformado reintenta: errores de red, timeout, auth, cuota y 4xx/5xx NO
+    // (esos cascadean igual que antes, sin gastar un segundo intento).
+    const SCHEMA_DRIFT_MAX_ATTEMPTS = 2;
+    for (let attempt = 1; attempt <= SCHEMA_DRIFT_MAX_ATTEMPTS; attempt++) {
+    const retriesLeft = attempt < SCHEMA_DRIFT_MAX_ATTEMPTS;
     let httpResult;
     try {
         httpResult = await doRequest({ spec, key, body, timeoutMs: effectiveTimeoutMs, httpImpl });
@@ -366,6 +445,7 @@ async function complete({
     try {
         parsed = JSON.parse(bodyText);
     } catch (e) {
+        if (retriesLeft) continue; // MP-12: reintentar una vez antes de claudicar.
         return {
             ok: false,
             error: { type: 'invalid_response', reason: 'schema_drift', statusCode, detail: 'JSON parse error' },
@@ -383,6 +463,7 @@ async function complete({
         : null;
 
     if (content === null) {
+        if (retriesLeft) continue; // MP-12: reintentar una vez antes de claudicar.
         return {
             ok: false,
             error: { type: 'invalid_response', reason: 'schema_drift', statusCode, detail: 'choices[0].message.content faltante' },
@@ -398,6 +479,16 @@ async function complete({
         outputTokens: (parsed.usage && typeof parsed.usage.completion_tokens === 'number') ? parsed.usage.completion_tokens : 0,
         provider,
         model: (typeof parsed.model === 'string' && parsed.model) ? parsed.model : model,
+        durationMs: Date.now() - startedAt,
+    };
+    } // fin loop MP-12
+
+    // Inalcanzable en la práctica (el loop retorna en cada rama salvo el
+    // `continue` de schema_drift, que en la última vuelta cae a su return).
+    return {
+        ok: false,
+        error: { type: 'invalid_response', reason: 'schema_drift', detail: 'agotados reintentos de schema_drift' },
+        ...baseResult,
         durationMs: Date.now() - startedAt,
     };
 }

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -847,6 +847,16 @@ function loadConfig() {
   return yaml.load(fs.readFileSync(CONFIG_PATH, 'utf8'));
 }
 
+// MP-01/MP-02 (#3803): decisión PURA del disclaimer por soft-timeout del
+// orquestador. El F-6 UX-2 solo se emite cuando el reloj de release ganó la
+// carrera SIN que el bloque Sherlock alcanzara un verdict (cuelgue genuino).
+// Si Sherlock ya resolvió (ok/rechazado/aborted), se honra ese resultado real
+// y NUNCA se pisa un OK con un F-6 espurio — la causa raíz del "no pude
+// verificar" recurrente.
+function shouldEmitSoftTimeoutDisclaimer(softTimedOut, resolved) {
+  return Boolean(softTimedOut) && !resolved;
+}
+
 function readYaml(filepath) {
   try {
     return yaml.load(fs.readFileSync(filepath, 'utf8')) || {};
@@ -9654,6 +9664,12 @@ INSTRUCCIÓN: Integrá los complementos del usuario en tu respuesta. Generá UNA
       let sherlockInvoked = false;
       let sherlockDisclaimerType = null;
       let sherlockSoftTimedOut = false;
+      // MP-01/MP-02 (#3803): flag que marca que el bloque Sherlock alcanzó un
+      // verdict real (ok/rechazado/aborted). Sin esto, una carrera microscópica
+      // entre el soft-timeout y la finalización del bloque podía pisar un OK
+      // legítimo con un F-6 espurio. El disclaimer SIEMPRE lo manda el verdict,
+      // no el reloj.
+      let sherlockResolved = false;
 
       // CA-UX-1: typing refresh loop. Se arranca antes y se limpia en finally.
       let typingTimer = null;
@@ -9667,10 +9683,27 @@ INSTRUCCIÓN: Integrá los complementos del usuario en tu respuesta. Generá UNA
         if (typingTimer) { try { clearInterval(typingTimer); } catch {} typingTimer = null; }
       };
 
-      // CA-UX-2: soft-timeout 120s. Promise.race contra el bloque completo de
-      // verificación. Si gana el timeout, marcamos sherlockSoftTimedOut y
-      // forzamos disclaimer F-6 + mensaje específico al usuario.
-      const SHERLOCK_SOFT_TIMEOUT_MS = 120_000;
+      // CA-UX-2 + MP-01/MP-02 (#3803): soft-timeout del turn handler. Promise.race
+      // contra el bloque completo de verificación; si gana el timeout, libera el
+      // chat con un mensaje honesto (evita el chat colgado indefinidamente — UX-2).
+      //
+      // MP-01/MP-02: el valor anterior (120s) era MENOR que el presupuesto que el
+      // propio cliente le concede a Sherlock — `completion-client` permite hasta
+      // 180s por request (ABSOLUTE_MAX_TIMEOUT_MS). Con reelaboración el bloque
+      // hace hasta 2 verify (≤180s c/u) + 1 reelaboración Claude. El reloj de 120s
+      // mataba a Sherlock ANTES de que terminara y disparaba un F-6 espurio aunque
+      // el verdict real fuese OK — la causa raíz del "no pude verificar" recurrente.
+      // Reconciliamos: el cutoff de release ahora es generoso (cubre el worst-case
+      // de la cascada) y configurable. El disclaimer lo decide el verdict, nunca
+      // el reloj (ver `sherlockResolved` abajo).
+      const SHERLOCK_SOFT_TIMEOUT_MS = (() => {
+        try {
+          const cfg = loadConfig();
+          const v = cfg && cfg.sherlock_soft_timeout_ms;
+          if (Number.isFinite(v) && v >= 60_000) return v;
+        } catch { /* fallback al default */ }
+        return 420_000; // 7 min — supera 2×180s (verify) + reelaboración Claude.
+      })();
 
       const sherlockBlock = (async () => {
         // Snapshot mínimo del estado del sistema. No incluimos paths sensibles
@@ -9766,6 +9799,9 @@ INSTRUCCIÓN: Reelaborá tu respuesta tomando en cuenta las contradicciones dete
           // CA-F-7 — silencio total cuando todo concuerda.
           log('commander', `🔍 Sherlock OK (provider=${verdict.sherlockProvider}, transport=${verdict.transport}, same_provider=${verdict.sameProvider}, ${verdict.durationMs}ms)`);
         }
+        // MP-01/MP-02: el bloque alcanzó un verdict conclusivo. A partir de acá
+        // el disclaimer (o su ausencia) refleja la decisión REAL de Sherlock.
+        sherlockResolved = true;
       })();
 
       try {
@@ -9786,12 +9822,12 @@ INSTRUCCIÓN: Reelaborá tu respuesta tomando en cuenta las contradicciones dete
         stopTypingLoop();
       }
 
-      if (sherlockSoftTimedOut) {
-        // CA-UX-2 — soft-timeout del turn handler. Avisamos al usuario sin
-        // jerga técnica y degradamos a F-6. La respuesta original (sin
-        // reelaboración garantizada) se envía igual debajo. El audit
-        // post-turn registra el outcome para telemetría.
-        log('commander', `⏱️ Sherlock soft-timeout ${SHERLOCK_SOFT_TIMEOUT_MS}ms disparó — liberando chat con mensaje UX-2`);
+      if (shouldEmitSoftTimeoutDisclaimer(sherlockSoftTimedOut, sherlockResolved)) {
+        // CA-UX-2 — soft-timeout del turn handler, SOLO cuando Sherlock no
+        // alcanzó un verdict (cuelgue genuino). Avisamos al usuario sin jerga
+        // técnica y degradamos a F-6. La respuesta original se envía igual
+        // debajo. El audit post-turn registra el outcome para telemetría.
+        log('commander', `⏱️ Sherlock soft-timeout ${SHERLOCK_SOFT_TIMEOUT_MS}ms disparó SIN verdict — liberando chat con mensaje UX-2`);
         try {
           sendTelegramPlain(
             'Esta respuesta me está tomando más tiempo de lo normal. ' +
@@ -9800,6 +9836,11 @@ INSTRUCCIÓN: Reelaborá tu respuesta tomando en cuenta las contradicciones dete
           );
         } catch { /* best-effort */ }
         sherlockDisclaimerType = sherlockVerifier.DISCLAIMER_TYPES.TIMEOUT_OR_NO_PROVIDER;
+      } else if (sherlockSoftTimedOut && sherlockResolved) {
+        // MP-01: el reloj ganó la carrera por microsegundos pero el bloque YA
+        // había resuelto. Honramos el verdict real (que ya seteó o no el
+        // disclaimer correspondiente). NUNCA pisamos un OK con un F-6 espurio.
+        log('commander', `⏱️ soft-timeout disparó pero Sherlock ya tenía verdict — se honra el resultado real (sin F-6 espurio)`);
       }
 
       if (sherlockDisclaimerType && respuesta) {
@@ -11651,6 +11692,8 @@ process.on('SIGTERM', () => {
 // Útil para tests unitarios y scripts de evidencia del gate predictivo.
 if (process.env.PULPO_NO_AUTOSTART === '1') {
   module.exports = {
+    // MP-01/MP-02 (#3803) — decisión pura del disclaimer por soft-timeout.
+    shouldEmitSoftTimeoutDisclaimer,
     predictResourceImpact,
     getEstimatedImpact,
     measureEmulatorMemPercent,

--- a/docs/pipeline/auditoria-3803-multi-provider.md
+++ b/docs/pipeline/auditoria-3803-multi-provider.md
@@ -19,18 +19,18 @@
 
 ## 🔴 Severidad ALTA
 
-### MP-01 · F-6 recurrente: `verdict: 'aborted'` cuando la cadena entera de providers degrada
-- **Estado:** CONFIRMADO
-- **Archivo:** `.pipeline/pulpo.js:9761-9764` (F-6 por `aborted`, camino independiente), `:9789-9803` (soft-timeout, hoy inerte). Evidencia: memoria `project_sherlock-f6-chain-degraded` (2026-06-02) contra `commander-dispatch` log
-- **Qué pasa:** El F-6 "no pude verificar con el verificador adversarial" se dispara cuando Sherlock devuelve `verdict: 'aborted'` porque **la cadena completa de providers cayó en el mismo turno**: schema_violation en Opus + spawn_exit en codex + cuota en gemini + invalid_model en cerebras. Sherlock recorre toda la cascada (ver MP-03, refutado) y aun así se queda sin ningún eslabón sano → aborta → F-6 legítimo pero molesto.
-- **NO es el soft-timeout.** El reloj de 120s ya quedó inerte (`DEFAULT_TIMEOUT_MS = 0` en Sherlock y completion-client, ver MP-02): el camino del `aborted` es independiente del camino del timeout. La causa vieja del timeout ya está corregida.
-- **Por qué importa:** Mientras los eslabones individuales no degraden con gracia (ver MP-04, MP-05, MP-12), cualquier turno con Anthropic en cuota arrastra a toda la cadena a fallar de golpe → F-6. La cura del F-6 recurrente NO es tocar el orquestador: es hacer que cada provider degrade limpio al siguiente en vez de matar el intento.
+### MP-01 · F-6 espurio: el soft-timeout del orquestador (120s) era MENOR que el presupuesto del cliente (180s) — ✅ CORREGIDO (#3803, 2026-06-02)
+- **Estado:** CORREGIDO
+- **Archivo:** `.pipeline/pulpo.js` soft-timeout del turn handler (`SHERLOCK_SOFT_TIMEOUT_MS`) + guard `sherlockResolved`
+- **Qué pasaba:** El orquestador envolvía TODO el bloque Sherlock en un `Promise.race` contra un reloj hardcoded de **120s**. Pero el `completion-client` le concede a cada request de Sherlock hasta **180s** (`ABSOLUTE_MAX_TIMEOUT_MS`), y el bloque puede hacer 2 verify + 1 reelaboración. Resultado: en cualquier verificación legítimamente lenta (cascada cruzando providers), el reloj de 120s ganaba la carrera y disparaba el F-6 "no pude verificar" **aunque el verdict real fuese OK**. Era la causa raíz del F-6 recurrente que reaparecía turno a turno.
+- **Corrección rumbo doble:** (1) el soft-timeout pasó a **420s** (cubre 2×180s + reelaboración) y es **configurable** vía `sherlock_soft_timeout_ms`; (2) se agregó el flag `sherlockResolved`: el disclaimer F-6 lo decide **el verdict real de Sherlock, nunca el reloj** — si el bloque resolvió, jamás se pisa un OK con un F-6 espurio.
+- **Nota de auditoría (qué falló en el barrido inicial):** la versión previa de este doc afirmaba que "el reloj de 120s ya quedó inerte". Eso era **incorrecto**: el código tenía el `Promise.race` de 120s plenamente activo. Ese error de lectura es la razón por la que MP-01/MP-02 no entró en el PR #3803 (commit `57ee9593`, que sí entregó MP-04/MP-12/MP-05): se trató el F-6 como puro camino de cascada-degradada. El path de cascada-degradada sigue vivo y se trackea aparte (ver nota MP-03/MP-03b abajo).
 
-### MP-02 · Sin presupuesto total de tiempo en la cascada (Sherlock sin timeout interno + orquestador con 120s)
-- **Estado:** CONFIRMADO (relacionado con MP-01)
-- **Archivo:** `.pipeline/lib/sherlock-verifier.js:167-172` (`DEFAULT_TIMEOUT_MS = 0`), `.pipeline/lib/multi-provider/completion-client.js:47-55` (`DEFAULT_TIMEOUT_MS = 0`)
-- **Qué pasa:** Tanto Sherlock como el completion-client corren sin timeout (decisión deliberada). Si un provider remoto se cuelga, el thread espera indefinidamente; el único corte es el soft-timeout de 120s del orquestador (MP-01), que arriba degrada a F-6 espurio. No hay un budget de tiempo que acote la cascada completa sin romper el contrato "sin reloj".
-- **Por qué importa:** Tensión de diseño: "sin timeout para que aguante la cascada" choca con "el usuario no puede esperar para siempre". Hay que reconciliar MP-01 y MP-02 juntos (p.ej. timeout solo si NO hubo veredicto, o cancelar Sherlock al timeout en vez de ignorar su resultado).
+### MP-02 · Reconciliar el presupuesto de tiempo de la cascada con el cutoff del orquestador — ✅ CORREGIDO (junto a MP-01)
+- **Estado:** CORREGIDO (junto a MP-01)
+- **Archivo:** `.pipeline/lib/sherlock-verifier.js` + `.pipeline/lib/multi-provider/completion-client.js` (presupuesto per-request) + `.pipeline/pulpo.js` (cutoff del orquestador)
+- **Qué pasaba:** Sherlock y el cliente corren sin timeout local (decisión deliberada); el presupuesto se delega al cliente (180s per-request). El único corte de release era el soft-timeout del orquestador, que estaba por DEBAJO de ese presupuesto → mataba la cascada antes de tiempo (MP-01).
+- **Cómo se reconcilió:** el cutoff del orquestador ahora es ≥ al worst-case del cliente (420s > 2×180s) y solo libera el chat (mensaje UX-2) cuando **NO hubo veredicto**. Se preserva el contrato "sin reloj que mate la cascada" + la garantía UX "el chat no queda colgado para siempre".
 
 ### MP-03 · ¿Sherlock perdió la cascada multi-provider en `verify()`? — REFUTADO
 - **Estado:** REFUTADO

--- a/docs/pipeline/auditoria-3803-multi-provider.md
+++ b/docs/pipeline/auditoria-3803-multi-provider.md
@@ -1,0 +1,159 @@
+# Auditoría integral end-to-end multi-provider (#3803)
+
+> **Estado:** barrido completo — fase de documentación. NO se aplicó ningún fix todavía.
+> Esta es la lista maestra de cuestiones detectadas para ir resolviendo de a poco.
+> Fecha del barrido: 2026-06-02.
+> Método: 5 auditores en paralelo (cadena de fallback, orquestador Commander/Sherlock,
+> health/conectores, config de modelos por agente, cobertura/smoke) + verificación
+> adversarial manual de los hallazgos críticos y contradictorios.
+
+## Cómo leer esta tabla
+
+- **ID** estable (`MP-NN`) para referenciar cada cuestión en los fixes posteriores.
+- **Estado de verificación:**
+  - `CONFIRMADO` — verificado contra el código real con archivo:línea.
+  - `A CONFIRMAR` — reportado por un auditor, plausible, falta confirmación fina.
+  - `REFUTADO` — un auditor lo reportó pero la verificación manual lo desmiente (se deja registrado para no perder tiempo re-investigándolo).
+
+---
+
+## 🔴 Severidad ALTA
+
+### MP-01 · F-6 recurrente: `verdict: 'aborted'` cuando la cadena entera de providers degrada
+- **Estado:** CONFIRMADO
+- **Archivo:** `.pipeline/pulpo.js:9761-9764` (F-6 por `aborted`, camino independiente), `:9789-9803` (soft-timeout, hoy inerte). Evidencia: memoria `project_sherlock-f6-chain-degraded` (2026-06-02) contra `commander-dispatch` log
+- **Qué pasa:** El F-6 "no pude verificar con el verificador adversarial" se dispara cuando Sherlock devuelve `verdict: 'aborted'` porque **la cadena completa de providers cayó en el mismo turno**: schema_violation en Opus + spawn_exit en codex + cuota en gemini + invalid_model en cerebras. Sherlock recorre toda la cascada (ver MP-03, refutado) y aun así se queda sin ningún eslabón sano → aborta → F-6 legítimo pero molesto.
+- **NO es el soft-timeout.** El reloj de 120s ya quedó inerte (`DEFAULT_TIMEOUT_MS = 0` en Sherlock y completion-client, ver MP-02): el camino del `aborted` es independiente del camino del timeout. La causa vieja del timeout ya está corregida.
+- **Por qué importa:** Mientras los eslabones individuales no degraden con gracia (ver MP-04, MP-05, MP-12), cualquier turno con Anthropic en cuota arrastra a toda la cadena a fallar de golpe → F-6. La cura del F-6 recurrente NO es tocar el orquestador: es hacer que cada provider degrade limpio al siguiente en vez de matar el intento.
+
+### MP-02 · Sin presupuesto total de tiempo en la cascada (Sherlock sin timeout interno + orquestador con 120s)
+- **Estado:** CONFIRMADO (relacionado con MP-01)
+- **Archivo:** `.pipeline/lib/sherlock-verifier.js:167-172` (`DEFAULT_TIMEOUT_MS = 0`), `.pipeline/lib/multi-provider/completion-client.js:47-55` (`DEFAULT_TIMEOUT_MS = 0`)
+- **Qué pasa:** Tanto Sherlock como el completion-client corren sin timeout (decisión deliberada). Si un provider remoto se cuelga, el thread espera indefinidamente; el único corte es el soft-timeout de 120s del orquestador (MP-01), que arriba degrada a F-6 espurio. No hay un budget de tiempo que acote la cascada completa sin romper el contrato "sin reloj".
+- **Por qué importa:** Tensión de diseño: "sin timeout para que aguante la cascada" choca con "el usuario no puede esperar para siempre". Hay que reconciliar MP-01 y MP-02 juntos (p.ej. timeout solo si NO hubo veredicto, o cancelar Sherlock al timeout en vez de ignorar su resultado).
+
+### MP-03 · ¿Sherlock perdió la cascada multi-provider en `verify()`? — REFUTADO
+- **Estado:** REFUTADO
+- **Archivo:** `.pipeline/lib/sherlock-verifier.js:49-74` (comentario #3668), evidencia: `commander-dispatch` log 2026-06-02 turno ~11:32
+- **Qué pasa:** Un auditor sospechó que la refactor #3668 dejó a Sherlock invocando un único provider y cayendo al primer error. **La evidencia logueada lo desmiente:** en el turno verificado Sherlock recorre la cadena completa provider-por-provider — `anthropic → openai-codex → gemini → cerebras → nvidia-nim` (5 eslabones intentados). NO cae al primer error.
+- **Conclusión:** la cascada de Sherlock está intacta. Se deja registrado para no re-investigarlo. NO es un defecto y NO condiciona nada.
+
+### MP-04 · Modelo inválido es error terminal (allowlist estática rompe la cascada)
+- **Estado:** CONFIRMADO
+- **Archivo:** `.pipeline/lib/multi-provider/completion-client.js:137-160` (allowlist hardcoded), `:254-260` (early-return `invalid_model`)
+- **Qué pasa:** Si un caller pide un modelo que no está en `PROVIDER_MODELS_ALLOWLIST[provider]`, el cliente retorna `invalid_model` **antes** de la request HTTP, y es un error no recuperable por la cascada. La allowlist es estática: un modelo nuevo (p.ej. otra variante de Cerebras) no figura hasta que un PR agregue el string.
+- **Por qué importa:** Una config con un nombre de modelo levemente distinto al de la allowlist hace fallar al provider de forma silenciosa y non-recoverable, en vez de degradar.
+
+### MP-05 · Sin pre-check de credenciales en skills genéricos (solo el Commander lo tiene)
+- **Estado:** CONFIRMADO
+- **Archivo:** `.pipeline/lib/multi-provider/completion-client.js:279-287` (`no_key_configured`), `.pipeline/lib/agent-launcher/dispatch-with-fallback.js:860-878` (gate por cuota, no por credencial), `.pipeline/lib/commander/credentials-precheck.js` (pre-check solo Commander)
+- **Qué pasa:** El dispatcher elige un fallback validando el flag de cuota (`shouldGateSpawn`), pero **no** valida que la credencial del fallback esté configurada. Si el fallback no tiene key, el spawn se intenta y falla recién en runtime con `no_key_configured`, que se ve como error de red. El pre-check de credenciales existe únicamente para el Commander, no para skills.
+- **Por qué importa:** Degradación no grácil: el operador ve un timeout/error de red en lugar de "credencial no configurada".
+
+---
+
+## 🟡 Severidad MEDIA
+
+### MP-06 · ElevenLabs contamina el semáforo de conectores LLM
+- **Estado:** CONFIRMADO
+- **Archivo:** `.pipeline/lib/multi-provider/secrets-rw.js:85-90` (en `MANAGED_KEYS`), `.pipeline/lib/multi-provider/live-ping.js:121-128`, `.pipeline/state/multi-provider-health.json` (snapshot: `red_count: 1` = ElevenLabs `no_key_configured`)
+- **Qué pasa:** ElevenLabs (TTS/STT de pago) está en `MANAGED_KEYS` y se pinguea como un provider más. El health-cron lo incluye y aparece rojo, mostrando "1 proveedor en rojo" cuando el pipeline LLM está 100% verde. No participa de la cascada multi-provider (no está en ningún skill de `agent-models.json`).
+- **Por qué importa:** Falso rojo recurrente que confunde el panorama. Hay que separarlo en una lista `MULTIMEDIA_KEYS` o excluirlo del health-cron de LLM.
+
+### MP-07 · Dos fuentes de verdad para el listado de providers en health
+- **Estado:** CONFIRMADO
+- **Archivo:** `.pipeline/lib/provider-health.js:115-124` (lee de `agent-models.json`) vs `.pipeline/lib/multi-provider/health-cron.js:257-260` (lee de `secrets-rw.MANAGED_KEYS`)
+- **Qué pasa:** `provider-health.js` (endpoint del dashboard) deriva los providers de `agent-models.json` y NO incluye ElevenLabs; `health-cron.js` los deriva de `MANAGED_KEYS` y SÍ lo incluye. El estado interno del Pulpo y el semáforo del dashboard pueden desalinearse.
+- **Por qué importa:** Inconsistencia de fuente de verdad; relacionado con MP-06.
+
+### MP-08 · `openai-codex` desalineado en `agent-models.json` (sin `auth_mode`/`cli_binary`)
+- **Estado:** CONFIRMADO
+- **Archivo:** `.pipeline/agent-models.json:40-67` (sin `auth_mode: 'oauth'`) vs `.pipeline/lib/multi-provider/secrets-rw.js:74-82` (sí tiene `auth_mode: 'oauth'`, `cli_binary: 'codex'`)
+- **Qué pasa:** El health-check del CLI-OAuth (#3802) funciona **por accidente** porque lee de `secrets-rw.js`, que es la fuente correcta. Pero `agent-models.json` quedó incompleto/desalineado. Una refactor futura que confíe en `agent-models.json` se rompería.
+- **Por qué importa:** Deuda de coherencia que puede morder en mantenimiento; documentar cuál es la fuente de verdad real.
+
+### MP-09 · Health-cron observa pero NO influye en la decisión de spawn
+- **Estado:** A CONFIRMAR
+- **Archivo:** `.pipeline/lib/multi-provider/health-cron.js`, `.pipeline/audit/multi-provider-health.jsonl`
+- **Qué pasa:** El cron pinguea providers cada ~15 min y persiste estados (verde/rojo), pero el gate de spawn no consulta ese estado: un provider marcado rojo igual se intenta. El único gate real es el de cuota (`shouldGateSpawn`).
+- **Por qué importa:** Se hacen spawns condenados a fallar cuando ya sabemos que el provider está caído; falta conectar health → gate pre-spawn (similar al quota-gate). Relacionado con MP-05.
+
+### MP-10 · `MAX_FALLBACK_DEPTH = 5` corta cadenas más largas silenciosamente
+- **Estado:** CONFIRMADO
+- **Archivo:** `.pipeline/lib/agent-launcher/dispatch-with-fallback.js:753-770`
+- **Qué pasa:** Si un skill declara más de 5 fallbacks, la iteración corta en el 5º con `break` y reporta `source: 'all-gated'`. Los fallbacks 6+ nunca se prueban (es anti-DoS intencional), pero el operador no se entera de que su config quedó truncada.
+- **Por qué importa:** Config silenciosamente ignorada. Hoy ningún skill supera 4 fallbacks, así que no muerde, pero conviene loguear el truncamiento.
+
+### MP-11 · Smoke-test corre en dry-run: no prueba cascada real ni consumo de tokens
+- **Estado:** A CONFIRMAR
+- **Archivo:** `.pipeline/lib/multi-provider/smoke-test.js`, `.pipeline/audit/multi-provider-smoke-test-2026-06-01.jsonl` (eventos `spawn_dry_run`, latencias ≤100ms)
+- **Qué pasa:** El último smoke-test (2026-06-01) fue 100% dry-run: valida shape sintáctico y que los providers estén registrados, pero no invoca ningún provider real, no ejercita la cascada con primario gateado, ni mide latencia/tokens reales. No se observó un modo `--run-real` en el grep inicial.
+- **Por qué importa:** El smoke da "PASS" sin garantizar que la integración real (auth/endpoint/parseo de tokens) funcione. Falta un modo que spawnee al menos 1 prompt real por skill×provider.
+
+### MP-12 · Schema-violation mata el intento sin retry (provider con contrato roto)
+- **Estado:** CONFIRMADO
+- **Archivo:** `.pipeline/lib/multi-provider/completion-client.js:371, 388` (`invalid_response` / `schema_drift`)
+- **Qué pasa:** Si un provider responde 2xx pero el payload no matchea el shape OpenAI esperado, se retorna `invalid_response` (determinístico). Si el shim de un provider cambia el schema, cada intento falla igual. Combinado con MP-03 (si Sherlock no recorre cascada), es falla silenciosa.
+- **Por qué importa:** Un cambio de contrato de un provider (p.ej. Gemini v1beta OpenAI-compat) rompe sin diagnóstico claro.
+
+---
+
+## 🟢 Severidad BAJA (deuda / consistencia)
+
+### MP-13 · Cadenas de fallback heterogéneas entre skills
+- **Estado:** CONFIRMADO
+- **Archivo:** `.pipeline/agent-models.json` — `refinar:429-441` (2 fallbacks, sin gemini), `review:273-276`, backend-dev/pipeline-dev/security (2 fallbacks, sin gemini) vs qa/po/ux/architect/perf (3 fallbacks)
+- **Qué pasa:** Algunos skills tienen 3 fallbacks (incluyen gemini-google) y otros 2 (lo omiten), sin criterio documentado. El fix de `refinar` quedó parcial respecto al Grupo B.
+- **Por qué importa:** Cobertura de degradación desigual; conviene decidir si es intencional o deuda y homogeneizar.
+
+### MP-14 · Naming inconsistente de modelos Codex (`gpt-5` vs `gpt-5-codex`)
+- **Estado:** CONFIRMADO
+- **Archivo:** `.pipeline/agent-models.json` — `review` usa `gpt-5-codex`; `qa`/`po`/`ux` usan `gpt-5`
+- **Qué pasa:** Ambos pasan la validación de schema (los dos están en la allowlist), pero el naming dispar confunde auditorías manuales.
+- **Por qué importa:** Pura mantenibilidad.
+
+### MP-15 · Gemini CLI se cuelga en OAuth headless (timeouts de ~120s)
+- **Estado:** A CONFIRMAR
+- **Archivo:** `.pipeline/audit/multi-provider-health.jsonl` (transiciones green↔red de Gemini con latencias >120s)
+- **Qué pasa:** El health log muestra a Gemini alternando verde/rojo con latencias de ~120s, patrón típico de OAuth interactivo sin sesión iniciada en la máquina headless del Pulpo.
+- **Por qué importa:** Gemini como fallback de skills multimodales (qa/po/ux) sería poco confiable en producción sin auth persistente.
+
+### MP-16 · Spike de Groq sin marca de descontinuado
+- **Estado:** A CONFIRMAR
+- **Archivo:** `docs/pipeline/multi-provider-free-tier-spike.md` (recomienda Groq), `resolve-provider.js:39-40` (Groq removido en #3353)
+- **Qué pasa:** Groq fue descontinuado (#3353) pero el doc del spike sigue recomendándolo sin header de deprecación. Un dev nuevo podría re-proponerlo.
+- **Por qué importa:** Deuda de documentación; agregar marca de descontinuado.
+
+### MP-17 · Audit log de dispatch demasiado granular
+- **Estado:** CONFIRMADO
+- **Archivo:** `.pipeline/lib/agent-launcher/dispatch-with-fallback.js:723-972`
+- **Qué pasa:** Se emite una línea de audit por cada micro-decisión (`gated_no_fallbacks`, `depth_exceeded`, `fallback_cycle_skipped`, etc.). Con muchos fallbacks gateados se infla el log sin contexto accionable.
+- **Por qué importa:** Ruido operacional menor.
+
+---
+
+## 🎯 Indispensables para considerar el multi-provider funcionando en todos los órdenes
+
+Esta es la lista de corte: **sin estos resueltos, NO podemos afirmar que el multi-provider
+funciona end-to-end con confianza.** El resto (semáforo, smoke, deuda/consistencia) mejora
+la operación pero no bloquea la afirmación de "funciona".
+
+La raíz del F-6 recurrente (MP-01) es que **la cadena entera degrada de golpe**: cada eslabón
+que falla mata el intento en vez de pasar limpio al siguiente, y cuando coinciden varios el
+veredicto queda `aborted`. Por eso los tres indispensables son precisamente los que hacen que
+cada eslabón degrade con gracia. Resueltos esos tres, el `aborted` solo ocurriría si TODOS los
+providers están realmente caídos a la vez — y ahí el F-6 es legítimo.
+
+| # | ID | Por qué es indispensable |
+|---|-----|--------------------------|
+| 1 | **MP-04** | Un modelo fuera de la allowlist estática hoy es error terminal: corta la cascada en vez de degradar al siguiente provider. Fue uno de los eslabones que tiró la cadena (cerebras `invalid_model`). |
+| 2 | **MP-12** | Un provider que responde con el schema cambiado mata el intento sin retry ni degradación. Fue otro eslabón caído (schema_violation en Opus). |
+| 3 | **MP-05** | Sin pre-check de credenciales en los skills (solo el Commander lo tiene): un fallback sin key falla recién en runtime como "error de red" en vez de saltearlo limpio. Tapa la degradación grácil del resto de la cadena. |
+
+> Con esos tres cerrados, el F-6 deja de aparecer por cadena-degradada (MP-01 se cura solo: ya
+> no quedan eslabones que aborten el intento). **MP-03 quedó REFUTADO** (Sherlock sí recorre la
+> cascada). MP-02 (reconciliar timeouts) y el resto (MP-06 a MP-11, MP-13 a MP-17) son mejoras de
+> semáforo, pruebas y deuda — importantes pero NO condicionan la afirmación "funciona en todos los
+> órdenes". Se atacan después.
+
+> Cada MP-NN se convertirá en su propio fix/issue cuando arranquemos a corregir de a poco.


### PR DESCRIPTION
## Qué resuelve

**MP-01/MP-02** de la auditoría #3803 — la **causa raíz** del mensaje *"no pude verificar"* recurrente.

El reloj de release del turn handler estaba en **120s**, MENOR que el presupuesto que el propio cliente le concede a Sherlock (**180s/request + reelaboración**). En worst-case de cascada, el reloj mataba el bloque ANTES de terminar y disparaba un **F-6 espurio aunque el verdict real fuese OK**.

## Cambios

| | |
|---|---|
| `SHERLOCK_SOFT_TIMEOUT_MS` | 120s → **420s**, config-aware (`sherlock_soft_timeout_ms`). Cubre 2×180s + reelaboración. |
| `sherlockResolved` (nuevo flag) | El disclaimer lo decide el **verdict real**, nunca el reloj. Si el timeout gana la carrera pero Sherlock ya resolvió, se honra el resultado — **nunca se pisa un OK con F-6**. |
| `shouldEmitSoftTimeoutDisclaimer()` | Decisión extraída a función pura testeable. |
| Doc auditoría | Corregida: la afirmación *"el reloj de 120s quedó inerte"* era falsa. |

## Tests

`sherlock-soft-timeout-mp01.test.js` — **5 tests, 0 fallos**. Cubre los 4 cuadrantes (timeout×resolved) + coerción de falsy.

Refs #3803

🤖 Generated with [Claude Code](https://claude.com/claude-code)