### PR TITLE
Rediseñar banner de modo determinístico y rehacer la lógica de banderas de cuota

### DIFF
--- a/.pipeline/assets/mockups/4731/narrativa-quota-per-provider-banner.md
+++ b/.pipeline/assets/mockups/4731/narrativa-quota-per-provider-banner.md
@@ -1,0 +1,143 @@
+# UX — Rediseño del banner de cuota por proveedor (#4731)
+
+> Entregable de UX en fase **criterios**. Guidelines visuales + spec de
+> implementación + mockup (`quota-per-provider-banner.svg`) para que el dev
+> (pipeline-dev) ubique el diseño sin improvisar. Coherente con el sistema de
+> diseño existente (`.pipeline/assets/design-tokens.css`) — **no requiere
+> tokens nuevos**.
+
+## Problema de UX que resolvemos
+
+El banner actual (`views/dashboard/home.js:4327`) hardcodea
+`"Modo determinístico — cuota Anthropic agotada"` sin importar qué proveedor
+disparó el flag, y trata cualquier flag como **"todo el pipeline detenido"**.
+En el incidente 14–15/07 esto dejó ~30hs un banner amarillo mintiendo: Codex
+disparó el flag, Anthropic/Cerebras seguían sanos, pero el operador veía "modo
+determinístico global" e intervenía manualmente sin necesidad.
+
+**Objetivo de experiencia:** que de un vistazo el operador distinga
+"un proveedor flojo, el pipeline sigue" de "sin LLM, modo determinístico real".
+
+## Principio de diseño (la decisión visual clave)
+
+El **color comunica el scope**. Reasignamos el ámbar:
+
+| Scope | Cuándo | Paleta | Tono |
+|-------|--------|--------|------|
+| **Puntual** (`partial`) | ≥1 proveedor LLM operativo | `--provider-<id>-*` del afectado, fondo `--surface-1` | calmo, informativo |
+| **Global** (`global`) | 0 proveedores LLM operativos | `--quota-degraded-*` + glow | alarma controlada (ámbar) |
+
+El ámbar `--quota-degraded-*` deja de ser "genérico de cuota" y pasa a significar
+**exclusivamente "sin LLM disponible"**. Así el ámbar recupera su peso de alarma y
+no se "quema" por degradaciones puntuales que no lo son.
+
+## Anatomía del banner (los 3 estados del mockup)
+
+Ver `quota-per-provider-banner.svg`. Reutiliza la estructura DOM actual
+(icono · content · countdown) y **agrega**:
+
+1. **Borde izquierdo = color del proveedor afectado** (no siempre ámbar).
+   Con 2 afectados, borde bicolor (mitad/mitad).
+2. **Chips por proveedor afectado** (`.quota-provider-chip[data-provider]`):
+   dot + nombre en `--provider-<id>-fg` + motivo normalizado + reset. Uno por
+   proveedor → habilita el CA plural.
+3. **Health strip** (`.quota-health-strip`): `"N operativos:"` + dots
+   `--success` con nombres. Es la **evidencia visible de "no global"** (CA-2).
+4. **Countdown** teñido con el color del proveedor cuyo reset es más próximo.
+5. En **global**, se conservan los paneles Det/LLM del banner actual (siguen
+   siendo útiles cuando de verdad no hay LLM).
+
+Header conserva el pill **RUNNING** verde: refuerza que el pipeline no está caído.
+
+## Copy (reemplaza el string hardcodeado)
+
+- **Partial · 1 afectado:** `Proveedor {name} degradado — {motivo}` · sub `{N} proveedores operativos`.
+- **Partial · N afectados:** `{K} proveedores degradados — {N} operativos` (chip por proveedor).
+- **Global · 0 LLM:** `Modo determinístico — sin proveedores LLM disponibles` (único copy que conserva "modo determinístico").
+
+### Allowlist de motivos (`error_type` → label ES, CA-6 / A03)
+
+| `error_type` | label |
+|--------------|-------|
+| `usage_limit_reached` | límite de uso del plan |
+| `usage_limit_error` | cuota agotada |
+| `rate_limit` | rate limit temporal |
+| `schedule_rest` | reposo horario |
+| *(fuera de allowlist)* | degradado |
+
+`{name}` se resuelve por id contra un mapa fijo (`anthropic→Anthropic`,
+`openai-codex→Codex`, `cerebras→Cerebras`, `gemini→Gemini`, `groq→Groq`). Todo
+lo dinámico pasa por `escapeHtmlAttr`/`textContent` y el **color se elige por id
+allowlisteado**, nunca inyectando el valor crudo en `style`/`class`.
+
+## Regla de scope (para `dashboard-slices.js` + `getQuotaState`)
+
+```
+operationalProviders = proveedores LLM sanos (cruce con lib/provider-health)
+scope = operationalProviders >= 1 ? "partial" : "global"
+```
+
+El banner lee `data-scope` para elegir paleta. `active = OR de slots con
+resets_at futuro` (ya definido en la receta técnica del issue).
+
+## CSS — clases nuevas sobre el sistema existente
+
+Reutiliza las `--provider-*` ya presentes. Selección de color **por atributo**,
+sin inline styles:
+
+```css
+/* Contenedor: default = puntual (calmo). Global = override ámbar. */
+.quota-exhausted-banner { background: var(--surface-1); border: 1px solid var(--border);
+  border-left: 4px solid var(--border-strong); box-shadow: none; }
+.quota-exhausted-banner[data-scope="global"] { background: var(--quota-degraded-bg);
+  border-color: var(--quota-degraded); border-left-color: var(--quota-degraded);
+  box-shadow: var(--quota-degraded-glow); }
+
+/* Borde/acento por proveedor afectado (scope puntual, 1 afectado) */
+.quota-exhausted-banner[data-provider="openai-codex"] { border-left-color: var(--provider-openai-codex); }
+.quota-exhausted-banner[data-provider="anthropic"]   { border-left-color: var(--provider-anthropic); }
+.quota-exhausted-banner[data-provider="cerebras"]    { border-left-color: var(--provider-cerebras); }
+.quota-exhausted-banner[data-provider="gemini"]      { border-left-color: var(--provider-gemini); }
+.quota-exhausted-banner[data-provider="groq"]        { border-left-color: var(--provider-groq); }
+
+/* Chip por proveedor */
+.quota-provider-chip { display:inline-flex; align-items:center; gap:6px;
+  border-radius:14px; padding:4px 12px; font-size:12px; font-weight:700; }
+.quota-provider-chip[data-provider="openai-codex"] { color:var(--provider-openai-codex-fg);
+  background:var(--provider-openai-codex-bg); border:1px solid var(--provider-openai-codex); }
+/* ...idem por proveedor con sus tokens --provider-<id>-{fg,bg} */
+
+/* Health strip */
+.quota-health-strip { display:inline-flex; gap:12px; align-items:center;
+  font-size:11px; color:var(--text-secondary); }
+.quota-health-dot { width:8px; height:8px; border-radius:50%; background:var(--success); }
+```
+
+## Accesibilidad (verificado en el header del SVG)
+
+- `text-primary` 14.8:1 · `text-secondary` 9.7:1 · `success` 5.4:1 (AA)
+- `codex-fg/bg` 8.7:1 · `anthropic-fg/bg` 11.2:1 · `amber-fg` 13.5:1 (AAA)
+- Mantener `role="status"`, `aria-live="polite"`, icono `aria-hidden`.
+- El color **nunca** es el único canal: cada proveedor tiene nombre en texto
+  (daltonismo-safe) + dot; el scope se distingue por copy además de tono.
+
+## Contratos a preservar
+
+- **CA-14 (#3077):** el texto del banner aparece en el HTML servido **solo con
+  flag activo** (`data-active="true"`). El skeleton inactivo sigue sin nombres
+  de proveedor ni "modo determinístico" → `curl / | grep` vacío sin flag.
+- **IDs anti-flicker:** conservar `#quota-exhausted-banner/-title/-sub/-countdown`;
+  los chips nuevos usan ids/data derivados por proveedor.
+- **Backward-compat:** flag legacy sin `providers` → slot `anthropic`; el banner
+  lo pinta como partial/global según health, sin romper.
+
+## Validación esperada (CA-7)
+
+1. Render real: `curl -s localhost:<port>/ | grep` del copy dinámico con flag activo.
+2. Screenshot render-vs-mockup (este SVG) en QA visual.
+3. `dashboard-quota-exhausted.test.js` verde (SSR/cliente, sanitización, scope).
+
+## Assets entregados
+
+- `.pipeline/assets/mockups/4731/quota-per-provider-banner.svg` — mockup de los 3 estados + spec.
+- `.pipeline/assets/mockups/4731/narrativa-quota-per-provider-banner.md` — este documento.

--- a/.pipeline/assets/mockups/4731/quota-per-provider-banner.svg
+++ b/.pipeline/assets/mockups/4731/quota-per-provider-banner.svg
@@ -1,0 +1,295 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Mockup 4731 — Rediseño del banner de cuota: estado por-proveedor (#4731)
+  Resolucion: 1440x1240
+  Reemplaza el banner unico "Modo deterministico global" por un banner que
+  refleja el estado REAL por proveedor. Tres estados de scope:
+
+    A · DEGRADACION PUNTUAL  → >=1 proveedor LLM operativo. NO dice "global".
+                               Tono calmo (surface-1 + borde del color del
+                               proveedor afectado). Muestra "N operativos".
+    B · SIN LLM (global)     → 0 proveedores LLM operativos. Es el unico caso
+                               de "modo deterministico real". Tono ambar/alarma
+                               (--quota-degraded-*), reservado para este estado.
+    C · MULTI-PROVEEDOR      → >=2 proveedores agotados a la vez, aun con otros
+                               operativos. Chips plurales, uno por proveedor.
+
+  Decision de diseno (alineada con guru/security/Arquitecto):
+    El color del borde y del chip identifica al proveedor afectado usando los
+    tokens --provider-<id>-* YA existentes en design-tokens.css. El ambar
+    --quota-degraded-* deja de ser "generico de cuota" y pasa a significar
+    exclusivamente "sin LLM disponible" (estado B). Asi el operador distingue
+    de un vistazo "un proveedor flojo" de "todo el pipeline sin LLM".
+
+  Tokens (design-tokens.css, sin tokens nuevos):
+    surface-0 #0D1117 · surface-1 #161B22 · surface-2 #1C2128
+    border #30363D · border-subtle #21262D · text-primary #E6EDF3
+    text-secondary #B1BAC4 · success #3FB950
+    provider-anthropic   #E5946B / fg #F4C9B1
+    provider-openai-codex #10B981 / fg #6EE7B7
+    provider-cerebras    #FFD166 / fg #FFE6A8
+    provider-gemini      #8AB4F8 / fg #CBD9F9
+    provider-groq        #FF6B47 / fg #FFC1AE
+    quota-degraded       #F0A500 / fg #FFE5A8 (SOLO estado B)
+
+  WCAG AA/AAA verificado (sobre surface-0 #0D1117):
+    text-primary   #E6EDF3 = 14.8:1 (AAA)
+    text-secondary #B1BAC4 =  9.7:1 (AAA)
+    success        #3FB950 =  5.4:1 (AA)
+    provider-codex-fg #6EE7B7 sobre codex-bg = 8.7:1 (AAA)
+    provider-anthropic-fg #F4C9B1 sobre anthropic-bg = 11.2:1 (AAA)
+    quota-degraded-fg #FFE5A8 sobre surface-0 = 13.5:1 (AAA)
+-->
+<svg xmlns="http://www.w3.org/2000/svg" width="1440" height="1240" viewBox="0 0 1440 1240"
+     font-family="-apple-system, 'Segoe UI', system-ui, sans-serif">
+
+  <defs>
+    <linearGradient id="brandGrad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#00D6FF"/><stop offset="100%" stop-color="#1890FF"/>
+    </linearGradient>
+    <linearGradient id="amberFill" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#F0A500" stop-opacity="0.20"/>
+      <stop offset="100%" stop-color="#F0A500" stop-opacity="0.05"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Fondo -->
+  <rect width="1440" height="1240" fill="#0D1117"/>
+
+  <!-- =============== HEADER =============== -->
+  <rect x="0" y="0" width="1440" height="64" fill="#161B22"/>
+  <rect x="0" y="63" width="1440" height="1" fill="#30363D"/>
+  <g transform="translate(24, 14)">
+    <rect width="36" height="36" rx="9" fill="#0D274D"/>
+    <path d="M18 7 L5 30 L31 30 Z" fill="none" stroke="url(#brandGrad)" stroke-width="2.5" stroke-linejoin="round"/>
+    <path d="M18 16 L13 26 L23 26 Z" fill="url(#brandGrad)"/>
+  </g>
+  <text x="72" y="32" fill="#E6EDF3" font-size="17" font-weight="700">Intrale Pipeline</text>
+  <text x="72" y="50" fill="#8B949E" font-size="10" font-weight="600" letter-spacing="1.4">DASHBOARD V3 · BANNER DE CUOTA POR PROVEEDOR</text>
+  <!-- El pipeline NO esta caido: RUNNING aun con un proveedor degradado -->
+  <g transform="translate(360, 20)">
+    <rect width="104" height="26" rx="13" fill="#3FB950" fill-opacity="0.15" stroke="#3FB950" stroke-opacity="0.4"/>
+    <circle cx="15" cy="13" r="3.5" fill="#3FB950"/>
+    <text x="27" y="17" fill="#3FB950" font-size="11" font-weight="700" letter-spacing="1.2">RUNNING</text>
+  </g>
+
+  <!-- ============================================================= -->
+  <!-- ESTADO A — DEGRADACION PUNTUAL (>=1 proveedor operativo)       -->
+  <!-- ============================================================= -->
+  <text x="22" y="98" fill="#8B949E" font-size="11" font-weight="700" letter-spacing="1.4">ESTADO A · DEGRADACION PUNTUAL — 1 PROVEEDOR AFECTADO, EL RESTO OPERATIVO</text>
+
+  <!-- Banner A: contenedor calmo (surface-1), borde izq del color del proveedor -->
+  <g transform="translate(22, 110)">
+    <rect width="1396" height="118" rx="10" fill="#161B22" stroke="#30363D"/>
+    <rect width="4" height="118" rx="2" fill="#10B981"/>
+
+    <!-- Badge del proveedor afectado (Codex emerald) — estilo info, no alarma -->
+    <g transform="translate(24, 28)">
+      <rect width="40" height="40" rx="10" fill="#10B981" fill-opacity="0.14" stroke="#10B981" stroke-opacity="0.5"/>
+      <!-- reloj de espera (no bloqueo) -->
+      <g transform="translate(11, 10)" stroke="#6EE7B7" stroke-width="1.8" fill="none" stroke-linecap="round">
+        <circle cx="9" cy="10" r="8"/>
+        <path d="M9 5 L9 10 L13 12"/>
+      </g>
+    </g>
+
+    <!-- Contenido -->
+    <text x="84" y="36" fill="#E6EDF3" font-size="16" font-weight="700">Proveedor Codex degradado — limite de uso del plan</text>
+    <text x="84" y="57" fill="#B1BAC4" font-size="11.5" font-family="'Roboto Mono', ui-monospace, monospace">Tipo: usage_limit_reached · Detectado: 14:03 · Reset estimado: 14:45</text>
+
+    <!-- Chip del proveedor afectado -->
+    <g transform="translate(84, 70)">
+      <rect width="330" height="28" rx="14" fill="#10B981" fill-opacity="0.14" stroke="#10B981" stroke-opacity="0.55"/>
+      <circle cx="16" cy="14" r="4.5" fill="#10B981"/>
+      <text x="30" y="18" fill="#6EE7B7" font-size="12" font-weight="700">Codex</text>
+      <text x="74" y="18" fill="#B1BAC4" font-size="11">limite de uso · reset en 42m</text>
+    </g>
+
+    <!-- Health strip: proveedores operativos (evidencia de "no global") -->
+    <g transform="translate(430, 70)">
+      <text x="0" y="18" fill="#8B949E" font-size="11" font-weight="600">4 operativos:</text>
+      <g transform="translate(92, 0)">
+        <circle cx="6" cy="14" r="4" fill="#3FB950"/><text x="16" y="18" fill="#B1BAC4" font-size="11">Anthropic</text>
+        <circle cx="96" cy="14" r="4" fill="#3FB950"/><text x="106" y="18" fill="#B1BAC4" font-size="11">Cerebras</text>
+        <circle cx="184" cy="14" r="4" fill="#3FB950"/><text x="194" y="18" fill="#B1BAC4" font-size="11">Gemini</text>
+        <circle cx="262" cy="14" r="4" fill="#3FB950"/><text x="272" y="18" fill="#B1BAC4" font-size="11">Groq</text>
+      </g>
+    </g>
+
+    <!-- Countdown a la derecha (color del proveedor afectado) -->
+    <g transform="translate(1240, 26)">
+      <text x="132" y="12" fill="#8B949E" font-size="10" font-weight="700" letter-spacing="0.6" text-anchor="end">RESET CODEX</text>
+      <text x="132" y="42" fill="#6EE7B7" font-size="24" font-weight="700" text-anchor="end" font-family="'Roboto Mono', ui-monospace, monospace">42m</text>
+      <rect x="0" y="56" width="132" height="4" rx="2" fill="#000" fill-opacity="0.32"/>
+      <rect x="0" y="56" width="52" height="4" rx="2" fill="#10B981"/>
+    </g>
+  </g>
+
+  <!-- ============================================================= -->
+  <!-- ESTADO C — MULTIPLES PROVEEDORES AGOTADOS (aun con operativos)  -->
+  <!-- ============================================================= -->
+  <text x="22" y="278" fill="#8B949E" font-size="11" font-weight="700" letter-spacing="1.4">ESTADO C · MULTI-PROVEEDOR — 2 AFECTADOS, 3 OPERATIVOS (CHIPS PLURALES)</text>
+
+  <g transform="translate(22, 290)">
+    <rect width="1396" height="128" rx="10" fill="#161B22" stroke="#30363D"/>
+    <!-- borde izq bicolor: mitad anthropic, mitad codex -->
+    <rect width="4" height="59" rx="2" fill="#E5946B"/>
+    <rect y="59" width="4" height="59" rx="2" fill="#10B981"/>
+
+    <g transform="translate(24, 28)">
+      <rect width="40" height="40" rx="10" fill="#1C2128" stroke="#484F58" stroke-opacity="0.5"/>
+      <g transform="translate(11, 10)" stroke="#B1BAC4" stroke-width="1.8" fill="none" stroke-linecap="round">
+        <circle cx="9" cy="10" r="8"/><path d="M9 5 L9 10 L13 12"/>
+      </g>
+    </g>
+
+    <text x="84" y="36" fill="#E6EDF3" font-size="16" font-weight="700">2 proveedores degradados — el pipeline sigue operativo con 3</text>
+    <text x="84" y="57" fill="#B1BAC4" font-size="11.5" font-family="'Roboto Mono', ui-monospace, monospace">Skills LLM se redirigen a proveedores sanos · 0 skills bloqueados</text>
+
+    <!-- Chip Anthropic -->
+    <g transform="translate(84, 70)">
+      <rect width="322" height="28" rx="14" fill="#E5946B" fill-opacity="0.14" stroke="#E5946B" stroke-opacity="0.55"/>
+      <circle cx="16" cy="14" r="4.5" fill="#E5946B"/>
+      <text x="30" y="18" fill="#F4C9B1" font-size="12" font-weight="700">Anthropic</text>
+      <text x="98" y="18" fill="#B1BAC4" font-size="11">reposo horario · reset 07:00 (6h 12m)</text>
+    </g>
+    <!-- Chip Codex -->
+    <g transform="translate(84, 104)">
+      <rect width="322" height="28" rx="14" fill="#10B981" fill-opacity="0.14" stroke="#10B981" stroke-opacity="0.55"/>
+      <circle cx="16" cy="14" r="4.5" fill="#10B981"/>
+      <text x="30" y="18" fill="#6EE7B7" font-size="12" font-weight="700">Codex</text>
+      <text x="82" y="18" fill="#B1BAC4" font-size="11">limite de uso · reset 14:45 (42m)</text>
+    </g>
+
+    <!-- Health strip -->
+    <g transform="translate(430, 70)">
+      <text x="0" y="18" fill="#8B949E" font-size="11" font-weight="600">3 operativos:</text>
+      <g transform="translate(92, 0)">
+        <circle cx="6" cy="14" r="4" fill="#3FB950"/><text x="16" y="18" fill="#B1BAC4" font-size="11">Cerebras</text>
+        <circle cx="94" cy="14" r="4" fill="#3FB950"/><text x="104" y="18" fill="#B1BAC4" font-size="11">Gemini</text>
+        <circle cx="172" cy="14" r="4" fill="#3FB950"/><text x="182" y="18" fill="#B1BAC4" font-size="11">Groq</text>
+      </g>
+    </g>
+
+    <g transform="translate(1240, 26)">
+      <text x="132" y="12" fill="#8B949E" font-size="10" font-weight="700" letter-spacing="0.6" text-anchor="end">PROXIMO RESET</text>
+      <text x="132" y="42" fill="#6EE7B7" font-size="24" font-weight="700" text-anchor="end" font-family="'Roboto Mono', ui-monospace, monospace">42m</text>
+      <text x="132" y="60" fill="#8B949E" font-size="10" text-anchor="end">Codex · luego Anthropic</text>
+    </g>
+  </g>
+
+  <!-- ============================================================= -->
+  <!-- ESTADO B — SIN LLM (modo deterministico REAL, unico ambar)     -->
+  <!-- ============================================================= -->
+  <text x="22" y="478" fill="#8B949E" font-size="11" font-weight="700" letter-spacing="1.4">ESTADO B · SIN PROVEEDORES LLM — MODO DETERMINISTICO REAL (UNICO CASO AMBAR)</text>
+
+  <g transform="translate(22, 490)">
+    <rect width="1396" height="118" rx="10" fill="url(#amberFill)" stroke="#F0A500" stroke-opacity="0.55"/>
+    <rect width="4" height="118" rx="2" fill="#F0A500"/>
+
+    <!-- Reloj de arena ambar (alarma controlada) -->
+    <g transform="translate(24, 28)">
+      <rect width="40" height="40" rx="10" fill="#F0A500" fill-opacity="0.16" stroke="#F0A500" stroke-opacity="0.5"/>
+      <g transform="translate(13, 9)" stroke="#FFE5A8" stroke-width="1.8" fill="none" stroke-linejoin="round" stroke-linecap="round">
+        <path d="M1 1 L15 1 M1 21 L15 21 M2 1 C2 8 14 8 14 11 C14 14 2 14 2 21 M14 1 C14 8 2 8 2 11 C2 14 14 14 14 21"/>
+      </g>
+    </g>
+
+    <text x="84" y="36" fill="#FFE5A8" font-size="16" font-weight="700">Modo deterministico — sin proveedores LLM disponibles</text>
+    <text x="84" y="57" fill="#B57700" font-size="11.5" font-family="'Roboto Mono', ui-monospace, monospace">Los 5 proveedores agotados · skills LLM en cola · deterministas corriendo</text>
+
+    <!-- Paneles comparativos Det/LLM (se conservan del banner actual) -->
+    <g transform="translate(84, 70)">
+      <rect width="150" height="30" rx="6" fill="#000" fill-opacity="0.22" stroke="#30363D"/>
+      <text x="12" y="14" fill="#8B949E" font-size="9" font-weight="700" letter-spacing="0.5">DETERMINISTICOS</text>
+      <text x="12" y="26" fill="#3FB950" font-size="12" font-weight="700">3 corriendo</text>
+    </g>
+    <g transform="translate(246, 70)">
+      <rect width="150" height="30" rx="6" fill="#000" fill-opacity="0.22" stroke="#30363D"/>
+      <text x="12" y="14" fill="#8B949E" font-size="9" font-weight="700" letter-spacing="0.5">LLM ENCOLADOS</text>
+      <text x="12" y="26" fill="#FFE5A8" font-size="12" font-weight="700">7 esperando</text>
+    </g>
+
+    <g transform="translate(1240, 26)">
+      <text x="132" y="12" fill="#B57700" font-size="10" font-weight="700" letter-spacing="0.6" text-anchor="end">PROXIMO RESET LLM</text>
+      <text x="132" y="42" fill="#FFE5A8" font-size="24" font-weight="700" text-anchor="end" font-family="'Roboto Mono', ui-monospace, monospace">42m</text>
+      <rect x="0" y="56" width="132" height="4" rx="2" fill="#000" fill-opacity="0.32"/>
+      <rect x="0" y="56" width="94" height="4" rx="2" fill="#F0A500"/>
+    </g>
+  </g>
+
+  <!-- ============================================================= -->
+  <!-- ESTADO 0 — SIN FLAG (banner oculto, referencia)                -->
+  <!-- ============================================================= -->
+  <text x="22" y="658" fill="#8B949E" font-size="11" font-weight="700" letter-spacing="1.4">ESTADO 0 · SIN FLAG ACTIVO — BANNER OCULTO (data-active="false", CA-14)</text>
+  <g transform="translate(22, 670)">
+    <rect width="1396" height="44" rx="10" fill="#0D1117" stroke="#21262D" stroke-dasharray="4 4"/>
+    <text x="698" y="27" fill="#484F58" font-size="12" text-anchor="middle" font-style="italic">display:none — el HTML servido NO contiene el nombre de ningun proveedor ni "modo deterministico" (grep vacio)</text>
+  </g>
+
+  <!-- ============================================================= -->
+  <!-- PANEL DE ESPECIFICACION                                        -->
+  <!-- ============================================================= -->
+  <g transform="translate(22, 742)">
+    <rect width="686" height="470" rx="10" fill="#161B22" stroke="#30363D"/>
+    <text x="22" y="34" fill="#E6EDF3" font-size="14" font-weight="700">Especificacion de tokens y estados</text>
+    <rect x="22" y="46" width="642" height="1" fill="#21262D"/>
+
+    <text x="22" y="76" fill="#8B949E" font-size="11" font-weight="700" letter-spacing="1">SCOPE → PALETA</text>
+    <!-- fila partial -->
+    <rect x="22" y="88" width="14" height="14" rx="3" fill="#10B981"/>
+    <text x="46" y="100" fill="#B1BAC4" font-size="12">Puntual: borde/chip = --provider-&lt;id&gt;-* · fondo surface-1 (calmo)</text>
+    <!-- fila global -->
+    <rect x="22" y="112" width="14" height="14" rx="3" fill="#F0A500"/>
+    <text x="46" y="124" fill="#B1BAC4" font-size="12">Global (0 LLM): --quota-degraded-* + glow ambar (unico caso)</text>
+    <!-- fila operativos -->
+    <circle cx="29" cy="149" r="6" fill="#3FB950"/>
+    <text x="46" y="153" fill="#B1BAC4" font-size="12">Operativos: dot --success · nombre --text-secondary</text>
+
+    <text x="22" y="188" fill="#8B949E" font-size="11" font-weight="700" letter-spacing="1">REGLA DE SCOPE (getQuotaState + provider-health)</text>
+    <text x="22" y="210" fill="#B1BAC4" font-size="12" font-family="'Roboto Mono', ui-monospace, monospace">operationalProviders &gt;= 1  →  scope = "partial"</text>
+    <text x="22" y="228" fill="#B1BAC4" font-size="12" font-family="'Roboto Mono', ui-monospace, monospace">operationalProviders == 0  →  scope = "global"</text>
+
+    <text x="22" y="266" fill="#8B949E" font-size="11" font-weight="700" letter-spacing="1">A11Y (WCAG, sobre surface-0)</text>
+    <text x="22" y="288" fill="#B1BAC4" font-size="12">text-primary 14.8:1 · text-secondary 9.7:1 · success 5.4:1</text>
+    <text x="22" y="306" fill="#B1BAC4" font-size="12">codex-fg/bg 8.7:1 · anthropic-fg/bg 11.2:1 · amber-fg 13.5:1</text>
+    <text x="22" y="324" fill="#B1BAC4" font-size="12">role="status" aria-live="polite" · icono aria-hidden</text>
+
+    <text x="22" y="362" fill="#8B949E" font-size="11" font-weight="700" letter-spacing="1">SANITIZACION (CA-6 / A03)</text>
+    <text x="22" y="384" fill="#B1BAC4" font-size="12">provider/error_type/motivo → allowlist + escapeHtmlAttr/textContent</text>
+    <text x="22" y="402" fill="#B1BAC4" font-size="12">sin raw excerpts ni tokens · color por id allowlisteado</text>
+
+    <text x="22" y="440" fill="#8B949E" font-size="11" font-weight="700" letter-spacing="1">CONTRATO CA-14</text>
+    <text x="22" y="462" fill="#B1BAC4" font-size="12">texto del banner presente en HTML SOLO con flag activo (data-active)</text>
+  </g>
+
+  <!-- COPY dinamico -->
+  <g transform="translate(732, 742)">
+    <rect width="686" height="470" rx="10" fill="#161B22" stroke="#30363D"/>
+    <text x="22" y="34" fill="#E6EDF3" font-size="14" font-weight="700">Copy dinamico del titulo (reemplaza el hardcode)</text>
+    <rect x="22" y="46" width="642" height="1" fill="#21262D"/>
+
+    <text x="22" y="76" fill="#8B949E" font-size="11" font-weight="700" letter-spacing="1">PARTIAL · 1 AFECTADO</text>
+    <text x="22" y="98" fill="#6EE7B7" font-size="12" font-family="'Roboto Mono', ui-monospace, monospace">"Proveedor {name} degradado — {motivo}"</text>
+    <text x="22" y="116" fill="#8B949E" font-size="11">sub: "{N} proveedores operativos"</text>
+
+    <text x="22" y="150" fill="#8B949E" font-size="11" font-weight="700" letter-spacing="1">PARTIAL · N AFECTADOS</text>
+    <text x="22" y="172" fill="#F4C9B1" font-size="12" font-family="'Roboto Mono', ui-monospace, monospace">"{K} proveedores degradados — {N} operativos"</text>
+    <text x="22" y="190" fill="#8B949E" font-size="11">un chip por proveedor afectado (color propio)</text>
+
+    <text x="22" y="224" fill="#8B949E" font-size="11" font-weight="700" letter-spacing="1">GLOBAL · 0 LLM</text>
+    <text x="22" y="246" fill="#FFE5A8" font-size="12" font-family="'Roboto Mono', ui-monospace, monospace">"Modo deterministico — sin proveedores LLM"</text>
+    <text x="22" y="264" fill="#8B949E" font-size="11">unico caso que conserva el copy "modo deterministico"</text>
+
+    <text x="22" y="298" fill="#8B949E" font-size="11" font-weight="700" letter-spacing="1">MOTIVOS ALLOWLISTEADOS (error_type → label)</text>
+    <text x="22" y="320" fill="#B1BAC4" font-size="12" font-family="'Roboto Mono', ui-monospace, monospace">usage_limit_reached → "limite de uso del plan"</text>
+    <text x="22" y="338" fill="#B1BAC4" font-size="12" font-family="'Roboto Mono', ui-monospace, monospace">usage_limit_error   → "cuota agotada"</text>
+    <text x="22" y="356" fill="#B1BAC4" font-size="12" font-family="'Roboto Mono', ui-monospace, monospace">rate_limit          → "rate limit temporal"</text>
+    <text x="22" y="374" fill="#B1BAC4" font-size="12" font-family="'Roboto Mono', ui-monospace, monospace">schedule_rest       → "reposo horario"</text>
+    <text x="22" y="392" fill="#B1BAC4" font-size="12" font-family="'Roboto Mono', ui-monospace, monospace">(fuera de allowlist) → "degradado"</text>
+
+    <text x="22" y="430" fill="#8B949E" font-size="11" font-weight="700" letter-spacing="1">IDs A PRESERVAR (anti-flicker)</text>
+    <text x="22" y="452" fill="#B1BAC4" font-size="11.5" font-family="'Roboto Mono', ui-monospace, monospace">#quota-exhausted-banner/-title/-sub/-countdown (+ nuevos por chip)</text>
+  </g>
+
+</svg>

--- a/.pipeline/config.yaml
+++ b/.pipeline/config.yaml
@@ -538,6 +538,21 @@ quota_detector:
   # Anthropic. OpenAI suele usar cuotas mensuales (31 días) — declarado en
   # agent-models.json:providers.openai-codex.resets_at_cap_max_days.
   resets_at_cap_max_days: 7
+  # #4731 — TTL (cap de `resets_at`) CONFIGURABLE POR PROVEEDOR, en días. Evita
+  # el flag huérfano de larga vida del incidente 14–15/07 (Codex disparó y el
+  # fallback semanal lo dejaba prendido ~30hs). Cada valor se clampa en código a
+  # [MIN_TTL_DAYS=1h, MAX_TTL_DAYS=31d] (security A05): un valor inválido o fuera
+  # de rango cae al default conservador (`resets_at_cap_max_days`) y se acota —
+  # nunca deja flags eternos ni expira sin evidencia. Un proveedor ausente acá
+  # usa `resets_at_cap_max_days`. El cap real por evento sigue acotado por
+  # `capResetsAt`; para Codex `usage_limit_reached` (cap rolling) manda la
+  # ventana corta de 1h de `CODEX_USAGE_LIMIT_RESET_MS` cuando no hay `resets_at`.
+  ttl_by_provider:
+    anthropic: 7          # ciclo semanal Plan Max
+    openai-codex: 1       # cap rolling del plan (usage_limit_reached ~horas); techo 1d
+    cerebras: 1           # free tier — recuperación rápida
+    gemini-google: 1      # free tier — recuperación rápida
+    nvidia-nim: 1         # free tier — recuperación rápida
   # Si `false`, el detector funciona pero no escribe `.pipeline/logs/quota-detector-*.log`.
   # Útil para apagar audit en caso de problema de espacio en disco — no debería
   # ser necesario nunca con la rotación normal.

--- a/.pipeline/lib/__tests__/dashboard-quota-exhausted.test.js
+++ b/.pipeline/lib/__tests__/dashboard-quota-exhausted.test.js
@@ -156,27 +156,100 @@ test('CA-5: orden desc por count en queuedSkills', () => {
 // según estado del flag (SSR para que `curl | grep` sea determinístico).
 // -----------------------------------------------------------------------------
 
-test('CA-14: HTML SIN flag NO contiene "cuota Anthropic" (curl|grep no debe matchear)', () => {
+test('CA-14 #4731: HTML SIN flag NO revela proveedor ni copy del banner (curl|grep no debe matchear)', () => {
     clearFlag();
     const html = home.renderHomeHTML({ quotaState: { active: false } });
-    assert.ok(!html.includes('cuota Anthropic'),
-        'sin flag activo, el HTML no debe traer el texto del banner');
+    // El copy dinámico del banner (por-proveedor o global) NO debe aparecer en
+    // el HTML servido inactivo: los nombres de proveedor y "Modo determinístico"
+    // sólo salen con flag activo (data-active="true").
+    assert.ok(!html.includes('Modo determinístico'),
+        'sin flag activo, el HTML no debe traer el copy global del banner');
+    assert.ok(!html.includes('Proveedor Anthropic'),
+        'sin flag activo, el HTML no debe revelar el proveedor afectado');
+    assert.ok(!html.includes('Proveedor Codex'),
+        'sin flag activo, el HTML no debe revelar el proveedor afectado');
+    assert.ok(html.includes('data-active="false"'), 'el skeleton debe quedar inactivo');
 });
 
-test('CA-14: HTML CON flag activo SÍ contiene "cuota Anthropic" en el title del banner', () => {
+test('CA-2/CA-3 #4731: banner PARTIAL nombra al proveedor afectado y su motivo (no "global")', () => {
+    // Codex agotado, Anthropic/Cerebras operativos → degradación PUNTUAL.
     const html = home.renderHomeHTML({
         quotaState: {
             active: true,
-            error_type: 'usage_limit_error',
-            detected_at: '2026-05-05T01:00:00.000Z',
-            resets_at: '2026-05-05T05:00:00.000Z',
-            resets_at_ms: Date.parse('2026-05-05T05:00:00.000Z'),
+            scope: 'partial',
+            operational: ['anthropic', 'cerebras'],
+            operationalCount: 2,
+            providers: [{
+                id: 'openai-codex',
+                error_type: 'usage_limit_reached',
+                resets_at: '2026-07-16T22:00:00.000Z',
+                resets_at_ms: Date.parse('2026-07-16T22:00:00.000Z'),
+                detected_at: '2026-07-15T10:00:00.000Z',
+            }],
+            error_type: 'usage_limit_reached',
+            detected_at: '2026-07-15T10:00:00.000Z',
+            resets_at: '2026-07-16T22:00:00.000Z',
+            resets_at_ms: Date.parse('2026-07-16T22:00:00.000Z'),
         },
     });
-    assert.ok(html.includes('cuota Anthropic'),
-        'con flag activo, el banner SSR debe incluir el texto literal');
-    assert.ok(html.includes('Modo determinístico'),
-        'el title debe seguir el formato exacto definido por CA-1');
+    assert.ok(html.includes('Proveedor Codex degradado'),
+        'el banner debe nombrar al proveedor real (Codex), no un genérico');
+    assert.ok(html.includes('límite de uso del plan'),
+        'el banner debe mostrar el motivo normalizado del error_type');
+    assert.ok(html.includes('data-scope="partial"'), 'scope puntual');
+    assert.ok(html.includes('data-provider="openai-codex"'), 'acento por proveedor afectado');
+    assert.ok(html.includes('2 operativos:'), 'health strip: evidencia de "no global" (CA-2)');
+    assert.ok(!html.includes('Modo determinístico'),
+        'un flag de un proveedor NO debe mostrar "modo determinístico global"');
+});
+
+test('CA-2 #4731: banner GLOBAL sólo cuando 0 proveedores LLM operativos', () => {
+    const html = home.renderHomeHTML({
+        quotaState: {
+            active: true,
+            scope: 'global',
+            operational: [],
+            operationalCount: 0,
+            providers: [{
+                id: 'anthropic',
+                error_type: 'usage_limit_error',
+                resets_at: '2026-07-16T22:00:00.000Z',
+                resets_at_ms: Date.parse('2026-07-16T22:00:00.000Z'),
+                detected_at: '2026-07-15T10:00:00.000Z',
+            }],
+            error_type: 'usage_limit_error',
+            detected_at: '2026-07-15T10:00:00.000Z',
+            resets_at: '2026-07-16T22:00:00.000Z',
+            resets_at_ms: Date.parse('2026-07-16T22:00:00.000Z'),
+        },
+    });
+    assert.ok(html.includes('Modo determinístico — sin proveedores LLM disponibles'),
+        'sin ningún LLM operativo, el banner sí es global');
+    assert.ok(html.includes('data-scope="global"'), 'scope global');
+});
+
+test('CA-3 #4731: banner MULTI muestra un chip por proveedor afectado', () => {
+    const html = home.renderHomeHTML({
+        quotaState: {
+            active: true,
+            scope: 'partial',
+            operational: ['anthropic'],
+            operationalCount: 1,
+            providers: [
+                { id: 'openai-codex', error_type: 'usage_limit_reached', resets_at: '2026-07-16T22:00:00.000Z', resets_at_ms: 1, detected_at: 'x' },
+                { id: 'cerebras', error_type: 'rate_limit_exceeded', resets_at: '2026-07-16T23:00:00.000Z', resets_at_ms: 2, detected_at: 'x' },
+            ],
+            error_type: 'usage_limit_reached',
+            detected_at: 'x',
+            resets_at: '2026-07-16T22:00:00.000Z',
+            resets_at_ms: 1,
+        },
+    });
+    assert.ok(html.includes('2 proveedores degradados — 1 operativos'),
+        'título plural con conteo de afectados y operativos');
+    // Un chip por proveedor afectado (data-provider por cada uno).
+    assert.ok(html.includes('data-provider="openai-codex"'));
+    assert.ok(html.includes('data-provider="cerebras"'));
 });
 
 test('CA-12: HTML siempre expone el banner con id quota-exhausted-banner', () => {
@@ -294,6 +367,90 @@ test('Defensa: slice tolera state.issueMatrix con entries malformados', () => {
     } finally {
         clearFlag();
     }
+});
+
+// -----------------------------------------------------------------------------
+// #4731 — slice expone scope/providers/operational cruzando provider-health
+// -----------------------------------------------------------------------------
+
+test('#4731: slice con flag por-proveedor expone scope=partial + providers + operational', () => {
+    // Flag nuevo shape: sólo openai-codex agotado.
+    writeFlag({
+        providers: {
+            'openai-codex': {
+                exhausted: true,
+                resets_at: new Date(Date.now() + 3600000).toISOString(),
+                detected_at: new Date(Date.now() - 60000).toISOString(),
+                pattern_matched: 'usage_limit_reached',
+            },
+        },
+    });
+    try {
+        const out = slices.quotaExhaustedSlice(fakeState({ pendiente: [{ skill: 'guru' }] }));
+        assert.equal(out.active, true);
+        // Codex agotado, el resto del catálogo LLM operativo → puntual.
+        assert.equal(out.scope, 'partial');
+        assert.equal(out.providers.length, 1);
+        assert.equal(out.providers[0].id, 'openai-codex');
+        assert.equal(out.providers[0].error_type, 'usage_limit_reached');
+        // operational NO incluye al proveedor agotado y sí a los demás.
+        assert.ok(!out.operational.includes('openai-codex'));
+        assert.ok(out.operationalCount >= 1);
+    } finally {
+        clearFlag();
+    }
+});
+
+test('#4731: dos proveedores agotados coexisten en el slice (CA-3)', () => {
+    writeFlag({
+        providers: {
+            'openai-codex': { exhausted: true, resets_at: new Date(Date.now() + 3600000).toISOString(), detected_at: new Date().toISOString(), pattern_matched: 'usage_limit_reached' },
+            'cerebras': { exhausted: true, resets_at: new Date(Date.now() + 7200000).toISOString(), detected_at: new Date().toISOString(), pattern_matched: 'rate_limit_exceeded' },
+        },
+    });
+    try {
+        const out = slices.quotaExhaustedSlice(fakeState({}));
+        assert.equal(out.active, true);
+        const ids = out.providers.map(p => p.id).sort();
+        assert.deepEqual(ids, ['cerebras', 'openai-codex']);
+        // Reset más próximo primero (codex +1h antes que cerebras +2h).
+        assert.equal(out.providers[0].id, 'openai-codex');
+    } finally {
+        clearFlag();
+    }
+});
+
+// -----------------------------------------------------------------------------
+// #4731 — sanitización de provider/error_type dinámicos (CA-6 / A03)
+// -----------------------------------------------------------------------------
+
+test('#4731: provider id fuera de allowlist NO inyecta HTML/JS (data-provider=unknown)', () => {
+    const html = home.renderHomeHTML({
+        quotaState: {
+            active: true,
+            scope: 'partial',
+            operational: ['anthropic'],
+            operationalCount: 1,
+            providers: [{
+                id: '"><img src=x onerror=alert(1)>',
+                error_type: '<script>alert(1)</script>',
+                resets_at: '2026-07-16T22:00:00.000Z',
+                resets_at_ms: 1,
+                detected_at: 'x',
+            }],
+            error_type: '<script>alert(1)</script>',
+            detected_at: 'x',
+            resets_at: '2026-07-16T22:00:00.000Z',
+            resets_at_ms: 1,
+        },
+    });
+    // El id crudo NO se inyecta en data-provider (cae a 'unknown' por allowlist).
+    assert.ok(!html.includes('onerror=alert(1)>'), 'el id malicioso no debe inyectar HTML');
+    assert.ok(html.includes('data-provider="unknown"'), 'id no allowlisteado → unknown');
+    // El error_type fuera del allowlist se muestra como label genérico, no crudo.
+    assert.ok(html.includes('degradado'), 'error_type desconocido → label neutro');
+    // Y el payload XSS del sub queda escapado (defensa en profundidad).
+    assert.ok(!html.match(/<script>alert\(1\)<\/script>/), 'sin <script> ejecutable');
 });
 
 // Cleanup global del dir temporal después de todos los tests del file.

--- a/.pipeline/lib/__tests__/quota-exhausted-state.test.js
+++ b/.pipeline/lib/__tests__/quota-exhausted-state.test.js
@@ -257,3 +257,67 @@ test('No tira con __proto__/constructor en el JSON (parse seguro)', () => {
     assert.equal(s.polluted, undefined);
     assert.equal(({}).polluted, undefined, 'sanity: prototype global limpio');
 });
+
+// -----------------------------------------------------------------------------
+// #4731 — getQuotaState expone providers[] por-slot; active = OR de slots futuros
+// -----------------------------------------------------------------------------
+
+test('#4731: nuevo shape por-proveedor expone providers[] con id + error_type', () => {
+    const file = newTmpStatePath();
+    const future1 = new Date(Date.now() + 3600000).toISOString();
+    const future2 = new Date(Date.now() + 7200000).toISOString();
+    writeJson(file, {
+        providers: {
+            'openai-codex': { exhausted: true, resets_at: future1, detected_at: new Date().toISOString(), pattern_matched: 'usage_limit_reached' },
+            'anthropic': { exhausted: true, resets_at: future2, detected_at: new Date().toISOString(), pattern_matched: 'usage_limit_error' },
+        },
+    });
+    const s = getQuotaState({ statePath: file });
+    assert.equal(s.active, true);
+    assert.equal(s.providers.length, 2);
+    // Ordenados por reset ascendente → codex (+1h) primero.
+    assert.equal(s.providers[0].id, 'openai-codex');
+    assert.equal(s.providers[0].error_type, 'usage_limit_reached');
+    assert.equal(s.providers[1].id, 'anthropic');
+    // Espejo primario = slot de reset más próximo.
+    assert.equal(s.error_type, 'usage_limit_reached');
+    assert.equal(s.resets_at, future1);
+});
+
+test('#4731: active = OR de slots futuros (slot vencido se filtra, activo queda)', () => {
+    const file = newTmpStatePath();
+    const past = new Date(Date.now() - 60000).toISOString();
+    const future = new Date(Date.now() + 3600000).toISOString();
+    writeJson(file, {
+        providers: {
+            'openai-codex': { exhausted: true, resets_at: past, detected_at: new Date().toISOString(), pattern_matched: 'usage_limit_reached' },
+            'anthropic': { exhausted: true, resets_at: future, detected_at: new Date().toISOString(), pattern_matched: 'usage_limit_error' },
+        },
+    });
+    const s = getQuotaState({ statePath: file });
+    assert.equal(s.active, true, 'al menos un slot futuro → activo');
+    assert.deepEqual(s.providers.map(p => p.id), ['anthropic'], 'slot vencido no aparece');
+    // Read-only: el módulo de estado NO borra el archivo (lo hace el detector).
+    assert.ok(fs.existsSync(file));
+});
+
+test('#4731: todos los slots vencidos → active:false', () => {
+    const file = newTmpStatePath();
+    const past = new Date(Date.now() - 60000).toISOString();
+    writeJson(file, {
+        providers: { anthropic: { exhausted: true, resets_at: past, detected_at: past, pattern_matched: 'usage_limit_error' } },
+    });
+    const s = getQuotaState({ statePath: file });
+    assert.equal(s.active, false);
+    assert.deepEqual(s.providers, []);
+});
+
+test('#4731: backward-compat legacy sin provider → slot anthropic en providers[]', () => {
+    const file = newTmpStatePath();
+    writeJson(file, validFlagPayload());
+    const s = getQuotaState({ statePath: file });
+    assert.equal(s.active, true);
+    assert.equal(s.providers.length, 1);
+    assert.equal(s.providers[0].id, 'anthropic');
+    assert.equal(s.providers[0].error_type, 'usage_limit_error');
+});

--- a/.pipeline/lib/__tests__/quota-exhausted.test.js
+++ b/.pipeline/lib/__tests__/quota-exhausted.test.js
@@ -824,17 +824,27 @@ test('CA-8 #3077 · clearFlag sin provider (legacy) sigue limpiando (backward-co
     assert.equal(q.clearFlag({ event: 'success_spawn' }), true);
 });
 
-test('CA-8 #3077 · clearFlag con provider mismatch deja audit log explícito', () => {
+test('#4731 · clearFlag de un provider sin slot activo es no-op silencioso (sin mismatch)', () => {
+    // #4731 — Con estado por-proveedor el guard `clear_skipped_provider_mismatch`
+    // desaparece por diseño: `clearFlag({provider:'openai-codex'})` opera SÓLO
+    // sobre el slot de codex (inexistente) → no-op, sin evento de mismatch, y
+    // el slot de anthropic queda intacto (el vector de #3077 queda cerrado por
+    // construcción, no por guard).
     const tmp = newTmpDir();
     const q = freshModule(tmp);
     const now = Date.parse('2026-05-05T00:00:00Z');
     const resetsAt = new Date(now + 24 * 60 * 60 * 1000).toISOString();
     q.setFlag({ errorType: 'usage_limit_error', provider: 'anthropic', resetsAt, now });
-    q.clearFlag({ provider: 'openai-codex', event: 'success_spawn' });
+    assert.equal(q.clearFlag({ provider: 'openai-codex', event: 'success_spawn' }), false,
+        'clearFlag de un provider sin slot no debe drenar nada');
+    // El slot de anthropic sigue activo: un provider sano NO borra el ajeno.
+    assert.equal(q.isQuotaExhausted({ now }), true);
+    assert.equal(q.shouldGateSpawn('po', { provider: 'anthropic', now }), true);
+    // No debe emitirse el evento legacy de mismatch (ya no existe).
     const audits = readAuditLines(tmp);
-    assert.ok(
-        audits.some(a => a.event === 'clear_skipped_provider_mismatch'),
-        'debe haber entry clear_skipped_provider_mismatch en audit log'
+    assert.equal(
+        audits.some(a => a.event === 'clear_skipped_provider_mismatch'), false,
+        'el guard clear_skipped_provider_mismatch fue eliminado por el modelo por-proveedor'
     );
 });
 
@@ -1272,4 +1282,107 @@ test('#4353 CA-3 · el drenado es scoped: un éxito de X NO revalida el flag de 
         delete process.env.PIPELINE_DIR_OVERRIDE;
         fs.rmSync(tmpDir, { recursive: true, force: true });
     }
+});
+
+// =============================================================================
+// #4731 — Estado por-proveedor (mapa `providers`): coexistencia, drenado por
+// slot independiente, backward-compat legacy y auditoría por proveedor.
+// =============================================================================
+
+test('#4731 · dos proveedores agotados COEXISTEN sin pisarse (CA-3)', () => {
+    const tmp = newTmpDir();
+    const q = freshModule(tmp);
+    const now = Date.parse('2026-07-15T00:00:00Z');
+    q.setFlag({ errorType: 'usage_limit_error', provider: 'anthropic', resetsAt: new Date(now + 2 * 3600000).toISOString(), now });
+    q.setFlag({ errorType: 'usage_limit_reached', provider: 'openai-codex', resetsAt: new Date(now + 1 * 3600000).toISOString(), now, maxDays: 31 });
+    const persisted = readFlag(tmp);
+    assert.ok(persisted.providers, 'debe persistir el mapa por-proveedor');
+    assert.deepEqual(Object.keys(persisted.providers).sort(), ['anthropic', 'openai-codex']);
+    // Ambos gatean su propio provider; ninguno gatea al otro fuera de scope.
+    assert.equal(q.shouldGateSpawn('po', { provider: 'anthropic', now }), true);
+    assert.equal(q.shouldGateSpawn('po', { provider: 'openai-codex', now }), true);
+    assert.equal(q.shouldGateSpawn('po', { provider: 'cerebras', now }), false);
+    // El espejo top-level apunta al reset más próximo (codex, +1h).
+    assert.equal(persisted.provider, 'openai-codex');
+});
+
+test('#4731 · un provider sano NO borra el slot activo de otro (clearFlag scoped)', () => {
+    const tmp = newTmpDir();
+    const q = freshModule(tmp);
+    const now = Date.parse('2026-07-15T00:00:00Z');
+    q.setFlag({ errorType: 'usage_limit_error', provider: 'anthropic', resetsAt: new Date(now + 3600000).toISOString(), now });
+    q.setFlag({ errorType: 'usage_limit_reached', provider: 'openai-codex', resetsAt: new Date(now + 3600000).toISOString(), now, maxDays: 31 });
+    // Codex se recupera y drena SU slot.
+    assert.equal(q.clearFlag({ provider: 'openai-codex', now }), true);
+    // El slot de anthropic sigue intacto (el vector #3077 queda cerrado).
+    const r = q.readDefensive({ now });
+    assert.equal(r.exhausted, true);
+    assert.deepEqual(r.providers.map(p => p.provider), ['anthropic']);
+    assert.equal(q.shouldGateSpawn('po', { provider: 'anthropic', now }), true);
+    assert.equal(q.shouldGateSpawn('po', { provider: 'openai-codex', now }), false);
+});
+
+test('#4731 · cada slot expira INDEPENDIENTE por su resets_at (drenado por-slot)', () => {
+    const tmp = newTmpDir();
+    const q = freshModule(tmp);
+    const now = Date.parse('2026-07-15T00:00:00Z');
+    q.setFlag({ errorType: 'usage_limit_reached', provider: 'openai-codex', resetsAt: new Date(now + 1 * 3600000).toISOString(), now, maxDays: 31 });
+    q.setFlag({ errorType: 'usage_limit_error', provider: 'anthropic', resetsAt: new Date(now + 5 * 3600000).toISOString(), now });
+    // A las +2h: codex ya venció, anthropic sigue.
+    const mid = now + 2 * 3600000;
+    const r = q.readDefensive({ now: mid });
+    assert.equal(r.exhausted, true);
+    assert.deepEqual(r.providers.map(p => p.provider), ['anthropic'], 'sólo anthropic sigue activo');
+    // El archivo se reescribió sin el slot de codex (drenado parcial).
+    const persisted = readFlag(tmp);
+    assert.deepEqual(Object.keys(persisted.providers), ['anthropic']);
+    // A las +6h: todos vencieron → archivo borrado.
+    assert.equal(q.isQuotaExhausted({ now: now + 6 * 3600000 }), false);
+    assert.equal(fs.existsSync(path.join(tmp, 'quota-exhausted.json')), false);
+});
+
+test('#4731 · backward-compat: flag legacy sin providers-map → slot anthropic', () => {
+    const tmp = newTmpDir();
+    const q = freshModule(tmp);
+    const now = Date.parse('2026-07-15T00:00:00Z');
+    fs.writeFileSync(path.join(tmp, 'quota-exhausted.json'), JSON.stringify({
+        exhausted: true,
+        resets_at: new Date(now + 3600000).toISOString(),
+        detected_at: new Date(now).toISOString(),
+        pattern_matched: 'usage_limit_error',
+    }));
+    const r = q.readDefensive({ now });
+    assert.equal(r.exhausted, true);
+    assert.equal(r.provider, 'anthropic');
+    assert.deepEqual(r.providers.map(p => p.provider), ['anthropic']);
+});
+
+test('#4731 · TTL configurable por proveedor: maxDays explícito clampea (A05)', () => {
+    const tmp = newTmpDir();
+    const q = freshModule(tmp);
+    // maxDays absurdo se acota a MAX_TTL_DAYS; el default cae al conservador.
+    assert.equal(q.resolveMaxDays('anthropic', { maxDays: 9999 }), q.MAX_TTL_DAYS);
+    assert.ok(q.resolveMaxDays('anthropic', { maxDays: 0.0001 }) >= q.MIN_TTL_DAYS);
+    // Sin config accesible (tmp aislado), cae al default legacy 7d.
+    assert.equal(q.resolveMaxDays('zzz-unknown'), q.DEFAULT_MAX_RESETS_AT_DAYS);
+});
+
+test('#4731 · auditoría por proveedor: set/clear/expire emiten evento con provider (A09)', () => {
+    const tmp = newTmpDir();
+    const q = freshModule(tmp);
+    const now = Date.parse('2026-07-15T00:00:00Z');
+    q.setFlag({ errorType: 'usage_limit_reached', provider: 'openai-codex', resetsAt: new Date(now + 3600000).toISOString(), now, maxDays: 31, agent: 'po' });
+    q.clearFlag({ provider: 'openai-codex', event: 'success_spawn', now });
+    // set flag de anthropic que vence → drenado con provider.
+    fs.writeFileSync(path.join(tmp, 'quota-exhausted.json'), JSON.stringify({
+        providers: { anthropic: { exhausted: true, resets_at: new Date(now - 1000).toISOString(), detected_at: new Date(now - 3600000).toISOString(), pattern_matched: 'usage_limit_error' } },
+    }));
+    q.readDefensive({ now });
+    const audits = readAuditLines(tmp);
+    const setEvt = audits.find(a => a.event === 'flag_set' && a.provider === 'openai-codex');
+    const clearEvt = audits.find(a => a.event === 'success_spawn' && a.provider === 'openai-codex');
+    const drainEvt = audits.find(a => a.event === 'drained_post_reset' && a.provider === 'anthropic');
+    assert.ok(setEvt, 'flag_set debe registrar el provider');
+    assert.ok(clearEvt, 'clear debe registrar el provider');
+    assert.ok(drainEvt, 'drenado por-slot debe registrar el provider');
 });

--- a/.pipeline/lib/dashboard-slices.js
+++ b/.pipeline/lib/dashboard-slices.js
@@ -35,6 +35,12 @@ function _redact(s) {
 let quotaExhaustedState = null;
 try { quotaExhaustedState = require('./quota-exhausted-state'); } catch { /* opcional */ }
 
+// #4731 — Cruce con salud de proveedores para decidir el SCOPE del banner de
+// cuota (puntual vs global). Sólo usamos `listConfiguredProviders()` (lectura
+// del catálogo, sin pings HTTP). Tolerante a la ausencia del módulo.
+let providerHealthLib = null;
+try { providerHealthLib = require('./provider-health'); } catch { /* opcional */ }
+
 // #4709 — Causa declarada del no-despacho (cola ociosa). Lectura defensiva del
 // artifact `dispatch-cause.json`; si el módulo no carga, el slice degrada a
 // `{ active: false }` sin romper el dashboard.
@@ -2580,9 +2586,37 @@ function pacingSlice(state, ctx) {
 // `state.issueMatrix` ya cacheado por el dashboard. Cero IO extra contra
 // el filesystem además del flag.
 // =============================================================================
+// #4731 — Proveedor que NO cuenta como "operativo LLM" para el cómputo de scope
+// (no es un launcher de IA gateable).
+const NON_LLM_PROVIDER_IDS = new Set(['deterministic']);
+
+// #4731 — Cómputo del SCOPE del banner (puntual vs global) cruzando los
+// proveedores agotados (`affected`) con el catálogo de proveedores LLM
+// configurados (`lib/provider-health.listConfiguredProviders`, sin pings).
+//   operationalProviders = proveedores LLM configurados NO agotados
+//   scope = (hay catálogo && 0 operativos) ? 'global' : 'partial'
+// Fail-safe hacia 'partial': si no podemos enumerar el catálogo (módulo ausente
+// o vacío), NUNCA declaramos 'global' — así evitamos el falso "modo
+// determinístico global" del incidente 14–15/07 (CA-2).
+function computeQuotaScope(affectedIds) {
+    let configured = [];
+    try {
+        if (providerHealthLib && typeof providerHealthLib.listConfiguredProviders === 'function') {
+            const list = providerHealthLib.listConfiguredProviders();
+            if (Array.isArray(list)) configured = list;
+        }
+    } catch { /* degradar a partial */ }
+    const llm = configured.filter((id) => id && !NON_LLM_PROVIDER_IDS.has(id));
+    const affected = new Set(affectedIds);
+    const operational = llm.filter((id) => !affected.has(id));
+    const scope = (llm.length > 0 && operational.length === 0) ? 'global' : 'partial';
+    return { scope, operational, operationalCount: operational.length };
+}
+
 function quotaExhaustedSlice(state) {
+    const emptyResult = { active: false, scope: 'partial', providers: [], operational: [], operationalCount: 0, deterministicRunning: 0, queuedSkills: [] };
     if (!quotaExhaustedState) {
-        return { active: false, deterministicRunning: 0, queuedSkills: [] };
+        return { ...emptyResult };
     }
     let flag;
     try {
@@ -2590,10 +2624,10 @@ function quotaExhaustedSlice(state) {
     } catch {
         // Defensa extra: aún si el módulo tiene un bug, el banner no debe
         // tumbar el dashboard.
-        return { active: false, deterministicRunning: 0, queuedSkills: [] };
+        return { ...emptyResult };
     }
     if (!flag || !flag.active) {
-        return { active: false, deterministicRunning: 0, queuedSkills: [] };
+        return { ...emptyResult };
     }
 
     // Conteo: agentes determinísticos `trabajando` (panel "Determinísticos
@@ -2631,9 +2665,27 @@ function quotaExhaustedSlice(state) {
         .map(([skill, count]) => ({ skill, count }))
         .sort((a, b) => b.count - a.count); // más esperando arriba
 
+    // #4731 — proveedores afectados (por-slot) + scope puntual/global.
+    const affected = Array.isArray(flag.providers) ? flag.providers : [];
+    const affectedIds = affected.map((p) => p.id).filter(Boolean);
+    const { scope, operational, operationalCount } = computeQuotaScope(affectedIds);
+
     return {
         active: true,
-        // Campos del flag, ya normalizados por quota-exhausted-state.js.
+        // #4731 — semántica por-proveedor. `scope` = 'partial' (≥1 LLM operativo)
+        // o 'global' (0 LLM operativo). `providers` = lista de afectados con su
+        // motivo y reset. `operational` = ids de proveedores LLM sanos.
+        scope,
+        providers: affected.map((p) => ({
+            id: p.id,
+            error_type: p.error_type,
+            resets_at: p.resets_at,
+            resets_at_ms: p.resets_at_ms,
+            detected_at: p.detected_at,
+        })),
+        operational,
+        operationalCount,
+        // Espejo del slot primario (compat con el countdown/banner legacy).
         error_type: flag.error_type,
         detected_at: flag.detected_at,
         resets_at: flag.resets_at,

--- a/.pipeline/lib/provider-health.js
+++ b/.pipeline/lib/provider-health.js
@@ -445,11 +445,24 @@ async function getProviderHealth(opts = {}) {
     const cache = readCache(opts);
 
     // Lectura del flag de cuota (single read, compartido entre providers).
+    // #4731 — estado por-proveedor: `flag.providers` lista TODOS los slots
+    // activos. Construimos un lookup por id para marcar `gated` a cada proveedor
+    // agotado (no sólo al primario). Backward-compat: si `providers` no viene,
+    // caemos al slot único (`flag.provider`).
     let activeFlag = null;
+    const exhaustedByProvider = Object.create(null);
     if (quotaModule && typeof quotaModule.readDefensive === 'function') {
         try {
             const flag = quotaModule.readDefensive({ auditLogEnabled: false, now });
-            if (flag && flag.exhausted === true) activeFlag = flag;
+            if (flag && flag.exhausted === true) {
+                activeFlag = flag;
+                const slots = Array.isArray(flag.providers) && flag.providers.length
+                    ? flag.providers
+                    : [flag];
+                for (const s of slots) {
+                    if (s && s.provider) exhaustedByProvider[s.provider] = s;
+                }
+            }
         } catch { /* best-effort */ }
     }
 
@@ -507,11 +520,12 @@ async function getProviderHealth(opts = {}) {
             continue;
         }
 
-        if (activeFlag && activeFlag.provider === provider) {
+        const slot = exhaustedByProvider[provider];
+        if (slot) {
             status = 'gated';
-            reason = activeFlag.pattern_matched || 'quota_exhausted';
-            lastQuotaFlagTs = activeFlag.detected_at || null;
-            resetsAt = activeFlag.resets_at || null;
+            reason = slot.pattern_matched || 'quota_exhausted';
+            lastQuotaFlagTs = slot.detected_at || null;
+            resetsAt = slot.resets_at || null;
         } else if (cacheFresh && cached.status) {
             // Honrar el cache hit aún si el flag no es nuestro.
             status = cached.status;

--- a/.pipeline/lib/quota-exhausted-state.js
+++ b/.pipeline/lib/quota-exhausted-state.js
@@ -79,8 +79,43 @@ function emptyQuotaState() {
         detected_at: null,
         resets_at: null,
         resets_at_ms: null,
+        // #4731 — lista de proveedores afectados (vacía cuando no hay flag).
+        providers: [],
         queued_skills: [],
     };
+}
+
+// #4731 — Normaliza cualquier shape persistido (legacy single-flag o el nuevo
+// mapa por-proveedor) a una lista de slots `{ id, error_type, detected_at,
+// resets_at, resets_at_ms }`. READ-ONLY: no toca el filesystem (a diferencia
+// de quota-exhausted.js:readDefensive, este módulo NUNCA borra el flag físico
+// — sólo lo hace el detector). Devuelve `[]` si el shape es inválido.
+// Backward-compat #3077 CA-14: legacy sin `provider` → id `anthropic`.
+function normalizeSlots(parsed) {
+    const out = [];
+    const pushSlot = (id, raw) => {
+        if (!raw || typeof raw !== 'object') return;
+        if (typeof raw.resets_at !== 'string') return;
+        if (typeof raw.detected_at !== 'string') return;
+        if (typeof raw.pattern_matched !== 'string') return;
+        const resetsMs = Date.parse(raw.resets_at);
+        const detectedMs = Date.parse(raw.detected_at);
+        if (!Number.isFinite(resetsMs) || !Number.isFinite(detectedMs)) return;
+        out.push({
+            id: (typeof raw.provider === 'string' && raw.provider) || id,
+            error_type: raw.pattern_matched,
+            detected_at: raw.detected_at,
+            resets_at: raw.resets_at,
+            resets_at_ms: resetsMs,
+        });
+    };
+    if (parsed && typeof parsed === 'object' && parsed.providers
+        && typeof parsed.providers === 'object' && !Array.isArray(parsed.providers)) {
+        for (const [id, raw] of Object.entries(parsed.providers)) pushSlot(id, raw);
+    } else if (parsed && typeof parsed === 'object' && parsed.exhausted === true) {
+        pushSlot(parsed.provider || 'anthropic', parsed);
+    }
+    return out;
 }
 
 /**
@@ -143,35 +178,37 @@ function getQuotaState(opts) {
     }
     if (!parsed || typeof parsed !== 'object') return emptyQuotaState();
 
-    // Validación estricta del shape (mismo criterio que #2974
-    // validateFlagShape). Cualquier campo faltante/mal tipado → safe default.
-    if (parsed.exhausted !== true) return emptyQuotaState();
-    if (typeof parsed.resets_at !== 'string') return emptyQuotaState();
-    if (typeof parsed.detected_at !== 'string') return emptyQuotaState();
-    if (typeof parsed.pattern_matched !== 'string') return emptyQuotaState();
+    // #4731 — Normalizamos a slots por-proveedor (legacy o nuevo shape) y nos
+    // quedamos SÓLO con los activos (`resets_at` futuro). `active = OR de slots
+    // con reset futuro`. Un slot vencido se oculta naturalmente sin borrar el
+    // archivo (CA-2: read-only; el borrado físico lo hace el detector).
+    const slots = normalizeSlots(parsed)
+        .filter((s) => s.resets_at_ms > now)
+        .sort((a, b) => a.resets_at_ms - b.resets_at_ms); // reset más próximo primero
+    if (slots.length === 0) return emptyQuotaState();
 
-    const resetsMs = Date.parse(parsed.resets_at);
-    const detectedMs = Date.parse(parsed.detected_at);
-    if (!Number.isFinite(resetsMs)) return emptyQuotaState();
-    if (!Number.isFinite(detectedMs)) return emptyQuotaState();
-
-    // `active` contra `now`. Si ya expiró, banner se oculta naturalmente
-    // (CA-2: desaparece sin reload manual). Devolvemos shape default
-    // pleno — el dashboard nunca debe ver datos "stale activos".
-    if (resetsMs <= now) return emptyQuotaState();
+    // Slot primario = reset más próximo → espejo legacy para el countdown y los
+    // consumidores que aún leen `error_type`/`resets_at` planos.
+    const primary = slots[0];
 
     return {
         active: true,
-        // Mapeo a `error_type` que el banner muestra al operador.
-        // El campo persistido se llama `pattern_matched` en #2974.
-        error_type: parsed.pattern_matched,
-        detected_at: parsed.detected_at,
-        resets_at: parsed.resets_at,
-        resets_at_ms: resetsMs,
-        // El módulo de estado no sabe de la matriz del pipeline; el slice
-        // del dashboard rellena esta lista con los skills LLM esperando
-        // en `pendiente/`. Devolver `[]` como default seguro mantiene el
-        // contrato sin obligar al consumidor a defensarse.
+        // Espejo del slot primario (compat con el banner legacy + countdown).
+        error_type: primary.error_type,
+        detected_at: primary.detected_at,
+        resets_at: primary.resets_at,
+        resets_at_ms: primary.resets_at_ms,
+        // #4731 — lista completa de proveedores afectados (fuente por-proveedor
+        // del banner). Cada uno con su motivo (`error_type`) y reset propio.
+        providers: slots.map((s) => ({
+            id: s.id,
+            error_type: s.error_type,
+            detected_at: s.detected_at,
+            resets_at: s.resets_at,
+            resets_at_ms: s.resets_at_ms,
+        })),
+        // El slice del dashboard rellena esta lista con los skills LLM esperando
+        // en `pendiente/`. Default `[]` seguro.
         queued_skills: [],
     };
 }

--- a/.pipeline/lib/quota-exhausted.js
+++ b/.pipeline/lib/quota-exhausted.js
@@ -44,15 +44,27 @@
 //   error similar). Si el siguiente spawn también dispara el flag, set/set
 //   son idempotentes. No hay corrupción posible.
 //
-// SCHEMA del archivo `.pipeline/quota-exhausted.json` (post-#3077):
+// SCHEMA del archivo `.pipeline/quota-exhausted.json` (post-#4731):
+//   ESTADO POR-PROVEEDOR (fuente de verdad = mapa `providers`). Los campos
+//   top-level son un ESPEJO del slot primario (reset más próximo) para
+//   backward-compat con lectores legacy (`commander /quota`, provider-health,
+//   tests #3077). Al haber un solo proveedor agotado, espejo == único slot.
 //   {
-//     exhausted: true,
-//     provider: "anthropic",                        // (opcional, default 'anthropic' para backward-compat)
-//     model: "claude-opus-4-7",                     // (opcional, informativo)
-//     resets_at: "2026-05-12T00:00:00.000Z",        // ISO8601, dentro de [now+5min, now+maxDays]
-//     detected_at: "2026-05-05T03:14:22.123Z",      // ISO8601 del momento de detección
-//     pattern_matched: "usage_limit_error"          // valor de error_type del CLI
+//     exhausted: true,                              // espejo: hay ≥1 slot activo
+//     provider: "openai-codex",                     // espejo: slot primario
+//     resets_at, detected_at, pattern_matched,      // espejo del slot primario
+//     providers: {                                  // AUTORITATIVO — por proveedor
+//       "openai-codex": { exhausted:true, resets_at, detected_at, pattern_matched, model? },
+//       "anthropic":    { exhausted:true, resets_at, detected_at, pattern_matched }
+//     }
 //   }
+//   #4731: cada slot expira INDEPENDIENTE por su `resets_at`. `clearFlag({provider})`
+//   drena SÓLO ese slot → el vector de #3077 (un provider limpia el ajeno) queda
+//   cerrado por construcción, sin el guard `clear_skipped_provider_mismatch`.
+//
+//   SCHEMA legacy pre-#4731 (aún leído por backward-compat #3077 CA-14):
+//   { exhausted:true, provider?, model?, resets_at, detected_at, pattern_matched }
+//   → se normaliza a slot `provider || 'anthropic'`.
 //
 // KILL-SWITCH OPERACIONAL: si por bug el flag queda persistente,
 //   `rm .pipeline/quota-exhausted.json` desbloquea el pipeline.
@@ -413,30 +425,151 @@ function capResetsAt(input, opts = {}) {
 }
 
 /**
- * Valida el shape del flag persistido. Devuelve `null` si no es válido.
- * No matchea por substring — solo valida tipos y rangos.
+ * #4731 — Valida el shape de UN slot de proveedor (los campos comunes al flag
+ * legacy y a cada entrada del mapa `providers`). NO muta el input: sólo valida
+ * tipos y que las fechas sean parseables. Devuelve `true`/`false`.
  *
- * #3077 CA-14: campo `provider` es opcional para backward-compat. Si no
- * está presente, se asume `anthropic` (único provider activo antes de #3077).
- * Análogamente, `model` es opcional/informativo.
+ * `exhausted` es opcional dentro de un slot del mapa nuevo (el mapa YA implica
+ * exhausted); si viene, debe ser exactamente `true`. `provider`/`model` son
+ * opcionales pero, si están, deben ser strings válidos.
+ */
+function isValidProviderSlot(slot) {
+    if (!slot || typeof slot !== 'object') return false;
+    if (slot.exhausted !== undefined && slot.exhausted !== true) return false;
+    if (typeof slot.resets_at !== 'string') return false;
+    if (typeof slot.detected_at !== 'string') return false;
+    if (typeof slot.pattern_matched !== 'string') return false;
+    if (!Number.isFinite(Date.parse(slot.resets_at))) return false;
+    if (!Number.isFinite(Date.parse(slot.detected_at))) return false;
+    if (slot.provider !== undefined) {
+        if (typeof slot.provider !== 'string' || slot.provider.length === 0) return false;
+    }
+    if (slot.model !== undefined && typeof slot.model !== 'string') return false;
+    return true;
+}
+
+/**
+ * Valida el shape del flag persistido. Devuelve `null` si no es válido, o el
+ * `parsed` intacto (sin normalizar) si lo es.
+ *
+ * #4731 — Soporta DOS shapes:
+ *   1. Nuevo (por-proveedor): `{ providers: { "<id>": { resets_at, detected_at,
+ *      pattern_matched, ... } } }`. Válido si el mapa tiene ≥1 slot válido.
+ *   2. Legacy (single-flag): `{ exhausted:true, provider?, resets_at,
+ *      detected_at, pattern_matched, model? }`. #3077 CA-14: `provider` opcional
+ *      (default `anthropic`).
+ *
+ * NO normaliza: los callers que necesitan el mapa unificado usan
+ * `readProvidersMap()`. Mantener el retorno "parsed intacto" preserva el
+ * contrato de los tests que hacen `deepEqual(validateFlagShape(x), x)`.
  */
 function validateFlagShape(parsed) {
     if (!parsed || typeof parsed !== 'object') return null;
+    // Shape nuevo por-proveedor.
+    if (parsed.providers !== undefined) {
+        const map = parsed.providers;
+        if (!map || typeof map !== 'object' || Array.isArray(map)) return null;
+        const ids = Object.keys(map);
+        if (ids.length === 0) return null;
+        // Requerimos que TODOS los slots presentes sean válidos: un slot
+        // corrupto es señal de manipulación → safe-default (no fail-open).
+        for (const id of ids) {
+            if (!isValidProviderSlot(map[id])) return null;
+        }
+        return parsed;
+    }
+    // Shape legacy single-flag.
     if (parsed.exhausted !== true) return null;
-    if (typeof parsed.resets_at !== 'string') return null;
-    if (typeof parsed.detected_at !== 'string') return null;
-    if (typeof parsed.pattern_matched !== 'string') return null;
-    if (!Number.isFinite(Date.parse(parsed.resets_at))) return null;
-    if (!Number.isFinite(Date.parse(parsed.detected_at))) return null;
-    // #3077: provider es opcional pero si está, debe ser string no vacío.
-    if (parsed.provider !== undefined) {
-        if (typeof parsed.provider !== 'string' || parsed.provider.length === 0) return null;
-    }
-    // model análogo: opcional, si está debe ser string.
-    if (parsed.model !== undefined) {
-        if (typeof parsed.model !== 'string') return null;
-    }
+    if (!isValidProviderSlot(parsed)) return null;
     return parsed;
+}
+
+/**
+ * #4731 — Normaliza cualquier shape persistido (legacy o nuevo) a un mapa
+ * unificado `{ "<id>": { provider, exhausted:true, resets_at, detected_at,
+ * pattern_matched, model|null, resets_at_ms } }`. Devuelve `null` si el shape
+ * es inválido. NO toca el filesystem ni drena por tiempo (eso lo hace el
+ * caller). Backward-compat #3077 CA-14 / seguridad A04: legacy sin `provider`
+ * → slot `DEFAULT_PROVIDER` (`anthropic`), NUNCA fail-open.
+ */
+function readProvidersMap(parsed) {
+    const valid = validateFlagShape(parsed);
+    if (!valid) return null;
+    const out = {};
+    const toSlot = (id, raw) => ({
+        provider: id,
+        exhausted: true,
+        resets_at: raw.resets_at,
+        detected_at: raw.detected_at,
+        pattern_matched: raw.pattern_matched,
+        model: raw.model || null,
+        resets_at_ms: Date.parse(raw.resets_at),
+    });
+    if (valid.providers) {
+        for (const [id, raw] of Object.entries(valid.providers)) {
+            const pid = (raw && typeof raw.provider === 'string' && raw.provider) || id;
+            out[pid] = toSlot(pid, raw);
+        }
+    } else {
+        const id = valid.provider || DEFAULT_PROVIDER;
+        out[id] = toSlot(id, valid);
+    }
+    return Object.keys(out).length ? out : null;
+}
+
+/**
+ * #4731 — Construye el payload persistido HÍBRIDO desde un mapa de slots. El
+ * mapa `providers` es la FUENTE DE VERDAD; los campos top-level (`exhausted`,
+ * `provider`, `resets_at`, ...) son un ESPEJO del slot primario (el de reset
+ * más próximo) para backward-compat con lectores que aún leen el shape legacy
+ * (`commander /quota`, `provider-health`, tests #3077). Al haber un solo slot,
+ * el espejo coincide con él (los tests legacy siguen verdes).
+ */
+function buildHybridPayload(map) {
+    const ids = Object.keys(map);
+    if (ids.length === 0) return null;
+    let primaryId = ids[0];
+    for (const id of ids) {
+        if (Date.parse(map[id].resets_at) < Date.parse(map[primaryId].resets_at)) {
+            primaryId = id;
+        }
+    }
+    const p = map[primaryId];
+    const providers = {};
+    for (const id of ids) {
+        const s = map[id];
+        providers[id] = {
+            exhausted: true,
+            resets_at: s.resets_at,
+            detected_at: s.detected_at,
+            pattern_matched: s.pattern_matched,
+            ...(s.model ? { model: s.model } : {}),
+        };
+    }
+    return {
+        exhausted: true,
+        provider: primaryId,
+        ...(p.model ? { model: p.model } : {}),
+        resets_at: p.resets_at,
+        detected_at: p.detected_at,
+        pattern_matched: p.pattern_matched,
+        providers,
+    };
+}
+
+/**
+ * #4731 — Lee y normaliza el mapa de slots del archivo persistido. Devuelve
+ * `{}` si el archivo no existe o es inválido (para read-modify-write en
+ * `setFlag`/`clearFlag`). NO drena por tiempo ni audita.
+ */
+function readCurrentMap() {
+    let raw;
+    try {
+        raw = fs.readFileSync(flagFile(), 'utf8');
+    } catch { return {}; }
+    let parsed;
+    try { parsed = JSON.parse(raw); } catch { return {}; }
+    return readProvidersMap(parsed) || {};
 }
 
 // -----------------------------------------------------------------------------
@@ -495,8 +628,8 @@ function readDefensive(opts = {}) {
         return { exhausted: false, reason: 'parse_error' };
     }
 
-    const valid = validateFlagShape(parsed);
-    if (!valid) {
+    const map = readProvidersMap(parsed);
+    if (!map) {
         if (auditEnabled) {
             appendAudit({
                 event: 'schema_invalid',
@@ -508,35 +641,75 @@ function readDefensive(opts = {}) {
         return { exhausted: false, reason: 'schema_invalid' };
     }
 
-    // Backward-compat: provider opcional → default 'anthropic'.
-    const provider = valid.provider || DEFAULT_PROVIDER;
-    const model = valid.model || null;
-
-    const resetsAtMs = Date.parse(valid.resets_at);
-    if (now >= resetsAtMs) {
-        // CA-7 del issue padre: drenado natural post-reset.
-        try { fs.unlinkSync(file); } catch {}
-        if (auditEnabled) {
-            appendAudit({
-                event: 'drained_post_reset',
-                provider,
-                model,
-                error_type: valid.pattern_matched,
-                raw_excerpt: `resets_at=${valid.resets_at}`,
-                flag_set: false,
-            });
+    // #4731 — Drenado POR SLOT: cada proveedor expira independiente por su
+    // `resets_at`. Los slots vencidos se drenan (audit `drained_post_reset`),
+    // los activos se conservan. Si todos vencieron → se borra el archivo.
+    const active = {};
+    const expiredIds = [];
+    for (const [id, slot] of Object.entries(map)) {
+        if (now >= slot.resets_at_ms) {
+            expiredIds.push(id);
+            if (auditEnabled) {
+                appendAudit({
+                    event: 'drained_post_reset',
+                    provider: id,
+                    model: slot.model,
+                    error_type: slot.pattern_matched,
+                    raw_excerpt: `resets_at=${slot.resets_at}`,
+                    flag_set: false,
+                });
+            }
+        } else {
+            active[id] = slot;
         }
-        return { exhausted: false, reason: 'expired', provider, model };
     }
+
+    const activeIds = Object.keys(active);
+    if (activeIds.length === 0) {
+        // Todos los slots vencieron (o el mapa quedó vacío) → drenado total.
+        try { fs.unlinkSync(file); } catch {}
+        const anyExpired = expiredIds.length > 0;
+        return { exhausted: false, reason: anyExpired ? 'expired' : 'absent' };
+    }
+
+    // Drenado PARCIAL: si algún slot venció pero quedan activos, reescribimos
+    // el archivo sólo con los activos (best-effort — no rompe el pipeline si
+    // falla la escritura; el drenado se reintenta en la próxima lectura).
+    if (expiredIds.length > 0) {
+        try { writeJsonAtomic(file, buildHybridPayload(active)); } catch { /* best-effort */ }
+    }
+
+    // Slot primario = reset más próximo (para el espejo legacy + countdown).
+    let primaryId = activeIds[0];
+    for (const id of activeIds) {
+        if (active[id].resets_at_ms < active[primaryId].resets_at_ms) primaryId = id;
+    }
+    const p = active[primaryId];
+
+    // Lista de proveedores afectados, ordenada por reset ascendente (el más
+    // próximo primero) para que el banner muestre el/los provider(s) real(es).
+    const providers = activeIds
+        .map((id) => ({
+            provider: id,
+            model: active[id].model,
+            resets_at: active[id].resets_at,
+            detected_at: active[id].detected_at,
+            pattern_matched: active[id].pattern_matched,
+            resets_at_ms: active[id].resets_at_ms,
+        }))
+        .sort((a, b) => a.resets_at_ms - b.resets_at_ms);
 
     return {
         exhausted: true,
-        provider,
-        model,
-        resets_at: valid.resets_at,
-        detected_at: valid.detected_at,
-        pattern_matched: valid.pattern_matched,
-        resets_at_ms: resetsAtMs,
+        // Espejo del slot primario — backward-compat con callers legacy.
+        provider: primaryId,
+        model: p.model,
+        resets_at: p.resets_at,
+        detected_at: p.detected_at,
+        pattern_matched: p.pattern_matched,
+        resets_at_ms: p.resets_at_ms,
+        // #4731 — lista completa de slots activos (fuente por-proveedor).
+        providers,
     };
 }
 
@@ -565,39 +738,15 @@ function clearFlag(opts = {}) {
     const auditEnabled = opts.auditLogEnabled !== false;
     const callerProvider = opts.provider || null;
 
-    // #3077 CA-8: si pasaron provider, validar scope antes de borrar.
-    if (callerProvider) {
-        // Leer el flag actual sin disparar audit ni drenado por fecha.
-        try {
-            const raw = fs.readFileSync(file, 'utf8');
-            const parsed = JSON.parse(raw);
-            const flagProvider = (parsed && parsed.provider) || DEFAULT_PROVIDER;
-            if (flagProvider !== callerProvider) {
-                if (auditEnabled) {
-                    appendAudit({
-                        event: 'clear_skipped_provider_mismatch',
-                        provider: callerProvider,
-                        model: opts.model || null,
-                        error_type: null,
-                        raw_excerpt: `flag_provider=${flagProvider} caller_provider=${callerProvider}`,
-                        flag_set: true,
-                    });
-                }
-                return false;
-            }
-        } catch (e) {
-            // ENOENT / parse_error → caer al unlink (idempotente).
-            if (e && e.code !== 'ENOENT') {
-                // No-op para otros errores.
-            }
-        }
-    }
-
+    // #4731 — Con estado por-proveedor el guard `clear_skipped_provider_mismatch`
+    // deja de ser necesario: `clearFlag({provider:X})` opera SÓLO sobre el slot
+    // de X. Un proveedor sano nunca puede limpiar el slot de otro (el vector
+    // de #3077 CA-8 / SEC-1 queda cerrado por construcción, no por guard).
+    //
     // #4577 GATE 3 — INVARIANTE log-antes-de-mutar (RS-2): registrar el clear
-    // del flag ANTES del unlink, y SOLO cuando hay un flag real que borrar (no
-    // floodear el audit con los `success_spawn` que no tocan estado). Incidente
-    // #4565 (misatribución de provider) es exactamente este sitio sin traza.
-    if (fs.existsSync(file)) {
+    // ANTES de mutar, y SOLO cuando hay algo real que borrar (no floodear el
+    // audit con `success_spawn` que no tocan estado).
+    const logBeforeMutate = () => {
         try {
             require('./kernel-actions-audit').safeAppendAction({
                 action: 'quota-flag-clear', impact: 'alto',
@@ -609,27 +758,51 @@ function clearFlag(opts = {}) {
                 reason: `clearFlag event=${opts.event || 'cleared'} provider=${callerProvider || 'any'} reason=${opts.reason || 'manual_or_post_success'}`,
             });
         } catch {}
-    }
-    let existed = false;
-    try {
-        fs.unlinkSync(file);
-        existed = true;
-    } catch (e) {
-        if (e && e.code !== 'ENOENT') {
-            // No-op: best-effort
-        }
-    }
-    if (existed && auditEnabled) {
+    };
+    const auditCleared = (provider, model) => {
+        if (!auditEnabled) return;
         appendAudit({
             event: opts.event || 'cleared',
-            provider: callerProvider,
-            model: opts.model || null,
+            provider: provider || null,
+            model: model || null,
             error_type: null,
             raw_excerpt: opts.reason || 'manual_or_post_success',
             flag_set: false,
         });
+    };
+
+    // Caller legacy sin provider: limpia TODO el flag (backward-compat).
+    if (!callerProvider) {
+        if (!fs.existsSync(file)) return false;
+        logBeforeMutate();
+        let existed = false;
+        try { fs.unlinkSync(file); existed = true; }
+        catch (e) { if (e && e.code !== 'ENOENT') { /* best-effort */ } }
+        if (existed) auditCleared(null, opts.model || null);
+        return existed;
     }
-    return existed;
+
+    // Scope por-proveedor: sólo drena el slot de `callerProvider`.
+    const map = readCurrentMap();
+    if (!map[callerProvider]) {
+        // El proveedor no tiene slot activo → no-op silencioso (NO es un
+        // mismatch: los otros slots, si existen, quedan intactos).
+        return false;
+    }
+    const model = map[callerProvider].model || opts.model || null;
+    logBeforeMutate();
+    delete map[callerProvider];
+    try {
+        if (Object.keys(map).length === 0) {
+            fs.unlinkSync(file);
+        } else {
+            writeJsonAtomic(file, buildHybridPayload(map));
+        }
+    } catch (e) {
+        if (e && e.code !== 'ENOENT') { /* best-effort */ }
+    }
+    auditCleared(callerProvider, model);
+    return true;
 }
 
 // -----------------------------------------------------------------------------
@@ -698,14 +871,15 @@ function setFlag(opts = {}) {
     if (effectiveResetsAt == null && errorType === 'usage_limit_reached') {
         effectiveResetsAt = now + CODEX_USAGE_LIMIT_RESET_MS;
     }
-    const cap = capResetsAt(effectiveResetsAt, { maxDays: opts.maxDays, now });
-    const payload = {
+    // #4731 — TTL configurable por proveedor (clampeado). Prioriza opts.maxDays.
+    const maxDays = resolveMaxDays(provider, opts);
+    const cap = capResetsAt(effectiveResetsAt, { maxDays, now });
+    const slot = {
         exhausted: true,
-        provider,
-        ...(model ? { model } : {}),
         resets_at: cap.iso,
         detected_at: new Date(now).toISOString(),
         pattern_matched: errorType,
+        ...(model ? { model } : {}),
     };
     // #4577 GATE 3 — INVARIANTE log-antes-de-mutar (RS-2): registrar el set del
     // flag de cuota ANTES del write atómico (incidente #4565).
@@ -720,6 +894,13 @@ function setFlag(opts = {}) {
             reason: `setFlag provider=${provider} error_type=${errorType} agent=${opts.agent || 'unknown'}`,
         });
     } catch {}
+    // #4731 — Read-modify-write del mapa por-proveedor: NO pisa slots de otros
+    // proveedores agotados (habilita coexistencia CA-3). Bajo concurrencia exacta
+    // aplica last-writer-wins sobre el mapa (documentado, atomicidad garantizada
+    // por el rename de writeJsonAtomic).
+    const map = readCurrentMap();
+    map[provider] = { provider, ...slot, resets_at_ms: cap.ms };
+    const payload = buildHybridPayload(map);
     writeJsonAtomic(flagFile(), payload);
     if (opts.auditLogEnabled !== false) {
         appendAudit({
@@ -803,6 +984,60 @@ const _CODEX_USAGE_LIMIT_PATTERN =
 // desperdiciamos el fallback pago durante días. Es auto-corrector: si al drenar
 // la cuota sigue agotada, el próximo intento re-setea el flag (idempotente).
 const CODEX_USAGE_LIMIT_RESET_MS = 60 * 60 * 1000; // 1h
+
+// #4731 — TTL (cap de `resets_at`) configurable POR PROVEEDOR. Fuente:
+// `config.yaml:quota_detector.ttl_by_provider.<id>` (en días) con default
+// `quota_detector.resets_at_cap_max_days`. Clampeado a rango seguro
+// [MIN_TTL_DAYS, MAX_TTL_DAYS] (security A05): un valor inválido o fuera de
+// rango cae al default conservador y se acota — nunca deja flags eternos ni
+// expira sin evidencia. La lectura es defensiva y cacheada: si el config no
+// carga, se usa DEFAULT_MAX_RESETS_AT_DAYS.
+const MIN_TTL_DAYS = 1 / 24;              // 1h — piso (evita flags que expiran al instante)
+const MAX_TTL_DAYS = 31;                  // 31d — techo (cuota mensual OpenAI)
+
+let _quotaDetectorCfgCache = null;
+function loadQuotaDetectorConfig() {
+    if (_quotaDetectorCfgCache !== null) return _quotaDetectorCfgCache;
+    let cfg = {};
+    try {
+        // Carga perezosa y defensiva de `config.yaml`. Si `js-yaml` o el archivo
+        // no están disponibles (tests aislados), quedamos con defaults.
+        const yaml = require('js-yaml');
+        const cfgPath = path.join(pipelineDir(), 'config.yaml');
+        const full = yaml.load(fs.readFileSync(cfgPath, 'utf8'));
+        if (full && full.quota_detector && typeof full.quota_detector === 'object') {
+            cfg = full.quota_detector;
+        }
+    } catch { /* best-effort: defaults */ }
+    _quotaDetectorCfgCache = cfg;
+    return cfg;
+}
+
+/**
+ * #4731 — Resuelve el cap de días (`maxDays`) para un proveedor. Prioridad:
+ *   1. `opts.maxDays` explícito del caller (contrato #3077 preservado).
+ *   2. `config.quota_detector.ttl_by_provider.<provider>`.
+ *   3. `config.quota_detector.resets_at_cap_max_days` (default legacy).
+ *   4. `DEFAULT_MAX_RESETS_AT_DAYS`.
+ * El resultado se clampa a [MIN_TTL_DAYS, MAX_TTL_DAYS]; un valor inválido cae
+ * al default conservador (`DEFAULT_MAX_RESETS_AT_DAYS`).
+ */
+function resolveMaxDays(provider, opts = {}) {
+    if (Number.isFinite(opts.maxDays) && opts.maxDays > 0) {
+        return Math.min(MAX_TTL_DAYS, Math.max(MIN_TTL_DAYS, opts.maxDays));
+    }
+    const cfg = loadQuotaDetectorConfig();
+    let days = DEFAULT_MAX_RESETS_AT_DAYS;
+    const perProvider = cfg && cfg.ttl_by_provider;
+    if (perProvider && typeof perProvider === 'object'
+        && Number.isFinite(perProvider[provider]) && perProvider[provider] > 0) {
+        days = perProvider[provider];
+    } else if (Number.isFinite(cfg && cfg.resets_at_cap_max_days) && cfg.resets_at_cap_max_days > 0) {
+        days = cfg.resets_at_cap_max_days;
+    }
+    if (!Number.isFinite(days) || days <= 0) days = DEFAULT_MAX_RESETS_AT_DAYS;
+    return Math.min(MAX_TTL_DAYS, Math.max(MIN_TTL_DAYS, days));
+}
 
 function _detectAnthropic(evt, allowlist) {
     if (!evt || typeof evt !== 'object') return { matched: false };
@@ -997,9 +1232,12 @@ function shouldGateSpawn(skill, opts = {}) {
     if (isDeterministicSkill(skill)) return false;
     const flag = readDefensive(opts);
     if (flag.exhausted !== true) return false;
-    // #3077 CA-7: si el caller pasó provider, requerir match exacto.
+    // #3077 CA-7 / #4731: si el caller pasó provider, gatear SOLO si ese
+    // proveedor tiene un slot activo (scope por-proveedor). Con múltiples
+    // proveedores agotados, cada uno gatea sólo sus propios skills.
     if (opts.provider) {
-        return flag.provider === opts.provider;
+        const slots = Array.isArray(flag.providers) ? flag.providers : [];
+        return slots.some((p) => p.provider === opts.provider);
     }
     // Sin provider del caller: comportamiento legacy (cualquier flag bloquea).
     return true;
@@ -1025,6 +1263,11 @@ module.exports = {
     capResetsAt,
     sanitizeRawExcerpt,
     validateFlagShape,
+    // #4731 — estado por-proveedor
+    isValidProviderSlot,
+    readProvidersMap,
+    buildHybridPayload,
+    resolveMaxDays,
 
     // Constantes públicas
     DEFAULT_ERROR_TYPES,
@@ -1036,6 +1279,8 @@ module.exports = {
     DETERMINISTIC_SKILLS,
     KNOWN_QUOTA_ERROR_TYPES_BY_PROVIDER,
     CODEX_USAGE_LIMIT_RESET_MS,
+    MIN_TTL_DAYS,
+    MAX_TTL_DAYS,
 
     // Paths (útiles para tests)
     flagFile,

--- a/.pipeline/views/dashboard/home.js
+++ b/.pipeline/views/dashboard/home.js
@@ -943,16 +943,22 @@ function homeStyles() {
  * empuja contenido; usa padding y se inserta en el flujo natural cuando
  * data-active="true". Mientras hidden ocupa 0px (display:none).
  * ========================================================================= */
+/* #4731 — Banner de cuota por-proveedor. El COLOR comunica el scope:
+ *  - Puntual (partial, ≥1 LLM operativo): calmo sobre --surface-1, acento =
+ *    color del proveedor afectado (--provider-<id>-*). NO usa el ámbar.
+ *  - Global (0 LLM operativo): ámbar --quota-degraded-* + glow (alarma real).
+ * Así el ámbar recupera su peso de "sin LLM" y no se quema por degradaciones
+ * puntuales (incidente 14–15/07). */
 .quota-exhausted-banner {
     display: none;
     margin: 0 22px;
     padding: 14px 18px;
-    background: var(--quota-degraded-bg);
-    color: var(--quota-degraded-fg);
-    border: 1px solid var(--quota-degraded);
-    border-left: 4px solid var(--quota-degraded);
+    background: var(--surface-1);
+    color: var(--text-primary);
+    border: 1px solid var(--border);
+    border-left: 4px solid var(--border-strong);
     border-radius: var(--in-radius, 8px);
-    box-shadow: var(--quota-degraded-glow);
+    box-shadow: none;
     font-size: 13px;
     line-height: 1.4;
     grid-template-columns: auto 1fr auto;
@@ -961,12 +967,30 @@ function homeStyles() {
 }
 .quota-exhausted-banner[data-active="true"] { display: grid; }
 
+/* Acento (borde izquierdo) por proveedor afectado — scope puntual. El color se
+ * elige POR ATRIBUTO allowlisteado, nunca inyectando el id crudo (CA-6/A03). */
+.quota-exhausted-banner[data-provider="openai-codex"] { border-left-color: var(--provider-openai-codex); }
+.quota-exhausted-banner[data-provider="anthropic"]    { border-left-color: var(--provider-anthropic); }
+.quota-exhausted-banner[data-provider="cerebras"]     { border-left-color: var(--provider-cerebras); }
+.quota-exhausted-banner[data-provider="gemini-google"]{ border-left-color: var(--provider-gemini); }
+.quota-exhausted-banner[data-provider="nvidia-nim"]   { border-left-color: var(--provider-nvidia-nim); }
+.quota-exhausted-banner[data-provider="groq"]         { border-left-color: var(--provider-groq); }
+
+/* Global: 0 proveedores LLM disponibles → ámbar de alarma controlada. */
+.quota-exhausted-banner[data-scope="global"] {
+    background: var(--quota-degraded-bg);
+    border-color: var(--quota-degraded);
+    border-left-color: var(--quota-degraded);
+    box-shadow: var(--quota-degraded-glow);
+}
+
 .quota-exhausted-icon {
     width: 28px;
     height: 28px;
     flex: 0 0 28px;
-    color: var(--quota-degraded);
+    color: var(--border-strong);
 }
+.quota-exhausted-banner[data-scope="global"] .quota-exhausted-icon { color: var(--quota-degraded); }
 .quota-exhausted-icon svg { width: 100%; height: 100%; fill: currentColor; }
 
 .quota-exhausted-content {
@@ -978,15 +1002,64 @@ function homeStyles() {
 .quota-exhausted-title {
     font-size: 14px;
     font-weight: 700;
-    color: var(--quota-degraded-fg);
+    color: var(--text-primary);
     letter-spacing: 0.2px;
 }
+.quota-exhausted-banner[data-scope="global"] .quota-exhausted-title { color: var(--quota-degraded-fg); }
 .quota-exhausted-sub {
     font-size: 11px;
-    color: var(--quota-degraded-dim);
+    color: var(--text-secondary);
     font-family: var(--in-mono, 'Roboto Mono', monospace);
     word-break: break-word;
 }
+
+/* #4731 — Chips por proveedor afectado (habilitan el CA plural). */
+.quota-exhausted-providers {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-top: 2px;
+}
+.quota-provider-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    border-radius: 14px;
+    padding: 4px 12px;
+    font-size: 12px;
+    font-weight: 700;
+    color: var(--provider-unknown-fg);
+    background: var(--provider-unknown-bg);
+    border: 1px solid var(--provider-unknown);
+}
+.quota-provider-chip[data-provider="openai-codex"] { color: var(--provider-openai-codex-fg); background: var(--provider-openai-codex-bg); border-color: var(--provider-openai-codex); }
+.quota-provider-chip[data-provider="anthropic"]    { color: var(--provider-anthropic-fg);    background: var(--provider-anthropic-bg);    border-color: var(--provider-anthropic); }
+.quota-provider-chip[data-provider="cerebras"]     { color: var(--provider-cerebras-fg);     background: var(--provider-cerebras-bg);     border-color: var(--provider-cerebras); }
+.quota-provider-chip[data-provider="gemini-google"]{ color: var(--provider-gemini-fg);       background: var(--provider-gemini-bg);       border-color: var(--provider-gemini); }
+.quota-provider-chip[data-provider="nvidia-nim"]   { color: var(--provider-nvidia-nim-fg);   background: var(--provider-nvidia-nim-bg);   border-color: var(--provider-nvidia-nim); }
+.quota-provider-chip[data-provider="groq"]         { color: var(--provider-groq-fg);         background: var(--provider-groq-bg);         border-color: var(--provider-groq); }
+.quota-provider-chip .quota-provider-dot {
+    width: 8px; height: 8px; border-radius: 50%;
+    background: currentColor;
+    flex: 0 0 8px;
+}
+.quota-provider-chip .quota-provider-reason { font-weight: 500; opacity: 0.9; }
+.quota-provider-chip .quota-provider-reset { font-weight: 500; opacity: 0.7; font-variant-numeric: tabular-nums; }
+
+/* #4731 — Health strip: evidencia visible de "no global" (CA-2). */
+.quota-health-strip {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    align-items: center;
+    font-size: 11px;
+    color: var(--text-secondary);
+    margin-top: 2px;
+}
+.quota-health-strip[data-empty="true"] { display: none; }
+.quota-health-item { display: inline-flex; align-items: center; gap: 5px; }
+.quota-health-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--success); flex: 0 0 8px; }
+
 .quota-exhausted-panels {
     display: flex;
     gap: 12px;
@@ -994,12 +1067,12 @@ function homeStyles() {
     margin-top: 4px;
 }
 .quota-exhausted-panel {
-    background: rgba(0, 0, 0, 0.22);
-    border: 1px solid var(--in-border, rgba(255,255,255,0.08));
+    background: var(--surface-2);
+    border: 1px solid var(--border-subtle);
     border-radius: 6px;
     padding: 6px 10px;
     font-size: 11px;
-    color: var(--in-fg-dim);
+    color: var(--text-secondary);
     display: flex;
     align-items: center;
     gap: 6px;
@@ -1008,16 +1081,16 @@ function homeStyles() {
     text-transform: uppercase;
     letter-spacing: 0.5px;
     font-size: 10px;
-    color: var(--in-fg-soft, rgba(255,255,255,0.55));
+    color: var(--text-secondary);
 }
 .quota-exhausted-panel-value {
     font-size: 13px;
     font-weight: 700;
-    color: var(--quota-degraded-fg);
+    color: var(--text-primary);
     font-variant-numeric: tabular-nums;
 }
 .quota-exhausted-panel.det .quota-exhausted-panel-value {
-    color: var(--in-ok, #3fb950);
+    color: var(--success);
 }
 .quota-exhausted-skills {
     display: inline-flex;
@@ -1026,9 +1099,9 @@ function homeStyles() {
     margin-left: 4px;
 }
 .quota-exhausted-skill-pill {
-    background: var(--quota-degraded-bg);
-    border: 1px solid var(--quota-degraded);
-    color: var(--quota-degraded-fg);
+    background: var(--surface-3);
+    border: 1px solid var(--border-subtle);
+    color: var(--text-secondary);
     border-radius: 12px;
     padding: 2px 8px;
     font-size: 10px;
@@ -1056,19 +1129,20 @@ function homeStyles() {
     font-size: 10px;
     text-transform: uppercase;
     letter-spacing: 0.6px;
-    color: var(--in-fg-soft, rgba(255,255,255,0.55));
+    color: var(--text-secondary);
 }
 .quota-exhausted-countdown-value {
     font-size: 18px;
     font-weight: 700;
-    color: var(--quota-degraded-fg);
+    color: var(--text-primary);
     font-variant-numeric: tabular-nums;
     font-family: var(--in-mono, 'Roboto Mono', monospace);
 }
+.quota-exhausted-banner[data-scope="global"] .quota-exhausted-countdown-value { color: var(--quota-degraded-fg); }
 .quota-exhausted-countdown-bar {
     width: 100%;
     height: 4px;
-    background: rgba(0, 0, 0, 0.32);
+    background: var(--surface-3);
     border-radius: 2px;
     overflow: hidden;
 }
@@ -1076,9 +1150,10 @@ function homeStyles() {
     display: block;
     height: 100%;
     width: 0%;
-    background: var(--quota-degraded);
+    background: var(--border-strong);
     transition: width 1s linear;
 }
+.quota-exhausted-banner[data-scope="global"] .quota-exhausted-countdown-bar > span { background: var(--quota-degraded); }
 
 /* #3361 — La card de salud de providers se movió a la ventana Providers
  * (multi-provider.js). Estilos y polling viven ahora ahí. El home queda
@@ -2641,6 +2716,43 @@ function fmtHHMMLocal(iso){
     return h + ':' + m;
 }
 
+// #4731 — Mapas de presentación (cliente). Los nombres de proveedor y las
+// palabras clave del copy se construyen con escapes Unicode en la PRIMERA letra
+// para que el source JS embebido en el HTML NO contenga las secuencias
+// literales: curl del HTML inactivo no revela proveedores ni el copy del banner
+// (CA-14). Los valores dinámicos siempre pasan por escapeHtml.
+var QUOTA_PROVIDER_NAMES = {
+    'anthropic': '\\u0041nthropic',
+    'openai-codex': '\\u0043odex',
+    'openai': '\\u004FpenAI',
+    'cerebras': '\\u0043erebras',
+    'gemini-google': '\\u0047emini',
+    'gemini': '\\u0047emini',
+    'groq': '\\u0047roq',
+    'nvidia-nim': '\\u004EVIDIA'
+};
+var QUOTA_PROVIDER_TOKENS = {
+    'anthropic':1,'openai-codex':1,'cerebras':1,'gemini-google':1,'nvidia-nim':1,'groq':1
+};
+var QUOTA_REASON_LABELS = {
+    'usage_limit_reached':'límite de uso del plan',
+    'usage_limit_error':'cuota agotada',
+    'weekly_quota_exhausted':'cuota semanal agotada',
+    'snapshot_threshold_90':'cuota casi agotada',
+    'insufficient_quota':'cuota agotada',
+    'billing_hard_limit_reached':'cuota agotada',
+    'tokens_exhausted':'cuota agotada',
+    'quota_exceeded':'cuota agotada',
+    'quota_exhausted':'cuota agotada',
+    'resource_exhausted':'cuota agotada',
+    'rate_limit':'rate limit temporal',
+    'rate_limit_exceeded':'rate limit temporal',
+    'schedule_rest':'reposo horario'
+};
+function quotaProviderName(id){ return QUOTA_PROVIDER_NAMES[id] || 'proveedor'; }
+function quotaProviderTokenAttr(id){ return QUOTA_PROVIDER_TOKENS[id] ? id : 'unknown'; }
+function quotaReasonLabel(t){ return QUOTA_REASON_LABELS[t] || 'degradado'; }
+
 function renderQuotaExhaustedBanner(d){
     const banner = document.getElementById('quota-exhausted-banner');
     if(!banner) return;
@@ -2651,28 +2763,80 @@ function renderQuotaExhaustedBanner(d){
         // Reset visual del countdown a "—" cuando se oculta para no dejar
         // un valor stale visible si el banner reaparece en el siguiente ciclo.
         setText('quota-exhausted-countdown', '—');
+        banner.dataset.scope = 'partial';
+        banner.removeAttribute('data-provider');
         return;
     }
 
-    // Texto principal del banner (CA-1, literal):
-    //   "Modo determinístico — cuota A·· agotada. Reset HH:MM (en X h Y min)."
-    //
-    // El nombre del proveedor (Anthropic) se construye con escapes Unicode
-    // para que grep del nombre completo sobre el HTML servido SOLO matchee
-    // cuando el SSR del banner activo lo emite (CA-14). El source del JS
-    // embebido en el script queda sin la secuencia literal del proveedor.
+    // #4731 — Estado por-proveedor. Fail-safe hacia 'partial' (nunca falso
+    // "global"). Backward-compat: flag sin providers-map → único afectado.
+    var affected = Array.isArray(d.providers) ? d.providers.slice() : [];
+    if(affected.length === 0 && d.error_type){
+        affected = [{ id:'anthropic', error_type:d.error_type, resets_at:d.resets_at, resets_at_ms:d.resets_at_ms, detected_at:d.detected_at }];
+    }
+    var scope = d.scope === 'global' ? 'global' : 'partial';
+    var operational = Array.isArray(d.operational) ? d.operational : [];
+    var operationalCount = (typeof d.operationalCount === 'number') ? d.operationalCount : operational.length;
+
+    banner.dataset.scope = scope;
+    // data-provider (acento por color) sólo en puntual con 1 afectado.
+    if(scope === 'partial' && affected.length === 1){
+        banner.dataset.provider = quotaProviderTokenAttr(affected[0].id);
+    } else {
+        banner.removeAttribute('data-provider');
+    }
+
+    // Título dinámico (reemplaza el string hardcodeado por-proveedor). '\\u004D'
+    // = 'M', '\\u0050' = 'P' — escapados para CA-14 (ver mapa arriba).
     const titleEl = document.getElementById('quota-exhausted-title');
     if(titleEl){
-        const hhmm = escapeHtml(fmtHHMMLocal(d.resets_at));
-        const remaining = Math.max(0, d.resets_at_ms - Date.now());
-        const inText = escapeHtml(fmtCountdown(remaining));
-        // \\u0041 = 'A'. El runtime del browser lo decodifica al nombre del
-        // proveedor pero el source JS embebido en el HTML no contiene la
-        // secuencia literal — clave para que grep sobre el HTML inactivo
-        // NO matchee el nombre completo (CA-14).
-        const PROVIDER = '\\u0041nthropic';
-        const txt = 'Modo determinístico — cuota '+PROVIDER+' agotada. Reset '+hhmm+' (en '+inText+').';
+        var txt;
+        if(scope === 'global'){
+            txt = '\\u004Do determinístico — sin proveedores LLM disponibles.';
+        } else if(affected.length === 1){
+            txt = '\\u0050roveedor ' + quotaProviderName(affected[0].id) + ' degradado — '
+                + quotaReasonLabel(affected[0].error_type) + '.';
+        } else {
+            txt = affected.length + ' proveedores degradados — ' + operationalCount + ' operativos.';
+        }
         if(titleEl.textContent !== txt) titleEl.textContent = txt;
+    }
+
+    // Chips por proveedor afectado (CA plural). textContent en cada nodo → XSS-safe.
+    const provEl = document.getElementById('quota-exhausted-providers');
+    if(provEl){
+        provEl.textContent = '';
+        affected.forEach(function(p){
+            var chip = document.createElement('span');
+            chip.className = 'quota-provider-chip';
+            chip.setAttribute('data-provider', quotaProviderTokenAttr(p.id));
+            var dot = document.createElement('span'); dot.className = 'quota-provider-dot'; dot.setAttribute('aria-hidden','true');
+            var name = document.createElement('span'); name.className = 'quota-provider-name'; name.textContent = quotaProviderName(p.id);
+            var reason = document.createElement('span'); reason.className = 'quota-provider-reason'; reason.textContent = quotaReasonLabel(p.error_type);
+            var reset = document.createElement('span'); reset.className = 'quota-provider-reset'; reset.textContent = '↻ ' + fmtHHMMLocal(p.resets_at);
+            chip.appendChild(dot); chip.appendChild(name); chip.appendChild(reason); chip.appendChild(reset);
+            provEl.appendChild(chip);
+        });
+    }
+
+    // Health strip: "N operativos:" + nombres (evidencia de "no global", CA-2).
+    const healthEl = document.getElementById('quota-exhausted-health');
+    if(healthEl){
+        var showHealth = scope === 'partial' && operationalCount > 0;
+        healthEl.textContent = '';
+        healthEl.setAttribute('data-empty', showHealth ? 'false' : 'true');
+        if(showHealth){
+            var label = document.createElement('span'); label.className = 'quota-health-label';
+            label.textContent = operationalCount + ' operativos:';
+            healthEl.appendChild(label);
+            operational.forEach(function(id){
+                var item = document.createElement('span'); item.className = 'quota-health-item';
+                var hdot = document.createElement('span'); hdot.className = 'quota-health-dot'; hdot.setAttribute('aria-hidden','true');
+                var hname = document.createElement('span'); hname.textContent = quotaProviderName(id);
+                item.appendChild(hdot); item.appendChild(hname);
+                healthEl.appendChild(item);
+            });
+        }
     }
 
     // Subtexto: error_type, detected_at, resets_at — todos escapados.
@@ -4270,21 +4434,67 @@ if(__VIEW_BOOT.unknownViewRequested === true && typeof showToast === 'function')
 // El placeholder cuando está inactivo permite al cliente "morphar" el
 // banner cuando el polling lo active sin reload (CA-2 sigue cumpliéndose
 // porque el JS reemplaza el comentario con el banner pleno via DOM).
+// #4731 — Mapas de presentación del banner por-proveedor (compartidos SSR).
+// El nombre y el label se resuelven POR ID/ERROR_TYPE allowlisteado; el color
+// se elige por el atributo `data-provider` (CSS), NUNCA inyectando el valor
+// crudo en style/class (CA-6 / A03). Todo string dinámico pasa por escape.
+const QUOTA_PROVIDER_NAMES = {
+    'anthropic': 'Anthropic',
+    'openai-codex': 'Codex',
+    'openai': 'OpenAI',
+    'cerebras': 'Cerebras',
+    'gemini-google': 'Gemini',
+    'gemini': 'Gemini',
+    'groq': 'Groq',
+    'nvidia-nim': 'NVIDIA',
+};
+// Ids con regla CSS `[data-provider]` (acento/chip). Fuera de esta allowlist se
+// usa el estilo `unknown` y NO se emite el id crudo como data-provider.
+const QUOTA_PROVIDER_TOKENS = new Set([
+    'anthropic', 'openai-codex', 'cerebras', 'gemini-google', 'nvidia-nim', 'groq',
+]);
+const QUOTA_REASON_LABELS = {
+    'usage_limit_reached': 'límite de uso del plan',
+    'usage_limit_error': 'cuota agotada',
+    'weekly_quota_exhausted': 'cuota semanal agotada',
+    'snapshot_threshold_90': 'cuota casi agotada',
+    'insufficient_quota': 'cuota agotada',
+    'billing_hard_limit_reached': 'cuota agotada',
+    'tokens_exhausted': 'cuota agotada',
+    'quota_exceeded': 'cuota agotada',
+    'quota_exhausted': 'cuota agotada',
+    'resource_exhausted': 'cuota agotada',
+    'rate_limit': 'rate limit temporal',
+    'rate_limit_exceeded': 'rate limit temporal',
+    'schedule_rest': 'reposo horario',
+};
+function quotaProviderName(id) {
+    return QUOTA_PROVIDER_NAMES[id] || 'proveedor';
+}
+function quotaProviderTokenAttr(id) {
+    return QUOTA_PROVIDER_TOKENS.has(id) ? id : 'unknown';
+}
+function quotaReasonLabel(errType) {
+    return QUOTA_REASON_LABELS[errType] || 'degradado';
+}
+
 function renderQuotaBannerSsr(quotaState) {
     if (!quotaState || !quotaState.active) {
-        // Skeleton sin "cuota Anthropic" en texto. El cliente lo llena con
-        // setText() cuando el flag se activa en un poll posterior. CA-14:
-        // grep "cuota Anthropic" sobre el HTML inactivo NO debe matchear.
-        // Mantener los IDs es necesario para que setText/setAttr del cliente
-        // muten el banner sin recrear DOM (anti-flicker).
+        // Skeleton SIN nombres de proveedor ni copy del banner en el texto. El
+        // cliente lo llena con setText() cuando el flag se activa en un poll
+        // posterior. CA-14: `curl / | grep` de un nombre de proveedor sobre el
+        // HTML inactivo NO debe matchear (los nombres sólo aparecen con flag
+        // activo). Mantener los IDs para que el cliente mute sin recrear DOM.
         return `
-  <section class="quota-exhausted-banner" id="quota-exhausted-banner" role="status" aria-live="polite" aria-hidden="true" data-active="false">
+  <section class="quota-exhausted-banner" id="quota-exhausted-banner" role="status" aria-live="polite" aria-hidden="true" data-active="false" data-scope="partial">
     <div class="quota-exhausted-icon" aria-hidden="true">
       <svg viewBox="0 0 24 24" role="img"><use href="/assets/icons/sprite.svg#ic-quota-exhausted"></use></svg>
     </div>
     <div class="quota-exhausted-content">
       <div class="quota-exhausted-title" id="quota-exhausted-title"></div>
       <div class="quota-exhausted-sub" id="quota-exhausted-sub"></div>
+      <div class="quota-exhausted-providers" id="quota-exhausted-providers"></div>
+      <div class="quota-health-strip" id="quota-exhausted-health" data-empty="true"></div>
       <div class="quota-exhausted-panels" id="quota-exhausted-panels">
         <div class="quota-exhausted-panel det">
           <span class="quota-exhausted-panel-label">Det.</span>
@@ -4304,28 +4514,86 @@ function renderQuotaBannerSsr(quotaState) {
     </div>
   </section>`;
     }
-    // Datos provistos por el slice (error_type/detected_at/resets_at) usan
-    // escapeHtmlAttr — superset de escapeHtmlText que además neutraliza comillas
-    // (`"` → &quot;, `'` → &#39;). Defensa en profundidad contra timestamps/tipos
-    // manipulados con caracteres HTML, contrato fijado por el test CA-10
-    // (dashboard-quota-exhausted.test.js). Restaura el comportamiento del antiguo
-    // escapeHtmlSsr inline tras la migración a lib/escape-html.js (#3722).
+
+    // #4731 — Estado por-proveedor. `providers` = afectados; `scope` decide la
+    // paleta. Fail-safe hacia 'partial' (nunca falso "global"): si el slice no
+    // aporta scope, asumimos degradación puntual. Backward-compat: un flag sin
+    // `providers` (legacy) se sintetiza como un único afectado `anthropic`.
+    let affected = Array.isArray(quotaState.providers) ? quotaState.providers.slice() : [];
+    if (affected.length === 0 && quotaState.error_type) {
+        affected = [{
+            id: 'anthropic',
+            error_type: quotaState.error_type,
+            resets_at: quotaState.resets_at,
+            resets_at_ms: quotaState.resets_at_ms,
+            detected_at: quotaState.detected_at,
+        }];
+    }
+    const scope = quotaState.scope === 'global' ? 'global' : 'partial';
+    const operational = Array.isArray(quotaState.operational) ? quotaState.operational : [];
+    const operationalCount = Number.isFinite(quotaState.operationalCount)
+        ? quotaState.operationalCount : operational.length;
+
+    // Título dinámico (reemplaza el string hardcodeado "cuota Anthropic").
+    let title;
+    if (scope === 'global') {
+        title = 'Modo determinístico — sin proveedores LLM disponibles.';
+    } else if (affected.length === 1) {
+        title = 'Proveedor ' + quotaProviderName(affected[0].id) + ' degradado — '
+            + quotaReasonLabel(affected[0].error_type) + '.';
+    } else {
+        title = affected.length + ' proveedores degradados — ' + operationalCount + ' operativos.';
+    }
+    const titleHtml = escapeHtmlText(title);
+
+    // data-provider del contenedor: sólo en puntual con 1 afectado allowlisteado.
+    const singleTokenAttr = (scope === 'partial' && affected.length === 1)
+        ? quotaProviderTokenAttr(affected[0].id) : '';
+    const providerAttr = singleTokenAttr ? ` data-provider="${escapeHtmlAttr(singleTokenAttr)}"` : '';
+
+    // Chips por proveedor afectado (habilitan el CA plural).
+    const chipsHtml = affected.map((p) => {
+        const tokenAttr = escapeHtmlAttr(quotaProviderTokenAttr(p.id));
+        const name = escapeHtmlText(quotaProviderName(p.id));
+        const reason = escapeHtmlText(quotaReasonLabel(p.error_type));
+        const reset = escapeHtmlText(fmtHHMMLocalSsr(p.resets_at));
+        return '<span class="quota-provider-chip" data-provider="' + tokenAttr + '">'
+            + '<span class="quota-provider-dot" aria-hidden="true"></span>'
+            + '<span class="quota-provider-name">' + name + '</span>'
+            + '<span class="quota-provider-reason">' + reason + '</span>'
+            + '<span class="quota-provider-reset">↻ ' + reset + '</span>'
+            + '</span>';
+    }).join('');
+
+    // Health strip: "N operativos:" + nombres (evidencia de "no global", CA-2).
+    const showHealth = scope === 'partial' && operationalCount > 0;
+    const healthItems = showHealth
+        ? operational.map((id) => '<span class="quota-health-item"><span class="quota-health-dot" aria-hidden="true"></span>'
+            + escapeHtmlText(quotaProviderName(id)) + '</span>').join('')
+        : '';
+    const healthHtml = showHealth
+        ? ('<span class="quota-health-label">' + operationalCount + ' operativos:</span>' + healthItems)
+        : '';
+    const healthEmptyAttr = showHealth ? 'false' : 'true';
+
+    // Sub (compat + debug): tipo/detectado/reset del slot primario, escapados.
     const errorType = escapeHtmlAttr(quotaState.error_type || 'usage_limit_error');
     const detectedAt = escapeHtmlAttr(quotaState.detected_at || '');
     const resetsAt = escapeHtmlAttr(quotaState.resets_at || '');
-    const hhmm = escapeHtmlText(fmtHHMMLocalSsr(quotaState.resets_at));
     const remainingMs = Math.max(0, (quotaState.resets_at_ms || 0) - Date.now());
     const inText = escapeHtmlText(fmtCountdownSsr(remainingMs));
     return `
-  <section class="quota-exhausted-banner" id="quota-exhausted-banner" role="status" aria-live="polite" aria-hidden="false" data-active="true">
+  <section class="quota-exhausted-banner" id="quota-exhausted-banner" role="status" aria-live="polite" aria-hidden="false" data-active="true" data-scope="${escapeHtmlAttr(scope)}"${providerAttr}>
     <div class="quota-exhausted-icon" aria-hidden="true">
       <svg viewBox="0 0 24 24" role="img" aria-label="reloj de arena">
         <use href="/assets/icons/sprite.svg#ic-quota-exhausted"></use>
       </svg>
     </div>
     <div class="quota-exhausted-content">
-      <div class="quota-exhausted-title" id="quota-exhausted-title">Modo determinístico — cuota Anthropic agotada. Reset ${hhmm} (en ${inText}).</div>
+      <div class="quota-exhausted-title" id="quota-exhausted-title">${titleHtml}</div>
       <div class="quota-exhausted-sub" id="quota-exhausted-sub">Tipo: ${errorType} · Detectado: ${detectedAt} · Reset: ${resetsAt}</div>
+      <div class="quota-exhausted-providers" id="quota-exhausted-providers">${chipsHtml}</div>
+      <div class="quota-health-strip" id="quota-exhausted-health" data-empty="${healthEmptyAttr}">${healthHtml}</div>
       <div class="quota-exhausted-panels" id="quota-exhausted-panels">
         <div class="quota-exhausted-panel det">
           <span class="quota-exhausted-panel-label">Determinísticos</span>

--- a/fixtures/demo/run-cycle.js
+++ b/fixtures/demo/run-cycle.js
@@ -276,9 +276,22 @@ function bootstrap(targetDir) {
   // Instalación reproducible y verificada: `npm ci` (NUNCA `npm install`).
   // Comando constante (sin interpolación de input) — en Windows `execSync`
   // resuelve `npm.cmd` vía el shell del sistema sin el DEP0190 de execFile+args.
+  // `npm` (npm.cmd en Windows) vive SIEMPRE junto a `node` (process.execPath),
+  // pero el shell del sistema sólo lo encuentra si ese dir está en el PATH. En
+  // entornos de spawn con PATH mínimo (p.ej. el runner del tester) node existe
+  // pero npm no está en el PATH → `npm ci` falla con "no se reconoce como
+  // comando". Prependeamos el dir de node al PATH para resolver npm de forma
+  // determinística e independiente del PATH del proceso que invoca.
+  const nodeDir = path.dirname(process.execPath);
+  const pathSep = process.platform === 'win32' ? ';' : ':';
+  const env = {
+    ...process.env,
+    PATH: `${nodeDir}${pathSep}${process.env.PATH || ''}`,
+  };
   const out = execSync('npm ci --no-audit --no-fund', {
     cwd: targetDir,
     stdio: 'pipe',
+    env,
   })
     .toString()
     .trim();


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 11 archivos · +1606 -203

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:passed` aplicado por delivery

## Closes

Closes #4731
