### PR TITLE
Pipeline: entregar por Telegram el artefacto/entregable real de cada agente al cerrar fase (cerrar hueco de #4255)

### DIFF
--- a/.claude/skills/android-dev/SKILL.md
+++ b/.claude/skills/android-dev/SKILL.md
@@ -394,7 +394,10 @@ Usá el helper compartido, que centraliza validación de `issue` (CA-5), redacci
 ```js
 const path = require("path");
 const { writeDeliverable } = require(path.resolve(".pipeline/lib/write-deliverable"));
-writeDeliverable("android-dev", issue, { md /* o svg para mockups/diagramas */ });
+// #4466 — pasar `fase` puebla el índice .pipeline/deliverables/<issue>.json (store #4255)
+// y da filename phase-scoped. Tomamos la fase real del pipeline desde el env inyectado.
+const fase = process.env.PIPELINE_FASE || "dev";
+writeDeliverable("android-dev", issue, { fase, md /* o svg para mockups/diagramas */ });
 ```
 
 El enforcement es **warn-only**: no generar el archivo no bloquea el pipeline, pero cuenta para la cobertura ≥80% de la ola (CA-4).

--- a/.claude/skills/backend-dev/SKILL.md
+++ b/.claude/skills/backend-dev/SKILL.md
@@ -273,7 +273,10 @@ Usá el helper compartido, que centraliza validación de `issue` (CA-5), redacci
 ```js
 const path = require("path");
 const { writeDeliverable } = require(path.resolve(".pipeline/lib/write-deliverable"));
-writeDeliverable("backend-dev", issue, { md /* o svg para mockups/diagramas */ });
+// #4466 — pasar `fase` puebla el índice .pipeline/deliverables/<issue>.json (store #4255)
+// y da filename phase-scoped. Tomamos la fase real del pipeline desde el env inyectado.
+const fase = process.env.PIPELINE_FASE || "dev";
+writeDeliverable("backend-dev", issue, { fase, md /* o svg para mockups/diagramas */ });
 ```
 
 El enforcement es **warn-only**: no generar el archivo no bloquea el pipeline, pero cuenta para la cobertura ≥80% de la ola (CA-4).

--- a/.claude/skills/builder/SKILL.md
+++ b/.claude/skills/builder/SKILL.md
@@ -216,7 +216,10 @@ Usá el helper compartido, que centraliza validación de `issue` (CA-5), redacci
 ```js
 const path = require("path");
 const { writeDeliverable } = require(path.resolve(".pipeline/lib/write-deliverable"));
-writeDeliverable("build", issue, { md /* o svg para mockups/diagramas */ });
+// #4466 — pasar `fase` puebla el índice .pipeline/deliverables/<issue>.json (store #4255)
+// y da filename phase-scoped. Tomamos la fase real del pipeline desde el env inyectado.
+const fase = process.env.PIPELINE_FASE || "build";
+writeDeliverable("build", issue, { fase, md /* o svg para mockups/diagramas */ });
 ```
 
 El enforcement es **warn-only**: no generar el archivo no bloquea el pipeline, pero cuenta para la cobertura ≥80% de la ola (CA-4).

--- a/.claude/skills/guru/SKILL.md
+++ b/.claude/skills/guru/SKILL.md
@@ -191,7 +191,10 @@ Usá el helper compartido, que centraliza validación de `issue` (CA-5), redacci
 ```js
 const path = require("path");
 const { writeDeliverable } = require(path.resolve(".pipeline/lib/write-deliverable"));
-writeDeliverable("guru", issue, { md /* o svg para mockups/diagramas */ });
+// #4466 — pasar `fase` puebla el índice .pipeline/deliverables/<issue>.json (store #4255)
+// y da filename phase-scoped. Tomamos la fase real del pipeline desde el env inyectado.
+const fase = process.env.PIPELINE_FASE || "analisis";
+writeDeliverable("guru", issue, { fase, md /* o svg para mockups/diagramas */ });
 ```
 
 El enforcement es **warn-only**: no generar el archivo no bloquea el pipeline, pero cuenta para la cobertura ≥80% de la ola (CA-4).

--- a/.claude/skills/pipeline-dev/SKILL.md
+++ b/.claude/skills/pipeline-dev/SKILL.md
@@ -214,7 +214,10 @@ Usá el helper compartido, que centraliza validación de `issue` (CA-5), redacci
 ```js
 const path = require("path");
 const { writeDeliverable } = require(path.resolve(".pipeline/lib/write-deliverable"));
-writeDeliverable("pipeline-dev", issue, { md /* o svg para mockups/diagramas */ });
+// #4466 — pasar `fase` puebla el índice .pipeline/deliverables/<issue>.json (store #4255)
+// y da filename phase-scoped. Tomamos la fase real del pipeline desde el env inyectado.
+const fase = process.env.PIPELINE_FASE || "dev";
+writeDeliverable("pipeline-dev", issue, { fase, md /* o svg para mockups/diagramas */ });
 ```
 
 El enforcement es **warn-only**: no generar el archivo no bloquea el pipeline, pero cuenta para la cobertura ≥80% de la ola (CA-4).

--- a/.claude/skills/planner/SKILL.md
+++ b/.claude/skills/planner/SKILL.md
@@ -1256,7 +1256,10 @@ Usá el helper compartido, que centraliza validación de `issue` (CA-5), redacci
 ```js
 const path = require("path");
 const { writeDeliverable } = require(path.resolve(".pipeline/lib/write-deliverable"));
-writeDeliverable("planner", issue, { md /* o svg para mockups/diagramas */ });
+// #4466 — pasar `fase` puebla el índice .pipeline/deliverables/<issue>.json (store #4255)
+// y da filename phase-scoped. Tomamos la fase real del pipeline desde el env inyectado.
+const fase = process.env.PIPELINE_FASE || "sizing";
+writeDeliverable("planner", issue, { fase, md /* o svg para mockups/diagramas */ });
 ```
 
 El enforcement es **warn-only**: no generar el archivo no bloquea el pipeline, pero cuenta para la cobertura ≥80% de la ola (CA-4).

--- a/.claude/skills/po/SKILL.md
+++ b/.claude/skills/po/SKILL.md
@@ -939,7 +939,10 @@ Usá el helper compartido, que centraliza validación de `issue` (CA-5), redacci
 ```js
 const path = require("path");
 const { writeDeliverable } = require(path.resolve(".pipeline/lib/write-deliverable"));
-writeDeliverable("po", issue, { md /* o svg para mockups/diagramas */ });
+// #4466 — pasar `fase` puebla el índice .pipeline/deliverables/<issue>.json (store #4255)
+// y da filename phase-scoped. Tomamos la fase real del pipeline desde el env inyectado.
+const fase = process.env.PIPELINE_FASE || "criterios";
+writeDeliverable("po", issue, { fase, md /* o svg para mockups/diagramas */ });
 ```
 
 El enforcement es **warn-only**: no generar el archivo no bloquea el pipeline, pero cuenta para la cobertura ≥80% de la ola (CA-4).

--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -520,7 +520,10 @@ Usá el helper compartido, que centraliza validación de `issue` (CA-5), redacci
 ```js
 const path = require("path");
 const { writeDeliverable } = require(path.resolve(".pipeline/lib/write-deliverable"));
-writeDeliverable("qa", issue, { md /* o svg para mockups/diagramas */ });
+// #4466 — pasar `fase` puebla el índice .pipeline/deliverables/<issue>.json (store #4255)
+// y da filename phase-scoped. Tomamos la fase real del pipeline desde el env inyectado.
+const fase = process.env.PIPELINE_FASE || "verificacion";
+writeDeliverable("qa", issue, { fase, md /* o svg para mockups/diagramas */ });
 ```
 
 El enforcement es **warn-only**: no generar el archivo no bloquea el pipeline, pero cuenta para la cobertura ≥80% de la ola (CA-4).

--- a/.claude/skills/security/SKILL.md
+++ b/.claude/skills/security/SKILL.md
@@ -341,7 +341,10 @@ Usá el helper compartido, que centraliza validación de `issue` (CA-5), redacci
 ```js
 const path = require("path");
 const { writeDeliverable } = require(path.resolve(".pipeline/lib/write-deliverable"));
-writeDeliverable("security", issue, { md /* o svg para mockups/diagramas */ });
+// #4466 — pasar `fase` puebla el índice .pipeline/deliverables/<issue>.json (store #4255)
+// y da filename phase-scoped. Tomamos la fase real del pipeline desde el env inyectado.
+const fase = process.env.PIPELINE_FASE || "analisis";
+writeDeliverable("security", issue, { fase, md /* o svg para mockups/diagramas */ });
 ```
 
 El enforcement es **warn-only**: no generar el archivo no bloquea el pipeline, pero cuenta para la cobertura ≥80% de la ola (CA-4).

--- a/.claude/skills/tester/SKILL.md
+++ b/.claude/skills/tester/SKILL.md
@@ -344,7 +344,10 @@ Usá el helper compartido, que centraliza validación de `issue` (CA-5), redacci
 ```js
 const path = require("path");
 const { writeDeliverable } = require(path.resolve(".pipeline/lib/write-deliverable"));
-writeDeliverable("tester", issue, { md /* o svg para mockups/diagramas */ });
+// #4466 — pasar `fase` puebla el índice .pipeline/deliverables/<issue>.json (store #4255)
+// y da filename phase-scoped. Tomamos la fase real del pipeline desde el env inyectado.
+const fase = process.env.PIPELINE_FASE || "verificacion";
+writeDeliverable("tester", issue, { fase, md /* o svg para mockups/diagramas */ });
 ```
 
 El enforcement es **warn-only**: no generar el archivo no bloquea el pipeline, pero cuenta para la cobertura ≥80% de la ola (CA-4).

--- a/.claude/skills/ux/SKILL.md
+++ b/.claude/skills/ux/SKILL.md
@@ -1177,7 +1177,10 @@ Usá el helper compartido, que centraliza validación de `issue` (CA-5), redacci
 ```js
 const path = require("path");
 const { writeDeliverable } = require(path.resolve(".pipeline/lib/write-deliverable"));
-writeDeliverable("ux", issue, { md /* o svg para mockups/diagramas */ });
+// #4466 — pasar `fase` puebla el índice .pipeline/deliverables/<issue>.json (store #4255)
+// y da filename phase-scoped. Tomamos la fase real del pipeline desde el env inyectado.
+const fase = process.env.PIPELINE_FASE || "criterios";
+writeDeliverable("ux", issue, { fase, md /* o svg para mockups/diagramas */ });
 ```
 
 El enforcement es **warn-only**: no generar el archivo no bloquea el pipeline, pero cuenta para la cobertura ≥80% de la ola (CA-4).

--- a/.claude/skills/web-dev/SKILL.md
+++ b/.claude/skills/web-dev/SKILL.md
@@ -290,7 +290,10 @@ Usá el helper compartido, que centraliza validación de `issue` (CA-5), redacci
 ```js
 const path = require("path");
 const { writeDeliverable } = require(path.resolve(".pipeline/lib/write-deliverable"));
-writeDeliverable("web-dev", issue, { md /* o svg para mockups/diagramas */ });
+// #4466 — pasar `fase` puebla el índice .pipeline/deliverables/<issue>.json (store #4255)
+// y da filename phase-scoped. Tomamos la fase real del pipeline desde el env inyectado.
+const fase = process.env.PIPELINE_FASE || "dev";
+writeDeliverable("web-dev", issue, { fase, md /* o svg para mockups/diagramas */ });
 ```
 
 El enforcement es **warn-only**: no generar el archivo no bloquea el pipeline, pero cuenta para la cobertura ≥80% de la ola (CA-4).

--- a/.pipeline/config.yaml
+++ b/.pipeline/config.yaml
@@ -963,6 +963,10 @@ deliverable_notifications:
     android-dev:  { types: [document],              formats: [.md, .pdf] }
     web-dev:      { types: [document],              formats: [.md, .pdf] }
     pipeline-dev: { types: [document],              formats: [.md, .pdf] }
+    # #4466 — `delivery` estaba en la whitelist `skills` pero sin perfil de
+    # adjuntos: el fallback determinístico no podía entregar su artefacto (resumen
+    # de entrega PR/commit). Perfil documental como el resto (CA-3, 14 skills).
+    delivery:     { types: [document],              formats: [.md, .pdf] }
 
   # CA-SEC-EXT-1: root allowlisteado por tipo. Cualquier path fuera del root
   # configurado se rechaza con `outside_root` SIN tocar disco.

--- a/.pipeline/lib/__tests__/deliverable-notify-attachments.test.js
+++ b/.pipeline/lib/__tests__/deliverable-notify-attachments.test.js
@@ -855,3 +855,98 @@ test('CA-UX-EXT-6 · html NO está en DEFAULT_ATTACHMENTS_PER_SKILL (V1)', () =>
         assert.ok(!cfg.formats.includes('.html'), 'ningún skill V1 acepta .html');
     }
 });
+
+// -----------------------------------------------------------------------------
+// #4466 (CA-4) · distinción de audit: artifact_delivery vs closing_notice
+// -----------------------------------------------------------------------------
+
+test('CA-4 · notify marca kind:closing_notice cuando NO hay adjunto', () => {
+    const { root, cleanup } = mkTmpRoot();
+    try {
+        const calls = [];
+        const result = dn.notify({
+            issue: 4466, skill: 'guru', fase: 'analisis', pipeline: 'definicion',
+            yaml: { notas: 'sólo aviso de cierre, sin artefacto físico' },
+            config: defaultCfg(),
+            pipelineRoot: root,
+            telegramQueueDir: path.join(root, '.pipeline/servicios/telegram/pendiente'),
+            deps: { writeQueueFile: (p, payload) => calls.push({ p, payload }) },
+        });
+        assert.equal(result.ok, true);
+        assert.equal(result.audit.kind, 'closing_notice');
+    } finally { cleanup(); }
+});
+
+test('CA-4 · notify marca kind:artifact_delivery cuando hay adjunto aceptado', () => {
+    const { root, cleanup } = mkTmpRoot();
+    try {
+        const pdf = path.join(root, '.pipeline/assets/docs/4466.pdf');
+        writeFixture(pdf, PDF_SIGNATURE);
+        const calls = [];
+        const result = dn.notify({
+            issue: 4466, skill: 'guru', fase: 'analisis', pipeline: 'definicion',
+            yaml: {
+                notas: 'análisis técnico con entregable',
+                attachments: [{ type: 'document', path: '.pipeline/assets/docs/4466.pdf' }],
+            },
+            config: defaultCfg(),
+            pipelineRoot: root,
+            telegramQueueDir: path.join(root, '.pipeline/servicios/telegram/pendiente'),
+            deps: { writeQueueFile: (p, payload) => calls.push({ p, payload }) },
+        });
+        assert.equal(result.ok, true);
+        assert.equal(result.audit.kind, 'artifact_delivery');
+        // El JSONL persiste el kind.
+        const auditPath = path.join(root, '.pipeline/audit/deliverable-notifications.jsonl');
+        const lines = fs.readFileSync(auditPath, 'utf8').trim().split('\n');
+        const last = JSON.parse(lines[lines.length - 1]);
+        assert.equal(last.kind, 'artifact_delivery');
+    } finally { cleanup(); }
+});
+
+test('CA-4 · adjunto RECHAZADO (no aceptado) mantiene kind:closing_notice', () => {
+    const { root, cleanup } = mkTmpRoot();
+    try {
+        // guru sólo acepta document; un image será rechazado → no hubo entrega real.
+        const png = path.join(root, '.pipeline/assets/mockups/4466.png');
+        writeFixture(png, PNG_SIGNATURE);
+        const calls = [];
+        const result = dn.notify({
+            issue: 4466, skill: 'guru', fase: 'analisis', pipeline: 'definicion',
+            yaml: {
+                notas: 'intento con adjunto no permitido para el perfil',
+                attachments: [{ type: 'image', path: '.pipeline/assets/mockups/4466.png' }],
+            },
+            config: defaultCfg(),
+            pipelineRoot: root,
+            telegramQueueDir: path.join(root, '.pipeline/servicios/telegram/pendiente'),
+            deps: { writeQueueFile: (p, payload) => calls.push({ p, payload }) },
+        });
+        assert.equal(result.ok, true);
+        assert.equal(result.audit.kind, 'closing_notice',
+            'un adjunto rechazado no cuenta como artifact_delivery');
+    } finally { cleanup(); }
+});
+
+test('CA-4 · el nuevo kind NO es tratado como audio por el dedup (sigue contando)', () => {
+    const { root, cleanup } = mkTmpRoot();
+    try {
+        const calls = [];
+        const args = {
+            issue: 4466, skill: 'guru', fase: 'analisis', pipeline: 'definicion',
+            yaml: { notas: 'contenido idéntico para probar dedup' },
+            config: defaultCfg(),
+            pipelineRoot: root,
+            telegramQueueDir: path.join(root, '.pipeline/servicios/telegram/pendiente'),
+            deps: { writeQueueFile: (p, payload) => calls.push({ p, payload }) },
+        };
+        const r1 = dn.notify(args);
+        const r2 = dn.notify(args);
+        assert.equal(r1.audit.kind, 'closing_notice');
+        // El record principal (kind:closing_notice) SÍ debe contar para dedup:
+        // la segunda invocación con el mismo content se saltea.
+        assert.equal(r2.ok, false);
+        assert.equal(r2.reason, 'dedup');
+        assert.equal(calls.length, 1);
+    } finally { cleanup(); }
+});

--- a/.pipeline/lib/deliverable-notify.js
+++ b/.pipeline/lib/deliverable-notify.js
@@ -1809,8 +1809,18 @@ function notify(args) {
         const audioEnabled = cfg.audio_enabled === true && cfg.kill_switch_audio !== true;
 
         // Audit OK del texto.
+        // #4466 (C) — CA-4: distinguir explícitamente "entrega de artefacto" de
+        // "aviso de cierre". `built.attachments` (= attachmentRecords) incluye
+        // aceptados Y rechazados, por eso miramos SÓLO los aceptados: si ningún
+        // adjunto llegó realmente, es un closing_notice aunque hubiera un intento.
+        // Este `kind` NO es 'audio' → los filtros de dedup de audio (L~1298/L~2448)
+        // no lo tocan y el record principal sigue contando para dedup.
+        const deliveredArtifact =
+            Array.isArray(built.attachments) &&
+            built.attachments.some((a) => a && a.accepted === true);
         const finalAudit = {
             ...built.auditRecord,
+            kind: deliveredArtifact ? 'artifact_delivery' : 'closing_notice',
             telegram_enqueue_ok: true,
             dropfile: firstDropfileName,
         };

--- a/.pipeline/lib/skill-deliverable-attachments.js
+++ b/.pipeline/lib/skill-deliverable-attachments.js
@@ -251,6 +251,20 @@ const SKILL_SOURCES = Object.freeze({
             descriptorHint: 'dev',
         },
     ],
+    // #4466 (B) — perfil `delivery`. Sin él, el fallback determinístico de
+    // pulpo.js (writeDeliverable('delivery', ...)) tiraba `skill sin perfil` y
+    // delivery quedaba sólo con closing_notice, incumpliendo CA-3 (los 14 skills
+    // de la whitelist entregan artefacto). Su entregable es el resumen de entrega
+    // (PR/commit) materializado desde `notas`. Issue-scoped, `.md`/`.pdf`.
+    delivery: [
+        {
+            dirTemplate: '.pipeline/assets/docs/{issue}',
+            nameMustInclude: [],
+            formats: ['.md', '.pdf'],
+            type: 'document',
+            descriptorHint: 'entrega',
+        },
+    ],
 });
 
 // Mapeo extensión → tipo de adjunto. Usado cuando la `source.type` es null

--- a/.pipeline/lib/write-deliverable.test.js
+++ b/.pipeline/lib/write-deliverable.test.js
@@ -280,6 +280,38 @@ test('writeDeliverable con fase + filename explícito respeta el filename y aún
 });
 
 // -----------------------------------------------------------------------------
+// #4466 (SEC-REQ-1 / CA-SEC-1) — el fallback determinístico enruta `notas` por
+// writeDeliverable (redact=true por default) y el .md sale redactado.
+// -----------------------------------------------------------------------------
+
+test('SEC-REQ-1 · fallback .md desde notas con AWS key / JWT / bot token sale redactado e indexado', () => {
+    const root = tmpRoot();
+    const jwt = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTYifQ.abc123defSIGNATURE';
+    const botToken = '123456789:AAHdqTcvbEXAMPLEbotTOKEN_do-not-leak-xyz';
+    const notas = [
+        '## Resultado del fallback',
+        'AWS=AKIAIOSFODNN7EXAMPLE',
+        `Authorization: Bearer ${jwt}`,
+        `curl https://api.telegram.org/bot${botToken}/sendMessage`,
+    ].join('\n');
+    // Simula exactamente el camino del fallback de pulpo.js: writeDeliverable(skill, issue, { fase, md }).
+    const { path: file } = writeDeliverable('pipeline-dev', '4466', {
+        md: notas,
+        fase: 'dev',
+        pipelineRoot: root,
+    });
+    const written = fs.readFileSync(file, 'utf8');
+    assert.ok(!written.includes('AKIAIOSFODNN7EXAMPLE'), `AWS key filtrada: ${written}`);
+    assert.ok(!written.includes(jwt), `JWT filtrado: ${written}`);
+    assert.ok(!written.includes(botToken), `bot token filtrado: ${written}`);
+    // Y quedó indexado en el store #4255 (la entrega efectiva depende del índice).
+    const read = deliverableIndex.readDeliverableIndex('4466', { pipelineRoot: root });
+    assert.equal(read.entries.length, 1);
+    assert.equal(read.entries[0].agente, 'pipeline-dev');
+    assert.equal(read.entries[0].fase, 'dev');
+});
+
+// -----------------------------------------------------------------------------
 // CA-9 — cap de tamaño
 // -----------------------------------------------------------------------------
 

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -207,6 +207,10 @@ const telegramReceipt = require('./lib/telegram-receipt');
 // fase OK. Default OFF (rollout gradual via config.yaml → deliverable_notifications.enabled).
 const deliverableNotify = require('./lib/deliverable-notify');
 const skillDeliverableAttachments = require('./lib/skill-deliverable-attachments');
+// #4466 (B) — fallback determinístico de entrega de artefacto: enruta SIEMPRE por
+// writeDeliverable (redacta secrets por default — SEC-REQ-1/CA-SEC-1). NUNCA se
+// construye el path a mano ni se adjuntan notas crudas.
+const { writeDeliverable } = require('./lib/write-deliverable');
 // #3481 — Evaluación de completitud de fases paralelas que considera
 // artefactos varados en `procesado/` (con whitelist estricta + anti-race
 // contra pendiente/trabajando). Resuelve el deadlock cuando un skill cerró
@@ -4720,6 +4724,47 @@ function brazoBarrido(config) {
               } catch (e) {
                 // Nunca bloquear notify por un fallo del helper.
                 log('barrido', `📎 #${issue} helper attachments error (${notifySkill}): ${e.message}`);
+              }
+
+              // #4466 (B) — Fallback determinístico. Cubre CA-3 (los 14 skills
+              // disparan entrega efectiva) incluyendo architect/delivery, que no
+              // llaman writeDeliverable desde su SKILL.md, y cualquier skill que
+              // aprobó sin dejar artefacto físico. Si tras el barrido NO hay
+              // adjuntos y el resultado trae notas/motivo SUSTANTIVO, se
+              // materializa un .md mínimo vía writeDeliverable (redacta secrets
+              // por default — SEC-REQ-1/CA-SEC-1) y se vuelve a barrer disco. La
+              // nota trivial (aviso corto de cierre) NO genera adjunto → se
+              // mantiene sólo el closing_notice (CA-5, anti-ruido).
+              try {
+                const sinAdjuntos = !Array.isArray(r.attachments) || r.attachments.length === 0;
+                const notasRaw =
+                  (typeof r.notas === 'string' && r.notas.trim().length > 0) ? r.notas
+                  : (typeof r.motivo === 'string' && r.motivo.trim().length > 0) ? r.motivo
+                  : '';
+                // Umbral anti-ruido: sólo notas sustantivas (no un "aprobado" seco)
+                // se convierten en artefacto entregable.
+                const esSustantiva = notasRaw.trim().length >= 80;
+                if (sinAdjuntos && esSustantiva) {
+                  try {
+                    // Enruta por writeDeliverable → hereda redactContent (SEC-REQ-1)
+                    // y valida `fase` contra el enum cerrado. NUNCA writeFileSync directo.
+                    writeDeliverable(notifySkill, issue, { fase, md: notasRaw, pipelineRoot: ROOT });
+                    // Re-barrer: el .md recién escrito debe aparecer como adjunto
+                    // pasando por la misma validación (path/magic-bytes/allowlist).
+                    const rescanned = skillDeliverableAttachments.collectAttachmentsForSkill(
+                      notifySkill, issue, fase, { pipelineRoot: ROOT },
+                    );
+                    if (Array.isArray(rescanned) && rescanned.length > 0) {
+                      r.attachments = rescanned;
+                      log('barrido', `📎 #${issue} fallback .md generado (${notifySkill}/${fase}): ${rescanned.length} adjunto`);
+                    }
+                  } catch (e) {
+                    // El fallback NUNCA bloquea la notificación (CA-6).
+                    log('barrido', `📎 #${issue} fallback .md error (${notifySkill}/${fase}): ${e.message}`);
+                  }
+                }
+              } catch (e) {
+                log('barrido', `📎 #${issue} fallback excepción (${notifySkill}): ${e.message}`);
               }
 
               const result = deliverableNotify.notify({


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 18 archivos · +248 -12

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:skipped` aplicado por delivery

## Closes

Closes #4466
