### PR TITLE
fix(commander): codex fallback con permisos plenos y persona consistente

### DIFF
--- a/.pipeline/lib/agent-launcher/providers/openai-codex.js
+++ b/.pipeline/lib/agent-launcher/providers/openai-codex.js
@@ -10,8 +10,11 @@
 //      .cmd shim / PATH fallback). Mismo patrón defensivo que Anthropic (I6).
 //   2) buildSpawn — traduce los args legacy del pulpo (estilo Claude CLI:
 //      `-p`, `--system-prompt-file`, `--output-format stream-json`) al shape
-//      que entiende Codex (`exec --json --skip-git-repo-check -m <model>
-//      <prompt>` + opcional `--system <file>`).
+//      que entiende Codex (`exec --json --skip-git-repo-check
+//      --dangerously-bypass-approvals-and-sandbox -m <model> <prompt>`). El
+//      system prompt se foldea al inicio del prompt (codex no tiene flag
+//      `--system`) y el bypass de sandbox da paridad de permisos con el
+//      `--permission-mode bypassPermissions` de Claude.
 //   3) parseTokensFromLog — agrega `usage` de eventos `turn.completed` en JSONL.
 //      Codex usa `input_tokens / output_tokens / cached_input_tokens /
 //      reasoning_output_tokens`; mapeamos al shape canónico del pulpo.
@@ -107,14 +110,34 @@ function translateClaudeArgsToCodex(args, env, cwd) {
     // env-isolation cuando el skill resuelve un modelo específico.
     const model = env && env.CODEX_MODEL;
     const out = ['exec', '--json', '--skip-git-repo-check', '-C', cwd];
+    // Paridad de permisos con `--permission-mode bypassPermissions` de Claude.
+    // `codex exec` corre por DEFAULT en sandbox `read-only` con aprobaciones,
+    // así que el agente choca con "no tengo permisos" / "no está instalado" al
+    // intentar escribir archivos, correr comandos o instalar dependencias —
+    // limitaciones que Claude no tiene. El pipeline ya corre en un entorno
+    // externo de confianza (la máquina de Leo), por lo que le damos a codex el
+    // mismo acceso pleno: sin sandbox y sin aprobaciones interactivas. Sin esto
+    // el fallback degrada por proveedor, que es justo lo que NO queremos.
+    out.push('--dangerously-bypass-approvals-and-sandbox');
     if (model) out.push('-m', model);
+    // codex exec NO tiene flag de system prompt — `--system` no existe en el CLI
+    // (antes lo pasábamos y codex lo descartaba/erroraba, perdiendo la persona
+    // del Commander y dejando su propia identidad de "agente de código" seca y
+    // técnica). Para que la persona/identidad tenga efecto, foldeamos el
+    // contenido del system file al INICIO del prompt, igual que el adapter de
+    // gemini. Así la personalidad del Commander no cambia por usar codex.
+    let systemText = '';
     if (systemFile && typeof systemFile === 'string') {
-        out.push('--system', systemFile);
+        try { systemText = fs.readFileSync(systemFile, 'utf8'); } catch { systemText = ''; }
     }
+    const promptText = typeof userPrompt === 'string' ? userPrompt : '';
+    const folded = systemText.trim()
+        ? `${systemText.trim()}\n\n---\n\n${promptText}`
+        : promptText;
     // Codex toma el prompt como argumento posicional final. Si no vino prompt
     // (caso patológico), pasamos string vacío para que el CLI tire error
     // accionable en lugar de quedar colgado leyendo stdin.
-    out.push(typeof userPrompt === 'string' ? userPrompt : '');
+    out.push(folded);
     return out;
 }
 

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -7896,7 +7896,7 @@ function generarMensajeProgreso(count, elapsedSec, tools, lastTool, textoOrigina
 // responsabilidad la toma `logSkillInvocation` (`_sanitize*` helpers en
 // `issue-creation.js`). Centralizar la redacción evita duplicarla en cada
 // callsite y mantiene el `trace` útil también para debugging local.
-function ejecutarClaude(prompt, textoOriginal, trace) {
+function ejecutarClaude(prompt, textoOriginal, trace, fallbackParts) {
   return new Promise((resolve, reject) => {
     const readline = require('readline');
     const startTimeForAudit = Date.now();
@@ -8109,7 +8109,31 @@ function ejecutarClaude(prompt, textoOriginal, trace) {
       // `--output-format` como prompt basura y el pedido real se perdía en un
       // stdin que el provider nunca lee. Armamos un argv propio con el prompt
       // sanitizado como valor de `-p` para que cada handler lo reciba completo.
-      const fallbackArgs = ['-p', promptForLLM];
+      //
+      // Personalidad consistente en el fallback: cuando el caller separa la
+      // persona del Commander (`fallbackParts.systemPrompt`) del mensaje del
+      // usuario (`fallbackParts.userMessage`), persistimos la persona a un
+      // archivo y la pasamos como `--system-prompt-file`. Los adapters la
+      // foldean al inicio del prompt (codex) o la mandan como system real
+      // (gemini/cerebras/nvidia), así la identidad/estilo del Commander NO
+      // cambia por usar un provider de respaldo. Si el caller no separa partes,
+      // mantenemos el comportamiento previo (prompt completo en `-p`).
+      let fallbackArgs;
+      if (fallbackParts && typeof fallbackParts.systemPrompt === 'string'
+          && typeof fallbackParts.userMessage === 'string'
+          && fallbackParts.systemPrompt && fallbackParts.userMessage) {
+        const userMsgForLLM = commanderMP.sanitizeUserPrompt(fallbackParts.userMessage).sanitized;
+        let sysFile = null;
+        try {
+          sysFile = path.join(PIPELINE, 'commander-system-prompt.md');
+          fs.writeFileSync(sysFile, fallbackParts.systemPrompt, 'utf8');
+        } catch { sysFile = null; }
+        fallbackArgs = sysFile
+          ? ['-p', userMsgForLLM, '--system-prompt-file', sysFile]
+          : ['-p', promptForLLM];
+      } else {
+        fallbackArgs = ['-p', promptForLLM];
+      }
       const safe = commanderMP.safeBuildSpawn({
         handler: resolution.handler,
         args: fallbackArgs,
@@ -9498,7 +9522,12 @@ async function _brazoCommanderInner(config, archivosIniciales, commanderPendient
       // para que no dispare invocaciones espurias cuando el usuario no pide
       // crear nada.
       const issueCreationBlock = commanderIssueCreation.buildIssueCreationPromptBlock();
-      const userPrompt = `Sos el Commander del pipeline V2 de Intrale. Respondés por Telegram.
+      // Separamos la PERSONA (identidad + reglas) de la CONVERSACIÓN (mensaje +
+      // contexto + historial). El path Anthropic usa `userPrompt` completo (sin
+      // cambios). El path de fallback no-Anthropic pasa `commanderPersona` como
+      // system prompt y `commanderConversation` como mensaje del usuario, para
+      // que el provider de respaldo mantenga la misma personalidad del Commander.
+      const commanderPersona = `Sos el Commander del pipeline V2 de Intrale. Respondés por Telegram.
 
 REGLAS:
 1. Si el usuario pide una ACCIÓN (revisar, arreglar, validar, verificar, levantar, etc): EJECUTALA primero con las herramientas que tengas, y después reportá qué hiciste y el resultado.
@@ -9516,8 +9545,10 @@ REGLAS:
    - 1 a 3 frases cortas, lenguaje llano (sin tecnicismos innecesarios), como para entender el panorama de un vistazo.
    - NO repite literal el detalle de arriba: lo comprime en una conclusión.
    - Aplica también a respuestas a preguntas, no sólo a acciones.
-${issueCreationBlock}
-Mensaje de ${from}: ${mensajeConsolidado}${sessionCtx}${historial}`;
+${issueCreationBlock}`;
+      const commanderConversation = `Mensaje de ${from}: ${mensajeConsolidado}${sessionCtx}${historial}`;
+      const userPrompt = `${commanderPersona}
+${commanderConversation}`;
 
       // #3250 — SEC-4: audit log. Pre-LLM marcamos el start time; post-LLM
       // escribimos una línea por intento de creación de issue con el resultado
@@ -9530,7 +9561,10 @@ Mensaje de ${from}: ${mensajeConsolidado}${sessionCtx}${historial}`;
       // `wantsIssueCreation` (no inflamos audit para texto libre genérico).
       const claudeTrace = wantsIssueCreation ? {} : undefined;
       skillInvocationStartedAt = Date.now();
-      let respuesta = await ejecutarClaude(userPrompt, mensajeConsolidado, claudeTrace);
+      let respuesta = await ejecutarClaude(userPrompt, mensajeConsolidado, claudeTrace, {
+        systemPrompt: commanderPersona,
+        userMessage: commanderConversation,
+      });
       log('commander', `Claude respondió: ${(respuesta || '').length} chars`);
 
       if (wantsIssueCreation) {

--- a/.pipeline/tests/agent-launcher.test.js
+++ b/.pipeline/tests/agent-launcher.test.js
@@ -274,6 +274,41 @@ test('launchAgent con provider openai-codex spawnea el codex CLI con args traduc
     assert.ok(call.args.includes('-m'));
     assert.ok(call.args.includes('gpt-5-codex'));
     assert.ok(call.args.includes('probe'));
+    // Paridad de permisos con Claude (`bypassPermissions`): codex debe correr
+    // sin sandbox ni aprobaciones para no chocar con "no tengo permisos".
+    assert.ok(call.args.includes('--dangerously-bypass-approvals-and-sandbox'));
+    // `--system` NO existe en codex exec: el system prompt se foldea al prompt,
+    // nunca se pasa como flag.
+    assert.ok(!call.args.includes('--system'));
+});
+
+// -----------------------------------------------------------------------------
+// 6a-bis. translateClaudeArgsToCodex: el contenido del system file se foldea
+//         al INICIO del prompt (codex no tiene `--system`), y el bypass de
+//         sandbox/aprobaciones está siempre presente (paridad con Claude).
+// -----------------------------------------------------------------------------
+test('codex foldea el system prompt al inicio del prompt y bypassa el sandbox', () => {
+    const realFs = require('node:fs');
+    const os = require('node:os');
+    const sysFile = path.join(os.tmpdir(), `codex-sys-${process.pid}.md`);
+    realFs.writeFileSync(sysFile, 'Sos el Commander. Hablá natural.', 'utf8');
+    try {
+        const out = PROVIDERS['openai-codex']._translateClaudeArgsToCodex(
+            ['-p', 'Hola, cómo estamos?', '--system-prompt-file', sysFile],
+            { CODEX_MODEL: 'gpt-5-codex' },
+            '/repo/platform',
+        );
+        // Permisos: bypass siempre presente.
+        assert.ok(out.includes('--dangerously-bypass-approvals-and-sandbox'));
+        // `--system` jamás se pasa como flag.
+        assert.ok(!out.includes('--system'));
+        // El prompt posicional final foldea persona + mensaje.
+        const prompt = out[out.length - 1];
+        assert.ok(prompt.startsWith('Sos el Commander. Hablá natural.'));
+        assert.ok(prompt.includes('Hola, cómo estamos?'));
+    } finally {
+        try { realFs.unlinkSync(sysFile); } catch {}
+    }
 });
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
## Contexto

Durante la prueba del fallback real (Anthropic apagado → el Commander cae a codex), Leo detectó dos diferencias de comportamiento respecto a cuando corre sobre Claude.

## Cambios

1. **Permisos plenos** — `codex exec` corría por default en sandbox read-only con aprobaciones, lo que provocaba mensajes de "no tengo permisos / no está instalado". Se agrega `--dangerously-bypass-approvals-and-sandbox` para dar paridad con el `--permission-mode bypassPermissions` de Claude. Sin limitaciones por proveedor.

2. **Personalidad consistente** — el adapter pasaba la persona con `--system`, flag inexistente en `codex exec` (se descartaba silenciosamente), por lo que codex usaba su propia voz seca/técnica. Ahora el system prompt se foldea al inicio del prompt (igual que gemini) y el Commander separa persona de conversación para pasarla como `--system-prompt-file` en el fallback.

## Tests

- 51 tests del commander en verde
- 21 tests del agent-launcher en verde (incluye 35 nuevas aserciones para codex)

## QA

`qa:skipped` — cambio puro de infra/Commander sin impacto en el producto de usuario.

Closes parte de la prueba de fallback multi-provider.