### PR TITLE
El /restart no libera el puerto 3200 (dashboard) → EADDRINUSE → rollback automático

### DIFF
--- a/.pipeline/lib/__tests__/pid-discovery-wait-port.test.js
+++ b/.pipeline/lib/__tests__/pid-discovery-wait-port.test.js
@@ -1,0 +1,117 @@
+// =============================================================================
+// Tests waitForPortFree / commandLineForPid — #4308
+//
+// El /restart no liberaba el puerto 3200 del dashboard → EADDRINUSE → rollback
+// espurio. El fix agrega una verificación ACOTADA de puerto libre entre
+// killAll() y launchAll(). Estos tests cubren CA-7 mockeando findPidByPort:
+//
+//   1. puerto libre a la primera          → true, onHolder NO se invoca
+//   2. puerto se libera tras N vueltas     → true, onHolder se invoca N veces
+//   3. puerto nunca se libera              → false tras EXACTAMENTE attempts
+//                                            vueltas (acota, sin loop infinito)
+//   4. holder con commandLine ajena        → el onHolder con validación de
+//                                            ownership NO mata + loguea PID+cmd
+//
+// Estrategia: mock de `findPidByPort` (resuelto vía module.exports dentro de
+// waitForPortFree) + delayMs: 0 para no spawnear procesos de sleep.
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const pid = require('../../pid-discovery');
+
+// Sustituye pid.findPidByPort por una secuencia de retornos y ejecuta `fn`,
+// restaurando siempre el original. waitForPortFree resuelve findPidByPort vía
+// module.exports, por lo que esta sustitución impacta sus llamadas internas.
+function withFindPidByPortSequence(sequence, fn) {
+  const original = pid.findPidByPort;
+  let i = 0;
+  const calls = [];
+  pid.findPidByPort = (port) => {
+    calls.push(port);
+    const v = i < sequence.length ? sequence[i] : sequence[sequence.length - 1];
+    i++;
+    return v;
+  };
+  try {
+    return fn(calls);
+  } finally {
+    pid.findPidByPort = original;
+  }
+}
+
+test('`waitForPortFree` retorna true a la primera cuando el puerto está libre y no invoca onHolder', () => {
+  const holders = [];
+  withFindPidByPortSequence([null], (calls) => {
+    const res = pid.waitForPortFree(3200, {
+      attempts: 6,
+      delayMs: 0,
+      onHolder: (p) => holders.push(p),
+    });
+    assert.equal(res, true);
+    assert.equal(calls.length, 1, 'consulta el puerto una sola vez');
+  });
+  assert.deepEqual(holders, [], 'onHolder no se invoca si el puerto ya está libre');
+});
+
+test('`waitForPortFree` retorna true cuando el puerto se libera tras N vueltas e invoca onHolder por cada holder', () => {
+  // holder las primeras 2 vueltas, luego libre
+  const holders = [];
+  withFindPidByPortSequence([1111, 1111, null], () => {
+    const res = pid.waitForPortFree(3200, {
+      attempts: 6,
+      delayMs: 0,
+      onHolder: (p) => holders.push(p),
+    });
+    assert.equal(res, true);
+  });
+  assert.deepEqual(holders, [1111, 1111], 'onHolder invocado una vez por cada vuelta con holder');
+});
+
+test('`waitForPortFree` retorna false tras exactamente `attempts` vueltas cuando el puerto nunca se libera (acota, sin loop infinito)', () => {
+  const holders = [];
+  withFindPidByPortSequence([2222], (calls) => {
+    const res = pid.waitForPortFree(3200, {
+      attempts: 4,
+      delayMs: 0,
+      onHolder: (p) => holders.push(p),
+    });
+    assert.equal(res, false);
+    // 4 vueltas del loop + 1 revalidación final = 5 consultas
+    assert.equal(calls.length, 5, 'consulta acotada: attempts + revalidación final');
+  });
+  assert.equal(holders.length, 4, 'onHolder invocado exactamente attempts veces, nunca más');
+});
+
+test('un onHolder con validación de ownership NO mata un PID cuya commandLine es ajena al pipeline y loguea PID + commandLine', () => {
+  // Simula el onHolder de restart.js: valida ownership por commandLine usando
+  // commandLineForPid (mockeado), loguea PID + cmd ANTES de matar, y solo mata
+  // procesos del pipeline (dashboard.js / .pipeline).
+  const originalCmdFor = pid.commandLineForPid;
+  pid.commandLineForPid = (p) => (p === 9999 ? 'C:\\\\Program Files\\\\Foo\\\\node.exe server.js' : null);
+
+  const logs = [];
+  const kills = [];
+  const buildOnHolder = () => (p) => {
+    const cmd = pid.commandLineForPid(p);
+    const owned = !!cmd && (cmd.includes('dashboard.js') || cmd.includes('.pipeline'));
+    logs.push(`holder PID ${p} cmd=${cmd || '<desconocido>'}`); // auditoría antes de matar
+    if (!owned) return;
+    kills.push(p);
+  };
+
+  try {
+    withFindPidByPortSequence([9999], () => {
+      pid.waitForPortFree(3200, { attempts: 2, delayMs: 0, onHolder: buildOnHolder() });
+    });
+  } finally {
+    pid.commandLineForPid = originalCmdFor;
+  }
+
+  assert.deepEqual(kills, [], 'un proceso ajeno que tomó el puerto NO se mata');
+  assert.ok(logs.length >= 1, 'se logueó el holder');
+  assert.match(logs[0], /PID 9999/, 'el log incluye el PID');
+  assert.match(logs[0], /server\.js/, 'el log incluye la commandLine');
+});

--- a/.pipeline/pid-discovery.js
+++ b/.pipeline/pid-discovery.js
@@ -178,6 +178,47 @@ function invalidateCache() {
   _scanCacheAt = 0;
 }
 
+// Sleep síncrono y bloqueante reusando spawnSync (mismo patrón que restart.js).
+// Evita meter timers async en una función que se llama desde un flujo
+// secuencial de restart. Acotado por el `timeout` del spawn.
+function _sleepBlocking(ms) {
+  if (!ms || ms <= 0) return;
+  try {
+    spawnSync(process.execPath, ['-e', `setTimeout(()=>{},${ms})`], { timeout: ms + 2000 });
+  } catch {}
+}
+
+// commandLineForPid(pid) → string | null
+// Busca el PID dentro del scan de procesos node (que ya devuelve
+// {pid, commandLine}) y retorna su commandLine. NO ejecuta comandos nuevos de
+// shell (CA-6 / SEC-1): solo lee el resultado del scan ya cacheado.
+function commandLineForPid(pid) {
+  const p = scanNodeProcesses().find(x => x.pid === pid);
+  return p ? p.commandLine : null;
+}
+
+// waitForPortFree(port, { attempts, delayMs, onHolder }) → boolean
+// Espera de forma ACOTADA a que `port` quede libre (sin proceso LISTENING).
+// En cada vuelta: invalida cache, consulta findPidByPort(port); si está libre
+// retorna true; si hay holder invoca onHolder(pid) — para que el caller valide
+// ownership y re-mate — y duerme delayMs. Al agotar `attempts` revalida una vez
+// más y retorna si el puerto quedó libre. Sin while(true) ni kill indiscriminado
+// (SEC-4 / CA-3): el peor caso es degradar al comportamiento actual, nunca peor.
+function waitForPortFree(port, { attempts = 6, delayMs = 500, onHolder } = {}) {
+  // Resolvemos findPidByPort vía module.exports para que los unit tests puedan
+  // sustituirlo (mock de findPidByPort, CA-7) sin tocar netstat real.
+  const findPid = (module.exports && module.exports.findPidByPort) || findPidByPort;
+  for (let i = 0; i < attempts; i++) {
+    invalidateCache();
+    const holder = findPid(port);
+    if (!holder) return true;                                // puerto libre
+    if (typeof onHolder === 'function') onHolder(holder);    // caller valida ownership + re-mata
+    _sleepBlocking(delayMs);
+  }
+  invalidateCache();
+  return findPid(port) == null;
+}
+
 module.exports = {
   SCRIPT_MAP,
   scanNodeProcesses,
@@ -188,4 +229,6 @@ module.exports = {
   findPidByPort,
   pidAlive,
   invalidateCache,
+  waitForPortFree,
+  commandLineForPid,
 };

--- a/.pipeline/restart.js
+++ b/.pipeline/restart.js
@@ -20,6 +20,8 @@ const {
   findPidByPort,
   pidAlive,
   invalidateCache,
+  waitForPortFree,
+  commandLineForPid,
   SCRIPT_MAP,
 } = require('./pid-discovery');
 const { clearAllMarkers } = require('./lib/ready-marker');
@@ -268,6 +270,46 @@ function killAll() {
   }
 }
 
+// --- LIBERACIÓN DETERMINÍSTICA DEL PUERTO DEL DASHBOARD (#4308) ---
+//
+// Entre killAll() y launchAll() verificamos de forma ACOTADA que el puerto del
+// dashboard (3200 por default) quedó libre antes de relanzar. Sin esto, si el
+// socket TCP no se liberó aún o un proceso respawneó entre scan y kill, el
+// dashboard nuevo choca con EADDRINUSE, el smoke test falla 2× y se dispara un
+// rollback espurio a `pipeline-stable`.
+//
+// onHolder (SEC-2 / CA-2): antes de re-matar valida ownership por commandLine
+// (solo procesos del pipeline: `dashboard.js` o `.pipeline`), LOGUEA PID +
+// commandLine ANTES de matar (auditoría), y mata SOLO por PID numérico vía
+// taskkill (SEC-1 / CA-6: nada de `$(...)`, `fkill <puerto>` ni interpolar
+// salida de netstat). Un proceso ajeno que casualmente tome el puerto NO se
+// mata. Si el backoff se agota, degradamos al comportamiento actual (avanzar +
+// retry EADDRINUSE del dashboard) — nunca peor que hoy (CA-3).
+function freeDashboardPortOrAdvance() {
+  const dashPort = parseInt(process.env.DASHBOARD_PORT || '3200', 10);
+  const onHolder = (pid) => {
+    if (pid === process.pid) return;
+    const cmd = commandLineForPid(pid);
+    const owned = !!cmd && (cmd.includes('dashboard.js') || cmd.includes('.pipeline'));
+    log(`  [puerto ${dashPort}] holder PID ${pid} cmd=${cmd || '<desconocido>'}`); // auditoría ANTES de matar
+    if (!owned) {
+      log(`  [puerto ${dashPort}] PID ${pid} no es del pipeline — no se mata`);
+      return;
+    }
+    try {
+      execSync(`taskkill /PID ${pid} /F /T`, { timeout: 5000, stdio: 'ignore' });
+      log(`  [puerto ${dashPort}] Re-killed PID ${pid}`);
+    } catch {}
+  };
+  const free = waitForPortFree(dashPort, { attempts: 6, delayMs: 500, onHolder });
+  if (free) {
+    log(`  [puerto ${dashPort}] libre antes de launchAll()`);
+  } else {
+    log(`  [puerto ${dashPort}] sigue tomado tras backoff — se avanza igual (retry EADDRINUSE del dashboard como red secundaria)`);
+  }
+  return free;
+}
+
 // --- LAUNCH ---
 
 function launchAll() {
@@ -479,6 +521,7 @@ switch (action) {
     } else {
       try { fs.unlinkSync(path.join(PIPELINE, '.paused')); } catch {}
     }
+    freeDashboardPortOrAdvance(); // #4308 — puerto 3200 libre antes de relanzar
     launchAll();
     const ok = status();
     log(ok ? '=== Pipeline operativo ===' : '=== Revisar componentes ===');
@@ -497,6 +540,7 @@ switch (action) {
       if (!smoke.ok && !flagNoRollback) {
         log('Primer smoke test FAIL — reintento tras limpieza de stragglers');
         killAll();
+        freeDashboardPortOrAdvance(); // #4308 — puerto 3200 libre antes de relanzar
         launchAll();
         sleep(5000);
         smoke = runSmokeTest();


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 3 archivos · +204 -0

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:skipped` aplicado por delivery

## Closes

Closes #4308
