### PR TITLE
[auto] Corregir cuota Codex entre sesiones concurrentes (Closes #4885)

### DIFF
--- a/.pipeline/lib/__tests__/dashboard-slices-kpis.test.js
+++ b/.pipeline/lib/__tests__/dashboard-slices-kpis.test.js
@@ -281,18 +281,19 @@ test('CA-5: quotaSlice expone `providers` con anthropic + stubs not_implemented'
             deterministic: {}, // debe filtrarse
         },
     }));
-    // #4598 — el adapter Codex lee `~/.codex/logs_2.sqlite`. Para hacer el test
-    // determinista (no dependa del estado real de la máquina/CI), apuntamos el
-    // log a un path inexistente → el adapter degrada a `no_usage_data`.
-    const prevLogEnv = process.env.CODEX_QUOTA_LOG_PATH;
-    process.env.CODEX_QUOTA_LOG_PATH = path.join(root, 'no-existe-codex.sqlite');
+    // #4885 — el adapter Codex lee los rollouts JSONL de `~/.codex/sessions`.
+    // Para hacer el test determinista (no dependa del estado real de la
+    // máquina/CI), apuntamos el dir a un path inexistente → el adapter degrada a
+    // `no_usage_data`.
+    const prevSessionsEnv = process.env.CODEX_SESSIONS_DIR;
+    process.env.CODEX_SESSIONS_DIR = path.join(root, 'no-existe-codex-sessions');
     const slices = freshSlices();
     let out;
     try {
         out = slices.quotaSlice({}, { ROOT: root, PIPELINE: pipeline });
     } finally {
-        if (prevLogEnv === undefined) delete process.env.CODEX_QUOTA_LOG_PATH;
-        else process.env.CODEX_QUOTA_LOG_PATH = prevLogEnv;
+        if (prevSessionsEnv === undefined) delete process.env.CODEX_SESSIONS_DIR;
+        else process.env.CODEX_SESSIONS_DIR = prevSessionsEnv;
     }
 
     assert.ok(out.providers, 'debe exponer `providers`');

--- a/.pipeline/lib/__tests__/quota-adapters/openai-codex.test.js
+++ b/.pipeline/lib/__tests__/quota-adapters/openai-codex.test.js
@@ -1,20 +1,25 @@
 // =============================================================================
-// Tests quota-adapters/openai-codex.js — adapter real desde el log de Codex (#4598)
+// Tests quota-adapters/openai-codex.js — adapter real desde los rollouts JSONL
+// de Codex >= v0.145.0 (#4885, evolución de #4868/#4865).
 //
 // Cubre:
 //
-//   * Parse tolerante del `feedback_log_body` (prefijo "Received message {...}").
-//   * Mapeo primary(5h)→sesión / secondary(7d)→semanal con used_percent + reset.
+//   * Extracción del objeto `payload.rate_limits` desde una línea JSONL.
+//   * Mapeo por `window_minutes` (5h→sesión / 7d→semanal), NO por posición
+//     primary/secondary — en v0.145.0 el semanal viene en `primary`.
+//   * Rename `reset_at` → `resets_at`.
 //   * Frescura (CA-3): evento viejo → degradado (`unknown`, pct null), NO stale.
-//   * Sin evento legible → `no_usage_data`, pct null (NO 0% — security CA-#3).
-//   * Body corrupto / shape inesperado → `error`, pct null.
-//   * Invariante offline (security CA-#6): cero HTTP en el fuente del adapter.
+//   * Sin rollout legible → `no_usage_data`, pct null (NO 0% — security CA-#3).
+//   * Shape inesperado → `error`, pct null.
+//   * Selección del rollout más nuevo entre archivos por fecha.
+//   * Invariante offline (security CA-#6): cero HTTP y cero proceso externo.
 // =============================================================================
 'use strict';
 
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 
 function freshAdapter() {
@@ -23,66 +28,101 @@ function freshAdapter() {
     return require('../../quota-adapters/openai-codex');
 }
 
-// Body real observado en `~/.codex/logs_2.sqlite` (#4598), con prefijo.
-function makeBody({ primaryPct = 44, secondaryPct = 68, primaryReset = 1783552546, secondaryReset = 1784002587 } = {}) {
-    return 'Received message ' + JSON.stringify({
-        type: 'codex.rate_limits',
+// Objeto `rate_limits` como lo persiste Codex v0.145.0. En v0.145.0 el semanal
+// viene en `primary` (window 10080) con `secondary: null`, pero el adapter debe
+// clasificar por ventana, así que los tests usan ambas variantes.
+function makeRateLimits({
+    sessionPct = 44, weeklyPct = 68,
+    sessionReset = 1783552546, weeklyReset = 1784002587,
+    includeSession = true, includeWeekly = true,
+} = {}) {
+    const primary = includeWeekly
+        ? { used_percent: weeklyPct, window_minutes: 10080, resets_at: weeklyReset }
+        : null;
+    const secondary = includeSession
+        ? { used_percent: sessionPct, window_minutes: 300, resets_at: sessionReset }
+        : null;
+    return {
+        limit_id: 'codex',
+        limit_name: null,
+        primary,
+        secondary,
+        credits: { has_credits: false, unlimited: false, balance: '0' },
         plan_type: 'plus',
-        rate_limits: {
-            allowed: true,
-            limit_reached: false,
-            primary: { used_percent: primaryPct, window_minutes: 300, reset_after_seconds: 7546, reset_at: primaryReset },
-            secondary: { used_percent: secondaryPct, window_minutes: 10080, reset_after_seconds: 457587, reset_at: secondaryReset },
-        },
-        code_review_rate_limits: null,
+    };
+}
+
+// Línea JSONL real (event_msg / token_count) que envuelve el rate_limits.
+function makeLine(rateLimits, timestamp) {
+    return JSON.stringify({
+        timestamp,
+        type: 'event_msg',
+        payload: { type: 'token_count', info: {}, rate_limits: rateLimits },
     });
 }
 
-// Inyector de `readLatestEvent` para no tocar el SQLite real.
+// Inyector de `readLatestEvent`: devuelve el evento ya extraído.
 function fakeReader(event) {
     return () => event;
 }
 
-// ts real observado (1783545001). Usamos un `now` justo después → fresco.
-const EVENT_TS = 1783545001;
-const NOW_FRESH = (EVENT_TS + 60) * 1000; // 1 min después.
+const EVENT_TS_ISO = '2026-07-23T19:38:32.183Z';
+const EVENT_TS_MS = Date.parse(EVENT_TS_ISO);
+const NOW_FRESH = EVENT_TS_MS + 60 * 1000; // 1 min después.
 
-test('codex mapea primary(5h)->sesion y secondary(7d)->semanal con el % real', () => {
+test('codex mapea por window_minutes: 5h->sesion, 7d->semanal, con el % real', () => {
     const adapter = freshAdapter();
     const r = adapter({
         now: NOW_FRESH,
-        readEventImpl: fakeReader({ ts: EVENT_TS, body: makeBody({ primaryPct: 44, secondaryPct: 68 }) }),
+        readEventImpl: fakeReader({
+            tsMs: EVENT_TS_MS,
+            rateLimits: makeRateLimits({ sessionPct: 44, weeklyPct: 68 }),
+        }),
     });
     assert.equal(r.adapterStatus, 'ok');
-    // secondary (semanal) → top-level.
+    // semanal (window 10080) → top-level.
     assert.equal(r.pct, 68);
     assert.equal(r.status, 'normal'); // 68% → 50..75
-    // primary (5h) → sesión.
+    // sesión (window 300) → session.
     assert.equal(r.session.pct, 44);
     assert.equal(r.session.status, 'ok'); // 44% < 50
-    // Resets propagados como ISO.
+    // Resets (resets_at) propagados como ISO.
     assert.equal(r.nextResetAt, new Date(1784002587 * 1000).toISOString());
     assert.equal(r.weeklyResetsAtReported, new Date(1784002587 * 1000).toISOString());
     assert.equal(r.sessionResetsAt, new Date(1783552546 * 1000).toISOString());
+});
+
+test('codex clasifica por ventana aunque el semanal venga en primary (v0.145.0)', () => {
+    const adapter = freshAdapter();
+    // Caso real v0.145.0: primary=semanal (10080), secondary=null.
+    const rateLimits = makeRateLimits({ weeklyPct: 73, includeSession: false });
+    const r = adapter({ now: NOW_FRESH, readEventImpl: fakeReader({ tsMs: EVENT_TS_MS, rateLimits }) });
+    assert.equal(r.adapterStatus, 'ok');
+    assert.equal(r.pct, 73, 'primary con window 10080 se mapea a semanal, no a sesión');
+    assert.equal(r.status, 'normal');
+    assert.equal(r.session.pct, null, 'sin ventana de sesión → session sin dato');
 });
 
 test('codex: status refleja los cortes del pipeline (critical >=90 en la ventana correcta)', () => {
     const adapter = freshAdapter();
     const r = adapter({
         now: NOW_FRESH,
-        readEventImpl: fakeReader({ ts: EVENT_TS, body: makeBody({ primaryPct: 95, secondaryPct: 30 }) }),
+        readEventImpl: fakeReader({
+            tsMs: EVENT_TS_MS,
+            rateLimits: makeRateLimits({ sessionPct: 95, weeklyPct: 30 }),
+        }),
     });
     assert.equal(r.adapterStatus, 'ok');
-    assert.equal(r.status, 'ok', 'semanal (secondary) 30% → ok');
-    assert.equal(r.session.status, 'critical', 'sesión (primary) 95% → critical');
+    assert.equal(r.status, 'ok', 'semanal 30% → ok');
+    assert.equal(r.session.status, 'critical', 'sesión 95% → critical');
 });
 
 test('codex: evento stale -> degradado (unknown, pct null), NO muestra el % viejo (CA-3)', () => {
     const adapter = freshAdapter();
-    const now = (EVENT_TS + 3 * 60 * 60) * 1000; // 3h después, umbral default 1h.
+    const now = EVENT_TS_MS + 3 * 60 * 60 * 1000; // 3h después, umbral default 1h.
     const r = adapter({
         now,
-        readEventImpl: fakeReader({ ts: EVENT_TS, body: makeBody() }),
+        readEventImpl: fakeReader({ tsMs: EVENT_TS_MS, rateLimits: makeRateLimits() }),
     });
     assert.equal(r.adapterStatus, 'unknown', 'dato viejo → unknown, no ok');
     assert.equal(r.pct, null, 'NUNCA mostrar el % stale como actual');
@@ -92,18 +132,52 @@ test('codex: evento stale -> degradado (unknown, pct null), NO muestra el % viej
 
 test('codex: umbral de frescura configurable por sessionData.stalenessMs', () => {
     const adapter = freshAdapter();
-    const now = (EVENT_TS + 120) * 1000; // 2 min después.
-    // Con umbral de 1 min, 2 min es stale.
+    const now = EVENT_TS_MS + 120 * 1000; // 2 min después.
     const r = adapter({
         now,
-        stalenessMs: 60 * 1000,
-        readEventImpl: fakeReader({ ts: EVENT_TS, body: makeBody() }),
+        stalenessMs: 60 * 1000, // con umbral de 1 min, 2 min es stale.
+        readEventImpl: fakeReader({ tsMs: EVENT_TS_MS, rateLimits: makeRateLimits() }),
     });
     assert.equal(r.adapterStatus, 'unknown');
     assert.equal(r.pct, null);
 });
 
-test('codex: sin evento legible -> no_usage_data (pct null, NO 0%)', () => {
+test('codex: evento sin timestamp -> degradado (unknown), no se garantiza frescura', () => {
+    const adapter = freshAdapter();
+    const r = adapter({
+        now: NOW_FRESH,
+        readEventImpl: fakeReader({ tsMs: null, rateLimits: makeRateLimits() }),
+    });
+    assert.equal(r.adapterStatus, 'unknown');
+    assert.equal(r.pct, null);
+});
+
+test('codex: evento fechado en el futuro -> degradado (clock skew, no se da por fresco)', () => {
+    const adapter = freshAdapter();
+    // Evento 3 meses adelante del `now`: edad negativa. Sin guard pasaría el
+    // chequeo de staleness y se mostraría como fresco un dato no confiable.
+    const now = EVENT_TS_MS - 90 * 24 * 60 * 60 * 1000;
+    const r = adapter({
+        now,
+        readEventImpl: fakeReader({ tsMs: EVENT_TS_MS, rateLimits: makeRateLimits() }),
+    });
+    assert.equal(r.adapterStatus, 'unknown');
+    assert.equal(r.pct, null);
+    assert.match(r.errorReason, /futuro|skew/i);
+});
+
+test('codex: tolera un skew chico hacia el futuro (reloj levemente adelantado)', () => {
+    const adapter = freshAdapter();
+    const now = EVENT_TS_MS - 60 * 1000; // evento 1 min en el futuro.
+    const r = adapter({
+        now,
+        readEventImpl: fakeReader({ tsMs: EVENT_TS_MS, rateLimits: makeRateLimits({ weeklyPct: 50 }) }),
+    });
+    assert.equal(r.adapterStatus, 'ok', 'skew menor a la tolerancia sigue siendo válido');
+    assert.equal(r.pct, 50);
+});
+
+test('codex: sin rollout legible -> no_usage_data (pct null, NO 0%)', () => {
     const adapter = freshAdapter();
     const r = adapter({ now: NOW_FRESH, readEventImpl: fakeReader(null) });
     assert.equal(r.adapterStatus, 'no_usage_data');
@@ -113,71 +187,50 @@ test('codex: sin evento legible -> no_usage_data (pct null, NO 0%)', () => {
     assert.equal(r.session.pct, null);
 });
 
-test('codex: body corrupto -> error (pct null)', () => {
+test('codex: rate_limits sin used_percent valido -> error', () => {
     const adapter = freshAdapter();
-    const r = adapter({
-        now: NOW_FRESH,
-        readEventImpl: fakeReader({ ts: EVENT_TS, body: 'Received message {no-json' }),
-    });
+    const rateLimits = { primary: {}, secondary: {} };
+    const r = adapter({ now: NOW_FRESH, readEventImpl: fakeReader({ tsMs: EVENT_TS_MS, rateLimits }) });
     assert.equal(r.adapterStatus, 'error');
     assert.equal(r.pct, null);
 });
 
-test('codex: evento sin used_percent valido -> error', () => {
+test('codex: solo semanal legible -> semanal poblado, sesion sin dato', () => {
     const adapter = freshAdapter();
-    const body = 'Received message ' + JSON.stringify({
-        type: 'codex.rate_limits',
-        rate_limits: { primary: {}, secondary: {} },
-    });
-    const r = adapter({ now: NOW_FRESH, readEventImpl: fakeReader({ ts: EVENT_TS, body }) });
-    assert.equal(r.adapterStatus, 'error');
-    assert.equal(r.pct, null);
-});
-
-test('codex: parseRateLimits es tolerante al prefijo y valida el type', () => {
-    const adapter = freshAdapter();
-    const rl = adapter.parseRateLimits(makeBody({ primaryPct: 10, secondaryPct: 20 }));
-    assert.ok(rl);
-    assert.equal(rl.primary.used_percent, 10);
-    assert.equal(rl.secondary.used_percent, 20);
-    // No es un evento rate_limits → null.
-    assert.equal(adapter.parseRateLimits('Received message {"type":"otra.cosa"}'), null);
-    // Sin JSON → null.
-    assert.equal(adapter.parseRateLimits('no hay json aca'), null);
-    assert.equal(adapter.parseRateLimits(''), null);
-    assert.equal(adapter.parseRateLimits(null), null);
-});
-
-test('codex: solo secondary legible -> semanal poblado, sesion sin dato', () => {
-    const adapter = freshAdapter();
-    const body = 'Received message ' + JSON.stringify({
-        type: 'codex.rate_limits',
-        rate_limits: { secondary: { used_percent: 55, reset_at: 1784002587 } },
-    });
-    const r = adapter({ now: NOW_FRESH, readEventImpl: fakeReader({ ts: EVENT_TS, body }) });
+    const rateLimits = { primary: { used_percent: 55, window_minutes: 10080, resets_at: 1784002587 } };
+    const r = adapter({ now: NOW_FRESH, readEventImpl: fakeReader({ tsMs: EVENT_TS_MS, rateLimits }) });
     assert.equal(r.adapterStatus, 'ok');
     assert.equal(r.pct, 55);
     assert.equal(r.session.pct, null);
 });
 
-test('codex: solo primary legible -> sesion poblada, semanal sin dato (status unknown)', () => {
+test('codex: solo sesion legible -> sesion poblada, semanal sin dato (status unknown)', () => {
     const adapter = freshAdapter();
-    const body = 'Received message ' + JSON.stringify({
-        type: 'codex.rate_limits',
-        rate_limits: { primary: { used_percent: 33, reset_at: 1783552546 } },
-    });
-    const r = adapter({ now: NOW_FRESH, readEventImpl: fakeReader({ ts: EVENT_TS, body }) });
+    const rateLimits = { primary: { used_percent: 33, window_minutes: 300, resets_at: 1783552546 } };
+    const r = adapter({ now: NOW_FRESH, readEventImpl: fakeReader({ tsMs: EVENT_TS_MS, rateLimits }) });
     assert.equal(r.adapterStatus, 'ok');
     assert.equal(r.pct, null, 'sin semanal → null, no fabricamos %');
     assert.equal(r.status, 'unknown');
     assert.equal(r.session.pct, 33);
 });
 
+test('codex: bucket sin window_minutes se trata como sesion (no fabrica semanal falso)', () => {
+    const adapter = freshAdapter();
+    const rateLimits = { primary: { used_percent: 40, resets_at: 1783552546 } };
+    const r = adapter({ now: NOW_FRESH, readEventImpl: fakeReader({ tsMs: EVENT_TS_MS, rateLimits }) });
+    assert.equal(r.adapterStatus, 'ok');
+    assert.equal(r.pct, null, 'ventana desconocida no alimenta el semanal/gating');
+    assert.equal(r.session.pct, 40);
+});
+
 test('codex: used_percent > 100 se capea a 100', () => {
     const adapter = freshAdapter();
     const r = adapter({
         now: NOW_FRESH,
-        readEventImpl: fakeReader({ ts: EVENT_TS, body: makeBody({ primaryPct: 150, secondaryPct: 120 }) }),
+        readEventImpl: fakeReader({
+            tsMs: EVENT_TS_MS,
+            rateLimits: makeRateLimits({ sessionPct: 150, weeklyPct: 120 }),
+        }),
     });
     assert.equal(r.pct, 100);
     assert.equal(r.session.pct, 100);
@@ -203,17 +256,99 @@ test('codex: excepcion del reader -> degradado, no propaga (fail-secure)', () =>
     assert.equal(r.pct, null);
 });
 
+// --- Helpers puros -----------------------------------------------------------
+
+test('codex: extractLatestRateLimits toma el ULTIMO rate_limits del JSONL', () => {
+    const adapter = freshAdapter();
+    const rlOld = makeRateLimits({ weeklyPct: 10, includeSession: false });
+    const rlNew = makeRateLimits({ weeklyPct: 88, includeSession: false });
+    const content = [
+        makeLine(rlOld, '2026-07-23T18:00:00.000Z'),
+        JSON.stringify({ timestamp: '2026-07-23T18:30:00.000Z', type: 'response_item', payload: { type: 'message' } }),
+        makeLine(rlNew, EVENT_TS_ISO),
+    ].join('\n') + '\n';
+    const ev = adapter.extractLatestRateLimits(content);
+    assert.ok(ev);
+    assert.equal(ev.tsMs, EVENT_TS_MS);
+    assert.equal(ev.rateLimits.primary.used_percent, 88, 'toma el evento más nuevo, no el primero');
+});
+
+test('codex: extractLatestRateLimits tolera lineas parciales/corruptas', () => {
+    const adapter = freshAdapter();
+    const rl = makeRateLimits({ weeklyPct: 42, includeSession: false });
+    // Primera línea partida (como quedaría un corte de cola) + una válida.
+    const content = 'ts":"parcial","payload":{"rate_limits":{ roto\n' + makeLine(rl, EVENT_TS_ISO) + '\n';
+    const ev = adapter.extractLatestRateLimits(content);
+    assert.ok(ev);
+    assert.equal(ev.rateLimits.primary.used_percent, 42);
+});
+
+test('codex: extractLatestRateLimits devuelve null sin eventos de cuota', () => {
+    const adapter = freshAdapter();
+    const content = JSON.stringify({ timestamp: EVENT_TS_ISO, type: 'response_item', payload: { type: 'message' } }) + '\n';
+    assert.equal(adapter.extractLatestRateLimits(content), null);
+    assert.equal(adapter.extractLatestRateLimits(''), null);
+    assert.equal(adapter.extractLatestRateLimits(null), null);
+});
+
+test('codex: classifyBuckets mapea por window_minutes con umbral 1440', () => {
+    const adapter = freshAdapter();
+    const { session, weekly } = adapter.classifyBuckets({
+        primary: { used_percent: 5, window_minutes: 10080, resets_at: 100 },
+        secondary: { used_percent: 9, window_minutes: 300, resets_at: 200 },
+    });
+    assert.equal(weekly.usedPercent, 5);
+    assert.equal(session.usedPercent, 9);
+    assert.equal(adapter.WEEKLY_WINDOW_MIN_THRESHOLD, 1440);
+});
+
+// --- Lectura real de FS (integración liviana con archivos temporales) --------
+
+test('codex: readLatestEvent elige el rollout mas nuevo entre archivos de fecha', () => {
+    const adapter = freshAdapter();
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-rollout-'));
+    const dayDir = path.join(base, '2026', '07', '23');
+    fs.mkdirSync(dayDir, { recursive: true });
+    // Dos rollouts; el de nombre lexicográficamente mayor es el más nuevo.
+    fs.writeFileSync(
+        path.join(dayDir, 'rollout-2026-07-23T10-00-00-aaaa.jsonl'),
+        makeLine(makeRateLimits({ weeklyPct: 11, includeSession: false }), '2026-07-23T10:00:00.000Z') + '\n');
+    fs.writeFileSync(
+        path.join(dayDir, 'rollout-2026-07-23T16-38-03-bbbb.jsonl'),
+        makeLine(makeRateLimits({ weeklyPct: 77, includeSession: false }), EVENT_TS_ISO) + '\n');
+
+    const ev = adapter.readLatestEvent(base);
+    assert.ok(ev);
+    assert.equal(ev.rateLimits.primary.used_percent, 77, 'toma el rollout más nuevo');
+
+    // End-to-end vía el adapter público, apuntando al dir temporal.
+    const r = adapter({ now: EVENT_TS_MS + 60 * 1000, codexSessionsDir: base });
+    assert.equal(r.adapterStatus, 'ok');
+    assert.equal(r.pct, 77);
+
+    fs.rmSync(base, { recursive: true, force: true });
+});
+
+test('codex: readLatestEvent devuelve null si el dir no existe', () => {
+    const adapter = freshAdapter();
+    assert.equal(adapter.readLatestEvent(path.join(os.tmpdir(), 'no-existe-codex-xyz-4885')), null);
+});
+
+// --- Invariantes de seguridad ------------------------------------------------
+
 test('codex: invariante offline — cero HTTP en el fuente (security CA-#6)', () => {
     const src = fs.readFileSync(
         path.join(__dirname, '..', '..', 'quota-adapters', 'openai-codex.js'), 'utf8');
     assert.ok(!/\bfetch\b|\baxios\b|https?\.request|node-fetch/.test(src),
-        'el adapter NO debe hacer HTTP — todo offline desde el SQLite local');
+        'el adapter NO debe hacer HTTP — todo offline desde los rollouts locales');
 });
 
-test('codex: no agrega dependencia SQLite nativa — usa el CLI sqlite3', () => {
+test('codex: sin proceso externo ni dependencia nativa — solo lectura fs', () => {
     const src = fs.readFileSync(
         path.join(__dirname, '..', '..', 'quota-adapters', 'openai-codex.js'), 'utf8');
     assert.ok(!/require\(['"](better-sqlite3|sqlite3)['"]\)/.test(src),
-        'sin dependencia nativa: se lee vía execFileSync del binario sqlite3');
-    assert.ok(/execFileSync/.test(src), 'lee el SQLite con execFileSync(sqlite3)');
+        'sin dependencia SQLite nativa');
+    assert.ok(!/child_process|execFileSync|execSync|spawn/.test(src),
+        'sin proceso externo: los rollouts se leen con fs, no con sqlite3 CLI');
+    assert.ok(/require\('fs'\)/.test(src), 'lee los rollouts con el módulo fs');
 });

--- a/.pipeline/lib/__tests__/quota-adapters/openai-codex.test.js
+++ b/.pipeline/lib/__tests__/quota-adapters/openai-codex.test.js
@@ -304,27 +304,33 @@ test('codex: classifyBuckets mapea por window_minutes con umbral 1440', () => {
 
 // --- Lectura real de FS (integración liviana con archivos temporales) --------
 
-test('codex: readLatestEvent elige el rollout mas nuevo entre archivos de fecha', () => {
+test('codex: readLatestEvent elige el evento global más reciente entre sesiones concurrentes', () => {
     const adapter = freshAdapter();
     const base = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-rollout-'));
     const dayDir = path.join(base, '2026', '07', '23');
     fs.mkdirSync(dayDir, { recursive: true });
-    // Dos rollouts; el de nombre lexicográficamente mayor es el más nuevo.
+    // La sesión que empezó antes recibe el evento global más reciente (12:00).
+    // Ordenar sólo por filename elegiría incorrectamente 11:05/pct=20.
     fs.writeFileSync(
         path.join(dayDir, 'rollout-2026-07-23T10-00-00-aaaa.jsonl'),
-        makeLine(makeRateLimits({ weeklyPct: 11, includeSession: false }), '2026-07-23T10:00:00.000Z') + '\n');
+        makeLine(makeRateLimits({ weeklyPct: 80, includeSession: false }), '2026-07-23T12:00:00.000Z') + '\n');
     fs.writeFileSync(
-        path.join(dayDir, 'rollout-2026-07-23T16-38-03-bbbb.jsonl'),
-        makeLine(makeRateLimits({ weeklyPct: 77, includeSession: false }), EVENT_TS_ISO) + '\n');
+        path.join(dayDir, 'rollout-2026-07-23T11-00-00-bbbb.jsonl'),
+        makeLine(makeRateLimits({ weeklyPct: 20, includeSession: false }), '2026-07-23T11:05:00.000Z') + '\n');
 
     const ev = adapter.readLatestEvent(base);
     assert.ok(ev);
-    assert.equal(ev.rateLimits.primary.used_percent, 77, 'toma el rollout más nuevo');
+    assert.equal(ev.tsMs, Date.parse('2026-07-23T12:00:00.000Z'));
+    assert.equal(ev.rateLimits.primary.used_percent, 80,
+        'toma el evento más reciente, aunque esté en la sesión iniciada antes');
 
     // End-to-end vía el adapter público, apuntando al dir temporal.
-    const r = adapter({ now: EVENT_TS_MS + 60 * 1000, codexSessionsDir: base });
+    const r = adapter({
+        now: Date.parse('2026-07-23T12:01:00.000Z'),
+        codexSessionsDir: base,
+    });
     assert.equal(r.adapterStatus, 'ok');
-    assert.equal(r.pct, 77);
+    assert.equal(r.pct, 80);
 
     fs.rmSync(base, { recursive: true, force: true });
 });

--- a/.pipeline/lib/__tests__/quota-adapters/openai-codex.test.js
+++ b/.pipeline/lib/__tests__/quota-adapters/openai-codex.test.js
@@ -334,6 +334,72 @@ test('codex: readLatestEvent devuelve null si el dir no existe', () => {
     assert.equal(adapter.readLatestEvent(path.join(os.tmpdir(), 'no-existe-codex-xyz-4885')), null);
 });
 
+// --- Aislamiento del origen (hook de tests hermeticos) -----------------------
+//
+// Los rollouts viven en `~/.codex/sessions`: estado GLOBAL de la máquina que NO
+// depende de `PIPELINE_DIR_OVERRIDE`. Las suites que ejercitan la reconciliación
+// de cuota (#4865: dispatch-billing-flag, reduced-mode) necesitan neutralizar esa
+// fuente para no depender de si el operador usó Codex hace un rato. El hook es
+// `CODEX_SESSIONS_DIR`; estos tests lo blindan como contrato.
+
+test('codex: CODEX_SESSIONS_DIR redirige el origen de los rollouts', () => {
+    const adapter = freshAdapter();
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-envdir-'));
+    const dayDir = path.join(base, '2026', '07', '23');
+    fs.mkdirSync(dayDir, { recursive: true });
+    fs.writeFileSync(
+        path.join(dayDir, 'rollout-2026-07-23T16-38-03-cccc.jsonl'),
+        makeLine(makeRateLimits({ weeklyPct: 42, includeSession: false }), EVENT_TS_ISO) + '\n');
+
+    const prev = process.env.CODEX_SESSIONS_DIR;
+    try {
+        process.env.CODEX_SESSIONS_DIR = base;
+        const r = adapter({ now: EVENT_TS_MS + 60 * 1000 });
+        assert.equal(r.adapterStatus, 'ok');
+        assert.equal(r.pct, 42, 'lee del dir apuntado por el env, no de ~/.codex/sessions');
+    } finally {
+        if (prev === undefined) delete process.env.CODEX_SESSIONS_DIR;
+        else process.env.CODEX_SESSIONS_DIR = prev;
+        fs.rmSync(base, { recursive: true, force: true });
+    }
+});
+
+test('codex: CODEX_SESSIONS_DIR a un dir vacío → no_usage_data (aísla tests)', () => {
+    const adapter = freshAdapter();
+    const prev = process.env.CODEX_SESSIONS_DIR;
+    try {
+        process.env.CODEX_SESSIONS_DIR = path.join(os.tmpdir(), 'codex-sessions-vacio-4885');
+        const r = adapter({ now: EVENT_TS_MS });
+        assert.equal(r.adapterStatus, 'no_usage_data',
+            'sin dato canónico ⇒ la reconciliación de #4865 queda fail-closed');
+        assert.equal(r.pct, null);
+    } finally {
+        if (prev === undefined) delete process.env.CODEX_SESSIONS_DIR;
+        else process.env.CODEX_SESSIONS_DIR = prev;
+    }
+});
+
+test('codex: el arg explícito codexSessionsDir gana sobre CODEX_SESSIONS_DIR', () => {
+    const adapter = freshAdapter();
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-prec-'));
+    const dayDir = path.join(base, '2026', '07', '23');
+    fs.mkdirSync(dayDir, { recursive: true });
+    fs.writeFileSync(
+        path.join(dayDir, 'rollout-2026-07-23T16-38-03-dddd.jsonl'),
+        makeLine(makeRateLimits({ weeklyPct: 33, includeSession: false }), EVENT_TS_ISO) + '\n');
+
+    const prev = process.env.CODEX_SESSIONS_DIR;
+    try {
+        process.env.CODEX_SESSIONS_DIR = path.join(os.tmpdir(), 'codex-env-ignorado-4885');
+        const r = adapter({ now: EVENT_TS_MS + 60 * 1000, codexSessionsDir: base });
+        assert.equal(r.pct, 33, 'precedencia: arg explícito → env → default ~/.codex/sessions');
+    } finally {
+        if (prev === undefined) delete process.env.CODEX_SESSIONS_DIR;
+        else process.env.CODEX_SESSIONS_DIR = prev;
+        fs.rmSync(base, { recursive: true, force: true });
+    }
+});
+
 // --- Invariantes de seguridad ------------------------------------------------
 
 test('codex: invariante offline — cero HTTP en el fuente (security CA-#6)', () => {

--- a/.pipeline/lib/__tests__/quota-exhausted.test.js
+++ b/.pipeline/lib/__tests__/quota-exhausted.test.js
@@ -24,6 +24,14 @@ const path = require('path');
 // tmp dir único, requiere fresh el módulo, y limpia al final. Esto evita
 // race entre tests que comparten `.pipeline/quota-exhausted.json`.
 
+// #4885 — HERMETICIDAD: `setFlag` pasa por el reconcile de cuota (#4865), que
+// consulta el adapter real de Codex. Desde #4885 ese adapter lee los rollouts
+// JSONL de `~/.codex/sessions`, así que sin aislar, los tests dependerían del
+// estado real de Codex en la máquina/CI (si Codex reporta cuota sobrante, el
+// reconcile vetea el flag y los asserts fallan). Apuntamos el dir a un path
+// inexistente → el adapter degrada a `no_usage_data` → fail-closed, sin veto.
+process.env.CODEX_SESSIONS_DIR = path.join(os.tmpdir(), 'no-existe-codex-sessions-4885');
+
 function freshModule(tmpDir) {
     process.env.PIPELINE_DIR_OVERRIDE = tmpDir;
     delete require.cache[require.resolve('../quota-exhausted')];

--- a/.pipeline/lib/agent-launcher/__tests__/dispatch-billing-flag.test.js
+++ b/.pipeline/lib/agent-launcher/__tests__/dispatch-billing-flag.test.js
@@ -54,18 +54,34 @@ function agentModels() {
     };
 }
 
+// #4885 — Aislamiento de la fuente única de cuota de Codex.
+//
+// `shouldGateSpawn` reconcilia el flag contra el adapter canónico (#4865): si el
+// adapter reporta el provider SANO con dato FRESCO, VETA el gate. El adapter de
+// Codex lee los rollouts JSONL de `~/.codex/sessions` — estado GLOBAL de la
+// máquina, ajeno al `PIPELINE_DIR_OVERRIDE`. Sin aislar, estos tests dependen de
+// si el operador usó Codex hace poco (con Codex fresco al 2% el flag se veta y
+// el fallback resuelve `openai-codex` en vez de `cerebras`).
+//
+// Apuntamos `CODEX_SESSIONS_DIR` a un dir vacío del tmp: el adapter devuelve
+// `no_usage_data` → la reconciliación es fail-closed → el flag de cuota MANDA,
+// que es exactamente el mundo que estos tests describen.
 function withTempPipeline(setupFiles, fn) {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'billing4870-'));
     const prev = process.env.PIPELINE_DIR_OVERRIDE;
+    const prevCodex = process.env.CODEX_SESSIONS_DIR;
     try {
         for (const [name, content] of Object.entries(setupFiles)) {
             fs.writeFileSync(path.join(tmp, name), content, 'utf8');
         }
         process.env.PIPELINE_DIR_OVERRIDE = tmp;
+        process.env.CODEX_SESSIONS_DIR = path.join(tmp, 'codex-sessions-vacio');
         return fn(tmp);
     } finally {
         if (prev === undefined) delete process.env.PIPELINE_DIR_OVERRIDE;
         else process.env.PIPELINE_DIR_OVERRIDE = prev;
+        if (prevCodex === undefined) delete process.env.CODEX_SESSIONS_DIR;
+        else process.env.CODEX_SESSIONS_DIR = prevCodex;
         try { fs.rmSync(tmp, { recursive: true, force: true }); } catch { /* best-effort */ }
     }
 }

--- a/.pipeline/lib/commander/__tests__/reduced-mode.test.js
+++ b/.pipeline/lib/commander/__tests__/reduced-mode.test.js
@@ -62,18 +62,32 @@ function agentModels() {
     };
 }
 
+// #4885 — Aislamiento de la fuente única de cuota de Codex.
+//
+// `shouldGateSpawn` reconcilia el flag contra el adapter canónico (#4865) y VETA
+// el gate si el provider está SANO con dato FRESCO. El adapter de Codex lee los
+// rollouts JSONL de `~/.codex/sessions`: estado GLOBAL de la máquina, ajeno al
+// `PIPELINE_DIR_OVERRIDE`. Sin aislar, "todos los pagos gateados" deja de valer
+// en cuanto el operador usó Codex hace poco y el modo reducido no se dispara.
+//
+// `CODEX_SESSIONS_DIR` apunta a un dir vacío del tmp → adapter `no_usage_data` →
+// reconciliación fail-closed → el flag de cuota manda (mundo del test).
 function withTempPipeline(setupFiles, fn) {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'reduced4870-'));
     const prev = process.env.PIPELINE_DIR_OVERRIDE;
+    const prevCodex = process.env.CODEX_SESSIONS_DIR;
     try {
         for (const [name, content] of Object.entries(setupFiles)) {
             fs.writeFileSync(path.join(tmp, name), content, 'utf8');
         }
         process.env.PIPELINE_DIR_OVERRIDE = tmp;
+        process.env.CODEX_SESSIONS_DIR = path.join(tmp, 'codex-sessions-vacio');
         return fn(tmp);
     } finally {
         if (prev === undefined) delete process.env.PIPELINE_DIR_OVERRIDE;
         else process.env.PIPELINE_DIR_OVERRIDE = prev;
+        if (prevCodex === undefined) delete process.env.CODEX_SESSIONS_DIR;
+        else process.env.CODEX_SESSIONS_DIR = prevCodex;
         try { fs.rmSync(tmp, { recursive: true, force: true }); } catch { /* best-effort */ }
     }
 }

--- a/.pipeline/lib/quota-adapters/index.js
+++ b/.pipeline/lib/quota-adapters/index.js
@@ -83,8 +83,8 @@ function getAdapter(provider) {
  *     metricsDir:        string,    path absoluto a .pipeline/metrics
  *     activityLogPath:   string,    path absoluto a .claude/activity-log.jsonl
  *     configLimitHours?: number,    límite del config (override, Anthropic)
- *     codexLogPath?:     string,    override del SQLite de Codex (#4598)
- *     stalenessMs?:      number,    umbral de frescura Codex (#4598)
+ *     codexSessionsDir?: string,    override del dir de rollouts de Codex (#4885)
+ *     stalenessMs?:      number,    umbral de frescura Codex (#4885)
  *     now?:              number,    timestamp para tests determinísticos
  *   }
  * @returns {QuotaResult}

--- a/.pipeline/lib/quota-adapters/openai-codex.js
+++ b/.pipeline/lib/quota-adapters/openai-codex.js
@@ -1,90 +1,110 @@
 // =============================================================================
-// quota-adapters/openai-codex.js — Adapter OpenAI/Codex (#4598).
+// quota-adapters/openai-codex.js — Adapter OpenAI/Codex.
 //
-// Estrategia (OFFLINE — security CA-#6): leer el USO REAL que Codex muestra en
-// `/status`, SIN inferir nada.
+// FUENTE DE VERDAD (#4868) + GATE DE CUOTA (#4865): un único adapter que lee el
+// USO REAL que Codex reportaría en `/status`, SIN inferir ni hacer red.
 //
-//   * `codex exec "/status"` NO ejecuta el slash command (corre el modelo),
-//     pero Codex **persiste** el rate-limit que mostraría `/status` en su log
-//     SQLite `~/.codex/logs_2.sqlite`, tabla `logs`, columna `feedback_log_body`,
-//     como eventos `codex.rate_limits`. Cada llamada de Codex escribe uno nuevo.
+// HISTORIA DEL FORMATO:
 //
-//   * Mapeo verificado en vivo (#4598):
-//       - `primary`   → ventana 5h  (`window_minutes: 300`)   → bucket SESIÓN.
-//       - `secondary` → ventana 7d  (`window_minutes: 10080`) → bucket SEMANAL.
-//     Cada uno trae `used_percent` (0..100) y `reset_at` (epoch s).
+//   * ANTES (Codex < 0.145.0): el rate-limit se persistía en el log SQLite
+//     `~/.codex/logs_2.sqlite` (tabla `logs`, columna `feedback_log_body`) como
+//     eventos `codex.rate_limits`. El adapter lo leía con el CLI `sqlite3`.
 //
-//   * El bucket SEMANAL (secondary) se mapea al top-level `pct`/`status`
-//     (igual que Anthropic) para que pacing (`pacing-bucket.js` lee
-//     `weekly.pct`) y el gating (`provider-health.assessProviderQuota` lee
-//     `status`) consuman el número real. El bucket SESIÓN (primary 5h) va a
-//     `session.pct`/`session.status`.
+//   * AHORA (Codex >= 0.145.0 — #4885): Codex dejó de persistir `used_percent`
+//     en el SQLite (el evento `account/rateLimits/read` sólo lleva el span de
+//     telemetría, sin porcentajes). El objeto con `used_percent` se MOVIÓ a los
+//     ROLLOUTS de sesión: `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`. Cada
+//     línea es un evento JSON; los eventos `event_msg`/`token_count` incluyen un
+//     objeto `payload.rate_limits`. Muestra real (v0.145.0):
 //
-//   * FRESCURA (CA-3): el evento se escribe en cada llamada de Codex. Si el
-//     último es viejo (Codex inactivo), NO mostramos el porcentaje stale como
-//     actual: devolvemos estado degradado (`adapterStatus: 'unknown'`,
-//     `pct: null`) con `errorReason` explicando la antigüedad. Umbral
-//     configurable vía `CODEX_QUOTA_STALENESS_MS` (piso conservador).
+//       {"timestamp":"2026-07-23T19:38:32.183Z","type":"event_msg",
+//        "payload":{"type":"token_count","info":{...},
+//          "rate_limits":{"limit_id":"codex","limit_name":null,
+//            "primary":{"used_percent":1.0,"window_minutes":10080,"resets_at":1785373521},
+//            "secondary":null,"credits":{...},"plan_type":"plus", ...}}}
 //
-//   * PARSE TOLERANTE: `feedback_log_body` viene prefijado como
-//     `Received message {...}` (no JSON puro). Extraemos desde el primer `{`,
-//     validamos `type === 'codex.rate_limits'` y navegamos defensivamente —
-//     es un log interno de Codex y puede cambiar entre versiones.
+// CAMBIOS QUE ESTE ADAPTER MANEJA (respecto del formato SQLite viejo):
 //
-//   * CERO INFERENCIA / CERO RED: leemos SQLite local con el binario `sqlite3`
-//     (CLI, `-readonly`, timeout acotado). No agregamos dependencia nativa
-//     (`better-sqlite3`) ni hacemos HTTP a OpenAI (evita SSRF/secrets en
-//     runtime del dashboard — el check de "cero clientes HTTP" sigue en verde).
+//   1. FUENTE: SQLite (`sqlite3` CLI) → archivos JSONL de rollout leídos con
+//      `fs` (sin dependencia de `sqlite3` ni proceso externo; sigue offline).
+//   2. RENAME DE CAMPO: `reset_at` (viejo) → `resets_at` (nuevo).
+//   3. SEMÁNTICA DE VENTANAS: el mapeo bucket→ventana YA NO es posicional
+//      (primary=5h, secondary=7d). Se clasifica por `window_minutes`:
+//        - `window_minutes` < 1440 (< 1 día)  → bucket SESIÓN (5h ≈ 300).
+//        - `window_minutes` >= 1440 (>= 1 día) → bucket SEMANAL (7d = 10080).
+//      En v0.145.0 el uso semanal viene en `primary` con `secondary: null`, así
+//      que la posición NO sirve: hay que mirar la ventana.
+//   4. FRESCURA (CA-3): anclada al `timestamp` ISO del evento en el JSONL (no al
+//      mtime del archivo). Si el evento es viejo (Codex inactivo), NO mostramos
+//      el % stale como actual → estado degradado (`unknown`, pct null).
+//
+// MAPEO AL SHAPE CANÓNICO (igual que antes, preservando #4868):
+//   * bucket SEMANAL → top-level `pct`/`status` (lo consume pacing
+//     `pacing-bucket.js` vía `weekly.pct` y el gating
+//     `provider-health.assessProviderQuota` vía `status`).
+//   * bucket SESIÓN  → `session.pct`/`session.status`.
+//
+// CERO INFERENCIA / CERO RED (security CA-#6): sólo lectura local de archivos
+// JSONL con `fs`. No HTTP a OpenAI, no proceso externo, no dependencia nativa.
 //
 // Estados degradados (security CA-#3 + UX G1: "sin dato" != "0% real"):
 //
-//   - No se pudo leer el SQLite (archivo ausente, `sqlite3` no disponible,
-//     query fallida) o DB sin eventos → `no_usage_data`, pct null (reprobe-elegible).
-//   - Evento presente pero body ilegible / shape inesperado
-//                             → `error`,          pct null.
-//   - Evento presente pero STALE (Codex inactivo)
-//                             → `unknown`,        pct null.
-//   - Evento fresco y válido  → `ok`, primary→sesión / secondary→semanal.
+//   - No hay rollout legible con un objeto `rate_limits` → `no_usage_data`,
+//     pct null (reprobe-elegible: Codex podría no haber corrido aún).
+//   - Rollout presente pero shape inesperado / sin `used_percent` válido en
+//     ninguna ventana → `error`, pct null.
+//   - Evento presente pero STALE (Codex inactivo) → `unknown`, pct null.
+//   - Evento fresco y válido → `ok`, semanal→top-level / sesión→session.
 // =============================================================================
 'use strict';
 
 const os = require('os');
 const path = require('path');
-const { execFileSync } = require('child_process');
+const fs = require('fs');
 const { ADAPTER_STATUS, QUOTA_STATUS, emptyResult } = require('./_shape');
 
-// Umbral de frescura por defecto (CA-3). Si el último evento `codex.rate_limits`
-// es más viejo que esto, el dato es stale (Codex inactivo) → degradado, NUNCA
-// mostramos el porcentaje viejo como actual. La ventana `primary` es de 5h y se
-// recarga continuamente: pasada ~1h de inactividad el % ya no representa el uso
-// real. Configurable vía env con piso conservador de 5 min anti-parpadeo.
+// Umbral de frescura por defecto (CA-3). Si el último evento `rate_limits` es
+// más viejo que esto, el dato es stale (Codex inactivo) → degradado, NUNCA
+// mostramos el porcentaje viejo como actual. Configurable vía env con piso
+// conservador de 5 min anti-parpadeo. Default 1 hora.
 const DEFAULT_STALENESS_MS = (() => {
     const raw = Number(process.env.CODEX_QUOTA_STALENESS_MS);
     if (Number.isFinite(raw) && raw >= 5 * 60 * 1000) return raw;
     return 60 * 60 * 1000; // 1 hora
 })();
 
-// Timeout del spawn de `sqlite3` (anti-cuelgue si la DB está bloqueada/inflada).
-const SQLITE_TIMEOUT_MS = 5000;
-// Cap de lectura del stdout de `sqlite3` (una fila JSON ~ pocos KB).
-const SQLITE_MAX_BUFFER = 1 * 1024 * 1024;
+// Tolerancia de desfasaje de reloj hacia el futuro. Un evento fechado más
+// adelante que esto no es confiable (clock skew, timestamp corrupto, rollout
+// copiado de otra máquina) y NO debe pasar como "fresco": una edad negativa
+// atraviesa el chequeo de staleness sin filtrarse.
+const FUTURE_SKEW_TOLERANCE_MS = 5 * 60 * 1000; // 5 min
 
-// Separador de columnas: unit separator (0x1f). No aparece en JSON compacto,
-// así evitamos colisión con `|` (default de sqlite3) que puede estar en el body.
-const COL_SEP = '\x1f';
+// Frontera semana/sesión por `window_minutes`. La ventana de sesión de Codex es
+// de 5h (300 min); la semanal es de 7d (10080 min). Cualquier ventana >= 1 día
+// (1440 min) se considera semanal; el resto, sesión. Umbral robusto ante
+// variaciones menores del proveedor.
+const WEEKLY_WINDOW_MIN_THRESHOLD = 1440;
 
-// Query: último evento `codex.rate_limits` por timestamp. Indexado por `ts DESC`.
-const RATE_LIMITS_SQL =
-    "SELECT ts, feedback_log_body FROM logs " +
-    "WHERE feedback_log_body LIKE '%codex.rate_limits%' " +
-    "ORDER BY ts DESC, id DESC LIMIT 1;";
+// Cantidad máxima de archivos de rollout a escanear (del más nuevo al más
+// viejo) buscando un objeto `rate_limits`. Cota anti-cuelgue si hay muchas
+// sesiones sin el dato. El activo, que se actualiza en cada llamada de Codex,
+// es el más nuevo → normalmente se resuelve en el primer archivo.
+const MAX_ROLLOUTS_TO_SCAN = 40;
+
+// Cap de bytes a leer del final de cada rollout. Los eventos `rate_limits` se
+// escriben continuamente, así que el último vive cerca del final del archivo.
+// Leer sólo la cola evita cargar archivos gigantes en memoria (anti-OOM). Si el
+// corte parte una línea, esa línea parcial falla el JSON.parse y se descarta:
+// escaneamos desde el final y la última línea completa queda intacta.
+const ROLLOUT_TAIL_BYTES = 512 * 1024; // 512 KB
 
 /**
- * Path por defecto del log SQLite de Codex (`~/.codex/logs_2.sqlite`).
+ * Path por defecto del directorio de sesiones/rollouts de Codex
+ * (`~/.codex/sessions`).
  * @returns {string}
  */
-function defaultCodexLogPath() {
-    return path.join(os.homedir(), '.codex', 'logs_2.sqlite');
+function defaultCodexSessionsDir() {
+    return path.join(os.homedir(), '.codex', 'sessions');
 }
 
 /**
@@ -98,50 +118,6 @@ function statusFromPct(pct) {
     if (pct >= 75) return QUOTA_STATUS.WARNING;
     if (pct >= 50) return QUOTA_STATUS.NORMAL;
     return QUOTA_STATUS.OK;
-}
-
-/**
- * Parse tolerante del `feedback_log_body`. El body viene prefijado (p.ej.
- * `Received message {...}`), así que extraemos desde el primer `{`, validamos
- * `type === 'codex.rate_limits'` y devolvemos el objeto `rate_limits`. NO lanza:
- * cualquier problema devuelve `null`.
- *
- * @param {string} bodyText
- * @returns {Object|null}  El objeto `rate_limits` ({primary, secondary, ...}).
- */
-function parseRateLimits(bodyText) {
-    if (typeof bodyText !== 'string' || bodyText.length === 0) return null;
-    const start = bodyText.indexOf('{');
-    if (start < 0) return null;
-    let obj;
-    try {
-        obj = JSON.parse(bodyText.slice(start));
-    } catch {
-        return null;
-    }
-    if (!obj || typeof obj !== 'object' || obj.type !== 'codex.rate_limits') return null;
-    const rl = obj.rate_limits;
-    if (!rl || typeof rl !== 'object') return null;
-    return rl;
-}
-
-/**
- * Extrae `{ usedPercent, resetAt }` de un bucket (`primary`/`secondary`) del
- * objeto `rate_limits`, defensivamente. Devuelve `null` si falta el
- * `used_percent` numérico (dato mínimo requerido).
- *
- * @param {Object} rateLimits
- * @param {string} key  'primary' | 'secondary'
- * @returns {{usedPercent:number, resetAt:(number|null)}|null}
- */
-function readBucket(rateLimits, key) {
-    const b = rateLimits && typeof rateLimits === 'object' ? rateLimits[key] : null;
-    if (!b || typeof b !== 'object') return null;
-    const usedPercent = Number(b.used_percent);
-    if (!Number.isFinite(usedPercent) || usedPercent < 0) return null;
-    const resetRaw = Number(b.reset_at);
-    const resetAt = Number.isFinite(resetRaw) && resetRaw > 0 ? resetRaw : null;
-    return { usedPercent: Math.min(100, usedPercent), resetAt };
 }
 
 /**
@@ -159,137 +135,263 @@ function isoFromEpochSeconds(epochSeconds) {
 }
 
 /**
- * Lee el último evento `codex.rate_limits` del SQLite vía CLI `sqlite3`
- * (`-readonly`, timeout acotado). NO lanza: devuelve `null` ante cualquier
- * error (archivo ausente, binario no disponible, query fallida).
+ * Lista los archivos de rollout más recientes bajo `sessionsDir`, ordenados del
+ * MÁS NUEVO al más viejo, sin `stat` por archivo: la jerarquía es
+ * `YYYY/MM/DD/rollout-<ISO>-<uuid>.jsonl` y tanto los directorios de fecha
+ * (zero-padded) como el nombre del rollout (prefijado por timestamp ISO) ordenan
+ * cronológicamente por comparación lexicográfica. NO lanza: devuelve `[]` ante
+ * cualquier error de FS.
  *
- * @param {string} logPath      path al `logs_2.sqlite`.
- * @param {string} sqlite3Bin   binario a invocar (default `sqlite3` del PATH).
- * @returns {{ts:number, body:string}|null}
+ * @param {string} sessionsDir
+ * @param {number} max  Cota superior de archivos a devolver.
+ * @returns {string[]}  Paths absolutos, más nuevo primero.
  */
-function readLatestEvent(logPath, sqlite3Bin) {
-    if (typeof logPath !== 'string' || logPath.length === 0) return null;
-    // Prioridad: override explícito → env `CODEX_SQLITE3_BIN` → `sqlite3` (PATH).
-    // El env permite apuntar al binario si no está en el PATH del runtime del
-    // pipeline (p.ej. el `sqlite3` de Android SDK platform-tools).
-    const envBin = typeof process.env.CODEX_SQLITE3_BIN === 'string'
-        && process.env.CODEX_SQLITE3_BIN.length > 0
-        ? process.env.CODEX_SQLITE3_BIN
-        : null;
-    const bin = (typeof sqlite3Bin === 'string' && sqlite3Bin.length > 0)
-        ? sqlite3Bin
-        : (envBin || 'sqlite3');
-    let out;
-    try {
-        out = execFileSync(
-            bin,
-            ['-readonly', '-batch', '-noheader', '-separator', COL_SEP, logPath, RATE_LIMITS_SQL],
-            { timeout: SQLITE_TIMEOUT_MS, maxBuffer: SQLITE_MAX_BUFFER, encoding: 'utf8', windowsHide: true },
-        );
-    } catch {
-        // Archivo ausente, `sqlite3` no instalado, DB corrupta, timeout, etc.
-        return null;
+function listRecentRolloutFiles(sessionsDir, max) {
+    const out = [];
+    if (typeof sessionsDir !== 'string' || sessionsDir.length === 0) return out;
+    const descNum = (a, b) => Number(b) - Number(a);
+    const descStr = (a, b) => (a < b ? 1 : a > b ? -1 : 0);
+    const readDirs = (dir, filter, sorter) => {
+        let entries;
+        try { entries = fs.readdirSync(dir); } catch { return []; }
+        return entries.filter(filter).sort(sorter);
+    };
+    const numeric = (name) => /^\d+$/.test(name);
+    const years = readDirs(sessionsDir, numeric, descNum);
+    for (const y of years) {
+        const yDir = path.join(sessionsDir, y);
+        for (const m of readDirs(yDir, numeric, descNum)) {
+            const mDir = path.join(yDir, m);
+            for (const d of readDirs(mDir, numeric, descNum)) {
+                const dDir = path.join(mDir, d);
+                const files = readDirs(dDir, (f) => /^rollout-.*\.jsonl$/.test(f), descStr);
+                for (const f of files) {
+                    out.push(path.join(dDir, f));
+                    if (out.length >= max) return out;
+                }
+            }
+        }
     }
-    if (typeof out !== 'string') return null;
-    const line = out.replace(/\r/g, '').split('\n').find((l) => l.length > 0);
-    if (!line) return null; // DB legible pero sin filas → sin eventos.
-    const sepIdx = line.indexOf(COL_SEP);
-    if (sepIdx < 0) return null;
-    const ts = Number(line.slice(0, sepIdx));
-    const body = line.slice(sepIdx + 1);
-    if (!Number.isFinite(ts) || ts <= 0) return null;
-    return { ts, body };
+    return out;
 }
 
 /**
- * Adapter OpenAI/Codex. Lee el uso real de `/status` desde el SQLite de Codex
- * (primary=5h → sesión, secondary=7d → semanal), con detección de dato stale.
+ * Lee la cola (últimos `maxBytes`) de un archivo como texto UTF-8. Para archivos
+ * chicos lee el archivo entero. NO lanza: devuelve `null` ante cualquier error.
+ *
+ * @param {string} filePath
+ * @param {number} maxBytes
+ * @returns {string|null}
+ */
+function readFileTail(filePath, maxBytes) {
+    let fd;
+    try {
+        fd = fs.openSync(filePath, 'r');
+    } catch {
+        return null;
+    }
+    try {
+        const size = fs.fstatSync(fd).size;
+        const start = size > maxBytes ? size - maxBytes : 0;
+        const len = size - start;
+        if (len <= 0) return '';
+        const buf = Buffer.alloc(len);
+        fs.readSync(fd, buf, 0, len, start);
+        return buf.toString('utf8');
+    } catch {
+        return null;
+    } finally {
+        try { fs.closeSync(fd); } catch { /* noop */ }
+    }
+}
+
+/**
+ * Extrae de un contenido JSONL el ÚLTIMO objeto `rate_limits` (el más reciente),
+ * escaneando de la última línea hacia atrás. Cada evento del rollout es un JSON
+ * por línea; los que traen cuota exponen `payload.rate_limits`. Devuelve el
+ * objeto de cuota + el timestamp ISO del evento (en ms). NO lanza: `null` si no
+ * hay ninguno legible.
+ *
+ * @param {string} content  Texto JSONL (puede ser una cola parcial del archivo).
+ * @returns {{tsMs:(number|null), rateLimits:Object}|null}
+ */
+function extractLatestRateLimits(content) {
+    if (typeof content !== 'string' || content.length === 0) return null;
+    const lines = content.split('\n');
+    for (let i = lines.length - 1; i >= 0; i--) {
+        const line = lines[i].trim();
+        // Fast-path: descartar líneas sin la clave antes de parsear JSON.
+        if (line.length === 0 || line.indexOf('rate_limits') < 0) continue;
+        let obj;
+        try {
+            obj = JSON.parse(line);
+        } catch {
+            // Línea parcial (corte de cola) o corrupta → seguir hacia atrás.
+            continue;
+        }
+        const rl = obj && obj.payload && typeof obj.payload === 'object'
+            ? obj.payload.rate_limits
+            : null;
+        if (!rl || typeof rl !== 'object') continue;
+        const tsMs = typeof obj.timestamp === 'string' ? Date.parse(obj.timestamp) : NaN;
+        return { tsMs: Number.isFinite(tsMs) ? tsMs : null, rateLimits: rl };
+    }
+    return null;
+}
+
+/**
+ * Recorre los rollouts más recientes (nuevo→viejo) y devuelve el primer evento
+ * con un objeto `rate_limits` legible. El rollout activo se actualiza en cada
+ * llamada de Codex, así que es el más nuevo y normalmente resuelve al primer
+ * archivo. NO lanza: `null` ante cualquier error o ausencia de dato.
+ *
+ * @param {string} sessionsDir  Directorio de sesiones (`~/.codex/sessions`).
+ * @returns {{tsMs:(number|null), rateLimits:Object}|null}
+ */
+function readLatestEvent(sessionsDir) {
+    const files = listRecentRolloutFiles(sessionsDir, MAX_ROLLOUTS_TO_SCAN);
+    for (const file of files) {
+        const content = readFileTail(file, ROLLOUT_TAIL_BYTES);
+        if (content == null) continue;
+        const event = extractLatestRateLimits(content);
+        if (event) return event;
+    }
+    return null;
+}
+
+/**
+ * Clasifica los buckets del objeto `rate_limits` en SESIÓN / SEMANAL según
+ * `window_minutes` (NO por posición primary/secondary — ver header). Recorre
+ * `primary` y `secondary`; para cada uno con `used_percent` numérico válido lo
+ * ubica en su ventana. Si dos buckets caen en la misma ventana, gana el primero
+ * (primary antes que secondary).
+ *
+ * @param {Object} rateLimits
+ * @returns {{session:(Bucket|null), weekly:(Bucket|null)}}
+ * @typedef {{usedPercent:number, resetAt:(number|null), windowMinutes:(number|null)}} Bucket
+ */
+function classifyBuckets(rateLimits) {
+    const result = { session: null, weekly: null };
+    if (!rateLimits || typeof rateLimits !== 'object') return result;
+    for (const key of ['primary', 'secondary']) {
+        const b = rateLimits[key];
+        if (!b || typeof b !== 'object') continue;
+        const usedPercent = Number(b.used_percent);
+        if (!Number.isFinite(usedPercent) || usedPercent < 0) continue;
+        const resetRaw = Number(b.resets_at);
+        const resetAt = Number.isFinite(resetRaw) && resetRaw > 0 ? resetRaw : null;
+        const wmRaw = Number(b.window_minutes);
+        const windowMinutes = Number.isFinite(wmRaw) && wmRaw > 0 ? wmRaw : null;
+        const bucket = {
+            usedPercent: Math.min(100, usedPercent),
+            resetAt,
+            windowMinutes,
+        };
+        // Sin window_minutes no podemos clasificar por ventana: lo tratamos como
+        // SESIÓN (bucket rolling corto) para no fabricar un semanal falso que
+        // alimente el gating/pacing con un número de ventana desconocida.
+        const isWeekly = windowMinutes != null && windowMinutes >= WEEKLY_WINDOW_MIN_THRESHOLD;
+        if (isWeekly) {
+            if (!result.weekly) result.weekly = bucket;
+        } else if (!result.session) {
+            result.session = bucket;
+        }
+    }
+    return result;
+}
+
+/**
+ * Adapter OpenAI/Codex. Lee el uso real desde el rollout JSONL más reciente de
+ * Codex (>= v0.145.0), clasificando buckets por `window_minutes` (sesión 5h /
+ * semanal 7d) y con detección de dato stale.
  *
  * @param {Object} sessionData
- *   @property {string}  [codexLogPath]  override del path al `logs_2.sqlite`.
- *   @property {string}  [sqlite3Path]   override del binario `sqlite3`.
- *   @property {number}  [stalenessMs]   override del umbral de frescura.
- *   @property {number}  [now]           epoch ms para tests / frescura.
- *   @property {Function} [readEventImpl] inyección de `readLatestEvent` (tests).
+ *   @property {string}   [codexSessionsDir]  override del dir de rollouts.
+ *   @property {number}   [stalenessMs]       override del umbral de frescura.
+ *   @property {number}   [now]               epoch ms para tests / frescura.
+ *   @property {Function} [readEventImpl]     inyección de `readLatestEvent` (tests).
  * @returns {QuotaResult}
  */
 function openaiCodexAdapter(sessionData) {
     const sd = sessionData && typeof sessionData === 'object' ? sessionData : {};
-    // Prioridad del path del SQLite: override explícito → env
-    // `CODEX_QUOTA_LOG_PATH` → default `~/.codex/logs_2.sqlite`. El env permite
-    // apuntar a otra ubicación (o a un path inexistente en tests) sin tocar el
-    // caller, que invoca con sessionData fijo.
-    const envLogPath = typeof process.env.CODEX_QUOTA_LOG_PATH === 'string'
-        && process.env.CODEX_QUOTA_LOG_PATH.length > 0
-        ? process.env.CODEX_QUOTA_LOG_PATH
+    // Prioridad del dir de rollouts: override explícito → env
+    // `CODEX_SESSIONS_DIR` → default `~/.codex/sessions`.
+    const envDir = typeof process.env.CODEX_SESSIONS_DIR === 'string'
+        && process.env.CODEX_SESSIONS_DIR.length > 0
+        ? process.env.CODEX_SESSIONS_DIR
         : null;
-    const logPath = (typeof sd.codexLogPath === 'string' && sd.codexLogPath.length > 0)
-        ? sd.codexLogPath
-        : (envLogPath || defaultCodexLogPath());
+    const sessionsDir = (typeof sd.codexSessionsDir === 'string' && sd.codexSessionsDir.length > 0)
+        ? sd.codexSessionsDir
+        : (envDir || defaultCodexSessionsDir());
     const stalenessMs = Number.isFinite(sd.stalenessMs) && sd.stalenessMs > 0
         ? sd.stalenessMs
         : DEFAULT_STALENESS_MS;
     const nowMs = Number.isFinite(sd.now) ? sd.now : Date.now();
     const readEvent = typeof sd.readEventImpl === 'function' ? sd.readEventImpl : readLatestEvent;
 
-    // 1. Leer el último evento del SQLite.
+    // 1. Leer el último evento `rate_limits` del rollout más reciente.
     let event;
     try {
-        event = readEvent(logPath, sd.sqlite3Path);
+        event = readEvent(sessionsDir);
     } catch {
         event = null; // fail-secure: cualquier excepción del reader → degradado.
     }
     if (!event) {
-        // No pudimos leer NINGÚN evento. Puede ser: DB ausente, `sqlite3` no
-        // disponible, o DB legible pero sin eventos `codex.rate_limits` todavía.
-        // No podemos discriminar con certeza desde el reader (devuelve null en
-        // ambos casos), así que lo tratamos como AUSENCIA DE DATO reprobe-elegible
-        // (Codex podría estar vivo pero sin haber escrito un rate_limits aún).
+        // No hay rollout legible con un objeto `rate_limits`. Puede ser: dir
+        // ausente, Codex no corrió aún, o rollouts sin cuota todavía. Ausencia
+        // de dato reprobe-elegible (Codex podría estar vivo sin haber escrito).
         return emptyResult('openai-codex', ADAPTER_STATUS.NO_USAGE_DATA,
-            'Cuota Codex: sin evento codex.rate_limits legible en el log SQLite '
-            + '(Codex no corrió aún o sqlite3 no disponible)');
+            'Cuota Codex: sin objeto rate_limits legible en los rollouts '
+            + '(~/.codex/sessions) — Codex no corrió aún o el formato cambió');
     }
 
-    // 2. Frescura (CA-3): el `ts` del log es epoch s. Si el evento es viejo,
-    //    Codex está inactivo → degradado, NO mostramos el % stale como actual.
-    const eventMs = event.ts * 1000;
+    // 2. Frescura (CA-3): si el evento no trae timestamp, no podemos afirmar que
+    //    sea actual → degradado. Si es viejo, Codex está inactivo → degradado.
+    const eventMs = Number.isFinite(event.tsMs) ? event.tsMs : null;
+    if (eventMs == null) {
+        return emptyResult('openai-codex', ADAPTER_STATUS.UNKNOWN,
+            'Cuota Codex: evento rate_limits sin timestamp legible — no se puede '
+            + 'garantizar frescura, no se muestra el % (posible dato stale)');
+    }
     const ageMs = nowMs - eventMs;
+    // Evento en el FUTURO (edad negativa): clock skew, timestamp corrupto o
+    // rollout de otra máquina. Una edad negativa pasaría el chequeo de staleness
+    // de abajo y mostraría como "fresco" un dato NO confiable. Toleramos un
+    // margen chico de desfasaje de reloj; más allá, degradamos.
+    if (-ageMs > FUTURE_SKEW_TOLERANCE_MS) {
+        const aheadMin = Math.round(-ageMs / 60000);
+        return emptyResult('openai-codex', ADAPTER_STATUS.UNKNOWN,
+            `Cuota Codex: evento rate_limits fechado ~${aheadMin} min en el futuro `
+            + '(clock skew o timestamp corrupto) — no se puede confiar en la frescura');
+    }
     if (ageMs > stalenessMs) {
         const ageMin = Math.round(ageMs / 60000);
         return emptyResult('openai-codex', ADAPTER_STATUS.UNKNOWN,
-            `Cuota Codex: dato stale (último /status hace ~${ageMin} min, umbral `
+            `Cuota Codex: dato stale (último rate_limits hace ~${ageMin} min, umbral `
             + `${Math.round(stalenessMs / 60000)} min) — Codex inactivo, no se muestra el % viejo`);
     }
 
-    // 3. Parse tolerante del body.
-    const rateLimits = parseRateLimits(event.body);
-    if (!rateLimits) {
+    // 3. Clasificar buckets por window_minutes.
+    const { session, weekly } = classifyBuckets(event.rateLimits);
+    if (!session && !weekly) {
         return emptyResult('openai-codex', ADAPTER_STATUS.ERROR,
-            'Cuota Codex: no se pudo parsear el evento codex.rate_limits '
-            + '(formato de log cambió o body corrupto)');
+            'Cuota Codex: objeto rate_limits sin used_percent válido en ninguna ventana');
     }
 
-    const primary = readBucket(rateLimits, 'primary');     // 5h → sesión
-    const secondary = readBucket(rateLimits, 'secondary'); // 7d → semanal
-    if (!primary && !secondary) {
-        return emptyResult('openai-codex', ADAPTER_STATUS.ERROR,
-            'Cuota Codex: evento codex.rate_limits sin used_percent válido en primary/secondary');
-    }
-
-    // 4. Construir el shape. secondary (7d) → top-level (pacing + gating);
-    //    primary (5h) → session.
+    // 4. Construir el shape. semanal (7d) → top-level (pacing + gating);
+    //    sesión (5h) → session.
     const result = emptyResult('openai-codex', ADAPTER_STATUS.OK, null);
 
-    if (secondary) {
-        const weeklyPct = Math.round(secondary.usedPercent * 10) / 10;
+    if (weekly) {
+        const weeklyPct = Math.round(weekly.usedPercent * 10) / 10;
         result.pct = weeklyPct;
         result.realPct = null; // el pct YA es el dato real de Codex.
         result.realPctRaw = weeklyPct;
         result.realPctCapped = false;
         result.status = statusFromPct(weeklyPct);
         result.realStatus = result.status;
-        result.nextResetAt = isoFromEpochSeconds(secondary.resetAt);
-        result.weeklyResetsAtReported = isoFromEpochSeconds(secondary.resetAt);
+        result.nextResetAt = isoFromEpochSeconds(weekly.resetAt);
+        result.weeklyResetsAtReported = isoFromEpochSeconds(weekly.resetAt);
     } else {
         // Sin bucket semanal legible pero sí sesión: top-level queda "sin dato"
         // (null) para no fabricar un % semanal. status 'unknown' (no verde).
@@ -297,26 +399,28 @@ function openaiCodexAdapter(sessionData) {
         result.realStatus = QUOTA_STATUS.UNKNOWN;
     }
 
-    if (primary) {
-        const sessionPct = Math.round(primary.usedPercent * 10) / 10;
+    if (session) {
+        const sessionPct = Math.round(session.usedPercent * 10) / 10;
         result.session.pct = sessionPct;
         result.session.realPct = null;
         result.session.realPctRaw = sessionPct;
         result.session.realPctCapped = false;
         result.session.status = statusFromPct(sessionPct);
         result.session.realStatus = result.session.status;
-        result.sessionResetsAt = isoFromEpochSeconds(primary.resetAt);
+        result.sessionResetsAt = isoFromEpochSeconds(session.resetAt);
     }
 
     return result;
 }
 
 // Exponer helpers puros + constantes para tests y consumidores.
-openaiCodexAdapter.parseRateLimits = parseRateLimits;
-openaiCodexAdapter.readBucket = readBucket;
-openaiCodexAdapter.statusFromPct = statusFromPct;
+openaiCodexAdapter.classifyBuckets = classifyBuckets;
+openaiCodexAdapter.extractLatestRateLimits = extractLatestRateLimits;
+openaiCodexAdapter.listRecentRolloutFiles = listRecentRolloutFiles;
 openaiCodexAdapter.readLatestEvent = readLatestEvent;
-openaiCodexAdapter.defaultCodexLogPath = defaultCodexLogPath;
+openaiCodexAdapter.statusFromPct = statusFromPct;
+openaiCodexAdapter.defaultCodexSessionsDir = defaultCodexSessionsDir;
 openaiCodexAdapter.DEFAULT_STALENESS_MS = DEFAULT_STALENESS_MS;
+openaiCodexAdapter.WEEKLY_WINDOW_MIN_THRESHOLD = WEEKLY_WINDOW_MIN_THRESHOLD;
 
 module.exports = openaiCodexAdapter;

--- a/.pipeline/lib/quota-adapters/openai-codex.js
+++ b/.pipeline/lib/quota-adapters/openai-codex.js
@@ -240,23 +240,34 @@ function extractLatestRateLimits(content) {
 }
 
 /**
- * Recorre los rollouts más recientes (nuevo→viejo) y devuelve el primer evento
- * con un objeto `rate_limits` legible. El rollout activo se actualiza en cada
- * llamada de Codex, así que es el más nuevo y normalmente resuelve al primer
- * archivo. NO lanza: `null` ante cualquier error o ausencia de dato.
+ * Recorre los rollouts más recientes (nuevo→viejo) y devuelve el evento
+ * `rate_limits` con el timestamp global más reciente. El nombre del rollout
+ * indica cuándo empezó la sesión, no cuándo recibió su último evento: una
+ * sesión anterior puede seguir activa o reanudarse y escribir después que una
+ * sesión cuyo archivo ordena primero. NO lanza: `null` ante cualquier error o
+ * ausencia de dato.
  *
  * @param {string} sessionsDir  Directorio de sesiones (`~/.codex/sessions`).
  * @returns {{tsMs:(number|null), rateLimits:Object}|null}
  */
 function readLatestEvent(sessionsDir) {
     const files = listRecentRolloutFiles(sessionsDir, MAX_ROLLOUTS_TO_SCAN);
+    let latest = null;
     for (const file of files) {
         const content = readFileTail(file, ROLLOUT_TAIL_BYTES);
         if (content == null) continue;
         const event = extractLatestRateLimits(content);
-        if (event) return event;
+        if (!event) continue;
+        // Conservar un evento sin timestamp sólo como fallback degradado. Un
+        // evento fechado siempre es preferible y, entre fechados, gana el más
+        // reciente sin importar el orden de inicio de las sesiones.
+        if (!latest
+            || (Number.isFinite(event.tsMs)
+                && (!Number.isFinite(latest.tsMs) || event.tsMs > latest.tsMs))) {
+            latest = event;
+        }
     }
-    return null;
+    return latest;
 }
 
 /**

--- a/.pipeline/lib/quota-exhausted.js
+++ b/.pipeline/lib/quota-exhausted.js
@@ -822,7 +822,8 @@ function clearFlag(opts = {}) {
 // cuota: decide spawn/no-spawn. Antes de #4865 decidía en base a la detección
 // por substring del stdout del agente (heurística), no al valor real del
 // adapter canónico (`lib/quota-adapters`) que #4861 (Anthropic, `claude -p
-// /usage`) y #4868/#4863 (Codex, `codex.rate_limits`) consolidan como fuente
+// /usage`) y #4868/#4863 (Codex, `rate_limits` local; fuente migrada a los
+// rollouts JSONL por #4885) consolidan como fuente
 // única. Un falso positivo por substring (issue cuyo body menciona "quota
 // exhausted") marcaba anthropic agotado siendo falso y bloqueaba todo el
 // dispatch.

--- a/.pipeline/process-transitions.jsonl
+++ b/.pipeline/process-transitions.jsonl
@@ -61,3 +61,17 @@
 {"ts":"2026-07-23T23:17:09.486Z","service":"svc-drive","from":"dead","to":"alive","reason":"recovered","lastError":""}
 {"ts":"2026-07-23T23:17:09.486Z","service":"svc-reconciler","from":"dead","to":"alive","reason":"recovered","lastError":""}
 {"ts":"2026-07-23T23:17:09.486Z","service":"dashboard","from":"dead","to":"alive","reason":"recovered","lastError":""}
+{"ts":"2026-07-24T02:23:50.252Z","service":"pulpo","from":"alive","to":"dead","reason":"unknown","lastError":""}
+{"ts":"2026-07-24T02:23:50.252Z","service":"listener","from":"alive","to":"dead","reason":"unknown","lastError":""}
+{"ts":"2026-07-24T02:23:50.252Z","service":"svc-telegram","from":"alive","to":"dead","reason":"unknown","lastError":""}
+{"ts":"2026-07-24T02:23:50.252Z","service":"svc-github","from":"alive","to":"dead","reason":"unknown","lastError":""}
+{"ts":"2026-07-24T02:23:50.252Z","service":"svc-drive","from":"alive","to":"dead","reason":"unknown","lastError":""}
+{"ts":"2026-07-24T02:23:50.252Z","service":"svc-reconciler","from":"alive","to":"dead","reason":"unknown","lastError":""}
+{"ts":"2026-07-24T02:23:50.252Z","service":"dashboard","from":"alive","to":"dead","reason":"unknown","lastError":""}
+{"ts":"2026-07-24T02:24:04.187Z","service":"pulpo","from":"dead","to":"alive","reason":"recovered","lastError":""}
+{"ts":"2026-07-24T02:24:04.187Z","service":"listener","from":"dead","to":"alive","reason":"recovered","lastError":""}
+{"ts":"2026-07-24T02:24:04.187Z","service":"svc-telegram","from":"dead","to":"alive","reason":"recovered","lastError":""}
+{"ts":"2026-07-24T02:24:04.187Z","service":"svc-github","from":"dead","to":"alive","reason":"recovered","lastError":""}
+{"ts":"2026-07-24T02:24:04.187Z","service":"svc-drive","from":"dead","to":"alive","reason":"recovered","lastError":""}
+{"ts":"2026-07-24T02:24:04.187Z","service":"svc-reconciler","from":"dead","to":"alive","reason":"recovered","lastError":""}
+{"ts":"2026-07-24T02:24:04.187Z","service":"dashboard","from":"dead","to":"alive","reason":"recovered","lastError":""}

--- a/.pipeline/runtime-boot.json
+++ b/.pipeline/runtime-boot.json
@@ -1,4 +1,4 @@
 {
-  "sha": "ea72a68e72e3130bb34a79c37efbe7e7b7145c1e",
-  "startedAt": "2026-07-23T23:06:21.203Z"
+  "sha": "5cd5f22e4b147f1b7f037e72dfa427d19b6f367c",
+  "startedAt": "2026-07-24T02:20:34.352Z"
 }

--- a/.pipeline/tests/home-quota-render-4327.test.js
+++ b/.pipeline/tests/home-quota-render-4327.test.js
@@ -147,6 +147,22 @@ test('#4863: mode event eventState "ok" → "sin límite" y proveedor sano', () 
         { mode: 'event', eventState: 'ok', win: 'Roll' });
     assert.match(els[cid + '-pct'].textContent, /sin límite/);
     assert.equal(r.healthy, true);
+
+    const legacyNull = makeCell('openai-codex', 'long');
+    loadWinCellHelper(legacyNull.els)._mzHydrateWinCell('openai-codex', 'long',
+        { mode: 'event', eventState: 'ok', pct: null, win: 'Sem' });
+    assert.match(legacyNull.els[legacyNull.cid + '-pct'].textContent, /sin límite/,
+        'pct null no se coerciona a 0%');
+});
+
+test('#4885: mode event con porcentaje fresco prioriza el porcentaje real', () => {
+    const { cid, els } = makeCell('openai-codex', 'long');
+    const r = loadWinCellHelper(els)._mzHydrateWinCell('openai-codex', 'long',
+        { mode: 'event', eventState: 'ok', eventOk: true, pct: 42, confidence: 'fresh', win: 'Sem' });
+    assert.equal(els[cid + '-pct'].textContent, '42%', 'el porcentaje real no se reemplaza por "sin límite"');
+    assert.ok(!/sin límite/.test(els[cid + '-pct'].textContent));
+    assert.match(els[cid].getAttribute('title'), /42% de uso/);
+    assert.equal(r.healthy, true);
 });
 
 test('#4863: mode event eventState "exhausted" → "tope activo", NO sano', () => {

--- a/.pipeline/views/dashboard/home.js
+++ b/.pipeline/views/dashboard/home.js
@@ -2608,7 +2608,8 @@ function _mzHydrateWinCell(key, slot, b){
 
     // Estado por eventos (Codex): sin barra. #4863 — TRES estados explícitos
     // (CA-4), derivados de la fuente única reconciliada con el banner:
-    //   'ok'        → "✓ sin límite" (dato fresco, sin tope).
+    //   'ok'        → porcentaje real cuando el adapter lo informa; para slices
+    //                 legacy sin porcentaje, "✓ sin límite".
     //   'exhausted' → "tope activo"  (mismo snapshot que el banner de degradación).
     //   'nodata'    → "sin dato"     (stale por inactividad / sin lectura fresca) —
     //                  NUNCA se pinta verde: distingue "sin dato por inactividad"
@@ -2630,6 +2631,18 @@ function _mzHydrateWinCell(key, slot, b){
             return { healthy: false };
         }
         const ok = evState === 'ok';
+        const eventPct = b && b.pct != null && b.pct !== '' && Number.isFinite(Number(b.pct))
+            ? Number(b.pct)
+            : null;
+        if(ok && eventPct != null){
+            if(pctEl) pctEl.textContent = eventPct.toFixed(0) + '%';
+            if(rstEl) rstEl.textContent = '';
+            cell.setAttribute('title', meta.name + ' · ' + (b.win || '')
+                + ': ' + eventPct.toFixed(0) + '% de uso (dato fresco · fuente ' + meta.src + ').');
+            cell.setAttribute('aria-label', meta.name + ' ' + (b.win || '')
+                + ': ' + eventPct.toFixed(0) + '% de uso');
+            return { healthy: true };
+        }
         if(pctEl) pctEl.textContent = ok ? '✓ sin límite' : 'tope activo';
         if(rstEl) rstEl.textContent = '';
         cell.setAttribute('title', ok

--- a/docs/pipeline/cuota-codex-fuente-unica.md
+++ b/docs/pipeline/cuota-codex-fuente-unica.md
@@ -9,11 +9,13 @@ El cálculo de cuota de Codex tenía **dos subsistemas que no se hablaban**, y e
 dashboard se contradecía a sí mismo:
 
 - **Tarjeta "cuota por proveedor"** (medición real): el adapter
-  `lib/quota-adapters/openai-codex.js` lee el uso real que Codex persiste en su
-  log local (`~/.codex/logs_2.sqlite`, eventos `codex.rate_limits`, equivalente a
-  su `/status`). Cero inferencia, cero HTTP. Regla de frescura: si el último
-  evento es de hace **>1h** (Codex inactivo) devuelve `adapterStatus:'unknown'` /
-  `pct:null`.
+  `lib/quota-adapters/openai-codex.js` lee el uso real que Codex persiste
+  localmente (equivalente a su `/status`). Cero inferencia, cero HTTP. Regla de
+  frescura: si el último evento es de hace **>1h** (Codex inactivo) devuelve
+  `adapterStatus:'unknown'` / `pct:null`.
+  > **Actualizado por #4885:** la fuente local cambió con Codex v0.145.0 — ya no
+  > es el SQLite `~/.codex/logs_2.sqlite` sino los rollouts JSONL de sesión.
+  > Ver §3.1.
 - **Banner de degradación** (arriba): lee el flag `.pipeline/quota-exhausted.json`
   (escrito por `detectQuotaExhausted()` cuando un spawn real falla por límite).
   Fuente totalmente distinta.
@@ -60,14 +62,70 @@ if (q === 'critical' || _isProviderExhausted(provider, opts)) {
 Se distingue explícitamente **"sin dato por inactividad"** de **"sin límite"** y
 de **"cuota agotada"** (CA-4).
 
+## 3.1. Fuente local del dato (actualizada por #4885 — Codex v0.145.0)
+
+Codex **v0.145.0 cambió dónde persiste la cuota**. El adapter se actualizó para
+seguir el dato; la disciplina de fuente única y el invariante offline no cambian.
+
+| | Antes (Codex < 0.145.0, #4868) | Ahora (Codex ≥ 0.145.0, #4885) |
+|---|---|---|
+| Archivo | `~/.codex/logs_2.sqlite` (tabla `logs`) | `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl` |
+| Evento | `codex.rate_limits` en `feedback_log_body` | `payload.rate_limits` en líneas `event_msg`/`token_count` |
+| Lectura | CLI `sqlite3` vía `execFileSync` | `fs` (sin proceso externo ni dependencia nativa) |
+| Campo de reset | `reset_at` | `resets_at` |
+| Mapeo de ventanas | **posicional**: `primary`=5h, `secondary`=7d | **por `window_minutes`**: `<1440`→sesión, `≥1440`→semanal |
+
+**Por qué el mapeo dejó de ser posicional:** en v0.145.0 el uso **semanal** llega
+en `primary` (`window_minutes: 10080`) con `secondary: null`. Asumir la posición
+mandaba el semanal al bucket de sesión y dejaba el gating/pacing sin dato. La
+ventana es el único discriminante confiable.
+
+Muestra real capturada (v0.145.0):
+
+```json
+{"timestamp":"2026-07-23T19:38:32.183Z","type":"event_msg",
+ "payload":{"type":"token_count","info":{...},
+   "rate_limits":{"limit_id":"codex","limit_name":null,
+     "primary":{"used_percent":1.0,"window_minutes":10080,"resets_at":1785373521},
+     "secondary":null,"plan_type":"plus", ...}}}
+```
+
+**Mecánica de lectura:** se recorren los rollouts del más nuevo al más viejo
+(orden lexicográfico de `YYYY/MM/DD` + nombre prefijado por ISO ⇒ cronológico,
+sin `stat` por archivo, tope de 40 archivos) y se toma el **último** objeto
+`rate_limits` del primer rollout que tenga uno. Se lee sólo la **cola** del
+archivo (512 KB) para no cargar rollouts grandes; las líneas partidas por el
+corte fallan el `JSON.parse` y se descartan.
+
+**Frescura:** anclada al `timestamp` del evento en el JSONL. Un evento sin
+timestamp, o fechado **en el futuro** más allá de 5 min (clock skew / timestamp
+corrupto), degrada a `unknown` — una edad negativa atravesaría el chequeo de
+staleness y mostraría como fresco un dato no confiable.
+
+**Override:** `CODEX_SESSIONS_DIR` (env) reemplaza a `CODEX_QUOTA_LOG_PATH`, que
+quedó obsoleto junto con la fuente SQLite (también `CODEX_SQLITE3_BIN`).
+
+> **Consecuencia operativa:** el reconcile de cuota (#4865) vuelve a recibir dato
+> real de Codex. Los tests que ejercitan `setFlag` deben fijar
+> `CODEX_SESSIONS_DIR` a un path inexistente para no depender del estado real de
+> la máquina (si Codex reporta cuota sobrante, el reconcile vetea el flag).
+
 ## 3. Probe / dato fresco tras inactividad (CA-3)
 
-**Estado actual: fail-safe SQLite-only.** Tras >1h sin eventos, la tarjeta
+> **Nota #4885:** el dilema de abajo era sobre **de dónde sacar el dato**. Con
+> v0.145.0 el dato **sigue persistiéndose localmente** (rollouts, §3.1), así que
+> **no hace falta probe ni canal HTTP** para leerlo: el invariante offline se
+> mantiene. Lo que sigue vigente es el problema de **inactividad** (si Codex no
+> corre, no hay evento nuevo y el dato envejece), y para eso la política sigue
+> siendo la de esta sección.
+
+**Estado actual: fail-safe, sin probe.** Tras >1h sin eventos, la tarjeta
 muestra **"sin dato"** (no un % viejo, no "sin límite" espurio). El síntoma que
 motivó el issue —el verde espurio por inactividad— queda **eliminado**.
 
-Refrescar el `codex.rate_limits` real de forma proactiva requiere una de dos
-rutas, ambas con costo, y la **decisión de arquitectura sigue abierta**:
+Refrescar el `rate_limits` real de forma proactiva **tras un período de
+inactividad** requiere una de dos rutas, ambas con costo, y la **decisión de
+arquitectura sigue abierta**:
 
 1. **`codex exec` mínimo** (prompt trivial hardcodeado): escribe un evento fresco
    pero **consume tokens** (un turn completo). Requiere medir el costo real y
@@ -140,6 +198,15 @@ al alcanzar el límite lo **quemaría en días**. Es un anti-patrón operacional
 - `views/dashboard/home.js` — `_mzHydrateWinCell`: render de `ok`/`exhausted`/`nodata`.
 - Tests: `tests/provider-quota-codex-reconcile-4863.test.js`,
   `tests/home-quota-render-4327.test.js` (casos #4863).
+
+**#4885 (migración a rollouts JSONL):**
+
+- `lib/quota-adapters/openai-codex.js` — lectura de rollouts JSONL, clasificación
+  por `window_minutes`, `resets_at`, guard de evento futuro.
+- `lib/quota-adapters/index.js` — doc del contrato (`codexSessionsDir`).
+- Tests: `lib/__tests__/quota-adapters/openai-codex.test.js` (reescrito),
+  `lib/__tests__/dashboard-slices-kpis.test.js` y
+  `lib/__tests__/quota-exhausted.test.js` (hermeticidad vía `CODEX_SESSIONS_DIR`).
 
 ## 7. Trabajo diferido (issues de recomendación)
 

--- a/docs/pipeline/cuota-codex-fuente-unica.md
+++ b/docs/pipeline/cuota-codex-fuente-unica.md
@@ -90,12 +90,14 @@ Muestra real capturada (v0.145.0):
      "secondary":null,"plan_type":"plus", ...}}}
 ```
 
-**Mecánica de lectura:** se recorren los rollouts del más nuevo al más viejo
-(orden lexicográfico de `YYYY/MM/DD` + nombre prefijado por ISO ⇒ cronológico,
-sin `stat` por archivo, tope de 40 archivos) y se toma el **último** objeto
-`rate_limits` del primer rollout que tenga uno. Se lee sólo la **cola** del
-archivo (512 KB) para no cargar rollouts grandes; las líneas partidas por el
-corte fallan el `JSON.parse` y se descartan.
+**Mecánica de lectura:** se inspeccionan hasta 40 rollouts, ordenados del más
+nuevo al más viejo por `YYYY/MM/DD` + nombre prefijado por ISO (sin `stat` por
+archivo). De cada rollout se obtiene su **último** objeto `rate_limits`; luego
+se comparan los timestamps internos de esos eventos y se elige el máximo
+global. Así, una sesión anterior que siga activa o sea reanudada puede superar
+a otra cuyo archivo tenga un nombre más reciente. Se lee sólo la **cola** de
+cada archivo (512 KB) para no cargar rollouts grandes; las líneas partidas por
+el corte fallan el `JSON.parse` y se descartan.
 
 **Frescura:** anclada al `timestamp` del evento en el JSONL. Un evento sin
 timestamp, o fechado **en el futuro** más allá de 5 min (clock skew / timestamp

--- a/docs/pipeline/cuota-codex-fuente-unica.md
+++ b/docs/pipeline/cuota-codex-fuente-unica.md
@@ -106,9 +106,35 @@ staleness y mostraría como fresco un dato no confiable.
 quedó obsoleto junto con la fuente SQLite (también `CODEX_SQLITE3_BIN`).
 
 > **Consecuencia operativa:** el reconcile de cuota (#4865) vuelve a recibir dato
-> real de Codex. Los tests que ejercitan `setFlag` deben fijar
-> `CODEX_SESSIONS_DIR` a un path inexistente para no depender del estado real de
-> la máquina (si Codex reporta cuota sobrante, el reconcile vetea el flag).
+> real de Codex. Los tests que ejercitan `setFlag` **o** `shouldGateSpawn` deben
+> fijar `CODEX_SESSIONS_DIR` a un path inexistente para no depender del estado
+> real de la máquina (si Codex reporta cuota sobrante, el reconcile vetea el
+> flag).
+
+### 3.1.1. Hermeticidad de los tests que reconcilian (regresión #4885)
+
+`PIPELINE_DIR_OVERRIDE` aísla el estado del pipeline, pero **no** los rollouts:
+viven en `~/.codex/sessions`, fuera del árbol del repo. Mientras la fuente era el
+SQLite (que en v0.145.0 ya no trae `used_percent`) el adapter siempre devolvía
+degradado y ningún test lo notaba. Al restaurar la lectura real, toda suite que
+escriba `quota-exhausted.json` y espere que el gate lo **honre** empezó a
+depender de si el operador usó Codex hace poco: con Codex fresco al 2% el
+reconcile vetea el gate (`provider_healthy_fresh`) y Codex resuelve como sano.
+
+Suites afectadas y ya blindadas (setean `CODEX_SESSIONS_DIR` a un dir vacío del
+tmp dentro de su helper `withTempPipeline`):
+
+| Suite | Qué asumía |
+|---|---|
+| `lib/agent-launcher/__tests__/dispatch-billing-flag.test.js` | Anthropic+Codex gateados ⇒ el fallback resuelve `cerebras` |
+| `lib/commander/__tests__/reduced-mode.test.js` | "todos los pagos gateados" ⇒ `isReducedMode=true` |
+| `lib/__tests__/quota-exhausted.test.js` | `setFlag` persiste sin veto |
+
+Regla para tests nuevos: **si el test escribe el flag de cuota y espera que se
+honre, apuntá `CODEX_SESSIONS_DIR` a un dir vacío.** Sin dato canónico el
+reconcile es fail-closed y manda el flag — que es el mundo que el test describe.
+La precedencia del origen (`codexSessionsDir` explícito → env → default) está
+cubierta por tests en `lib/__tests__/quota-adapters/openai-codex.test.js`.
 
 ## 3. Probe / dato fresco tras inactividad (CA-3)
 


### PR DESCRIPTION
## Resumen
- Migra la cuota de Codex a los rollouts JSONL de v0.145.0.
- Selecciona el evento `rate_limits` globalmente más reciente entre sesiones concurrentes o reanudadas.
- Agrega una regresión que reproduce 11:05/pct=20 vs 12:00/pct=80.

## Checklist
- [x] Base del PR en `main`.
- [x] Título con formato `[auto] ... (Closes #4885)`.
- [x] Cuerpo incluye `Closes #4885`.
- [x] PR asignado a @leitolarreta.

## Evidencias
- Tests: `node --test .pipeline/lib/__tests__/quota-adapters/openai-codex.test.js` — 27 pass, 0 fail.
- Smoke: `C:\Program Files\Git\bin\bash.exe .pipeline/smoke-test.sh` — OK (pulpo/dashboard/svc-telegram, HTTP 200).
- Gradle: `gradlew.bat check --no-daemon` alcanzó tests Kotlin y falló fuera del alcance en `DeliveryViewModelsTest.kt` por `FakeResetCache`/`ToDoResetLoginCache` y `MessageKey` no resuelto.

Closes #4885