### PR TITLE
Re-evaluación automática de bloqueos needs-human cuando desaparece el motivo del rechazo

### DIFF
--- a/.pipeline/lib/__tests__/anthropic-usage.test.js
+++ b/.pipeline/lib/__tests__/anthropic-usage.test.js
@@ -143,9 +143,10 @@ test('triggerRefreshAsync spawnea /usage, parsea y escribe el cache', async () =
         capturedArgs = args;
         return fakeChild('Current session: 30% used\nCurrent week (all models): 70% used\n');
     };
-    u.triggerRefreshAsync({ metricsDir: dir, spawnImpl, launcher: { cmd: 'claude', prefixArgs: [], shell: false } });
-    // Esperar a que el 'close' async escriba el cache.
-    await new Promise((res) => setTimeout(res, 30));
+    // Esperar el fin real del refresh (determinístico) en vez de un timeout fijo.
+    await new Promise((res) => {
+        u.triggerRefreshAsync({ metricsDir: dir, spawnImpl, launcher: { cmd: 'claude', prefixArgs: [], shell: false }, onDone: res });
+    });
     assert.ok(capturedArgs.includes('/usage'), 'debe invocar /usage');
     assert.ok(capturedArgs.includes('-p'), 'debe usar print mode');
     const c = u.readCache(dir);
@@ -156,12 +157,14 @@ test('triggerRefreshAsync spawnea /usage, parsea y escribe el cache', async () =
 test('triggerRefreshAsync no escribe cache si el spawn no produce dato parseable', async () => {
     const u = fresh();
     const dir = tmpMetrics();
-    u.triggerRefreshAsync({
-        metricsDir: dir,
-        spawnImpl: () => fakeChild('sin porcentajes aquí'),
-        launcher: { cmd: 'claude', prefixArgs: [], shell: false },
+    await new Promise((res) => {
+        u.triggerRefreshAsync({
+            metricsDir: dir,
+            spawnImpl: () => fakeChild('sin porcentajes aquí'),
+            launcher: { cmd: 'claude', prefixArgs: [], shell: false },
+            onDone: res,
+        });
     });
-    await new Promise((res) => setTimeout(res, 30));
     assert.equal(u.readCache(dir), null, 'fallback: no escribe basura');
 });
 

--- a/.pipeline/lib/__tests__/brazo-desbloqueo-core.test.js
+++ b/.pipeline/lib/__tests__/brazo-desbloqueo-core.test.js
@@ -20,7 +20,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
-const { selectMarkersToRelease, allDepsClosed } = require('../brazo-desbloqueo-core');
+const { selectMarkersToRelease, selectHumanBlocksToRelease, allDepsClosed } = require('../brazo-desbloqueo-core');
 
 // -----------------------------------------------------------------------------
 // allDepsClosed
@@ -157,4 +157,90 @@ test('CA-4: releaseDependencyBlockToPendiente reingresa work-files a pendiente/'
   // Limpieza de cache para no contaminar otros tests del mismo proceso.
   delete require.cache[require.resolve('../rebote-classifier')];
   delete require.cache[require.resolve('../traceability')];
+});
+
+// =============================================================================
+// #4748 · selectHumanBlocksToRelease — re-evaluación de needs-human de
+// precondición de dependencia. Cubre 100% de las ramas del selector fail-closed.
+// =============================================================================
+
+test('selectHumanBlocksToRelease (a): dependency con todas las deps CLOSED → toRelease', () => {
+  const markers = [{ issue: 4745, precondition: { type: 'dependency', depends_on: [4744] } }];
+  const { toRelease, blocked } = selectHumanBlocksToRelease({ markers, issueStates: { 4744: 'CLOSED' } });
+  assert.equal(toRelease.length, 1);
+  assert.equal(toRelease[0].issue, 4745);
+  assert.equal(blocked.length, 0);
+});
+
+test('selectHumanBlocksToRelease (b): alguna dep OPEN → blocked, no libera (SEC-3)', () => {
+  const markers = [{ issue: 10, precondition: { type: 'dependency', depends_on: [1, 2] } }];
+  const { toRelease, blocked } = selectHumanBlocksToRelease({ markers, issueStates: { 1: 'CLOSED', 2: 'OPEN' } });
+  assert.equal(toRelease.length, 0);
+  assert.equal(blocked.length, 1);
+  assert.deepEqual(blocked[0].openDeps, ['2']);
+});
+
+test('selectHumanBlocksToRelease (b2): dep con estado desconocido → blocked, no libera', () => {
+  const markers = [{ issue: 11, precondition: { type: 'dependency', depends_on: [7] } }];
+  const { toRelease, blocked } = selectHumanBlocksToRelease({ markers, issueStates: {} });
+  assert.equal(toRelease.length, 0);
+  assert.equal(blocked.length, 1);
+  assert.deepEqual(blocked[0].openDeps, ['7']);
+});
+
+test('selectHumanBlocksToRelease (c): human_judgment ignorado aunque deps CLOSED (CA-3/SEC-4)', () => {
+  const markers = [{ issue: 20, precondition: { type: 'human_judgment' }, depends_on: [1] }];
+  const { toRelease, blocked } = selectHumanBlocksToRelease({ markers, issueStates: { 1: 'CLOSED' } });
+  assert.equal(toRelease.length, 0);
+  assert.equal(blocked.length, 0, 'juicio humano no entra ni a toRelease ni a blocked');
+});
+
+test('selectHumanBlocksToRelease (d): marker sin precondition → ignorado (SEC-4)', () => {
+  const { toRelease, blocked } = selectHumanBlocksToRelease({ markers: [{ issue: 30 }], issueStates: { 1: 'CLOSED' } });
+  assert.equal(toRelease.length, 0);
+  assert.equal(blocked.length, 0);
+});
+
+test('selectHumanBlocksToRelease (e): depends_on vacío → ignorado', () => {
+  const markers = [{ issue: 40, precondition: { type: 'dependency', depends_on: [] } }];
+  const { toRelease, blocked } = selectHumanBlocksToRelease({ markers, issueStates: {} });
+  assert.equal(toRelease.length, 0);
+  assert.equal(blocked.length, 0);
+});
+
+test('selectHumanBlocksToRelease: type desconocido → ignorado', () => {
+  const markers = [{ issue: 50, precondition: { type: 'otro', depends_on: [1] } }];
+  const { toRelease, blocked } = selectHumanBlocksToRelease({ markers, issueStates: { 1: 'CLOSED' } });
+  assert.equal(toRelease.length, 0);
+  assert.equal(blocked.length, 0);
+});
+
+test('selectHumanBlocksToRelease: mezcla — libera sólo los que corresponden', () => {
+  const markers = [
+    { issue: 1, precondition: { type: 'dependency', depends_on: [100] } },      // CLOSED → release
+    { issue: 2, precondition: { type: 'dependency', depends_on: [200, 201] } }, // 201 OPEN → blocked
+    { issue: 3, precondition: { type: 'human_judgment' } },                     // ignorado
+    { issue: 4 },                                                               // ignorado
+  ];
+  const { toRelease, blocked } = selectHumanBlocksToRelease({
+    markers, issueStates: { 100: 'CLOSED', 200: 'CLOSED', 201: 'OPEN' },
+  });
+  assert.deepEqual(toRelease.map(m => m.issue), [1]);
+  assert.deepEqual(blocked.map(m => m.issue), [2]);
+});
+
+test('selectHumanBlocksToRelease: args vacíos → estructura vacía (defensivo)', () => {
+  assert.deepEqual(selectHumanBlocksToRelease(), { toRelease: [], blocked: [] });
+  assert.deepEqual(selectHumanBlocksToRelease({}), { toRelease: [], blocked: [] });
+  assert.deepEqual(selectHumanBlocksToRelease({ markers: null, issueStates: null }), { toRelease: [], blocked: [] });
+});
+
+test('#4745: dep OPEN → permanece; dep pasa a CLOSED → se libera (CA-4)', () => {
+  const marker = { issue: 4745, precondition: { type: 'dependency', depends_on: [4744] } };
+  let out = selectHumanBlocksToRelease({ markers: [marker], issueStates: { 4744: 'OPEN' } });
+  assert.equal(out.toRelease.length, 0);
+  assert.equal(out.blocked.length, 1);
+  out = selectHumanBlocksToRelease({ markers: [marker], issueStates: { 4744: 'CLOSED' } });
+  assert.equal(out.toRelease.length, 1);
+  assert.equal(out.toRelease[0].issue, 4745);
 });

--- a/.pipeline/lib/__tests__/human-block.test.js
+++ b/.pipeline/lib/__tests__/human-block.test.js
@@ -715,3 +715,153 @@ test('mergeGithubBlockedLabels es tolerante a args no-array', () => {
 test('GITHUB_HUMAN_BLOCK_LABELS incluye blocked:routing-manual', () => {
     assert.ok(hb.GITHUB_HUMAN_BLOCK_LABELS.includes('blocked:routing-manual'));
 });
+
+// =============================================================================
+// #4748 — precondition: registro estructurado del motivo del freeze
+// =============================================================================
+
+test('reportHumanBlock persiste precondition dependency en .reason.json', () => {
+    resetFs();
+    const result = hb.reportHumanBlock({
+        issue: 4745, skill: 'po', phase: 'dev', pipeline: 'desarrollo',
+        reason: 'necesita intervención humana: depende de #4744 abierto',
+        question: '¿mergeamos #4744?',
+        precondition: { type: 'dependency', depends_on: [4744] },
+    });
+    assert.deepEqual(result.precondition, { type: 'dependency', depends_on: [4744] });
+    const meta = JSON.parse(fs.readFileSync(result.marker_path + '.reason.json', 'utf8'));
+    assert.deepEqual(meta.precondition, { type: 'dependency', depends_on: [4744] });
+});
+
+test('reportHumanBlock sin precondition → default human_judgment (fail-closed SEC-4)', () => {
+    resetFs();
+    const result = hb.reportHumanBlock({
+        issue: 4801, skill: 'review', phase: 'dev', pipeline: 'desarrollo',
+        reason: 'rechazo semántico: el criterio AC#3 no se cumple',
+        question: '¿revisás el enfoque?',
+    });
+    assert.deepEqual(result.precondition, { type: 'human_judgment' });
+    const meta = JSON.parse(fs.readFileSync(result.marker_path + '.reason.json', 'utf8'));
+    assert.deepEqual(meta.precondition, { type: 'human_judgment' });
+});
+
+test('reportHumanBlock: dependency con depends_on vacío degrada a human_judgment', () => {
+    resetFs();
+    const result = hb.reportHumanBlock({
+        issue: 4802, skill: 'po', phase: 'dev', pipeline: 'desarrollo',
+        reason: 'r', question: 'q',
+        precondition: { type: 'dependency', depends_on: [] },
+    });
+    assert.deepEqual(result.precondition, { type: 'human_judgment' });
+});
+
+test('reportHumanBlock: depends_on con basura se coacciona a enteros positivos únicos', () => {
+    resetFs();
+    const result = hb.reportHumanBlock({
+        issue: 4803, skill: 'po', phase: 'dev', pipeline: 'desarrollo',
+        reason: 'r', question: 'q',
+        precondition: { type: 'dependency', depends_on: [4744, '4744', -1, 0, 'x', 4700] },
+    });
+    assert.deepEqual(result.precondition, { type: 'dependency', depends_on: [4700, 4744] });
+});
+
+test('listBlockedIssues expone precondition (dependency y default legacy)', () => {
+    resetFs();
+    hb.reportHumanBlock({
+        issue: 4810, skill: 'po', phase: 'dev', pipeline: 'desarrollo',
+        reason: 'r', question: 'q',
+        precondition: { type: 'dependency', depends_on: [4744, 4700] },
+    });
+    // marker legacy sin precondition en el .reason.json
+    const dir = path.join(TMP_DIR, '.pipeline', 'desarrollo', 'dev', 'bloqueado-humano');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, '4811.review'), '');
+    fs.writeFileSync(path.join(dir, '4811.review.reason.json'), JSON.stringify({
+        issue: 4811, skill: 'review', phase: 'dev', pipeline: 'desarrollo',
+        reason: 'legacy', question: 'q',
+    }));
+    const list = hb.listBlockedIssues();
+    const dep = list.find(i => i.issue === 4810);
+    assert.deepEqual(dep.precondition, { type: 'dependency', depends_on: [4700, 4744] });
+    const legacy = list.find(i => i.issue === 4811);
+    assert.deepEqual(legacy.precondition, { type: 'human_judgment' }, 'legacy sin precondition → human_judgment');
+});
+
+test('normalizePrecondition: formas inválidas colapsan a human_judgment', () => {
+    assert.deepEqual(hb.normalizePrecondition(null), { type: 'human_judgment' });
+    assert.deepEqual(hb.normalizePrecondition({}), { type: 'human_judgment' });
+    assert.deepEqual(hb.normalizePrecondition({ type: 'dependency' }), { type: 'human_judgment' });
+    assert.deepEqual(hb.normalizePrecondition({ type: 'dependency', depends_on: ['x'] }), { type: 'human_judgment' });
+});
+
+// --- classifyPrecondition: SÓLO hint estructural, nunca texto libre (SEC-1) ---
+
+test('classifyPrecondition: campo estructurado depende_de → dependency', () => {
+    const pc = hb.classifyPrecondition([{ motivo: 'necesita intervención humana', depende_de: [4744] }]);
+    assert.deepEqual(pc, { type: 'dependency', depends_on: [4744] });
+});
+
+test('classifyPrecondition: campo precondicion_issues también sirve', () => {
+    const pc = hb.classifyPrecondition([{ motivo: 'x', precondicion_issues: [10, 11] }]);
+    assert.deepEqual(pc, { type: 'dependency', depends_on: [10, 11] });
+});
+
+test('classifyPrecondition: #NNNN en texto libre NO clasifica dependency (SEC-1)', () => {
+    const pc = hb.classifyPrecondition([
+        { motivo: 'bloqueo humano: revisar el diseño relacionado con #4744 y #4700' },
+    ]);
+    assert.deepEqual(pc, { type: 'human_judgment' }, 'texto libre nunca alimenta dependency');
+});
+
+test('classifyPrecondition: extraDeps (hint estructural) se incorpora', () => {
+    const pc = hb.classifyPrecondition([{ motivo: 'x' }], [4744, 4700]);
+    assert.deepEqual(pc, { type: 'dependency', depends_on: [4700, 4744] });
+});
+
+test('classifyPrecondition: sin rechazos ni extraDeps → human_judgment', () => {
+    assert.deepEqual(hb.classifyPrecondition([]), { type: 'human_judgment' });
+    assert.deepEqual(hb.classifyPrecondition(null), { type: 'human_judgment' });
+    assert.deepEqual(hb.classifyPrecondition([{ motivo: 'x' }]), { type: 'human_judgment' });
+});
+
+test('classifyPrecondition: combina deps de varios rechazos + extraDeps y dedup', () => {
+    const pc = hb.classifyPrecondition([
+        { motivo: 'a', depende_de: [4744] },
+        { motivo: 'b', depende_de: [4744, 4700] },
+    ], [4700, 4800]);
+    assert.deepEqual(pc, { type: 'dependency', depends_on: [4700, 4744, 4800] });
+});
+
+test('unblockIssue borra el .reason.json (con precondition) al re-encolar', () => {
+    resetFs();
+    const r = hb.reportHumanBlock({
+        issue: 4820, skill: 'po', phase: 'dev', pipeline: 'desarrollo',
+        reason: 'r', question: 'q',
+        precondition: { type: 'dependency', depends_on: [4744] },
+    });
+    assert.ok(fs.existsSync(r.marker_path + '.reason.json'));
+    const res = hb.unblockIssue({ issue: 4820, unlocker: 'brazo-desbloqueo:precondicion' });
+    assert.equal(res.ok, true);
+    assert.equal(fs.existsSync(r.marker_path + '.reason.json'), false, 'reason.json (y su precondition) se limpia');
+});
+
+test('e2e #4748: precondición resuelta → selector core lo mueve a toRelease; juicio humano intacto', () => {
+    resetFs();
+    hb.reportHumanBlock({
+        issue: 4745, skill: 'po', phase: 'dev', pipeline: 'desarrollo',
+        reason: 'necesita intervención humana: depende de #4744', question: '¿mergeás #4744?',
+        precondition: { type: 'dependency', depends_on: [4744] },
+    });
+    hb.reportHumanBlock({
+        issue: 4746, skill: 'review', phase: 'dev', pipeline: 'desarrollo',
+        reason: 'rechazo semántico del enfoque', question: '¿revisás?',
+    });
+    const core = require('../brazo-desbloqueo-core');
+    const markers = hb.listBlockedIssues();
+    // #4744 abierto → nada se libera.
+    let out = core.selectHumanBlocksToRelease({ markers, issueStates: { 4744: 'OPEN' } });
+    assert.equal(out.toRelease.length, 0);
+    // #4744 cerrado → sólo #4745 (dependency) se libera; #4746 (juicio) intacto.
+    out = core.selectHumanBlocksToRelease({ markers, issueStates: { 4744: 'CLOSED' } });
+    assert.deepEqual(out.toRelease.map(m => m.issue), [4745]);
+});

--- a/.pipeline/lib/__tests__/rebote-classifier.test.js
+++ b/.pipeline/lib/__tests__/rebote-classifier.test.js
@@ -151,6 +151,15 @@ test('CA-3: "depende de #N" extrae el número', () => {
     assert.equal(r.matched, true);
     assert.deepEqual(r.dependsOn, [3083]);
     assert.equal(r.assetOnly, false);
+    // #4748 — patrón de texto libre: NO es señal confiable para auto-destrabar
+    // un needs-human (SEC-1).
+    assert.equal(r.source, 'text_pattern');
+});
+
+test('#4748: motivo sin patrón → source null', () => {
+    const r = rc.detectDependencyBlock('NullPointerException en línea 42');
+    assert.equal(r.matched, false);
+    assert.equal(r.source, null);
 });
 
 test('CA-3: "bloqueado por #N" extrae el número', () => {
@@ -201,6 +210,8 @@ test('CA-4: hint estructural detecta dependency_block sin patrones de texto', ()
     );
     assert.equal(r.matched, true);
     assert.deepEqual(r.dependsOn, [2734, 3083]);
+    // #4748 — SÓLO esta rama habilita auto-destrabe de needs-human (SEC-1).
+    assert.equal(r.source, 'structured_hint');
 });
 
 test('CA-4: hint estructural + dependsOn extra del caller', () => {

--- a/.pipeline/lib/anthropic-usage.js
+++ b/.pipeline/lib/anthropic-usage.js
@@ -181,7 +181,10 @@ function resolveLauncher() {
 // NUNCA bloquea ni lanza. Guarda contra spawns concurrentes con `_refreshing`.
 // Al cerrar el proceso, parsea stdout y (si hubo dato) reescribe el cache.
 //
-// @param {object} opts { metricsDir, spawnImpl?, launcher?, env? }
+// @param {object} opts { metricsDir, spawnImpl?, launcher?, env?, onDone? }
+//   @property {function} [onDone]  callback opcional invocado 1 vez al terminar
+//                                  el refresh (para esperar el fin de forma
+//                                  determinística en tests). Best-effort.
 // -----------------------------------------------------------------------------
 function triggerRefreshAsync(opts) {
     if (_refreshing) return;
@@ -194,7 +197,17 @@ function triggerRefreshAsync(opts) {
 
     _refreshing = true;
     let done = false;
-    const finish = () => { if (!done) { done = true; _refreshing = false; } };
+    // onDone: callback opcional de completitud (tests). Se invoca exactamente
+    // una vez al terminar el refresh (close/error/timeout/spawn-throw), después
+    // de haber (o no) reescrito el cache. Permite esperar el fin de forma
+    // determinística en vez de un setTimeout fijo. NUNCA lanza hacia afuera.
+    const onDone = (opts && typeof opts.onDone === 'function') ? opts.onDone : null;
+    const finish = () => {
+        if (done) return;
+        done = true;
+        _refreshing = false;
+        if (onDone) { try { onDone(); } catch { /* best-effort */ } }
+    };
 
     let child;
     try {

--- a/.pipeline/lib/brazo-desbloqueo-core.js
+++ b/.pipeline/lib/brazo-desbloqueo-core.js
@@ -94,8 +94,51 @@ function selectMarkersToRelease({ markers, issueStates } = {}) {
   return { toRelease, blocked };
 }
 
+/**
+ * #4748 — SEGUNDA fuente de markers para el MISMO motor fail-closed: los
+ * `needs-human` cuyo motivo de freeze se congeló como precondición de
+ * dependencia (`precondition.type === 'dependency'`). Reutiliza `allDepsClosed`
+ * — la misma decisión que gobierna los `blocked:dependencies` — para que exista
+ * una sola máquina de destrabe, no dos divergentes.
+ *
+ * Sólo considera markers con `precondition.type === 'dependency'` y
+ * `precondition.depends_on` no vacío. Cualquier otro (juicio humano, ausente,
+ * tipo desconocido) se IGNORA por completo: no entra ni a `toRelease` ni a
+ * `blocked`, dejando el fail-closed del juicio humano intacto (SEC-4, CA-3).
+ *
+ * @param {object} p
+ * @param {Array<{issue:(string|number), precondition?:{type:string, depends_on?:Array<string|number>}}>} p.markers
+ * @param {Record<string,string>} p.issueStates - estado observado por dep
+ * @returns {{ toRelease: Array<object>, blocked: Array<object> }}
+ */
+function selectHumanBlocksToRelease({ markers, issueStates } = {}) {
+  const list = Array.isArray(markers) ? markers : [];
+  const states = issueStates && typeof issueStates === 'object' ? issueStates : {};
+  const toRelease = [];
+  const blocked = [];
+
+  for (const m of list) {
+    const pc = m && m.precondition;
+    // SÓLO dependencia estructurada. Juicio humano / ausente / tipo raro →
+    // intocable (SEC-4). No lo agregamos ni a toRelease ni a blocked.
+    if (!pc || pc.type !== 'dependency') continue;
+    const deps = Array.isArray(pc.depends_on) ? pc.depends_on : [];
+    if (deps.length === 0) continue; // sin deps declaradas → intocable
+    if (allDepsClosed(deps, states)) {
+      toRelease.push(m);
+    } else {
+      const openDeps = deps.map(depKey).filter((d) => states[d] !== CLOSED);
+      blocked.push({ ...m, openDeps });
+    }
+  }
+
+  return { toRelease, blocked };
+}
+
 module.exports = {
   selectMarkersToRelease,
+  selectHumanBlocksToRelease,
   allDepsClosed,
+  depKey,
   CLOSED,
 };

--- a/.pipeline/lib/human-block.js
+++ b/.pipeline/lib/human-block.js
@@ -156,6 +156,66 @@ function guidanceFilePath(targetDir, marker) {
     return path.join(targetDir, marker + '.guidance.txt');
 }
 
+// #4748 — Precondición del freeze. Dos tipos:
+//   - 'human_judgment' (default, fail-closed): requiere juicio humano genuino
+//     (rechazo semántico, decisión de negocio). NUNCA se auto-suelta.
+//   - 'dependency': el freeze depende de que ciertos issues/PRs cierren. Es
+//     objetivamente verificable → el brazo de desbloqueo lo re-evalúa cada
+//     ciclo y lo suelta cuando `depends_on` está todo cerrado.
+const HUMAN_JUDGMENT = { type: 'human_judgment' };
+
+/**
+ * Normaliza/valida un objeto precondition antes de persistirlo o exponerlo.
+ * Cualquier forma inválida colapsa a `human_judgment` (fail-closed, SEC-4).
+ * Para `dependency`, coacciona `depends_on` a enteros positivos únicos; si no
+ * queda ninguno, degrada a `human_judgment` (una precondición de dependencia
+ * sin dependencias no es auto-re-evaluable).
+ */
+function normalizePrecondition(pc) {
+    if (!pc || typeof pc !== 'object') return { ...HUMAN_JUDGMENT };
+    if (pc.type !== 'dependency') return { ...HUMAN_JUDGMENT };
+    const raw = Array.isArray(pc.depends_on) ? pc.depends_on : [];
+    const seen = new Set();
+    const deps = [];
+    for (const v of raw) {
+        const n = Number(v);
+        if (Number.isFinite(n) && n > 0 && !seen.has(n)) {
+            seen.add(n);
+            deps.push(n);
+        }
+    }
+    if (deps.length === 0) return { ...HUMAN_JUDGMENT };
+    return { type: 'dependency', depends_on: deps.sort((a, b) => a - b) };
+}
+
+/**
+ * #4748 — Clasifica la precondición de un freeze a partir de hints
+ * ESTRUCTURALES explícitos, NUNCA por extracción laxa de `#NNNN` del texto
+ * libre del motivo (SEC-1). Fuentes válidas:
+ *   - campo YAML `depende_de` / `precondicion_issues` de cada rechazo.
+ *   - `extraDeps`: issue numbers derivados por el llamador SÓLO de la rama
+ *     `source === 'structured_hint'` de `detectDependencyBlock`.
+ * Ante cualquier duda → juicio humano (fail-closed).
+ *
+ * @param {Array<Object>} rechazados  YAMLs de rechazo (con posibles
+ *   `depende_de` / `precondicion_issues`).
+ * @param {Array<string|number>} [extraDeps]  deps ya validadas por hint estructural.
+ * @returns {{type:'dependency',depends_on:number[]}|{type:'human_judgment'}}
+ */
+function classifyPrecondition(rechazados, extraDeps = []) {
+    const list = Array.isArray(rechazados) ? rechazados : [];
+    const deps = [];
+    for (const r of list) {
+        if (!r || typeof r !== 'object') continue;
+        const raw = r.depende_de != null ? r.depende_de : r.precondicion_issues;
+        const arr = Array.isArray(raw) ? raw : (raw != null ? [raw] : []);
+        for (const v of arr) deps.push(v);
+    }
+    if (Array.isArray(extraDeps)) for (const v of extraDeps) deps.push(v);
+    // normalizePrecondition dedup + ordena + degrada a human_judgment si vacío.
+    return normalizePrecondition({ type: 'dependency', depends_on: deps });
+}
+
 function reportHumanBlock(opts) {
     const issue = Number(opts.issue);
     const skill = String(opts.skill || '').trim();
@@ -192,8 +252,15 @@ function reportHumanBlock(opts) {
         fs.writeFileSync(targetFile, '');
     }
 
+    // #4748 — Congelar la precondición del freeze en el momento del escalado.
+    // El brazo de desbloqueo la lee de acá y JAMÁS re-deriva del body/comments
+    // de GitHub (SEC-2). Default fail-closed: si el llamador no clasificó una
+    // precondición estructurada → juicio humano → nunca auto-re-evaluable (SEC-4).
+    const precondition = normalizePrecondition(opts.precondition);
+
     fs.writeFileSync(reasonFilePath(targetFile), JSON.stringify({
         issue, skill, phase, pipeline, reason, question,
+        precondition,
         blocked_at: new Date().toISOString(),
     }, null, 2));
 
@@ -206,7 +273,7 @@ function reportHumanBlock(opts) {
         enqueueNeedsHumanLabel(issue);
     }
 
-    return { issue, skill, phase, pipeline, marker_path: targetFile };
+    return { issue, skill, phase, pipeline, precondition, marker_path: targetFile };
 }
 
 function listBlockedIssues() {
@@ -228,19 +295,24 @@ function listBlockedIssues() {
                 const skill = f.slice(dot + 1);
                 if (!Number.isFinite(issue)) continue;
                 const file = path.join(dir, f);
-                let reason = '', question = '', blockedAt = null;
+                let reason = '', question = '', blockedAt = null, precondition = null;
                 try {
                     const meta = JSON.parse(fs.readFileSync(reasonFilePath(file), 'utf8'));
                     reason = meta.reason || '';
                     question = meta.question || '';
                     blockedAt = meta.blocked_at || null;
+                    precondition = meta.precondition || null;
                 } catch {}
+                // #4748 — Markers legacy sin `precondition` (backward-compat,
+                // SEC-4) o con forma inválida → default juicio humano → jamás
+                // elegibles para auto-destrabe.
+                precondition = normalizePrecondition(precondition);
                 let mtime;
                 try { mtime = fs.statSync(file).mtimeMs; } catch { mtime = Date.now(); }
                 const ageHours = (Date.now() - mtime) / 3600000;
                 result.push({
                     issue, skill, phase, pipeline,
-                    reason, question,
+                    reason, question, precondition,
                     blocked_at: blockedAt || new Date(mtime).toISOString(),
                     age_hours: Math.round(ageHours * 10) / 10,
                     marker_path: file,
@@ -832,6 +904,8 @@ module.exports = {
     findBlockedMarker,
     isHumanBlockReason,
     inferHumanBlockQuestion,
+    classifyPrecondition,
+    normalizePrecondition,
     buildBlockedSummaryMarkdown,
     buildNeedHumanAudioText,
     sendNeedHumanAudio,

--- a/.pipeline/lib/rebote-classifier.js
+++ b/.pipeline/lib/rebote-classifier.js
@@ -400,11 +400,17 @@ function classifyRebote(opts = {}) {
  * Detecta si un motivo describe una dependency_block. Combina hint
  * estructural (rebote_categoria/depende_de) + pattern matching.
  *
- * @returns {{ matched: boolean, dependsOn: number[], assetOnly: boolean }}
+ * `source` distingue POR QUÉ matcheó (SEC-1, #4748): sólo
+ * `'structured_hint'` (el agente declaró `rebote_categoria: dependency_block`)
+ * es señal confiable para auto-re-evaluar un `needs-human`; las ramas
+ * `'text_pattern'` / `'asset_pattern'` son extracción laxa y NO deben
+ * degradar un juicio humano a auto-destrabe.
+ *
+ * @returns {{ matched: boolean, dependsOn: number[], assetOnly: boolean, source: (null|'structured_hint'|'text_pattern'|'asset_pattern') }}
  */
 function detectDependencyBlock(motivo, hintDeps = []) {
     if (typeof motivo !== 'string' || !motivo.trim()) {
-        return { matched: false, dependsOn: [], assetOnly: false };
+        return { matched: false, dependsOn: [], assetOnly: false, source: null };
     }
 
     // 2a. Hint estructural (agente ya clasificó explícitamente)
@@ -420,7 +426,7 @@ function detectDependencyBlock(motivo, hintDeps = []) {
         const sorted = Array.from(deps).sort((a, b) => a - b).slice(0, MAX_DEPS_PER_BLOCK);
         // Si solo hubo hint pero no logramos extraer números, igual lo
         // marcamos como matched: el agente sabe lo que hace.
-        return { matched: true, dependsOn: sorted, assetOnly: sorted.length === 0 };
+        return { matched: true, dependsOn: sorted, assetOnly: sorted.length === 0, source: 'structured_hint' };
     }
 
     // 2b. Patrones de texto (issue numbers)
@@ -439,17 +445,17 @@ function detectDependencyBlock(motivo, hintDeps = []) {
 
     if (found.size > 0) {
         const sorted = Array.from(found).sort((a, b) => a - b).slice(0, MAX_DEPS_PER_BLOCK);
-        return { matched: true, dependsOn: sorted, assetOnly: false };
+        return { matched: true, dependsOn: sorted, assetOnly: false, source: 'text_pattern' };
     }
 
     // 2c. Patrones de assets/recursos (sin issue number explícito)
     for (const pat of DEPENDENCY_ASSET_PATTERNS) {
         if (pat.test(motivo)) {
-            return { matched: true, dependsOn: [], assetOnly: true };
+            return { matched: true, dependsOn: [], assetOnly: true, source: 'asset_pattern' };
         }
     }
 
-    return { matched: false, dependsOn: [], assetOnly: false };
+    return { matched: false, dependsOn: [], assetOnly: false, source: null };
 }
 
 /**

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -3832,6 +3832,26 @@ function brazoBarrido(config) {
             ).slice(0, 1500);
             const question = humanBlock.inferHumanBlockQuestion(principal.motivo, { skill: skillBloq });
 
+            // #4748 — Congelar la precondición del freeze SÓLO por hint
+            // estructural (SEC-1): campos YAML `depende_de` del agente, y la rama
+            // `source === 'structured_hint'` de detectDependencyBlock (agente
+            // declaró `rebote_categoria: dependency_block`). NUNCA por extracción
+            // laxa de `#NNNN` del texto libre (ramas text_pattern/asset_pattern).
+            // Si el freeze quedó atado a issues verificables → el brazo de
+            // desbloqueo lo re-evalúa y auto-destraba al cerrar; si no → juicio
+            // humano (fail-closed, no se toca nunca por silencio).
+            const hintDeps = [];
+            for (const m of motivosHumanos) {
+              const det = reboteClassifier.detectDependencyBlock(
+                m.motivo || '',
+                Array.isArray(m.depende_de) ? m.depende_de : [],
+              );
+              if (det && det.matched && det.source === 'structured_hint') {
+                for (const n of (det.dependsOn || [])) hintDeps.push(n);
+              }
+            }
+            const precondition = humanBlock.classifyPrecondition(motivosHumanos, hintDeps);
+
             // Dedup: si ya hay marker activo en bloqueado-humano/ no spamear.
             const yaBloqueado = humanBlock.findBlockedMarker(issue);
 
@@ -3864,6 +3884,7 @@ function brazoBarrido(config) {
                   pipeline: pipelineName,
                   reason: motivoTxt,
                   question,
+                  precondition, // #4748 — congelada al escalar (SEC-2)
                   moveFromActive: false,
                 });
               } catch (e) {
@@ -16479,6 +16500,119 @@ async function brazoTransicionOla(config) {
   }
 }
 
+/**
+ * #4748 — Reaper de `needs-human` con precondición de dependencia resuelta.
+ *
+ * SEGUNDA fuente de markers para el MISMO motor de destrabe: recorre los
+ * markers de `bloqueado-humano/` cuyo `precondition.type` es `dependency`,
+ * verifica el estado REAL de cada dependencia en GitHub y, si TODAS cerraron,
+ * saca el `needs-human` y re-encola el issue — dejando traza. Los `needs-human`
+ * de juicio humano (default, fail-closed) jamás se tocan.
+ *
+ * Fail-closed en todos los bordes (SEC-3): dependencia con estado desconocido,
+ * error de `gh`, timeout o respuesta vacía → NO libera. La decisión final la
+ * toma el motor puro `selectHumanBlocksToRelease` (reutiliza `allDepsClosed`).
+ *
+ * Corre dentro del guard/throttle del brazo (mismo tick, sin abrir una segunda
+ * pasada) reutilizando `ghDesbloqueoCall`.
+ */
+async function reapStaleHumanBlocks({ allowlistSet } = {}) {
+  let markers;
+  try {
+    markers = humanBlock.listBlockedIssues().filter(b =>
+      b.precondition
+      && b.precondition.type === 'dependency'
+      && Array.isArray(b.precondition.depends_on)
+      && b.precondition.depends_on.length > 0
+    );
+  } catch (e) {
+    log('desbloqueo', `[human-block] error listando bloqueados: ${e.message}`);
+    return;
+  }
+
+  // Respetar pausa parcial: sólo re-evaluar los que están en el allowlist.
+  if (allowlistSet) markers = markers.filter(m => allowlistSet.has(String(m.issue)));
+  if (markers.length === 0) return;
+
+  // Recolectar el set de dependencias únicas (minimiza llamadas a gh). SEC-6:
+  // coercionar a entero positivo antes de usar como argumento de `gh`.
+  const depSet = new Set();
+  for (const m of markers) {
+    for (const d of m.precondition.depends_on) {
+      const n = Number(d);
+      if (Number.isFinite(n) && n > 0) depSet.add(n);
+    }
+  }
+
+  // Consultar el estado observado de cada dependencia. Fail-closed: cualquier
+  // dep sin estado conocido queda fuera de `issueStates` → no libera.
+  const issueStates = {};
+  for (const dep of depSet) {
+    ghThrottle();
+    try {
+      const { stdout: depState } = await ghDesbloqueoCall(
+        ['issue', 'view', String(dep), '--json', 'state', '--jq', '.state', '--repo', 'intrale/platform'],
+        10000
+      );
+      const st = String(depState || '').trim();
+      if (st) issueStates[String(dep)] = st; // 'OPEN' | 'CLOSED'
+    } catch (e) {
+      log('desbloqueo', `[human-block] no se pudo leer estado de #${dep}: ${e.message} — fail-closed`);
+    }
+  }
+
+  const { toRelease } = brazoDesbloqueoCore.selectHumanBlocksToRelease({ markers, issueStates });
+
+  for (const m of toRelease) {
+    const deps = m.precondition.depends_on;
+    const depStates = deps.map(n => `#${n}=${issueStates[String(n)] || 'desconocido'}`).join(', ');
+    const guidance = `Auto-destrabe (#4748): precondición resuelta. Dependencia(s) ${deps.map(n => '#' + n).join(', ')} cerrada(s). El pipeline re-encola este issue para continuar su ciclo.`;
+
+    let res;
+    try {
+      res = humanBlock.unblockIssue({
+        issue: m.issue,
+        unlocker: 'brazo-desbloqueo:precondicion',
+        guidance,
+      });
+    } catch (e) {
+      log('desbloqueo', `[human-block] error unblock #${m.issue}: ${e.message}`);
+      continue;
+    }
+    if (!res || !res.ok) {
+      // Idempotente: marker ausente (destrabado por /unblock manual entre el
+      // listado y ahora) → no-op benigno.
+      log('desbloqueo', `[human-block] unblock #${m.issue} no-op: ${res && res.error}`);
+      continue;
+    }
+
+    // Quitar el label needs-human en GitHub + comentario de traza vía la cola.
+    try {
+      const ghQueueDir = path.join(PIPELINE, 'servicios', 'github', 'pendiente');
+      fs.mkdirSync(ghQueueDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(ghQueueDir, `${m.issue}-remove-needs-human-${Date.now()}.json`),
+        JSON.stringify({ action: 'remove-label', issue: Number(m.issue), label: humanBlock.NEEDS_HUMAN_LABEL }),
+      );
+      fs.writeFileSync(
+        path.join(ghQueueDir, `${m.issue}-auto-unblock-comment-${Date.now()}.json`),
+        JSON.stringify({
+          action: 'comment',
+          issue: Number(m.issue),
+          body: `## 🔓 Auto-destrabado por el pipeline\n\nEste issue estaba en \`needs-human\` porque su precondición dependía de ${deps.map(n => '#' + n).join(', ')}. Esa(s) dependencia(s) ya cerró(aron) (${depStates}), así que el motivo del freeze dejó de ser cierto.\n\nEl pipeline lo sacó de \`needs-human\` y lo re-encoló automáticamente para continuar su ciclo — sin intervención humana.\n\n_Destrabado por el brazo de desbloqueo (#4748). El fail-closed sigue vigente para los bloqueos de juicio humano._`,
+        }),
+      );
+    } catch (e) {
+      log('desbloqueo', `[human-block] error encolando acciones GitHub #${m.issue}: ${e.message}`);
+    }
+
+    log('desbloqueo', `🔓 #${m.issue} auto-destrabado de needs-human — precondición resuelta (${depStates}) → re-encolado a ${res.pipeline}/${res.to_phase}`);
+    try {
+      sendTelegram(`🔓 Issue #${m.issue} auto-destrabado — precondición resuelta (deps: ${deps.map(n => '#' + n).join(', ')}). Vuelve a la cola del pipeline.`);
+    } catch {}
+  }
+}
+
 async function brazoDesbloqueoImpl(config) {
   // #2506: respetar pausa parcial — los bloqueados fuera del allowlist no se van
   // a ejecutar aunque se desbloqueen ahora, así que no tiene sentido gastar el
@@ -16488,6 +16622,12 @@ async function brazoDesbloqueoImpl(config) {
   const allowlistSet = pipelineMode.mode === 'partial_pause'
     ? new Set(pipelineMode.allowedIssues.map(String))
     : null;
+
+  // #4748 — Re-evaluar los `needs-human` de precondición ANTES del barrido de
+  // blocked:dependencies, para no depender de su early-return (cuando no hay
+  // ningún blocked:dependencies el barrido retorna, pero los needs-human de
+  // precondición igual deben re-evaluarse cada ciclo).
+  await reapStaleHumanBlocks({ allowlistSet });
 
   try {
     // 1. Buscar issues abiertos con label blocked:dependencies


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 9 archivos · +546 -20

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:skipped` aplicado por delivery

## Closes

Closes #4748
