### PR TITLE
fix(dashboard): fetch async de info de PRs para no bloquear el event loop (#4131)

### DIFF
--- a/.pipeline/dashboard.js
+++ b/.pipeline/dashboard.js
@@ -785,15 +785,18 @@ function _schedulePrInfoRefresh(doneIssues) {
   });
   if (stale.length === 0) return;
   _prInfoInflight = true;
-  // fire-and-forget: el fetch corre tras devolver el HTML del tick actual; el
-  // siguiente poll ya lee el cache poblado (igual que la ETA de ola).
+  // #4133 — fire-and-forget REAL: usa fetchPrInfoForIssueAsync (execFile no
+  // bloqueante). Antes llamaba la versión sync (spawnSync) dentro de este
+  // Promise.then, lo cual NO la hacía async: clavaba el event loop hasta 5s por
+  // issue (15s/tick con batch 3) → /api/health no respondía → rollback falso del
+  // smoke. Ahora los fetches del batch corren en paralelo sin bloquear el loop.
   Promise.resolve()
-    .then(() => {
+    .then(async () => {
       const batch = stale.slice(0, PRINFO_BATCH_PER_TICK);
-      for (const n of batch) {
+      await Promise.all(batch.map(async (n) => {
         let info = null;
         try {
-          info = prInfoFetcherLib.fetchPrInfoForIssue(n, { cwd: ROOT });
+          info = await prInfoFetcherLib.fetchPrInfoForIssueAsync(n, { cwd: ROOT });
         } catch { info = null; }
         const ok = info && !info.error;
         _prInfoCache.set(String(n), {
@@ -802,7 +805,7 @@ function _schedulePrInfoRefresh(doneIssues) {
           state: ok ? (info.state || null) : null,
           fetchedAt: Date.now(),
         });
-      }
+      }));
     })
     .catch((err) => { try { log(`prInfo refresh error: ${err && err.message ? err.message : err}`); } catch {} })
     .finally(() => { _prInfoInflight = false; });

--- a/.pipeline/lib/__tests__/pr-info-fetcher.test.js
+++ b/.pipeline/lib/__tests__/pr-info-fetcher.test.js
@@ -19,7 +19,7 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 
-const { fetchPrInfoForIssue } = require('../pr-info-fetcher');
+const { fetchPrInfoForIssue, fetchPrInfoForIssueAsync } = require('../pr-info-fetcher');
 
 /** Crea un runner falso con los efectos solicitados y registra todas las invocaciones. */
 function makeRunner(fakeResult) {
@@ -157,4 +157,77 @@ test('Filtro estricto | descarta PRs cuyo branch NO empieza con agent/<n>-', () 
 test('Sin matches | array vacío → null', () => {
   const runner = makeRunner({ status: 0, stdout: '[]' });
   assert.equal(fetchPrInfoForIssue(3030, { runner }), null);
+});
+
+// =============================================================================
+// #4133 — fetchPrInfoForIssueAsync (versión NO bloqueante, execFile)
+//
+// Misma lógica/contrato que la versión sync, pero devuelve Promise y no clava el
+// event loop. Es la pata que faltaba migrar tras #4128: el path sync envuelto en
+// Promise.then NO era async → spawnSync bloqueaba /api/health → rollback falso.
+// Usamos el asyncRunner inyectable (firma async tipo-spawnSync) para evitar gh.
+// =============================================================================
+
+/** Crea un asyncRunner falso que resuelve `fakeResult` y registra invocaciones. */
+function makeAsyncRunner(fakeResult) {
+  const calls = [];
+  const runner = async (cmd, args, opts) => {
+    calls.push({ cmd, args, opts });
+    if (typeof fakeResult === 'function') return fakeResult(cmd, args, opts);
+    return fakeResult;
+  };
+  runner.calls = calls;
+  return runner;
+}
+
+test('async | CA-11 — issue no numérico → Promise<null> y NO invoca gh', async () => {
+  const asyncRunner = makeAsyncRunner({ status: 0, stdout: '[]' });
+  for (const bogus of ['abc', '0', '-1', '', null, undefined, NaN, '3030; rm -rf /']) {
+    const out = await fetchPrInfoForIssueAsync(bogus, { asyncRunner, ghBin: 'fake-gh' });
+    assert.equal(out, null, `bogus=${JSON.stringify(bogus)}`);
+  }
+  assert.equal(asyncRunner.calls.length, 0, 'gh no debe invocarse para entradas inválidas');
+});
+
+test('async | devuelve una Promise (no bloquea el llamador)', () => {
+  const asyncRunner = makeAsyncRunner({ status: 0, stdout: '[]' });
+  const p = fetchPrInfoForIssueAsync(3030, { asyncRunner });
+  assert.ok(p && typeof p.then === 'function', 'debe retornar un thenable');
+  return p;
+});
+
+test('async | args como array (sin shell-string) y mismo search prefix', async () => {
+  const asyncRunner = makeAsyncRunner({ status: 0, stdout: '[]' });
+  await fetchPrInfoForIssueAsync(3030, { asyncRunner, ghBin: 'fake-gh' });
+  const call = asyncRunner.calls[0];
+  assert.equal(call.cmd, 'fake-gh');
+  assert.ok(Array.isArray(call.args), 'args debe ser array');
+  const searchIdx = call.args.indexOf('--search');
+  assert.equal(call.args[searchIdx + 1], 'head:agent/3030-');
+  for (const a of call.args) assert.doesNotMatch(a, /[;&|`$]/);
+});
+
+test('async | selección del PR más reciente (mismo contrato que sync)', async () => {
+  const stdout = JSON.stringify([
+    { number: 100, headRefName: 'agent/3030-x', state: 'CLOSED', updatedAt: '2026-05-01T10:00:00Z', url: 'https://x/100' },
+    { number: 101, headRefName: 'agent/3030-x', state: 'MERGED', updatedAt: '2026-05-06T22:00:00Z', url: 'https://x/101' },
+  ]);
+  const asyncRunner = makeAsyncRunner({ status: 0, stdout });
+  const out = await fetchPrInfoForIssueAsync(3030, { asyncRunner });
+  assert.equal(out.number, 101);
+  assert.equal(out.state, 'MERGED');
+});
+
+test('async | exit code != 0 → fallback con error (no propaga)', async () => {
+  const asyncRunner = makeAsyncRunner({ status: 1, stdout: '', stderr: 'auth required' });
+  const out = await fetchPrInfoForIssueAsync(3030, { asyncRunner });
+  assert.equal(out.error, true);
+  assert.equal(out.reason, 'non_zero_exit');
+});
+
+test('async | runner que rechaza → fallback spawn_failed (no propaga)', async () => {
+  const asyncRunner = makeAsyncRunner(() => Promise.reject(new Error('execFile boom')));
+  const out = await fetchPrInfoForIssueAsync(3030, { asyncRunner });
+  assert.equal(out.error, true);
+  assert.equal(out.reason, 'spawn_failed');
 });

--- a/.pipeline/lib/pr-info-fetcher.js
+++ b/.pipeline/lib/pr-info-fetcher.js
@@ -20,7 +20,7 @@
 // =============================================================================
 'use strict';
 
-const { spawnSync } = require('child_process');
+const { spawnSync, execFile } = require('child_process');
 
 const DEFAULT_TIMEOUT_MS = 5000;
 const DEFAULT_LIMIT = 5;
@@ -50,21 +50,11 @@ const FIELDS = [
  * @returns {object|null} prInfo parseado, o `null` si no hay PR detectable, o
  *   `{ error: true }` si gh falló / timeout / JSON malformado.
  */
-function fetchPrInfoForIssue(issue, options) {
-  const opts = options || {};
-
-  // CA-11 — validación de entrada antes de invocar gh.
-  const n = Number(issue);
-  if (!Number.isInteger(n) || n <= 0) return null;
-
-  const ghBin = opts.ghBin || process.env.GH_BIN || 'gh';
-  const cwd = opts.cwd || process.cwd();
-  const timeoutMs = Number.isFinite(opts.timeoutMs) ? opts.timeoutMs : DEFAULT_TIMEOUT_MS;
-  const runner = typeof opts.runner === 'function' ? opts.runner : spawnSync;
-
-  // Buscamos por head branch prefix para usar la convención agent/<issue>-<slug>.
-  // El guion final evita matchear agent/30300-... cuando issue=3030.
-  const args = [
+// Args de `gh pr list` compartidos por la versión sync y la async. Buscamos por
+// head branch prefix (convención agent/<issue>-<slug>). El guion final evita
+// matchear agent/30300-... cuando issue=3030.
+function _buildArgs(n) {
+  return [
     'pr',
     'list',
     '--search',
@@ -76,22 +66,14 @@ function fetchPrInfoForIssue(issue, options) {
     '--json',
     FIELDS,
   ];
+}
 
-  let result;
-  try {
-    result = runner(ghBin, args, {
-      encoding: 'utf8',
-      timeout: timeoutMs,
-      windowsHide: true,
-      cwd,
-    });
-  } catch (e) {
-    return { error: true, reason: 'spawn_failed', message: e && e.message };
-  }
-
+// Normaliza un resultado tipo-spawnSync (`{ status, stdout, stderr, error? }`)
+// al prInfo parseado. Compartido entre el path sync (spawnSync) y el async
+// (execFile, que adapta su callback a esta misma forma). Mantiene los mismos
+// códigos de `reason` (CA-14) para no cambiar el contrato observable.
+function _parseResult(result, n) {
   if (!result) return { error: true, reason: 'no_result' };
-  // CA-14 — timeout real. spawnSync setea result.error.code === 'ETIMEDOUT'
-  // (o status null + signal 'SIGTERM') cuando excede el timeout.
   if (result.error) return { error: true, reason: 'spawn_error', message: result.error.message };
   if (result.status !== 0) {
     return { error: true, reason: 'non_zero_exit', exit: result.status, stderr: (result.stderr || '').slice(0, 200) };
@@ -115,8 +97,91 @@ function fetchPrInfoForIssue(issue, options) {
   return candidates[0];
 }
 
+function fetchPrInfoForIssue(issue, options) {
+  const opts = options || {};
+
+  // CA-11 — validación de entrada antes de invocar gh.
+  const n = Number(issue);
+  if (!Number.isInteger(n) || n <= 0) return null;
+
+  const ghBin = opts.ghBin || process.env.GH_BIN || 'gh';
+  const cwd = opts.cwd || process.cwd();
+  const timeoutMs = Number.isFinite(opts.timeoutMs) ? opts.timeoutMs : DEFAULT_TIMEOUT_MS;
+  const runner = typeof opts.runner === 'function' ? opts.runner : spawnSync;
+
+  let result;
+  try {
+    result = runner(ghBin, _buildArgs(n), {
+      encoding: 'utf8',
+      timeout: timeoutMs,
+      windowsHide: true,
+      cwd,
+    });
+  } catch (e) {
+    return { error: true, reason: 'spawn_failed', message: e && e.message };
+  }
+
+  // CA-14 — timeout real. spawnSync setea result.error.code === 'ETIMEDOUT'
+  // (o status null + signal 'SIGTERM') cuando excede el timeout.
+  return _parseResult(result, n);
+}
+
+// #4133 — versión ASÍNCRONA de fetchPrInfoForIssue. Idéntica lógica, pero usa
+// `execFile` (no bloqueante) en vez de `spawnSync`. El consumidor en el
+// dashboard (_schedulePrInfoRefresh) la llamaba envuelta en un Promise.then(),
+// lo cual NO la hacía async: spawnSync clavaba el event loop hasta 5s por issue
+// (15s/tick con batch 3) → /api/health dejaba de responder y el smoke del
+// restart lo leía como caída → rollback falso en loop. Misma pata que #4128
+// arregló para los títulos (execSync → _execGhAsync), que quedó sin migrar acá.
+// Mantiene args como array (no shell-string) → sin superficie de inyección.
+function fetchPrInfoForIssueAsync(issue, options) {
+  const opts = options || {};
+
+  // CA-11 — misma validación que la versión sync.
+  const n = Number(issue);
+  if (!Number.isInteger(n) || n <= 0) return Promise.resolve(null);
+
+  const ghBin = opts.ghBin || process.env.GH_BIN || 'gh';
+  const cwd = opts.cwd || process.cwd();
+  const timeoutMs = Number.isFinite(opts.timeoutMs) ? opts.timeoutMs : DEFAULT_TIMEOUT_MS;
+  // Runner async inyectable para tests: firma `(bin, args, opts) => Promise<{ status, stdout, stderr, error? }>`.
+  const asyncRunner = typeof opts.asyncRunner === 'function' ? opts.asyncRunner : null;
+
+  if (asyncRunner) {
+    return Promise.resolve()
+      .then(() => asyncRunner(ghBin, _buildArgs(n), { timeoutMs, cwd }))
+      .then((result) => _parseResult(result, n))
+      .catch((e) => ({ error: true, reason: 'spawn_failed', message: e && e.message }));
+  }
+
+  return new Promise((resolve) => {
+    execFile(ghBin, _buildArgs(n), {
+      encoding: 'utf8',
+      timeout: timeoutMs,
+      windowsHide: true,
+      cwd,
+      maxBuffer: 1024 * 1024,
+    }, (err, stdout, stderr) => {
+      // Adaptamos el callback de execFile a la forma tipo-spawnSync que espera
+      // _parseResult. ETIMEDOUT/killed (timeout) y exit != 0 entran como `error`.
+      if (err) {
+        if (err.killed || err.code === 'ETIMEDOUT') {
+          resolve(_parseResult({ status: null, error: err, stderr }, n));
+        } else if (typeof err.code === 'number') {
+          resolve(_parseResult({ status: err.code, stdout, stderr }, n));
+        } else {
+          resolve({ error: true, reason: 'spawn_failed', message: err.message });
+        }
+        return;
+      }
+      resolve(_parseResult({ status: 0, stdout, stderr }, n));
+    });
+  });
+}
+
 module.exports = {
   fetchPrInfoForIssue,
+  fetchPrInfoForIssueAsync,
   DEFAULT_TIMEOUT_MS,
   __FIELDS: FIELDS,
 };


### PR DESCRIPTION
## Causa raíz
El refresh de info de PRs de issues cerrados usaba `fetchPrInfoForIssue` con `spawnSync` envuelto en un `Promise.then` que **parecía** async pero no lo era: clavaba el event loop hasta 5s por issue (~15s por tick). Mientras tanto `/api/health` dejaba de responder y el smoke test del `/restart` lo leía como caída del dashboard → **rollback falso**.

Es la **misma pata** que arregló #4128 para títulos/labels, pero que había quedado sin migrar en el fetch de PRs. Los fixes previos (#4128 timeout, gate retry) mitigaron pero no eliminaron la ventana.

## Cambios
- `lib/pr-info-fetcher.js`: nueva `fetchPrInfoForIssueAsync` con `execFile` (no bloqueante), mismo contrato y misma validación de seguridad (args como array, sin inyección de shell).
- `dashboard.js`: usa la versión async con `Promise.all` → el batch corre en paralelo sin tocar el event loop.

## Verificación
- Suite del fetcher: **18/18 en verde**, incluidos 6 tests async nuevos (contrato sync vs async, fallback ante error/timeout, no propaga, args como array).
- `node --check` OK en `dashboard.js` y `pr-info-fetcher.js`.

## QA
`qa:skipped` — fix puro de infra del pipeline (event loop del dashboard), sin impacto en el producto de usuario.

Closes #4131

🤖 Generated with [Claude Code](https://claude.com/claude-code)