### PR TITLE
Reconciler: cruzar label needs-human contra el estado físico de fases antes de plantar bloqueo (evitar bloqueos fantasma)

### DIFF
--- a/.pipeline/lib/__tests__/servicio-reconciler.test.js
+++ b/.pipeline/lib/__tests__/servicio-reconciler.test.js
@@ -697,3 +697,153 @@ test('#2994 CA5 appendStaleOrderLog persiste línea JSONL', () => {
     assert.equal(ev.snapshot_at, '2026-05-05T19:30:00Z');
     assert.ok(/^\d{4}-/.test(ev.ts));
 });
+
+// =============================================================================
+// #4222 — Cruce label needs-human ↔ avance físico de fases (anti bloqueo fantasma)
+// =============================================================================
+
+// Crea un marker físico de avance (`listo/` o `procesado/`) para un issue en una
+// fase concreta del pipeline desarrollo/definicion.
+function writeProgressMarker(pipeline, phase, state, issue, skill) {
+    const dir = path.join(PIPELINE, pipeline, phase, state);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, `${issue}.${skill}`), '');
+}
+
+function clearProgressMarkers() {
+    for (const pipeline of ['desarrollo', 'definicion']) {
+        const root = path.join(PIPELINE, pipeline);
+        if (!fs.existsSync(root)) continue;
+        for (const phase of fs.readdirSync(root)) {
+            for (const state of ['listo', 'procesado']) {
+                const dir = path.join(root, phase, state);
+                if (!fs.existsSync(dir)) continue;
+                for (const f of fs.readdirSync(dir)) {
+                    try { fs.unlinkSync(path.join(dir, f)); } catch {}
+                }
+            }
+        }
+    }
+}
+
+function listGhQueueRemoveLabels() {
+    return fs.readdirSync(GH_QUEUE)
+        .filter(f => f.endsWith('.json'))
+        .map(f => JSON.parse(fs.readFileSync(path.join(GH_QUEUE, f), 'utf8')))
+        .filter(c => c.action === 'remove-label');
+}
+
+test('#4222 findFurthestPhysicalPhaseIndex devuelve la fase física más avanzada', () => {
+    clearProgressMarkers();
+    const order = reconciler.loadGlobalPhaseOrder();
+    // Sin markers → -1
+    assert.equal(reconciler.findFurthestPhysicalPhaseIndex(4191, order), -1);
+    // Marker en verificacion/listo → índice de desarrollo/verificacion
+    writeProgressMarker('desarrollo', 'verificacion', 'listo', 4191, 'tester');
+    const idxVerif = reconciler.globalPhaseIndex(order, 'desarrollo', 'verificacion');
+    assert.equal(reconciler.findFurthestPhysicalPhaseIndex(4191, order), idxVerif);
+    // Agregar marker más avanzado (aprobacion/procesado) → debe ganar el más avanzado
+    writeProgressMarker('desarrollo', 'aprobacion', 'procesado', 4191, 'review');
+    const idxAprob = reconciler.globalPhaseIndex(order, 'desarrollo', 'aprobacion');
+    assert.equal(reconciler.findFurthestPhysicalPhaseIndex(4191, order), idxAprob);
+    clearProgressMarkers();
+});
+
+test('#4222 findFurthestPhysicalPhaseIndex ignora artifacts (.reason.json)', () => {
+    clearProgressMarkers();
+    const order = reconciler.loadGlobalPhaseOrder();
+    const dir = path.join(PIPELINE, 'desarrollo', 'verificacion', 'listo');
+    fs.mkdirSync(dir, { recursive: true });
+    // Solo un artifact, sin marker base → no cuenta como avance
+    fs.writeFileSync(path.join(dir, '4191.tester.reason.json'), '{}');
+    assert.equal(reconciler.findFurthestPhysicalPhaseIndex(4191, order), -1);
+    clearProgressMarkers();
+});
+
+test('#4222 isNeedsHumanStaleByProgress: stale cuando progresó más allá del placeholder', () => {
+    clearProgressMarkers();
+    // Placeholder de un issue Ready cae en desarrollo/dev. Marker físico en
+    // verificacion (posterior) → stale.
+    writeProgressMarker('desarrollo', 'verificacion', 'listo', 4191, 'tester');
+    const r = reconciler.isNeedsHumanStaleByProgress(4191, 'desarrollo', 'dev');
+    assert.equal(r.stale, true);
+    assert.equal(r.furthestPhase, 'desarrollo/verificacion');
+    clearProgressMarkers();
+});
+
+test('#4222 isNeedsHumanStaleByProgress: NO stale cuando avance == fase del placeholder', () => {
+    clearProgressMarkers();
+    // Marker en la MISMA fase del placeholder (dev) — done con dev pero el bloqueo
+    // en dev sigue siendo consistente. Conservador: no stale.
+    writeProgressMarker('desarrollo', 'dev', 'listo', 4300, 'pipeline-dev');
+    const r = reconciler.isNeedsHumanStaleByProgress(4300, 'desarrollo', 'dev');
+    assert.equal(r.stale, false);
+    clearProgressMarkers();
+});
+
+test('#4222 isNeedsHumanStaleByProgress: NO stale sin markers de avance', () => {
+    clearProgressMarkers();
+    const r = reconciler.isNeedsHumanStaleByProgress(4301, 'desarrollo', 'dev');
+    assert.equal(r.stale, false);
+    clearProgressMarkers();
+});
+
+// Escenario Gherkin 1: Label needs-human stale no genera bloqueo fantasma
+test('#4222 Gherkin: needs-human stale NO crea bloqueo y limpia el label', () => {
+    clearAllMarkers();
+    clearGhQueue();
+    clearProgressMarkers();
+    const logFile = path.join(PIPELINE, 'logs', 'stale-orders.log');
+    try { fs.unlinkSync(logFile); } catch {}
+
+    // Issue #4191: markers físicos en fase posterior (verificacion + aprobacion + listo),
+    // pero label needs-human viejo en GitHub (Ready → placeholder en dev).
+    writeProgressMarker('desarrollo', 'verificacion', 'procesado', 4191, 'tester');
+    writeProgressMarker('desarrollo', 'aprobacion', 'listo', 4191, 'review');
+
+    const ghIssues = [{ number: 4191, labels: ['ready', 'needs-human'] }];
+    const created = reconciler.reconcileLabelToFilesystem(ghIssues, new Map());
+
+    // No crea placeholder
+    assert.equal(created, 0, 'no debe crear placeholder para label stale');
+    const marker = path.join(PIPELINE, 'desarrollo', 'dev', 'bloqueado-humano', '4191.guru');
+    assert.equal(fs.existsSync(marker), false, 'no debe existir marker de bloqueo');
+
+    // Limpia el label stale (encola remove-label)
+    const removes = listGhQueueRemoveLabels();
+    assert.equal(removes.length, 1, 'debe encolar un remove-label');
+    assert.equal(removes[0].issue, 4191);
+    assert.equal(removes[0].label, 'needs-human');
+
+    // Registra el destrabe en el log para auditoría (CA-3)
+    const logRaw = fs.readFileSync(logFile, 'utf8').trim();
+    const ev = JSON.parse(logRaw.split('\n').pop());
+    assert.equal(ev.reason, 'stale-needs-human-phase-progress');
+    assert.equal(ev.issue, 4191);
+    assert.match(ev.detail, /progres/i);
+
+    clearProgressMarkers();
+});
+
+// Escenario Gherkin 2: Label needs-human legítimo mantiene el bloqueo
+test('#4222 Gherkin: needs-human legítimo (sin avance) mantiene el bloqueo', () => {
+    clearAllMarkers();
+    clearGhQueue();
+    clearProgressMarkers();
+
+    // Issue cuya fase física actual justifica decisión humana: sin markers de
+    // avance posterior. Mantiene el comportamiento actual (crea placeholder).
+    const ghIssues = [{ number: 4400, labels: ['ready', 'needs-human'] }];
+    const created = reconciler.reconcileLabelToFilesystem(ghIssues, new Map());
+
+    assert.equal(created, 1, 'debe crear placeholder legítimo');
+    const marker = path.join(PIPELINE, 'desarrollo', 'dev', 'bloqueado-humano', '4400.guru');
+    assert.equal(fs.existsSync(marker), true, 'debe existir marker de bloqueo');
+
+    // No limpia ningún label
+    const removes = listGhQueueRemoveLabels();
+    assert.equal(removes.length, 0, 'no debe encolar remove-label para bloqueo legítimo');
+
+    clearProgressMarkers();
+    clearAllMarkers();
+});

--- a/.pipeline/servicio-reconciler.js
+++ b/.pipeline/servicio-reconciler.js
@@ -28,10 +28,12 @@
 const { execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
+const yaml = require('js-yaml');
 
 require('./lib/sanitize-console').install();
 const { sanitize } = require('./sanitizer');
 const humanBlock = require('./lib/human-block');
+const { isMarkerArtifact } = require('./lib/marker-artifact');
 const admissionGate = require('./lib/admission-gate');
 // #3381 — Gate de screenshots+mockup (default OFF, activable por env var).
 const screenshotsMockupGate = require('./hooks/screenshots-mockup-gate');
@@ -178,9 +180,112 @@ function isRecommendationIssue(labels) {
     return false;
 }
 
-function reconcileLabelToFilesystem(ghIssues, blockedByIssue) {
+// -----------------------------------------------------------------------------
+// #4222 — Cruce label needs-human ↔ avance físico de fases (anti bloqueo fantasma)
+// -----------------------------------------------------------------------------
+//
+// Caso #4191: un issue ya había avanzado físicamente a `verificacion`/`aprobacion`
+// (sus markers en disco existían), pero en GitHub quedó pegado un `needs-human`
+// stale. El reconciler veía el label, no lo cruzaba contra el avance real y
+// plantaba un placeholder de bloqueo "para no perderlo" → bloqueo fantasma que
+// figuraba como decisión humana pendiente cuando el issue ya venía resuelto.
+//
+// La guarda: antes de crear el placeholder, calcular la fase física más avanzada
+// que alcanzó el issue (markers en `listo/` o `procesado/`) y compararla con la
+// fase donde se plantaría el bloqueo. Si el issue progresó MÁS ALLÁ de esa fase,
+// el label es stale: se limpia en GitHub y NO se planta bloqueo.
+
+// Estados que evidencian que el issue YA superó (o cerró el trabajo de) una fase.
+//   - `listo`     = la fase terminó su trabajo y espera evaluación.
+//   - `procesado` = la fase siguiente ya tomó el issue (trabajo de la fase cerrado).
+// Deliberadamente NO miramos `pendiente`/`trabajando`: estar encolado o en curso
+// en una fase no implica haberla superado. Solo declaramos `stale` ante evidencia
+// fuerte de avance (conservador: minimiza el riesgo de limpiar un bloqueo legítimo).
+const PROGRESS_STATES = ['listo', 'procesado'];
+
+// Fallback canónico si no se puede leer config.yaml (degradación segura). Debe
+// mantenerse sincronizado con `pipelines.<p>.fases` de config.yaml.
+const FALLBACK_PHASE_ORDER = {
+    definicion: ['analisis', 'criterios', 'sizing'],
+    desarrollo: ['validacion', 'dev', 'build', 'verificacion', 'linteo', 'aprobacion', 'entrega'],
+};
+
+let _globalPhaseOrderCache = null;
+
+// Construye el orden GLOBAL de fases (pipeline+fase) leyendo el orden canónico
+// de config.yaml. El orden global encadena los pipelines en el orden en que
+// aparecen en config (definicion → desarrollo), reflejando el flujo natural del
+// issue. Se cachea: el orden de fases no cambia en runtime.
+function loadGlobalPhaseOrder() {
+    if (_globalPhaseOrderCache) return _globalPhaseOrderCache;
+    let orders = FALLBACK_PHASE_ORDER;
+    try {
+        const cfg = yaml.load(fs.readFileSync(path.join(PIPELINE, 'config.yaml'), 'utf8')) || {};
+        if (cfg.pipelines && typeof cfg.pipelines === 'object') {
+            const parsed = {};
+            for (const [pname, pcfg] of Object.entries(cfg.pipelines)) {
+                if (pcfg && Array.isArray(pcfg.fases)) parsed[pname] = pcfg.fases.slice();
+            }
+            if (Object.keys(parsed).length > 0) orders = parsed;
+        }
+    } catch {
+        // config.yaml ausente o ilegible (p. ej. entorno de test) → fallback.
+    }
+    const global = [];
+    for (const pname of Object.keys(orders)) {
+        for (const fase of orders[pname]) global.push({ pipeline: pname, phase: fase });
+    }
+    _globalPhaseOrderCache = global;
+    return global;
+}
+
+// Índice en el orden global de una terna (pipeline, fase). -1 si no existe.
+function globalPhaseIndex(globalOrder, pipeline, phase) {
+    return globalOrder.findIndex(g => g.pipeline === pipeline && g.phase === phase);
+}
+
+// Devuelve el índice (en el orden global) de la fase física más avanzada que
+// alcanzó el issue, mirando markers en `listo/`/`procesado/` de cada fase.
+// -1 si el issue no tiene evidencia física de avance en ninguna fase.
+function findFurthestPhysicalPhaseIndex(issueNum, globalOrder) {
+    const prefix = String(issueNum) + '.';
+    let furthest = -1;
+    for (let i = 0; i < globalOrder.length; i++) {
+        const { pipeline, phase } = globalOrder[i];
+        for (const state of PROGRESS_STATES) {
+            const dir = path.join(PIPELINE, pipeline, phase, state);
+            let entries;
+            try { entries = fs.readdirSync(dir); } catch { continue; }
+            const hasMarker = entries.some(
+                f => f.startsWith(prefix) && f !== '.gitkeep' && !isMarkerArtifact(f),
+            );
+            if (hasMarker) { furthest = i; break; }
+        }
+    }
+    return furthest;
+}
+
+// Decide si el `needs-human` de un issue es stale por avance físico de fases.
+// Devuelve { stale: bool, furthestPhase?: string } — stale cuando el issue
+// progresó ESTRICTAMENTE más allá de la fase donde se plantaría el bloqueo.
+function isNeedsHumanStaleByProgress(issueNum, placeholderPipeline, placeholderPhase, opts = {}) {
+    const globalOrder = opts.globalOrder || loadGlobalPhaseOrder();
+    const findFurthest = opts.findFurthest || findFurthestPhysicalPhaseIndex;
+    const placeholderIdx = globalPhaseIndex(globalOrder, placeholderPipeline, placeholderPhase);
+    if (placeholderIdx < 0) return { stale: false };
+    const furthestIdx = findFurthest(issueNum, globalOrder);
+    if (furthestIdx > placeholderIdx) {
+        return { stale: true, furthestPhase: `${globalOrder[furthestIdx].pipeline}/${globalOrder[furthestIdx].phase}` };
+    }
+    return { stale: false };
+}
+
+function reconcileLabelToFilesystem(ghIssues, blockedByIssue, opts = {}) {
     let created = 0;
     let skippedRecommendations = 0;
+    let staleCleared = 0;
+    const enqueueRemoveFn = opts.enqueueLabelRemove || enqueueLabelRemove;
+    const logStaleFn = opts.logStaleOrder || appendStaleOrderLog;
     for (const issue of ghIssues) {
         if (blockedByIssue.has(issue.number)) continue;
         // Skip: recomendaciones auto-generadas (security/guru/planner) que
@@ -192,6 +297,28 @@ function reconcileLabelToFilesystem(ghIssues, blockedByIssue) {
         }
         // Issue tiene label `needs-human` pero no hay marker físico → crear placeholder
         const { pipeline, phase, skill } = decidirFasePlaceholder(issue.labels);
+        // #4222 — Guarda anti bloqueo fantasma: si el issue ya progresó más allá
+        // de la fase donde se plantaría el bloqueo, el `needs-human` es stale.
+        // Limpiar el label en GitHub y NO crear placeholder.
+        const staleCheck = isNeedsHumanStaleByProgress(issue.number, pipeline, phase, opts);
+        if (staleCheck.stale) {
+            try { enqueueRemoveFn(issue.number, RECONCILER_LABEL); } catch (e) {
+                log(`Error encolando remove-label stale #${issue.number}: ${e.message.slice(0, 120)}`);
+            }
+            try {
+                logStaleFn({
+                    reason: 'stale-needs-human-phase-progress',
+                    issue: issue.number,
+                    label: RECONCILER_LABEL,
+                    snapshot_at: null,
+                    current_mtime: null,
+                    detail: `needs-human stale: issue progresó a ${staleCheck.furthestPhase} (más allá de ${pipeline}/${phase}); label limpiado, sin bloqueo`,
+                });
+            } catch {}
+            log(`#${issue.number} needs-human stale (progresó a ${staleCheck.furthestPhase} > ${pipeline}/${phase}) — label limpiado, sin placeholder`);
+            staleCleared++;
+            continue;
+        }
         const targetDir = path.join(PIPELINE, pipeline, phase, humanBlock.BLOCK_SUBDIR);
         const targetFile = path.join(targetDir, `${issue.number}.${skill}`);
         if (fs.existsSync(targetFile)) continue;
@@ -215,6 +342,9 @@ function reconcileLabelToFilesystem(ghIssues, blockedByIssue) {
     }
     if (skippedRecommendations > 0) {
         log(`Skipped ${skippedRecommendations} issues con labels de recomendación (no se crean placeholders)`);
+    }
+    if (staleCleared > 0) {
+        log(`Limpiados ${staleCleared} labels needs-human stale por avance físico de fases (sin bloqueo)`);
     }
     return created;
 }
@@ -948,6 +1078,13 @@ module.exports = {
     decidirFasePlaceholder,
     isRecommendationIssue,
     RECOMMENDATION_LABELS,
+    // #4222 — Cruce label↔avance físico de fases (anti bloqueo fantasma)
+    loadGlobalPhaseOrder,
+    globalPhaseIndex,
+    findFurthestPhysicalPhaseIndex,
+    isNeedsHumanStaleByProgress,
+    PROGRESS_STATES,
+    FALLBACK_PHASE_ORDER,
     listGhIssuesWithLabel,
     getIssueState,
     enqueueLabelApply,


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 2 archivos · +288 -1

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:passed` aplicado por delivery

## Closes

Closes #4222
