### PR TITLE
Activar GATE 2 (firma de aceptación) en dry-run

### DIFF
--- a/.pipeline/config.yaml
+++ b/.pipeline/config.yaml
@@ -1443,7 +1443,7 @@ operator_signoff:
 # credentials.json (`TELEGRAM_LEO_OPERATOR_CHAT_ID`) y se inyecta al gate en
 # runtime (`options.authorizedSigners`). NO se crea allowlist paralela.
 operator_signature:
-  enabled: false
+  enabled: true
   gate_mode: dry-run
   go_live_date: '2026-07-10T00:00:00Z'
   preauthorized_classes: []


### PR DESCRIPTION
## Qué

Enciende `operator_signature.enabled: true` manteniendo `gate_mode: dry-run` (config.yaml, #4575).

- El gate **evalúa y loguea** los barridos de firma de aceptación pero **NUNCA bloquea** el merge (modo observación previo a `enforce`).
- La auto-aprobación calibrada (`firma_operador`) queda **OFF**: la firma es humana.
- Toggle operativo aprobado por el operador (Leo) para iniciar el piloto de firma.

## Por qué

Arranque del rollout gradual del GATE 2 (firma de aceptación del operador) según `docs/pipeline/gates-firma-operador.md` §11/§12. Dry-run permite medir los barridos sin riesgo de trabar el pipeline antes de pasar a `enforce`.

## QA

`qa:skipped` — cambio puro de config/infra (feature-flag en dry-run, sin bloqueo ni impacto en producto de usuario).