### PR TITLE
Dashboard: el tablero por fase muestra issues cerrados/entregados en "Definición" en vez de "Entregado"

### DIFF
--- a/.pipeline/views/dashboard/__tests__/pipeline-redesign.test.js
+++ b/.pipeline/views/dashboard/__tests__/pipeline-redesign.test.js
@@ -20,9 +20,121 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const path = require('node:path');
+const vm = require('node:vm');
 
 const MOD_PATH = path.resolve(__dirname, '..', 'pipeline-redesign.js');
 const pr = require(MOD_PATH);
+
+// #4866 — El bucketing por fase (plBuildPhaseBuckets) vive dentro del client
+// script (template string servido al browser), así que para testearlo lo
+// ejecutamos en un sandbox vm con stubs de las APIs de browser/commonHelpers.
+// Las funciones declaradas con `function` quedan expuestas en el global del
+// contexto; los `const` (PL_PHASE_FLOW…) siguen accesibles por cierre léxico.
+function loadClientSandbox() {
+    const script = pr.pipelineRedesignClientScript();
+    const noop = () => {};
+    const domNode = { style: {}, dataset: {}, setAttribute: noop, getAttribute: () => null,
+        appendChild: noop, addEventListener: noop, textContent: '', innerHTML: '' };
+    const sandbox = {
+        console,
+        JSON, Math, Object, Array, Number, String, Boolean, Promise,
+        sessionStorage: { getItem: () => null, setItem: noop },
+        document: {
+            getElementById: () => null, querySelector: () => null,
+            querySelectorAll: () => [], createElement: () => domNode,
+        },
+        window: {},
+        location: { href: '' },
+        setInterval: () => 0, clearInterval: noop, setTimeout: () => 0,
+        fetchJson: async () => null,
+        setText: noop, escapeHtml: (s) => String(s == null ? '' : s),
+        SKILL_ICONS: {}, pipelineModeState: { mode: 'running', allowedIssues: [] },
+        moveIssue: noop, pauseIssue: noop,
+        // Ticks definidos en otros client-scripts concatenados en la página real;
+        // acá los stubeamos para que el módulo cargue aislado.
+        tickHeader: async () => {}, tickWaves: async () => {},
+    };
+    vm.createContext(sandbox);
+    vm.runInContext(script, sandbox, { filename: 'pipeline-redesign.client.js' });
+    return sandbox;
+}
+
+const SANDBOX = loadClientSandbox();
+const plBuildPhaseBuckets = SANDBOX.plBuildPhaseBuckets;
+
+// Helpers de aserción sobre buckets.
+// Array.from del realm del test: los buckets vienen del realm del vm y su
+// prototype no es reference-equal con el Array del host (rompería deepEqual).
+function idsIn(buckets, key) { return Array.from(buckets[key] || [], (i) => String(i.issue)); }
+
+// --- #4866 · Bucketing por fase: issues cerrados/entregados ------------------
+test('plBuildPhaseBuckets está expuesto por el client script', () => {
+    assert.equal(typeof plBuildPhaseBuckets, 'function');
+});
+
+test('CA-1: issue cerrado/entregado (no en matrix) va a done, nunca a def', () => {
+    const waveMembers = ['1001'];
+    const waveDelivered = { '1001': { delivered: true, title: 'Feature cerrada' } };
+    const buckets = plBuildPhaseBuckets({}, {}, [], waveMembers, waveDelivered);
+    assert.deepEqual(idsIn(buckets, 'done'), ['1001']);
+    assert.ok(!idsIn(buckets, 'def').includes('1001'), 'no debe caer en Definición');
+    // Reusa el path visual terminal 'finalizado' (columna verde 📦✓, guideline UX).
+    const item = buckets.done.find((i) => String(i.issue) === '1001');
+    assert.equal(item.estado, 'finalizado');
+    assert.equal(item.title, 'Feature cerrada');
+});
+
+test('CA-3: fallback a Definición solo para issue sin fase y NO cerrado', () => {
+    const waveMembers = ['2001', '2002'];
+    const waveDelivered = {
+        '2001': { delivered: false, title: 'Abierto sin arrancar' }, // → def (no-ingreso)
+        '2002': { delivered: true, title: 'Cerrado' },               // → done
+    };
+    const buckets = plBuildPhaseBuckets({}, {}, [], waveMembers, waveDelivered);
+    assert.ok(idsIn(buckets, 'def').includes('2001'), 'abierto sin fase cae a def');
+    assert.deepEqual(idsIn(buckets, 'done'), ['2002']);
+    assert.ok(!idsIn(buckets, 'def').includes('2002'), 'cerrado nunca en def');
+});
+
+test('CA-5: precedencia — entregado gana aunque tenga faseActual en matrix', () => {
+    const waveMembers = ['3001'];
+    const matrix = { '3001': { faseActual: 'desarrollo/dev', title: 'En transición', agents: [] } };
+    const waveDelivered = { '3001': { delivered: true, title: 'En transición' } };
+    const buckets = plBuildPhaseBuckets(matrix, {}, [], waveMembers, waveDelivered);
+    assert.deepEqual(idsIn(buckets, 'done'), ['3001'], 'gana entregado');
+    assert.ok(!idsIn(buckets, 'dev').includes('3001'), 'no queda en dev pese al faseActual');
+});
+
+test('CA-2: consistencia — mayoría cerrados se distribuyen en done, no amontonados en def', () => {
+    const waveMembers = ['10', '11', '12', '13'];
+    const matrix = { '13': { faseActual: 'desarrollo/dev', title: 'En vuelo', agents: [] } };
+    const waveDelivered = {
+        '10': { delivered: true, title: 'a' },
+        '11': { delivered: true, title: 'b' },
+        '12': { delivered: true, title: 'c' },
+        '13': { delivered: false, title: 'd' }, // el único en vuelo real
+    };
+    const buckets = plBuildPhaseBuckets(matrix, {}, [], waveMembers, waveDelivered);
+    assert.deepEqual(idsIn(buckets, 'done').sort(), ['10', '11', '12']);
+    assert.deepEqual(idsIn(buckets, 'dev'), ['13']);
+    assert.equal(idsIn(buckets, 'def').length, 0, 'nada amontonado en Definición');
+});
+
+test('regresión: issue en vuelo (no entregado) respeta su fase real del matrix', () => {
+    const waveMembers = ['4001'];
+    const matrix = { '4001': { faseActual: 'desarrollo/build', title: 'Compilando', agents: [] } };
+    const waveDelivered = { '4001': { delivered: false, title: 'Compilando' } };
+    const buckets = plBuildPhaseBuckets(matrix, {}, [], waveMembers, waveDelivered);
+    assert.deepEqual(idsIn(buckets, 'build'), ['4001']);
+    assert.equal(idsIn(buckets, 'done').length, 0);
+});
+
+test('franja terminal finalizado (sin flag delivered) sigue yendo a done', () => {
+    const waveMembers = ['5001'];
+    const extraById = { '5001': { issue: '5001', estado: 'finalizado', title: 'Entregado legacy' } };
+    const buckets = plBuildPhaseBuckets({}, extraById, [], waveMembers, {});
+    assert.deepEqual(idsIn(buckets, 'done'), ['5001']);
+});
 
 // --- 1. Mapeo macro de fases -------------------------------------------------
 test('macroPhaseOf mapea cada pipeline/fase real a su etapa macro', () => {

--- a/.pipeline/views/dashboard/pipeline-redesign.js
+++ b/.pipeline/views/dashboard/pipeline-redesign.js
@@ -774,6 +774,91 @@ function plItemTerminal(issue, title, macro, estado){
     };
 }
 
+// #4866 — Clasificación pura de los issues en columnas por fase (buckets). Se
+// extrajo de tickPipelineRedesign para poder testearla sin DOM ni fetch.
+//   matrix        : hijos en vuelo (faseActual/agentes), del /api/dash/pipeline.
+//   extraById     : franja terminal por id ('finalizado'/'no-ingreso').
+//   waveExtra     : misma franja como array (para el fallback sin ola).
+//   waveMembers   : ids de la ola activa (fuente de verdad) o null.
+//   waveDelivered : id → { delivered, title } derivado del payload de olas.
+function plBuildPhaseBuckets(matrix, extraById, waveExtra, waveMembers, waveDelivered){
+    matrix = matrix || {};
+    extraById = extraById || {};
+    waveExtra = Array.isArray(waveExtra) ? waveExtra : [];
+    waveDelivered = waveDelivered || {};
+    const buckets = {};
+    for(const p of PL_PHASE_FLOW) buckets[p.key] = [];
+
+    if(waveMembers && waveMembers.length){
+        // WAVE MODE: todos los hijos de la ola, enriquecidos. Sin filtro allowlist:
+        // la membresía de la ola ya delimita la vista (CA-1).
+        for(const id of waveMembers){
+            const m = matrix[id];
+            const ex = extraById[id];
+            const wd = waveDelivered[id];
+            // #4866 — CA-1/CA-3/CA-5: si el payload de olas lo marca entregado
+            // (cerrado/merge), gana "entregado" ANTES de re-derivar la fase o de
+            // caer al fallback "Definición". Precedencia intencional: aunque el
+            // issue todavía tenga faseActual en matrix (edge case de transición),
+            // la pantalla principal es la fuente de verdad y lo muestra entregado
+            // → el tablero por fase debe coincidir (CA-2). Reusa el mismo path
+            // visual que los hijos 'finalizado' (columna Done, tono verde + 📦 + ✓).
+            if(wd && wd.delivered){
+                const title = (m && m.title) || (ex && ex.title) || wd.title;
+                buckets.done.push(plItemTerminal(id, title, 'done', 'finalizado'));
+                continue;
+            }
+            if(m){
+                const macro = plMacroOf(m.faseActual);
+                if(macro){ buckets[macro].push(plItemFromMatrix(id, m, macro)); }
+                else if(m.progressState === 'entre-fases'){
+                    // #4362 — avanza entre fases: NO es "sin arrancar". Se ubica
+                    // en la columna Definición pero con badge/tono "En curso".
+                    const it = plItemFromMatrix(id, m, 'def');
+                    it.between = true;
+                    buckets.def.push(it);
+                }
+                else { buckets.def.push(plItemTerminal(id, m.title, 'def', m.estadoActual)); }
+                continue;
+            }
+            if(ex && ex.estado === 'finalizado'){
+                buckets.done.push(plItemTerminal(id, ex.title, 'done', 'finalizado'));
+            } else {
+                // no-ingreso (open, sin work-file) o desconocido → definición sin
+                // arrancar. #4866 CA-3: este fallback solo aplica a issues no
+                // entregados (los entregados ya se ramificaron arriba a 'done').
+                buckets.def.push(plItemTerminal(id, ex ? ex.title : '', 'def', 'no-ingreso'));
+            }
+        }
+        return buckets;
+    }
+
+    // FALLBACK (sin ola activa): vista legacy basada en el matrix, con el
+    // filtro de allowlist de la pausa parcial. Mantiene el pipeline vivo
+    // cuando waves.json no expone una ola activa.
+    for(const [issue, data] of Object.entries(matrix)){
+        const macro = plMacroOf(data.faseActual);
+        if(!macro){
+            // #4362 — sin fase activa pero avanza entre fases: hacerlo visible
+            // (antes se descartaba, quedaba en blanco) en Definición como "En curso".
+            if(data.progressState === 'entre-fases' && (!plOnlyWave || plAllowlistOk(issue))){
+                const it = plItemFromMatrix(issue, data, 'def');
+                it.between = true;
+                buckets.def.push(it);
+            }
+            continue;
+        }
+        if(plOnlyWave && !plAllowlistOk(issue)) continue;
+        buckets[macro].push(plItemFromMatrix(issue, data, macro));
+    }
+    for(const ex of waveExtra){
+        if(plOnlyWave && !plAllowlistOk(ex.issue)) continue;
+        if(ex.estado === 'finalizado') buckets.done.push(plItemTerminal(ex.issue, ex.title, 'done', 'finalizado'));
+        else buckets.def.push(plItemTerminal(ex.issue, ex.title, 'def', 'no-ingreso'));
+    }
+    return buckets;
+}
+
 async function tickPipelineRedesign(){
     // #4234 — VISTA TOTAL DE LA OLA: cruzamos la membresía de la ola activa
     // (/api/dash/waves → solo IDs) con el matrix del pipeline (hijos en vuelo,
@@ -790,68 +875,27 @@ async function tickPipelineRedesign(){
     for(const e of waveExtra){ if(e && e.issue != null) extraById[String(e.issue)] = e; }
 
     // Membresía de la ola (CA-1). Si hay ola activa, ES la fuente de verdad.
+    // #4866 — además del id, conservamos el estado de entrega que viaja en el
+    // payload de /api/dash/waves (status:'completed' / merged:true) y el title,
+    // para no re-derivar la fase de un issue ya cerrado y mandarlo al fallback
+    // "Definición". La pantalla principal usa ese mismo dato como entregado.
     let waveMembers = null;
+    const waveDelivered = {};   // id → { delivered:bool, title:string }
     if(w && w.active_wave && Array.isArray(w.active_wave.issues)){
         waveMembers = [];
         for(const x of w.active_wave.issues){
-            if(x && x.id != null) waveMembers.push(String(x.id));
+            if(x && x.id != null){
+                const id = String(x.id);
+                waveMembers.push(id);
+                waveDelivered[id] = {
+                    delivered: (x.status === 'completed' || x.merged === true),
+                    title: x.title || '',
+                };
+            }
         }
     }
 
-    const buckets = {};
-    for(const p of PL_PHASE_FLOW) buckets[p.key] = [];
-
-    if(waveMembers && waveMembers.length){
-        // WAVE MODE: todos los hijos de la ola, enriquecidos. Sin filtro allowlist:
-        // la membresía de la ola ya delimita la vista (CA-1).
-        for(const id of waveMembers){
-            const m = matrix[id];
-            if(m){
-                const macro = plMacroOf(m.faseActual);
-                if(macro){ buckets[macro].push(plItemFromMatrix(id, m, macro)); }
-                else if(m.progressState === 'entre-fases'){
-                    // #4362 — avanza entre fases: NO es "sin arrancar". Se ubica
-                    // en la columna Definición pero con badge/tono "En curso".
-                    const it = plItemFromMatrix(id, m, 'def');
-                    it.between = true;
-                    buckets.def.push(it);
-                }
-                else { buckets.def.push(plItemTerminal(id, m.title, 'def', m.estadoActual)); }
-                continue;
-            }
-            const ex = extraById[id];
-            if(ex && ex.estado === 'finalizado'){
-                buckets.done.push(plItemTerminal(id, ex.title, 'done', 'finalizado'));
-            } else {
-                // no-ingreso (open, sin work-file) o desconocido → definición sin arrancar.
-                buckets.def.push(plItemTerminal(id, ex ? ex.title : '', 'def', 'no-ingreso'));
-            }
-        }
-    } else {
-        // FALLBACK (sin ola activa): vista legacy basada en el matrix, con el
-        // filtro de allowlist de la pausa parcial. Mantiene el pipeline vivo
-        // cuando waves.json no expone una ola activa.
-        for(const [issue, data] of Object.entries(matrix)){
-            const macro = plMacroOf(data.faseActual);
-            if(!macro){
-                // #4362 — sin fase activa pero avanza entre fases: hacerlo visible
-                // (antes se descartaba, quedaba en blanco) en Definición como "En curso".
-                if(data.progressState === 'entre-fases' && (!plOnlyWave || plAllowlistOk(issue))){
-                    const it = plItemFromMatrix(issue, data, 'def');
-                    it.between = true;
-                    buckets.def.push(it);
-                }
-                continue;
-            }
-            if(plOnlyWave && !plAllowlistOk(issue)) continue;
-            buckets[macro].push(plItemFromMatrix(issue, data, macro));
-        }
-        for(const ex of waveExtra){
-            if(plOnlyWave && !plAllowlistOk(ex.issue)) continue;
-            if(ex.estado === 'finalizado') buckets.done.push(plItemTerminal(ex.issue, ex.title, 'done', 'finalizado'));
-            else buckets.def.push(plItemTerminal(ex.issue, ex.title, 'def', 'no-ingreso'));
-        }
-    }
+    const buckets = plBuildPhaseBuckets(matrix, extraById, waveExtra, waveMembers, waveDelivered);
 
     // Bloque 1: Flujo de fases — SIEMPRE las 6 fases con su conteo (CA-3),
     // atenuando las que están en 0 (su conteo se conserva acá).


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 2 archivos · +203 -47

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:passed` aplicado por delivery

## Closes

Closes #4866
