### PR TITLE
Dashboard: rediseñar el encabezado común MIZPÁ a una sola fila con bandeja de estado unificada

### DIFF
--- a/.pipeline/lib/__tests__/dashboard-slices-header-counts-4454.test.js
+++ b/.pipeline/lib/__tests__/dashboard-slices-header-counts-4454.test.js
@@ -15,6 +15,8 @@
 
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
 const path = require('node:path');
 
 const slices = require('../dashboard-slices');
@@ -93,4 +95,33 @@ test('#4454: sin bloqueados-humano el badge refleja los dependency-blocked', () 
     const out = slices.headerSlice(baseState({ activeWave: { issues: [1] } }), CTX);
     assert.equal(out.counts.bloqueados, new Set(dep).size,
         'sólo dependency-blocked cuando state.bloqueados está vacío');
+});
+
+test('#4531: headerSlice expone build status real y degrada sin signo de pregunta', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'intrale-header-build-'));
+    try {
+        fs.writeFileSync(path.join(tmp, 'build-status.json'), JSON.stringify({
+            status: 'passing',
+            branch: 'agent/4531-pipeline-dev',
+            commit: 'abcdef1234567890',
+        }));
+        const out = slices.headerSlice(baseState({ activeWave: { issues: [4531] } }), { PIPELINE: tmp });
+        assert.deepEqual(out.build, {
+            status: 'passing',
+            branch: 'agent/4531-pipeline-dev',
+            commit: 'abcdef123456',
+        });
+    } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+    }
+});
+
+test('#4531: headerSlice devuelve build unknown cuando falta el marker', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'intrale-header-build-missing-'));
+    try {
+        const out = slices.headerSlice(baseState({ activeWave: { issues: [4531] } }), { PIPELINE: tmp });
+        assert.deepEqual(out.build, { status: 'unknown', branch: '', commit: '' });
+    } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+    }
 });

--- a/.pipeline/lib/dashboard-slices.js
+++ b/.pipeline/lib/dashboard-slices.js
@@ -179,6 +179,17 @@ function safeReadJson(filepath, fallback) {
     catch { return fallback; }
 }
 
+function readBuildStatus(pipelineDir) {
+    const raw = safeReadJson(path.join(pipelineDir, 'build-status.json'), null);
+    if (!raw || typeof raw !== 'object') return { status: 'unknown', branch: '', commit: '' };
+    const allowed = { passing: 1, failing: 1, running: 1, unknown: 1 };
+    return {
+        status: allowed[raw.status] ? raw.status : 'unknown',
+        branch: typeof raw.branch === 'string' ? raw.branch.slice(0, 80) : '',
+        commit: typeof raw.commit === 'string' ? raw.commit.slice(0, 12) : '',
+    };
+}
+
 // #4335 — Directorio de logs servido por los endpoints genéricos del dashboard
 // (`/logs/view|stream/<file>`). __dirname = `.pipeline/lib` → `.pipeline/logs`.
 // `_logDirOverride` permite aislar el directorio en tests (mismo patrón que el
@@ -661,6 +672,7 @@ function headerSlice(state, ctx) {
         },
         priorityWindows,
         resources,
+        build: readBuildStatus(PIPELINE),
         restMode,
         timestamp: Date.now(),
     };

--- a/.pipeline/views/dashboard/__tests__/header-meta.test.js
+++ b/.pipeline/views/dashboard/__tests__/header-meta.test.js
@@ -26,10 +26,18 @@ const { renderHeaderMetaSsr, headerPillsClientScript, headerPillsPollClientScrip
 
 test('renderHeaderMetaSsr() emite los tres IDs invariantes (recursos, pulpo, reloj)', () => {
     const html = renderHeaderMetaSsr();
+    assert.match(html, /id="bld-status"/, 'falta la pill de build');
     assert.match(html, /id="hdr-resources"/, 'falta la pill de recursos CPU/RAM');
     assert.match(html, /id="hdr-pulpo"/, 'falta la pill de uptime del Pulpo');
     assert.match(html, /id="hdr-clock"/, 'falta el reloj');
     assert.match(html, /class="in-header-meta"/, 'falta el contenedor in-header-meta');
+});
+
+test('la bandeja de estado no muestra signo de pregunta en build desconocido', () => {
+    const html = renderHeaderMetaSsr({ withMode: true });
+    const script = headerPillsClientScript();
+    assert.doesNotMatch(html + script, /Build \?/, 'el estado unknown debe mostrarse como Build sin datos');
+    assert.match(html + script, /Build sin datos/, 'fallback explícito para build desconocido');
 });
 
 test('sin withMode NO emite #hdr-mode (comportamiento de home, #4227)', () => {
@@ -52,15 +60,17 @@ test('preserva title y aria-label literales de las pills (contrato de accesibili
     assert.match(html, /title="CPU y RAM del sistema"/, 'title de recursos preservado');
     assert.match(html, /aria-label="Recursos CPU y RAM"/, 'aria-label de recursos preservado');
     assert.match(html, /aria-label="Estado del pulpo"/, 'aria-label del pulpo preservado');
-    assert.match(html, /aria-label="Hora local"/, 'aria-label del reloj preservado');
+    assert.match(html, /aria-label="Fecha y hora local"/, 'aria-label del reloj preservado');
 });
 
 test('orden estable de las pills: [mode] → recursos → pulpo → reloj (guideline UX-3)', () => {
     const html = renderHeaderMetaSsr({ withMode: true });
+    const iBuild = html.indexOf('id="bld-status"');
     const iMode = html.indexOf('id="hdr-mode"');
     const iRes = html.indexOf('id="hdr-resources"');
     const iPulpo = html.indexOf('id="hdr-pulpo"');
     const iClock = html.indexOf('id="hdr-clock"');
+    assert.ok(iBuild >= 0 && iBuild < iMode, 'build antes de mode');
     assert.ok(iMode >= 0 && iMode < iRes, 'mode antes de recursos');
     assert.ok(iRes < iPulpo, 'recursos antes de pulpo');
     assert.ok(iPulpo < iClock, 'pulpo antes del reloj');
@@ -87,6 +97,7 @@ test('la hidratación conserva la señal de presión de recursos (ok/warn/bad)',
     assert.match(script, /in-pill-ok/, 'clase ok');
     assert.match(script, /in-pill-warn/, 'clase warn');
     assert.match(script, /in-pill-bad/, 'clase bad');
+    assert.match(script, /in-resource-alert/, 'resalta la métrica específica que supera el cap');
     // Umbrales históricos preservados (cálculo sin cambios).
     assert.match(script, /maxCpu/, 'umbral de CPU');
     assert.match(script, /maxMem/, 'umbral de RAM');

--- a/.pipeline/views/dashboard/__tests__/home.test.js
+++ b/.pipeline/views/dashboard/__tests__/home.test.js
@@ -68,11 +68,12 @@ test('cada sub-función devuelve string con state {} (sin throw)', () => {
     }
 });
 
-test('renderBrandBar poblado emite el pill de build status', () => {
+test('renderBrandBar poblado emite identidad y selector sin mezclar build', () => {
     const out = renderBrandBar({ build: { status: 'passing', branch: 'main', commit: 'abc1234' } });
-    assert.match(out, /id="bld-status"/);
-    assert.match(out, /Build OK/);
-    assert.match(out, /in-pill-ok/);
+    assert.match(out, /MIZP/);
+    assert.match(out, /id="mz-projsel"/);
+    assert.doesNotMatch(out, /id="bld-status"/);
+    assert.doesNotMatch(out, /Build OK/);
 });
 
 test('renderInfraHealth poblado emite UP/DOWN + filas por servicio', () => {
@@ -103,26 +104,28 @@ test('renderSystemCard poblado emite las 4 celdas whitelisted', () => {
 // ---------------------------------------------------------------------------
 // CA-3725.1 — build status 'unknown' degradado cuando el marker no existe.
 // ---------------------------------------------------------------------------
-test('renderBrandBar sin build status muestra unknown sin romper', () => {
-    const out = renderBrandBar({ build: { status: 'unknown', branch: '', commit: '' } });
-    assert.match(out, /Build \?/);
+test('renderHomeHTML sin build status muestra fallback explícito sin romper', () => {
+    const out = renderHomeHTML({});
+    assert.match(out, /id="bld-status"/);
+    assert.match(out, /Build sin datos/);
     assert.match(out, /in-pill-info/);
+    assert.doesNotMatch(out, /Build \?/);
 });
 
-test('renderBrandBar nunca invoca gh api (R-G4) — sin la cadena en el markup', () => {
-    const out = renderBrandBar({ build: { status: 'passing', branch: 'main', commit: 'abc' } });
+test('renderHomeHTML nunca invoca gh api (R-G4) — sin la cadena en el markup', () => {
+    const out = renderHomeHTML({});
     assert.ok(!/gh api/.test(out) || /sin gh api/.test(out),
         'el markup no debe sugerir invocación de gh api salvo en la nota explicativa');
 });
 
 // ---------------------------------------------------------------------------
-// CA-3725.13 — XSS en contexto BODY: el payload se escapa, no se inyecta crudo.
-// renderBrandBar consume branch/commit (atacante-controlables vía Git).
+// CA-3725.13 — XSS en contexto BODY: el payload de build ya no se interpola en
+// SSR. El detalle branch/commit se hidrata por textContent/title en el cliente.
 // ---------------------------------------------------------------------------
-test('XSS body: renderBrandBar escapa <script> en branch', () => {
+test('XSS body: renderBrandBar no interpola branch en la marca', () => {
     const out = renderBrandBar({ build: { status: 'passing', branch: XSS_BODY, commit: '' } });
     assert.ok(!out.includes(XSS_BODY), 'el <script> crudo NO debe aparecer en el body');
-    assert.match(out, /&lt;script&gt;/, 'debe aparecer escapado');
+    assert.doesNotMatch(out, /&lt;script&gt;/, 'la marca no debe renderizar detalle de build');
 });
 
 test('XSS body: sin doble-escape de entidades existentes', () => {
@@ -132,13 +135,13 @@ test('XSS body: sin doble-escape de entidades existentes', () => {
 });
 
 // ---------------------------------------------------------------------------
-// CA-3725.13 / CA-3725.10 — XSS en contexto ATRIBUTO: branch en aria-label/title.
+// CA-3725.13 / CA-3725.10 — XSS en contexto ATRIBUTO: branch no entra al SSR.
 // ---------------------------------------------------------------------------
-test('XSS atributo: renderBrandBar escapa comillas en title/aria-label', () => {
+test('XSS atributo: renderBrandBar no interpola branch en title/aria-label', () => {
     const out = renderBrandBar({ build: { status: 'passing', branch: XSS_ATTR, commit: '' } });
     // El payload rompe-atributo no debe aparecer crudo dentro de un valor.
     assert.ok(!out.includes('onerror=alert(1)>'), 'el payload no debe romper el atributo');
-    assert.match(out, /&quot;|&gt;/, 'las comillas/ángulos deben quedar escapados');
+    assert.ok(!out.includes('&quot;'), 'la marca no debe renderizar detalle de build en atributos');
 });
 
 test('XSS atributo: renderSystemCard escapa tooltips (defensa, tips estáticos)', () => {

--- a/.pipeline/views/dashboard/header-meta.js
+++ b/.pipeline/views/dashboard/header-meta.js
@@ -55,9 +55,17 @@ function renderHeaderMetaSsr(opts) {
         : '';
     return `
     <div class="in-header-meta">
-      ${modePill}<span class="in-pill" id="hdr-resources" title="CPU y RAM del sistema" aria-label="Recursos CPU y RAM">…</span>
+      <span class="in-pill in-build-status in-pill-info" id="bld-status"
+            title="Estado del último build (marker local .pipeline/build-status.json, sin gh api)."
+            aria-label="Build sin datos"><span class="in-status-dot" aria-hidden="true">○</span><span id="bld-status-label">Build sin datos</span></span>
+      ${modePill}<span class="in-pill" id="hdr-resources" title="CPU y RAM del sistema" aria-label="Recursos CPU y RAM">
+        <span aria-hidden="true">🖥</span>
+        <span id="hdr-resources-cpu">CPU …</span>
+        <span class="in-header-divider" aria-hidden="true">·</span>
+        <span id="hdr-resources-mem">RAM …</span>
+      </span>
       <span class="in-pill" id="hdr-pulpo" aria-label="Estado del pulpo">…</span>
-      <span class="in-pill in-clock" id="hdr-clock" aria-label="Hora local">…</span>
+      <span class="in-pill in-clock" id="hdr-clock" aria-label="Fecha y hora local">…</span>
     </div>`;
 }
 
@@ -95,6 +103,29 @@ if (!window.__hydrateHeaderPills) {
     };
     window.__hydrateHeaderPills = function (d) {
         if (!d) return;
+        var buildPill = document.getElementById('bld-status');
+        if (buildPill) {
+            var status = d.build && d.build.status ? d.build.status : 'unknown';
+            var buildMeta = {
+                passing: { cls: 'in-pill-ok', dot: '🟢', label: 'Build OK' },
+                failing: { cls: 'in-pill-bad', dot: '🔴', label: 'Build roto' },
+                running: { cls: 'in-pill-warn', dot: '🟡', label: 'Build corriendo' },
+                unknown: { cls: 'in-pill-info', dot: '○', label: 'Build sin datos' }
+            };
+            var bm = buildMeta[status] || buildMeta.unknown;
+            buildPill.classList.remove('in-pill-ok', 'in-pill-warn', 'in-pill-bad', 'in-pill-info');
+            buildPill.classList.add(bm.cls);
+            var dot = buildPill.querySelector('.in-status-dot');
+            var labelEl = document.getElementById('bld-status-label');
+            if (dot) dot.textContent = bm.dot;
+            if (labelEl) labelEl.textContent = bm.label;
+            var detail = [];
+            if (d.build && d.build.branch) detail.push(d.build.branch);
+            if (d.build && d.build.commit) detail.push(d.build.commit);
+            buildPill.title = 'Estado del último build (marker local .pipeline/build-status.json, sin gh api). '
+                + bm.label + (detail.length ? ' · ' + detail.join(' · ') : '');
+            buildPill.setAttribute('aria-label', bm.label + (detail.length ? ' ' + detail.join(' ') : ''));
+        }
         // Pill del Pulpo: estado (verde/rojo) + uptime formateado.
         var pulpoPill = document.getElementById('hdr-pulpo');
         if (pulpoPill) {
@@ -108,17 +139,34 @@ if (!window.__hydrateHeaderPills) {
         if (resPill && res) {
             var cpu = res.cpuPercent != null ? res.cpuPercent : '?';
             var mem = res.memPercent != null ? res.memPercent : '?';
-            resPill.textContent = '🖥 CPU ' + cpu + '% · RAM ' + mem + '%';
+            var cpuEl = document.getElementById('hdr-resources-cpu');
+            var memEl = document.getElementById('hdr-resources-mem');
+            if (cpuEl) cpuEl.textContent = 'CPU ' + cpu + '%';
+            if (memEl) memEl.textContent = 'RAM ' + mem + '%';
             resPill.classList.remove('in-pill-ok', 'in-pill-warn', 'in-pill-bad');
+            if (cpuEl) cpuEl.classList.remove('in-resource-alert');
+            if (memEl) memEl.classList.remove('in-resource-alert');
             var maxCpu = res.maxCpu || 70;
             var maxMem = res.maxMem || 70;
             var worst = Math.max(Number(cpu) || 0, Number(mem) || 0);
-            if ((Number(cpu) || 0) > maxCpu || (Number(mem) || 0) > maxMem) resPill.classList.add('in-pill-bad');
+            var cpuAlert = (Number(cpu) || 0) > maxCpu;
+            var memAlert = (Number(mem) || 0) > maxMem;
+            if (cpuAlert && cpuEl) cpuEl.classList.add('in-resource-alert');
+            if (memAlert && memEl) memEl.classList.add('in-resource-alert');
+            if (cpuAlert || memAlert) resPill.classList.add('in-pill-bad');
             else if (worst > 50) resPill.classList.add('in-pill-warn');
             else resPill.classList.add('in-pill-ok');
             resPill.title = 'CPU ' + cpu + '% (cap ' + maxCpu + '%) · RAM ' + mem + '% ('
                 + (res.memUsedGB || '?') + 'GB / ' + (res.memTotalGB || '?') + 'GB · cap ' + maxMem + '%) · '
                 + (res.cpuCores || '?') + ' cores';
+        }
+        var clockPill = document.getElementById('hdr-clock');
+        if (clockPill) {
+            var now = new Date();
+            var date = now.toLocaleDateString('es-AR', { weekday: 'short', day: '2-digit', month: '2-digit' });
+            var time = now.toLocaleTimeString('es-AR', { hour: '2-digit', minute: '2-digit' });
+            clockPill.textContent = '🕒 ' + date + ' · ' + time;
+            clockPill.title = 'Fecha y hora local: ' + date + ' ' + time;
         }
     };
 }

--- a/.pipeline/views/dashboard/home.js
+++ b/.pipeline/views/dashboard/home.js
@@ -4412,24 +4412,12 @@ function collectHomeState(opts) {
 
 // --- Sub-función pura: brand bar V3 (logo + ambiente + build status) --------
 function renderBrandBar(state) {
-    const b = (state && state.build) || { status: 'unknown', branch: '', commit: '' };
-    const STATUS_META = {
-        passing: { cls: 'in-pill-ok', icon: '🟢', label: 'Build OK' },
-        failing: { cls: 'in-pill-bad', icon: '🔴', label: 'Build roto' },
-        running: { cls: 'in-pill-warn', icon: '🟡', label: 'Build corriendo' },
-        unknown: { cls: 'in-pill-info', icon: '○', label: 'Build ?' },
-    };
-    const meta = STATUS_META[b.status] || STATUS_META.unknown;
-    const detail = [b.branch, b.commit].filter(Boolean).join(' · ');
-    const tip = 'Estado del último build (marker local .pipeline/build-status.json, sin gh api). '
-        + meta.label + (detail ? ' · ' + detail : '');
-    const detailHtml = detail ? ' · <span class="in-build-detail">' + escapeHtmlText(detail) + '</span>' : '';
     // #4189 — Marca producto MIZPÁ (atalaya de agentes, Génesis 31:49) + selector
     // de proyecto multiproyecto. MIZPÁ es el motor; el proyecto es intercambiable
     // (hoy Intrale, 1 de 3). El selector es informativo/estático en esta entrega
     // (la conmutación real de proyecto es trabajo futuro); lleva tooltip que lo
-    // explica. El pill de build (id="bld-status") se conserva para el ticker
-    // tickHeader y los contratos de test (R-G1/CA-3725).
+    // explica. El estado de build vive en la bandeja derecha común
+    // renderHeaderMetaSsr(), junto a CPU/RAM, Pulpo y reloj.
     const logoSvg = '<svg viewBox="0 0 24 24" fill="none" aria-hidden="true">'
         + '<path d="M12 2.5 5 6v5c0 4.6 3 8 7 9.5 4-1.5 7-4.9 7-9.5V6l-7-3.5Z" stroke="#06121a" stroke-width="1.6" fill="rgba(255,255,255,.16)"/>'
         + '<path d="M9.5 12.5 11.3 14.3 14.8 10.4" stroke="#06121a" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"/></svg>';
@@ -4451,9 +4439,6 @@ function renderBrandBar(state) {
         <span class="mz-proj-badge">1 / 3</span>
         <span class="mz-proj-caret" aria-hidden="true">▾</span>
       </div>
-      <span class="in-pill in-build-status ${meta.cls}" id="bld-status"
-            title="${escapeHtmlAttr(tip)}"
-            aria-label="${escapeHtmlAttr(meta.label + (detail ? ' ' + detail : ''))}">${meta.icon} ${escapeHtmlText(meta.label)}${detailHtml}</span>
     </div>`;
 }
 

--- a/.pipeline/views/dashboard/issues.js
+++ b/.pipeline/views/dashboard/issues.js
@@ -1352,7 +1352,7 @@ function renderIssuesClientScript() {
     if (bld && d.build) {
       var META = {
         passing: { cls: 'in-pill-ok', t: '🟢 Build OK' }, failing: { cls: 'in-pill-bad', t: '🔴 Build roto' },
-        running: { cls: 'in-pill-warn', t: '🟡 Build corriendo' }, unknown: { cls: 'in-pill-info', t: '○ Build ?' }
+        running: { cls: 'in-pill-warn', t: '🟡 Build corriendo' }, unknown: { cls: 'in-pill-info', t: '○ Build sin datos' }
       };
       var m = META[d.build.status] || META.unknown;
       bld.classList.remove('in-pill-ok', 'in-pill-bad', 'in-pill-warn', 'in-pill-info');

--- a/.pipeline/views/dashboard/kpis.js
+++ b/.pipeline/views/dashboard/kpis.js
@@ -1197,7 +1197,7 @@ function renderKpisChromeScript() {
     }
     var bld=document.getElementById("bld-status");
     if(bld&&d.build){
-      var META={passing:{cls:"in-pill-ok",t:"🟢 Build OK"},failing:{cls:"in-pill-bad",t:"🔴 Build roto"},running:{cls:"in-pill-warn",t:"🟡 Build corriendo"},unknown:{cls:"in-pill-info",t:"○ Build ?"}};
+      var META={passing:{cls:"in-pill-ok",t:"🟢 Build OK"},failing:{cls:"in-pill-bad",t:"🔴 Build roto"},running:{cls:"in-pill-warn",t:"🟡 Build corriendo"},unknown:{cls:"in-pill-info",t:"○ Build sin datos"}};
       var m=META[d.build.status]||META.unknown;
       bld.classList.remove("in-pill-ok","in-pill-bad","in-pill-warn","in-pill-info");
       bld.classList.add(m.cls);

--- a/.pipeline/views/dashboard/pipeline-redesign.js
+++ b/.pipeline/views/dashboard/pipeline-redesign.js
@@ -119,7 +119,7 @@ function renderBrandBarPipeline() {
         <span class="mz-proj-caret" aria-hidden="true">▾</span>
       </div>
       <span class="in-pill in-pill-info in-build-status" id="bld-status"
-            title="Estado del último build (marker local .pipeline/build-status.json).">○ Build ?</span>
+            title="Estado del último build (marker local .pipeline/build-status.json).">○ Build sin datos</span>
     </div>`;
 }
 

--- a/.pipeline/views/dashboard/theme.css
+++ b/.pipeline/views/dashboard/theme.css
@@ -111,6 +111,16 @@ a:hover { color: var(--in-accent); }
   font-size: 12px;
   font-weight: 500;
 }
+.in-header-meta {
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+.in-header-divider { color: var(--in-fg-dim); }
+.in-status-dot { line-height: 1; }
+.in-resource-alert {
+  color: var(--in-bad);
+  font-weight: 800;
+}
 .in-pill-ok { background: var(--in-ok-soft); border-color: var(--in-ok); color: var(--in-ok); }
 .in-pill-warn { background: var(--in-warn-soft); border-color: var(--in-warn); color: var(--in-warn); }
 .in-pill-bad { background: var(--in-bad-soft); border-color: var(--in-bad); color: var(--in-bad); }


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 10 archivos · +141 -41

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:passed` aplicado por delivery

## Closes

Closes #4531
