### PR TITLE
fix(pipeline): MP-01/MP-02 — fin del "no pude verificar" espurio (soft-timeout vs presupuesto Sherlock) (#3803)

### DIFF
--- a/.pipeline/lib/__tests__/sherlock-soft-timeout-mp01.test.js
+++ b/.pipeline/lib/__tests__/sherlock-soft-timeout-mp01.test.js
@@ -1,0 +1,44 @@
+// =============================================================================
+// sherlock-soft-timeout-mp01.test.js — MP-01/MP-02 (#3803)
+//
+// El orquestador del Commander corre el bloque Sherlock contra un reloj de
+// release (Promise.race). El bug raíz del "no pude verificar" recurrente era
+// que el reloj (antes 120s, MENOR que el presupuesto del cliente de 180s+
+// reelaboración) podía ganar la carrera y disparar un F-6 espurio aunque
+// Sherlock ya hubiese resuelto con OK.
+//
+// `shouldEmitSoftTimeoutDisclaimer(softTimedOut, resolved)` centraliza la
+// decisión: el disclaimer SOLO se emite cuando el reloj ganó SIN verdict.
+// Si Sherlock resolvió, se honra su resultado real (nunca se pisa un OK).
+// =============================================================================
+'use strict';
+
+process.env.PULPO_NO_AUTOSTART = '1';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const pulpo = require('../../pulpo.js');
+const { shouldEmitSoftTimeoutDisclaimer } = pulpo;
+
+test('emite F-6 cuando el soft-timeout gana SIN verdict (cuelgue genuino)', () => {
+  assert.equal(shouldEmitSoftTimeoutDisclaimer(true, false), true);
+});
+
+test('NO emite F-6 espurio cuando el reloj gana pero Sherlock ya resolvió', () => {
+  // Causa raíz del "no pude verificar": el verdict real manda, no el reloj.
+  assert.equal(shouldEmitSoftTimeoutDisclaimer(true, true), false);
+});
+
+test('NO emite F-6 cuando no hubo soft-timeout (flujo normal con verdict)', () => {
+  assert.equal(shouldEmitSoftTimeoutDisclaimer(false, true), false);
+});
+
+test('NO emite F-6 cuando no hubo soft-timeout ni verdict (sin carrera)', () => {
+  assert.equal(shouldEmitSoftTimeoutDisclaimer(false, false), false);
+});
+
+test('coerce de valores falsy/undefined → trata como sin timeout', () => {
+  assert.equal(shouldEmitSoftTimeoutDisclaimer(undefined, undefined), false);
+  assert.equal(shouldEmitSoftTimeoutDisclaimer(null, false), false);
+});

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -847,6 +847,16 @@ function loadConfig() {
   return yaml.load(fs.readFileSync(CONFIG_PATH, 'utf8'));
 }
 
+// MP-01/MP-02 (#3803): decisión PURA del disclaimer por soft-timeout del
+// orquestador. El F-6 UX-2 solo se emite cuando el reloj de release ganó la
+// carrera SIN que el bloque Sherlock alcanzara un verdict (cuelgue genuino).
+// Si Sherlock ya resolvió (ok/rechazado/aborted), se honra ese resultado real
+// y NUNCA se pisa un OK con un F-6 espurio — la causa raíz del "no pude
+// verificar" recurrente.
+function shouldEmitSoftTimeoutDisclaimer(softTimedOut, resolved) {
+  return Boolean(softTimedOut) && !resolved;
+}
+
 function readYaml(filepath) {
   try {
     return yaml.load(fs.readFileSync(filepath, 'utf8')) || {};
@@ -9654,6 +9664,12 @@ INSTRUCCIÓN: Integrá los complementos del usuario en tu respuesta. Generá UNA
       let sherlockInvoked = false;
       let sherlockDisclaimerType = null;
       let sherlockSoftTimedOut = false;
+      // MP-01/MP-02 (#3803): flag que marca que el bloque Sherlock alcanzó un
+      // verdict real (ok/rechazado/aborted). Sin esto, una carrera microscópica
+      // entre el soft-timeout y la finalización del bloque podía pisar un OK
+      // legítimo con un F-6 espurio. El disclaimer SIEMPRE lo manda el verdict,
+      // no el reloj.
+      let sherlockResolved = false;
 
       // CA-UX-1: typing refresh loop. Se arranca antes y se limpia en finally.
       let typingTimer = null;
@@ -9667,10 +9683,27 @@ INSTRUCCIÓN: Integrá los complementos del usuario en tu respuesta. Generá UNA
         if (typingTimer) { try { clearInterval(typingTimer); } catch {} typingTimer = null; }
       };
 
-      // CA-UX-2: soft-timeout 120s. Promise.race contra el bloque completo de
-      // verificación. Si gana el timeout, marcamos sherlockSoftTimedOut y
-      // forzamos disclaimer F-6 + mensaje específico al usuario.
-      const SHERLOCK_SOFT_TIMEOUT_MS = 120_000;
+      // CA-UX-2 + MP-01/MP-02 (#3803): soft-timeout del turn handler. Promise.race
+      // contra el bloque completo de verificación; si gana el timeout, libera el
+      // chat con un mensaje honesto (evita el chat colgado indefinidamente — UX-2).
+      //
+      // MP-01/MP-02: el valor anterior (120s) era MENOR que el presupuesto que el
+      // propio cliente le concede a Sherlock — `completion-client` permite hasta
+      // 180s por request (ABSOLUTE_MAX_TIMEOUT_MS). Con reelaboración el bloque
+      // hace hasta 2 verify (≤180s c/u) + 1 reelaboración Claude. El reloj de 120s
+      // mataba a Sherlock ANTES de que terminara y disparaba un F-6 espurio aunque
+      // el verdict real fuese OK — la causa raíz del "no pude verificar" recurrente.
+      // Reconciliamos: el cutoff de release ahora es generoso (cubre el worst-case
+      // de la cascada) y configurable. El disclaimer lo decide el verdict, nunca
+      // el reloj (ver `sherlockResolved` abajo).
+      const SHERLOCK_SOFT_TIMEOUT_MS = (() => {
+        try {
+          const cfg = loadConfig();
+          const v = cfg && cfg.sherlock_soft_timeout_ms;
+          if (Number.isFinite(v) && v >= 60_000) return v;
+        } catch { /* fallback al default */ }
+        return 420_000; // 7 min — supera 2×180s (verify) + reelaboración Claude.
+      })();
 
       const sherlockBlock = (async () => {
         // Snapshot mínimo del estado del sistema. No incluimos paths sensibles
@@ -9766,6 +9799,9 @@ INSTRUCCIÓN: Reelaborá tu respuesta tomando en cuenta las contradicciones dete
           // CA-F-7 — silencio total cuando todo concuerda.
           log('commander', `🔍 Sherlock OK (provider=${verdict.sherlockProvider}, transport=${verdict.transport}, same_provider=${verdict.sameProvider}, ${verdict.durationMs}ms)`);
         }
+        // MP-01/MP-02: el bloque alcanzó un verdict conclusivo. A partir de acá
+        // el disclaimer (o su ausencia) refleja la decisión REAL de Sherlock.
+        sherlockResolved = true;
       })();
 
       try {
@@ -9786,12 +9822,12 @@ INSTRUCCIÓN: Reelaborá tu respuesta tomando en cuenta las contradicciones dete
         stopTypingLoop();
       }
 
-      if (sherlockSoftTimedOut) {
-        // CA-UX-2 — soft-timeout del turn handler. Avisamos al usuario sin
-        // jerga técnica y degradamos a F-6. La respuesta original (sin
-        // reelaboración garantizada) se envía igual debajo. El audit
-        // post-turn registra el outcome para telemetría.
-        log('commander', `⏱️ Sherlock soft-timeout ${SHERLOCK_SOFT_TIMEOUT_MS}ms disparó — liberando chat con mensaje UX-2`);
+      if (shouldEmitSoftTimeoutDisclaimer(sherlockSoftTimedOut, sherlockResolved)) {
+        // CA-UX-2 — soft-timeout del turn handler, SOLO cuando Sherlock no
+        // alcanzó un verdict (cuelgue genuino). Avisamos al usuario sin jerga
+        // técnica y degradamos a F-6. La respuesta original se envía igual
+        // debajo. El audit post-turn registra el outcome para telemetría.
+        log('commander', `⏱️ Sherlock soft-timeout ${SHERLOCK_SOFT_TIMEOUT_MS}ms disparó SIN verdict — liberando chat con mensaje UX-2`);
         try {
           sendTelegramPlain(
             'Esta respuesta me está tomando más tiempo de lo normal. ' +
@@ -9800,6 +9836,11 @@ INSTRUCCIÓN: Reelaborá tu respuesta tomando en cuenta las contradicciones dete
           );
         } catch { /* best-effort */ }
         sherlockDisclaimerType = sherlockVerifier.DISCLAIMER_TYPES.TIMEOUT_OR_NO_PROVIDER;
+      } else if (sherlockSoftTimedOut && sherlockResolved) {
+        // MP-01: el reloj ganó la carrera por microsegundos pero el bloque YA
+        // había resuelto. Honramos el verdict real (que ya seteó o no el
+        // disclaimer correspondiente). NUNCA pisamos un OK con un F-6 espurio.
+        log('commander', `⏱️ soft-timeout disparó pero Sherlock ya tenía verdict — se honra el resultado real (sin F-6 espurio)`);
       }
 
       if (sherlockDisclaimerType && respuesta) {
@@ -11651,6 +11692,8 @@ process.on('SIGTERM', () => {
 // Útil para tests unitarios y scripts de evidencia del gate predictivo.
 if (process.env.PULPO_NO_AUTOSTART === '1') {
   module.exports = {
+    // MP-01/MP-02 (#3803) — decisión pura del disclaimer por soft-timeout.
+    shouldEmitSoftTimeoutDisclaimer,
     predictResourceImpact,
     getEstimatedImpact,
     measureEmulatorMemPercent,

--- a/docs/pipeline/auditoria-3803-multi-provider.md
+++ b/docs/pipeline/auditoria-3803-multi-provider.md
@@ -19,18 +19,18 @@
 
 ## 🔴 Severidad ALTA
 
-### MP-01 · F-6 recurrente: `verdict: 'aborted'` cuando la cadena entera de providers degrada
-- **Estado:** CONFIRMADO
-- **Archivo:** `.pipeline/pulpo.js:9761-9764` (F-6 por `aborted`, camino independiente), `:9789-9803` (soft-timeout, hoy inerte). Evidencia: memoria `project_sherlock-f6-chain-degraded` (2026-06-02) contra `commander-dispatch` log
-- **Qué pasa:** El F-6 "no pude verificar con el verificador adversarial" se dispara cuando Sherlock devuelve `verdict: 'aborted'` porque **la cadena completa de providers cayó en el mismo turno**: schema_violation en Opus + spawn_exit en codex + cuota en gemini + invalid_model en cerebras. Sherlock recorre toda la cascada (ver MP-03, refutado) y aun así se queda sin ningún eslabón sano → aborta → F-6 legítimo pero molesto.
-- **NO es el soft-timeout.** El reloj de 120s ya quedó inerte (`DEFAULT_TIMEOUT_MS = 0` en Sherlock y completion-client, ver MP-02): el camino del `aborted` es independiente del camino del timeout. La causa vieja del timeout ya está corregida.
-- **Por qué importa:** Mientras los eslabones individuales no degraden con gracia (ver MP-04, MP-05, MP-12), cualquier turno con Anthropic en cuota arrastra a toda la cadena a fallar de golpe → F-6. La cura del F-6 recurrente NO es tocar el orquestador: es hacer que cada provider degrade limpio al siguiente en vez de matar el intento.
+### MP-01 · F-6 espurio: el soft-timeout del orquestador (120s) era MENOR que el presupuesto del cliente (180s) — ✅ CORREGIDO (#3803, 2026-06-02)
+- **Estado:** CORREGIDO
+- **Archivo:** `.pipeline/pulpo.js` soft-timeout del turn handler (`SHERLOCK_SOFT_TIMEOUT_MS`) + guard `sherlockResolved`
+- **Qué pasaba:** El orquestador envolvía TODO el bloque Sherlock en un `Promise.race` contra un reloj hardcoded de **120s**. Pero el `completion-client` le concede a cada request de Sherlock hasta **180s** (`ABSOLUTE_MAX_TIMEOUT_MS`), y el bloque puede hacer 2 verify + 1 reelaboración. Resultado: en cualquier verificación legítimamente lenta (cascada cruzando providers), el reloj de 120s ganaba la carrera y disparaba el F-6 "no pude verificar" **aunque el verdict real fuese OK**. Era la causa raíz del F-6 recurrente que reaparecía turno a turno.
+- **Corrección rumbo doble:** (1) el soft-timeout pasó a **420s** (cubre 2×180s + reelaboración) y es **configurable** vía `sherlock_soft_timeout_ms`; (2) se agregó el flag `sherlockResolved`: el disclaimer F-6 lo decide **el verdict real de Sherlock, nunca el reloj** — si el bloque resolvió, jamás se pisa un OK con un F-6 espurio.
+- **Nota de auditoría (qué falló en el barrido inicial):** la versión previa de este doc afirmaba que "el reloj de 120s ya quedó inerte". Eso era **incorrecto**: el código tenía el `Promise.race` de 120s plenamente activo. Ese error de lectura es la razón por la que MP-01/MP-02 no entró en el PR #3803 (commit `57ee9593`, que sí entregó MP-04/MP-12/MP-05): se trató el F-6 como puro camino de cascada-degradada. El path de cascada-degradada sigue vivo y se trackea aparte (ver nota MP-03/MP-03b abajo).
 
-### MP-02 · Sin presupuesto total de tiempo en la cascada (Sherlock sin timeout interno + orquestador con 120s)
-- **Estado:** CONFIRMADO (relacionado con MP-01)
-- **Archivo:** `.pipeline/lib/sherlock-verifier.js:167-172` (`DEFAULT_TIMEOUT_MS = 0`), `.pipeline/lib/multi-provider/completion-client.js:47-55` (`DEFAULT_TIMEOUT_MS = 0`)
-- **Qué pasa:** Tanto Sherlock como el completion-client corren sin timeout (decisión deliberada). Si un provider remoto se cuelga, el thread espera indefinidamente; el único corte es el soft-timeout de 120s del orquestador (MP-01), que arriba degrada a F-6 espurio. No hay un budget de tiempo que acote la cascada completa sin romper el contrato "sin reloj".
-- **Por qué importa:** Tensión de diseño: "sin timeout para que aguante la cascada" choca con "el usuario no puede esperar para siempre". Hay que reconciliar MP-01 y MP-02 juntos (p.ej. timeout solo si NO hubo veredicto, o cancelar Sherlock al timeout en vez de ignorar su resultado).
+### MP-02 · Reconciliar el presupuesto de tiempo de la cascada con el cutoff del orquestador — ✅ CORREGIDO (junto a MP-01)
+- **Estado:** CORREGIDO (junto a MP-01)
+- **Archivo:** `.pipeline/lib/sherlock-verifier.js` + `.pipeline/lib/multi-provider/completion-client.js` (presupuesto per-request) + `.pipeline/pulpo.js` (cutoff del orquestador)
+- **Qué pasaba:** Sherlock y el cliente corren sin timeout local (decisión deliberada); el presupuesto se delega al cliente (180s per-request). El único corte de release era el soft-timeout del orquestador, que estaba por DEBAJO de ese presupuesto → mataba la cascada antes de tiempo (MP-01).
+- **Cómo se reconcilió:** el cutoff del orquestador ahora es ≥ al worst-case del cliente (420s > 2×180s) y solo libera el chat (mensaje UX-2) cuando **NO hubo veredicto**. Se preserva el contrato "sin reloj que mate la cascada" + la garantía UX "el chat no queda colgado para siempre".
 
 ### MP-03 · ¿Sherlock perdió la cascada multi-provider en `verify()`? — REFUTADO
 - **Estado:** REFUTADO


### PR DESCRIPTION
## Qué resuelve

**MP-01/MP-02** de la auditoría #3803 — la **causa raíz** del mensaje *"no pude verificar"* recurrente.

El reloj de release del turn handler estaba en **120s**, MENOR que el presupuesto que el propio cliente le concede a Sherlock (**180s/request + reelaboración**). En worst-case de cascada, el reloj mataba el bloque ANTES de terminar y disparaba un **F-6 espurio aunque el verdict real fuese OK**.

## Cambios

| | |
|---|---|
| `SHERLOCK_SOFT_TIMEOUT_MS` | 120s → **420s**, config-aware (`sherlock_soft_timeout_ms`). Cubre 2×180s + reelaboración. |
| `sherlockResolved` (nuevo flag) | El disclaimer lo decide el **verdict real**, nunca el reloj. Si el timeout gana la carrera pero Sherlock ya resolvió, se honra el resultado — **nunca se pisa un OK con F-6**. |
| `shouldEmitSoftTimeoutDisclaimer()` | Decisión extraída a función pura testeable. |
| Doc auditoría | Corregida: la afirmación *"el reloj de 120s quedó inerte"* era falsa. |

## Tests

`sherlock-soft-timeout-mp01.test.js` — **5 tests, 0 fallos**. Cubre los 4 cuadrantes (timeout×resolved) + coerción de falsy.

Refs #3803

🤖 Generated with [Claude Code](https://claude.com/claude-code)