### PR TITLE
Reforzar el gate de validación UX para que valide el render final contra el mockup aprobado (Ola 7.1)

### DIFF
--- a/.claude/skills/ux/SKILL.md
+++ b/.claude/skills/ux/SKILL.md
@@ -91,6 +91,7 @@ Al iniciar, parsear el primer argumento:
 | `mejorar <pantalla>` | Propuestas de mejora concreta | Seccion "Modo: Mejorar" |
 | `guia` | Generar/actualizar guia UX | Seccion "Modo: Guia" |
 | `screenshot-mockup <issue>` | Captura actual + genera mockup esperado por LLM | Seccion "Modo: Screenshot+Mockup" |
+| `validar-render <issue>` | Compara el render final implementado vs el mockup aprobado y emite veredicto pasa/rechaza | Seccion "Modo: Validar render vs mockup" |
 | `criterios-android <issue>` | Adjunta "Estado actual" + "Estado esperado" a un issue Android en definicion/criterios | Seccion "Modo: Criterios Android" |
 | sin argumento / `escalar` | Escalar issues UX detectados | Seccion "Modo: Escalar" |
 
@@ -729,6 +730,122 @@ Tokens en `docs/design-system/tokens.json`. Si no existe, el helper usa defaults
 
 ---
 
+## Modo: Validar render vs mockup (`/ux validar-render <issue>`)
+
+**Gate de validación UX (issue [#4228](https://github.com/intrale/platform/issues/4228), parte de #4227).** Este es el modo que UX corre **como gate** cuando participa en una fase de validación de un issue de rediseño: en lugar de aprobar por criterios genéricos, **compara el render final implementado contra el mockup aprobado del issue** y **rebota a dev** ante divergencias visibles relevantes.
+
+> Motivación: en la Ola 7.1 (rediseños del dashboard MIZPÁ) el gate dejó pasar entregas con divergencias visuales claras respecto del mockup propuesto (caso testigo #4189 / HOME). La causa raíz era de proceso: el gate **no validaba que el diseño final quede como el diseño propuesto**. Este modo cierra ese hueco.
+
+### Cuándo correr este modo
+
+- Issue de **rediseño** con un **mockup aprobado** embebido (sección `## Screenshots & Mockups` con la imagen "esperado") o un asset en `.pipeline/assets/mockups/<issue>/`.
+- Aplica a **todas** las pantallas de rediseño (Ola 7.1 y futuras), no a una sola.
+- Caso A — **Dashboard** (`area:pipeline`/`area:infra` que toca `dashboard.js` / `.pipeline/public/`): el render se captura del dashboard vivo en `http://localhost:3200` (`node .pipeline/dashboard.js`).
+- Si el issue NO tiene impacto visual o no tiene mockup de referencia → este gate no aprueba a ciegas: ver Paso V1.
+
+### Regla de oro del gate
+
+**No aprobás sin evidencia comparativa.** Está prohibido aprobar citando "se ve bien" o criterios genéricos sin haber capturado el render real y comparado contra el mockup en esta misma pasada. Si no podés capturar el render (dashboard caído) o no hay mockup → **no aprobás**: rebotás/anotás con el motivo concreto (la lógica determinística la centraliza `.pipeline/lib/ux-render-compare.js`).
+
+### Paso V1: Resolver el mockup de referencia
+
+```js
+const cmp = require('./.pipeline/lib/ux-render-compare');
+const body = /* gh issue view <N> --json body -q .body */;
+const ref = cmp.resolveMockupReference({ body, issue: N, repoRoot: process.cwd() });
+```
+
+- `ref.ok === true` → `ref.source` es `issue-body` o `local-assets`, `ref.refs` son las URLs/paths del mockup esperado.
+- `ref.ok === false` → **no hay contra qué comparar**. El gate **rechaza** con `causa: sin-mockup` (ver Paso V4): no aprobar sin mockup. Si el issue no debería tener mockup (no es rediseño), no corresponde este modo — devolver el control al flujo normal.
+
+### Paso V2: Capturar el render real
+
+**Caso A — Dashboard** (puerto 3200):
+
+```js
+const ts = /* timestamp del contexto */;
+const dir = cmp.evidenceDir(N, process.cwd()); // .pipeline/assets/mockups/<N>/validacion/
+const cap = await cmp.captureCurrentRender({
+  outputPath: `render-actual-${ts}.png`,
+  allowedRoot: dir,
+  dashboardPath: '/',           // o '/v3' (sólo paths de ALLOWED_PATHS)
+});
+const degradation = cmp.classifyDegradation(cap);
+```
+
+- `cap.ok === true` → tenés el PNG del render real en `cap.outputPath`.
+- `cap.ok === false` → `degradation.degraded === true`. Si `degradation.infra` (dashboard-down, timeout, puppeteer-missing) → es degradación de infra, **no defecto del dev**, pero **igual no se aprueba** (ver Paso V4). Anotar el motivo y dejar que se reprocese con el dashboard arriba.
+
+### Paso V3: Comparar (juicio vision-capable) y clasificar divergencias
+
+Sos vision-capable: abrí ambas imágenes (mockup esperado de `ref.refs` y render real de `cap.outputPath`) y compará **estructura, layout, jerarquía visual, paleta/tokens, tipografía, espaciado, componentes presentes/ausentes**. Por cada divergencia que detectes, clasificá su severidad:
+
+| Severidad | Criterio | ¿Bloquea? |
+|-----------|----------|-----------|
+| `critica` | Falta un componente clave, layout completamente distinto, pantalla no implementada | Sí |
+| `alta` | Estructura/jerarquía divergente, columnas/grid distintos, color de marca incorrecto | Sí |
+| `media` | Espaciados, tamaños o tokens claramente fuera de lo propuesto, visibles a simple vista | Sí (umbral default) |
+| `baja` | Diferencias cosméticas sub-perceptuales (1-2px, anti-aliasing, jitter de render) | No |
+
+Armá la lista de divergencias como objetos `{ aspecto, descripcion, severidad }`. Sé concreto y objetivable (citá el aspecto y qué difiere), nunca "no me gusta".
+
+### Paso V4: Veredicto determinístico
+
+```js
+const verdict = cmp.decideVerdict({
+  mockupResolved: ref.ok,
+  degradation,                       // de classifyDegradation
+  divergences,                       // las que clasificaste en V3
+  threshold: 'media',                // default: critica/alta/media bloquean
+});
+// verdict.resultado === 'aprobado' | 'rechazado'
+// verdict.causa === 'coincide' | 'divergencia' | 'no-verificable' | 'sin-mockup'
+// verdict.motivo === texto accionable
+```
+
+Reglas que aplica `decideVerdict` (no las reimplementes a mano):
+
+1. **Sin mockup** (`mockupResolved:false`) → `rechazado` / `sin-mockup`.
+2. **Captura degradada** → `rechazado` / `no-verificable` (no aprobar a ciegas; si es infra lo aclara en el motivo).
+3. **≥1 divergencia que alcanza el umbral** → `rechazado` / `divergencia` (**rebote a dev** con el detalle).
+4. **Sin divergencias bloqueantes** → `aprobado` / `coincide` (registra las menores como nota).
+
+### Paso V5: Producir evidencia y escribir el resultado
+
+1. **Evidencia comparativa** (CA del issue): dejá el render real (`render-actual-<ts>.png`) en `.pipeline/assets/mockups/<N>/validacion/` y, si el mockup vino del body como URL, descargá una copia local `mockup-esperado-<ts>.png` en el mismo dir. Esa carpeta es el artefacto de la fase.
+2. **Comentario auditable** en el issue con el veredicto y el detalle de divergencias (usá el marker `cmp.EVIDENCE_MARKER` para idempotencia):
+
+   ```bash
+   export PATH="/c/Workspaces/gh-cli/bin:$PATH"
+   gh issue comment <N> --body "$(cat <<'EOF'
+   <!-- ux-render-compare:4228 -->
+   ## Gate UX — Validación render vs mockup
+
+   **Veredicto:** <APROBADO|RECHAZADO> (causa: <causa>)
+
+   <motivo del verdict>
+
+   ### Divergencias detectadas
+   1. [alta] layout: la card HOME usa 1 columna en vez de 3
+   ...
+
+   Evidencia: `.pipeline/assets/mockups/<N>/validacion/`
+   EOF
+   )"
+   ```
+
+3. **Resultado del gate** en tu archivo de trabajo del pipeline:
+   - `verdict.resultado === 'aprobado'` → `resultado: aprobado`.
+   - `verdict.resultado === 'rechazado'` → `resultado: rechazado` + `motivo: <verdict.motivo>` (rebote a dev por el mecanismo estándar del pipeline V2).
+
+### Seguridad
+
+- La URL del dashboard está **hardcodeada** en `screenshot-capture.js` (anti-SSRF). NO inventes URLs; usá sólo paths de `ALLOWED_PATHS`.
+- `captureCurrentRender` sanitiza el `outputPath` (anti path-traversal) y nunca tira por dashboard caído (devuelve `{ok:false, reason}`).
+- Screenshots **nunca con datos productivos** (PII/secrets): el dashboard del Pulpo es estado interno, sin datos de usuario.
+
+---
+
 ## Modo: Criterios Android (`/ux criterios-android <issue>`)
 
 **Workflow automatizado en fase `definicion/criterios`** para issues Android con impacto visual (#3408). Adjunta dos referencias visuales al issue:
@@ -1030,6 +1147,10 @@ duda o conflicto.
 - **Resolver disputas visuales** con argumentos basados en `design-system.md`,
   tokens existentes, accesibilidad. Si el conflicto es entre estilos
   intencionados, escalar a PO.
+- **Validar render vs mockup** cuando el issue es un rediseño con mockup
+  aprobado: corré el gate del modo "Validar render vs mockup"
+  (`/ux validar-render <issue>`) — captura el render real y rebota a dev ante
+  divergencias relevantes en vez de aprobar por criterios genéricos (#4228).
 - **No inventar paleta**: consumir `.pipeline/assets/design-tokens.css`. Cero
   paleta nueva sin issue dedicado.
 

--- a/.pipeline/lib/ux-render-compare.js
+++ b/.pipeline/lib/ux-render-compare.js
@@ -1,0 +1,357 @@
+'use strict';
+
+// -----------------------------------------------------------------------------
+// ux-render-compare.js — Gate de validación UX: render real vs mockup aprobado.
+//
+// Issue #4228 (parte de #4227). Refuerza el gate de validación UX para que
+// compare el render final implementado contra el mockup aprobado del issue y
+// rebote a dev ante divergencias visibles relevantes, en lugar de aprobar por
+// criterios genéricos.
+//
+// Este módulo concentra la lógica DETERMINÍSTICA del gate:
+//   - Resolver el mockup de referencia (body del issue + assets locales).
+//   - Capturar el render real (delegado a screenshot-capture.js, puerto 3200).
+//   - Decidir el veredicto pasa/rechaza a partir de las divergencias que
+//     clasifica el agente vision-capable.
+//   - Manejar la degradación (dashboard caído): NO aprobar a ciegas.
+//
+// La comparación visual en sí (juicio "estas dos imágenes divergen") la hace el
+// agente UX que es vision-capable; este módulo le arma el andamiaje y aplica la
+// regla de decisión de forma testeable. Un diff pixel-perfect (pixelmatch/sharp)
+// es un refinamiento futuro, no un blocker (ver análisis técnico del issue).
+// -----------------------------------------------------------------------------
+
+const fs = require('fs');
+const path = require('path');
+
+const { extractSectionSlice, truncateBody } = require('./qa-evidence-gate');
+const screenshotCapture = require('./screenshot-capture');
+
+// -----------------------------------------------------------------------------
+// Severidades de divergencia
+// -----------------------------------------------------------------------------
+
+// Orden de mayor a menor relevancia. El umbral por default ('media') bloquea
+// las divergencias 'visibles relevantes' (critica/alta/media) y deja pasar las
+// puramente cosméticas (baja).
+const SEVERITIES = ['critica', 'alta', 'media', 'baja'];
+const DEFAULT_BLOCKING_THRESHOLD = 'media';
+
+// Marker estable para grep en logs / comments idempotentes.
+const EVIDENCE_MARKER = '<!-- ux-render-compare:4228 -->';
+
+// Patrón de imágenes markdown — replica el de qa-evidence-gate sin exponerlo,
+// para no acoplar al detalle interno de ese módulo.
+const IMAGE_MD_RE = /!\[[^\]]*\]\(([^)\s]+)[^)]*\)/g;
+const MAX_REFS = 20;
+
+// -----------------------------------------------------------------------------
+// Resolución del mockup de referencia
+// -----------------------------------------------------------------------------
+
+/**
+ * Extrae las referencias de imagen de la sección `## Screenshots & Mockups`
+ * del body del issue. Distingue heurísticamente la imagen "esperado" (mockup)
+ * de la "actual" mirando el alt-text.
+ *
+ * @param {string} body — body crudo del issue (markdown).
+ * @returns {{ all: string[], mockups: string[], reason: string }}
+ */
+function extractMockupRefs(body) {
+    const truncated = truncateBody(body);
+    if (!truncated) {
+        return { all: [], mockups: [], reason: 'empty-body' };
+    }
+    const slice = extractSectionSlice(truncated);
+    if (slice === null) {
+        return { all: [], mockups: [], reason: 'section-missing' };
+    }
+
+    const all = [];
+    const mockups = [];
+    IMAGE_MD_RE.lastIndex = 0;
+    let m;
+    while ((m = IMAGE_MD_RE.exec(slice)) !== null && all.length < MAX_REFS) {
+        const url = m[1];
+        const alt = m[0].slice(2, m[0].indexOf(']')).toLowerCase();
+        all.push(url);
+        // El mockup "esperado" se marca con alt-text que lo identifica.
+        if (/esperad|mockup|propuest|disen|diseñ|target/.test(alt)) {
+            mockups.push(url);
+        }
+        if (IMAGE_MD_RE.lastIndex === m.index) IMAGE_MD_RE.lastIndex += 1;
+    }
+
+    if (all.length === 0) {
+        return { all, mockups, reason: 'no-images' };
+    }
+    return { all, mockups, reason: 'ok' };
+}
+
+/**
+ * Busca mockups locales en `.pipeline/assets/mockups/{issue}/`.
+ *
+ * @param {string|number} issue
+ * @param {string} repoRoot
+ * @returns {string[]} paths absolutos a los assets encontrados (png/svg)
+ */
+function resolveLocalMockups(issue, repoRoot) {
+    const safeIssue = String(issue).replace(/[^0-9]/g, '');
+    if (!safeIssue) return [];
+    const dir = path.join(repoRoot, '.pipeline', 'assets', 'mockups', safeIssue);
+    let entries;
+    try {
+        entries = fs.readdirSync(dir);
+    } catch {
+        return [];
+    }
+    return entries
+        .filter((f) => /\.(png|svg)$/i.test(f))
+        .map((f) => path.join(dir, f));
+}
+
+/**
+ * Resuelve la referencia de mockup combinando el body del issue y los assets
+ * locales. Devuelve un objeto con la fuente elegida y motivo.
+ *
+ * @param {object} opts
+ * @param {string} opts.body — body del issue
+ * @param {string|number} opts.issue
+ * @param {string} opts.repoRoot
+ * @returns {{ ok: boolean, source: string, refs: string[], reason: string }}
+ */
+function resolveMockupReference(opts = {}) {
+    const { body = '', issue, repoRoot = process.cwd() } = opts;
+
+    const fromBody = extractMockupRefs(body);
+    // Preferimos las marcadas como "esperado"; si no hay, usamos todas las del body.
+    const bodyRefs = fromBody.mockups.length > 0 ? fromBody.mockups : fromBody.all;
+
+    if (bodyRefs.length > 0) {
+        return { ok: true, source: 'issue-body', refs: bodyRefs, reason: 'ok' };
+    }
+
+    const localRefs = resolveLocalMockups(issue, repoRoot);
+    if (localRefs.length > 0) {
+        return { ok: true, source: 'local-assets', refs: localRefs, reason: 'ok' };
+    }
+
+    // Sin mockup no se puede comparar — el gate no debe aprobar a ciegas.
+    return {
+        ok: false,
+        source: 'none',
+        refs: [],
+        reason: fromBody.reason === 'ok' ? 'no-mockup-ref' : fromBody.reason,
+    };
+}
+
+// -----------------------------------------------------------------------------
+// Captura del render real
+// -----------------------------------------------------------------------------
+
+/**
+ * Captura el render real del dashboard (puerto 3200) delegando en
+ * screenshot-capture.capture(). Normaliza el resultado.
+ *
+ * @param {object} opts
+ * @param {string} opts.outputPath
+ * @param {string} opts.allowedRoot
+ * @param {string} [opts.dashboardPath='/']
+ * @param {Function} [opts._capture] — DI para tests
+ * @returns {Promise<{ ok: boolean, outputPath?: string, reason?: string, detail?: string }>}
+ */
+async function captureCurrentRender(opts = {}) {
+    const capture = opts._capture || screenshotCapture.capture;
+    try {
+        const result = await capture({
+            outputPath: opts.outputPath,
+            allowedRoot: opts.allowedRoot,
+            dashboardPath: opts.dashboardPath || '/',
+        });
+        return result;
+    } catch (e) {
+        // capture() sólo tira por validación de input (path traversal, etc).
+        return { ok: false, reason: 'capture-input-error', detail: String((e && e.message) || e) };
+    }
+}
+
+/**
+ * Clasifica una degradación de captura para la lógica de veredicto.
+ * Distingue las causas de infra (no es culpa de dev) de las verificables.
+ *
+ * @param {{ ok: boolean, reason?: string }} captureResult
+ * @returns {{ degraded: boolean, infra: boolean, reason: string|null }}
+ */
+function classifyDegradation(captureResult) {
+    if (captureResult && captureResult.ok) {
+        return { degraded: false, infra: false, reason: null };
+    }
+    const reason = (captureResult && captureResult.reason) || 'unknown';
+    // dashboard-down / timeout / puppeteer-missing / mkdir-failed son infra:
+    // impiden verificar pero no implican defecto del dev.
+    const infraReasons = new Set([
+        'dashboard-down',
+        'timeout',
+        'puppeteer-missing',
+        'mkdir-failed',
+        'capture-input-error',
+        'unknown',
+    ]);
+    return { degraded: true, infra: infraReasons.has(reason), reason };
+}
+
+// -----------------------------------------------------------------------------
+// Regla de decisión del veredicto
+// -----------------------------------------------------------------------------
+
+/**
+ * Normaliza una severidad arbitraria a una de SEVERITIES; default 'media'
+ * (conservador: ante duda, bloquea).
+ */
+function normalizeSeverity(value) {
+    const v = String(value || '').trim().toLowerCase();
+    return SEVERITIES.includes(v) ? v : 'media';
+}
+
+/**
+ * ¿La severidad alcanza el umbral de bloqueo? (>= threshold en relevancia)
+ */
+function isBlocking(severity, threshold) {
+    const sIdx = SEVERITIES.indexOf(normalizeSeverity(severity));
+    const tIdx = SEVERITIES.indexOf(normalizeSeverity(threshold));
+    // Índice menor = más relevante. Bloquea si es igual o más relevante que el umbral.
+    return sIdx <= tIdx;
+}
+
+/**
+ * Decide el veredicto del gate a partir de las divergencias clasificadas por el
+ * agente vision y el estado de captura.
+ *
+ * Reglas (en orden):
+ *   1. Si no hay mockup de referencia → no-verificable (NO aprobar).
+ *   2. Si la captura está degradada → no-verificable (NO aprobar a ciegas).
+ *   3. Si hay >=1 divergencia que alcanza el umbral de bloqueo → rechazado (rebote a dev).
+ *   4. Si no → aprobado (con nota de divergencias menores si las hay).
+ *
+ * @param {object} opts
+ * @param {Array<{aspecto?:string,descripcion?:string,severidad?:string}>} [opts.divergences=[]]
+ * @param {boolean} [opts.mockupResolved=true]
+ * @param {{degraded:boolean,infra:boolean,reason:string|null}} [opts.degradation]
+ * @param {string} [opts.threshold='media']
+ * @returns {{ resultado: 'aprobado'|'rechazado', causa: string, motivo: string, blocking: Array, menores: Array }}
+ */
+function decideVerdict(opts = {}) {
+    const divergences = Array.isArray(opts.divergences) ? opts.divergences : [];
+    const threshold = opts.threshold || DEFAULT_BLOCKING_THRESHOLD;
+    const degradation = opts.degradation || { degraded: false, infra: false, reason: null };
+    const mockupResolved = opts.mockupResolved !== false;
+
+    // 1. Sin mockup → no se puede comparar. No aprobar.
+    if (!mockupResolved) {
+        return {
+            resultado: 'rechazado',
+            causa: 'sin-mockup',
+            motivo:
+                'No se encontró mockup de referencia (ni en la sección "## Screenshots & Mockups" ' +
+                'del issue ni en .pipeline/assets/mockups/<issue>/). El gate no aprueba sin algo ' +
+                'contra qué comparar: adjuntar el mockup aprobado y reprocesar.',
+            blocking: [],
+            menores: [],
+        };
+    }
+
+    // 2. Captura degradada → no-verificable. No aprobar a ciegas.
+    if (degradation.degraded) {
+        const infraNote = degradation.infra
+            ? ' Es una degradación de infra (no necesariamente defecto del dev): asegurar que el ' +
+              'dashboard esté levantado en el puerto 3200 (node .pipeline/dashboard.js) y reprocesar.'
+            : '';
+        return {
+            resultado: 'rechazado',
+            causa: 'no-verificable',
+            motivo:
+                `No se pudo capturar el render real para comparar (motivo: ${degradation.reason}). ` +
+                'El gate de validación UX no aprueba sin evidencia comparativa.' +
+                infraNote,
+            blocking: [],
+            menores: [],
+        };
+    }
+
+    // 3/4. Particionar divergencias por umbral.
+    const blocking = divergences.filter((d) => isBlocking(d && d.severidad, threshold));
+    const menores = divergences.filter((d) => !isBlocking(d && d.severidad, threshold));
+
+    if (blocking.length > 0) {
+        const detalle = blocking
+            .map((d, i) => `  ${i + 1}. [${normalizeSeverity(d.severidad)}] ${d.aspecto ? d.aspecto + ': ' : ''}${d.descripcion || ''}`.trimEnd())
+            .join('\n');
+        return {
+            resultado: 'rechazado',
+            causa: 'divergencia',
+            motivo:
+                `El render final diverge del mockup aprobado en ${blocking.length} aspecto(s) ` +
+                `visible(s) relevante(s) (umbral: ${threshold}):\n${detalle}\n` +
+                'Rebote a dev para alinear la implementación con el mockup. Evidencia comparativa adjunta.',
+            blocking,
+            menores,
+        };
+    }
+
+    const notaMenores =
+        menores.length > 0
+            ? ` Divergencias menores (no bloqueantes) registradas: ${menores.length}.`
+            : '';
+    return {
+        resultado: 'aprobado',
+        causa: 'coincide',
+        motivo:
+            'El render final coincide con el mockup aprobado dentro del umbral de tolerancia.' +
+            notaMenores +
+            ' Evidencia comparativa adjunta como artefacto de la fase.',
+        blocking: [],
+        menores,
+    };
+}
+
+// -----------------------------------------------------------------------------
+// Evidencia
+// -----------------------------------------------------------------------------
+
+/**
+ * Construye (y crea) el directorio de evidencia issue-scoped.
+ *
+ * @param {string|number} issue
+ * @param {string} repoRoot
+ * @returns {string} path absoluto al directorio de evidencia
+ */
+function evidenceDir(issue, repoRoot = process.cwd()) {
+    const safeIssue = String(issue).replace(/[^0-9]/g, '') || 'unknown';
+    const dir = path.join(repoRoot, '.pipeline', 'assets', 'mockups', safeIssue, 'validacion');
+    try {
+        fs.mkdirSync(dir, { recursive: true });
+    } catch {
+        /* best-effort: el caller maneja la ausencia */
+    }
+    return dir;
+}
+
+module.exports = {
+    // constantes
+    SEVERITIES,
+    DEFAULT_BLOCKING_THRESHOLD,
+    EVIDENCE_MARKER,
+    // resolución de mockup
+    extractMockupRefs,
+    resolveLocalMockups,
+    resolveMockupReference,
+    // captura
+    captureCurrentRender,
+    classifyDegradation,
+    // veredicto
+    normalizeSeverity,
+    isBlocking,
+    decideVerdict,
+    // evidencia
+    evidenceDir,
+};

--- a/.pipeline/tests/ux-render-compare.test.js
+++ b/.pipeline/tests/ux-render-compare.test.js
@@ -1,0 +1,211 @@
+'use strict';
+
+// Tests de ux-render-compare (issue #4228 — gate de validación UX render vs mockup).
+//
+// Cubre la lógica determinística del gate:
+//   - extractMockupRefs / resolveMockupReference (resolución del mockup esperado)
+//   - classifyDegradation (dashboard caído → no aprobar a ciegas)
+//   - decideVerdict (regla de decisión pasa/rechaza por severidad y degradación)
+//   - captureCurrentRender (wrapper, con captura inyectada)
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const os = require('os');
+const fs = require('fs');
+const path = require('path');
+
+const mod = require('../lib/ux-render-compare');
+
+// ----- extractMockupRefs ----------------------------------------------------
+
+test('extractMockupRefs detecta el mockup "esperado" por alt-text', () => {
+    const body = [
+        '## Objetivo',
+        'Rediseño HOME.',
+        '',
+        '## Screenshots & Mockups',
+        '![estado actual](https://x/actual.png)',
+        '![estado esperado (mockup)](https://x/esperado.png)',
+        '',
+        '## Criterios',
+    ].join('\n');
+    const r = mod.extractMockupRefs(body);
+    assert.equal(r.reason, 'ok');
+    assert.deepEqual(r.all, ['https://x/actual.png', 'https://x/esperado.png']);
+    assert.deepEqual(r.mockups, ['https://x/esperado.png']);
+});
+
+test('extractMockupRefs reporta section-missing si no hay sección', () => {
+    const r = mod.extractMockupRefs('## Objetivo\nsin screenshots');
+    assert.equal(r.reason, 'section-missing');
+    assert.equal(r.all.length, 0);
+});
+
+test('extractMockupRefs reporta no-images si la sección está vacía', () => {
+    const body = '## Screenshots & Mockups\n\n(pendiente)\n\n## Criterios';
+    const r = mod.extractMockupRefs(body);
+    assert.equal(r.reason, 'no-images');
+});
+
+test('extractMockupRefs reporta empty-body con body vacío', () => {
+    assert.equal(mod.extractMockupRefs('').reason, 'empty-body');
+});
+
+// ----- resolveMockupReference ----------------------------------------------
+
+test('resolveMockupReference prioriza el mockup del body del issue', () => {
+    const body = [
+        '## Screenshots & Mockups',
+        '![actual](https://x/a.png)',
+        '![esperado](https://x/e.png)',
+    ].join('\n');
+    const r = mod.resolveMockupReference({ body, issue: 4228, repoRoot: process.cwd() });
+    assert.equal(r.ok, true);
+    assert.equal(r.source, 'issue-body');
+    assert.deepEqual(r.refs, ['https://x/e.png']);
+});
+
+test('resolveMockupReference cae a assets locales cuando el body no tiene mockup', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'uxrc-'));
+    const issue = 9999;
+    const dir = path.join(tmp, '.pipeline', 'assets', 'mockups', String(issue));
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'home-esperado.png'), 'fake');
+    fs.writeFileSync(path.join(dir, 'notas.txt'), 'ignorar');
+
+    const r = mod.resolveMockupReference({ body: '## Objetivo\nsin imgs', issue, repoRoot: tmp });
+    assert.equal(r.ok, true);
+    assert.equal(r.source, 'local-assets');
+    assert.equal(r.refs.length, 1);
+    assert.match(r.refs[0], /home-esperado\.png$/);
+
+    fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+test('resolveMockupReference falla (ok:false) si no hay mockup en ningún lado', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'uxrc-'));
+    const r = mod.resolveMockupReference({ body: '## Objetivo\nnada', issue: 1, repoRoot: tmp });
+    assert.equal(r.ok, false);
+    assert.equal(r.source, 'none');
+    fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+// ----- classifyDegradation --------------------------------------------------
+
+test('classifyDegradation: captura ok → no degradado', () => {
+    const d = mod.classifyDegradation({ ok: true, outputPath: '/x.png' });
+    assert.deepEqual(d, { degraded: false, infra: false, reason: null });
+});
+
+test('classifyDegradation: dashboard-down → degradado + infra', () => {
+    const d = mod.classifyDegradation({ ok: false, reason: 'dashboard-down' });
+    assert.equal(d.degraded, true);
+    assert.equal(d.infra, true);
+    assert.equal(d.reason, 'dashboard-down');
+});
+
+test('classifyDegradation: puppeteer-missing → degradado + infra', () => {
+    const d = mod.classifyDegradation({ ok: false, reason: 'puppeteer-missing' });
+    assert.equal(d.infra, true);
+});
+
+// ----- decideVerdict --------------------------------------------------------
+
+test('decideVerdict: sin mockup → rechazado por sin-mockup', () => {
+    const v = mod.decideVerdict({ mockupResolved: false, divergences: [] });
+    assert.equal(v.resultado, 'rechazado');
+    assert.equal(v.causa, 'sin-mockup');
+});
+
+test('decideVerdict: captura degradada → rechazado no-verificable (no aprueba a ciegas)', () => {
+    const v = mod.decideVerdict({
+        mockupResolved: true,
+        degradation: { degraded: true, infra: true, reason: 'dashboard-down' },
+        divergences: [],
+    });
+    assert.equal(v.resultado, 'rechazado');
+    assert.equal(v.causa, 'no-verificable');
+    assert.match(v.motivo, /3200/);
+});
+
+test('decideVerdict: divergencia relevante (alta) → rechazado y rebote a dev', () => {
+    const v = mod.decideVerdict({
+        divergences: [
+            { aspecto: 'layout', descripcion: 'la card HOME usa 1 columna en vez de 3', severidad: 'alta' },
+        ],
+    });
+    assert.equal(v.resultado, 'rechazado');
+    assert.equal(v.causa, 'divergencia');
+    assert.equal(v.blocking.length, 1);
+    assert.match(v.motivo, /layout/);
+});
+
+test('decideVerdict: solo divergencia baja → aprobado con nota', () => {
+    const v = mod.decideVerdict({
+        divergences: [{ aspecto: 'spacing', descripcion: '2px de diferencia', severidad: 'baja' }],
+    });
+    assert.equal(v.resultado, 'aprobado');
+    assert.equal(v.menores.length, 1);
+});
+
+test('decideVerdict: sin divergencias → aprobado', () => {
+    const v = mod.decideVerdict({ divergences: [] });
+    assert.equal(v.resultado, 'aprobado');
+    assert.equal(v.causa, 'coincide');
+});
+
+test('decideVerdict: severidad desconocida se trata como media (bloquea por default)', () => {
+    const v = mod.decideVerdict({
+        divergences: [{ descripcion: 'algo raro', severidad: 'no-existe' }],
+    });
+    assert.equal(v.resultado, 'rechazado');
+});
+
+test('decideVerdict: umbral configurable a alta deja pasar divergencias media', () => {
+    const v = mod.decideVerdict({
+        threshold: 'alta',
+        divergences: [{ descripcion: 'color levemente distinto', severidad: 'media' }],
+    });
+    assert.equal(v.resultado, 'aprobado');
+});
+
+// ----- isBlocking -----------------------------------------------------------
+
+test('isBlocking: critica/alta/media bloquean con umbral media; baja no', () => {
+    assert.equal(mod.isBlocking('critica', 'media'), true);
+    assert.equal(mod.isBlocking('alta', 'media'), true);
+    assert.equal(mod.isBlocking('media', 'media'), true);
+    assert.equal(mod.isBlocking('baja', 'media'), false);
+});
+
+// ----- captureCurrentRender (captura inyectada) -----------------------------
+
+test('captureCurrentRender delega en capture() y propaga el resultado ok', async () => {
+    const fakeCapture = async (o) => ({ ok: true, outputPath: o.outputPath });
+    const r = await mod.captureCurrentRender({
+        outputPath: 'render.png',
+        allowedRoot: '/tmp',
+        _capture: fakeCapture,
+    });
+    assert.equal(r.ok, true);
+    assert.equal(r.outputPath, 'render.png');
+});
+
+test('captureCurrentRender atrapa throws de capture() como capture-input-error', async () => {
+    const boom = async () => {
+        throw new Error('path traversal detectado');
+    };
+    const r = await mod.captureCurrentRender({ outputPath: '../evil', allowedRoot: '/tmp', _capture: boom });
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, 'capture-input-error');
+});
+
+// ----- evidenceDir ----------------------------------------------------------
+
+test('evidenceDir crea el directorio issue-scoped de validación', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'uxrc-ev-'));
+    const dir = mod.evidenceDir(4228, tmp);
+    assert.ok(fs.existsSync(dir));
+    assert.match(dir, /4228[\\/]validacion$/);
+    fs.rmSync(tmp, { recursive: true, force: true });
+});


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 3 archivos · +689 -0

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:skipped` aplicado por delivery

## Closes

Closes #4228
