### PR TITLE
Brazo de lanzamiento re-bloquea issues por leer labels de caché vieja en vez de en vivo (re-bloqueo fantasma)

### DIFF
--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -4456,6 +4456,38 @@ function isIssueClosed(issueNum) {
   return getIssueInfo(issueNum).state === 'CLOSED';
 }
 
+/**
+ * #4023 CA-1 — Decide si un issue debe re-bloquearse por `blocked:dependencies`,
+ * releyendo labels EN VIVO contra GitHub para no caer en el "re-bloqueo
+ * fantasma" causado por la caché stale (LABELS_CACHE_TTL_MS = 10 min).
+ *
+ * Invalida puntualmente la caché de ESTE issue (no baja el TTL global) y
+ * re-fetchea. Devuelve `true` SOLO si el label sigue presente en vivo.
+ *
+ * Extraído como función inyectable para testeo unitario (los defaults usan la
+ * caché y `getIssueLabels` reales del módulo).
+ *
+ * @param {string|number} issue
+ * @param {object} [deps]
+ * @param {() => void} [deps.invalidateCache]
+ * @param {() => string[]} [deps.readLiveLabels]
+ * @returns {boolean}
+ */
+function _shouldReblockForDependencies(issue, {
+  invalidateCache = () => issueLabelsCache.delete(String(issue)),
+  readLiveLabels = () => getIssueLabels(issue),
+} = {}) {
+  try { invalidateCache(); } catch { /* invalidación best-effort */ }
+  let liveLbls;
+  try { liveLbls = readLiveLabels(); }
+  catch {
+    // Fail-closed: si no se puede releer en vivo, mantener el bloqueo (no
+    // arriesgar lanzar un issue que GitHub todavía podría tener bloqueado).
+    return true;
+  }
+  return Array.isArray(liveLbls) && liveLbls.includes('blocked:dependencies');
+}
+
 /** Calcular score de prioridad para un issue (menor = más prioritario) */
 function calcularPrioridad(issueNum, config) {
   const labels = getIssueLabels(issueNum);
@@ -4792,6 +4824,17 @@ function brazoLanzamiento(config) {
     // `bloqueado-dependencias/` para que el dashboard lo vea segregado y
     // el brazoDesbloqueo pueda devolverlo a pendiente/ al destrabar.
     if (issueLbls.includes('blocked:dependencies')) {
+      // #4023 — Re-bloqueo fantasma: `issueLbls` viene de la caché (TTL 10min,
+      // LABELS_CACHE_TTL_MS). Si el issue se destrabó en GitHub dentro de esa
+      // ventana, la caché todavía muestra el label viejo y re-escribiríamos los
+      // archivos de bloqueo en disco (incidente #3953). Antes de actuar,
+      // invalidar SOLO este issue y releer labels en vivo contra GitHub (fuente
+      // de verdad). Si el label ya no está → NO re-bloquear, seguir flujo normal.
+      if (!_shouldReblockForDependencies(issue)) {
+        log('lanzamiento', `🟢 #${issue} label blocked:dependencies ya removido en GitHub (caché stale) — NO re-bloquear (#4023)`);
+        // No mover a bloqueado-dependencias/, no `continue` por bloqueo: el
+        // issue sigue evaluándose por el resto de gates (needs-human, etc.).
+      } else {
       try {
         const blockedDepDir = path.join(fasePath(pipelineName, fase), 'bloqueado-dependencias');
         fs.mkdirSync(blockedDepDir, { recursive: true });
@@ -4824,6 +4867,7 @@ function brazoLanzamiento(config) {
       }
       log('lanzamiento', `#${issue} omitido — blocked:dependencies`);
       continue;
+      } // fin else (#4023): label vigente en vivo
     }
 
     // 0b-bis. NEEDS-HUMAN (#2549): si el issue tiene label needs-human, no
@@ -11882,9 +11926,19 @@ async function brazoDesbloqueoImpl(config) {
       30000
     );
     let blockedIssues = JSON.parse(result || '[]');
+    // #4023 — issues que GitHub reporta con el label EN VIVO. El self-heal los
+    // saltea (ya los consultó este brazo / el label está vigente → no son
+    // fantasmas) para no gastar requests extra.
+    const seenLive = new Set(blockedIssues.map(i => String(i.number)));
     if (blockedIssues.length === 0) {
       // Limpiar datos stale — si ya no hay bloqueados, el dashboard debe saberlo
       try { fs.writeFileSync(path.join(PIPELINE, 'blocked-issues.json'), JSON.stringify({ blockedBy: {}, blocks: {} }, null, 2)); } catch {}
+      // #4023 — Aunque GitHub no liste NINGÚN issue con el label, puede haber
+      // markers huérfanos en disco (re-bloqueo fantasma #3953): el issue se
+      // destrabó en GitHub pero quedó trabado en `bloqueado-dependencias/`.
+      // El brazo principal nunca lo ve (sólo enumera issues con el label). Este
+      // barrido lo cierra. Corre acá, dentro del guard `_unblockRunning`.
+      await _selfHealPhantomBlocks({ allowlistSet, seenLive });
       return;
     }
 
@@ -12107,6 +12161,12 @@ async function brazoDesbloqueoImpl(config) {
       }
     }
 
+    // #4023 — Self-heal de re-bloqueo fantasma: reconciliar markers de disco
+    // contra GitHub en vivo. Corre al final, ya bajo el guard `_unblockRunning`
+    // (sin carrera con el release del brazo principal); `seenLive` evita
+    // re-consultar los issues que este brazo ya procesó.
+    await _selfHealPhantomBlocks({ allowlistSet, seenLive });
+
     // Persistir mapeos para el dashboard
     try {
       fs.writeFileSync(path.join(PIPELINE, 'blocked-issues.json'), JSON.stringify({ blockedBy, blocks }, null, 2));
@@ -12116,6 +12176,158 @@ async function brazoDesbloqueoImpl(config) {
   } catch (e) {
     log('desbloqueo', `Error en brazo de desbloqueo: ${e.message}`);
   }
+}
+
+/**
+ * #4023 — Self-heal del "re-bloqueo fantasma".
+ *
+ * El brazo de lanzamiento puede re-escribir los archivos de bloqueo en disco
+ * leyendo labels de una caché stale (TTL 10min). Si `blocked:dependencies` ya
+ * fue removido en GitHub dentro de esa ventana, el issue queda trabado en disco
+ * PERO el brazo de desbloqueo principal nunca lo ve (enumera sólo issues que
+ * TODAVÍA tienen el label vía `gh issue list --label blocked:dependencies`). Cae
+ * en el hueco entre ambos brazos (incidente #3953).
+ *
+ * Este barrido cierra el hueco: itera los markers de disco
+ * (`listDependencyBlockedMarkers()`) y los reconcilia EN VIVO contra GitHub
+ * (fuente de verdad). Un issue se auto-rescata SOLO si, leído en vivo:
+ *   - ya NO tiene el label `blocked:dependencies`, Y
+ *   - no tiene dependencias abiertas (re-resueltas en vivo con
+ *     `resolveDependencies()`, SIN confiar en el `reason.depends_on: []` del
+ *     marker mínimo — vacío puede significar "deps aún no parseadas").
+ *
+ * Fail-closed: ante cualquier ambigüedad (read en vivo falla, respuesta no
+ * parseable, estado de dep ilegible, issue number no válido) → mantener el
+ * bloqueo. Un falso destrabe lanza trabajo antes de que cierren sus deps.
+ *
+ * Seguridad: el issue se valida como entero positivo (A03) antes de
+ * interpolarlo en cualquier comando `gh` o path; los paths los deriva
+ * `releaseDependencyBlockToPendiente()` anclados a `fasePath(...)` (A01). El log
+ * de auto-rescate sólo registra `{issue numérico, timestamp, motivo fijo}`
+ * (anti log-injection A09 — nunca vuelca título/body crudo).
+ *
+ * Diseñado inyectable para testeo unitario (`node --test`).
+ *
+ * @param {object} [opts]
+ * @param {Set<string>|null} [opts.allowlistSet] — pausa parcial; null = sin filtro.
+ * @param {Set<string>}      [opts.seenLive]     — issues que el brazo principal ya consultó en vivo.
+ * @returns {Promise<{rescued:number, maintained:number}>}
+ */
+async function _selfHealPhantomBlocks({
+  allowlistSet = null,
+  seenLive = new Set(),
+  listMarkers = reboteClassifier.listDependencyBlockedMarkers,
+  releaseFn = reboteClassifier.releaseDependencyBlockToPendiente,
+  ghCall = ghDesbloqueoCall,
+  throttleFn = ghThrottle,
+  resolveDeps = resolveDependencies,
+  logFn = log,
+} = {}) {
+  let markers;
+  try { markers = listMarkers(); }
+  catch (e) {
+    logFn('desbloqueo-selfheal', `[WARN] no se pudieron listar markers (no bloqueante): ${e.message}`);
+    return { rescued: 0, maintained: 0 };
+  }
+  if (!Array.isArray(markers)) return { rescued: 0, maintained: 0 };
+
+  let rescued = 0;
+  let maintained = 0;
+
+  for (const m of markers) {
+    // SEC-2 / A03 — validación numérica estricta del issue ANTES de
+    // interpolarlo en cualquier comando gh o path.
+    if (!m || !Number.isInteger(m.issue) || m.issue <= 0) continue;
+    const issueStr = String(m.issue);
+
+    // Cero requests extra: el brazo principal ya consultó en vivo a estos (y
+    // como aparecieron con el label, no son fantasmas).
+    if (seenLive.has(issueStr)) continue;
+    // Respetar pausa parcial: no rescatar issues fuera del allowlist.
+    if (allowlistSet && !allowlistSet.has(issueStr)) continue;
+
+    // 1) Releer labels + estado EN VIVO (fuente de verdad).
+    let liveLabels = null;
+    let liveState = null;
+    try {
+      throttleFn();
+      const { stdout } = await ghCall(
+        ['issue', 'view', issueStr, '--json', 'labels,state', '--repo', 'intrale/platform'],
+        10000
+      );
+      const parsed = JSON.parse(stdout || '{}');
+      liveLabels = Array.isArray(parsed.labels) ? parsed.labels.map(l => l.name) : null;
+      liveState = typeof parsed.state === 'string' ? parsed.state : null;
+    } catch (e) {
+      logFn('desbloqueo-selfheal', `[INFO] #${issueStr} labels no legibles en vivo — fail-closed, mantengo bloqueo`);
+      maintained++;
+      continue;
+    }
+    if (liveLabels === null) { maintained++; continue; }      // respuesta rara → fail-closed
+    if (liveState === 'CLOSED') continue;                      // issue cerrado: no es un fantasma de bloqueo
+    if (liveLabels.includes('blocked:dependencies')) { maintained++; continue; } // label vigente → mantener
+
+    // 2) Label removido. CA-4: re-resolver deps EN VIVO (NO confiar en
+    //    reason.depends_on del marker). Leer body+comments y resolver.
+    let body = '';
+    let comments = [];
+    try {
+      throttleFn();
+      const { stdout } = await ghCall(
+        ['issue', 'view', issueStr, '--json', 'body,comments', '--repo', 'intrale/platform'],
+        10000
+      );
+      const parsed = JSON.parse(stdout || '{}');
+      body = typeof parsed.body === 'string' ? parsed.body : '';
+      comments = Array.isArray(parsed.comments) ? parsed.comments : [];
+    } catch (e) {
+      logFn('desbloqueo-selfheal', `[INFO] #${issueStr} deps no legibles en vivo — fail-closed, mantengo bloqueo`);
+      maintained++;
+      continue;
+    }
+
+    let resolved;
+    try { resolved = resolveDeps({ body, comments, selfIssue: m.issue }); }
+    catch { resolved = null; }
+    if (resolved == null) { maintained++; continue; }          // ambigüedad → fail-closed
+
+    const declaredDeps = Array.isArray(resolved.deps) ? resolved.deps.map(String) : [];
+
+    // 3) Verificar que ninguna dep declarada siga abierta. Si no se puede leer
+    //    el estado de una dep → asumir abierta (fail-closed, igual que el
+    //    brazo principal).
+    let anyOpen = false;
+    for (const depNum of declaredDeps) {
+      if (!/^\d+$/.test(depNum)) { anyOpen = true; break; }    // A03: dep no numérica → fail-closed
+      try {
+        throttleFn();
+        const { stdout: depState } = await ghCall(
+          ['issue', 'view', depNum, '--json', 'state', '--jq', '.state', '--repo', 'intrale/platform'],
+          10000
+        );
+        if (String(depState).trim() !== 'CLOSED') { anyOpen = true; break; }
+      } catch {
+        anyOpen = true; break;                                  // estado ilegible → fail-closed
+      }
+    }
+    if (anyOpen) { maintained++; continue; }
+
+    // 4) Auto-rescate (CA-2): label removido en GitHub + sin deps abiertas.
+    try {
+      const releaseRes = releaseFn({ issue: m.issue });
+      if (releaseRes && releaseRes.moved > 0) {
+        rescued++;
+        // CA-3 — traza auditable: sólo {issue validado, timestamp, motivo fijo}.
+        logFn('desbloqueo-selfheal',
+          `🩹 #${issueStr} auto-rescatado: label blocked:dependencies removido en GitHub + sin deps abiertas (re-bloqueo fantasma #4023) @ ${new Date().toISOString()} → ${releaseRes.moved} archivo(s) a ${releaseRes.pipeline}/${releaseRes.phase}/pendiente/`);
+      }
+      // moved === 0: el marker ya no estaba (otro ciclo lo movió). Idempotente.
+    } catch (e) {
+      logFn('desbloqueo-selfheal', `[WARN] #${issueStr} release falló (no bloqueante): ${e.message}`);
+    }
+  }
+
+  return { rescued, maintained };
 }
 
 // =============================================================================
@@ -12921,6 +13133,9 @@ if (process.env.PULPO_NO_AUTOSTART === '1') {
     _sanitizeGhArgs,
     _checkAndResetUnblockWedge,
     _maybeLogReentrySkip,
+    // #4023 — re-bloqueo fantasma: lectura en vivo + self-heal (testing).
+    _shouldReblockForDependencies,
+    _selfHealPhantomBlocks,
     UNBLOCK_WEDGE_TIMEOUT_MS,
     REENTRY_LOG_COOLDOWN_MS,
     _getUnblockState: () => ({

--- a/.pipeline/tests/brazo-rebloqueo-fantasma.test.js
+++ b/.pipeline/tests/brazo-rebloqueo-fantasma.test.js
@@ -1,0 +1,313 @@
+// =============================================================================
+// brazo-rebloqueo-fantasma.test.js — Tests del "re-bloqueo fantasma" (#4023).
+//
+// Cubre los criterios de aceptación del issue #4023:
+//   CA-1: el brazo de lanzamiento relee labels EN VIVO (invalidando la caché
+//         stale) antes de re-bloquear; si el label ya fue removido, NO bloquea.
+//   CA-2: self-heal — un issue trabado en disco pero sin label en GitHub y sin
+//         deps abiertas se auto-rescata (releaseDependencyBlockToPendiente).
+//   CA-3: el auto-rescate deja traza {issue, timestamp, motivo} en el log.
+//   CA-4: sin falsos destrabes — label vigente, deps abiertas reales o
+//         cualquier ambigüedad (read fallido, parse error) → mantener bloqueo.
+//
+// Diseño: ambas funciones (`_shouldReblockForDependencies`,
+// `_selfHealPhantomBlocks`) son inyectables; mockeamos gh/markers/release sin
+// tocar el filesystem ni la API real de GitHub.
+//
+// Ejecución: `node --test .pipeline/tests/brazo-rebloqueo-fantasma.test.js`
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+
+process.env.PULPO_NO_AUTOSTART = '1';
+const pulpo = require(path.join(__dirname, '..', 'pulpo.js'));
+
+const { _shouldReblockForDependencies, _selfHealPhantomBlocks } = pulpo;
+
+// --- helpers ---
+
+const noopThrottle = () => {};
+
+/**
+ * Construye un mock de ghCall que rutea por los args del comando gh.
+ * @param {object} cfg
+ * @param {string[]} cfg.labels       — labels live del issue principal
+ * @param {string}   cfg.state        — estado live ('OPEN'|'CLOSED')
+ * @param {string}   [cfg.body]       — body del issue
+ * @param {object[]} [cfg.comments]   — comentarios del issue
+ * @param {object}   [cfg.depStates]  — { '100': 'OPEN', '101': 'CLOSED' }
+ * @param {object}   [cfg.raw]        — overrides crudos: { labelsCall, bodyCall, depCall } => string|Error
+ */
+function makeGhCall(cfg) {
+  return async function ghCall(args) {
+    const json = args[args.indexOf('--json') + 1];
+    // Lectura de estado de dependencia: incluye --jq .state
+    if (args.includes('--jq')) {
+      const depNum = args[args.indexOf('view') + 1];
+      if (cfg.raw && cfg.raw.depCall) {
+        const r = cfg.raw.depCall(depNum);
+        if (r instanceof Error) throw r;
+        return { stdout: r };
+      }
+      const st = (cfg.depStates || {})[depNum] || 'OPEN';
+      return { stdout: st };
+    }
+    if (json === 'labels,state') {
+      if (cfg.raw && cfg.raw.labelsCall) {
+        const r = cfg.raw.labelsCall();
+        if (r instanceof Error) throw r;
+        return { stdout: r };
+      }
+      return { stdout: JSON.stringify({ labels: (cfg.labels || []).map(name => ({ name })), state: cfg.state || 'OPEN' }) };
+    }
+    if (json === 'body,comments') {
+      if (cfg.raw && cfg.raw.bodyCall) {
+        const r = cfg.raw.bodyCall();
+        if (r instanceof Error) throw r;
+        return { stdout: r };
+      }
+      return { stdout: JSON.stringify({ body: cfg.body || '', comments: cfg.comments || [] }) };
+    }
+    throw new Error('ghCall mock: args no reconocidos ' + JSON.stringify(args));
+  };
+}
+
+function captureLog() {
+  const lines = [];
+  return { lines, fn: (brazo, msg) => lines.push(`${brazo}|${msg}`) };
+}
+
+// =============================================================================
+// CA-1 — lectura en vivo antes de re-bloquear
+// =============================================================================
+
+test('CA-1: el brazo NO re-bloquea un issue cuyo blocked:dependencies fue removido dentro de la ventana de caché', () => {
+  let invalidated = false;
+  const should = _shouldReblockForDependencies('3953', {
+    invalidateCache: () => { invalidated = true; },
+    readLiveLabels: () => [], // GitHub en vivo: label ya removido, deps vacías
+  });
+  assert.equal(should, false, 'con el label removido en vivo NO se debe re-bloquear');
+  assert.equal(invalidated, true, 'debe invalidar la caché puntual antes de releer');
+});
+
+test('CA-1: el brazo SÍ re-bloquea si el label sigue vigente en vivo', () => {
+  const should = _shouldReblockForDependencies('3953', {
+    invalidateCache: () => {},
+    readLiveLabels: () => ['blocked:dependencies', 'Ready'],
+  });
+  assert.equal(should, true, 'con el label vigente en vivo se mantiene el bloqueo');
+});
+
+test('CA-1/CA-4: fail-closed — si la relectura en vivo falla, se mantiene el bloqueo', () => {
+  const should = _shouldReblockForDependencies('3953', {
+    invalidateCache: () => {},
+    readLiveLabels: () => { throw new Error('gh wedged'); },
+  });
+  assert.equal(should, true, 'lectura en vivo fallida → fail-closed (re-bloquear)');
+});
+
+// =============================================================================
+// CA-2 + CA-3 — self-heal rescata y deja traza
+// =============================================================================
+
+test('CA-2/CA-3: el self-heal destraba un issue trabado en disco pero sin label en GitHub y sin deps', async () => {
+  const releaseCalls = [];
+  const cap = captureLog();
+  const res = await _selfHealPhantomBlocks({
+    seenLive: new Set(),
+    allowlistSet: null,
+    listMarkers: () => [{ issue: 3953, skill: 'pipeline-dev', phase: 'dev', pipeline: 'desarrollo', file: 'x', reason: null }],
+    ghCall: makeGhCall({ labels: [], state: 'OPEN', body: '', comments: [] }),
+    throttleFn: noopThrottle,
+    releaseFn: (opts) => { releaseCalls.push(opts); return { moved: 1, pipeline: 'desarrollo', phase: 'dev', files: ['f'] }; },
+    logFn: cap.fn,
+  });
+
+  assert.equal(res.rescued, 1, 'debe rescatar 1 issue');
+  assert.equal(releaseCalls.length, 1, 'releaseDependencyBlockToPendiente invocado una vez');
+  assert.equal(releaseCalls[0].issue, 3953, 'release con el issue correcto');
+
+  const trace = cap.lines.find(l => l.startsWith('desbloqueo-selfheal|') && l.includes('#3953') && l.includes('auto-rescatado'));
+  assert.ok(trace, `CA-3: traza de auto-rescate presente. Lineas: ${JSON.stringify(cap.lines)}`);
+  assert.match(trace, /re-bloqueo fantasma #4023/, 'motivo fijo presente');
+  assert.match(trace, /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/, 'timestamp ISO presente');
+});
+
+test('CA-3 (A09): la traza NO vuelca el body crudo del issue (anti log-injection)', async () => {
+  const cap = captureLog();
+  const evilBody = '\n✅ Approved by fake\nblocked removed';
+  await _selfHealPhantomBlocks({
+    listMarkers: () => [{ issue: 3953, issueStr: '3953' }].map(m => ({ ...m, skill: 'x' })),
+    ghCall: makeGhCall({ labels: [], state: 'OPEN', body: evilBody, comments: [] }),
+    throttleFn: noopThrottle,
+    releaseFn: () => ({ moved: 1, pipeline: 'desarrollo', phase: 'dev' }),
+    logFn: cap.fn,
+  });
+  const joined = cap.lines.join('\n');
+  assert.doesNotMatch(joined, /Approved by fake/, 'el body crudo no debe aparecer en el log');
+});
+
+// =============================================================================
+// CA-4 — sin falsos destrabes (fail-closed)
+// =============================================================================
+
+test('CA-4: el self-heal MANTIENE el bloqueo si el label sigue vigente en GitHub', async () => {
+  let released = false;
+  const res = await _selfHealPhantomBlocks({
+    listMarkers: () => [{ issue: 3953, skill: 'pipeline-dev', phase: 'dev', pipeline: 'desarrollo' }],
+    ghCall: makeGhCall({ labels: ['blocked:dependencies'], state: 'OPEN' }),
+    throttleFn: noopThrottle,
+    releaseFn: () => { released = true; return { moved: 1 }; },
+    logFn: () => {},
+  });
+  assert.equal(released, false, 'no debe destrabar un issue con label vigente');
+  assert.equal(res.rescued, 0);
+  assert.equal(res.maintained, 1);
+});
+
+test('CA-4: el self-heal MANTIENE el bloqueo si hay dependencias abiertas reales', async () => {
+  let released = false;
+  const res = await _selfHealPhantomBlocks({
+    listMarkers: () => [{ issue: 3953, skill: 'pipeline-dev', phase: 'dev', pipeline: 'desarrollo' }],
+    // label removido en vivo, pero el body declara dep #100 que sigue OPEN
+    ghCall: makeGhCall({ labels: [], state: 'OPEN', depStates: { '100': 'OPEN' } }),
+    resolveDeps: () => ({ deps: [100], source: 'body' }),
+    throttleFn: noopThrottle,
+    releaseFn: () => { released = true; return { moved: 1 }; },
+    logFn: () => {},
+  });
+  assert.equal(released, false, 'no debe destrabar con una dependencia abierta real');
+  assert.equal(res.rescued, 0);
+  assert.equal(res.maintained, 1);
+});
+
+test('CA-2: el self-heal SÍ destraba si todas las deps declaradas están cerradas', async () => {
+  let released = false;
+  const res = await _selfHealPhantomBlocks({
+    listMarkers: () => [{ issue: 3953, skill: 'pipeline-dev', phase: 'dev', pipeline: 'desarrollo' }],
+    ghCall: makeGhCall({ labels: [], state: 'OPEN', depStates: { '100': 'CLOSED', '101': 'CLOSED' } }),
+    resolveDeps: () => ({ deps: [100, 101], source: 'body' }),
+    throttleFn: noopThrottle,
+    releaseFn: () => { released = true; return { moved: 1, pipeline: 'desarrollo', phase: 'dev' }; },
+    logFn: () => {},
+  });
+  assert.equal(released, true, 'todas las deps cerradas + label removido → destrabar');
+  assert.equal(res.rescued, 1);
+});
+
+test('CA-4 (fail-closed): respuesta de gh no parseable al leer deps → NO destraba', async () => {
+  let released = false;
+  const cap = captureLog();
+  const res = await _selfHealPhantomBlocks({
+    listMarkers: () => [{ issue: 3953, skill: 'pipeline-dev', phase: 'dev', pipeline: 'desarrollo' }],
+    ghCall: makeGhCall({ labels: [], state: 'OPEN', raw: { bodyCall: () => 'esto no es json{{{' } }),
+    throttleFn: noopThrottle,
+    releaseFn: () => { released = true; return { moved: 1 }; },
+    logFn: cap.fn,
+  });
+  assert.equal(released, false, 'respuesta no parseable → fail-closed, mantener bloqueo');
+  assert.equal(res.maintained, 1);
+  assert.ok(cap.lines.some(l => l.includes('deps no legibles')), 'log de fail-closed presente');
+});
+
+test('CA-4 (fail-closed): error de gh al leer labels → NO destraba', async () => {
+  let released = false;
+  const res = await _selfHealPhantomBlocks({
+    listMarkers: () => [{ issue: 3953, skill: 'pipeline-dev', phase: 'dev', pipeline: 'desarrollo' }],
+    ghCall: makeGhCall({ raw: { labelsCall: () => new Error('gh timeout') } }),
+    throttleFn: noopThrottle,
+    releaseFn: () => { released = true; return { moved: 1 }; },
+    logFn: () => {},
+  });
+  assert.equal(released, false, 'gh error en labels → fail-closed');
+  assert.equal(res.maintained, 1);
+});
+
+test('CA-4 (fail-closed): resolveDependencies devuelve null (ambigüedad) → NO destraba', async () => {
+  let released = false;
+  const res = await _selfHealPhantomBlocks({
+    listMarkers: () => [{ issue: 3953, skill: 'pipeline-dev', phase: 'dev', pipeline: 'desarrollo' }],
+    ghCall: makeGhCall({ labels: [], state: 'OPEN' }),
+    resolveDeps: () => null,
+    throttleFn: noopThrottle,
+    releaseFn: () => { released = true; return { moved: 1 }; },
+    logFn: () => {},
+  });
+  assert.equal(released, false, 'resolved == null → fail-closed');
+  assert.equal(res.maintained, 1);
+});
+
+test('self-heal: issue CLOSED en GitHub no se rescata (no es un fantasma de bloqueo)', async () => {
+  let released = false;
+  const res = await _selfHealPhantomBlocks({
+    listMarkers: () => [{ issue: 3953, skill: 'pipeline-dev', phase: 'dev', pipeline: 'desarrollo' }],
+    ghCall: makeGhCall({ labels: [], state: 'CLOSED' }),
+    throttleFn: noopThrottle,
+    releaseFn: () => { released = true; return { moved: 1 }; },
+    logFn: () => {},
+  });
+  assert.equal(released, false, 'issue cerrado → no reingresar a pendiente/');
+  assert.equal(res.rescued, 0);
+});
+
+// =============================================================================
+// Optimización + seguridad
+// =============================================================================
+
+test('self-heal: saltea issues ya consultados por el brazo principal (seenLive), sin requests extra', async () => {
+  let ghCalls = 0;
+  const res = await _selfHealPhantomBlocks({
+    seenLive: new Set(['3953']),
+    listMarkers: () => [{ issue: 3953, skill: 'pipeline-dev', phase: 'dev', pipeline: 'desarrollo' }],
+    ghCall: async () => { ghCalls++; return { stdout: '{}' }; },
+    throttleFn: noopThrottle,
+    releaseFn: () => ({ moved: 1 }),
+    logFn: () => {},
+  });
+  assert.equal(ghCalls, 0, 'seenLive → cero llamadas a gh para ese issue');
+  assert.equal(res.rescued, 0);
+});
+
+test('self-heal: respeta la pausa parcial (allowlistSet) y no rescata issues fuera del allowlist', async () => {
+  let ghCalls = 0;
+  await _selfHealPhantomBlocks({
+    allowlistSet: new Set(['9999']),
+    listMarkers: () => [{ issue: 3953, skill: 'pipeline-dev', phase: 'dev', pipeline: 'desarrollo' }],
+    ghCall: async () => { ghCalls++; return { stdout: '{}' }; },
+    throttleFn: noopThrottle,
+    releaseFn: () => ({ moved: 1 }),
+    logFn: () => {},
+  });
+  assert.equal(ghCalls, 0, 'issue fuera del allowlist → no se consulta ni rescata');
+});
+
+test('SEC (A03): un issue no numérico en el marker se descarta sin interpolar en gh', async () => {
+  let ghCalls = 0;
+  await _selfHealPhantomBlocks({
+    listMarkers: () => [
+      { issue: NaN, skill: 'x', phase: 'dev', pipeline: 'desarrollo' },
+      { issue: -5, skill: 'x', phase: 'dev', pipeline: 'desarrollo' },
+      { issue: '3953; rm -rf /', skill: 'x', phase: 'dev', pipeline: 'desarrollo' },
+    ],
+    ghCall: async () => { ghCalls++; return { stdout: '{}' }; },
+    throttleFn: noopThrottle,
+    releaseFn: () => ({ moved: 1 }),
+    logFn: () => {},
+  });
+  assert.equal(ghCalls, 0, 'issues no enteros positivos no llegan a gh');
+});
+
+test('self-heal: listMarkers que tira excepción no rompe el ciclo (no bloqueante)', async () => {
+  const cap = captureLog();
+  const res = await _selfHealPhantomBlocks({
+    listMarkers: () => { throw new Error('fs error'); },
+    throttleFn: noopThrottle,
+    logFn: cap.fn,
+  });
+  assert.deepEqual(res, { rescued: 0, maintained: 0 });
+  assert.ok(cap.lines.some(l => l.includes('no se pudieron listar markers')), 'log de error no bloqueante');
+});


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 2 archivos · +528 -0

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:skipped` aplicado por delivery

## Closes

Closes #4023
