### PR TITLE
feat(dashboard): watchdog externo de freeze del event loop en Worker thread (#4131)

### DIFF
--- a/.pipeline/dashboard.js
+++ b/.pipeline/dashboard.js
@@ -623,6 +623,7 @@ let _stateSnapshotAt = 0;           // timestamp del último refresh exitoso
 let _stateRefreshInflight = false;  // evita solapar cómputos pesados
 let _stateRefreshTimer = null;      // handle del setInterval (para clearInterval)
 let _loopMonitor = null;            // #4131-followup — handle del monitor de lag del event loop
+let _freezeWatchdog = null;         // #4131-followup-2 — handle del watchdog externo de freeze
 // #4126 — cadencia configurable por env para que los tests puedan forzar un
 // worker casi-siempre-activo y verificar que /api/health no se cuelga.
 const STATE_REFRESH_MS = Number(process.env.DASHBOARD_STATE_REFRESH_MS) || 3000;
@@ -11531,6 +11532,30 @@ function startListen() {
         });
       } catch (e) { try { log(`no se pudo arrancar el monitor de event-loop: ${e && e.message ? e.message : e}`); } catch {} }
     }
+    // #4131-followup-2 — Watchdog EXTERNO de freeze. El monitor de arriba es
+    // ciego al freeze TOTAL (su timer vive dentro del loop congelado y nunca
+    // dispara). Este corre en un Worker thread con su propio loop y un heartbeat
+    // por SharedArrayBuffer: detecta cuando el main deja de latir AUNQUE esté
+    // 100% clavado, y deja en `logs/freeze-watchdog.log` el timestamp, la
+    // duración y la operación que estaba en vuelo al congelarse. Es el testigo
+    // que nos faltaba para el cuelgue intermitente del /restart.
+    if (!_freezeWatchdog) {
+      try {
+        const { startFreezeWatchdog } = require('./lib/freeze-watchdog');
+        _freezeWatchdog = startFreezeWatchdog({
+          logDir: LOG_DIR,
+          thresholdMs: Number(process.env.DASHBOARD_FREEZE_THRESHOLD_MS) || 3000,
+          getInflight: () => ({
+            stateSnapshot: _stateRefreshInflight,
+            procStatus: _procStatusInflight,
+            prInfo: _prInfoInflight,
+            olaETA: _olaETARefreshInflight,
+            titleRefresh: _titleRefreshInflight,
+          }),
+          onLog: (line) => { try { log(line.replace(/^\[[^\]]+\]\s*/, '')); } catch {} },
+        });
+      } catch (e) { try { log(`no se pudo arrancar el watchdog de freeze: ${e && e.message ? e.message : e}`); } catch {} }
+    }
   });
 }
 server.on('error', (err) => {
@@ -11551,8 +11576,8 @@ startListen();
 // uptime y para diagnóstico humano). NO es fuente de verdad: el dashboard
 // descubre sus peers vía pid-discovery.
 try { fs.writeFileSync(path.join(PIPELINE, 'dashboard.pid'), String(process.pid)); } catch {}
-process.on('SIGINT', () => { if (_stateRefreshTimer) clearInterval(_stateRefreshTimer); if (_loopMonitor) _loopMonitor.stop(); server.close(); process.exit(0); });
-process.on('SIGTERM', () => { if (_stateRefreshTimer) clearInterval(_stateRefreshTimer); if (_loopMonitor) _loopMonitor.stop(); server.close(); process.exit(0); });
+process.on('SIGINT', () => { if (_stateRefreshTimer) clearInterval(_stateRefreshTimer); if (_loopMonitor) _loopMonitor.stop(); if (_freezeWatchdog) _freezeWatchdog.stop(); server.close(); process.exit(0); });
+process.on('SIGTERM', () => { if (_stateRefreshTimer) clearInterval(_stateRefreshTimer); if (_loopMonitor) _loopMonitor.stop(); if (_freezeWatchdog) _freezeWatchdog.stop(); server.close(); process.exit(0); });
 
 // Crash handlers — loguear antes de morir para diagnóstico
 process.on('uncaughtException', (err) => {

--- a/.pipeline/lib/freeze-watchdog-worker.js
+++ b/.pipeline/lib/freeze-watchdog-worker.js
@@ -1,0 +1,90 @@
+'use strict';
+
+// Worker del watchdog de freeze (#4131-followup-2). Corre en su PROPIO event
+// loop, totalmente independiente del loop del dashboard. Por eso puede detectar
+// un freeze TOTAL del main: aunque el main esté clavado en código sync y no
+// procese nada, este loop sigue girando y ve que el contador de latido dejó de
+// avanzar.
+//
+// No depende de NADA del main más que de la SharedArrayBuffer. Escribe su
+// evidencia directo a `freeze-watchdog.log` con fs sincrónico, así un freeze
+// del main no le impide dejar registro.
+
+const fs = require('fs');
+const path = require('path');
+const { parentPort, workerData } = require('worker_threads');
+
+const IDX_HEARTBEAT = 0;
+const IDX_INFLIGHT = 1;
+
+// Mantener en sync con INFLIGHT_BITS de `freeze-watchdog.js`.
+const INFLIGHT_NAMES = [
+  [1, 'stateSnapshot'],
+  [2, 'procStatus'],
+  [4, 'prInfo'],
+  [8, 'olaETA'],
+  [16, 'titleRefresh'],
+];
+
+const { sab, thresholdMs, bumpMs, logDir } = workerData;
+const view = new Int32Array(sab);
+const logFile = path.join(logDir, 'freeze-watchdog.log');
+
+// El check corre a ~1/3 del threshold (mínimo el doble del bumpMs) para
+// detectar rápido sin spamear CPU.
+const checkMs = Math.max(bumpMs * 2, Math.floor(thresholdMs / 3));
+
+function decodeInflight(mask) {
+  if (!mask) return 'ninguno-inflight (operacion sync NO rastreada: revisar)';
+  const names = [];
+  for (const [bit, name] of INFLIGHT_NAMES) {
+    if (mask & bit) names.push(name);
+  }
+  return names.length ? names.join('+') : `mask:${mask}`;
+}
+
+function appendLog(line) {
+  try { fs.appendFileSync(logFile, line + '\n'); } catch {}
+  try { if (parentPort) parentPort.postMessage({ type: 'freeze', line }); } catch {}
+}
+
+let lastCount = Atomics.load(view, IDX_HEARTBEAT);
+let lastChangeAt = Date.now();
+let inFreeze = false;
+let freezeStartAt = 0;
+let freezeInflightMask = 0;
+
+const timer = setInterval(() => {
+  const now = Date.now();
+  const count = Atomics.load(view, IDX_HEARTBEAT);
+
+  if (count !== lastCount) {
+    // El main late: si veníamos de un freeze, lo cerramos con la duración real.
+    if (inFreeze) {
+      const durMs = now - freezeStartAt;
+      const ts = new Date(now).toISOString().replace('T', ' ').slice(0, 19);
+      appendLog(`[${ts}] [freeze-watchdog] FREEZE FIN: el event loop se recupero tras ${durMs}ms congelado — operacion al inicio del freeze: ${decodeInflight(freezeInflightMask)}`);
+      inFreeze = false;
+    }
+    lastCount = count;
+    lastChangeAt = now;
+    return;
+  }
+
+  // El contador no se movió: medimos cuánto hace que el main no late.
+  const stalledFor = now - lastChangeAt;
+  if (!inFreeze && stalledFor >= thresholdMs) {
+    inFreeze = true;
+    freezeStartAt = lastChangeAt;
+    // El bitmask quedó congelado en el último latido previo al freeze: refleja
+    // exactamente qué operación estaba en vuelo cuando el loop se clavó.
+    freezeInflightMask = Atomics.load(view, IDX_INFLIGHT);
+    const ts = new Date(now).toISOString().replace('T', ' ').slice(0, 19);
+    appendLog(`[${ts}] [freeze-watchdog] FREEZE DETECTADO: el event loop del dashboard lleva ${stalledFor}ms sin latir (umbral ${thresholdMs}ms) — operacion en vuelo al congelarse: ${decodeInflight(freezeInflightMask)}`);
+  }
+}, checkMs);
+// OJO: NO hacer unref() de este timer. Es lo único que mantiene vivo el loop
+// del worker; si lo desreferenciamos, el worker sale al instante y deja de
+// vigilar. El worker NO mantiene vivo al proceso principal porque el main ya lo
+// desreferencia con `worker.unref()`.
+void timer;

--- a/.pipeline/lib/freeze-watchdog.js
+++ b/.pipeline/lib/freeze-watchdog.js
@@ -1,0 +1,119 @@
+'use strict';
+
+// Watchdog EXTERNO de freeze del event loop del dashboard (#4131-followup-2).
+//
+// POR QUÉ existe (la lección cara de #4127→#4133):
+// El monitor previo (`event-loop-monitor.js`) usa `monitorEventLoopDelay` + un
+// `setInterval` que LEE el histograma. Ese timer vive DENTRO del mismo event
+// loop que vigila: sirve para un lag intermitente (el loop se traba, se suelta,
+// y al soltarse el timer dispara tarde y reporta el pico). Pero ante un FREEZE
+// TOTAL —el loop se clava en código sync y no se suelta— el timer NUNCA corre y
+// el monitor queda mudo. Medimos al enfermo con un termómetro adentro del
+// enfermo congelado. Por eso el último /restart no dejó una sola línea de STALL.
+//
+// QUÉ hace distinto: pone el testigo AFUERA del event loop, en un Worker thread
+// con su propio loop. La comunicación es un `SharedArrayBuffer` (memoria
+// compartida, lectura sin pasar por el loop del main):
+//   - El main "late": incrementa un contador cada `bumpMs` y escribe en la SAB
+//     un bitmask de qué operación pesada tiene EN VUELO en ese instante.
+//   - El Worker, desde su loop independiente, mira el contador cada `checkMs`.
+//     Si el contador deja de avanzar por más de `thresholdMs`, el main está
+//     CONGELADO: el Worker lo registra al instante (con timestamps duros y la
+//     operación inflight leída de la SAB), aunque el main jamás vuelva.
+//
+// Es puramente observacional: el main solo incrementa un entero y escribe un
+// bitmask en cada latido (costo despreciable, no toca el hot path de requests).
+// El Worker hace su propio fs.appendFileSync a un log dedicado, sin depender en
+// nada del main congelado.
+
+const path = require('path');
+
+// Layout de la SharedArrayBuffer (Int32Array):
+//   [0] HEARTBEAT  — contador que el main incrementa en cada latido.
+//   [1] INFLIGHT   — bitmask de operaciones pesadas en vuelo (ver INFLIGHT_BITS).
+const IDX_HEARTBEAT = 0;
+const IDX_INFLIGHT = 1;
+const SAB_INTS = 2;
+
+// Bits de operaciones pesadas rastreadas. Mantener en sync con el decode del
+// worker (`freeze-watchdog-worker.js`). Si el freeze ocurre con bitmask 0
+// ("ninguno-inflight"), el culpable es una operación sync NO rastreada y hay
+// que sumarla acá.
+const INFLIGHT_BITS = {
+  stateSnapshot: 1,
+  procStatus: 2,
+  prInfo: 4,
+  olaETA: 8,
+  titleRefresh: 16,
+};
+
+const DEFAULT_BUMP_MS = 200;        // cada cuánto late el main
+const DEFAULT_THRESHOLD_MS = 3000;  // sin latido por más de esto => freeze
+
+// Arranca el watchdog. Devuelve un handle con `.stop()`.
+//
+// opts:
+//   - logDir:        dir donde el worker escribe `freeze-watchdog.log` (oblig.)
+//   - thresholdMs:   ventana sin latido que cuenta como freeze (default 3000)
+//   - bumpMs:        período del latido del main (default 200)
+//   - getInflight(): callback que devuelve un objeto { stateSnapshot, procStatus,
+//                    prInfo, olaETA, titleRefresh } con booleanos. Se invoca en
+//                    cada latido para refrescar el bitmask compartido.
+//   - onLog(msg):    callback opcional para espejar eventos al log del dashboard.
+function startFreezeWatchdog(opts = {}) {
+  const logDir = opts.logDir;
+  if (!logDir) throw new Error('freeze-watchdog: logDir es obligatorio');
+  const thresholdMs = Number(opts.thresholdMs) > 0 ? Number(opts.thresholdMs) : DEFAULT_THRESHOLD_MS;
+  const bumpMs = Number(opts.bumpMs) > 0 ? Number(opts.bumpMs) : DEFAULT_BUMP_MS;
+  const getInflight = typeof opts.getInflight === 'function' ? opts.getInflight : () => ({});
+  const onLog = typeof opts.onLog === 'function' ? opts.onLog : () => {};
+
+  const { Worker } = require('worker_threads');
+
+  const sab = new SharedArrayBuffer(SAB_INTS * Int32Array.BYTES_PER_ELEMENT);
+  const view = new Int32Array(sab);
+
+  // Calcula el bitmask inflight a partir del callback del dashboard.
+  function inflightMask() {
+    let mask = 0;
+    let f;
+    try { f = getInflight() || {}; } catch { f = {}; }
+    for (const [name, bit] of Object.entries(INFLIGHT_BITS)) {
+      if (f[name]) mask |= bit;
+    }
+    return mask;
+  }
+
+  // El latido del main: incrementa el contador y publica el inflight actual.
+  // `unref()` para que el timer no mantenga vivo el proceso por sí solo.
+  const bumpTimer = setInterval(() => {
+    Atomics.store(view, IDX_INFLIGHT, inflightMask());
+    Atomics.add(view, IDX_HEARTBEAT, 1);
+  }, bumpMs);
+  if (bumpTimer && typeof bumpTimer.unref === 'function') bumpTimer.unref();
+
+  // Primer latido inmediato para que el worker tenga un baseline al instante.
+  Atomics.store(view, IDX_INFLIGHT, inflightMask());
+  Atomics.add(view, IDX_HEARTBEAT, 1);
+
+  const worker = new Worker(path.join(__dirname, 'freeze-watchdog-worker.js'), {
+    workerData: { sab, thresholdMs, bumpMs, logDir },
+  });
+  worker.unref(); // el watchdog no debe impedir que el proceso cierre
+  worker.on('message', (m) => {
+    if (m && m.type === 'freeze' && m.line) onLog(m.line);
+  });
+  worker.on('error', (e) => { try { onLog(`freeze-watchdog worker error: ${e && e.message ? e.message : e}`); } catch {} });
+
+  let stopped = false;
+  function stop() {
+    if (stopped) return;
+    stopped = true;
+    try { clearInterval(bumpTimer); } catch {}
+    try { worker.terminate(); } catch {}
+  }
+
+  return { stop };
+}
+
+module.exports = { startFreezeWatchdog, INFLIGHT_BITS, IDX_HEARTBEAT, IDX_INFLIGHT, SAB_INTS };

--- a/.pipeline/lib/freeze-watchdog.test.js
+++ b/.pipeline/lib/freeze-watchdog.test.js
@@ -1,0 +1,87 @@
+'use strict';
+
+// Tests del watchdog externo de freeze (#4131-followup-2). Verifican lo que el
+// monitor previo NO podía: que un freeze TOTAL del event loop (busy-loop sync
+// que nunca cede) sea detectado igual, porque el testigo vive en otro thread.
+// Son tests de integración reales: levantan el Worker y congelan el loop a
+// propósito. Aislados del dashboard: usan un logDir temporal.
+
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { startFreezeWatchdog, INFLIGHT_BITS } = require('./freeze-watchdog');
+
+function tmpLogDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'wd-test-'));
+}
+
+// Congela el event loop del thread principal por `ms` con un busy-loop sync:
+// reproduce el cuelgue real (proceso vivo, loop clavado, no cede a timers).
+function freezeSync(ms) {
+  const end = Date.now() + ms;
+  while (Date.now() < end) { /* quema CPU, no cede el loop */ }
+}
+
+test('detecta un freeze TOTAL del event loop y nombra la operación en vuelo', async () => {
+  const logDir = tmpLogDir();
+  const events = [];
+  const wd = startFreezeWatchdog({
+    logDir,
+    thresholdMs: 800,
+    bumpMs: 80,
+    getInflight: () => ({ prInfo: true }), // simula prInfo inflight al congelarse
+    onLog: (line) => events.push(line),
+  });
+
+  // Dejamos latir normal y luego clavamos el loop 2s (> umbral).
+  await new Promise((r) => setTimeout(r, 400));
+  freezeSync(2000);
+  // Tras liberar, damos tiempo a que el worker registre DETECTADO y FIN.
+  await new Promise((r) => setTimeout(r, 1200));
+  wd.stop();
+
+  const detectado = events.find((l) => l.includes('FREEZE DETECTADO'));
+  const fin = events.find((l) => l.includes('FREEZE FIN'));
+  assert.ok(detectado, 'debe registrar FREEZE DETECTADO durante el freeze total');
+  assert.ok(detectado.includes('prInfo'), 'debe nombrar la operación en vuelo (prInfo)');
+  assert.ok(fin, 'debe registrar FREEZE FIN al recuperarse el loop');
+
+  // La evidencia también queda persistida en disco, independiente del main.
+  const logTxt = fs.readFileSync(path.join(logDir, 'freeze-watchdog.log'), 'utf8');
+  assert.ok(logTxt.includes('FREEZE DETECTADO'), 'el log en disco debe contener el evento');
+});
+
+test('no reporta freeze cuando el loop late normal', async () => {
+  const logDir = tmpLogDir();
+  const events = [];
+  const wd = startFreezeWatchdog({
+    logDir,
+    thresholdMs: 800,
+    bumpMs: 80,
+    getInflight: () => ({}),
+    onLog: (line) => events.push(line),
+  });
+
+  // Loop sano por más de un umbral: cero detecciones.
+  await new Promise((r) => setTimeout(r, 1500));
+  wd.stop();
+
+  assert.strictEqual(events.length, 0, 'sin freeze no debe haber eventos');
+  assert.ok(!fs.existsSync(path.join(logDir, 'freeze-watchdog.log')), 'no debe crear el log sin freezes');
+});
+
+test('logDir es obligatorio', () => {
+  assert.throws(() => startFreezeWatchdog({}), /logDir es obligatorio/);
+});
+
+test('INFLIGHT_BITS expone los bits esperados y son potencias de 2 únicas', () => {
+  const bits = Object.values(INFLIGHT_BITS);
+  const expected = ['stateSnapshot', 'procStatus', 'prInfo', 'olaETA', 'titleRefresh'];
+  assert.deepStrictEqual(Object.keys(INFLIGHT_BITS), expected);
+  // Únicos y potencias de 2 (para combinarse como bitmask sin colisión).
+  assert.strictEqual(new Set(bits).size, bits.length);
+  for (const b of bits) assert.strictEqual(b & (b - 1), 0, `${b} debe ser potencia de 2`);
+});


### PR DESCRIPTION
## Qué resuelve

El monitor previo (#4133) es **ciego al freeze TOTAL**: su timer lee el histograma desde adentro del mismo event loop que vigila, así que cuando el loop se clava en código sync y no se suelta, el timer nunca corre y no reporta. Por eso el último `/restart` no dejó una sola línea de STALL.

## Cómo

Pone el testigo **afuera** del loop, en un **Worker thread** con su propio event loop. Comunicación por `SharedArrayBuffer`: el main late cada 200ms e inscribe qué operación pesada tiene en vuelo; el Worker mira el heartbeat desde su loop independiente y, si deja de avanzar por más de 3s, registra el freeze con timestamp, duración real y la operación culpable — aunque el main jamás vuelva. Evidencia en `logs/freeze-watchdog.log`.

## Verificación

- Test de integración congela el loop con busy-loop sync 2s → el Worker lo detecta y nombra la operación en vuelo (4/4 verde).
- `node --check` OK en dashboard y watchdog.

## Nota

Reemplaza al PR #4134, que había quedado apuntando al commit viejo del monitor por una divergencia de la rama (el squash-merge de #4133 reescribió el SHA). Esta rama sale limpia de `main` + el commit del watchdog.

Closes #4131