### PR TITLE
Auto-recovery del halt automático del Pulpo cuando config.yaml vuelve a estar sano

### DIFF
--- a/.pipeline/lib/__tests__/partial-pause.test.js
+++ b/.pipeline/lib/__tests__/partial-pause.test.js
@@ -266,3 +266,67 @@ test('#4030: sanitizeWaveMetaForWrite strip de control-chars', () => {
     assert.equal(m.wave_name, 'Memoria');
     assert.equal(m.wave_number, 4);
 });
+
+// -----------------------------------------------------------------------------
+// #4832 — readFullPauseOrigin (fail-closed): distingue pausa auto-generada por
+// corrupción de config (recuperable) de pausa manual/legacy (persistente).
+// -----------------------------------------------------------------------------
+
+function writePauseFile(content) {
+    const { PAUSE_FILE } = pp._paths();
+    fs.writeFileSync(PAUSE_FILE, content);
+}
+
+test('#4832: marker JSON con source=config-corruption-halt → recuperable', () => {
+    resetFs();
+    writePauseFile(JSON.stringify({
+        source: 'config-corruption-halt',
+        ts: '2026-07-21T00:00:00.000Z',
+        detail: 'YAML inválido (línea 3, col 1)',
+    }));
+    const origin = pp.readFullPauseOrigin();
+    assert.equal(origin.source, 'config-corruption-halt');
+});
+
+test('#4832: marker ISO plano legacy → manual (NO recuperable)', () => {
+    resetFs();
+    writePauseFile('2026-07-21T00:00:00.000Z');
+    assert.equal(pp.readFullPauseOrigin().source, 'manual');
+});
+
+test('#4832: marker JSON con otro source → manual (NO recuperable)', () => {
+    resetFs();
+    writePauseFile(JSON.stringify({ source: 'manual', ts: '2026-07-21T00:00:00.000Z' }));
+    assert.equal(pp.readFullPauseOrigin().source, 'manual');
+});
+
+test('#4832: marker JSON sin campo source → manual (NO recuperable)', () => {
+    resetFs();
+    writePauseFile(JSON.stringify({ ts: '2026-07-21T00:00:00.000Z' }));
+    assert.equal(pp.readFullPauseOrigin().source, 'manual');
+});
+
+test('#4832: marker JSON malformado → manual (NO recuperable)', () => {
+    resetFs();
+    writePauseFile('{ source: "config-corruption-halt"');  // JSON roto
+    assert.equal(pp.readFullPauseOrigin().source, 'manual');
+});
+
+test('#4832: marker vacío → manual (NO recuperable)', () => {
+    resetFs();
+    writePauseFile('   ');
+    assert.equal(pp.readFullPauseOrigin().source, 'manual');
+});
+
+test('#4832: sin marker .paused → unknown (NO recuperable)', () => {
+    resetFs();
+    const origin = pp.readFullPauseOrigin();
+    assert.equal(origin.source, 'unknown');
+    assert.equal(origin.raw, null);
+});
+
+test('#4832: source config-corruption-halt como substring pero no exacto → manual', () => {
+    resetFs();
+    writePauseFile(JSON.stringify({ source: 'config-corruption-halt-manual' }));
+    assert.equal(pp.readFullPauseOrigin().source, 'manual');
+});

--- a/.pipeline/lib/__tests__/pulpo-config-recovery.test.js
+++ b/.pipeline/lib/__tests__/pulpo-config-recovery.test.js
@@ -1,0 +1,134 @@
+// =============================================================================
+// pulpo-config-recovery.test.js — Test de INTEGRACIÓN del ciclo loadConfig ↔
+// haltOnConfigCorruption ↔ auto-recovery (#4832).
+//
+// La Definition of Done (fase criterios, PO) exige un test de integración del
+// ciclo completo, no sólo del helper puro `readFullPauseOrigin` (ya cubierto en
+// partial-pause.test.js). Este archivo ejercita el WIRING real dentro de
+// pulpo.js:
+//   - CA-1: config.yaml corrupto → `haltOnConfigCorruption` escribe el marker
+//     `.paused` como JSON estructurado con `source: config-corruption-halt`.
+//   - CA-2: config.yaml vuelve a parsear OK → `loadConfig` (branch de éxito)
+//     levanta la pausa auto-generada en un tick (clearFullPause) + log + flag
+//     `paused` en false.
+//   - CA-5 (⇔ CA-3): una pausa MANUAL/legacy preexistente (ISO plano) sobrevive
+//     al halt (idempotente, no la pisa) y NUNCA se auto-levanta al sanar el
+//     config → la pausa deliberada del operador se respeta (límite de control
+//     authorization-like que marcó security).
+//
+// Aislamiento (convención del repo, ver partial-pause.test.js y
+// pulpo-corruption.test.js): se setea `PIPELINE_DIR_OVERRIDE` a un tmpdir ANTES
+// de requerir pulpo.js con `PULPO_NO_AUTOSTART=1`. Ese override redirige
+// CONFIG_PATH, PAUSE_FILE, el `pauseFile()` de partial-pause y la cola de
+// Telegram al MISMO tmpdir → cero contacto con el `.paused` real ni con la cola
+// de Telegram de producción. Cada archivo de `node --test` corre en su propio
+// proceso, así el env queda contenido.
+// node --test
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+// --- Aislamiento: tmpdir + override ANTES de requerir pulpo.js ----------------
+const TMP_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'pulpo-config-recovery-'));
+const TG_QUEUE = path.join(TMP_DIR, 'servicios', 'telegram', 'pendiente');
+fs.mkdirSync(path.join(TMP_DIR, 'logs'), { recursive: true });
+fs.mkdirSync(TG_QUEUE, { recursive: true });
+
+// Fixture "config sano": copiamos el config.yaml real (garantiza pasar
+// validateConfig — es el mismo schema con el que corre el pipeline).
+const REAL_CONFIG = path.join(__dirname, '..', '..', 'config.yaml');
+const GOOD_YAML = fs.readFileSync(REAL_CONFIG, 'utf8');
+const BAD_YAML = 'foo: : : bad\n  : indentacion rota\n :nope';
+
+process.env.PULPO_NO_AUTOSTART = '1';
+process.env.PIPELINE_DIR_OVERRIDE = TMP_DIR;
+
+const pulpo = require('../../pulpo.js');
+const { PAUSE_FILE, CONFIG_PATH } = pulpo;
+
+// Sanity del seam: los paths tienen que caer dentro del tmpdir, no en el real.
+assert.ok(CONFIG_PATH.startsWith(TMP_DIR), 'CONFIG_PATH debe apuntar al tmpdir aislado');
+assert.ok(PAUSE_FILE.startsWith(TMP_DIR), 'PAUSE_FILE debe apuntar al tmpdir aislado');
+
+function writeConfig(content) { fs.writeFileSync(CONFIG_PATH, content); }
+function removePause() { try { fs.unlinkSync(PAUSE_FILE); } catch {} }
+function clearTelegramQueue() {
+    for (const f of fs.readdirSync(TG_QUEUE)) fs.unlinkSync(path.join(TG_QUEUE, f));
+}
+
+test('CA-1: config.yaml corrupto → halt escribe .paused como marker JSON con source config-corruption-halt', () => {
+    pulpo._resetConfigCorruptionState();
+    removePause();
+    writeConfig(BAD_YAML);
+
+    const returned = pulpo.loadConfig();
+
+    // El halt debe activar el flag global y crear el marker.
+    assert.equal(pulpo._getPaused(), true, 'loadConfig sobre config corrupto debe dejar el pipeline en paused');
+    assert.ok(fs.existsSync(PAUSE_FILE), 'el marker .paused debe existir tras el halt');
+
+    // El marker debe ser JSON estructurado con el origen distinguible (no ISO plano).
+    const marker = JSON.parse(fs.readFileSync(PAUSE_FILE, 'utf8'));
+    assert.equal(marker.source, 'config-corruption-halt', 'el marker debe declarar el origen auto-generado');
+    assert.equal(typeof marker.ts, 'string', 'el marker debe llevar timestamp');
+
+    // Fail-safe de loadConfig: devuelve lastGoodConfig || {} para no matar el loop.
+    assert.deepEqual(returned, {}, 'sin config buena previa, loadConfig degrada a {} manteniendo el loop vivo');
+});
+
+test('CA-2: config.yaml sano → auto-recovery levanta la pausa auto-generada en un tick', () => {
+    // Precondición: pausa auto-generada activa (heredada del ciclo de corrupción).
+    pulpo._resetConfigCorruptionState();
+    removePause();
+    writeConfig(BAD_YAML);
+    pulpo.loadConfig();
+    assert.ok(fs.existsSync(PAUSE_FILE), 'precondición: la pausa por corrupción debe estar activa');
+    clearTelegramQueue();
+
+    // El operador corrige config.yaml → un solo tick de loadConfig debe reanudar.
+    writeConfig(GOOD_YAML);
+    const returned = pulpo.loadConfig();
+
+    assert.equal(fs.existsSync(PAUSE_FILE), false, 'la pausa auto-generada debe levantarse (marker removido) al sanar el config');
+    assert.equal(pulpo._getPaused(), false, 'el flag paused debe quedar en false tras el auto-recovery');
+    assert.equal(returned && returned !== null && typeof returned, 'object', 'loadConfig devuelve el config parseado real');
+
+    // CA-4: la reanudación emite alerta Telegram (encolada al tmpdir, no a prod).
+    const enqueued = fs.readdirSync(TG_QUEUE);
+    assert.ok(enqueued.length >= 1, 'el auto-recovery debe encolar la alerta de reanudación (evidencia del tick)');
+});
+
+test('CA-5: pausa manual/legacy preexistente + corrupción posterior → NO se auto-levanta al sanar', () => {
+    // El operador pausó a propósito (marker legacy = ISO plano, no JSON).
+    pulpo._resetConfigCorruptionState();
+    const manualMarker = '2026-07-21T00:00:00.000Z';
+    fs.writeFileSync(PAUSE_FILE, manualMarker);
+
+    // Sobreviene corrupción de config: el halt NO debe pisar la pausa manual.
+    writeConfig(BAD_YAML);
+    pulpo.loadConfig();
+    assert.ok(fs.existsSync(PAUSE_FILE), 'la pausa manual debe seguir activa tras el halt');
+    assert.equal(
+        fs.readFileSync(PAUSE_FILE, 'utf8'),
+        manualMarker,
+        'haltOnConfigCorruption es idempotente: no pisa el marker manual preexistente',
+    );
+
+    // El operador corrige el config → el auto-recovery NO debe tocar la pausa
+    // manual (readFullPauseOrigin la clasifica como 'manual' → fail-closed).
+    writeConfig(GOOD_YAML);
+    pulpo.loadConfig();
+    assert.ok(fs.existsSync(PAUSE_FILE), 'la pausa MANUAL debe persistir: sanar el config no la auto-levanta');
+    assert.equal(
+        fs.readFileSync(PAUSE_FILE, 'utf8'),
+        manualMarker,
+        'el marker manual queda intacto: cero auto-clear de una pausa deliberada (CA-3/CA-5)',
+    );
+
+    removePause();
+});

--- a/.pipeline/lib/partial-pause.js
+++ b/.pipeline/lib/partial-pause.js
@@ -729,6 +729,54 @@ function resumeAll(opts = {}) {
     return { removedFull, removedPartial };
 }
 
+// -----------------------------------------------------------------------------
+// #4832 — Lectura del ORIGEN de la pausa total (`.paused`), fail-closed.
+//
+// Distingue una pausa AUTO-GENERADA por corrupción de config.yaml
+// (`haltOnConfigCorruption` escribe el marker como JSON
+// `{ source: 'config-corruption-halt', ... }`) de una pausa MANUAL del operador
+// (marker legacy = ISO plano, o cualquier otro contenido).
+//
+// Regla fail-closed (SEC / A08 fail-closed): sólo devuelve
+// `source: 'config-corruption-halt'` cuando el marker parsea como JSON válido
+// **y** `parsed.source === 'config-corruption-halt'`. CUALQUIER otro caso
+// (ISO plano legacy, JSON malformado, `source` distinto, string vacío,
+// archivo ilegible, o inexistente) → `manual`/`unknown`, es decir NUNCA
+// auto-recuperable. Esto garantiza que un auto-recovery ingenuo jamás pise una
+// pausa que el operador puso a propósito (CA-3).
+//
+// @returns {{ source: 'config-corruption-halt'|'manual'|'unknown', raw: string|null }}
+// -----------------------------------------------------------------------------
+function readFullPauseOrigin() {
+    let raw = null;
+    try {
+        if (!fs.existsSync(pauseFile())) {
+            return { source: 'unknown', raw: null };
+        }
+        raw = fs.readFileSync(pauseFile(), 'utf8');
+    } catch {
+        // Ilegible → fail-closed (no auto-recuperable).
+        return { source: 'manual', raw: null };
+    }
+    const trimmed = typeof raw === 'string' ? raw.trim() : '';
+    if (!trimmed) {
+        // Vacío → manual (fail-closed).
+        return { source: 'manual', raw };
+    }
+    let parsed;
+    try {
+        parsed = JSON.parse(trimmed);
+    } catch {
+        // No es JSON (ej. ISO plano legacy) → manual (fail-closed).
+        return { source: 'manual', raw };
+    }
+    if (parsed && typeof parsed === 'object' && parsed.source === 'config-corruption-halt') {
+        return { source: 'config-corruption-halt', raw };
+    }
+    // JSON válido pero con otro source (o sin source) → manual (fail-closed).
+    return { source: 'manual', raw };
+}
+
 /**
  * Activa la pausa TOTAL del pipeline (marker `.paused`). Hermana de
  * `setPartialPause` pero para el halt total — el wizard de pausa (#3741) lo
@@ -814,6 +862,8 @@ module.exports = {
     // #3741 — pausa total gateada (wizard de pausa, scope full).
     setFullPause,
     clearFullPause,
+    // #4832 — lectura fail-closed del origen de la pausa total (auto vs manual).
+    readFullPauseOrigin,
     // #3625 — exportados para callers que quieran leer estado raw y para tests.
     readPreviousAllowlist,
     evaluateAndAudit,

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -438,7 +438,17 @@ process.on('unhandledRejection', (reason) => {
 });
 
 const ROOT = path.resolve(__dirname, '..');
-const PIPELINE = path.resolve(__dirname);
+// #4832 — El directorio base del pipeline honra `PIPELINE_DIR_OVERRIDE` (LA MISMA
+// env var que ya usa `lib/partial-pause.js`), de modo que `CONFIG_PATH`,
+// `PAUSE_FILE`, el `pauseFile()` del helper y la cola de Telegram apunten todos
+// al MISMO directorio. Esto habilita el test de integración hermético del ciclo
+// loadConfig ↔ haltOnConfigCorruption ↔ auto-recovery sobre un tmpdir aislado,
+// sin tocar el `.paused` real ni la cola de Telegram de producción.
+// En producción la env var NUNCA está definida → PIPELINE = __dirname (idéntico
+// al comportamiento previo; cero cambio en caliente).
+const PIPELINE = process.env.PIPELINE_DIR_OVERRIDE
+  ? path.resolve(process.env.PIPELINE_DIR_OVERRIDE)
+  : path.resolve(__dirname);
 const CONFIG_PATH = path.join(PIPELINE, 'config.yaml');
 const LOG_DIR = path.join(PIPELINE, 'logs');
 
@@ -18715,6 +18725,22 @@ if (process.env.PULPO_NO_AUTOSTART === '1') {
     readYamlSafe,
     WorkFileCorruptionError,
     PAUSE_FILE,
+    // #4832 — seam de integración del ciclo loadConfig ↔ haltOnConfigCorruption ↔
+    // auto-recovery. Se ejercen sobre un tmpdir aislado vía PIPELINE_DIR_OVERRIDE
+    // (que redirige CONFIG_PATH/PAUSE_FILE/cola-Telegram). Los getters/reset
+    // permiten aseverar el flag `paused` y resetear estado entre casos sin tocar
+    // producción. Cubren CA-1 (halt→marker JSON con origen), CA-2 (config sano→
+    // auto-recovery levanta la pausa en un tick) y CA-5 (pausa manual/legacy
+    // persiste, jamás se auto-levanta).
+    loadConfig,
+    haltOnConfigCorruption,
+    CONFIG_PATH,
+    _getPaused: () => paused,
+    _resetConfigCorruptionState: () => {
+      paused = false;
+      lastGoodConfig = null;
+      lastConfigCorruptionAlertMs = 0;
+    },
     // EP5-H1 (#3938) — módulos puros de los brazos + frontera FS, expuestos
     // para tests de integración del cableado (la lógica pura se testea en
     // lib/__tests__/brazo-*-core.test.js y workfile-name.test.js).

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -1233,7 +1233,18 @@ function haltOnConfigCorruption(reason, redactedDetail) {
   // (sólo en runtime, nunca en carga) ya está inicializado.
   try {
     if (!fs.existsSync(PAUSE_FILE)) {
-      fs.writeFileSync(PAUSE_FILE, new Date().toISOString());
+      // #4832 — Marker estructurado con ORIGEN distinguible. Permite el paso
+      // inverso de auto-recovery (loadConfig branch de éxito) que sólo levanta
+      // la pausa si la generó esta ruta (`source: config-corruption-halt`).
+      // Idempotente: si el marker ya existe (ej. pausa manual preexistente) NO
+      // lo pisamos → la manual gana y nunca se auto-levanta.
+      // SEC-2: `detail` sólo lleva metadata YA redactada (reason + línea/col),
+      // NUNCA el snippet crudo de config.yaml.
+      fs.writeFileSync(PAUSE_FILE, JSON.stringify({
+        source: 'config-corruption-halt',
+        ts: new Date().toISOString(),
+        detail: redactedDetail || reason || 'config-corruption',
+      }));
     }
     paused = true;
   } catch (e) {
@@ -1281,6 +1292,33 @@ function loadConfig() {
     return lastGoodConfig || {};
   }
   lastGoodConfig = raw;
+  // #4832 — Paso INVERSO de haltOnConfigCorruption: si la pausa activa fue
+  // auto-generada por corrupción (source: config-corruption-halt) y el config
+  // volvió a parsear OK, la levantamos solas dentro de este mismo ciclo (~30s).
+  // Fail-closed: readFullPauseOrigin devuelve 'config-corruption-halt' SÓLO si
+  // el marker es JSON válido con ese source; cualquier ambigüedad → 'manual'
+  // → NO se auto-levanta (respeta CA-3 y la pausa deliberada del operador).
+  try {
+    if (fs.existsSync(PAUSE_FILE) &&
+        partialPause.readFullPauseOrigin().source === 'config-corruption-halt') {
+      partialPause.clearFullPause({
+        source: 'config-auto-recovery',
+        justification: 'config.yaml volvió a parsear OK — halt por corrupción levantado',
+      });
+      paused = false;
+      // Log auditable (CA-4): qué disparó el halt / config sano detectado / reanudación.
+      log('pulpo', '[#4832] Auto-recovery: config.yaml sano → pausa config-corruption-halt levantada → dispatch reanudado');
+      // Alerta Telegram redactada (sin volcar contenido del marker, SEC-2/A09).
+      try {
+        sendTelegram(
+          '✅ *Pipeline REANUDADO* — `config.yaml` volvió a parsear OK.\n' +
+          'La pausa automática por corrupción se levantó sola (auto-recovery #4832).'
+        );
+      } catch { /* best-effort */ }
+    }
+  } catch (e) {
+    // Fail-closed: ante cualquier error, la pausa persiste (no reanudamos).
+  }
   return raw;
 }
 


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 4 archivos · +314 -2

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:passed` aplicado por delivery

## Closes

Closes #4832
