### PR TITLE
[ux] Mostrar el estado de sincronización allowlist↔ola en el dashboard/monitor

### DIFF
--- a/.pipeline/dashboard.js
+++ b/.pipeline/dashboard.js
@@ -2455,6 +2455,16 @@ function generateHTML(state) {
     if (slice && !slice.error) waveIssueAuditData = slice;
   } catch {}
 
+  // #4375 — Semáforo de sincronización allowlist↔ola (read-only). SSR inicial +
+  // refresh cliente cada 30s vía /api/dash/desync-status. Ante error del slice
+  // dejamos el estado degradado 'desconocido' (gris), nunca falso verde.
+  let desyncStatusData = { estado: 'desconocido', added: [], removed: [], count: 0, bloqueado: false };
+  try {
+    const slices = require('./lib/dashboard-slices');
+    const slice = slices.desyncStatusSlice({}, {});
+    if (slice && typeof slice === 'object') desyncStatusData = slice;
+  } catch {}
+
   // V3 detection: workers determinísticos en .pipeline/workers/*.js
   let v3Workers = [];
   try {
@@ -4309,6 +4319,30 @@ ${loadDesignTokens()}
    total. Se mantiene .pipe-status-partial por back-compat de otros call-sites. */
 .pipe-status-allowlist{animation:none;letter-spacing:0.8px}
 .pipe-status-partial{background:var(--warning-bg,rgba(210,153,34,0.14));color:var(--warning,var(--yl));border-color:rgba(210,153,34,0.45)}
+
+/* #4375 — Semáforo de sync allowlist↔ola. 4 estados: nunca sólo color (icono +
+   texto, WCAG AA). Tokens semánticos --success/--warning/--danger/--text-dim con
+   fallback. Pulso sutil SÓLO en 🔴 y respetando prefers-reduced-motion. */
+.dss-wrap{display:flex;align-items:center;gap:8px;margin:8px 0 4px;flex-wrap:wrap}
+.dss-caption{font-size:var(--fs-xs,0.75rem);color:var(--text-dim,var(--dim));font-weight:var(--fw-semibold,600);letter-spacing:0.8px;text-transform:uppercase}
+.dss-pill{display:inline-flex;align-items:center;gap:8px;font-size:var(--fs-xs,0.78rem);font-weight:var(--fw-semibold,600);padding:5px 12px;border-radius:var(--radius-full,9999px);border:1px solid transparent}
+.dss-pill .pl-ic{width:14px;height:14px;flex:0 0 auto}
+.dss-label{font-weight:var(--fw-bold,700);letter-spacing:0.4px}
+.dss-detail{color:var(--text-secondary,var(--tx));opacity:0.85;font-size:var(--fs-xs,0.72rem)}
+.dss-chips{display:inline-flex;align-items:center;gap:4px;flex-wrap:wrap}
+.dss-chip{font-size:var(--fs-xs,0.68rem);font-weight:var(--fw-bold,700);padding:1px 6px;border-radius:var(--radius-full,9999px);font-variant-numeric:tabular-nums}
+.dss-chip-add{background:var(--warning-bg,rgba(210,153,34,0.16));color:var(--warning,var(--yl))}
+.dss-chip-rem{background:var(--danger-bg,rgba(248,81,73,0.14));color:var(--danger,var(--rd,#F85149))}
+.dss-ok{background:var(--success-bg,rgba(63,185,80,0.14));color:var(--success,var(--gn));border-color:rgba(63,185,80,0.4)}
+.dss-ok .pl-ic{color:var(--success,var(--gn))}
+.dss-warn{background:var(--warning-bg,rgba(210,153,34,0.14));color:var(--warning,var(--yl));border-color:rgba(210,153,34,0.45)}
+.dss-warn .pl-ic{color:var(--warning,var(--yl))}
+.dss-danger{background:var(--danger-bg,rgba(248,81,73,0.14));color:var(--danger,var(--rd,#F85149));border-color:rgba(248,81,73,0.45);animation:dssPulse 2.2s ease-in-out infinite}
+.dss-danger .pl-ic{color:var(--danger,var(--rd,#F85149))}
+.dss-unknown{background:var(--deterministic-bg,rgba(110,118,129,0.15));color:var(--text-dim,var(--dim));border-color:rgba(139,148,158,0.35)}
+.dss-unknown .pl-ic{color:var(--text-dim,var(--dim))}
+@keyframes dssPulse{0%,100%{box-shadow:0 0 0 rgba(248,81,73,0)}50%{box-shadow:0 0 10px rgba(248,81,73,0.45)}}
+@media (prefers-reduced-motion: reduce){.dss-danger{animation:none}}
 
 /* (#2892 PR-C) — Pill compacta de alerta de consumo anómalo en el header.
  * Usa los tokens --alert-anomaly-* del design system (fuente: assets/design-tokens.css).
@@ -6588,6 +6622,7 @@ body.standalone .section-collapsed .section-body{display:block !important}
     allowlistCandidatesList,
     partialPauseAuditData,
     waveIssueAuditData,
+    desyncStatusData,
     state,
     stale,
     blocked: (typeof blocked !== 'undefined') && blocked,
@@ -7897,6 +7932,70 @@ if (typeof window !== 'undefined') {
   window.addEventListener('DOMContentLoaded', function() {
     refreshAuditTrail();
     setInterval(refreshAuditTrail, 30 * 1000);
+  });
+}
+
+// #4375 — Refresh client-side del semáforo de sync allowlist↔ola.
+// Polling 30s (alineado con el resto de /api/dash/*, CA-6) + skip si tab oculto.
+// Repinta en silencio; ante error de fetch mantiene el último estado (no rompe
+// el layout). Render client-side equivalente al SSR renderDesyncPill del view
+// pipeline.js (mismas clases dss-*, mismos estados, CA-8: enteros escapados).
+var _DSS_META = {
+  sincronizado:          { icon: 'allowlist-check',   label: 'Sincronizado',          cls: 'dss-ok',      aria: 'sincronizado' },
+  realineado_reductivo:  { icon: 'estado-retrying',   label: 'Realineado',            cls: 'dss-warn',    aria: 'realineado, divergencia autoresoluble' },
+  divergencia_bloqueada: { icon: 'warn',              label: 'Divergencia bloqueada', cls: 'dss-danger',  aria: 'divergencia bloqueada, requiere intervención' },
+  desconocido:           { icon: 'stage-not-entered', label: 'Sin datos',             cls: 'dss-unknown', aria: 'sin datos de sincronización' },
+};
+function _dssDetailText(estado, count) {
+  switch (estado) {
+    case 'sincronizado': return count > 0 ? (count + ' issues alineados') : 'allowlist alineada con la ola';
+    case 'realineado_reductivo': return 'divergencia autoresoluble por el Pulpo · no bloquea';
+    case 'divergencia_bloqueada': return 'requiere intervención · ambiguo o flag de desync activo';
+    default: return 'waves/partial-pause ausente o degradado';
+  }
+}
+function _dssChips(added, removed) {
+  var parts = [];
+  (Array.isArray(added) ? added : []).filter(Number.isInteger).slice(0, 6)
+    .forEach(function(n) { parts.push('<span class="dss-chip dss-chip-add">+#' + _ppaClientEsc(String(n)) + '</span>'); });
+  (Array.isArray(removed) ? removed : []).filter(Number.isInteger).slice(0, 6)
+    .forEach(function(n) { parts.push('<span class="dss-chip dss-chip-rem">−#' + _ppaClientEsc(String(n)) + '</span>'); });
+  if (parts.length === 0) return '';
+  return '<span class="dss-chips">' + parts.join('') + '</span>';
+}
+function renderDesyncStatus(data) {
+  var pill = document.getElementById('dss-pill');
+  if (!pill) return;
+  var d = data && typeof data === 'object' ? data : {};
+  var estado = Object.prototype.hasOwnProperty.call(_DSS_META, d.estado) ? d.estado : 'desconocido';
+  var meta = _DSS_META[estado];
+  var count = Number.isInteger(d.count) ? d.count : 0;
+  var detail = _dssDetailText(estado, count);
+  pill.className = 'dss-pill ' + meta.cls;
+  var ariaFull = 'Estado de sincronización allowlist↔ola: ' + meta.aria + '. ' + detail;
+  pill.setAttribute('aria-label', ariaFull);
+  pill.setAttribute('title', detail);
+  pill.innerHTML = ''
+    + '<span class="dss-ic">' + _ppaIcUse(meta.icon, meta.aria) + '</span>'
+    + '<span class="dss-label">' + _ppaClientEsc(meta.label) + '</span>'
+    + '<span class="dss-detail">' + _ppaClientEsc(detail) + '</span>'
+    + _dssChips(d.added, d.removed);
+}
+async function refreshDesyncStatus() {
+  if (typeof document === 'undefined' || document.hidden) return;
+  try {
+    const r = await fetch('/api/dash/desync-status', { cache: 'no-store' });
+    if (!r.ok) throw new Error('HTTP ' + r.status);
+    const data = await r.json();
+    renderDesyncStatus(data);
+  } catch (_) {
+    // Best-effort: mantener el último estado pintado; reintenta en 30s.
+  }
+}
+if (typeof window !== 'undefined') {
+  window.addEventListener('DOMContentLoaded', function() {
+    refreshDesyncStatus();
+    setInterval(refreshDesyncStatus, 30 * 1000);
   });
 }
 

--- a/.pipeline/lib/dashboard-routes.js
+++ b/.pipeline/lib/dashboard-routes.js
@@ -1375,6 +1375,13 @@ const API_ROUTES = {
     // Sec-Fetch-Site / no-store que el resto de `/api/dash/*`.
     '/api/dash/wave-issue-audit': (state, ctx) => slices.waveIssueAuditSlice(state, ctx),
     '/api/wave-issue-audit': (state, ctx) => slices.waveIssueAuditSlice(state, ctx),
+    // #4375 — indicador de estado de sincronización allowlist↔ola (semáforo
+    // read-only). Consume desync-detector.detectDesync({skipFlag,skipAlert}):
+    // observa sin mutar estado ni alertar (CA-5) y sin llamadas de red a
+    // GitHub (CA-7). Hereda el gate loopback / Sec-Fetch-Site / no-store del
+    // resto de `/api/dash/*`. Alias humano para curl/debug.
+    '/api/dash/desync-status': (state, ctx) => slices.desyncStatusSlice(state, ctx),
+    '/api/desync-status': (state, ctx) => slices.desyncStatusSlice(state, ctx),
     // #3954 EP8-H1 CA-5 — Bandeja de alertas del Home mission-control. Lectura
     // del audit trail (ack/snooze): últimas N entries, stats 24h, estado del
     // hash-chain y supresiones vigentes. Refresh natural 30s desde el cliente.

--- a/.pipeline/lib/dashboard-slices.js
+++ b/.pipeline/lib/dashboard-slices.js
@@ -2967,6 +2967,94 @@ function partialPauseAuditSlice(state, ctx) {
 }
 
 // -----------------------------------------------------------------------------
+// #4375 — Slice del indicador de estado de sincronización allowlist↔ola.
+// Superficie READ-ONLY (CA-5): consume `desync-detector.detectDesync()` con
+// `skipFlag:true, skipAlert:true` → observa sin mutar estado ni disparar
+// Telegram. NO pasa `isClosed` (CA-7): sin llamadas de red a GitHub; el peor
+// caso es marcar ámbar/rojo de más (fail-safe), nunca un falso verde.
+//
+// Mapeo estado→color (fuente: classifyDesync en desync-detector.js:170 +
+// contrato PO CA-1..CA-4):
+//   🟢 sincronizado          → desync===false && reason===null
+//   🟡 realineado_reductivo  → desync===true && classification==='resoluble_reductivo'
+//   🔴 divergencia_bloqueada → (desync===true && classification==='ambiguo') || isDesyncFlagSet()
+//   ⚪ desconocido           → reason 'no_waves_yet'/'no_partial_pause', o try/catch capturó error
+//
+// Riesgo del FALSO VERDE (receta): detectDesync devuelve `desync:false` con
+// `reason` seteado en los casos degradados. Por eso el slice chequea `reason`
+// ANTES de concluir `sincronizado`. Todo envuelto en try/catch (CA-4): ante
+// cualquier error → `{ estado:'desconocido', error }` sin propagar.
+// -----------------------------------------------------------------------------
+
+// Detector real (opcional; si el módulo no carga, el slice degrada a
+// 'desconocido'). Override inyectable para tests (CA-10) sin tocar el estado
+// global del pipeline — mismo patrón que `_setLogDir`.
+let desyncDetector = null;
+try { desyncDetector = require('./desync-detector'); } catch { /* opcional */ }
+let _desyncDetectorOverride = null;
+
+function desyncStatusSlice(state, ctx) {
+    const detector = _desyncDetectorOverride || desyncDetector;
+    // Base defensiva del contrato JSON (CA-6): siempre devolvemos el shape
+    // completo aunque falte el detector o algo falle.
+    const base = {
+        estado: 'desconocido',
+        classification: null,
+        desync: null,
+        reason: null,
+        added: [],
+        removed: [],
+        bloqueado: false,
+        count: 0,
+    };
+    if (!detector || typeof detector.detectDesync !== 'function') {
+        return { ...base, error: 'desync_detector_unavailable' };
+    }
+    try {
+        const probe = detector.detectDesync({ skipFlag: true, skipAlert: true }) || {};
+        const bloqueado = typeof detector.isDesyncFlagSet === 'function'
+            ? detector.isDesyncFlagSet() === true
+            : false;
+        // CA-8: issue numbers sólo enteros validados antes de exponerlos.
+        const added = (Array.isArray(probe.added) ? probe.added : []).filter(Number.isInteger);
+        const removed = (Array.isArray(probe.removed) ? probe.removed : []).filter(Number.isInteger);
+        const reason = probe.reason != null ? probe.reason : null;
+        const classification = probe.classification != null ? probe.classification : null;
+        const count = (Array.isArray(probe.waves_allowlist) ? probe.waves_allowlist : []).length;
+
+        // Mapeo estado→color. El orden importa: flag y casos degradados se
+        // evalúan ANTES de concluir 'sincronizado' (evita el falso verde).
+        let estado;
+        if (bloqueado) {
+            estado = 'divergencia_bloqueada';
+        } else if (reason === 'no_waves_yet' || reason === 'no_partial_pause') {
+            estado = 'desconocido';
+        } else if (probe.desync === false && reason === null) {
+            estado = 'sincronizado';
+        } else if (probe.desync === true && classification === 'resoluble_reductivo') {
+            estado = 'realineado_reductivo';
+        } else if (probe.desync === true && classification === 'ambiguo') {
+            estado = 'divergencia_bloqueada';
+        } else {
+            estado = 'desconocido';
+        }
+
+        return {
+            estado,
+            classification,
+            desync: typeof probe.desync === 'boolean' ? probe.desync : null,
+            reason,
+            added,
+            removed,
+            bloqueado,
+            count,
+        };
+    } catch (err) {
+        return { ...base, error: String((err && err.message) || err) };
+    }
+}
+
+// -----------------------------------------------------------------------------
 // #4371 (Ola 8.3) CA-8/CA-10 — Slice del widget "Audit trail · Olas & Issues".
 // Modelado 1:1 sobre `partialPauseAuditSlice`: tail de eventos de olas/issues
 // (add/remove/priority/promote/archive) con actor, evento, estados previo/
@@ -3597,6 +3685,10 @@ module.exports = {
     deliverablesBySkillSlice,
     // #3625 — widget de audit trail de allowlist
     partialPauseAuditSlice,
+    // #4375 — indicador de estado de sync allowlist↔ola (semáforo read-only)
+    desyncStatusSlice,
+    _setDesyncDetector: (d) => { _desyncDetectorOverride = d || null; },
+    _resetDesyncDetector: () => { _desyncDetectorOverride = null; },
     // #4371 — widget de audit trail de olas & issues
     waveIssueAuditSlice,
     _classifyWaveAuditVisual: classifyWaveAuditVisual,

--- a/.pipeline/test-desync-status-slice.js
+++ b/.pipeline/test-desync-status-slice.js
@@ -1,0 +1,185 @@
+// #4375 — Tests del slice `desyncStatusSlice` (indicador de estado de sync
+// allowlist↔ola). Cubre el mapeo estado→color (CA-10), la garantía read-only
+// (CA-5), el fail-safe sin llamadas a GitHub (CA-7) y la validación de enteros
+// (CA-8). Framework: node --test (built-in, sin dependencias).
+//
+// Estrategia de aislamiento:
+//   - Mapeo: se inyecta un detector FAKE vía `_setDesyncDetector` — no toca el
+//     estado global del pipeline; cada caso fuerza un probe determinístico.
+//   - Read-only: se corre el detector REAL contra un directorio temporal
+//     (PIPELINE_DIR_OVERRIDE) con fixtures, y se asserta que NO se crea el flag
+//     ni cambian los mtimes de los archivos de estado tras N invocaciones.
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const slices = require('./lib/dashboard-slices');
+
+// --- Helpers -----------------------------------------------------------------
+
+// Detector fake: devuelve un probe fijo y un flag configurable. `calls` acumula
+// las opts recibidas para poder assertar el contrato read-only (CA-5/CA-7).
+function makeFakeDetector(probe, flagSet, calls) {
+    return {
+        detectDesync(opts) {
+            if (calls) calls.push(opts);
+            if (typeof probe === 'function') return probe();
+            return probe;
+        },
+        isDesyncFlagSet() { return flagSet === true; },
+    };
+}
+
+function runWithFake(probe, flagSet, calls) {
+    slices._setDesyncDetector(makeFakeDetector(probe, flagSet, calls));
+    try {
+        return slices.desyncStatusSlice({}, {});
+    } finally {
+        slices._resetDesyncDetector();
+    }
+}
+
+// --- Mapeo estado→color (CA-10) ----------------------------------------------
+
+test('desync:false + reason:null → sincronizado', () => {
+    const r = runWithFake({ desync: false, reason: null, classification: null, added: [], removed: [], waves_allowlist: [1, 2] }, false);
+    assert.strictEqual(r.estado, 'sincronizado');
+    assert.strictEqual(r.count, 2);
+    assert.strictEqual(r.bloqueado, false);
+});
+
+test('desync:true + classification:resoluble_reductivo → realineado_reductivo', () => {
+    const r = runWithFake({ desync: true, reason: 'allowlist_mismatch', classification: 'resoluble_reductivo', added: [], removed: [3], waves_allowlist: [1, 2, 3] }, false);
+    assert.strictEqual(r.estado, 'realineado_reductivo');
+    assert.deepStrictEqual(r.removed, [3]);
+});
+
+test('desync:true + classification:ambiguo → divergencia_bloqueada', () => {
+    const r = runWithFake({ desync: true, reason: 'allowlist_mismatch', classification: 'ambiguo', added: [9], removed: [], waves_allowlist: [1, 2] }, false);
+    assert.strictEqual(r.estado, 'divergencia_bloqueada');
+    assert.deepStrictEqual(r.added, [9]);
+});
+
+test('isDesyncFlagSet()===true → divergencia_bloqueada aunque el probe diga sincronizado', () => {
+    const r = runWithFake({ desync: false, reason: null, classification: null, added: [], removed: [], waves_allowlist: [1] }, true);
+    assert.strictEqual(r.estado, 'divergencia_bloqueada');
+    assert.strictEqual(r.bloqueado, true);
+});
+
+test('reason:no_waves_yet → desconocido (evita el falso verde)', () => {
+    const r = runWithFake({ desync: false, reason: 'no_waves_yet', classification: null, added: [], removed: [], waves_allowlist: null }, false);
+    assert.strictEqual(r.estado, 'desconocido');
+});
+
+test('reason:no_partial_pause → desconocido (evita el falso verde)', () => {
+    const r = runWithFake({ desync: false, reason: 'no_partial_pause', classification: null, added: [], removed: [], waves_allowlist: [1, 2] }, false);
+    assert.strictEqual(r.estado, 'desconocido');
+});
+
+test('detector que tira excepción → desconocido, sin propagar (CA-4)', () => {
+    const r = runWithFake(() => { throw new Error('boom'); }, false);
+    assert.strictEqual(r.estado, 'desconocido');
+    assert.ok(r.error, 'debe exponer el error capturado');
+});
+
+test('detector ausente → desconocido con error explícito', () => {
+    slices._setDesyncDetector({}); // sin detectDesync
+    try {
+        const r = slices.desyncStatusSlice({}, {});
+        assert.strictEqual(r.estado, 'desconocido');
+        assert.strictEqual(r.error, 'desync_detector_unavailable');
+    } finally {
+        slices._resetDesyncDetector();
+    }
+});
+
+// --- Validación de enteros (CA-8) --------------------------------------------
+
+test('added/removed filtran no-enteros (CA-8)', () => {
+    const r = runWithFake({
+        desync: true, reason: 'allowlist_mismatch', classification: 'ambiguo',
+        added: [1, '2', 2.5, 3, null, undefined, NaN],
+        removed: [4, '5', 6],
+        waves_allowlist: [1, 2, 3],
+    }, false);
+    assert.deepStrictEqual(r.added, [1, 3]);
+    assert.deepStrictEqual(r.removed, [4, 6]);
+});
+
+// --- Contrato JSON (CA-6) ----------------------------------------------------
+
+test('el slice siempre devuelve el shape completo del contrato', () => {
+    const r = runWithFake({ desync: false, reason: null, classification: null, added: [], removed: [], waves_allowlist: [] }, false);
+    for (const k of ['estado', 'classification', 'desync', 'reason', 'added', 'removed', 'bloqueado', 'count']) {
+        assert.ok(Object.prototype.hasOwnProperty.call(r, k), `falta la clave ${k}`);
+    }
+});
+
+// --- Read-only garantizado (CA-5) con detector REAL + fixtures ---------------
+
+test('CA-5/CA-7 — el slice pide modo read-only y sin isClosed', () => {
+    const calls = [];
+    runWithFake({ desync: false, reason: null, classification: null, added: [], removed: [], waves_allowlist: [] }, false, calls);
+    assert.strictEqual(calls.length, 1);
+    assert.strictEqual(calls[0].skipFlag, true, 'skipFlag debe ser true (no mutar)');
+    assert.strictEqual(calls[0].skipAlert, true, 'skipAlert debe ser true (no alertar)');
+    assert.ok(!('isClosed' in calls[0]), 'no debe pasar isClosed (sin red a GitHub)');
+});
+
+test('CA-5 — N invocaciones del detector REAL no crean el flag ni mutan estado', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'desync-4375-'));
+    const wavesPath = path.join(dir, 'waves.json');
+    const partialPath = path.join(dir, '.partial-pause.json');
+    const flagPath = path.join(dir, '.desync-detected.flag');
+    // Fixture con divergencia AMBIGUA (extra abierto en la allowlist) para
+    // ejercitar el camino más "caliente" del detector — igual no debe mutar.
+    fs.writeFileSync(wavesPath, JSON.stringify({ active_wave: { issues: [{ number: 1 }, { number: 2 }] } }));
+    fs.writeFileSync(partialPath, JSON.stringify({ allowed_issues: [1, 2, 9] }));
+
+    const prevOverride = process.env.PIPELINE_DIR_OVERRIDE;
+    process.env.PIPELINE_DIR_OVERRIDE = dir;
+    // Aseguramos el detector REAL (no el fake de tests previos).
+    slices._resetDesyncDetector();
+    try {
+        const mtWavesBefore = fs.statSync(wavesPath).mtimeMs;
+        const mtPartialBefore = fs.statSync(partialPath).mtimeMs;
+
+        let last;
+        for (let i = 0; i < 5; i++) {
+            last = slices.desyncStatusSlice({}, {});
+        }
+
+        // Estado esperado: extra abierto sin isClosed → ambiguo → bloqueada.
+        assert.strictEqual(last.estado, 'divergencia_bloqueada');
+        assert.deepStrictEqual(last.added, [9]);
+        // Read-only: no se creó el flag, ni cambiaron los mtimes.
+        assert.strictEqual(fs.existsSync(flagPath), false, 'NO debe crearse .desync-detected.flag');
+        assert.strictEqual(fs.statSync(wavesPath).mtimeMs, mtWavesBefore, 'waves.json no debe mutar');
+        assert.strictEqual(fs.statSync(partialPath).mtimeMs, mtPartialBefore, '.partial-pause.json no debe mutar');
+    } finally {
+        if (prevOverride === undefined) delete process.env.PIPELINE_DIR_OVERRIDE;
+        else process.env.PIPELINE_DIR_OVERRIDE = prevOverride;
+        try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort */ }
+    }
+});
+
+test('CA-4 — waves.json corrupto → desconocido sin crash (detector REAL)', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'desync-4375-corrupt-'));
+    fs.writeFileSync(path.join(dir, 'waves.json'), '{ esto no es json valido');
+    fs.writeFileSync(path.join(dir, '.partial-pause.json'), JSON.stringify({ allowed_issues: [1] }));
+    const prevOverride = process.env.PIPELINE_DIR_OVERRIDE;
+    process.env.PIPELINE_DIR_OVERRIDE = dir;
+    slices._resetDesyncDetector();
+    try {
+        const r = slices.desyncStatusSlice({}, {});
+        // waves ilegible → readWavesAllowlist null → reason no_waves_yet → desconocido.
+        assert.strictEqual(r.estado, 'desconocido');
+    } finally {
+        if (prevOverride === undefined) delete process.env.PIPELINE_DIR_OVERRIDE;
+        else process.env.PIPELINE_DIR_OVERRIDE = prevOverride;
+        try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort */ }
+    }
+});

--- a/.pipeline/views/dashboard/pipeline.js
+++ b/.pipeline/views/dashboard/pipeline.js
@@ -130,6 +130,8 @@ function renderPipelineHTML(params) {
        ============================================================ -->
   ${renderControlBar({ ic, state, stale, blocked, isPaused, partialActive, trabajando, pwThreshold, now, allowedIssues })}
 
+  ${renderDesyncPill({ ic, desync: normalizeDesyncStatus(p.desyncStatusData) })}
+
   ${renderDepsBanner({ ic })}
 
   ${renderAllowlistSection({ ic, allowedIssues, allowlistCandidatesList, partialActive })}
@@ -247,6 +249,75 @@ function renderDepsBanner({ ic }) {
     <span id="partial-pause-deps-msg" style="margin-left:10px;color:var(--text,#c9d1d9);"></span>
     <button onclick="includeMissingDeps()" style="margin-left:12px;padding:4px 10px;background:#f0a500;color:#1c2128;border:0;border-radius:4px;cursor:pointer;font-weight:600;" title="${escapeHtmlAttr(TOOLTIPS.includeDeps)}">Agregar dependencias al allowlist</button>
     <button onclick="dismissDepsBanner()" style="margin-left:6px;padding:4px 10px;background:transparent;color:#c9d1d9;border:1px solid rgba(255,255,255,0.2);border-radius:4px;cursor:pointer;" title="${escapeHtmlAttr(TOOLTIPS.dismissDeps)}">Ocultar</button>
+  </div>`;
+}
+
+// --- 2.5 Semáforo de sync allowlist↔ola (#4375) ------------------------------
+// Indicador READ-ONLY de 4 estados que expone el estado de sincronización entre
+// `.partial-pause.json` (allowed_issues) y `waves.json` (active_wave.issues).
+// Consume el slice `desyncStatusSlice` (via /api/dash/desync-status). Contrato
+// UX: nunca sólo color — cada estado se distingue por icono + texto (WCAG AA),
+// `role="status"` + aria-label con el estado completo. Prohibido el falso
+// verde: `desconocido` es ⚪ gris, no 🟢. Sin colores hardcodeados (tokens).
+// CA-8: issue numbers sólo enteros (`Number.isInteger`) escapados.
+const DSS_META = {
+    sincronizado:          { icon: 'allowlist-check',   label: 'Sincronizado',          cls: 'dss-ok',      aria: 'sincronizado' },
+    realineado_reductivo:  { icon: 'estado-retrying',   label: 'Realineado',            cls: 'dss-warn',    aria: 'realineado, divergencia autoresoluble' },
+    divergencia_bloqueada: { icon: 'warn',              label: 'Divergencia bloqueada', cls: 'dss-danger',  aria: 'divergencia bloqueada, requiere intervención' },
+    desconocido:           { icon: 'stage-not-entered', label: 'Sin datos',             cls: 'dss-unknown', aria: 'sin datos de sincronización' },
+};
+
+// Normalización defensiva del contrato del slice: ante campo ausente/corrupto
+// degradamos a `desconocido` (riesgo del render de `undefined`).
+function normalizeDesyncStatus(raw) {
+    const d = raw && typeof raw === 'object' ? raw : {};
+    const estado = Object.prototype.hasOwnProperty.call(DSS_META, d.estado) ? d.estado : 'desconocido';
+    return {
+        estado,
+        added: (Array.isArray(d.added) ? d.added : []).filter(Number.isInteger),
+        removed: (Array.isArray(d.removed) ? d.removed : []).filter(Number.isInteger),
+        count: Number.isInteger(d.count) ? d.count : 0,
+        bloqueado: Boolean(d.bloqueado),
+    };
+}
+
+// Texto de detalle por estado (sin JSON crudo ni paths — CA-8).
+function desyncDetailText(d) {
+    switch (d.estado) {
+        case 'sincronizado':
+            return d.count > 0 ? `${d.count} issues alineados` : 'allowlist alineada con la ola';
+        case 'realineado_reductivo':
+            return 'divergencia autoresoluble por el Pulpo · no bloquea';
+        case 'divergencia_bloqueada':
+            return 'requiere intervención · ambiguo o flag de desync activo';
+        default:
+            return 'waves/partial-pause ausente o degradado';
+    }
+}
+
+// Chips de issues added/removed — sólo enteros escapados, tope de 6 (CA-8).
+function desyncIssueChips(d) {
+    const parts = [];
+    d.added.slice(0, 6).forEach((n) => parts.push('<span class="dss-chip dss-chip-add">+#' + escapeHtmlText(String(n)) + '</span>'));
+    d.removed.slice(0, 6).forEach((n) => parts.push('<span class="dss-chip dss-chip-rem">−#' + escapeHtmlText(String(n)) + '</span>'));
+    if (parts.length === 0) return '';
+    return '<span class="dss-chips">' + parts.join('') + '</span>';
+}
+
+function renderDesyncPill({ ic, desync }) {
+    const d = normalizeDesyncStatus(desync);
+    const meta = DSS_META[d.estado] || DSS_META.desconocido;
+    const detail = desyncDetailText(d);
+    const ariaFull = 'Estado de sincronización allowlist↔ola: ' + meta.aria + '. ' + detail;
+    return `
+  <div class="dss-wrap" data-test-id="desync-status">
+    <span class="dss-caption">Sync allowlist↔ola</span>
+    <span id="dss-pill" class="dss-pill ${meta.cls}" role="status" aria-label="${escapeHtmlAttr(ariaFull)}" title="${escapeHtmlAttr(detail)}">
+      <span class="dss-ic">${ic(meta.icon, meta.aria)}</span>
+      <span class="dss-label">${escapeHtmlText(meta.label)}</span>
+      <span class="dss-detail">${escapeHtmlText(detail)}</span>
+      ${desyncIssueChips(d)}
+    </span>
   </div>`;
 }
 
@@ -506,4 +577,14 @@ function renderWaveAuditTrail({ ic, audit, renderRows, auditNeedsAttention }) {
   </details>`;
 }
 
-module.exports = { renderPipelineHTML, normalizeAudit, normalizeWaveAudit, TOOLTIPS };
+module.exports = {
+    renderPipelineHTML,
+    normalizeAudit,
+    normalizeWaveAudit,
+    TOOLTIPS,
+    // #4375 — helpers del semáforo de sync (exportados para test unitario)
+    renderDesyncPill,
+    normalizeDesyncStatus,
+    desyncDetailText,
+    DSS_META,
+};


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 5 archivos · +465 -1

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:passed` aplicado por delivery

## Closes

Closes #4375
