### PR TITLE
fix(pipeline): stall detector timeout_no_new_bytes_30s saca a Anthropic en turnos largos con tool-use — subir a >=180s

### DIFF
--- a/.pipeline/lib/__tests__/commander-inflight-shadow.test.js
+++ b/.pipeline/lib/__tests__/commander-inflight-shadow.test.js
@@ -273,15 +273,30 @@ test('CA-A1 · first-byte NO se re-dispara (alreadyFired)', () => {
 // CA-A2 / R-1 — shouldFireStreamGap
 // =============================================================================
 
-test('CA-A2 · stream-gap dispara con 30s+ sin nuevos lines', () => {
+test('CA-A2 · stream-gap dispara con 180s+ sin nuevos lines (default #4530)', () => {
     assert.equal(
         detectors.shouldFireStreamGap({
             lastLineAt: 1_700_000_000_000,
-            now: 1_700_000_030_001,
+            now: 1_700_000_180_001, // 180.001s de silencio, sin tool-use in-flight
             pendingSkillCallsSize: 0,
+            pendingToolUseSize: 0,
             alreadyFired: false,
         }),
         true
+    );
+});
+
+test('CA-A2 · stream-gap NO dispara con 30s (umbral subió a 180s — #4530)', () => {
+    assert.equal(
+        detectors.shouldFireStreamGap({
+            lastLineAt: 1_700_000_000_000,
+            now: 1_700_000_030_001, // 30s: antes disparaba, ahora NO
+            pendingSkillCallsSize: 0,
+            pendingToolUseSize: 0,
+            alreadyFired: false,
+        }),
+        false,
+        '#4530: 30s de silencio ya no es señal de cuelgue'
     );
 });
 
@@ -289,12 +304,105 @@ test('CA-A2.b / R-1 / SR-S5 · stream-gap NO dispara si hay Skill in-flight', ()
     assert.equal(
         detectors.shouldFireStreamGap({
             lastLineAt: 1_700_000_000_000,
-            now: 1_700_000_060_000, // 60s gap, debería disparar
+            now: 1_700_000_200_000, // 200s gap, superaría el umbral
             pendingSkillCallsSize: 1, // pero hay Skill in-flight
+            pendingToolUseSize: 0,
             alreadyFired: false,
         }),
         false,
         'R-1: el SKILL_WATCHDOG_MS cubre Skills, stream-gap no debe duplicar señal'
+    );
+});
+
+// =============================================================================
+// #4530 — CA-2: pausar ante cualquier tool_use in-flight
+// =============================================================================
+
+test('#4530 CA-2 · gap 60-150s por tool-use NO dispara (silencio por herramienta larga)', () => {
+    // Turno legítimo: una herramienta (Bash/gradlew) corriendo 120s.
+    // Aunque el gap supere umbrales bajos, el tool_use pendiente lo pausa.
+    for (const gapMs of [60_000, 90_000, 120_000, 150_000]) {
+        assert.equal(
+            detectors.shouldFireStreamGap({
+                lastLineAt: 1_700_000_000_000,
+                now: 1_700_000_000_000 + gapMs,
+                pendingSkillCallsSize: 0,
+                pendingToolUseSize: 1, // herramienta ejecutándose
+                alreadyFired: false,
+            }),
+            false,
+            `gap de ${gapMs}ms con tool-use in-flight NO debe disparar fallback`
+        );
+    }
+});
+
+test('#4530 CA-2 · gap largo (300s) con tool-use in-flight NO dispara', () => {
+    // Cubre los casos de la evidencia 237s/300s que el solo umbral 180s no cubría.
+    assert.equal(
+        detectors.shouldFireStreamGap({
+            lastLineAt: 1_700_000_000_000,
+            now: 1_700_000_300_000, // 300s
+            pendingSkillCallsSize: 0,
+            pendingToolUseSize: 2,
+            alreadyFired: false,
+        }),
+        false
+    );
+});
+
+test('#4530 CA-2 · sin tool-use pendiente y gap > umbral SÍ dispara', () => {
+    // Silencio real sin ninguna herramienta corriendo → cuelgue legítimo.
+    assert.equal(
+        detectors.shouldFireStreamGap({
+            lastLineAt: 1_700_000_000_000,
+            now: 1_700_000_181_000,
+            pendingSkillCallsSize: 0,
+            pendingToolUseSize: 0,
+            alreadyFired: false,
+        }),
+        true
+    );
+});
+
+// =============================================================================
+// #4530 — CA-3: threshold configurable por env con clamp fail-closed
+// =============================================================================
+
+test('#4530 CA-3 · default 180s cuando el env está ausente o no es numérico', () => {
+    assert.equal(detectors.resolveStreamGapThresholdMs(undefined), 180 * 1000);
+    assert.equal(detectors.resolveStreamGapThresholdMs(''), 180 * 1000);
+    assert.equal(detectors.resolveStreamGapThresholdMs('abc'), 180 * 1000);
+    assert.equal(detectors.resolveStreamGapThresholdMs(null), 180 * 1000);
+});
+
+test('#4530 CA-3 · valor por debajo del piso se clampea a 180s (fail-closed)', () => {
+    assert.equal(detectors.resolveStreamGapThresholdMs('30000'), 180 * 1000);
+    assert.equal(detectors.resolveStreamGapThresholdMs(0), 180 * 1000);
+    assert.equal(detectors.resolveStreamGapThresholdMs(-5000), 180 * 1000);
+});
+
+test('#4530 CA-3 · valor por encima del techo se clampea a 600s', () => {
+    assert.equal(detectors.resolveStreamGapThresholdMs('9000000'), 600 * 1000);
+    assert.equal(detectors.resolveStreamGapThresholdMs(600001), 600 * 1000);
+});
+
+test('#4530 CA-3 · valor dentro del rango se respeta', () => {
+    assert.equal(detectors.resolveStreamGapThresholdMs('240000'), 240 * 1000);
+    assert.equal(detectors.resolveStreamGapThresholdMs(300000), 300 * 1000);
+});
+
+test('#4530 CA-3 · thresholdMs inyectado manda sobre el default', () => {
+    // Con umbral 300s, un gap de 200s (sin tool-use) NO dispara.
+    assert.equal(
+        detectors.shouldFireStreamGap({
+            lastLineAt: 1_700_000_000_000,
+            now: 1_700_000_200_000,
+            pendingSkillCallsSize: 0,
+            pendingToolUseSize: 0,
+            thresholdMs: 300 * 1000,
+            alreadyFired: false,
+        }),
+        false
     );
 });
 

--- a/.pipeline/lib/commander/inflight-shadow-detectors.js
+++ b/.pipeline/lib/commander/inflight-shadow-detectors.js
@@ -60,6 +60,11 @@ const ALLOWED_FIELDS = Object.freeze([
 
 const ERROR_CLASSES = Object.freeze([
     'timeout_first_byte',
+    // #4530 — el sufijo `_30s` es HISTÓRICO. El umbral por defecto ahora es
+    // 180s (ver STREAM_GAP_THRESHOLD_MS). El label se mantiene estable para no
+    // romper el análisis de logs/dashboards existentes que filtran por este
+    // string; el valor real del gap viaja en `primary_duration_ms`. No renombrar
+    // sin migración del histórico de `commander-dispatch-*.jsonl`.
     'timeout_no_new_bytes_30s',
     'eof_premature',
     'transient_5xx',
@@ -195,14 +200,53 @@ function detectTransient5xx(evt, options = {}) {
 //
 // Dispara solo si:
 //   - Ya se recibió el primer line (`lastLineAt > 0`).
-//   - Pasaron >= 30000ms desde el último line.
+//   - Pasaron >= thresholdMs desde el último line (default 180s — #4530).
 //   - NO hay Skill in-flight (R-1 / SR-S5 — pausar si `pendingSkillCallsSize > 0`).
+//   - NO hay NINGÚN tool_use in-flight (#4530 CA-2 — pausar si `pendingToolUseSize > 0`).
 //   - No se disparó antes en este turn (`alreadyFired === false`).
+//
+// #4530 — El umbral pasó de 30s a 180s. El 30s original confundía turnos
+// legítimos con tool-use largo (ej. Bash/gradlew de 120-300s) con un cuelgue:
+// entre el `tool_use` y su `tool_result` no llega ningún line nuevo, así que el
+// gap de 30s disparaba fallback innecesario y sacaba a Anthropic teniendo cuota.
+// Dos defensas complementarias:
+//   1. Umbral base 180s (cubre la mayoría de la evidencia: 118s-186s).
+//   2. Guard `pendingToolUseSize` (cubre también los 237s/300s): si hay CUALQUIER
+//      herramienta ejecutándose, el silencio de texto es esperado → no disparar.
 // -----------------------------------------------------------------------------
-const STREAM_GAP_THRESHOLD_MS = 30 * 1000;
+const STREAM_GAP_THRESHOLD_MS = 180 * 1000; // #4530 — antes 30s
+const STREAM_GAP_MIN_MS = 180 * 1000;       // #4530 — piso fail-closed (no aflojar por debajo)
+const STREAM_GAP_MAX_MS = 600 * 1000;       // #4530 — techo sano (= HARD_TIMEOUT 10min)
+
+// #4530 — Umbral del early-cascade NON-Anthropic (#3571). Se mantiene en 30s a
+// propósito: es otra feature (cascada temprana de providers de fallback frente
+// al kill duro de 600s) con su propia semántica y test. El bump a 180s aplica
+// SOLO al shadow detector del turno Anthropic del commander; el path
+// non-Anthropic conserva su agresividad histórica. `nonanthropic-stall-detect.js`
+// usa esta constante como default en vez de STREAM_GAP_THRESHOLD_MS.
+const NONANTH_STREAM_GAP_THRESHOLD_MS = 30 * 1000;
+
+// -----------------------------------------------------------------------------
+// #4530 CA-3 — resolveStreamGapThresholdMs
+//
+// Resuelve el umbral efectivo desde el env `COMMANDER_STREAM_GAP_MS`, con
+// semántica fail-closed y clamp:
+//   - Valor ausente/no numérico → default 180s (fail-closed: nunca más agresivo).
+//   - Valor < 180s → clampeado a 180s (no se permite reintroducir el gap agresivo).
+//   - Valor > 600s → clampeado a 600s (techo = HARD_TIMEOUT, evita gap inútil).
+// El env se lee inyectado (`rawEnv`) para que sea testeable sin tocar process.env.
+// -----------------------------------------------------------------------------
+function resolveStreamGapThresholdMs(rawEnv) {
+    const n = Number(rawEnv);
+    if (!Number.isFinite(n)) return STREAM_GAP_THRESHOLD_MS;
+    return Math.min(STREAM_GAP_MAX_MS, Math.max(STREAM_GAP_MIN_MS, n));
+}
 
 function shouldFireStreamGap(opts = {}) {
-    const { lastLineAt, now, pendingSkillCallsSize, alreadyFired, thresholdMs } = opts;
+    const {
+        lastLineAt, now, pendingSkillCallsSize, pendingToolUseSize,
+        alreadyFired, thresholdMs,
+    } = opts;
     if (alreadyFired) return false;
     if (!Number.isFinite(lastLineAt) || lastLineAt <= 0) return false;
     const _now = Number.isFinite(now) ? now : Date.now();
@@ -211,6 +255,11 @@ function shouldFireStreamGap(opts = {}) {
     // R-1 / SR-S5: pausar si hay Skill in-flight (el SKILL_WATCHDOG_MS=60s
     // cubre el caso con semántica propia).
     if (Number.isFinite(pendingSkillCallsSize) && pendingSkillCallsSize > 0) return false;
+    // #4530 CA-2: pausar si hay CUALQUIER tool_use in-flight. Entre el `tool_use`
+    // y su `tool_result` no llegan lines; una herramienta larga (Bash/gradlew)
+    // es actividad legítima, no un cuelgue. Generaliza el guard de Skills a
+    // cualquier herramienta pendiente.
+    if (Number.isFinite(pendingToolUseSize) && pendingToolUseSize > 0) return false;
     return true;
 }
 
@@ -269,6 +318,9 @@ module.exports = {
     TRANSIENT_5XX_ERROR_TYPES,
     FIRST_BYTE_THRESHOLD_MS,
     STREAM_GAP_THRESHOLD_MS,
+    STREAM_GAP_MIN_MS,
+    STREAM_GAP_MAX_MS,
+    NONANTH_STREAM_GAP_THRESHOLD_MS, // #4530 — early-cascade non-Anthropic (#3571)
 
     // Core
     buildInflightSignalEntry,
@@ -279,6 +331,7 @@ module.exports = {
     shouldFireFirstByte,
     shouldFireStreamGap,
     shouldFireEofPremature,
+    resolveStreamGapThresholdMs, // #4530 CA-3
 
     // Helpers
     auditFile,

--- a/.pipeline/lib/commander/nonanthropic-stall-detect.js
+++ b/.pipeline/lib/commander/nonanthropic-stall-detect.js
@@ -85,9 +85,13 @@ function createStallDetectors(opts = {}) {
     const _fbThreshold = Number.isFinite(firstByteThresholdMs)
         ? firstByteThresholdMs
         : inflightShadow.FIRST_BYTE_THRESHOLD_MS;
+    // #4530 — default 30s (NONANTH_STREAM_GAP_THRESHOLD_MS), NO el 180s del turno
+    // Anthropic. El early-cascade non-Anthropic conserva su agresividad histórica
+    // (#3571): cascadea rápido vs el kill duro de 600s. El bump de #4530 aplica
+    // sólo al shadow detector del commander Anthropic.
     const _sgThreshold = Number.isFinite(streamGapThresholdMs)
         ? streamGapThresholdMs
-        : inflightShadow.STREAM_GAP_THRESHOLD_MS;
+        : inflightShadow.NONANTH_STREAM_GAP_THRESHOLD_MS;
     const _pollMs = Number.isFinite(streamGapPollMs) ? streamGapPollMs : 5000;
 
     const _setTimeout = (timers && timers.setTimeout) || setTimeout;

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -10304,7 +10304,7 @@ function ejecutarClaude(prompt, textoOriginal, trace, fallbackParts) {
               },
               onStreamGap: () => {
                 clearTimeout(timer);
-                log('commander', `Provider ${res.provider} stream-gap >${Math.round(inflightShadow.STREAM_GAP_THRESHOLD_MS / 1000)}s — cascada temprana.`);
+                log('commander', `Provider ${res.provider} stream-gap >${Math.round(inflightShadow.NONANTH_STREAM_GAP_THRESHOLD_MS / 1000)}s — cascada temprana.`);
                 return advanceOrGiveUp(res.provider, 'timeout_no_new_bytes_30s');
               },
             });
@@ -10497,6 +10497,20 @@ function ejecutarClaude(prompt, textoOriginal, trace, fallbackParts) {
     const pendingSkillCalls = new Map(); // tool_use_id → { startedAt, skillName }
     let skillTimedOut = false; // flag que finish() expone al caller
     let skillTimedOutInfo = null; // { skillName, durationMs }
+
+    // #4530 CA-2 — tracker GENERAL de tool_use in-flight (cualquier herramienta,
+    // no solo Skills). Se agrega el `tool_use_id` cuando el assistant emite un
+    // `tool_use` y se elimina cuando llega el `tool_result` correspondiente.
+    // Sirve para pausar el stream-gap detector mientras una herramienta larga
+    // (Bash/gradlew de 120-300s) está corriendo: en ese tramo no llegan lines
+    // nuevos, pero es actividad legítima, no un cuelgue. NO tiene watchdog propio
+    // (el HARD_TIMEOUT de 10min sigue siendo el límite duro para tools no-Skill).
+    const pendingToolUses = new Set(); // tool_use_id
+    // #4530 CA-3 — umbral efectivo del stream-gap, resuelto una vez por turn
+    // desde el env con fail-closed 180s + clamp [180s, 600s].
+    const streamGapThresholdMs = inflightShadow.resolveStreamGapThresholdMs(
+        process.env.COMMANDER_STREAM_GAP_MS,
+    );
 
     // =============================================================================
     // #3577 — Detectores in-stream (parte 1/2 del split de #3472).
@@ -10770,6 +10784,9 @@ function ejecutarClaude(prompt, textoOriginal, trace, fallbackParts) {
             if (b.type === 'text' && b.text) lastText = b.text;
             if (b.type === 'tool_use') {
               toolCount++;
+              // #4530 CA-2 — registrar CUALQUIER tool_use in-flight para pausar
+              // el stream-gap detector mientras la herramienta corre.
+              if (typeof b.id === 'string' && b.id) pendingToolUses.add(b.id);
               lastToolDesc = b.input?.description || b.input?.command?.slice(0, 50) || b.name || '';
               log('commander', `  [tool ${toolCount}] ${b.name}: ${lastToolDesc.slice(0, 80)}`);
               // #3587 CA-1 — registrar el tool_use en el trace. Guardamos
@@ -10809,6 +10826,8 @@ function ejecutarClaude(prompt, textoOriginal, trace, fallbackParts) {
           const blocks = Array.isArray(evt.message.content) ? evt.message.content : [evt.message.content];
           for (const b of blocks) {
             if (b.type === 'tool_result' && b.tool_use_id) {
+              // #4530 CA-2 — la herramienta terminó: sacarla del tracker general.
+              pendingToolUses.delete(b.tool_use_id);
               // #3587 CA-1 — registrar TODOS los tool_result en el trace
               // (no solo los de Skill). El sanitizer del audit log se encarga
               // del redact + truncate. `content` puede ser string o array de
@@ -11045,9 +11064,11 @@ function ejecutarClaude(prompt, textoOriginal, trace, fallbackParts) {
       }
     }, inflightShadow.FIRST_BYTE_THRESHOLD_MS);
 
-    // #3577 CA-A2 / R-1 / SR-S5 — stream-gap detector (30s sin nuevos lines).
+    // #3577 CA-A2 / R-1 / SR-S5 — stream-gap detector (default 180s sin nuevos
+    // lines — #4530, antes 30s; configurable por COMMANDER_STREAM_GAP_MS).
     // Implementado con setInterval(5000), NO busy-wait. Pausado mientras hay
-    // Skill in-flight (el SKILL_WATCHDOG_MS=60s cubre Skills con semántica propia).
+    // Skill in-flight (el SKILL_WATCHDOG_MS=60s cubre Skills con semántica propia)
+    // o CUALQUIER tool_use in-flight (#4530 CA-2 — tools largas tipo Bash/gradlew).
     // Modo shadow: solo emite al audit.
     const streamGapShadowTimer = setInterval(() => {
       if (resolved) return;
@@ -11055,6 +11076,8 @@ function ejecutarClaude(prompt, textoOriginal, trace, fallbackParts) {
         lastLineAt,
         now: Date.now(),
         pendingSkillCallsSize: pendingSkillCalls.size,
+        pendingToolUseSize: pendingToolUses.size, // #4530 CA-2
+        thresholdMs: streamGapThresholdMs,        // #4530 CA-3 (env fail-closed 180s)
         alreadyFired: streamGapFired,
       })) {
         streamGapFired = true;

--- a/.pipeline/tests/pulpo-nonanthropic-early-detect.test.js
+++ b/.pipeline/tests/pulpo-nonanthropic-early-detect.test.js
@@ -88,7 +88,7 @@ test('runNonAnthropic cascadea si el stream stallea >30s tras un chunk parcial',
     stall.createStallDetectors({
         startTime,
         getLastChunkAt: () => chunkAt,
-        now: () => chunkAt + inflightShadow.STREAM_GAP_THRESHOLD_MS, // 30s tras el chunk
+        now: () => chunkAt + inflightShadow.NONANTH_STREAM_GAP_THRESHOLD_MS, // 30s tras el chunk
         killProc: () => calls.push(['kill']),
         onFirstByte: () => calls.push(['firstByte']),
         onStreamGap: () => calls.push(['streamGap']),
@@ -137,7 +137,10 @@ test('runNonAnthropic no cascadea dos veces cuando close llega tras el kill temp
 // -----------------------------------------------------------------------------
 test('los thresholds provienen de inflightShadow (15s/30s), no se inventan valores', () => {
     assert.equal(inflightShadow.FIRST_BYTE_THRESHOLD_MS, 15 * 1000);
-    assert.equal(inflightShadow.STREAM_GAP_THRESHOLD_MS, 30 * 1000);
+    // #4530 — el early-cascade non-Anthropic conserva 30s vía la constante
+    // dedicada NONANTH_STREAM_GAP_THRESHOLD_MS. STREAM_GAP_THRESHOLD_MS (turno
+    // Anthropic) subió a 180s y ya no aplica a esta rama.
+    assert.equal(inflightShadow.NONANTH_STREAM_GAP_THRESHOLD_MS, 30 * 1000);
 
     const ft = makeFakeTimers();
     stall.createStallDetectors({
@@ -181,7 +184,7 @@ test('los timers de deteccion temprana se limpian por stream-gap', () => {
     stall.createStallDetectors({
         startTime,
         getLastChunkAt: () => chunkAt,
-        now: () => chunkAt + inflightShadow.STREAM_GAP_THRESHOLD_MS,
+        now: () => chunkAt + inflightShadow.NONANTH_STREAM_GAP_THRESHOLD_MS,
         killProc: () => {},
         onFirstByte: () => {},
         onStreamGap: () => {},


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 5 archivos · +204 -13

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:skipped` aplicado por delivery

## Closes

Closes #4530
