### PR TITLE
[Split de #4324] /api/state + HOME renderizan cuota por provider con estado explícito y timestamp

### DIFF
--- a/.pipeline/dashboard.js
+++ b/.pipeline/dashboard.js
@@ -1583,6 +1583,21 @@ function* _genPipelineState() {
     state.prInfo[id] = { mergedAt: info.mergedAt, url: info.url, state: info.state };
   }
 
+  // #4327 (CA-4) — Bloque de cuota por proveedor servido por /api/state. Se
+  // compone de fuentes YA sanitizadas (getBannerState + quotaSlice) vía el helper
+  // dedicado `lib/quota-state-block`. Corre en el worker de background (el driver
+  // getPipelineStateAsync cede el loop entre chunks); /api/state sirve el snapshot
+  // prearmado en O(1), así que el costo NO cae en el hot path del request. Se pide
+  // `skipSideEffects` para no re-disparar el guard/pacing (su cadencia sigue atada
+  // al poll de /api/dash/quota). Fail-closed: si el helper no cargó o falla, el
+  // bloque queda en estado 'missing' con providers vacío (nunca dato viejo/0 como
+  // fresco). El helper NO expone account_handle (allowlist de sanitizeSnapshotForOutput).
+  state.quota = { snapshotAt: Date.now(), state: 'missing', ageMs: null, lastSnapshot: null, providers: {} };
+  try {
+    const { buildQuotaStateBlock } = require('./lib/quota-state-block');
+    state.quota = buildQuotaStateBlock({ PIPELINE, ROOT });
+  } catch { /* mantiene el default fail-closed */ }
+
   return state;
 }
 

--- a/.pipeline/lib/__tests__/dashboard-slices-declared-providers-4327.test.js
+++ b/.pipeline/lib/__tests__/dashboard-slices-declared-providers-4327.test.js
@@ -1,0 +1,116 @@
+// =============================================================================
+// Tests #4327 (CA-3) — `quotaSlice.declaredProviders` alineado con la config
+// real (`agent-models.json`) y SIN el fantasma `groq` (descontinuado #3353),
+// tanto en el path config-driven como en el fallback hardcodeado.
+//
+// Cubre además:
+//   - `skipSideEffects: true` NO altera el shape de providers y evita re-correr
+//     el guard/pacing (out.preventiveAlert inactivo, out.pacing deshabilitado).
+//   - normalizeProviderQuota usa el pct del snapshot más reciente, no cae a 0.
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+// Alineado con los `providers` reales de agent-models.json (sin `deterministic`).
+const REAL_PROVIDERS = ['anthropic', 'openai-codex', 'gemini-google', 'cerebras', 'nvidia-nim'];
+
+function freshSlices() {
+    delete require.cache[require.resolve('../dashboard-slices')];
+    return require('../dashboard-slices');
+}
+
+function mkTmpPipeline() {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'v3-declared-4327-'));
+    const pipeline = path.join(root, '.pipeline');
+    fs.mkdirSync(path.join(pipeline, 'metrics'), { recursive: true });
+    fs.mkdirSync(path.join(root, '.claude'), { recursive: true });
+    return { root, pipeline };
+}
+
+// ---------------------------------------------------------------------------
+// CA-3 — path config-driven: providers salen de agent-models.json (sin groq,
+// sin deterministic).
+// ---------------------------------------------------------------------------
+test('CA-3: quotaSlice deriva providers de agent-models.json sin groq ni deterministic', () => {
+    const { root, pipeline } = mkTmpPipeline();
+    fs.writeFileSync(path.join(pipeline, 'agent-models.json'), JSON.stringify({
+        providers: {
+            anthropic: {}, 'openai-codex': {}, 'gemini-google': {},
+            cerebras: {}, 'nvidia-nim': {}, deterministic: {},
+        },
+    }));
+    const slices = freshSlices();
+    const out = slices.quotaSlice({}, { ROOT: root, PIPELINE: pipeline });
+
+    const keys = Object.keys(out.providers).sort();
+    assert.deepEqual(keys, [...REAL_PROVIDERS].sort(), 'providers exactos de la config (sin groq, sin deterministic)');
+    assert.ok(!keys.includes('groq'), 'groq no debe aparecer');
+});
+
+// ---------------------------------------------------------------------------
+// CA-3 — fallback hardcodeado (sin agent-models.json): la lista mínima ya NO
+// incluye groq. Blinda el escenario de fallo de lectura de config.
+// ---------------------------------------------------------------------------
+test('CA-3: fallback (sin agent-models.json) usa la lista real sin groq', () => {
+    const { root, pipeline } = mkTmpPipeline();
+    // NO se escribe agent-models.json → se ejercita el fallback hardcodeado.
+    assert.ok(!fs.existsSync(path.join(pipeline, 'agent-models.json')), 'sanity: sin config');
+    const slices = freshSlices();
+    const out = slices.quotaSlice({}, { ROOT: root, PIPELINE: pipeline });
+
+    const keys = Object.keys(out.providers).sort();
+    assert.deepEqual(keys, [...REAL_PROVIDERS].sort(), 'el fallback lista exactamente los 5 providers reales');
+    assert.ok(!keys.includes('groq'), 'el fallback NO debe reintroducir el fantasma groq');
+});
+
+// ---------------------------------------------------------------------------
+// CA-3 — fuente estática: la lista hardcodeada del fallback y la config real de
+// agent-models.json (del repo) coinciden. Evita drift silencioso.
+// ---------------------------------------------------------------------------
+test('CA-3: el fallback hardcodeado del source coincide con los providers del repo', () => {
+    const src = fs.readFileSync(path.join(__dirname, '..', 'dashboard-slices.js'), 'utf8');
+    const m = src.match(/let declaredProviders = \[([^\]]*)\]/);
+    assert.ok(m, 'debe existir la declaración del fallback declaredProviders');
+    const listed = m[1].split(',').map(s => s.trim().replace(/^['"]|['"]$/g, '')).filter(Boolean).sort();
+    assert.deepEqual(listed, [...REAL_PROVIDERS].sort(), 'el fallback del source son los 5 providers reales');
+    assert.ok(!listed.includes('groq'), 'el fallback del source no menciona groq');
+});
+
+// ---------------------------------------------------------------------------
+// skipSideEffects — mismo shape de providers, sin re-correr guard/pacing.
+// ---------------------------------------------------------------------------
+test('skipSideEffects: providers intactos y guard/pacing no se evalúan', () => {
+    const { root, pipeline } = mkTmpPipeline();
+    fs.writeFileSync(path.join(pipeline, 'agent-models.json'), JSON.stringify({
+        providers: { anthropic: {}, 'openai-codex': {} },
+    }));
+    const slices = freshSlices();
+    const base = slices.quotaSlice({}, { ROOT: root, PIPELINE: pipeline });
+    const skipped = slices.quotaSlice({}, { ROOT: root, PIPELINE: pipeline, skipSideEffects: true });
+
+    // El desglose por proveedor es idéntico con y sin efectos secundarios.
+    assert.deepEqual(Object.keys(skipped.providers).sort(), Object.keys(base.providers).sort());
+    // Con skip, el guard anticipatorio no marca banner activo y el pacing queda off.
+    assert.equal(skipped.preventiveAlert.active, false, 'guard no activa banner con skipSideEffects');
+    assert.equal(skipped.pacing.enabled, false, 'pacing deshabilitado con skipSideEffects');
+});
+
+// ---------------------------------------------------------------------------
+// normalizeProviderQuota usa el pct más reciente (realPct del snapshot), NO cae
+// a 0/viejo cuando hay dato confiable.
+// ---------------------------------------------------------------------------
+test('normalizeProviderQuota toma el pct real más reciente, no cae a 0', () => {
+    const slices = freshSlices();
+    const n = slices.normalizeProviderQuota('anthropic', {
+        provider: 'anthropic', adapterStatus: 'ok',
+        pct: 0, realPct: 42,                       // realPct (reciente) debe ganar
+        session: { pct: 0, realPct: 18 },
+    });
+    assert.equal(n.weekly.pct, 42, 'weekly usa realPct reciente, no el pct viejo/0');
+    assert.equal(n.session.pct, 18, 'session usa session.realPct reciente, no 0');
+});

--- a/.pipeline/lib/__tests__/quota-state-block-4327.test.js
+++ b/.pipeline/lib/__tests__/quota-state-block-4327.test.js
@@ -1,0 +1,170 @@
+// =============================================================================
+// Tests #4327 (CA-4) — bloque de cuota servido por `/api/state`
+// (`lib/quota-state-block.buildQuotaStateBlock`).
+//
+// Cubre:
+//   CA-4 — el bloque está poblado (providers por proveedor) con un timestamp
+//          reciente (`snapshotAt`) y estado explícito (`state`).
+//   Seguridad req#2 — el JSON servido NO contiene `account_handle` NI ninguna
+//          clave de identidad (`handle|email|account|token|secret|password`),
+//          incluso cuando el snapshot en disco SÍ trae `account_handle` crudo
+//          (se verifica el paso por la allowlist `sanitizeSnapshotForOutput`).
+//   CA-3 — la lista de proveedores no incluye el fantasma `groq`.
+//   CA-5 — fail-closed: sin snapshot → estado `missing`, providers igual listados
+//          (nunca número viejo/0 presentado como fresco).
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const IDENTITY_KEY_RE = /handle|email|account|token|secret|password/i;
+
+function freshBlock() {
+    delete require.cache[require.resolve('../quota-state-block')];
+    delete require.cache[require.resolve('../quota-snapshot-integration')];
+    delete require.cache[require.resolve('../dashboard-slices')];
+    return require('../quota-state-block');
+}
+
+function mkTmpPipeline() {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'v3-quota-4327-'));
+    const pipeline = path.join(root, '.pipeline');
+    fs.mkdirSync(path.join(pipeline, 'metrics'), { recursive: true });
+    fs.mkdirSync(path.join(root, '.claude'), { recursive: true });
+    // agent-models.json real (sin groq, sin deterministic filtrado en la vista).
+    fs.writeFileSync(path.join(pipeline, 'agent-models.json'), JSON.stringify({
+        providers: {
+            anthropic: {}, 'openai-codex': {}, 'gemini-google': {},
+            cerebras: {}, 'nvidia-nim': {}, deterministic: {},
+        },
+    }));
+    return { root, pipeline };
+}
+
+function withEnv(overrides, fn) {
+    const prev = {};
+    for (const [k, v] of Object.entries(overrides)) {
+        prev[k] = process.env[k];
+        if (v == null) delete process.env[k]; else process.env[k] = v;
+    }
+    try { return fn(); }
+    finally {
+        for (const [k, v] of Object.entries(prev)) {
+            if (v == null) delete process.env[k]; else process.env[k] = v;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CA-5 — fail-closed: sin snapshot en disco → estado 'missing', pero providers
+// igual se listan (nunca vacío que lea como "todo OK").
+// ---------------------------------------------------------------------------
+test('CA-5: sin snapshot → estado missing con providers listados (fail-closed)', () => {
+    const { pipeline, root } = mkTmpPipeline();
+    const { buildQuotaStateBlock } = freshBlock();
+    const block = withEnv({ PIPELINE_DIR_OVERRIDE: pipeline, QUOTA_SNAPSHOT_ENABLED: null }, () =>
+        buildQuotaStateBlock({ PIPELINE: pipeline, ROOT: root }));
+
+    assert.equal(block.state, 'missing', 'sin .quota-history.jsonl → missing');
+    assert.equal(block.lastSnapshot, null, 'sin snapshot fresco → lastSnapshot null (no dato viejo)');
+    assert.ok(Object.keys(block.providers).length > 0, 'providers se listan aunque falte snapshot');
+});
+
+// ---------------------------------------------------------------------------
+// CA-4 — bloque poblado con timestamp reciente.
+// ---------------------------------------------------------------------------
+test('CA-4: bloque poblado con snapshotAt reciente y providers por proveedor', () => {
+    const { pipeline, root } = mkTmpPipeline();
+    const { buildQuotaStateBlock } = freshBlock();
+    const before = Date.now();
+    const block = withEnv({ PIPELINE_DIR_OVERRIDE: pipeline }, () =>
+        buildQuotaStateBlock({ PIPELINE: pipeline, ROOT: root }));
+    const after = Date.now();
+
+    assert.ok(Number.isFinite(block.snapshotAt), 'snapshotAt es numérico');
+    assert.ok(block.snapshotAt >= before && block.snapshotAt <= after, 'snapshotAt es reciente');
+    // Cada provider expone SOLO el shape mínimo {provider, adapterStatus, session, weekly}.
+    for (const [p, v] of Object.entries(block.providers)) {
+        assert.deepEqual(Object.keys(v).sort(), ['adapterStatus', 'provider', 'session', 'weekly'],
+            `${p} expone solo el shape mínimo`);
+        for (const bucket of ['session', 'weekly']) {
+            assert.deepEqual(Object.keys(v[bucket]).sort(), ['confidence', 'pct'],
+                `${p}.${bucket} expone solo {pct, confidence}`);
+        }
+    }
+});
+
+// ---------------------------------------------------------------------------
+// CA-3 — sin provider fantasma `groq`.
+// ---------------------------------------------------------------------------
+test('CA-3: la lista de providers del bloque NO incluye groq', () => {
+    const { pipeline, root } = mkTmpPipeline();
+    const { buildQuotaStateBlock } = freshBlock();
+    const block = withEnv({ PIPELINE_DIR_OVERRIDE: pipeline }, () =>
+        buildQuotaStateBlock({ PIPELINE: pipeline, ROOT: root }));
+    assert.ok(!Object.keys(block.providers).includes('groq'), 'groq (descontinuado #3353) no debe aparecer');
+    // Los 5 proveedores reales presentes.
+    for (const p of ['anthropic', 'openai-codex', 'gemini-google', 'cerebras', 'nvidia-nim']) {
+        assert.ok(p in block.providers, `${p} presente`);
+    }
+});
+
+// ---------------------------------------------------------------------------
+// Seguridad req#2 — regresión OBLIGATORIA: aunque el snapshot en disco traiga
+// `account_handle` crudo, el bloque servido NO lo filtra (allowlist).
+// ---------------------------------------------------------------------------
+test('SEC: snapshot con account_handle en disco → el bloque NO lo filtra', () => {
+    const { pipeline, root } = mkTmpPipeline();
+    // Snapshot "sucio": incluye PII y campos de identidad que NUNCA deben salir.
+    const dirtySnap = {
+        ts: new Date().toISOString(),               // fresco → estado 'fresh'
+        weekly_all_models_pct: 24, weekly_sonnet_pct: 12, weekly_design_pct: 3,
+        session_pct: 6, session_minutes_to_reset: 120,
+        daily_routines_used: 2, daily_routines_max: 15,
+        api_overage_used_usd: 0, api_overage_cap_usd: 50,
+        parse_confidence: 0.9,
+        account_handle: 'leito@example.com',        // PII: debe desaparecer
+        account_email: 'secret@intrale.com',
+        api_token: 'sk-SECRET-TOKEN-123',
+    };
+    fs.writeFileSync(path.join(pipeline, '.quota-history.jsonl'), JSON.stringify(dirtySnap) + '\n');
+
+    const { buildQuotaStateBlock } = freshBlock();
+    const block = withEnv({ PIPELINE_DIR_OVERRIDE: pipeline }, () =>
+        buildQuotaStateBlock({ PIPELINE: pipeline, ROOT: root }));
+
+    // El snapshot se leyó (estado no-missing) y trae los pct numéricos sanos.
+    assert.notEqual(block.state, 'missing', 'con snapshot fresco el estado NO es missing');
+    assert.ok(block.lastSnapshot && typeof block.lastSnapshot === 'object', 'lastSnapshot poblado');
+    assert.equal(block.lastSnapshot.weekly_all_models_pct, 24, 'los pct sanitizados sí viajan');
+
+    // Ninguna clave de identidad sobrevive en el JSON del bloque completo.
+    const json = JSON.stringify(block);
+    assert.ok(!json.includes('account_handle'), 'account_handle NUNCA debe aparecer');
+    assert.ok(!json.includes('leito@example.com'), 'el valor de account_handle no debe filtrarse');
+    assert.ok(!json.includes('secret@intrale.com'), 'account_email no debe filtrarse');
+    assert.ok(!json.includes('sk-SECRET-TOKEN-123'), 'api_token no debe filtrarse');
+    // Barrido por regex de claves de identidad sobre las claves del lastSnapshot.
+    for (const k of Object.keys(block.lastSnapshot)) {
+        assert.ok(!IDENTITY_KEY_RE.test(k), `lastSnapshot no debe exponer la clave "${k}"`);
+    }
+});
+
+// ---------------------------------------------------------------------------
+// Defensa: el compositor es fail-closed ante fuentes rotas (no throw).
+// ---------------------------------------------------------------------------
+test('fail-closed: fuentes que lanzan → bloque missing sin providers, sin throw', () => {
+    const { buildQuotaStateBlock } = freshBlock();
+    const boom = { getBannerState() { throw new Error('boom'); } };
+    const boomSlices = { quotaSlice() { throw new Error('boom'); } };
+    const block = buildQuotaStateBlock({ PIPELINE: '/nope', ROOT: '/nope' },
+        { integration: boom, slices: boomSlices, now: () => 4327 });
+    assert.equal(block.state, 'missing');
+    assert.equal(block.snapshotAt, 4327);
+    assert.deepEqual(block.providers, {});
+    assert.equal(block.lastSnapshot, null);
+});

--- a/.pipeline/lib/dashboard-slices.js
+++ b/.pipeline/lib/dashboard-slices.js
@@ -1964,6 +1964,13 @@ function normalizeProviderQuota(provider, result) {
 function quotaSlice(state, ctx) {
     const PIPELINE = ctx.PIPELINE;
     const ROOT = ctx.ROOT;
+    // #4327 — Cuando el compositor de `/api/state` reusa quotaSlice para poblar
+    // el bloque de cuota por proveedor (worker de background), pide SOLO el shape
+    // normalizado sin re-disparar los efectos secundarios (guard anticipatorio
+    // #4282 + pacing #4289). Esos evalúan/persisten estado y disparan alertas:
+    // su cadencia debe seguir atada al poll real de `/api/dash/quota`, no al tick
+    // del snapshot de estado. Default false → comportamiento intacto.
+    const skipSideEffects = !!(ctx && ctx.skipSideEffects);
     const metricsDir = path.join(PIPELINE, 'metrics');
     const activityLog = path.join(ROOT, '.claude', 'activity-log.jsonl');
     const configLimitHours = Number(process.env.ANTHROPIC_MAX_WEEKLY_HOURS) || undefined;
@@ -1971,7 +1978,11 @@ function quotaSlice(state, ctx) {
     // Resolver providers declarados en agent-models.json. Si el archivo no
     // está disponible (caso edge), cae al set mínimo conocido. NO usar `eval`
     // ni `require` dinámico con paths construidos — siempre el path fijo.
-    let declaredProviders = ['anthropic', 'openai-codex', 'gemini-google', 'groq', 'cerebras', 'nvidia-nim'];
+    // #4327 (CA-3) — Fallback alineado EXACTAMENTE con los `providers` reales de
+    // agent-models.json (sin `deterministic`, que no consume cuota, y sin `groq`,
+    // descontinuado en #3353). Blinda contra un provider fantasma si la lectura de
+    // config falla. El path config-driven (abajo) es el primario.
+    let declaredProviders = ['anthropic', 'openai-codex', 'gemini-google', 'cerebras', 'nvidia-nim'];
     try {
         const modelsPath = path.join(PIPELINE, 'agent-models.json');
         const models = safeReadJson(modelsPath, null);
@@ -2044,7 +2055,7 @@ function quotaSlice(state, ctx) {
     // re-extracción). Idempotente: el guard dedup-ea (una alerta por cruce) y
     // solo escribe estado si algo cambió. Best-effort: NUNCA rompe el slice.
     out.preventiveAlert = { active: false };
-    if (providerQuotaGuard && typeof providerQuotaGuard.evaluate === 'function') {
+    if (!skipSideEffects && providerQuotaGuard && typeof providerQuotaGuard.evaluate === 'function') {
         try {
             const rawConfig = _loadGuardRawConfig(PIPELINE);
             const res = providerQuotaGuard.evaluate({
@@ -2064,7 +2075,7 @@ function quotaSlice(state, ctx) {
     // Telegram). Best-effort: NUNCA rompe el slice de cuota. Si `pacing.enabled`
     // está en false (default), `evaluate` es no-op y `out.pacing` queda vacío.
     out.pacing = { enabled: false, providers: {} };
-    if (pacingBucket && typeof pacingBucket.evaluate === 'function') {
+    if (!skipSideEffects && pacingBucket && typeof pacingBucket.evaluate === 'function') {
         try {
             const rawConfig = _loadGuardRawConfig(PIPELINE);
             pacingBucket.evaluate({

--- a/.pipeline/lib/quota-state-block.js
+++ b/.pipeline/lib/quota-state-block.js
@@ -1,0 +1,106 @@
+// =============================================================================
+// quota-state-block.js — Compositor del bloque de cuota servido por `/api/state`
+// (#4327, CA-4). Empaqueta DOS fuentes YA sanitizadas, con un timestamp reciente,
+// para que `/api/state` exponga la cuota por proveedor con estado explícito y sin
+// PII, sin re-disparar mecanismos ni serializar el snapshot OCR crudo:
+//
+//   - getBannerState() (quota-snapshot-integration) → estado explícito del
+//     snapshot real (`fresh|stale|missing|parser-offline`), su edad (`ageMs`) y
+//     `lastSnapshot` YA pasado por la allowlist `sanitizeSnapshotForOutput`
+//     (sin `account_handle`; invariantes de seguridad #1/#4 de #4324).
+//   - quotaSlice().providers (dashboard-slices) → % por proveedor/bucket
+//     normalizado a `{pct, confidence}` (security req#5: sin cost_usd, tokens
+//     crudos, ruta de snapshot ni campos de identidad). Se invoca con
+//     `skipSideEffects: true` para NO re-correr el guard anticipatorio (#4282)
+//     ni el pacing (#4289) desde el worker de estado.
+//
+// Defensa en profundidad: aunque ambas fuentes ya vienen sanitizadas, este
+// compositor RECONSTRUYE el bloque por allowlist explícita (no copia el objeto
+// crudo). Cualquier clave nueva que aparezca upstream NO se filtra a `/api/state`
+// salvo que se la agregue acá a propósito.
+//
+// Fail-closed (CA-5): ante cualquier error de lectura/cómputo, el bloque queda
+// en estado `missing` con `providers: {}` — NUNCA un número viejo presentado
+// como fresco ni `0` como dato vigente.
+// =============================================================================
+'use strict';
+
+// Estados válidos del banner (enum cerrado de getBannerState). Cualquier otro
+// valor degrada a 'missing' (fail-closed).
+const BANNER_STATES = Object.freeze(['fresh', 'stale', 'missing', 'parser-offline']);
+
+// Normaliza un bucket (session/weekly) al shape mínimo del cliente. Sólo
+// `{pct, confidence}`: `pct` numérico finito o null ("sin dato"); `confidence`
+// string o 'missing'. Nunca propaga otras claves.
+function sanitizeBucket(b) {
+    const pct = (b && typeof b.pct === 'number' && Number.isFinite(b.pct)) ? b.pct : null;
+    const confidence = (b && typeof b.confidence === 'string') ? b.confidence : 'missing';
+    return { pct, confidence };
+}
+
+/**
+ * Construye el bloque de cuota para `/api/state`.
+ *
+ * @param {{PIPELINE:string, ROOT:string}} ctx — dirs del pipeline (los mismos
+ *        que usa el resto del snapshot de estado).
+ * @param {object} [deps] — inyección para test: `{ integration, slices, now }`.
+ * @returns {{snapshotAt:number, state:string, ageMs:(number|null),
+ *            lastSnapshot:(object|null), providers:object}}
+ */
+function buildQuotaStateBlock(ctx, deps) {
+    const now = (deps && typeof deps.now === 'function') ? deps.now() : Date.now();
+
+    // Default fail-closed: estado 'missing', sin providers, con timestamp reciente.
+    const block = {
+        snapshotAt: now,
+        state: 'missing',
+        ageMs: null,
+        lastSnapshot: null,
+        providers: {},
+    };
+
+    // --- Estado explícito + snapshot sanitizado (getBannerState) --------------
+    try {
+        const integration = (deps && deps.integration)
+            || require('./quota-snapshot-integration');
+        if (integration && typeof integration.getBannerState === 'function') {
+            const banner = integration.getBannerState();
+            if (banner && typeof banner === 'object') {
+                block.state = BANNER_STATES.includes(banner.state) ? banner.state : 'missing';
+                block.ageMs = Number.isFinite(banner.ageMs) ? banner.ageMs : null;
+                // `lastSnapshot` ya pasó por sanitizeSnapshotForOutput (allowlist,
+                // sin account_handle). Se acepta tal cual sólo si es objeto.
+                block.lastSnapshot = (banner.lastSnapshot && typeof banner.lastSnapshot === 'object')
+                    ? banner.lastSnapshot
+                    : null;
+            }
+        }
+    } catch { /* fail-closed: queda 'missing' */ }
+
+    // --- % por proveedor normalizado (quotaSlice, sin efectos secundarios) -----
+    try {
+        const slices = (deps && deps.slices) || require('./dashboard-slices');
+        if (slices && typeof slices.quotaSlice === 'function') {
+            const q = slices.quotaSlice({}, {
+                PIPELINE: ctx && ctx.PIPELINE,
+                ROOT: ctx && ctx.ROOT,
+                skipSideEffects: true,
+            });
+            if (q && q.providers && typeof q.providers === 'object') {
+                for (const [provider, v] of Object.entries(q.providers)) {
+                    if (!v || typeof v !== 'object') continue;
+                    block.providers[provider] = {
+                        provider: typeof v.provider === 'string' ? v.provider : provider,
+                        adapterStatus: typeof v.adapterStatus === 'string' ? v.adapterStatus : 'unknown',
+                        session: sanitizeBucket(v.session),
+                        weekly: sanitizeBucket(v.weekly),
+                    };
+                }
+            }
+        }
+    } catch { /* providers vacío: no se cae a números viejos */ }
+
+    return block;
+}
+
+module.exports = { buildQuotaStateBlock, sanitizeBucket, BANNER_STATES };

--- a/.pipeline/tests/home-quota-render-4327.test.js
+++ b/.pipeline/tests/home-quota-render-4327.test.js
@@ -1,0 +1,159 @@
+// =============================================================================
+// Tests #4327 (CA-5 / UX-G4) — render de cuota en la HOME: un estado
+// `stale`/`missing` NUNCA se renderiza como número fresco, y "sin dato" se
+// escribe como literal, jamás como `0%`.
+//
+// Estrategia: los helpers de render viven dentro del script cliente de
+// `home.js` (string emitido por renderClientScript, no exportado). Se extraen
+// por rango contiguo del source y se evalúan con un DOM falso, igual que otros
+// tests del repo (ver views/dashboard/__tests__ y tests/dashboard-xss-modal).
+//
+// Cubre:
+//   UX-G4 — `_hydrateProviderRow` con bucket sin dato (pct null) escribe el
+//           literal "sin dato" (no "0%", no un número).
+//   CA-5  — `pillTextFor(state)` para `stale`/`missing` devuelve la etiqueta de
+//           estado, nunca un porcentaje; `pctTextClient(null)` → "--%" (no "0%").
+//   UX-G5 — `MZ_ACTIVE_PROVIDERS` (fuente única) lista exactamente los 5
+//           proveedores reales, sin el fantasma `groq`.
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const home = require('../views/dashboard/home.js');
+const HOME_SRC = fs.readFileSync(path.join(__dirname, '..', 'views', 'dashboard', 'home.js'), 'utf8');
+
+// Extrae un rango contiguo del source [desde `startAnchor`, hasta ANTES de
+// `endAnchor`]. Las anclas son literales de declaración, estables al refactor.
+function sliceRange(src, startAnchor, endAnchor) {
+    const start = src.indexOf(startAnchor);
+    assert.ok(start >= 0, `ancla de inicio no encontrada: ${startAnchor}`);
+    const end = src.indexOf(endAnchor, start + startAnchor.length);
+    assert.ok(end > start, `ancla de fin no encontrada: ${endAnchor}`);
+    return src.slice(start, end);
+}
+
+// DOM falso mínimo: registra por id los elementos que el render toca.
+function makeFakeDom(ids) {
+    const els = {};
+    for (const id of ids) {
+        els[id] = {
+            id, textContent: '', className: '', _classes: new Set(), style: {}, _attrs: {},
+            classList: {
+                add(c) { els[id]._classes.add(c); },
+                remove(c) { els[id]._classes.delete(c); },
+                contains(c) { return els[id]._classes.has(c); },
+            },
+            getAttribute(k) { return els[id]._attrs[k] != null ? els[id]._attrs[k] : null; },
+            setAttribute(k, v) { els[id]._attrs[k] = String(v); },
+            closest() { return els[id]._row || null; },
+        };
+    }
+    return els;
+}
+
+// Construye el entorno de los helpers por-proveedor (rango REASON→renderProviderQuotaRows).
+function loadProviderRowHelpers() {
+    const body = sliceRange(HOME_SRC, 'const QUOTA_SINDATO_REASON = {', 'function renderProviderQuotaRows(');
+    // Fakes de las dependencias globales que usan los helpers.
+    const captured = { texts: {}, bars: {} };
+    const factory = new Function('document', 'setText', 'setBarPct', `
+        ${body}
+        return { _hydrateProviderRow, _quotaConfidenceColor };
+    `);
+    return { factory, captured };
+}
+
+// Construye pillTextFor + fmtAge (rango fmtAge→classifyPctClient).
+function loadPillHelpers() {
+    const body = sliceRange(HOME_SRC, 'function fmtAge(ageMs){', 'function classifyPctClient(');
+    const factory = new Function(`
+        ${body}
+        return { pillTextFor, fmtAge, pctTextClient: (function(n){ return Number.isFinite(n) ? (Math.round(n) + '%') : '--%'; }) };
+    `);
+    return factory();
+}
+
+// ---------------------------------------------------------------------------
+// UX-G4 — "sin dato" literal, nunca 0%, cuando el bucket no tiene pct.
+// ---------------------------------------------------------------------------
+test('UX-G4: _hydrateProviderRow con pct null escribe "sin dato" (no 0%, no número)', () => {
+    const { factory } = loadProviderRowHelpers();
+    const ids = ['mz-quota-session-cerebras-bar', 'mz-quota-session-cerebras-pct'];
+    const els = makeFakeDom(ids);
+    const row = { id: 'row', _classes: new Set(), _attrs: {},
+        classList: { add(c) { row._classes.add(c); }, remove(c) { row._classes.delete(c); } },
+        getAttribute(k) { return row._attrs[k] != null ? row._attrs[k] : null; },
+        setAttribute(k, v) { row._attrs[k] = String(v); } };
+    els['mz-quota-session-cerebras-bar']._row = row;
+
+    const texts = {};
+    const document = { getElementById: (id) => els[id] || null };
+    const setText = (id, v) => { texts[id] = v; };
+    const setBarPct = () => {};
+    const { _hydrateProviderRow } = factory(document, setText, setBarPct);
+
+    // Bucket sin dato: b = null.
+    _hydrateProviderRow('session', 'cerebras', null);
+    assert.equal(texts['mz-quota-session-cerebras-pct'], 'sin dato', 'debe escribir el literal "sin dato"');
+    assert.notEqual(texts['mz-quota-session-cerebras-pct'], '0%', 'NUNCA "0%"');
+    assert.ok(!/^\d/.test(String(texts['mz-quota-session-cerebras-pct'])), 'no empieza con un dígito');
+    assert.equal(row.getAttribute('aria-label'), 'sin dato', 'aria-label explícito "sin dato"');
+
+    // Bucket con confidence 'missing' pero SIN pct real → también "sin dato".
+    _hydrateProviderRow('session', 'cerebras', { pct: null, confidence: 'missing' });
+    assert.equal(texts['mz-quota-session-cerebras-pct'], 'sin dato', 'pct null aunque venga confidence');
+});
+
+test('UX-G4: _hydrateProviderRow con pct real sí escribe el porcentaje', () => {
+    const { factory } = loadProviderRowHelpers();
+    const ids = ['mz-quota-week-openai-codex-bar', 'mz-quota-week-openai-codex-pct'];
+    const els = makeFakeDom(ids);
+    const row = { _classes: new Set(), _attrs: {},
+        classList: { add(c) { row._classes.add(c); }, remove(c) { row._classes.delete(c); } },
+        getAttribute(k) { return row._attrs[k] != null ? row._attrs[k] : null; },
+        setAttribute(k, v) { row._attrs[k] = String(v); } };
+    els['mz-quota-week-openai-codex-bar']._row = row;
+    const texts = {};
+    const { _hydrateProviderRow } = factory(
+        { getElementById: (id) => els[id] || null },
+        (id, v) => { texts[id] = v; },
+        () => {});
+
+    _hydrateProviderRow('week', 'openai-codex', { pct: 25, confidence: 'fresh' });
+    assert.equal(texts['mz-quota-week-openai-codex-pct'], '25.0%', 'con dato real muestra el %');
+});
+
+// ---------------------------------------------------------------------------
+// CA-5 — pillTextFor: stale/missing nunca es un número.
+// ---------------------------------------------------------------------------
+test('CA-5: pillTextFor(stale/missing) devuelve etiqueta de estado, nunca un %', () => {
+    const { pillTextFor, pctTextClient } = loadPillHelpers();
+    const stale = pillTextFor('stale', 3 * 3600 * 1000);
+    assert.match(stale, /STALE/, 'stale → etiqueta SNAPSHOT STALE');
+    assert.ok(!/\d+%/.test(stale), 'stale NO contiene un porcentaje');
+
+    const parserOffline = pillTextFor('parser-offline', null);
+    assert.match(parserOffline, /PARSER OFFLINE/);
+
+    // 'missing' u otro → ESTIMADO (fail-closed), nunca un número fresco.
+    assert.equal(pillTextFor('missing', null), 'ESTIMADO');
+    assert.equal(pillTextFor('whatever', null), 'ESTIMADO');
+
+    // pctTextClient con valor no finito → "--%", no "0%".
+    assert.equal(pctTextClient(null), '--%', 'sin dato numérico → "--%", nunca "0%"');
+    assert.equal(pctTextClient(NaN), '--%');
+    assert.equal(pctTextClient(24), '24%');
+});
+
+// ---------------------------------------------------------------------------
+// UX-G5 — fuente única de proveedores: 5 reales, sin groq.
+// ---------------------------------------------------------------------------
+test('UX-G5: MZ_ACTIVE_PROVIDERS lista los 5 providers reales sin groq', () => {
+    assert.deepEqual([...home.MZ_ACTIVE_PROVIDERS].sort(),
+        ['anthropic', 'cerebras', 'gemini-google', 'nvidia-nim', 'openai-codex'].sort());
+    assert.ok(!home.MZ_ACTIVE_PROVIDERS.includes('groq'), 'groq no debe estar en la fuente única');
+});


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 6 archivos · +580 -3

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:skipped` aplicado por delivery

## Closes

Closes #4327
