### PR TITLE
Persistencia robusta del roadmap de olas ante reinicios

### DIFF
--- a/.pipeline/lib/__tests__/waves-integrity.test.js
+++ b/.pipeline/lib/__tests__/waves-integrity.test.js
@@ -1,0 +1,348 @@
+// =============================================================================
+// waves-integrity.test.js — #4370 · Persistencia robusta del roadmap de olas.
+//
+// Cubre los caminos nuevos de hardening sobre `lib/waves.js`:
+//   CA-2  restore corre validateStateStrict ANTES de promover (fail-closed).
+//   CA-3  restore exige contención de path (archived/) + whitelist de nombre.
+//   CA-4  integrity_hash persistido + verificación (ok/missing/mismatch).
+//   CA-5  validateStateStrict rechaza issue.number no-entero y campos no-string.
+//   CA-6  rotación conserva N backups, loguea descartes, respeta markers vivos.
+//   CA-9  waves.json legacy sin hash carga OK y se sella en el primer save.
+//
+// Ejecutar:  node --test .pipeline/lib/__tests__/waves-integrity.test.js
+// =============================================================================
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const crypto = require('node:crypto');
+
+function setupTmp() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'waves-integrity-'));
+    process.env.PIPELINE_DIR_OVERRIDE = dir;
+    delete require.cache[require.resolve('../waves')];
+    const waves = require('../waves');
+    waves.invalidateCache();
+    return { dir, waves };
+}
+
+function teardownTmp(dir) {
+    delete process.env.PIPELINE_DIR_OVERRIDE;
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+}
+
+function validState(overrides = {}) {
+    return {
+        version: '1.0',
+        meta: {
+            created_at: '2026-07-01T00:00:00.000Z',
+            updated_at: '2026-07-01T00:00:00.000Z',
+            updated_by: 'System',
+            source: 'manual',
+            note: 'seed',
+        },
+        active_wave: {
+            number: 7,
+            name: 'Ola N+7',
+            goal: null,
+            issues: [{ number: 3451, status: 'in_progress' }],
+        },
+        planned_waves: [{ number: 8, name: 'Ola N+8', issues: [{ number: 3520 }] }],
+        archived_waves: [],
+        dependencies: [],
+        ...overrides,
+    };
+}
+
+function sha256File(p) {
+    return crypto.createHash('sha256').update(fs.readFileSync(p)).digest('hex');
+}
+
+function writeBackup(dir, name, content) {
+    const archived = path.join(dir, 'archived');
+    fs.mkdirSync(archived, { recursive: true });
+    const p = path.join(archived, name);
+    fs.writeFileSync(p, typeof content === 'string' ? content : JSON.stringify(content, null, 2));
+    return p;
+}
+
+// ─── CA-4 — hash de integridad canónico ──────────────────────────────────────
+
+test('CA-4: computeIntegrityHash omite el propio campo y es estable ante reordenamiento de claves', () => {
+    const { dir, waves } = setupTmp();
+    try {
+        const a = validState();
+        const h1 = waves.computeIntegrityHash(a);
+        // Reordenar claves top-level + agregar un integrity_hash falso: el hash
+        // no debe cambiar (el campo se omite y el orden es canónico).
+        const b = { integrity_hash: 'deadbeef', dependencies: a.dependencies, meta: a.meta, version: a.version, active_wave: a.active_wave, planned_waves: a.planned_waves, archived_waves: a.archived_waves };
+        const h2 = waves.computeIntegrityHash(b);
+        assert.equal(h1, h2);
+        assert.match(h1, /^[0-9a-f]{64}$/);
+    } finally {
+        teardownTmp(dir);
+    }
+});
+
+test('CA-4/CA-9: primer save sella integrity_hash y verifyIntegrityHash da OK', () => {
+    const { dir, waves } = setupTmp();
+    try {
+        waves._internal.saveState(validState(), { source: 'manual', note: 'test' });
+        const persisted = JSON.parse(fs.readFileSync(path.join(dir, 'waves.json'), 'utf8'));
+        assert.match(persisted.integrity_hash, /^[0-9a-f]{64}$/);
+        assert.equal(waves.verifyIntegrityHash(persisted).status, 'ok');
+        assert.equal(waves.checkStateIntegrity().status, 'ok');
+    } finally {
+        teardownTmp(dir);
+    }
+});
+
+test('CA-4: alterar 1 byte fuera del flujo normal → verifyIntegrityHash mismatch + loadStateStrict tira EWAVES_INTEGRITY', () => {
+    const { dir, waves } = setupTmp();
+    try {
+        waves._internal.saveState(validState(), { source: 'manual' });
+        const p = path.join(dir, 'waves.json');
+        const parsed = JSON.parse(fs.readFileSync(p, 'utf8'));
+        // Tamper: cambiar un campo sin recomputar el hash.
+        parsed.active_wave.name = 'Ola HACKEADA';
+        fs.writeFileSync(p, JSON.stringify(parsed, null, 2));
+
+        assert.equal(waves.verifyIntegrityHash(parsed).status, 'mismatch');
+        assert.equal(waves.checkStateIntegrity().status, 'mismatch');
+        waves.invalidateCache();
+        assert.throws(() => waves.loadStateStrict(), (e) => e.code === 'EWAVES_INTEGRITY');
+    } finally {
+        teardownTmp(dir);
+    }
+});
+
+test('CA-9: waves.json legacy sin integrity_hash carga OK (missing) y se sella en el próximo save', () => {
+    const { dir, waves } = setupTmp();
+    try {
+        // Legacy: escrito a mano SIN integrity_hash.
+        fs.writeFileSync(path.join(dir, 'waves.json'), JSON.stringify(validState(), null, 2));
+        assert.equal(waves.checkStateIntegrity().status, 'missing');
+        // loadStateStrict NO tira para legacy (missing se tolera).
+        assert.doesNotThrow(() => waves.loadStateStrict());
+        // Primer save lo sella.
+        waves._internal.saveState(waves.loadWaves(), { source: 'manual' });
+        assert.equal(waves.checkStateIntegrity().status, 'ok');
+    } finally {
+        teardownTmp(dir);
+    }
+});
+
+// ─── CA-5 — validación estricta de tipos ─────────────────────────────────────
+
+test('CA-5: validateStateStrict rechaza issue.number string', () => {
+    const { dir, waves } = setupTmp();
+    try {
+        const bad = validState();
+        bad.active_wave.issues = [{ number: '3451' }];
+        const errors = waves.validateStateStrict(bad);
+        assert.ok(errors.some((e) => /issues\[0\]\.number debe ser entero/.test(e)), errors.join('|'));
+    } finally {
+        teardownTmp(dir);
+    }
+});
+
+test('CA-5: validateStateStrict rechaza campos libres no-string (name objeto, note number)', () => {
+    const { dir, waves } = setupTmp();
+    try {
+        const bad = validState();
+        bad.active_wave.name = { $gt: '' };
+        bad.meta.note = 12345;
+        const errors = waves.validateStateStrict(bad);
+        assert.ok(errors.some((e) => /active_wave\.name debe ser string/.test(e)), errors.join('|'));
+        assert.ok(errors.some((e) => /meta\.note debe ser string/.test(e)), errors.join('|'));
+    } finally {
+        teardownTmp(dir);
+    }
+});
+
+test('CA-5: validateStateStrict tolera null en campos libres (goal: null) y acepta estado válido', () => {
+    const { dir, waves } = setupTmp();
+    try {
+        assert.deepEqual(waves.validateStateStrict(validState()), []);
+    } finally {
+        teardownTmp(dir);
+    }
+});
+
+test('CA-6: validateStateStrict rechaza arrays que exceden el límite anti-OOM', () => {
+    const { dir, waves } = setupTmp();
+    try {
+        const bad = validState();
+        bad.planned_waves = Array.from({ length: 501 }, (_, i) => ({ number: i + 1, issues: [] }));
+        const errors = waves.validateStateStrict(bad);
+        assert.ok(errors.some((e) => /planned_waves excede el límite/.test(e)), errors.join('|'));
+    } finally {
+        teardownTmp(dir);
+    }
+});
+
+// ─── CA-2 / CA-3 — restore hardening ─────────────────────────────────────────
+
+test('CA-3: restore rechaza marker con path fuera de archived/ aunque el SHA coincida', () => {
+    const { dir, waves } = setupTmp();
+    try {
+        // Backup "legítimo por contenido" pero ubicado FUERA de archived/.
+        const outside = path.join(dir, 'evil-waves.json');
+        fs.writeFileSync(outside, JSON.stringify(validState(), null, 2));
+        const marker = {
+            waves_bak_path: outside,
+            waves_bak_sha: sha256File(outside), // SHA correcto → el atacante controla el marker.
+        };
+        const res = waves._internal.restoreFromSnapshots(marker);
+        assert.equal(res.ok, false);
+        assert.match(res.reason, /contención de path/);
+        // El estado activo no fue tocado (no existe waves.json aún).
+        assert.equal(fs.existsSync(path.join(dir, 'waves.json')), false);
+    } finally {
+        teardownTmp(dir);
+    }
+});
+
+test('CA-3: restore rechaza nombre de backup que no matchea la whitelist', () => {
+    const { dir, waves } = setupTmp();
+    try {
+        const bak = writeBackup(dir, 'waves.2026-07-01.json', validState()); // nombre NO whitelisted (falta -rollback)
+        const marker = { waves_bak_path: bak, waves_bak_sha: sha256File(bak) };
+        const res = waves._internal.restoreFromSnapshots(marker);
+        assert.equal(res.ok, false);
+        assert.match(res.reason, /whitelist/);
+    } finally {
+        teardownTmp(dir);
+    }
+});
+
+test('CA-2: restore rechaza .bak con shape inválido (validateStateStrict pre-promote, no promueve)', () => {
+    const { dir, waves } = setupTmp();
+    try {
+        // Estado activo bueno previo.
+        waves._internal.saveState(validState(), { source: 'manual' });
+        const before = fs.readFileSync(path.join(dir, 'waves.json'), 'utf8');
+
+        // Backup parseable pero hostil: issue.number string.
+        const hostile = validState();
+        hostile.active_wave.issues = [{ number: '99; DROP TABLE' }];
+        const bak = writeBackup(dir, 'waves-rollback.2026-07-01T00-00-00-000Z.json', hostile);
+        const marker = { waves_bak_path: bak, waves_bak_sha: sha256File(bak) };
+
+        const res = waves._internal.restoreFromSnapshots(marker);
+        assert.equal(res.ok, false);
+        assert.match(res.reason, /shape inválido|no se promueve|CA-2/);
+        // Estado activo intacto — NO se promovió el hostil.
+        assert.equal(fs.readFileSync(path.join(dir, 'waves.json'), 'utf8'), before);
+    } finally {
+        teardownTmp(dir);
+    }
+});
+
+test('CA-2/CA-3: restore acepta un backup válido dentro de archived/ con nombre whitelisted', () => {
+    const { dir, waves } = setupTmp();
+    try {
+        const good = validState({ active_wave: { number: 9, name: 'Restaurada', goal: null, issues: [{ number: 111 }] } });
+        const bak = writeBackup(dir, 'waves-rollback.2026-07-01T12-00-00-000Z.json', good);
+        const marker = { waves_bak_path: bak, waves_bak_sha: sha256File(bak) };
+        const res = waves._internal.restoreFromSnapshots(marker);
+        assert.equal(res.ok, true);
+        assert.equal(res.wavesRestored, true);
+        const restored = JSON.parse(fs.readFileSync(path.join(dir, 'waves.json'), 'utf8'));
+        assert.equal(restored.active_wave.number, 9);
+    } finally {
+        teardownTmp(dir);
+    }
+});
+
+// ─── CA-6 — rotación de backups ──────────────────────────────────────────────
+
+test('CA-6: rotateArchivedBackups conserva N más recientes y descarta el resto', () => {
+    const { dir, waves } = setupTmp();
+    try {
+        const archived = path.join(dir, 'archived');
+        fs.mkdirSync(archived, { recursive: true });
+        // 30 backups de la familia waves-rollback con mtime creciente.
+        const created = [];
+        for (let i = 0; i < 30; i++) {
+            const name = `waves-rollback.2026-07-01T00-00-${String(i).padStart(2, '0')}-000Z.json`;
+            const p = path.join(archived, name);
+            fs.writeFileSync(p, JSON.stringify(validState(), null, 2));
+            const t = new Date(Date.UTC(2026, 6, 1, 0, 0, i)).getTime();
+            fs.utimesSync(p, t / 1000, t / 1000);
+            created.push(name);
+        }
+        const result = waves.rotateArchivedBackups(10);
+        assert.equal(result.rotated.length, 20);
+        const remaining = fs.readdirSync(archived).filter((f) => /^waves-rollback\./.test(f));
+        assert.equal(remaining.length, 10);
+        // Los 10 más nuevos (índices 20..29) sobreviven.
+        assert.ok(remaining.includes(created[29]));
+        assert.ok(!remaining.includes(created[0]));
+    } finally {
+        teardownTmp(dir);
+    }
+});
+
+test('CA-6: rotación NO toca backups referenciados por un marker in-progress vivo', () => {
+    const { dir, waves } = setupTmp();
+    try {
+        const archived = path.join(dir, 'archived');
+        fs.mkdirSync(archived, { recursive: true });
+        const names = [];
+        for (let i = 0; i < 5; i++) {
+            const name = `waves-rollback.2026-07-01T00-00-0${i}-000Z.json`;
+            const p = path.join(archived, name);
+            fs.writeFileSync(p, JSON.stringify(validState(), null, 2));
+            const t = new Date(Date.UTC(2026, 6, 1, 0, 0, i)).getTime();
+            fs.utimesSync(p, t / 1000, t / 1000);
+            names.push(name);
+        }
+        // Marker in-progress referenciando el backup MÁS VIEJO (que sino sería rotado).
+        fs.writeFileSync(path.join(dir, 'wave-promote.in-progress.json'), JSON.stringify({
+            waves_bak_path: path.join(archived, names[0]),
+        }, null, 2));
+
+        const result = waves.rotateArchivedBackups(2);
+        // El backup referenciado por el marker nunca se rota.
+        assert.ok(!result.rotated.includes(names[0]));
+        assert.ok(fs.existsSync(path.join(archived, names[0])));
+    } finally {
+        teardownTmp(dir);
+    }
+});
+
+// ─── CA-6 — redacción de secretos en note/source ─────────────────────────────
+
+test('CA-6/SEC-5: save redacta secretos en meta.note (API keys) preservando texto normal', () => {
+    const { dir, waves } = setupTmp();
+    try {
+        waves._internal.saveState(validState(), {
+            source: 'telegram',
+            note: 'token AKIAIOSFODNN7EXAMPLE filtrado',
+        });
+        const persisted = JSON.parse(fs.readFileSync(path.join(dir, 'waves.json'), 'utf8'));
+        assert.ok(!/AKIAIOSFODNN7EXAMPLE/.test(persisted.meta.note), `no debe persistir el secreto crudo: ${persisted.meta.note}`);
+    } finally {
+        teardownTmp(dir);
+    }
+});
+
+// ─── CA-8 — backward-compat: loadWaves permisivo sigue verde ─────────────────
+
+test('CA-8: loadWaves (permisivo) tolera waves.json con integrity_hash sin romper consumers', () => {
+    const { dir, waves } = setupTmp();
+    try {
+        waves._internal.saveState(validState(), { source: 'manual' });
+        // Consumer legacy vía loadWaves: no debe explotar ni exponer integrity_hash como clave requerida.
+        const w = waves.loadWaves();
+        assert.equal(w.active_wave.number, 7);
+        assert.ok(Array.isArray(w.planned_waves));
+    } finally {
+        teardownTmp(dir);
+    }
+});

--- a/.pipeline/lib/waves.js
+++ b/.pipeline/lib/waves.js
@@ -37,9 +37,37 @@ const path = require('path');
 const crypto = require('crypto');
 const { withLockSync } = require('./file-lock');
 const { notifyTelegram } = require('./notify-telegram');
+const { redactSecretValue } = require('./redact');
 
 const SCHEMA_VERSION = '1.0';
 const CACHE_TTL_MS = 2000;
+
+// ─── #4370 — Integridad, tipos estrictos y retención del estado ──────────────
+// Campo top-level donde se persiste el hash de integridad canónico del estado
+// (CA-4/SEC-3). Se omite del propio cómputo para evitar recursión.
+const INTEGRITY_FIELD = 'integrity_hash';
+
+// CA-6/SEC-5 — retención de backups en archived/. Conservamos los N más
+// recientes por familia; el resto se rota (borra) con log. Configurable por env
+// para tests.
+const ARCHIVED_BACKUPS_KEEP = (() => {
+    const v = Number(process.env.WAVES_ARCHIVED_KEEP);
+    return Number.isInteger(v) && v > 0 ? v : 20;
+})();
+
+// CA-6/SEC-5 — límites anti-OOM al validar un estado potencialmente hostil
+// (restore/boot de un waves.json que un atacante podría inflar).
+const MAX_WAVES_PER_BUCKET = 500;         // planned_waves / archived_waves
+const MAX_ISSUES_PER_WAVE = 2000;
+const MAX_FREE_STRING_LEN = 20000;        // name/goal/note/source/updated_by/status/notes
+const MAX_STATE_BYTES = 5 * 1024 * 1024;  // 5MB — waves.json real ≈ 3KB
+
+// CA-3/SEC-2 — nombres de backup aceptados en restore desde un marker. El
+// snapshot transaccional (`snapshotForTransaction`) genera `waves-rollback` /
+// `partial-pause-rollback`; el snapshot de la transacción de archivado (#4378,
+// `archiveWave`) genera `waves-archive-rollback`. Cualquier otro nombre se
+// rechaza fail-closed.
+const BACKUP_NAME_WHITELIST = /^(waves-rollback|waves-archive-rollback|partial-pause-rollback)\.[0-9A-Za-z._\-]+\.json$/;
 
 // #3520 — TTL para considerar un marker `wave-promote.in-progress.json`
 // como stale (rollback automático). Configurable vía env para tests.
@@ -1185,8 +1213,12 @@ function saveStateLocked(state, metadata = {}) {
     if (!state.meta) state.meta = {};
     state.meta.updated_at = nowIso();
     if (metadata.updated_by) state.meta.updated_by = metadata.updated_by;
-    if (metadata.source) state.meta.source = metadata.source;
-    if (metadata.note) state.meta.note = metadata.note;
+    // CA-6/SEC-5 — redacción defensiva de secretos en campos libres provenientes
+    // de Telegram (note/source). `redactSecretValue` sólo toca tokens que
+    // parecen secretos (regex por proveedor + alta entropía) — texto normal
+    // ("add issue #123 → wave 5") queda intacto.
+    if (metadata.source) state.meta.source = redactSecretValue(String(metadata.source));
+    if (metadata.note) state.meta.note = redactSecretValue(String(metadata.note));
     if (!state.meta.created_at) state.meta.created_at = state.meta.updated_at;
 
     // CA-5: validar shape ANTES de persistir. Un state inválido se rechaza
@@ -1232,6 +1264,12 @@ function saveStateLocked(state, metadata = {}) {
         logWarn(`Error preparando backup: ${err.message}`);
     }
 
+    // CA-4/SEC-3 — sellar el estado con el hash de integridad canónico (omitiendo
+    // el propio campo). Se computa DESPUÉS de la validación y del backup, sobre el
+    // shape final que se persiste. Migración (CA-9): un waves.json legacy sin hash
+    // queda sellado en este primer save.
+    state[INTEGRITY_FIELD] = computeIntegrityHash(state);
+
     // Write atómico vía helper compartido (CA-1: tmp + fsync + rename + retry).
     try {
         atomicWriteFile(wavesFile(), JSON.stringify(state, null, 2));
@@ -1243,6 +1281,14 @@ function saveStateLocked(state, metadata = {}) {
     // Invalidar cache post-save.
     invalidateCache();
     logInfo(`waves.json persistido (updated_by=${state.meta.updated_by}, source=${state.meta.source}).`);
+
+    // CA-6/SEC-5 — rotar backups fuera de transacción (best-effort). No corre si
+    // hay un promote in-progress (rotateArchivedBackups lo detecta y se abstiene).
+    try {
+        rotateArchivedBackups();
+    } catch (err) {
+        logWarn(`[rotación] falló (no bloqueante): ${err.message}`);
+    }
 }
 
 /**
@@ -1255,14 +1301,76 @@ function saveStateLocked(state, metadata = {}) {
  *   - Devuelve errores detallados accionables.
  *   - Es la base de la verificación pre-write y post-load strict.
  */
+function isValidFreeString(v) {
+    return typeof v === 'string' && v.length <= MAX_FREE_STRING_LEN;
+}
+
+/**
+ * CA-5/SEC-4 — valida un objeto ola: tipos de campos libres (string) e
+ * `issue.number` como entero positivo. Los campos libres fluyen a sinks
+ * (dashboard=XSS, Telegram=markdown injection) e `issue.number` dispara trabajo
+ * automático del pipeline — deben tener tipo estricto.
+ */
+function validateWaveObject(w, ctx, errors) {
+    if (!w || typeof w !== 'object') {
+        errors.push(`${ctx} debe ser objeto`);
+        return;
+    }
+    // null se tolera como "ausente" (la producción setea `goal: prev.goal || null`).
+    for (const f of ['name', 'goal', 'note', 'updated_by', 'source']) {
+        if (w[f] !== undefined && w[f] !== null && !isValidFreeString(w[f])) {
+            errors.push(`${ctx}.${f} debe ser string ≤${MAX_FREE_STRING_LEN} chars`);
+        }
+    }
+    if (w.issues !== undefined && w.issues !== null) {
+        if (!Array.isArray(w.issues)) {
+            errors.push(`${ctx}.issues debe ser array`);
+        } else {
+            if (w.issues.length > MAX_ISSUES_PER_WAVE) {
+                errors.push(`${ctx}.issues excede el límite (${w.issues.length} > ${MAX_ISSUES_PER_WAVE})`);
+            }
+            w.issues.forEach((iss, k) => {
+                if (!iss || typeof iss !== 'object') {
+                    errors.push(`${ctx}.issues[${k}] debe ser objeto`);
+                    return;
+                }
+                if (!Number.isInteger(iss.number) || iss.number <= 0) {
+                    errors.push(`${ctx}.issues[${k}].number debe ser entero positivo (recibido: ${JSON.stringify(iss.number)})`);
+                }
+                for (const f of ['status', 'notes']) {
+                    if (iss[f] !== undefined && iss[f] !== null && !isValidFreeString(iss[f])) {
+                        errors.push(`${ctx}.issues[${k}].${f} debe ser string ≤${MAX_FREE_STRING_LEN} chars`);
+                    }
+                }
+            });
+        }
+    }
+}
+
 function validateStateStrict(raw, opts = {}) {
     const errors = [];
     if (!raw || typeof raw !== 'object') {
         errors.push('state debe ser objeto');
         return errors;
     }
+    // CA-6/SEC-5 — cota de tamaño total anti-OOM (defensa ante un waves.json
+    // hostil enorme en el load de arranque/restore). Se corta temprano para no
+    // recorrer algo gigante.
+    try {
+        const bytes = Buffer.byteLength(JSON.stringify(raw), 'utf8');
+        if (bytes > MAX_STATE_BYTES) {
+            errors.push(`state excede el límite de tamaño (${bytes} > ${MAX_STATE_BYTES} bytes)`);
+            return errors;
+        }
+    } catch { /* ciclos u otros no-JSON: se detectan por los checks de tipo abajo */ }
+
     if (raw.version !== SCHEMA_VERSION) {
         errors.push(`version esperada ${SCHEMA_VERSION}, recibida ${JSON.stringify(raw.version)}`);
+    }
+    // CA-4 — integrity_hash, si está presente, debe ser SHA-256 hex de 64 chars.
+    if (raw[INTEGRITY_FIELD] !== undefined
+        && (typeof raw[INTEGRITY_FIELD] !== 'string' || !/^[0-9a-f]{64}$/.test(raw[INTEGRITY_FIELD]))) {
+        errors.push('integrity_hash debe ser SHA-256 hex de 64 chars');
     }
     if (!raw.meta || typeof raw.meta !== 'object') {
         errors.push('meta ausente o no-objeto');
@@ -1271,18 +1379,34 @@ function validateStateStrict(raw, opts = {}) {
         if (typeof raw.meta.updated_at !== 'string' || !Number.isFinite(Date.parse(raw.meta.updated_at))) {
             errors.push(`meta.updated_at no es ISO string parseable (recibido: ${JSON.stringify(raw.meta.updated_at)})`);
         }
+        // CA-5/SEC-4 — campos libres de meta deben ser string (null se tolera).
+        for (const f of ['updated_by', 'source', 'note']) {
+            if (raw.meta[f] !== undefined && raw.meta[f] !== null && !isValidFreeString(raw.meta[f])) {
+                errors.push(`meta.${f} debe ser string ≤${MAX_FREE_STRING_LEN} chars`);
+            }
+        }
     }
     if (raw.active_wave !== null && raw.active_wave !== undefined && typeof raw.active_wave !== 'object') {
         errors.push(`active_wave debe ser objeto o null, recibido: ${typeof raw.active_wave}`);
     }
-    if (raw.active_wave && typeof raw.active_wave === 'object' && raw.active_wave.issues !== undefined && !Array.isArray(raw.active_wave.issues)) {
-        errors.push('active_wave.issues debe ser array');
+    if (raw.active_wave && typeof raw.active_wave === 'object') {
+        validateWaveObject(raw.active_wave, 'active_wave', errors);
     }
     if (raw.planned_waves !== undefined && !Array.isArray(raw.planned_waves)) {
         errors.push('planned_waves debe ser array');
+    } else if (Array.isArray(raw.planned_waves)) {
+        if (raw.planned_waves.length > MAX_WAVES_PER_BUCKET) {
+            errors.push(`planned_waves excede el límite (${raw.planned_waves.length} > ${MAX_WAVES_PER_BUCKET})`);
+        }
+        raw.planned_waves.forEach((w, k) => validateWaveObject(w, `planned_waves[${k}]`, errors));
     }
     if (raw.archived_waves !== undefined && !Array.isArray(raw.archived_waves)) {
         errors.push('archived_waves debe ser array');
+    } else if (Array.isArray(raw.archived_waves)) {
+        if (raw.archived_waves.length > MAX_WAVES_PER_BUCKET) {
+            errors.push(`archived_waves excede el límite (${raw.archived_waves.length} > ${MAX_WAVES_PER_BUCKET})`);
+        }
+        raw.archived_waves.forEach((w, k) => validateWaveObject(w, `archived_waves[${k}]`, errors));
     }
     if (raw.dependencies !== undefined && !Array.isArray(raw.dependencies)) {
         errors.push('dependencies debe ser array');
@@ -1364,6 +1488,25 @@ function loadStateStrict() {
         e.errors = errors;
         throw e;
     }
+    // CA-4/SEC-3 — verificar hash de integridad. `missing` = estado legacy
+    // pre-#4370 (se sella en el próximo save, CA-9): se tolera. `mismatch` =
+    // corrupción silenciosa o tampering schema-válido → fail-closed human-block.
+    const integrity = verifyIntegrityHash(parsed);
+    if (integrity.status === 'mismatch') {
+        try {
+            notifyTelegram({
+                level: 'error',
+                component: 'waves-integrity',
+                message: 'integrity_hash mismatch en waves.json',
+                detail: `esperado ${integrity.expected}, recomputado ${integrity.actual}`,
+                action: 'Pipeline en modo human-block. El estado fue alterado fuera del flujo normal (corrupción o tampering). Restaurá desde archived/ o revisá manualmente.',
+                diag: `jq . ${file}`,
+            });
+        } catch {}
+        const e = new Error(`waves.json: integrity_hash mismatch (esperado ${integrity.expected}, actual ${integrity.actual})`);
+        e.code = 'EWAVES_INTEGRITY';
+        throw e;
+    }
     return parsed;
 }
 
@@ -1418,6 +1561,173 @@ function sha256File(filePath) {
     } catch {
         return null;
     }
+}
+
+// ─── #4370 — Hash de integridad canónico (CA-4/SEC-3) ────────────────────────
+
+/**
+ * Serialización canónica determinística: claves de objeto ordenadas
+ * recursivamente. Garantiza que el hash de integridad sea estable aunque el
+ * orden de claves del JSON persistido cambie (ej. read-modify-write que reordena).
+ * No maneja ciclos (el estado nunca los tiene) ni valores no-JSON.
+ */
+function canonicalStringify(value) {
+    if (value === null || typeof value !== 'object') {
+        return JSON.stringify(value);
+    }
+    if (Array.isArray(value)) {
+        return '[' + value.map(canonicalStringify).join(',') + ']';
+    }
+    const keys = Object.keys(value).sort();
+    return '{' + keys.map((k) => JSON.stringify(k) + ':' + canonicalStringify(value[k])).join(',') + '}';
+}
+
+/**
+ * Computa el hash de integridad SHA-256 del estado, OMITIENDO el propio campo
+ * `integrity_hash` para evitar recursión (CA-4). Devuelve hex de 64 chars.
+ */
+function computeIntegrityHash(state) {
+    const clone = {};
+    for (const k of Object.keys(state)) {
+        if (k === INTEGRITY_FIELD) continue;
+        clone[k] = state[k];
+    }
+    return sha256Buffer(Buffer.from(canonicalStringify(clone), 'utf8'));
+}
+
+/**
+ * Verifica el hash de integridad persistido contra el estado cargado.
+ * Nunca tira. Devuelve:
+ *   - { status: 'missing' }              → estado legacy sin hash (CA-9: tolerar).
+ *   - { status: 'ok' }                   → hash coincide.
+ *   - { status: 'mismatch', expected, actual } → corrupción/tampering.
+ */
+function verifyIntegrityHash(state) {
+    const stored = state && typeof state === 'object' ? state[INTEGRITY_FIELD] : undefined;
+    if (stored === undefined || stored === null) {
+        return { status: 'missing' };
+    }
+    const actual = computeIntegrityHash(state);
+    return actual === stored
+        ? { status: 'ok' }
+        : { status: 'mismatch', expected: stored, actual };
+}
+
+/**
+ * CA-4 — carga defensiva del estado activo y verifica el hash de integridad SIN
+ * tirar excepción. Pensado para el boot del pulpo: devuelve un status
+ * estructurado para log/alerta sin poner el pipeline fuera de servicio.
+ *
+ * @returns {{ status: 'absent'|'unreadable'|'schema_invalid'|'missing'|'ok'|'mismatch',
+ *             error?: string, errors?: string[], expected?: string, actual?: string }}
+ */
+function checkStateIntegrity() {
+    const file = wavesFile();
+    if (!fs.existsSync(file)) return { status: 'absent' };
+    let parsed;
+    try {
+        parsed = JSON.parse(fs.readFileSync(file, 'utf8'));
+    } catch (e) {
+        return { status: 'unreadable', error: e.message };
+    }
+    const schemaErrors = validateStateStrict(parsed, { source: 'boot' });
+    if (schemaErrors.length > 0) return { status: 'schema_invalid', errors: schemaErrors };
+    return verifyIntegrityHash(parsed);
+}
+
+/**
+ * CA-7/SEC-6 — expone el lock de waves.json para que el boot del pulpo envuelva
+ * la recuperación bajo el MISMO lock que las escrituras (TOCTOU). Reentrante:
+ * el `saveState` interno de un restore comparte este lock.
+ */
+function withWavesLock(fn) {
+    return withLockSync(wavesFile(), fn, {
+        component: 'waves-lock',
+        timeoutMs: LOCK_TIMEOUT_MS,
+        maxRetries: LOCK_MAX_RETRIES,
+        notify: notifyTelegram,
+    });
+}
+
+/**
+ * CA-3/SEC-2 — un backup referenciado por un marker debe resolver DENTRO de
+ * `archived/` y matchear la whitelist de nombre. Defensa ante un marker hostil
+ * cuyo `*_bak_path` apunte fuera (el SHA no protege si el atacante controla el
+ * marker completo). Devuelve el path real resuelto o tira.
+ */
+function assertBackupPathSafe(bakPath) {
+    const base = path.resolve(archivedDir());
+    let real;
+    try {
+        real = fs.realpathSync(bakPath);
+    } catch (err) {
+        throw new Error(`backup path no resoluble: ${bakPath} (${err.message})`);
+    }
+    if (real !== base && !real.startsWith(base + path.sep)) {
+        throw new Error(`backup path fuera de archived/: ${real} ∉ ${base}`);
+    }
+    if (!BACKUP_NAME_WHITELIST.test(path.basename(real))) {
+        throw new Error(`backup name no matchea whitelist: ${path.basename(real)}`);
+    }
+    return real;
+}
+
+/**
+ * CA-6/SEC-5 — conserva los `keep` backups más recientes por familia en
+ * `archived/` y borra el resto, logueando cada descarte. NO toca backups
+ * referenciados por un marker de promote en vuelo (evita romper un restore en
+ * curso). Best-effort: nunca tira; si el marker no parsea, es conservador y no
+ * rota nada.
+ *
+ * @param {number} [keep=ARCHIVED_BACKUPS_KEEP]
+ * @returns {{ rotated: string[], kept: number, skipped?: string }}
+ */
+function rotateArchivedBackups(keep = ARCHIVED_BACKUPS_KEEP) {
+    const dir = archivedDir();
+    let entries;
+    try {
+        entries = fs.readdirSync(dir);
+    } catch {
+        return { rotated: [], kept: keep };
+    }
+
+    // Backups referenciados por un marker in-progress: intocables.
+    const inFlight = new Set();
+    try {
+        if (fs.existsSync(promoteMarkerFile())) {
+            const m = JSON.parse(fs.readFileSync(promoteMarkerFile(), 'utf8'));
+            if (m && m.waves_bak_path) inFlight.add(path.basename(m.waves_bak_path));
+            if (m && m.partial_bak_path) inFlight.add(path.basename(m.partial_bak_path));
+        }
+    } catch {
+        // Marker presente pero ilegible → no rotamos (podría referenciar un bak vivo).
+        return { rotated: [], kept: keep, skipped: 'marker-unparseable' };
+    }
+
+    const families = [
+        /^waves\.[^\\/]+\.json$/,               // backups de saveStateLocked
+        /^waves-rollback\.[^\\/]+\.json$/,       // snapshot transaccional
+        /^partial-pause-rollback\.[^\\/]+\.json$/,
+    ];
+    const rotated = [];
+    for (const fam of families) {
+        const matched = entries.filter((f) => fam.test(f) && !inFlight.has(f));
+        const withMtime = matched.map((f) => {
+            let mtime = 0;
+            try { mtime = fs.statSync(path.join(dir, f)).mtimeMs; } catch {}
+            return { f, mtime };
+        }).sort((a, b) => b.mtime - a.mtime); // más nuevo primero
+        for (const { f, mtime } of withMtime.slice(keep)) {
+            try {
+                fs.unlinkSync(path.join(dir, f));
+                rotated.push(f);
+                logInfo(`[rotación] descartado backup ${f} (mtime ${new Date(mtime).toISOString()}) — excede retención KEEP=${keep}.`);
+            } catch (err) {
+                logWarn(`[rotación] no pude borrar ${f}: ${err.message}`);
+            }
+        }
+    }
+    return { rotated, kept: keep };
 }
 
 function nowMs() { return Date.now(); }
@@ -1518,37 +1828,69 @@ function snapshotForTransaction(ts) {
 function restoreFromSnapshots(marker) {
     const out = { ok: false, wavesRestored: false, partialRestored: false };
 
-    // Validar SHAs antes de restaurar — fail-closed.
+    // Validar SHAs + contención de path + shape antes de restaurar — fail-closed.
     if (marker.waves_bak_path) {
-        if (!fs.existsSync(marker.waves_bak_path)) {
-            out.reason = `waves backup ausente: ${marker.waves_bak_path}`;
+        // CA-3/SEC-2 — el SHA no protege si el atacante controla el marker
+        // completo (puede fijar path externo + su hash). Resolver realpath y
+        // exigir contención en archived/ + whitelist de nombre ANTES de leer.
+        let safePath;
+        try {
+            safePath = assertBackupPathSafe(marker.waves_bak_path);
+        } catch (e) {
+            out.reason = `waves backup rechazado por contención de path (CA-3): ${e.message}`;
             return out;
         }
-        const currentSha = sha256File(marker.waves_bak_path);
+        if (!fs.existsSync(safePath)) {
+            out.reason = `waves backup ausente: ${safePath}`;
+            return out;
+        }
+        const currentSha = sha256File(safePath);
         if (currentSha !== marker.waves_bak_sha) {
             out.reason = `SHA mismatch en waves backup (esperado ${marker.waves_bak_sha}, leído ${currentSha})`;
             return out;
         }
-        // Parse defensivo — si el .bak no parsea, no escribimos basura.
-        try { JSON.parse(fs.readFileSync(marker.waves_bak_path, 'utf8')); } catch (e) {
+        // CA-2/SEC-1 — parsear una vez y correr validateStateStrict ANTES de
+        // promover. Un .bak parseable pero con shape inválido/hostil NO se
+        // promueve nunca (fail-closed): dejamos el estado activo intacto.
+        let parsedWaves;
+        try {
+            parsedWaves = JSON.parse(fs.readFileSync(safePath, 'utf8'));
+        } catch (e) {
             out.reason = `JSON corrupto en waves backup: ${e.message}`;
             return out;
         }
-    }
-    if (marker.partial_bak_path) {
-        if (!fs.existsSync(marker.partial_bak_path)) {
-            out.reason = `partial backup ausente: ${marker.partial_bak_path}`;
+        const shapeErrors = validateStateStrict(parsedWaves, { source: 'restore' });
+        if (shapeErrors.length > 0) {
+            out.reason = `waves backup con shape inválido — no se promueve (CA-2): ${shapeErrors.join('; ')}`;
             return out;
         }
-        const currentSha = sha256File(marker.partial_bak_path);
+        // Usar el path resuelto y contenido para el copy posterior.
+        marker.waves_bak_path = safePath;
+    }
+    if (marker.partial_bak_path) {
+        // CA-3/SEC-2 — misma contención para el backup de la allowlist. NO se
+        // corre validateStateStrict acá (schema distinto: allowlist, no waves).
+        let safePath;
+        try {
+            safePath = assertBackupPathSafe(marker.partial_bak_path);
+        } catch (e) {
+            out.reason = `partial backup rechazado por contención de path (CA-3): ${e.message}`;
+            return out;
+        }
+        if (!fs.existsSync(safePath)) {
+            out.reason = `partial backup ausente: ${safePath}`;
+            return out;
+        }
+        const currentSha = sha256File(safePath);
         if (currentSha !== marker.partial_bak_sha) {
             out.reason = `SHA mismatch en partial backup (esperado ${marker.partial_bak_sha}, leído ${currentSha})`;
             return out;
         }
-        try { JSON.parse(fs.readFileSync(marker.partial_bak_path, 'utf8')); } catch (e) {
+        try { JSON.parse(fs.readFileSync(safePath, 'utf8')); } catch (e) {
             out.reason = `JSON corrupto en partial backup: ${e.message}`;
             return out;
         }
+        marker.partial_bak_path = safePath;
     }
 
     // Restaurar waves.json
@@ -2364,6 +2706,12 @@ module.exports = {
     // CA-5: variantes strict que tiran si el shape rompe.
     loadStateStrict,
     validateStateStrict,
+    // #4370 — integridad, retención y lock del boot.
+    checkStateIntegrity,
+    verifyIntegrityHash,
+    computeIntegrityHash,
+    rotateArchivedBackups,
+    withWavesLock,
     // CA-1: helper de write atómico reusable por partial-pause.js.
     atomicWriteFile,
     // #3738 — bounds de creación de olas planificadas.
@@ -2399,6 +2747,12 @@ module.exports = {
         // #4378 — archive helpers visibles a tests.
         archiveMarkerFile,
         listArchiveFailedMarkers,
+        // #4370 — helpers de integridad/restore expuestos a tests.
+        assertBackupPathSafe,
+        canonicalStringify,
+        computeIntegrityHash,
+        verifyIntegrityHash,
+        rotateArchivedBackups,
         // #3616 — reset del dedupe in-memory de la alerta "allowlist vacío".
         _resetEmptyAllowlistDedupeForTests,
     },

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -14411,7 +14411,13 @@ async function mainLoop() {
   // pasó. La transacción próxima la frena el gate del Commander si quedó .failed.
   try {
     const waves = require('./lib/waves');
-    const promoteRecovery = waves.recoverIncompletePromote();
+    // #4370 CA-7/SEC-6 (TOCTOU): la recuperación de boot adquiere el MISMO lock
+    // que las escrituras para no colisionar con un write en vuelo. El manejo de
+    // lock stale (rename-based dentro de recoverIncompletePromote) NO habilita
+    // bypass de la validación de shape (CA-2) — esa corre siempre en restore.
+    const promoteRecovery = typeof waves.withWavesLock === 'function'
+      ? waves.withWavesLock(() => waves.recoverIncompletePromote())
+      : waves.recoverIncompletePromote();
     if (promoteRecovery && promoteRecovery.action === 'recovered') {
       const m = promoteRecovery.originalMarker || {};
       const startedAt = m.started_at || 'desconocido';
@@ -14504,6 +14510,42 @@ async function mainLoop() {
     }
   } catch (e) {
     log('pulpo', `WARN [wave-recovery] boot hook falló: ${e.message}`);
+  }
+
+  // #4370 CA-4/SEC-3 — verificación de integridad del estado al arrancar.
+  // Distingue corrupción silenciosa / tampering schema-válido de un estado sano.
+  // Best-effort: NO pone el pipeline fuera de servicio (regla "el pipeline no
+  // puede morir"); alerta + log para que el operador decida.
+  try {
+    const waves = require('./lib/waves');
+    if (typeof waves.checkStateIntegrity === 'function') {
+      const integ = waves.checkStateIntegrity();
+      if (integ.status === 'mismatch') {
+        log('pulpo', `WARN [wave-integrity] MISMATCH en waves.json (esperado ${integ.expected}, recomputado ${integ.actual}). Estado alterado fuera del flujo normal.`);
+        try {
+          sendTelegram(
+            `🔐 *Integridad de waves.json comprometida al boot*\n\n` +
+            `El hash de integridad NO coincide: el estado fue alterado fuera del flujo normal ` +
+            `\\(corrupción silenciosa o tampering schema\\-válido\\)\\.\n\n` +
+            `*Acción manual requerida:* revisá \`.pipeline/waves.json\` y, si corresponde, restaurá desde \`.pipeline/archived/\`\\.\n` +
+            `_El pipeline sigue operando con el estado actual hasta tu revisión\\._`
+          );
+        } catch (e2) {
+          log('pulpo', `WARN [wave-integrity] no pude enviar alerta de mismatch: ${e2.message}`);
+        }
+      } else if (integ.status === 'schema_invalid') {
+        log('pulpo', `WARN [wave-integrity] waves.json con shape inválido al boot: ${(integ.errors || []).join('; ')}`);
+      } else if (integ.status === 'unreadable') {
+        log('pulpo', `WARN [wave-integrity] waves.json ilegible al boot: ${integ.error}`);
+      } else if (integ.status === 'missing') {
+        log('pulpo', `[wave-integrity] waves.json legacy sin hash — se sellará en el próximo save (CA-9).`);
+      } else if (integ.status === 'ok') {
+        log('pulpo', `[wave-integrity] OK — hash de integridad verificado.`);
+      }
+      // status='absent' → sin waves.json todavía, caso normal en boot fresco.
+    }
+  } catch (e) {
+    log('pulpo', `WARN [wave-integrity] check falló (no bloqueante): ${e.message}`);
   }
 
   // #3616 — Boot hook: seed inicial de waves.json desde .partial-pause.json.

--- a/docs/pipeline/waves-schema.md
+++ b/docs/pipeline/waves-schema.md
@@ -122,7 +122,8 @@ Lectura del diagrama:
   ],
   "dependencies": [                            // grafo de bloqueos
     { "blocker": 3559, "blocked": 3700, "reason": "API contract" }
-  ]
+  ],
+  "integrity_hash": "3f1a…64hex"               // #4370 — SHA-256 canónico (ver abajo)
 }
 ```
 
@@ -149,12 +150,84 @@ Lectura del diagrama:
 | `archived_waves[].issues_failed` | int | Cuántos fallaron o quedaron bloqueados. |
 | `archived_waves[].actual_duration_days` | int | Días reales. |
 | `dependencies[]` | array | Grafo bloqueador → bloqueado. |
+| `integrity_hash` | string (hex 64) | #4370 — SHA-256 canónico del estado (omite el propio campo). Sellado en cada save; verificado al boot/load. Opcional en legacy (se sella en el primer save). |
 
 ### Validación
 
 `lib/waves.validateStateStrict(state)` aplica antes de cada write. Si devuelve
 errores, el write se rechaza con `EWAVES_SCHEMA` + alerta Telegram. **Cero
 escritura de basura**.
+
+Desde **#4370** la validación estricta cubre además (defensa ante estados
+hostiles que disparan trabajo automático del pipeline):
+
+- **`issue.number` como entero positivo** en `active_wave`, `planned_waves[]` y
+  `archived_waves[]` (no strings arbitrarios — el número construye trabajo real).
+- **Tipos string** de los campos libres (`name`, `goal`, `note`, `updated_by`,
+  `source`, `status`, `notes`). `null` se tolera como "ausente". Estos campos
+  fluyen a sinks (dashboard = XSS almacenado, Telegram = markdown injection); el
+  tipo estricto en el schema + el escape en el punto de render (`esc()` en el
+  dashboard, `escapeMarkdownV2`/`fill-template` en Telegram) son las dos capas.
+- **Límites anti-OOM**: `MAX_WAVES_PER_BUCKET=500`, `MAX_ISSUES_PER_WAVE=2000`,
+  `MAX_FREE_STRING_LEN=20000`, `MAX_STATE_BYTES=5MB`. Un `waves.json` inflado por
+  un atacante se rechaza antes de recorrerse en el load de arranque.
+
+La variante permisiva `loadWaves()` se mantiene intacta para los consumers
+legacy (dashboard, commander-deterministic, planner-waves, wave-resolver,
+eta-wave, canonical-facts, wizards): la strictness sólo aplica en los caminos de
+**escritura / restore / boot**.
+
+### Hash de integridad — `integrity_hash` (#4370)
+
+`waves.json` persiste un campo top-level `integrity_hash`: el **SHA-256 del
+estado canónico** (claves ordenadas recursivamente) **omitiendo el propio campo**
+para evitar recursión. Se computa y sella en cada `saveStateLocked` dentro del
+write atómico existente.
+
+```jsonc
+{
+  "version": "1.0",
+  "meta": { /* ... */ },
+  "active_wave": { /* ... */ },
+  "planned_waves": [],
+  "archived_waves": [],
+  "dependencies": [],
+  "integrity_hash": "3f1a…64hex"   // SHA-256 canónico, sellado en cada save
+}
+```
+
+- **Verificación al boot** (`waves.checkStateIntegrity()`, llamado por `pulpo.js`):
+  distingue *corrupción silenciosa* / *tampering schema-válido* de un estado
+  sano. `ok` → log; `mismatch` → log WARN + alerta Telegram (human-block blando:
+  el pipeline sigue con el estado actual hasta revisión humana, no se autodestruye);
+  `missing` → estado legacy (ver migración); `schema_invalid`/`unreadable` → log.
+- **Verificación en `loadStateStrict()`**: `mismatch` tira `EWAVES_INTEGRITY` +
+  alerta (fail-closed para los caminos que exigen estado íntegro).
+- **Migración tolerante (CA-9)**: un `waves.json` **legacy sin `integrity_hash`**
+  se carga OK (`missing`, no falla) y queda **sellado en el primer save**. No se
+  bumpea `SCHEMA_VERSION` porque el shape sólo agrega un campo opcional
+  retrocompatible.
+
+### Retención / rotación de backups en `archived/` (#4370)
+
+`saveStateLocked` deja un backup timestamped `waves.<ts>.json` antes de
+sobreescribir, y `snapshotForTransaction` deja `waves-rollback.<ts>.json` /
+`partial-pause-rollback.<ts>.json` por transacción de `/wave promote`. Sin cota,
+`archived/` crecía sin fin (baseline previo: 29 backups) → DoS por disco, parse
+lento en restart y exposición indefinida de secretos.
+
+`waves.rotateArchivedBackups(keep = WAVES_ARCHIVED_KEEP || 20)`:
+
+- Conserva los **N más recientes por familia** (por `mtime`) y **borra el resto,
+  logueando cada descarte** (`[rotación] descartado backup … — excede retención`).
+- **No toca** backups referenciados por un `wave-promote.in-progress.json` vivo
+  (evita romper un restore en curso). Si el marker está presente pero ilegible,
+  es conservador y **no rota nada**.
+- Corre best-effort al final de cada save (nunca bloquea el write).
+- **Redacción defensiva**: `meta.note` / `meta.source` pasan por
+  `redact.redactSecretValue` antes de persistir — un secreto pegado desde
+  Telegram no queda en texto plano en `waves.json` ni en sus backups. Texto
+  normal ("add issue #123 → wave 5") queda intacto.
 
 ---
 


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 4 archivos · +833 -16

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:passed` aplicado por delivery

## Closes

Closes #4370
