### PR TITLE
[enhancement] Cuota Anthropic: leer el uso real de `claude -p /usage`, eliminar la inferencia heurística + calibración manual

### DIFF
--- a/.pipeline/.gh-summary-1783549276922-o2iu1.graphql
+++ b/.pipeline/.gh-summary-1783549276922-o2iu1.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783549277328-x9zu9.graphql
+++ b/.pipeline/.gh-summary-1783549277328-x9zu9.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783549277728-89fzh.graphql
+++ b/.pipeline/.gh-summary-1783549277728-89fzh.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783549278010-2t80p.graphql
+++ b/.pipeline/.gh-summary-1783549278010-2t80p.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783549278186-yt9o4.graphql
+++ b/.pipeline/.gh-summary-1783549278186-yt9o4.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783549278349-jm6jx.graphql
+++ b/.pipeline/.gh-summary-1783549278349-jm6jx.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783549278525-ucb7l.graphql
+++ b/.pipeline/.gh-summary-1783549278525-ucb7l.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783549278693-u78ky.graphql
+++ b/.pipeline/.gh-summary-1783549278693-u78ky.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783549278893-1a0tv.graphql
+++ b/.pipeline/.gh-summary-1783549278893-1a0tv.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783549279097-l11sg.graphql
+++ b/.pipeline/.gh-summary-1783549279097-l11sg.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783549279286-w7r8y.graphql
+++ b/.pipeline/.gh-summary-1783549279286-w7r8y.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783549279473-uqsor.graphql
+++ b/.pipeline/.gh-summary-1783549279473-uqsor.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783549279657-qaw8l.graphql
+++ b/.pipeline/.gh-summary-1783549279657-qaw8l.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783549279813-peb9f.graphql
+++ b/.pipeline/.gh-summary-1783549279813-peb9f.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783549280129-badda.graphql
+++ b/.pipeline/.gh-summary-1783549280129-badda.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783549759082-mgd8l.graphql
+++ b/.pipeline/.gh-summary-1783549759082-mgd8l.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783549759556-lt7nh.graphql
+++ b/.pipeline/.gh-summary-1783549759556-lt7nh.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783549759998-8dax9.graphql
+++ b/.pipeline/.gh-summary-1783549759998-8dax9.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783549760205-1msvh.graphql
+++ b/.pipeline/.gh-summary-1783549760205-1msvh.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783549760389-sx2rk.graphql
+++ b/.pipeline/.gh-summary-1783549760389-sx2rk.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783549760561-25409.graphql
+++ b/.pipeline/.gh-summary-1783549760561-25409.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783549760746-8cm2t.graphql
+++ b/.pipeline/.gh-summary-1783549760746-8cm2t.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783549760899-6nku7.graphql
+++ b/.pipeline/.gh-summary-1783549760899-6nku7.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783549761041-aqgtd.graphql
+++ b/.pipeline/.gh-summary-1783549761041-aqgtd.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783549761189-sybo4.graphql
+++ b/.pipeline/.gh-summary-1783549761189-sybo4.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783549761379-52eq5.graphql
+++ b/.pipeline/.gh-summary-1783549761379-52eq5.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783549761623-3ngcj.graphql
+++ b/.pipeline/.gh-summary-1783549761623-3ngcj.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783549761814-cv2x6.graphql
+++ b/.pipeline/.gh-summary-1783549761814-cv2x6.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783549762147-i3jn4.graphql
+++ b/.pipeline/.gh-summary-1783549762147-i3jn4.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783550374242-4xbak.graphql
+++ b/.pipeline/.gh-summary-1783550374242-4xbak.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783550374697-dm41l.graphql
+++ b/.pipeline/.gh-summary-1783550374697-dm41l.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783550375043-z1o4y.graphql
+++ b/.pipeline/.gh-summary-1783550375043-z1o4y.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783550375333-fgnso.graphql
+++ b/.pipeline/.gh-summary-1783550375333-fgnso.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783550375549-n4l9g.graphql
+++ b/.pipeline/.gh-summary-1783550375549-n4l9g.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783550375833-31wlf.graphql
+++ b/.pipeline/.gh-summary-1783550375833-31wlf.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783550376012-arb9c.graphql
+++ b/.pipeline/.gh-summary-1783550376012-arb9c.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783550376205-7cqg2.graphql
+++ b/.pipeline/.gh-summary-1783550376205-7cqg2.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783550376497-m2icx.graphql
+++ b/.pipeline/.gh-summary-1783550376497-m2icx.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783550376700-do3lh.graphql
+++ b/.pipeline/.gh-summary-1783550376700-do3lh.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783550376964-wf45m.graphql
+++ b/.pipeline/.gh-summary-1783550376964-wf45m.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783550377164-qlq7l.graphql
+++ b/.pipeline/.gh-summary-1783550377164-qlq7l.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783550377338-rewtx.graphql
+++ b/.pipeline/.gh-summary-1783550377338-rewtx.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783550773078-srsui.graphql
+++ b/.pipeline/.gh-summary-1783550773078-srsui.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783550773561-f0lul.graphql
+++ b/.pipeline/.gh-summary-1783550773561-f0lul.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783550773932-bu746.graphql
+++ b/.pipeline/.gh-summary-1783550773932-bu746.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783550774105-taztp.graphql
+++ b/.pipeline/.gh-summary-1783550774105-taztp.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783550774444-67830.graphql
+++ b/.pipeline/.gh-summary-1783550774444-67830.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783550774627-hrth5.graphql
+++ b/.pipeline/.gh-summary-1783550774627-hrth5.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783550774884-0d6jq.graphql
+++ b/.pipeline/.gh-summary-1783550774884-0d6jq.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783550775100-si1rj.graphql
+++ b/.pipeline/.gh-summary-1783550775100-si1rj.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783550775429-cgv1f.graphql
+++ b/.pipeline/.gh-summary-1783550775429-cgv1f.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783550775694-c18wu.graphql
+++ b/.pipeline/.gh-summary-1783550775694-c18wu.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783550775992-5jkt5.graphql
+++ b/.pipeline/.gh-summary-1783550775992-5jkt5.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783551676923-zmeju.graphql
+++ b/.pipeline/.gh-summary-1783551676923-zmeju.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783551677375-x4mhq.graphql
+++ b/.pipeline/.gh-summary-1783551677375-x4mhq.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783551677551-tig1k.graphql
+++ b/.pipeline/.gh-summary-1783551677551-tig1k.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783551677731-4221b.graphql
+++ b/.pipeline/.gh-summary-1783551677731-4221b.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783551677993-bm1v7.graphql
+++ b/.pipeline/.gh-summary-1783551677993-bm1v7.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783551678334-15hs3.graphql
+++ b/.pipeline/.gh-summary-1783551678334-15hs3.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783551678616-0r28f.graphql
+++ b/.pipeline/.gh-summary-1783551678616-0r28f.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783551678825-e5338.graphql
+++ b/.pipeline/.gh-summary-1783551678825-e5338.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783551678991-l985y.graphql
+++ b/.pipeline/.gh-summary-1783551678991-l985y.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783551679145-ez5jt.graphql
+++ b/.pipeline/.gh-summary-1783551679145-ez5jt.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783551679341-r2uvf.graphql
+++ b/.pipeline/.gh-summary-1783551679341-r2uvf.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783551679630-odbw8.graphql
+++ b/.pipeline/.gh-summary-1783551679630-odbw8.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783551679837-65ktj.graphql
+++ b/.pipeline/.gh-summary-1783551679837-65ktj.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783551679979-redbu.graphql
+++ b/.pipeline/.gh-summary-1783551679979-redbu.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/.gh-summary-1783551680219-ebs4n.graphql
+++ b/.pipeline/.gh-summary-1783551680219-ebs4n.graphql
@@ -1,0 +1,1 @@
+{ repository(owner:"intrale",name:"platform") { i0: issue(number:4507) { number body comments(last:20) { nodes { author { login } body createdAt } } } } }

--- a/.pipeline/__tests__/quota-snapshot-scheduler.test.js
+++ b/.pipeline/__tests__/quota-snapshot-scheduler.test.js
@@ -34,12 +34,18 @@ test('isEnabled: respeta QUOTA_SNAPSHOT_ENABLED=false', () => {
   }
 });
 
-test('isEnabled: default es habilitado', () => {
+// #4597 — El snapshot OCR del panel "Uso" de Claude Desktop quedó DEPRECADO: la
+// cuota Anthropic ahora se lee directo de `claude -p /usage`. Por eso el default
+// del scheduler pasó a DESHABILITADO; sólo corre con opt-in explícito.
+test('isEnabled: default es deshabilitado (#4597, OCR deprecado)', () => {
   const prev = process.env.QUOTA_SNAPSHOT_ENABLED;
   try {
     delete process.env.QUOTA_SNAPSHOT_ENABLED;
-    assert.strictEqual(scheduler.isEnabled(), true);
+    assert.strictEqual(scheduler.isEnabled(), false);
+    // Sólo con opt-in explícito se habilita.
     process.env.QUOTA_SNAPSHOT_ENABLED = 'true';
+    assert.strictEqual(scheduler.isEnabled(), true);
+    process.env.QUOTA_SNAPSHOT_ENABLED = '1';
     assert.strictEqual(scheduler.isEnabled(), true);
   } finally {
     if (prev === undefined) delete process.env.QUOTA_SNAPSHOT_ENABLED;
@@ -87,40 +93,58 @@ test('runOnce: kill switch ON → retorna sin error', async () => {
 });
 
 test('runOnce: capture exit 2 (operador enfocado) es skip silencioso, sin alerta', async () => {
-  const calls = { failure: 0, success: 0, mismatch: 0, accountOk: 0 };
-  const fakeAlerter = {
-    recordFailure: () => { calls.failure += 1; },
-    recordSuccess: () => { calls.success += 1; },
-    recordAccountMismatch: () => { calls.mismatch += 1; },
-    recordAccountOk: () => { calls.accountOk += 1; },
-  };
-  const r = await scheduler.runOnce({
-    runCapture: async () => ({ exitCode: 2, stdout: '', stderr: '' }),
-    alerter: fakeAlerter,
-  });
-  assert.strictEqual(r.ok, false);
-  assert.strictEqual(r.reason, 'capture_skipped');
-  assert.strictEqual(calls.failure, 0);
+  // #4597 — con el scheduler default-OFF, hay que optar explícitamente para
+  // ejercitar el pipeline de captura (el kill switch se cubre aparte).
+  const prev = process.env.QUOTA_SNAPSHOT_ENABLED;
+  process.env.QUOTA_SNAPSHOT_ENABLED = 'true';
+  try {
+    const calls = { failure: 0, success: 0, mismatch: 0, accountOk: 0 };
+    const fakeAlerter = {
+      recordFailure: () => { calls.failure += 1; },
+      recordSuccess: () => { calls.success += 1; },
+      recordAccountMismatch: () => { calls.mismatch += 1; },
+      recordAccountOk: () => { calls.accountOk += 1; },
+    };
+    const r = await scheduler.runOnce({
+      runCapture: async () => ({ exitCode: 2, stdout: '', stderr: '' }),
+      alerter: fakeAlerter,
+    });
+    assert.strictEqual(r.ok, false);
+    assert.strictEqual(r.reason, 'capture_skipped');
+    assert.strictEqual(calls.failure, 0);
+  } finally {
+    if (prev === undefined) delete process.env.QUOTA_SNAPSHOT_ENABLED;
+    else process.env.QUOTA_SNAPSHOT_ENABLED = prev;
+  }
 });
 
 test('runOnce: capture exit 5 (timeout) registra fallo categorizado session_disconnected', async () => {
-  let lastFailure = null;
-  const fakeAlerter = {
-    recordFailure: (cat) => { lastFailure = cat; },
-    recordSuccess: () => {},
-    recordAccountMismatch: () => {},
-    recordAccountOk: () => {},
-  };
-  const r = await scheduler.runOnce({
-    runCapture: async () => ({ exitCode: 5, stdout: '', stderr: '' }),
-    alerter: fakeAlerter,
-  });
-  assert.strictEqual(r.ok, false);
-  assert.strictEqual(r.category, 'session_disconnected');
-  assert.strictEqual(lastFailure, 'session_disconnected');
+  const prev = process.env.QUOTA_SNAPSHOT_ENABLED;
+  process.env.QUOTA_SNAPSHOT_ENABLED = 'true';
+  try {
+    let lastFailure = null;
+    const fakeAlerter = {
+      recordFailure: (cat) => { lastFailure = cat; },
+      recordSuccess: () => {},
+      recordAccountMismatch: () => {},
+      recordAccountOk: () => {},
+    };
+    const r = await scheduler.runOnce({
+      runCapture: async () => ({ exitCode: 5, stdout: '', stderr: '' }),
+      alerter: fakeAlerter,
+    });
+    assert.strictEqual(r.ok, false);
+    assert.strictEqual(r.category, 'session_disconnected');
+    assert.strictEqual(lastFailure, 'session_disconnected');
+  } finally {
+    if (prev === undefined) delete process.env.QUOTA_SNAPSHOT_ENABLED;
+    else process.env.QUOTA_SNAPSHOT_ENABLED = prev;
+  }
 });
 
 test('runOnce: ciclo completo OK con fakes ejecuta append + recordSuccess + recordAccountOk', async () => {
+  const prev = process.env.QUOTA_SNAPSHOT_ENABLED;
+  process.env.QUOTA_SNAPSHOT_ENABLED = 'true';
   const tmp = path.join(os.tmpdir(), `sched-${process.pid}-${Date.now()}`);
   fs.mkdirSync(tmp, { recursive: true });
   const fakePng = path.join(tmp, 'quota-fake.png');
@@ -140,27 +164,33 @@ test('runOnce: ciclo completo OK con fakes ejecuta append + recordSuccess + reco
     parse_confidence: 91,
   };
 
-  const r = await scheduler.runOnce({
-    runCapture: async () => ({ exitCode: 0, stdout: fakePng + '\n', stderr: '' }),
-    parseSnapshot: async () => ({ ok: true, snapshot: fakeSnapshot }),
-    appendSnapshot: () => { calls.append += 1; },
-    rotateIfNeeded: () => { calls.rotate += 1; return { rotated: false }; },
-    cleanupOldPngs: () => { calls.cleanup += 1; return { deleted: 0 }; },
-    alerter: fakeAlerter,
-    allowedRoot: tmp,
-  });
+  try {
+    const r = await scheduler.runOnce({
+      runCapture: async () => ({ exitCode: 0, stdout: fakePng + '\n', stderr: '' }),
+      parseSnapshot: async () => ({ ok: true, snapshot: fakeSnapshot }),
+      appendSnapshot: () => { calls.append += 1; },
+      rotateIfNeeded: () => { calls.rotate += 1; return { rotated: false }; },
+      cleanupOldPngs: () => { calls.cleanup += 1; return { deleted: 0 }; },
+      alerter: fakeAlerter,
+      allowedRoot: tmp,
+    });
 
-  assert.strictEqual(r.ok, true);
-  assert.strictEqual(calls.append, 1);
-  assert.strictEqual(calls.success, 1);
-  assert.strictEqual(calls.accountOk, 1);
-  assert.strictEqual(calls.rotate, 1);
-  assert.strictEqual(calls.cleanup, 1);
-
-  fs.rmSync(tmp, { recursive: true, force: true });
+    assert.strictEqual(r.ok, true);
+    assert.strictEqual(calls.append, 1);
+    assert.strictEqual(calls.success, 1);
+    assert.strictEqual(calls.accountOk, 1);
+    assert.strictEqual(calls.rotate, 1);
+    assert.strictEqual(calls.cleanup, 1);
+  } finally {
+    if (prev === undefined) delete process.env.QUOTA_SNAPSHOT_ENABLED;
+    else process.env.QUOTA_SNAPSHOT_ENABLED = prev;
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
 });
 
 test('runOnce: account_mismatch llama recordAccountMismatch, no recordFailure', async () => {
+  const prev = process.env.QUOTA_SNAPSHOT_ENABLED;
+  process.env.QUOTA_SNAPSHOT_ENABLED = 'true';
   const tmp = path.join(os.tmpdir(), `sched-mismatch-${process.pid}-${Date.now()}`);
   fs.mkdirSync(tmp, { recursive: true });
   const fakePng = path.join(tmp, 'quota-mm.png');
@@ -174,21 +204,25 @@ test('runOnce: account_mismatch llama recordAccountMismatch, no recordFailure', 
     recordAccountOk: () => {},
   };
 
-  const r = await scheduler.runOnce({
-    runCapture: async () => ({ exitCode: 0, stdout: fakePng + '\n', stderr: '' }),
-    parseSnapshot: async () => ({ ok: false, category: 'account_mismatch', reason: 'account_mismatch' }),
-    appendSnapshot: () => {},
-    rotateIfNeeded: () => ({ rotated: false }),
-    cleanupOldPngs: () => ({ deleted: 0 }),
-    alerter: fakeAlerter,
-    allowedRoot: tmp,
-  });
+  try {
+    const r = await scheduler.runOnce({
+      runCapture: async () => ({ exitCode: 0, stdout: fakePng + '\n', stderr: '' }),
+      parseSnapshot: async () => ({ ok: false, category: 'account_mismatch', reason: 'account_mismatch' }),
+      appendSnapshot: () => {},
+      rotateIfNeeded: () => ({ rotated: false }),
+      cleanupOldPngs: () => ({ deleted: 0 }),
+      alerter: fakeAlerter,
+      allowedRoot: tmp,
+    });
 
-  assert.strictEqual(r.ok, false);
-  assert.strictEqual(calls.mismatch, 1);
-  assert.strictEqual(calls.failure, 0);
-
-  fs.rmSync(tmp, { recursive: true, force: true });
+    assert.strictEqual(r.ok, false);
+    assert.strictEqual(calls.mismatch, 1);
+    assert.strictEqual(calls.failure, 0);
+  } finally {
+    if (prev === undefined) delete process.env.QUOTA_SNAPSHOT_ENABLED;
+    else process.env.QUOTA_SNAPSHOT_ENABLED = prev;
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
 });
 
 test('categorizeCaptureExit: mapea exit codes a la whitelist o null', () => {

--- a/.pipeline/dashboard.js
+++ b/.pipeline/dashboard.js
@@ -713,6 +713,7 @@ let _stateSnapshot = null;          // última vista computada (o null en cold s
 let _stateSnapshotAt = 0;           // timestamp del último refresh exitoso
 let _stateRefreshInflight = false;  // evita solapar cómputos pesados
 let _stateRefreshTimer = null;      // handle del setInterval (para clearInterval)
+let _usageRefreshTimer = null;      // #4597 — handle del poller de `claude -p /usage`
 let _loopMonitor = null;            // #4131-followup — handle del monitor de lag del event loop
 let _freezeWatchdog = null;         // #4131-followup-2 — handle del watchdog externo de freeze
 let _logServeInflight = false;      // #4521 — servido de logs en vuelo (lectura de disco)
@@ -13717,6 +13718,24 @@ function startListen() {
     if (!_stateRefreshTimer) {
       _stateRefreshTimer = setInterval(refreshStateSnapshot, STATE_REFRESH_MS);
       if (_stateRefreshTimer.unref) _stateRefreshTimer.unref();
+    }
+    // #4597 — Poller del uso REAL de Anthropic (`claude -p /usage`). Es la
+    // fuente de verdad de la cuota Anthropic (reemplaza la heurística de
+    // duración + calibración + OCR). Refresca el cache en background con
+    // throttle; el adapter (quota-adapters/anthropic.js) SÓLO LEE ese cache y
+    // nunca spawnea en el hot path. Fire-and-forget, no bloquea el loop.
+    // `.unref()` evita que el timer mantenga vivo el proceso al cerrar.
+    if (!_usageRefreshTimer) {
+      try {
+        const anthropicUsage = require('./lib/anthropic-usage');
+        const usageMetricsDir = path.join(PIPELINE, 'metrics');
+        const kickUsage = () => {
+          try { anthropicUsage.triggerRefreshAsync({ metricsDir: usageMetricsDir }); } catch { /* noop */ }
+        };
+        setImmediate(kickUsage);
+        _usageRefreshTimer = setInterval(kickUsage, anthropicUsage.THROTTLE_MS);
+        if (_usageRefreshTimer.unref) _usageRefreshTimer.unref();
+      } catch { /* noop: no bloquear el boot del dashboard */ }
     }
     // #4460 — Asegurar que el trust anchor `runtime-boot.json` refleje el HEAD
     // real al bootear. Mitiga el "restart manual sin restart.js": si el marker

--- a/.pipeline/lib/__tests__/anthropic-usage.test.js
+++ b/.pipeline/lib/__tests__/anthropic-usage.test.js
@@ -1,0 +1,193 @@
+// =============================================================================
+// Tests lib/anthropic-usage.js — lectura del uso real de `claude -p /usage` (#4597)
+//
+// Cubre: parseo de la salida, cache read/write, throttle/freshness de getUsage,
+// refresh async fire-and-forget (spawn inyectado) y fallback seguro.
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { EventEmitter } = require('events');
+
+function fresh() {
+    delete require.cache[require.resolve('../anthropic-usage')];
+    return require('../anthropic-usage');
+}
+
+function tmpMetrics() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'usage-4597-'));
+    fs.mkdirSync(path.join(dir, 'metrics'), { recursive: true });
+    return path.join(dir, 'metrics');
+}
+
+// ---------------------------------------------------------------------------
+// parseUsageOutput
+// ---------------------------------------------------------------------------
+test('parseUsageOutput extrae sesión% y semana% (all models) + resets', () => {
+    const u = fresh();
+    const out = u.parseUsageOutput(
+        'Current session: 20% used · resets Jul 8, 10pm (America/Buenos_Aires)\n' +
+        'Current week (all models): 64% used · resets Jul 12, 9pm (America/Buenos_Aires)\n' +
+        'Current week (Fable): 0% used\n');
+    assert.equal(out.sessionPct, 20);
+    assert.equal(out.weeklyPct, 64);
+    assert.match(out.sessionResetsRaw, /Jul 8, 10pm/);
+    assert.match(out.weeklyResetsRaw, /Jul 12, 9pm/);
+});
+
+test('parseUsageOutput ignora el bucket por-modelo (Fable) y tolera ANSI', () => {
+    const u = fresh();
+    const out = u.parseUsageOutput(
+        '\x1B[1mCurrent week (all models):\x1B[0m 5% used\n' +
+        'Current week (Fable): 99% used\n');
+    assert.equal(out.weeklyPct, 5);
+    assert.equal(out.sessionPct, null);
+});
+
+test('parseUsageOutput devuelve null cuando no hay ningún porcentaje', () => {
+    const u = fresh();
+    assert.equal(u.parseUsageOutput('bla bla sin datos'), null);
+    assert.equal(u.parseUsageOutput(''), null);
+    assert.equal(u.parseUsageOutput(null), null);
+});
+
+// ---------------------------------------------------------------------------
+// cache read/write
+// ---------------------------------------------------------------------------
+test('writeCache + readCache round-trip', () => {
+    const u = fresh();
+    const dir = tmpMetrics();
+    const now = 1_700_000_000_000;
+    u.writeCache(dir, { sessionPct: 12, weeklyPct: 48, sessionResetsRaw: null, weeklyResetsRaw: null }, now);
+    const c = u.readCache(dir);
+    assert.equal(c.sessionPct, 12);
+    assert.equal(c.weeklyPct, 48);
+    assert.equal(c.capturedAtMs, now);
+    assert.equal(c.source, 'claude -p /usage');
+});
+
+test('readCache devuelve null ante archivo ausente o corrupto', () => {
+    const u = fresh();
+    const dir = tmpMetrics();
+    assert.equal(u.readCache(dir), null);
+    fs.writeFileSync(path.join(dir, 'anthropic-usage.json'), '}{not json');
+    assert.equal(u.readCache(dir), null);
+});
+
+// ---------------------------------------------------------------------------
+// getUsage — freshness / throttle / no-spawn por default
+// ---------------------------------------------------------------------------
+test('getUsage marca fresh cuando el cache es reciente', () => {
+    const u = fresh();
+    const dir = tmpMetrics();
+    const now = 2_000_000_000_000;
+    u.writeCache(dir, { sessionPct: 10, weeklyPct: 50 }, now);
+    const r = u.getUsage({ metricsDir: dir, now: now + 60_000, autoRefresh: false });
+    assert.equal(r.data.weeklyPct, 50);
+    assert.equal(r.fresh, true);
+    assert.equal(r.stale, false);
+});
+
+test('getUsage marca stale cuando el cache supera STALE_MS', () => {
+    const u = fresh();
+    const dir = tmpMetrics();
+    const now = 2_000_000_000_000;
+    u.writeCache(dir, { sessionPct: 10, weeklyPct: 50 }, now - (u.STALE_MS + 60_000));
+    const r = u.getUsage({ metricsDir: dir, now, autoRefresh: false });
+    assert.equal(r.stale, true);
+    assert.equal(r.fresh, false);
+    assert.equal(r.data.weeklyPct, 50);
+});
+
+test('getUsage sin cache devuelve data:null y NO spawnea por default', () => {
+    const u = fresh();
+    const dir = tmpMetrics();
+    let spawned = 0;
+    const r = u.getUsage({ metricsDir: dir, spawnImpl: () => { spawned++; } });
+    assert.equal(r.data, null);
+    assert.equal(r.stale, true);
+    assert.equal(spawned, 0, 'default read-only: no spawn');
+});
+
+test('getUsage sin metricsDir no lanza, devuelve reason', () => {
+    const u = fresh();
+    const r = u.getUsage({});
+    assert.equal(r.data, null);
+    assert.match(r.reason, /metricsDir/);
+});
+
+// ---------------------------------------------------------------------------
+// triggerRefreshAsync — spawn inyectado, escribe cache al cerrar
+// ---------------------------------------------------------------------------
+function fakeChild(stdout) {
+    const child = new EventEmitter();
+    child.stdout = new EventEmitter();
+    child.kill = () => {};
+    // Emitir stdout + close en el próximo tick.
+    setImmediate(() => {
+        if (stdout) child.stdout.emit('data', Buffer.from(stdout));
+        child.emit('close', 0);
+    });
+    return child;
+}
+
+test('triggerRefreshAsync spawnea /usage, parsea y escribe el cache', async () => {
+    const u = fresh();
+    const dir = tmpMetrics();
+    let capturedArgs = null;
+    const spawnImpl = (cmd, args) => {
+        capturedArgs = args;
+        return fakeChild('Current session: 30% used\nCurrent week (all models): 70% used\n');
+    };
+    u.triggerRefreshAsync({ metricsDir: dir, spawnImpl, launcher: { cmd: 'claude', prefixArgs: [], shell: false } });
+    // Esperar a que el 'close' async escriba el cache.
+    await new Promise((res) => setTimeout(res, 30));
+    assert.ok(capturedArgs.includes('/usage'), 'debe invocar /usage');
+    assert.ok(capturedArgs.includes('-p'), 'debe usar print mode');
+    const c = u.readCache(dir);
+    assert.equal(c.weeklyPct, 70);
+    assert.equal(c.sessionPct, 30);
+});
+
+test('triggerRefreshAsync no escribe cache si el spawn no produce dato parseable', async () => {
+    const u = fresh();
+    const dir = tmpMetrics();
+    u.triggerRefreshAsync({
+        metricsDir: dir,
+        spawnImpl: () => fakeChild('sin porcentajes aquí'),
+        launcher: { cmd: 'claude', prefixArgs: [], shell: false },
+    });
+    await new Promise((res) => setTimeout(res, 30));
+    assert.equal(u.readCache(dir), null, 'fallback: no escribe basura');
+});
+
+test('triggerRefreshAsync es fail-secure si spawn lanza', () => {
+    const u = fresh();
+    const dir = tmpMetrics();
+    assert.doesNotThrow(() => {
+        u.triggerRefreshAsync({
+            metricsDir: dir,
+            spawnImpl: () => { throw new Error('spawn roto'); },
+            launcher: { cmd: 'claude', prefixArgs: [], shell: false },
+        });
+    });
+    u._resetRefreshingForTesting();
+});
+
+test('getUsage con autoRefresh:true dispara el spawn cuando el cache está viejo', () => {
+    const u = fresh();
+    const dir = tmpMetrics();
+    let spawned = 0;
+    u.getUsage({
+        metricsDir: dir,
+        autoRefresh: true,
+        spawnImpl: () => { spawned++; return fakeChild(''); },
+        launcher: { cmd: 'claude', prefixArgs: [], shell: false },
+    });
+    assert.equal(spawned, 1);
+    u._resetRefreshingForTesting();
+});

--- a/.pipeline/lib/__tests__/dashboard-slices-kpis.test.js
+++ b/.pipeline/lib/__tests__/dashboard-slices-kpis.test.js
@@ -249,7 +249,23 @@ test('CA-1: prsLast7d arranca en null cuando gh no responde, NO 0', () => {
 
 test('CA-5: quotaSlice expone `providers` con anthropic + stubs not_implemented', () => {
     const { root, pipeline, metrics } = mkTmpPipeline();
-    // Activity log mínimo con un session:end de Anthropic en la ventana actual.
+    // #4597 — La fuente de verdad de la cuota Anthropic ya NO es la heurística de
+    // `duration_ms` del activity-log, sino el uso REAL de `claude -p /usage`,
+    // cacheado en `metrics/anthropic-usage.json`. Seedeamos un snapshot fresco
+    // (capturedAtMs = ahora) para que el adapter reporte adapterStatus 'ok'.
+    fs.writeFileSync(path.join(metrics, 'anthropic-usage.json'), JSON.stringify({
+        schema: 1,
+        source: 'claude -p /usage',
+        capturedAt: new Date().toISOString(),
+        capturedAtMs: Date.now(),
+        sessionPct: 34,
+        weeklyPct: 66,
+        sessionResetsRaw: null,
+        weeklyResetsRaw: null,
+        sessionResetsAt: null,
+        weeklyResetsAt: null,
+    }));
+    // Activity log mínimo (compat: alimenta métricas legacy no-cuota del banner).
     const log = path.join(root, '.claude', 'activity-log.jsonl');
     fs.writeFileSync(log, JSON.stringify({
         event: 'session:end',

--- a/.pipeline/lib/__tests__/quota-adapters/anthropic.test.js
+++ b/.pipeline/lib/__tests__/quota-adapters/anthropic.test.js
@@ -1,14 +1,14 @@
 // =============================================================================
-// Tests quota-adapters/anthropic.js — adapter Anthropic Plan Max (#3092)
+// Tests quota-adapters/anthropic.js — adapter Anthropic Plan Max (reescrito #4597)
 //
-// Cubre los CAs verificables del adapter (delega lógica a `computeQuota`,
-// los tests bordes finos de reset/calibración ya están en otros archivos):
+// El adapter ya NO usa la heurística de duración (`computeQuota`): su fuente es
+// el uso REAL de `claude -p "/usage"`, cacheado por lib/anthropic-usage.js en
+// `metrics/anthropic-usage.json`. Estos tests cubren el mapeo cache→shape:
 //
-//   * Shape envelope correcto cuando OK (provider/adapterStatus/...).
-//   * Errores controlados → fail-secure con `pct: null`, NO 0.
-//   * Reset boundary, salto de mes, snapshot integration están cubiertos
-//     en quota-snapshot-integration.test.js (que ya pasa) — acá nos
-//     concentramos en lo nuevo del adapter.
+//   * pct = semanal% real; session.pct = sesión% real; status derivado del %.
+//   * dato stale → adapterStatus 'unknown' pero conserva el número.
+//   * sin cache / error → fallback degradado 'unknown', pct null (NUNCA 0).
+//   * error de input (sin metricsDir) → fail-secure 'error'.
 // =============================================================================
 'use strict';
 
@@ -18,101 +18,113 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
-function makeTmpDir() { return fs.mkdtempSync(path.join(os.tmpdir(), 'quota-anthropic-')); }
-function writeJsonl(filePath, events) {
-    fs.writeFileSync(filePath, events.map((e) => JSON.stringify(e)).join('\n') + '\n');
+function makeTmpMetrics() {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'quota-anthropic-'));
+    const metricsDir = path.join(tmp, 'metrics');
+    fs.mkdirSync(metricsDir, { recursive: true });
+    return metricsDir;
+}
+
+function writeUsageCache(metricsDir, data) {
+    fs.writeFileSync(path.join(metricsDir, 'anthropic-usage.json'), JSON.stringify(data));
 }
 
 function freshAdapter() {
     delete require.cache[require.resolve('../../quota-adapters/anthropic')];
     delete require.cache[require.resolve('../../quota-adapters/_shape')];
-    delete require.cache[require.resolve('../../weekly-quota')];
+    delete require.cache[require.resolve('../../anthropic-usage')];
     return require('../../quota-adapters/anthropic');
 }
 
-test('anthropic adapter devuelve adapterStatus=ok y campos legacy completos cuando hay datos', () => {
-    const tmp = makeTmpDir();
-    const metricsDir = path.join(tmp, 'metrics');
-    fs.mkdirSync(metricsDir);
-    const log = path.join(tmp, 'activity-log.jsonl');
-    writeJsonl(log, [
-        { event: 'session:end', ts: new Date().toISOString(), duration_ms: 3600000, model: 'claude' },
-    ]);
+test('adapter mapea el número real de /usage: pct=semanal, session.pct=sesión, status derivado', () => {
+    const metricsDir = makeTmpMetrics();
+    const now = Date.now();
+    writeUsageCache(metricsDir, {
+        schema: 1, source: 'claude -p /usage',
+        capturedAt: new Date(now).toISOString(), capturedAtMs: now,
+        sessionPct: 20, weeklyPct: 64,
+        sessionResetsRaw: 'Jul 8, 10pm (America/Buenos_Aires)',
+        weeklyResetsRaw: 'Jul 12, 9pm (America/Buenos_Aires)',
+        sessionResetsAt: null, weeklyResetsAt: '2026-07-12T21:00:00.000Z',
+    });
 
     const adapter = freshAdapter();
-    const r = adapter({ metricsDir, activityLogPath: log });
+    const r = adapter({ metricsDir, now });
 
     assert.equal(r.provider, 'anthropic');
     assert.equal(r.adapterStatus, 'ok');
     assert.equal(r.errorReason, null);
     assert.equal(r.schemaVersion, 2);
+    assert.equal(r.pct, 64);
+    assert.equal(r.status, 'normal');      // 50 ≤ 64 < 75
+    assert.equal(r.session.pct, 20);
+    assert.equal(r.session.status, 'ok');  // < 50
+    assert.equal(r.realPct, null);         // ya no hay calibración
+    assert.equal(r.calibration, null);
+    assert.equal(r.nextResetAt, '2026-07-12T21:00:00.000Z');
     assert.deepEqual(r.breakdown, []);
-    // Campos legacy presentes
-    assert.equal(typeof r.pct, 'number');
-    assert.equal(typeof r.status, 'string');
-    assert.equal(typeof r.session, 'object');
 });
 
-test('anthropic adapter sin metricsDir devuelve error explícito (no lanza)', () => {
+test('adapter clasifica critical cuando el semanal ≥ 90%', () => {
+    const metricsDir = makeTmpMetrics();
+    const now = Date.now();
+    writeUsageCache(metricsDir, {
+        schema: 1, capturedAtMs: now, sessionPct: 95, weeklyPct: 92,
+    });
     const adapter = freshAdapter();
-    const r = adapter({ activityLogPath: '/tmp/x.jsonl' });
+    const r = adapter({ metricsDir, now });
+    assert.equal(r.adapterStatus, 'ok');
+    assert.equal(r.status, 'critical');
+    assert.equal(r.session.status, 'critical');
+});
+
+test('adapter con dato stale (> 30 min) degrada a unknown pero conserva el número', () => {
+    const metricsDir = makeTmpMetrics();
+    const now = Date.now();
+    writeUsageCache(metricsDir, {
+        schema: 1, capturedAtMs: now - 40 * 60 * 1000, // 40 min → stale
+        sessionPct: 10, weeklyPct: 55,
+    });
+    const adapter = freshAdapter();
+    const r = adapter({ metricsDir, now });
+    assert.equal(r.adapterStatus, 'unknown');   // degradado
+    assert.equal(r.pct, 55);                     // pero muestra el último número
+    assert.match(r.errorReason, /stale/);
+    assert.equal(r.usageSource.stale, true);
+});
+
+test('adapter sin cache de /usage → fallback degradado unknown, pct null (nunca 0)', () => {
+    const metricsDir = makeTmpMetrics();
+    const adapter = freshAdapter();
+    const r = adapter({ metricsDir });
+    assert.equal(r.adapterStatus, 'unknown');
+    assert.equal(r.pct, null);
+    assert.match(r.errorReason, /fallback degradado/);
+});
+
+test('adapter sin metricsDir devuelve error explícito (no lanza)', () => {
+    const adapter = freshAdapter();
+    const r = adapter({});
     assert.equal(r.adapterStatus, 'error');
     assert.match(r.errorReason, /metricsDir/);
     assert.equal(r.pct, null);
 });
 
-test('anthropic adapter sin activityLogPath devuelve error explícito (no lanza)', () => {
-    const tmp = makeTmpDir();
-    const metricsDir = path.join(tmp, 'metrics');
-    fs.mkdirSync(metricsDir);
+test('adapter es resiliente a cache corrupto (no lanza, degrada a unknown)', () => {
+    const metricsDir = makeTmpMetrics();
+    fs.writeFileSync(path.join(metricsDir, 'anthropic-usage.json'), 'not json {{{');
     const adapter = freshAdapter();
     const r = adapter({ metricsDir });
-    assert.equal(r.adapterStatus, 'error');
-    assert.match(r.errorReason, /activityLogPath/);
+    assert.equal(r.adapterStatus, 'unknown');
+    assert.equal(r.pct, null);
 });
 
-test('anthropic adapter excluye eventos model:deterministic igual que computeQuota legacy', () => {
-    const tmp = makeTmpDir();
-    const metricsDir = path.join(tmp, 'metrics');
-    fs.mkdirSync(metricsDir);
-    const log = path.join(tmp, 'activity-log.jsonl');
-    const now = Date.now();
-    writeJsonl(log, [
-        { event: 'session:end', ts: new Date(now - 3600000).toISOString(), duration_ms: 3600000, model: 'claude' },
-        { event: 'session:end', ts: new Date(now - 7200000).toISOString(), duration_ms: 9000000, model: 'deterministic' },
-    ]);
-
+test('adapter NO spawnea al leer (getUsage read-only): sin cache y sin refresh explícito', () => {
+    const metricsDir = makeTmpMetrics();
+    let spawnCalls = 0;
     const adapter = freshAdapter();
-    const r = adapter({ metricsDir, activityLogPath: log });
-    assert.equal(r.adapterStatus, 'ok');
-    // 1h Claude + 0h determinístico (excluido) = 1h total — no 3.5h.
-    assert.ok(r.hoursUsed7d <= 1.1, `hoursUsed7d (${r.hoursUsed7d}) debe contar solo Claude`);
-});
-
-test('anthropic adapter respeta configLimitHours opcional', () => {
-    const tmp = makeTmpDir();
-    const metricsDir = path.join(tmp, 'metrics');
-    fs.mkdirSync(metricsDir);
-    const log = path.join(tmp, 'activity-log.jsonl');
-    fs.writeFileSync(log, '');
-
-    const adapter = freshAdapter();
-    const r = adapter({ metricsDir, activityLogPath: log, configLimitHours: 80 });
-    assert.equal(r.adapterStatus, 'ok');
-    assert.equal(r.configLimitHours, 80);
-    assert.ok(r.effectiveLimitHours >= 80);
-});
-
-test('anthropic adapter es resiliente a JSONL corrupto (no lanza, devuelve ok con counts=0)', () => {
-    const tmp = makeTmpDir();
-    const metricsDir = path.join(tmp, 'metrics');
-    fs.mkdirSync(metricsDir);
-    const log = path.join(tmp, 'activity-log.jsonl');
-    fs.writeFileSync(log, 'this is not json\n{"missing": true}\n');
-
-    const adapter = freshAdapter();
-    const r = adapter({ metricsDir, activityLogPath: log });
-    assert.equal(r.adapterStatus, 'ok');
-    assert.equal(r.hoursUsed7d, 0);
-    assert.equal(r.sessionsCount7d, 0);
+    // spawnImpl no debería invocarse nunca porque el adapter no pide autoRefresh.
+    const r = adapter({ metricsDir, spawnImpl: () => { spawnCalls++; throw new Error('no debe spawnear'); } });
+    assert.equal(spawnCalls, 0);
+    assert.equal(r.adapterStatus, 'unknown');
 });

--- a/.pipeline/lib/__tests__/weekly-quota.test.js
+++ b/.pipeline/lib/__tests__/weekly-quota.test.js
@@ -47,13 +47,14 @@ test('quotaUsage re-exportado dispatcha al adapter Anthropic correctamente', () 
     const tmp = makeTmpDir();
     const metricsDir = path.join(tmp, 'metrics');
     fs.mkdirSync(metricsDir);
-    const log = path.join(tmp, 'activity-log.jsonl');
-    writeJsonl(log, [
-        { event: 'session:end', ts: new Date().toISOString(), duration_ms: 3600000, model: 'claude' },
-    ]);
+    const now = Date.now();
+    // Cache de /usage fresco (fuente de verdad #4597).
+    fs.writeFileSync(path.join(metricsDir, 'anthropic-usage.json'), JSON.stringify({
+        schema: 1, capturedAtMs: now, sessionPct: 10, weeklyPct: 42,
+    }));
 
     const wq = freshWeekly();
-    const result = wq.quotaUsage('anthropic', { metricsDir, activityLogPath: log });
+    const result = wq.quotaUsage('anthropic', { metricsDir, autoRefresh: false, now });
 
     assert.equal(result.provider, 'anthropic');
     assert.equal(result.adapterStatus, 'ok');
@@ -105,67 +106,44 @@ test('state nuevo (sin archivo) se inicializa con schema_version: 2 explícito',
     assert.deepEqual(fresh.calibrations, []);
 });
 
-test('regresión cero del banner: quotaUsage(anthropic) wrappea computeQuota sin alterar campos legacy', () => {
+test('#4597: quotaUsage(anthropic) mapea el número REAL de /usage (pct=semanal, session.pct=sesión)', () => {
     const tmp = makeTmpDir();
     const metricsDir = path.join(tmp, 'metrics');
     fs.mkdirSync(metricsDir);
-    const log = path.join(tmp, 'activity-log.jsonl');
     const now = Date.now();
-    writeJsonl(log, [
-        { event: 'session:end', ts: new Date(now - 3600000).toISOString(), duration_ms: 7200000, model: 'claude' },
-        { event: 'session:end', ts: new Date(now - 7200000).toISOString(), duration_ms: 5400000, model: 'claude' },
-        // Determinístico debe excluirse igual que en legacy.
-        { event: 'session:end', ts: new Date(now - 10800000).toISOString(), duration_ms: 9000000, model: 'deterministic' },
-    ]);
+    // Cache de /usage escrito por lib/anthropic-usage.js — fresco (age 0).
+    fs.writeFileSync(path.join(metricsDir, 'anthropic-usage.json'), JSON.stringify({
+        schema: 1,
+        source: 'claude -p /usage',
+        capturedAt: new Date(now).toISOString(),
+        capturedAtMs: now,
+        sessionPct: 20,
+        weeklyPct: 64,
+        sessionResetsRaw: 'Jul 8, 10pm (America/Buenos_Aires)',
+        weeklyResetsRaw: 'Jul 12, 9pm (America/Buenos_Aires)',
+        sessionResetsAt: null,
+        weeklyResetsAt: null,
+    }));
 
     const wq = freshWeekly();
-    const legacy = wq.computeQuota(metricsDir, log);
-    const wrapped = wq.quotaUsage('anthropic', { metricsDir, activityLogPath: log });
+    const r = wq.quotaUsage('anthropic', { metricsDir, autoRefresh: false, now });
 
-    // Campos del banner que NO pueden romper (UX G5 + security CA-#7).
-    // `observedMaxAt` se actualiza con `new Date().toISOString()` cada llamada
-    // que detecta nuevo máximo; entre dos invocaciones consecutivas puede
-    // diferir en ms aunque la lógica sea idéntica → lo verificamos por tipo.
-    const bannerFieldsExact = [
-        'hoursUsed7d', 'sessionsCount7d', 'hoursLast24h',
-        'effectiveLimitHours', 'configLimitHours',
-        'pct', 'realPct', 'realPctRaw', 'realPctCapped', 'realStatus',
-        'hoursRemaining', 'burnRatePerDay', 'daysToLimit', 'status',
-        'adjustmentsCount', 'observedMaxHours', 'autoAdjusted',
-        'lastResetAt', // depende del día/hora, no del ms — estable.
-        'calibrationAgeDays', 'calibrationStale',
-        'sessionResetsAt', 'weeklyResetsAtReported',
-        'weeklyResetDriftMin',
-    ];
-    for (const f of bannerFieldsExact) {
-        assert.deepEqual(wrapped[f], legacy[f], `campo "${f}" debe coincidir byte-a-byte`);
-    }
-    // Campos timestamp-dependent: misma forma + tolerancia razonable (< 1s).
-    if (legacy.observedMaxAt) {
-        assert.ok(wrapped.observedMaxAt, 'observedMaxAt debe estar presente igual que en legacy');
-        const dt = Math.abs(new Date(wrapped.observedMaxAt).getTime() - new Date(legacy.observedMaxAt).getTime());
-        assert.ok(dt < 1000, `observedMaxAt debe estar dentro de 1s del legacy (delta=${dt}ms)`);
-    } else {
-        assert.equal(wrapped.observedMaxAt, null);
-    }
-    // nextResetAt/daysToReset se computan con Date.now() puro pero el "día"
-    // del próximo domingo 21:00 no cambia entre llamadas consecutivas.
-    assert.equal(wrapped.nextResetAt, legacy.nextResetAt, 'nextResetAt debe ser estable');
-    // daysToReset: tolerancia 0.001 días (~1.4 min) — puede diferir por el ms entre llamadas.
-    assert.ok(Math.abs(wrapped.daysToReset - legacy.daysToReset) < 0.001,
-        `daysToReset debe coincidir con tolerancia (legacy=${legacy.daysToReset}, wrapped=${wrapped.daysToReset})`);
-    // session.* también debe coincidir
-    assert.deepEqual(wrapped.session, legacy.session);
-    // calibration y calibrations también
-    assert.deepEqual(wrapped.calibration, legacy.calibration);
-    assert.deepEqual(wrapped.calibrations, legacy.calibrations);
-
-    // Y los nuevos campos del envelope multi-provider
-    assert.equal(wrapped.provider, 'anthropic');
-    assert.equal(wrapped.adapterStatus, 'ok');
-    assert.equal(wrapped.errorReason, null);
-    assert.equal(wrapped.schemaVersion, 2);
-    assert.deepEqual(wrapped.breakdown, []);
+    assert.equal(r.provider, 'anthropic');
+    assert.equal(r.adapterStatus, 'ok');
+    assert.equal(r.errorReason, null);
+    assert.equal(r.schemaVersion, 2);
+    // El % semanal ES el real de /usage (64%) — NADA de heurística de duración.
+    assert.equal(r.pct, 64);
+    assert.equal(r.status, 'normal'); // 50 ≤ 64 < 75
+    assert.equal(r.session.pct, 20);
+    assert.equal(r.session.status, 'ok'); // < 50
+    // Ya no hay calibración: realPct null, pct ES el real.
+    assert.equal(r.realPct, null);
+    assert.equal(r.calibration, null);
+    // Sin heurística de duración → campos de horas nulos.
+    assert.equal(r.hoursUsed7d, null);
+    assert.equal(r.effectiveLimitHours, null);
+    assert.deepEqual(r.breakdown, []);
 });
 
 test('quotaUsage(anthropic) sin metricsDir devuelve adapterStatus error con errorReason accionable', () => {
@@ -177,18 +155,17 @@ test('quotaUsage(anthropic) sin metricsDir devuelve adapterStatus error con erro
     assert.match(result.errorReason, /metricsDir/);
 });
 
-test('quotaUsage(anthropic) con activity-log corrupto NO lanza, devuelve estado consistente', () => {
+test('#4597: quotaUsage(anthropic) SIN cache de /usage degrada a unknown (fallback seguro, no lanza, pct null)', () => {
     const tmp = makeTmpDir();
     const metricsDir = path.join(tmp, 'metrics');
     fs.mkdirSync(metricsDir);
-    const log = path.join(tmp, 'activity-log.jsonl');
-    fs.writeFileSync(log, 'this is not json\n{"broken": "yes"}\n{"event": "session:end"}\n');
 
     const wq = freshWeekly();
-    const result = wq.quotaUsage('anthropic', { metricsDir, activityLogPath: log });
-    // computeQuota tolera líneas corruptas (las saltea) → adapter ok.
-    assert.equal(result.adapterStatus, 'ok');
-    assert.equal(result.hoursUsed7d, 0);
+    // Sin cache de /usage y sin spawnear (autoRefresh false): fallback degradado.
+    const result = wq.quotaUsage('anthropic', { metricsDir, autoRefresh: false });
+    assert.equal(result.adapterStatus, 'unknown');
+    assert.equal(result.pct, null); // nunca 0 silencioso
+    assert.match(result.errorReason, /fallback degradado/);
 });
 
 test('computeQuota legacy sigue funcionando sin cambios (no breaking)', () => {

--- a/.pipeline/lib/anthropic-usage.js
+++ b/.pipeline/lib/anthropic-usage.js
@@ -1,0 +1,302 @@
+// =============================================================================
+// anthropic-usage.js — Lectura del uso REAL del Plan Max de Anthropic (#4597).
+//
+// PROBLEMA QUE RESUELVE
+//   La cuota Anthropic se estimaba sumando `duration_ms` de sesiones
+//   (`weekly-quota.js#computeQuota`) + una calibración manual con factor EMA +
+//   un snapshot OCR del panel "Uso" de Claude Desktop. Todo frágil: el número
+//   oscilaba 51–98% cuando el real era ~62%.
+//
+// APPROACH (confirmado en vivo, CLI 2.1.204 — ver #4597)
+//   `claude -p "/usage"` corre el slash-command CLIENT-SIDE (no consume turno de
+//   modelo, lo computa del historial local) y devuelve:
+//
+//     Current session: 20% used · resets Jul 8, 10pm (America/Buenos_Aires)
+//     Current week (all models): 64% used · resets Jul 12, 9pm (America/Buenos_Aires)
+//     Current week (Fable): 0% used
+//
+//   El semanal (all models) coincide con la app de Claude. Es fuente suficiente-
+//   mente fiel — no una aproximación descartable.
+//
+// DISEÑO — el pipeline no puede morir (regla inquebrantable pipeline-dev #1)
+//   * NUNCA se spawnea en el hot-path de forma bloqueante. `getUsage()` es
+//     síncrono, sólo LEE el cache. Cuando el cache está viejo dispara un refresh
+//     ASÍNCRONO fire-and-forget (spawn con timeout + kill), que escribe el cache
+//     al terminar. El caller siempre recibe el último valor conocido al instante.
+//   * Throttle: no se re-spawnea más seguido que THROTTLE_MS (default 3 min),
+//     aunque `getUsage` se llame en cada poll del dashboard/health.
+//   * Fallback seguro: si el CLI no responde / el parse falla, el cache no se
+//     actualiza; `getUsage` devuelve el último dato marcado como `stale` (o
+//     `data:null` si nunca hubo). El adapter degrada a `adapterStatus:'unknown'`
+//     — NUNCA congela el pipeline ni presenta un número viejo como fresco.
+//   * Sin shell cuando el launcher lo permite (evita el MSYS path-mangling de
+//     Git Bash que convertía `/usage` → `C:/Program Files/Git/usage`). Reusa el
+//     `detectLauncher()` multi-tier de agent-launcher/providers/anthropic.
+// =============================================================================
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+// No re-spawnear más seguido que esto, aunque getUsage se llame en cada poll.
+const THROTTLE_MS = 3 * 60 * 1000;
+// ≤ FRESH_MS → dato confiable/fresh.
+const FRESH_MS = 5 * 60 * 1000;
+// > STALE_MS → dato demasiado viejo; el adapter degrada a 'unknown'.
+const STALE_MS = 30 * 60 * 1000;
+// Corte duro del spawn: /usage es client-side y rápido; si cuelga, lo matamos.
+const SPAWN_TIMEOUT_MS = 30 * 1000;
+// Cota de stdout para no volar memoria si el CLI escupe basura.
+const MAX_STDOUT_BYTES = 1 * 1024 * 1024;
+
+const CACHE_FILE = 'anthropic-usage.json';
+const CACHE_SCHEMA = 1;
+
+// Guard en-memoria: evita spawns concurrentes DENTRO del mismo proceso. Entre
+// procesos distintos, el throttle por edad del cache serializa de facto.
+let _refreshing = false;
+
+function cachePath(metricsDir) {
+    return path.join(metricsDir, CACHE_FILE);
+}
+
+// -----------------------------------------------------------------------------
+// parseUsageOutput — parsea la salida textual de `claude -p /usage`.
+//
+// Tolerante: line-by-line, insensible a mayúsculas, ignora códigos ANSI. Sólo
+// mira "Current session" y "Current week (all models)" — el bucket por-modelo
+// (Fable) se ignora a propósito (el operador razona sobre el agregado).
+//
+// @param {string} text
+// @returns {{sessionPct:number|null, weeklyPct:number|null,
+//            sessionResetsRaw:string|null, weeklyResetsRaw:string|null}|null}
+//          null si no se pudo extraer NINGÚN porcentaje.
+// -----------------------------------------------------------------------------
+function parseUsageOutput(text) {
+    if (typeof text !== 'string' || text.length === 0) return null;
+    // Quitar secuencias de escape ANSI (colores/cursor) que ensucian el parse.
+    const clean = text.replace(/\x1B\[[0-9;?]*[A-Za-z]/g, '');
+    const out = {
+        sessionPct: null,
+        weeklyPct: null,
+        sessionResetsRaw: null,
+        weeklyResetsRaw: null,
+    };
+    for (const rawLine of clean.split(/\r?\n/)) {
+        const line = rawLine.trim();
+        let m;
+        if ((m = line.match(/Current session:\s*(\d+(?:\.\d+)?)\s*%\s*used/i))) {
+            out.sessionPct = Number(m[1]);
+            const r = line.match(/resets?\s+(.+)$/i);
+            if (r) out.sessionResetsRaw = r[1].trim();
+        } else if ((m = line.match(/Current week\s*\(all models\):\s*(\d+(?:\.\d+)?)\s*%\s*used/i))) {
+            out.weeklyPct = Number(m[1]);
+            const r = line.match(/resets?\s+(.+)$/i);
+            if (r) out.weeklyResetsRaw = r[1].trim();
+        }
+    }
+    if (out.sessionPct === null && out.weeklyPct === null) return null;
+    return out;
+}
+
+// -----------------------------------------------------------------------------
+// parseResetToIso — best-effort de "Jul 12, 9pm (America/Buenos_Aires)" → ISO.
+//
+// El texto de /usage no trae año y la TZ va entre paréntesis; el parse es
+// imperfecto por diseño. Devolvemos ISO cuando Date lo entiende, sino null (el
+// raw se conserva aparte). NO es dato crítico — los resets son informativos.
+// -----------------------------------------------------------------------------
+function parseResetToIso(raw, refMs) {
+    if (typeof raw !== 'string' || raw.length === 0) return null;
+    // Descartar el paréntesis de TZ (no interpretable por Date sin libs).
+    const noTz = raw.replace(/\s*\([^)]*\)\s*$/, '').trim();
+    if (!noTz) return null;
+    const ref = Number.isFinite(refMs) ? new Date(refMs) : new Date();
+    const year = ref.getUTCFullYear();
+    // Date.parse necesita un espacio antes de am/pm: "8:59pm" → "8:59 pm".
+    const spaced = noTz.replace(/(\d)\s*(am|pm)\b/i, '$1 $2');
+    // "Jul 12, 8:59 pm" → "Jul 12, 2026 8:59 pm"
+    const withYear = spaced.replace(/,/, `, ${year}`);
+    let ts = Date.parse(withYear);
+    if (!Number.isFinite(ts)) ts = Date.parse(spaced);
+    if (!Number.isFinite(ts)) return null;
+    return new Date(ts).toISOString();
+}
+
+// -----------------------------------------------------------------------------
+// Cache read/write — .pipeline/metrics/anthropic-usage.json
+// -----------------------------------------------------------------------------
+function readCache(metricsDir) {
+    try {
+        const raw = fs.readFileSync(cachePath(metricsDir), 'utf8');
+        const parsed = JSON.parse(raw);
+        if (parsed && typeof parsed === 'object' && Number.isFinite(parsed.capturedAtMs)) {
+            return parsed;
+        }
+        return null;
+    } catch {
+        return null;
+    }
+}
+
+function writeCache(metricsDir, parsed, nowMs) {
+    const now = Number.isFinite(nowMs) ? nowMs : Date.now();
+    const data = {
+        schema: CACHE_SCHEMA,
+        source: 'claude -p /usage',
+        capturedAt: new Date(now).toISOString(),
+        capturedAtMs: now,
+        sessionPct: Number.isFinite(parsed.sessionPct) ? parsed.sessionPct : null,
+        weeklyPct: Number.isFinite(parsed.weeklyPct) ? parsed.weeklyPct : null,
+        sessionResetsRaw: parsed.sessionResetsRaw || null,
+        weeklyResetsRaw: parsed.weeklyResetsRaw || null,
+        sessionResetsAt: parseResetToIso(parsed.sessionResetsRaw, now),
+        weeklyResetsAt: parseResetToIso(parsed.weeklyResetsRaw, now),
+    };
+    try {
+        fs.mkdirSync(metricsDir, { recursive: true });
+        fs.writeFileSync(cachePath(metricsDir), JSON.stringify(data, null, 2));
+    } catch { /* best-effort: si no se puede escribir, el próximo tick reintenta */ }
+    return data;
+}
+
+// -----------------------------------------------------------------------------
+// resolveLauncher — reusa la detección multi-tier del provider anthropic para
+// spawnear el mismo binario de Claude Code que usa el resto del pipeline.
+// -----------------------------------------------------------------------------
+function resolveLauncher() {
+    try {
+        const prov = require('./agent-launcher/providers/anthropic');
+        if (prov && typeof prov.detectLauncher === 'function') {
+            const l = prov.detectLauncher();
+            if (l && l.cmd) return l;
+        }
+    } catch { /* cae al fallback de abajo */ }
+    return { cmd: process.env.CLAUDE_BIN || 'claude', prefixArgs: [], shell: true };
+}
+
+// -----------------------------------------------------------------------------
+// triggerRefreshAsync — spawn fire-and-forget de `claude -p /usage`.
+//
+// NUNCA bloquea ni lanza. Guarda contra spawns concurrentes con `_refreshing`.
+// Al cerrar el proceso, parsea stdout y (si hubo dato) reescribe el cache.
+//
+// @param {object} opts { metricsDir, spawnImpl?, launcher?, env? }
+// -----------------------------------------------------------------------------
+function triggerRefreshAsync(opts) {
+    if (_refreshing) return;
+    const metricsDir = opts && opts.metricsDir;
+    if (typeof metricsDir !== 'string' || metricsDir.length === 0) return;
+
+    const spawnImpl = (opts && opts.spawnImpl)
+        || require('child_process').spawn;
+    const launcher = (opts && opts.launcher) || resolveLauncher();
+
+    _refreshing = true;
+    let done = false;
+    const finish = () => { if (!done) { done = true; _refreshing = false; } };
+
+    let child;
+    try {
+        child = spawnImpl(launcher.cmd, [...launcher.prefixArgs, '-p', '/usage'], {
+            shell: !!launcher.shell,
+            windowsHide: true,
+            stdio: ['ignore', 'pipe', 'pipe'],
+            env: (opts && opts.env) || process.env,
+        });
+    } catch {
+        finish();
+        return;
+    }
+    if (!child || typeof child.on !== 'function') { finish(); return; }
+
+    let stdout = '';
+    const timer = setTimeout(() => {
+        try { child.kill(); } catch { /* noop */ }
+        finish();
+    }, SPAWN_TIMEOUT_MS);
+    if (timer && typeof timer.unref === 'function') timer.unref();
+
+    if (child.stdout && typeof child.stdout.on === 'function') {
+        child.stdout.on('data', (d) => {
+            stdout += d.toString();
+            if (stdout.length > MAX_STDOUT_BYTES) {
+                try { child.kill(); } catch { /* noop */ }
+            }
+        });
+    }
+    child.on('error', () => { clearTimeout(timer); finish(); });
+    child.on('close', () => {
+        clearTimeout(timer);
+        const parsed = parseUsageOutput(stdout);
+        if (parsed) writeCache(metricsDir, parsed);
+        finish();
+    });
+}
+
+// -----------------------------------------------------------------------------
+// getUsage — API pública SÍNCRONA que consume el adapter. Sólo LEE el cache;
+// dispara refresh async si está viejo (throttle). Nunca bloquea ni lanza.
+//
+// @param {object} opts
+//   @property {string}  metricsDir       path a .pipeline/metrics (requerido)
+//   @property {number}  [now]            reloj override (tests)
+//   @property {boolean} [autoRefresh]    default FALSE — getUsage sólo LEE. El
+//                                        refresh lo dispara el poller del
+//                                        dashboard (triggerRefreshAsync). Pasar
+//                                        true sólo si un caller quiere refrescar.
+//   @property {function}[spawnImpl]      inyección de child_process.spawn (tests)
+//   @property {object}  [launcher]       launcher override (tests)
+// @returns {{data:object|null, ageMs:number|null, fresh:boolean, stale:boolean,
+//            reason?:string}}
+// -----------------------------------------------------------------------------
+function getUsage(opts) {
+    opts = opts || {};
+    const metricsDir = opts.metricsDir;
+    const now = Number.isFinite(opts.now) ? opts.now : Date.now();
+
+    if (typeof metricsDir !== 'string' || metricsDir.length === 0) {
+        return { data: null, ageMs: null, fresh: false, stale: true, reason: 'metricsDir requerido' };
+    }
+
+    const cache = readCache(metricsDir);
+    const ageMs = cache ? (now - cache.capturedAtMs) : null;
+    const needsRefresh = !cache || ageMs >= THROTTLE_MS || ageMs < 0;
+
+    // getUsage sólo LEE por default (nunca spawnea en el hot path del dashboard/
+    // health/tests). El refresh lo dispara el poller del dashboard llamando
+    // triggerRefreshAsync. `autoRefresh: true` es opt-in explícito.
+    if (needsRefresh && opts.autoRefresh === true) {
+        try { triggerRefreshAsync(opts); } catch { /* best-effort */ }
+    }
+
+    if (!cache) {
+        return { data: null, ageMs: null, fresh: false, stale: true, reason: 'sin snapshot de /usage todavía' };
+    }
+    return {
+        data: cache,
+        ageMs,
+        fresh: ageMs >= 0 && ageMs <= FRESH_MS,
+        stale: ageMs > STALE_MS || ageMs < 0,
+    };
+}
+
+// Para tests: resetea el guard en-memoria entre casos.
+function _resetRefreshingForTesting() { _refreshing = false; }
+
+module.exports = {
+    getUsage,
+    parseUsageOutput,
+    parseResetToIso,
+    readCache,
+    writeCache,
+    triggerRefreshAsync,
+    resolveLauncher,
+    _resetRefreshingForTesting,
+    // Constantes expuestas para tests/consumidores.
+    THROTTLE_MS,
+    FRESH_MS,
+    STALE_MS,
+    SPAWN_TIMEOUT_MS,
+    CACHE_FILE,
+};

--- a/.pipeline/lib/dashboard-slices.js
+++ b/.pipeline/lib/dashboard-slices.js
@@ -2281,33 +2281,17 @@ function historialTimelineSlice(state, ctx, opts) {
 // Exposición mínima (security req#5): por proveedor/bucket SOLO viaja
 // `{pct, confidence}` — NO `cost_usd`, tokens crudos ni ruta del snapshot.
 
-// #4202 — Mapea el estado del banner real-snapshot (getBannerState) a un valor
-// de `confidence` estable que consume el cliente. Defensivo: si el módulo no
-// está disponible o falla, devuelve 'missing' (tratado como "sin dato").
-function _anthropicConfidence() {
-    if (!quotaSnapshotIntegration || typeof quotaSnapshotIntegration.getBannerState !== 'function') {
-        return 'missing';
-    }
-    try {
-        const banner = quotaSnapshotIntegration.getBannerState();
-        const st = banner && banner.state;
-        if (st === 'fresh' || st === 'stale' || st === 'parser-offline' || st === 'missing') {
-            return st;
-        }
-        return 'missing';
-    } catch {
-        return 'missing';
-    }
-}
-
 // #4202 — Normaliza un QuotaResult de adapter al shape mínimo de cliente.
 // Solo expone `{pct, confidence}` por bucket (security req#5). El mapeo de
 // buckets sesión/semanal por proveedor sigue la decisión validada por PO:
-//   - anthropic: session ← session.realPct ?? session.pct; weekly ← realPct ?? pct.
+//   - anthropic: session ← session.pct; weekly ← pct (números REALES de /usage).
 //   - openai-codex: session = "sin dato" (null); weekly ← realPct ?? pct (budget mensual).
 //   - gemini-google + resto: ambos "sin dato" salvo que el adapter dé un pct real.
-// `confidence`: anthropic deriva del snapshot OCR; el resto es 'fresh' cuando
-// hay dato confiable y 'missing' ("sin dato") cuando no.
+// `confidence` (#4597): ya NO deriva del snapshot OCR (deprecado). Para TODOS los
+// providers es 'fresh' cuando el adapter respondió `ok` con un pct válido, y
+// 'missing' ("sin dato") cuando no. El adapter Anthropic degrada a
+// `adapterStatus:'unknown'` cuando el dato de /usage está stale → confidence
+// 'missing' → pacing/presión lo ignoran (no actúan sobre un número viejo).
 function normalizeProviderQuota(provider, result) {
     const out = {
         provider,
@@ -2320,12 +2304,12 @@ function normalizeProviderQuota(provider, result) {
     const num = (v) => (typeof v === 'number' && Number.isFinite(v) ? v : null);
 
     if (provider === 'anthropic') {
-        const conf = _anthropicConfidence();
+        const isOk = result.adapterStatus === 'ok';
         const sess = result.session && typeof result.session === 'object' ? result.session : {};
         const sessPct = num(sess.realPct != null ? sess.realPct : sess.pct);
         const weekPct = num(result.realPct != null ? result.realPct : result.pct);
-        out.session = { pct: sessPct, confidence: sessPct != null ? conf : 'missing' };
-        out.weekly = { pct: weekPct, confidence: weekPct != null ? conf : 'missing' };
+        out.session = { pct: sessPct, confidence: (isOk && sessPct != null) ? 'fresh' : 'missing' };
+        out.weekly = { pct: weekPct, confidence: (isOk && weekPct != null) ? 'fresh' : 'missing' };
         return out;
     }
 

--- a/.pipeline/lib/quota-adapters/anthropic.js
+++ b/.pipeline/lib/quota-adapters/anthropic.js
@@ -1,93 +1,177 @@
 // =============================================================================
-// quota-adapters/anthropic.js — Adapter Anthropic Plan Max (#3092 + #3065 §5.4).
+// quota-adapters/anthropic.js — Adapter Anthropic Plan Max (#3092, reescrito #4597).
 //
-// Estrategia:
+// FUENTE DE VERDAD: el uso REAL que expone `claude -p "/usage"` (client-side,
+// coincide con la app de Claude). Reemplaza por completo la cadena vieja:
 //
-//   * Anthropic NO expone API pública del uso del Plan Max, así que el
-//     pipeline aproxima sumando `duration_ms` de eventos `session:end` del
-//     activity-log. Esa heurística vive en `weekly-quota.js#computeQuota`,
-//     se mantiene intacta y el adapter la **delega** sin reimplementar.
+//   * ❌ heurística de `duration_ms` de sesiones (`weekly-quota.js#computeQuota`)
+//        — daba 2.6–4.9% cuando el real era ~62%.
+//   * ❌ calibración manual (factor EMA `saveCalibration`) — drifteaba, quedó
+//        en 20× absurdo.
+//   * ❌ snapshot OCR del panel "Uso" de Claude Desktop.
 //
-//   * Adicionalmente, el operador puede calibrar contra dato real de
-//     claude.ai (snapshots #3055/#3057 + EMA #3008) — esos campos vienen
-//     ya incluidos en `computeQuota`, así que pasan transparentes al shape.
+// El número lo obtiene y cachea `lib/anthropic-usage.js` (spawn throttled +
+// fallback stale, sin bloquear el pipeline). Este adapter sólo MAPEA ese cache
+// al shape canónico QuotaResult.
 //
-//   * Reset semantics — domingo 21:00 hora local (ART por default), con
-//     drift de TZ persistido si el operador reporta otra hora en calibración.
+// MAPEO (decisión #4597):
+//   * `pct`          = semanal% (all models) — YA es el real, no hay `realPct`.
+//   * `session.pct`  = sesión 5h%.
+//   * `status`/`session.status` derivan del % con los cortes estándar
+//     (ok<50, normal<75, warning<90, critical≥90).
+//   * `nextResetAt`/`sessionResetsAt` = resets parseados de /usage (best-effort).
 //
-// Backward-compat byte-a-byte (regresión cero del banner):
-//
-//   * Cuando `adapterStatus === 'ok'`, el shape devuelto por este adapter
-//     es **idéntico** al que devolvía `computeQuota` en M1, con tres
-//     campos nuevos no-rompedores: `provider`, `adapterStatus`, `errorReason`,
-//     `schemaVersion`, `breakdown`.
-//
-//   * El test de regresión `weekly-quota.test.js` verifica esto con assertions
-//     campo-a-campo sobre el subset que el banner consume (UX G5 + security
-//     CA-#7).
+// ESTADOS (security CA-#3 / UX G1):
+//   * dato fresco/tolerable   → adapterStatus 'ok', pct real.
+//   * dato demasiado viejo    → adapterStatus 'unknown' PERO con el último número
+//                               (degradado: el dashboard lo pinta stale, no lo
+//                               presenta como fresco; pacing lo ignora).
+//   * sin dato / CLI caído    → adapterStatus 'unknown', pct null (emptyResult).
+//   Nunca pct:0 silencioso (eso daría "luz verde" a la degradación).
 // =============================================================================
 'use strict';
 
-const { ADAPTER_STATUS, SCHEMA_VERSION, emptyResult } = require('./_shape');
+const { ADAPTER_STATUS, QUOTA_STATUS, SCHEMA_VERSION, emptyResult } = require('./_shape');
+
+const round1 = (n) => Math.round(n * 10) / 10;
+
+function statusFromPct(pct) {
+    if (pct >= 90) return QUOTA_STATUS.CRITICAL;
+    if (pct >= 75) return QUOTA_STATUS.WARNING;
+    if (pct >= 50) return QUOTA_STATUS.NORMAL;
+    return QUOTA_STATUS.OK;
+}
+
+/**
+ * Construye el QuotaResult con los números reales de /usage. Cuando `ok` es
+ * false (dato stale) mantiene los números pero marca adapterStatus 'unknown'
+ * para que el consumidor NO los trate como frescos.
+ */
+function buildResult(d, ok, errorReason) {
+    const weeklyPct = Number.isFinite(d.weeklyPct) ? round1(d.weeklyPct) : null;
+    const sessPct = Number.isFinite(d.sessionPct) ? round1(d.sessionPct) : null;
+    const weeklyStatus = weeklyPct != null ? statusFromPct(weeklyPct) : QUOTA_STATUS.UNKNOWN;
+    const sessStatus = sessPct != null ? statusFromPct(sessPct) : QUOTA_STATUS.UNKNOWN;
+
+    return {
+        provider: 'anthropic',
+        adapterStatus: ok ? ADAPTER_STATUS.OK : ADAPTER_STATUS.UNKNOWN,
+        errorReason: ok ? null : (errorReason || null),
+        schemaVersion: SCHEMA_VERSION,
+
+        // Semanal — número REAL de /usage. Sin heurística de duración: los
+        // campos de horas/límite/burn quedan null (ya no aplican).
+        hoursUsed7d: null,
+        sessionsCount7d: null,
+        hoursLast24h: null,
+        effectiveLimitHours: null,
+        configLimitHours: null,
+        pct: weeklyPct,
+        // `realPct` era el pct calibrado; ya no calibramos: pct ES el real.
+        realPct: null,
+        realPctRaw: null,
+        realPctCapped: false,
+        realStatus: weeklyStatus,
+        hoursRemaining: null,
+        burnRatePerDay: null,
+        daysToLimit: null,
+        status: weeklyStatus,
+        adjustmentsCount: 0,
+        observedMaxHours: null,
+        observedMaxAt: null,
+        autoAdjusted: false,
+
+        lastResetAt: null,
+        nextResetAt: d.weeklyResetsAt || null,
+        daysToReset: null,
+
+        session: {
+            hoursUsed: null,
+            sessionsCount: null,
+            limitHours: 5,
+            pct: sessPct,
+            realPct: null,
+            realPctRaw: null,
+            realPctCapped: false,
+            realStatus: sessStatus,
+            hoursRemaining: null,
+            status: sessStatus,
+        },
+
+        // Calibración deprecada (#4597): ya no se usa ni se requiere.
+        calibration: null,
+        calibrations: [],
+        weeklyResetDriftMin: 0,
+        calibrationAgeDays: null,
+        calibrationStale: false,
+        sessionResetsAt: d.sessionResetsAt || null,
+        weeklyResetsAtReported: d.weeklyResetsAt || null,
+
+        // Metadata de frescura del snapshot de /usage (UX: affordance de stale).
+        usageSource: {
+            capturedAt: d.capturedAt || null,
+            ageMs: Number.isFinite(d._ageMs) ? d._ageMs : null,
+            stale: !ok,
+        },
+        sessionResetsRaw: d.sessionResetsRaw || null,
+        weeklyResetsRaw: d.weeklyResetsRaw || null,
+
+        breakdown: [],
+    };
+}
 
 /**
  * Adapter Anthropic. Recibe sessionData y devuelve un QuotaResult.
- *
- * Errores → fail-secure (devuelve emptyResult con motivo, no lanza).
+ * Fail-secure: ante cualquier error devuelve emptyResult con motivo, no lanza.
  *
  * @param {Object} sessionData
- *   @property {string} metricsDir        path a .pipeline/metrics
- *   @property {string} activityLogPath   path a .claude/activity-log.jsonl
- *   @property {number} [configLimitHours]
+ *   @property {string}   metricsDir     path a .pipeline/metrics (requerido)
+ *   @property {number}   [now]          reloj override (tests)
+ *   @property {Object}   [usageImpl]    inyección del módulo anthropic-usage (tests)
+ *   @property {boolean}  [autoRefresh]  default true; false = no spawnear (tests)
+ *   @property {function} [spawnImpl]    inyección de spawn (tests)
+ *   @property {Object}   [launcher]     launcher override (tests)
  * @returns {QuotaResult}
  */
 function anthropicAdapter(sessionData) {
     const metricsDir = sessionData && sessionData.metricsDir;
-    const activityLogPath = sessionData && sessionData.activityLogPath;
-
     if (typeof metricsDir !== 'string' || metricsDir.length === 0) {
         return emptyResult('anthropic', ADAPTER_STATUS.ERROR,
             'metricsDir requerido para adapter Anthropic');
     }
-    if (typeof activityLogPath !== 'string' || activityLogPath.length === 0) {
-        return emptyResult('anthropic', ADAPTER_STATUS.ERROR,
-            'activityLogPath requerido para adapter Anthropic');
-    }
 
-    // Cargar la lógica legacy. require dinámico para evitar ciclo
-    // weekly-quota → quota-adapters → weekly-quota.
-    const weekly = require('../weekly-quota');
-    const opts = {};
-    if (sessionData.configLimitHours) {
-        opts.configLimitHours = sessionData.configLimitHours;
-    }
+    const usageLib = (sessionData && sessionData.usageImpl) || require('../anthropic-usage');
 
-    let legacy;
+    let u;
     try {
-        legacy = weekly.computeQuota(metricsDir, activityLogPath, opts);
+        u = usageLib.getUsage({
+            metricsDir,
+            now: Number.isFinite(sessionData.now) ? sessionData.now : undefined,
+            autoRefresh: sessionData.autoRefresh,
+            spawnImpl: sessionData.spawnImpl,
+            launcher: sessionData.launcher,
+        });
     } catch (err) {
         const reason = err && err.message ? String(err.message).slice(0, 200) : 'unknown';
-        return emptyResult('anthropic', ADAPTER_STATUS.ERROR,
-            `Cuota Anthropic: error calculando (${reason})`);
-    }
-
-    // Defensa: computeQuota nunca debería devolver null/undefined, pero
-    // si pasa, lo tratamos como estado degradado.
-    if (!legacy || typeof legacy !== 'object') {
         return emptyResult('anthropic', ADAPTER_STATUS.UNKNOWN,
-            'Cuota Anthropic: computeQuota devolvió shape inválido');
+            `Cuota Anthropic: error leyendo /usage (${reason}) — fallback degradado`);
     }
 
-    // Wrappear el shape legacy con el envelope multi-provider. Backward-compat:
-    // todos los campos legacy quedan exactamente como estaban.
-    return {
-        ...legacy,
-        provider: 'anthropic',
-        adapterStatus: ADAPTER_STATUS.OK,
-        errorReason: null,
-        schemaVersion: SCHEMA_VERSION,
-        breakdown: [],
-    };
+    // Sin dato todavía (primer arranque) o CLI caído → degradar, NUNCA congelar.
+    if (!u || !u.data) {
+        const reason = (u && u.reason)
+            ? `Cuota Anthropic: ${u.reason} (fallback degradado)`
+            : 'Cuota Anthropic: sin dato de /usage (fallback degradado)';
+        return emptyResult('anthropic', ADAPTER_STATUS.UNKNOWN, reason);
+    }
+
+    const d = { ...u.data, _ageMs: u.ageMs };
+    if (u.stale) {
+        const mins = Number.isFinite(u.ageMs) ? Math.round(u.ageMs / 60000) : '?';
+        return buildResult(d, false,
+            `Cuota Anthropic: dato de /usage stale (${mins} min) — refrescando en background`);
+    }
+    return buildResult(d, true, null);
 }
 
 module.exports = anthropicAdapter;

--- a/.pipeline/lib/weekly-quota.js
+++ b/.pipeline/lib/weekly-quota.js
@@ -1,5 +1,15 @@
 // Weekly Quota — estimación del consumo del Plan Max de Anthropic.
 //
+// ⚠️ DEPRECADO como FUENTE de la cuota Anthropic (#4597).
+//   `computeQuota` (heurística de `duration_ms`) y la calibración manual
+//   (`saveCalibration`/EMA/factor) ya NO alimentan el adapter Anthropic: la
+//   fuente de verdad pasó a ser el uso REAL de `claude -p "/usage"`
+//   (ver lib/anthropic-usage.js + quota-adapters/anthropic.js). Este archivo se
+//   conserva SÓLO por compatibilidad (fallback de último recurso en
+//   dashboard-slices y helpers de reset como getLastWeeklyResetMs que pacing
+//   sigue usando para anclar la ventana semanal). No agregar consumidores
+//   nuevos de `computeQuota`/`saveCalibration`.
+//
 // Anthropic NO expone API pública del uso del plan, así que aproximamos:
 //
 //  1. Sumamos `duration_ms` de eventos `session:end` del activity-log

--- a/.pipeline/quota-snapshot-scheduler.js
+++ b/.pipeline/quota-snapshot-scheduler.js
@@ -61,9 +61,14 @@ function log(msg) {
 }
 
 function isEnabled() {
+  // #4597 — DEPRECADO. El snapshot OCR del panel "Uso" de Claude Desktop ya no
+  // es la fuente de la cuota Anthropic: se reemplazó por la lectura directa de
+  // `claude -p "/usage"` (ver lib/anthropic-usage.js + quota-adapters/anthropic.js).
+  // Por eso el default pasó a DESHABILITADO: el scheduler sólo corre si el
+  // operador lo pide EXPLÍCITAMENTE con QUOTA_SNAPSHOT_ENABLED=true (p.ej. para
+  // depurar el parser OCR). Cualquier otro valor => no-op silencioso.
   const raw = String(process.env.QUOTA_SNAPSHOT_ENABLED || '').toLowerCase();
-  // Default: habilitado salvo que esté explícitamente "false" (CA-18).
-  return raw !== 'false' && raw !== '0' && raw !== 'no';
+  return raw === 'true' || raw === '1' || raw === 'yes';
 }
 
 function getIntervalMs() {


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 79 archivos · +994 -290

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:passed` aplicado por delivery

## Closes

Closes #4597
