### PR TITLE
fix(commander): aviso por Telegram cuando fallan todos los providers y fallbacks (#3887)

### DIFF
--- a/.pipeline/lib/commander/multi-provider.js
+++ b/.pipeline/lib/commander/multi-provider.js
@@ -1039,6 +1039,33 @@ function cannedAllGatedResponse() {
 }
 
 // -----------------------------------------------------------------------------
+// #3887 — cannedAllProvidersFailedResponse — ÚLTIMA OPCIÓN.
+//
+// A diferencia de `cannedAllGatedResponse` (que habla de "sin cuota", el caso
+// pre-spawn donde la cadena entera está gateada por cuota), este mensaje cubre
+// el caso en que se INTENTÓ spawnear y TODOS los providers Y todos los modelos
+// de fallback FALLARON en runtime (spawn error, ENAMETOOLONG, env-isolation,
+// timeout, empty_output, etc.). Es el último eslabón: cuando no queda ningún
+// LLM con el que generar la respuesta, al menos le avisamos a Leo que no se le
+// puede contestar y por qué — para que NUNCA quede mudo sin saber qué pasó.
+//
+// `chainTried` (opcional) lista los providers que se intentaron, para dar
+// contexto sin jerga técnica de stack traces.
+// -----------------------------------------------------------------------------
+function cannedAllProvidersFailedResponse({ chainTried } = {}) {
+    const chain = Array.isArray(chainTried) && chainTried.length
+        ? ` Intenté con: ${chainTried.join(', ')}.`
+        : '';
+    return (
+        `⚠️ No te puedo responder en este momento: fallaron TODOS los providers y ` +
+        `todos los modelos de fallback.${chain} No hay ningún modelo LLM disponible ` +
+        `para generar una respuesta ahora mismo. ` +
+        `Los comandos determinísticos (/status, /listado, /lanzar) siguen funcionando — ` +
+        `probá de nuevo en un rato.`
+    );
+}
+
+// -----------------------------------------------------------------------------
 // #3275 — Re-export del módulo de fallback in-flight para tener una sola
 // superficie pública en `require('./multi-provider')`. El módulo dedicado
 // vive en `./inflight-fallback.js` y tiene su propia suite de tests.
@@ -1066,6 +1093,7 @@ module.exports = {
 
     cannedFallbackUnavailableResponse,
     cannedAllGatedResponse,
+    cannedAllProvidersFailedResponse,
     cannedDataResidencyResponse,
 
     // #3275 — in-flight fallback (re-export del módulo dedicado)

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -8221,7 +8221,14 @@ function ejecutarClaude(prompt, textoOriginal, trace, fallbackParts) {
             requestId: turnRequestId, // #3577 CA-S6
           });
         } catch { /* best-effort */ }
-        return resolve(commanderMP.cannedAllGatedResponse());
+        // #3887 — ÚLTIMA OPCIÓN: se intentó spawnear y fallaron TODOS los
+        // providers y modelos de fallback. En vez del canned de "sin cuota"
+        // (que es el caso pre-spawn gateado), avisamos explícitamente que no
+        // hay con qué responder — para que el usuario NUNCA quede mudo sin
+        // saber qué pasó.
+        return resolve(commanderMP.cannedAllProvidersFailedResponse({
+          chainTried: Array.from(triedNonAnthropic),
+        }));
       };
 
       const runNonAnthropic = (res, preEnv) => {
@@ -10214,7 +10221,18 @@ INSTRUCCIÓN: Reelaborá tu respuesta tomando en cuenta las contradicciones dete
           }, { log });
         } catch { /* best-effort */ }
       } else {
-        sendTelegram('⚠️ Error procesando tu mensaje. Intentá de nuevo.');
+        // #3887 — ÚLTIMA OPCIÓN para texto libre: si ejecutarClaude rechazó por
+        // un fallo total de providers (spawn ENAMETOOLONG, env-isolation,
+        // sin LLM, timeout de red), avisamos explícitamente que fallaron todos
+        // los providers y modelos de fallback en vez del genérico vago — así el
+        // usuario se entera de qué pasó y no queda mudo.
+        const errMsg = (e && e.message) || '';
+        const totalProviderFailure = /ENAMETOOLONG|spawn|env-isolation|env_isolation|provider|quota|rate.?limit|usage_limit|ECONNREFUSED|ETIMEDOUT|ENOTFOUND|all.?gated/i.test(errMsg);
+        if (totalProviderFailure) {
+          try { sendTelegram(commanderMP.cannedAllProvidersFailedResponse({})); } catch { /* best-effort */ }
+        } else {
+          sendTelegram('⚠️ Error procesando tu mensaje. Intentá de nuevo.');
+        }
       }
     }
 


### PR DESCRIPTION
## Problema

El Telegram Commander quedaba **mudo** cuando Anthropic estaba apagado y la cadena de fallback fallaba a mitad de request (`spawn ENAMETOOLONG`, env-isolation, sin LLM disponible, timeout de red). El usuario mandaba mensajes y no recibía nada: ni respuesta ni aviso de la falla.

## Solución

Última red de seguridad: cuando se agota toda la cadena de providers y modelos de fallback, en vez de quedar mudo (o devolver un genérico vago), se avisa explícitamente por Telegram qué pasó.

### Cambios
- **`.pipeline/lib/commander/multi-provider.js`**: nueva `cannedAllProvidersFailedResponse({ chainTried })`. Mensaje de última opción que lista los providers intentados y aclara que los comandos determinísticos (`/status`, `/listado`, `/lanzar`) siguen funcionando.
- **`.pipeline/pulpo.js`**: enganchada en los **2 puntos** donde la cadena se agota:
  1. El `reject` de `ejecutarClaude` tras intentar todos los providers no-Anthropic (pasa `chainTried`).
  2. El `catch` de texto libre, que distingue un fallo total de providers de un error genérico.

## Notas
- Cambio acotado a 2 archivos del pipeline del Commander; no toca producto de usuario.
- Sintaxis validada con `node --check` en ambos archivos.

Closes #3887

🤖 Generated with [Claude Code](https://claude.com/claude-code)