### PR TITLE
Roadmap del dashboard: promover ola planificada → activa desde la pantalla (con sync de allowlist)

### DIFF
--- a/.pipeline/lib/__tests__/dashboard-routes-wave-promote.test.js
+++ b/.pipeline/lib/__tests__/dashboard-routes-wave-promote.test.js
@@ -1,0 +1,232 @@
+// =============================================================================
+// dashboard-routes-wave-promote.test.js — #4435 CA-1..CA-9.
+//
+// Endpoint mutante para promover una ola planificada → activa
+// (POST /dashboard/wave/promote) con sincronización recursiva de la allowlist.
+// Espejo de dashboard-routes-wave-archive.test.js. Verifica:
+//   - Cinturón de gates replicado de handleWaveArchiveMutation:
+//       método≠POST → 405 · no-loopback → 403 (REQ-SEC-1) · cross-site → 403
+//       (REQ-SEC-1) · Content-Type≠json → 415 · waveNumber inválido → 400
+//       (sin reflejar input — REQ-SEC-2/CA-6).
+//   - Preview sin `confirmed` NO escribe (CA-4).
+//   - PROMOTE_CAP_EXCEEDED cuando toAdd > cap sin mutar (CA-4).
+//   - active_wave_exists → 409 cuando ya hay activa (CA-3).
+//   - Confirmado promueve + sincroniza allowlist recursiva; cerrados NO (CA-1/CA-2).
+//   - Actor fijo `operador-local` en la auditoría (CA-8).
+//   - Ola inexistente → 404.
+//
+// Ejecutar:  node --test .pipeline/lib/__tests__/dashboard-routes-wave-promote.test.js
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { EventEmitter } = require('node:events');
+
+const TMP_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'v3-wave-promote-'));
+process.env.PIPELINE_DIR_OVERRIDE = TMP_DIR;
+
+try { delete require.cache[require.resolve('../waves')]; } catch {}
+try { delete require.cache[require.resolve('../partial-pause')]; } catch {}
+try { delete require.cache[require.resolve('../dashboard-routes')]; } catch {}
+
+const routes = require('../dashboard-routes');
+const waves = require('../waves');
+const handleWavePromoteMutation = routes._internal.handleWavePromoteMutation;
+const WAVE_PROMOTE_CAP_ISSUES = routes._internal.WAVE_PROMOTE_CAP_ISSUES;
+
+function seedWaves(state) {
+    fs.writeFileSync(path.join(TMP_DIR, 'waves.json'), JSON.stringify(state, null, 2));
+    waves.invalidateCache();
+}
+function readWaves() {
+    return JSON.parse(fs.readFileSync(path.join(TMP_DIR, 'waves.json'), 'utf8'));
+}
+function readPartial() {
+    const p = path.join(TMP_DIR, '.partial-pause.json');
+    if (!fs.existsSync(p)) return null;
+    return JSON.parse(fs.readFileSync(p, 'utf8'));
+}
+// Estado base: SIN ola activa (promote sólo procede si no hay activa — CA-3),
+// una planificada #8 con un issue abierto.
+function baseState() {
+    return {
+        version: '1.0',
+        meta: { created_at: '2026-06-20T10:00:00.000Z', updated_at: '2026-06-20T10:00:00.000Z', updated_by: 'System', source: 'manual' },
+        active_wave: null,
+        planned_waves: [{ number: 8, name: 'Ola 8', issues: [{ number: 200 }] }],
+        archived_waves: [],
+        dependencies: [],
+    };
+}
+
+function makeReq({ method = 'POST', url = '/dashboard/wave/promote', remoteAddress = '127.0.0.1', headers = {} } = {}) {
+    const req = new EventEmitter();
+    req.method = method;
+    req.url = url;
+    req.headers = Object.assign({ 'content-type': 'application/json' }, headers);
+    req.socket = { remoteAddress };
+    req.destroy = () => {};
+    return req;
+}
+function makeRes() {
+    let resolve;
+    const done = new Promise((r) => { resolve = r; });
+    const res = {
+        statusCode: null, headers: null, body: '',
+        writeHead(status, headers) { this.statusCode = status; this.headers = headers; },
+        end(chunk) { if (chunk) this.body += chunk; resolve(); },
+        done,
+    };
+    return res;
+}
+async function invoke(reqOpts, body) {
+    const req = makeReq(reqOpts);
+    const res = makeRes();
+    const handled = handleWavePromoteMutation(req, res);
+    if (body !== undefined) {
+        process.nextTick(() => {
+            req.emit('data', Buffer.from(body));
+            req.emit('end');
+        });
+    }
+    await res.done;
+    return { handled, res };
+}
+
+test('ruta ajena no se maneja (devuelve false)', () => {
+    const req = makeReq({ url: '/api/dash/header' });
+    const res = makeRes();
+    assert.equal(handleWavePromoteMutation(req, res), false);
+});
+
+test('método incorrecto → 405', async () => {
+    seedWaves(baseState());
+    const { handled, res } = await invoke({ method: 'GET' });
+    assert.equal(handled, true);
+    assert.equal(res.statusCode, 405);
+});
+
+test('no-loopback → 403 (REQ-SEC-1/7)', async () => {
+    seedWaves(baseState());
+    const { res } = await invoke({ remoteAddress: '10.0.0.5' });
+    assert.equal(res.statusCode, 403);
+});
+
+test('cross-site (Sec-Fetch-Site) → 403 (anti-CSRF, REQ-SEC-1)', async () => {
+    seedWaves(baseState());
+    const { res } = await invoke({ headers: { 'sec-fetch-site': 'cross-site' } });
+    assert.equal(res.statusCode, 403);
+});
+
+test('Content-Type no JSON → 415', async () => {
+    seedWaves(baseState());
+    const { res } = await invoke({ headers: { 'content-type': 'text/plain' } });
+    assert.equal(res.statusCode, 415);
+});
+
+test('waveNumber inválido (float/string/≤0/null) → 400 sin mutar (REQ-SEC-2/CA-6)', async () => {
+    for (const bad of [1.5, '8', 0, -3, null]) {
+        seedWaves(baseState());
+        const { res } = await invoke({}, JSON.stringify({ waveNumber: bad }));
+        assert.equal(res.statusCode, 400, `esperaba 400 para ${JSON.stringify(bad)}`);
+        // No mutó: la planificada sigue, no hay activa.
+        const st = readWaves();
+        assert.equal(st.active_wave, null);
+        assert.ok(st.planned_waves.find((w) => w.number === 8));
+    }
+});
+
+test('preview sin confirmed NO escribe + devuelve total (CA-4)', async () => {
+    seedWaves(baseState());
+    const { res } = await invoke({}, JSON.stringify({ waveNumber: 8 }));
+    assert.equal(res.statusCode, 200);
+    const payload = JSON.parse(res.body);
+    assert.equal(payload.preview, true);
+    assert.equal(payload.total, 1);
+    assert.deepEqual(payload.toAdd, [200]);
+    // NO mutó: sigue sin activa, planificada intacta, sin partial-pause escrito.
+    const st = readWaves();
+    assert.equal(st.active_wave, null);
+    assert.ok(st.planned_waves.find((w) => w.number === 8));
+    assert.equal(readPartial(), null);
+});
+
+test('PROMOTE_CAP_EXCEEDED cuando toAdd > cap, sin mutar (CA-4)', async () => {
+    const s = baseState();
+    // Planificada con cap+1 issues abiertos → supera el tope.
+    const many = [];
+    for (let i = 0; i < WAVE_PROMOTE_CAP_ISSUES + 1; i++) many.push({ number: 1000 + i });
+    s.planned_waves = [{ number: 8, name: 'Ola 8', issues: many }];
+    seedWaves(s);
+    const { res } = await invoke({}, JSON.stringify({ waveNumber: 8, confirmed: true }));
+    assert.equal(res.statusCode, 409);
+    const payload = JSON.parse(res.body);
+    assert.equal(payload.error, 'PROMOTE_CAP_EXCEEDED');
+    assert.equal(payload.applied, false);
+    assert.equal(payload.total, WAVE_PROMOTE_CAP_ISSUES + 1);
+    // NO mutó.
+    const st = readWaves();
+    assert.equal(st.active_wave, null);
+    assert.ok(st.planned_waves.find((w) => w.number === 8));
+});
+
+test('active_wave_exists → 409 cuando ya hay activa (CA-3)', async () => {
+    const s = baseState();
+    s.active_wave = { number: 7, name: 'Ola 7', started_at: '2026-06-20T10:00:00.000Z', issues: [{ number: 100, status: 'in-progress' }] };
+    seedWaves(s);
+    const { res } = await invoke({}, JSON.stringify({ waveNumber: 8, confirmed: true }));
+    assert.equal(res.statusCode, 409);
+    assert.equal(JSON.parse(res.body).error, 'active_wave_exists');
+    // No promovió: la activa sigue siendo #7, #8 sigue planificada.
+    const st = readWaves();
+    assert.equal(st.active_wave.number, 7);
+    assert.ok(st.planned_waves.find((w) => w.number === 8));
+});
+
+test('ola planificada inexistente → 404 not_found', async () => {
+    seedWaves(baseState());
+    const { res } = await invoke({}, JSON.stringify({ waveNumber: 99, confirmed: true }));
+    assert.equal(res.statusCode, 404);
+    assert.equal(JSON.parse(res.body).error, 'not_found');
+});
+
+test('confirmado promueve + sincroniza allowlist recursiva; cerrados NO (CA-1/CA-2/CA-8)', async () => {
+    const s = baseState();
+    // Grafo: 200 → (bloqueado por) 201 → (bloqueado por) 202.
+    // 202 está CERRADO (status completed en una ola archivada) → NO entra (CA-2).
+    s.planned_waves = [{ number: 8, name: 'Ola 8', issues: [{ number: 200 }] }];
+    s.archived_waves = [{ number: 6, name: 'Ola 6', issues: [{ number: 202, status: 'completed' }] }];
+    s.dependencies = [
+        { blocker: 201, blocked: 200 },
+        { blocker: 202, blocked: 201 },
+    ];
+    seedWaves(s);
+
+    const { res } = await invoke({}, JSON.stringify({ waveNumber: 8, confirmed: true }));
+    assert.equal(res.statusCode, 200);
+    const payload = JSON.parse(res.body);
+    assert.equal(payload.ok, true);
+    assert.equal(payload.applied, true);
+    assert.equal(payload.actor, 'operador-local');
+
+    // Estado: #8 pasó a activa.
+    const st = readWaves();
+    assert.ok(st.active_wave && st.active_wave.number === 8);
+    assert.equal(st.planned_waves.find((w) => w.number === 8), undefined);
+    // Auditoría con actor fijo server-side (nunca del body) — CA-8.
+    assert.equal(st.meta.updated_by, 'operador-local');
+
+    // Allowlist recursiva: 200 (seed) + 201 (dep abierta). 202 cerrado NO entra.
+    const pp = readPartial();
+    assert.ok(pp, '.partial-pause.json debe existir tras el promote');
+    assert.deepEqual(pp.allowed_issues, [200, 201]);
+});
+
+test('cleanup', () => {
+    delete process.env.PIPELINE_DIR_OVERRIDE;
+    try { fs.rmSync(TMP_DIR, { recursive: true, force: true }); } catch {}
+});

--- a/.pipeline/lib/dashboard-routes.js
+++ b/.pipeline/lib/dashboard-routes.js
@@ -1828,6 +1828,222 @@ function handleWaveArchiveMutation(req, res) {
     return true;
 }
 
+// #4435 — Cap defensivo de issues que una promoción puede sumar a la allowlist
+// (REQ-SEC-4/CA-4). Espejo del `promoteCapIssues` de dashboard.js:11525 — misma
+// semántica anti-DoS que el promote de candidatos.
+const WAVE_PROMOTE_CAP_ISSUES = 50;
+
+// #4435 — Set de issues cerrados CONFIRMADOS según waves.json (filesystem propio,
+// in-process). Un issue se considera cerrado si su `status` en cualquier ola es
+// `completed`. Alimenta el predicado `isClosed` de `expandRecursiveOpenIssues`
+// SIN consultar GitHub ni shell (REQ-SEC-3). Fail-safe (SEC-4): lo que no
+// aparezca acá queda indeterminado → se conserva en la allowlist.
+function _buildWaveClosedSet(waves) {
+    const closed = new Set();
+    try {
+        const state = waves.loadWaves();
+        const buckets = [];
+        if (state && state.active_wave) buckets.push(state.active_wave);
+        if (state && Array.isArray(state.planned_waves)) buckets.push(...state.planned_waves);
+        if (state && Array.isArray(state.archived_waves)) buckets.push(...state.archived_waves);
+        for (const w of buckets) {
+            if (!w || !Array.isArray(w.issues)) continue;
+            for (const it of w.issues) {
+                if (it && Number.isInteger(it.number) && it.status === 'completed') {
+                    closed.add(it.number);
+                }
+            }
+        }
+    } catch { /* fail-safe: sin datos legibles → nada cerrado, todo se conserva */ }
+    return closed;
+}
+
+// #4435 — Endpoint mutante para PROMOVER una ola planificada → activa,
+// sincronizando la allowlist (`.partial-pause.json`) con los issues de la ola +
+// hijos/dependencias recursivas ABIERTOS (motor #4350). Replica LITERALMENTE el
+// cinturón de gates de `handleWaveArchiveMutation`, en el MISMO orden:
+//   método≠POST → 405 · no-loopback → 403 · cross-site → 403 (anti-CSRF,
+//   REQ-SEC-1) · Content-Type≠json → 415 · body sobre cap → 413 · waveNumber
+//   inválido → 400 (SIN reflejar input — REQ-SEC-2/CA-6).
+//
+// Sobre esa base agrega el flujo preview→confirm + cap (plantilla
+// `/api/allowlist-candidates/:issue/promote`), gobernado por `body.confirmed`:
+//   - Invariante "una sola ola activa" (REQ-SEC-5/CA-3): chequeo server-side
+//     ANTES de escribir; la carrera doble-submit la corta el marker
+//     transaccional de `promoteWaveAtomic` (lanza si hay otra promoción en curso).
+//   - Expansión 100% in-process (REQ-SEC-3/CA-2): `expandRecursiveOpenIssues`
+//     camina el grafo `dependencies[]` de waves.json (`getBlockingIssues`) — sin
+//     red, sin shell, sin interpolar `waveNumber` en un path. El set expandido
+//     se pasa como AUTORITATIVO a `promoteWaveAtomic` (`metadata.expandedIssues`);
+//     waves.js NO re-consulta GitHub.
+//   - Cap defensivo (REQ-SEC-4/CA-4): si el set supera `WAVE_PROMOTE_CAP_ISSUES`
+//     → `PROMOTE_CAP_EXCEEDED` (409) sin escribir.
+//   - Preview (sin `confirmed:true`): devuelve el total sin mutar.
+// El actor se graba server-side FIJO (`operador-local`), NUNCA del body
+// (REQ-SEC-6). El audit `wave_promoted` lo emite `promoteWaveAtomic`
+// (`emitPromoteAudit`) → CA-8.
+function handleWavePromoteMutation(req, res) {
+    const pathnameOnly = (req.url || '').split('?')[0];
+    if (pathnameOnly !== '/dashboard/wave/promote') return false;
+
+    // Gate 1 — método.
+    if (req.method !== 'POST') {
+        _logPartialRejected(req, 'wave_promote_method_not_allowed');
+        sendMutationJson(res, { error: 'method_not_allowed' }, 405);
+        return true;
+    }
+    // Gate 2 — loopback (REQ-SEC-1/7, independiente del bind).
+    if (!isLoopbackReq(req)) {
+        _logPartialRejected(req, 'wave_promote_non_loopback');
+        sendMutationJson(res, { error: 'forbidden' }, 403);
+        return true;
+    }
+    // Gate 3 — same-origin (anti-CSRF, REQ-SEC-1).
+    if (!isSameOriginFetch(req)) {
+        _logPartialRejected(req, 'wave_promote_cross_origin');
+        sendMutationJson(res, { error: 'forbidden' }, 403);
+        return true;
+    }
+    // Gate 4 — Content-Type debe ser JSON.
+    const ct = (req.headers && req.headers['content-type']) || '';
+    if (!/^application\/json\b/i.test(ct)) {
+        _logPartialRejected(req, 'wave_promote_bad_content_type');
+        sendMutationJson(res, { error: 'unsupported_media_type' }, 415);
+        return true;
+    }
+
+    // Módulos de dominio disponibles (motor #4350 in-process).
+    let waves, recursivePromote;
+    try { waves = require('./waves'); } catch { waves = null; }
+    try { recursivePromote = require('./allowlist-recursive-promote'); } catch { recursivePromote = null; }
+    if (!waves
+        || typeof waves.promoteWaveAtomic !== 'function'
+        || typeof waves.getActiveWave !== 'function'
+        || typeof waves.getPlannedWave !== 'function'
+        || typeof waves.getBlockingIssues !== 'function'
+        || !recursivePromote
+        || typeof recursivePromote.expandRecursiveOpenIssues !== 'function') {
+        sendMutationJson(res, { error: 'module_unavailable' }, 503);
+        return true;
+    }
+
+    // Gate 5 — body con cap (REQ-SEC-8) + parseo + validación estricta.
+    readBodyCapped(req, ALERT_BODY_MAX_BYTES, (err, raw) => {
+        if (err) {
+            const tooLarge = err.message === 'body_too_large';
+            _logPartialRejected(req, tooLarge ? 'wave_promote_body_too_large' : 'wave_promote_body_read_error');
+            sendMutationJson(res, { error: tooLarge ? 'payload_too_large' : 'bad_request' }, tooLarge ? 413 : 400);
+            return;
+        }
+        let parsed = null;
+        try { parsed = raw ? JSON.parse(raw) : {}; } catch { parsed = null; }
+        if (!parsed || typeof parsed !== 'object') {
+            sendMutationJson(res, { error: 'bad_request' }, 400);
+            return;
+        }
+        // Validación server-side ESTRICTA del número de ola (path safety CA-6):
+        // entero positivo. Rechaza float / string / ≤0 / NaN SIN reflejar input.
+        const value = parsed.waveNumber != null ? parsed.waveNumber : parsed.wave_number;
+        if (typeof value !== 'number' || !Number.isInteger(value) || value < 1) {
+            sendMutationJson(res, { error: 'bad_request', applied: false }, 400);
+            return;
+        }
+        const confirmed = parsed.confirmed === true;
+
+        try {
+            // Gate fail-closed (marker .failed de promote activo).
+            if (typeof waves.isWavePromoteBlocked === 'function' && waves.isWavePromoteBlocked().blocked) {
+                sendMutationJson(res, { error: 'promote_blocked', applied: false }, 409);
+                return;
+            }
+            // Invariante "una sola ola activa" (REQ-SEC-5/CA-3) — server-side,
+            // ANTES de escribir. La carrera doble-submit la corta el marker de
+            // promoteWaveAtomic (ver catch abajo).
+            const active = waves.getActiveWave();
+            if (active) {
+                sendMutationJson(res, { error: 'active_wave_exists', applied: false }, 409);
+                return;
+            }
+            // La ola planificada debe existir.
+            const planned = waves.getPlannedWave(value);
+            if (!planned) {
+                sendMutationJson(res, { error: 'not_found', applied: false }, 404);
+                return;
+            }
+
+            // Expansión recursiva IN-PROCESS (REQ-SEC-3/CA-2): seeds = issues de
+            // la ola; getDeps camina el grafo `dependencies[]` de waves.json;
+            // isClosed filtra SOLO cierres confirmados por filesystem (fail-safe:
+            // indeterminado se conserva). Sin red, sin GitHub, sin shell.
+            const seedIssues = Array.isArray(planned.issues)
+                ? planned.issues.map((i) => i && i.number).filter((n) => Number.isInteger(n) && n > 0)
+                : [];
+            const closedSet = _buildWaveClosedSet(waves);
+            const expandedIssues = recursivePromote.expandRecursiveOpenIssues({
+                seedIssues,
+                isClosed: (n) => closedSet.has(n),
+                getDeps: (n) => waves.getBlockingIssues(n),
+            });
+
+            // Cap defensivo (REQ-SEC-4/CA-4). Como el chequeo de invariante ya
+            // garantizó que NO hay ola activa, la allowlist final ES el set
+            // expandido → el cap aplica sobre su tamaño total.
+            if (expandedIssues.length > WAVE_PROMOTE_CAP_ISSUES) {
+                sendMutationJson(res, {
+                    error: 'PROMOTE_CAP_EXCEEDED',
+                    applied: false,
+                    total: expandedIssues.length,
+                    cap: WAVE_PROMOTE_CAP_ISSUES,
+                }, 409);
+                return;
+            }
+
+            // Preview (sin confirmed:true) — NO escribe (REQ-SEC-4/CA-4).
+            if (!confirmed) {
+                sendMutationJson(res, {
+                    ok: true,
+                    preview: true,
+                    waveNumber: value,
+                    toAdd: expandedIssues,
+                    finalAllowlist: expandedIssues,
+                    total: expandedIssues.length,
+                }, 200);
+                return;
+            }
+
+            // Confirmado — promoción atómica con el set expandido AUTORITATIVO.
+            // Actor FIJO server-side (REQ-SEC-6); waves.js emite `wave_promoted`.
+            const result = waves.promoteWaveAtomic(value, {
+                expandedIssues,
+                updated_by: 'operador-local',
+                source: 'dashboard/wave-promote',
+                note: `promote wave ${value} → active (dashboard)`,
+            });
+            sendMutationJson(res, {
+                ok: true,
+                applied: true,
+                preview: false,
+                actor: 'operador-local',
+                waveNumber: value,
+                total: (result && Array.isArray(result.newAllowlist))
+                    ? result.newAllowlist.length
+                    : expandedIssues.length,
+            }, 200);
+        } catch (e) {
+            const msg = (e && e.message) ? e.message : '';
+            // Doble-submit / carrera: el marker transaccional de promoteWaveAtomic
+            // lanza si hay otra promoción en curso (REQ-SEC-5). 409, no 500.
+            if (/transacci[oó]n en curso/i.test(msg) || /crear marker/i.test(msg)) {
+                sendMutationJson(res, { error: 'promote_in_progress', applied: false }, 409);
+                return;
+            }
+            try { console.error(JSON.stringify({ event: 'wave_promote_mutation_error', msg, ts: new Date().toISOString() })); } catch {}
+            sendMutationJson(res, { error: 'internal_error' }, 500);
+        }
+    });
+    return true;
+}
+
 // =============================================================================
 // #4436 — Endpoints mutantes de ciclo de vida de la ola activa desde la ventana
 // Roadmap: pausar / reanudar / relanzar despacho. Cablean a los MISMOS
@@ -2067,6 +2283,10 @@ function handle(req, res, ctx) {
     // #4378 — endpoint mutante para archivar una ola. Mismo lugar que los
     // anteriores: ANTES del gate GET-only, con su propio cinturón de gates.
     if (handleWaveArchiveMutation(req, res)) return true;
+    // #4435 — endpoint mutante para promover una ola planificada → activa
+    // (sync de allowlist). Hermano de archive: ANTES del gate GET-only, con su
+    // propio cinturón de gates + flujo preview→confirm + cap.
+    if (handleWavePromoteMutation(req, res)) return true;
     // #4436 — endpoints mutantes de ciclo de vida de la ola activa (pausar /
     // reanudar / relanzar despacho). Mismo lugar y mismo cinturón de gates.
     if (handleWavePauseMutation(req, res)) return true;
@@ -2307,6 +2527,9 @@ module.exports = {
         renderCostosView,
         // #4378 — endpoint mutante para archivar una ola + vista roadmap.
         handleWaveArchiveMutation,
+        // #4435 — endpoint mutante para promover una ola planificada → activa.
+        handleWavePromoteMutation,
+        WAVE_PROMOTE_CAP_ISSUES,
         // #4436 — endpoints mutantes de ciclo de vida de la ola activa.
         handleWavePauseMutation,
         handleWaveResumeMutation,

--- a/.pipeline/views/dashboard/wave-roadmap.js
+++ b/.pipeline/views/dashboard/wave-roadmap.js
@@ -333,6 +333,13 @@ function renderPlannedCard(wave, position) {
     const nameTxt = wave.name != null && wave.name !== '' ? String(wave.name) : (num !== null ? `Ola ${num}` : 'Ola');
     const goalTxt = wave.goal != null ? String(wave.goal) : '';
     const issues = normalizeIssues(wave.issues);
+    // #4435 GUX-1/GUX-4 — "Promover a activa": acción PRIMARIA/positiva, sólo en
+    // olas planificadas (esta función es exclusiva de planned → CA-9). Ícono
+    // #ic-promote + label textual + title/aria descriptivos vía escapeHtmlAttr.
+    const promoteBtn = num !== null
+        ? `<button type="button" class="wr-btn wr-btn-promote" onclick="roadmapPromote(${num})" title="${escapeHtmlAttr('Promover la ola ' + num + ' (planificada) a activa y sincronizar la lista de bailes')}" aria-label="${escapeHtmlAttr('Promover la ola ' + num + ' (planificada) a activa y sincronizar la lista de bailes')}">`
+            + '<svg class="wr-btn-ic" aria-hidden="true"><use href="#ic-promote"></use></svg> Promover a activa</button>'
+        : '';
     const archiveBtn = num !== null
         ? `<button type="button" class="wr-btn wr-btn-archive" onclick="roadmapArchive(${num}, 'planificada')" title="${escapeHtmlAttr('Archivar la ola planificada ' + num)}" aria-label="${escapeHtmlAttr('Archivar la ola planificada ' + num)}">`
             + '<svg class="wr-btn-ic" aria-hidden="true"><use href="#ic-archive-box"></use></svg> Archivar</button>'
@@ -357,7 +364,7 @@ function renderPlannedCard(wave, position) {
           <span class="wr-card-title">${escapeHtmlText(nameTxt)}</span>
           ${num !== null ? `<span class="wr-card-num">Ola ${num}</span>` : ''}
         </div>
-        <div class="wr-card-actions">${archiveBtn}</div>
+        <div class="wr-card-actions">${promoteBtn}${archiveBtn}</div>
       </header>
       ${goalTxt ? `<div class="wr-card-goal">${escapeHtmlText(goalTxt)}</div>` : ''}
       ${renderIssueList(issues, null, num)}
@@ -436,6 +443,9 @@ function roadmapStyle() {
 .wr-btn{display:inline-flex;align-items:center;gap:6px;font-size:12px;font-weight:700;cursor:pointer;padding:6px 11px;border-radius:8px;border:1px solid var(--border,rgba(255,255,255,.12));background:transparent;color:var(--text-secondary,#8A93A6);white-space:nowrap}
 .wr-btn-ic{width:14px;height:14px}
 .wr-btn-archive:hover{color:var(--text-primary,#e6edf3);border-color:var(--purple,#BC8CFF)}
+/* #4435 GUX-1 — Promover es la acción PRIMARIA/positiva: acento --success en hover
+   (constructivo, no destructivo). El label textual porta el significado (WCAG 1.4.1). */
+.wr-btn-promote:hover{color:var(--success,#3FB950);border-color:var(--success,#3FB950)}
 .wr-btn:disabled{opacity:.5;cursor:not-allowed}
 .wr-btn[hidden]{display:none}
 /* #4436 — controles de ciclo de vida de la ola activa (hover reusando tokens). */
@@ -790,6 +800,76 @@ async function roadmapDisassociate(waveNum, issueNum){
     _roadmapSetStatus(statusId, 'Error de red: ' + e.message, 'err');
   }
 }
+// #4435 — Promover una ola planificada a activa. Flujo preview then confirm
+// contra la ruta mutante (gate loopback+same-origin). Fase 1: POST sin confirmar
+// para leer el total real de issues que entran a la lista de bailes (no muta).
+// Fase 2: tras confirmar en el modal (no destructivo), POST con confirmed:true.
+// Sin reflejar input crudo; errores con copy accionable en espanol (GUX-5).
+async function roadmapPromote(waveNum){
+  waveNum = parseInt(waveNum, 10);
+  if(!Number.isInteger(waveNum) || waveNum < 1) return;
+  var btns = document.querySelectorAll('.wr-card[data-wave="' + waveNum + '"] .wr-btn');
+  function reenable(){ btns.forEach(function(b){ b.disabled = false; }); }
+  function promoteErr(j, status){
+    if(j && j.error === 'active_wave_exists'){
+      return 'Ya hay una ola activa. Archivala o esperá a que cierre antes de promover la ola ' + waveNum + '.';
+    }
+    if(j && j.error === 'PROMOTE_CAP_EXCEEDED'){
+      return 'La ola ' + waveNum + ' arrastra demasiados issues (' + (j.total != null ? j.total : '?') + ', supera el tope de seguridad). Revisá el alcance antes de promover.';
+    }
+    if(j && j.error === 'promote_blocked'){
+      return 'Promover está bloqueado por una recovery fallida anterior. Revisá .pipeline/waves.json y los markers .failed.';
+    }
+    if(j && j.error === 'promote_in_progress'){
+      return 'Hay otra promoción en curso. Esperá a que termine antes de reintentar.';
+    }
+    if(j && j.error === 'not_found'){
+      return 'La ola ' + waveNum + ' ya no existe entre las planificadas. Refrescá la vista.';
+    }
+    return 'No pude promover la ola ' + waveNum + ' (' + (j && j.error ? j.error : ('HTTP ' + status)) + ').';
+  }
+  btns.forEach(function(b){ b.disabled = true; });
+  try {
+    // Fase 1 — preview (sin confirmed): total real de issues a agregar.
+    var pr = await fetch('/dashboard/wave/promote', {
+      method: 'POST',
+      headers: Object.assign({ 'Content-Type': 'application/json' }, nhCsrfHeaders()),
+      body: JSON.stringify({ waveNumber: waveNum })
+    });
+    var pj = await pr.json().catch(function(){ return {}; });
+    if(!pr.ok || !pj.preview){
+      alert(promoteErr(pj, pr.status));
+      reenable();
+      return;
+    }
+    var total = pj.total != null ? pj.total : (Array.isArray(pj.toAdd) ? pj.toAdd.length : 0);
+    // Fase 2 — confirmación NO destructiva con preview del impacto (GUX-3).
+    var ok = await inConfirm({
+      title: 'Promover ola a activa',
+      message: 'La ola ' + waveNum + ' pasará a activa y su lista de bailes se sincronizará con los issues de la ola (más hijos y dependencias abiertos).',
+      confirmLabel: 'Promover',
+      danger: false,
+      preview: [
+        { label: 'Ola', value: '#' + waveNum },
+        { label: 'Issues a la lista de bailes', value: String(total) }
+      ]
+    });
+    if(!ok){ reenable(); return; }
+    // Fase 3 — commit.
+    var r = await fetch('/dashboard/wave/promote', {
+      method: 'POST',
+      headers: Object.assign({ 'Content-Type': 'application/json' }, nhCsrfHeaders()),
+      body: JSON.stringify({ waveNumber: waveNum, confirmed: true })
+    });
+    var j = await r.json().catch(function(){ return {}; });
+    if(r.ok && j.ok){ location.reload(); return; }
+    alert(promoteErr(j, r.status));
+    reenable();
+  } catch(e){
+    alert('Error promoviendo la ola ' + waveNum + ': ' + e.message);
+    reenable();
+  }
+}
 // #4436 — Controles de ciclo de vida de la ola activa. Cablean a los endpoints
 // mutantes (mismo gate loopback+same-origin que /dashboard/wave/archive) usando
 // nhCsrfHeaders() + confirmación previa. Las destructivas (Pausar, Relanzar)
@@ -900,6 +980,7 @@ window.roadmapNewWaveToggle = roadmapNewWaveToggle;
 window.roadmapCreateWave = roadmapCreateWave;
 window.roadmapAssociate = roadmapAssociate;
 window.roadmapDisassociate = roadmapDisassociate;
+window.roadmapPromote = roadmapPromote;
 window.roadmapPause = roadmapPause;
 window.roadmapResume = roadmapResume;
 window.roadmapDispatch = roadmapDispatch;


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 3 archivos · +537 -1

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:passed` aplicado por delivery

## Closes

Closes #4435
