### PR TITLE
fix(pulpo): reconciler usa loadConfig() local (#4614 hotfix)

### DIFF
--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -14609,6 +14609,8 @@ function runStuckReconcilerTick() {
   if (Date.now() - _lastStuckReconcilerAt < STUCK_RECONCILER_INTERVAL_MS) return;
   _lastStuckReconcilerAt = Date.now();
   try {
+    const config = loadConfig();
+    if (!config || !config.pipelines) return;
     const STUCK_STATE_FILE = path.join(PIPELINE, '.stuck-reconciler-state.json');
     const ghQueueDir = path.join(PIPELINE, 'servicios', 'github', 'pendiente');
     const ppMode = partialPause.getPipelineMode();


### PR DESCRIPTION
Hotfix de #4614: el tick del reconciler usaba `config` (no en scope module-level). Ahora `loadConfig()` local. El try/catch atajaba el error (loop sano) pero el reconciler no corría.