### PR TITLE
fix(pipeline): cascada Codex→Gemini ante usage-limit de cuenta ChatGPT

### DIFF
--- a/.pipeline/agent-models.json
+++ b/.pipeline/agent-models.json
@@ -52,7 +52,8 @@
       "output_parser": "openai-sse",
       "quota_error_types": [
         "insufficient_quota",
-        "billing_hard_limit_reached"
+        "billing_hard_limit_reached",
+        "usage_limit_reached"
       ],
       "resets_at_cap_max_days": 31,
       "supports_tool_use": true,

--- a/.pipeline/lib/__tests__/quota-exhausted.test.js
+++ b/.pipeline/lib/__tests__/quota-exhausted.test.js
@@ -516,7 +516,7 @@ const PROVIDER_DEF_OPENAI = Object.freeze({
     launcher: 'codex',
     model: 'gpt-5-codex',
     output_parser: 'openai-sse',
-    quota_error_types: ['insufficient_quota', 'billing_hard_limit_reached', 'tokens_exhausted'],
+    quota_error_types: ['insufficient_quota', 'billing_hard_limit_reached', 'tokens_exhausted', 'usage_limit_reached'],
     resets_at_cap_max_days: 31,
 });
 
@@ -559,6 +559,79 @@ test('CA-4 #3077 · detectQuotaError(openai-codex) matchea shape alternativo res
     const det = q.detectQuotaError(evt, PROVIDER_DEF_OPENAI);
     assert.equal(det.matched, true);
     assert.equal(det.errorType, 'billing_hard_limit_reached');
+});
+
+// -----------------------------------------------------------------------------
+// Codex CLI con cuenta ChatGPT (OAuth) — usage_limit_reached por canal de control
+//
+// El CLI reporta el cap rolling como texto libre SIN error_type estructurado,
+// en frames de control `turn.failed` / `error`. Estos frames NO son inyectables
+// por el modelo, así que el regex acotado sobre `message` es seguro. Cierra el
+// gap de la cascada Codex→Gemini: sin esta detección el flag nunca se seteaba y
+// el agente moría en codex en vez de cascadear al free tier.
+// -----------------------------------------------------------------------------
+
+test('codex ChatGPT · detectQuotaError matchea turn.failed con "usage limit" (canal de control)', () => {
+    const tmp = newTmpDir();
+    const q = freshModule(tmp);
+    const evt = { type: 'turn.failed', error: { message: "You've hit your usage limit. Upgrade to Pro or try again at Jul 6th, 2026 2:19 AM." } };
+    const det = q.detectQuotaError(evt, PROVIDER_DEF_OPENAI);
+    assert.equal(det.matched, true);
+    assert.equal(det.errorType, 'usage_limit_reached');
+});
+
+test('codex ChatGPT · detectQuotaError matchea evento type=error con message top-level', () => {
+    const tmp = newTmpDir();
+    const q = freshModule(tmp);
+    const evt = { type: 'error', message: "You've hit your usage limit. Upgrade to Pro." };
+    const det = q.detectQuotaError(evt, PROVIDER_DEF_OPENAI);
+    assert.equal(det.matched, true);
+    assert.equal(det.errorType, 'usage_limit_reached');
+});
+
+test('codex ChatGPT · ANTI-INJECTION: mismo texto en canal de contenido del modelo NO matchea', () => {
+    const tmp = newTmpDir();
+    const q = freshModule(tmp);
+    // item.completed/agent_message es el canal de CONTENIDO — el modelo podría
+    // escribir el texto adversarialmente; NO debe activar el flag.
+    const evt = { type: 'item.completed', item: { type: 'agent_message', text: "you've hit your usage limit (texto del modelo)" } };
+    const det = q.detectQuotaError(evt, PROVIDER_DEF_OPENAI);
+    assert.equal(det.matched, false);
+});
+
+test('codex ChatGPT · turn.failed con otro error (no usage-limit) NO matchea', () => {
+    const tmp = newTmpDir();
+    const q = freshModule(tmp);
+    const evt = { type: 'turn.failed', error: { message: 'network unreachable: ECONNRESET' } };
+    const det = q.detectQuotaError(evt, PROVIDER_DEF_OPENAI);
+    assert.equal(det.matched, false);
+});
+
+test('codex ChatGPT · usage_limit_reached fuera de la allowlist del provider NO matchea (SR-7)', () => {
+    const tmp = newTmpDir();
+    const q = freshModule(tmp);
+    // providerDef legacy sin usage_limit_reached → el gate por allowlist protege.
+    const legacyDef = { ...PROVIDER_DEF_OPENAI, quota_error_types: ['insufficient_quota'] };
+    const evt = { type: 'turn.failed', error: { message: "You've hit your usage limit." } };
+    const det = q.detectQuotaError(evt, legacyDef);
+    assert.equal(det.matched, false);
+});
+
+test('codex ChatGPT · setFlag(usage_limit_reached) sin resets_at usa ventana corta (no fallback semanal)', () => {
+    const tmp = newTmpDir();
+    const q = freshModule(tmp);
+    try {
+        const now = 1777000000000;
+        const r = q.setFlag({ provider: 'openai-codex', errorType: 'usage_limit_reached', now });
+        const deltaMs = Date.parse(r.payload.resets_at) - now;
+        assert.equal(deltaMs, q.CODEX_USAGE_LIMIT_RESET_MS, 'reset debe ser la ventana corta rolling (1h), no el fallback semanal');
+        // Verifica la cascada: codex gateado, gemini libre.
+        assert.equal(q.shouldGateSpawn('po', { provider: 'openai-codex', now }), true);
+        assert.equal(q.shouldGateSpawn('po', { provider: 'gemini-google', now }), false);
+    } finally {
+        delete process.env.PIPELINE_DIR_OVERRIDE;
+        fs.rmSync(tmp, { recursive: true, force: true });
+    }
 });
 
 test('CA-4 #3077 · detectQuotaError NO matchea cuando providerDef es null/inválido', () => {

--- a/.pipeline/lib/agent-launcher/__tests__/provider-error-parser.test.js
+++ b/.pipeline/lib/agent-launcher/__tests__/provider-error-parser.test.js
@@ -99,6 +99,26 @@ test('CA-7 cross-skill: qa/OpenAI Codex SSE event=error con insufficient_quota c
     assert.equal(r.shouldFallback, true);
 });
 
+test('codex ChatGPT: turn.failed con "usage limit" (canal de control) clasifica quota_exhausted', () => {
+    // Shape real del CLI Codex con cuenta ChatGPT (OAuth): sin error.type
+    // estructurado, sólo message en el frame de control turn.failed.
+    const raw = [
+        '{"type":"turn.started"}',
+        '{"type":"error","message":"You\\u0027ve hit your usage limit. Upgrade to Pro or try again at Jul 6th, 2026 2:19 AM."}',
+        '{"type":"turn.failed","error":{"message":"You\\u0027ve hit your usage limit. Upgrade to Pro or try again at Jul 6th, 2026 2:19 AM."}}',
+    ].join('\n');
+    const r = parseProviderError(raw, { provider: 'openai-codex', transport: 'cli' });
+    assert.equal(r.errorClass, 'quota_exhausted');
+    assert.equal(r.shouldFallback, true);
+});
+
+test('codex ChatGPT: "hit your usage limit" en stderr texto plano clasifica quota_exhausted via regex', () => {
+    const raw = "API error: You've hit your usage limit. Upgrade to Pro.";
+    const r = parseProviderError(raw, { provider: 'openai-codex', transport: 'cli' });
+    assert.equal(r.errorClass, 'quota_exhausted');
+    assert.equal(r.shouldFallback, true);
+});
+
 test('CA-7 cross-skill: commander result event estructural clasifica quota_exhausted (mismo shape que skills)', () => {
     const fx = loadFixture('commander-anthropic-result-event.json');
     const r = parseProviderError(fx.raw, { provider: fx.provider, transport: fx.transport });

--- a/.pipeline/lib/agent-launcher/provider-error-parser.js
+++ b/.pipeline/lib/agent-launcher/provider-error-parser.js
@@ -195,6 +195,10 @@ const CLI_QUOTA_PATTERNS = Object.freeze([
     // "You've hit your session limit" — Anthropic CLI cuando la sesión OAuth
     // del usuario tocó el techo semanal.
     /\bhit\s+your\s+session\s+limit\b/i,
+    // "You've hit your usage limit" — Codex CLI con cuenta ChatGPT (OAuth)
+    // cuando el cap rolling de uso se agota. Viene por el canal de control del
+    // CLI (turn.failed/error), no por el contenido del modelo.
+    /\bhit\s+your\s+usage\s+limit\b/i,
     // "weekly quota exhausted" o "quota exhausted" — texto genérico.
     /\bweekly\s+quota\s+exhausted\b/i,
     /\bquota\s+exhausted\b/i,

--- a/.pipeline/lib/quota-exhausted.js
+++ b/.pipeline/lib/quota-exhausted.js
@@ -165,10 +165,14 @@ const KNOWN_QUOTA_ERROR_TYPES_BY_PROVIDER = Object.freeze({
         'plan_max_reset_required',
     ]),
     'openai-codex': Object.freeze([
-        // Externos (CLI codex / OpenAI)
+        // Externos (CLI codex / OpenAI con API key paga)
         'insufficient_quota',
         'billing_hard_limit_reached',
         'tokens_exhausted',
+        // Codex con cuenta ChatGPT (OAuth): el CLI reporta el cap rolling como
+        // texto libre en el canal de control ("You've hit your usage limit").
+        // error_type sintético emitido por _detectOpenAI (no viene del CLI).
+        'usage_limit_reached',
     ]),
     // #3220 — rename ex-`gemini` → `gemini-google` (sign-off 2026-05-15).
     // Coordinación cross-archivo: ALLOWED_LAUNCHERS, ALLOWED_PROVIDERS y
@@ -670,7 +674,14 @@ function setFlag(opts = {}) {
     const provider = opts.provider || DEFAULT_PROVIDER;
     const model = opts.model || null;
     const now = Number.isFinite(opts.now) ? opts.now : Date.now();
-    const cap = capResetsAt(opts.resetsAt, { maxDays: opts.maxDays, now });
+    // Codex/ChatGPT `usage_limit_reached` es un cap rolling: si el caller no
+    // aportó un `resets_at` (el CLI lo emite como texto libre, sin campo
+    // estructurado), gateamos por una ventana corta en vez del fallback semanal.
+    let effectiveResetsAt = opts.resetsAt;
+    if (effectiveResetsAt == null && errorType === 'usage_limit_reached') {
+        effectiveResetsAt = now + CODEX_USAGE_LIMIT_RESET_MS;
+    }
+    const cap = capResetsAt(effectiveResetsAt, { maxDays: opts.maxDays, now });
     const payload = {
         exhausted: true,
         provider,
@@ -744,6 +755,25 @@ function appendAudit(entry, opts = {}) {
 const _CLI_1M_CONTEXT_GLITCH_PATTERN =
     /\bUsage\s+credits?\s+required\s+for\s+1M\s+context\b/i;
 
+// Codex CLI con cuenta ChatGPT (OAuth, sin API key paga) reporta el límite de
+// uso como TEXTO LIBRE, sin `error.type` estructurado, en eventos del canal de
+// CONTROL del CLI:
+//   {"type":"error","message":"You've hit your usage limit. Upgrade to Pro..."}
+//   {"type":"turn.failed","error":{"message":"You've hit your usage limit..."}}
+// A diferencia del canal de contenido del modelo, estos frames de protocolo NO
+// pueden ser inyectados por el modelo, así que matchear un regex ACOTADO sobre
+// su `message` es seguro (mismo criterio estructural que el glitch 1M de
+// Anthropic). ReDoS-safe: clases restringidas y cuantificadores acotados.
+const _CODEX_USAGE_LIMIT_PATTERN =
+    /\byou'?ve\s+hit\s+your\s+usage\s+limit\b/i;
+
+// El límite de uso de la cuenta ChatGPT es un cap ROLLING (resetea en minutos/
+// horas, no semanal). Cuando el CLI no entrega un `resets_at` estructurado,
+// gateamos codex por esta ventana corta en vez del fallback semanal — así no
+// desperdiciamos el fallback pago durante días. Es auto-corrector: si al drenar
+// la cuota sigue agotada, el próximo intento re-setea el flag (idempotente).
+const CODEX_USAGE_LIMIT_RESET_MS = 60 * 60 * 1000; // 1h
+
 function _detectAnthropic(evt, allowlist) {
     if (!evt || typeof evt !== 'object') return { matched: false };
     if (evt.type !== 'result') return { matched: false };
@@ -810,6 +840,21 @@ function _detectOpenAI(evt, allowlist) {
         const errType = typeof evt.error.type === 'string' ? evt.error.type : null;
         if (errType && allowlist.includes(errType)) {
             return { matched: true, errorType: errType };
+        }
+    }
+
+    // Codex CLI (cuenta ChatGPT): límite de uso reportado como texto libre en el
+    // canal de control (`turn.failed` / `error`), sin `error.type` estructurado.
+    // Solo se activa si el provider declara el error_type sintético
+    // `usage_limit_reached` en su allowlist (SR-7). El regex se aplica ÚNICAMENTE
+    // sobre eventos de control — nunca sobre el canal de contenido del modelo.
+    if ((evt.type === 'turn.failed' || evt.type === 'error')
+        && allowlist.includes('usage_limit_reached')) {
+        const msg = (evt.error && typeof evt.error.message === 'string')
+            ? evt.error.message
+            : (typeof evt.message === 'string' ? evt.message : '');
+        if (msg && _CODEX_USAGE_LIMIT_PATTERN.test(msg)) {
+            return { matched: true, errorType: 'usage_limit_reached' };
         }
     }
 
@@ -960,6 +1005,7 @@ module.exports = {
     PATTERN_MATCHED_MAX_CHARS,
     DETERMINISTIC_SKILLS,
     KNOWN_QUOTA_ERROR_TYPES_BY_PROVIDER,
+    CODEX_USAGE_LIMIT_RESET_MS,
 
     // Paths (útiles para tests)
     flagFile,
@@ -971,4 +1017,5 @@ module.exports = {
     _detectAnthropic,
     _detectOpenAI,
     _CLI_1M_CONTEXT_GLITCH_PATTERN,
+    _CODEX_USAGE_LIMIT_PATTERN,
 };


### PR DESCRIPTION
## Problema

Con Anthropic fuera de horario (provider-schedule), **todos los agentes caían a Codex, morían y no cascadeaban a Gemini** — el pipeline quedaba trabado y el Telegram Commander también.

Causa raíz: el CLI de Codex con **cuenta ChatGPT (OAuth)** reporta el cap rolling de uso como **texto libre, sin `error.type` estructurado**, en frames de control del CLI:

```json
{"type":"error","message":"You've hit your usage limit..."}
{"type":"turn.failed","error":{"message":"You've hit your usage limit..."}}
```

El detector `_detectOpenAI` solo matcheaba `error.type` estructurado → nunca clasificaba esto como cuota agotada → nunca se seteaba el flag → nunca cascadeaba al free tier. El agente moría en `turn.failed`.

## Solución

- **`_detectOpenAI`**: reconoce el usage-limit de Codex en los frames de control `turn.failed`/`error` vía regex acotado sobre `message`. Seguro porque esos frames son del **canal de control** del CLI (no inyectables por el modelo) — mismo criterio estructural que el glitch 1M de Anthropic. Solo se activa si el provider declara el error_type sintético `usage_limit_reached`.
- Nuevo error_type **`usage_limit_reached`** en la meta-allowlist de codex (`quota-exhausted.js`) y en `agent-models.json` (pasa la cross-validation del boot).
- **`setFlag`**: para `usage_limit_reached` sin `resets_at`, gatea por **ventana corta (1h, cap rolling)** en vez del fallback semanal — no desperdicia el fallback pago durante días. Auto-corrector e idempotente.
- **`provider-error-parser`**: patrón `hit your usage limit` en `CLI_QUOTA_PATTERNS` (cubre el path generalizado y la variante texto-plano en stderr).

Un solo cambio en el detector cubre **skills, commander y el path generalizado** porque todos pasan por `detectQuotaError`/`_detectOpenAI`.

## Verificación

- `detectQuotaError` matchea `turn.failed`/`error` con usage-limit → `usage_limit_reached`.
- **Anti-injection**: el mismo texto en el canal de contenido del modelo (`item.completed`/`agent_message`) **NO** matchea.
- Gate per-provider: codex gateado ✔, **gemini libre ✔** (cascada confirmada).
- `setFlag` sin resets_at usa ventana corta (1h), no el fallback semanal.
- Cross-validation del boot (`validateCrossReferences`) sin errores.
- **133/133 tests verdes** en las suites tocadas (quota-exhausted, provider-error-parser, onSpawnExit), 8 nuevos.

## Notas

- Requiere **merge a main + restart del pulpo** para tomar efecto (el pulpo corre desde `main`).
- El fix de `provider-schedule` (ventanas de inactividad de Anthropic) ya se aplicó al estado operativo vivo por separado (efecto inmediato, no requiere restart).
- QA: `qa:skipped` — cambio de infra/pipeline sin superficie de producto de usuario; validado con tests unitarios + repro contra los shapes reales del log del incidente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)