### PR TITLE
El estado de la ola no llega limpio a Telegram: envelope visible (pipeline-meta + notis init/completion de wave) y tabla real incompleta

### DIFF
--- a/.pipeline/config.yaml
+++ b/.pipeline/config.yaml
@@ -816,6 +816,18 @@ deliverable_notifications:
 #                             agent. Doble check con regex `^[a-z][a-z0-9-]{0,40}$`.
 #                             Comandos fuera de esta lista → audit
 #                             `invalid_command` y NO notifican.
+#   - query_only_commands:    (#4145) subconjunto de `allowed_commands` que son
+#                             solo-consulta de estado. Saltean el auto-emit de
+#                             notis `init`/`completion` (y su envelope
+#                             `<!-- pipeline-meta -->`): la respuesta del handler
+#                             ya es la entrega, las notis serían ruido en Telegram.
+#                             NUNCA incluir comandos con efecto lateral (pausar,
+#                             reanudar, restart, stop, limpiar, load-wave,
+#                             allowlist, dashboard-up/down, ghostbusters, descanso):
+#                             esos SÍ deben emitir trazabilidad. Un comando aquí
+#                             que no esté en `allowed_commands` simplemente no
+#                             tiene efecto (el gate exige ambas listas). El audit
+#                             (`auditLog.record`) corre igual para todos.
 #   - truncate_chars:         max chars del preview narrable. Excede →
 #                             truncatePreserveLines + ' (continúa en el issue)'.
 #                             Default 1500 (igual que pipeline issues).
@@ -876,6 +888,19 @@ cua:
     - restart
     - bloqueados
     - stop
+  # Comandos solo-consulta: saltean el auto-emit de notis init/completion
+  # (#4145). La respuesta del handler ya es la entrega; las notis serían ruido.
+  # NO incluir comandos con efecto lateral (ver doc del bloque arriba).
+  query_only_commands:
+    - wave
+    - status
+    - listado
+    - snapshot
+    - salud
+    - quota
+    - actividad
+    - costos
+    - bloqueados
   truncate_chars: 1500
   dedup_window_hours: 1
   max_attachment_bytes: 5242880  # 5 MB (CA-SEC-2)

--- a/.pipeline/lib/commander-deterministic.js
+++ b/.pipeline/lib/commander-deterministic.js
@@ -697,7 +697,7 @@ function validateArgs(command, args) {
  * @param {string} opts.telegramQueueDir
  * @param {object} [opts.deps]
  * @param {function} [opts.log] - logger del caller (pulpo.log) para visibilidad.
- * @returns {{ emit: function, enabled: boolean, notifiableStages: string[], allowedCommands: string[] }}
+ * @returns {{ emit: function, enabled: boolean, notifiableStages: string[], allowedCommands: string[], queryOnlyCommands: string[] }}
  */
 function createCuaEmitter(opts) {
     const o = opts || {};
@@ -707,6 +707,11 @@ function createCuaEmitter(opts) {
         ? cfg.notifiable_stages
         : [];
     const allowedCommands = Array.isArray(cfg.allowed_commands) ? cfg.allowed_commands : [];
+    // #4145 — comandos solo-consulta: saltean el auto-emit de notis
+    // `init`/`completion`. La respuesta del handler ya es la entrega; las notis
+    // serían ruido (header `⚙️ /wave · init` + envelope `<!-- pipeline-meta -->`).
+    // Default `[]` si ausente (rollout seguro: sin la lista, comportamiento previo).
+    const queryOnlyCommands = Array.isArray(cfg.query_only_commands) ? cfg.query_only_commands : [];
     const log = typeof o.log === 'function' ? o.log : (() => {});
 
     function emit(entregable) {
@@ -760,6 +765,7 @@ function createCuaEmitter(opts) {
         enabled,
         notifiableStages,
         allowedCommands,
+        queryOnlyCommands,
     };
 }
 
@@ -1020,9 +1026,16 @@ function createDispatcher(opts) {
         // del handler y `completion` después. Los handlers pueden también
         // emitir `validation`/`analysis` desde dentro usando `ctx.cuaEmit`.
         // Cumple CA-FUNC-6 (enqueue por stage) y CA-TEC-2 (filtro en caller).
+        // #4145 — los comandos solo-consulta (`cua.query_only_commands`, ej.
+        // `wave`) saltean el auto-emit: su respuesta YA es la entrega y las
+        // notis init/completion (con su envelope) son ruido en Telegram. NO se
+        // toca `ctx.cuaEmit` (un handler query-only puede emitir stages manuales
+        // si los necesita) ni `buildCuaText`/`buildCuaEnvelope` (el envelope
+        // legítimo del path reply-to de entregables de issues queda intacto).
         const cuaShouldAutoEmit = cuaEmitter.enabled
             && cuaEmitter.allowedCommands.length > 0
-            && cuaEmitter.allowedCommands.includes(intent.command);
+            && cuaEmitter.allowedCommands.includes(intent.command)
+            && !cuaEmitter.queryOnlyCommands.includes(intent.command);
         const handlerStartedAt = now();
         if (cuaShouldAutoEmit) {
             cuaEmitter.emit({

--- a/.pipeline/tests/cua-notifications.test.js
+++ b/.pipeline/tests/cua-notifications.test.js
@@ -590,6 +590,96 @@ test('handler puede emitir stages intermedios via ctx.cuaEmit', async () => {
 });
 
 // ---------------------------------------------------------------------------
+// #4145 — comandos query-only saltean el auto-emit init/completion
+// ---------------------------------------------------------------------------
+
+test('#4145 — createCuaEmitter expone queryOnlyCommands desde config', () => {
+    const e = cd.createCuaEmitter({ config: { enabled: true, query_only_commands: ['wave', 'status'] } });
+    assert.deepEqual(e.queryOnlyCommands, ['wave', 'status']);
+    // Ausente o no-array → default [] (rollout seguro: comportamiento previo).
+    const e2 = cd.createCuaEmitter({ config: { enabled: true } });
+    assert.deepEqual(e2.queryOnlyCommands, []);
+    const e3 = cd.createCuaEmitter({ config: { enabled: true, query_only_commands: 'wave' } });
+    assert.deepEqual(e3.queryOnlyCommands, []);
+});
+
+test('#4145 — comando query-only (wave) NO dispara auto-emit init/completion', async () => {
+    const tmp = mkTmp('query-only');
+    const calls = [];
+    const fakeMod = {
+        notifyCua: (a) => { calls.push(a.entregable); return { ok: true, action: 'enqueued' }; },
+    };
+    cd.DETERMINISTIC_SLASH.add('wave');
+    try {
+        const d = cd.createDispatcher({
+            pipelineRoot: tmp,
+            logsDir: tmp,
+            expectedChatId: '1',
+            handlers: { 'wave': () => ({ reply: 'TABLA DE ESTADO' }) },
+            cua: {
+                config: {
+                    enabled: true,
+                    allowed_commands: ['wave'],
+                    query_only_commands: ['wave'],
+                    notifiable_stages: ['init', 'completion'],
+                    audit_file: path.join(tmp, 'audit.jsonl'),
+                },
+                pipelineRoot: tmp,
+                telegramQueueDir: path.join(tmp, 'queue'),
+                deps: { deliverableNotify: fakeMod },
+            },
+        });
+        const r = await d.dispatch({ chat_id: '1', text: '/wave', from: 'tester' });
+        assert.equal(r.status, 'ok');
+        assert.equal(r.reply, 'TABLA DE ESTADO', 'la tabla del handler llega intacta');
+        assert.equal(calls.length, 0, 'query-only NO debe emitir notis CUA (sin init/completion ni envelope)');
+        // CA-3: ninguna noti se encoló → la tabla queda como único contenido.
+        const queueFiles = fs.readdirSync(path.join(tmp, 'queue'));
+        assert.equal(queueFiles.length, 0, 'no debe encolarse ninguna noti CUA para wave');
+    } finally {
+        cd.DETERMINISTIC_SLASH.delete('wave');
+    }
+});
+
+test('#4145 — comando mutador (pausar) SIGUE emitiendo init/completion (no-regresión)', async () => {
+    const tmp = mkTmp('mutator');
+    const calls = [];
+    const fakeMod = {
+        notifyCua: (a) => { calls.push(a.entregable); return { ok: true, action: 'enqueued' }; },
+    };
+    cd.DETERMINISTIC_SLASH.add('pausar');
+    try {
+        const d = cd.createDispatcher({
+            pipelineRoot: tmp,
+            logsDir: tmp,
+            expectedChatId: '1',
+            handlers: { 'pausar': () => ({ reply: 'OK' }) },
+            cua: {
+                config: {
+                    enabled: true,
+                    // `pausar` está en allowed pero NO en query_only → mutador.
+                    allowed_commands: ['pausar', 'wave'],
+                    query_only_commands: ['wave'],
+                    notifiable_stages: ['init', 'completion'],
+                    audit_file: path.join(tmp, 'audit.jsonl'),
+                },
+                pipelineRoot: tmp,
+                telegramQueueDir: path.join(tmp, 'queue'),
+                deps: { deliverableNotify: fakeMod },
+            },
+        });
+        const r = await d.dispatch({ chat_id: '1', text: '/pausar', from: 'tester' });
+        assert.equal(r.status, 'ok');
+        assert.equal(calls.length, 2, 'init + completion siguen emitiéndose para mutadores');
+        assert.equal(calls[0].stage, 'init');
+        assert.equal(calls[1].stage, 'completion');
+        assert.equal(calls[1].status, 'ok');
+    } finally {
+        cd.DETERMINISTIC_SLASH.delete('pausar');
+    }
+});
+
+// ---------------------------------------------------------------------------
 // parseCuaTextArgs
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 3 archivos · +130 -2

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:skipped` aplicado por delivery

## Closes

Closes #4145
