### PR TITLE
fix(pipeline): quota-detector atribuye usage-limit de Codex/ChatGPT a Anthropic (misatribución) → Anthropic falsamente gateado y todo rebota a fallback

### DIFF
--- a/.pipeline/assets/docs/4541/review-aprobacion-4541.md
+++ b/.pipeline/assets/docs/4541/review-aprobacion-4541.md
@@ -1,0 +1,19 @@
+# Code Review — Issue #4541 (quota-detector misatribucion)
+
+**Veredicto: APROBADO** · fase aprobacion · pipeline desarrollo
+
+## Alcance revisado
+- pulpo.js onSpawnExit (Bug 1), provider-error-parser.js detectFromCliStderr (Bug 2)
+- Tests onSpawnExit.test.js + provider-error-parser.test.js
+- Bundle #4513: config.yaml, skill-deliverable-attachments.js, SKILL.md
+
+## Hallazgos
+- Bloqueantes: ninguno.
+- Menor no bloqueante: skillModel par provider/model inconsistente si effectiveModel null (rama casi nunca alcanzada; gateo per-provider).
+
+## Verificacion empirica
+- node --check OK; node --test 56/56 pass 0 fail.
+- Tests #4541 usan modulo real de quota + raw_excerpt reales del incidente.
+
+## Calidad
+- Bug 1 usa dispatchResolution.provider (fuente #4284). Bug 2 acota a plainTextLines. Respeta #3077.

--- a/.pipeline/deliverables/4541.json
+++ b/.pipeline/deliverables/4541.json
@@ -1,0 +1,15 @@
+{
+  "issue": 4541,
+  "entries": [
+    {
+      "issue": 4541,
+      "fase": "aprobacion",
+      "agente": "review",
+      "tipo": "document",
+      "path": ".pipeline/assets/docs/4541/review-aprobacion-4541.md",
+      "bytes": 807,
+      "sensible": false,
+      "timestamp": "2026-07-07T16:29:12.993Z"
+    }
+  ]
+}

--- a/.pipeline/lib/agent-launcher/__tests__/onSpawnExit.test.js
+++ b/.pipeline/lib/agent-launcher/__tests__/onSpawnExit.test.js
@@ -239,6 +239,104 @@ test('CA-2 onSpawnExit extrae errorType del evidence cuando es JSON', () => {
         'debe usar el errorType extraído, no el primer default');
 });
 
+// -----------------------------------------------------------------------------
+// #4541 — Misatribución de provider (Codex → Anthropic) + falso positivo sobre
+// contenido. Estos tests usan el módulo REAL de quota (con el `_detectOpenAI`
+// completo y el regex de canal de control de Codex) y espían `setFlag` para
+// verificar el provider EFECTIVO al que se atribuye el flag.
+// -----------------------------------------------------------------------------
+
+// Módulo real con setFlag espiado (preserva _detectAnthropic/_detectOpenAI/
+// KNOWN_QUOTA_ERROR_TYPES_BY_PROVIDER/sanitizeRawExcerpt reales vía prototype).
+function realQuotaWithSpy() {
+    const realQuota = require('../../quota-exhausted');
+    const setCalls = [];
+    const spy = Object.create(realQuota);
+    spy.setFlag = (input) => { setCalls.push(input); return { flagPath: '/tmp/x', payload: {}, source: 'input' }; };
+    spy._setCalls = setCalls;
+    return spy;
+}
+
+// Frame REAL de error del CLI Codex (canal de control) del incidente 2026-07-07.
+const INCIDENT_CODEX_ERROR_FRAME =
+    '{"type":"error","message":"You\'ve hit your usage limit. Upgrade to Pro ' +
+    '(https://chatgpt.com/explore/pro), visit https://chatgpt.com/codex/settings/usage ' +
+    'to purchase more credits or try again at Jul 7th, 2026 11:19 AM."}';
+
+const INCIDENT_TOOL_RESULT_CONTENT =
+    '{"type":"user","message":{"role":"user","content":[{"tool_use_id":"toolu_01TQ9E5H6kQaGL9GT7LKwPJE",' +
+    '"type":"tool_result","content":"Analicé el log del detector y encontré este mensaje de Codex: ' +
+    'You\'ve hit your usage limit. Upgrade to Pro (https://chatgpt.com/codex/settings/usage)."}]}}';
+
+test('#4541 CA-1/CA-3: error real de Codex con provider efectivo=openai-codex flaguea a openai-codex', () => {
+    const tmp = makeTmpPipeline();
+    const quota = realQuotaWithSpy();
+    const result = dispatcher.onSpawnExit({
+        skill: 'qa',
+        issue: 4541,
+        // El pulpo pasa el provider EFECTIVO que corrió (el fallback codex), no
+        // el primary configurado del skill. Este es el fix de atribución (Bug 1).
+        provider: 'openai-codex',
+        transport: 'cli',
+        rawOutput: INCIDENT_CODEX_ERROR_FRAME,
+        exitCode: 1,
+        timedOut: false,
+        durationMs: 4000,
+        pipelineDir: tmp,
+        quotaModule: quota,
+    });
+    assert.equal(result.errorClass, 'quota_exhausted');
+    assert.equal(result.flagSet, true);
+    assert.equal(quota._setCalls.length, 1, 'debe setear exactamente un flag');
+    assert.equal(quota._setCalls[0].provider, 'openai-codex',
+        'el flag DEBE atribuirse a Codex, nunca a Anthropic');
+    // El errorType persistido debe pertenecer a la allowlist de Codex.
+    const codexTypes = quota.KNOWN_QUOTA_ERROR_TYPES_BY_PROVIDER['openai-codex'];
+    assert.ok(codexTypes.includes(quota._setCalls[0].errorType),
+        `errorType "${quota._setCalls[0].errorType}" debe ser de Codex`);
+});
+
+test('#4541 CA-1: mismo error de Codex con provider=anthropic NO setea flag de Anthropic', () => {
+    const tmp = makeTmpPipeline();
+    const quota = realQuotaWithSpy();
+    const result = dispatcher.onSpawnExit({
+        skill: 'qa',
+        issue: 4541,
+        provider: 'anthropic',
+        transport: 'cli',
+        rawOutput: INCIDENT_CODEX_ERROR_FRAME,
+        exitCode: 1,
+        timedOut: false,
+        durationMs: 4000,
+        pipelineDir: tmp,
+        quotaModule: quota,
+    });
+    assert.notEqual(result.errorClass, 'quota_exhausted',
+        'un error de Codex NO debe clasificar quota bajo la allowlist de Anthropic');
+    assert.equal(quota._setCalls.length, 0,
+        'NUNCA setear un flag de Anthropic desde un error de Codex');
+});
+
+test('#4541 CA-2: tool_result con "usage limit" NO setea flag (falso positivo del incidente)', () => {
+    const tmp = makeTmpPipeline();
+    const quota = realQuotaWithSpy();
+    const result = dispatcher.onSpawnExit({
+        skill: 'qa',
+        issue: 4541,
+        provider: 'anthropic',
+        transport: 'cli',
+        rawOutput: INCIDENT_TOOL_RESULT_CONTENT,
+        exitCode: 0,
+        timedOut: false,
+        durationMs: 4000,
+        pipelineDir: tmp,
+        quotaModule: quota,
+    });
+    assert.notEqual(result.errorClass, 'quota_exhausted');
+    assert.equal(quota._setCalls.length, 0,
+        'contenido de tool_result no debe disparar setFlag');
+});
+
 test('CA-2 _selectErrorTypeForFlag cae al primer elemento de la allowlist si no puede extraer', () => {
     const verdict = { errorClass: 'quota_exhausted', evidence: 'texto libre sin shape' };
     const errorType = dispatcher._selectErrorTypeForFlag('gemini-google', verdict, {

--- a/.pipeline/lib/agent-launcher/__tests__/provider-error-parser.test.js
+++ b/.pipeline/lib/agent-launcher/__tests__/provider-error-parser.test.js
@@ -119,6 +119,94 @@ test('codex ChatGPT: "hit your usage limit" en stderr texto plano clasifica quot
     assert.equal(r.shouldFallback, true);
 });
 
+// -----------------------------------------------------------------------------
+// #4541 — Misatribución de provider + falso positivo sobre contenido normal.
+//
+// Regresión del incidente 2026-07-07: el detector marcaba a Anthropic como
+// quota-exhausted usando errores de límite de Codex/ChatGPT. Dos causas:
+//   Bug 1 (misatribución): el error de Codex se atribuía al primary configurado
+//     (anthropic) en vez del provider efectivo que corrió (openai-codex).
+//   Bug 2 (falso positivo): los regex de texto libre matcheaban contenido
+//     legítimo del agente (`tool_result` que menciona "usage limit").
+//
+// Los `raw_excerpt` de estos tests son los REALES del incidente
+// (`.pipeline/logs/quota-detector-2026-07-07.log`), saneados.
+// -----------------------------------------------------------------------------
+
+// Frame REAL de error del CLI Codex (canal de control) del incidente.
+const INCIDENT_CODEX_ERROR_FRAME =
+    '{"type":"error","message":"You\'ve hit your usage limit. Upgrade to Pro ' +
+    '(https://chatgpt.com/explore/pro), visit https://chatgpt.com/codex/settings/usage ' +
+    'to purchase more credits or try again at Jul 7th, 2026 11:19 AM."}';
+
+// Línea REAL de contenido (`type:user` → `tool_result`) del incidente: NO es un
+// error, es contenido del agente. Aunque acá le agregamos el texto "usage limit"
+// embebido para forzar el peor caso del falso positivo (Bug 2).
+const INCIDENT_TOOL_RESULT_CONTENT =
+    '{"type":"user","message":{"role":"user","content":[{"tool_use_id":"toolu_01TQ9E5H6kQaGL9GT7LKwPJE",' +
+    '"type":"tool_result","content":"Analicé el log del detector y encontré este mensaje de Codex: ' +
+    'You\'ve hit your usage limit. Upgrade to Pro (https://chatgpt.com/codex/settings/usage)."}]}}';
+
+test('#4541 CA-3: frame de error REAL de Codex con provider=openai-codex clasifica quota_exhausted', () => {
+    const r = parseProviderError(INCIDENT_CODEX_ERROR_FRAME, {
+        provider: 'openai-codex',
+        transport: 'cli',
+    });
+    assert.equal(r.errorClass, 'quota_exhausted',
+        'el error real de Codex debe clasificar quota (para flaguear codex)');
+    assert.equal(r.shouldFallback, true);
+});
+
+test('#4541 CA-1: el MISMO frame de Codex bajo provider=anthropic NO clasifica quota (no misatribución)', () => {
+    // Bajo la allowlist de Anthropic, un frame de Codex (`type:error`, sin
+    // `error_type` estructural de anthropic) NO debe clasificar quota: es una
+    // línea JSON del stream, así que los regex de texto libre no la tocan y la
+    // detección estructural de anthropic (type:result+is_error) no matchea.
+    // Antes de #4541 el regex `hit your usage limit` la marcaba → flag espurio
+    // de anthropic.
+    const r = parseProviderError(INCIDENT_CODEX_ERROR_FRAME, {
+        provider: 'anthropic',
+        transport: 'cli',
+    });
+    assert.notEqual(r.errorClass, 'quota_exhausted',
+        'un error de Codex NUNCA debe setear el flag de Anthropic');
+});
+
+test('#4541 CA-2: tool_result con "usage limit" en el contenido NO clasifica quota (falso positivo)', () => {
+    // El primer flag del incidente (01:17) era exactamente esto: contenido
+    // legítimo de un `tool_result` que menciona "usage limit". No es un error.
+    const r = parseProviderError(INCIDENT_TOOL_RESULT_CONTENT, {
+        provider: 'anthropic',
+        transport: 'cli',
+    });
+    assert.notEqual(r.errorClass, 'quota_exhausted',
+        'contenido del agente (tool_result) NO debe disparar quota_exhausted');
+});
+
+test('#4541 CA-2: tool_result con texto de Codex tampoco flaguea bajo provider=openai-codex', () => {
+    // Defensa en profundidad: aun si el provider efectivo fuese codex, el texto
+    // dentro de un `tool_result` (contenido, no canal de control) no debe
+    // clasificar quota. Solo el frame de control estructural (type:error /
+    // turn.failed) cuenta como error real del CLI.
+    const r = parseProviderError(INCIDENT_TOOL_RESULT_CONTENT, {
+        provider: 'openai-codex',
+        transport: 'cli',
+    });
+    assert.notEqual(r.errorClass, 'quota_exhausted',
+        'el contenido tool_result no es el payload de error del CLI');
+});
+
+test('#4541 Bug 2: stderr de texto plano legítimo (sin JSON) SIGUE clasificando quota', () => {
+    // No sobre-corregimos: un error de CLI que llega como texto plano degradado
+    // (crash antes del JSON) debe seguir detectándose por regex.
+    const r = parseProviderError('API Error: Usage credits required — sin créditos.', {
+        provider: 'anthropic',
+        transport: 'cli',
+    });
+    assert.equal(r.errorClass, 'quota_exhausted',
+        'el stderr de texto plano real no debe verse afectado por el fix de contenido');
+});
+
 test('CA-7 cross-skill: commander result event estructural clasifica quota_exhausted (mismo shape que skills)', () => {
     const fx = loadFixture('commander-anthropic-result-event.json');
     const r = parseProviderError(fx.raw, { provider: fx.provider, transport: fx.transport });

--- a/.pipeline/lib/agent-launcher/provider-error-parser.js
+++ b/.pipeline/lib/agent-launcher/provider-error-parser.js
@@ -390,41 +390,60 @@ function detectFromCliStderr(input, provider, quotaModule) {
     }
 
     // 3. Heurística regex (CLI stderr de texto libre).
+    //
+    // #4541 (Bug 2 — falso positivo sobre contenido normal): SOLO aplicamos los
+    // regex de texto libre sobre líneas que NO son frames estructurados del
+    // stream (stream-json / SSE). Un frame JSON del stream —incluyendo el
+    // `tool_result` y el contenido del modelo (`type:user`/`assistant`/`item.*`)—
+    // NUNCA debe clasificarse por substring: ya tuvo su chance en los pasos 1
+    // (`_detectAnthropic`) y 2 (`_detectOpenAI`), que matchean sólo el payload de
+    // ERROR estructurado del provider correcto. Durante el incidente 2026-07-07 el
+    // caller (pulpo onSpawnExit) pasaba el stdout stream-json COMPLETO del agente
+    // como `rawOutput`; un `tool_result` cuyo contenido mencionaba "usage limit"
+    // (p.ej. el propio log del detector, o un frame de error de Codex embebido)
+    // matcheaba `CLI_QUOTA_PATTERNS` y disparaba un flag espurio. Acotar el regex
+    // a texto plano (stderr real degradado, sin shape JSON) elimina la clase
+    // entera de falsos positivos sin perder los errores genuinos de CLI que sí
+    // llegan como texto libre (crash del CLI antes del JSON, "Usage credits
+    // required", etc.). Alineado con SR-1 ("PROHIBIDO substring sobre el content
+    // del modelo").
+    const plainTextLines = lines.filter((line) => parseJsonOrSSE(line) == null);
+
     // #3506: el subcaso "Usage credits required for 1M context" se evalúa
     // ANTES del genérico para evitar misclassification a quota_exhausted.
     // #3508 SEC-2: short-circuit del flag para preservar ReDoS budget con OFF.
     if (workaroundEnabled) {
-        for (const line of lines) {
+        for (const line of plainTextLines) {
             if (CLI_1M_CONTEXT_GLITCH_PATTERN.test(line)) {
                 return { errorClass: 'cli_1m_context_glitch', evidence: line };
             }
         }
     }
-    for (const line of lines) {
+    for (const line of plainTextLines) {
         // Cuota
         for (const re of CLI_QUOTA_PATTERNS) {
             if (re.test(line)) return { errorClass: 'quota_exhausted', evidence: line };
         }
     }
-    for (const line of lines) {
+    for (const line of plainTextLines) {
         // Rate limit
         for (const re of CLI_RATE_LIMIT_PATTERNS) {
             if (re.test(line)) return { errorClass: 'rate_limit', evidence: line };
         }
     }
-    for (const line of lines) {
+    for (const line of plainTextLines) {
         // Auth
         for (const re of CLI_AUTH_PATTERNS) {
             if (re.test(line)) return { errorClass: 'auth', evidence: line };
         }
     }
-    for (const line of lines) {
+    for (const line of plainTextLines) {
         // Permanente
         for (const re of CLI_PERMANENT_PATTERNS) {
             if (re.test(line)) return { errorClass: 'permanent_failure', evidence: line };
         }
     }
-    for (const line of lines) {
+    for (const line of plainTextLines) {
         // Transitorio (5xx)
         for (const re of CLI_TRANSIENT_PATTERNS) {
             if (re.test(line)) return { errorClass: 'transient_5xx', evidence: line };

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -7731,13 +7731,28 @@ function lanzarAgenteClaude(skill, issue, trabajandoPath, pipeline, fase, config
         let raw = '';
         try { raw = fs.readFileSync(logPath, 'utf8'); } catch {}
 
-        // Resolución provider/model del skill — necesaria en ambos paths.
+        // Resolución provider/model — necesaria en ambos paths.
+        //
+        // #4541 (Bug 1 — misatribución de provider): el detector de cuota DEBE
+        // atribuir el flag al provider que REALMENTE corrió y produjo el error,
+        // no al primary configurado del skill. Durante el incidente 2026-07-07 el
+        // primary (anthropic) estaba (falsamente) gateado y todos los spawns
+        // cayeron al fallback codex; codex pegó contra SU límite real ("You've hit
+        // your usage limit") y ese error se re-atribuía a anthropic porque el exit
+        // handler resolvía `resolveSkillProvider(skill)` (el primary configurado)
+        // en vez del provider efectivo del router. `dispatchResolution.provider`
+        // es la provider-key efectiva (misma fuente que el marker #4284): en
+        // fallback vale el provider del fallback (p.ej. openai-codex), en primary
+        // vale el primary. Si por algún motivo no está resuelto, caemos al
+        // provider configurado del skill (comportamiento previo).
         let skillProvider = null;
         let skillModel = null;
         let providerDef = null;
         try {
-          skillProvider = resolveSkillProvider(skill);
-          skillModel = resolveSkillModel(skill);
+          const effectiveProvider = (dispatchResolution && dispatchResolution.provider) || null;
+          const effectiveModel = (dispatchResolution && dispatchResolution.model) || null;
+          skillProvider = effectiveProvider || resolveSkillProvider(skill);
+          skillModel = effectiveProvider ? (effectiveModel || resolveSkillModel(skill)) : resolveSkillModel(skill);
           providerDef = getSkillProviderDef(skillProvider);
         } catch { /* defensa */ }
 


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 6 archivos · +263 -9

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:passed` aplicado por delivery

## Closes

Closes #4541
