### PR TITLE
[bug] Entregables se envían multiplicados a Telegram: perfil de adjuntos con nameMustInclude vacío barre toda la carpeta del issue

### DIFF
--- a/.pipeline/.gh-summary-1783549858736-sq08f.graphql
+++ b/.pipeline/.gh-summary-1783549858736-sq08f.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783549859273-xq6cl.graphql
+++ b/.pipeline/.gh-summary-1783549859273-xq6cl.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783549859486-4r6a0.graphql
+++ b/.pipeline/.gh-summary-1783549859486-4r6a0.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783549859719-gkd5o.graphql
+++ b/.pipeline/.gh-summary-1783549859719-gkd5o.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783549859927-3qymq.graphql
+++ b/.pipeline/.gh-summary-1783549859927-3qymq.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783549860130-bqwbt.graphql
+++ b/.pipeline/.gh-summary-1783549860130-bqwbt.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783549860331-i6k1x.graphql
+++ b/.pipeline/.gh-summary-1783549860331-i6k1x.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783549860495-beig5.graphql
+++ b/.pipeline/.gh-summary-1783549860495-beig5.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783549860664-1wv88.graphql
+++ b/.pipeline/.gh-summary-1783549860664-1wv88.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783549860832-wd1qx.graphql
+++ b/.pipeline/.gh-summary-1783549860832-wd1qx.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783549861015-om5g5.graphql
+++ b/.pipeline/.gh-summary-1783549861015-om5g5.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783549861194-j345j.graphql
+++ b/.pipeline/.gh-summary-1783549861194-j345j.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783549861306-4hw43.graphql
+++ b/.pipeline/.gh-summary-1783549861306-4hw43.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783549861462-i213d.graphql
+++ b/.pipeline/.gh-summary-1783549861462-i213d.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783549861605-wvvy7.graphql
+++ b/.pipeline/.gh-summary-1783549861605-wvvy7.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783549861811-g6kse.graphql
+++ b/.pipeline/.gh-summary-1783549861811-g6kse.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783549861985-ca2jq.graphql
+++ b/.pipeline/.gh-summary-1783549861985-ca2jq.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/lib/__tests__/skill-deliverable-attachments.test.js
+++ b/.pipeline/lib/__tests__/skill-deliverable-attachments.test.js
@@ -194,13 +194,14 @@ test('CA-1.4 — sourceIsIssueScoped() valida el catálogo completo', () => {
 test('po recolecta documentos en docs/<issue>/ con extensiones permitidas', () => {
     const tmp = mkTmpRoot();
     try {
-        writeFile(tmp.root, '.pipeline/assets/docs/3647/criterios-refinados.md', '# X');
-        writeFile(tmp.root, '.pipeline/assets/docs/3647/diseño-rechazado.exe', 'no');
+        // #4584: los archivos siguen la convención `<skill>-<fase>-<issue>.<ext>`.
+        writeFile(tmp.root, '.pipeline/assets/docs/3647/po-criterios-3647.md', '# X');
+        writeFile(tmp.root, '.pipeline/assets/docs/3647/po-diseño-rechazado.exe', 'no');
 
         const res = helper.collectAttachmentsForSkill('po', 3647, 'criterios', { pipelineRoot: tmp.root });
         assert.equal(res.length, 1);
         assert.equal(res[0].type, 'document');
-        assert.ok(res[0].path.endsWith('criterios-refinados.md'));
+        assert.ok(res[0].path.endsWith('po-criterios-3647.md'));
     } finally {
         tmp.cleanup();
     }
@@ -209,7 +210,7 @@ test('po recolecta documentos en docs/<issue>/ con extensiones permitidas', () =
 test('guru recolecta análisis en docs/<issue>/', () => {
     const tmp = mkTmpRoot();
     try {
-        writeFile(tmp.root, '.pipeline/assets/docs/3647/analisis-tecnico.pdf', '%PDF');
+        writeFile(tmp.root, '.pipeline/assets/docs/3647/guru-analisis-3647.pdf', '%PDF');
         const res = helper.collectAttachmentsForSkill('guru', 3647, 'analisis', { pipelineRoot: tmp.root });
         assert.equal(res.length, 1);
         assert.equal(res[0].type, 'document');
@@ -340,7 +341,8 @@ for (const { skill, descriptor } of DOC_PROFILES) {
     test(`CA-1 — ${skill} recolecta 1 documento en docs/<issue>/`, () => {
         const tmp = mkTmpRoot();
         try {
-            writeFile(tmp.root, `.pipeline/assets/docs/3928/resumen-${skill}.md`, '# resumen');
+            // #4584: filename con prefijo `<skill>-` (convención de write-deliverable).
+            writeFile(tmp.root, `.pipeline/assets/docs/3928/${skill}-resumen.md`, '# resumen');
             const res = helper.collectAttachmentsForSkill(skill, 3928, 'dev', { pipelineRoot: tmp.root });
             assert.equal(res.length, 1, `${skill}: esperaba 1 adjunto`);
             assert.equal(res[0].type, 'document');
@@ -355,7 +357,7 @@ for (const { skill, descriptor } of DOC_PROFILES) {
     test(`CA-1 — ${skill} también acepta .pdf`, () => {
         const tmp = mkTmpRoot();
         try {
-            writeFile(tmp.root, `.pipeline/assets/docs/3928/informe-${skill}.pdf`, '%PDF');
+            writeFile(tmp.root, `.pipeline/assets/docs/3928/${skill}-informe.pdf`, '%PDF');
             const res = helper.collectAttachmentsForSkill(skill, 3928, 'dev', { pipelineRoot: tmp.root });
             assert.equal(res.length, 1);
             assert.equal(res[0].type, 'document');
@@ -406,8 +408,8 @@ test('CA-2 — qa con solo video devuelve solo el video', () => {
 test('CA-6 (SEC-2) — tester con docs de 3928 y 3929 devuelve solo los de 3928', () => {
     const tmp = mkTmpRoot();
     try {
-        writeFile(tmp.root, '.pipeline/assets/docs/3928/cobertura.md', 'A');
-        writeFile(tmp.root, '.pipeline/assets/docs/3929/cobertura.md', 'B');
+        writeFile(tmp.root, '.pipeline/assets/docs/3928/tester-cobertura.md', 'A');
+        writeFile(tmp.root, '.pipeline/assets/docs/3929/tester-cobertura.md', 'B');
         const res = helper.collectAttachmentsForSkill('tester', 3928, 'verificacion', { pipelineRoot: tmp.root });
         assert.equal(res.length, 1);
         assert.ok(res[0].path.includes('3928'), `cross-contamination: ${res[0].path}`);
@@ -545,7 +547,9 @@ test('#4255 — manifest tiene prioridad sobre la inferencia del filename', () =
 test('#4255 — sin manifest ni patrón, cae al phase hint recibido', () => {
     const tmp = mkTmpRoot();
     try {
-        writeFile(tmp.root, '.pipeline/assets/docs/321/analisis-tecnico.md', 'x');
+        // #4584: token `guru-` presente pero SIN el patrón `<skill>-<fase>-<issue>`
+        // (no termina en `-321`), así inferFaseFromName devuelve null y cae al hint.
+        writeFile(tmp.root, '.pipeline/assets/docs/321/guru-dossier.md', 'x');
         const res = helper.collectAttachmentsForSkill('guru', 321, 'analisis', { pipelineRoot: tmp.root });
         assert.equal(res.length, 1);
         assert.equal(res[0].fase, 'analisis');
@@ -611,6 +615,99 @@ test('#4514 — buildManifestSensibleMap devuelve mapa vacío sin índice (best-
         const map = helper.__internals.buildManifestSensibleMap('4514', tmp.root);
         assert.ok(map instanceof Map);
         assert.equal(map.size, 0);
+    } finally {
+        tmp.cleanup();
+    }
+});
+
+// =============================================================================
+// #4584 — Regresión: entregables NO se multiplican. Con varios skills dejando
+// su `.md` en la MISMA carpeta `.pipeline/assets/docs/<issue>/`, cada notify
+// resuelve SÓLO su propio archivo (token `<skill>-`), nunca los ajenos.
+// Reproduce el escape real de #4523 (architect re-envió 4 archivos ajenos).
+// =============================================================================
+
+// Fixture exacto del incidente #4523: 4 entregables de fases previas conviven en
+// la carpeta del issue antes de que corran las fases tardías.
+function seedMultiSkillFolder(root, issue) {
+    writeFile(root, `.pipeline/assets/docs/${issue}/build-build-${issue}.md`, '# build');
+    writeFile(root, `.pipeline/assets/docs/${issue}/guru-validacion-${issue}.md`, '# guru');
+    writeFile(root, `.pipeline/assets/docs/${issue}/security-verificacion-${issue}.md`, '# sec');
+    writeFile(root, `.pipeline/assets/docs/${issue}/tester-verificacion-${issue}.md`, '# tester');
+}
+
+test('#4584 CA-3 — architect con 4 entregables ajenos en la carpeta resuelve 0 (entrega por comentario)', () => {
+    const tmp = mkTmpRoot();
+    try {
+        seedMultiSkillFolder(tmp.root, 4523);
+        // architect entrega su receta como comentario; no hay `architect-*.md`.
+        const res = helper.collectAttachmentsForSkill('architect', 4523, 'aprobacion', { pipelineRoot: tmp.root });
+        assert.deepEqual(res, [], `architect NO debe re-enviar entregables ajenos, vino ${JSON.stringify(res.map(r => r.path))}`);
+    } finally {
+        tmp.cleanup();
+    }
+});
+
+test('#4584 CA-3 — architect con su propio archivo resuelve exactamente 1 (el suyo)', () => {
+    const tmp = mkTmpRoot();
+    try {
+        seedMultiSkillFolder(tmp.root, 4523);
+        // El fallback de pulpo.js escribe `architect-<fase>-<issue>.md`.
+        writeFile(tmp.root, '.pipeline/assets/docs/4523/architect-aprobacion-4523.md', '# receta');
+        const res = helper.collectAttachmentsForSkill('architect', 4523, 'aprobacion', { pipelineRoot: tmp.root });
+        assert.equal(res.length, 1, `architect debe resolver SOLO su archivo, vino ${JSON.stringify(res.map(r => r.path))}`);
+        assert.ok(res[0].path.endsWith('architect-aprobacion-4523.md'));
+    } finally {
+        tmp.cleanup();
+    }
+});
+
+test('#4584 CA-3 — cada skill en una carpeta multi-skill resuelve exactamente su propio archivo', () => {
+    const tmp = mkTmpRoot();
+    try {
+        seedMultiSkillFolder(tmp.root, 4523);
+        const expected = {
+            build: 'build-build-4523.md',
+            guru: 'guru-validacion-4523.md',
+            security: 'security-verificacion-4523.md',
+            tester: 'tester-verificacion-4523.md',
+        };
+        for (const [skill, filename] of Object.entries(expected)) {
+            const res = helper.collectAttachmentsForSkill(skill, 4523, 'verificacion', { pipelineRoot: tmp.root });
+            assert.equal(res.length, 1, `${skill}: esperaba 1 adjunto propio, vino ${res.length} (${JSON.stringify(res.map(r => r.path))})`);
+            assert.ok(res[0].path.endsWith(filename), `${skill}: esperaba ${filename}, vino ${res[0].path}`);
+        }
+    } finally {
+        tmp.cleanup();
+    }
+});
+
+test('#4584 CA-3 — los 4 devs comparten carpeta y NO se pisan entre sí (token completo <skill>-)', () => {
+    const tmp = mkTmpRoot();
+    try {
+        const issue = 4600;
+        writeFile(tmp.root, `.pipeline/assets/docs/${issue}/backend-dev-dev-${issue}.md`, '# be');
+        writeFile(tmp.root, `.pipeline/assets/docs/${issue}/android-dev-dev-${issue}.md`, '# an');
+        writeFile(tmp.root, `.pipeline/assets/docs/${issue}/web-dev-dev-${issue}.md`, '# we');
+        writeFile(tmp.root, `.pipeline/assets/docs/${issue}/pipeline-dev-dev-${issue}.md`, '# pi');
+        for (const skill of ['backend-dev', 'android-dev', 'web-dev', 'pipeline-dev']) {
+            const res = helper.collectAttachmentsForSkill(skill, issue, 'dev', { pipelineRoot: tmp.root });
+            assert.equal(res.length, 1, `${skill}: colisión entre devs, vino ${JSON.stringify(res.map(r => r.path))}`);
+            assert.ok(res[0].path.endsWith(`${skill}-dev-${issue}.md`), `${skill}: vino ${res[0].path}`);
+        }
+    } finally {
+        tmp.cleanup();
+    }
+});
+
+test('#4584 — token corto no cae en falso positivo por substring (po vs qa-reporte)', () => {
+    const tmp = mkTmpRoot();
+    try {
+        // `qa-reporte.pdf` contiene la subcadena "po" (rePOrte); el token `po-`
+        // (con guión de cierre) evita el falso positivo.
+        writeFile(tmp.root, '.pipeline/assets/docs/4601/qa-reporte.pdf', '%PDF');
+        const res = helper.collectAttachmentsForSkill('po', 4601, 'aprobacion', { pipelineRoot: tmp.root });
+        assert.deepEqual(res, [], `po NO debe agarrar el reporte de qa por substring, vino ${JSON.stringify(res.map(r => r.path))}`);
     } finally {
         tmp.cleanup();
     }

--- a/.pipeline/lib/skill-deliverable-attachments.js
+++ b/.pipeline/lib/skill-deliverable-attachments.js
@@ -47,11 +47,22 @@ const path = require('node:path');
 // del path — esto resulta en directorios issue-scoped en disco (ej:
 // `qa/evidence/3647/`).
 //
-// `nameMustInclude` lista substrings que el filename DEBE contener. Si la lista
-// es no vacía, **se exige siempre que aparezca `{issue}`** (CA-1.4) — si el
-// directorio padre ya es issue-scoped (`{issue}` en `dirTemplate`), el check
+// `nameMustInclude` lista substrings que el filename DEBE contener (TODOS). Si
+// el directorio padre ya es issue-scoped (`{issue}` en `dirTemplate`), el check
 // del filename se relaja a "no exigir {issue} en el name". Sino, exigir
 // `{issue}` en filename es obligatorio.
+//
+// #4584 — Filtrado por skill: los perfiles documentales apuntan TODOS a la misma
+// carpeta `.pipeline/assets/docs/{issue}/`, donde conviven los `.md`/`.pdf` de
+// varias fases/skills (`build-build-N.md`, `guru-validacion-N.md`, …). Con
+// `nameMustInclude: []` el helper barría TODOS y cada skill re-enviaba los
+// entregables ajenos bajo su nombre (hasta 4-5 mensajes por uno en Telegram).
+// El fix puebla el token propio de cada skill como prefijo `<skill>-` (la
+// convención de `write-deliverable.js` es `<skill>-<fase>-<issue>.<ext>` o
+// `<skill>-<issue>.<ext>`). Se usa el nombre COMPLETO del skill (`backend-dev-`,
+// no `dev-`) para que los devs no colisionen entre sí, y el guión de cierre
+// evita falsos positivos por substring (ej. token `po` matchearía `qa-rePOrte`).
+// Skills que entregan por comentario (architect) resuelven 0 adjuntos, correcto.
 //
 // `formats` filtra por extensión (lowercased).
 //
@@ -95,16 +106,19 @@ const SKILL_SOURCES = Object.freeze({
     ],
     po: [
         // Documentos del PO — markdown / PDF con criterios refinados.
+        // #4584: `nameMustInclude: ['po-']` — filtra por el token propio del skill
+        // (prefijo `<skill>-` de la convención `<skill>-<fase>-<issue>.<ext>`) para
+        // NO barrer los `.md`/`.pdf` de otros skills en la misma carpeta del issue.
         {
             dirTemplate: '.pipeline/assets/docs/{issue}',
-            nameMustInclude: [],
+            nameMustInclude: ['po-'],
             formats: ['.pdf', '.md'],
             type: 'document',
             descriptorHint: 'criterios',
         },
         {
             dirTemplate: '.pipeline/assets/docs',
-            nameMustInclude: ['{issue}'],
+            nameMustInclude: ['{issue}', 'po-'],
             formats: ['.pdf', '.md'],
             type: 'document',
             descriptorHint: 'criterios',
@@ -113,14 +127,14 @@ const SKILL_SOURCES = Object.freeze({
     guru: [
         {
             dirTemplate: '.pipeline/assets/docs/{issue}',
-            nameMustInclude: [],
+            nameMustInclude: ['guru-'],
             formats: ['.pdf', '.md'],
             type: 'document',
             descriptorHint: 'analisis',
         },
         {
             dirTemplate: '.pipeline/assets/docs',
-            nameMustInclude: ['{issue}'],
+            nameMustInclude: ['{issue}', 'guru-'],
             formats: ['.pdf', '.md'],
             type: 'document',
             descriptorHint: 'analisis',
@@ -129,14 +143,14 @@ const SKILL_SOURCES = Object.freeze({
     planner: [
         {
             dirTemplate: '.pipeline/assets/docs/{issue}',
-            nameMustInclude: [],
+            nameMustInclude: ['planner-'],
             formats: ['.pdf', '.md', '.png', '.svg'],
             type: 'document',
             descriptorHint: 'planner',
         },
         {
             dirTemplate: '.pipeline/assets/docs',
-            nameMustInclude: ['{issue}'],
+            nameMustInclude: ['{issue}', 'planner-'],
             formats: ['.pdf', '.md'],
             type: 'document',
             descriptorHint: 'planner',
@@ -172,7 +186,7 @@ const SKILL_SOURCES = Object.freeze({
         },
         {
             dirTemplate: '.pipeline/assets/docs/{issue}',
-            nameMustInclude: [],
+            nameMustInclude: ['qa-'],
             formats: ['.pdf', '.md'],
             type: 'document',
             descriptorHint: 'qa-reporte',
@@ -181,7 +195,7 @@ const SKILL_SOURCES = Object.freeze({
     tester: [
         {
             dirTemplate: '.pipeline/assets/docs/{issue}',
-            nameMustInclude: [],
+            nameMustInclude: ['tester-'],
             formats: ['.pdf', '.md'],
             type: 'document',
             descriptorHint: 'cobertura',
@@ -190,7 +204,7 @@ const SKILL_SOURCES = Object.freeze({
     security: [
         {
             dirTemplate: '.pipeline/assets/docs/{issue}',
-            nameMustInclude: [],
+            nameMustInclude: ['security-'],
             formats: ['.pdf', '.md'],
             type: 'document',
             descriptorHint: 'seguridad',
@@ -200,25 +214,33 @@ const SKILL_SOURCES = Object.freeze({
     build: [
         {
             dirTemplate: '.pipeline/assets/docs/{issue}',
-            nameMustInclude: [],
+            nameMustInclude: ['build-'],
             formats: ['.pdf', '.md'],
             type: 'document',
             descriptorHint: 'build',
         },
     ],
     architect: [
+        // #4584: el architect entrega su receta como COMENTARIO del issue
+        // (`<!-- architect-signoff -->`), no como archivo. Con `['architect-']`
+        // sólo matchea SU propio `architect-<fase>-<issue>.md` (el que escribe el
+        // fallback de pulpo.js). Si no existe, resuelve 0 adjuntos — que es lo
+        // correcto: antes barría los N entregables ajenos de la carpeta del issue.
         {
             dirTemplate: '.pipeline/assets/docs/{issue}',
-            nameMustInclude: [],
+            nameMustInclude: ['architect-'],
             formats: ['.pdf', '.md'],
             type: 'document',
             descriptorHint: 'receta',
         },
     ],
+    // #4584: los 4 devs comparten `descriptorHint: 'dev'` y la misma carpeta.
+    // El token DEBE ser el nombre completo del skill (`backend-dev-`, `android-dev-`,
+    // …) — NO `dev-` — para que no colisionen entre sí (todos terminan en `-dev`).
     'backend-dev': [
         {
             dirTemplate: '.pipeline/assets/docs/{issue}',
-            nameMustInclude: [],
+            nameMustInclude: ['backend-dev-'],
             formats: ['.md', '.pdf'],
             type: 'document',
             descriptorHint: 'dev',
@@ -227,7 +249,7 @@ const SKILL_SOURCES = Object.freeze({
     'android-dev': [
         {
             dirTemplate: '.pipeline/assets/docs/{issue}',
-            nameMustInclude: [],
+            nameMustInclude: ['android-dev-'],
             formats: ['.md', '.pdf'],
             type: 'document',
             descriptorHint: 'dev',
@@ -236,7 +258,7 @@ const SKILL_SOURCES = Object.freeze({
     'web-dev': [
         {
             dirTemplate: '.pipeline/assets/docs/{issue}',
-            nameMustInclude: [],
+            nameMustInclude: ['web-dev-'],
             formats: ['.md', '.pdf'],
             type: 'document',
             descriptorHint: 'dev',
@@ -245,7 +267,7 @@ const SKILL_SOURCES = Object.freeze({
     'pipeline-dev': [
         {
             dirTemplate: '.pipeline/assets/docs/{issue}',
-            nameMustInclude: [],
+            nameMustInclude: ['pipeline-dev-'],
             formats: ['.md', '.pdf'],
             type: 'document',
             descriptorHint: 'dev',
@@ -260,7 +282,7 @@ const SKILL_SOURCES = Object.freeze({
     review: [
         {
             dirTemplate: '.pipeline/assets/docs/{issue}',
-            nameMustInclude: [],
+            nameMustInclude: ['review-'],
             formats: ['.md', '.pdf'],
             type: 'document',
             descriptorHint: 'review',
@@ -274,7 +296,7 @@ const SKILL_SOURCES = Object.freeze({
     delivery: [
         {
             dirTemplate: '.pipeline/assets/docs/{issue}',
-            nameMustInclude: [],
+            nameMustInclude: ['delivery-'],
             formats: ['.md', '.pdf'],
             type: 'document',
             descriptorHint: 'entrega',


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 19 archivos · +165 -29

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:passed` aplicado por delivery

## Closes

Closes #4584
