### PR TITLE
[Split de #3946] Evidencia QA fuera de git (Drive upload + .gitignore)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,11 +64,21 @@ qa/artifacts/
 # QA E2E — tests generados (efímeros, se regeneran con /qa validate)
 qa/generated/
 
-# QA E2E — evidencias versionadas (NO ignorar)
+# QA E2E — evidencias versionadas (NO ignorar la carpeta)
 !qa/evidence/
-# QA E2E — videos locales (pesados, se suben a Google Drive)
+# QA E2E — assets binarios locales (pesados / posible PII, se suben a Google Drive — #4173)
 qa/evidence/**/*.mp4
 qa/evidence/**/*.mp4.tmp
+qa/evidence/**/*.png
+qa/evidence/**/*.zip
+qa/evidence/**/*.html
+qa/evidence/**/*.mp3
+# Re-incluir SOLO los metadatos tracked (orden importa: el ! va DESPUES del ignore — #4173)
+!qa/evidence/**/*.json
+!qa/evidence/**/.gitkeep
+# SEC-3 — configs con credenciales nunca a git (defensivo, aunque no existan hoy — #4173)
+qa/scripts/telegram-config.json
+**/service-account*.json
 .maestro/tests/
 
 # Claude Code — estado de sesión y logs (no commitear)

--- a/qa/scripts/__tests__/qa-asset-share.test.js
+++ b/qa/scripts/__tests__/qa-asset-share.test.js
@@ -1,0 +1,114 @@
+// =============================================================================
+// Tests qa-video-share.js — modo assets / qa-results.json — Issue #4173
+//
+// Cubre los controles que el cierre de /qa debe garantizar para sacar la
+// evidencia binaria de git sin filtrar material de firma:
+//   - isCanonicalUrl: distingue webViewLink de Drive (canónica) vs presigned R2
+//     con X-Amz-*/Signature= (SEC-1).
+//   - updateQaResults: shape {video_url, assets[{name,type,url}]}, descarta URLs
+//     con material de firma (SEC-1), merge idempotente por name, preserva
+//     video_url entre escrituras, crea carpeta/archivo si no existen.
+//   - require() del módulo NO auto-ejecuta main() (guard require.main, evita
+//     doble envío Telegram).
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const { updateQaResults, isCanonicalUrl } = require('../qa-video-share');
+
+// updateQaResults escribe siempre bajo <repo>/qa/evidence/<issue>/, derivado de
+// __dirname. Usamos un issue sentinela improbable y limpiamos al terminar.
+const TEST_ISSUE = '9990001';
+const PROJECT_ROOT = path.resolve(__dirname, '../../..');
+const RESULTS_DIR = path.join(PROJECT_ROOT, 'qa', 'evidence', TEST_ISSUE);
+const RESULTS_PATH = path.join(RESULTS_DIR, 'qa-results.json');
+
+function cleanup() {
+    try { fs.rmSync(RESULTS_DIR, { recursive: true, force: true }); } catch { /* noop */ }
+}
+
+const DRIVE_URL = 'https://drive.google.com/file/d/AAA111/view';
+const DRIVE_URL_2 = 'https://drive.google.com/file/d/BBB222/view';
+const PRESIGNED = 'https://acct.r2.cloudflarestorage.com/qa/x.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Signature=deadbeef';
+
+test('isCanonicalUrl acepta webViewLink de Drive y rechaza presigned/vacío', () => {
+    assert.equal(isCanonicalUrl(DRIVE_URL), true);
+    assert.equal(isCanonicalUrl(PRESIGNED), false);
+    assert.equal(isCanonicalUrl('https://x/y?Signature=abc'), false);
+    assert.equal(isCanonicalUrl(''), false);
+    assert.equal(isCanonicalUrl(null), false);
+    assert.equal(isCanonicalUrl(undefined), false);
+});
+
+test('updateQaResults crea qa-results.json con el shape esperado', () => {
+    cleanup();
+    updateQaResults(TEST_ISSUE, [
+        { name: 'screenshot-1.png', type: 'png', url: DRIVE_URL },
+    ], DRIVE_URL);
+
+    assert.ok(fs.existsSync(RESULTS_PATH), 'qa-results.json debe existir');
+    const out = JSON.parse(fs.readFileSync(RESULTS_PATH, 'utf8'));
+    assert.equal(out.video_url, DRIVE_URL);
+    assert.deepEqual(out.assets, [
+        { name: 'screenshot-1.png', type: 'png', url: DRIVE_URL },
+    ]);
+    cleanup();
+});
+
+test('updateQaResults descarta URLs con material de firma (SEC-1)', () => {
+    cleanup();
+    updateQaResults(TEST_ISSUE, [
+        { name: 'ok.png', type: 'png', url: DRIVE_URL },
+        { name: 'evil.zip', type: 'zip', url: PRESIGNED },
+    ], PRESIGNED);
+
+    const raw = fs.readFileSync(RESULTS_PATH, 'utf8');
+    assert.equal(/X-Amz-|Signature=/.test(raw), false, 'sin material de firma en el JSON');
+
+    const out = JSON.parse(raw);
+    assert.equal(out.video_url, '', 'video_url presigned descartado');
+    assert.equal(out.assets.length, 1);
+    assert.equal(out.assets[0].name, 'ok.png');
+    cleanup();
+});
+
+test('updateQaResults mergea por name y preserva video_url entre escrituras', () => {
+    cleanup();
+    updateQaResults(TEST_ISSUE, [
+        { name: 'a.png', type: 'png', url: DRIVE_URL },
+    ], DRIVE_URL);
+    // Segunda escritura: nuevo asset + sin video_url → no debe perder el previo
+    updateQaResults(TEST_ISSUE, [
+        { name: 'b.html', type: 'html', url: DRIVE_URL_2 },
+    ], '');
+
+    const out = JSON.parse(fs.readFileSync(RESULTS_PATH, 'utf8'));
+    assert.equal(out.video_url, DRIVE_URL, 'video_url previo preservado');
+    const names = out.assets.map(a => a.name).sort();
+    assert.deepEqual(names, ['a.png', 'b.html']);
+    cleanup();
+});
+
+test('updateQaResults es idempotente: re-escribir el mismo asset no duplica', () => {
+    cleanup();
+    updateQaResults(TEST_ISSUE, [{ name: 'a.png', type: 'png', url: DRIVE_URL }], DRIVE_URL);
+    updateQaResults(TEST_ISSUE, [{ name: 'a.png', type: 'png', url: DRIVE_URL_2 }], DRIVE_URL);
+
+    const out = JSON.parse(fs.readFileSync(RESULTS_PATH, 'utf8'));
+    assert.equal(out.assets.length, 1, 'un solo asset por name');
+    assert.equal(out.assets[0].url, DRIVE_URL_2, 'url actualizada al último valor');
+    cleanup();
+});
+
+test('require() del módulo expone la API y no auto-ejecuta main()', () => {
+    // Si main() corriera al require, fallaría por falta de Telegram/args.
+    // Que el require haya resuelto y exponga las funciones ya prueba el guard.
+    const mod = require('../qa-video-share');
+    assert.equal(typeof mod.uploadToDrive, 'function');
+    assert.equal(typeof mod.updateQaResults, 'function');
+    assert.equal(typeof mod.isCanonicalUrl, 'function');
+});

--- a/qa/scripts/qa-android.sh
+++ b/qa/scripts/qa-android.sh
@@ -823,6 +823,28 @@ if command -v node &>/dev/null && [ -f "$SCRIPT_DIR/qa-video-share.js" ]; then
             --total "${TOTAL_TESTS:-0}" \
             2>&1 | tail -5 &
     fi
+
+    # ── 10b. Subir assets binarios restantes (png/zip/html/mp3) a Drive (#4173) ──
+    # Sacar la evidencia binaria de git: se sube a Drive y se registran los links
+    # en qa/evidence/<issue>/qa-results.json. Best-effort, no bloquea $MAESTRO_EXIT.
+    ASSETS_LIST=""
+    for adir in "$RECORDINGS_DIR" "${PROJECT_ROOT}/qa/evidence/${ISSUE_NUMBER:-0}"; do
+        [ -d "$adir" ] || continue
+        for af in "$adir"/*.png "$adir"/*.zip "$adir"/*.html "$adir"/*.mp3; do
+            [ -f "$af" ] || continue
+            ASSETS_LIST="${ASSETS_LIST:+$ASSETS_LIST,}$af"
+        done
+    done
+    if [ -n "$ASSETS_LIST" ]; then
+        echo ""
+        echo "[10b] Subiendo assets de evidencia (png/zip/html/mp3) a Google Drive..."
+        node "$SCRIPT_DIR/qa-video-share.js" \
+            --issue "${ISSUE_NUMBER:-0}" \
+            --title "${ISSUE_TITLE:-}" \
+            --sprint "${SPRINT_ID:-}" \
+            --assets "$ASSETS_LIST" \
+            2>&1 | tail -5 &
+    fi
 fi
 
 exit $MAESTRO_EXIT

--- a/qa/scripts/qa-video-share.js
+++ b/qa/scripts/qa-video-share.js
@@ -44,6 +44,15 @@ const MAX_RETRIES = 2;
 const RETRY_DELAY_MS = 2000;
 const R2_PRESIGNED_EXPIRY_SECONDS = 7 * 24 * 60 * 60; // 7 dias
 
+// #4173: mapa extension -> mime para subir assets de evidencia a Drive
+const ASSET_MIME = {
+    png: "image/png",
+    zip: "application/zip",
+    html: "text/html",
+    mp3: "audio/mpeg",
+    mp4: "video/mp4",
+};
+
 // --- Config ---
 
 const HOOKS_DIR = path.resolve(__dirname, "../../.claude/hooks");
@@ -91,6 +100,9 @@ function parseArgs() {
         criteriosFallidos: "",
         narratorProvider: "",
         rejectionPdf: "",
+        // #4173: modo assets — subir evidencia binaria (png/zip/html/mp3) a Drive
+        assets: "",
+        videoUrl: "",
     };
     for (let i = 0; i < args.length; i++) {
         switch (args[i]) {
@@ -106,6 +118,8 @@ function parseArgs() {
             case "--criterios-fallidos": result.criteriosFallidos = args[++i] || ""; break;
             case "--narrator": result.narratorProvider = args[++i] || ""; break;
             case "--rejection-pdf": result.rejectionPdf = args[++i] || ""; break;
+            case "--assets":  result.assets  = args[++i] || ""; break;
+            case "--video-url": result.videoUrl = args[++i] || ""; break;
         }
     }
     return result;
@@ -408,8 +422,9 @@ async function driveGetOrCreateFolder(accessToken, name, parentId) {
     return created.id;
 }
 
-// Subir video a Drive (multipart upload)
-function driveUploadFile(accessToken, videoBuffer, filename, folderId) {
+// Subir un asset a Drive (multipart upload). #4173: mimeType parametrizable
+// (default video/mp4 para preservar el comportamiento de los videos).
+function driveUploadFile(accessToken, assetBuffer, filename, folderId, mimeType = "video/mp4") {
     return new Promise((resolve, reject) => {
         const boundary = "----DriveBoundary" + Date.now().toString(36);
         const CRLF = "\r\n";
@@ -420,10 +435,10 @@ function driveUploadFile(accessToken, videoBuffer, filename, folderId) {
             "Content-Type: application/json; charset=UTF-8" + CRLF + CRLF +
             metadata + CRLF +
             "--" + boundary + CRLF +
-            "Content-Type: video/mp4" + CRLF + CRLF
+            "Content-Type: " + mimeType + CRLF + CRLF
         );
         const postamble = Buffer.from(CRLF + "--" + boundary + "--" + CRLF);
-        const body = Buffer.concat([preamble, videoBuffer, postamble]);
+        const body = Buffer.concat([preamble, assetBuffer, postamble]);
 
         const req = https.request({
             hostname: "www.googleapis.com",
@@ -509,8 +524,9 @@ function driveGetFileLink(accessToken, fileId) {
     });
 }
 
-// Subir video completo a Google Drive: auth + carpetas + upload + permisos
-async function uploadToDrive(videoBuffer, filename, issueNumber, issueTitle, sprintId) {
+// Subir cualquier asset a Google Drive: auth + carpetas + upload + permisos.
+// #4173: generalizado de "video" a "asset" (mismo camino para png/zip/html/mp3).
+async function uploadToDrive(assetBuffer, filename, issueNumber, issueTitle, sprintId, mimeType = "video/mp4") {
     const credentials = loadDriveCredentials();
     const accessToken = await getGoogleAccessToken(credentials);
 
@@ -524,8 +540,8 @@ async function uploadToDrive(videoBuffer, filename, issueNumber, issueTitle, spr
     console.log("[qa-video-share] Drive: creando/usando carpeta " + issueFolder);
     const issueFolderId = await driveGetOrCreateFolder(accessToken, issueFolder, rootFolderId);
 
-    console.log("[qa-video-share] Drive: subiendo " + filename + " (" + formatSize(videoBuffer.length) + ")...");
-    const uploaded = await driveUploadFile(accessToken, videoBuffer, filename, issueFolderId);
+    console.log("[qa-video-share] Drive: subiendo " + filename + " (" + formatSize(assetBuffer.length) + ")...");
+    const uploaded = await driveUploadFile(accessToken, assetBuffer, filename, issueFolderId, mimeType);
     await driveSetPublic(accessToken, uploaded.id);
 
     // Preferir webViewLink (abre el video en el navegador)
@@ -551,6 +567,109 @@ function updateQaReport(issueNumber, videoUrl) {
         console.log("[qa-video-share] qa-report.json actualizado con video_url");
     } catch (e) {
         console.error("[qa-video-share] No se pudo actualizar qa-report.json:", e.message);
+    }
+}
+
+// SEC-1 (#4173): una URL es segura para commitear solo si NO lleva material de
+// firma en el querystring. Las presigned de R2 emiten X-Amz-*/Signature= y NO
+// deben llegar al repo público; las webViewLink de Drive son canónicas.
+function isCanonicalUrl(url) {
+    if (!url || typeof url !== "string") return false;
+    return !/X-Amz-/i.test(url) && !/[?&]Signature=/i.test(url);
+}
+
+// #4173: registrar los links de assets (png/zip/html/mp3) + video en
+// qa/evidence/<issue>/qa-results.json (archivo distinto de qa-report.json).
+// Merge idempotente por nombre. Descarta cualquier URL con material de firma
+// (SEC-1). Crea el archivo y la carpeta si no existen.
+function updateQaResults(issueNumber, assets, videoUrl) {
+    const PROJECT_ROOT = path.resolve(__dirname, "../..");
+    const dir = path.join(PROJECT_ROOT, "qa", "evidence", String(issueNumber));
+    const resultsPath = path.join(dir, "qa-results.json");
+    try {
+        if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+
+        let results = { video_url: "", assets: [] };
+        if (fs.existsSync(resultsPath)) {
+            try {
+                const parsed = JSON.parse(fs.readFileSync(resultsPath, "utf8"));
+                if (parsed && typeof parsed === "object") results = parsed;
+            } catch (_) { /* JSON corrupto: se reescribe limpio */ }
+        }
+        if (!Array.isArray(results.assets)) results.assets = [];
+
+        // video_url: solo canónica (SEC-1)
+        if (videoUrl) {
+            if (isCanonicalUrl(videoUrl)) results.video_url = videoUrl;
+            else console.error("[qa-video-share] video_url descartado por material de firma (SEC-1)");
+        }
+
+        // Merge por name; descartar URLs con material de firma (SEC-1)
+        const byName = new Map(results.assets.filter(a => a && a.name).map(a => [a.name, a]));
+        for (const a of (assets || [])) {
+            if (!a || !a.name || !a.url) continue;
+            if (!isCanonicalUrl(a.url)) {
+                console.error("[qa-video-share] URL de asset descartada por material de firma (SEC-1): " + a.name);
+                continue;
+            }
+            byName.set(a.name, { name: a.name, type: a.type || "", url: a.url });
+        }
+        results.assets = Array.from(byName.values());
+
+        fs.writeFileSync(resultsPath, JSON.stringify(results, null, 2) + "\n", "utf8");
+        console.log("[qa-video-share] qa-results.json actualizado (" + results.assets.length + " asset(s))");
+        return resultsPath;
+    } catch (e) {
+        console.error("[qa-video-share] No se pudo actualizar qa-results.json:", e.message);
+        return null;
+    }
+}
+
+// #4173: subir assets de evidencia binaria a Drive y registrar links en
+// qa-results.json. Best-effort: cada fallo registra fallback explícito con el
+// path local (CA-5/SEC-5), nunca vuelca secrets ni rompe el flujo.
+async function runAssetUpload(data) {
+    const issue = data.issue;
+    const assetPaths = String(data.assets).split(",").map(s => s.trim()).filter(Boolean);
+    if (assetPaths.length === 0) {
+        console.log("[qa-video-share] Modo assets: sin assets para subir");
+        return;
+    }
+    if (!driveAvailable()) {
+        // Fallback explícito — nunca fallar mudo (CA-5/SEC-5)
+        for (const p of assetPaths) {
+            console.error("[qa-video-share] Drive no configurado: no se pudo subir, evidencia local en " + path.resolve(p));
+        }
+        return;
+    }
+
+    const sprintId = data.sprint || readActiveSprint();
+    const uploaded = [];
+    for (const assetPath of assetPaths) {
+        const full = path.resolve(assetPath);
+        if (!fs.existsSync(full)) {
+            console.error("[qa-video-share] Asset no encontrado: " + full);
+            continue;
+        }
+        const name = path.basename(full);
+        const type = path.extname(full).replace(/^\./, "").toLowerCase();
+        const mimeType = ASSET_MIME[type] || "application/octet-stream";
+        try {
+            const buf = fs.readFileSync(full);
+            const url = await withRetry(
+                () => uploadToDrive(buf, name, issue, data.title, sprintId, mimeType),
+                "Drive asset upload " + name
+            );
+            uploaded.push({ name, type, url });
+            console.log("[qa-video-share] Asset subido a Drive: " + name);
+        } catch (e) {
+            // CA-5/SEC-5: fallback explícito con path local, sin volcar secrets
+            console.error("[qa-video-share] No se pudo subir " + name + ", evidencia local en " + full);
+        }
+    }
+
+    if (uploaded.length > 0 || data.videoUrl) {
+        updateQaResults(issue, uploaded, data.videoUrl || "");
     }
 }
 
@@ -736,6 +855,13 @@ function readActiveSprint() {
 
 async function main() {
     const data = parseArgs();
+
+    // #4173: modo assets — sube evidencia binaria (png/zip/html/mp3) a Drive y
+    // registra links en qa-results.json. No requiere Telegram; corta acá.
+    if (data.assets) {
+        await runAssetUpload(data);
+        return;
+    }
 
     if (!BOT_TOKEN || !CHAT_ID) {
         console.error("[qa-video-share] Telegram no configurado");
@@ -956,7 +1082,14 @@ async function sendFallback(filename, fullPath, stats, sizeStr, data, verdictIco
     }
 }
 
-main().catch(e => {
-    console.error("[qa-video-share] Error fatal:", e.message);
-    process.exit(1);
-});
+// #4173: guard require.main — permite `require()` desde otro script Node sin
+// disparar el flujo Telegram (evita doble envío). main() solo corre como CLI.
+if (require.main === module) {
+    main().catch(e => {
+        console.error("[qa-video-share] Error fatal:", e.message);
+        process.exit(1);
+    });
+}
+
+// #4173: API reusable para subir assets y registrar qa-results.json
+module.exports = { uploadToDrive, updateQaResults, isCanonicalUrl };


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 4 archivos · +293 -14

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:passed` aplicado por delivery

## Closes

Closes #4173
