### PR TITLE
Rediseñar los mensajes de error del Commander cuando falla el LLM (UX inaceptable para el operador)

### DIFF
--- a/.pipeline/lib/__tests__/commander-chain-walk-4438.test.js
+++ b/.pipeline/lib/__tests__/commander-chain-walk-4438.test.js
@@ -250,27 +250,37 @@ test('#4438 CA-3 — auditCommanderRequest sin chainEvaluated deja chain_evaluat
 });
 
 // -----------------------------------------------------------------------------
-// CA-3 — la alerta al operador (cannedAllProvidersFailedResponse) enumera los
-// providers evaluados y su motivo, REDACTADO (nada de secretos en el chat).
+// CA-3 (#4438) — el requisito durable es que NINGÚN secreto llegue al chat.
+// #4440 SUPERSEDE la parte de UX de este CA: el mensaje al operador ya NO
+// enumera providers/modelos/motivos (CA-2 de #4440: "ningún mensaje visible
+// expone nombres de providers, modelos de fallback, timers ni conteo de
+// reintentos"). El detalle por eslabón sigue viajando redactado al audit
+// server-side (cubierto por los tests de auditCommanderRequest de arriba).
+// Estos tests, por tanto, verifican la NO-fuga de jerga en el copy visible.
 // -----------------------------------------------------------------------------
-test('#4438 CA-3 — cannedAllProvidersFailedResponse: detalle por provider redactado', () => {
+test('#4438/#4440 — cannedAllProvidersFailedResponse nunca filtra secretos ni nombres de provider al chat', () => {
     const msg = cmp.cannedAllProvidersFailedResponse({
         chainTried: ['openai-codex'],
+        verifiedAllFailed: true,
         chainEvaluated: [
             { provider: 'openai-codex', reason: 'spawn_throw', details: 'token sk-ant-api03-SECRET0123456789abcdef0123456789 filtrado' },
             { provider: 'gemini-google', reason: 'quota_exhausted', details: 'sin cuota' },
         ],
     });
     assert.ok(!/sk-ant-api03-SECRET/.test(msg), 'el mensaje al operador NO debe contener la API key');
-    assert.match(msg, /openai-codex/, 'enumera el provider intentado');
-    assert.match(msg, /gemini-google/, 'enumera el resto de la cadena evaluada');
-    assert.match(msg, /quota_exhausted/, 'muestra el motivo por eslabón');
+    // #4440 CA-2 — el copy visible ya NO enumera providers/modelos/motivos.
+    assert.ok(!/openai-codex/.test(msg), 'no expone el provider intentado');
+    assert.ok(!/gemini-google/.test(msg), 'no expone el resto de la cadena');
+    assert.ok(!/quota_exhausted|spawn_throw/.test(msg), 'no expone motivos técnicos por eslabón');
     // Los comandos determinísticos siguen anunciados (accionabilidad UX).
     assert.match(msg, /\/status/);
 });
 
-test('#4438 CA-3 — cannedAllProvidersFailedResponse sin chainEvaluated preserva texto base', () => {
+test('#4438/#4440 — cannedAllProvidersFailedResponse sin chainEvaluated no interpola jerga de reintento', () => {
     const msg = cmp.cannedAllProvidersFailedResponse({ chainTried: ['openai-codex'] });
-    assert.match(msg, /Intenté con: openai-codex/);
-    assert.ok(!/Detalle de la cadena/.test(msg), 'sin data, no agrega bloque de detalle');
+    // #4440 CA-2 — el texto "Intenté con: <provider>" fue eliminado del copy.
+    assert.ok(!/Intenté con/.test(msg), 'no menciona la cadena intentada');
+    assert.ok(!/openai-codex/.test(msg), 'no menciona nombres de provider');
+    assert.ok(!/Detalle de la cadena/.test(msg), 'no agrega bloque de detalle');
+    assert.match(msg, /\/status/, 'mantiene la acción determinística para el operador');
 });

--- a/.pipeline/lib/__tests__/commander-inflight-fallback.test.js
+++ b/.pipeline/lib/__tests__/commander-inflight-fallback.test.js
@@ -258,9 +258,11 @@ test('CA-1 — 5xx in-flight resuelve a openai-codex con noticeText UX-G1', () =
         assert.equal(d.shouldRetry, true);
         assert.equal(d.secondaryProvider, 'openai-codex');
         assert.equal(d.reason, 'ok');
-        // UX-G1 / G2: copy en voseo argentino, no "Retrying with..."
-        assert.match(d.noticeText, /⚠️/);
-        assert.match(d.noticeText, /reintentando con openai-codex/i);
+        // #4440 CA-2: copy orientado al operador (demora + reintento automático),
+        // sin nombres de provider ni jerga interna en el texto visible.
+        assert.match(d.noticeText, /⏳/);
+        assert.match(d.noticeText, /reintent/i);
+        assert.ok(!/anthropic|openai|codex/i.test(d.noticeText), `fuga de provider: ${d.noticeText}`);
         // CA-3: hash del partial output expuesto, no contenido
         assert.ok(d.partialOutputHash);
         assert.equal(d.partialOutputHash.length, 12);
@@ -275,7 +277,7 @@ test('CA-1 — 5xx in-flight resuelve a openai-codex con noticeText UX-G1', () =
     } finally { cleanup(dir); }
 });
 
-test('CA-1 — timeout_no_new_bytes_30s genera noticeText con motivo "silencio"', () => {
+test('#4440 — timeout_no_new_bytes_30s genera noticeText genérico sin exponer timer', () => {
     const dir = mkTmpPipelineDir();
     try {
         const d = decideWithFakeMP({
@@ -289,11 +291,12 @@ test('CA-1 — timeout_no_new_bytes_30s genera noticeText con motivo "silencio"'
             requestId: 'req-to-1',
         }, makeFakeMultiProvider([]));
         assert.equal(d.shouldRetry, true);
-        assert.match(d.noticeText, /silencio/i);
+        assert.match(d.noticeText, /⏳/);
+        assert.ok(!/silencio|30s|\d+\s*seg/i.test(d.noticeText), `fuga de timer: ${d.noticeText}`);
     } finally { cleanup(dir); }
 });
 
-test('CA-1 — eof_premature genera noticeText con motivo "cortó antes de tiempo"', () => {
+test('#4440 — eof_premature genera noticeText genérico sin jerga de errorClass', () => {
     const dir = mkTmpPipelineDir();
     try {
         const d = decideWithFakeMP({
@@ -307,7 +310,8 @@ test('CA-1 — eof_premature genera noticeText con motivo "cortó antes de tiemp
             requestId: 'req-eof-1',
         }, makeFakeMultiProvider([]));
         assert.equal(d.shouldRetry, true);
-        assert.match(d.noticeText, /cortó la respuesta/i);
+        assert.match(d.noticeText, /⏳/);
+        assert.ok(!/eof|cortó la respuesta|mid-flight/i.test(d.noticeText), `fuga de errorClass: ${d.noticeText}`);
     } finally { cleanup(dir); }
 });
 
@@ -332,7 +336,7 @@ test('CA-5 / G3 — fallback a cerebras genera segunda línea ℹ️ tool_use de
         }, makeFakeMultiProvider(['anthropic'])); // anthropic gated → codex excluded → cerebras
 
         assert.equal(d.secondaryProvider, 'cerebras');
-        assert.match(d.noticeText, /⚠️/);
+        assert.match(d.noticeText, /⏳/);
         assert.match(d.noticeText, /ℹ️.*Modo conversacional/i);
         assert.equal(d.supportsToolUse, false);
     } finally { cleanup(dir); }
@@ -661,28 +665,43 @@ test('formatPrecheckReport reporta ranking activo en formato legible', () => {
 // formatInflightFallbackNotice — verificación exhaustiva de motivos
 // -----------------------------------------------------------------------------
 
-test('formatInflightFallbackNotice mapea cada errorClass al copy correcto', () => {
-    const cases = [
-        { ec: 'transient_5xx',           rx: /error del servidor/i },
-        { ec: '5xx',                     rx: /error del servidor/i },
-        { ec: 'timeout_no_new_bytes_30s',rx: /silencio/i },
-        { ec: 'timeout',                 rx: /silencio/i },
-        { ec: 'eof_premature',           rx: /cortó la respuesta/i },
-        { ec: 'rate_limit',              rx: /rate-limit/i },
+test('#4440 CA-2 — formatInflightFallbackNotice NO expone jerga interna para ningún errorClass', () => {
+    // Aunque la firma sigue recibiendo primaryProvider/secondaryProvider/errorClass
+    // (backward-compat con los callers), NINGUNO debe filtrarse al texto visible.
+    const errorClasses = [
+        'transient_5xx', '5xx', 'timeout_no_new_bytes_30s', 'timeout',
+        'eof_premature', 'rate_limit', 'unknown', undefined,
     ];
-    for (const c of cases) {
+    for (const ec of errorClasses) {
         const t = inflight.formatInflightFallbackNotice({
             primaryProvider: 'anthropic',
             secondaryProvider: 'openai-codex',
-            errorClass: c.ec,
+            errorClass: ec,
             supportsToolUse: true,
         });
-        assert.match(t, c.rx, `errorClass=${c.ec} → texto=${t}`);
-        assert.match(t, /⚠️/);
-        assert.match(t, /reintentando con openai-codex/i);
-        // No debe haber jerga técnica de stack/request_id
+        // Estado A (demora + reintento automático en curso)
+        assert.match(t, /⏳/, `errorClass=${ec} → texto=${t}`);
+        assert.match(t, /reintent/i, `errorClass=${ec} → debe comunicar reintento automático`);
+        // CA-2 — sin nombres de provider, timers, errorClass ni conteo de reintentos
+        assert.ok(!/anthropic|openai|codex|cerebras|gemini|groq/i.test(t), `fuga de provider: ${t}`);
+        assert.ok(!/30s|30 segundos|\d+\s*seg/i.test(t), `fuga de timer: ${t}`);
+        assert.ok(!/errorClass|transient_5xx|eof_premature|rate-limit|rate_limit|mid-flight|sin clasificar/i.test(t), `fuga de errorClass: ${t}`);
+        assert.ok(!/reintentando con|reintento \d/i.test(t), `fuga de conteo/target de reintento: ${t}`);
+        // Sin jerga técnica de stack/request_id
         assert.ok(!/stack|trace|request_id|prompt_hash/i.test(t));
     }
+});
+
+test('#4440 — formatInflightFallbackNotice varía por requestId (semilla determinística)', () => {
+    const mk = (rid) => inflight.formatInflightFallbackNotice({
+        primaryProvider: 'anthropic', secondaryProvider: 'openai-codex',
+        errorClass: 'timeout', supportsToolUse: true, requestId: rid,
+    });
+    // Mismo requestId → mismo mensaje (estable dentro del turno)
+    assert.equal(mk('req-abc'), mk('req-abc'));
+    // Al menos dos requestId distintos producen textos distintos entre un set variado
+    const set = new Set(['a', 'b', 'c', 'd', 'e', 'f'].map(mk));
+    assert.ok(set.size >= 2, 'debería rotar entre variantes');
 });
 
 test('formatInflightFallbackNotice agrega segunda línea ℹ️ cuando supportsToolUse=false', () => {
@@ -692,9 +711,46 @@ test('formatInflightFallbackNotice agrega segunda línea ℹ️ cuando supportsT
         errorClass: 'transient_5xx',
         supportsToolUse: false,
     });
-    assert.match(t, /⚠️/);
+    assert.match(t, /⏳/);
     assert.match(t, /ℹ️/);
     assert.match(t, /Modo conversacional/i);
+});
+
+// -----------------------------------------------------------------------------
+// #4440 — cannedAllProvidersFailedResponse: honestidad de estado + sin jerga
+// -----------------------------------------------------------------------------
+
+test('#4440 CA-1 — cannedAllProvidersFailedResponse rama NO verificada no afirma falla total', () => {
+    const mp = require('../commander/multi-provider');
+    // Default (sin flag) y explícito false: ambos NO deben afirmar "TODOS".
+    for (const args of [{}, { verifiedAllFailed: false }, { chainTried: ['anthropic', 'openai-codex'] }]) {
+        const t = mp.cannedAllProvidersFailedResponse(args);
+        assert.ok(!/TODOS/i.test(t), `no debe afirmar falla total: ${t}`);
+        assert.match(t, /⚠️/);
+        // CA-3 — expectativa/acción clara: comandos determinísticos
+        assert.match(t, /\/status|\/listado|\/lanzar/);
+    }
+});
+
+test('#4440 CA-1 — cannedAllProvidersFailedResponse rama verificada puede afirmar imposibilidad total', () => {
+    const mp = require('../commander/multi-provider');
+    const t = mp.cannedAllProvidersFailedResponse({ verifiedAllFailed: true, chainTried: ['anthropic', 'openai-codex'] });
+    assert.match(t, /⚠️/);
+    assert.match(t, /no.*(tengo|puedo).*IA|IA/i, `debe comunicar imposibilidad de IA: ${t}`);
+    assert.match(t, /\/status|\/listado|\/lanzar/);
+});
+
+test('#4440 CA-2 — cannedAllProvidersFailedResponse nunca interpola chainTried ni nombres de provider', () => {
+    const mp = require('../commander/multi-provider');
+    for (const verifiedAllFailed of [true, false]) {
+        const t = mp.cannedAllProvidersFailedResponse({
+            verifiedAllFailed,
+            chainTried: ['anthropic', 'openai-codex', 'cerebras'],
+        });
+        assert.ok(!/Intenté con/i.test(t), `fuga de chainTried: ${t}`);
+        assert.ok(!/anthropic|openai|codex|cerebras|gemini|groq/i.test(t), `fuga de provider: ${t}`);
+        assert.ok(!/30s|\d+\s*seg|reintento \d|fallback/i.test(t), `fuga de jerga: ${t}`);
+    }
 });
 
 // -----------------------------------------------------------------------------

--- a/.pipeline/lib/commander/inflight-fallback.js
+++ b/.pipeline/lib/commander/inflight-fallback.js
@@ -143,33 +143,34 @@ function _appendAudit({ pipelineDir, entry, auditLog, fsImpl, now }) {
 }
 
 // -----------------------------------------------------------------------------
-// formatInflightFallbackNotice — copy UX-G1 alineado con
-// `commander/multi-provider.js#formatFallbackNotice` (mismo formato, pero el
-// motivo viene del errorClass del intento in-flight en vez del flag de cuota
-// pre-spawn). UX-G2 / G7: solo ⚠️ y ℹ️, sin stack ni request_id.
+// formatInflightFallbackNotice — #4440: copy orientado al operador para el
+// estado "demora + reintento automático en curso" (Estado A del PO/UX).
 //
-// errorClass → copy en español natural (voseo argentino, feedback_telegram-messages-natural.md).
+// UX (CA-2): el texto visible NO expone nombres de providers, `errorClass`,
+// timers (`30s`) ni conteo de reintentos. Todo ese detalle sigue yendo solo a
+// logs server-side (`_log(...)`, línea ~541). La firma se mantiene intacta:
+// `primaryProvider`/`secondaryProvider`/`errorClass` se siguen recibiendo por
+// backward-compat de los callers, pero NO se interpolan al operador.
+//
+// Variación anti-robot (feedback_telegram-messages-natural.md): rota entre 3
+// variantes usando `requestId` como semilla determinística (mismo turno → mismo
+// mensaje; turnos distintos → variación). `requestId` es opcional; sin él se usa
+// una variante estable.
 // -----------------------------------------------------------------------------
-function formatInflightFallbackNotice({ primaryProvider, secondaryProvider, errorClass, supportsToolUse }) {
+const _INFLIGHT_NOTICE_VARIANTS = Object.freeze([
+    '⏳ Estoy con una demora para responderte — reintento solo en un momento, no hace falta que hagas nada.',
+    '⏳ Se me demoró la respuesta, ya lo estoy reintentando por mi cuenta. Dame un momento.',
+    '⏳ Esto está tardando un poco más de lo normal — reintento automático en curso, aguantame un toque.',
+]);
+function formatInflightFallbackNotice({ primaryProvider, secondaryProvider, errorClass, supportsToolUse, requestId } = {}) {
+    // primaryProvider/secondaryProvider/errorClass se aceptan por backward-compat
+    // de firma pero NO se interpolan al operador (CA-2): jerga interna solo a logs.
     const lines = [];
-    const motive = (() => {
-        switch (errorClass) {
-            case 'transient_5xx':
-            case '5xx':
-                return `${primaryProvider} tuvo un error del servidor en medio de la respuesta`;
-            case 'timeout_no_new_bytes_30s':
-            case 'timeout':
-                return `${primaryProvider} se quedó en silencio (sin nueva respuesta hace 30s)`;
-            case 'eof_premature':
-                return `${primaryProvider} cortó la respuesta antes de tiempo`;
-            case 'rate_limit':
-                return `${primaryProvider} pegó contra el rate-limit a mitad del turno`;
-            default:
-                return `${primaryProvider} falló mid-flight (${errorClass || 'sin clasificar'})`;
-        }
-    })();
 
-    lines.push(`⚠️ ${motive} — reintentando con ${secondaryProvider}.`);
+    const idx = requestId
+        ? parseInt(hashFor(requestId).slice(0, 4), 16) % _INFLIGHT_NOTICE_VARIANTS.length
+        : 0;
+    lines.push(_INFLIGHT_NOTICE_VARIANTS[idx]);
 
     if (supportsToolUse === false) {
         lines.push(
@@ -530,12 +531,13 @@ function decideInflightFallback(opts = {}) {
         }
     } catch { /* default true */ }
 
-    // 7. Armar copy UX-G1 (verbose, voseo argentino).
+    // 7. Armar copy orientado al operador (#4440: sin jerga interna).
     const noticeText = formatInflightFallbackNotice({
         primaryProvider: primaryProvider || '?',
         secondaryProvider: resolution.provider,
         errorClass: primaryErrorClass || 'unknown',
         supportsToolUse,
+        requestId, // #4440 — semilla de variación anti-robot (no se interpola al texto)
     });
 
     _log('commander', `↪️ inflight: ${primaryProvider} (${primaryErrorClass}) → ${resolution.provider} (request_id=${requestId || '?'})`);

--- a/.pipeline/lib/commander/multi-provider.js
+++ b/.pipeline/lib/commander/multi-provider.js
@@ -1691,40 +1691,48 @@ function cannedAllGatedResponse(resolution = null) {
 // LLM con el que generar la respuesta, al menos le avisamos a Leo que no se le
 // puede contestar y por qué — para que NUNCA quede mudo sin saber qué pasó.
 //
-// `chainTried` (opcional) lista los providers que se intentaron, para dar
-// contexto sin jerga técnica de stack traces.
+// #4440 — CA-1/CA-2: el copy visible ya NO afirma "fallaron TODOS los providers"
+// salvo verificación server-side (`verifiedAllFailed === true`) y NO expone
+// nombres de providers, modelos, timers ni la lista de intentos.
+//
+// `chainTried` se sigue aceptando por backward-compat de firma (los 3 callers en
+// pulpo.js lo pasan) pero NO se interpola al operador — su detalle solo viaja a
+// los logs/audit server-side, nunca al canal.
+//
+// Estados (CA-4):
+//  - `verifiedAllFailed === false` (default): imposibilidad NO verificada
+//    (p.ej. caso pre-spawn donde nunca se intentó la cadena completa). Copy
+//    honesto SIN afirmar falla total.
+//  - `verifiedAllFailed === true`: se intentó spawnear y efectivamente se agotó
+//    toda la cadena. Recién acá el copy puede afirmar que no hay IA disponible
+//    (siempre sin nombrar providers/modelos/timers).
+//
+// Variación anti-robot (feedback_telegram-messages-natural.md): rota entre
+// variantes con `requestId` como semilla determinística. `requestId` es opcional.
 // -----------------------------------------------------------------------------
-function cannedAllProvidersFailedResponse({ chainTried, chainEvaluated } = {}) {
-    const chain = Array.isArray(chainTried) && chainTried.length
-        ? ` Intenté con: ${chainTried.join(', ')}.`
-        : '';
-
-    // #4438 CA-3 + UX-G1 — detalle honesto por provider (qué se evaluó y por
-    // qué falló cada eslabón), REDACTADO antes de llegar al chat (requisito de
-    // security: ningún token/API key en claro). Sólo se agrega si hay data;
-    // preserva el texto histórico cuando no la hay (back-compat).
-    let detail = '';
-    const evaluated = redactSkipReasons(chainEvaluated);
-    if (evaluated.length) {
-        const lines = evaluated
-            .filter((s) => s.provider)
-            .map((s) => {
-                const reason = s.reason || 'motivo desconocido';
-                const extra = s.details ? ` — ${s.details}` : '';
-                return `• ${s.provider}: ${reason}${extra}`;
-            });
-        if (lines.length) {
-            detail = `\n\nDetalle de la cadena:\n${lines.join('\n')}`;
-        }
-    }
-
-    return (
-        `⚠️ No te puedo responder en este momento: fallaron todos los providers y ` +
-        `todos los modelos de fallback.${chain} No hay ningún modelo LLM disponible ` +
-        `para generar una respuesta ahora mismo.${detail}\n\n` +
-        `Los comandos determinísticos (/status, /listado, /lanzar) siguen funcionando — ` +
-        `probá de nuevo en un rato.`
-    );
+const _ALL_FAILED_UNVERIFIED_VARIANTS = Object.freeze([
+    '⚠️ Tuve un problema para responderte en este momento. ' +
+        'Los comandos determinísticos (/status, /listado, /lanzar) siguen funcionando — probá de nuevo en un momento.',
+    '⚠️ No pude generar la respuesta ahora mismo. ' +
+        'Mientras tanto, los comandos determinísticos (/status, /listado, /lanzar) siguen andando — reintentá en un rato.',
+]);
+const _ALL_FAILED_VERIFIED_VARIANTS = Object.freeze([
+    '⚠️ Ahora mismo no tengo forma de responderte con IA. ' +
+        'Los comandos determinísticos (/status, /listado, /lanzar) siguen funcionando — probá de nuevo más tarde.',
+    '⚠️ Por el momento no puedo responderte con IA. ' +
+        'Igual podés seguir con los comandos determinísticos (/status, /listado, /lanzar); volvé a intentar en un rato.',
+]);
+function cannedAllProvidersFailedResponse({ chainTried, verifiedAllFailed = false, requestId } = {}) {
+    // chainTried se acepta por backward-compat de firma pero NO se interpola al
+    // operador (CA-2). El detalle técnico ya viaja a los logs server-side.
+    void chainTried;
+    const variants = verifiedAllFailed
+        ? _ALL_FAILED_VERIFIED_VARIANTS
+        : _ALL_FAILED_UNVERIFIED_VARIANTS;
+    const idx = requestId
+        ? parseInt(hashFor(requestId).slice(0, 4), 16) % variants.length
+        : 0;
+    return variants[idx];
 }
 
 // -----------------------------------------------------------------------------

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -9659,7 +9659,9 @@ function ejecutarClaude(prompt, textoOriginal, trace, fallbackParts) {
               requestId: turnRequestId, // #3577 CA-S6
             });
           } catch { /* best-effort */ }
-          return resolve(commanderMP.cannedAllProvidersFailedResponse({ chainTried: ['anthropic'] }));
+          // #4440 CA-1 — caso pre-spawn: nunca se intentó la cadena completa,
+          // por lo que NO se afirma falla total (verifiedAllFailed: false).
+          return resolve(commanderMP.cannedAllProvidersFailedResponse({ chainTried: ['anthropic'], verifiedAllFailed: false, requestId: turnRequestId }));
         }
       } else {
         log('commander', '   degradando a Anthropic por compatibilidad (primario habilitado).');
@@ -9990,10 +9992,13 @@ function ejecutarClaude(prompt, textoOriginal, trace, fallbackParts) {
         // providers y modelos de fallback. En vez del canned de "sin cuota"
         // (que es el caso pre-spawn gateado), avisamos explícitamente que no
         // hay con qué responder — para que el usuario NUNCA quede mudo sin
-        // saber qué pasó. El detalle por provider viaja redactado (CA-3).
+        // saber qué pasó.
+        // #4440 CA-1 — se spawneó y efectivamente falló toda la cadena:
+        // imposibilidad verificada (verifiedAllFailed: true).
         return resolve(commanderMP.cannedAllProvidersFailedResponse({
           chainTried: Array.from(triedNonAnthropic),
-          chainEvaluated,
+          verifiedAllFailed: true,
+          requestId: turnRequestId,
         }));
       };
 
@@ -12993,7 +12998,9 @@ INSTRUCCIÓN: Reelaborá tu respuesta tomando en cuenta las contradicciones dete
         const errMsg = (e && e.message) || '';
         const totalProviderFailure = /ENAMETOOLONG|spawn|env-isolation|env_isolation|provider|quota|rate.?limit|usage_limit|ECONNREFUSED|ETIMEDOUT|ENOTFOUND|all.?gated/i.test(errMsg);
         if (totalProviderFailure) {
-          try { sendTelegram(commanderMP.cannedAllProvidersFailedResponse({})); } catch { /* best-effort */ }
+          // #4440 CA-1 — path best-effort sin verificación de falla total real:
+          // se mantiene el default verifiedAllFailed: false (no afirma "TODOS").
+          try { sendTelegram(commanderMP.cannedAllProvidersFailedResponse({ verifiedAllFailed: false })); } catch { /* best-effort */ }
         } else {
           sendTelegram('⚠️ Error procesando tu mensaje. Intentá de nuevo.');
         }


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 5 archivos · +176 -93

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:passed` aplicado por delivery

## Closes

Closes #4440
