### PR TITLE
[Split de #3715] Sub-0: helper lib/escape-html.js + esqueleto de inventario

### DIFF
--- a/.pipeline/dashboard.js
+++ b/.pipeline/dashboard.js
@@ -1400,13 +1400,13 @@ function renderRecommendationsSection() {
   return `<details class="collapse-section reco-section" open>${summary}<div class="collapse-body">${errorTxt}<div style="margin:6px 0 10px"><button class="reco-btn" onclick="recoRefresh()">🔄 Refrescar</button></div><table class="reco-table"><thead><tr><th>Issue</th><th>Agente</th><th>Título</th><th>Origen</th><th>Creado</th><th>Acciones</th></tr></thead><tbody>${rows}</tbody></table></div></details>`;
 }
 
+const { escapeHtmlAttr: __escapeHtmlAttrShared } = require('./lib/escape-html');
+// #3722 (cierra #2901) — la implementación local delega al helper compartido.
+// Los 60+ call sites de escapeHtml(...) en este archivo se mantienen sin cambio;
+// las hijas de #3715 que extraigan ventanas a views/dashboard/<slug>.js van a
+// importar escapeHtmlText/escapeHtmlAttr directo desde el helper.
 function escapeHtml(s) {
-  return String(s == null ? '' : s)
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
+  return __escapeHtmlAttrShared(s);
 }
 
 // #3638 CA-F-12 / CA-SEC-9 — Widget de estado del ghost-artifact-cleaner.

--- a/.pipeline/lib/__tests__/escape-html.test.js
+++ b/.pipeline/lib/__tests__/escape-html.test.js
@@ -1,0 +1,84 @@
+// =============================================================================
+// Tests escape-html.js — #3722 (padre #3715, cierra #2901)
+//
+// Cubre los 6 casos mínimos del CA-2 del issue:
+//
+//   1. Payload XSS canónico neutralizado en escapeHtmlText.
+//   2. escapeHtmlAttr escapa comilla doble (breakout title="...").
+//   3. escapeHtmlAttr escapa comilla simple (breakout title='...').
+//   4. Contrato text-vs-attr: escapeHtmlText NO escapa comillas literales.
+//   5. Coerción defensiva: null/undefined/0/false/objetos no crashean.
+//   6. Idempotencia: doble encode no introduce nuevos '<' o '>' literales.
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { escapeHtmlText, escapeHtmlAttr } = require('../escape-html');
+
+test('escapeHtmlText escapa el payload XSS canónico <img src=x onerror=alert(1)>', () => {
+    const payload = '<img src=x onerror=alert(1)>';
+    const out = escapeHtmlText(payload);
+    assert.equal(out, '&lt;img src=x onerror=alert(1)&gt;');
+    // Garantía operativa: ningún '<' o '>' literal sobrevive.
+    assert.equal(out.includes('<'), false);
+    assert.equal(out.includes('>'), false);
+});
+
+test('escapeHtmlAttr escapa la comilla doble para prevenir breakout de atributo', () => {
+    const payload = '" onload="alert(1)';
+    const out = escapeHtmlAttr(payload);
+    assert.equal(out, '&quot; onload=&quot;alert(1)');
+    // Sin comillas dobles literales sobrevive el escape.
+    assert.equal(out.includes('"'), false);
+});
+
+test('escapeHtmlAttr escapa la comilla simple para prevenir breakout en single-quoted attrs', () => {
+    const payload = "' onload='alert(1)";
+    const out = escapeHtmlAttr(payload);
+    assert.equal(out, '&#39; onload=&#39;alert(1)');
+    assert.equal(out.includes("'"), false);
+});
+
+test('escapeHtmlText preserva las comillas literales (contrato text vs attr)', () => {
+    // En contexto de texto las comillas son seguras; sólo se escapan & < >.
+    assert.equal(escapeHtmlText('"hola"'), '"hola"');
+    assert.equal(escapeHtmlText("'mundo'"), "'mundo'");
+    assert.equal(escapeHtmlText('a & b < c > d'), 'a &amp; b &lt; c &gt; d');
+});
+
+test('los helpers aceptan null, undefined, 0, false y objetos sin crashear', () => {
+    // null y undefined coercionan a string vacío.
+    assert.equal(escapeHtmlText(null), '');
+    assert.equal(escapeHtmlText(undefined), '');
+    assert.equal(escapeHtmlAttr(null), '');
+    assert.equal(escapeHtmlAttr(undefined), '');
+
+    // 0 y false se renderizan como su String() — son datos válidos del operador.
+    assert.equal(escapeHtmlText(0), '0');
+    assert.equal(escapeHtmlText(false), 'false');
+    assert.equal(escapeHtmlAttr(0), '0');
+    assert.equal(escapeHtmlAttr(false), 'false');
+
+    // Objetos con toString() se coercionan y luego se escapan.
+    const obj = { toString: () => '<x>' };
+    assert.equal(escapeHtmlText(obj), '&lt;x&gt;');
+    assert.equal(escapeHtmlAttr(obj), '&lt;x&gt;');
+});
+
+test('los helpers son idempotentes (double encode no rompe ni introduce XSS)', () => {
+    // El segundo pase re-escapa el '&' que introdujo el primero — texto peor
+    // pero sin '<' ni '>' literales nuevos. Eso es lo que importa para XSS.
+    const onceText = escapeHtmlText('<x>');
+    const twiceText = escapeHtmlText(onceText);
+    assert.equal(twiceText, '&amp;lt;x&amp;gt;');
+    assert.equal(twiceText.includes('<'), false);
+    assert.equal(twiceText.includes('>'), false);
+
+    const onceAttr = escapeHtmlAttr('"<x>"');
+    const twiceAttr = escapeHtmlAttr(onceAttr);
+    assert.equal(twiceAttr.includes('<'), false);
+    assert.equal(twiceAttr.includes('>'), false);
+    assert.equal(twiceAttr.includes('"'), false);
+});

--- a/.pipeline/lib/escape-html.js
+++ b/.pipeline/lib/escape-html.js
@@ -1,0 +1,49 @@
+'use strict';
+
+// =============================================================================
+// escape-html.js — Helper unificado de escape HTML server-side (#3722, padre #3715).
+// Cierra #2901. Bloqueante para todas las sub-historias del rediseño dashboard V3
+// que rendericen datos dinámicos.
+// =============================================================================
+
+const TEXT_MAP = { '&': '&amp;', '<': '&lt;', '>': '&gt;' };
+const ATTR_MAP = { ...TEXT_MAP, '"': '&quot;', "'": '&#39;', '`': '&#96;' };
+
+/**
+ * Escapa texto para uso DENTRO de elementos HTML.
+ *
+ *   SEGURO PARA:  <span>${escapeHtmlText(x)}</span>, <div>${...}</div>
+ *   INSEGURO PARA: <span title="${...}">, <a href="${...}"> — usá escapeHtmlAttr() ahí.
+ *                  <a href="javascript:..."> — URL context requiere validación adicional.
+ *
+ * Coerción defensiva: null/undefined → '', cualquier otro tipo → String(input)
+ * antes del replace.
+ *
+ * @param {*} input - Cualquier valor; null/undefined → ''
+ * @returns {string} - Texto con `& < >` reemplazados por sus entidades HTML.
+ */
+function escapeHtmlText(input) {
+    if (input === null || input === undefined) return '';
+    return String(input).replace(/[&<>]/g, c => TEXT_MAP[c]);
+}
+
+/**
+ * Escapa texto para uso dentro de VALORES DE ATRIBUTO HTML (delimitados por " o ').
+ *
+ *   SEGURO PARA:  <span title="${escapeHtmlAttr(x)}">, <input value='${...}'>
+ *   INSEGURO PARA: <a href="javascript:${...}">, <a href="${userUrl}"> — URL context
+ *                  requiere validación de protocolo aparte (ver issue futuro de
+ *                  escapeHtmlUrl).
+ *
+ * Coerción defensiva: null/undefined → '', cualquier otro tipo → String(input)
+ * antes del replace.
+ *
+ * @param {*} input - Cualquier valor; null/undefined → ''
+ * @returns {string} - Texto con `& < > " ' \`` reemplazados por sus entidades HTML.
+ */
+function escapeHtmlAttr(input) {
+    if (input === null || input === undefined) return '';
+    return String(input).replace(/[&<>"'`]/g, c => ATTR_MAP[c]);
+}
+
+module.exports = { escapeHtmlText, escapeHtmlAttr };

--- a/docs/pipeline/dashboard-v3-inventory.md
+++ b/docs/pipeline/dashboard-v3-inventory.md
@@ -1,0 +1,24 @@
+# Dashboard V3 — Inventario de migración
+
+> Mapeo "qué existe hoy → dónde queda en el rediseño V3" (épico #3715).
+> Esta tabla se completa progresivamente por cada sub-historia hija que
+> extrae una ventana o componente. Sin pérdida de funcionalidad: si algo
+> existe hoy, debe tener entrada en este inventario antes de cerrar el épico.
+
+## Cómo llenar este inventario
+
+Cada sub-historia hija que extrae una ventana o mueve un componente:
+
+1. Agrega una fila por componente migrado.
+2. Marca `Estado` con `pendiente` / `en-progreso` / `migrado` / `eliminado`.
+3. Si el componente se elimina (no aporta valor en V3), justifica en `Notas`.
+4. Si se mueve a otra ventana, refleja el destino real en `Ventana V3 destino`.
+5. Si el origen no es un archivo sino una sección de `dashboard.js`, indica el
+   rango aproximado de líneas (ej. `dashboard.js:1403-1410`) para que el
+   próximo agente pueda anclarse rápido.
+
+## Tabla
+
+| Componente actual | Archivo origen | Ventana V3 destino | Estado | Notas |
+|-------------------|----------------|--------------------|--------|-------|
+| _(las hijas de #3715 llenan acá)_ | | | | |


### PR DESCRIPTION
Recupera el entregable de #3722, que quedó **construido en la rama `agent/3722-backend-dev` pero nunca se abrió PR ni se mergeó** cuando pausamos la Ola N+12 para corregir el multi-provider.

## Contenido (revisado el 30/05)
- `.pipeline/lib/escape-html.js` — helper de escape HTML server-side (49 líneas)
- `.pipeline/lib/__tests__/escape-html.test.js` — tests (84 líneas)
- `.pipeline/dashboard.js` — adopción del helper (scope disciplinado, sin migrar las 62 ocurrencias)
- `docs/pipeline/dashboard-v3-inventory.md` — inventario

## Estado de revisión
Pasó seguridad, tester y QA contra el diff exacto de esta rama (evidencia en los marcadores de verificación del 30/05). Cierra la recomendación de seguridad #2901 y **desbloquea bloqueantemente a todas las hijas de #3715** que renderizan datos dinámicos.

Mergea limpio sobre `main` (sin conflictos; `dashboard.js` no cambió en main desde la rama).

Closes #3722