### PR TITLE
Métricas de la ola siguen mal tras #4320: avance clavado en 2%, velocidad y entregados no se muestran (follow-up #4320)

### DIFF
--- a/.pipeline/dashboard.js
+++ b/.pipeline/dashboard.js
@@ -785,7 +785,14 @@ function _scheduleOlaETARefresh(state) {
             // incompleto (wave-state.js:268). `PIPELINE` está en scope de módulo.
             const wave = waveResolverLib.resolveActiveWave({ pipelineRoot: PIPELINE });
             const wState = waveStateLib.getCachedWaveState({ pipelineRoot: PIPELINE });
-            const wSnap = waveSnapshotLib.buildWaveSnapshot({ state: wState, wave });
+            // #4325 — sin `closedIssues`, `buildWaveSnapshot` deja `closedCount`
+            // en 0 y `totalPct` colapsa a ~2% aunque la ola tenga issues CLOSED
+            // en GitHub. `computeClosedSet` deriva los cerrados de la cache cruda
+            // (`state.issueTitles`) igual que `handleWaveStatus`. Require lazy DENTRO
+            // de la función para preservar el patrón anti-circular (idem L3860/L10535).
+            const { computeClosedSet } = require('./lib/commander-deterministic');
+            const closedIssues = computeClosedSet({ wave, state: wState });
+            const wSnap = waveSnapshotLib.buildWaveSnapshot({ state: wState, wave, closedIssues });
             if (wSnap && Number.isFinite(wSnap.totalPct)) {
               waveTotalPct = wSnap.totalPct;
               const nowTs = Date.now();

--- a/.pipeline/lib/__tests__/mission-ola-eta.test.js
+++ b/.pipeline/lib/__tests__/mission-ola-eta.test.js
@@ -13,7 +13,7 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 
-const { deriveMissionOlaEta, missionOlaEtaClientScript } = require('../mission-ola-eta');
+const { deriveMissionOlaEta, missionOlaEtaClientScript, MISSION_INSUFFICIENT_DATA } = require('../mission-ola-eta');
 
 test('payload nulo/indefinido degrada a estructura neutra sin romper', () => {
     for (const input of [null, undefined, 42, 'x']) {
@@ -24,6 +24,7 @@ test('payload nulo/indefinido degrada a estructura neutra sin romper', () => {
             etaRemainingMin: null,
             etaFromVelocity: false,
             hasVelocity: false,
+            velocityState: 'sin datos suficientes', // #4325 CA-4: estado explícito, no mudo
         });
     }
 });
@@ -107,4 +108,38 @@ test('el emisor de script cliente reusa la función pura y es self-wiring/idempo
     // Unidad alineada con la HOME (%/h, no iss/h).
     assert.ok(src.includes('%/h'));
     assert.ok(!src.includes('iss/h'));
+});
+
+// -----------------------------------------------------------------------------
+// #4325 (CA-4) — estado explícito "sin datos suficientes" cuando no hay ritmo
+// medido, en vez del guion mudo o un 0 silencioso.
+// -----------------------------------------------------------------------------
+
+test('etaSource fallback → velocityState expone "sin datos suficientes" (no "—" ni 0)', () => {
+    const m = deriveMissionOlaEta({ etaSource: 'fallback', totalPct: 66 });
+    assert.equal(m.hasVelocity, false);
+    assert.equal(m.velocityPctPerHour, null);            // sigue null (no se inventa un valor)
+    assert.equal(m.velocityState, 'sin datos suficientes');
+    assert.equal(m.velocityState, MISSION_INSUFFICIENT_DATA); // misma cadena exportada
+    assert.notEqual(m.velocityState, '—');
+    assert.notEqual(m.velocityState, 0);
+});
+
+test('etaSource velocity con ritmo medido → velocityState "measured"', () => {
+    const m = deriveMissionOlaEta({
+        etaSource: 'velocity',
+        totalPct: 40,
+        velocityETA: { source: 'velocity', velocityPctPerMin: 0.5, remainingMs: 600000 },
+    });
+    assert.equal(m.hasVelocity, true);
+    assert.equal(m.velocityState, 'measured');
+});
+
+test('el script cliente renderiza la leyenda explícita (velocityState) en vez del guion', () => {
+    const src = missionOlaEtaClientScript();
+    // El cliente traduce el estado a la leyenda cuando no hay ritmo medido.
+    assert.ok(src.includes('velocityState'));
+    // La cadena viaja dentro de la función serializada (self-contained, sin ref a
+    // constante de módulo que rompería el eval del cliente).
+    assert.ok(src.includes('sin datos suficientes'));
 });

--- a/.pipeline/lib/__tests__/wave-snapshot.test.js
+++ b/.pipeline/lib/__tests__/wave-snapshot.test.js
@@ -625,3 +625,34 @@ test('#4075: bloqueo sin blockDependencies queda sin dependencies (fallback)', (
     assert.ok(blk);
     assert.equal(blk.dependencies, undefined);
 });
+
+// -----------------------------------------------------------------------------
+// #4325 — Regresión: sin `closedIssues`, el avance colapsaba (~2%) aunque la ola
+// tuviera issues CLOSED en GitHub. Con el set poblado, `closedCount`/`totalPct`
+// reflejan los cerrados reales. Réplica del escenario de la ola activa (5 de 6).
+// -----------------------------------------------------------------------------
+
+test('#4325: 5 de 6 issues cerrados → closedCount=5 y totalPct >= 80 (no ~2%)', () => {
+    // Ninguno tiene entrada en issueMatrix (cerrados por merge, sin actividad en
+    // pipeline): el único dato de cierre viene del set `closedIssues`.
+    const state = makeState({ issues: {} });
+    const wave = { label: 'N', issues: [4308, 4309, 4313, 4318, 4320, 4324], source: 'test' };
+    const snap = buildWaveSnapshot({
+        state,
+        wave,
+        closedIssues: new Set([4308, 4309, 4313, 4318, 4320]), // 5 de 6
+        now: NOW,
+    });
+    assert.equal(snap.closedCount, 5);
+    assert.equal(snap.activeCount, 1);
+    // (5*100 + 0) / 6 = 83 → muy por encima del 2% del bug.
+    assert.ok(snap.totalPct >= 80, `totalPct=${snap.totalPct} debería ser >= 80`);
+});
+
+test('#4325: sin closedIssues el avance NO cuenta cerrados (reproduce el bug)', () => {
+    const state = makeState({ issues: {} });
+    const wave = { label: 'N', issues: [4308, 4309, 4313, 4318, 4320, 4324], source: 'test' };
+    const snap = buildWaveSnapshot({ state, wave, now: NOW }); // sin closedIssues
+    assert.equal(snap.closedCount, 0);
+    assert.equal(snap.totalPct, 0); // el colapso que motivó el fix
+});

--- a/.pipeline/lib/dashboard-routes.js
+++ b/.pipeline/lib/dashboard-routes.js
@@ -654,10 +654,17 @@ function computeLiveWaveStatus(state) {
     if (!activeWave || !Array.isArray(activeWave.issues) || activeWave.issues.length === 0) return null;
     let snap;
     try {
+        // #4325 — pasar `closedIssues` para que el status vivo por lane sea
+        // coherente con el avance (sin él, `buildWaveSnapshot` no marca los
+        // issues CLOSED y el board queda desalineado con el % de la ola).
+        // `computeClosedSet` deriva los cerrados de `state.issueTitles`. Require
+        // lazy DENTRO de la función (patrón anti-circular, idem L445).
+        const { computeClosedSet } = require('./commander-deterministic');
         snap = waveSnapshot.buildWaveSnapshot({
             state,
             wave: activeWave,
             blocked: Array.isArray(state.bloqueados) ? state.bloqueados : [],
+            closedIssues: computeClosedSet({ wave: activeWave, state }),
         });
     } catch {
         return null;

--- a/.pipeline/lib/mission-ola-eta.js
+++ b/.pipeline/lib/mission-ola-eta.js
@@ -36,10 +36,18 @@
  *   - `etaRemainingMin`: restante proyectado por velocidad cuando hay ritmo
  *     medido; si no, la mediana teórica `totalP50`; `null` si nada disponible.
  *
+ * #4325 — CA-4: cuando no hay ritmo medido (`etaSource === 'fallback'` o serie de
+ * velocidad ausente), en vez del guion mudo `—` se expone un estado explícito
+ * `velocityState === 'sin datos suficientes'` que el cliente traduce a leyenda.
+ * La cadena se inlinea DENTRO de la función a propósito: `deriveMissionOlaEta`
+ * se serializa vía `.toString()` en `missionOlaEtaClientScript`, así que NO puede
+ * referenciar constantes de módulo (romperían el eval del cliente por
+ * ReferenceError). Ver `MISSION_INSUFFICIENT_DATA` para el mismo literal en tests.
+ *
  * @param {object|null} d — payload de `/api/dash/ola-eta`.
  * @returns {{avancePct:number|null, velocityPctPerHour:number|null,
  *            etaRemainingMin:number|null, etaFromVelocity:boolean,
- *            hasVelocity:boolean}}
+ *            hasVelocity:boolean, velocityState:string}}
  */
 function deriveMissionOlaEta(d) {
     const data = (d && typeof d === 'object') ? d : {};
@@ -52,7 +60,8 @@ function deriveMissionOlaEta(d) {
     const etaRemainingMin = etaFromVelocity
         ? vel.remainingMs / 60000
         : (Number.isFinite(data.totalP50) ? data.totalP50 : null);
-    return { avancePct, velocityPctPerHour, etaRemainingMin, etaFromVelocity, hasVelocity };
+    const velocityState = hasVelocity ? 'measured' : 'sin datos suficientes';
+    return { avancePct, velocityPctPerHour, etaRemainingMin, etaFromVelocity, hasVelocity, velocityState };
 }
 
 /**
@@ -90,7 +99,16 @@ function missionOlaEtaClientScript() {
       var pctEl = document.getElementById('mission-avance-pct');
       if(pctEl){ var t = (m.avancePct !== null ? m.avancePct + '%' : '—'); if(pctEl.textContent !== t) pctEl.textContent = t; }
       var vv = document.getElementById('mission-vel-value');
-      if(vv) setMzValueUnit(vv, (m.velocityPctPerHour !== null ? m.velocityPctPerHour.toFixed(1) : '—'), '%/h');
+      if(vv){
+        // #4325 (CA-4) — ritmo medido → "N.N %/h"; sin datos → leyenda explícita
+        // (velocityState), NUNCA un "—" mudo ni un 0 silencioso.
+        if(m.velocityPctPerHour !== null){
+          setMzValueUnit(vv, m.velocityPctPerHour.toFixed(1), '%/h');
+        } else {
+          while(vv.firstChild) vv.removeChild(vv.firstChild);
+          vv.appendChild(document.createTextNode(m.velocityState));
+        }
+      }
       var ev = document.getElementById('mission-eta-value');
       if(ev){
         var x = Number(m.etaRemainingMin), txt;
@@ -113,4 +131,10 @@ function missionOlaEtaClientScript() {
 `;
 }
 
-module.exports = { deriveMissionOlaEta, missionOlaEtaClientScript };
+// #4325 — leyenda del estado explícito "sin datos suficientes" (CA-4). El mismo
+// literal se inlinea dentro de `deriveMissionOlaEta` (no puede referenciar esta
+// constante por la serialización `.toString()` al cliente); se exporta para que
+// los tests y otros consumidores usen la misma cadena sin hardcodearla.
+const MISSION_INSUFFICIENT_DATA = 'sin datos suficientes';
+
+module.exports = { deriveMissionOlaEta, missionOlaEtaClientScript, MISSION_INSUFFICIENT_DATA };


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 5 archivos · +110 -6

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:passed` aplicado por delivery

## Closes

Closes #4325
