### PR TITLE
Dashboard: rediseñar el encabezado común (pills de CPU/RAM y uptime del Pulpo + hora) con el estilo del dashboard y compartirlo entre todas las ventanas

### DIFF
--- a/.pipeline/assets/docs/4463/pipeline-dev-4463.md
+++ b/.pipeline/assets/docs/4463/pipeline-dev-4463.md
@@ -1,0 +1,30 @@
+# #4463 — Encabezado común compartido del dashboard (pills CPU/RAM + uptime Pulpo)
+
+## Qué se hizo
+Se extrajo un módulo compartido **`header-meta.js`** (espejo de `nav-tabs.js`) que emite
+las pastillas del encabezado (CPU/RAM, uptime del Pulpo + hora) y centraliza su hidratación.
+Consumido por las 4 ventanas del issue: **Inicio, Pipeline, Roadmap, Providers**.
+
+## Causa raíz corregida
+Cada ventana armaba su propio `<div class="in-header-meta">`. Los satélites, Providers y
+Roadmap **no mostraban** las pills de CPU/RAM ni uptime del Pulpo → header inconsistente.
+
+## API del módulo
+- `renderHeaderMetaSsr({ withMode })` → markup SSR con IDs invariantes
+  (`hdr-resources`, `hdr-pulpo`, `hdr-clock`) + `hdr-mode` opcional.
+- `headerPillsClientScript()` → hidratación compartida (umbrales `in-pill-ok/warn/bad`),
+  uptime autocontenido (portable a vistas sin `fmtDur`). Sólo `textContent`/`classList`/`title`.
+- `headerPillsPollClientScript()` → poller standalone para vistas sin ticker propio (Providers).
+
+## Diseño / seguridad
+- Reusa tokens y clases de `theme.css` (`.in-pill*`, `--in-ok/warn/bad`) — sin colores ad-hoc.
+- SEC-1/FE-SEC-4: sin `innerHTML` sobre datos de `/api/dash/header`. Endpoint sin cambios.
+- IDs literales preservados → snapshot R-G1 de `home.test.js` verde.
+
+## Verificación
+- 29 tests nuevos: `header-meta.test.js` + `header-meta-consistency.test.js`.
+- Suite completa del dashboard: **450/450 verde**.
+- `dashboard-routes.js` carga sin errores (todas las vistas requeridas).
+
+## QA
+`qa:skipped` — feature interna de dashboard (`area:infra`, sin `app:*`).

--- a/.pipeline/views/dashboard/__tests__/header-meta-consistency.test.js
+++ b/.pipeline/views/dashboard/__tests__/header-meta-consistency.test.js
@@ -1,0 +1,56 @@
+// =============================================================================
+// Tests de consistencia del encabezado entre ventanas (#4463 · CA-4).
+//
+// Antes del fix, las pills de CPU/RAM (#hdr-resources) y uptime del Pulpo
+// (#hdr-pulpo) SÓLO existían en la HOME. Los satélites, Providers y Roadmap
+// armaban su propio <div class="in-header-meta"> sin esas pills → header
+// inconsistente. Este test verifica que las cuatro ventanas del issue (Inicio,
+// Pipeline, Roadmap, Providers) ahora emiten las mismas pills desde el
+// componente compartido header-meta.js y cablean su hidratación.
+//
+// node:test, sin Jest.
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const sat = require(path.resolve(__dirname, '..', 'satellites.js'));
+const home = require(path.resolve(__dirname, '..', 'home.js'));
+const providers = require(path.resolve(__dirname, '..', 'providers.js'));
+const roadmap = require(path.resolve(__dirname, '..', 'wave-roadmap.js'));
+
+// Cada entrada: [nombre de ventana, HTML SSR renderizado].
+const WINDOWS = [
+    ['Inicio (home)', home.renderHomeHTML({})],
+    ['Pipeline (satélite)', sat.renderPipeline()],
+    ['Roadmap', roadmap.renderRoadmap()],
+    ['Providers', providers.renderProviders()],
+];
+
+for (const [name, html] of WINDOWS) {
+    test(`CA-4: ${name} emite la pill de CPU/RAM (#hdr-resources)`, () => {
+        assert.match(html, /id="hdr-resources"/, `${name} no muestra la pill de CPU/RAM`);
+    });
+    test(`CA-4: ${name} emite la pill de uptime del Pulpo (#hdr-pulpo)`, () => {
+        assert.match(html, /id="hdr-pulpo"/, `${name} no muestra la pill de uptime del Pulpo`);
+    });
+    test(`CA-4: ${name} emite el reloj (#hdr-clock)`, () => {
+        assert.match(html, /id="hdr-clock"/, `${name} no muestra el reloj`);
+    });
+    test(`CA-4/CA-5: ${name} cablea la hidratación compartida de las pills`, () => {
+        assert.match(html, /window\.__hydrateHeaderPills/,
+            `${name} no inyecta el helper de hidratación → las pills quedarían en "…"`);
+    });
+    test(`CA-7 (SEC-1): ${name} hidrata sin innerHTML sobre datos del header`, () => {
+        // El bloque de hidratación de pills nunca usa innerHTML. (No aserta sobre
+        // todo el documento porque otras vistas legítimamente usan innerHTML en
+        // otros componentes; sí garantiza que el helper compartido no lo hace.)
+        const marker = 'window.__hydrateHeaderPills = function';
+        const idx = html.indexOf(marker);
+        assert.ok(idx >= 0, `${name}: no se encontró el helper de hidratación`);
+        const slice = html.slice(idx, idx + 1200);
+        assert.doesNotMatch(slice, /innerHTML/, `${name}: la hidratación de pills no debe usar innerHTML`);
+    });
+}

--- a/.pipeline/views/dashboard/__tests__/header-meta.test.js
+++ b/.pipeline/views/dashboard/__tests__/header-meta.test.js
@@ -1,0 +1,102 @@
+// =============================================================================
+// Tests del módulo compartido del encabezado (#4463).
+//
+// header-meta.js es el espejo de nav-tabs.js para las PILLS del header. Emite
+// el <div class="in-header-meta"> con los IDs invariantes (hdr-resources,
+// hdr-pulpo, hdr-clock) + hdr-mode opcional, y centraliza la hidratación
+// (window.__hydrateHeaderPills) con la lógica de umbrales in-pill-ok/warn/bad.
+//
+// Contratos verificados:
+//   1. renderHeaderMetaSsr() emite los tres IDs invariantes.
+//   2. withMode:true agrega además #hdr-mode; withMode:false no lo emite.
+//   3. IDs, title y aria-label literales preservados (snapshot R-G1).
+//   4. SEC-1: el SSR no usa innerHTML ni interpola datos dinámicos; la
+//      hidratación usa sólo textContent/classList/title (sin innerHTML).
+//
+// node:test, sin Jest.
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const HM_PATH = path.resolve(__dirname, '..', 'header-meta.js');
+const { renderHeaderMetaSsr, headerPillsClientScript, headerPillsPollClientScript } = require(HM_PATH);
+
+test('renderHeaderMetaSsr() emite los tres IDs invariantes (recursos, pulpo, reloj)', () => {
+    const html = renderHeaderMetaSsr();
+    assert.match(html, /id="hdr-resources"/, 'falta la pill de recursos CPU/RAM');
+    assert.match(html, /id="hdr-pulpo"/, 'falta la pill de uptime del Pulpo');
+    assert.match(html, /id="hdr-clock"/, 'falta el reloj');
+    assert.match(html, /class="in-header-meta"/, 'falta el contenedor in-header-meta');
+});
+
+test('sin withMode NO emite #hdr-mode (comportamiento de home, #4227)', () => {
+    const html = renderHeaderMetaSsr({ withMode: false });
+    assert.doesNotMatch(html, /id="hdr-mode"/, 'home no debe mostrar la pill de estado del pipeline');
+    // El default (sin opts) también es withMode:false.
+    assert.doesNotMatch(renderHeaderMetaSsr(), /id="hdr-mode"/, 'default withMode:false');
+});
+
+test('withMode:true agrega #hdr-mode además de las tres pills (satélites/roadmap)', () => {
+    const html = renderHeaderMetaSsr({ withMode: true });
+    assert.match(html, /id="hdr-mode"/, 'falta la pill de estado del pipeline en satélites');
+    assert.match(html, /id="hdr-resources"/);
+    assert.match(html, /id="hdr-pulpo"/);
+    assert.match(html, /id="hdr-clock"/);
+});
+
+test('preserva title y aria-label literales de las pills (contrato de accesibilidad)', () => {
+    const html = renderHeaderMetaSsr({ withMode: true });
+    assert.match(html, /title="CPU y RAM del sistema"/, 'title de recursos preservado');
+    assert.match(html, /aria-label="Recursos CPU y RAM"/, 'aria-label de recursos preservado');
+    assert.match(html, /aria-label="Estado del pulpo"/, 'aria-label del pulpo preservado');
+    assert.match(html, /aria-label="Hora local"/, 'aria-label del reloj preservado');
+});
+
+test('orden estable de las pills: [mode] → recursos → pulpo → reloj (guideline UX-3)', () => {
+    const html = renderHeaderMetaSsr({ withMode: true });
+    const iMode = html.indexOf('id="hdr-mode"');
+    const iRes = html.indexOf('id="hdr-resources"');
+    const iPulpo = html.indexOf('id="hdr-pulpo"');
+    const iClock = html.indexOf('id="hdr-clock"');
+    assert.ok(iMode >= 0 && iMode < iRes, 'mode antes de recursos');
+    assert.ok(iRes < iPulpo, 'recursos antes de pulpo');
+    assert.ok(iPulpo < iClock, 'pulpo antes del reloj');
+});
+
+test('SEC-1: el SSR no usa innerHTML ni interpola datos dinámicos', () => {
+    const html = renderHeaderMetaSsr({ withMode: true });
+    assert.doesNotMatch(html, /innerHTML/, 'el SSR no debe contener innerHTML');
+    // Las pills nacen con el placeholder "…" — sin ningún valor dinámico de CPU/RAM/uptime.
+    assert.match(html, />…</, 'las pills arrancan con placeholder … (hidratación client-side)');
+});
+
+test('SEC-1: la hidratación compartida usa textContent/classList/title, nunca innerHTML', () => {
+    const script = headerPillsClientScript();
+    assert.doesNotMatch(script, /innerHTML/, 'la hidratación no debe usar innerHTML (vector XSS FE-SEC-4)');
+    assert.match(script, /\.textContent/, 'usa textContent para valores dinámicos');
+    assert.match(script, /window\.__hydrateHeaderPills/, 'expone el helper global de hidratación');
+    // Guard de idempotencia (no redefinir en re-render).
+    assert.match(script, /if \(!window\.__hydrateHeaderPills\)/, 'guard de idempotencia');
+});
+
+test('la hidratación conserva la señal de presión de recursos (ok/warn/bad)', () => {
+    const script = headerPillsClientScript();
+    assert.match(script, /in-pill-ok/, 'clase ok');
+    assert.match(script, /in-pill-warn/, 'clase warn');
+    assert.match(script, /in-pill-bad/, 'clase bad');
+    // Umbrales históricos preservados (cálculo sin cambios).
+    assert.match(script, /maxCpu/, 'umbral de CPU');
+    assert.match(script, /maxMem/, 'umbral de RAM');
+    assert.match(script, /> 50/, 'umbral warn en 50%');
+});
+
+test('el poller standalone fetchea /api/dash/header y llama al helper, con catch defensivo', () => {
+    const poll = headerPillsPollClientScript();
+    assert.match(poll, /\/api\/dash\/header/, 'consume el endpoint de header');
+    assert.match(poll, /window\.__hydrateHeaderPills/, 'invoca el helper compartido');
+    assert.match(poll, /\.catch\(/, 'catch defensivo (el pipeline/dashboard no puede morir)');
+    assert.match(poll, /setInterval\(/, 'refresca periódicamente');
+});

--- a/.pipeline/views/dashboard/header-meta.js
+++ b/.pipeline/views/dashboard/header-meta.js
@@ -1,0 +1,152 @@
+'use strict';
+
+// ============================================================================
+// Issue #4463 — Encabezado común: pills de CPU/RAM y uptime del Pulpo + hora
+// ----------------------------------------------------------------------------
+// Modulo compartido entre home.js y satellites.js. Es el espejo de nav-tabs.js
+// para las PILLS del header (no para la nav). Centraliza:
+//   1. renderHeaderMetaSsr({ withMode }): markup SSR del <div class="in-header-meta">
+//      con las tres pills invariantes (#hdr-resources, #hdr-pulpo, #hdr-clock) y,
+//      cuando `withMode` es true, la pill de estado del pipeline (#hdr-mode).
+//   2. headerPillsClientScript(): script cliente (STRING) que define
+//      window.__hydrateHeaderPills(d) — la lógica de coloreo/umbrales de la pill
+//      de recursos (in-pill-ok/warn/bad) y de la pill del Pulpo, UNIFICADA para
+//      home y satélites (evita el drift entre dos tickHeader duplicados).
+//
+// Contexto del problema (issue #4463):
+//   - Antes, home.js armaba su propio <div class="in-header-meta"> con las tres
+//     pills, y satellites.js armaba OTRO con sólo #hdr-mode + #hdr-clock. Las
+//     pills de CPU/RAM y uptime del Pulpo NO existían en los satélites → header
+//     inconsistente entre Inicio y Pipeline/Roadmap/Providers. Este módulo emite
+//     el MISMO markup en ambos y comparte la hidratación.
+//
+// Por qué módulo separado (misma razón que nav-tabs.js):
+//   - satellites.js no requiere a home.js ni viceversa. Exportar el render desde
+//     home.js obligaría a un ciclo de require. header-meta.js queda chico y con
+//     una única responsabilidad.
+//
+// Seguridad (SEC-1 / FE-SEC-4, comment de security en #4463):
+//   - El SSR es 100% literal estático: IDs, title y aria-label son constantes
+//     hardcoded. Nunca se interpola dato dinámico del slice /api/dash/header en
+//     el markup del servidor.
+//   - La hidratación usa SIEMPRE .textContent / .classList / .title (property).
+//     PROHIBIDO innerHTML sobre datos del slice. Los emojis son prefijos string
+//     estáticos concatenados a valores numéricos vía textContent — sin XSS.
+//
+// Contratos preservados (no romper):
+//   - IDs literales hdr-resources / hdr-pulpo / hdr-clock / hdr-mode
+//     (snapshot R-G1 en __tests__/home.test.js; tickers de home y satélites).
+// ============================================================================
+
+// renderHeaderMetaSsr(opts)
+//   opts.withMode (bool, default false): si true, antepone la pill de estado del
+//     pipeline (#hdr-mode). home NO la muestra en el header visible (vive en el
+//     sink oculto, #4227) → withMode:false. Los satélites SÍ la muestran →
+//     withMode:true.
+//   Devuelve el HTML del <div class="in-header-meta"> con orden estable:
+//     [mode?] → recursos → pulpo → reloj (guideline UX-3: mismo orden y gap en
+//     todas las vistas).
+function renderHeaderMetaSsr(opts) {
+    const withMode = !!(opts && opts.withMode);
+    // Todos los atributos son literales hardcoded. NO concatenar con datos
+    // externos / query params / slice. Placeholder "…" hasta la 1ª hidratación.
+    const modePill = withMode
+        ? '<span class="in-pill" id="hdr-mode">…</span>\n      '
+        : '';
+    return `
+    <div class="in-header-meta">
+      ${modePill}<span class="in-pill" id="hdr-resources" title="CPU y RAM del sistema" aria-label="Recursos CPU y RAM">…</span>
+      <span class="in-pill" id="hdr-pulpo" aria-label="Estado del pulpo">…</span>
+      <span class="in-clock" id="hdr-clock" aria-label="Hora local">…</span>
+    </div>`;
+}
+
+// headerPillsClientScript()
+//   Devuelve el script cliente (STRING) que define window.__hydrateHeaderPills(d)
+//   con la lógica compartida de las pills de recursos y del Pulpo. Se inyecta una
+//   sola vez dentro del <script> principal de home.js y de satellites.js (ambos
+//   comparten este módulo), después de que fmtDur() esté definido en ese scope.
+//
+//   Idempotente: guard `window.__hydrateHeaderPills` para no redefinir en
+//   re-render (mismo patrón que navMoreAutoCloseClientScript).
+//
+//   `d` es el slice de GET /api/dash/header (CPU%, RAM%, pulpoAlive,
+//   pulpoUptimeMs, resources.{cpuPercent,memPercent,maxCpu,maxMem,...}).
+//
+//   Umbrales (idénticos a los históricos de home.js, no se cambia el cálculo):
+//     - cpu>maxCpu || mem>maxMem  → in-pill-bad
+//     - max(cpu,mem) > 50         → in-pill-warn
+//     - resto                     → in-pill-ok
+//
+//   SEC-1: sólo .textContent / .classList / .title (property). Sin innerHTML.
+function headerPillsClientScript() {
+    return `
+if (!window.__hydrateHeaderPills) {
+    // Formateo de uptime autocontenido (idéntico a fmtDur de home/satélites) para
+    // que el helper sea portable a vistas que no definen fmtDur (providers, roadmap).
+    var __fmtUptime = function (ms) {
+        if (!ms || ms < 0) return '—';
+        var s = Math.round(ms / 1000);
+        if (s < 60) return s + 's';
+        var m = Math.floor(s / 60), r = s % 60;
+        if (m < 60) return m + 'm ' + r + 's';
+        var h = Math.floor(m / 60), rm = m % 60;
+        return h + 'h ' + rm + 'm';
+    };
+    window.__hydrateHeaderPills = function (d) {
+        if (!d) return;
+        // Pill del Pulpo: estado (verde/rojo) + uptime formateado.
+        var pulpoPill = document.getElementById('hdr-pulpo');
+        if (pulpoPill) {
+            pulpoPill.classList.remove('in-pill-ok', 'in-pill-bad');
+            pulpoPill.classList.add(d.pulpoAlive ? 'in-pill-ok' : 'in-pill-bad');
+            pulpoPill.textContent = (d.pulpoAlive ? '🟢' : '🔴') + ' Pulpo · ' + __fmtUptime(d.pulpoUptimeMs);
+        }
+        // Pill de recursos: CPU/RAM con coloreo semántico por umbrales.
+        var res = d.resources;
+        var resPill = document.getElementById('hdr-resources');
+        if (resPill && res) {
+            var cpu = res.cpuPercent != null ? res.cpuPercent : '?';
+            var mem = res.memPercent != null ? res.memPercent : '?';
+            resPill.textContent = '🖥 CPU ' + cpu + '% · RAM ' + mem + '%';
+            resPill.classList.remove('in-pill-ok', 'in-pill-warn', 'in-pill-bad');
+            var maxCpu = res.maxCpu || 70;
+            var maxMem = res.maxMem || 70;
+            var worst = Math.max(Number(cpu) || 0, Number(mem) || 0);
+            if ((Number(cpu) || 0) > maxCpu || (Number(mem) || 0) > maxMem) resPill.classList.add('in-pill-bad');
+            else if (worst > 50) resPill.classList.add('in-pill-warn');
+            else resPill.classList.add('in-pill-ok');
+            resPill.title = 'CPU ' + cpu + '% (cap ' + maxCpu + '%) · RAM ' + mem + '% ('
+                + (res.memUsedGB || '?') + 'GB / ' + (res.memTotalGB || '?') + 'GB · cap ' + maxMem + '%) · '
+                + (res.cpuCores || '?') + ' cores';
+        }
+    };
+}
+`;
+}
+
+// headerPillsPollClientScript()
+//   Poller autocontenido (STRING) para vistas standalone que NO tienen ya un
+//   ticker sobre /api/dash/header (ej. providers.js). Fetch cada 5s + llamada a
+//   window.__hydrateHeaderPills. Defensivo: .catch silencioso, sin innerHTML.
+//   Requiere que headerPillsClientScript() se inyecte antes en el mismo <script>.
+function headerPillsPollClientScript() {
+    return `
+(function () {
+    function __tickHeaderPills() {
+        fetch('/api/dash/header', { cache: 'no-store' })
+            .then(function (r) { return r.json(); })
+            .then(function (d) { if (typeof window.__hydrateHeaderPills === 'function') window.__hydrateHeaderPills(d); })
+            .catch(function () {});
+    }
+    __tickHeaderPills();
+    setInterval(__tickHeaderPills, 5000);
+})();
+`;
+}
+
+module.exports = {
+    renderHeaderMetaSsr,
+    headerPillsClientScript,
+    headerPillsPollClientScript,
+};

--- a/.pipeline/views/dashboard/home.js
+++ b/.pipeline/views/dashboard/home.js
@@ -33,6 +33,11 @@ const { CONFIRM_MODAL_JS } = require('./confirm-modal.js');
 // home.js consume todo desde aca para no duplicar el catalogo de tabs ni
 // abrir un segundo cache del sprite (mantiene paridad con satellites.js).
 const { renderNavTabsSsr, loadIconSprite, navMoreAutoCloseClientScript } = require('./nav-tabs');
+// #4463 — Header compartido: pills de CPU/RAM y uptime del Pulpo + hora. Espejo
+// de nav-tabs.js. renderHeaderMetaSsr emite el <div class="in-header-meta"> con
+// los IDs invariantes (hdr-resources/hdr-pulpo/hdr-clock) y headerPillsClientScript
+// centraliza la hidratación (mismos umbrales in-pill-ok/warn/bad en home y satélites).
+const { renderHeaderMetaSsr, headerPillsClientScript } = require('./header-meta');
 // #4450 — writer ÚNICO del banner de ola (avance %, velocidad throughput
 // issues/día, ETA). La HOME lo inyecta igual que las otras 9 ventanas para no
 // reintroducir la divergencia de #4296 (antes la HOME hidrataba el banner con un
@@ -1995,12 +2000,10 @@ async function tickHeader(){
         }
     }
     bindModeToggle();
-    const pulpoPill = document.getElementById('hdr-pulpo');
-    if(pulpoPill){
-        pulpoPill.classList.remove('in-pill-ok','in-pill-bad');
-        pulpoPill.classList.add(d.pulpoAlive ? 'in-pill-ok' : 'in-pill-bad');
-        pulpoPill.textContent = (d.pulpoAlive ? '🟢' : '🔴') + ' Pulpo · '+fmtDur(d.pulpoUptimeMs);
-    }
+    // #4463 — Pills de Pulpo (uptime) y recursos (CPU/RAM) hidratadas por el
+    // helper compartido header-meta.js → misma lógica de umbrales que satélites,
+    // sin drift. Sólo .textContent/.classList/.title (SEC-1, sin innerHTML).
+    if(typeof window.__hydrateHeaderPills === 'function') window.__hydrateHeaderPills(d);
     // Badges de la botonera de áreas (counts vienen en el header slice).
     const counts = d.counts || {};
     for(const [area, count] of Object.entries(counts)){
@@ -2116,22 +2119,10 @@ async function tickHeader(){
             restPill.title = titleBase.length > 200 ? titleBase.slice(0, 197) + '…' : titleBase;
         }
     }
-    // Recursos: CPU/RAM con coloreo según umbrales.
+    // #4463 — La pill de recursos (#hdr-resources) se hidrata arriba vía
+    // window.__hydrateHeaderPills(d) (helper compartido). La System card sigue
+    // consumiendo el MISMO slice de resources (un solo endpoint, R-G3).
     const res = d.resources;
-    const resPill = document.getElementById('hdr-resources');
-    if(resPill && res){
-        const cpu = res.cpuPercent != null ? res.cpuPercent : '?';
-        const mem = res.memPercent != null ? res.memPercent : '?';
-        resPill.textContent = '🖥 CPU '+cpu+'% · RAM '+mem+'%';
-        resPill.classList.remove('in-pill-ok','in-pill-warn','in-pill-bad');
-        const worst = Math.max(Number(cpu)||0, Number(mem)||0);
-        const maxCpu = res.maxCpu || 70;
-        const maxMem = res.maxMem || 70;
-        if((Number(cpu)||0) > maxCpu || (Number(mem)||0) > maxMem) resPill.classList.add('in-pill-bad');
-        else if(worst > 50) resPill.classList.add('in-pill-warn');
-        else resPill.classList.add('in-pill-ok');
-        resPill.title = 'CPU '+cpu+'% (cap '+maxCpu+'%) · RAM '+mem+'% ('+(res.memUsedGB||'?')+'GB / '+(res.memTotalGB||'?')+'GB · cap '+maxMem+'%) · '+(res.cpuCores||'?')+' cores';
-    }
     // #3725 — System card: hidrata CPU/RAM desde el MISMO slice de resources
     // (un solo endpoint /api/dash/header, dos consumidores — R-G3). Disco y
     // uptime quedan en su valor SSR hasta que el slice los exponga.
@@ -4421,12 +4412,11 @@ function renderBrandBar(state) {
 // y mantener vivos los tickers (tickHeader, R-G1) sin mostrarlas. Tooltips en
 // `title=`/`aria-label=` con escapeHtmlAttr (CA-3725.2/10).
 function renderControlBar(state) {
-    return `
-    <div class="in-header-meta">
-      <span class="in-pill" id="hdr-resources" title="CPU y RAM del sistema" aria-label="Recursos CPU y RAM">…</span>
-      <span class="in-pill" id="hdr-pulpo" aria-label="Estado del pulpo">…</span>
-      <span class="in-clock" id="hdr-clock" aria-label="Hora local">…</span>
-    </div>`;
+    // #4463 — Delegado al módulo compartido header-meta.js. home NO muestra la
+    // pill de estado del pipeline en el header visible (vive en el sink oculto,
+    // #4227) → withMode:false. Los IDs (hdr-resources/hdr-pulpo/hdr-clock),
+    // title y aria-label se preservan literalmente (contrato R-G1).
+    return renderHeaderMetaSsr({ withMode: false });
 }
 
 // #4227 (CA-1) — Controles operativos heredados (estado del pipeline + ventanas
@@ -5296,6 +5286,7 @@ window.__VIEW_BOOT__ = ${JSON.stringify({
 <script>${FETCH_CLIENT_JS}
 ${CONFIRM_MODAL_JS}
 ${script}
+${headerPillsClientScript()}
 ${missionOlaEtaClientScript()}
 ${navMoreAutoCloseClientScript()}</script>
 </body>

--- a/.pipeline/views/dashboard/providers.js
+++ b/.pipeline/views/dashboard/providers.js
@@ -39,6 +39,9 @@ const path = require('node:path');
 const { escapeHtmlText, escapeHtmlAttr } = require('../../lib/escape-html.js');
 const { renderStatusBadge } = require('./components');
 const { renderNavTabsSsr, loadIconSprite } = require('./nav-tabs');
+// #4463 — Header compartido: pills de CPU/RAM y uptime del Pulpo + hora, mismo
+// componente que home/satélites. Providers antes sólo mostraba el reloj.
+const { renderHeaderMetaSsr, headerPillsClientScript, headerPillsPollClientScript } = require('./header-meta');
 // #4296 — Accessor compartido del banner de ola (avance %, velocidad %/h, ETA)
 // desde la fuente determinística viva /api/dash/ola-eta (no conteos done/total).
 const { missionOlaEtaClientScript } = require('../../lib/mission-ola-eta.js');
@@ -851,9 +854,7 @@ function renderProviders() {
 <div class="satellite-frame">
   <header class="in-header">
     ${brandHtml}
-    <div class="in-header-meta">
-      <span class="in-clock" id="hdr-clock">${escapeHtmlText(new Date().toLocaleTimeString('es-AR'))}</span>
-    </div>
+    ${renderHeaderMetaSsr({ withMode: false })}
   </header>
   ${missionHtml}
   ${navHtml}
@@ -864,7 +865,9 @@ function renderProviders() {
     <span>Intrale · MIZPÁ · #4201</span>
   </footer>
 </div>
-<script>${PROVIDERS_CLIENT_JS}</script>
+<script>${PROVIDERS_CLIENT_JS}
+${headerPillsClientScript()}
+${headerPillsPollClientScript()}</script>
 </body>
 </html>`;
 }

--- a/.pipeline/views/dashboard/satellites.js
+++ b/.pipeline/views/dashboard/satellites.js
@@ -15,6 +15,10 @@ const path = require('path');
 // con los 12 tabs en TODOS los satelites y loadIconSprite() lee el cache
 // compartido del sprite.svg para que <use href="#ic-tab-*"> resuelva inline.
 const { renderNavTabsSsr, loadIconSprite, navMoreAutoCloseClientScript } = require('./nav-tabs');
+// #4463 — Header compartido con home.js. Emite las tres pills invariantes
+// (#hdr-resources, #hdr-pulpo, #hdr-clock) + #hdr-mode en los satélites, que
+// antes NO mostraban CPU/RAM ni uptime del Pulpo (causa raíz del problema 2).
+const { renderHeaderMetaSsr, headerPillsClientScript } = require('./header-meta');
 
 // #3953 (EP8-H0) — Wrapper único de fetchJson (CA-2) y framework de modal de
 // confirmación con preview (CA-3). Reemplazan la copia local con .catch(()=>null)
@@ -110,6 +114,10 @@ async function tickHeader(){
         else if(d.mode==='partial_pause'){ modePill.classList.add('in-mode-partial'); modePill.textContent='⏸ Parcial · '+pipelineModeState.allowedIssues.length+' issues'; }
         else { modePill.classList.add('in-mode-running'); modePill.textContent='🟢 Running'; }
     }
+    // #4463 — Pills de recursos (CPU/RAM) y uptime del Pulpo: ahora presentes en
+    // los satélites y hidratadas con la MISMA lógica que home (helper compartido
+    // header-meta.js). Sólo .textContent/.classList/.title (SEC-1, sin innerHTML).
+    if(typeof window.__hydrateHeaderPills === 'function') window.__hydrateHeaderPills(d);
     // #3045 — Si el filtro de allowlist está montado en la Pipeline view,
     // refrescar su visibilidad cuando cambia el modo (running ⇄ partial_pause).
     if(typeof refreshAllowlistToggleVisibility === 'function'){
@@ -282,10 +290,7 @@ ${extraCss}
 <div class="satellite-frame">
   <header class="in-header">
     ${brandHtml}
-    <div class="in-header-meta">
-      <span class="in-pill" id="hdr-mode">…</span>
-      <span class="in-clock" id="hdr-clock">…</span>
-    </div>
+    ${renderHeaderMetaSsr({ withMode: true })}
   </header>
   ${missionHtml}
   ${navHtml}
@@ -296,7 +301,7 @@ ${extraCss}
     <span>Intrale V3</span>
   </footer>
 </div>
-<script>${FETCH_CLIENT_JS}\n${CONFIRM_MODAL_JS}\n${commonHelpers()}\n${scripts}\n${missionOlaEtaClientScript()}\n${navMoreAutoCloseClientScript()}</script>
+<script>${FETCH_CLIENT_JS}\n${CONFIRM_MODAL_JS}\n${commonHelpers()}\n${scripts}\n${headerPillsClientScript()}\n${missionOlaEtaClientScript()}\n${navMoreAutoCloseClientScript()}</script>
 </body>
 </html>`;
 }

--- a/.pipeline/views/dashboard/wave-roadmap.js
+++ b/.pipeline/views/dashboard/wave-roadmap.js
@@ -39,6 +39,9 @@ const fs = require('fs');
 const path = require('path');
 
 const { renderNavTabsSsr, loadIconSprite } = require('./nav-tabs');
+// #4463 — Header compartido: pills de CPU/RAM y uptime del Pulpo + hora. Roadmap
+// antes sólo mostraba estado del pipeline + reloj (sin CPU/RAM ni uptime).
+const { renderHeaderMetaSsr, headerPillsClientScript } = require('./header-meta');
 const { FETCH_CLIENT_JS } = require('./fetch-client.js');
 const { CONFIRM_MODAL_JS } = require('./confirm-modal.js');
 
@@ -1210,6 +1213,8 @@ async function tickHeader(){
     else if(d.mode==='partial_pause'){ modePill.classList.add('in-mode-partial'); modePill.textContent='⏸ Parcial'; }
     else { modePill.classList.add('in-mode-running'); modePill.textContent='🟢 Running'; }
   }
+  // #4463 — Pills de CPU/RAM y uptime del Pulpo (helper compartido header-meta.js).
+  if(typeof window.__hydrateHeaderPills === 'function') window.__hydrateHeaderPills(d);
 }
 tickHeader();
 setInterval(function(){ tickHeader().catch(function(){}); }, 5000);
@@ -1248,10 +1253,7 @@ function renderRoadmap(opts) {
 <div class="satellite-frame">
   <header class="in-header">
     <div class="in-header-title"><h1>Roadmap de olas</h1></div>
-    <div class="in-header-meta">
-      <span class="in-pill" id="hdr-mode">…</span>
-      <span class="in-clock" id="hdr-clock">…</span>
-    </div>
+    ${renderHeaderMetaSsr({ withMode: true })}
   </header>
   ${navHtml}
   <main class="satellite-body">${fragment}</main>
@@ -1260,7 +1262,7 @@ function renderRoadmap(opts) {
     <span>Intrale V3 · #4378 · #4373</span>
   </footer>
 </div>
-<script>${FETCH_CLIENT_JS}\n${CONFIRM_MODAL_JS}\n${COMMON_HELPERS}\n${renderRoadmapClientScript()}</script>
+<script>${FETCH_CLIENT_JS}\n${CONFIRM_MODAL_JS}\n${headerPillsClientScript()}\n${COMMON_HELPERS}\n${renderRoadmapClientScript()}</script>
 </body>
 </html>`;
 }


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 8 archivos · +382 -41

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:skipped` aplicado por delivery

## Closes

Closes #4463
