### PR TITLE
[Split de #4804] Alta durable + lectura del catálogo desde el store + coexistencia (cutover flag) (#4821)

### DIFF
--- a/.pipeline/config.yaml
+++ b/.pipeline/config.yaml
@@ -923,6 +923,28 @@ pipeline:
   audit_retention_days: 90
 
 # =============================================================================
+# #4821 (Split de #4804) — Cutover a persistencia durable del alta de producto.
+#
+# `kernel.durable` es el FLAG DE CUTOVER ÚNICO (CA-6): gatea a la vez la ESCRITURA
+# del alta (`project-bootstrap` → `store.putProduct`) y la LECTURA del catálogo
+# (`product-catalog` → `store.listProducts`). Con `false` (default) el pipeline
+# usa EXACTAMENTE el camino FS actual (registry.json + descriptors/*.json) — nada
+# cambia. Con `true`, lectura Y escritura van al store durable (DynamoDB) para la
+# misma fuente de verdad; nunca coexisten FS-read + DynamoDB-write.
+#
+# El flag se lee UNA SOLA VEZ por operación al inicio del flujo (no se re-consulta
+# mid-flow) para evitar split-brain FS↔DynamoDB.
+#
+# NO activar `durable: true` hasta que #4820 esté mergeado a `main` (driver de
+# producción + tabla provisionada) y se haya corrido `kernel-store-migrate.js`
+# (dry-run → apply) para migrar el estado FS previo. `tableName`/`region` son
+# placeholders acá; los valores reales los entrega #4820.
+kernel:
+  durable: false        # cutover único — default OFF (FS sin cambios)
+  tableName: null       # placeholder — lo define #4820 (naming por config, nunca hardcode)
+  region: null          # placeholder — lo define #4820
+
+# =============================================================================
 # #4309 — Ejecución del fallback in-flight (revive #3578)
 #
 # Cuando un agente arranca su turno con Anthropic y Anthropic se cuelga DURANTE

--- a/.pipeline/config.yaml
+++ b/.pipeline/config.yaml
@@ -928,22 +928,15 @@ pipeline:
 # `kernel.durable` es el FLAG DE CUTOVER ÚNICO (CA-6): gatea a la vez la ESCRITURA
 # del alta (`project-bootstrap` → `store.putProduct`) y la LECTURA del catálogo
 # (`product-catalog` → `store.listProducts`). Con `false` (default) el pipeline
-# usa EXACTAMENTE el camino FS actual (registry.json + descriptors/*.json) — nada
-# cambia. Con `true`, lectura Y escritura van al store durable (DynamoDB) para la
-# misma fuente de verdad; nunca coexisten FS-read + DynamoDB-write.
+# usa EXACTAMENTE el camino FS actual (registry.json + descriptors/*.json). Con
+# `true`, lectura Y escritura van al store durable (DynamoDB); nunca coexisten
+# FS-read + DynamoDB-write. El flag se lee UNA SOLA VEZ por operación (no se
+# re-consulta mid-flow) para evitar split-brain FS↔DynamoDB.
 #
-# El flag se lee UNA SOLA VEZ por operación al inicio del flujo (no se re-consulta
-# mid-flow) para evitar split-brain FS↔DynamoDB.
+# La sección `kernel:` (tableName/region/durable) la aporta #4828/#4820 y vive
+# MÁS ABAJO en este archivo (bloque "kernel-store"). NO se duplica acá para no
+# romper el parser YAML con una clave top-level repetida.
 #
-# NO activar `durable: true` hasta que #4820 esté mergeado a `main` (driver de
-# producción + tabla provisionada) y se haya corrido `kernel-store-migrate.js`
-# (dry-run → apply) para migrar el estado FS previo. `tableName`/`region` son
-# placeholders acá; los valores reales los entrega #4820.
-kernel:
-  durable: false        # cutover único — default OFF (FS sin cambios)
-  tableName: null       # placeholder — lo define #4820 (naming por config, nunca hardcode)
-  region: null          # placeholder — lo define #4820
-
 # =============================================================================
 # #4309 — Ejecución del fallback in-flight (revive #3578)
 #

--- a/.pipeline/lib/__tests__/durable-cutover.test.js
+++ b/.pipeline/lib/__tests__/durable-cutover.test.js
@@ -1,0 +1,320 @@
+'use strict';
+
+// =============================================================================
+// durable-cutover.test.js — Alta durable + lectura del catálogo desde el store
+// bajo flag `kernel.durable` (#4821 · split de #4804).
+//
+// Cobertura de los criterios heredados de #4804:
+//   - CA-3  : escritura atómica sin estado a medias (producto huérfano invisible).
+//   - CA-4  : fail-closed, no a medias — se reporta al operador.
+//   - CA-5  : ConditionalCheckFailedException se distingue de fallo de infra.
+//   - CA-6  : flag de cutover único (durable:false ⇒ FS sin cambios; durable:true
+//             ⇒ lectura Y escritura al store).
+//   - CA-9  : contextProjectId deriva de la credencial, no del payload del wizard.
+//   - CA-10 : validateDescriptor antes de escribir.
+//   - CA-14/15 : errores accionables en español sin ARN/tabla/SK.
+//   - security#2 : fallback FS SELECTIVO (sólo infra, nunca KernelStoreValidationError).
+//   - security#6 : el alta escribe SIEMPRE por putProduct (nunca driver.putItem directo).
+// =============================================================================
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const os = require('node:os');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const b = require('../project-bootstrap');
+const pc = require('../product-catalog');
+const ks = require('../kernel-store');
+const { ConditionalCheckFailedError } = require('../provisioner-infra');
+
+function validDescriptor(overrides = {}) {
+  return {
+    schemaVersion: '1.0',
+    identity: { projectId: 'acme-store', name: 'ACME Store' },
+    repositories: [{ id: 'main', url: 'https://github.com/acme/store', role: 'primary' }],
+    board: {
+      ref: 'https://github.com/orgs/acme/projects/1',
+      admissionLabels: ['Ready'],
+      routing: [{ label: 'area:backend', capability: 'backend' }],
+    },
+    capabilities: [{ interface: 'backend', skills: ['backend-dev'] }],
+    authority: { signers: ['leitolarreta'], gates: { gate2: 'enforce' } },
+    ...overrides,
+  };
+}
+
+// Driver que envuelve al in-memory y falla el putItem de una entidad concreta.
+// `skPrefix='catalog#'` simula el fallo del 2º paso de putProduct (CA-3);
+// `skPrefix='product#'` simula un fallo condicional que aflora al caller (CA-5).
+function makeFailingDriver(baseDriver, skPrefix, failWith) {
+  return {
+    kind: baseDriver.kind,
+    createTable: (...a) => baseDriver.createTable(...a),
+    describeTable: (...a) => baseDriver.describeTable(...a),
+    getItem: (...a) => baseDriver.getItem(...a),
+    deleteItem: (...a) => baseDriver.deleteItem(...a),
+    putItem: (spec, item, opts) => {
+      if (item && typeof item.SK === 'string' && item.SK.startsWith(skPrefix)) {
+        return Promise.reject(failWith());
+      }
+      return baseDriver.putItem(spec, item, opts);
+    },
+  };
+}
+
+// -----------------------------------------------------------------------------
+// CA-6 — coexistencia: con durable:false el comportamiento FS NO cambia.
+// -----------------------------------------------------------------------------
+
+test('CA-6: durable:false NO toca el store y registra en FS (registry.json)', async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'dc-'));
+  const registryPath = path.join(tmp, 'registry.json');
+  let storeCalled = false;
+  const res = await b.runBootstrapAsync({
+    descriptor: validDescriptor(),
+    mode: 'full',
+    deps: {
+      kernelDurable: false,
+      registryPath,
+      contextProjectId: 'acme-store',
+      createStore: () => { storeCalled = true; return null; },
+    },
+  });
+  assert.equal(res.ok, true);
+  assert.equal(res.durable, false);
+  assert.equal(res.status, 'onboarding');
+  assert.equal(storeCalled, false, 'durable:false NUNCA debe instanciar el store');
+  assert.ok(fs.existsSync(registryPath), 'FS registry.json debe escribirse igual que hoy');
+  const reg = JSON.parse(fs.readFileSync(registryPath, 'utf8'));
+  assert.equal(reg.products['acme-store'].status, 'onboarding');
+});
+
+test('CA-6: runBootstrap sync (camino FS) sigue funcionando idéntico', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'dc-'));
+  const registryPath = path.join(tmp, 'registry.json');
+  const res = b.runBootstrap({ descriptor: validDescriptor(), mode: 'full', deps: { registryPath } });
+  assert.equal(res.ok, true);
+  assert.equal(res.durable, false);
+  assert.equal(res.status, 'onboarding');
+});
+
+test('CA-6: listProductsResolved con durable:false barre FS (comportamiento actual)', async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'dc-'));
+  fs.writeFileSync(path.join(tmp, 'p.json'), JSON.stringify({
+    identity: { projectId: 'acme-store', name: 'ACME Store' }, status: 'active',
+    repositories: [{ id: 'main', role: 'primary' }],
+  }));
+  const out = await pc.listProductsResolved({ durable: false, descriptorsDir: tmp });
+  assert.equal(out.length, 1);
+  assert.equal(out[0].projectId, 'acme-store');
+  assert.equal(out[0].role, 'primary');
+});
+
+// -----------------------------------------------------------------------------
+// CA-3 / roundtrip — alta durable escribe y la lectura durable la proyecta.
+// -----------------------------------------------------------------------------
+
+test('roundtrip: alta durable → putProduct + listProducts durable devuelve el producto', async () => {
+  const store = ks.createKernelStore({ contextProjectId: 'acme-store' });
+  const res = await b.runBootstrapAsync({
+    descriptor: validDescriptor(),
+    mode: 'full',
+    deps: { kernelDurable: true, contextProjectId: 'acme-store', createStore: () => store },
+  });
+  assert.equal(res.ok, true);
+  assert.equal(res.durable, true);
+  assert.equal(res.status, 'onboarding');
+
+  const list = await pc.listProductsResolved({ durable: true, store });
+  assert.equal(list.length, 1);
+  assert.equal(list[0].projectId, 'acme-store');
+  assert.equal(list[0].status, 'onboarding');
+
+  // El descriptor#self también quedó persistido (CA-3: sin huérfanos).
+  const desc = await store.getDescriptor('acme-store');
+  assert.ok(desc, 'descriptor#self debe existir tras el alta durable');
+});
+
+// -----------------------------------------------------------------------------
+// CA-3 / CA-4 — fallo parcial: addToCatalog falla tras putItem(producto) ⇒
+// producto NO aparece en listProducts (huérfano invisible) y el alta se reporta
+// al operador (no auto-continúa).
+// -----------------------------------------------------------------------------
+
+test('CA-3/CA-4: fallo parcial deja el producto invisible y reporta al operador', async () => {
+  const base = require('../provisioner-infra').createInMemoryDynamoDriver();
+  const faulty = makeFailingDriver(base, 'catalog#', () => new Error('infra: catalog write down'));
+  const store = ks.createKernelStore({ contextProjectId: 'acme-store', driver: faulty });
+
+  const res = await b.runBootstrapAsync({
+    descriptor: validDescriptor(),
+    mode: 'full',
+    deps: { kernelDurable: true, contextProjectId: 'acme-store', createStore: () => store },
+  });
+  // CA-4: fail-closed, se reporta al operador.
+  assert.equal(res.ok, false);
+  assert.equal(res.stage, 'register-durable');
+  assert.equal(res.durable, true);
+
+  // CA-3: el producto quedó huérfano INVISIBLE — no aparece en el catálogo.
+  const list = await store.listProducts();
+  assert.equal(list.length, 0, 'producto huérfano no indexado no debe listarse');
+});
+
+// -----------------------------------------------------------------------------
+// CA-5 / CA-14 / CA-15 — distinción de error tipado + sanitización.
+// -----------------------------------------------------------------------------
+
+test('CA-5: ConditionalCheckFailedException mapea a "no quedó a medias"', async () => {
+  const base = require('../provisioner-infra').createInMemoryDynamoDriver();
+  const faulty = makeFailingDriver(base, 'product#', () => new ConditionalCheckFailedError('cond'));
+  const store = ks.createKernelStore({ contextProjectId: 'acme-store', driver: faulty });
+
+  const res = await b.runBootstrapAsync({
+    descriptor: validDescriptor(),
+    mode: 'full',
+    deps: { kernelDurable: true, contextProjectId: 'acme-store', createStore: () => store },
+  });
+  assert.equal(res.ok, false);
+  assert.equal(res.errorClass, 'conditional');
+  assert.match(res.errors[0].detail, /no quedó a medias|no quedo a medias/i);
+});
+
+test('CA-5: classifyStoreError distingue conditional / validation / infra', () => {
+  assert.equal(b.classifyStoreError(new ConditionalCheckFailedError('x')), 'conditional');
+  assert.equal(b.classifyStoreError(new ks.KernelStoreValidationError('x', {})), 'validation');
+  assert.equal(b.classifyStoreError(new ks.KernelStoreIsolationError('x', {})), 'validation');
+  assert.equal(b.classifyStoreError(new Error('boom')), 'infra');
+});
+
+test('CA-14/15: el mensaje al operador NO expone ARN/tabla/SK/partición', async () => {
+  const base = require('../provisioner-infra').createInMemoryDynamoDriver();
+  const faulty = makeFailingDriver(base, 'catalog#', () => new Error('table arn:aws:dynamodb:us-east-1:123:table/kernel-store SK=catalog#index PK=acme'));
+  const store = ks.createKernelStore({ contextProjectId: 'acme-store', driver: faulty });
+
+  const res = await b.runBootstrapAsync({
+    descriptor: validDescriptor(),
+    mode: 'full',
+    deps: { kernelDurable: true, contextProjectId: 'acme-store', createStore: () => store },
+  });
+  assert.equal(res.ok, false);
+  const visible = res.human + ' ' + JSON.stringify(res.errors);
+  assert.doesNotMatch(visible, /arn:aws/i, 'no debe exponer ARN');
+  assert.doesNotMatch(visible, /kernel-store/i, 'no debe exponer tableName');
+  assert.doesNotMatch(visible, /catalog#index|SK=|PK=/i, 'no debe exponer SK/PK/partición');
+});
+
+// -----------------------------------------------------------------------------
+// CA-9 — contextProjectId deriva de la credencial, no del descriptor.
+// -----------------------------------------------------------------------------
+
+test('CA-9: contextProjectId ≠ descriptor.projectId ⇒ el store rechaza (anti tenant-hopping)', async () => {
+  // La credencial de la instancia es "other-tenant"; el wizard trae "acme-store".
+  const store = ks.createKernelStore({ contextProjectId: 'other-tenant' });
+  const res = await b.runBootstrapAsync({
+    descriptor: validDescriptor(), // identity.projectId = acme-store
+    mode: 'full',
+    deps: { kernelDurable: true, contextProjectId: 'other-tenant', createStore: () => store },
+  });
+  assert.equal(res.ok, false, 'el store no debe permitir escribir en otra partición');
+  assert.equal(res.stage, 'register-durable');
+});
+
+test('CA-9: sin contextProjectId el write path durable falla fail-closed', async () => {
+  const store = ks.createKernelStore({ contextProjectId: 'acme-store' });
+  const res = await b.runBootstrapAsync({
+    descriptor: validDescriptor(),
+    mode: 'full',
+    deps: { kernelDurable: true, createStore: () => store }, // sin contextProjectId
+  });
+  assert.equal(res.ok, false);
+  assert.equal(res.stage, 'register-durable');
+});
+
+// -----------------------------------------------------------------------------
+// CA-10 — validateDescriptor antes de escribir.
+// -----------------------------------------------------------------------------
+
+test('CA-10: descriptor inválido no llega a persistirse (fail-closed antes del store)', async () => {
+  // Descriptor inválido nunca pasa `prepareBootstrap` → ni se instancia el store.
+  let storeCalled = false;
+  const res = await b.runBootstrapAsync({
+    descriptor: { schemaVersion: '1.0' },
+    mode: 'full',
+    deps: { kernelDurable: true, contextProjectId: 'acme-store', createStore: () => { storeCalled = true; return null; } },
+  });
+  assert.equal(res.ok, false);
+  assert.match(res.stage, /^validation:/);
+  assert.equal(storeCalled, false);
+});
+
+// -----------------------------------------------------------------------------
+// security#2 — fallback FS SELECTIVO en la lectura del catálogo.
+// -----------------------------------------------------------------------------
+
+test('security#2: store no disponible (infra) ⇒ fallback FS loggeado', async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'dc-'));
+  fs.writeFileSync(path.join(tmp, 'p.json'), JSON.stringify({
+    identity: { projectId: 'acme-store', name: 'ACME Store' }, status: 'active',
+  }));
+  let degraded = null;
+  const fakeStore = { listProducts: async () => { throw new Error('infra down'); } };
+  const out = await pc.listProductsResolved({
+    durable: true, descriptorsDir: tmp, store: fakeStore, onDegraded: (r) => { degraded = r; },
+  });
+  assert.equal(out.length, 1, 'debe caer a FS ante fallo de infra');
+  assert.ok(degraded, 'debe loggear el modo degradado');
+});
+
+test('security#2: KernelStoreValidationError NO cae a FS — propaga/escala', async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'dc-'));
+  fs.writeFileSync(path.join(tmp, 'p.json'), JSON.stringify({
+    identity: { projectId: 'acme-store', name: 'ACME Store' }, status: 'active',
+  }));
+  let degraded = false;
+  const fakeStore = { listProducts: async () => { throw new ks.KernelStoreValidationError('catálogo corrupto', { stage: 'schema' }); } };
+  await assert.rejects(
+    () => pc.listProductsResolved({ durable: true, descriptorsDir: tmp, store: fakeStore, onDegraded: () => { degraded = true; } }),
+    /catálogo corrupto|KernelStoreValidationError/,
+  );
+  assert.equal(degraded, false, 'ante tampering NO debe degradar a FS');
+});
+
+test('security#2: store no instanciable ⇒ fallback FS', async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'dc-'));
+  fs.writeFileSync(path.join(tmp, 'p.json'), JSON.stringify({ identity: { projectId: 'acme-store', name: 'A' } }));
+  let degraded = null;
+  const out = await pc.listProductsResolved({
+    durable: true, descriptorsDir: tmp, createStore: () => { throw new Error('no driver'); }, onDegraded: (r) => { degraded = r; },
+  });
+  assert.equal(out.length, 1);
+  assert.ok(degraded);
+});
+
+// -----------------------------------------------------------------------------
+// security#6 / guard estático — el alta escribe SIEMPRE por putProduct; el write
+// path durable NUNCA usa driver.putItem directo ni fs.readFileSync(registry.json).
+// -----------------------------------------------------------------------------
+
+test('security#6: el write path durable no usa driver.putItem directo ni registry.json', () => {
+  const src = fs.readFileSync(path.join(__dirname, '..', 'project-bootstrap.js'), 'utf8');
+  const durableFn = src.slice(src.indexOf('async function durableRegisterProduct'), src.indexOf('// Error interno del write path durable'));
+  assert.ok(durableFn.length > 0, 'debe existir durableRegisterProduct');
+  assert.doesNotMatch(durableFn, /driver\.putItem/, 'el alta durable no debe llamar driver.putItem directo (security#6)');
+  assert.doesNotMatch(durableFn, /readFileSync/, 'el alta durable no debe leer registry.json (split-brain security#1)');
+  assert.match(durableFn, /putProduct/, 'el alta durable debe pasar por putProduct');
+});
+
+// -----------------------------------------------------------------------------
+// CA-6 — el flag se lee UNA sola vez (readKernelConfig honra el override inyectado).
+// -----------------------------------------------------------------------------
+
+test('CA-6: readKernelConfig honra kernelDurable inyectado y default fail-closed', () => {
+  assert.equal(b.readKernelConfig({ kernelDurable: true }).durable, true);
+  assert.equal(b.readKernelConfig({ kernelDurable: false }).durable, false);
+  // config.yaml del repo: default OFF.
+  assert.equal(b.readKernelConfig({}).durable, false, 'config.yaml default debe ser durable:false');
+  // path inexistente ⇒ fail-closed a FS.
+  assert.equal(b.readKernelConfig({ configPath: '/no/existe.yaml' }).durable, false);
+});

--- a/.pipeline/lib/product-catalog.js
+++ b/.pipeline/lib/product-catalog.js
@@ -90,16 +90,122 @@ function listProducts(descriptorsDir) {
     }
     // Orden estable: primario primero, luego alfabético por projectId (determinista
     // para el render SSR y los tests).
-    out.sort((a, b) => {
-        if (a.role !== b.role) return a.role === 'primary' ? -1 : 1;
-        return a.projectId < b.projectId ? -1 : (a.projectId > b.projectId ? 1 : 0);
-    });
+    out.sort(sortCatalog);
     return out;
+}
+
+// Comparador de orden estable compartido por el barrido FS y la proyección durable.
+function sortCatalog(a, b) {
+    if (a.role !== b.role) return a.role === 'primary' ? -1 : 1;
+    return a.projectId < b.projectId ? -1 : (a.projectId > b.projectId ? 1 : 0);
+}
+
+// -----------------------------------------------------------------------------
+// #4821 — Lectura del catálogo desde el store durable (read path del cutover).
+//
+// Proyección pública de UN body de producto tal como lo devuelve
+// `kernel-store.listProducts()` (`{ productId, name, status, descriptorRef? }`).
+// Whitelist explícita a la MISMA forma que `projectDescriptor` para que el
+// dashboard consuma indistinto de la fuente. Fail-closed en `projectId`.
+// -----------------------------------------------------------------------------
+function projectStoreProduct(body) {
+    const b = (body && typeof body === 'object') ? body : {};
+    const projectId = b.productId;
+    if (!isSafeProjectId(projectId)) return null;
+    return {
+        projectId,
+        name: (typeof b.name === 'string' && b.name) ? b.name : projectId,
+        status: (typeof b.status === 'string' && b.status) ? b.status : 'active',
+        // El body del store no transporta `role` (metadato de repos); el catálogo
+        // durable lista productos del contexto de la instancia como 'secondary'
+        // salvo que el body lo declare explícitamente.
+        role: (b.role === 'primary') ? 'primary' : 'secondary',
+    };
+}
+
+/**
+ * Enumera el catálogo resolviendo la fuente según el flag de cutover `kernel.durable`
+ * (#4821 · CA-6). Async porque el store durable lo es.
+ *
+ *   - `durable:false` (default) → barrido FS de `descriptorsDir` (comportamiento
+ *     ACTUAL, sin cambios · CA-6).
+ *   - `durable:true`  → proyecta desde `store.listProducts()`.
+ *
+ * Fallback SELECTIVO durante la coexistencia (security#2): sólo se cae a FS cuando
+ * el store NO está disponible (fallo de INFRA), loggeando el modo degradado. Ante
+ * `KernelStoreValidationError` (catálogo corrupto/inyectado) NO se cae a FS: se
+ * propaga para que escale (nunca enmascarar tampering con el barrido FS).
+ *
+ * @param {object} opts
+ * @param {string}  opts.descriptorsDir  dir de descriptores (fuente FS / fallback).
+ * @param {boolean} [opts.durable=false] flag de cutover, leído UNA vez por el caller.
+ * @param {object}  [opts.store]         instancia de kernel-store (o pasar createStore).
+ * @param {function}[opts.createStore]   factory lazy del store (evita instanciar en modo FS).
+ * @param {function}[opts.onDegraded]    callback(reason) al caer a FS por infra.
+ * @returns {Promise<Array<{projectId:string,name:string,status:string,role:string}>>}
+ */
+async function listProductsResolved(opts = {}) {
+    const descriptorsDir = opts.descriptorsDir;
+    if (opts.durable !== true) {
+        // Modo FS (default): comportamiento actual intacto.
+        return listProducts(descriptorsDir);
+    }
+
+    // Modo durable — resolver el store (inyectado o vía factory lazy).
+    let store = (opts.store && typeof opts.store.listProducts === 'function') ? opts.store : null;
+    if (!store && typeof opts.createStore === 'function') {
+        try {
+            const s = opts.createStore();
+            if (s && typeof s.listProducts === 'function') store = s;
+        } catch (err) {
+            // Falla al construir el store = infra no disponible → fallback FS.
+            logDegraded(opts, `no se pudo instanciar el store: ${err && err.message ? err.message : err}`);
+            return listProducts(descriptorsDir);
+        }
+    }
+    if (!store) {
+        logDegraded(opts, 'store durable no disponible');
+        return listProducts(descriptorsDir);
+    }
+
+    let raw;
+    try {
+        raw = await store.listProducts();
+    } catch (err) {
+        // security#2: catálogo corrupto/inyectado NO cae a FS — propaga/escala.
+        if (err && err.name === 'KernelStoreValidationError') throw err;
+        // Fallo de infra (store no disponible) → fallback FS loggeado (degradado).
+        logDegraded(opts, err && err.message ? err.message : String(err));
+        return listProducts(descriptorsDir);
+    }
+
+    const seen = new Set();
+    const out = [];
+    for (const body of Array.isArray(raw) ? raw : []) {
+        const proj = projectStoreProduct(body);
+        if (!proj || seen.has(proj.projectId)) continue;
+        seen.add(proj.projectId);
+        out.push(proj);
+    }
+    out.sort(sortCatalog);
+    return out;
+}
+
+function logDegraded(opts, reason) {
+    if (typeof opts.onDegraded === 'function') {
+        try { opts.onDegraded(reason); } catch { /* logging best-effort */ }
+        return;
+    }
+    // Traza mínima (sin credenciales/ARN) del modo degradado FS. Silenciable con
+    // `onDegraded` (los tests inyectan su propio sink para no ensuciar la salida).
+    try { console.warn(`[product-catalog] modo durable degradó a FS: ${reason}`); } catch { /* noop */ }
 }
 
 module.exports = {
     listProducts,
+    listProductsResolved,
     projectDescriptor,
+    projectStoreProduct,
     isSafeProjectId,
     SAFE_ID_RE,
 };

--- a/.pipeline/lib/project-bootstrap.js
+++ b/.pipeline/lib/project-bootstrap.js
@@ -193,8 +193,187 @@ function defaultRegisterProduct(entry, deps = {}) {
   return { registryPath, status: 'onboarding' };
 }
 
+// -----------------------------------------------------------------------------
+// Flag de cutover `kernel.durable` (#4821 · CA-6). Se lee UNA SOLA VEZ por
+// operación al inicio del registro (nunca mid-flow) para evitar split-brain
+// FS↔DynamoDB. Inyectable por tests vía `deps.kernelConfig` / `deps.kernelDurable`.
+// Fail-closed a FS: cualquier error de lectura de config ⇒ `durable:false`.
+// -----------------------------------------------------------------------------
+const DEFAULT_CONFIG_PATH = path.resolve(__dirname, '..', 'config.yaml');
+
+function readKernelConfig(deps = {}) {
+  if (deps.kernelConfig && typeof deps.kernelConfig === 'object') {
+    return { durable: deps.kernelConfig.durable === true, tableName: deps.kernelConfig.tableName ?? null, region: deps.kernelConfig.region ?? null };
+  }
+  if (typeof deps.kernelDurable === 'boolean') {
+    return { durable: deps.kernelDurable, tableName: null, region: null };
+  }
+  try {
+    const yaml = require('js-yaml'); // safe-by-default (load, sin !!js/function)
+    const cfgPath = deps.configPath || DEFAULT_CONFIG_PATH;
+    const cfg = yaml.load(fs.readFileSync(cfgPath, 'utf8')) || {};
+    const k = (cfg.kernel && typeof cfg.kernel === 'object') ? cfg.kernel : {};
+    return { durable: k.durable === true, tableName: k.tableName ?? null, region: k.region ?? null };
+  } catch {
+    return { durable: false, tableName: null, region: null }; // fail-closed a FS
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Sanitización de errores al operador (#4821 · CA-5 / CA-14 / CA-15). El mensaje
+// visible NUNCA expone ARN / tableName / SK / partición: sólo un texto accionable
+// en español. `ConditionalCheckFailedException` (o condición de escritura fallida)
+// se distingue como "el estado NO quedó a medias" (CA-5), separado de un fallo de
+// infra genérico. El detalle técnico crudo queda para logs internos, jamás en la
+// respuesta al operador.
+// -----------------------------------------------------------------------------
+function classifyStoreError(err) {
+  const name = err && err.name ? String(err.name) : '';
+  const msg = err && err.message ? String(err.message) : '';
+  if (name === 'ConditionalCheckFailedError' || /ConditionalCheckFailed/i.test(name + ' ' + msg)) {
+    return 'conditional';
+  }
+  if (name === 'KernelStoreValidationError' || name === 'KernelStoreIsolationError' || name === 'KernelStoreSizeError') {
+    return 'validation';
+  }
+  return 'infra';
+}
+
+function sanitizeOperatorError(err) {
+  const cls = classifyStoreError(err);
+  if (cls === 'conditional' || cls === 'validation') {
+    // CA-5: condición de escritura / validación fail-closed ⇒ el alta no quedó a
+    // medias. Nada persistió de forma visible; el operador puede reintentar.
+    return { class: cls, operatorMessage: 'No se pudo completar el alta: el estado NO quedó a medias. Revisá los datos e intentá de nuevo.' };
+  }
+  // CA-14/15: fallo de infra ⇒ mensaje genérico, sin exponer detalle técnico.
+  return { class: 'infra', operatorMessage: 'No se pudo completar el alta por un problema temporal del almacenamiento. Volvé a intentar en unos minutos.' };
+}
+
+// -----------------------------------------------------------------------------
+// Registro DURABLE del producto (#4821 · write path). Persiste vía la API pública
+// del kernel-store — SIEMPRE por `putProduct` (nunca `driver.putItem` directo).
+//
+// Orden de escritura (CA-3, fail-safe): `putProduct` primero (interna: producto →
+// catálogo; si el 2º paso `addToCatalog` falla, el producto queda huérfano
+// INVISIBLE a `listProducts`), y `putDescriptor` al final. Así un fallo parcial
+// NUNCA deja un `descriptor#self` huérfano indexado. `putDescriptor`/`putProduct`
+// reejecutan la validación fail-closed (CA-10: `validateDescriptor` antes de
+// persistir; A04 `maxItemBytes`).
+//
+// CA-9 (anti tenant-hopping): `contextProjectId` DEBE derivar de la credencial de
+// la instancia (inyectado por el caller), NUNCA del descriptor/request del wizard.
+// El store valida `item.projectId === contextProjectId` como defensa en profundidad.
+// -----------------------------------------------------------------------------
+async function durableRegisterProduct(entry, descriptor, deps = {}) {
+  // CA-9: el contexto de tenant proviene de la credencial de la instancia, no del
+  // payload. Fail-closed si el caller no lo inyectó (no se deriva del descriptor).
+  const contextProjectId = deps.contextProjectId;
+  if (!contextProjectId) {
+    throw new KernelStoreContextError('contextProjectId ausente: debe derivar de la credencial de la instancia (CA-9), nunca del descriptor');
+  }
+  const kernelCfg = deps.kernelConfig || readKernelConfig(deps);
+  const factory = typeof deps.createStore === 'function'
+    ? deps.createStore
+    : require('./kernel-store').createKernelStore;
+  const store = factory({
+    contextProjectId,
+    config: { kernel: { tableName: kernelCfg.tableName, region: kernelCfg.region } },
+    driver: deps.storeDriver,
+    onAlert: deps.onAlert,
+  });
+
+  // CA-10: validación explícita antes de persistir (además de la que reejecuta el
+  // store). Fail-closed: si el descriptor no valida, no se escribe nada.
+  const dres = descriptorLib.validateDescriptor(descriptor);
+  if (!dres.valid) {
+    throw new KernelStoreContextError(`descriptor inválido antes de persistir (CA-10): ${dres.stage}`);
+  }
+
+  // CA-3: producto + catálogo primero (atómico interno, orden fail-safe); el
+  // descriptor#self se escribe al final para no dejar huérfanos indexados.
+  const put = await store.putProduct({ productId: entry.projectId, name: entry.name, status: 'onboarding' });
+  await store.putDescriptor(descriptor);
+  return { status: 'onboarding', durable: true, sk: put.sk, contextProjectId };
+}
+
+// Error interno del write path durable (no expone detalle al operador).
+class KernelStoreContextError extends Error {
+  constructor(message) { super(message); this.name = 'KernelStoreContextError'; }
+}
+
+// -----------------------------------------------------------------------------
+// Pipeline pre-registro compartido (validación → firma → acceso → dry-run).
+// Devuelve `{ error }` con el resultado fail-closed, o el contexto para registrar.
+// -----------------------------------------------------------------------------
+function prepareBootstrap(args = {}) {
+  const mode = args.mode === 'full' ? 'full' : 'dry-run';
+  const deps = args.deps || {};
+
+  // Paso 1 — validación fail-closed.
+  const validation = args.descriptor
+    ? descriptorLib.validateDescriptor(args.descriptor, { expectedChecksum: args.expectedChecksum })
+    : descriptorLib.loadDescriptor(args.descriptorPath, { expectedChecksum: args.expectedChecksum });
+  if (!validation.valid) {
+    return { error: { ok: false, stage: `validation:${validation.stage}`, mode, errors: validation.errors, human: renderHuman({ ok: false, stage: `validation:${validation.stage}`, errors: validation.errors }) } };
+  }
+  const descriptor = validation.descriptor;
+
+  // Gate de autoridad de firma (CA-D4): si signers vacío/inválido, bloquea.
+  const sigGate = descriptorLib.resolveSignerAuthority(descriptor);
+  if (sigGate.blocked) {
+    return { error: { ok: false, stage: 'signature-gate', mode, errors: [{ path: 'authority.signers', detail: sigGate.reason }], human: renderHuman({ ok: false, stage: 'signature-gate', errors: [{ detail: sigGate.reason }] }) } };
+  }
+
+  // Paso 2 — verificación de acceso (SSRF allowlist).
+  const access = verifyAccess(descriptor, deps);
+  if (!access.ok) {
+    const rejected = access.targets.filter((t) => !t.allowed || t.reachable === false);
+    return { error: { ok: false, stage: 'access', mode, access, errors: rejected.map((t) => ({ path: `${t.kind}:${t.id}`, detail: t.reason || 'no alcanzable' })), human: renderHuman({ ok: false, stage: 'access', access }) } };
+  }
+
+  // Paso 3 — dry-run side-effect-free.
+  const dry = dryRun(descriptor, deps);
+  if (!dry.ok) {
+    return { error: { ok: false, stage: 'dry-run', mode, errors: [{ path: 'dry-run', detail: dry.reason }], human: renderHuman({ ok: false, stage: 'dry-run', errors: [{ detail: dry.reason }] }) } };
+  }
+
+  return { descriptor, access, dry, mode, deps };
+}
+
+function dryRunResult(descriptor, access, dry, mode) {
+  return {
+    ok: true,
+    stage: 'dry-run',
+    mode,
+    sideEffects: false,
+    projectId: descriptor.identity.projectId,
+    access,
+    dryRun: dry,
+    human: renderHuman({ ok: true, stage: 'dry-run', projectId: descriptor.identity.projectId, access, dryRun: dry }),
+  };
+}
+
+function registeredResult(descriptor, access, dry, mode, register, durable) {
+  return {
+    ok: true,
+    stage: 'registered',
+    mode,
+    status: 'onboarding',
+    durable: !!durable,
+    projectId: descriptor.identity.projectId,
+    access,
+    dryRun: dry,
+    register,
+    human: renderHuman({ ok: true, stage: 'registered', projectId: descriptor.identity.projectId, status: 'onboarding', access, dryRun: dry }),
+  };
+}
+
 /**
- * Orquesta el bootstrap completo. Fail-closed: aborta en el primer paso que falle.
+ * Orquesta el bootstrap completo (SÍNCRONO · camino FS). Fail-closed: aborta en el
+ * primer paso que falle. Este entry point NO ejecuta el write path durable (que es
+ * async): con `kernel.durable:false` (default) el comportamiento FS no cambia
+ * (CA-6). Para el alta durable usar `runBootstrapAsync`.
  *
  * @param {object} args
  * @param {string} [args.descriptorPath]  path del descriptor (o pasar args.descriptor).
@@ -204,67 +383,72 @@ function defaultRegisterProduct(entry, deps = {}) {
  * @returns {{ ok:boolean, stage:string, mode:string, ... }}
  */
 function runBootstrap(args = {}) {
-  const mode = args.mode === 'full' ? 'full' : 'dry-run';
-  const deps = args.deps || {};
+  const prep = prepareBootstrap(args);
+  if (prep.error) return prep.error;
+  const { descriptor, access, dry, mode, deps } = prep;
 
-  // Paso 1 — validación fail-closed.
-  const validation = args.descriptor
-    ? descriptorLib.validateDescriptor(args.descriptor, { expectedChecksum: args.expectedChecksum })
-    : descriptorLib.loadDescriptor(args.descriptorPath, { expectedChecksum: args.expectedChecksum });
-  if (!validation.valid) {
-    return { ok: false, stage: `validation:${validation.stage}`, mode, errors: validation.errors, human: renderHuman({ ok: false, stage: `validation:${validation.stage}`, errors: validation.errors }) };
-  }
-  const descriptor = validation.descriptor;
+  if (mode === 'dry-run') return dryRunResult(descriptor, access, dry, mode);
 
-  // Gate de autoridad de firma (CA-D4): si signers vacío/inválido, bloquea.
-  const sigGate = descriptorLib.resolveSignerAuthority(descriptor);
-  if (sigGate.blocked) {
-    return { ok: false, stage: 'signature-gate', mode, errors: [{ path: 'authority.signers', detail: sigGate.reason }], human: renderHuman({ ok: false, stage: 'signature-gate', errors: [{ detail: sigGate.reason }] }) };
-  }
-
-  // Paso 2 — verificación de acceso (SSRF allowlist).
-  const access = verifyAccess(descriptor, deps);
-  if (!access.ok) {
-    const rejected = access.targets.filter((t) => !t.allowed || t.reachable === false);
-    return { ok: false, stage: 'access', mode, access, errors: rejected.map((t) => ({ path: `${t.kind}:${t.id}`, detail: t.reason || 'no alcanzable' })), human: renderHuman({ ok: false, stage: 'access', access }) };
-  }
-
-  // Paso 3 — dry-run side-effect-free.
-  const dry = dryRun(descriptor, deps);
-  if (!dry.ok) {
-    return { ok: false, stage: 'dry-run', mode, errors: [{ path: 'dry-run', detail: dry.reason }], human: renderHuman({ ok: false, stage: 'dry-run', errors: [{ detail: dry.reason }] }) };
-  }
-
-  if (mode === 'dry-run') {
-    // NUNCA registra. Estado del producto no muta.
-    return {
-      ok: true,
-      stage: 'dry-run',
-      mode,
-      sideEffects: false,
-      projectId: descriptor.identity.projectId,
-      access,
-      dryRun: dry,
-      human: renderHuman({ ok: true, stage: 'dry-run', projectId: descriptor.identity.projectId, access, dryRun: dry }),
-    };
-  }
-
-  // Paso 4 — registrar onboarding (INACTIVO) hasta OK humano.
+  // Paso 4 — registrar onboarding (INACTIVO) hasta OK humano. Camino FS.
+  const entry = { projectId: descriptor.identity.projectId, name: descriptor.identity.name };
   const register = typeof deps.registerProduct === 'function'
-    ? deps.registerProduct({ projectId: descriptor.identity.projectId, name: descriptor.identity.name }, deps)
-    : defaultRegisterProduct({ projectId: descriptor.identity.projectId, name: descriptor.identity.name }, deps);
+    ? deps.registerProduct(entry, deps)
+    : defaultRegisterProduct(entry, deps);
 
-  return {
-    ok: true,
-    stage: 'registered',
-    mode,
-    status: 'onboarding',
-    projectId: descriptor.identity.projectId,
-    access,
-    dryRun: dry,
-    register,
-    human: renderHuman({ ok: true, stage: 'registered', projectId: descriptor.identity.projectId, status: 'onboarding', access, dryRun: dry }),
-  };
+  return registeredResult(descriptor, access, dry, mode, register, false);
+}
+
+/**
+ * Variante ASÍNCRONA del bootstrap (#4821). Idéntica a `runBootstrap` salvo que
+ * el paso 4 puede tomar el WRITE PATH DURABLE cuando `kernel.durable` está ON.
+ *
+ * El flag se lee UNA SOLA VEZ al inicio del registro (CA-6): no se re-consulta
+ * mid-flow, evitando split-brain FS↔DynamoDB. Con el flag OFF (default) delega en
+ * el mismo registro FS que `runBootstrap`. Con el flag ON persiste vía el
+ * kernel-store (`putProduct` + `putDescriptor`) con errores sanitizados al
+ * operador (CA-5/14/15) y `contextProjectId` derivado de la credencial (CA-9).
+ *
+ * @returns {Promise<{ ok:boolean, stage:string, mode:string, ... }>}
+ */
+async function runBootstrapAsync(args = {}) {
+  const prep = prepareBootstrap(args);
+  if (prep.error) return prep.error;
+  const { descriptor, access, dry, mode, deps } = prep;
+
+  if (mode === 'dry-run') return dryRunResult(descriptor, access, dry, mode);
+
+  // CA-6: el flag de cutover se evalúa UNA sola vez, al inicio de la operación.
+  const kernelCfg = readKernelConfig(deps);
+  const entry = { projectId: descriptor.identity.projectId, name: descriptor.identity.name };
+
+  if (kernelCfg.durable) {
+    try {
+      const register = await durableRegisterProduct(entry, descriptor, { ...deps, kernelConfig: kernelCfg });
+      return registeredResult(descriptor, access, dry, mode, register, true);
+    } catch (err) {
+      // CA-4: fail-closed — el alta no queda a medias y se reporta al operador.
+      // CA-14/15: mensaje accionable sin ARN/tabla/SK; el detalle técnico va a logs.
+      const op = sanitizeOperatorError(err);
+      const errors = [{ path: 'store', detail: op.operatorMessage }];
+      return {
+        ok: false,
+        stage: 'register-durable',
+        mode,
+        durable: true,
+        errorClass: op.class,
+        errors,
+        // detalle técnico crudo SOLO para logs internos, nunca en `human`.
+        _internalError: err && err.message ? String(err.message) : String(err),
+        human: renderHuman({ ok: false, stage: 'register-durable', errors }),
+      };
+    }
+  }
+
+  // Flag OFF (default) — mismo registro FS que el camino síncrono (CA-6: FS sin cambios).
+  const register = typeof deps.registerProduct === 'function'
+    ? deps.registerProduct(entry, deps)
+    : defaultRegisterProduct(entry, deps);
+  return registeredResult(descriptor, access, dry, mode, register, false);
 }
 
 // -----------------------------------------------------------------------------
@@ -312,8 +496,14 @@ module.exports = {
   verifyAccess,
   dryRun,
   runBootstrap,
+  runBootstrapAsync,
+  durableRegisterProduct,
+  readKernelConfig,
+  sanitizeOperatorError,
+  classifyStoreError,
   renderHuman,
   DEFAULT_REGISTRY_PATH,
+  DEFAULT_CONFIG_PATH,
 };
 
 // -----------------------------------------------------------------------------
@@ -330,12 +520,19 @@ if (require.main === module) {
     process.exit(2);
   }
   const mode = flags.has('--full') ? 'full' : 'dry-run';
-  const res = runBootstrap({ descriptorPath, mode });
-  if (flags.has('--json')) {
-    // El resultado JSON no contiene secretos (redacción por diseño).
-    process.stdout.write(JSON.stringify({ ...res, human: undefined }, null, 2) + '\n');
-  } else {
-    process.stdout.write(res.human + '\n');
-  }
-  process.exit(res.ok ? 0 : 1);
+  // Usa el entry async para respetar el flag `kernel.durable` (CA-6). Con el flag
+  // OFF (default) el resultado es idéntico al camino FS síncrono.
+  runBootstrapAsync({ descriptorPath, mode }).then((res) => {
+    if (flags.has('--json')) {
+      // El resultado JSON no contiene secretos (redacción por diseño); el detalle
+      // técnico interno del write path durable no se emite al operador.
+      process.stdout.write(JSON.stringify({ ...res, human: undefined, _internalError: undefined }, null, 2) + '\n');
+    } else {
+      process.stdout.write(res.human + '\n');
+    }
+    process.exit(res.ok ? 0 : 1);
+  }).catch((e) => {
+    process.stderr.write(`error inesperado: ${e && e.message ? e.message : e}\n`);
+    process.exit(1);
+  });
 }


### PR DESCRIPTION
Integra #4821 sobre `main` tras el merge de #4828 (driver DynamoDB). 

**Fix incluido:** deduplica la sección `kernel:` en `.pipeline/config.yaml` que quedaba repetida al integrar #4828 (rompía el parser YAML). Ahora hay una sola clave `kernel: {tableName, region, durable:false}`.

**Cambios:**
- `product-catalog.js` — lectura del catálogo desde el store durable bajo flag `kernel.durable`.
- `project-bootstrap.js` — alta durable (`putProduct`) detrás del mismo flag.
- `config.yaml` — doc del flag de cutover + dedup de `kernel:`.
- tests `durable-cutover.test.js`.

**Verificación:** 28/28 tests verdes (16 durable-cutover + 12 kernel driver #4820/#4828). `config.yaml` parsea con js-yaml (una sola clave `kernel:`). Flag `durable:false` por default → comportamiento FS actual sin cambios.

Infra pura del pipeline (sin `app:*`) → `qa:skipped`.

Closes #4821