### PR TITLE
Integrar el proveedor Kimi (Moonshot) al pipeline multi-provider (CLI-first, endpoint Anthropic-compatible)

### DIFF
--- a/.pipeline/agent-models.json
+++ b/.pipeline/agent-models.json
@@ -168,6 +168,40 @@
       "permissions_mode": "bypassPermissions",
       "billing": "free"
     },
+    "kimi-moonshot": {
+      "launcher": "claude",
+      "model": "kimi-k2-6",
+      "spawn_args_template": [
+        "-p",
+        "{user_prompt}",
+        "--system-prompt-file",
+        "{system_file}",
+        "--output-format",
+        "stream-json",
+        "--verbose",
+        "--permission-mode",
+        "bypassPermissions"
+      ],
+      "output_parser": "anthropic-stream-json",
+      "quota_error_types": [
+        "rate_limit_exceeded",
+        "quota_exceeded",
+        "insufficient_quota"
+      ],
+      "resets_at_cap_max_days": 31,
+      "supports_tool_use": false,
+      "capabilities": [],
+      "prompt_caching": {
+        "supported": false
+      },
+      "credentials_env": [
+        "ANTHROPIC_AUTH_TOKEN"
+      ],
+      "permissions_mode": "bypassPermissions",
+      "auth_mode": "api_key",
+      "display_in_health": "live",
+      "billing": "free"
+    },
     "deterministic": {
       "launcher": "node",
       "model": "deterministic",
@@ -310,6 +344,10 @@
         {
           "provider": "cerebras",
           "model_override": "gpt-oss-120b"
+        },
+        {
+          "provider": "kimi-moonshot",
+          "model_override": "kimi-k2-6"
         }
       ]
     },
@@ -328,6 +366,10 @@
         {
           "provider": "cerebras",
           "model_override": "gpt-oss-120b"
+        },
+        {
+          "provider": "kimi-moonshot",
+          "model_override": "kimi-k2-6"
         }
       ]
     },

--- a/.pipeline/lib/__tests__/agent-models-validate.test.js
+++ b/.pipeline/lib/__tests__/agent-models-validate.test.js
@@ -1064,7 +1064,9 @@ test('#3220 + #3353 + #3501 · ALLOWED_MODELS_BY_LAUNCHER declara modelos por pr
   const models = validateMod.ALLOWED_MODELS_BY_LAUNCHER;
   assert.ok(models, 'ALLOWED_MODELS_BY_LAUNCHER debe exportarse');
   assert.ok(Object.isFrozen(models), 'top-level debe estar congelado');
-  assert.deepEqual([...models.claude].sort(), ['claude-haiku-4-5', 'claude-opus-4-7', 'claude-sonnet-4-6']);
+  // #4880 — `kimi-k2-6` se suma a la allowlist del launcher `claude` porque el
+  // provider `kimi-moonshot` reusa ese launcher (drop-in Anthropic-compat).
+  assert.deepEqual([...models.claude].sort(), ['claude-haiku-4-5', 'claude-opus-4-7', 'claude-sonnet-4-6', 'kimi-k2-6']);
   // #3799 — Sherlock baja su fallback Codex de gpt-5.4 → gpt-5.4-mini (sign-off Leo
   // 2026-06-02), por lo que gpt-5.4-mini se suma a la allowlist del launcher codex.
   assert.deepEqual([...models.codex].sort(), ['gpt-5.4', 'gpt-5.4-mini', 'gpt-5.5']);

--- a/.pipeline/lib/agent-launcher/provider-error-parser.js
+++ b/.pipeline/lib/agent-launcher/provider-error-parser.js
@@ -159,6 +159,10 @@ const KNOWN_PROVIDERS = Object.freeze(new Set([
     'gemini-google',
     'cerebras',
     'nvidia-nim',
+    // #4880 — Kimi (Moonshot), drop-in Anthropic-compatible. Provider conocido
+    // para que el parser NO falle cerrado al detectar su cuota (usa
+    // `_detectAnthropic` con la allowlist de kimi-moonshot).
+    'kimi-moonshot',
 ]));
 
 // Transports válidos.

--- a/.pipeline/lib/agent-launcher/providers/kimi-moonshot.js
+++ b/.pipeline/lib/agent-launcher/providers/kimi-moonshot.js
@@ -1,0 +1,97 @@
+// =============================================================================
+// providers/kimi-moonshot.js — Handler del provider Kimi (Moonshot) (#4880)
+//
+// Kimi se integra como DROP-IN de Claude Code: expone un endpoint
+// Anthropic-compatible (`https://api.moonshot.ai/anthropic`) y se invoca con el
+// MISMO launcher `claude` que Anthropic, apuntado a esa base URL vía
+// `ANTHROPIC_BASE_URL` (que inyecta `build-child-env.js`, scopeado a este
+// provider — SEC-2) y autenticado con `ANTHROPIC_AUTH_TOKEN` (el token de Kimi,
+// NUNCA la key real de Anthropic — SEC-1).
+//
+// Por eso este handler DELEGA en el handler de Anthropic todo lo que es
+// idéntico al drop-in:
+//   - detectLauncher  → misma detección multi-tier del binario Claude Code.
+//   - buildSpawn      → mismo objeto de spawn (los args son estilo Claude CLI).
+//   - parseTokensFromLog → mismo stream-json (`assistant`/`usage`).
+//
+// Lo ÚNICO propio es `detectQuotaExhausted`: el endpoint de Moonshot devuelve
+// errores con SU allowlist de tipos (`KNOWN_QUOTA_ERROR_TYPES_BY_PROVIDER
+// ['kimi-moonshot']`), distinta de la de Anthropic MAX. Reusa el mismo parser
+// estructural Anthropic-shaped (`_detectAnthropic`) porque el shape del error
+// es Anthropic-compatible, pero con el provider/allowlist de Kimi.
+// =============================================================================
+'use strict';
+
+const fs = require('node:fs');
+const anthropic = require('./anthropic');
+
+// -----------------------------------------------------------------------------
+// detectQuotaExhausted — igual que el de Anthropic pero con provider
+// 'kimi-moonshot' (su propia allowlist de quota_error_types). El shape del
+// error es Anthropic-compatible, así que reusamos `_detectAnthropic`.
+//
+// Contrato preservado: {matched, errorType, resetsAt, rawLine, evt} |
+// {matched:false}. Nunca lanza (try/catch por lectura y por línea — I5).
+// -----------------------------------------------------------------------------
+function detectQuotaExhausted(logPath, cfg, quotaExhaustedModule, fsImpl, parserModuleOverride) {
+    const _fs = fsImpl || fs;
+    if (!quotaExhaustedModule || typeof quotaExhaustedModule._detectAnthropic !== 'function') {
+        return { matched: false };
+    }
+    let raw = '';
+    try { raw = _fs.readFileSync(logPath, 'utf8'); } catch { return { matched: false }; }
+    if (!raw) return { matched: false };
+
+    const parser = parserModuleOverride || require('../provider-error-parser');
+    let verdict;
+    try {
+        verdict = parser.parseProviderError(raw, {
+            provider: 'kimi-moonshot',
+            transport: 'cli',
+            _quotaModule: quotaExhaustedModule,
+        });
+    } catch {
+        return { matched: false };
+    }
+
+    if (!verdict || verdict.errorClass !== 'quota_exhausted') {
+        return { matched: false };
+    }
+
+    // Recuperamos el evt completo + errorType byte-idéntico al detector legacy,
+    // usando la allowlist canónica de Kimi.
+    const allowlist = (quotaExhaustedModule.KNOWN_QUOTA_ERROR_TYPES_BY_PROVIDER || {})['kimi-moonshot']
+        || (cfg && cfg.error_types)
+        || [];
+    for (const line of raw.split('\n')) {
+        if (!line.startsWith('{')) continue;
+        let evt;
+        try { evt = JSON.parse(line); } catch { continue; }
+        const r = quotaExhaustedModule._detectAnthropic(evt, allowlist);
+        if (r && r.matched) {
+            return {
+                matched: true,
+                errorType: r.errorType,
+                resetsAt: evt.resets_at,
+                rawLine: line,
+                evt,
+            };
+        }
+    }
+
+    return { matched: false };
+}
+
+module.exports = {
+    name: 'kimi-moonshot',
+    // Drop-in: delega en Anthropic el launcher/spawn/token-parsing.
+    detectLauncher: anthropic.detectLauncher,
+    buildSpawn: anthropic.buildSpawn,
+    parseTokensFromLog: anthropic.parseTokensFromLog,
+    // Propio de Kimi: allowlist de quota distinta de Anthropic MAX.
+    detectQuotaExhausted,
+    // exports internos para tests (delegados al de Anthropic).
+    _detectLauncherFresh: anthropic._detectLauncherFresh,
+    _setLauncherForTesting: anthropic._setLauncherForTesting,
+    _resetLauncherCacheForTesting: anthropic._resetLauncherCacheForTesting,
+};

--- a/.pipeline/lib/agent-launcher/resolve-provider.js
+++ b/.pipeline/lib/agent-launcher/resolve-provider.js
@@ -35,6 +35,10 @@ const PROVIDER_HANDLERS = {
     // otros 3 free providers: error accionable hasta que #3198 entregue el
     // wrapper real, sin tokens consumidos, sin crash del pulpo.
     'nvidia-nim': require('./providers/nvidia-nim'),
+    // #4880 — Kimi (Moonshot), drop-in de Claude Code contra su endpoint
+    // Anthropic-compatible. El handler delega en el de Anthropic (mismo launcher
+    // `claude`, spawn y stream-json) y sólo aporta su propia detección de cuota.
+    'kimi-moonshot': require('./providers/kimi-moonshot'),
     'deterministic': require('./providers/deterministic'),
     // Groq fue descontinuado en #3353 (mayo 2026) por política de bloqueos
     // arbitrarios — el handler stub y la referencia se removieron del mapa.

--- a/.pipeline/lib/agent-models-validate.js
+++ b/.pipeline/lib/agent-models-validate.js
@@ -150,6 +150,12 @@ const ALLOWED_MODELS_BY_LAUNCHER = Object.freeze({
     // Era el primario de ~12 skills + el Commander → causa raíz de fragilidad.
     'claude-sonnet-4-6',
     'claude-haiku-4-5',
+    // #4880 — Kimi K2.6 (Moonshot). El provider `kimi-moonshot` reusa el
+    // launcher `claude` apuntado al endpoint Anthropic-compat de Moonshot
+    // (ANTHROPIC_BASE_URL), por lo que su `model` viaja por el mismo template
+    // que Anthropic y se valida contra ESTA allowlist. El id es el que acepta el
+    // endpoint Moonshot (spike #4871), no un modelo de Anthropic.
+    'kimi-k2-6',
   ]),
   codex: Object.freeze([
     // 2026-06-04 (sign-off Leo por voz) — Codex con cuenta ChatGPT (OAuth) solo
@@ -256,6 +262,13 @@ const ALLOWED_CREDENTIAL_ENV_VARS = Object.freeze([
   // convención `<PROVIDER>_API_KEY` (credencial explícita del provider, no var
   // del SO). Security aprobó el handler en el análisis del issue.
   'NVIDIA_NIM_API_KEY',
+  // #4880 SEC-1 — Kimi (Moonshot) se integra como drop-in de Claude Code contra
+  // su endpoint Anthropic-compatible (launcher `claude` + ANTHROPIC_BASE_URL).
+  // Autentica con su PROPIO token en `ANTHROPIC_AUTH_TOKEN` (var distinta de
+  // `ANTHROPIC_API_KEY`, la key OAuth/Max real de Anthropic) — así el child de
+  // Kimi nunca recibe la credencial de Anthropic. Termina en `_TOKEN`, respeta
+  // la convención de credencial explícita del provider.
+  'ANTHROPIC_AUTH_TOKEN',
   'GH_TOKEN',
   'GITHUB_TOKEN',
   'OLLAMA_HOST',

--- a/.pipeline/lib/build-child-env.js
+++ b/.pipeline/lib/build-child-env.js
@@ -159,6 +159,37 @@ const CREDENTIAL_SCOPES = Object.freeze({
 const SCOPES_ALWAYS_ON = Object.freeze(['telegram-hooks']);
 
 // -----------------------------------------------------------------------------
+// PROVIDER_STATIC_ENV — variables de entorno ESTÁTICAS por provider (#4880).
+//
+// A diferencia de las API keys (que vienen del env del pulpo hidratado desde
+// credentials.json), estas son CONSTANTES DE CÓDIGO: no derivan del issue, del
+// prompt, del título ni de ningún input de usuario. Se vuelcan al env del child
+// SOLO cuando el provider activo coincide con la clave del mapa.
+//
+// Caso `kimi-moonshot` (SEC-2, #4880): Kimi (Moonshot) se integra como drop-in
+// de Claude Code apuntando `ANTHROPIC_BASE_URL` a su endpoint Anthropic-compat.
+// Requisitos de seguridad que este diseño satisface:
+//   - La URL es una CONSTANTE HTTPS literal (no `NODE_TLS_REJECT_UNAUTHORIZED=0`,
+//     sin proxy, jamás derivada de input). Previene SSRF / redirección de
+//     tráfico Anthropic a un endpoint atacante.
+//   - Se inyecta SOLO en el child con `providerName === 'kimi-moonshot'`. NUNCA
+//     global en el pulpo ni en childs de anthropic/codex/otros → no envenena el
+//     tráfico Anthropic legítimo (que va a api.anthropic.com por default).
+//   - `ANTHROPIC_BASE_URL` no está en SYSTEM_ALLOWLIST ni en ningún scope, así
+//     que aunque el operador la exporte global NUNCA se propaga desde processEnv:
+//     el único origen posible es este mapa.
+//
+// **NO agregar entradas sin justificación de seguridad** — cada var estática es
+// una decisión de plataforma (igual criterio que SYSTEM_ALLOWLIST / SCOPES).
+const PROVIDER_STATIC_ENV = Object.freeze({
+    'kimi-moonshot': Object.freeze({
+        // Endpoint Anthropic-compatible de Moonshot (spike #4871). El launcher
+        // `claude` habla contra esta base URL en vez de api.anthropic.com.
+        ANTHROPIC_BASE_URL: 'https://api.moonshot.ai/anthropic',
+    }),
+});
+
+// -----------------------------------------------------------------------------
 // DEFAULT_REQUIRES_BY_SKILL — defaults usados cuando agent-models.json no
 // existe o el skill no declara `requires_credentials`. Se sobreescribe por el
 // archivo cuando #3072 (H1) lo entregue.
@@ -344,6 +375,19 @@ function buildChildEnv(opts = {}) {
         out[providerKeyVar] = processEnv[providerKeyVar];
     }
 
+    // 3.b Env estático por provider (#4880). Constantes de código scopeadas al
+    //     provider activo (ej. ANTHROPIC_BASE_URL → endpoint Kimi para
+    //     `kimi-moonshot`). Se vuelca DESPUÉS de la key del provider y ANTES de
+    //     los scopes/pipelineExtras. Nunca se toma de processEnv (SEC-2): el
+    //     único origen es PROVIDER_STATIC_ENV, así el operador no puede
+    //     envenenar el tráfico Anthropic legítimo con una var global.
+    const staticEnv = PROVIDER_STATIC_ENV[providerName];
+    if (staticEnv) {
+        for (const [k, v] of Object.entries(staticEnv)) {
+            out[k] = v;
+        }
+    }
+
     // 4. Scopes declarados por el skill (`requires_credentials`) o defaults
     //    hardcoded por skill (DEFAULT_REQUIRES_BY_SKILL) cuando el archivo no
     //    los declara.
@@ -437,6 +481,7 @@ module.exports = {
     // Constantes exportadas para inspección (tests + dashboard futuro).
     SYSTEM_ALLOWLIST,
     PROVIDER_DEFAULT_CREDENTIAL_ENV,
+    PROVIDER_STATIC_ENV,
     CREDENTIAL_SCOPES,
     SCOPES_ALWAYS_ON,
     DEFAULT_REQUIRES_BY_SKILL,

--- a/.pipeline/lib/credentials.js
+++ b/.pipeline/lib/credentials.js
@@ -48,6 +48,12 @@ const ENV_MAPPING = Object.freeze({
   // providers.groq.api_key se removió en #3353 — Groq descontinuado.
   'providers.cerebras.api_key':    'CEREBRAS_API_KEY',
   'providers.nvidia.api_key':      'NVIDIA_NIM_API_KEY',
+  // #4880 — Kimi (Moonshot). Drop-in de Claude Code contra el endpoint
+  // Anthropic-compat: autentica con su token en `ANTHROPIC_AUTH_TOKEN` (var
+  // distinta de `ANTHROPIC_API_KEY`, la OAuth/Max real). Fuente única en
+  // credentials.json; jamás por Telegram (SEC-5). El valor nunca se loguea (el
+  // loader sólo lista nombres de var).
+  'providers.moonshot.api_key':    'ANTHROPIC_AUTH_TOKEN',
 });
 
 // Mapeo legacy: telegram-config.json usa flat keys (no nested). Solo cubre las

--- a/.pipeline/lib/multi-provider/model-catalog.js
+++ b/.pipeline/lib/multi-provider/model-catalog.js
@@ -84,6 +84,20 @@ const CATALOG = Object.freeze({
             recommended_for: ['telegram-sherlock'],
         },
     ]),
+    // #4880 — Kimi (Moonshot), drop-in de Claude Code contra el endpoint
+    // Anthropic-compatible. Provider CLI-first para roles NO agénticos (po/review).
+    // Costo/ventana de contexto según spike #4871 (K2.6, pay-per-token barato).
+    'kimi-moonshot': Object.freeze([
+        {
+            id: 'kimi-k2-6',
+            label: 'Kimi K2.6 (Moonshot, Anthropic-compat)',
+            capabilities: ['chat', 'cache'],
+            cost_per_1m: { input: 0.60, output: 2.50 },
+            context_window: 256_000,
+            release_date: '2026-07',
+            recommended_for: ['po', 'review'],
+        },
+    ]),
     deterministic: Object.freeze([
         {
             id: 'deterministic',

--- a/.pipeline/lib/provider-quota.js
+++ b/.pipeline/lib/provider-quota.js
@@ -40,6 +40,13 @@ const PROVIDER_WINDOWS = Object.freeze({
     'gemini-google': { short: { win: 'Min', kind: 'short' }, long: { win: 'Día', kind: 'long' }, mode: 'gauge' },
     'cerebras':      { short: { win: 'Min', kind: 'short' }, long: { win: 'Día', kind: 'long' }, mode: 'gauge' },
     'nvidia-nim':    { short: { win: 'Min', kind: 'short' }, long: { win: 'Día', kind: 'long' }, mode: 'gauge' },
+    // #4880 — Kimi (Moonshot): auth por API-key metered (pay-per-token), NO el
+    // contador central OAuth/MAX de Anthropic. Se rinde en modo 'gauge' con
+    // medición LOCAL (recordSample), igual que los free — evita reusar la lógica
+    // de snapshot MAX (`snapshot_threshold_90`) que dispararía un falso
+    // "degradado". Sin muestra fresca cae a 'nodata' ("sin dato" explícito),
+    // nunca a un falso "sin cuota".
+    'kimi-moonshot': { short: { win: 'Min', kind: 'short' }, long: { win: 'Día', kind: 'long' }, mode: 'gauge' },
 });
 
 const DEFAULT_WINDOW = Object.freeze({
@@ -54,8 +61,14 @@ const DEFAULT_WINDOW = Object.freeze({
 //     se pierde. Medición fidedigna (feedback_quota-fidedigna-pagos-vs-free).
 //   - FREE (Gemini/Groq-Cerebras/NVIDIA): medición LOCAL flexible (recordSample,
 //     snapshot de disponible por headers/eventos). No requiere contador central.
+// NOTA: esta clasificación es por MODELO DE CONTABILIDAD de cuota, no por si el
+// provider cuesta dinero. #4880 — Kimi (Moonshot) es pay-per-token (cuesta),
+// pero su cuota se mide LOCALMENTE (metered api-key, sin contador central
+// OAuth/MAX), así que va en el bucket FREE de accounting: usa recordSample y
+// NO el débito atómico ni `snapshot_threshold_90` (que son propios de Anthropic
+// MAX y generarían un falso "degradado" — CA-9).
 const PAID_PROVIDERS = Object.freeze(['anthropic', 'openai-codex']);
-const FREE_PROVIDERS = Object.freeze(['gemini-google', 'cerebras', 'nvidia-nim']);
+const FREE_PROVIDERS = Object.freeze(['gemini-google', 'cerebras', 'nvidia-nim', 'kimi-moonshot']);
 
 function isPaidProvider(provider) {
     return PAID_PROVIDERS.includes(provider);

--- a/.pipeline/lib/providers-key-validator.js
+++ b/.pipeline/lib/providers-key-validator.js
@@ -29,6 +29,9 @@ const PROVIDER_REGEX = Object.freeze({
     google:    /^[A-Za-z0-9_-]{30,}$/,          // GEMINI_API_KEY (Google AI Studio, formato variable).
     cerebras:  /^csk-[A-Za-z0-9_-]{32,}$/,
     nvidia:    /^nvapi-[A-Za-z0-9_-]{32,}$/,
+    // #4880 — Kimi (Moonshot). Las keys de Moonshot usan prefijo `sk-` seguido de
+    // ~48 chars. Se guarda en `providers.moonshot.api_key` → ANTHROPIC_AUTH_TOKEN.
+    moonshot:  /^sk-[A-Za-z0-9_-]{32,}$/,
 });
 
 /**

--- a/.pipeline/lib/quota-exhausted.js
+++ b/.pipeline/lib/quota-exhausted.js
@@ -214,6 +214,16 @@ const KNOWN_QUOTA_ERROR_TYPES_BY_PROVIDER = Object.freeze({
         'quota_exceeded',
         'insufficient_quota',
     ]),
+    // #4880 — Kimi (Moonshot). Drop-in de Claude Code contra el endpoint
+    // Anthropic-compatible: el error viaja con shape Anthropic-like por el
+    // stream-json, pero con SU allowlist de tipos (api-key metered, NO el
+    // snapshot MAX de Anthropic). El handler `providers/kimi-moonshot.js` la usa
+    // vía `_detectAnthropic` con `provider: 'kimi-moonshot'`.
+    'kimi-moonshot': Object.freeze([
+        'rate_limit_exceeded',
+        'quota_exceeded',
+        'insufficient_quota',
+    ]),
 });
 
 // -----------------------------------------------------------------------------

--- a/.pipeline/tests/dashboard/wizard-providers-flow.test.js
+++ b/.pipeline/tests/dashboard/wizard-providers-flow.test.js
@@ -49,7 +49,10 @@ function newSession() { return { steps: new Map() }; }
 
 test('listProviders deriva los providers de ENV_MAPPING (sin hardcoding)', () => {
     const names = providers.listProviders().map((p) => p.name);
-    assert.deepEqual([...names].sort(), ['anthropic', 'cerebras', 'google', 'nvidia', 'openai']);
+    // #4880 — 'moonshot' (Kimi) se suma al derivar la lista de ENV_MAPPING
+    // (providers.moonshot.api_key → ANTHROPIC_AUTH_TOKEN). El operador carga su
+    // token por este wizard, fuente única credentials.json.
+    assert.deepEqual([...names].sort(), ['anthropic', 'cerebras', 'google', 'moonshot', 'nvidia', 'openai']);
 });
 
 test('validateStep rechaza providers fuera de la allowlist (R#4 path-traversal)', () => {

--- a/.pipeline/tests/dashboard/wizard-providers-regex.test.js
+++ b/.pipeline/tests/dashboard/wizard-providers-regex.test.js
@@ -19,6 +19,8 @@ const VALID = {
     google:    'C'.repeat(39),
     cerebras:  'csk-' + 'D'.repeat(40),
     nvidia:    'nvapi-' + 'E'.repeat(40),
+    // #4880 — Kimi (Moonshot): prefijo `sk-` + ≥32 chars.
+    moonshot:  'sk-' + 'F'.repeat(48),
 };
 
 // ≥2 inválidos por provider (prefijo errado / muy corta).
@@ -28,6 +30,8 @@ const INVALID = {
     google:    ['short', 'has space here aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', null],
     cerebras:  ['sk-' + 'D'.repeat(40), 'csk-short', undefined],
     nvidia:    ['nv-' + 'E'.repeat(40), 'nvapi-short', {}],
+    // #4880 — prefijo errado / muy corta / no-string.
+    moonshot:  ['nope-' + 'F'.repeat(48), 'sk-short', 42],
 };
 
 test('cada provider de PROVIDER_REGEX tiene válido + inválidos definidos', () => {

--- a/.pipeline/tests/kimi-provider-4880.test.js
+++ b/.pipeline/tests/kimi-provider-4880.test.js
@@ -1,0 +1,206 @@
+// =============================================================================
+// kimi-provider-4880.test.js — Integración de Kimi (Moonshot) como provider
+// CLI-first drop-in de Claude Code (#4880).
+//
+// Cubre los CA verificables como código del issue:
+//   - CA-1 : entry providers.kimi-moonshot bien formada (launcher/parser/auth).
+//   - CA-2 : el config con Kimi valida fail-closed (validate + validate-chains).
+//   - CA-3 : capabilities:[] excluye a Kimi de roles agénticos (fail-closed).
+//   - CA-4 : Kimi sólo en fallbacks de roles no-agénticos (po/review).
+//   - CA-5 : SEC-1 — el child de Kimi NUNCA recibe la ANTHROPIC_API_KEY real.
+//   - CA-7 : SEC-2 — ANTHROPIC_BASE_URL sólo en el child de Kimi, constante de
+//            código, jamás propagada desde processEnv ni a otros providers.
+//   - CA-10: credencial en la fuente única mapeada a ANTHROPIC_AUTH_TOKEN.
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const { buildChildEnv, PROVIDER_STATIC_ENV } = require('../lib/build-child-env');
+const amv = require('../lib/agent-models-validate');
+const vc = require('../lib/multi-provider/validate-chains');
+const cred = require('../lib/credentials');
+const modelCatalog = require('../lib/multi-provider/model-catalog');
+const providerQuota = require('../lib/provider-quota');
+
+const CONFIG = require('../agent-models.json');
+const KIMI = 'kimi-moonshot';
+const KIMI_MODEL = 'kimi-k2-6';
+const KIMI_BASE_URL = 'https://api.moonshot.ai/anthropic';
+
+// Env "worst case": el operador tiene la key REAL de Anthropic, el token de
+// Kimi, y hasta una ANTHROPIC_BASE_URL global maliciosa. Ninguna debe filtrarse
+// donde no corresponde.
+function operatorEnv(extra = {}) {
+    return {
+        PATH: '/usr/bin:/bin',
+        ANTHROPIC_API_KEY: 'sk-ant-REAL-anthropic-oauth-token-NO-LEAK',
+        ANTHROPIC_AUTH_TOKEN: 'kimi-moonshot-token-value',
+        ANTHROPIC_BASE_URL: 'https://evil.attacker.example/poison',
+        OPENAI_API_KEY: 'openai-NO-LEAK',
+        CEREBRAS_API_KEY: 'cerebras-key',
+        TELEGRAM_BOT_TOKEN: 'tg-bot',
+        TELEGRAM_CHAT_ID: 'tg-chat',
+        ...extra,
+    };
+}
+
+function kimiChildEnv(env) {
+    // Full override: forzamos el provider del skill a kimi-moonshot preservando
+    // el bloque real de providers (para resolver credentials_env/auth_mode).
+    return buildChildEnv({
+        skill: 'review',
+        processEnv: env,
+        skillConfigOverride: {
+            skill: { provider: KIMI },
+            providers: CONFIG.providers,
+        },
+    });
+}
+
+// -----------------------------------------------------------------------------
+// CA-1 — Entry bien formada.
+// -----------------------------------------------------------------------------
+test('CA-1 · providers.kimi-moonshot declara launcher/parser/auth esperados', () => {
+    const p = CONFIG.providers[KIMI];
+    assert.ok(p, 'debe existir la entry kimi-moonshot');
+    assert.equal(p.launcher, 'claude', 'reusa el launcher claude (drop-in)');
+    assert.equal(p.output_parser, 'anthropic-stream-json', 'reusa el parser Anthropic');
+    assert.equal(p.auth_mode, 'api_key', 'auth por api-key, NO oauth');
+    assert.equal(p.supports_tool_use, false, 'no agéntico');
+    assert.deepEqual(p.capabilities, [], 'capabilities vacío → excluido de agénticos');
+    assert.deepEqual(p.credentials_env, ['ANTHROPIC_AUTH_TOKEN'], 'token propio, no la key Anthropic');
+    assert.equal(p.model, KIMI_MODEL);
+});
+
+// -----------------------------------------------------------------------------
+// CA-2 — El config con Kimi valida fail-closed (no rompe nada).
+// -----------------------------------------------------------------------------
+test('CA-2 · agent-models.json valida OK con Kimi (validate + validate-chains)', () => {
+    const r = amv.validate(path.join(__dirname, '..', 'agent-models.json'));
+    assert.equal(r.ok, true, `validate debe pasar; errores: ${JSON.stringify(r.errors)}`);
+
+    const chains = vc.validateChains(CONFIG);
+    assert.equal(chains.ok, true, `validate-chains debe pasar; errores: ${JSON.stringify(chains.errors)}`);
+});
+
+test('CA-2b · ANTHROPIC_AUTH_TOKEN y kimi-k2-6 están en las allowlists', () => {
+    assert.ok(
+        amv.ALLOWED_CREDENTIAL_ENV_VARS.includes('ANTHROPIC_AUTH_TOKEN'),
+        'ANTHROPIC_AUTH_TOKEN debe estar en ALLOWED_CREDENTIAL_ENV_VARS',
+    );
+    assert.ok(
+        amv.ALLOWED_MODELS_BY_LAUNCHER.claude.includes(KIMI_MODEL),
+        'kimi-k2-6 debe estar en ALLOWED_MODELS_BY_LAUNCHER.claude',
+    );
+});
+
+// -----------------------------------------------------------------------------
+// CA-3 — capabilities:[] excluye a Kimi de roles agénticos (fail-closed).
+// -----------------------------------------------------------------------------
+test('CA-3 · Kimi como fallback de un rol agéntico es rechazado fail-closed', () => {
+    const bad = JSON.parse(JSON.stringify(CONFIG));
+    bad.skills['pipeline-dev'].fallbacks.push({ provider: KIMI, model_override: KIMI_MODEL });
+    const errs = amv.validateExecutionCapabilities(bad);
+    assert.ok(errs.length >= 1, 'debe emitir error de capability');
+    assert.ok(
+        errs.some(e => e.message.includes(KIMI) && e.message.includes('agentic-tool-use')),
+        `el error debe mencionar a kimi y la capability faltante: ${JSON.stringify(errs)}`,
+    );
+});
+
+test('CA-3b · el config real NO ubica a Kimi en ningún rol con required_capabilities', () => {
+    const errs = amv.validateExecutionCapabilities(CONFIG);
+    assert.equal(errs.length, 0, `no debe haber violaciones de capability: ${JSON.stringify(errs)}`);
+});
+
+// -----------------------------------------------------------------------------
+// CA-4 — Kimi sólo en fallbacks de roles no-agénticos (po/review).
+// -----------------------------------------------------------------------------
+test('CA-4 · Kimi aparece sólo en fallbacks de roles sin required_capabilities', () => {
+    for (const [skillName, skillDef] of Object.entries(CONFIG.skills)) {
+        const fbs = Array.isArray(skillDef.fallbacks) ? skillDef.fallbacks : [];
+        const hasKimi = fbs.some(f => (typeof f === 'string' ? f : f && f.provider) === KIMI);
+        if (hasKimi) {
+            assert.ok(
+                !Array.isArray(skillDef.required_capabilities) || skillDef.required_capabilities.length === 0,
+                `Kimi no debe estar en el rol agéntico "${skillName}"`,
+            );
+        }
+    }
+    // Y debe estar presente al menos en po y review (roles no-agénticos objetivo).
+    for (const role of ['po', 'review']) {
+        const fbs = CONFIG.skills[role].fallbacks || [];
+        assert.ok(
+            fbs.some(f => (typeof f === 'string' ? f : f.provider) === KIMI),
+            `Kimi debe estar en el fallback de "${role}"`,
+        );
+    }
+});
+
+// -----------------------------------------------------------------------------
+// CA-5 — SEC-1: el child de Kimi NUNCA recibe la ANTHROPIC_API_KEY real.
+// -----------------------------------------------------------------------------
+test('CA-5 · child Kimi recibe su token y NUNCA la ANTHROPIC_API_KEY real (SEC-1)', () => {
+    const env = kimiChildEnv(operatorEnv());
+    assert.equal(env.ANTHROPIC_AUTH_TOKEN, 'kimi-moonshot-token-value', 'recibe su propio token');
+    assert.equal(env.ANTHROPIC_API_KEY, undefined, 'NUNCA la key real de Anthropic');
+    assert.equal(env.OPENAI_API_KEY, undefined, 'ni la de otro provider');
+    assert.equal(env.CEREBRAS_API_KEY, undefined, 'ni la de otro provider');
+});
+
+// -----------------------------------------------------------------------------
+// CA-7 — SEC-2: ANTHROPIC_BASE_URL scopeada, constante, no propagada.
+// -----------------------------------------------------------------------------
+test('CA-7 · ANTHROPIC_BASE_URL es constante de código sólo en el child Kimi (SEC-2)', () => {
+    const env = kimiChildEnv(operatorEnv());
+    assert.equal(env.ANTHROPIC_BASE_URL, KIMI_BASE_URL, 'usa la constante de código, no la global maliciosa');
+    assert.notEqual(env.ANTHROPIC_BASE_URL, 'https://evil.attacker.example/poison');
+});
+
+test('CA-7b · childs de otros providers NO reciben ANTHROPIC_BASE_URL', () => {
+    for (const provider of ['anthropic', 'openai-codex', 'cerebras']) {
+        const env = buildChildEnv({
+            skill: 'review',
+            processEnv: operatorEnv(),
+            skillConfigOverride: { skill: { provider }, providers: CONFIG.providers },
+        });
+        assert.equal(
+            env.ANTHROPIC_BASE_URL, undefined,
+            `el child de ${provider} NO debe recibir ANTHROPIC_BASE_URL (aunque esté global en el env)`,
+        );
+    }
+});
+
+test('CA-7c · PROVIDER_STATIC_ENV expone kimi-moonshot con URL HTTPS literal', () => {
+    const staticEnv = PROVIDER_STATIC_ENV[KIMI];
+    assert.ok(staticEnv, 'debe existir el mapa estático de kimi-moonshot');
+    assert.equal(staticEnv.ANTHROPIC_BASE_URL, KIMI_BASE_URL);
+    assert.ok(staticEnv.ANTHROPIC_BASE_URL.startsWith('https://'), 'debe ser HTTPS (anti-SSRF)');
+    // No hay flags de bypass TLS ni proxy en el mapa estático.
+    assert.equal(staticEnv.NODE_TLS_REJECT_UNAUTHORIZED, undefined);
+});
+
+// -----------------------------------------------------------------------------
+// CA-10 — Credencial en la fuente única, mapeada a ANTHROPIC_AUTH_TOKEN.
+// -----------------------------------------------------------------------------
+test('CA-10 · credentials.js mapea providers.moonshot.api_key → ANTHROPIC_AUTH_TOKEN', () => {
+    assert.equal(cred.ENV_MAPPING['providers.moonshot.api_key'], 'ANTHROPIC_AUTH_TOKEN');
+});
+
+// -----------------------------------------------------------------------------
+// Catálogo y clasificación de cuota (CA-9 — sin snapshot MAX).
+// -----------------------------------------------------------------------------
+test('CA-9 · Kimi se clasifica con medición local (no PAID/snapshot MAX)', () => {
+    assert.equal(providerQuota.isPaidProvider(KIMI), false, 'NO usa el contador central PAID/snapshot MAX');
+    assert.equal(providerQuota.isFreeProvider(KIMI), true, 'medición local estilo FREE');
+});
+
+test('CA-9b · model-catalog expone kimi-k2-6 con ventana de contexto y costo', () => {
+    const m = modelCatalog.getModel(KIMI_MODEL);
+    assert.ok(m, 'kimi-k2-6 debe estar en el catálogo');
+    assert.ok(m.context_window > 0, 'ventana de contexto declarada');
+    assert.ok(m.cost_per_1m && typeof m.cost_per_1m.input === 'number', 'costo declarado (no-bloqueante)');
+});


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 15 archivos · +469 -3

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:skipped` aplicado por delivery

## Closes

Closes #4880
