### PR TITLE
El seeder de olas pierde el nombre/numero real del plan maestro al resembrar tras /restart

### DIFF
--- a/.pipeline/lib/__tests__/init-waves-from-partial.test.js
+++ b/.pipeline/lib/__tests__/init-waves-from-partial.test.js
@@ -379,6 +379,184 @@ test('#3616: normaliza IDs con prefijo "#"', () => {
     } finally { teardownTmp(dir); }
 });
 
+// ─── #4030 — Nombre/número real de la ola del plan maestro ───────────────────
+
+test('#4030 CA-1: seed con metadata estructurada → nombre/número reales del plan maestro', () => {
+    const dir = setupTmp();
+    try {
+        // waves.json con olas archivadas 1..3 → maxArchivedNumber=3.
+        writeWaves(dir, JSON.stringify({
+            version: '1.0',
+            active_wave: null,
+            planned_waves: [],
+            archived_waves: [{ number: 1 }, { number: 2 }, { number: 3 }],
+        }));
+        writePartial(dir, JSON.stringify({
+            allowed_issues: [3934, 3935, 4030],
+            source: 'telegram:commander',
+            wave_number: 4,
+            wave_name: 'Memoria + dashboard operativo núcleo',
+            wave_goal: 'Núcleo operativo de memoria y dashboard.',
+        }));
+
+        const r = init.initWavesFromPartial({ skipAlert: true });
+        assert.equal(r.action, 'seeded');
+        assert.equal(r.waveNumber, 4);
+
+        const state = readWaves(dir);
+        assert.equal(state.active_wave.number, 4);
+        assert.equal(state.active_wave.name, 'Memoria + dashboard operativo núcleo');
+        assert.equal(state.active_wave.goal, 'Núcleo operativo de memoria y dashboard.');
+    } finally { teardownTmp(dir); }
+});
+
+test('#4030 CA-1: fallback al `note` de texto libre cuando no hay campos estructurados', () => {
+    const dir = setupTmp();
+    try {
+        writeWaves(dir, JSON.stringify({
+            version: '1.0',
+            active_wave: null,
+            planned_waves: [],
+            archived_waves: [{ number: 3 }],
+        }));
+        writePartial(dir, JSON.stringify({
+            allowed_issues: [4030],
+            source: 'telegram:commander',
+            note: "Ola 4 'Memoria + dashboard operativo núcleo' habilitada por OK de Leo.",
+        }));
+
+        const r = init.initWavesFromPartial({ skipAlert: true });
+        assert.equal(r.waveNumber, 4);
+        const state = readWaves(dir);
+        assert.equal(state.active_wave.number, 4);
+        assert.equal(state.active_wave.name, 'Memoria + dashboard operativo núcleo');
+    } finally { teardownTmp(dir); }
+});
+
+test('#4030 CA-3: sin metadata → fallback genérico Ola seed #N (maxArchived+1)', () => {
+    const dir = setupTmp();
+    try {
+        writeWaves(dir, JSON.stringify({
+            version: '1.0',
+            active_wave: null,
+            planned_waves: [],
+            archived_waves: [{ number: 3 }],
+        }));
+        writePartial(dir, JSON.stringify({
+            allowed_issues: [100, 200],
+            source: 'manual',
+        }));
+
+        const r = init.initWavesFromPartial({ skipAlert: true });
+        assert.equal(r.waveNumber, 4);
+        const state = readWaves(dir);
+        assert.equal(state.active_wave.name, 'Ola seed #4');
+    } finally { teardownTmp(dir); }
+});
+
+test('#4030 CA-4: número de ola que colisiona con archived → se ignora, cae al cálculo seguro', () => {
+    const dir = setupTmp();
+    try {
+        // archived ya tiene 4 → maxArchivedNumber=4. wave_number=4 NO es > 4.
+        writeWaves(dir, JSON.stringify({
+            version: '1.0',
+            active_wave: null,
+            planned_waves: [],
+            archived_waves: [{ number: 4 }],
+        }));
+        writePartial(dir, JSON.stringify({
+            allowed_issues: [4030],
+            source: 'telegram:commander',
+            wave_number: 4,
+            wave_name: 'Nombre que colisiona',
+        }));
+
+        const r = init.initWavesFromPartial({ skipAlert: true });
+        assert.equal(r.waveNumber, 5, 'cae al cálculo seguro maxArchived+1');
+        const state = readWaves(dir);
+        assert.equal(state.active_wave.name, 'Ola seed #5');
+    } finally { teardownTmp(dir); }
+});
+
+test('#4030 CA-4: colisión contra planned_waves también degrada a fallback', () => {
+    const dir = setupTmp();
+    try {
+        writeWaves(dir, JSON.stringify({
+            version: '1.0',
+            active_wave: null,
+            planned_waves: [{ number: 7 }],
+            archived_waves: [{ number: 3 }],
+        }));
+        writePartial(dir, JSON.stringify({
+            allowed_issues: [4030],
+            source: 'telegram:commander',
+            wave_number: 5, // 5 <= maxArchived(7) → colisión.
+            wave_name: 'No debería usarse',
+        }));
+
+        const r = init.initWavesFromPartial({ skipAlert: true });
+        assert.equal(r.waveNumber, 8);
+        const state = readWaves(dir);
+        assert.equal(state.active_wave.name, 'Ola seed #8');
+    } finally { teardownTmp(dir); }
+});
+
+test('#4030: meta inválida (name no-string / number ≤0 / control-chars) → degrada sin lanzar', () => {
+    const dir = setupTmp();
+    try {
+        writeWaves(dir, JSON.stringify({
+            version: '1.0',
+            active_wave: null,
+            planned_waves: [],
+            archived_waves: [{ number: 2 }],
+        }));
+        writePartial(dir, JSON.stringify({
+            allowed_issues: [4030],
+            source: 'telegram:commander',
+            wave_number: 0,            // inválido (≤0)
+            wave_name: { not: 'a string' }, // inválido (no-string)
+        }));
+
+        const r = init.initWavesFromPartial({ skipAlert: true });
+        assert.equal(r.action, 'seeded');
+        assert.equal(r.waveNumber, 3);
+        const state = readWaves(dir);
+        assert.equal(state.active_wave.name, 'Ola seed #3');
+    } finally { teardownTmp(dir); }
+});
+
+test('#4030: sanitizeWaveMeta strip de control-chars + cap de longitud + strip prefijo "Ola N — "', () => {
+    const { sanitizeWaveMeta } = init._internal;
+    // Strip de control-chars y prefijo "Ola N — ".
+    const m1 = sanitizeWaveMeta({ wave_number: 4, wave_name: 'Ola 4 — Memoria núcleo' });
+    assert.equal(m1.number, 4);
+    assert.equal(m1.name, 'Memoria núcleo');
+    // Cap de longitud: name ≤120, goal ≤500.
+    const longName = 'x'.repeat(200);
+    const m2 = sanitizeWaveMeta({ wave_number: 2, wave_name: longName, wave_goal: 'y'.repeat(700) });
+    assert.equal(m2.name.length, 120);
+    assert.equal(m2.goal.length, 500);
+    // Sin número o nombre válido → null.
+    assert.equal(sanitizeWaveMeta({ wave_name: 'sin numero' }), null);
+    assert.equal(sanitizeWaveMeta({ wave_number: 4 }), null);
+    assert.equal(sanitizeWaveMeta(null), null);
+});
+
+test('#4030: parseWaveMetaFromNote tolera comillas simples/dobles/tipográficas y no matchea basura', () => {
+    const { parseWaveMetaFromNote } = init._internal;
+    assert.deepEqual(
+        parseWaveMetaFromNote("Ola 4 'Memoria núcleo' habilitada"),
+        { number: 4, name: 'Memoria núcleo', goal: '' },
+    );
+    assert.deepEqual(
+        parseWaveMetaFromNote('Ola 12 "Otra ola" activa'),
+        { number: 12, name: 'Otra ola', goal: '' },
+    );
+    assert.equal(parseWaveMetaFromNote('sin formato de ola'), null);
+    assert.equal(parseWaveMetaFromNote(''), null);
+    assert.equal(parseWaveMetaFromNote(null), null);
+});
+
 // ─── Smoke: el script CLI no crashea ───────────────────────────────────────
 
 test('#3616: el script existe como CLI ejecutable', () => {

--- a/.pipeline/lib/__tests__/partial-pause.test.js
+++ b/.pipeline/lib/__tests__/partial-pause.test.js
@@ -203,3 +203,66 @@ test('isIssueAllowedInState — partial_pause con allowedIssues no-array es segu
     const state = { mode: 'partial_pause' };
     assert.equal(pp.isIssueAllowedInState(2891, state), false);
 });
+
+// ─── #4030 — Metadata estructurada de la ola (campos aditivos) ──────────────
+
+function readPartialRaw() {
+    const { PARTIAL_FILE } = pp._paths();
+    return JSON.parse(fs.readFileSync(PARTIAL_FILE, 'utf8'));
+}
+
+test('#4030: setPartialPause persiste wave_number/wave_name/wave_goal cuando se proveen por opts', () => {
+    resetFs();
+    pp.setPartialPause([4030], {
+        source: 'telegram:commander',
+        waveNumber: 4,
+        waveName: 'Memoria + dashboard operativo núcleo',
+        waveGoal: 'Núcleo operativo.',
+    });
+    const raw = readPartialRaw();
+    assert.equal(raw.wave_number, 4);
+    assert.equal(raw.wave_name, 'Memoria + dashboard operativo núcleo');
+    assert.equal(raw.wave_goal, 'Núcleo operativo.');
+});
+
+test('#4030: setPartialPause NO escribe los campos de ola cuando no se proveen', () => {
+    resetFs();
+    pp.setPartialPause([4030], { source: 'telegram' });
+    const raw = readPartialRaw();
+    assert.equal('wave_number' in raw, false);
+    assert.equal('wave_name' in raw, false);
+    assert.equal('wave_goal' in raw, false);
+});
+
+test('#4030: setPartialPauseAtomic persiste los campos de ola saneados (cap + strip prefijo)', () => {
+    resetFs();
+    pp.setPartialPauseAtomic([4030], {
+        source: 'wave-promote-atomic',
+        authorizedBy: 'wave-promote',
+        waveNumber: 5,
+        waveName: 'Ola 5 — Título con prefijo',
+        waveGoal: 'g'.repeat(600),
+    });
+    const raw = readPartialRaw();
+    assert.equal(raw.wave_number, 5);
+    assert.equal(raw.wave_name, 'Título con prefijo', 'strip del prefijo "Ola N — "');
+    assert.equal(raw.wave_goal.length, 500, 'cap de goal a 500');
+});
+
+test('#4030: meta de ola inválida (number ≤0 / name no-string) NO se persiste', () => {
+    resetFs();
+    pp.setPartialPause([4030], {
+        source: 'telegram',
+        waveNumber: 0,
+        waveName: 'Nombre',
+    });
+    const raw = readPartialRaw();
+    assert.equal('wave_number' in raw, false);
+    assert.equal('wave_name' in raw, false);
+});
+
+test('#4030: sanitizeWaveMetaForWrite strip de control-chars', () => {
+    const m = pp.sanitizeWaveMetaForWrite({ waveNumber: 4, waveName: 'Mem\x00oria\x1f' });
+    assert.equal(m.wave_name, 'Memoria');
+    assert.equal(m.wave_number, 4);
+});

--- a/.pipeline/lib/partial-pause.js
+++ b/.pipeline/lib/partial-pause.js
@@ -88,6 +88,32 @@ function normalizeIssue(issue) {
     return Number.isInteger(n) && n > 0 ? n : null;
 }
 
+// #4030 — Metadata estructurada de la ola activa (campos aditivos). Permite que
+// el seeder (init-waves-from-partial) recupere nombre/número reales tras un
+// `/restart` sin tener que parsear el `note` de texto libre. Saneado fail-closed
+// (mismo criterio que el resto del marker + hardening de security #4030):
+//   - `wave_number`: entero positivo.
+//   - `wave_name`: string, strip de control-chars (U+0000..U+001F), cap 120.
+//   - `wave_goal`: string opcional, strip de control-chars, cap 500.
+// Convención de display (UX #4030): `wave_name` guarda SÓLO el título; si el
+// caller trae el prefijo "Ola N — " lo normalizamos quitándolo, para que cada
+// consumidor (/wave, dashboard) componga "Ola N — <título>" sin duplicar.
+// Devuelve null si falta número+nombre válidos (el seeder cae al fallback).
+function sanitizeWaveMetaForWrite(opts) {
+    if (!opts || typeof opts !== 'object') return null;
+    const stripCtl = (s) => String(s).replace(/[\x00-\x1f]/g, '').trim();
+    const num = Number.isInteger(opts.waveNumber) && opts.waveNumber > 0
+        ? opts.waveNumber : null;
+    const rawName = typeof opts.waveName === 'string' ? stripCtl(opts.waveName) : '';
+    const name = rawName
+        ? rawName.replace(/^Ola\s+\d+\s*[—–-]\s*/i, '').slice(0, 120)
+        : null;
+    const goal = typeof opts.waveGoal === 'string'
+        ? stripCtl(opts.waveGoal).slice(0, 500) : '';
+    if (num === null || !name) return null;
+    return { wave_number: num, wave_name: name, wave_goal: goal };
+}
+
 function readPartialFile() {
     try {
         const raw = fs.readFileSync(partialFile(), 'utf8');
@@ -408,6 +434,14 @@ function setPartialPause(issues, opts = {}) {
     if (uniqueSkills.length > 0) {
         data.allowed_skills = uniqueSkills;
     }
+    // #4030 — Metadata estructurada de la ola (aditiva). Sólo se persiste
+    // cuando el caller la provee por opts y pasa el saneado fail-closed.
+    const waveMeta = sanitizeWaveMetaForWrite(opts);
+    if (waveMeta) {
+        data.wave_number = waveMeta.wave_number;
+        data.wave_name = waveMeta.wave_name;
+        if (waveMeta.wave_goal) data.wave_goal = waveMeta.wave_goal;
+    }
     if (opts.acceptedDepRisk === true) data.accepted_dep_risk = true;
     if (opts.depSources && typeof opts.depSources === 'object') {
         // Filtrar a las claves que efectivamente terminaron en el allowlist.
@@ -560,6 +594,13 @@ function setPartialPauseAtomic(issues, opts = {}) {
     };
     if (uniqueSkills.length > 0) {
         data.allowed_skills = uniqueSkills;
+    }
+    // #4030 — Metadata estructurada de la ola (aditiva, igual que setPartialPause).
+    const waveMeta = sanitizeWaveMetaForWrite(opts);
+    if (waveMeta) {
+        data.wave_number = waveMeta.wave_number;
+        data.wave_name = waveMeta.wave_name;
+        if (waveMeta.wave_goal) data.wave_goal = waveMeta.wave_goal;
     }
     if (opts.acceptedDepRisk === true) data.accepted_dep_risk = true;
     if (opts.depSources && typeof opts.depSources === 'object') {
@@ -776,5 +817,7 @@ module.exports = {
     // #3625 — exportados para callers que quieran leer estado raw y para tests.
     readPreviousAllowlist,
     evaluateAndAudit,
+    // #4030 — saneado de metadata de ola (expuesto para tests).
+    sanitizeWaveMetaForWrite,
     _paths: () => ({ PARTIAL_FILE: partialFile(), PAUSE_FILE: pauseFile() }),
 };

--- a/.pipeline/lib/waves.js
+++ b/.pipeline/lib/waves.js
@@ -1401,10 +1401,26 @@ function promoteWaveAtomic(waveNumber, metadata = {}) {
         // partial-pause acepte los removals que provoca la rotación de olas.
         newAllowlist = getAllowlist();
         const partialPause = require('./partial-pause');
+        // #4030 — Recuperar metadata real de la ola recién promovida para que
+        // sobreviva al seeder tras un /restart. Reutilizamos la misma fuente que
+        // ya expone active_wave (no duplicamos lógica de naming). Best-effort:
+        // si no podemos leerla, el seeder cae a su fallback genérico.
+        let waveMetaForPartial = {};
+        try {
+            const activeNow = loadWaves().active_wave;
+            if (activeNow && Number.isInteger(activeNow.number)) {
+                waveMetaForPartial = {
+                    waveNumber: activeNow.number,
+                    waveName: activeNow.name || '',
+                    waveGoal: activeNow.goal || '',
+                };
+            }
+        } catch { /* defensivo: degradar al fallback del seeder */ }
         partialPause.setPartialPauseAtomic(newAllowlist, {
             source: metadata.source || 'wave-promote-atomic',
             authorizedBy: 'wave-promote',
             justification: metadata.note || `promote wave ${waveNumber} → active (atomic)`,
+            ...waveMetaForPartial,
         });
     } catch (err) {
         // Rollback inmediato: ambos archivos vuelven al snapshot.

--- a/.pipeline/scripts/init-waves-from-partial.js
+++ b/.pipeline/scripts/init-waves-from-partial.js
@@ -73,6 +73,69 @@ function normalizeIssue(issue) {
     return Number.isInteger(n) && n > 0 ? n : null;
 }
 
+// ─── #4030 — Metadata real de la ola (nombre/número del plan maestro) ────────
+//
+// El seeder recupera el nombre/número reales de la ola activa para que
+// sobrevivan a un `/restart` sin renombrado manual. Fuente de verdad en orden
+// de preferencia:
+//   1. Campos estructurados `wave_number`/`wave_name`/`wave_goal` (robusto).
+//   2. Parseo del `note` de texto libre (fallback de compatibilidad, tolerante).
+//   3. `Ola seed #N` (último recurso, en el constructor del seed).
+//
+// Ambos extractores son TOLERANTES A FALLO: nunca lanzan ni convierten el
+// payload en `aborted_invalid_partial`. Un meta inválido degrada al fallback.
+
+/**
+ * Saneado fail-closed de los campos estructurados (security #4030):
+ *   - `wave_number`: entero positivo.
+ *   - `wave_name`: string, strip de control-chars (U+0000..U+001F), cap 120.
+ *   - `wave_goal`: string opcional, strip de control-chars, cap 500.
+ * Convención de display (UX #4030): el `name` guarda SÓLO el título; si viene
+ * con prefijo "Ola N — " se normaliza quitándolo. Devuelve null si falta
+ * número+nombre válidos.
+ */
+function sanitizeWaveMeta(parsed) {
+    if (!parsed || typeof parsed !== 'object') return null;
+    const stripCtl = (s) => String(s).replace(/[\x00-\x1f]/g, '').trim();
+    const num = Number.isInteger(parsed.wave_number) && parsed.wave_number > 0
+        ? parsed.wave_number : null;
+    const rawName = typeof parsed.wave_name === 'string' ? stripCtl(parsed.wave_name) : '';
+    const name = rawName
+        ? rawName.replace(/^Ola\s+\d+\s*[—–-]\s*/i, '').slice(0, 120)
+        : null;
+    const goal = typeof parsed.wave_goal === 'string'
+        ? stripCtl(parsed.wave_goal).slice(0, 500) : '';
+    if (num === null || !name) return null;
+    return { number: num, name, goal };
+}
+
+/**
+ * Fallback de compatibilidad: parsea el `note` de texto libre del Commander
+ * (ej. "Ola 4 'Memoria + dashboard operativo núcleo' habilitada por..."). Tolera
+ * comillas simples, dobles y tipográficas. NO lanza ni loguea el contenido
+ * crudo (security req 3). Si no matchea, devuelve null.
+ */
+function parseWaveMetaFromNote(note) {
+    if (typeof note !== 'string' || !note) return null;
+    const stripCtl = (s) => String(s).replace(/[\x00-\x1f]/g, '').trim();
+    const m = note.match(/Ola\s+(\d+)\s+['"‘’“”]([^'"‘’“”]+)['"‘’“”]/);
+    if (!m) return null;
+    const num = Number(m[1]);
+    if (!Number.isInteger(num) || num <= 0) return null;
+    const name = stripCtl(m[2]).slice(0, 120);
+    if (!name) return null;
+    return { number: num, name, goal: '' };
+}
+
+/**
+ * Extrae la metadata de ola del payload, preferencia estructurado > note > null.
+ * Tolerante a fallo: nunca lanza.
+ */
+function extractWaveMeta(parsed) {
+    if (!parsed || typeof parsed !== 'object') return null;
+    return sanitizeWaveMeta(parsed) || parseWaveMetaFromNote(parsed.note) || null;
+}
+
 function nowIso() {
     return new Date().toISOString();
 }
@@ -159,7 +222,10 @@ function readPartialStrict() {
     }
     // Deduplicar manteniendo orden de aparición.
     const unique = [...new Set(allowed)];
-    return { ok: true, allowedIssues: unique, errors: [] };
+    // #4030 — Extracción tolerante de metadata de ola (aditiva, NO fail-closed):
+    // un meta ausente/inválido degrada a null y el seed cae al fallback genérico.
+    const waveMeta = extractWaveMeta(parsed);
+    return { ok: true, allowedIssues: unique, errors: [], waveMeta };
 }
 
 /**
@@ -342,12 +408,31 @@ function initWavesFromPartial(opts = {}) {
     }
 
     // 5. Construir el seed: ola activa con los issues del allowlist.
-    //    Numeración: max(archived.number) + 1, default 1.
-    const waveNumber = wavesState.maxArchivedNumber + 1;
+    //    Numeración por defecto: max(archived/planned.number) + 1, default 1.
+    //    #4030 — Si el partial-pause trae metadata real de la ola (campos
+    //    estructurados o, como fallback, el `note`), usamos nombre/número reales
+    //    del plan maestro en vez de `Ola seed #N`.
+    //    Guard de colisión OBLIGATORIO (riesgo guru #1 + security #4): sólo
+    //    confiamos en el número externo si es estrictamente mayor que cualquier
+    //    archived/planned. Si choca, lo ignoramos y caemos al cálculo seguro
+    //    `maxArchivedNumber + 1` con nombre genérico (no se confía en el número
+    //    provisto desde una fuente semi-confiable).
+    let waveNumber = wavesState.maxArchivedNumber + 1;
+    let name = `Ola seed #${waveNumber}`;
+    let goal = 'Seed inicial generado desde .partial-pause.json (issue #3616).';
+    if (partial.waveMeta && partial.waveMeta.number > wavesState.maxArchivedNumber) {
+        waveNumber = partial.waveMeta.number;
+        name = partial.waveMeta.name;
+        goal = partial.waveMeta.goal || goal;
+        logInfo(`Metadata de ola recuperada del plan maestro: ola #${waveNumber} "${name}".`);
+    } else if (partial.waveMeta) {
+        logWarn(`Número de ola provisto (#${partial.waveMeta.number}) colisiona con ` +
+            `archived/planned (max=${wavesState.maxArchivedNumber}) — uso fallback #${waveNumber}.`);
+    }
     const seededWave = {
         number: waveNumber,
-        name: `Ola seed #${waveNumber}`,
-        goal: 'Seed inicial generado desde .partial-pause.json (issue #3616).',
+        name,
+        goal,
         started_at: nowIso(),
         issues: partial.allowedIssues.map((n) => ({ number: n, status: 'in_progress' })),
     };
@@ -392,8 +477,11 @@ function initWavesFromPartial(opts = {}) {
             updated_at: nowIso(),
             updated_by: 'init-waves-from-partial',
             source: 'auto-seed',
-            note: `Seed inicial desde .partial-pause.json (#3616). ` +
-                `${partial.allowedIssues.length} issue(s) sembrados en ola #${waveNumber}.`,
+            note: (partial.waveMeta && waveNumber === partial.waveMeta.number)
+                ? `Seed desde .partial-pause.json (#3616/#4030): ola #${waveNumber} "${name}" ` +
+                    `con ${partial.allowedIssues.length} issue(s).`
+                : `Seed inicial desde .partial-pause.json (#3616). ` +
+                    `${partial.allowedIssues.length} issue(s) sembrados en ola #${waveNumber}.`,
         },
         active_wave: seededWave,
         planned_waves: Array.isArray(prev.planned_waves) ? prev.planned_waves : [],
@@ -461,6 +549,10 @@ module.exports = {
         readWavesState,
         normalizeIssue,
         _resetDedupeForTests,
+        // #4030 — extractores de metadata de ola (expuestos para tests).
+        sanitizeWaveMeta,
+        parseWaveMetaFromNote,
+        extractWaveMeta,
     },
 };
 


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 5 archivos · +399 -7

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:skipped` aplicado por delivery

## Closes

Closes #4030
