### PR TITLE
Dashboard: rediseñar 'Estado del sistema + Cuotas' — cuota por proveedor × ventana + fix 'resetea · reseteó' (#4533)

### DIFF
--- a/.pipeline/lib/__tests__/quota-adapters/slice-normalize.test.js
+++ b/.pipeline/lib/__tests__/quota-adapters/slice-normalize.test.js
@@ -145,6 +145,15 @@ test('CA-5: quotaSlice mantiene el % agregado top-level tras el desglose', () =>
     assert.ok('status' in out.session, 'session top-level conserva shape rico');
     // Y el desglose normalizado coexiste.
     assert.ok(out.providers.anthropic.session, 'desglose normalizado presente');
-    assert.equal(Object.keys(out.providers.anthropic.session).sort().join(','),
-        'confidence,pct', 'desglose es el shape minimal');
+    // #4533 — el desglose se enriquece con available%, reset propio por bucket,
+    // rótulo de ventana y modo de render. Contrato de exposición mínima
+    // (security req#5): SOLO estos campos derivados/labels, NUNCA tokens crudos,
+    // cost_usd, secretos ni rutas de snapshot.
+    const ALLOWED_KEYS = ['available', 'confidence', 'kind', 'mode', 'pct', 'resetAt', 'win'];
+    const gotKeys = Object.keys(out.providers.anthropic.session).sort();
+    assert.deepEqual(gotKeys, ALLOWED_KEYS, 'desglose expone solo el shape enriquecido permitido');
+    for (const forbidden of ['cost_usd', 'tokens_in', 'tokens_out', 'snapshotPath', 'apiKey', 'key']) {
+        assert.ok(!(forbidden in out.providers.anthropic.session),
+            `el desglose NO debe exponer ${forbidden}`);
+    }
 });

--- a/.pipeline/lib/dashboard-slices.js
+++ b/.pipeline/lib/dashboard-slices.js
@@ -65,6 +65,13 @@ try { providerQuotaGuard = require('./provider-quota-guard'); } catch { /* opcio
 let pacingBucket = null;
 try { pacingBucket = require('./pacing-bucket'); } catch { /* opcional */ }
 
+// #4533 — Agregador de cuota DISPONIBLE por proveedor × ventana. Enriquece el
+// sub-shape normalizado con available%, reset propio por bucket, rótulo de
+// ventana y modo de render (gauge/event/nodata). Tolerante a la ausencia del
+// módulo: si no carga, el slice degrada al shape previo sin romper.
+let providerQuotaAgg = null;
+try { providerQuotaAgg = require('./provider-quota'); } catch { /* opcional */ }
+
 // #2976 — Skills determinísticos: corren en Node puro sin tokens LLM y por
 // eso siguen ejecutándose aún con `quota-exhausted.json` activo. Mantener
 // sincronizado con `DETERMINISTIC_SKILLS` del detector (#2974,
@@ -2412,8 +2419,22 @@ function quotaSlice(state, ctx) {
     // así el flat-merge de Anthropic al top-level (out.session/realPct/pct)
     // queda intacto (CA-5).
     const providersClient = {};
+    // #4533 — cache de muestras reales (headers/eventos) por proveedor+bucket,
+    // leída una vez por poll. Best-effort: si el módulo no está o falla, el
+    // enrich degrada a "sin dato" sin romper el slice.
+    let quotaCache = {};
+    if (providerQuotaAgg && typeof providerQuotaAgg.readCache === 'function') {
+        try { quotaCache = providerQuotaAgg.readCache(PIPELINE) || {}; } catch { quotaCache = {}; }
+    }
+    const nowMs = Date.now();
     for (const [p, result] of Object.entries(providers)) {
-        providersClient[p] = normalizeProviderQuota(p, result);
+        const normalized = normalizeProviderQuota(p, result);
+        // #4533 — agrega available%, reset propio por bucket, ventana y modo.
+        if (providerQuotaAgg && typeof providerQuotaAgg.enrich === 'function') {
+            try { providerQuotaAgg.enrich(p, normalized, result, { cache: quotaCache, now: nowMs }); }
+            catch { /* fail-safe: el enrich nunca tumba el slice de cuota */ }
+        }
+        providersClient[p] = normalized;
     }
     out.providers = providersClient;
 

--- a/.pipeline/lib/provider-quota.js
+++ b/.pipeline/lib/provider-quota.js
@@ -1,0 +1,251 @@
+// =============================================================================
+// provider-quota.js — Agregador de cuota DISPONIBLE por proveedor × ventana
+// (#4533).
+//
+// Motivación (issue #4533):
+//   El panel "Estado del sistema + Cuotas" del home MIZPÁ debe mostrar la cuota
+//   DISPONIBLE (no consumida) por CADA proveedor y por CADA ventana (corta /
+//   larga), leída de la fuente fidedigna del propio proveedor, con su PROPIO
+//   reset por bucket (no uno global compartido).
+//
+// Este módulo NO hace requests HTTP (los adapters son offline por diseño,
+// security CA-#6 de #3092). Deriva la cuota disponible del `QuotaResult` que
+// ya computan los adapters (`lib/quota-adapters/*`) y expone un "seam" para que
+// la capa de dispatch multi-provider — que SÍ ve las respuestas HTTP — cachee
+// el último `{remaining, limit, resetAt}` real por proveedor+bucket (headers
+// `x-ratelimit-*`, evento `usage-limit`, metadatos `QuotaFailure`) sin llamadas
+// extra. Mientras esa captura no exista para un proveedor, la celda cae a
+// "sin dato" explícito en vez de una estimación nuestra (CA #4533).
+//
+// Contrato de exposición mínima (security req#5 de #4202): por proveedor+bucket
+// SOLO viaja `{ pct, confidence, available, resetAt, win, kind, mode }`. NUNCA
+// tokens crudos, cost_usd, secretos ni rutas de snapshot.
+// =============================================================================
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+// Metadata de ventanas por proveedor — FUENTE ÚNICA de los rótulos de ventana
+// (CA #4533: "cada celda rotula su ventana real"). El front NO hardcodea los
+// labels: los recibe del slice.
+//
+//   - kind: 'short' (ventana corta) | 'long' (ventana larga). Mapea a los
+//     buckets del slice: short ↔ session, long ↔ weekly.
+//   - mode: 'gauge' (barra con % disponible) | 'event' (estado por eventos,
+//     e.g. Codex "sin límite" hasta que salta un usage-limit).
+const PROVIDER_WINDOWS = Object.freeze({
+    'anthropic':     { short: { win: '5h',  kind: 'short' }, long: { win: 'Sem', kind: 'long' }, mode: 'gauge' },
+    'openai-codex':  { short: { win: 'Roll', kind: 'short' }, long: { win: 'Sem', kind: 'long' }, mode: 'event' },
+    'gemini-google': { short: { win: 'Min', kind: 'short' }, long: { win: 'Día', kind: 'long' }, mode: 'gauge' },
+    'cerebras':      { short: { win: 'Min', kind: 'short' }, long: { win: 'Día', kind: 'long' }, mode: 'gauge' },
+    'nvidia-nim':    { short: { win: 'Min', kind: 'short' }, long: { win: 'Día', kind: 'long' }, mode: 'gauge' },
+});
+
+const DEFAULT_WINDOW = Object.freeze({
+    short: { win: 'Min', kind: 'short' },
+    long:  { win: 'Día', kind: 'long' },
+    mode:  'gauge',
+});
+
+// TTL de una muestra cacheada (headers/eventos) antes de tratarla como stale.
+// Una muestra más vieja que esto NO se usa como dato fresco: la celda cae a
+// "sin dato" (evita mostrar cuota fantasma de hace horas como si fuera real).
+const CACHE_TTL_MS = 15 * 60 * 1000; // 15 min
+
+function _cachePath(pipelineDir) {
+    return path.join(pipelineDir || '.', 'state', 'provider-quota.json');
+}
+
+// clamp 0..100 defensivo. Devuelve null si el input no es número finito.
+function _clampPct(v) {
+    if (typeof v !== 'number' || !Number.isFinite(v)) return null;
+    if (v < 0) return 0;
+    if (v > 100) return 100;
+    return v;
+}
+
+// consumido% -> disponible% (clamp). CA #4533: fórmula `disponible = 100 - consumido`.
+function _availableFromConsumed(consumedPct) {
+    const c = _clampPct(consumedPct);
+    if (c == null) return null;
+    return _clampPct(100 - c);
+}
+
+// Lee el `resetAt` (ISO) del bucket correspondiente desde el QuotaResult del
+// adapter. Cada proveedor tiene su propio campo/semántica (CA #4533: reset
+// independiente por proveedor y ventana):
+//   - Anthropic: sessionResetsAt (5h) / weeklyResetsAtReported (semanal).
+//   - Resto (cuando el adapter lo provea): nextResetAt.
+function _resetAtFor(provider, bucketKind, adapterResult) {
+    if (!adapterResult || typeof adapterResult !== 'object') return null;
+    const iso = (v) => (typeof v === 'string' && v.length > 0 ? v : null);
+    if (provider === 'anthropic') {
+        return bucketKind === 'short'
+            ? iso(adapterResult.sessionResetsAt)
+            : iso(adapterResult.weeklyResetsAtReported);
+    }
+    return iso(adapterResult.nextResetAt);
+}
+
+/**
+ * Lee la caché de muestras reales por proveedor+bucket. Best-effort: si el
+ * archivo no existe o está corrupto, devuelve {}. NUNCA lanza.
+ *
+ * Shape: { "<provider>": { "<bucketKind>": { available, resetAt, capturedAt } } }
+ *
+ * @param {string} pipelineDir
+ * @returns {Object}
+ */
+function readCache(pipelineDir) {
+    try {
+        const raw = fs.readFileSync(_cachePath(pipelineDir), 'utf8');
+        const parsed = JSON.parse(raw);
+        return (parsed && typeof parsed === 'object') ? parsed : {};
+    } catch {
+        return {};
+    }
+}
+
+/**
+ * Seam para la capa de dispatch multi-provider: cachea la última muestra real
+ * `{remaining, limit, resetAt}` por proveedor+bucket (headers `x-ratelimit-*`,
+ * evento `usage-limit`, `QuotaFailure`). Idempotente y fail-secure: si algo
+ * falla, no rompe el dispatch (best-effort). Escribe atómicamente (tmp+rename).
+ *
+ * @param {Object} sample { provider, bucketKind ('short'|'long'), remaining,
+ *                          limit, resetAt (ISO|null), now (ms), pipelineDir }
+ * @returns {boolean} true si persistió
+ */
+function recordSample(sample) {
+    try {
+        const s = sample || {};
+        const provider = s.provider;
+        const bucketKind = s.bucketKind === 'long' ? 'long' : 'short';
+        if (typeof provider !== 'string' || provider.length === 0) return false;
+        const remaining = Number(s.remaining);
+        const limit = Number(s.limit);
+        if (!Number.isFinite(remaining) || !Number.isFinite(limit) || limit <= 0) return false;
+        const available = _clampPct(100 * (remaining / limit));
+        const now = Number.isFinite(s.now) ? s.now : Date.now();
+        const pipelineDir = s.pipelineDir || '.';
+
+        const cache = readCache(pipelineDir);
+        if (!cache[provider] || typeof cache[provider] !== 'object') cache[provider] = {};
+        cache[provider][bucketKind] = {
+            available,
+            resetAt: (typeof s.resetAt === 'string' && s.resetAt.length > 0) ? s.resetAt : null,
+            capturedAt: now,
+        };
+
+        const file = _cachePath(pipelineDir);
+        fs.mkdirSync(path.dirname(file), { recursive: true });
+        const tmp = file + '.tmp';
+        fs.writeFileSync(tmp, JSON.stringify(cache, null, 2));
+        fs.renameSync(tmp, file);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+// Devuelve la muestra cacheada fresca para provider+bucket, o null si no hay o
+// está stale (más vieja que CACHE_TTL_MS).
+function _freshCacheSample(cache, provider, bucketKind, now) {
+    const perProvider = cache && cache[provider];
+    const sample = perProvider && perProvider[bucketKind];
+    if (!sample || typeof sample !== 'object') return null;
+    const capturedAt = Number(sample.capturedAt);
+    if (!Number.isFinite(capturedAt)) return null;
+    if ((now - capturedAt) > CACHE_TTL_MS) return null;
+    return sample;
+}
+
+/**
+ * Enriquece el sub-shape normalizado de cliente (`{ pct, confidence }` por
+ * bucket) con la cuota DISPONIBLE, el reset propio, el rótulo de ventana y el
+ * modo de render. Muta y devuelve el mismo objeto `normalized` (in-place) para
+ * encajar sin fricción en el loop de `quotaSlice`.
+ *
+ * Prioridad de la fuente de cada bucket:
+ *   1. Muestra real cacheada y fresca (headers/eventos) — confianza 'fresh'.
+ *   2. QuotaResult del adapter (Anthropic real / Codex evento) — deriva
+ *      available de `pct` consumido.
+ *   3. Sin ninguna de las dos → mode 'nodata' (celda "sin dato" explícita).
+ *
+ * @param {string} provider
+ * @param {Object} normalized  { provider, adapterStatus, session:{pct,confidence}, weekly:{pct,confidence} }
+ * @param {Object} adapterResult  QuotaResult crudo del adapter (para reset/estado)
+ * @param {Object} [opts] { cache, now }
+ * @returns {Object} el mismo `normalized`, enriquecido
+ */
+function enrich(provider, normalized, adapterResult, opts) {
+    if (!normalized || typeof normalized !== 'object') return normalized;
+    const meta = PROVIDER_WINDOWS[provider] || DEFAULT_WINDOW;
+    const now = (opts && Number.isFinite(opts.now)) ? opts.now : Date.now();
+    const cache = (opts && opts.cache) || {};
+
+    // bucketKey = clave del sub-shape en `normalized`; bucketMeta = ventana.
+    const buckets = [
+        { key: 'session', meta: meta.short },
+        { key: 'weekly',  meta: meta.long },
+    ];
+
+    for (const { key, meta: bmeta } of buckets) {
+        const sub = normalized[key] && typeof normalized[key] === 'object'
+            ? normalized[key]
+            : (normalized[key] = { pct: null, confidence: 'missing' });
+
+        sub.win = bmeta.win;
+        sub.kind = bmeta.kind;
+
+        // 1. Muestra real cacheada (seam de headers/eventos).
+        const cached = _freshCacheSample(cache, provider, bmeta.kind, now);
+        if (cached && cached.available != null) {
+            sub.available = _clampPct(cached.available);
+            sub.resetAt = cached.resetAt || _resetAtFor(provider, bmeta.kind, adapterResult);
+            sub.confidence = 'fresh';
+            sub.mode = 'gauge';
+            continue;
+        }
+
+        // 2. Codex y otros proveedores por eventos: no hay barra, hay estado.
+        if (meta.mode === 'event') {
+            sub.mode = 'event';
+            sub.available = null;
+            sub.resetAt = _resetAtFor(provider, bmeta.kind, adapterResult);
+            // "sin límite" salvo que el adapter reporte un tope activo.
+            const st = adapterResult && adapterResult.adapterStatus;
+            const q = adapterResult && adapterResult.status;
+            sub.eventOk = !(st === 'error' || q === 'critical');
+            continue;
+        }
+
+        // 3. Dato del adapter (available derivado del consumido).
+        const available = _availableFromConsumed(sub.pct);
+        if (available != null) {
+            sub.available = available;
+            sub.resetAt = _resetAtFor(provider, bmeta.kind, adapterResult);
+            sub.mode = 'gauge';
+            continue;
+        }
+
+        // 4. Sin dato confiable → celda explícita "sin dato" (no estimamos).
+        sub.available = null;
+        sub.resetAt = null;
+        sub.mode = 'nodata';
+    }
+
+    return normalized;
+}
+
+module.exports = {
+    PROVIDER_WINDOWS,
+    CACHE_TTL_MS,
+    enrich,
+    readCache,
+    recordSample,
+    // exportados para test
+    _availableFromConsumed,
+    _resetAtFor,
+};

--- a/.pipeline/lib/quota-adapters/index.js
+++ b/.pipeline/lib/quota-adapters/index.js
@@ -41,11 +41,15 @@ const { ADAPTER_STATUS, emptyResult } = require('./_shape');
 //
 // #3353 (mayo 2026) — Groq fue descontinuado por política de bloqueos
 // arbitrarios. El adapter standalone y la entrada del switch se removieron.
+// #4533 — `nvidia-nim` se suma a la allowlist. API drop-in OpenAI-compatible
+// (headers `x-ratelimit-*`, idéntico a Cerebras). Adapter stub por ahora; la
+// cuota real se hidrata desde headers vía provider-quota.recordSample.
 const ALLOWED_PROVIDERS = Object.freeze([
     'anthropic',
     'openai-codex',
     'gemini-google',
     'cerebras',
+    'nvidia-nim',
     'ollama',
     'deterministic',
 ]);
@@ -63,6 +67,7 @@ function getAdapter(provider) {
         case 'openai-codex':    return require('./openai-codex');
         case 'gemini-google':   return require('./gemini-google');
         case 'cerebras':        return require('./cerebras');
+        case 'nvidia-nim':      return require('./nvidia-nim');
         case 'ollama':          return require('./ollama');
         case 'deterministic':   return require('./deterministic');
         default:                return null; // unreachable — la allowlist ya filtró.

--- a/.pipeline/lib/quota-adapters/nvidia-nim.js
+++ b/.pipeline/lib/quota-adapters/nvidia-nim.js
@@ -1,0 +1,26 @@
+// =============================================================================
+// quota-adapters/nvidia-nim.js — Stub para NVIDIA NIM (#4533).
+//
+// NVIDIA NIM expone endpoints OpenAI-compatible con límites por minuto y por
+// día, y devuelve los headers `x-ratelimit-remaining` / `x-ratelimit-limit` /
+// `x-ratelimit-reset` en cada respuesta (idéntico patrón a Cerebras). El
+// cálculo de cuota real (available% + reset por ventana) se hidrata desde esos
+// headers vía el seam `provider-quota.recordSample()` que puebla la capa de
+// dispatch multi-provider — NO desde este adapter offline (security CA-#6 de
+// #3092: los adapters no hacen requests HTTP).
+//
+// Mientras la captura de headers no esté conectada para NVIDIA, el adapter
+// devuelve `not_implemented` con `pct: null` para que la celda del dashboard
+// caiga a "sin dato" explícito en vez de mostrar luz verde silenciosa
+// (security req#4). Esto NO significa "cuota agotada".
+// =============================================================================
+'use strict';
+
+const { ADAPTER_STATUS, emptyResult } = require('./_shape');
+
+function nvidiaNimAdapter(_sessionData) {
+    return emptyResult('nvidia-nim', ADAPTER_STATUS.NOT_IMPLEMENTED,
+        'Cuota NVIDIA NIM: se hidrata desde headers x-ratelimit-* vía provider-quota.recordSample (#4533).');
+}
+
+module.exports = nvidiaNimAdapter;

--- a/.pipeline/tests/home-mz-provider-rows-4249.test.js
+++ b/.pipeline/tests/home-mz-provider-rows-4249.test.js
@@ -1,26 +1,27 @@
 'use strict';
 
-// #4249 — Bloque A: desglose de cuota POR PROVEEDOR en la home MIZPÁ.
-//
-// Contexto: el % real por proveedor depende del backend de extracción #4202
-// (OPEN); hasta entonces las filas muestran "—" por diseño. Lo entregable AHORA
-// (independiente de #4202) es la lista correcta de proveedores, derivada de una
-// fuente única, con ids canónicos para hidratación futura y escapado seguro.
+// #4249 + #4533 — Matriz de cuota DISPONIBLE por proveedor × ventana en la home
+// MIZPÁ. El % real por proveedor lo hidrata el slice `/api/dash/quota`; el SSR
+// entrega el skeleton correcto: una fila por proveedor activo, cada una con dos
+// celdas de ventana (corta/larga) e ids canónicos para hidratación.
 //
 // Cubre:
 //   * CA-A1 — aparece una fila por cada proveedor activo (≥5); NO aparece Groq.
 //   * CA-A2 — la lista se deriva de una fuente única (MZ_PROVIDER_META), no de
 //             un array fijo de 3: el render no se rompe al sumar un proveedor.
-//   * CA-A3 — cada fila usa el id canónico `mz-quota-${bucket}-${key}-{bar,pct}`.
-//   * CA-A5 / security — un `name` con markup no produce HTML ejecutable (XSS).
+//   * CA-A3 — cada celda usa el id canónico `mz-qm-${key}-${slot}-{tag,bar,pct,rst}`.
+//   * #4533 — cada celda rotula su ventana real (5h/Sem, Min/Día, Roll).
+//   * CA-A5 / security — un label con markup no produce HTML ejecutable (XSS).
 
 const test = require('node:test');
 const assert = require('node:assert/strict');
 
 const {
-    _mzProviderRow,
-    _mzProviderRows,
+    _mzWinCell,
+    _mzProviderMatrixRow,
+    _mzProviderMatrix,
     MZ_PROVIDER_META,
+    MZ_PROVIDER_WINDOWS,
     MZ_ACTIVE_PROVIDERS,
 } = require('../views/dashboard/home');
 
@@ -28,67 +29,68 @@ const {
 // ALLOWED_PROVIDERS (ids canónicos). Groq queda fuera (descontinuado #3353).
 const EXPECTED_PROVIDERS = ['anthropic', 'openai-codex', 'gemini-google', 'cerebras', 'nvidia-nim'];
 
-test('CA-A1 — _mzProviderRows renderiza una fila por cada proveedor activo (≥5)', () => {
-    const html = _mzProviderRows('session');
-    const rowCount = (html.match(/class="mz-prow"/g) || []).length;
+test('CA-A1 — _mzProviderMatrix renderiza una fila por cada proveedor activo (≥5)', () => {
+    const html = _mzProviderMatrix();
+    const rowCount = (html.match(/class="mz-qm-row"/g) || []).length;
     assert.ok(rowCount >= 5, `esperaba ≥5 filas de proveedor, hubo ${rowCount}`);
     assert.equal(rowCount, MZ_ACTIVE_PROVIDERS.length, 'la cantidad de filas debe igualar a los proveedores activos');
 });
 
 test('CA-A1 — Cerebras y NVIDIA NIM presentes; Groq ausente', () => {
-    const html = _mzProviderRows('session');
+    const html = _mzProviderMatrix();
     assert.match(html, /Cerebras/, 'falta la fila de Cerebras');
     assert.match(html, /NVIDIA NIM/, 'falta la fila de NVIDIA NIM');
     assert.doesNotMatch(html, /Groq/i, 'Groq fue descontinuado (#3353) y no debe renderizarse');
 });
 
 test('CA-A2 — la lista deriva de fuente única (MZ_PROVIDER_META), no de 3 hardcodeados', () => {
-    // La fuente única debe contener exactamente los proveedores canónicos.
     assert.deepEqual(MZ_ACTIVE_PROVIDERS.slice().sort(), EXPECTED_PROVIDERS.slice().sort());
     assert.ok(MZ_ACTIVE_PROVIDERS.length > 3, 'la lista no puede ser un array fijo de 3');
     // Sumar un proveedor a la fuente debe reflejarse en el render sin tocar
-    // _mzProviderRows. Simulamos derivando a mano desde la misma fuente.
-    const derived = MZ_ACTIVE_PROVIDERS
-        .map((k) => _mzProviderRow('session', k, MZ_PROVIDER_META[k].name, MZ_PROVIDER_META[k].color))
-        .join('');
-    assert.equal(derived, _mzProviderRows('session'), '_mzProviderRows debe derivar de MZ_PROVIDER_META');
+    // _mzProviderMatrix. Simulamos derivando a mano desde la misma fuente.
+    const derived = MZ_ACTIVE_PROVIDERS.map(_mzProviderMatrixRow).join('');
+    assert.equal(derived, _mzProviderMatrix(), '_mzProviderMatrix debe derivar de MZ_ACTIVE_PROVIDERS');
 });
 
-test('CA-A3 — cada fila usa el id canónico mz-quota-${bucket}-${key}-{bar,pct}', () => {
-    for (const bucket of ['session', 'week']) {
-        const html = _mzProviderRows(bucket);
-        for (const key of MZ_ACTIVE_PROVIDERS) {
-            assert.ok(
-                html.includes(`id="mz-quota-${bucket}-${key}-pct"`),
-                `falta id de % para ${key} en bucket ${bucket}`,
-            );
-            assert.ok(
-                html.includes(`id="mz-quota-${bucket}-${key}-bar"`),
-                `falta id de barra para ${key} en bucket ${bucket}`,
-            );
+test('CA-A3 — cada celda usa el id canónico mz-qm-${key}-${slot}-{tag,bar,pct,rst}', () => {
+    const html = _mzProviderMatrix();
+    for (const key of MZ_ACTIVE_PROVIDERS) {
+        for (const slot of ['short', 'long']) {
+            for (const part of ['tag', 'bar', 'pct', 'rst']) {
+                assert.ok(
+                    html.includes(`id="mz-qm-${key}-${slot}-${part}"`),
+                    `falta id mz-qm-${key}-${slot}-${part}`,
+                );
+            }
         }
     }
 });
 
-test('CA-A3 — el bucket distingue session de week en los ids', () => {
-    const sess = _mzProviderRows('session');
-    const week = _mzProviderRows('week');
-    assert.match(sess, /id="mz-quota-session-anthropic-pct"/);
-    assert.match(week, /id="mz-quota-week-anthropic-pct"/);
-    assert.doesNotMatch(sess, /mz-quota-week-/);
+test('#4533 — cada proveedor rotula su ventana real (5h/Sem, Min/Día, Roll)', () => {
+    const anth = _mzProviderMatrixRow('anthropic');
+    assert.match(anth, />5h</, 'Anthropic ventana corta = 5h');
+    assert.match(anth, />Sem</, 'Anthropic ventana larga = Sem');
+    const codex = _mzProviderMatrixRow('openai-codex');
+    assert.match(codex, />Roll</, 'Codex ventana corta = Roll');
+    const gem = _mzProviderMatrixRow('gemini-google');
+    assert.match(gem, />Min</, 'Gemini ventana corta = Min');
+    assert.match(gem, />Día</, 'Gemini ventana larga = Día');
+    // Los labels del skeleton derivan de MZ_PROVIDER_WINDOWS (fuente única SSR).
+    assert.equal(MZ_PROVIDER_WINDOWS.anthropic.short, '5h');
+    assert.equal(MZ_PROVIDER_WINDOWS['nvidia-nim'].long, 'Día');
 });
 
-test('CA-A5 / security — un name con markup no produce HTML ejecutable (XSS)', () => {
+test('#4533 — la fila muestra la fuente fidedigna del proveedor (CLI/API/headers)', () => {
+    assert.match(_mzProviderMatrixRow('anthropic'), /· CLI/, 'Anthropic: fuente CLI');
+    assert.match(_mzProviderMatrixRow('gemini-google'), /· API/, 'Gemini: fuente API');
+    assert.match(_mzProviderMatrixRow('cerebras'), /· headers/, 'Cerebras: fuente headers');
+    // La fuente declarada en la meta coincide con lo renderizado.
+    assert.equal(MZ_PROVIDER_META['nvidia-nim'].src, 'headers');
+});
+
+test('CA-A5 / security — un label con markup no produce HTML ejecutable (XSS)', () => {
     const evil = '<script>alert(1)</script>';
-    const html = _mzProviderRow('session', 'evilkey', evil, 'var(--in-warn,#d29922)');
-    // El payload crudo no debe aparecer como tag ejecutable.
+    const html = _mzWinCell('evilkey', 'short', evil);
     assert.doesNotMatch(html, /<script>alert\(1\)<\/script>/, 'el markup no debe quedar sin escapar');
-    // Debe estar presente en forma escapada.
-    assert.match(html, /&lt;script&gt;/, 'el name debe escaparse (escapeHtmlText)');
-});
-
-test('CA-UX2 — el estado pendiente "—" se marca como atenuado, no como 0%', () => {
-    const html = _mzProviderRows('session');
-    assert.match(html, /class="mz-ppct mz-ppct-pending"/, 'el % stub debe llevar la clase pending');
-    assert.match(html, /Pendiente/, 'el title debe comunicar estado pendiente');
+    assert.match(html, /&lt;script&gt;/, 'el label debe escaparse (escapeHtmlText)');
 });

--- a/.pipeline/tests/home-quota-render-4327.test.js
+++ b/.pipeline/tests/home-quota-render-4327.test.js
@@ -1,7 +1,7 @@
 // =============================================================================
-// Tests #4327 (CA-5 / UX-G4) — render de cuota en la HOME: un estado
-// `stale`/`missing` NUNCA se renderiza como número fresco, y "sin dato" se
-// escribe como literal, jamás como `0%`.
+// Tests #4327 (CA-5 / UX-G4) + #4533 — render de cuota en la HOME: un estado
+// sin dato NUNCA se renderiza como número fresco ni como `0%`; el % disponible
+// y su color por umbral se derivan del sub-shape del slice.
 //
 // Estrategia: los helpers de render viven dentro del script cliente de
 // `home.js` (string emitido por renderClientScript, no exportado). Se extraen
@@ -9,8 +9,11 @@
 // tests del repo (ver views/dashboard/__tests__ y tests/dashboard-xss-modal).
 //
 // Cubre:
-//   UX-G4 — `_hydrateProviderRow` con bucket sin dato (pct null) escribe el
-//           literal "sin dato" (no "0%", no un número).
+//   UX-G4 — `_mzHydrateWinCell` con bucket sin dato (mode 'nodata' o null)
+//           escribe el literal "sin dato" (no "0%", no un número).
+//   #4533 — con % disponible real escribe "<n>%" y color por umbral
+//           (ok/warn/bad); 0% disponible => bad (AGOTADA).
+//   #4533 — Codex (mode 'event') muestra "✓ sin límite", sin barra ni %.
 //   CA-5  — `pillTextFor(state)` para `stale`/`missing` devuelve la etiqueta de
 //           estado, nunca un porcentaje; `pctTextClient(null)` → "--%" (no "0%").
 //   UX-G5 — `MZ_ACTIVE_PROVIDERS` (fuente única) lista exactamente los 5
@@ -25,6 +28,7 @@ const path = require('node:path');
 
 const home = require('../views/dashboard/home.js');
 const HOME_SRC = fs.readFileSync(path.join(__dirname, '..', 'views', 'dashboard', 'home.js'), 'utf8');
+const { MZ_PROVIDER_META } = home;
 
 // Extrae un rango contiguo del source [desde `startAnchor`, hasta ANTES de
 // `endAnchor`]. Las anclas son literales de declaración, estables al refactor.
@@ -36,35 +40,38 @@ function sliceRange(src, startAnchor, endAnchor) {
     return src.slice(start, end);
 }
 
-// DOM falso mínimo: registra por id los elementos que el render toca.
-function makeFakeDom(ids) {
-    const els = {};
-    for (const id of ids) {
-        els[id] = {
-            id, textContent: '', className: '', _classes: new Set(), style: {}, _attrs: {},
+// Construye una celda falsa mz-qm-<key>-<slot> con sus hijos -tag/-bar/-pct/-rst.
+function makeCell(key, slot) {
+    const cid = 'mz-qm-' + key + '-' + slot;
+    const mkEl = () => {
+        const classes = new Set();
+        const attrs = {};
+        return {
+            textContent: '', style: {}, _classes: classes, _attrs: attrs,
             classList: {
-                add(c) { els[id]._classes.add(c); },
-                remove(c) { els[id]._classes.delete(c); },
-                contains(c) { return els[id]._classes.has(c); },
+                add(c) { classes.add(c); }, remove(c) { classes.delete(c); },
+                contains(c) { return classes.has(c); },
             },
-            getAttribute(k) { return els[id]._attrs[k] != null ? els[id]._attrs[k] : null; },
-            setAttribute(k, v) { els[id]._attrs[k] = String(v); },
-            closest() { return els[id]._row || null; },
+            getAttribute(k) { return attrs[k] != null ? attrs[k] : null; },
+            setAttribute(k, v) { attrs[k] = String(v); },
         };
-    }
-    return els;
+    };
+    const els = {
+        [cid]: mkEl(), [cid + '-tag']: mkEl(), [cid + '-bar']: mkEl(),
+        [cid + '-pct']: mkEl(), [cid + '-rst']: mkEl(),
+    };
+    return { cid, els };
 }
 
-// Construye el entorno de los helpers por-proveedor (rango REASON→renderProviderQuotaRows).
-function loadProviderRowHelpers() {
-    const body = sliceRange(HOME_SRC, 'const QUOTA_SINDATO_REASON = {', 'function renderProviderQuotaRows(');
-    // Fakes de las dependencias globales que usan los helpers.
-    const captured = { texts: {}, bars: {} };
-    const factory = new Function('document', 'setText', 'setBarPct', `
+// Carga _mzHydrateWinCell + helpers de umbral/reset con un DOM falso.
+function loadWinCellHelper(els) {
+    const body = sliceRange(HOME_SRC, 'const QUOTA_SINDATO_REASON = {', 'function renderProviderQuotaMatrix(');
+    const factory = new Function('document', 'MZ_PROVIDER_META', `
         ${body}
-        return { _hydrateProviderRow, _quotaConfidenceColor };
+        return { _mzHydrateWinCell, _mzThresholdClass, _fmtResetShort };
     `);
-    return { factory, captured };
+    const document = { getElementById: (id) => els[id] || null };
+    return factory(document, MZ_PROVIDER_META);
 }
 
 // Construye pillTextFor + fmtAge (rango fmtAge→classifyPctClient).
@@ -78,53 +85,68 @@ function loadPillHelpers() {
 }
 
 // ---------------------------------------------------------------------------
-// UX-G4 — "sin dato" literal, nunca 0%, cuando el bucket no tiene pct.
+// UX-G4 — "sin dato" literal, nunca 0%, cuando el bucket no tiene dato.
 // ---------------------------------------------------------------------------
-test('UX-G4: _hydrateProviderRow con pct null escribe "sin dato" (no 0%, no número)', () => {
-    const { factory } = loadProviderRowHelpers();
-    const ids = ['mz-quota-session-cerebras-bar', 'mz-quota-session-cerebras-pct'];
-    const els = makeFakeDom(ids);
-    const row = { id: 'row', _classes: new Set(), _attrs: {},
-        classList: { add(c) { row._classes.add(c); }, remove(c) { row._classes.delete(c); } },
-        getAttribute(k) { return row._attrs[k] != null ? row._attrs[k] : null; },
-        setAttribute(k, v) { row._attrs[k] = String(v); } };
-    els['mz-quota-session-cerebras-bar']._row = row;
+test('UX-G4: _mzHydrateWinCell con mode nodata escribe "sin dato" (no 0%, no número)', () => {
+    const { cid, els } = makeCell('cerebras', 'short');
+    const { _mzHydrateWinCell } = loadWinCellHelper(els);
 
-    const texts = {};
-    const document = { getElementById: (id) => els[id] || null };
-    const setText = (id, v) => { texts[id] = v; };
-    const setBarPct = () => {};
-    const { _hydrateProviderRow } = factory(document, setText, setBarPct);
+    // Sub-shape "sin dato" del slice.
+    const r = _mzHydrateWinCell('cerebras', 'short', { mode: 'nodata', available: null, win: 'Min' });
+    assert.equal(els[cid + '-pct'].textContent, 'sin dato', 'debe escribir el literal "sin dato"');
+    assert.notEqual(els[cid + '-pct'].textContent, '0%', 'NUNCA "0%"');
+    assert.ok(els[cid]._classes.has('mz-qm-nodata'), 'la celda marca estado sin dato');
+    assert.equal(r.healthy, false, 'sin dato no cuenta como proveedor sano');
 
-    // Bucket sin dato: b = null.
-    _hydrateProviderRow('session', 'cerebras', null);
-    assert.equal(texts['mz-quota-session-cerebras-pct'], 'sin dato', 'debe escribir el literal "sin dato"');
-    assert.notEqual(texts['mz-quota-session-cerebras-pct'], '0%', 'NUNCA "0%"');
-    assert.ok(!/^\d/.test(String(texts['mz-quota-session-cerebras-pct'])), 'no empieza con un dígito');
-    assert.equal(row.getAttribute('aria-label'), 'sin dato', 'aria-label explícito "sin dato"');
-
-    // Bucket con confidence 'missing' pero SIN pct real → también "sin dato".
-    _hydrateProviderRow('session', 'cerebras', { pct: null, confidence: 'missing' });
-    assert.equal(texts['mz-quota-session-cerebras-pct'], 'sin dato', 'pct null aunque venga confidence');
+    // b = null también cae a "sin dato".
+    const c2 = makeCell('cerebras', 'long');
+    const { _mzHydrateWinCell: h2 } = loadWinCellHelper(c2.els);
+    h2('cerebras', 'long', null);
+    assert.equal(c2.els[c2.cid + '-pct'].textContent, 'sin dato', 'b null → sin dato');
 });
 
-test('UX-G4: _hydrateProviderRow con pct real sí escribe el porcentaje', () => {
-    const { factory } = loadProviderRowHelpers();
-    const ids = ['mz-quota-week-openai-codex-bar', 'mz-quota-week-openai-codex-pct'];
-    const els = makeFakeDom(ids);
-    const row = { _classes: new Set(), _attrs: {},
-        classList: { add(c) { row._classes.add(c); }, remove(c) { row._classes.delete(c); } },
-        getAttribute(k) { return row._attrs[k] != null ? row._attrs[k] : null; },
-        setAttribute(k, v) { row._attrs[k] = String(v); } };
-    els['mz-quota-week-openai-codex-bar']._row = row;
-    const texts = {};
-    const { _hydrateProviderRow } = factory(
-        { getElementById: (id) => els[id] || null },
-        (id, v) => { texts[id] = v; },
-        () => {});
+test('#4533: _mzHydrateWinCell con % disponible real escribe el porcentaje + color por umbral', () => {
+    // Holgado → ok (verde).
+    const a = makeCell('anthropic', 'short');
+    loadWinCellHelper(a.els)._mzHydrateWinCell('anthropic', 'short',
+        { mode: 'gauge', available: 82, win: '5h', resetAt: null });
+    assert.equal(a.els[a.cid + '-pct'].textContent, '82%', 'con dato real muestra el % disponible');
+    assert.ok(a.els[a.cid]._classes.has('ok'), '82% disponible → color ok');
 
-    _hydrateProviderRow('week', 'openai-codex', { pct: 25, confidence: 'fresh' });
-    assert.equal(texts['mz-quota-week-openai-codex-pct'], '25.0%', 'con dato real muestra el %');
+    // Medio → warn (ámbar).
+    const b = makeCell('anthropic', 'short');
+    loadWinCellHelper(b.els)._mzHydrateWinCell('anthropic', 'short',
+        { mode: 'gauge', available: 40, win: '5h', resetAt: null });
+    assert.ok(b.els[b.cid]._classes.has('warn'), '40% disponible → color warn');
+
+    // Agotado → bad (rojo), 0% disponible = AGOTADA.
+    const c = makeCell('anthropic', 'long');
+    const res = loadWinCellHelper(c.els)._mzHydrateWinCell('anthropic', 'long',
+        { mode: 'gauge', available: 0, win: 'Sem', resetAt: null });
+    assert.equal(c.els[c.cid + '-pct'].textContent, '0%', '0% disponible');
+    assert.ok(c.els[c.cid]._classes.has('bad'), '0% disponible → color bad (AGOTADA)');
+    assert.match(c.els[c.cid].getAttribute('title'), /AGOTADA/, 'tooltip marca AGOTADA');
+    assert.equal(res.healthy, false, '0% disponible no es proveedor sano');
+});
+
+test('#4533: _mzHydrateWinCell mode event (Codex) muestra "sin límite" sin barra ni %', () => {
+    const { cid, els } = makeCell('openai-codex', 'short');
+    const r = loadWinCellHelper(els)._mzHydrateWinCell('openai-codex', 'short',
+        { mode: 'event', eventOk: true, win: 'Roll' });
+    assert.match(els[cid + '-pct'].textContent, /sin límite/, 'evento sin tope → "sin límite"');
+    assert.ok(els[cid]._classes.has('mz-qm-event'), 'la celda marca estado por evento');
+    assert.equal(r.healthy, true, 'sin límite cuenta como proveedor sano');
+});
+
+test('#4533: _mzThresholdClass respeta los umbrales verde/ámbar/rojo', () => {
+    const { _mzThresholdClass } = loadWinCellHelper({});
+    assert.equal(_mzThresholdClass(80), 'ok');
+    assert.equal(_mzThresholdClass(50), 'ok');
+    assert.equal(_mzThresholdClass(49), 'warn');
+    assert.equal(_mzThresholdClass(20), 'warn');
+    assert.equal(_mzThresholdClass(19), 'bad');
+    assert.equal(_mzThresholdClass(0), 'bad');
+    assert.equal(_mzThresholdClass(null), '');
 });
 
 // ---------------------------------------------------------------------------

--- a/.pipeline/tests/provider-quota-4533.test.js
+++ b/.pipeline/tests/provider-quota-4533.test.js
@@ -1,0 +1,133 @@
+'use strict';
+
+// #4533 — Tests del agregador de cuota DISPONIBLE por proveedor × ventana.
+// Cubre: fórmula available = 100 - consumido (clamp), reset propio por bucket,
+// rótulos de ventana, modo event (Codex), estado "sin dato", y el seam de
+// caché de muestras reales (recordSample/readCache).
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const pq = require('../lib/provider-quota');
+
+// Normalizado mínimo tal como lo produce normalizeProviderQuota (dashboard-slices).
+function norm(provider, sessionPct, weeklyPct, conf) {
+    return {
+        provider,
+        adapterStatus: 'ok',
+        session: { pct: sessionPct, confidence: conf || 'fresh' },
+        weekly: { pct: weeklyPct, confidence: conf || 'fresh' },
+    };
+}
+
+test('available = 100 - consumido, con clamp 0..100', () => {
+    assert.equal(pq._availableFromConsumed(0), 100);
+    assert.equal(pq._availableFromConsumed(40), 60);
+    assert.equal(pq._availableFromConsumed(100), 0);
+    assert.equal(pq._availableFromConsumed(140), 0, 'consumo saturado > 100 → 0 disponible');
+    assert.equal(pq._availableFromConsumed(-10), 100, 'consumo negativo → clamp 100');
+    assert.equal(pq._availableFromConsumed(null), null, 'sin dato → null (no 0)');
+});
+
+test('Anthropic: available por bucket + ventana 5h/Sem + reset propio por bucket', () => {
+    const adapterResult = {
+        adapterStatus: 'ok',
+        sessionResetsAt: '2026-07-06T23:00:00Z',
+        weeklyResetsAtReported: '2026-07-12T21:00:00Z',
+    };
+    const n = norm('anthropic', 60.1, 100, 'fresh');
+    pq.enrich('anthropic', n, adapterResult, { cache: {}, now: Date.parse('2026-07-06T20:00:00Z') });
+
+    assert.equal(n.session.win, '5h');
+    assert.equal(n.session.kind, 'short');
+    assert.equal(n.session.mode, 'gauge');
+    assert.ok(Math.abs(n.session.available - 39.9) < 1e-6, 'disponible = 100 - 60.1');
+    assert.equal(n.session.resetAt, '2026-07-06T23:00:00Z', 'reset de sesión propio (5h)');
+
+    assert.equal(n.weekly.win, 'Sem');
+    assert.equal(n.weekly.available, 0, 'semanal 100% consumido → 0 disponible (AGOTADA)');
+    assert.equal(n.weekly.resetAt, '2026-07-12T21:00:00Z', 'reset semanal propio, distinto del de sesión');
+    assert.notEqual(n.session.resetAt, n.weekly.resetAt, 'reset NO compartido entre buckets');
+});
+
+test('Codex: mode event ("sin límite") en ambas ventanas, sin barra', () => {
+    const n = norm('openai-codex', null, null, 'missing');
+    pq.enrich('openai-codex', n, { adapterStatus: 'ok', status: 'ok' }, { cache: {}, now: Date.now() });
+    assert.equal(n.session.mode, 'event');
+    assert.equal(n.weekly.mode, 'event');
+    assert.equal(n.session.eventOk, true, 'sin tope activo → eventOk true');
+    assert.equal(n.session.win, 'Roll');
+    assert.equal(n.weekly.win, 'Sem');
+    assert.equal(n.session.available, null, 'event no tiene barra de %');
+});
+
+test('Codex: tope activo (status critical) → eventOk false', () => {
+    const n = norm('openai-codex', null, null, 'missing');
+    pq.enrich('openai-codex', n, { adapterStatus: 'ok', status: 'critical' }, { cache: {}, now: Date.now() });
+    assert.equal(n.session.eventOk, false, 'status critical → tope activo');
+});
+
+test('Proveedor sin dato (Cerebras not_implemented): mode nodata + ventana Min/Día', () => {
+    const n = norm('cerebras', null, null, 'missing');
+    pq.enrich('cerebras', n, { adapterStatus: 'not_implemented' }, { cache: {}, now: Date.now() });
+    assert.equal(n.session.mode, 'nodata');
+    assert.equal(n.session.available, null, 'sin dato → null, jamás 0');
+    assert.equal(n.session.win, 'Min');
+    assert.equal(n.weekly.win, 'Día');
+    assert.equal(n.session.resetAt, null);
+});
+
+test('Caché fresca (headers/eventos) tiene prioridad sobre el adapter', () => {
+    const now = Date.parse('2026-07-06T20:00:00Z');
+    const cache = {
+        cerebras: {
+            short: { available: 68, resetAt: '2026-07-06T20:01:00Z', capturedAt: now - 1000 },
+        },
+    };
+    const n = norm('cerebras', null, null, 'missing');
+    pq.enrich('cerebras', n, { adapterStatus: 'not_implemented' }, { cache, now });
+    assert.equal(n.session.mode, 'gauge', 'con muestra cacheada fresca → gauge, no nodata');
+    assert.equal(n.session.available, 68);
+    assert.equal(n.session.confidence, 'fresh');
+    assert.equal(n.session.resetAt, '2026-07-06T20:01:00Z');
+    // el bucket largo sin muestra sigue en nodata
+    assert.equal(n.weekly.mode, 'nodata');
+});
+
+test('Caché stale (más vieja que TTL) se ignora → cae a nodata', () => {
+    const now = Date.now();
+    const cache = {
+        cerebras: { short: { available: 68, resetAt: null, capturedAt: now - (pq.CACHE_TTL_MS + 60000) } },
+    };
+    const n = norm('cerebras', null, null, 'missing');
+    pq.enrich('cerebras', n, { adapterStatus: 'not_implemented' }, { cache, now });
+    assert.equal(n.session.mode, 'nodata', 'muestra vencida no se usa');
+});
+
+test('recordSample persiste available derivado de remaining/limit y readCache lo lee', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pq-4533-'));
+    const now = Date.now();
+    const ok = pq.recordSample({
+        provider: 'nvidia-nim', bucketKind: 'short',
+        remaining: 900, limit: 1000, resetAt: '2026-07-06T20:01:00Z',
+        now, pipelineDir: dir,
+    });
+    assert.equal(ok, true);
+    const cache = pq.readCache(dir);
+    assert.ok(cache['nvidia-nim'] && cache['nvidia-nim'].short, 'la muestra quedó cacheada');
+    assert.equal(cache['nvidia-nim'].short.available, 90, 'available = 100 * remaining/limit');
+    assert.equal(cache['nvidia-nim'].short.resetAt, '2026-07-06T20:01:00Z');
+
+    // readCache defensivo ante archivo inexistente.
+    assert.deepEqual(pq.readCache(path.join(dir, 'nope')), {});
+    fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('recordSample rechaza input inválido sin lanzar', () => {
+    assert.equal(pq.recordSample({ provider: '', remaining: 1, limit: 2 }), false);
+    assert.equal(pq.recordSample({ provider: 'x', remaining: 1, limit: 0 }), false, 'limit 0 inválido');
+    assert.equal(pq.recordSample(null), false);
+});

--- a/.pipeline/views/dashboard/__tests__/home.test.js
+++ b/.pipeline/views/dashboard/__tests__/home.test.js
@@ -253,17 +253,20 @@ test('#4189: renderHomeHTML emite el layout MIZPÁ (banner + panel + grilla 2-co
         && html.includes('id="mission-eta-value"') && html.includes('id="mission-delivered-value"'),
         'el banner expone número de ola, avance, ETA y entregados (hidratables)');
     assert.ok(html.includes('class="mz-sysquota"'), 'panel estado + cuotas');
-    assert.ok(html.includes('id="mz-quota-session-pct"') && html.includes('id="mz-quota-week-pct"'),
-        'cuotas de sesión y semanal con % agregado');
-    // #4249: el desglose por proveedor usa los ids canónicos de ALLOWED_PROVIDERS
-    // (`openai-codex`, `gemini-google`, etc.) para alinear con el backend de #4202,
-    // no las claves cortas viejas. Se renderizan los 5 proveedores activos.
-    assert.ok(html.includes('id="mz-quota-session-anthropic-bar"')
-        && html.includes('id="mz-quota-session-openai-codex-bar"')
-        && html.includes('id="mz-quota-session-gemini-google-bar"')
-        && html.includes('id="mz-quota-session-cerebras-bar"')
-        && html.includes('id="mz-quota-session-nvidia-nim-bar"'),
-        'desglose por proveedor con ids canónicos Anthropic/Codex/Gemini/Cerebras/NVIDIA NIM (CA-6, #4249)');
+    // #4533 — el panel pasó a matriz de cuota DISPONIBLE por proveedor × ventana
+    // (corta/larga). Ya no hay % agregado (mz-quota-session-pct removido); cada
+    // proveedor tiene dos celdas de ventana (short/long) con ids mz-qm-<key>-<slot>-*.
+    assert.ok(html.includes('id="mz-sig-healthy"'),
+        'estado compacto con señal accionable "proveedores sanos"');
+    // #4249/#4533: la matriz usa los ids canónicos de ALLOWED_PROVIDERS
+    // (openai-codex, gemini-google, etc.). Se renderizan los 5 proveedores activos
+    // en su ventana corta (short) y larga (long).
+    assert.ok(html.includes('id="mz-qm-anthropic-short-bar"') && html.includes('id="mz-qm-anthropic-long-bar"')
+        && html.includes('id="mz-qm-openai-codex-short-bar"')
+        && html.includes('id="mz-qm-gemini-google-short-bar"')
+        && html.includes('id="mz-qm-cerebras-long-bar"')
+        && html.includes('id="mz-qm-nvidia-nim-long-bar"'),
+        'matriz proveedor×ventana con ids canónicos Anthropic/Codex/Gemini/Cerebras/NVIDIA NIM (CA-6, #4533)');
     assert.ok(html.includes('class="mz-grid"'), 'grilla de 2 columnas');
     assert.ok(html.includes('class="mz-panel mz-now"') && html.includes('class="mz-panel mz-board"'),
         'columna Ahora·Ejecución + Tablero de la Ola');

--- a/.pipeline/views/dashboard/home.js
+++ b/.pipeline/views/dashboard/home.js
@@ -1699,35 +1699,62 @@ function homeStyles() {
 .v3-more-menu .v3-tab-label + .v3-tab-desc { margin-left: -6px; }
 .v3-more-menu .v3-tab > .v3-tab-label { display: flex; flex-direction: column; align-items: flex-start; gap: 0; }
 
-/* --- Panel estado + cuotas (3 columnas) --- */
-.mz-sysquota { display: grid; grid-template-columns: 1.05fr 1.1fr 1.1fr; overflow: hidden;
+/* --- Panel estado + cuotas (#4533: status compacto + matriz proveedor×ventana)
+ * Panel de APOYO: compacto, una línea por proveedor, NO compite con "Ahora ·
+ * En Ejecución" ni con "Issues de la Ola". */
+.mz-sysquota { display: grid; grid-template-columns: 0.9fr 2.3fr; overflow: hidden;
     background: linear-gradient(180deg, var(--in-bg-2,#11151E), var(--in-bg-3,#141925));
     border: 1px solid var(--in-border,rgba(255,255,255,.07)); border-radius: 16px; }
-.mz-sq-cell { padding: 18px 20px; border-right: 1px solid var(--in-border,rgba(255,255,255,.07)); }
-.mz-sq-cell:last-child { border-right: 0; }
-.mz-sq-status { background: linear-gradient(135deg, rgba(251,191,36,.10), transparent 72%); }
-.mz-sq-head { font-size: 10.5px; color: var(--in-fg-dim,#8A93A6); font-weight: 800; letter-spacing: 1px; margin-bottom: 11px; }
-.mz-sq-chips { display: flex; flex-wrap: wrap; gap: 7px; margin-top: 13px; }
-.mz-chip { display: flex; align-items: center; gap: 6px; font-size: 11px; font-weight: 700;
-    background: rgba(255,255,255,.04); border: 1px solid var(--in-border,rgba(255,255,255,.12)); border-radius: 9px; padding: 6px 10px; }
-.mz-chip.mz-chip-ok { border-color: rgba(52,211,153,.3); }
-.mz-chip[data-on="0"] { opacity: .45; }
-.mz-chip[data-on="1"] { border-color: rgba(251,191,36,.35); background: rgba(251,191,36,.08); opacity: 1; }
-.mz-chip b { font-variant-numeric: tabular-nums; color: #6ee7b7; }
-.mz-q-head { display: flex; align-items: baseline; justify-content: space-between; gap: 8px; }
-.mz-q-klbl { font-size: 10.5px; color: var(--in-fg-dim,#8A93A6); font-weight: 700; letter-spacing: .6px; }
-.mz-q-kval { font-size: 24px; font-weight: 800; line-height: 1; margin-top: 4px; font-variant-numeric: tabular-nums; }
-.mz-q-ksub { font-size: 10px; color: var(--in-fg-dim,#5B6376); text-align: right; }
-.mz-prov { display: flex; flex-direction: column; gap: 9px; margin-top: 13px; }
-.mz-prow { display: grid; grid-template-columns: 80px 1fr 42px; align-items: center; gap: 9px; }
-.mz-pname { display: flex; align-items: center; gap: 7px; font-size: 11px; font-weight: 700; }
+.mz-sq-side { padding: 13px 16px; border-right: 1px solid var(--in-border,rgba(255,255,255,.07));
+    display: flex; flex-direction: column; gap: 10px; }
+.mz-sq-head { font-size: 10px; color: var(--in-fg-dim,#8A93A6); font-weight: 800; letter-spacing: 1px; }
+/* Estado del sistema: semáforo COMPACTO (dot + label), sin el círculo gigante
+ * ni el chip redundante que repetía el subtítulo (CA #4533). */
+.mz-status-line { display: flex; align-items: center; gap: 8px; }
+.mz-status-dot { width: 11px; height: 11px; border-radius: 50%; flex: none; background: var(--in-fg-dim,#8b949e); }
+.mz-status-lbl { font-size: 15px; font-weight: 800; }
+.mz-status-ok .mz-status-dot { background: var(--in-ok,#3fb950); box-shadow: 0 0 8px rgba(63,185,80,.5); }
+.mz-status-ok .mz-status-lbl { color: var(--in-ok,#3fb950); }
+.mz-status-warn .mz-status-dot { background: var(--in-warn,#d29922); }
+.mz-status-warn .mz-status-lbl { color: var(--in-warn,#d29922); }
+.mz-status-alert .mz-status-dot { background: var(--in-bad,#f85149); }
+.mz-status-alert .mz-status-lbl { color: var(--in-bad,#f85149); }
+.mz-status-stale .mz-status-dot { background: var(--in-fg-dim,#8b949e); }
+.mz-status-stale .mz-status-lbl { color: var(--in-fg-dim,#8b949e); }
+/* Señales accionables (anomalía, rebote, proveedores sanos). */
+.mz-sq-signals { display: flex; flex-direction: column; gap: 6px; margin-top: 2px; }
+.mz-sig { display: flex; align-items: center; gap: 6px; font-size: 10.5px; font-weight: 700;
+    color: var(--in-fg-dim,#8A93A6); background: rgba(255,255,255,.04);
+    border: 1px solid var(--in-border,rgba(255,255,255,.10)); border-radius: 8px; padding: 5px 9px; }
+.mz-sig b { font-variant-numeric: tabular-nums; color: #6ee7b7; margin-left: auto; }
+.mz-sig[data-on="0"] { opacity: .4; }
+.mz-sig[data-on="1"] { border-color: rgba(248,81,73,.4); background: rgba(248,81,73,.09); color: var(--in-bad,#f85149); opacity: 1; }
+
+/* Matriz proveedor × ventana. */
+.mz-sq-matrix { padding: 13px 16px; min-width: 0; }
+.mz-qm-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 8px; gap: 8px; }
+.mz-qm-h-l { font-size: 10px; font-weight: 800; letter-spacing: .7px; color: var(--in-fg-dim,#8A93A6); }
+.mz-qm-h-note { font-size: 8.5px; color: var(--in-fg-soft,#6e7681); font-weight: 600; }
+.mz-qm-cols, .mz-qm-row { display: grid; grid-template-columns: 1.25fr 1fr 1fr; column-gap: 16px; align-items: center; }
+.mz-qm-gh { font-size: 8.5px; font-weight: 800; letter-spacing: .4px; color: var(--in-fg-soft,#6e7681); text-transform: uppercase; padding-bottom: 4px; }
+.mz-qm-row > * { border-top: 1px solid var(--in-border,rgba(255,255,255,.07)); min-height: 30px; display: flex; align-items: center; }
+.mz-qm-prov { gap: 7px; }
 .mz-pdot { width: 8px; height: 8px; border-radius: 50%; flex: none; }
-.mz-pbar { height: 6px; border-radius: 5px; background: rgba(255,255,255,.07); overflow: hidden; }
-.mz-pbar i { display: block; height: 100%; border-radius: 5px; transition: width .4s ease; }
-.mz-ppct { font-size: 11px; font-weight: 700; text-align: right; font-variant-numeric: tabular-nums; color: var(--in-fg-dim,#8A93A6); }
-/* #4249 CA-UX2 — estado "pendiente" (—): atenuado para no confundirlo con
- * consumo 0% ni con un proveedor caído. Se quita al hidratar con #4202. */
-.mz-ppct-pending { opacity: .55; font-weight: 600; }
+.mz-qm-pn { font-size: 12px; font-weight: 800; }
+.mz-qm-src { font-size: 8.5px; color: var(--in-fg-soft,#6e7681); font-weight: 700; }
+.mz-qm-cell { gap: 7px; font-size: 11px; }
+.mz-qm-wtag { font-size: 8px; font-weight: 800; letter-spacing: .3px; color: var(--in-fg-soft,#6e7681); text-transform: uppercase; min-width: 26px; }
+.mz-qm-mini { width: 52px; height: 5px; border-radius: 3px; background: rgba(255,255,255,.09); overflow: hidden; flex: none; }
+.mz-qm-mini i { display: block; height: 100%; border-radius: 3px; background: var(--in-fg-dim,#8b949e); transition: width .4s ease; }
+.mz-qm-pct { font-weight: 800; font-variant-numeric: tabular-nums; min-width: 34px; color: var(--in-fg-dim,#8A93A6); }
+.mz-qm-rst { font-size: 9px; color: var(--in-fg-dim,#8A93A6); font-weight: 700; font-variant-numeric: tabular-nums; margin-left: auto; white-space: nowrap; }
+.mz-qm-cell.ok   .mz-qm-pct { color: var(--in-ok,#3fb950); }   .mz-qm-cell.ok   .mz-qm-mini i { background: var(--in-ok,#3fb950); }
+.mz-qm-cell.warn .mz-qm-pct { color: var(--in-warn,#d29922); } .mz-qm-cell.warn .mz-qm-mini i { background: var(--in-warn,#d29922); }
+.mz-qm-cell.bad  .mz-qm-pct { color: var(--in-bad,#f85149); }  .mz-qm-cell.bad  .mz-qm-mini i { background: var(--in-bad,#f85149); }
+.mz-qm-cell.mz-qm-event .mz-qm-mini, .mz-qm-cell.mz-qm-event .mz-qm-rst { display: none; }
+.mz-qm-cell.mz-qm-event .mz-qm-pct { color: var(--in-info,#58a6ff); background: rgba(88,166,255,.14); border-radius: 5px; padding: 2px 7px; font-size: 9.5px; font-weight: 700; min-width: 0; }
+.mz-qm-cell.mz-qm-nodata .mz-qm-mini, .mz-qm-cell.mz-qm-nodata .mz-qm-rst { display: none; }
+.mz-qm-cell.mz-qm-nodata .mz-qm-pct { color: var(--in-fg-soft,#6e7681); font-weight: 600; font-size: 10px; }
 
 /* --- Grilla 2-col + paneles --- */
 .mz-grid { display: grid; grid-template-columns: 1fr 1.62fr; gap: 16px; align-items: start; }
@@ -1902,7 +1929,7 @@ function homeStyles() {
 /* Responsive: en viewports angostos las grillas colapsan a 1 columna. */
 @media (max-width: 920px) {
     .mz-sysquota { grid-template-columns: 1fr; }
-    .mz-sq-cell { border-right: 0; border-bottom: 1px solid var(--in-border,rgba(255,255,255,.07)); }
+    .mz-sq-side { border-right: 0; border-bottom: 1px solid var(--in-border,rgba(255,255,255,.07)); }
     .mz-grid { grid-template-columns: 1fr; }
     .mz-mission { flex-direction: column; align-items: stretch; }
 }
@@ -1934,6 +1961,13 @@ function renderClientScript() {
     return `
 const SKILL_ICONS = ${JSON.stringify(SKILL_ICONS)};
 const SKILL_COLORS = ${JSON.stringify(SKILL_COLORS)};
+// #4533 — Metadata de proveedores embebida como constantes de cliente. Antes el
+// script del navegador referenciaba MZ_ACTIVE_PROVIDERS / MZ_PROVIDER_META (de
+// ámbito de módulo, NO disponibles en el browser) y la hidratación de las filas
+// por proveedor lanzaba ReferenceError silencioso → las filas quedaban en "—".
+// Ahora se serializan desde la fuente única del server (misma que usa el SSR).
+const MZ_ACTIVE_PROVIDERS = ${JSON.stringify(MZ_ACTIVE_PROVIDERS)};
+const MZ_PROVIDER_META = ${JSON.stringify(MZ_PROVIDER_META)};
 
 function fmtDur(ms){ if(!ms||ms<0) return '—'; const s=Math.round(ms/1000); if(s<60) return s+'s'; const m=Math.floor(s/60), r=s%60; if(m<60) return m+'m '+r+'s'; const h=Math.floor(m/60), rm=m%60; return h+'h '+rm+'m'; }
 // #3035 — Formato dd/MM HH:mm:ss en hora local para timestamp de fin.
@@ -2319,33 +2353,34 @@ function renderQuotaCard(d){
     setText('kpi-quota-session-pct', sessPct.toFixed(1)+'%');
     setText('kpi-quota-week-pct', weekPct.toFixed(1)+'%');
 
-    // #4189 — Espeja el % AGREGADO real en el panel de cuotas del home MIZPÁ.
-    // Aca solo tocamos el % AGREGADO de sesion/semana. El desglose POR PROVEEDOR
-    // (filas mz-quota-<bucket>-<prov>-*) ya NO es stub: lo hidrata en vivo
-    // tickProviderQuota (#4202) desde /api/dash/quota; ver renderProviderQuotaRows.
-    //
     // #4249 CA-A4 — ORIGEN CANONICO DE CADA METRICA DE CUOTA (auditoria):
     //   - % sesion (5h) / semanal AGREGADO  -> endpoint /api/dash/quota
     //     (ticker tickQuota, este archivo) -> lib/quota-adapters/* (Anthropic
     //     real) + lib/weekly-quota.js, calibrado contra muestras de claude.ai.
-    //     Mide el Plan Max de Anthropic; NO es multi-proveedor. Dato real.
-    //   - Salud / disponibilidad por proveedor -> .pipeline/state/
-    //     multi-provider-health.json (campo last_checked_at); expone solo
-    //     key_status/auth_mode/state, NUNCA el secreto (guardrail A02/A01).
-    //   - Desglose de cuota POR PROVEEDOR (filas mz-quota-bucket-prov-*) ->
-    //     ya entregado por #4202 (tickProviderQuota). Las filas sin dato del
-    //     slice (cerebras / nvidia-nim) caen a "sin dato" de forma explicita.
-    setText('mz-quota-session-pct', sessPct.toFixed(1)+'%');
-    setText('mz-quota-week-pct', weekPct.toFixed(1)+'%');
+    //     Alimenta el kpi card oculto (kpi-quota-*), NO el panel visible.
+    //   - #4533 — El panel visible del home MIZPA ya NO muestra un % agregado:
+    //     pasó a la matriz de cuota DISPONIBLE por proveedor × ventana
+    //     (mz-qm-<key>-<slot>-*), hidratada por tickProviderQuota /
+    //     renderProviderQuotaMatrix desde d.providers[key]. Por eso acá ya no
+    //     se escriben los ids mz-quota-session-pct/week-pct (removidos).
 
     // Cuenta regresiva: si tenemos session_resets_at o weekly_resets_at, usar
     // diferencia con now. Si no, usar daysToReset del backend (semanal) o
     // hoursRemaining (sesión, asume rolling 5h sin punto fijo).
     const now = Date.now();
+    // #4533 — FIX bug "resetea · reseteó": cuando el reset ya venció (dato
+    // stale) el código previo concatenaba 'resetea ' + '· reseteó' (texto sin
+    // sentido). _resetEta devuelve un countdown válido, o 'renovando...' si ya
+    // venció, o el fallback si no hay timestamp. Sin prefijo (el kpi card ya lo
+    // rotula en su propio HTML).
+    function _resetEta(ts, fallback){
+        if(!Number.isFinite(ts)) return fallback;
+        const diff = ts - now;
+        return diff > 0 ? fmtETA(diff) : 'renovando…';
+    }
     let sessETA;
     if(d.sessionResetsAt){
-        const ts = new Date(d.sessionResetsAt).getTime();
-        sessETA = ts > now ? fmtETA(ts - now) : '· reseteó';
+        sessETA = _resetEta(new Date(d.sessionResetsAt).getTime(), '·');
     } else if(d.session && d.session.hoursRemaining != null){
         sessETA = '~'+d.session.hoursRemaining.toFixed(1)+'h al cap';
     } else {
@@ -2353,8 +2388,7 @@ function renderQuotaCard(d){
     }
     let weekETA;
     if(d.weeklyResetsAtReported){
-        const ts = new Date(d.weeklyResetsAtReported).getTime();
-        weekETA = ts > now ? fmtETA(ts - now) : '· reseteó';
+        weekETA = _resetEta(new Date(d.weeklyResetsAtReported).getTime(), '·');
     } else if(d.daysToReset != null){
         weekETA = fmtETA(d.daysToReset * 86400000);
     } else {
@@ -2362,9 +2396,6 @@ function renderQuotaCard(d){
     }
     setText('kpi-quota-session-eta', sessETA);
     setText('kpi-quota-week-eta', weekETA);
-    // #4189 — mismo dato de reseteo en el panel del home MIZPÁ.
-    setText('mz-quota-session-eta', 'resetea ' + sessETA);
-    setText('mz-quota-week-eta', 'resetea ' + weekETA);
 
     const sessRow = document.getElementById('kpi-quota-session');
     const weekRow = document.getElementById('kpi-quota-week');
@@ -2403,110 +2434,150 @@ async function tickQuota(){
     renderQuotaCard(d);
 }
 
-// #4202 — Desglose de cuota por proveedor en las 2 ventanas (Sesion 5h y
-// Semanal). Hidrata los IDs emitidos por _mzProviderRow
-// (mz-quota-<bucket>-<key>-bar / -pct) — NO re-render.
+// #4533 — Matriz de cuota DISPONIBLE por proveedor × ventana. Hidrata los IDs
+// emitidos por _mzWinCell (mz-qm-<key>-<slot>-{tag,bar,pct,rst}) — NO re-render.
 //
-// CRITICO (CA-6 + #4249 CA-A3): la key de cada fila ES el id canonico del
-// slice (anthropic / openai-codex / gemini-google / cerebras / nvidia-nim). El
-// lookup en d.providers usa esa misma key directamente — sin tabla de
-// traduccion intermedia (la fuente unica es MZ_PROVIDER_META, ver mas abajo).
+// La key de cada fila ES el id canonico del slice (anthropic / openai-codex /
+// gemini-google / cerebras / nvidia-nim). El lookup en d.providers usa esa misma
+// key directamente; los buckets del slice (session/weekly) mapean a las ventanas
+// corta/larga (short/long).
 
 // Motivo de "sin dato" por (bucket, key canonica) para el tooltip (UX G3): evita
 // que el operador lea la ausencia como un bug.
 const QUOTA_SINDATO_REASON = {
-    'session-openai-codex': 'Codex opera por presupuesto mensual: no hay ventana de 5h.',
-    'session-gemini-google': 'Free tier de Gemini no expone consumo acumulado por API.',
-    'week-gemini-google': 'Free tier de Gemini no expone consumo acumulado por API.',
+    'session-openai-codex': 'Codex opera por eventos (usage-limit): no hay ventana de 5h con %.',
+    'session-gemini-google': 'Free tier de Gemini: el % por minuto se hidrata desde metadatos de la API cuando estén disponibles.',
+    'week-gemini-google': 'Free tier de Gemini: el % diario se hidrata desde metadatos de la API cuando estén disponibles.',
+    'session-cerebras': 'Cerebras: el % por minuto se hidrata desde los headers x-ratelimit-* cuando estén conectados.',
+    'week-cerebras': 'Cerebras: el % diario se hidrata desde los headers x-ratelimit-* cuando estén conectados.',
+    'session-nvidia-nim': 'NVIDIA NIM: el % por minuto se hidrata desde los headers x-ratelimit-* cuando estén conectados.',
+    'week-nvidia-nim': 'NVIDIA NIM: el % diario se hidrata desde los headers x-ratelimit-* cuando estén conectados.',
 };
-const QUOTA_SINDATO_DEFAULT = 'Sin dato de consumo disponible para este proveedor en esta ventana.';
+const QUOTA_SINDATO_DEFAULT = 'Sin dato de cuota disponible para este proveedor en esta ventana.';
 
-// Colores de confianza (UX G2): reusa la paleta del banner de snapshot.
-//   fresh = verde, stale = ambar, missing/parser-offline = dim (= "sin dato").
-function _quotaConfidenceColor(confidence){
-    if(confidence === 'fresh') return 'var(--in-ok,#3fb950)';
-    if(confidence === 'stale') return 'var(--in-warn,#d29922)';
-    return 'var(--text-dim,#8b949e)';
+// Umbral de color por cuota DISPONIBLE (CA #4533): verde=holgado, ámbar=medio,
+// rojo=agotado. 0% disponible (= consumo 100%) => rojo AGOTADA.
+function _mzThresholdClass(avail){
+    if(avail == null) return '';
+    if(avail <= 0) return 'bad';
+    if(avail < 20) return 'bad';
+    if(avail < 50) return 'warn';
+    return 'ok';
 }
 
-// Hidrata una fila proveedor/bucket. b es el sub-shape {pct, confidence} del
-// slice, o null. uiKey en {anthropic,codex,gemini}; bucket en {session,week}.
-function _hydrateProviderRow(bucket, uiKey, b){
-    const barId = 'mz-quota-'+bucket+'-'+uiKey+'-bar';
-    const pctId = 'mz-quota-'+bucket+'-'+uiKey+'-pct';
-    const pctEl = document.getElementById(pctId);
-    const barEl = document.getElementById(barId);
-    const rowEl = barEl ? barEl.closest('.mz-prow') : null;
-    const hasData = b && b.pct != null && Number.isFinite(Number(b.pct));
-    // #4287 (CA-3) — la fila ya no está "pendiente de #4202": la hidratación
-    // ocurrió. Quitamos la clase placeholder en ambas ramas para que el estilo
-    // refleje el estado real (dato medido o "sin dato"), no el de carga.
-    if(pctEl) pctEl.classList.remove('mz-ppct-pending');
-    if(hasData){
-        const pct = Number(b.pct);
-        setBarPct(barId, pct);
-        setText(pctId, pct.toFixed(1)+'%');
-        const color = _quotaConfidenceColor(b.confidence);
-        if(pctEl && pctEl.style.color !== color) pctEl.style.color = color;
-        // La barra mantiene el color del proveedor (no la atenuamos cuando hay
-        // dato); solo el % refleja la confianza (ambar si el snapshot esta stale).
-        if(rowEl){
-            rowEl.classList.remove('mz-prow-nodata');
-            // #4287 (CA-3) — tooltip con el consumo real medido (reemplaza el
-            // "en preparación · #4202" del SSR). Solo % + confianza legible; NO
-            // se vuelca el objeto health (security req#2). Strings estáticos +
-            // número formateado → sin interpolación cruda de datos externos.
-            const confLabel = b.confidence === 'stale' ? 'dato con retraso (snapshot stale)'
-                : b.confidence === 'fresh' ? 'dato reciente'
-                : 'dato medido';
-            const tip = 'Consumo medido: ' + pct.toFixed(1) + '% · ' + confLabel + '.';
-            if(rowEl.getAttribute('title') !== tip) rowEl.setAttribute('title', tip);
-            const ariaPct = pct.toFixed(1)+'%';
-            if(rowEl.getAttribute('aria-label') !== ariaPct) rowEl.setAttribute('aria-label', ariaPct);
-        }
-    } else {
-        // "sin dato" explicito (CA-1 + UX G1): texto literal (no 0%, no guion),
-        // barra a 0, tono dim, tooltip con el motivo.
-        setBarPct(barId, 0);
-        setText(pctId, 'sin dato');
-        const dim = 'var(--text-dim,#8b949e)';
-        if(pctEl && pctEl.style.color !== dim) pctEl.style.color = dim;
-        if(rowEl){
-            rowEl.classList.add('mz-prow-nodata');
-            const reason = QUOTA_SINDATO_REASON[bucket+'-'+uiKey] || QUOTA_SINDATO_DEFAULT;
-            if(rowEl.getAttribute('title') !== reason) rowEl.setAttribute('title', reason);
-            if(rowEl.getAttribute('aria-label') !== 'sin dato') rowEl.setAttribute('aria-label', 'sin dato');
-        }
+// Countdown corto para el reset de un bucket (ms restantes). '' si venció/inválido.
+function _fmtResetShort(ms){
+    if(!Number.isFinite(ms) || ms <= 0) return '';
+    const totalMin = Math.floor(ms / 60000);
+    if(totalMin < 1) return '↻' + Math.max(1, Math.floor(ms / 1000)) + 's';
+    if(totalMin < 60) return '↻' + totalMin + 'm';
+    const h = Math.floor(totalMin / 60), m = totalMin % 60;
+    if(h < 24) return '↻' + h + 'h' + (m > 0 ? m + 'm' : '');
+    const d = Math.floor(h / 24), rh = h % 24;
+    return '↻' + d + 'd' + (rh > 0 ? rh + 'h' : '');
+}
+
+// Hidrata una celda proveedor+ventana. b es el sub-shape del slice
+// {pct, confidence, available, resetAt, win, kind, mode} o null.
+// Devuelve { healthy } para el conteo de "proveedores sanos".
+function _mzHydrateWinCell(key, slot, b){
+    const cid = 'mz-qm-' + key + '-' + slot;
+    const cell = document.getElementById(cid);
+    if(!cell) return { healthy: false };
+    const tagEl = document.getElementById(cid + '-tag');
+    const barEl = document.getElementById(cid + '-bar');
+    const pctEl = document.getElementById(cid + '-pct');
+    const rstEl = document.getElementById(cid + '-rst');
+    cell.classList.remove('ok', 'warn', 'bad', 'mz-qm-event', 'mz-qm-nodata');
+    if(tagEl && b && b.win) tagEl.textContent = b.win;
+    const meta = MZ_PROVIDER_META[key] || { name: key, src: '' };
+    const mode = b && b.mode;
+
+    // Estado por eventos (Codex): sin barra, chip "sin límite" / "tope activo".
+    if(mode === 'event'){
+        cell.classList.add('mz-qm-event');
+        if(barEl) barEl.style.width = '0%';
+        const ok = !b || b.eventOk !== false;
+        if(pctEl) pctEl.textContent = ok ? '✓ sin límite' : 'tope activo';
+        if(rstEl) rstEl.textContent = '';
+        cell.setAttribute('title', ok
+            ? meta.name + ': sin tope de cuota activo (estado por eventos del proveedor · fuente ' + meta.src + ').'
+            : meta.name + ': tope de cuota activo — el proveedor rechazó por límite.');
+        cell.setAttribute('aria-label', meta.name + ' ' + (b && b.win ? b.win : '') + ': ' + (ok ? 'sin límite' : 'tope activo'));
+        return { healthy: ok };
     }
+
+    // Gauge con % disponible real.
+    if(mode === 'gauge' && b && b.available != null && Number.isFinite(Number(b.available))){
+        const avail = Number(b.available);
+        const cls = _mzThresholdClass(avail);
+        if(cls) cell.classList.add(cls);
+        if(barEl) barEl.style.width = Math.max(0, Math.min(100, avail)) + '%';
+        if(pctEl) pctEl.textContent = avail.toFixed(0) + '%';
+        let rst = '';
+        if(b.resetAt){
+            const ts = Date.parse(b.resetAt);
+            if(Number.isFinite(ts)) rst = _fmtResetShort(ts - Date.now());
+        }
+        if(rstEl) rstEl.textContent = rst;
+        const label = avail <= 0 ? 'AGOTADA (0% disponible)' : avail.toFixed(0) + '% disponible';
+        cell.setAttribute('title', meta.name + ' · ' + (b.win || '') + ': ' + label
+            + (rst ? ' · reset ' + rst.replace('↻', '') : '') + ' (fuente: ' + meta.src + ').');
+        cell.setAttribute('aria-label', meta.name + ' ' + (b.win || '') + ': ' + label);
+        return { healthy: avail > 0 };
+    }
+
+    // Sin dato explícito.
+    cell.classList.add('mz-qm-nodata');
+    if(barEl) barEl.style.width = '0%';
+    if(pctEl) pctEl.textContent = 'sin dato';
+    if(rstEl) rstEl.textContent = '';
+    const reason = QUOTA_SINDATO_REASON[(slot === 'short' ? 'session' : 'week') + '-' + key] || QUOTA_SINDATO_DEFAULT;
+    cell.setAttribute('title', reason);
+    cell.setAttribute('aria-label', meta.name + ' ' + (b && b.win ? b.win : '') + ': sin dato');
+    return { healthy: false };
 }
 
-function renderProviderQuotaRows(d){
+function renderProviderQuotaMatrix(d){
     if(!d || !d.providers) return;
-    // UI usa bucket 'week'; el slice usa 'weekly'. Traduccion explicita.
-    const BUCKET_SLICE = { session: 'session', week: 'weekly' };
-    // La key de la fila ES el id canonico del slice (#4249 CA-A2/A3): se itera la
-    // FUENTE UNICA MZ_ACTIVE_PROVIDERS y se busca d.providers[key] sin traduccion.
-    // Proveedores activos sin sub-shape en el slice (p.ej. cerebras / nvidia-nim)
-    // caen a "sin dato" explicito dentro de _hydrateProviderRow.
-    for(const bucket of ['session','week']){
-        for(const key of MZ_ACTIVE_PROVIDERS){
-            const p = d.providers[key];
-            const b = p ? p[BUCKET_SLICE[bucket]] : null;
-            _hydrateProviderRow(bucket, key, b);
+    // Buckets del slice: short ↔ session, long ↔ weekly.
+    const SLOT_BUCKET = { short: 'session', long: 'weekly' };
+    let healthyCount = 0;
+    for(const key of MZ_ACTIVE_PROVIDERS){
+        const p = d.providers[key];
+        let provHealthy = false;
+        for(const slot of ['short', 'long']){
+            const b = p ? p[SLOT_BUCKET[slot]] : null;
+            const r = _mzHydrateWinCell(key, slot, b);
+            if(r.healthy) provHealthy = true;
         }
+        if(provHealthy) healthyCount++;
     }
+    const healthyEl = document.getElementById('mz-sig-healthy');
+    if(healthyEl) healthyEl.textContent = healthyCount + '/' + MZ_ACTIVE_PROVIDERS.length;
 }
 
-// Ticker dedicado (CA-5): SOLO hidrata las filas por proveedor; NO toca
-// renderQuotaCard ni tickQuota (el % agregado sigue intacto).
+// Alias retro-compat: algún ticker antiguo podría llamar renderProviderQuotaRows.
+function renderProviderQuotaRows(d){ return renderProviderQuotaMatrix(d); }
+
+// Último slice de cuota por proveedor, para recomputar countdowns cada segundo
+// sin re-fetch (#4533).
+let _providerQuotaData = null;
+
+// Ticker dedicado (CA-5): SOLO hidrata la matriz por proveedor; NO toca
+// renderQuotaCard ni tickQuota (el % agregado del kpi card sigue intacto).
 async function tickProviderQuota(){
     const d = await fetchJson('/api/dash/quota');
     if(!d) return;
-    renderProviderQuotaRows(d);
+    _providerQuotaData = d;
+    renderProviderQuotaMatrix(d);
 }
 
 // Cuenta regresiva del ETA actualizada cada segundo sin re-fetch.
 setInterval(() => { if(_quotaLastData) renderQuotaCard(_quotaLastData); }, 1000);
+// #4533 — countdowns de reset de la matriz por proveedor, refrescados cada
+// segundo desde el último slice (sin re-fetch).
+setInterval(() => { if(_providerQuotaData) renderProviderQuotaMatrix(_providerQuotaData); }, 1000);
 
 // #2976 — Banner amarillo cuota agotada (modo determinístico).
 //
@@ -5038,84 +5109,111 @@ function renderMissionBanner(state) {
 // *pendiente*, no como consumo 0% ni caído. Se atenúa con la clase
 // `mz-ppct-pending` (opacity reducida en theme.css) y un `title` explícito; el
 // primer tick de tickProviderQuota reemplaza el texto con el dato real.
-function _mzProviderRow(bucket, key, name, color) {
-    return `
-        <div class="mz-prow" title="Consumo de ${escapeHtmlAttr(name)} en esta ventana (se hidrata con el dato real de cuota por proveedor).">
-          <span class="mz-pname"><span class="mz-pdot" style="background:${color}"></span>${escapeHtmlText(name)}</span>
-          <span class="mz-pbar"><i id="mz-quota-${bucket}-${key}-bar" style="width:0%;background:${color}"></i></span>
-          <span class="mz-ppct mz-ppct-pending" id="mz-quota-${bucket}-${key}-pct" title="Pendiente — se hidrata con el dato real de cuota del proveedor.">—</span>
-        </div>`;
-}
-
-// FUENTE ÚNICA de proveedores del desglose de cuota (CA-A2 #4249). La lista NO
-// se hardcodea suelta: se deriva de este mapa, alineado con los `provider`
-// activos de `.pipeline/state/multi-provider-health.json` y la allowlist de
-// adapters `ALLOWED_PROVIDERS` en `lib/quota-adapters/index.js`.
+// FUENTE ÚNICA de proveedores de la matriz de cuota (CA-A2 #4249, #4533). La
+// lista se deriva de este mapa, alineado con los `provider` activos de
+// `.pipeline/state/multi-provider-health.json` y la allowlist de adapters
+// `ALLOWED_PROVIDERS` en `lib/quota-adapters/index.js`.
 //
-// La `key` de cada entrada ES el id canónico de hidratación: las filas usan
-// `mz-quota-${bucket}-${key}-{bar,pct}`, por lo que la `key` DEBE coincidir
-// EXACTO con el id que emita el backend de #4202, o la fila queda en "—"
-// permanente (CA-A3 / CA-UX3). Se usan los ids de `ALLOWED_PROVIDERS`
-// (`openai-codex`, `gemini-google`) como canónicos.
+// La `key` de cada entrada ES el id canónico de hidratación (anthropic /
+// openai-codex / gemini-google / cerebras / nvidia-nim) y DEBE coincidir EXACTO
+// con el id que emite el slice `/api/dash/quota` (d.providers[key]).
 //
-// Colores: un hue perceptualmente distinto por proveedor (CA-UX1) — sin dos
-// puntos en la misma familia. `--in-accent2` (morado) se agrega en theme.css
-// para NVIDIA NIM y evitar el tercer verde.
-//
+// `src`: fuente fidedigna del % (CA #4533) — CLI (OAuth), API o headers
+// x-ratelimit. `color`: un hue perceptualmente distinto por proveedor (CA-UX1).
 // Groq fue descontinuado en #3353 — NO incluir.
 const MZ_PROVIDER_META = Object.freeze({
-    'anthropic':     { name: 'Anthropic',  color: 'var(--in-warn,#d29922)' },
-    'openai-codex':  { name: 'Codex',      color: 'var(--in-ok,#3fb950)' },
-    'gemini-google': { name: 'Gemini',     color: 'var(--in-info,#58a6ff)' },
-    'cerebras':      { name: 'Cerebras',   color: 'var(--in-accent,#2ee6c1)' },
-    'nvidia-nim':    { name: 'NVIDIA NIM', color: 'var(--in-accent2,#bc8cff)' },
+    'anthropic':     { name: 'Anthropic',  color: 'var(--in-warn,#d29922)',   src: 'CLI' },
+    'openai-codex':  { name: 'Codex',      color: 'var(--in-ok,#3fb950)',     src: 'CLI' },
+    'gemini-google': { name: 'Gemini',     color: 'var(--in-info,#58a6ff)',   src: 'API' },
+    'cerebras':      { name: 'Cerebras',   color: 'var(--in-accent,#2ee6c1)', src: 'headers' },
+    'nvidia-nim':    { name: 'NVIDIA NIM', color: 'var(--in-accent2,#bc8cff)', src: 'headers' },
 });
 const MZ_ACTIVE_PROVIDERS = Object.freeze(Object.keys(MZ_PROVIDER_META));
 
-function _mzProviderRows(bucket) {
-    return MZ_ACTIVE_PROVIDERS
-        .map((key) => _mzProviderRow(bucket, key, MZ_PROVIDER_META[key].name, MZ_PROVIDER_META[key].color))
-        .join('');
+// Rótulos de ventana por proveedor para el skeleton SSR (#4533). El backend
+// (lib/provider-quota.js PROVIDER_WINDOWS) es la fuente autoritativa y
+// sobreescribe estos labels al hidratar (cada celda rotula su ventana real);
+// acá sólo evitan un flash vacío antes del primer tick.
+const MZ_PROVIDER_WINDOWS = Object.freeze({
+    'anthropic':     { short: '5h',   long: 'Sem' },
+    'openai-codex':  { short: 'Roll', long: 'Sem' },
+    'gemini-google': { short: 'Min',  long: 'Día' },
+    'cerebras':      { short: 'Min',  long: 'Día' },
+    'nvidia-nim':    { short: 'Min',  long: 'Día' },
+});
+
+// Celda de ventana (skeleton). `slot` in {short,long}. La hidratación
+// (_mzHydrateWinCell) reescribe estado/color/countdown sin re-render.
+function _mzWinCell(key, slot, winLabel) {
+    const cid = 'mz-qm-' + key + '-' + slot;
+    return `
+        <div class="mz-qm-cell" id="${cid}" title="Se hidrata con la cuota disponible real del proveedor en esta ventana.">
+          <span class="mz-qm-wtag" id="${cid}-tag">${escapeHtmlText(winLabel)}</span>
+          <span class="mz-qm-mini"><i id="${cid}-bar" style="width:0%"></i></span>
+          <span class="mz-qm-pct" id="${cid}-pct">…</span>
+          <span class="mz-qm-rst" id="${cid}-rst"></span>
+        </div>`;
 }
 
-// Panel "Estado del sistema + Cuotas" (3 columnas). Col 1: semáforo global
-// (reusa renderSemaforo, vivo) + chips de anomalía / % rebote ola / agentes
-// vivos. Col 2/3: cuota de Sesión y Semanal con % agregado real + desglose por
-// proveedor. Reemplaza la barra inferior de tokens/rebotes/PRs (CA-5).
+function _mzProviderMatrixRow(key) {
+    const m = MZ_PROVIDER_META[key];
+    const w = MZ_PROVIDER_WINDOWS[key] || { short: 'Min', long: 'Día' };
+    return `
+      <div class="mz-qm-row">
+        <div class="mz-qm-prov">
+          <span class="mz-pdot" style="background:${m.color}"></span>
+          <span class="mz-qm-pn">${escapeHtmlText(m.name)}</span>
+          <span class="mz-qm-src">· ${escapeHtmlText(m.src)}</span>
+        </div>
+        ${_mzWinCell(key, 'short', w.short)}
+        ${_mzWinCell(key, 'long', w.long)}
+      </div>`;
+}
+
+function _mzProviderMatrix() {
+    return MZ_ACTIVE_PROVIDERS.map(_mzProviderMatrixRow).join('');
+}
+
+// Panel "Estado del sistema + Cuotas" (#4533). Izquierda: estado del sistema
+// COMPACTO (semáforo dot + label, sin el círculo gigante ni el chip redundante)
+// + señales accionables (anomalía, rebote de la ola, proveedores sanos).
+// Derecha: matriz de cuota DISPONIBLE por proveedor (5) × ventana (corta/larga)
+// con % disponible, color por umbral, y reset propio por bucket. Panel de
+// APOYO: compacto, no compite con "Ahora · En Ejecución" ni "Issues de la Ola".
+// El semáforo completo (con sus IDs `semaforo-*`) vive en el sink de telemetría
+// oculto para que `_missionMirrorKpis` y `tickAlertTray` sigan leyéndolo.
 function renderSystemQuotaPanel(state) {
+    const sem = (state && state.semaforo) || { level: 'ok', label: 'SALUDABLE' };
+    const lvl = (sem.level === 'warn' || sem.level === 'alert' || sem.level === 'stale') ? sem.level : 'ok';
     return `
     <section class="mz-sysquota" aria-label="Estado del sistema y cuotas">
-      <div class="mz-sq-cell mz-sq-status" title="Salud global del sistema y alertas activas (anomalía de consumo, % de rebotes de la ola).">
-        <div class="mz-sq-head">📟 ESTADO DEL SISTEMA</div>
-        ${renderSemaforo(state)}
-        <div class="mz-sq-chips">
-          <span class="mz-chip" id="mz-chip-anomaly" data-on="0"
-                title="Alerta de consumo anómalo de tokens. Se integra junto al estado del sistema.">⚠ <span>Anomalía consumo</span></span>
-          <span class="mz-chip mz-chip-ok"
-                title="Porcentaje de issues de la ola que rebotaron al menos una vez.">↩ Rebote ola <b id="mz-chip-rebote-value">—</b></span>
+      <div class="mz-sq-side" title="Salud global del sistema y señales accionables.">
+        <div class="mz-sq-head">📟 ESTADO</div>
+        <div class="mz-status-line mz-status-${escapeHtmlAttr(lvl)}" role="status"
+             aria-label="Salud global: ${escapeHtmlAttr(sem.label || '')}">
+          <span class="mz-status-dot" aria-hidden="true"></span>
+          <span class="mz-status-lbl">${escapeHtmlText(sem.label || '')}</span>
+        </div>
+        <div class="mz-sq-signals">
+          <span class="mz-sig" id="mz-chip-anomaly" data-on="0"
+                title="Consumo anómalo de tokens detectado por el semáforo.">⚠ <span>Anomalía consumo</span></span>
+          <span class="mz-sig mz-sig-ok"
+                title="Issues de la ola que rebotaron al menos una vez.">↩ Rebote ola <b id="mz-chip-rebote-value">—</b></span>
+          <span class="mz-sig mz-sig-ok"
+                title="Proveedores con cuota disponible (no agotados) sobre el total.">✓ Proveedores <b id="mz-sig-healthy">—</b></span>
         </div>
       </div>
-
-      <div class="mz-sq-cell" title="Cuota de la ventana de sesión (5h). % agregado real; desglose por proveedor en preparación.">
-        <div class="mz-q-head">
-          <div>
-            <div class="mz-q-klbl">⏱ CUOTA SESIÓN · 5H</div>
-            <div class="mz-q-kval" id="mz-quota-session-pct">…</div>
-          </div>
-          <div class="mz-q-ksub" id="mz-quota-session-eta">·</div>
+      <div class="mz-sq-matrix">
+        <div class="mz-qm-head">
+          <span class="mz-qm-h-l">🔌 CUOTA DISPONIBLE POR PROVEEDOR</span>
+          <span class="mz-qm-h-note">% leído del proveedor · reset propio por bucket</span>
         </div>
-        <div class="mz-prov">${_mzProviderRows('session')}</div>
-      </div>
-
-      <div class="mz-sq-cell" title="Cuota semanal. % agregado real; desglose por proveedor en preparación.">
-        <div class="mz-q-head">
-          <div>
-            <div class="mz-q-klbl">📅 CUOTA SEMANAL</div>
-            <div class="mz-q-kval" id="mz-quota-week-pct">…</div>
-          </div>
-          <div class="mz-q-ksub" id="mz-quota-week-eta">·</div>
+        <div class="mz-qm-cols">
+          <span class="mz-qm-gh">Proveedor</span>
+          <span class="mz-qm-gh">Ventana corta</span>
+          <span class="mz-qm-gh">Ventana larga</span>
         </div>
-        <div class="mz-prov">${_mzProviderRows('week')}</div>
+        <div class="mz-qm-body">${_mzProviderMatrix()}</div>
       </div>
     </section>`;
 }
@@ -5186,6 +5284,7 @@ function renderDiagnostics(state) {
     return `
     <div class="mz-telemetry-sink" id="mz-telemetry-sink" hidden aria-hidden="true">
       ${renderHiddenControls()}
+      ${renderSemaforo(state)}
       ${renderInfraHealth(state)}
       ${renderSystemCard(state)}
       ${renderKpiGrid(state)}
@@ -5385,10 +5484,12 @@ module.exports = {
     renderNowColumn,
     renderWaveBoard,
     renderDiagnostics,
-    // #4249 — desglose de cuota por proveedor (Bloque A): fuente única +
-    // helpers puros expuestos para test aislado del render por proveedor.
-    _mzProviderRow,
-    _mzProviderRows,
+    // #4249/#4533 — matriz de cuota por proveedor × ventana (Bloque A): fuente
+    // única + helpers puros expuestos para test aislado del render por proveedor.
+    _mzWinCell,
+    _mzProviderMatrixRow,
+    _mzProviderMatrix,
     MZ_PROVIDER_META,
+    MZ_PROVIDER_WINDOWS,
     MZ_ACTIVE_PROVIDERS,
 };


### PR DESCRIPTION
## Resumen

Rediseña el área **"Estado del sistema + Cuotas"** del home MIZPÁ: matriz de cuota **disponible por proveedor (5) × ventana (corta/larga)** con fuente fidedigna, panel compacto de apoyo, y **fix del bug "resetea · reseteó"**.

## Cambios

- **Fix bug "resetea · reseteó"** (`home.js`): cuando el reset venció (dato stale) ya no concatena `'resetea ' + '· reseteó'`. Nuevo helper `_resetEta(ts)` devuelve countdown válido o `'renovando…'`. Los ids `mz-quota-*-eta` pasan a `kpi-quota-*-eta`.
- **Nuevo agregador** `.pipeline/lib/provider-quota.js`: `available% = 100 - consumido` (clamp 0..100), reset propio por bucket, rótulo de ventana y modo (gauge/event/nodata) por proveedor. Seam `recordSample()`/`readCache()` para cachear `{remaining, limit, reset_at}` real (headers x-ratelimit / eventos) por proveedor+bucket, sin llamadas HTTP extra.
- **`quotaSlice`** enriquece `d.providers[key].{session,weekly}` con `available/resetAt/win/kind/mode` (exposición mínima: sin secretos/tokens/cost).
- **Frontend**: matriz con % disponible + color por umbral (verde/ámbar/rojo), 100% consumido = 0% disponible = rojo AGOTADA, countdown por bucket, chip "✓ sin límite" para Codex (eventos), "sin dato" explícito.
- **Adapter `nvidia-nim`** (stub headers x-ratelimit) + sumado a `ALLOWED_PROVIDERS`.
- Fix latente: el script del navegador referenciaba `MZ_ACTIVE_PROVIDERS`/`MZ_PROVIDER_META` de ámbito de módulo → ReferenceError silencioso; ahora embebidos como constantes de cliente.

## Verificación

- `node --test .pipeline/tests/provider-quota-4533.test.js` → 9/9 ✓
- `node --test .pipeline/lib/quota-adapters/*.test.js .pipeline/lib/__tests__/dashboard-slices*.test.js` → 128/128 ✓
- `node --check` sobre home.js, dashboard-slices.js, provider-quota.js, nvidia-nim.js → OK

## QA / merge

Cambio de **dashboard** (`.pipeline/*`, CODEOWNERS humano). Requiere merge a `main` + **restart del dashboard** para que la QA visual del home (CA-1..CA-8) evalúe el panel en vivo. `qa:skipped` no aplica: es UI de dashboard, QA visual obligatoria post-merge.

Closes #4533
