### PR TITLE
fix(pipeline): ejecutor de fallback in-flight default ON (follow-up #4309)

### DIFF
--- a/.pipeline/config.yaml
+++ b/.pipeline/config.yaml
@@ -715,15 +715,17 @@ pipeline:
 #      override → aislamiento de credenciales S-2 → runNonAnthropic),
 #   4. emite `inflight_fallback_completed` (EJECUCIÓN ≠ señal de decisión).
 #
-# Cuando `false` (DEFAULT, rollout gradual): comportamiento idéntico a #3577 —
-# los detectores SOLO emiten la señal shadow, sin matar el primario ni spawnear
-# el secundario. Preserva regresión cero hasta validar el wire-up en caliente.
+# DEFAULT: ON. El ejecutor in-flight viene prendido — un fix no puede shippear
+# apagado y degradar al comportamiento viejo (detecta pero no ejecuta). Este
+# flag queda SOLO como kill-switch explícito: para volver al modo shadow-only
+# (#3577, sin matar el primario ni spawnear el secundario) hay que setearlo
+# explícitamente en `false`. Ausente/indefinido => ON.
 #
 # Aplica a CUALQUIER agente del pipeline (el ejecutor es skill-agnóstico), no
 # solo al Telegram Commander. El cap=1 + budget acotan la amplificación de
 # spawns ante una caída sostenida de Anthropic (modo de falla conocido).
 inflight_fallback:
-  execution_enabled: false
+  execution_enabled: true
 
 # =============================================================================
 # #3343 — Sherlock verifier adversarial (split de #3331)

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -9488,18 +9488,21 @@ function ejecutarClaude(prompt, textoOriginal, trace, fallbackParts) {
     });
 
     // #4309 — Ejecución del fallback in-flight (revive #3578).
-    //   - `inflightExecEnabled`: gate de config (default OFF, rollout gradual).
-    //     Con OFF el comportamiento es idéntico a #3577 (solo shadow signals).
+    //   - `inflightExecEnabled`: gate de config. Default ON: un fix no puede
+    //     shippear apagado y degradar al bug viejo (detecta pero no ejecuta).
+    //     El flag queda SOLO como kill-switch explícito de opt-out: para
+    //     desactivar hay que setear `inflight_fallback.execution_enabled: false`.
     //   - `inflightFallbackAttempted`: cap a nivel wiring — máximo UNA ejecución
     //     de fallback in-flight por turno (complementa el cap=1 del core).
     //   - `inflightFallbackClaimed`: cuando el executor toma el turno, el
     //     orquestador del intento Anthropic NO resuelve el Promise externo (el
     //     secundario lo resuelve). Evita la carrera primario-muerto vs secundario.
-    let inflightExecEnabled = false;
+    let inflightExecEnabled = true;
     try {
       const cfgRoot = loadConfig() || {};
-      inflightExecEnabled = !!(cfgRoot.inflight_fallback && cfgRoot.inflight_fallback.execution_enabled);
-    } catch { /* default false: preserva comportamiento shadow-only */ }
+      // Solo OFF si está explícitamente en false; ausente/indefinido => ON.
+      inflightExecEnabled = !(cfgRoot.inflight_fallback && cfgRoot.inflight_fallback.execution_enabled === false);
+    } catch { /* default true: el fix viene prendido salvo opt-out explícito */ }
     let inflightFallbackAttempted = false;
     let inflightFallbackClaimed = false;
 


### PR DESCRIPTION
## Resumen

- El flag `inflight_fallback.execution_enabled` venía con **default OFF** (rollout gradual). Con OFF, un fix shippeaba apagado y el comportamiento era idéntico al bug viejo: detecta la caída in-flight de Anthropic pero **no ejecuta** el secundario (Codex).
- Ahora el ejecutor in-flight **viene prendido por default**. El flag queda solo como **kill-switch explícito de opt-out**: para desactivar hay que setear `execution_enabled: false` de forma explícita; ausente/indefinido ⇒ ON.

## Cambios

- `.pipeline/config.yaml`: `execution_enabled: true` + comentario corregido (default ON, opt-out explícito).
- `.pipeline/pulpo.js`: `inflightExecEnabled` default `true`; solo OFF si está explícitamente en `=== false`.

## Plan de tests

- [x] 38/38 tests del ejecutor in-flight en verde
- [x] config parsea OK (`execution_enabled = true`)

QA Validate: `qa:skipped` — cambio de infra pura del pipeline (motor de fallback), sin impacto en producto de usuario.

Follow-up de #4309

🤖 Generado con [Claude Code](https://claude.com/claude-code)