### PR TITLE
fix(dashboard): submenús de acciones por issue se desplegaban todos a la vez (ventana ISSUES)

### DIFF
--- a/.pipeline/views/dashboard/issues.js
+++ b/.pipeline/views/dashboard/issues.js
@@ -905,6 +905,9 @@ const ISSUES_CSS = `
 }
 .iss-menu-btn:hover { border-color: var(--info, var(--in-accent)); color: var(--info, var(--in-accent)); }
 .iss-menu-btn[aria-expanded="true"] { border-color: var(--info, var(--in-info)); color: var(--info, var(--in-info)); }
+/* Reset: el atributo [hidden] debe ganarle al display:flex de los menús flotantes,
+   sino todos los submenús se despliegan a la vez (bug visto en la ventana ISSUES). */
+.iss-menu[hidden], .mz-proj-menu[hidden], .mz-more-menu[hidden] { display: none !important; }
 .iss-menu {
     position: absolute; right: 0; bottom: calc(100% + 6px); z-index: 60; min-width: 250px;
     display: flex; flex-direction: column; gap: 2px; padding: 6px;


### PR DESCRIPTION
## Problema
En la ventana **ISSUES** del dashboard MIZPÁ, los menús de acciones (⋯) de **todos** los issues se mostraban desplegados al mismo tiempo, tapando la pantalla. Lo mismo pasaba con el selector de proyecto y el menú «Más».

## Causa
Los menús se ocultan con el atributo HTML `hidden` (toggle por JS), pero la regla CSS `.iss-menu { display: flex }` (y `.mz-proj-menu` / `.mz-more-menu`) tiene mayor especificidad que el `[hidden] { display:none }` del user-agent, por lo que el `hidden` no surtía efecto y todos los popovers quedaban abiertos.

## Fix
Se agrega el reset:
```css
.iss-menu[hidden], .mz-proj-menu[hidden], .mz-more-menu[hidden] { display: none !important; }
```

## Validación
- Render verificado en el dashboard en vivo (`curl + grep`): la regla aparece en el HTML servido y los menús salen con el atributo `hidden`.
- Dashboard reiniciado para tomar el módulo cacheado.

qa:skipped — fix puro de CSS en infra del dashboard, sin impacto en producto de usuario final.

🤖 Generated with [Claude Code](https://claude.com/claude-code)