### PR TITLE
Unificar la fuente de verdad del estado de olas (fin del modo legacy)

### DIFF
--- a/.pipeline/dashboard.js
+++ b/.pipeline/dashboard.js
@@ -790,6 +790,11 @@ function _scheduleOlaETARefresh(state) {
       // avance % desde la MISMA fuente que el handler de estado de ola, incluso
       // cuando todavía no hay ritmo medido (etaSource === 'fallback').
       let waveTotalPct = null;
+      // #4399 — conteo de cerrados/total del MISMO `computeClosedSet` que la
+      // lista, elevado al cache para que el panel de métricas exponga el mismo
+      // "N de M" (CA-2). null si no se pudo derivar.
+      let waveClosedCount = null;
+      let waveTotalIssues = null;
       try {
         if (waveProgressLib && wavesLib && waveResolverLib && waveSnapshotLib && waveStateLib) {
           const activeWave = wavesLib.getActiveWave();
@@ -810,6 +815,9 @@ function _scheduleOlaETARefresh(state) {
             // de la función para preservar el patrón anti-circular (idem L3860/L10535).
             const { computeClosedSet } = require('./lib/commander-deterministic');
             const closedIssues = computeClosedSet({ wave, state: wState });
+            // #4399 — el conteo de cerrados/total sale del MISMO set que la lista.
+            waveClosedCount = closedIssues.size;
+            waveTotalIssues = Array.isArray(wave && wave.issues) ? wave.issues.length : 0;
             const wSnap = waveSnapshotLib.buildWaveSnapshot({ state: wState, wave, closedIssues });
             if (wSnap && Number.isFinite(wSnap.totalPct)) {
               waveTotalPct = wSnap.totalPct;
@@ -821,9 +829,9 @@ function _scheduleOlaETARefresh(state) {
           }
         }
       } catch { /* fallback: sin velocityETA */ }
-      return { olaResult, historical, velocityETA, waveTotalPct };
+      return { olaResult, historical, velocityETA, waveTotalPct, waveClosedCount, waveTotalIssues };
     })
-    .then(({ olaResult, historical, velocityETA, waveTotalPct }) => {
+    .then(({ olaResult, historical, velocityETA, waveTotalPct, waveClosedCount, waveTotalIssues }) => {
       _olaETACache = {
         issues: olaIssues,
         totalP50: olaResult.totalP50,
@@ -838,6 +846,11 @@ function _scheduleOlaETARefresh(state) {
         etaSource: velocityETA ? 'velocity' : 'fallback',
         // #4287 (CA-1) — avance % determinístico (null si no hubo snapshot).
         totalPct: Number.isFinite(waveTotalPct) ? waveTotalPct : null,
+        // #4399 — conteo cerrados/total del MISMO `computeClosedSet` que la lista
+        // del pipeline, para que el panel de métricas muestre idéntico "N de M"
+        // (CA-2). null cuando no se pudo derivar la ola canónica.
+        closedCount: Number.isInteger(waveClosedCount) ? waveClosedCount : null,
+        totalIssues: Number.isInteger(waveTotalIssues) ? waveTotalIssues : null,
         refreshedAt: Date.now(),
       };
       _olaETACacheAt = Date.now();

--- a/.pipeline/lib/__tests__/commander-closed-set.test.js
+++ b/.pipeline/lib/__tests__/commander-closed-set.test.js
@@ -92,3 +92,71 @@ test('#4099: inputs vacíos/ausentes no rompen (no throw)', () => {
     assert.equal(computeClosedSet({ wave: {}, state: {} }).size, 0);
     assert.equal(computeClosedSet({ wave: { issues: [] }, state: { issueTitles: {} } }).size, 0);
 });
+
+// =============================================================================
+// #4399 — CA-2/CA-3: la LISTA del pipeline y el PANEL de métricas producen el
+// MISMO conteo de cerrados desde `computeClosedSet`. Reproduce el bug real de la
+// Ola 8.3 ("11 de 14" en la lista vs "2 de 14" en el panel) y verifica que, tras
+// converger ambas zonas sobre la misma fuente, el número es idéntico.
+// =============================================================================
+
+const slices = require('../dashboard-slices');
+
+// Fixture: ola de 14 issues, 11 CLOSED en la cache de títulos (el escenario real).
+function buildOla83State() {
+    const issues = [4380, 4381, 4382, 4383, 4384, 4385, 4386, 4387, 4388, 4389, 4390, 4391, 4392, 4393];
+    const closedIds = issues.slice(0, 11); // 11 cerrados
+    const issueTitles = {};
+    for (const id of issues) {
+        issueTitles[String(id)] = {
+            state: closedIds.includes(id) ? 'CLOSED' : 'OPEN',
+            labels: [],
+        };
+    }
+    return { issues, closedIds, issueTitles };
+}
+
+test('#4399 CA-2: lista y panel de métricas cuentan el mismo # de cerrados (11 de 14)', () => {
+    const { issues, issueTitles } = buildOla83State();
+    // `state.activeWave.issues` = number[] (output del resolver), igual que en el
+    // dashboard real. `state.issueTitles` = cache cruda de títulos.
+    const state = {
+        activeWave: { label: 'Ola 8.3', issues, source: 'waves.json', resolved: true },
+        issueTitles,
+        issueMatrix: {},
+    };
+
+    // Camino LISTA (idéntico a dashboard-routes.computeLiveWaveStatus:730).
+    const listaSet = computeClosedSet({ wave: state.activeWave, state });
+    const listaClosed = listaSet.size;
+
+    // Camino PANEL de métricas (dashboard-slices._roadmapAvance tras #4399).
+    const avance = slices._roadmapAvance(state.activeWave, state);
+
+    assert.equal(listaClosed, 11, 'la lista cuenta 11 cerrados');
+    assert.equal(avance.closed, 11, 'el panel cuenta 11 cerrados (mismo set)');
+    assert.equal(avance.closed, listaClosed, 'CA-2: lista y panel deben coincidir');
+    assert.equal(avance.total, 14, 'total = # issues de la ola');
+    assert.equal(avance.pct, 79, 'CA-3: % de avance coherente (round(11/14*100))');
+});
+
+test('#4399 CA-3: el panel NO usa la foto .status/.merged desincronizada', () => {
+    // La foto enriquecida marca sólo 2 como completados/merged (el bug "2 de 14"),
+    // pero la cache de títulos tiene 11 CLOSED. El panel debe reportar 11, no 2.
+    const { issues, issueTitles } = buildOla83State();
+    const state = {
+        // issues como number[] (nunca la foto {status/merged}) — el panel deriva
+        // los cerrados de issueTitles, no de flags por issue.
+        activeWave: { label: 'Ola 8.3', issues, source: 'waves.json', resolved: true },
+        issueTitles,
+        issueMatrix: {},
+    };
+    const avance = slices._roadmapAvance(state.activeWave, state);
+    assert.equal(avance.closed, 11, 'deriva de computeClosedSet, no de 2 flags stale');
+    assert.notEqual(avance.closed, 2);
+});
+
+test('#4399: _roadmapAvance degrada grácil sin activeWave (0 de 0, sin throw)', () => {
+    assert.deepEqual(slices._roadmapAvance(undefined, {}), { closed: 0, total: 0, pct: 0 });
+    assert.deepEqual(slices._roadmapAvance({ issues: [] }, { issueTitles: {} }), { closed: 0, total: 0, pct: 0 });
+});

--- a/.pipeline/lib/__tests__/dashboard-routes-roadmap.test.js
+++ b/.pipeline/lib/__tests__/dashboard-routes-roadmap.test.js
@@ -64,6 +64,11 @@ function fakeState() {
     return {
         bloqueados: [{ issue: 4360, blocker: 4350, reason: 'espera schema', token: 'LEAK-BLOCK' }],
         olaETA: { totalP50: 45, totalP75: 90, totalP90: 150, totalPct: 33, byIssue: { 4373: { samples: 3 } } },
+        // #4399 — el avance del panel deriva de `state.activeWave` (ola canónica,
+        // issues: number[]) + `state.issueTitles` (misma fuente que la lista del
+        // pipeline vía computeClosedSet), NO de la foto enriquecida .status/.merged.
+        activeWave: { label: 'Ola 8', issues: [4373], source: 'waves.json', resolved: true },
+        issueTitles: { '4373': { state: 'OPEN', labels: [] } },
     };
 }
 
@@ -109,8 +114,25 @@ test('CA-6: roadmapSlice calcula avance de la ola activa (cerrados/total/%)', ()
     withStubbedWaves(fakeWavesOk(), () => {
         const slices = require('../dashboard-slices');
         const out = slices.roadmapSlice(fakeState(), {});
-        // 1 issue in-progress → 0 cerrados de 1.
+        // #4399 — 4373 OPEN en issueTitles → 0 cerrados de 1 (deriva de computeClosedSet).
         assert.deepEqual(out.avance, { closed: 0, total: 1, pct: 0 });
+    });
+});
+
+test('#4399 CA-2: roadmapSlice cuenta cerrados desde computeClosedSet (mismo que la lista)', () => {
+    withStubbedWaves(fakeWavesOk(), () => {
+        const slices = require('../dashboard-slices');
+        const { computeClosedSet } = require('../commander-deterministic');
+        const state = fakeState();
+        // El issue 4373 pasa a CLOSED en la cache de títulos → 1 de 1 cerrado.
+        state.issueTitles = { '4373': { state: 'CLOSED', labels: [] } };
+        const out = slices.roadmapSlice(state, {});
+        // La lista deriva del MISMO set.
+        const listaClosed = computeClosedSet({ wave: state.activeWave, state }).size;
+        assert.equal(out.avance.closed, 1);
+        assert.equal(out.avance.closed, listaClosed, 'panel == lista');
+        assert.equal(out.avance.total, 1);
+        assert.equal(out.avance.pct, 100);
     });
 });
 

--- a/.pipeline/lib/__tests__/wave-resolver.test.js
+++ b/.pipeline/lib/__tests__/wave-resolver.test.js
@@ -1,10 +1,15 @@
 // =============================================================================
 // wave-resolver.test.js — Tests del resolver de ola activa.
 //
-// Cubre la cascada de fuentes post-#3502:
+// Cubre la cascada de fuentes post-#4399 (modo legacy eliminado):
 //   1. waves.json (vía `lib/waves.js`, source-of-truth canónica)
-//   2. .partial-pause.json (legacy, mientras waves.json no esté poblado)
-//   3. filesystem scan (último recurso, CA-15 fallback grácil)
+//   2. filesystem scan (último recurso, CA-15 fallback grácil)
+//
+// #4399 — la fuente intermedia `.partial-pause.json → allowed_issues`
+// (`readPartialPauseFile`) fue ELIMINADA: producía conteos incoherentes
+// cuando `waves.json` no tenía `active_wave`. Ahora `waves.json` sin
+// `active_wave` cae DIRECTO a `fs-fallback`; `.partial-pause.json` deja de
+// ser fuente de resolución de ola (sigue usándose para deps/split).
 //
 // Adicionalmente cubre el normalizador defensivo (CA-4) que tolera AMBOS
 // shapes de issues que aparecen en el wild:
@@ -176,29 +181,32 @@ test('normalizeIssueNumber: cubre los shapes esperados y rechaza inválidos', ()
 });
 
 // -----------------------------------------------------------------------------
-// CA-2 — Fallback a partial-pause cuando waves.json está vacío
+// CA-2 (#4399) — `.partial-pause.json` ya NO es fuente de resolución de ola.
+// Con `waves.json` sin `active_wave`, la cascada cae DIRECTO a `fs-fallback`,
+// ignorando `allowed_issues`. Sin `null` ni crash.
 // -----------------------------------------------------------------------------
 
-test('resolveActiveWave: cae a partial-pause cuando waves.json tiene active_wave=null (CA-2)', () => {
+test('#4399: waves.json active_wave=null IGNORA partial-pause y cae a fs-fallback', () => {
     const dir = mkTmpPipeline();
     try {
         writeWavesJson(dir, null);
+        // partial-pause con datos que ANTES eran adoptados como ola: ahora se ignoran.
         fs.writeFileSync(path.join(dir, '.partial-pause.json'), JSON.stringify({
             allowed_issues: [3253, 3257, '3262', '#3260'],
             created_at: '2026-05-16T20:00:00Z',
             source: 'telegram',
         }));
         const r = resolveActiveWave({ pipelineRoot: dir });
-        assert.equal(r.source, 'partial-pause.json');
-        assert.equal(r.label, 'Ola actual');
-        // Normaliza strings/leading # y deduplica.
-        assert.deepEqual(r.issues, [3253, 3257, 3260, 3262]);
-        assert.equal(r.resolved, true);
-        assert.equal(r.openedAt, '2026-05-16T20:00:00Z');
+        // Sin archivos de pipeline activos → fs-fallback vacío (degradación grácil).
+        assert.equal(r.source, 'fs-fallback');
+        assert.deepEqual(r.issues, []);
+        assert.equal(r.resolved, false);
+        // Nunca `partial-pause.json` (fuente 2 eliminada).
+        assert.notEqual(r.source, 'partial-pause.json');
     } finally { resetCache(); rmrf(dir); }
 });
 
-test('resolveActiveWave: cae a partial-pause cuando waves.json no existe', () => {
+test('#4399: waves.json ausente + partial-pause presente → fs-fallback (no partial-pause)', () => {
     const dir = mkTmpPipeline();
     try {
         // Sin waves.json en disco.
@@ -206,13 +214,16 @@ test('resolveActiveWave: cae a partial-pause cuando waves.json no existe', () =>
             allowed_issues: [4001, 4002],
             created_at: '2026-05-26T00:00:00Z',
         }));
+        // Archivos de pipeline activos SON la fuente real ahora (fs-fallback).
+        fs.writeFileSync(path.join(dir, 'desarrollo/dev/trabajando/7001.pipeline-dev'), '');
         const r = resolveActiveWave({ pipelineRoot: dir });
-        assert.equal(r.source, 'partial-pause.json');
-        assert.deepEqual(r.issues, [4001, 4002]);
+        assert.equal(r.source, 'fs-fallback');
+        // Deriva de los archivos del pipeline, NO de allowed_issues.
+        assert.deepEqual(r.issues, [7001]);
     } finally { resetCache(); rmrf(dir); }
 });
 
-test('resolveActiveWave: cae a partial-pause cuando waves.json tiene issues:[]', () => {
+test('#4399: waves.json issues:[] IGNORA partial-pause y cae a fs-fallback', () => {
     const dir = mkTmpPipeline();
     try {
         writeWavesJson(dir, {
@@ -225,13 +236,19 @@ test('resolveActiveWave: cae a partial-pause cuando waves.json tiene issues:[]',
             created_at: 'x',
         }));
         const r = resolveActiveWave({ pipelineRoot: dir });
-        assert.equal(r.source, 'partial-pause.json');
-        assert.deepEqual(r.issues, [5001]);
+        assert.equal(r.source, 'fs-fallback');
+        assert.deepEqual(r.issues, []);
+        assert.equal(r.resolved, false);
     } finally { resetCache(); rmrf(dir); }
 });
 
+test('#4399: readPartialPauseFile fue eliminada del módulo', () => {
+    // La fuente 2 legacy ya no existe como export interno.
+    assert.equal(typeof _internal.readPartialPauseFile, 'undefined');
+});
+
 // -----------------------------------------------------------------------------
-// CA-3 — Fallback FS cuando no hay waves.json activa ni partial-pause
+// CA-3 — Fallback FS cuando no hay waves.json activa
 // -----------------------------------------------------------------------------
 
 test('resolveActiveWave: fallback FS cuando no hay ningún marker (CA-3)', () => {
@@ -263,17 +280,19 @@ test('resolveActiveWave: degrada a issues:[] cuando no hay nada', () => {
 // Robustez frente a entrada corrupta
 // -----------------------------------------------------------------------------
 
-test('resolveActiveWave: ignora waves.json mal formado y sigue cascada', () => {
+test('resolveActiveWave: ignora waves.json mal formado y cae a fs-fallback (#4399)', () => {
     const dir = mkTmpPipeline();
     try {
         fs.writeFileSync(path.join(dir, 'waves.json'), '{not-json,');
+        // partial-pause presente pero ya no se adopta como ola.
         fs.writeFileSync(path.join(dir, '.partial-pause.json'), JSON.stringify({
             allowed_issues: [9999],
             created_at: 'x',
         }));
+        fs.writeFileSync(path.join(dir, 'desarrollo/dev/pendiente/8888.guru'), '');
         const r = resolveActiveWave({ pipelineRoot: dir });
-        assert.equal(r.source, 'partial-pause.json');
-        assert.deepEqual(r.issues, [9999]);
+        assert.equal(r.source, 'fs-fallback');
+        assert.deepEqual(r.issues, [8888]);
     } finally { resetCache(); rmrf(dir); }
 });
 

--- a/.pipeline/lib/dashboard-slices.js
+++ b/.pipeline/lib/dashboard-slices.js
@@ -1776,12 +1776,32 @@ function _roadmapNormalizeArchivedWave(raw) {
     return { number, name, goal, closedAt, issuesCompleted: completed, issuesFailed: failed, durationDays, issues };
 }
 
-// Avance de una ola (CA-6): cerrados/total + %. `closed` = status 'completed' o
-// merged (enrichWaveIssue marca ambos para issues cerrados en GitHub).
-function _roadmapAvance(wave) {
+// Avance de una ola (CA-6 / #4399): cerrados/total + %.
+//
+// #4399 — FUENTE ÚNICA de cerrados. Antes contaba `i.status==='completed' ||
+// i.merged` sobre la foto enriquecida del title-cache (`enrichWaveIssue`), una
+// fuente "de prestado" que quedaba desincronizada y mostraba "2 de 14" mientras
+// la lista del pipeline (`computeLiveWaveStatus` → `computeClosedSet`) mostraba
+// "11 de 14". Ahora el panel de métricas deriva los cerrados del MISMO set que
+// la lista: `computeClosedSet({ wave, state })` sobre `state.issueTitles`
+// (cache cruda, sin query `gh` viva → sin vector de inyección, A03). `total` y
+// `closed` salen de la MISMA `wave` canónica para garantizar closed ≤ total.
+//
+// @param {object} wave  - ola canónica con `issues: number[]` (resolver output).
+// @param {object} state - state del dashboard con `issueTitles`/`issueMatrix`.
+function _roadmapAvance(wave, state) {
     const issues = (wave && Array.isArray(wave.issues)) ? wave.issues : [];
     const total = issues.length;
-    const closed = issues.filter((i) => i && (i.status === 'completed' || i.merged === true)).length;
+    let closed = 0;
+    try {
+        // Require lazy DENTRO de la función (patrón anti-circular, idem otras
+        // slices que requieren commander-deterministic en request-time).
+        const { computeClosedSet } = require('./commander-deterministic');
+        closed = computeClosedSet({ wave, state }).size;
+    } catch {
+        // Degradación grácil: sin el set no inventamos cerrados (0), nunca > total.
+        closed = 0;
+    }
     const pct = total > 0 ? Math.round((closed / total) * 100) : 0;
     return { closed, total, pct };
 }
@@ -1846,7 +1866,12 @@ function roadmapSlice(state, ctx) {
         };
     }
 
-    const avance = _roadmapAvance(activeWave);
+    // #4399 — el avance deriva de `s.activeWave` (ola canónica del resolver, con
+    // `issues: number[]`) + `s` (title-cache), la MISMA fuente que la lista del
+    // pipeline (`computeLiveWaveStatus` en dashboard-routes). NO de `activeWave`
+    // (la foto enriquecida de `buildWavesPayload`), que era la fuente "de
+    // prestado" desincronizada. Así lista y panel muestran el mismo "N de M".
+    const avance = _roadmapAvance(s.activeWave, s);
 
     return {
         activeWave,
@@ -3404,6 +3429,9 @@ module.exports = {
     bloqueadosSlice,
     // #4373 (Ola 8.3) — slice consolidado de la vista Roadmap de olas.
     roadmapSlice,
+    // #4399 — helper de avance (cerrados/total/%) exportado para test unitario:
+    // asserta que deriva del MISMO `computeClosedSet` que la lista del pipeline.
+    _roadmapAvance,
     opsSlice,
     historialSlice,
     // #3963 — Historial timeline agrupado por día (CA-1..CA-5)

--- a/.pipeline/lib/wave-resolver.js
+++ b/.pipeline/lib/wave-resolver.js
@@ -11,15 +11,18 @@
 //      con TTL cache 2s. Es la única fuente canónica desde #3489 / H1.
 //      → source: 'waves.json'.
 //
-//   2. `.pipeline/.partial-pause.json` → fuente legacy de hecho mientras
-//      `waves.json` no esté poblado. Migration path heredado del diseño
-//      original; se mantiene para compatibilidad operativa.
-//      Schema: { allowed_issues: [...], created_at, source }
-//      → source: 'partial-pause.json'.
-//
-//   3. Fallback: todos los issues con archivos activos en el pipeline.
+//   2. Fallback: todos los issues con archivos activos en el pipeline.
 //      Etiqueta "Ola actual (sin label)" — degradación grácil (CA-15).
 //      → source: 'fs-fallback'.
+//
+// Modo legacy eliminado (#4399): la fuente intermedia que derivaba la ola
+// desde `.partial-pause.json → allowed_issues` (`readPartialPauseFile`)
+// producía números incoherentes cuando `waves.json` no tenía `active_wave`.
+// La cascada quedó `waves.json → fs-fallback`: `waves.json` sin `active_wave`
+// deja de ser un caso válido y cae directo a la degradación grácil.
+// (`resolveBlockDependencies`/`resolveLiveSplitChildren` SÍ siguen leyendo
+// `.partial-pause.json` para deps/split — uso legítimo distinto de la
+// resolución de ola.)
 //
 // Reglas inquebrantables:
 // - Sin red. Sin GitHub API. Solo filesystem propio del pipeline.
@@ -141,40 +144,6 @@ function readFromWavesJson(pipelineRoot) {
         issues: [...new Set(issues)].sort((a, b) => a - b),
         openedAt,
         source: 'waves.json',
-    };
-}
-
-/**
- * Lee `.partial-pause.json` y deriva la "ola actual" desde los issues permitidos.
- *
- * @param {string} pipelineRoot
- * @returns {{label: string, issues: number[], openedAt: string|null, source: string}|null}
- */
-function readPartialPauseFile(pipelineRoot) {
-    const file = path.join(pipelineRoot, '.partial-pause.json');
-    let raw;
-    try {
-        raw = fs.readFileSync(file, 'utf8');
-    } catch {
-        return null;
-    }
-    let parsed;
-    try {
-        parsed = JSON.parse(raw);
-    } catch {
-        return null;
-    }
-    if (!parsed || typeof parsed !== 'object') return null;
-    const issuesRaw = Array.isArray(parsed.allowed_issues) ? parsed.allowed_issues : [];
-    const issues = issuesRaw
-        .map(normalizeIssueNumber)
-        .filter(Boolean);
-    if (issues.length === 0) return null;
-    return {
-        label: 'Ola actual',
-        issues: [...new Set(issues)].sort((a, b) => a - b),
-        openedAt: typeof parsed.created_at === 'string' ? parsed.created_at : null,
-        source: 'partial-pause.json',
     };
 }
 
@@ -334,7 +303,7 @@ function resolveLiveSplitChildren(opts) {
  *   label: string,
  *   issues: number[],
  *   openedAt: string|null,
- *   source: 'waves.json'|'partial-pause.json'|'fs-fallback',
+ *   source: 'waves.json'|'fs-fallback',
  *   resolved: boolean,
  * }}
  */
@@ -344,12 +313,13 @@ function resolveActiveWave(opts) {
         return { label: 'Ola actual (sin label)', issues: [], openedAt: null, source: 'fs-fallback', resolved: false };
     }
 
+    // 1) Fuente canónica: waves.json → getActiveWave (#4399: única fuente).
     const fromWaves = readFromWavesJson(pipelineRoot);
     if (fromWaves) return { ...fromWaves, resolved: true };
 
-    const fromPartial = readPartialPauseFile(pipelineRoot);
-    if (fromPartial) return { ...fromPartial, resolved: true };
-
+    // 2) Degradación grácil: issues con archivos activos en el pipeline.
+    //    (#4399: eliminada la fuente intermedia `.partial-pause.json`; si
+    //    `waves.json` no tiene `active_wave`, se cae directo acá.)
     const fromFs = collectActiveIssuesFromFs(pipelineRoot);
     return { ...fromFs, resolved: fromFs.issues.length > 0 };
 }
@@ -459,7 +429,6 @@ module.exports = {
     // Exports internos para tests
     _internal: {
         readFromWavesJson,
-        readPartialPauseFile,
         collectActiveIssuesFromFs,
         normalizeIssueNumber,
         effectiveWavesPipelineDir,


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 6 archivos · +194 -75

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:skipped` aplicado por delivery

## Closes

Closes #4399
