### PR TITLE
Corregir disparo de la notificación de cola ociosa: alertar solo por causa real (saturación de recursos o deadlock humano), no por modo ola

### DIFF
--- a/.pipeline/lib/__tests__/dispatch-cause-dashboard.test.js
+++ b/.pipeline/lib/__tests__/dispatch-cause-dashboard.test.js
@@ -62,6 +62,25 @@ test('slice degrada a inactivo ante artifact corrupto (no-JSON)', () => {
     assert.deepStrictEqual(slices.dispatchCauseSlice({}, { PIPELINE: dir }), { active: false });
 });
 
+test('#4751: slice detecta MODO_OLA y lo muestra con su label (banner no se filtra)', () => {
+    const dir = tmpDir();
+    // MODO_OLA es silenciosa (no alerta a Telegram) pero SÍ se publica el banner.
+    dc.publish({
+        pipelineDir: dir,
+        snapshot: { anyLaunched: false, hayPendientes: true, gatesActivos: new Set([dc.CAUSAS.MODO_OLA]), detalles: { [dc.CAUSAS.MODO_OLA]: 'sólo se despachan los issues de la ola activa' } },
+        now: 2_000_000,
+    });
+    const s = slices.dispatchCauseSlice({}, { PIPELINE: dir, nowMs: 2_000_000 });
+    assert.strictEqual(s.active, true);
+    assert.strictEqual(s.causa, dc.CAUSAS.MODO_OLA);
+    assert.strictEqual(s.label, 'Modo de ejecución en olas');
+    assert.strictEqual(s.anomalia, false);
+    const html = renderDispatchCauseBanner(s);
+    assert.match(html, /Modo de ejecución en olas/);
+    assert.doesNotMatch(html, /Detenido por humano/i);
+    assert.doesNotMatch(html, /pausa parcial/i);
+});
+
 test('slice marca anomalia y su label destacado', () => {
     const dir = tmpDir();
     dc.publish({ pipelineDir: dir, snapshot: { anyLaunched: false, hayPendientes: true, gatesActivos: new Set() }, now: 1 });

--- a/.pipeline/lib/__tests__/dispatch-cause.test.js
+++ b/.pipeline/lib/__tests__/dispatch-cause.test.js
@@ -53,6 +53,7 @@ const TABLA_GATES = [
     [CAUSAS.COOLDOWN, 'En cooldown'],
     [CAUSAS.BLOQUEO_DEPENDENCIA, 'Bloqueado por dependencia'],
     [CAUSAS.DEADLOCK, 'Deadlock detectado'],
+    [CAUSAS.MODO_OLA, 'Modo de ejecución en olas'],
     [CAUSAS.SIN_AGENTES, 'Sin agentes disponibles'],
 ];
 
@@ -67,8 +68,8 @@ for (const [causa, labelEsperado] of TABLA_GATES) {
     });
 }
 
-test('los 9 gates conocidos están cubiertos por la precedencia', () => {
-    assert.strictEqual(dc.PRECEDENCIA.length, 9);
+test('los 10 gates conocidos están cubiertos por la precedencia', () => {
+    assert.strictEqual(dc.PRECEDENCIA.length, 10);
     for (const [causa] of TABLA_GATES) {
         assert.ok(dc.PRECEDENCIA.includes(causa), `PRECEDENCIA debe incluir ${causa}`);
     }
@@ -187,16 +188,16 @@ test('publish alerta en transición de causa y preserva ts mientras la causa per
     const dir = tmpDir();
     const alerts = [];
     const alert = (m) => alerts.push(m);
-    // Tick 1: causa nueva → alerta.
-    dc.publish({ pipelineDir: dir, snapshot: snap({ gatesActivos: new Set([CAUSAS.COOLDOWN]) }), now: NOW, alert });
+    // Tick 1: causa nueva ALERTABLE → alerta.
+    dc.publish({ pipelineDir: dir, snapshot: snap({ gatesActivos: new Set([CAUSAS.PRESION_RECURSOS]) }), now: NOW, alert });
     assert.strictEqual(alerts.length, 1);
     // Tick 2: misma causa → sin nueva alerta, ts preservado, lastSeenTs avanza.
-    dc.publish({ pipelineDir: dir, snapshot: snap({ gatesActivos: new Set([CAUSAS.COOLDOWN]) }), now: NOW + 5000, alert });
+    dc.publish({ pipelineDir: dir, snapshot: snap({ gatesActivos: new Set([CAUSAS.PRESION_RECURSOS]) }), now: NOW + 5000, alert });
     assert.strictEqual(alerts.length, 1, 'no re-alerta una causa no-anómala persistente');
     const disk = JSON.parse(fs.readFileSync(dc.artifactPath(dir), 'utf8'));
     assert.strictEqual(disk.ts, NOW, 'ts de inicio preservado');
     assert.strictEqual(disk.lastSeenTs, NOW + 5000, 'lastSeenTs refleja el último tick');
-    // Tick 3: causa distinta → nueva alerta + ts nuevo.
+    // Tick 3: causa distinta (también alertable) → nueva alerta + ts nuevo.
     dc.publish({ pipelineDir: dir, snapshot: snap({ gatesActivos: new Set([CAUSAS.CB_INFRA]) }), now: NOW + 9000, alert });
     assert.strictEqual(alerts.length, 2);
     const disk2 = JSON.parse(fs.readFileSync(dc.artifactPath(dir), 'utf8'));
@@ -270,4 +271,83 @@ test('el módulo NO altera caracteres HTML del detalle (el escape es del render)
     // El string se guarda literal (el render lo escapará); acá sólo confirmamos
     // que el módulo no lo "sanea a medias" (que sería un falso sentido de seguridad).
     assert.ok(disk.detalle.includes('<img'), 'el módulo persiste el detalle literal; el escape es del render');
+});
+
+// =============================================================================
+// #4751 — Clasificación alertable vs. silenciosa. La notificación de "cola
+// ociosa" (Telegram) sólo debe emitirse por causas que ameriten intervención;
+// el banner (artifact en disco) se publica SIEMPRE.
+// =============================================================================
+
+// Publica una causa y devuelve cuántas alertas Telegram se emitieron + si quedó
+// el artifact (banner) en disco.
+function publishAndProbe(gate, detalle) {
+    const dir = tmpDir();
+    const alerts = [];
+    dc.publish({
+        pipelineDir: dir,
+        snapshot: snap({ gatesActivos: new Set([gate]), detalles: detalle ? { [gate]: detalle } : {} }),
+        now: NOW,
+        alert: (m) => alerts.push(m),
+    });
+    return { alerts, bannerPublicado: fs.existsSync(dc.artifactPath(dir)) };
+}
+
+test('CA-1/CA-4/CA-5: MODO_OLA publica banner pero NO alerta a Telegram (silenciosa)', () => {
+    const { alerts, bannerPublicado } = publishAndProbe(
+        CAUSAS.MODO_OLA, 'Modo de ejecución en olas — sólo se despachan los issues de la ola activa');
+    assert.strictEqual(alerts.length, 0, 'modo ola NO debe alertar (estado esperado)');
+    assert.strictEqual(bannerPublicado, true, 'el banner del dashboard SÍ se publica');
+});
+
+test('MODO_OLA no está en CAUSAS_ALERTABLES; su label no dice "Detenido"/"pausa parcial"', () => {
+    assert.strictEqual(dc.CAUSAS_ALERTABLES.has(CAUSAS.MODO_OLA), false);
+    const label = dc.LABELS[CAUSAS.MODO_OLA];
+    assert.strictEqual(label, 'Modo de ejecución en olas');
+    assert.doesNotMatch(label, /Detenido por humano/i);
+    assert.doesNotMatch(label, /pausa parcial/i);
+});
+
+test('CA-2: PRESION_RECURSOS (saturación) SÍ alerta indicando el motivo real', () => {
+    const { alerts } = publishAndProbe(CAUSAS.PRESION_RECURSOS, 'Sistema sobrecargado (presión de recursos RED)');
+    assert.strictEqual(alerts.length, 1);
+    assert.match(alerts[0], /Presión de recursos/);
+    assert.doesNotMatch(alerts[0], /Detenido por humano/i);
+});
+
+test('CA-3: DEADLOCK y HALT_HUMANO (deadlock humano) SÍ alertan', () => {
+    assert.strictEqual(publishAndProbe(CAUSAS.DEADLOCK).alerts.length, 1);
+    assert.strictEqual(publishAndProbe(CAUSAS.HALT_HUMANO).alerts.length, 1);
+    assert.strictEqual(publishAndProbe(CAUSAS.BLOQUEO_DEPENDENCIA).alerts.length, 1);
+    assert.strictEqual(publishAndProbe(CAUSAS.CB_INFRA).alerts.length, 1);
+});
+
+test('causas transitorias esperadas NO alertan (banner sí): VENTANA/REST/COOLDOWN/SIN_AGENTES', () => {
+    for (const gate of [CAUSAS.VENTANA_HORARIA, CAUSAS.REST_MODE, CAUSAS.COOLDOWN, CAUSAS.SIN_AGENTES]) {
+        const { alerts, bannerPublicado } = publishAndProbe(gate);
+        assert.strictEqual(alerts.length, 0, `${gate} no debe alertar`);
+        assert.strictEqual(bannerPublicado, true, `${gate} debe publicar banner`);
+    }
+});
+
+test('CA-7: coexistencia modo ola + saturación → gana PRESION_RECURSOS y alerta', () => {
+    const dir = tmpDir();
+    const alerts = [];
+    const out = dc.publish({
+        pipelineDir: dir,
+        snapshot: snap({ gatesActivos: new Set([CAUSAS.MODO_OLA, CAUSAS.PRESION_RECURSOS]) }),
+        now: NOW,
+        alert: (m) => alerts.push(m),
+    });
+    assert.strictEqual(out.causa, CAUSAS.PRESION_RECURSOS, 'la saturación gana a MODO_OLA en PRECEDENCIA');
+    assert.strictEqual(alerts.length, 1, 'y por ser alertable, emite la notificación');
+});
+
+test('CA-6: causa ausente/ilegible → anomalía SÍ alerta (fail-closed) aunque no esté en el set', () => {
+    // Cola con pendientes y ningún gate conocido → ANOMALIA. No está en
+    // CAUSAS_ALERTABLES, pero debe alertar igual por ser anomalía (R1).
+    assert.strictEqual(dc.CAUSAS_ALERTABLES.has(CAUSAS.ANOMALIA), false);
+    const { alerts } = publishAndProbe(/* sin gate → anomalía */);
+    assert.strictEqual(alerts.length, 1, 'la anomalía nunca se silencia');
+    assert.match(alerts[0], /ANOMAL/i);
 });

--- a/.pipeline/lib/dispatch-cause.js
+++ b/.pipeline/lib/dispatch-cause.js
@@ -51,6 +51,11 @@ const CAUSAS = Object.freeze({
     COOLDOWN: 'cooldown',
     BLOQUEO_DEPENDENCIA: 'bloqueo_dependencia',
     DEADLOCK: 'deadlock',
+    // #4751 — Modo de ejecución en olas (allowlist / ex "pausa parcial"). Es un
+    // estado ESPERADO inducido por el operador: sólo se despachan los issues de
+    // la ola activa. Se publica en el banner pero NO alerta a Telegram (causa
+    // silenciosa). Antes reusaba HALT_HUMANO, lo que generaba ruido recurrente.
+    MODO_OLA: 'modo_ola',
     SIN_AGENTES: 'sin_agentes',
     ANOMALIA: 'anomalia_no_determinable',
 });
@@ -69,6 +74,10 @@ const PRECEDENCIA = Object.freeze([
     CAUSAS.COOLDOWN,
     CAUSAS.BLOQUEO_DEPENDENCIA,
     CAUSAS.DEADLOCK,
+    // #4751 — MODO_OLA estrictamente POR DEBAJO de PRESION_RECURSOS/DEADLOCK (R4):
+    // si coexisten modo ola + saturación, gana la causa alertable y la alerta se
+    // emite. Un orden invertido escondería el problema real.
+    CAUSAS.MODO_OLA,
     CAUSAS.SIN_AGENTES,
 ]);
 
@@ -84,9 +93,26 @@ const LABELS = Object.freeze({
     [CAUSAS.COOLDOWN]: 'En cooldown',
     [CAUSAS.BLOQUEO_DEPENDENCIA]: 'Bloqueado por dependencia',
     [CAUSAS.DEADLOCK]: 'Deadlock detectado',
+    [CAUSAS.MODO_OLA]: 'Modo de ejecución en olas',
     [CAUSAS.SIN_AGENTES]: 'Sin agentes disponibles',
     [CAUSAS.ANOMALIA]: '⚠ Anomalía: causa no determinable',
 });
+
+// #4751 — Clasificación de causas ALERTABLES (envían Telegram). Las demás sólo
+// publican el banner del dashboard (silenciosas). El objetivo es que la
+// notificación de "cola ociosa" signifique SIEMPRE algo que amerita atención del
+// operador (saturación de recursos, deadlock, bloqueo real, infra caída) y no se
+// dispare por estados esperados como el modo de ejecución en olas (allowlist).
+// La ANOMALÍA (fail-closed, R1) se trata aparte y SIEMPRE alerta.
+// Silenciosas (sólo banner): MODO_OLA, VENTANA_HORARIA, REST_MODE, COOLDOWN,
+// SIN_AGENTES.
+const CAUSAS_ALERTABLES = Object.freeze(new Set([
+    CAUSAS.HALT_HUMANO,        // pausa/desync/needs-human real → requiere intervención
+    CAUSAS.CB_INFRA,           // circuit breaker de infra abierto
+    CAUSAS.PRESION_RECURSOS,   // saturación → "hace rato sin ejecución por recursos"
+    CAUSAS.BLOQUEO_DEPENDENCIA,
+    CAUSAS.DEADLOCK,
+]));
 
 // Conjunto de valores válidos del enum (para validación O(1)).
 const CAUSAS_VALIDAS = new Set(Object.values(CAUSAS));
@@ -312,7 +338,12 @@ function publish(opts) {
         return null;
     }
 
-    if (debeAlertar && alertFn) {
+    // #4751 — Sólo alertar a Telegram si la causa es ALERTABLE (o anomalía
+    // fail-closed). El banner/artifact se publica SIEMPRE (writeArtifact arriba);
+    // acá se filtra únicamente el envío al canal externo. Un estado esperado como
+    // MODO_OLA se ve en el dashboard pero no genera ruido de notificación.
+    const esAlertable = resolved.anomalia || CAUSAS_ALERTABLES.has(resolved.causa);
+    if (debeAlertar && esAlertable && alertFn) {
         try {
             const prefijo = resolved.anomalia ? '⚠ ANOMALÍA de despacho' : 'Cola ociosa';
             const detTxt = resolved.detalle ? ` — ${resolved.detalle}` : '';
@@ -329,6 +360,7 @@ module.exports = {
     CAUSAS,
     PRECEDENCIA,
     LABELS,
+    CAUSAS_ALERTABLES,
     CAUSAS_VALIDAS,
     ARTIFACT_FILENAME,
     ANOMALY_REALERT_COOLDOWN_MS,

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -6959,8 +6959,11 @@ function brazoLanzamientoImpl(config, _dcMark, _dcState) {
       const mode = partialPause.getPipelineMode();
       if (mode.mode === 'partial_pause') {
         log('lanzamiento', `#${issue} skipped by partial_pause (allowed: ${mode.allowedIssues.map(i => `#${i}`).join(', ')})`);
-        // #4709 — pausa parcial es un halt humano (allowlist explícita).
-        _dcMark(dispatchCause.CAUSAS.HALT_HUMANO, 'Pausa parcial activa — sólo issues de la allowlist se despachan');
+        // #4751 — el modo de ejecución en olas (allowlist) es un estado ESPERADO
+        // inducido por el operador, NO un halt humano anómalo. Se marca con la
+        // causa propia MODO_OLA (silenciosa: banner sí, Telegram no) para eliminar
+        // el ruido recurrente de "Cola ociosa: Detenido por humano — Pausa parcial".
+        _dcMark(dispatchCause.CAUSAS.MODO_OLA, 'Modo de ejecución en olas — sólo se despachan los issues de la ola activa');
       }
       continue;
     }


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 4 archivos · +143 -9

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:passed` aplicado por delivery

## Closes

Closes #4751
