### PR TITLE
feat(pipeline): audit log JSONL trazable de Sherlock + sanitización (#3896)

### DIFF
--- a/.pipeline/lib/sherlock-audit-jsonl.js
+++ b/.pipeline/lib/sherlock-audit-jsonl.js
@@ -1,0 +1,171 @@
+// =============================================================================
+// sherlock-audit-jsonl.js — Writer del audit log JSONL de Sherlock.
+//
+// Issue: #3896 (split de #3894, hija 2/3) — CA-1..CA-6, SEC-2/3/4.
+//
+// Loguea cada validación canónica de Sherlock en un JSONL append-only por
+// sesión (`.pipeline/audit/sherlock-<session>.jsonl`) con trazabilidad
+// completa: claim → comando canónico → resultado → resolución.
+//
+// Principio rector: **envolver, no reimplementar**.
+//   - La integridad (O_APPEND + hash chain + lock cross-process fail-closed)
+//     la aporta `audit-log.js:appendChained()`. Acá NUNCA se toca
+//     `fs.appendFileSync` directo sobre el audit (SEC-3 resuelto por
+//     construcción: `appendChained` hace `JSON.stringify(entry)+'\n'`, que
+//     escapa `\n`/`\r` → una línea por registro, sin log forging).
+//   - La redacción de secrets la aportan `commander/redact-read.js` y
+//     `redact.js`. Acá se ENCADENAN ambos (SEC-2) + se cubre el gap del PAT
+//     fine-grained `github_pat_*` que ninguno de los dos contempla.
+//
+// Requisitos de seguridad NO NEGOCIABLES (verificados contra HEAD):
+//   - SEC-2 (CWE-532): TODO stdout/stderr/claim/comando pasa por
+//     `redactAll()` antes de escribir. Nunca se serializa `process.env` ni el
+//     prompt crudo (eso lo garantiza el caller pasando hashes). Cobertura
+//     explícita: `ghp_` (40 chars), `github_pat_*` (fine-grained), AWS `AKIA`.
+//   - SEC-3 (CWE-117): un `JSON.stringify(record)+'\n'` por línea, append-only.
+//   - SEC-4 (CWE-22): `session` validado con allowlist ANTES de construir el
+//     path + verificación redundante de que el path resuelto cae dentro de
+//     `.pipeline/audit/`. Fail-closed: si algo no cuadra, throw SIN crear
+//     archivo.
+// =============================================================================
+'use strict';
+
+const path = require('node:path');
+const { appendChained } = require('./audit-log');
+const { redactReadOutput } = require('./commander/redact-read');
+const { redactSecretValue } = require('./redact');
+
+// SEC-4 — allowlist del nombre de sesión. Sin `.`, `/`, `\`, `%` ni NUL → ningún
+// vector de path traversal pasa. Largo acotado a 64 para evitar nombres
+// patológicos. Se valida ANTES de construir cualquier path.
+const SESSION_RE = /^[A-Za-z0-9_-]{1,64}$/;
+
+// Subdirectorio canónico del audit. El path final SIEMPRE cae acá adentro.
+const AUDIT_SUBDIR = 'audit';
+
+const REDACTION_MARKER = '[REDACTED]';
+
+// SEC-2 — gap real verificado contra HEAD:
+//   - `redact-read.js` cubre `\bgh[pousr]_[A-Za-z0-9]{30,}\b` (ghp_/gho_/ghu_/
+//     ghs_/ghr_) pero NO `github_pat_*` (el 3er char de "github" es 't', fuera
+//     del set [pousr]).
+//   - `redact.js SECRET_VALUE_PATTERNS` no tiene NINGÚN patrón GitHub; el
+//     fallback de entropía exige `length > 40` estricto → frágil.
+// Por eso agregamos un patrón explícito para el PAT fine-grained (formato
+// `github_pat_` + base62/underscore, ~82 chars). El `{50,}` es holgado y no
+// solapa con el patrón corto.
+const GITHUB_PAT_FINE_GRAINED_RE = /\bgithub_pat_[A-Za-z0-9_]{50,}\b/g;
+
+/**
+ * Cadena de redacción obligatoria (SEC-2). Idempotente y null-safe.
+ *
+ * Orden:
+ *   1. PAT fine-grained `github_pat_*` (gap no cubierto por ninguno de los dos
+ *      redactores oficiales).
+ *   2. `redactReadOutput()` — cubre `gh[pousr]_` (incluye `ghp_` de 40 chars
+ *      por longitud ≥30), AWS, JWT, API keys varias, telegram, slack, emails.
+ *      OJO: devuelve `{ text, redactedCount }`, NO un string.
+ *   3. `redactSecretValue()` — patrones por valor + fallback de entropía.
+ *
+ * No confiamos en el fallback de entropía como única defensa.
+ *
+ * @param {*} text — cualquier valor; null/undefined se devuelven tal cual.
+ * @returns {*} string redactado, o el valor original si no era string.
+ */
+function redactAll(text) {
+    if (text == null) return text;
+    let s = String(text);
+    s = s.replace(GITHUB_PAT_FINE_GRAINED_RE, REDACTION_MARKER);
+    const readRes = redactReadOutput(s);
+    // redactReadOutput devuelve { text, redactedCount }. Defensivo por si la
+    // firma cambia a string en el futuro.
+    s = (readRes && typeof readRes === 'object' && typeof readRes.text === 'string')
+        ? readRes.text
+        : (typeof readRes === 'string' ? readRes : s);
+    s = redactSecretValue(s);
+    return s;
+}
+
+/**
+ * Resuelve y valida el path del archivo de audit para una sesión (SEC-4).
+ * Fail-closed: lanza si la sesión no pasa la allowlist o si el path resuelto
+ * se sale de `.pipeline/audit/`. NO crea el archivo.
+ *
+ * @param {string} session
+ * @param {string} pipelineDir — raíz `.pipeline/` (absoluta).
+ * @returns {string} path absoluto a `sherlock-<session>.jsonl`.
+ */
+function resolveAuditFile(session, pipelineDir) {
+    if (typeof session !== 'string' || !SESSION_RE.test(session)) {
+        throw new Error(
+            `[sherlock-audit] session inválida (SEC-4): rechazado sin crear archivo. ` +
+            `Debe matchear ${SESSION_RE}`
+        );
+    }
+    if (typeof pipelineDir !== 'string' || pipelineDir.length === 0) {
+        throw new Error('[sherlock-audit] pipelineDir requerido (string absoluto).');
+    }
+    const auditDir = path.resolve(pipelineDir, AUDIT_SUBDIR);
+    // `path.basename(session)` es no-op para una sesión que ya pasó la allowlist
+    // (no tiene separadores), pero lo dejamos como defensa redundante explícita.
+    const fileName = `sherlock-${path.basename(session)}.jsonl`;
+    const file = path.resolve(auditDir, fileName);
+    // Defensa redundante: el path resuelto DEBE caer dentro de auditDir.
+    const expected = path.join(auditDir, `sherlock-${session}.jsonl`);
+    if (file !== expected || !file.startsWith(auditDir + path.sep)) {
+        throw new Error('[sherlock-audit] path fuera de .pipeline/audit/ (SEC-4).');
+    }
+    return file;
+}
+
+/**
+ * Persiste UN registro de validación canónica en el JSONL de la sesión.
+ *
+ * Firma sync, fail-closed. Redacta TODO stdout/stderr/claim/comando antes de
+ * escribir y delega la escritura (append-only + hash chain + lock) en
+ * `audit-log.appendChained`. NO reimplementa hash chain ni lock.
+ *
+ * @param {object} params
+ * @param {string} params.session — id de sesión (allowlist SEC-4).
+ * @param {object} params.record — datos del evento canónico:
+ *   { timestamp, claim, canonical_command, stdout, stderr, resultado,
+ *     commander_vs_sherlock, resolucion }.
+ * @param {string} params.pipelineDir — raíz `.pipeline/`.
+ * @param {object} [params.fsImpl] — inyectable para tests.
+ * @returns {{hash_self: string, hash_prev: string, line: string}}
+ */
+function appendSherlockAudit({ session, record, pipelineDir, fsImpl } = {}) {
+    if (!record || typeof record !== 'object' || Array.isArray(record)) {
+        throw new Error('[sherlock-audit] record requerido (objeto plano).');
+    }
+    // SEC-4 ANTES de tocar el FS. Si falla, throw sin crear nada.
+    const file = resolveAuditFile(session, pipelineDir);
+
+    // CA-1 — shape canónico del registro. Los campos de texto pasan por la
+    // cadena de redacción (SEC-2). Los enums de control (resultado/resolución)
+    // NO se redactan (no transportan secrets y son valores acotados).
+    const entry = {
+        timestamp: record.timestamp != null ? record.timestamp : new Date().toISOString(),
+        claim: redactAll(record.claim),
+        canonical_command: redactAll(record.canonical_command),
+        stdout: redactAll(record.stdout),
+        stderr: redactAll(record.stderr),
+        resultado: record.resultado,                   // 'true' | 'false' | 'not_verifiable'
+        commander_vs_sherlock: record.commander_vs_sherlock,
+        resolucion: record.resolucion,                 // 'accepted' | 'rejected' | 'escalated'
+    };
+
+    // appendChained agrega created_at + hash_prev/hash_self y escribe
+    // exactamente UNA línea (`JSON.stringify(entry)+'\n'`) con O_APPEND + lock.
+    // Resuelve SEC-3 por construcción.
+    return appendChained({ file, entry, fsImpl });
+}
+
+module.exports = {
+    appendSherlockAudit,
+    redactAll,
+    resolveAuditFile,
+    SESSION_RE,
+    AUDIT_SUBDIR,
+    GITHUB_PAT_FINE_GRAINED_RE,
+};

--- a/.pipeline/lib/sherlock-audit-jsonl.test.js
+++ b/.pipeline/lib/sherlock-audit-jsonl.test.js
@@ -1,0 +1,289 @@
+// =============================================================================
+// sherlock-audit-jsonl.test.js — Suite del writer del audit JSONL (#3896).
+//
+// Cubre los criterios de aceptación CA-1..CA-5 y los requisitos de seguridad
+// NO NEGOCIABLES SEC-2/3/4:
+//   - append-only + hash chain intacta tras N escrituras (CA-2).
+//   - SEC-2 (3 casos): `ghp_` de 40 chars exactos, `github_pat_*` fine-grained,
+//     AWS `AKIA…` → los tres AUSENTES del archivo final.
+//   - SEC-2 no-env: el writer nunca serializa `process.env`.
+//   - SEC-3 log forging: claim con `\n`/`\r` → 1 sola línea física, control
+//     chars escapados (no salto real).
+//   - SEC-4 path traversal: `../`, `..\`, separador absoluto, NUL, `%2e%2e`,
+//     largo > 64, vacío → rechazados SIN crear archivo.
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+    appendSherlockAudit,
+    redactAll,
+    resolveAuditFile,
+    SESSION_RE,
+    AUDIT_SUBDIR,
+} = require('./sherlock-audit-jsonl');
+const { verifyChain } = require('./audit-log');
+
+// --- helpers -----------------------------------------------------------------
+
+function tmpPipelineDir() {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'sherlock-audit-'));
+}
+
+function auditDirOf(pipelineDir) {
+    return path.join(pipelineDir, AUDIT_SUBDIR);
+}
+
+function readLines(file) {
+    if (!fs.existsSync(file)) return [];
+    return fs.readFileSync(file, 'utf8').split('\n').filter(l => l.trim().length > 0);
+}
+
+function baseRecord(extra = {}) {
+    return {
+        timestamp: '2026-06-10T12:00:00.000Z',
+        claim: '#3896/entregable_en_main',
+        canonical_command: 'git ls-tree origin/main .pipeline/lib/x.js',
+        stdout: 'true',
+        stderr: null,
+        resultado: 'true',
+        commander_vs_sherlock: 'consistent',
+        resolucion: 'accepted',
+        ...extra,
+    };
+}
+
+// Tokens de prueba (NO son secrets reales — formatos sintéticos para el test).
+const GHP_40 = 'ghp_' + 'A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8'; // 4 + 36 = 40 chars
+const GITHUB_PAT_FG = 'github_pat_' + '11ABCDEFG0' + 'aZ9'.repeat(20) + 'xY'; // > 50 cuerpo
+const AWS_AKIA = 'AKIAIOSFODNN7EXAMPLE'; // AKIA + 16 = 20 chars
+
+// --- CA-1 / CA-2: shape + append-only + hash chain ---------------------------
+
+test('CA-1 — el registro persiste todos los campos canónicos', () => {
+    const pipelineDir = tmpPipelineDir();
+    const session = 'sess123';
+    appendSherlockAudit({ session, pipelineDir, record: baseRecord() });
+
+    const file = resolveAuditFile(session, pipelineDir);
+    const lines = readLines(file);
+    assert.strictEqual(lines.length, 1, 'una sola línea tras un append');
+    const entry = JSON.parse(lines[0]);
+    for (const k of ['timestamp', 'claim', 'canonical_command', 'stdout', 'stderr',
+        'resultado', 'commander_vs_sherlock', 'resolucion']) {
+        assert.ok(k in entry, `falta el campo ${k}`);
+    }
+    assert.strictEqual(entry.resultado, 'true');
+    assert.strictEqual(entry.resolucion, 'accepted');
+    assert.strictEqual(entry.commander_vs_sherlock, 'consistent');
+    // appendChained agrega la cadena de integridad.
+    assert.ok('hash_self' in entry && 'hash_prev' in entry && 'created_at' in entry);
+});
+
+test('CA-2 — append-only: cada escritura suma exactamente 1 línea y la chain queda intacta', () => {
+    const pipelineDir = tmpPipelineDir();
+    const session = 'chain-test';
+    const file = resolveAuditFile(session, pipelineDir);
+
+    const N = 5;
+    for (let i = 0; i < N; i++) {
+        appendSherlockAudit({
+            session, pipelineDir,
+            record: baseRecord({ claim: `#${3896 + i}/issue_cerrado` }),
+        });
+        assert.strictEqual(readLines(file).length, i + 1, `tras ${i + 1} writes hay ${i + 1} líneas`);
+    }
+
+    const v = verifyChain(file);
+    assert.strictEqual(v.ok, true, `hash chain intacta: ${v.reason || ''}`);
+    assert.strictEqual(v.entriesChecked, N);
+});
+
+// --- CA-3 / SEC-2: no-fuga de secrets ----------------------------------------
+
+test('SEC-2 — `ghp_` de 40 chars exactos se redacta (ausente del archivo)', () => {
+    const pipelineDir = tmpPipelineDir();
+    const session = 'sec2ghp';
+    assert.strictEqual(GHP_40.length, 40, 'el fixture debe medir 40 chars');
+    appendSherlockAudit({
+        session, pipelineDir,
+        record: baseRecord({ stdout: `salida con token ${GHP_40} embebido` }),
+    });
+    const raw = fs.readFileSync(resolveAuditFile(session, pipelineDir), 'utf8');
+    assert.ok(!raw.includes(GHP_40), 'el ghp_ no debe aparecer en claro');
+});
+
+test('SEC-2 — `github_pat_*` fine-grained se redacta (ausente del archivo)', () => {
+    const pipelineDir = tmpPipelineDir();
+    const session = 'sec2pat';
+    assert.ok(GITHUB_PAT_FG.length > 50);
+    appendSherlockAudit({
+        session, pipelineDir,
+        record: baseRecord({ claim: `claim con ${GITHUB_PAT_FG}` }),
+    });
+    const raw = fs.readFileSync(resolveAuditFile(session, pipelineDir), 'utf8');
+    assert.ok(!raw.includes(GITHUB_PAT_FG), 'el github_pat_ no debe aparecer en claro');
+});
+
+test('SEC-2 — AWS AKIA… se redacta (ausente del archivo)', () => {
+    const pipelineDir = tmpPipelineDir();
+    const session = 'sec2aws';
+    appendSherlockAudit({
+        session, pipelineDir,
+        record: baseRecord({ stderr: `error AWS key ${AWS_AKIA} denied` }),
+    });
+    const raw = fs.readFileSync(resolveAuditFile(session, pipelineDir), 'utf8');
+    assert.ok(!raw.includes(AWS_AKIA), 'la AWS key no debe aparecer en claro');
+});
+
+test('SEC-2 — los tres tokens juntos en un mismo registro se redactan', () => {
+    const pipelineDir = tmpPipelineDir();
+    const session = 'sec2all';
+    appendSherlockAudit({
+        session, pipelineDir,
+        record: baseRecord({
+            claim: `claim ${GHP_40}`,
+            canonical_command: `gh api ${GITHUB_PAT_FG}`,
+            stdout: `out ${AWS_AKIA}`,
+        }),
+    });
+    const raw = fs.readFileSync(resolveAuditFile(session, pipelineDir), 'utf8');
+    assert.ok(!raw.includes(GHP_40));
+    assert.ok(!raw.includes(GITHUB_PAT_FG));
+    assert.ok(!raw.includes(AWS_AKIA));
+});
+
+test('SEC-2 — el writer nunca serializa process.env', () => {
+    const pipelineDir = tmpPipelineDir();
+    const session = 'sec2env';
+    // Sembramos un valor reconocible en el entorno del test.
+    const marker = 'SENTINEL_ENV_VALUE_9f3a';
+    process.env.SHERLOCK_AUDIT_TEST_ENV = marker;
+    try {
+        appendSherlockAudit({ session, pipelineDir, record: baseRecord() });
+        const raw = fs.readFileSync(resolveAuditFile(session, pipelineDir), 'utf8');
+        const entry = JSON.parse(raw.trim());
+        assert.ok(!('env' in entry), 'no debe existir un campo env');
+        assert.ok(!raw.includes(marker), 'ningún valor de process.env debe filtrarse');
+        // El shape de claves es cerrado y conocido.
+        const keys = Object.keys(entry).sort();
+        assert.deepStrictEqual(keys, [
+            'canonical_command', 'claim', 'commander_vs_sherlock', 'created_at',
+            'hash_prev', 'hash_self', 'resolucion', 'resultado', 'stderr',
+            'stdout', 'timestamp',
+        ]);
+    } finally {
+        delete process.env.SHERLOCK_AUDIT_TEST_ENV;
+    }
+});
+
+test('redactAll — null/undefined se devuelven tal cual (null-safe)', () => {
+    assert.strictEqual(redactAll(null), null);
+    assert.strictEqual(redactAll(undefined), undefined);
+    assert.strictEqual(redactAll('texto limpio'), 'texto limpio');
+    assert.ok(!redactAll(`x ${GHP_40} y`).includes(GHP_40));
+});
+
+// --- CA-4 / SEC-3: log forging -----------------------------------------------
+
+test('SEC-3 — claim con `\\n`/`\\r` no forja entradas (1 sola línea, escapado)', () => {
+    const pipelineDir = tmpPipelineDir();
+    const session = 'sec3forge';
+    const file = resolveAuditFile(session, pipelineDir);
+
+    appendSherlockAudit({
+        session, pipelineDir,
+        record: baseRecord({
+            claim: 'línea1\nFORJADA: {"hash_self":"fake"}\r\notra',
+        }),
+    });
+
+    // El archivo gana EXACTAMENTE 1 línea física pese a los \n embebidos.
+    assert.strictEqual(readLines(file).length, 1);
+    const raw = fs.readFileSync(file, 'utf8');
+    // El salto embebido aparece ESCAPADO (\n literal), no como salto real.
+    assert.ok(raw.includes('\\n'), 'el newline embebido debe quedar escapado como \\n');
+    // Una segunda escritura sigue sumando 1 sola línea (no se rompió el conteo).
+    appendSherlockAudit({ session, pipelineDir, record: baseRecord() });
+    assert.strictEqual(readLines(file).length, 2);
+    assert.strictEqual(verifyChain(file).ok, true);
+});
+
+// --- CA-5 / SEC-4: path traversal --------------------------------------------
+
+test('SEC-4 — sesiones maliciosas son rechazadas SIN crear archivo', () => {
+    const badSessions = [
+        '../etc',
+        '..\\windows',
+        '/abs/path',
+        'a/b',
+        'a\\b',
+        'a'+String.fromCharCode(0)+'b',          // NUL
+        '%2e%2e',
+        'dots..dots',        // contiene '.'
+        '',                  // vacío
+        'x'.repeat(65),      // > 64
+        'tab\tname',
+        'space name',
+    ];
+    for (const session of badSessions) {
+        const pipelineDir = tmpPipelineDir();
+        assert.throws(
+            () => appendSherlockAudit({ session, pipelineDir, record: baseRecord() }),
+            /SEC-4|session inválida/,
+            `debió rechazar session=${JSON.stringify(session)}`,
+        );
+        // Fail-closed: no se creó ni el dir de audit ni archivo alguno.
+        const auditDir = auditDirOf(pipelineDir);
+        const created = fs.existsSync(auditDir) ? fs.readdirSync(auditDir) : [];
+        assert.deepStrictEqual(created, [], `no debió crear archivos para ${JSON.stringify(session)}`);
+    }
+});
+
+test('SEC-4 — resolveAuditFile acepta sesiones válidas y arma el path dentro de audit/', () => {
+    const pipelineDir = tmpPipelineDir();
+    const file = resolveAuditFile('Valid_session-123', pipelineDir);
+    assert.ok(file.startsWith(auditDirOf(pipelineDir) + path.sep));
+    assert.ok(file.endsWith('sherlock-Valid_session-123.jsonl'));
+});
+
+test('SEC-4 — pipelineDir inválido es rechazado', () => {
+    assert.throws(() => resolveAuditFile('ok', ''), /pipelineDir/);
+    assert.throws(() => resolveAuditFile('ok', null), /pipelineDir/);
+});
+
+test('SESSION_RE — allowlist exacta', () => {
+    assert.ok(SESSION_RE.test('abc'));
+    assert.ok(SESSION_RE.test('A-b_9'));
+    assert.ok(!SESSION_RE.test('a.b'));
+    assert.ok(!SESSION_RE.test('a/b'));
+    assert.ok(!SESSION_RE.test(''));
+    assert.ok(!SESSION_RE.test('x'.repeat(65)));
+});
+
+// --- validación de argumentos ------------------------------------------------
+
+test('appendSherlockAudit — record inválido es rechazado', () => {
+    const pipelineDir = tmpPipelineDir();
+    for (const bad of [null, undefined, 'str', 42, [1, 2]]) {
+        assert.throws(
+            () => appendSherlockAudit({ session: 'ok', pipelineDir, record: bad }),
+            /record requerido/,
+        );
+    }
+});
+
+test('appendSherlockAudit — timestamp ausente usa default ISO', () => {
+    const pipelineDir = tmpPipelineDir();
+    const session = 'nots';
+    const rec = baseRecord();
+    delete rec.timestamp;
+    appendSherlockAudit({ session, pipelineDir, record: rec });
+    const entry = JSON.parse(readLines(resolveAuditFile(session, pipelineDir))[0]);
+    assert.match(entry.timestamp, /^\d{4}-\d{2}-\d{2}T/);
+});

--- a/.pipeline/lib/sherlock-verifier.js
+++ b/.pipeline/lib/sherlock-verifier.js
@@ -127,6 +127,8 @@ const commanderMP = require('./commander/multi-provider');
 const independentVerifierModule = require('./sherlock-independent-verifier');
 // #3895 — diccionario determinístico claim→fuente canónica (árbitro CA-3).
 const canonicalFactsModule = require('./canonical-facts');
+// #3896 CA-6 — writer del audit JSONL trazable de cada validación canónica.
+const sherlockAuditJsonl = require('./sherlock-audit-jsonl');
 
 // Invariante CA-SEC-9 — hardcoded, NO depende de config.
 const HARDCODED_MAX_REELABORACIONES = 1;
@@ -1007,6 +1009,76 @@ function emitAuditEvent({ pipelineDir, event, payload, fsImpl, auditLog, now }) 
 }
 
 // -----------------------------------------------------------------------------
+// #3896 CA-6 — Audit JSONL trazable de cada validación canónica de Sherlock.
+//
+// Reconstruye el comando canónico (sólo para trazabilidad legible — NO se
+// re-ejecuta) a partir del diccionario `CANONICAL_FACTS`, reusando el mismo
+// `argsBuilder` que `resolveClaim`. Devuelve null ante cualquier falla (la
+// trazabilidad del comando es best-effort; el resto del registro igual se
+// escribe).
+// -----------------------------------------------------------------------------
+function buildCanonicalCommand(claimKey, params) {
+    try {
+        const fact = canonicalFactsModule.CANONICAL_FACTS[claimKey];
+        if (!fact || typeof fact.argsBuilder !== 'function') return null;
+        const args = fact.argsBuilder(params || {});
+        if (!Array.isArray(args)) return null;
+        const bin = fact.source === 'git' ? 'git'
+            : fact.source === 'github-api' ? 'gh'
+            : fact.source === 'heartbeat' ? 'process-check'
+            : fact.source === 'filesystem' ? 'fs-exists'
+            : String(fact.source || 'canonical');
+        return `${bin} ${args.join(' ')}`.trim();
+    } catch {
+        return null;
+    }
+}
+
+// Mapea el tri-estado canónico (`consistent|inconsistent|not_verifiable`) a los
+// enums de CA-1: `resultado` ∈ {true,false,not_verifiable} y `resolucion` ∈
+// {accepted,rejected,escalated}. `commander_vs_sherlock` conserva el tri-estado
+// crudo (es exactamente la comparación commander-vs-árbitro por claim).
+function mapCanonicalStatus(status) {
+    if (status === 'consistent') return { resultado: 'true', resolucion: 'accepted' };
+    if (status === 'inconsistent') return { resultado: 'false', resolucion: 'rejected' };
+    return { resultado: 'not_verifiable', resolucion: 'escalated' };
+}
+
+// Enruta el evento `sherlock_canonical_validation` hacia el writer del audit
+// JSONL (#3896). Best-effort: un fallo del writer NUNCA aborta `verify()`.
+// Reusa el pattern de hashes/no-prompt-crudo de `emitAuditEvent`: sólo persiste
+// claim derivado + comando reconstruido + valor canónico, nunca el prompt.
+function emitCanonicalValidationAudit({ pipelineDir, session, canonicalResults, timestamp, fsImpl, log }) {
+    const _log = typeof log === 'function' ? log : () => {};
+    if (!pipelineDir || !Array.isArray(canonicalResults) || canonicalResults.length === 0) return;
+    for (const c of canonicalResults) {
+        try {
+            const { resultado, resolucion } = mapCanonicalStatus(c.status);
+            sherlockAuditJsonl.appendSherlockAudit({
+                session,
+                pipelineDir,
+                fsImpl,
+                record: {
+                    timestamp,
+                    claim: `#${c.issue}/${c.claim}`,
+                    canonical_command: buildCanonicalCommand(c.claim, { issue: c.issue }),
+                    // `value` canónico = stdout interpretado (true/false/null). El
+                    // stdout/stderr crudos no se propagan (resolveClaim los descarta
+                    // por fail-open); el valor resuelto basta para la trazabilidad.
+                    stdout: c.value != null ? String(c.value) : null,
+                    stderr: null,
+                    resultado,
+                    commander_vs_sherlock: c.status,
+                    resolucion,
+                },
+            });
+        } catch (e) {
+            _log('sherlock', `[CA-6] audit canónico #${c && c.issue}/${c && c.claim} falló (best-effort): ${e && e.message}`);
+        }
+    }
+}
+
+// -----------------------------------------------------------------------------
 // verify — la API principal del módulo. Llamada desde pulpo.js post-`ejecutarClaude`.
 //
 // Args (obligatorios):
@@ -1348,6 +1420,26 @@ async function verify(opts = {}) {
     const notVerifiable = canonicalResults
         .filter(c => c.status === 'not_verifiable')
         .map(c => ({ issue: c.issue, claim: c.claim }));
+
+    // #3896 CA-6 — audit JSONL trazable de cada validación canónica. Best-effort
+    // (no aborta verify()). Session derivada de los issues normalizados; si no
+    // pasa la allowlist SEC-4, el writer la rechaza y el helper loguea y sigue.
+    if (canonicalResults.length > 0) {
+        const _auditSession = (() => {
+            const joined = _normalizedIssues.join('-');
+            return sherlockAuditJsonl.SESSION_RE.test(joined)
+                ? joined
+                : String(_normalizedIssues[0] || '');
+        })();
+        emitCanonicalValidationAudit({
+            pipelineDir,
+            session: _auditSession,
+            canonicalResults,
+            timestamp: new Date(_now).toISOString(),
+            fsImpl,
+            log: _log,
+        });
+    }
 
     // Render para el prompt fiscal — texto plano, una línea por hecho resuelto.
     const canonicalFactsText = canonicalResults.length


### PR DESCRIPTION
## Resumen
Normaliza el #3896: su commit `7a686041` estaba pusheado a la rama pero nunca se abrió PR ni entró a `main`, pese a estar el issue CLOSED con `qa:passed`. Este PR cierra esa brecha.

## Cambios (552 inserciones, 3 archivos)
- `.pipeline/lib/sherlock-audit-jsonl.js` — audit log JSONL trazable de Sherlock
- `.pipeline/lib/sherlock-audit-jsonl.test.js` — tests del módulo
- `.pipeline/lib/sherlock-verifier.js` — sanitización (CA-6, SEC-2/3/4)

## QA
Issue ya validado con label `qa:passed`.

Closes #3896