### PR TITLE
fix(commander): /wave y eco de audio respetan dialecto MarkdownV2 en Telegram

### DIFF
--- a/.pipeline/lib/commander-deterministic.js
+++ b/.pipeline/lib/commander-deterministic.js
@@ -1008,6 +1008,12 @@ function createDispatcher(opts) {
         let reply = null;
         let audioText = null;
         let extraMessages = [];
+        // #4130 — parse_mode del reply. Por defecto null (el caller usa el
+        // legacy 'Markdown'). Handlers que producen MarkdownV2 (ej. `/wave`,
+        // cuyo cuadro lo genera `wave-renderer` con escapes `\#`/`\(`) lo
+        // declaran explícito para que el saliente se envíe con el dialecto
+        // correcto y no muestre los escapes literales en pantalla.
+        let parseMode = null;
         let status = 'ok';
         // Issue #3541 — Si el comando ejecutado está en `cua.allowed_commands`
         // y el feature está habilitado, emitimos automáticamente `init` antes
@@ -1051,6 +1057,9 @@ function createDispatcher(opts) {
                 // caller (pulpo.brazoCommander) los envía consecutivos tras el
                 // reply principal. Si no los soporta, se ignoran sin romper.
                 if (Array.isArray(result.extraMessages)) extraMessages = result.extraMessages;
+                // #4130 — parse_mode opcional del handler (ej. MarkdownV2 para
+                // `/wave`). Si el caller no lo soporta, lo ignora y usa su default.
+                if (typeof result.parseMode === 'string') parseMode = result.parseMode;
             }
         } catch (e) {
             status = 'error';
@@ -1090,7 +1099,7 @@ function createDispatcher(opts) {
             result_status: status,
             duration_ms: durationMs,
         });
-        return { reply, audioText, extraMessages, status, handler: intent.command, intent, durationMs };
+        return { reply, audioText, extraMessages, parseMode, status, handler: intent.command, intent, durationMs };
     }
 
     /**
@@ -1488,20 +1497,32 @@ function buildDefaultHandlers(ctx) {
             // (no debería suceder por ARG_SCHEMAS.wave.allow), respondemos error
             // en español sin colgar el dispatcher.
             if (!parsed) {
-                return fillTemplate('wave-error', {
-                    'error-kind': 'subcomando-invalido',
-                    message: 'Subcomando inválido. Usá: `status` · `next` · `add <num> #issue` · `promote`.',
-                });
+                return {
+                    reply: fillTemplate('wave-error', {
+                        'error-kind': 'subcomando-invalido',
+                        message: 'Subcomando inválido. Usá: `status` · `next` · `add <num> #issue` · `promote`.',
+                    }),
+                    parseMode: 'MarkdownV2', // #4130 — el template wave-error es MarkdownV2
+                };
             }
 
-            // Mapeo subcomando → handler dedicado. Cada uno responde { reply, audioText? }.
+            // Mapeo subcomando → handler dedicado. Cada uno responde { reply, audioText? }
+            // (o un string para los de error). TODO el árbol `/wave` produce
+            // MarkdownV2: el cuadro lo arma `wave-renderer` y los templates
+            // (`wave-error`/`wave-next`/`wave-add-ok`/`wave-promote-ok`) escapan
+            // con `\#`/`\(`/`\-`. #4130 — normalizamos a objeto con
+            // `parseMode: 'MarkdownV2'` para que el saliente NO se envíe con el
+            // legacy 'Markdown' (que mostraría los escapes literales en pantalla).
+            let res;
             switch (parsed.subcommand) {
                 case 'status':
-                    return handleWaveStatus({ pipelineRoot: PIPELINE, audio: parsed.audio });
+                    res = await handleWaveStatus({ pipelineRoot: PIPELINE, audio: parsed.audio });
+                    break;
                 case 'next':
-                    return handleWaveNext({ pipelineRoot: PIPELINE });
+                    res = await handleWaveNext({ pipelineRoot: PIPELINE });
+                    break;
                 case 'add':
-                    return handleWaveAdd({
+                    res = await handleWaveAdd({
                         pipelineRoot: PIPELINE,
                         waveNumber: parsed.waveNumber,
                         issueNumber: parsed.issueNumber,
@@ -1509,19 +1530,26 @@ function buildDefaultHandlers(ctx) {
                         chatId: message && message.chat_id !== undefined ? String(message.chat_id) : null,
                         from: message && message.from ? String(message.from) : 'Leo',
                     });
+                    break;
                 case 'promote':
-                    return handleWavePromote({
+                    res = await handleWavePromote({
                         pipelineRoot: PIPELINE,
                         cooldown: waveSubCooldown,
                         chatId: message && message.chat_id !== undefined ? String(message.chat_id) : null,
                         from: message && message.from ? String(message.from) : 'Leo',
                     });
+                    break;
                 default:
-                    return fillTemplate('wave-error', {
+                    res = fillTemplate('wave-error', {
                         'error-kind': 'subcomando-no-soportado',
                         message: `Subcomando "${parsed.subcommand}" no soportado.`,
                     });
             }
+            // #4130 — stamp MarkdownV2 preservando el resto del shape (audioText,
+            // extraMessages). Un string se promueve a { reply, parseMode }.
+            if (typeof res === 'string') return { reply: res, parseMode: 'MarkdownV2' };
+            if (res && typeof res === 'object') return { ...res, parseMode: 'MarkdownV2' };
+            return res;
         },
 
         snapshot: async () => {

--- a/.pipeline/lib/commander/transcript-echo.js
+++ b/.pipeline/lib/commander/transcript-echo.js
@@ -15,6 +15,7 @@
 //         por audio) con elipsis.
 
 const { redactSensitive, redactSecretValue } = require('../redact');
+const { escapeMarkdownV2 } = require('./fill-template');
 
 const DEFAULT_MAX_LEN = 200;
 
@@ -33,6 +34,15 @@ const MD_LEGACY_SPECIALS = /([_*`\[])/g;
 function escapeMarkdown(text) {
     if (text === null || text === undefined) return '';
     return String(text).replace(MD_LEGACY_SPECIALS, '\\$1');
+}
+
+// #4130 — Cuando el eco se prepende a un reply MarkdownV2 (ej. `/wave` por
+// audio), debe escaparse con las reglas de MarkdownV2 (muchos más metacaracteres:
+// `. ! - ( ) #` …). Un `.` o `(` sin escapar en la transcripción rompería el
+// parseo del MENSAJE COMPLETO (Telegram 400 → el saliente nunca se entrega). El
+// dialecto del escape debe coincidir con el `parse_mode` del saliente.
+function escapeForMode(text, markdownV2) {
+    return markdownV2 ? escapeMarkdownV2(text) : escapeMarkdown(text);
 }
 
 /**
@@ -64,7 +74,10 @@ function redactEcho(text) {
  *   5. Escapar Markdown (RS-1) — último paso, sobre el texto ya acotado.
  *
  * @param {string[]} transcripts - transcripciones a consolidar.
- * @param {{maxLen?: number}} [opts]
+ * @param {{maxLen?: number, markdownV2?: boolean}} [opts] - #4130: `markdownV2`
+ *   escapa con las reglas del dialecto V2 cuando el eco se prepende a un reply
+ *   MarkdownV2 (ej. `/wave` por audio). El dialecto del escape DEBE coincidir
+ *   con el `parse_mode` del saliente o el mensaje completo rompe (Telegram 400).
  * @returns {string} eco listo para enviar, o '' si no hay nada que ecoar.
  */
 function formatTranscriptEcho(transcripts, opts = {}) {
@@ -81,7 +94,7 @@ function formatTranscriptEcho(transcripts, opts = {}) {
     const truncated = redacted.length > maxLen
         ? redacted.slice(0, maxLen).trimEnd() + '…'
         : redacted;
-    const escaped = escapeMarkdown(truncated);
+    const escaped = escapeForMode(truncated, !!opts.markdownV2);
     return `🎤 Entendí: «${escaped}»`;
 }
 

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -10786,7 +10786,12 @@ async function _brazoCommanderInner(config, archivosIniciales, commanderPendient
         // reply sale igual.
         if (m._esAudio && m._audio && m._audio.ok && m._audio.transcript) {
           try {
-            const eco = transcriptEcho.formatTranscriptEcho([m._audio.transcript]);
+            // #4130 — el eco se prepende al reply y viaja en el MISMO mensaje, así
+            // que su escape debe coincidir con el dialecto del reply. Si el handler
+            // declaró MarkdownV2 (ej. `/wave`), el eco se escapa con reglas V2 o el
+            // mensaje completo rompe (Telegram 400 → el saliente no se entrega).
+            const markdownV2 = !!(result && result.parseMode === 'MarkdownV2');
+            const eco = transcriptEcho.formatTranscriptEcho([m._audio.transcript], { markdownV2 });
             if (eco) respuesta = eco + '\n\n' + respuesta;
           } catch { /* fail-open */ }
         }
@@ -10859,7 +10864,11 @@ async function _brazoCommanderInner(config, archivosIniciales, commanderPendient
       session.lastTimestamp = new Date().toISOString();
       // #3934 (CA-2 / SEC-6) — Ya no se escribe `session.context`: el contexto
       // conversacional vive únicamente en `commander-history.jsonl` por chat.
-      sendTelegram(respuesta);
+      // #4130 — dialecto del saliente. Sólo el dispatcher declara parseMode; los
+      // handlers legacy del switch responden siempre en 'Markdown' (default).
+      const replyParseMode = (result && typeof result.parseMode === 'string') ? result.parseMode : undefined;
+      const replySendOpts = replyParseMode ? { parseMode: replyParseMode } : undefined;
+      sendTelegram(respuesta, replySendOpts);
 
       // #4075 — Mensajes de continuación del paginado (ej. `/wave status` con
       // una ola grande que no entra en un solo mensaje). Se envían consecutivos
@@ -10868,7 +10877,10 @@ async function _brazoCommanderInner(config, archivosIniciales, commanderPendient
       const extraMessages = result && Array.isArray(result.extraMessages) ? result.extraMessages : [];
       for (const extra of extraMessages) {
         if (extra && typeof extra === 'string' && extra.trim().length > 0) {
-          try { sendTelegram(extra); } catch (e) { log('commander', `[wave-paginado] fallo enviar extra: ${e.message}`); }
+          // #4130 — los extras del paginado de `/wave` comparten dialecto con el
+          // reply principal (mismo renderer MarkdownV2). Si salieran en 'Markdown'
+          // mostrarían los escapes literales igual que el cuadro original.
+          try { sendTelegram(extra, replySendOpts); } catch (e) { log('commander', `[wave-paginado] fallo enviar extra: ${e.message}`); }
         }
       }
 
@@ -12229,8 +12241,11 @@ INSTRUCCIÓN: Reelaborá tu respuesta tomando en cuenta las contradicciones dete
   saveSession(session);
 }
 
-function sendTelegram(text) {
-  return sendTelegramWithMarkup(text, null);
+// #4130 — `opts.parseMode` permite que el caller declare el dialecto del
+// saliente (ej. 'MarkdownV2' para el cuadro de `/wave`, cuyos escapes `\#`/`\(`
+// sólo los entiende V2). Si no se pasa, se usa el legacy 'Markdown'.
+function sendTelegram(text, opts) {
+  return sendTelegramWithMarkup(text, null, opts);
 }
 
 // #2975 — Variante texto plano (CA-13): omite `parse_mode: 'Markdown'` para
@@ -12251,6 +12266,11 @@ function sendTelegramWithMarkup(text, replyMarkup, opts) {
 
   const msg = text.length > 4000 ? text.slice(0, 4000) + '...' : text;
   const plain = !!(opts && opts.plain);
+  // #4130 — dialecto del saliente. Default legacy 'Markdown'; un handler que
+  // produce escapes V2 (ej. `/wave`) lo declara vía opts.parseMode. `plain` gana
+  // (omite parse_mode por completo, defensa anti-inyección del canned de cuota).
+  const parseMode = (opts && typeof opts.parseMode === 'string' && opts.parseMode)
+    ? opts.parseMode : 'Markdown';
 
   // #4082 — correlationId que liga este saliente con el recibo que escribirá
   // `svc-telegram` al confirmar (o fallar) la entrega. Se estampa en el dropfile
@@ -12262,7 +12282,7 @@ function sendTelegramWithMarkup(text, replyMarkup, opts) {
   const svcDir = path.join(PIPELINE, 'servicios', 'telegram', 'pendiente');
   const filename = `${Date.now()}-cmd.json`;
   try {
-    const payload = plain ? { text: msg } : { text: msg, parse_mode: 'Markdown' };
+    const payload = plain ? { text: msg } : { text: msg, parse_mode: parseMode };
     if (replyMarkup && typeof replyMarkup === 'object') payload.reply_markup = replyMarkup;
     payload._correlationId = correlationId;
     fs.writeFileSync(path.join(svcDir, filename), JSON.stringify(payload));

--- a/.pipeline/tests/transcript-echo.test.js
+++ b/.pipeline/tests/transcript-echo.test.js
@@ -49,6 +49,21 @@ test('RS-1: escapa metacaracteres Markdown legacy (* _ ` [)', () => {
     assert.match(out, /\\\[link/);
 });
 
+test('#4130: markdownV2 escapa metacaracteres V2 que el legacy deja crudos (. ! - ( ) #)', () => {
+    const txt = 'estado de la ola (urgente)! ola #1 - 50%';
+    const legacy = echo.formatTranscriptEcho([txt]);
+    const v2 = echo.formatTranscriptEcho([txt], { markdownV2: true });
+    // El legacy NO escapa paréntesis / punto / guion / `!` / `#` (no son
+    // metacaracteres del dialecto viejo) → saldrían crudos en un mensaje V2.
+    assert.match(legacy, /\(urgente\)/);
+    // En V2 esos caracteres DEBEN quedar escapados o el mensaje completo rompe
+    // (Telegram 400 → el saliente con el cuadro de `/wave` nunca se entrega).
+    assert.match(v2, /\\\(urgente\\\)/);
+    assert.match(v2, /\\!/);
+    assert.match(v2, /\\#1/);
+    assert.match(v2, /\\-/);
+});
+
 test('RS-1: caracteres especiales no rompen ni dejan entidad sin cerrar', () => {
     // Asteriscos/underscores impares (caso clásico de rechazo 400 de Telegram).
     const out = echo.formatTranscriptEcho(['*_[]()<>& ` un solo asterisco *']);


### PR DESCRIPTION
## Problema

El cuadro de estado de la ola (`/wave`) se mostraba en Telegram con caracteres de formato en crudo (`\#`, corchetes y barras invertidas sueltas) en vez de interpretarse. Reportado por Leo por Telegram (audios pidiendo el estado de la ola); **no había issue formal** — la rama lleva número `4130` sin issue asociado.

Causa raíz: `wave-renderer` produce el cuadro con escapes **MarkdownV2** (`\#`, `\(`, `\-`), pero el saliente del commander mandaba todo con `parse_mode: 'Markdown'` (legacy) hardcodeado. El dialecto viejo no entiende esos escapes → los muestra literales.

Efecto secundario: cuando el pedido venía por audio, el eco "🎤 Entendí: …" se prepende al reply y viaja en el **mismo** mensaje. Como escapaba con reglas legacy, un `.` o `(` sin escapar en la transcripción rompía el mensaje **entero** (Telegram 400) y el cuadro no llegaba.

## Solución

- **`pulpo.js`**: `sendTelegram`/`sendTelegramWithMarkup` aceptan `opts.parseMode`. El dispatcher declara el dialecto por handler y el saliente (reply + extras del paginado) lo respeta. Default legacy `Markdown`; `plain` sigue ganando (defensa anti-inyección del canned de cuota).
- **`commander-deterministic.js`**: todo el árbol `/wave` (cuadro + templates de error) declara `parseMode: 'MarkdownV2'`.
- **`transcript-echo.js`**: el eco de audio escapa con reglas V2 cuando se prepende a un reply MarkdownV2.
- **Test de regresión** del escape V2 del eco.

## Verificación

- `node .pipeline/tests/transcript-echo.test.js` → 19/19 en verde (incluye el caso nuevo `#4130: markdownV2 escapa metacaracteres V2 que el legacy deja crudos`).
- `node -c` sobre los 3 archivos JS modificados → sin errores de sintaxis.

`qa:skipped`: fix puro de infra del commander (formato de salida a Telegram), validado por test automatizado. Sin impacto en el producto de usuario (app).