### PR TITLE
Cuota de Anthropic: fuente única de verdad = `claude -p /usage` (eliminar cálculo/calibración residual del dashboard)

### DIFF
--- a/.pipeline/dashboard.js
+++ b/.pipeline/dashboard.js
@@ -14181,63 +14181,12 @@ const server = http.createServer((req, res) => {
     return;
   }
 
-  // #2801 — Calibración manual de la cuota Plan Max contra el real de claude.ai.
-  // El operador pega los % que ve en claude.ai/settings/usage; el sistema guarda
-  // factor = real/pipeline para extrapolar futuras lecturas.
-  if (req.url === '/api/dash/quota/calibrate' && req.method === 'POST') {
-    let body = '';
-    req.on('data', c => { body += c; if (body.length > 4 * 1024) req.destroy(); });
-    req.on('end', () => {
-      try {
-        const payload = body ? JSON.parse(body) : {};
-        const realWeekly = Number(payload.real_weekly_pct);
-        const realSession = Number(payload.real_session_pct);
-        if (!Number.isFinite(realWeekly) || !Number.isFinite(realSession)) {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ ok: false, msg: 'real_weekly_pct y real_session_pct son requeridos (números)' }));
-          return;
-        }
-        const quotaLib = require('./lib/weekly-quota');
-        const metricsDir = path.join(PIPELINE, 'metrics');
-        const activityLog = path.join(ROOT, '.claude', 'activity-log.jsonl');
-        const current = quotaLib.computeQuota(metricsDir, activityLog);
-        const calibration = quotaLib.saveCalibration(metricsDir, {
-          realWeeklyPct: realWeekly,
-          realSessionPct: realSession,
-          pipelineWeeklyPct: current.pct,
-          pipelineSessionPct: current.session ? current.session.pct : 0,
-          // Opcionales — tiempos de reset reportados por el operador.
-          // Acepta ISO absoluto (preferido) o minutos relativos (legacy).
-          sessionResetsAt: payload.session_resets_at || null,
-          weeklyResetsAt: payload.weekly_resets_at || null,
-          sessionResetsInMinutes: Number.isFinite(payload.session_resets_in_minutes) ? Number(payload.session_resets_in_minutes) : null,
-          weeklyResetsInMinutes: Number.isFinite(payload.weekly_resets_in_minutes) ? Number(payload.weekly_resets_in_minutes) : null,
-        });
-        log(`quota: calibrado #${calibration.sample_count} real(w=${realWeekly}%, s=${realSession}%) → pipeline(w=${current.pct}%, s=${current.session?.pct}%) → factor smooth(w=${calibration.weekly_factor}, s=${calibration.session_factor}) raw(w=${calibration.weekly_factor_obs}, s=${calibration.session_factor_obs}) α=${calibration.ema_alpha}`);
-        res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ ok: true, msg: `Calibración #${calibration.sample_count} guardada · factor semanal ×${calibration.weekly_factor} · sesión ×${calibration.session_factor} (EMA α=${calibration.ema_alpha})`, calibration }));
-      } catch (e) {
-        res.writeHead(500, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ ok: false, msg: 'Error: ' + e.message }));
-      }
-    });
-    return;
-  }
-
-  if (req.url === '/api/dash/quota/calibrate' && req.method === 'DELETE') {
-    try {
-      const quotaLib = require('./lib/weekly-quota');
-      const metricsDir = path.join(PIPELINE, 'metrics');
-      const result = quotaLib.clearCalibration(metricsDir);
-      log('quota: calibración borrada por operador');
-      res.writeHead(200, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ ok: true, msg: result.msg }));
-    } catch (e) {
-      res.writeHead(500, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ ok: false, msg: 'Error: ' + e.message }));
-    }
-    return;
-  }
+  // #4861 — Endpoints POST/DELETE /api/dash/quota/calibrate ELIMINADOS.
+  // La calibración manual EMA (factor real/pipeline sobre la heurística
+  // duration_ms) producía el valor divergente 57%/76%. La fuente única de
+  // verdad de la cuota Anthropic es ahora `claude -p /usage` vía
+  // lib/anthropic-usage.js + lib/quota-adapters/anthropic.js. Se retiran
+  // ambas rutas mutantes no autenticadas (mejora de postura OWASP A01/A05).
 
   // Nuevo dashboard kiosk vertical (#2801) — home + 9 tabs satélite + slices JSON
   // bajo /api/dash/*. Anti-flicker: cliente hace polling JSON y muta DOM in-place.

--- a/.pipeline/lib/__tests__/dashboard-slices-quota-failclosed-4861.test.js
+++ b/.pipeline/lib/__tests__/dashboard-slices-quota-failclosed-4861.test.js
@@ -1,0 +1,74 @@
+// =============================================================================
+// Tests #4861 — Cuota Anthropic: fuente única = claude -p /usage.
+//
+// Verifica el FAIL-CLOSED del slice de cuota (`quotaSlice`) cuando no hay dato
+// real de /usage: el resultado de Anthropic debe ser SIN-DATO explícito
+// (`pct: null`, `status: 'unknown'`), NUNCA un valor heurístico ni un default
+// permisivo (pct: 0). La cuota gobierna pacing/gating; un fail-open habilitaría
+// cost-DoS por sobreconsumo pago (security OWASP A04, CA-4 del PO).
+//
+// También chequea que la heurística `computeQuota` y la calibración EMA ya no
+// forman parte del módulo weekly-quota (retiradas en #4861).
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+function freshSlices() {
+    delete require.cache[require.resolve('../dashboard-slices')];
+    return require('../dashboard-slices');
+}
+
+function mkTmpPipeline() {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'v3-quota-failclosed-4861-'));
+    const pipeline = path.join(root, '.pipeline');
+    fs.mkdirSync(path.join(pipeline, 'metrics'), { recursive: true });
+    fs.mkdirSync(path.join(root, '.claude'), { recursive: true });
+    // activity-log vacío: sin datos que una heurística pudiera usar.
+    fs.writeFileSync(path.join(root, '.claude', 'activity-log.jsonl'), '');
+    return { root, pipeline };
+}
+
+// ---------------------------------------------------------------------------
+// CA-4 — fail-closed: sin cache de /usage, la cuota Anthropic es "sin dato".
+// ---------------------------------------------------------------------------
+test('CA-4: sin cache de /usage, quotaSlice devuelve Anthropic fail-closed (pct null, status unknown)', () => {
+    const { root, pipeline } = mkTmpPipeline();
+    // Sanity: NO existe el cache de anthropic-usage → el adapter degrada.
+    assert.ok(!fs.existsSync(path.join(pipeline, 'metrics', 'anthropic-usage.json')), 'sanity: sin cache /usage');
+
+    const slices = freshSlices();
+    const out = slices.quotaSlice({}, { ROOT: root, PIPELINE: pipeline });
+
+    // Flat-merge legacy al top-level (lo consumen renderQuotaCard/tickQuota).
+    assert.equal(out.pct, null, 'pct debe ser null — NUNCA 0 ni un valor heurístico');
+    assert.equal(out.status, 'unknown', 'status debe ser unknown');
+    assert.notEqual(typeof out.pct, 'number', 'no debe haber pct numérico calculado');
+
+    // El provider Anthropic dentro de `providers` (shape cliente normalizado)
+    // también fail-closed: pct null y confidence 'missing' por ventana.
+    const a = out.providers && out.providers.anthropic;
+    assert.ok(a, 'debe existir el provider anthropic');
+    assert.ok(['unknown', 'error'].includes(a.adapterStatus), 'adapterStatus debe ser unknown/error, no ok');
+    assert.equal(a.weekly.pct, null, 'providers.anthropic.weekly.pct debe ser null');
+    assert.equal(a.session.pct, null, 'providers.anthropic.session.pct debe ser null');
+    assert.equal(a.weekly.confidence, 'missing', 'weekly.confidence debe ser missing (sin dato)');
+});
+
+// ---------------------------------------------------------------------------
+// CA-2 / CA-3 — la heurística y la calibración salieron del módulo.
+// ---------------------------------------------------------------------------
+test('CA-3: weekly-quota ya no expone computeQuota/saveCalibration/clearCalibration', () => {
+    delete require.cache[require.resolve('../weekly-quota')];
+    const wq = require('../weekly-quota');
+    assert.equal(wq.computeQuota, undefined);
+    assert.equal(wq.saveCalibration, undefined);
+    assert.equal(wq.clearCalibration, undefined);
+    // Los helpers de reset semanal se conservan (pacing/exhaustion los usan).
+    assert.equal(typeof wq.getLastWeeklyResetMs, 'function');
+    assert.equal(typeof wq.getNextWeeklyResetMs, 'function');
+});

--- a/.pipeline/lib/__tests__/quota-snapshot-integration.test.js
+++ b/.pipeline/lib/__tests__/quota-snapshot-integration.test.js
@@ -5,7 +5,8 @@
 // quota-exhausted.js ni weekly-quota.js — CA-15):
 //
 //   CA-12 — setFlag con errorType 'snapshot_threshold_90', firma intacta.
-//   CA-13 — saveCalibration invocado con dato real, algoritmo EMA intacto.
+//   CA-13 — (#4861) RETIRADO: la calibración EMA salió de la cadena Anthropic;
+//           integrar un snapshot ya NO invoca saveCalibration/computeQuota.
 //   CA-14 — getBannerState con 4 estados (fresh/stale/missing/parser-offline).
 //   CA-15 — kill switch (QUOTA_SNAPSHOT_ENABLED=false) → comportamiento
 //           idéntico al pre-feature.
@@ -17,7 +18,7 @@
 //   CA-S3 — sanitizeSnapshotForOutput elimina account_handle (no PII leak).
 //   CA-S4 — anti-spam: una sola alerta gate por ventana semanal; mismatch
 //           account no spammea.
-//   CA-S6 — kill switch granular: GATE_ENABLED=false mantiene calibración.
+//   CA-S6 — kill switch granular: GATE_ENABLED=false → no setFlag (#4861: sin calibración).
 //   CA-S8 — race en lectura del JSONL durante rotación → fallback silencioso.
 // =============================================================================
 'use strict';
@@ -388,7 +389,7 @@ test('CA-15 / CA-S6 · QUOTA_SNAPSHOT_ENABLED=false → evaluateSnapshotAndGate 
     } finally { teardownTmp(tmp); }
 });
 
-test('CA-S6 · QUOTA_SNAPSHOT_GATE_ENABLED=false → no setFlag, sí calibración', () => {
+test('CA-S6 · QUOTA_SNAPSHOT_GATE_ENABLED=false → no setFlag (y #4861: ya no calibra)', () => {
     const tmp = setupTmp();
     try {
         process.env.QUOTA_SNAPSHOT_GATE_ENABLED = 'false';
@@ -401,8 +402,12 @@ test('CA-S6 · QUOTA_SNAPSHOT_GATE_ENABLED=false → no setFlag, sí calibració
 
         const r = m.evaluateSnapshotAndGate(validSnapshot({ weekly_all_models_pct: 95 }));
         assert.equal(r.ok, true);
-        // Calibración sí ocurrió, gate no.
-        assert.equal(r.action, 'calibrated');
+        // #4861 — La calibración EMA se retiró de la cadena Anthropic; con el
+        // gate deshabilitado no queda ninguna acción → 'none'.
+        assert.equal(r.action, 'none');
+        // El wire de snapshot ya NO escribe estado de calibración (weekly-quota.json).
+        assert.equal(fs.existsSync(path.join(tmp, 'metrics', 'weekly-quota.json')), false,
+            'integrar snapshot no debe invocar saveCalibration/computeQuota');
 
         const after = exhausted.isQuotaExhausted();
         assert.equal(after, false, 'gate deshabilitado → flag no se setea');
@@ -410,7 +415,7 @@ test('CA-S6 · QUOTA_SNAPSHOT_GATE_ENABLED=false → no setFlag, sí calibració
 });
 
 // ---------------------------------------------------------------------------
-// CA-12 / CA-13 — Wire al setFlag y saveCalibration
+// CA-12 — Wire al setFlag (#4861: saveCalibration retirado de la cadena)
 // ---------------------------------------------------------------------------
 
 test('CA-12 · evaluateSnapshotAndGate dispara setFlag con errorType correcto al cruzar umbral', () => {
@@ -443,7 +448,8 @@ test('CA-12 · evaluateSnapshotAndGate NO dispara setFlag debajo del umbral', ()
 
         const r = m.evaluateSnapshotAndGate(validSnapshot({ weekly_all_models_pct: 80 }));
         assert.equal(r.ok, true);
-        assert.equal(r.action, 'calibrated');
+        // #4861 — debajo del umbral no hay gate, y la calibración se retiró → 'none'.
+        assert.equal(r.action, 'none');
         assert.equal(exhausted.isQuotaExhausted(), false);
     } finally { teardownTmp(tmp); }
 });

--- a/.pipeline/lib/__tests__/weekly-quota.test.js
+++ b/.pipeline/lib/__tests__/weekly-quota.test.js
@@ -168,23 +168,28 @@ test('#4597: quotaUsage(anthropic) SIN cache de /usage degrada a unknown (fallba
     assert.match(result.errorReason, /fallback degradado/);
 });
 
-test('computeQuota legacy sigue funcionando sin cambios (no breaking)', () => {
-    const tmp = makeTmpDir();
-    const metricsDir = path.join(tmp, 'metrics');
-    fs.mkdirSync(metricsDir);
-    const log = path.join(tmp, 'activity-log.jsonl');
-    writeJsonl(log, [
-        { event: 'session:end', ts: new Date().toISOString(), duration_ms: 3600000, model: 'claude' },
-    ]);
-
+test('#4861: computeQuota/saveCalibration/clearCalibration ya NO se exportan (heurística/EMA retiradas)', () => {
     const wq = freshWeekly();
-    const result = wq.computeQuota(metricsDir, log);
-    // Shape legacy intacto — NO tiene los campos del envelope multi-provider.
-    assert.equal(typeof result.pct, 'number');
-    assert.equal(typeof result.status, 'string');
-    assert.equal(typeof result.session, 'object');
-    // Estos campos son nuevos del envelope; la API legacy NO los expone.
-    assert.equal(result.provider, undefined);
-    assert.equal(result.adapterStatus, undefined);
-    assert.equal(result.schemaVersion, undefined);
+    // La heurística de duration_ms y la calibración manual EMA salieron del
+    // módulo: la fuente única de cuota Anthropic es claude -p /usage.
+    assert.equal(wq.computeQuota, undefined, 'computeQuota debe estar retirada');
+    assert.equal(wq.saveCalibration, undefined, 'saveCalibration debe estar retirada');
+    assert.equal(wq.clearCalibration, undefined, 'clearCalibration debe estar retirada');
+});
+
+test('#4861: helpers de reset semanal siguen exportados (pacing/exhaustion los consumen)', () => {
+    const wq = freshWeekly();
+    assert.equal(typeof wq.getLastWeeklyResetMs, 'function', 'getLastWeeklyResetMs debe seguir exportado');
+    assert.equal(typeof wq.getNextWeeklyResetMs, 'function', 'getNextWeeklyResetMs debe seguir exportado');
+    const now = Date.now();
+    const last = wq.getLastWeeklyResetMs(now);
+    const next = wq.getNextWeeklyResetMs(now);
+    assert.equal(typeof last, 'number');
+    assert.equal(typeof next, 'number');
+    assert.ok(next > last, 'el próximo reset debe ser posterior al último');
+    // Los módulos que dependen de estos helpers deben resolverlos sin romperse.
+    assert.doesNotThrow(() => {
+        require('../pacing-bucket');
+        require('../quota-exhausted');
+    });
 });

--- a/.pipeline/lib/dashboard-slices.js
+++ b/.pipeline/lib/dashboard-slices.js
@@ -2407,24 +2407,35 @@ function quotaSlice(state, ctx) {
                 if (provider === 'anthropic') anthropicResult = result;
             } catch (err) {
                 // Defensa: el dispatcher es fail-secure, pero por si acaso.
-                providers[provider] = {
+                const failClosed = {
                     provider,
                     adapterStatus: 'error',
                     errorReason: err && err.message ? err.message : 'unknown',
                     pct: null,
                     status: 'unknown',
                 };
+                providers[provider] = failClosed;
+                // #4861 / CA-4 (OWASP A04): si el adapter de Anthropic falla,
+                // el resultado top-level debe ser sin-dato explícito, NUNCA un
+                // default permisivo (pct:0) — la cuota gobierna pacing/gating y
+                // un fail-open habilita cost-DoS por sobreconsumo pago.
+                if (provider === 'anthropic') anthropicResult = failClosed;
             }
         }
     } catch (e) {
-        // quota-adapters no está disponible — cae al cómputo legacy directo.
-        try {
-            const quotaLib = require('./weekly-quota');
-            anthropicResult = quotaLib.computeQuota(metricsDir, activityLog, { configLimitHours });
-            providers.anthropic = anthropicResult;
-        } catch (e2) {
-            return { error: e2.message, hoursUsed7d: 0, pct: 0, status: 'unknown', providers: {} };
-        }
+        // #4861 — quota-adapters no está disponible. Antes se caía a la
+        // heurística `computeQuota` (calibración EMA), que producía el valor
+        // divergente 57%/76%. Ahora fail-closed: sin dato de cuota Anthropic,
+        // NO un default permisivo. La fuente única es `claude -p /usage` vía
+        // quota-adapters/anthropic.js; si no carga, se reporta unknown/stale.
+        anthropicResult = {
+            provider: 'anthropic',
+            adapterStatus: 'error',
+            errorReason: e && e.message ? e.message : 'quota-adapters unavailable',
+            pct: null,
+            status: 'unknown',
+        };
+        providers.anthropic = anthropicResult;
     }
 
     // Retrocompat: campos legacy de Anthropic en el top-level (alimentan
@@ -2433,7 +2444,8 @@ function quotaSlice(state, ctx) {
     // o se rompería `out.session` (misma referencia).
     const out = anthropicResult && typeof anthropicResult === 'object'
         ? { ...anthropicResult }
-        : { hoursUsed7d: 0, pct: 0, status: 'unknown' };
+        // #4861 / CA-4: fail-closed por defensa (pct:null, no pct:0 permisivo).
+        : { hoursUsed7d: 0, pct: null, status: 'unknown', adapterStatus: 'error' };
 
     // #4202 — `providers` se entrega NORMALIZADO al shape mínimo de cliente
     // (security req#5): por proveedor/bucket solo `{pct, confidence}`. Se

--- a/.pipeline/lib/quota-snapshot-integration.js
+++ b/.pipeline/lib/quota-snapshot-integration.js
@@ -9,8 +9,9 @@
 //
 //   1. `evaluateSnapshotAndGate(snapshot, opts)` — invocada por el scheduler
 //      del #3012 después de cada parse exitoso. Decide si llamar
-//      `setFlag({errorType:'snapshot_threshold_90', resetsAt})` y/o
-//      `saveCalibration(metricsDir, obs)` con defense-in-depth (CA-S1).
+//      `setFlag({errorType:'snapshot_threshold_90', resetsAt})`.
+//      #4861: la calibración EMA (`saveCalibration`) se retiró de esta cadena;
+//      la fuente única de cuota Anthropic es el snapshot real de `/usage`.
 //
 //   2. `getBannerState(opts)` — lectura pasiva para el dashboard
 //      (`/api/dash/quota-snapshot`). Devuelve `{state, lastSnapshot, ageMs,
@@ -59,14 +60,8 @@ function integrationStateFile() {
     return path.join(pipelineDir(), '.quota-snapshot-integration-state.json');
 }
 
-function metricsDir() {
-    return path.join(pipelineDir(), 'metrics');
-}
-
-function activityLogPath() {
-    if (process.env.ACTIVITY_LOG_PATH) return process.env.ACTIVITY_LOG_PATH;
-    return path.resolve(pipelineDir(), '..', '.claude', 'activity-log.jsonl');
-}
+// #4861: metricsDir()/activityLogPath() se retiraron junto con la calibración
+// EMA — eran sólo insumos de weeklyQuota.computeQuota, ya fuera del flujo.
 
 // TTL/STALE/GATE defaults (configurables por env, narrativa §2.1).
 const DEFAULT_TTL_MIN = 90;             // QUOTA_BANNER_TTL_MIN
@@ -632,7 +627,9 @@ function evaluateSnapshotAndGate(snapshot, opts = {}) {
     }
 
     let didGate = false;
-    let didCalibrate = false;
+    // #4861: didCalibrate queda en false permanente — la calibración EMA se
+    // retiró de la cadena Anthropic (fuente única = snapshot real de /usage).
+    const didCalibrate = false;
     const gatePct = getGatePct();
 
     // CA-12 / CA-S5: gate al detector binario (con kill switch granular).
@@ -678,28 +675,11 @@ function evaluateSnapshotAndGate(snapshot, opts = {}) {
         }
     }
 
-    // CA-13: calibración EMA con dato real. Importante: computeQuota ANTES
-    // para tener el pct heurístico SIN calibrar (ver guru §"Calibración:
-    // secuencia obligatoria"). Si computeQuota falla (sin metrics dir),
-    // saltea calibración pero NO falla todo el wire.
-    try {
-        const baseline = weeklyQuota.computeQuota(metricsDir(), activityLogPath());
-        weeklyQuota.saveCalibration(metricsDir(), {
-            realWeeklyPct: snapshot.weekly_all_models_pct,
-            realSessionPct: snapshot.session_pct,
-            pipelineWeeklyPct: baseline && Number.isFinite(baseline.pct) ? baseline.pct : 0,
-            pipelineSessionPct: baseline && baseline.session && Number.isFinite(baseline.session.pct)
-                ? baseline.session.pct : 0,
-            sessionResetsInMinutes: snapshot.session_minutes_to_reset,
-        });
-        didCalibrate = true;
-        const state = loadIntegrationState();
-        state.last_calibration_at = new Date(now).toISOString();
-        saveIntegrationState(state);
-    } catch (e) {
-        // Logs sin PII (R7): solo categoría.
-        log('warn', `quota-snapshot-integration: calibration skipped — ${e.message ? 'io_error' : 'unknown'}`);
-    }
+    // #4861: la calibración EMA (computeQuota + saveCalibration) se retiró de
+    // la cadena Anthropic. La fuente única de verdad es el snapshot real de
+    // `claude -p /usage` vía lib/anthropic-usage.js + quota-adapters/anthropic.js.
+    // El snapshot ya no se usa para calibrar una heurística; sólo alimenta el
+    // gate y las alertas más arriba. Ver docs/quota-tracking.md.
 
     // #4282 — evaluación anticipatoria multi-provider. Best-effort: nunca debe
     // romper el wire del snapshot. Reusa el ciclo periódico de este módulo como
@@ -711,6 +691,8 @@ function evaluateSnapshotAndGate(snapshot, opts = {}) {
         log('warn', `quota-snapshot-integration: provider-quota-guard skip — ${e && e.message ? 'error' : 'unknown'}`);
     }
 
+    // #4861: didCalibrate ya no puede ser true (calibración EMA retirada). El
+    // action 'calibrated'/'gated_and_calibrated' queda como legacy inalcanzable.
     let action = 'none';
     if (didGate && didCalibrate) action = 'gated_and_calibrated';
     else if (didGate) action = 'gated';

--- a/.pipeline/lib/weekly-quota.js
+++ b/.pipeline/lib/weekly-quota.js
@@ -1,14 +1,15 @@
 // Weekly Quota — estimación del consumo del Plan Max de Anthropic.
 //
-// ⚠️ DEPRECADO como FUENTE de la cuota Anthropic (#4597).
-//   `computeQuota` (heurística de `duration_ms`) y la calibración manual
-//   (`saveCalibration`/EMA/factor) ya NO alimentan el adapter Anthropic: la
-//   fuente de verdad pasó a ser el uso REAL de `claude -p "/usage"`
+// ⚠️ DEPRECADO como FUENTE de la cuota Anthropic (#4597) — y RETIRADO en #4861.
+//   `computeQuota` (heurística de `duration_ms`), `saveCalibration` y
+//   `clearCalibration` (calibración manual EMA/factor) fueron ELIMINADAS: eran
+//   la causa del valor divergente 57%/76% que mostraba el dashboard. La fuente
+//   ÚNICA de verdad de la cuota Anthropic es el uso REAL de `claude -p "/usage"`
 //   (ver lib/anthropic-usage.js + quota-adapters/anthropic.js). Este archivo se
-//   conserva SÓLO por compatibilidad (fallback de último recurso en
-//   dashboard-slices y helpers de reset como getLastWeeklyResetMs que pacing
-//   sigue usando para anclar la ventana semanal). No agregar consumidores
-//   nuevos de `computeQuota`/`saveCalibration`.
+//   conserva ÚNICAMENTE por los helpers de reset semanal standalone
+//   (`getLastWeeklyResetMs`/`getNextWeeklyResetMs`) que consumen pacing-bucket.js
+//   y quota-exhausted.js para anclar la ventana semanal, más el re-export de
+//   `quotaUsage`. No re-introducir cálculo/calibración de cuota Anthropic acá.
 //
 // Anthropic NO expone API pública del uso del plan, así que aproximamos:
 //
@@ -18,9 +19,8 @@
 //
 // Multi-provider (M2 #3092 + #3065 §5.4):
 //
-//   * Este archivo mantiene la API legacy `computeQuota(metricsDir, log)`
-//     intacta — sigue siendo Anthropic-only y respeta el contrato byte-a-
-//     byte que consume el banner del dashboard (regresión cero).
+//   * La API legacy `computeQuota(metricsDir, log)` fue retirada en #4861.
+//     Los consumidores usan `quotaUsage('anthropic', ...)`.
 //
 //   * La API multi-provider canónica vive en `lib/quota-adapters/`:
 //
@@ -145,119 +145,13 @@ function loadState(metricsDir) {
     }
 }
 
-const round2 = (n) => Math.round(n * 100) / 100;
-
-/**
- * Persiste una calibración manual con APRENDIZAJE INCREMENTAL:
- *
- *   1. Cada calibración se acumula en `calibrations[]` (historial — últimas 20).
- *   2. Los factores semanal/sesión se calculan por **EMA** (Exponential Moving
- *      Average) en lugar de reemplazo total: `nuevo = α·obs + (1-α)·viejo`.
- *      α se ajusta según cantidad de muestras (más muestras → α menor → más
- *      conservador, menos sensible a outliers individuales).
- *   3. Si el operador reporta `sessionResetsInMinutes` o `weeklyResetsInMinutes`,
- *      persistimos esos timestamps absolutos. El cliente los usa para mostrar
- *      cuenta regresiva precisa, y el server detecta drift de TZ del weekly
- *      reset (e.g. si reportado != calculado por nuestra fórmula, ajustamos
- *      el offset persistido).
- *   4. `weighted_pipeline_pct_at` registra el pipeline pct al momento de
- *      calibrar — sirve para recalcular factor cuando el pipeline cambia
- *      mucho entre calibraciones (no implementado aún, queda como hook).
- *
- * @param {string} metricsDir
- * @param {{realWeeklyPct, realSessionPct, pipelineWeeklyPct, pipelineSessionPct, sessionResetsInMinutes?, weeklyResetsInMinutes?}} obs
- */
-function saveCalibration(metricsDir, obs) {
-    const state = loadState(metricsDir);
-    const realWeekly = Number(obs.realWeeklyPct);
-    const realSession = Number(obs.realSessionPct);
-    const pipelineWeekly = Number(obs.pipelineWeeklyPct);
-    const pipelineSession = Number(obs.pipelineSessionPct);
-    const newWeeklyFactor = pipelineWeekly > 0 ? realWeekly / pipelineWeekly : 1;
-    const newSessionFactor = pipelineSession > 0 ? realSession / pipelineSession : 1;
-
-    const now = Date.now();
-    // Aceptar tanto "minutos al reset" (legacy) como "timestamp ISO absoluto"
-    // (preferido — más natural cuando el operador pega una hora del datetime
-    // picker o de claude.ai). Si vienen ambos, gana el ISO absoluto.
-    function parseResetAt(directIso, minutesField) {
-        if (directIso) {
-            const ts = new Date(directIso).getTime();
-            if (Number.isFinite(ts) && ts > now) return new Date(ts).toISOString();
-        }
-        if (Number.isFinite(minutesField) && minutesField > 0) {
-            return new Date(now + minutesField * 60000).toISOString();
-        }
-        return null;
-    }
-    const sessionResetsAt = parseResetAt(obs.sessionResetsAt, obs.sessionResetsInMinutes);
-    const weeklyResetsAt = parseResetAt(obs.weeklyResetsAt, obs.weeklyResetsInMinutes);
-
-    // Detectar drift del reset semanal: si nuestro cálculo predice X y user
-    // reporta Y con > 30 min de diferencia, persistir el offset para corregir
-    // próximas invocaciones de getNextWeeklyResetMs().
-    let weeklyResetDriftMin = state.weekly_reset_drift_min || 0;
-    if (weeklyResetsAt) {
-        const ourPredicted = getNextWeeklyResetMs(now);
-        const reportedMs = new Date(weeklyResetsAt).getTime();
-        const driftMs = reportedMs - ourPredicted;
-        if (Math.abs(driftMs) > 30 * 60000) {
-            weeklyResetDriftMin = Math.round(driftMs / 60000);
-        }
-    }
-
-    const entry = {
-        at: new Date(now).toISOString(),
-        real_weekly_pct: realWeekly,
-        real_session_pct: realSession,
-        pipeline_weekly_pct_at: pipelineWeekly,
-        pipeline_session_pct_at: pipelineSession,
-        weekly_factor_obs: round2(newWeeklyFactor),
-        session_factor_obs: round2(newSessionFactor),
-        session_resets_at: sessionResetsAt,
-        weekly_resets_at: weeklyResetsAt,
-    };
-    state.calibrations.push(entry);
-    if (state.calibrations.length > 20) state.calibrations = state.calibrations.slice(-20);
-
-    // EMA: α decrece con número de muestras. Primera muestra: α=1 (exact).
-    // De ahí en adelante: α = max(0.2, 1 / sqrt(n)) — equilibra respuesta
-    // a cambios reales con resistencia a ruido.
-    const n = state.calibrations.length;
-    const alpha = n === 1 ? 1.0 : Math.max(0.2, 1 / Math.sqrt(n));
-    const prevWeeklyFactor = state.calibration ? state.calibration.weekly_factor : newWeeklyFactor;
-    const prevSessionFactor = state.calibration ? state.calibration.session_factor : newSessionFactor;
-    const smoothWeekly = alpha * newWeeklyFactor + (1 - alpha) * prevWeeklyFactor;
-    const smoothSession = alpha * newSessionFactor + (1 - alpha) * prevSessionFactor;
-
-    state.calibration = {
-        at: new Date(now).toISOString(),
-        real_weekly_pct: realWeekly,
-        real_session_pct: realSession,
-        pipeline_weekly_pct_at: pipelineWeekly,
-        pipeline_session_pct_at: pipelineSession,
-        weekly_factor: round2(smoothWeekly),
-        session_factor: round2(smoothSession),
-        weekly_factor_obs: round2(newWeeklyFactor),
-        session_factor_obs: round2(newSessionFactor),
-        sample_count: n,
-        ema_alpha: round2(alpha),
-        session_resets_at: sessionResetsAt,
-        weekly_resets_at: weeklyResetsAt,
-    };
-    state.weekly_reset_drift_min = weeklyResetDriftMin;
-    saveState(metricsDir, state);
-    return state.calibration;
-}
-
-function clearCalibration(metricsDir) {
-    const state = loadState(metricsDir);
-    state.calibration = null;
-    state.weekly_reset_drift_min = 0;
-    // calibrations[] (historial) se conserva para auditoría/debug.
-    saveState(metricsDir, state);
-    return { ok: true, msg: 'Calibración borrada — los KPIs vuelven a mostrar el pipeline raw.' };
-}
+// #4861 — saveCalibration/clearCalibration y el helper round2 se RETIRARON.
+// La calibración manual EMA (factor real/pipeline sobre la heurística
+// duration_ms) producía el valor divergente 57%/76% del dashboard. La fuente
+// única de verdad de la cuota Anthropic es ahora claude -p /usage vía
+// lib/anthropic-usage.js + lib/quota-adapters/anthropic.js. computeQuota
+// tambien se retiro (ver mas abajo). getLastWeeklyResetMs/getNextWeeklyResetMs
+// se conservan: los consumen pacing-bucket.js y quota-exhausted.js.
 
 function saveState(metricsDir, state) {
     try {
@@ -315,194 +209,11 @@ function computeUsage(activityLogPath, windowMs = WEEK_MS) {
     return computeUsageSince(activityLogPath, Date.now() - windowMs);
 }
 
-/**
- * Calcula la cuota actual con auto-ajuste pasivo.
- * Ventana semanal = desde el último domingo 21:00 local (Argentina por default).
- * Sesión = rolling 5h.
- * Si las horas usadas en la semana exceden el effective_limit (sin bloqueo
- * observado), subimos el límite al observado + buffer.
- */
-function computeQuota(metricsDir, activityLogPath, opts = {}) {
-    const state = loadState(metricsDir);
-    if (opts.configLimitHours && opts.configLimitHours !== state.config_limit_hours) {
-        // El config cambió; honrarlo como nuevo piso (pero respetar effective si era mayor)
-        state.config_limit_hours = opts.configLimitHours;
-        if (state.effective_limit_hours < opts.configLimitHours) {
-            state.effective_limit_hours = opts.configLimitHours;
-        }
-    }
-    // Reset semanal del observed_max_hours: si pasamos por un reset desde la
-    // última vez que actualizamos, el observado debe limpiarse para que
-    // refleje la semana nueva (no acumular del histórico).
-    const lastReset = getLastWeeklyResetMs();
-    if (state.observed_max_at) {
-        const observedTs = new Date(state.observed_max_at).getTime();
-        if (observedTs < lastReset) {
-            state.observed_max_hours = 0;
-            state.observed_max_at = null;
-        }
-    }
-    const usage = computeUsageSince(activityLogPath, lastReset);
-
-    // Auto-ajuste UP: si el uso observado en 7d supera el effective_limit
-    // sin bloqueo (asumimos que si Anthropic hubiera cortado, no estaríamos
-    // ejecutando este snippet), entonces el límite real es mayor.
-    let adjusted = false;
-    if (usage.hoursUsed > state.effective_limit_hours) {
-        const oldLimit = state.effective_limit_hours;
-        state.effective_limit_hours = Math.ceil(usage.hoursUsed + ADJUSTMENT_BUFFER_HOURS);
-        state.adjustments.push({
-            at: new Date().toISOString(),
-            from: oldLimit,
-            to: state.effective_limit_hours,
-            reason: `observed_max=${usage.hoursUsed.toFixed(1)}h > previous_limit=${oldLimit}h, no rate-limit observed`,
-        });
-        // Mantener solo las últimas 50 ajustes
-        if (state.adjustments.length > 50) state.adjustments = state.adjustments.slice(-50);
-        adjusted = true;
-    }
-    if (usage.hoursUsed > state.observed_max_hours) {
-        state.observed_max_hours = usage.hoursUsed;
-        state.observed_max_at = new Date().toISOString();
-    }
-    if (adjusted) saveState(metricsDir, state);
-
-    const pct = state.effective_limit_hours > 0
-        ? (usage.hoursUsed / state.effective_limit_hours) * 100
-        : 0;
-    const hoursRemaining = Math.max(0, state.effective_limit_hours - usage.hoursUsed);
-
-    // Burn rate diario: extrapolar últimas 24h. Si no hay datos en 24h,
-    // usar promedio de la semana en curso.
-    const daysSinceReset = Math.max(1, (Date.now() - lastReset) / DAY_MS);
-    const burnRatePerDay = usage.hoursLast24h > 0
-        ? usage.hoursLast24h
-        : (usage.hoursUsed / daysSinceReset);
-    const daysToLimit = burnRatePerDay > 0
-        ? hoursRemaining / burnRatePerDay
-        : Infinity;
-    // Si el operador reportó el reset semanal exacto en una calibración
-    // reciente, lo usamos por encima de nuestro cálculo (que corrige TZ
-    // drift via weekly_reset_drift_min).
-    let nextReset = getNextWeeklyResetMs(Date.now(), state.weekly_reset_drift_min || 0);
-    if (state.calibration && state.calibration.weekly_resets_at) {
-        const reportedReset = new Date(state.calibration.weekly_resets_at).getTime();
-        // Solo respetar si está en el futuro (no expiró). Sino caer al cálculo.
-        if (reportedReset > Date.now()) nextReset = reportedReset;
-    }
-    const msToReset = nextReset - Date.now();
-    const daysToReset = msToReset / DAY_MS;
-
-    let status = 'ok';
-    if (pct >= 90) status = 'critical';
-    else if (pct >= 75) status = 'warning';
-    else if (pct >= 50) status = 'normal';
-
-    // Sesión rolling 5h — el plan Max define una sesión de 5h que empieza
-    // con el primer mensaje y resetea 5h después. Aproximación pragmática:
-    // sumar duration_ms en las últimas 5h. No es exactamente lo que muestra
-    // claude.ai (que detecta el "primer mensaje" como pivote), pero da una
-    // señal útil de saturación de la sesión actual.
-    const sessionUsage = computeUsageSince(activityLogPath, Date.now() - DEFAULT_SESSION_LIMIT_HOURS * HOUR_MS);
-    const sessionPct = (sessionUsage.hoursUsed / DEFAULT_SESSION_LIMIT_HOURS) * 100;
-    let sessionStatus = 'ok';
-    if (sessionPct >= 90) sessionStatus = 'critical';
-    else if (sessionPct >= 75) sessionStatus = 'warning';
-    else if (sessionPct >= 50) sessionStatus = 'normal';
-
-    // Aplicar calibración manual (si existe). Multiplica el % del pipeline
-    // por el factor observado contra el % real de claude.ai. El resultado es
-    // un "estimado real" más cercano a la cuota verdadera de Anthropic
-    // (que incluye uso interactivo del operador, no solo el pipeline).
-    //
-    // **Cap al 100%**: el factor es lineal y queda fijo desde la calibración,
-    // pero el pipeline pct rolling 5h puede crecer (porque el pipeline procesa
-    // más) sin que necesariamente la cuota real crezca proporcional. Resultado:
-    // sin cap, se llegan a valores absurdos (211%, 300%). Capear refleja la
-    // realidad (la cuota nunca puede pasar 100%) y exponer `*PctRaw` permite
-    // detectar saturación: si pasa >120%, la calibración está obsoleta y
-    // conviene recalibrar.
-    let realPct = null;
-    let realPctRaw = null;
-    let realPctCapped = false;
-    let realSessionPct = null;
-    let realSessionPctRaw = null;
-    let realSessionPctCapped = false;
-    let realStatus = status;
-    let realSessionStatus = sessionStatus;
-    if (state.calibration && state.calibration.weekly_factor) {
-        realPctRaw = Math.round(pct * state.calibration.weekly_factor * 10) / 10;
-        realPct = Math.min(100, realPctRaw);
-        realPctCapped = realPctRaw > 100;
-        if (realPct >= 90) realStatus = 'critical';
-        else if (realPct >= 75) realStatus = 'warning';
-        else if (realPct >= 50) realStatus = 'normal';
-        else realStatus = 'ok';
-    }
-    if (state.calibration && state.calibration.session_factor) {
-        realSessionPctRaw = Math.round(sessionPct * state.calibration.session_factor * 10) / 10;
-        realSessionPct = Math.min(100, realSessionPctRaw);
-        realSessionPctCapped = realSessionPctRaw > 100;
-        if (realSessionPct >= 90) realSessionStatus = 'critical';
-        else if (realSessionPct >= 75) realSessionStatus = 'warning';
-        else if (realSessionPct >= 50) realSessionStatus = 'normal';
-        else realSessionStatus = 'ok';
-    }
-
-    return {
-        // Semanal (ventana real, reset domingo 21:00 local)
-        hoursUsed7d: Math.round(usage.hoursUsed * 10) / 10,
-        sessionsCount7d: usage.sessionsCount,
-        hoursLast24h: Math.round(usage.hoursLast24h * 10) / 10,
-        effectiveLimitHours: state.effective_limit_hours,
-        configLimitHours: state.config_limit_hours,
-        pct: Math.round(pct * 10) / 10,
-        realPct,
-        realPctRaw,
-        realPctCapped,
-        realStatus,
-        hoursRemaining: Math.round(hoursRemaining * 10) / 10,
-        burnRatePerDay: Math.round(burnRatePerDay * 10) / 10,
-        daysToLimit: Number.isFinite(daysToLimit) ? Math.round(daysToLimit * 10) / 10 : null,
-        status,
-        adjustmentsCount: state.adjustments.length,
-        observedMaxHours: Math.round(state.observed_max_hours * 10) / 10,
-        observedMaxAt: state.observed_max_at,
-        autoAdjusted: adjusted,
-        // Reset semanal real
-        lastResetAt: new Date(lastReset).toISOString(),
-        nextResetAt: new Date(nextReset).toISOString(),
-        daysToReset: Math.round(daysToReset * 10) / 10,
-        // Sesión rolling 5h
-        session: {
-            hoursUsed: Math.round(sessionUsage.hoursUsed * 100) / 100,
-            sessionsCount: sessionUsage.sessionsCount,
-            limitHours: DEFAULT_SESSION_LIMIT_HOURS,
-            pct: Math.round(sessionPct * 10) / 10,
-            realPct: realSessionPct,
-            realPctRaw: realSessionPctRaw,
-            realPctCapped: realSessionPctCapped,
-            realStatus: realSessionStatus,
-            hoursRemaining: Math.round(Math.max(0, DEFAULT_SESSION_LIMIT_HOURS - sessionUsage.hoursUsed) * 100) / 100,
-            status: sessionStatus,
-        },
-        // Calibración (si existe) + historial reciente (últimas 20)
-        calibration: state.calibration,
-        calibrations: (state.calibrations || []).slice(-20),
-        weeklyResetDriftMin: state.weekly_reset_drift_min || 0,
-        // Stale: la calibración pierde precisión con el tiempo. Marcamos
-        // stale > 7d para sugerir recalibrar.
-        calibrationAgeDays: state.calibration
-            ? Math.round((Date.now() - new Date(state.calibration.at).getTime()) / DAY_MS * 10) / 10
-            : null,
-        calibrationStale: state.calibration
-            ? (Date.now() - new Date(state.calibration.at).getTime()) > 7 * DAY_MS
-            : false,
-        // Reset times reportados por el operador (si los proveyó en última calib)
-        sessionResetsAt: state.calibration ? state.calibration.session_resets_at : null,
-        weeklyResetsAtReported: state.calibration ? state.calibration.weekly_resets_at : null,
-    };
-}
+// #4861 — computeQuota (heuristica duration_ms + weekly_factor/session_factor)
+// se RETIRO. Producia el porcentaje calibrado divergente. La fuente unica de
+// cuota Anthropic es claude -p /usage via quota-adapters/anthropic.js. Los
+// helpers computeUsage/computeUsageSince quedan disponibles pero fuera del
+// flujo activo de cuota.
 
 // API multi-provider — dispatch a adapters/. Re-exportado acá para que
 // callers que migran de `computeQuota` a `quotaUsage` no necesiten cambiar
@@ -517,15 +228,15 @@ function quotaUsage(provider, sessionData) {
 }
 
 module.exports = {
-    computeQuota,
+    // #4861 — computeQuota/saveCalibration/clearCalibration retiradas (fuente
+    // única = claude -p /usage). getLastWeeklyResetMs/getNextWeeklyResetMs se
+    // conservan: los consumen pacing-bucket.js y quota-exhausted.js.
     computeUsage,
     computeUsageSince,
     getLastWeeklyResetMs,
     getNextWeeklyResetMs,
     loadState,
     saveState,
-    saveCalibration,
-    clearCalibration,
     quotaUsage,
     DEFAULT_LIMIT_HOURS,
     DEFAULT_SESSION_LIMIT_HOURS,

--- a/.pipeline/tests/dashboard-fetch-client.test.js
+++ b/.pipeline/tests/dashboard-fetch-client.test.js
@@ -136,7 +136,9 @@ test('fetchJson adjunta X-CSRF-Token en DELETE (R2)', async () => {
     let captured = null;
     const fetchImpl = async (url, opts) => { captured = opts; return { ok: true, status: 200, json: async () => ({}) }; };
     const { api } = loadClient({ fetchImpl, csrfToken: 'tok-xyz' });
-    await api.fetchJson('/api/dash/quota/calibrate', { method: 'DELETE' });
+    // #4861 — el endpoint /api/dash/quota/calibrate se eliminó; este test valida
+    // el header CSRF genérico en DELETE con un path de mutación cualquiera.
+    await api.fetchJson('/api/dash/some-mutation', { method: 'DELETE' });
     assert.equal(captured.headers['X-CSRF-Token'], 'tok-xyz');
 });
 

--- a/.pipeline/views/dashboard/__tests__/costos.test.js
+++ b/.pipeline/views/dashboard/__tests__/costos.test.js
@@ -301,9 +301,11 @@ test('renderCostosRedesign: compone todo con el contenedor morphing-target', () 
     assert.match(html, /Cuota por proveedor/);        // sección de cuotas
     assert.match(html, /cz-budget-save/);             // presupuesto
     assert.match(html, /id="cz-budget-input"/);
-    // Calibración de Claude preservada con IDs invariantes (binding del shell).
-    assert.match(html, /id="calib-weekly"/);
-    assert.match(html, /id="calib-save"/);
+    // #4861 — La herramienta de calibración manual se ELIMINÓ (fuente única =
+    // claude -p /usage). El markup ya no debe contener controles de calibración.
+    assert.ok(!/id="calib-weekly"/.test(html), 'no debe quedar input de calibración');
+    assert.ok(!/id="calib-save"/.test(html), 'no debe quedar botón de calibración');
+    assert.ok(!/cz-calib/.test(html), 'no debe quedar markup .cz-calib');
 });
 
 test('renderCostosRedesign: NO re-renderiza la chrome del shell (sin onclick inline)', () => {
@@ -327,6 +329,7 @@ test('renders degradan a aviso visible ante slice vacío (no rompen)', () => {
     assert.doesNotThrow(() => costos.renderProjectionsCards({}));
     assert.doesNotThrow(() => costos.renderDrillDown({}));
     assert.doesNotThrow(() => costos.renderProviderQuota({}));
-    assert.doesNotThrow(() => costos.renderCalibrationTool());
+    // #4861 — renderCalibrationTool eliminado (ya no se exporta).
+    assert.equal(costos.renderCalibrationTool, undefined);
     assert.doesNotThrow(() => costos.renderCostosRedesign({}));
 });

--- a/.pipeline/views/dashboard/costos.js
+++ b/.pipeline/views/dashboard/costos.js
@@ -755,29 +755,10 @@ function renderProviderQuota(slice) {
     }
 }
 
-// --- Calibración de la estimación de Claude (preservada de #3735) ------------
-// Mantiene los IDs invariantes que el client script del shell (satellites.js
-// tickQuota) bindea por getElementById: calib-weekly / calib-session /
-// calib-session-at / calib-weekly-at / calib-save / calib-clear / calib-status /
-// calib-history. Mover el markup acá no rompe el binding (es por ID, no por DOM).
-function renderCalibrationTool() {
-    return `<details class="cz-calib" id="quota-calib">
-  <summary>🎯 Calibrar la estimación de Claude con valores reales de claude.ai/settings/usage</summary>
-  <p class="cz-calib-help">Pegá los % que ves y, si querés mejorar la precisión del reset semanal, también el día/hora de cada reset. Cada calibración entra al historial — los factores se promedian con EMA.</p>
-  <div class="cz-calib-grid">
-    <div><label>% semanal real</label><input id="calib-weekly" type="number" step="0.1" min="0" max="100" placeholder="ej: 22"></div>
-    <div><label>% sesión 5h real</label><input id="calib-session" type="number" step="0.1" min="0" max="100" placeholder="ej: 60"></div>
-    <div><label>Sesión: día y hora del reset (opcional)</label><input id="calib-session-at" type="datetime-local"></div>
-    <div><label>Semanal: día y hora del reset (opcional)</label><input id="calib-weekly-at" type="datetime-local"></div>
-  </div>
-  <div class="cz-calib-actions">
-    <button id="calib-save" class="cz-calib-btn cz-calib-apply" type="button">▶ Aplicar y aprender</button>
-    <button id="calib-clear" class="cz-calib-btn" type="button">✕ Borrar calibración</button>
-  </div>
-  <div id="calib-status" class="cz-calib-status" role="status" aria-live="polite"></div>
-  <div id="calib-history"></div>
-</details>`;
-}
+// #4861 — renderCalibrationTool() ELIMINADO. La herramienta de calibración
+// manual (IDs calib-weekly/calib-session/calib-save/calib-clear/…) alimentaba
+// los endpoints POST/DELETE /api/dash/quota/calibrate, ya retirados. La cuota
+// Anthropic ahora tiene fuente única (claude -p /usage) y no se calibra a mano.
 
 // --- Script cliente del presupuesto: POST + re-render sin recarga completa ---
 // Tras un POST 200, re-fetchea el partial de la vista Costos y reemplaza el
@@ -942,7 +923,6 @@ function renderCostosRedesign(slice) {
   <div class="cz-panel">
     ${panelHeader('🔌', 'Cuota por proveedor', 'límites y consumo de los 5 proveedores del pipeline — no solo Anthropic', 'Cada proveedor tiene su propio modelo de límite: Claude por sesión 5h + semanal (Plan Max), Codex por plan pago, y los free tier (Groq/Gemini/Cerebras) por requests y tokens diarios. Las cuotas que el proveedor no expone por API se estiman desde el activity-log.')}
     ${renderProviderQuota(slice)}
-    ${renderCalibrationTool()}
   </div>`;
     } catch (e) {
         inner = `<div class="cz-empty">Rediseño de Costos no disponible.</div>`;
@@ -1114,18 +1094,7 @@ function costosRedesignStyle() {
 #costos-redesign .cz-pqbar i{display:block;height:100%;border-radius:5px}
 #costos-redesign .cz-pqreset{font-size:9.5px;color:var(--cz-mut2);line-height:1.35;margin-top:auto}
 #costos-redesign .cz-est{color:#fdba74;font-weight:700}
-/* CALIBRACIÓN */
-#costos-redesign .cz-calib{margin-top:16px;border-top:1px solid var(--cz-line);padding-top:13px}
-#costos-redesign .cz-calib>summary{cursor:pointer;font-size:12px;color:var(--cz-mut);user-select:none;font-weight:600}
-#costos-redesign .cz-calib-help{font-size:11px;color:var(--cz-mut2);margin:10px 0 8px}
-#costos-redesign .cz-calib-grid{display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-bottom:10px}
-@media (max-width:560px){#costos-redesign .cz-calib-grid{grid-template-columns:1fr}}
-#costos-redesign .cz-calib-grid label{font-size:11px;color:var(--cz-mut2);display:block;margin-bottom:4px}
-#costos-redesign .cz-calib-grid input{width:100%;background:var(--cz-bg);border:1px solid var(--cz-line2);border-radius:8px;padding:7px 10px;color:var(--cz-txt);font-size:13px;font-family:'Cascadia Code',Consolas,monospace}
-#costos-redesign .cz-calib-actions{display:flex;gap:8px;flex-wrap:wrap}
-#costos-redesign .cz-calib-btn{font-size:12px;font-weight:700;padding:8px 14px;border-radius:9px;cursor:pointer;background:transparent;border:1px solid var(--cz-line2);color:var(--cz-mut)}
-#costos-redesign .cz-calib-apply{border-color:var(--cz-cy);color:var(--cz-cy)}
-#costos-redesign .cz-calib-status{margin-top:10px;font-size:11px;color:var(--cz-mut2)}
+/* #4861 — estilos de la herramienta de calibración eliminados (fuente única) */
 </style>`;
 }
 
@@ -1142,7 +1111,6 @@ module.exports = {
     renderProjectionsCards,
     renderDrillDown,
     renderProviderQuota,
-    renderCalibrationTool,
     renderBudgetClientScript,
     renderCostosRedesign,
     PROVIDER_STACK_ORDER,

--- a/.pipeline/views/dashboard/home.js
+++ b/.pipeline/views/dashboard/home.js
@@ -2439,18 +2439,34 @@ function fmtETA(ms){
 function renderQuotaCard(d){
     const card = document.getElementById('kpi-quota');
     if(!card || !d) return;
-    const weekPct = d.realPct != null ? d.realPct : (d.pct || 0);
-    const sessPct = d.session && d.session.realPct != null ? d.session.realPct : ((d.session && d.session.pct) || 0);
-    const weekStatus = d.realPct != null ? d.realStatus : d.status;
-    const sessStatus = d.session && d.session.realPct != null ? d.session.realStatus : (d.session && d.session.status);
+    // #4861 — Fuente UNICA: claude -p /usage. El % que se muestra ES el real
+    // (sin calibracion). Fail-closed: si el adapter no tiene dato fresco
+    // (adapterStatus != ok o pct null) mostramos 'sin dato', NUNCA 0.0%
+    // (0% se leeria como cuota disponible → decision de pacing erronea).
+    const hasReal = d.adapterStatus === 'ok' && d.pct != null;
+    if(!hasReal){
+        setText('kpi-quota-session-pct', '—');
+        setText('kpi-quota-week-pct', '—');
+        setText('kpi-quota-session-eta', '·');
+        setText('kpi-quota-week-eta', '·');
+        card.classList.remove('kpi-ok','kpi-warn','kpi-bad');
+        card.classList.add('kpi-warn');
+        card.title = d.errorReason || 'Sin lectura de /usage (adapter no disponible o snapshot vencido) — pacing en modo conservador';
+        return;
+    }
+    const weekPct = d.pct;
+    const sessPct = (d.session && d.session.pct != null) ? d.session.pct : 0;
+    const weekStatus = d.status;
+    const sessStatus = d.session && d.session.status;
 
     setText('kpi-quota-session-pct', sessPct.toFixed(1)+'%');
     setText('kpi-quota-week-pct', weekPct.toFixed(1)+'%');
 
-    // #4249 CA-A4 — ORIGEN CANONICO DE CADA METRICA DE CUOTA (auditoria):
+    // #4249 CA-A4 / #4861 — ORIGEN CANONICO DE CADA METRICA DE CUOTA (auditoria):
     //   - % sesion (5h) / semanal AGREGADO  -> endpoint /api/dash/quota
-    //     (ticker tickQuota, este archivo) -> lib/quota-adapters/* (Anthropic
-    //     real) + lib/weekly-quota.js, calibrado contra muestras de claude.ai.
+    //     (ticker tickQuota, este archivo) -> lib/quota-adapters/anthropic.js
+    //     (uso REAL de claude -p /usage, fuente unica). Sin heuristica de
+    //     duracion ni calibracion manual.
     //     Alimenta el kpi card oculto (kpi-quota-*), NO el panel visible.
     //   - #4533 — El panel visible del home MIZPA ya NO muestra un % agregado:
     //     pasó a la matriz de cuota DISPONIBLE por proveedor × ventana
@@ -2512,13 +2528,16 @@ function renderQuotaCard(d){
     else if(worst === 'warning') card.classList.add('kpi-warn');
     else if(worst === 'normal') card.classList.add('kpi-ok');
 
-    const realLine = d.realPct != null
-        ? 'Calibrado vs claude.ai (×'+(d.calibration?d.calibration.weekly_factor:'?')+' sem, ×'+(d.calibration?d.calibration.session_factor:'?')+' ses, '+(d.calibration?d.calibration.sample_count:0)+' muestras).'
-        : 'Sin calibrar — pipeline raw. Calibrá en /costos para mejor precisión.';
-    let extraTitle = '';
-    if(d.realPctCapped) extraTitle += ' ⚠ Semanal capeado al 100% (raw '+d.realPctRaw+'%) — recalibrar.';
-    if(d.session && d.session.realPctCapped) extraTitle += ' ⚠ Sesión capeada al 100% (raw '+d.session.realPctRaw+'%) — recalibrar.';
-    card.title = realLine+extraTitle;
+    // #4861 — Fuente única: el % ES el real de claude -p /usage. Sin líneas de
+    // calibración (×factor/muestras) ni capeado-recalibrar.
+    let sourceLine = 'Cuota Anthropic real (claude -p /usage).';
+    if(d.usageSource && d.usageSource.capturedAt){
+        try {
+            const cap = new Date(d.usageSource.capturedAt).toLocaleString('es-AR', { hour12: false, day: '2-digit', month: '2-digit', hour: '2-digit', minute: '2-digit' });
+            sourceLine += ' Capturado: '+cap+'.';
+        } catch(e){ /* fecha inválida: omitir */ }
+    }
+    card.title = sourceLine;
 }
 
 async function tickQuota(){
@@ -4908,7 +4927,7 @@ function renderKpiGrid(state) {
 function _pulseFaroKpis() {
     return `
     <div class="pulse-kpis" aria-label="KPIs clave">
-      <div class="kpi-quota-wrap" id="kpi-quota" title="Cuota Plan Max (sin API pública de Anthropic — calibrado contra valores reales de claude.ai).">
+      <div class="kpi-quota-wrap" id="kpi-quota" title="Cuota Plan Max — uso real de claude -p /usage (fuente única).">
         <div class="kpi-faro" id="kpi-quota-session">
           <span class="kpi-faro-label">⏳ Cuota sesión 5h</span>
           <span class="kpi-faro-value" id="kpi-quota-session-pct">…</span>

--- a/.pipeline/views/dashboard/satellites.js
+++ b/.pipeline/views/dashboard/satellites.js
@@ -1715,11 +1715,11 @@ function renderCostos(opts) {
     //
     // El rediseño ABSORBE el contenido legacy: la antigua sección «Cuota Plan
     // Max» (sólo Anthropic) la reemplazan las 5 tarjetas de cuota por proveedor
-    // (CA-2); la herramienta de calibración de Claude se preserva DENTRO del
-    // rediseño con los mismos IDs (calib-*), por lo que el script de abajo
-    // (tickQuota) la sigue cableando por getElementById sin cambios. Los IDs
-    // legacy que ya no existen (quota-grid/costos-grid/costos-detail) están
-    // guardados con `if(el)` en el script → no rompen.
+    // (CA-2). #4861 — la herramienta de calibración manual de Claude se ELIMINÓ
+    // (fuente única = claude -p /usage); `tickQuota` ahora muestra sólo el % real
+    // y hace fail-closed sin dato. Los IDs legacy que ya no existen
+    // (quota-grid/costos-grid/costos-detail) están guardados con `if(el)` en el
+    // script → no rompen.
     const redesignHtml = (opts && typeof opts.redesignHtml === 'string') ? opts.redesignHtml : '';
     const body = redesignHtml || `<section class="in-section"><div class="in-empty">Pantalla de Costos no disponible (módulo de render no cargó). Reintentá el refresh.</div></section>`;
     const css = `
@@ -1739,168 +1739,63 @@ function renderCostos(opts) {
 .kp-tile.kp-ok .kp-tile-value { color: var(--in-ok); }`;
     const script = `
 async function tickQuota(){
+    // #4861 — Fuente UNICA de cuota Anthropic: claude -p /usage (adapter
+    // quota-adapters/anthropic.js). Ya no hay heuristica de duracion ni
+    // calibracion manual: el % que se muestra ES el real. Fail-closed si el
+    // adapter no tiene dato fresco (adapterStatus != ok o pct null): mostramos
+    // 'sin dato', NUNCA 0% (0% se leeria como cuota disponible y desviaria el
+    // pacing). Ver guidelines UX G1/G2 del issue.
     const d = await fetchJson('/api/dash/quota');
     const grid = document.getElementById('quota-grid');
     const barWrap = document.getElementById('quota-bar-wrap');
     const meta = document.getElementById('quota-meta');
     if(!d || d.error){
-        if(grid) grid.innerHTML = '<div class="in-empty">Sin datos de cuota: '+(d && d.error || 'activity-log vacío')+'</div>';
+        if(grid) grid.innerHTML = '<div class="in-empty">Sin datos de cuota: '+(d && d.error || 'activity-log vacio')+'</div>';
         return;
     }
-    const sess = d.session || { hoursUsed: 0, pct: 0, realPct: null, hoursRemaining: 5, status: 'ok', realStatus: 'ok' };
-    const sessShownPct = sess.realPct != null ? sess.realPct : sess.pct;
-    const sessShownStatus = sess.realPct != null ? sess.realStatus : sess.status;
-    const sessCls = sessShownStatus==='critical'?'kp-bad':sessShownStatus==='warning'?'kp-warn':sessShownStatus==='normal'?'':'kp-ok';
-    const weekShownPct = d.realPct != null ? d.realPct : d.pct;
-    const weekShownStatus = d.realPct != null ? d.realStatus : d.status;
-    const weekCls = weekShownStatus==='critical'?'kp-bad':weekShownStatus==='warning'?'kp-warn':weekShownStatus==='normal'?'':'kp-ok';
-    const resetTxt = d.daysToReset != null ? 'Reset en '+d.daysToReset.toFixed(1)+' días' : '';
-    const sessLabel = sess.realPct != null ? 'Sesión 5h · estimado real' : 'Sesión actual · 5h';
-    const sessCap = sess.realPctCapped ? ' ⚠ recalibrar' : '';
-    const sessRawTxt = sess.realPctRaw != null && sess.realPctCapped
-        ? ' (raw '+sess.realPctRaw.toFixed(1)+'%)'
-        : '';
-    const sessSub = sess.realPct != null
-        ? 'pipeline '+sess.pct.toFixed(1)+'% × '+(d.calibration && d.calibration.session_factor ? d.calibration.session_factor : 1)+sessRawTxt+sessCap
-        : sess.hoursUsed.toFixed(2)+'h / 5h';
-    const weekLabel = d.realPct != null ? 'Semanal · estimado real' : 'Semanal · cuota';
-    const weekCap = d.realPctCapped ? ' ⚠ recalibrar' : '';
-    const weekRawTxt = d.realPctRaw != null && d.realPctCapped
-        ? ' (raw '+d.realPctRaw.toFixed(1)+'%)'
-        : '';
-    const weekSub = d.realPct != null
-        ? 'pipeline '+d.pct.toFixed(1)+'% × '+(d.calibration && d.calibration.weekly_factor ? d.calibration.weekly_factor : 1)+weekRawTxt+weekCap
-        : 'de '+d.effectiveLimitHours+'h estimadas';
+    const hasReal = d.adapterStatus === 'ok' && d.pct != null;
+    const sess = d.session || {};
+    const clsOf = (st) => st==='critical'?'kp-bad':st==='warning'?'kp-warn':st==='normal'?'':st==='ok'?'kp-ok':'kp-warn';
+    if(!hasReal){
+        const reason = d.errorReason || 'Sin lectura de /usage (adapter no disponible o snapshot vencido) — pacing en modo conservador';
+        if(grid){
+            const html = '<div class="kp-tile kp-warn" role="status" aria-label="Sin dato de cuota Anthropic" title="'+escapeHtml(reason)+'">'
+                +'<div class="kp-tile-label">Cuota Anthropic</div>'
+                +'<div class="kp-tile-value">&#9203; sin dato</div>'
+                +'<div class="kp-tile-sub">'+escapeHtml(reason)+'</div></div>';
+            if(grid.innerHTML !== html) grid.innerHTML = html;
+        }
+        if(barWrap && barWrap.innerHTML !== '') barWrap.innerHTML = '';
+        if(meta && meta.textContent !== reason) meta.textContent = reason;
+        return;
+    }
+    const weekPct = d.pct;
+    const weekStatus = d.status;
+    const sessPct = sess.pct;
+    const sessStatus = sess.status;
+    const fmtPct = (v) => (v != null ? Number(v).toFixed(1)+'%' : '—');
     const tiles = [
-        { label: sessLabel, value: sessShownPct.toFixed(1)+'%', sub: sessSub, cls: sessCls },
-        { label: 'Sesión · restante (pipeline)', value: sess.hoursRemaining.toFixed(2)+'h', sub: 'reset rolling 5h', cls: '' },
-        { label: 'Semanal · pipeline usado', value: d.hoursUsed7d.toFixed(1)+'h', sub: d.sessionsCount7d+' sesiones desde dom 21h', cls: '' },
-        { label: weekLabel, value: weekShownPct.toFixed(1)+'%', sub: weekSub, cls: weekCls },
-        { label: 'Horas restantes (pipeline)', value: d.hoursRemaining+'h', sub: resetTxt, cls: '' },
-        { label: 'Burn rate (pipeline)', value: d.burnRatePerDay+'h/d', sub: 'últimas 24h o promedio semana', cls: '' },
-        { label: 'Días al límite', value: d.daysToLimit != null ? d.daysToLimit.toFixed(1)+'d' : '∞', sub: 'al ritmo actual', cls: d.daysToLimit != null && d.daysToLimit < 1 ? 'kp-bad' : d.daysToLimit != null && d.daysToLimit < 2 ? 'kp-warn' : '' },
-        { label: 'Auto-ajustes', value: d.adjustmentsCount, sub: 'observed: '+d.observedMaxHours+'h', cls: '' },
+        { label: 'Sesion 5h - uso real', value: fmtPct(sessPct), sub: d.sessionResetsRaw ? 'reset: '+d.sessionResetsRaw : 'rolling 5h', cls: clsOf(sessStatus) },
+        { label: 'Semanal - uso real', value: fmtPct(weekPct), sub: d.weeklyResetsRaw ? 'reset: '+d.weeklyResetsRaw : 'ventana semanal', cls: clsOf(weekStatus) },
     ];
     let html = '';
     for(const t of tiles) html += '<div class="kp-tile '+t.cls+'"><div class="kp-tile-label">'+escapeHtml(t.label)+'</div><div class="kp-tile-value">'+escapeHtml(String(t.value))+'</div><div class="kp-tile-sub">'+escapeHtml(t.sub)+'</div></div>';
     if(grid && grid.innerHTML !== html) grid.innerHTML = html;
     if(barWrap){
-        const barCls = d.status==='critical'?'bad':d.status==='warning'?'warn':'';
-        const barHtml = '<div class="quota-bar '+barCls+'"><span style="width:'+Math.min(100,d.pct).toFixed(1)+'%"></span></div><div class="quota-bar-label"><span>'+d.hoursUsed7d.toFixed(1)+'h consumidas</span><span>'+d.effectiveLimitHours+'h estimadas</span></div>';
+        const barCls = weekStatus==='critical'?'bad':weekStatus==='warning'?'warn':'';
+        const sessTxt = sessPct != null ? sessPct.toFixed(1)+'% sesion' : '';
+        const barHtml = '<div class="quota-bar '+barCls+'"><span style="width:'+Math.min(100,weekPct).toFixed(1)+'%"></span></div><div class="quota-bar-label"><span>'+weekPct.toFixed(1)+'% semanal</span><span>'+sessTxt+'</span></div>';
         if(barWrap.innerHTML !== barHtml) barWrap.innerHTML = barHtml;
     }
-    // fmtART al scope de la función (no dentro de if(meta)) porque también
-    // lo usa el bloque de calibración debajo. Antes estaba scoped al if(meta)
-    // y rompía con ReferenceError → el binding del botón nunca se ejecutaba.
-    const fmtART = (iso) => new Date(iso).toLocaleString('es-AR', { hour12: false, day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit' });
     if(meta){
-        const lines = [];
-        if(d.lastResetAt && d.nextResetAt){
-            lines.push('🗓 Semana actual: ' + fmtART(d.lastResetAt) + ' → ' + fmtART(d.nextResetAt));
+        const lines = ['Fuente: claude -p /usage (valor real).'];
+        if(d.usageSource && d.usageSource.capturedAt){
+            const cap = new Date(d.usageSource.capturedAt).toLocaleString('es-AR', { hour12: false, day: '2-digit', month: '2-digit', hour: '2-digit', minute: '2-digit' });
+            lines.push('Capturado: '+cap);
         }
-        if(d.adjustmentsCount > 0) lines.push('🔧 Límite auto-ajustado '+d.adjustmentsCount+' vez/veces (config: '+d.configLimitHours+'h → actual: '+d.effectiveLimitHours+'h)');
-        if(d.daysToLimit != null && d.daysToLimit < 2) lines.push('⚠ Llegás al límite en ~'+d.daysToLimit.toFixed(1)+' días al ritmo actual');
-        else if(d.daysToLimit == null || d.daysToLimit > (d.daysToReset || 7)) lines.push('✓ Cuota dura hasta el próximo reset al ritmo actual');
-        if(d.observedMaxAt) lines.push('Pico observado en la semana: '+d.observedMaxHours+'h (' + fmtART(d.observedMaxAt) + ')');
-        const txt = lines.join(' · ');
+        if(d.weeklyResetsRaw) lines.push('Reset semanal: '+d.weeklyResetsRaw);
+        const txt = lines.join(' - ');
         if(meta.textContent !== txt) meta.textContent = txt;
-    }
-    // Renderizar status de calibración + bind del botón (idempotente).
-    const calibStatus = document.getElementById('calib-status');
-    if(calibStatus){
-        let ctxt;
-        if(d.calibration){
-            const at = fmtART(d.calibration.at);
-            const stale = d.calibrationStale ? ' ⚠ ' : ' ✓ ';
-            const ageInfo = d.calibrationAgeDays != null ? ' (hace '+d.calibrationAgeDays+'d)' : '';
-            ctxt = stale+'Calibrado #'+d.calibration.sample_count+' · '+at+ageInfo+' · factor smooth(w=×'+d.calibration.weekly_factor+', s=×'+d.calibration.session_factor+') raw esta vez(w=×'+d.calibration.weekly_factor_obs+', s=×'+d.calibration.session_factor_obs+') · α EMA '+d.calibration.ema_alpha;
-            if(d.calibrationStale) ctxt += ' — recomendado recalibrar';
-            if(d.weeklyResetDriftMin) ctxt += ' · drift TZ del reset semanal: '+d.weeklyResetDriftMin+' min';
-        } else {
-            ctxt = 'Sin calibrar. Pegá los % que ves en claude.ai/settings/usage para extrapolar el real.';
-        }
-        if(calibStatus.textContent !== ctxt) calibStatus.textContent = ctxt;
-    }
-
-    // Historial de calibraciones (tabla compacta)
-    const calibHist = document.getElementById('calib-history');
-    if(calibHist){
-        const arr = (d.calibrations || []).slice().reverse();
-        if(arr.length === 0){
-            calibHist.innerHTML = '';
-        } else {
-            const rows = arr.slice(0, 10).map(c => '<tr>'+
-                '<td style="padding:4px 8px">'+fmtART(c.at)+'</td>'+
-                '<td style="padding:4px 8px;text-align:right">'+c.real_weekly_pct+'%</td>'+
-                '<td style="padding:4px 8px;text-align:right">'+c.real_session_pct+'%</td>'+
-                '<td style="padding:4px 8px;text-align:right;color:var(--in-fg-dim)">'+c.pipeline_weekly_pct_at.toFixed(1)+'%</td>'+
-                '<td style="padding:4px 8px;text-align:right;color:var(--in-fg-dim)">'+c.pipeline_session_pct_at.toFixed(1)+'%</td>'+
-                '<td style="padding:4px 8px;text-align:right">×'+c.weekly_factor_obs+'</td>'+
-                '<td style="padding:4px 8px;text-align:right">×'+c.session_factor_obs+'</td>'+
-                '</tr>').join('');
-            const html = '<details style="margin-top:6px"><summary style="cursor:pointer;font-size:11px;color:var(--in-fg-dim);user-select:none">📜 Historial de '+arr.length+' calibración'+(arr.length===1?'':'es')+'</summary>'+
-                '<table style="width:100%;font-size:11px;font-family:var(--in-mono);margin-top:8px;border-collapse:collapse"><thead><tr style="color:var(--in-fg-dim);border-bottom:1px solid var(--in-border)">'+
-                '<th style="padding:4px 8px;text-align:left">Fecha</th>'+
-                '<th style="padding:4px 8px;text-align:right">Sem real</th>'+
-                '<th style="padding:4px 8px;text-align:right">Ses real</th>'+
-                '<th style="padding:4px 8px;text-align:right">Sem pipe</th>'+
-                '<th style="padding:4px 8px;text-align:right">Ses pipe</th>'+
-                '<th style="padding:4px 8px;text-align:right">×Sem</th>'+
-                '<th style="padding:4px 8px;text-align:right">×Ses</th>'+
-                '</tr></thead><tbody>'+rows+'</tbody></table></details>';
-            if(calibHist.innerHTML !== html) calibHist.innerHTML = html;
-        }
-    }
-
-    // Bind del botón Aplicar
-    const calibBtn = document.getElementById('calib-save');
-    if(calibBtn && !calibBtn.dataset._bound){
-        calibBtn.dataset._bound = '1';
-        calibBtn.addEventListener('click', async () => {
-            const w = parseFloat(document.getElementById('calib-weekly').value);
-            const s = parseFloat(document.getElementById('calib-session').value);
-            const sAtRaw = document.getElementById('calib-session-at').value;
-            const wAtRaw = document.getElementById('calib-weekly-at').value;
-            // datetime-local NO incluye TZ — el browser lo interpreta como local.
-            // new Date('2026-04-27T22:00') usa TZ del browser, que para el
-            // operador es ART (lo que queremos). Convertimos a ISO UTC.
-            const sAt = sAtRaw ? new Date(sAtRaw).toISOString() : null;
-            const wAt = wAtRaw ? new Date(wAtRaw).toISOString() : null;
-            if(!Number.isFinite(w) || !Number.isFinite(s)){
-                showToast('Ingresá ambos % (semanal y sesión)', false);
-                return;
-            }
-            try{
-                const body = { real_weekly_pct: w, real_session_pct: s };
-                if(sAt) body.session_resets_at = sAt;
-                if(wAt) body.weekly_resets_at = wAt;
-                const r = await fetch('/api/dash/quota/calibrate', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(body)});
-                const j = await r.json();
-                showToast(j.msg || (j.ok?'Calibrado':'Falló'), j.ok);
-                if(j.ok){
-                    document.getElementById('calib-weekly').value = '';
-                    document.getElementById('calib-session').value = '';
-                    document.getElementById('calib-session-at').value = '';
-                    document.getElementById('calib-weekly-at').value = '';
-                }
-                setTimeout(() => tickQuota().catch(()=>{}), 400);
-            } catch(e){ showToast('Error: '+e.message, false); }
-        });
-    }
-
-    // Bind del botón Borrar
-    const calibClear = document.getElementById('calib-clear');
-    if(calibClear && !calibClear.dataset._bound){
-        calibClear.dataset._bound = '1';
-        calibClear.addEventListener('click', async () => {
-            if(!(await inConfirm({ title:'Borrar calibración', message:'El KPI vuelve a mostrar el pipeline raw. El historial de calibraciones previas se conserva.', confirmLabel:'Borrar' }))) return;
-            try{
-                const r = await fetch('/api/dash/quota/calibrate', {method:'DELETE', headers: nhCsrfHeaders()});
-                const j = await r.json();
-                showToast(j.msg || (j.ok?'Borrada':'Falló'), j.ok);
-                setTimeout(() => tickQuota().catch(()=>{}), 400);
-            } catch(e){ showToast('Error: '+e.message, false); }
-        });
     }
 }
 


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 12 archivos · +271 -645

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:passed` aplicado por delivery

## Closes

Closes #4861
