### PR TITLE
Separar estado activo del histórico en el pipeline V3 (frontera activo/histórico)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,6 +186,12 @@ scripts/planner-plan.json
 .pipeline/archivado/
 .pipeline/audit/
 
+# #4136 — histórico de artefactos del pipeline (frontera activo/histórico).
+# Contiene YAML de tareas terminadas (motivos de rechazo, metadata interna).
+# Igual que `archivado/`: efímero por máquina, NO se versiona.
+.pipeline/historico/
+.pipeline/historico-transitions.jsonl
+
 # #3539 — audios .ogg generados por deliverable-notify (CA-SEC-8).
 # El cleanup/retencion sera tratado en #3544.
 .pipeline/audio/

--- a/.pipeline/config.yaml
+++ b/.pipeline/config.yaml
@@ -499,6 +499,23 @@ handoff:
     - aprobacion
     - entrega
 
+# #4136 — Frontera activo/histórico.
+#
+# El Pulpo muda al `historico/` (raíz aparte, mismo volumen → rename atómico) los
+# artefactos `procesado/` de issues en REPOSO TOTAL (sin archivos en
+# pendiente/trabajando/listo de ninguna fase, y que alcanzaron su fase terminal o
+# están `closed` en GitHub). Así el camino vivo se mantiene acotado solo y el
+# snapshot del dashboard (`_genPipelineState`) deja de congelar el event loop.
+# El histórico se consulta on-demand por id validado; NO lo walkea el snapshot.
+#
+#   - enabled:        habilita el barrido (rollout gradual; default true).
+#   - max_per_tick:   tope de issues archivados por tick del Pulpo.
+#   - retention_days: ventana de retención del histórico (limpieza futura).
+historico:
+  enabled: true
+  max_per_tick: 200
+  retention_days: 90
+
 # #3416 — Rebobinado del pipeline tras rechazo del operador.
 #
 # El operador dispara `/rechazar <issue> <alias>` desde Telegram. El Commander

--- a/.pipeline/lib/config-schema.js
+++ b/.pipeline/lib/config-schema.js
@@ -122,6 +122,17 @@ const SCHEMA = {
             },
         },
 
+        // --- historico: frontera activo/histórico (#4136) -------------------
+        historico: {
+            type: 'object',
+            additionalProperties: true,
+            properties: {
+                enabled: { type: 'boolean' },
+                max_per_tick: { type: 'integer', minimum: 1 },
+                retention_days: { type: 'integer', minimum: 1 },
+            },
+        },
+
         // --- pipelines: cada pipeline DEBE declarar skills_por_fase ----------
         pipelines: {
             type: 'object',

--- a/.pipeline/lib/ghost-artifact-lint.allowlist.json
+++ b/.pipeline/lib/ghost-artifact-lint.allowlist.json
@@ -36,8 +36,8 @@
     },
     {
       "file": "smoke-test.js",
-      "line": 206,
-      "reason": "Lee `servicios/commander/trabajando/` (no es definicion/desarrollo) buscando mensajes .json del commander. Filtro explícito endsWith('.json'). (línea recalculada por #4096: el bloque desacoplado de checks /api/state + /api/health desplazó el readdir de 189 a 206)."
+      "line": 230,
+      "reason": "Lee `servicios/commander/trabajando/` (no es definicion/desarrollo) buscando mensajes .json del commander. Filtro explícito endsWith('.json'). (línea recalculada por #4136: el merge de #4131 —gate de rollback resiliente al pico de arranque— agregó código antes del readdir y lo desplazó de 206 a 230)."
     }
   ]
 }

--- a/.pipeline/lib/historico.js
+++ b/.pipeline/lib/historico.js
@@ -1,0 +1,298 @@
+'use strict';
+
+// =============================================================================
+// historico.js — Frontera explícita entre el ESTADO ACTIVO y el HISTÓRICO del
+// pipeline V3 (issue #4136).
+//
+// Problema que resuelve: hoy el trabajo activo y el histórico de tareas ya
+// terminadas conviven en el MISMO camino vivo (`<pipeline>/<fase>/procesado`).
+// El snapshot del dashboard (`_genPipelineState`) recorre TODO ese camino y
+// parsea miles de YAML, congelando el event loop durante `/restart` (freezes de
+// 54s..92s medidos por el watchdog #4135) → rollback por timeout del smoke test.
+//
+// Diseño (receta del Arquitecto, validada por guru/security):
+//   1. `procesado/` SIGUE siendo el sink por-fase del CICLO VIVO. No se redirige
+//      cada `renameSync(... 'procesado')` (rompería la lectura de "pasadas
+//      anteriores" del rebote y la detección de ola, que usan `procesado/`
+//      DENTRO del ciclo activo).
+//   2. Cuando un issue queda EN REPOSO TOTAL (sin archivos en
+//      pendiente/trabajando/listo de NINGUNA fase de NINGÚN pipeline, y alcanzó
+//      su fase terminal o está `closed` en GitHub), un barrido centralizado muda
+//      TODOS sus artefactos `procesado/` (de todas las fases) a `historico/`.
+//      Así el camino vivo se mantiene acotado solo, sin re-acumular.
+//   3. `historico/` vive en una RAÍZ APARTE (`.pipeline/historico/`), nunca hija
+//      de `<pipeline>/<fase>/`, por lo que el snapshot no lo walkea.
+//
+// Toda la lógica de la frontera se concentra acá para NO tocar los ~30
+// call-sites sueltos de `renameSync(... 'procesado')` del Pulpo (riesgo #5 de
+// guru).
+//
+// Atomicidad: `historico/` es hijo de `pipelineDir` → MISMO volumen →
+// `renameSync` atómico en Windows. `moverAHistorico` tolera reintentos por la
+// no-confiabilidad de `renameSync` bajo concurrencia en Windows (pulpo.js:833).
+//
+// Seguridad (lector on-demand): `issue` forzado a `^\d+$`, `pipeline`/`fase`
+// validados contra la allowlist de `config.pipelines`, path resuelto y acotado
+// con `startsWith(root + sep)` para cortar `../` y rutas absolutas. Nunca lista
+// el árbol completo (no es file-server).
+// =============================================================================
+
+const fs = require('fs');
+const path = require('path');
+
+// Fase terminal por pipeline: alcanzar su `procesado/` marca al issue como
+// "completado el flujo". Coincide con config.pipelines[*].fases (último elemento).
+const TERMINAL_FASES = {
+  desarrollo: 'entrega',
+  definicion: 'sizing',
+};
+
+const TRANSITIONS_LOG = 'historico-transitions.jsonl';
+
+// --- helpers internos --------------------------------------------------------
+
+function safeReaddir(dir) {
+  try {
+    return fs.readdirSync(dir).filter((f) => !f.startsWith('.') && !f.endsWith('.gitkeep'));
+  } catch {
+    return [];
+  }
+}
+
+/** Archivos de un issue en un dir, por prefijo exacto `<issue>.` (no matchea 41360 con 4136). */
+function listIssueFiles(dir, issue) {
+  const prefix = String(issue) + '.';
+  return safeReaddir(dir).filter((f) => f.startsWith(prefix));
+}
+
+function hasIssueFiles(dir, issue) {
+  return listIssueFiles(dir, issue).length > 0;
+}
+
+/** Raíz del histórico. Hijo de pipelineDir ⇒ mismo volumen ⇒ rename atómico. */
+function historicoRoot(pipelineDir) {
+  return path.join(pipelineDir, 'historico');
+}
+
+/**
+ * Asegura que el histórico esté en el MISMO volumen que el pipeline (CA-1).
+ * Por construcción (hijo de pipelineDir) siempre lo está; esta verificación
+ * documenta el invariante y atrapa el caso de un pipelineDir vía symlink a otro
+ * drive. Lanza si los drive-roots difieren.
+ */
+function assertSameVolume(pipelineDir) {
+  const root = historicoRoot(pipelineDir);
+  const a = path.parse(path.resolve(pipelineDir)).root.toLowerCase();
+  const b = path.parse(path.resolve(root)).root.toLowerCase();
+  if (a !== b) {
+    throw new Error(`historico: ${root} no está en el mismo volumen que ${pipelineDir} (rename no atómico)`);
+  }
+  return true;
+}
+
+/** Registro append-only de cada muda (NUNCA writeFileSync). Best-effort. */
+function appendTransition(pipelineDir, record) {
+  try {
+    const line = JSON.stringify({ ts: new Date().toISOString(), ...record }) + '\n';
+    fs.appendFileSync(path.join(pipelineDir, TRANSITIONS_LOG), line, 'utf8');
+  } catch {
+    /* el log es best-effort: no abortar la muda si el log falla */
+  }
+}
+
+/**
+ * Mueve un archivo de origen a destino con tolerancia a la no-confiabilidad de
+ * `renameSync` bajo concurrencia en Windows (EPERM/EBUSY/EEXIST). Idempotente:
+ * si el origen ya no está pero el destino sí, asume que otra pasada ya lo movió.
+ */
+function moveWithRetry(src, dest, retries = 5) {
+  for (let i = 0; i < retries; i++) {
+    try {
+      fs.renameSync(src, dest);
+      return true;
+    } catch (e) {
+      // Ya movido por otra pasada/proceso (idempotencia).
+      if (e.code === 'ENOENT' && fs.existsSync(dest)) return true;
+      // Destino ya existe (re-corrida): el destino es la copia canónica del
+      // histórico; descartamos el origen duplicado.
+      if (e.code === 'EEXIST' || e.code === 'EPERM' || e.code === 'EBUSY') {
+        if (fs.existsSync(dest)) {
+          try { fs.rmSync(src, { force: true }); } catch { /* noop */ }
+          return true;
+        }
+      }
+      if (i === retries - 1) {
+        // Último intento: fallback copy+unlink (no atómico, pero mismo volumen
+        // hace que sea raro llegar acá). Mantiene el dato a salvo.
+        try {
+          fs.copyFileSync(src, dest);
+          fs.rmSync(src, { force: true });
+          return true;
+        } catch (e2) {
+          throw new Error(`historico: no pude mover ${src} → ${dest}: ${e2.message}`);
+        }
+      }
+    }
+  }
+  return false;
+}
+
+// --- API pública -------------------------------------------------------------
+
+/**
+ * Muda un artefacto concreto de `<pipeline>/<fase>/procesado/<fname>` a
+ * `historico/<pipeline>/<fase>/<fname>`. Registra la muda (append-only).
+ * @returns {string} path destino
+ */
+function moverAHistorico({ issue, pipeline, fase, fname, pipelineDir, logTransition = true }) {
+  const src = path.join(pipelineDir, pipeline, fase, 'procesado', fname);
+  const destDir = path.join(historicoRoot(pipelineDir), pipeline, fase);
+  fs.mkdirSync(destDir, { recursive: true });
+  const dest = path.join(destDir, fname);
+  moveWithRetry(src, dest);
+  if (logTransition) {
+    appendTransition(pipelineDir, { issue: String(issue), pipeline, fase, fname, op: 'mover_a_historico' });
+  }
+  return dest;
+}
+
+/**
+ * Predicado de reposo total: el issue NO tiene archivos en
+ * pendiente/trabajando/listo de NINGUNA fase de NINGÚN pipeline.
+ */
+function estaEnReposo({ issue, config, pipelineDir }) {
+  for (const [pName, pCfg] of Object.entries(config.pipelines || {})) {
+    for (const fase of pCfg.fases || []) {
+      for (const estado of ['pendiente', 'trabajando', 'listo']) {
+        if (hasIssueFiles(path.join(pipelineDir, pName, fase, estado), issue)) {
+          return false;
+        }
+      }
+    }
+  }
+  return true;
+}
+
+/** ¿El issue alcanzó la fase terminal (tiene marker en su procesado terminal)? */
+function alcanzoTerminal({ issue, config, pipelineDir }) {
+  for (const [pName, fase] of Object.entries(TERMINAL_FASES)) {
+    if (!config.pipelines || !config.pipelines[pName]) continue;
+    if (hasIssueFiles(path.join(pipelineDir, pName, fase, 'procesado'), issue)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * ¿El issue es archivable? Debe estar en reposo total Y (haber alcanzado su
+ * fase terminal O estar cerrado en GitHub según el predicado opcional isClosed).
+ */
+function esArchivable({ issue, config, pipelineDir, isClosed }) {
+  if (!estaEnReposo({ issue, config, pipelineDir })) return false;
+  if (alcanzoTerminal({ issue, config, pipelineDir })) return true;
+  if (typeof isClosed === 'function') {
+    try { if (isClosed(String(issue))) return true; } catch { /* best-effort */ }
+  }
+  return false;
+}
+
+/**
+ * Si el issue es archivable, muda TODOS sus artefactos de `procesado/` (de todas
+ * las fases de todos los pipelines) a `historico/`. Idempotente.
+ * @returns {{archived:boolean, moved:string[]}}
+ */
+function archivarIssueTerminado({ issue, config, pipelineDir, isClosed }) {
+  issue = String(issue);
+  if (!/^\d+$/.test(issue)) {
+    throw new Error(`historico: issue inválido: ${issue}`);
+  }
+  if (!esArchivable({ issue, config, pipelineDir, isClosed })) {
+    return { archived: false, moved: [] };
+  }
+  const moved = [];
+  for (const [pName, pCfg] of Object.entries(config.pipelines || {})) {
+    for (const fase of pCfg.fases || []) {
+      const procesadoDir = path.join(pipelineDir, pName, fase, 'procesado');
+      for (const fname of listIssueFiles(procesadoDir, issue)) {
+        moverAHistorico({ issue, pipeline: pName, fase, fname, pipelineDir });
+        moved.push(`${pName}/${fase}/${fname}`);
+      }
+    }
+  }
+  return { archived: moved.length > 0, moved };
+}
+
+/**
+ * Barrido idempotente: recorre todos los `procesado/` del camino vivo, junta los
+ * issues presentes y archiva los que cumplan el predicado. Cubre también el
+ * histórico previo al deploy (CA-6, sin script de migración aparte).
+ * @returns {{scanned:number, archivedIssues:string[], movedCount:number}}
+ */
+function barrerHistorico({ config, pipelineDir, isClosed, max = Infinity }) {
+  const issues = new Set();
+  for (const [pName, pCfg] of Object.entries(config.pipelines || {})) {
+    for (const fase of pCfg.fases || []) {
+      const dir = path.join(pipelineDir, pName, fase, 'procesado');
+      for (const fname of safeReaddir(dir)) {
+        const m = fname.match(/^(\d+)\./);
+        if (m) issues.add(m[1]);
+      }
+    }
+  }
+  const result = { scanned: issues.size, archivedIssues: [], movedCount: 0 };
+  let n = 0;
+  for (const issue of issues) {
+    if (n >= max) break;
+    const r = archivarIssueTerminado({ issue, config, pipelineDir, isClosed });
+    if (r.archived) {
+      result.archivedIssues.push(issue);
+      result.movedCount += r.moved.length;
+      n++;
+    }
+  }
+  return result;
+}
+
+/**
+ * Lector on-demand del histórico de un issue en una fase concreta. Devuelve solo
+ * los nombres de archivo `<issue>.*`, nunca el árbol completo. Validación de path
+ * obligatoria (security):
+ *   - issue: `^\d+$`
+ *   - pipeline/fase: allowlist de config.pipelines (nunca concatenar crudo)
+ *   - path resuelto y acotado con startsWith(root + sep) (corta ../ y absolutos)
+ * @returns {string[]} nombres de archivo
+ */
+function leerHistorico({ issue, pipeline, fase, config, pipelineDir }) {
+  if (!/^\d+$/.test(String(issue))) {
+    throw new Error('historico: issue inválido');
+  }
+  const pipelines = Object.keys(config.pipelines || {});
+  if (!pipelines.includes(pipeline)) {
+    throw new Error(`historico: pipeline inválido: ${pipeline}`);
+  }
+  const fases = (config.pipelines[pipeline] && config.pipelines[pipeline].fases) || [];
+  if (!fases.includes(fase)) {
+    throw new Error(`historico: fase inválida: ${fase}`);
+  }
+  const root = historicoRoot(pipelineDir);
+  const dir = path.resolve(root, pipeline, fase);
+  if (!(dir === path.resolve(root) || dir.startsWith(path.resolve(root) + path.sep))) {
+    throw new Error('historico: path fuera de la raíz');
+  }
+  return listIssueFiles(dir, issue);
+}
+
+module.exports = {
+  TERMINAL_FASES,
+  TRANSITIONS_LOG,
+  historicoRoot,
+  assertSameVolume,
+  moverAHistorico,
+  estaEnReposo,
+  alcanzoTerminal,
+  esArchivable,
+  archivarIssueTerminado,
+  barrerHistorico,
+  leerHistorico,
+};

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -4876,6 +4876,51 @@ function reboteVerificacionABuild(issue, pipelineName, preflightResult) {
   }
 }
 
+// ---------------------------------------------------------------------------
+// #4136 — Brazo de ARCHIVADO: muda al `historico/` los artefactos `procesado/`
+// de issues en reposo total (frontera activo/histórico). Mantiene el camino
+// vivo acotado solo, sin re-acumular, así `stateSnapshot` no se congela.
+//
+// Idempotente: recorre `procesado/` cada tick y archiva solo lo archivable
+// (predicado en `lib/historico.js`). Cubre también el histórico previo al deploy
+// (CA-6, sin script de migración aparte). Best-effort: nunca rompe el tick.
+// ---------------------------------------------------------------------------
+
+// Tope de issues archivados por tick: el barrido es idempotente y `procesado/`
+// queda acotado tras la primera corrida, así que un cap alto absorbe la
+// migración inicial sin saturar un solo tick.
+const ARCHIVADO_MAX_PER_TICK = 200;
+
+/** Construye un predicado isClosed(issue) best-effort desde el title-cache. */
+function makeIsClosedFromTitleCache() {
+  let cache = {};
+  try {
+    const file = path.join(PIPELINE, '.issue-title-cache.json');
+    cache = JSON.parse(fs.readFileSync(file, 'utf8')) || {};
+  } catch {
+    return null; // sin cache → solo se archiva por fase terminal alcanzada
+  }
+  return (issue) => {
+    const entry = cache[String(issue)];
+    return Boolean(entry && String(entry.state).toUpperCase() === 'CLOSED');
+  };
+}
+
+function brazoArchivado(config) {
+  try {
+    if (config.historico && config.historico.enabled === false) return; // rollout gradual
+    const historico = require('./lib/historico');
+    const max = (config.historico && config.historico.max_per_tick) || ARCHIVADO_MAX_PER_TICK;
+    const isClosed = makeIsClosedFromTitleCache();
+    const r = historico.barrerHistorico({ config, pipelineDir: PIPELINE, isClosed, max });
+    if (r.archivedIssues.length) {
+      log('archivado', `mudados ${r.movedCount} artefacto(s) de ${r.archivedIssues.length} issue(s) a historico/: ${r.archivedIssues.join(', ')}`);
+    }
+  } catch (e) {
+    log('archivado', `error en brazo (no fatal): ${e.message}`);
+  }
+}
+
 /**
  * #3939 (CA-4) — Barrido de claims huérfanos (`*.claimed-<pid>`) en todos los
  * `pendiente/`. Un proceso que muere entre el `renameSync(c.path, claimPath)` y
@@ -14384,6 +14429,7 @@ async function mainLoop() {
         // barrido ni lanzamiento; el guard interno previene re-entrada.
         brazoDesbloqueo(config).catch(e => log('desbloqueo', `error en brazo async: ${e.message}`));
         brazoBarrido(config);     // Cuarto: promover entre fases
+        brazoArchivado(config);   // #4136 — mudar procesado/ de issues en reposo a historico/
         sweepClaimsHuerfanos(config); // #3939 — restaurar claims huérfanos antes de lanzar
         brazoLanzamiento(config); // Quinto: asignar trabajo a agentes
         brazoHuerfanos(config);   // Sexto: recuperar trabajo trabado
@@ -14438,6 +14484,10 @@ process.on('SIGTERM', () => {
 // Útil para tests unitarios y scripts de evidencia del gate predictivo.
 if (process.env.PULPO_NO_AUTOSTART === '1') {
   module.exports = {
+    // #4136 — brazo de archivado (frontera activo/histórico).
+    brazoArchivado,
+    makeIsClosedFromTitleCache,
+    ARCHIVADO_MAX_PER_TICK,
     // #4051 — ventana nocturna: límites efectivos + piso de concurrencia.
     getEffectiveResourceLimits,
     orangeFloorReached,

--- a/.pipeline/test/dashboard-snapshot-historico.test.js
+++ b/.pipeline/test/dashboard-snapshot-historico.test.js
@@ -1,0 +1,63 @@
+'use strict';
+
+// =============================================================================
+// dashboard-snapshot-historico.test.js — Issue #4136 (CA-3 / CA-7).
+//   node --test .pipeline/test/dashboard-snapshot-historico.test.js
+//
+// Verifica que `_genPipelineState` (el snapshot del dashboard) recorre SOLO el
+// camino vivo (`<pipeline>/<fase>/{pendiente,trabajando,listo,procesado}`) y
+// NUNCA la raíz `historico/`.
+//
+// No booteamos el dashboard (arranca un server HTTP + workers al requerirlo):
+//   1. Invariante estructural: la raíz del histórico es hermana del camino vivo,
+//      nunca hija de un `<pipeline>/<fase>` que el snapshot walkea.
+//   2. Chequeo estático del walk: el cuerpo de `_genPipelineState` itera los 4
+//      estados vivos y no incluye `historico` en su lista de directorios.
+// =============================================================================
+
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const historico = require('../lib/historico');
+
+const CONFIG = {
+  pipelines: {
+    definicion: { fases: ['analisis', 'criterios', 'sizing'] },
+    desarrollo: { fases: ['validacion', 'dev', 'build', 'verificacion', 'linteo', 'aprobacion', 'entrega'] },
+  },
+};
+
+test('la raíz historico/ no es hija de ningún <pipeline>/<fase> que walkea el snapshot', () => {
+  const pipelineDir = path.resolve('/tmp/fake-pipeline');
+  const root = path.resolve(historico.historicoRoot(pipelineDir));
+  for (const [pName, pCfg] of Object.entries(CONFIG.pipelines)) {
+    for (const fase of pCfg.fases) {
+      const faseDir = path.resolve(path.join(pipelineDir, pName, fase));
+      assert.ok(
+        root !== faseDir && !root.startsWith(faseDir + path.sep),
+        `historico/ (${root}) NO debe estar dentro de ${faseDir}`,
+      );
+    }
+  }
+  // Y es hijo directo de pipelineDir (raíz aparte, mismo volumen).
+  assert.strictEqual(root, path.join(pipelineDir, 'historico'));
+});
+
+test('_genPipelineState walkea solo los 4 estados vivos, sin historico', () => {
+  const src = fs.readFileSync(path.join(__dirname, '..', 'dashboard.js'), 'utf8');
+
+  // Aislar el cuerpo del generador del snapshot.
+  const startIdx = src.indexOf('function* _genPipelineState()');
+  assert.ok(startIdx >= 0, 'debe existir _genPipelineState');
+  // Tomamos una ventana amplia del cuerpo (suficiente para cubrir el walk).
+  const body = src.slice(startIdx, startIdx + 4000);
+
+  // El walk de estados debe contener los 4 vivos…
+  for (const estado of ['pendiente', 'trabajando', 'listo', 'procesado']) {
+    assert.ok(body.includes(`'${estado}'`), `el walk debe incluir el estado '${estado}'`);
+  }
+  // …y NO debe incluir 'historico' como directorio walkeado.
+  assert.ok(!/['"]historico['"]/.test(body), 'el walk del snapshot NO debe referenciar historico');
+});

--- a/.pipeline/test/historico.test.js
+++ b/.pipeline/test/historico.test.js
@@ -1,0 +1,323 @@
+'use strict';
+
+// =============================================================================
+// historico.test.js — Issue #4136 (frontera activo/histórico).
+//   node --test .pipeline/test/historico.test.js
+//
+// Cubre los CA-7 del PO:
+//   - moverAHistorico mueve preservando contenido + registro append-only
+//   - archivarIssueTerminado NO archiva un issue con archivos en trabajando
+//   - archivarIssueTerminado archiva todas las fases de un issue cerrado
+//   - leerHistorico rechaza issue no numérico / traversal ../ / fase fuera de allowlist
+// =============================================================================
+
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const historico = require('../lib/historico');
+
+// Config mínima espejo de config.yaml (fases reales).
+const CONFIG = {
+  pipelines: {
+    definicion: { fases: ['analisis', 'criterios', 'sizing'] },
+    desarrollo: { fases: ['validacion', 'dev', 'build', 'verificacion', 'linteo', 'aprobacion', 'entrega'] },
+  },
+};
+
+function mkTmpPipeline() {
+  const dir = path.join(os.tmpdir(), `historico-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+  // crear todas las carpetas estado de todas las fases
+  for (const [pName, pCfg] of Object.entries(CONFIG.pipelines)) {
+    for (const fase of pCfg.fases) {
+      for (const estado of ['pendiente', 'trabajando', 'listo', 'procesado']) {
+        fs.mkdirSync(path.join(dir, pName, fase, estado), { recursive: true });
+      }
+    }
+  }
+  return dir;
+}
+
+function cleanup(dir) {
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* noop */ }
+}
+
+function writeMarker(dir, pipeline, fase, estado, fname, content) {
+  const p = path.join(dir, pipeline, fase, estado, fname);
+  fs.writeFileSync(p, content || `issue: ${fname.split('.')[0]}\n`);
+  return p;
+}
+
+// -----------------------------------------------------------------------------
+
+test('moverAHistorico mueve el artefacto de procesado a historico preservando contenido', () => {
+  const dir = mkTmpPipeline();
+  try {
+    const contenido = 'issue: 4136\nresultado: aprobado\n';
+    writeMarker(dir, 'desarrollo', 'dev', 'procesado', '4136.pipeline-dev', contenido);
+
+    const dest = historico.moverAHistorico({
+      issue: '4136', pipeline: 'desarrollo', fase: 'dev', fname: '4136.pipeline-dev', pipelineDir: dir,
+    });
+
+    assert.ok(fs.existsSync(dest), 'el destino debe existir');
+    assert.strictEqual(fs.readFileSync(dest, 'utf8'), contenido, 'contenido preservado');
+    assert.ok(!fs.existsSync(path.join(dir, 'desarrollo', 'dev', 'procesado', '4136.pipeline-dev')), 'origen ya no existe');
+    assert.strictEqual(dest, path.join(historico.historicoRoot(dir), 'desarrollo', 'dev', '4136.pipeline-dev'));
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test('la muda queda registrada en el log de transiciones (append-only)', () => {
+  const dir = mkTmpPipeline();
+  try {
+    writeMarker(dir, 'desarrollo', 'dev', 'procesado', '4136.pipeline-dev');
+    writeMarker(dir, 'desarrollo', 'build', 'procesado', '4136.build');
+    historico.moverAHistorico({ issue: '4136', pipeline: 'desarrollo', fase: 'dev', fname: '4136.pipeline-dev', pipelineDir: dir });
+    historico.moverAHistorico({ issue: '4136', pipeline: 'desarrollo', fase: 'build', fname: '4136.build', pipelineDir: dir });
+
+    const logPath = path.join(dir, historico.TRANSITIONS_LOG);
+    assert.ok(fs.existsSync(logPath), 'el log de transiciones debe existir');
+    const lines = fs.readFileSync(logPath, 'utf8').trim().split('\n');
+    assert.strictEqual(lines.length, 2, 'una línea por muda');
+    const rec = JSON.parse(lines[0]);
+    assert.strictEqual(rec.issue, '4136');
+    assert.strictEqual(rec.op, 'mover_a_historico');
+    assert.ok(rec.ts, 'cada registro lleva timestamp');
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test('archivarIssueTerminado NO archiva un issue con archivos en trabajando', () => {
+  const dir = mkTmpPipeline();
+  try {
+    // Terminal alcanzado, pero todavía activo en otra fase → NO archivable.
+    writeMarker(dir, 'desarrollo', 'entrega', 'procesado', '4136.delivery');
+    writeMarker(dir, 'desarrollo', 'dev', 'trabajando', '4136.pipeline-dev');
+
+    const r = historico.archivarIssueTerminado({ issue: '4136', config: CONFIG, pipelineDir: dir });
+
+    assert.strictEqual(r.archived, false, 'no archivable con trabajando activo');
+    assert.ok(fs.existsSync(path.join(dir, 'desarrollo', 'entrega', 'procesado', '4136.delivery')), 'procesado intacto');
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test('archivarIssueTerminado NO archiva un issue sin fase terminal ni closed', () => {
+  const dir = mkTmpPipeline();
+  try {
+    // En reposo pero solo llegó a dev/procesado (no terminal) y no está closed.
+    writeMarker(dir, 'desarrollo', 'dev', 'procesado', '4136.pipeline-dev');
+    const r = historico.archivarIssueTerminado({ issue: '4136', config: CONFIG, pipelineDir: dir });
+    assert.strictEqual(r.archived, false);
+    assert.ok(fs.existsSync(path.join(dir, 'desarrollo', 'dev', 'procesado', '4136.pipeline-dev')));
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test('archivarIssueTerminado archiva todas las fases de un issue cerrado', () => {
+  const dir = mkTmpPipeline();
+  try {
+    // En reposo, no llegó a terminal, pero está closed → archivable por isClosed.
+    writeMarker(dir, 'desarrollo', 'dev', 'procesado', '4136.pipeline-dev');
+    writeMarker(dir, 'desarrollo', 'verificacion', 'procesado', '4136.tester');
+    writeMarker(dir, 'definicion', 'criterios', 'procesado', '4136.po');
+
+    const r = historico.archivarIssueTerminado({
+      issue: '4136', config: CONFIG, pipelineDir: dir, isClosed: () => true,
+    });
+
+    assert.strictEqual(r.archived, true);
+    assert.strictEqual(r.moved.length, 3, 'mueve las 3 fases');
+    // Camino vivo vacío
+    for (const [p, f] of [['desarrollo', 'dev'], ['desarrollo', 'verificacion'], ['definicion', 'criterios']]) {
+      assert.ok(!fs.existsSync(path.join(dir, p, f, 'procesado', `4136.${f === 'dev' ? 'pipeline-dev' : f === 'verificacion' ? 'tester' : 'po'}`)));
+    }
+    // En histórico
+    assert.ok(fs.existsSync(path.join(historico.historicoRoot(dir), 'desarrollo', 'dev', '4136.pipeline-dev')));
+    assert.ok(fs.existsSync(path.join(historico.historicoRoot(dir), 'definicion', 'criterios', '4136.po')));
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test('archivarIssueTerminado archiva un issue que alcanzó la fase terminal (sin closed)', () => {
+  const dir = mkTmpPipeline();
+  try {
+    writeMarker(dir, 'desarrollo', 'entrega', 'procesado', '4136.delivery');
+    writeMarker(dir, 'desarrollo', 'dev', 'procesado', '4136.pipeline-dev');
+
+    const r = historico.archivarIssueTerminado({ issue: '4136', config: CONFIG, pipelineDir: dir });
+
+    assert.strictEqual(r.archived, true, 'terminal alcanzado → archivable sin isClosed');
+    assert.strictEqual(r.moved.length, 2);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test('archivarIssueTerminado solo toca el issue pedido (no arrastra otros)', () => {
+  const dir = mkTmpPipeline();
+  try {
+    writeMarker(dir, 'desarrollo', 'entrega', 'procesado', '4136.delivery');
+    writeMarker(dir, 'desarrollo', 'dev', 'procesado', '4137.pipeline-dev'); // otro issue activo
+    writeMarker(dir, 'desarrollo', 'dev', 'trabajando', '4137.pipeline-dev');
+
+    const r = historico.archivarIssueTerminado({ issue: '4136', config: CONFIG, pipelineDir: dir });
+
+    assert.strictEqual(r.archived, true);
+    assert.ok(fs.existsSync(path.join(dir, 'desarrollo', 'dev', 'procesado', '4137.pipeline-dev')), 'el otro issue intacto');
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test('prefijo exacto: el issue 4136 no arrastra artefactos de 41360', () => {
+  const dir = mkTmpPipeline();
+  try {
+    writeMarker(dir, 'desarrollo', 'entrega', 'procesado', '4136.delivery');
+    writeMarker(dir, 'desarrollo', 'entrega', 'procesado', '41360.delivery');
+
+    const r = historico.archivarIssueTerminado({ issue: '4136', config: CONFIG, pipelineDir: dir });
+
+    assert.strictEqual(r.moved.length, 1);
+    assert.ok(fs.existsSync(path.join(dir, 'desarrollo', 'entrega', 'procesado', '41360.delivery')), '41360 no se toca');
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test('barrerHistorico recorre procesado/ y archiva solo lo archivable', () => {
+  const dir = mkTmpPipeline();
+  try {
+    // 4136: terminal alcanzado + reposo → archivable
+    writeMarker(dir, 'desarrollo', 'entrega', 'procesado', '4136.delivery');
+    // 4137: en dev/procesado pero activo en trabajando → NO archivable
+    writeMarker(dir, 'desarrollo', 'dev', 'procesado', '4137.pipeline-dev');
+    writeMarker(dir, 'desarrollo', 'dev', 'trabajando', '4137.pipeline-dev');
+    // 4138: en sizing/procesado terminal de definicion → archivable
+    writeMarker(dir, 'definicion', 'sizing', 'procesado', '4138.planner');
+
+    const r = historico.barrerHistorico({ config: CONFIG, pipelineDir: dir });
+
+    assert.strictEqual(r.scanned, 3);
+    assert.deepStrictEqual(r.archivedIssues.sort(), ['4136', '4138']);
+    assert.ok(fs.existsSync(path.join(dir, 'desarrollo', 'dev', 'procesado', '4137.pipeline-dev')), '4137 sigue vivo');
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test('barrerHistorico es idempotente (segunda corrida no archiva nada nuevo)', () => {
+  const dir = mkTmpPipeline();
+  try {
+    writeMarker(dir, 'desarrollo', 'entrega', 'procesado', '4136.delivery');
+    const r1 = historico.barrerHistorico({ config: CONFIG, pipelineDir: dir });
+    const r2 = historico.barrerHistorico({ config: CONFIG, pipelineDir: dir });
+    assert.strictEqual(r1.archivedIssues.length, 1);
+    assert.strictEqual(r2.archivedIssues.length, 0, 'segunda corrida no re-archiva');
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test('barrerHistorico respeta el cap max', () => {
+  const dir = mkTmpPipeline();
+  try {
+    writeMarker(dir, 'desarrollo', 'entrega', 'procesado', '4136.delivery');
+    writeMarker(dir, 'desarrollo', 'entrega', 'procesado', '4137.delivery');
+    writeMarker(dir, 'desarrollo', 'entrega', 'procesado', '4138.delivery');
+    const r = historico.barrerHistorico({ config: CONFIG, pipelineDir: dir, max: 1 });
+    assert.strictEqual(r.archivedIssues.length, 1, 'solo archiva 1 con max=1');
+  } finally {
+    cleanup(dir);
+  }
+});
+
+// --- leerHistorico (seguridad) -----------------------------------------------
+
+test('leerHistorico devuelve los archivos del issue por id', () => {
+  const dir = mkTmpPipeline();
+  try {
+    writeMarker(dir, 'desarrollo', 'entrega', 'procesado', '4136.delivery');
+    historico.archivarIssueTerminado({ issue: '4136', config: CONFIG, pipelineDir: dir });
+    const files = historico.leerHistorico({ issue: '4136', pipeline: 'desarrollo', fase: 'entrega', config: CONFIG, pipelineDir: dir });
+    assert.deepStrictEqual(files, ['4136.delivery']);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test('leerHistorico rechaza issue no numérico', () => {
+  const dir = mkTmpPipeline();
+  try {
+    assert.throws(
+      () => historico.leerHistorico({ issue: 'abc', pipeline: 'desarrollo', fase: 'dev', config: CONFIG, pipelineDir: dir }),
+      /issue inválido/,
+    );
+    assert.throws(
+      () => historico.leerHistorico({ issue: '12; rm -rf', pipeline: 'desarrollo', fase: 'dev', config: CONFIG, pipelineDir: dir }),
+      /issue inválido/,
+    );
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test('leerHistorico rechaza path traversal con ../', () => {
+  const dir = mkTmpPipeline();
+  try {
+    assert.throws(
+      () => historico.leerHistorico({ issue: '4136', pipeline: '../../etc', fase: 'dev', config: CONFIG, pipelineDir: dir }),
+      /pipeline inválido/,
+    );
+    assert.throws(
+      () => historico.leerHistorico({ issue: '4136', pipeline: 'desarrollo', fase: '../../../secrets', config: CONFIG, pipelineDir: dir }),
+      /fase inválida/,
+    );
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test('leerHistorico rechaza fase fuera de la allowlist de config', () => {
+  const dir = mkTmpPipeline();
+  try {
+    assert.throws(
+      () => historico.leerHistorico({ issue: '4136', pipeline: 'desarrollo', fase: 'inexistente', config: CONFIG, pipelineDir: dir }),
+      /fase inválida/,
+    );
+    assert.throws(
+      () => historico.leerHistorico({ issue: '4136', pipeline: 'pipeline-falso', fase: 'dev', config: CONFIG, pipelineDir: dir }),
+      /pipeline inválido/,
+    );
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test('historicoRoot está en el mismo volumen que el pipeline (CA-1)', () => {
+  const dir = mkTmpPipeline();
+  try {
+    assert.ok(historico.assertSameVolume(dir));
+    assert.strictEqual(historico.historicoRoot(dir), path.join(dir, 'historico'));
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test('estaEnReposo es false si hay archivos en pendiente/listo de cualquier fase', () => {
+  const dir = mkTmpPipeline();
+  try {
+    writeMarker(dir, 'desarrollo', 'build', 'pendiente', '4136.build');
+    assert.strictEqual(historico.estaEnReposo({ issue: '4136', config: CONFIG, pipelineDir: dir }), false);
+  } finally {
+    cleanup(dir);
+  }
+});


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 8 archivos · +770 -2

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:skipped` aplicado por delivery

## Closes

Closes #4136
