### PR TITLE
fix(pipeline): paridad de guardrail + contexto para providers API-pelados en agentes

### DIFF
--- a/.pipeline/lib/agent-launcher/__tests__/agent-system-prompt-api-pelada.test.js
+++ b/.pipeline/lib/agent-launcher/__tests__/agent-system-prompt-api-pelada.test.js
@@ -1,0 +1,96 @@
+// =============================================================================
+// agent-system-prompt-api-pelada.test.js — Paridad agente ↔ Commander.
+//
+// Contexto: el Commander ya aumenta su system prompt con guardrail
+// anti-alucinación + contexto del proyecto cuando cae a un provider integrado
+// como API REST pelada (cerebras, nvidia-nim) — incidente Cerebras/Whisper
+// 2026-06-05, PR #3838. Este test bloquea la regresión de que el spawn de un
+// AGENTE del pipeline (sherlock, devs, qa, etc.) haga lo mismo: cuando la
+// resolución de provider devuelve un API-pelado, su system prompt también debe
+// llevar el pack; y para los agénticos (anthropic/openai-codex/gemini-google)
+// debe quedar intacto (no-op).
+//
+// Replica la lógica de wiring de pulpo.js (función de spawn del agente):
+//   systemContent = augmentSystemPromptForProvider(`${base}\n\n${rol}`,
+//                       dispatchResolution.provider, { root: ROOT });
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+    augmentSystemPromptForProvider,
+    isApiPeladaProvider,
+    _GUARDRAIL,
+} = require('../../commander/api-context-pack');
+
+// fsImpl falso con una doc de proyecto controlada (no dependemos del CLAUDE.md
+// real del repo para que el test sea hermético).
+function fakeFs(docContent) {
+    return {
+        readFileSync(p) {
+            if (String(p).endsWith('CLAUDE.md')) {
+                if (docContent == null) throw new Error('ENOENT');
+                return docContent;
+            }
+            throw new Error('unexpected read: ' + p);
+        },
+    };
+}
+
+// Reproduce el snippet de wiring de pulpo.js para el spawn del agente.
+function buildAgentSystemContent(base, rol, dispatchResolution, opts) {
+    const effectiveProvider = (dispatchResolution && dispatchResolution.provider) || null;
+    return augmentSystemPromptForProvider(`${base}\n\n${rol}`, effectiveProvider, opts);
+}
+
+const BASE = '# _base.md\nReglas comunes de todos los agentes.';
+const ROL = '# sherlock.md\nSos el verificador del pipeline.';
+
+test('agente con provider API-pelado (cerebras) recibe guardrail + contexto', () => {
+    const out = buildAgentSystemContent(BASE, ROL, { provider: 'cerebras' }, {
+        root: '/repo',
+        fsImpl: fakeFs('# CLAUDE.md\nMonorepo Kotlin Ktor + Compose.'),
+    });
+    assert.ok(out.startsWith(`${BASE}\n\n${ROL}`), 'el rol original queda al inicio');
+    assert.ok(out.includes(_GUARDRAIL), 'incluye el guardrail anti-alucinación');
+    assert.ok(out.includes('CONTEXTO DEL PROYECTO'), 'incluye el bloque de contexto');
+    assert.ok(out.includes('Monorepo Kotlin'), 'incluye el extracto de CLAUDE.md');
+});
+
+test('agente con nvidia-nim también recibe el pack', () => {
+    const out = buildAgentSystemContent(BASE, ROL, { provider: 'nvidia-nim' }, {
+        root: '/repo',
+        fsImpl: fakeFs('# CLAUDE.md\nbla'),
+    });
+    assert.ok(out.includes(_GUARDRAIL));
+});
+
+test('agente con provider agéntico no toca el system prompt (no-op)', () => {
+    for (const prov of ['anthropic', 'openai-codex', 'gemini-google']) {
+        const out = buildAgentSystemContent(BASE, ROL, { provider: prov }, {
+            root: '/repo',
+            fsImpl: fakeFs('# CLAUDE.md\nbla'),
+        });
+        assert.equal(out, `${BASE}\n\n${ROL}`, `no toca el system prompt con ${prov}`);
+    }
+});
+
+test('resolución sin provider (null) es no-op seguro', () => {
+    const out = buildAgentSystemContent(BASE, ROL, null, {
+        root: '/repo',
+        fsImpl: fakeFs('# CLAUDE.md\nbla'),
+    });
+    assert.equal(out, `${BASE}\n\n${ROL}`);
+    assert.ok(!isApiPeladaProvider(null));
+});
+
+test('el guardrail va aunque CLAUDE.md no se pueda leer', () => {
+    const out = buildAgentSystemContent(BASE, ROL, { provider: 'cerebras' }, {
+        root: '/repo',
+        fsImpl: fakeFs(null),
+    });
+    assert.ok(out.includes(_GUARDRAIL), 'el guardrail es lo crítico y va siempre');
+    assert.ok(out.startsWith(`${BASE}\n\n${ROL}`), 'el rol queda intacto al inicio');
+});

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -5576,7 +5576,28 @@ function lanzarAgenteClaude(skill, issue, trabajandoPath, pipeline, fase, config
 
   // Escribir system prompt (rol) a archivo y user prompt corto como argumento
   const systemFile = path.join(LOG_DIR, `agent-${issue}-${skill}-system.txt`);
-  fs.writeFileSync(systemFile, `${base}\n\n${rol}`);
+  // Paridad con el Commander (incidente Cerebras/Whisper 2026-06-05): si el
+  // spawn de este agente cae a un provider integrado como API REST pelada
+  // (cerebras, nvidia-nim), el agente TAMPOCO ve el filesystem, los logs ni el
+  // runtime — sólo recibe el texto del system + user prompt. Igual que el
+  // Commander, ante preguntas/decisiones de estado en vivo tiende a alucinar.
+  // Le aumentamos el system prompt con el MISMO guardrail anti-alucinación +
+  // extracto de CLAUDE.md. Es no-op para los providers agénticos (anthropic,
+  // openai-codex, gemini-google), que ya investigan el repo de verdad.
+  let systemContent = `${base}\n\n${rol}`;
+  try {
+    const effectiveProvider = (dispatchResolution && dispatchResolution.provider) || null;
+    systemContent = commanderApiContext.augmentSystemPromptForProvider(
+      systemContent, effectiveProvider, { root: ROOT });
+    if (commanderApiContext.isApiPeladaProvider(effectiveProvider)) {
+      log('lanzamiento', `🧱 ${skill}:#${issue} provider API-pelado "${effectiveProvider}": inyecto guardrail anti-alucinación + contexto del proyecto al system prompt.`);
+    }
+  } catch (augErr) {
+    // Best-effort: nunca bloquear el spawn por el augment. Cae al system base.
+    log('lanzamiento', `⚠️ ${skill}:#${issue} no se pudo aumentar el system prompt para provider API-pelado (best-effort): ${augErr.message}`);
+    systemContent = `${base}\n\n${rol}`;
+  }
+  fs.writeFileSync(systemFile, systemContent);
 
   // Construir user prompt — enriquecer si es un rebote con contexto del rechazo
   let userPrompt = `Archivo de trabajo: ${path.basename(trabajandoPath)}\nPath: ${trabajandoPath}\nContenido:\n${yaml.dump(workData, { lineWidth: -1 })}`;


### PR DESCRIPTION
## Qué

Extiende a **todos los agentes del pipeline** (sherlock, devs, qa, builder LLM, etc.) la misma defensa que el Commander recibió en #3838: cuando el spawn de un agente cae a un provider integrado como **API REST pelada** (`cerebras`, `nvidia-nim`), su system prompt se aumenta con el **guardrail anti-alucinación** + un **extracto de CLAUDE.md** como contexto del proyecto.

## Por qué

Incidente Cerebras/Whisper (2026-06-05): los providers API-pelados no ven el filesystem, los logs ni el runtime — sólo reciben el texto del prompt. Ante preguntas/decisiones de estado en vivo tienden a inventar una explicación plausible pero falsa. El Commander ya quedó cubierto en #3838; faltaba la misma cobertura para los agentes que también pueden caer a Cerebras/Nvidia al final de su cadena de fallback.

## Cambios

- `.pipeline/pulpo.js`: wiring en el spawn del agente. Reusa `commanderApiContext.augmentSystemPromptForProvider` con `dispatchResolution.provider` y `{ root: ROOT }`. **No-op** para providers agénticos (anthropic/openai-codex/gemini-google), que ya investigan el repo. Best-effort: nunca bloquea el spawn.
- Test de regresión de paridad agente↔Commander (5 casos: cerebras, nvidia-nim, agénticos no-op, provider null, guardrail sin CLAUDE.md).

## Validación

- `node --check .pipeline/pulpo.js` → OK
- 7/7 tests `api-context-pack` + 5/5 tests nuevos de paridad → verdes

Cambio puro de infra/pipeline interno, sin impacto en producto de usuario → `qa:skipped`.