### PR TITLE
fix(pipeline): subir threshold de liveness del Pulpo 90s->180s para evitar kill prematuro en arranque

### DIFF
--- a/.pipeline/config.yaml
+++ b/.pipeline/config.yaml
@@ -412,7 +412,7 @@ watchdog:
   # 90s = max(90, 3×poll_interval) evita falsos positivos (CA-4) y restart-storms
   # (SEC-3). Override por env PULPO_LIVENESS_KILL_SECONDS (entero positivo;
   # inválido → default, NUNCA "nunca stale" — SEC-2).
-  pulpo_liveness_kill_seconds: 90
+  pulpo_liveness_kill_seconds: 180
 
 # Dashboard — opciones del dashboard del pipeline
 dashboard:


### PR DESCRIPTION
## Contexto

Parche en caliente aplicado en produccion durante la madrugada del 2026-06-25, **versionado ahora para que no se pierda**.

El control de liveness del Pulpo introducido en #4163 ("detectar zombi y reiniciar") quedo demasiado agresivo: el umbral de 90s mataba al Pulpo de forma prematura durante el arranque, provocando un periodo de ~2hs sin respuesta del Commander.

## Cambio

`.pipeline/config.yaml` - `watchdog.pulpo_liveness_kill_seconds`: **90 -> 180**.

Una linea. Sube el margen antes de declarar al Pulpo zombi, evitando el kill prematuro en arranque sin desactivar la deteccion de liveness.

## QA

`qa:skipped` - cambio puro de configuracion de infra del pipeline (watchdog), sin impacto en producto de usuario (app/backend).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

Generated with Claude Code