### PR TITLE
fix(pipeline): gate de markers resiliente para el dashboard + fin del freeze sync al servir logs (#4520 #4521)

### DIFF
--- a/.pipeline/dashboard.js
+++ b/.pipeline/dashboard.js
@@ -707,6 +707,22 @@ let _stateRefreshInflight = false;  // evita solapar cómputos pesados
 let _stateRefreshTimer = null;      // handle del setInterval (para clearInterval)
 let _loopMonitor = null;            // #4131-followup — handle del monitor de lag del event loop
 let _freezeWatchdog = null;         // #4131-followup-2 — handle del watchdog externo de freeze
+let _logServeInflight = false;      // #4521 — servido de logs en vuelo (lectura de disco)
+// #4521 — tope de bytes leídos del disco para el preview inicial del SSE de
+// logs. Cubre de sobra las últimas 1000 líneas de un log típico sin leer el
+// archivo entero (que en logs multi-MB clavaba el event loop varios segundos).
+const SSE_INIT_TAIL_BYTES = Number(process.env.DASHBOARD_SSE_INIT_TAIL_BYTES) || (512 * 1024);
+
+// #4521 — marca el servido de logs como en vuelo y lo PUBLICA sincrónicamente al
+// SAB del freeze-watchdog. La publicación inmediata es clave: el latido del
+// watchdog corre cada 200ms, pero una lectura de disco que se clave arranca y
+// congela el loop dentro del mismo tick, sin latido intermedio; sin publicar en
+// el acto, el freeze se reportaría como "ninguno-inflight". Best-effort: si el
+// watchdog aún no arrancó, sólo togglea el flag (lo tomará el próximo latido).
+function _markLogServe(on) {
+  _logServeInflight = on;
+  try { if (_freezeWatchdog && _freezeWatchdog.publishInflight) _freezeWatchdog.publishInflight(); } catch {}
+}
 // #4126 — cadencia configurable por env para que los tests puedan forzar un
 // worker casi-siempre-activo y verificar que /api/health no se cuelga.
 const STATE_REFRESH_MS = Number(process.env.DASHBOARD_STATE_REFRESH_MS) || 3000;
@@ -11534,20 +11550,28 @@ const server = http.createServer((req, res) => {
       // logs multi-MB (>4MB) en disco; leerlos enteros con readFileSync es un
       // vector de DoS por memoria. Servimos la cola capeada (config
       // logs_history.max_bytes_per_log) con un marcador si se truncó.
-      if (isPdf) {
-        res.end(fs.readFileSync(logPath));
-      } else {
-        let raw;
-        try {
-          const cap = (agentLogHistory && agentLogHistory.resolveRetentionConfig(
-            (loadConfig() || {}).logs_history)).max_bytes_per_log;
-          raw = agentLogHistory
-            ? agentLogHistory.readLogCapped(logPath, cap).text
-            : fs.readFileSync(logPath, 'utf8');
-        } catch {
-          raw = fs.readFileSync(logPath, 'utf8');
+      // #4521 — marcamos el servido como en vuelo: son lecturas de disco
+      // sincrónicas y, si una clava el loop, el freeze queda NOMBRADO (logServe)
+      // en el freeze-watchdog en vez de "operacion sync NO rastreada".
+      _markLogServe(true);
+      try {
+        if (isPdf) {
+          res.end(fs.readFileSync(logPath));
+        } else {
+          let raw;
+          try {
+            const cap = (agentLogHistory && agentLogHistory.resolveRetentionConfig(
+              (loadConfig() || {}).logs_history)).max_bytes_per_log;
+            raw = agentLogHistory
+              ? agentLogHistory.readLogCapped(logPath, cap).text
+              : fs.readFileSync(logPath, 'utf8');
+          } catch {
+            raw = fs.readFileSync(logPath, 'utf8');
+          }
+          res.end(redactLogText(raw));
         }
-        res.end(redactLogText(raw));
+      } finally {
+        _markLogServe(false);
       }
     } else {
       res.writeHead(404); res.end('Log no encontrado: ' + filename);
@@ -11576,8 +11600,24 @@ const server = http.createServer((req, res) => {
     // muestra logs heterogéneos que pueden contener AWS keys / JWT / tokens;
     // `_sanitizeLog` los redacta a `[REDACTED:...]`. Sin esto, los secrets
     // llegarían crudos al browser.
-    const content = fs.readFileSync(logPath, 'utf8');
-    const lines = content.split('\n');
+    // #4521 — leer sólo la COLA acotada, NO el archivo entero. Antes esto hacía
+    // fs.readFileSync(logPath,'utf8') del archivo COMPLETO (logs multi-MB) sólo
+    // para quedarse con las últimas 1000 líneas → clavaba el event loop varios
+    // segundos (freeze-watchdog: "operacion sync NO rastreada"). readLogCapped
+    // trae sólo los últimos SSE_INIT_TAIL_BYTES del disco; de ahí tomamos las
+    // últimas 1000 líneas. El flag logServe deja nombrado cualquier freeze.
+    _markLogServe(true);
+    let initialContent = '';
+    try {
+      initialContent = agentLogHistory
+        ? agentLogHistory.readLogCapped(logPath, SSE_INIT_TAIL_BYTES).text
+        : fs.readFileSync(logPath, 'utf8');
+    } catch {
+      initialContent = '';
+    } finally {
+      _markLogServe(false);
+    }
+    const lines = initialContent.split('\n');
     const initialLines = lines.slice(-1000).map(l => _sanitizeLog(l));
     res.write(`data: ${JSON.stringify({ type: 'init', lines: initialLines })}\n\n`);
 
@@ -13672,6 +13712,7 @@ function startListen() {
             if (_prInfoInflight) inflight.push('prInfo');
             if (_olaETARefreshInflight) inflight.push('olaETA');
             if (_titleRefreshInflight) inflight.push('titleRefresh');
+            if (_logServeInflight) inflight.push('logServe');
             const who = inflight.length ? inflight.join('+') : 'ninguno-inflight';
             log(`⚠️ event-loop STALL: lag pico ${lagMs}ms (mean ${meanMs}ms, p99 ${p99Ms}ms) — inflight: ${who}`);
           },
@@ -13697,6 +13738,7 @@ function startListen() {
             prInfo: _prInfoInflight,
             olaETA: _olaETARefreshInflight,
             titleRefresh: _titleRefreshInflight,
+            logServe: _logServeInflight,
           }),
           onLog: (line) => { try { log(line.replace(/^\[[^\]]+\]\s*/, '')); } catch {} },
         });

--- a/.pipeline/lib/freeze-watchdog-worker.js
+++ b/.pipeline/lib/freeze-watchdog-worker.js
@@ -24,6 +24,7 @@ const INFLIGHT_NAMES = [
   [4, 'prInfo'],
   [8, 'olaETA'],
   [16, 'titleRefresh'],
+  [32, 'logServe'],
 ];
 
 const { sab, thresholdMs, bumpMs, logDir } = workerData;

--- a/.pipeline/lib/freeze-watchdog.js
+++ b/.pipeline/lib/freeze-watchdog.js
@@ -45,6 +45,7 @@ const INFLIGHT_BITS = {
   prInfo: 4,
   olaETA: 8,
   titleRefresh: 16,
+  logServe: 32,
 };
 
 const DEFAULT_BUMP_MS = 200;        // cada cuánto late el main
@@ -105,6 +106,18 @@ function startFreezeWatchdog(opts = {}) {
   });
   worker.on('error', (e) => { try { onLog(`freeze-watchdog worker error: ${e && e.message ? e.message : e}`); } catch {} });
 
+  // Publicación SINCRÓNICA del bitmask al SAB (#4521). El latido corre cada
+  // `bumpMs` (200ms), pero una operación sync que se clava ARRANCA y CONGELA el
+  // loop dentro del mismo tick: ningún latido intermedio llega a capturar su
+  // flag, y el worker termina leyendo el mask del latido ANTERIOR (→ el freeze
+  // se reporta como "ninguno-inflight" aunque el flag esté en true en el main).
+  // publishInflight() escribe el mask al SAB en el acto, sin esperar al próximo
+  // latido, de modo que un handler que setea su flag y llama acá justo antes de
+  // la operación pesada queda NOMBRADO aunque congele el loop a continuación.
+  function publishInflight() {
+    try { Atomics.store(view, IDX_INFLIGHT, inflightMask()); } catch {}
+  }
+
   let stopped = false;
   function stop() {
     if (stopped) return;
@@ -113,7 +126,7 @@ function startFreezeWatchdog(opts = {}) {
     try { worker.terminate(); } catch {}
   }
 
-  return { stop };
+  return { stop, publishInflight };
 }
 
 module.exports = { startFreezeWatchdog, INFLIGHT_BITS, IDX_HEARTBEAT, IDX_INFLIGHT, SAB_INTS };

--- a/.pipeline/smoke-test.js
+++ b/.pipeline/smoke-test.js
@@ -31,6 +31,7 @@ const path = require('path');
 const http = require('http');
 const { spawnSync } = require('child_process');
 const { componentState, waitForMarkers } = require('./lib/ready-marker');
+const { isMarkerArtifact } = require('./lib/marker-artifact');
 
 const PIPELINE_DIR = __dirname;
 const LOG_FILE = path.join(PIPELINE_DIR, 'logs', 'smoke-test.log');
@@ -277,7 +278,8 @@ async function main() {
   const orphanDir = path.join(PIPELINE_DIR, 'servicios', 'commander', 'trabajando');
   try {
     if (fs.existsSync(orphanDir)) {
-      const orphans = fs.readdirSync(orphanDir).filter(f => f.endsWith('.json')).length;
+      // Excluir marker artifacts: no son mensajes operacionales huérfanos.
+      const orphans = fs.readdirSync(orphanDir).filter(f => f.endsWith('.json') && !isMarkerArtifact(f)).length;
       if (orphans > 0) {
         log(`  WARN ${orphans} mensaje(s) en commander/trabajando/ (esperado 0 post-restart)`);
       }

--- a/.pipeline/smoke-test.js
+++ b/.pipeline/smoke-test.js
@@ -151,6 +151,51 @@ async function checkDashboardHttpWithRetry(port, urlPath, { attempts = 5, perAtt
   return last;
 }
 
+// #4520 — Espera de markers con ventana DIFERENCIADA para el dashboard.
+//
+// El dashboard es el proceso más pesado y, bajo la contención del arranque
+// (pulpo + 7 servicios peleando CPU al mismo tiempo), su boot se estira más
+// allá de los 60s planos que a los componentes livianos les alcanzan de sobra
+// (ready en ~5-7s). #4130 hizo resiliente al pico de arranque SÓLO la sonda
+// HTTP (/api/health, gate B / exit 2) pero dejó este gate de markers (gate A /
+// exit 1) con 60s parejos → un dashboard sano-pero-lento gatillaba un rollback
+// espurio a pipeline-stable. Darle una ventana mayor NO relaja la detección: un
+// dashboard realmente caído sigue sin escribir marker tras dashTimeoutMs y el
+// gate lo detecta igual; sólo absorbe la contención, igual que el retry con
+// backoff de #4130 absorbe la del HTTP.
+//
+// `waitFn`/`now` son inyectables para test (por defecto: IO real de markers).
+async function waitForComponentMarkers(components, {
+  lightTimeoutMs = 60000,
+  dashTimeoutMs = 120000,
+  waitFn = waitForMarkers,
+  now = Date.now,
+} = {}) {
+  const start = now();
+  const hasDashboard = components.includes('dashboard');
+  const lightComponents = components.filter(n => n !== 'dashboard');
+
+  // 1a) Componentes livianos — timeout estándar.
+  const resLight = lightComponents.length
+    ? await waitFn(lightComponents, lightTimeoutMs, 1000)
+    : { ok: true, results: {} };
+
+  // 1b) Dashboard — ventana extendida. Ya venía booteando durante 1a, así que
+  // descontamos lo transcurrido para acotar el peor caso (dashboard caído) y no
+  // encadenar dos timeouts en serie.
+  let resDash = { ok: true, results: {} };
+  if (hasDashboard) {
+    const dashRemaining = Math.max(5000, dashTimeoutMs - (now() - start));
+    resDash = await waitFn(['dashboard'], dashRemaining, 1000);
+  }
+
+  return {
+    ok: resLight.ok && resDash.ok,
+    results: { ...resLight.results, ...resDash.results },
+    waitedMs: now() - start,
+  };
+}
+
 async function main() {
   const args = parseArgs(process.argv);
   const components = args.components || DEFAULT_COMPONENTS;
@@ -158,9 +203,14 @@ async function main() {
   log('=== SMOKE TEST ===');
   log(`Esperando marker ready de: ${components.join(', ')} (timeout ${args.timeoutMs / 1000}s)`);
 
-  // 1) Componentes listos — polling sobre los markers.
+  // 1) Componentes listos — polling sobre los markers, con ventana propia y más
+  // holgada para el dashboard (ver waitForComponentMarkers / #4520).
   const start = Date.now();
-  const res = await waitForMarkers(components, args.timeoutMs, 1000);
+  const dashTimeoutMs = parseInt(process.env.DASHBOARD_MARKER_TIMEOUT_MS || '120000', 10);
+  const res = await waitForComponentMarkers(components, {
+    lightTimeoutMs: args.timeoutMs,
+    dashTimeoutMs,
+  });
   const waitedSec = Math.round((Date.now() - start) / 1000);
 
   // Log del estado final componente por componente.
@@ -255,4 +305,4 @@ if (require.main === module) {
   });
 }
 
-module.exports = { checkDashboardHttp, checkDashboardHttpWithRetry };
+module.exports = { checkDashboardHttp, checkDashboardHttpWithRetry, waitForComponentMarkers };

--- a/.pipeline/tests/freeze-watchdog-logserve-4521.test.js
+++ b/.pipeline/tests/freeze-watchdog-logserve-4521.test.js
@@ -1,0 +1,73 @@
+// =============================================================================
+// freeze-watchdog-logserve-4521.test.js — el servido de logs queda NOMBRADO
+// en un freeze (#4521).
+//
+// Contexto: el freeze-watchdog captura el bitmask de operaciones en vuelo en
+// cada latido (200ms). Una lectura de disco sincrónica que se clava arranca y
+// congela el loop dentro del MISMO tick, sin latido intermedio → el freeze se
+// reportaba como "ninguno-inflight (operacion sync NO rastreada)". El fix expone
+// publishInflight(): publica el bitmask al SAB en el acto, de modo que un
+// handler que marca su flag justo antes de la operación pesada queda nombrado
+// aunque congele el loop a continuación.
+//
+// Cubre:
+//   1. El bit logServe existe y es distinto del resto (contrato main↔worker).
+//   2. Un freeze con logServe publicado sincrónicamente se registra NOMBRADO
+//      como "logServe" (no "ninguno-inflight").
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { startFreezeWatchdog, INFLIGHT_BITS } = require('../lib/freeze-watchdog.js');
+
+test('1 · logServe es un bit propio del bitmask inflight', () => {
+  assert.equal(INFLIGHT_BITS.logServe, 32, 'bit esperado 32 (sync con el worker)');
+  const bits = Object.values(INFLIGHT_BITS);
+  assert.equal(new Set(bits).size, bits.length, 'todos los bits son distintos');
+});
+
+// Bloqueo sincrónico del event loop (busy-wait): simula la lectura de disco que
+// clava el loop. No usa setTimeout porque eso cedería el loop.
+function freezeLoopFor(ms) {
+  const end = Date.now() + ms;
+  while (Date.now() < end) { /* spin: mantiene el loop clavado */ }
+}
+
+test('2 · un freeze con logServe publicado queda nombrado (no "ninguno-inflight")', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'fw-logserve-'));
+  const logFile = path.join(dir, 'freeze-watchdog.log');
+  let logServe = false;
+  const wd = startFreezeWatchdog({
+    logDir: dir,
+    thresholdMs: 300,
+    bumpMs: 50,
+    getInflight: () => ({ logServe }),
+  });
+  try {
+    // Dejar que el worker tome un baseline con logServe=false.
+    await new Promise(r => setTimeout(r, 150));
+
+    // Handler entra: marca el flag y lo PUBLICA sincrónicamente al SAB, luego
+    // "lee un log grande" que clava el loop por encima del umbral.
+    logServe = true;
+    wd.publishInflight();
+    freezeLoopFor(700);
+
+    // Ceder el loop para que el worker cierre el ciclo y escriba el evento.
+    await new Promise(r => setTimeout(r, 400));
+
+    const content = fs.existsSync(logFile) ? fs.readFileSync(logFile, 'utf8') : '';
+    assert.match(content, /FREEZE DETECTADO/, 'el worker detectó el freeze');
+    assert.match(content, /logServe/, 'el freeze quedó NOMBRADO como logServe');
+    assert.doesNotMatch(content, /operacion en vuelo al congelarse: ninguno-inflight/,
+      'no debe reportarse como "ninguno-inflight" habiendo publicado el flag');
+  } finally {
+    wd.stop();
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+  }
+});

--- a/.pipeline/tests/smoke-marker-gate-4520.test.js
+++ b/.pipeline/tests/smoke-marker-gate-4520.test.js
@@ -1,0 +1,87 @@
+// =============================================================================
+// smoke-marker-gate-4520.test.js — gate de markers con ventana diferenciada
+// para el dashboard (#4520).
+//
+// Contexto: tras un restart, el smoke test gatea el rollback esperando el
+// marker `.ready` de cada componente. Con 60s planos para los 8, el dashboard
+// (el proceso más pesado) no alcanzaba a escribir su marker bajo la contención
+// del arranque y disparaba un rollback espurio a pipeline-stable. #4130 hizo
+// resiliente sólo la sonda HTTP; este fix le da al MARKER del dashboard una
+// ventana mayor que a los componentes livianos.
+//
+// Cubre:
+//   1. El dashboard recibe una ventana mayor que los componentes livianos.
+//   2. Un dashboard sano-pero-lento (ready entre 60s y el nuevo umbral) → ok.
+//   3. Un dashboard realmente caído (nunca escribe marker) → !ok.
+//   4. Un componente liviano caído → !ok (no se relaja su detección).
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { waitForComponentMarkers } = require('../smoke-test.js');
+
+const COMPONENTS = [
+  'pulpo', 'listener', 'svc-telegram', 'svc-github',
+  'svc-drive', 'svc-emulador', 'svc-reconciler', 'dashboard',
+];
+
+const ready = (names) => ({
+  ok: true,
+  results: Object.fromEntries(names.map(n => [n, { state: 'ready', marker: { pid: 1, readyAt: new Date(0).toISOString() } }])),
+});
+const missing = (names) => ({
+  ok: false,
+  results: Object.fromEntries(names.map(n => [n, { state: 'missing', marker: null }])),
+});
+
+test('1 · el dashboard recibe una ventana mayor que los componentes livianos', async () => {
+  const calls = [];
+  const waitFn = async (names, timeoutMs) => { calls.push({ names, timeoutMs }); return ready(names); };
+  const r = await waitForComponentMarkers(COMPONENTS, {
+    lightTimeoutMs: 60000, dashTimeoutMs: 120000, waitFn, now: () => 0,
+  });
+  assert.equal(r.ok, true);
+  const light = calls.find(c => !c.names.includes('dashboard'));
+  const dash = calls.find(c => c.names.includes('dashboard') && c.names.length === 1);
+  assert.ok(light && dash, 'se esperó livianos y dashboard por separado');
+  assert.equal(light.timeoutMs, 60000, 'livianos: timeout estándar');
+  assert.ok(dash.timeoutMs > light.timeoutMs, 'dashboard: ventana mayor');
+  assert.ok(!light.names.includes('dashboard'), 'el dashboard no viaja con los livianos');
+});
+
+test('2 · dashboard sano-pero-lento (ready a los ~90s) → ok', async () => {
+  // Livianos ready al toque; dashboard sólo "ready" si le dan >60s de ventana.
+  const waitFn = async (names, timeoutMs) => {
+    if (names.length === 1 && names[0] === 'dashboard') {
+      return timeoutMs > 60000 ? ready(names) : missing(names);
+    }
+    return ready(names);
+  };
+  const r = await waitForComponentMarkers(COMPONENTS, {
+    lightTimeoutMs: 60000, dashTimeoutMs: 120000, waitFn, now: () => 0,
+  });
+  assert.equal(r.ok, true, 'con la ventana extendida el dashboard lento pasa');
+  assert.equal(r.results.dashboard.state, 'ready');
+});
+
+test('3 · dashboard realmente caído (nunca escribe marker) → !ok', async () => {
+  const waitFn = async (names) => (names.includes('dashboard') && names.length === 1)
+    ? missing(names) : ready(names);
+  const r = await waitForComponentMarkers(COMPONENTS, {
+    lightTimeoutMs: 60000, dashTimeoutMs: 120000, waitFn, now: () => 0,
+  });
+  assert.equal(r.ok, false, 'un dashboard caído sigue gateando el fail');
+  assert.equal(r.results.dashboard.state, 'missing');
+});
+
+test('4 · componente liviano caído → !ok (no se relaja su detección)', async () => {
+  const waitFn = async (names) => names.includes('svc-github')
+    ? { ok: false, results: { ...ready(names.filter(n => n !== 'svc-github')).results, 'svc-github': { state: 'missing', marker: null } } }
+    : ready(names);
+  const r = await waitForComponentMarkers(COMPONENTS, {
+    lightTimeoutMs: 60000, dashTimeoutMs: 120000, waitFn, now: () => 0,
+  });
+  assert.equal(r.ok, false, 'un liviano caído sigue gateando el fail');
+});


### PR DESCRIPTION
## Contexto

El smoke test post-restart de esta madrugada (2026-07-06 ~02:57–03:03) falló 2× (`exit 1`, `Componentes no-ready: dashboard`) y disparó un **rollback a `pipeline-stable`** (`rollback.log` 03:00). Los 7 componentes livianos quedaron ready en ~5-7s; sólo el dashboard no alcanzó a escribir su `.ready` en la ventana de 60s. Fue inocuo esta vez (`HEAD == pipeline-stable`), pero con cambios locales en `.pipeline/` sin taggear los habría descartado.

Esto ya se había trabajado (cadena #4097/#4127/#4128/#4130/#4131/#4132/#4133/#4310, todos en HEAD, nada revertido) pero el fix quedó **incompleto** en dos frentes.

## Fix A — gate de markers resiliente (#4520)

`#4130` hizo resiliente al pico de arranque **sólo la sonda HTTP** (`/api/health`, gate B / `exit 2`) pero dejó el **gate de markers** (`waitForMarkers`, gate A / `exit 1`) con **60s planos parejos**. La falla de esta noche fue `exit 1` — el gate A — prueba directa del hueco.

- `smoke-test.js`: nuevo `waitForComponentMarkers()` que le da al **dashboard** una ventana propia y más holgada (default 120s, `DASHBOARD_MARKER_TIMEOUT_MS`), separada de los 7 livianos (60s). No relaja la detección: un dashboard realmente caído sigue sin marker tras el umbral y falla igual.
- Test de regresión: rápido / lento-recupera / caído / liviano-caído.

## Fix B — fin del freeze sync al servir logs (#4521)

El `freeze-watchdog` (#4133) venía registrando **hasta hoy** freezes de 4-6s con `"operacion sync NO rastreada: revisar"`. Causa raíz identificada:

- **`/logs/stream/` (SSE), `dashboard.js`**: leía el archivo **entero** (`fs.readFileSync`, logs multi-MB) sólo para quedarse con las últimas 1000 líneas → clavaba el event loop varios segundos. Ahora lee sólo la **cola acotada** (`readLogCapped`, `SSE_INIT_TAIL_BYTES` = 512KB).
- **Instrumentación**: nuevo bit `logServe` + `publishInflight()` en el `freeze-watchdog`, que publica el bitmask al SAB de forma **sincrónica** (el latido de 200ms no alcanza a capturar una op que arranca y congela el loop en el mismo tick). Así cualquier freeze durante el servido de logs queda **NOMBRADO** en vez de `"ninguno-inflight"` — cierra el gap de diagnóstico de forma permanente.
- Los handlers de servido de logs (`/logs/` estático y SSE) marcan el flag.
- Test de integración: un freeze con `logServe` publicado se registra nombrado.

## Validación

- `node --test`: 9/9 verde (gate de markers 4/4, freeze-watchdog logServe 2/2, health-retry #4131 3/3).
- `node -c` OK en los 4 archivos tocados.
- Sin tests preexistentes dependientes del bitmask (ampliación segura).

## QA

`qa:skipped` — cambio de infra/pipeline interno (`.pipeline/`), sin impacto en el producto de usuario (app/backend). Cubierto por tests unitarios/integración.

Closes #4520
Closes #4521

🤖 Generated with [Claude Code](https://claude.com/claude-code)