### PR TITLE
[bug] Fallo transitorio de gh envenena issue-title-cache con notFound permanente → avance de ola colapsa (77%→12%)

### DIFF
--- a/.pipeline/dashboard.js
+++ b/.pipeline/dashboard.js
@@ -97,6 +97,13 @@ try { restModeWindow = require('./lib/rest-mode-window'); } catch { /* opcional 
 const { isMarkerArtifact } = require('./lib/marker-artifact');
 // #4099 — predicado puro de frescura del title-cache (reactiva TITLE_CACHE_TTL).
 const { needsRefetch: titleCacheNeedsRefetch } = require('./lib/title-cache-freshness');
+// #4566 — clasificación de respuestas/errores de gh: distingue 404 genuino de
+// error transitorio (rate-limit/red/timeout) para NO envenenar el title-cache.
+const {
+    parseGraphqlBody: _ghParseGraphqlBody,
+    applyGraphqlBatch: _ghApplyGraphqlBatch,
+    applyFallbackError: _ghApplyFallbackError,
+} = require('./lib/gh-title-fetch');
 // #4360 — helper puro que filtra la cola por la ola activa. Se requiere a nivel de
 // módulo (no dentro del IIFE del render) porque el test dashboard-header-cola-xss
 // extrae el cuerpo del IIFE y lo corre en un sandbox `vm` sin `require`. El IIFE
@@ -295,36 +302,37 @@ function fetchIssueTitles(issueIds, cache) {
       // Write query to temp file to avoid shell escaping issues on Windows
       fs.writeFileSync(tmpQuery, query);
       const cmd = `${ghPath} api graphql -F query=@${tmpQuery}`;
-      const out = execSync(cmd, { encoding: 'utf8', timeout: 30000, windowsHide: true });
-      const data = JSON.parse(out)?.data?.repository || {};
-      // Negative cache: issues ausentes/null en la respuesta se marcan como notFound
-      // para que no vuelvan a consultarse en cada refresh (evita loop gh api).
-      batch.forEach((id, i) => {
-        const val = data[`i${i}`];
-        if (val?.number) {
-          cache[String(val.number)] = {
-            title: val.title,
-            state: val.state, // #3905 — OPEN | CLOSED
-            labels: (val.labels?.nodes || []).map(l => l.name),
-            fetchedAt: Date.now()
-          };
-        } else {
-          cache[String(id)] = { title: '', labels: [], notFound: true, fetchedAt: Date.now() };
-        }
-      });
-    } catch (e) {
-      // Fallback: fetch one by one
-      for (const id of batch) {
-        try {
-          const cmd2 = `${ghPath} issue view ${id} --repo intrale/platform --json title,labels,state`;
-          const out2 = execSync(cmd2, { encoding: 'utf8', timeout: 10000, windowsHide: true });
-          const iss = JSON.parse(out2);
-          cache[id] = { title: iss.title, state: iss.state, labels: (iss.labels || []).map(l => l.name), fetchedAt: Date.now() };
-        } catch {
-          // Issue no resoluble: cachear como notFound para evitar re-consulta en cada refresh
-          cache[String(id)] = { title: '', labels: [], notFound: true, fetchedAt: Date.now() };
+      // #4566 — gh imprime el body en stdout aun con exit≠0 (errores GraphQL como
+      // RATE_LIMITED / NOT_FOUND). Capturamos stdout del error para clasificar en
+      // vez de asumir que TODO falló y envenenar el cache.
+      let out;
+      try {
+        out = execSync(cmd, { encoding: 'utf8', timeout: 30000, windowsHide: true });
+      } catch (e) {
+        out = (e && e.stdout) ? String(e.stdout) : '';
+      }
+      const body = _ghParseGraphqlBody(out);
+      if (body.ok) {
+        // #4566 — clasifica por issue: bueno / 404 genuino / transitorio (no envenena).
+        _ghApplyGraphqlBatch(cache, batch, body, Date.now());
+      } else {
+        // Body ilegible (fallo real del comando): fallback 1×1.
+        for (const id of batch) {
+          try {
+            const cmd2 = `${ghPath} issue view ${id} --repo intrale/platform --json title,labels,state`;
+            const out2 = execSync(cmd2, { encoding: 'utf8', timeout: 10000, windowsHide: true });
+            const iss = JSON.parse(out2);
+            cache[id] = { title: iss.title, state: iss.state, labels: (iss.labels || []).map(l => l.name), fetchedAt: Date.now() };
+          } catch (e2) {
+            // #4566 — sólo notFound ante evidencia real de 404; error transitorio se reintenta.
+            _ghApplyFallbackError(cache, id, e2, Date.now());
+          }
         }
       }
+    } catch (eOuter) {
+      // #4566 — error inesperado del batch (p.ej. writeFileSync): tratar como
+      // transitorio para NO envenenar (conserva entradas previas buenas).
+      for (const id of batch) _ghApplyFallbackError(cache, id, eOuter, Date.now());
     } finally {
       // Garantiza limpieza del tmp aunque execSync falle (evita acumulación .gh-query-*.graphql)
       try { fs.unlinkSync(tmpQuery); } catch {}
@@ -366,32 +374,32 @@ async function fetchIssueTitlesAsync(issueIds, cache) {
       const query = `{ repository(owner:"intrale",name:"platform") { ${fields} } }`;
       fs.writeFileSync(tmpQuery, query);
       const cmd = `${ghPath} api graphql -F query=@${tmpQuery}`;
-      const out = await _execGhAsync(cmd, 30000);
-      const data = JSON.parse(out)?.data?.repository || {};
-      batch.forEach((id, i) => {
-        const val = data[`i${i}`];
-        if (val?.number) {
-          cache[String(val.number)] = {
-            title: val.title,
-            state: val.state,
-            labels: (val.labels?.nodes || []).map(l => l.name),
-            fetchedAt: Date.now()
-          };
-        } else {
-          cache[String(id)] = { title: '', labels: [], notFound: true, fetchedAt: Date.now() };
-        }
-      });
-    } catch (e) {
-      for (const id of batch) {
-        try {
-          const cmd2 = `${ghPath} issue view ${id} --repo intrale/platform --json title,labels,state`;
-          const out2 = await _execGhAsync(cmd2, 10000);
-          const iss = JSON.parse(out2);
-          cache[id] = { title: iss.title, state: iss.state, labels: (iss.labels || []).map(l => l.name), fetchedAt: Date.now() };
-        } catch {
-          cache[String(id)] = { title: '', labels: [], notFound: true, fetchedAt: Date.now() };
+      // #4566 — mismo criterio que la versión sync: capturar stdout aun con exit≠0
+      // y clasificar (bueno / 404 genuino / transitorio) en vez de envenenar.
+      let out;
+      try {
+        out = await _execGhAsync(cmd, 30000);
+      } catch (e) {
+        out = (e && e.stdout) ? String(e.stdout) : '';
+      }
+      const body = _ghParseGraphqlBody(out);
+      if (body.ok) {
+        _ghApplyGraphqlBatch(cache, batch, body, Date.now());
+      } else {
+        for (const id of batch) {
+          try {
+            const cmd2 = `${ghPath} issue view ${id} --repo intrale/platform --json title,labels,state`;
+            const out2 = await _execGhAsync(cmd2, 10000);
+            const iss = JSON.parse(out2);
+            cache[id] = { title: iss.title, state: iss.state, labels: (iss.labels || []).map(l => l.name), fetchedAt: Date.now() };
+          } catch (e2) {
+            _ghApplyFallbackError(cache, id, e2, Date.now());
+          }
         }
       }
+    } catch (eOuter) {
+      // #4566 — error inesperado del batch: transitorio, no envenenar.
+      for (const id of batch) _ghApplyFallbackError(cache, id, eOuter, Date.now());
     } finally {
       try { fs.unlinkSync(tmpQuery); } catch {}
     }

--- a/.pipeline/lib/gh-title-fetch.js
+++ b/.pipeline/lib/gh-title-fetch.js
@@ -1,0 +1,170 @@
+// =============================================================================
+// gh-title-fetch.js — Clasificación de respuestas/errores de `gh` al poblar el
+// issue-title-cache (#4566).
+//
+// PROBLEMA (incidente 2026-07-08): un hipo transitorio de `gh` (rate-limit / red
+// / timeout) hacía que el handler de error confundiera "el comando gh falló" con
+// "el issue no existe" y persistiera cada issue como `{ notFound: true }` — una
+// negative-cache PERMANENTE (title-cache-freshness nunca la re-consultaba). Un
+// fallo de 3 segundos envenenó los 31 issues de la ola y clavó el avance en 12%.
+//
+// SOLUCIÓN: estas funciones PURAS distinguen tres estados por issue:
+//   - GOOD        → hay datos (title/state/labels) → se cachea.
+//   - notFound    → 404 GENUINO (issue borrado): evidencia real de NOT_FOUND.
+//   - transient   → error transitorio (rate-limit/red/timeout/body ilegible):
+//                   NO se envenena. Se conserva la entrada previa buena; si no
+//                   hay, se marca `{ transientError: true }` que SÍ se reintenta.
+//
+// Se comparten entre el path sync (`fetchIssueTitles`) y el async
+// (`fetchIssueTitlesAsync`) de dashboard.js para que el fix cubra AMBOS (#4128).
+// =============================================================================
+
+'use strict';
+
+// Evidencia de 404 GENUINO en GraphQL error.type / stderr de `gh issue view`.
+const NOT_FOUND_RE = /NOT_FOUND|Could not resolve to an? (Issue|node)/i;
+// Errores transitorios conocidos (rate-limit / red / timeout / 5xx). Un error
+// que matchea esto NUNCA debe interpretarse como 404 aunque también mencione algo.
+const TRANSIENT_RE = /RATE_LIMITED|rate limit|timeout|timed out|ETIMEDOUT|ECONNRESET|ECONNREFUSED|ENOTFOUND|EAI_AGAIN|network|socket hang up|\b50[234]\b|Bad gateway|Service unavailable|Internal Server Error|abuse detection/i;
+
+/**
+ * Construye la entrada de cache "buena" a partir del nodo de issue devuelto por
+ * GraphQL o por `gh issue view --json`.
+ * @param {object} val - nodo con { number|title, state, labels }
+ * @param {number} now - epoch ms
+ */
+function buildGoodEntry(val, now) {
+    // labels puede venir como { nodes: [...] } (GraphQL) o [...] (gh issue view --json)
+    const rawLabels = Array.isArray(val.labels) ? val.labels : (val.labels?.nodes || []);
+    return {
+        title: val.title || '',
+        state: val.state, // #3905 — OPEN | CLOSED
+        labels: rawLabels.map(l => (typeof l === 'string' ? l : l.name)).filter(Boolean),
+        fetchedAt: now,
+    };
+}
+
+/**
+ * Parsea el stdout de `gh api graphql`, tolerante a exit≠0 (gh imprime el body
+ * en stdout aunque la respuesta contenga `errors` GraphQL).
+ *
+ * @param {string} out - stdout crudo del comando
+ * @returns {{ok:boolean, repo:(object|null), notFoundAliases:Set<string>, transient:boolean}}
+ *   - ok:false  → body ilegible (fallo real del comando) → tratar todo como transitorio.
+ *   - transient → hubo error top-level no-404 (rate-limit, etc.) o `repository:null`.
+ *   - notFoundAliases → aliases (`i0`,`i1`,…) con evidencia de 404 GENUINO.
+ */
+function parseGraphqlBody(out) {
+    let parsed = null;
+    try { parsed = out ? JSON.parse(out) : null; } catch { parsed = null; }
+    if (!parsed || typeof parsed !== 'object') {
+        return { ok: false, repo: null, notFoundAliases: new Set(), transient: true };
+    }
+    const repo = parsed.data && typeof parsed.data === 'object' ? parsed.data.repository : undefined;
+    const errors = Array.isArray(parsed.errors) ? parsed.errors : [];
+    const notFoundAliases = new Set();
+    let transient = false;
+    for (const er of errors) {
+        const type = String(er && er.type || '');
+        const msg = String(er && er.message || '');
+        const text = type + ' ' + msg;
+        const p = Array.isArray(er && er.path) ? er.path : [];
+        const alias = p[p.length - 1];
+        if (NOT_FOUND_RE.test(text) && !TRANSIENT_RE.test(text)) {
+            if (alias) notFoundAliases.add(String(alias));
+        } else {
+            // Cualquier otro error top-level (RATE_LIMITED, INTERNAL, etc.) = transitorio.
+            transient = true;
+        }
+    }
+    // `repository: null` (típico de RATE_LIMITED / auth transitorio a nivel raíz)
+    // envenenaba todo el batch antes de este fix. Es transitorio, no un 404.
+    if (repo === null) transient = true;
+    return { ok: true, repo: repo || null, notFoundAliases, transient };
+}
+
+/**
+ * Aplica el resultado del batch GraphQL al cache SIN envenenar en errores
+ * transitorios. Muta `cache`.
+ *
+ * @param {object} cache - mapa id → entrada (contiene entradas previas)
+ * @param {Array<string|number>} batch - ids del batch, en el mismo orden que los aliases i0..iN
+ * @param {object} body - salida de parseGraphqlBody
+ * @param {number} now - epoch ms
+ */
+function applyGraphqlBatch(cache, batch, body, now) {
+    const { repo, notFoundAliases, transient } = body;
+    batch.forEach((id, i) => {
+        const alias = 'i' + i;
+        const key = String(id);
+        const val = repo ? repo[alias] : undefined;
+        if (val && val.number) {
+            cache[key] = buildGoodEntry(val, now);
+        } else if (notFoundAliases.has(alias) && !transient) {
+            // 404 GENUINO: sólo si NO hubo error transitorio global en la respuesta.
+            cache[key] = { title: '', labels: [], notFound: true, fetchedAt: now };
+        } else {
+            // Transitorio: preservar la entrada previa buena; si no hay usable,
+            // marcar transientError (freshness lo reintenta).
+            markTransient(cache, key, now);
+        }
+    });
+}
+
+/**
+ * Clasifica el error de un `gh issue view` 1×1 en el fallback.
+ * @param {Error} err - error de exec (puede traer .stderr / .message)
+ * @returns {'notfound'|'transient'}
+ */
+function classify1x1Error(err) {
+    const stderr = String(err && err.stderr || '');
+    const msg = String(err && err.message || '');
+    const stdout = String(err && err.stdout || '');
+    const text = stderr + '\n' + msg + '\n' + stdout;
+    // Sólo 404 genuino si hay evidencia explícita y NINGÚN indicio transitorio.
+    if (NOT_FOUND_RE.test(text) && !TRANSIENT_RE.test(text)) return 'notfound';
+    return 'transient';
+}
+
+/**
+ * Aplica el error de un fallback 1×1 al cache. Muta `cache`.
+ * @param {object} cache
+ * @param {string|number} id
+ * @param {Error} err
+ * @param {number} now
+ */
+function applyFallbackError(cache, id, err, now) {
+    const key = String(id);
+    if (classify1x1Error(err) === 'notfound') {
+        cache[key] = { title: '', labels: [], notFound: true, fetchedAt: now };
+    } else {
+        markTransient(cache, key, now);
+    }
+}
+
+/**
+ * Marca una entrada como transitoria SIN pisar una entrada previa buena o un
+ * 404 genuino previo. Sólo escribe transientError si no hay dato utilizable.
+ */
+function markTransient(cache, key, now) {
+    const prev = cache[key];
+    // Conservar entrada previa con datos reales (buena) o 404 genuino previo.
+    if (prev && (prev.state !== undefined || prev.notFound)) return;
+    cache[key] = {
+        title: (prev && prev.title) || '',
+        labels: (prev && prev.labels) || [],
+        transientError: true,
+        fetchedAt: now,
+    };
+}
+
+module.exports = {
+    NOT_FOUND_RE,
+    TRANSIENT_RE,
+    buildGoodEntry,
+    parseGraphqlBody,
+    applyGraphqlBatch,
+    classify1x1Error,
+    applyFallbackError,
+    markTransient,
+};

--- a/.pipeline/lib/title-cache-freshness.js
+++ b/.pipeline/lib/title-cache-freshness.js
@@ -13,33 +13,46 @@
 //
 // Reglas (en orden):
 //   1. sin entrada en cache              → refetch
-//   2. negative cache (`notFound: true`) → NO refetch (SEC-3: no martillar gh)
-//   3. entrada pre-#3905 (sin `state`)   → refetch (para poblar state)
-//   4. entrada vencida (now - fetchedAt > ttlMs) → refetch
-//   5. entrada fresca con `state`        → NO refetch
+//   2. error transitorio (`transientError`) → refetch (#4566: se reintenta ya)
+//   3. negative cache (`notFound: true`) → refetch sólo tras TTL negativo largo
+//      (#4566: SEC-3 no martillar gh, PERO auto-curar envenenamientos históricos;
+//       antes NUNCA se re-consultaba y un blip de gh clavaba la métrica de ola)
+//   4. entrada pre-#3905 (sin `state`)   → refetch (para poblar state)
+//   5. entrada vencida (now - fetchedAt > ttlMs) → refetch
+//   6. entrada fresca con `state`        → NO refetch
 // =============================================================================
 
 'use strict';
 
-const DEFAULT_TITLE_CACHE_TTL_MS = 3600000; // 1 hora (alineado con dashboard.js)
+const DEFAULT_TITLE_CACHE_TTL_MS = 3600000;   // 1 hora (alineado con dashboard.js)
+// #4566 — TTL de la negative-cache. Un `notFound` legítimo (issue borrado) se
+// re-verifica sólo cada 24h (no martilla gh), pero una entrada envenenada por un
+// fallo transitorio se auto-cura en ≤24h sin intervención manual.
+const DEFAULT_NEGATIVE_CACHE_TTL_MS = 86400000; // 24 horas
 
 /**
  * ¿Hay que re-pedir esta entrada del title-cache a `gh`?
  *
- * @param {object|undefined} entry  - entrada cacheada: { state, labels, notFound, fetchedAt }
+ * @param {object|undefined} entry  - entrada cacheada: { state, labels, notFound, transientError, fetchedAt }
  * @param {object} [opts]
- * @param {number} [opts.now]   - epoch ms (default Date.now())
- * @param {number} [opts.ttlMs] - TTL en ms (default 1h)
+ * @param {number} [opts.now]            - epoch ms (default Date.now())
+ * @param {number} [opts.ttlMs]          - TTL positivo en ms (default 1h)
+ * @param {number} [opts.negativeTtlMs]  - TTL de la negative-cache en ms (default 24h)
  * @returns {boolean} true si debe refetchearse
  */
 function needsRefetch(entry, opts = {}) {
     const now = typeof opts.now === 'number' ? opts.now : Date.now();
     const ttlMs = Number.isFinite(opts.ttlMs) && opts.ttlMs > 0 ? opts.ttlMs : DEFAULT_TITLE_CACHE_TTL_MS;
+    const negTtlMs = Number.isFinite(opts.negativeTtlMs) && opts.negativeTtlMs > 0
+        ? opts.negativeTtlMs : DEFAULT_NEGATIVE_CACHE_TTL_MS;
 
-    if (!entry) return true;                                  // 1. sin cache
-    if (entry.notFound) return false;                         // 2. negative cache
-    if (entry.state === undefined) return true;               // 3. entradas pre-#3905
-    return (now - (entry.fetchedAt || 0)) > ttlMs;            // 4/5. TTL
+    if (!entry) return true;                                         // 1. sin cache
+    if (entry.transientError) return true;                          // 2. error transitorio (#4566): reintentar ya
+    if (entry.notFound) {                                            // 3. negative cache con TTL largo (#4566)
+        return (now - (entry.fetchedAt || 0)) > negTtlMs;
+    }
+    if (entry.state === undefined) return true;                     // 4. entradas pre-#3905
+    return (now - (entry.fetchedAt || 0)) > ttlMs;                  // 5/6. TTL positivo
 }
 
-module.exports = { needsRefetch, DEFAULT_TITLE_CACHE_TTL_MS };
+module.exports = { needsRefetch, DEFAULT_TITLE_CACHE_TTL_MS, DEFAULT_NEGATIVE_CACHE_TTL_MS };

--- a/.pipeline/tests/gh-title-cache-poison-4566.test.js
+++ b/.pipeline/tests/gh-title-cache-poison-4566.test.js
@@ -1,0 +1,210 @@
+'use strict';
+
+// =============================================================================
+// gh-title-cache-poison-4566.test.js — regresión #4566.
+//
+// Incidente 2026-07-08: un hipo transitorio de `gh` (rate-limit / red / timeout)
+// hizo que el handler de error confundiera "el comando gh falló" con "el issue no
+// existe" y persistiera cada issue como `{ notFound: true }` — una negative-cache
+// PERMANENTE. `title-cache-freshness` nunca la re-consultaba, así un fallo de 3s
+// envenenó los 31 issues de la ola y clavó el avance del dashboard en ~12%.
+//
+// Estos tests cubren las funciones PURAS de clasificación (lib/gh-title-fetch.js)
+// y la frescura (lib/title-cache-freshness.js). Sin red, determinísticos.
+// =============================================================================
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+
+const {
+    parseGraphqlBody,
+    applyGraphqlBatch,
+    classify1x1Error,
+    applyFallbackError,
+} = require('../lib/gh-title-fetch');
+const { needsRefetch } = require('../lib/title-cache-freshness');
+
+const NOW = 1_000_000;
+
+// --- parseGraphqlBody --------------------------------------------------------
+
+test('parseGraphqlBody: respuesta sana clasifica issues como buenos, sin transitorio', () => {
+    const out = JSON.stringify({
+        data: { repository: {
+            i0: { number: 10, title: 'A', state: 'CLOSED', labels: { nodes: [{ name: 'bug' }] } },
+            i1: { number: 11, title: 'B', state: 'OPEN', labels: { nodes: [] } },
+        } },
+    });
+    const body = parseGraphqlBody(out);
+    assert.equal(body.ok, true);
+    assert.equal(body.transient, false);
+    assert.equal(body.notFoundAliases.size, 0);
+});
+
+test('parseGraphqlBody: RATE_LIMITED con repository:null marca transitorio, NO notFound', () => {
+    const out = JSON.stringify({
+        data: { repository: null },
+        errors: [{ type: 'RATE_LIMITED', message: 'API rate limit exceeded' }],
+    });
+    const body = parseGraphqlBody(out);
+    assert.equal(body.ok, true);
+    assert.equal(body.transient, true);
+    assert.equal(body.notFoundAliases.size, 0);
+});
+
+test('parseGraphqlBody: NOT_FOUND por-alias marca ese alias, sin transitorio', () => {
+    const out = JSON.stringify({
+        data: { repository: { i0: { number: 10, title: 'A', state: 'OPEN', labels: { nodes: [] } }, i1: null } },
+        errors: [{ type: 'NOT_FOUND', path: ['repository', 'i1'], message: 'Could not resolve to an Issue' }],
+    });
+    const body = parseGraphqlBody(out);
+    assert.equal(body.ok, true);
+    assert.equal(body.transient, false);
+    assert.ok(body.notFoundAliases.has('i1'));
+    assert.ok(!body.notFoundAliases.has('i0'));
+});
+
+test('parseGraphqlBody: body ilegible → ok:false y transitorio', () => {
+    const body = parseGraphqlBody('esto no es json <html>500</html>');
+    assert.equal(body.ok, false);
+    assert.equal(body.transient, true);
+});
+
+test('parseGraphqlBody: stdout vacío (comando falló sin body) → ok:false y transitorio', () => {
+    const body = parseGraphqlBody('');
+    assert.equal(body.ok, false);
+    assert.equal(body.transient, true);
+});
+
+// --- applyGraphqlBatch: EL BUG DEL INCIDENTE ---------------------------------
+
+test('applyGraphqlBatch: batch RATE_LIMITED NO envenena entradas previas buenas (CA principal)', () => {
+    // Cache previo: los 3 issues estaban resueltos y CLOSED (avance real 100%).
+    const cache = {
+        '10': { title: 'A', state: 'CLOSED', labels: [], fetchedAt: NOW - 5000 },
+        '11': { title: 'B', state: 'CLOSED', labels: [], fetchedAt: NOW - 5000 },
+        '12': { title: 'C', state: 'CLOSED', labels: [], fetchedAt: NOW - 5000 },
+    };
+    const out = JSON.stringify({
+        data: { repository: null },
+        errors: [{ type: 'RATE_LIMITED', message: 'rate limit' }],
+    });
+    applyGraphqlBatch(cache, ['10', '11', '12'], parseGraphqlBody(out), NOW);
+
+    // NINGUNA entrada quedó como notFound; todas conservan state CLOSED.
+    for (const k of ['10', '11', '12']) {
+        assert.equal(cache[k].notFound, undefined, `#${k} no debe marcarse notFound`);
+        assert.equal(cache[k].state, 'CLOSED', `#${k} conserva state CLOSED`);
+    }
+});
+
+test('applyGraphqlBatch: transitorio sin entrada previa marca transientError (reintentar), no notFound', () => {
+    const cache = {};
+    const out = JSON.stringify({ data: { repository: null }, errors: [{ type: 'RATE_LIMITED' }] });
+    applyGraphqlBatch(cache, ['99'], parseGraphqlBody(out), NOW);
+    assert.equal(cache['99'].transientError, true);
+    assert.equal(cache['99'].notFound, undefined);
+});
+
+test('applyGraphqlBatch: 404 GENUINO sí marca notFound', () => {
+    const cache = {};
+    const out = JSON.stringify({
+        data: { repository: { i0: null } },
+        errors: [{ type: 'NOT_FOUND', path: ['repository', 'i0'], message: 'Could not resolve to an Issue' }],
+    });
+    applyGraphqlBatch(cache, ['777'], parseGraphqlBody(out), NOW);
+    assert.equal(cache['777'].notFound, true);
+    assert.equal(cache['777'].transientError, undefined);
+});
+
+test('applyGraphqlBatch: mezcla bueno + 404 genuino sin transitorio global', () => {
+    const cache = {};
+    const out = JSON.stringify({
+        data: { repository: {
+            i0: { number: 10, title: 'A', state: 'OPEN', labels: { nodes: [{ name: 'Ready' }] } },
+            i1: null,
+        } },
+        errors: [{ type: 'NOT_FOUND', path: ['repository', 'i1'] }],
+    });
+    applyGraphqlBatch(cache, ['10', '11'], parseGraphqlBody(out), NOW);
+    assert.equal(cache['10'].state, 'OPEN');
+    assert.deepEqual(cache['10'].labels, ['Ready']);
+    assert.equal(cache['11'].notFound, true);
+});
+
+test('applyGraphqlBatch: 404 aparente PERO con error transitorio global → no envenena (conserva previo)', () => {
+    // Si hubo RATE_LIMITED en el batch, un `null` de issue NO es prueba de 404.
+    const cache = { '11': { title: 'B', state: 'CLOSED', labels: [], fetchedAt: NOW - 5000 } };
+    const out = JSON.stringify({
+        data: { repository: { i0: null } },
+        errors: [{ type: 'RATE_LIMITED' }],
+    });
+    applyGraphqlBatch(cache, ['11'], parseGraphqlBody(out), NOW);
+    assert.equal(cache['11'].notFound, undefined);
+    assert.equal(cache['11'].state, 'CLOSED');
+});
+
+// --- classify1x1Error / applyFallbackError -----------------------------------
+
+test('classify1x1Error: error de red (ECONNRESET) es transitorio', () => {
+    assert.equal(classify1x1Error({ message: 'read ECONNRESET' }), 'transient');
+});
+
+test('classify1x1Error: timeout es transitorio', () => {
+    assert.equal(classify1x1Error(new Error('Command timed out after 10000ms')), 'transient');
+});
+
+test('classify1x1Error: rate limit en stderr es transitorio (aunque mencione recurso)', () => {
+    assert.equal(classify1x1Error({ stderr: 'HTTP 403: API rate limit exceeded' }), 'transient');
+});
+
+test('classify1x1Error: stderr "Could not resolve to an Issue" es 404 genuino', () => {
+    assert.equal(classify1x1Error({ stderr: 'GraphQL: Could not resolve to an Issue with the number of 999 (repository.issue)' }), 'notfound');
+});
+
+test('applyFallbackError: error de red NO escribe notFound (marca transientError si no hay previo)', () => {
+    const cache = {};
+    applyFallbackError(cache, '55', { message: 'connect ETIMEDOUT' }, NOW);
+    assert.equal(cache['55'].notFound, undefined);
+    assert.equal(cache['55'].transientError, true);
+});
+
+test('applyFallbackError: error de red conserva entrada previa buena', () => {
+    const cache = { '55': { title: 'X', state: 'CLOSED', labels: [], fetchedAt: NOW - 5000 } };
+    applyFallbackError(cache, '55', { message: 'connect ETIMEDOUT' }, NOW);
+    assert.equal(cache['55'].state, 'CLOSED');
+    assert.equal(cache['55'].transientError, undefined);
+});
+
+test('applyFallbackError: 404 genuino SÍ escribe notFound', () => {
+    const cache = {};
+    applyFallbackError(cache, '55', { stderr: 'Could not resolve to an Issue with the number of 55' }, NOW);
+    assert.equal(cache['55'].notFound, true);
+});
+
+// --- needsRefetch (freshness) ------------------------------------------------
+
+test('needsRefetch: transientError siempre se reintenta', () => {
+    assert.equal(needsRefetch({ transientError: true, fetchedAt: NOW }, { now: NOW }), true);
+});
+
+test('needsRefetch: notFound reciente NO se re-consulta (SEC-3)', () => {
+    assert.equal(needsRefetch({ notFound: true, fetchedAt: NOW }, { now: NOW }), false);
+});
+
+test('needsRefetch: notFound viejo (> TTL negativo) se re-consulta (auto-cura)', () => {
+    const veryOld = NOW - 25 * 3600000; // 25h > 24h
+    assert.equal(needsRefetch({ notFound: true, fetchedAt: veryOld }, { now: NOW }), true);
+});
+
+test('needsRefetch: entrada buena fresca NO se re-consulta', () => {
+    assert.equal(needsRefetch({ state: 'CLOSED', fetchedAt: NOW }, { now: NOW }), false);
+});
+
+test('needsRefetch: entrada buena vencida se re-consulta', () => {
+    assert.equal(needsRefetch({ state: 'CLOSED', fetchedAt: NOW - 2 * 3600000 }, { now: NOW }), true);
+});
+
+test('needsRefetch: sin entrada se re-consulta', () => {
+    assert.equal(needsRefetch(undefined, { now: NOW }), true);
+});

--- a/security-report.md
+++ b/security-report.md
@@ -1,47 +1,40 @@
-## Reporte de auditoría de seguridad — issue #4513
+## Reporte de auditoría de seguridad — issue #4566
 
 **Veredicto:** sin hallazgos
 
-**Alcance auditado:** diff `origin/main...HEAD` (HEAD `d43098394`). Archivos con
-superficie de seguridad: `.pipeline/lib/skill-deliverable-attachments.js`,
-`.pipeline/config.yaml`, `.claude/skills/review/SKILL.md`. Cambio de infra pura del
-pipeline: registra el skill `review` como perfil documental que persiste su reporte
-de revisión vía el choke point `writeDeliverable`.
+**Alcance auditado:** rama `agent/4566-pipeline-dev`, commit `40d51ca56`, diff vs `origin/main`:
+- `.pipeline/lib/gh-title-fetch.js` (nuevo — clasificación pura 404 genuino / transitorio)
+- `.pipeline/dashboard.js` — `fetchIssueTitles` (~L281-354) y `fetchIssueTitlesAsync` (~L364-406)
+- `.pipeline/lib/title-cache-freshness.js` — negative-cache TTL
+- `.pipeline/tests/gh-title-cache-poison-4566.test.js` — 23 tests, todos PASS
 
 ### Hallazgos
 
-Sin hallazgos.
+**Sin hallazgos.** El cambio es una corrección de robustez sobre herramienta interna
+del pipeline (dashboard Node.js); no introduce vulnerabilidades explotables.
 
-Verificación empírica por categoría OWASP:
+Ejes OWASP evaluados:
 
-- **[A03 Injection]** Sin superficie nueva. La escritura del artefacto y del índice
-  pasa exclusivamente por `writeDeliverable`/`writeDeliverableException`
-  (`.claude/skills/review/SKILL.md:329,340`). El SKILL.md prohíbe explícitamente
-  `fs.writeFileSync` directo (línea 318) y no se detecta ninguno en el diff.
-- **[A01 Broken Access Control — path traversal]** `writeDeliverable` valida
-  `issue` contra `^\d+$` antes de construir el path desde `{issue}` del
-  `dirTemplate` (`write-deliverable.js:56`) y valida `filename` contra separadores
-  y `..` (`write-deliverable.js:197`).
-- **[A02 Cryptographic Failures / exposición de datos sensibles]** Redacción de
-  secrets (`redactSecretValue` + `redactSensitive`: AWS keys, JWT, API keys,
-  emails, query-params) aplicada antes de persistir y antes de notificar por
-  Telegram (`write-deliverable.js:30,126,128`).
-- **[A05 Security Misconfiguration — XSS/XXE]** `sanitizeSvg`
-  (`write-deliverable.js:102`) strippea `script`/`on*`/`javascript:`/DTD/ENTITY.
-  Cap defensivo de tamaño 5 MiB (`DEFAULT_MAX_BYTES`, línea 35).
-- **[A07 Auth Failures]** No aplica: sin endpoints ni flujos de autenticación
-  tocados.
-- **[Secrets hardcodeados]** Scan del diff `origin/main...HEAD` sin coincidencias
-  para `AKIA...`, `-----BEGIN`, `password=`, `secret=`, `api-key=`, `bearer`, JWT.
-- **[A06 Vulnerable Components]** Sin cambios en manifests/locks de dependencias.
+- **A03 Inyección — CWE-78 (command injection):** SIN riesgo nuevo. La única
+  superficie es `${id}` interpolado en `gh issue view ${id}` (fallback shell,
+  `dashboard.js`) y en la query GraphQL. Ambos paths conservan intacto el guard
+  SEC-1 (#4096): `safeIds = issueIds.filter(id => /^\d+$/.test(String(id)))` en
+  `dashboard.js:290-292` (sync) y `dashboard.js:366-367` (async), aplicado ANTES
+  de cualquier `execSync`/`exec`. Un id no numérico (p.ej. `"4096; rm -rf .build"`)
+  se descarta antes de tocar el shell. El fix no altera ese filtro.
+  - **Vector (criollo):** para meter un comando, un atacante tendría que colar un
+    "número de issue" con caracteres de shell; el filtro numérico lo tira antes.
+- **A02 Exposición de datos sensibles:** sin secrets/tokens/passwords en el diff;
+  solo procesa título, labels y state (datos públicos) del propio repo.
+- **A07 Fallas de auth:** no aplica — sin JWT/Cognito, sin endpoints,
+  sin `SecuredFunction`. Herramienta interna desatendida.
+- **ReDoS:** `NOT_FOUND_RE` y `TRANSIENT_RE` (`gh-title-fetch.js:26-28`) son
+  alternaciones simples, sin cuantificadores anidados ni backtracking catastrófico.
+- **DoS / abuso de estado:** el `negativeTtlMs` (24h) auto-cura envenenamientos sin
+  martillar `gh`; `transientError` reintenta acotado por el flujo de refetch. No
+  abre amplificación de requests.
 
-### Evidencia de tests
+### Remediación
 
-- `node --test .pipeline/lib/write-deliverable.test.js` → 36/36 pass.
-- `node --test .pipeline/lib/__tests__/skill-deliverable-attachments.test.js` → 49/49 pass.
-
-### Nota de sincronización (anti-regresión CA-4)
-
-Los 3 registros quedaron sincronizados: `config.yaml:931` (whitelist `skills`),
-`config.yaml:970` (`attachments_per_skill`), `skill-deliverable-attachments.js:260-266`
-(`SKILL_SOURCES.review`).
+No requerida. El fix, además, elimina un modo de fallo operacional (negative-cache
+permanente que clavaba la métrica de avance) sin abrir superficie de seguridad nueva.


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 5 archivos · +500 -106

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:passed` aplicado por delivery

## Closes

Closes #4566
