### PR TITLE
Notificar avance de la ola al entregar cada issue (porcentaje, cerrados/abiertos y cierre de ola)

### DIFF
--- a/.pipeline/config.yaml
+++ b/.pipeline/config.yaml
@@ -638,7 +638,9 @@ deliverable_notifications:
   # EP3-H2 (#3928) — whitelist ampliada a 13 skills. Sincronizada con
   # `attachments_per_skill` (abajo) y `SKILL_SOURCES`
   # (.pipeline/lib/skill-deliverable-attachments.js). Los 3 cambios van juntos.
-  skills: [guru, po, ux, planner, qa, tester, security, build, architect, backend-dev, android-dev, web-dev, pipeline-dev]
+  # #4019 — `delivery` sumado para notificar el avance de ola al entregar/mergear
+  # un issue (la sección de ola solo se calcula para skill=delivery, fase=entrega).
+  skills: [guru, po, ux, planner, qa, tester, security, build, architect, backend-dev, android-dev, web-dev, pipeline-dev, delivery]
   truncate_chars: 1500
   attachment_root: ".pipeline/assets/mockups"
   dedup_window_hours: 24

--- a/.pipeline/lib/__tests__/deliverable-notify-wave.test.js
+++ b/.pipeline/lib/__tests__/deliverable-notify-wave.test.js
@@ -214,6 +214,73 @@ test('CA-5 · runGh que tira excepción → null (capturado)', () => {
     assert.equal(out, null);
 });
 
+// Captura temporal de console.warn para verificar el logger por DEFAULT.
+function captureWarn(fn) {
+    const original = console.warn;
+    const messages = [];
+    console.warn = (...args) => { messages.push(args.join(' ')); };
+    try {
+        fn();
+    } finally {
+        console.warn = original;
+    }
+    return messages;
+}
+
+test('CA-5 · el logger por DEFAULT (sin inyectar logFail) deja traza del fallo de gh', () => {
+    // Reproduce el cableado de PRODUCCIÓN: NO se inyecta `logFail`, solo los
+    // stubs imprescindibles. El default debe ser console.warn, no un no-op,
+    // o el fallo se traga en silencio (lo que el rebote rev-1 detectó).
+    const wave = { number: 3, name: 'Ola 3', issues: [1, 2] };
+    const runGh = fakeRunGh([{ number: 1, state: 'CLOSED' }], { exitCode: 1 });
+    let out;
+    const warnings = captureWarn(() => {
+        out = buildWaveProgressSection({
+            issue: 1,
+            pipelineRoot: '/tmp/x',
+            deps: { resolveWaveForIssue: fakeResolveWave(wave), runGh },
+        });
+    });
+    assert.equal(out, null);
+    assert.equal(warnings.length, 1, 'debe loguear exactamente un warning');
+    assert.match(warnings[0], /\[deliverable-notify\]/);
+    assert.match(warnings[0], /gh issue list/);
+});
+
+test('CA-5 · el logger por DEFAULT deja traza ante JSON inválido', () => {
+    const wave = { number: 3, name: 'Ola 3', issues: [1, 2] };
+    const runGh = () => ({ exit_code: 0, stdout: 'no-es-json', stderr: '' });
+    let out;
+    const warnings = captureWarn(() => {
+        out = buildWaveProgressSection({
+            issue: 1,
+            pipelineRoot: '/tmp/x',
+            deps: { resolveWaveForIssue: fakeResolveWave(wave), runGh },
+        });
+    });
+    assert.equal(out, null);
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /\[deliverable-notify\]/);
+    assert.match(warnings[0], /JSON inválido/);
+});
+
+test('CA-5 · el logger por DEFAULT deja traza ante excepción inesperada', () => {
+    const wave = { number: 3, name: 'Ola 3', issues: [1, 2] };
+    const runGh = () => { throw new Error('spawn falló'); };
+    let out;
+    const warnings = captureWarn(() => {
+        out = buildWaveProgressSection({
+            issue: 1,
+            pipelineRoot: '/tmp/x',
+            deps: { resolveWaveForIssue: fakeResolveWave(wave), runGh },
+        });
+    });
+    assert.equal(out, null);
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /\[deliverable-notify\]/);
+    assert.match(warnings[0], /excepción inesperada/);
+});
+
 // -----------------------------------------------------------------------------
 // CA-6 — seguridad: una sola llamada, sin shell, solo números
 // -----------------------------------------------------------------------------

--- a/.pipeline/lib/__tests__/deliverable-notify-wave.test.js
+++ b/.pipeline/lib/__tests__/deliverable-notify-wave.test.js
@@ -1,0 +1,333 @@
+// =============================================================================
+// deliverable-notify-wave.test.js — #4019
+//
+// Cubre la sección de avance de ola en la notificación de entrega:
+//   - CA-1: avance intermedio → `🌊 Ola N — C/M cerradas (P%) · quedan K ...`
+//   - CA-2: último issue (open === 0) → `🎉 Ola N finalizada — M/M cerradas.`
+//   - CA-3: conteo con estado fresco de GitHub (mock de runGh)
+//   - CA-4: issue sin ola → null, buildText no agrega sección
+//   - CA-5: degradación elegante ante fallo de gh / JSON inválido → null
+//   - CA-6: una sola llamada gh, listado solo con números, input saneado
+//   - G-5: truncado del listado de abiertos
+//
+// Estrategia: inyectamos `deps = { resolveWaveForIssue, runGh }` para no tocar
+// ni waves.json real ni GitHub. `buildWaveProgressSection` es la única capa
+// impura; la testeamos con stubs deterministas.
+//
+// Ejecutar: node --test .pipeline/lib/__tests__/deliverable-notify-wave.test.js
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const dn = require('../deliverable-notify');
+const { buildWaveProgressSection, formatOpenIssueList, buildText } = dn.__forTests__;
+
+// Stub de runGh que devuelve el shape de `runCmd` (exit_code/stdout/stderr).
+function fakeRunGh(states, { exitCode = 0 } = {}) {
+    const calls = [];
+    const fn = (args) => {
+        calls.push(args);
+        return {
+            cmd: `gh ${args.join(' ')}`,
+            exit_code: exitCode,
+            stdout: states === null ? '' : JSON.stringify(states),
+            stderr: exitCode === 0 ? '' : 'boom',
+            wall_ms: 1,
+            signal: null,
+            error: null,
+        };
+    };
+    fn.calls = calls;
+    return fn;
+}
+
+function fakeResolveWave(wave) {
+    return () => wave;
+}
+
+// -----------------------------------------------------------------------------
+// CA-1 — avance intermedio
+// -----------------------------------------------------------------------------
+
+test('CA-1 · avance intermedio: 3/6 cerradas (50%) + lista de abiertos', () => {
+    const wave = { number: 3, name: 'Ola 3', issues: [3001, 3002, 3003, 3004, 3005, 3006] };
+    const runGh = fakeRunGh([
+        { number: 3001, state: 'CLOSED' },
+        { number: 3002, state: 'CLOSED' },
+        { number: 3003, state: 'CLOSED' },
+        { number: 3004, state: 'OPEN' },
+        { number: 3005, state: 'OPEN' },
+        { number: 3006, state: 'OPEN' },
+    ]);
+    const out = buildWaveProgressSection({
+        issue: 3003,
+        pipelineRoot: '/tmp/x',
+        deps: { resolveWaveForIssue: fakeResolveWave(wave), runGh },
+    });
+    assert.equal(out, '🌊 Ola 3 — 3/6 cerradas (50%) · quedan 3 abiertas: #3004, #3005, #3006');
+});
+
+test('CA-1 · concordancia singular: "quedan 1 abierta"', () => {
+    const wave = { number: 4, name: 'Ola 4', issues: [4001, 4002] };
+    const runGh = fakeRunGh([
+        { number: 4001, state: 'CLOSED' },
+        { number: 4002, state: 'OPEN' },
+    ]);
+    const out = buildWaveProgressSection({
+        issue: 4001,
+        pipelineRoot: '/tmp/x',
+        deps: { resolveWaveForIssue: fakeResolveWave(wave), runGh },
+    });
+    assert.equal(out, '🌊 Ola 4 — 1/2 cerradas (50%) · quedan 1 abierta: #4002');
+});
+
+test('CA-1 · porcentaje redondeado a entero (67%)', () => {
+    const wave = { number: 3, name: 'Ola 3', issues: [1, 2, 3, 4, 5, 6] };
+    const runGh = fakeRunGh([
+        { number: 1, state: 'CLOSED' },
+        { number: 2, state: 'CLOSED' },
+        { number: 3, state: 'CLOSED' },
+        { number: 4, state: 'CLOSED' },
+        { number: 5, state: 'OPEN' },
+        { number: 6, state: 'OPEN' },
+    ]);
+    const out = buildWaveProgressSection({
+        issue: 1,
+        pipelineRoot: '/tmp/x',
+        deps: { resolveWaveForIssue: fakeResolveWave(wave), runGh },
+    });
+    assert.match(out, /4\/6 cerradas \(67%\)/);
+});
+
+// -----------------------------------------------------------------------------
+// CA-2 — último issue (cierre de ola)
+// -----------------------------------------------------------------------------
+
+test('CA-2 · último issue: ola finalizada + sugerencia de próximo paso', () => {
+    const wave = { number: 3, name: 'Ola 3', issues: [3001, 3002, 3003] };
+    const runGh = fakeRunGh([
+        { number: 3001, state: 'CLOSED' },
+        { number: 3002, state: 'CLOSED' },
+        { number: 3003, state: 'CLOSED' },
+    ]);
+    const out = buildWaveProgressSection({
+        issue: 3003,
+        pipelineRoot: '/tmp/x',
+        deps: { resolveWaveForIssue: fakeResolveWave(wave), runGh },
+    });
+    assert.equal(
+        out,
+        '🎉 Ola 3 finalizada — 3/3 cerradas. Sugerencia: habilitá la Ola 4 para arrancar.',
+    );
+});
+
+test('CA-2 · NO declara finalizada si un issue de la ola no aparece en gh (conservador)', () => {
+    // gh devuelve solo 2 de 3 issues de la ola (límite / no existe). El tercero
+    // se cuenta como NO cerrado → nunca "finalizada" de más.
+    const wave = { number: 5, name: 'Ola 5', issues: [5001, 5002, 5003] };
+    const runGh = fakeRunGh([
+        { number: 5001, state: 'CLOSED' },
+        { number: 5002, state: 'CLOSED' },
+        // 5003 ausente
+    ]);
+    const out = buildWaveProgressSection({
+        issue: 5002,
+        pipelineRoot: '/tmp/x',
+        deps: { resolveWaveForIssue: fakeResolveWave(wave), runGh },
+    });
+    assert.match(out, /^🌊 Ola 5 — 2\/3 cerradas \(67%\)/);
+    assert.doesNotMatch(out, /finalizada/);
+});
+
+// -----------------------------------------------------------------------------
+// CA-4 — issue sin ola
+// -----------------------------------------------------------------------------
+
+test('CA-4 · issue sin ola → null (sin sección, sin llamar a gh)', () => {
+    const runGh = fakeRunGh([]);
+    const out = buildWaveProgressSection({
+        issue: 9999,
+        pipelineRoot: '/tmp/x',
+        deps: { resolveWaveForIssue: fakeResolveWave(null), runGh },
+    });
+    assert.equal(out, null);
+    assert.equal(runGh.calls.length, 0); // no se consultó GitHub
+});
+
+test('CA-4 · ola sin issues → null', () => {
+    const runGh = fakeRunGh([]);
+    const out = buildWaveProgressSection({
+        issue: 1,
+        pipelineRoot: '/tmp/x',
+        deps: { resolveWaveForIssue: fakeResolveWave({ number: 1, name: 'Ola 1', issues: [] }), runGh },
+    });
+    assert.equal(out, null);
+});
+
+// -----------------------------------------------------------------------------
+// CA-5 — degradación elegante (resiliencia)
+// -----------------------------------------------------------------------------
+
+test('CA-5 · gh con exit_code !== 0 → null (no tira)', () => {
+    const wave = { number: 3, name: 'Ola 3', issues: [1, 2] };
+    const runGh = fakeRunGh([{ number: 1, state: 'CLOSED' }], { exitCode: 1 });
+    const out = buildWaveProgressSection({
+        issue: 1,
+        pipelineRoot: '/tmp/x',
+        deps: { resolveWaveForIssue: fakeResolveWave(wave), runGh },
+    });
+    assert.equal(out, null);
+});
+
+test('CA-5 · gh con stdout vacío → null', () => {
+    const wave = { number: 3, name: 'Ola 3', issues: [1, 2] };
+    const runGh = fakeRunGh(null); // stdout = ''
+    const out = buildWaveProgressSection({
+        issue: 1,
+        pipelineRoot: '/tmp/x',
+        deps: { resolveWaveForIssue: fakeResolveWave(wave), runGh },
+    });
+    assert.equal(out, null);
+});
+
+test('CA-5 · JSON inválido de gh → null', () => {
+    const wave = { number: 3, name: 'Ola 3', issues: [1, 2] };
+    const runGh = () => ({ exit_code: 0, stdout: 'no-es-json', stderr: '' });
+    const out = buildWaveProgressSection({
+        issue: 1,
+        pipelineRoot: '/tmp/x',
+        deps: { resolveWaveForIssue: fakeResolveWave(wave), runGh },
+    });
+    assert.equal(out, null);
+});
+
+test('CA-5 · runGh que tira excepción → null (capturado)', () => {
+    const wave = { number: 3, name: 'Ola 3', issues: [1, 2] };
+    const runGh = () => { throw new Error('spawn falló'); };
+    const out = buildWaveProgressSection({
+        issue: 1,
+        pipelineRoot: '/tmp/x',
+        deps: { resolveWaveForIssue: fakeResolveWave(wave), runGh },
+    });
+    assert.equal(out, null);
+});
+
+// -----------------------------------------------------------------------------
+// CA-6 — seguridad: una sola llamada, sin shell, solo números
+// -----------------------------------------------------------------------------
+
+test('CA-6 · una sola llamada a gh con array de args (sin shell)', () => {
+    const wave = { number: 3, name: 'Ola 3', issues: [1, 2, 3] };
+    const runGh = fakeRunGh([
+        { number: 1, state: 'CLOSED' },
+        { number: 2, state: 'OPEN' },
+        { number: 3, state: 'OPEN' },
+    ]);
+    buildWaveProgressSection({
+        issue: 1,
+        pipelineRoot: '/tmp/x',
+        deps: { resolveWaveForIssue: fakeResolveWave(wave), runGh },
+    });
+    assert.equal(runGh.calls.length, 1);
+    const args = runGh.calls[0];
+    assert.ok(Array.isArray(args));
+    assert.deepEqual(args.slice(0, 3), ['issue', 'list', '--repo']);
+    assert.ok(args.includes('--state'));
+    assert.ok(args.includes('all'));
+    assert.ok(args.includes('number,state'));
+});
+
+test('CA-6 · el listado solo contiene números de issue (sin títulos)', () => {
+    const wave = { number: 3, name: 'Ola 3', issues: [1, 2, 3] };
+    const runGh = fakeRunGh([
+        { number: 1, state: 'CLOSED' },
+        { number: 2, state: 'OPEN', title: '<script>alert(1)</script>' },
+        { number: 3, state: 'OPEN' },
+    ]);
+    const out = buildWaveProgressSection({
+        issue: 1,
+        pipelineRoot: '/tmp/x',
+        deps: { resolveWaveForIssue: fakeResolveWave(wave), runGh },
+    });
+    assert.match(out, /quedan 2 abiertas: #2, #3$/);
+    assert.doesNotMatch(out, /script/);
+});
+
+// -----------------------------------------------------------------------------
+// G-5 — truncado del listado de abiertos
+// -----------------------------------------------------------------------------
+
+test('G-5 · formatOpenIssueList trunca a 8 con marcador (+N)', () => {
+    const nums = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
+    const out = formatOpenIssueList(nums);
+    assert.equal(out, '#1, #2, #3, #4, #5, #6, #7, #8 … (+3)');
+});
+
+test('G-5 · formatOpenIssueList sin truncado cuando entra completo', () => {
+    assert.equal(formatOpenIssueList([1, 2, 3]), '#1, #2, #3');
+});
+
+test('G-5 · avance con muchos abiertos trunca la lista en el mensaje', () => {
+    const issues = [];
+    for (let i = 1; i <= 12; i++) issues.push(i);
+    const wave = { number: 7, name: 'Ola 7', issues };
+    const states = issues.map((n) => ({ number: n, state: n === 1 ? 'CLOSED' : 'OPEN' }));
+    const runGh = fakeRunGh(states);
+    const out = buildWaveProgressSection({
+        issue: 1,
+        pipelineRoot: '/tmp/x',
+        deps: { resolveWaveForIssue: fakeResolveWave(wave), runGh },
+    });
+    assert.match(out, /quedan 11 abiertas: #2, #3, #4, #5, #6, #7, #8, #9 … \(\+3\)/);
+});
+
+// -----------------------------------------------------------------------------
+// buildText — integración de la sección
+// -----------------------------------------------------------------------------
+
+test('buildText · anexa waveProgress después del body y antes del link', () => {
+    const txt = buildText({
+        issue: 4019,
+        title: 'Avance de ola',
+        fase: 'entrega',
+        skill: 'delivery',
+        preview: 'Cuerpo de la entrega.',
+        envelope: '<!-- env -->',
+        waveProgress: '🌊 Ola 4 — 1/2 cerradas (50%) · quedan 1 abierta: #4023',
+    });
+    const lines = txt.split('\n');
+    const idxBody = lines.findIndex((l) => l.includes('Cuerpo de la entrega'));
+    const idxWave = lines.findIndex((l) => l.includes('🌊 Ola 4'));
+    const idxLink = lines.findIndex((l) => l.includes('🔗 https://'));
+    assert.ok(idxBody !== -1 && idxWave !== -1 && idxLink !== -1);
+    assert.ok(idxBody < idxWave, 'wave va después del body');
+    assert.ok(idxWave < idxLink, 'wave va antes del link');
+});
+
+test('buildText · omite la sección cuando waveProgress es null (CA-4)', () => {
+    const txt = buildText({
+        issue: 4019,
+        title: 'Sin ola',
+        fase: 'entrega',
+        skill: 'delivery',
+        preview: 'Cuerpo.',
+        envelope: '<!-- env -->',
+        waveProgress: null,
+    });
+    assert.doesNotMatch(txt, /🌊|🎉/);
+});
+
+test('buildText · omite la sección cuando waveProgress es string vacío', () => {
+    const txt = buildText({
+        issue: 4019,
+        title: 'Vacío',
+        fase: 'entrega',
+        skill: 'delivery',
+        preview: 'Cuerpo.',
+        envelope: '<!-- env -->',
+        waveProgress: '   ',
+    });
+    assert.doesNotMatch(txt, /🌊|🎉/);
+});

--- a/.pipeline/lib/__tests__/skill-deliverable-attachments.test.js
+++ b/.pipeline/lib/__tests__/skill-deliverable-attachments.test.js
@@ -471,9 +471,16 @@ test('CA-5 — coherencia inversa: todo skill notificable tiene source en SKILL_
     const catalog = helper.getSkillSourcesCatalog();
     const catalogSkills = new Set(Object.keys(catalog));
 
-    // Cada skill de la whitelist de notificación debe poder recolectar (tener
-    // entrada en SKILL_SOURCES); sino sería "notificable pero sin adjuntos".
+    // #4019 — `delivery` es notificable de TEXTO PURO: la notificación de
+    // entrega anexa el avance de ola como sección de texto en el cuerpo del
+    // mensaje (ver `buildWaveProgressSection` en deliverable-notify.js), no como
+    // adjunto. Por eso no tiene entrada en SKILL_SOURCES y queda exento de la
+    // invariante "notificable ⟹ tiene adjuntos" (a runtime `collectAttachments`
+    // devuelve [] sin crash). Toda otra skill notificable sí debe poder recolectar.
+    const TEXT_ONLY = new Set(['delivery']);
+
     for (const skill of dn.skills) {
+        if (TEXT_ONLY.has(skill)) continue;
         assert.ok(catalogSkills.has(skill),
             `${skill} está en deliverable_notifications.skills pero falta en SKILL_SOURCES`);
     }

--- a/.pipeline/lib/__tests__/wave-resolver.test.js
+++ b/.pipeline/lib/__tests__/wave-resolver.test.js
@@ -330,3 +330,133 @@ test('CA-6: shape externo { label, issues, openedAt, source, resolved } preserva
         assert.equal(typeof r.resolved, 'boolean');
     } finally { resetCache(); rmrf(dir); }
 });
+
+// =============================================================================
+// #4019 — resolveWaveForIssue (lookup issue→ola multi-lista)
+// =============================================================================
+
+const { resolveWaveForIssue } = require('../wave-resolver');
+
+function writeMultiWaveJson(dir, { active_wave, planned_waves = [], archived_waves = [] }) {
+    const state = {
+        version: '1.0',
+        meta: {
+            created_at: '2026-06-01T00:00:00Z',
+            updated_at: '2026-06-01T00:00:00Z',
+            updated_by: 'test',
+            source: 'manual',
+            note: 'fixture #4019',
+        },
+        active_wave,
+        planned_waves,
+        archived_waves,
+        dependencies: [],
+    };
+    fs.writeFileSync(path.join(dir, 'waves.json'), JSON.stringify(state, null, 2));
+}
+
+test('resolveWaveForIssue: encuentra el issue en active_wave (#4019)', () => {
+    const dir = mkTmpPipeline();
+    try {
+        writeMultiWaveJson(dir, {
+            active_wave: {
+                number: 4,
+                name: 'Ola 4',
+                issues: [{ number: 3934 }, { number: 4019 }, { number: 4023 }],
+            },
+        });
+        const w = resolveWaveForIssue(4019, { pipelineRoot: dir });
+        assert.ok(w);
+        assert.equal(w.number, 4);
+        assert.equal(w.name, 'Ola 4');
+        assert.deepEqual(w.issues, [3934, 4019, 4023]);
+    } finally { resetCache(); rmrf(dir); }
+});
+
+test('resolveWaveForIssue: encuentra el issue en archived_waves (#4019)', () => {
+    const dir = mkTmpPipeline();
+    try {
+        writeMultiWaveJson(dir, {
+            active_wave: { number: 4, name: 'Ola 4', issues: [{ number: 4019 }] },
+            archived_waves: [
+                { number: 3, name: 'Ola 3', issues: [{ number: 3949 }, { number: 3950 }] },
+            ],
+        });
+        const w = resolveWaveForIssue(3949, { pipelineRoot: dir });
+        assert.ok(w);
+        assert.equal(w.number, 3);
+        assert.deepEqual(w.issues, [3949, 3950]);
+    } finally { resetCache(); rmrf(dir); }
+});
+
+test('resolveWaveForIssue: encuentra el issue en planned_waves (#4019)', () => {
+    const dir = mkTmpPipeline();
+    try {
+        writeMultiWaveJson(dir, {
+            active_wave: { number: 4, name: 'Ola 4', issues: [{ number: 4019 }] },
+            planned_waves: [
+                { number: 5, name: 'Ola 5', issues: [{ number: 4100 }] },
+            ],
+        });
+        const w = resolveWaveForIssue(4100, { pipelineRoot: dir });
+        assert.ok(w);
+        assert.equal(w.number, 5);
+        assert.deepEqual(w.issues, [4100]);
+    } finally { resetCache(); rmrf(dir); }
+});
+
+test('resolveWaveForIssue: devuelve null para issue sin ola (CA-4)', () => {
+    const dir = mkTmpPipeline();
+    try {
+        writeMultiWaveJson(dir, {
+            active_wave: { number: 4, name: 'Ola 4', issues: [{ number: 4019 }] },
+        });
+        assert.equal(resolveWaveForIssue(9999, { pipelineRoot: dir }), null);
+    } finally { resetCache(); rmrf(dir); }
+});
+
+test('resolveWaveForIssue: tolera shapes #3501 / " 3501 " / int plano / {number} (CA-6 security)', () => {
+    const dir = mkTmpPipeline();
+    try {
+        // issues con shapes mixtos en disco — normalizeIssueNumber los castea.
+        writeMultiWaveJson(dir, {
+            active_wave: {
+                number: 4,
+                name: 'Ola 4',
+                issues: [3934, { number: 4019 }, '  4023  ', '#4026', 'basura'],
+            },
+        });
+        // input con prefijo y whitespace resuelve igual.
+        const w = resolveWaveForIssue(' #4023 ', { pipelineRoot: dir });
+        assert.ok(w);
+        assert.equal(w.number, 4);
+        // 'basura' se descarta; el resto queda ordenado y deduplicado.
+        assert.deepEqual(w.issues, [3934, 4019, 4023, 4026]);
+    } finally { resetCache(); rmrf(dir); }
+});
+
+test('resolveWaveForIssue: input no-entero / inválido devuelve null sin crash (CA-6 security)', () => {
+    const dir = mkTmpPipeline();
+    try {
+        writeMultiWaveJson(dir, {
+            active_wave: { number: 4, name: 'Ola 4', issues: [{ number: 4019 }] },
+        });
+        assert.equal(resolveWaveForIssue('rm -rf', { pipelineRoot: dir }), null);
+        assert.equal(resolveWaveForIssue(null, { pipelineRoot: dir }), null);
+        assert.equal(resolveWaveForIssue(-5, { pipelineRoot: dir }), null);
+        assert.equal(resolveWaveForIssue(0, { pipelineRoot: dir }), null);
+    } finally { resetCache(); rmrf(dir); }
+});
+
+test('resolveWaveForIssue: sin pipelineRoot devuelve null (defensa)', () => {
+    assert.equal(resolveWaveForIssue(4019, {}), null);
+    assert.equal(resolveWaveForIssue(4019, undefined), null);
+});
+
+test('resolveWaveForIssue: waves.json ilegible devuelve null (CA-5 degradación)', () => {
+    const dir = mkTmpPipeline();
+    try {
+        fs.writeFileSync(path.join(dir, 'waves.json'), '{ esto no es json válido');
+        assert.equal(resolveWaveForIssue(4019, { pipelineRoot: dir }), null);
+    } finally { resetCache(); rmrf(dir); }
+});

--- a/.pipeline/lib/deliverable-notify.js
+++ b/.pipeline/lib/deliverable-notify.js
@@ -884,9 +884,19 @@ function buildWaveProgressSection(args) {
     const { issue, pipelineRoot, deps } = args || {};
     const resolveWave = (deps && deps.resolveWaveForIssue) || waveResolver.resolveWaveForIssue;
     const runGh = (deps && deps.runGh) || gitOps.runGh;
+    // CA-5 / UX G-6 — el fallo del cálculo de ola DEBE quedar logueado, también
+    // en producción (donde `notify` no inyecta `deps`). El default no puede ser
+    // un no-op: usa `console.warn` con el prefijo convencional del módulo
+    // (consistente con la línea ~1785), para que gh-error/JSON-inválido/excepción
+    // dejen traza sin que el call site de producción tenga que cablear nada.
     const logFail = (deps && typeof deps.logFail === 'function')
         ? deps.logFail
-        : () => {};
+        : (msg, detail) => {
+            // eslint-disable-next-line no-console
+            console.warn(
+                `[deliverable-notify] wave-progress: ${msg}${detail ? `: ${detail}` : ''}`,
+            );
+        };
 
     try {
         // CA-4 — issue sin ola → sin sección, comportamiento de hoy.

--- a/.pipeline/lib/deliverable-notify.js
+++ b/.pipeline/lib/deliverable-notify.js
@@ -53,6 +53,11 @@ const {
     probeVideoDurationSeconds,
     MIME_TO_KIND,
 } = require('./multimedia-attachment');
+// #4019 — avance de ola en la notificación de entrega. `resolveWaveForIssue`
+// (filesystem-only) y `runGh` (GitHub, una sola llamada sin shell) son los dos
+// side-effects que viven en la capa impura (`notify`), no en `buildPreview`.
+const waveResolver = require('./wave-resolver');
+const gitOps = require('../skills-deterministicos/lib/git-ops');
 
 // -----------------------------------------------------------------------------
 // CA-UX-2 — Emojis canónicos fijos por skill. Cualquier skill no listado cae
@@ -791,11 +796,17 @@ function buildText(input) {
         ? input.preview
         : EMPTY_NOTAS_FALLBACK;
     const link = `🔗 https://github.com/intrale/platform/issues/${input.issue}`;
+    // #4019 — sección de avance de ola: va DESPUÉS del cuerpo y ANTES del link
+    // (G-1). Se omite si viene vacía o no es string (CA-4: notificación intacta).
+    const wave = typeof input.waveProgress === 'string' && input.waveProgress.trim().length > 0
+        ? input.waveProgress.trim()
+        : null;
     const parts = [
         header,
         subtitle,
         '',
         body,
+        ...(wave ? ['', wave] : []),
         '',
         link,
         '',
@@ -815,6 +826,139 @@ function buildCaption(input) {
     const subtitle = shortenTitle(input.title || '');
     const link = `🔗 https://github.com/intrale/platform/issues/${input.issue}`;
     return [header, subtitle, '', link, '', input.envelope].join('\n');
+}
+
+// -----------------------------------------------------------------------------
+// #4019 — Sección de avance de ola en la notificación de entrega.
+// -----------------------------------------------------------------------------
+
+// Cantidad máxima de issues abiertos a listar antes de truncar (G-5, alineado
+// con la convención `slice(0, MAX)` + `(+N)` de wave-renderer.js).
+const WAVE_OPEN_LIST_MAX = 8;
+
+// Límite de `gh issue list`. `gh` devuelve los N issues más recientes del repo
+// (no filtrados por ola), así que un límite chico (p.ej. 30) puede dejar afuera
+// issues de olas que arrancaron hace muchos issues. 500 cubre con holgura la
+// ola activa y las recientes; las olas muy viejas degradan con gracia (los
+// issues no devueltos se cuentan como "no cerrados", nunca como cerrados, para
+// no declarar una ola finalizada por error — CA-2 + CA-5).
+const WAVE_GH_LIST_LIMIT = 500;
+
+/**
+ * Formatea el listado de issues abiertos truncando si es largo (G-5).
+ *   `#1, #2, #3 … (+5)`
+ *
+ * @param {number[]} openNums - números de issue abiertos (ya ordenados).
+ * @returns {string}
+ */
+function formatOpenIssueList(openNums) {
+    const visible = openNums.slice(0, WAVE_OPEN_LIST_MAX);
+    const hidden = openNums.length - visible.length;
+    const base = visible.map((n) => `#${n}`).join(', ');
+    return hidden > 0 ? `${base} … (+${hidden})` : base;
+}
+
+/**
+ * Construye la línea de avance de la ola a la que pertenece el issue entregado
+ * (CA-1/CA-2). Es la **única capa impura** de este flujo: lee `waves.json`
+ * (filesystem) y consulta el estado real de GitHub (`gh issue list`, una sola
+ * llamada sin shell). Por eso vive fuera de `buildPreview`/`buildText`, que
+ * permanecen puros y reciben el string ya calculado vía `waveProgress`.
+ *
+ * Garantías de resiliencia (CA-5): nunca tira. Ante cualquier fallo (issue sin
+ * ola, `waves.json` ilegible, `gh` con error, JSON inválido) devuelve `null` y
+ * la notificación se entrega sin la sección, como hoy (CA-4).
+ *
+ * Seguridad (CA-6): los números de issue se castean a int positivo en
+ * `resolveWaveForIssue` (vía `normalizeIssueNumber`); la única llamada a `gh`
+ * usa `runGh` con array de args y `shell:false` (sin interpolación shell); el
+ * listado solo incluye números de issue (sin títulos atacante-controlables).
+ *
+ * @param {object} args
+ * @param {string|number} args.issue
+ * @param {string} args.pipelineRoot
+ * @param {object} [args.deps] - inyección para tests: { resolveWaveForIssue, runGh, logger }.
+ * @returns {string|null} línea de avance o `null` si no aplica / falla.
+ */
+function buildWaveProgressSection(args) {
+    const { issue, pipelineRoot, deps } = args || {};
+    const resolveWave = (deps && deps.resolveWaveForIssue) || waveResolver.resolveWaveForIssue;
+    const runGh = (deps && deps.runGh) || gitOps.runGh;
+    const logFail = (deps && typeof deps.logFail === 'function')
+        ? deps.logFail
+        : () => {};
+
+    try {
+        // CA-4 — issue sin ola → sin sección, comportamiento de hoy.
+        const wave = resolveWave(issue, { pipelineRoot });
+        if (!wave) return null;
+
+        const waveIssues = Array.isArray(wave.issues) ? wave.issues : [];
+        const total = waveIssues.length;
+        if (total === 0) return null;
+
+        // CA-3/CA-6 — estado fresco de GitHub, una sola llamada, sin shell.
+        const limit = Math.max(total, WAVE_GH_LIST_LIMIT);
+        const res = runGh([
+            'issue', 'list',
+            '--repo', 'intrale/platform',
+            '--state', 'all',
+            '--json', 'number,state',
+            '--limit', String(limit),
+        ]);
+
+        // CA-5 — degradación elegante: cualquier fallo de gh → sin sección.
+        if (!res || res.exit_code !== 0 || typeof res.stdout !== 'string' || !res.stdout.trim()) {
+            logFail('gh issue list falló o vino vacío', res && res.stderr);
+            return null;
+        }
+
+        let states;
+        try {
+            states = JSON.parse(res.stdout);
+        } catch (e) {
+            logFail('JSON inválido de gh issue list', e && e.message);
+            return null;
+        }
+        if (!Array.isArray(states)) return null;
+
+        const waveSet = new Set(waveIssues);
+        const inWave = states.filter(
+            (s) => s && typeof s.number === 'number' && waveSet.has(s.number),
+        );
+        const openNums = inWave
+            .filter((s) => s.state === 'OPEN')
+            .map((s) => s.number)
+            .sort((a, b) => a - b);
+
+        // Issues de la ola que `gh` no devolvió (límite / no existen). Se cuentan
+        // como "no cerrados" para nunca declarar una ola finalizada de más.
+        const unknown = total - inWave.length;
+        const open = openNums.length + unknown;
+        const closed = total - open;
+
+        const waveLabel = wave.number != null ? `Ola ${wave.number}` : 'Ola';
+
+        // CA-2 — último issue: ola finalizada.
+        if (open === 0) {
+            const next = wave.number != null
+                ? `la Ola ${wave.number + 1}`
+                : 'la siguiente ola';
+            return `🎉 ${waveLabel} finalizada — ${total}/${total} cerradas. `
+                + `Sugerencia: habilitá ${next} para arrancar.`;
+        }
+
+        // CA-1 — avance intermedio.
+        const pct = Math.round((closed / total) * 100);
+        const plural = open === 1 ? 'abierta' : 'abiertas';
+        const lista = formatOpenIssueList(openNums);
+        return `🌊 ${waveLabel} — ${closed}/${total} cerradas (${pct}%) · `
+            + `quedan ${open} ${plural}: ${lista}`;
+    } catch (e) {
+        // CA-5 — jamás romper la notificación de entrega por el avance de ola.
+        logFail('excepción inesperada en buildWaveProgressSection', e && e.message);
+        return null;
+    }
 }
 
 // -----------------------------------------------------------------------------
@@ -853,6 +997,7 @@ function buildPreview(args) {
         title,
         config,
         pipelineRoot,
+        waveProgress,
     } = args;
 
     const cfg = config || {};
@@ -967,6 +1112,7 @@ function buildPreview(args) {
                 issue, title, fase, skill,
                 preview: textBody,
                 envelope,
+                waveProgress,
             }),
             parse_mode: 'Markdown',
         };
@@ -980,6 +1126,7 @@ function buildPreview(args) {
                 issue, title, fase, skill,
                 preview: textBody,
                 envelope,
+                waveProgress,
             }),
             parse_mode: 'Markdown',
         };
@@ -1529,10 +1676,24 @@ function notify(args) {
             return { ok: false, action: 'skipped', reason: 'skill_not_notifiable' };
         }
 
+        // #4019 — avance de ola SOLO en la entrega (delivery/entrega). Es un
+        // side-effect (lee waves.json + consulta GitHub), por eso se calcula acá
+        // (capa impura) y se pasa ya resuelto como string a `buildPreview`, que
+        // permanece puro. Resiliente: `buildWaveProgressSection` nunca tira y
+        // devuelve `null` ante cualquier fallo (CA-4/CA-5).
+        let waveProgress = null;
+        if (skill === 'delivery' && fase === 'entrega') {
+            waveProgress = buildWaveProgressSection({
+                issue,
+                pipelineRoot,
+                deps: deps && deps.waveDeps,
+            });
+        }
+
         // Construir payload.
         const built = buildPreview({
             issue, skill, fase, pipeline, yaml, title,
-            config: cfg, pipelineRoot,
+            config: cfg, pipelineRoot, waveProgress,
         });
 
         // Dedup CA-FN-7.
@@ -2714,6 +2875,9 @@ module.exports = {
         shortenTitle,
         buildText,
         buildCaption,
+        // #4019 — avance de ola
+        buildWaveProgressSection,
+        formatOpenIssueList,
         // audio TTS
         withTimeout,
         safeRedact,

--- a/.pipeline/lib/wave-resolver.js
+++ b/.pipeline/lib/wave-resolver.js
@@ -247,8 +247,106 @@ function resolveActiveWave(opts) {
     return { ...fromFs, resolved: fromFs.issues.length > 0 };
 }
 
+// =============================================================================
+// resolveWaveForIssue — lookup issue→ola multi-lista (issue #4019).
+//
+// A diferencia de `resolveActiveWave` (que solo resuelve la ola ACTIVA), este
+// helper escanea las TRES listas de `waves.json` (`active_wave`,
+// `planned_waves`, `archived_waves`) y devuelve la ola que contiene al issue.
+// Necesario para notificar la entrega de un issue que ya cayó a una ola
+// archivada (su PR mergeado cierra vía `Closes #`, pero la ola pudo rotar).
+//
+// Reglas:
+// - Sin red, solo filesystem (delega en `lib/waves.js::loadWaves`, fuente
+//   canónica con cache TTL — mismo override de `PIPELINE_DIR_OVERRIDE` que
+//   `readFromWavesJson` para soportar tests con tmp dirs).
+// - `normalizeIssueNumber` castea cada issue a int positivo y descarta `null`
+//   (defensa security CA-6: los issues de `waves.json` son editables a mano).
+// - Devuelve `null` si el issue no pertenece a ninguna ola (CA-4: la
+//   notificación se comporta como hoy, sin sección de avance).
+// - Sin throw a callers: cualquier excepción de I/O degrada a `null`.
+// =============================================================================
+
+/**
+ * Lee el documento completo de `waves.json` delegando en `lib/waves.js`
+ * (fuente canónica) respetando el override temporal de `PIPELINE_DIR_OVERRIDE`
+ * — mismo patrón que `readFromWavesJson` — para que los tests con tmp dirs
+ * funcionen y producción herede la cache TTL.
+ *
+ * @param {string} pipelineRoot
+ * @returns {{active_wave: object|null, planned_waves: object[], archived_waves: object[]}|null}
+ */
+function readWavesDoc(pipelineRoot) {
+    const wavesDir = effectiveWavesPipelineDir();
+    const needsOverride = path.resolve(pipelineRoot) !== path.resolve(wavesDir);
+    const prevOverride = process.env.PIPELINE_DIR_OVERRIDE;
+
+    if (needsOverride) {
+        process.env.PIPELINE_DIR_OVERRIDE = pipelineRoot;
+        waves.invalidateCache();
+    }
+
+    let doc = null;
+    try {
+        doc = waves.loadWaves();
+    } catch {
+        doc = null;
+    } finally {
+        if (needsOverride) {
+            if (prevOverride === undefined) delete process.env.PIPELINE_DIR_OVERRIDE;
+            else process.env.PIPELINE_DIR_OVERRIDE = prevOverride;
+            waves.invalidateCache();
+        }
+    }
+
+    return (doc && typeof doc === 'object') ? doc : null;
+}
+
+/**
+ * Resuelve la ola a la que pertenece un issue escaneando active+planned+archived.
+ *
+ * @param {number|string|object} issueNumber - acepta `3501`, `"#3501"`, `{number}`.
+ * @param {object} opts
+ * @param {string} opts.pipelineRoot - Path absoluto al directorio `.pipeline`.
+ * @returns {{number: number|null, name: string, issues: number[]}|null}
+ *          La ola con sus issues normalizados a int, o `null` si no pertenece a
+ *          ninguna (o si falta `pipelineRoot` / `waves.json` no es legible).
+ */
+function resolveWaveForIssue(issueNumber, opts) {
+    const target = normalizeIssueNumber(issueNumber);
+    if (target === null) return null;
+
+    const pipelineRoot = opts && opts.pipelineRoot;
+    if (!pipelineRoot) return null;
+
+    const doc = readWavesDoc(pipelineRoot);
+    if (!doc) return null;
+
+    const allWaves = [
+        doc.active_wave,
+        ...(Array.isArray(doc.planned_waves) ? doc.planned_waves : []),
+        ...(Array.isArray(doc.archived_waves) ? doc.archived_waves : []),
+    ].filter(Boolean);
+
+    for (const w of allWaves) {
+        const nums = (Array.isArray(w.issues) ? w.issues : [])
+            .map(normalizeIssueNumber)
+            .filter((n) => n !== null);
+        if (nums.includes(target)) {
+            const nameTrim = typeof w.name === 'string' ? w.name.trim() : '';
+            return {
+                number: Number.isInteger(w.number) ? w.number : null,
+                name: nameTrim,
+                issues: [...new Set(nums)].sort((a, b) => a - b),
+            };
+        }
+    }
+    return null;
+}
+
 module.exports = {
     resolveActiveWave,
+    resolveWaveForIssue,
     // Exports internos para tests
     _internal: {
         readFromWavesJson,
@@ -256,5 +354,6 @@ module.exports = {
         collectActiveIssuesFromFs,
         normalizeIssueNumber,
         effectiveWavesPipelineDir,
+        readWavesDoc,
     },
 };


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 6 archivos · +816 -4

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:passed` aplicado por delivery

## Closes

Closes #4019
