### PR TITLE
[guru] Extender wire-up in-flight fallback a la rama non-Anthropic de ejecutarClaude

### DIFF
--- a/.pipeline/lib/commander/nonanthropic-stall-detect.js
+++ b/.pipeline/lib/commander/nonanthropic-stall-detect.js
@@ -1,0 +1,157 @@
+'use strict';
+
+// =============================================================================
+// nonanthropic-stall-detect.js — Detección in-stream temprana (first-byte 15s /
+// stream-gap 30s) para la rama non-Anthropic de `runNonAnthropic` (pulpo.js).
+//
+// Contexto (#3571):
+//   La rama Anthropic de `ejecutarClaude` ya cascadea temprano ante un provider
+//   que se cuelga (first-byte 15s / stream-gap 30s, `pulpo.js` ~10781-10813).
+//   La rama non-Anthropic sólo tenía el kill duro `HARD_NON_ANTH_MS`
+//   (= `TURN_BUDGET_MS` = 600s): si el fallback emitía parcial y stalleaba, o
+//   nunca emitía first-byte, el usuario esperaba hasta 10 min antes de cascadear.
+//
+//   Este helper encapsula SÓLO el ciclo de vida de los dos timers de detección
+//   + el guard `settled` (idempotencia frente a `close`/`error`). Reusa las
+//   primitivas ya validadas en producción de `inflight-shadow-detectors.js`
+//   (`shouldFireFirstByte`, `shouldFireStreamGap`, thresholds), sin definir
+//   constantes nuevas (CA-4).
+//
+// DECISIÓN DE ARQUITECTURA (arquitecto + security SEC-1):
+//   Este módulo NO es el `lib/commander/inflight-wire.js` que el issue descartó
+//   explícitamente. NO spawnea procesos, NO resuelve providers y NO toca el gate
+//   de data-residency (`drCheck2`). El `spawn` + `enforceDataResidency` por
+//   candidato quedan INLINE en `runNonAnthropic` (pulpo.js), aguas arriba de este
+//   helper. Acá sólo vive lógica de temporizadores pura y testeable — el caller
+//   provee los callbacks de cascada (`onFirstByte`/`onStreamGap`), que apuntan a
+//   `advanceOrGiveUp`, cuya re-resolución de cadena vuelve a pasar por `drCheck2`.
+//
+// SEC-2: el provider del siguiente intento NUNCA sale del stdout — lo resuelve
+//   `advanceOrGiveUp` (caller). Este módulo no lee stdout/stderr.
+// SEC-3: este módulo no loguea contenido crudo; el caller referencia sólo
+//   `res.provider` + thresholds en sus `log('commander', ...)`.
+// SEC-4: `cleanup()` limpia AMBOS timers en todos los caminos (first-byte,
+//   stream-gap, close, error) — sin fugas de handles en un proceso de días.
+// =============================================================================
+
+const inflightShadow = require('./inflight-shadow-detectors');
+
+// -----------------------------------------------------------------------------
+// createStallDetectors — arma los timers de detección temprana para UN intento
+// de provider non-Anthropic.
+//
+// opts:
+//   startTime         (number)   — timestamp del spawn (para first-byte).
+//   getLastChunkAt    (fn→number)— devuelve el timestamp del último chunk de
+//                                   stdout, o 0 si todavía no llegó ninguno
+//                                   (semántica `lastLineAt` del shadow detector).
+//   killProc          (fn)       — mata el proceso (SIGTERM). Envuelto en try/catch.
+//   onFirstByte       (fn)       — cascada por ausencia de first-byte (15s).
+//   onStreamGap       (fn)       — cascada por stream-gap (>30s tras un chunk).
+//   now               (fn→number)— reloj inyectable (default Date.now).
+//   firstByteThresholdMs / streamGapThresholdMs — override de thresholds (default
+//                                   los de `inflightShadow`, NO se inventan valores).
+//   streamGapPollMs   (number)   — período del interval de stream-gap (default 5000,
+//                                   NO busy-wait; espeja la rama Anthropic).
+//   timers            (obj)      — inyección de setTimeout/setInterval/clear* para tests.
+//
+// Devuelve: { cleanup, markSettled, isSettled }.
+//   - markSettled(): idempotencia para `close`/`error`. Devuelve `true` si el
+//     intento YA estaba settled (p. ej. porque un detector ya cascadeó) → el
+//     caller debe cortar (`return`) para no doble-invocar `advanceOrGiveUp` (CA-3).
+//   - cleanup(): limpia ambos timers (llamado internamente al disparar y expuesto
+//     para el caller en `close`/`error`).
+// -----------------------------------------------------------------------------
+function createStallDetectors(opts = {}) {
+    const {
+        startTime,
+        getLastChunkAt,
+        killProc,
+        onFirstByte,
+        onStreamGap,
+        now,
+        firstByteThresholdMs,
+        streamGapThresholdMs,
+        streamGapPollMs,
+        timers,
+    } = opts;
+
+    const _now = typeof now === 'function' ? now : () => Date.now();
+    const _lastChunkAt = typeof getLastChunkAt === 'function' ? getLastChunkAt : () => 0;
+    const _kill = typeof killProc === 'function' ? killProc : () => {};
+    const _onFirstByte = typeof onFirstByte === 'function' ? onFirstByte : () => {};
+    const _onStreamGap = typeof onStreamGap === 'function' ? onStreamGap : () => {};
+
+    const _fbThreshold = Number.isFinite(firstByteThresholdMs)
+        ? firstByteThresholdMs
+        : inflightShadow.FIRST_BYTE_THRESHOLD_MS;
+    const _sgThreshold = Number.isFinite(streamGapThresholdMs)
+        ? streamGapThresholdMs
+        : inflightShadow.STREAM_GAP_THRESHOLD_MS;
+    const _pollMs = Number.isFinite(streamGapPollMs) ? streamGapPollMs : 5000;
+
+    const _setTimeout = (timers && timers.setTimeout) || setTimeout;
+    const _setInterval = (timers && timers.setInterval) || setInterval;
+    const _clearTimeout = (timers && timers.clearTimeout) || clearTimeout;
+    const _clearInterval = (timers && timers.clearInterval) || clearInterval;
+
+    let settled = false;
+    let firstByteFired = false;
+    let streamGapFired = false;
+    let firstByteTimer = null;
+    let streamGapTimer = null;
+
+    const cleanup = () => {
+        if (firstByteTimer !== null) { _clearTimeout(firstByteTimer); firstByteTimer = null; }
+        if (streamGapTimer !== null) { _clearInterval(streamGapTimer); streamGapTimer = null; }
+    };
+
+    // Marca el intento como resuelto (por close/error del caller). Idempotente:
+    // devuelve el estado PREVIO para que el caller sepa si un detector ya cascadeó.
+    const markSettled = () => {
+        const was = settled;
+        settled = true;
+        cleanup();
+        return was;
+    };
+
+    firstByteTimer = _setTimeout(() => {
+        if (settled) return;
+        if (inflightShadow.shouldFireFirstByte({
+            startTime,
+            now: _now(),
+            lastLineAt: _lastChunkAt(),
+            alreadyFired: firstByteFired,
+            thresholdMs: _fbThreshold,
+        })) {
+            firstByteFired = true;
+            settled = true;
+            cleanup();
+            try { _kill(); } catch { /* best-effort */ }
+            _onFirstByte();
+        }
+    }, _fbThreshold);
+
+    streamGapTimer = _setInterval(() => {
+        if (settled) return;
+        if (inflightShadow.shouldFireStreamGap({
+            lastLineAt: _lastChunkAt(),
+            now: _now(),
+            // El subproceso fallback non-Anthropic no ejecuta Skills → nunca hay
+            // Skill in-flight que deba pausar el detector (nota de diseño guru p.4).
+            pendingSkillCallsSize: 0,
+            alreadyFired: streamGapFired,
+            thresholdMs: _sgThreshold,
+        })) {
+            streamGapFired = true;
+            settled = true;
+            cleanup();
+            try { _kill(); } catch { /* best-effort */ }
+            _onStreamGap();
+        }
+    }, _pollMs);
+
+    return { cleanup, markSettled, isSettled: () => settled };
+}
+
+module.exports = { createStallDetectors };

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -90,6 +90,10 @@ const commanderApiRag = require('./lib/commander/api-rag');
 // y los emiten al audit log SIN matar el primario ni spawnear secundario.
 // Wire-up real va en #3578.
 const inflightShadow = require('./lib/commander/inflight-shadow-detectors');
+// #3571 — detección in-stream temprana (first-byte 15s / stream-gap 30s) para la
+// rama non-Anthropic de runNonAnthropic. Sólo ciclo de timers + guard `settled`
+// (NO spawn, NO drCheck2 — quedan inline en pulpo, SEC-1 intacto).
+const nonAnthStall = require('./lib/commander/nonanthropic-stall-detect');
 // #3577 — generateRequestId para correlación cross-event (CA-S6): el mismo
 // requestId se propaga a TODOS los `auditCommanderRequest` del turn.
 const inflightFallback = require('./lib/commander/inflight-fallback');
@@ -10066,10 +10070,39 @@ function ejecutarClaude(prompt, textoOriginal, trace, fallbackParts) {
               try { proc.kill('SIGTERM'); } catch {}
               log('commander', `Provider ${res.provider} timeout ${Math.round(HARD_NON_ANTH_MS / 1000)}s — abortando`);
             }, HARD_NON_ANTH_MS);
-            proc.stdout && proc.stdout.on('data', (d) => { stdout += d.toString(); });
+            // #3571 — timestamp del último chunk de stdout (0 = ningún chunk aún,
+            // semántica first-byte). El detector temprano lo lee vía closure.
+            let lastChunkAt = 0;
+            proc.stdout && proc.stdout.on('data', (d) => { stdout += d.toString(); lastChunkAt = Date.now(); });
             proc.stderr && proc.stderr.on('data', (d) => { stderr += d.toString(); });
+            // #3571 — detección in-stream temprana (first-byte 15s / stream-gap 30s)
+            // para cascadear al detectar stall en ~15s/30s en vez de esperar el kill
+            // duro (HARD_NON_ANTH_MS=TURN_BUDGET_MS=600s). Reusa `inflightShadow`; el
+            // helper sólo maneja timers + guard `settled` (spawn/drCheck2 quedan inline,
+            // SEC-1 intacto). El provider del siguiente intento sale de advanceOrGiveUp
+            // (resolver), NUNCA del stdout (SEC-2). Los logs referencian sólo
+            // res.provider + thresholds, jamás stdout/stderr crudo (SEC-3).
+            const stall = nonAnthStall.createStallDetectors({
+              startTime: startNon,
+              getLastChunkAt: () => lastChunkAt,
+              killProc: () => { try { proc.kill('SIGTERM'); } catch {} },
+              onFirstByte: () => {
+                clearTimeout(timer);
+                log('commander', `Provider ${res.provider} sin first-byte en ${Math.round(inflightShadow.FIRST_BYTE_THRESHOLD_MS / 1000)}s — cascada temprana.`);
+                return advanceOrGiveUp(res.provider, 'timeout_first_byte');
+              },
+              onStreamGap: () => {
+                clearTimeout(timer);
+                log('commander', `Provider ${res.provider} stream-gap >${Math.round(inflightShadow.STREAM_GAP_THRESHOLD_MS / 1000)}s — cascada temprana.`);
+                return advanceOrGiveUp(res.provider, 'timeout_no_new_bytes_30s');
+              },
+            });
             proc.on('close', () => {
               clearTimeout(timer);
+              // #3571 — si un detector temprano ya cascadeó (settled), este `close`
+              // (disparado por el SIGTERM del kill temprano) NO debe re-invocar
+              // advanceOrGiveUp (CA-3). markSettled() limpia también ambos timers (SEC-4).
+              if (stall.markSettled()) return;
               const elapsed = Date.now() - startNon;
               const extracted = commanderMP.extractFallbackReply(stdout);
               log('commander', `Provider ${res.provider} terminó (${elapsed}ms, stdout=${stdout.length}c, reply=${extracted.text.length}c, parsed=${extracted.parsed}, stderr=${stderr.length}c)`);
@@ -10133,6 +10166,8 @@ function ejecutarClaude(prompt, textoOriginal, trace, fallbackParts) {
             });
             proc.on('error', (e) => {
               clearTimeout(timer);
+              // #3571 — mismo guard de idempotencia + cleanup de timers que en `close`.
+              if (stall.markSettled()) return;
               log('commander', `Error spawning ${res.provider}: ${e.message} — intento siguiente provider.`);
               return advanceOrGiveUp(res.provider, 'spawn_error');
             });

--- a/.pipeline/tests/pulpo-nonanthropic-early-detect.test.js
+++ b/.pipeline/tests/pulpo-nonanthropic-early-detect.test.js
@@ -1,0 +1,255 @@
+// =============================================================================
+// pulpo-nonanthropic-early-detect.test.js — Detección in-stream temprana de la
+// rama non-Anthropic de runNonAnthropic (#3571).
+//
+// La lógica inline de `runNonAnthropic` (pulpo.js) no es unit-testeable de forma
+// aislada (pulpo.js no exporta `ejecutarClaude`), así que el ciclo de vida de los
+// timers de detección temprana + el guard `settled` vive en el helper puro
+// `lib/commander/nonanthropic-stall-detect.js`, que pulpo cablea inline. Estos
+// tests ejercen ese helper con timers y reloj fakeados.
+//
+// Cubre los CA del PO (#3571):
+//   CA-1 — cascada temprana por ausencia de first-byte (15s) → onFirstByte + kill.
+//   CA-2 — cascada temprana por stream-gap (30s) tras un chunk parcial → onStreamGap.
+//   CA-3 — idempotencia: close tras el kill temprano NO re-cascadea (markSettled).
+//   CA-4 — thresholds reusados de inflightShadow (15s/30s), sin constantes nuevas.
+//   CA-6 — cleanup completo de timers en todos los caminos de salida (SEC-4).
+//   Negativos — first-byte no dispara si ya hubo chunk; stream-gap no dispara sin chunk.
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const stall = require('../lib/commander/nonanthropic-stall-detect');
+const inflightShadow = require('../lib/commander/inflight-shadow-detectors');
+
+// -----------------------------------------------------------------------------
+// Harness de fake-timers: captura callbacks de setTimeout/setInterval y permite
+// dispararlos manualmente + registra clears para verificar cleanup (SEC-4).
+// -----------------------------------------------------------------------------
+function makeFakeTimers() {
+    let seq = 0;
+    const timeouts = new Map();
+    const intervals = new Map();
+    const clears = { timeouts: [], intervals: [] };
+    return {
+        timeouts,
+        intervals,
+        clears,
+        api: {
+            setTimeout: (fn, ms) => { const id = ++seq; timeouts.set(id, { fn, ms, cleared: false }); return id; },
+            setInterval: (fn, ms) => { const id = ++seq; intervals.set(id, { fn, ms, cleared: false }); return id; },
+            clearTimeout: (id) => { clears.timeouts.push(id); const t = timeouts.get(id); if (t) t.cleared = true; },
+            clearInterval: (id) => { clears.intervals.push(id); const t = intervals.get(id); if (t) t.cleared = true; },
+        },
+        fireTimeout: (id) => { const t = timeouts.get(id); if (t && !t.cleared) t.fn(); },
+        tickInterval: (id) => { const t = intervals.get(id); if (t && !t.cleared) t.fn(); },
+    };
+}
+
+// El primer setTimeout registrado es el firstByteTimer; el primer setInterval es
+// el streamGapTimer (orden de creación en el helper).
+function firstTimeoutId(ft) { return [...ft.timeouts.keys()][0]; }
+function firstIntervalId(ft) { return [...ft.intervals.keys()][0]; }
+
+// -----------------------------------------------------------------------------
+// CA-1 — first-byte: sin ningún chunk en 15s → cascada temprana.
+// -----------------------------------------------------------------------------
+test('runNonAnthropic cascadea al siguiente provider si no hay first-byte en 15s', () => {
+    const ft = makeFakeTimers();
+    const calls = [];
+    const startTime = 1_000_000;
+    stall.createStallDetectors({
+        startTime,
+        getLastChunkAt: () => 0, // nunca llegó un chunk
+        now: () => startTime + inflightShadow.FIRST_BYTE_THRESHOLD_MS, // 15s exactos
+        killProc: () => calls.push(['kill']),
+        onFirstByte: () => calls.push(['firstByte']),
+        onStreamGap: () => calls.push(['streamGap']),
+        timers: ft.api,
+    });
+
+    ft.fireTimeout(firstTimeoutId(ft));
+
+    assert.deepEqual(calls, [['kill'], ['firstByte']]);
+    // no debe haber disparado stream-gap
+    assert.ok(!calls.some(c => c[0] === 'streamGap'));
+});
+
+// -----------------------------------------------------------------------------
+// CA-2 — stream-gap: un chunk parcial y luego silencio >30s → cascada temprana.
+// -----------------------------------------------------------------------------
+test('runNonAnthropic cascadea si el stream stallea >30s tras un chunk parcial', () => {
+    const ft = makeFakeTimers();
+    const calls = [];
+    const startTime = 2_000_000;
+    const chunkAt = startTime + 1_000; // llegó un chunk al segundo
+    stall.createStallDetectors({
+        startTime,
+        getLastChunkAt: () => chunkAt,
+        now: () => chunkAt + inflightShadow.STREAM_GAP_THRESHOLD_MS, // 30s tras el chunk
+        killProc: () => calls.push(['kill']),
+        onFirstByte: () => calls.push(['firstByte']),
+        onStreamGap: () => calls.push(['streamGap']),
+        timers: ft.api,
+    });
+
+    // el tick del interval evalúa el detector de stream-gap
+    ft.tickInterval(firstIntervalId(ft));
+
+    assert.deepEqual(calls, [['kill'], ['streamGap']]);
+    // first-byte NO debe disparar: ya hubo chunk (lastChunkAt > 0)
+    assert.ok(!calls.some(c => c[0] === 'firstByte'));
+});
+
+// -----------------------------------------------------------------------------
+// CA-3 — idempotencia: close tras el kill temprano NO re-cascadea.
+// -----------------------------------------------------------------------------
+test('runNonAnthropic no cascadea dos veces cuando close llega tras el kill temprano', () => {
+    const ft = makeFakeTimers();
+    const calls = [];
+    const startTime = 3_000_000;
+    const det = stall.createStallDetectors({
+        startTime,
+        getLastChunkAt: () => 0,
+        now: () => startTime + inflightShadow.FIRST_BYTE_THRESHOLD_MS,
+        killProc: () => calls.push(['kill']),
+        onFirstByte: () => calls.push(['firstByte']),
+        onStreamGap: () => calls.push(['streamGap']),
+        timers: ft.api,
+    });
+
+    // el detector temprano dispara la cascada
+    ft.fireTimeout(firstTimeoutId(ft));
+    assert.equal(calls.filter(c => c[0] === 'firstByte').length, 1);
+
+    // el proc muere por el SIGTERM → llega `close`. El caller consulta markSettled():
+    const wasSettled = det.markSettled();
+    assert.equal(wasSettled, true, 'markSettled debe indicar que el intento YA estaba resuelto');
+
+    // el caller cortó (return) → onFirstByte no se invocó de nuevo
+    assert.equal(calls.filter(c => c[0] === 'firstByte').length, 1);
+});
+
+// -----------------------------------------------------------------------------
+// CA-4 — thresholds reusados de inflightShadow (sin constantes nuevas).
+// -----------------------------------------------------------------------------
+test('los thresholds provienen de inflightShadow (15s/30s), no se inventan valores', () => {
+    assert.equal(inflightShadow.FIRST_BYTE_THRESHOLD_MS, 15 * 1000);
+    assert.equal(inflightShadow.STREAM_GAP_THRESHOLD_MS, 30 * 1000);
+
+    const ft = makeFakeTimers();
+    stall.createStallDetectors({
+        startTime: 0,
+        getLastChunkAt: () => 0,
+        killProc: () => {},
+        onFirstByte: () => {},
+        onStreamGap: () => {},
+        timers: ft.api,
+    });
+    // el firstByteTimer se arma al threshold de inflightShadow
+    assert.equal(ft.timeouts.get(firstTimeoutId(ft)).ms, inflightShadow.FIRST_BYTE_THRESHOLD_MS);
+    // el stream-gap corre por interval a 5000ms (NO busy-wait; espeja la rama Anthropic)
+    assert.equal(ft.intervals.get(firstIntervalId(ft)).ms, 5000);
+});
+
+// -----------------------------------------------------------------------------
+// CA-6 (SEC-4) — cleanup completo de timers en todos los caminos de salida.
+// -----------------------------------------------------------------------------
+test('los timers de deteccion temprana se limpian por first-byte', () => {
+    const ft = makeFakeTimers();
+    const startTime = 4_000_000;
+    stall.createStallDetectors({
+        startTime,
+        getLastChunkAt: () => 0,
+        now: () => startTime + inflightShadow.FIRST_BYTE_THRESHOLD_MS,
+        killProc: () => {},
+        onFirstByte: () => {},
+        onStreamGap: () => {},
+        timers: ft.api,
+    });
+    ft.fireTimeout(firstTimeoutId(ft));
+    assert.equal(ft.clears.timeouts.length, 1, 'firstByteTimer limpiado');
+    assert.equal(ft.clears.intervals.length, 1, 'streamGapTimer limpiado');
+});
+
+test('los timers de deteccion temprana se limpian por stream-gap', () => {
+    const ft = makeFakeTimers();
+    const startTime = 5_000_000;
+    const chunkAt = startTime + 1_000;
+    stall.createStallDetectors({
+        startTime,
+        getLastChunkAt: () => chunkAt,
+        now: () => chunkAt + inflightShadow.STREAM_GAP_THRESHOLD_MS,
+        killProc: () => {},
+        onFirstByte: () => {},
+        onStreamGap: () => {},
+        timers: ft.api,
+    });
+    ft.tickInterval(firstIntervalId(ft));
+    assert.equal(ft.clears.timeouts.length, 1);
+    assert.equal(ft.clears.intervals.length, 1);
+});
+
+test('los timers de deteccion temprana se limpian por close/error (markSettled)', () => {
+    const ft = makeFakeTimers();
+    const det = stall.createStallDetectors({
+        startTime: 6_000_000,
+        getLastChunkAt: () => 0,
+        killProc: () => {},
+        onFirstByte: () => {},
+        onStreamGap: () => {},
+        timers: ft.api,
+    });
+    // close/error del caller → markSettled() limpia ambos timers
+    const was = det.markSettled();
+    assert.equal(was, false, 'primer markSettled reporta que NO estaba resuelto');
+    assert.equal(ft.clears.timeouts.length, 1);
+    assert.equal(ft.clears.intervals.length, 1);
+    assert.equal(det.isSettled(), true);
+});
+
+// -----------------------------------------------------------------------------
+// Negativo — tras markSettled los detectores ya no cascadean (guard settled).
+// -----------------------------------------------------------------------------
+test('un detector que dispara tras markSettled NO cascadea (guard settled)', () => {
+    const ft = makeFakeTimers();
+    const calls = [];
+    const startTime = 7_000_000;
+    const det = stall.createStallDetectors({
+        startTime,
+        getLastChunkAt: () => 0,
+        now: () => startTime + inflightShadow.FIRST_BYTE_THRESHOLD_MS,
+        killProc: () => calls.push(['kill']),
+        onFirstByte: () => calls.push(['firstByte']),
+        onStreamGap: () => calls.push(['streamGap']),
+        timers: ft.api,
+    });
+
+    // el intento se resolvió por otro camino (p. ej. close-ok) antes del timer
+    det.markSettled();
+    // el timer intenta disparar después: el guard `settled` lo corta
+    ft.fireTimeout(firstTimeoutId(ft));
+    assert.equal(calls.length, 0, 'ningún callback tras settled');
+});
+
+// -----------------------------------------------------------------------------
+// Negativo — first-byte no dispara si YA hubo un chunk (lastChunkAt > 0).
+// -----------------------------------------------------------------------------
+test('first-byte no dispara si ya llegó un chunk antes del threshold', () => {
+    const ft = makeFakeTimers();
+    const calls = [];
+    const startTime = 8_000_000;
+    stall.createStallDetectors({
+        startTime,
+        getLastChunkAt: () => startTime + 2_000, // ya hubo chunk
+        now: () => startTime + inflightShadow.FIRST_BYTE_THRESHOLD_MS,
+        killProc: () => calls.push(['kill']),
+        onFirstByte: () => calls.push(['firstByte']),
+        onStreamGap: () => calls.push(['streamGap']),
+        timers: ft.api,
+    });
+    ft.fireTimeout(firstTimeoutId(ft));
+    assert.ok(!calls.some(c => c[0] === 'firstByte'), 'no cascadea por first-byte si hubo chunk');
+});


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 3 archivos · +448 -1

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:passed` aplicado por delivery

## Closes

Closes #3571
