### PR TITLE
[Split de #4689] Supervisor de instancias: registro + spawn aislado por producto

### DIFF
--- a/.pipeline/assets/docs/4762/security-verificacion-4762.md
+++ b/.pipeline/assets/docs/4762/security-verificacion-4762.md
@@ -1,0 +1,79 @@
+## Reporte de auditoría de seguridad — issue #4762
+
+**Veredicto:** sin hallazgos
+
+**Alcance auditado:** rama `agent/4762-pipeline-dev` @ commit `ab6c503` vs `origin/main`.
+Diff = 2 archivos nuevos (785 líneas):
+- `.pipeline/lib/kernel-supervisor.js` (345 L) — supervisor de instancias multi-tenant.
+- `.pipeline/lib/__tests__/kernel-supervisor.test.js` (440 L) — suite `node --test`.
+
+Esta pieza (Ola Puente P4, split 1/3 de #4689) es una **frontera de confianza**:
+aislamiento fuerte por `projectId` de N pipelines en el mismo proceso. La auditoría
+se centró en las 6 requisitos obligatorios de seguridad definidos en la fase de
+análisis + el mapa OWASP 2021.
+
+### Hallazgos
+
+**Sin hallazgos.** Ningún defecto de seguridad explotable. Todos los requisitos
+obligatorios verificados empíricamente:
+
+- **[OWASP A01 · Broken Access Control]** `kernel-supervisor.js:108` — `contextProjectId`
+  derivado del registro (out-of-band), nunca de input en banda.
+  - **Vector (criollo):** si el supervisor tomara el id del tenant desde un dato que
+    viaja "en la petición", un producto podría pedir el id de otro y leerle los datos.
+    Acá el id sale siempre del catálogo de productos, no de input manipulable.
+  - **Estado:** correcto. Defensa en profundidad en `kernel-supervisor.js:115`: si el
+    factory devolviera un store ligado a otra partición, lanza `KernelStoreIsolationError`
+    antes de usarlo. Test "CA-2/A01" verde: store de A rechaza `getDescriptor('globex')`.
+
+- **[OWASP A03/A08 · Injection / Path-traversal]** `kernel-supervisor.js:183,204,234,299`
+  — `isSafeId()` fail-closed sobre todo id antes de derivar path/spawn.
+  - **Vector (criollo):** si un id de producto como `../../etc/passwd` se metiera crudo
+    en una ruta de archivo o en un comando, un atacante escaparía de su carpeta o
+    ejecutaría comandos. Acá cada id pasa por `isSafeId`, que rechaza `..`, `/`, `\` y
+    caracteres raros ANTES de tocarlo.
+  - **Estado:** correcto. Verificado empíricamente: `isSafeId` devuelve `false` para
+    `../evil`, `a/b`, `../../etc/passwd`, `$(rm -rf)`, `null`, `''`. No hay
+    `child_process`/`exec` nativo: el `spawn` es dependencia inyectada, sin superficie
+    de command-injection en el módulo.
+
+- **[OWASP A01/A04 · Insecure Design · fuga de estado efímero]** `kernel-supervisor.js:122-137`
+  — todo estado efímero (cooldowns, offsets, circuit-breaker, rebotes) en
+  `instanceContext` propio por `projectId`.
+  - **Vector (criollo):** el riesgo real de esta pieza. Si los cooldowns/contadores se
+    guardaran en variables globales o en un archivo único (como hace hoy `pulpo.js` con
+    `cooldowns.json`), el estado de un producto sería visible/mutable por otro.
+  - **Estado:** correcto. Grep estático: CERO `globalThis`, CERO `let`/`var` de módulo
+    para estado, CERO `writeFile`/`cooldowns.json` (únicas coincidencias = comentarios).
+    Tests A05 verdes: efímeros de A no observables desde B; dos supervisores no comparten
+    Map de módulo.
+
+- **[OWASP A04 · Fault isolation / DoS cruzado]** `kernel-supervisor.js:220,298,146` —
+  spawn/restart/hydrate aislados por instancia.
+  - **Vector (criollo):** que el crash de un producto reinicie o tumbe a los demás.
+  - **Estado:** correcto. `restartInstance(A)` recrea solo el ctx de A; `safeSpawn` y
+    `hydrateInstance` capturan errores sin propagar. Tests verdes: descriptor corrupto
+    de A no aborta el boot de B; restart de A no toca a B.
+
+- **[OWASP A09 · Security Logging]** `kernel-supervisor.js:159,185,227,270` — rechazos
+  fail-closed propagados por `onAlert` con `projectId` de origen, sin filtrar payload
+  del tenant víctima. Correcto.
+
+- **Secrets:** grep de patrones (AKIA/token/password/api-key/Bearer) → sin coincidencias.
+  Ningún secret hardcodeado.
+
+### Gate de seguridad de la pieza
+
+Los tests A01 (`projectId` manipulado → `KernelStoreIsolationError`) y A05 (efímeros de
+A no observables desde B) son el gate de seguridad definido en análisis. **Ambos verdes.**
+Suite completa: `node --test` → 23/23 pass. Cobertura de `kernel-supervisor.js`:
+100% líneas / 86.21% branch / 84.21% funcs (≥80% exigido).
+
+### Requisitos obligatorios (checklist de análisis) — todos CUMPLIDOS
+
+1. Un store inmutable por instancia, `contextProjectId` derivado, handle no compartido ✓
+2. Cero estado efímero global compartido ✓
+3. Solo instancias `status === "active"` ✓ (`kernel-supervisor.js:178`)
+4. Validación de id fail-closed con `isSafeId` ✓
+5. Tests adversariales A01 + A05 verdes + cobertura ≥80% ✓
+6. Sin secrets hardcodeados ✓

--- a/.pipeline/deliverables/4762.json
+++ b/.pipeline/deliverables/4762.json
@@ -1,0 +1,15 @@
+{
+  "issue": 4762,
+  "entries": [
+    {
+      "issue": 4762,
+      "fase": "verificacion",
+      "agente": "security",
+      "tipo": "document",
+      "path": ".pipeline/assets/docs/4762/security-verificacion-4762.md",
+      "bytes": 4599,
+      "sensible": true,
+      "timestamp": "2026-07-18T04:50:52.359Z"
+    }
+  ]
+}

--- a/.pipeline/lib/__tests__/kernel-supervisor.test.js
+++ b/.pipeline/lib/__tests__/kernel-supervisor.test.js
@@ -1,0 +1,440 @@
+'use strict';
+
+// =============================================================================
+// kernel-supervisor.test.js — Tests del supervisor de instancias (Ola Puente P4 · #4762)
+//
+// Mapea los criterios de aceptación del issue #4762 (con la store in-memory real,
+// offline):
+//   CA-1  bootProducts() instancia EXACTAMENTE UNO por producto `active`;
+//         onboarding/archived NO se instancian; A no pisa B.
+//   CA-2  Aislamiento durable + efímero por projectId:
+//           A01 · projectId manipulado → KernelStoreIsolationError (fail-closed).
+//           A05 · efímeros de A (cooldowns/offsets/circuit-breaker/rebotes) no
+//                 observables ni mutables desde B; cero estado de módulo compartido.
+//   CA-3  Aislamiento de fallo/reinicio: restartInstance(A) no toca a B.
+//   CA-4  Validación de id fail-closed (isSafeId) anti path-traversal / injection.
+//   CA-5  Suite node --test verde + cobertura ≥ 80%.
+// =============================================================================
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { createInMemoryDynamoDriver } = require('../provisioner-infra');
+const { createKernelStore, KernelStoreIsolationError } = require('../kernel-store');
+const { createKernelSupervisor, resolveProjectId } = require('../kernel-supervisor');
+
+// -----------------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------------
+
+// Store fake mínimo que sólo expone listProducts() (rol de catálogo/control-plane).
+function fakeCatalogStore(products) {
+  return { listProducts: async () => products.slice() };
+}
+
+// storeFactory fake: crea un store in-memory REAL por projectId (aislamiento
+// durable garantizado por kernel-store). Cada llamada obtiene su propio driver,
+// de modo que las particiones no se comparten a nivel de driver tampoco.
+function realStoreFactory(opts) {
+  return createKernelStore({
+    driver: createInMemoryDynamoDriver(),
+    contextProjectId: opts.contextProjectId,
+    allowedNamespaces: opts.allowedNamespaces,
+    onAlert: opts.onAlert,
+  });
+}
+
+// storeFactory fake que registra las llamadas y devuelve un handle liviano.
+function recordingStoreFactory(calls) {
+  return (opts) => {
+    calls.push(opts);
+    return { contextProjectId: opts.contextProjectId, getDescriptor: async () => null };
+  };
+}
+
+const CATALOG_MIXTO = [
+  { productId: 'acme', projectId: 'acme', name: 'ACME', status: 'active' },
+  { productId: 'globex', projectId: 'globex', name: 'Globex', status: 'active' },
+  { productId: 'initech', projectId: 'initech', name: 'Initech', status: 'onboarding' },
+  { productId: 'umbrella', projectId: 'umbrella', name: 'Umbrella', status: 'archived' },
+];
+
+// -----------------------------------------------------------------------------
+// CA-1 · Registro de productos e instanciación exacta
+// -----------------------------------------------------------------------------
+
+test('CA-1 · bootProducts instancia exactamente uno por producto active y omite inactivos', async () => {
+  const calls = [];
+  const supervisor = createKernelSupervisor({
+    catalogStore: fakeCatalogStore(CATALOG_MIXTO),
+    storeFactory: recordingStoreFactory(calls),
+    hydrate: false,
+  });
+
+  const res = await supervisor.bootProducts();
+
+  assert.deepEqual(res.spawned.sort(), ['acme', 'globex']);
+  assert.equal(supervisor.listInstances().length, 2, 'solo 2 activos instanciados');
+  assert.ok(supervisor.getInstance('acme'), 'acme instanciado');
+  assert.ok(supervisor.getInstance('globex'), 'globex instanciado');
+  assert.equal(supervisor.getInstance('initech'), null, 'onboarding NO instanciado');
+  assert.equal(supervisor.getInstance('umbrella'), null, 'archived NO instanciado');
+  // cada instancia activa ligó su store a su propio projectId
+  assert.deepEqual(calls.map((c) => c.contextProjectId).sort(), ['acme', 'globex']);
+  assert.deepEqual(calls.find((c) => c.contextProjectId === 'acme').allowedNamespaces, ['acme']);
+});
+
+test('CA-1 · spawnInstance es idempotente: exactamente una instancia por projectId', async () => {
+  const supervisor = createKernelSupervisor({
+    catalogStore: fakeCatalogStore([]),
+    storeFactory: recordingStoreFactory([]),
+    hydrate: false,
+  });
+  const a1 = supervisor.spawnInstance({ productId: 'acme', projectId: 'acme', status: 'active' });
+  const a2 = supervisor.spawnInstance({ productId: 'acme', projectId: 'acme', status: 'active' });
+  assert.equal(a1, a2, 'devuelve la MISMA instancia (no duplica)');
+  assert.equal(supervisor.listInstances().length, 1);
+});
+
+test('CA-1 · A no pisa B: escrituras durables en A no son visibles en B', async () => {
+  const supervisor = createKernelSupervisor({
+    catalogStore: fakeCatalogStore(CATALOG_MIXTO),
+    storeFactory: realStoreFactory,
+    hydrate: false,
+  });
+  await supervisor.bootProducts();
+  const a = supervisor.getInstance('acme');
+  const b = supervisor.getInstance('globex');
+
+  await a.store.putProduct({ productId: 'secret-a', name: 'Secreto de A', status: 'active' });
+  const listedInA = await a.store.listProducts();
+  const listedInB = await b.store.listProducts();
+
+  assert.ok(listedInA.some((p) => p.productId === 'secret-a'), 'A ve su propio dato');
+  assert.ok(!listedInB.some((p) => p.productId === 'secret-a'), 'B NO ve el dato de A');
+});
+
+// -----------------------------------------------------------------------------
+// CA-2 · A01 · projectId manipulado → falla cerrado
+// -----------------------------------------------------------------------------
+
+test('CA-2/A01 · store de A rechaza operar la partición de B (KernelStoreIsolationError)', async () => {
+  const supervisor = createKernelSupervisor({
+    catalogStore: fakeCatalogStore(CATALOG_MIXTO),
+    storeFactory: realStoreFactory,
+    hydrate: false,
+  });
+  await supervisor.bootProducts();
+  const a = supervisor.getInstance('acme');
+
+  // A intenta leer el descriptor de B con un projectId manipulado in-band.
+  await assert.rejects(
+    () => a.store.getDescriptor('globex'),
+    (err) => err instanceof KernelStoreIsolationError,
+    'falla cerrado sin fuga de datos de B',
+  );
+  // el store de A quedó ligado inmutablemente a 'acme'
+  assert.equal(a.store.contextProjectId, 'acme');
+});
+
+test('CA-2/A01 · buildInstance falla cerrado si el factory devuelve un store de otra partición', () => {
+  const supervisor = createKernelSupervisor({
+    catalogStore: fakeCatalogStore([]),
+    // factory malicioso/roto: devuelve un handle ligado a OTRO projectId
+    storeFactory: () => ({ contextProjectId: 'otro-tenant', getDescriptor: async () => null }),
+    hydrate: false,
+  });
+  assert.throws(
+    () => supervisor.spawnInstance({ productId: 'acme', projectId: 'acme', status: 'active' }),
+    (err) => err instanceof KernelStoreIsolationError,
+  );
+});
+
+// -----------------------------------------------------------------------------
+// CA-2 · A05 · efímeros de A no observables desde B
+// -----------------------------------------------------------------------------
+
+test('CA-2/A05 · estado efímero de A (cooldowns/offsets/circuit-breaker) no observable ni mutable desde B', async () => {
+  const supervisor = createKernelSupervisor({
+    catalogStore: fakeCatalogStore(CATALOG_MIXTO),
+    storeFactory: recordingStoreFactory([]),
+    hydrate: false,
+  });
+  await supervisor.bootProducts();
+  const a = supervisor.getInstance('acme');
+  const b = supervisor.getInstance('globex');
+
+  // A setea todo su estado efímero
+  a.cooldowns.set('dev', 12345);
+  a.intakeOffsets.set('repo/main', 99);
+  a.circuitBreaker.rebotes.set('issue-1', 3);
+
+  // B tiene su propio estado efímero, aislado y vacío
+  assert.equal(b.cooldowns.size, 0, 'cooldowns de B vacíos');
+  assert.equal(b.intakeOffsets.size, 0, 'offsets de B vacíos');
+  assert.equal(b.circuitBreaker.rebotes.size, 0, 'circuit-breaker de B vacío');
+
+  // los Maps no son el mismo objeto (no hay handle compartido)
+  assert.notEqual(a.cooldowns, b.cooldowns);
+  assert.notEqual(a.circuitBreaker.rebotes, b.circuitBreaker.rebotes);
+
+  // mutar B no toca A
+  b.cooldowns.set('dev', 1);
+  assert.equal(a.cooldowns.get('dev'), 12345, 'A intacto tras mutar B');
+});
+
+test('CA-2/A05 · dos supervisores NO comparten estado de módulo (mismo projectId, ctx distintos)', () => {
+  const sup1 = createKernelSupervisor({ catalogStore: fakeCatalogStore([]), storeFactory: recordingStoreFactory([]), hydrate: false });
+  const sup2 = createKernelSupervisor({ catalogStore: fakeCatalogStore([]), storeFactory: recordingStoreFactory([]), hydrate: false });
+
+  const a1 = sup1.spawnInstance({ productId: 'acme', projectId: 'acme', status: 'active' });
+  const a2 = sup2.spawnInstance({ productId: 'acme', projectId: 'acme', status: 'active' });
+
+  a1.cooldowns.set('dev', 111);
+  assert.notEqual(a1, a2, 'instancias de supervisores distintos son objetos distintos');
+  assert.equal(a2.cooldowns.size, 0, 'el efímero de sup1 no aparece en sup2 (no hay Map de módulo)');
+});
+
+// -----------------------------------------------------------------------------
+// CA-3 · Aislamiento de fallo / reinicio
+// -----------------------------------------------------------------------------
+
+test('CA-3 · restartInstance(A) recrea sólo A y no altera el estado de B', async () => {
+  const stopped = [];
+  const supervisor = createKernelSupervisor({
+    catalogStore: fakeCatalogStore(CATALOG_MIXTO),
+    storeFactory: recordingStoreFactory([]),
+    stop: (ctx) => stopped.push(ctx.projectId),
+    hydrate: false,
+  });
+  await supervisor.bootProducts();
+  const aOld = supervisor.getInstance('acme');
+  const b = supervisor.getInstance('globex');
+  aOld.cooldowns.set('dev', 500);
+  b.cooldowns.set('dev', 700);
+
+  const aNew = supervisor.restartInstance('acme');
+
+  assert.notEqual(aNew, aOld, 'A fue recreada (ctx nuevo)');
+  assert.equal(aNew.health.restarts, 1, 'contador de restarts preservado/incrementado');
+  assert.equal(aNew.cooldowns.size, 0, 'estado efímero de A reseteado');
+  assert.deepEqual(stopped, ['acme'], 'sólo se detuvo A');
+  // B intacto
+  assert.equal(supervisor.getInstance('globex'), b, 'B es la MISMA instancia');
+  assert.equal(b.cooldowns.get('dev'), 700, 'estado efímero de B intacto');
+});
+
+test('CA-3 · restartInstance sobre projectId inexistente devuelve null', () => {
+  const supervisor = createKernelSupervisor({ catalogStore: fakeCatalogStore([]), storeFactory: recordingStoreFactory([]), hydrate: false });
+  assert.equal(supervisor.restartInstance('nadie'), null);
+});
+
+test('CA-3 · healthcheck con autoRestart reinicia sólo las instancias caídas', async () => {
+  let health = { acme: true, globex: true };
+  const supervisor = createKernelSupervisor({
+    catalogStore: fakeCatalogStore(CATALOG_MIXTO),
+    storeFactory: recordingStoreFactory([]),
+    healthProbe: (ctx) => health[ctx.projectId],
+    hydrate: false,
+  });
+  await supervisor.bootProducts();
+
+  // A cae, B sigue viva
+  health.acme = false;
+  const report = supervisor.healthcheck({ autoRestart: true });
+
+  assert.equal(report.acme.restarted, true, 'A reiniciada');
+  assert.equal(report.acme.restarts, 1);
+  assert.notEqual(report.globex.restarted, true, 'B no reiniciada');
+  assert.equal(report.globex.restarts, 0, 'B sin restarts');
+});
+
+test('CA-3 · markInstanceUnhealthy marca A caída sin tocar B', async () => {
+  const alerts = [];
+  const supervisor = createKernelSupervisor({
+    catalogStore: fakeCatalogStore(CATALOG_MIXTO),
+    storeFactory: recordingStoreFactory([]),
+    onAlert: (a) => alerts.push(a),
+    hydrate: false,
+  });
+  await supervisor.bootProducts();
+
+  assert.equal(supervisor.markInstanceUnhealthy('acme', new Error('boom')), true);
+  assert.equal(supervisor.getInstance('acme').health.alive, false);
+  assert.equal(supervisor.getInstance('globex').health.alive, true, 'B sigue viva');
+  assert.equal(supervisor.markInstanceUnhealthy('nadie'), false, 'inexistente → false');
+  assert.ok(alerts.some((a) => a.stage === 'crash'), 'A09: crash alertado');
+});
+
+test('CA-3 · superviseInstance actualiza salud vía probe y aísla el fallo del probe', async () => {
+  const supervisor = createKernelSupervisor({
+    catalogStore: fakeCatalogStore(CATALOG_MIXTO),
+    storeFactory: recordingStoreFactory([]),
+    healthProbe: (ctx) => { if (ctx.projectId === 'acme') throw new Error('probe roto'); return true; },
+    hydrate: false,
+  });
+  await supervisor.bootProducts();
+  const snapA = supervisor.superviseInstance('acme');
+  const snapB = supervisor.superviseInstance('globex');
+  assert.equal(snapA.alive, false, 'probe que lanza → caída fail-closed');
+  assert.equal(snapB.alive, true, 'B sana');
+  assert.equal(supervisor.superviseInstance('nadie'), null);
+});
+
+// -----------------------------------------------------------------------------
+// CA-4 · Validación de id fail-closed (anti path-traversal / injection)
+// -----------------------------------------------------------------------------
+
+test('CA-4 · bootProducts descarta projectId inseguro sin abortar el resto', async () => {
+  const alerts = [];
+  const catalog = [
+    { productId: '../evil', projectId: '../evil', name: 'Path traversal', status: 'active' },
+    { productId: 'a/b', projectId: 'a/b', name: 'Slash', status: 'active' },
+    { productId: 'goodco', projectId: 'goodco', name: 'OK', status: 'active' },
+  ];
+  const supervisor = createKernelSupervisor({
+    catalogStore: fakeCatalogStore(catalog),
+    storeFactory: recordingStoreFactory([]),
+    onAlert: (a) => alerts.push(a),
+    hydrate: false,
+  });
+  const res = await supervisor.bootProducts();
+  assert.deepEqual(res.spawned, ['goodco'], 'sólo el id seguro se instancia');
+  assert.equal(res.skipped.filter((s) => s.reason === 'projectId inseguro').length, 2);
+  assert.ok(alerts.some((a) => a.stage === 'isSafeId'), 'A09: id inseguro alertado');
+});
+
+test('CA-4 · spawnInstance lanza fail-closed ante projectId inseguro', () => {
+  const supervisor = createKernelSupervisor({ catalogStore: fakeCatalogStore([]), storeFactory: recordingStoreFactory([]), hydrate: false });
+  assert.throws(
+    () => supervisor.spawnInstance({ productId: '../../etc/passwd', projectId: '../../etc/passwd', status: 'active' }),
+    (err) => err instanceof KernelStoreIsolationError,
+  );
+});
+
+test('CA-4 · getInstance/restartInstance fail-closed sobre id inseguro', () => {
+  const supervisor = createKernelSupervisor({ catalogStore: fakeCatalogStore([]), storeFactory: recordingStoreFactory([]), hydrate: false });
+  assert.equal(supervisor.getInstance('bad/id'), null);
+  assert.throws(() => supervisor.restartInstance('bad/id'), (err) => err instanceof KernelStoreIsolationError);
+});
+
+// -----------------------------------------------------------------------------
+// Reuso de derivers + hidratación aislada (fault isolation en boot)
+// -----------------------------------------------------------------------------
+
+test('hydrate deriva routing/concurrencia/particiones del descriptor de la instancia', async () => {
+  const descByPid = {
+    acme: {
+      identity: { projectId: 'acme', name: 'ACME' },
+      board: { routing: [{ label: 'area:backend', capability: 'backend' }] },
+      thresholds: { concurrency: { 'backend-dev': 2 } },
+      capabilities: [{ interface: 'backend', skills: ['backend-dev'] }],
+    },
+  };
+  const storeFactory = (opts) => ({
+    contextProjectId: opts.contextProjectId,
+    getDescriptor: async () => {
+      const body = descByPid[opts.contextProjectId];
+      return body ? { body } : null;
+    },
+  });
+  const supervisor = createKernelSupervisor({
+    catalogStore: fakeCatalogStore([{ productId: 'acme', projectId: 'acme', name: 'ACME', status: 'active' }]),
+    storeFactory,
+    hydrate: true,
+  });
+  await supervisor.bootProducts();
+  const a = supervisor.getInstance('acme');
+  assert.equal(a.routing.get('area:backend'), 'backend');
+  assert.deepEqual(a.concurrency, { 'backend-dev': 2 });
+  assert.deepEqual(a.partitions, { backend: ['backend-dev'] });
+});
+
+test('hydrate aislado: descriptor corrupto de A no aborta el boot de B (A04)', async () => {
+  const alerts = [];
+  const storeFactory = (opts) => ({
+    contextProjectId: opts.contextProjectId,
+    getDescriptor: async () => {
+      if (opts.contextProjectId === 'acme') throw new Error('descriptor corrupto');
+      return { body: { identity: { projectId: opts.contextProjectId } } };
+    },
+  });
+  const supervisor = createKernelSupervisor({
+    catalogStore: fakeCatalogStore(CATALOG_MIXTO),
+    storeFactory,
+    onAlert: (a) => alerts.push(a),
+    hydrate: true,
+  });
+  const res = await supervisor.bootProducts();
+  assert.deepEqual(res.spawned.sort(), ['acme', 'globex'], 'ambos instanciados pese al fallo de hidratación de A');
+  assert.ok(supervisor.getInstance('acme').health.lastError, 'A registró su error de hidratación');
+  assert.ok(alerts.some((a) => a.stage === 'hydrate'), 'A09: fallo de hidratación alertado');
+});
+
+// -----------------------------------------------------------------------------
+// Lifecycle y guardas varias
+// -----------------------------------------------------------------------------
+
+test('spawn que lanza no tumba al supervisor (fault isolation A04)', () => {
+  const alerts = [];
+  const supervisor = createKernelSupervisor({
+    catalogStore: fakeCatalogStore([]),
+    storeFactory: recordingStoreFactory([]),
+    spawn: () => { throw new Error('spawn falló'); },
+    onAlert: (a) => alerts.push(a),
+    hydrate: false,
+  });
+  const ctx = supervisor.spawnInstance({ productId: 'acme', projectId: 'acme', status: 'active' });
+  assert.equal(ctx.handle, null);
+  assert.equal(ctx.health.alive, false);
+  assert.ok(alerts.some((a) => a.stage === 'spawn'));
+});
+
+test('spawn recibe el ctx propio y guarda el handle en la instancia', () => {
+  const handles = {};
+  const supervisor = createKernelSupervisor({
+    catalogStore: fakeCatalogStore([]),
+    storeFactory: recordingStoreFactory([]),
+    spawn: (ctx) => { handles[ctx.projectId] = { pid: ctx.projectId }; return handles[ctx.projectId]; },
+    hydrate: false,
+  });
+  const ctx = supervisor.spawnInstance({ productId: 'acme', projectId: 'acme', status: 'active' });
+  assert.equal(ctx.handle, handles.acme);
+});
+
+test('stopInstance detiene y remueve; inexistente → false', async () => {
+  const stopped = [];
+  const supervisor = createKernelSupervisor({
+    catalogStore: fakeCatalogStore(CATALOG_MIXTO),
+    storeFactory: recordingStoreFactory([]),
+    stop: (ctx) => stopped.push(ctx.projectId),
+    hydrate: false,
+  });
+  await supervisor.bootProducts();
+  assert.equal(supervisor.stopInstance('acme'), true);
+  assert.equal(supervisor.getInstance('acme'), null);
+  assert.deepEqual(stopped, ['acme']);
+  assert.equal(supervisor.stopInstance('acme'), false, 'ya removida → false');
+});
+
+test('bootProducts sin catalogStore válido lanza error claro', async () => {
+  const supervisor = createKernelSupervisor({ storeFactory: recordingStoreFactory([]), hydrate: false });
+  await assert.rejects(() => supervisor.bootProducts(), /catalogStore/);
+});
+
+test('bootProducts tolera catálogo no-array y productos nulos', async () => {
+  const supervisor = createKernelSupervisor({
+    catalogStore: { listProducts: async () => null },
+    storeFactory: recordingStoreFactory([]),
+    hydrate: false,
+  });
+  const res = await supervisor.bootProducts();
+  assert.deepEqual(res.spawned, []);
+});
+
+test('resolveProjectId: projectId explícito, fallback a productId, null si falta', () => {
+  assert.equal(resolveProjectId({ projectId: 'a', productId: 'b' }), 'a');
+  assert.equal(resolveProjectId({ productId: 'b' }), 'b');
+  assert.equal(resolveProjectId({}), null);
+  assert.equal(resolveProjectId(null), null);
+});

--- a/.pipeline/lib/kernel-supervisor.js
+++ b/.pipeline/lib/kernel-supervisor.js
@@ -1,0 +1,345 @@
+'use strict';
+
+// =============================================================================
+// kernel-supervisor.js — Capa supervisor de instancias (Ola Puente P4 · #4762)
+//
+// Split 1/3 de #4689. Este módulo es el CIMIENTO del modelo multi-producto: lee
+// el registro de productos y instancia + supervisa EXACTAMENTE UN pipeline por
+// producto `active`, con AISLAMIENTO FUERTE por `projectId` en dos superficies:
+//
+//   1. Durable (store DynamoDB): ya garantizado por `kernel-store.js`. El
+//      supervisor sólo liga UN `createKernelStore` inmutable por `projectId` y
+//      NUNCA re-liga ni comparte un handle entre instancias.
+//   2. Efímero (in-process): AQUÍ está el trabajo real de esta pieza. TODO el
+//      estado efímero (cooldowns, offsets de intake, circuit-breaker, contadores
+//      de rebote) vive en el `instanceContext` propio de cada instancia
+//      (closure/objeto ligado al `projectId`). CERO estado en `let` de módulo,
+//      CERO `globalThis`, CERO caché de módulo compartida, CERO archivo de estado
+//      sin namespace por tenant. `pulpo.js` hoy lo hace mal (globals `cooldowns`,
+//      `COOLDOWN_FILE` global, `activeProcesses` Map de módulo) — este módulo NO
+//      copia ese patrón (ver #4761 para la modularización de pulpo, no bloqueante).
+//
+// SEGURIDAD (mapa OWASP 2021 del análisis de seguridad de definición · #4762)
+//   A01  Broken Access Control: `contextProjectId` SIEMPRE derivado del registro
+//        (out-of-band), NUNCA de input en banda. Cruce de partición con
+//        `projectId` manipulado ⇒ `KernelStoreIsolationError` fail-closed (lo
+//        provee la store; el supervisor liga 1 store por partición).
+//   A03/A08  Injection / path-traversal: `isSafeId(id)` fail-closed sobre TODO id
+//        (projectId/productId) ANTES de derivar ruta de FS o argumento de spawn.
+//   A04  Insecure Design (fault isolation): healthcheck + `restartInstance`
+//        AISLADO recrea SÓLO el ctx afectado. El fallo de A nunca reinicia ni
+//        bloquea a B (sin DoS cruzado). Un descriptor corrupto de A no aborta el
+//        boot de B.
+//   A09  Security Logging: los rechazos fail-closed de la store se propagan por
+//        `onAlert` con `projectId` de origen (sin filtrar payload del tenant).
+//
+// El módulo es un FACTORY autocontenido: `createKernelSupervisor(deps)` con todo
+// el estado en el closure. No importa globals de pulpo ni escribe archivos de
+// estado sin namespace.
+// =============================================================================
+
+const { createKernelStore, KernelStoreIsolationError } = require('./kernel-store');
+const {
+  isSafeId,
+  deriveRouting,
+  deriveConcurrency,
+  deriveCapabilityPartitions,
+} = require('./project-descriptor');
+
+const ACTIVE_STATUS = 'active';
+
+/**
+ * Resuelve el `projectId` del tenant a partir de un registro de producto. Deriva
+ * SIEMPRE del registro (out-of-band), nunca de input en banda (A01). Acepta
+ * `projectId` explícito y cae a `productId` (convención cuando el registro no
+ * distingue ambos). El caller DEBE validar con `isSafeId` antes de usarlo.
+ */
+function resolveProjectId(product) {
+  if (!product || typeof product !== 'object') return null;
+  if (typeof product.projectId === 'string' && product.projectId) return product.projectId;
+  if (typeof product.productId === 'string' && product.productId) return product.productId;
+  return null;
+}
+
+/**
+ * Crea el supervisor de instancias del kernel.
+ *
+ * @param {object} deps
+ * @param {object}   deps.catalogStore        store de solo-lectura para `listProducts()`
+ *                                             (registro de productos del control-plane).
+ * @param {function} [deps.storeFactory]       factory de store por instancia
+ *                                             (default: `createKernelStore`). Recibe
+ *                                             `{ contextProjectId, allowedNamespaces, onAlert }`.
+ * @param {function} [deps.spawn]              lanza el pipeline aislado de la instancia;
+ *                                             recibe el `instanceContext`, devuelve un handle.
+ *                                             Default: no-op (parts 2/3 inyectan el real).
+ * @param {function} [deps.stop]               detiene el handle de una instancia (default: no-op).
+ * @param {function} [deps.healthProbe]        `(ctx) => boolean` probe de salud (default: alive).
+ * @param {boolean}  [deps.hydrate]            si carga el descriptor y deriva routing/concurrencia/
+ *                                             particiones al boot (default: true).
+ * @param {function} [deps.onAlert]            callback de alerta fail-closed (A09).
+ * @param {function} [deps.now]                fuente de tiempo (ms).
+ * @returns {object} API del supervisor.
+ */
+function createKernelSupervisor(deps = {}) {
+  const catalogStore = deps.catalogStore;
+  const storeFactory = typeof deps.storeFactory === 'function' ? deps.storeFactory : createKernelStore;
+  const spawnFn = typeof deps.spawn === 'function' ? deps.spawn : () => null;
+  const stopFn = typeof deps.stop === 'function' ? deps.stop : () => {};
+  const healthProbe = typeof deps.healthProbe === 'function' ? deps.healthProbe : () => true;
+  const hydrate = deps.hydrate !== false;
+  const onAlert = typeof deps.onAlert === 'function' ? deps.onAlert : () => {};
+  const now = typeof deps.now === 'function' ? deps.now : () => 0;
+
+  // Mapa PRIVADO del closure: projectId → instanceContext. Jamás expuesto por
+  // referencia; jamás a nivel módulo. Dos supervisores distintos tienen mapas
+  // distintos (A05: no hay estado compartido de módulo).
+  const instances = new Map();
+
+  // ---- construcción de una instancia aislada --------------------------------
+
+  /**
+   * Construye el `instanceContext` de un producto: liga UN store inmutable a su
+   * `projectId` y crea su estado efímero PROPIO. Nunca comparte ni re-liga
+   * handles ni Maps con otra instancia.
+   */
+  function buildInstance(product, projectId) {
+    const store = storeFactory({
+      contextProjectId: projectId,      // SIEMPRE del registro, nunca en banda (A01)
+      allowedNamespaces: [projectId],
+      onAlert,                          // A09: rechazos fail-closed de la store se loguean
+    });
+
+    // Defensa en profundidad: el store DEBE quedar ligado a ESTE projectId. Si el
+    // factory devolviera un handle de otra partición, fallamos cerrado antes de usarlo.
+    if (store && store.contextProjectId && store.contextProjectId !== projectId) {
+      throw new KernelStoreIsolationError(
+        `aislamiento A01: el store devuelto por el factory no coincide con "${projectId}"`,
+        { requested: projectId, context: store.contextProjectId },
+      );
+    }
+
+    return {
+      projectId,
+      product,
+      store,                            // handle inmutable — jamás re-ligado a otro projectId
+      // --- estado EFÍMERO propio de la instancia (A05: nunca global/módulo) ---
+      cooldowns: new Map(),             // no archivo global ni let de módulo
+      intakeOffsets: new Map(),
+      circuitBreaker: { rebotes: new Map() },
+      // --- config derivada del descriptor (reuso de derivers, opcional) -------
+      routing: null,
+      concurrency: null,
+      partitions: null,
+      // --- lifecycle ----------------------------------------------------------
+      handle: null,
+      health: { alive: true, restarts: 0, lastError: null },
+    };
+  }
+
+  /**
+   * Hidrata la config derivada del descriptor de la instancia (routing,
+   * concurrencia, particiones de capability). Best-effort y AISLADO: un descriptor
+   * ausente o corrupto de una instancia NO rompe a las demás (A04 · fault
+   * isolation). Reusa los derivers de `project-descriptor.js` sin cambiar firma.
+   */
+  async function hydrateInstance(ctx) {
+    if (!hydrate) return;
+    try {
+      const desc = await ctx.store.getDescriptor(ctx.projectId);
+      const body = desc && desc.body;
+      if (body) {
+        ctx.routing = deriveRouting(body);
+        ctx.concurrency = deriveConcurrency(body);
+        ctx.partitions = deriveCapabilityPartitions(body);
+      }
+    } catch (err) {
+      // El fallo de hidratación de A no degrada a B: se registra y se sigue.
+      ctx.health.lastError = err && err.message ? err.message : String(err);
+      onAlert({ projectId: ctx.projectId, stage: 'hydrate', errors: [{ detail: ctx.health.lastError }] });
+    }
+  }
+
+  // ---- API pública -----------------------------------------------------------
+
+  /**
+   * CA-1 · Instancia EXACTAMENTE UN pipeline por producto `active`. Los productos
+   * `onboarding`/`archived` NO obtienen instancia ni store (reduce superficie). Un
+   * `projectId` inseguro se descarta fail-closed (A03/A08) sin abortar el resto.
+   */
+  async function bootProducts() {
+    if (!catalogStore || typeof catalogStore.listProducts !== 'function') {
+      throw new Error('bootProducts requiere un catalogStore con listProducts()');
+    }
+    const products = await catalogStore.listProducts();
+    const spawned = [];
+    const skipped = [];
+    for (const p of Array.isArray(products) ? products : []) {
+      if (!p || p.status !== ACTIVE_STATUS) {
+        skipped.push({ projectId: resolveProjectId(p), reason: 'inactivo' });
+        continue;
+      }
+      const projectId = resolveProjectId(p);
+      if (!isSafeId(projectId)) {                 // fail-closed antes de usar en path/spawn
+        skipped.push({ projectId: projectId == null ? null : String(projectId), reason: 'projectId inseguro' });
+        onAlert({ projectId: null, stage: 'isSafeId', errors: [{ detail: `projectId inseguro descartado: ${String(projectId)}` }] });
+        continue;
+      }
+      const ctx = spawnInstance(p);
+      if (ctx) {
+        await hydrateInstance(ctx);
+        spawned.push(projectId);
+      }
+    }
+    return { spawned, skipped };
+  }
+
+  /**
+   * Instancia UN producto de forma idempotente: exactamente una instancia por
+   * `projectId`. Liga el store inmutable, crea el estado efímero propio y lanza el
+   * pipeline aislado vía `spawn`. Devuelve el `instanceContext` (o el existente).
+   */
+  function spawnInstance(product) {
+    const projectId = resolveProjectId(product);
+    if (!isSafeId(projectId)) {                   // A03/A08: nunca interpolar id sin validar
+      throw new KernelStoreIsolationError(
+        `spawnInstance: projectId inseguro "${String(projectId)}" — fail-closed antes de derivar path/spawn`,
+        { requested: projectId == null ? null : String(projectId) },
+      );
+    }
+    const existing = instances.get(projectId);
+    if (existing) return existing;                // exactamente 1 por producto
+
+    const ctx = buildInstance(product, projectId);
+    instances.set(projectId, ctx);
+    // spawn AISLADO: sólo se le pasa el ctx propio; el handle vive en su instancia.
+    ctx.handle = safeSpawn(ctx);
+    return ctx;
+  }
+
+  function safeSpawn(ctx) {
+    try {
+      return spawnFn(ctx);
+    } catch (err) {
+      // El fallo de spawn de una instancia no puede tumbar a las demás (A04).
+      ctx.health.alive = false;
+      ctx.health.lastError = err && err.message ? err.message : String(err);
+      onAlert({ projectId: ctx.projectId, stage: 'spawn', errors: [{ detail: ctx.health.lastError }] });
+      return null;
+    }
+  }
+
+  /** Devuelve el `instanceContext` de un `projectId`, o `null` si no existe. */
+  function getInstance(projectId) {
+    if (!isSafeId(projectId)) return null;        // fail-closed sobre id en banda
+    return instances.get(projectId) || null;
+  }
+
+  /** Lista los `projectId` con instancia activa. */
+  function listInstances() {
+    return [...instances.keys()];
+  }
+
+  /**
+   * Ejecuta el probe de salud de UNA instancia y actualiza su estado. AISLADO: no
+   * toca ninguna otra instancia. Devuelve el snapshot de salud (o `null`).
+   */
+  function superviseInstance(projectId) {
+    const ctx = getInstance(projectId);
+    if (!ctx) return null;
+    let alive;
+    try {
+      alive = healthProbe(ctx) !== false;
+    } catch (err) {
+      alive = false;
+      ctx.health.lastError = err && err.message ? err.message : String(err);
+    }
+    ctx.health.alive = alive;
+    return { projectId, ...ctx.health };
+  }
+
+  /**
+   * CA-3 · Marca una instancia como caída (callback de crash del pipeline). NO
+   * afecta a las demás. Fail-closed sobre id.
+   */
+  function markInstanceUnhealthy(projectId, error) {
+    const ctx = getInstance(projectId);
+    if (!ctx) return false;
+    ctx.health.alive = false;
+    if (error != null) ctx.health.lastError = error && error.message ? error.message : String(error);
+    onAlert({ projectId, stage: 'crash', errors: [{ detail: ctx.health.lastError || 'instancia caída' }] });
+    return true;
+  }
+
+  /**
+   * CA-3 · Healthcheck de TODAS las instancias. Con `autoRestart`, reinicia SÓLO
+   * las caídas — de forma aislada, sin tocar las sanas. Devuelve el reporte por
+   * `projectId`.
+   */
+  function healthcheck({ autoRestart = false } = {}) {
+    const report = {};
+    for (const projectId of listInstances()) {
+      const snap = superviseInstance(projectId);
+      report[projectId] = { alive: snap.alive, restarts: snap.restarts };
+      if (!snap.alive && autoRestart) {
+        const ctx = restartInstance(projectId);
+        report[projectId] = { alive: ctx.health.alive, restarts: ctx.health.restarts, restarted: true };
+      }
+    }
+    return report;
+  }
+
+  /**
+   * CA-3 (CRÍTICO) · Reinicio AISLADO: recrea SÓLO el ctx de `projectId` (nuevo
+   * store inmutable + estado efímero fresco), preservando el contador de restarts.
+   * El estado de las demás instancias NO se reinicia, altera ni bloquea (sin DoS
+   * cruzado · A04). Devuelve el nuevo ctx (o `null` si no existía).
+   */
+  function restartInstance(projectId) {
+    if (!isSafeId(projectId)) {                   // fail-closed
+      throw new KernelStoreIsolationError(
+        `restartInstance: projectId inseguro "${String(projectId)}"`,
+        { requested: projectId == null ? null : String(projectId) },
+      );
+    }
+    const prev = instances.get(projectId);
+    if (!prev) return null;
+    const restarts = (prev.health.restarts || 0) + 1;
+    const product = prev.product;
+
+    // Detener el handle previo de forma aislada (el fallo de stop de A no afecta a B).
+    try { stopFn(prev); } catch (_) { /* aislado: no propaga */ }
+
+    // Recrear SÓLO esta instancia. La referencia al ctx viejo queda huérfana; su
+    // estado efímero (Maps) se descarta con ella. Ninguna otra instancia se toca.
+    instances.delete(projectId);
+    const ctx = buildInstance(product, projectId);
+    ctx.health.restarts = restarts;
+    instances.set(projectId, ctx);
+    ctx.handle = safeSpawn(ctx);
+    return ctx;
+  }
+
+  /** Detiene y remueve una instancia de forma aislada. `true` si existía. */
+  function stopInstance(projectId) {
+    const ctx = getInstance(projectId);
+    if (!ctx) return false;
+    try { stopFn(ctx); } catch (_) { /* aislado */ }
+    instances.delete(projectId);
+    return true;
+  }
+
+  return {
+    bootProducts,
+    spawnInstance,
+    getInstance,
+    listInstances,
+    superviseInstance,
+    markInstanceUnhealthy,
+    healthcheck,
+    restartInstance,
+    stopInstance,
+  };
+}
+
+module.exports = { createKernelSupervisor, resolveProjectId };


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 4 archivos · +879 -0

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:skipped` aplicado por delivery

## Closes

Closes #4762
