### PR TITLE
feat(dashboard): monitor de lag del event loop para cazar el cuelgue intermitente (#4131)

### DIFF
--- a/.pipeline/dashboard.js
+++ b/.pipeline/dashboard.js
@@ -622,6 +622,7 @@ let _stateSnapshot = null;          // última vista computada (o null en cold s
 let _stateSnapshotAt = 0;           // timestamp del último refresh exitoso
 let _stateRefreshInflight = false;  // evita solapar cómputos pesados
 let _stateRefreshTimer = null;      // handle del setInterval (para clearInterval)
+let _loopMonitor = null;            // #4131-followup — handle del monitor de lag del event loop
 // #4126 — cadencia configurable por env para que los tests puedan forzar un
 // worker casi-siempre-activo y verificar que /api/health no se cuelga.
 const STATE_REFRESH_MS = Number(process.env.DASHBOARD_STATE_REFRESH_MS) || 3000;
@@ -11504,6 +11505,32 @@ function startListen() {
       _stateRefreshTimer = setInterval(refreshStateSnapshot, STATE_REFRESH_MS);
       if (_stateRefreshTimer.unref) _stateRefreshTimer.unref();
     }
+    // #4131-followup — Monitor de lag del event loop. Tras toda la cadena de
+    // fixes async (#4128/#4126/#4132) el dashboard seguía colgándose de forma
+    // intermitente y parchábamos a ciegas porque NO sabíamos qué operación
+    // clavaba el loop. Esto deja evidencia dura: cuando el loop estuvo clavado
+    // por encima del umbral, logueamos el lag pico Y qué refresh estaba inflight
+    // en ese instante. El próximo cuelgue se diagnostica con datos, no teoría.
+    if (!_loopMonitor) {
+      try {
+        const { startEventLoopMonitor } = require('./lib/event-loop-monitor');
+        _loopMonitor = startEventLoopMonitor({
+          thresholdMs: Number(process.env.DASHBOARD_LOOP_LAG_THRESHOLD_MS) || 1500,
+          onStall: ({ lagMs, meanMs, p99Ms }) => {
+            // Qué operación pesada estaba en vuelo durante el stall. La que esté
+            // en `true` es la principal sospechosa de haber bloqueado el loop.
+            const inflight = [];
+            if (_stateRefreshInflight) inflight.push('stateSnapshot');
+            if (_procStatusInflight) inflight.push('procStatus');
+            if (_prInfoInflight) inflight.push('prInfo');
+            if (_olaETARefreshInflight) inflight.push('olaETA');
+            if (_titleRefreshInflight) inflight.push('titleRefresh');
+            const who = inflight.length ? inflight.join('+') : 'ninguno-inflight';
+            log(`⚠️ event-loop STALL: lag pico ${lagMs}ms (mean ${meanMs}ms, p99 ${p99Ms}ms) — inflight: ${who}`);
+          },
+        });
+      } catch (e) { try { log(`no se pudo arrancar el monitor de event-loop: ${e && e.message ? e.message : e}`); } catch {} }
+    }
   });
 }
 server.on('error', (err) => {
@@ -11524,8 +11551,8 @@ startListen();
 // uptime y para diagnóstico humano). NO es fuente de verdad: el dashboard
 // descubre sus peers vía pid-discovery.
 try { fs.writeFileSync(path.join(PIPELINE, 'dashboard.pid'), String(process.pid)); } catch {}
-process.on('SIGINT', () => { if (_stateRefreshTimer) clearInterval(_stateRefreshTimer); server.close(); process.exit(0); });
-process.on('SIGTERM', () => { if (_stateRefreshTimer) clearInterval(_stateRefreshTimer); server.close(); process.exit(0); });
+process.on('SIGINT', () => { if (_stateRefreshTimer) clearInterval(_stateRefreshTimer); if (_loopMonitor) _loopMonitor.stop(); server.close(); process.exit(0); });
+process.on('SIGTERM', () => { if (_stateRefreshTimer) clearInterval(_stateRefreshTimer); if (_loopMonitor) _loopMonitor.stop(); server.close(); process.exit(0); });
 
 // Crash handlers — loguear antes de morir para diagnóstico
 process.on('uncaughtException', (err) => {

--- a/.pipeline/lib/event-loop-monitor.js
+++ b/.pipeline/lib/event-loop-monitor.js
@@ -1,0 +1,106 @@
+'use strict';
+
+// Monitor de lag del event loop para el dashboard (#4131-followup).
+//
+// CONTEXTO — por qué existe:
+// Durante todo el ciclo de fixes #4127→#4133 perseguimos a ciegas un cuelgue
+// INTERMITENTE del dashboard: el proceso queda vivo pero mudo (ni /api/health
+// ni la raíz responden) quemando CPU, el smoke del /restart lo lee como caída y
+// dispara rollback. Migramos a async una operación sync por vez (títulos #4128,
+// proc-status #4126, PR-info #4132) pero el cuelgue volvía: queda ≥1 operación
+// sync que clava el event loop por ventanas largas y NO sabíamos cuál.
+//
+// Este monitor deja de adivinar: mide el lag real del loop con el histograma
+// nativo `perf_hooks.monitorEventLoopDelay` (precisión ns, costo despreciable,
+// NO bloquea) y, cuando el loop estuvo clavado por encima de un umbral, dispara
+// un callback con el lag pico para que el dashboard loguee QUÉ operación estaba
+// inflight en ese momento. Así el próximo cuelgue deja evidencia dura en el log
+// en vez de una nueva ronda de teorías.
+//
+// Es puramente observacional: no cambia el comportamiento del dashboard, solo
+// lo instrumenta.
+
+const { monitorEventLoopDelay } = require('perf_hooks');
+
+const DEFAULT_SAMPLE_MS = 2000;     // cada cuánto evaluamos el pico de lag
+const DEFAULT_THRESHOLD_MS = 1000;  // lag pico por encima del cual reportamos un stall
+const RESOLUTION_MS = 20;           // resolución del histograma (muestreo del loop)
+
+// ns → ms con un decimal, tolerante a valores inválidos del histograma
+// (`Infinity`/`NaN` aparecen si nunca hubo una muestra en la ventana).
+function nsToMs(ns) {
+  if (typeof ns !== 'number' || !Number.isFinite(ns) || ns < 0) return 0;
+  return Math.round(ns / 1e5) / 10;
+}
+
+// Arranca el monitor. Devuelve un handle con `.stop()` y `.sample()` (snapshot
+// manual, útil para tests y diagnóstico bajo demanda). El timer interno está
+// `unref()`-eado: nunca mantiene vivo el proceso por sí solo.
+//
+// opts:
+//   - sampleMs:    período de evaluación (default 2000)
+//   - thresholdMs: umbral de stall en ms (default 1000)
+//   - onStall(info): callback al detectar un stall. info = { lagMs, meanMs,
+//                    p99Ms, sampleMs, at }. Errores del callback se tragan para
+//                    que la instrumentación nunca tumbe al proceso que observa.
+//   - setIntervalFn / now: inyectables para tests (default globales).
+function startEventLoopMonitor(opts = {}) {
+  const sampleMs = Number(opts.sampleMs) > 0 ? Number(opts.sampleMs) : DEFAULT_SAMPLE_MS;
+  const thresholdMs = Number(opts.thresholdMs) >= 0 ? Number(opts.thresholdMs) : DEFAULT_THRESHOLD_MS;
+  const onStall = typeof opts.onStall === 'function' ? opts.onStall : () => {};
+  const setIntervalFn = typeof opts.setIntervalFn === 'function' ? opts.setIntervalFn : setInterval;
+  const clearIntervalFn = typeof opts.clearIntervalFn === 'function' ? opts.clearIntervalFn : clearInterval;
+  const now = typeof opts.now === 'function' ? opts.now : () => Date.now();
+
+  const histogram = monitorEventLoopDelay({ resolution: RESOLUTION_MS });
+  histogram.enable();
+
+  // Lee el pico/medias de la ventana actual y resetea para la próxima. El lag
+  // "real" del loop es `max` menos la resolución del muestreo (el histograma
+  // siempre incluye el período base entre muestras).
+  function readAndReset() {
+    const maxMs = Math.max(0, nsToMs(histogram.max) - RESOLUTION_MS);
+    const meanMs = Math.max(0, nsToMs(histogram.mean) - RESOLUTION_MS);
+    const p99Ms = Math.max(0, nsToMs(histogram.percentile(99)) - RESOLUTION_MS);
+    histogram.reset();
+    return { maxMs, meanMs, p99Ms };
+  }
+
+  // Snapshot manual sin resetear (para /api/health diagnostics o tests).
+  function sample() {
+    return {
+      lagMs: Math.max(0, nsToMs(histogram.max) - RESOLUTION_MS),
+      meanMs: Math.max(0, nsToMs(histogram.mean) - RESOLUTION_MS),
+      p99Ms: Math.max(0, nsToMs(histogram.percentile(99)) - RESOLUTION_MS),
+    };
+  }
+
+  const timer = setIntervalFn(() => {
+    let r;
+    try { r = readAndReset(); } catch { return; }
+    if (r.maxMs >= thresholdMs) {
+      try {
+        onStall({
+          lagMs: r.maxMs,
+          meanMs: r.meanMs,
+          p99Ms: r.p99Ms,
+          sampleMs,
+          at: now(),
+        });
+      } catch { /* la instrumentación nunca tumba al observado */ }
+    }
+  }, sampleMs);
+  if (timer && typeof timer.unref === 'function') timer.unref();
+
+  let stopped = false;
+  function stop() {
+    if (stopped) return;
+    stopped = true;
+    try { clearIntervalFn(timer); } catch {}
+    try { histogram.disable(); } catch {}
+  }
+
+  return { stop, sample };
+}
+
+module.exports = { startEventLoopMonitor, nsToMs, DEFAULT_SAMPLE_MS, DEFAULT_THRESHOLD_MS };

--- a/.pipeline/lib/event-loop-monitor.test.js
+++ b/.pipeline/lib/event-loop-monitor.test.js
@@ -1,0 +1,109 @@
+'use strict';
+
+// Tests del monitor de lag del event loop (#4131-followup).
+// Cubren: conversión ns→ms, disparo del callback solo por encima del umbral,
+// uso de timers/now inyectados (sin tiempo real), y que un callback que explota
+// no tumbe al monitor. Aislados: no tocan el dashboard ni el FS.
+
+const test = require('node:test');
+const assert = require('node:assert');
+
+const { startEventLoopMonitor, nsToMs, DEFAULT_THRESHOLD_MS } = require('./event-loop-monitor');
+
+// Fake de setInterval: captura el callback y permite dispararlo a mano (tick),
+// sin esperar tiempo real. Devuelve un objeto con `.unref()` no-op.
+function fakeTimers() {
+  let cb = null;
+  const setIntervalFn = (fn) => { cb = fn; return { unref() {} }; };
+  const clearIntervalFn = () => { cb = null; };
+  return { setIntervalFn, clearIntervalFn, tick: () => { if (cb) cb(); } };
+}
+
+test('nsToMs convierte nanosegundos a ms con un decimal y tolera valores inválidos', () => {
+  assert.strictEqual(nsToMs(1e6), 1);        // 1e6 ns = 1 ms
+  assert.strictEqual(nsToMs(5e6), 5);        // 5e6 ns = 5 ms
+  assert.strictEqual(nsToMs(15e5), 1.5);     // 1.5e6 ns = 1.5 ms (un decimal)
+  assert.strictEqual(nsToMs(0), 0);
+  assert.strictEqual(nsToMs(Infinity), 0);   // histograma sin muestras
+  assert.strictEqual(nsToMs(NaN), 0);
+  assert.strictEqual(nsToMs(-1), 0);
+});
+
+test('expone DEFAULT_THRESHOLD_MS y arranca/para sin tirar', () => {
+  assert.strictEqual(typeof DEFAULT_THRESHOLD_MS, 'number');
+  const t = fakeTimers();
+  const mon = startEventLoopMonitor({ setIntervalFn: t.setIntervalFn, clearIntervalFn: t.clearIntervalFn });
+  assert.strictEqual(typeof mon.stop, 'function');
+  assert.strictEqual(typeof mon.sample, 'function');
+  mon.stop();
+  mon.stop(); // idempotente
+});
+
+test('sample() devuelve métricas numéricas no negativas', () => {
+  const t = fakeTimers();
+  const mon = startEventLoopMonitor({ setIntervalFn: t.setIntervalFn, clearIntervalFn: t.clearIntervalFn });
+  const s = mon.sample();
+  assert.ok(Number.isFinite(s.lagMs) && s.lagMs >= 0);
+  assert.ok(Number.isFinite(s.meanMs) && s.meanMs >= 0);
+  assert.ok(Number.isFinite(s.p99Ms) && s.p99Ms >= 0);
+  mon.stop();
+});
+
+test('dispara onStall cuando el loop estuvo realmente clavado por encima del umbral', async () => {
+  const t = fakeTimers();
+  const stalls = [];
+  const mon = startEventLoopMonitor({
+    thresholdMs: 200,
+    setIntervalFn: t.setIntervalFn,
+    clearIntervalFn: t.clearIntervalFn,
+    now: () => 1700000000000,
+    onStall: (info) => stalls.push(info),
+  });
+
+  // El histograma de perf_hooks solo mide bloqueos que ocurren mientras su timer
+  // interno ya está armado: cedemos una vez tras enable() antes de bloquear.
+  await new Promise((r) => setTimeout(r, 60));
+
+  // Bloqueo sintético del loop: ocupar el thread > umbral para que el histograma
+  // registre lag real (no inyectamos el histograma; medimos de verdad).
+  const start = process.hrtime.bigint();
+  while (Number(process.hrtime.bigint() - start) / 1e6 < 350) { /* spin ~350ms */ }
+
+  // El histograma registra el retraso de su propio timer recién en el próximo
+  // turno del loop: cedemos antes de evaluar la ventana.
+  await new Promise((r) => setTimeout(r, 60));
+  t.tick();
+
+  assert.strictEqual(stalls.length, 1, 'debió reportar exactamente un stall');
+  assert.ok(stalls[0].lagMs >= 200, `lag reportado ${stalls[0].lagMs}ms debe superar el umbral`);
+  assert.strictEqual(stalls[0].at, 1700000000000, 'usa el now() inyectado');
+  assert.strictEqual(stalls[0].sampleMs > 0, true);
+  mon.stop();
+});
+
+test('NO dispara onStall cuando el loop estuvo sano (sin bloqueo) entre ticks', () => {
+  const t = fakeTimers();
+  const stalls = [];
+  const mon = startEventLoopMonitor({
+    thresholdMs: 1000,
+    setIntervalFn: t.setIntervalFn,
+    clearIntervalFn: t.clearIntervalFn,
+    onStall: (info) => stalls.push(info),
+  });
+  // Sin bloqueo: el tick inmediato no debería superar 1s de lag.
+  t.tick();
+  assert.strictEqual(stalls.length, 0, 'loop sano no debe reportar stall');
+  mon.stop();
+});
+
+test('un onStall que explota no tumba el monitor', () => {
+  const t = fakeTimers();
+  const mon = startEventLoopMonitor({
+    thresholdMs: 0, // cualquier lag >= 0 dispara
+    setIntervalFn: t.setIntervalFn,
+    clearIntervalFn: t.clearIntervalFn,
+    onStall: () => { throw new Error('boom en el callback'); },
+  });
+  assert.doesNotThrow(() => t.tick(), 'el throw del callback debe quedar contenido');
+  mon.stop();
+});


### PR DESCRIPTION
## Qué

Agrega un monitor de lag del event loop al dashboard que, cuando el loop estuvo clavado por encima de un umbral, loguea el lag pico y **qué refresh estaba inflight** (stateSnapshot / procStatus / prInfo / olaETA / titleRefresh).

## Por qué

El dashboard se colgaba de forma **intermitente** (proceso vivo pero mudo, quemando CPU) y el smoke del `/restart` lo leía como caída → rollback en loop. La cadena de fixes async (#4128 títulos, #4126 proc-status, #4132 PR-info) redujo pero no eliminó el cuelgue: queda ≥1 operación sync que clava el loop por ventanas largas y la veníamos persiguiendo a ciegas.

Este monitor deja de adivinar: deja **evidencia dura** en `dashboard.log` la próxima vez que se cuelgue, apuntando a la operación culpable.

## Detalles

- `lib/event-loop-monitor.js` — usa `perf_hooks.monitorEventLoopDelay` (histograma nativo, costo despreciable, no bloquea). Timer `unref()`-eado.
- Integrado en `startListen` tras `signalReady`; limpieza en SIGINT/SIGTERM.
- Umbral configurable por env `DASHBOARD_LOOP_LAG_THRESHOLD_MS` (default 1500ms).
- **Instrumentación pura, aditiva**: no cambia el comportamiento del dashboard.

## Verificación

- Tests del monitor: **6/6 verde** (perf_hooks real, timers inyectados, bloqueo sintético detectado).
- `node --check` OK en dashboard y lib.
- E2E con timers reales: stall de 494ms detectado y reportado.

`qa:skipped` — instrumentación interna de infra, sin impacto en producto de usuario.

Closes #4131

🤖 Generated with [Claude Code](https://claude.com/claude-code)