### PR TITLE
Dashboard — issues recién ingresados a la ola activa se muestran como "listo" sin haber empezado a ejecutar

### DIFF
--- a/.pipeline/lib/__tests__/dashboard-routes-waves-enrich.test.js
+++ b/.pipeline/lib/__tests__/dashboard-routes-waves-enrich.test.js
@@ -356,3 +356,46 @@ test('#4330: mergeSplitChildren es no-op sin issues o sin resolver', () => {
     const emptyIssues = { number: 8, issues: [] };
     assert.equal(_internal.mergeSplitChildren(emptyIssues, '/x'), emptyIssues);
 });
+
+// #4331 — Regresión: un issue abierto SIN work-file recién ingresado a la ola
+// activa NO debe salir como 'ready' (que la UI pinta "Lista"/"listo"). El
+// overlay del snapshot vivo (`computeLiveWaveStatus` → `mapSnapshotStatusToWave`)
+// corre DESPUÉS de `enrichWaveIssue` y antes del fix pisaba el `queued` que ya
+// derivaba enrichWaveIssue: `classifyStatus` devuelve 'pending' sin fase, y ese
+// 'pending' caía en el `default → 'ready'`. Con el fix, 'pending' → 'queued', y
+// el overlay respeta el estado en cola. Este test fuerza que el overlay corra
+// (state.activeWave presente) para cubrir esa capa, no sólo enrichWaveIssue.
+test('#4331: overlay del snapshot no pisa queued con ready para issue sin work-file', () => {
+    const fakeWaves = {
+        getHorizon: () => ([
+            {
+                status: 'active',
+                number: 8,
+                name: 'Ola 8',
+                goal: 'En ejecución',
+                started_at: '2026-06-30T00:00:00.000Z',
+                // 501: recién ingresado, abierto, sin work-file (no está en issueMatrix).
+                issues: [{ number: 501, status: 'pending' }],
+            },
+        ]),
+    };
+    const state = {
+        // activeWave presente → computeLiveWaveStatus corre el overlay del snapshot.
+        activeWave: { label: 'Ola 8', source: 'waves', issues: [501] },
+        bloqueados: [],
+        issueTitles: {
+            '501': { title: 'Issue recién ingresado a la ola', state: 'OPEN', labels: [] },
+        },
+        // issueMatrix presente pero SIN 501 → snapshot lo clasifica 'pending'.
+        issueMatrix: {},
+    };
+    withFakeWaves(fakeWaves, () => {
+        const { _internal } = fresh();
+        const payload = _internal.buildWavesPayload(state);
+        const iss = payload.active_wave.issues.find((i) => i.id === 501);
+        assert.ok(iss, 'el issue 501 debe estar en el payload');
+        assert.equal(iss.status, 'queued', 'sin fase iniciada = En cola, nunca ready/Lista');
+        assert.equal(iss.progress, 0);
+        assert.equal(iss.merged, false);
+    });
+});

--- a/.pipeline/lib/__tests__/dashboard-routes-waves.test.js
+++ b/.pipeline/lib/__tests__/dashboard-routes-waves.test.js
@@ -341,8 +341,8 @@ test('#4248: mapSnapshotStatusToWave traduce al vocabulario del header', () => {
     assert.equal(m('definition'), 'in-progress');
     assert.equal(m('blocked'), 'blocked');
     assert.equal(m('paused'), 'blocked');
-    assert.equal(m('pending'), 'ready');
-    assert.equal(m('cualquier-cosa'), 'ready');
+    assert.equal(m('pending'), 'queued'); // #4331 — sin fase iniciada = En cola, no Lista
+    assert.equal(m('cualquier-cosa'), 'ready'); // default fail-safe se mantiene
 });
 
 // State realista para el snapshot: la ola activa nº2 tiene 3 issues que en
@@ -402,7 +402,7 @@ test('#4248 (D1+D2): enriquece status de la ola activa con el estado vivo del pi
     const byId = new Map(payload.active_wave.issues.map((i) => [i.id, i.status]));
     assert.equal(byId.get(4248), 'completed', 'issue cerrado → completed (no queda en planned/unknown)');
     assert.equal(byId.get(100), 'in-progress', 'issue en dev → in-progress');
-    assert.equal(byId.get(200), 'ready', 'issue sin actividad → ready (cola)');
+    assert.equal(byId.get(200), 'queued', '#4331 — issue sin actividad → queued (En cola), no ready/Lista');
     // openedAt presente para que el header calcule velocidad.
     assert.equal(payload.active_wave.openedAt, '2026-05-24T10:00:00Z');
     // El conteo del header (done) deja de ser 0 cuando hay avance real.

--- a/.pipeline/lib/dashboard-routes.js
+++ b/.pipeline/lib/dashboard-routes.js
@@ -630,7 +630,8 @@ function normalizeWave(raw) {
 //   - closed                         → 'completed'  (ENTREGADOS / done)
 //   - approval | dev | definition    → 'in-progress' (un agente lo está procesando)
 //   - blocked | paused               → 'blocked'    (no avanza, requiere atención)
-//   - pending | resto                → 'ready'      (en cola, sin fase iniciada)
+//   - pending                        → 'queued'     (en cola, sin fase iniciada)
+//   - resto                          → 'ready'      (fail-safe: valores desconocidos)
 // El resultado siempre cae dentro de la whitelist → no se propaga texto crudo.
 function mapSnapshotStatusToWave(snapStatus) {
     switch (snapStatus) {
@@ -640,7 +641,8 @@ function mapSnapshotStatusToWave(snapStatus) {
         case 'definition': return 'in-progress';
         case 'blocked':
         case 'paused': return 'blocked';
-        default: return 'ready';
+        case 'pending': return 'queued';   // #4331 — sin fase iniciada = En cola, no Lista
+        default: return 'ready';           // fail-safe: valores desconocidos
     }
 }
 


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 3 archivos · +50 -5

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:passed` aplicado por delivery

## Closes

Closes #4331
