### PR TITLE
Incidente: notas de voz a Telegram se descartan en silencio por ruta .ogg con separadores Windows corruptos

### DIFF
--- a/.pipeline/lib/__tests__/servicio-telegram-voice.test.js
+++ b/.pipeline/lib/__tests__/servicio-telegram-voice.test.js
@@ -108,3 +108,122 @@ test('buildMultipartBody: Content-Type con CRLF cae al default (defensa inyecci�
   assert.ok(!s.includes('X-Injected'), 'header inyectado no viaja');
   assert.ok(s.includes('Content-Type: application/octet-stream'), 'cae al default seguro');
 });
+
+// -----------------------------------------------------------------------------
+// #4796 — Normalización de ruta de adjunto + guarda fail-closed del solo-audio +
+// canonical-prefix allowlist (seguridad). Incidente 2026-07-19: audios TTS
+// marcados "Enviado" sin llegar por ruta `.ogg` con separadores Windows corruptos.
+// -----------------------------------------------------------------------------
+
+// CA-1 / CA-4 (path feliz) — la normalización resuelve al archivo real y lo deja
+// listo para `sendVoice` (dentro del allowlist).
+test('#4796 resolveAttachmentPath: ruta de voz con separadores redundantes se normaliza y resuelve al .ogg real', () => {
+  const media = svc.mediaBaseDir();
+  fs.mkdirSync(media, { recursive: true });
+  const real = path.join(media, 'tts-happy.ogg');
+  fs.writeFileSync(real, Buffer.from('OggS-fake-audio'));
+
+  // Ruta "sucia" con separadores redundantes (`//` y `/./`) que `path.normalize`
+  // colapsa de forma determinística en cualquier plataforma.
+  const dirty = `${media}//./tts-happy.ogg`;
+  const resolved = svc.resolveAttachmentPath('voice', dirty);
+  assert.ok(resolved, 'una ruta normalizable resuelve a un path no nulo');
+  assert.equal(fs.realpathSync(resolved), fs.realpathSync(real), 'apunta al .ogg real');
+
+  // En Windows, además, el caso exacto del incidente: separadores backslash.
+  if (process.platform === 'win32') {
+    const withBackslashes = real.replace(/\//g, '\\');
+    assert.ok(
+      svc.resolveAttachmentPath('voice', withBackslashes),
+      'ruta con backslashes de Windows también resuelve al archivo real',
+    );
+  }
+});
+
+// CA-2 / CA-3 (fail-closed decisión) — solo-audio con archivo inexistente NO
+// resuelve y dispara la guarda; los caminos con respaldo (texto/edición) o sin
+// adjunto declarado NO se bloquean (sin regresión del cierre optimista legítimo).
+test('#4796 solo-audio inexistente: no resuelve y shouldFailClosed=true; respaldos no se bloquean', () => {
+  const missing = path.join(svc.mediaBaseDir(), 'no-existe-tts.ogg');
+  assert.equal(svc.resolveAttachmentPath('voice', missing), null, 'archivo inexistente → null');
+
+  // Ruta corrupta del incidente (separadores perdidos): no existe → null.
+  assert.equal(
+    svc.resolveAttachmentPath('voice', 'C:WorkspacesIntraleplatformlogsmediatts.ogg'),
+    null,
+    'ruta con separadores perdidos no se "reconstruye" a ciegas → null (fail-closed)',
+  );
+
+  // multipartType null (no resolvió) + sin texto → fail-closed (throw → fallido/).
+  assert.equal(svc.shouldFailClosed({ voice: missing }, null), true);
+  // Con texto de respaldo NO se bloquea (se envía por sendMessage).
+  assert.equal(svc.shouldFailClosed({ voice: missing, text: 'hola' }, null), false);
+  // Edición NO se bloquea.
+  assert.equal(svc.shouldFailClosed({ method: 'editMessageText', message_id: 5 }, null), false);
+  // Dropfile sin adjunto declarado NO se bloquea (cierre optimista legítimo intacto).
+  assert.equal(svc.shouldFailClosed({}, null), false);
+  // Si el adjunto SÍ resolvió (multipartType presente) NO se bloquea.
+  assert.equal(svc.shouldFailClosed({ voice: missing }, 'voice'), false);
+});
+
+// CA-2 / CA-3 (end-to-end del ruteo) — un solo-audio con archivo inexistente,
+// enrutado a `handleSendFailure`, termina en `fallido/` y NUNCA en `listo/`
+// (nunca se marca "Enviado").
+test('#4796 fail-closed enruta a handleSendFailure → fallido/, nunca listo/', () => {
+  const svcDir = path.join(SANDBOX, 'servicios', 'telegram');
+  const pendiente = path.join(svcDir, 'pendiente');
+  const trabajando = path.join(svcDir, 'trabajando');
+  const fallido = path.join(svcDir, 'fallido');
+  const listo = path.join(svcDir, 'listo');
+  for (const d of [pendiente, trabajando, fallido, listo]) fs.mkdirSync(d, { recursive: true });
+
+  const name = 'voice-broken-4796.json';
+  const wp = path.join(trabajando, name);
+  const missing = path.join(svc.mediaBaseDir(), 'nope-4796.ogg');
+  const payload = {
+    voice: missing,
+    _correlationId: rec.generateCorrelationId('voice'),
+    _partIndex: 0,
+    _partTotal: 1,
+  };
+  // La decisión de processQueue: como no resuelve y no hay texto → fail-closed.
+  assert.equal(svc.shouldFailClosed(payload, null), true);
+
+  const err = new Error(`Adjunto declarado sin archivo resoluble (voice=${missing})`);
+  const file = { name, path: path.join(pendiente, name) };
+  fs.writeFileSync(wp, JSON.stringify(payload));
+
+  // Iterar hasta el fallo terminal (el contador de intentos se persiste en el
+  // archivo; cada 'retry' lo devuelve a pendiente/ con backoff).
+  let res;
+  for (let i = 0; i < 20; i++) {
+    res = svc.handleSendFailure(file, wp, err);
+    if (res === 'failed') break;
+    // 'retry' → el archivo quedó en pendiente/; devolverlo a trabajando/ para el
+    // próximo intento (simula el poll de selección tras vencer el backoff).
+    fs.renameSync(file.path, wp);
+  }
+  assert.equal(res, 'failed', 'agota reintentos y termina en fallo terminal');
+  assert.ok(fs.existsSync(path.join(fallido, name)), 'el dropfile queda en fallido/');
+  assert.equal(fs.existsSync(path.join(listo, name)), false, 'NUNCA se movió a listo/ (no "Enviado")');
+});
+
+// CA-4 (seguridad) — una ruta de voz que resuelve FUERA del dir base allowlisted
+// es rechazada (LANZA), nunca se lee ni se envía (anti-exfiltración OWASP A01/A08).
+test('#4796 [seguridad] ruta de voz fuera del dir base allowlisted → rechazada (nunca enviada)', () => {
+  fs.mkdirSync(svc.mediaBaseDir(), { recursive: true });
+  // Archivo "sensible" simulado fuera de logs/media (raíz del sandbox).
+  const outside = path.join(SANDBOX, 'application.conf');
+  fs.writeFileSync(outside, 'BOT_TOKEN=super-secreto-no-exfiltrar');
+
+  assert.throws(
+    () => svc.resolveAttachmentPath('voice', outside),
+    /fuera del dir permitido|seguridad/,
+    'voice fuera del allowlist LANZA (fail-closed) → se enruta a handleSendFailure',
+  );
+
+  // El allowlist estricto aplica SOLO a `voice` (productor con dir base fijo). Los
+  // otros adjuntos (rutas de otros flujos: PDFs de rejection, screenshots) no se
+  // restringen a media/ y conservan el comportamiento previo.
+  assert.doesNotThrow(() => svc.resolveAttachmentPath('document', outside));
+});

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -15331,9 +15331,17 @@ function enqueueTelegramVoice(audioPath, opts = {}) {
   const pt = telegramReceipt.coercePartInt(partTotal);
   const svcDir = path.join(PIPELINE, 'servicios', 'telegram', 'pendiente');
   const filename = `${Date.now()}-voice-p${pi}.json`;
+  // #4796 — Fix de ORIGEN: normalizar a forward-slashes ANTES de serializar. En
+  // Windows los `\` pueden perderse si la ruta atraviesa una segunda ronda de
+  // parse/serialize (incidente 2026-07-19: `C:\…\tts.ogg` → `C:WorkspacesIntrale…ogg`,
+  // que da `existsSync=false` en el consumidor y se descartaba en silencio). El
+  // forward-slash sobrevive cualquier round-trip JSON (no es carácter de escape) y
+  // Node lo acepta en Windows. Este es el choke-point único: tanto el dispatch
+  // inicial como el reenvío del sweep de reconciliación pasan por acá.
+  const normalizedAudioPath = audioPath.replace(/\\/g, '/');
   try {
     const payload = {
-      voice: audioPath,
+      voice: normalizedAudioPath,
       _correlationId: correlationId,
       _partIndex: pi,
       _partTotal: pt,

--- a/.pipeline/servicio-telegram.js
+++ b/.pipeline/servicio-telegram.js
@@ -611,6 +611,84 @@ async function processBurstGroup(group, consolidatedText) {
   log(`Consolidado: ${trabajandoPaths.length} mensajes en burst (key=${group.key.split('|').slice(1).join('|')})`);
 }
 
+// #4796 — Tipos de adjunto que se envían por multipart (ruta a un archivo en
+// disco). El orden fija la precedencia de resolución (document > … > voice),
+// igual que la cadena ternaria histórica.
+const ATTACHMENT_TYPES = ['document', 'photo', 'video', 'animation', 'voice'];
+
+// #4796 — Directorio base allowlisted para adjuntos de tipo `voice` (audio TTS).
+// El productor (`pulpo.dispatchVoiceParts`) genera los `.ogg` en `logs/media/`
+// (`path.join(LOG_DIR, 'media')`, con `LOG_DIR = path.join(PIPELINE, 'logs')`).
+// Cualquier ruta de voz que tras normalizar/canonizar NO caiga bajo este dir se
+// rechaza (fail-closed) para no leer/exfiltrar archivos arbitrarios — un path
+// "reconstruido" jamás debe resolver a `~/.claude/secrets/*` o `application.conf`
+// y terminar subido a Telegram (OWASP A01/A08).
+function mediaBaseDir() {
+  return path.join(PIPELINE, 'logs', 'media');
+}
+
+// #4796 — ¿`target` (canónico) cae bajo `base` (canónico)? Usa path.relative:
+// si el relativo empieza con `..` o es absoluto, target está FUERA de base.
+// `''` (target === base, o sea el propio dir) también se considera fuera (un
+// adjunto nunca es el directorio base).
+function isUnderBase(base, target) {
+  const rel = path.relative(base, target);
+  return rel !== '' && !rel.startsWith('..') && !path.isAbsolute(rel);
+}
+
+// #4796 — Devuelve los tipos de adjunto DECLARADOS en el dropfile (key presente),
+// sin importar si la ruta resuelve. Sirve para la guarda fail-closed: un dropfile
+// que declara `voice` pero cuyo archivo no existe NO debe caer al cierre optimista.
+function declaredAttachmentTypes(data) {
+  if (!data || typeof data !== 'object') return [];
+  return ATTACHMENT_TYPES.filter((t) => data[t] != null);
+}
+
+// #4796 — Normaliza la ruta de un adjunto y, SOLO para `voice`, valida
+// canonical-prefix contra el dir base allowlisted antes de tocar el archivo.
+//
+// Normalización: unifica separadores `\` → `/` y colapsa con `path.normalize`.
+// NO reinserta separadores perdidos (imposible sin heurística que podría resolver
+// a un archivo distinto — vector de exfiltración): una ruta cuyos separadores ya
+// se perdieron (`C:WorkspacesIntrale…ogg`) simplemente NO existirá → se devuelve
+// null → la guarda fail-closed la enruta a `handleSendFailure` (nunca silencio).
+//
+// Retorno:
+//   - string  → ruta canónica segura y existente (usar ESTA para enviar).
+//   - null    → la ruta no resuelve a un archivo existente.
+//   - LANZA   → (voice) la ruta resuelve FUERA del allowlist → exfiltración; el
+//               caller la enruta a `handleSendFailure` (fallo explícito).
+function resolveAttachmentPath(type, rawPath) {
+  if (typeof rawPath !== 'string' || rawPath.length === 0) return null;
+  const normalized = path.normalize(rawPath.replace(/\\/g, '/'));
+  if (!fs.existsSync(normalized)) return null;
+  if (type === 'voice') {
+    // Canonizar ambos lados (resuelve symlinks/`..`) y comparar prefijo.
+    const base = fs.realpathSync(mediaBaseDir());
+    const real = fs.realpathSync(normalized);
+    if (!isUnderBase(base, real)) {
+      throw new Error(
+        `Ruta de adjunto voice fuera del dir permitido (rechazada por seguridad); esperada bajo ${base}`,
+      );
+    }
+    return real;
+  }
+  return normalized;
+}
+
+// #4796 — Decisión pura fail-closed: ¿debe LANZARSE el envío porque el dropfile
+// declaró un adjunto pero ninguno resolvió a un archivo real y no hay respaldo
+// (texto / edición)? Cierra el hueco del solo-audio: antes, `multipartType===null`
+// sin `data.text` caía al cierre optimista (`renameSync → listo/` + log "Enviado")
+// sin haber enviado nada. Ahora → throw → `handleSendFailure`.
+function shouldFailClosed(data, multipartType) {
+  if (multipartType) return false;                 // se resolvió y se envía
+  if (!data || typeof data !== 'object') return false;
+  if (data.text) return false;                     // hay texto de respaldo (sendMessage)
+  if (data.method === 'editMessageText' && Number.isFinite(data.message_id)) return false;
+  return declaredAttachmentTypes(data).length > 0; // adjunto declarado sin archivo
+}
+
 async function processQueue() {
   const allFiles = listWorkFiles(PENDIENTE);
   if (allFiles.length === 0) return;
@@ -675,12 +753,17 @@ async function processQueue() {
       // #4750 — rama `voice`: el audio TTS se enruta por la cola (Opción A) para
       // heredar `assertDelivered` (fail-closed) + `writeSentReceiptIfAny` con la
       // dimensión de chunk. Telegram exige OGG/OPUS para `sendVoice`.
-      const multipartType = data.document && fs.existsSync(data.document) ? 'document'
-        : data.photo && fs.existsSync(data.photo) ? 'photo'
-        : data.video && fs.existsSync(data.video) ? 'video'
-        : data.animation && fs.existsSync(data.animation) ? 'animation'
-        : data.voice && fs.existsSync(data.voice) ? 'voice'
-        : null;
+      // #4796 — Normalización de separadores + canonical-prefix allowlist (voice)
+      // ANTES del envío. Resolvemos la ruta REAL (canónica) del primer adjunto
+      // declarado que exista; se envía ESA, no la cruda del dropfile. Una ruta
+      // de voz que resuelve fuera del allowlist LANZA → cae a handleSendFailure.
+      const declaredAttach = declaredAttachmentTypes(data);
+      let multipartType = null;
+      let resolvedAttachPath = null;
+      for (const t of declaredAttach) {
+        const resolved = resolveAttachmentPath(t, data[t]); // lanza si voice fuera de allowlist
+        if (resolved) { multipartType = t; resolvedAttachPath = resolved; break; }
+      }
 
       if (multipartType) {
         const methodByType = {
@@ -705,7 +788,7 @@ async function processQueue() {
         const mpBody = await telegramSendMultipart(
           methodByType[multipartType],
           multipartType,
-          data[multipartType],
+          resolvedAttachPath, // #4796 — ruta canónica resuelta (no la cruda del dropfile)
           extra,
           contentTypeByType[multipartType] || 'application/octet-stream',
         );
@@ -761,6 +844,18 @@ async function processQueue() {
         // El edit devuelve el mismo message_id; escribimos recibo `enviado` para
         // que el reconciliador del Commander cierre el correlationId del edit.
         writeSentReceiptIfAny(data, [editBody.result.message_id]);
+      } else if (shouldFailClosed(data, multipartType)) {
+        // #4796 — Guarda fail-closed: el dropfile DECLARÓ un adjunto (p.ej.
+        // solo-audio `voice`) pero ninguno resolvió a un archivo real y no hay
+        // texto/edición de respaldo. Antes esto caía al cierre optimista de abajo
+        // (`renameSync → listo/` + log "Enviado") sin haber enviado NADA a Telegram
+        // — descarte silencioso (incidente 2026-07-19). Ahora lanzamos para caer en
+        // el `catch` → `handleSendFailure` (reintento acotado → fallido/ → alerta).
+        // Log con ruta esperada + motivo (sin volcar contenido ni secrets — CA-3).
+        const declaredPaths = declaredAttach.map((t) => `${t}=${data[t]}`).join(', ');
+        throw new Error(
+          `Adjunto declarado sin archivo resoluble (${declaredPaths}); no se marca "Enviado"`,
+        );
       }
 
       const listoPath = path.join(LISTO, file.name);
@@ -812,6 +907,14 @@ module.exports = {
   editMessageText,
   // #4586 (Palanca 2a) — normalizador de message_thread_id, expuesto para tests.
   normalizeThreadId,
+  // #4796 — helpers de normalización/allowlist de rutas de adjunto + guarda
+  // fail-closed del solo-audio. Puros (o I/O acotado sobre disco); no arrancan el
+  // servicio ni tocan red. Expuestos para `node --test`.
+  resolveAttachmentPath,
+  declaredAttachmentTypes,
+  shouldFailClosed,
+  isUnderBase,
+  mediaBaseDir,
 };
 
 // Arranque del servicio: SOLO cuando se ejecuta directamente (`node servicio-telegram.js`),


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 3 archivos · +238 -8

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:skipped` aplicado por delivery

## Closes

Closes #4796
