### PR TITLE
Fallback in-flight de proveedor no ejecuta el reemplazo (Codex) cuando Anthropic se cuelga a mitad del turno

### DIFF
--- a/.pipeline/config.yaml
+++ b/.pipeline/config.yaml
@@ -699,6 +699,33 @@ pipeline:
   audit_retention_days: 90
 
 # =============================================================================
+# #4309 — Ejecución del fallback in-flight (revive #3578)
+#
+# Cuando un agente arranca su turno con Anthropic y Anthropic se cuelga DURANTE
+# el stream (caída in-flight, no pre-spawn), los detectores shadow de #3577
+# (first-byte / stream-gap / eof-premature / transient-5xx) emiten la señal de
+# DECISIÓN (`inflight_signal_observed`). Lo que faltaba cablear era la
+# EJECUCIÓN: tras decidir el secundario (openai-codex), spawnearlo y correr el
+# turno con él reusando la maquinaria pre-spawn.
+#
+# Cuando `execution_enabled: true`, el pulpo, al disparar un detector in-flight:
+#   1. mata el primario (taskkill /T confirma terminación),
+#   2. decide el secundario vía `decideInflightFallback` (cap=1 + budget 90s),
+#   3. lo spawnea con la MISMA ruta que el pre-spawn (buildChildEnv partial-
+#      override → aislamiento de credenciales S-2 → runNonAnthropic),
+#   4. emite `inflight_fallback_completed` (EJECUCIÓN ≠ señal de decisión).
+#
+# Cuando `false` (DEFAULT, rollout gradual): comportamiento idéntico a #3577 —
+# los detectores SOLO emiten la señal shadow, sin matar el primario ni spawnear
+# el secundario. Preserva regresión cero hasta validar el wire-up en caliente.
+#
+# Aplica a CUALQUIER agente del pipeline (el ejecutor es skill-agnóstico), no
+# solo al Telegram Commander. El cap=1 + budget acotan la amplificación de
+# spawns ante una caída sostenida de Anthropic (modo de falla conocido).
+inflight_fallback:
+  execution_enabled: false
+
+# =============================================================================
 # #3343 — Sherlock verifier adversarial (split de #3331)
 #
 # Sherlock corre como capa interna del Commander de Telegram: antes de mandar

--- a/.pipeline/lib/commander/inflight-fallback.js
+++ b/.pipeline/lib/commander/inflight-fallback.js
@@ -547,6 +547,11 @@ function noteInflightCompleted(opts = {}) {
         chatId,
         requestId,
         cacheMissDueToProviderChange,
+        // #4309 — skill del agente que ejecutó el fallback. Default COMMANDER_SKILL
+        // por backward-compat: el camino del Commander no lo pasa y sigue
+        // registrando `telegram-commander`. Los agentes de pipeline pasan su
+        // propio skill para que el audit refleje quién cayó al secundario (CA-3).
+        skill,
         // inyectables
         auditLog,
         fsImpl,
@@ -557,7 +562,7 @@ function noteInflightCompleted(opts = {}) {
         pipelineDir, auditLog, fsImpl, now,
         entry: {
             event: 'inflight_fallback_completed',
-            skill: COMMANDER_SKILL,
+            skill: skill || COMMANDER_SKILL,
             primary_provider: primaryProvider || null,
             secondary_provider: secondaryProvider || null,
             success: !!success,
@@ -587,6 +592,8 @@ function noteLateResponseDiscarded(opts = {}) {
         partialOutput,
         chatId,
         requestId,
+        // #4309 — ver noteInflightCompleted: default COMMANDER_SKILL.
+        skill,
         auditLog,
         fsImpl,
         now,
@@ -596,7 +603,7 @@ function noteLateResponseDiscarded(opts = {}) {
         pipelineDir, auditLog, fsImpl, now,
         entry: {
             event: 'late_response_discarded',
-            skill: COMMANDER_SKILL,
+            skill: skill || COMMANDER_SKILL,
             primary_provider: primaryProvider || null,
             request_id: requestId || null,
             chat_id_hash: hashFor(chatId || 'unknown'),

--- a/.pipeline/lib/inflight-executor.js
+++ b/.pipeline/lib/inflight-executor.js
@@ -1,0 +1,191 @@
+// =============================================================================
+// inflight-executor.js — Ejecutor del fallback in-flight (#4309).
+//
+// CONTEXTO
+// --------
+// `commander/inflight-fallback.js` resuelve la **DECISIÓN** del fallback
+// in-flight (qué provider de reemplazo usar cuando el primario se cuelga a
+// mitad del stream) y ya está testeado. Lo que faltaba — y este módulo cierra —
+// es la **EJECUCIÓN**: tras decidir, efectivamente disparar el secundario,
+// reusando la MISMA maquinaria de spawn que el camino pre-spawn (paridad).
+//
+// El épico #3472 se partió en #3577 (detectores shadow, MERGEADO) y #3578
+// (wire-up live, CERRADO-SIN-ENTREGAR). #4309 revive #3578 + lo generaliza
+// más allá del Telegram Commander para que aplique a CUALQUIER agente del
+// pipeline que se quede sin cuota propia a mitad de turno (CA-3).
+//
+// DISEÑO
+// ------
+// Este módulo es el "cerebro" skill-agnóstico, compartido entre el Commander y
+// el lifecycle de spawn de agentes. NO spawnea ni manda Telegram: esos efectos
+// se inyectan como callbacks (`runSecondary`, `onNotice`, `onCanned`). Eso lo
+// hace 100% testeable con fakes, y garantiza que el spawn real reuse la
+// maquinaria existente del caller (no un segundo ejecutor — requisito de
+// paridad del architect).
+//
+// ORDEN DE ORQUESTACIÓN (CA-B1 de #3578)
+// --------------------------------------
+//   El caller ya hizo:  detector dispara -> _emitShadowSignal (DECISIÓN, se
+//                       conserva) -> killProc(primario) + confirmar muerte.
+//   Acá:
+//     1. decideInflightFallback({ skill, attemptIndex, budgetMs, ... })
+//        -> { shouldRetry, secondaryProvider, secondaryHandler, secondaryModel }
+//        (emite inflight_fallback_initiated / exhausted / global_timeout).
+//     2. Si NO shouldRetry -> onCanned(cannedResponse) y devolvemos executed:false.
+//     3. Si shouldRetry:
+//        a. acquireInflightLock (late-response del primario muerto se descarta).
+//        b. onNotice(noticeText) — aviso UX al usuario.
+//        c. runSecondary(decision) — el caller spawnea con la maquinaria
+//           pre-spawn (buildChildEnv partial-override + spawn) y resuelve el turno.
+//     El caller emite `inflight_fallback_completed` (EJECUCIÓN, distinto de la
+//     señal de decisión — CA-4) cuando recibe executed:true.
+//
+// SEGURIDAD
+// ---------
+//   - NO construye env del child: eso lo hace `runSecondary` vía `buildChildEnv`
+//     con partial-override `{ provider: secondary }` (invariante S-2, aislamiento
+//     de credenciales cross-provider). Este módulo NUNCA toca API keys.
+//   - Cap=1: lo impone `decideInflightFallback` (attemptIndex >= MAX). El caller
+//     además NO debe llamar este executor más de una vez por turno.
+//   - fail-closed: si `decide` lanza, devolvemos executed:false sin spawnear.
+// =============================================================================
+'use strict';
+
+const inflightFallback = require('./commander/inflight-fallback');
+
+const COMMANDER_SKILL = inflightFallback.COMMANDER_SKILL;
+
+/**
+ * runInflightFallback — orquesta decisión + lock + ejecución del secundario.
+ *
+ * @param {object} opts
+ * @param {string} [opts.skill]              skill del agente (default COMMANDER_SKILL).
+ * @param {string} opts.primaryProvider      provider del intento que se colgó.
+ * @param {string} opts.primaryErrorClass    clasificación del fallo in-flight.
+ * @param {number} [opts.primaryDurationMs]  ms acumulados del primario.
+ * @param {string} [opts.primaryPartialOutput] parcial del primario (se hashea).
+ * @param {number} [opts.attemptIndex]       0 = primer fallback in-flight del turno.
+ * @param {number} [opts.budgetMs]           budget global (default 90s en el core).
+ * @param {string} opts.pipelineDir          dir del pipeline (audit log).
+ * @param {string} opts.lockNamespace        namespace del late-response lock:
+ *                                           chat_id para el Commander,
+ *                                           `issue-<n>` para agentes de pipeline.
+ * @param {string} opts.requestId            id atómico del turno.
+ * @param {function} [opts.runSecondary]     (decision) => void — spawnea el
+ *                                           secundario y resuelve el turno.
+ * @param {function} [opts.onNotice]         (noticeText) => void — aviso UX.
+ * @param {function} [opts.onCanned]         (cannedText, reason) => void — el
+ *                                           caller resuelve el turno con canned.
+ * @param {function} [opts.decide]           inyectable (default core).
+ * @param {function} [opts.acquireLock]      inyectable (default core).
+ * @param {function} [opts.log]              (level, msg) => void.
+ * @returns {{ executed:boolean, reason:string, secondaryProvider:?string,
+ *             secondaryModel:?string, secondaryHandler:?object }}
+ */
+function runInflightFallback(opts = {}) {
+    const {
+        skill,
+        primaryProvider,
+        primaryErrorClass,
+        primaryDurationMs,
+        primaryPartialOutput,
+        attemptIndex,
+        budgetMs,
+        pipelineDir,
+        lockNamespace,
+        requestId,
+        runSecondary,
+        onNotice,
+        onCanned,
+        // inyectables (default: módulo real)
+        decide,
+        acquireLock,
+        log,
+    } = opts;
+
+    const _log = typeof log === 'function' ? log : () => {};
+    const _decide = typeof decide === 'function' ? decide : inflightFallback.decideInflightFallback;
+    const _acquireLock = typeof acquireLock === 'function' ? acquireLock : inflightFallback.acquireInflightLock;
+    const _skill = skill || COMMANDER_SKILL;
+
+    // 1. DECISIÓN — emite inflight_fallback_initiated/exhausted/global_timeout.
+    let decision;
+    try {
+        decision = _decide({
+            skill: _skill,
+            primaryProvider,
+            primaryErrorClass,
+            primaryDurationMs,
+            primaryPartialOutput,
+            attemptIndex,
+            budgetMs,
+            pipelineDir,
+            // El late-response lock + audit se namespacean por `chatId`. Para
+            // agentes de pipeline `lockNamespace` es `issue-<n>` (no hay chat).
+            chatId: lockNamespace,
+            requestId,
+            log,
+        });
+    } catch (e) {
+        _log('inflight', `❌ executor: decideInflightFallback lanzó (${e && e.message}). Fail-closed, sin spawn.`);
+        return { executed: false, reason: 'decide_error', secondaryProvider: null, secondaryModel: null, secondaryHandler: null };
+    }
+
+    // 2. Sin candidato (cap / budget / all_gated / sin credencial): canned.
+    if (!decision || !decision.shouldRetry) {
+        const reason = (decision && decision.reason) || 'no_decision';
+        if (typeof onCanned === 'function') {
+            try { onCanned(decision && decision.cannedResponse, reason); }
+            catch (e) { _log('inflight', `⚠️ executor: onCanned lanzó (best-effort): ${e && e.message}`); }
+        }
+        return { executed: false, reason, secondaryProvider: null, secondaryModel: null, secondaryHandler: null };
+    }
+
+    // 3a. Claim del turno ANTES de spawnear el secundario: cualquier respuesta
+    //     tardía del primario muerto se reconoce como duplicada (CA-7).
+    try {
+        _acquireLock({
+            chatId: lockNamespace,
+            requestId,
+            secondaryProvider: decision.secondaryProvider,
+        });
+    } catch (e) {
+        _log('inflight', `⚠️ executor: acquireInflightLock falló (best-effort): ${e && e.message}`);
+    }
+
+    // 3b. Aviso UX (decisión visible para el usuario/operador).
+    if (decision.noticeText && typeof onNotice === 'function') {
+        try { onNotice(decision.noticeText); }
+        catch (e) { _log('inflight', `⚠️ executor: onNotice lanzó (best-effort): ${e && e.message}`); }
+    }
+
+    // 3c. EJECUCIÓN — el caller spawnea el secundario con la maquinaria pre-spawn
+    //     y resuelve el turno. Si lanza, lo reportamos sin romper el lifecycle.
+    if (typeof runSecondary === 'function') {
+        try {
+            runSecondary(decision);
+        } catch (e) {
+            _log('inflight', `❌ executor: runSecondary lanzó (${e && e.message}).`);
+            return {
+                executed: false,
+                reason: 'run_secondary_error',
+                secondaryProvider: decision.secondaryProvider || null,
+                secondaryModel: decision.secondaryModel || null,
+                secondaryHandler: decision.secondaryHandler || null,
+            };
+        }
+    }
+
+    return {
+        executed: true,
+        reason: 'ok',
+        secondaryProvider: decision.secondaryProvider,
+        secondaryModel: decision.secondaryModel || null,
+        secondaryHandler: decision.secondaryHandler || null,
+    };
+}
+
+module.exports = {
+    runInflightFallback,
+    COMMANDER_SKILL,
+};

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -89,6 +89,10 @@ const inflightShadow = require('./lib/commander/inflight-shadow-detectors');
 // #3577 — generateRequestId para correlación cross-event (CA-S6): el mismo
 // requestId se propaga a TODOS los `auditCommanderRequest` del turn.
 const inflightFallback = require('./lib/commander/inflight-fallback');
+// #4309 — Ejecutor del fallback in-flight (revive #3578, skill-agnóstico):
+// tras la DECISIÓN del fallback (decideInflightFallback) dispara la EJECUCIÓN
+// reusando la maquinaria pre-spawn. Gated por `inflight_fallback.execution_enabled`.
+const inflightExecutor = require('./lib/inflight-executor');
 // #3343 — Sherlock verifier adversarial. Corre IN-PROCESS entre
 // `ejecutarClaude` y `sendTelegram` del flujo texto-libre. Refuta el análisis
 // con un provider distinto al del Commander. Bypass total si
@@ -9483,6 +9487,22 @@ function ejecutarClaude(prompt, textoOriginal, trace, fallbackParts) {
       now: startTimeForAudit,
     });
 
+    // #4309 — Ejecución del fallback in-flight (revive #3578).
+    //   - `inflightExecEnabled`: gate de config (default OFF, rollout gradual).
+    //     Con OFF el comportamiento es idéntico a #3577 (solo shadow signals).
+    //   - `inflightFallbackAttempted`: cap a nivel wiring — máximo UNA ejecución
+    //     de fallback in-flight por turno (complementa el cap=1 del core).
+    //   - `inflightFallbackClaimed`: cuando el executor toma el turno, el
+    //     orquestador del intento Anthropic NO resuelve el Promise externo (el
+    //     secundario lo resuelve). Evita la carrera primario-muerto vs secundario.
+    let inflightExecEnabled = false;
+    try {
+      const cfgRoot = loadConfig() || {};
+      inflightExecEnabled = !!(cfgRoot.inflight_fallback && cfgRoot.inflight_fallback.execution_enabled);
+    } catch { /* default false: preserva comportamiento shadow-only */ }
+    let inflightFallbackAttempted = false;
+    let inflightFallbackClaimed = false;
+
     // #3258 — SR-4: sanitizar el input del usuario ANTES de cualquier dispatch.
     // Si detecta patrones de prompt-injection, recorta al primer match y
     // dejamos constancia en el audit log (best-effort). El prompt efectivo que
@@ -9674,7 +9694,18 @@ function ejecutarClaude(prompt, textoOriginal, trace, fallbackParts) {
     // handler real vía `safeBuildSpawn`. Los providers no-Anthropic son stubs
     // hasta #3198 — `buildSpawn` tira `_notImplemented`. En ese caso, audit
     // log + respondemos canned al usuario sin matar el flow.
-    if (resolution.provider !== 'anthropic') {
+    // #4309 — Los closures de ejecución no-Anthropic (buildEnvFor /
+    // buildFallbackArgs / advanceOrGiveUp / runNonAnthropic) se definen SIEMPRE,
+    // no solo en el camino pre-spawn no-Anthropic. Razón: el ejecutor del
+    // fallback IN-FLIGHT del camino Anthropic (cuando el primario se cuelga a
+    // mitad del stream) los reusa para correr el secundario con la MISMA
+    // maquinaria de spawn (paridad pre-spawn, revive #3578). Son closures
+    // inertes hasta invocarse → cero efecto para el happy-path Anthropic.
+    //
+    // El bloque corre incondicionalmente; expone `runNonAnthropic` al scope del
+    // Promise vía `runNonAnthropicShared` (el bloque crea su propio scope léxico).
+    let runNonAnthropicShared = null;
+    {
       // ---------------------------------------------------------------------
       // Reintento de cadena ante respuesta vacía / spawn fallido (incidente
       // Cerebras empty_output 2026-06-05). Antes, si el provider efectivo
@@ -9903,8 +9934,16 @@ function ejecutarClaude(prompt, textoOriginal, trace, fallbackParts) {
         });
       };
 
+      // #4309 — exponemos el runner al scope del Promise para que el ejecutor
+      // del fallback in-flight (camino Anthropic) lo reuse al caer el primario.
+      runNonAnthropicShared = runNonAnthropic;
+
       // Primer intento: reusamos el env ya construido para el provider inicial.
-      return runNonAnthropic(resolution, cleanEnv);
+      // Solo para el camino pre-spawn (provider efectivo ya distinto de Anthropic);
+      // en el camino Anthropic el bloque solo define los closures y sigue de largo.
+      if (resolution.provider !== 'anthropic') {
+        return runNonAnthropic(resolution, cleanEnv);
+      }
     }
 
     // =========================================================================
@@ -10035,6 +10074,86 @@ function ejecutarClaude(prompt, textoOriginal, trace, fallbackParts) {
       }
     }
 
+    // #4309 — EJECUCIÓN del fallback in-flight (revive #3578). Se invoca DESPUÉS
+    // de `_emitShadowSignal(errorClass)` (que conserva la telemetría de DECISIÓN
+    // `inflight_signal_observed`). Mientras `inflight_fallback.execution_enabled`
+    // esté OFF (default), es no-op → comportamiento idéntico al modo shadow puro.
+    //
+    // Cuando está ON y el primario Anthropic se cae in-flight:
+    //   1. mata el primario (killProc — taskkill /T confirma terminación),
+    //   2. delega al ejecutor skill-agnóstico (decide + lock + spawn secundario),
+    //   3. el secundario corre por la MISMA maquinaria pre-spawn (runNonAnthropic),
+    //   4. emite `inflight_fallback_completed` (EJECUCIÓN ≠ señal — CA-4).
+    // El cap a nivel wiring (`inflightFallbackAttempted`) garantiza UNA sola
+    // ejecución por turno (complementa el cap=1 del core anti-amplificación).
+    function _maybeExecuteInflightFallback(errorClass) {
+      if (!inflightExecEnabled) return false;
+      // El ejecutor in-flight cubre el camino Anthropic (el no-Anthropic ya
+      // cascadea solo vía advanceOrGiveUp). Si el primario no es Anthropic, no-op.
+      if (resolution.provider !== 'anthropic') return false;
+      if (inflightFallbackAttempted) return false;
+      if (typeof runNonAnthropicShared !== 'function') return false;
+      inflightFallbackAttempted = true;
+
+      log('commander', `🛠️ inflight-exec: detector "${errorClass}" disparó EJECUCIÓN de fallback (request_id=${turnRequestId.slice(0, 20)}…)`);
+
+      // Paso 2 (CA-B1): matar el primario y confirmar terminación efectiva ANTES
+      // de spawnear el secundario (evita race de writes/late-response).
+      try { killProc(); } catch (e) { log('commander', `⚠️ inflight-exec: killProc falló (best-effort): ${e && e.message}`); }
+
+      const chatId = getTelegramChatId();
+      const res = inflightExecutor.runInflightFallback({
+        skill: commanderMP.COMMANDER_SKILL,
+        primaryProvider: 'anthropic',
+        primaryErrorClass: errorClass,
+        primaryDurationMs: Date.now() - startTime,
+        primaryPartialOutput: lastText,
+        attemptIndex: 0,
+        pipelineDir: PIPELINE,
+        lockNamespace: chatId,
+        requestId: turnRequestId,
+        log: (l, m) => log(l || 'commander', m),
+        onNotice: (notice) => { try { sendTelegramPlain(notice); } catch {} },
+        onCanned: (canned, reason) => {
+          // Sin secundario disponible (cap/budget/all_gated): el usuario NO queda
+          // mudo — recibe el canned. Reclamamos el turno para que el orquestador
+          // del intento Anthropic no resuelva con su texto de fallo.
+          inflightFallbackClaimed = true;
+          log('commander', `🚫 inflight-exec: sin ejecución (${reason}) — respondiendo canned.`);
+          try { if (canned) sendTelegramPlain(canned); } catch {}
+          resolve(canned || '');
+        },
+        runSecondary: (decision) => {
+          // Reclamamos el turno: el secundario lo resuelve (no el primario muerto).
+          inflightFallbackClaimed = true;
+          log('commander', `↪️ inflight-exec: spawn secundario "${decision.secondaryProvider}" (reuso maquinaria pre-spawn).`);
+          runNonAnthropicShared({
+            provider: decision.secondaryProvider,
+            handler: decision.secondaryHandler,
+            model: decision.secondaryModel,
+          }, null);
+        },
+      });
+
+      // CA-4: distinguir DECISIÓN de EJECUCIÓN. `inflight_fallback_completed`
+      // marca que el secundario fue efectivamente spawneado (no que la tarea de
+      // código tuvo éxito — eso es la salud del adapter, fuera de alcance).
+      if (res && res.executed) {
+        try {
+          inflightFallback.noteInflightCompleted({
+            pipelineDir: PIPELINE,
+            skill: commanderMP.COMMANDER_SKILL,
+            primaryProvider: 'anthropic',
+            secondaryProvider: res.secondaryProvider,
+            success: true,
+            chatId,
+            requestId: turnRequestId,
+          });
+        } catch (e) { log('commander', `⚠️ inflight-exec: noteInflightCompleted falló (best-effort): ${e && e.message}`); }
+      }
+      return !!(res && (res.executed || inflightFallbackClaimed));
+    }
+
     function finish(code, reason) {
       if (resolved) return;
       resolved = true;
@@ -10059,6 +10178,7 @@ function ejecutarClaude(prompt, textoOriginal, trace, fallbackParts) {
       })) {
         eofPrematureFired = true;
         _emitShadowSignal('eof_premature');
+        _maybeExecuteInflightFallback('eof_premature'); // #4309
       }
       const elapsed = Math.round((Date.now() - startTime) / 1000);
       // #3587 CA-1 — finalizar subprocess metadata en el trace antes de resolver.
@@ -10155,6 +10275,7 @@ function ejecutarClaude(prompt, textoOriginal, trace, fallbackParts) {
           if (inflightShadow.detectTransient5xx(evt, { cliGlitchDetector })) {
             transient5xxFired = true;
             _emitShadowSignal('transient_5xx');
+            _maybeExecuteInflightFallback('transient_5xx'); // #4309
           }
         }
 
@@ -10435,6 +10556,7 @@ function ejecutarClaude(prompt, textoOriginal, trace, fallbackParts) {
       })) {
         firstByteFired = true;
         _emitShadowSignal('timeout_first_byte');
+        _maybeExecuteInflightFallback('timeout_first_byte'); // #4309
       }
     }, inflightShadow.FIRST_BYTE_THRESHOLD_MS);
 
@@ -10452,6 +10574,7 @@ function ejecutarClaude(prompt, textoOriginal, trace, fallbackParts) {
       })) {
         streamGapFired = true;
         _emitShadowSignal('timeout_no_new_bytes_30s');
+        _maybeExecuteInflightFallback('timeout_no_new_bytes_30s'); // #4309
       }
     }, 5000);
 
@@ -10507,6 +10630,13 @@ function ejecutarClaude(prompt, textoOriginal, trace, fallbackParts) {
       const MAX_ATTEMPTS = glitchRetry.MAX_SAME_CONTEXT_RETRIES + 2;
       while (attempt <= MAX_ATTEMPTS) {
         const outcome = await attemptAnthropicSpawn({ attempt, forceStandardContext });
+        // #4309 — Si el ejecutor del fallback in-flight reclamó el turno (el
+        // primario Anthropic se cayó mid-stream y el secundario está corriendo o
+        // ya respondió canned), NO resolvemos acá: el secundario es el dueño de
+        // la resolución. Sin este guard, el texto de fallo del primario muerto
+        // ganaría la carrera y el usuario quedaría con un mensaje de error pese a
+        // que el fallback está respondiendo.
+        if (inflightFallbackClaimed) return;
         if (!outcome || outcome.kind !== 'glitch') {
           // Éxito (o resultado no-glitch): el usuario recibe su respuesta normal
           // sin ninguna mención del glitch ni del retry (CA-3 / UX G-2).

--- a/.pipeline/tests/build-child-env.test.js
+++ b/.pipeline/tests/build-child-env.test.js
@@ -521,6 +521,65 @@ test('CA-7: lectura de agent-models.json fallida (JSON inválido) cae a defaults
     assert.equal(env.GH_TOKEN, 'ghp_XXXXX');
 });
 
+// =============================================================================
+// #4309 — Aislamiento de credenciales en el camino IN-FLIGHT (BLOQUEANTE,
+// requisito de seguridad #1). El ejecutor del fallback in-flight re-spawnea con
+// el partial-override `{ provider: 'openai-codex' }` (la MISMA maquinaria que el
+// pre-spawn). El env del child secundario DEBE contener OPENAI_API_KEY y NUNCA
+// ANTHROPIC_API_KEY — un panic dump del CLI de Codex no debe poder exponer la
+// key de Anthropic del primario muerto (invariante S-2).
+// =============================================================================
+test('#4309: re-spawn in-flight (partial override openai-codex) → OPENAI sí, ANTHROPIC NO', () => {
+    const fakeFs = {
+        existsSync: () => true,
+        readFileSync: () => JSON.stringify({
+            providers: {
+                anthropic: { launcher: 'claude', credentials_env: 'ANTHROPIC_API_KEY' },
+                'openai-codex': { launcher: 'codex', credentials_env: 'OPENAI_API_KEY' },
+            },
+            skills: {
+                'telegram-commander': { provider: 'anthropic' },
+            },
+        }),
+    };
+    const env = buildChildEnv({
+        // El skill primario es telegram-commander (provider=anthropic en disk),
+        // pero el fallback in-flight fuerza el provider del secundario.
+        skill: 'telegram-commander',
+        pipelineDir: '/fake/.pipeline',
+        fsImpl: fakeFs,
+        processEnv: fullOperatorEnv(), // incluye AMBAS keys
+        skillConfigOverride: { provider: 'openai-codex' }, // partial override (#3198)
+    });
+    // S-2: el secundario recibe SOLO la key del fallback.
+    assert.equal(env.OPENAI_API_KEY, 'sk-openai-XXXXX');
+    assert.equal(env.ANTHROPIC_API_KEY, undefined, 'ANTHROPIC_API_KEY NO debe viajar al child de Codex');
+});
+
+test('#4309: re-spawn in-flight para agente de pipeline genérico también aísla credenciales', () => {
+    const fakeFs = {
+        existsSync: () => true,
+        readFileSync: () => JSON.stringify({
+            providers: {
+                anthropic: { launcher: 'claude', credentials_env: 'ANTHROPIC_API_KEY' },
+                'openai-codex': { launcher: 'codex', credentials_env: 'OPENAI_API_KEY' },
+            },
+            skills: {
+                'android-dev': { provider: 'anthropic' },
+            },
+        }),
+    };
+    const env = buildChildEnv({
+        skill: 'android-dev', // CA-3: cualquier agente, no solo el Commander
+        pipelineDir: '/fake/.pipeline',
+        fsImpl: fakeFs,
+        processEnv: fullOperatorEnv(),
+        skillConfigOverride: { provider: 'openai-codex' },
+    });
+    assert.equal(env.OPENAI_API_KEY, 'sk-openai-XXXXX');
+    assert.equal(env.ANTHROPIC_API_KEY, undefined);
+});
+
 test('CA-7: agent-models.json válido OVERRIDE los defaults hardcoded', () => {
     const fakeFs = {
         existsSync: () => true,

--- a/.pipeline/tests/inflight-executor.test.js
+++ b/.pipeline/tests/inflight-executor.test.js
@@ -1,0 +1,315 @@
+// =============================================================================
+// inflight-executor.test.js — Tests del ejecutor del fallback in-flight (#4309).
+//
+// Cubre el wire-up de EJECUCIÓN (distinto de la DECISIÓN, ya testeada en
+// commander-inflight-fallback.test.js):
+//   CA-1 — happy path: decide → lock → notice → runSecondary (spawn) → executed.
+//   CA-3 — skill-agnóstico: cualquier agente (no solo el Commander) usa el core.
+//   CA-4 — distinción decisión/ejecución: el caller emite completed solo si executed.
+//   CA-6 — cap/all-gated: sin secundario → onCanned, NO runSecondary, executed:false.
+//   CA-7 — late-response lock: el lock se adquiere antes de spawnear el secundario.
+//   Robustez — decide lanza / runSecondary lanza → fail-closed sin romper.
+//   Orden — acquireLock y onNotice ocurren ANTES de runSecondary.
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const executor = require('../lib/inflight-executor');
+const inflight = require('../lib/commander/inflight-fallback');
+
+// Decisión fake "ok" reutilizable.
+function okDecision(overrides = {}) {
+    return {
+        shouldRetry: true,
+        secondaryProvider: 'openai-codex',
+        secondaryHandler: { providerDef: { supports_tool_use: true } },
+        secondaryModel: 'gpt-5-codex',
+        reason: 'ok',
+        noticeText: '⚠️ anthropic se cayó — reintentando con openai-codex.',
+        ...overrides,
+    };
+}
+
+// -----------------------------------------------------------------------------
+// CA-1 — happy path: ejecución efectiva del secundario.
+// -----------------------------------------------------------------------------
+test('CA-1 — happy path: decide→lock→notice→runSecondary y executed:true', () => {
+    const calls = [];
+    const res = executor.runInflightFallback({
+        skill: 'telegram-commander',
+        primaryProvider: 'anthropic',
+        primaryErrorClass: 'transient_5xx',
+        primaryDurationMs: 12_000,
+        primaryPartialOutput: 'parcial',
+        attemptIndex: 0,
+        pipelineDir: '/tmp/nope',
+        lockNamespace: 'chat-1',
+        requestId: 'req-happy-1',
+        decide: (opts) => { calls.push(['decide', opts.skill]); return okDecision(); },
+        acquireLock: (opts) => { calls.push(['lock', opts.requestId, opts.secondaryProvider]); return true; },
+        onNotice: (txt) => { calls.push(['notice', txt]); },
+        onCanned: () => { calls.push(['canned']); },
+        runSecondary: (dec) => { calls.push(['runSecondary', dec.secondaryProvider]); },
+        log: () => {},
+    });
+
+    assert.equal(res.executed, true);
+    assert.equal(res.secondaryProvider, 'openai-codex');
+    assert.equal(res.secondaryModel, 'gpt-5-codex');
+    // onCanned NUNCA se llama en el happy path.
+    assert.ok(!calls.some(c => c[0] === 'canned'));
+    // runSecondary se llamó con el provider secundario.
+    assert.ok(calls.some(c => c[0] === 'runSecondary' && c[1] === 'openai-codex'));
+});
+
+// -----------------------------------------------------------------------------
+// Orden — acquireLock y onNotice ANTES de runSecondary (CA-7 / UX).
+// -----------------------------------------------------------------------------
+test('Orden — lock y notice ocurren antes de runSecondary', () => {
+    const order = [];
+    executor.runInflightFallback({
+        primaryProvider: 'anthropic',
+        primaryErrorClass: 'timeout_no_new_bytes_30s',
+        lockNamespace: 'chat-ord',
+        requestId: 'req-ord',
+        decide: () => okDecision(),
+        acquireLock: () => { order.push('lock'); return true; },
+        onNotice: () => { order.push('notice'); },
+        runSecondary: () => { order.push('runSecondary'); },
+        log: () => {},
+    });
+    assert.deepEqual(order, ['lock', 'notice', 'runSecondary']);
+});
+
+// -----------------------------------------------------------------------------
+// CA-3 — skill-agnóstico: un agente de pipeline (no Commander) usa el core.
+// -----------------------------------------------------------------------------
+test('CA-3 — skill propagado al core + lockNamespace por issue (cross-agente)', () => {
+    let seenSkill = null;
+    let seenChatId = null;
+    const res = executor.runInflightFallback({
+        skill: 'android-dev',
+        primaryProvider: 'anthropic',
+        primaryErrorClass: 'eof_premature',
+        lockNamespace: 'issue-4309',
+        requestId: 'req-android',
+        decide: (opts) => { seenSkill = opts.skill; seenChatId = opts.chatId; return okDecision(); },
+        acquireLock: () => true,
+        runSecondary: () => {},
+        log: () => {},
+    });
+    assert.equal(seenSkill, 'android-dev');
+    // El namespace del lock viaja como chatId al core (issue+request_id para agentes).
+    assert.equal(seenChatId, 'issue-4309');
+    assert.equal(res.executed, true);
+});
+
+test('CA-3 — sin skill explícito, default COMMANDER_SKILL', () => {
+    let seenSkill = null;
+    executor.runInflightFallback({
+        primaryProvider: 'anthropic',
+        primaryErrorClass: 'transient_5xx',
+        lockNamespace: 'chat-def',
+        requestId: 'req-def',
+        decide: (opts) => { seenSkill = opts.skill; return okDecision(); },
+        acquireLock: () => true,
+        runSecondary: () => {},
+        log: () => {},
+    });
+    assert.equal(seenSkill, executor.COMMANDER_SKILL);
+    assert.equal(executor.COMMANDER_SKILL, 'telegram-commander');
+});
+
+// -----------------------------------------------------------------------------
+// CA-6 — sin candidato (cap/budget/all_gated): onCanned, NO runSecondary.
+// -----------------------------------------------------------------------------
+test('CA-6 — shouldRetry:false → onCanned y executed:false (sin spawn)', () => {
+    const calls = [];
+    const res = executor.runInflightFallback({
+        primaryProvider: 'anthropic',
+        primaryErrorClass: 'transient_5xx',
+        lockNamespace: 'chat-cap',
+        requestId: 'req-cap',
+        decide: () => ({
+            shouldRetry: false,
+            reason: 'cap_exhausted',
+            cannedResponse: '❌ Dos intentos fallidos seguidos.',
+        }),
+        acquireLock: () => { calls.push('lock'); return true; },
+        onCanned: (txt, reason) => { calls.push(['canned', txt, reason]); },
+        runSecondary: () => { calls.push('runSecondary'); },
+        log: () => {},
+    });
+    assert.equal(res.executed, false);
+    assert.equal(res.reason, 'cap_exhausted');
+    // NO spawn, NO lock cuando no hay retry.
+    assert.ok(!calls.includes('runSecondary'));
+    assert.ok(!calls.includes('lock'));
+    // onCanned recibió el canned + reason.
+    const canned = calls.find(c => Array.isArray(c) && c[0] === 'canned');
+    assert.ok(canned);
+    assert.equal(canned[2], 'cap_exhausted');
+});
+
+// -----------------------------------------------------------------------------
+// Robustez — fail-closed.
+// -----------------------------------------------------------------------------
+test('Robustez — decide lanza → executed:false reason decide_error, sin spawn', () => {
+    let spawned = false;
+    const res = executor.runInflightFallback({
+        primaryProvider: 'anthropic',
+        primaryErrorClass: 'transient_5xx',
+        lockNamespace: 'chat-err',
+        requestId: 'req-err',
+        decide: () => { throw new Error('boom'); },
+        runSecondary: () => { spawned = true; },
+        log: () => {},
+    });
+    assert.equal(res.executed, false);
+    assert.equal(res.reason, 'decide_error');
+    assert.equal(spawned, false);
+});
+
+test('Robustez — runSecondary lanza → executed:false reason run_secondary_error', () => {
+    const res = executor.runInflightFallback({
+        primaryProvider: 'anthropic',
+        primaryErrorClass: 'transient_5xx',
+        lockNamespace: 'chat-rs',
+        requestId: 'req-rs',
+        decide: () => okDecision(),
+        acquireLock: () => true,
+        runSecondary: () => { throw new Error('spawn falló'); },
+        log: () => {},
+    });
+    assert.equal(res.executed, false);
+    assert.equal(res.reason, 'run_secondary_error');
+    assert.equal(res.secondaryProvider, 'openai-codex');
+});
+
+// -----------------------------------------------------------------------------
+// CA-7 — late-response lock real: tras ejecutar, el primario tardío es duplicado.
+// Usa las funciones REALES del core (no inyectadas) para validar integración.
+// -----------------------------------------------------------------------------
+test('CA-7 — lock real adquirido: late-response del primario se reconoce duplicado', () => {
+    inflight._resetInflightLocks();
+    const ns = 'issue-7777';
+    const requestId = 'req-late-real';
+    // Antes de ejecutar: no hay lock.
+    assert.equal(inflight.isLateResponseDuplicate({ chatId: ns, requestId }), false);
+
+    const res = executor.runInflightFallback({
+        skill: 'backend-dev',
+        primaryProvider: 'anthropic',
+        primaryErrorClass: 'timeout_no_new_bytes_30s',
+        lockNamespace: ns,
+        requestId,
+        decide: () => okDecision(),
+        // acquireLock NO inyectado → usa inflight.acquireInflightLock real.
+        runSecondary: () => {},
+        log: () => {},
+    });
+    assert.equal(res.executed, true);
+    // Tras ejecutar: una respuesta tardía del primario muerto es duplicada.
+    assert.equal(inflight.isLateResponseDuplicate({ chatId: ns, requestId }), true);
+    inflight._resetInflightLocks();
+});
+
+// -----------------------------------------------------------------------------
+// Integración real con el core: decide real (con MP fake) emite
+// inflight_fallback_initiated y dispara runSecondary.
+// -----------------------------------------------------------------------------
+test('Integración — decide real emite initiated y ejecuta el secundario', () => {
+    const fs = require('node:fs');
+    const path = require('node:path');
+    const os = require('node:os');
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'inflight-exec-'));
+    fs.mkdirSync(path.join(dir, 'logs'), { recursive: true });
+    try {
+        // Monkey-patch del cache de multi-provider para forzar el secundario.
+        const mpPath = require.resolve('../lib/commander/multi-provider');
+        const original = require.cache[mpPath];
+        const fakeMP = {
+            resolveCommanderProviderExcluding(excluded) {
+                return {
+                    gated: false,
+                    provider: 'openai-codex',
+                    model: 'gpt-5-codex',
+                    handler: { providerDef: { supports_tool_use: true } },
+                    chainTried: [excluded, 'openai-codex'],
+                };
+            },
+        };
+        require.cache[mpPath] = { exports: { ...((original && original.exports) || {}), ...fakeMP } };
+
+        let spawnedProvider = null;
+        try {
+            const res = executor.runInflightFallback({
+                skill: 'telegram-commander',
+                primaryProvider: 'anthropic',
+                primaryErrorClass: 'transient_5xx',
+                primaryDurationMs: 8_000,
+                primaryPartialOutput: 'algo',
+                attemptIndex: 0,
+                pipelineDir: dir,
+                lockNamespace: 'chat-int',
+                requestId: 'req-int',
+                runSecondary: (dec) => { spawnedProvider = dec.secondaryProvider; },
+                log: () => {},
+            });
+            assert.equal(res.executed, true);
+            assert.equal(spawnedProvider, 'openai-codex');
+        } finally {
+            if (original) require.cache[mpPath] = original;
+            else delete require.cache[mpPath];
+        }
+
+        // El core emitió la señal de DECISIÓN inflight_fallback_initiated.
+        const d = new Date();
+        const f = path.join(dir, 'logs',
+            `commander-dispatch-${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}-${String(d.getUTCDate()).padStart(2, '0')}.jsonl`);
+        const lines = fs.readFileSync(f, 'utf8').split('\n').filter(Boolean).map(JSON.parse);
+        assert.ok(lines.some(e => e.event === 'inflight_fallback_initiated'), 'falta inflight_fallback_initiated');
+        // CA-3: el partial NO se vuelca literal (solo hash).
+        assert.ok(!fs.readFileSync(f, 'utf8').includes('algo viejo'));
+    } finally {
+        try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+        inflight._resetInflightLocks();
+    }
+});
+
+// -----------------------------------------------------------------------------
+// CA-4 — el caller distingue decisión de ejecución: noteInflightCompleted con
+// skill arbitrario emite inflight_fallback_completed con ese skill.
+// -----------------------------------------------------------------------------
+test('CA-4 — noteInflightCompleted acepta skill arbitrario (cross-agente)', () => {
+    const fs = require('node:fs');
+    const path = require('node:path');
+    const os = require('node:os');
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'inflight-completed-'));
+    fs.mkdirSync(path.join(dir, 'logs'), { recursive: true });
+    try {
+        const ok = inflight.noteInflightCompleted({
+            pipelineDir: dir,
+            skill: 'web-dev',
+            primaryProvider: 'anthropic',
+            secondaryProvider: 'openai-codex',
+            success: true,
+            chatId: 'issue-99',
+            requestId: 'req-completed',
+        });
+        assert.equal(ok, true);
+        const d = new Date();
+        const f = path.join(dir, 'logs',
+            `commander-dispatch-${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}-${String(d.getUTCDate()).padStart(2, '0')}.jsonl`);
+        const lines = fs.readFileSync(f, 'utf8').split('\n').filter(Boolean).map(JSON.parse);
+        const ev = lines.find(e => e.event === 'inflight_fallback_completed');
+        assert.ok(ev, 'falta inflight_fallback_completed');
+        assert.equal(ev.skill, 'web-dev'); // skill del agente, NO el default commander
+        assert.equal(ev.secondary_provider, 'openai-codex');
+        assert.equal(ev.success, true);
+    } finally {
+        try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+    }
+});


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 6 archivos · +733 -4

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:skipped` aplicado por delivery

## Closes

Closes #4309
