### PR TITLE
[Split de #4363] Auditoría, stickiness por conversación y dashboard del balanceo de providers

### DIFF
--- a/.pipeline/lib/__tests__/commander-multi-provider.test.js
+++ b/.pipeline/lib/__tests__/commander-multi-provider.test.js
@@ -1187,3 +1187,247 @@ test('#4412 CA-5/SEC-2 — el validator rechaza clave arbitraria y valor fuera d
         cleanup(dir);
     }
 });
+
+// =============================================================================
+// #4413 (Parte 3/3 de #4363) — Auditoría aditiva + stickiness por conversación.
+// =============================================================================
+
+const auditLog = require('../audit-log');
+const stickiness = require('../commander/provider-stickiness');
+
+// Balancer fake "completo": implementa selectProvider + los internos que
+// consulta la ruta de stickiness (_buildCandidateSet / _computeWeights). Permite
+// controlar qué providers están SANOS (eligible) y qué reelige el SWRR (pick).
+function fakeBalancerFull({ eligible = [], pick = null, weight = 0.5 } = {}) {
+    return {
+        selectProvider: () => pick,
+        _buildCandidateSet: () => eligible.map((p) => ({ provider: p, quotaPct: 100 })),
+        _computeWeights: (cands) => cands.map((c) => ({
+            provider: c.provider, weight, quotaPct: c.quotaPct,
+        })),
+    };
+}
+
+// -----------------------------------------------------------------------------
+// CA-9 / A09 — auditCommanderRequest persiste weight/quota_pct/selection_reason
+// -----------------------------------------------------------------------------
+
+test('#4413 CA-9 — auditCommanderRequest persiste weight/quota_pct/selection_reason sin romper campos canónicos', () => {
+    const dir = mkTmpPipelineDir();
+    try {
+        const ok = cmp.auditCommanderRequest({
+            pipelineDir: dir,
+            event: 'dispatch',
+            providerIntended: 'anthropic',
+            providerEffective: 'openai-codex',
+            chainTried: ['anthropic', 'openai-codex'],
+            chatId: 'chat-xyz',
+            prompt: 'hola',
+            weight: 0.42,
+            quotaPct: 73,
+            selectionReason: 'quota_rebalance',
+        });
+        assert.equal(ok, true);
+        const files = fs.readdirSync(path.join(dir, 'logs')).filter((f) => f.startsWith('commander-dispatch-'));
+        const content = fs.readFileSync(path.join(dir, 'logs', files[0]), 'utf8').trim();
+        const entry = JSON.parse(content.split('\n').pop());
+        // Campos nuevos (aditivos).
+        assert.equal(entry.weight, 0.42);
+        assert.equal(entry.quota_pct, 73);
+        assert.equal(entry.selection_reason, 'quota_rebalance');
+        // Campos canónicos intactos (A09 — prohibido reordenar/renombrar).
+        assert.equal(entry.event, 'dispatch');
+        assert.equal(entry.provider_intended, 'anthropic');
+        assert.equal(entry.provider_effective, 'openai-codex');
+        assert.deepEqual(entry.chain_tried, ['anthropic', 'openai-codex']);
+        assert.equal(entry.chat_id_hash.length, 12);
+        assert.equal(entry.prompt_hash.length, 12);
+        assert.ok('created_at' in entry);
+    } finally {
+        cleanup(dir);
+    }
+});
+
+test('#4413 CA-9 — back-compat: sin los 3 campos nuevos, quedan en null (eventos sin balanceo)', () => {
+    const dir = mkTmpPipelineDir();
+    try {
+        cmp.auditCommanderRequest({
+            pipelineDir: dir, event: 'dispatch', providerIntended: 'anthropic',
+            providerEffective: 'anthropic', chatId: 'c', prompt: 'x',
+        });
+        const files = fs.readdirSync(path.join(dir, 'logs')).filter((f) => f.startsWith('commander-dispatch-'));
+        const entry = JSON.parse(fs.readFileSync(path.join(dir, 'logs', files[0]), 'utf8').trim().split('\n').pop());
+        assert.equal(entry.weight, null);
+        assert.equal(entry.quota_pct, null);
+        assert.equal(entry.selection_reason, null);
+    } finally {
+        cleanup(dir);
+    }
+});
+
+// -----------------------------------------------------------------------------
+// CA-2 / A08 — verifyChain sigue verde tras persistir los campos nuevos
+// -----------------------------------------------------------------------------
+
+test('#4413 CA-2/A08 — audit-log.verifyChain sigue verde tras persistir weight/quota_pct/selection_reason', () => {
+    const dir = mkTmpPipelineDir();
+    try {
+        for (let i = 0; i < 4; i++) {
+            cmp.auditCommanderRequest({
+                pipelineDir: dir, event: 'dispatch', providerIntended: 'anthropic',
+                providerEffective: i % 2 ? 'openai-codex' : 'anthropic',
+                chainTried: ['anthropic', 'openai-codex'], chatId: `c-${i}`, prompt: `p-${i}`,
+                weight: 0.1 * i, quotaPct: 10 * i, selectionReason: 'quality_bias',
+            });
+        }
+        const file = cmp._auditFile(dir, Date.now());
+        const res = auditLog.verifyChain(file);
+        assert.equal(res.ok, true, `hash-chain debe verificar verde: ${JSON.stringify(res)}`);
+        assert.equal(res.entriesChecked, 4);
+    } finally {
+        cleanup(dir);
+    }
+});
+
+// -----------------------------------------------------------------------------
+// A02 — redact aplicado en el log de la ruta de balanceo (selection_reason)
+// -----------------------------------------------------------------------------
+
+test('#4413 A02 — selection_reason se redacta en origen: un secreto embebido NO viaja al audit', () => {
+    const dir = mkTmpPipelineDir();
+    try {
+        // selection_reason con una AWS access-key-id embebida (nunca debería pasar,
+        // pero probamos la defensa en profundidad de redacción en origen).
+        cmp.auditCommanderRequest({
+            pipelineDir: dir, event: 'dispatch', providerEffective: 'anthropic',
+            chatId: 'c', prompt: 'x',
+            selectionReason: 'AKIAIOSFODNN7EXAMPLE',
+        });
+        const files = fs.readdirSync(path.join(dir, 'logs')).filter((f) => f.startsWith('commander-dispatch-'));
+        const content = fs.readFileSync(path.join(dir, 'logs', files[0]), 'utf8');
+        assert.doesNotMatch(content, /AKIAIOSFODNN7EXAMPLE/, 'la key NO debe quedar en el log');
+        const entry = JSON.parse(content.trim().split('\n').pop());
+        assert.match(entry.selection_reason, /\[REDACTED\]/);
+    } finally {
+        cleanup(dir);
+    }
+});
+
+test('#4413 A02 — _redactSelectionReason preserva un reason legítimo (enum del balancer)', () => {
+    assert.equal(cmp._redactSelectionReason('quota_rebalance'), 'quota_rebalance');
+    assert.equal(cmp._redactSelectionReason(''), null);
+    assert.equal(cmp._redactSelectionReason(null), null);
+});
+
+// -----------------------------------------------------------------------------
+// CA-4 / CA-6 — stickiness (unidad del módulo)
+// -----------------------------------------------------------------------------
+
+test('#4413 CA-4 — stickiness mantiene el provider para el mismo chat_id_hash dentro de la ventana', () => {
+    const store = new Map();
+    const hash = cmp._hashFor('chat-1');
+    const t0 = 1_000_000;
+    assert.equal(stickiness.getStickyProvider({ chatIdHash: hash, now: t0, store }), null);
+    assert.equal(stickiness.setStickyProvider({ chatIdHash: hash, provider: 'openai-codex', now: t0, store }), true);
+    // Turno siguiente dentro de la ventana (30 min default): mismo provider.
+    assert.equal(
+        stickiness.getStickyProvider({ chatIdHash: hash, now: t0 + 5 * 60 * 1000, store }),
+        'openai-codex',
+    );
+});
+
+test('#4413 CA-4 — stickiness expira al superar la ventana temporal → null (reelección)', () => {
+    const store = new Map();
+    const hash = cmp._hashFor('chat-2');
+    const t0 = 1_000_000;
+    stickiness.setStickyProvider({ chatIdHash: hash, provider: 'anthropic', now: t0, store, windowMs: 1000 });
+    // Dentro de la ventana explícita de 1s.
+    assert.equal(stickiness.getStickyProvider({ chatIdHash: hash, now: t0 + 500, windowMs: 1000, store }), 'anthropic');
+    // Fuera de la ventana → null + purga.
+    assert.equal(stickiness.getStickyProvider({ chatIdHash: hash, now: t0 + 1500, windowMs: 1000, store }), null);
+    assert.equal(store.has(hash), false, 'la entry expirada se purga (lazy expiry)');
+});
+
+test('#4413 CA-6 — stickiness indexa por chat_id_hash y NUNCA materializa chat_id crudo', () => {
+    const store = new Map();
+    const rawChatId = '987654321'; // chat_id crudo de Telegram
+    const hash = cmp._hashFor(rawChatId);
+    stickiness.setStickyProvider({ chatIdHash: hash, provider: 'anthropic', now: 1000, store });
+    // El store guarda SOLO el hash, no el chat_id crudo.
+    assert.equal(store.has(hash), true);
+    assert.equal(store.has(rawChatId), false, 'el chat_id crudo NO debe ser una clave del store');
+    // El módulo rechaza un chatIdHash que no sea hex-only (defensa de formato).
+    assert.equal(stickiness.setStickyProvider({ chatIdHash: 'not-a-hash!', provider: 'x', now: 1, store }), false);
+});
+
+// -----------------------------------------------------------------------------
+// CA-6 / CA-5 — stickiness integrada en la ruta de balanceo
+// -----------------------------------------------------------------------------
+
+test('#4413 CA-6 — la ruta de balanceo REUSA el provider pegado en el turno siguiente (stickiness > reelección)', () => {
+    const dir = mkTmpBalancingDir({ enabled: true, quality_bias: 0.7, min_primary_quota_pct: 30 });
+    stickiness._resetState(); // aislar el store in-memory compartido
+    try {
+        const chatId = 'chat-sticky-1';
+        // Turno 1: sin sticky → reelige openai-codex (pick del fake) y lo pega.
+        const r1 = cmp.resolveCommanderProvider({
+            pipelineDir: dir, log: () => {}, quotaModule: makeFakeQuotaModule([]),
+            requestText: '/lanzar', requiresToolUse: false, chatId,
+            balancerModule: fakeBalancerFull({ eligible: ['anthropic', 'openai-codex'], pick: { provider: 'openai-codex', weight: 0.5, quotaPct: 80, reason: 'quota_rebalance' } }),
+        });
+        assert.equal(r1.provider, 'openai-codex');
+        assert.equal(r1.selectionReason, 'quota_rebalance');
+        // Turno 2: el SWRR ahora "elegiría" anthropic, pero el sticky openai-codex
+        // sigue SANO dentro de la ventana → se reusa (no reelige).
+        const r2 = cmp.resolveCommanderProvider({
+            pipelineDir: dir, log: () => {}, quotaModule: makeFakeQuotaModule([]),
+            requestText: '/lanzar', requiresToolUse: false, chatId,
+            balancerModule: fakeBalancerFull({ eligible: ['anthropic', 'openai-codex'], pick: { provider: 'anthropic', weight: 1, quotaPct: 100, reason: 'quality_bias' } }),
+        });
+        assert.equal(r2.provider, 'openai-codex', 'debe mantener el provider pegado (CA-6)');
+        assert.equal(r2.selectionReason, 'stickiness');
+    } finally {
+        stickiness._resetState();
+        cleanup(dir);
+    }
+});
+
+test('#4413 CA-5/D3 — la ruta de balanceo FUERZA reelección cuando el provider pegado ya no está sano (gateado)', () => {
+    const dir = mkTmpBalancingDir({ enabled: true, quality_bias: 0.7, min_primary_quota_pct: 30 });
+    stickiness._resetState();
+    try {
+        const chatId = 'chat-sticky-2';
+        // Turno 1: pega openai-codex.
+        cmp.resolveCommanderProvider({
+            pipelineDir: dir, log: () => {}, quotaModule: makeFakeQuotaModule([]),
+            requestText: '/lanzar', requiresToolUse: false, chatId,
+            balancerModule: fakeBalancerFull({ eligible: ['anthropic', 'openai-codex'], pick: { provider: 'openai-codex', weight: 0.5, quotaPct: 80, reason: 'quota_rebalance' } }),
+        });
+        // Turno 2: openai-codex YA NO está en el candidato sano (gateado) →
+        // reelección forzada → anthropic. No queda pinned al provider caído.
+        const r2 = cmp.resolveCommanderProvider({
+            pipelineDir: dir, log: () => {}, quotaModule: makeFakeQuotaModule([]),
+            requestText: '/lanzar', requiresToolUse: false, chatId,
+            balancerModule: fakeBalancerFull({ eligible: ['anthropic'], pick: { provider: 'anthropic', weight: 1, quotaPct: 100, reason: 'quality_bias' } }),
+        });
+        assert.equal(r2.provider, 'anthropic', 'reelección forzada al gatearse el sticky (D3)');
+        assert.equal(r2.selectionReason, 'quality_bias');
+    } finally {
+        stickiness._resetState();
+        cleanup(dir);
+    }
+});
+
+test('#4413 CA-1 — shape estricto (OFF) también expone weight/quotaPct/selectionReason en null (paridad + audit)', () => {
+    const dir = mkTmpBalancingDir({ enabled: false });
+    try {
+        const r = cmp.resolveCommanderProvider({
+            pipelineDir: dir, log: () => {}, quotaModule: makeFakeQuotaModule([]), requestText: 'hola',
+        });
+        assert.equal(r.weight, null);
+        assert.equal(r.quotaPct, null);
+        assert.equal(r.selectionReason, null);
+    } finally {
+        cleanup(dir);
+    }
+});

--- a/.pipeline/lib/commander/multi-provider.js
+++ b/.pipeline/lib/commander/multi-provider.js
@@ -61,6 +61,20 @@ const fs = require('node:fs');
 const path = require('node:path');
 const crypto = require('node:crypto');
 
+// #4413 (A02) — redacción en origen de todo campo de texto libre nuevo de la
+// ruta de balanceo antes de que llegue al audit log. `selection_reason` es un
+// enum acotado por el balancer, pero lo pasamos igual por `redactSecretValue`
+// (defensa en profundidad: si alguna vez arrastra texto libre, no viajan
+// secretos). Carga perezosa para no penalizar el require en callers que no
+// tocan la ruta de balanceo.
+let _redact = null;
+function redactModule() {
+    if (_redact === null) {
+        try { _redact = require('../redact'); } catch { _redact = false; }
+    }
+    return _redact || null;
+}
+
 const COMMANDER_SKILL = 'telegram-commander';
 
 // -----------------------------------------------------------------------------
@@ -165,6 +179,10 @@ function resolveCommanderProvider(opts = {}) {
         agentModelsReader,
         requestClassifyModule,
         balancerStore,
+        // #4413 — stickiness por conversación (opcional; sólo relevante con el
+        // balanceo ON). `chatId` se hashea dentro del balancer con `hashFor`.
+        chatId,
+        stickinessModule,
     } = opts;
 
     const _dispatch = dispatchModule || require('../agent-launcher/dispatch-with-fallback');
@@ -190,13 +208,18 @@ function resolveCommanderProvider(opts = {}) {
             agentModelsReader,
             requestClassifyModule,
             balancerStore,
+            chatId,
+            stickinessModule,
         });
         if (balanced) return balanced;
     } catch (e) {
         _log('commander', `⚠️ #4412 balanceo degradó a orden estricto: ${(e && e.message) || e}`);
     }
 
-    return _dispatch.resolveSpawnWithFallback({
+    // #4413 CA-9 — la cadena estricta no produce metadata de balanceo; la
+    // normalizamos a null para que el shape sea idéntico al balanceado (CA-1) y
+    // el audit persista siempre las 3 claves aditivas (null en el camino OFF).
+    const strict = _dispatch.resolveSpawnWithFallback({
         skill: COMMANDER_SKILL,
         issue: issue || 'commander-chat',
         pipelineDir,
@@ -205,6 +228,19 @@ function resolveCommanderProvider(opts = {}) {
         onLog: _log,
         now,
     });
+    return _normalizeBalancerMeta(strict);
+}
+
+// #4413 — asegura que una resolución exponga las 3 claves de metadata de
+// balanceo (weight/quotaPct/selectionReason). Si ya vienen (camino balanceado),
+// no las pisa; si no (camino estricto), las agrega en null. Aditivo: preserva
+// el resto del shape. Devuelve el mismo objeto (o uno vacío si `res` es falsy).
+function _normalizeBalancerMeta(res) {
+    if (!res || typeof res !== 'object') return res;
+    if (!('weight' in res)) res.weight = null;
+    if (!('quotaPct' in res)) res.quotaPct = null;
+    if (!('selectionReason' in res)) res.selectionReason = null;
+    return res;
 }
 
 // -----------------------------------------------------------------------------
@@ -320,6 +356,11 @@ function _resolveViaBalancer(ctx = {}) {
         agentModelsReader,
         requestClassifyModule,
         balancerStore,
+        // #4413 (Parte 3/3) — stickiness por conversación. `chatId` se hashea
+        // acá con `hashFor` (nunca se materializa crudo); `stickinessModule` es
+        // inyectable en tests.
+        chatId,
+        stickinessModule,
     } = ctx;
     const _fs = fsImpl || fs;
     const _log = typeof log === 'function' ? log : () => {};
@@ -388,30 +429,95 @@ function _resolveViaBalancer(ctx = {}) {
     const allowSet = new Set(chain);
     const store = balancerStore || makeBalancerStore(pipelineDir, _fs, allowSet);
 
-    // 7. Selección ponderada.
+    // 7. Deps compartidas por el balancer (candidatos + pesos + SWRR).
     const _balancer = balancerModule || require('./provider-balancer');
-    const picked = _balancer.selectProvider({
-        chain,
-        requiresToolUse: needsToolUse,
-        pipelineDir,
-        deps: {
-            modelsMeta,
-            store,
-            now: typeof now === 'function' ? now : undefined,
-            // shouldGateSpawn del quotaModule efectivo (test inyecta el fake).
-            shouldGateSpawn: quotaModule && typeof quotaModule.shouldGateSpawn === 'function'
-                ? (skill, q) => quotaModule.shouldGateSpawn(skill, q)
+    const deps = {
+        modelsMeta,
+        store,
+        now: typeof now === 'function' ? now : undefined,
+        // shouldGateSpawn del quotaModule efectivo (test inyecta el fake).
+        shouldGateSpawn: quotaModule && typeof quotaModule.shouldGateSpawn === 'function'
+            ? (skill, q) => quotaModule.shouldGateSpawn(skill, q)
+            : undefined,
+        config: {
+            quality_bias: Number.isFinite(balCfg.quality_bias) ? balCfg.quality_bias : undefined,
+            min_primary_quota_pct: Number.isFinite(balCfg.min_primary_quota_pct)
+                ? balCfg.min_primary_quota_pct
                 : undefined,
-            config: {
-                quality_bias: Number.isFinite(balCfg.quality_bias) ? balCfg.quality_bias : undefined,
-                min_primary_quota_pct: Number.isFinite(balCfg.min_primary_quota_pct)
-                    ? balCfg.min_primary_quota_pct
-                    : undefined,
-            },
         },
-    });
+    };
 
-    // 8. 0 sanos → null → cadena estricta (CA-8).
+    // 8. Stickiness por conversación (D3, #4413). El balanceo es POR
+    //    CONVERSACIÓN, no por request: consultamos el provider pegado al
+    //    `chat_id_hash` ANTES de reelegir. Sólo lo reusamos si sigue en el
+    //    conjunto de candidatos SANOS del balancer (no gateado, con credencial,
+    //    tool-use compatible) — si se gateó o expiró la ventana, se fuerza
+    //    reelección (nunca pinnea a un provider caído). El hash blinda la PII:
+    //    `hashFor(chatId)` nunca materializa el `chat_id` crudo.
+    const _stick = stickinessModule || require('./provider-stickiness');
+    const chatIdHash = hashFor(chatId || 'unknown');
+    const nowMs = typeof now === 'function'
+        ? now()
+        : (Number.isFinite(now) ? now : Date.now());
+    const windowMs = Number.isFinite(balCfg.stickiness_window_ms) && balCfg.stickiness_window_ms > 0
+        ? balCfg.stickiness_window_ms
+        : undefined; // undefined → default del módulo (30 min)
+
+    let picked = null;
+
+    let sticky = null;
+    try {
+        sticky = _stick.getStickyProvider({ chatIdHash, now: nowMs, windowMs });
+    } catch { sticky = null; }
+
+    if (sticky) {
+        let candidates = [];
+        try {
+            candidates = _balancer._buildCandidateSet({
+                chain, requiresToolUse: needsToolUse, pipelineDir, deps,
+            });
+        } catch { candidates = []; }
+        const cand = Array.isArray(candidates)
+            ? candidates.find((c) => c && c.provider === sticky)
+            : null;
+        if (cand) {
+            // Recuperar el peso del sticky para la auditoría (mismo cálculo que
+            // usaría el SWRR). No avanzamos el contador SWRR: reusar el sticky
+            // es justamente saltear la rotación por-request.
+            let weightVal = null;
+            try {
+                const weighted = _balancer._computeWeights(candidates, deps.config || {});
+                const w = Array.isArray(weighted)
+                    ? weighted.find((x) => x && x.provider === sticky)
+                    : null;
+                if (w && Number.isFinite(w.weight)) weightVal = w.weight;
+            } catch { weightVal = null; }
+            picked = {
+                provider: sticky,
+                weight: weightVal,
+                quotaPct: cand.quotaPct == null ? null : cand.quotaPct,
+                reason: 'stickiness',
+            };
+            _log('commander', `📌 #4413 stickiness: conversación pegada a "${sticky}" (ventana activa).`);
+        } else {
+            _log('commander', `📌 #4413 stickiness: "${sticky}" ya no está sano — reelección forzada (D3).`);
+        }
+    }
+
+    if (!picked) {
+        // Reelección ponderada: conversación nueva, ventana expirada o sticky
+        // gateado. El provider elegido queda pegado para los próximos turnos.
+        picked = _balancer.selectProvider({
+            chain, requiresToolUse: needsToolUse, pipelineDir, deps,
+        });
+        if (picked && picked.provider) {
+            try {
+                _stick.setStickyProvider({ chatIdHash, provider: picked.provider, now: nowMs });
+            } catch { /* best-effort: la stickiness nunca rompe el dispatch */ }
+        }
+    }
+
+    // 9. 0 sanos → null → cadena estricta (CA-8).
     if (!picked || !picked.provider) return null;
 
     return _buildBalancedResolution({
@@ -453,6 +559,15 @@ function _buildBalancedResolution(args = {}) {
     const defaultModel = (models.defaults && models.defaults.model) || null;
     const isPrimary = provider === primaryProvider;
 
+    // #4413 CA-9 — metadata ADITIVA de la decisión de ruteo para la auditoría.
+    // El caller (pulpo) la pasa a `auditCommanderRequest`. En el camino estricto
+    // (OFF) estas claves no existen → el audit las persiste como null.
+    const balMeta = {
+        weight: Number.isFinite(picked.weight) ? picked.weight : null,
+        quotaPct: Number.isFinite(picked.quotaPct) ? picked.quotaPct : null,
+        selectionReason: picked.reason ? String(picked.reason) : null,
+    };
+
     if (isPrimary) {
         // Espejo EXACTO del shape estricto-primario (…resolveProviderForSkill +
         // metadatos de dispatch). Mismas claves que el retorno OFF (CA-1).
@@ -471,6 +586,7 @@ function _buildBalancedResolution(args = {}) {
             crossProvider: false,
             depthExceeded: false,
             skipReasons: [],
+            ...balMeta,
         };
     }
 
@@ -496,6 +612,7 @@ function _buildBalancedResolution(args = {}) {
         depthExceeded: false,
         disqualifyReason: 'balancer_selected',
         skipReasons: [],
+        ...balMeta,
     };
 }
 
@@ -701,6 +818,20 @@ function auditFile(pipelineDir, now) {
     return path.join(pipelineDir || '.', 'logs', `commander-dispatch-${yyyy}-${mm}-${dd}.jsonl`);
 }
 
+// #4413 A02 — redacta `selection_reason` en origen antes de persistirlo al
+// audit. Devuelve null cuando no hay valor (mantiene el patrón "null si no
+// aplica" del resto de campos enriched). Si `redact.js` no está disponible en
+// runtime, degrada a String() truncado (nunca deja pasar el objeto crudo).
+function _redactSelectionReason(selectionReason) {
+    if (selectionReason == null || selectionReason === '') return null;
+    const raw = String(selectionReason);
+    const r = redactModule();
+    if (r && typeof r.redactSecretValue === 'function') {
+        try { return r.redactSecretValue(raw); } catch { /* fall-through */ }
+    }
+    return raw;
+}
+
 function auditCommanderRequest(opts = {}) {
     const {
         pipelineDir,
@@ -737,6 +868,15 @@ function auditCommanderRequest(opts = {}) {
         // para el resto de eventos quedan en null y no afectan el shape canónico.
         sourcesChecked,
         findingsCount,
+        // #4413 CA-9 (A09) — campos ADITIVOS de la decisión de ruteo balanceado.
+        // Solo los provee el caller cuando el dispatch salió del balancer
+        // ponderado (#4411/#4412); para el resto de eventos quedan en null y no
+        // afectan el shape canónico ni el hash-chain (mismo patrón enriched
+        // #3484/#3501/#3846). `selectionReason` es texto acotado (enum del
+        // balancer) pero se redacta en origen (A02).
+        weight,
+        quotaPct,
+        selectionReason,
         // inyectables tests
         fsImpl,
         auditLog,
@@ -780,6 +920,12 @@ function auditCommanderRequest(opts = {}) {
         // #3846 — evidencia independiente. Null para eventos que no la usan.
         sources_checked: Array.isArray(sourcesChecked) ? sourcesChecked : null,
         findings_count: Number.isFinite(findingsCount) ? findingsCount : null,
+        // #4413 CA-9 — decisión de ruteo del balanceo ponderado. Estrictamente
+        // aditivos al FINAL del entry: null cuando el dispatch no salió del
+        // balancer (preserva shape canónico y hash-chain — req A09/A08).
+        weight: Number.isFinite(weight) ? weight : null,
+        quota_pct: Number.isFinite(quotaPct) ? quotaPct : null,
+        selection_reason: _redactSelectionReason(selectionReason),
     };
 
     try {
@@ -1502,6 +1648,11 @@ module.exports = {
     _saveBalancerState: saveBalancerState,
     _makeBalancerStore: makeBalancerStore,
     BALANCER_STATE_FILE,
+
+    // #4413 (Parte 3/3) — stickiness por conversación (re-export del módulo
+    // dedicado) + redacción de selection_reason.
+    stickiness: require('./provider-stickiness'),
+    _redactSelectionReason,
 
     // exports internos para tests
     _hashFor: hashFor,

--- a/.pipeline/lib/commander/provider-stickiness.js
+++ b/.pipeline/lib/commander/provider-stickiness.js
@@ -1,0 +1,146 @@
+'use strict';
+
+// =============================================================================
+// #4413 (Parte 3/3 de #4363) — Stickiness por conversación (D3, obligatoria).
+//
+// El balanceo ponderado del Commander (#4411/#4412) elige provider POR REQUEST.
+// Sin stickiness, dos turnos consecutivos de la MISMA conversación pueden caer
+// en providers distintos y perder el contexto conversacional. Este módulo
+// "pega" un `chat_id_hash` a un provider dentro de una ventana temporal: el
+// selector consulta stickiness ANTES de reelegir y reusa el provider pegado
+// mientras siga sano y dentro de la ventana.
+//
+// Reglas de seguridad (heredadas del análisis de security/guru de #4413):
+//   - CONFIDENCIALIDAD: se indexa SIEMPRE por `chat_id_hash` (SHA-256 truncado
+//     de `hashFor`), NUNCA por `chat_id` crudo. El módulo NO hashea: recibe el
+//     hash ya calculado por el caller (`multi-provider.hashFor`). No materializa
+//     PII de Telegram.
+//   - EFÍMERO / NO AUTORITATIVO: el estado vive en memoria de proceso (Map).
+//     No se persiste a disco (nada de secretos ni PII en el filesystem) y se
+//     resetea al reiniciar el pulpo. NO es fuente de decisiones de seguridad:
+//     la re-elección forzada al gatearse el provider la decide el balancer.
+//   - RE-ELECCIÓN FORZADA (D3): la stickiness NO fija a un provider caído. El
+//     integrador (`_resolveViaBalancer`) sólo reusa el sticky si sigue en el
+//     conjunto de candidatos SANOS del balancer; si se gateó / perdió cuota /
+//     ya no soporta tool-use, reelige. Al expirar la ventana o abrir
+//     conversación nueva (hash sin entry), también reelige.
+//
+// Ventana temporal: default 30 min. Configurable vía
+// `balancing.stickiness_window_ms` en `agent-models.json`.
+// =============================================================================
+
+// Ventana de continuidad conversacional por default (30 min). Un turno dentro
+// de este lapso del anterior se considera la misma conversación.
+const DEFAULT_WINDOW_MS = 30 * 60 * 1000;
+
+// GC: entradas más viejas que esto se purgan al escribir para que el Map no
+// crezca sin techo en un proceso long-running (pulpo).
+const GC_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+// Estado in-memory por default. Map<chatIdHash, { provider, ts }>. Efímero:
+// muere con el proceso. Los tests inyectan su propio Map por `store` para
+// aislarse.
+const _memStore = new Map();
+
+// Un `chat_id_hash` de `hashFor` es SHA-256 truncado a 12 hex. Aceptamos un
+// rango (8-64 hex) por robustez, pero rechazamos cualquier cosa que no sea
+// hex-only para no aceptar accidentalmente un `chat_id` crudo con formato raro.
+// NOTA: un chat_id numérico de Telegram (solo dígitos) podría, en teoría, pasar
+// el regex — la garantía real de "sólo hash" la da el integrador, que SIEMPRE
+// pasa `hashFor(chatId)`. Este guard es defensa en profundidad de formato.
+const HASH_RE = /^[0-9a-f]{8,64}$/;
+
+function _isHash(s) {
+    return typeof s === 'string' && HASH_RE.test(s);
+}
+
+function _resolveStore(store) {
+    return store instanceof Map ? store : _memStore;
+}
+
+function _now(now) {
+    return Number.isFinite(now) ? now : Date.now();
+}
+
+function _windowMs(windowMs) {
+    return Number.isFinite(windowMs) && windowMs > 0 ? windowMs : DEFAULT_WINDOW_MS;
+}
+
+/**
+ * Devuelve el provider pegado a `chatIdHash` si sigue dentro de la ventana, o
+ * `null` si no hay entry, la entry expiró o el hash es inválido. Una entry
+ * expirada se elimina de paso (lazy expiry).
+ *
+ * @param {object} params
+ * @param {string} params.chatIdHash  hash del chat (de `hashFor`). NUNCA crudo.
+ * @param {number} [params.now]       epoch ms (inyectable en tests).
+ * @param {number} [params.windowMs]  ventana temporal; default 30 min.
+ * @param {Map}    [params.store]     store inyectable (tests). Default in-memory.
+ * @returns {string|null}
+ */
+function getStickyProvider({ chatIdHash, now, windowMs, store } = {}) {
+    if (!_isHash(chatIdHash)) return null;
+    const m = _resolveStore(store);
+    const rec = m.get(chatIdHash);
+    if (!rec || typeof rec.provider !== 'string' || !rec.provider) return null;
+    if (!Number.isFinite(rec.ts)) { m.delete(chatIdHash); return null; }
+    const ts = _now(now);
+    if (ts - rec.ts >= _windowMs(windowMs)) {
+        m.delete(chatIdHash); // ventana expirada → reelección en el próximo turno
+        return null;
+    }
+    return rec.provider;
+}
+
+/**
+ * Pega `provider` a `chatIdHash` con timestamp `now`. Renueva la ventana en
+ * cada set (sliding window: mientras la conversación siga activa, se mantiene).
+ * Ignora silenciosamente hashes/providers inválidos (best-effort, nunca rompe
+ * el dispatch).
+ *
+ * @returns {boolean} true si se guardó.
+ */
+function setStickyProvider({ chatIdHash, provider, now, store } = {}) {
+    if (!_isHash(chatIdHash)) return false;
+    if (typeof provider !== 'string' || !provider) return false;
+    const m = _resolveStore(store);
+    const ts = _now(now);
+    m.set(chatIdHash, { provider, ts });
+    _gc(m, ts);
+    return true;
+}
+
+/**
+ * Borra la entry de una conversación (p.ej. al cerrar/expirar explícitamente).
+ * Best-effort.
+ */
+function clearStickyProvider({ chatIdHash, store } = {}) {
+    if (!_isHash(chatIdHash)) return false;
+    return _resolveStore(store).delete(chatIdHash);
+}
+
+// Purga entradas viejas para acotar el Map. O(n) sobre el store — el volumen
+// de conversaciones concurrentes del Commander es chico, así que es barato.
+function _gc(m, now) {
+    for (const [k, v] of m) {
+        if (!v || !Number.isFinite(v.ts) || now - v.ts > GC_MAX_AGE_MS) {
+            m.delete(k);
+        }
+    }
+}
+
+// Reset del store default. Solo para tests (aislar entre casos).
+function _resetState(store) {
+    _resolveStore(store).clear();
+}
+
+module.exports = {
+    getStickyProvider,
+    setStickyProvider,
+    clearStickyProvider,
+    DEFAULT_WINDOW_MS,
+    // Internos expuestos para tests (patrón provider-balancer.js / credentials-precheck.js).
+    _isHash,
+    _resetState,
+    _memStore,
+};

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -9589,6 +9589,9 @@ function ejecutarClaude(prompt, textoOriginal, trace, fallbackParts) {
         // default) clasifica tool-vs-chat desde el prompt para decidir qué
         // providers son elegibles. Con el flag OFF este insumo es inocuo.
         requestText: prompt,
+        // #4413 (Parte 3/3) — stickiness por conversación. El resolver hashea
+        // el chatId con `hashFor` internamente (nunca se materializa crudo).
+        chatId: getTelegramChatId(),
       });
     } catch (e) {
       // #4313 (CA-7) — instrumentar el catch ANTES de degradar: el degradado
@@ -10515,6 +10518,11 @@ function ejecutarClaude(prompt, textoOriginal, trace, fallbackParts) {
           injectionHits: sanRes.hits,
           supportsToolUse: true,
           requestId: turnRequestId, // #3577 CA-S6
+          // #4413 CA-9 — decisión de ruteo del balanceo (aditivo; null cuando el
+          // dispatch salió de la cadena estricta, no del balancer ponderado).
+          weight: resolution.weight,
+          quotaPct: resolution.quotaPct,
+          selectionReason: resolution.selectionReason,
         });
       } catch { /* best-effort */ }
       // #3950 — resolvemos el INTENTO (no el Promise externo). El orquestador


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 4 archivos · +570 -21

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:skipped` aplicado por delivery

## Closes

Closes #4413
