### PR TITLE
Aprobación · PO debe entregar SIEMPRE el veredicto de aceptación

### DIFF
--- a/.claude/skills/po/SKILL.md
+++ b/.claude/skills/po/SKILL.md
@@ -945,4 +945,33 @@ const fase = process.env.PIPELINE_FASE || "criterios";
 writeDeliverable("po", issue, { fase, md /* o svg para mockups/diagramas */ });
 ```
 
-El enforcement es **warn-only**: no generar el archivo no bloquea el pipeline, pero cuenta para la cobertura ≥80% de la ola (CA-4).
+### Obligatorio en fase `aprobacion`: veredicto de aceptación (#4515)
+
+Si `fase === "aprobacion"`, el entregable **no es opcional**. Después de determinar
+el dictamen en RV5, SIEMPRE persistí el veredicto con:
+
+```js
+const path = require("path");
+const { writeDeliverable } = require(path.resolve(".pipeline/lib/write-deliverable"));
+const fase = process.env.PIPELINE_FASE || "aprobacion";
+
+// OBLIGATORIO en aprobacion: veredicto o excepción explícita, nunca silencio.
+const md = veredictoMarkdown;
+writeDeliverable("po", issue, { fase, md });
+```
+
+El `md` del veredicto debe contener, como mínimo:
+
+- Primera línea escaneable con el dictamen final: `✅ aceptado` o `❌ rechazado`.
+- Cada criterio de aceptación uno por uno, con estado y evidencia de QA asociada.
+- Sección **Brechas** cuando el dictamen sea rechazado, con gaps concretos.
+- Sección **Alcance evaluado** con issue, fase, artefactos QA revisados y límites de la evaluación.
+
+Si por la naturaleza del issue el veredicto-entregable no aplica, igual llamá
+`writeDeliverable("po", issue, { fase: "aprobacion", md })` con un bloque destacado
+que registre el motivo de la excepción. En `aprobacion`, cerrar sin archivo y sin
+motivo explícito es incumplimiento del contrato de fase.
+
+Para fases distintas de `aprobacion`, el enforcement sigue siendo **warn-only**: no
+generar el archivo no bloquea el pipeline, pero cuenta para la cobertura ≥80% de la
+ola (CA-4).

--- a/.pipeline/lib/__tests__/skill-deliverable-attachments.test.js
+++ b/.pipeline/lib/__tests__/skill-deliverable-attachments.test.js
@@ -505,6 +505,22 @@ test('#4255 — collector devuelve fase inferida del filename phase-scoped', () 
     }
 });
 
+test('#4515 — collector devuelve el veredicto PO de aprobacion como document enviable', () => {
+    const tmp = mkTmpRoot();
+    try {
+        writeFile(tmp.root, '.pipeline/assets/docs/4515/po-aprobacion-4515.md', '# ✅ aceptado\n\n## Alcance evaluado\n- Issue 4515');
+        const res = helper.collectAttachmentsForSkill('po', 4515, 'aprobacion', { pipelineRoot: tmp.root });
+
+        assert.equal(res.length, 1);
+        assert.equal(res[0].type, 'document');
+        assert.equal(res[0].fase, 'aprobacion');
+        assert.equal(res[0].descriptor, 'criterios');
+        assert.ok(res[0].path.endsWith('po-aprobacion-4515.md'), res[0].path);
+    } finally {
+        tmp.cleanup();
+    }
+});
+
 test('#4255 — manifest tiene prioridad sobre la inferencia del filename', () => {
     const tmp = mkTmpRoot();
     try {

--- a/.pipeline/lib/write-deliverable.test.js
+++ b/.pipeline/lib/write-deliverable.test.js
@@ -241,6 +241,41 @@ test('writeDeliverable con fase escribe <skill>-<fase>-<issue>.ext y actualiza e
     assert.ok(!path.isAbsolute(read.entries[0].path), 'el índice guarda path relativo');
 });
 
+test('#4515 · PO en aprobacion persiste veredicto phase-scoped e indexado como documento', () => {
+    const root = tmpRoot();
+    const md = [
+        '# ✅ aceptado',
+        '',
+        '## Criterios',
+        '- [x] CA-1 persistencia: evidencia QA revisada.',
+        '',
+        '## Alcance evaluado',
+        '- Issue: 4515',
+    ].join('\n');
+
+    const res = writeDeliverable('po', '4515', {
+        md,
+        fase: 'aprobacion',
+        timestamp: '2026-07-07T10:00:00.000Z',
+        pipelineRoot: root,
+    });
+
+    assert.ok(
+        res.path.replace(/\\/g, '/').endsWith('.pipeline/assets/docs/4515/po-aprobacion-4515.md'),
+        res.path,
+    );
+    assert.equal(res.indexed, true);
+    assert.equal(res.fase, 'aprobacion');
+    assert.equal(fs.readFileSync(res.path, 'utf8'), md);
+
+    const read = deliverableIndex.readDeliverableIndex('4515', { pipelineRoot: root });
+    assert.equal(read.entries.length, 1);
+    assert.equal(read.entries[0].agente, 'po');
+    assert.equal(read.entries[0].fase, 'aprobacion');
+    assert.equal(read.entries[0].tipo, 'document');
+    assert.ok(read.entries[0].path.endsWith('po-aprobacion-4515.md'), read.entries[0].path);
+});
+
 test('writeDeliverable multi-fase del mismo agente NO colisiona en disco ni en el índice', () => {
     const root = tmpRoot();
     const ts = '2026-07-01T10:00:00.000Z';

--- a/.pipeline/lib/write-deliverable.test.js
+++ b/.pipeline/lib/write-deliverable.test.js
@@ -268,7 +268,7 @@ test('#4515 · PO en aprobacion persiste veredicto phase-scoped e indexado como 
     assert.equal(res.fase, 'aprobacion');
     assert.equal(fs.readFileSync(res.path, 'utf8'), md);
 
-    const read = deliverableIndex.readDeliverableIndex('4515', { pipelineRoot: root });
+    const read = deliverableIndex.readDeliverableIndex('4515', { pipelineRoot: pipelineDirOf(root) });
     assert.equal(read.entries.length, 1);
     assert.equal(read.entries[0].agente, 'po');
     assert.equal(read.entries[0].fase, 'aprobacion');


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 3 archivos · +81 -1

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:passed` aplicado por delivery

## Closes

Closes #4515
