### PR TITLE
Fallback pre-turno: el ejecutor revienta al instante tras seleccionar Codex y nunca lo invoca (follow-up #4313)

### DIFF
--- a/.pipeline/lib/commander/__tests__/spawn-attempt-guard.test.js
+++ b/.pipeline/lib/commander/__tests__/spawn-attempt-guard.test.js
@@ -1,0 +1,129 @@
+// =============================================================================
+// spawn-attempt-guard.test.js — Tests del guard síncrono del intento de spawn
+// no-Anthropic del Commander (#4318).
+//
+// El guard es la unidad pura que captura la esencia del fix: si el cuerpo
+// SÍNCRONO del intento de spawn lanza (Windows: launcher ENOENT / cmd inválido,
+// sin `proc.on('error')`), NO propaga la excepción — la enruta a `onSyncThrow`
+// para que el caller degrade vía advanceOrGiveUp (resolve canned, NUNCA reject).
+//
+// Cobertura de los escenarios Gherkin del issue (a nivel del seam testeable):
+//   - CA-1/CA-4: throw síncrono → NO se propaga; se invoca el degradado con
+//                reason 'spawn_throw'; el Promise del turno resolvería (canned).
+//   - CA-1/CA-2: camino feliz → el guard devuelve el valor del intento sin
+//                invocar el degradado (Codex se invoca de verdad, async).
+//   - CA-3/SR-D: el degradado recibe el provider EFECTIVO del reemplazo para que
+//                el caller lo use como atribución (no 'anthropic').
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const guard = require('../spawn-attempt-guard');
+
+// ---------------------------------------------------------------------------
+// CA-1 / CA-4 — Throw SÍNCRONO del intento: NO se propaga, se degrada.
+// ---------------------------------------------------------------------------
+test('CA-1/CA-4 — attempt lanza síncrono → onSyncThrow, NO rethrow', () => {
+  const calls = [];
+  const boom = new Error('spawn openai-codex ENOENT');
+
+  // El guard NO debe propagar: si lo hiciera, este assert.doesNotThrow falla.
+  let ret;
+  assert.doesNotThrow(() => {
+    ret = guard.runGuardedSpawnAttempt({
+      provider: 'openai-codex',
+      attempt: () => { throw boom; },
+      onSyncThrow: (provider, reason, err) => {
+        calls.push({ provider, reason, err });
+        return 'CANNED_DEGRADED'; // simula el retorno de advanceOrGiveUp (resolve)
+      },
+    });
+  });
+
+  // El valor de retorno es el del degradado (el caller lo propaga como resolve).
+  assert.equal(ret, 'CANNED_DEGRADED');
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].provider, 'openai-codex');
+  assert.equal(calls[0].reason, 'spawn_throw'); // reason por defecto
+  assert.equal(calls[0].err, boom); // la causa real llega al caller (para audit)
+});
+
+// ---------------------------------------------------------------------------
+// CA-1 / CA-2 — Camino feliz: el intento no lanza → se invoca de verdad y su
+// valor de retorno se propaga; el degradado NUNCA se llama.
+// ---------------------------------------------------------------------------
+test('CA-1/CA-2 — attempt no lanza → devuelve su valor, sin degradado', () => {
+  let degraded = false;
+  let attemptRan = false;
+
+  const ret = guard.runGuardedSpawnAttempt({
+    provider: 'openai-codex',
+    attempt: () => { attemptRan = true; return 'ATTEMPT_RESULT'; },
+    onSyncThrow: () => { degraded = true; return 'SHOULD_NOT_HAPPEN'; },
+  });
+
+  assert.equal(attemptRan, true);
+  assert.equal(ret, 'ATTEMPT_RESULT');
+  assert.equal(degraded, false);
+});
+
+// ---------------------------------------------------------------------------
+// CA-3 / SR-D — La razón del degradado es configurable y se propaga tal cual al
+// degradado (para que el caller la use como errorCode del audit / atribución).
+// ---------------------------------------------------------------------------
+test('CA-3/SR-D — reason custom se propaga al degradado', () => {
+  let seenReason = null;
+  guard.runGuardedSpawnAttempt({
+    provider: 'gemini-google',
+    reason: 'custom_reason',
+    attempt: () => { throw new Error('x'); },
+    onSyncThrow: (_p, reason) => { seenReason = reason; },
+  });
+  assert.equal(seenReason, 'custom_reason');
+});
+
+test('CA-3/SR-D — reason por defecto es DEFAULT_SYNC_THROW_REASON', () => {
+  assert.equal(guard.DEFAULT_SYNC_THROW_REASON, 'spawn_throw');
+});
+
+// ---------------------------------------------------------------------------
+// Robustez — el degradado también puede lanzar como último recurso; el guard NO
+// lo enmascara (es responsabilidad del caller que advanceOrGiveUp no lance). El
+// comportamiento esperado es que se propague ese error del degradado (no el del
+// attempt), documentando el contrato.
+// ---------------------------------------------------------------------------
+test('Robustez — si onSyncThrow lanza, se propaga su error (no el del attempt)', () => {
+  const degradeErr = new Error('advanceOrGiveUp roto');
+  assert.throws(
+    () => guard.runGuardedSpawnAttempt({
+      provider: 'openai-codex',
+      attempt: () => { throw new Error('attempt error'); },
+      onSyncThrow: () => { throw degradeErr; },
+    }),
+    /advanceOrGiveUp roto/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Contrato de tipos — argumentos inválidos fallan rápido (fail-fast) para no
+// enmascarar un cableado incorrecto del caller.
+// ---------------------------------------------------------------------------
+test('Contrato — attempt no-función lanza TypeError', () => {
+  assert.throws(
+    () => guard.runGuardedSpawnAttempt({ provider: 'x', attempt: null, onSyncThrow: () => {} }),
+    /TypeError|attempt/,
+  );
+});
+
+test('Contrato — onSyncThrow no-función lanza TypeError', () => {
+  assert.throws(
+    () => guard.runGuardedSpawnAttempt({ provider: 'x', attempt: () => {}, onSyncThrow: 'nope' }),
+    /TypeError|onSyncThrow/,
+  );
+});
+
+test('Contrato — args ausente lanza TypeError (no crash silencioso)', () => {
+  assert.throws(() => guard.runGuardedSpawnAttempt(), /TypeError/);
+});

--- a/.pipeline/lib/commander/spawn-attempt-guard.js
+++ b/.pipeline/lib/commander/spawn-attempt-guard.js
@@ -1,0 +1,89 @@
+// =============================================================================
+// spawn-attempt-guard.js — Guard SÍNCRONO del intento de spawn de un provider
+// no-Anthropic del Commander (#4318).
+//
+// Contexto del bug (#4318, follow-up de #4313):
+//   El ejecutor pre-turno del fallback (`runNonAnthropic` en `pulpo.js`) corre
+//   el setup del spawn de forma SÍNCRONA: data-residency → safeBuildSpawn →
+//   `spawn(...)`. En Windows, un launcher mal cableado (ENOENT / cmd inválido)
+//   hace que `spawn()` (o el resto del setup) LANCE de forma síncrona SIN emitir
+//   el evento `proc.on('error')`. Ese throw escapaba del executor del `Promise`
+//   de `ejecutarClaude` → lo RECHAZABA en ~ms (sin llegar a invocar Codex de
+//   verdad) → se saltaba el override de atribución del turno y el resultado
+//   quedaba como `error / provider:anthropic / cross_provider:false`.
+//
+// Este módulo aísla la ÚNICA decisión del fix en una unidad pura y testeable:
+//   "si el cuerpo síncrono del intento lanza, NO propagar — degradar vía el
+//    mismo camino que `proc.on('error')` (advanceOrGiveUp → resolve canned,
+//    NUNCA reject)".
+//
+// El módulo es PURO: no importa `child_process` ni toca disco. Recibe el thunk
+// del intento y el degradado por inyección, de modo que se testea sin levantar
+// el pulpo (que no es unit-testeable). El caller real (`pulpo.js::runNonAnthropic`)
+// lo usa como wrapper del cuerpo síncrono; ambos caminos (pre-turno #4313 e
+// in-flight #4309) comparten el closure, así que el guard cubre a los dos.
+//
+// Seguridad (SR-A / SR-7, fase análisis #4318): el guard NO expone `stderr` ni
+// el prompt crudo. La causa del throw se entrega como `Error` al `onSyncThrow`
+// del caller, que decide qué loguear/auditar con redacción propia (prompt_hash,
+// nunca literal). Acá no se serializa nada.
+// =============================================================================
+'use strict';
+
+// Razón por defecto del degradado ante throw síncrono. Es un enum-string
+// estático (no derivado de input) → apto para audit log / atribución sin riesgo
+// de log-forging.
+const DEFAULT_SYNC_THROW_REASON = 'spawn_throw';
+
+/**
+ * Ejecuta el cuerpo síncrono de un intento de spawn bajo un try/catch. Si el
+ * intento lanza SÍNCRONAMENTE, enruta al degradado `onSyncThrow` en vez de
+ * propagar la excepción (fail-soft: el turno NUNCA queda mudo por un throw del
+ * launcher). Si el intento no lanza, devuelve tal cual su valor de retorno (la
+ * resolución real del turno ocurre async vía los `proc.on(...)` que el intento
+ * registró — fuera del alcance de este guard).
+ *
+ * @param {object} args
+ * @param {string} args.provider        Provider efectivo del intento (atribución).
+ * @param {function} args.attempt       Thunk con el cuerpo SÍNCRONO del intento
+ *                                       (data-residency + safeBuildSpawn + spawn +
+ *                                       wiring de eventos). Puede devolver cualquier
+ *                                       cosa; su valor se propaga en el camino feliz.
+ * @param {function} args.onSyncThrow   (provider, reason, err) => X — degradado
+ *                                       invocado SÓLO si `attempt` lanza. Su valor
+ *                                       de retorno se propaga.
+ * @param {string} [args.reason]        Código de razón del degradado
+ *                                       (default: 'spawn_throw').
+ * @returns {*} el retorno de `attempt()` (feliz) o de `onSyncThrow()` (ante throw).
+ * @throws {TypeError} si `attempt` u `onSyncThrow` no son funciones.
+ */
+function runGuardedSpawnAttempt(args) {
+  const {
+    provider,
+    attempt,
+    onSyncThrow,
+    reason = DEFAULT_SYNC_THROW_REASON,
+  } = (args && typeof args === 'object') ? args : {};
+
+  if (typeof attempt !== 'function') {
+    throw new TypeError('runGuardedSpawnAttempt: `attempt` debe ser una función');
+  }
+  if (typeof onSyncThrow !== 'function') {
+    throw new TypeError('runGuardedSpawnAttempt: `onSyncThrow` debe ser una función');
+  }
+
+  try {
+    return attempt();
+  } catch (err) {
+    // Throw síncrono del setup/spawn → degradar (NUNCA propagar). El caller
+    // convierte esto en advanceOrGiveUp(provider, reason): re-resuelve la cadena
+    // o resuelve canned. El forense (errorCode real, provider) queda en el audit
+    // log del caller, no acá.
+    return onSyncThrow(provider, reason, err);
+  }
+}
+
+module.exports = {
+  runGuardedSpawnAttempt,
+  DEFAULT_SYNC_THROW_REASON,
+};

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -93,6 +93,10 @@ const inflightFallback = require('./lib/commander/inflight-fallback');
 // tras la DECISIÓN del fallback (decideInflightFallback) dispara la EJECUCIÓN
 // reusando la maquinaria pre-spawn. Gated por `inflight_fallback.execution_enabled`.
 const inflightExecutor = require('./lib/inflight-executor');
+// #4318 — Guard síncrono del intento de spawn no-Anthropic: si el setup/spawn
+// lanza SÍNCRONAMENTE (Windows: launcher ENOENT/cmd inválido, sin proc.on('error')),
+// degrada vía advanceOrGiveUp en vez de propagar y rechazar el Promise del turno.
+const spawnAttemptGuard = require('./lib/commander/spawn-attempt-guard');
 // #3343 — Sherlock verifier adversarial. Corre IN-PROCESS entre
 // `ejecutarClaude` y `sendTelegram` del flujo texto-libre. Refuta el análisis
 // con un provider distinto al del Commander. Bypass total si
@@ -9886,6 +9890,20 @@ function ejecutarClaude(prompt, textoOriginal, trace, fallbackParts) {
       const runNonAnthropic = (res, preEnv) => {
         triedNonAnthropic.add(res.provider);
 
+        // #4318 (CA-3 / SR-D) — Reflejar el provider EFECTIVO del reemplazo en el
+        // trace ANTES de spawnear, para que la atribución del turno sea correcta
+        // (provider = reemplazo, cross_provider = true) TANTO en el camino de ÉXITO
+        // COMO en el de FALLO del ejecutor. Antes esto solo se seteaba en el camino
+        // de éxito (proc.on('close') con texto), así que un fallo/throw del reemplazo
+        // dejaba la atribución en el default Anthropic (bug del issue). Fuente
+        // autoritativa = resolver/`res` (anti log-forging: NUNCA del texto de salida
+        // del subproceso). Idempotente si el resolver ya lo había marcado (#4313).
+        if (_trace && _trace.resolution) {
+          _trace.resolution.provider = res.provider;
+          _trace.resolution.crossProvider = true;
+          _trace.resolution.fallbackUsed = String(res.provider);
+        }
+
         let attemptEnv;
         try {
           attemptEnv = preEnv || buildEnvFor(res.provider);
@@ -9894,117 +9912,148 @@ function ejecutarClaude(prompt, textoOriginal, trace, fallbackParts) {
           return advanceOrGiveUp(res.provider, 'env_isolation_error');
         }
 
-        // Data-residency por provider: los retries no pasaron por el check
-        // del provider inicial, así que re-chequeamos para cada candidato.
-        const drCheck2 = commanderMP.enforceDataResidency({
-          pipelineDir: PIPELINE,
+        // #4318 (CA-1 / CA-4) — El cuerpo SÍNCRONO del intento (data-residency +
+        // safeBuildSpawn + spawn + wiring de eventos) va bajo un guard. En Windows,
+        // un launcher mal cableado (ENOENT / cmd inválido) hace que `spawn()` (o el
+        // resto del setup) LANCE de forma SÍNCRONA sin emitir `proc.on('error')`.
+        // Sin este guard, el throw escapaba del executor del Promise de
+        // `ejecutarClaude` → lo RECHAZABA en ~ms (sin invocar Codex de verdad) →
+        // se saltaba el override de atribución del turno y el resultado quedaba como
+        // `error / provider:anthropic / cross_provider:false` (firma del bug). Ahora
+        // convergemos al MISMO degradado que `proc.on('error')`: advanceOrGiveUp
+        // (re-resuelve la cadena o resuelve canned — NUNCA reject). El forense del
+        // throw queda en el audit log (`spawn_error` / errorCode `spawn_throw`).
+        return spawnAttemptGuard.runGuardedSpawnAttempt({
           provider: res.provider,
-          paths: [],
-          chatId: getTelegramChatId(),
-          prompt: prompt,
-          log: (l, m) => log(l || 'commander', m),
-        });
-        if (!drCheck2.ok) {
-          log('commander', `🚫 data-residency bloqueó "${res.provider}" (${drCheck2.reason}) — intento siguiente provider.`);
-          return advanceOrGiveUp(res.provider, 'data_residency_blocked');
-        }
-
-        const safe = commanderMP.safeBuildSpawn({
-          handler: res.handler,
-          args: buildFallbackArgs(res.provider),
-          cwd: ROOT,
-          env: attemptEnv,
-        });
-        if (!safe.ok) {
-          try {
-            commanderMP.auditCommanderRequest({
-              pipelineDir: PIPELINE,
-              event: 'fallback_unavailable',
-              providerIntended: resolution.primaryProvider || 'anthropic',
-              providerEffective: res.provider,
-              chainTried: Array.from(triedNonAnthropic),
-              chatId: getTelegramChatId(),
-              prompt: prompt,
-              latencyMs: Date.now() - startTimeForAudit,
-              errorCode: 'not_implemented',
-              injectionHits: sanRes.hits,
-              requestId: turnRequestId, // #3577 CA-S6
-            });
-          } catch { /* best-effort */ }
-          log('commander', `⚠️ Fallback provider "${res.provider}" no implementado (${safe.reason}) — intento siguiente.`);
-          return advanceOrGiveUp(res.provider, 'not_implemented');
-        }
-
-        // Si #3198 está deployed y el handler real funciona, llegamos acá. Los
-        // providers no-Anthropic emiten JSONL (un evento por línea), no texto
-        // plano; `extractFallbackReply` saca SÓLO el/los `agent_message`
-        // finales para que a Telegram llegue un único mensaje conversacional.
-        const proc = spawn(safe.spawnDef.cmd, safe.spawnDef.args, safe.spawnDef.spawnOpts);
-        proc.stdin && proc.stdin.end && proc.stdin.end();
-        let stdout = '';
-        let stderr = '';
-        const startNon = Date.now();
-        const HARD_NON_ANTH_MS = 90 * 1000; // SR-5 — budget 90s para providers no-stream-json
-        const timer = setTimeout(() => {
-          try { proc.kill('SIGTERM'); } catch {}
-          log('commander', `Provider ${res.provider} timeout 90s — abortando`);
-        }, HARD_NON_ANTH_MS);
-        proc.stdout && proc.stdout.on('data', (d) => { stdout += d.toString(); });
-        proc.stderr && proc.stderr.on('data', (d) => { stderr += d.toString(); });
-        proc.on('close', () => {
-          clearTimeout(timer);
-          const elapsed = Date.now() - startNon;
-          const extracted = commanderMP.extractFallbackReply(stdout);
-          log('commander', `Provider ${res.provider} terminó (${elapsed}ms, stdout=${stdout.length}c, reply=${extracted.text.length}c, parsed=${extracted.parsed}, stderr=${stderr.length}c)`);
-          if (extracted.text) {
+          reason: 'spawn_throw',
+          onSyncThrow: (provider, reason, err) => {
             try {
               commanderMP.auditCommanderRequest({
                 pipelineDir: PIPELINE,
-                event: 'fallback_used',
+                event: 'spawn_error',
                 providerIntended: resolution.primaryProvider || 'anthropic',
-                providerEffective: res.provider,
+                providerEffective: provider,
                 chainTried: Array.from(triedNonAnthropic),
                 chatId: getTelegramChatId(),
-                prompt: prompt,
-                latencyMs: elapsed,
-                errorCode: null,
+                prompt: prompt, // hasheado por auditCommanderRequest (SR-A: nunca literal)
+                latencyMs: Date.now() - startTimeForAudit,
+                errorCode: reason, // 'spawn_throw' — enum-string estático, no input
                 requestId: turnRequestId, // #3577 CA-S6
               });
             } catch { /* best-effort */ }
-            // #3951 EP7-H4 — un fallback no-Anthropic ganó: reflejar el provider
-            // EFECTIVO en el trace para que el cierre del turno clasifique como
-            // `fallback` con el provider correcto (anti log-forging: el provider
-            // sale del resolver, NUNCA del texto de la respuesta).
-            if (_trace && _trace.resolution) {
-              _trace.resolution.provider = res.provider;
-              _trace.resolution.crossProvider = true;
-              _trace.resolution.fallbackUsed = String(res.provider);
-            }
-            return resolve(extracted.text);
-          }
-          // Respuesta vacía → audit + intentar el siguiente provider de la
-          // cadena en vez de cortar seco.
-          try {
-            commanderMP.auditCommanderRequest({
+            // SR-A: sólo `err.message` (no stderr crudo — el proceso ni arrancó).
+            log('commander', `❌ Throw síncrono al preparar/spawnear "${provider}": ${err && err.message} — degradando (${reason}).`);
+            return advanceOrGiveUp(provider, reason);
+          },
+          attempt: () => {
+            // Data-residency por provider: los retries no pasaron por el check
+            // del provider inicial, así que re-chequeamos para cada candidato.
+            const drCheck2 = commanderMP.enforceDataResidency({
               pipelineDir: PIPELINE,
-              event: 'fallback_used',
-              providerIntended: resolution.primaryProvider || 'anthropic',
-              providerEffective: res.provider,
-              chainTried: Array.from(triedNonAnthropic),
+              provider: res.provider,
+              paths: [],
               chatId: getTelegramChatId(),
               prompt: prompt,
-              latencyMs: elapsed,
-              errorCode: 'empty_output',
-              requestId: turnRequestId, // #3577 CA-S6
+              log: (l, m) => log(l || 'commander', m),
             });
-          } catch { /* best-effort */ }
-          log('commander', `Provider ${res.provider} devolvió vacío (empty_output) — intento siguiente provider.`);
-          return advanceOrGiveUp(res.provider, 'empty_output');
-        });
-        proc.on('error', (e) => {
-          clearTimeout(timer);
-          log('commander', `Error spawning ${res.provider}: ${e.message} — intento siguiente provider.`);
-          return advanceOrGiveUp(res.provider, 'spawn_error');
+            if (!drCheck2.ok) {
+              log('commander', `🚫 data-residency bloqueó "${res.provider}" (${drCheck2.reason}) — intento siguiente provider.`);
+              return advanceOrGiveUp(res.provider, 'data_residency_blocked');
+            }
+
+            const safe = commanderMP.safeBuildSpawn({
+              handler: res.handler,
+              args: buildFallbackArgs(res.provider),
+              cwd: ROOT,
+              env: attemptEnv,
+            });
+            if (!safe.ok) {
+              try {
+                commanderMP.auditCommanderRequest({
+                  pipelineDir: PIPELINE,
+                  event: 'fallback_unavailable',
+                  providerIntended: resolution.primaryProvider || 'anthropic',
+                  providerEffective: res.provider,
+                  chainTried: Array.from(triedNonAnthropic),
+                  chatId: getTelegramChatId(),
+                  prompt: prompt,
+                  latencyMs: Date.now() - startTimeForAudit,
+                  errorCode: 'not_implemented',
+                  injectionHits: sanRes.hits,
+                  requestId: turnRequestId, // #3577 CA-S6
+                });
+              } catch { /* best-effort */ }
+              log('commander', `⚠️ Fallback provider "${res.provider}" no implementado (${safe.reason}) — intento siguiente.`);
+              return advanceOrGiveUp(res.provider, 'not_implemented');
+            }
+
+            // Si #3198 está deployed y el handler real funciona, llegamos acá. Los
+            // providers no-Anthropic emiten JSONL (un evento por línea), no texto
+            // plano; `extractFallbackReply` saca SÓLO el/los `agent_message`
+            // finales para que a Telegram llegue un único mensaje conversacional.
+            const proc = spawn(safe.spawnDef.cmd, safe.spawnDef.args, safe.spawnDef.spawnOpts);
+            proc.stdin && proc.stdin.end && proc.stdin.end();
+            let stdout = '';
+            let stderr = '';
+            const startNon = Date.now();
+            const HARD_NON_ANTH_MS = 90 * 1000; // SR-5 — budget 90s para providers no-stream-json
+            const timer = setTimeout(() => {
+              try { proc.kill('SIGTERM'); } catch {}
+              log('commander', `Provider ${res.provider} timeout 90s — abortando`);
+            }, HARD_NON_ANTH_MS);
+            proc.stdout && proc.stdout.on('data', (d) => { stdout += d.toString(); });
+            proc.stderr && proc.stderr.on('data', (d) => { stderr += d.toString(); });
+            proc.on('close', () => {
+              clearTimeout(timer);
+              const elapsed = Date.now() - startNon;
+              const extracted = commanderMP.extractFallbackReply(stdout);
+              log('commander', `Provider ${res.provider} terminó (${elapsed}ms, stdout=${stdout.length}c, reply=${extracted.text.length}c, parsed=${extracted.parsed}, stderr=${stderr.length}c)`);
+              if (extracted.text) {
+                try {
+                  commanderMP.auditCommanderRequest({
+                    pipelineDir: PIPELINE,
+                    event: 'fallback_used',
+                    providerIntended: resolution.primaryProvider || 'anthropic',
+                    providerEffective: res.provider,
+                    chainTried: Array.from(triedNonAnthropic),
+                    chatId: getTelegramChatId(),
+                    prompt: prompt,
+                    latencyMs: elapsed,
+                    errorCode: null,
+                    requestId: turnRequestId, // #3577 CA-S6
+                  });
+                } catch { /* best-effort */ }
+                // #3951 EP7-H4 / #4318 — el trace ya refleja el provider efectivo
+                // (seteado al inicio de runNonAnthropic, cubre éxito y fallo). Aquí
+                // sólo resolvemos con el texto del reemplazo (anti log-forging: el
+                // provider sale del resolver, NUNCA del texto de la respuesta).
+                return resolve(extracted.text);
+              }
+              // Respuesta vacía → audit + intentar el siguiente provider de la
+              // cadena en vez de cortar seco.
+              try {
+                commanderMP.auditCommanderRequest({
+                  pipelineDir: PIPELINE,
+                  event: 'fallback_used',
+                  providerIntended: resolution.primaryProvider || 'anthropic',
+                  providerEffective: res.provider,
+                  chainTried: Array.from(triedNonAnthropic),
+                  chatId: getTelegramChatId(),
+                  prompt: prompt,
+                  latencyMs: elapsed,
+                  errorCode: 'empty_output',
+                  requestId: turnRequestId, // #3577 CA-S6
+                });
+              } catch { /* best-effort */ }
+              log('commander', `Provider ${res.provider} devolvió vacío (empty_output) — intento siguiente provider.`);
+              return advanceOrGiveUp(res.provider, 'empty_output');
+            });
+            proc.on('error', (e) => {
+              clearTimeout(timer);
+              log('commander', `Error spawning ${res.provider}: ${e.message} — intento siguiente provider.`);
+              return advanceOrGiveUp(res.provider, 'spawn_error');
+            });
+          },
         });
       };
 
@@ -10015,8 +10064,18 @@ function ejecutarClaude(prompt, textoOriginal, trace, fallbackParts) {
       // Primer intento: reusamos el env ya construido para el provider inicial.
       // Solo para el camino pre-spawn (provider efectivo ya distinto de Anthropic);
       // en el camino Anthropic el bloque solo define los closures y sigue de largo.
+      // #4318 — Defensa en profundidad: aunque `runNonAnthropic` ya envuelve su
+      // cuerpo síncrono en el guard, blindamos también el punto de invocación para
+      // que NINGUNA excepción síncrona (incluida una del wiring del propio guard)
+      // escape del executor del Promise y lo rechace. Convergemos al mismo
+      // degradado (advanceOrGiveUp → resolve canned, nunca reject).
       if (resolution.provider !== 'anthropic') {
-        return runNonAnthropic(resolution, cleanEnv);
+        try {
+          return runNonAnthropic(resolution, cleanEnv);
+        } catch (e) {
+          log('commander', `❌ runNonAnthropic lanzó fuera del guard (provider=${resolution.provider}): ${e && e.message} — degradando (spawn_throw).`);
+          return advanceOrGiveUp(resolution.provider, 'spawn_throw');
+        }
       }
     }
 


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 3 archivos · +375 -98

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:passed` aplicado por delivery

## Closes

Closes #4318
