### PR TITLE
feat(pipeline): self-healing de fases varadas (#4614, parte B) — revisado por arquitecto+PO, 63 tests, dry-run limpio

### DIFF
--- a/.pipeline/lib/stuck-phase-detector.js
+++ b/.pipeline/lib/stuck-phase-detector.js
@@ -1,0 +1,129 @@
+// =============================================================================
+// stuck-phase-detector.js — Self-healing del estado de fase post-crash (#4614,
+// parte B de #4612).
+//
+// Cuando el Pulpo se cae/reinicia (o un fast-fail-rebote deja artefactos a
+// medias), un issue puede quedar VARADO en una fase: tiene deliverables pero la
+// fase nunca completa ni avanza, y como el issue "está activo" el intake no lo
+// re-admite. Ejemplos reales: #4507 (skill `ux` faltante), #4534 (po/ux
+// `cancelado_por: fast-fail-rebote`).
+//
+// Este módulo es un DETECTOR PURO: dado el estado de una fase para un issue,
+// decide una acción SEGURA:
+//   - `requeue`  → re-encolar los skills requeridos faltantes/cancelados
+//                  (acción segura: re-corre el agente, NO fabrica aprobaciones).
+//   - `escalate` → marcar `needs-human` cuando hay un RECHAZO real (no re-encolar
+//                  para no loopear) o estado indeterminado.
+//   - `none`     → fase completa, hay trabajo vivo, o el deliverable es muy
+//                  reciente (aún puede avanzar solo).
+//
+// Correctitud (CA de #4614): NUNCA auto-completa una fase. `archivado` NO se
+// cuenta como "hecho" salvo que el propio artefacto sea `resultado: aprobado`
+// (reusa `isApprovedArtifact`, que ya excluye `cancelado_por`). Ante ambigüedad,
+// escala a humano.
+//
+// PURO: sin IO. El caller lee el FS y pasa el estado + `nowMs`.
+// =============================================================================
+
+'use strict';
+
+const { isApprovedArtifact } = require('./phase-completion');
+
+const DEFAULT_STALE_THRESHOLD_MS = 15 * 60 * 1000; // 15 min sin avance
+
+/**
+ * Clasifica el estado de UN skill requerido en la fase.
+ * @param {string} skill
+ * @param {Array<{skill:string,state:string,yaml:object,mtimeMs:number}>} deliverables
+ * @param {Set<string>} liveSkills  skills en pendiente/trabajando (activos)
+ * @returns {{skill:string, status:'live'|'done'|'cancelled'|'rejected'|'corrupt'|'missing', state?:string}}
+ */
+function classifySkill(skill, deliverables, liveSkills) {
+    if (liveSkills.has(skill)) return { skill, status: 'live' };
+
+    // Prioridad listo > procesado > archivado (mismo criterio que la promoción).
+    const byState = {};
+    for (const d of deliverables) {
+        if (d && d.skill === skill && !byState[d.state]) byState[d.state] = d;
+    }
+    for (const st of ['listo', 'procesado', 'archivado']) {
+        const d = byState[st];
+        if (!d) continue;
+        const y = (d && d.yaml) || {};
+        if (isApprovedArtifact(y)) return { skill, status: 'done', state: st };
+        if (y.cancelado_por != null && y.cancelado_por !== '') return { skill, status: 'cancelled', state: st };
+        if (y.resultado === 'rechazado') return { skill, status: 'rejected', state: st };
+        return { skill, status: 'corrupt', state: st }; // presente pero indeterminado
+    }
+    return { skill, status: 'missing' };
+}
+
+/**
+ * Analiza un issue en una fase y decide la acción de self-healing.
+ * @param {object} args
+ * @param {string[]} args.requiredSkills
+ * @param {Array<{skill:string,state:string,yaml:object,mtimeMs:number}>} args.deliverables
+ * @param {Set<string>|string[]} [args.liveSkills]
+ * @param {number} args.nowMs
+ * @param {number} [args.staleThresholdMs]
+ * @returns {{stuck:boolean, action:'requeue'|'escalate'|'none', requeueSkills?:string[], reason:string}}
+ */
+function analyzeStuckIssue(args = {}) {
+    const requiredSkills = Array.isArray(args.requiredSkills) ? args.requiredSkills : [];
+    const deliverables = Array.isArray(args.deliverables) ? args.deliverables : [];
+    const liveSkills = args.liveSkills instanceof Set
+        ? args.liveSkills
+        : new Set(Array.isArray(args.liveSkills) ? args.liveSkills : []);
+    const nowMs = Number.isFinite(args.nowMs) ? args.nowMs : Date.now();
+    const staleThresholdMs = Number.isFinite(args.staleThresholdMs) && args.staleThresholdMs > 0
+        ? args.staleThresholdMs : DEFAULT_STALE_THRESHOLD_MS;
+
+    if (requiredSkills.length === 0) return { stuck: false, action: 'none', reason: 'sin-skills-requeridos' };
+
+    const classes = requiredSkills.map((s) => classifySkill(s, deliverables, liveSkills));
+    const done = classes.filter((c) => c.status === 'done');
+    const live = classes.filter((c) => c.status === 'live');
+    const rejected = classes.filter((c) => c.status === 'rejected');
+    const corrupt = classes.filter((c) => c.status === 'corrupt');
+    const cancelled = classes.filter((c) => c.status === 'cancelled');
+    const missing = classes.filter((c) => c.status === 'missing');
+
+    // Fase completa → no stuck (la promoción normal debería llevarlo).
+    if (done.length === requiredSkills.length) return { stuck: false, action: 'none', reason: 'completo' };
+    // Hay trabajo vivo (encolado/corriendo) → no interferir.
+    // NOTA: el caller DEBE construir `liveSkills` con liveness real (mtime reciente
+    // o PID vivo); un `trabajando/` huérfano de agente muerto NO debe pasar acá
+    // (arquitecto P1-3), sino la fase varada nunca se cura.
+    if (live.length > 0) return { stuck: false, action: 'none', reason: 'trabajo-vivo' };
+
+    // Antigüedad: si no hay deliverables, no es un varado de FASE (lo maneja el
+    // intake re-admitiendo). Si el más nuevo es reciente, darle tiempo.
+    const mtimes = deliverables.map((d) => d && d.mtimeMs).filter(Number.isFinite);
+    if (mtimes.length === 0) return { stuck: false, action: 'none', reason: 'sin-deliverables' };
+    const age = nowMs - Math.max(...mtimes);
+    if (age < staleThresholdMs) return { stuck: false, action: 'none', reason: 'reciente' };
+
+    // AMBIGÜEDAD → escalar a humano, NUNCA re-encolar a ciegas (review PO+arquitecto):
+    //   - `rejected`: decisión válida, no es limbo; re-encolar loopearía.
+    //   - `cancelled`: un cancelado implica que hubo un rechazo en la fase; puede
+    //     estar en doble-track (el caller ya filtró los vivos cross-fase). Solo/humano.
+    //   - `corrupt`: verdict ilegible → indeterminado, no re-correr sobre trabajo
+    //     posiblemente bueno.
+    // La línea roja del PO: jamás auto-completar; ante duda, humano.
+    const ambiguous = [...rejected, ...cancelled, ...corrupt];
+    if (ambiguous.length > 0) {
+        const detail = ambiguous.map((c) => `${c.skill}:${c.status}`).join(',');
+        return { stuck: true, action: 'escalate', reason: `ambigüedad (rechazo/cancelado/corrupto): ${detail}` };
+    }
+
+    // Único caso de auto-remediación: skill(s) GENUINAMENTE faltante(s) (nunca
+    // corrió, no hay artefacto en ningún lado) → re-encolar (re-corre el agente).
+    if (missing.length > 0) {
+        const skills = missing.map((c) => c.skill);
+        return { stuck: true, action: 'requeue', requeueSkills: skills, reason: `re-encolar skills faltantes (nunca corrieron): ${skills.join(',')}` };
+    }
+
+    return { stuck: true, action: 'escalate', reason: 'estado indeterminado' };
+}
+
+module.exports = { analyzeStuckIssue, classifySkill, DEFAULT_STALE_THRESHOLD_MS };

--- a/.pipeline/lib/stuck-phase-detector.test.js
+++ b/.pipeline/lib/stuck-phase-detector.test.js
@@ -1,0 +1,196 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { analyzeStuckIssue, classifySkill, DEFAULT_STALE_THRESHOLD_MS } = require('./stuck-phase-detector');
+
+const NOW = 1_800_000_000_000;
+const OLD = NOW - 20 * 60 * 1000;   // 20 min → stale
+const RECENT = NOW - 60 * 1000;      // 1 min → reciente
+const APROB = { resultado: 'aprobado' };
+const CANCEL = { cancelado_por: 'fast-fail-rebote', cancelado_ts: 'x' };
+const RECHAZO = { resultado: 'rechazado', motivo: 'x' };
+const CORRUPT = { issue: 1, fase: 'validacion' }; // sin resultado
+
+function deliv(skill, state, yaml, mtimeMs = OLD) { return { skill, state, yaml, mtimeMs }; }
+
+// ─── classifySkill ──────────────────────────────────────────────────────────
+test('classifySkill: aprobado en listo → done', () => {
+    assert.equal(classifySkill('po', [deliv('po', 'listo', APROB)], new Set()).status, 'done');
+});
+test('classifySkill: cancelado → cancelled', () => {
+    assert.equal(classifySkill('po', [deliv('po', 'procesado', CANCEL)], new Set()).status, 'cancelled');
+});
+test('classifySkill: rechazado → rejected', () => {
+    assert.equal(classifySkill('po', [deliv('po', 'listo', RECHAZO)], new Set()).status, 'rejected');
+});
+test('classifySkill: presente sin resultado → corrupt', () => {
+    assert.equal(classifySkill('po', [deliv('po', 'listo', CORRUPT)], new Set()).status, 'corrupt');
+});
+test('classifySkill: ausente → missing', () => {
+    assert.equal(classifySkill('ux', [deliv('po', 'listo', APROB)], new Set()).status, 'missing');
+});
+test('classifySkill: en pendiente/trabajando → live (gana sobre todo)', () => {
+    assert.equal(classifySkill('po', [deliv('po', 'listo', APROB)], new Set(['po'])).status, 'live');
+});
+test('classifySkill: prioridad listo(aprobado) > procesado(cancelado)', () => {
+    const dels = [deliv('po', 'procesado', CANCEL), deliv('po', 'listo', APROB)];
+    assert.equal(classifySkill('po', dels, new Set()).status, 'done');
+});
+test('classifySkill: archivado aprobado cuenta como done', () => {
+    assert.equal(classifySkill('po', [deliv('po', 'archivado', APROB)], new Set()).status, 'done');
+});
+test('classifySkill: archivado cancelado NO es done', () => {
+    assert.equal(classifySkill('po', [deliv('po', 'archivado', CANCEL)], new Set()).status, 'cancelled');
+});
+
+// ─── analyzeStuckIssue: no-stuck ────────────────────────────────────────────
+test('completo → none', () => {
+    const r = analyzeStuckIssue({
+        requiredSkills: ['po', 'ux', 'guru'],
+        deliverables: [deliv('po', 'listo', APROB), deliv('ux', 'listo', APROB), deliv('guru', 'listo', APROB)],
+        nowMs: NOW,
+    });
+    assert.deepEqual([r.stuck, r.action], [false, 'none']);
+});
+test('hay trabajo vivo → none (no interferir)', () => {
+    const r = analyzeStuckIssue({
+        requiredSkills: ['po', 'ux'],
+        deliverables: [deliv('po', 'listo', APROB)],
+        liveSkills: ['ux'],
+        nowMs: NOW,
+    });
+    assert.equal(r.action, 'none');
+    assert.equal(r.reason, 'trabajo-vivo');
+});
+test('deliverable reciente (< threshold) → none (darle tiempo)', () => {
+    const r = analyzeStuckIssue({
+        requiredSkills: ['po', 'ux'],
+        deliverables: [deliv('po', 'listo', APROB, RECENT), deliv('ux', 'procesado', CANCEL, RECENT)],
+        nowMs: NOW,
+    });
+    assert.equal(r.action, 'none');
+    assert.equal(r.reason, 'reciente');
+});
+test('sin deliverables → none (lo maneja el intake)', () => {
+    const r = analyzeStuckIssue({ requiredSkills: ['po'], deliverables: [], nowMs: NOW });
+    assert.equal(r.action, 'none');
+});
+test('sin skills requeridos → none', () => {
+    const r = analyzeStuckIssue({ requiredSkills: [], deliverables: [deliv('po', 'listo', APROB)], nowMs: NOW });
+    assert.equal(r.action, 'none');
+});
+
+// ─── analyzeStuckIssue: requeue ─────────────────────────────────────────────
+test('CASO #4534: guru aprobado + po/ux cancelados (stale) → ESCALATE (cancelado = ambiguo)', () => {
+    const r = analyzeStuckIssue({
+        requiredSkills: ['po', 'ux', 'guru'],
+        deliverables: [
+            deliv('guru', 'listo', APROB),
+            deliv('po', 'procesado', CANCEL),
+            deliv('ux', 'procesado', CANCEL),
+        ],
+        nowMs: NOW,
+    });
+    assert.equal(r.action, 'escalate', 'un cancelado implica rechazo previo → humano decide, no re-encolar a ciegas');
+    assert.match(r.reason, /cancel/);
+});
+test('CASO #4507: review aprobado + po/architect archivado-aprobado + ux faltante → requeue [ux]', () => {
+    const r = analyzeStuckIssue({
+        requiredSkills: ['review', 'po', 'ux', 'architect'],
+        deliverables: [
+            deliv('review', 'listo', APROB),
+            deliv('po', 'archivado', APROB),
+            deliv('architect', 'archivado', APROB),
+        ],
+        nowMs: NOW,
+    });
+    assert.equal(r.action, 'requeue');
+    assert.deepEqual(r.requeueSkills, ['ux']);
+});
+test('skill missing (stale, no live) → requeue', () => {
+    const r = analyzeStuckIssue({
+        requiredSkills: ['po', 'ux'],
+        deliverables: [deliv('po', 'listo', APROB)],
+        nowMs: NOW,
+    });
+    assert.equal(r.action, 'requeue');
+    assert.deepEqual(r.requeueSkills, ['ux']);
+});
+test('skill corrupto (sin resultado) → ESCALATE (indeterminado, no re-correr a ciegas)', () => {
+    const r = analyzeStuckIssue({
+        requiredSkills: ['po', 'ux'],
+        deliverables: [deliv('po', 'listo', APROB), deliv('ux', 'listo', CORRUPT)],
+        nowMs: NOW,
+    });
+    assert.equal(r.action, 'escalate');
+});
+test('mixto: faltante + cancelado → ESCALATE (la ambigüedad gana sobre requeue)', () => {
+    const r = analyzeStuckIssue({
+        requiredSkills: ['po', 'ux', 'guru'],
+        deliverables: [deliv('po', 'listo', APROB), deliv('ux', 'procesado', CANCEL)], // guru missing
+        nowMs: NOW,
+    });
+    assert.equal(r.action, 'escalate', 'si hay cualquier ambigüedad, no auto-remediar parcial');
+});
+
+// ─── analyzeStuckIssue: escalate ────────────────────────────────────────────
+test('rechazo REAL → escalate (NO re-encolar, evita loop)', () => {
+    const r = analyzeStuckIssue({
+        requiredSkills: ['po', 'ux'],
+        deliverables: [deliv('po', 'listo', APROB), deliv('ux', 'listo', RECHAZO)],
+        nowMs: NOW,
+    });
+    assert.equal(r.action, 'escalate');
+    assert.match(r.reason, /rechazo/);
+});
+test('rechazo + faltante → escalate gana (el rechazo manda)', () => {
+    const r = analyzeStuckIssue({
+        requiredSkills: ['po', 'ux', 'guru'],
+        deliverables: [deliv('po', 'listo', RECHAZO)],
+        nowMs: NOW,
+    });
+    assert.equal(r.action, 'escalate');
+});
+
+// ─── boundaries ─────────────────────────────────────────────────────────────
+test('boundary: 1ms bajo el threshold → none (aún no stale)', () => {
+    const r = analyzeStuckIssue({
+        requiredSkills: ['po', 'ux'],
+        deliverables: [deliv('po', 'listo', APROB, NOW - DEFAULT_STALE_THRESHOLD_MS + 1)],
+        nowMs: NOW,
+    });
+    assert.equal(r.action, 'none', 'edad < threshold no es stale');
+});
+test('boundary: exactamente en el threshold → stale (age >= threshold)', () => {
+    const r = analyzeStuckIssue({
+        requiredSkills: ['po', 'ux'],
+        deliverables: [deliv('po', 'listo', APROB, NOW - DEFAULT_STALE_THRESHOLD_MS)],
+        nowMs: NOW,
+    });
+    assert.equal(r.stuck, true);
+    assert.equal(r.action, 'requeue');
+});
+test('threshold custom respetado', () => {
+    const r = analyzeStuckIssue({
+        requiredSkills: ['po', 'ux'],
+        deliverables: [deliv('po', 'listo', APROB, NOW - 5 * 60 * 1000)],
+        nowMs: NOW,
+        staleThresholdMs: 3 * 60 * 1000,
+    });
+    assert.equal(r.action, 'requeue', '5min > threshold custom de 3min');
+});
+
+// ─── robustez de inputs ─────────────────────────────────────────────────────
+test('inputs vacíos/undefined no tiran', () => {
+    assert.doesNotThrow(() => analyzeStuckIssue());
+    assert.doesNotThrow(() => analyzeStuckIssue({ requiredSkills: ['po'], deliverables: null, nowMs: NOW }));
+    assert.doesNotThrow(() => analyzeStuckIssue({ requiredSkills: ['po'], deliverables: [{ skill: 'po' }], nowMs: NOW }));
+});
+test('yaml faltante en deliverable no tira y cuenta como corrupt → escalate', () => {
+    const r = analyzeStuckIssue({
+        requiredSkills: ['po'],
+        deliverables: [{ skill: 'po', state: 'listo', mtimeMs: OLD }], // sin yaml
+        nowMs: NOW,
+    });
+    assert.equal(r.action, 'escalate'); // corrupt → indeterminado → humano
+});

--- a/.pipeline/lib/stuck-phase-reconciler-runner.js
+++ b/.pipeline/lib/stuck-phase-reconciler-runner.js
@@ -1,0 +1,142 @@
+// =============================================================================
+// stuck-phase-reconciler-runner.js — Integración FS del reconciler de fases
+// varadas (#4614). Arma el CONTEXTO real (deliverables + liveness + cross-phase
+// + retry state) desde el filesystem del pipeline y ejecuta el plan.
+//
+// Todo el IO entra por `deps` inyectables → el flujo end-to-end se testea con
+// mocks, sin tocar el FS real. `pulpo.js` cablea los deps reales y lo llama en
+// un tick throttled.
+//
+// Liveness (Arq P1-3): un `pendiente/` siempre cuenta como vivo; un `trabajando/`
+// cuenta como vivo SOLO si `deps.livenessOk(name, mtimeMs)` (mtime reciente / PID
+// vivo). Un `trabajando/` huérfano de agente muerto NO cuenta → la fase se cura.
+// =============================================================================
+
+'use strict';
+
+const { planReconciliation, executeDecisions } = require('./stuck-phase-reconciler');
+
+const DELIVERABLE_STATES = ['listo', 'procesado', 'archivado'];
+const LIVE_STATES = ['pendiente', 'trabajando'];
+
+function issueFromName(name) { return String(name).split('.')[0]; }
+function skillFromName(name) { const p = String(name).split('.'); return p.length > 1 ? p[1] : null; }
+
+/**
+ * Arma el contexto de issues varados desde el FS (vía deps).
+ * @returns {Array} issues para planReconciliation
+ */
+function buildIssuesContext(deps) {
+    const out = [];
+    const phases = Array.isArray(deps.parallelPhases) ? deps.parallelPhases : [];
+
+    for (const { pipeline, fase } of phases) {
+        const required = deps.requiredSkillsFor(pipeline, fase);
+        if (!Array.isArray(required) || required.length === 0) continue;
+
+        const map = new Map(); // issue → { deliverables:[], liveSkills:Set }
+        const ensure = (issue) => {
+            if (!map.has(issue)) map.set(issue, { deliverables: [], liveSkills: new Set() });
+            return map.get(issue);
+        };
+
+        // Deliverables (listo/procesado/archivado).
+        for (const state of DELIVERABLE_STATES) {
+            for (const f of (deps.listPhaseFiles(pipeline, fase, state) || [])) {
+                const issue = issueFromName(f.name);
+                const skill = skillFromName(f.name);
+                if (!issue || !skill) continue;
+                ensure(issue).deliverables.push({
+                    skill, state,
+                    yaml: deps.readYaml(pipeline, fase, state, f.name),
+                    mtimeMs: f.mtimeMs,
+                });
+            }
+        }
+
+        // Live skills: pendiente siempre vivo; trabajando solo si liveness OK.
+        for (const state of LIVE_STATES) {
+            for (const f of (deps.listPhaseFiles(pipeline, fase, state) || [])) {
+                const issue = issueFromName(f.name);
+                const skill = skillFromName(f.name);
+                if (!issue || !skill) continue;
+                const alive = state === 'pendiente' || deps.livenessOk(f.name, f.mtimeMs);
+                if (!alive) continue; // trabajando huérfano → no cuenta (P1-3)
+                ensure(issue).liveSkills.add(skill);
+            }
+        }
+
+        for (const [issue, data] of map) {
+            // Un issue sin deliverables (solo pendiente/trabajando) lo maneja el
+            // flujo normal, no el reconciler.
+            if (data.deliverables.length === 0) continue;
+            const retryKey = `${issue}|${fase}`;
+            out.push({
+                issue: Number(issue),
+                pipeline, fase,
+                requiredSkills: required,
+                deliverables: data.deliverables,
+                liveSkills: data.liveSkills,
+                liveElsewhere: !!deps.issueLiveElsewhere(issue, pipeline, fase),
+                hasNeedsHuman: !!deps.hasNeedsHuman(issue),
+                retryCounts: (deps.retryState && deps.retryState[retryKey]) || {},
+                allowed: deps.isAllowed ? !!deps.isAllowed(issue) : true,
+                isMonoSkill: false, // los phases mono-skill no se pasan en parallelPhases
+            });
+        }
+    }
+    return out;
+}
+
+/**
+ * Corre una pasada del reconciler. Deps inyectables (ver pulpo.js para el cableado).
+ * @returns {{requeued:number, escalated:number, skipped:number, decisions:Array}}
+ */
+function runStuckPhaseReconciler(deps, opts = {}) {
+    deps.retryState = (deps.loadRetryState && deps.loadRetryState()) || {};
+
+    const issues = buildIssuesContext(deps);
+    if (issues.length === 0) {
+        return { requeued: 0, escalated: 0, skipped: 0, decisions: [] };
+    }
+
+    const { decisions, retryUpdates } = planReconciliation({
+        issues,
+        nowMs: Number.isFinite(deps.nowMs) ? deps.nowMs : Date.now(),
+        paused: deps.isPaused ? !!deps.isPaused() : false,
+        maxRequeueAttempts: opts.maxRequeueAttempts,
+        capPerTick: opts.capPerTick,
+        staleThresholdMs: opts.staleThresholdMs,
+    });
+
+    const summary = executeDecisions(decisions, {
+        requeueWorkItem: deps.requeueWorkItem,
+        escalate: deps.escalate,
+        notify: deps.notify,
+        audit: deps.audit,
+        workItemExists: deps.workItemExists,
+    });
+
+    // Persistir contadores de reintento (merge). Clave de retryUpdates:
+    // `${issue}|${fase}|${skill}` → nuevo count.
+    let changed = false;
+    for (const [key, val] of Object.entries(retryUpdates)) {
+        const idx1 = key.indexOf('|');
+        const idx2 = key.indexOf('|', idx1 + 1);
+        const issue = key.slice(0, idx1);
+        const fase = key.slice(idx1 + 1, idx2);
+        const skill = key.slice(idx2 + 1);
+        const k = `${issue}|${fase}`;
+        deps.retryState[k] = deps.retryState[k] || {};
+        deps.retryState[k][skill] = val;
+        changed = true;
+    }
+    // Limpieza: al re-encolar o escalar exitosamente, los contadores viejos de un
+    // issue que ya salió de la fase se podan por el caller (no acá) para no perder
+    // el histórico dentro de una misma corrida.
+    if (changed && deps.saveRetryState) deps.saveRetryState(deps.retryState);
+
+    return { ...summary, decisions };
+}
+
+module.exports = { runStuckPhaseReconciler, buildIssuesContext };

--- a/.pipeline/lib/stuck-phase-reconciler-runner.js
+++ b/.pipeline/lib/stuck-phase-reconciler-runner.js
@@ -81,6 +81,9 @@ function buildIssuesContext(deps) {
                 hasNeedsHuman: !!deps.hasNeedsHuman(issue),
                 retryCounts: (deps.retryState && deps.retryState[retryKey]) || {},
                 allowed: deps.isAllowed ? !!deps.isAllowed(issue) : true,
+                // active: solo actuar sobre issues confirmados OPEN (no residuo
+                // de cerrados). Sin dep → asume activo (para tests puros).
+                active: deps.isIssueOpen ? !!deps.isIssueOpen(issue) : true,
                 isMonoSkill: false, // los phases mono-skill no se pasan en parallelPhases
             });
         }

--- a/.pipeline/lib/stuck-phase-reconciler-runner.test.js
+++ b/.pipeline/lib/stuck-phase-reconciler-runner.test.js
@@ -1,0 +1,172 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { runStuckPhaseReconciler, buildIssuesContext } = require('./stuck-phase-reconciler-runner');
+
+const NOW = 1_800_000_000_000;
+const OLD = NOW - 30 * 60 * 1000;
+const APROB = { resultado: 'aprobado' };
+const CANCEL = { cancelado_por: 'fast-fail-rebote' };
+
+// FS mock: fs[pipeline][fase][state] = { 'issue.skill': {yaml, mtimeMs} }
+function makeDeps(fs, over = {}) {
+    const calls = { requeue: [], escalate: [], notify: [], audit: [] };
+    const retryState = over.retryState || {};
+    const deps = {
+        calls,
+        nowMs: NOW,
+        parallelPhases: over.parallelPhases || [
+            { pipeline: 'desarrollo', fase: 'validacion' },
+            { pipeline: 'desarrollo', fase: 'aprobacion' },
+        ],
+        requiredSkillsFor: over.requiredSkillsFor || ((p, f) => ({
+            validacion: ['po', 'ux', 'guru'],
+            aprobacion: ['review', 'po', 'ux', 'architect'],
+        }[f] || [])),
+        listPhaseFiles: (p, f, state) => {
+            const d = (((fs[p] || {})[f] || {})[state]) || {};
+            return Object.keys(d).map((name) => ({ name, mtimeMs: d[name].mtimeMs }));
+        },
+        readYaml: (p, f, state, name) => (((fs[p] || {})[f] || {})[state] || {})[name].yaml,
+        issueLiveElsewhere: over.issueLiveElsewhere || (() => false),
+        hasNeedsHuman: over.hasNeedsHuman || (() => false),
+        isAllowed: over.isAllowed || (() => true),
+        isPaused: over.isPaused || (() => false),
+        livenessOk: over.livenessOk || (() => true), // por default trabajando cuenta vivo
+        loadRetryState: () => retryState,
+        saveRetryState: (s) => { deps._savedRetry = s; },
+        requeueWorkItem: (p, f, s, i) => calls.requeue.push(`${i}.${s}@${f}`),
+        escalate: (i, r) => calls.escalate.push({ i, r }),
+        workItemExists: over.workItemExists || (() => false),
+        notify: (m) => calls.notify.push(m),
+        audit: (rec) => calls.audit.push(rec),
+    };
+    return deps;
+}
+
+test('E2E #4507: ux faltante en aprobacion → requeue ux', () => {
+    const fs = { desarrollo: { aprobacion: {
+        listo: { '4507.review': { yaml: APROB, mtimeMs: OLD } },
+        archivado: {
+            '4507.po': { yaml: APROB, mtimeMs: OLD },
+            '4507.architect': { yaml: APROB, mtimeMs: OLD },
+        },
+    } } };
+    const deps = makeDeps(fs);
+    const res = runStuckPhaseReconciler(deps, {});
+    assert.equal(res.requeued, 1);
+    assert.deepEqual(deps.calls.requeue, ['4507.ux@aprobacion']);
+    assert.equal(deps.calls.escalate.length, 0);
+    assert.equal(deps._savedRetry['4507|aprobacion'].ux, 1, 'contador de reintento persistido');
+});
+
+test('E2E #4534: po/ux cancelados en validacion → escalate (no requeue)', () => {
+    const fs = { desarrollo: { validacion: {
+        listo: { '4534.guru': { yaml: APROB, mtimeMs: OLD } },
+        procesado: {
+            '4534.po': { yaml: CANCEL, mtimeMs: OLD },
+            '4534.ux': { yaml: CANCEL, mtimeMs: OLD },
+        },
+    } } };
+    const deps = makeDeps(fs);
+    const res = runStuckPhaseReconciler(deps, {});
+    assert.equal(res.escalated, 1);
+    assert.equal(res.requeued, 0);
+    assert.equal(deps.calls.escalate[0].i, '4534');
+    assert.equal(deps.calls.requeue.length, 0);
+});
+
+test('E2E cross-phase: issue vivo en otra fase → none (no doble-track)', () => {
+    const fs = { desarrollo: { validacion: {
+        listo: { '4534.guru': { yaml: APROB, mtimeMs: OLD } },
+        procesado: { '4534.po': { yaml: CANCEL, mtimeMs: OLD }, '4534.ux': { yaml: CANCEL, mtimeMs: OLD } },
+    } } };
+    const deps = makeDeps(fs, { issueLiveElsewhere: (i) => String(i) === '4534' });
+    const res = runStuckPhaseReconciler(deps, {});
+    assert.equal(res.requeued, 0);
+    assert.equal(res.escalated, 0);
+});
+
+test('E2E orphan trabajando: marker de agente muerto NO cuenta vivo → cura el faltante', () => {
+    const fs = { desarrollo: { validacion: {
+        listo: { '200.po': { yaml: APROB, mtimeMs: OLD }, '200.guru': { yaml: APROB, mtimeMs: OLD } },
+        trabajando: { '200.ux': { yaml: {}, mtimeMs: OLD } }, // ux "trabajando" pero huérfano
+    } } };
+    // livenessOk=false → el trabajando huérfano no cuenta → ux queda missing → requeue
+    const deps = makeDeps(fs, { livenessOk: () => false });
+    const res = runStuckPhaseReconciler(deps, {});
+    assert.equal(res.requeued, 1);
+    assert.deepEqual(deps.calls.requeue, ['200.ux@validacion']);
+});
+
+test('E2E orphan trabajando VIVO: si el agente está vivo → none (no interferir)', () => {
+    const fs = { desarrollo: { validacion: {
+        listo: { '200.po': { yaml: APROB, mtimeMs: OLD }, '200.guru': { yaml: APROB, mtimeMs: OLD } },
+        trabajando: { '200.ux': { yaml: {}, mtimeMs: NOW - 1000 } },
+    } } };
+    const deps = makeDeps(fs, { livenessOk: () => true }); // agente vivo
+    const res = runStuckPhaseReconciler(deps, {});
+    assert.equal(res.requeued, 0);
+    assert.equal(res.skipped >= 1, true);
+});
+
+test('E2E cap reintentos persistido: ux ya en 2 → escalate en vez de requeue', () => {
+    const fs = { desarrollo: { aprobacion: {
+        listo: { '4507.review': { yaml: APROB, mtimeMs: OLD } },
+        archivado: { '4507.po': { yaml: APROB, mtimeMs: OLD }, '4507.architect': { yaml: APROB, mtimeMs: OLD } },
+    } } };
+    const deps = makeDeps(fs, { retryState: { '4507|aprobacion': { ux: 2 } } });
+    const res = runStuckPhaseReconciler(deps, {});
+    assert.equal(res.escalated, 1);
+    assert.equal(res.requeued, 0);
+    assert.match(deps.calls.escalate[0].r, /tope de reintentos/);
+});
+
+test('E2E pausa: no re-encola', () => {
+    const fs = { desarrollo: { aprobacion: {
+        listo: { '4507.review': { yaml: APROB, mtimeMs: OLD } },
+        archivado: { '4507.po': { yaml: APROB, mtimeMs: OLD }, '4507.architect': { yaml: APROB, mtimeMs: OLD } },
+    } } };
+    const deps = makeDeps(fs, { isPaused: () => true });
+    const res = runStuckPhaseReconciler(deps, {});
+    assert.equal(res.requeued, 0);
+});
+
+test('E2E idempotente: si el work-item ya existe, no re-escribe', () => {
+    const fs = { desarrollo: { aprobacion: {
+        listo: { '4507.review': { yaml: APROB, mtimeMs: OLD } },
+        archivado: { '4507.po': { yaml: APROB, mtimeMs: OLD }, '4507.architect': { yaml: APROB, mtimeMs: OLD } },
+    } } };
+    const deps = makeDeps(fs, { workItemExists: () => true });
+    runStuckPhaseReconciler(deps, {});
+    assert.equal(deps.calls.requeue.length, 0);
+});
+
+test('E2E completo: nada varado → sin acciones', () => {
+    const fs = { desarrollo: { validacion: {
+        listo: { '300.po': { yaml: APROB, mtimeMs: OLD }, '300.ux': { yaml: APROB, mtimeMs: OLD }, '300.guru': { yaml: APROB, mtimeMs: OLD } },
+    } } };
+    const deps = makeDeps(fs);
+    const res = runStuckPhaseReconciler(deps, {});
+    assert.equal(res.requeued, 0);
+    assert.equal(res.escalated, 0);
+});
+
+test('buildIssuesContext: no incluye issues sin deliverables (solo pendiente)', () => {
+    const fs = { desarrollo: { validacion: {
+        pendiente: { '400.po': { yaml: {}, mtimeMs: NOW } },
+    } } };
+    const deps = makeDeps(fs);
+    const ctx = buildIssuesContext(deps);
+    assert.equal(ctx.length, 0, 'un issue solo-pendiente lo maneja el flujo normal');
+});
+
+test('E2E deliverable reciente → none (ventana de gracia)', () => {
+    const fs = { desarrollo: { aprobacion: {
+        listo: { '4507.review': { yaml: APROB, mtimeMs: NOW - 60 * 1000 } }, // 1 min
+        archivado: { '4507.po': { yaml: APROB, mtimeMs: NOW - 60 * 1000 }, '4507.architect': { yaml: APROB, mtimeMs: NOW - 60 * 1000 } },
+    } } };
+    const deps = makeDeps(fs);
+    const res = runStuckPhaseReconciler(deps, {});
+    assert.equal(res.requeued, 0, 'muy reciente, darle tiempo');
+});

--- a/.pipeline/lib/stuck-phase-reconciler-runner.test.js
+++ b/.pipeline/lib/stuck-phase-reconciler-runner.test.js
@@ -31,6 +31,7 @@ function makeDeps(fs, over = {}) {
         issueLiveElsewhere: over.issueLiveElsewhere || (() => false),
         hasNeedsHuman: over.hasNeedsHuman || (() => false),
         isAllowed: over.isAllowed || (() => true),
+        isIssueOpen: over.isIssueOpen || (() => true),
         isPaused: over.isPaused || (() => false),
         livenessOk: over.livenessOk || (() => true), // por default trabajando cuenta vivo
         loadRetryState: () => retryState,
@@ -142,6 +143,15 @@ test('E2E idempotente: si el work-item ya existe, no re-escribe', () => {
     assert.equal(deps.calls.requeue.length, 0);
 });
 
+test('E2E issue CERRADO con residuo → none (no escala issues cerrados)', () => {
+    const fs = { desarrollo: { validacion: {
+        archivado: { '4510.po': { yaml: {}, mtimeMs: OLD }, '4510.ux': { yaml: {}, mtimeMs: OLD }, '4510.guru': { yaml: {}, mtimeMs: OLD } },
+    } } };
+    const deps = makeDeps(fs, { isIssueOpen: () => false }); // cerrado
+    const res = runStuckPhaseReconciler(deps, {});
+    assert.equal(res.escalated, 0);
+    assert.equal(res.requeued, 0);
+});
 test('E2E completo: nada varado → sin acciones', () => {
     const fs = { desarrollo: { validacion: {
         listo: { '300.po': { yaml: APROB, mtimeMs: OLD }, '300.ux': { yaml: APROB, mtimeMs: OLD }, '300.guru': { yaml: APROB, mtimeMs: OLD } },

--- a/.pipeline/lib/stuck-phase-reconciler.js
+++ b/.pipeline/lib/stuck-phase-reconciler.js
@@ -1,0 +1,196 @@
+// =============================================================================
+// stuck-phase-reconciler.js — Reconciliador de fases varadas (#4614, parte B de
+// #4612). Envuelve al detector puro (`stuck-phase-detector`) con TODAS las
+// guardas de seguridad exigidas por el review de arquitecto + PO antes de tocar
+// el estado real del pipeline.
+//
+// Separado en dos capas para testeo exhaustivo:
+//   1. `planReconciliation(ctx)`  → PURO. Dado el estado completo (issues +
+//      deliverables + liveness + retry counts + flags), produce una lista de
+//      DECISIONES (`requeue`/`escalate`/`none`). Sin IO. Acá viven las guardas.
+//   2. `executeDecisions(decisions, deps)` → shell de IO (escribe work-items,
+//      escala needs-human, notifica, audita). Deps inyectables → mockeable.
+//
+// GUARDAS (review):
+//   - Cross-phase (Arq P0-2): issue vivo en OTRA fase → `none` (evita doble-track
+//     con el issue que ya rebotó a `dev`).
+//   - Mono-skill (Arq P0-1): fases `dev`/`build`/`entrega` corren 1 solo skill
+//     ruteado por labels → el reconciler NO las toca (evita lanzar devs errados).
+//   - Cap de reintentos persistente (Arq P0-3 + PO SG-1): máx N requeue por
+//     (issue,fase,skill); al agotarse → `escalate`. El contador lo persiste el
+//     shell (sobrevive restarts).
+//   - Dedupe de escalate (Arq P1-1): no re-escalar si ya tiene `needs-human`.
+//   - Cap por tick + orden determinista (Arq P2-3 + PO SG-4): máx N acciones por
+//     corrida, issues en orden asc (sin starvation).
+//   - Respetar pausa/allowlist (PO SG-5): en `.paused` o fuera de allowlist NO
+//     re-encola (no spawnea agentes); escalar/notificar sí está permitido.
+//   - Liveness real (Arq P1-3): el shell construye `liveSkills`/`liveElsewhere`
+//     validando mtime/PID; un `trabajando/` huérfano NO cuenta como vivo.
+//   - Nunca fabricar aprobaciones (PO línea roja): solo re-encola (re-corre el
+//     agente) o escala; jamás escribe `resultado: aprobado`.
+// =============================================================================
+
+'use strict';
+
+const { analyzeStuckIssue } = require('./stuck-phase-detector');
+
+const DEFAULT_MAX_REQUEUE_ATTEMPTS = 2;
+const DEFAULT_CAP_PER_TICK = 5;
+const MONO_SKILL_PHASES = new Set(['dev', 'build', 'entrega']);
+
+/**
+ * Decide la acción efectiva para UN issue aplicando las guardas.
+ * @returns {{action:'requeue'|'escalate'|'none', skills?:string[], reason:string, consumesTick:boolean}}
+ */
+function decideForIssue(it, cfg) {
+    const base = (action, reason, extra) => ({ action, reason, consumesTick: false, ...extra });
+
+    // Guard mono-skill (Arq P0-1)
+    if (cfg.monoSkillPhases.has(it.fase) || it.isMonoSkill) {
+        return base('none', 'fase-mono-skill');
+    }
+    // Guard cross-phase (Arq P0-2)
+    if (it.liveElsewhere) {
+        return base('none', 'vivo-en-otra-fase');
+    }
+
+    const analysis = analyzeStuckIssue({
+        requiredSkills: it.requiredSkills || [],
+        deliverables: it.deliverables || [],
+        liveSkills: it.liveSkills || new Set(),
+        nowMs: cfg.nowMs,
+        staleThresholdMs: Number.isFinite(it.staleThresholdMs) ? it.staleThresholdMs : cfg.staleThresholdMs,
+    });
+
+    if (analysis.action === 'none') return base('none', analysis.reason);
+
+    if (analysis.action === 'escalate') {
+        if (it.hasNeedsHuman) return base('none', 'ya-escalado (dedupe)');
+        return base('escalate', analysis.reason, { consumesTick: true });
+    }
+
+    // requeue
+    const retryCounts = it.retryCounts || {};
+    const skills = analysis.requeueSkills || [];
+    const capped = skills.filter((s) => (retryCounts[s] || 0) >= cfg.maxRequeueAttempts);
+    if (capped.length > 0) {
+        // Skill(s) agotaron reintentos → escalar (no re-encolar para siempre, Arq P0-3).
+        if (it.hasNeedsHuman) return base('none', 'tope-reintentos + ya-escalado (dedupe)');
+        return base('escalate', `tope de reintentos (${cfg.maxRequeueAttempts}) alcanzado para: ${capped.join(',')}`, { consumesTick: true });
+    }
+    // Pausa / allowlist: no re-encolar (no spawnear), PO SG-5.
+    if (cfg.paused) return base('none', 'pipeline-en-pausa (no re-encola)');
+    if (it.allowed === false) return base('none', 'issue-fuera-de-allowlist (no re-encola)');
+
+    return base('requeue', analysis.reason, { skills, consumesTick: true });
+}
+
+/**
+ * PURO: plan de reconciliación para un set de issues varados.
+ * @param {object} ctx
+ * @param {Array} ctx.issues  [{issue,pipeline,fase,requiredSkills,deliverables,liveSkills,liveElsewhere,hasNeedsHuman,retryCounts,isMonoSkill,allowed,staleThresholdMs}]
+ * @param {number} [ctx.nowMs]
+ * @param {number} [ctx.staleThresholdMs]
+ * @param {number} [ctx.maxRequeueAttempts]
+ * @param {number} [ctx.capPerTick]
+ * @param {boolean} [ctx.paused]
+ * @param {Set<string>} [ctx.monoSkillPhases]
+ * @returns {{decisions:Array, retryUpdates:object}}
+ */
+function planReconciliation(ctx = {}) {
+    const cfg = {
+        nowMs: Number.isFinite(ctx.nowMs) ? ctx.nowMs : Date.now(),
+        staleThresholdMs: ctx.staleThresholdMs,
+        maxRequeueAttempts: Number.isFinite(ctx.maxRequeueAttempts) && ctx.maxRequeueAttempts > 0 ? ctx.maxRequeueAttempts : DEFAULT_MAX_REQUEUE_ATTEMPTS,
+        capPerTick: Number.isFinite(ctx.capPerTick) && ctx.capPerTick > 0 ? ctx.capPerTick : DEFAULT_CAP_PER_TICK,
+        paused: !!ctx.paused,
+        monoSkillPhases: ctx.monoSkillPhases instanceof Set ? ctx.monoSkillPhases : MONO_SKILL_PHASES,
+    };
+
+    const issues = Array.isArray(ctx.issues) ? ctx.issues : [];
+    // Orden determinista por número de issue asc (evita starvation bajo cap).
+    const sorted = [...issues].sort((a, b) => Number(a.issue) - Number(b.issue));
+
+    const decisions = [];
+    const retryUpdates = {};
+    let actionsThisTick = 0;
+
+    for (const it of sorted) {
+        const base = { issue: it.issue, pipeline: it.pipeline, fase: it.fase };
+        const d = decideForIssue(it, cfg);
+
+        // Cap por tick: solo las acciones REALES (escalate/requeue) consumen cupo.
+        if (d.consumesTick && actionsThisTick >= cfg.capPerTick) {
+            decisions.push({ ...base, action: 'none', reason: 'cap-por-tick-alcanzado' });
+            continue;
+        }
+
+        decisions.push({ ...base, action: d.action, skills: d.skills, reason: d.reason });
+        if (d.consumesTick) {
+            actionsThisTick += 1;
+            if (d.action === 'requeue') {
+                for (const s of (d.skills || [])) {
+                    retryUpdates[`${it.issue}|${it.fase}|${s}`] = ((it.retryCounts || {})[s] || 0) + 1;
+                }
+            }
+        }
+    }
+
+    return { decisions, retryUpdates };
+}
+
+/**
+ * Shell de IO: ejecuta las decisiones vía deps inyectables. NUNCA fabrica
+ * aprobaciones. Cada dep es best-effort: un fallo no aborta el resto.
+ * @param {Array} decisions  salida de planReconciliation
+ * @param {object} deps
+ *   @param {(pipeline,fase,skill,issue)=>void} deps.requeueWorkItem  (idempotente por nombre)
+ *   @param {(issue,reason)=>void} deps.escalate  (agrega needs-human, idempotente)
+ *   @param {(msg)=>void} [deps.notify]
+ *   @param {(record)=>void} [deps.audit]
+ *   @param {(pipeline,fase,skill,issue)=>boolean} [deps.workItemExists] re-check idempotente
+ * @returns {{requeued:number, escalated:number, skipped:number}}
+ */
+function executeDecisions(decisions, deps = {}) {
+    let requeued = 0, escalated = 0, skipped = 0;
+    const audit = (rec) => { try { if (deps.audit) deps.audit(rec); } catch { /* best-effort */ } };
+    const notify = (msg) => { try { if (deps.notify) deps.notify(msg); } catch { /* best-effort */ } };
+
+    for (const d of (decisions || [])) {
+        if (d.action === 'requeue') {
+            for (const skill of (d.skills || [])) {
+                try {
+                    // Re-check idempotente justo antes de escribir (Arq P1-2): no
+                    // duplicar si ya existe el work-item (agente arrancó en paralelo).
+                    if (deps.workItemExists && deps.workItemExists(d.pipeline, d.fase, skill, d.issue)) continue;
+                    deps.requeueWorkItem(d.pipeline, d.fase, skill, d.issue);
+                } catch (e) {
+                    audit({ ...d, skill, error: String(e && e.message).slice(0, 120) });
+                    continue;
+                }
+            }
+            requeued += 1;
+            audit({ action: 'requeue', issue: d.issue, fase: d.fase, skills: d.skills, reason: d.reason });
+            notify(`🔧 Self-healing: re-encolé ${(d.skills || []).join(',')} de #${d.issue} (${d.fase}) — ${d.reason}`);
+        } else if (d.action === 'escalate') {
+            try { deps.escalate(d.issue, d.reason); } catch (e) { audit({ ...d, error: String(e && e.message).slice(0, 120) }); }
+            escalated += 1;
+            audit({ action: 'escalate', issue: d.issue, fase: d.fase, reason: d.reason });
+            notify(`🙋 Self-healing: #${d.issue} (${d.fase}) necesita tu decisión — ${d.reason}`);
+        } else {
+            skipped += 1;
+            // Los `none` se auditan a nivel debug (razón) pero no notifican.
+            audit({ action: 'none', issue: d.issue, fase: d.fase, reason: d.reason });
+        }
+    }
+    return { requeued, escalated, skipped };
+}
+
+module.exports = {
+    planReconciliation,
+    executeDecisions,
+    decideForIssue,
+    MONO_SKILL_PHASES,
+    DEFAULT_MAX_REQUEUE_ATTEMPTS,
+    DEFAULT_CAP_PER_TICK,
+};

--- a/.pipeline/lib/stuck-phase-reconciler.js
+++ b/.pipeline/lib/stuck-phase-reconciler.js
@@ -53,6 +53,21 @@ function decideForIssue(it, cfg) {
     if (it.liveElsewhere) {
         return base('none', 'vivo-en-otra-fase');
     }
+    // Guard allowlist: solo la OLA ACTUAL. Los issues fuera de la allowlist son
+    // backlog dormido que el operador excluyó a propósito — el reconciler NO los
+    // toca (ni requeue ni escalate), sino spamea needs-human sobre issues muertos.
+    // (Hallazgo del dry-run contra estado real; endurece PO SG-5.)
+    if (it.allowed === false) {
+        return base('none', 'fuera-de-allowlist (backlog dormido, no tocar)');
+    }
+    // Guard issue-cerrado: las fases se llenan de RESIDUO de issues ya CLOSED/
+    // mergeados (work-items stub). Escalar/re-encolar un issue cerrado es ruido.
+    // Actuar SOLO sobre issues confirmados OPEN. `active !== true` (cerrado,
+    // notFound, o desconocido) → no tocar. (Hallazgo del dry-run: #4510/#4533/#4536
+    // CLOSED con residuo se escalaban.)
+    if (it.active !== true) {
+        return base('none', 'issue-cerrado-o-inactivo (residuo, no tocar)');
+    }
 
     const analysis = analyzeStuckIssue({
         requiredSkills: it.requiredSkills || [],
@@ -78,9 +93,9 @@ function decideForIssue(it, cfg) {
         if (it.hasNeedsHuman) return base('none', 'tope-reintentos + ya-escalado (dedupe)');
         return base('escalate', `tope de reintentos (${cfg.maxRequeueAttempts}) alcanzado para: ${capped.join(',')}`, { consumesTick: true });
     }
-    // Pausa / allowlist: no re-encolar (no spawnear), PO SG-5.
+    // Pausa: no re-encolar (no spawnear), PO SG-5. El escalate SÍ sigue permitido
+    // para issues de la ola (ya filtrados por allowlist arriba).
     if (cfg.paused) return base('none', 'pipeline-en-pausa (no re-encola)');
-    if (it.allowed === false) return base('none', 'issue-fuera-de-allowlist (no re-encola)');
 
     return base('requeue', analysis.reason, { skills, consumesTick: true });
 }

--- a/.pipeline/lib/stuck-phase-reconciler.test.js
+++ b/.pipeline/lib/stuck-phase-reconciler.test.js
@@ -1,0 +1,179 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert');
+const {
+    planReconciliation, executeDecisions, decideForIssue,
+    DEFAULT_MAX_REQUEUE_ATTEMPTS, DEFAULT_CAP_PER_TICK,
+} = require('./stuck-phase-reconciler');
+
+const NOW = 1_800_000_000_000;
+const OLD = NOW - 30 * 60 * 1000; // stale
+const APROB = { resultado: 'aprobado' };
+const CANCEL = { cancelado_por: 'fast-fail-rebote' };
+
+function deliv(skill, state, yaml, mtimeMs = OLD) { return { skill, state, yaml, mtimeMs }; }
+// issue varado típico: fase paralela, deliverable viejo, sin trabajo vivo
+function stuckIssue(over = {}) {
+    return {
+        issue: 100, pipeline: 'desarrollo', fase: 'validacion',
+        requiredSkills: ['po', 'ux', 'guru'],
+        deliverables: [deliv('po', 'listo', APROB), deliv('guru', 'listo', APROB)], // ux missing
+        liveSkills: new Set(), liveElsewhere: false, hasNeedsHuman: false,
+        retryCounts: {}, isMonoSkill: false, allowed: true,
+        ...over,
+    };
+}
+function plan(issues, extra = {}) { return planReconciliation({ issues, nowMs: NOW, ...extra }); }
+function only(issues, extra = {}) { return plan(issues, extra).decisions[0]; }
+
+// ─── Guardas P0 ─────────────────────────────────────────────────────────────
+test('P0-1 mono-skill: fase dev → none', () => {
+    assert.equal(only([stuckIssue({ fase: 'dev' })]).action, 'none');
+    assert.match(only([stuckIssue({ fase: 'dev' })]).reason, /mono-skill/);
+});
+test('P0-1 mono-skill: flag isMonoSkill → none aunque la fase no esté en la lista', () => {
+    assert.equal(only([stuckIssue({ fase: 'validacion', isMonoSkill: true })]).action, 'none');
+});
+test('P0-2 cross-phase: issue vivo en otra fase → none (evita doble-track)', () => {
+    assert.equal(only([stuckIssue({ liveElsewhere: true })]).action, 'none');
+    assert.match(only([stuckIssue({ liveElsewhere: true })]).reason, /otra-fase/);
+});
+test('P0-3 cap reintentos: skill faltante en el tope → escalate (no loop)', () => {
+    const d = only([stuckIssue({ retryCounts: { ux: DEFAULT_MAX_REQUEUE_ATTEMPTS } })]);
+    assert.equal(d.action, 'escalate');
+    assert.match(d.reason, /tope de reintentos/);
+});
+test('P0-3 cap reintentos: bajo el tope → requeue e incrementa contador', () => {
+    const { decisions, retryUpdates } = plan([stuckIssue({ retryCounts: { ux: 1 } })]);
+    assert.equal(decisions[0].action, 'requeue');
+    assert.deepEqual(decisions[0].skills, ['ux']);
+    assert.equal(retryUpdates['100|validacion|ux'], 2);
+});
+
+// ─── requeue vs escalate según detector ─────────────────────────────────────
+test('CASO #4507: ux faltante + resto aprobado → requeue [ux]', () => {
+    const it = stuckIssue({
+        issue: 4507, fase: 'aprobacion', requiredSkills: ['review', 'po', 'ux', 'architect'],
+        deliverables: [deliv('review', 'listo', APROB), deliv('po', 'archivado', APROB), deliv('architect', 'archivado', APROB)],
+    });
+    assert.deepEqual(only([it]).skills, ['ux']);
+    assert.equal(only([it]).action, 'requeue');
+});
+test('CASO #4534: po/ux cancelados → escalate (no requeue)', () => {
+    const it = stuckIssue({
+        issue: 4534,
+        deliverables: [deliv('guru', 'listo', APROB), deliv('po', 'procesado', CANCEL), deliv('ux', 'procesado', CANCEL)],
+    });
+    assert.equal(only([it]).action, 'escalate');
+});
+
+// ─── Dedupe de escalate (P1-1) ──────────────────────────────────────────────
+test('P1-1 dedupe: escalate con needs-human ya presente → none', () => {
+    const it = stuckIssue({
+        deliverables: [deliv('guru', 'listo', APROB), deliv('po', 'procesado', CANCEL)],
+        hasNeedsHuman: true,
+    });
+    assert.equal(only([it]).action, 'none');
+    assert.match(only([it]).reason, /dedupe/);
+});
+test('P1-1 dedupe: requeue-capeado con needs-human → none (no re-escala)', () => {
+    const it = stuckIssue({ retryCounts: { ux: DEFAULT_MAX_REQUEUE_ATTEMPTS }, hasNeedsHuman: true });
+    assert.equal(only([it]).action, 'none');
+});
+
+// ─── Pausa / allowlist (PO SG-5) ────────────────────────────────────────────
+test('SG-5 pausa: no re-encola (requeue → none)', () => {
+    assert.equal(only([stuckIssue()], { paused: true }).action, 'none');
+    assert.match(only([stuckIssue()], { paused: true }).reason, /pausa/);
+});
+test('SG-5 pausa: SÍ permite escalate (label, no spawnea)', () => {
+    const it = stuckIssue({ deliverables: [deliv('po', 'listo', CANCEL)] });
+    assert.equal(only([it], { paused: true }).action, 'escalate');
+});
+test('SG-5 allowlist: issue fuera de allowlist → no re-encola', () => {
+    assert.equal(only([stuckIssue({ allowed: false })]).action, 'none');
+});
+
+// ─── Cap por tick + orden (P2-3) ────────────────────────────────────────────
+test('P2-3 cap por tick: solo N acciones reales, resto → none(cap)', () => {
+    const issues = [1, 2, 3, 4].map((n) => stuckIssue({ issue: n }));
+    const { decisions } = plan(issues, { capPerTick: 2 });
+    const reales = decisions.filter((d) => d.action !== 'none');
+    assert.equal(reales.length, 2);
+    assert.equal(decisions.filter((d) => d.reason === 'cap-por-tick-alcanzado').length, 2);
+});
+test('P2-3 orden determinista: procesa issues asc (sin starvation)', () => {
+    const issues = [30, 10, 20].map((n) => stuckIssue({ issue: n }));
+    const { decisions } = plan(issues, { capPerTick: 1 });
+    const actuo = decisions.find((d) => d.action === 'requeue');
+    assert.equal(actuo.issue, 10, 'el issue más chico se procesa primero');
+});
+test('los none NO consumen cupo del tick', () => {
+    const issues = [
+        stuckIssue({ issue: 1, liveElsewhere: true }), // none (no consume)
+        stuckIssue({ issue: 2 }),                        // requeue
+        stuckIssue({ issue: 3 }),                        // requeue
+    ];
+    const reales = plan(issues, { capPerTick: 2 }).decisions.filter((d) => d.action !== 'none');
+    assert.equal(reales.length, 2, 'los 2 requeue caben porque el none no gastó cupo');
+});
+
+// ─── decideForIssue directo (unidad) ────────────────────────────────────────
+test('decideForIssue: completo → none', () => {
+    const it = stuckIssue({ deliverables: [deliv('po', 'listo', APROB), deliv('ux', 'listo', APROB), deliv('guru', 'listo', APROB)] });
+    assert.equal(decideForIssue(it, { nowMs: NOW, maxRequeueAttempts: 2, capPerTick: 5, paused: false, monoSkillPhases: new Set(['dev']) }).action, 'none');
+});
+
+// ─── executeDecisions (shell con mocks) ─────────────────────────────────────
+function mockDeps() {
+    const calls = { requeue: [], escalate: [], notify: [], audit: [] };
+    return {
+        calls,
+        requeueWorkItem: (p, f, s, i) => calls.requeue.push(`${i}.${s}@${p}/${f}`),
+        escalate: (i, r) => calls.escalate.push({ i, r }),
+        notify: (m) => calls.notify.push(m),
+        audit: (rec) => calls.audit.push(rec),
+    };
+}
+test('execute requeue: escribe work-item por skill + notifica + audita', () => {
+    const deps = mockDeps();
+    const res = executeDecisions([{ action: 'requeue', issue: 100, pipeline: 'desarrollo', fase: 'validacion', skills: ['ux'], reason: 'x' }], deps);
+    assert.deepEqual(deps.calls.requeue, ['100.ux@desarrollo/validacion']);
+    assert.equal(res.requeued, 1);
+    assert.equal(deps.calls.notify.length, 1);
+    assert.ok(deps.calls.audit.some((a) => a.action === 'requeue'));
+});
+test('execute requeue idempotente: si el work-item ya existe, no lo re-escribe', () => {
+    const deps = mockDeps();
+    deps.workItemExists = () => true;
+    executeDecisions([{ action: 'requeue', issue: 100, pipeline: 'desarrollo', fase: 'validacion', skills: ['ux'], reason: 'x' }], deps);
+    assert.equal(deps.calls.requeue.length, 0, 'no re-escribe si ya existe');
+});
+test('execute escalate: llama escalate + notifica', () => {
+    const deps = mockDeps();
+    const res = executeDecisions([{ action: 'escalate', issue: 4534, pipeline: 'desarrollo', fase: 'validacion', reason: 'ambiguo' }], deps);
+    assert.equal(deps.calls.escalate.length, 1);
+    assert.equal(res.escalated, 1);
+    assert.equal(deps.calls.notify.length, 1);
+});
+test('execute none: audita pero NO notifica', () => {
+    const deps = mockDeps();
+    executeDecisions([{ action: 'none', issue: 1, fase: 'validacion', reason: 'reciente' }], deps);
+    assert.equal(deps.calls.notify.length, 0);
+    assert.equal(deps.calls.audit.length, 1);
+});
+test('execute best-effort: un dep que tira no aborta el resto', () => {
+    const deps = mockDeps();
+    deps.requeueWorkItem = () => { throw new Error('fs falló'); };
+    assert.doesNotThrow(() => executeDecisions([
+        { action: 'requeue', issue: 1, pipeline: 'desarrollo', fase: 'validacion', skills: ['ux'], reason: 'x' },
+        { action: 'escalate', issue: 2, pipeline: 'desarrollo', fase: 'validacion', reason: 'y' },
+    ], deps));
+    assert.equal(deps.calls.escalate.length, 1, 'el escalate siguiente igual se ejecuta');
+});
+test('NUNCA fabrica aprobaciones: executeDecisions no expone forma de escribir resultado:aprobado', () => {
+    const deps = mockDeps();
+    // el shell solo tiene requeueWorkItem/escalate/notify/audit — no hay "aprobar"
+    executeDecisions([{ action: 'requeue', issue: 1, pipeline: 'desarrollo', fase: 'validacion', skills: ['ux'], reason: 'x' }], deps);
+    assert.ok(!('approve' in deps), 'no hay dep de aprobación');
+});

--- a/.pipeline/lib/stuck-phase-reconciler.test.js
+++ b/.pipeline/lib/stuck-phase-reconciler.test.js
@@ -19,7 +19,7 @@ function stuckIssue(over = {}) {
         requiredSkills: ['po', 'ux', 'guru'],
         deliverables: [deliv('po', 'listo', APROB), deliv('guru', 'listo', APROB)], // ux missing
         liveSkills: new Set(), liveElsewhere: false, hasNeedsHuman: false,
-        retryCounts: {}, isMonoSkill: false, allowed: true,
+        retryCounts: {}, isMonoSkill: false, allowed: true, active: true,
         ...over,
     };
 }
@@ -90,8 +90,23 @@ test('SG-5 pausa: SÍ permite escalate (label, no spawnea)', () => {
     const it = stuckIssue({ deliverables: [deliv('po', 'listo', CANCEL)] });
     assert.equal(only([it], { paused: true }).action, 'escalate');
 });
-test('SG-5 allowlist: issue fuera de allowlist → no re-encola', () => {
-    assert.equal(only([stuckIssue({ allowed: false })]).action, 'none');
+test('allowlist: issue fuera de allowlist (requeue) → none (backlog dormido)', () => {
+    const d = only([stuckIssue({ allowed: false })]);
+    assert.equal(d.action, 'none');
+    assert.match(d.reason, /allowlist/);
+});
+test('allowlist: issue fuera de allowlist que ESCALARÍA → none (no spamea backlog)', () => {
+    const it = stuckIssue({ allowed: false, deliverables: [deliv('po', 'listo', CANCEL)] });
+    assert.equal(only([it]).action, 'none', 'ni siquiera escala si está fuera de la ola');
+});
+test('issue CERRADO (active=false) → none (residuo, no tocar)', () => {
+    const it = stuckIssue({ active: false, deliverables: [deliv('po', 'listo', CANCEL)] });
+    assert.equal(only([it]).action, 'none');
+    assert.match(only([it]).reason, /cerrado/);
+});
+test('issue con active undefined → none (desconocido = no tocar)', () => {
+    const it = stuckIssue({ active: undefined });
+    assert.equal(only([it]).action, 'none', 'sin confirmación de OPEN, no actúa');
 });
 
 // ─── Cap por tick + orden (P2-3) ────────────────────────────────────────────

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -183,6 +183,8 @@ const waveAutoTransition = require('./lib/wave-auto-transition');
 const { resolveReboteDestino } = require('./lib/rebote-destino');
 // #2893 — Detección de dependencias del allowlist en pausa parcial
 const partialPauseDeps = require('./lib/partial-pause-deps');
+// #4614 — self-healing de fases varadas (reconciler).
+const { runStuckPhaseReconciler } = require('./lib/stuck-phase-reconciler-runner');
 // #2801 — emit session:start/end por cada lanzamiento de agente Claude (LLM)
 // para que el aggregator pueda contabilizar tokens consumidos. Los skills
 // determinísticos (delivery, builder, linter, tester) ya emiten por su cuenta.
@@ -14596,6 +14598,116 @@ function pollQuotaFlag() {
   lastQuotaFlagPresent = present;
 }
 
+// #4614 — Tick del reconciler de fases varadas. Auto-throttled (cada 10 min) +
+// try/catch: jamás tumba el loop del Pulpo. Solo actúa sobre fases PARALELAS
+// (no mono-skill dev/build/entrega). Guardas dentro del reconciler (cross-phase,
+// cap de reintentos persistente, dedupe, pausa/allowlist, liveness).
+let _lastStuckReconcilerAt = 0;
+const STUCK_RECONCILER_INTERVAL_MS = 10 * 60 * 1000;
+const STUCK_STALE_MS = 15 * 60 * 1000;
+function runStuckReconcilerTick() {
+  if (Date.now() - _lastStuckReconcilerAt < STUCK_RECONCILER_INTERVAL_MS) return;
+  _lastStuckReconcilerAt = Date.now();
+  try {
+    const STUCK_STATE_FILE = path.join(PIPELINE, '.stuck-reconciler-state.json');
+    const ghQueueDir = path.join(PIPELINE, 'servicios', 'github', 'pendiente');
+    const ppMode = partialPause.getPipelineMode();
+    // Fases PARALELAS de `desarrollo` (todos los skills deben estar, modelo
+    // `resultado: aprobado`). Mono-skill (dev/build/entrega) quedan afuera. Las
+    // de `definicion` (analisis/criterios) también: sus deliverables son dossiers
+    // que NO usan `resultado: aprobado`, así que el detector los malinterpretaría
+    // (hallazgo del dry-run). v1 acotado a desarrollo.
+    const parallelPhases = [
+      { pipeline: 'desarrollo', fase: 'validacion' },
+      { pipeline: 'desarrollo', fase: 'verificacion' },
+      { pipeline: 'desarrollo', fase: 'aprobacion' },
+    ];
+    const allPhasesOf = (p) => (config.pipelines?.[p]?.fases) || [];
+
+    const deps = {
+      nowMs: Date.now(),
+      parallelPhases,
+      requiredSkillsFor: (p, f) => (config.pipelines?.[p]?.skills_por_fase?.[f]) || [],
+      listPhaseFiles: (p, f, state) => {
+        const dir = path.join(fasePath(p, f), state);
+        return (listWorkFiles(dir) || []).map((wf) => {
+          let mtimeMs = 0;
+          try { mtimeMs = fs.statSync(wf.path).mtimeMs; } catch { /* ausente */ }
+          return { name: wf.name, mtimeMs };
+        });
+      },
+      readYaml: (p, f, state, name) => readYamlSafe(path.join(fasePath(p, f), state, name)),
+      issueLiveElsewhere: (issue, p, currentFase) => {
+        for (const f of allPhasesOf(p)) {
+          if (f === currentFase) continue;
+          for (const st of ['pendiente', 'trabajando']) {
+            try {
+              if (fs.readdirSync(path.join(fasePath(p, f), st)).some((n) => n.startsWith(issue + '.'))) return true;
+            } catch { /* dir ausente */ }
+          }
+        }
+        return false;
+      },
+      hasNeedsHuman: (issue) => {
+        try {
+          if (fs.readdirSync(ghQueueDir).some((n) => n.startsWith(issue + '-needs-human'))) return true;
+        } catch { /* ausente */ }
+        for (const p of Object.keys(config.pipelines || {})) {
+          for (const f of allPhasesOf(p)) {
+            try {
+              if (fs.readdirSync(path.join(fasePath(p, f), 'bloqueado-humano')).some((n) => n.startsWith(issue + '.'))) return true;
+            } catch { /* ausente */ }
+          }
+        }
+        return false;
+      },
+      isAllowed: (issue) => ppMode.mode !== 'partial_pause' || (ppMode.allowed_issues || []).includes(Number(issue)),
+      // Solo actuar sobre issues confirmados OPEN (el title-cache trae el estado
+      // real de GitHub). Cerrado/notFound/desconocido → no tocar (residuo).
+      isIssueOpen: (issue) => {
+        try {
+          const cache = JSON.parse(fs.readFileSync(path.join(PIPELINE, '.issue-title-cache.json'), 'utf8'));
+          const e = cache[String(issue)];
+          return !!(e && e.state === 'OPEN');
+        } catch { return false; }
+      },
+      isPaused: () => { try { return fs.existsSync(PAUSE_FILE); } catch { return false; } },
+      livenessOk: (name, mtimeMs) => (Date.now() - mtimeMs) < STUCK_STALE_MS, // trabajando reciente = vivo
+      loadRetryState: () => { try { return JSON.parse(fs.readFileSync(STUCK_STATE_FILE, 'utf8')); } catch { return {}; } },
+      saveRetryState: (s) => { try { fs.writeFileSync(STUCK_STATE_FILE, JSON.stringify(s, null, 2)); } catch { /* best-effort */ } },
+      requeueWorkItem: (p, f, skill, issue) => {
+        const dir = path.join(fasePath(p, f), 'pendiente');
+        fs.mkdirSync(dir, { recursive: true });
+        fs.writeFileSync(path.join(dir, `${issue}.${skill}`), `issue: ${issue}\nfase: ${f}\npipeline: ${p}\n`);
+      },
+      escalate: (issue, reason) => {
+        try {
+          fs.mkdirSync(ghQueueDir, { recursive: true });
+          fs.writeFileSync(
+            path.join(ghQueueDir, `${issue}-needs-human-stuck-${Date.now()}.json`),
+            JSON.stringify({ action: 'label', issue: parseInt(issue, 10), label: 'needs-human' })
+          );
+        } catch (e) { log('reconciler', `error encolando needs-human #${issue}: ${e.message}`); }
+      },
+      workItemExists: (p, f, skill, issue) => {
+        for (const st of ['pendiente', 'trabajando']) {
+          try { if (fs.existsSync(path.join(fasePath(p, f), st, `${issue}.${skill}`))) return true; } catch { /* no-op */ }
+        }
+        return false;
+      },
+      notify: (msg) => { try { sendTelegram(msg); } catch { /* best-effort */ } },
+      audit: (rec) => log('reconciler', typeof rec === 'string' ? rec : JSON.stringify(rec)),
+    };
+
+    const res = runStuckPhaseReconciler(deps, { maxRequeueAttempts: 2, capPerTick: 5, staleThresholdMs: STUCK_STALE_MS });
+    if (res.requeued || res.escalated) {
+      log('reconciler', `🔧 self-healing tick: requeue=${res.requeued} escalate=${res.escalated} skip=${res.skipped}`);
+    }
+  } catch (e) {
+    log('reconciler', `tick error (no tumba el loop): ${e && e.message}`);
+  }
+}
+
 // Rotación del historial del commander (descartar > 24hs)
 let lastHistoryRotation = 0;
 function rotateHistory() {
@@ -16195,6 +16307,11 @@ async function mainLoop() {
       // pausado) para que el notifier dispare cierre cuando se borra el flag,
       // independiente del estado de pausa del pipeline.
       try { pollQuotaFlag(); } catch (e) { log('quota', `pollQuotaFlag error: ${e.message}`); }
+
+      // #4614 — Self-healing de fases varadas. Auto-throttled (cada 10min) +
+      // try/catch interno: jamás tumba el loop. Reconcilia issues que quedaron
+      // colgados por crash/rebote (re-encola faltantes o escala ambiguos).
+      runStuckReconcilerTick();
 
       // #3260 — Healthcheck multi-provider. Corre SIEMPRE (idempotente, con
       // lock + jitter ±60s anti-thundering-herd). El módulo decide internamente


### PR DESCRIPTION
## Qué
Parte B de #4612: **self-healing de issues varados en fase** post-crash/rebote. Detecta un issue con deliverables presentes pero fase incompleta y sin avanzar, y toma una acción SEGURA: **re-encola** el skill genuinamente faltante o **escala a needs-human** lo ambiguo. **Nunca fabrica aprobaciones.**

## Módulos (todo con deps inyectables → testeable sin FS/gh reales)
- `lib/stuck-phase-detector.js` — decisión pura per-(issue,fase). Reusa `isApprovedArtifact`.
- `lib/stuck-phase-reconciler.js` — planner con guardas + shell de ejecución.
- `lib/stuck-phase-reconciler-runner.js` — integración FS.
- `pulpo.js` — tick auto-throttled (10min) + try/catch (jamás tumba el loop).

## Guardas (review arquitecto + PO)
- Cross-phase (no doble-track con issue rebotado a dev) · mono-skill (no toca dev/build/entrega) · cap de reintentos persistente (2 → escalate) · dedupe de escalate · cap por tick + orden asc · respeta pausa/allowlist · liveness real de `trabajando/` · **nunca fabrica aprobaciones**.
- **Guardas caladas por el dry-run contra estado real:** gating por allowlist (no toca backlog dormido) · fases acotadas a desarrollo (definicion usa dossiers, no `resultado:aprobado`) · **guard issue-cerrado** (no escala residuo de CLOSED como #4510/#4533/#4536).

## Verificación
- **63 tests** (detector 28 + reconciler 24 + runner E2E 11), casos reales #4507/#4534.
- **Dry-run contra el estado real del pipeline (cero side-effects): 0 requeue, 0 escalate** — todo `none` correcto (backlog fuera-de-allowlist, cerrados como residuo, activos vivos).

## Deploy
Wiring NO desplegado a producción todavía — a la espera del OK del operador. Tag de rollback `modelo-operativo-pre-4614` creado.

Closes #4614.

🤖 Generated with [Claude Code](https://claude.com/claude-code)