### PR TITLE
[bug] Notificador de cuota: misatribuye provider (siempre 'Anthropic') y muestra reset '--:--' por Number() sobre ISO; gate genérico bloquea LLM sano

### DIFF
--- a/.pipeline/lib/__tests__/quota-notifier.test.js
+++ b/.pipeline/lib/__tests__/quota-notifier.test.js
@@ -23,10 +23,15 @@ const {
   DEFAULT_REMINDER_INTERVAL_MIN,
   DEBOUNCE_CANNED_MS,
   MIN_BLOCK_DURATION_FOR_RESTORED_MS,
+  PROVIDER_LABELS,
+  DEFAULT_PROVIDER_KEY,
   formatHHMM,
   formatCountdown,
   interpolate,
   buildVars,
+  parseResetsAt,
+  providerLabel,
+  normalizeProviderKey,
 } = require('../quota-notifier');
 
 // -- Test helper: clock + setInterval/clearInterval mockeables ----------------
@@ -442,9 +447,10 @@ test('CA-10 · canned NO contiene caracteres peligrosos del input (CA-S7: prohib
       `template canned contiene placeholder peligroso ${ch}`);
   }
   // Y los placeholders del canned deben ser solo del set permitido
+  // (#4565: se agrega `provider`, campo de sistema — NO input de usuario).
   const placeholders = [...QUOTA_COPY.cannedFreeText.matchAll(/\{(\w+)\}/g)].map(m => m[1]);
   for (const p of placeholders) {
-    assert.ok(['hhmm', 'countdown', 'n', 'isFallback'].includes(p),
+    assert.ok(['hhmm', 'countdown', 'n', 'isFallback', 'provider'].includes(p),
       `placeholder no autorizado en canned: ${p}`);
   }
 });
@@ -633,4 +639,349 @@ test('constantes públicas tienen los valores documentados', () => {
   assert.equal(DEFAULT_REMINDER_INTERVAL_MIN, 120);
   assert.equal(DEBOUNCE_CANNED_MS, 2 * 60 * 1000);
   assert.equal(MIN_BLOCK_DURATION_FOR_RESTORED_MS, 5 * 60 * 1000);
+});
+
+// =============================================================================
+// #4565 Bug 2 — parseResetsAt / buildVars con resets_at ISO8601
+// =============================================================================
+test('#4565 · parseResetsAt acepta ISO8601 (el bug del --:--)', () => {
+  const iso = '2026-07-13T00:00:00.000Z';
+  assert.equal(parseResetsAt(iso), Date.parse(iso));
+  assert.ok(Number.isFinite(parseResetsAt(iso)));
+});
+
+test('#4565 · parseResetsAt acepta epoch-ms number (fixtures y flag legacy)', () => {
+  assert.equal(parseResetsAt(5_000_000), 5_000_000);
+});
+
+test('#4565 · parseResetsAt acepta string numérico epoch-ms', () => {
+  assert.equal(parseResetsAt('5000000'), 5_000_000);
+});
+
+test('#4565 · parseResetsAt devuelve NaN para basura', () => {
+  assert.ok(Number.isNaN(parseResetsAt(undefined)));
+  assert.ok(Number.isNaN(parseResetsAt(null)));
+  assert.ok(Number.isNaN(parseResetsAt('')));
+  assert.ok(Number.isNaN(parseResetsAt('no-es-fecha')));
+  assert.ok(Number.isNaN(parseResetsAt(NaN)));
+});
+
+test('#4565 · buildVars con resets_at ISO8601 produce hhmm real (NO "--:--")', () => {
+  // Reset a las 14:30 hora local, expresado como ISO8601 (como persiste el flag).
+  const resetLocal = new Date(2026, 6, 8, 14, 30, 0);
+  const nowMs = new Date(2026, 6, 8, 10, 0, 0).getTime();
+  const vars = buildVars(
+    { resets_at: resetLocal.toISOString() },
+    nowMs,
+    0
+  );
+  assert.equal(vars.hhmm, '14:30');
+  assert.notEqual(vars.hhmm, '--:--');
+  assert.equal(vars.countdown, '4 h 30 min');
+});
+
+test('#4565 · regresión: Number() sobre ISO daba NaN → "--:--"; parseResetsAt lo evita', () => {
+  const iso = '2026-07-13T00:00:00.000Z';
+  // Comportamiento viejo (bug):
+  assert.ok(Number.isNaN(Number(iso)));
+  assert.equal(formatHHMM(Number(iso)), '--:--');
+  // Comportamiento nuevo:
+  assert.notEqual(formatHHMM(parseResetsAt(iso)), '--:--');
+});
+
+// =============================================================================
+// #4565 Bug 1 — provider legible en templates (no hardcodear "Anthropic")
+// =============================================================================
+test('#4565 · providerLabel mapea claves a labels humanos, nunca la clave cruda', () => {
+  assert.equal(providerLabel('anthropic'), 'Anthropic');
+  assert.equal(providerLabel('openai-codex'), 'OpenAI Codex');
+  assert.equal(providerLabel('gemini-google'), 'Gemini');
+  // Aliases
+  assert.equal(providerLabel('openai'), 'OpenAI Codex');
+  assert.equal(providerLabel('codex'), 'OpenAI Codex');
+  // Desconocido / faltante → default anthropic (backward-compat)
+  assert.equal(providerLabel(undefined), 'Anthropic');
+  assert.equal(providerLabel(''), 'Anthropic');
+  assert.equal(providerLabel('proveedor-inexistente'), 'Anthropic');
+  // Nunca devuelve la clave cruda
+  assert.notEqual(providerLabel('openai-codex'), 'openai-codex');
+});
+
+test('#4565 · normalizeProviderKey canoniza aliases y default', () => {
+  assert.equal(normalizeProviderKey('openai'), 'openai-codex');
+  assert.equal(normalizeProviderKey('claude'), 'anthropic');
+  assert.equal(normalizeProviderKey('anthropic'), 'anthropic');
+  assert.equal(normalizeProviderKey(undefined), DEFAULT_PROVIDER_KEY);
+  assert.equal(normalizeProviderKey('OPENAI-CODEX'), 'openai-codex');
+});
+
+test('#4565 · notificacion inicial nombra el provider agotado (Codex, no Anthropic)', () => {
+  const clock = makeFakeClock();
+  const sender = makeFakeSender();
+  clock.nowMs = new Date(2026, 6, 8, 10, 0, 0).getTime();
+  const notifier = createQuotaNotifier({
+    sendMessage: sender.sendMessage,
+    now: () => clock.nowMs,
+    setIntervalFn: clock.setIntervalFn,
+    clearIntervalFn: clock.clearIntervalFn,
+    // El commander usa Codex en este escenario, así que el gate igual bloquea.
+    getCommanderProvider: () => 'openai-codex',
+  });
+  notifier.onFlagSet(makeFlag(clock, {
+    provider: 'openai-codex',
+    resets_at: new Date(2026, 6, 8, 14, 30, 0).toISOString(),
+  }));
+
+  assert.equal(sender.sent.length, 1);
+  const msg = sender.sent[0].text;
+  assert.match(msg, /Cuota OpenAI Codex agotada/);
+  assert.doesNotMatch(msg, /Cuota Anthropic agotada/);
+  assert.match(msg, /14:30/);
+  // Nunca la clave cruda
+  assert.doesNotMatch(msg, /openai-codex/);
+});
+
+test('#4565 · mensaje de restaurada nombra el provider recuperado', () => {
+  const clock = makeFakeClock();
+  const sender = makeFakeSender();
+  const notifier = createQuotaNotifier({
+    sendMessage: sender.sendMessage,
+    now: () => clock.nowMs,
+    setIntervalFn: clock.setIntervalFn,
+    clearIntervalFn: clock.clearIntervalFn,
+    getQueuedAgentsCount: () => 0,
+    getCommanderProvider: () => 'gemini-google',
+  });
+  notifier.onFlagSet(makeFlag(clock, { provider: 'gemini-google' }));
+  clock.advance(10 * 60 * 1000); // > 5min
+  notifier.onFlagCleared();
+  const closeMsg = sender.sent[sender.sent.length - 1].text;
+  assert.match(closeMsg, /Cuota Gemini restaurada/);
+});
+
+test('#4565 · sin campo provider, cae a "Anthropic" (backward-compat)', () => {
+  const clock = makeFakeClock();
+  const sender = makeFakeSender();
+  const notifier = createQuotaNotifier({
+    sendMessage: sender.sendMessage,
+    now: () => clock.nowMs,
+    setIntervalFn: clock.setIntervalFn,
+    clearIntervalFn: clock.clearIntervalFn,
+  });
+  notifier.onFlagSet(makeFlag(clock)); // sin provider
+  assert.match(sender.sent[0].text, /Cuota Anthropic agotada/);
+});
+
+// =============================================================================
+// #4565 CA-3 — gate selectivo por provider
+// =============================================================================
+test('#4565 CA-3 · provider agotado != commander → gate NO bloquea (gatesLlm=false)', () => {
+  const clock = makeFakeClock();
+  const sender = makeFakeSender();
+  const notifier = createQuotaNotifier({
+    sendMessage: sender.sendMessage,
+    now: () => clock.nowMs,
+    setIntervalFn: clock.setIntervalFn,
+    clearIntervalFn: clock.clearIntervalFn,
+    // Se agotó Codex; el commander usa Anthropic → NO debe bloquear.
+    getCommanderProvider: () => 'anthropic',
+  });
+  notifier.onFlagSet(makeFlag(clock, { provider: 'openai-codex' }));
+  sender.sent.length = 0;
+
+  const st = notifier.getState();
+  assert.equal(st.active, true, 'el flag sigue activo (hay notificaciones)');
+  assert.equal(st.gatesLlm, false, 'NO gatea el LLM del commander');
+  assert.equal(st.provider, 'openai-codex');
+
+  const gate = notifier.handleCommanderFreeText();
+  assert.equal(gate.gated, false, 'el LLM sano debe procesar el texto libre');
+  assert.equal(sender.sent.length, 0, 'no se envía canned');
+});
+
+test('#4565 CA-3 · provider agotado == commander → gate SÍ bloquea', () => {
+  const clock = makeFakeClock();
+  const sender = makeFakeSender();
+  const notifier = createQuotaNotifier({
+    sendMessage: sender.sendMessage,
+    now: () => clock.nowMs,
+    setIntervalFn: clock.setIntervalFn,
+    clearIntervalFn: clock.clearIntervalFn,
+    getCommanderProvider: () => 'anthropic',
+  });
+  notifier.onFlagSet(makeFlag(clock, {
+    provider: 'anthropic',
+    resets_at: new Date(2026, 6, 8, 14, 30, 0).toISOString(),
+  }));
+  sender.sent.length = 0;
+
+  const st = notifier.getState();
+  assert.equal(st.gatesLlm, true, 'Anthropic agotado + commander Anthropic → gatea');
+
+  const gate = notifier.handleCommanderFreeText();
+  assert.equal(gate.gated, true);
+  assert.equal(gate.debounced, false);
+  assert.equal(sender.sent.length, 1, 'se envía canned');
+  assert.equal(sender.sent[0].opts.plain, true);
+});
+
+test('#4565 CA-3 · aliases: commander "claude" == flag "anthropic" → bloquea', () => {
+  const clock = makeFakeClock();
+  const sender = makeFakeSender();
+  const notifier = createQuotaNotifier({
+    sendMessage: sender.sendMessage,
+    now: () => clock.nowMs,
+    setIntervalFn: clock.setIntervalFn,
+    clearIntervalFn: clock.clearIntervalFn,
+    getCommanderProvider: () => 'claude', // alias de anthropic
+  });
+  notifier.onFlagSet(makeFlag(clock, { provider: 'anthropic' }));
+  assert.equal(notifier.getState().gatesLlm, true);
+});
+
+test('#4565 CA-3 · sin flag activo, gatesLlm=false y getState.provider=null', () => {
+  const clock = makeFakeClock();
+  const sender = makeFakeSender();
+  const notifier = createQuotaNotifier({
+    sendMessage: sender.sendMessage,
+    now: () => clock.nowMs,
+    setIntervalFn: clock.setIntervalFn,
+    clearIntervalFn: clock.clearIntervalFn,
+  });
+  const st = notifier.getState();
+  assert.equal(st.active, false);
+  assert.equal(st.gatesLlm, false);
+  assert.equal(st.provider, null);
+  assert.equal(st.providerLabel, null);
+});
+
+test('#4565 CA-3 · default getCommanderProvider es anthropic', () => {
+  const clock = makeFakeClock();
+  const sender = makeFakeSender();
+  const notifier = createQuotaNotifier({
+    sendMessage: sender.sendMessage,
+    now: () => clock.nowMs,
+    setIntervalFn: clock.setIntervalFn,
+    clearIntervalFn: clock.clearIntervalFn,
+  });
+  // flag anthropic + default commander → bloquea
+  notifier.onFlagSet(makeFlag(clock, { provider: 'anthropic' }));
+  assert.equal(notifier.getState().gatesLlm, true);
+});
+
+// =============================================================================
+// #4565 (rebote rev-1) CA-3 — gate por RESOLUCIÓN DE CADENA (isLlmGated)
+// Cierra el gap del rechazo de review: cuando Anthropic (primario) está agotado
+// pero hay un fallback SANO en la cadena, el gate NO debe pre-emptir con canned;
+// debe dejar que `ejecutarClaude` use ese provider sano. La autoridad es la
+// resolución de la cadena completa (`isLlmGated`), NO el estado del primario.
+// =============================================================================
+test('#4565 rebote · Anthropic agotado + fallback SANO → gatesLlm=false (NO pre-emptir canned)', () => {
+  const clock = makeFakeClock();
+  const sender = makeFakeSender();
+  const notifier = createQuotaNotifier({
+    sendMessage: sender.sendMessage,
+    now: () => clock.nowMs,
+    setIntervalFn: clock.setIntervalFn,
+    clearIntervalFn: clock.clearIntervalFn,
+    // La cadena resuelve a un fallback sano → NO gateada, aunque el primario
+    // Anthropic esté agotado. Este es exactamente el escenario del rechazo.
+    isLlmGated: () => false,
+    // Heurístico que, de usarse, bloquearía (anthropic==anthropic). Debe ser
+    // IGNORADO cuando isLlmGated resuelve.
+    getCommanderProvider: () => 'anthropic',
+  });
+  notifier.onFlagSet(makeFlag(clock, { provider: 'anthropic' }));
+  sender.sent.length = 0;
+
+  const st = notifier.getState();
+  assert.equal(st.active, true, 'el flag sigue activo');
+  assert.equal(st.gatesLlm, false, 'hay fallback sano → NO gatea el LLM');
+
+  const gate = notifier.handleCommanderFreeText();
+  assert.equal(gate.gated, false, 'ejecutarClaude debe usar el fallback sano');
+  assert.equal(sender.sent.length, 0, 'no se envía canned determinístico');
+});
+
+test('#4565 rebote · cadena ENTERAMENTE gateada → gatesLlm=true (canned)', () => {
+  const clock = makeFakeClock();
+  const sender = makeFakeSender();
+  const notifier = createQuotaNotifier({
+    sendMessage: sender.sendMessage,
+    now: () => clock.nowMs,
+    setIntervalFn: clock.setIntervalFn,
+    clearIntervalFn: clock.clearIntervalFn,
+    // Primario + todos los fallbacks gateados → sí bloquea.
+    isLlmGated: () => true,
+    getCommanderProvider: () => 'anthropic',
+  });
+  notifier.onFlagSet(makeFlag(clock, {
+    provider: 'anthropic',
+    resets_at: new Date(2026, 6, 8, 14, 30, 0).toISOString(),
+  }));
+  sender.sent.length = 0;
+
+  assert.equal(notifier.getState().gatesLlm, true, 'sin provider sano → gatea');
+  const gate = notifier.handleCommanderFreeText();
+  assert.equal(gate.gated, true);
+  assert.equal(gate.debounced, false);
+  assert.equal(sender.sent.length, 1, 'se envía canned');
+  assert.equal(sender.sent[0].opts.plain, true);
+});
+
+test('#4565 rebote · isLlmGated tiene PRECEDENCIA sobre el heurístico por provider', () => {
+  const clock = makeFakeClock();
+  const sender = makeFakeSender();
+  const notifier = createQuotaNotifier({
+    sendMessage: sender.sendMessage,
+    now: () => clock.nowMs,
+    setIntervalFn: clock.setIntervalFn,
+    clearIntervalFn: clock.clearIntervalFn,
+    // El heurístico diría "bloquear" (exhausted anthropic == commander anthropic),
+    // pero la cadena tiene un sano → isLlmGated manda y NO bloquea.
+    isLlmGated: () => false,
+    getCommanderProvider: () => 'anthropic',
+  });
+  notifier.onFlagSet(makeFlag(clock, { provider: 'anthropic' }));
+  assert.equal(notifier.getState().gatesLlm, false, 'isLlmGated=false gana sobre el heurístico');
+});
+
+test('#4565 rebote · isLlmGated que lanza → fail-open (NO bloquea, cae al no-gate)', () => {
+  const clock = makeFakeClock();
+  const sender = makeFakeSender();
+  const logs = [];
+  const notifier = createQuotaNotifier({
+    sendMessage: sender.sendMessage,
+    now: () => clock.nowMs,
+    setIntervalFn: clock.setIntervalFn,
+    clearIntervalFn: clock.clearIntervalFn,
+    log: (m) => logs.push(m),
+    // Bug del resolver: lanza. Fail-open = NO pre-emptir con canned; que
+    // ejecutarClaude re-resuelva y decida (preserva CA-3 en el error path).
+    isLlmGated: () => { throw new Error('resolver boom'); },
+    getCommanderProvider: () => 'anthropic',
+  });
+  notifier.onFlagSet(makeFlag(clock, { provider: 'anthropic' }));
+  sender.sent.length = 0;
+
+  assert.equal(notifier.getState().gatesLlm, false, 'fail-open: no bloquea ante error del resolver');
+  const gate = notifier.handleCommanderFreeText();
+  assert.equal(gate.gated, false);
+  assert.equal(sender.sent.length, 0, 'no se envía canned');
+  assert.ok(logs.some((m) => /isLlmGated lanzó/.test(m)), 'loguea el fail-open');
+});
+
+test('#4565 rebote · sin isLlmGated → heurístico por provider (backward-compat)', () => {
+  const clock = makeFakeClock();
+  const sender = makeFakeSender();
+  const notifier = createQuotaNotifier({
+    sendMessage: sender.sendMessage,
+    now: () => clock.nowMs,
+    setIntervalFn: clock.setIntervalFn,
+    clearIntervalFn: clock.clearIntervalFn,
+    // NO se inyecta isLlmGated → cae al heurístico existente.
+    getCommanderProvider: () => 'anthropic',
+  });
+  notifier.onFlagSet(makeFlag(clock, { provider: 'anthropic' }));
+  assert.equal(notifier.getState().gatesLlm, true, 'heurístico: anthropic==anthropic → bloquea');
 });

--- a/.pipeline/lib/commander/multi-provider.js
+++ b/.pipeline/lib/commander/multi-provider.js
@@ -231,6 +231,50 @@ function resolveCommanderProvider(opts = {}) {
     return _normalizeBalancerMeta(strict);
 }
 
+// -----------------------------------------------------------------------------
+// #4565 (rebote rev-1) — ¿la cadena de fallback del commander está ENTERAMENTE
+// gateada? Chequeo READ-ONLY para el gate de cuota del pulpo (pre-ejecutarClaude).
+//
+// El bug del rebote: el gate consultaba solo si el PRIMARIO (Anthropic) estaba
+// agotado y, de estarlo, respondía canned determinístico ANTES de que el
+// dispatcher pudiera resolver un fallback sano (viola CA-3). La autoridad real
+// sobre "¿hay algún provider para procesar texto libre?" es la resolución de la
+// cadena completa: `resolveSpawnWithFallback(...).gated` es true SOLO cuando el
+// primario y TODOS los fallbacks están gateados.
+//
+// Reusamos `resolveSpawnWithFallback` (la MISMA lógica que usa `ejecutarClaude`
+// vía `resolveCommanderProvider`) pero silenciando TODO side-effect: sin escritura
+// de audit (`auditLog` no-op), sin notice a Telegram (`notify` no-op) y sin logs
+// (`onLog` no-op). NO pasamos por el balancer (`_resolveViaBalancer`) para no
+// tocar contadores/stickiness: la determinación de "gated" es idéntica en ambos
+// caminos (si la cadena estricta encuentra un sano, el balanceo también; si la
+// estricta reporta all-gated, el balanceo devuelve null → cae a la estricta).
+//
+// Fail-open: ante cualquier error devuelve `false` (NO bloquear). Nunca queremos
+// que un bug del resolver deje mudo al commander con canned cuando podría haber
+// un provider sano; `ejecutarClaude` re-resuelve y decide con su propio manejo.
+// -----------------------------------------------------------------------------
+function isCommanderChainGated(opts = {}) {
+    const { pipelineDir, fsImpl, quotaModule, now, dispatchModule } = opts;
+    try {
+        const _dispatch = dispatchModule || require('../agent-launcher/dispatch-with-fallback');
+        const res = _dispatch.resolveSpawnWithFallback({
+            skill: COMMANDER_SKILL,
+            issue: 'commander-gate-check',
+            pipelineDir,
+            fsImpl,
+            quotaModule: quotaModule || require('../quota-exhausted'),
+            now,
+            onLog: () => {},                          // sin logs
+            notify: () => {},                         // sin notice a Telegram
+            auditLog: { appendChained: () => {} },    // sin escritura de audit
+        });
+        return !!(res && res.gated);
+    } catch {
+        return false; // fail-open: nunca pre-emptir con canned por un bug propio
+    }
+}
+
 // #4413 — asegura que una resolución exponga las 3 claves de metadata de
 // balanceo (weight/quotaPct/selectionReason). Si ya vienen (camino balanceado),
 // no las pisa; si no (camino estricto), las agrega en null. Aditivo: preserva
@@ -1752,6 +1796,8 @@ module.exports = {
     sanitizeUserPrompt,
     resolveCommanderProvider,
     resolveCommanderProviderExcluding,
+    // #4565 (rebote rev-1) — gate de cuota read-only: ¿toda la cadena gateada?
+    isCommanderChainGated,
     formatFallbackNotice,
     shouldEmitFallbackNotice,
     auditCommanderRequest,

--- a/.pipeline/lib/quota-notifier.js
+++ b/.pipeline/lib/quota-notifier.js
@@ -24,11 +24,11 @@ const { redactSensitive } = require('./redact');
 const QUOTA_COPY = {
   // §2 — inicial
   initial:
-    'Cuota Anthropic agotada.\n' +
+    'Cuota {provider} agotada.\n' +
     'Pipeline en modo deterministico. Reset estimado: {hhmm} (en {countdown}).',
   // §2 — variante para resets_at fallback (CA-8 hereditario)
   initialFallback:
-    'Cuota Anthropic agotada.\n' +
+    'Cuota {provider} agotada.\n' +
     'Pipeline en modo deterministico. Reset estimado: proximo reset semanal (en {countdown}).',
   // §3 — recordatorios A/B/C/D
   reminders: [
@@ -41,7 +41,7 @@ const QUOTA_COPY = {
     'Reset al volver la cuota: {hhmm} (en {countdown}).\n' +
     '{n} archivos LLM esperando en cola.',
     // C — corta
-    'Cuota Anthropic: {countdown} para el reset ({hhmm}).\n' +
+    'Cuota {provider}: {countdown} para el reset ({hhmm}).\n' +
     'Determinisicos siguen avanzando.',
     // D — con hint a comandos
     'Pipeline aun en modo deterministico (reset {hhmm}, en {countdown}).\n' +
@@ -49,17 +49,17 @@ const QUOTA_COPY = {
   ],
   // §4 — canned a texto libre (sin interpolación de input usuario, CA-S7)
   cannedFreeText:
-    'Cuota Anthropic agotada hasta las {hhmm}.\n' +
+    'Cuota {provider} agotada hasta las {hhmm}.\n' +
     'Pipeline operando en modo deterministico.\n' +
     'Comandos disponibles: /status /metrics /dashboard /intake /pause /ghostbusters /restart /limpiar.',
   // §5 — restaurada con cola
   restored:
-    'Cuota Anthropic restaurada.\n' +
+    'Cuota {provider} restaurada.\n' +
     'Drenando cola de {n} agentes encolados.\n' +
     'Pipeline volviendo a operacion full.',
   // §5 — restaurada sin cola (N=0)
   restoredEmpty:
-    'Cuota Anthropic restaurada.\n' +
+    'Cuota {provider} restaurada.\n' +
     'No habia agentes encolados — pipeline directo a operacion full.\n' +
     'Pipeline volviendo a operacion full.',
   // §3013 — alerta de umbral 90% por snapshot real (CA-UX-7 / narrativa §4.1).
@@ -83,6 +83,43 @@ const QUOTA_COPY = {
 
 // Etiquetas para logging (mapean rotationIndex → letra)
 const REMINDER_LABELS = ['A', 'B', 'C', 'D'];
+
+// -- Provider legible (#4565 Bug 1) -------------------------------------------
+// Mapa provider-key canónica → label humano para interpolar en los templates.
+// El flag persiste `provider` como clave interna cruda (ej. 'openai-codex');
+// NUNCA mostramos esa clave al operador (guideline UX del issue). Si el provider
+// es desconocido o falta, cae a 'anthropic' (default histórico backward-compat
+// documentado en quota-exhausted.js:DEFAULT_PROVIDER).
+const DEFAULT_PROVIDER_KEY = 'anthropic';
+const PROVIDER_LABELS = {
+  anthropic: 'Anthropic',
+  'openai-codex': 'OpenAI Codex',
+  'gemini-google': 'Gemini',
+  cerebras: 'Cerebras',
+  'nvidia-nim': 'NVIDIA NIM',
+  groq: 'Groq',
+  deterministic: 'Deterministico',
+};
+// Aliases de provider-key → canónica (algún codepath usa el alias corto).
+const PROVIDER_ALIASES = {
+  openai: 'openai-codex',
+  codex: 'openai-codex',
+  gemini: 'gemini-google',
+  claude: 'anthropic',
+};
+
+/** Normaliza una provider-key cruda a su forma canónica. */
+function normalizeProviderKey(raw) {
+  if (typeof raw !== 'string' || raw.trim() === '') return DEFAULT_PROVIDER_KEY;
+  const key = raw.trim().toLowerCase();
+  return PROVIDER_ALIASES[key] || key;
+}
+
+/** Resuelve el label humano de una provider-key (nunca la clave cruda). */
+function providerLabel(raw) {
+  const key = normalizeProviderKey(raw);
+  return PROVIDER_LABELS[key] || PROVIDER_LABELS[DEFAULT_PROVIDER_KEY];
+}
 
 // -- Reglas operativas (configurables) ----------------------------------------
 const DEFAULT_REMINDER_INTERVAL_MIN = 120;            // 2h, override en config.yaml
@@ -133,20 +170,43 @@ function interpolate(template, vars) {
 }
 
 /**
+ * Normaliza `resets_at` a epoch-ms, aceptando dos representaciones (#4565 Bug 2):
+ *   - number epoch-ms (formato de los fixtures de test y del flag legacy).
+ *   - string ISO8601 (formato real que persiste el flag #2974, ej.
+ *     "2026-07-13T00:00:00.000Z"). `Number()` sobre un ISO string devuelve NaN
+ *     → el bug histórico que renderizaba `--:--`. Usamos `Date.parse()` como el
+ *     módulo hermano quota-exhausted-state.js:153.
+ *   - string numérico ("5000000") → epoch-ms (tolerancia defensiva).
+ * Devuelve NaN si no se puede interpretar.
+ */
+function parseResetsAt(value) {
+  if (Number.isFinite(value)) return value;               // epoch-ms number
+  if (typeof value === 'number') return NaN;              // NaN / Infinity
+  if (typeof value !== 'string') return NaN;
+  const s = value.trim();
+  if (s === '') return NaN;
+  if (/^-?\d+$/.test(s)) return Number(s);                // string numérico → epoch-ms
+  const parsed = Date.parse(s);                           // ISO8601 → epoch-ms
+  return Number.isFinite(parsed) ? parsed : NaN;
+}
+
+/**
  * Construye el set de variables para los templates a partir del flag.
  *   - hhmm: `HH:MM` formateado de `resets_at`.
  *   - countdown: delta hasta el reset.
  *   - n: cantidad de agentes encolados.
  *   - isFallback: true si el flag tiene `resets_at_fallback`.
+ *   - provider: label humano del provider agotado (#4565 Bug 1).
  */
 function buildVars(flagData, nowMs, queuedCount) {
-  const resetsAt = Number(flagData && flagData.resets_at);
+  const resetsAt = parseResetsAt(flagData && flagData.resets_at);
   const isFallback = !!(flagData && flagData.resets_at_fallback);
   return {
     hhmm: formatHHMM(resetsAt),
     countdown: formatCountdown(resetsAt, nowMs, { hoursOnly: isFallback }),
     n: Number.isFinite(queuedCount) ? queuedCount : 0,
     isFallback,
+    provider: providerLabel(flagData && flagData.provider),
   };
 }
 
@@ -179,6 +239,19 @@ function buildVars(flagData, nowMs, queuedCount) {
  *        Override del umbral anti-falso-positivo (default 5 min).
  * @param {number} [deps.debounceCannedMs]
  *        Override del debounce de canned response (default 2 min).
+ * @param {() => boolean} [deps.isLlmGated]
+ *        #4565 (rebote rev-1) — AUTORIDAD del gate de texto libre. Predicado que
+ *        resuelve la cadena de fallback EFECTIVA del commander y devuelve `true`
+ *        SOLO cuando NO hay ningún provider sano para procesar (primario + todos
+ *        los fallbacks gateados). Cuando se inyecta, el gate lo usa como veredicto
+ *        único: si Anthropic está agotado pero hay un fallback sano, devuelve
+ *        `false` y NO pre-emptimos con canned — dejamos que `ejecutarClaude` use
+ *        ese provider sano (CA-3). Sin inyectar, se cae al heurístico por provider
+ *        (`getCommanderProvider`), usado por los tests unitarios del notifier.
+ * @param {() => string} [deps.getCommanderProvider]
+ *        Heurístico de RESPALDO (solo si `isLlmGated` no se inyecta): provider-key
+ *        que el commander usa como primario. Default `'anthropic'`. El gate
+ *        bloquea cuando el provider agotado coincide con este.
  */
 function createQuotaNotifier(deps) {
   if (!deps || typeof deps.sendMessage !== 'function') {
@@ -202,6 +275,11 @@ function createQuotaNotifier(deps) {
   const debounceCannedMs = Number.isFinite(deps.debounceCannedMs)
     ? deps.debounceCannedMs
     : DEBOUNCE_CANNED_MS;
+  const getCommanderProvider = typeof deps.getCommanderProvider === 'function'
+    ? deps.getCommanderProvider
+    : () => DEFAULT_PROVIDER_KEY;
+  // #4565 (rebote rev-1) — predicado autoritativo de la cadena de fallback.
+  const isLlmGated = typeof deps.isLlmGated === 'function' ? deps.isLlmGated : null;
 
   const state = {
     flagData: null,
@@ -296,7 +374,9 @@ function createQuotaNotifier(deps) {
     if (blockDuration >= minBlockDurationForRestoredMs) {
       const queued = getQueuedAgentsCount();
       const tpl = queued >= 1 ? QUOTA_COPY.restored : QUOTA_COPY.restoredEmpty;
-      emit(interpolate(tpl, { n: queued }));
+      // #4565: el mensaje de restaurada debe nombrar el provider que se recuperó,
+      // no hardcodear "Anthropic". state.flagData sigue disponible (se limpia abajo).
+      emit(interpolate(tpl, { n: queued, provider: providerLabel(state.flagData && state.flagData.provider) }));
       log(`quota-notifier: restaurada enviada (queued=${queued}, duracion=${(blockDuration / 1000).toFixed(1)}s)`);
     } else {
       log(`quota-notifier: bloqueo duro ${(blockDuration / 1000).toFixed(1)}s (<${minBlockDurationForRestoredMs / 1000}s) — omito mensaje de restaurada`);
@@ -316,8 +396,43 @@ function createQuotaNotifier(deps) {
    *   - gated=true, debounced=true: flag activo pero ya respondió hace <2 min.
    *     Caller debe abortar SIN enviar otra canned (anti spam-self).
    */
+  /**
+   * #4565 CA-3 — ¿el flag activo debe bloquear el LLM del commander?
+   *
+   * Rebote rev-1: la comparación por-provider (exhausted === primario) era
+   * insuficiente. Cuando Anthropic está agotado pero hay un fallback sano en la
+   * cadena, el gate bloqueaba con canned ANTES de que `ejecutarClaude` pudiera
+   * usar ese fallback (viola CA-3). La AUTORIDAD real es la resolución de la
+   * cadena completa: bloqueamos SOLO cuando NO hay ningún provider sano.
+   *
+   *   - Con `isLlmGated` inyectado (producción): veredicto único de la cadena.
+   *     `true` sii primario + todos los fallbacks gateados. Fail-open ante error
+   *     (NO pre-emptir: `ejecutarClaude` re-resuelve y decide).
+   *   - Sin `isLlmGated` (tests aislados del notifier): heurístico por provider.
+   *
+   * Sin flag → no bloquea (no hay nada que gatear).
+   */
+  function shouldGateProvider() {
+    if (!state.flagData) return false;
+    if (isLlmGated) {
+      try {
+        return isLlmGated() === true;
+      } catch (e) {
+        // Fail-open: un bug del resolver NUNCA debe silenciar al commander con
+        // canned si podría haber un provider sano. Preserva CA-3 en el error path.
+        log(`quota-notifier: isLlmGated lanzó (${e && e.message}) — fail-open, no bloqueo`);
+        return false;
+      }
+    }
+    const exhausted = normalizeProviderKey(state.flagData.provider);
+    const commander = normalizeProviderKey(getCommanderProvider());
+    return exhausted === commander;
+  }
+
   function handleCommanderFreeText() {
-    if (!state.flagData) {
+    if (!state.flagData || !shouldGateProvider()) {
+      // Sin flag, o el provider agotado no es el que usa el commander:
+      // el flujo normal de LLM debe continuar (CA-3).
       return { gated: false, debounced: false, text: null };
     }
     const t = now();
@@ -339,6 +454,14 @@ function createQuotaNotifier(deps) {
   function getState() {
     return {
       active: !!state.flagData,
+      // #4565 (rebote rev-1) CA-3 — provider agotado y si la cadena de fallback
+      // del commander está ENTERAMENTE gateada. El gate de pulpo debe consultar
+      // `gatesLlm`, NO `active`: `active` es true aunque haya un provider sano en
+      // la cadena (Codex agotado ⇏ bloquear Claude; Anthropic agotado con fallback
+      // sano ⇏ bloquear). `gatesLlm` es true SOLO cuando no hay provider sano.
+      provider: state.flagData ? normalizeProviderKey(state.flagData.provider) : null,
+      providerLabel: state.flagData ? providerLabel(state.flagData.provider) : null,
+      gatesLlm: shouldGateProvider(),
       flagSetAt: state.flagSetAt,
       rotationIndex: state.rotationIndex,
       hasInterval: state.intervalHandle != null,
@@ -371,8 +494,13 @@ module.exports = {
   DEFAULT_REMINDER_INTERVAL_MIN,
   DEBOUNCE_CANNED_MS,
   MIN_BLOCK_DURATION_FOR_RESTORED_MS,
+  PROVIDER_LABELS,
+  DEFAULT_PROVIDER_KEY,
   formatHHMM,
   formatCountdown,
   interpolate,
   buildVars,
+  parseResetsAt,
+  providerLabel,
+  normalizeProviderKey,
 };

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -12351,12 +12351,21 @@ async function _brazoCommanderInner(config, archivosIniciales, commanderPendient
     return;
   }
 
-  // --- #2975 — GATE DE CUOTA ANTHROPIC AGOTADA (CA-9/CA-10/CA-11) ---
+  // --- #2975 — GATE DE CUOTA AGOTADA (CA-9/CA-10/CA-11) ---
   // Si el flag está activo, los comandos nativos del switch case YA respondieron
   // arriba (sin pasar por LLM, garantizado por construcción — CA-3 hereditario).
   // Acá interceptamos texto libre ANTES de `ejecutarClaude` y respondemos canned
   // con debounce 2 min, sin interpolar input del usuario (CA-S7).
-  if (textoLibre.length > 0 && quotaNotifier.getState().active) {
+  //
+  // #4565 (rebote rev-1) CA-3 — gate por RESOLUCIÓN DE CADENA: consultamos
+  // `gatesLlm` (no `active`), que ahora refleja `resolveSpawnWithFallback(...).
+  // gated` de la cadena de fallback completa del commander. Solo bloqueamos
+  // cuando NO hay ningún provider sano (primario + todos los fallbacks gateados).
+  // Si el provider agotado es OTRO (ej. Codex) o si Anthropic está agotado pero
+  // hay un fallback sano, `gatesLlm` es false y dejamos que `ejecutarClaude` use
+  // ese provider sano en vez de caer a determinístico. `handleCommanderFreeText`
+  // aplica el mismo criterio internamente (defensa en profundidad).
+  if (textoLibre.length > 0 && quotaNotifier.getState().gatesLlm) {
     const gate = quotaNotifier.handleCommanderFreeText();
     if (gate.gated) {
       log('commander', `Gate de cuota activo — ${gate.debounced ? 'debounced' : 'canned response enviada'}`);
@@ -14394,6 +14403,18 @@ const quotaNotifier = createQuotaNotifier({
     return DEFAULT_REMINDER_INTERVAL_MIN;
   },
   getQueuedAgentsCount: () => countQueuedLlmAgents(),
+  // #4565 (rebote rev-1) CA-3 — el gate debe reflejar la resolución EFECTIVA de
+  // la cadena de fallback del commander, no solo el estado del primario. Si
+  // Anthropic está agotado pero hay un fallback sano, `isLlmGated()` es false y
+  // NO pre-emptimos con canned: dejamos que `ejecutarClaude` (que resuelve la
+  // MISMA cadena vía `resolveCommanderProvider`) use ese provider sano. Solo
+  // bloqueamos cuando TODA la cadena está gateada (mismo veredicto que
+  // `resolveSpawnWithFallback(...).gated`). Read-only: el helper silencia audit,
+  // notice de Telegram y logs para no duplicar los side-effects del dispatch real.
+  isLlmGated: () => commanderMP.isCommanderChainGated({ pipelineDir: PIPELINE }),
+  // Heurístico de respaldo (no se usa mientras `isLlmGated` resuelva): provider
+  // primario del commander para la comparación por-provider en tests aislados.
+  getCommanderProvider: () => 'anthropic',
 });
 
 let lastQuotaFlagPresent = false;

--- a/.pipeline/tests/commander-chain-gated-4565.test.js
+++ b/.pipeline/tests/commander-chain-gated-4565.test.js
@@ -1,0 +1,148 @@
+// =============================================================================
+// commander-chain-gated-4565.test.js — #4565 (rebote rev-1)
+//
+// Test de integración del helper `isCommanderChainGated` (módulos REALES:
+// dispatch-with-fallback + quota-exhausted + provider-disabled, leyendo flags
+// de disco vía PIPELINE_DIR_OVERRIDE). Cierra el gap del rechazo de review:
+//
+//   El gate de cuota del pulpo pre-emptía con canned determinístico cuando
+//   Anthropic estaba agotado, SIN considerar la cadena de fallback. Si había un
+//   fallback sano (ej. Codex), el commander debía usarlo (CA-3), pero el gate
+//   respondía canned antes de que `ejecutarClaude` pudiera hacerlo.
+//
+// `isCommanderChainGated` resuelve la MISMA cadena que `ejecutarClaude` y
+// devuelve `true` SOLO cuando NO hay ningún provider sano. Read-only: silencia
+// audit, notice a Telegram y logs.
+// =============================================================================
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const commanderMP = require('../lib/commander/multi-provider');
+
+// agent-models.json mínimo: telegram-commander con primario anthropic y fallback
+// openai-codex (auth_mode oauth → no requiere secretos, test determinístico).
+function agentModels() {
+    return {
+        defaults: { model: 'claude-sonnet-4-6' },
+        default_provider: 'anthropic',
+        providers: {
+            anthropic: { launcher: 'claude', model: 'claude-sonnet-4-6', auth_mode: 'oauth', credentials_env: ['ANTHROPIC_API_KEY'] },
+            'openai-codex': { launcher: 'codex', model: 'gpt-5.5', auth_mode: 'oauth', credentials_env: ['OPENAI_API_KEY'] },
+        },
+        skills: {
+            'telegram-commander': {
+                provider: 'anthropic',
+                model_override: 'claude-sonnet-4-6',
+                fallbacks: [{ provider: 'openai-codex', model_override: 'gpt-5.5' }],
+            },
+        },
+    };
+}
+
+function withTempPipeline(setupFiles, fn) {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'chain4565-'));
+    const prev = process.env.PIPELINE_DIR_OVERRIDE;
+    try {
+        for (const [name, content] of Object.entries(setupFiles)) {
+            fs.writeFileSync(path.join(tmp, name), content, 'utf8');
+        }
+        process.env.PIPELINE_DIR_OVERRIDE = tmp;
+        return fn(tmp);
+    } finally {
+        if (prev === undefined) delete process.env.PIPELINE_DIR_OVERRIDE;
+        else process.env.PIPELINE_DIR_OVERRIDE = prev;
+        try { fs.rmSync(tmp, { recursive: true, force: true }); } catch { /* best-effort */ }
+    }
+}
+
+// Flag de cuota REAL con schema post-#3077 (validateFlagShape exige
+// resets_at/detected_at/pattern_matched como strings; provider opcional).
+function quotaFlag(provider) {
+    return JSON.stringify({
+        exhausted: true,
+        provider,
+        resets_at: new Date(Date.now() + 3600_000).toISOString(),
+        detected_at: new Date().toISOString(),
+        pattern_matched: 'usage_limit_reached',
+    });
+}
+
+test('#4565 rebote · Anthropic agotado + Codex sano → isCommanderChainGated=false (CA-3)', () => {
+    withTempPipeline({
+        'agent-models.json': JSON.stringify(agentModels()),
+        // SOLO Anthropic agotado. El fallback Codex NO está en el flag (scope por
+        // provider) → la cadena resuelve a Codex y NO está gateada. Este es
+        // EXACTAMENTE el escenario del rechazo de review.
+        'quota-exhausted.json': quotaFlag('anthropic'),
+    }, (tmp) => {
+        const gated = commanderMP.isCommanderChainGated({ pipelineDir: tmp });
+        assert.equal(gated, false, 'hay fallback sano (Codex) → NO gatea, el commander debe usarlo');
+
+        // Sanity: la resolución real efectivamente salta a Codex (mismo veredicto).
+        const res = commanderMP.resolveCommanderProvider({ pipelineDir: tmp, log: () => {} });
+        assert.equal(res.gated, false);
+        assert.equal(res.provider, 'openai-codex', 'la cadena efectiva usa el fallback sano');
+    });
+});
+
+test('#4565 rebote · Anthropic agotado + Codex apagado → isCommanderChainGated=true (canned)', () => {
+    withTempPipeline({
+        'agent-models.json': JSON.stringify(agentModels()),
+        'quota-exhausted.json': quotaFlag('anthropic'),
+        // El único fallback también fuera de servicio → NO hay provider sano.
+        'provider-disabled.json': JSON.stringify({
+            disabled: [{ name: 'openai-codex', disabled_at: new Date(0).toISOString() }],
+        }),
+    }, (tmp) => {
+        const gated = commanderMP.isCommanderChainGated({ pipelineDir: tmp });
+        assert.equal(gated, true, 'primario agotado + fallback apagado → cadena entera gateada');
+    });
+});
+
+test('#4565 rebote · sin flags → isCommanderChainGated=false (happy path)', () => {
+    withTempPipeline({
+        'agent-models.json': JSON.stringify(agentModels()),
+    }, (tmp) => {
+        assert.equal(commanderMP.isCommanderChainGated({ pipelineDir: tmp }), false);
+    });
+});
+
+test('#4565 rebote · Codex agotado (no Anthropic) → isCommanderChainGated=false', () => {
+    withTempPipeline({
+        'agent-models.json': JSON.stringify(agentModels()),
+        // Se agotó Codex; el primario Anthropic sigue sano → NO gatea.
+        'quota-exhausted.json': quotaFlag('openai-codex'),
+    }, (tmp) => {
+        assert.equal(commanderMP.isCommanderChainGated({ pipelineDir: tmp }), false);
+    });
+});
+
+test('#4565 rebote · es READ-ONLY: no escribe audit ni notice en el pipeline dir', () => {
+    withTempPipeline({
+        'agent-models.json': JSON.stringify(agentModels()),
+        'quota-exhausted.json': quotaFlag('anthropic'),
+    }, (tmp) => {
+        const before = fs.readdirSync(tmp).sort();
+        // Varias invocaciones no deben acumular side-effects.
+        commanderMP.isCommanderChainGated({ pipelineDir: tmp });
+        commanderMP.isCommanderChainGated({ pipelineDir: tmp });
+        const after = fs.readdirSync(tmp).sort();
+        assert.deepEqual(after, before, 'no crea archivos nuevos (audit/notice silenciados)');
+    });
+});
+
+test('#4565 rebote · fail-open: dispatchModule que lanza → false (no pre-emptir)', () => {
+    // Inyectamos un dispatch que revienta: nunca queremos bloquear al commander
+    // por un bug del resolver. Fail-open = false.
+    const boom = {
+        resolveSpawnWithFallback() { throw new Error('dispatch boom'); },
+    };
+    const gated = commanderMP.isCommanderChainGated({ pipelineDir: '/tmp/nope', dispatchModule: boom });
+    assert.equal(gated, false, 'fail-open ante error del dispatch');
+});


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 5 archivos · +706 -12

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:passed` aplicado por delivery

## Closes

Closes #4565
