### PR TITLE
fix(pulpo): circuit-breaker de conectividad gh — no morir en outage de GitHub (#4612 parte A)

### DIFF
--- a/.pipeline/lib/gh-circuit-breaker.js
+++ b/.pipeline/lib/gh-circuit-breaker.js
@@ -1,0 +1,165 @@
+// =============================================================================
+// gh-circuit-breaker.js — Circuit-breaker de conectividad para llamadas a `gh`
+// (GitHub CLI). Incidente #4612: un outage de red a GitHub
+// (`error connecting to api.github.com`) hizo que el loop del Pulpo acumulara
+// cientos de llamadas `gh` fallidas y quedara demorado, dejando el heartbeat de
+// liveness stale → el watchdog lo mató como zombi.
+//
+// Este breaker evita eso: tras N fallos CONSECUTIVOS de conexión, "abre" el
+// circuito y hace que las llamadas siguientes cortocircuiten (retornen rápido
+// sin spawnear `gh`) durante un cooldown. Pasado el cooldown, deja pasar UNA
+// llamada de prueba (half-open): si funciona, cierra; si falla, reabre.
+//
+// Efecto: durante un outage, el loop del Pulpo NO se bloquea llamando a `gh` una
+// y otra vez — degrada rápido, mantiene el heartbeat fresco, y reanuda solo
+// cuando la red vuelve.
+//
+// PURO / DETERMINÍSTICO: sin IO, sin timers propios. El caller inyecta `now`
+// (epoch ms) para test. Un default singleton se expone para el Pulpo.
+//
+// Semántica de error de conexión (CA): solo los fallos de RED/DNS/conexión
+// cuentan para abrir el circuito. Un `gh` que responde 404/permiso/validación
+// NO es un problema de conectividad y NO debe abrir el breaker.
+// =============================================================================
+
+'use strict';
+
+// Patrones de error que indican problema de CONECTIVIDAD (no de negocio).
+// `gh` imprime "error connecting to api.github.com" ante outage; Node/undici
+// tiran ENOTFOUND/ECONNREFUSED/ETIMEDOUT/EAI_AGAIN/getaddrinfo/fetch failed.
+const CONN_ERROR_PATTERNS = [
+    /error connecting to/i,
+    /\bENOTFOUND\b/,
+    /\bECONNREFUSED\b/,
+    /\bECONNRESET\b/,
+    /\bETIMEDOUT\b/,
+    /\bEAI_AGAIN\b/,
+    /getaddrinfo/i,
+    /fetch failed/i,
+    /network is unreachable/i,
+    /could not resolve host/i,
+    /dial tcp/i,
+    /connection refused/i,
+    /timeout|timed out/i, // incluye GH_CALL_TIMEOUT del wrapper del Pulpo
+];
+
+/**
+ * ¿El error/salida indica un problema de conectividad (no de negocio)?
+ * @param {Error|string|{code?:string,message?:string,stderr?:string}} err
+ * @returns {boolean}
+ */
+function isConnError(err) {
+    if (!err) return false;
+    if (err.code === 'GH_CALL_TIMEOUT') return true;
+    const parts = [];
+    if (typeof err === 'string') parts.push(err);
+    else {
+        if (err.code) parts.push(String(err.code));
+        if (err.message) parts.push(String(err.message));
+        if (err.stderr) parts.push(String(err.stderr));
+    }
+    const hay = parts.join(' \n ');
+    return CONN_ERROR_PATTERNS.some((re) => re.test(hay));
+}
+
+/**
+ * @param {object} [opts]
+ * @param {number} [opts.threshold=3]   fallos de conexión consecutivos para abrir.
+ * @param {number} [opts.cooldownMs=30000] tiempo abierto antes de permitir un probe.
+ * @param {function} [opts.onOpen]  callback(state) al abrir (para loguear una sola vez).
+ * @param {function} [opts.onClose] callback(state) al cerrar tras recuperación.
+ */
+function createGhCircuitBreaker(opts = {}) {
+    const threshold = Number.isFinite(opts.threshold) && opts.threshold > 0 ? opts.threshold : 3;
+    const cooldownMs = Number.isFinite(opts.cooldownMs) && opts.cooldownMs > 0 ? opts.cooldownMs : 30000;
+    const onOpen = typeof opts.onOpen === 'function' ? opts.onOpen : null;
+    const onClose = typeof opts.onClose === 'function' ? opts.onClose : null;
+
+    let consecutiveFailures = 0;
+    let openUntil = 0;      // epoch ms; 0 = cerrado
+    let probing = false;    // true cuando dejamos pasar un probe half-open
+    let wasOpen = false;    // para disparar onClose una sola vez
+
+    /**
+     * ¿Debe el caller SALTEAR esta llamada a `gh` (cortocircuito)?
+     * - Circuito cerrado → false (llamar normal).
+     * - Circuito abierto y dentro del cooldown → true (cortar).
+     * - Cooldown vencido → false pero marca `probing` (half-open: 1 llamada de prueba).
+     * @param {number} now epoch ms
+     * @returns {boolean}
+     */
+    function shouldShortCircuit(now) {
+        if (openUntil === 0) return false;            // cerrado
+        if (now < openUntil) return true;             // abierto, en cooldown → cortar
+        // cooldown vencido → permitir UN probe
+        probing = true;
+        return false;
+    }
+
+    /**
+     * Registrar el resultado de una llamada a `gh`.
+     * @param {{ok:boolean, error?:*}} result
+     * @param {number} now epoch ms
+     */
+    function record(result, now) {
+        const ok = !!(result && result.ok);
+        const connFail = !ok && isConnError(result && result.error);
+
+        if (ok) {
+            consecutiveFailures = 0;
+            if (openUntil !== 0 || wasOpen) {
+                openUntil = 0;
+                probing = false;
+                if (wasOpen && onClose) { try { onClose(getState(now)); } catch { /* no-op */ } }
+                wasOpen = false;
+            }
+            return;
+        }
+
+        if (!connFail) {
+            // Fallo de NEGOCIO (404/permiso/validación): no cuenta para el breaker.
+            // Un probe fallido por negocio NO reabre (la red está bien).
+            if (probing) { openUntil = 0; probing = false; wasOpen = false; }
+            return;
+        }
+
+        // Fallo de conexión.
+        consecutiveFailures += 1;
+        if (probing) {
+            // El probe half-open falló → reabrir el circuito.
+            probing = false;
+            openUntil = now + cooldownMs;
+            return;
+        }
+        if (consecutiveFailures >= threshold && openUntil === 0) {
+            openUntil = now + cooldownMs;
+            wasOpen = true;
+            if (onOpen) { try { onOpen(getState(now)); } catch { /* no-op */ } }
+        } else if (openUntil !== 0) {
+            // ya abierto y sigue fallando fuera de probe → extender cooldown
+            openUntil = now + cooldownMs;
+        }
+    }
+
+    function getState(now) {
+        return {
+            open: openUntil !== 0 && (!Number.isFinite(now) || now < openUntil),
+            openUntil,
+            consecutiveFailures,
+            probing,
+            threshold,
+            cooldownMs,
+        };
+    }
+
+    function reset() {
+        consecutiveFailures = 0;
+        openUntil = 0;
+        probing = false;
+        wasOpen = false;
+    }
+
+    return { shouldShortCircuit, record, getState, reset, isConnError };
+}
+
+module.exports = { createGhCircuitBreaker, isConnError, CONN_ERROR_PATTERNS };

--- a/.pipeline/lib/gh-circuit-breaker.test.js
+++ b/.pipeline/lib/gh-circuit-breaker.test.js
@@ -1,0 +1,82 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { createGhCircuitBreaker, isConnError } = require('./gh-circuit-breaker');
+
+test('isConnError distingue conexión de negocio', () => {
+    assert.equal(isConnError('error connecting to api.github.com'), true);
+    assert.equal(isConnError({ code: 'ENOTFOUND' }), true);
+    assert.equal(isConnError({ code: 'GH_CALL_TIMEOUT' }), true);
+    assert.equal(isConnError({ message: 'could not resolve host' }), true);
+    // Negocio: NO cuenta
+    assert.equal(isConnError({ message: 'HTTP 404: Not Found' }), false);
+    assert.equal(isConnError({ message: 'Resource not accessible' }), false);
+    assert.equal(isConnError(null), false);
+});
+
+test('abre tras N fallos de conexión consecutivos y cortocircuita en cooldown', () => {
+    const b = createGhCircuitBreaker({ threshold: 3, cooldownMs: 1000 });
+    let t = 0;
+    // 2 fallos: aún cerrado
+    b.record({ ok: false, error: { code: 'ENOTFOUND' } }, t);
+    b.record({ ok: false, error: { code: 'ENOTFOUND' } }, t);
+    assert.equal(b.shouldShortCircuit(t), false, 'con 2 fallos sigue cerrado');
+    // 3er fallo: abre
+    b.record({ ok: false, error: { message: 'error connecting to api.github.com' } }, t);
+    assert.equal(b.shouldShortCircuit(t), true, 'con 3 fallos abre y cortocircuita');
+    assert.equal(b.getState(t).open, true);
+    // dentro del cooldown sigue cortando
+    assert.equal(b.shouldShortCircuit(t + 500), true);
+});
+
+test('half-open: probe exitoso cierra el circuito', () => {
+    const b = createGhCircuitBreaker({ threshold: 1, cooldownMs: 1000 });
+    b.record({ ok: false, error: { code: 'ETIMEDOUT' } }, 0); // abre (threshold 1)
+    assert.equal(b.shouldShortCircuit(0), true);
+    // cooldown vencido → deja pasar un probe (no cortocircuita)
+    assert.equal(b.shouldShortCircuit(1500), false, 'tras cooldown permite probe');
+    // el probe sale bien → cierra
+    b.record({ ok: true }, 1500);
+    assert.equal(b.shouldShortCircuit(1600), false, 'cerrado tras probe OK');
+    assert.equal(b.getState(1600).open, false);
+});
+
+test('half-open: probe fallido reabre', () => {
+    const b = createGhCircuitBreaker({ threshold: 1, cooldownMs: 1000 });
+    b.record({ ok: false, error: { code: 'ETIMEDOUT' } }, 0);
+    assert.equal(b.shouldShortCircuit(1500), false); // probe permitido
+    b.record({ ok: false, error: { code: 'ETIMEDOUT' } }, 1500); // probe falla
+    assert.equal(b.shouldShortCircuit(1600), true, 'reabre tras probe fallido');
+});
+
+test('un fallo de NEGOCIO no abre el circuito', () => {
+    const b = createGhCircuitBreaker({ threshold: 2, cooldownMs: 1000 });
+    b.record({ ok: false, error: { message: 'HTTP 404' } }, 0);
+    b.record({ ok: false, error: { message: 'HTTP 404' } }, 0);
+    b.record({ ok: false, error: { message: 'HTTP 404' } }, 0);
+    assert.equal(b.shouldShortCircuit(0), false, 'los 404 no abren el breaker');
+});
+
+test('éxito resetea el contador de fallos', () => {
+    const b = createGhCircuitBreaker({ threshold: 3, cooldownMs: 1000 });
+    b.record({ ok: false, error: { code: 'ENOTFOUND' } }, 0);
+    b.record({ ok: false, error: { code: 'ENOTFOUND' } }, 0);
+    b.record({ ok: true }, 0); // reset
+    b.record({ ok: false, error: { code: 'ENOTFOUND' } }, 0);
+    b.record({ ok: false, error: { code: 'ENOTFOUND' } }, 0);
+    assert.equal(b.shouldShortCircuit(0), false, 'el éxito intermedio evita abrir');
+});
+
+test('onOpen/onClose se disparan una sola vez', () => {
+    let opens = 0, closes = 0;
+    const b = createGhCircuitBreaker({
+        threshold: 1, cooldownMs: 1000,
+        onOpen: () => opens++, onClose: () => closes++,
+    });
+    b.record({ ok: false, error: { code: 'ENOTFOUND' } }, 0); // abre
+    b.record({ ok: false, error: { code: 'ENOTFOUND' } }, 0); // sigue abierto (fuera de probe)
+    assert.equal(opens, 1, 'onOpen una vez');
+    b.shouldShortCircuit(1500); // probe
+    b.record({ ok: true }, 1500); // cierra
+    assert.equal(closes, 1, 'onClose una vez');
+});

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -13955,9 +13955,9 @@ function dedupDependencyIssue(issue, allIssuesInBatch) {
   if (Date.now() - depIssuesCache.fetchedAt > 600000) {
     try {
       ghThrottle();
-      const raw = execSync(
+      const raw = _ghExecSyncGuarded( // #4612 — breaker-aware
         `"${GH_BIN}" issue list --label "qa:dependency" --state open --json number,title --limit 100`,
-        { cwd: ROOT, encoding: 'utf8', timeout: 30000, windowsHide: true }
+        { cwd: ROOT, encoding: 'utf8', timeout: 15000, windowsHide: true }
       );
       depIssuesCache = { issues: JSON.parse(raw || '[]'), fetchedAt: Date.now() };
     } catch (e) {
@@ -14065,9 +14065,9 @@ function brazoIntake(config) {
       // #2405 CA-4: excluir issues con label `needs-human` — el circuit breaker
       // de infra los saca de la cola de intake hasta que un humano quite el label.
       ghThrottle();
-      const result = execSync(
+      const result = _ghExecSyncGuarded( // #4612 — breaker-aware
         `"${GH_BIN}" issue list --label "${label}" --state open --json number,title,labels --limit 50 --search "-label:needs-human"`,
-        { cwd: ROOT, encoding: 'utf8', timeout: 30000, windowsHide: true }
+        { cwd: ROOT, encoding: 'utf8', timeout: 15000, windowsHide: true }
       );
       let issues = JSON.parse(result || '[]');
 
@@ -14755,8 +14755,47 @@ function _sanitizeGhArgs(args) {
  *     `_unblockActivePid` para que el watchdog del brazo pueda matarlo
  *     si el race promise/timer mismo se cuelga.
  */
+// #4612 — Circuit-breaker de conectividad a GitHub. Durante un outage de red,
+// las llamadas `gh` fallaban en masa y demoraban el loop del Pulpo → heartbeat
+// stale → el watchdog lo mataba como zombi. El breaker corta rápido tras N
+// fallos de conexión consecutivos y reanuda solo cuando la red vuelve.
+const { createGhCircuitBreaker } = require('./lib/gh-circuit-breaker');
+const _ghBreaker = createGhCircuitBreaker({
+  threshold: 3,
+  cooldownMs: 30000,
+  onOpen: (st) => log('gh-breaker', `⚡ ABIERTO — ${st.consecutiveFailures} fallos de conexión a GitHub; cortocircuitando llamadas gh ${Math.round(st.cooldownMs / 1000)}s (degradado, sin bloquear el loop)`),
+  onClose: () => log('gh-breaker', '✓ CERRADO — conectividad a GitHub recuperada, gh normal'),
+});
+
+// #4612 — execSync de `gh` consciente del breaker. Reemplaza a `execSync(gh...)`
+// crudo en el hot-path del intake: si el circuito está abierto, tira rápido SIN
+// spawnear gh (evita bloquear el event loop 30s por llamada durante un outage).
+// El caller ya envuelve en try/catch y degrada — el throw se maneja igual.
+function _ghExecSyncGuarded(command, opts = {}) {
+  if (_ghBreaker.shouldShortCircuit(Date.now())) {
+    const err = new Error('gh-circuit-open: GitHub inalcanzable, execSync cortocircuitado');
+    err.code = 'GH_CIRCUIT_OPEN';
+    throw err;
+  }
+  try {
+    const out = execSync(command, { timeout: 15000, ...opts });
+    _ghBreaker.record({ ok: true }, Date.now());
+    return out;
+  } catch (err) {
+    _ghBreaker.record({ ok: false, error: { code: err.code, message: err.message, stderr: err.stderr && String(err.stderr) } }, Date.now());
+    throw err;
+  }
+}
+
 function _ghCallWithTimeout(bin, args, timeoutMs) {
   return new Promise((resolve, reject) => {
+    // #4612 — cortocircuito: si el breaker está abierto, fallar rápido SIN
+    // spawnear gh (no bloquear el loop del Pulpo durante un outage de red).
+    if (_ghBreaker.shouldShortCircuit(Date.now())) {
+      const err = new Error('gh-circuit-open: GitHub inalcanzable, llamada cortocircuitada');
+      err.code = 'GH_CIRCUIT_OPEN';
+      return reject(err);
+    }
     let settled = false;
     let timer = null;
     let pid = null;
@@ -14771,7 +14810,11 @@ function _ghCallWithTimeout(bin, args, timeoutMs) {
       settled = true;
       if (timer) { clearTimeout(timer); timer = null; }
       if (_unblockActivePid === pid) _unblockActivePid = null;
-      if (err) return reject(err);
+      if (err) {
+        _ghBreaker.record({ ok: false, error: { code: err.code, message: err.message, stderr } }, Date.now());
+        return reject(err);
+      }
+      _ghBreaker.record({ ok: true }, Date.now());
       resolve({ stdout, stderr });
     });
 
@@ -14803,6 +14846,7 @@ function _ghCallWithTimeout(bin, args, timeoutMs) {
       err.pid = pid;
       err.killStatus = killStatus;
       err.args = args.slice();
+      _ghBreaker.record({ ok: false, error: { code: err.code, message: err.message } }, Date.now()); // #4612
       reject(err);
     }, timeoutMs);
     // No queremos que el timer mantenga vivo el proceso del pulpo.


### PR DESCRIPTION
## Qué

Resuelve la **parte A (resiliencia)** de #4612 (crash del pulpo por outage de red a GitHub, incidente 2026-07-09).

Un outage (`error connecting to api.github.com`) hacía que el intake acumulara llamadas `gh` `execSync` bloqueantes (30s c/u) → el heartbeat de liveness quedaba stale → el watchdog mataba el pulpo como zombi.

## Cambios
- **`lib/gh-circuit-breaker.js`** (nuevo, 7 tests): tras 3 fallos de **conexión** consecutivos abre el circuito y cortocircuita las llamadas `gh` 30s (retorno rápido sin spawnear); half-open probe reanuda al volver la red. Distingue conexión vs negocio (404/permiso NO abren).
- **`pulpo.js`**: wireado en `_ghCallWithTimeout` (async) + nuevo `_ghExecSyncGuarded` para las llamadas `execSync` del intake (issue list por label + qa:dependency), timeout 30s→15s. Un outage ahora **degrada rápido en vez de bloquear el loop**.

## Verificación
- `node --test lib/gh-circuit-breaker.test.js` → 7/7.
- `node --check pulpo.js` OK.

Parte B (self-healing de fase post-crash) queda pendiente en #4612.

Closes parcial de #4612.

🤖 Generated with [Claude Code](https://claude.com/claude-code)