### PR TITLE
Barrido automático de markers de fase huérfanos al cerrar un issue

### DIFF
--- a/.pipeline/lib/__tests__/servicio-reconciler.test.js
+++ b/.pipeline/lib/__tests__/servicio-reconciler.test.js
@@ -847,3 +847,196 @@ test('#4222 Gherkin: needs-human legítimo (sin avance) mantiene el bloqueo', ()
     clearProgressMarkers();
     clearAllMarkers();
 });
+
+// =============================================================================
+// #4231 — Barrido de markers de fase huérfanos al cerrar un issue.
+// listPhaseMarkers (human-block) recorre colas normales; reconcileClosedPhaseMarkers
+// archiva los markers de issues CLOSED de esas colas (no solo bloqueado-humano).
+// =============================================================================
+
+function writeNormalQueueMarker(pipeline, phase, state, issue, skill) {
+    const dir = path.join(PIPELINE, pipeline, phase, state);
+    fs.mkdirSync(dir, { recursive: true });
+    const p = path.join(dir, `${issue}.${skill}`);
+    fs.writeFileSync(p, '');
+    return p;
+}
+
+function clearNormalQueues() {
+    for (const pipeline of ['desarrollo', 'definicion']) {
+        const root = path.join(PIPELINE, pipeline);
+        if (!fs.existsSync(root)) continue;
+        for (const phase of fs.readdirSync(root)) {
+            for (const state of ['pendiente', 'trabajando', 'listo', 'procesado', 'archivado']) {
+                const dir = path.join(root, phase, state);
+                if (!fs.existsSync(dir)) continue;
+                for (const f of fs.readdirSync(dir)) {
+                    try { fs.unlinkSync(path.join(dir, f)); } catch {}
+                }
+            }
+        }
+    }
+}
+
+test('#4231 listPhaseMarkers recorre colas normales y omite artifacts/.gitkeep', () => {
+    clearNormalQueues();
+    writeNormalQueueMarker('definicion', 'analisis', 'listo', 3488, 'security');
+    writeNormalQueueMarker('desarrollo', 'validacion', 'listo', 3987, 'ux');
+    writeNormalQueueMarker('desarrollo', 'dev', 'trabajando', 4231, 'backend-dev');
+    // Artifacts que NO deben contar como markers
+    const dir = path.join(PIPELINE, 'definicion', 'analisis', 'listo');
+    fs.writeFileSync(path.join(dir, '3488.security.reason.json'), '{}');
+    fs.writeFileSync(path.join(dir, '.gitkeep'), '');
+
+    const markers = humanBlock.listPhaseMarkers();
+    const keys = markers.map(m => `${m.pipeline}/${m.phase}/${m.state}/${m.issue}.${m.skill}`).sort();
+    assert.deepEqual(keys, [
+        'definicion/analisis/listo/3488.security',
+        'desarrollo/dev/trabajando/4231.backend-dev',
+        'desarrollo/validacion/listo/3987.ux',
+    ]);
+    // El artifact .reason.json no aparece
+    assert.equal(markers.some(m => m.skill.includes('reason')), false);
+    clearNormalQueues();
+});
+
+test('#4231 listPhaseMarkers NO mira bloqueado-humano/', () => {
+    clearNormalQueues();
+    clearAllMarkers();
+    const blockedDir = path.join(PIPELINE, 'desarrollo', 'validacion', 'bloqueado-humano');
+    fs.mkdirSync(blockedDir, { recursive: true });
+    fs.writeFileSync(path.join(blockedDir, '9100.po'), '');
+    const markers = humanBlock.listPhaseMarkers();
+    assert.equal(markers.some(m => m.issue === 9100), false, 'bloqueado-humano fuera de scope');
+    clearNormalQueues();
+    clearAllMarkers();
+});
+
+test('#4231 reconcileClosedPhaseMarkers archiva marker de issue CLOSED (mueve, no borra)', () => {
+    clearNormalQueues();
+    const src = writeNormalQueueMarker('definicion', 'analisis', 'listo', 3488, 'security');
+    const markers = humanBlock.listPhaseMarkers();
+    const archived = reconciler.reconcileClosedPhaseMarkers(markers, () => 'CLOSED');
+
+    assert.equal(archived, 1);
+    assert.equal(fs.existsSync(src), false, 'marker movido fuera de la cola');
+    const dst = path.join(PIPELINE, 'definicion', 'analisis', 'archivado', '3488.security');
+    assert.equal(fs.existsSync(dst), true, 'marker presente en archivado/ (no borrado)');
+    clearNormalQueues();
+});
+
+test('#4231 reconcileClosedPhaseMarkers NO toca markers de issues OPEN', () => {
+    clearNormalQueues();
+    const src = writeNormalQueueMarker('desarrollo', 'dev', 'trabajando', 4231, 'backend-dev');
+    const markers = humanBlock.listPhaseMarkers();
+    const archived = reconciler.reconcileClosedPhaseMarkers(markers, () => 'OPEN');
+
+    assert.equal(archived, 0);
+    assert.equal(fs.existsSync(src), true, 'marker de issue OPEN permanece en su cola');
+    clearNormalQueues();
+});
+
+test('#4231 reconcileClosedPhaseMarkers NO toca UNKNOWN (degradación segura)', () => {
+    clearNormalQueues();
+    const src = writeNormalQueueMarker('desarrollo', 'dev', 'pendiente', 4500, 'backend-dev');
+    const markers = humanBlock.listPhaseMarkers();
+    const archived = reconciler.reconcileClosedPhaseMarkers(markers, () => 'UNKNOWN');
+    assert.equal(archived, 0);
+    assert.equal(fs.existsSync(src), true, 'UNKNOWN no se archiva');
+    clearNormalQueues();
+});
+
+test('#4231 reconcileClosedPhaseMarkers archiva markers del MISMO issue en varias fases/colas', () => {
+    clearNormalQueues();
+    // #3987 CLOSED con markers en 3 ubicaciones distintas (backfill real)
+    const s1 = writeNormalQueueMarker('definicion', 'analisis', 'listo', 3987, 'security');
+    const s2 = writeNormalQueueMarker('desarrollo', 'validacion', 'listo', 3987, 'guru');
+    const s3 = writeNormalQueueMarker('desarrollo', 'validacion', 'procesado', 3987, 'ux');
+
+    const markers = humanBlock.listPhaseMarkers();
+    const archived = reconciler.reconcileClosedPhaseMarkers(markers, () => 'CLOSED');
+
+    assert.equal(archived, 3, 'archiva los 3 markers del issue cerrado');
+    assert.equal(fs.existsSync(s1), false);
+    assert.equal(fs.existsSync(s2), false);
+    assert.equal(fs.existsSync(s3), false);
+    assert.equal(fs.existsSync(path.join(PIPELINE, 'definicion', 'analisis', 'archivado', '3987.security')), true);
+    assert.equal(fs.existsSync(path.join(PIPELINE, 'desarrollo', 'validacion', 'archivado', '3987.guru')), true);
+    assert.equal(fs.existsSync(path.join(PIPELINE, 'desarrollo', 'validacion', 'archivado', '3987.ux')), true);
+    clearNormalQueues();
+});
+
+test('#4231 reconcileClosedPhaseMarkers deduplica el chequeo de estado por issue', () => {
+    clearNormalQueues();
+    writeNormalQueueMarker('definicion', 'analisis', 'listo', 4110, 'security');
+    writeNormalQueueMarker('desarrollo', 'validacion', 'listo', 4110, 'guru');
+    writeNormalQueueMarker('desarrollo', 'validacion', 'listo', 4110, 'po');
+
+    const markers = humanBlock.listPhaseMarkers();
+    const seen = [];
+    const archived = reconciler.reconcileClosedPhaseMarkers(markers, (n) => { seen.push(n); return 'CLOSED'; });
+
+    assert.equal(archived, 3, 'archiva los 3 markers');
+    assert.equal(seen.length, 1, 'el estado se consulta una sola vez para el issue 4110');
+    assert.equal(seen[0], 4110);
+    clearNormalQueues();
+});
+
+test('#4231 reconcileClosedPhaseMarkers usa sufijo timestamp ante colisión en archivado/', () => {
+    clearNormalQueues();
+    // Ya existe un archivado previo con el mismo nombre.
+    const archDir = path.join(PIPELINE, 'desarrollo', 'dev', 'archivado');
+    fs.mkdirSync(archDir, { recursive: true });
+    fs.writeFileSync(path.join(archDir, '4600.backend-dev'), 'previo');
+    writeNormalQueueMarker('desarrollo', 'dev', 'pendiente', 4600, 'backend-dev');
+
+    const markers = humanBlock.listPhaseMarkers();
+    const archived = reconciler.reconcileClosedPhaseMarkers(markers, () => 'CLOSED', { now: Date.parse('2026-06-26T12:00:00.000Z') });
+
+    assert.equal(archived, 1);
+    // El archivado previo no se pisa
+    assert.equal(fs.readFileSync(path.join(archDir, '4600.backend-dev'), 'utf8'), 'previo');
+    const suffixed = fs.readdirSync(archDir).filter(f => f.startsWith('4600.backend-dev.'));
+    assert.equal(suffixed.length, 1, 'el nuevo se archiva con sufijo timestamp');
+    assert.match(suffixed[0], /4600\.backend-dev\.2026-06-26T12-00-00-000Z/);
+    clearNormalQueues();
+});
+
+test('#4231 reconcileClosedPhaseMarkers escribe stale-orders.log con reason closed-phase-marker-archived', () => {
+    clearNormalQueues();
+    const logFile = path.join(PIPELINE, 'logs', 'stale-orders.log');
+    try { fs.unlinkSync(logFile); } catch {}
+    writeNormalQueueMarker('definicion', 'analisis', 'listo', 3935, 'security');
+
+    const markers = humanBlock.listPhaseMarkers();
+    reconciler.reconcileClosedPhaseMarkers(markers, () => 'CLOSED');
+
+    const ev = JSON.parse(fs.readFileSync(logFile, 'utf8').trim().split('\n').pop());
+    assert.equal(ev.reason, 'closed-phase-marker-archived');
+    assert.equal(ev.issue, 3935);
+    assert.match(ev.detail, /definicion\/analisis\/listo\/3935\.security/);
+    clearNormalQueues();
+});
+
+// Escenario Gherkin 1: issue cerrado con marker en cola normal → se archiva
+test('#4231 Gherkin: issue CLOSED con marker en listo/ se archiva', () => {
+    clearNormalQueues();
+    const src = writeNormalQueueMarker('desarrollo', 'verificacion', 'listo', 3488, 'tester');
+    const markers = humanBlock.listPhaseMarkers();
+    const archived = reconciler.reconcileClosedPhaseMarkers(markers, () => 'CLOSED');
+    assert.equal(archived, 1);
+    assert.equal(fs.existsSync(src), false);
+    assert.equal(fs.existsSync(path.join(PIPELINE, 'desarrollo', 'verificacion', 'archivado', '3488.tester')), true);
+    clearNormalQueues();
+});
+
+// Escenario Gherkin 2: issue abierto con marker en trabajando/ → no se toca
+test('#4231 Gherkin: issue OPEN con marker en trabajando/ permanece', () => {
+    clearNormalQueues();
+    const src = writeNormalQueueMarker('desarrollo', 'dev', 'trabajando', 4231, 'backend-dev');
+    const markers = humanBlock.listPhaseMarkers();
+    const archived = reconciler.reconcileClosedPhaseMarkers(markers, () => 'OPEN');
+    assert.equal(archived, 0);
+    assert.equal(fs.existsSync(src), true);
+    clearNormalQueues();
+});

--- a/.pipeline/lib/human-block.js
+++ b/.pipeline/lib/human-block.js
@@ -251,6 +251,57 @@ function listBlockedIssues() {
     return result.sort((a, b) => b.age_hours - a.age_hours);
 }
 
+// #4231 — Colas normales de fase (no bloqueado-humano). Un marker de fase en
+// cualquiera de estas colas representa trabajo del issue en esa etapa. La vista
+// del pipeline las lee como "trabajo activo".
+const PHASE_QUEUE_STATES = ['pendiente', 'trabajando', 'listo', 'procesado'];
+
+// #4231 — Lista los markers de fase que viven en las colas NORMALES
+// (pendiente/trabajando/listo/procesado), NO en bloqueado-humano/. Análogo a
+// listBlockedIssues() pero sobre el flujo normal del pipeline.
+//
+// El reconciler lo usa para cerrar el hueco de markers huérfanos: cuando un
+// issue cierra en GitHub, sus markers de fase en estas colas quedaban sin
+// archivar (el barrido de bloqueado-humano no las mira, y el limpiador de ghost
+// artifacts por diseño no toca markers de fase). Devuelve entries con la cola
+// (`state`) para que el caller sepa de dónde mover el marker a archivado/.
+//
+// @param {object} [opts]
+// @param {string[]} [opts.states] — subconjunto de colas a recorrer (default: todas).
+// @returns {Array<{issue,skill,phase,pipeline,state,marker_path}>}
+function listPhaseMarkers(opts = {}) {
+    const states = Array.isArray(opts.states) && opts.states.length
+        ? opts.states
+        : PHASE_QUEUE_STATES;
+    const result = [];
+    for (const pipeline of PIPELINES) {
+        const pipeRoot = path.join(PIPELINE_DIR, pipeline);
+        let phases = [];
+        try { phases = fs.readdirSync(pipeRoot).filter(f => fs.statSync(path.join(pipeRoot, f)).isDirectory()); }
+        catch { continue; }
+        for (const phase of phases) {
+            for (const state of states) {
+                const dir = path.join(pipeRoot, phase, state);
+                let entries = [];
+                try { entries = fs.readdirSync(dir); } catch { continue; }
+                for (const f of entries) {
+                    if (f === '.gitkeep' || isMarkerArtifact(f)) continue;
+                    const dot = f.indexOf('.');
+                    if (dot <= 0) continue;
+                    const issue = Number(f.slice(0, dot));
+                    const skill = f.slice(dot + 1);
+                    if (!Number.isInteger(issue) || !skill) continue;
+                    result.push({
+                        issue, skill, phase, pipeline, state,
+                        marker_path: path.join(dir, f),
+                    });
+                }
+            }
+        }
+    }
+    return result;
+}
+
 function unblockIssue(opts) {
     const issue = Number(opts.issue);
     if (!issue) throw new Error('unblockIssue requiere issue');
@@ -700,6 +751,8 @@ module.exports = {
     unblockIssue,
     dismissBlockedIssue,
     listBlockedIssues,
+    listPhaseMarkers,
+    PHASE_QUEUE_STATES,
     findActiveMarker,
     findBlockedMarker,
     isHumanBlockReason,

--- a/.pipeline/servicio-reconciler.js
+++ b/.pipeline/servicio-reconciler.js
@@ -435,6 +435,96 @@ function reconcileClosedMarkers(blockedMarkers, ghIssueSet, getStateFn = getIssu
 }
 
 // -----------------------------------------------------------------------------
+// #4231 — Barrido de markers de fase huérfanos de issues CLOSED en colas normales
+// -----------------------------------------------------------------------------
+//
+// Hueco que cierra: `reconcileClosedMarkers` (arriba) solo archiva markers de
+// issues CLOSED que están en `bloqueado-humano/`. Los markers de fase normales
+// (pendiente/trabajando/listo/procesado) de un issue ya cerrado nunca se
+// archivaban — quedaban huérfanos y la vista del pipeline los leía como trabajo
+// activo. El limpiador de ghost artifacts tampoco los toca (por diseño no pisa
+// markers de fase, contrato Pulpo↔agente).
+//
+// Reusa el mismo patrón de archivado: rename del marker a `<pipeline>/<phase>/
+// archivado/`. Nunca borra. Solo archiva markers de issues CLOSED; los OPEN no
+// se tocan (trabajo activo).
+//
+// Costo `gh`: el caller (reconcileOnce) resuelve el estado con UNA sola consulta
+// batch (`gh issue list --state closed`) por ciclo y pasa un resolver sobre ese
+// Set, en vez de N `gh issue view`. Igual deduplicamos el chequeo por issue acá
+// (un issue puede tener markers en varias fases/colas) para no consultar de más
+// si el resolver hiciera I/O.
+function reconcileClosedPhaseMarkers(phaseMarkers, getStateFn = getIssueState, opts = {}) {
+    const now = opts.now || Date.now();
+    const logFn = opts.logStaleOrder || appendStaleOrderLog;
+    let archived = 0;
+    const stateCache = new Map(); // issue -> state (dedup del chequeo, no del archivado)
+    for (const m of phaseMarkers) {
+        let state = stateCache.get(m.issue);
+        if (state === undefined) {
+            state = getStateFn(m.issue);
+            stateCache.set(m.issue, state);
+        }
+        if (state !== 'CLOSED') continue; // OPEN/UNKNOWN → trabajo activo, no tocar
+
+        const baseName = `${m.issue}.${m.skill}`;
+        const srcMarker = m.marker_path
+            || path.join(PIPELINE, m.pipeline, m.phase, m.state, baseName);
+        const archiveDir = path.join(PIPELINE, m.pipeline, m.phase, 'archivado');
+        try {
+            if (!fs.existsSync(srcMarker)) continue; // movido entre listado y ahora
+            fs.mkdirSync(archiveDir, { recursive: true });
+            // Colisión: mismo issue.skill ya archivado (otra cola/ciclo previo) →
+            // sufijo timestamp Windows-safe para no pisar el histórico.
+            let dstMarker = path.join(archiveDir, baseName);
+            if (fs.existsSync(dstMarker)) {
+                dstMarker = path.join(archiveDir, `${baseName}.${safeTsSuffix(now)}`);
+            }
+            fs.renameSync(srcMarker, dstMarker);
+            // Sidecar .reason.json (raro en colas normales) — limpiar si quedó.
+            try { fs.unlinkSync(srcMarker + '.reason.json'); } catch {}
+            archived++;
+            try {
+                logFn({
+                    reason: 'closed-phase-marker-archived',
+                    issue: m.issue,
+                    label: null,
+                    snapshot_at: null,
+                    current_mtime: null,
+                    detail: `${m.pipeline}/${m.phase}/${m.state}/${baseName} → archivado/`,
+                });
+            } catch {}
+        } catch (e) {
+            log(`Error archivando phase marker #${m.issue}.${m.skill}: ${e.message.slice(0, 120)}`);
+        }
+    }
+    return archived;
+}
+
+// #4231 — Resuelve en UNA consulta el set de issues CLOSED del repo. El sweep de
+// markers de fase recorre ~decenas de issues por ciclo; un `gh issue view` por
+// cada uno multiplicaría las llamadas (nota de guru en #4231). Una sola
+// `gh issue list --state closed` cubre todo el histórico (gh pagina internamente)
+// y el resolver queda como lookup O(1) sobre el Set. Devuelve null si GitHub no
+// responde → el caller saltea el sweep (degradación segura: jamás archiva OPEN).
+const CLOSED_SWEEP_LIMIT = parseInt(process.env.RECONCILER_CLOSED_LIMIT || '5000', 10);
+
+function listClosedIssueNumbers(opts = {}) {
+    const limit = opts.limit || CLOSED_SWEEP_LIMIT;
+    try {
+        const raw = execSync(
+            `"${GH_BIN}" issue list --state closed --json number --limit ${limit}`,
+            { cwd: ROOT, encoding: 'utf8', timeout: 30000, windowsHide: true },
+        );
+        const issues = JSON.parse(raw || '[]');
+        return new Set(issues.map(i => i.number));
+    } catch (e) {
+        log(`Error listando closed issues (phase-marker sweep): ${e.message.slice(0, 120)}`);
+        return null;
+    }
+}
+
+// -----------------------------------------------------------------------------
 // CA3 (#2994) — Detectar destrabe humano y reconciliar siguiendo a GitHub
 // -----------------------------------------------------------------------------
 //
@@ -992,6 +1082,24 @@ function reconcileOnce() {
     const enqueued = reconcileMarkerToLabel(remaining, ghIssueSet);
     const archived = reconcileClosedMarkers(remaining, ghIssueSet);
 
+    // #4231 — Barrido de markers de fase huérfanos de issues CLOSED en las colas
+    // NORMALES (pendiente/trabajando/listo/procesado). reconcileClosedMarkers de
+    // arriba solo cubre bloqueado-humano/; este cierra el hueco. Fail-soft: si
+    // GitHub no responde para el batch de cerrados, se saltea (nunca archiva OPEN).
+    let archivedPhase = 0;
+    try {
+        const phaseMarkers = humanBlock.listPhaseMarkers();
+        if (phaseMarkers.length > 0) {
+            const closedSet = listClosedIssueNumbers();
+            if (closedSet) {
+                const closedResolver = (issueNum) => (closedSet.has(issueNum) ? 'CLOSED' : 'OPEN');
+                archivedPhase = reconcileClosedPhaseMarkers(phaseMarkers, closedResolver);
+            }
+        }
+    } catch (e) {
+        log(`Phase-marker sweep error: ${e.message.slice(0, 120)}`);
+    }
+
     // #3175 — Sweep paralelo del admission gate (defensa en profundidad).
     // Fallas del sweep son no-fatales: si GH no responde o falla la cola,
     // el ciclo del reconciler debe completar igual.
@@ -1021,8 +1129,9 @@ function reconcileOnce() {
     const screenshotsSummary = screenshotsResult && !screenshotsResult.skipped && !screenshotsResult.error && screenshotsResult.appliedCount
         ? `, +${screenshotsResult.appliedCount} screenshots-gate`
         : '';
-    if (created || enqueued || archived || detected || resolved || (admissionResult && admissionResult.appliedCount) || (screenshotsResult && screenshotsResult.appliedCount)) {
-        log(`Ciclo ${cycleCount} (${elapsed}ms): GH=${ghIssues.length} markers=${blockedMarkers.length} → +${created} placeholders, +${enqueued} labels encolados, +${archived} archivados (closed), +${detected} destrabes humanos, +${resolved} resueltos por guardian/TTL (-${resolvedRemovedLabels} labels removidos)${admissionSummary}${screenshotsSummary}`);
+    const phaseSummary = archivedPhase ? `, +${archivedPhase} markers de fase archivados (closed)` : '';
+    if (created || enqueued || archived || archivedPhase || detected || resolved || (admissionResult && admissionResult.appliedCount) || (screenshotsResult && screenshotsResult.appliedCount)) {
+        log(`Ciclo ${cycleCount} (${elapsed}ms): GH=${ghIssues.length} markers=${blockedMarkers.length} → +${created} placeholders, +${enqueued} labels encolados, +${archived} archivados (closed), +${detected} destrabes humanos, +${resolved} resueltos por guardian/TTL (-${resolvedRemovedLabels} labels removidos)${phaseSummary}${admissionSummary}${screenshotsSummary}`);
     } else {
         log(`Ciclo ${cycleCount} (${elapsed}ms): GH=${ghIssues.length} markers=${blockedMarkers.length} — sincronizado`);
     }
@@ -1071,6 +1180,10 @@ module.exports = {
     reconcileLabelToFilesystem,
     reconcileMarkerToLabel,
     reconcileClosedMarkers,
+    // #4231 — barrido de markers de fase huérfanos (colas normales)
+    reconcileClosedPhaseMarkers,
+    listClosedIssueNumbers,
+    CLOSED_SWEEP_LIMIT,
     reconcileHumanUnblockDetected,
     reconcileResolvedMarkers,
     findGuardianResolution,


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 3 archivos · +361 -2

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:passed` aplicado por delivery

## Closes

Closes #4231
