### PR TITLE
[Split de #4351] Gestión de olas — Desasociar issues + Reordenar plan

### DIFF
--- a/.pipeline/lib/__tests__/commander-wave-subcommands.test.js
+++ b/.pipeline/lib/__tests__/commander-wave-subcommands.test.js
@@ -709,6 +709,7 @@ test('describeAvailableWaves: formato `N (activa), M, K`', () => {
     assert.equal(describeAvailableWaves(null, [{ number: 1 }]), '1');
 });
 
+
 // -----------------------------------------------------------------------------
 // #4376 (split #4351) — `/wave create` (creación de olas planificadas)
 // -----------------------------------------------------------------------------
@@ -965,4 +966,202 @@ test('dispatcher: /wave create con chat_id no autorizado -> unauthorized, sin IO
         const st = JSON.parse(fs.readFileSync(path.join(dir, 'waves.json'), 'utf8'));
         assert.equal(st.planned_waves.length, 2);
     } finally { teardown(dir); }
+});
+
+// =============================================================================
+// #4377 — Subcomandos `remove` / `reorder` (Parte B, Ola 8.3)
+// =============================================================================
+
+// ─── parseWaveArgs — remove ───────────────────────────────────────────────
+
+test('#4377 parseWaveArgs: `remove 2 #3460` happy path', () => {
+    const cd = require('../commander-deterministic');
+    assert.deepEqual(cd.parseWaveArgs('remove 2 #3460'), {
+        subcommand: 'remove', waveNumber: 2, issueNumber: 3460,
+    });
+});
+
+test('#4377 parseWaveArgs: `remove` reusa el gate estricto de enteros (CA-8)', () => {
+    const cd = require('../commander-deterministic');
+    assert.equal(cd.parseWaveArgs('remove 2.5 #3460'), null); // float
+    assert.equal(cd.parseWaveArgs('remove -1 #3460'), null);  // negativo
+    assert.equal(cd.parseWaveArgs('remove 0 #3460'), null);   // cero
+    assert.equal(cd.parseWaveArgs('remove 0x2 #3460'), null); // hex
+    assert.equal(cd.parseWaveArgs('remove 2 3460'), null);    // sin `#`
+    assert.equal(cd.parseWaveArgs('remove 2 #3460a'), null);  // sufijo
+    assert.equal(cd.parseWaveArgs('remove dos #3460'), null); // texto
+    assert.equal(cd.parseWaveArgs('remove 2 #3460 extra'), null); // token extra
+    assert.equal(cd.parseWaveArgs('remove 2'), null);         // falta issue
+});
+
+// ─── parseWaveArgs — reorder ──────────────────────────────────────────────
+
+test('#4377 parseWaveArgs: `reorder 3 2` y `reorder 4 2 3` happy path', () => {
+    const cd = require('../commander-deterministic');
+    assert.deepEqual(cd.parseWaveArgs('reorder 3 2'), { subcommand: 'reorder', order: [3, 2] });
+    assert.deepEqual(cd.parseWaveArgs('reorder 4 2 3'), { subcommand: 'reorder', order: [4, 2, 3] });
+});
+
+test('#4377 parseWaveArgs: `reorder` rechaza floats/negativos/texto/duplicados/<2 (CA-8)', () => {
+    const cd = require('../commander-deterministic');
+    assert.equal(cd.parseWaveArgs('reorder 2'), null);        // menos de 2
+    assert.equal(cd.parseWaveArgs('reorder'), null);          // vacío
+    assert.equal(cd.parseWaveArgs('reorder 2 2'), null);      // duplicado
+    assert.equal(cd.parseWaveArgs('reorder 2 3.5'), null);    // float
+    assert.equal(cd.parseWaveArgs('reorder 2 -3'), null);     // negativo
+    assert.equal(cd.parseWaveArgs('reorder 2 tres'), null);   // texto
+    assert.equal(cd.parseWaveArgs('reorder 0 2'), null);      // cero
+    assert.equal(cd.parseWaveArgs('reorder 2 0x3'), null);    // hex
+});
+
+// ─── destructiveCommands / cooldown ───────────────────────────────────────
+
+test('#4377 wave-remove y wave-reorder aplican cooldown destructivo (REQ-SEC-5)', () => {
+    const { createDestructiveCooldown } = require('../commander/destructive-cooldown');
+    let now = 1000000;
+    const cd = createDestructiveCooldown({
+        cooldownMs: 30 * 1000,
+        destructiveCommands: ['wave-add', 'wave-promote', 'wave-remove', 'wave-reorder'],
+        now: () => now,
+    });
+    for (const cmd of ['wave-remove', 'wave-reorder']) {
+        assert.equal(cd.check('leo', cmd).allowed, true, `${cmd} primer uso permitido`);
+        cd.recordSuccess('leo', cmd);
+        assert.equal(cd.check('leo', cmd).allowed, false, `${cmd} bloqueado dentro de ventana`);
+        now += 31 * 1000;
+        assert.equal(cd.check('leo', cmd).allowed, true, `${cmd} permitido tras ventana`);
+        now -= 31 * 1000;
+    }
+});
+
+// ─── handleWaveRemove ─────────────────────────────────────────────────────
+
+test('#4377 handleWaveRemove: happy path desasocia de ola planificada', async () => {
+    const dir = setupTmp();
+    try {
+        writeWavesFixture(dir, sampleWavesState()); // ola 10 tiene 3600
+        const cd = require('../commander-deterministic');
+        const { reply } = await cd._waveInternal.handleWaveRemove({
+            pipelineRoot: dir, waveNumber: 10, issueNumber: 3600,
+            cooldown: null, chatId: 'leo', from: 'Leo',
+        });
+        assert.ok(/3600/.test(reply));
+        assert.ok(/10/.test(reply));
+        const fresh = JSON.parse(fs.readFileSync(path.join(dir, 'waves.json'), 'utf8'));
+        const wave10 = fresh.planned_waves.find((w) => w.number === 10);
+        assert.deepEqual(wave10.issues.map((i) => i.number), []);
+    } finally { teardown(dir); }
+});
+
+test('#4377 handleWaveRemove: rechazo sobre ola ACTIVA con mensaje accionable (A04)', async () => {
+    const dir = setupTmp();
+    try {
+        writeWavesFixture(dir, sampleWavesState()); // ola 9 activa tiene 3500
+        const before = fs.readFileSync(path.join(dir, 'waves.json'), 'utf8');
+        const cd = require('../commander-deterministic');
+        const { reply } = await cd._waveInternal.handleWaveRemove({
+            pipelineRoot: dir, waveNumber: 9, issueNumber: 3500,
+            cooldown: null, chatId: 'leo', from: 'Leo',
+        });
+        assert.ok(/activa/i.test(reply), 'menciona que la ola está activa');
+        assert.ok(/planificada/i.test(reply), 'sugiere qué sí se puede');
+        // No debe haber tocado el estado.
+        assert.equal(fs.readFileSync(path.join(dir, 'waves.json'), 'utf8'), before);
+    } finally { teardown(dir); }
+});
+
+test('#4377 handleWaveRemove: no-op explícito si el issue no pertenecía', async () => {
+    const dir = setupTmp();
+    try {
+        writeWavesFixture(dir, sampleWavesState());
+        const cd = require('../commander-deterministic');
+        const { reply } = await cd._waveInternal.handleWaveRemove({
+            pipelineRoot: dir, waveNumber: 10, issueNumber: 9999,
+            cooldown: null, chatId: 'leo', from: 'Leo',
+        });
+        assert.ok(/no pertenecía/i.test(reply));
+        assert.ok(/9999/.test(reply));
+    } finally { teardown(dir); }
+});
+
+test('#4377 handleWaveRemove: ola inexistente → wave_not_found', async () => {
+    const dir = setupTmp();
+    try {
+        writeWavesFixture(dir, sampleWavesState());
+        const cd = require('../commander-deterministic');
+        const { reply } = await cd._waveInternal.handleWaveRemove({
+            pipelineRoot: dir, waveNumber: 77, issueNumber: 3600,
+            cooldown: null, chatId: 'leo', from: 'Leo',
+        });
+        assert.ok(/no encontré la ola planificada/i.test(reply));
+        assert.ok(/77/.test(reply));
+    } finally { teardown(dir); }
+});
+
+// ─── handleWaveReorder ────────────────────────────────────────────────────
+
+test('#4377 handleWaveReorder: happy path permuta olas planificadas + muestra prev→nuevo', async () => {
+    const dir = setupTmp();
+    try {
+        writeWavesFixture(dir, sampleWavesState()); // planned: 10, 11
+        const cd = require('../commander-deterministic');
+        const { reply } = await cd._waveInternal.handleWaveReorder({
+            pipelineRoot: dir, order: [11, 10],
+            cooldown: null, chatId: 'leo', from: 'Leo',
+        });
+        assert.ok(/10/.test(reply) && /11/.test(reply));
+        const fresh = JSON.parse(fs.readFileSync(path.join(dir, 'waves.json'), 'utf8'));
+        assert.deepEqual(fresh.planned_waves.map((w) => w.number), [11, 10]);
+    } finally { teardown(dir); }
+});
+
+test('#4377 handleWaveReorder: no-permutación → error específico (falta/no existe)', async () => {
+    const dir = setupTmp();
+    try {
+        writeWavesFixture(dir, sampleWavesState()); // planned: 10, 11
+        const before = fs.readFileSync(path.join(dir, 'waves.json'), 'utf8');
+        const cd = require('../commander-deterministic');
+        const { reply } = await cd._waveInternal.handleWaveReorder({
+            pipelineRoot: dir, order: [10, 99],
+            cooldown: null, chatId: 'leo', from: 'Leo',
+        });
+        assert.ok(/permutación/i.test(reply));
+        assert.ok(/falta/i.test(reply) && /11/.test(reply), 'indica el number faltante');
+        assert.ok(/no existe/i.test(reply) && /99/.test(reply), 'indica el number inexistente');
+        assert.equal(fs.readFileSync(path.join(dir, 'waves.json'), 'utf8'), before, 'no persiste');
+    } finally { teardown(dir); }
+});
+
+test('#4377 handleWaveReorder: menos de 2 olas planificadas → not_enough_waves', async () => {
+    const dir = setupTmp();
+    try {
+        const state = sampleWavesState();
+        state.planned_waves = [{ number: 10, name: 'Ola única', issues: [] }];
+        writeWavesFixture(dir, state);
+        const cd = require('../commander-deterministic');
+        const { reply } = await cd._waveInternal.handleWaveReorder({
+            pipelineRoot: dir, order: [10, 11],
+            cooldown: null, chatId: 'leo', from: 'Leo',
+        });
+        assert.ok(/al menos 2 olas/i.test(reply));
+    } finally { teardown(dir); }
+});
+
+// ─── Templates nuevos cargan sin error ────────────────────────────────────
+
+test('#4377 templates wave-remove-ok / wave-remove-noop / wave-reorder-ok renderizan', () => {
+    const { fillTemplate, clearCache } = require('../commander/fill-template');
+    clearCache();
+    const removeOk = fillTemplate('wave-remove-ok', {
+        'issue-number': 3460, 'wave-number': 2, 'wave-name': 'Ola A', 'new-size': 1,
+    });
+    assert.ok(removeOk.includes('3460') && removeOk.includes('2'));
+    const noop = fillTemplate('wave-remove-noop', {
+        'issue-number': 9999, 'wave-number': 2, 'wave-name': 'Ola A',
+    });
+    assert.ok(noop.includes('9999'));
+    const reorderOk = fillTemplate('wave-reorder-ok', {
+        'prev-order': '2, 3, 4', 'new-order': '4, 2, 3',
+    });
+    assert.ok(reorderOk.includes('4, 2, 3'));
 });

--- a/.pipeline/lib/__tests__/waves-remove-issue.test.js
+++ b/.pipeline/lib/__tests__/waves-remove-issue.test.js
@@ -1,0 +1,218 @@
+// =============================================================================
+// waves-remove-issue.test.js — Tests de `removeIssueFromWave` (#4377 CA-2/7/9).
+//
+// Cubre:
+//   (1) remove sobre planificada OK y re-normaliza (issue fuera, resto intacto).
+//   (2) no-op idempotente si el issue no pertenece (sin escritura espuria).
+//   (3) rechazo sobre ola ACTIVA (Política A04 / REQ-SEC-3).
+//   (4) rechazo si la ola planificada no existe.
+//   (5) rechazo si issueNumber es inválido.
+//   (6) fallo parcial (rename falla) deja estado consistente (CA-7) + sin .tmp.
+//   (7) audit trail: meta.updated_by/source/note persistidos (REQ-SEC-6).
+//
+// Ejecutar:  node --test .pipeline/lib/__tests__/waves-remove-issue.test.js
+// =============================================================================
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+let waves; // se re-requiere con PIPELINE_DIR_OVERRIDE seteado
+
+function setupTmp() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'waves-remove-'));
+    process.env.PIPELINE_DIR_OVERRIDE = dir;
+    delete require.cache[require.resolve('../waves')];
+    waves = require('../waves');
+    waves.invalidateCache();
+    return dir;
+}
+
+function teardownTmp(dir) {
+    if (waves) waves.invalidateCache();
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+    delete process.env.PIPELINE_DIR_OVERRIDE;
+}
+
+function sampleState() {
+    return {
+        version: '1.0',
+        meta: {
+            created_at: '2026-06-01T00:00:00.000Z',
+            updated_at: '2026-06-01T00:00:00.000Z',
+            updated_by: 'System',
+            source: 'manual',
+            note: 'fixture',
+        },
+        active_wave: {
+            number: 1,
+            name: 'Ola activa',
+            goal: 'objetivo',
+            started_at: '2026-06-01T10:00:00.000Z',
+            issues: [{ number: 3451, status: 'in_progress' }],
+        },
+        planned_waves: [
+            {
+                number: 2,
+                name: 'Ola planificada A',
+                goal: 'g',
+                issues: [{ number: 3460 }, { number: 3461 }],
+            },
+            {
+                number: 3,
+                name: 'Ola planificada B',
+                issues: [{ number: 3470 }],
+            },
+        ],
+        archived_waves: [],
+        dependencies: [],
+    };
+}
+
+function writeFixture(dir, state) {
+    fs.writeFileSync(path.join(dir, 'waves.json'), JSON.stringify(state, null, 2));
+}
+function readDisk(dir) {
+    return JSON.parse(fs.readFileSync(path.join(dir, 'waves.json'), 'utf8'));
+}
+
+// ─── (1) remove OK ────────────────────────────────────────────────────────
+
+test('removeIssueFromWave: remueve de ola planificada y persiste (CA-2)', () => {
+    const dir = setupTmp();
+    try {
+        writeFixture(dir, sampleState());
+        waves.removeIssueFromWave(2, 3460, { updated_by: 'Planner', note: 'mal asignado' });
+        const fresh = readDisk(dir);
+        const wave2 = fresh.planned_waves.find((w) => w.number === 2);
+        const nums = wave2.issues.map((i) => i.number);
+        assert.deepEqual(nums, [3461], 'solo queda 3461 en la ola 2');
+        // Otras olas intactas.
+        assert.deepEqual(fresh.planned_waves.find((w) => w.number === 3).issues.map((i) => i.number), [3470]);
+        assert.deepEqual(fresh.active_wave.issues.map((i) => i.number), [3451]);
+    } finally {
+        teardownTmp(dir);
+    }
+});
+
+test('removeIssueFromWave: tolera "#123" y " 123 " en issueNumber', () => {
+    const dir = setupTmp();
+    try {
+        writeFixture(dir, sampleState());
+        waves.removeIssueFromWave(2, ' #3461 ');
+        const wave2 = readDisk(dir).planned_waves.find((w) => w.number === 2);
+        assert.deepEqual(wave2.issues.map((i) => i.number), [3460]);
+    } finally {
+        teardownTmp(dir);
+    }
+});
+
+// ─── (2) no-op idempotente ────────────────────────────────────────────────
+
+test('removeIssueFromWave: no-op idempotente si el issue no pertenece (CA-2)', () => {
+    const dir = setupTmp();
+    try {
+        writeFixture(dir, sampleState());
+        const before = fs.readFileSync(path.join(dir, 'waves.json'), 'utf8');
+        // 9999 no está en la ola 2 → no-op, sin escritura espuria.
+        waves.removeIssueFromWave(2, 9999);
+        const after = fs.readFileSync(path.join(dir, 'waves.json'), 'utf8');
+        assert.equal(after, before, 'el archivo no debe cambiar en un no-op');
+    } finally {
+        teardownTmp(dir);
+    }
+});
+
+// ─── (3) rechazo sobre ola activa (Política A04) ──────────────────────────
+
+test('removeIssueFromWave: rechaza sobre la ola ACTIVA (Política A04 / REQ-SEC-3)', () => {
+    const dir = setupTmp();
+    try {
+        writeFixture(dir, sampleState());
+        const before = fs.readFileSync(path.join(dir, 'waves.json'), 'utf8');
+        assert.throws(
+            () => waves.removeIssueFromWave(1, 3451),
+            /no se permite desasociar sobre la ola activa/i,
+        );
+        const after = fs.readFileSync(path.join(dir, 'waves.json'), 'utf8');
+        assert.equal(after, before, 'rechazo A04 no debe tocar el estado');
+    } finally {
+        teardownTmp(dir);
+    }
+});
+
+// ─── (4) ola inexistente ──────────────────────────────────────────────────
+
+test('removeIssueFromWave: rechaza si la ola planificada no existe', () => {
+    const dir = setupTmp();
+    try {
+        writeFixture(dir, sampleState());
+        assert.throws(
+            () => waves.removeIssueFromWave(99, 3460),
+            /ola planificada 99 no existe/i,
+        );
+    } finally {
+        teardownTmp(dir);
+    }
+});
+
+// ─── (5) issueNumber inválido ─────────────────────────────────────────────
+
+test('removeIssueFromWave: rechaza issueNumber inválido', () => {
+    const dir = setupTmp();
+    try {
+        writeFixture(dir, sampleState());
+        assert.throws(() => waves.removeIssueFromWave(2, 'abc'), /inválido/i);
+        assert.throws(() => waves.removeIssueFromWave(2, -5), /inválido/i);
+        assert.throws(() => waves.removeIssueFromWave(2, 0), /inválido/i);
+    } finally {
+        teardownTmp(dir);
+    }
+});
+
+// ─── (6) fallo parcial → estado consistente (CA-7) ────────────────────────
+
+test('removeIssueFromWave: fallo de rename deja el estado original intacto (CA-7)', () => {
+    const dir = setupTmp();
+    try {
+        writeFixture(dir, sampleState());
+        const before = fs.readFileSync(path.join(dir, 'waves.json'), 'utf8');
+
+        // Inyectar fallo NO reintentables en el rename atómico (mid-write).
+        const origRename = fs.renameSync;
+        fs.renameSync = () => { const e = new Error('disco lleno simulado'); e.code = 'EIO'; throw e; };
+        try {
+            assert.throws(() => waves.removeIssueFromWave(2, 3460), /EIO|disco lleno/i);
+        } finally {
+            fs.renameSync = origRename;
+        }
+
+        const after = fs.readFileSync(path.join(dir, 'waves.json'), 'utf8');
+        assert.equal(after, before, 'el archivo original debe quedar intacto ante fallo parcial');
+        assert.ok(!fs.existsSync(path.join(dir, 'waves.json.tmp')), 'no debe quedar .tmp huérfano');
+    } finally {
+        teardownTmp(dir);
+    }
+});
+
+// ─── (7) audit trail ──────────────────────────────────────────────────────
+
+test('removeIssueFromWave: registra meta.updated_by/source/note (REQ-SEC-6)', () => {
+    const dir = setupTmp();
+    try {
+        writeFixture(dir, sampleState());
+        waves.removeIssueFromWave(2, 3460, {
+            updated_by: 'Commander', source: 'test-src', note: 'nota forense',
+        });
+        const meta = readDisk(dir).meta;
+        assert.equal(meta.updated_by, 'Commander');
+        assert.equal(meta.source, 'test-src');
+        assert.equal(meta.note, 'nota forense');
+    } finally {
+        teardownTmp(dir);
+    }
+});

--- a/.pipeline/lib/__tests__/waves-reorder.test.js
+++ b/.pipeline/lib/__tests__/waves-reorder.test.js
@@ -1,0 +1,211 @@
+// =============================================================================
+// waves-reorder.test.js — Tests de `reorderPlannedWaves` (#4377 CA-3/7).
+//
+// Cubre:
+//   (1) permutación válida OK y preserva `number` (identidad).
+//   (2) rechazo de no-permutación (falta / duplicado / number inexistente).
+//   (3) rechazo de tipo inválido (no-array, floats, negativos → REQ-SEC-2).
+//   (4) fallo parcial (rename falla) deja estado consistente (CA-7).
+//   (5) audit trail: meta.note describe orden previo→nuevo (REQ-SEC-6).
+//
+// Ejecutar:  node --test .pipeline/lib/__tests__/waves-reorder.test.js
+// =============================================================================
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+let waves;
+
+function setupTmp() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'waves-reorder-'));
+    process.env.PIPELINE_DIR_OVERRIDE = dir;
+    delete require.cache[require.resolve('../waves')];
+    waves = require('../waves');
+    waves.invalidateCache();
+    return dir;
+}
+
+function teardownTmp(dir) {
+    if (waves) waves.invalidateCache();
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+    delete process.env.PIPELINE_DIR_OVERRIDE;
+}
+
+function sampleState() {
+    return {
+        version: '1.0',
+        meta: {
+            created_at: '2026-06-01T00:00:00.000Z',
+            updated_at: '2026-06-01T00:00:00.000Z',
+            updated_by: 'System',
+            source: 'manual',
+            note: 'fixture',
+        },
+        active_wave: {
+            number: 1,
+            name: 'Ola activa',
+            goal: 'g',
+            started_at: '2026-06-01T10:00:00.000Z',
+            issues: [{ number: 3451 }],
+        },
+        planned_waves: [
+            { number: 2, name: 'Ola A', goal: 'ga', issues: [{ number: 3460 }] },
+            { number: 3, name: 'Ola B', issues: [{ number: 3470 }] },
+            { number: 4, name: 'Ola C', issues: [{ number: 3480 }] },
+        ],
+        archived_waves: [],
+        dependencies: [],
+    };
+}
+
+function writeFixture(dir, state) {
+    fs.writeFileSync(path.join(dir, 'waves.json'), JSON.stringify(state, null, 2));
+}
+function readDisk(dir) {
+    return JSON.parse(fs.readFileSync(path.join(dir, 'waves.json'), 'utf8'));
+}
+
+// ─── (1) permutación válida ───────────────────────────────────────────────
+
+test('reorderPlannedWaves: permutación válida cambia orden y preserva number/identidad (CA-3)', () => {
+    const dir = setupTmp();
+    try {
+        writeFixture(dir, sampleState());
+        waves.reorderPlannedWaves([4, 2, 3], { updated_by: 'Planner' });
+        const fresh = readDisk(dir);
+        // El array quedó en el nuevo orden…
+        assert.deepEqual(fresh.planned_waves.map((w) => w.number), [4, 2, 3]);
+        // …pero cada ola conserva su number + name + issues (identidad intacta).
+        const wave4 = fresh.planned_waves[0];
+        assert.equal(wave4.number, 4);
+        assert.equal(wave4.name, 'Ola C');
+        assert.deepEqual(wave4.issues.map((i) => i.number), [3480]);
+        // La ola activa no se toca.
+        assert.equal(fresh.active_wave.number, 1);
+    } finally {
+        teardownTmp(dir);
+    }
+});
+
+test('reorderPlannedWaves: identidad — mismo orden es válido (no-op semántico persistente)', () => {
+    const dir = setupTmp();
+    try {
+        writeFixture(dir, sampleState());
+        waves.reorderPlannedWaves([2, 3, 4]);
+        assert.deepEqual(readDisk(dir).planned_waves.map((w) => w.number), [2, 3, 4]);
+    } finally {
+        teardownTmp(dir);
+    }
+});
+
+// ─── (2) rechazo de no-permutación ────────────────────────────────────────
+
+test('reorderPlannedWaves: rechaza si falta un number (no-permutación) (CA-3)', () => {
+    const dir = setupTmp();
+    try {
+        writeFixture(dir, sampleState());
+        const before = fs.readFileSync(path.join(dir, 'waves.json'), 'utf8');
+        assert.throws(() => waves.reorderPlannedWaves([2, 3]), /no es permutación exacta/i);
+        assert.equal(fs.readFileSync(path.join(dir, 'waves.json'), 'utf8'), before, 'no persiste ante rechazo');
+    } finally {
+        teardownTmp(dir);
+    }
+});
+
+test('reorderPlannedWaves: rechaza si duplica un number', () => {
+    const dir = setupTmp();
+    try {
+        writeFixture(dir, sampleState());
+        assert.throws(() => waves.reorderPlannedWaves([2, 2, 3]), /no es permutación exacta/i);
+    } finally {
+        teardownTmp(dir);
+    }
+});
+
+test('reorderPlannedWaves: rechaza si inyecta un number inexistente', () => {
+    const dir = setupTmp();
+    try {
+        writeFixture(dir, sampleState());
+        assert.throws(() => waves.reorderPlannedWaves([2, 3, 99]), /no es permutación exacta/i);
+    } finally {
+        teardownTmp(dir);
+    }
+});
+
+// ─── (3) rechazo de tipo inválido (REQ-SEC-2) ─────────────────────────────
+
+test('reorderPlannedWaves: rechaza tipos inválidos (no-array, floats, negativos) (REQ-SEC-2)', () => {
+    const dir = setupTmp();
+    try {
+        writeFixture(dir, sampleState());
+        assert.throws(() => waves.reorderPlannedWaves('2,3,4'), /array de enteros/i);
+        assert.throws(() => waves.reorderPlannedWaves(null), /array de enteros/i);
+        assert.throws(() => waves.reorderPlannedWaves([2, 3.5, 4]), /array de enteros/i);
+        assert.throws(() => waves.reorderPlannedWaves([2, -3, 4]), /array de enteros/i);
+        assert.throws(() => waves.reorderPlannedWaves([2, '3', 4]), /array de enteros/i);
+    } finally {
+        teardownTmp(dir);
+    }
+});
+
+test('reorderPlannedWaves: input con __proto__ no contamina (REQ-SEC-2)', () => {
+    const dir = setupTmp();
+    try {
+        writeFixture(dir, sampleState());
+        // Array con clave peligrosa adjunta: sigue siendo array de enteros en índices,
+        // pero la validación de permutación exacta lo rechaza igual (largo 3 vs 3 ok,
+        // pero .every corre sobre índices — la clave __proto__ no es índice).
+        const evil = [2, 3, 4];
+        evil.__proto__.polluted = 'x'; // eslint-disable-line no-proto
+        try {
+            waves.reorderPlannedWaves(evil);
+            assert.equal(({}).polluted, undefined, 'Object.prototype no debe quedar contaminado');
+        } finally {
+            delete Object.prototype.polluted;
+        }
+    } finally {
+        teardownTmp(dir);
+    }
+});
+
+// ─── (4) fallo parcial → estado consistente (CA-7) ────────────────────────
+
+test('reorderPlannedWaves: fallo de rename deja el estado original intacto (CA-7)', () => {
+    const dir = setupTmp();
+    try {
+        writeFixture(dir, sampleState());
+        const before = fs.readFileSync(path.join(dir, 'waves.json'), 'utf8');
+        const origRename = fs.renameSync;
+        fs.renameSync = () => { const e = new Error('IO simulado'); e.code = 'EIO'; throw e; };
+        try {
+            assert.throws(() => waves.reorderPlannedWaves([4, 3, 2]), /EIO|IO simulado/i);
+        } finally {
+            fs.renameSync = origRename;
+        }
+        assert.equal(fs.readFileSync(path.join(dir, 'waves.json'), 'utf8'), before, 'estado original intacto');
+        assert.ok(!fs.existsSync(path.join(dir, 'waves.json.tmp')), 'sin .tmp huérfano');
+    } finally {
+        teardownTmp(dir);
+    }
+});
+
+// ─── (5) audit trail ──────────────────────────────────────────────────────
+
+test('reorderPlannedWaves: note por defecto describe orden previo→nuevo (REQ-SEC-6)', () => {
+    const dir = setupTmp();
+    try {
+        writeFixture(dir, sampleState());
+        waves.reorderPlannedWaves([3, 2, 4]);
+        const note = readDisk(dir).meta.note;
+        assert.match(note, /reorder planned waves/i);
+        assert.match(note, /\[2,3,4\]/);
+        assert.match(note, /\[3,2,4\]/);
+    } finally {
+        teardownTmp(dir);
+    }
+});

--- a/.pipeline/lib/commander-deterministic.js
+++ b/.pipeline/lib/commander-deterministic.js
@@ -311,7 +311,9 @@ const LISTADO_FILTERS = new Set([
 // #4376 (split #4351) — `create` suma la creación de olas planificadas desde
 // Telegram (`/wave create --nombre ... --issues #1,#2 ...`). Op mutante: reusa
 // el cooldown/allowlist/rate-limit del resto de subcomandos mutantes.
-const WAVE_SUBCOMMANDS = new Set(['status', 'next', 'add', 'promote', 'create']);
+// #4377 — H8.3 Parte B suma `remove` (desasociar issue de ola planificada) y
+// `reorder` (permutar orden de olas planificadas). Ambos destructivos.
+const WAVE_SUBCOMMANDS = new Set(['status', 'next', 'add', 'promote', 'create', 'remove', 'reorder']);
 
 /**
  * Parsea `args` de `/wave` y devuelve `{ subcommand, audio, waveNumber, issueNumber }`
@@ -322,6 +324,8 @@ const WAVE_SUBCOMMANDS = new Set(['status', 'next', 'add', 'promote', 'create'])
  *   - `status [--audio]`         → status con audio opt-in.
  *   - `next`                     → próxima ola, sin args extra.
  *   - `add <num> #issue`         → `num` entero positivo, `#issue` matchea `^#\d+$`.
+ *   - `remove <num> #issue`      → mismo gate estricto que `add` (#4377 CA-8).
+ *   - `reorder <n1> <n2> [...]`  → ≥2 enteros positivos, sin duplicados (#4377 CA-8).
  *   - `promote`                  → promote, sin args extra.
  *   - Cualquier otra combinación devuelve `null` (handler genera error claro).
  */
@@ -363,6 +367,35 @@ function parseWaveArgs(rawArgs) {
         const issueNumber = parseInt(issueToken.slice(1), 10);
         if (!Number.isInteger(issueNumber) || issueNumber < 1) return null;
         return { subcommand: 'add', waveNumber, issueNumber };
+    }
+    if (head === 'remove') {
+        // #4377 CA-8 — MISMO gate estricto que `add`: exactamente 3 tokens.
+        if (tokens.length !== 3) return null;
+        const numToken = tokens[1];
+        const issueToken = tokens[2];
+        if (!/^\d+$/.test(numToken)) return null;
+        const waveNumber = parseInt(numToken, 10);
+        if (!Number.isInteger(waveNumber) || waveNumber < 1) return null;
+        if (!/^#\d+$/.test(issueToken)) return null;
+        const issueNumber = parseInt(issueToken.slice(1), 10);
+        if (!Number.isInteger(issueNumber) || issueNumber < 1) return null;
+        return { subcommand: 'remove', waveNumber, issueNumber };
+    }
+    if (head === 'reorder') {
+        // #4377 CA-8 — lista de `number`: ≥2 enteros positivos decimales puros,
+        // sin duplicados. La validación de permutación exacta contra el estado
+        // real vive en `waves.reorderPlannedWaves` (server-side).
+        const numTokens = tokens.slice(1);
+        if (numTokens.length < 2) return null;
+        const order = [];
+        for (const t of numTokens) {
+            if (!/^\d+$/.test(t)) return null;
+            const num = parseInt(t, 10);
+            if (!Number.isInteger(num) || num < 1) return null;
+            order.push(num);
+        }
+        if (new Set(order).size !== order.length) return null; // sin duplicados
+        return { subcommand: 'reorder', order };
     }
     if (head === 'create') {
         // #4376 — parseo por flags nombrados (texto libre con espacios). Toda la
@@ -1207,9 +1240,11 @@ function buildDefaultHandlers(ctx) {
     // 60s porque las mutaciones son granulares y la idempotencia de
     // `waves.addIssueToWave` (no-op si ya está) ya cubre el doble-tap accidental.
     // CA-9 — destructiveCooldown MUST en add/promote (refuerzo security pt.3).
+    // #4377 REQ-SEC-5 — `wave-remove` y `wave-reorder` también mutan estado
+    // irreversible → cooldown destructivo obligatorio.
     const waveSubCooldown = createDestructiveCooldown({
         cooldownMs: 30 * 1000,
-        destructiveCommands: ['wave-add', 'wave-promote', 'wave-create'],
+        destructiveCommands: ['wave-add', 'wave-promote', 'wave-create', 'wave-remove', 'wave-reorder'],
         now: ctx.now,
     });
 
@@ -1572,6 +1607,25 @@ function buildDefaultHandlers(ctx) {
                 case 'promote':
                     res = await handleWavePromote({
                         pipelineRoot: PIPELINE,
+                        cooldown: waveSubCooldown,
+                        chatId: message && message.chat_id !== undefined ? String(message.chat_id) : null,
+                        from: message && message.from ? String(message.from) : 'Leo',
+                    });
+                    break;
+                case 'remove':
+                    res = await handleWaveRemove({
+                        pipelineRoot: PIPELINE,
+                        waveNumber: parsed.waveNumber,
+                        issueNumber: parsed.issueNumber,
+                        cooldown: waveSubCooldown,
+                        chatId: message && message.chat_id !== undefined ? String(message.chat_id) : null,
+                        from: message && message.from ? String(message.from) : 'Leo',
+                    });
+                    break;
+                case 'reorder':
+                    res = await handleWaveReorder({
+                        pipelineRoot: PIPELINE,
+                        order: parsed.order,
                         cooldown: waveSubCooldown,
                         chatId: message && message.chat_id !== undefined ? String(message.chat_id) : null,
                         from: message && message.from ? String(message.from) : 'Leo',
@@ -2745,6 +2799,186 @@ async function handleWavePromote({ pipelineRoot, cooldown, chatId, from }) {
 }
 
 /**
+ * `/wave remove <num> #issue` — Desasocia un issue de una ola PLANIFICADA.
+ * #4377 CA-2. Aplica:
+ *   - destructiveCooldown (REQ-SEC-5, MUST).
+ *   - Política A04 (REQ-SEC-3): rechazo si la ola es la ACTIVA. El enforcement
+ *     real vive en `waves.removeIssueFromWave`; acá lo detectamos temprano para
+ *     dar un mensaje accionable (UX guideline 1) sin depender del throw.
+ *   - No-op idempotente con confirmación explícita si el issue no pertenecía
+ *     (UX guideline 2).
+ *   - Read-fresh (`invalidateCache`) + atomic write (vía `waves.removeIssueFromWave`).
+ */
+async function handleWaveRemove({ pipelineRoot, waveNumber, issueNumber, cooldown, chatId, from }) {
+    // REQ-SEC-5 — Cooldown previo. Defensa contra doble-tap accidental.
+    if (cooldown && chatId) {
+        const cd = cooldown.check(chatId, 'wave-remove');
+        if (!cd.allowed) {
+            return {
+                reply: fillTemplate('wave-error', {
+                    'error-kind': 'cooldown_blocked',
+                    message: `Esperá ${humanizeRetryAfter(cd.retryAfterMs)} antes de repetir \`/wave remove\` (anti doble-tap).`,
+                }),
+            };
+        }
+    }
+
+    const waves = require('./waves');
+    waves.invalidateCache();
+    const state = waves.loadWaves();
+    const active = state.active_wave || null;
+    const planned = Array.isArray(state.planned_waves) ? state.planned_waves : [];
+
+    // Política A04 (REQ-SEC-3): mensaje accionable si apuntan a la ola activa.
+    if (active && active.number === waveNumber) {
+        return {
+            reply: fillTemplate('wave-error', {
+                'error-kind': 'active_wave_locked',
+                message: `La ola \`${waveNumber}\` está *activa*: desasociar ahí re-sincronizaría la allowlist, así que está bloqueado. Sólo se puede desasociar de olas *planificadas* — mirá \`/wave next\` para ver cuáles.`,
+            }),
+        };
+    }
+
+    const target = planned.find((w) => w.number === waveNumber);
+    if (!target) {
+        return {
+            reply: fillTemplate('wave-error', {
+                'error-kind': 'wave_not_found',
+                message: `No encontré la ola planificada \`${waveNumber}\`. Olas disponibles: ${describeAvailableWaves(active, planned)}.`,
+            }),
+        };
+    }
+
+    // ¿El issue pertenecía a la ola? Define no-op vs removido (UX guideline 2).
+    const wasPresent = Array.isArray(target.issues)
+        && target.issues.some((i) => Number(String(i.number).replace(/^#/, '')) === issueNumber);
+
+    try {
+        waves.removeIssueFromWave(waveNumber, issueNumber, {
+            updated_by: from || 'Leo',
+            source: 'telegram-commander/wave-remove',
+            note: `remove issue #${issueNumber} ← wave ${waveNumber}`,
+        });
+    } catch (e) {
+        return {
+            reply: fillTemplate('wave-error', {
+                'error-kind': 'fs_error',
+                message: `Algo falló escribiendo el estado: ${String(e && e.message ? e.message : e)}`,
+            }),
+        };
+    }
+
+    if (cooldown && chatId) cooldown.recordSuccess(chatId, 'wave-remove');
+
+    if (!wasPresent) {
+        return {
+            reply: fillTemplate('wave-remove-noop', {
+                'issue-number': issueNumber,
+                'wave-number': waveNumber,
+                'wave-name': target.name || `Ola ${waveNumber}`,
+            }),
+        };
+    }
+
+    // Releer para reportar el tamaño actualizado de la ola.
+    waves.invalidateCache();
+    const refreshed = waves.loadWaves();
+    const refreshedTarget = (refreshed.planned_waves || []).find((w) => w.number === waveNumber);
+    const newSize = refreshedTarget && Array.isArray(refreshedTarget.issues)
+        ? refreshedTarget.issues.length
+        : 0;
+
+    return {
+        reply: fillTemplate('wave-remove-ok', {
+            'issue-number': issueNumber,
+            'wave-number': waveNumber,
+            'wave-name': target.name || `Ola ${waveNumber}`,
+            'new-size': newSize,
+        }),
+    };
+}
+
+/**
+ * `/wave reorder <n1> <n2> [...]` — Reordena las olas PLANIFICADAS.
+ * #4377 CA-3. Aplica:
+ *   - destructiveCooldown (REQ-SEC-5, MUST).
+ *   - Validación de permutación exacta: la impone `waves.reorderPlannedWaves`
+ *     server-side; acá pre-computamos faltantes/sobrantes para dar un mensaje
+ *     específico (UX guideline 4) antes de tocar el estado.
+ *   - Read-fresh + atomic write (vía `waves.reorderPlannedWaves`).
+ *   - Mensaje de éxito con orden previo → nuevo (UX guideline 3).
+ */
+async function handleWaveReorder({ pipelineRoot, order, cooldown, chatId, from }) {
+    if (cooldown && chatId) {
+        const cd = cooldown.check(chatId, 'wave-reorder');
+        if (!cd.allowed) {
+            return {
+                reply: fillTemplate('wave-error', {
+                    'error-kind': 'cooldown_blocked',
+                    message: `Esperá ${humanizeRetryAfter(cd.retryAfterMs)} antes de repetir \`/wave reorder\` (anti doble-tap).`,
+                }),
+            };
+        }
+    }
+
+    const waves = require('./waves');
+    waves.invalidateCache();
+    const state = waves.loadWaves();
+    const planned = Array.isArray(state.planned_waves) ? state.planned_waves : [];
+    const current = planned.map((w) => w.number);
+
+    if (current.length < 2) {
+        return {
+            reply: fillTemplate('wave-error', {
+                'error-kind': 'not_enough_waves',
+                message: `Necesitás al menos 2 olas planificadas para reordenar. Ahora hay ${current.length}.`,
+            }),
+        };
+    }
+
+    // UX guideline 4 — mensaje específico: qué number falta o cuál no existe.
+    const currentSet = new Set(current);
+    const orderSet = new Set(order);
+    const missing = current.filter((n) => !orderSet.has(n));
+    const unknown = order.filter((n) => !currentSet.has(n));
+    if (missing.length > 0 || unknown.length > 0) {
+        const parts = [];
+        if (missing.length > 0) parts.push(`falta(n): ${missing.join(', ')}`);
+        if (unknown.length > 0) parts.push(`no existe(n): ${unknown.join(', ')}`);
+        return {
+            reply: fillTemplate('wave-error', {
+                'error-kind': 'not_a_permutation',
+                message: `El nuevo orden tiene que ser una permutación exacta de las olas planificadas [${current.join(', ')}]. Problema: ${parts.join(' · ')}.`,
+            }),
+        };
+    }
+
+    try {
+        waves.reorderPlannedWaves(order, {
+            updated_by: from || 'Leo',
+            source: 'telegram-commander/wave-reorder',
+            note: `reorder planned waves [${current.join(', ')}] → [${order.join(', ')}]`,
+        });
+    } catch (e) {
+        return {
+            reply: fillTemplate('wave-error', {
+                'error-kind': 'fs_error',
+                message: `Algo falló reordenando las olas: ${String(e && e.message ? e.message : e)}`,
+            }),
+        };
+    }
+
+    if (cooldown && chatId) cooldown.recordSuccess(chatId, 'wave-reorder');
+
+    return {
+        reply: fillTemplate('wave-reorder-ok', {
+            'prev-order': current.join(', '),
+            'new-order': order.join(', '),
+        }),
+    };
+}
+
+/**
  * Helper de UX: humaniza las olas disponibles para el mensaje de error
  * `wave_not_found`. Devuelve algo como "1 (activa) o 2, 3".
  */
@@ -2941,6 +3175,8 @@ module.exports = {
         handleWaveAdd,
         handleWavePromote,
         handleWaveCreate,
+        handleWaveRemove,
+        handleWaveReorder,
         getKnownIssues,
         invalidateKnownIssuesCache,
         describeAvailableWaves,

--- a/.pipeline/lib/commander/templates/wave-remove-noop.md
+++ b/.pipeline/lib/commander/templates/wave-remove-noop.md
@@ -1,0 +1,3 @@
+ℹ️ *\#{{issue-number}}* no pertenecía a la *ola \#{{wave-number}}* \("{{wave-name}}"\)
+
+_No se cambió nada — la operación es idempotente\._

--- a/.pipeline/lib/commander/templates/wave-remove-ok.md
+++ b/.pipeline/lib/commander/templates/wave-remove-ok.md
@@ -1,0 +1,5 @@
+✅ *\#{{issue-number}}* desasociado de *ola \#{{wave-number}}*
+
+_Ola "{{wave-name}}" tiene ahora *{{new-size}}* issue\(s\)._
+
+_Cambio versionado en `.pipeline/waves.json` · source `telegram-commander/wave-remove`_

--- a/.pipeline/lib/commander/templates/wave-reorder-ok.md
+++ b/.pipeline/lib/commander/templates/wave-reorder-ok.md
@@ -1,0 +1,8 @@
+✅ *Olas planificadas reordenadas*
+
+*Orden previo:* {{prev-order}}
+*Orden nuevo:* {{new-order}}
+
+_El `number` \(identidad\) de cada ola se preservó — sólo cambió el orden de procesamiento\._
+
+_Cambio versionado en `.pipeline/waves.json` · source `telegram-commander/wave-reorder`_

--- a/.pipeline/lib/waves.js
+++ b/.pipeline/lib/waves.js
@@ -403,7 +403,135 @@ function addIssueToWaveLocked(waveNumber, issue, n, meta) {
 }
 
 /**
+ * Desasocia un issue de una ola PLANIFICADA. Sigue el patrón canónico
+ * `fn()`+`fnLocked()` de `addIssueToWave`: el read-modify-write completo corre
+ * bajo `withLockSync` (reentrante — el `saveState` interno comparte el lock).
+ *
+ * Política A04 (#4377 CA-2 / REQ-SEC-3): se RECHAZA desasociar sobre la ola
+ * ACTIVA. Tocar la activa dispararía un re-sync de la allowlist (dep #4350,
+ * fuera de scope). El enforcement vive acá, en el código — el chip
+ * `ic-shield-lock` de UX es solo señalización cosmética, no defensa.
+ *
+ * Idempotencia (CA-2): si el issue no pertenece a la ola, es no-op sin escritura
+ * espuria (no `saveState`).
+ *
+ * @example
+ *   removeIssueFromWave(2, 3460, { updated_by: 'Commander', note: 'mal asignado' });
+ *
+ * @param {number} waveNumber — number de la ola planificada destino.
+ * @param {number|string} issueNumber — issue a remover (tolera "#123" / " 123 ").
+ * @param {Object} [meta] — { updated_by?: string, source?: string, note?: string }
+ * @throws si `issueNumber` es inválido, la ola es la activa, o la ola no existe.
+ */
+function removeIssueFromWave(waveNumber, issueNumber, meta = {}) {
+    const n = normalizeIssue(issueNumber);
+    if (!n) {
+        throw new Error(`removeIssueFromWave: issue.number inválido (${issueNumber})`);
+    }
+    return withLockSync(wavesFile(), () => removeIssueFromWaveLocked(waveNumber, n, meta), {
+        component: 'waves-lock',
+        timeoutMs: LOCK_TIMEOUT_MS,
+        maxRetries: LOCK_MAX_RETRIES,
+        notify: notifyTelegram,
+    });
+}
+
+function removeIssueFromWaveLocked(waveNumber, n, meta) {
+    // CA-7: invalidar cache ANTES de leer para ver el último commit en disco.
+    invalidateCache();
+    const state = loadWaves();
+
+    // Política A04 (REQ-SEC-3): rechazar si el target es la ola ACTIVA.
+    if (state.active_wave && state.active_wave.number === waveNumber) {
+        throw new Error(`removeIssueFromWave: no se permite desasociar sobre la ola activa (${waveNumber}). Solo olas planificadas.`);
+    }
+
+    const target = (state.planned_waves || []).find((w) => w.number === waveNumber);
+    if (!target) {
+        throw new Error(`removeIssueFromWave: ola planificada ${waveNumber} no existe`);
+    }
+
+    // No-op idempotente (CA-2): el issue no está en la ola → sin saveState.
+    if (!Array.isArray(target.issues) || !target.issues.some((i) => normalizeIssue(i.number) === n)) {
+        logInfo(`Issue #${n} no está en ola ${waveNumber} — no-op idempotente.`);
+        return;
+    }
+
+    target.issues = target.issues.filter((i) => normalizeIssue(i.number) !== n);
+    logInfo(`Issue #${n} removido de ola ${waveNumber}.`);
+    saveState(state, {
+        updated_by: meta.updated_by || 'System',
+        source: meta.source || 'manual',
+        note: meta.note || `remove issue #${n} ← wave ${waveNumber}`,
+    });
+}
+
+/**
+ * Reordena las olas PLANIFICADAS según `newOrder` (lista de `number`). Sólo
+ * permuta el orden del array `planned_waves`; el `number` (identidad) de cada
+ * ola queda intacto — cambia el orden de PROCESAMIENTO, no la identidad.
+ *
+ * Validación estricta ANTES de mutar (CA-3 + REQ-SEC-1/2): `newOrder` debe ser
+ * un array de enteros ≥1 (cierra prototype pollution — un array de primitivos
+ * no lleva `__proto__`/`constructor` como claves) y una PERMUTACIÓN EXACTA del
+ * multiset de `number` actuales: mismo largo, sin duplicados, sin faltantes,
+ * sin `number` inexistentes. Cualquier input que no sea permutación se rechaza
+ * sin persistir (nada de escritura parcial).
+ *
+ * @example
+ *   reorderPlannedWaves([3, 2], { updated_by: 'Planner', note: 'priorizar N+9' });
+ *
+ * @param {number[]} newOrder — permutación exacta de los `number` planificados.
+ * @param {Object} [meta] — { updated_by?: string, source?: string, note?: string }
+ * @throws si `newOrder` no es array de enteros ≥1 o no es permutación exacta.
+ */
+function reorderPlannedWaves(newOrder, meta = {}) {
+    return withLockSync(wavesFile(), () => reorderPlannedWavesLocked(newOrder, meta), {
+        component: 'waves-lock',
+        timeoutMs: LOCK_TIMEOUT_MS,
+        maxRetries: LOCK_MAX_RETRIES,
+        notify: notifyTelegram,
+    });
+}
+
+function reorderPlannedWavesLocked(newOrder, meta) {
+    // CA-7: leer el último commit en disco.
+    invalidateCache();
+    const state = loadWaves();
+
+    // Tipo estricto (REQ-SEC-2): array de enteros ≥1. Rechaza no-array, floats,
+    // negativos, NaN y strings. Un array de enteros no puede vehicular
+    // prototype pollution (las claves peligrosas viajan en objetos, no acá).
+    if (!Array.isArray(newOrder) || !newOrder.every((x) => Number.isInteger(x) && x >= 1)) {
+        throw new Error('reorderPlannedWaves: newOrder debe ser un array de enteros ≥ 1');
+    }
+
+    const current = (state.planned_waves || []).map((w) => w.number);
+
+    // Permutación exacta: mismo multiset, sin duplicados, sin faltantes,
+    // sin `number` inexistentes. Comparamos ordenados + sin duplicados.
+    const sortedA = [...current].sort((a, b) => a - b);
+    const sortedB = [...newOrder].sort((a, b) => a - b);
+    const isPerm = sortedA.length === sortedB.length
+        && sortedA.every((v, i) => v === sortedB[i])
+        && new Set(newOrder).size === newOrder.length;
+    if (!isPerm) {
+        throw new Error(`reorderPlannedWaves: newOrder no es permutación exacta de ${JSON.stringify(current)} (recibido ${JSON.stringify(newOrder)})`);
+    }
+
+    // Permutar SOLO el orden del array; `number` (identidad) intacto.
+    state.planned_waves = newOrder.map((num) => state.planned_waves.find((w) => w.number === num));
+    logInfo(`Olas planificadas reordenadas: ${JSON.stringify(current)} → ${JSON.stringify(newOrder)}.`);
+    saveState(state, {
+        updated_by: meta.updated_by || 'System',
+        source: meta.source || 'manual',
+        note: meta.note || `reorder planned waves ${JSON.stringify(current)} → ${JSON.stringify(newOrder)}`,
+    });
+}
+
+/**
  * Promueve una ola planificada a activa. La ola activa anterior (si existe)
+ * pasa a archived_waves con métricas de cierre.
  * pasa a archived_waves con métricas de cierre.
  *
  * @example
@@ -1669,6 +1797,8 @@ module.exports = {
     getActiveWave,
     getPlannedWave,
     addIssueToWave,
+    removeIssueFromWave,
+    reorderPlannedWaves,
     promoteWaveToActive,
     createPlannedWave,
     getAllowlist,

--- a/.pipeline/scripts/planner-waves-cli.js
+++ b/.pipeline/scripts/planner-waves-cli.js
@@ -269,6 +269,62 @@ function cmdComponerOla(rawN, opts) {
     }
 }
 
+/**
+ * `desasociar <ola> <issue>` — Quita un issue de una ola PLANIFICADA (#4377).
+ * Delega en `waves.removeIssueFromWave`, que impone la Política A04 (rechazo
+ * sobre la ola activa) y el no-op idempotente. Toda la integridad (lock +
+ * atomic + backup + audit) la garantiza la lib.
+ */
+function cmdDesasociar(rawWave, rawIssue) {
+    if (!/^\d+$/.test(String(rawWave)) || !/^\d+$/.test(String(rawIssue))) {
+        die(1, 'Uso: desasociar <ola> <issue> — ambos enteros positivos');
+    }
+    const waveNumber = parseInt(rawWave, 10);
+    const issueNumber = parseInt(rawIssue, 10);
+    if (waveNumber < 1 || issueNumber < 1) {
+        die(1, 'desasociar: ola e issue deben ser enteros ≥ 1');
+    }
+    try {
+        waves.removeIssueFromWave(waveNumber, issueNumber, {
+            updated_by: 'Planner', source: 'planner-waves-cli/desasociar',
+        });
+    } catch (err) {
+        die(2, err.message);
+    }
+    process.stdout.write(`✅ Issue #${issueNumber} desasociado de la ola planificada ${waveNumber} (o no-op si no pertenecía).\n`);
+}
+
+/**
+ * `reordenar <n1> <n2> [...]` — Permuta el orden de las olas PLANIFICADAS
+ * (#4377). Delega en `waves.reorderPlannedWaves`, que valida permutación exacta
+ * (mismo multiset, sin duplicados/faltantes/inexistentes) ANTES de persistir.
+ */
+function cmdReordenar(rawOrder) {
+    if (!Array.isArray(rawOrder) || rawOrder.length < 2) {
+        die(1, 'Uso: reordenar <n1> <n2> [...] — al menos 2 números de ola');
+    }
+    const order = [];
+    for (const t of rawOrder) {
+        if (!/^\d+$/.test(String(t))) {
+            die(1, `reordenar: "${t}" no es un entero positivo`);
+        }
+        const num = parseInt(t, 10);
+        if (num < 1) die(1, `reordenar: "${t}" debe ser ≥ 1`);
+        order.push(num);
+    }
+    if (new Set(order).size !== order.length) {
+        die(1, `reordenar: hay números de ola duplicados en [${order.join(', ')}]`);
+    }
+    try {
+        waves.reorderPlannedWaves(order, {
+            updated_by: 'Planner', source: 'planner-waves-cli/reordenar',
+        });
+    } catch (err) {
+        die(2, err.message);
+    }
+    process.stdout.write(`✅ Olas planificadas reordenadas a [${order.join(', ')}].\n`);
+}
+
 // #4376 (split #4351) — crear-ola: crea una ola planificada sin editar el JSON
 // a mano. Reusa `createPlannedWave` (único punto de mutación, CA-3) y la MISMA
 // validación de input que el subcomando Commander `/wave create`
@@ -369,7 +425,7 @@ function renderRoadmap(wavesList) {
 function main(argv) {
     const [, , cmd, ...rest] = argv;
     if (!cmd) {
-        die(4, 'Uso: olas | roadmap | horizonte <N> | componer-ola <N> [--force] [--json] | crear-ola --nombre <n> --concurrency <c> --window <m> --issues <#a #b> [--objetivo <o>]');
+        die(4, 'Uso: olas | roadmap | horizonte <N> | componer-ola <N> [--force] [--json] | crear-ola --nombre <n> --concurrency <c> --window <m> --issues <#a #b> [--objetivo <o>] | desasociar <ola> <issue> | reordenar <n1> <n2> [...]');
     }
 
     const opts = {
@@ -391,8 +447,14 @@ function main(argv) {
             return cmdCrearOla(rest);
         case 'roadmap':
             return cmdRoadmap();
+        case 'desasociar':
+            if (positional.length < 2) die(4, 'Uso: desasociar <ola> <issue>');
+            return cmdDesasociar(positional[0], positional[1]);
+        case 'reordenar':
+            if (positional.length < 2) die(4, 'Uso: reordenar <n1> <n2> [...]');
+            return cmdReordenar(positional);
         default:
-            die(4, `Comando desconocido: ${cmd}. Válidos: olas, roadmap, horizonte, componer-ola, crear-ola`);
+            die(4, `Comando desconocido: ${cmd}. Válidos: olas, roadmap, horizonte, componer-ola, crear-ola, desasociar, reordenar`);
     }
 }
 


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 9 archivos · +1076 -4

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:skipped` aplicado por delivery

## Closes

Closes #4377
