### PR TITLE
[Split de #4804] Boot del supervisor multi-producto desde el store durable

### DIFF
--- a/.pipeline/config.yaml
+++ b/.pipeline/config.yaml
@@ -1389,6 +1389,13 @@ kernel:
   tableName: ""      # requerido para el driver real (normalizeConfig lo exige)
   region: ""         # región AWS destino (vacío mientras durable:false)
   durable: false     # default OFF -- todo sigue en FS, cero llamadas AWS
+  # #4822 (split 3/3 de #4804) — Cota de instancias del boot durable del supervisor
+  # multi-producto (CA-SEC-4 / REQ-SEC-BOOT-5, A04/DoS). Sibling de `durable` (que
+  # sigue siendo booleano para no romper el fail-closed de #4820). El boot durable
+  # spawnea COMO MÁXIMO este número de pipelines por producto `active`; un catálogo
+  # con más activos saltea el excedente y lo audita. Default conservador: la RAM
+  # del host es crítica (ver umbrales de presión del Pulpo).
+  max_concurrent_instances: 2
 
 # =============================================================================
 # #3613 — Bootstrap del skill `architect` (paraguas #3559, spike #3507)

--- a/.pipeline/lib/__tests__/kernel-supervisor.test.js
+++ b/.pipeline/lib/__tests__/kernel-supervisor.test.js
@@ -21,7 +21,12 @@ const assert = require('node:assert/strict');
 
 const { createInMemoryDynamoDriver } = require('../provisioner-infra');
 const { createKernelStore, KernelStoreIsolationError } = require('../kernel-store');
-const { createKernelSupervisor, resolveProjectId } = require('../kernel-supervisor');
+const {
+  createKernelSupervisor,
+  resolveProjectId,
+  bootKernelDurable,
+  MAX_CONCURRENT_INSTANCES_DEFAULT,
+} = require('../kernel-supervisor');
 const { isSafeId } = require('../project-descriptor');
 const { isSafeProjectId, segmentProductState } = require('../product-state-segment');
 
@@ -891,4 +896,143 @@ test('#4805 CA-8 · bootProducts instancia el producto recién activado (idempot
   // 3ra reconciliación idempotente: no cambia el conteo.
   await supervisor.bootProducts();
   assert.equal(supervisor.listInstances().length, 2, 'idempotente: sin duplicados');
+});
+
+// =============================================================================
+// #4822 (Split 3/3 de #4804) — Cota de instancias + boot durable gateado
+// =============================================================================
+
+// Catálogo de N>cap productos active para ejercitar la cota (CA-SEC-4).
+const CATALOG_N_ACTIVOS = [
+  { productId: 'acme', projectId: 'acme', name: 'ACME', status: 'active' },
+  { productId: 'globex', projectId: 'globex', name: 'Globex', status: 'active' },
+  { productId: 'initech', projectId: 'initech', name: 'Initech', status: 'active' },
+  { productId: 'soylent', projectId: 'soylent', name: 'Soylent', status: 'active' },
+];
+
+// CA-SEC-4 / REQ-SEC-BOOT-5 — la cota es el núcleo de este split: un catálogo con
+// N>cap productos active NO spawnea sin techo; el excedente se saltea y se audita.
+test('#4822 · CA-SEC-4 · bootProducts respeta el cap con catálogo de N>cap activos', async () => {
+  const alerts = [];
+  const supervisor = createKernelSupervisor({
+    catalogStore: fakeCatalogStore(CATALOG_N_ACTIVOS),
+    storeFactory: recordingStoreFactory([]),
+    hydrate: false,
+    maxConcurrentInstances: 2,
+    onAlert: (a) => alerts.push(a),
+  });
+
+  const res = await supervisor.bootProducts();
+
+  assert.equal(res.spawned.length, 2, 'exactamente `cap` instancias spawneadas');
+  assert.equal(supervisor.listInstances().length, 2, 'solo 2 instancias vivas');
+  const capSkips = res.skipped.filter((s) => s.reason === 'cap de instancias alcanzado');
+  assert.equal(capSkips.length, 2, 'los N-cap restantes se saltean por cap');
+  const capAlerts = alerts.filter((a) => a.stage === 'cap');
+  assert.equal(capAlerts.length, 2, 'cada excedente emite alerta de cap (CA-SEC-6)');
+  assert.ok(capAlerts.every((a) => a.projectId), 'la alerta de cap lleva el projectId de origen');
+});
+
+// Compat: sin cota configurada, el comportamiento previo se mantiene (todos los
+// activos se instancian). La cota es opt-in a nivel supervisor.
+test('#4822 · sin maxConcurrentInstances el boot instancia todos los activos (compat)', async () => {
+  const supervisor = createKernelSupervisor({
+    catalogStore: fakeCatalogStore(CATALOG_N_ACTIVOS),
+    storeFactory: recordingStoreFactory([]),
+    hydrate: false,
+  });
+  const res = await supervisor.bootProducts();
+  assert.equal(res.spawned.length, 4, 'sin cap se instancian los 4 activos');
+  assert.equal(res.skipped.filter((s) => s.reason === 'cap de instancias alcanzado').length, 0, 'sin skips por cap');
+});
+
+// CA-6 / CA-SEC-1 — fail-closed del flag: sin `kernel.durable === true` el boot
+// durable NO corre. buildCatalogStore NUNCA se invoca (no se toca AWS) y el
+// supervisor tampoco se instancia.
+for (const [caso, cfg] of [
+  ['flag ausente', {}],
+  ['kernel ausente', { otra: 1 }],
+  ['durable:false', { kernel: { durable: false } }],
+  ['durable truthy no-booleano', { kernel: { durable: 'true' } }],
+  ['durable:1', { kernel: { durable: 1 } }],
+]) {
+  test(`#4822 · CA-6/CA-SEC-1 · boot durable NO corre con ${caso}`, async () => {
+    let builtStore = false;
+    let builtSupervisor = false;
+    const res = await bootKernelDurable({
+      config: cfg,
+      buildCatalogStore: () => { builtStore = true; return fakeCatalogStore([]); },
+      createSupervisor: () => { builtSupervisor = true; return { bootProducts: async () => ({ spawned: [], skipped: [] }) }; },
+    });
+    assert.equal(res.ran, false, 'no corre el boot durable');
+    assert.equal(res.reason, 'flag-off', 'razón flag-off');
+    assert.equal(builtStore, false, 'buildCatalogStore NO se invoca (cero AWS con flag OFF)');
+    assert.equal(builtSupervisor, false, 'no se instancia el supervisor con flag OFF');
+  });
+}
+
+// CA-1 (integración del wiring) — con el flag ON, bootKernelDurable carga los
+// `active` desde el catálogo durable y los instancia respetando la cota de config.
+test('#4822 · CA-1 · boot durable con flag ON instancia los active del store durable', async () => {
+  const spawnedProducts = [];
+  const res = await bootKernelDurable({
+    config: { kernel: { durable: true, max_concurrent_instances: 3 } },
+    buildCatalogStore: () => fakeCatalogStore(CATALOG_MIXTO),
+    buildStoreFactory: () => recordingStoreFactory([]),
+    spawn: (ctx) => { spawnedProducts.push(ctx.projectId); return { alive: true }; },
+  });
+  assert.equal(res.ran, true, 'corre el boot durable');
+  assert.equal(res.cap, 3, 'usa la cota de config');
+  assert.deepEqual(res.spawned.sort(), ['acme', 'globex'], 'solo los active se instancian');
+  assert.deepEqual(spawnedProducts.sort(), ['acme', 'globex'], 'spawn AISLADO invocado por cada active');
+  assert.ok(res.skipped.some((s) => s.reason === 'inactivo'), 'onboarding/archived salteados');
+});
+
+// CA-SEC-4 end-to-end vía bootKernelDurable: cap de config aplicado sobre N>cap.
+test('#4822 · CA-SEC-4 · boot durable aplica el cap de config sobre N>cap activos', async () => {
+  const res = await bootKernelDurable({
+    config: { kernel: { durable: true, max_concurrent_instances: 1 } },
+    buildCatalogStore: () => fakeCatalogStore(CATALOG_N_ACTIVOS),
+    buildStoreFactory: () => recordingStoreFactory([]),
+    spawn: () => ({ alive: true }),
+  });
+  assert.equal(res.ran, true);
+  assert.equal(res.cap, 1, 'cap=1 de config');
+  assert.equal(res.spawned.length, 1, 'solo 1 instancia bajo cap=1');
+  assert.equal(res.skipped.filter((s) => s.reason === 'cap de instancias alcanzado').length, 3, 'los 3 restantes salteados por cap');
+});
+
+// Con flag ON pero sin cota válida en config, cae al default seguro (nunca sin techo).
+test('#4822 · CA-SEC-4 · sin cota válida en config el boot durable usa el default seguro', async () => {
+  const res = await bootKernelDurable({
+    config: { kernel: { durable: true } },
+    buildCatalogStore: () => fakeCatalogStore(CATALOG_N_ACTIVOS),
+    buildStoreFactory: () => recordingStoreFactory([]),
+    spawn: () => ({ alive: true }),
+  });
+  assert.equal(res.ran, true);
+  assert.equal(res.cap, MAX_CONCURRENT_INSTANCES_DEFAULT, 'cae al default seguro');
+  assert.equal(res.spawned.length, MAX_CONCURRENT_INSTANCES_DEFAULT, 'no spawnea por encima del default');
+});
+
+// Best-effort: un fallo construyendo el store NO lanza; devuelve {ran:false} y audita.
+test('#4822 · boot durable es best-effort: un fallo del store no lanza (no tumba el pulpo)', async () => {
+  const alerts = [];
+  const res = await bootKernelDurable({
+    config: { kernel: { durable: true, max_concurrent_instances: 2 } },
+    buildCatalogStore: () => { throw new Error('driver AWS no disponible'); },
+    onAlert: (a) => alerts.push(a),
+  });
+  assert.equal(res.ran, false, 'no corrió (falló)');
+  assert.equal(res.reason, 'error', 'razón error');
+  assert.match(res.error, /driver AWS no disponible/, 'propaga el detalle del fallo');
+  assert.ok(alerts.some((a) => a.stage === 'boot-durable'), 'audita el fallo por onAlert');
+});
+
+// Falta buildCatalogStore con flag ON ⇒ best-effort error, no throw.
+test('#4822 · boot durable sin buildCatalogStore devuelve error sin lanzar', async () => {
+  const res = await bootKernelDurable({ config: { kernel: { durable: true } } });
+  assert.equal(res.ran, false);
+  assert.equal(res.reason, 'error');
+  assert.match(res.error, /buildCatalogStore/, 'explica el requisito faltante');
 });

--- a/.pipeline/lib/kernel-supervisor.js
+++ b/.pipeline/lib/kernel-supervisor.js
@@ -67,6 +67,13 @@ const BREAKER_WINDOW_MS = 60 * 1000; // ventana deslizante del contador de fallo
 const BREAKER_COOLDOWN_MS = 30 * 1000; // espera en `open` antes de probar (open → half-open)
 const BREAKER_RECOVERY_MS = 30 * 1000; // permanencia en `half-open` sin fallos → closed
 
+// #4822 · CA-SEC-4 (REQ-SEC-BOOT-5, A04/DoS) — techo de instancias concurrentes
+// que el boot durable puede spawnear. Default conservador: la RAM del host es
+// crítica y un catálogo envenenado con N productos `active` no debe poder
+// spawnear procesos sin cota. El valor efectivo lo pasa el caller (out-of-band,
+// desde config.yaml); esta constante es el piso seguro del boot durable.
+const MAX_CONCURRENT_INSTANCES_DEFAULT = 2;
+
 // -----------------------------------------------------------------------------
 // Multiplexor de ruteo product-aware (Ola Puente P4 · #4763 · split 2/3 de #4689)
 //
@@ -308,6 +315,15 @@ function createKernelSupervisor(deps = {}) {
   const breakerRecoveryMs = Number.isFinite(deps.breakerRecoveryMs) && deps.breakerRecoveryMs > 0
     ? deps.breakerRecoveryMs : BREAKER_RECOVERY_MS;
 
+  // #4822 · CA-SEC-4 — cota de instancias del boot durable, leída OUT-OF-BAND de
+  // `deps` (el caller la resuelve de config.yaml, nunca de datos del producto —
+  // CA-SEC-1). `null` = sin cota (compat: los tests/callers legacy que no la
+  // pasan mantienen el comportamiento previo). El boot durable (`bootKernelDurable`)
+  // SIEMPRE la provee con un default seguro, de modo que en producción hay techo.
+  const maxConcurrentInstances = Number.isInteger(deps.maxConcurrentInstances) && deps.maxConcurrentInstances > 0
+    ? deps.maxConcurrentInstances
+    : null;
+
   // Mapa PRIVADO del closure: projectId → instanceContext. Jamás expuesto por
   // referencia; jamás a nivel módulo. Dos supervisores distintos tienen mapas
   // distintos (A05: no hay estado compartido de módulo).
@@ -435,6 +451,15 @@ function createKernelSupervisor(deps = {}) {
       if (!isSafeId(projectId)) {                 // fail-closed antes de usar en path/spawn
         skipped.push({ projectId: projectId == null ? null : String(projectId), reason: 'projectId inseguro' });
         onAlert({ projectId: null, stage: 'isSafeId', errors: [{ detail: `projectId inseguro descartado: ${String(projectId)}` }] });
+        continue;
+      }
+      // #4822 · CA-SEC-4 (REQ-SEC-BOOT-5) — cota de instancias concurrentes: un
+      // catálogo con N>cap productos `active` NO spawnea procesos sin techo (RAM
+      // crítica del host). No aborta el boot: saltea el excedente y lo audita, de
+      // modo que el catálogo entero se clasifica igual (paridad con los otros skips).
+      if (maxConcurrentInstances != null && spawned.length >= maxConcurrentInstances) {
+        skipped.push({ projectId, reason: 'cap de instancias alcanzado' });
+        onAlert({ projectId, stage: 'cap', errors: [{ detail: `boot durable alcanzó el cap de ${maxConcurrentInstances} instancias` }] });
         continue;
       }
       const ctx = spawnInstance(p);
@@ -839,9 +864,83 @@ function createKernelSupervisor(deps = {}) {
   };
 }
 
+/**
+ * #4822 · Boot durable del supervisor multi-producto — Parte 3/3 de #4804.
+ *
+ * Gatea OUT-OF-BAND por `config.kernel.durable === true` (fail-closed: flag
+ * ausente/false/no-booleano ⇒ NO corre — CA-6/CA-SEC-1). El flag se lee
+ * EXCLUSIVAMENTE de `config` (que el caller obtiene de `config.yaml` vía
+ * `loadConfig()`), NUNCA de datos del propio store/producto.
+ *
+ * BEST-EFFORT: la función NUNCA lanza. Cualquier fallo (construcción del store,
+ * driver AWS ausente, catálogo corrupto) se captura, se audita por `onAlert` y
+ * se devuelve como `{ ran:false, reason:'error' }`. El boot del pulpo — el único
+ * caller de producción — no puede morir por esto (mismo criterio que el boot-hook
+ * de wave-recovery).
+ *
+ * La cota de instancias (CA-SEC-4) SIEMPRE se aplica: si `config.kernel.max_concurrent_instances`
+ * no es un entero > 0, cae a `MAX_CONCURRENT_INSTANCES_DEFAULT`. Así el boot
+ * durable jamás spawnea sin techo, ni siquiera con config incompleta.
+ *
+ * @param {object}   opts
+ * @param {object}    opts.config              config del pipeline (loadConfig()); el flag y la cota se leen de acá.
+ * @param {function}  opts.buildCatalogStore   () => catalogStore durable con `listProducts()`. LAZY: sólo se invoca con el flag ON (con flag OFF no se instancia nada AWS — CA-6).
+ * @param {function} [opts.buildStoreFactory]  () => storeFactory por instancia (liga el driver durable a cada tenant). Opcional (default: in-memory de createKernelStore).
+ * @param {function} [opts.spawn]              spawn(ctx) AISLADO por instancia (A04). Opcional.
+ * @param {function} [opts.onAlert]            callback de alerta fail-closed (A09).
+ * @param {function} [opts.createSupervisor]   factory del supervisor (test override; default: createKernelSupervisor).
+ * @returns {Promise<{ran:boolean, reason?:string, cap?:number, spawned?:string[], skipped?:Array, error?:string}>}
+ */
+async function bootKernelDurable(opts = {}) {
+  const config = opts.config && typeof opts.config === 'object' ? opts.config : {};
+  const kernel = config.kernel && typeof config.kernel === 'object' ? config.kernel : {};
+  const onAlert = typeof opts.onAlert === 'function' ? opts.onAlert : () => {};
+
+  // Fail-closed (CA-SEC-1/CA-6): SÓLO corre con el flag EXACTAMENTE en `true`.
+  // Ausente, `false`, o cualquier truthy no-booleano ⇒ el boot durable NO corre
+  // y el arranque FS actual del pulpo no cambia.
+  if (kernel.durable !== true) {
+    return { ran: false, reason: 'flag-off' };
+  }
+
+  const createSupervisor = typeof opts.createSupervisor === 'function'
+    ? opts.createSupervisor
+    : createKernelSupervisor;
+
+  try {
+    if (typeof opts.buildCatalogStore !== 'function') {
+      throw new Error('bootKernelDurable requiere buildCatalogStore() para listar el catálogo durable');
+    }
+    const catalogStore = opts.buildCatalogStore();
+
+    // Cota out-of-band de config (CA-SEC-4). Sin valor válido ⇒ default seguro.
+    const cap = Number.isInteger(kernel.max_concurrent_instances) && kernel.max_concurrent_instances > 0
+      ? kernel.max_concurrent_instances
+      : MAX_CONCURRENT_INSTANCES_DEFAULT;
+
+    const supervisor = createSupervisor({
+      catalogStore,
+      storeFactory: typeof opts.buildStoreFactory === 'function' ? opts.buildStoreFactory() : undefined,
+      spawn: typeof opts.spawn === 'function' ? opts.spawn : undefined,
+      maxConcurrentInstances: cap,
+      onAlert,
+    });
+
+    const { spawned, skipped } = await supervisor.bootProducts();
+    return { ran: true, cap, spawned, skipped };
+  } catch (e) {
+    const detail = e && e.message ? e.message : String(e);
+    try { onAlert({ projectId: null, stage: 'boot-durable', errors: [{ detail }] }); } catch { /* alerta best-effort */ }
+    return { ran: false, reason: 'error', error: detail };
+  }
+}
+
 module.exports = {
   createKernelSupervisor,
   resolveProjectId,
+  // #4822 · Boot durable del supervisor multi-producto (gateado + best-effort).
+  bootKernelDurable,
+  MAX_CONCURRENT_INSTANCES_DEFAULT,
   // #4763 · Multiplexor de ruteo product-aware (standalone + adaptadores).
   resolveInstanceForEvent,
   deriveRepoConfig,

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -17736,6 +17736,69 @@ async function mainLoop() {
     log('pulpo', `WARN [wave-recovery] boot hook falló: ${e.message}`);
   }
 
+  // #4822 (Split 3/3 de #4804) — Boot durable del supervisor multi-producto.
+  // Gateado OUT-OF-BAND por `config.kernel.durable === true` (fail-closed:
+  // ausente/false ⇒ NO corre, el arranque FS actual del pulpo no cambia — CA-6/
+  // CA-SEC-1). En modo durable, `bootKernelDurable` carga los productos `active`
+  // desde el store durable (DynamoDB) y spawnea un pipeline AISLADO por producto,
+  // respetando la cota de instancias (CA-SEC-4).
+  //
+  // BEST-EFFORT: un fallo del boot durable (driver AWS ausente, catálogo corrupto,
+  // credenciales faltantes) NUNCA tumba el arranque del pulpo — `bootKernelDurable`
+  // no lanza y este bloque va igual en try/catch (mismo patrón que wave-recovery).
+  try {
+    const cfg = loadConfig();
+    if (cfg && cfg.kernel && cfg.kernel.durable === true) {
+      // Constructor LAZY del store durable: sólo se instancia con el flag ON, de
+      // modo que con `durable:false` NO se construye ningún driver ni se toca AWS.
+      const buildDurableStore = (contextProjectId, allowedNamespaces, onAlert) => {
+        const { createAwsCliRunner, createAwsCliDynamoDriver } = require('./lib/provisioner-infra');
+        const { buildAwsScopedEnv } = require('./lib/kernel-provision');
+        const { createKernelStore } = require('./lib/kernel-store');
+        const env = buildAwsScopedEnv(process.env, cfg.kernel.region);
+        const { run } = createAwsCliRunner(env);
+        const driver = createAwsCliDynamoDriver({ run });
+        return createKernelStore({
+          driver,
+          config: { kernel: cfg.kernel },
+          contextProjectId,
+          allowedNamespaces,
+          onAlert,
+        });
+      };
+
+      const result = await kernelSupervisor.bootKernelDurable({
+        config: cfg,
+        onAlert: (a) => {
+          const pid = a && a.projectId ? String(a.projectId) : '—';
+          const det = a && a.errors && a.errors[0] && a.errors[0].detail ? a.errors[0].detail : '';
+          log('pulpo', `WARN [kernel-durable] rechazo boot (${(a && a.stage) || '?'}/${pid}): ${det}`);
+        },
+        // Catálogo del control-plane: `listProducts()` lee el índice global (no una
+        // partición de tenant), por eso usa un contextProjectId dedicado y seguro.
+        buildCatalogStore: () => buildDurableStore('kernel-control-plane', ['kernel-control-plane']),
+        // Store por instancia: MISMO driver durable ligado a cada tenant con su
+        // propio `projectId` derivado del registro (A01 — nunca en banda).
+        buildStoreFactory: () => (o) => buildDurableStore(o.contextProjectId, o.allowedNamespaces, o.onAlert),
+        // spawn AISLADO por instancia. El runtime concreto del pipeline por producto
+        // se cablea en un split posterior; acá se registra/audita la instancia. El
+        // supervisor la trackea e hidrata de forma aislada aunque el handle sea null.
+        spawn: (ctx) => {
+          log('pulpo', `[kernel-durable] instancia registrada para producto ${ctx && ctx.projectId}`);
+          return null;
+        },
+      });
+
+      if (result.ran) {
+        log('pulpo', `[kernel-durable] boot: ${(result.spawned || []).length} activos instanciados, ${(result.skipped || []).length} salteados (cap ${result.cap}).`);
+      } else if (result.reason === 'error') {
+        log('pulpo', `WARN [kernel-durable] boot durable falló (no bloquea el arranque): ${result.error}`);
+      }
+    }
+  } catch (e) {
+    log('pulpo', `WARN [kernel-durable] boot hook falló: ${e.message}`);
+  }
+
   // #4370 CA-4/SEC-3 — verificación de integridad del estado al arrancar.
   // Distingue corrupción silenciosa / tampering schema-válido de un estado sano.
   // Best-effort: NO pone el pipeline fuera de servicio (regla "el pipeline no


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 4 archivos · +314 -1

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:skipped` aplicado por delivery

## Closes

Closes #4822
