### PR TITLE
Pipeline · Muerte por provider no-disponible no debe penalizar al issue con cooldown de 60min

### DIFF
--- a/.pipeline/cache/codex-reprobe.json
+++ b/.pipeline/cache/codex-reprobe.json
@@ -1,1 +1,1 @@
-{"ts":1783632624403,"healthy":true}
+{"ts":1783754237997,"healthy":true}

--- a/.pipeline/lib/agent-launcher/__tests__/provider-death-classifier.test.js
+++ b/.pipeline/lib/agent-launcher/__tests__/provider-death-classifier.test.js
@@ -1,0 +1,90 @@
+// =============================================================================
+// __tests__/provider-death-classifier.test.js — Issue #4648.
+//
+// Cobertura de la clasificación provider-death vs agent-death (CA-1, CA-5 y
+// escenarios Gherkin del issue). Función PURA: sin IO, sin fixtures.
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { classifyPrematureDeath } = require('../provider-death-classifier');
+
+test('muerte <15s code=1 con provider fallback → provider-death (no penaliza al issue)', () => {
+    // Gherkin: Anthropic gateado, fallback gemini-google muere al spawn en 5s.
+    const v = classifyPrematureDeath({
+        code: 1, elapsedSec: 5, hasVerdict: false,
+        source: 'fallback', provider: 'gemini-google',
+    });
+    assert.equal(v.kind, 'provider-death');
+    assert.match(v.reason, /gemini-google/);
+});
+
+test('muerte <15s code=1 con primary disponible → agent-death (SÍ penaliza — CA-5)', () => {
+    // Gherkin: Anthropic disponible, qa:#4632 muere en 3s por su propio código.
+    const v = classifyPrematureDeath({
+        code: 1, elapsedSec: 3, hasVerdict: false,
+        source: 'primary', provider: 'anthropic',
+    });
+    assert.equal(v.kind, 'agent-death');
+});
+
+test('source ausente (resolver falló) → agent-death (fail-closed conservador)', () => {
+    const v = classifyPrematureDeath({
+        code: 1, elapsedSec: 4, hasVerdict: false,
+        source: null, provider: null,
+    });
+    assert.equal(v.kind, 'agent-death');
+});
+
+test('exit 0 → normal (no es muerte prematura) aunque sea fallback', () => {
+    const v = classifyPrematureDeath({
+        code: 0, elapsedSec: 5, hasVerdict: false,
+        source: 'fallback', provider: 'gemini-google',
+    });
+    assert.equal(v.kind, 'normal');
+    assert.equal(v.reason, 'not_premature');
+});
+
+test('vivió ≥ umbral → normal aunque code≠0 y fallback', () => {
+    const v = classifyPrematureDeath({
+        code: 1, elapsedSec: 40, hasVerdict: false,
+        source: 'fallback', provider: 'gemini-google',
+    });
+    assert.equal(v.kind, 'normal');
+});
+
+test('con veredicto válido → normal (no muerte prematura, #2524)', () => {
+    const v = classifyPrematureDeath({
+        code: 1, elapsedSec: 2, hasVerdict: true,
+        source: 'fallback', provider: 'gemini-google',
+    });
+    assert.equal(v.kind, 'normal');
+    assert.equal(v.reason, 'verdict');
+});
+
+test('source dispatch-fallback también cuenta como provider-death', () => {
+    const v = classifyPrematureDeath({
+        code: 1, elapsedSec: 6, hasVerdict: false,
+        source: 'dispatch-fallback', provider: 'cerebras',
+    });
+    assert.equal(v.kind, 'provider-death');
+});
+
+test('provider deterministic nunca es provider-death (skill Node puro)', () => {
+    const v = classifyPrematureDeath({
+        code: 1, elapsedSec: 2, hasVerdict: false,
+        source: 'fallback', provider: 'deterministic',
+    });
+    assert.equal(v.kind, 'agent-death');
+});
+
+test('umbral configurable (prematureSec)', () => {
+    const v = classifyPrematureDeath({
+        code: 1, elapsedSec: 20, hasVerdict: false,
+        source: 'fallback', provider: 'gemini-google',
+        prematureSec: 30,
+    });
+    assert.equal(v.kind, 'provider-death');
+});

--- a/.pipeline/lib/agent-launcher/__tests__/provider-spawn-health.test.js
+++ b/.pipeline/lib/agent-launcher/__tests__/provider-spawn-health.test.js
@@ -1,0 +1,124 @@
+// =============================================================================
+// __tests__/provider-spawn-health.test.js — Issue #4648 (Capa 3).
+//
+// Cobertura del health/backoff por provider ante muertes al spawn:
+//   - el cooldown va al PROVIDER (no al issue),
+//   - se apaga al alcanzar el umbral (fail-closed de Capa 1 por reuse),
+//   - reset en corrida sana, ventana deslizante, fail-open.
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const psh = require('../provider-spawn-health');
+
+function tmpPipeline() {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'psh-'));
+}
+
+// Fake inyectable del módulo provider-disabled: registra las llamadas a
+// setProviderDisabled sin tocar el filesystem real de disabled.
+function fakeDisabledModule() {
+    const calls = [];
+    return {
+        calls,
+        setProviderDisabled(provider, opts) {
+            calls.push({ provider, opts });
+            return { ok: true, ttl_ms: opts && opts.ttlMs };
+        },
+    };
+}
+
+test('una sola muerte NO apaga el provider (umbral 2 por default)', () => {
+    const dir = tmpPipeline();
+    const disabled = fakeDisabledModule();
+    const r = psh.recordProviderSpawnDeath({
+        pipelineDir: dir, provider: 'gemini-google', skill: 'po', issue: 4630,
+        disabledModule: disabled,
+    });
+    assert.equal(r.consecutiveDeaths, 1);
+    assert.equal(r.disabled, false);
+    assert.equal(disabled.calls.length, 0);
+});
+
+test('al alcanzar el umbral se apaga el provider (backoff a nivel provider)', () => {
+    const dir = tmpPipeline();
+    const disabled = fakeDisabledModule();
+    // Muertes de dos issues distintos (contador es POR PROVIDER, no por issue).
+    psh.recordProviderSpawnDeath({ pipelineDir: dir, provider: 'gemini-google', skill: 'po', issue: 4630, disabledModule: disabled });
+    const r = psh.recordProviderSpawnDeath({ pipelineDir: dir, provider: 'gemini-google', skill: 'ux', issue: 4588, disabledModule: disabled });
+    assert.equal(r.consecutiveDeaths, 2);
+    assert.equal(r.disabled, true);
+    assert.equal(disabled.calls.length, 1);
+    assert.equal(disabled.calls[0].provider, 'gemini-google');
+    assert.equal(disabled.calls[0].opts.source, 'spawn-death');
+    assert.ok(disabled.calls[0].opts.ttlMs > 0);
+});
+
+test('el estado se persiste POR PROVIDER, nunca por (skill,issue)', () => {
+    const dir = tmpPipeline();
+    psh.recordProviderSpawnDeath({ pipelineDir: dir, provider: 'gemini-google', skill: 'po', issue: 4630, disabledModule: fakeDisabledModule() });
+    const raw = psh._readRaw(dir);
+    assert.deepEqual(Object.keys(raw.providers), ['gemini-google']);
+    // No hay ninguna clave que mezcle skill/issue (la penalización no toca al issue).
+    const serialized = JSON.stringify(raw);
+    assert.equal(/4630|po:/.test(serialized), false);
+});
+
+test('corrida sana resetea el contador (recordProviderHealthy)', () => {
+    const dir = tmpPipeline();
+    const disabled = fakeDisabledModule();
+    psh.recordProviderSpawnDeath({ pipelineDir: dir, provider: 'gemini-google', skill: 'po', issue: 1, disabledModule: disabled });
+    assert.equal(psh.peekProviderSpawnHealth({ pipelineDir: dir, provider: 'gemini-google' }).consecutiveDeaths, 1);
+    const cleared = psh.recordProviderHealthy({ pipelineDir: dir, provider: 'gemini-google' });
+    assert.equal(cleared, true);
+    assert.equal(psh.peekProviderSpawnHealth({ pipelineDir: dir, provider: 'gemini-google' }), null);
+    // Tras el reset, una nueva muerte arranca de 1 (no acumula con la vieja).
+    const r = psh.recordProviderSpawnDeath({ pipelineDir: dir, provider: 'gemini-google', skill: 'po', issue: 2, disabledModule: disabled });
+    assert.equal(r.consecutiveDeaths, 1);
+    assert.equal(r.disabled, false);
+});
+
+test('ventana deslizante: muerte fuera de ventana reinicia el contador', () => {
+    const dir = tmpPipeline();
+    const disabled = fakeDisabledModule();
+    const t0 = 1_000_000;
+    psh.recordProviderSpawnDeath({ pipelineDir: dir, provider: 'gemini-google', skill: 'po', issue: 1, now: t0, windowMs: 1000, disabledModule: disabled });
+    // 2s después → ventana vencida → cuenta reinicia a 1, no llega a umbral.
+    const r = psh.recordProviderSpawnDeath({ pipelineDir: dir, provider: 'gemini-google', skill: 'po', issue: 2, now: t0 + 2000, windowMs: 1000, disabledModule: disabled });
+    assert.equal(r.consecutiveDeaths, 1);
+    assert.equal(r.disabled, false);
+    assert.equal(disabled.calls.length, 0);
+});
+
+test('providers distintos no se cruzan', () => {
+    const dir = tmpPipeline();
+    const disabled = fakeDisabledModule();
+    psh.recordProviderSpawnDeath({ pipelineDir: dir, provider: 'gemini-google', skill: 'po', issue: 1, disabledModule: disabled });
+    const r = psh.recordProviderSpawnDeath({ pipelineDir: dir, provider: 'cerebras', skill: 'po', issue: 1, disabledModule: disabled });
+    assert.equal(r.consecutiveDeaths, 1);
+    assert.equal(r.disabled, false);
+});
+
+test('fail-open: sin pipelineDir o provider devuelve no-op sin lanzar', () => {
+    assert.doesNotThrow(() => {
+        const r = psh.recordProviderSpawnDeath({ provider: 'gemini-google' });
+        assert.equal(r.disabled, false);
+        assert.equal(r.consecutiveDeaths, 0);
+    });
+    assert.equal(psh.recordProviderHealthy({}), false);
+});
+
+test('archivo de estado se crea con 0o600 (no en Windows)', () => {
+    const dir = tmpPipeline();
+    psh.recordProviderSpawnDeath({ pipelineDir: dir, provider: 'gemini-google', skill: 'po', issue: 1, disabledModule: fakeDisabledModule() });
+    const file = psh.stateFile(dir);
+    assert.ok(fs.existsSync(file));
+    if (process.platform !== 'win32') {
+        assert.equal(fs.statSync(file).mode & 0o777, 0o600);
+    }
+});

--- a/.pipeline/lib/agent-launcher/provider-death-classifier.js
+++ b/.pipeline/lib/agent-launcher/provider-death-classifier.js
@@ -1,0 +1,102 @@
+// =============================================================================
+// agent-launcher/provider-death-classifier.js — Clasificación de muerte prematura
+// de agente: causa PROVIDER (infra) vs causa AGENTE (crash del código). Issue #4648.
+//
+// PROBLEMA QUE RESUELVE
+// ---------------------
+// El handler de muerte prematura del Pulpo (`pulpo.js`, bloque
+// `if (code !== 0 && elapsedSec < 15)`) contaba CUALQUIER muerte temprana con
+// `code≠0` sin veredicto como fallo del ISSUE, aplicando `registerFastFail` +
+// cooldown de hasta 60min al `(skill,issue)`.
+//
+// Durante la ventana de inactividad de Anthropic, el primary queda gateado y el
+// resolver cae a un fallback (ej. `gemini-google`). Si ese fallback "resuelve
+// como viable" pero muere al spawn en 4-5s (`code=1`), la causa NO es el issue:
+// es INDISPONIBILIDAD del provider. Penalizar al issue lo congela ~1h por algo
+// que fue culpa del entorno de providers.
+//
+// PRINCIPIO RECTOR: una muerte por provider no disponible NUNCA debe penalizar
+// al issue. El cooldown por muerte-de-provider va al PROVIDER, no al (skill,issue).
+//
+// HEURÍSTICA (guru risk#2: basarla en el ESTADO DEL RESOLVER al momento del
+// spawn, no sólo en `elapsedSec`):
+//   - `source === 'fallback'` ⇒ el primary estaba gateado y el resolver cayó a
+//     un fallback. Una muerte inmediata (`code≠0`, `elapsedSec < threshold`) en
+//     ese estado degradado es atribuible a la fragilidad de la cadena de
+//     providers, no al código del agente ⇒ 'provider-death'.
+//   - `source === 'primary'` (o ausente) ⇒ el agente corrió con su provider
+//     configurado y disponible. Una muerte temprana es un crash REAL del agente
+//     ⇒ 'agent-death' (comportamiento actual preservado — CA-5 del issue).
+//
+// La clasificación es una función PURA (sin IO, sin estado): recibe las señales
+// ya observadas por el caller y devuelve el veredicto. Testeable en aislamiento.
+//
+// Sin dependencias externas (Node puro).
+// =============================================================================
+'use strict';
+
+// Umbral de "muerte prematura" en segundos (paridad con el bloque del Pulpo).
+const DEFAULT_PREMATURE_SEC = 15;
+
+/**
+ * classifyPrematureDeath — clasifica la causa de una muerte de agente.
+ *
+ * @param {object} opts
+ * @param {number} opts.code            exit code del proceso hijo.
+ * @param {number} opts.elapsedSec      segundos de vida del agente.
+ * @param {boolean} [opts.hasVerdict]   el agente escribió un YAML con
+ *        `resultado: aprobado|rechazado` (terminación legítima, no muerte).
+ * @param {string} [opts.source]        origen de la resolución de provider:
+ *        'primary' | 'fallback' | 'dispatch-fallback' | 'all-gated' | null.
+ * @param {string} [opts.provider]      provider EFECTIVO con el que se spawneó.
+ * @param {number} [opts.prematureSec]  umbral de muerte prematura (default 15s).
+ * @returns {{ kind: 'normal'|'provider-death'|'agent-death', reason: string }}
+ *   - 'normal'         → no es muerte prematura (éxito, veredicto, o vivió ≥ umbral).
+ *   - 'provider-death' → muerte prematura atribuible a infra de providers (NO
+ *                        penalizar al issue; backoff al provider).
+ *   - 'agent-death'    → muerte prematura por crash real del agente (penalizar
+ *                        con fast-fail + cooldown, comportamiento preservado).
+ */
+function classifyPrematureDeath(opts = {}) {
+    const {
+        code,
+        elapsedSec,
+        hasVerdict = false,
+        source = null,
+        provider = null,
+    } = opts;
+    const prematureSec = Number.isFinite(opts.prematureSec) && opts.prematureSec > 0
+        ? opts.prematureSec
+        : DEFAULT_PREMATURE_SEC;
+
+    // Terminación legítima con veredicto (#2524): no es muerte prematura.
+    if (hasVerdict) return { kind: 'normal', reason: 'verdict' };
+
+    // No cumple el patrón de muerte prematura (exit 0, o vivió el umbral).
+    if (!(code !== 0 && Number.isFinite(elapsedSec) && elapsedSec < prematureSec)) {
+        return { kind: 'normal', reason: 'not_premature' };
+    }
+
+    // El fallback nunca es 'deterministic' (skill Node puro sin tokens): si por
+    // algún camino el provider efectivo fuese deterministic, tratamos como crash
+    // del agente (su muerte no es indisponibilidad de un provider LLM externo).
+    const spawnedViaFallback = source === 'fallback' || source === 'dispatch-fallback';
+    const providerAttributable = spawnedViaFallback
+        && typeof provider === 'string'
+        && provider.length > 0
+        && provider !== 'deterministic';
+
+    if (providerAttributable) {
+        return {
+            kind: 'provider-death',
+            reason: `fallback_spawn_death:${provider}`,
+        };
+    }
+
+    return { kind: 'agent-death', reason: 'primary_or_unknown_crash' };
+}
+
+module.exports = {
+    classifyPrematureDeath,
+    DEFAULT_PREMATURE_SEC,
+};

--- a/.pipeline/lib/agent-launcher/provider-spawn-health.js
+++ b/.pipeline/lib/agent-launcher/provider-spawn-health.js
@@ -1,0 +1,233 @@
+// =============================================================================
+// agent-launcher/provider-spawn-health.js — Health/backoff por PROVIDER ante
+// muertes al spawn. Issue #4648 (Capa 3).
+//
+// PROBLEMA QUE RESUELVE
+// ---------------------
+// Un provider de fallback (ej. `gemini-google`) que "resuelve como viable" pero
+// muere al spawn en 4-5s debe marcarse INVÁLIDO para que el resolver lo saltee,
+// igual que ya hace con los providers gated o apagados. El cooldown por
+// muerte-de-provider se registra a nivel PROVIDER (backoff), no al (skill,issue):
+// así ningún issue queda congelado por la fragilidad de la cadena de providers.
+//
+// MECÁNICA
+// --------
+// - `recordProviderSpawnDeath` incrementa un contador de muertes consecutivas
+//   por provider dentro de una ventana deslizante. Cuando alcanza el umbral,
+//   apaga el provider vía `provider-disabled.setProviderDisabled` (source
+//   `spawn-death`, con TTL). `dispatch-with-fallback` ya saltea providers
+//   apagados → el fail-closed de Capa 1 emerge por reuse (primary gateado +
+//   fallbacks apagados ⇒ `gated:true` ⇒ el Pulpo NO spawnea, sin penalizar al
+//   issue).
+// - `recordProviderHealthy` resetea el contador cuando un agente corre bien con
+//   ese provider (exit 0 o vida ≥ umbral). Evita apagados por muertes viejas.
+//
+// PERSISTENCIA: `.pipeline/state/provider-spawn-health.json`
+//   {
+//     "providers": {
+//       "gemini-google": {
+//         "consecutiveDeaths": 2,
+//         "firstDeathAt": "2026-07-11T...", "lastDeathAt": "2026-07-11T...",
+//         "windowExpiresAt": "2026-07-11T..."
+//       }
+//     }
+//   }
+//
+// GARANTÍAS
+// ---------
+// - Fail-open: cualquier error de IO/parseo → no-op (jamás rompe el lifecycle).
+// - 0o600, escritura atómica (espejo de spawn-failure-state.js).
+// - El disable se delega a `provider-disabled` (módulo inyectable para tests).
+// - Sin secrets: sólo metadata de control (provider, timestamps, contador).
+//
+// Sin dependencias externas más allá de `provider-disabled` (Node puro: fs, path).
+// =============================================================================
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+// Umbral de muertes consecutivas al spawn antes de apagar el provider. ≥ 2 para
+// no apagar por un fluke único ("muere REITERADAMENTE" del issue).
+const DEFAULT_DEATH_THRESHOLD = 2;
+
+// Ventana deslizante: muertes separadas por más que esto reinician el contador
+// (una muerte vieja no debe sumar con una nueva no relacionada).
+const DEFAULT_WINDOW_MS = 15 * 60 * 1000; // 15 min
+
+// TTL del apagado del provider (backoff a nivel provider). Modesto: si el
+// provider se recupera, vuelve a la cadena en el próximo ciclo.
+const DEFAULT_DISABLE_TTL_MS = 30 * 60 * 1000; // 30 min
+
+function stateFile(pipelineDir) {
+    return path.join(pipelineDir, 'state', 'provider-spawn-health.json');
+}
+
+// -----------------------------------------------------------------------------
+// Lectura defensiva. Cualquier error → { providers: {} }. NUNCA lanza.
+// -----------------------------------------------------------------------------
+function readRaw(pipelineDir, fsImpl) {
+    const _fs = fsImpl || fs;
+    try {
+        const file = stateFile(pipelineDir);
+        if (!_fs.existsSync(file)) return { providers: {} };
+        const parsed = JSON.parse(_fs.readFileSync(file, 'utf8'));
+        if (!parsed || typeof parsed !== 'object' || !parsed.providers || typeof parsed.providers !== 'object') {
+            return { providers: {} };
+        }
+        return { providers: parsed.providers };
+    } catch {
+        return { providers: {} };
+    }
+}
+
+// Escritura atómica con 0o600 (espejo de spawn-failure-state.js). Best-effort.
+function writeAtomic(pipelineDir, data, fsImpl) {
+    const _fs = fsImpl || fs;
+    try {
+        const file = stateFile(pipelineDir);
+        const dir = path.dirname(file);
+        _fs.mkdirSync(dir, { recursive: true });
+        const tmp = `${file}.${process.pid}.${Date.now()}.tmp`;
+        const fd = _fs.openSync(tmp, 'w', 0o600);
+        try {
+            _fs.writeSync(fd, JSON.stringify(data, null, 2));
+            try { _fs.fsyncSync(fd); } catch { /* best-effort */ }
+        } finally {
+            try { _fs.closeSync(fd); } catch { /* best-effort */ }
+        }
+        _fs.renameSync(tmp, file);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * recordProviderSpawnDeath — registra una muerte al spawn atribuida al provider
+ * e, idempotente por provider, incrementa el contador dentro de la ventana. Si
+ * alcanza el umbral, apaga el provider (backoff a nivel provider).
+ *
+ * @param {object} opts
+ * @param {string} opts.pipelineDir
+ * @param {string} opts.provider          provider efectivo que murió al spawn.
+ * @param {string} [opts.skill]           sólo para audit del disable (no penaliza).
+ * @param {number|string} [opts.issue]    idem (contexto, no key de penalización).
+ * @param {number} [opts.threshold]       muertes consecutivas para apagar (default 2).
+ * @param {number} [opts.windowMs]        ventana deslizante (default 15min).
+ * @param {number} [opts.disableTtlMs]    TTL del apagado (default 30min).
+ * @param {number} [opts.now]
+ * @param {object} [opts.fsImpl]
+ * @param {object} [opts.disabledModule]  inyectable en tests (provider-disabled).
+ * @returns {{ consecutiveDeaths:number, disabled:boolean, threshold:number }}
+ */
+function recordProviderSpawnDeath(opts = {}) {
+    const { pipelineDir, provider } = opts;
+    const result = { consecutiveDeaths: 0, disabled: false, threshold: DEFAULT_DEATH_THRESHOLD };
+    if (!pipelineDir || !provider || typeof provider !== 'string') return result;
+
+    const _fs = opts.fsImpl || fs;
+    const now = Number.isFinite(opts.now) ? opts.now : Date.now();
+    const threshold = Number.isFinite(opts.threshold) && opts.threshold > 0
+        ? opts.threshold : DEFAULT_DEATH_THRESHOLD;
+    const windowMs = Number.isFinite(opts.windowMs) && opts.windowMs > 0
+        ? opts.windowMs : DEFAULT_WINDOW_MS;
+    const disableTtlMs = Number.isFinite(opts.disableTtlMs) && opts.disableTtlMs > 0
+        ? opts.disableTtlMs : DEFAULT_DISABLE_TTL_MS;
+    result.threshold = threshold;
+
+    try {
+        const { providers } = readRaw(pipelineDir, _fs);
+        const prev = providers[provider];
+        // Si la ventana venció (o no había registro), arrancamos de cero.
+        const windowAlive = prev
+            && prev.windowExpiresAt
+            && now < Date.parse(prev.windowExpiresAt);
+        const consecutiveDeaths = (windowAlive ? (prev.consecutiveDeaths || 0) : 0) + 1;
+
+        providers[provider] = {
+            consecutiveDeaths,
+            firstDeathAt: windowAlive && prev.firstDeathAt ? prev.firstDeathAt : new Date(now).toISOString(),
+            lastDeathAt: new Date(now).toISOString(),
+            windowExpiresAt: new Date(now + windowMs).toISOString(),
+        };
+        writeAtomic(pipelineDir, { providers }, _fs);
+        result.consecutiveDeaths = consecutiveDeaths;
+
+        if (consecutiveDeaths >= threshold) {
+            const disabledModule = opts.disabledModule || _loadDisabledModule();
+            if (disabledModule && typeof disabledModule.setProviderDisabled === 'function') {
+                // provider-disabled valida contra su allowlist; un provider fuera
+                // de ella devuelve {ok:false} y no rompe nada (fail-open).
+                const r = disabledModule.setProviderDisabled(provider, {
+                    ttlMs: disableTtlMs,
+                    source: 'spawn-death',
+                    now,
+                });
+                result.disabled = !!(r && r.ok);
+            }
+        }
+    } catch {
+        // fail-open
+    }
+    return result;
+}
+
+/**
+ * recordProviderHealthy — resetea el contador de muertes de un provider cuando
+ * corrió bien (exit 0 o vida ≥ umbral). Idempotente. Fail-open.
+ *
+ * @param {object} opts { pipelineDir, provider, now, fsImpl }
+ * @returns {boolean} true si había estado que limpiar.
+ */
+function recordProviderHealthy(opts = {}) {
+    const { pipelineDir, provider } = opts;
+    if (!pipelineDir || !provider || typeof provider !== 'string') return false;
+    const _fs = opts.fsImpl || fs;
+    try {
+        const { providers } = readRaw(pipelineDir, _fs);
+        if (!providers[provider]) return false;
+        delete providers[provider];
+        writeAtomic(pipelineDir, { providers }, _fs);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * peekProviderSpawnHealth — devuelve el estado actual del provider (sin mutar).
+ * null si no hay registro. Útil para diagnóstico/tests.
+ */
+function peekProviderSpawnHealth(opts = {}) {
+    const { pipelineDir, provider } = opts;
+    if (!pipelineDir || !provider) return null;
+    try {
+        const { providers } = readRaw(pipelineDir, opts.fsImpl);
+        return providers[provider] || null;
+    } catch {
+        return null;
+    }
+}
+
+// Carga perezosa de provider-disabled (evita ciclo de require en boot). Devuelve
+// null si no está disponible (fail-open: no se apaga, pero tampoco rompe).
+function _loadDisabledModule() {
+    try {
+        return require('../provider-disabled');
+    } catch {
+        return null;
+    }
+}
+
+module.exports = {
+    recordProviderSpawnDeath,
+    recordProviderHealthy,
+    peekProviderSpawnHealth,
+    stateFile,
+    DEFAULT_DEATH_THRESHOLD,
+    DEFAULT_WINDOW_MS,
+    DEFAULT_DISABLE_TTL_MS,
+    // internos para tests
+    _readRaw: readRaw,
+};

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -295,6 +295,16 @@ try { sherlockPresence = require('./lib/sherlock-presence'); } catch { /* opcion
 // resolución no-gated en lugar de devolver el archivo a pendiente/. Mantiene
 // hash-chain SHA-256 en logs/cross-provider-dispatch-*.jsonl + notify Telegram.
 const { resolveSpawnWithFallback, formatProviderResolutionLog } = require('./lib/agent-launcher/dispatch-with-fallback');
+// #4648 — clasificación de muerte prematura (provider-death vs agent-death) y
+// health/backoff por provider ante muertes al spawn. Una muerte por provider no
+// disponible (fallback que muere al spawn durante ventana de inactividad del
+// primary) NUNCA debe penalizar al issue con fast-fail + cooldown de 60min: el
+// backoff va al PROVIDER, no al (skill,issue). Require defensivo: si no cargan,
+// el handler cae al comportamiento clásico (penaliza) — fail-closed conservador.
+let providerDeathClassifier = null;
+try { providerDeathClassifier = require('./lib/agent-launcher/provider-death-classifier'); } catch { /* opcional */ }
+let providerSpawnHealth = null;
+try { providerSpawnHealth = require('./lib/agent-launcher/provider-spawn-health'); } catch { /* opcional */ }
 // #4284 — marker de runtime del provider EFECTIVO por agente en curso. Best-effort:
 // el dashboard lo lee para mostrar el provider real (no el configurado por skill).
 // Require defensivo: si el módulo no carga, el spawn no se bloquea.
@@ -8705,6 +8715,64 @@ function lanzarAgenteClaude(skill, issue, trabajandoPath, pipeline, fase, config
         hasVerdict = quickYaml.resultado === 'aprobado' || quickYaml.resultado === 'rechazado';
       } catch {}
 
+      // #4648 — Clasificar la causa ANTES de penalizar. Una muerte prematura
+      // atribuible a INDISPONIBILIDAD del provider (el resolver cayó a un
+      // fallback porque el primary estaba gateado, y ese fallback murió al
+      // spawn) NO es culpa del issue: se trata como INFRA (mover a pendiente/
+      // sin registerFastFail, sin cooldown de 60min al (skill,issue)), análogo
+      // al path `bloqueado_por_infra`. El cooldown por muerte-de-provider se
+      // aplica al PROVIDER (health/backoff), no al issue.
+      let deathKind = 'agent-death';
+      if (!hasVerdict && providerDeathClassifier) {
+        try {
+          const effProvider = (launchResult && launchResult.provider)
+            || (dispatchResolution && dispatchResolution.provider) || null;
+          const effSource = (dispatchResolution && dispatchResolution.source) || null;
+          const verdict = providerDeathClassifier.classifyPrematureDeath({
+            code, elapsedSec, hasVerdict,
+            source: effSource, provider: effProvider,
+          });
+          deathKind = verdict.kind;
+        } catch (clsErr) {
+          // Fail-closed: si la clasificación falla, penalizamos como antes.
+          log('lanzamiento', `⚠️ clasificación de muerte falló para ${skill}:#${issue}: ${clsErr.message} — trato como agent-death`);
+          deathKind = 'agent-death';
+        }
+      }
+
+      // #4648 — Muerte por provider no disponible: NO penalizar al issue.
+      if (!hasVerdict && deathKind === 'provider-death') {
+        const effProvider = (launchResult && launchResult.provider)
+          || (dispatchResolution && dispatchResolution.provider) || 'unknown';
+        // Capa 3: registrar el backoff a nivel PROVIDER. Si acumula muertes al
+        // spawn, el provider se apaga con TTL y el resolver lo saltea en el
+        // próximo tick (fail-closed de Capa 1 emerge por reuse del gate `gated`).
+        let disabled = false;
+        if (providerSpawnHealth) {
+          try {
+            const r = providerSpawnHealth.recordProviderSpawnDeath({
+              pipelineDir: PIPELINE, provider: effProvider, skill, issue,
+            });
+            disabled = !!(r && r.disabled);
+          } catch (hErr) {
+            log('lanzamiento', `⚠️ provider-spawn-health falló para ${effProvider} (${skill}:#${issue}): ${hErr.message}`);
+          }
+        }
+        log('lanzamiento', `🔌 ${skill}:#${issue} murió en ${elapsedSec.toFixed(0)}s (code=${code}) con provider fallback="${effProvider}" — muerte por provider no disponible: NO penaliza al issue${disabled ? `; provider "${effProvider}" apagado con TTL (backoff a nivel provider)` : ''}. Devuelvo a pendiente/ para reintentar al próximo tick.`);
+        const pendienteDir = path.join(fasePath(pipeline, fase), 'pendiente');
+        try { moveFile(trabajandoPath, pendienteDir); } catch {}
+        activeProcesses.delete(processKey(skill, issue));
+        killGradleDaemonsForCwd((needsWorktree || useExistingWorktree) ? worktreePath : ROOT, `${skill}:#${issue} (provider-death)`);
+        if (contextChannelId) {
+          try {
+            const cm = require(path.join(ROOT, '.claude', 'hooks', 'context-manager'));
+            cm.leaveChannelByType(contextChannelId, 'agent');
+          } catch (e) {}
+        }
+        sendTelegram(`🔌 ${skill}:#${issue} NO penalizado: su provider (fallback "${effProvider}") murió al spawn durante indisponibilidad del primary. Sin cooldown al issue; se reintenta al restaurarse un provider viable.${disabled ? ` Provider "${effProvider}" apagado con TTL.` : ''}`);
+        return;
+      }
+
       if (!hasVerdict) {
         const { failures, delayMin } = registerFastFail(skill, issue);
         log('lanzamiento', `⚠️ ${skill}:#${issue} murió en ${elapsedSec.toFixed(0)}s (code=${code}) — fallo #${failures}, cooldown ${delayMin}min`);
@@ -8760,6 +8828,20 @@ function lanzarAgenteClaude(skill, issue, trabajandoPath, pipeline, fase, config
 
     // Éxito o finalización normal → limpiar cooldown
     if (code === 0) clearCooldown(skill, issue);
+
+    // #4648 — Reset del health de spawn del provider efectivo: si el agente
+    // corrió bien (exit 0) o vivió lo suficiente (≥15s, no es muerte prematura),
+    // el provider demostró estar sano → limpiamos su contador de muertes al
+    // spawn para no apagarlo por muertes viejas no relacionadas. Best-effort.
+    if (providerSpawnHealth && (code === 0 || elapsedSec >= 15)) {
+      try {
+        const effProvider = (launchResult && launchResult.provider)
+          || (dispatchResolution && dispatchResolution.provider) || null;
+        if (effProvider && effProvider !== 'deterministic') {
+          providerSpawnHealth.recordProviderHealthy({ pipelineDir: PIPELINE, provider: effProvider });
+        }
+      } catch { /* best-effort: no rompe el lifecycle */ }
+    }
 
     // Registrar consumo de recursos del agente para perfiles predictivos
     if (elapsedSec > 30) { // Solo si corrió suficiente para tener snapshots


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 6 archivos · +632 -1

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:skipped` aplicado por delivery

## Closes

Closes #4648
