### PR TITLE
[Split de #4816] Guards de supervisor para impedir boot y spawn del id reservado

### DIFF
--- a/.pipeline/lib/__tests__/kernel-supervisor.test.js
+++ b/.pipeline/lib/__tests__/kernel-supervisor.test.js
@@ -1094,3 +1094,92 @@ test('#4809 · drainCreateWaveQueue usa el drenador real por default (sin impl i
   const sum = await supervisor.drainCreateWaveQueue({ queueDir: '/tmp/no-existe-4809', processedDir: '/tmp/p', auditFile: '/tmp/a.jsonl' });
   assert.deepEqual(sum, { created: [], idempotent: [], rejected: [], errors: [] });
 });
+
+// -----------------------------------------------------------------------------
+// #4853 · Política de ids reservados en supervisor/runtime
+//   El namespace raíz del monorepo (`intrale-platform`) NO puede materializarse
+//   como tenant/instancia aunque el catálogo activo llegue a contenerlo.
+//   Sintaxis (isSafeId=true) ≠ política (isReservedProjectId=true).
+// -----------------------------------------------------------------------------
+
+const CATALOG_RESERVADO = [
+  { productId: 'acme', projectId: 'acme', name: 'ACME', status: 'active' },
+  { productId: 'intrale-platform', projectId: 'intrale-platform', name: 'Root', status: 'active' },
+];
+
+test('#4853 · bootProducts descarta el producto active con id reservado antes de spawnInstance (skipped + alerta, sin store)', async () => {
+  const calls = [];
+  const alerts = [];
+  const supervisor = createKernelSupervisor({
+    catalogStore: fakeCatalogStore(CATALOG_RESERVADO),
+    storeFactory: recordingStoreFactory(calls),
+    hydrate: false,
+    onAlert: (a) => alerts.push(a),
+  });
+
+  const res = await supervisor.bootProducts();
+
+  // el reservado NO se instancia; el resto del catálogo boota normal
+  assert.deepEqual(res.spawned, ['acme'], 'solo el activo no-reservado se instancia');
+  assert.equal(supervisor.getInstance('intrale-platform'), null, 'el id reservado NO tiene instancia');
+  assert.equal(supervisor.listInstances().length, 1, 'exactamente una instancia (la no-reservada)');
+
+  // queda auditado en skipped con razón clara
+  const skip = res.skipped.find((s) => s.projectId === 'intrale-platform');
+  assert.ok(skip, 'el reservado aparece en skipped');
+  assert.equal(skip.reason, 'id reservado', 'razón explícita del descarte');
+
+  // alerta operativa emitida (descarte NO silencioso)
+  const alert = alerts.find((a) => a.stage === 'reserved-id' && a.projectId === 'intrale-platform');
+  assert.ok(alert, 'se emitió alerta operativa del id reservado');
+
+  // NINGÚN store fue creado para el id reservado (guard antes de storeFactory)
+  assert.ok(!calls.some((c) => c.contextProjectId === 'intrale-platform'), 'no se creó store para el reservado');
+});
+
+test('#4853 · spawnInstance falla cerrado ante id reservado antes de consultar instances/construir store', () => {
+  const calls = [];
+  const supervisor = createKernelSupervisor({
+    catalogStore: fakeCatalogStore([]),
+    storeFactory: recordingStoreFactory(calls),
+    hydrate: false,
+  });
+
+  assert.throws(
+    () => supervisor.spawnInstance({ productId: 'intrale-platform', projectId: 'intrale-platform', status: 'active' }),
+    (err) => err instanceof KernelStoreIsolationError && /reservado/.test(err.message),
+    'spawnInstance lanza KernelStoreIsolationError para id reservado',
+  );
+
+  // fail-closed: ni instancia ni store creados
+  assert.equal(supervisor.getInstance('intrale-platform'), null, 'no quedó instancia registrada');
+  assert.equal(supervisor.listInstances().length, 0, 'no se registró ninguna instancia');
+  assert.ok(!calls.some((c) => c.contextProjectId === 'intrale-platform'), 'no se creó store para el reservado');
+});
+
+test('#4853 · spawnInstance con id reservado NO crea store REAL (verificación con store namespaceado)', () => {
+  const supervisor = createKernelSupervisor({
+    catalogStore: fakeCatalogStore([]),
+    storeFactory: realStoreFactory,
+    hydrate: false,
+  });
+
+  assert.throws(
+    () => supervisor.spawnInstance({ productId: 'intrale-platform', projectId: 'intrale-platform', status: 'active' }),
+    (err) => err instanceof KernelStoreIsolationError,
+  );
+  assert.equal(supervisor.getInstance('intrale-platform'), null, 'sin instancia tras el fallo');
+});
+
+test('#4853 · authorizedProjectIdSet excluye ids reservados (no autoriza el namespace raíz como tenant)', async () => {
+  const supervisor = createKernelSupervisor({
+    catalogStore: fakeCatalogStore(CATALOG_RESERVADO),
+    storeFactory: recordingStoreFactory([]),
+    hydrate: false,
+  });
+
+  const authorized = await supervisor.authorizedProjectIdSet();
+
+  assert.ok(authorized.has('acme'), 'el producto no-reservado sí está autorizado');
+  assert.ok(!authorized.has('intrale-platform'), 'el id reservado NO está autorizado out-of-band');
+});

--- a/.pipeline/lib/__tests__/kernel-supervisor.test.js
+++ b/.pipeline/lib/__tests__/kernel-supervisor.test.js
@@ -1171,6 +1171,35 @@ test('#4853 · spawnInstance con id reservado NO crea store REAL (verificación 
   assert.equal(supervisor.getInstance('intrale-platform'), null, 'sin instancia tras el fallo');
 });
 
+test('#4853 · bootProducts descarta el reservado aunque resolveProjectId lo DERIVE de productId (sin projectId explícito)', async () => {
+  // El issue exige descartar productos cuyo `resolveProjectId()` DERIVE un id
+  // reservado, no solo el literal `projectId`. `resolveProjectId` cae a `productId`
+  // cuando no hay `projectId`; el guard debe atrapar igual ese camino de derivación.
+  const calls = [];
+  const alerts = [];
+  const supervisor = createKernelSupervisor({
+    catalogStore: fakeCatalogStore([
+      { productId: 'acme', name: 'ACME', status: 'active' },
+      { productId: 'intrale-platform', name: 'Root', status: 'active' }, // sin projectId → deriva de productId
+    ]),
+    storeFactory: recordingStoreFactory(calls),
+    hydrate: false,
+    onAlert: (a) => alerts.push(a),
+  });
+
+  const res = await supervisor.bootProducts();
+
+  assert.deepEqual(res.spawned, ['acme'], 'solo el activo no-reservado se instancia');
+  assert.equal(supervisor.getInstance('intrale-platform'), null, 'el id reservado derivado NO tiene instancia');
+  const skip = res.skipped.find((s) => s.projectId === 'intrale-platform');
+  assert.ok(skip && skip.reason === 'id reservado', 'el reservado derivado queda en skipped con razón clara');
+  assert.ok(
+    alerts.some((a) => a.stage === 'reserved-id' && a.projectId === 'intrale-platform'),
+    'se emitió alerta del reservado derivado (descarte no silencioso)',
+  );
+  assert.ok(!calls.some((c) => c.contextProjectId === 'intrale-platform'), 'no se creó store para el reservado derivado');
+});
+
 test('#4853 · authorizedProjectIdSet excluye ids reservados (no autoriza el namespace raíz como tenant)', async () => {
   const supervisor = createKernelSupervisor({
     catalogStore: fakeCatalogStore(CATALOG_RESERVADO),

--- a/.pipeline/lib/kernel-supervisor.js
+++ b/.pipeline/lib/kernel-supervisor.js
@@ -43,6 +43,7 @@ const path = require('node:path');
 const { createKernelStore, KernelStoreIsolationError } = require('./kernel-store');
 const {
   isSafeId,
+  isReservedProjectId,
   deriveRouting,
   deriveConcurrency,
   deriveCapabilityPartitions,
@@ -486,6 +487,17 @@ function createKernelSupervisor(deps = {}) {
         onAlert({ projectId: null, stage: 'isSafeId', errors: [{ detail: `projectId inseguro descartado: ${String(projectId)}` }] });
         continue;
       }
+      // #4853 · A01/A04/A05 — política de ids reservados: un producto `active` cuyo
+      // id resuelto sea el namespace raíz del monorepo (`intrale-platform`) NO puede
+      // materializarse como tenant. Se descarta fail-closed ANTES de spawnInstance
+      // (nunca deriva path/worktree ni crea store), se audita en `skipped` y se emite
+      // la alerta operativa (descarte NO silencioso). Sintaxis (isSafeId) ≠ política:
+      // `intrale-platform` es sintácticamente válido pero está reservado.
+      if (isReservedProjectId(projectId)) {
+        skipped.push({ projectId, reason: 'id reservado' });
+        onAlert({ projectId, stage: 'reserved-id', errors: [{ detail: `id reservado descartado del boot: ${projectId}` }] });
+        continue;
+      }
       // #4822 · CA-SEC-4 (REQ-SEC-BOOT-5) — cota de instancias concurrentes: un
       // catálogo con N>cap productos `active` NO spawnea procesos sin techo (RAM
       // crítica del host). No aborta el boot: saltea el excedente y lo audita, de
@@ -515,6 +527,18 @@ function createKernelSupervisor(deps = {}) {
       throw new KernelStoreIsolationError(
         `spawnInstance: projectId inseguro "${String(projectId)}" — fail-closed antes de derivar path/spawn`,
         { requested: projectId == null ? null : String(projectId) },
+      );
+    }
+    // #4853 · A01/A04 — guard fail-closed propio de la política de ids reservados:
+    // aunque `bootProducts()` ya filtra, un caller directo (o futuro) de
+    // `spawnInstance()` NO puede materializar el namespace raíz (`intrale-platform`)
+    // como tenant. Falla ANTES de consultar `instances`, construir la instancia,
+    // derivar paths/worktree o crear store/runtime. Defensa en profundidad, no
+    // duplica la fuente de verdad: reutiliza `isReservedProjectId` del descriptor.
+    if (isReservedProjectId(projectId)) {
+      throw new KernelStoreIsolationError(
+        `spawnInstance: projectId reservado "${projectId}" — el namespace raíz del monorepo no puede spawnearse como tenant (fail-closed)`,
+        { requested: projectId, reserved: true },
       );
     }
     const existing = instances.get(projectId);
@@ -881,6 +905,10 @@ function createKernelSupervisor(deps = {}) {
    * Resuelve el conjunto AUTORIZADO de `projectId` OUT-OF-BAND (CA-5 · A01): el
    * catálogo propio de ESTE contexto (credencial), NUNCA el id en banda. Incluye
    * productos `onboarding` (la primera ola puede crearse antes de activar · #4805).
+   *
+   * #4853 · A01 — excluye ids reservados: aunque boot/spawn ya los filtren, el
+   * namespace raíz del monorepo (`intrale-platform`) NO puede colarse como tenant
+   * autorizado si el catálogo llegara a contenerlo (defensa en profundidad).
    */
   async function authorizedProjectIdSet() {
     const set = new Set();
@@ -888,7 +916,7 @@ function createKernelSupervisor(deps = {}) {
       const products = await catalogStore.listProducts();
       for (const p of Array.isArray(products) ? products : []) {
         const pid = resolveProjectId(p);
-        if (isSafeId(pid)) set.add(pid);
+        if (isSafeId(pid) && !isReservedProjectId(pid)) set.add(pid);
       }
     }
     return set;
@@ -963,6 +991,9 @@ function createKernelSupervisor(deps = {}) {
 
   return {
     bootProducts,
+    // #4853 · A01 — conjunto autorizado out-of-band (excluye reservados). Expuesto
+    // para verificación: los drenajes de create/edit/deactivate lo usan internamente.
+    authorizedProjectIdSet,
     drainCreateWaveQueue,
     drainEditQueue,
     drainDeactivateQueue,


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 2 archivos · +150 -1

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:passed` aplicado por delivery

## Closes

Closes #4853
