### PR TITLE
fix: inyectar guardrail + contexto a providers API-pelados en spawn de agentes

### DIFF
--- a/.pipeline/lib/agent-launcher/__tests__/agent-system-prompt-api-pelada.test.js
+++ b/.pipeline/lib/agent-launcher/__tests__/agent-system-prompt-api-pelada.test.js
@@ -1,0 +1,96 @@
+// =============================================================================
+// agent-system-prompt-api-pelada.test.js — Paridad agente ↔ Commander.
+//
+// Contexto: el Commander ya aumenta su system prompt con guardrail
+// anti-alucinación + contexto del proyecto cuando cae a un provider integrado
+// como API REST pelada (cerebras, nvidia-nim) — incidente Cerebras/Whisper
+// 2026-06-05, PR #3838. Este test bloquea la regresión de que el spawn de un
+// AGENTE del pipeline (sherlock, devs, qa, etc.) haga lo mismo: cuando la
+// resolución de provider devuelve un API-pelado, su system prompt también debe
+// llevar el pack; y para los agénticos (anthropic/openai-codex/gemini-google)
+// debe quedar intacto (no-op).
+//
+// Replica la lógica de wiring de pulpo.js (función de spawn del agente):
+//   systemContent = augmentSystemPromptForProvider(`${base}\n\n${rol}`,
+//                       dispatchResolution.provider, { root: ROOT });
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+    augmentSystemPromptForProvider,
+    isApiPeladaProvider,
+    _GUARDRAIL,
+} = require('../../commander/api-context-pack');
+
+// fsImpl falso con una doc de proyecto controlada (no dependemos del CLAUDE.md
+// real del repo para que el test sea hermético).
+function fakeFs(docContent) {
+    return {
+        readFileSync(p) {
+            if (String(p).endsWith('CLAUDE.md')) {
+                if (docContent == null) throw new Error('ENOENT');
+                return docContent;
+            }
+            throw new Error('unexpected read: ' + p);
+        },
+    };
+}
+
+// Reproduce el snippet de wiring de pulpo.js para el spawn del agente.
+function buildAgentSystemContent(base, rol, dispatchResolution, opts) {
+    const effectiveProvider = (dispatchResolution && dispatchResolution.provider) || null;
+    return augmentSystemPromptForProvider(`${base}\n\n${rol}`, effectiveProvider, opts);
+}
+
+const BASE = '# _base.md\nReglas comunes de todos los agentes.';
+const ROL = '# sherlock.md\nSos el verificador del pipeline.';
+
+test('agente con provider API-pelado (cerebras) recibe guardrail + contexto', () => {
+    const out = buildAgentSystemContent(BASE, ROL, { provider: 'cerebras' }, {
+        root: '/repo',
+        fsImpl: fakeFs('# CLAUDE.md\nMonorepo Kotlin Ktor + Compose.'),
+    });
+    assert.ok(out.startsWith(`${BASE}\n\n${ROL}`), 'el rol original queda al inicio');
+    assert.ok(out.includes(_GUARDRAIL), 'incluye el guardrail anti-alucinación');
+    assert.ok(out.includes('CONTEXTO DEL PROYECTO'), 'incluye el bloque de contexto');
+    assert.ok(out.includes('Monorepo Kotlin'), 'incluye el extracto de CLAUDE.md');
+});
+
+test('agente con nvidia-nim también recibe el pack', () => {
+    const out = buildAgentSystemContent(BASE, ROL, { provider: 'nvidia-nim' }, {
+        root: '/repo',
+        fsImpl: fakeFs('# CLAUDE.md\nbla'),
+    });
+    assert.ok(out.includes(_GUARDRAIL));
+});
+
+test('agente con provider agéntico no toca el system prompt (no-op)', () => {
+    for (const prov of ['anthropic', 'openai-codex', 'gemini-google']) {
+        const out = buildAgentSystemContent(BASE, ROL, { provider: prov }, {
+            root: '/repo',
+            fsImpl: fakeFs('# CLAUDE.md\nbla'),
+        });
+        assert.equal(out, `${BASE}\n\n${ROL}`, `no toca el system prompt con ${prov}`);
+    }
+});
+
+test('resolución sin provider (null) es no-op seguro', () => {
+    const out = buildAgentSystemContent(BASE, ROL, null, {
+        root: '/repo',
+        fsImpl: fakeFs('# CLAUDE.md\nbla'),
+    });
+    assert.equal(out, `${BASE}\n\n${ROL}`);
+    assert.ok(!isApiPeladaProvider(null));
+});
+
+test('el guardrail va aunque CLAUDE.md no se pueda leer', () => {
+    const out = buildAgentSystemContent(BASE, ROL, { provider: 'cerebras' }, {
+        root: '/repo',
+        fsImpl: fakeFs(null),
+    });
+    assert.ok(out.includes(_GUARDRAIL), 'el guardrail es lo crítico y va siempre');
+    assert.ok(out.startsWith(`${BASE}\n\n${ROL}`), 'el rol queda intacto al inicio');
+});

--- a/.pipeline/lib/commander/__tests__/api-context-pack.test.js
+++ b/.pipeline/lib/commander/__tests__/api-context-pack.test.js
@@ -1,0 +1,98 @@
+// =============================================================================
+// api-context-pack.test.js — Cobertura de la inyección de contexto + guardrail
+// anti-alucinación para providers API-pelados del Commander.
+//
+// Contexto: cerebras/nvidia-nim se integran como API REST pelada (sin CLI
+// agéntico, sin acceso al filesystem ni a los logs). Ante una pregunta de
+// estado en vivo inventaban una explicación plausible pero falsa (incidente
+// Cerebras/Whisper 2026-06-05). El pack les inyecta un guardrail + contexto del
+// proyecto. Para providers agénticos el augment es no-op.
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+    API_PELADA_PROVIDERS,
+    isApiPeladaProvider,
+    buildContextPack,
+    augmentSystemPromptForProvider,
+    _GUARDRAIL,
+} = require('../api-context-pack');
+
+// fsImpl falso que devuelve una doc de proyecto controlada.
+function fakeFs(docContent) {
+    return {
+        readFileSync(p, enc) {
+            if (String(p).endsWith('CLAUDE.md')) {
+                if (docContent == null) throw new Error('ENOENT');
+                return docContent;
+            }
+            throw new Error('unexpected read: ' + p);
+        },
+    };
+}
+
+test('cerebras y nvidia-nim son API-pelados; los agénticos no', () => {
+    assert.ok(isApiPeladaProvider('cerebras'));
+    assert.ok(isApiPeladaProvider('nvidia-nim'));
+    assert.ok(!isApiPeladaProvider('anthropic'));
+    assert.ok(!isApiPeladaProvider('openai-codex'));
+    assert.ok(!isApiPeladaProvider('gemini-google'));
+    assert.ok(!isApiPeladaProvider(''));
+    assert.ok(!isApiPeladaProvider(null));
+    assert.ok(!isApiPeladaProvider(undefined));
+});
+
+test('augment para provider API-pelado prepende guardrail + contexto', () => {
+    const persona = 'Sos el Commander.';
+    const out = augmentSystemPromptForProvider(persona, 'cerebras', {
+        root: '/repo',
+        fsImpl: fakeFs('# CLAUDE.md\nMonorepo Kotlin Ktor + Compose.'),
+    });
+    assert.ok(out.startsWith(persona), 'la persona original queda al inicio');
+    assert.ok(out.includes(_GUARDRAIL), 'incluye el guardrail anti-alucinación');
+    assert.ok(out.includes('CONTEXTO DEL PROYECTO'), 'incluye el bloque de contexto');
+    assert.ok(out.includes('Monorepo Kotlin'), 'incluye el extracto de CLAUDE.md');
+    assert.ok(out.length > persona.length, 'el resultado es más largo que la persona');
+});
+
+test('augment es no-op para providers agénticos', () => {
+    const persona = 'Sos el Commander.';
+    for (const prov of ['anthropic', 'openai-codex', 'gemini-google']) {
+        const out = augmentSystemPromptForProvider(persona, prov, {
+            root: '/repo',
+            fsImpl: fakeFs('# CLAUDE.md\nbla'),
+        });
+        assert.equal(out, persona, `no toca el system prompt de ${prov}`);
+    }
+});
+
+test('el guardrail va aunque no se pueda leer CLAUDE.md', () => {
+    const out = augmentSystemPromptForProvider('persona', 'cerebras', {
+        root: '/repo',
+        fsImpl: fakeFs(null), // readFileSync lanza ENOENT
+    });
+    assert.ok(out.includes(_GUARDRAIL), 'el guardrail es lo crítico y va siempre');
+    assert.ok(!out.includes('fuente de verdad del repo'), 'sin doc no agrega el bloque de contexto');
+});
+
+test('buildContextPack trunca docs largas al cap', () => {
+    const huge = '# CLAUDE.md\n' + 'x'.repeat(20000);
+    const pack = buildContextPack({ root: '/repo', fsImpl: fakeFs(huge) });
+    assert.ok(pack.includes('documento truncado'), 'marca el truncado');
+    // El pack no arrastra los 20K chars completos.
+    assert.ok(pack.length < 20000, 'el pack quedó por debajo del tamaño crudo');
+});
+
+test('guardrail menciona explícitamente no inventar estado en vivo', () => {
+    // Defensa de regresión sobre el contenido del guardrail: si alguien lo
+    // suaviza y saca el "no lo inventes", este test pega.
+    assert.ok(/no lo inventes/i.test(_GUARDRAIL));
+    assert.ok(/no ten[ée]s acceso/i.test(_GUARDRAIL));
+});
+
+test('API_PELADA_PROVIDERS contiene exactamente cerebras y nvidia-nim', () => {
+    assert.deepEqual([...API_PELADA_PROVIDERS].sort(), ['cerebras', 'nvidia-nim']);
+});

--- a/.pipeline/lib/commander/api-context-pack.js
+++ b/.pipeline/lib/commander/api-context-pack.js
@@ -1,0 +1,129 @@
+// =============================================================================
+// commander/api-context-pack.js — Inyección de contexto del proyecto + guardrail
+// anti-alucinación para los providers integrados como API REST pelada.
+//
+// PROBLEMA QUE RESUELVE (incidente Cerebras/Whisper 2026-06-05)
+// ------------------------------------------------------------
+// Los providers del Commander se integran de dos formas distintas:
+//
+//   - CLI AGÉNTICO (anthropic, openai-codex, gemini-google): arrancan con
+//     herramientas (leer archivos, grep, logs, ejecutar comandos). Cuando se
+//     les pregunta "¿por qué falló X?", PRIMERO investigan el repo y los logs
+//     y después contestan sobre material real.
+//
+//   - API REST PELADA (cerebras, nvidia-nim): endpoints OpenAI-compatible
+//     `chat/completions` sin estado. Reciben SOLO el texto del prompt + el
+//     system prompt. No ven el filesystem, ni los logs, ni el runtime. Si se
+//     les pregunta por estado en vivo, no tienen cómo chequear nada y tienden
+//     a **rellenar con una explicación plausible pero falsa** (alucinación).
+//
+// Eso fue exactamente lo que pasó: con Anthropic/Codex/Gemini apagados, el
+// fallback cayó en Cerebras y, ante "¿por qué no llegó la transcripción?",
+// inventó un cuento sobre un timeout de Whisper que nunca ocurrió.
+//
+// SOLUCIÓN (opción "más simple" — inyección de contexto estático)
+// ---------------------------------------------------------------
+// Antes de spawnear un provider API-pelado, le aumentamos el system prompt con:
+//   1. Un GUARDRAIL anti-alucinación: le decimos explícitamente que en este
+//      modo no ve el runtime y que, ante preguntas de estado en vivo, debe
+//      admitir el límite en vez de inventar.
+//   2. Un CONTEXTO DEL PROYECTO estático (extracto de CLAUDE.md, la fuente de
+//      verdad del repo) para que las preguntas conceptuales/de arquitectura las
+//      conteste sobre material real y no sobre suposiciones.
+//
+// Los providers agénticos NO se tocan (ya ven el repo de verdad): el augment es
+// un no-op para todo provider que no esté en `API_PELADA_PROVIDERS`.
+// =============================================================================
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+// -----------------------------------------------------------------------------
+// Providers integrados como API REST pelada (sin CLI agéntico ni herramientas).
+// Frozen a propósito: agregar un provider acá es una decisión consciente, no un
+// efecto colateral. Los providers agénticos (anthropic, openai-codex,
+// gemini-google) NO van en este set.
+// -----------------------------------------------------------------------------
+const API_PELADA_PROVIDERS = Object.freeze(new Set(['cerebras', 'nvidia-nim']));
+
+// Cap del extracto de CLAUDE.md inyectado. El free tier de Cerebras tiene TPM
+// bajo (~60K) y el prompt ya incluye persona + historial; 6000 chars (~1.5K
+// tokens) alcanzan para grounding sin reventar el budget.
+const MAX_PROJECT_DOC_CHARS = 6000;
+
+// -----------------------------------------------------------------------------
+// GUARDRAIL — la parte más importante del pack. Le marca al modelo API-pelado
+// que NO tiene visibilidad del runtime y que ante preguntas de estado en vivo
+// debe admitir el límite antes que inventar.
+// -----------------------------------------------------------------------------
+const GUARDRAIL = `LÍMITES DE ESTE MODO DE RESPALDO (leer con atención):
+- Estás respondiendo como proveedor de respaldo vía API REST. En este modo NO tenés acceso al filesystem, a los logs, ni al estado en vivo del pipeline. NO podés ejecutar comandos, leer archivos ni inspeccionar procesos.
+- El bloque "CONTEXTO DEL PROYECTO" de abajo es TODO lo que sabés del sistema. No des por cierto nada que no esté ahí.
+- Si te preguntan por estado en vivo —por qué falló algo, qué dice un log, si un proceso está corriendo, el resultado de una corrida, métricas actuales— NO lo inventes. Decí con claridad que en este modo de respaldo no podés inspeccionar el runtime y que para eso hace falta que lo revise el Commander corriendo sobre Claude/Codex. Es preferible admitir el límite a dar una explicación plausible pero falsa.
+- Para preguntas conceptuales o de arquitectura (cómo funciona X, qué es Y, cómo está organizado el proyecto) usá el contexto del proyecto y respondé normal.`;
+
+// -----------------------------------------------------------------------------
+// readProjectDoc — lee CLAUDE.md de la raíz del repo y lo recorta al cap.
+// Devuelve null si no se puede leer (el pack sigue funcionando solo con el
+// guardrail, que es lo crítico).
+// -----------------------------------------------------------------------------
+function readProjectDoc(root, fsImpl) {
+    const _fs = fsImpl || fs;
+    try {
+        const p = path.join(root || process.cwd(), 'CLAUDE.md');
+        const raw = _fs.readFileSync(p, 'utf8');
+        if (typeof raw !== 'string' || !raw.trim()) return null;
+        if (raw.length <= MAX_PROJECT_DOC_CHARS) return raw.trim();
+        return raw.slice(0, MAX_PROJECT_DOC_CHARS).trim() + '\n\n[…documento truncado…]';
+    } catch {
+        return null;
+    }
+}
+
+// -----------------------------------------------------------------------------
+// buildContextPack — arma el bloque de contexto (guardrail + extracto de doc).
+// El guardrail va SIEMPRE; el contexto del proyecto solo si pudimos leer la doc.
+// -----------------------------------------------------------------------------
+function buildContextPack(opts = {}) {
+    const { root, fsImpl } = opts;
+    const parts = [GUARDRAIL];
+    const doc = readProjectDoc(root, fsImpl);
+    if (doc) {
+        parts.push(
+            `CONTEXTO DEL PROYECTO (extracto de CLAUDE.md, fuente de verdad del repo):\n${doc}`
+        );
+    }
+    return parts.join('\n\n');
+}
+
+// -----------------------------------------------------------------------------
+// isApiPeladaProvider — true si el provider se integra como API REST pelada.
+// -----------------------------------------------------------------------------
+function isApiPeladaProvider(provider) {
+    return API_PELADA_PROVIDERS.has(String(provider == null ? '' : provider).trim());
+}
+
+// -----------------------------------------------------------------------------
+// augmentSystemPromptForProvider — devuelve el system prompt aumentado con el
+// pack SOLO si el provider es API-pelado. Para providers agénticos (o input
+// inválido) devuelve el system prompt tal cual (no-op).
+// -----------------------------------------------------------------------------
+function augmentSystemPromptForProvider(systemPrompt, provider, opts = {}) {
+    const base = typeof systemPrompt === 'string' ? systemPrompt : '';
+    if (!isApiPeladaProvider(provider)) return base;
+    const pack = buildContextPack(opts);
+    if (!pack) return base;
+    return base ? `${base}\n\n${pack}` : pack;
+}
+
+module.exports = {
+    API_PELADA_PROVIDERS,
+    MAX_PROJECT_DOC_CHARS,
+    isApiPeladaProvider,
+    buildContextPack,
+    augmentSystemPromptForProvider,
+    // exports internos para tests
+    _GUARDRAIL: GUARDRAIL,
+    _readProjectDoc: readProjectDoc,
+};

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -5576,7 +5576,28 @@ function lanzarAgenteClaude(skill, issue, trabajandoPath, pipeline, fase, config
 
   // Escribir system prompt (rol) a archivo y user prompt corto como argumento
   const systemFile = path.join(LOG_DIR, `agent-${issue}-${skill}-system.txt`);
-  fs.writeFileSync(systemFile, `${base}\n\n${rol}`);
+  // Paridad con el Commander (incidente Cerebras/Whisper 2026-06-05): si el
+  // spawn de este agente cae a un provider integrado como API REST pelada
+  // (cerebras, nvidia-nim), el agente TAMPOCO ve el filesystem, los logs ni el
+  // runtime — sólo recibe el texto del system + user prompt. Igual que el
+  // Commander, ante preguntas/decisiones de estado en vivo tiende a alucinar.
+  // Le aumentamos el system prompt con el MISMO guardrail anti-alucinación +
+  // extracto de CLAUDE.md. Es no-op para los providers agénticos (anthropic,
+  // openai-codex, gemini-google), que ya investigan el repo de verdad.
+  let systemContent = `${base}\n\n${rol}`;
+  try {
+    const effectiveProvider = (dispatchResolution && dispatchResolution.provider) || null;
+    systemContent = commanderApiContext.augmentSystemPromptForProvider(
+      systemContent, effectiveProvider, { root: ROOT });
+    if (commanderApiContext.isApiPeladaProvider(effectiveProvider)) {
+      log('lanzamiento', `🧱 ${skill}:#${issue} provider API-pelado "${effectiveProvider}": inyecto guardrail anti-alucinación + contexto del proyecto al system prompt.`);
+    }
+  } catch (augErr) {
+    // Best-effort: nunca bloquear el spawn por el augment. Cae al system base.
+    log('lanzamiento', `⚠️ ${skill}:#${issue} no se pudo aumentar el system prompt para provider API-pelado (best-effort): ${augErr.message}`);
+    systemContent = `${base}\n\n${rol}`;
+  }
+  fs.writeFileSync(systemFile, systemContent);
 
   // Construir user prompt — enriquecer si es un rebote con contexto del rechazo
   let userPrompt = `Archivo de trabajo: ${path.basename(trabajandoPath)}\nPath: ${trabajandoPath}\nContenido:\n${yaml.dump(workData, { lineWidth: -1 })}`;

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -61,6 +61,11 @@ const oneMWorkaround = require('./lib/commander/anthropic-1m-workaround');
 // log con hash-chain (CA-4 / SR-3) y formatea las notificaciones a Leo según
 // UX-G1 (lenguaje natural, no log operativo).
 const commanderMP = require('./lib/commander/multi-provider');
+// Inyección de contexto del proyecto + guardrail anti-alucinación para providers
+// integrados como API REST pelada (cerebras, nvidia-nim). Sin esto, ante una
+// pregunta de estado en vivo inventan una explicación plausible pero falsa
+// (incidente Cerebras/Whisper 2026-06-05). No-op para providers agénticos.
+const commanderApiContext = require('./lib/commander/api-context-pack');
 // #3577 — Detectores in-stream del Commander en modo SHADOW (parte 1/2 del
 // split de #3472). Observan first-byte/stream-gap/eof-premature/transient-5xx
 // y los emiten al audit log SIN matar el primario ni spawnear secundario.
@@ -8138,7 +8143,7 @@ function ejecutarClaude(prompt, textoOriginal, trace, fallbackParts) {
         return e;
       };
 
-      const buildFallbackArgs = () => {
+      const buildFallbackArgs = (provider) => {
         if (fallbackParts && typeof fallbackParts.systemPrompt === 'string'
             && typeof fallbackParts.userMessage === 'string'
             && fallbackParts.systemPrompt && fallbackParts.userMessage) {
@@ -8146,7 +8151,12 @@ function ejecutarClaude(prompt, textoOriginal, trace, fallbackParts) {
           let sysFile = null;
           try {
             sysFile = path.join(PIPELINE, 'commander-system-prompt.md');
-            fs.writeFileSync(sysFile, fallbackParts.systemPrompt, 'utf8');
+            // Para providers API-pelados (cerebras, nvidia-nim) aumentamos el
+            // system prompt con contexto del proyecto + guardrail anti-alucinación.
+            // No-op para providers agénticos: devuelve la persona tal cual.
+            const systemForProvider = commanderApiContext.augmentSystemPromptForProvider(
+              fallbackParts.systemPrompt, provider, { root: ROOT });
+            fs.writeFileSync(sysFile, systemForProvider, 'utf8');
           } catch { sysFile = null; }
           return sysFile
             ? ['-p', userMsgForLLM, '--system-prompt-file', sysFile]
@@ -8221,7 +8231,7 @@ function ejecutarClaude(prompt, textoOriginal, trace, fallbackParts) {
 
         const safe = commanderMP.safeBuildSpawn({
           handler: res.handler,
-          args: buildFallbackArgs(),
+          args: buildFallbackArgs(res.provider),
           cwd: ROOT,
           env: attemptEnv,
         });


### PR DESCRIPTION
## Resumen

Extiende al resto de agentes del pipeline (Sherlock, devs, qa, etc.) la misma defensa anti-alucinación + contexto del proyecto que ya tiene el Commander cuando caen a un provider API-pelado (Cerebras/Nvidia).

## Cambios

- `.pipeline/pulpo.js` — guardrail + contexto para spawn de agentes
- `.pipeline/lib/agent-launcher/__tests__/agent-system-prompt-api-pelada.test.js` — 5 tests de regresión (todos verdes)

**Impacto:** Cambio puro de infra/pipeline, sin impacto en producto de usuario.

**QA:** `qa:skipped` — cambio de infra sin impacto en usuario, tests manuales verdes.

---

🤖 Generado con [Claude Code](https://claude.ai/claude-code)