### PR TITLE
EP5-H2 – Claim-by-rename en reencolarInfraBloqueados y reserva atómica de slots

### DIFF
--- a/.pipeline/lib/slot-claim.js
+++ b/.pipeline/lib/slot-claim.js
@@ -1,0 +1,231 @@
+// =============================================================================
+// slot-claim.js — Primitivas atómicas para cerrar dos TOCTOU del orquestador
+// (issue #3939, épica EP-5 #3937):
+//
+//   1. claim-by-rename: propiedad exclusiva de un work file en `pendiente/`
+//      antes de operar sobre él (usado en `reencolarInfraBloqueados`).
+//   2. reserva atómica de slot: conteo + move+spawn dentro de una sección
+//      crítica por skill, para no superar `maxConcurrencia` (brazo de
+//      lanzamiento).
+//   3. sweep de claims huérfanos: restaurar `*.claimed-<pid>` dejados por un
+//      proceso muerto, reusando la heurística PID+startTime de `file-lock`.
+//
+// Diseño
+// ------
+//   - Cero deps npm — solo `fs`, `path` del core y `lib/file-lock`.
+//   - `fs.renameSync` es atómico en POSIX y Windows: gana un solo proceso, el
+//     perdedor recibe `ENOENT`/`EEXIST`. Misma garantía que `moveFile`
+//     (`pulpo.js:986`).
+//   - La fuente de verdad DURABLE sigue siendo el filesystem (`trabajando/`).
+//     El lock de slot solo cierra la ventana de admisión entre el conteo y el
+//     move — no mantiene estado de vida del agente.
+//   - Inyección de `fsImpl`/`fl`/`now` para tests sin tocar disco real.
+//
+// Seguridad (requisitos del issue #3939)
+// --------------------------------------
+//   - CWE-22/CWE-59: `claimPath` se construye SOLO por template sobre el path
+//     ya validado (proviene de `listWorkFiles`, confinado a `pendiente/`).
+//     Nunca se deriva el sufijo de contenido no sanitizado del work file.
+//   - CWE-367 (PID reciclado): el sweep reusa `file-lock._internal.isPidAlive`
+//     + `STALE_AGE_MS`, NO un simple "¿el PID existe?".
+//   - CWE-404/CWE-772 (self-DoS): la reserva usa `withLockSync`, que libera el
+//     lock SIEMPRE en su `finally` interno (nunca `acquireLockSync` suelto).
+// =============================================================================
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const fileLock = require('./file-lock');
+
+// Patrón de un archivo de claim: `<nombreCanonico>.claimed-<pid>`.
+const CLAIM_RE = /^(.+)\.claimed-(\d+)$/;
+
+/**
+ * Reclama propiedad exclusiva de `filePath` renombrándolo a
+ * `<filePath>.claimed-<pid>`.
+ *
+ * ⚠ EXCLUSIVIDAD REAL VÍA `file-lock`, NO vía el retorno de `renameSync`.
+ * ----------------------------------------------------------------------------
+ * En Windows (entorno target del proyecto) el valor de retorno de
+ * `fs.renameSync` NO es una señal confiable de exclusión bajo concurrencia
+ * real: se verificó empíricamente (8 procesos hijo alineados por IPC) que
+ * VARIOS procesos reciben "éxito" para el mismo `source` aunque el filesystem
+ * termina con un solo archivo físico. Confiar en `ENOENT`/`EEXIST` del rename
+ * dejaría a 2+ procesos creyéndose dueños → doble reencolado (el TOCTOU que
+ * este issue cierra). La decisión de ownership la toma `file-lock`
+ * (`linkSync` atómico, exactamente-uno en 8/8 trials), y el rename se ejecuta
+ * DENTRO de la sección crítica.
+ *
+ * @param {string} filePath — path del work file (ya validado/confinado).
+ * @param {number} pid — pid del proceso que reclama (process.pid).
+ * @param {object} [opts]
+ * @param {object} [opts.fsImpl=fs] — inyectable para tests.
+ * @param {object} [opts.fl=fileLock] — inyectable para tests.
+ * @param {number} [opts.timeoutMs=2000] — acotado (anti self-DoS).
+ * @returns {{claimed: boolean, claimPath?: string, reason?: string}}
+ *   - `{ claimed: true, claimPath }` si ganó la sección crítica.
+ *   - `{ claimed: false, reason: 'ENOENT'|'EEXIST' }` si otro proceso lo tomó.
+ */
+function claimByRename(filePath, pid, opts = {}) {
+  const fsImpl = opts.fsImpl || fs;
+  const fl = opts.fl || fileLock;
+  const timeoutMs = opts.timeoutMs || 2000;
+  // CWE-22/CWE-59: el sufijo es un template sobre `filePath`, sin datos del
+  // contenido del work file. Confinado al mismo directorio.
+  const claimPath = `${filePath}.claimed-${pid}`;
+  let result = { claimed: false, reason: 'ENOENT' };
+  fl.withLockSync(filePath, () => {
+    if (!fsImpl.existsSync(filePath)) {
+      // Otro proceso ya lo reclamó (lo renombró) antes de que ganáramos el lock.
+      result = { claimed: false, reason: 'ENOENT' };
+      return;
+    }
+    try {
+      fsImpl.renameSync(filePath, claimPath);
+      result = { claimed: true, claimPath };
+    } catch (e) {
+      if (e && (e.code === 'ENOENT' || e.code === 'EEXIST')) {
+        result = { claimed: false, reason: e.code };
+        return;
+      }
+      throw e;
+    }
+  }, { timeoutMs, component: 'slot-claim' });
+  return result;
+}
+
+/**
+ * Restaura un archivo reclamado a su nombre canónico (best-effort).
+ * No-op si el claim ya no existe.
+ *
+ * @returns {boolean} true si restauró.
+ */
+function restoreClaim(claimPath, canonicalPath, fsImpl = fs) {
+  try {
+    if (!fsImpl.existsSync(claimPath)) return false;
+    if (fsImpl.existsSync(canonicalPath)) {
+      // Ya hay un canónico (otro proceso lo restauró/reencoló) → descartar el
+      // claim para no pisarlo.
+      try { fsImpl.unlinkSync(claimPath); } catch {}
+      return false;
+    }
+    fsImpl.renameSync(claimPath, canonicalPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Reserva atómica de un slot por skill. Ejecuta `onAcquired()` SOLO si, dentro
+ * de la sección crítica, `countFn() < max`. El lock se libera siempre
+ * (semántica de `withLockSync`).
+ *
+ * @param {string} slotLockFile — path base del lock (`.lock` se deriva).
+ * @param {object} opts
+ * @param {number} opts.max — tope de concurrencia del skill.
+ * @param {() => number} opts.countFn — conteo observacional (trabajando/).
+ * @param {() => void} opts.onAcquired — move+spawn; corre dentro del lock.
+ * @param {number} [opts.timeoutMs=2000] — acotado para no frenar el tick.
+ * @param {object} [opts.fl=fileLock] — inyectable para tests.
+ * @param {(payload:object)=>void} [opts.notify] — alerta en fallo de lock.
+ * @returns {boolean} true si reservó y lanzó.
+ */
+function reserveSlot(slotLockFile, opts) {
+  const {
+    max,
+    countFn,
+    onAcquired,
+    timeoutMs = 2000,
+    fl = fileLock,
+    notify,
+  } = opts;
+  let launched = false;
+  fl.withLockSync(
+    slotLockFile,
+    () => {
+      // Re-check AUTORITATIVO dentro del lock: cierra la ventana TOCTOU entre
+      // el conteo y el move+spawn. `trabajando/` es la fuente de verdad.
+      if (countFn() >= max) return;
+      onAcquired();
+      launched = true;
+    },
+    { timeoutMs, component: 'slot-claim', notify },
+  );
+  return launched;
+}
+
+/**
+ * Barre claims huérfanos (`*.claimed-<pid>`) en una lista de directorios y los
+ * restaura al nombre canónico SOLO si el PID no está vivo o el claim supera
+ * `STALE_AGE_MS` (CWE-367: un PID reciclado no debe revivir un huérfano).
+ *
+ * Un `*.claimed-<pid-vivo>` reciente NO se toca.
+ *
+ * @param {string[]} dirs — directorios a barrer (ej. todos los `pendiente/`).
+ * @param {object} [opts]
+ * @param {object} [opts.fsImpl=fs]
+ * @param {object} [opts.fl=fileLock]
+ * @param {() => number} [opts.now=Date.now]
+ * @param {(msg:string)=>void} [opts.log]
+ * @returns {{restored: number, discarded: number, skipped: number}}
+ */
+function sweepOrphanClaims(dirs, opts = {}) {
+  const fsImpl = opts.fsImpl || fs;
+  const fl = opts.fl || fileLock;
+  const now = opts.now || Date.now;
+  const log = opts.log || (() => {});
+  const staleAgeMs = fl._internal.STALE_AGE_MS;
+
+  let restored = 0;
+  let discarded = 0;
+  let skipped = 0;
+
+  for (const dir of dirs) {
+    let entries;
+    try { entries = fsImpl.readdirSync(dir); } catch { continue; }
+    for (const name of entries) {
+      const m = CLAIM_RE.exec(name);
+      if (!m) continue;
+      const canonicalName = m[1];
+      const pid = parseInt(m[2], 10);
+      const claimPath = path.join(dir, name);
+
+      let ageMs = Infinity;
+      try { ageMs = now() - fsImpl.statSync(claimPath).mtimeMs; } catch { continue; }
+
+      // No tocar un claim VIVO y RECIENTE — pertenece a un proceso en curso.
+      if (fl._internal.isPidAlive(pid) && ageMs < staleAgeMs) {
+        skipped++;
+        continue;
+      }
+
+      const canonicalPath = path.join(dir, canonicalName);
+      try {
+        if (fsImpl.existsSync(canonicalPath)) {
+          // Ya hay un canónico → el huérfano es redundante, descartarlo.
+          fsImpl.unlinkSync(claimPath);
+          discarded++;
+          log(`claim huérfano ${name} descartado (canónico ya existe)`);
+        } else {
+          fsImpl.renameSync(claimPath, canonicalPath);
+          restored++;
+          log(`claim huérfano ${name} (pid ${pid}, age ${Math.round(ageMs / 1000)}s) restaurado a ${canonicalName}`);
+        }
+      } catch (e) {
+        log(`error barriendo claim huérfano ${name}: ${e.message}`);
+      }
+    }
+  }
+
+  return { restored, discarded, skipped };
+}
+
+module.exports = {
+  claimByRename,
+  restoreClaim,
+  reserveSlot,
+  sweepOrphanClaims,
+  CLAIM_RE,
+};

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -45,6 +45,10 @@ const visualGate = require('./lib/visual-gate');
 // #2549 — Detección de bloqueo humano en motivos de rechazo + helpers de marker.
 // Evita relanzar al infinito skills cuyo rechazo es "esperando merge humano".
 const humanBlock = require('./lib/human-block');
+// #3939 — Primitivas atómicas anti-TOCTOU: claim-by-rename + reserva de slot +
+// sweep de claims huérfanos (épica EP-5 #3937).
+const slotClaim = require('./lib/slot-claim');
+const fileLock = require('./lib/file-lock');
 // #2490 — Pausa parcial con allowlist explícita de issues
 const partialPause = require('./lib/partial-pause');
 // #3518 CA-6 — Detector de desync waves.json ↔ .partial-pause.json
@@ -773,18 +777,38 @@ function reencolarInfraBloqueados(config) {
   }
 
   // ── Fase 3 — YAML: limpiar markers de infra en cada archivo ───────────
+  //
+  // #3939 (CA-1) — CLAIM-BY-RENAME: entre el scan (Fase 1, sin lock) y este
+  // write hay una ventana TOCTOU donde otro tick/proceso podría mover o
+  // reclamar el mismo archivo → doble reencolado. `slotClaim.claimByRename`
+  // reclama propiedad exclusiva renombrando a `*.claimed-<pid>` DENTRO de una
+  // sección crítica de `file-lock` (la exclusividad real la da el lock: en
+  // Windows el retorno de `fs.renameSync` no es confiable bajo concurrencia,
+  // ver slot-claim.js). Si otro proceso ganó (`ENOENT`/`EEXIST`) salteamos el
+  // candidato (no es error). Operamos sobre el `claimPath` y restauramos el
+  // nombre canónico al final.
   const reencolados = [];
   for (const c of candidatos) {
+    const claim = slotClaim.claimByRename(c.path, process.pid);
+    if (!claim.claimed) {
+      // Otro proceso/tick lo reclamó primero — saltar, no contar como error.
+      log('precheck', `#${c.issue} ya reclamado por otro proceso (${claim.reason}), salteando reencolado`);
+      continue;
+    }
     try {
       // Anotar la ventana `reintentando` en el propio work file para que otros
       // consumidores (dashboard, diagnosticos) puedan leerlo sin consultar el
       // state global. Campo no obligatorio, solo metadata.
       c.cleaned.retrying_until_ms = retryingUntil;
       c.cleaned.retrying_since_ms = tickStartMs;
-      writeYaml(c.path, c.cleaned);
+      writeYaml(claim.claimPath, c.cleaned);
+      fs.renameSync(claim.claimPath, c.path); // devolver al nombre canónico
       reencolados.push(c.issue);
     } catch (e) {
       log('precheck', `Error reencolando #${c.issue}: ${e.message}`);
+      // Best-effort: si quedó el claim sin restaurar, devolver el nombre
+      // canónico para que el archivo no quede invisible al scan.
+      slotClaim.restoreClaim(claim.claimPath, c.path);
     }
   }
 
@@ -4412,6 +4436,34 @@ function reboteVerificacionABuild(issue, pipelineName, preflightResult) {
   }
 }
 
+/**
+ * #3939 (CA-4) — Barrido de claims huérfanos (`*.claimed-<pid>`) en todos los
+ * `pendiente/`. Un proceso que muere entre el `renameSync(c.path, claimPath)` y
+ * el restore en `reencolarInfraBloqueados` deja el archivo invisible al scan
+ * (issue trabado). Reusa la heurística PID+startTime de `file-lock` (NO un
+ * simple "¿el PID existe?": un PID reciclado por el SO revive un huérfano,
+ * CWE-367). Best-effort: nunca rompe el tick.
+ */
+function sweepClaimsHuerfanos(config) {
+  const dirs = [];
+  for (const [pipelineName, pipelineConfig] of Object.entries(config.pipelines || {})) {
+    for (const fase of pipelineConfig.fases || []) {
+      dirs.push(path.join(fasePath(pipelineName, fase), 'pendiente'));
+    }
+  }
+  try {
+    const res = slotClaim.sweepOrphanClaims(dirs, {
+      fl: fileLock,
+      log: (msg) => log('huerfanos', msg),
+    });
+    if (res.restored > 0 || res.discarded > 0) {
+      log('huerfanos', `🧹 claims huérfanos: ${res.restored} restaurados, ${res.discarded} descartados (skipped=${res.skipped})`);
+    }
+  } catch (e) {
+    log('huerfanos', `Error en sweep de claims huérfanos: ${e.message}`);
+  }
+}
+
 function brazoLanzamiento(config) {
   // Circuit breaker de infra (#2305): si está abierto, no tomar nuevos issues.
   // Se reabre manualmente con `node .pipeline/resume.js` una vez validada la red.
@@ -4737,44 +4789,75 @@ function brazoLanzamiento(config) {
       continue;
     }
 
-    // Mover a trabajando/ (atómico)
+    // Mover a trabajando/ + spawn dentro de una SECCIÓN CRÍTICA por skill
+    // (#3939, CA-2/CA-3). El check de concurrencia de arriba (`running >=
+    // maxConcurrencia`) es un fast-path: evita pagar el preflight cuando el
+    // slot ya está obviamente lleno. Pero entre ese conteo y este move hay una
+    // ventana TOCTOU: dos ticks/procesos podrían ver el mismo `running` y ambos
+    // lanzar, superando `maxConcurrencia`. El lock `.slots.<skill>` re-verifica
+    // `countRunningBySkill` DENTRO de la sección crítica y serializa el move,
+    // de modo que a lo sumo `maxConcurrencia` archivos terminan en trabajando/.
+    //
+    // El lock SOLO cubre la admisión (conteo + move + spawn), no la vida del
+    // agente: la fuente de verdad durable sigue siendo `trabajando/`. La muerte
+    // prematura del agente ya está cubierta por el on-exit del Pulpo. CA-3:
+    // `withLockSync` libera el lock SIEMPRE (finally interno), con timeout
+    // acotado para no frenar el tick (anti self-DoS).
+    const slotLockFile = path.join(PIPELINE, `.slots.${skill}`);
+    let launched = false;
+    let slotErrored = false;
     try {
-      const trabajandoPath = moveFile(archivo.path, trabajandoDir);
+      launched = slotClaim.reserveSlot(slotLockFile, {
+        max: maxConcurrencia,
+        countFn: () => countRunningBySkill(skill),
+        timeoutMs: 2000,
+        notify: ({ message, detail }) => log('lanzamiento', `⚠️ slot-lock ${skill}: ${message} — ${detail || ''}`),
+        onAcquired: () => {
+          const trabajandoPath = moveFile(archivo.path, trabajandoDir);
 
-      // Lanzar agente (todas las fases, incluyendo build)
-      // Capa 3: pasar qaMode al agente QA via extraEnv
-      const extraEnv = {};
-      if (preflightResult && preflightResult.qaMode) {
-        extraEnv.QA_MODE = preflightResult.qaMode;
-        extraEnv.QA_ISSUE = String(issue);
-        extraEnv.QA_BASE_URL = 'https://mgnr0htbvd.execute-api.us-east-2.amazonaws.com/dev';
-        if (preflightResult.flavors && preflightResult.flavors.length > 0) {
-          extraEnv.QA_FLAVOR = preflightResult.flavors[0];
-        }
-        if (preflightResult.emulatorSerial) {
-          extraEnv.QA_EMULATOR_SERIAL = preflightResult.emulatorSerial;
-        }
+          // Lanzar agente (todas las fases, incluyendo build)
+          // Capa 3: pasar qaMode al agente QA via extraEnv
+          const extraEnv = {};
+          if (preflightResult && preflightResult.qaMode) {
+            extraEnv.QA_MODE = preflightResult.qaMode;
+            extraEnv.QA_ISSUE = String(issue);
+            extraEnv.QA_BASE_URL = 'https://mgnr0htbvd.execute-api.us-east-2.amazonaws.com/dev';
+            if (preflightResult.flavors && preflightResult.flavors.length > 0) {
+              extraEnv.QA_FLAVOR = preflightResult.flavors[0];
+            }
+            if (preflightResult.emulatorSerial) {
+              extraEnv.QA_EMULATOR_SERIAL = preflightResult.emulatorSerial;
+            }
 
-        // Inyectar `modo` al archivo YAML para que gate-evidencia-on-exit lo
-        // respete sin depender de que el agente lo escriba. El preflight ya
-        // sabe el qaMode correcto — esa es la fuente de verdad. Si el agente
-        // QA aprueba pero omite el campo (ocurrió con #2159 structural y
-        // disparó falso rechazo aunque el fix #2345 estuviera activo), el
-        // gate igual lee `modo: structural` desde acá.
-        if (skill === 'qa') {
-          try {
-            const data = readYaml(trabajandoPath) || {};
-            data.modo = preflightResult.qaMode;
-            writeYaml(trabajandoPath, data);
-          } catch (e) {
-            log('lanzamiento', `⚠️ No pude inyectar modo al YAML de ${archivo.name}: ${e.message.slice(0, 80)}`);
+            // Inyectar `modo` al archivo YAML para que gate-evidencia-on-exit lo
+            // respete sin depender de que el agente lo escriba. El preflight ya
+            // sabe el qaMode correcto — esa es la fuente de verdad. Si el agente
+            // QA aprueba pero omite el campo (ocurrió con #2159 structural y
+            // disparó falso rechazo aunque el fix #2345 estuviera activo), el
+            // gate igual lee `modo: structural` desde acá.
+            if (skill === 'qa') {
+              try {
+                const data = readYaml(trabajandoPath) || {};
+                data.modo = preflightResult.qaMode;
+                writeYaml(trabajandoPath, data);
+              } catch (e) {
+                log('lanzamiento', `⚠️ No pude inyectar modo al YAML de ${archivo.name}: ${e.message.slice(0, 80)}`);
+              }
+            }
           }
-        }
-      }
-      lanzarAgenteClaude(skill, issue, trabajandoPath, pipelineName, fase, config, extraEnv);
-      anyLaunched = true;
+          lanzarAgenteClaude(skill, issue, trabajandoPath, pipelineName, fase, config, extraEnv);
+        },
+      });
     } catch (e) {
-      log('lanzamiento', `Error moviendo/lanzando ${archivo.name}: ${e.message}`);
+      slotErrored = true;
+      log('lanzamiento', `Error moviendo/lanzando ${archivo.name} (slot ${skill}): ${e.message}`);
+    }
+    if (launched) {
+      anyLaunched = true;
+    } else if (!slotErrored) {
+      // El slot se llenó dentro de la sección crítica (otro proceso ganó la
+      // admisión) — reintentar en el próximo ciclo. CA observabilidad (UX).
+      log('lanzamiento', `slot lleno para ${skill} (#${issue}) al re-verificar bajo lock — reintenta próximo ciclo`);
     }
   }
 
@@ -12431,6 +12514,7 @@ async function mainLoop() {
         // barrido ni lanzamiento; el guard interno previene re-entrada.
         brazoDesbloqueo(config).catch(e => log('desbloqueo', `error en brazo async: ${e.message}`));
         brazoBarrido(config);     // Cuarto: promover entre fases
+        sweepClaimsHuerfanos(config); // #3939 — restaurar claims huérfanos antes de lanzar
         brazoLanzamiento(config); // Quinto: asignar trabajo a agentes
         brazoHuerfanos(config);   // Sexto: recuperar trabajo trabado
         // #3416 — rewind del operador (fire-and-forget). Procesa eventos en

--- a/.pipeline/tests/toctou-claim-slot.test.js
+++ b/.pipeline/tests/toctou-claim-slot.test.js
@@ -1,0 +1,299 @@
+// =============================================================================
+// toctou-claim-slot.test.js — Tests de concurrencia para el fix #3939
+// (épica EP-5 #3937): claim-by-rename + reserva atómica de slot + sweep de
+// claims huérfanos.
+//
+// Las dos primeras suites usan PROCESOS HIJO REALES (child_process.fork) para
+// generar concurrencia genuina cross-process: `lib/file-lock` discrimina holders
+// por pid+startTime, así que worker_threads (que comparten process.pid) NO
+// reproducirían la carrera. Cada hijo arranca a un instante común (barrier por
+// timestamp) y compite sobre el mismo filesystem.
+//
+// Invariantes verificados (CA-6):
+//   - claim-by-rename: EXACTAMENTE-UNA-VEZ sobre el mismo work file.
+//   - reserva de slot: a lo sumo `maxConcurrencia` archivos en `trabajando/`.
+//   - sweep de huérfanos: PID muerto restaura; PID vivo reciente no se toca.
+// =============================================================================
+
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+// -----------------------------------------------------------------------------
+// MODO WORKER — cuando el archivo se forkea con SLOT_WORKER_ROLE, ejecuta la
+// acción de carrera y sale. NO registra tests en ese modo.
+// -----------------------------------------------------------------------------
+if (process.env.SLOT_WORKER_ROLE) {
+  runWorker();
+} else {
+  defineTests();
+}
+
+function busyWaitUntil(epochMs) {
+  while (Date.now() < epochMs) { /* spin para alinear el arranque */ }
+}
+
+function runWorker() {
+  const role = process.env.SLOT_WORKER_ROLE;
+  // Pre-cargar el módulo ANTES del handshake para que el require pesado no
+  // desalinee el arranque de la carrera (causa de flakiness por barrier).
+  const slotClaim = require('../lib/slot-claim');
+
+  // Barrier por IPC: avisamos "ready" y esperamos un `{ start }` del parent,
+  // que sólo lo emite cuando TODOS los hijos están listos. Así la contención es
+  // máxima y determinística, sin depender de tiempos de fork/require.
+  function runAt(startAt, fn) {
+    busyWaitUntil(startAt);
+    let out;
+    try { out = fn(); } catch (e) { out = { error: e.code || e.message }; }
+    process.stdout.write(JSON.stringify(out));
+    process.exit(0);
+  }
+
+  process.on('message', (msg) => {
+    if (!msg || typeof msg.start !== 'number') return;
+    if (role === 'claim') {
+      const target = process.env.SLOT_TARGET;
+      runAt(msg.start, () => {
+        try {
+          return slotClaim.claimByRename(target, process.pid);
+        } catch (e) {
+          return { claimed: false, reason: `THROW:${e.code || e.message}` };
+        }
+      });
+    } else if (role === 'slot') {
+      const lockFile = process.env.SLOT_LOCK_FILE;
+      const skill = process.env.SLOT_SKILL;
+      const max = parseInt(process.env.SLOT_MAX, 10);
+      const trabajando = process.env.SLOT_TRABAJANDO;
+      const myPendiente = process.env.SLOT_PENDIENTE_FILE;
+      runAt(msg.start, () => {
+        const launched = slotClaim.reserveSlot(lockFile, {
+          max,
+          countFn: () => fs.readdirSync(trabajando).filter((f) => f.endsWith(`.${skill}`)).length,
+          timeoutMs: 8000,
+          onAcquired: () => {
+            // Emular el move durable a trabajando/ (atómico).
+            fs.renameSync(myPendiente, path.join(trabajando, path.basename(myPendiente)));
+            // Pequeña ventana ocupada para forzar contención real del lock.
+            busyWaitUntil(Date.now() + 15);
+          },
+        });
+        return { launched, pid: process.pid };
+      });
+    } else {
+      process.exit(0);
+    }
+  });
+
+  // Señal de readiness al parent.
+  if (process.send) process.send({ ready: true });
+}
+
+// -----------------------------------------------------------------------------
+// MODO TEST
+// -----------------------------------------------------------------------------
+function defineTests() {
+  const test = require('node:test');
+  const assert = require('node:assert/strict');
+  const cp = require('child_process');
+
+  const slotClaim = require('../lib/slot-claim');
+  const fileLock = require('../lib/file-lock');
+
+  function mkTmpDir(prefix) {
+    return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  }
+
+  // Lanza N hijos, espera a que TODOS señalen `ready`, luego les difunde un
+  // `start` común (now + delta) para que la carrera arranque alineada. Devuelve
+  // la lista de resultados parseados en el mismo orden de `envs`.
+  function raceWorkers(envs, startDeltaMs = 200) {
+    const children = [];
+    const outs = envs.map(() => '');
+    const readyFlags = envs.map(() => false);
+    const exitPromises = [];
+
+    let resolveAllReady;
+    const allReady = new Promise((r) => { resolveAllReady = r; });
+
+    envs.forEach((env, i) => {
+      const child = cp.fork(__filename, [], {
+        env: { ...process.env, ...env },
+        stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+      });
+      children.push(child);
+      child.stdout.on('data', (d) => { outs[i] += d.toString(); });
+      child.on('message', (msg) => {
+        if (msg && msg.ready) {
+          readyFlags[i] = true;
+          if (readyFlags.every(Boolean)) resolveAllReady();
+        }
+      });
+      exitPromises.push(new Promise((res) => {
+        child.on('exit', () => {
+          let parsed = null;
+          try { parsed = JSON.parse(outs[i].trim()); } catch { parsed = { _raw: outs[i] }; }
+          res(parsed);
+        });
+      }));
+    });
+
+    return allReady.then(() => {
+      const startAt = Date.now() + startDeltaMs;
+      for (const c of children) c.send({ start: startAt });
+      return Promise.all(exitPromises);
+    });
+  }
+
+  // ===========================================================================
+  // Suite 1 — claim-by-rename: exactamente-una-vez
+  // ===========================================================================
+  test('claim-by-rename: exactamente-una-vez bajo N reclamos concurrentes', async () => {
+    const dir = mkTmpDir('toctou-claim-');
+    const target = path.join(dir, '3939.pipeline-dev');
+    fs.writeFileSync(target, 'issue: 3939\n');
+
+    const N = 8;
+    const results = await raceWorkers(
+      Array.from({ length: N }, () => ({
+        SLOT_WORKER_ROLE: 'claim',
+        SLOT_TARGET: target,
+      })),
+    );
+
+    const winners = results.filter((r) => r && r.claimed === true);
+    const losers = results.filter((r) => r && r.claimed === false);
+
+    assert.equal(winners.length, 1, `exactamente un proceso debe ganar el rename (ganaron ${winners.length})`);
+    assert.equal(losers.length, N - 1, 'el resto debe perder');
+    for (const l of losers) {
+      assert.ok(['ENOENT', 'EEXIST'].includes(l.reason), `perdedor con razón inesperada: ${l.reason}`);
+    }
+
+    // El archivo canónico ya NO está (lo tiene el ganador como *.claimed-<pid>).
+    assert.ok(!fs.existsSync(target), 'el work file canónico fue reclamado');
+    const claimed = fs.readdirSync(dir).filter((f) => slotClaim.CLAIM_RE.test(f));
+    assert.equal(claimed.length, 1, 'debe existir exactamente un archivo .claimed-<pid>');
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  // ===========================================================================
+  // Suite 2 — reserva de slot: <= maxConcurrencia
+  // ===========================================================================
+  test('reserva de slot: a lo sumo maxConcurrencia archivos terminan en trabajando/', async () => {
+    const root = mkTmpDir('toctou-slot-');
+    const trabajando = path.join(root, 'trabajando');
+    const pendiente = path.join(root, 'pendiente');
+    fs.mkdirSync(trabajando, { recursive: true });
+    fs.mkdirSync(pendiente, { recursive: true });
+
+    const skill = 'pipeline-dev';
+    const K = 2;            // maxConcurrencia del skill
+    const N = 6;            // intentos de spawn concurrentes
+    const lockFile = path.join(root, `.slots.${skill}`);
+
+    // Un work file por candidato.
+    const candidates = [];
+    for (let i = 0; i < N; i++) {
+      const p = path.join(pendiente, `${1000 + i}.${skill}`);
+      fs.writeFileSync(p, `issue: ${1000 + i}\n`);
+      candidates.push(p);
+    }
+
+    const results = await raceWorkers(
+      candidates.map((p) => ({
+        SLOT_WORKER_ROLE: 'slot',
+        SLOT_LOCK_FILE: lockFile,
+        SLOT_SKILL: skill,
+        SLOT_MAX: String(K),
+        SLOT_TRABAJANDO: trabajando,
+        SLOT_PENDIENTE_FILE: p,
+      })),
+    );
+
+    const launchedCount = results.filter((r) => r && r.launched === true).length;
+    const enTrabajando = fs.readdirSync(trabajando).filter((f) => f.endsWith(`.${skill}`)).length;
+
+    assert.ok(enTrabajando <= K, `no debe superar maxConcurrencia=${K} (hubo ${enTrabajando})`);
+    assert.equal(enTrabajando, K, `con N=${N} > K=${K} deben llenarse exactamente ${K} slots`);
+    assert.equal(launchedCount, enTrabajando, 'cada launched=true corresponde a un archivo movido');
+    // No quedan locks colgados (CA-3: liberación garantizada).
+    assert.ok(!fs.existsSync(`${lockFile}.lock`), 'el lock de slot debe liberarse siempre');
+
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  // ===========================================================================
+  // Suite 3 — sweep de huérfanos: PID muerto restaura, PID vivo reciente no
+  // ===========================================================================
+  test('sweep de huérfanos: PID muerto restaura el archivo; PID vivo reciente no se toca', () => {
+    const dir = mkTmpDir('toctou-sweep-');
+    const pendiente = path.join(dir, 'pendiente');
+    fs.mkdirSync(pendiente, { recursive: true });
+
+    // PID con altísima probabilidad de NO existir.
+    const deadPid = 2147483600;
+    assert.equal(fileLock._internal.isPidAlive(deadPid), false, 'el pid de prueba debe estar muerto');
+
+    // (a) claim huérfano de PID muerto → debe restaurarse.
+    const orphanDead = path.join(pendiente, `4001.guru.claimed-${deadPid}`);
+    fs.writeFileSync(orphanDead, 'issue: 4001\n');
+
+    // (b) claim de PID VIVO (este proceso) y RECIENTE → NO debe tocarse.
+    const orphanAliveRecent = path.join(pendiente, `4002.po.claimed-${process.pid}`);
+    fs.writeFileSync(orphanAliveRecent, 'issue: 4002\n');
+
+    // (c) claim de PID VIVO pero ANTIGUO (> STALE_AGE_MS) → debe restaurarse
+    //     (heurística PID-reciclado: superó el umbral de stale).
+    const orphanAliveStale = path.join(pendiente, `4003.tester.claimed-${process.pid}`);
+    fs.writeFileSync(orphanAliveStale, 'issue: 4003\n');
+    const old = Date.now() - (fileLock._internal.STALE_AGE_MS + 5000);
+    fs.utimesSync(orphanAliveStale, new Date(old), new Date(old));
+
+    const res = slotClaim.sweepOrphanClaims([pendiente], { fl: fileLock });
+
+    // (a) restaurado al nombre canónico.
+    assert.ok(fs.existsSync(path.join(pendiente, '4001.guru')), 'el huérfano de PID muerto debe restaurarse');
+    assert.ok(!fs.existsSync(orphanDead), 'el claim de PID muerto ya no existe');
+
+    // (b) intacto.
+    assert.ok(fs.existsSync(orphanAliveRecent), 'el claim de PID vivo reciente NO debe tocarse');
+    assert.ok(!fs.existsSync(path.join(pendiente, '4002.po')), 'no debe restaurarse un claim vivo reciente');
+
+    // (c) restaurado por antigüedad.
+    assert.ok(fs.existsSync(path.join(pendiente, '4003.tester')), 'el huérfano vivo pero antiguo debe restaurarse');
+
+    assert.equal(res.restored, 2, 'deben restaurarse exactamente 2 (muerto + viejo)');
+    assert.equal(res.skipped, 1, 'debe saltearse exactamente 1 (vivo reciente)');
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  // ===========================================================================
+  // Suite 4 — sweep: claim huérfano con canónico ya presente → descarta
+  // ===========================================================================
+  test('sweep de huérfanos: descarta el claim si el canónico ya existe', () => {
+    const dir = mkTmpDir('toctou-sweep2-');
+    const pendiente = path.join(dir, 'pendiente');
+    fs.mkdirSync(pendiente, { recursive: true });
+
+    const deadPid = 2147483601;
+    const canonical = path.join(pendiente, '5001.guru');
+    const orphan = path.join(pendiente, `5001.guru.claimed-${deadPid}`);
+    fs.writeFileSync(canonical, 'issue: 5001\n');
+    fs.writeFileSync(orphan, 'issue: 5001\n');
+
+    const res = slotClaim.sweepOrphanClaims([pendiente], { fl: fileLock });
+
+    assert.ok(fs.existsSync(canonical), 'el canónico se preserva');
+    assert.ok(!fs.existsSync(orphan), 'el huérfano redundante se descarta');
+    assert.equal(res.discarded, 1, 'debe descartar exactamente 1');
+    assert.equal(res.restored, 0, 'no debe restaurar ninguno');
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+}


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 3 archivos · +649 -35

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:passed` aplicado por delivery

## Closes

Closes #3939
