### PR TITLE
feat(ux): assets visuales ventana Equipo V3 (#3727)

### DIFF
--- a/.pipeline/assets/mockups/27-equipo-panel-v3.svg
+++ b/.pipeline/assets/mockups/27-equipo-panel-v3.svg
@@ -1,0 +1,331 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Mockup 27 — Rediseño ventana Equipo V3 (#3727, split de #3715)
+  ============================================================================
+  Spec de diseño vinculante para la extracción de la ventana Equipo del
+  monolito .pipeline/dashboard.js → .pipeline/views/dashboard/equipo.js.
+
+  Render previsto: kiosk dashboard del operador (localhost, dark-first).
+  Todos los colores provienen de .pipeline/assets/design-tokens.css — CERO
+  colores nuevos. Emojis de AGENT_PERSONA se mantienen literales (identidad
+  de cada agente).
+
+  Estructura de la ventana (entry point único renderEquipoSsr(state)):
+    1. eq-head      → título 🧠 Equipo + chevron colapsable + popout ↗ + summary
+    2. active-strip → eq-active-cards: agentes corriendo ahora (provider badge)
+    3. eq-areas-grid 2×2 → Producto · Desarrollo · Calidad · Operaciones,
+                            cada categoría con sus persona-chips
+    4. eq-svc-section → Servicios en 3 capas (Intake / Processing / Output)
+                        — Opción A: Servicios viaja con Equipo (#3732 migra a Ops)
+
+  Decisiones cerradas (alineadas con architect signoff + criterios PO):
+    - Rail vertical 4px gradient brand-cyan→purple→success como identidad
+      del panel (.bar-section.panel-equipo::before, L4256).
+    - Función pura renderEquipoSsr(state); personaCard + eqAreaGrid + servicios
+      como helpers privados del módulo.
+    - Tokens consumidos exclusivamente desde design-tokens.css.
+    - Fallback visible '<span class="empty-label">Equipo no disponible</span>'.
+    - Tooltips obligatorios en cada chip persona y cada acción de servicio,
+      escapados con escapeHtmlAttr() de lib/escape-html.js (#3722, CLOSED).
+
+  Seguridad (CA-Equipo-2/3/4):
+    - escapeHtmlBody() en cuerpo, escapeHtmlAttr() en title=/aria-label=/data-*=.
+    - tip.replace(/"/g,'&quot;') (L2607) → escapeHtmlAttr(tip).
+    - style="background:${p.color}" validado regex ^#[0-9a-fA-F]{3,8}$|^var\(--[a-z0-9-]+\)$.
+    - href de logs: whitelist /logs/view/ + encodeURIComponent.
+
+  WCAG AA: todos los ratios de texto ≥ 4.5:1 sobre surface-0/surface-1;
+  estados nunca sólo por color (icono + badge ×N + texto en tooltip).
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1680 1500"
+     font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif">
+  <defs>
+    <linearGradient id="railEquipo" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%"   stop-color="#00D6FF"/>
+      <stop offset="50%"  stop-color="#BC8CFF"/>
+      <stop offset="100%" stop-color="#3FB950"/>
+    </linearGradient>
+    <linearGradient id="brandText" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%"   stop-color="#00D6FF"/>
+      <stop offset="100%" stop-color="#1890FF"/>
+    </linearGradient>
+    <filter id="elev" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="2" stdDeviation="5" flood-color="#000" flood-opacity="0.40"/>
+    </filter>
+  </defs>
+
+  <!-- ============================================================ BACKGROUND -->
+  <rect x="0" y="0" width="1680" height="1500" fill="#0D1117"/>
+
+  <!-- ============================================================ HEADER -->
+  <text x="40" y="52" fill="#E6EDF3" font-size="26" font-weight="700">Issue #3727 — Rediseño ventana Equipo V3</text>
+  <text x="40" y="82" fill="#8B949E" font-size="15">Mockup UX · split de #3715 · personas + servicios · eq-areas-grid 2×2 · 3 capas de servicios · tokens design-tokens.css · WCAG AA</text>
+  <rect x="40" y="98" width="1600" height="1" fill="#21262D"/>
+
+  <!-- ============================================================ PANEL V3 (principal) -->
+  <g transform="translate(40, 120)">
+    <!-- card -->
+    <rect x="0" y="0" width="1000" height="1340" rx="16" fill="#161B22" stroke="#30363D" stroke-width="1" filter="url(#elev)"/>
+    <!-- rail identidad: cyan→purple→success -->
+    <rect x="0" y="0" width="5" height="1340" rx="2.5" fill="url(#railEquipo)"/>
+
+    <!-- ─────────────────────────── eq-head ─────────────────────────── -->
+    <g transform="translate(28, 30)">
+      <text x="0" y="22" fill="#8B949E" font-size="16">▼</text>
+      <text x="26" y="24" fill="#E6EDF3" font-size="22" font-weight="700">🧠 Equipo</text>
+      <!-- popout -->
+      <text x="922" y="22" fill="#8B949E" font-size="20">↗</text>
+      <!-- summary -->
+      <g transform="translate(0, 46)" font-size="14" fill="#8B949E">
+        <text x="0" y="14">Activos <tspan fill="#E6EDF3" font-weight="700">3</tspan>/15</text>
+        <text x="120" y="14">·</text>
+        <text x="140" y="14">Utilización <tspan fill="#E6EDF3" font-weight="700">20%</tspan></text>
+        <text x="300" y="14">·</text>
+        <text x="320" y="14">Cola <tspan fill="#E6EDF3" font-weight="700">4</tspan></text>
+      </g>
+      <rect x="0" y="72" width="944" height="1" fill="#30363D"/>
+    </g>
+
+    <!-- ─────────────────────────── active-strip ─────────────────────────── -->
+    <g transform="translate(28, 142)">
+      <text x="0" y="12" fill="#6E7681" font-size="11" font-weight="700" letter-spacing="0.8">EN EJECUCIÓN AHORA</text>
+      <!-- card android-dev #1949 -->
+      <g transform="translate(0, 22)">
+        <rect x="0" y="0" width="300" height="62" rx="10" fill="#1C2128" stroke="#30363D"/>
+        <circle cx="26" cy="31" r="15" fill="#58A6FF"/>
+        <text x="26" y="36" text-anchor="middle" font-size="15">📱</text>
+        <text x="50" y="26" fill="#E6EDF3" font-size="14" font-weight="700">AndroidDev</text>
+        <text x="50" y="44" fill="#8B949E" font-size="12">#1949 · validando</text>
+        <rect x="214" y="10" width="76" height="18" rx="9" fill="rgba(88,166,255,0.14)"/>
+        <text x="252" y="23" text-anchor="middle" fill="#58A6FF" font-size="10" font-weight="700">claude:opus</text>
+        <rect x="214" y="36" width="76" height="6" rx="3" fill="#30363D"/>
+        <rect x="214" y="36" width="50" height="6" rx="3" fill="#58A6FF"/>
+      </g>
+      <!-- card backend-dev #3722 -->
+      <g transform="translate(322, 22)">
+        <rect x="0" y="0" width="300" height="62" rx="10" fill="#1C2128" stroke="#30363D"/>
+        <circle cx="26" cy="31" r="15" fill="#3FB950"/>
+        <text x="26" y="36" text-anchor="middle" font-size="15">⚡</text>
+        <text x="50" y="26" fill="#E6EDF3" font-size="14" font-weight="700">BackendDev</text>
+        <text x="50" y="44" fill="#8B949E" font-size="12">#3736 · escribiendo</text>
+        <rect x="214" y="10" width="76" height="18" rx="9" fill="rgba(63,185,80,0.14)"/>
+        <text x="252" y="23" text-anchor="middle" fill="#3FB950" font-size="10" font-weight="700">codex</text>
+        <rect x="214" y="36" width="76" height="6" rx="3" fill="#30363D"/>
+        <rect x="214" y="36" width="32" height="6" rx="3" fill="#3FB950"/>
+      </g>
+      <!-- card ux #3727 (este issue) -->
+      <g transform="translate(644, 22)">
+        <rect x="0" y="0" width="300" height="62" rx="10" fill="#1C2128" stroke="#f778ba" stroke-opacity="0.5"/>
+        <circle cx="26" cy="31" r="15" fill="#F778BA"/>
+        <text x="26" y="36" text-anchor="middle" font-size="15">🎨</text>
+        <text x="50" y="26" fill="#E6EDF3" font-size="14" font-weight="700">UX</text>
+        <text x="50" y="44" fill="#8B949E" font-size="12">#3727 · mockup Equipo</text>
+        <rect x="214" y="10" width="76" height="18" rx="9" fill="rgba(247,120,186,0.16)"/>
+        <text x="252" y="23" text-anchor="middle" fill="#F778BA" font-size="10" font-weight="700">claude</text>
+        <rect x="214" y="36" width="76" height="6" rx="3" fill="#30363D"/>
+        <rect x="214" y="36" width="60" height="6" rx="3" fill="#F778BA"/>
+      </g>
+    </g>
+
+    <!-- ─────────────────────────── eq-areas-grid 2×2 ─────────────────────────── -->
+    <!-- Cada area-card: head (dot color categoría + label + sub) + chips persona -->
+
+    <!-- PRODUCTO (#d29922) -->
+    <g transform="translate(28, 252)">
+      <rect x="0" y="0" width="458" height="232" rx="12" fill="#1C2128" stroke="#30363D"/>
+      <circle cx="20" cy="28" r="6" fill="#D29922"/>
+      <text x="34" y="33" fill="#E6EDF3" font-size="15" font-weight="700">Producto</text>
+      <text x="438" y="33" text-anchor="end" fill="#8B949E" font-size="12"><tspan fill="#E6EDF3" font-weight="700">2</tspan>/3 libres · <tspan fill="#3FB950">1 activo</tspan></text>
+      <!-- chips -->
+      <g transform="translate(18, 56)">
+        <!-- po -->
+        <g><rect x="0" y="0" width="138" height="40" rx="20" fill="#252B33" stroke="#30363D"/><circle cx="22" cy="20" r="13" fill="#D29922"/><text x="22" y="25" text-anchor="middle" font-size="13">📋</text><text x="44" y="25" fill="#E6EDF3" font-size="13" font-weight="600">PO</text></g>
+        <!-- ux (busy ×1) -->
+        <g transform="translate(154, 0)"><rect x="0" y="0" width="158" height="40" rx="20" fill="#252B33" stroke="#F778BA" stroke-opacity="0.7"/><circle cx="22" cy="20" r="13" fill="#F778BA"/><text x="22" y="25" text-anchor="middle" font-size="13">🎨</text><text x="44" y="25" fill="#E6EDF3" font-size="13" font-weight="600">UX</text><circle cx="140" cy="20" r="5" fill="#3FB950"/></g>
+        <!-- planner -->
+        <g transform="translate(0, 52)"><rect x="0" y="0" width="158" height="40" rx="20" fill="#252B33" stroke="#30363D"/><circle cx="22" cy="20" r="13" fill="#A371F7"/><text x="22" y="25" text-anchor="middle" font-size="13">📐</text><text x="44" y="25" fill="#E6EDF3" font-size="13" font-weight="600">Planner</text></g>
+      </g>
+      <text x="18" y="218" fill="#6E7681" font-size="11">tooltip: «UX — 1 issue en ejecución (#3727)» · escapeHtmlAttr()</text>
+    </g>
+
+    <!-- DESARROLLO (#3fb950) -->
+    <g transform="translate(514, 252)">
+      <rect x="0" y="0" width="458" height="232" rx="12" fill="#1C2128" stroke="#30363D"/>
+      <circle cx="20" cy="28" r="6" fill="#3FB950"/>
+      <text x="34" y="33" fill="#E6EDF3" font-size="15" font-weight="700">Desarrollo</text>
+      <text x="438" y="33" text-anchor="end" fill="#8B949E" font-size="12"><tspan fill="#E6EDF3" font-weight="700">1</tspan>/3 libres · <tspan fill="#3FB950">2 activos</tspan></text>
+      <g transform="translate(18, 56)">
+        <!-- backend-dev busy ×2 -->
+        <g><rect x="0" y="0" width="178" height="40" rx="20" fill="#252B33" stroke="#3FB950" stroke-opacity="0.7"/><circle cx="22" cy="20" r="13" fill="#3FB950"/><text x="22" y="25" text-anchor="middle" font-size="13">⚡</text><text x="44" y="25" fill="#E6EDF3" font-size="13" font-weight="600">BackendDev</text><rect x="138" y="9" width="30" height="20" rx="10" fill="#3FB950"/><text x="153" y="23" text-anchor="middle" fill="#0D1117" font-size="11" font-weight="800">×2</text></g>
+        <!-- android-dev busy ×1 -->
+        <g transform="translate(0, 52)"><rect x="0" y="0" width="178" height="40" rx="20" fill="#252B33" stroke="#58A6FF" stroke-opacity="0.7"/><circle cx="22" cy="20" r="13" fill="#58A6FF"/><text x="22" y="25" text-anchor="middle" font-size="13">📱</text><text x="44" y="25" fill="#E6EDF3" font-size="13" font-weight="600">AndroidDev</text><circle cx="160" cy="20" r="5" fill="#3FB950"/></g>
+        <!-- web-dev idle -->
+        <g transform="translate(194, 52)"><rect x="0" y="0" width="150" height="40" rx="20" fill="#252B33" stroke="#30363D"/><circle cx="22" cy="20" r="13" fill="#79C0FF"/><text x="22" y="25" text-anchor="middle" font-size="13">🌐</text><text x="44" y="25" fill="#E6EDF3" font-size="13" font-weight="600">WebDev</text></g>
+      </g>
+      <text x="18" y="218" fill="#6E7681" font-size="11">badge ×N + borde + dot: estado nunca sólo por color (WCAG)</text>
+    </g>
+
+    <!-- CALIDAD (#d2a8ff) -->
+    <g transform="translate(28, 504)">
+      <rect x="0" y="0" width="458" height="232" rx="12" fill="#1C2128" stroke="#30363D"/>
+      <circle cx="20" cy="28" r="6" fill="#D2A8FF"/>
+      <text x="34" y="33" fill="#E6EDF3" font-size="15" font-weight="700">Calidad</text>
+      <text x="438" y="33" text-anchor="end" fill="#8B949E" font-size="12"><tspan fill="#E6EDF3" font-weight="700">4</tspan> libres</text>
+      <g transform="translate(18, 56)">
+        <g><rect x="0" y="0" width="140" height="40" rx="20" fill="#252B33" stroke="#30363D"/><circle cx="22" cy="20" r="13" fill="#D2A8FF"/><text x="22" y="25" text-anchor="middle" font-size="13">🧪</text><text x="44" y="25" fill="#E6EDF3" font-size="13" font-weight="600">Tester</text></g>
+        <g transform="translate(156, 0)"><rect x="0" y="0" width="120" height="40" rx="20" fill="#252B33" stroke="#30363D"/><circle cx="22" cy="20" r="13" fill="#3FB950"/><text x="22" y="25" text-anchor="middle" font-size="13">✅</text><text x="44" y="25" fill="#E6EDF3" font-size="13" font-weight="600">QA</text></g>
+        <g transform="translate(0, 52)"><rect x="0" y="0" width="140" height="40" rx="20" fill="#252B33" stroke="#30363D"/><circle cx="22" cy="20" r="13" fill="#FFA657"/><text x="22" y="25" text-anchor="middle" font-size="13">👁</text><text x="44" y="25" fill="#E6EDF3" font-size="13" font-weight="600">Review</text></g>
+        <g transform="translate(156, 52)"><rect x="0" y="0" width="150" height="40" rx="20" fill="#252B33" stroke="#30363D"/><circle cx="22" cy="20" r="13" fill="#F85149"/><text x="22" y="25" text-anchor="middle" font-size="13">🔒</text><text x="44" y="25" fill="#E6EDF3" font-size="13" font-weight="600">Security</text></g>
+      </g>
+      <text x="18" y="218" fill="#6E7681" font-size="11">tasa de aprobación + 📈 runs en tooltip de cada persona-card</text>
+    </g>
+
+    <!-- OPERACIONES (#58a6ff) -->
+    <g transform="translate(514, 504)">
+      <rect x="0" y="0" width="458" height="232" rx="12" fill="#1C2128" stroke="#30363D"/>
+      <circle cx="20" cy="28" r="6" fill="#58A6FF"/>
+      <text x="34" y="33" fill="#E6EDF3" font-size="15" font-weight="700">Operaciones</text>
+      <text x="438" y="33" text-anchor="end" fill="#8B949E" font-size="12"><tspan fill="#E6EDF3" font-weight="700">4</tspan> libres</text>
+      <g transform="translate(18, 56)">
+        <g><rect x="0" y="0" width="130" height="40" rx="20" fill="#252B33" stroke="#30363D"/><circle cx="22" cy="20" r="13" fill="#BC8CFF"/><text x="22" y="25" text-anchor="middle" font-size="13">🧠</text><text x="44" y="25" fill="#E6EDF3" font-size="13" font-weight="600">Guru</text></g>
+        <g transform="translate(146, 0)"><rect x="0" y="0" width="120" height="40" rx="20" fill="#252B33" stroke="#30363D"/><circle cx="22" cy="20" r="13" fill="#D29922"/><text x="22" y="25" text-anchor="middle" font-size="13">⚡</text><text x="44" y="25" fill="#E6EDF3" font-size="13" font-weight="600">Perf</text></g>
+        <g transform="translate(0, 52)"><rect x="0" y="0" width="130" height="40" rx="20" fill="#252B33" stroke="#30363D"/><circle cx="22" cy="20" r="13" fill="#8B949E"/><text x="22" y="25" text-anchor="middle" font-size="13">🏗</text><text x="44" y="25" fill="#E6EDF3" font-size="13" font-weight="600">Builder</text></g>
+        <g transform="translate(146, 52)"><rect x="0" y="0" width="150" height="40" rx="20" fill="#252B33" stroke="#30363D"/><circle cx="22" cy="20" r="13" fill="#F0883E"/><text x="22" y="25" text-anchor="middle" font-size="13">🚀</text><text x="44" y="25" fill="#E6EDF3" font-size="13" font-weight="600">Delivery</text></g>
+      </g>
+      <text x="18" y="218" fill="#6E7681" font-size="11">AGENT_PERSONA hardcoded — no se vuelve dinámico (CA-Equipo-3)</text>
+    </g>
+
+    <!-- ─────────────────────────── eq-svc-section (3 capas) ─────────────────────────── -->
+    <g transform="translate(28, 766)">
+      <rect x="0" y="0" width="944" height="1" fill="#30363D"/>
+      <text x="0" y="26" fill="#8B949E" font-size="12" font-weight="700" letter-spacing="0.8">⚙ SERVICIOS · Opción A (migración → Ops en #3732)</text>
+
+      <!-- INTAKE -->
+      <g transform="translate(0, 40)">
+        <text x="0" y="12" fill="#58A6FF" font-size="11" font-weight="700">INTAKE</text>
+        <g transform="translate(0, 20)">
+          <rect x="0" y="0" width="300" height="56" rx="10" fill="#1C2128" stroke="#30363D"/>
+          <text x="18" y="34" font-size="18">📨</text><text x="44" y="28" fill="#E6EDF3" font-size="13" font-weight="600">Telegram</text><text x="44" y="45" fill="#8B949E" font-size="11">listener · svc-telegram</text>
+          <circle cx="280" cy="28" r="6" fill="#3FB950"/>
+        </g>
+        <g transform="translate(322, 20)">
+          <rect x="0" y="0" width="300" height="56" rx="10" fill="#1C2128" stroke="#30363D"/>
+          <text x="18" y="34" font-size="18">🐙</text><text x="44" y="28" fill="#E6EDF3" font-size="13" font-weight="600">GitHub</text><text x="44" y="45" fill="#8B949E" font-size="11">svc-github</text>
+          <circle cx="280" cy="28" r="6" fill="#3FB950"/>
+        </g>
+      </g>
+
+      <!-- PROCESSING -->
+      <g transform="translate(0, 140)">
+        <text x="0" y="12" fill="#BC8CFF" font-size="11" font-weight="700">PROCESSING</text>
+        <g transform="translate(0, 20)">
+          <rect x="0" y="0" width="300" height="56" rx="10" fill="#1C2128" stroke="#30363D"/>
+          <text x="18" y="34" font-size="18">🐙</text><text x="44" y="28" fill="#E6EDF3" font-size="13" font-weight="600">Pulpo</text><text x="44" y="45" fill="#8B949E" font-size="11">orquestador</text>
+          <circle cx="280" cy="28" r="6" fill="#3FB950"/>
+        </g>
+        <g transform="translate(322, 20)">
+          <rect x="0" y="0" width="300" height="56" rx="10" fill="#1C2128" stroke="#30363D"/>
+          <text x="18" y="34" font-size="18">📤</text><text x="44" y="28" fill="#E6EDF3" font-size="13" font-weight="600">Outbox</text><text x="44" y="45" fill="#8B949E" font-size="11">outbox-drain</text>
+          <circle cx="280" cy="28" r="6" fill="#3FB950"/>
+        </g>
+        <g transform="translate(644, 20)">
+          <rect x="0" y="0" width="300" height="56" rx="10" fill="#1C2128" stroke="#30363D"/>
+          <text x="18" y="34" font-size="18">📊</text><text x="44" y="28" fill="#E6EDF3" font-size="13" font-weight="600">Dashboard</text><text x="44" y="45" fill="#8B949E" font-size="11">kiosk localhost</text>
+          <circle cx="280" cy="28" r="6" fill="#3FB950"/>
+        </g>
+      </g>
+
+      <!-- OUTPUT -->
+      <g transform="translate(0, 240)">
+        <text x="0" y="12" fill="#D29922" font-size="11" font-weight="700">OUTPUT</text>
+        <g transform="translate(0, 20)">
+          <rect x="0" y="0" width="300" height="56" rx="10" fill="#1C2128" stroke="#30363D"/>
+          <text x="18" y="34" font-size="18">📁</text><text x="44" y="28" fill="#E6EDF3" font-size="13" font-weight="600">Drive</text><text x="44" y="45" fill="#8B949E" font-size="11">svc-drive</text>
+          <circle cx="280" cy="28" r="6" fill="#3FB950"/>
+        </g>
+        <g transform="translate(322, 20)">
+          <rect x="0" y="0" width="300" height="56" rx="10" fill="#1C2128" stroke="#30363D"/>
+          <text x="18" y="34" font-size="18">📱</text><text x="44" y="28" fill="#E6EDF3" font-size="13" font-weight="600">Emulador</text><text x="44" y="45" fill="#8B949E" font-size="11">svc-emulador</text>
+          <circle cx="280" cy="28" r="6" fill="#3FB950"/>
+        </g>
+        <!-- acción operativa con tooltip -->
+        <g transform="translate(644, 20)">
+          <rect x="0" y="0" width="300" height="56" rx="10" fill="#161B22" stroke="#30363D" stroke-dasharray="4 3"/>
+          <text x="18" y="34" font-size="14" fill="#8B949E">⏯</text>
+          <text x="44" y="28" fill="#B1BAC4" font-size="12">start/stop por servicio</text>
+          <text x="44" y="45" fill="#6E7681" font-size="10">title + aria-label escapados</text>
+        </g>
+      </g>
+    </g>
+  </g>
+
+  <!-- ============================================================ SIDEBAR ANOTACIONES -->
+  <g transform="translate(1080, 120)">
+
+    <!-- Tokens consumidos -->
+    <rect x="0" y="0" width="560" height="318" rx="12" fill="#161B22" stroke="#30363D"/>
+    <text x="20" y="30" fill="#E6EDF3" font-size="15" font-weight="700">Tokens consumidos · design-tokens.css</text>
+    <text x="20" y="50" fill="#8B949E" font-size="11">cero colores hardcoded — todo referencia variables CSS</text>
+    <g transform="translate(20, 66)" font-size="12">
+      <g><rect x="0" y="0" width="22" height="22" rx="4" fill="#0D1117" stroke="#30363D"/><text x="32" y="16" fill="#B1BAC4">--surface-0 · #0D1117 (body)</text></g>
+      <g transform="translate(0,30)"><rect x="0" y="0" width="22" height="22" rx="4" fill="#161B22" stroke="#30363D"/><text x="32" y="16" fill="#B1BAC4">--surface-1 · #161B22 (panel)</text></g>
+      <g transform="translate(0,60)"><rect x="0" y="0" width="22" height="22" rx="4" fill="#1C2128"/><text x="32" y="16" fill="#B1BAC4">--surface-2 · #1C2128 (cards)</text></g>
+      <g transform="translate(0,90)"><rect x="0" y="0" width="22" height="22" rx="4" fill="#252B33"/><text x="32" y="16" fill="#B1BAC4">--surface-3 · #252B33 (chips)</text></g>
+      <g transform="translate(0,120)"><rect x="0" y="0" width="22" height="22" rx="4" fill="#D29922"/><rect x="120" y="0" width="22" height="22" rx="4" fill="#3FB950"/><rect x="240" y="0" width="22" height="22" rx="4" fill="#D2A8FF"/><rect x="360" y="0" width="22" height="22" rx="4" fill="#58A6FF"/><text x="0" y="40" fill="#8B949E" font-size="11">CATEGORY_META: Producto · Desarrollo · Calidad · Operaciones</text></g>
+      <g transform="translate(0,182)"><rect x="0" y="0" width="22" height="22" rx="4" fill="#E6EDF3"/><text x="32" y="16" fill="#B1BAC4">--text-primary #E6EDF3 · 14.8:1 sobre surface-0</text></g>
+    </g>
+
+    <!-- WCAG AA -->
+    <rect x="0" y="338" width="560" height="262" rx="12" fill="#161B22" stroke="#30363D"/>
+    <text x="20" y="368" fill="#E6EDF3" font-size="15" font-weight="700">WCAG AA — contrastes verificados</text>
+    <g transform="translate(20, 388)" font-size="12" fill="#B1BAC4">
+      <text x="0" y="16">Texto principal (#E6EDF3 / surface-0)</text><text x="540" y="16" text-anchor="end" fill="#3FB950" font-weight="700">14.8:1 ✓</text>
+      <text x="0" y="42">Texto secundario (#B1BAC4 / surface-1)</text><text x="540" y="42" text-anchor="end" fill="#3FB950" font-weight="700">9.7:1 ✓</text>
+      <text x="0" y="68">Texto dim (#8B949E / surface-0)</text><text x="540" y="68" text-anchor="end" fill="#3FB950" font-weight="700">5.3:1 ✓</text>
+      <text x="0" y="94">Categoría Producto (#D29922 / surface-2)</text><text x="540" y="94" text-anchor="end" fill="#3FB950" font-weight="700">≥3:1 ✓ (icono)</text>
+      <text x="0" y="120">Activo verde (#3FB950 / surface-2)</text><text x="540" y="120" text-anchor="end" fill="#3FB950" font-weight="700">≥3:1 ✓</text>
+      <text x="0" y="152" fill="#8B949E" font-size="11">Estado nunca sólo por color: icono + badge ×N + dot + texto</text>
+      <text x="0" y="172" fill="#8B949E" font-size="11">en tooltip. Touch targets ≥ 24×24px. Foco con --border-strong.</text>
+      <text x="0" y="200" fill="#8B949E" font-size="11">aria-label redundante en iconos sin texto (chevron, popout, ⏯).</text>
+    </g>
+
+    <!-- Seguridad -->
+    <rect x="0" y="620" width="560" height="276" rx="12" fill="#161B22" stroke="#30363D"/>
+    <text x="20" y="650" fill="#E6EDF3" font-size="15" font-weight="700">Seguridad · lib/escape-html.js (#3722 CLOSED)</text>
+    <g transform="translate(20, 670)" font-size="12" fill="#B1BAC4">
+      <text x="0" y="16"><tspan fill="#F778BA" font-weight="700">CA-2</tspan> escapeHtmlBody() en cuerpo · escapeHtmlAttr() en</text>
+      <text x="0" y="34">title= / aria-label= / data-*= / href= parcial.</text>
+      <text x="0" y="60"><tspan fill="#F778BA" font-weight="700">CA-2</tspan> tip.replace(/"/g,'&amp;quot;') (L2607) → escapeHtmlAttr(tip).</text>
+      <text x="0" y="86"><tspan fill="#F778BA" font-weight="700">CA-3</tspan> style="background:${p.color}" validado regex</text>
+      <text x="0" y="104" font-family="monospace" fill="#8B949E" font-size="11">^#[0-9a-fA-F]{3,8}$|^var\(--[a-z0-9-]+\)$</text>
+      <text x="0" y="130"><tspan fill="#F778BA" font-weight="700">CA-4</tspan> href logs: whitelist /logs/view/ + encodeURIComponent.</text>
+      <text x="0" y="156"><tspan fill="#F778BA" font-weight="700">CA-5</tspan> test SSR con 5 vectores XSS canónicos (img onerror,</text>
+      <text x="0" y="174">javascript:, ';alert//, &lt;/script&gt;, doble-escape).</text>
+      <text x="0" y="200" fill="#8B949E" font-size="11">No leak de internals: nada de process.env ni paths del FS.</text>
+      <text x="0" y="226" fill="#8B949E" font-size="11">Fallback visible (no return ''): «Equipo no disponible».</text>
+    </g>
+
+    <!-- Mapa de criterios -->
+    <rect x="0" y="916" width="560" height="424" rx="12" fill="#161B22" stroke="#30363D"/>
+    <text x="20" y="946" fill="#E6EDF3" font-size="15" font-weight="700">Mapa de criterios (CA-Equipo-1..12)</text>
+    <g transform="translate(20, 966)" font-size="12" fill="#B1BAC4">
+      <text x="0" y="16"><tspan fill="#58A6FF" font-weight="700">CA-1</tspan> renderEquipoSsr(state) función pura · registro try/catch</text>
+      <text x="0" y="42"><tspan fill="#58A6FF" font-weight="700">CA-2</tspan> escape-html.js obligatorio (sin helper local)</text>
+      <text x="0" y="68"><tspan fill="#58A6FF" font-weight="700">CA-3</tspan> CSS injection mitigado · AGENT_PERSONA hardcoded</text>
+      <text x="0" y="94"><tspan fill="#58A6FF" font-weight="700">CA-4</tspan> href seguro (whitelist + encodeURIComponent)</text>
+      <text x="0" y="120"><tspan fill="#58A6FF" font-weight="700">CA-5</tspan> tests node --test · ≥80% líneas · 5 vectores XSS</text>
+      <text x="0" y="146"><tspan fill="#58A6FF" font-weight="700">CA-6</tspan> smoke curl id="equipo" + bar-section panel-equipo</text>
+      <text x="0" y="172"><tspan fill="#58A6FF" font-weight="700">CA-7</tspan> inventario dashboard-v3-inventory.md + nota Ops→#3732</text>
+      <text x="0" y="198"><tspan fill="#58A6FF" font-weight="700">CA-8</tspan> CSS .eq-* / .persona-* migra a views/dashboard/theme.css</text>
+      <text x="0" y="224"><tspan fill="#58A6FF" font-weight="700">CA-9</tspan> tooltips operativos (Servicios start/stop) escapados</text>
+      <text x="0" y="250"><tspan fill="#58A6FF" font-weight="700">CA-10</tspan> fallback visible (no silencioso)</text>
+      <text x="0" y="276"><tspan fill="#58A6FF" font-weight="700">CA-11</tspan> WCAG AA · contraste ≥4.5:1 · navegación teclado</text>
+      <text x="0" y="302"><tspan fill="#58A6FF" font-weight="700">CA-12</tspan> este mockup + screenshot real vs mockup lado a lado</text>
+      <text x="0" y="338" fill="#8B949E" font-size="11">Layout = eq-head + active-strip + eq-areas-grid 2×2 +</text>
+      <text x="0" y="356" fill="#8B949E" font-size="11">eq-svc-section (3 capas). Servicios = Opción A confirmada PO.</text>
+    </g>
+  </g>
+
+  <!-- footer -->
+  <text x="40" y="1486" fill="#6E7681" font-size="12">UX · Intrale Pipeline V3 · mockup vinculante para .pipeline/views/dashboard/equipo.js · narrativa: narrativa-equipo-panel-v3.md</text>
+</svg>

--- a/.pipeline/assets/mockups/README.md
+++ b/.pipeline/assets/mockups/README.md
@@ -20,6 +20,7 @@ no bocetos de baja fidelidad). Cada mockup usa los tokens reales de
 | `16b-telegram-exhaustion.svg`    | 1080x940   | Formato Telegram de pausa por exhaustion (#3259 CA-8) + destrabe automatico (#3259 CA-10) |
 | `17-multi-provider-health.svg`   | 1440x1180  | Seccion "Health" del tab Multi-Provider (#3260 CA-1..CA-6): banner cron + 4 cards por provider (verde/amarillo/rojo/muted) + feed Telegram con dedupe + KPIs + tabla free tier real |
 | `24-multi-provider-coverage-widget.svg` | 1440x1180 | Widget "Coverage" del tab Multi-Provider (#3681 split de #3669): matriz skill × provider con 5 estados (PASS/WARN/FAIL/SKIPPED/N/A) + 5 buckets de latencia, banner de último run, banner de coordinación con `--rest-mode`, botón "Ejecutar harness" con guard, panel lateral de issues auto-creados, tooltip popover custom, leyenda permanente. **Nota de numeración:** el issue #3681 referencia el archivo como `23-...` pero ese slot ya está ocupado por `23-ghost-artifacts-widget.svg` (#3638) — UX asignó el siguiente número libre (24). |
+| `27-equipo-panel-v3.svg`         | 1680x1500  | Ventana "Equipo" V3 (#3727 split de #3715): rail gradient cyan→purple→success, eq-head + active-strip con badge provider:model + eq-areas-grid 2×2 (Producto/Desarrollo/Calidad/Operaciones con persona-chips) + eq-svc-section 3 capas (Intake/Processing/Output, Opción A: Servicios viaja con Equipo, migra a Ops en #3732). Sidebar con tokens, tabla WCAG AA, reglas de seguridad CA-2/3/4 y mapa CA-Equipo-1..12 |
 | `narrativa-commander-routing.md` | —          | Script narrado del sistema visual del Commander determinístico (#3257) — generar mp3 en fase `dev` |
 | `narrativa-continuidad-pulpo.md` | —          | Guidelines UX + tabla de contrastes + reglas de copy de los mensajes Telegram (#3259) |
 | `narrativa-lili.md`              | —          | Script narrado del sistema visual base (mockups 01-03) |
@@ -27,6 +28,7 @@ no bocetos de baja fidelidad). Cada mockup usa los tokens reales de
 | `narrativa-modo-descanso.md`     | —          | Script narrado del modo descanso (#2882, mockups 04-06) — generar mp3 en fase `dev` |
 | `narrativa-multi-provider-health.md` | —      | Guidelines UX + microcopy + reglas inquebrantables del panel Health (#3260, mockup 17) |
 | `narrativa-multi-provider-coverage.md` | —    | Guidelines UX + microcopy + tabla de iconografía + reglas inquebrantables del widget Coverage (#3681, mockup 24) — generar mp3 en fase `dev` |
+| `narrativa-equipo-panel-v3.md`   | —          | Guidelines UX + tabla de contrastes WCAG AA + microcopy + reglas de seguridad + mapa CA-Equipo-1..12 de la ventana Equipo (#3727, mockup 27) — generar mp3 en fase `dev` |
 
 ## Ver los mockups
 

--- a/.pipeline/assets/mockups/narrativa-equipo-panel-v3.md
+++ b/.pipeline/assets/mockups/narrativa-equipo-panel-v3.md
@@ -1,0 +1,218 @@
+# Narrativa UX — Ventana Equipo V3 (#3727, split de #3715)
+
+> Guidelines de diseño vinculantes para la extracción de la ventana **Equipo**
+> del monolito `.pipeline/dashboard.js` hacia `.pipeline/views/dashboard/equipo.js`.
+> Acompaña al mockup `27-equipo-panel-v3.svg`. Voz de referencia para el MP3:
+> `es-AR-ElenaNeural` (generar en fase `dev` si se requiere audio).
+
+---
+
+## 1. Qué es la ventana Equipo
+
+La ventana **Equipo** es el panel del dashboard del operador que responde una
+sola pregunta de un vistazo: **¿quién está trabajando ahora y con qué capacidad
+cuenta el sistema?** Combina dos planos:
+
+1. **Personas** — los 15 skills/agentes del pipeline, agrupados por las cuatro
+   áreas semánticas del proyecto (Producto, Desarrollo, Calidad, Operaciones).
+2. **Servicios** — la infraestructura que rodea a los agentes (Telegram, GitHub,
+   Pulpo, Outbox, Dashboard, Drive, Emulador), organizada en tres capas de flujo
+   (Intake → Processing → Output).
+
+Es una ventana **read-only** salvo por las acciones operativas de Servicios
+(`start`/`stop` de un proceso). El operador la usa para diagnosticar de un
+golpe de vista la salud del equipo y de la infra.
+
+---
+
+## 2. Identidad visual
+
+- **Rail vertical de 4-5px** sobre el borde izquierdo del panel, con gradient
+  `--brand-cyan (#00D6FF) → --purple (#BC8CFF) → --success (#3FB950)`. Es la
+  firma del panel Equipo (regla existente `.bar-section.panel-equipo::before`,
+  L4256 del `dashboard.js`). El gradient cuenta visualmente la historia del
+  panel: personas (cyan/brand) → calidad (purple) → entrega/verde (success).
+- **Dark-first**, coherente con el resto del kiosk. Superficies en escalera de
+  elevación: `surface-0` (body) → `surface-1` (panel) → `surface-2` (cards de
+  área y de servicio) → `surface-3` (chips de persona).
+- **Cero colores nuevos.** Todo proviene de `.pipeline/assets/design-tokens.css`.
+  Los emojis de `AGENT_PERSONA` se mantienen literales: son parte de la
+  identidad de cada agente y NO se reemplazan por íconos del sprite.
+
+---
+
+## 3. Anatomía y jerarquía (orden de lectura top-down)
+
+### 3.1 `eq-head` — cabecera
+- Título `🧠 Equipo` con chevron `▼` colapsable (`toggleSection('equipo')`) y
+  popout `↗` para abrir la ventana aislada (`/?section=equipo`).
+- **Resumen de capacidad** en una línea: `Activos N/M · Utilización X% · Cola K`.
+  Es el dato más importante de la ventana — debe leerse primero.
+- Divisor inferior `1px solid --border` separando cabecera del cuerpo.
+
+### 3.2 `active-strip` (`eq-active-cards`) — quién corre ahora
+- Tira horizontal de tarjetas compactas, una por agente **en ejecución**.
+- Cada tarjeta: avatar con color de persona, nombre, issue + acción actual,
+  **badge `provider:model`** (claude/codex/gemini/…) y barra de progreso.
+- Si no hay nadie corriendo, la tira se omite (no se renderiza una tira vacía).
+
+### 3.3 `eq-areas-grid` 2×2 — capacidad por área
+Cuatro `eq-area-card`, una por categoría, en grilla 2×2 que colapsa a 1 columna
+en `max-width: 720px`:
+
+| Área | Color (`CATEGORY_META`) | Personas |
+|------|-------------------------|----------|
+| **Producto** | `#D29922` | PO 📋 · UX 🎨 · Planner 📐 |
+| **Desarrollo** | `#3FB950` | BackendDev ⚡ · AndroidDev 📱 · WebDev 🌐 |
+| **Calidad** | `#D2A8FF` | Tester 🧪 · QA ✅ · Review 👁 · Security 🔒 |
+| **Operaciones** | `#58A6FF` | Guru 🧠 · Perf ⚡ · Builder 🏗 · Delivery 🚀 |
+
+Cada `eq-area-card` tiene:
+- **Head**: dot del color de categoría + label + sub-resumen
+  `N/M libres · K activos` (los activos en verde `--success`).
+- **Chips persona** (`eq-chip`): pill con avatar coloreado + nombre. Los chips
+  ocupados llevan borde de color de la persona, **badge `×N`** cuando hay más de
+  un issue en ejecución, y un dot de estado. El badge numérico garantiza que el
+  estado **no dependa sólo del color** (WCAG).
+
+### 3.4 `eq-svc-section` — servicios en 3 capas
+Sección separada por divisor superior, encabezada por `⚙ Servicios`. Grilla de
+3 columnas (colapsa a 1 en `max-width: 900px`) organizada por capa de flujo:
+
+- **Intake**: Telegram 📨 (listener, svc-telegram), GitHub 🐙 (svc-github).
+- **Processing**: Pulpo 🐙, Outbox 📤 (outbox-drain), Dashboard 📊.
+- **Output**: Drive 📁 (svc-drive), Emulador 📱 (svc-emulador).
+
+Cada `svc` card: ícono, nombre, sub-label de procesos, dot de salud
+(verde/amarillo/rojo). Las acciones operativas (`ctlAction('<proc>','start'|'stop')`)
+llevan tooltip descriptivo + `aria-label`, ambos escapados.
+
+> **Opción A confirmada por PO**: Servicios viaja **junto con** Equipo en esta
+> historia. La migración a la ventana **Ops** queda documentada como pendiente
+> en el inventario y se ejecuta en el split **#3732**. No perder funcionalidad
+> (CA-A1 del padre).
+
+---
+
+## 4. Tabla de contrastes WCAG AA
+
+Verificado contra los tokens de `design-tokens.css` (ratios del propio archivo
+de tokens, sección 2-3). Todos cumplen AA (≥4.5:1 texto normal, ≥3:1 texto
+grande/iconos).
+
+| Elemento | Color | Fondo | Ratio | Cumple |
+|----------|-------|-------|-------|--------|
+| Texto principal (nombres, summary) | `#E6EDF3` | `--surface-0` | 14.8:1 | AAA ✓ |
+| Texto secundario (sub-labels) | `#B1BAC4` | `--surface-1` | 9.7:1 | AAA ✓ |
+| Texto dim (timestamps, runs) | `#8B949E` | `--surface-0` | 5.3:1 | AA ✓ |
+| Dot/label Producto | `#D29922` | `--surface-2` | ≥3:1 | AA (icono) ✓ |
+| Dot/label Desarrollo | `#3FB950` | `--surface-2` | ≥3:1 | AA (icono) ✓ |
+| Dot/label Calidad | `#D2A8FF` | `--surface-2` | ≥4.5:1 | AA ✓ |
+| Dot/label Operaciones | `#58A6FF` | `--surface-2` | ≥4.5:1 | AA ✓ |
+| Badge `×N` (texto sobre verde) | `#0D1117` | `#3FB950` | ≥7:1 | AAA ✓ |
+
+**Reglas de accesibilidad no negociables:**
+- El estado de un agente **nunca** se comunica sólo por color: siempre
+  acompañado de icono + badge `×N` + dot + texto en el tooltip.
+- Touch targets ≥ 24×24px (chips y acciones de servicio).
+- Foco visible con `--border-strong` (#484F58) para navegación por teclado;
+  `tabindex` correcto en chips y acciones.
+- `aria-label` redundante en iconos sin texto: chevron, popout `↗`, acción `⏯`.
+
+---
+
+## 5. Seguridad — reglas inquebrantables (CA-Equipo-2/3/4)
+
+`#3722` cerró: `lib/escape-html.js` existe en `main` y expone `escapeHtmlBody`
+y `escapeHtmlAttr`. **Prohibido replicar `escapeHtmlSsr` local** (viola CA-B3).
+
+1. **CA-2 (XSS body/attr).** Todo dato dinámico interpolado al HTML pasa por
+   `escapeHtmlBody()` en cuerpo y `escapeHtmlAttr()` en `title=`, `aria-label=`,
+   `data-*=` y `href=` parcial. El `tip.replace(/"/g,'&quot;')` actual (L2607)
+   se reemplaza por `escapeHtmlAttr(tip)` — el replace parcial deja pasar
+   `';alert(1);//`, `<`, `>`, `&`.
+2. **CA-3 (CSS injection).** Cualquier color en `style=` (`--agent-color`,
+   `background:`) se valida contra `^#[0-9a-fA-F]{3,8}$|^var\(--[a-z0-9-]+\)$`
+   antes de interpolar, o se pasa por `data-color=` + resolución por CSS var.
+   `AGENT_PERSONA` permanece **hardcoded** en esta historia (no se vuelve
+   dinámico).
+3. **CA-4 (href seguro).** Los links de historial (`skillHistoryStrip`) validan
+   prefijo whitelist `/logs/view/` + `encodeURIComponent()` del nombre de log.
+   Prohibido aceptar `javascript:`, `data:`, `file:`.
+4. **No leak de internals.** El SSR y el JSON de refresh NO incluyen
+   `process.env`, paths absolutos del FS ni credenciales.
+5. **Fallback visible (CA-10).** Si `require('./views/dashboard/equipo')` falla,
+   el `catch` loggea `warn` y el template renderiza
+   `<span class="empty-label">Equipo no disponible</span>` — nunca `return ''`
+   silencioso. El smoke curl (CA-6) detecta si el fallback se activa por error.
+
+**Vectores XSS canónicos para el test SSR (CA-5):**
+```
+"><img src=x onerror=alert(1)>
+javascript:alert(1)
+';alert(1);//
+</script><script>alert(1)</script>
+&#x3C;script&#x3E;
+```
+Aplicados sobre `agentPersona.name`, `agentPersona.tagline`, `tip` del chip,
+`p.color` y `r.logFile`. Assert: el HTML NO contiene `<img src=x` / `<script>` /
+`javascript:` activos; SÍ contiene `&lt;img` / `&quot;`.
+
+---
+
+## 6. Microcopy (tono y reglas de texto)
+
+- Resumen de capacidad: `Activos {busy}/{total} · Utilización {pct}% · Cola {n}`.
+- Sub-resumen de área con activos: `{libres}/{total} libres · {activos} activo(s)`.
+- Sub-resumen sin activos: `{libres} libres`.
+- Tooltip de chip ocupado: `{Nombre} — {N} issue(s) en ejecución ({runs} runs)`.
+- Tooltip de chip libre: `{Nombre} — libre ({runs} runs)`.
+- Meta de persona-card: `✓ {successRate}%` (aprobación histórica) + `📈 {usage}`
+  (issues trabajados).
+- Empty states: `Sin skills configurados` (grid vacío) · `Equipo no disponible`
+  (módulo no carga) · `—` (historial vacío).
+- Español neutro, conciso, sin jerga técnica innecesaria en lo visible al
+  operador. Los nombres de proceso (`svc-telegram`, `outbox-drain`) sí se
+  muestran como sub-label porque son el identificador operativo real.
+
+---
+
+## 7. Mapa a los criterios de aceptación (CA-Equipo-1..12)
+
+| CA | Cómo lo cubre el diseño |
+|----|--------------------------|
+| CA-1 | `renderEquipoSsr(state)` función pura; `personaCard`/`eqAreaGrid`/servicios helpers privados; registro `try/catch` con fallback visible. |
+| CA-2 | escape-html.js obligatorio; `escapeHtmlAttr(tip)` reemplaza el replace parcial. |
+| CA-3 | regex de validación de color; `AGENT_PERSONA` hardcoded. |
+| CA-4 | href whitelist `/logs/view/` + `encodeURIComponent`. |
+| CA-5 | tests `node --test` con 5 vectores XSS, ≥80% líneas. |
+| CA-6 | smoke curl `id="equipo"` + `bar-section panel-equipo`. |
+| CA-7 | entrada en `docs/pipeline/dashboard-v3-inventory.md` + nota Servicios→Ops (#3732). |
+| CA-8 | CSS `.eq-*`/`.persona-*`/`.panel-equipo*` migra a `views/dashboard/theme.css`; tokens permanecen en theme global. |
+| CA-9 | tooltips operativos en Servicios start/stop, escapados con `escapeHtmlAttr()`. |
+| CA-10 | fallback visible `Equipo no disponible` (no `return ''`). |
+| CA-11 | tabla de contrastes §4 (todos ≥AA); navegación teclado + aria-label. |
+| CA-12 | este mockup `27-equipo-panel-v3.svg` + narrativa; el dev adjunta screenshot real vs mockup lado a lado al PR. |
+
+---
+
+## 8. Notas de implementación para el dev (no perder en la extracción)
+
+- El layout 2×2 + servicios 3-capas ya existe embebido en `dashboard.js`
+  (L2524-2625 personas, L2627-2722 servicios, L5478-5497 template). La
+  extracción **reordena y endurece** (escape, fallback, tests), no reinventa la
+  UX. Reanclar con `grep -n "personaCard("`, `"eqAreaGridHTML"`, `"panel-equipo"`
+  antes de editar.
+- `renderEquipoSsr(state)` recibe todos los derivados como input (sin leer FS ni
+  globals) para que los tests SSR + XSS sean triviales de montar.
+- Sprite: NO se agregan iconos nuevos. Los emojis de persona y de servicio se
+  mantienen literales.
+- Tokens: si se mueve CSS `eq-*`/`persona-*` a `theme.css`, NO duplicar las
+  variables `--ac/--pu/--gn/--rd/--yl` ni los tokens de `design-tokens.css`.
+
+---
+
+_Narrativa producida por el agente `ux` en pipeline V3 — fase `criterios`.
+Acompaña al mockup `27-equipo-panel-v3.svg`. Assets commiteados y pusheados a
+rama remota para garantizar su persistencia (fix del rebote cross-phase desde
+`validacion`)._


### PR DESCRIPTION
## Qué

Assets visuales de UX para el rediseño V3 de la ventana **Equipo** del dashboard (split de #3715):

- `.pipeline/assets/mockups/27-equipo-panel-v3.svg` — mockup de alta fidelidad (rail gradient, eq-head + active-strip + eq-areas-grid 2×2 + eq-svc-section 3 capas, Opción A: Servicios viaja con Equipo → migra a Ops en #3732). Sidebar con tokens, tabla WCAG AA, reglas de seguridad CA-2/3/4 y mapa CA-Equipo-1..12.
- `.pipeline/assets/mockups/narrativa-equipo-panel-v3.md` — guidelines UX, tabla de contrastes, microcopy, reglas de seguridad.
- `.pipeline/assets/mockups/README.md` — entradas de inventario.

## Por qué

Regenera y **persiste** los assets que se perdieron en la pasada anterior de `criterios/ux` (corrió sin worktree → los archivos se evaporaron, rebote cross-phase desde `validacion`). Cubre CA-Equipo-12 (CA-F1-F4 heredado): el dev necesita el mockup como spec de diseño para el PR de `equipo.js`.

## Scope

Solo assets de `.pipeline/assets/mockups/`. NO toca código del dashboard ni estado del pipeline. Sin `Closes` (la implementación de #3727 la hace el dev en su fase). Sin auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)