### PR TITLE
fix(commander): entregar solo el mensaje final del fallback (no el JSONL crudo)

### DIFF
--- a/.pipeline/lib/commander/__tests__/extract-fallback-reply.test.js
+++ b/.pipeline/lib/commander/__tests__/extract-fallback-reply.test.js
@@ -1,0 +1,80 @@
+// =============================================================================
+// extract-fallback-reply.test.js — Cobertura del normalizador de salida de los
+// providers de respaldo del Commander.
+//
+// Contexto: los providers no-Anthropic (codex `exec --json`, gemini, cerebras,
+// nvidia) emiten su salida como JSONL. El path de fallback dumpeaba ese stream
+// crudo a Telegram y el TTS lo partía en una lluvia de audios técnicos. El
+// helper extrae sólo el/los `agent_message` finales para entregar un único
+// mensaje conversacional.
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { extractFallbackReply } = require('../multi-provider');
+
+test('extrae el agent_message de un stream JSONL de codex', () => {
+    const stdout = [
+        '{"type":"turn.started"}',
+        '{"type":"item.completed","item":{"type":"tool_call","name":"Bash"}}',
+        '{"type":"item.completed","item":{"type":"agent_message","text":"Listo Leo, el pipeline está arriba."}}',
+        '{"type":"turn.completed","usage":{"input_tokens":10,"output_tokens":5}}',
+    ].join('\n');
+    const r = extractFallbackReply(stdout);
+    assert.equal(r.parsed, true);
+    assert.equal(r.text, 'Listo Leo, el pipeline está arriba.');
+});
+
+test('concatena múltiples agent_message en orden', () => {
+    const stdout = [
+        '{"type":"item.completed","item":{"type":"agent_message","text":"Parte uno."}}',
+        '{"type":"item.completed","item":{"type":"agent_message","text":"Parte dos."}}',
+    ].join('\n');
+    const r = extractFallbackReply(stdout);
+    assert.equal(r.parsed, true);
+    assert.equal(r.text, 'Parte uno.\n\nParte dos.');
+});
+
+test('JSONL sin agent_message → texto vacío (caller cae al canned)', () => {
+    const stdout = [
+        '{"type":"turn.started"}',
+        '{"type":"item.completed","item":{"type":"tool_call","name":"Bash"}}',
+        '{"type":"turn.completed","usage":{"input_tokens":10,"output_tokens":0}}',
+    ].join('\n');
+    const r = extractFallbackReply(stdout);
+    assert.equal(r.parsed, false);
+    assert.equal(r.text, '');
+});
+
+test('texto plano (provider no-stream-json) se devuelve tal cual', () => {
+    const r = extractFallbackReply('Respuesta en texto plano sin JSON.');
+    assert.equal(r.parsed, false);
+    assert.equal(r.text, 'Respuesta en texto plano sin JSON.');
+});
+
+test('stdout vacío o nulo → vacío sin romper', () => {
+    assert.deepEqual(extractFallbackReply(''), { text: '', parsed: false });
+    assert.deepEqual(extractFallbackReply('   '), { text: '', parsed: false });
+    assert.deepEqual(extractFallbackReply(null), { text: '', parsed: false });
+    assert.deepEqual(extractFallbackReply(undefined), { text: '', parsed: false });
+});
+
+test('ignora líneas JSON malformadas sin tirar', () => {
+    const stdout = [
+        '{ esto no es json valido',
+        '{"type":"item.completed","item":{"type":"agent_message","text":"OK igual."}}',
+        'ruido suelto',
+    ].join('\n');
+    const r = extractFallbackReply(stdout);
+    assert.equal(r.parsed, true);
+    assert.equal(r.text, 'OK igual.');
+});
+
+test('agent_message sin campo text se ignora (no rompe)', () => {
+    const stdout = '{"type":"item.completed","item":{"type":"agent_message"}}';
+    const r = extractFallbackReply(stdout);
+    assert.equal(r.parsed, false);
+    assert.equal(r.text, '');
+});

--- a/.pipeline/lib/commander/multi-provider.js
+++ b/.pipeline/lib/commander/multi-provider.js
@@ -878,6 +878,57 @@ function safeBuildSpawn({ handler, args, cwd, env }) {
 }
 
 // -----------------------------------------------------------------------------
+// extractFallbackReply — normaliza el stdout de un provider de respaldo a un
+// único mensaje conversacional listo para Telegram.
+//
+// Problema que resuelve: los providers no-Anthropic (codex `exec --json`,
+// gemini, cerebras, nvidia) emiten su salida como **JSONL** (un evento por
+// línea), NO como texto plano. El path de fallback del commander capturaba el
+// `stdout` crudo y lo mandaba tal cual a Telegram — el TTS partía ese stream de
+// eventos en una lluvia de audios cortos y técnicos, totalmente heterogéneo con
+// la voz del Commander cuando corre sobre Claude.
+//
+// Codex marca el mensaje final del asistente con un evento
+// `item.completed` cuyo `item.type === 'agent_message'` y el texto en
+// `item.text`. Concatenamos todos los `agent_message` en orden (por si el
+// provider parte la respuesta en varios) y devolvemos sólo eso.
+//
+// Contrato de salida: { text, parsed }
+//   - parsed=true  → extrajimos al menos un agent_message (homogéneo).
+//   - parsed=false + text==''  → era JSONL pero sin agent_message: el caller
+//     responde canned en lugar de dumpear el stream crudo.
+//   - parsed=false + text!=''  → no era JSONL (provider de texto plano):
+//     devolvemos el texto tal cual (best-effort, back-compat).
+// -----------------------------------------------------------------------------
+function extractFallbackReply(stdout) {
+    const raw = typeof stdout === 'string' ? stdout : '';
+    if (!raw.trim()) return { text: '', parsed: false };
+
+    const messages = [];
+    let sawJson = false;
+    for (const line of raw.split('\n')) {
+        const t = line.trim();
+        if (!t.startsWith('{')) continue;
+        let obj;
+        try { obj = JSON.parse(t); } catch { continue; }
+        sawJson = true;
+        if (obj && obj.type === 'item.completed' && obj.item
+            && obj.item.type === 'agent_message'
+            && typeof obj.item.text === 'string') {
+            messages.push(obj.item.text);
+        }
+    }
+
+    if (messages.length > 0) {
+        return { text: messages.join('\n\n').trim(), parsed: true };
+    }
+    // JSONL sin agent_message → vacío: el caller cae al canned y NO dumpea el
+    // stream crudo. Texto plano → lo devolvemos tal cual (comportamiento previo).
+    if (sawJson) return { text: '', parsed: false };
+    return { text: raw.trim(), parsed: false };
+}
+
+// -----------------------------------------------------------------------------
 // cannedFallbackUnavailableResponse — Mensaje al usuario para el caso de borde
 // en que el dispatcher resolvió un fallback pero su `buildSpawn` falla (handler
 // roto / binario ausente). Mensaje no técnico, sin paths internos.
@@ -923,6 +974,7 @@ module.exports = {
     auditCommanderRequest,
     readCommanderStats,
     safeBuildSpawn,
+    extractFallbackReply,
     enforceDataResidency,
     runCommanderSpawn,
 

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -8159,7 +8159,12 @@ function ejecutarClaude(prompt, textoOriginal, trace) {
       proc.on('close', () => {
         clearTimeout(timer);
         const elapsed = Date.now() - startNon;
-        log('commander', `Provider ${resolution.provider} terminó (${elapsed}ms, stdout=${stdout.length}c, stderr=${stderr.length}c)`);
+        // Los providers no-Anthropic emiten JSONL (un evento por línea), no
+        // texto plano. Extraemos SÓLO el/los `agent_message` finales para que a
+        // Telegram llegue un único mensaje conversacional — y no el stream de
+        // eventos crudo, que el TTS partía en una lluvia de audios técnicos.
+        const extracted = commanderMP.extractFallbackReply(stdout);
+        log('commander', `Provider ${resolution.provider} terminó (${elapsed}ms, stdout=${stdout.length}c, reply=${extracted.text.length}c, parsed=${extracted.parsed}, stderr=${stderr.length}c)`);
         try {
           commanderMP.auditCommanderRequest({
             pipelineDir: PIPELINE,
@@ -8170,11 +8175,11 @@ function ejecutarClaude(prompt, textoOriginal, trace) {
             chatId: getTelegramChatId(),
             prompt: prompt,
             latencyMs: elapsed,
-            errorCode: stdout ? null : 'empty_output',
+            errorCode: extracted.text ? null : 'empty_output',
             requestId: turnRequestId, // #3577 CA-S6
           });
         } catch { /* best-effort */ }
-        resolve(stdout || `No pude completar tu pedido vía ${resolution.provider}. Intentá de nuevo.`);
+        resolve(extracted.text || `No pude completar tu pedido vía ${resolution.provider}. Intentá de nuevo.`);
       });
       proc.on('error', (e) => {
         clearTimeout(timer);


### PR DESCRIPTION
## Problema

Cuando el Commander cae al fallback (Anthropic apagado → codex u otro), la respuesta a Telegram llegaba como una **lluvia de audios cortos y técnicos**, totalmente distinta a la voz del Commander corriendo sobre Claude.

**Causa raíz:** los providers no-Anthropic (codex `exec --json`, gemini, cerebras, nvidia) emiten su salida como **JSONL** (un evento por línea), no texto plano. El path de fallback en `pulpo.js` capturaba el `stdout` crudo y lo mandaba tal cual; el TTS partía ese stream de eventos en muchos chunks.

## Fix

- Nuevo helper `extractFallbackReply(stdout)` en `lib/commander/multi-provider.js`: extrae sólo el/los `agent_message` finales del JSONL y los concatena en un único mensaje conversacional.
- Si el JSONL no trae `agent_message` → responde canned en vez de dumpear el stream crudo.
- Texto plano (provider no-stream-json) → se devuelve tal cual (back-compat).
- `pulpo.js` usa el helper en el close del subprocess de fallback y ajusta el `errorCode` del audit log a partir del texto extraído.

## Tests

- `lib/commander/__tests__/extract-fallback-reply.test.js` — 7 casos (codex JSONL, multi-message, sin agent_message, texto plano, vacío/nulo, JSON malformado, agent_message sin text). Todos verdes.
- Suite `commander-multi-provider.test.js` sigue en verde (30/30).

## QA

`qa:skipped` — cambio de infra del Commander (comportamiento del fallback LLM por Telegram), sin impacto en el producto de usuario (app cliente/business/delivery).

🤖 Generated with [Claude Code](https://claude.com/claude-code)