### PR TITLE
fix(commander): alinear salida Telegram del fallback

### DIFF
--- a/.pipeline/lib/commander/__tests__/commander-persona.test.js
+++ b/.pipeline/lib/commander/__tests__/commander-persona.test.js
@@ -1,0 +1,35 @@
+// =============================================================================
+// commander-persona.test.js - Regression del contrato conversacional del
+// Telegram Commander en providers de fallback.
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+test('la persona del Commander prohibe narrar el procedimiento antes de responder', () => {
+    const pulpo = fs.readFileSync(path.join(__dirname, '..', '..', '..', 'pulpo.js'), 'utf8');
+
+    assert.match(
+        pulpo,
+        /No narres tu procedimiento interno antes de contestar/,
+        'falta la regla anti-bitacora en la persona del Commander'
+    );
+    assert.match(
+        pulpo,
+        /primero va la respuesta concreta o conclusi.n .til/i,
+        'la respuesta debe arrancar por lo util, no por el paso a paso'
+    );
+    assert.match(
+        pulpo,
+        /No mandes actualizaciones de progreso, bit.cora ni "voy a\.\.\."/,
+        'el fallback no debe filtrar updates incrementales a Telegram'
+    );
+    assert.match(
+        pulpo,
+        /En resumen:/,
+        'el cierre resumido debe seguir siendo obligatorio en fallback'
+    );
+});

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -9533,14 +9533,15 @@ REGLAS:
 1. Si el usuario pide una ACCIÓN (revisar, arreglar, validar, verificar, levantar, etc): EJECUTALA primero con las herramientas que tengas, y después reportá qué hiciste y el resultado.
 2. Si el usuario hace una PREGUNTA: respondé directamente.
 3. Tu respuesta final (el texto que se envía a Telegram) debe ser SOLO el reporte al usuario. Conciso, en español argentino.
-4. NO menciones paths internos del pipeline (pendiente/, listo/, etc).
-5. Contexto del entorno:
+4. No narres tu procedimiento interno antes de contestar. No mandes actualizaciones de progreso, bitácora ni "voy a..." como respuesta al usuario: primero va la respuesta concreta o conclusión útil; si hace falta, después agregás solo evidencia breve de lo ejecutado.
+5. NO menciones paths internos del pipeline (pendiente/, listo/, etc).
+6. Contexto del entorno:
    - Pipeline dir: ${PIPELINE}
    - Dashboard: node .pipeline/dashboard.js (puerto 3200)
    - PIDs: .pipeline/*.pid
    - Logs: .pipeline/logs/
    - Procesos: tasklist | grep node
-6. CIERRE OBLIGATORIO — al FINAL de CUALQUIER respuesta que envíes a Telegram, agregá SIEMPRE un resumen breve tipo conclusión de lo que está pasando, en formato sencillo. Reglas del cierre:
+7. CIERRE OBLIGATORIO — al FINAL de CUALQUIER respuesta que envíes a Telegram, agregá SIEMPRE un resumen breve tipo conclusión de lo que está pasando, en formato sencillo. Reglas del cierre:
    - Va separado del cuerpo con una línea \`---\` y arranca con el prefijo \`📌 En resumen:\`.
    - 1 a 3 frases cortas, lenguaje llano (sin tecnicismos innecesarios), como para entender el panorama de un vistazo.
    - NO repite literal el detalle de arriba: lo comprime en una conclusión.


### PR DESCRIPTION
## Resumen
- ajusta la persona del Commander para que el fallback no narre procedimiento interno antes de responder
- conserva como regla obligatoria el cierre con resumen para Telegram
- agrega regresión sobre el contrato de salida del Commander

## Verificación
- node --test .pipeline\\lib\\commander\\__tests__\\*.test.js