### PR TITLE
Ampliar el timeout del turno del Commander de 90s a 10 minutos (no cortar investigación en vivo)

### DIFF
--- a/.pipeline/lib/__tests__/commander-inflight-fallback.test.js
+++ b/.pipeline/lib/__tests__/commander-inflight-fallback.test.js
@@ -178,9 +178,10 @@ test('CA-7 — primaryDurationMs >= budget dispara global_budget_exceeded', () =
         const d = inflight.decideInflightFallback({
             primaryProvider: 'anthropic',
             primaryErrorClass: 'timeout_no_new_bytes_30s',
-            primaryDurationMs: 91_000, // excede budget default 90s
+            primaryDurationMs: 601_000, // #4329 — excede budget default 600s
             primaryPartialOutput: '',
             attemptIndex: 0,
+            budgetMs: inflight.TURN_BUDGET_MS,
             pipelineDir: dir,
             chatId: 'chat-bg',
             requestId: 'req-budget-1',
@@ -188,12 +189,33 @@ test('CA-7 — primaryDurationMs >= budget dispara global_budget_exceeded', () =
         assert.equal(d.shouldRetry, false);
         assert.equal(d.reason, 'global_budget_exceeded');
         assert.equal(d.budgetRemainingMs, 0);
-        assert.match(d.cannedResponse, /90s|⏱️/);
+        assert.match(d.cannedResponse, /⏱️/);
+        // #4329 CA-3 — el mensaje ya no debe mencionar "90s".
+        assert.doesNotMatch(d.cannedResponse, /90s/);
         const audit = readAuditLines(dir);
         const ev = audit.find(e => e.event === 'inflight_fallback_global_timeout');
         assert.ok(ev, 'falta evento global_timeout');
-        assert.equal(ev.primary_duration_ms, 91_000);
-        assert.equal(ev.budget_ms, 90_000);
+        assert.equal(ev.primary_duration_ms, 601_000);
+        assert.equal(ev.budget_ms, 600_000);
+    } finally { cleanup(dir); }
+});
+
+test('#4329 no-regresión — dur corta con budget 600s NO dispara timeout', () => {
+    const dir = mkTmpPipelineDir();
+    try {
+        const d = inflight.decideInflightFallback({
+            primaryProvider: 'anthropic',
+            primaryErrorClass: 'http_5xx',
+            primaryDurationMs: 3_000, // pocos segundos — muy por debajo del budget
+            primaryPartialOutput: '',
+            attemptIndex: 0,
+            budgetMs: inflight.TURN_BUDGET_MS,
+            pipelineDir: dir,
+            chatId: 'chat-fast',
+            requestId: 'req-fast',
+        });
+        assert.notEqual(d.reason, 'global_budget_exceeded');
+        assert.equal(d.shouldRetry, true, 'un pedido rápido con error debe intentar fallback, no cortar por tiempo');
     } finally { cleanup(dir); }
 });
 
@@ -688,6 +710,87 @@ test('re-exports desde commander/multi-provider apuntan al módulo dedicado', ()
     assert.equal(typeof mp.precheckCommanderProviderRanking, 'function');
     assert.equal(typeof mp.makePrecheckHandle, 'function');
     assert.equal(typeof mp.formatInflightFallbackNotice, 'function');
-    assert.equal(mp.INFLIGHT_BUDGET_MS, 90 * 1000);
+    assert.equal(mp.INFLIGHT_BUDGET_MS, 600 * 1000); // #4329 — budget efectivo (default 600s)
     assert.equal(mp.MAX_INFLIGHT_FALLBACKS, 1);
+});
+
+// -----------------------------------------------------------------------------
+// #4329 — Budget del turno del Commander: resolver env + clamp + copy sincronizado
+// -----------------------------------------------------------------------------
+
+test('#4329 CA-1 — resolveTurnBudgetMs sin env → 600000 (default 600s)', () => {
+    assert.equal(inflight.resolveTurnBudgetMs({}), 600_000);
+    assert.equal(inflight.DEFAULT_BUDGET_MS, 600_000);
+    assert.equal(inflight.TURN_BUDGET_MS, 600_000);
+});
+
+test('#4329 CA-2 — resolveTurnBudgetMs con env válido → valor configurado', () => {
+    assert.equal(inflight.resolveTurnBudgetMs({ COMMANDER_TURN_BUDGET_MS: '300000' }), 300_000);
+    assert.equal(inflight.resolveTurnBudgetMs({ COMMANDER_TURN_BUDGET_MS: '120000' }), 120_000);
+});
+
+test('#4329 CA-5 (SR-1) — resolveTurnBudgetMs fail-closed ante env inválido', () => {
+    for (const bad of ['', 'abc', '0', '-5', 'NaN', '  ', undefined]) {
+        assert.equal(
+            inflight.resolveTurnBudgetMs({ COMMANDER_TURN_BUDGET_MS: bad }),
+            600_000,
+            `env inválido ${JSON.stringify(bad)} debe caer al default 600s`,
+        );
+    }
+    // Sin la clave definida.
+    assert.equal(inflight.resolveTurnBudgetMs({ OTRA: 'x' }), 600_000);
+});
+
+test('#4329 CA-6 (SR-2) — resolveTurnBudgetMs clampea al techo MAX_BUDGET_MS', () => {
+    assert.equal(inflight.MAX_BUDGET_MS, 30 * 60 * 1000);
+    assert.equal(inflight.resolveTurnBudgetMs({ COMMANDER_TURN_BUDGET_MS: '999999999' }), 1_800_000);
+    // Exactamente en el techo → se mantiene.
+    assert.equal(inflight.resolveTurnBudgetMs({ COMMANDER_TURN_BUDGET_MS: String(1_800_000) }), 1_800_000);
+    // Justo por encima → clamp.
+    assert.equal(inflight.resolveTurnBudgetMs({ COMMANDER_TURN_BUDGET_MS: String(1_800_001) }), 1_800_000);
+});
+
+test('#4329 CA-7 (SR-3) — LATE_RESPONSE_TTL_MS estrictamente mayor al peor budget', () => {
+    assert.ok(inflight.LATE_RESPONSE_TTL_MS > inflight.MAX_BUDGET_MS, 'TTL debe superar MAX_BUDGET_MS');
+    assert.ok(inflight.LATE_RESPONSE_TTL_MS > inflight.TURN_BUDGET_MS, 'TTL debe superar TURN_BUDGET_MS');
+    assert.equal(inflight.LATE_RESPONSE_TTL_MS, 2 * inflight.MAX_BUDGET_MS);
+});
+
+test('#4329 CA-3 — cannedInflightBudgetTimeoutResponse no dice "90s" y refleja minutos', () => {
+    const def = inflight.cannedInflightBudgetTimeoutResponse();
+    assert.doesNotMatch(def, /90s/);
+    assert.match(def, /10 min/); // 600000ms → 10 min
+    // Budget custom en minutos.
+    assert.match(inflight.cannedInflightBudgetTimeoutResponse(300_000), /5 min/);
+    // Budget < 60s → expresado en segundos (guideline UX, evita "0 min").
+    const chico = inflight.cannedInflightBudgetTimeoutResponse(30_000);
+    assert.match(chico, /30s/);
+    assert.doesNotMatch(chico, /0 min/);
+    // Argumento inválido → cae al default 600s (10 min).
+    assert.match(inflight.cannedInflightBudgetTimeoutResponse('nope'), /10 min/);
+});
+
+test('#4329 SR-4 — pulpo.js deriva HARD_NON_ANTH_MS del budget, no del literal 90*1000', () => {
+    const fs = require('node:fs');
+    const path = require('node:path');
+    const pulpoSrc = fs.readFileSync(
+        path.join(__dirname, '..', '..', 'pulpo.js'), 'utf8',
+    );
+    // HARD_NON_ANTH_MS ya no puede asignarse el literal 90 * 1000.
+    assert.doesNotMatch(
+        pulpoSrc,
+        /HARD_NON_ANTH_MS\s*=\s*90\s*\*\s*1000/,
+        'HARD_NON_ANTH_MS no debe seguir hardcodeado en 90 * 1000',
+    );
+    assert.match(
+        pulpoSrc,
+        /HARD_NON_ANTH_MS\s*=\s*inflightFallback\.TURN_BUDGET_MS/,
+        'HARD_NON_ANTH_MS debe derivar de inflightFallback.TURN_BUDGET_MS',
+    );
+    // COMMANDER_SUMMARY_TIMEOUT_MS (timeout distinto) NO se toca.
+    assert.match(
+        pulpoSrc,
+        /COMMANDER_SUMMARY_TIMEOUT_MS\s*=\s*90\s*\*\s*1000/,
+        'COMMANDER_SUMMARY_TIMEOUT_MS debe seguir en 90 * 1000',
+    );
 });

--- a/.pipeline/lib/commander/inflight-fallback.js
+++ b/.pipeline/lib/commander/inflight-fallback.js
@@ -92,8 +92,25 @@ const crypto = require('node:crypto');
 const path = require('node:path');
 
 const COMMANDER_SKILL = 'telegram-commander';
-const DEFAULT_BUDGET_MS = 90 * 1000;
+// #4329 — budget global del turno del Commander. Subido de 90s → 600s (10 min)
+// para no cortar investigación en vivo. Configurable por env
+// `COMMANDER_TURN_BUDGET_MS`, fail-closed (SR-1) + clamp superior (SR-2).
+const DEFAULT_BUDGET_MS = 600 * 1000;        // 600s / 10 min (era 90s)
+const MAX_BUDGET_MS = 30 * 60 * 1000;        // techo duro: 30 min (SR-2, no eliminar el breaker)
 const MAX_INFLIGHT_FALLBACKS = 1;   // 1 fallback in-flight + el intento primario = 2 totales
+
+// resolveTurnBudgetMs — resuelve el budget del turno desde el env, una sola vez
+// a nivel módulo. SR-1 fail-closed: no numérico / NaN / <=0 / vacío → default
+// 600s (nunca desactiva el corte). SR-2 clamp: por encima del techo → clamp al
+// techo, no al valor crudo (un env mal configurado no reintroduce el cuelgue).
+function resolveTurnBudgetMs(env = process.env) {
+    const v = Number(env && env.COMMANDER_TURN_BUDGET_MS);
+    const base = (Number.isFinite(v) && v > 0) ? v : DEFAULT_BUDGET_MS;
+    return Math.min(base, MAX_BUDGET_MS);
+}
+// Budget efectivo del turno (env-resuelto + clampeado). Lo derivan tanto el
+// ciclo lógico como el kill duro de `pulpo.js` (SR-4: un único valor).
+const TURN_BUDGET_MS = resolveTurnBudgetMs();
 
 // -----------------------------------------------------------------------------
 // hashFor — SHA-256 truncado a 12 hex. Mismo helper que el módulo padre.
@@ -182,12 +199,19 @@ function cannedInflightExhaustedResponse({ requestId }) {
 
 // -----------------------------------------------------------------------------
 // cannedInflightBudgetTimeoutResponse — Mensaje cuando el budget global SR-5
-// (90s) se agotó antes de poder completar el ciclo. Distinto de exhausted
-// porque puede haber sido un primario lento, no necesariamente fallido.
+// se agotó antes de poder completar el ciclo. Distinto de exhausted porque
+// puede haber sido un primario lento, no necesariamente fallido.
+// #4329 (CA-3): el umbral se deriva del budget efectivo, sin literal "90s".
+// Para budgets < 60s (posible vía env) se expresa en segundos, para no mostrar
+// "más de 0 min" (guideline UX).
 // -----------------------------------------------------------------------------
-function cannedInflightBudgetTimeoutResponse() {
+function cannedInflightBudgetTimeoutResponse(budgetMs = TURN_BUDGET_MS) {
+    const ms = (Number.isFinite(budgetMs) && budgetMs > 0) ? budgetMs : DEFAULT_BUDGET_MS;
+    const umbral = ms >= 60000
+        ? `${Math.round(ms / 60000)} min`
+        : `${Math.round(ms / 1000)}s`;
     return (
-        '⏱️ Tu pedido tardó más de 90s en completarse y corté para no dejarte esperando. ' +
+        `⏱️ Tu pedido tardó más de ${umbral} en completarse y corté para no dejarte esperando. ` +
         'Reformulá con algo más puntual o probá de nuevo en un momento.'
     );
 }
@@ -202,15 +226,17 @@ function cannedInflightBudgetTimeoutResponse() {
 //   ya está cerrado para ese par → el caller descarta la respuesta tardía
 //   con audit `late_response_discarded`.
 //
-// TTL: 10 minutos (configurable). Suficiente para descartar late-responses
-// realistas; supera el budget global de 90s con margen para llamadas async
-// que demoran cleanup.
+// TTL (#4329 / SR-3): estrictamente mayor que el peor caso de budget
+// (2 × MAX_BUDGET_MS = 60 min). Con el budget nuevo de 600s, un TTL == budget
+// dejaría una ventana donde un primario tardío en el borde se trata como turno
+// nuevo y su parcial podría llegar al usuario (viola la garantía de no entregar
+// parciales). El margen amplio evita esa ventana para cualquier budget efectivo.
 //
 // **In-process only**: el lock vive en memoria del pulpo. Si pulpo se
 // reinicia, el lock se pierde — pero también lo hace el contexto del
 // primario tardío (su socket muere con el padre). No hay race cross-process.
 // -----------------------------------------------------------------------------
-const LATE_RESPONSE_TTL_MS = 10 * 60 * 1000;
+const LATE_RESPONSE_TTL_MS = 2 * MAX_BUDGET_MS;   // estrictamente > cualquier budget efectivo
 const _inflightLocks = new Map();
 
 function _lockKey(chatId, requestId) {
@@ -373,7 +399,7 @@ function decideInflightFallback(opts = {}) {
             noticeText: null,
             budgetRemainingMs: 0,
             partialOutputHash: partialHash,
-            cannedResponse: cannedInflightBudgetTimeoutResponse(),
+            cannedResponse: cannedInflightBudgetTimeoutResponse(_budget),
         };
     }
 
@@ -628,6 +654,9 @@ module.exports = {
     // Constantes
     COMMANDER_SKILL,
     DEFAULT_BUDGET_MS,
+    MAX_BUDGET_MS,
+    TURN_BUDGET_MS,
+    resolveTurnBudgetMs,
     MAX_INFLIGHT_FALLBACKS,
     LATE_RESPONSE_TTL_MS,
 

--- a/.pipeline/lib/commander/multi-provider.js
+++ b/.pipeline/lib/commander/multi-provider.js
@@ -1142,7 +1142,9 @@ module.exports = {
     isLateResponseDuplicate: inflight.isLateResponseDuplicate,
     releaseInflightLock: inflight.releaseInflightLock,
     generateRequestId: inflight.generateRequestId,
-    INFLIGHT_BUDGET_MS: inflight.DEFAULT_BUDGET_MS,
+    // #4329 — exponer el budget EFECTIVO (env-resuelto + clampeado), no solo el
+    // default literal, para que refleje overrides por COMMANDER_TURN_BUDGET_MS.
+    INFLIGHT_BUDGET_MS: inflight.TURN_BUDGET_MS,
     MAX_INFLIGHT_FALLBACKS: inflight.MAX_INFLIGHT_FALLBACKS,
 
     // #3275 — credentials precheck al boot

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -10001,10 +10001,13 @@ function ejecutarClaude(prompt, textoOriginal, trace, fallbackParts) {
             let stdout = '';
             let stderr = '';
             const startNon = Date.now();
-            const HARD_NON_ANTH_MS = 90 * 1000; // SR-5 — budget 90s para providers no-stream-json
+            // #4329 / SR-4 — el kill duro deriva del MISMO budget configurado
+            // (env-resuelto + clampeado) que el ciclo lógico, para que los
+            // turnos de providers no-Anthropic no se sigan matando a los 90s.
+            const HARD_NON_ANTH_MS = inflightFallback.TURN_BUDGET_MS;
             const timer = setTimeout(() => {
               try { proc.kill('SIGTERM'); } catch {}
-              log('commander', `Provider ${res.provider} timeout 90s — abortando`);
+              log('commander', `Provider ${res.provider} timeout ${Math.round(HARD_NON_ANTH_MS / 1000)}s — abortando`);
             }, HARD_NON_ANTH_MS);
             proc.stdout && proc.stdout.on('data', (d) => { stdout += d.toString(); });
             proc.stderr && proc.stderr.on('data', (d) => { stderr += d.toString(); });
@@ -10247,6 +10250,9 @@ function ejecutarClaude(prompt, textoOriginal, trace, fallbackParts) {
         primaryDurationMs: Date.now() - startTime,
         primaryPartialOutput: lastText,
         attemptIndex: 0,
+        // #4329 / SR-4 — mismo budget efectivo (env-resuelto + clampeado) que el
+        // kill duro; el fallback a DEFAULT_BUDGET_MS en el core queda como red.
+        budgetMs: inflightFallback.TURN_BUDGET_MS,
         pipelineDir: PIPELINE,
         lockNamespace: chatId,
         requestId: turnRequestId,


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 4 archivos · +158 -18

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:passed` aplicado por delivery

## Closes

Closes #4329
