### PR TITLE
fix(pipeline): gate de rollback del smoke test resiliente al pico de arranque (#4131)

### DIFF
--- a/.pipeline/smoke-test.js
+++ b/.pipeline/smoke-test.js
@@ -127,6 +127,30 @@ async function checkDashboardHttp(port, timeoutMs = 5000, urlPath = '/api/health
   });
 }
 
+// Gate de rollback resiliente al pico de arranque (#4131).
+// El dashboard responde /api/health en ~0,2-0,7s ya estabilizado, pero durante
+// el arranque (pulpo + 7 servicios peleando CPU al mismo tiempo) ese tiempo se
+// estira y un único tiro de 5s gatillaba un FALSO rollback. Reintentamos varias
+// veces con espera corta: damos una ventana holgada (~30s) para que el health
+// responda 200 cuando sólo está lento por contención, pero un dashboard
+// realmente caído (ECONNREFUSED inmediato) sigue fallando todas las pasadas y
+// el gate lo detecta igual. No relaja la condición de salud, sólo la espera.
+async function checkDashboardHttpWithRetry(port, urlPath, { attempts = 5, perAttemptMs = 5000, delayMs = 1500 } = {}) {
+  let last = { ok: false, status: 'unknown' };
+  for (let i = 1; i <= attempts; i++) {
+    last = await checkDashboardHttp(port, perAttemptMs, urlPath);
+    if (last.ok) {
+      if (i > 1) log(`  ${urlPath} respondió 200 en intento ${i}/${attempts}`);
+      return last;
+    }
+    if (i < attempts) {
+      log(`  ${urlPath} intento ${i}/${attempts} status=${last.status} — reintento en ${delayMs}ms`);
+      await new Promise(r => setTimeout(r, delayMs));
+    }
+  }
+  return last;
+}
+
 async function main() {
   const args = parseArgs(process.argv);
   const components = args.components || DEFAULT_COMPONENTS;
@@ -170,9 +194,9 @@ async function main() {
   if (args.http) {
     log('Verificando dashboard HTTP :3200 (/api/health)...');
     const dashPort = parseInt(process.env.DASHBOARD_PORT || '3200', 10);
-    const healthRes = await checkDashboardHttp(dashPort, 5000, '/api/health');
+    const healthRes = await checkDashboardHttpWithRetry(dashPort, '/api/health');
     if (!healthRes.ok) {
-      fail(`Dashboard /api/health no responde en :${dashPort} (status=${healthRes.status})`, 2);
+      fail(`Dashboard /api/health no responde en :${dashPort} tras reintentos (status=${healthRes.status})`, 2);
     }
     log(`  OK dashboard /api/health HTTP 200`);
 
@@ -224,7 +248,11 @@ async function main() {
   process.exit(0);
 }
 
-main().catch(e => {
-  log(`Smoke test error: ${e.stack || e.message}`);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch(e => {
+    log(`Smoke test error: ${e.stack || e.message}`);
+    process.exit(1);
+  });
+}
+
+module.exports = { checkDashboardHttp, checkDashboardHttpWithRetry };

--- a/.pipeline/tests/smoke-health-retry-4131.test.js
+++ b/.pipeline/tests/smoke-health-retry-4131.test.js
@@ -1,0 +1,80 @@
+// =============================================================================
+// smoke-health-retry-4131.test.js — gate de rollback resiliente al pico de
+// arranque (#4131).
+//
+// Contexto: el smoke test del restart gatea el rollback contra /api/health del
+// dashboard. Con un único tiro de 5s, el pico de arranque (pulpo + 7 servicios
+// peleando CPU) estiraba la respuesta del health por encima de los 5s y
+// disparaba un FALSO rollback, aunque el dashboard estaba sano (respondía 200
+// 0,5-0,7s ya estabilizado). El fix reintenta el health con espera corta antes
+// de declarar caído.
+//
+// Cubre:
+//   1. Health sano al primer intento → ok, sin reintentos.
+//   2. Health lento (falla N veces y luego responde 200) → ok tras reintentos.
+//   3. Health realmente caído (falla siempre) → !ok tras agotar los intentos.
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('node:http');
+
+const { checkDashboardHttpWithRetry } = require('../smoke-test.js');
+
+// Servidor local que falla las primeras `failFirst` requests (cerrando el
+// socket sin responder) y a partir de ahí responde 200. Simula el pico de
+// arranque: caído un rato, después sano.
+function makeFlakyServer(failFirst) {
+    let hits = 0;
+    const server = http.createServer((req, res) => {
+        hits++;
+        if (hits <= failFirst) {
+            res.socket.destroy(); // simula no-respuesta / error de conexión
+            return;
+        }
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end('{"ok":true}');
+    });
+    return { server, hits: () => hits };
+}
+
+function listen(server) {
+    return new Promise(resolve => server.listen(0, '127.0.0.1', () => resolve(server.address().port)));
+}
+
+test('1 · health sano al primer intento → ok sin reintentos', async () => {
+    const { server, hits } = makeFlakyServer(0);
+    const port = await listen(server);
+    try {
+        const r = await checkDashboardHttpWithRetry(port, '/api/health', { attempts: 5, perAttemptMs: 1000, delayMs: 50 });
+        assert.equal(r.ok, true);
+        assert.equal(hits(), 1, 'no reintentó: respondió al primer tiro');
+    } finally {
+        server.close();
+    }
+});
+
+test('2 · health lento (falla 3 y luego responde 200) → ok tras reintentos', async () => {
+    const { server, hits } = makeFlakyServer(3);
+    const port = await listen(server);
+    try {
+        const r = await checkDashboardHttpWithRetry(port, '/api/health', { attempts: 6, perAttemptMs: 1000, delayMs: 20 });
+        assert.equal(r.ok, true, 'el retry absorbe el pico de arranque');
+        assert.equal(hits(), 4, 'falló 3 veces y respondió 200 en el 4.º intento');
+    } finally {
+        server.close();
+    }
+});
+
+test('3 · health realmente caído (falla siempre) → !ok tras agotar intentos', async () => {
+    const { server, hits } = makeFlakyServer(Infinity);
+    const port = await listen(server);
+    try {
+        const r = await checkDashboardHttpWithRetry(port, '/api/health', { attempts: 3, perAttemptMs: 500, delayMs: 20 });
+        assert.equal(r.ok, false, 'dashboard caído sigue gateando rollback');
+        assert.equal(hits(), 3, 'agotó los 3 intentos configurados');
+    } finally {
+        server.close();
+    }
+});


### PR DESCRIPTION
## Problema

El smoke test del `/restart` gatea el auto-rollback contra `/api/health` del dashboard con un **único tiro de 5s**. Durante el pico de arranque (pulpo + 7 servicios peleando CPU al mismo tiempo) la respuesta del health se estira por encima de los 5s → `FAIL: /api/health timeout` → **rollback falso**, aunque el dashboard está sano (ya estabilizado responde 200 en 0,5-0,7s).

Esto es lo que volvió a disparar el rollback en los `/restart` de las 14:45 y 18:36 del 2026-06-22, tras los fixes #4128 (que mejoró el cuelgue del event loop pero dejó el health al límite) y el merge de #4130.

## Fix

El gate ahora **reintenta** el health con espera corta antes de declarar el dashboard caído:
- 5 intentos, 5s de timeout cada uno, 1,5s entre tiros (~30s de ventana en el peor caso de cuelgue, holgado dentro del timeout de 90s del smoke).
- Un dashboard **realmente caído** (ECONNREFUSED inmediato) sigue fallando todas las pasadas → el gate lo detecta igual y el rollback se dispara cuando corresponde.
- **No relaja** la condición de salud (sigue exigiendo 200), sólo la espera.

`/api/state` queda como chequeo secundario no bloqueante (sin cambios).

## Verificación

Test de regresión `smoke-health-retry-4131.test.js` — **3/3**:
1. Health sano al primer intento → ok sin reintentos.
2. Health lento (falla 3 veces y luego 200) → ok tras reintentos.
3. Health realmente caído (falla siempre) → !ok tras agotar intentos.

Cambio puro de infra del pipeline (gate del smoke test), sin impacto en el producto de usuario → `qa:skipped`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)