### PR TITLE
Kill-switch operacional para apagar/encender providers de IA por separado

### DIFF
--- a/.pipeline/lib/__tests__/agent-models-validate.test.js
+++ b/.pipeline/lib/__tests__/agent-models-validate.test.js
@@ -1031,7 +1031,7 @@ function providerGeminiGoogle() {
 function providerCerebras() {
   return {
     launcher: 'cerebras',
-    model: 'llama-3.3-70b',
+    model: 'gpt-oss-120b',
     spawn_args_template: ['--model', '{model}', '--system', '{system_file}', '{user_prompt}'],
     output_parser: 'openai-sse',
     quota_error_types: ['rate_limit_exceeded', 'quota_exceeded'],
@@ -1065,12 +1065,16 @@ test('#3220 + #3353 + #3501 · ALLOWED_MODELS_BY_LAUNCHER declara modelos por pr
   assert.ok(models, 'ALLOWED_MODELS_BY_LAUNCHER debe exportarse');
   assert.ok(Object.isFrozen(models), 'top-level debe estar congelado');
   assert.deepEqual([...models.claude].sort(), ['claude-haiku-4-5', 'claude-opus-4-7', 'claude-sonnet-4-7']);
-  assert.deepEqual([...models.codex].sort(), ['gpt-5', 'gpt-5-codex']);
-  // #3501 — gemini-1.5-flash y llama-3.1-70b agregados como modelos alternativos
-  // para preservar adversariality intra-provider en Sherlock (ver
+  // #3799 — Sherlock baja su fallback Codex de gpt-5 → gpt-5-mini (sign-off Leo
+  // 2026-06-02), por lo que gpt-5-mini se suma a la allowlist del launcher codex.
+  assert.deepEqual([...models.codex].sort(), ['gpt-5', 'gpt-5-codex', 'gpt-5-mini']);
+  // #3501 — gemini-1.5-flash agregado como modelo alternativo para preservar
+  // adversariality intra-provider en Sherlock (ver
   // sherlock-verifier.js::resolveSherlockProvider).
   assert.deepEqual([...models['gemini-google']].sort(), ['gemini-1.5-flash', 'gemini-2.0-flash']);
-  assert.deepEqual([...models.cerebras].sort(), ['llama-3.1-70b', 'llama-3.3-70b']);
+  // #3797 — Corrección free tier real de Cerebras: NO sirve modelos llama-*. Los
+  // únicos servibles son gpt-oss-120b (default) y zai-glm-4.7 (alternativo #3501).
+  assert.deepEqual([...models.cerebras].sort(), ['gpt-oss-120b', 'zai-glm-4.7']);
   // #3353 — `groq` no debe estar en la allowlist de modelos.
   assert.equal(models.groq, undefined, 'groq debería estar removido tras #3353');
 });
@@ -1262,7 +1266,7 @@ function providerOpenAICodex() {
 function providerCerebrasEntry() {
   return {
     launcher: 'cerebras',
-    model: 'llama-3.3-70b',
+    model: 'gpt-oss-120b',
     spawn_args_template: ['--model', '{model}', '--system', '{system_file}', '{user_prompt}'],
     output_parser: 'openai-sse',
     quota_error_types: ['rate_limit_exceeded', 'quota_exceeded'],
@@ -1327,7 +1331,7 @@ test('#3221 happy path · skill con fallbacks objects {provider, model_override}
     fallbacks: [
       { provider: 'openai-codex', model_override: 'gpt-5-codex' },
       { provider: 'gemini-google', model_override: 'gemini-2.0-flash' },
-      { provider: 'cerebras', model_override: 'llama-3.3-70b' },
+      { provider: 'cerebras', model_override: 'gpt-oss-120b' },
     ],
   };
   const file = tmpFile(cfg);
@@ -1361,7 +1365,7 @@ test('#3221 mixto · skill puede mezclar strings y objects en fallbacks', () => 
     provider: 'anthropic',
     fallbacks: [
       'openai-codex',
-      { provider: 'cerebras', model_override: 'llama-3.3-70b' },
+      { provider: 'cerebras', model_override: 'gpt-oss-120b' },
     ],
   };
   const file = tmpFile(cfg);
@@ -1495,14 +1499,14 @@ test('#3221 · resolveSkillChain devuelve primary primero, después fallbacks en
     model_override: 'claude-opus-4-7',
     fallbacks: [
       { provider: 'openai-codex', model_override: 'gpt-5-codex' },
-      { provider: 'cerebras', model_override: 'llama-3.3-70b' },
+      { provider: 'cerebras', model_override: 'gpt-oss-120b' },
     ],
   };
   const chain = validateMod.resolveSkillChain(cfg, 'backend-dev');
   assert.equal(chain.length, 3);
   assert.deepEqual(chain[0], { provider: 'anthropic', model: 'claude-opus-4-7', source: 'primary' });
   assert.deepEqual(chain[1], { provider: 'openai-codex', model: 'gpt-5-codex', source: 'fallback' });
-  assert.deepEqual(chain[2], { provider: 'cerebras', model: 'llama-3.3-70b', source: 'fallback' });
+  assert.deepEqual(chain[2], { provider: 'cerebras', model: 'gpt-oss-120b', source: 'fallback' });
 });
 
 test('#3221 · resolveSkillChain con fallback string usa provider.model default', () => {

--- a/.pipeline/lib/__tests__/provider-disabled.test.js
+++ b/.pipeline/lib/__tests__/provider-disabled.test.js
@@ -1,0 +1,264 @@
+// =============================================================================
+// provider-disabled.test.js — Tests unitarios del kill-switch por provider (#3811)
+//
+// Cobertura:
+//   - set/read/clear idempotentes.
+//   - TTL expira + drenado natural en lectura.
+//   - Apagado permanente (ttlMs: null).
+//   - Backward-compat: archivo ausente → false / lista vacía.
+//   - Validación de nombre de provider (allowlist).
+//   - listDisabledProviders con ttl_remaining_ms.
+//   - clearAll borra todo.
+//   - Persistencia: el archivo se borra cuando no quedan entradas activas.
+//   - Tolerancia a JSON corrupto.
+// =============================================================================
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+// Sandbox por test: directorio temporal apuntado por PIPELINE_DIR_OVERRIDE.
+function withSandbox(fn) {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'provider-disabled-'));
+    const prev = process.env.PIPELINE_DIR_OVERRIDE;
+    process.env.PIPELINE_DIR_OVERRIDE = dir;
+    // Reimportar fresco para que pipelineDir() lea el override actual.
+    delete require.cache[require.resolve('../provider-disabled')];
+    const mod = require('../provider-disabled');
+    try {
+        fn(mod, dir);
+    } finally {
+        if (prev === undefined) delete process.env.PIPELINE_DIR_OVERRIDE;
+        else process.env.PIPELINE_DIR_OVERRIDE = prev;
+        try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+    }
+}
+
+const NOAUDIT = { auditLogEnabled: false };
+
+// -----------------------------------------------------------------------------
+// Validación de provider
+// -----------------------------------------------------------------------------
+
+test('isValidProvider acepta solo la allowlist', () => {
+    withSandbox((mod) => {
+        assert.equal(mod.isValidProvider('anthropic'), true);
+        assert.equal(mod.isValidProvider('openai-codex'), true);
+        assert.equal(mod.isValidProvider('gemini-google'), true);
+        assert.equal(mod.isValidProvider('cerebras'), true);
+        assert.equal(mod.isValidProvider('nvidia-nim'), true);
+        // deterministic NO es un provider de IA → no apagable.
+        assert.equal(mod.isValidProvider('deterministic'), false);
+        assert.equal(mod.isValidProvider('groq'), false);
+        assert.equal(mod.isValidProvider('inexistente'), false);
+        assert.equal(mod.isValidProvider(null), false);
+        assert.equal(mod.isValidProvider(123), false);
+    });
+});
+
+test('setProviderDisabled rechaza provider inválido sin escribir archivo', () => {
+    withSandbox((mod) => {
+        const r = mod.setProviderDisabled('groq', NOAUDIT);
+        assert.equal(r.ok, false);
+        assert.match(r.error, /provider inválido/);
+        assert.equal(fs.existsSync(mod.flagFile()), false);
+    });
+});
+
+// -----------------------------------------------------------------------------
+// set / read / clear idempotentes
+// -----------------------------------------------------------------------------
+
+test('set/read básico: apaga anthropic y isProviderDisabled lo refleja', () => {
+    withSandbox((mod) => {
+        assert.equal(mod.isProviderDisabled('anthropic', NOAUDIT), false);
+        const r = mod.setProviderDisabled('anthropic', NOAUDIT);
+        assert.equal(r.ok, true);
+        assert.equal(typeof r.filePath, 'string');
+        assert.equal(mod.isProviderDisabled('anthropic', NOAUDIT), true);
+        // Scope por provider: openai-codex sigue habilitado.
+        assert.equal(mod.isProviderDisabled('openai-codex', NOAUDIT), false);
+    });
+});
+
+test('set es idempotente: apagar dos veces no duplica la entrada', () => {
+    withSandbox((mod) => {
+        mod.setProviderDisabled('anthropic', NOAUDIT);
+        mod.setProviderDisabled('anthropic', NOAUDIT);
+        const list = mod.listDisabledProviders(NOAUDIT);
+        const anthropic = list.disabled.filter((e) => e.name === 'anthropic');
+        assert.equal(anthropic.length, 1);
+    });
+});
+
+test('clear re-habilita y devuelve true; clear de no-apagado devuelve false', () => {
+    withSandbox((mod) => {
+        mod.setProviderDisabled('cerebras', NOAUDIT);
+        assert.equal(mod.clearProviderDisabled('cerebras', NOAUDIT), true);
+        assert.equal(mod.isProviderDisabled('cerebras', NOAUDIT), false);
+        // Segundo clear: ya no estaba apagado.
+        assert.equal(mod.clearProviderDisabled('cerebras', NOAUDIT), false);
+    });
+});
+
+test('clear de un provider no afecta a los demás apagados', () => {
+    withSandbox((mod) => {
+        mod.setProviderDisabled('anthropic', NOAUDIT);
+        mod.setProviderDisabled('gemini-google', NOAUDIT);
+        mod.clearProviderDisabled('anthropic', NOAUDIT);
+        assert.equal(mod.isProviderDisabled('anthropic', NOAUDIT), false);
+        assert.equal(mod.isProviderDisabled('gemini-google', NOAUDIT), true);
+    });
+});
+
+// -----------------------------------------------------------------------------
+// TTL + drenado natural
+// -----------------------------------------------------------------------------
+
+test('TTL: entrada vencida se drena en lectura (auto-restaurado)', () => {
+    withSandbox((mod) => {
+        const t0 = 1_000_000_000_000;
+        mod.setProviderDisabled('anthropic', { ttlMs: 1000, now: t0, auditLogEnabled: false });
+        // Antes del vencimiento sigue apagado.
+        assert.equal(mod.isProviderDisabled('anthropic', { now: t0 + 500, auditLogEnabled: false }), true);
+        // Después del TTL: drenado natural → habilitado.
+        assert.equal(mod.isProviderDisabled('anthropic', { now: t0 + 2000, auditLogEnabled: false }), false);
+    });
+});
+
+test('TTL vencido se persiste como drenado: el archivo refleja la limpieza', () => {
+    withSandbox((mod) => {
+        const t0 = 2_000_000_000_000;
+        mod.setProviderDisabled('cerebras', { ttlMs: 1000, now: t0, auditLogEnabled: false });
+        mod.setProviderDisabled('anthropic', { ttlMs: null, now: t0, auditLogEnabled: false });
+        // Lectura post-vencimiento de cerebras: drena cerebras, conserva anthropic.
+        const list = mod.listDisabledProviders({ now: t0 + 5000, auditLogEnabled: false });
+        const names = list.disabled.map((e) => e.name);
+        assert.deepEqual(names, ['anthropic']);
+    });
+});
+
+test('apagado permanente (ttlMs:null) no vence', () => {
+    withSandbox((mod) => {
+        const t0 = 3_000_000_000_000;
+        const r = mod.setProviderDisabled('nvidia-nim', { ttlMs: null, now: t0, auditLogEnabled: false });
+        assert.equal(r.ok, true);
+        assert.equal(r.ttl_ms, null);
+        // Mucho después sigue apagado.
+        assert.equal(mod.isProviderDisabled('nvidia-nim', { now: t0 + 999_999_999, auditLogEnabled: false }), true);
+    });
+});
+
+test('TTL default es 20min cuando no se especifica', () => {
+    withSandbox((mod) => {
+        const r = mod.setProviderDisabled('anthropic', NOAUDIT);
+        assert.equal(r.ttl_ms, mod.DEFAULT_TTL_MS);
+        assert.equal(mod.DEFAULT_TTL_MS, 20 * 60 * 1000);
+    });
+});
+
+test('TTL se acota a MAX_TTL_MS', () => {
+    withSandbox((mod) => {
+        const r = mod.setProviderDisabled('anthropic', { ttlMs: mod.MAX_TTL_MS * 10, auditLogEnabled: false });
+        assert.equal(r.ttl_ms, mod.MAX_TTL_MS);
+    });
+});
+
+test('ttlMs inválido (0, negativo, NaN) es rechazado', () => {
+    withSandbox((mod) => {
+        assert.equal(mod.setProviderDisabled('anthropic', { ttlMs: 0, auditLogEnabled: false }).ok, false);
+        assert.equal(mod.setProviderDisabled('anthropic', { ttlMs: -5, auditLogEnabled: false }).ok, false);
+        assert.equal(mod.setProviderDisabled('anthropic', { ttlMs: NaN, auditLogEnabled: false }).ok, false);
+    });
+});
+
+// -----------------------------------------------------------------------------
+// listDisabledProviders
+// -----------------------------------------------------------------------------
+
+test('listDisabledProviders devuelve ttl_remaining_ms', () => {
+    withSandbox((mod) => {
+        const t0 = 4_000_000_000_000;
+        mod.setProviderDisabled('anthropic', { ttlMs: 10_000, now: t0, auditLogEnabled: false });
+        const list = mod.listDisabledProviders({ now: t0 + 3000, auditLogEnabled: false });
+        const e = list.disabled.find((x) => x.name === 'anthropic');
+        assert.equal(e.ttl_remaining_ms, 7000);
+        assert.equal(typeof e.ttl_expires_at, 'string');
+    });
+});
+
+test('listDisabledProviders: ttl_remaining_ms null para apagado permanente', () => {
+    withSandbox((mod) => {
+        mod.setProviderDisabled('anthropic', { ttlMs: null, auditLogEnabled: false });
+        const list = mod.listDisabledProviders(NOAUDIT);
+        const e = list.disabled.find((x) => x.name === 'anthropic');
+        assert.equal(e.ttl_remaining_ms, null);
+        assert.equal(e.ttl_expires_at, null);
+    });
+});
+
+// -----------------------------------------------------------------------------
+// Backward-compat / robustez
+// -----------------------------------------------------------------------------
+
+test('archivo ausente: isProviderDisabled=false, lista vacía', () => {
+    withSandbox((mod) => {
+        assert.equal(fs.existsSync(mod.flagFile()), false);
+        assert.equal(mod.isProviderDisabled('anthropic', NOAUDIT), false);
+        assert.deepEqual(mod.listDisabledProviders(NOAUDIT).disabled, []);
+    });
+});
+
+test('JSON corrupto: degrada a habilitado (fail-open) sin crashear', () => {
+    withSandbox((mod) => {
+        fs.writeFileSync(mod.flagFile(), '{ esto no es json válido', 'utf8');
+        assert.equal(mod.isProviderDisabled('anthropic', NOAUDIT), false);
+        assert.deepEqual(mod.listDisabledProviders(NOAUDIT).disabled, []);
+    });
+});
+
+test('entradas con shape inválido se filtran', () => {
+    withSandbox((mod) => {
+        fs.writeFileSync(mod.flagFile(), JSON.stringify({
+            disabled: [
+                { name: 'anthropic', disabled_at: '2026-06-03T00:00:00.000Z' },
+                { name: 'groq-invalido' },          // provider fuera de allowlist
+                { foo: 'bar' },                       // sin name
+                'string-suelto',                      // no objeto
+            ],
+        }), 'utf8');
+        const list = mod.listDisabledProviders(NOAUDIT);
+        assert.deepEqual(list.disabled.map((e) => e.name), ['anthropic']);
+    });
+});
+
+test('el archivo se borra cuando no quedan entradas activas', () => {
+    withSandbox((mod) => {
+        mod.setProviderDisabled('anthropic', NOAUDIT);
+        assert.equal(fs.existsSync(mod.flagFile()), true);
+        mod.clearProviderDisabled('anthropic', NOAUDIT);
+        assert.equal(fs.existsSync(mod.flagFile()), false);
+    });
+});
+
+test('clearAll borra el archivo entero', () => {
+    withSandbox((mod) => {
+        mod.setProviderDisabled('anthropic', NOAUDIT);
+        mod.setProviderDisabled('cerebras', NOAUDIT);
+        assert.equal(mod.clearAll(NOAUDIT), true);
+        assert.equal(fs.existsSync(mod.flagFile()), false);
+        // clearAll sobre archivo ausente → false.
+        assert.equal(mod.clearAll(NOAUDIT), false);
+    });
+});
+
+test('provider inválido en isProviderDisabled siempre false', () => {
+    withSandbox((mod) => {
+        assert.equal(mod.isProviderDisabled('groq', NOAUDIT), false);
+        assert.equal(mod.isProviderDisabled(null, NOAUDIT), false);
+    });
+});

--- a/.pipeline/lib/agent-launcher/dispatch-with-fallback.js
+++ b/.pipeline/lib/agent-launcher/dispatch-with-fallback.js
@@ -82,6 +82,12 @@ const { resolveProviderForSkill, getProviderHandler } = require('./resolve-provi
 // elegir un fallback (no solo el Commander la tenía).
 const { _validateProviderCredentials: validateProviderCredentials } = require('../commander/credentials-precheck');
 
+// #3811 — Kill-switch operacional por provider. Apagar un provider acá ordena
+// el salto a fallback (semántica de "caída en runtime"), distinto del gate de
+// cuota (semántica de "esperar reset"). Carga perezosa vía default param para
+// poder inyectar un fake en los tests sin require cruzado.
+const providerDisabledModule = require('../provider-disabled');
+
 // -----------------------------------------------------------------------------
 // Constantes
 // -----------------------------------------------------------------------------
@@ -550,6 +556,16 @@ function resolveSpawnWithFallback(opts = {}) {
     const _resolveHandler = providerHandlerResolver || getProviderHandler;
     const _notify = notify || enqueueTelegramNotice;
     const _now = Number.isFinite(now) ? now : Date.now();
+    // #3811 — módulo del kill-switch. Inyectable para tests (opts.disabledModule).
+    const _disabled = opts.disabledModule || providerDisabledModule;
+    const _isProviderDisabled = (p) => {
+        try {
+            return typeof _disabled.isProviderDisabled === 'function'
+                && _disabled.isProviderDisabled(p, { now: _now });
+        } catch {
+            return false; // fail-open: el kill-switch nunca bloquea por bug propio.
+        }
+    };
 
     // -------------------------------------------------------------------------
     // #3680 CA-A8 — FORCE_PROVIDER_OVERRIDE branch.
@@ -695,10 +711,36 @@ function resolveSpawnWithFallback(opts = {}) {
         };
     }
 
-    const primaryGated = quotaModule.shouldGateSpawn(skill, {
+    // #3811 — el primario salta a fallback por dos causas independientes:
+    //   (a) gate de cuota (shouldGateSpawn) — "esperar reset".
+    //   (b) kill-switch operacional (isProviderDisabled) — "caída en runtime".
+    // Ambas se OR-ean: cualquiera fuerza la cascada a fallbacks. El audit
+    // distingue la causa con el evento `provider_disabled`.
+    const primaryQuotaGated = quotaModule.shouldGateSpawn(skill, {
         provider: primaryProvider,
         now: _now,
     });
+    const primaryDisabled = _isProviderDisabled(primaryProvider);
+    const primaryGated = primaryQuotaGated || primaryDisabled;
+
+    if (primaryDisabled) {
+        // Audit dedicado del salto por deshabilitación (CA: audit log registra
+        // saltos por deshabilitación con event 'provider_disabled').
+        auditAppend({
+            pipelineDir, fsImpl, sanitize: (s) => String(s || ''),
+            auditLog, now: _now,
+            entry: {
+                event: 'provider_disabled',
+                skill,
+                issue: issue || null,
+                primary_provider: primaryProvider,
+                primary_model: primary.model || null,
+                quota_gated: primaryQuotaGated,
+                raw_excerpt: `primary=${primaryProvider} disabled_by_killswitch -> salto a fallbacks`,
+            },
+        });
+        log('lanzamiento', `🔌 ${skill}:#${issue || '?'} provider primario "${primaryProvider}" APAGADO (kill-switch) — saltando a fallbacks.`);
+    }
 
     if (!primaryGated) {
         // Happy path: primary disponible.
@@ -880,6 +922,26 @@ function resolveSpawnWithFallback(opts = {}) {
                     raw_excerpt: `fallback_${fbName}_gated_too`,
                 },
             });
+            continue;
+        }
+
+        // 3.d.killswitch (#3811) — el fallback también puede estar APAGADO por
+        // el kill-switch operacional. Lo saltamos igual que un fallback gateado
+        // por cuota, con audit dedicado para distinguir la causa.
+        if (_isProviderDisabled(fbName)) {
+            auditAppend({
+                pipelineDir, fsImpl, sanitize, auditLog, now: _now,
+                entry: {
+                    event: 'fallback_provider_disabled',
+                    skill,
+                    issue: issue || null,
+                    fallback_index: i,
+                    fallback_provider: fbName,
+                    primary_provider: primaryProvider,
+                    raw_excerpt: `fallback_${fbName}_disabled_by_killswitch`,
+                },
+            });
+            log('lanzamiento', `🔌 ${skill}:#${issue || '?'} fallback "${fbName}" APAGADO (kill-switch) — salto al siguiente.`);
             continue;
         }
 

--- a/.pipeline/lib/multi-provider/api.js
+++ b/.pipeline/lib/multi-provider/api.js
@@ -40,6 +40,10 @@ const validator = require('../agent-models-validate');
 const permValidator = require('../permission-validator');
 const auditLog = require('../audit-log');
 
+// #3811 — kill-switch operacional por provider (misma fuente de verdad que la
+// CLI manage-providers.sh y que dispatch-with-fallback).
+const providerDisabled = require('../provider-disabled');
+
 // Health snapshot (#3260) — endpoint read-only que el panel "Health" consume.
 // El cron de healthcheck es disparado por el pulpo (o el dashboard, si está
 // solo activo) cada ~15min; este módulo SOLO lee el snapshot persistido. No
@@ -513,8 +517,95 @@ async function handleCommanderDistribution(req, res, _params, query) {
     }
 }
 
+// =============================================================================
+// #3811 — Kill-switch operacional por provider (perilla del dashboard).
+//
+// GET  /api/multi-provider/providers-disabled            estado de apagados
+// POST /api/multi-provider/providers/:provider/disable   apaga (opc. ttl_ms)
+// POST /api/multi-provider/providers/:provider/enable    enciende
+//
+// Reutiliza lib/provider-disabled.js (misma fuente de verdad que la CLI). El
+// efecto es idéntico al switch por terminal: dispatch-with-fallback salta al
+// siguiente eslabón de la cadena del skill cuando el provider está apagado.
+// =============================================================================
+
+async function handleProvidersDisabledGet(req, res) {
+    if (req.method !== 'GET') return sendError(res, 405, 'method_not_allowed', 'GET only');
+    try {
+        const list = providerDisabled.listDisabledProviders();
+        const disabledSet = new Set(list.disabled.map((e) => e.name));
+        // Proyectamos TODOS los providers válidos con su estado on/off para que
+        // la UI pueda renderizar un toggle por provider sin asumir el catálogo.
+        const providers = providerDisabled.VALID_PROVIDERS.map((name) => {
+            const entry = list.disabled.find((e) => e.name === name) || null;
+            return {
+                name,
+                disabled: disabledSet.has(name),
+                disabled_at: entry ? entry.disabled_at : null,
+                ttl_expires_at: entry ? entry.ttl_expires_at : null,
+                ttl_remaining_ms: entry ? entry.ttl_remaining_ms : null,
+            };
+        });
+        sendJson(res, { ok: true, providers });
+    } catch (e) {
+        sendError(res, 500, 'read_failed', e.message);
+    }
+}
+
+async function handleProviderDisable(req, res, params) {
+    if (!csrf.requireCSRF(req, res)) return;
+    const provider = params && params.provider;
+    if (!providerDisabled.isValidProvider(provider)) {
+        return sendError(res, 400, 'invalid_provider',
+            `provider inválido: "${provider}". Válidos: ${providerDisabled.VALID_PROVIDERS.join(', ')}`);
+    }
+    let body = {};
+    try { body = await readBody(req); }
+    catch (e) { return sendError(res, 400, e.code || 'bad_request', e.message); }
+    // ttl_ms opcional: undefined → default 20min; null → permanente; número → acotado.
+    let ttlMs;
+    if (Object.prototype.hasOwnProperty.call(body, 'ttl_ms')) {
+        ttlMs = body.ttl_ms; // el módulo valida null / número / rechaza inválidos.
+    }
+    const author = resolveAuthor();
+    const r = providerDisabled.setProviderDisabled(provider, {
+        ...(ttlMs !== undefined ? { ttlMs } : {}),
+        source: `dashboard:${author || 'unknown'}`,
+    });
+    if (!r.ok) return sendError(res, 422, 'disable_failed', r.error);
+    const list = providerDisabled.listDisabledProviders();
+    const entry = list.disabled.find((e) => e.name === provider) || null;
+    sendJson(res, {
+        ok: true,
+        provider,
+        disabled: true,
+        ttl_ms: r.ttl_ms,
+        ttl_expires_at: entry ? entry.ttl_expires_at : null,
+        ttl_remaining_ms: entry ? entry.ttl_remaining_ms : null,
+        author,
+    });
+}
+
+async function handleProviderEnable(req, res, params) {
+    if (!csrf.requireCSRF(req, res)) return;
+    const provider = params && params.provider;
+    if (!providerDisabled.isValidProvider(provider)) {
+        return sendError(res, 400, 'invalid_provider',
+            `provider inválido: "${provider}". Válidos: ${providerDisabled.VALID_PROVIDERS.join(', ')}`);
+    }
+    const author = resolveAuthor();
+    const changed = providerDisabled.clearProviderDisabled(provider, {
+        source: `dashboard:${author || 'unknown'}`,
+    });
+    sendJson(res, { ok: true, provider, disabled: false, changed, author });
+}
+
 const ROUTES = [
     { method: 'GET',  pattern: /^\/api\/multi-provider\/csrf-token$/,            handler: handleCsrfToken },
+    // #3811 — kill-switch por provider.
+    { method: 'GET',  pattern: /^\/api\/multi-provider\/providers-disabled$/,    handler: handleProvidersDisabledGet },
+    { method: 'POST', pattern: /^\/api\/multi-provider\/providers\/([a-z0-9-]+)\/disable$/, handler: handleProviderDisable, params: ['provider'] },
+    { method: 'POST', pattern: /^\/api\/multi-provider\/providers\/([a-z0-9-]+)\/enable$/,  handler: handleProviderEnable, params: ['provider'] },
     { method: 'GET',  pattern: /^\/api\/multi-provider\/commander-distribution(\?.*)?$/, handler: handleCommanderDistribution },
     { method: 'GET',  pattern: /^\/api\/multi-provider\/config$/,                handler: handleConfigGet },
     { method: 'POST', pattern: /^\/api\/multi-provider\/config\/diff$/,          handler: handleConfigDiff },
@@ -577,6 +668,9 @@ module.exports = {
     handleReload,
     handleHealthGet,
     handleHealthRun,
+    handleProvidersDisabledGet,
+    handleProviderDisable,
+    handleProviderEnable,
     readBody,
     RELOAD_SIGNAL_PATH,
 };

--- a/.pipeline/lib/provider-disabled.js
+++ b/.pipeline/lib/provider-disabled.js
@@ -1,0 +1,467 @@
+// =============================================================================
+// provider-disabled.js — Kill-switch operacional por provider de IA (#3811)
+//
+// Módulo paralelo a `quota-exhausted.js`. Mientras el flag de cuota tiene
+// semántica de "cuota agotada → esperar reset" (pausa el spawn dejándolo en
+// `pendiente/` SIN cascadear al siguiente eslabón), este módulo provee un
+// switch operacional explícito por provider que simula una **caída en runtime**:
+// cuando un provider está "apagado", `dispatch-with-fallback` debe SALTAR al
+// siguiente eslabón de la cadena del skill, igual que si estuviera gateado por
+// cuota.
+//
+// MOTIVACIÓN (#3811):
+//   En la prueba controlada del 2026-06-03, marcar Anthropic como agotado NO
+//   hizo saltar los agentes a Codex: `shouldGateSpawn` es un gate (pausa), no
+//   un dispatcher (salto). Este módulo da el primitivo determinístico para
+//   apagar/encender providers y disparar fallbacks reales.
+//
+// PERSISTENCIA: `.pipeline/provider-disabled.json`
+//   {
+//     "disabled": [
+//       { "name": "anthropic", "disabled_at": "2026-06-03T...", "ttl_expires_at": "2026-06-03T..." }
+//     ]
+//   }
+//   - `ttl_expires_at` opcional: si está y ya pasó, la entrada se drena en lectura.
+//   - Si `ttl_expires_at` es null/ausente, la entrada es permanente hasta clear.
+//
+// TTL: default 20 minutos (configurable por opts.ttlMs). Auto-restaurado:
+//   `isProviderDisabled` / `listDisabledProviders` drenan entradas vencidas.
+//
+// SCOPE POR PROVIDER: granular — apagar `anthropic` no afecta a `openai-codex`.
+//
+// DETERMINÍSTICO: no usa LLM, no toca credenciales. Solo filesystem JSON +
+//   comparación de strings. Controlable por terminal (manage-providers.sh) o
+//   por el dashboard (POST /api/providers/:name/disable).
+//
+// KILL-SWITCH DEL KILL-SWITCH: si por bug el archivo queda corrupto o pegado,
+//   `rm .pipeline/provider-disabled.json` restaura todos los providers.
+//
+// Sin dependencias externas (Node puro: fs, path).
+// =============================================================================
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+// -----------------------------------------------------------------------------
+// Allowlist de providers (single source of truth replicada de
+// resolve-provider.js :: PROVIDER_HANDLERS). `deterministic` se excluye a
+// propósito — no es un provider de IA y nunca se "apaga".
+// -----------------------------------------------------------------------------
+const VALID_PROVIDERS = Object.freeze([
+    'anthropic',
+    'openai-codex',
+    'gemini-google',
+    'cerebras',
+    'nvidia-nim',
+]);
+
+// TTL default 20 min (igual orden de magnitud que el reset de cuota corto).
+const DEFAULT_TTL_MS = 20 * 60 * 1000;
+
+// Cap defensivo del TTL: máximo 7 días. Un apagado "permanente" se hace con
+// ttlMs: null explícito, no con un número gigante.
+const MAX_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+// -----------------------------------------------------------------------------
+// Paths
+// -----------------------------------------------------------------------------
+
+function pipelineDir() {
+    // Override en tests (mismo patrón que quota-exhausted / partial-pause).
+    if (process.env.PIPELINE_DIR_OVERRIDE) return process.env.PIPELINE_DIR_OVERRIDE;
+    return path.resolve(__dirname, '..');
+}
+
+function flagFile() {
+    return path.join(pipelineDir(), 'provider-disabled.json');
+}
+
+function tmpDir() {
+    return path.join(pipelineDir(), 'tmp');
+}
+
+function logsDir() {
+    return path.join(pipelineDir(), 'logs');
+}
+
+function auditLogFile(now = new Date()) {
+    const yyyy = now.getUTCFullYear();
+    const mm = String(now.getUTCMonth() + 1).padStart(2, '0');
+    const dd = String(now.getUTCDate()).padStart(2, '0');
+    return path.join(logsDir(), `provider-disabled-${yyyy}-${mm}-${dd}.log`);
+}
+
+// -----------------------------------------------------------------------------
+// IO atómica (espejo del patrón de quota-exhausted.js)
+// -----------------------------------------------------------------------------
+
+function ensureDir(dir) {
+    try { fs.mkdirSync(dir, { recursive: true }); } catch {}
+}
+
+const RENAME_RETRY_MAX_ATTEMPTS = 3;
+const RENAME_RETRY_MAX_TOTAL_MS = 50;
+const RENAME_RETRY_INITIAL_MS = 5;
+const RENAME_RETRYABLE_ERRORS = new Set(['EBUSY', 'EPERM', 'EEXIST']);
+
+function sleepSyncMs(ms) {
+    const end = Date.now() + ms;
+    // eslint-disable-next-line no-empty
+    while (Date.now() < end) {}
+}
+
+function renameWithRetry(tmp, filepath) {
+    let lastErr = null;
+    let delayMs = RENAME_RETRY_INITIAL_MS;
+    const totalDeadline = Date.now() + RENAME_RETRY_MAX_TOTAL_MS;
+    for (let attempt = 1; attempt <= RENAME_RETRY_MAX_ATTEMPTS; attempt++) {
+        try {
+            fs.renameSync(tmp, filepath);
+            return;
+        } catch (err) {
+            lastErr = err;
+            const code = err && err.code;
+            const retriable = RENAME_RETRYABLE_ERRORS.has(code);
+            const lastAttempt = attempt === RENAME_RETRY_MAX_ATTEMPTS;
+            const overBudget = Date.now() + delayMs > totalDeadline;
+            if (!retriable || lastAttempt || overBudget) throw err;
+            sleepSyncMs(delayMs);
+            delayMs = Math.min(delayMs * 2, totalDeadline - Date.now());
+            if (delayMs <= 0) throw lastErr;
+        }
+    }
+    throw lastErr || new Error('renameWithRetry: unexpected fallthrough');
+}
+
+function writeJsonAtomic(filepath, data) {
+    ensureDir(tmpDir());
+    ensureDir(path.dirname(filepath));
+    const tmp = path.join(
+        tmpDir(),
+        `${path.basename(filepath)}.${process.pid}.${Date.now()}.tmp`
+    );
+    const payload = JSON.stringify(data, null, 2);
+    const fd = fs.openSync(tmp, 'w', 0o600);
+    try {
+        fs.writeSync(fd, payload);
+        try { fs.fsyncSync(fd); } catch { /* best-effort */ }
+    } finally {
+        try { fs.closeSync(fd); } catch {}
+    }
+    try {
+        renameWithRetry(tmp, filepath);
+    } catch (err) {
+        try { fs.unlinkSync(tmp); } catch {}
+        throw err;
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Audit log (best-effort, una línea JSON por evento)
+// -----------------------------------------------------------------------------
+
+function appendAudit(entry, opts = {}) {
+    try {
+        const ts = entry.timestamp || new Date().toISOString();
+        const line = JSON.stringify({
+            timestamp: ts,
+            event: entry.event || null,
+            provider: entry.provider || null,
+            ttl_expires_at: entry.ttl_expires_at || null,
+            source: entry.source || null,
+            detail: typeof entry.detail === 'string'
+                ? entry.detail.replace(/[\r\n\t]/g, ' ').slice(0, 200)
+                : null,
+        }) + '\n';
+        ensureDir(logsDir());
+        fs.appendFileSync(auditLogFile(opts.now ? new Date(opts.now) : undefined), line, {
+            flag: 'a',
+            mode: 0o600,
+        });
+    } catch { /* best-effort */ }
+}
+
+// -----------------------------------------------------------------------------
+// Validación + parseo defensivo
+// -----------------------------------------------------------------------------
+
+function isValidProvider(name) {
+    return typeof name === 'string' && VALID_PROVIDERS.includes(name);
+}
+
+/**
+ * Lee y parsea el archivo de forma defensiva. Devuelve siempre un objeto con
+ * `entries` (array, posiblemente vacío). Tolera:
+ *   - Archivo ausente → entries: [].
+ *   - JSON corrupto / shape inválido → entries: [] + audit.
+ *   - Entradas con shape inválido se filtran silenciosamente.
+ */
+function readRaw(opts = {}) {
+    const file = flagFile();
+    let raw;
+    try {
+        raw = fs.readFileSync(file, 'utf8');
+    } catch (e) {
+        if (e && e.code === 'ENOENT') return { entries: [] };
+        return { entries: [], ioError: true };
+    }
+    let parsed;
+    try {
+        parsed = JSON.parse(raw);
+    } catch {
+        if (opts.auditLogEnabled !== false) {
+            appendAudit({ event: 'parse_error', detail: 'provider-disabled.json corrupto' }, opts);
+        }
+        return { entries: [], parseError: true };
+    }
+    if (!parsed || typeof parsed !== 'object' || !Array.isArray(parsed.disabled)) {
+        return { entries: [] };
+    }
+    const entries = parsed.disabled.filter((e) =>
+        e && typeof e === 'object' && isValidProvider(e.name)
+    );
+    return { entries };
+}
+
+/**
+ * Drena entradas con TTL vencido. Devuelve `{ active, expired }`. NO escribe;
+ * el caller decide persistir si hubo cambios.
+ */
+function partitionByTtl(entries, now) {
+    const active = [];
+    const expired = [];
+    for (const e of entries) {
+        const exp = e.ttl_expires_at ? Date.parse(e.ttl_expires_at) : NaN;
+        if (Number.isFinite(exp) && now >= exp) {
+            expired.push(e);
+        } else {
+            active.push(e);
+        }
+    }
+    return { active, expired };
+}
+
+/**
+ * Persiste la lista de entradas activas. Si queda vacía, borra el archivo
+ * (limpieza natural — el archivo ausente == ningún provider apagado).
+ */
+function persist(active) {
+    const file = flagFile();
+    if (!active || active.length === 0) {
+        try { fs.unlinkSync(file); } catch (e) {
+            if (e && e.code !== 'ENOENT') { /* best-effort */ }
+        }
+        return;
+    }
+    writeJsonAtomic(file, { disabled: active });
+}
+
+/**
+ * Lee, drena vencidos y persiste el resultado si hubo drenado. Devuelve la
+ * lista de entradas activas (post-drenado).
+ */
+function readAndDrain(opts = {}) {
+    const now = Number.isFinite(opts.now) ? opts.now : Date.now();
+    const { entries } = readRaw(opts);
+    if (entries.length === 0) return [];
+    const { active, expired } = partitionByTtl(entries, now);
+    if (expired.length > 0) {
+        try { persist(active); } catch { /* best-effort */ }
+        if (opts.auditLogEnabled !== false) {
+            for (const e of expired) {
+                appendAudit({
+                    event: 'drained_ttl_expired',
+                    provider: e.name,
+                    ttl_expires_at: e.ttl_expires_at || null,
+                    detail: 'TTL vencido, provider re-habilitado',
+                }, opts);
+            }
+        }
+    }
+    return active;
+}
+
+// -----------------------------------------------------------------------------
+// API pública
+// -----------------------------------------------------------------------------
+
+/**
+ * `isProviderDisabled(providerName, opts?)` → boolean.
+ * Drena TTL vencido en lectura. Provider inválido → false (no apaga lo que no
+ * existe). Lectura defensiva: cualquier error de IO → false (fail-open: el
+ * kill-switch NUNCA debe bloquear el pipeline por un bug propio).
+ *
+ * @param {string} providerName
+ * @param {object} [opts] { now, auditLogEnabled }
+ * @returns {boolean}
+ */
+function isProviderDisabled(providerName, opts = {}) {
+    if (!isValidProvider(providerName)) return false;
+    try {
+        const active = readAndDrain(opts);
+        return active.some((e) => e.name === providerName);
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * `setProviderDisabled(providerName, opts?)` → {ok:true, filePath, ttl_ms} | {ok:false, error}.
+ * Idempotente: apagar dos veces el mismo provider refresca el TTL.
+ *
+ * @param {string} providerName
+ * @param {object} [opts]
+ * @param {number|null} [opts.ttlMs] TTL en ms. Default DEFAULT_TTL_MS. `null`
+ *        explícito = apagado permanente (sin ttl_expires_at).
+ * @param {string} [opts.source] origen del cambio (cli|dashboard|test) para audit.
+ * @param {number} [opts.now] Date.now() override.
+ * @returns {{ok:boolean, filePath?:string, ttl_ms?:number|null, error?:string}}
+ */
+function setProviderDisabled(providerName, opts = {}) {
+    if (!isValidProvider(providerName)) {
+        return {
+            ok: false,
+            error: `provider inválido: "${providerName}". Válidos: ${VALID_PROVIDERS.join(', ')}`,
+        };
+    }
+    const now = Number.isFinite(opts.now) ? opts.now : Date.now();
+
+    // TTL: undefined → default; null → permanente; número → acotado a [0, MAX].
+    let ttlMs;
+    if (opts.ttlMs === null) {
+        ttlMs = null;
+    } else if (opts.ttlMs === undefined) {
+        ttlMs = DEFAULT_TTL_MS;
+    } else if (Number.isFinite(opts.ttlMs) && opts.ttlMs > 0) {
+        ttlMs = Math.min(opts.ttlMs, MAX_TTL_MS);
+    } else {
+        return { ok: false, error: `ttlMs inválido: ${opts.ttlMs}` };
+    }
+
+    const disabledAt = new Date(now).toISOString();
+    const ttlExpiresAt = ttlMs == null ? null : new Date(now + ttlMs).toISOString();
+
+    try {
+        // Leer activos (drenando vencidos), reemplazar la entrada del provider.
+        const active = readAndDrain({ ...opts, now });
+        const next = active.filter((e) => e.name !== providerName);
+        const entry = { name: providerName, disabled_at: disabledAt };
+        if (ttlExpiresAt) entry.ttl_expires_at = ttlExpiresAt;
+        next.push(entry);
+        persist(next);
+        if (opts.auditLogEnabled !== false) {
+            appendAudit({
+                event: 'provider_disabled',
+                provider: providerName,
+                ttl_expires_at: ttlExpiresAt,
+                source: opts.source || 'unknown',
+                detail: ttlMs == null ? 'apagado permanente' : `ttl=${ttlMs}ms`,
+            }, { now });
+        }
+        return { ok: true, filePath: flagFile(), ttl_ms: ttlMs };
+    } catch (e) {
+        return { ok: false, error: e.message };
+    }
+}
+
+/**
+ * `clearProviderDisabled(providerName, opts?)` → boolean.
+ * Devuelve true si el provider estaba apagado y se re-habilitó; false si no
+ * estaba apagado (o provider inválido).
+ */
+function clearProviderDisabled(providerName, opts = {}) {
+    if (!isValidProvider(providerName)) return false;
+    const now = Number.isFinite(opts.now) ? opts.now : Date.now();
+    try {
+        const active = readAndDrain({ ...opts, now });
+        const existed = active.some((e) => e.name === providerName);
+        if (!existed) return false;
+        const next = active.filter((e) => e.name !== providerName);
+        persist(next);
+        if (opts.auditLogEnabled !== false) {
+            appendAudit({
+                event: 'provider_enabled',
+                provider: providerName,
+                source: opts.source || 'unknown',
+                detail: 'provider re-habilitado manualmente',
+            }, { now });
+        }
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * `listDisabledProviders(opts?)` → {disabled:[{name, disabled_at, ttl_expires_at}]}.
+ * Drena vencidos. `ttl_expires_at` es null para apagados permanentes. Agrega
+ * `ttl_remaining_ms` (informativo) para callers/UI.
+ */
+function listDisabledProviders(opts = {}) {
+    const now = Number.isFinite(opts.now) ? opts.now : Date.now();
+    let active = [];
+    try {
+        active = readAndDrain({ ...opts, now });
+    } catch {
+        active = [];
+    }
+    return {
+        disabled: active.map((e) => {
+            const exp = e.ttl_expires_at ? Date.parse(e.ttl_expires_at) : NaN;
+            return {
+                name: e.name,
+                disabled_at: e.disabled_at || null,
+                ttl_expires_at: e.ttl_expires_at || null,
+                ttl_remaining_ms: Number.isFinite(exp) ? Math.max(0, exp - now) : null,
+            };
+        }),
+    };
+}
+
+/**
+ * `clearAll(opts?)` → boolean. Borra el archivo entero (escape manual). Útil
+ * para el `manage-providers.sh clear-all`.
+ */
+function clearAll(opts = {}) {
+    const file = flagFile();
+    try {
+        fs.unlinkSync(file);
+        if (opts.auditLogEnabled !== false) {
+            appendAudit({ event: 'cleared_all', detail: 'todos los providers re-habilitados' }, opts);
+        }
+        return true;
+    } catch (e) {
+        if (e && e.code === 'ENOENT') return false;
+        return false;
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Exports
+// -----------------------------------------------------------------------------
+
+module.exports = {
+    isProviderDisabled,
+    setProviderDisabled,
+    clearProviderDisabled,
+    listDisabledProviders,
+    clearAll,
+    isValidProvider,
+
+    // Constantes públicas
+    VALID_PROVIDERS,
+    DEFAULT_TTL_MS,
+    MAX_TTL_MS,
+
+    // Paths (útiles para tests / CLI)
+    flagFile,
+    auditLogFile,
+    pipelineDir,
+
+    // Hooks internos para tests
+    _writeJsonAtomic: writeJsonAtomic,
+    _readRaw: readRaw,
+    _readAndDrain: readAndDrain,
+};

--- a/.pipeline/scripts/manage-providers.sh
+++ b/.pipeline/scripts/manage-providers.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# =============================================================================
+# manage-providers.sh — CLI operacional del kill-switch por provider (#3811)
+#
+# Apaga/enciende providers de IA por terminal, sin tocar archivos JSON a mano
+# ni pasar por Telegram/LLM. Fuente de verdad: lib/provider-disabled.js (mismo
+# módulo que usa el dashboard).
+#
+# USO:
+#   ./manage-providers.sh disable <provider> [--ttl 20m]
+#   ./manage-providers.sh enable  <provider>
+#   ./manage-providers.sh list
+#   ./manage-providers.sh clear-all
+#
+# Providers válidos: anthropic, openai-codex, gemini-google, cerebras, nvidia-nim
+#
+# TTL: acepta sufijos s|m|h|d (ej. 20m, 2h, 90s). Default 20m. `--ttl never`
+#      = apagado permanente (hasta `enable` o `clear-all`).
+#
+# Ejemplos:
+#   ./manage-providers.sh disable anthropic              # apaga 20min
+#   ./manage-providers.sh disable anthropic --ttl 2h     # apaga 2 horas
+#   ./manage-providers.sh disable cerebras --ttl never   # apaga permanente
+#   ./manage-providers.sh enable anthropic               # re-habilita
+#   ./manage-providers.sh list                           # estado + TTL restante
+#   ./manage-providers.sh clear-all                      # re-habilita todo
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PIPELINE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+MODULE="${PIPELINE_DIR}/lib/provider-disabled.js"
+
+if [[ ! -f "${MODULE}" ]]; then
+    echo "ERROR: no encuentro lib/provider-disabled.js en ${PIPELINE_DIR}" >&2
+    exit 1
+fi
+
+usage() {
+    sed -n '2,40p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+    exit "${1:-0}"
+}
+
+# Convierte una duración con sufijo (20m, 2h, 90s, 1d) a milisegundos.
+# Imprime "null" para "never". Sale con error si el formato es inválido.
+parse_ttl_ms() {
+    local raw="$1"
+    if [[ "${raw}" == "never" ]]; then
+        echo "null"
+        return 0
+    fi
+    if [[ ! "${raw}" =~ ^([0-9]+)([smhd])$ ]]; then
+        echo "ERROR: --ttl inválido: '${raw}'. Formato: <número><s|m|h|d> o 'never'." >&2
+        exit 2
+    fi
+    local num="${BASH_REMATCH[1]}"
+    local unit="${BASH_REMATCH[2]}"
+    local mult
+    case "${unit}" in
+        s) mult=1000 ;;
+        m) mult=60000 ;;
+        h) mult=3600000 ;;
+        d) mult=86400000 ;;
+    esac
+    echo "$(( num * mult ))"
+}
+
+# Invoca el módulo Node con una función y argumentos. Toda la lógica de
+# validación de provider / persistencia / TTL vive en el módulo.
+run_node() {
+    PIPELINE_DIR_OVERRIDE="${PIPELINE_DIR}" node "$@"
+}
+
+cmd="${1:-}"; shift || true
+
+case "${cmd}" in
+    disable)
+        provider="${1:-}"; shift || true
+        ttl_arg="20m"
+        while [[ $# -gt 0 ]]; do
+            case "$1" in
+                --ttl) ttl_arg="${2:-}"; shift 2 ;;
+                *) echo "ERROR: argumento desconocido: $1" >&2; exit 2 ;;
+            esac
+        done
+        if [[ -z "${provider}" ]]; then echo "ERROR: falta <provider>." >&2; usage 2; fi
+        ttl_ms="$(parse_ttl_ms "${ttl_arg}")"
+        run_node -e '
+            const m = require(process.env.PIPELINE_DIR_OVERRIDE + "/lib/provider-disabled");
+            const [, provider, ttlRaw] = process.argv;
+            const ttlMs = ttlRaw === "null" ? null : Number(ttlRaw);
+            const r = m.setProviderDisabled(provider, { ttlMs, source: "cli" });
+            if (!r.ok) { console.error("ERROR: " + r.error); process.exit(1); }
+            const ttlTxt = r.ttl_ms == null ? "permanente" : (r.ttl_ms / 60000) + "min";
+            console.log("APAGADO: " + provider + " (ttl=" + ttlTxt + ")");
+        ' "${provider}" "${ttl_ms}"
+        ;;
+    enable)
+        provider="${1:-}"
+        if [[ -z "${provider}" ]]; then echo "ERROR: falta <provider>." >&2; usage 2; fi
+        run_node -e '
+            const m = require(process.env.PIPELINE_DIR_OVERRIDE + "/lib/provider-disabled");
+            const provider = process.argv[1];
+            if (!m.isValidProvider(provider)) {
+                console.error("ERROR: provider inválido: " + provider + ". Válidos: " + m.VALID_PROVIDERS.join(", "));
+                process.exit(1);
+            }
+            const changed = m.clearProviderDisabled(provider, { source: "cli" });
+            console.log(changed ? ("ENCENDIDO: " + provider) : (provider + " ya estaba encendido."));
+        ' "${provider}"
+        ;;
+    list)
+        run_node -e '
+            const m = require(process.env.PIPELINE_DIR_OVERRIDE + "/lib/provider-disabled");
+            const { disabled } = m.listDisabledProviders();
+            if (disabled.length === 0) { console.log("Todos los providers ENCENDIDOS."); process.exit(0); }
+            console.log("Providers APAGADOS:");
+            for (const e of disabled) {
+                const ttl = e.ttl_remaining_ms == null
+                    ? "permanente"
+                    : Math.ceil(e.ttl_remaining_ms / 60000) + "min restantes";
+                console.log("  - " + e.name + " (" + ttl + ", desde " + e.disabled_at + ")");
+            }
+        '
+        ;;
+    clear-all)
+        run_node -e '
+            const m = require(process.env.PIPELINE_DIR_OVERRIDE + "/lib/provider-disabled");
+            const changed = m.clearAll({ source: "cli" });
+            console.log(changed ? "Todos los providers re-habilitados." : "No había providers apagados.");
+        '
+        ;;
+    -h|--help|help|"")
+        usage 0
+        ;;
+    *)
+        echo "ERROR: comando desconocido: ${cmd}" >&2
+        usage 2
+        ;;
+esac

--- a/.pipeline/tests/dispatch-with-fallback.test.js
+++ b/.pipeline/tests/dispatch-with-fallback.test.js
@@ -934,3 +934,117 @@ test('#3680 · FORCE_PROVIDER_OVERRIDE shape del audit entry estable (CA-A11)', 
     assert.equal(entry.entry.source, 'smoke-test');
     assert.ok('primary_provider_bypassed' in entry.entry);
 });
+
+// -----------------------------------------------------------------------------
+// #3811 — Kill-switch operacional por provider (provider-disabled)
+// -----------------------------------------------------------------------------
+
+// Fake del módulo provider-disabled. Inyectable vía opts.disabledModule.
+function fakeDisabledModule(disabledProviders = []) {
+    const set = new Set(disabledProviders);
+    return {
+        isProviderDisabled: (provider) => set.has(provider),
+    };
+}
+
+test('#3811 · primario APAGADO (kill-switch) salta a fallback aunque no haya cuota agotada', () => {
+    const models = baseAgentModels();
+    const fsImpl = fakeFsWithAgentModels(PIPELINE_DIR, models);
+    const audit = fakeAuditLog();
+    const notify = fakeNotify();
+
+    const r = resolveSpawnWithFallback({
+        skill: 'guru',
+        issue: ISSUE,
+        pipelineDir: PIPELINE_DIR,
+        fsImpl,
+        // Cuota NO agotada: el salto se debe exclusivamente al kill-switch.
+        quotaModule: fakeQuotaModule({ gatedProviders: [] }),
+        disabledModule: fakeDisabledModule(['anthropic']),
+        primaryResolver: fakeResolver,
+        auditLog: audit,
+        notify,
+    });
+
+    assert.equal(r.gated, false);
+    assert.equal(r.provider, 'openai-codex', 'salta al fallback');
+    assert.equal(r.source, 'fallback');
+    assert.equal(r.crossProvider, true);
+    // Audit registra el salto por deshabilitación.
+    const disabledEvent = audit.entries.find(e => e.entry.event === 'provider_disabled');
+    assert.ok(disabledEvent, 'audit provider_disabled emitido');
+    assert.equal(disabledEvent.entry.primary_provider, 'anthropic');
+    assert.equal(disabledEvent.entry.quota_gated, false);
+});
+
+test('#3811 · primario apagado SIN fallbacks → all-gated (no spawnea)', () => {
+    const models = baseAgentModels();
+    const fsImpl = fakeFsWithAgentModels(PIPELINE_DIR, models);
+    const audit = fakeAuditLog();
+
+    const r = resolveSpawnWithFallback({
+        skill: 'lone-wolf',
+        issue: ISSUE,
+        pipelineDir: PIPELINE_DIR,
+        fsImpl,
+        quotaModule: fakeQuotaModule({ gatedProviders: [] }),
+        disabledModule: fakeDisabledModule(['anthropic']),
+        primaryResolver: fakeResolver,
+        auditLog: audit,
+        notify: fakeNotify(),
+    });
+
+    assert.equal(r.gated, true);
+    assert.equal(r.source, 'all-gated');
+    // El salto por kill-switch quedó registrado antes del gated_no_fallbacks.
+    assert.ok(audit.entries.some(e => e.entry.event === 'provider_disabled'));
+    assert.ok(audit.entries.some(e => e.entry.event === 'gated_no_fallbacks'));
+});
+
+test('#3811 · fallback también apagado → salta al siguiente eslabón', () => {
+    const models = baseAgentModels();
+    const fsImpl = fakeFsWithAgentModels(PIPELINE_DIR, models);
+    const audit = fakeAuditLog();
+
+    const r = resolveSpawnWithFallback({
+        skill: 'chain-skill', // anthropic → [openai-codex, gemini]
+        issue: ISSUE,
+        pipelineDir: PIPELINE_DIR,
+        fsImpl,
+        quotaModule: fakeQuotaModule({ gatedProviders: [] }),
+        // anthropic (primario) y openai-codex (1er fallback) apagados → debe ir a gemini.
+        disabledModule: fakeDisabledModule(['anthropic', 'openai-codex']),
+        primaryResolver: fakeResolver,
+        providerHandlerResolver: fakeProviderHandlerResolver(['anthropic', 'openai-codex', 'gemini']),
+        auditLog: audit,
+        notify: fakeNotify(),
+    });
+
+    assert.equal(r.gated, false);
+    assert.equal(r.provider, 'gemini', 'salta al 2do fallback');
+    const fbDisabled = audit.entries.find(e => e.entry.event === 'fallback_provider_disabled');
+    assert.ok(fbDisabled, 'audit fallback_provider_disabled emitido');
+    assert.equal(fbDisabled.entry.fallback_provider, 'openai-codex');
+});
+
+test('#3811 · sin disabledModule inyectado, el flow legacy no cambia (default módulo real, archivo ausente)', () => {
+    const models = baseAgentModels();
+    const fsImpl = fakeFsWithAgentModels(PIPELINE_DIR, models);
+    const audit = fakeAuditLog();
+
+    // No pasamos disabledModule → usa el real, que sin archivo devuelve false.
+    const r = resolveSpawnWithFallback({
+        skill: 'guru',
+        issue: ISSUE,
+        pipelineDir: PIPELINE_DIR,
+        fsImpl,
+        quotaModule: fakeQuotaModule({ gatedProviders: [] }),
+        primaryResolver: fakeResolver,
+        auditLog: audit,
+        notify: fakeNotify(),
+    });
+
+    assert.equal(r.gated, false);
+    assert.equal(r.provider, 'anthropic', 'happy path intacto');
+    assert.ok(!audit.entries.some(e => e.entry.event === 'provider_disabled'));
+});

--- a/.pipeline/views/dashboard/multi-provider.js
+++ b/.pipeline/views/dashboard/multi-provider.js
@@ -120,6 +120,19 @@ const PANEL_CSS = `
 .mp-override-table tr { border-left: 3px solid transparent; }
 .mp-override-table tr.has-provider-accent td:first-child { border-left: 3px solid var(--row-accent, var(--in-warn)); padding-left: 12px; }
 .mp-ttl-countdown { font-variant-numeric: tabular-nums; color: var(--in-warn); font-weight: 500; display: inline-flex; align-items: center; gap: 4px; }
+/* #3811 — toggle del kill-switch por provider */
+.mp-switch { position: relative; display: inline-block; width: 44px; height: 24px; flex: none; }
+.mp-switch input { opacity: 0; width: 0; height: 0; }
+.mp-switch .mp-slider { position: absolute; cursor: pointer; inset: 0; background: var(--in-ok, #2ea043); border-radius: 24px; transition: background .15s; }
+.mp-switch .mp-slider::before { content: ""; position: absolute; height: 18px; width: 18px; left: 3px; bottom: 3px; background: #fff; border-radius: 50%; transition: transform .15s; }
+/* checked == provider APAGADO → rojo + knob a la izquierda */
+.mp-switch input:checked + .mp-slider { background: var(--in-bad, #d1242f); }
+.mp-switch input:checked + .mp-slider::before { transform: translateX(20px); }
+.mp-switch input:disabled + .mp-slider { opacity: .5; cursor: not-allowed; }
+.mp-ks-state { font-size: 11px; font-weight: 600; letter-spacing: .03em; }
+.mp-ks-state.on { color: var(--in-ok); }
+.mp-ks-state.off { color: var(--in-bad); }
+.mp-ks-ttl { font-variant-numeric: tabular-nums; color: var(--in-fg-dim); font-size: 11px; }
 .mp-ttl-countdown .mp-icon { color: currentColor; }
 .mp-ttl-countdown.expiring { color: var(--in-bad); }
 
@@ -192,6 +205,22 @@ function bodyHtml() {
         <span>🟡 amarillo · quota_exhausted</span>
         <span>🟠 naranja · forbidden</span>
       </div>
+    </div>
+
+    <!--
+      #3811 — Kill-switch operacional por provider. Toggle on/off por provider
+      que escribe/borra .pipeline/provider-disabled.json (misma fuente de verdad
+      que la CLI manage-providers.sh). Apagar dispara el salto a fallback en
+      runtime, igual que una caída del provider.
+    -->
+    <div class="mp-card" id="mp-card-killswitch">
+      <div class="mp-card-head">
+        <div>
+          <div class="mp-card-title"><svg class="mp-icon lg" viewBox="0 0 24 24" aria-hidden="true"><use href="/assets/icons/sprite.svg#ic-provider-health"></use></svg> Apagar / encender providers</div>
+          <div class="mp-card-sub">Kill-switch operacional. Apagar un provider hace que el pipeline salte al siguiente eslabón de la cadena del skill, como si el provider estuviera caído. Default 20 min (auto-restaurado por TTL).</div>
+        </div>
+      </div>
+      <div id="mp-killswitch-list"></div>
     </div>
 
     <div class="mp-card">
@@ -332,6 +361,8 @@ let mpState = {
     overrides: { active: [], history: [] }, csrfToken: null, dirty: false,
     // #3361 — snapshot del último GET /api/pulpo/provider-health (live).
     liveProviders: null,
+    // #3811 — estado del kill-switch por provider (GET providers-disabled).
+    killSwitch: null,
 };
 
 function showToast(msg, ok) {
@@ -456,12 +487,13 @@ function connIcon(status) {
 async function loadAll() {
     setMsg('Cargando configuración…');
     await fetchCsrf();
-    const [cfg, cat, sk, ovs, health] = await Promise.all([
+    const [cfg, cat, sk, ovs, health, ks] = await Promise.all([
         fetchJson('/api/multi-provider/config'),
         fetchJson('/api/multi-provider/catalog'),
         fetchJson('/api/multi-provider/skills'),
         fetchJson('/api/multi-provider/overrides'),
         fetchJson('/api/multi-provider/health'),
+        fetchJson('/api/multi-provider/providers-disabled'),
     ]);
     if (!cfg || !cfg.config) { setMsg('Error cargando config'); return; }
     mpState.config = cfg.config;
@@ -471,6 +503,7 @@ async function loadAll() {
     mpState.skills = sk || null;
     mpState.overrides = ovs || { active: [], history: [] };
     mpState.health = health || null;
+    mpState.killSwitch = (ks && ks.ok) ? ks.providers : [];
     mpState.dirty = false;
     renderAll();
     setMsg('OK');
@@ -478,6 +511,7 @@ async function loadAll() {
 
 function renderAll() {
     renderProviders();
+    renderKillSwitch();
     renderDefaultProvider();
     renderSkillsGrid();
     renderCatalog();
@@ -680,6 +714,86 @@ function renderProviders() {
             if (btn.dataset.act === 'rotate') return startRotate(provider);
         });
     });
+}
+
+// =====================================================================
+// #3811 — Kill-switch operacional por provider.
+//
+// Toggle on/off por provider. ENCENDIDO (verde) = provider activo;
+// APAGADO (rojo, checkbox checked) = el pipeline lo trata como caído y
+// salta al siguiente eslabón de la cadena del skill. Escribe vía
+// POST /api/multi-provider/providers/:p/disable|enable (con CSRF),
+// reutilizando lib/provider-disabled.js (misma fuente de verdad que la CLI).
+//
+// Defensa XSS (A03): todo nombre/valor interpolado pasa por escapeHtml().
+// =====================================================================
+function ksTtlText(p) {
+    if (!p.disabled) return '';
+    if (p.ttl_remaining_ms == null) return 'apagado · permanente';
+    const mins = Math.max(0, Math.ceil(p.ttl_remaining_ms / 60000));
+    return 'apagado · ' + mins + ' min restantes';
+}
+
+function renderKillSwitch() {
+    const c = document.getElementById('mp-killswitch-list');
+    if (!c) return;
+    const providers = mpState.killSwitch || [];
+    if (providers.length === 0) {
+        c.innerHTML = '<div style="color:var(--in-fg-dim);font-size:12px;padding:14px 0">No hay providers disponibles para el kill-switch.</div>';
+        return;
+    }
+    c.innerHTML = '';
+    for (const p of providers) {
+        const row = document.createElement('div');
+        row.className = 'mp-row has-provider-accent';
+        row.style.setProperty('--row-accent', 'var(' + providerToken(p.name) + ')');
+        const stateCls = p.disabled ? 'off' : 'on';
+        const stateTxt = p.disabled ? 'APAGADO' : 'ENCENDIDO';
+        // checkbox.checked == provider APAGADO (el switch rojo significa "caído").
+        row.innerHTML = \`
+            <div class="mp-row-label" title="Provider \${escapeHtml(p.name)}">
+                \${providerIcon(p.name, 'lg')}
+                <span>\${escapeHtml(p.name)}</span>
+            </div>
+            <div class="mp-row-input">
+                <span class="mp-ks-state \${stateCls}">\${stateTxt}</span>
+                <span class="mp-ks-ttl" style="margin-left:10px">\${escapeHtml(ksTtlText(p))}</span>
+            </div>
+            <div class="mp-row-actions">
+                <label class="mp-switch" title="\${p.disabled ? 'Encender' : 'Apagar'} \${escapeHtml(p.name)}">
+                    <input type="checkbox" data-ks-provider="\${escapeHtml(p.name)}" \${p.disabled ? 'checked' : ''}>
+                    <span class="mp-slider"></span>
+                </label>
+            </div>\`;
+        c.appendChild(row);
+    }
+    c.querySelectorAll('input[data-ks-provider]').forEach(input => {
+        input.addEventListener('change', () => toggleProvider(input.dataset.ksProvider, input.checked, input));
+    });
+}
+
+async function toggleProvider(provider, disable, inputEl) {
+    if (inputEl) inputEl.disabled = true;
+    setMsg((disable ? 'Apagando ' : 'Encendiendo ') + provider + '…');
+    const action = disable ? 'disable' : 'enable';
+    const r = await authedPost('/api/multi-provider/providers/' + provider + '/' + action, {});
+    if (r && r.ok) {
+        showToast(provider + (disable ? ' APAGADO' : ' ENCENDIDO'), true);
+    } else {
+        showToast(provider + ': ' + ((r && (r.message || r.error)) || 'falla'), false);
+        // Revertir el toggle visual si falló.
+        if (inputEl) inputEl.checked = !disable;
+    }
+    if (inputEl) inputEl.disabled = false;
+    // Refrescar el estado real desde el server (TTL, etc).
+    await refreshKillSwitch();
+    setMsg('OK');
+}
+
+async function refreshKillSwitch() {
+    const ks = await fetchJson('/api/multi-provider/providers-disabled');
+    mpState.killSwitch = (ks && ks.ok) ? ks.providers : (mpState.killSwitch || []);
+    renderKillSwitch();
 }
 
 async function pingProvider(provider) {

--- a/docs/pipeline/provider-disabled.md
+++ b/docs/pipeline/provider-disabled.md
@@ -1,0 +1,150 @@
+# Kill-switch operacional por provider (`provider-disabled`)
+
+> Issue: #3811 · Módulo: `.pipeline/lib/provider-disabled.js`
+
+## Qué resuelve
+
+El pipeline V3 ya tenía un mecanismo para tratar un provider de IA como no
+disponible: el flag de **cuota agotada** (`.pipeline/quota-exhausted.json`). Pero
+ese flag tiene semántica de *"cuota agotada → esperar reset"*: **pausa** el spawn
+del skill (lo deja en `pendiente/`) y NO cascadea al siguiente provider de la
+cadena de fallbacks.
+
+En la prueba controlada del 2026-06-03, marcar Anthropic como agotado **no hizo
+saltar** los agentes (architect/po/ux/planner) a Codex: todos corrieron en
+Anthropic igual, porque `shouldGateSpawn` es un **gate** (pausa), no un
+**dispatcher** (salto).
+
+El kill-switch agrega un primitivo operacional explícito: **un switch por
+provider** que, al apagarlo, ordena a `dispatch-with-fallback` **saltar al
+siguiente eslabón de la cadena del skill**, replicando una *"caída en runtime"*
+en lugar de una *"espera de reset de cuota"*.
+
+## Modelo de datos
+
+Persistencia: `.pipeline/provider-disabled.json`
+
+```json
+{
+  "disabled": [
+    { "name": "anthropic", "disabled_at": "2026-06-03T20:00:00.000Z", "ttl_expires_at": "2026-06-03T20:20:00.000Z" },
+    { "name": "cerebras",  "disabled_at": "2026-06-03T20:05:00.000Z" }
+  ]
+}
+```
+
+- `ttl_expires_at` ausente/`null` → apagado **permanente** (hasta `enable`/`clear-all`).
+- `ttl_expires_at` presente y vencido → la entrada se **drena en lectura** (auto-restaurado).
+- Archivo ausente == **ningún provider apagado** (todos encendidos).
+
+Providers válidos (allowlist, espejo de `resolve-provider.js`):
+`anthropic`, `openai-codex`, `gemini-google`, `cerebras`, `nvidia-nim`.
+`deterministic` **no** es apagable (no es un provider de IA).
+
+## TTL
+
+- Default: **20 minutos** (`DEFAULT_TTL_MS`).
+- Cap máximo: **7 días** (`MAX_TTL_MS`). Un apagado "indefinido" se hace con TTL
+  `never` (permanente), no con un número gigante.
+- Auto-restaurado: cualquier lectura (`isProviderDisabled`, `listDisabledProviders`)
+  drena las entradas vencidas y re-habilita el provider.
+
+## CLI operacional
+
+Script: `.pipeline/scripts/manage-providers.sh` (bash, delega en el módulo Node).
+
+```bash
+# Apagar anthropic por 20 min (default)
+.pipeline/scripts/manage-providers.sh disable anthropic
+
+# Apagar por una duración explícita (s|m|h|d)
+.pipeline/scripts/manage-providers.sh disable anthropic --ttl 2h
+.pipeline/scripts/manage-providers.sh disable cerebras  --ttl 90s
+
+# Apagar permanente (hasta enable / clear-all)
+.pipeline/scripts/manage-providers.sh disable cerebras --ttl never
+
+# Encender un provider
+.pipeline/scripts/manage-providers.sh enable anthropic
+
+# Ver estado + TTL restante
+.pipeline/scripts/manage-providers.sh list
+
+# Re-habilitar TODO (escape manual)
+.pipeline/scripts/manage-providers.sh clear-all
+```
+
+La operación es **por terminal Windows**, sin pasar por Telegram ni LLM
+(determinístico: solo filesystem JSON + comparación de strings).
+
+## Perilla en el Dashboard
+
+El panel **Providers** del dashboard (`/dashboard` → tab "1 · Proveedores")
+expone un **toggle on/off por provider** bajo la tarjeta *"Apagar / encender
+providers"*.
+
+- Encendido = verde; apagado = rojo (el switch en rojo significa "caído").
+- Muestra el TTL restante cuando un provider está apagado.
+- Escribe la misma fuente de verdad (`provider-disabled.json`) vía:
+  - `GET  /api/multi-provider/providers-disabled` — estado de todos los providers.
+  - `POST /api/multi-provider/providers/:provider/disable` — apaga (body opcional `{ "ttl_ms": <num|null> }`).
+  - `POST /api/multi-provider/providers/:provider/enable` — enciende.
+- Las mutaciones exigen **CSRF** (igual que el resto del panel multi-provider).
+
+El efecto desde el dashboard es **idéntico** al switch por terminal.
+
+## Integración en el dispatcher
+
+`.pipeline/lib/agent-launcher/dispatch-with-fallback.js :: resolveSpawnWithFallback`
+consulta `isProviderDisabled(provider)` **además** del gate de cuota:
+
+```
+primaryGated = shouldGateSpawn(skill, {provider})  ||  isProviderDisabled(provider)
+```
+
+- Si el primario está apagado → salta a `fallbacks[]` como si estuviera gateado
+  por cuota. Audit: evento `provider_disabled`.
+- Si un fallback está apagado → se saltea al siguiente eslabón. Audit:
+  evento `fallback_provider_disabled`.
+- Audit log: `.pipeline/logs/cross-provider-dispatch-YYYY-MM-DD.jsonl`
+  (hash-chain SHA-256, mismo archivo que el resto del dispatch).
+
+> **Fase 1 (este issue):** el módulo + integración en `dispatch-with-fallback`.
+> No requiere cambio obligatorio de `pulpo.js`: el dispatcher ya es el punto
+> único de resolución de provider pre-spawn.
+
+## Diferencia con `quota-exhausted`
+
+| | `quota-exhausted` | `provider-disabled` (kill-switch) |
+|---|---|---|
+| Semántica | "cuota agotada → esperar reset" | "caída en runtime → saltar a fallback" |
+| Disparador | detector automático del CLI | **operador** (terminal o dashboard) |
+| Efecto | pausa el spawn (queda en `pendiente/`) | salta al siguiente provider de la cadena |
+| TTL | hasta `resets_at` (semanal/mensual) | default 20 min (corto, operacional) |
+
+## Kill-switch del kill-switch
+
+Si por un bug el archivo queda corrupto o pegado:
+
+```bash
+rm .pipeline/provider-disabled.json
+```
+
+restaura todos los providers (el archivo ausente == ningún provider apagado).
+El módulo además es **fail-open**: cualquier error de IO o JSON corrupto degrada
+a "provider encendido" — el kill-switch nunca bloquea el pipeline por un bug
+propio.
+
+## Tests
+
+- `.pipeline/lib/__tests__/provider-disabled.test.js` — 20 casos: set/read/clear
+  idempotentes, TTL + drenado, apagado permanente, backward-compat, validación
+  de provider, JSON corrupto.
+- `.pipeline/tests/dispatch-with-fallback.test.js` — casos `#3811`: salto del
+  primario apagado, sin-fallbacks → all-gated, fallback apagado → siguiente
+  eslabón, sin-módulo → flow legacy intacto.
+
+```bash
+node --test .pipeline/lib/__tests__/provider-disabled.test.js
+node --test .pipeline/tests/dispatch-with-fallback.test.js
+```


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 9 archivos · +1421 -12

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:passed` aplicado por delivery

## Closes

Closes #3811
