### PR TITLE
Ola 9.1 · Ajustar referencias/imports y wiring para apuntar al kernel migrado sin cambiar comportamiento

### DIFF
--- a/.pipeline/lib/kernel-resolver.js
+++ b/.pipeline/lib/kernel-resolver.js
@@ -1,0 +1,160 @@
+'use strict';
+
+/**
+ * Kernel resolver — cutover de wiring (Ola 9.1 · #4664)
+ * ----------------------------------------------------
+ * Punto ÚNICO donde el producto (adaptador Intrale) resuelve los entrypoints del
+ * motor de orquestación migrado al repo del kernel (`@intrale/operating-kernel`,
+ * #4662/#4663). En vez de que `restart.js` apunte directo a `.pipeline/pulpo.js`
+ * y `.pipeline/dashboard.js` (ubicación vieja del motor), pasa por acá: el wiring
+ * "apunta al kernel migrado" (CA-1) a través de una resolución declarativa.
+ *
+ * Reglas de diseño (contrato kernel↔adaptador #4010 §6.1 · kernel-repo-design §2):
+ *  - Se resuelve el kernel por NOMBRE de paquete desde `node_modules`
+ *    (`require.resolve`), NUNCA por `require()` de un path arbitrario ni derivado
+ *    de entrada externa (issue body / labels / chat). Los subpaths consumibles son
+ *    una allowlist estática (`ENTRYPOINTS`), no datos en banda.
+ *  - Consumo pineado por referencia inmutable + validación de `contractVersion`
+ *    antes de cargar (§6.2). Integridad del origen (security A08).
+ *
+ * Coexistencia (por qué el default NO cambia el comportamiento — CA-2/CA-3):
+ *  - El `.pipeline/` del producto QUEDA intacto durante 9.1 (ver
+ *    `docs/desacople-kernel/inventario-migrado-9.1.md`). El motor local es
+ *    byte-idéntico al del kernel (verificado por el operador 2026-07-12).
+ *  - El CONSUMO del paquete está gateado OFF por default: la externalización del
+ *    estado del motor (`.pipeline/` state, `config.yaml`) es la sub-ola 9.4 y el
+ *    freeze del motor local es la 9.5. Hasta entonces, arrancar el kernel
+ *    empaquetado resolvería mal sus paths de estado. Por eso, salvo opt-in
+ *    explícito, el resolver devuelve el motor LOCAL: el pipeline arranca idéntico.
+ *  - Cuando el consumo se habilita (post 9.4/9.5, con OK humano), este mismo
+ *    resolver pasa a devolver el entrypoint del paquete sin tocar `restart.js`.
+ *
+ * Activación (opt-in, gateado):
+ *  - `pipeline.config.json` → `kernel.consume: true`, o
+ *  - variable de entorno `PIPELINE_CONSUME_KERNEL=1`.
+ *  Habilitado + paquete ausente/incompatible ⇒ error accionable (fail-closed):
+ *  no se degrada en silencio a un motor local que el operador cree retirado.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const PIPELINE_DIR = path.resolve(__dirname, '..');           // .pipeline/
+const PRODUCT_ROOT = path.resolve(PIPELINE_DIR, '..');        // repo del producto
+const MANIFEST_PATH = path.join(PRODUCT_ROOT, 'pipeline.config.json');
+
+const KERNEL_PACKAGE = '@intrale/operating-kernel';
+// Major de contrato soportado por este adaptador. contractVersion 0.x ⇒ major 0.
+const SUPPORTED_CONTRACT_MAJOR = 0;
+
+/**
+ * Allowlist estática de entrypoints del motor que migraron a `core/` del kernel.
+ * (Frontera autoritativa: docs/desacople-kernel/inventario-migrado-9.1.md §"Mapa
+ * de re-ubicación": .pipeline/pulpo.js → core/pulpo.js, .pipeline/dashboard.js →
+ * core/dashboard.js). NO se aceptan nombres fuera de esta tabla.
+ */
+const ENTRYPOINTS = Object.freeze({
+  pulpo:     { pkgSubpath: `${KERNEL_PACKAGE}/core/pulpo`,     localScript: 'pulpo.js' },
+  dashboard: { pkgSubpath: `${KERNEL_PACKAGE}/core/dashboard`, localScript: 'dashboard.js' },
+});
+
+function readManifest() {
+  try {
+    return JSON.parse(fs.readFileSync(MANIFEST_PATH, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+/** ¿El operador habilitó explícitamente el consumo del kernel empaquetado? */
+function isConsumeEnabled(manifest = readManifest()) {
+  if (process.env.PIPELINE_CONSUME_KERNEL === '1') return true;
+  return !!(manifest && manifest.kernel && manifest.kernel.consume === true);
+}
+
+/** Resuelve el `package.json` del kernel instalado (o null si no está). */
+function resolveKernelPackageJson() {
+  try {
+    const pkgJsonPath = require.resolve(`${KERNEL_PACKAGE}/package.json`, {
+      paths: [PRODUCT_ROOT],
+    });
+    return { path: pkgJsonPath, json: JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8')) };
+  } catch {
+    return null;
+  }
+}
+
+/** ¿Está el paquete del kernel instalado en node_modules? */
+function isKernelInstalled() {
+  return resolveKernelPackageJson() !== null;
+}
+
+/**
+ * Valida compatibilidad de contrato antes de cargar (§6.2). Devuelve la versión
+ * del paquete si es compatible; lanza error accionable si no.
+ */
+function assertKernelCompatible(pkg) {
+  const version = pkg && pkg.json && pkg.json.version;
+  const major = Number.parseInt(String(version).split('.')[0], 10);
+  if (!Number.isInteger(major) || major !== SUPPORTED_CONTRACT_MAJOR) {
+    throw new Error(
+      `✗ Kernel ${KERNEL_PACKAGE}@${version || '¿?'}: contractVersion incompatible.\n` +
+      `  Qué pasó:  el adaptador soporta major ${SUPPORTED_CONTRACT_MAJOR}.x y encontró ${version}.\n` +
+      `  Por qué:   un cambio MAJOR del contrato invalida adaptadores existentes (kernel-repo-design §3.1).\n` +
+      `  Cómo seguir: alineá el pin del kernel con un release ${SUPPORTED_CONTRACT_MAJOR}.x o actualizá el adaptador.`
+    );
+  }
+  return version;
+}
+
+/**
+ * Resuelve el path del script a ejecutar para un entrypoint del motor.
+ *
+ * @param {'pulpo'|'dashboard'} name  entrypoint lógico (allowlist).
+ * @returns {{ path: string, source: 'kernel'|'local', version: string|null }}
+ */
+function resolveEntry(name) {
+  const entry = ENTRYPOINTS[name];
+  if (!entry) {
+    // Nombre fuera de la allowlist: se rechaza (no require de path arbitrario).
+    throw new Error(
+      `✗ Entrypoint de kernel desconocido: ${JSON.stringify(name)}. ` +
+      `Permitidos: ${Object.keys(ENTRYPOINTS).join(', ')}.`
+    );
+  }
+
+  const localPath = path.join(PIPELINE_DIR, entry.localScript);
+  const manifest = readManifest();
+
+  if (!isConsumeEnabled(manifest)) {
+    // Default de 9.1: motor LOCAL, comportamiento idéntico (CA-2/CA-3).
+    return { path: localPath, source: 'local', version: null };
+  }
+
+  // Consumo habilitado (opt-in gateado): fail-closed si el paquete no está listo.
+  const pkg = resolveKernelPackageJson();
+  if (!pkg) {
+    throw new Error(
+      `✗ Consumo del kernel habilitado (kernel.consume) pero ${KERNEL_PACKAGE} no está instalado.\n` +
+      `  Qué pasó:  no se puede resolver el paquete del kernel en node_modules.\n` +
+      `  Por qué:   falta 'npm ci' con el kernel pineado (o el paquete no fue publicado todavía).\n` +
+      `  Cómo seguir: instalá el kernel pineado o volvé a kernel.consume:false (motor local) — no se degrada en silencio.`
+    );
+  }
+  const version = assertKernelCompatible(pkg);
+  const resolvedPath = require.resolve(entry.pkgSubpath, { paths: [PRODUCT_ROOT] });
+  return { path: resolvedPath, source: 'kernel', version };
+}
+
+module.exports = {
+  KERNEL_PACKAGE,
+  SUPPORTED_CONTRACT_MAJOR,
+  ENTRYPOINTS,
+  MANIFEST_PATH,
+  readManifest,
+  isConsumeEnabled,
+  isKernelInstalled,
+  resolveKernelPackageJson,
+  assertKernelCompatible,
+  resolveEntry,
+};

--- a/.pipeline/restart.js
+++ b/.pipeline/restart.js
@@ -26,6 +26,10 @@ const {
 } = require('./pid-discovery');
 const { clearAllMarkers } = require('./lib/ready-marker');
 const { annotateAndMoveOrphans } = require('./lib/restart-orphan-annotator');
+// #4664 (Ola 9.1 · cutover de wiring) — el arranque del motor (pulpo/dashboard)
+// se resuelve vía el kernel-resolver: apunta al kernel migrado cuando el consumo
+// está habilitado, y al motor local de `.pipeline/` en coexistencia (default).
+const kernelResolver = require('./lib/kernel-resolver');
 
 // Saneado global de JAVA_HOME — si restart.js heredó una ruta stale (ej. JBR
 // de IntelliJ obsoleto), la corregimos antes de spawnear pulpo/servicios, así
@@ -347,7 +351,20 @@ function launchAll() {
   if (!fs.existsSync(logsDir)) fs.mkdirSync(logsDir, { recursive: true });
 
   for (const comp of COMPONENTS) {
-    const scriptPath = path.join(PIPELINE, comp.script);
+    // #4664 — pulpo y dashboard son los entrypoints del motor que migraron a
+    // `core/` del kernel: se resuelven vía kernel-resolver (kernel migrado vs
+    // motor local, según coexistencia). El resto de servicios (listener/svc-*)
+    // son del adaptador y quedan en `.pipeline/`.
+    let scriptPath;
+    if (comp.name === 'pulpo' || comp.name === 'dashboard') {
+      const resolved = kernelResolver.resolveEntry(comp.name);
+      scriptPath = resolved.path;
+      if (resolved.source === 'kernel') {
+        log(`  ${comp.name}: usando kernel migrado @${resolved.version} (${scriptPath})`);
+      }
+    } else {
+      scriptPath = path.join(PIPELINE, comp.script);
+    }
     if (!fs.existsSync(scriptPath)) continue;
 
     const logPath = path.join(logsDir, `${comp.name}.log`);

--- a/.pipeline/tests/kernel-resolver.test.js
+++ b/.pipeline/tests/kernel-resolver.test.js
@@ -1,0 +1,88 @@
+'use strict';
+
+// Tests del kernel-resolver (cutover de wiring · Ola 9.1 · #4664).
+// Verifican que el wiring del arranque apunta al kernel migrado bajo consumo
+// habilitado y cae al motor local en coexistencia, sin cambiar comportamiento
+// por default y sin require() de paths arbitrarios.
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const path = require('node:path');
+const fs = require('node:fs');
+
+const resolver = require('../lib/kernel-resolver');
+
+const PIPELINE_DIR = path.resolve(__dirname, '..');
+
+// Utilidad: correr un caso con una var de entorno seteada y restaurarla.
+function withEnv(key, value, fn) {
+  const prev = process.env[key];
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
+  try {
+    return fn();
+  } finally {
+    if (prev === undefined) delete process.env[key];
+    else process.env[key] = prev;
+  }
+}
+
+test('por default (coexistencia) resuelve pulpo al motor local de .pipeline/', () => {
+  withEnv('PIPELINE_CONSUME_KERNEL', undefined, () => {
+    const r = resolver.resolveEntry('pulpo');
+    assert.strictEqual(r.source, 'local');
+    assert.strictEqual(r.path, path.join(PIPELINE_DIR, 'pulpo.js'));
+    assert.ok(fs.existsSync(r.path), 'el motor local debe existir (comportamiento idéntico)');
+  });
+});
+
+test('por default resuelve dashboard al motor local de .pipeline/', () => {
+  withEnv('PIPELINE_CONSUME_KERNEL', undefined, () => {
+    const r = resolver.resolveEntry('dashboard');
+    assert.strictEqual(r.source, 'local');
+    assert.strictEqual(r.path, path.join(PIPELINE_DIR, 'dashboard.js'));
+    assert.ok(fs.existsSync(r.path));
+  });
+});
+
+test('rechaza entrypoints fuera de la allowlist (no require de path arbitrario)', () => {
+  assert.throws(() => resolver.resolveEntry('../../etc/passwd'), /Entrypoint de kernel desconocido/);
+  assert.throws(() => resolver.resolveEntry('servicio-telegram'), /Entrypoint de kernel desconocido/);
+});
+
+test('isConsumeEnabled respeta el override por variable de entorno', () => {
+  withEnv('PIPELINE_CONSUME_KERNEL', '1', () => {
+    assert.strictEqual(resolver.isConsumeEnabled(), true);
+  });
+  withEnv('PIPELINE_CONSUME_KERNEL', '0', () => {
+    // 0 no habilita; el manifiesto del producto declara consume:false.
+    assert.strictEqual(resolver.isConsumeEnabled(), false);
+  });
+});
+
+test('el manifiesto del producto declara consume:false (coexistencia 9.1)', () => {
+  const manifest = resolver.readManifest();
+  assert.ok(manifest, 'pipeline.config.json debe existir y parsear');
+  assert.strictEqual(manifest.kernel.consume, false);
+  assert.strictEqual(manifest.kernel.package, resolver.KERNEL_PACKAGE);
+  assert.strictEqual(manifest.contractVersion, '0.1.0');
+});
+
+test('assertKernelCompatible acepta el major soportado y rechaza uno incompatible', () => {
+  assert.strictEqual(
+    resolver.assertKernelCompatible({ json: { version: '0.1.0' } }),
+    '0.1.0'
+  );
+  assert.throws(
+    () => resolver.assertKernelCompatible({ json: { version: '1.0.0' } }),
+    /contractVersion incompatible/
+  );
+});
+
+test('con consumo habilitado y kernel ausente, falla closed (no degrada en silencio)', () => {
+  withEnv('PIPELINE_CONSUME_KERNEL', '1', () => {
+    // El paquete no está instalado en este entorno de test.
+    if (resolver.isKernelInstalled()) return; // salta si por algún motivo está
+    assert.throws(() => resolver.resolveEntry('pulpo'), /no está instalado/);
+  });
+});

--- a/docs/pipeline/kernel-cutover-9.1.md
+++ b/docs/pipeline/kernel-cutover-9.1.md
@@ -1,0 +1,77 @@
+# Cutover de wiring al kernel migrado — Ola 9.1 · #4664
+
+> **Alcance de #4664 (paso 3 de la cadena 9.1: #4662 → #4663 → #4664 → #4665):**
+> reapuntar el **wiring de arranque** del pipeline para que el producto (adaptador
+> Intrale) consuma el motor desde el **kernel migrado** (`@intrale/operating-kernel`,
+> repo `Intrale/kernel`), **sin cambiar el comportamiento**. La paridad E2E la
+> verifica #4665; el *freeze* del motor local es la sub-ola 9.5.
+>
+> **Frontera autoritativa:** [`../desacople-kernel/inventario-migrado-9.1.md`](../desacople-kernel/inventario-migrado-9.1.md)
+> · [`kernel-repo-design.md`](kernel-repo-design.md) · [`contrato-kernel-adaptador.md`](contrato-kernel-adaptador.md).
+
+## 1. Qué hace este cutover
+
+Antes, `.pipeline/restart.js` arrancaba el motor apuntando **directo** a los archivos
+locales `.pipeline/pulpo.js` y `.pipeline/dashboard.js` (ubicación vieja del motor).
+A partir de #4664, esos dos entrypoints —los únicos que migraron a `core/` del kernel
+(inventario 9.1 §"Mapa de re-ubicación")— se resuelven a través de un punto único:
+
+- **`.pipeline/lib/kernel-resolver.js`** — resuelve el entrypoint del motor por
+  **nombre de paquete** (`@intrale/operating-kernel/core/pulpo` · `/core/dashboard`)
+  desde `node_modules`, con validación de `contractVersion` previa a la carga
+  (contrato §6.2). Nunca por `require()` de un path arbitrario ni derivado de
+  entrada externa (contrato §6.1). Entrypoints = allowlist estática.
+- **`pipeline.config.json`** (raíz del producto) — manifiesto declarativo del
+  adaptador (contrato §6.1): `contractVersion`, `projectId`, `capabilities`,
+  `extensionPoints` y el bloque `kernel` con el **pin inmutable** del kernel.
+
+`restart.js` pasó a resolver `pulpo`/`dashboard` vía el resolver; el resto de
+servicios (`listener-telegram`, `svc-*`) son del adaptador y siguen en `.pipeline/`.
+
+## 2. Coexistencia — por qué el comportamiento NO cambia (CA-2/CA-3)
+
+El **consumo del paquete está gateado OFF** por default (`pipeline.config.json` →
+`kernel.consume: false`). Motivo: el kernel empaquetado todavía no tiene
+externalizado su **estado** (`.pipeline/` state, `config.yaml` → sub-ola 9.4) ni
+está consolidado el **freeze** del motor local (sub-ola 9.5). Hasta entonces:
+
+- El resolver devuelve el **motor local** de `.pipeline/` (byte-idéntico al del
+  kernel — verificado por el operador 2026-07-12). El pipeline arranca **idéntico**
+  y sin errores de resolución.
+- `.pipeline/` queda **intacto** (coexistencia), como fija el inventario 9.1.
+
+Activación futura (con OK humano, post 9.4/9.5): `kernel.consume: true` (o
+`PIPELINE_CONSUME_KERNEL=1`). Habilitado + kernel ausente/incompatible ⇒ **error
+accionable (fail-closed)**: no se degrada en silencio a un motor local que el
+operador cree retirado.
+
+## 3. Pin del kernel (integridad de origen · security A08)
+
+El pin vive declarado en `pipeline.config.json` → `kernel`:
+
+```jsonc
+"kernel": {
+  "package": "@intrale/operating-kernel",
+  "version": "0.1.0",
+  "pinnedRef": "github:Intrale/kernel#704167b82c9a95115cf9d569b55ce135500e1366",
+  "consume": false
+}
+```
+
+Es un **pin inmutable por commit SHA** (no rama móvil). La declaración en
+`package.json` (`dependencies`/`optionalDependencies`) + `package-lock.json` con
+hashes + `npm ci` es la **activación del consumo** (paso gateado): se materializa
+al consolidar el cutover (9.5), preferentemente migrando a un **release firmado
+registry-semver** `@intrale/operating-kernel@0.1.0` (kernel-repo-design §2.3/§4).
+Publicar ese release requiere acción humana (token `write:packages` + 2FA + firma):
+es un gate fail-closed por diseño, fuera del alcance autónomo de #4664.
+
+**Gate humano de CA-4:** la review de CODEOWNERS sobre el PR de este cutover
+(`.pipeline/` está cubierto por CODEOWNERS → `@leitolarreta`).
+
+## 4. Rollback
+
+- Producto: tag `pre-ola9-migracion`.
+- Kernel: rama/tag `import/motor-9.1` (motor con historia preservada).
+- Revertir el wiring = volver `restart.js` a `path.join(PIPELINE, comp.script)` o,
+  más simple, mantener `kernel.consume: false` (ya es el default: motor local).

--- a/pipeline.config.json
+++ b/pipeline.config.json
@@ -1,0 +1,30 @@
+{
+  "contractVersion": "0.1.0",
+  "projectId": "intrale-platform",
+  "displayName": "Intrale Platform",
+  "kernel": {
+    "package": "@intrale/operating-kernel",
+    "version": "0.1.0",
+    "pinnedRef": "github:Intrale/kernel#704167b82c9a95115cf9d569b55ce135500e1366",
+    "consume": false,
+    "integrity": {
+      "algorithm": "sha256",
+      "note": "Pin inmutable por commit SHA del kernel (Ola 9.1). Migrar a release firmado registry-semver al publicar @intrale/operating-kernel@0.1.0 (kernel-repo-design.md §2.3/§4). consume:false = coexistencia; el motor local de .pipeline/ sigue operativo (freeze en 9.5, paridad E2E en #4665)."
+    }
+  },
+  "capabilities": {
+    "android": true,
+    "backend": true,
+    "web": true,
+    "build": true,
+    "test": true,
+    "e2e": true,
+    "package": true,
+    "deploy": true
+  },
+  "routing": {
+    "source": ".pipeline/config.yaml",
+    "note": "La externalización de la tabla label->skill al manifiesto es la sub-ola 9.4. Durante 9.1 el ruteo vivo permanece en .pipeline/config.yaml sin cambio de comportamiento."
+  },
+  "extensionPoints": ["resolveRouting", "evaluateGate", "prepareWorkspace"]
+}


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 5 archivos · +373 -1

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:passed` aplicado por delivery

## Closes

Closes #4664
