### PR TITLE
fix(commander): fail-open ante rojo transitorio + reintento de cadena ante respuesta vacia

### DIFF
--- a/.pipeline/lib/__tests__/commander-multi-provider.test.js
+++ b/.pipeline/lib/__tests__/commander-multi-provider.test.js
@@ -206,6 +206,84 @@ test('CA-7 — Claude libre → resuelve primary (anthropic), sin fallback', () 
 });
 
 // -----------------------------------------------------------------------------
+// Fix 2 — reintento de cadena ante respuesta vacía / spawn fallido
+// (incidente Cerebras empty_output 2026-06-05).
+//
+// Antes, si el provider EFECTIVO devolvía vacío o no se podía spawnear, el
+// Commander cortaba seco con un canned y NO probaba el siguiente eslabón de la
+// cascada. Ahora `ejecutarClaude` re-resuelve la cadena excluyendo TODOS los
+// providers ya intentados (`resolveCommanderProviderExcluding(triedArray)`) y
+// reintenta con el siguiente; sólo cuando no queda ninguno responde limpio
+// (`cannedAllGatedResponse`). Estos tests cubren ese seam de re-resolución.
+// -----------------------------------------------------------------------------
+
+test('Fix2 — provider efectivo falla (empty_output) → re-resuelve y avanza al siguiente non-anthropic', () => {
+    const dir = mkTmpPipelineDir();
+    try {
+        // Sólo anthropic gated → el efectivo del turno es codex. codex devuelve
+        // vacío: re-resolvemos excluyendo codex, anthropic sigue gated por cuota.
+        const fakeQuota = makeFakeQuotaModule(['anthropic']);
+        const next = cmp.resolveCommanderProviderExcluding(['openai-codex'], {
+            pipelineDir: dir,
+            skill: 'telegram-commander',
+            quotaModule: fakeQuota,
+            log: () => {},
+            issue: 'commander-chat',
+        });
+        assert.equal(next.gated, false, 'aún queda cerebras libre en la cadena');
+        assert.equal(next.provider, 'cerebras');
+        assert.notEqual(next.provider, 'anthropic');
+        assert.notEqual(next.provider, 'openai-codex');
+    } finally {
+        cleanup(dir);
+    }
+});
+
+test('Fix2 — todos los non-anthropic ya intentados → cadena agotada → canned all-gated', () => {
+    const dir = mkTmpPipelineDir();
+    try {
+        // Caso real del incidente: anthropic + codex apagados, efectivo cerebras,
+        // cerebras devuelve vacío. Re-resolver excluyendo cerebras (los tried) y
+        // con anthropic+codex gated por cuota → no queda ningún provider.
+        const fakeQuota = makeFakeQuotaModule(['anthropic', 'openai-codex']);
+        const next = cmp.resolveCommanderProviderExcluding(['cerebras'], {
+            pipelineDir: dir,
+            skill: 'telegram-commander',
+            quotaModule: fakeQuota,
+            log: () => {},
+            issue: 'commander-chat',
+        });
+        assert.equal(next.gated, true, 'cadena entera agotada → gated');
+        assert.equal(next.source, 'all-gated');
+        // Mensaje limpio al usuario (no el "no pude completar" seco de antes).
+        const canned = cmp.cannedAllGatedResponse();
+        assert.match(canned, /sin cuota disponible/);
+    } finally {
+        cleanup(dir);
+    }
+});
+
+test('Fix2 — exclusión por ARRAY descarta varios providers de una (tried acumulado)', () => {
+    const dir = mkTmpPipelineDir();
+    try {
+        // Sin cuotas gateadas, pero ya intentamos codex Y cerebras (ambos
+        // fallaron). Excluyendo el array completo no queda non-anthropic libre.
+        const fakeQuota = makeFakeQuotaModule(['anthropic']);
+        const next = cmp.resolveCommanderProviderExcluding(['openai-codex', 'cerebras'], {
+            pipelineDir: dir,
+            skill: 'telegram-commander',
+            quotaModule: fakeQuota,
+            log: () => {},
+            issue: 'commander-chat',
+        });
+        assert.equal(next.gated, true, 'array de exclusión saca a codex y cerebras');
+        assert.equal(next.source, 'all-gated');
+    } finally {
+        cleanup(dir);
+    }
+});
+
+// -----------------------------------------------------------------------------
 // CA-5 — formatFallbackNotice (UX-G1)
 // -----------------------------------------------------------------------------
 

--- a/.pipeline/lib/agent-launcher/dispatch-with-fallback.js
+++ b/.pipeline/lib/agent-launcher/dispatch-with-fallback.js
@@ -442,6 +442,28 @@ function readAgentModelsRaw(pipelineDir, fsImpl) {
 // más viejo que esto se considera no-confiable → fail-open (no gatea).
 const HEALTH_FRESHNESS_MS = 20 * 60 * 1000;
 
+// Refinamiento del fail-open (incidente Gemini timeout 2026-06-05): un rojo
+// FRESCO sólo debe gatear si su causa es DURABLE — el provider seguirá caído
+// hasta intervención (credencial inválida, sin key, binario CLI ausente,
+// provider mal declarado). Un rojo TRANSITORIO (timeout, network blip, 5xx,
+// rate-limit puntual) es exactamente la incertidumbre que la política fail-open
+// quiere preservar: el provider pudo recuperarse entre el ping del cron y este
+// spawn. Gatearlo por un timeout lo saca de la cascada hasta 20min aunque ya
+// esté sano (Gemini quedó rojo por un timeout y la cascada saltó a Cerebras
+// aunque Gemini ya respondía 200). Ante causa NO-durable → fail-open.
+//
+// Los reason_code provienen de `health-alerts.sanitizeReasonCode` (allowlist
+// cerrada en live-ping/health-alerts). Sólo estos justifican gatear:
+const DURABLE_RED_REASONS = Object.freeze(new Set([
+    'invalid_credentials',     // key incorrecta — no se arregla sola
+    'forbidden',               // 403 persistente
+    'no_key_configured',       // sin credencial declarada
+    'unknown_provider',        // misconfig
+    'cli_unavailable',         // binario CLI ausente del PATH
+    'cli_binary_undeclared',   // provider CLI sin binario declarado
+    'quota_exhausted',         // sin cuota — el flag de cuota ya lo cubre, doble defensa
+]));
+
 // El health-cron nombra a OpenAI/Codex como 'openai', pero la config de skills
 // (agent-models.json) usa la key 'openai-codex'. Mapeamos provider-key → nombre
 // en el snapshot de health. Si no hay alias, se busca por la key tal cual.
@@ -489,8 +511,16 @@ function evaluateHealthGate(providerKey, healthSnapshot, now) {
         result.reason = 'red_stale';            // rojo viejo o reloj desfasado → fail-open
         return result;
     }
-    result.gated = true;                        // rojo fresco y confiable → gatear
-    result.reason = entry.reason_code || 'red_fresh';
+    // Rojo fresco PERO la causa decide: sólo gateamos si es durable. Un rojo
+    // transitorio (timeout/network/5xx) no debe sacar a un provider que pudo
+    // recuperarse de la cascada — fail-open preservando cobertura.
+    const reasonCode = entry.reason_code || null;
+    if (!DURABLE_RED_REASONS.has(reasonCode)) {
+        result.reason = 'red_transient';        // rojo fresco pero causa no-durable → fail-open
+        return result;
+    }
+    result.gated = true;                        // rojo fresco, confiable y durable → gatear
+    result.reason = reasonCode || 'red_fresh';
     return result;
 }
 
@@ -1340,6 +1370,7 @@ module.exports = {
     evaluateHealthGate,
     HEALTH_FRESHNESS_MS,
     HEALTH_PROVIDER_ALIAS,
+    DURABLE_RED_REASONS,
 
     // #3576 — Hook generalizado post-spawn cross-skill.
     onSpawnExit,

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -8102,115 +8102,215 @@ function ejecutarClaude(prompt, textoOriginal, trace, fallbackParts) {
     // hasta #3198 — `buildSpawn` tira `_notImplemented`. En ese caso, audit
     // log + respondemos canned al usuario sin matar el flow.
     if (resolution.provider !== 'anthropic') {
-      // Los adapters no-Anthropic (codex, gemini, cerebras, nvidia) toman el
-      // prompt del VALOR de `-p` en los args (`userPrompt = args[i+1]`) y abren
-      // stdin como 'ignore'. El `args` legacy de arriba trae `-p` PELADO porque
-      // el path Anthropic manda el prompt por stdin — así el adapter levantaba
-      // `--output-format` como prompt basura y el pedido real se perdía en un
-      // stdin que el provider nunca lee. Armamos un argv propio con el prompt
-      // sanitizado como valor de `-p` para que cada handler lo reciba completo.
+      // ---------------------------------------------------------------------
+      // Reintento de cadena ante respuesta vacía / spawn fallido (incidente
+      // Cerebras empty_output 2026-06-05). Antes, si el provider efectivo
+      // devolvía vacío o no se podía spawnear, cortábamos seco con un mensaje
+      // canned y NO probábamos el siguiente eslabón de la cascada (ej. tras
+      // cerebras quedaba nvidia-nim sin usar). Ahora, ante empty_output /
+      // spawn-error / no_implemented / data-residency, re-resolvemos la cadena
+      // excluyendo el provider que falló y reintentamos con el siguiente, hasta
+      // agotar la cascada. Sólo cuando NO queda ningún provider damos el
+      // mensaje limpio.
       //
-      // Personalidad consistente en el fallback: cuando el caller separa la
-      // persona del Commander (`fallbackParts.systemPrompt`) del mensaje del
-      // usuario (`fallbackParts.userMessage`), persistimos la persona a un
-      // archivo y la pasamos como `--system-prompt-file`. Los adapters la
-      // foldean al inicio del prompt (codex) o la mandan como system real
-      // (gemini/cerebras/nvidia), así la identidad/estilo del Commander NO
-      // cambia por usar un provider de respaldo. Si el caller no separa partes,
-      // mantenemos el comportamiento previo (prompt completo en `-p`).
-      let fallbackArgs;
-      if (fallbackParts && typeof fallbackParts.systemPrompt === 'string'
-          && typeof fallbackParts.userMessage === 'string'
-          && fallbackParts.systemPrompt && fallbackParts.userMessage) {
-        const userMsgForLLM = commanderMP.sanitizeUserPrompt(fallbackParts.userMessage).sanitized;
-        let sysFile = null;
+      // Los adapters no-Anthropic toman el prompt del VALOR de `-p` y abren
+      // stdin como 'ignore'. Persona consistente: si el caller separó
+      // `fallbackParts.systemPrompt`/`userMessage`, la persona va por
+      // `--system-prompt-file` (codex la foldea, el resto la manda como system
+      // real) para que la identidad del Commander NO cambie por usar respaldo.
+      // ---------------------------------------------------------------------
+      const triedNonAnthropic = new Set();
+
+      const buildEnvFor = (prov) => {
+        let e;
+        if (commanderEnvIsolation) {
+          e = buildChildEnvLib.buildChildEnv({
+            skill: commanderMP.COMMANDER_SKILL,
+            pipelineDir: PIPELINE,
+            processEnv: process.env,
+            pipelineExtras: { CLAUDE_PROJECT_DIR: ROOT },
+            skillConfigOverride: { provider: prov },
+          });
+        } else {
+          e = { ...process.env, CLAUDE_PROJECT_DIR: ROOT };
+        }
+        delete e.CLAUDECODE;
+        return e;
+      };
+
+      const buildFallbackArgs = () => {
+        if (fallbackParts && typeof fallbackParts.systemPrompt === 'string'
+            && typeof fallbackParts.userMessage === 'string'
+            && fallbackParts.systemPrompt && fallbackParts.userMessage) {
+          const userMsgForLLM = commanderMP.sanitizeUserPrompt(fallbackParts.userMessage).sanitized;
+          let sysFile = null;
+          try {
+            sysFile = path.join(PIPELINE, 'commander-system-prompt.md');
+            fs.writeFileSync(sysFile, fallbackParts.systemPrompt, 'utf8');
+          } catch { sysFile = null; }
+          return sysFile
+            ? ['-p', userMsgForLLM, '--system-prompt-file', sysFile]
+            : ['-p', promptForLLM];
+        }
+        return ['-p', promptForLLM];
+      };
+
+      // Re-resuelve la cadena excluyendo todos los providers ya intentados y
+      // reintenta con el siguiente; si no queda ninguno, responde limpio.
+      const advanceOrGiveUp = (failedProvider, reason) => {
+        let next = null;
         try {
-          sysFile = path.join(PIPELINE, 'commander-system-prompt.md');
-          fs.writeFileSync(sysFile, fallbackParts.systemPrompt, 'utf8');
-        } catch { sysFile = null; }
-        fallbackArgs = sysFile
-          ? ['-p', userMsgForLLM, '--system-prompt-file', sysFile]
-          : ['-p', promptForLLM];
-      } else {
-        fallbackArgs = ['-p', promptForLLM];
-      }
-      const safe = commanderMP.safeBuildSpawn({
-        handler: resolution.handler,
-        args: fallbackArgs,
-        cwd: ROOT,
-        env: cleanEnv,
-      });
-      try {
-        commanderMP.auditCommanderRequest({
-          pipelineDir: PIPELINE,
-          event: safe.ok ? 'fallback_used' : 'fallback_unavailable',
-          providerIntended: resolution.primaryProvider || 'anthropic',
-          providerEffective: resolution.provider,
-          chainTried: resolution.chainTried,
-          chatId: getTelegramChatId(),
-          prompt: prompt,
-          latencyMs: Date.now() - startTimeForAudit,
-          errorCode: safe.ok ? null : 'not_implemented',
-          injectionHits: sanRes.hits,
-          requestId: turnRequestId, // #3577 CA-S6
-        });
-      } catch { /* best-effort */ }
-      if (!safe.ok) {
-        log('commander', `⚠️ Fallback provider "${resolution.provider}" no implementado (${safe.reason}). Respondiendo canned.`);
-        return resolve(commanderMP.cannedFallbackUnavailableResponse({ provider: resolution.provider }));
-      }
-      // Si #3198 está deployed y el handler real funciona, llegamos acá. La
-      // parsing de output stream-json de Anthropic NO aplica directamente a
-      // otros providers (cada uno tiene su `output_parser`). Esta es la
-      // observación G1/G2 que dejamos para una iteración futura — por ahora
-      // si el handler responde con buildSpawn pero el output no es
-      // stream-json, capturamos stdout crudo y lo devolvemos al usuario.
-      const proc = spawn(safe.spawnDef.cmd, safe.spawnDef.args, safe.spawnDef.spawnOpts);
-      // El prompt ya viaja como valor de `-p` en los args del handler; estos
-      // providers abren stdin como 'ignore', así que no escribimos por ahí.
-      // Cerramos stdin sólo si el handler lo dejó abierto (interactive).
-      proc.stdin && proc.stdin.end && proc.stdin.end();
-      let stdout = '';
-      let stderr = '';
-      const startNon = Date.now();
-      const HARD_NON_ANTH_MS = 90 * 1000; // SR-5 — budget 90s para providers no-stream-json
-      const timer = setTimeout(() => {
-        try { proc.kill('SIGTERM'); } catch {}
-        log('commander', `Provider ${resolution.provider} timeout 90s — abortando`);
-      }, HARD_NON_ANTH_MS);
-      proc.stdout && proc.stdout.on('data', (d) => { stdout += d.toString(); });
-      proc.stderr && proc.stderr.on('data', (d) => { stderr += d.toString(); });
-      proc.on('close', () => {
-        clearTimeout(timer);
-        const elapsed = Date.now() - startNon;
-        // Los providers no-Anthropic emiten JSONL (un evento por línea), no
-        // texto plano. Extraemos SÓLO el/los `agent_message` finales para que a
-        // Telegram llegue un único mensaje conversacional — y no el stream de
-        // eventos crudo, que el TTS partía en una lluvia de audios técnicos.
-        const extracted = commanderMP.extractFallbackReply(stdout);
-        log('commander', `Provider ${resolution.provider} terminó (${elapsed}ms, stdout=${stdout.length}c, reply=${extracted.text.length}c, parsed=${extracted.parsed}, stderr=${stderr.length}c)`);
+          next = commanderMP.resolveCommanderProviderExcluding(Array.from(triedNonAnthropic), {
+            skill: commanderMP.COMMANDER_SKILL,
+            pipelineDir: PIPELINE,
+            log: (l, m) => log(l || 'commander', m),
+            issue: 'commander-chat',
+          });
+        } catch (e) {
+          log('commander', `⚠️ re-resolución de cadena tras "${failedProvider}" falló: ${e.message}`);
+        }
+        if (next && !next.gated && next.provider
+            && next.provider !== 'anthropic'
+            && !triedNonAnthropic.has(next.provider)) {
+          log('commander', `↪️ fallback "${failedProvider}" ${reason} — reintento con "${next.provider}"`);
+          return runNonAnthropic(next, null);
+        }
+        log('commander', `🚫 Cadena de respaldo agotada tras "${failedProvider}" (${reason}); sin más providers disponibles.`);
         try {
           commanderMP.auditCommanderRequest({
             pipelineDir: PIPELINE,
-            event: 'fallback_used',
+            event: 'fallback_chain_exhausted',
             providerIntended: resolution.primaryProvider || 'anthropic',
-            providerEffective: resolution.provider,
-            chainTried: resolution.chainTried,
+            providerEffective: failedProvider,
+            chainTried: Array.from(triedNonAnthropic),
             chatId: getTelegramChatId(),
             prompt: prompt,
-            latencyMs: elapsed,
-            errorCode: extracted.text ? null : 'empty_output',
+            latencyMs: Date.now() - startTimeForAudit,
+            errorCode: reason,
             requestId: turnRequestId, // #3577 CA-S6
           });
         } catch { /* best-effort */ }
-        resolve(extracted.text || `No pude completar tu pedido vía ${resolution.provider}. Intentá de nuevo.`);
-      });
-      proc.on('error', (e) => {
-        clearTimeout(timer);
-        log('commander', `Error spawning ${resolution.provider}: ${e.message}`);
-        resolve(commanderMP.cannedFallbackUnavailableResponse({ provider: resolution.provider }));
-      });
-      return;
+        return resolve(commanderMP.cannedAllGatedResponse());
+      };
+
+      const runNonAnthropic = (res, preEnv) => {
+        triedNonAnthropic.add(res.provider);
+
+        let attemptEnv;
+        try {
+          attemptEnv = preEnv || buildEnvFor(res.provider);
+        } catch (e) {
+          log('commander', `❌ env-isolation rechazó spawn (provider=${res.provider}): ${e.message}`);
+          return advanceOrGiveUp(res.provider, 'env_isolation_error');
+        }
+
+        // Data-residency por provider: los retries no pasaron por el check
+        // del provider inicial, así que re-chequeamos para cada candidato.
+        const drCheck2 = commanderMP.enforceDataResidency({
+          pipelineDir: PIPELINE,
+          provider: res.provider,
+          paths: [],
+          chatId: getTelegramChatId(),
+          prompt: prompt,
+          log: (l, m) => log(l || 'commander', m),
+        });
+        if (!drCheck2.ok) {
+          log('commander', `🚫 data-residency bloqueó "${res.provider}" (${drCheck2.reason}) — intento siguiente provider.`);
+          return advanceOrGiveUp(res.provider, 'data_residency_blocked');
+        }
+
+        const safe = commanderMP.safeBuildSpawn({
+          handler: res.handler,
+          args: buildFallbackArgs(),
+          cwd: ROOT,
+          env: attemptEnv,
+        });
+        if (!safe.ok) {
+          try {
+            commanderMP.auditCommanderRequest({
+              pipelineDir: PIPELINE,
+              event: 'fallback_unavailable',
+              providerIntended: resolution.primaryProvider || 'anthropic',
+              providerEffective: res.provider,
+              chainTried: Array.from(triedNonAnthropic),
+              chatId: getTelegramChatId(),
+              prompt: prompt,
+              latencyMs: Date.now() - startTimeForAudit,
+              errorCode: 'not_implemented',
+              injectionHits: sanRes.hits,
+              requestId: turnRequestId, // #3577 CA-S6
+            });
+          } catch { /* best-effort */ }
+          log('commander', `⚠️ Fallback provider "${res.provider}" no implementado (${safe.reason}) — intento siguiente.`);
+          return advanceOrGiveUp(res.provider, 'not_implemented');
+        }
+
+        // Si #3198 está deployed y el handler real funciona, llegamos acá. Los
+        // providers no-Anthropic emiten JSONL (un evento por línea), no texto
+        // plano; `extractFallbackReply` saca SÓLO el/los `agent_message`
+        // finales para que a Telegram llegue un único mensaje conversacional.
+        const proc = spawn(safe.spawnDef.cmd, safe.spawnDef.args, safe.spawnDef.spawnOpts);
+        proc.stdin && proc.stdin.end && proc.stdin.end();
+        let stdout = '';
+        let stderr = '';
+        const startNon = Date.now();
+        const HARD_NON_ANTH_MS = 90 * 1000; // SR-5 — budget 90s para providers no-stream-json
+        const timer = setTimeout(() => {
+          try { proc.kill('SIGTERM'); } catch {}
+          log('commander', `Provider ${res.provider} timeout 90s — abortando`);
+        }, HARD_NON_ANTH_MS);
+        proc.stdout && proc.stdout.on('data', (d) => { stdout += d.toString(); });
+        proc.stderr && proc.stderr.on('data', (d) => { stderr += d.toString(); });
+        proc.on('close', () => {
+          clearTimeout(timer);
+          const elapsed = Date.now() - startNon;
+          const extracted = commanderMP.extractFallbackReply(stdout);
+          log('commander', `Provider ${res.provider} terminó (${elapsed}ms, stdout=${stdout.length}c, reply=${extracted.text.length}c, parsed=${extracted.parsed}, stderr=${stderr.length}c)`);
+          if (extracted.text) {
+            try {
+              commanderMP.auditCommanderRequest({
+                pipelineDir: PIPELINE,
+                event: 'fallback_used',
+                providerIntended: resolution.primaryProvider || 'anthropic',
+                providerEffective: res.provider,
+                chainTried: Array.from(triedNonAnthropic),
+                chatId: getTelegramChatId(),
+                prompt: prompt,
+                latencyMs: elapsed,
+                errorCode: null,
+                requestId: turnRequestId, // #3577 CA-S6
+              });
+            } catch { /* best-effort */ }
+            return resolve(extracted.text);
+          }
+          // Respuesta vacía → audit + intentar el siguiente provider de la
+          // cadena en vez de cortar seco.
+          try {
+            commanderMP.auditCommanderRequest({
+              pipelineDir: PIPELINE,
+              event: 'fallback_used',
+              providerIntended: resolution.primaryProvider || 'anthropic',
+              providerEffective: res.provider,
+              chainTried: Array.from(triedNonAnthropic),
+              chatId: getTelegramChatId(),
+              prompt: prompt,
+              latencyMs: elapsed,
+              errorCode: 'empty_output',
+              requestId: turnRequestId, // #3577 CA-S6
+            });
+          } catch { /* best-effort */ }
+          log('commander', `Provider ${res.provider} devolvió vacío (empty_output) — intento siguiente provider.`);
+          return advanceOrGiveUp(res.provider, 'empty_output');
+        });
+        proc.on('error', (e) => {
+          clearTimeout(timer);
+          log('commander', `Error spawning ${res.provider}: ${e.message} — intento siguiente provider.`);
+          return advanceOrGiveUp(res.provider, 'spawn_error');
+        });
+      };
+
+      // Primer intento: reusamos el env ya construido para el provider inicial.
+      return runNonAnthropic(resolution, cleanEnv);
     }
 
     // Path por default: Anthropic. Comportamiento byte-equivalente al previo.

--- a/.pipeline/tests/health-gate-3809.test.js
+++ b/.pipeline/tests/health-gate-3809.test.js
@@ -3,7 +3,9 @@
 //
 // Cubre:
 //   A. MP-09 health-gate FAIL-OPEN (unit sobre evaluateHealthGate):
-//      - rojo fresco y confiable → gateado.
+//      - rojo fresco y DURABLE (credenciales/config) → gateado.
+//      - rojo fresco pero TRANSITORIO (timeout/network/unknown) → NO gateado
+//        (fail-open — incidente Gemini timeout 2026-06-05).
 //      - rojo viejo (fuera de la ventana) → NO gateado (fail-open).
 //      - rojo sin timestamp → NO gateado.
 //      - verde → NO gateado.
@@ -47,7 +49,12 @@ function healthEntry(provider, state, ageMs, extra = {}) {
     return {
         provider,
         state,
-        reason_code: extra.reason_code || (state === 'red' ? 'live_ping_failed' : 'authenticated'),
+        // Default DURABLE para reds: estos tests asumen un rojo que debe gatear.
+        // El refinamiento del fail-open (incidente Gemini timeout) sólo gatea
+        // reds con causa durable (credenciales/config); los transitorios hacen
+        // fail-open. Para no reescribir cada caso, el default es durable y los
+        // tests de transitorio pasan reason_code explícito (timeout/unknown).
+        reason_code: extra.reason_code || (state === 'red' ? 'invalid_credentials' : 'authenticated'),
         last_checked_at: ('last_checked_at' in extra) ? extra.last_checked_at : checkedAt,
         ...extra,
     };
@@ -192,6 +199,35 @@ test('A8 · snapshot null/ilegible → NO gateado (fail-open)', () => {
     assert.equal(evaluateHealthGate('cerebras', { providers: 'x' }, NOW).gated, false);
 });
 
+test('A9 · rojo FRESCO pero TRANSITORIO (timeout) → NO gateado (fail-open, caso Gemini)', () => {
+    // Gemini quedó rojo por un timeout puntual y se recuperó minutos después,
+    // pero el rojo cacheado lo sacaba de la cascada hasta 20min. Un timeout es
+    // incertidumbre, no una falla durable → fail-open.
+    const snap = healthSnapshot([healthEntry('gemini-google', 'red', 60 * 1000, { reason_code: 'timeout' })]);
+    const r = evaluateHealthGate('gemini-google', snap, NOW);
+    assert.equal(r.gated, false, 'timeout es transitorio → no gatea');
+    assert.equal(r.reason, 'red_transient');
+    assert.equal(r.state, 'red');
+});
+
+test('A9b · rojo FRESCO transitorio (network_error/unknown) → NO gateado (fail-open)', () => {
+    for (const reason of ['network_error', 'unknown', 'rate_limited']) {
+        const snap = healthSnapshot([healthEntry('cerebras', 'red', 60 * 1000, { reason_code: reason })]);
+        const r = evaluateHealthGate('cerebras', snap, NOW);
+        assert.equal(r.gated, false, `${reason} es transitorio → no gatea`);
+        assert.equal(r.reason, 'red_transient');
+    }
+});
+
+test('A10 · rojo FRESCO y DURABLE (no_key_configured/forbidden) → gateado', () => {
+    for (const reason of ['no_key_configured', 'forbidden', 'invalid_credentials', 'unknown_provider']) {
+        const snap = healthSnapshot([healthEntry('cerebras', 'red', 60 * 1000, { reason_code: reason })]);
+        const r = evaluateHealthGate('cerebras', snap, NOW);
+        assert.equal(r.gated, true, `${reason} es durable → gatea`);
+        assert.equal(r.reason, reason);
+    }
+});
+
 // =============================================================================
 // B. Integración con resolveSpawnWithFallback
 // =============================================================================
@@ -277,6 +313,35 @@ test('B3 · el primario NUNCA se health-gatea (aunque esté rojo-fresco)', () =>
     assert.notEqual(r.source, 'fallback', 'no degradó a un fallback por health del primario');
     assert.equal(r.gated, false);
     assert.equal(r.crossProvider, false);
+});
+
+test('B5 · fallback rojo-fresco TRANSITORIO (timeout) se USA igual (caso Gemini en la cascada)', () => {
+    const models = modelsWithChain('anthropic', [
+        { provider: 'gemini-google', model_override: 'gemini-2.0-flash' },
+        { provider: 'cerebras', model_override: 'gpt-oss-120b' },
+    ]);
+    const audit = fakeAuditLog();
+    const snap = healthSnapshot([
+        healthEntry('gemini-google', 'red', 60 * 1000, { reason_code: 'timeout' }), // rojo fresco PERO transitorio
+        healthEntry('cerebras', 'green', 60 * 1000),
+    ]);
+    const r = resolveSpawnWithFallback({
+        skill: 'test-skill',
+        issue: ISSUE,
+        pipelineDir: PIPELINE_DIR,
+        fsImpl: fakeFsWithModels(models),
+        quotaModule: fakeQuotaGatePrimary('anthropic'),
+        primaryResolver: fakeResolver,
+        providerHandlerResolver: fakeProviderHandlerResolver(),
+        auditLog: audit,
+        notify: fakeNotify(),
+        healthReader: () => snap,
+        now: NOW,
+    });
+    assert.equal(r.provider, 'gemini-google', 'rojo por timeout NO saca a Gemini de la cascada (fail-open)');
+    assert.equal(r.source, 'fallback');
+    assert.ok(!audit.entries.find(e => e.event === 'fallback_health_gated'),
+        'no se emitió health-gate para un rojo transitorio');
 });
 
 test('B4 · healthReader que tira → fail-open (no rompe la resolución)', () => {


### PR DESCRIPTION
## Qué resuelve

Dos correcciones al fallback multi-provider del Commander, detectadas probando la cascada con Anthropic/Codex apagados (2026-06-05).

### Fix 1 — fail-open ante rojo transitorio
Un provider marcado en ROJO por el monitor de salud sólo se saltea de la cascada si la causa es **durable** (credencial inválida, sin key, sin cuota, CLI ausente, misconfig). Si el rojo fue **transitorio** (timeout, network blip, 5xx, rate-limit puntual) se sigue intentando, porque pudo recuperarse entre el ping del cron y el spawn.

**Incidente:** Gemini quedó rojo por un timeout puntual y a los 2min volvió a verde (HTTP 200), pero el rojo cacheado lo dejó fuera de la cascada ~20min y el fallback saltó a Cerebras.

Archivos: `dispatch-with-fallback.js` (`evaluateHealthGate` + `DURABLE_RED_REASONS`).

### Fix 2 — reintento de cadena ante respuesta vacía
Si el provider efectivo devolvía vacío (`empty_output`), no se podía spawnear, o no estaba implementado, el Commander cortaba seco con un canned y **no probaba el siguiente eslabón**. Ahora re-resuelve la cadena excluyendo los providers ya intentados y reintenta con el próximo, hasta agotar la cascada; sólo entonces responde limpio (`cannedAllGatedResponse`).

**Incidente:** Cerebras (`gpt-oss-120b`) devolvió respuesta vacía y el flujo terminó con "No pude completar tu pedido" sin probar el resto.

Archivos: `pulpo.js` (`ejecutarClaude` → `advanceOrGiveUp`/`runNonAnthropic`).

## Regresión
- `health-gate-3809.test.js`: A9/A9b/A10 (durable vs transitorio en `evaluateHealthGate`) + B5 (transitorio se usa igual en la cascada).
- `commander-multi-provider.test.js`: 3 tests nuevos del seam de re-resolución (avanza al siguiente non-anthropic / cadena agotada → canned / exclusión por array).

Suites verde: commander-multi-provider 33/33, health-gate + dispatch 47/47.

## QA
qa:skipped — cambio de infra interna del pipeline (lógica de fallback del Commander de Telegram), sin impacto en el producto de usuario final.