### PR TITLE
Roadmap del dashboard: ver y editar la allowlist (lista de bailes) desde la pantalla con validacion de dependencias

### DIFF
--- a/.pipeline/lib/__tests__/waves-api-allowlist.test.js
+++ b/.pipeline/lib/__tests__/waves-api-allowlist.test.js
@@ -1,0 +1,335 @@
+// =============================================================================
+// waves-api-allowlist.test.js — Tests del editor de allowlist de la ventana
+// Roadmap (#4437), enrutado por `handleWavesApi` bajo `/api/roadmap/allowlist*`.
+//
+// Cubre (CA-1..CA-8):
+//   - matchRoute mapea las 4 rutas nuevas y rechaza métodos inválidos.
+//   - Validación A03: IDs no numéricos → 400 `bad-id` SIN invocar resolveOpenDeps.
+//   - preview NO escribe .partial-pause.json (contenido idéntico antes/después)
+//     y devuelve aArrastrar/inconsistencias/truncado.
+//   - add expande recursivamente y persiste SÓLO vía setPartialPause.
+//   - remove con inconsistencia → blocked hasta confirm; confirm:true persiste.
+//   - remove que desincroniza la ola activa → warning bloqueante.
+//   - preview truncado expone truncado:true + reason.
+//   - los 3 gates (loopback/same-origin/auth) rechazan preview y mutaciones.
+//
+// Aislamiento por PIPELINE_DIR_OVERRIDE + ghRunner mockeado (sin red).
+//
+// Ejecutar:  node --test .pipeline/lib/__tests__/waves-api-allowlist.test.js
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { Readable } = require('node:stream');
+
+let waves, wavesApi, csrf, partialPause;
+
+// Grafo de issues falso para el ghRunner mockeado.
+//   100 (épico, open)   → Closes #101, Closes #102   (forward deps)
+//   101 (hijo, open)    → Split de #100               (procedencia = parent)
+//   102 (hijo, open)    → Split de #100, Depends on #103
+//   103 (dep, open)     → (sin deps)
+//   200 (suelto, open)  → (sin deps)
+const FAKE_ISSUES = {
+    100: { number: 100, title: 'Épico A', state: 'open', body: 'Closes #101\nCloses #102', comments: [] },
+    101: { number: 101, title: 'Hijo 1', state: 'open', body: 'Split de #100', comments: [] },
+    102: { number: 102, title: 'Hijo 2', state: 'open', body: 'Split de #100\nDepends on #103', comments: [] },
+    103: { number: 103, title: 'Dep de 102', state: 'open', body: '', comments: [] },
+    200: { number: 200, title: 'Suelto', state: 'open', body: '', comments: [] },
+};
+
+let ghCalls = 0;
+function makeGhRunner() {
+    ghCalls = 0;
+    return function ghRunner(args) {
+        ghCalls += 1;
+        // args = ['issue','view','<n>','--repo',repo,'--json',...]
+        const n = Number(args[2]);
+        const issue = FAKE_ISSUES[n];
+        if (!issue) return { ok: false, stdout: '', stderr: 'not found', status: 1 };
+        return { ok: true, stdout: JSON.stringify(issue), stderr: '', status: 0 };
+    };
+}
+
+function setupTmp() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'waves-api-allowlist-'));
+    process.env.PIPELINE_DIR_OVERRIDE = dir;
+    for (const m of ['../waves', '../waves-api', '../partial-pause']) {
+        try { delete require.cache[require.resolve(m)]; } catch { /* noop */ }
+    }
+    waves = require('../waves');
+    wavesApi = require('../waves-api');
+    csrf = require('../kill-agent-csrf');
+    partialPause = require('../partial-pause');
+    waves.invalidateCache();
+    wavesApi._internal._resetForTests();
+    // Inyectar el ghRunner mockeado + cache aislado en el tmp dir.
+    wavesApi._internal._setDepsOptsForTests({
+        ghRunner: makeGhRunner(),
+        cacheFile: path.join(dir, 'deps-cache.json'),
+    });
+    return dir;
+}
+
+function teardownTmp(dir) {
+    delete process.env.PIPELINE_DIR_OVERRIDE;
+    wavesApi._internal._resetForTests();
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort */ }
+}
+
+function makeReq({ method = 'GET', url = '/', headers = {}, body = null, ip = '127.0.0.1' } = {}) {
+    const req = Readable.from(body != null ? [Buffer.from(body)] : []);
+    req.method = method;
+    req.url = url;
+    req.headers = {};
+    for (const [k, v] of Object.entries(headers)) req.headers[k.toLowerCase()] = v;
+    req.socket = { remoteAddress: ip };
+    return req;
+}
+
+function makeRes(onDone) {
+    const res = { statusCode: null, headers: {}, body: '', ended: false };
+    res.setHeader = (k, v) => { res.headers[k] = v; };
+    res.writeHead = (s, h) => { res.statusCode = s; Object.assign(res.headers, h || {}); return res; };
+    res.end = (b) => { res.body = b || ''; res.ended = true; if (onDone) onDone(res); };
+    return res;
+}
+
+function invoke(reqOpts) {
+    return new Promise((resolve) => {
+        const req = makeReq(reqOpts);
+        const res = makeRes((r) => resolve(r));
+        const handled = wavesApi.handleWavesApi(req, res, {});
+        if (!handled) resolve({ notHandled: true });
+    });
+}
+
+function json(res) { return JSON.parse(res.body); }
+
+function authHeaders() {
+    const tok = csrf.generateToken();
+    return { 'x-csrf-token': tok, 'cookie': `${csrf.COOKIE_NAME}=${tok}`, 'content-type': 'application/json' };
+}
+
+function seedAllowlist(issues) {
+    const r = partialPause.setPartialPause(issues, {
+        source: 'dashboard:roadmap:allowlist',
+        authorizedBy: 'dashboard:roadmap:allowlist',
+        justification: 'seed de test',
+    });
+    assert.ok(!r.rejected, 'seed no debe ser rechazado por el gate');
+}
+
+function partialFilePath(dir) { return path.join(dir, '.partial-pause.json'); }
+
+// --- matchRoute ---------------------------------------------------------------
+
+test('matchRoute mapea las 4 rutas nuevas de allowlist', () => {
+    const mr = require('../waves-api')._internal.matchRoute;
+    assert.deepEqual(mr('GET', '/api/roadmap/allowlist'), { surface: true, kind: 'read', action: 'allowlist-read' });
+    assert.deepEqual(mr('POST', '/api/roadmap/allowlist/preview'), { surface: true, kind: 'mutation', action: 'allowlist-preview', method: 'POST' });
+    assert.deepEqual(mr('POST', '/api/roadmap/allowlist/add'), { surface: true, kind: 'mutation', action: 'allowlist-add', method: 'POST' });
+    assert.deepEqual(mr('POST', '/api/roadmap/allowlist/remove'), { surface: true, kind: 'mutation', action: 'allowlist-remove', method: 'POST' });
+    // Método inválido → unknown (405), no null.
+    assert.equal(mr('DELETE', '/api/roadmap/allowlist/add').kind, 'unknown');
+    assert.equal(mr('PUT', '/api/roadmap/allowlist').kind, 'unknown');
+    // Operación desconocida → null (no es de la superficie).
+    assert.equal(mr('POST', '/api/roadmap/allowlist/nope'), null);
+});
+
+// --- Lectura enriquecida (CA-1) ----------------------------------------------
+
+test('GET allowlist devuelve metadata whitelisteada (número/título/estado/parent)', async () => {
+    const dir = setupTmp();
+    try {
+        seedAllowlist([101]);
+        // Calentar el cache de deps para 101 (fetchIssueInfo popula title/state/parent).
+        wavesApi._internal.computeDrag([101]);
+        const res = await invoke({ method: 'GET', url: '/api/roadmap/allowlist' });
+        assert.equal(res.statusCode, 200);
+        const b = json(res);
+        assert.equal(b.count, 1);
+        const row = b.allowlist[0];
+        assert.equal(row.number, 101);
+        assert.equal(row.title, 'Hijo 1');
+        assert.equal(row.status, 'open');
+        assert.equal(row.parent, 100); // Split de #100 → parent
+        // A05: ninguna clave de path/timestamp filtrada.
+        assert.deepEqual(Object.keys(row).sort(), ['number', 'parent', 'status', 'title']);
+    } finally { teardownTmp(dir); }
+});
+
+// --- Validación A03 -----------------------------------------------------------
+
+test('add con ID no numérico → 400 bad-id SIN invocar resolveOpenDeps', async () => {
+    const dir = setupTmp();
+    try {
+        for (const bad of [['abc'], [-1], [1.5], ['12x'], [0]]) {
+            const res = await invoke({
+                method: 'POST', url: '/api/roadmap/allowlist/add',
+                headers: authHeaders(), body: JSON.stringify({ issues: bad }),
+            });
+            assert.equal(res.statusCode, 400, `esperaba 400 para ${JSON.stringify(bad)}`);
+            assert.equal(json(res).code, 'bad-id');
+        }
+        // El ghRunner nunca fue invocado: la validación cortó en el borde HTTP.
+        assert.equal(ghCalls, 0, 'resolveOpenDeps no debe correr con IDs inválidos');
+    } finally { teardownTmp(dir); }
+});
+
+// --- Preview dry-run (CA-2) ---------------------------------------------------
+
+test('preview NO escribe .partial-pause.json y devuelve aArrastrar/inconsistencias', async () => {
+    const dir = setupTmp();
+    try {
+        seedAllowlist([100]);
+        const before = fs.readFileSync(partialFilePath(dir), 'utf8');
+        // preview de agregar #100 (ya está): arrastra 101,102,103 recursivamente.
+        const res = await invoke({
+            method: 'POST', url: '/api/roadmap/allowlist/preview',
+            headers: authHeaders(), body: JSON.stringify({ issues: [100] }),
+        });
+        assert.equal(res.statusCode, 200);
+        const b = json(res);
+        assert.equal(b.persisted, false);
+        assert.deepEqual(b.aArrastrar, [101, 102, 103]);
+        // El archivo NO cambió (dry-run).
+        const after = fs.readFileSync(partialFilePath(dir), 'utf8');
+        assert.equal(before, after, 'preview no debe modificar .partial-pause.json');
+    } finally { teardownTmp(dir); }
+});
+
+test('preview truncado expone truncado:true + reason', async () => {
+    const dir = setupTmp();
+    try {
+        seedAllowlist([100]);
+        // maxNodes=1 fuerza truncado por nodos.
+        wavesApi._internal._setDepsOptsForTests({
+            ghRunner: makeGhRunner(),
+            cacheFile: path.join(dir, 'deps-cache.json'),
+            maxNodes: 1,
+        });
+        const res = await invoke({
+            method: 'POST', url: '/api/roadmap/allowlist/preview',
+            headers: authHeaders(), body: JSON.stringify({ issues: [100] }),
+        });
+        const b = json(res);
+        assert.equal(b.truncado, true);
+        assert.equal(b.reason, 'max_nodes');
+    } finally { teardownTmp(dir); }
+});
+
+// --- Add recursivo (CA-3) -----------------------------------------------------
+
+test('add expande recursivamente y persiste SOLO vía setPartialPause', async () => {
+    const dir = setupTmp();
+    try {
+        seedAllowlist([200]);
+        const res = await invoke({
+            method: 'POST', url: '/api/roadmap/allowlist/add',
+            headers: authHeaders(), body: JSON.stringify({ issues: [100] }),
+        });
+        assert.equal(res.statusCode, 200);
+        const b = json(res);
+        assert.equal(b.persisted, true);
+        assert.deepEqual(b.aArrastrar, [101, 102, 103]);
+        // La persistencia refleja el union recursivo (200 previo + 100 y su subgrafo).
+        assert.deepEqual(b.allowlist, [100, 101, 102, 103, 200]);
+        // Prueba empírica de que fue por el gate: readPreviousAllowlist coincide.
+        assert.deepEqual(partialPause.readPreviousAllowlist().sort((x, y) => x - y), [100, 101, 102, 103, 200]);
+    } finally { teardownTmp(dir); }
+});
+
+// --- Remove bloqueante (CA-4/CA-5) -------------------------------------------
+
+test('remove que deja dependencia faltante → blocked hasta confirm', async () => {
+    const dir = setupTmp();
+    try {
+        seedAllowlist([100, 101, 102, 103]);
+        // Quitar 103 deja a 102 con su dependencia #103 faltante.
+        const res = await invoke({
+            method: 'POST', url: '/api/roadmap/allowlist/remove',
+            headers: authHeaders(), body: JSON.stringify({ issues: [103] }),
+        });
+        assert.equal(res.statusCode, 200);
+        const b = json(res);
+        assert.equal(b.ok, false);
+        assert.equal(b.blocked, true);
+        assert.equal(b.persisted, false);
+        assert.deepEqual(b.inconsistencias['102'], [103]);
+        // No persistió: 103 sigue en la allowlist.
+        assert.ok(partialPause.readPreviousAllowlist().includes(103));
+
+        // Con confirm:true persiste igual.
+        const res2 = await invoke({
+            method: 'POST', url: '/api/roadmap/allowlist/remove',
+            headers: authHeaders(), body: JSON.stringify({ issues: [103], confirm: true }),
+        });
+        const b2 = json(res2);
+        assert.equal(b2.ok, true);
+        assert.equal(b2.persisted, true);
+        assert.ok(!partialPause.readPreviousAllowlist().includes(103));
+    } finally { teardownTmp(dir); }
+});
+
+test('remove que desincroniza la ola activa → warning bloqueante (desync proyectado)', async () => {
+    const dir = setupTmp();
+    try {
+        // Ola activa con issues 100 y 200 (sin deps forward entre sí).
+        waves.createPlannedWave({ name: 'Ola X', issues: [100, 200], concurrency_max: 2, window_minutes: 30 }, {});
+        waves.promoteWaveToActive(1, {});
+        seedAllowlist([100, 200]);
+        // Quitar 100: sigue en la ola activa → desync proyectado.
+        const res = await invoke({
+            method: 'POST', url: '/api/roadmap/allowlist/remove',
+            headers: authHeaders(), body: JSON.stringify({ issues: [100] }),
+        });
+        const b = json(res);
+        assert.equal(b.blocked, true);
+        assert.ok(b.desync, 'debe reportar desync proyectado');
+        assert.ok(b.desync.missingFromAllowlist.includes(100));
+    } finally { teardownTmp(dir); }
+});
+
+// --- Gates de seguridad (CA-7) ------------------------------------------------
+
+test('preview y mutaciones sin credencial → 401', async () => {
+    const dir = setupTmp();
+    try {
+        for (const op of ['preview', 'add', 'remove']) {
+            const res = await invoke({
+                method: 'POST', url: `/api/roadmap/allowlist/${op}`,
+                headers: { 'content-type': 'application/json' }, // sin CSRF
+                body: JSON.stringify({ issues: [100] }),
+            });
+            assert.equal(res.statusCode, 401, `${op} sin credencial debe dar 401`);
+            assert.equal(json(res).code, 'unauthorized');
+        }
+    } finally { teardownTmp(dir); }
+});
+
+test('mutación con origen cruzado → 403 (anti-CSRF)', async () => {
+    const dir = setupTmp();
+    try {
+        const res = await invoke({
+            method: 'POST', url: '/api/roadmap/allowlist/preview',
+            headers: Object.assign(authHeaders(), { 'sec-fetch-site': 'cross-site' }),
+            body: JSON.stringify({ issues: [100] }),
+        });
+        assert.equal(res.statusCode, 403);
+        assert.equal(json(res).code, 'forbidden');
+    } finally { teardownTmp(dir); }
+});
+
+test('lectura de allowlist sólo desde loopback', async () => {
+    const dir = setupTmp();
+    try {
+        seedAllowlist([100]);
+        const res = await invoke({ method: 'GET', url: '/api/roadmap/allowlist', ip: '10.0.0.5' });
+        assert.equal(res.statusCode, 403);
+    } finally { teardownTmp(dir); }
+});

--- a/.pipeline/lib/partial-pause-audit.js
+++ b/.pipeline/lib/partial-pause-audit.js
@@ -70,6 +70,7 @@ const AUTHORIZED_BY_STATIC = Object.freeze([
     'pause:dashboard',       // /dashboard/wave/pause → setFullPause (halt total)
     'resume:dashboard',      // /dashboard/wave/resume → resumeAll
     'dispatch:dashboard',    // /dashboard/wave/dispatch → realign de la ola activa
+    'dashboard:roadmap:allowlist', // #4437: editor de allowlist en la ventana Roadmap
 ]);
 
 // `recursive-deps:from-<N>` donde N es el número del issue padre (>0).
@@ -83,6 +84,7 @@ const RECURSIVE_DEPS_RE = /^recursive-deps:from-(\d+)$/;
 const KNOWN_SOURCES = Object.freeze([
     'dashboard:wizard:allowlist',   // wizard de triaje de allowlist (#3742)
     'dashboard:wizard:pausa',       // wizard de pausar / despausar (#3741)
+    'dashboard:roadmap:allowlist',  // #4437: editor de allowlist en la ventana Roadmap
 ]);
 
 const AUTHORIZED_BY_ENUM = Object.freeze([

--- a/.pipeline/lib/waves-api.js
+++ b/.pipeline/lib/waves-api.js
@@ -37,6 +37,13 @@ let csrf = null;
 try { csrf = require('./kill-agent-csrf'); } catch { /* opcional */ }
 let issueOrder = null;
 try { issueOrder = require('./issue-order'); } catch { /* opcional */ }
+// #4437 — editor de allowlist en la ventana Roadmap. Reutiliza el gate + audit
+// de partial-pause y la resolución recursiva de deps ya probada. Todos opcionales
+// (degradan a 503 si el checkout no los tiene).
+let partialPause = null;
+try { partialPause = require('./partial-pause'); } catch { /* opcional */ }
+let ppDeps = null;
+try { ppDeps = require('./partial-pause-deps'); } catch { /* opcional */ }
 
 // -----------------------------------------------------------------------------
 // Constantes de política (server-side, jamás del request).
@@ -55,9 +62,20 @@ const AUDIT_SOURCE = 'api:waves';
 const _rateHits = new Map();       // ip → number[] (timestamps dentro de la ventana)
 const _idempotency = new Map();    // key → { status, body, expiresAt }
 
+// #4437 — seam de inyección para tests del editor de allowlist. Permite mockear
+// el runner de `gh` (spawnSync) y aislar el cache de deps en un tmp dir sin
+// tocar red ni el filesystem del repo. En producción queda null → default.
+let _depsOptsOverride = null;
+function _setDepsOptsForTests(o) { _depsOptsOverride = o || null; }
+function depsOpts() { return _depsOptsOverride || {}; }
+
+const ALLOWLIST_SOURCE = 'dashboard:roadmap:allowlist';       // #4437 (KNOWN_SOURCES)
+const ALLOWLIST_AUTHORIZED_BY = 'dashboard:roadmap:allowlist'; // #4437 (AUTHORIZED_BY enum)
+
 function _resetForTests() {
     _rateHits.clear();
     _idempotency.clear();
+    _depsOptsOverride = null;
     if (csrf && typeof csrf._resetForTests === 'function') csrf._resetForTests();
 }
 
@@ -302,10 +320,29 @@ function matchRoute(method, pathnameOnly) {
     const segs = pathnameOnly.split('/').filter(Boolean); // ['api', ...]
     if (segs[0] !== 'api') return null;
 
-    // /api/roadmap/status
+    // /api/roadmap/status  |  /api/roadmap/allowlist[/preview|/add|/remove]  (#4437)
     if (segs[1] === 'roadmap') {
         if (segs.length === 3 && segs[2] === 'status') {
             return { surface: true, kind: 'read', action: 'roadmap-status' };
+        }
+        // #4437 — editor de allowlist de la ola desde la ventana Roadmap.
+        if (segs[2] === 'allowlist') {
+            // GET /api/roadmap/allowlist → lectura enriquecida (loopback, sin auth).
+            if (segs.length === 3) {
+                if (method === 'GET') return { surface: true, kind: 'read', action: 'allowlist-read' };
+                return { surface: true, kind: 'unknown', action: 'allowlist-read' };
+            }
+            // POST /api/roadmap/allowlist/{preview|add|remove} → mutación (cinturón completo).
+            // `preview` es dry-run (NO persiste) pero pasa por los mismos 3 gates
+            // (loopback/same-origin/auth) para no filtrar el grafo de deps (A01).
+            if (segs.length === 4) {
+                const op = segs[3];
+                if (op === 'preview' || op === 'add' || op === 'remove') {
+                    if (method === 'POST') return { surface: true, kind: 'mutation', action: `allowlist-${op}`, method: 'POST' };
+                    return { surface: true, kind: 'unknown', action: `allowlist-${op}` };
+                }
+            }
+            return null;
         }
         return null;
     }
@@ -363,9 +400,262 @@ function matchRoute(method, pathnameOnly) {
 }
 
 // -----------------------------------------------------------------------------
+// #4437 — Editor de allowlist de la ola (ventana Roadmap).
+//
+// Toda la lógica pesada se reutiliza de módulos ya mergeados:
+//   - lectura/persistencia de la allowlist: lib/partial-pause (gate + audit).
+//   - arrastre recursivo de deps abiertas: lib/partial-pause-deps (caps depth/
+//     nodes/ciclo ya internos).
+//   - warning padre-sin-hijos / desync waves↔partial: lib/desync-detector.
+//
+// Invariantes (CA-3/CA-6/A04):
+//   - NUNCA se escribe `.partial-pause.json` con fs directo: SIEMPRE vía
+//     partialPause.setPartialPause() con authorizedBy ∈ enum cerrado.
+//   - NUNCA se escribe `waves.json` desde acá (separación intencional #3518/#4439).
+//   - El preview es dry-run puro: no persiste ni dispara efectos colaterales.
+// -----------------------------------------------------------------------------
+const ALLOWLIST_ACTIONS = new Set(['allowlist-preview', 'allowlist-add', 'allowlist-remove']);
+
+// Allowlist vigente exacta (raw) del marker, sin el mapeo a `running` de
+// getPipelineMode(). Coacciona a enteros positivos (defensa en profundidad).
+function currentAllowlist() {
+    if (!partialPause) return [];
+    try {
+        return (partialPause.readPreviousAllowlist() || [])
+            .map(Number)
+            .filter((n) => Number.isInteger(n) && n > 0);
+    } catch { return []; }
+}
+
+// A03 — parseo/validación de los issues del body EN EL BORDE HTTP, antes de
+// tocar `resolveOpenDeps`/`setPartialPause`. Rechaza NaN/negativos/no enteros.
+// Devuelve { ids } o { error: {status, code, message, field} }.
+function parseIssueIds(parsed) {
+    let raw;
+    if (Array.isArray(parsed.issues)) raw = parsed.issues;
+    else if (parsed.issue != null) raw = [parsed.issue];
+    else raw = [];
+    const ids = [];
+    for (const item of raw) {
+        // Rechazo estricto: sólo enteros positivos. `Number('12abc')` → NaN;
+        // floats y strings con basura también caen. No confiar en coerción downstream.
+        const n = Number(item);
+        if (!Number.isInteger(n) || n <= 0 || String(item).trim() !== String(n)) {
+            return { error: { status: 400, code: 'bad-id', message: 'Cada issue debe ser un entero positivo.', field: 'issues' } };
+        }
+        ids.push(n);
+    }
+    if (ids.length === 0) {
+        return { error: { status: 400, code: 'invalid_input', message: 'Se requiere al menos un issue en "issues".', field: 'issues' } };
+    }
+    return { ids: [...new Set(ids)] };
+}
+
+// Resolución recursiva del arrastre para un set candidato. Reutiliza
+// resolveOpenDeps (que ya recurre con caps depth/nodes/ciclo). A diferencia de
+// findMissingDeps, conserva `reason` para exponer "truncado" honesto (CA-2/A05).
+// Devuelve { missing:{[issue]:deps[]}, truncado, reason }.
+function computeDrag(candidate) {
+    const allowed = new Set(candidate.map(Number));
+    const missing = {};
+    let truncado = false;
+    let reason = null;
+    for (const issue of allowed) {
+        const r = ppDeps.resolveOpenDeps(issue, depsOpts());
+        if (r.truncated) { truncado = true; if (!reason) reason = r.reason; }
+        const miss = (r.openDeps || []).filter((d) => !allowed.has(Number(d)));
+        if (miss.length) missing[String(issue)] = miss;
+    }
+    return { missing, truncado, reason };
+}
+
+// Enriquecimiento por issue SOLO desde el cache de deps (NO dispara `gh` en
+// runtime → no bloquea el event loop del dashboard; "pipeline no puede morir").
+// Whitelist estricta de campos (A05/CA-1): number, title, status, parent. Nunca
+// paths ni timestamps. `parent` se deriva de las refs de procedencia (Split de /
+// Tracked by), que son exactamente `deps \ forwardDeps`.
+function enrichFromCache(n, cache) {
+    const base = { number: n, title: null, status: null, parent: null };
+    const e = cache && cache.issues ? cache.issues[String(n)] : null;
+    if (e && typeof e === 'object') {
+        base.title = (typeof e.title === 'string' && e.title) ? e.title : null;
+        base.status = (typeof e.state === 'string' && e.state) ? e.state : null;
+        const fwd = new Set((e.forwardDeps || []).map(Number));
+        const prov = (e.deps || []).map(Number).filter((d) => !fwd.has(d));
+        base.parent = prov.length ? prov[0] : null;
+    }
+    return base;
+}
+
+function handleAllowlistRead(res) {
+    if (!partialPause) {
+        return sendError(res, 503, 'module_unavailable', 'La edición de allowlist no está disponible.');
+    }
+    try {
+        const list = currentAllowlist();
+        const cache = ppDeps ? ppDeps.readCache(depsOpts().cacheFile) : { issues: {} };
+        const allowlist = list.map((n) => enrichFromCache(n, cache));
+        return send(res, 200, { allowlist, count: allowlist.length });
+    } catch (e) {
+        try { console.error(JSON.stringify({ event: 'allowlist_read_error', msg: e && e.message, ts: new Date().toISOString() })); } catch { /* noop */ }
+        return sendError(res, 500, 'internal_error', 'Error interno leyendo la allowlist.');
+    }
+}
+
+// Dispatch de las mutaciones de allowlist (ya pasado el cinturón de gates).
+// Devuelve el shape { status, body } | { errorStatus, code, message, field }
+// que consume finishMutation.
+function dispatchAllowlistMutation(route, parsed) {
+    if (!partialPause || !ppDeps) {
+        return { errorStatus: 503, code: 'module_unavailable', message: 'La edición de allowlist no está disponible.' };
+    }
+    const parsedIds = parseIssueIds(parsed);
+    if (parsedIds.error) {
+        const e = parsedIds.error;
+        return { errorStatus: e.status, code: e.code, message: e.message, field: e.field };
+    }
+    const ids = parsedIds.ids;
+
+    if (route.action === 'allowlist-preview') return allowlistPreview(ids);
+    if (route.action === 'allowlist-add') return allowlistAdd(ids);
+    if (route.action === 'allowlist-remove') return allowlistRemove(ids, parsed);
+    return { errorStatus: 404, code: 'not_found', message: 'Operación de allowlist desconocida.' };
+}
+
+// PREVIEW — dry-run. NO persiste, NO efectos colaterales. Muestra qué issues se
+// arrastran recursivamente al sumar `ids` y qué inconsistencias quedarían (A05).
+function allowlistPreview(ids) {
+    const current = currentAllowlist();
+    const candidate = [...new Set([...current, ...ids])].sort((a, b) => a - b);
+    const { missing, truncado, reason } = computeDrag(candidate);
+    const conDeps = ppDeps.allowlistWithDeps(candidate, missing);
+    const aArrastrar = conDeps.filter((n) => !candidate.includes(n));
+    return { status: 200, body: {
+        ok: true,
+        persisted: false,
+        candidate,
+        aArrastrar,
+        inconsistencias: missing,
+        truncado,
+        reason: reason || null,
+    } };
+}
+
+// ADD — expande recursivamente ANTES de persistir y escribe SÓLO vía el gate.
+function allowlistAdd(ids) {
+    const current = currentAllowlist();
+    const candidate = [...new Set([...current, ...ids])].sort((a, b) => a - b);
+    const { missing, truncado, reason } = computeDrag(candidate);
+    const union = ppDeps.allowlistWithDeps(candidate, missing);
+    const aArrastrar = union.filter((n) => !candidate.includes(n));
+
+    const r = partialPause.setPartialPause(union, {
+        source: ALLOWLIST_SOURCE,
+        authorizedBy: ALLOWLIST_AUTHORIZED_BY,
+        justification: `Editor Roadmap: agregar ${ids.map((n) => `#${n}`).join(', ')} (arrastre recursivo)`,
+    });
+    if (r.rejected) {
+        return { errorStatus: 409, code: 'gate_rejected', message: r.msg || 'La mutación fue rechazada por el gate de allowlist.' };
+    }
+    return { status: 200, body: {
+        ok: true,
+        persisted: true,
+        allowlist: r.allowedIssues || union,
+        added: ids,
+        aArrastrar,
+        truncado,
+        reason: reason || null,
+    } };
+}
+
+// REMOVE — avisa (bloqueante) inconsistencias/desync ANTES de persistir. Sólo
+// persiste con `confirm: true` explícito del operador (CA-4/CA-5).
+function allowlistRemove(ids, parsed) {
+    const current = currentAllowlist();
+    const toRemove = new Set(ids);
+    const remaining = current.filter((n) => !toRemove.has(n));
+
+    // Inconsistencia interna de la allowlist tras la remoción (padre que queda
+    // sin su hijo / dependencia faltante) — findMissingDeps sobre el remanente.
+    const { missing, truncado, reason } = computeDrag(remaining);
+
+    // Desync waves↔partial que introduciría la remoción (issue que sigue en la
+    // ola activa pero saldría de la allowlist). Se PROYECTA sobre `remaining`
+    // comparando contra la ola activa (waves.json, lectura pura). NO se usa
+    // desync-detector.detectDesync() acá: ese lee el estado en disco (pre-
+    // remoción, no el proyectado) y además crea el flag de bloqueo + alerta
+    // Telegram — efectos colaterales inadmisibles en un chequeo previo (CA-6).
+    const desync = projectedDesync(remaining);
+
+    const hasInconsistencias = Object.keys(missing).length > 0;
+    const hasDesync = !!desync;
+    const bloqueado = hasInconsistencias || hasDesync;
+
+    if (bloqueado && parsed.confirm !== true) {
+        // 200 con ok:false: la operación NO falló, se frenó a la espera de
+        // confirmación explícita. El cliente muestra el warning y re-postea con confirm.
+        return { status: 200, body: {
+            ok: false,
+            blocked: true,
+            persisted: false,
+            requested: ids,
+            inconsistencias: missing,
+            desync,
+            truncado,
+            reason: reason || null,
+            message: 'La remoción deja dependencias huérfanas o desincroniza la ola. Confirmá para persistir.',
+        } };
+    }
+
+    const r = partialPause.setPartialPause(remaining, {
+        source: ALLOWLIST_SOURCE,
+        authorizedBy: ALLOWLIST_AUTHORIZED_BY,
+        justification: `Editor Roadmap: quitar ${ids.map((n) => `#${n}`).join(', ')}${bloqueado ? ' (confirmado con inconsistencias)' : ''}`,
+    });
+    if (r.rejected) {
+        return { errorStatus: 409, code: 'gate_rejected', message: r.msg || 'La mutación fue rechazada por el gate de allowlist.' };
+    }
+    return { status: 200, body: {
+        ok: true,
+        persisted: true,
+        allowlist: r.allowedIssues || remaining,
+        removed: ids,
+        inconsistencias: missing,
+        desync,
+        truncado,
+        reason: reason || null,
+    } };
+}
+
+// Proyección PURA del desync waves↔partial que dejaría un `remaining` dado, SIN
+// efectos colaterales. Compara el remanente proyectado contra la allowlist de la
+// ola activa (waves.json, lectura pura vía activeAllowlist()). Devuelve null si
+// no hay desync, o un resumen display-ready (whitelist de campos, A05).
+//   - missingFromAllowlist: issues que la ola activa todavía tiene pero que la
+//     remoción dejaría FUERA de la allowlist (padre/hijo huérfano de la ola).
+//   - extraInAllowlist: issues en la allowlist que la ola activa no contiene.
+function projectedDesync(remaining) {
+    if (!waves) return null;
+    let waveAllow;
+    try { waveAllow = activeAllowlist(); } catch { return null; }
+    if (!Array.isArray(waveAllow) || waveAllow.length === 0) return null;
+    const rem = new Set(remaining.map(Number));
+    const wave = new Set(waveAllow.map(Number));
+    const missingFromAllowlist = waveAllow.map(Number).filter((n) => !rem.has(n));
+    const extraInAllowlist = remaining.map(Number).filter((n) => !wave.has(n));
+    if (missingFromAllowlist.length === 0 && extraInAllowlist.length === 0) return null;
+    return { missingFromAllowlist, extraInAllowlist };
+}
+
+// -----------------------------------------------------------------------------
 // Handlers de lectura.
 // -----------------------------------------------------------------------------
 function handleRead(res, route) {
+    // #4437 — la lectura de allowlist no depende de `waves` (opera sobre
+    // .partial-pause.json) → su propio guard de módulo.
+    if (route.action === 'allowlist-read') {
+        return handleAllowlistRead(res);
+    }
     if (!waves) {
         return sendError(res, 503, 'module_unavailable', 'La gestión de olas no está disponible.');
     }
@@ -402,6 +692,11 @@ function handleRead(res, route) {
 // Dispatch de mutación al dominio (ya validado el cinturón de gates + body).
 // -----------------------------------------------------------------------------
 function dispatchMutation(res, route, parsed, ifMatch) {
+    // #4437 — las mutaciones de allowlist operan sobre .partial-pause.json (no
+    // sobre waves.json) y no usan el modelo de versión If-Match de olas.
+    if (ALLOWLIST_ACTIONS.has(route.action)) {
+        return dispatchAllowlistMutation(route, parsed);
+    }
     const meta = { updated_by: FIXED_ACTOR, source: AUDIT_SOURCE, expectedVersion: ifMatch };
     try {
         if (route.action === 'create') {
@@ -531,7 +826,10 @@ function handleMutation(req, res, route) {
     // idempotencia se cubre con el nombre único + Idempotency-Key. Ausente en una
     // mutación que lo requiere → 428 Precondition Required.
     let ifMatchClean; // undefined → el dominio saltea la verificación de versión.
-    if (route.action !== 'create') {
+    // #4437 — las mutaciones de allowlist NO exigen If-Match: no hay recurso de
+    // olas versionado (operan sobre .partial-pause.json). Igual que create, se
+    // saltean el gate de precondición pero conservan el resto del cinturón.
+    if (route.action !== 'create' && !ALLOWLIST_ACTIONS.has(route.action)) {
         const ifMatch = header(req, 'if-match');
         if (!ifMatch) {
             return sendError(res, 428, 'precondition_required', 'Falta el header If-Match con la versión actual del estado.');
@@ -644,5 +942,14 @@ module.exports = {
         WAVES_RATE_WINDOW_MS,
         FIXED_ACTOR,
         _resetForTests,
+        // #4437 — editor de allowlist (ventana Roadmap).
+        parseIssueIds,
+        computeDrag,
+        currentAllowlist,
+        projectedDesync,
+        enrichFromCache,
+        ALLOWLIST_SOURCE,
+        ALLOWLIST_AUTHORIZED_BY,
+        _setDepsOptsForTests,
     },
 };

--- a/.pipeline/views/dashboard/wave-roadmap.js
+++ b/.pipeline/views/dashboard/wave-roadmap.js
@@ -529,8 +529,65 @@ function roadmapStyle() {
 .wr-chip-remove{display:inline-flex;align-items:center;justify-content:center;width:22px;height:22px;min-width:22px;padding:0;cursor:pointer;background:transparent;border:none;border-radius:999px;color:var(--text-dim,#8B949E)}
 .wr-chip-remove:hover{color:var(--danger,#F85149);background:var(--danger-bg,#160B0B)}
 .wr-chip-remove-ic{width:15px;height:15px}
+/* #4437 — Editor de allowlist ("lista de bailes"). */
+.al-list{display:flex;flex-direction:column;gap:6px}
+.al-row{display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+.al-parent{font-size:10.5px;font-weight:700;color:var(--text-dim,#8B949E);font-variant-numeric:tabular-nums}
+.al-add{display:flex;align-items:center;gap:8px;flex-wrap:wrap;padding-top:10px;margin-top:2px;border-top:1px solid var(--border-subtle,rgba(255,255,255,.08))}
+.al-input{font:inherit;font-size:13px;color:var(--text-primary,#e6edf3);background:var(--surface-0,#0d1117);border:1px solid var(--border,rgba(255,255,255,.12));border-radius:8px;padding:7px 10px;max-width:180px}
+.al-input:focus{outline:none;border-color:var(--purple,#BC8CFF)}
+.al-preview{display:flex;flex-direction:column;gap:5px;padding:10px 13px;border-radius:10px;border:1px solid var(--purple-dim,#8957E5);background:var(--purple-bg,rgba(188,140,255,.12))}
+.al-preview-head{display:flex;align-items:center;gap:7px;font-size:11px;font-weight:800;letter-spacing:.3px;text-transform:uppercase;color:var(--purple,#BC8CFF)}
+.al-preview-body{font-size:12.5px;color:var(--text-secondary,#8A93A6);font-variant-numeric:tabular-nums}
+.al-trunc{font-size:11.5px;font-weight:700;color:var(--warning,#D29922)}
+.al-warn{display:flex;flex-direction:column;gap:5px;padding:10px 13px;border-radius:10px;border:1px solid var(--danger,#F85149);background:var(--danger-bg,#160B0B)}
+.al-warn-head{display:flex;align-items:center;gap:7px;font-size:11px;font-weight:800;letter-spacing:.3px;text-transform:uppercase;color:#F5B0AC}
+.al-warn-row{font-size:12.5px;color:var(--text-secondary,#8A93A6);font-variant-numeric:tabular-nums}
 @media (prefers-reduced-motion:reduce){.wr-archived-toggle .wr-expand-ic{transition:none}}
 </style>`;
+}
+
+// #4437 — Panel editor de la allowlist ("lista de bailes") de la ola. La data se
+// carga client-side vía GET /api/roadmap/allowlist (no bloquea el SSR con `gh`).
+// El panel entrega: lista editable (CA-1), preview de arrastre recursivo (CA-2/
+// CA-3), y avisos de inconsistencia bloqueantes antes de guardar (CA-4/CA-5).
+// Todo el CSS usa tokens de design-tokens.css; íconos del sprite (sin nuevos).
+function renderAllowlistPanel() {
+    return '<section class="wr-section al-section" aria-label="Allowlist de la ola">'
+        + '<div class="wr-section-head">'
+        + '<svg class="wr-section-ic" aria-hidden="true"><use href="#ic-shield-lock"></use></svg>'
+        + '<span class="wr-section-title">Allowlist de la ola</span>'
+        + '<span class="wr-section-count" id="al-count">…</span>'
+        + '<span class="wr-head-spacer"></span>'
+        + '<button type="button" class="wr-btn" onclick="allowlistReload()" title="Refrescar la allowlist">'
+        + '<svg class="wr-btn-ic" aria-hidden="true"><use href="#ic-expand"></use></svg> Refrescar</button>'
+        + '</div>'
+        // Lista editable (poblada por el cliente).
+        + '<div class="al-list" id="al-list" role="list" aria-live="polite">'
+        + '<div class="wr-empty-issues">Cargando allowlist…</div>'
+        + '</div>'
+        // Fila para agregar issue(s) + preview dry-run.
+        + '<div class="al-add">'
+        + '<label class="wr-compose-label" for="al-add-input">Agregar issue(s)</label>'
+        + '<input type="text" class="al-input" id="al-add-input" inputmode="numeric" placeholder="#1234 #1235" aria-label="Números de issue a agregar a la allowlist">'
+        + '<button type="button" class="wr-btn" onclick="allowlistPreview()" title="Ver qué se arrastra recursivamente antes de guardar">'
+        + '<svg class="wr-btn-ic" aria-hidden="true"><use href="#ic-expand"></use></svg> Vista previa</button>'
+        + '<button type="button" class="wr-btn wr-btn-primary" id="al-add-btn" onclick="allowlistAdd()" title="Agregar los issues (arrastra hijos/dependencias)">'
+        + '<svg class="wr-btn-ic" aria-hidden="true"><use href="#ic-wave-add"></use></svg> <span id="al-add-label">Agregar</span></button>'
+        + '<span class="wr-compose-status" id="al-add-status" role="status" aria-live="polite"></span>'
+        + '</div>'
+        // Banner de preview (dry-run): arrastre recursivo + truncado honesto.
+        + '<div class="al-preview" id="al-preview" hidden role="note"></div>'
+        // Panel de inconsistencias (bloqueante) para remociones.
+        + '<div class="al-warn" id="al-warn" hidden role="alert"></div>'
+        // Footer: separación de artefactos + traza de audit (CA-6/CA-7).
+        + '<div class="wr-integrity" role="note">'
+        + '<svg class="wr-integrity-ic" aria-hidden="true"><use href="#ic-shield-lock"></use></svg>'
+        + '<span>Editar la allowlist toca sólo <code>.partial-pause.json</code> (nunca <code>waves.json</code>). '
+        + 'Cada cambio pasa por el gate con audit trail (<code>authorizedBy=dashboard:roadmap:allowlist</code>). '
+        + 'Todo arrastre e inconsistencia se muestran <strong>antes</strong> de guardar.</span>'
+        + '</div>'
+        + '</section>';
 }
 
 /**
@@ -596,6 +653,8 @@ function renderRoadmapSsr(opts) {
         + '<span class="wr-section-title">Ola activa</span></div>'
         + activeHtml
         + '</section>'
+        // #4437 — Sección ALLOWLIST (editor "lista de bailes" de la ola).
+        + renderAllowlistPanel()
         // Sección PLANIFICADAS.
         + '<section class="wr-section" aria-label="Olas planificadas">'
         + '<div class="wr-section-head"><svg class="wr-section-ic" aria-hidden="true"><use href="#ic-wave"></use></svg>'
@@ -974,6 +1033,150 @@ async function roadmapTickState(){
   if(pauseBtn) pauseBtn.hidden = showResume;
   if(resumeBtn) resumeBtn.hidden = !showResume;
 }
+// #4437 — Editor de allowlist ("lista de bailes"). Lee/edita vía los endpoints
+// /api/roadmap/allowlist*, todos bajo el mismo cinturón de gates que las olas.
+// Regla rectora UX: el operador nunca descubre un efecto después de guardar —
+// todo arrastre e inconsistencia se muestra ANTES de persistir.
+function alEsc(s){ var d=document.createElement('div'); d.textContent=(s==null?'':String(s)); return d.innerHTML; }
+function alSetStatus(msg, kind){
+  var el=document.getElementById('al-add-status');
+  if(!el) return;
+  el.textContent=msg||'';
+  el.className='wr-compose-status'+(kind?' wr-st-'+kind:'');
+}
+function alParseIssues(raw){
+  var out=[]; var seen={};
+  (String(raw||'').match(/\\d+/g)||[]).forEach(function(t){
+    var n=parseInt(t,10);
+    if(Number.isInteger(n)&&n>0&&!seen[n]){ seen[n]=1; out.push(n); }
+  });
+  return out;
+}
+function alRenderList(rows){
+  var host=document.getElementById('al-list');
+  var cnt=document.getElementById('al-count');
+  if(cnt) cnt.textContent=String(rows.length);
+  if(!host) return;
+  if(!rows.length){ host.innerHTML='<div class="wr-empty-issues">La allowlist está vacía (la ola corre sin restricción de issues).</div>'; return; }
+  host.innerHTML=rows.map(function(r){
+    var num=parseInt(r.number,10);
+    var title=r.title?(' · '+alEsc(r.title)):'';
+    var st=r.status?('<span class="wr-chip-status">'+alEsc(r.status)+'</span>'):'';
+    var parent=(r.parent!=null)?('<span class="al-parent" title="Issue padre">↳ #'+parseInt(r.parent,10)+'</span>'):'';
+    return '<div class="al-row" role="listitem">'
+      +'<a class="wr-chip" href="https://github.com/intrale/platform/issues/'+num+'" target="_blank" rel="noopener noreferrer">'
+      +'<span class="wr-chip-num">#'+num+title+'</span>'+st+'</a>'+parent
+      +'<button type="button" class="wr-chip-remove" onclick="allowlistRemove('+num+')" title="Quitar #'+num+' de la allowlist" aria-label="Quitar el issue '+num+' de la allowlist">'
+      +'<svg class="wr-chip-remove-ic" aria-hidden="true"><use href="#ic-remove-circle"></use></svg></button>'
+      +'</div>';
+  }).join('');
+}
+function alTruncadoMsg(reason){
+  var m={max_depth:'profundidad máxima',max_nodes:'demasiados nodos',cycle:'ciclo de dependencias'};
+  return 'Grafo truncado ('+(m[reason]||reason||'límite')+'): puede faltar arrastre.';
+}
+async function allowlistReload(){
+  var host=document.getElementById('al-list');
+  try {
+    var r=await fetch('/api/roadmap/allowlist', { headers: nhCsrfHeaders() });
+    var j=await r.json().catch(function(){ return {}; });
+    if(r.ok && Array.isArray(j.allowlist)){ alRenderList(j.allowlist); return; }
+    if(host) host.innerHTML='<div class="wr-empty-issues">No se pudo leer la allowlist (HTTP '+r.status+').</div>';
+  } catch(e){
+    if(host) host.innerHTML='<div class="wr-empty-issues">Error de red leyendo la allowlist: '+alEsc(e.message)+'</div>';
+  }
+}
+async function allowlistPreview(){
+  var input=document.getElementById('al-add-input');
+  var ids=alParseIssues(input?input.value:'');
+  var banner=document.getElementById('al-preview');
+  var addLabel=document.getElementById('al-add-label');
+  if(!ids.length){ alSetStatus('Indicá al menos un issue numérico.', 'err'); return; }
+  alSetStatus('Calculando arrastre…', null);
+  try {
+    var r=await roadmapWavePost('/api/roadmap/allowlist/preview', { issues: ids });
+    var j=await r.json().catch(function(){ return {}; });
+    if(!r.ok || !j.ok){ alSetStatus('No se pudo previsualizar: '+((j&&j.message)?j.message:('HTTP '+r.status)), 'err'); return; }
+    alSetStatus('', null);
+    var drag=Array.isArray(j.aArrastrar)?j.aArrastrar:[];
+    var parts=[];
+    parts.push('<div class="al-preview-head"><svg class="wr-btn-ic" aria-hidden="true"><use href="#ic-wave-add"></use></svg> Vista previa (dry-run) — <code>.partial-pause.json</code> intacto</div>');
+    if(drag.length){
+      parts.push('<div class="al-preview-body">Arrastra recursivamente '+drag.length+' issue(s): '+drag.map(function(n){ return '#'+parseInt(n,10); }).join(', ')+'</div>');
+    } else {
+      parts.push('<div class="al-preview-body">No se arrastra ningún issue adicional.</div>');
+    }
+    if(j.truncado){ parts.push('<div class="al-trunc">⚠ '+alEsc(alTruncadoMsg(j.reason))+'</div>'); }
+    if(banner){ banner.innerHTML=parts.join(''); banner.hidden=false; }
+    if(addLabel) addLabel.textContent='Agregar (arrastra '+drag.length+')';
+  } catch(e){ alSetStatus('Error de red: '+e.message, 'err'); }
+}
+async function allowlistAdd(){
+  var input=document.getElementById('al-add-input');
+  var ids=alParseIssues(input?input.value:'');
+  if(!ids.length){ alSetStatus('Indicá al menos un issue numérico.', 'err'); return; }
+  alSetStatus('Agregando…', null);
+  try {
+    var r=await roadmapWavePost('/api/roadmap/allowlist/add', { issues: ids });
+    var j=await r.json().catch(function(){ return {}; });
+    if(r.ok && j.ok){
+      alSetStatus('Agregado ✓'+(Array.isArray(j.aArrastrar)&&j.aArrastrar.length?(' (+'+j.aArrastrar.length+' arrastrados)'):''), 'ok');
+      if(input) input.value='';
+      var banner=document.getElementById('al-preview'); if(banner){ banner.hidden=true; }
+      var addLabel=document.getElementById('al-add-label'); if(addLabel) addLabel.textContent='Agregar';
+      alRenderList((j.allowlist||[]).map(function(n){ return { number:n }; }));
+      allowlistReload();
+      return;
+    }
+    alSetStatus('No se pudo agregar: '+((j&&j.message)?j.message:('HTTP '+r.status)), 'err');
+  } catch(e){ alSetStatus('Error de red: '+e.message, 'err'); }
+}
+function alRenderWarn(j, ids){
+  var warn=document.getElementById('al-warn');
+  if(!warn) return;
+  var parts=['<div class="al-warn-head"><svg class="wr-blocked-ic" aria-hidden="true"><use href="#ic-pause-lock"></use></svg> Quitar '+ids.map(function(n){ return '#'+n; }).join(', ')+' deja inconsistencias</div>'];
+  var inc=j.inconsistencias||{};
+  Object.keys(inc).forEach(function(k){
+    parts.push('<div class="al-warn-row">#'+parseInt(k,10)+' quedaría sin su dependencia: '+inc[k].map(function(n){ return '#'+parseInt(n,10); }).join(', ')+'</div>');
+  });
+  if(j.desync && Array.isArray(j.desync.missingFromAllowlist) && j.desync.missingFromAllowlist.length){
+    parts.push('<div class="al-warn-row">La ola activa todavía incluye: '+j.desync.missingFromAllowlist.map(function(n){ return '#'+parseInt(n,10); }).join(', ')+' (quedaría fuera de la lista de bailes).</div>');
+  }
+  if(j.truncado){ parts.push('<div class="al-trunc">⚠ '+alEsc(alTruncadoMsg(j.reason))+'</div>'); }
+  warn.innerHTML=parts.join('');
+  warn.hidden=false;
+}
+async function allowlistRemove(issueNum){
+  issueNum=parseInt(issueNum,10);
+  if(!Number.isInteger(issueNum) || issueNum<1) return;
+  var warn=document.getElementById('al-warn');
+  if(warn){ warn.hidden=true; }
+  try {
+    // 1er intento sin confirmar: el server avisa inconsistencias antes de persistir.
+    var r=await roadmapWavePost('/api/roadmap/allowlist/remove', { issues: [issueNum] });
+    var j=await r.json().catch(function(){ return {}; });
+    if(r.ok && j.blocked){
+      alRenderWarn(j, [issueNum]);
+      var ok=await inConfirm({
+        title: 'Quitar con inconsistencias',
+        message: 'Quitar #'+issueNum+' deja dependencias huérfanas o desincroniza la ola. El aviso está sobre la lista. ¿Confirmás igual?',
+        confirmLabel: 'Quitar igual',
+        danger: true,
+        preview: [{ label: 'Issue', value: '#'+issueNum }]
+      });
+      if(!ok) return;
+      r=await roadmapWavePost('/api/roadmap/allowlist/remove', { issues: [issueNum], confirm: true });
+      j=await r.json().catch(function(){ return {}; });
+    }
+    if(r.ok && j.ok){
+      if(warn){ warn.hidden=true; }
+      alRenderList((j.allowlist||[]).map(function(n){ return { number:n }; }));
+      allowlistReload();
+      return;
+    }
+    if(!j.blocked) alSetStatus('No se pudo quitar #'+issueNum+': '+((j&&j.message)?j.message:('HTTP '+r.status)), 'err');
+  } catch(e){ alSetStatus('Error de red: '+e.message, 'err'); }
+}
 window.roadmapToggleArchived = roadmapToggleArchived;
 window.roadmapArchive = roadmapArchive;
 window.roadmapNewWaveToggle = roadmapNewWaveToggle;
@@ -984,8 +1187,13 @@ window.roadmapPromote = roadmapPromote;
 window.roadmapPause = roadmapPause;
 window.roadmapResume = roadmapResume;
 window.roadmapDispatch = roadmapDispatch;
+window.allowlistReload = allowlistReload;
+window.allowlistPreview = allowlistPreview;
+window.allowlistAdd = allowlistAdd;
+window.allowlistRemove = allowlistRemove;
 roadmapTickState();
 setInterval(function(){ roadmapTickState().catch(function(){}); }, 5000);
+allowlistReload();
 `;
 }
 

--- a/docs/pipeline/waves-api.md
+++ b/docs/pipeline/waves-api.md
@@ -156,6 +156,73 @@ Estado agregado del roadmap:
 { "version": "...", "horizon": [ /* waves */ ], "allowlist": [4372, 4381] }
 ```
 
+#### `GET /api/roadmap/allowlist` (#4437)
+Allowlist ("lista de bailes") vigente de la ola, enriquecida por issue. Rol
+lectura (loopback). Metadata desde el cache de deps (no dispara `gh` en runtime).
+Whitelist estricta de campos (A05): **sólo** `number`, `title`, `status`, `parent`
+— nunca paths ni timestamps internos.
+
+```json
+// 200 OK
+{ "count": 2, "allowlist": [
+  { "number": 4433, "title": "…", "status": "open", "parent": 4300 },
+  { "number": 4437, "title": null, "status": "unknown", "parent": null }
+] }
+```
+
+### Editor de allowlist (rol operador — #4437)
+
+Operan **sólo** sobre `.partial-pause.json` (nunca `waves.json`). Persisten
+**exclusivamente** vía `partial-pause.setPartialPause()` con
+`authorizedBy: "dashboard:roadmap:allowlist"` + `justification` (gate + audit
+trail, regla `feedback_allowlist-no-tocar`). Pasan por los tres gates
+(loopback → same-origin → credencial de operador). **No** usan `If-Match`
+(no hay recurso de olas versionado). `add`/`remove` respetan `Idempotency-Key`.
+
+#### `POST /api/roadmap/allowlist/preview`
+Dry-run: calcula el arrastre recursivo sin persistir (`.partial-pause.json`
+intacto). Mismo cinturón de gates que las mutaciones (para no filtrar el grafo
+de deps a orígenes externos, A01).
+
+```json
+// Request  ·  { "issues": [100] }
+// 200 OK
+{ "ok": true, "persisted": false, "candidate": [100],
+  "aArrastrar": [101, 102, 103], "inconsistencias": { "102": [103] },
+  "truncado": false, "reason": null }
+```
+
+#### `POST /api/roadmap/allowlist/add`
+Agrega issue(s) expandiendo recursivamente sus hijos/dependencias/bloqueos
+abiertos antes de persistir.
+
+```json
+// Request  ·  { "issues": [100] }
+// 200 OK
+{ "ok": true, "persisted": true, "allowlist": [100, 101, 102, 103],
+  "added": [100], "aArrastrar": [101, 102, 103], "truncado": false, "reason": null }
+```
+
+#### `POST /api/roadmap/allowlist/remove`
+Quita issue(s). Si la remoción deja dependencias huérfanas (padre sin su hijo)
+o desincroniza la ola activa, responde `blocked: true` **sin persistir**; el
+cliente muestra el aviso y re-postea con `confirm: true` para forzar.
+
+```json
+// Request  ·  { "issues": [103] }
+// 200 OK (bloqueado — no persistió)
+{ "ok": false, "blocked": true, "persisted": false, "requested": [103],
+  "inconsistencias": { "102": [103] }, "desync": null,
+  "truncado": false, "reason": null, "message": "…" }
+// Request  ·  { "issues": [103], "confirm": true }
+// 200 OK (persistido)
+{ "ok": true, "persisted": true, "allowlist": [100, 101, 102], "removed": [103] }
+```
+
+Validación A03 (borde HTTP): cada issue se coerce a `Number()` y se exige entero
+positivo; NaN/negativos/no-numéricos → `400 { code: "bad-id" }` **sin** invocar
+`resolveOpenDeps`.
+
 ### Mutaciones (rol operador)
 
 #### `POST /api/waves`


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 5 archivos · +921 -2

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:passed` aplicado por delivery

## Closes

Closes #4437
