### PR TITLE
[BUG] El smoke test del restart dispara rollback en loop: el event loop del dashboard se bloquea (regresión #4097)

### DIFF
--- a/.pipeline/dashboard.js
+++ b/.pipeline/dashboard.js
@@ -18,14 +18,15 @@ const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
-const { execSync, spawn, spawnSync } = require('child_process');
+const { execSync, execFile, spawn, spawnSync } = require('child_process');
 const yaml = require('js-yaml');
+const pidDiscovery = require('./pid-discovery');
 const {
   findPidByComponent,
   findPidByPort,
   pidAlive,
   invalidateCache,
-} = require('./pid-discovery');
+} = pidDiscovery;
 // #2337 CA8 — estado `reintentando` (anti-parpadeo FS-driven).
 // Best-effort require: si el modulo no existe (pipeline antiguo), degradamos
 // silenciosamente sin el estado `retrying`.
@@ -535,7 +536,32 @@ let _stateSnapshot = null;          // última vista computada (o null en cold s
 let _stateSnapshotAt = 0;           // timestamp del último refresh exitoso
 let _stateRefreshInflight = false;  // evita solapar cómputos pesados
 let _stateRefreshTimer = null;      // handle del setInterval (para clearInterval)
-const STATE_REFRESH_MS = 3000;      // cadencia de refresh fuera del hot path
+// #4126 — cadencia configurable por env para que los tests puedan forzar un
+// worker casi-siempre-activo y verificar que /api/health no se cuelga.
+const STATE_REFRESH_MS = Number(process.env.DASHBOARD_STATE_REFRESH_MS) || 3000;
+// Tamaño de chunk del scan del FS: cada N archivos procesados el generador
+// cede el event loop (setImmediate) para que /api/health y el resto de rutas
+// sigan respondiendo mientras el worker reconstruye el snapshot.
+const STATE_SCAN_CHUNK = Number(process.env.DASHBOARD_STATE_SCAN_CHUNK) || 250;
+
+// #4126 — Cache async de estado de procesos + QA env. Los scans del SO
+// (`wmic` para PIDs, `tasklist` para servicios QA) eran spawnSync/execSync
+// DENTRO del worker de snapshot: un único `wmic` podía clavar el event loop
+// hasta 15s y dejaba /api/health sin responder → el smoke del restart lo leía
+// como caída y disparaba rollback en loop (regresión #4119). Ahora se computan
+// con `exec`/`execFile` async, fuera del tick, y el snapshot lee este cache en
+// O(1). Swap atómico del objeto (nunca mutación in-place).
+let _procStatusCache = null;        // { procesos, qaEnv } | null en cold start
+let _procStatusCacheAt = 0;
+let _procStatusInflight = false;
+const PROC_STATUS_TTL_MS = Number(process.env.DASHBOARD_PROC_STATUS_TTL_MS) || 10000;
+
+// #4126 — Cache TTL del walk de eta-markers. Es una agregación histórica
+// (lstat sobre ~todos los `procesado/`) que cambia lento; recomputarla en cada
+// tick (cada 3s) era trabajo de FS caro e innecesario.
+let _etaAveragesCache = null;
+let _etaAveragesCacheAt = 0;
+const ETA_AVERAGES_TTL_MS = Number(process.env.DASHBOARD_ETA_TTL_MS) || 30000;
 
 // #3492 — Cache de la ETA agregada por ola actual. El cálculo es async (depende
 // de streaming de metrics-history.jsonl + markers FS) pero el `state` se construye
@@ -697,6 +723,13 @@ function _schedulePrInfoRefresh(doneIssues) {
 }
 
 function getCachedPipelineState() {
+  // #4126 — preferir SIEMPRE el snapshot que el worker ya computó en background
+  // (no bloquea: está armado). Esto saca el escaneo pesado del path de render de
+  // `/` (legacy), SSE y dashRoutes, que antes llamaban getPipelineState() sync.
+  // Solo en cold start (el worker todavía no pobló _stateSnapshot) caemos a un
+  // cómputo sync acotado por el TTL para no romper vistas que necesitan estado
+  // inmediato.
+  if (_stateSnapshot) return _stateSnapshot;
   const now = Date.now();
   if (_stateCache && (now - _stateCacheAt) < STATE_CACHE_TTL_MS) return _stateCache;
   _stateCache = getPipelineState();
@@ -704,30 +737,183 @@ function getCachedPipelineState() {
   return _stateCache;
 }
 
-// #4096 — Worker de refresh del snapshot de estado. Corre FUERA del request
-// (arrancado por startListen via setInterval). Cada tick computa el estado
-// pesado dentro de un setImmediate para no bloquear el tick actual del event
-// loop, y un flag inflight evita solapar cómputos cuando un escaneo tarda más
-// que el intervalo. El request de /api/state NUNCA llama a esto: lee el último
-// `_stateSnapshot` ya armado en O(1).
+// #4096 / #4126 — Worker de refresh del snapshot de estado. Corre FUERA del
+// request (arrancado por startListen via setInterval). El cómputo se trocea en
+// chunks con yields reales (`getPipelineStateAsync` cede el loop con setImmediate
+// entre chunks) para no starvar el event loop: /api/health y el resto de rutas
+// siguen respondiendo mientras el worker escanea el FS. Un flag inflight evita
+// solapar cómputos cuando un escaneo tarda más que el intervalo. El request de
+// /api/state NUNCA llama a esto: lee el último `_stateSnapshot` ya armado en O(1).
+// Swap atómico: se asigna el snapshot nuevo recién al terminar (nunca se muta
+// _stateSnapshot in-place durante el scan).
 function refreshStateSnapshot() {
   if (_stateRefreshInflight) return;   // no solapar escaneos pesados
   _stateRefreshInflight = true;
   setImmediate(() => {
-    try {
-      _stateSnapshot = getPipelineState();
-      _stateSnapshotAt = Date.now();
-    } catch (e) {
-      try { log(`state snapshot refresh error: ${e && e.message ? e.message : e}`); } catch {}
-    } finally {
-      _stateRefreshInflight = false;
-    }
+    getPipelineStateAsync()
+      .then((snap) => { _stateSnapshot = snap; _stateSnapshotAt = Date.now(); })
+      .catch((e) => { try { log(`state snapshot refresh error: ${e && e.message ? e.message : e}`); } catch {} })
+      .finally(() => { _stateRefreshInflight = false; });
   });
 }
 
+// #4126 — Refresh async (fire-and-forget, TTL) del estado de procesos + QA env.
+// Reemplaza los spawnSync(wmic)/execSync(tasklist) que vivían sincrónicos dentro
+// de getPipelineState(). El generador del snapshot solo lo agenda y lee el cache.
+function _scheduleProcStatusRefresh() {
+  const now = Date.now();
+  if (_procStatusInflight) return;
+  if (_procStatusCache && (now - _procStatusCacheAt) < PROC_STATUS_TTL_MS) return;
+  _procStatusInflight = true;
+  Promise.resolve()
+    .then(() => _computeProcStatusAsync())
+    .then((snap) => { _procStatusCache = snap; _procStatusCacheAt = Date.now(); })
+    .catch((err) => { try { log(`proc status refresh error: ${err && err.message ? err.message : err}`); } catch {} })
+    .finally(() => { _procStatusInflight = false; });
+}
+
+// tasklist async (Windows) para chequear si un PID de servicio QA sigue vivo.
+// Fuera de Windows no hay tasklist → degradamos a "no vivo" (mismo efecto que el
+// catch silencioso del código sync previo). Timeout corto + stderr ignorado para
+// que un filtro inválido nunca floodee el log.
+function _tasklistAliveAsync(n) {
+  return new Promise((resolve) => {
+    if (process.platform !== 'win32') return resolve(false);
+    try {
+      execFile('tasklist', ['/FI', `PID eq ${n}`, '/NH', '/FO', 'CSV'],
+        { encoding: 'utf8', timeout: 3000, windowsHide: true },
+        (err, stdout) => { resolve(!err && String(stdout || '').includes(`"${n}"`)); });
+    } catch { resolve(false); }
+  });
+}
+
+async function _computeProcStatusAsync() {
+  // PIDs de componentes: un único scan async del SO + matcher puro por componente.
+  let list = [];
+  try { list = await pidDiscovery.scanNodeProcessesAsync(); } catch { list = []; }
+  const procesos = {};
+  for (const comp of ['pulpo', 'listener', 'svc-telegram', 'svc-github', 'svc-drive', 'svc-reconciler', 'outbox-drain', 'dashboard']) {
+    const script = pidDiscovery.SCRIPT_MAP[comp] || `${comp}.js`;
+    const found = pidDiscovery.findPidByScriptIn(list, script);
+    if (found && pidAlive(found.pid)) {
+      procesos[comp] = { pid: String(found.pid), alive: true, uptime: getProcessUptime(comp) };
+    } else {
+      procesos[comp] = { pid: null, alive: false };
+    }
+  }
+
+  // EP8-H7 (#3960) CA-1 — registrar el flanco vivo↔muerto por componente. Se
+  // movió acá desde getPipelineState() para que la persistencia/lectura del log
+  // de transiciones tampoco viva en el path sync del snapshot.
+  if (processTransitions) {
+    try { processTransitions.recordSnapshot(procesos, { pipelineDir: PIPELINE }); }
+    catch { /* best-effort: el store de transiciones no debe romper el state */ }
+  }
+
+  // QA env: tasklist async por PID de servicio QA registrado.
+  const qaEnv = { emulator: false };
+  try {
+    const qaState = JSON.parse(fs.readFileSync(path.join(PIPELINE, 'qa-env-state.json'), 'utf8'));
+    // PID máximo válido en Windows (rango DWORD). Claves de metadata (timestamps)
+    // superan este rango y dispararían "filtro inválido" → se filtran.
+    const MAX_PID = 0xFFFFFFFF;
+    const checks = [];
+    for (const [svc, pid] of Object.entries(qaState)) {
+      const n = Number(pid);
+      if (!Number.isInteger(n) || n <= 0 || n > MAX_PID) continue;
+      checks.push(_tasklistAliveAsync(n).then((alive) => { qaEnv[svc] = alive; }).catch(() => {}));
+    }
+    await Promise.all(checks);
+  } catch {}
+
+  return { procesos, qaEnv };
+}
+
+// #4126 — etaAverages cacheado con TTL. collectMarkers hace un lstat-walk de
+// todos los `procesado/` (caro y de cambio lento). El fallback inline se usa solo
+// si la lib no cargó.
+function _getEtaAveragesCached(allFases) {
+  const now = Date.now();
+  if (_etaAveragesCache && (now - _etaAveragesCacheAt) < ETA_AVERAGES_TTL_MS) return _etaAveragesCache;
+  let result = {};
+  if (etaMarkersLib) {
+    try {
+      const markers = etaMarkersLib.collectMarkers({ root: PIPELINE, allFases, includeRejection: false });
+      result = markers.perFaseSkill || {};
+    } catch { result = {}; }
+  } else {
+    result = _computeEtaAveragesFallback(allFases);
+  }
+  _etaAveragesCache = result;
+  _etaAveragesCacheAt = now;
+  return result;
+}
+
+// Fallback histórico inline (idéntico al previo) por si el extracto a
+// `eta-markers.js` no está disponible. Mantiene vivo el dashboard.
+function _computeEtaAveragesFallback(allFases) {
+  const out = {};
+  for (const { pipeline: pName, fase } of allFases) {
+    const procesadoDir = path.join(PIPELINE, pName, fase, 'procesado');
+    const listoDir = path.join(PIPELINE, pName, fase, 'listo');
+    for (const dir of [procesadoDir, listoDir]) {
+      for (const f of listWorkFiles(dir)) {
+        const skill = f.split('.').slice(1).join('.');
+        const st = fileStat(path.join(dir, f));
+        if (!st) continue;
+        const dur = st.ctimeMs - st.birthtimeMs;
+        if (dur <= 5000 || dur > 4 * 3600000) continue;
+        const key = `${fase}/${skill}`;
+        if (!out[key]) out[key] = { total: 0, count: 0 };
+        out[key].total += dur;
+        out[key].count++;
+      }
+    }
+  }
+  for (const [key, data] of Object.entries(out)) {
+    data.avgMs = Math.round(data.total / data.count);
+    const fase = key.split('/')[0];
+    if (!out[fase]) out[fase] = { total: 0, count: 0 };
+    out[fase].total += data.total;
+    out[fase].count += data.count;
+  }
+  for (const [key, data] of Object.entries(out)) {
+    if (!key.includes('/')) data.avgMs = Math.round(data.total / data.count);
+  }
+  return out;
+}
+
+// #4126 — Driver SÍNCRONO del generador: corre el builder a fondo ignorando los
+// yields. Lo usan los callers legacy (cold start, getMetricsData, tests). Bloquea
+// igual que antes, pero esos callers NO están en el path del smoke (/api/health).
 function getPipelineState() {
+  const g = _genPipelineState();
+  let r = g.next();
+  while (!r.done) r = g.next();
+  return r.value;
+}
+
+// #4126 — Driver ASÍNCRONO: cede el event loop (setImmediate) en cada yield del
+// generador, de modo que el HTTP server atiende /api/health y otras rutas entre
+// chunks. Lo usa el worker de snapshot.
+async function getPipelineStateAsync() {
+  const g = _genPipelineState();
+  let r = g.next();
+  while (!r.done) {
+    await new Promise((resolve) => setImmediate(resolve));
+    r = g.next();
+  }
+  return r.value;
+}
+
+// #4126 — Generador del snapshot. Un único cuerpo (fuente de verdad) que cede
+// el event loop con `yield` en los loops pesados del FS. Lo manejan dos drivers:
+// getPipelineState() (sync, corre a fondo) y getPipelineStateAsync() (cede el
+// loop con setImmediate en cada yield). Así el worker no starva /api/health.
+function* _genPipelineState() {
   const config = loadConfig();
   const state = { config };
+  let _scanCount = 0;   // contador de archivos para trocear el scan en chunks
 
   // Todas las fases de ambos pipelines en orden
   const allFases = [];
@@ -814,6 +1000,11 @@ function getPipelineState() {
             state.issueMatrix[issue].estadoActual = estado;
           }
         }
+
+        // #4126 — yield cada STATE_SCAN_CHUNK archivos: en el driver async esto
+        // cede el event loop (setImmediate) y deja respirar a /api/health; en el
+        // driver sync es un no-op.
+        if ((++_scanCount % STATE_SCAN_CHUNK) === 0) yield;
       }
     }
   }
@@ -920,57 +1111,30 @@ function getPipelineState() {
     } catch { /* defensivo */ }
   }
 
-  // ETA: calcular promedios históricos por skill+fase desde archivos procesados.
-  // Usa ctime (movido a procesado) - birthtime (creación) como proxy de duración.
-  //
-  // #3517 — el walk + filtros + agregación viven ahora en `lib/eta-markers.js`;
-  // este builder solo expone la vista `perFaseSkill` como `state.etaAverages`.
-  // El shape, las keys (`${fase}/${skill}` finegrain + `${fase}` coarse) y los
-  // valores `{ total, count, avgMs }` son byte-a-byte iguales al inline previo.
-  // Si el módulo no está disponible (best-effort require falló), caemos al
-  // inline histórico para no degradar el dashboard en ningún caso.
-  state.etaAverages = {};
-  if (etaMarkersLib) {
+  // ETA: promedios históricos por skill+fase desde archivos procesados.
+  // #3517 — el walk + filtros + agregación viven en `lib/eta-markers.js`.
+  // #4126 — doble defensa contra el bloqueo del event loop:
+  //   1) cache TTL (`_etaAveragesCache`): el walk es un lstat sobre todos los
+  //      `procesado/`, caro y de cambio lento; no se recomputa en cada tick.
+  //   2) cuando SÍ recomputa, lo hace con `collectMarkersChunked` vía `yield*`:
+  //      cede el event loop cada ~250 archivos (en el driver async). El shape
+  //      (`${fase}/${skill}` + `${fase}` coarse, `{ total, count, avgMs }`) es
+  //      idéntico al de `collectMarkers`.
+  yield;
+  const _nowEta = Date.now();
+  if (_etaAveragesCache && (_nowEta - _etaAveragesCacheAt) < ETA_AVERAGES_TTL_MS) {
+    state.etaAverages = _etaAveragesCache;
+  } else if (etaMarkersLib && typeof etaMarkersLib.collectMarkersChunked === 'function') {
+    let markers = null;
     try {
-      const markers = etaMarkersLib.collectMarkers({
-        root: PIPELINE,
-        allFases,
-        includeRejection: false,
-      });
-      state.etaAverages = markers.perFaseSkill || {};
-    } catch {
-      state.etaAverages = {};
-    }
+      markers = yield* etaMarkersLib.collectMarkersChunked({ root: PIPELINE, allFases, includeRejection: false });
+    } catch { markers = null; }
+    state.etaAverages = (markers && markers.perFaseSkill) || {};
+    _etaAveragesCache = state.etaAverages;
+    _etaAveragesCacheAt = _nowEta;
   } else {
-    // Fallback: inline histórico (mantener vivo el dashboard si el extracto
-    // a `eta-markers.js` falla por cualquier motivo). Idéntico al previo.
-    for (const { pipeline: pName, fase } of allFases) {
-      const procesadoDir = path.join(PIPELINE, pName, fase, 'procesado');
-      const listoDir = path.join(PIPELINE, pName, fase, 'listo');
-      for (const dir of [procesadoDir, listoDir]) {
-        for (const f of listWorkFiles(dir)) {
-          const skill = f.split('.').slice(1).join('.');
-          const st = fileStat(path.join(dir, f));
-          if (!st) continue;
-          const dur = st.ctimeMs - st.birthtimeMs;
-          if (dur <= 5000 || dur > 4 * 3600000) continue;
-          const key = `${fase}/${skill}`;
-          if (!state.etaAverages[key]) state.etaAverages[key] = { total: 0, count: 0 };
-          state.etaAverages[key].total += dur;
-          state.etaAverages[key].count++;
-        }
-      }
-    }
-    for (const [key, data] of Object.entries(state.etaAverages)) {
-      data.avgMs = Math.round(data.total / data.count);
-      const fase = key.split('/')[0];
-      if (!state.etaAverages[fase]) state.etaAverages[fase] = { total: 0, count: 0 };
-      state.etaAverages[fase].total += data.total;
-      state.etaAverages[fase].count += data.count;
-    }
-    for (const [key, data] of Object.entries(state.etaAverages)) {
-      if (!key.includes('/')) data.avgMs = Math.round(data.total / data.count);
-    }
+    // Fallback sin lib (pipeline antiguo): TTL + cómputo inline.
+    state.etaAverages = _getEtaAveragesCached(allFases);
   }
 
   // V3 — Bloqueados esperando humano (issue #2478)
@@ -1071,48 +1235,21 @@ function getPipelineState() {
     }
   } catch {}
 
-  // Procesos — descubiertos al vuelo desde el SO, no desde archivos .pid.
-  state.procesos = {};
-  invalidateCache();
-  for (const comp of ['pulpo', 'listener', 'svc-telegram', 'svc-github', 'svc-drive', 'svc-reconciler', 'outbox-drain', 'dashboard']) {
-    const found = findPidByComponent(comp);
-    if (found && pidAlive(found.pid)) {
-      const uptime = getProcessUptime(comp);
-      state.procesos[comp] = { pid: String(found.pid), alive: true, uptime };
-    } else {
-      state.procesos[comp] = { pid: null, alive: false };
-    }
-  }
+  // Procesos + QA env — #4126: servidos desde el cache async (_procStatusCache),
+  // poblado por `_computeProcStatusAsync` con `exec`/`execFile` FUERA del tick.
+  // Antes esto hacía spawnSync(wmic) (invalidando el cache cada tick → ~15s de
+  // bloqueo posible) y execSync(tasklist) por servicio QA, clavando el event
+  // loop y colgando /api/health. El generador ahora solo agenda el refresh y
+  // lee el último valor en O(1). En cold start (cache aún null) degrada a vacío;
+  // el próximo tick ya trae datos. El registro de transiciones de proceso
+  // (#3960) también vive ahora en el refresh async.
+  _scheduleProcStatusRefresh();
+  const _ps = _procStatusCache || { procesos: {}, qaEnv: { emulator: false } };
+  state.procesos = _ps.procesos || {};
+  state.qaEnv = { emulator: false, ...(_ps.qaEnv || {}) };
 
-  // EP8-H7 (#3960) CA-1 — registrar el flanco vivo↔muerto por componente contra
-  // el snapshot previo en memoria. Idempotente si no hay cambio de estado; sólo
-  // persiste y lee el log (último error, redactado) cuando hay una transición.
-  if (processTransitions) {
-    try { processTransitions.recordSnapshot(state.procesos, { pipelineDir: PIPELINE }); }
-    catch { /* best-effort: el store de transiciones no debe romper el state */ }
-  }
-
-  // QA Environment
-  state.qaEnv = { emulator: false };
-  state.qaRemote = { active: false, url: '', ref: '', startedAt: '' };
-  try {
-    const qaState = JSON.parse(fs.readFileSync(path.join(PIPELINE, 'qa-env-state.json'), 'utf8'));
-    // PID máximo válido en Windows (rango DWORD). Claves de metadata como
-    // `lastStartedAt` guardan timestamps que superan este rango: si se las
-    // pasa a `tasklist /FI "PID eq <n>"`, el comando responde "No se reconoce
-    // el filtro de búsqueda" y floodea el log. Por eso filtramos a PIDs reales.
-    const MAX_PID = 0xFFFFFFFF;
-    for (const [svc, pid] of Object.entries(qaState)) {
-      const n = Number(pid);
-      if (!Number.isInteger(n) || n <= 0 || n > MAX_PID) continue;
-      try {
-        // `stdio` ignora stderr para que un filtro inválido nunca floodee el log.
-        const r = execSync(`tasklist /FI "PID eq ${n}" /NH /FO CSV`, { encoding: 'utf8', timeout: 3000, windowsHide: true, stdio: ['ignore', 'pipe', 'ignore'] });
-        state.qaEnv[svc] = r.includes(`"${n}"`);
-      } catch {}
-    }
-  } catch {}
   // QA Remote state
+  state.qaRemote = { active: false, url: '', ref: '', startedAt: '' };
   try {
     const remoteStateFile = path.join(ROOT, 'qa', '.qa-remote-state');
     if (fs.existsSync(remoteStateFile)) {
@@ -1152,18 +1289,20 @@ function getPipelineState() {
     } catch {}
   }
 
-  // Rechazos recientes
+  // Rechazos recientes — #4126: derivados del `issueMatrix` ya construido (que
+  // ya leyó resultado/motivo de cada `procesado/`), en vez de re-walkear y
+  // re-parsear TODOS los YAML de procesado en cada tick. Eran ~miles de
+  // readYamlSafe extra por refresh que, junto con wmic/tasklist, starvaban el
+  // event loop. Mismo shape y mismo orden de salida (sort por ts desc + top 10).
   state.rechazos = [];
-  for (const { pipeline: pName, fase } of allFases) {
-    const procesadoDir = path.join(PIPELINE, pName, fase, 'procesado');
-    for (const f of listWorkFiles(procesadoDir)) {
-      const data = readYamlSafe(path.join(procesadoDir, f));
-      if (data.resultado === 'rechazado') {
-        const stat = fileStat(path.join(procesadoDir, f));
+  for (const [issueId, data] of Object.entries(state.issueMatrix)) {
+    for (const entries of Object.values(data.fases || {})) {
+      for (const e of entries) {
+        if (e.estado !== 'procesado' || e.resultado !== 'rechazado') continue;
         state.rechazos.push({
-          issue: f.split('.')[0], skill: f.split('.').slice(1).join('.'),
-          fase, pipeline: pName, motivo: data.motivo || '',
-          ts: stat?.mtimeMs || 0
+          issue: issueId, skill: e.skill,
+          fase: e.fase, pipeline: e.pipeline, motivo: e.motivo || '',
+          ts: e.updatedAt || 0,
         });
       }
     }
@@ -9690,7 +9829,9 @@ const server = http.createServer((req, res) => {
     res.writeHead(200, { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache', 'Connection': 'keep-alive' });
     const send = () => {
       try {
-        const state = getPipelineState();
+        // #4126 — leer el snapshot del worker (no recomputar en el path del SSE):
+        // antes este tick reescaneaba todo el FS cada 5s por cada cliente SSE.
+        const state = getCachedPipelineState();
         const hash = crypto.createHash('md5').update(JSON.stringify(state.issueMatrix)).digest('hex').slice(0, 8);
         res.write(`data: ${hash}\n\n`);
       } catch {}
@@ -11220,8 +11361,10 @@ const server = http.createServer((req, res) => {
     log(`dashboard-routes error: ${e.message}`);
   }
 
-  // HTML dashboard legacy (accesible vía /legacy o como fallback de URLs no matcheadas).
-  const state = getPipelineState();
+  // HTML dashboard legacy (accesible vía /legacy o como fallback de URLs no
+  // matcheadas). #4126 — sirve desde el snapshot del worker (no recomputa en el
+  // request) para que `/` no se cuelgue bajo el ciclo de refresh (CA-3).
+  const state = getCachedPipelineState();
   res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
   res.end(generateHTML(state));
 });

--- a/.pipeline/lib/eta-markers.js
+++ b/.pipeline/lib/eta-markers.js
@@ -180,10 +180,19 @@ function hasRejectionMarker(filePath) {
  *   totalRejected: number,
  * }}
  */
-function collectMarkers(opts) {
+// Tamaño de chunk del walk troceado (#4126). Cada N archivos el generador
+// cede al driver para que un consumidor async no bloquee el event loop.
+const COLLECT_CHUNK = 250;
+
+// Cuerpo ÚNICO del walk, expresado como generador (#4126). `collectMarkers`
+// (sync) y `collectMarkersChunked` (para `yield*` desde un generador async)
+// comparten exactamente esta lógica → cero divergencia de output. `chunkSize`
+// finito hace que ceda cada N archivos; 0/Infinity nunca cede (modo sync).
+function* _collectMarkersGen(opts, chunkSize) {
   const o = opts || {};
   const root = o.root || defaultPipelineDir();
   const includeRejection = o.includeRejection === true;
+  const chunk = (Number.isFinite(chunkSize) && chunkSize > 0) ? chunkSize : 0;
 
   // Resolver lista de (pipeline, fase) a recorrer.
   let pairs = [];
@@ -214,11 +223,16 @@ function collectMarkers(opts) {
   const perFaseSkill = {};
   let totalProcessed = 0;
   let totalRejected = 0;
+  let scanned = 0;
 
   for (const { pipeline: pName, fase } of pairs) {
     const faseDir = path.join(root, pName, fase);
     const files = listProcessedFiles(faseDir);
     for (const { dir, name } of files) {
+      // #4126 — yield troceado: contamos archivos VISTOS (antes de filtrar) para
+      // ceder de forma pareja aunque muchos se descarten.
+      if (chunk && (++scanned % chunk) === 0) yield;
+
       const fullPath = path.join(dir, name);
       const st = safeLstat(fullPath);
       if (!st) continue;
@@ -295,6 +309,24 @@ function collectMarkers(opts) {
   return { perIssue, perFase, perFaseSkill, totalProcessed, totalRejected };
 }
 
+function collectMarkers(opts) {
+  // Driver SÍNCRONO: corre el walk a fondo sin ceder (chunkSize 0). Contrato y
+  // output idénticos a la implementación previa (CA #3517).
+  const g = _collectMarkersGen(opts, 0);
+  let r = g.next();
+  while (!r.done) r = g.next();
+  return r.value;
+}
+
+// #4126 — Variante TROCEADA para consumidores async. Devuelve el generador para
+// usar con `yield*` desde otro generador (p.ej. el builder del snapshot del
+// dashboard): cada ~COLLECT_CHUNK archivos cede el event loop, evitando que el
+// lstat-walk de miles de `procesado/` starve /api/health. El valor de retorno
+// del `yield*` es el mismo objeto que devuelve `collectMarkers`.
+function collectMarkersChunked(opts) {
+  return _collectMarkersGen(opts, COLLECT_CHUNK);
+}
+
 // ─── fmtAbsoluteHHMM — re-uso del helper desde eta.js (#2895) ─────────────
 
 /**
@@ -316,6 +348,7 @@ function fmtAbsoluteHHMM(epochMs) {
 module.exports = {
   // API pública
   collectMarkers,
+  collectMarkersChunked,
   listProcessedFiles,
   fmtAbsoluteHHMM,
   // Constantes

--- a/.pipeline/pid-discovery.js
+++ b/.pipeline/pid-discovery.js
@@ -14,7 +14,7 @@
 //   invalidateCache()         → fuerza refresh del próximo scan
 //   SCRIPT_MAP                → mapa nombre → scriptfile
 
-const { spawnSync } = require('child_process');
+const { spawnSync, exec } = require('child_process');
 
 const SCRIPT_MAP = {
   'pulpo': 'pulpo.js',
@@ -32,50 +32,62 @@ const CACHE_TTL_MS = 2000;
 let _scanCache = null;
 let _scanCacheAt = 0;
 
+// Comando del scan de procesos node por plataforma. Extraído para que el
+// scan SÍNCRONO (spawnSync) y el ASÍNCRONO (exec) compartan exactamente el
+// mismo comando + parser, evitando divergencias.
+// Sin WHERE en wmic: con shell, cmd.exe /c quita las comillas externas y el
+// filtro "name='node.exe'" llega sin comillas → "No se reconoce el filtro de
+// búsqueda" en loop. Solución: traer todos y filtrar Name=node.exe en JS.
+const _WMIC_CMD = 'wmic process get Name,ProcessId,CommandLine,CreationDate /format:csv';
+
+function _parseWmicCsv(stdout) {
+  const processes = [];
+  const lines = (stdout || '').split('\n');
+  for (const line of lines) {
+    const t = line.trim();
+    if (!t || !t.includes(',')) continue;
+    // header: Node,CommandLine,CreationDate,Name,ProcessId
+    if (/^Node,/i.test(t)) continue;
+    const parts = t.split(',');
+    if (parts.length < 5) continue;
+    const pid = parseInt(parts[parts.length - 1], 10);
+    if (!pid || Number.isNaN(pid)) continue;
+    const name = (parts[parts.length - 2] || '').trim();
+    if (name.toLowerCase() !== 'node.exe') continue;
+    const creationDate = parts[parts.length - 3] || '';
+    const commandLine = parts.slice(1, -3).join(',');
+    processes.push({ pid, commandLine, creationDate });
+  }
+  return processes;
+}
+
+function _parsePsOutput(stdout) {
+  const processes = [];
+  const lines = (stdout || '').split('\n').slice(1);
+  for (const line of lines) {
+    const m = line.match(/^\s*(\d+)\s+(.{24})\s+(.+)$/);
+    if (!m) continue;
+    const cmd = m[3];
+    if (!cmd.includes('node')) continue;
+    processes.push({ pid: parseInt(m[1], 10), commandLine: cmd, creationDate: m[2] });
+  }
+  return processes;
+}
+
 function scanNodeProcesses() {
   const now = Date.now();
   if (_scanCache && (now - _scanCacheAt) < CACHE_TTL_MS) return _scanCache;
 
-  const processes = [];
+  let processes = [];
   if (process.platform === 'win32') {
     try {
-      // Sin WHERE. Cuando el comando se pasa con shell:true, Node lanza
-      // cmd.exe /d /s /c "<cmd>"; cmd.exe /c quita las comillas externas y
-      // el filtro "name='node.exe'" llega a wmic sin comillas (name=node.exe),
-      // disparando "No se reconoce el filtro de búsqueda" en loop.
-      // Solución: traer todos los procesos y filtrar Name=node.exe en JS.
-      const r = spawnSync(
-        'wmic process get Name,ProcessId,CommandLine,CreationDate /format:csv',
-        { encoding: 'utf8', timeout: 15000, windowsHide: true, shell: true }
-      );
-      const lines = (r.stdout || '').split('\n');
-      for (const line of lines) {
-        const t = line.trim();
-        if (!t || !t.includes(',')) continue;
-        // header: Node,CommandLine,CreationDate,Name,ProcessId
-        if (/^Node,/i.test(t)) continue;
-        const parts = t.split(',');
-        if (parts.length < 5) continue;
-        const pid = parseInt(parts[parts.length - 1], 10);
-        if (!pid || Number.isNaN(pid)) continue;
-        const name = (parts[parts.length - 2] || '').trim();
-        if (name.toLowerCase() !== 'node.exe') continue;
-        const creationDate = parts[parts.length - 3] || '';
-        const commandLine = parts.slice(1, -3).join(',');
-        processes.push({ pid, commandLine, creationDate });
-      }
+      const r = spawnSync(_WMIC_CMD, { encoding: 'utf8', timeout: 15000, windowsHide: true, shell: true });
+      processes = _parseWmicCsv(r.stdout);
     } catch {}
   } else {
     try {
       const r = spawnSync('ps', ['-eo', 'pid,lstart,command'], { encoding: 'utf8', timeout: 5000 });
-      const lines = (r.stdout || '').split('\n').slice(1);
-      for (const line of lines) {
-        const m = line.match(/^\s*(\d+)\s+(.{24})\s+(.+)$/);
-        if (!m) continue;
-        const cmd = m[3];
-        if (!cmd.includes('node')) continue;
-        processes.push({ pid: parseInt(m[1], 10), commandLine: cmd, creationDate: m[2] });
-      }
+      processes = _parsePsOutput(r.stdout);
     } catch {}
   }
 
@@ -84,9 +96,45 @@ function scanNodeProcesses() {
   return processes;
 }
 
+// Variante ASÍNCRONA del scan (#4126). Idéntica salida que scanNodeProcesses()
+// pero usando `exec` para NO bloquear el event loop: spawnSync(wmic) podía
+// clavar el loop hasta 15s y starvar el smoke (/api/health) del restart. El
+// dashboard la consume desde un refresh en background con TTL; el resto del
+// pipeline puede seguir usando la versión sync. Comparte `_scanCache`, así que
+// cualquier llamada sync posterior dentro del TTL reusa el resultado caliente.
+function scanNodeProcessesAsync() {
+  return new Promise((resolve) => {
+    const now = Date.now();
+    if (_scanCache && (now - _scanCacheAt) < CACHE_TTL_MS) return resolve(_scanCache);
+
+    const onDone = (stdout, parser) => {
+      let processes = [];
+      try { processes = parser(stdout); } catch { processes = []; }
+      _scanCache = processes;
+      _scanCacheAt = Date.now();
+      resolve(processes);
+    };
+
+    if (process.platform === 'win32') {
+      exec(_WMIC_CMD, { encoding: 'utf8', timeout: 15000, windowsHide: true },
+        (err, stdout) => onDone(err ? '' : stdout, _parseWmicCsv));
+    } else {
+      exec('ps -eo pid,lstart,command', { encoding: 'utf8', timeout: 5000 },
+        (err, stdout) => onDone(err ? '' : stdout, _parsePsOutput));
+    }
+  });
+}
+
 function findPidByScript(scriptName) {
-  for (const p of scanNodeProcesses()) {
-    if (p.commandLine && p.commandLine.includes(scriptName)) return p;
+  return findPidByScriptIn(scanNodeProcesses(), scriptName);
+}
+
+// Matcher PURO (sin syscalls) sobre una lista ya obtenida. Permite que un
+// consumidor que ya escaneó async (scanNodeProcessesAsync) resuelva varios
+// componentes sin re-spawnear nada. (#4126)
+function findPidByScriptIn(list, scriptName) {
+  for (const p of (Array.isArray(list) ? list : [])) {
+    if (p && p.commandLine && p.commandLine.includes(scriptName)) return p;
   }
   return null;
 }
@@ -133,7 +181,9 @@ function invalidateCache() {
 module.exports = {
   SCRIPT_MAP,
   scanNodeProcesses,
+  scanNodeProcessesAsync,
   findPidByScript,
+  findPidByScriptIn,
   findPidByComponent,
   findPidByPort,
   pidAlive,

--- a/.pipeline/tests/dashboard-health-under-load-4126.test.js
+++ b/.pipeline/tests/dashboard-health-under-load-4126.test.js
@@ -1,0 +1,185 @@
+'use strict';
+
+// =============================================================================
+// dashboard-health-under-load-4126.test.js — regresión #4126.
+//
+// Contexto: el worker de snapshot (refreshStateSnapshot → getPipelineState)
+// escaneaba TODO el FS del pipeline de forma SÍNCRONA y, peor, spawneaba
+// `wmic` (PIDs) con spawnSync invalidando su cache en cada tick (hasta 15s de
+// bloqueo) + `tasklist` por servicio QA. Con la cola grande, ese bloque
+// monolítico clavaba el event loop por segundos: /api/health no respondía, el
+// smoke (paso 2) del restart lo leía como caída y disparaba rollback en LOOP.
+//
+// El fix:
+//   - Procesos/QA → `exec`/`execFile` async, cacheados con TTL, FUERA del tick.
+//   - El builder es un generador con yields reales; el worker lo maneja con un
+//     driver async que cede el event loop (setImmediate) en cada chunk.
+//
+// Este test levanta el dashboard real contra un pipeline PESADO (miles de
+// markers en `procesado/`) y con el worker casi-siempre-activo
+// (DASHBOARD_STATE_REFRESH_MS chico), y verifica el CA central:
+//
+//   GET /api/health responde < 500ms incluso mientras el worker computa el
+//   snapshot, y /api/state se sirve sin colgarse.
+// =============================================================================
+
+const { test, before, after } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const http = require('http');
+const { spawn } = require('child_process');
+
+const PIPELINE_SRC = path.resolve(__dirname, '..');
+const dashboardPath = path.join(PIPELINE_SRC, 'dashboard.js');
+
+// Escala del pipeline sintético. Suficiente para que un escaneo SÍNCRONO sin
+// yields supere holgadamente los 500ms (en HEAD reproducía el cuelgue), pero
+// acotado para que el `before()` no tarde demasiado.
+const TOTAL_MARKERS = 6000;
+const HEALTH_BUDGET_MS = 500;
+const HAMMER_MS = 3000;
+
+let tmpDir, child, port;
+
+function mkdirp(p) { fs.mkdirSync(p, { recursive: true }); }
+
+function getJson(p, urlPath, timeoutMs, cb) {
+  const req = http.get({ host: '127.0.0.1', port: p, path: urlPath, timeout: timeoutMs }, (res) => {
+    let data = '';
+    res.on('data', (c) => { data += c; });
+    res.on('end', () => cb(null, { status: res.statusCode, body: data }));
+  });
+  req.on('error', cb);
+  req.on('timeout', function () { this.destroy(); cb(new Error('timeout')); });
+}
+
+function timedHealth(p) {
+  return new Promise((resolve) => {
+    const t0 = Date.now();
+    // Damos margen alto al timeout HTTP (2s) para MEDIR la latencia real: si el
+    // loop está starvado, queremos ver 1500ms, no un corte temprano.
+    getJson(p, '/api/health', 2000, (err, r) => {
+      const elapsed = Date.now() - t0;
+      resolve({ elapsed, ok: !err && r && r.status === 200, err: err && err.message });
+    });
+  });
+}
+
+before(async () => {
+  const yaml = require('js-yaml');
+  const config = yaml.load(fs.readFileSync(path.join(PIPELINE_SRC, 'config.yaml'), 'utf8'));
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dash4126-'));
+
+  // Estructura de fases/estados.
+  const faseDirs = [];
+  for (const [pname, pcfg] of Object.entries(config.pipelines)) {
+    for (const fase of pcfg.fases) {
+      for (const st of ['pendiente', 'trabajando', 'listo', 'procesado']) {
+        mkdirp(path.join(tmpDir, pname, fase, st));
+      }
+      faseDirs.push({ pname, fase });
+    }
+  }
+  mkdirp(path.join(tmpDir, 'logs'));
+  fs.copyFileSync(path.join(PIPELINE_SRC, 'config.yaml'), path.join(tmpDir, 'config.yaml'));
+
+  // Poblar `procesado/` con muchos markers (round-robin sobre las fases) +
+  // pre-poblar el cache de títulos para que el worker NO dispare gh (aislamos el
+  // costo del escaneo del FS, que es lo que el fix trocea).
+  const skills = ['dev', 'verificacion', 'build', 'qa', 'review'];
+  const titleCache = {};
+  const now = Date.now();
+  for (let i = 0; i < TOTAL_MARKERS; i++) {
+    const issue = 200000 + i;
+    const skill = skills[i % skills.length];
+    const { pname, fase } = faseDirs[i % faseDirs.length];
+    const file = path.join(tmpDir, pname, fase, 'procesado', `${issue}.${skill}`);
+    const resultado = (i % 7 === 0) ? 'rechazado' : 'aprobado';
+    fs.writeFileSync(file,
+      `issue: ${issue}\nfase: ${fase}\npipeline: ${pname}\nresultado: ${resultado}\nmotivo: "marker sintético #4126"\n`);
+    titleCache[String(issue)] = { title: `synthetic ${issue}`, state: 'OPEN', labels: [], fetchedAt: now };
+  }
+  fs.writeFileSync(path.join(tmpDir, '.issue-title-cache.json'), JSON.stringify(titleCache));
+
+  port = 3700 + Math.floor((Date.now() % 200));
+  child = spawn(process.execPath, [dashboardPath], {
+    env: {
+      ...process.env,
+      PIPELINE_STATE_DIR: tmpDir,
+      PIPELINE_DIR_OVERRIDE: tmpDir,
+      DASHBOARD_PORT: String(port),
+      DASHBOARD_HOST: '127.0.0.1',
+      GH_BIN: 'gh-noop-nonexistent',
+      // Worker casi-siempre-activo: refresca apenas termina un ciclo, de modo que
+      // los GET /api/health del hammer caen mientras el snapshot se está computando.
+      DASHBOARD_STATE_REFRESH_MS: '30',
+      DASHBOARD_PROC_STATUS_TTL_MS: '50',
+      DASHBOARD_ETA_TTL_MS: '50',
+    },
+    stdio: 'ignore',
+  });
+
+  // Esperar a que /api/health levante.
+  await new Promise((resolve, reject) => {
+    let tries = 0;
+    const tick = () => {
+      getJson(port, '/api/health', 5000, (err, r) => {
+        if (!err && r && r.status === 200) return resolve();
+        if (++tries > 60) return reject(new Error('dashboard no levantó: ' + (err && err.message)));
+        setTimeout(tick, 250);
+      });
+    };
+    setTimeout(tick, 500);
+  });
+});
+
+after(() => {
+  if (child) { try { child.kill(); } catch {} }
+  if (tmpDir) { try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch {} }
+});
+
+test('CA-1/CA-4 — /api/health responde < 500ms mientras el worker computa el snapshot', async () => {
+  // Dar un primer ciclo de refresh para garantizar que el worker está activo
+  // y, sobre un pipeline de miles de markers, en pleno escaneo.
+  await new Promise((r) => setTimeout(r, 300));
+
+  const samples = [];
+  const tEnd = Date.now() + HAMMER_MS;
+  while (Date.now() < tEnd) {
+    samples.push(await timedHealth(port));
+  }
+
+  assert.ok(samples.length >= 20, `se esperaban muchas muestras de health, hubo ${samples.length}`);
+
+  const failures = samples.filter((s) => !s.ok);
+  assert.deepStrictEqual(
+    failures, [],
+    `/api/health falló/expiró en ${failures.length}/${samples.length} muestras: ${JSON.stringify(failures.slice(0, 3))}`,
+  );
+
+  const max = Math.max(...samples.map((s) => s.elapsed));
+  const slow = samples.filter((s) => s.elapsed >= HEALTH_BUDGET_MS);
+  assert.deepStrictEqual(
+    slow.map((s) => s.elapsed), [],
+    `REGRESIÓN #4126: /api/health superó ${HEALTH_BUDGET_MS}ms mientras el worker computaba ` +
+    `(max=${max}ms, lentas=${slow.length}/${samples.length}). El event loop se starvó: ` +
+    `el snapshot volvió a un escaneo síncrono monolítico o reintrodujo wmic/tasklist sync.`,
+  );
+});
+
+test('CA-3 — /api/state se sirve (200 + JSON) sin colgarse bajo el ciclo de refresh', async () => {
+  const t0 = Date.now();
+  const r = await new Promise((res, rej) => getJson(port, '/api/state', 5000, (e, x) => e ? rej(e) : res(x)));
+  const elapsed = Date.now() - t0;
+  assert.strictEqual(r.status, 200, 'HTTP 200');
+  const json = JSON.parse(r.body); // no debe tirar
+  assert.ok(json && typeof json === 'object', 'JSON objeto');
+  // Una vez poblado el snapshot, /api/state es O(1).
+  assert.ok(elapsed < 1000, `/api/state debe servirse rápido desde el snapshot, tardó ${elapsed}ms`);
+  // El worker efectivamente escaneó el pipeline pesado (issueMatrix poblado).
+  if (json.issueMatrix) {
+    assert.ok(Object.keys(json.issueMatrix).length > 1000, 'el snapshot debe reflejar el pipeline pesado escaneado');
+  }
+});

--- a/.pipeline/tests/dashboard-health-under-load-4126.test.js
+++ b/.pipeline/tests/dashboard-health-under-load-4126.test.js
@@ -40,6 +40,15 @@ const dashboardPath = path.join(PIPELINE_SRC, 'dashboard.js');
 const TOTAL_MARKERS = 6000;
 const HEALTH_BUDGET_MS = 500;
 const HAMMER_MS = 3000;
+// Piso de muestras a recolectar antes de evaluar la latencia. NO se deriva del
+// wall-clock: el tester corre las 355 suites Node en UN proceso, así que el
+// proceso padre que mide (este test) está saturado y recoge menos muestras por
+// segundo. Atar la cantidad esperada a HAMMER_MS hacía el test flaky (hubo 12
+// muestras healthy <500ms en 3s y el `>= 20` rebotaba). Martillamos hasta
+// juntar MIN_SAMPLES con un cap duro; la regresión real (loop starvado) la
+// detectan las aserciones de fallos/latencia, no la cantidad.
+const MIN_SAMPLES = 12;
+const HAMMER_HARD_CAP_MS = 20000;
 
 let tmpDir, child, port;
 
@@ -145,13 +154,27 @@ test('CA-1/CA-4 — /api/health responde < 500ms mientras el worker computa el s
   // y, sobre un pipeline de miles de markers, en pleno escaneo.
   await new Promise((r) => setTimeout(r, 300));
 
+  // Martillar al menos HAMMER_MS (para cruzar varios ciclos del worker) y, además,
+  // hasta juntar MIN_SAMPLES. Bajo carga del tester el padre recoge pocas muestras
+  // por segundo, así que extendemos el martilleo en vez de exigir un ritmo fijo.
+  // Cap duro para no colgar si el loop está realmente starvado: en ese caso cada
+  // `timedHealth` tarda ~2s (su timeout HTTP) y las aserciones de abajo lo marcan
+  // como regresión.
   const samples = [];
-  const tEnd = Date.now() + HAMMER_MS;
-  while (Date.now() < tEnd) {
+  const tStart = Date.now();
+  while (
+    (Date.now() - tStart < HAMMER_MS || samples.length < MIN_SAMPLES) &&
+    Date.now() - tStart < HAMMER_HARD_CAP_MS
+  ) {
     samples.push(await timedHealth(port));
   }
 
-  assert.ok(samples.length >= 20, `se esperaban muchas muestras de health, hubo ${samples.length}`);
+  assert.ok(
+    samples.length >= MIN_SAMPLES,
+    `se esperaban al menos ${MIN_SAMPLES} muestras de health en ${HAMMER_HARD_CAP_MS}ms, hubo ${samples.length}: ` +
+    `el event loop del dashboard está starvado (cada request demora ~su timeout). ` +
+    `Muestras lentas/fallidas: ${JSON.stringify(samples.filter((s) => !s.ok || s.elapsed >= HEALTH_BUDGET_MS).slice(0, 3))}`,
+  );
 
   const failures = samples.filter((s) => !s.ok);
   assert.deepStrictEqual(

--- a/.pipeline/tests/dashboard-state-hotpath.test.js
+++ b/.pipeline/tests/dashboard-state-hotpath.test.js
@@ -84,7 +84,52 @@ test('refreshStateSnapshot usa setImmediate + flag inflight (no bloquea el tick)
   const body = src.slice(start, start + 800);
   assert.match(body, /_stateRefreshInflight/, 'debe usar el flag inflight para no solapar');
   assert.match(body, /setImmediate\(/, 'debe sacar el cómputo pesado del tick con setImmediate');
-  assert.match(body, /_stateSnapshot\s*=\s*getPipelineState\(\)/, 'el worker (no el request) computa el estado');
+  // #4126 — el worker computa el snapshot con el driver ASÍNCRONO chunked
+  // (getPipelineStateAsync cede el loop entre chunks). NUNCA con getPipelineState()
+  // sync a fondo: ese bloque monolítico starvaba /api/health y disparaba el
+  // rollback en loop del restart.
+  assert.match(body, /getPipelineStateAsync\(\)/, 'el worker usa el driver async-chunked (no el sync a fondo)');
+  assert.match(body, /_stateSnapshot\s*=\s*snap/, 'swap atómico del snapshot recién al terminar el cómputo');
+});
+
+// #4126 — GUARDRAIL: el snapshot se construye con un generador con yields reales
+// y dos drivers (sync para legacy, async-chunked para el worker). Congelar esta
+// estructura evita que una ola futura vuelva a un escaneo síncrono monolítico.
+test('GUARDRAIL #4126 — getPipelineState se construye con generador + driver async-chunked', () => {
+  assert.match(src, /function\*\s*_genPipelineState\s*\(/, 'debe existir el generador _genPipelineState');
+  // El driver async cede el event loop con setImmediate en cada yield.
+  const asyncStart = src.indexOf('async function getPipelineStateAsync()');
+  assert.ok(asyncStart > 0, 'getPipelineStateAsync debe existir');
+  const asyncBody = src.slice(asyncStart, asyncStart + 400);
+  assert.match(asyncBody, /setImmediate/, 'el driver async debe ceder el loop entre chunks');
+  assert.match(asyncBody, /\.next\(\)/, 'el driver async debe pumpear el generador');
+  // El driver sync corre el generador a fondo (legacy callers).
+  assert.match(src, /function getPipelineState\(\)\s*\{[\s\S]*?_genPipelineState\(\)/, 'getPipelineState (sync) maneja el mismo generador');
+});
+
+// #4126 — GUARDRAIL: los scans del SO (wmic/tasklist) NO pueden vivir síncronos
+// dentro del generador del snapshot — eran el bloqueo principal del event loop.
+test('GUARDRAIL #4126 — el generador del snapshot no spawnea wmic/tasklist sync', () => {
+  const genStart = src.indexOf('function* _genPipelineState()');
+  assert.ok(genStart > 0, 'el generador debe existir');
+  // Acotar al cuerpo del generador: hasta la próxima función top-level que le
+  // sigue (readGhostArtifactSummary). Los drivers sync/async están definidos
+  // ANTES del generador, así que no sirven como cota inferior.
+  const genEnd = src.indexOf('\nfunction readGhostArtifactSummary', genStart);
+  assert.ok(genEnd > genStart, 'el cierre del generador debe ubicarse');
+  const genBody = src.slice(genStart, genEnd);
+  // Stripear comentarios (de línea y de bloque) para chequear CÓDIGO real: los
+  // comentarios documentan justamente lo que se sacó (execSync(tasklist), etc.).
+  const genCode = genBody
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+  assert.doesNotMatch(genCode, /execSync\s*\(/, 'REGRESIÓN #4126: execSync sync dentro del snapshot bloquea el loop');
+  assert.doesNotMatch(genCode, /spawnSync\s*\(/, 'REGRESIÓN #4126: spawnSync sync dentro del snapshot bloquea el loop');
+  assert.doesNotMatch(genCode, /tasklist/, 'REGRESIÓN #4126: tasklist debe resolverse async (cache), no en el snapshot');
+  assert.doesNotMatch(genCode, /invalidateCache\s*\(\)/, 'REGRESIÓN #4126: invalidar el cache de PIDs forzaba un wmic fresco por tick');
+  // Procesos + QA env se sirven desde el cache async.
+  assert.match(genCode, /_scheduleProcStatusRefresh\s*\(\)/, 'procesos/QA se agendan async');
+  assert.match(genCode, /_procStatusCache/, 'procesos/QA se leen del cache async');
 });
 
 test('startListen arranca el worker de snapshot (refresh + setInterval unref)', () => {


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 5 archivos · +636 -157

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:skipped` aplicado por delivery

## Closes

Closes #4126
