### PR TITLE
Dead-man's switch de la ola: alertar cuando hay trabajo habilitado y 0 despacho sin causa declarada

### DIFF
--- a/.pipeline/assets/docs/4708/architect-aprobacion-4708.md
+++ b/.pipeline/assets/docs/4708/architect-aprobacion-4708.md
@@ -1,0 +1,3 @@
+## Dictamen de integridad técnica — issue #4708
+**N/A — no aplica dictamen técnico.**
+Motivo: gate architect Fase 2 deshabilitado (architect.enabled=false, gate_mode=dry-run), sin verificación de adherencia; además el issue aún no tiene PR abierto (se crea en la fase entrega, posterior) ni receta firmada de pre-admisión que evaluar.

--- a/.pipeline/config.yaml
+++ b/.pipeline/config.yaml
@@ -454,6 +454,27 @@ watchdog:
   # inválido → default, NUNCA "nunca stale" — SEC-2).
   pulpo_liveness_kill_seconds: 180
 
+# =============================================================================
+# Wave-stall watchdog (#4708) — dead-man's switch de la ola
+# =============================================================================
+# Detecta la condición "trabajo habilitado + 0 despacho durante N minutos + sin
+# causa declarada" y alerta a Telegram + escala la ola a `needs_attention`
+# (label `needs-human`). NO cierra la ola ni mata agentes: sólo observabilidad
+# fail-closed (incidente raíz #4700). La lógica de decisión vive en
+# .pipeline/lib/wave-stall-watchdog.js (función pura testeada con node --test);
+# el brazo del Pulpo recolecta los hechos del filesystem y la invoca.
+#
+# stall_minutes se valida con clamp fail-closed (SEC-3): 0, negativo, no-numérico
+# o absurdamente grande (> 1440 min = 24h) cae al default seguro — NUNCA
+# "nunca stall" ni deshabilita de facto el watchdog.
+wave_watchdog:
+  enabled: false                 # rollout gradual — activar tras smoke test post-restart
+  kill_switch: false             # corte de emergencia: true desactiva el brazo sin tocar `enabled`
+  stall_minutes: 20              # 0 despacho más de esto (con trabajo habilitado y sin causa) = estancada
+  alert_cooldown_minutes: 30     # SEC-4: mín. entre re-alertas del mismo episodio (anti-flood)
+  window_minutes: 60             # ventana de referencia para la serie de avance/despacho
+  tick_ms: 60000                 # cada cuánto corre el brazo (default 1 min)
+
 # Dashboard — opciones del dashboard del pipeline
 dashboard:
   # #2895 — Threshold (% del promedio histórico) a partir del cual un agente

--- a/.pipeline/deliverables/4708.json
+++ b/.pipeline/deliverables/4708.json
@@ -1,0 +1,15 @@
+{
+  "issue": 4708,
+  "entries": [
+    {
+      "issue": 4708,
+      "fase": "aprobacion",
+      "agente": "architect",
+      "tipo": "document",
+      "path": ".pipeline/assets/docs/4708/architect-aprobacion-4708.md",
+      "bytes": 345,
+      "sensible": false,
+      "timestamp": "2026-07-14T18:34:11.684Z"
+    }
+  ]
+}

--- a/.pipeline/lib/wave-audit.js
+++ b/.pipeline/lib/wave-audit.js
@@ -48,6 +48,8 @@ const EVENTS = Object.freeze([
     'dependency_declared', // #4525: dependencia padre→hijos declarada (split auto-incorporado)
     'wave_waiting_operator',         // #4578: ola retenida por el gate de coherencia (veto operador)
     'wave_waiting_operator_cleared', // #4578: retención waiting-operator liberada
+    'wave_stalled',                  // #4708: dead-man's switch marcó la ola estancada
+    'wave_stalled_cleared',          // #4708: marca de estancamiento liberada
 ]);
 
 // -----------------------------------------------------------------------------

--- a/.pipeline/lib/wave-stall-watchdog.js
+++ b/.pipeline/lib/wave-stall-watchdog.js
@@ -1,0 +1,316 @@
+// =============================================================================
+// wave-stall-watchdog.js — Dead-man's switch de la ola (#4708)
+//
+// Por qué este módulo existe
+// --------------------------
+// El 2026-07-14 la Ola Puente quedó con trabajo abierto/habilitado y 0 agentes
+// despachando durante un largo rato sin que saltara ninguna alarma. No existía
+// un dead-man's switch que dijera "esta ola lleva N minutos sin mover una ficha
+// y sin causa declarada". Combinado con el corte silencioso del circuit breaker,
+// el sistema se quedó ciego (incidente raíz #4700).
+//
+// Este módulo aporta la lógica de decisión PURA (`decide(facts)`) modelada 1:1
+// sobre `watchdog-supervisor.js::decide` (fail-closed, cap/cooldown/dedup por
+// ventana, parse de umbral con clamp). El brazo del Pulpo (pulpo.js) recolecta
+// los hechos del filesystem y llama `decide`; ante `alert`/`escalate` dispara
+// Telegram + estado de ola `stalled` + escalada `needs-human`.
+//
+// Defensas de seguridad incorporadas (de la fase de criterios, #4708):
+//   SEC-1  Integridad de la 'causa declarada' (fail-closed): causa ausente,
+//          ilegible, corrupta o EXPIRADA => tratar como *sin causa* => disparar.
+//          Nunca asumir "hay causa, callar".
+//   SEC-2  El mensaje sólo lleva waveKey + motivo. Prohibido paths absolutos,
+//          tokens o dumps de estado (validado por buildAlertMessage + test).
+//   SEC-3  stall_minutes desde config validada: 0, negativo, no-numérico o
+//          gigante => default seguro. NUNCA "nunca stall" ni deshabilitar de
+//          facto (clamp con MAX_STALL_MINUTES).
+//   SEC-4  Anti-flooding: dedup por ventana (lastAlertTs por ola) — una alerta
+//          + escalado por episodio, cooldown entre re-alertas. Un episodio nuevo
+//          (la ola movió ficha y volvió a estancarse) SÍ re-alerta.
+//
+// Cero dependencias npm. `decide` es una función PURA: NO lee del filesystem
+// (las señales entran como `facts`), y devuelve el `nextState` a persistir.
+// =============================================================================
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const DEFAULT_STALL_MINUTES = 20;
+// Cota superior de seguridad (SEC-3): un N gigante equivaldría a "nunca stall".
+// 1440 min = 24h. Un umbral mayor a esto se trata como inválido → default.
+const MAX_STALL_MINUTES = 1440;
+const DEFAULT_COOLDOWN_MINUTES = 30;
+const DEFAULT_WINDOW_MINUTES = 60;
+
+/**
+ * Valida el umbral de estancamiento en minutos (SEC-3).
+ * Debe ser entero en [1, MAX_STALL_MINUTES]. Un valor no numérico / 0 /
+ * negativo / absurdamente grande NO debe degradar el chequeo a "nunca stall":
+ * cae al default seguro.
+ *
+ * @param {*} raw            valor crudo (string de env o number de config)
+ * @param {number} fallback  default si raw es inválido
+ * @returns {number} entero positivo acotado
+ */
+function parseStallMinutes(raw, fallback = DEFAULT_STALL_MINUTES) {
+  const safeFallback =
+    Number.isInteger(fallback) && fallback >= 1 && fallback <= MAX_STALL_MINUTES
+      ? fallback
+      : DEFAULT_STALL_MINUTES;
+  const inRange = (n) => Number.isInteger(n) && n >= 1 && n <= MAX_STALL_MINUTES;
+  if (typeof raw === 'number') {
+    return inRange(raw) ? raw : safeFallback;
+  }
+  if (typeof raw === 'string') {
+    const trimmed = raw.trim();
+    if (/^[0-9]+$/.test(trimmed)) {
+      const n = parseInt(trimmed, 10);
+      if (inRange(n)) return n;
+    }
+  }
+  return safeFallback;
+}
+
+/**
+ * Valida un entero positivo genérico (cooldown, window).
+ */
+function parsePositiveInt(raw, fallback) {
+  const safeFallback = Number.isInteger(fallback) && fallback >= 1 ? fallback : 1;
+  if (typeof raw === 'number' && Number.isInteger(raw) && raw >= 1) return raw;
+  if (typeof raw === 'string' && /^[0-9]+$/.test(raw.trim())) {
+    const n = parseInt(raw.trim(), 10);
+    if (n >= 1) return n;
+  }
+  return safeFallback;
+}
+
+const DEFAULT_STATE = Object.freeze({
+  lastMovementTs: 0,
+  lastSignature: null,
+  lastAlertTs: 0,
+  alertCount: 0,
+});
+
+/**
+ * Normaliza el estado persistido del watchdog. Tolerante: campos ausentes o de
+ * tipo inválido caen a su default. NO propaga basura al resto de la lógica.
+ */
+function normalizeState(obj) {
+  const out = { lastMovementTs: 0, lastSignature: null, lastAlertTs: 0, alertCount: 0 };
+  if (!obj || typeof obj !== 'object') return out;
+  if (Number.isFinite(obj.lastMovementTs) && obj.lastMovementTs > 0) {
+    out.lastMovementTs = obj.lastMovementTs;
+  }
+  if (typeof obj.lastSignature === 'string') {
+    out.lastSignature = obj.lastSignature;
+  }
+  if (Number.isFinite(obj.lastAlertTs) && obj.lastAlertTs > 0) {
+    out.lastAlertTs = obj.lastAlertTs;
+  }
+  if (Number.isInteger(obj.alertCount) && obj.alertCount >= 0) {
+    out.alertCount = obj.alertCount;
+  }
+  return out;
+}
+
+/**
+ * Carga el estado del watchdog. Fail-soft: archivo ausente o corrupto =>
+ * estado vacío (NO bloquea la vigilancia).
+ */
+function loadState(file) {
+  try {
+    const raw = fs.readFileSync(file, 'utf8');
+    const parsed = JSON.parse(raw);
+    return normalizeState(parsed);
+  } catch (_) {
+    return { ...DEFAULT_STATE };
+  }
+}
+
+/**
+ * Escritura atómica del estado (tmp + rename).
+ */
+function saveStateAtomic(file, state) {
+  const tmp = `${file}.tmp`;
+  const dir = path.dirname(file);
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+  } catch (_) {
+    /* fail-soft */
+  }
+  fs.writeFileSync(tmp, JSON.stringify(normalizeState(state), null, 2));
+  fs.renameSync(tmp, file);
+}
+
+/**
+ * ¿La causa declarada es válida para suprimir la alarma? (SEC-1, fail-closed).
+ *
+ * Una causa sólo suprime la alarma si:
+ *   - existe (no null / no undefined),
+ *   - es legible (readable !== false: corrupta/ilegible => NO suprime),
+ *   - está declarada (declared === true),
+ *   - NO está expirada (si trae expiresAt finito, now <= expiresAt).
+ *
+ * Ante CUALQUIER ambigüedad (ausente, ilegible, expirada) => NO válida => la
+ * alarma se dispara. Nunca "hay causa, callar".
+ *
+ * @param {object|null} cause  { declared, kind?, expiresAt?, readable? }
+ * @param {number} now         timestamp actual (ms)
+ * @returns {boolean}
+ */
+function isCauseValid(cause, now) {
+  if (!cause || typeof cause !== 'object') return false;     // ausente
+  if (cause.readable === false) return false;                // corrupta/ilegible
+  if (cause.declared !== true) return false;                 // sin causa real
+  // Expiración (anti "causa zombi"): si trae expiresAt finito y ya venció → inválida.
+  if (cause.expiresAt != null) {
+    const exp = Number(cause.expiresAt);
+    if (!Number.isFinite(exp)) return false;                 // expiración ilegible → fail-closed
+    if (Number.isFinite(now) && now > exp) return false;     // expirada
+  }
+  return true;
+}
+
+/**
+ * Firma de movimiento de la ola: combina el conteo de despacho (`trabajando/`
+ * de todas las fases) con el último `avancePct`. La ola "movió una ficha" si
+ * cambia CUALQUIERA de los dos (definición del PO, CA). Evita el falso
+ * estancamiento por trabajo intra-fase (agente trabajando sin promover ficha).
+ */
+function movementSignature(dispatching, progressSeries) {
+  const d = Number.isFinite(dispatching) ? dispatching : 0;
+  let avance = 'na';
+  if (Array.isArray(progressSeries) && progressSeries.length > 0) {
+    const last = progressSeries[progressSeries.length - 1];
+    if (last && Number.isFinite(last.avancePct)) avance = String(last.avancePct);
+  }
+  return `${d}:${avance}`;
+}
+
+/**
+ * Construye el mensaje de alerta (SEC-2 / CA-5 / guidelines UX).
+ * SÓLO waveKey + motivo + contexto operativo mínimo. Prohibido paths absolutos,
+ * tokens, secrets o dumps de estado. Determinístico y testeable.
+ *
+ * @param {{waveKey:*, stallMinutes:number, enabledCount:number}} p
+ * @returns {string}
+ */
+function buildAlertMessage(p) {
+  const waveKey = p && p.waveKey != null ? String(p.waveKey) : '?';
+  const mins = Number.isFinite(p && p.stallMinutes) ? p.stallMinutes : DEFAULT_STALL_MINUTES;
+  const enabled = Number.isInteger(p && p.enabledCount) && p.enabledCount >= 0 ? p.enabledCount : 0;
+  return (
+    `Ola ${waveKey} estancada — 0 despacho hace ${mins} min sin causa declarada. ` +
+    `${enabled} issue(s) habilitado(s) esperando; ola marcada needs_attention.`
+  );
+}
+
+/**
+ * Decide qué hacer dada la foto de la ola. Función PURA: no lee FS, no muta el
+ * input; devuelve la decisión y el `nextState` a persistir por el caller.
+ *
+ * @param {object} facts
+ * @param {number} facts.now                  timestamp actual (ms)
+ * @param {*}      facts.waveKey              identificador de la ola activa
+ * @param {number} facts.enabledCount         # issues habilitados (no completados, sin bloqueo)
+ * @param {number} facts.dispatching          # archivos en trabajando/ de todas las fases
+ * @param {Array}  [facts.progressSeries]     serie {ts, waveKey, avancePct} de wave-progress
+ * @param {object|null} [facts.cause]         causa declarada normalizada (ver isCauseValid)
+ * @param {object} [facts.state]              estado persistido del watchdog
+ * @param {*}      [facts.stallMinutes]
+ * @param {*}      [facts.cooldownMinutes]
+ * @param {*}      [facts.windowMinutes]
+ * @returns {{action:'skip'|'alert'|'escalate', reason:string, level:'info'|'warn'|'error',
+ *            stalledMs:number, message:string|null, waveKey:*, enabledCount:number,
+ *            stallMinutes:number, nextState:object}}
+ */
+function decide(facts) {
+  const stallMinutes = parseStallMinutes(facts.stallMinutes, DEFAULT_STALL_MINUTES);
+  const cooldownMinutes = parsePositiveInt(facts.cooldownMinutes, DEFAULT_COOLDOWN_MINUTES);
+  parsePositiveInt(facts.windowMinutes, DEFAULT_WINDOW_MINUTES); // validado (reservado para poda futura)
+
+  const now = Number.isFinite(facts.now) ? facts.now : 0;
+  const stallMs = stallMinutes * 60 * 1000;
+  const cooldownMs = cooldownMinutes * 60 * 1000;
+
+  const state = normalizeState(facts.state);
+  const enabledCount = Number.isInteger(facts.enabledCount) && facts.enabledCount > 0 ? facts.enabledCount : 0;
+  const dispatching = Number.isInteger(facts.dispatching) && facts.dispatching > 0 ? facts.dispatching : 0;
+
+  // --- 1. Detección de "ficha movida" -----------------------------------
+  // La firma combina despacho + avancePct. Si cambia (o es la primera foto),
+  // la ola se movió: reiniciamos el reloj de estancamiento y el episodio de
+  // alerta (SEC-4: un episodio nuevo posterior SÍ re-alerta).
+  const signature = movementSignature(dispatching, facts.progressSeries);
+  const movedFicha = state.lastSignature == null || state.lastSignature !== signature;
+  const nextState = { ...state, lastSignature: signature };
+  if (movedFicha) {
+    nextState.lastMovementTs = now;
+    nextState.lastAlertTs = 0;
+    nextState.alertCount = 0;
+  }
+  const lastMovementTs = nextState.lastMovementTs > 0 ? nextState.lastMovementTs : now;
+
+  const base = (action, reason, level) => ({
+    action,
+    reason,
+    level,
+    stalledMs: Math.max(0, now - lastMovementTs),
+    message: null,
+    waveKey: facts.waveKey != null ? facts.waveKey : null,
+    enabledCount,
+    stallMinutes,
+    nextState,
+  });
+
+  // --- 2. Sin trabajo habilitado => nada que vigilar --------------------
+  if (enabledCount <= 0) return base('skip', 'no-enabled-work', 'info');
+
+  // --- 3. Hay despacho actual => la ola no está muda --------------------
+  if (dispatching > 0) return base('skip', 'dispatching', 'info');
+
+  // --- 4. Causa declarada vigente => no falsa-alarma (CA-2 / SEC-1) -----
+  // Fail-closed: causa ausente/ilegible/expirada NO es válida => seguimos.
+  if (isCauseValid(facts.cause, now)) {
+    const kind = (facts.cause && facts.cause.kind) ? String(facts.cause.kind) : 'declared';
+    return base('skip', `declared-cause:${kind}`, 'info');
+  }
+
+  // --- 5. ¿Cuánto lleva mudo? -------------------------------------------
+  const stalledMs = Math.max(0, now - lastMovementTs);
+  if (stalledMs < stallMs) return base('skip', 'within-threshold', 'info');
+
+  // --- 6. Anti-flooding: dedup por cooldown dentro del episodio (SEC-4) -
+  if (state.lastAlertTs > 0 && now - state.lastAlertTs < cooldownMs) {
+    return base('skip', 'cooldown', 'info');
+  }
+
+  // --- 7. Estancamiento inexplicado confirmado: disparar ----------------
+  const prevAlerts = state.alertCount || 0;
+  const action = prevAlerts === 0 ? 'alert' : 'escalate';
+  nextState.lastAlertTs = now;
+  nextState.alertCount = prevAlerts + 1;
+
+  const decision = base(action, 'unexplained-stall', action === 'alert' ? 'warn' : 'error');
+  decision.stalledMs = stalledMs;
+  decision.message = buildAlertMessage({ waveKey: facts.waveKey, stallMinutes, enabledCount });
+  return decision;
+}
+
+module.exports = {
+  decide,
+  isCauseValid,
+  buildAlertMessage,
+  movementSignature,
+  parseStallMinutes,
+  parsePositiveInt,
+  normalizeState,
+  loadState,
+  saveStateAtomic,
+  DEFAULT_STALL_MINUTES,
+  MAX_STALL_MINUTES,
+  DEFAULT_COOLDOWN_MINUTES,
+  DEFAULT_WINDOW_MINUTES,
+};

--- a/.pipeline/lib/wave-stall-watchdog.test.js
+++ b/.pipeline/lib/wave-stall-watchdog.test.js
@@ -1,0 +1,351 @@
+// =============================================================================
+// wave-stall-watchdog.test.js — Tests de la lógica de decisión (#4708)
+//
+// Cobertura objetivo: 100% de ramas de `decide`, `parseStallMinutes`,
+// `isCauseValid` y `buildAlertMessage` (fail-closed es crítico).
+// =============================================================================
+
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const wd = require('./wave-stall-watchdog');
+
+const MIN = 60 * 1000;
+
+// Helper: foto base "estancada" (trabajo habilitado, 0 despacho, sin causa).
+function stalledFacts(overrides = {}) {
+  return {
+    now: 100 * MIN,
+    waveKey: 7,
+    enabledCount: 3,
+    dispatching: 0,
+    progressSeries: [{ ts: 1, waveKey: 7, avancePct: 42 }],
+    cause: null,
+    state: { lastMovementTs: 0, lastSignature: '0:42', lastAlertTs: 0, alertCount: 0 },
+    stallMinutes: 20,
+    cooldownMinutes: 30,
+    windowMinutes: 60,
+    ...overrides,
+  };
+}
+
+// ─── CA-1 · Estancamiento inexplicado dispara alerta ────────────────────────
+
+test('CA-1: trabajo habilitado + 0 despacho + avancePct constante > N min + sin causa => alert', () => {
+  // Movimiento fijado hace 40 min (> 20 min de umbral), firma sin cambios.
+  const f = stalledFacts({
+    now: 100 * MIN,
+    state: { lastMovementTs: 60 * MIN, lastSignature: '0:42', lastAlertTs: 0, alertCount: 0 },
+  });
+  const d = wd.decide(f);
+  assert.equal(d.action, 'alert');
+  assert.equal(d.reason, 'unexplained-stall');
+  assert.equal(d.level, 'warn');
+  assert.ok(d.message.includes('Ola 7'));
+  assert.equal(d.nextState.alertCount, 1);
+  assert.equal(d.nextState.lastAlertTs, 100 * MIN);
+});
+
+test('CA-1: segundo disparo del mismo episodio (tras cooldown) escala', () => {
+  const f = stalledFacts({
+    now: 100 * MIN,
+    state: { lastMovementTs: 40 * MIN, lastSignature: '0:42', lastAlertTs: 60 * MIN, alertCount: 1 },
+  });
+  const d = wd.decide(f);
+  assert.equal(d.action, 'escalate');
+  assert.equal(d.level, 'error');
+  assert.equal(d.nextState.alertCount, 2);
+});
+
+// ─── CA-2 · Causa declarada legítima ⇒ NO falsa alarma ──────────────────────
+
+for (const kind of ['human-halt', 'quota', 'night-window', 'blocked-dependencies', 'resource-pressure', 'waiting-operator']) {
+  test(`CA-2: causa declarada vigente (${kind}) => skip, NO alerta`, () => {
+    const f = stalledFacts({
+      state: { lastMovementTs: 40 * MIN, lastSignature: '0:42', lastAlertTs: 0, alertCount: 0 },
+      cause: { declared: true, kind, expiresAt: 200 * MIN, readable: true },
+    });
+    const d = wd.decide(f);
+    assert.equal(d.action, 'skip');
+    assert.equal(d.reason, `declared-cause:${kind}`);
+    assert.equal(d.message, null);
+  });
+}
+
+test('CA-2: causa sin expiresAt (perpetua vigente) suprime', () => {
+  const f = stalledFacts({
+    state: { lastMovementTs: 40 * MIN, lastSignature: '0:42', lastAlertTs: 0, alertCount: 0 },
+    cause: { declared: true, kind: 'human-halt', readable: true },
+  });
+  assert.equal(wd.decide(f).action, 'skip');
+});
+
+// ─── CA-3 · Fail-closed ante causa ausente/ilegible/corrupta/expirada ───────
+
+test('CA-3: causa null => fail-closed => alert', () => {
+  const f = stalledFacts({
+    state: { lastMovementTs: 40 * MIN, lastSignature: '0:42', lastAlertTs: 0, alertCount: 0 },
+    cause: null,
+  });
+  assert.equal(wd.decide(f).action, 'alert');
+});
+
+test('CA-3: causa ilegible (readable:false) => fail-closed => alert', () => {
+  const f = stalledFacts({
+    state: { lastMovementTs: 40 * MIN, lastSignature: '0:42', lastAlertTs: 0, alertCount: 0 },
+    cause: { declared: true, kind: 'quota', readable: false },
+  });
+  assert.equal(wd.decide(f).action, 'alert');
+});
+
+test('CA-3: causa expirada (causa zombi) => fail-closed => alert', () => {
+  const f = stalledFacts({
+    now: 100 * MIN,
+    state: { lastMovementTs: 40 * MIN, lastSignature: '0:42', lastAlertTs: 0, alertCount: 0 },
+    cause: { declared: true, kind: 'quota', expiresAt: 50 * MIN, readable: true },
+  });
+  assert.equal(wd.decide(f).action, 'alert');
+});
+
+test('CA-3: causa con expiresAt ilegible => fail-closed => alert', () => {
+  const f = stalledFacts({
+    state: { lastMovementTs: 40 * MIN, lastSignature: '0:42', lastAlertTs: 0, alertCount: 0 },
+    cause: { declared: true, kind: 'quota', expiresAt: 'nunca', readable: true },
+  });
+  assert.equal(wd.decide(f).action, 'alert');
+});
+
+test('CA-3: causa con declared !== true => fail-closed => alert', () => {
+  const f = stalledFacts({
+    state: { lastMovementTs: 40 * MIN, lastSignature: '0:42', lastAlertTs: 0, alertCount: 0 },
+    cause: { declared: false, kind: 'quota', readable: true },
+  });
+  assert.equal(wd.decide(f).action, 'alert');
+});
+
+test('isCauseValid: matriz de validez', () => {
+  const now = 100 * MIN;
+  assert.equal(wd.isCauseValid(null, now), false);
+  assert.equal(wd.isCauseValid(undefined, now), false);
+  assert.equal(wd.isCauseValid('paused', now), false);
+  assert.equal(wd.isCauseValid({ declared: true, readable: true }, now), true);
+  assert.equal(wd.isCauseValid({ declared: true, readable: false }, now), false);
+  assert.equal(wd.isCauseValid({ declared: true, expiresAt: 200 * MIN }, now), true);
+  assert.equal(wd.isCauseValid({ declared: true, expiresAt: 50 * MIN }, now), false);
+});
+
+// ─── CA-4 · parseStallMinutes con clamp (SEC-3) ─────────────────────────────
+
+test('CA-4: parseStallMinutes cae al default en valores inválidos', () => {
+  assert.equal(wd.parseStallMinutes(0), wd.DEFAULT_STALL_MINUTES);
+  assert.equal(wd.parseStallMinutes(-5), wd.DEFAULT_STALL_MINUTES);
+  assert.equal(wd.parseStallMinutes('abc'), wd.DEFAULT_STALL_MINUTES);
+  assert.equal(wd.parseStallMinutes(999999), wd.DEFAULT_STALL_MINUTES); // gigante → default
+  assert.equal(wd.parseStallMinutes(null), wd.DEFAULT_STALL_MINUTES);
+  assert.equal(wd.parseStallMinutes(3.5), wd.DEFAULT_STALL_MINUTES);
+});
+
+test('CA-4: parseStallMinutes acepta valores válidos', () => {
+  assert.equal(wd.parseStallMinutes(20), 20);
+  assert.equal(wd.parseStallMinutes('45'), 45);
+  assert.equal(wd.parseStallMinutes(wd.MAX_STALL_MINUTES), wd.MAX_STALL_MINUTES);
+});
+
+test('CA-4: parseStallMinutes con fallback inválido usa el default duro', () => {
+  assert.equal(wd.parseStallMinutes('x', 0), wd.DEFAULT_STALL_MINUTES);
+  assert.equal(wd.parseStallMinutes('x', 9999999), wd.DEFAULT_STALL_MINUTES);
+  assert.equal(wd.parseStallMinutes('x', 15), 15);
+});
+
+test('CA-4: un N gigante NO deshabilita de facto (no cae en "nunca stall")', () => {
+  // Con stallMinutes gigante, el clamp lo lleva al default (20 min); un
+  // estancamiento de 40 min DEBE disparar igual.
+  const f = stalledFacts({
+    stallMinutes: 999999,
+    state: { lastMovementTs: 60 * MIN, lastSignature: '0:42', lastAlertTs: 0, alertCount: 0 },
+  });
+  assert.equal(wd.decide(f).action, 'alert');
+});
+
+// ─── CA-5 · Mensaje sin datos sensibles (SEC-2) ─────────────────────────────
+
+test('CA-5: buildAlertMessage NO contiene paths absolutos ni tokens', () => {
+  const msg = wd.buildAlertMessage({ waveKey: 7, stallMinutes: 20, enabledCount: 3 });
+  assert.ok(msg.includes('Ola 7'));
+  assert.ok(msg.includes('20 min'));
+  // Sin rutas absolutas (Windows o POSIX)
+  assert.ok(!/[A-Za-z]:\\/.test(msg), 'no debe tener path Windows');
+  assert.ok(!/\/(home|c|Workspaces|Users|pipeline)\//i.test(msg), 'no debe tener path POSIX');
+  // Sin tokens/secrets típicos
+  assert.ok(!/[0-9]{6,}:[A-Za-z0-9_-]{20,}/.test(msg), 'no debe tener bot token');
+  assert.ok(!/AKIA[0-9A-Z]{16}/.test(msg), 'no debe tener AWS key');
+  assert.ok(!/eyJ[A-Za-z0-9_-]+\./.test(msg), 'no debe tener JWT');
+});
+
+test('CA-5: el message de una decisión de alerta es sanitizado', () => {
+  const f = stalledFacts({
+    state: { lastMovementTs: 60 * MIN, lastSignature: '0:42', lastAlertTs: 0, alertCount: 0 },
+  });
+  const d = wd.decide(f);
+  assert.ok(!/[A-Za-z]:\\/.test(d.message));
+  assert.ok(d.message.includes('Ola 7'));
+});
+
+// ─── CA-6 · Anti-flooding: dedup por cooldown ───────────────────────────────
+
+test('CA-6: dentro del cooldown desde lastAlertTs => skip (no re-alerta)', () => {
+  const f = stalledFacts({
+    now: 100 * MIN,
+    // alertó hace 10 min, cooldown 30 min → todavía en cooldown
+    state: { lastMovementTs: 40 * MIN, lastSignature: '0:42', lastAlertTs: 90 * MIN, alertCount: 1 },
+  });
+  const d = wd.decide(f);
+  assert.equal(d.action, 'skip');
+  assert.equal(d.reason, 'cooldown');
+});
+
+test('CA-6: pasado el cooldown en el MISMO episodio => re-dispara (escalate)', () => {
+  const f = stalledFacts({
+    now: 100 * MIN,
+    // alertó hace 40 min, cooldown 30 min → ya pasó
+    state: { lastMovementTs: 40 * MIN, lastSignature: '0:42', lastAlertTs: 60 * MIN, alertCount: 1 },
+  });
+  const d = wd.decide(f);
+  assert.equal(d.action, 'escalate');
+});
+
+test('CA-6: un episodio NUEVO (movió ficha y volvió a estancarse) re-alerta como alert', () => {
+  // La firma cambió respecto de la persistida → resetea episodio (alertCount=0)
+  // y el reloj de movimiento a `now`. NO dispara en la misma foto (recién movió).
+  const f = stalledFacts({
+    now: 100 * MIN,
+    dispatching: 0,
+    progressSeries: [{ ts: 1, waveKey: 7, avancePct: 55 }], // avancePct distinto → firma nueva
+    state: { lastMovementTs: 40 * MIN, lastSignature: '0:42', lastAlertTs: 60 * MIN, alertCount: 3 },
+  });
+  const d = wd.decide(f);
+  assert.equal(d.action, 'skip'); // recién movió, reloj reiniciado
+  assert.equal(d.nextState.alertCount, 0);
+  assert.equal(d.nextState.lastAlertTs, 0);
+  assert.equal(d.nextState.lastMovementTs, 100 * MIN);
+});
+
+// ─── Definición de "ficha movida" ───────────────────────────────────────────
+
+test('ficha movida: cambia conteo trabajando/ con avancePct constante => NO estancada', () => {
+  // Firma persistida "0:42"; ahora hay 2 en trabajando/ → firma "2:42" (nueva).
+  // dispatching>0 además corta antes: skip 'dispatching'.
+  const f = stalledFacts({
+    dispatching: 2,
+    progressSeries: [{ ts: 1, waveKey: 7, avancePct: 42 }],
+    state: { lastMovementTs: 40 * MIN, lastSignature: '0:42', lastAlertTs: 0, alertCount: 0 },
+  });
+  const d = wd.decide(f);
+  assert.equal(d.action, 'skip');
+  assert.equal(d.reason, 'dispatching');
+});
+
+test('ficha movida: avancePct cambió (promovió ficha) => reloj reiniciado', () => {
+  const f = stalledFacts({
+    now: 100 * MIN,
+    dispatching: 0,
+    progressSeries: [{ ts: 1, waveKey: 7, avancePct: 99 }],
+    state: { lastMovementTs: 40 * MIN, lastSignature: '0:42', lastAlertTs: 0, alertCount: 0 },
+  });
+  const d = wd.decide(f);
+  assert.equal(d.nextState.lastMovementTs, 100 * MIN);
+});
+
+test('movementSignature: primera foto (sin firma previa) reinicia el reloj', () => {
+  const f = stalledFacts({
+    now: 100 * MIN,
+    state: { lastMovementTs: 0, lastSignature: null, lastAlertTs: 0, alertCount: 0 },
+  });
+  const d = wd.decide(f);
+  // Primera foto: movedFicha=true → lastMovementTs=now → stalledMs=0 < umbral → skip
+  assert.equal(d.action, 'skip');
+  assert.equal(d.reason, 'within-threshold');
+  assert.equal(d.nextState.lastMovementTs, 100 * MIN);
+});
+
+// ─── Ramas de guarda ────────────────────────────────────────────────────────
+
+test('guard: sin trabajo habilitado => skip no-enabled-work', () => {
+  const f = stalledFacts({
+    enabledCount: 0,
+    state: { lastMovementTs: 40 * MIN, lastSignature: '0:42', lastAlertTs: 0, alertCount: 0 },
+  });
+  const d = wd.decide(f);
+  assert.equal(d.action, 'skip');
+  assert.equal(d.reason, 'no-enabled-work');
+});
+
+test('guard: dispatching>0 => skip dispatching', () => {
+  const f = stalledFacts({
+    dispatching: 1,
+    state: { lastMovementTs: 40 * MIN, lastSignature: '1:42', lastAlertTs: 0, alertCount: 0 },
+  });
+  const d = wd.decide(f);
+  assert.equal(d.action, 'skip');
+  assert.equal(d.reason, 'dispatching');
+});
+
+test('guard: dentro del umbral (< N min) => skip within-threshold', () => {
+  const f = stalledFacts({
+    now: 100 * MIN,
+    state: { lastMovementTs: 90 * MIN, lastSignature: '0:42', lastAlertTs: 0, alertCount: 0 },
+  });
+  const d = wd.decide(f);
+  assert.equal(d.action, 'skip');
+  assert.equal(d.reason, 'within-threshold');
+});
+
+test('guard: now no finito se trata como 0 sin romper', () => {
+  const f = stalledFacts({ now: NaN });
+  const d = wd.decide(f);
+  assert.ok(['skip', 'alert'].includes(d.action));
+});
+
+test('movementSignature: serie vacía o inválida => avance "na"', () => {
+  assert.equal(wd.movementSignature(0, []), '0:na');
+  assert.equal(wd.movementSignature(3, null), '3:na');
+  assert.equal(wd.movementSignature(0, [{ ts: 1, waveKey: 7, avancePct: 'x' }]), '0:na');
+});
+
+// ─── Estado: load/save/normalize ────────────────────────────────────────────
+
+test('normalizeState: tolera basura y campos ausentes', () => {
+  assert.deepEqual(wd.normalizeState(null), {
+    lastMovementTs: 0, lastSignature: null, lastAlertTs: 0, alertCount: 0,
+  });
+  assert.deepEqual(wd.normalizeState({ lastMovementTs: -1, lastSignature: 5, lastAlertTs: 'x', alertCount: -2 }), {
+    lastMovementTs: 0, lastSignature: null, lastAlertTs: 0, alertCount: 0,
+  });
+  assert.deepEqual(wd.normalizeState({ lastMovementTs: 10, lastSignature: '0:1', lastAlertTs: 20, alertCount: 3 }), {
+    lastMovementTs: 10, lastSignature: '0:1', lastAlertTs: 20, alertCount: 3,
+  });
+});
+
+test('loadState/saveStateAtomic round-trip + fail-soft ante archivo ausente', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wave-wd-'));
+  const file = path.join(dir, 'state.json');
+  // Ausente → default
+  assert.deepEqual(wd.loadState(file), {
+    lastMovementTs: 0, lastSignature: null, lastAlertTs: 0, alertCount: 0,
+  });
+  wd.saveStateAtomic(file, { lastMovementTs: 5, lastSignature: '2:9', lastAlertTs: 7, alertCount: 1 });
+  assert.deepEqual(wd.loadState(file), {
+    lastMovementTs: 5, lastSignature: '2:9', lastAlertTs: 7, alertCount: 1,
+  });
+  // Corrupto → default (fail-soft)
+  fs.writeFileSync(file, '{no json');
+  assert.deepEqual(wd.loadState(file), {
+    lastMovementTs: 0, lastSignature: null, lastAlertTs: 0, alertCount: 0,
+  });
+  fs.rmSync(dir, { recursive: true, force: true });
+});

--- a/.pipeline/lib/waves-stalled.test.js
+++ b/.pipeline/lib/waves-stalled.test.js
@@ -1,0 +1,125 @@
+'use strict';
+
+// =============================================================================
+// waves-stalled.test.js — Estado `stalled` / `needs_attention` a nivel ola (#4708).
+// Framework: node --test. Aísla el estado con PIPELINE_DIR_OVERRIDE a un tmp dir.
+// =============================================================================
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+function seedWaves(activeWave) {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wv-st-'));
+    const seed = {
+        version: '1.0',
+        meta: {
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-01T00:00:00Z',
+            updated_by: 'System',
+            source: 'test',
+            next_wave_number: 3,
+        },
+        active_wave: activeWave,
+        planned_waves: [],
+        archived_waves: [],
+        dependencies: [],
+    };
+    fs.writeFileSync(path.join(dir, 'waves.json'), JSON.stringify(seed));
+    return dir;
+}
+
+function loadWavesInDir(dir) {
+    process.env.PIPELINE_DIR_OVERRIDE = dir;
+    delete require.cache[require.resolve('./waves')];
+    const w = require('./waves');
+    w.invalidateCache();
+    return w;
+}
+
+test('setWaveStalled marca la ola activa con shape estructurado + audit', () => {
+    const dir = seedWaves({ number: 8, name: 'Ola Puente', issues: [{ number: 4708, status: 'in_progress' }] });
+    const w = loadWavesInDir(dir);
+    assert.strictEqual(w.isWaveStalled(), false);
+    const st = w.setWaveStalled(8, { reason: 'unexplained-stall', updated_by: 'wave-stall-watchdog' });
+    assert.strictEqual(st.reason, 'unexplained-stall');
+    assert.ok(Number.isFinite(Date.parse(st.since)));
+    assert.strictEqual(w.isWaveStalled(), true);
+    assert.deepStrictEqual(w.getWaveStalled(), st);
+    // El audit debió registrar el evento wave_stalled.
+    const auditFile = path.join(dir, 'wave-audit.jsonl');
+    if (fs.existsSync(auditFile)) {
+        const lines = fs.readFileSync(auditFile, 'utf8').split('\n').filter(Boolean);
+        assert.ok(lines.some((l) => l.includes('wave_stalled')));
+    }
+});
+
+test('setWaveStalled default reason cuando no se provee', () => {
+    const dir = seedWaves({ number: 8, issues: [] });
+    const w = loadWavesInDir(dir);
+    const st = w.setWaveStalled(8, {});
+    assert.strictEqual(st.reason, 'unexplained-stall');
+});
+
+test('el estado stalled sobrevive una relectura desde disco', () => {
+    const dir = seedWaves({ number: 5, issues: [] });
+    const w = loadWavesInDir(dir);
+    w.setWaveStalled(5, { reason: 'unexplained-stall' });
+    const w2 = loadWavesInDir(dir);
+    assert.strictEqual(w2.isWaveStalled(), true);
+    assert.strictEqual(w2.getWaveStalled().reason, 'unexplained-stall');
+});
+
+test('clearWaveStalled remueve la marca (idempotente)', () => {
+    const dir = seedWaves({ number: 8, issues: [] });
+    const w = loadWavesInDir(dir);
+    w.setWaveStalled(8, { reason: 'x' });
+    assert.strictEqual(w.clearWaveStalled(8, { updated_by: 'operator' }), true);
+    assert.strictEqual(w.isWaveStalled(), false);
+    assert.strictEqual(w.clearWaveStalled(8), false);
+});
+
+test('setWaveStalled rechaza una ola que no es la activa', () => {
+    const dir = seedWaves({ number: 8, issues: [] });
+    const w = loadWavesInDir(dir);
+    assert.throws(() => w.setWaveStalled(99, {}), /no es la activa/);
+});
+
+test('setWaveStalled sin ola activa lanza', () => {
+    const dir = seedWaves(null);
+    const w = loadWavesInDir(dir);
+    assert.throws(() => w.setWaveStalled(8, {}), /no es la activa/);
+    assert.strictEqual(w.isWaveStalled(), false);
+});
+
+test('validateStateStrict rechaza un stalled con shape inválido', () => {
+    const dir = seedWaves({ number: 8, issues: [] });
+    const w = loadWavesInDir(dir);
+    const bad = {
+        version: '1.0',
+        meta: { updated_at: '2026-01-01T00:00:00Z' },
+        active_wave: { number: 8, stalled: { since: 'no-es-fecha', reason: 5 } },
+        planned_waves: [],
+        archived_waves: [],
+        dependencies: [],
+    };
+    const errors = w.validateStateStrict(bad, { source: 'test' });
+    assert.ok(errors.some((e) => /stalled.since/.test(e)));
+    assert.ok(errors.some((e) => /stalled.reason/.test(e)));
+});
+
+test('validateStateStrict acepta stalled null/ausente', () => {
+    const dir = seedWaves({ number: 8, issues: [] });
+    const w = loadWavesInDir(dir);
+    const ok = {
+        version: '1.0',
+        meta: { updated_at: '2026-01-01T00:00:00Z' },
+        active_wave: { number: 8, stalled: null },
+        planned_waves: [],
+        archived_waves: [],
+        dependencies: [],
+    };
+    assert.deepStrictEqual(w.validateStateStrict(ok, { source: 'test' }), []);
+});

--- a/.pipeline/lib/waves.js
+++ b/.pipeline/lib/waves.js
@@ -1002,6 +1002,116 @@ function clearWaveWaitingOperatorLocked(waveNumber, info) {
     return true;
 }
 
+// ─── #4708 — Estado `stalled` / `needs_attention` a nivel ola ───────────────
+//
+// Dead-man's switch de la ola (wave-stall-watchdog): cuando la ola activa lleva
+// N minutos con trabajo habilitado, 0 despacho y SIN causa declarada, el brazo
+// del Pulpo marca la ola como estancada. NO cierra la ola ni mata agentes; sólo
+// deja el estado para observabilidad + escalada (`needs-human`). Molde exacto de
+// `setWaveWaitingOperator`/`clearWaveWaitingOperator` (withLockSync + audit).
+
+/**
+ * Marca la ola activa como estancada (`stalled`). Idempotente a nivel de estado:
+ * sobreescribe el `stalled` previo. NO cambia el lifecycle de la ola.
+ *
+ * @param {number} waveNumber — debe ser la ola ACTIVA.
+ * @param {object} [info] — { reason?, since?, updated_by? }.
+ * @returns {object} el objeto `stalled` persistido.
+ * @throws si `waveNumber` no es la ola activa.
+ */
+function setWaveStalled(waveNumber, info = {}) {
+    return withLockSync(wavesFile(), () => setWaveStalledLocked(waveNumber, info), {
+        component: 'waves-lock',
+        timeoutMs: LOCK_TIMEOUT_MS,
+        maxRetries: LOCK_MAX_RETRIES,
+        notify: notifyTelegram,
+    });
+}
+
+function setWaveStalledLocked(waveNumber, info) {
+    invalidateCache();
+    const state = loadWaves();
+    if (!state.active_wave || state.active_wave.number !== waveNumber) {
+        throw new Error(`setWaveStalled: ola ${waveNumber} no es la activa`);
+    }
+    const st = {
+        since: typeof info.since === 'string' && Number.isFinite(Date.parse(info.since))
+            ? info.since : nowIso(),
+        reason: typeof info.reason === 'string' ? info.reason.slice(0, MAX_FREE_STRING_LEN) : 'unexplained-stall',
+    };
+    state.active_wave.stalled = st;
+    saveState(state, {
+        updated_by: info.updated_by || 'System',
+        source: 'wave-stall-watchdog',
+        note: `wave ${waveNumber} → stalled (needs_attention)`,
+    });
+    emitWaveAudit({
+        event: 'wave_stalled',
+        wave: waveNumber,
+        actor: info.updated_by || 'System',
+        estado_previo: 'active',
+        estado_posterior: 'stalled',
+        note: st.reason,
+    });
+    return deepClone(st);
+}
+
+/**
+ * Limpia el estado `stalled` de la ola activa (la ola volvió a despachar o el
+ * operador atendió). No cierra la ola — sólo remueve la marca.
+ *
+ * @param {number} waveNumber — debe ser la ola ACTIVA.
+ * @param {object} [info] — { updated_by?, note? }.
+ * @returns {boolean} true si había estado que limpiar.
+ */
+function clearWaveStalled(waveNumber, info = {}) {
+    return withLockSync(wavesFile(), () => clearWaveStalledLocked(waveNumber, info), {
+        component: 'waves-lock',
+        timeoutMs: LOCK_TIMEOUT_MS,
+        maxRetries: LOCK_MAX_RETRIES,
+        notify: notifyTelegram,
+    });
+}
+
+function clearWaveStalledLocked(waveNumber, info) {
+    invalidateCache();
+    const state = loadWaves();
+    if (!state.active_wave || state.active_wave.number !== waveNumber) {
+        throw new Error(`clearWaveStalled: ola ${waveNumber} no es la activa`);
+    }
+    const had = state.active_wave.stalled != null;
+    if (!had) return false;
+    delete state.active_wave.stalled;
+    saveState(state, {
+        updated_by: info.updated_by || 'System',
+        source: 'wave-stall-watchdog',
+        note: info.note || `wave ${waveNumber} → stalled limpiado`,
+    });
+    emitWaveAudit({
+        event: 'wave_stalled_cleared',
+        wave: waveNumber,
+        actor: info.updated_by || 'System',
+        estado_previo: 'stalled',
+        estado_posterior: 'active',
+        note: info.note || null,
+    });
+    return true;
+}
+
+/**
+ * ¿La ola activa está marcada como estancada? Devuelve el objeto `stalled` o null.
+ * @returns {object|null}
+ */
+function getWaveStalled() {
+    const active = getActiveWave();
+    return active && active.stalled ? active.stalled : null;
+}
+
+/** ¿La ola activa está estancada? Predicado booleano. @returns {boolean} */
+function isWaveStalled() {
+    return getWaveStalled() != null;
+}
+
 // #4673 -- Aviso proactivo de finalizacion de ola. El flag vive en waves.json
 // bajo la ola activa para evitar paths derivados de input y conservar lock unico.
 function setWaveCompletionNotified(waveNumber, info = {}) {
@@ -1854,6 +1964,22 @@ function validateWaveObject(w, ctx, errors) {
             if (wo.conflicts_count !== undefined
                 && (!Number.isInteger(wo.conflicts_count) || wo.conflicts_count < 0)) {
                 errors.push(`${ctx}.waiting_operator.conflicts_count debe ser entero ≥ 0`);
+            }
+        }
+    }
+    // #4708 — estado `stalled` a nivel ola (dead-man's switch). Opcional
+    // (ausente = ola sin estancamiento detectado). Shape estricto igual que
+    // `waiting_operator`: los campos libres fluyen a sinks (dashboard/Telegram).
+    if (w.stalled !== undefined && w.stalled !== null) {
+        const st = w.stalled;
+        if (typeof st !== 'object' || Array.isArray(st)) {
+            errors.push(`${ctx}.stalled debe ser objeto o null`);
+        } else {
+            if (typeof st.since !== 'string' || !Number.isFinite(Date.parse(st.since))) {
+                errors.push(`${ctx}.stalled.since debe ser ISO string`);
+            }
+            if (st.reason !== undefined && st.reason !== null && !isValidFreeString(st.reason)) {
+                errors.push(`${ctx}.stalled.reason debe ser string ≤${MAX_FREE_STRING_LEN} chars`);
             }
         }
     }
@@ -3264,6 +3390,11 @@ module.exports = {
     clearWaveCompletionNotified,
     getWaveWaitingOperator,
     isWaveWaitingOperator,
+    // #4708 — estado stalled/needs_attention a nivel ola (dead-man's switch).
+    setWaveStalled,
+    clearWaveStalled,
+    getWaveStalled,
+    isWaveStalled,
     // CA-5: variantes strict que tiran si el shape rompe.
     loadStateStrict,
     validateStateStrict,

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -62,6 +62,8 @@ const operatorSignature = require('./lib/operator-signature');
 // #2549 — Detección de bloqueo humano en motivos de rechazo + helpers de marker.
 // Evita relanzar al infinito skills cuyo rechazo es "esperando merge humano".
 const humanBlock = require('./lib/human-block');
+// #4708 — Alerta operacional genérica del control-plane (wave-stall watchdog).
+const { notifyTelegram: notifyTelegramFn } = require('./lib/notify-telegram');
 // #3939 — Primitivas atómicas anti-TOCTOU: claim-by-rename + reserva de slot +
 // sweep de claims huérfanos (épica EP-5 #3937).
 const slotClaim = require('./lib/slot-claim');
@@ -1395,6 +1397,60 @@ function listWorkFiles(dir) {
       .filter(f => !f.startsWith('.') && !f.endsWith('.gitkeep') && !isMarkerArtifactPulpo(f))
       .map(f => ({ name: f, path: path.join(dir, f) }));
   } catch { return []; }
+}
+
+/**
+ * #4708 — Recolecta la "causa declarada" que explica legítimamente un no-despacho
+ * de la ola, para que el wave-stall watchdog NO falsa-alarme (CA-2).
+ *
+ * Todas las causas se computan EN VIVO por el Pulpo (no se leen de un artefacto
+ * arbitrario del FS que un agente pueda spoofear — SEC-1). Cada chequeo es
+ * defensivo: si tira, se ignora (fail-closed: la ausencia de causa dispara). Al
+ * ser cómputo en vivo, la causa es inherentemente vigente (no requiere TTL).
+ *
+ * Causas reconocidas (interino hasta #4709 unifique el registro):
+ *   - halt humano (.paused / .partial-pause.json)   → kind 'human-halt'
+ *   - ventana de reposo / night-window              → kind 'night-window'
+ *   - cuota agotada                                 → kind 'quota'
+ *   - presión de recursos (ORANGE/RED)              → kind 'resource-pressure'
+ *   - gate de coherencia waiting-operator (#4578)   → kind 'waiting-operator'
+ *
+ * @returns {{declared:true, kind:string, readable:true}|null} null = sin causa.
+ */
+function readDeclaredCauseForWave(cfgRoot, waves) {
+  const declare = (kind) => ({ declared: true, kind, readable: true });
+
+  // 1. Halt humano (pausa total o parcial declarada por el operador).
+  try {
+    const mode = partialPause.getPipelineMode().mode;
+    if (mode && mode !== 'running') return declare('human-halt');
+  } catch { /* fail-closed */ }
+
+  // 2. Ventana de reposo / madrugada — no alertar de noche (CA-2).
+  try {
+    const nw = (cfgRoot.resource_limits || {}).night_window;
+    if (isNightWindow(Date.now(), nw)) return declare('night-window');
+  } catch { /* fail-closed */ }
+
+  // 3. Cuota agotada (primary/fallbacks sin capacidad).
+  try {
+    if (quotaExhausted.isQuotaExhausted()) return declare('quota');
+  } catch { /* fail-closed */ }
+
+  // 4. Presión de recursos: ORANGE/RED suprimen despacho legítimamente.
+  try {
+    const level = getResourcePressure(cfgRoot).level;
+    if (level === PRESSURE_LEVELS.ORANGE || level === PRESSURE_LEVELS.RED) {
+      return declare('resource-pressure');
+    }
+  } catch { /* fail-closed */ }
+
+  // 5. Gate de coherencia (#4578): ola retenida esperando al operador.
+  try {
+    if (waves.isWaveWaitingOperator()) return declare('waiting-operator');
+  } catch { /* fail-closed */ }
+
+  return null;
 }
 
 /** Extraer issue number del nombre de archivo (ej: "1732.po" → "1732").
@@ -16747,6 +16803,134 @@ async function mainLoop() {
     log('anomaly', `Detector iniciado: cada ${anomalyDetector.config.intervalMin}min, threshold +${Math.round(anomalyDetector.config.pctThreshold * 100)}%, warmup ${anomalyDetector.config.warmupDays}d`);
   } catch (e) {
     log('anomaly', `No se pudo iniciar el detector: ${e.message}`);
+  }
+
+  // #4708 — Wave-stall watchdog (dead-man's switch de la ola).
+  // Brazo periódico que detecta "trabajo habilitado + 0 despacho durante N min
+  // + sin causa declarada" y alerta a Telegram + marca la ola `stalled`
+  // (needs_attention). La lógica de decisión vive en lib/wave-stall-watchdog.js
+  // (función pura testeada). Este brazo SÓLO recolecta hechos del filesystem y
+  // la invoca. Es ACCESORIO: si tira, try/catch loguea y NO mata el loop (mismo
+  // criterio que el anomalyDetector). Rollout gradual: `wave_watchdog.enabled`
+  // default false.
+  try {
+    const waveWatchdog = require('./lib/wave-stall-watchdog');
+    const cfgRoot0 = loadConfig() || {};
+    const wwCfg0 = cfgRoot0.wave_watchdog || {};
+    const tickMs = waveWatchdog.parsePositiveInt(wwCfg0.tick_ms, 60000);
+    const stateFile = path.join(PIPELINE, 'state', 'wave-stall-watchdog-state.json');
+
+    const runWaveStallTick = () => {
+      try {
+        const cfgRoot = loadConfig() || {};
+        const cfg = cfgRoot.wave_watchdog || {};
+        // Kill-switch / rollout gradual: leídos en cada tick para permitir
+        // activar/desactivar en caliente sin reiniciar el Pulpo.
+        if (cfg.enabled !== true || cfg.kill_switch === true) return;
+
+        const waves = require('./lib/waves');
+        const waveProgress = require('./lib/wave-progress');
+
+        const active = waves.getActiveWave();
+        if (!active || !Number.isInteger(active.number)) return; // sin ola activa: nada que vigilar
+
+        // 1. Trabajo habilitado: issues no completados y sin bloqueo de dependencia.
+        //    (Un issue con TODOS sus bloqueantes abiertos NO cuenta como habilitado
+        //     → un estancamiento por dependencia queda como enabledCount=0 = skip.)
+        const enabled = (active.issues || []).filter((i) => {
+          if (!i || i.status === 'completed') return false;
+          try { return waves.getBlockingIssues(i.number).length === 0; }
+          catch { return true; }
+        });
+
+        // 2. Despacho: archivos en trabajando/ de TODAS las fases de TODOS los pipelines.
+        let dispatching = 0;
+        for (const [pName, pConfig] of Object.entries(cfgRoot.pipelines || {})) {
+          for (const fase of (pConfig.fases || [])) {
+            dispatching += listWorkFiles(path.join(PIPELINE, pName, fase, 'trabajando')).length;
+          }
+        }
+
+        // 3. Serie de avance (avancePct) de la ola activa.
+        let progressSeries = [];
+        try { progressSeries = waveProgress.readSnapshots({ waveKey: active.number }); }
+        catch { progressSeries = []; }
+
+        // 4. Causa declarada (interino hasta #4709 — markers dispersos, computados
+        //    EN VIVO por el Pulpo, no leídos de un artefacto spoofeable por agentes:
+        //    SEC-1). Cada chequeo es defensivo; si tira, NO se asume causa
+        //    (fail-closed: la ausencia de causa dispara). Al ser cómputo en vivo,
+        //    la causa es inherentemente vigente (no requiere TTL propio).
+        const cause = readDeclaredCauseForWave(cfgRoot, waves);
+
+        const state = waveWatchdog.loadState(stateFile);
+        const decision = waveWatchdog.decide({
+          now: Date.now(),
+          waveKey: active.number,
+          enabledCount: enabled.length,
+          dispatching,
+          progressSeries,
+          cause,
+          state,
+          stallMinutes: cfg.stall_minutes,
+          cooldownMinutes: cfg.alert_cooldown_minutes,
+          windowMinutes: cfg.window_minutes,
+        });
+
+        // Persistir SIEMPRE el nextState (reloj de movimiento, episodio de alerta).
+        try { waveWatchdog.saveStateAtomic(stateFile, decision.nextState); }
+        catch (e) { log('wave-stall', `no pude persistir estado: ${e.message}`); }
+
+        if (decision.action === 'alert' || decision.action === 'escalate') {
+          log('wave-stall', `Ola ${active.number} estancada (${decision.action}): ${decision.reason}, ` +
+            `${enabled.length} habilitado(s), ${Math.round(decision.stalledMs / 60000)}min sin mover ficha`);
+
+          // Alerta Telegram — SÓLO waveKey + motivo (SEC-2/CA-5). El mensaje ya
+          // viene sanitizado desde decide(): sin paths, tokens ni dumps.
+          try {
+            notifyTelegramFn({
+              level: decision.level,
+              component: 'wave-stall-watchdog',
+              message: decision.message,
+              action: 'Revisá por qué la ola no despacha (dashboard needs_attention).',
+              context: { ola: active.number, habilitados: enabled.length },
+            });
+          } catch (e) { log('wave-stall', `notify falló: ${e.message}`); }
+
+          // Estado ola: marcar estancada (needs_attention). Es la escalada a
+          // atención humana a NIVEL OLA — no bloquea los issues habilitados
+          // (aplicar needs-human a issues sanos los sacaría del despacho y
+          // agravaría el propio estancamiento que estamos alertando).
+          try {
+            waves.setWaveStalled(active.number, {
+              reason: decision.reason,
+              since: new Date(Date.now() - decision.stalledMs).toISOString(),
+              updated_by: 'wave-stall-watchdog',
+            });
+          } catch (e) { log('wave-stall', `setWaveStalled falló: ${e.message}`); }
+        } else if (decision.reason === 'dispatching' || decision.reason === 'no-enabled-work') {
+          // La ola volvió a moverse / no hay trabajo pendiente: limpiar la marca
+          // de estancamiento si estaba puesta (auto-clear del episodio).
+          try {
+            if (waves.isWaveStalled()) {
+              waves.clearWaveStalled(active.number, { note: 'ola volvió a despachar' });
+              log('wave-stall', `Ola ${active.number} destrabada: marca stalled limpiada`);
+            }
+          } catch (_e) { /* no bloqueante */ }
+        }
+      } catch (err) {
+        log('wave-stall', `tick excepción (no bloqueante): ${err.message}`);
+      }
+    };
+
+    // setInterval propio (patrón idéntico al anomalyDetector). unref() para no
+    // impedir un shutdown limpio del proceso.
+    const waveStallTimer = setInterval(runWaveStallTick, tickMs);
+    if (typeof waveStallTimer.unref === 'function') waveStallTimer.unref();
+    log('wave-stall', `Watchdog de avance de ola iniciado: cada ${Math.round(tickMs / 1000)}s ` +
+      `(enabled=${wwCfg0.enabled === true}, kill_switch=${wwCfg0.kill_switch === true})`);
+  } catch (e) {
+    log('wave-stall', `No se pudo iniciar el watchdog de avance de ola: ${e.message}`);
   }
 
   // #3080 / S1 multi-provider — Cron de rotación de credenciales.


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 9 archivos · +1148 -0

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:skipped` aplicado por delivery

## Closes

Closes #4708
