### PR TITLE
Desarrollo · pipeline-dev debe entregar SIEMPRE la nota de implementación

### DIFF
--- a/.claude/skills/pipeline-dev/SKILL.md
+++ b/.claude/skills/pipeline-dev/SKILL.md
@@ -233,7 +233,7 @@ writeDeliverable("pipeline-dev", issue, { fase, md /* o svg para mockups/diagram
 > const pipelineRoot = process.env.PIPELINE_ROOT || process.cwd();
 > writeDeliverableException("pipeline-dev", issue, {
 >   fase,                          // 'dev' — token del enum, no la etiqueta humana
->   motivo_no_aplica: "Por qué no corresponde entregable en este issue",
+>   motivo: "Por qué no corresponde entregable en este issue",
 >   pipelineRoot,
 > });
 > ```

--- a/.claude/skills/pipeline-dev/SKILL.md
+++ b/.claude/skills/pipeline-dev/SKILL.md
@@ -220,4 +220,27 @@ const fase = process.env.PIPELINE_FASE || "dev";
 writeDeliverable("pipeline-dev", issue, { fase, md /* o svg para mockups/diagramas */ });
 ```
 
-El enforcement es **warn-only**: no generar el archivo no bloquea el pipeline, pero cuenta para la cobertura ≥80% de la ola (CA-4).
+> **Obligatorio en `desarrollo/dev` (#4509).** Para `pipeline-dev` al cerrar la
+> fase `dev`, el warn-only original **quedó superado**: la nota de implementación
+> ya **no es opcional**. Al aprobar sin adjunto, el pulpo materializa SIEMPRE un
+> `.md` mínimo por vos (fallback obligatorio #4523, `pulpo.js`), así que el
+> silencio es imposible. Si por la naturaleza del issue el entregable **no
+> aplica**, registrá una **excepción explícita** con motivo redactado en vez de
+> dejar la carpeta vacía:
+>
+> ```js
+> const { writeDeliverableException } = require(path.resolve(".pipeline/lib/write-deliverable"));
+> writeDeliverableException("pipeline-dev", issue, {
+>   fase,                          // 'dev' — token del enum, no la etiqueta humana
+>   motivo_no_aplica: "Por qué no corresponde entregable en este issue",
+>   pipelineRoot: ROOT,
+> });
+> ```
+>
+> Ambos caminos (nota o excepción) terminan en el store `issue → fase → agente`
+> (`.pipeline/deliverables/<issue>.json`) y se disponibilizan por Telegram sin
+> allowlist que los bloquee. La ausencia silenciosa **no** satisface el cierre.
+
+Para el resto de los skills/fases sigue vigente el enforcement **warn-only**: no
+generar el archivo no bloquea el pipeline, pero cuenta para la cobertura ≥80% de
+la ola (CA-4).

--- a/.claude/skills/pipeline-dev/SKILL.md
+++ b/.claude/skills/pipeline-dev/SKILL.md
@@ -230,10 +230,11 @@ writeDeliverable("pipeline-dev", issue, { fase, md /* o svg para mockups/diagram
 >
 > ```js
 > const { writeDeliverableException } = require(path.resolve(".pipeline/lib/write-deliverable"));
+> const pipelineRoot = process.env.PIPELINE_ROOT || process.cwd();
 > writeDeliverableException("pipeline-dev", issue, {
 >   fase,                          // 'dev' — token del enum, no la etiqueta humana
 >   motivo_no_aplica: "Por qué no corresponde entregable en este issue",
->   pipelineRoot: ROOT,
+>   pipelineRoot,
 > });
 > ```
 >

--- a/.pipeline/cache/codex-reprobe.json
+++ b/.pipeline/cache/codex-reprobe.json
@@ -1,1 +1,1 @@
-{"ts":1783568066396,"healthy":true}
+{"ts":1783571492654,"healthy":true}

--- a/.pipeline/cache/codex-reprobe.json
+++ b/.pipeline/cache/codex-reprobe.json
@@ -1,1 +1,1 @@
-{"ts":1783562014167,"healthy":true}
+{"ts":1783568066396,"healthy":true}

--- a/docs/pipeline/entregables-multimedia-por-agente.md
+++ b/docs/pipeline/entregables-multimedia-por-agente.md
@@ -383,7 +383,7 @@ const { path, bytes } = writeDeliverable('guru', issue, { md /* o svg */ });
 >   umbral anti-ruido de 80 chars que aplica al resto de los skills. El bypass del
 >   umbral está scopeado exclusivamente a `pipeline-dev/dev`.
 > - **Excepción explícita (#4524).** `writeDeliverableException('pipeline-dev',
->   issue, { fase: 'dev', motivo_no_aplica, pipelineRoot })` persiste una entry
+>   issue, { fase: 'dev', motivo, pipelineRoot })` persiste una entry
 >   `tipo: 'exception'` con `motivo_no_aplica` redactado en el mismo store
 >   `issue → fase → agente`, sin un segundo writer del manifest. La excepción vive
 >   en el índice y **no** se convierte en attachment físico.

--- a/docs/pipeline/entregables-multimedia-por-agente.md
+++ b/docs/pipeline/entregables-multimedia-por-agente.md
@@ -371,6 +371,26 @@ const { path, bytes } = writeDeliverable('guru', issue, { md /* o svg */ });
 > del épico #4255 se materializa. La primera relación endurecida es
 > `Definición → PO → Ficha de definición`.
 
+> **Actualización #4509 (pipeline-dev/Desarrollo).** La relación
+> `Desarrollo → pipeline-dev → Nota de implementación` **también queda endurecida**:
+> ya **no** está cubierta por warn-only. Al cerrar `desarrollo/dev` con
+> `resultado: aprobado`, `pipeline-dev` debe producir **siempre** su documento o
+> registrar una **excepción explícita** con `motivo_no_aplica` redactado. La
+> ausencia silenciosa no satisface el cierre. Garantías de plomería:
+>
+> - **Fallback obligatorio (#4523).** Si `pipeline-dev` aprueba `dev` sin adjunto,
+>   el pulpo materializa SIEMPRE un `.md` mínimo vía `writeDeliverable`, sin el
+>   umbral anti-ruido de 80 chars que aplica al resto de los skills. El bypass del
+>   umbral está scopeado exclusivamente a `pipeline-dev/dev`.
+> - **Excepción explícita (#4524).** `writeDeliverableException('pipeline-dev',
+>   issue, { fase: 'dev', motivo_no_aplica, pipelineRoot })` persiste una entry
+>   `tipo: 'exception'` con `motivo_no_aplica` redactado en el mismo store
+>   `issue → fase → agente`, sin un segundo writer del manifest. La excepción vive
+>   en el índice y **no** se convierte en attachment físico.
+> - **Telegram sin allowlist.** El perfil documental `.md/.pdf` bajo
+>   `.pipeline/assets/docs/{issue}` y la whitelist de notificación ya incluyen a
+>   `pipeline-dev`; el cierre se disponibiliza sin bloqueo por allowlist ni formato.
+
 Histórico (warn-only, aún vigente para las relaciones no endurecidas): la
 cobertura ≥80% de la primera ola se **mide** reutilizando la telemetría que ya
 emite `deliverable-notify.js`. Un agente que no genere el archivo no traba el


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 3 archivos · +46 -2

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:skipped` aplicado por delivery

## Closes

Closes #4509
