### PR TITLE
[Split de #4685] P0-C — Publish + firma + pin/bump del kernel (supply-chain)

### DIFF
--- a/.pipeline/lib/kernel-resolver.js
+++ b/.pipeline/lib/kernel-resolver.js
@@ -47,6 +47,11 @@ const KERNEL_PACKAGE = '@intrale/operating-kernel';
 // Major de contrato soportado por este adaptador. contractVersion 0.x ⇒ major 0.
 const SUPPORTED_CONTRACT_MAJOR = 0;
 
+// Pin EXACTO obligatorio (CA-C3 · #4695 · OWASP A08). Sólo "X.Y.Z"; se rechazan
+// rangos (`^1.2.3`, `~1.2.3`), comodines (`1.x`) y prereleases (`1.2.3-beta`).
+// Un auto-update silencioso del kernel = superficie de supply-chain (RCE en dev).
+const EXACT_SEMVER = /^\d+\.\d+\.\d+$/;
+
 /**
  * Allowlist estática de entrypoints del motor que migraron a `core/` del kernel.
  * (Frontera autoritativa: docs/desacople-kernel/inventario-migrado-9.1.md §"Mapa
@@ -108,6 +113,120 @@ function assertKernelCompatible(pkg) {
 }
 
 /**
+ * Mapea la versión pineada al git tag firmado del release (CA-C2 · #4695).
+ *
+ * INVARIANTE A03 (no romper): el tag a verificar sale SIEMPRE de
+ * `manifest.kernel.version` + `kernel.signature.tagPattern` (allowlist estática /
+ * config del producto), NUNCA de datos en banda (issue body / labels / chat).
+ * `{version}` es el único placeholder soportado.
+ */
+function resolveKernelTag(manifest) {
+  const version = manifest && manifest.kernel && manifest.kernel.version;
+  const sig = (manifest && manifest.kernel && manifest.kernel.signature) || {};
+  const pattern = typeof sig.tagPattern === 'string' ? sig.tagPattern : 'v{version}';
+  return pattern.replace('{version}', String(version));
+}
+
+/**
+ * Verificador REAL por defecto (CA-C2 · #4695). Corre `cosign verify-blob` sobre
+ * el asset detached del GitHub Release mapeado por tag (sigstore/OIDC keyless — NO
+ * GPG, NO provenance npm: GitHub Packages no la soporta, decisión de diseño cerrada
+ * por el arquitecto). Fail-closed: cualquier estado ≠ 0, binario ausente o material
+ * de firma incompleto ⇒ `false`. Se ejecuta sólo con consumo habilitado; hoy
+ * `consume:false` ⇒ no corre.
+ *
+ * @param {string} tag  git tag firmado (ej. "v1.4.2").
+ * @param {object} sig  bloque `kernel.signature` del manifiesto.
+ * @returns {boolean}   true sólo si cosign valida la firma.
+ */
+function verifyTagSignatureCosign(tag, sig) {
+  const { spawnSync } = require('child_process');
+  const blob = sig && sig.blobPath;
+  const signature = sig && sig.signaturePath;
+  const certificate = sig && sig.certificatePath;
+  // Sin material de firma no hay nada que verificar ⇒ fail-closed.
+  if (!blob || !signature || !certificate) return false;
+  try {
+    const res = spawnSync('cosign', [
+      'verify-blob',
+      '--certificate-identity-regexp', String(sig.certificateIdentityRegexp),
+      '--certificate-oidc-issuer', String(sig.certificateOidcIssuer),
+      '--signature', String(signature),
+      '--certificate', String(certificate),
+      String(blob),
+    ], { encoding: 'utf8' });
+    return res.status === 0;
+  } catch {
+    return false; // cosign ausente o error de spawn ⇒ fail-closed.
+  }
+}
+
+/**
+ * Gate de integridad del release ANTES de aceptar el bump (CA-C2/CA-C3 · #4695).
+ * Mismo contrato de error accionable que `assertKernelCompatible` (Qué pasó / Por
+ * qué / Cómo seguir), distinguiendo las 3 causas (guideline DX de ux):
+ *   (b) la versión es un rango en vez de un pin exacto,
+ *   (a) la firma está ausente o no verifica.
+ * (La causa (c) — paquete habilitado pero ausente/incompatible — la cubre
+ * `resolveEntry` antes de llegar acá.)
+ *
+ * Fail-closed: si la firma no verifica NO se degrada en silencio al motor local.
+ *
+ * @param {object} pkg       package.json resuelto del kernel (para el mensaje).
+ * @param {object} manifest  pipeline.config.json parseado.
+ * @param {(tag:string, sig:object)=>boolean} [verify]  verificador inyectable.
+ * @returns {string}         la versión exacta validada.
+ */
+function assertReleaseSignature(pkg, manifest, verify = verifyTagSignatureCosign) {
+  const version = manifest && manifest.kernel && manifest.kernel.version;
+
+  // (b) Pin exacto obligatorio — se rechazan rangos/comodines/prereleases (A08).
+  if (!EXACT_SEMVER.test(String(version))) {
+    throw new Error(
+      `✗ Kernel ${KERNEL_PACKAGE}: versión ${JSON.stringify(version)} no es un pin exacto.\n` +
+      `  Qué pasó:  el manifiesto declara un rango o versión no exacta, no "X.Y.Z".\n` +
+      `  Por qué:   CA-C3 prohíbe rangos (^/~) — un auto-update silencioso es supply-chain (OWASP A08).\n` +
+      `  Cómo seguir: fijá una versión exacta ("1.4.2") en pipeline.config.json → kernel.version.`
+    );
+  }
+
+  const sig = manifest && manifest.kernel && manifest.kernel.signature;
+
+  // (a.1) Config de firma ausente — sin identidad/emisor no hay qué verificar.
+  if (!sig || !sig.certificateIdentityRegexp || !sig.certificateOidcIssuer) {
+    throw new Error(
+      `✗ Kernel ${KERNEL_PACKAGE}@${version}: falta la configuración de firma del release.\n` +
+      `  Qué pasó:  kernel.signature no declara identidad/emisor OIDC para verificar el tag.\n` +
+      `  Por qué:   CA-C2 exige verificar la firma sigstore/cosign del tag antes de bumpear (OWASP A08).\n` +
+      `  Cómo seguir: completá kernel.signature (mechanism/tagPattern/certificateIdentityRegexp/certificateOidcIssuer).`
+    );
+  }
+
+  const tag = resolveKernelTag(manifest);
+  let ok = false;
+  try {
+    ok = verify(tag, sig) === true;
+  } catch {
+    ok = false; // fail-closed ante cualquier excepción del verificador.
+  }
+
+  // (a.2) La firma no verifica — fail-closed, no se degrada en silencio.
+  if (!ok) {
+    throw new Error(
+      `✗ Kernel ${KERNEL_PACKAGE}@${version}: la firma del release no verifica (tag ${tag}).\n` +
+      `  Qué pasó:  cosign no validó la firma del tag firmado del kernel.\n` +
+      `  Por qué:   release sin firmar, registry comprometido o identidad OIDC distinta (OWASP A08).\n` +
+      `  Cómo seguir: verificá manualmente con\n` +
+      `    cosign verify-blob --certificate-identity-regexp ${JSON.stringify(sig.certificateIdentityRegexp)} \\\n` +
+      `      --certificate-oidc-issuer ${sig.certificateOidcIssuer} <blob> --signature <sig> --certificate <cert>\n` +
+      `  y hacé rollback al último tag estable verificado — no se degrada en silencio al motor local.`
+    );
+  }
+
+  return version;
+}
+
+/**
  * Resuelve el path del script a ejecutar para un entrypoint del motor.
  *
  * @param {'pulpo'|'dashboard'} name  entrypoint lógico (allowlist).
@@ -142,6 +261,10 @@ function resolveEntry(name) {
     );
   }
   const version = assertKernelCompatible(pkg);
+  // Gate de supply-chain (CA-C2/CA-C3 · #4695): pin exacto + firma verificada del
+  // release ANTES de resolver el entrypoint. Corre también en el self-bootstrap
+  // (kernel-N que construye kernel-N+1) para evitar el loop de envenenamiento.
+  assertReleaseSignature(pkg, manifest);
   const resolvedPath = require.resolve(entry.pkgSubpath, { paths: [PRODUCT_ROOT] });
   return { path: resolvedPath, source: 'kernel', version };
 }
@@ -149,6 +272,7 @@ function resolveEntry(name) {
 module.exports = {
   KERNEL_PACKAGE,
   SUPPORTED_CONTRACT_MAJOR,
+  EXACT_SEMVER,
   ENTRYPOINTS,
   MANIFEST_PATH,
   readManifest,
@@ -156,5 +280,8 @@ module.exports = {
   isKernelInstalled,
   resolveKernelPackageJson,
   assertKernelCompatible,
+  resolveKernelTag,
+  verifyTagSignatureCosign,
+  assertReleaseSignature,
   resolveEntry,
 };

--- a/.pipeline/tests/kernel-resolver.test.js
+++ b/.pipeline/tests/kernel-resolver.test.js
@@ -86,3 +86,105 @@ test('con consumo habilitado y kernel ausente, falla closed (no degrada en silen
     assert.throws(() => resolver.resolveEntry('pulpo'), /no está instalado/);
   });
 });
+
+// ── Supply-chain: pin exacto + firma verificada (CA-C2/CA-C3 · #4695) ──────────
+
+// Manifiesto de firma bien formado (mismo shape que pipeline.config.json.kernel).
+function manifestConSignature(version, overrides = {}) {
+  return {
+    kernel: {
+      package: resolver.KERNEL_PACKAGE,
+      version,
+      signature: {
+        mechanism: 'sigstore-cosign-oidc',
+        tagPattern: 'v{version}',
+        certificateIdentityRegexp: '^https://github\\.com/Intrale/kernel/.*$',
+        certificateOidcIssuer: 'https://token.actions.githubusercontent.com',
+        ...overrides,
+      },
+    },
+  };
+}
+const pkgFake = { json: { version: '0.1.0' } };
+const verifyOk = () => true;
+const verifyFail = () => false;
+
+// (a) Rechazo de bump sin firma verificada → fail-closed accionable.
+test('(a) rechaza el bump si la firma del release no verifica (fail-closed)', () => {
+  const manifest = manifestConSignature('0.1.0');
+  assert.throws(
+    () => resolver.assertReleaseSignature(pkgFake, manifest, verifyFail),
+    /la firma del release no verifica/
+  );
+});
+
+test('(a) rechaza el bump si el verificador lanza excepción (fail-closed ante error)', () => {
+  const manifest = manifestConSignature('0.1.0');
+  const verifyThrows = () => { throw new Error('cosign no está instalado'); };
+  assert.throws(
+    () => resolver.assertReleaseSignature(pkgFake, manifest, verifyThrows),
+    /la firma del release no verifica/
+  );
+});
+
+test('(a) rechaza el bump si falta la configuración de firma (identidad/emisor)', () => {
+  const sinSig = { kernel: { package: resolver.KERNEL_PACKAGE, version: '0.1.0' } };
+  assert.throws(
+    () => resolver.assertReleaseSignature(pkgFake, sinSig, verifyOk),
+    /falta la configuración de firma/
+  );
+});
+
+// (b) Rechazo de rango semver → sólo versión exacta aceptada.
+test('(b) rechaza rangos semver y comodines; sólo acepta versión exacta', () => {
+  for (const rango of ['^1.2.3', '~1.2.3', '1.x', '1.2', 'latest', '1.2.3-beta', '']) {
+    assert.throws(
+      () => resolver.assertReleaseSignature(pkgFake, manifestConSignature(rango), verifyOk),
+      /no es un pin exacto/,
+      `debería rechazar "${rango}"`
+    );
+  }
+});
+
+// (c) Fail-closed con paquete habilitado pero ausente/incompatible.
+test('(c) con consumo habilitado y kernel incompatible (major distinto), falla closed', () => {
+  assert.throws(
+    () => resolver.assertKernelCompatible({ json: { version: '1.0.0' } }),
+    /contractVersion incompatible/
+  );
+});
+
+// (d) Happy-path: versión exacta + firma verificada → devuelve la versión.
+test('(d) happy-path: versión exacta + firma verificada devuelve la versión', () => {
+  const manifest = manifestConSignature('1.4.2');
+  assert.strictEqual(
+    resolver.assertReleaseSignature(pkgFake, manifest, verifyOk),
+    '1.4.2'
+  );
+});
+
+// A03: el tag a verificar sale SIEMPRE del manifiesto (version + tagPattern),
+// nunca de datos en banda. Verifica el mapeo version→tag.
+test('resolveKernelTag mapea version→tag desde el manifiesto (invariante A03)', () => {
+  assert.strictEqual(resolver.resolveKernelTag(manifestConSignature('1.4.2')), 'v1.4.2');
+  assert.strictEqual(
+    resolver.resolveKernelTag(manifestConSignature('2.0.0', { tagPattern: 'release-{version}' })),
+    'release-2.0.0'
+  );
+});
+
+// El manifiesto real del producto declara el bloque de firma cosign OIDC (CA-C2).
+test('pipeline.config.json declara la firma cosign OIDC y pin exacto (CA-C2/CA-C3)', () => {
+  const manifest = resolver.readManifest();
+  assert.strictEqual(manifest.kernel.signature.mechanism, 'sigstore-cosign-oidc');
+  assert.strictEqual(manifest.kernel.signature.certificateOidcIssuer, 'https://token.actions.githubusercontent.com');
+  assert.match(manifest.kernel.version, resolver.EXACT_SEMVER);
+  // consume:false permanece intacto (coexistencia; freeze del motor local es 9.5).
+  assert.strictEqual(manifest.kernel.consume, false);
+});
+
+// El verificador real es fail-closed sin material de firma (blob/sig/cert).
+test('verifyTagSignatureCosign devuelve false sin material de firma (fail-closed)', () => {
+  const sig = { certificateIdentityRegexp: 'x', certificateOidcIssuer: 'y' };
+  assert.strictEqual(resolver.verifyTagSignatureCosign('v1.4.2', sig), false);
+});

--- a/docs/pipeline/kernel-release-workflow.md
+++ b/docs/pipeline/kernel-release-workflow.md
@@ -1,0 +1,88 @@
+# Workflow de release del kernel — supply-chain (#4695 · Workstream C)
+
+> Publish + firma + pin/bump del kernel `@intrale/operating-kernel`. Superficie
+> nueva de cadena de suministro (OWASP **A08** integridad + **A01** control de
+> acceso). Ver diseño en [`kernel-repo-design.md` §2–§4](kernel-repo-design.md),
+> [`contrato-kernel-adaptador.md` §7](contrato-kernel-adaptador.md).
+
+## Qué entrega este issue
+
+Tres piezas, dos repos:
+
+| Pieza | Repo | Estado |
+|-------|------|--------|
+| `release.yml` (publish + gate humano + firma cosign) | `intrale/kernel` | **Propuesto**, sin commitear (CA-C0, ver abajo) |
+| `pipeline.config.json:kernel` (pin exacto + firma) | `intrale/platform` (este) | Migrado |
+| `.pipeline/lib/kernel-resolver.js` (verificación fail-closed) | `intrale/platform` (este) | Implementado |
+
+## CA-C0 · Gate bloqueante antes de commitear el `release.yml`
+
+El `release.yml` destinado a `intrale/kernel/.github/workflows/release.yml` se
+versiona **en este repo** como
+[`kernel-release-workflow.proposed.yml`](kernel-release-workflow.proposed.yml)
+—artefacto revisable—, **no** en el repo del kernel. Motivo: CA-C0 exige el
+**sign-off de `security` sobre el YAML concreto ANTES del commit** del workflow
+(el kernel ejecuta código arbitrario en las máquinas de dev: una versión
+maliciosa = RCE). El commit al repo del kernel se hace recién con el sign-off
+registrado, junto al escaneo de secretos previo al primer commit.
+
+### Controles verificables en el YAML propuesto
+
+- **CA-C1 (A01):** sin auto-publish. `permissions: contents: read` a nivel
+  workflow; el job `publish` corre detrás de `environment: release` con required
+  reviewers (gate humano nativo de GitHub) y eleva `packages/id-token/contents:
+  write` sólo ahí. El job `verify` chequea `tag == package.json.version` (pin
+  exacto) antes de publicar.
+- **CA-C2 (A08):** firma del tag con **sigstore/cosign OIDC keyless** (`id-token:
+  write`), sin claves privadas de larga vida (decisión de diseño cerrada por el
+  arquitecto — NO GPG, NO provenance npm: GitHub Packages no la soporta). La
+  firma se adjunta al GitHub Release.
+- **CA-C4 (A01):** token de publish = `secrets.GITHUB_TOKEN` scoped al job (no
+  PAT embebido). Branch protection en `main` del kernel + 2FA obligatorio en el
+  registry se configuran en Settings del repo del kernel (fuera del YAML; parte
+  del checklist de CA-C0).
+
+## CA-C2/CA-C3 · Consumo pineado y verificado en el adaptador
+
+`pipeline.config.json:kernel` migró el pin por SHA
+(`pinnedRef: github:Intrale/kernel#704167b…`) a **versión exacta de registry** +
+bloque `signature` (cosign OIDC) + `integrity` SRI:
+
+- **Pin exacto:** `version: "0.1.0"` (nunca `^`/`~`). `kernel-resolver` rechaza
+  rangos con `EXACT_SEMVER` (`/^\d+\.\d+\.\d+$/`).
+- **Firma verificada antes de bumpear:** `assertReleaseSignature(pkg, manifest)`
+  se invoca en `resolveEntry` (después de `assertKernelCompatible`) y es
+  **fail-closed** — si la firma no verifica, NO se degrada en silencio al motor
+  local. Corre también en el self-bootstrap (kernel-N → kernel-N+1) para evitar
+  el loop de envenenamiento.
+- **`npm ci` + SRI:** consumo reproducible contra `package-lock.json` con hashes
+  SRI. El campo `integrity.sri` se puebla desde el lockfile cuando
+  `@intrale/operating-kernel@0.1.0` esté publicado y firmado (gate humano CA-C1).
+- **Coexistencia:** `consume: false` permanece intacto. El motor local de
+  `.pipeline/` sigue operativo; el freeze es la sub-ola 9.5, fuera de este issue.
+
+### Contrato de error accionable (DX · ux)
+
+El gate fail-closed distingue las 3 causas con formato `Qué pasó / Por qué / Cómo
+seguir` (mismo contrato que `assertKernelCompatible`):
+
+1. **firma ausente/no verifica** → incluye el comando `cosign verify-blob …`.
+2. **versión es un rango** en vez de exacta.
+3. **paquete habilitado pero ausente/incompatible** (lo cubre `resolveEntry`).
+
+## Comando de verificación manual (cosign)
+
+```bash
+cosign verify-blob \
+  --certificate-identity-regexp '^https://github\.com/Intrale/kernel/\.github/workflows/release\.yml@refs/tags/v\d+\.\d+\.\d+$' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  <blob.tgz> --signature <kernel-X.Y.Z.sig> --certificate <kernel-X.Y.Z.pem>
+```
+
+## Tests
+
+`node --test .pipeline/tests/kernel-resolver.test.js` cubre: (a) rechazo sin
+firma verificada (incluye verificador que lanza excepción y config de firma
+ausente), (b) rechazo de rangos/comodines semver, (c) fail-closed con paquete
+ausente/incompatible, (d) happy-path de firma verificada, más el mapeo A03
+`version→tag` y la declaración de firma en el manifiesto real.

--- a/docs/pipeline/kernel-release-workflow.proposed.yml
+++ b/docs/pipeline/kernel-release-workflow.proposed.yml
@@ -1,0 +1,135 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# PROPUESTA de release.yml para el repo SEPARADO `intrale/kernel`
+# Destino real: intrale/kernel/.github/workflows/release.yml  (hoy 404 · greenfield)
+#
+# ⚠️ CA-C0 (BLOQUEANTE · #4695 · OWASP A01): este YAML NO se commitea al repo del
+#    kernel hasta el sign-off de `security` sobre este archivo concreto. Se versiona
+#    acá (repo del producto) como artefacto revisable para que la fase de
+#    verificación lo evalúe contra el checklist §4 de kernel-repo-design.md.
+#
+# Controles de seguridad incorporados (verificables punto por punto):
+#  · CA-C1 (A01): sin auto-publish. El job `publish` está detrás de un
+#    `environment: release` con required reviewers → GitHub PAUSA el job hasta la
+#    aprobación humana. `permissions:` a nivel workflow = `contents: read`;
+#    `packages/id-token/contents: write` se elevan SÓLO en `publish`.
+#  · CA-C1: chequeo `tag == package.json.version` antes de publicar (job `verify`,
+#    sin permisos elevados) → impide publicar una versión que no corresponde al tag.
+#  · CA-C2 (A08): firma del tag con sigstore/cosign OIDC keyless (id-token: write),
+#    sin gestión de claves privadas de larga vida. La firma se adjunta al GitHub
+#    Release; el consumidor la verifica en kernel-resolver.assertReleaseSignature.
+#  · CA-C4 (A01): token de publish = `secrets.GITHUB_TOKEN` scoped al job (NO PAT de
+#    larga vida embebido). Branch protection + 2FA se configuran fuera del YAML
+#    (Settings del repo del kernel) y forman parte del checklist de CA-C0.
+#  · A05/A07: sin secretos hardcodeados; sólo el GITHUB_TOKEN builtin. Escaneo de
+#    secretos antes del primer commit (parte de CA-C0).
+# ─────────────────────────────────────────────────────────────────────────────
+name: release
+
+# Dispara al pushear un tag de versión (vX.Y.Z), o manualmente sobre un tag
+# existente. El PUBLISH NO es automático: queda detrás del gate humano del
+# environment `release` (required reviewers). Nada se publica sin aprobación.
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag de release existente a publicar (vX.Y.Z)'
+        required: true
+
+# Permisos mínimos a nivel workflow: SÓLO lectura. Se elevan por-job.
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ github.event.inputs.tag || github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  # 1) Validación SIN permisos elevados: el tag debe coincidir con
+  #    package.json.version y ser un pin exacto (nada de rangos).
+  verify:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.check.outputs.version }}
+    steps:
+      - name: Checkout del tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref_name }}
+          persist-credentials: false
+      - name: Verificar tag == package.json.version (pin exacto)
+        id: check
+        run: |
+          set -euo pipefail
+          REF="${{ github.event.inputs.tag || github.ref_name }}"
+          TAG_VERSION="${REF#v}"
+          PKG_VERSION="$(node -p "require('./package.json').version")"
+          echo "tag=$TAG_VERSION package.json=$PKG_VERSION"
+          if ! printf '%s' "$PKG_VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::package.json.version ($PKG_VERSION) no es un pin exacto X.Y.Z."
+            exit 1
+          fi
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::El tag ($TAG_VERSION) no coincide con package.json.version ($PKG_VERSION)."
+            exit 1
+          fi
+          echo "version=$PKG_VERSION" >> "$GITHUB_OUTPUT"
+
+  # 2) Publish + firma. GATE HUMANO: environment `release` con required reviewers.
+  #    GitHub pausa este job hasta la aprobación de un reviewer autorizado ⇒ no hay
+  #    auto-publish (CA-C1). Permisos elevados SÓLO en este job.
+  publish:
+    needs: verify
+    runs-on: ubuntu-latest
+    environment: release   # required reviewers en Settings → Environments (gate humano)
+    permissions:
+      contents: write      # adjuntar los assets de firma al GitHub Release
+      packages: write      # publicar a GitHub Packages
+      id-token: write      # OIDC keyless para cosign (CA-C2)
+    steps:
+      - name: Checkout del tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref_name }}
+          persist-credentials: false
+      - name: Setup Node + registry de GitHub Packages
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@intrale'
+      - name: Instalar dependencias (reproducible)
+        run: npm ci
+      - name: Publicar a GitHub Packages
+        run: npm publish
+        env:
+          # Token scoped al job (builtin), NO un PAT de larga vida embebido (CA-C4).
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Instalar cosign
+        uses: sigstore/cosign-installer@v3
+      - name: Firmar el release con cosign (OIDC keyless · CA-C2)
+        env:
+          COSIGN_YES: 'true'
+        run: |
+          set -euo pipefail
+          VERSION="${{ needs.verify.outputs.version }}"
+          # Blob canónico firmado = tarball publicado del paquete.
+          npm pack
+          BLOB="$(ls intrale-operating-kernel-*.tgz)"
+          cosign sign-blob --yes \
+            --output-signature "kernel-${VERSION}.sig" \
+            --output-certificate "kernel-${VERSION}.pem" \
+            "$BLOB"
+      - name: Adjuntar firma al GitHub Release (consumidor la verifica antes de bumpear)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          VERSION="${{ needs.verify.outputs.version }}"
+          gh release upload "v${VERSION}" \
+            "kernel-${VERSION}.sig" "kernel-${VERSION}.pem" \
+            --clobber

--- a/pipeline.config.json
+++ b/pipeline.config.json
@@ -5,11 +5,19 @@
   "kernel": {
     "package": "@intrale/operating-kernel",
     "version": "0.1.0",
-    "pinnedRef": "github:Intrale/kernel#704167b82c9a95115cf9d569b55ce135500e1366",
+    "registry": "https://npm.pkg.github.com",
     "consume": false,
+    "signature": {
+      "mechanism": "sigstore-cosign-oidc",
+      "tagPattern": "v{version}",
+      "certificateIdentityRegexp": "^https://github\\.com/Intrale/kernel/\\.github/workflows/release\\.yml@refs/tags/v\\d+\\.\\d+\\.\\d+$",
+      "certificateOidcIssuer": "https://token.actions.githubusercontent.com",
+      "note": "CA-C2 (#4695): firma del git tag con sigstore/cosign OIDC keyless (NO GPG, NO provenance npm — GitHub Packages no la soporta; decisión de diseño cerrada por el arquitecto). kernel-resolver.assertReleaseSignature mapea version->tag (tagPattern) y verifica la firma del asset detached del GitHub Release ANTES de bumpear (fail-closed). blobPath/signaturePath/certificatePath los provee el flujo de consumo cuando consume:true. Comando manual: cosign verify-blob --certificate-identity-regexp <id> --certificate-oidc-issuer https://token.actions.githubusercontent.com <blob> --signature <sig> --certificate <cert>."
+    },
     "integrity": {
-      "algorithm": "sha256",
-      "note": "Pin inmutable por commit SHA del kernel (Ola 9.1). Migrar a release firmado registry-semver al publicar @intrale/operating-kernel@0.1.0 (kernel-repo-design.md §2.3/§4). consume:false = coexistencia; el motor local de .pipeline/ sigue operativo (freeze en 9.5, paridad E2E en #4665)."
+      "algorithm": "sha512",
+      "sri": null,
+      "note": "CA-C3 (#4695): pin EXACTO (version 'X.Y.Z', nunca ^/~) + npm ci contra package-lock.json con hashes SRI. 'sri' se puebla desde el lockfile cuando @intrale/operating-kernel@0.1.0 esté publicado y firmado (gate humano CA-C1 en intrale/kernel/.github/workflows/release.yml). Migrado desde pinnedRef 'github:Intrale/kernel#704167b82c9a95115cf9d569b55ce135500e1366' (Ola 9.1). consume:false permanece = coexistencia; el motor local de .pipeline/ sigue operativo (freeze en sub-ola 9.5, fuera de #4695). No degradar en silencio: resolver fail-closed si consume:true y firma/paquete no verifican."
     }
   },
   "capabilities": {


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 5 archivos · +463 -3

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:skipped` aplicado por delivery

## Closes

Closes #4695
