### PR TITLE
[#4700] P0-D2 — Demo verificable dev→build→QA→delivery sobre intrale/kernel

### DIFF
--- a/.pipeline/tests/kernel-demo-cycle.test.js
+++ b/.pipeline/tests/kernel-demo-cycle.test.js
@@ -1,0 +1,147 @@
+// =============================================================================
+// kernel-demo-cycle.test.js — E2E de la demo del ciclo del kernel (#4700 · CA-D2)
+// Cubre: avance por fase dev->build->QA->delivery, target verificado en cada
+// fase mutante (CA-D2.2), abort ante target = intrale/platform (blast radius),
+// delivery sin auto-merge/sin main/token scoped (CA-D2.3) y lockfile pineado
+// (CA-D2.4).
+// =============================================================================
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const HARNESS = path.join(__dirname, '..', '..', 'fixtures', 'demo', 'run-cycle.js');
+const {
+  runCycle,
+  verifyTarget,
+  bootstrap,
+  deliver,
+  AbortError,
+  __constants__,
+} = require(HARNESS);
+
+const BUNDLED_TARGET = path.join(__dirname, '..', '..', 'fixtures', 'demo', 'target');
+
+function mkTmp(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+// Copia el target bundled a un dir nuevo (para casos que mutan el marker).
+function copyTarget(dest) {
+  fs.cpSync(BUNDLED_TARGET, dest, {
+    recursive: true,
+    filter: (src) => !src.includes(`${path.sep}node_modules${path.sep}`),
+  });
+  return dest;
+}
+
+test('el ciclo completo avanza dev->build->QA->delivery con trail correcto', () => {
+  const { summary, trail, verifications } = runCycle({ runDir: mkTmp('demo-run-') });
+  assert.equal(summary.ok, true);
+  assert.deepEqual(trail, ['pendiente', 'trabajando', 'listo', 'procesado']);
+  // Las 3 fases mutantes quedaron verificadas.
+  assert.deepEqual(
+    verifications.map((v) => v.phase),
+    ['build', 'qa', 'delivery']
+  );
+  for (const v of verifications) {
+    assert.equal(v.ok, true);
+    assert.equal(v.projectId, 'kernel-fixtures');
+    assert.match(v.line, /target = kernel-fixtures \(verificado\)/);
+  }
+});
+
+test('cada fase mutante deja evidencia con target verificado', () => {
+  const runDir = mkTmp('demo-ev-');
+  const { evidence } = runCycle({ runDir });
+  const mutantes = evidence.filter((e) => e.mutating);
+  assert.deepEqual(mutantes.map((e) => e.phase), ['build', 'qa', 'delivery']);
+  for (const e of mutantes) {
+    assert.ok(e.targetVerification, `fase ${e.phase} sin targetVerification`);
+    assert.equal(e.targetVerification.repo, 'intrale/kernel');
+    // Artefacto de evidencia por fase persistido.
+    assert.ok(fs.existsSync(path.join(runDir, `phase-${e.phase}.json`)));
+  }
+  assert.ok(fs.existsSync(path.join(runDir, 'summary.json')));
+});
+
+test('verifyTarget ABORTA si el marker declara repo intrale/platform (blast radius)', () => {
+  const dir = copyTarget(mkTmp('demo-bad-repo-'));
+  const markerFile = path.join(dir, '.kernel-target.json');
+  const marker = JSON.parse(fs.readFileSync(markerFile, 'utf8'));
+  marker.repo = 'intrale/platform';
+  fs.writeFileSync(markerFile, JSON.stringify(marker));
+
+  assert.throws(
+    () => verifyTarget(dir, { phase: 'build', platformRoot: path.join(os.tmpdir(), '__none__') }),
+    (err) => err instanceof AbortError && /intrale\/platform/.test(err.message)
+  );
+});
+
+test('verifyTarget ABORTA si el target resuelve dentro de intrale/platform', () => {
+  const dir = copyTarget(mkTmp('demo-inside-'));
+  // Simulamos que el platformRoot es el padre del target -> debe abortar.
+  const fakePlatformRoot = path.dirname(fs.realpathSync(dir));
+  assert.throws(
+    () => verifyTarget(dir, { phase: 'delivery', platformRoot: fakePlatformRoot }),
+    (err) => err instanceof AbortError && /DENTRO de intrale\/platform/.test(err.message)
+  );
+});
+
+test('verifyTarget ABORTA si falta el marker de identidad', () => {
+  const dir = copyTarget(mkTmp('demo-nomarker-'));
+  fs.rmSync(path.join(dir, '.kernel-target.json'));
+  assert.throws(
+    () => verifyTarget(dir, { phase: 'qa', platformRoot: path.join(os.tmpdir(), '__none__') }),
+    (err) => err instanceof AbortError && /marker/.test(err.message)
+  );
+});
+
+test('bootstrap RECHAZA rangos abiertos en el package.json del target (supply chain)', () => {
+  const dir = copyTarget(mkTmp('demo-openrange-'));
+  const pkgFile = path.join(dir, 'package.json');
+  const pkg = JSON.parse(fs.readFileSync(pkgFile, 'utf8'));
+  pkg.dependencies = { 'some-lib': '^1.0.0' };
+  fs.writeFileSync(pkgFile, JSON.stringify(pkg));
+  assert.throws(
+    () => bootstrap(dir),
+    (err) => err instanceof AbortError && /rangos abiertos/.test(err.message)
+  );
+});
+
+test('bootstrap con lockfile pineado corre npm ci sin dependencias externas', () => {
+  const dir = copyTarget(mkTmp('demo-ci-'));
+  const boot = bootstrap(dir);
+  assert.equal(boot.tool, 'npm ci');
+  assert.equal(boot.openRanges, 0);
+  assert.ok(boot.lockfileVersion >= 2);
+});
+
+test('deliver corre dry-run: sin auto-merge, sin main, token scoped (CA-D2.3)', () => {
+  const dir = copyTarget(mkTmp('demo-deliver-'));
+  const runDir = mkTmp('demo-deliver-run-');
+  const { manifest, manifestFile } = deliver(dir, { runDir });
+  assert.equal(manifest.dryRun, true);
+  assert.equal(manifest.executed, false);
+  assert.equal(manifest.autoMerge, false);
+  assert.equal(manifest.mergeToMain, false);
+  assert.equal(manifest.sign, false);
+  assert.equal(manifest.targetRepo, 'intrale/kernel');
+  assert.notEqual(manifest.targetRepo, 'intrale/platform');
+  assert.match(manifest.tokenScope, /^repo:intrale\/kernel:/);
+  assert.ok(fs.existsSync(manifestFile));
+});
+
+test('las constantes de política declaran kernel permitido y platform prohibido', () => {
+  assert.equal(__constants__.ALLOWED_REPO, 'intrale/kernel');
+  assert.equal(__constants__.FORBIDDEN_REPO, 'intrale/platform');
+  assert.equal(__constants__.EXPECTED_PROJECT_ID, 'kernel-fixtures');
+  assert.ok(__constants__.MUTATING_PHASES.has('build'));
+  assert.ok(__constants__.MUTATING_PHASES.has('qa'));
+  assert.ok(__constants__.MUTATING_PHASES.has('delivery'));
+  assert.ok(!__constants__.MUTATING_PHASES.has('dev'));
+});

--- a/docs/runbooks/demo-cycle.md
+++ b/docs/runbooks/demo-cycle.md
@@ -1,0 +1,135 @@
+# Runbook — Demo del ciclo del kernel (dev → build → QA → delivery)
+
+> Issue: [intrale/platform#4700](https://github.com/intrale/platform/issues/4700)
+> (Split de #4696 · Ola Puente P0 · CA-D2) ·
+> Diseño: [`docs/pipeline/kernel-repo-design.md §1`](../pipeline/kernel-repo-design.md) ·
+> Harness: [`fixtures/demo/run-cycle.js`](../../fixtures/demo/run-cycle.js)
+
+## Propósito
+
+Demostrar de forma **verificable y reproducible** un ciclo completo
+**dev → build → QA → delivery** del motor del kernel apuntado **exclusivamente**
+a un **target controlado** (copia local equivalente del fixture
+`agent/4699-fixtures` de `intrale/kernel`), **sin depender** de que
+`intrale/kernel@main` esté publicado y **sin ningún riesgo** de mutar
+`intrale/platform`. Es la **evidencia de aceptación de P0** que destraba P1→P7.
+
+La prueba **real** contra `intrale/kernel@main` publicado vive en
+[#4706](https://github.com/intrale/platform/issues/4706); este mismo harness se
+reutiliza cambiando el target (ver [Reuso por #4706](#reuso-por-4706)).
+
+## Precondiciones
+
+- Node.js ≥ 18 y npm ≥ 7 en el PATH (`node --version`, `npm --version`).
+- El target controlado local está bundleado en `fixtures/demo/target/`
+  (marker `.kernel-target.json`, `pipeline.config.json`, `package.json` +
+  `package-lock.json` pineado, y el work file en
+  `demo-pipeline/demo-phase/pendiente/`). No requiere red.
+- **No** requiere que `intrale/kernel#1` esté mergeado ni que `fixtures/`
+  exista en `intrale/kernel@main` (esa verificación es #4706).
+
+## Pasos
+
+```bash
+# Desde el root de intrale/platform
+node fixtures/demo/run-cycle.js
+# o el wrapper equivalente:
+bash fixtures/demo/run-cycle.sh
+```
+
+El ciclo:
+
+1. **Copia** el target controlado a un **sandbox temporal** (`os.tmpdir`). Ninguna
+   fase mutante toca el working tree de `intrale/platform`.
+2. Corre las fases `dev → build → QA → delivery` sobre el sandbox, avanzando el
+   work file por el lifecycle `pendiente → trabajando → listo → procesado`.
+3. **Antes de cada fase mutante** (`build`, `qa`, `delivery`) verifica el target
+   (`verifyTarget`) y emite la línea de evidencia
+   `✔ target = kernel-fixtures (verificado)`.
+4. Deja la evidencia por fase en el directorio de run (`phase-*.json`,
+   `delivery-manifest.json`, `summary.json`).
+
+## Evidencia esperada por fase
+
+| Fase | Mutante | Evidencia en stdout | Artefacto |
+|------|---------|---------------------|-----------|
+| `dev` | no | `work file tomado (pendiente -> trabajando)` | `phase-dev.json` |
+| `build` | **sí** | `✔ target = kernel-fixtures (verificado) [build]` + `bootstrap pineado (npm ci)` | `phase-build.json` |
+| `qa` | **sí** | `✔ target = kernel-fixtures (verificado) [qa]` + `verificación estructural OK` | `phase-qa.json` |
+| `delivery` | **sí** | `✔ target = kernel-fixtures (verificado) [delivery]` + `dry-run sin auto-merge, sin main, token scoped` | `phase-delivery.json`, `delivery-manifest.json` |
+
+Cierre esperado:
+
+```
+Trail lifecycle: pendiente -> trabajando -> listo -> procesado
+Fases mutantes con target verificado: build, qa, delivery
+✔ Ciclo completo. Delivery en dry-run (sin auto-merge, sin main).
+```
+
+Exit code `0` = ciclo completo; `1` = abort (con contrato de error
+qué pasó · por qué · cómo seguir). En cualquier abort, **ninguna fase mutó
+`intrale/platform`**.
+
+## Garantías de seguridad (mapa a criterios)
+
+- **CA-D2.2 — blast radius (BLOQUEANTE):** `verifyTarget` corre antes de cada
+  fase mutante y **aborta** si el target resuelve dentro de `intrale/platform`,
+  si el marker declara `repo: intrale/platform`, si `projectId ≠ kernel-fixtures`,
+  o si el remote git de un clon apunta al producto.
+- **CA-D2.3 — delivery seguro:** `deliver` corre en **dry-run**; asevera
+  `autoMerge=false`, `mergeToMain=false`, `sign=false` y `tokenScope` scoped al
+  repo/rama del kernel (rechaza PAT org-wide). **No ejecuta** push ni `gh` real;
+  deja `delivery-manifest.json` como evidencia de gate.
+- **CA-D2.4 — supply chain:** `bootstrap` corre `npm ci` contra el lockfile
+  pineado (lockfileVersion ≥ 2, hashes SRI), **rechaza rangos abiertos**
+  (`^`/`~`/`latest`/`>=`) y **nunca** `npm install`. Sin auto-update silencioso.
+
+## Reuso por #4706
+
+El harness es **agnóstico del origen del target**. Para la prueba real contra el
+kernel publicado, sin tocar el código:
+
+```bash
+KERNEL_TARGET_REMOTE=https://github.com/intrale/kernel \
+KERNEL_TARGET_REF=main \
+  node fixtures/demo/run-cycle.js
+```
+
+Clona esa rama (shallow) al sandbox y aplica **las mismas** verificaciones de
+target y garantías de delivery/supply-chain. Mientras `main` no tenga
+`fixtures/`, `KERNEL_TARGET_REF=agent/4699-fixtures` apunta al target integrable
+disponible.
+
+## Variables de entorno
+
+| Variable | Default | Efecto |
+|----------|---------|--------|
+| `KERNEL_TARGET_REMOTE` | (vacío) | Si se define, clona ese remote en vez del bundled local. |
+| `KERNEL_TARGET_REF` | `agent/4699-fixtures` | Rama/tag a clonar (reuso #4706 → `main`). |
+| `KERNEL_DEMO_KEEP` | `0` | `1` conserva el sandbox y la evidencia (no los borra al cerrar). |
+
+## Troubleshooting
+
+| Síntoma | Causa probable | Acción |
+|---------|----------------|--------|
+| `ABORT [build]: rangos abiertos detectados` | El `package.json` del target usa `^`/`~`/`latest`. | Pineá cada dependencia a versión exacta y regenerá el lockfile. |
+| `ABORT [<fase>]: el target resuelve DENTRO de intrale/platform` | El ciclo intentó operar en-place sobre el repo del producto. | Es el guard de blast radius funcionando: el ciclo debe correr sobre el sandbox; revisá `resolveTarget`. |
+| `ABORT [<fase>]: falta el marker .kernel-target.json` | El target no es la copia del fixture del kernel. | Restaurá `fixtures/demo/target/` o apuntá a `intrale/kernel` con `KERNEL_TARGET_REMOTE`. |
+| `npm ci` falla por lockfile desincronizado | `package.json` y `package-lock.json` divergen. | Regenerá el lockfile con `npm install --package-lock-only` en `fixtures/demo/target/`. |
+| Clon (`KERNEL_TARGET_REMOTE`) falla por auth | El repo del kernel es privado y falta credencial scoped. | Autenticá `gh`/git con un token **scoped** al repo del kernel (nunca org-wide). |
+
+## Verificación automatizada
+
+La prueba E2E vive en
+[`.pipeline/tests/kernel-demo-cycle.test.js`](../../.pipeline/tests/kernel-demo-cycle.test.js)
+y se corre con la suite del pipeline:
+
+```bash
+npm run test:pipeline
+# o puntual:
+node --test .pipeline/tests/kernel-demo-cycle.test.js
+```
+
+Cubre: avance por fase, target verificado en cada fase mutante, **abort** ante un
+target que apunta a `intrale/platform`, delivery sin auto-merge, y lockfile
+pineado.

--- a/fixtures/demo/.gitignore
+++ b/fixtures/demo/.gitignore
@@ -1,0 +1,4 @@
+# Artefactos de ejecucion de la demo del ciclo (#4700). El ciclo corre en un
+# sandbox temporal (os.tmpdir); estos paths solo aparecen si se ejecuta en-place.
+target/node_modules/
+runs/

--- a/fixtures/demo/run-cycle.js
+++ b/fixtures/demo/run-cycle.js
@@ -1,0 +1,486 @@
+'use strict';
+
+// =============================================================================
+// fixtures/demo/run-cycle.js — Demo del ciclo dev -> build -> QA -> delivery
+// Issue: intrale/platform#4700 (Split de #4696 · Ola Puente P0 · CA-D2)
+// Diseño: docs/pipeline/kernel-repo-design.md §1 · Runbook: docs/runbooks/demo-cycle.md
+//
+// Qué hace
+// --------
+// Ejecuta un ciclo dev -> build -> QA -> delivery apuntado EXCLUSIVAMENTE a un
+// target controlado del kernel (copia local equivalente del fixture
+// `agent/4699-fixtures` de intrale/kernel), NUNCA a intrale/platform. Es la
+// evidencia de aceptación de P0 (CA-D2), reutilizable por #4706 cambiando el
+// target al `intrale/kernel@main` real (vía env KERNEL_TARGET_REMOTE/REF).
+//
+// Garantías de seguridad cableadas (criterios del issue)
+// ------------------------------------------------------
+//  · CA-D2.2 (blast radius, BLOQUEANTE): antes de cada fase mutante
+//    (build/QA/delivery) se verifica el target con `verifyTarget`; si el target
+//    resuelve a intrale/platform o fuera del sandbox, ABORTA con error accionable.
+//  · CA-D2.3: `deliver` corre en dry-run — sin auto-merge, sin merge/firma a
+//    `main`, con token scoped al repo/rama del kernel (nunca PAT org-wide). No
+//    ejecuta ningún push/gh real.
+//  · CA-D2.4 (supply chain): el bootstrap usa `npm ci` contra un lockfile
+//    pineado con hashes; rechaza rangos abiertos (^/~/latest) y no auto-actualiza.
+//
+// El ciclo corre sobre una COPIA del target en un sandbox temporal (os.tmpdir),
+// así ninguna fase mutante toca el working tree de intrale/platform.
+// =============================================================================
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync, execSync } = require('child_process');
+
+// --- Constantes de política de blast radius ---------------------------------
+const ALLOWED_REPO = 'intrale/kernel';
+const FORBIDDEN_REPO = 'intrale/platform';
+const EXPECTED_PROJECT_ID = 'kernel-fixtures';
+const PHASES = ['dev', 'build', 'qa', 'delivery'];
+const MUTATING_PHASES = new Set(['build', 'qa', 'delivery']);
+const LIFECYCLE = ['pendiente', 'trabajando', 'listo', 'procesado'];
+const OPEN_RANGE_RE = /[\^~*]|>=|<=|>|<|\s-\s|\|\||x|latest/i;
+
+const BUNDLED_TARGET = path.join(__dirname, 'target');
+
+// --- Errores ----------------------------------------------------------------
+class AbortError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'AbortError';
+  }
+}
+
+// Contrato de error accionable: qué pasó · por qué · cómo seguir.
+function abort(phase, what, why, how) {
+  throw new AbortError(
+    `✗ ABORT [${phase}]: ${what}\n` +
+      `  Por qué:    ${why}\n` +
+      `  Cómo seguir: ${how}`
+  );
+}
+
+// --- Helpers de FS ----------------------------------------------------------
+function readJson(file) {
+  return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+
+function realpath(p) {
+  try {
+    return fs.realpathSync(p);
+  } catch {
+    return path.resolve(p);
+  }
+}
+
+// Detecta el root de intrale/platform (repo donde vive este script) para el
+// guard de blast radius. Best-effort: sube buscando un `.git`.
+function detectPlatformRoot(startDir) {
+  let dir = realpath(startDir);
+  for (let i = 0; i < 12; i++) {
+    if (fs.existsSync(path.join(dir, '.git'))) return dir;
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  // Fallback: dos niveles arriba de fixtures/demo/.
+  return realpath(path.join(startDir, '..', '..'));
+}
+
+// --- Resolución del target --------------------------------------------------
+// Copia el target controlado a un sandbox temporal. Si se pasa un remote
+// (reuso #4706), clona esa rama en su lugar. Nunca opera en-place sobre el
+// bundled ni sobre el working tree de platform.
+function resolveTarget(opts = {}) {
+  const sandboxRoot = opts.sandboxRoot || os.tmpdir();
+  const sandbox = fs.mkdtempSync(path.join(sandboxRoot, 'kernel-demo-cycle-'));
+  const dir = path.join(sandbox, 'target');
+
+  const remote = opts.remote || process.env.KERNEL_TARGET_REMOTE || null;
+  const ref = opts.ref || process.env.KERNEL_TARGET_REF || 'agent/4699-fixtures';
+
+  if (remote) {
+    // Reuso #4706: clon pineado de la rama del kernel real.
+    execFileSync(
+      'git',
+      ['clone', '--depth', '1', '--branch', ref, remote, dir],
+      { stdio: 'pipe' }
+    );
+    return { dir, sandbox, source: `clone:${remote}@${ref}`, remote, ref };
+  }
+
+  // Default: copia local equivalente del fixture (bundled).
+  const bundled = opts.bundledDir || BUNDLED_TARGET;
+  if (!fs.existsSync(bundled)) {
+    abort(
+      'setup',
+      `no existe el target bundled en ${bundled}`,
+      'la copia local equivalente del fixture del kernel no está presente',
+      'restaurá fixtures/demo/target/ o pasá KERNEL_TARGET_REMOTE para clonar el kernel real'
+    );
+  }
+  fs.cpSync(bundled, dir, {
+    recursive: true,
+    filter: (src) => !src.includes(`${path.sep}node_modules${path.sep}`),
+  });
+  return { dir, sandbox, source: `local:${bundled}`, remote: null, ref };
+}
+
+// --- Verificación de target (CA-D2.2) ---------------------------------------
+// Se invoca antes de CADA fase mutante. Devuelve la línea de evidencia
+// `✔ target = kernel-fixtures (verificado)` o ABORTA con error accionable.
+function verifyTarget(targetDir, ctx) {
+  const phase = ctx.phase;
+  const platformRoot = ctx.platformRoot;
+  const resolved = realpath(targetDir);
+
+  // 1. Blast radius: el target NO puede ser (ni estar dentro de) el repo platform.
+  if (resolved === platformRoot || resolved.startsWith(platformRoot + path.sep)) {
+    abort(
+      phase,
+      `el target resuelve DENTRO de ${FORBIDDEN_REPO} (${resolved})`,
+      'una fase mutante sobre intrale/platform es exactamente el blast radius prohibido',
+      'el ciclo debe operar sobre una copia en sandbox (os.tmpdir); revisá resolveTarget'
+    );
+  }
+
+  // 2. Marker de identidad del target.
+  const markerFile = path.join(targetDir, '.kernel-target.json');
+  if (!fs.existsSync(markerFile)) {
+    abort(
+      phase,
+      `falta el marker .kernel-target.json en ${targetDir}`,
+      'sin marker no se puede afirmar que el target sea el kernel/fixtures',
+      'verificá que el target sea la copia del fixture agent/4699-fixtures'
+    );
+  }
+  const marker = readJson(markerFile);
+  if (marker.repo === FORBIDDEN_REPO) {
+    abort(
+      phase,
+      `el marker declara repo=${FORBIDDEN_REPO}`,
+      'el target apunta al producto, no al kernel',
+      'apuntá al kernel/fixtures (intrale/kernel)'
+    );
+  }
+  if (marker.repo !== ALLOWED_REPO) {
+    abort(
+      phase,
+      `el marker declara repo=${marker.repo}, se esperaba ${ALLOWED_REPO}`,
+      'el target no es el repo del kernel',
+      'apuntá exclusivamente al target controlado del kernel'
+    );
+  }
+  if (marker.projectId !== EXPECTED_PROJECT_ID) {
+    abort(
+      phase,
+      `projectId del marker = ${marker.projectId}, se esperaba ${EXPECTED_PROJECT_ID}`,
+      'el target no es el fixture del ciclo del kernel',
+      'usá el fixture kernel-fixtures'
+    );
+  }
+
+  // 3. Consistencia con el manifiesto.
+  const configFile = path.join(targetDir, 'pipeline.config.json');
+  const config = readJson(configFile);
+  if (config.projectId !== EXPECTED_PROJECT_ID) {
+    abort(
+      phase,
+      `pipeline.config.projectId = ${config.projectId} ≠ ${EXPECTED_PROJECT_ID}`,
+      'el manifiesto del target no coincide con el marker',
+      'el target está corrupto o mezclado; regeneralo desde el fixture'
+    );
+  }
+
+  // 4. Si es un clon real, el remote git no puede ser platform.
+  if (fs.existsSync(path.join(targetDir, '.git'))) {
+    let originUrl = '';
+    try {
+      originUrl = execFileSync('git', ['-C', targetDir, 'remote', 'get-url', 'origin'], {
+        stdio: 'pipe',
+      })
+        .toString()
+        .trim();
+    } catch {
+      originUrl = '';
+    }
+    if (originUrl.includes(FORBIDDEN_REPO)) {
+      abort(
+        phase,
+        `el remote origin del clon apunta a ${FORBIDDEN_REPO} (${originUrl})`,
+        'una fase mutante contra el producto es el blast radius prohibido',
+        'cloná exclusivamente intrale/kernel'
+      );
+    }
+    if (originUrl && !originUrl.includes(ALLOWED_REPO)) {
+      abort(
+        phase,
+        `el remote origin del clon (${originUrl}) no es ${ALLOWED_REPO}`,
+        'el target clonado no es el kernel',
+        'cloná exclusivamente intrale/kernel'
+      );
+    }
+  }
+
+  return {
+    ok: true,
+    phase,
+    repo: marker.repo,
+    projectId: marker.projectId,
+    dir: resolved,
+    line: `✔ target = ${EXPECTED_PROJECT_ID} (verificado) [${phase}] repo=${marker.repo} dir=${resolved}`,
+  };
+}
+
+// --- Bootstrap pineado (CA-D2.4) --------------------------------------------
+function bootstrap(targetDir) {
+  const pkgFile = path.join(targetDir, 'package.json');
+  const lockFile = path.join(targetDir, 'package-lock.json');
+  if (!fs.existsSync(pkgFile) || !fs.existsSync(lockFile)) {
+    abort(
+      'build',
+      'falta package.json o package-lock.json en el target',
+      'sin lockfile no hay instalación reproducible',
+      'el fixture debe traer package.json + package-lock.json pineado'
+    );
+  }
+  const lock = readJson(lockFile);
+  if (!(lock.lockfileVersion >= 2)) {
+    abort(
+      'build',
+      `lockfileVersion=${lock.lockfileVersion} (<2, sin soporte de hashes)`,
+      'un lockfile viejo no garantiza integridad SRI',
+      'regenerá el lockfile con npm >= 7 (lockfileVersion 3)'
+    );
+  }
+
+  // Rechazo de rangos abiertos: el kernel se pinea por versión exacta.
+  const pkg = readJson(pkgFile);
+  const openRanges = [];
+  for (const bucket of ['dependencies', 'devDependencies', 'optionalDependencies']) {
+    const deps = pkg[bucket] || {};
+    for (const [name, spec] of Object.entries(deps)) {
+      if (OPEN_RANGE_RE.test(String(spec))) openRanges.push(`${bucket}.${name}=${spec}`);
+    }
+  }
+  if (openRanges.length) {
+    abort(
+      'build',
+      `rangos abiertos detectados: ${openRanges.join(', ')}`,
+      'un rango ^/~/latest habilita auto-update silencioso (A08 supply chain)',
+      'pineá cada dependencia del kernel a versión exacta'
+    );
+  }
+
+  // Instalación reproducible y verificada: `npm ci` (NUNCA `npm install`).
+  // Comando constante (sin interpolación de input) — en Windows `execSync`
+  // resuelve `npm.cmd` vía el shell del sistema sin el DEP0190 de execFile+args.
+  const out = execSync('npm ci --no-audit --no-fund', {
+    cwd: targetDir,
+    stdio: 'pipe',
+  })
+    .toString()
+    .trim();
+
+  return {
+    tool: 'npm ci',
+    lockfileVersion: lock.lockfileVersion,
+    openRanges: 0,
+    log: out || 'npm ci: sin dependencias externas (lockfile pineado verificado)',
+  };
+}
+
+// --- Movimiento de work file por el lifecycle -------------------------------
+function moveWorkFile(targetDir, workFile, fromState, toState) {
+  const base = path.join(targetDir, 'demo-pipeline', 'demo-phase');
+  const fromDir = path.join(base, fromState);
+  const toDir = path.join(base, toState);
+  fs.mkdirSync(toDir, { recursive: true });
+  const src = path.join(fromDir, workFile);
+  const dst = path.join(toDir, workFile);
+  fs.renameSync(src, dst);
+  return { workFile, from: fromState, to: toState };
+}
+
+// --- Delivery dry-run (CA-D2.3) ---------------------------------------------
+function deliver(targetDir, ctx) {
+  const marker = readJson(path.join(targetDir, '.kernel-target.json'));
+  const plan = {
+    dryRun: true,
+    targetRepo: marker.repo, // intrale/kernel
+    headBranch: `agent/4700-demo-cycle`,
+    baseBranch: marker.ref || 'agent/4699-fixtures',
+    autoMerge: false,
+    mergeToMain: false,
+    sign: false,
+    tokenScope: `repo:${marker.repo}:${marker.ref || 'agent/4699-fixtures'}`,
+  };
+
+  // Aserciones de seguridad — el delivery NO puede degradar ninguna de estas.
+  if (plan.targetRepo === FORBIDDEN_REPO) {
+    abort('delivery', `delivery apunta a ${FORBIDDEN_REPO}`, 'el producto es blast radius prohibido', 'apuntá al kernel');
+  }
+  if (plan.autoMerge !== false) {
+    abort('delivery', 'autoMerge != false', 'el gate QA + GATE 2 no permite auto-merge', 'delivery debe ser dry-run/gate');
+  }
+  if (plan.mergeToMain !== false || plan.sign !== false) {
+    abort('delivery', 'mergeToMain/sign != false', 'no se puede mergear/firmar a main sin gate humano', 'delivery no muta main');
+  }
+  if (/org|all|:\*|^ghp_/.test(plan.tokenScope) || plan.tokenScope === '*') {
+    abort('delivery', `tokenScope sospechoso (${plan.tokenScope})`, 'un PAT org-wide expone toda la organización', 'usá un token scoped al repo/rama del kernel');
+  }
+
+  // Evidencia de delivery: manifiesto declarativo. NO ejecuta push/gh real.
+  const manifest = {
+    ...plan,
+    executed: false,
+    note: 'dry-run: no se ejecutó push ni gh; evidencia de gate/delivery únicamente',
+  };
+  const manifestFile = path.join(ctx.runDir, 'delivery-manifest.json');
+  fs.writeFileSync(manifestFile, JSON.stringify(manifest, null, 2));
+  return { manifest, manifestFile };
+}
+
+// --- Orquestación del ciclo -------------------------------------------------
+function runCycle(opts = {}) {
+  const platformRoot = realpath(opts.platformRoot || detectPlatformRoot(__dirname));
+  const runDir =
+    opts.runDir || fs.mkdtempSync(path.join(os.tmpdir(), 'kernel-demo-run-'));
+  fs.mkdirSync(runDir, { recursive: true });
+
+  const resolved = resolveTarget(opts);
+  const targetDir = resolved.dir;
+  const workFile = 'sample-1.demo-skill';
+
+  const evidence = [];
+  const verifications = [];
+  const trail = [];
+
+  const record = (phase, data) => {
+    const entry = { phase, ...data };
+    evidence.push(entry);
+    fs.writeFileSync(
+      path.join(runDir, `phase-${phase}.json`),
+      JSON.stringify(entry, null, 2)
+    );
+    return entry;
+  };
+
+  const gate = (phase) => {
+    if (!MUTATING_PHASES.has(phase)) return null;
+    const v = verifyTarget(targetDir, { phase, platformRoot });
+    verifications.push(v);
+    return v;
+  };
+
+  // --- Fase dev (no mutante externamente) ---
+  const devMove = moveWorkFile(targetDir, workFile, 'pendiente', 'trabajando');
+  trail.push('trabajando');
+  record('dev', { mutating: false, targetVerification: null, action: devMove, log: 'dev: work file tomado (pendiente -> trabajando)' });
+
+  // --- Fase build (mutante) ---
+  const buildV = gate('build');
+  const boot = bootstrap(targetDir);
+  const buildMove = moveWorkFile(targetDir, workFile, 'trabajando', 'listo');
+  trail.push('listo');
+  record('build', { mutating: true, targetVerification: buildV, bootstrap: boot, action: buildMove, log: `build: bootstrap pineado (${boot.tool}) + avance a listo` });
+
+  // --- Fase QA (mutante) ---
+  const qaV = gate('qa');
+  const config = readJson(path.join(targetDir, 'pipeline.config.json'));
+  const qaChecks = {
+    projectId: config.projectId === EXPECTED_PROJECT_ID,
+    lifecycleOk: JSON.stringify(config.lifecycle) === JSON.stringify(LIFECYCLE),
+    workFileEnListo: fs.existsSync(
+      path.join(targetDir, 'demo-pipeline', 'demo-phase', 'listo', workFile)
+    ),
+  };
+  if (!qaChecks.projectId || !qaChecks.lifecycleOk || !qaChecks.workFileEnListo) {
+    abort('qa', `checks estructurales fallaron: ${JSON.stringify(qaChecks)}`, 'el ciclo no avanzó como se esperaba', 'revisá el motor del ciclo y el fixture');
+  }
+  record('qa', { mutating: true, targetVerification: qaV, checks: qaChecks, log: 'qa: verificación estructural del ciclo OK' });
+
+  // --- Fase delivery (mutante, dry-run) ---
+  const delV = gate('delivery');
+  const del = deliver(targetDir, { runDir });
+  const delMove = moveWorkFile(targetDir, workFile, 'listo', 'procesado');
+  trail.push('procesado');
+  record('delivery', { mutating: true, targetVerification: delV, delivery: del.manifest, action: delMove, log: 'delivery: dry-run sin auto-merge, sin main, token scoped -> procesado' });
+
+  trail.unshift('pendiente');
+
+  const summary = {
+    ok: true,
+    issue: 4700,
+    target: { source: resolved.source, dir: targetDir, ref: resolved.ref },
+    platformRoot,
+    trail,
+    phases: PHASES,
+    mutatingPhasesVerified: verifications.map((v) => v.phase),
+    runDir,
+  };
+  fs.writeFileSync(path.join(runDir, 'summary.json'), JSON.stringify({ summary, evidence }, null, 2));
+
+  return { summary, evidence, verifications, trail, runDir, targetDir, sandbox: resolved.sandbox };
+}
+
+// --- CLI --------------------------------------------------------------------
+function main() {
+  const cleanup = process.env.KERNEL_DEMO_KEEP !== '1';
+  let result;
+  try {
+    result = runCycle({});
+  } catch (err) {
+    console.error('');
+    console.error(err.message);
+    console.error('');
+    console.error('Ciclo ABORTADO. Ninguna fase mutó intrale/platform.');
+    process.exit(1);
+    return;
+  }
+
+  const { summary, evidence, verifications } = result;
+  console.log('=============================================================');
+  console.log(' Demo del ciclo del kernel — dev -> build -> QA -> delivery');
+  console.log(' Issue #4700 (CA-D2) · target controlado, sin blast radius');
+  console.log('=============================================================');
+  console.log(`Target: ${summary.target.source}`);
+  console.log(`Sandbox: ${summary.target.dir}`);
+  console.log(`Platform root (protegido): ${summary.platformRoot}`);
+  console.log('');
+  for (const e of evidence) {
+    const tag = e.mutating ? 'MUTANTE ' : 'no-mut  ';
+    console.log(`[${tag}] fase ${e.phase.padEnd(9)} -> ${e.log}`);
+    if (e.targetVerification) console.log(`           ${e.targetVerification.line}`);
+  }
+  console.log('');
+  console.log(`Trail lifecycle: ${summary.trail.join(' -> ')}`);
+  console.log(`Fases mutantes con target verificado: ${verifications.map((v) => v.phase).join(', ')}`);
+  console.log(`Evidencia por fase: ${summary.runDir}`);
+  console.log('');
+  console.log('✔ Ciclo completo. Delivery en dry-run (sin auto-merge, sin main).');
+
+  if (cleanup && result.sandbox) {
+    try {
+      fs.rmSync(result.sandbox, { recursive: true, force: true });
+    } catch {
+      /* best-effort */
+    }
+  }
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  runCycle,
+  resolveTarget,
+  verifyTarget,
+  bootstrap,
+  deliver,
+  detectPlatformRoot,
+  AbortError,
+  __constants__: { ALLOWED_REPO, FORBIDDEN_REPO, EXPECTED_PROJECT_ID, PHASES, MUTATING_PHASES, LIFECYCLE },
+};

--- a/fixtures/demo/run-cycle.sh
+++ b/fixtures/demo/run-cycle.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# =============================================================================
+# fixtures/demo/run-cycle.sh — wrapper del ciclo demo dev->build->QA->delivery
+# Issue: intrale/platform#4700 (CA-D2). Runbook: docs/runbooks/demo-cycle.md
+#
+# Invoca el harness Node.js y propaga su código de salida. El harness es la
+# fuente de verdad: verifica el target antes de cada fase mutante (CA-D2.2),
+# corre delivery en dry-run sin auto-merge (CA-D2.3) y bootstrap pineado con
+# `npm ci` (CA-D2.4).
+#
+# Uso:
+#   bash fixtures/demo/run-cycle.sh                 # target controlado local (default)
+#   KERNEL_TARGET_REMOTE=https://github.com/intrale/kernel \
+#   KERNEL_TARGET_REF=agent/4699-fixtures \
+#     bash fixtures/demo/run-cycle.sh               # target clonado (reuso #4706 -> ref=main)
+#   KERNEL_DEMO_KEEP=1 bash fixtures/demo/run-cycle.sh   # conservar sandbox/evidencia
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "▶ Ejecutando ciclo demo del kernel (#4700)…"
+code=0
+node "${SCRIPT_DIR}/run-cycle.js" || code=$?
+
+if [ "${code}" -eq 0 ]; then
+  echo "✔ run-cycle.sh: ciclo completo (delivery dry-run, sin blast radius)."
+else
+  echo "✗ run-cycle.sh: ciclo abortado (exit ${code}). Ninguna fase mutó intrale/platform." >&2
+fi
+exit "${code}"

--- a/fixtures/demo/target/.kernel-target.json
+++ b/fixtures/demo/target/.kernel-target.json
@@ -1,0 +1,7 @@
+{
+  "repo": "intrale/kernel",
+  "projectId": "kernel-fixtures",
+  "origin": "https://github.com/intrale/kernel",
+  "ref": "agent/4699-fixtures",
+  "note": "Marker de identidad del target controlado del kernel. Copia local equivalente del fixture agent/4699-fixtures (#4699). NUNCA representa intrale/platform. #4706 reemplaza ref por 'main' cuando los fixtures esten publicados en intrale/kernel@main."
+}

--- a/fixtures/demo/target/demo-pipeline/demo-phase/pendiente/sample-1.demo-skill
+++ b/fixtures/demo/target/demo-pipeline/demo-phase/pendiente/sample-1.demo-skill
@@ -1,0 +1,4 @@
+issue: 4700
+fase: demo-phase
+pipeline: kernel-fixtures
+skill: demo-skill

--- a/fixtures/demo/target/package-lock.json
+++ b/fixtures/demo/target/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "kernel-fixtures-demo-target",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "kernel-fixtures-demo-target",
+      "version": "0.0.0"
+    }
+  }
+}

--- a/fixtures/demo/target/package.json
+++ b/fixtures/demo/target/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "kernel-fixtures-demo-target",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Target controlado del kernel para la demo del ciclo (#4700). Deps vacias a proposito: el bootstrap 'npm ci' verifica el lockfile pineado sin instalar rangos abiertos.",
+  "dependencies": {}
+}

--- a/fixtures/demo/target/pipeline.config.json
+++ b/fixtures/demo/target/pipeline.config.json
@@ -1,0 +1,13 @@
+{
+  "projectId": "kernel-fixtures",
+  "contractVersion": "0.1.0",
+  "phases": ["dev", "build", "qa", "delivery"],
+  "lifecycle": ["pendiente", "trabajando", "listo", "procesado"],
+  "routing": {
+    "demo-skill": "demo-phase"
+  },
+  "integrity": {
+    "pinned": true,
+    "install": "npm ci"
+  }
+}


### PR DESCRIPTION
## Resumen

Demo verificable end-to-end del ciclo del kernel (dev → build → QA → delivery) contra un repo target de fixtures (`intrale/kernel` simulado). Cierra P0-D2 de la Ola Puente.

Cambio **100% aditivo** — no toca runtime del pipeline:
- `fixtures/demo/run-cycle.js` + `run-cycle.sh` — harness del ciclo, agnóstico del origen del target (reutilizable por #4706 vía `KERNEL_TARGET_REMOTE`/`REF`)
- `fixtures/demo/target/` — repo target de ejemplo (config, package, skill de muestra)
- `docs/runbooks/demo-cycle.md` — runbook completo
- `.pipeline/tests/kernel-demo-cycle.test.js` — test E2E (globea `.pipeline/tests/**/*.test.js`)

## Validación del pipeline (todas las fases aprobadas)

- **dev** (pipeline-dev) · **build** ✓
- **verificación**: security ✓ · tester ✓ · qa ✓
- **aprobación**: architect ✓ · po ✓ · review ✓ · ux ✓

Review semántico del commit `3bec0a325`: cambio aditivo, sin código muerto ni TODOs, runbook correcto.

## QA

`qa:skipped` — infra pura de pipeline (`area:pipeline`, sin `app:*`), sin UI de usuario final ni assets visuales. PO y UX confirmaron que no requiere video E2E por política de CLAUDE.md.

Closes #4700

🤖 Generado con [Claude Code](https://claude.ai/claude-code)