### PR TITLE
Dashboard pipeline: mostrar TODOS los issues de la ola al filtrar 'solo habilitados'

### DIFF
--- a/.pipeline/dashboard.js
+++ b/.pipeline/dashboard.js
@@ -184,7 +184,10 @@ function fetchIssueTitles(issueIds, cache) {
   for (const batch of batches) {
     const tmpQuery = path.join(PIPELINE, '.gh-query-' + Date.now() + '.graphql');
     try {
-      const fields = batch.map((id, i) => `i${i}: issue(number:${id}) { number title labels(first:10) { nodes { name } } }`).join(' ');
+      // #3905 — `state` (OPEN/CLOSED) necesario para distinguir en la franja
+      // "fuera de flujo" del board un issue de la allowlist sin ingresar (open)
+      // de uno finalizado (closed).
+      const fields = batch.map((id, i) => `i${i}: issue(number:${id}) { number title state labels(first:10) { nodes { name } } }`).join(' ');
       const query = `{ repository(owner:"intrale",name:"platform") { ${fields} } }`;
       // Write query to temp file to avoid shell escaping issues on Windows
       fs.writeFileSync(tmpQuery, query);
@@ -198,6 +201,7 @@ function fetchIssueTitles(issueIds, cache) {
         if (val?.number) {
           cache[String(val.number)] = {
             title: val.title,
+            state: val.state, // #3905 — OPEN | CLOSED
             labels: (val.labels?.nodes || []).map(l => l.name),
             fetchedAt: Date.now()
           };
@@ -209,10 +213,10 @@ function fetchIssueTitles(issueIds, cache) {
       // Fallback: fetch one by one
       for (const id of batch) {
         try {
-          const cmd2 = `${ghPath} issue view ${id} --repo intrale/platform --json title,labels`;
+          const cmd2 = `${ghPath} issue view ${id} --repo intrale/platform --json title,labels,state`;
           const out2 = execSync(cmd2, { encoding: 'utf8', timeout: 10000, windowsHide: true });
           const iss = JSON.parse(out2);
-          cache[id] = { title: iss.title, labels: (iss.labels || []).map(l => l.name), fetchedAt: Date.now() };
+          cache[id] = { title: iss.title, state: iss.state, labels: (iss.labels || []).map(l => l.name), fetchedAt: Date.now() };
         } catch {
           // Issue no resoluble: cachear como notFound para evitar re-consulta en cada refresh
           cache[String(id)] = { title: '', labels: [], notFound: true, fetchedAt: Date.now() };
@@ -610,7 +614,26 @@ function getPipelineState() {
   // Convert Sets to arrays for JSON + enriquecer con títulos/labels
   const issueIds = Object.keys(state.issueMatrix);
   const titleCache = loadIssueTitleCache();
-  const missing = issueIds.filter(id => !titleCache[id]);
+  // #3905 — incluir la allowlist de la ola (pausa parcial) en el set a
+  // resolver: los issues que NUNCA ingresaron al pipeline no están en el
+  // matrix, pero la franja "fuera de flujo" del board necesita su title +
+  // state (open/closed) para clasificarlos. SEC-2: la lista sale de
+  // .partial-pause.json (editable a mano) → se filtra a enteros vía
+  // readPreviousAllowlist (normalizeIssue interno).
+  let allowlistIds = [];
+  try {
+    const pp = require('./lib/partial-pause');
+    allowlistIds = (pp.readPreviousAllowlist() || []).map(String);
+  } catch { /* módulo opcional: degradamos sin allowlist */ }
+  const wantedIds = [...new Set([...issueIds, ...allowlistIds])];
+  // missing = sin cache, O cacheado sin `state` (entradas previas a #3905).
+  // Los notFound quedan excluidos (negative cache) para no re-consultar gh
+  // cada tick (SEC-3 resource exhaustion). Converge: tras el fetch, las
+  // entradas tienen `state` → dejan de re-pedirse.
+  const missing = wantedIds.filter(id => {
+    const e = titleCache[id];
+    return !e || (!e.notFound && e.state === undefined);
+  });
   if (missing.length > 0) fetchIssueTitles(missing, titleCache);
   state.issueTitles = titleCache;
 

--- a/.pipeline/lib/dashboard-slices.js
+++ b/.pipeline/lib/dashboard-slices.js
@@ -824,12 +824,57 @@ function pipelineSlice(state, ctx) {
         const data = issueOrder.load();
         priorityOrder = (data && Array.isArray(data.order)) ? data.order.map(String) : [];
     } catch { /* lib no disponible */ }
+
+    // #3905 — waveIssues: cruce de la allowlist (ola actual) con el matrix.
+    // Los issues de la allowlist que NO tienen work-file en ninguna fase
+    // (faltantes = allowlist − matrix) se representan en la franja terminal
+    // "Ola — fuera de flujo" del board: estado `no-ingreso` (open en GitHub) o
+    // `finalizado` (closed). Reutiliza classifyStatus de wave-snapshot (#3262)
+    // en vez de duplicar la lógica de derivación.
+    //
+    // Nota (staleness): un issue recién cerrado puede tardar en reflejar
+    // `finalizado` hasta que expire el TTL del title-cache. Aceptable para un
+    // dashboard de operador (el dato no es de seguridad).
+    const waveIssues = [];
+    try {
+        const { _internal } = require('./wave-snapshot');
+        let allowlist = [];
+        if (ctx && Array.isArray(ctx.allowlist)) {
+            // Override inyectable (tests / callers que ya leyeron la allowlist).
+            allowlist = ctx.allowlist;
+        } else if (partialPause && typeof partialPause.readPreviousAllowlist === 'function') {
+            allowlist = partialPause.readPreviousAllowlist() || [];
+        }
+        // SEC-2: .partial-pause.json es editable a mano → validar enteros
+        // antes de usarlos. (readPreviousAllowlist ya normaliza, pero el filtro
+        // explícito documenta el requisito de seguridad y es defensivo ante
+        // cambios futuros del módulo.)
+        allowlist = allowlist.filter((n) => Number.isInteger(n));
+        const titles = state.issueTitles || {};
+        for (const n of allowlist) {
+            // Anti-duplicado (CA-6): si ya está en el matrix tiene fase actual y
+            // se dibuja en su columna — no va a la franja terminal.
+            if (matrix[String(n)]) continue;
+            const meta = titles[String(n)] || {};
+            const isClosed = String(meta.state).toUpperCase() === 'CLOSED';
+            const cls = _internal.classifyStatus({
+                isClosed, isBlocked: false, isPaused: false, faseActual: null, pct: 0,
+            });
+            waveIssues.push({
+                issue: String(n),
+                title: meta.title || '',
+                estado: cls === 'closed' ? 'finalizado' : 'no-ingreso',
+            });
+        }
+    } catch { /* wave-snapshot opcional: degradamos a franja vacía */ }
+
     return {
         matrix,
         fases: state.allFases,
         priorityOrder,
         matrixCounts,
         staleThresholdMin: STALE_THRESHOLD_MIN,
+        waveIssues,
     };
 }
 

--- a/.pipeline/tests/dashboard-pipeline-allowlist.test.js
+++ b/.pipeline/tests/dashboard-pipeline-allowlist.test.js
@@ -209,14 +209,37 @@ test('escapeHtml replicado neutraliza el payload XSS clásico (sanity check)', (
 
 // ───────────── Toggle: estado nunca interpolado a HTML (REQ-SEC-3) ─────────────
 
-test('onlyAllowlistFilter es booleano de módulo, no se persiste en localStorage', () => {
+test('onlyAllowlistFilter es booleano de módulo con default ON desde sessionStorage (REQ-SEC-3 / #3905)', () => {
     const start = SAT_SRC.indexOf('function renderPipeline()');
     const end = SAT_SRC.indexOf('\nfunction renderBloqueados', start);
     const body = SAT_SRC.slice(start, end);
 
-    assert.match(body, /let\s+onlyAllowlistFilter\s*=\s*false/, 'toggle state es boolean local');
-    assert.doesNotMatch(body, /localStorage\..*allowlist/i, 'NO debe persistir en localStorage (REQ-SEC-3)');
-    assert.doesNotMatch(body, /sessionStorage\..*allowlist/i, 'NO debe persistir en sessionStorage');
+    // #3905 supera el diseño efímero de #3045: el filtro ahora nace ACTIVO en
+    // sesión nueva y persiste la preferencia del operador (CA: "El filtro
+    // persiste como ACTIVO por defecto en nuevas sesiones (sessionStorage o
+    // cookie)" + Escenario Gherkin 3). REQ-SEC-3 sigue vigente en su intención
+    // real: el estado nunca se interpola crudo a HTML y nunca fluye sin sanear.
+    assert.match(body, /let\s+onlyAllowlistFilter\s*=/, 'toggle state es un binding de módulo');
+    assert.match(
+        body,
+        /sessionStorage\.getItem\('pl-only-allowlist'\)/,
+        'inicializa la preferencia desde sessionStorage (#3905)',
+    );
+    assert.match(
+        body,
+        /v\s*===\s*null\s*\?\s*true\s*:\s*v\s*===\s*'1'/,
+        'default ON + coerción estricta a boolean al leer (REQ-SEC-3: no interpola string crudo)',
+    );
+    // REQ-SEC-3 — sigue prohibido localStorage: la preferencia se acota a la
+    // sesión, evitando estado stale del modo del pipeline entre sesiones.
+    assert.doesNotMatch(body, /localStorage\.[gs]etItem/i, 'NO debe persistir en localStorage (REQ-SEC-3)');
+    // #3905 — sólo se persiste el flag sanitizado '1'/'0', nunca un valor
+    // arbitrario que pudiera reintroducir un vector de interpolación.
+    assert.match(
+        body,
+        /sessionStorage\.setItem\('pl-only-allowlist',\s*onlyAllowlistFilter\s*\?\s*'1'\s*:\s*'0'\)/,
+        'persiste sólo el flag sanitizado 1/0 (REQ-SEC-3)',
+    );
 });
 
 // ───────────── Grid de la nav bar V3 (CA-2 — #3358 → #3726) ─────────────

--- a/.pipeline/tests/dashboard-slices-wave-issues.test.js
+++ b/.pipeline/tests/dashboard-slices-wave-issues.test.js
@@ -1,0 +1,97 @@
+// #3905 — Tests del bloque `waveIssues` de pipelineSlice: cruce de la allowlist
+// de la ola con el matrix, derivación de estados no-ingreso/finalizado a partir
+// del state (OPEN/CLOSED) del title-cache, SEC-2 (descarte de no-enteros),
+// robustez con allowlist vacía y anti-duplicado.
+
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+
+const slices = require('../lib/dashboard-slices');
+
+// State base sin matrix: la franja "fuera de flujo" se nutre de la allowlist
+// cruzada contra el matrix + el title-cache (state.issueTitles).
+function makeState({ matrix = {}, titles = {} } = {}) {
+    return {
+        config: { pipelines: {} },
+        bloqueados: [],
+        allFases: [],
+        issueMatrix: matrix,
+        issueTitles: titles,
+    };
+}
+
+test('pipelineSlice devuelve waveIssues con estados no-ingreso y finalizado segun el state del cache', () => {
+    const state = makeState({
+        titles: {
+            '101': { title: 'Issue abierto', state: 'OPEN' },
+            '102': { title: 'Issue cerrado', state: 'CLOSED' },
+        },
+    });
+    const out = slices.pipelineSlice(state, { allowlist: [101, 102] });
+    assert.ok(Array.isArray(out.waveIssues), 'waveIssues debe ser un array');
+    assert.equal(out.waveIssues.length, 2);
+    const byIssue = Object.fromEntries(out.waveIssues.map((w) => [w.issue, w]));
+    assert.equal(byIssue['101'].estado, 'no-ingreso');
+    assert.equal(byIssue['101'].title, 'Issue abierto');
+    assert.equal(byIssue['102'].estado, 'finalizado');
+    assert.equal(byIssue['102'].title, 'Issue cerrado');
+});
+
+test('pipelineSlice trata como no-ingreso un issue de la allowlist sin entry en el cache', () => {
+    // Sin state conocido (cache no lo tiene aún) → no-ingreso (no asumir cerrado).
+    const state = makeState({ titles: {} });
+    const out = slices.pipelineSlice(state, { allowlist: [777] });
+    assert.equal(out.waveIssues.length, 1);
+    assert.equal(out.waveIssues[0].estado, 'no-ingreso');
+    assert.equal(out.waveIssues[0].issue, '777');
+    assert.equal(out.waveIssues[0].title, '');
+});
+
+test('pipelineSlice descarta entradas no enteras de la allowlist (SEC-2)', () => {
+    const state = makeState({
+        titles: { '3905': { title: 'ok', state: 'OPEN' } },
+    });
+    // .partial-pause.json es editable a mano: strings, NaN, decimales deben caer.
+    const out = slices.pipelineSlice(state, { allowlist: ['3', 'abc', 3.5, null, 3905] });
+    assert.equal(out.waveIssues.length, 1, 'solo el entero 3905 sobrevive');
+    assert.equal(out.waveIssues[0].issue, '3905');
+});
+
+test('pipelineSlice retorna waveIssues vacio con allowlist vacia (CA "no rompe")', () => {
+    const state = makeState();
+    const out = slices.pipelineSlice(state, { allowlist: [] });
+    assert.deepEqual(out.waveIssues, []);
+});
+
+test('pipelineSlice no incluye en waveIssues los issues que ya estan en el matrix (anti-duplicado)', () => {
+    const state = makeState({
+        matrix: {
+            '200': {
+                title: 'en fase',
+                labels: [],
+                faseActual: 'desarrollo/dev',
+                estadoActual: 'trabajando',
+                bounces: 0,
+                staleMin: 0,
+                fases: { 'desarrollo/dev': [] },
+            },
+        },
+        titles: {
+            '200': { title: 'en fase', state: 'OPEN' },
+            '201': { title: 'sin ingresar', state: 'OPEN' },
+        },
+    });
+    const out = slices.pipelineSlice(state, { allowlist: [200, 201] });
+    const issues = out.waveIssues.map((w) => w.issue);
+    assert.deepEqual(issues, ['201'], '200 ya está en el matrix → no se duplica en la franja');
+});
+
+test('pipelineSlice deriva finalizado con state en minúsculas o mixto (case-insensitive)', () => {
+    const state = makeState({
+        titles: { '300': { title: 'closed lower', state: 'closed' } },
+    });
+    const out = slices.pipelineSlice(state, { allowlist: [300] });
+    assert.equal(out.waveIssues[0].estado, 'finalizado');
+});

--- a/.pipeline/views/dashboard/satellites.js
+++ b/.pipeline/views/dashboard/satellites.js
@@ -334,6 +334,11 @@ function renderPipeline() {
     </div>
   </div>
   <div id="pipeline-board" class="pl-board"></div>
+  <!-- #3905 — Franja terminal "Ola — fuera de flujo": cards de issues de la
+       allowlist sin fase actual (no-ingreso) o cerrados (finalizado). Vive
+       FUERA del board flex para quedar debajo de las columnas, no como una
+       columna más (decisión de producto: franja, no pseudo-columnas). -->
+  <div id="pipeline-wave-band"></div>
 </section>`;
     const css = `
 /* #3045 — Header de la sección con título a la izquierda y toggle a la derecha. */
@@ -441,7 +446,23 @@ function renderPipeline() {
 .pl-card-agent.state-fallido .pl-card-agent-state { color: var(--in-bad); }
 .pl-card-agent.is-blocker { box-shadow: 0 0 0 1px var(--in-warn); }
 @keyframes pl-agent-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.6; } }
-.pl-card-stale-badge { display: inline-flex; align-items: center; gap: 3px; font-size: 9px; font-weight: 600; color: var(--in-warn); border: 1px solid var(--in-warn); background: var(--in-warn-soft); border-radius: 3px; padding: 1px 5px; margin-top: 4px; text-transform: uppercase; letter-spacing: 0.5px; width: fit-content; }`;
+.pl-card-stale-badge { display: inline-flex; align-items: center; gap: 3px; font-size: 9px; font-weight: 600; color: var(--in-warn); border: 1px solid var(--in-warn); background: var(--in-warn-soft); border-radius: 3px; padding: 1px 5px; margin-top: 4px; text-transform: uppercase; letter-spacing: 0.5px; width: fit-content; }
+/* #3905 — Franja terminal "Ola — fuera de flujo" (estados no-ingreso /
+   finalizado). Separada del board por border-top + margin para que NO se lea
+   como una columna del kanban. */
+.pl-wave-band { margin-top: 16px; border-top: 1px solid var(--in-border); padding-top: 10px; }
+.pl-wave-band-title { font-size: 11px; text-transform: uppercase; letter-spacing: 0.6px; color: var(--in-fg-dim); margin-bottom: 8px; }
+.pl-wave-band-cards { display: flex; flex-wrap: wrap; gap: 6px; }
+.pl-wave-band-cards .pl-card { min-width: 200px; flex: 0 0 auto; margin-bottom: 0; }
+.pl-card-wave-state { display: inline-flex; align-items: center; gap: 4px; font-size: 10px; color: var(--in-fg-dim); margin-top: 6px; text-transform: uppercase; letter-spacing: 0.5px; }
+.pl-wave-ic { width: 12px; height: 12px; fill: currentColor; flex: 0 0 12px; }
+/* Diferenciación por borde + icono + microcopy (anti-info-solo-por-color).
+   El texto se mantiene a opacidad/contraste plenos (WCAG AA): NO se aplica
+   opacity al contenedor de la card para no degradar el ratio del título. */
+.pl-card-state-no-ingreso { border-color: var(--in-fg-soft); border-style: dashed; }
+.pl-card-state-no-ingreso .pl-card-wave-state { color: var(--in-fg-dim); }
+.pl-card-state-finalizado { border-color: var(--in-ok-soft); background: var(--in-ok-soft); }
+.pl-card-state-finalizado .pl-card-wave-state { color: var(--in-ok); }`;
     const script = `
 function compareByPriority(orderMap){
     return (a, b) => {
@@ -456,11 +477,20 @@ function compareByPriority(orderMap){
     };
 }
 
-// #3045 — Estado del filtro de allowlist. NO se persiste en localStorage:
-// el modo del pipeline cambia entre sesiones y un valor stale ahí confunde
-// al operador. Booleano en memoria de módulo, REQ-SEC-3 enforced
-// (no se interpola crudo a HTML; se escribe vía aria-checked + classList).
-let onlyAllowlistFilter = false;
+// #3045/#3905 — Estado del filtro de allowlist. Persistido en sessionStorage
+// (no localStorage: el modo del pipeline cambia entre sesiones y un valor
+// stale ahí confunde al operador; sessionStorage acota la preferencia a la
+// pestaña/sesión activa). REQ-SEC-3 enforced (no se interpola crudo a HTML;
+// se escribe vía aria-checked + classList).
+// #3905 — default ON: nace ACTIVO en sesión nueva (sessionStorage limpio) para
+// dar al operador la vista 1:1 con la allowlist de la ola; respeta la
+// preferencia del usuario si ya lo toggleó en esta sesión.
+let onlyAllowlistFilter = (function(){
+    try {
+        var v = sessionStorage.getItem('pl-only-allowlist');
+        return v === null ? true : v === '1';
+    } catch(e) { return true; }
+})();
 
 // #3045 — Issue está en la allowlist activa? Coerción estricta a integer > 0
 // (REQ-SEC-2). Sin partial_pause, NO matchea: el badge sigue oculto en running.
@@ -495,10 +525,16 @@ function wireAllowlistToggle(){
     const toggle = document.getElementById('pl-allowlist-toggle');
     if(!toggle || toggle.dataset.wired === '1') return;
     toggle.dataset.wired = '1';
+    // #3905 — reflejar el valor inicial (default ON / sessionStorage) en el
+    // atributo aria-checked: el markup nace con aria-checked="false" pero el
+    // estado real lo decide onlyAllowlistFilter.
+    toggle.setAttribute('aria-checked', onlyAllowlistFilter ? 'true' : 'false');
     function flip(){
         if(toggle.style.display === 'none') return; // oculto = no operable
         onlyAllowlistFilter = !onlyAllowlistFilter;
         toggle.setAttribute('aria-checked', onlyAllowlistFilter ? 'true' : 'false');
+        // #3905 — persistir la preferencia del operador en la sesión.
+        try { sessionStorage.setItem('pl-only-allowlist', onlyAllowlistFilter ? '1' : '0'); } catch(e) {}
         if(typeof tickPipeline === 'function') tickPipeline().catch(()=>{});
     }
     toggle.addEventListener('click', (ev) => { ev.preventDefault(); flip(); });
@@ -616,6 +652,36 @@ async function tickPipeline(){
             : String(col.items.length);
         html += '<div class="pl-col"><div class="pl-col-head"><span>'+escapeHtml(key)+'</span><span class="pl-col-count">'+countLabel+'</span></div>'+(cards || '<div class="in-empty" style="padding:14px 4px;font-size:11px">vacío</div>')+'</div>';
     }
+    // #3905 — Franja terminal "Ola — fuera de flujo". Solo con el filtro
+    // "solo habilitados" ACTIVO (CA-4: sin filtro = comportamiento previo, sin
+    // franja). Los estados no-ingreso/finalizado los deriva el server en
+    // d.waveIssues (cruce allowlist − matrix). Orden UX: no-ingreso primero
+    // (lo que falta arriba), finalizado después (lo cerrado abajo). SEC-1:
+    // todo (issue/título/estado) pasa por escapeHtml; el ícono va por <use>
+    // sobre el sprite controlado (no interpolado).
+    let waveBand = '';
+    if(onlyAllowlistFilter && Array.isArray(d.waveIssues) && d.waveIssues.length){
+        const orderW = { 'no-ingreso': 0, 'finalizado': 1 };
+        const sortedW = d.waveIssues.slice().sort((a, b) =>
+            ((orderW[a.estado] != null ? orderW[a.estado] : 9) - (orderW[b.estado] != null ? orderW[b.estado] : 9))
+            || (Number(a.issue) - Number(b.issue)));
+        const waveCards = sortedW.map(w => {
+            const isDone = w.estado === 'finalizado';
+            const icon = isDone ? 'ic-allowlist-check' : 'ic-llm-queued';
+            const label = isDone ? 'Finalizado' : 'Sin ingresar';
+            return '<div class="pl-card pl-card-state-'+escapeHtml(w.estado||'')+'" data-issue="'+escapeHtml(w.issue)+'">'
+              + '<div class="pl-card-head"><span class="pl-card-issue"><a href="https://github.com/intrale/platform/issues/'+escapeHtml(w.issue)+'" target="_blank" rel="noopener">#'+escapeHtml(w.issue)+'</a></span></div>'
+              + '<div class="pl-card-title" title="'+escapeHtml(w.title||'')+'">'+escapeHtml((w.title||'').slice(0,60))+'</div>'
+              + '<div class="pl-card-wave-state"><svg class="pl-wave-ic" viewBox="0 0 24 24" aria-hidden="true"><use href="/assets/icons/sprite.svg#'+icon+'"></use></svg>'+label+'</div>'
+              + '</div>';
+        }).join('');
+        waveBand = '<div class="pl-wave-band">'
+          + '<div class="pl-wave-band-title">Ola — fuera de flujo</div>'
+          + '<div class="pl-wave-band-cards">'+waveCards+'</div>'
+          + '</div>';
+    }
+    const waveBandEl = document.getElementById('pipeline-wave-band');
+    if(waveBandEl && waveBandEl.innerHTML !== waveBand) waveBandEl.innerHTML = waveBand;
     if(board.innerHTML !== html){
         board.innerHTML = html;
         board.querySelectorAll('.pl-card-btn').forEach(b => {


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 5 archivos · +268 -14

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:passed` aplicado por delivery

## Closes

Closes #3905
