### PR TITLE
[Split de #4689] Multiplexor de ruteo product-aware (fail-closed) + fixtures A/B

### DIFF
--- a/.pipeline/lib/__tests__/fixtures/routing-product-a.descriptor.json
+++ b/.pipeline/lib/__tests__/fixtures/routing-product-a.descriptor.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": "1.0",
+  "status": "active",
+  "identity": {
+    "projectId": "product-a",
+    "name": "Producto A (fixture de ruteo)",
+    "description": "Descriptor sintetico A para tests del multiplexor product-aware (#4763). Datos inertes: sin secrets ni repos productivos."
+  },
+  "repositories": [
+    {
+      "id": "product-a-app",
+      "url": "https://github.com/acme-org/product-a",
+      "role": "primary",
+      "defaultBaseRef": "main"
+    },
+    {
+      "id": "product-a-infra",
+      "url": "acme-org/product-a-infra",
+      "role": "secondary"
+    }
+  ],
+  "board": {
+    "ref": "acme-org/product-a/projects/1",
+    "admissionLabels": ["Ready"],
+    "routing": [
+      { "label": "area:backend", "capability": "backend" },
+      { "label": "area:pipeline", "capability": "pipeline" }
+    ]
+  },
+  "capabilities": [
+    { "interface": "backend", "skills": ["backend-dev"] },
+    { "interface": "pipeline", "skills": ["pipeline-dev"] }
+  ],
+  "authority": {
+    "signers": ["acme-signer"],
+    "gates": { "gate0": "enforce", "gate2": "enforce" }
+  }
+}

--- a/.pipeline/lib/__tests__/fixtures/routing-product-b.descriptor.json
+++ b/.pipeline/lib/__tests__/fixtures/routing-product-b.descriptor.json
@@ -1,0 +1,31 @@
+{
+  "schemaVersion": "1.0",
+  "status": "active",
+  "identity": {
+    "projectId": "product-b",
+    "name": "Producto B (fixture de ruteo)",
+    "description": "Descriptor sintetico B para tests del multiplexor product-aware (#4763). Datos inertes: sin secrets ni repos productivos."
+  },
+  "repositories": [
+    {
+      "id": "product-b-app",
+      "url": "https://github.com/globex-org/product-b",
+      "role": "primary",
+      "defaultBaseRef": "trunk"
+    }
+  ],
+  "board": {
+    "ref": "globex-org/product-b/projects/7",
+    "admissionLabels": ["Ready"],
+    "routing": [
+      { "label": "area:frontend", "capability": "frontend" }
+    ]
+  },
+  "capabilities": [
+    { "interface": "frontend", "skills": ["web-dev"] }
+  ],
+  "authority": {
+    "signers": ["globex-signer"],
+    "gates": { "gate0": "enforce" }
+  }
+}

--- a/.pipeline/lib/__tests__/kernel-supervisor-routing.test.js
+++ b/.pipeline/lib/__tests__/kernel-supervisor-routing.test.js
@@ -1,0 +1,336 @@
+'use strict';
+
+// =============================================================================
+// kernel-supervisor-routing.test.js — Multiplexor de ruteo product-aware
+// (Ola Puente P4 · #4763 · split 2/3 de #4689)
+//
+// Mapea los criterios de aceptación (PO) del issue #4763, con las fixtures de
+// repos dummy A/B (descriptores sinteticos, inertes):
+//   CA-1  Ruteo positivo: evento en allowlist → instancia correcta (A→A, B→B).
+//   CA-2  Fail-closed por projectId inseguro (A03 adversarial): traversal /
+//         separadores / control chars → null ANTES de tocar path/clave + audita.
+//   CA-3  Fail-closed por repo/proyecto fuera de allowlist (REQ-SEC-MUX-1): sin
+//         fallback-a-primary; descarta + audita.
+//   CA-4  Auditoria no opcional (A09): todo descarte deja registro.
+//   CA-5  No-regresion single-product: cubierta ademas en pulpo (fallback a
+//         getPrimaryRepo). Aqui: descriptors vacio → fail-closed (no primary global).
+//   CA-6  Reuso, no reimplementacion (isSafeId + repo-target) — verificado por el
+//         diff (no reescribe repo-target.js ni project-descriptor.js).
+//
+// Los ids/repos con control chars se construyen en runtime (String.fromCharCode)
+// para mantener el fuente ASCII-safe.
+// =============================================================================
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const {
+  resolveInstanceForEvent,
+  deriveRepoConfig,
+  extractRepoSlug,
+  createKernelSupervisor,
+} = require('../kernel-supervisor');
+
+const NUL = String.fromCharCode(0);
+const LF = String.fromCharCode(10);
+const TAB = String.fromCharCode(9);
+
+// -----------------------------------------------------------------------------
+// Fixtures A/B (descriptores dummy inertes)
+// -----------------------------------------------------------------------------
+
+const FIXTURES_DIR = path.join(__dirname, 'fixtures');
+
+function loadFixture(name) {
+  return JSON.parse(fs.readFileSync(path.join(FIXTURES_DIR, name), 'utf8'));
+}
+
+const DESCRIPTOR_A = loadFixture('routing-product-a.descriptor.json');
+const DESCRIPTOR_B = loadFixture('routing-product-b.descriptor.json');
+
+// Catalogo projectId → instancia. La instancia sólo necesita exponer su descriptor;
+// el multiplexor deriva la allowlist repo-target por instancia (adaptador).
+function buildCatalog() {
+  const map = new Map();
+  map.set(DESCRIPTOR_A.identity.projectId, { projectId: DESCRIPTOR_A.identity.projectId, descriptor: DESCRIPTOR_A });
+  map.set(DESCRIPTOR_B.identity.projectId, { projectId: DESCRIPTOR_B.identity.projectId, descriptor: DESCRIPTOR_B });
+  return map;
+}
+
+// Envuelve un catalogo con un espia sobre `.get` para probar que un id inseguro se
+// rechaza ANTES de tocar el catalogo (primer punto donde el id derivaria path/clave).
+function spyCatalog(map) {
+  const lookups = [];
+  return {
+    lookups,
+    descriptors: {
+      get: (k) => { lookups.push(k); return map.get(k); },
+    },
+  };
+}
+
+// Sink de auditoria que colecciona descartes (interfaz `{ discard }` de la receta).
+function auditCollector() {
+  const entries = [];
+  return {
+    entries,
+    audit: { discard: (event, reason, meta) => entries.push({ event, reason, meta: meta || {} }) },
+  };
+}
+
+// -----------------------------------------------------------------------------
+// CA-1 · Ruteo positivo (evento en allowlist → instancia correcta)
+// -----------------------------------------------------------------------------
+
+test('CA-1 · evento de A en allowlist resuelve a la instancia A (sin cruce)', () => {
+  const descriptors = buildCatalog();
+  const { entries, audit } = auditCollector();
+  const res = resolveInstanceForEvent(
+    { projectId: 'product-a', number: 1, origin_repo: 'acme-org/product-a' },
+    { descriptors, audit },
+  );
+  assert.ok(res, 'resuelve');
+  assert.equal(res.projectId, 'product-a');
+  assert.equal(res.instance.descriptor.identity.projectId, 'product-a');
+  assert.equal(res.repo, 'acme-org/product-a');
+  assert.equal(entries.length, 0, 'ruteo positivo no audita descarte');
+});
+
+test('CA-1 · evento de B resuelve a la instancia B', () => {
+  const descriptors = buildCatalog();
+  const res = resolveInstanceForEvent(
+    { projectId: 'product-b', number: 2, origin_repo: 'globex-org/product-b' },
+    { descriptors },
+  );
+  assert.ok(res);
+  assert.equal(res.instance.descriptor.identity.projectId, 'product-b');
+  assert.equal(res.repo, 'globex-org/product-b');
+});
+
+test('CA-1 · repo secundario allowlisted de A rutea a A (no sólo el primario)', () => {
+  const descriptors = buildCatalog();
+  const res = resolveInstanceForEvent(
+    { projectId: 'product-a', origin_repo: 'acme-org/product-a-infra' },
+    { descriptors },
+  );
+  assert.ok(res);
+  assert.equal(res.repo, 'acme-org/product-a-infra');
+});
+
+test('CA-1 · casing distinto del repo se normaliza (allowlist case-insensitive)', () => {
+  const descriptors = buildCatalog();
+  const res = resolveInstanceForEvent(
+    { projectId: 'product-a', origin_repo: 'ACME-ORG/Product-A' },
+    { descriptors },
+  );
+  assert.ok(res);
+  assert.equal(res.repo, 'acme-org/product-a');
+});
+
+test('CA-1 · evento sin repo cae al primary DE LA INSTANCIA (mismo tenant, no cross-tenant)', () => {
+  const descriptors = buildCatalog();
+  const res = resolveInstanceForEvent({ projectId: 'product-b' }, { descriptors });
+  assert.ok(res);
+  assert.equal(res.repo, 'globex-org/product-b', 'primary de B, nunca de A');
+});
+
+// -----------------------------------------------------------------------------
+// CA-2 · A03 adversarial · projectId inseguro → null ANTES de tocar path/clave
+// -----------------------------------------------------------------------------
+
+const UNSAFE_PROJECT_IDS = [
+  ['path traversal', '../otro'],
+  ['traversal profundo', '../../etc/passwd'],
+  ['separador /', 'product/a'],
+  ['separador backslash', 'product\\a'],
+  ['NUL control char', `product${NUL}a`],
+  ['newline control char', `product${LF}a`],
+  ['tab control char', `product${TAB}a`],
+  ['string vacio', ''],
+  ['mayusculas fuera de patron', 'ProductA'],
+];
+
+for (const [label, badId] of UNSAFE_PROJECT_IDS) {
+  test(`CA-2/A03 · projectId inseguro (${label}) → null + audita, sin tocar el catalogo`, () => {
+    const spy = spyCatalog(buildCatalog());
+    const { entries, audit } = auditCollector();
+    const res = resolveInstanceForEvent(
+      { projectId: badId, origin_repo: 'acme-org/product-a' },
+      { descriptors: spy.descriptors, audit },
+    );
+    assert.equal(res, null, 'rechazado fail-closed');
+    // REQ-SEC-MUX-2: isSafeId corre ANTES de la busqueda en catalogo (primer punto
+    // donde el id derivaria un path/clave). El catalogo NO se consulta.
+    assert.deepEqual(spy.lookups, [], 'no se consultó el catalogo con el id inseguro');
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].reason, 'projectId inseguro');
+  });
+}
+
+test('CA-2/A03 · projectId no-string (null/objeto/numero) → null + audita', () => {
+  const descriptors = buildCatalog();
+  for (const bad of [null, undefined, 42, {}, ['product-a']]) {
+    const { entries, audit } = auditCollector();
+    const res = resolveInstanceForEvent({ projectId: bad, origin_repo: 'acme-org/product-a' }, { descriptors, audit });
+    assert.equal(res, null);
+    assert.equal(entries[0].reason, 'projectId inseguro');
+  }
+});
+
+test('CA-2/A03 · control chars del id ofensivo se neutralizan en el log de auditoria', () => {
+  const descriptors = buildCatalog();
+  const { entries, audit } = auditCollector();
+  resolveInstanceForEvent({ projectId: `evil${LF}id${NUL}` }, { descriptors, audit });
+  const logged = entries[0].meta.projectId;
+  assert.ok(!/[\u0000-\u001f\u007f]/.test(logged), 'sin control chars crudos en el registro');
+});
+
+// -----------------------------------------------------------------------------
+// CA-3 · Fail-closed por repo/proyecto fuera de allowlist (sin fallback-a-primary)
+// -----------------------------------------------------------------------------
+
+test('CA-3 · projectId fuera de catalogo → descarta + audita (sin instancia implicita)', () => {
+  const descriptors = buildCatalog();
+  const { entries, audit } = auditCollector();
+  const res = resolveInstanceForEvent({ projectId: 'product-c', origin_repo: 'acme-org/product-a' }, { descriptors, audit });
+  assert.equal(res, null);
+  assert.equal(entries[0].reason, 'projectId fuera de catálogo');
+});
+
+test('CA-3 · repo valido pero fuera de la allowlist de la instancia → descarta, NUNCA cae a primary', () => {
+  const descriptors = buildCatalog();
+  const { entries, audit } = auditCollector();
+  const res = resolveInstanceForEvent({ projectId: 'product-a', origin_repo: 'evil/repo' }, { descriptors, audit });
+  // REQ-SEC-MUX-1: fuera de allowlist ⇒ descartado, no ⇒ primary de A.
+  assert.equal(res, null, 'descartado (no reencaminado a acme-org/product-a)');
+  assert.equal(entries[0].reason, 'repo fuera de allowlist');
+});
+
+test('CA-3 · repo de OTRA instancia (cross-tenant) contra projectId A → descarta', () => {
+  const descriptors = buildCatalog();
+  const res = resolveInstanceForEvent({ projectId: 'product-a', origin_repo: 'globex-org/product-b' }, { descriptors });
+  assert.equal(res, null, 'el repo de B no rutea bajo el tenant A');
+});
+
+test('CA-3 · repo con control chars / metacaracteres → descarta (isRepoAllowed default-deny)', () => {
+  const descriptors = buildCatalog();
+  const badRepos = [
+    `acme-org/product-a${NUL}`,
+    'acme-org/pro duct',
+    'acme-org/product-a; rm -rf',
+    'notaslug',
+  ];
+  for (const badRepo of badRepos) {
+    const res = resolveInstanceForEvent({ projectId: 'product-a', origin_repo: badRepo }, { descriptors });
+    assert.equal(res, null, `repo ofensivo rechazado: ${JSON.stringify(badRepo)}`);
+  }
+});
+
+test('CA-3 · instancia sin repos allowlisted → fail-closed (no FALLBACK_PRIMARY global)', () => {
+  const descriptors = new Map();
+  descriptors.set('empty', { projectId: 'empty', descriptor: { repositories: [] } });
+  const { entries, audit } = auditCollector();
+  const res = resolveInstanceForEvent({ projectId: 'empty', origin_repo: 'intrale/platform' }, { descriptors, audit });
+  assert.equal(res, null);
+  assert.equal(entries[0].reason, 'instancia sin repos allowlisted');
+});
+
+// -----------------------------------------------------------------------------
+// CA-4 · Auditoria no opcional (A09) + robustez del sink
+// -----------------------------------------------------------------------------
+
+test('CA-4 · el sink de auditoria acepta forma funcion (info) además de { discard }', () => {
+  const descriptors = buildCatalog();
+  const infos = [];
+  const res = resolveInstanceForEvent(
+    { projectId: '../evil' },
+    { descriptors, audit: (info) => infos.push(info) },
+  );
+  assert.equal(res, null);
+  assert.equal(infos.length, 1);
+  assert.equal(infos[0].reason, 'projectId inseguro');
+  assert.ok('event' in infos[0], 'el info funcional trae el evento');
+});
+
+test('CA-4 · sin sink de auditoria no crashea (no-op) pero igual descarta', () => {
+  const descriptors = buildCatalog();
+  const res = resolveInstanceForEvent({ projectId: '../evil' }, { descriptors });
+  assert.equal(res, null);
+});
+
+test('CA-4 · evento invalido (no objeto) → null + audita', () => {
+  const { entries, audit } = auditCollector();
+  assert.equal(resolveInstanceForEvent(null, { descriptors: buildCatalog(), audit }), null);
+  assert.equal(entries[0].reason, 'evento inválido');
+});
+
+// -----------------------------------------------------------------------------
+// CA-5 · descriptors vacio/ausente → fail-closed (no primary global)
+// -----------------------------------------------------------------------------
+
+test('CA-5 · descriptors ausente → descarta fail-closed (el fallback single-product vive en pulpo)', () => {
+  const { entries, audit } = auditCollector();
+  const res = resolveInstanceForEvent({ projectId: 'product-a', origin_repo: 'acme-org/product-a' }, { audit });
+  assert.equal(res, null);
+  assert.equal(entries[0].reason, 'projectId fuera de catálogo');
+});
+
+// -----------------------------------------------------------------------------
+// Integracion: supervisor.resolveEvent con instancias vivas (hydrate)
+// -----------------------------------------------------------------------------
+
+test('supervisor.resolveEvent rutea usando el descriptor hidratado de la instancia + audita por onAlert', async () => {
+  const alerts = [];
+  const storeFactory = (opts) => ({
+    contextProjectId: opts.contextProjectId,
+    getDescriptor: async (pid) => (pid === 'product-a' ? { body: DESCRIPTOR_A } : null),
+  });
+  const supervisor = createKernelSupervisor({
+    catalogStore: { listProducts: async () => [{ productId: 'product-a', projectId: 'product-a', status: 'active' }] },
+    storeFactory,
+    onAlert: (a) => alerts.push(a),
+    hydrate: true,
+  });
+  await supervisor.bootProducts();
+
+  const ok = supervisor.resolveEvent({ projectId: 'product-a', origin_repo: 'acme-org/product-a' });
+  assert.ok(ok);
+  assert.equal(ok.repo, 'acme-org/product-a');
+
+  const bad = supervisor.resolveEvent({ projectId: 'product-a', origin_repo: 'evil/repo' });
+  assert.equal(bad, null);
+  assert.ok(alerts.some((a) => a.stage === 'route-discard'), 'A09: descarte auditado por onAlert');
+});
+
+// -----------------------------------------------------------------------------
+// Adaptadores puros: extractRepoSlug / deriveRepoConfig
+// -----------------------------------------------------------------------------
+
+test('extractRepoSlug acepta slug directo, URL https y ssh; rechaza formas invalidas', () => {
+  assert.equal(extractRepoSlug('acme-org/product-a'), 'acme-org/product-a');
+  assert.equal(extractRepoSlug('https://github.com/Acme-Org/Product-A'), 'acme-org/product-a');
+  assert.equal(extractRepoSlug('https://github.com/acme-org/product-a.git'), 'acme-org/product-a');
+  assert.equal(extractRepoSlug('git@github.com:acme-org/product-a.git'), 'acme-org/product-a');
+  assert.equal(extractRepoSlug(''), null);
+  assert.equal(extractRepoSlug(null), null);
+  assert.equal(extractRepoSlug('no-slash'), null);
+});
+
+test('deriveRepoConfig arma el config repo-target (primary por role, allowlist, base ref)', () => {
+  const cfg = deriveRepoConfig(DESCRIPTOR_A);
+  assert.equal(cfg.repos.primary, 'acme-org/product-a');
+  assert.deepEqual(cfg.repos.allowlist, ['acme-org/product-a', 'acme-org/product-a-infra']);
+  assert.equal(cfg.repos.default_base_ref, 'main');
+});
+
+test('deriveRepoConfig sin role primary usa el primer repo valido como primary', () => {
+  const cfg = deriveRepoConfig({ repositories: [{ id: 'x', url: 'org/uno' }, { id: 'y', url: 'org/dos' }] });
+  assert.equal(cfg.repos.primary, 'org/uno');
+});
+
+test('deriveRepoConfig descarta urls invalidas (no rompe la derivacion)', () => {
+  const cfg = deriveRepoConfig({ repositories: [{ id: 'a', url: 'no-slash' }, { id: 'b', url: 'org/ok' }] });
+  assert.deepEqual(cfg.repos.allowlist, ['org/ok']);
+});

--- a/.pipeline/lib/__tests__/pulpo-intake-routing.test.js
+++ b/.pipeline/lib/__tests__/pulpo-intake-routing.test.js
@@ -1,0 +1,64 @@
+'use strict';
+
+// =============================================================================
+// pulpo-intake-routing.test.js — Ruteo del intake por instancia (P4 · #4763)
+//
+// CA-5 (no-regresión single-product): sin router multi-instancia, `resolveIntakeRepo`
+// rutea EXACTAMENTE como el path vigente (repo-target.getRepoForIssue → repo de
+// origen propagado o primary). Con router multi-instancia activo, delega en el
+// multiplexor fail-closed y descarta (null) lo que cae fuera de allowlist.
+// =============================================================================
+
+process.env.PULPO_NO_AUTOSTART = '1'; // permitir require sin arrancar el pulpo.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const pulpo = require('../../pulpo.js');
+const repoTarget = require('../repo-target');
+
+test('CA-5 · sin router multi-instancia: resolveIntakeRepo == getRepoForIssue (single-product)', () => {
+  pulpo.setMultiInstanceRouter(null);
+  assert.equal(pulpo.getMultiInstanceRouter(), null);
+  // issue sin repo de origen → primary global (comportamiento vigente).
+  const issue = { number: 1, title: 'x' };
+  assert.equal(pulpo.resolveIntakeRepo(issue), repoTarget.getPrimaryRepo());
+});
+
+test('CA-5 · router ignora descriptores mal formados (sin .get) → sigue en single-product', () => {
+  pulpo.setMultiInstanceRouter({ descriptors: {} }); // sin get() válido
+  assert.equal(pulpo.getMultiInstanceRouter(), null, 'router inválido no se activa');
+  assert.equal(pulpo.resolveIntakeRepo({ number: 2 }), repoTarget.getPrimaryRepo());
+});
+
+test('router multi-instancia activo: issue con projectId+repo en allowlist → repo de la instancia', () => {
+  const descriptors = new Map();
+  descriptors.set('product-a', {
+    projectId: 'product-a',
+    descriptor: { repositories: [{ id: 'a', url: 'acme-org/product-a', role: 'primary' }] },
+  });
+  const discards = [];
+  pulpo.setMultiInstanceRouter({ descriptors, audit: (info) => discards.push(info) });
+
+  assert.equal(
+    pulpo.resolveIntakeRepo({ number: 3, projectId: 'product-a', origin_repo: 'acme-org/product-a' }),
+    'acme-org/product-a',
+  );
+  // fuera de allowlist ⇒ null (descartado + auditado), NUNCA primary.
+  assert.equal(pulpo.resolveIntakeRepo({ number: 4, projectId: 'product-a', origin_repo: 'evil/repo' }), null);
+  // projectId inseguro ⇒ null.
+  assert.equal(pulpo.resolveIntakeRepo({ number: 5, projectId: '../evil' }), null);
+  assert.ok(discards.some((d) => d.reason === 'repo fuera de allowlist'));
+  assert.ok(discards.some((d) => d.reason === 'projectId inseguro'));
+
+  pulpo.setMultiInstanceRouter(null); // restaurar estado single-product para otros tests.
+});
+
+test('router activo pero issue SIN projectId → cae al ruteo global (compat intake single-product)', () => {
+  const descriptors = new Map();
+  descriptors.set('product-a', { projectId: 'product-a', descriptor: { repositories: [{ id: 'a', url: 'acme-org/product-a', role: 'primary' }] } });
+  pulpo.setMultiInstanceRouter({ descriptors });
+  // Sin projectId, el intake vigente (issues de un solo producto) sigue funcionando.
+  assert.equal(pulpo.resolveIntakeRepo({ number: 6 }), repoTarget.getPrimaryRepo());
+  pulpo.setMultiInstanceRouter(null);
+});

--- a/.pipeline/lib/kernel-supervisor.js
+++ b/.pipeline/lib/kernel-supervisor.js
@@ -45,8 +45,186 @@ const {
   deriveConcurrency,
   deriveCapabilityPartitions,
 } = require('./project-descriptor');
+const repoTarget = require('./repo-target');
 
 const ACTIVE_STATUS = 'active';
+
+// -----------------------------------------------------------------------------
+// Multiplexor de ruteo product-aware (Ola Puente P4 · #4763 · split 2/3 de #4689)
+//
+// Resuelve `projectId`/repo de un evento (issue) a la instancia/pipeline del
+// producto correcto, fail-closed contra la allowlist derivada del descriptor.
+// NO reimplementa validación: se apoya en `isSafeId` (project-descriptor) e
+// `isRepoAllowed`/`getRepoForIssue`/`getPrimaryRepo` (repo-target). Ver los
+// requisitos de seguridad REQ-SEC-MUX-1..6 del análisis de seguridad del issue.
+// -----------------------------------------------------------------------------
+
+// Forma canónica GitHub `owner/repo` (espeja repo-target.REPO_RE). Se usa para
+// derivar la allowlist repo-target desde `repositories[].url` del descriptor.
+const REPO_SLUG_RE = /^[A-Za-z0-9._-]{1,39}\/[A-Za-z0-9._-]{1,100}$/;
+
+/**
+ * Extrae el slug `owner/repo` de un `repositories[].url` del descriptor. Acepta el
+ * slug directo (`owner/repo`) o una URL GitHub (`https://github.com/owner/repo`,
+ * `git@github.com:owner/repo.git`). Devuelve `null` si no matchea forma canónica.
+ * Adaptador PURO: sólo arma el input de repo-target, no valida confianza.
+ */
+function extractRepoSlug(url) {
+  if (typeof url !== 'string') return null;
+  const s = url.trim();
+  if (!s) return null;
+  if (REPO_SLUG_RE.test(s)) return s.toLowerCase();
+  const m = s.match(/github\.com[/:]+([A-Za-z0-9._-]{1,39}\/[A-Za-z0-9._-]{1,100}?)(?:\.git)?\/?$/i);
+  if (m && REPO_SLUG_RE.test(m[1])) return m[1].toLowerCase();
+  return null;
+}
+
+/**
+ * Deriva un config repo-target (`{ repos: { primary, allowlist, default_base_ref } }`)
+ * desde las `repositories[]` de un descriptor de instancia. Es un ADAPTADOR (no
+ * validación): no reimplementa `isRepoAllowed`/`getRepoForIssue`, sólo construye su
+ * `configOverride` para que la frontera de confianza siga siendo la de repo-target.
+ */
+function deriveRepoConfig(descriptor) {
+  const repos = (descriptor && Array.isArray(descriptor.repositories)) ? descriptor.repositories : [];
+  const allowlist = [];
+  let primary = null;
+  let defaultBaseRef = null;
+  for (const r of repos) {
+    const slug = extractRepoSlug(r && r.url);
+    if (!slug) continue;
+    allowlist.push(slug);
+    if (r && r.role === 'primary' && !primary) {
+      primary = slug;
+      if (typeof r.defaultBaseRef === 'string' && r.defaultBaseRef) defaultBaseRef = r.defaultBaseRef;
+    }
+  }
+  if (!primary && allowlist.length > 0) primary = allowlist[0];
+  const cfg = { repos: { allowlist } };
+  if (primary) cfg.repos.primary = primary;
+  if (defaultBaseRef) cfg.repos.default_base_ref = defaultBaseRef;
+  return cfg;
+}
+
+/**
+ * Normaliza el sink de auditoría a una fn `discard(event, reason, meta)`. Acepta:
+ *   - `{ discard(event, reason, meta) }`  (interfaz de la receta del issue).
+ *   - `function(info)`                     (recibe `{ event, reason, ...meta }`).
+ *   - ausente → no-op.
+ * REQ-SEC-MUX-3 (A09): todo descarte del multiplexor pasa por acá; sin descartes
+ * silenciosos cuando hay sink.
+ */
+function normalizeAudit(audit) {
+  if (audit && typeof audit.discard === 'function') {
+    return (event, reason, meta) => audit.discard(event, reason, meta || {});
+  }
+  if (typeof audit === 'function') {
+    return (event, reason, meta) => audit(Object.assign({ event, reason }, meta || {}));
+  }
+  return () => {};
+}
+
+/**
+ * Etiqueta segura de un id/repo NO confiable para el log de auditoría. Neutraliza
+ * control chars y trunca — NUNCA se usa como path/clave, sólo para trazabilidad
+ * (A09). Que el ofensivo sea inseguro no debe envenenar el propio registro.
+ */
+function safeAuditLabel(value) {
+  if (typeof value !== 'string') {
+    return value === null || value === undefined ? String(value) : `<${typeof value}>`;
+  }
+  const cleaned = Array.from(value, (ch) => (ch.charCodeAt(0) < 0x20 || ch.charCodeAt(0) === 0x7f) ? "?" : ch).join("");
+  return cleaned.length > 80 ? `${cleaned.slice(0, 77)}...` : cleaned;
+}
+
+/** Candidato de repo de origen propagado en el evento (mismo contrato que repo-target). */
+function extractEventRepo(event) {
+  if (!event || typeof event !== 'object') return null;
+  const c = event.origin_repo || event.repo || event.repository || null;
+  return (typeof c === 'string' && c.trim()) ? c.trim() : null;
+}
+
+/**
+ * CA-3 · Multiplexor de ruteo product-aware FAIL-CLOSED. Resuelve el evento a la
+ * instancia/pipeline correcta o lo descarta+audita. Orden fail-closed:
+ *
+ *   1. `isSafeId(projectId)` ANTES de tocar path/clave (A03 · REQ-SEC-MUX-2). El
+ *      regex `^[a-z0-9][a-z0-9-]{1,63}$` + rechazo de `..`/`/`/`\` cubre traversal,
+ *      confusión de namespace y control chars.
+ *   2. `descriptors.get(projectId)` — fuera de catálogo ⇒ descartar (sin instancia
+ *      implícita).
+ *   3. Allowlist derivada del descriptor de la instancia (default-deny). Un repo
+ *      explícito fuera de allowlist se DESCARTA — nunca se reencamina a `primary`
+ *      (REQ-SEC-MUX-1: prohibido el fallback-a-primary cross-tenant del path
+ *      single-product de `getRepoForIssue`).
+ *
+ * @param {object} event  evento entrante. `projectId` in-band se valida fail-closed.
+ *                        `origin_repo`/`repo`/`repository` (opcional) es el repo de
+ *                        origen propagado.
+ * @param {object} opts
+ * @param {Map}    opts.descriptors  catálogo `projectId → instancia`. La instancia
+ *                                   aporta el config repo-target vía `.config` o un
+ *                                   descriptor crudo vía `.descriptor`.
+ * @param {function|object} [opts.audit]  sink de auditoría (fn o `{ discard }`).
+ * @returns {{instance:object, repo:string, projectId:string}|null}  `null` ⇒ descartado.
+ */
+function resolveInstanceForEvent(event, opts = {}) {
+  const audit = normalizeAudit(opts.audit);
+  const descriptors = opts.descriptors;
+
+  if (!event || typeof event !== 'object') {
+    audit(event, 'evento inválido');
+    return null;
+  }
+
+  const projectId = event.projectId;
+
+  // 1) Defensa-en-profundidad ANTES de derivar cualquier path/estado/clave.
+  if (!isSafeId(projectId)) {
+    audit(event, 'projectId inseguro', { projectId: safeAuditLabel(projectId) });
+    return null;
+  }
+
+  // 2) Catálogo → instancia. Fuera de catálogo ⇒ descartar sin crear instancia.
+  const inst = (descriptors && typeof descriptors.get === 'function') ? descriptors.get(projectId) : null;
+  if (!inst) {
+    audit(event, 'projectId fuera de catálogo', { projectId });
+    return null;
+  }
+
+  // Config repo-target de la instancia (adaptador desde su descriptor). Cacheado
+  // en la instancia para no rederivar en cada evento.
+  let cfg = inst.config;
+  if (!cfg && inst.descriptor) {
+    cfg = inst._repoConfig || (inst._repoConfig = deriveRepoConfig(inst.descriptor));
+  }
+  const allowlist = (cfg && cfg.repos && Array.isArray(cfg.repos.allowlist)) ? cfg.repos.allowlist : [];
+  if (allowlist.length === 0) {
+    // Fail-closed: una instancia sin repos allowlisted no rutea nada. Sin este
+    // guard, repo-target caería a su FALLBACK_PRIMARY global (fail-open).
+    audit(event, 'instancia sin repos allowlisted', { projectId });
+    return null;
+  }
+
+  // 3) Allowlist derivada del descriptor (default-deny). REQ-SEC-MUX-1.
+  const candidate = extractEventRepo(event);
+  let repo;
+  if (candidate != null) {
+    if (!repoTarget.isRepoAllowed(candidate, cfg)) {
+      audit(event, 'repo fuera de allowlist', { projectId, repo: safeAuditLabel(candidate) });
+      return null;
+    }
+    // El candidato ya está allowlisted: getRepoForIssue devuelve el mismo repo
+    // normalizado (no cae a primary porque pasa el chequeo de allowlist).
+    repo = repoTarget.getRepoForIssue(event, cfg);
+  } else {
+    // Sin repo en el evento: primary DE LA INSTANCIA ya resuelta (mismo tenant, no
+    // cross-tenant). No hay reencaminamiento entre productos.
+    repo = repoTarget.getPrimaryRepo(cfg);
+  }
+
+  return { instance: inst, repo, projectId };
+}
 
 /**
  * Resuelve el `projectId` del tenant a partir de un registro de producto. Deriva
@@ -128,6 +306,7 @@ function createKernelSupervisor(deps = {}) {
       intakeOffsets: new Map(),
       circuitBreaker: { rebotes: new Map() },
       // --- config derivada del descriptor (reuso de derivers, opcional) -------
+      descriptor: null,                 // #4763 — retenido en hydrate para el multiplexor
       routing: null,
       concurrency: null,
       partitions: null,
@@ -149,6 +328,9 @@ function createKernelSupervisor(deps = {}) {
       const desc = await ctx.store.getDescriptor(ctx.projectId);
       const body = desc && desc.body;
       if (body) {
+        // #4763 — retener el descriptor de la instancia para que el multiplexor de
+        // ruteo (resolveEvent) derive su allowlist repo-target por instancia.
+        ctx.descriptor = body;
         ctx.routing = deriveRouting(body);
         ctx.concurrency = deriveConcurrency(body);
         ctx.partitions = deriveCapabilityPartitions(body);
@@ -329,6 +511,23 @@ function createKernelSupervisor(deps = {}) {
     return true;
   }
 
+  /**
+   * #4763 · Multiplexor de ruteo product-aware ligado a las instancias vivas de
+   * ESTE supervisor. Resuelve `event.projectId`/repo a la instancia correcta
+   * fail-closed, auditando cada descarte por `onAlert` (A09). Sin descriptor
+   * multi-instancia el caller (pulpo) cae al ruteo global de repo-target.
+   */
+  function resolveEvent(event) {
+    return resolveInstanceForEvent(event, {
+      descriptors: instances,
+      audit: (info) => onAlert({
+        projectId: info && info.projectId != null ? info.projectId : null,
+        stage: 'route-discard',
+        errors: [{ detail: info && info.reason ? info.reason : 'evento descartado por el multiplexor' }],
+      }),
+    });
+  }
+
   return {
     bootProducts,
     spawnInstance,
@@ -339,7 +538,15 @@ function createKernelSupervisor(deps = {}) {
     healthcheck,
     restartInstance,
     stopInstance,
+    resolveEvent,
   };
 }
 
-module.exports = { createKernelSupervisor, resolveProjectId };
+module.exports = {
+  createKernelSupervisor,
+  resolveProjectId,
+  // #4763 · Multiplexor de ruteo product-aware (standalone + adaptadores).
+  resolveInstanceForEvent,
+  deriveRepoConfig,
+  extractRepoSlug,
+};

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -77,6 +77,10 @@ const dispatchCause = require('./lib/dispatch-cause');
 // allowlist fail-closed, repo de origen propagado). Reemplaza los literales
 // `intrale/platform` hardcodeados y el intake atado al remote del cwd.
 const repoTarget = require('./lib/repo-target');
+// #4763 (Ola Puente P4, split 2/3) — multiplexor de ruteo product-aware.
+// En single-product (default hoy) el router queda en null y el ruteo cae al
+// repo-target global (getRepoForIssue/getPrimaryRepo) sin cambio de comportamiento.
+const kernelSupervisor = require('./lib/kernel-supervisor');
 // #2490 — Pausa parcial con allowlist explícita de issues
 const partialPause = require('./lib/partial-pause');
 // #3518 CA-6 — Detector de desync waves.json ↔ .partial-pause.json
@@ -15491,6 +15495,43 @@ function findLastRejection(pipelineName, issueNum, config) {
 //
 // Reusa la fuente-de-verdad única del repo destino (repo-target, #4693) y su
 // allowlist fail-closed. El exec de `gh` es inyectable para tests (sin red).
+// #4763 (Ola Puente P4, split 2/3) — router product-aware OPCIONAL. En
+// single-product (estado actual) es null: el ruteo del intake cae al repo-target
+// global vía `getRepoForIssue()` (CA-5 no-regresión). Cuando el supervisor
+// multi-instancia registre descriptores, `setMultiInstanceRouter({ descriptors })`
+// activa el multiplexor fail-closed por instancia (kernelSupervisor.resolveInstanceForEvent).
+let multiInstanceRouter = null; // { descriptors: Map, audit?: fn|{discard} }
+
+function setMultiInstanceRouter(router) {
+  multiInstanceRouter = (router && router.descriptors && typeof router.descriptors.get === 'function')
+    ? router
+    : null;
+}
+
+function getMultiInstanceRouter() {
+  return multiInstanceRouter;
+}
+
+// Resuelve el repo destino de un issue del intake. Fallback fail-closed:
+//   - sin router multi-instancia (single-product) ⇒ `repoTarget.getRepoForIssue`
+//     (comportamiento vigente: repo de origen propagado o primary).
+//   - con router y `issue.projectId` presente ⇒ multiplexor product-aware. Si el
+//     multiplexor descarta (id inseguro / fuera de allowlist / fuera de catálogo)
+//     devuelve `null` y el caller NO encola el issue (no reencamina a primary global).
+function resolveIntakeRepo(issue) {
+  if (multiInstanceRouter && issue && issue.projectId != null) {
+    const resolved = kernelSupervisor.resolveInstanceForEvent(issue, {
+      descriptors: multiInstanceRouter.descriptors,
+      audit: multiInstanceRouter.audit || ((info) => {
+        const pid = info && info.projectId != null ? info.projectId : '?';
+        log('intake', `ruteo descartado — ${info && info.reason ? info.reason : 'motivo desconocido'} (projectId=${pid})`);
+      }),
+    });
+    return resolved ? resolved.repo : null;
+  }
+  return repoTarget.getRepoForIssue(issue);
+}
+
 function discoverWorkDryRun(config, opts = {}) {
   const execFn = typeof opts.exec === 'function'
     ? opts.exec
@@ -15643,7 +15684,17 @@ function brazoIntake(config) {
         // CA-A2 — el repo de origen (propagado en el intake) viaja en el work-yaml
         // para que las fases aguas abajo operen sobre el repo correcto. Fail-closed
         // a primary si el issue no trae repo válido/allowlisted.
-        const baseYaml = { issue: parseInt(issueNum), fase: faseEntrada, pipeline: pipelineName, repo: repoTarget.getRepoForIssue(issue) };
+        // #4763 — `resolveIntakeRepo` parametriza el ruteo por instancia cuando hay
+        // router multi-instancia; en single-product es exactamente `getRepoForIssue`.
+        const intakeRepo = resolveIntakeRepo(issue);
+        if (intakeRepo == null) {
+          // Sólo posible con router multi-instancia: el multiplexor descartó el
+          // evento (id inseguro / fuera de allowlist). Ya fue auditado; no encolar
+          // ni reencaminar al primary global (REQ-SEC-MUX-1 fail-closed).
+          log('intake', `#${issueNum} omitido — multiplexor product-aware descartó el ruteo`);
+          continue;
+        }
+        const baseYaml = { issue: parseInt(issueNum), fase: faseEntrada, pipeline: pipelineName, repo: intakeRepo };
         if (previousRejection) {
           baseYaml.rebote = true;
           baseYaml.rebote_tipo = 're-intake';
@@ -18334,6 +18385,10 @@ if (process.env.PULPO_NO_AUTOSTART === '1') {
   module.exports = {
     // #4687 (Ola Puente P2) — descubrimiento side-effect-free del tablero (dry-run).
     discoverWorkDryRun,
+    // #4763 (Ola Puente P4) — ruteo product-aware por instancia (fallback single-product).
+    resolveIntakeRepo,
+    setMultiInstanceRouter,
+    getMultiInstanceRouter,
     // #4136 — brazo de archivado (frontera activo/histórico).
     brazoArchivado,
     makeIsClosedFromTitleCache,


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 6 archivos · +733 -2

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:skipped` aplicado por delivery

## Closes

Closes #4763
