### PR TITLE
Mostrar el proveedor real por agente en ejecución en el dashboard (no siempre cloud/Anthropic)

### DIFF
--- a/.pipeline/lib/__tests__/dashboard-slices-active-effective-provider-4284.test.js
+++ b/.pipeline/lib/__tests__/dashboard-slices-active-effective-provider-4284.test.js
@@ -1,0 +1,104 @@
+// =============================================================================
+// Tests `activeAgents` — provider EFECTIVO sobre el configurado (#4284)
+//
+// Cubre los CA verificables del slice:
+//   - CA-1/CA-2: con marker efectivo (Anthropic apagado → openai-codex), la card
+//     muestra id "openai-codex" + label "Codex", NO el configurado por skill.
+//   - CA-3: sin marker (TTL vencido / no escrito), cae al provider CONFIGURADO
+//     manteniendo el shape `{ id, label, model }` (happy path intacto).
+//   - CA-8: el label sale de PROVIDER_LABELS (naming canónico).
+//
+// El marker se aísla monkeypatcheando `readRunningProviders` sobre la instancia
+// cacheada de `running-providers` que captura el slice — jamás toca el archivo
+// real del repo.
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const runningProviders = require('../running-providers');
+const slices = require('../dashboard-slices');
+
+// El slice llama `runningProviders.readRunningProviders()` sin args en runtime;
+// sobreescribimos el método sobre la instancia cacheada para inyectar markers.
+const realReadMarkers = runningProviders.readRunningProviders;
+function setMarkers(map) {
+    runningProviders.readRunningProviders = () => map;
+}
+function restoreMarkers() {
+    runningProviders.readRunningProviders = realReadMarkers;
+}
+
+// Estado con un agente pipeline-dev en `trabajando/`. El skill configurado en
+// agent-models.json es 'anthropic' (default), así que sin marker debe mostrar
+// Claude; con marker openai-codex debe mostrar Codex.
+function stateWithAgent() {
+    return {
+        issueMatrix: {
+            '4284': {
+                title: 'Provider efectivo',
+                estadoActual: 'trabajando',
+                faseActual: 'desarrollo/dev',
+                fases: {
+                    'desarrollo/dev': [
+                        { skill: 'pipeline-dev', pipeline: 'desarrollo', fase: 'dev', estado: 'trabajando', durationMs: 60000 },
+                    ],
+                },
+            },
+        },
+        etaAverages: {},
+    };
+}
+
+test('CA-1/CA-2: marker efectivo (openai-codex) tiene prioridad sobre el configurado', () => {
+    setMarkers({
+        'desarrollo/dev/pipeline-dev:4284': {
+            provider: 'openai-codex', model: 'gpt-5-codex', source: 'fallback', startedAt: Date.now(), durationMs: 1000,
+        },
+    });
+    try {
+        const out = slices.activeAgents(stateWithAgent());
+        const agent = out.find(a => a.issue === '4284');
+        assert.ok(agent, 'el agente debe estar');
+        assert.ok(agent.provider, 'debe tener provider');
+        assert.equal(agent.provider.id, 'openai-codex', 'id efectivo, no el configurado');
+        assert.equal(agent.provider.label, 'Codex', 'label canónico de PROVIDER_LABELS (CA-8)');
+        assert.equal(agent.provider.model, 'gpt-5-codex', 'modelo efectivo del marker');
+    } finally {
+        restoreMarkers();
+    }
+});
+
+test('CA-3: sin marker, cae al provider configurado (happy path, shape intacto)', () => {
+    setMarkers({}); // ningún marker para este agente
+    try {
+        const out = slices.activeAgents(stateWithAgent());
+        const agent = out.find(a => a.issue === '4284');
+        assert.ok(agent);
+        assert.ok(agent.provider, 'debe resolver el provider configurado');
+        // Shape `{ id, label, model }` presente.
+        assert.ok('id' in agent.provider && 'label' in agent.provider && 'model' in agent.provider);
+        // El configurado por skill no debe ser openai-codex (no hay fallback).
+        assert.notEqual(agent.provider.id, 'openai-codex');
+    } finally {
+        restoreMarkers();
+    }
+});
+
+test('CA-3: marker de OTRO agente no contamina a éste (match por clave exacta)', () => {
+    setMarkers({
+        'desarrollo/dev/otro-skill:9999': {
+            provider: 'cerebras', model: null, source: 'fallback', startedAt: Date.now(), durationMs: 1000,
+        },
+    });
+    try {
+        const out = slices.activeAgents(stateWithAgent());
+        const agent = out.find(a => a.issue === '4284');
+        assert.ok(agent);
+        // No debe tomar el provider del marker ajeno.
+        assert.notEqual(agent.provider && agent.provider.id, 'cerebras');
+    } finally {
+        restoreMarkers();
+    }
+});

--- a/.pipeline/lib/__tests__/running-providers.test.js
+++ b/.pipeline/lib/__tests__/running-providers.test.js
@@ -1,0 +1,170 @@
+// =============================================================================
+// Tests `running-providers` — marker del provider EFECTIVO por agente (#4284)
+//
+// Cubre los criterios verificables del helper de runtime:
+//   - CA-1/CA-2: write → read → clear (round-trip + idempotencia)
+//   - CA-4 / TTL: markers vencidos se ignoran al leer
+//   - CA-7 / SEC (A02): whitelist estricta — campos espurios (keys/tokens) NO
+//     se persisten
+//   - CA-8: naming canónico — alias (openai/codex/gemini) se normalizan a la
+//     provider-key de PROVIDER_LABELS
+//   - atomicidad: no quedan temps; lectura nunca ve JSON parcial
+//   - concurrencia: write/clear hacen read-modify-write (no pierden entradas)
+//
+// Todo se aísla en un tmp dir vía `pipelineRoot` — jamás toca el
+// `running-providers.json` real del repo.
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const rp = require('../running-providers');
+
+function mkTmpRoot() {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'running-providers-'));
+}
+
+test('CA-1/CA-2: write persiste y readRunningProviders lo recupera', () => {
+    const root = mkTmpRoot();
+    const rec = rp.writeRunningProvider(
+        { key: 'desarrollo/dev/pipeline-dev:4284', provider: 'openai-codex', model: 'gpt-5-codex', source: 'fallback' },
+        { pipelineRoot: root, now: () => 1000 },
+    );
+    assert.equal(rec.provider, 'openai-codex');
+    assert.equal(rec.model, 'gpt-5-codex');
+    assert.equal(rec.source, 'fallback');
+    assert.equal(rec.startedAt, 1000);
+
+    const map = rp.readRunningProviders({ pipelineRoot: root, now: () => 1500 });
+    const entry = map['desarrollo/dev/pipeline-dev:4284'];
+    assert.ok(entry, 'la entrada debe existir');
+    assert.equal(entry.provider, 'openai-codex');
+    assert.equal(entry.model, 'gpt-5-codex');
+    assert.equal(entry.source, 'fallback');
+    assert.equal(entry.durationMs, 500);
+});
+
+test('CA-2/CA-6: clearRunningProvider elimina la entrada correcta y es idempotente', () => {
+    const root = mkTmpRoot();
+    rp.writeRunningProvider({ key: 'a/b/x:1', provider: 'anthropic' }, { pipelineRoot: root });
+    rp.writeRunningProvider({ key: 'a/b/y:2', provider: 'cerebras' }, { pipelineRoot: root });
+
+    assert.equal(rp.clearRunningProvider('a/b/x:1', { pipelineRoot: root }), true);
+    const map = rp.readRunningProviders({ pipelineRoot: root });
+    assert.equal(map['a/b/x:1'], undefined, 'la entrada borrada no debe estar');
+    assert.ok(map['a/b/y:2'], 'la otra entrada sobrevive (no pierde entradas)');
+
+    // Idempotente: borrar de nuevo no lanza y devuelve false.
+    assert.equal(rp.clearRunningProvider('a/b/x:1', { pipelineRoot: root }), false);
+});
+
+test('CA-4: markers vencidos por TTL se descartan al leer', () => {
+    const root = mkTmpRoot();
+    rp.writeRunningProvider({ key: 'a/b/c:1', provider: 'anthropic' }, { pipelineRoot: root, now: () => 0 });
+    // now muy posterior al TTL (30 min default)
+    const stale = rp.readRunningProviders({ pipelineRoot: root, now: () => rp.DEFAULT_TTL_MS + 1 });
+    assert.equal(stale['a/b/c:1'], undefined, 'marker stale debe ignorarse');
+    // Justo dentro del TTL sigue visible.
+    const fresh = rp.readRunningProviders({ pipelineRoot: root, now: () => rp.DEFAULT_TTL_MS - 1 });
+    assert.ok(fresh['a/b/c:1'], 'marker dentro del TTL debe verse');
+});
+
+test('CA-7 / SEC: whitelist estricta — campos espurios (keys/tokens) no se persisten', () => {
+    const root = mkTmpRoot();
+    rp.writeRunningProvider(
+        {
+            key: 'a/b/c:1',
+            provider: 'anthropic',
+            model: 'claude',
+            source: 'primary',
+            // basura que NUNCA debe llegar a disco:
+            apiKey: 'sk-ant-SECRET',
+            token: 'eyJhbGciOi.JWT.payload',
+            password: 'hunter2',
+            dispatchResolution: { chainTried: ['a', 'b'] },
+        },
+        { pipelineRoot: root, now: () => 100 },
+    );
+
+    const onDisk = JSON.parse(fs.readFileSync(rp.markersPath(root), 'utf8'));
+    const entry = onDisk['a/b/c:1'];
+    assert.deepEqual(
+        Object.keys(entry).sort(),
+        ['model', 'provider', 'source', 'startedAt'],
+        'solo campos whitelisteados deben persistir',
+    );
+    const serialized = fs.readFileSync(rp.markersPath(root), 'utf8');
+    assert.ok(!serialized.includes('sk-ant-SECRET'), 'no debe filtrarse la apiKey');
+    assert.ok(!serialized.includes('JWT'), 'no debe filtrarse el token');
+    assert.ok(!serialized.includes('hunter2'), 'no debe filtrarse el password');
+    assert.ok(!serialized.includes('chainTried'), 'no debe filtrarse dispatchResolution');
+});
+
+test('CA-8: naming canónico — alias se normalizan a la provider-key de PROVIDER_LABELS', () => {
+    const root = mkTmpRoot();
+    rp.writeRunningProvider({ key: 'k:openai', provider: 'openai' }, { pipelineRoot: root, now: () => 1 });
+    rp.writeRunningProvider({ key: 'k:codex', provider: 'Codex' }, { pipelineRoot: root, now: () => 1 });
+    rp.writeRunningProvider({ key: 'k:gemini', provider: 'gemini' }, { pipelineRoot: root, now: () => 1 });
+    const map = rp.readRunningProviders({ pipelineRoot: root, now: () => 2 });
+    assert.equal(map['k:openai'].provider, 'openai-codex');
+    assert.equal(map['k:codex'].provider, 'openai-codex');
+    assert.equal(map['k:gemini'].provider, 'gemini-google');
+
+    // normalizeProvider directo (helper exportado).
+    assert.equal(rp.normalizeProvider('openai-codex'), 'openai-codex');
+    assert.equal(rp.normalizeProvider('  ANTHROPIC '), 'anthropic');
+    assert.equal(rp.normalizeProvider(null), null);
+    assert.equal(rp.normalizeProvider(''), null);
+});
+
+test('source inválido se normaliza a "primary" (enum cerrado)', () => {
+    const root = mkTmpRoot();
+    rp.writeRunningProvider({ key: 'k:1', provider: 'anthropic', source: 'hackeado' }, { pipelineRoot: root });
+    const map = rp.readRunningProviders({ pipelineRoot: root });
+    assert.equal(map['k:1'].source, 'primary');
+});
+
+test('write sin key o sin provider devuelve null y no crea archivo basura', () => {
+    const root = mkTmpRoot();
+    assert.equal(rp.writeRunningProvider({ provider: 'anthropic' }, { pipelineRoot: root }), null);
+    assert.equal(rp.writeRunningProvider({ key: 'k:1' }, { pipelineRoot: root }), null);
+    assert.equal(rp.writeRunningProvider({ key: 'k:1', provider: '   ' }, { pipelineRoot: root }), null);
+    assert.equal(fs.existsSync(rp.markersPath(root)), false, 'no debe crearse el archivo sin datos válidos');
+});
+
+test('atomicidad: tras varias escrituras no quedan archivos temp', () => {
+    const root = mkTmpRoot();
+    rp.writeRunningProvider({ key: 'a:1', provider: 'anthropic' }, { pipelineRoot: root });
+    rp.writeRunningProvider({ key: 'b:2', provider: 'cerebras' }, { pipelineRoot: root });
+    rp.clearRunningProvider('a:1', { pipelineRoot: root });
+    const leftovers = fs.readdirSync(root).filter(f => f.includes('.tmp'));
+    assert.deepEqual(leftovers, [], 'no debe quedar ningún .tmp');
+});
+
+test('concurrencia: dos writes a claves distintas preservan ambas entradas', () => {
+    const root = mkTmpRoot();
+    rp.writeRunningProvider({ key: 'a:1', provider: 'anthropic' }, { pipelineRoot: root, now: () => 1 });
+    rp.writeRunningProvider({ key: 'b:2', provider: 'openai-codex' }, { pipelineRoot: root, now: () => 1 });
+    rp.writeRunningProvider({ key: 'c:3', provider: 'cerebras' }, { pipelineRoot: root, now: () => 1 });
+    const map = rp.readRunningProviders({ pipelineRoot: root, now: () => 2 });
+    assert.equal(Object.keys(map).length, 3);
+    assert.equal(map['a:1'].provider, 'anthropic');
+    assert.equal(map['b:2'].provider, 'openai-codex');
+    assert.equal(map['c:3'].provider, 'cerebras');
+});
+
+test('archivo corrupto → read degrada a {} sin lanzar', () => {
+    const root = mkTmpRoot();
+    fs.writeFileSync(rp.markersPath(root), '{ corrupto sin cerrar');
+    let map;
+    assert.doesNotThrow(() => { map = rp.readRunningProviders({ pipelineRoot: root }); });
+    assert.deepEqual(map, {});
+    // Un write posterior se recupera (read-modify-write tolera corrupción previa).
+    rp.writeRunningProvider({ key: 'k:1', provider: 'anthropic' }, { pipelineRoot: root, now: () => 1 });
+    const map2 = rp.readRunningProviders({ pipelineRoot: root, now: () => 2 });
+    assert.ok(map2['k:1']);
+});

--- a/.pipeline/lib/dashboard-slices.js
+++ b/.pipeline/lib/dashboard-slices.js
@@ -98,6 +98,14 @@ const AGENT_MODELS_FILE = path.join(__dirname, '..', 'agent-models.json');
 let equipoRoster = null;
 try { equipoRoster = require('./equipo-roster'); } catch { /* opcional */ }
 
+// #4284 — Markers de runtime del provider EFECTIVO por agente en curso. El pulpo
+// los escribe en el spawn con la decisión real del router (`dispatchResolution`)
+// y los limpia en `onSpawnExit`. `activeAgents` los prioriza sobre el provider
+// CONFIGURADO por skill. Lectura defensiva: si el módulo no carga, se cae al
+// comportamiento previo (provider configurado) sin romper nada.
+let runningProviders = null;
+try { runningProviders = require('./running-providers'); } catch { /* opcional */ }
+
 // #4195 — Registro de agentes (branch/worktree por issue). Es fuente best-effort
 // (la fuente de verdad operativa es el filesystem): se usa solo para enriquecer
 // la rama mostrada en la ficha; si falta, se cae a la convención agent/<issue>.
@@ -152,6 +160,10 @@ function activeAgents(state) {
     // request para enriquecer la ficha de cada agente (provider/branch/rebotes).
     const agentModels = safeReadJson(AGENT_MODELS_FILE, null);
     const branchMap = branchByIssueFromRegistry();
+    // #4284 — Markers del provider EFECTIVO, leídos una sola vez por request (TTL
+    // aplicado al leer → markers stale descartados, CA-4). Mapa por clave
+    // canónica `<pipeline>/<fase>/<skill>:<issue>`.
+    const effectiveMarkers = runningProviders ? runningProviders.readRunningProviders() : {};
     const now = Date.now();
     for (const [issueId, data] of Object.entries(state.issueMatrix || {})) {
         if (data.estadoActual !== 'trabajando') continue;
@@ -160,8 +172,25 @@ function activeAgents(state) {
             if (e.estado !== 'trabajando') continue;
             // #4195 — Proveedor configurado para el skill (provider visible) y
             // rama del worktree (registry best-effort → convención agent/<issue>).
-            const provider = equipoRoster ? equipoRoster.resolveProvider(agentModels, e.skill) : null;
+            // #4284 — Si hay marker del provider EFECTIVO para este agente, lo
+            // priorizamos sobre el configurado (CA-1/CA-2); si no hay marker (TTL
+            // vencido o no escrito), caemos al configurado (CA-3, happy path
+            // intacto). Mantenemos el shape `{ id, label, model }` que consume el
+            // front; el `label` sale de `PROVIDER_LABELS` (CA-8 naming canónico).
             const issueNum = String(issueId).replace(/[^0-9]/g, '');
+            const markerKey = `${e.pipeline}/${e.fase}/${e.skill}:${issueNum}`;
+            const effective = effectiveMarkers[markerKey] || null;
+            let provider = equipoRoster ? equipoRoster.resolveProvider(agentModels, e.skill) : null;
+            if (effective && effective.provider) {
+                const labels = equipoRoster ? equipoRoster.PROVIDER_LABELS : null;
+                provider = {
+                    id: effective.provider,
+                    label: (labels && labels[effective.provider]) || effective.provider,
+                    // Modelo efectivo del marker; si no vino, preservamos el del
+                    // provider configurado (no romper el shape).
+                    model: effective.model || (provider && provider.model) || null,
+                };
+            }
             const branch = branchMap[issueNum] || `agent/${issueNum || issueId}-${e.skill}`;
             out.push({
                 issue: issueId,

--- a/.pipeline/lib/running-providers.js
+++ b/.pipeline/lib/running-providers.js
@@ -1,0 +1,224 @@
+'use strict';
+
+// =============================================================================
+// running-providers.js — Marker de runtime del provider EFECTIVO por agente en
+// curso (#4284).
+//
+// Problema: el dashboard ("Ahora · En Ejecución") muestra el provider
+// CONFIGURADO por skill (`resolveProvider(agentModels, skill)` →
+// `skills.<skill>.provider` de agent-models.json), no el EFECTIVO con el que el
+// pulpo lanzó el agente tras evaluar cuota/kill-switch/fallbacks. Con Anthropic
+// apagado, un agente corre en Codex pero el dashboard sigue mostrando Claude.
+//
+// Solución: el pulpo persiste, best-effort en el spawn, el provider efectivo
+// (`dispatchResolution.provider`) en un único archivo de runtime
+// (`running-providers.json`) en la RAÍZ de `.pipeline/`. El dashboard lo lee y
+// lo prioriza sobre el configurado.
+//
+// Modelado sobre `commander-presence.js` (mismo patrón probado):
+//   - CA-5: el archivo vive en la raíz de runtime, NUNCA bajo
+//     `<pipeline>/<fase>/trabajando/`. Los contadores de concurrencia del pulpo
+//     (`countRunningBySkill`) solo escanean `trabajando/` → el marker no
+//     consume slot ni altera el paralelismo. Se cumple por construcción.
+//   - CA-7 / SEC (A02): whitelist estricta de campos. SOLO se persiste
+//     `provider`/`model`/`source`/`startedAt`. Jamás keys, tokens, JWT ni el
+//     objeto `dispatchResolution` completo.
+//   - SEC (A03): el render del dashboard usa `textContent` (invariante de
+//     `home.js`); este módulo nunca produce HTML.
+//   - CA-4 / riesgo stale: `readRunningProviders` aplica TTL por `startedAt`;
+//     un marker viejo (proceso muerto sin limpiar) se ignora al leer.
+//   - CA-6: `clearRunningProvider` borra la entrada en `onSpawnExit`.
+//   - CA-8: naming canónico — `writeRunningProvider` normaliza alias
+//     (`openai`/`codex` → `openai-codex`, `gemini` → `gemini-google`) para que
+//     `PROVIDER_LABELS` resuelva el label correcto.
+//
+// Concurrencia: read-modify-write atómico (tmp + rename). El rename es atómico
+// dentro del mismo filesystem → el dashboard nunca lee un JSON parcial. Cada
+// `write`/`clear` re-lee el archivo antes de escribir para no perder entradas
+// de spawns concurrentes (single-writer real: el pulpo, pero defensivo).
+// =============================================================================
+
+const fs = require('fs');
+const path = require('path');
+
+// Nombre del archivo de markers. Vive en la raíz de runtime del pipeline, igual
+// que `commander-presence.json` / `commander-session.json`.
+const FILENAME = 'running-providers.json';
+
+// TTL por defecto: los markers de "en curso" viven más que una presencia
+// Commander (5 min) porque un agente dev puede tardar bastante. 30 min cubre el
+// caso normal; si el proceso muere sin limpiar, el TTL descarta el marker stale.
+const DEFAULT_TTL_MS = 30 * 60 * 1000;
+
+// CA-7 / SEC: whitelist estricta de campos persistidos. Cualquier otro campo del
+// objeto recibido se descarta — nunca se filtra material de credencial.
+const ALLOWED_FIELDS = Object.freeze(['provider', 'model', 'source', 'startedAt']);
+
+// CA-8: normalización de alias → provider-key canónica de `PROVIDER_LABELS`.
+// El `dispatchResolution.provider` ya suele venir canónico (sale de
+// agent-models.json), pero algún codepath (health-cron) usa alias; normalizamos
+// defensivamente para que el label del dashboard resuelva bien.
+const PROVIDER_ALIASES = Object.freeze({
+    openai: 'openai-codex',
+    codex: 'openai-codex',
+    gemini: 'gemini-google',
+    google: 'gemini-google',
+    claude: 'anthropic',
+    nvidia: 'nvidia-nim',
+});
+
+// Fuentes válidas de la decisión del router (enum cerrado, defensa en
+// profundidad). Cualquier otro valor se normaliza a 'primary'.
+const VALID_SOURCES = Object.freeze(new Set(['primary', 'fallback', 'forced-override']));
+
+// Raíz por defecto del pipeline: `.pipeline/` (este módulo vive en
+// `.pipeline/lib/`). Los tests inyectan un dir temporal vía `pipelineRoot`.
+function defaultPipelineRoot() {
+    return path.join(__dirname, '..');
+}
+
+function markersPath(pipelineRoot) {
+    return path.join(pipelineRoot || defaultPipelineRoot(), FILENAME);
+}
+
+// CA-8: normaliza un provider-key crudo a su forma canónica. Tolera null/no-string.
+function normalizeProvider(provider) {
+    if (!provider || typeof provider !== 'string') return null;
+    const trimmed = provider.trim();
+    if (!trimmed) return null;
+    const lower = trimmed.toLowerCase();
+    return PROVIDER_ALIASES[lower] || lower;
+}
+
+function normalizeSource(source) {
+    if (typeof source === 'string' && VALID_SOURCES.has(source)) return source;
+    return 'primary';
+}
+
+// Lectura tolerante: archivo ausente/corrupto → objeto vacío. Nunca lanza.
+function safeReadMap(filepath) {
+    let raw = null;
+    try { raw = JSON.parse(fs.readFileSync(filepath, 'utf8')); }
+    catch { return {}; }
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {};
+    return raw;
+}
+
+// Escritura atómica: temp único por proceso + rename sobre el destino. El rename
+// es atómico dentro del mismo filesystem → el dashboard nunca lee JSON parcial.
+function atomicWrite(filepath, obj) {
+    const dir = path.dirname(filepath);
+    const tmp = path.join(dir, `.${FILENAME}.${process.pid}.tmp`);
+    fs.writeFileSync(tmp, JSON.stringify(obj, null, 2));
+    fs.renameSync(tmp, filepath);
+}
+
+// Reconstruye un record desde cero con SOLO los campos whitelisteados (SEC).
+function sanitizeRecord({ provider, model, source, startedAt }) {
+    const record = {};
+    record.provider = normalizeProvider(provider);
+    record.model = (model != null && model !== '') ? String(model) : null;
+    record.source = normalizeSource(source);
+    record.startedAt = typeof startedAt === 'number' ? startedAt : null;
+    return record;
+}
+
+/**
+ * Persiste el provider EFECTIVO de un agente en curso. Read-modify-write
+ * atómico: re-lee el mapa, agrega/pisa la entrada de `key` y reescribe.
+ *
+ * Solo persiste campos whitelisteados (CA-7): provider/model/source/startedAt.
+ * Normaliza el provider a su key canónica (CA-8).
+ *
+ * @param {{key: string, provider: string, model?: string, source?: string, startedAt?: number}} input
+ * @param {{pipelineRoot?: string, now?: () => number}} [opts]
+ * @returns {{provider: string, model: string|null, source: string, startedAt: number}|null}
+ *          el record persistido, o null si faltan key/provider válidos (no lanza)
+ */
+function writeRunningProvider(input, opts = {}) {
+    const key = input && input.key;
+    if (!key || typeof key !== 'string') return null;
+    const provider = normalizeProvider(input && input.provider);
+    if (!provider) return null; // sin provider efectivo no hay nada que persistir
+
+    const now = (opts.now || Date.now)();
+    const startedAt = typeof input.startedAt === 'number' ? input.startedAt : now;
+    const record = sanitizeRecord({
+        provider,
+        model: input.model,
+        source: input.source,
+        startedAt,
+    });
+
+    const filepath = markersPath(opts.pipelineRoot);
+    const map = safeReadMap(filepath);
+    map[key] = record;
+    atomicWrite(filepath, map);
+    return record;
+}
+
+/**
+ * Limpia el marker de un agente (al terminar, éxito o error). Idempotente:
+ * si la entrada no existe, es no-op. Re-lee antes de escribir para no pisar
+ * entradas de spawns concurrentes (CA-6).
+ *
+ * @param {string} key
+ * @param {{pipelineRoot?: string}} [opts]
+ * @returns {boolean} true si borró una entrada, false si no había nada
+ */
+function clearRunningProvider(key, opts = {}) {
+    if (!key || typeof key !== 'string') return false;
+    const filepath = markersPath(opts.pipelineRoot);
+    const map = safeReadMap(filepath);
+    if (!Object.prototype.hasOwnProperty.call(map, key)) return false;
+    delete map[key];
+    // Si quedó vacío, dejamos el `{}` en disco (no borramos el archivo) para que
+    // el patrón read-modify-write siga siendo consistente.
+    atomicWrite(filepath, map);
+    return true;
+}
+
+/**
+ * Lee todos los markers válidos, descartando los vencidos por TTL (CA-4). NO
+ * borra los stale del disco (limpieza la hace el writer en `onSpawnExit`); solo
+ * los ignora en lectura. Valida la shape de cada entrada (defensa en profundidad).
+ *
+ * @param {{pipelineRoot?: string, ttlMs?: number, now?: () => number}} [opts]
+ * @returns {Object<string, {provider: string, model: string|null, source: string, startedAt: number, durationMs: number}>}
+ */
+function readRunningProviders(opts = {}) {
+    const filepath = markersPath(opts.pipelineRoot);
+    const map = safeReadMap(filepath);
+    const now = (opts.now || Date.now)();
+    const ttlMs = typeof opts.ttlMs === 'number' ? opts.ttlMs : DEFAULT_TTL_MS;
+    const out = {};
+    for (const [key, raw] of Object.entries(map)) {
+        if (!raw || typeof raw !== 'object') continue;
+        const provider = normalizeProvider(raw.provider);
+        if (!provider) continue;
+        const startedAt = typeof raw.startedAt === 'number' ? raw.startedAt : null;
+        if (startedAt === null) continue;
+        const durationMs = now - startedAt;
+        if (durationMs >= ttlMs) continue; // stale (CA-4)
+        out[key] = {
+            provider,
+            model: (raw.model != null && raw.model !== '') ? String(raw.model) : null,
+            source: normalizeSource(raw.source),
+            startedAt,
+            durationMs,
+        };
+    }
+    return out;
+}
+
+module.exports = {
+    writeRunningProvider,
+    clearRunningProvider,
+    readRunningProviders,
+    markersPath,
+    normalizeProvider,
+    FILENAME,
+    DEFAULT_TTL_MS,
+    ALLOWED_FIELDS,
+    PROVIDER_ALIASES,
+};

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -223,6 +223,11 @@ try { commanderPresence = require('./lib/commander-presence'); } catch { /* opci
 // resolución no-gated en lugar de devolver el archivo a pendiente/. Mantiene
 // hash-chain SHA-256 en logs/cross-provider-dispatch-*.jsonl + notify Telegram.
 const { resolveSpawnWithFallback, formatProviderResolutionLog } = require('./lib/agent-launcher/dispatch-with-fallback');
+// #4284 — marker de runtime del provider EFECTIVO por agente en curso. Best-effort:
+// el dashboard lo lee para mostrar el provider real (no el configurado por skill).
+// Require defensivo: si el módulo no carga, el spawn no se bloquea.
+let runningProviders = null;
+try { runningProviders = require('./lib/running-providers'); } catch { /* opcional */ }
 // #4274 — resolución de modo canónico por provider, usada como defense-in-depth
 // en launchResolveImpl y en bootResolveSkill para no defaultear al modo más
 // privilegiado cuando el `mode` no viene resuelto (SR-1, fail-fast).
@@ -6557,6 +6562,25 @@ function lanzarAgenteClaude(skill, issue, trabajandoPath, pipeline, fase, config
   // extracto de CLAUDE.md. Es no-op para los providers agénticos (anthropic,
   // openai-codex, gemini-google), que ya investigan el repo de verdad.
   let systemContent = `${base}\n\n${rol}`;
+  // #4284 — persistir el provider EFECTIVO (router decision real) para que el
+  // dashboard ("Ahora · En Ejecución") muestre con qué provider corre realmente
+  // el agente, no el configurado por skill. Best-effort: un fallo acá NUNCA
+  // bloquea el spawn (mismo estilo que el augment del system prompt contiguo).
+  // CA-5: el marker vive en la raíz de `.pipeline/`, no bajo `trabajando/` → no
+  // altera los contadores de concurrencia.
+  if (runningProviders && dispatchResolution && dispatchResolution.provider) {
+    try {
+      const key = `${pipeline}/${fase}/${skill}:${issue}`;
+      runningProviders.writeRunningProvider({
+        key,
+        provider: dispatchResolution.provider, // provider-key canónica (se normaliza en el helper)
+        model: dispatchResolution.model || null,
+        source: dispatchResolution.source || 'primary',
+      });
+    } catch (rpErr) {
+      log('lanzamiento', `⚠️ ${skill}:#${issue} no se pudo escribir el marker de provider efectivo (best-effort): ${rpErr.message}`);
+    }
+  }
   try {
     const effectiveProvider = (dispatchResolution && dispatchResolution.provider) || null;
     systemContent = commanderApiContext.augmentSystemPromptForProvider(
@@ -7252,6 +7276,16 @@ function lanzarAgenteClaude(skill, issue, trabajandoPath, pipeline, fase, config
     try { agentLogWriter.close().catch(() => {}); } catch {}
     // Cancelar watchdog de timeout (ya terminó, por el motivo que sea)
     clearTimeout(watchdog);
+
+    // #4284 — limpiar el marker de provider efectivo (CA-6). Best-effort y al
+    // inicio del handler para que corra siempre, sin importar el codepath del
+    // quota-detector (generalizado/legacy) ni el resultado del agente. Si el
+    // proceso muriera sin llegar acá, el TTL de `readRunningProviders` descarta
+    // el marker stale (CA-4).
+    if (runningProviders) {
+      try { runningProviders.clearRunningProvider(`${pipeline}/${fase}/${skill}:${issue}`); }
+      catch { /* idempotente: best-effort, nunca rompe el lifecycle */ }
+    }
 
     // #3605 — Desregistrar del agent-ipc registry. Idempotente: si nunca se
     // registró (interactive_supported=false), unregister es no-op. Drena

--- a/.pipeline/views/dashboard/home.js
+++ b/.pipeline/views/dashboard/home.js
@@ -1816,6 +1816,15 @@ function homeStyles() {
 .mz-now .active-card-prov[data-prov="anthropic"]::before { background: #FB923C; }
 .mz-now .active-card-prov[data-prov="codex"]::before { background: #34D399; }
 .mz-now .active-card-prov[data-prov="gemini"]::before { background: #60A5FA; }
+/* #4284 (CA-UX-1) — colores por provider-key CANÓNICA (el data-prov sale del id
+   canónico de PROVIDER_LABELS: openai-codex, gemini-google, etc.). Sin estas
+   reglas, el dot del provider EFECTIVO (ej. fallback a Codex) quedaría incoloro
+   justo cuando más importa distinguirlo. */
+.mz-now .active-card-prov[data-prov="openai-codex"]::before { background: #34D399; }
+.mz-now .active-card-prov[data-prov="gemini-google"]::before { background: #60A5FA; }
+.mz-now .active-card-prov[data-prov="cerebras"]::before { background: #F472B6; }
+.mz-now .active-card-prov[data-prov="nvidia-nim"]::before { background: #A3E635; }
+.mz-now .active-card-prov[data-prov="deterministic"]::before { background: #94A3B8; }
 /* Eyebrow "CORRE" sobre el tiempo (mockup .ameta). */
 .mz-now .active-card-time { position: relative; }
 .mz-now .active-card-time::before {


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 6 archivos · +571 -1

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:passed` aplicado por delivery

## Closes

Closes #4284
