### PR TITLE
Rebote automático a dev cuando review rechaza por falta de tests para funcionalidad nueva (en vez de bloquear por humano)

### DIFF
--- a/.pipeline/lib/__tests__/rebote-classifier.test.js
+++ b/.pipeline/lib/__tests__/rebote-classifier.test.js
@@ -430,3 +430,91 @@ test('#4046 · rechazo técnico normal sigue contando contra circuit breaker', (
     assert.equal(r.category, 'code');
     assert.equal(r.counts_against_circuit_breaker, true);
 });
+
+// =============================================================================
+// #4223 — Rebote automático a dev cuando review rechaza por tests faltantes
+// =============================================================================
+//
+//   CA-1 · Rechazo por "tests faltantes para funcionalidad nueva" → code
+//          (rebota a dev), NO human_block.
+//   CA-2 · El motivo (lista de lo que falta testear) se preserva intacto en
+//          classifyRebote (no se trunca ni se reemplaza); el pulpo lo propaga
+//          como motivo_rechazo por el flujo `code` normal.
+//   CA-3 · counts_against_circuit_breaker=true → el breaker sigue activo.
+//   CA-4 · Rechazos de review por OTRA causa mantienen su comportamiento.
+
+test('#4223 · CA-1: "falta de tests para funcionalidad nueva" → code, no human_block', () => {
+    const r = rc.classifyRebote({ motivo: 'Falta de tests para funcionalidad nueva (gate de review).' });
+    assert.equal(r.category, 'code');
+    assert.equal(r.label, null);
+});
+
+test('#4223 · CA-1: variantes de motivo de tests faltantes → code', () => {
+    const motivos = [
+        'El PR agrega 6 funciones nuevas sin un solo test que las ejercite.',
+        'tests faltantes para los nuevos criterios de aceptación',
+        'La lógica nueva queda sin cobertura de tests.',
+        'ausencia de cobertura para la logica nueva',
+        'missing tests for the new pure functions',
+        'no hay tests que cubran el caso de uso nuevo',
+        'cobertura insuficiente: faltan tests del agrupado',
+    ];
+    for (const motivo of motivos) {
+        assert.equal(rc.isMissingTestsReason(motivo), true, `"${motivo}" debería ser missing-tests`);
+        assert.equal(rc.classifyRebote({ motivo }).category, 'code', `"${motivo}" debería clasificar como code`);
+    }
+});
+
+test('#4223 · CA-1 (incidente #4192): motivo que cita el label needs-human NO queda en human_block', () => {
+    // Motivo realístico del review de #4192: menciona el literal `needs-human`
+    // al describir la lógica de agrupado, lo que disparaba isHumanBlockReason.
+    const motivo = [
+        'Falta de tests para funcionalidad nueva (criterio de rechazo del gate de aprobación).',
+        'Introduce 9 criterios de aceptación y 6 funciones puras nuevas sin un solo test.',
+        'Cambios requeridos: deriveGroup debe priorizar bloqueado>trabajando>listo>backlog',
+        'y mapear labels needs-human/blocked:dependencies en el agrupado.',
+    ].join('\n');
+    const r = rc.classifyRebote({ motivo });
+    assert.equal(r.category, 'code', 'debe rebotar a dev, no a bloqueado-humano');
+    assert.match(r.reason_summary, /test/i);
+});
+
+test('#4223 · CA-3: rebote por tests faltantes cuenta contra el circuit breaker', () => {
+    const r = rc.classifyRebote({ motivo: 'falta de tests para la nueva función' });
+    assert.equal(r.counts_against_circuit_breaker, true);
+});
+
+test('#4223 · precedencia: hint explícito human_block del agente se respeta', () => {
+    // Si el agente declara DELIBERADAMENTE human_block, no lo pisamos aunque el
+    // texto mencione tests.
+    const r = rc.classifyRebote({
+        motivo: 'faltan tests pero requiere decisión humana sobre el alcance',
+        rebote_categoria: 'human_block',
+    });
+    assert.equal(r.category, 'human_block');
+});
+
+test('#4223 · precedencia: dependency_block gana sobre missing-tests', () => {
+    const r = rc.classifyRebote({
+        motivo: 'faltan tests, pero además depende de #3083 todavía OPEN',
+    });
+    assert.equal(r.category, 'dependency_block');
+});
+
+test('#4223 · CA-4: rechazo de review por OTRA causa no cambia (sigue human_block)', () => {
+    const r = rc.classifyRebote({ motivo: 'PR #4547 mergeable pero CODEOWNERS requiere review humano' });
+    assert.equal(r.category, 'human_block');
+});
+
+test('#4223 · CA-4: rechazo técnico sin tests no se clasifica como missing-tests', () => {
+    assert.equal(rc.isMissingTestsReason('la función X no respeta el patrón Do'), false);
+    assert.equal(rc.isMissingTestsReason('lógica de negocio fuera de asdo/'), false);
+    assert.equal(rc.isMissingTestsReason('nombres que no reflejan el dominio'), false);
+});
+
+test('#4223 · isMissingTestsReason robusto ante input inválido', () => {
+    assert.equal(rc.isMissingTestsReason(''), false);
+    assert.equal(rc.isMissingTestsReason(undefined), false);
+    assert.equal(rc.isMissingTestsReason(null), false);
+    assert.equal(rc.isMissingTestsReason(12345), false);
+});

--- a/.pipeline/lib/rebote-classifier.js
+++ b/.pipeline/lib/rebote-classifier.js
@@ -132,6 +132,71 @@ const STRUCTURED_DEPENDENCY_HINT = /\brebote_categoria\s*[:=]\s*['"]?dependency_
 const STRUCTURED_DEPS_LIST = /\b(?:depende_de|depends_on|dependencias)\s*[:=]\s*\[?\s*([\d,\s#]+)\]?/i;
 
 // -----------------------------------------------------------------------------
+// PATRONES MISSING_TESTS — issue #4223
+//
+// Cuando el gate de `review` (fase aprobacion) rechaza un PR porque la
+// funcionalidad nueva no tiene tests que la cubran, ese rechazo es una
+// CORRECCIÓN AUTOMÁTICA: el dev escribe los tests faltantes. NO es un bloqueo
+// humano.
+//
+// Causa raíz que motivó esta capa (incidente #4192): el motivo de un rechazo
+// legítimo por tests faltantes mencionaba el literal `needs-human` (describía
+// la lógica de agrupado de issues por label) y eso disparaba el patrón
+// `/\bneeds[-_:\s]?human\b/i` de `human-block.js` → el issue terminaba en
+// `bloqueado-humano/` esperando que un operador lo destrabe a mano, en vez de
+// rebotar a `dev` para escribir los tests.
+//
+// Estos patrones tienen PRECEDENCIA sobre la clasificación `human_block`
+// (tanto el hint explícito como la heurística textual): si el motivo describe
+// "falta de tests para funcionalidad nueva", clasifica como `code` (rebote a
+// la fase de rechazo = dev) y cuenta contra el circuit breaker.
+//
+// Acotados a frases que mencionan explícitamente test(s)/cobertura/coverage
+// para NO canibalizar rechazos legítimos de `human_block` ni otros rechazos de
+// review (CA-4): un patrón de bloqueo humano (merge/CODEOWNERS/aprobación
+// humana) nunca menciona "test" ni "cobertura".
+// -----------------------------------------------------------------------------
+const MISSING_TESTS_PATTERNS = [
+    // "falta(n) (de) test(s)" — cubre "Falta de tests para funcionalidad nueva"
+    /\bfalta(?:n)?\s+(?:de\s+)?tests?\b/i,
+    // "tests faltantes" / "test faltante"
+    /\btests?\s+faltantes?\b/i,
+    // "sin (un solo) test(s)" — cubre "sin un solo test"
+    /\bsin\s+(?:un\s+(?:solo\s+)?)?tests?\b/i,
+    // "no hay / no incluye / no agrega / no tiene / no existe(n) (ningún) test(s)"
+    /\bno\s+(?:hay|incluye[n]?|agrega[n]?|tiene[n]?|existe[n]?)\s+(?:ning[uú]n[oa]?\s+)?tests?\b/i,
+    // "sin cobertura" / "cobertura faltante|insuficiente|ausente|nula" / "ausencia de cobertura"
+    /\bsin\s+cobertura\b/i,
+    /\bcobertura\s+(?:de\s+tests?\s+)?(?:faltante|insuficiente|ausente|nula)\b/i,
+    /\bausencia\s+de\s+(?:cobertura|tests?)\b/i,
+    /\bfalta\s+(?:de\s+)?cobertura\b/i,
+    // "funcionalidad|código|función|criterios nuev@s sin cobertura|tests"
+    /\b(?:funcionalidad|c[oó]digo|funci[oó]n(?:es)?|criterios?)\s+nuev[oa]s?\s+sin\s+(?:cobertura|tests?)\b/i,
+    // Inglés: "missing tests" / "missing test coverage" / "no tests for|covering"
+    /\bmissing\s+tests?\b/i,
+    /\bmissing\s+test\s+coverage\b/i,
+    /\bno\s+tests?\s+(?:for|cover)/i,
+];
+
+/**
+ * Devuelve true si el motivo describe "falta de tests para funcionalidad
+ * nueva" (issue #4223). Usado por classifyRebote (precedencia sobre
+ * human_block) y por el consumer en pulpo.js (filtro de motivos humanos).
+ *
+ * @param {string} motivo
+ * @returns {boolean}
+ */
+function isMissingTestsReason(motivo) {
+    if (!motivo || typeof motivo !== 'string') return false;
+    const txt = truncateForClassify(motivo);
+    if (!txt.trim()) return false;
+    for (const re of MISSING_TESTS_PATTERNS) {
+        if (re.test(txt)) return true;
+    }
+    return false;
+}
+
+// -----------------------------------------------------------------------------
 // API PÚBLICA
 // -----------------------------------------------------------------------------
 
@@ -253,6 +318,31 @@ function classifyRebote(opts = {}) {
             reason_summary: depDetect.assetOnly
                 ? 'Espera asset/recurso no en main'
                 : 'Depende de issue(s) abierto(s): ' + depDetect.dependsOn.map(n => '#' + n).join(', '),
+        };
+    }
+
+    // 2.4 — #4223: MISSING_TESTS gana sobre human_block.
+    //
+    // Un rechazo de review por "falta de tests para funcionalidad nueva" es una
+    // corrección automática (el dev escribe los tests), NO un bloqueo humano.
+    // Se ubica ANTES de las dos vías de human_block (hint explícito + heurística
+    // textual) para que un motivo que mencione `needs-human`/`aprobación humana`
+    // como parte de la descripción del cambio (incidente #4192) no quede
+    // atrapado en `bloqueado-humano/`.
+    //
+    // Excepción: si el agente declaró EXPLÍCITAMENTE `rebote_categoria:
+    // human_block`, respetamos esa señal deliberada (no la pisamos por heurística
+    // textual). El caso #4192 NO declara categoría explícita, así que cae acá.
+    if (explicitCategory !== 'human_block'
+        && explicitCategory !== 'dependency_block'
+        && isMissingTestsReason(motivo)) {
+        return {
+            category: 'code',
+            label: null,
+            dependsOn: [],
+            counts_against_circuit_breaker: true,
+            autounlock: null,
+            reason_summary: 'Falta de tests para funcionalidad nueva — rebota a dev (corrección automática, #4223)',
         };
     }
 
@@ -855,6 +945,7 @@ function emitBlocked(opts) {
 module.exports = {
     classifyRebote,
     detectDependencyBlock,
+    isMissingTestsReason, // #4223
     buildDependencyComment,
     reportDependencyBlock,
     sanitizeDepsList,
@@ -867,6 +958,7 @@ module.exports = {
     sweepFastFailRebotesFromProcesado,
     DEPENDENCY_PATTERNS,
     DEPENDENCY_ASSET_PATTERNS,
+    MISSING_TESTS_PATTERNS, // #4223
     DEPS_LABEL,
     DEPS_BLOCK_SUBDIR,
     MAX_DEPS_PER_BLOCK,

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -3502,7 +3502,25 @@ function brazoBarrido(config) {
           // etc), marcar el issue como `bloqueado-humano/` y NO incrementar rev.
           // Sin esto el pulpo relanza el skill cada ciclo y rebota infinitamente
           // (caso #2519 → 41 rebotes contra PR #2547 mergeable).
-          const motivosHumanos = motivosClasificados.filter(m => humanBlock.isHumanBlockReason(m.motivo));
+          // #4223 — un rechazo por "falta de tests para funcionalidad nueva" NO
+          // es bloqueo humano: es corrección automática → rebote a dev. Aunque el
+          // texto del motivo mencione `needs-human`/`aprobación humana` como parte
+          // de la descripción del cambio (incidente #4192, donde el review citaba
+          // el label `needs-human` al describir la lógica de agrupado), la
+          // detección de tests faltantes tiene precedencia y deja caer el motivo
+          // al flujo normal de rebote `code` → faseRechazo (dev), propagando la
+          // lista de lo que falta testear vía `motivo_rechazo`.
+          const motivosHumanos = motivosClasificados.filter(m => {
+            if (!humanBlock.isHumanBlockReason(m.motivo)) return false;
+            // Missing-tests gana sobre la heurística textual de human_block,
+            // salvo que el agente haya declarado `human_block` explícitamente
+            // (esa señal deliberada se respeta).
+            if (reboteClassifier.isMissingTestsReason(m.motivo)
+                && m.rebote_categoria !== 'human_block') {
+              return false;
+            }
+            return true;
+          });
           if (motivosHumanos.length > 0 && !esReboteDeInfra) {
             const principal = motivosHumanos[0];
             const skillBloq = principal.skill || skillFromFile(rechazados[0].file.name);


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 3 archivos · +199 -1

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:skipped` aplicado por delivery

## Closes

Closes #4223
