### PR TITLE
Test flaky de probe heredado de #4155 hace rebotar verificaciones ajenas (debe ser determinista)

### DIFF
--- a/.pipeline/skills-deterministicos/__tests__/build.test.js
+++ b/.pipeline/skills-deterministicos/__tests__/build.test.js
@@ -8,6 +8,26 @@ const assert = require('node:assert/strict');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const { EventEmitter } = require('events');
+
+// #4164 — Stub in-process del probe del lock. Reemplaza el spawn real de un
+// proceso `node` (load-sensitive: EAGAIN/EMFILE al forkear bajo saturación → el
+// test rebotaba con exit_code 1) por una réplica determinista de la lógica del
+// probe: lee el lockfile y escribe el marker síncronamente, luego emite exit 0.
+// Solo se inyecta vía el parámetro `spawnFn` de runGradle/spawnGradle (DI de test).
+function fakeProbeSpawn(_cmd, _args, opts) {
+    const env = (opts && opts.env) || {};
+    try {
+        if (env.MARKER) {
+            fs.writeFileSync(env.MARKER, fs.existsSync(env.LOCKFILE) ? 'held' : 'free');
+        }
+    } catch {}
+    const child = new EventEmitter();
+    child.stdout = null;
+    child.stderr = null;
+    process.nextTick(() => child.emit('exit', 0));
+    return child;
+}
 
 // Aislar REPO_ROOT a un tmp — el módulo resuelve paths a partir de env vars.
 const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'v3-build-'));
@@ -266,22 +286,17 @@ test('runGradle envuelve el spawn con el lock global de Gradle (#4155)', async (
     const lockLogical = path.join(TMP, 'build-gradle.lock');
     const lockFile = `${lockLogical}.lock`;
     const marker = path.join(TMP, 'lock-probe.marker');
-    const probe = path.join(TMP, 'lock-probe.js');
     process.env.GRADLE_LOCK_PATH = lockLogical;
-    fs.writeFileSync(
-        probe,
-        "const fs=require('fs');"
-        + "fs.writeFileSync(process.env.MARKER, fs.existsSync(process.env.LOCKFILE)?'held':'free');",
-    );
     try {
         delete require.cache[require.resolve('../../lib/gradle-lock')];
         delete require.cache[require.resolve('../build')];
         const b = require('../build');
         const res = await b.runGradle({
             cmd: 'node',
-            args: [probe],
+            args: [],
             cwd: TMP,
             env: { ...process.env, LOCKFILE: lockFile, MARKER: marker },
+            spawnFn: fakeProbeSpawn,
         });
         assert.equal(res.exit_code, 0, 'el proceso probe debe salir 0');
         assert.equal(fs.readFileSync(marker, 'utf8'), 'held', 'el lock debe estar tomado durante el spawn');
@@ -300,20 +315,15 @@ test('spawnGradle NO toma el lock global (#4155)', async () => {
     const lockLogical = path.join(TMP, 'build-spawn.lock');
     const lockFile = `${lockLogical}.lock`;
     const marker = path.join(TMP, 'spawn-probe.marker');
-    const probe = path.join(TMP, 'spawn-probe.js');
     process.env.GRADLE_LOCK_PATH = lockLogical;
-    fs.writeFileSync(
-        probe,
-        "const fs=require('fs');"
-        + "fs.writeFileSync(process.env.MARKER, fs.existsSync(process.env.LOCKFILE)?'held':'free');",
-    );
     try {
         const b = require('../build');
         const res = await b.spawnGradle({
             cmd: 'node',
-            args: [probe],
+            args: [],
             cwd: TMP,
             env: { ...process.env, LOCKFILE: lockFile, MARKER: marker },
+            spawnFn: fakeProbeSpawn,
         });
         assert.equal(res.exit_code, 0);
         assert.equal(fs.readFileSync(marker, 'utf8'), 'free', 'spawnGradle no debe tomar el lock');
@@ -321,4 +331,46 @@ test('spawnGradle NO toma el lock global (#4155)', async () => {
         if (savedLock === undefined) delete process.env.GRADLE_LOCK_PATH;
         else process.env.GRADLE_LOCK_PATH = savedLock;
     }
+});
+
+// #4164 — Wiring de la inyección: `spawnGradle` debe invocar el `spawnFn` provisto
+// (espía) en vez del spawn real, forwardeando cmd/args/opts intactos. Prueba que el
+// punto de DI funciona sin forkear ningún proceso.
+test('spawnGradle invoca el spawnFn inyectado (wiring #4164)', async () => {
+    const b = require('../build');
+    let calls = 0;
+    let seenCmd = null;
+    let seenArgs = null;
+    const spy = (cmd, args) => {
+        calls += 1;
+        seenCmd = cmd;
+        seenArgs = args;
+        const child = new EventEmitter();
+        child.stdout = null;
+        child.stderr = null;
+        process.nextTick(() => child.emit('exit', 0));
+        return child;
+    };
+    const res = await b.spawnGradle({ cmd: 'node', args: ['--version'], cwd: TMP, env: process.env, spawnFn: spy });
+    assert.equal(calls, 1, 'el spawnFn inyectado debe invocarse exactamente una vez');
+    assert.equal(seenCmd, 'node', 'el cmd debe forwardearse sin cambios (resolveBashCommand solo reescribe cmd === "bash")');
+    assert.deepEqual(seenArgs, ['--version'], 'los args deben forwardearse intactos');
+    assert.equal(res.exit_code, 0);
+});
+
+// #4164 — Determinismo del caso de fallo: si el proceso emite `error`, el helper
+// resuelve exit_code 1 de forma determinista (cubre el path de retry/fallo sin
+// depender de saturación real del SO).
+test('spawnGradle resuelve exit_code 1 ante error del proceso (fallo determinista #4164)', async () => {
+    const b = require('../build');
+    const failingSpawn = () => {
+        const child = new EventEmitter();
+        child.stdout = null;
+        child.stderr = null;
+        process.nextTick(() => child.emit('error', new Error('EAGAIN simulado')));
+        return child;
+    };
+    const res = await b.spawnGradle({ cmd: 'node', args: [], cwd: TMP, env: process.env, spawnFn: failingSpawn });
+    assert.equal(res.exit_code, 1, 'el error del proceso debe mapear a exit_code 1 de forma determinista');
+    assert.match(res.stderr, /\[spawn-error\]/, 'el stderr debe registrar el spawn-error');
 });

--- a/.pipeline/skills-deterministicos/__tests__/tester.test.js
+++ b/.pipeline/skills-deterministicos/__tests__/tester.test.js
@@ -13,6 +13,26 @@ const assert = require('node:assert/strict');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const { EventEmitter } = require('events');
+
+// #4164 — Stub in-process del probe del lock (idéntico al de build.test.js).
+// Reemplaza el spawn real de `node` (load-sensitive: EAGAIN/EMFILE al forkear bajo
+// saturación → rebotaba con exit_code 1) por una réplica determinista: lee el
+// lockfile y escribe el marker síncronamente, luego emite exit 0. Solo se inyecta
+// vía el parámetro `spawnFn` de runGradle/spawnGradle (DI exclusiva de test).
+function fakeProbeSpawn(_cmd, _args, opts) {
+    const env = (opts && opts.env) || {};
+    try {
+        if (env.MARKER) {
+            fs.writeFileSync(env.MARKER, fs.existsSync(env.LOCKFILE) ? 'held' : 'free');
+        }
+    } catch {}
+    const child = new EventEmitter();
+    child.stdout = null;
+    child.stderr = null;
+    process.nextTick(() => child.emit('exit', 0));
+    return child;
+}
 
 // rebote #2891 rev-3: garantizar git en PATH antes de invocar `execSync('git ...')`.
 // El test `findIssueWorktree` arma un repo temporal con `git init` y depende
@@ -1413,22 +1433,17 @@ test('runGradle del tester envuelve el spawn con el lock global de Gradle (#4155
     const lockLogical = path.join(TMP, 'tester-gradle.lock');
     const lockFile = `${lockLogical}.lock`;
     const marker = path.join(TMP, 'tester-lock-probe.marker');
-    const probe = path.join(TMP, 'tester-lock-probe.js');
     process.env.GRADLE_LOCK_PATH = lockLogical;
-    fs.writeFileSync(
-        probe,
-        "const fs=require('fs');"
-        + "fs.writeFileSync(process.env.MARKER, fs.existsSync(process.env.LOCKFILE)?'held':'free');",
-    );
     try {
         delete require.cache[require.resolve('../../lib/gradle-lock')];
         delete require.cache[require.resolve('../tester')];
         const t = require('../tester');
         const res = await t.runGradle({
             cmd: 'node',
-            args: [probe],
+            args: [],
             cwd: TMP,
             env: { ...process.env, LOCKFILE: lockFile, MARKER: marker },
+            spawnFn: fakeProbeSpawn,
         });
         assert.equal(res.exit_code, 0, 'el proceso probe debe salir 0');
         assert.equal(fs.readFileSync(marker, 'utf8'), 'held', 'el lock debe estar tomado durante el spawn');
@@ -1446,19 +1461,14 @@ test('spawnGradle del tester NO toma el lock global (#4155)', async () => {
     const lockLogical = path.join(TMP, 'tester-spawn.lock');
     const lockFile = `${lockLogical}.lock`;
     const marker = path.join(TMP, 'tester-spawn-probe.marker');
-    const probe = path.join(TMP, 'tester-spawn-probe.js');
     process.env.GRADLE_LOCK_PATH = lockLogical;
-    fs.writeFileSync(
-        probe,
-        "const fs=require('fs');"
-        + "fs.writeFileSync(process.env.MARKER, fs.existsSync(process.env.LOCKFILE)?'held':'free');",
-    );
     try {
         const res = await tester.spawnGradle({
             cmd: 'node',
-            args: [probe],
+            args: [],
             cwd: TMP,
             env: { ...process.env, LOCKFILE: lockFile, MARKER: marker },
+            spawnFn: fakeProbeSpawn,
         });
         assert.equal(res.exit_code, 0);
         assert.equal(fs.readFileSync(marker, 'utf8'), 'free', 'spawnGradle no debe tomar el lock');
@@ -1466,6 +1476,44 @@ test('spawnGradle del tester NO toma el lock global (#4155)', async () => {
         if (savedLock === undefined) delete process.env.GRADLE_LOCK_PATH;
         else process.env.GRADLE_LOCK_PATH = savedLock;
     }
+});
+
+// #4164 — Wiring de la inyección: `spawnGradle` del tester debe invocar el `spawnFn`
+// provisto (espía) en vez del spawn real, forwardeando cmd/args intactos.
+test('spawnGradle del tester invoca el spawnFn inyectado (wiring #4164)', async () => {
+    let calls = 0;
+    let seenCmd = null;
+    let seenArgs = null;
+    const spy = (cmd, args) => {
+        calls += 1;
+        seenCmd = cmd;
+        seenArgs = args;
+        const child = new EventEmitter();
+        child.stdout = null;
+        child.stderr = null;
+        process.nextTick(() => child.emit('exit', 0));
+        return child;
+    };
+    const res = await tester.spawnGradle({ cmd: 'node', args: ['--version'], cwd: TMP, env: process.env, spawnFn: spy });
+    assert.equal(calls, 1, 'el spawnFn inyectado debe invocarse exactamente una vez');
+    assert.equal(seenCmd, 'node', 'el cmd debe forwardearse sin cambios');
+    assert.deepEqual(seenArgs, ['--version'], 'los args deben forwardearse intactos');
+    assert.equal(res.exit_code, 0);
+});
+
+// #4164 — Determinismo del caso de fallo del tester: si el proceso emite `error`,
+// el helper resuelve exit_code 1 de forma determinista.
+test('spawnGradle del tester resuelve exit_code 1 ante error del proceso (#4164)', async () => {
+    const failingSpawn = () => {
+        const child = new EventEmitter();
+        child.stdout = null;
+        child.stderr = null;
+        process.nextTick(() => child.emit('error', new Error('EAGAIN simulado')));
+        return child;
+    };
+    const res = await tester.spawnGradle({ cmd: 'node', args: [], cwd: TMP, env: process.env, spawnFn: failingSpawn });
+    assert.equal(res.exit_code, 1, 'el error del proceso debe mapear a exit_code 1 de forma determinista');
+    assert.match(res.stderr, /\[spawn-error\]/, 'el stderr debe registrar el spawn-error');
 });
 
 // ── Rebote #4155 rev-1 ────────────────────────────────────────────────

--- a/.pipeline/skills-deterministicos/build.js
+++ b/.pipeline/skills-deterministicos/build.js
@@ -167,17 +167,23 @@ function resolveBashCommand(cmd) {
 // NUNCA corra en simultáneo con otra invocación pesada (build/tester) de otro
 // agente (CA-4). Si el lock está tomado, encola hasta que se libera. El lock se
 // libera en `finally` aunque el spawn falle (auto-release, CA-5).
-function runGradle({ cmd, args, cwd, env }) {
-    return withGradleLock(() => spawnGradle({ cmd, args, cwd, env }));
+// `spawnFn` es un parámetro de inyección OPCIONAL exclusivo para tests (#4164):
+// permite reemplazar el `spawn` real por un stub in-process y volver determinista
+// el test del probe. SEGURIDAD: NUNCA debe leerse de env/config/runtime — solo se
+// inyecta como argumento de función desde el test — para no convertir la DI en un
+// sink de RCE. El default preserva el comportamiento productivo exacto.
+function runGradle({ cmd, args, cwd, env, spawnFn }) {
+    return withGradleLock(() => spawnGradle({ cmd, args, cwd, env, spawnFn }));
 }
 
-function spawnGradle({ cmd, args, cwd, env }) {
+function spawnGradle({ cmd, args, cwd, env, spawnFn }) {
+    const _spawn = spawnFn || spawn;
     return new Promise((resolve) => {
         const started = Date.now();
         let stdout = '';
         let stderr = '';
         const { cmd: resolvedCmd, useShell } = resolveBashCommand(cmd);
-        const child = spawn(resolvedCmd, args, { cwd, env, shell: useShell, windowsHide: true });
+        const child = _spawn(resolvedCmd, args, { cwd, env, shell: useShell, windowsHide: true });
         if (child.stdout) child.stdout.on('data', (d) => { stdout += d.toString(); });
         if (child.stderr) child.stderr.on('data', (d) => { stderr += d.toString(); });
         child.on('error', (e) => {

--- a/.pipeline/skills-deterministicos/tester.js
+++ b/.pipeline/skills-deterministicos/tester.js
@@ -1114,16 +1114,22 @@ function allExpectedTestTasksUpToDate(stdout, modules) {
 // es parte de la causa raíz del incidente inter-agente del 2026-06-24. Con el
 // lock, la suite de tests encola en vez de competir por CPU/RAM (CA-4). El lock
 // se libera en `finally` aunque el spawn falle (auto-release, CA-5).
-function runGradle({ cmd, args, cwd, env }) {
-    return withGradleLock(() => spawnGradle({ cmd, args, cwd, env }));
+// `spawnFn` es un parámetro de inyección OPCIONAL exclusivo para tests (#4164):
+// permite reemplazar el `spawn` real por un stub in-process y volver determinista
+// el test del probe. SEGURIDAD: NUNCA debe leerse de env/config/runtime — solo se
+// inyecta como argumento de función desde el test — para no convertir la DI en un
+// sink de RCE. El default preserva el comportamiento productivo exacto.
+function runGradle({ cmd, args, cwd, env, spawnFn }) {
+    return withGradleLock(() => spawnGradle({ cmd, args, cwd, env, spawnFn }));
 }
 
-function spawnGradle({ cmd, args, cwd, env }) {
+function spawnGradle({ cmd, args, cwd, env, spawnFn }) {
+    const _spawn = spawnFn || spawn;
     return new Promise((resolve) => {
         const started = Date.now();
         let stdout = '';
         let stderr = '';
-        const child = spawn(cmd, args, { cwd, env, shell: process.platform === 'win32', windowsHide: true });
+        const child = _spawn(cmd, args, { cwd, env, shell: process.platform === 'win32', windowsHide: true });
         if (child.stdout) child.stdout.on('data', (d) => { stdout += d.toString(); });
         if (child.stderr) child.stderr.on('data', (d) => { stderr += d.toString(); });
         child.on('error', (e) => {


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 4 archivos · +148 -36

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:passed` aplicado por delivery

## Closes

Closes #4164
