### PR TITLE
Gate de APK exige binario a issues de dashboard/pipeline (label app:client) y dispara rebotes y alertas de atascado falsas

### DIFF
--- a/.pipeline/lib/__tests__/qa-evidence-gate.test.js
+++ b/.pipeline/lib/__tests__/qa-evidence-gate.test.js
@@ -153,3 +153,113 @@ test('R3 · formatBypassLogLine incluye JSON parseable + prefijo legible', () =>
     assert.match(line, /#2023/);
     assert.match(line, /qaMode=api/);
 });
+
+// ─── resolveApkRequirement (Issue #4046) ────────────────────────────────────
+const {
+    resolveApkRequirement,
+    normalizeLabels,
+    normalizeRepoPath,
+} = require('../qa-evidence-gate');
+
+test('#4046 · area:pipeline + app:client con paths .pipeline/* → infra-no-apk (caso #3954)', () => {
+    const r = resolveApkRequirement({
+        labels: ['area:pipeline', 'app:client'],
+        changedFiles: ['.pipeline/lib/qa-evidence-gate.js', '.pipeline/pulpo.js'],
+    });
+    assert.equal(r.requiresApk, false);
+    assert.equal(r.reason, 'infra-no-apk');
+    assert.deepEqual(r.flavors, []);
+});
+
+test('#4046 · area:dashboard con paths .pipeline/* → infra-no-apk', () => {
+    const r = resolveApkRequirement({
+        labels: [{ name: 'area:dashboard' }],
+        changedFiles: ['.pipeline/dashboard-v2.js'],
+    });
+    assert.equal(r.requiresApk, false);
+    assert.equal(r.reason, 'infra-no-apk');
+});
+
+test('#4046 · app:client con cambios en app/composeApp/ → requiere APK client', () => {
+    const r = resolveApkRequirement({
+        labels: ['app:client'],
+        changedFiles: ['app/composeApp/src/commonMain/Foo.kt'],
+    });
+    assert.equal(r.requiresApk, true);
+    assert.equal(r.reason, 'app-flavor');
+    assert.deepEqual(r.flavors, ['client']);
+});
+
+test('#4046 · area:pipeline + app:client PERO con cambios en app/composeApp/ → NO afloja, requiere APK', () => {
+    // Si el issue de pipeline igual toca la app, el binario sí se produce.
+    const r = resolveApkRequirement({
+        labels: ['area:pipeline', 'app:client'],
+        changedFiles: ['.pipeline/pulpo.js', 'app/composeApp/src/androidMain/Bar.kt'],
+    });
+    assert.equal(r.requiresApk, true);
+    assert.equal(r.reason, 'app-flavor');
+    assert.deepEqual(r.flavors, ['client']);
+});
+
+test('#4046 · app:business y app:delivery conservan flavor correcto', () => {
+    const biz = resolveApkRequirement({
+        labels: ['app:business'],
+        changedFiles: ['app/composeApp/src/businessMain/X.kt'],
+    });
+    assert.deepEqual(biz.flavors, ['business']);
+    assert.equal(biz.requiresApk, true);
+
+    const del = resolveApkRequirement({
+        labels: ['app:delivery'],
+        changedFiles: ['app/composeApp/src/deliveryMain/Y.kt'],
+    });
+    assert.deepEqual(del.flavors, ['delivery']);
+    assert.equal(del.requiresApk, true);
+});
+
+test('#4046 · FAIL-CLOSED: area:pipeline + app:client SIN origen conocido → requiere APK (no relaja por ausencia de datos)', () => {
+    const r = resolveApkRequirement({
+        labels: ['area:pipeline', 'app:client'],
+        changedFiles: [],
+        changedFilesKnown: false,
+    });
+    assert.equal(r.requiresApk, true);
+    assert.equal(r.reason, 'app-flavor');
+});
+
+test('#4046 · area:pipeline + app:client con origen conocido pero diff vacío → infra-no-apk', () => {
+    const r = resolveApkRequirement({
+        labels: ['area:pipeline', 'app:client'],
+        changedFiles: [],
+        changedFilesKnown: true,
+    });
+    assert.equal(r.requiresApk, false);
+    assert.equal(r.reason, 'infra-no-apk');
+});
+
+test('#4046 · sin label app y sin área infra → no-app-label (no requiere APK)', () => {
+    const r = resolveApkRequirement({
+        labels: ['area:backend'],
+        changedFiles: ['users/src/Foo.kt'],
+    });
+    assert.equal(r.requiresApk, false);
+    assert.equal(r.reason, 'no-app-label');
+    assert.deepEqual(r.flavors, []);
+});
+
+test('#4046 · path con backslashes y ./ se normaliza para el prefijo app/composeApp/', () => {
+    assert.equal(normalizeRepoPath('app\\composeApp\\src\\X.kt'), 'app/composeApp/src/X.kt');
+    assert.equal(normalizeRepoPath('./app/composeApp/X.kt'), 'app/composeApp/X.kt');
+    const r = resolveApkRequirement({
+        labels: ['app:client'],
+        changedFiles: ['app\\composeApp\\src\\androidMain\\Z.kt'],
+    });
+    assert.equal(r.requiresApk, true);
+});
+
+test('#4046 · normalizeLabels tolera strings y objetos {name}', () => {
+    assert.deepEqual(
+        normalizeLabels(['App:Client', { name: 'AREA:Pipeline' }, null, 42, '  Bug ']),
+        ['app:client', 'area:pipeline', 'bug'],
+    );
+});

--- a/.pipeline/lib/__tests__/rebote-classifier.test.js
+++ b/.pipeline/lib/__tests__/rebote-classifier.test.js
@@ -405,3 +405,28 @@ test('SMOKE #3086: motivo realístico del guru → dependency_block con #3083', 
     assert.ok(r.dependsOn.includes(3083), '#3083 debe estar en dependsOn');
     assert.equal(r.label, 'blocked:dependencies');
 });
+
+// ─── #4046 · infra_no_apk no penaliza circuit breaker ───────────────────────
+test('#4046 · rebote_categoria=infra_no_apk → infra, counts_against_circuit_breaker=false', () => {
+    const r = rc.classifyRebote({
+        rebote_categoria: 'infra_no_apk',
+        motivo: 'Issue de dashboard sin cambios de app',
+    });
+    assert.equal(r.category, 'infra');
+    assert.equal(r.counts_against_circuit_breaker, false);
+    assert.equal(r.label, null);
+});
+
+test('#4046 · motivo con "infra-no-apk" en texto → infra, no penaliza', () => {
+    const r = rc.classifyRebote({
+        motivo: 'preflight resolvió reason=infra-no-apk (área pipeline sin app/composeApp)',
+    });
+    assert.equal(r.category, 'infra');
+    assert.equal(r.counts_against_circuit_breaker, false);
+});
+
+test('#4046 · rechazo técnico normal sigue contando contra circuit breaker', () => {
+    const r = rc.classifyRebote({ motivo: 'la función X no respeta el patrón Do' });
+    assert.equal(r.category, 'code');
+    assert.equal(r.counts_against_circuit_breaker, true);
+});

--- a/.pipeline/lib/qa-evidence-gate.js
+++ b/.pipeline/lib/qa-evidence-gate.js
@@ -28,6 +28,114 @@
 const SKIPPABLE_QA_MODES = Object.freeze(['api', 'structural']);
 
 // =============================================================================
+// resolveApkRequirement — Issue #4046
+//
+// Decide si un issue requiere efectivamente un APK por el flavor REAL de su
+// trabajo, no por la mera presencia de `app:client` (que puede convivir con
+// trabajo 100% de dashboard/pipeline, caso #3954 "Home Kiosk → mission
+// control").
+//
+// La heurística clave es "¿este issue produce un artefacto APK?", no "¿tiene
+// label app:client?":
+//
+//   - Un issue con `area:pipeline`/`area:dashboard` y SIN cambios reales en
+//     `app/composeApp/` resuelve `{ requiresApk:false, reason:'infra-no-apk' }`
+//     (equivalente al bypass `qa:skipped`), aunque tenga `app:client`.
+//   - Un issue con cambios reales en `app/composeApp/` + `app:*` sigue
+//     exigiendo APK del flavor correspondiente (no se afloja el gate legítimo).
+//
+// FAIL-CLOSED: el bypass `infra-no-apk` se habilita SÓLO con evidencia positiva
+// del origen de cambios (paths conocidos). Si `changedFiles` no se pudo
+// resolver (sin worktree/PR), NO se relaja el gate sólo por ausencia de datos:
+// se cae a la decisión por label (`app:*` → requiere APK). El llamador indica
+// si el origen es conocido vía `changedFilesKnown`; si no lo pasa, se infiere
+// de la presencia de paths.
+//
+// Pure JS — sin fs/net — para testear con `node --test`.
+// =============================================================================
+
+const APP_LABELS = Object.freeze(['app:client', 'app:business', 'app:delivery']);
+const LABEL_TO_FLAVOR = Object.freeze({
+    'app:client': 'client',
+    'app:business': 'business',
+    'app:delivery': 'delivery',
+});
+const INFRA_AREA_LABELS = Object.freeze(['area:pipeline', 'area:dashboard']);
+const APP_PATH_PREFIX = 'app/composeApp/';
+
+/**
+ * Normaliza un label (string o {name}) a string lowercase trimado. '' si inválido.
+ */
+function normalizeLabelName(label) {
+    if (typeof label === 'string') return label.trim().toLowerCase();
+    if (label && typeof label === 'object' && typeof label.name === 'string') {
+        return label.name.trim().toLowerCase();
+    }
+    return '';
+}
+
+/**
+ * Normaliza una lista de labels a strings lowercase (descarta vacíos).
+ */
+function normalizeLabels(labels) {
+    if (!Array.isArray(labels)) return [];
+    return labels.map(normalizeLabelName).filter(Boolean);
+}
+
+/**
+ * Normaliza un path de archivo a separadores POSIX, sin `./` ni `/` inicial,
+ * lowercase-insensitive para el prefijo de comparación.
+ */
+function normalizeRepoPath(file) {
+    return String(file == null ? '' : file)
+        .replace(/\\/g, '/')
+        .replace(/^\.\//, '')
+        .replace(/^\/+/, '')
+        .trim();
+}
+
+/**
+ * Resuelve si un issue requiere APK y qué flavors, dado sus labels y los
+ * archivos tocados. PURE — la lectura de `changedFiles` queda fuera (la hace
+ * el llamador con una función defensiva/inyectable).
+ *
+ * @param {object} opts
+ * @param {Array<string|{name:string}>} [opts.labels]
+ * @param {string[]} [opts.changedFiles] — paths tocados (relativos al repo).
+ * @param {boolean} [opts.changedFilesKnown] — true si el origen de cambios se
+ *        pudo resolver. Si se omite, se infiere de la presencia de paths.
+ * @returns {{ requiresApk: boolean, reason: 'infra-no-apk'|'app-flavor'|'no-app-label', flavors: string[] }}
+ */
+function resolveApkRequirement({ labels = [], changedFiles = [], changedFilesKnown } = {}) {
+    const names = normalizeLabels(labels);
+    const appLabels = APP_LABELS.filter((label) => names.includes(label));
+    const files = Array.isArray(changedFiles)
+        ? changedFiles.map(normalizeRepoPath).filter(Boolean)
+        : [];
+    const touchesApp = files.some((file) => file.startsWith(APP_PATH_PREFIX));
+    const isInfraArea = INFRA_AREA_LABELS.some((l) => names.includes(l));
+
+    // Evidencia positiva del origen de cambios: explícito o por presencia de paths.
+    const known = changedFilesKnown === undefined ? files.length > 0 : Boolean(changedFilesKnown);
+
+    // Bypass infra-no-apk: área pipeline/dashboard, origen de cambios conocido y
+    // ningún path en app/composeApp/. Fail-closed si el origen es desconocido.
+    if (isInfraArea && known && !touchesApp) {
+        return { requiresApk: false, reason: 'infra-no-apk', flavors: [] };
+    }
+
+    if (appLabels.length > 0) {
+        return {
+            requiresApk: true,
+            reason: 'app-flavor',
+            flavors: appLabels.map((label) => LABEL_TO_FLAVOR[label]),
+        };
+    }
+
+    return { requiresApk: false, reason: 'no-app-label', flavors: [] };
+}
+
+// =============================================================================
 // hasVisualReference — Issue #3383 (CA-1, CA-3, CA-7, CA-UX-3)
 //
 // Valida que el body de un issue tenga sección "## Screenshots & Mockups" con
@@ -250,6 +358,14 @@ function formatBypassLogLine(event) {
 
 module.exports = {
     SKIPPABLE_QA_MODES,
+    // Issue #4046 — requerimiento de APK por flavor real, no por label.
+    resolveApkRequirement,
+    normalizeLabels,
+    normalizeLabelName,
+    normalizeRepoPath,
+    APP_LABELS,
+    LABEL_TO_FLAVOR,
+    INFRA_AREA_LABELS,
     normalizeMode,
     resolveQaMode,
     shouldSkipVisualEvidence,

--- a/.pipeline/lib/rebote-classifier.js
+++ b/.pipeline/lib/rebote-classifier.js
@@ -197,6 +197,25 @@ function classifyRebote(opts = {}) {
         ? opts.rebote_categoria.trim().toLowerCase()
         : null;
 
+    // 1.5 infra_no_apk — Issue #4046
+    //
+    // Issues de dashboard/pipeline (sin flavor real de app) que cayeron en el
+    // path de "APK faltante" NO deben contar contra el circuit breaker ni
+    // disparar la alerta de atascamiento. El bypass primario vive en
+    // `preflightQaChecks` (corta antes de retornar `apk_missing`), pero si el
+    // motivo `infra-no-apk` llega al barrido general por otra vía, lo
+    // clasificamos explícitamente como infra que no penaliza.
+    if (explicitCategory === 'infra_no_apk' || /infra[-_]no[-_]apk/i.test(motivo)) {
+        return {
+            category: 'infra',
+            label: null,
+            dependsOn: [],
+            counts_against_circuit_breaker: false,
+            autounlock: null,
+            reason_summary: 'Issue de dashboard/pipeline sin APK — no genera artefacto, no penaliza circuit breaker',
+        };
+    }
+
     if (explicitCategory === 'dependency_block') {
         // Confiamos en el agente — usamos el dependsOn que pasó (sanitizado)
         // y NO corremos los regex (evitamos falsos negativos por motivos

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -4462,6 +4462,49 @@ function getIssueLabels(issueNum) {
   return getIssueInfo(issueNum).labels;
 }
 
+/**
+ * #4046 — Resuelve los paths tocados por el trabajo de un issue, priorizando el
+ * diff real del worktree del agente contra `origin/main`. Función defensiva e
+ * inyectable: si no puede resolver un origen de cambios conocido, devuelve
+ * `{ files: [], known: false }` para que el gate de APK haga FAIL-CLOSED (no
+ * relajar por ausencia de datos).
+ *
+ * @param {string|number} issue
+ * @param {object} [deps]
+ * @param {Function} [deps.execSyncImpl] — inyectable para tests.
+ * @returns {{ files: string[], known: boolean }}
+ */
+function getChangedFilesForIssue(issue, { execSyncImpl } = {}) {
+  const _execSync = execSyncImpl || execSync;
+  try {
+    // Localizar el worktree del issue (mismo needle que resolveDeterministicScript).
+    const needle = `platform.agent-${issue}-`;
+    let issueWorktree = null;
+    const worktrees = _execSync('git worktree list --porcelain', {
+      cwd: ROOT, encoding: 'utf8', timeout: 5000, windowsHide: true,
+    });
+    for (const line of String(worktrees).split('\n')) {
+      if (line.startsWith('worktree ') && line.includes(needle)) {
+        issueWorktree = line.replace('worktree ', '').trim();
+        break;
+      }
+    }
+    if (!issueWorktree) {
+      return { files: [], known: false };
+    }
+    // Diff de la rama del worktree contra la base origin/main (three-dot:
+    // sólo cambios introducidos por la rama, sin ruido de avances de main).
+    const raw = _execSync('git diff --name-only origin/main...HEAD', {
+      cwd: issueWorktree, encoding: 'utf8', timeout: 10000, windowsHide: true,
+    });
+    const files = String(raw).split('\n').map(s => s.trim()).filter(Boolean);
+    return { files, known: true };
+  } catch (e) {
+    log('preflight', `#${issue}: no se pudieron resolver changed-files (fail-closed): ${String(e.message).slice(0, 80)}`);
+    return { files: [], known: false };
+  }
+}
+
 /** Verifica si un issue está cerrado en GitHub (usa cache) */
 function isIssueClosed(issueNum) {
   return getIssueInfo(issueNum).state === 'CLOSED';
@@ -4579,6 +4622,17 @@ function sortByPriority(archivos, config) {
  */
 function reboteVerificacionABuild(issue, pipelineName, preflightResult) {
   const MAX_REBOTES_APK = 3;
+
+  // #4046 — Fail-open defensivo: si el preflight resolvió que el issue NO
+  // genera APK (dashboard/pipeline sin cambios de app), no rebotar a build, no
+  // escribir `rebote_numero` y no encolar build. Esto evita que un "APK
+  // faltante" espurio cuente contra MAX_REBOTES_APK y dispare la alerta de
+  // atascamiento. El bypass primario corta en preflightQaChecks (retorna ok),
+  // este guard es defensa por si el motivo llega por otra vía.
+  if (preflightResult && (preflightResult.reason === 'infra-no-apk' || preflightResult.requiresEmulator === false)) {
+    log('lanzamiento', `🟢 #${issue}: reboteVerificacionABuild fail-open (reason=${preflightResult.reason}, requiresEmulator=${preflightResult.requiresEmulator}) — issue no produce APK, no se rebota ni cuenta contra circuit breaker`);
+    return false;
+  }
 
   try {
     const verPendDir = path.join(fasePath(pipelineName, 'verificacion'), 'pendiente');
@@ -5187,7 +5241,10 @@ function brazoLanzamiento(config) {
 
 const APP_LABELS = ['app:client', 'app:business', 'app:delivery'];
 const LABEL_TO_FLAVOR = { 'app:client': 'client', 'app:business': 'business', 'app:delivery': 'delivery' };
-const ROUTING_LABELS = [...APP_LABELS, 'area:backend', 'area:infra', 'area:pipeline', 'tipo:infra', 'docs'];
+// #4046 — `area:dashboard` agregado como label de ruteo: un issue de dashboard
+// no debe disparar auto-clasificación (que lo reetiquetaría y rompería el
+// bypass infra-no-apk). El dashboard es dominio pipeline-dev determinístico.
+const ROUTING_LABELS = [...APP_LABELS, 'area:backend', 'area:infra', 'area:pipeline', 'area:dashboard', 'tipo:infra', 'docs'];
 
 // Keywords para auto-clasificación inteligente de issues sin labels de ruteo
 const AUTO_CLASSIFY_RULES = [
@@ -5549,12 +5606,16 @@ function checkDynamoDbRemote(issue) {
   return { ok, checks };
 }
 
-function preflightQaChecks(issue) {
+function preflightQaChecks(issue, {
+  getLabels = getIssueLabels,
+  getChangedFiles = getChangedFilesForIssue,
+  qaArtifactsDir = QA_ARTIFACTS_DIR,
+} = {}) {
   const startMs = Date.now();
   const checks = {};
 
   // --- Check 1: Clasificar issue (requiere emulador o no) ---
-  let labels = getIssueLabels(issue);
+  let labels = getLabels(issue);
 
   // Auto-clasificación: si el issue no tiene ningún label de ruteo, inferir y asignar
   const hasRoutingLabel = labels.some(l => ROUTING_LABELS.includes(l));
@@ -5563,11 +5624,40 @@ function preflightQaChecks(issue) {
     const assignedLabel = autoClassifyIssue(issue);
     if (assignedLabel) {
       // Re-leer labels después de la asignación
-      labels = getIssueLabels(issue);
+      labels = getLabels(issue);
       sendTelegram(`🏷️ Issue #${issue} auto-clasificado como \`${assignedLabel}\` (no tenía label de ruteo QA).`);
     } else {
       log('preflight', `#${issue}: auto-clasificación falló — cae en structural por defecto`);
     }
+  }
+
+  // #4046 — Decidir el requerimiento de APK por flavor REAL, no por label
+  // `app:client` a secas. Un issue de dashboard/pipeline sin cambios en
+  // app/composeApp/ no produce binario: el gate no debe exigirlo ni rebotar.
+  const changed = getChangedFiles(issue);
+  const apkReq = qaEvidenceGate.resolveApkRequirement({
+    labels,
+    changedFiles: changed.files,
+    changedFilesKnown: changed.known,
+  });
+  if (apkReq.reason === 'infra-no-apk') {
+    const qaMode = 'structural';
+    qaModeByIssue.set(String(issue), qaMode);
+    checks.classify = 'infra-no-apk';
+    checks.apk = 'bypass:infra-no-apk';
+    const bypassEvent = {
+      event: 'gate-bypass',
+      issue: String(issue),
+      qaMode,
+      source: 'preflight',
+      reason: 'infra-no-apk',
+      decision: 'skip-apk',
+      labels: Array.isArray(labels) ? labels.slice() : [],
+      changedFiles: changed.files.slice(0, 20),
+    };
+    log('preflight', `🟢 gate-bypass #${issue} reason=infra-no-apk — área pipeline/dashboard sin cambios en app/composeApp/ → no exige APK ${JSON.stringify(bypassEvent)}`);
+    logPreflight(issue, checks, 'pass', startMs);
+    return { ok: true, result: 'pass', reason: 'infra-no-apk', flavors: [], requiresEmulator: false, qaMode, apkRequirement: 'infra-no-apk' };
   }
 
   const appLabels = labels.filter(l => APP_LABELS.includes(l));
@@ -5654,11 +5744,11 @@ function preflightQaChecks(issue) {
   }
 
   // --- Check 2: APK disponible (solo si requiere emulador) ---
-  fs.mkdirSync(QA_ARTIFACTS_DIR, { recursive: true });
+  fs.mkdirSync(qaArtifactsDir, { recursive: true });
   const missingApks = [];
   for (const flavor of flavors) {
     const apkName = `${issue}-composeApp-${flavor}-debug.apk`;
-    const apkPath = path.join(QA_ARTIFACTS_DIR, apkName);
+    const apkPath = path.join(qaArtifactsDir, apkName);
     if (!fs.existsSync(apkPath)) {
       missingApks.push(apkName);
     }
@@ -13457,6 +13547,10 @@ if (process.env.PULPO_NO_AUTOSTART === '1') {
     _setBuildPriorityState: (active, manual) => { buildPriorityActive = active; buildPriorityManual = manual || false; },
     // #2893 — resolver de script determinístico (preferencia worktree-first).
     resolveDeterministicScript,
+    // #4046 — preflight de APK por flavor real + resolución de changed-files.
+    preflightQaChecks,
+    getChangedFilesForIssue,
+    reboteVerificacionABuild,
     // #2957 — counter de fase build expuesto para tests del filtro por allowlist.
     countPendingBuild,
     // #3059 — wrapper robusto + watchdog del brazo de desbloqueo (testing).

--- a/.pipeline/tests/pulpo-apk-preflight.test.js
+++ b/.pipeline/tests/pulpo-apk-preflight.test.js
@@ -1,0 +1,101 @@
+// =============================================================================
+// Tests pulpo-apk-preflight — Issue #4046
+//
+// Smoke determinístico de `preflightQaChecks`: el gate de APK debe decidir por
+// el flavor REAL del trabajo (paths tocados), no por la mera presencia del
+// label `app:client`.
+//
+//   - Issue pipeline/dashboard SIN cambios en app/composeApp/ (caso #3954):
+//     retorna ok:true, qaMode:'structural', reason:'infra-no-apk' — sin exigir
+//     APK ni rebotar.
+//   - Issue con cambios reales en app/composeApp/ + app:client: sigue
+//     retornando apk_missing si no existe el APK (no se afloja el gate legítimo).
+//   - El guard de `reboteVerificacionABuild` hace fail-open para infra-no-apk
+//     (no cuenta contra el circuit breaker).
+//
+// Se inyectan `getLabels`, `getChangedFiles` y `qaArtifactsDir` para que el
+// smoke sea hermético (sin gh, sin worktree, sin emulador, sin backend).
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+process.env.PULPO_NO_AUTOSTART = '1';
+const pulpo = require('../pulpo.js');
+
+function tmpEmptyArtifactsDir() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'apk-preflight-'));
+    return dir;
+}
+
+// ─── Caso #3954: pipeline-only sin APK ──────────────────────────────────────
+test('#4046 · issue area:pipeline + app:client con paths .pipeline/* → ok, structural, infra-no-apk', () => {
+    const res = pulpo.preflightQaChecks(3954, {
+        getLabels: () => ['area:pipeline', 'app:client', 'Ready'],
+        getChangedFiles: () => ({ files: ['.pipeline/lib/qa-evidence-gate.js', '.pipeline/pulpo.js'], known: true }),
+        qaArtifactsDir: tmpEmptyArtifactsDir(),
+    });
+    assert.equal(res.ok, true);
+    assert.equal(res.result, 'pass');
+    assert.equal(res.reason, 'infra-no-apk');
+    assert.equal(res.qaMode, 'structural');
+    assert.equal(res.requiresEmulator, false);
+    assert.deepEqual(res.flavors, []);
+});
+
+test('#4046 · issue area:dashboard sin app label con paths .pipeline/* → infra-no-apk', () => {
+    const res = pulpo.preflightQaChecks(4001, {
+        getLabels: () => ['area:dashboard'],
+        getChangedFiles: () => ({ files: ['.pipeline/dashboard-v2.js'], known: true }),
+        qaArtifactsDir: tmpEmptyArtifactsDir(),
+    });
+    assert.equal(res.ok, true);
+    assert.equal(res.reason, 'infra-no-apk');
+    assert.equal(res.requiresEmulator, false);
+});
+
+// ─── Issue de app real sigue exigiendo APK ──────────────────────────────────
+test('#4046 · issue app:client con cambios en app/composeApp/ y sin APK → apk_missing', () => {
+    const res = pulpo.preflightQaChecks(4002, {
+        getLabels: () => ['app:client'],
+        getChangedFiles: () => ({ files: ['app/composeApp/src/androidMain/Foo.kt'], known: true }),
+        qaArtifactsDir: tmpEmptyArtifactsDir(), // vacío → APK no existe
+    });
+    assert.equal(res.ok, false);
+    assert.equal(res.result, 'apk_missing');
+    assert.equal(res.requiresEmulator, true);
+    assert.deepEqual(res.flavors, ['client']);
+});
+
+test('#4046 · FAIL-CLOSED: app:client + area:pipeline sin origen conocido → sigue exigiendo APK', () => {
+    const res = pulpo.preflightQaChecks(4003, {
+        getLabels: () => ['area:pipeline', 'app:client'],
+        getChangedFiles: () => ({ files: [], known: false }),
+        qaArtifactsDir: tmpEmptyArtifactsDir(),
+    });
+    // Sin evidencia positiva del origen, no se relaja: cae al gate por label.
+    assert.equal(res.ok, false);
+    assert.equal(res.result, 'apk_missing');
+    assert.equal(res.requiresEmulator, true);
+});
+
+// ─── reboteVerificacionABuild fail-open ─────────────────────────────────────
+test('#4046 · reboteVerificacionABuild fail-open para reason=infra-no-apk → false, sin rebote', () => {
+    const out = pulpo.reboteVerificacionABuild(3954, 'desarrollo', {
+        reason: 'infra-no-apk',
+        requiresEmulator: false,
+    });
+    assert.equal(out, false);
+});
+
+test('#4046 · reboteVerificacionABuild fail-open para requiresEmulator=false → false', () => {
+    const out = pulpo.reboteVerificacionABuild(4004, 'desarrollo', {
+        reason: 'pass',
+        requiresEmulator: false,
+    });
+    assert.equal(out, false);
+});


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 6 archivos · +471 -6

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:passed` aplicado por delivery

## Closes

Closes #4046
