### PR TITLE
fix(dashboard): resolver títulos de issues async fuera del event loop — corta el rollback en loop del restart (#4126)

### DIFF
--- a/.pipeline/dashboard.js
+++ b/.pipeline/dashboard.js
@@ -18,7 +18,7 @@ const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
-const { execSync, execFile, spawn, spawnSync } = require('child_process');
+const { exec, execSync, execFile, spawn, spawnSync } = require('child_process');
 const yaml = require('js-yaml');
 const pidDiscovery = require('./pid-discovery');
 const {
@@ -288,6 +288,92 @@ function fetchIssueTitles(issueIds, cache) {
     }
   }
   saveIssueTitleCache(cache);
+}
+
+// #4128 — `exec` async (mismo shell que la versión sync: preserva la resolución
+// de `gh` por PATH y el arg `query=@tmpfile`) envuelto en Promise. La diferencia
+// crítica vs `execSync` es que el event loop sigue atendiendo /api/health y el
+// resto de rutas mientras gh hace su llamada de red (hasta 30s).
+function _execGhAsync(cmd, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    exec(cmd, { encoding: 'utf8', timeout: timeoutMs, windowsHide: true }, (err, stdout) => {
+      if (err) reject(err); else resolve(stdout);
+    });
+  });
+}
+
+// #4128 — versión ASÍNCRONA de fetchIssueTitles. El fetch a GitHub es de red y
+// puede tardar segundos; hacerlo con execSync DENTRO del worker de snapshot
+// clavaba el event loop entero durante la llamada → /api/health no respondía y
+// el smoke del restart lo leía como caída y disparaba rollback en loop. Esa era
+// la pata que #4096/#4126 no cubrieron: trocearon el escaneo del FS y movieron
+// wmic/tasklist a async, pero dejaron este execSync(gh) sincrónico en el camino.
+// La lógica (batch GraphQL 50/query, negative-cache, fallback 1×1) es idéntica a
+// la sync; sólo cambia execSync → await _execGhAsync.
+async function fetchIssueTitlesAsync(issueIds, cache) {
+  const ghPath = GH_BIN;
+  const safeIds = (Array.isArray(issueIds) ? issueIds : [])
+    .filter(id => /^\d+$/.test(String(id)));
+  const batches = [];
+  for (let i = 0; i < safeIds.length; i += 50) batches.push(safeIds.slice(i, i + 50));
+  for (const batch of batches) {
+    const tmpQuery = path.join(PIPELINE, '.gh-query-' + Date.now() + '.graphql');
+    try {
+      const fields = batch.map((id, i) => `i${i}: issue(number:${id}) { number title state labels(first:10) { nodes { name } } }`).join(' ');
+      const query = `{ repository(owner:"intrale",name:"platform") { ${fields} } }`;
+      fs.writeFileSync(tmpQuery, query);
+      const cmd = `${ghPath} api graphql -F query=@${tmpQuery}`;
+      const out = await _execGhAsync(cmd, 30000);
+      const data = JSON.parse(out)?.data?.repository || {};
+      batch.forEach((id, i) => {
+        const val = data[`i${i}`];
+        if (val?.number) {
+          cache[String(val.number)] = {
+            title: val.title,
+            state: val.state,
+            labels: (val.labels?.nodes || []).map(l => l.name),
+            fetchedAt: Date.now()
+          };
+        } else {
+          cache[String(id)] = { title: '', labels: [], notFound: true, fetchedAt: Date.now() };
+        }
+      });
+    } catch (e) {
+      for (const id of batch) {
+        try {
+          const cmd2 = `${ghPath} issue view ${id} --repo intrale/platform --json title,labels,state`;
+          const out2 = await _execGhAsync(cmd2, 10000);
+          const iss = JSON.parse(out2);
+          cache[id] = { title: iss.title, state: iss.state, labels: (iss.labels || []).map(l => l.name), fetchedAt: Date.now() };
+        } catch {
+          cache[String(id)] = { title: '', labels: [], notFound: true, fetchedAt: Date.now() };
+        }
+      }
+    } finally {
+      try { fs.unlinkSync(tmpQuery); } catch {}
+    }
+  }
+  saveIssueTitleCache(cache);
+}
+
+// #4128 — refresh fire-and-forget del cache de títulos/labels. El worker de
+// snapshot ya NO resuelve títulos sincrónicamente (clavaba el event loop con
+// execSync(gh)). En su lugar registra los ids faltantes en el snapshot y acá los
+// resolvemos async, FUERA del tick. El siguiente refresh lee el cache en disco
+// ya poblado (mismo patrón fire-and-forget que prInfo/olaETA). Un flag inflight
+// evita solapar fetches y un cap acota cuántos ids consulta por ronda.
+let _titleRefreshInflight = false;
+const TITLE_REFRESH_BATCH_CAP = Number(process.env.DASHBOARD_TITLE_BATCH_CAP) || 100;
+function _scheduleTitleRefresh(missingIds) {
+  if (_titleRefreshInflight) return;
+  const ids = Array.isArray(missingIds) ? missingIds.filter(id => /^\d+$/.test(String(id))) : [];
+  if (ids.length === 0) return;
+  _titleRefreshInflight = true;
+  const batch = ids.slice(0, TITLE_REFRESH_BATCH_CAP);
+  Promise.resolve()
+    .then(() => fetchIssueTitlesAsync(batch, loadIssueTitleCache()))
+    .catch((err) => { try { log(`title refresh error: ${err && err.message ? err.message : err}`); } catch {} })
+    .finally(() => { _titleRefreshInflight = false; });
 }
 
 function isProcessAlive(pid) {
@@ -751,7 +837,13 @@ function refreshStateSnapshot() {
   _stateRefreshInflight = true;
   setImmediate(() => {
     getPipelineStateAsync()
-      .then((snap) => { _stateSnapshot = snap; _stateSnapshotAt = Date.now(); })
+      .then((snap) => {
+        _stateSnapshot = snap;
+        _stateSnapshotAt = Date.now();
+        // #4128 — fire-and-forget: resolver títulos/labels faltantes async, fuera
+        // del tick. El próximo refresh ya lee el cache poblado.
+        if (snap && snap._missingTitleIds) _scheduleTitleRefresh(snap._missingTitleIds);
+      })
       .catch((e) => { try { log(`state snapshot refresh error: ${e && e.message ? e.message : e}`); } catch {} })
       .finally(() => { _stateRefreshInflight = false; });
   });
@@ -1034,7 +1126,14 @@ function* _genPipelineState() {
   // el chequeo de TTL respetando negative-cache y batching.
   const now = Date.now();
   const missing = wantedIds.filter(id => titleCacheNeedsRefetch(titleCache[id], { now, ttlMs: TITLE_CACHE_TTL }));
-  if (missing.length > 0) fetchIssueTitles(missing, titleCache);
+  // #4128 — NO resolver títulos acá: fetchIssueTitles usaba execSync(gh) (red,
+  // hasta 30s) y, aun corriendo dentro del generador troceado, clavaba el event
+  // loop ENTERO durante la llamada → /api/health no respondía y el smoke del
+  // restart disparaba rollback en loop. Sólo registramos los faltantes; el
+  // worker de snapshot los resuelve async fire-and-forget (_scheduleTitleRefresh)
+  // y el próximo refresh lee el cache ya poblado. La vista de este tick usa lo
+  // que haya en cache (igual que prInfo/olaETA degradan al cache previo).
+  if (missing.length > 0) state._missingTitleIds = missing;
   state.issueTitles = titleCache;
 
   // #2337 CA8 — snapshot del estado `reintentando` activo en este refresh.
@@ -11126,7 +11225,11 @@ const server = http.createServer((req, res) => {
     try {
       const titleCache = loadIssueTitleCache();
       delete titleCache[issueNum];
-      fetchIssueTitles([issueNum], titleCache);
+      saveIssueTitleCache(titleCache);
+      // #4128 — refresh async fire-and-forget en vez de execSync(gh) en el path
+      // del request: el borrado + persist ya fuerza el refetch en el próximo
+      // refresh del worker; esto sólo lo adelanta sin bloquear el event loop.
+      _scheduleTitleRefresh([issueNum]);
     } catch (e) { log(`pauseIssue: cache refresh failed for #${issueNum}: ${e.message}`); }
     _stateCache = null; _stateCacheAt = 0;
     log(`pauseIssue: #${issueNum} ${action === 'pause' ? 'pausado (+blocked:dependencies)' : 'reanudado (-blocked:dependencies)'}`);

--- a/.pipeline/tests/dashboard-health-title-fetch-4128.test.js
+++ b/.pipeline/tests/dashboard-health-title-fetch-4128.test.js
@@ -1,0 +1,195 @@
+'use strict';
+
+// =============================================================================
+// dashboard-health-title-fetch-4128.test.js — regresión #4128.
+//
+// Contexto: #4096/#4126 trocearon el escaneo del FS y movieron wmic/tasklist a
+// async, pero el worker de snapshot SEGUÍA resolviendo títulos/labels de issues
+// con `fetchIssueTitles` → `execSync(gh api graphql, timeout 30s)` SINCRÓNICO
+// dentro del generador. Esa llamada de red clavaba el event loop ENTERO mientras
+// gh respondía: /api/health no contestaba, el smoke (paso 2) del restart lo leía
+// como caída y disparaba rollback en LOOP. Era la pata que faltaba: el test de
+// #4126 pre-poblaba el cache de títulos y usaba un gh noop, así que NUNCA
+// ejercitaba este camino.
+//
+// El fix: el generador ya NO llama gh; sólo registra los ids faltantes y el
+// worker los resuelve async (`fetchIssueTitlesAsync` vía `exec`, fire-and-forget).
+//
+// Este test levanta el dashboard real con:
+//   - cache de títulos VENCIDO (fetchedAt viejo) → `missing` no vacío → se
+//     dispara el refresh de títulos en cada ciclo del worker.
+//   - un `gh` FALSO y LENTO (~2s por invocación): si el fetch fuese síncrono,
+//     /api/health superaría holgadamente el budget.
+// y verifica el CA central: GET /api/health responde < 500ms igual.
+// =============================================================================
+
+const { test, before, after } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const http = require('http');
+const { spawn } = require('child_process');
+
+const PIPELINE_SRC = path.resolve(__dirname, '..');
+const dashboardPath = path.join(PIPELINE_SRC, 'dashboard.js');
+
+const ISSUE_COUNT = 120;        // suficiente para >1 batch GraphQL y forzar el cap
+const HEALTH_BUDGET_MS = 500;   // budget objetivo del endpoint liviano (p90)
+// Cota dura: un solo sample por encima de esto significa que el event loop quedó
+// clavado segundos = regresión a gh síncrono. El gate REAL del smoke (smoke-test.js)
+// usa timeout 5000ms sin reintento; con gh síncrono CADA tick bloqueaba ~2-30s, así
+// que TODOS los samples se irían >2s. Un único outlier de ~1s por el costo de spawn
+// de cmd.exe en Windows (exec async) NO es la regresión y no dispara rollback.
+const HEALTH_HARD_BLOCK_MS = 2500;
+const HEALTH_P90_MAX_OUTLIERS_PCT = 0.10; // <=10% de samples pueden pasar el budget
+const HAMMER_MS = 3000;
+const MIN_SAMPLES = 12;
+const HAMMER_HARD_CAP_MS = 20000;
+
+let tmpDir, child, port;
+const isWin = process.platform === 'win32';
+
+function mkdirp(p) { fs.mkdirSync(p, { recursive: true }); }
+
+function getJson(p, urlPath, timeoutMs, cb) {
+  const req = http.get({ host: '127.0.0.1', port: p, path: urlPath, timeout: timeoutMs }, (res) => {
+    let data = '';
+    res.on('data', (c) => { data += c; });
+    res.on('end', () => cb(null, { status: res.statusCode, body: data }));
+  });
+  req.on('error', cb);
+  req.on('timeout', function () { this.destroy(); cb(new Error('timeout')); });
+}
+
+function timedHealth(p) {
+  return new Promise((resolve) => {
+    const t0 = Date.now();
+    getJson(p, '/api/health', 2000, (err, r) => {
+      const elapsed = Date.now() - t0;
+      resolve({ elapsed, ok: !err && r && r.status === 200, err: err && err.message });
+    });
+  });
+}
+
+before(async function () {
+  if (!isWin) return; // el gh falso es un .cmd (Windows); fuera de win32 se omite
+  const yaml = require('js-yaml');
+  const config = yaml.load(fs.readFileSync(path.join(PIPELINE_SRC, 'config.yaml'), 'utf8'));
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dash4128-'));
+
+  const faseDirs = [];
+  for (const [pname, pcfg] of Object.entries(config.pipelines)) {
+    for (const fase of pcfg.fases) {
+      for (const st of ['pendiente', 'trabajando', 'listo', 'procesado']) {
+        mkdirp(path.join(tmpDir, pname, fase, st));
+      }
+      faseDirs.push({ pname, fase });
+    }
+  }
+  mkdirp(path.join(tmpDir, 'logs'));
+  fs.copyFileSync(path.join(PIPELINE_SRC, 'config.yaml'), path.join(tmpDir, 'config.yaml'));
+
+  // Markers en `trabajando/` → entran al issueMatrix (= wantedIds). El cache de
+  // títulos se pre-puebla pero VENCIDO (fetchedAt muy viejo) → titleCacheNeedsRefetch
+  // los marca como `missing` y el worker dispara el fetch de títulos cada ciclo.
+  const skills = ['dev', 'verificacion', 'build', 'qa', 'review'];
+  const titleCache = {};
+  const stale = Date.now() - (2 * 3600 * 1000); // 2h: supera TITLE_CACHE_TTL (1h)
+  for (let i = 0; i < ISSUE_COUNT; i++) {
+    const issue = 300000 + i;
+    const skill = skills[i % skills.length];
+    const { pname, fase } = faseDirs[i % faseDirs.length];
+    const file = path.join(tmpDir, pname, fase, 'trabajando', `${issue}.${skill}`);
+    fs.writeFileSync(file, `issue: ${issue}\nfase: ${fase}\npipeline: ${pname}\n`);
+    titleCache[String(issue)] = { title: `stale ${issue}`, state: 'OPEN', labels: [], fetchedAt: stale };
+  }
+  fs.writeFileSync(path.join(tmpDir, '.issue-title-cache.json'), JSON.stringify(titleCache));
+
+  // `gh` FALSO y LENTO: un .cmd que duerme ~2s (ping) y emite un JSON GraphQL
+  // vacío. Si el dashboard llamara gh sincrónicamente, cada ciclo del worker
+  // clavaría el event loop ~2s → /api/health > budget. (El path del .cmd no
+  // tiene espacios — mkdtemp en %TEMP% —, así que la interpolación sin comillas
+  // del dashboard funciona.)
+  const fakeGh = path.join(tmpDir, 'fake-gh.cmd');
+  fs.writeFileSync(fakeGh,
+    '@echo off\r\nping -n 3 127.0.0.1 >nul\r\necho {"data":{"repository":{}}}\r\n');
+
+  port = 3760 + Math.floor((Date.now() % 200));
+  child = spawn(process.execPath, [dashboardPath], {
+    env: {
+      ...process.env,
+      PIPELINE_STATE_DIR: tmpDir,
+      PIPELINE_DIR_OVERRIDE: tmpDir,
+      DASHBOARD_PORT: String(port),
+      DASHBOARD_HOST: '127.0.0.1',
+      GH_BIN: fakeGh,
+      DASHBOARD_STATE_REFRESH_MS: '30',
+      DASHBOARD_PROC_STATUS_TTL_MS: '50',
+      DASHBOARD_ETA_TTL_MS: '50',
+    },
+    stdio: ['ignore', 'ignore', 'ignore'],
+  });
+
+  await new Promise((resolve, reject) => {
+    let tries = 0;
+    const tick = () => {
+      getJson(port, '/api/health', 5000, (err, r) => {
+        if (!err && r && r.status === 200) return resolve();
+        if (++tries > 60) return reject(new Error('dashboard no levantó: ' + (err && err.message)));
+        setTimeout(tick, 250);
+      });
+    };
+    setTimeout(tick, 500);
+  });
+});
+
+after(() => {
+  if (child) { try { child.kill(); } catch {} }
+  if (tmpDir) { try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch {} }
+});
+
+test('/api/health responde < 500ms aunque el worker resuelva títulos contra un gh lento', async function (t) {
+  if (!isWin) { t.skip('gh falso requiere Windows (.cmd)'); return; }
+
+  // Margen para que el worker arranque y dispare el refresh de títulos.
+  await new Promise((r) => setTimeout(r, 400));
+
+  const samples = [];
+  const tStart = Date.now();
+  while (
+    (Date.now() - tStart < HAMMER_MS || samples.length < MIN_SAMPLES) &&
+    Date.now() - tStart < HAMMER_HARD_CAP_MS
+  ) {
+    samples.push(await timedHealth(port));
+  }
+
+  assert.ok(
+    samples.length >= MIN_SAMPLES,
+    `se esperaban >= ${MIN_SAMPLES} muestras, hubo ${samples.length}: event loop starvado. ` +
+    `Lentas/fallidas: ${JSON.stringify(samples.filter((s) => !s.ok || s.elapsed >= HEALTH_BUDGET_MS).slice(0, 3))}`,
+  );
+
+  const failures = samples.filter((s) => !s.ok);
+  assert.deepStrictEqual(failures, [],
+    `/api/health falló/expiró en ${failures.length}/${samples.length}: ${JSON.stringify(failures.slice(0, 3))}`);
+
+  const max = Math.max(...samples.map((s) => s.elapsed));
+
+  // (a) Invariante DURA: ningún sample puede clavarse segundos. Con gh síncrono
+  // CADA tick bloqueaba ~2-30s → habría samples por encima de la cota. Que el max
+  // quede por debajo prueba que el event loop nunca se congela como antes.
+  const blocked = samples.filter((s) => s.elapsed >= HEALTH_HARD_BLOCK_MS);
+  assert.deepStrictEqual(blocked.map((s) => s.elapsed), [],
+    `REGRESIÓN #4128: /api/health se clavó >=${HEALTH_HARD_BLOCK_MS}ms (max=${max}ms, ${blocked.length}/${samples.length}). ` +
+    `El fetch de títulos volvió a ser síncrono (execSync(gh)) dentro del worker de snapshot.`);
+
+  // (b) Invariante de presupuesto: con gh síncrono TODOS los samples pasarían el
+  // budget; en sano sólo se tolera un outlier aislado (spawn de cmd.exe en Windows).
+  const slow = samples.filter((s) => s.elapsed >= HEALTH_BUDGET_MS);
+  const slowPct = slow.length / samples.length;
+  assert.ok(slowPct <= HEALTH_P90_MAX_OUTLIERS_PCT,
+    `REGRESIÓN #4128: ${slow.length}/${samples.length} samples (${Math.round(slowPct * 100)}%) superaron ` +
+    `${HEALTH_BUDGET_MS}ms (max=${max}ms). Tolerancia ${Math.round(HEALTH_P90_MAX_OUTLIERS_PCT * 100)}%. ` +
+    `Un fetch síncrono dispararía el 100%, no un outlier aislado.`);
+});


### PR DESCRIPTION
## Problema

El smoke del `/restart` seguía disparando **rollback en loop** aún con #4127 aplicado. Causa raíz real (distinta a la que atacó #4127): el worker de snapshot del dashboard resolvía títulos/labels de issues con `fetchIssueTitles` → `execSync(gh api graphql, timeout 30s)` **síncrono** dentro del generador. Esa llamada de red clavaba el event loop entero mientras `gh` respondía (2-30s) → `/api/health` no contestaba → el smoke (timeout 5s, sin reintento) lo leía como caída → revertía al punto estable → relanzaba → loop.

#4096/#4126 trocearon el escaneo del FS y movieron `wmic`/`tasklist` a async, pero dejaron este `execSync(gh)` en el camino. El test de #4126 pre-poblaba el cache de títulos y usaba un `gh` noop, así que **nunca ejercitaba este camino**.

## Fix

- `_genPipelineState` ya **no** llama `gh`: sólo registra los ids faltantes en `snap._missingTitleIds`. La vista del tick usa lo que haya en cache (degrada igual que `prInfo`/`olaETA`).
- Nueva `fetchIssueTitlesAsync` vía `exec` async envuelto en Promise (mismo shell → preserva resolución de `gh` por PATH y `query=@tmpfile`). El event loop sigue atendiendo `/api/health` mientras `gh` hace la llamada de red.
- `refreshStateSnapshot` dispara `_scheduleTitleRefresh(missingIds)` **fire-and-forget** fuera del tick; flag inflight evita solapes, cap acota ids por ronda. El próximo refresh lee el cache ya poblado.
- El endpoint de pause/reanudar issue también pasa a refresh async.

## Test de regresión

`dashboard-health-title-fetch-4128.test.js`: levanta el dashboard real con cache de títulos **vencido** + un `gh` **falso y lento (~2s)** y martilla `/api/health` exigiendo `<500ms` (p90, tolera 1 outlier por spawn de cmd.exe en Windows) y cota dura `<2500ms`. Con `gh` síncrono el 100% de los samples pasaría el budget. Cubre el camino que el test de #4126 nunca tocaba.

Verificado en verde local + sin regresión sobre `dashboard-health-under-load-4126.test.js`.

## Notas

- La rama se llama `agent/4128-*` pero **nunca existió un issue #4128**; el bug genuino es #4126 (reabierto porque #4127 fue incompleto). Por eso `Closes #4126`.
- **Requiere restart del dashboard tras merge** para cargar el código nuevo.

Closes #4126

🤖 Generated with [Claude Code](https://claude.com/claude-code)