### PR TITLE
Bug: reconciliador de Telegram reenvía audios duplicados al reintentar un mensaje con entrega fallida

### DIFF
--- a/.pipeline/lib/__tests__/voice-parts-dedup-4903.test.js
+++ b/.pipeline/lib/__tests__/voice-parts-dedup-4903.test.js
@@ -1,0 +1,212 @@
+// =============================================================================
+// Tests de deduplicación cross-retry de audios (#4903)
+//
+// Cubre los 2 escenarios Gherkin del issue #4903:
+//   (a) Un mensaje con texto + N audios cuya confirmación de entrega falla (pero
+//       cuyos audios ya llegaron) reintenta reenviando solo el texto, sin duplicar
+//       audios → al re-despachar el mismo audio (mismo dedupeKey), TODAS las partes
+//       se detectan ya-entregadas y NO se reenvía ninguna.
+//   (b) Un mensaje que efectivamente no llegó (nada entregado) sí se reenvía
+//       completo → sin estado previo confirmado, `findDeliveredParts` no encuentra
+//       nada y las partes se reenvían.
+//
+// Testea el módulo puro/DI `voice-parts.js` (la dedup en `dispatchVoiceParts` de
+// `pulpo.js` es un wrapper delgado sobre estas funciones). Sin credenciales, sin red.
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const vp = require('../voice-parts');
+
+function sandbox() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'voice-dedup-'));
+}
+
+// -----------------------------------------------------------------------------
+// computeDedupeKey — estable por (chat, texto), robusto a whitespace, null si vacío
+// -----------------------------------------------------------------------------
+test('computeDedupeKey: mismo (chat, texto) → misma key (sobrevive al reintento)', () => {
+  const a = vp.computeDedupeKey({ chatId: 55, text: 'Hola, estas son tus opciones' });
+  const b = vp.computeDedupeKey({ chatId: 55, text: 'Hola,   estas son   tus opciones ' });
+  assert.equal(a, b, 'normaliza whitespace: el reintento del mismo turno matchea');
+  assert.ok(/^vk_[0-9a-f]{32}$/.test(a), 'formato de key');
+});
+
+test('computeDedupeKey: distinto chat o texto → distinta key', () => {
+  const base = vp.computeDedupeKey({ chatId: 55, text: 'X' });
+  assert.notEqual(base, vp.computeDedupeKey({ chatId: 56, text: 'X' }), 'chat distinto');
+  assert.notEqual(base, vp.computeDedupeKey({ chatId: 55, text: 'Y' }), 'texto distinto');
+});
+
+test('computeDedupeKey: texto vacío o solo-espacios → null (no deduplica basura)', () => {
+  assert.equal(vp.computeDedupeKey({ chatId: 55, text: '' }), null);
+  assert.equal(vp.computeDedupeKey({ chatId: 55, text: '   ' }), null);
+  assert.equal(vp.computeDedupeKey({ chatId: 55, text: null }), null);
+});
+
+// -----------------------------------------------------------------------------
+// isFullyDelivered / confirmedIndexes — puros
+// -----------------------------------------------------------------------------
+test('isFullyDelivered: true sólo cuando TODAS las partes están confirmadas', () => {
+  const s = vp.buildInitialState({ correlationId: 'voice-f-abcdef', partTotal: 2, chatId: 9,
+    parts: [{ partIndex: 0, path: '/a' }, { partIndex: 1, path: '/b' }], now: 1000 });
+  assert.equal(vp.isFullyDelivered(s), false, 'ninguna confirmada');
+  vp.applyConfirmation(s, 0);
+  assert.equal(vp.isFullyDelivered(s), false, 'parcial');
+  vp.applyConfirmation(s, 1);
+  assert.equal(vp.isFullyDelivered(s), true, 'todas confirmadas');
+});
+
+test('confirmedIndexes: devuelve los índices confirmados', () => {
+  const s = vp.buildInitialState({ correlationId: 'voice-g-abcdef', partTotal: 3, chatId: 9,
+    parts: [{ partIndex: 0 }, { partIndex: 1 }, { partIndex: 2 }], now: 1000 });
+  vp.applyConfirmation(s, 0);
+  vp.applyConfirmation(s, 2);
+  assert.deepEqual([...vp.confirmedIndexes(s)].sort(), [0, 2]);
+});
+
+// -----------------------------------------------------------------------------
+// buildInitialState: persiste dedupeKey y respeta parts pre-confirmadas
+// -----------------------------------------------------------------------------
+test('buildInitialState: guarda dedupeKey y confirmed inicial por parte', () => {
+  const s = vp.buildInitialState({ correlationId: 'voice-h-abcdef', partTotal: 2, chatId: 9,
+    parts: [{ partIndex: 0, confirmed: true }, { partIndex: 1 }], now: 1000, dedupeKey: 'vk_deadbeef' });
+  assert.equal(s.dedupeKey, 'vk_deadbeef');
+  assert.equal(s.parts['0'].confirmed, true, 'parte pre-confirmada (ya entregada)');
+  assert.equal(s.parts['1'].confirmed, false);
+  assert.equal(vp.isValidState(s), true, 'estado con dedupeKey sigue siendo válido');
+});
+
+test('isValidState: dedupeKey no-string → inválido (fail-closed); ausente → válido', () => {
+  const base = { correlationId: 'voice-i-abcdef', partTotal: 1, parts: {} };
+  assert.equal(vp.isValidState(base), true, 'sin dedupeKey: backward-compat');
+  assert.equal(vp.isValidState({ ...base, dedupeKey: 42 }), false, 'número no vale');
+  assert.equal(vp.isValidState({ ...base, dedupeKey: '' }), false, 'vacío no vale');
+  assert.equal(vp.isValidState({ ...base, dedupeKey: 'vk_x' }), true);
+});
+
+// -----------------------------------------------------------------------------
+// findDeliveredParts — consolida entregas por dedupeKey en activos + archivados
+// -----------------------------------------------------------------------------
+test('findDeliveredParts: encuentra partes confirmadas del estado activo por dedupeKey', () => {
+  const dir = sandbox();
+  const key = vp.computeDedupeKey({ chatId: 55, text: 'respuesta con audios' });
+  vp.initState({ pipelineDir: dir, correlationId: 'voice-p1-abcdef', partTotal: 2, chatId: 55,
+    parts: [{ partIndex: 0, path: '/0' }, { partIndex: 1, path: '/1' }], now: 100000, dedupeKey: key });
+  vp.recordPartConfirmation({ pipelineDir: dir, correlationId: 'voice-p1-abcdef', partIndex: 0 });
+  vp.recordPartConfirmation({ pipelineDir: dir, correlationId: 'voice-p1-abcdef', partIndex: 1 });
+
+  const res = vp.findDeliveredParts({ pipelineDir: dir, dedupeKey: key, now: 110000, ttlMs: 86400000 });
+  assert.equal(res.found, true);
+  assert.equal(res.partTotal, 2);
+  assert.deepEqual([...res.confirmed].sort(), [0, 1], 'ambas partes ya entregadas');
+});
+
+test('findDeliveredParts: también lee estados ARCHIVADOS (el turno previo se cerró/archivó)', () => {
+  const dir = sandbox();
+  const key = vp.computeDedupeKey({ chatId: 55, text: 'ya archivado' });
+  vp.initState({ pipelineDir: dir, correlationId: 'voice-p2-abcdef', partTotal: 2, chatId: 55,
+    parts: [{ partIndex: 0, path: '/0' }, { partIndex: 1, path: '/1' }], now: 100000, dedupeKey: key });
+  vp.recordPartConfirmation({ pipelineDir: dir, correlationId: 'voice-p2-abcdef', partIndex: 0 });
+  vp.recordPartConfirmation({ pipelineDir: dir, correlationId: 'voice-p2-abcdef', partIndex: 1 });
+  // Cerramos el turno: el sweep archiva el estado (todas confirmadas → terminal).
+  const swept = vp.sweepVoiceStates({ pipelineDir: dir, now: 110000,
+    config: { max_retries: 3, backoff_base_ms: 5000, backoff_max_ms: 300000, stale_ttl_ms: 86400000 },
+    enqueue: () => {}, notify: () => {} });
+  assert.equal(swept.closed, 1, 'el estado se archivó');
+  assert.equal(fs.existsSync(vp.statePath(vp.voicePartsDir(dir), 'voice-p2-abcdef')), false);
+
+  const res = vp.findDeliveredParts({ pipelineDir: dir, dedupeKey: key, now: 120000, ttlMs: 86400000 });
+  assert.equal(res.found, true, 'lo encuentra en archivado');
+  assert.deepEqual([...res.confirmed].sort(), [0, 1]);
+});
+
+test('findDeliveredParts: dedupeKey distinto → no matchea (respuesta diferente se reenvía)', () => {
+  const dir = sandbox();
+  const key = vp.computeDedupeKey({ chatId: 55, text: 'A' });
+  vp.initState({ pipelineDir: dir, correlationId: 'voice-p3-abcdef', partTotal: 1, chatId: 55,
+    parts: [{ partIndex: 0, path: '/0' }], now: 100000, dedupeKey: key });
+  vp.recordPartConfirmation({ pipelineDir: dir, correlationId: 'voice-p3-abcdef', partIndex: 0 });
+
+  const other = vp.computeDedupeKey({ chatId: 55, text: 'B' });
+  const res = vp.findDeliveredParts({ pipelineDir: dir, dedupeKey: other, now: 110000, ttlMs: 86400000 });
+  assert.equal(res.found, false, 'otra respuesta → no dedup');
+  assert.equal(res.confirmed.size, 0);
+});
+
+test('findDeliveredParts: fuera de la ventana ttl → se ignora (no dedup infinito)', () => {
+  const dir = sandbox();
+  const key = vp.computeDedupeKey({ chatId: 55, text: 'viejo' });
+  vp.initState({ pipelineDir: dir, correlationId: 'voice-p4-abcdef', partTotal: 1, chatId: 55,
+    parts: [{ partIndex: 0, path: '/0' }], now: 100000, dedupeKey: key });
+  vp.recordPartConfirmation({ pipelineDir: dir, correlationId: 'voice-p4-abcdef', partIndex: 0 });
+
+  const res = vp.findDeliveredParts({ pipelineDir: dir, dedupeKey: key, now: 100000 + 86400000 + 1, ttlMs: 86400000 });
+  assert.equal(res.found, false, 'fuera de ttl → ignorado');
+});
+
+test('findDeliveredParts: solo partes NO confirmadas → confirmed vacío (nada que dedupear)', () => {
+  const dir = sandbox();
+  const key = vp.computeDedupeKey({ chatId: 55, text: 'no entregado' });
+  vp.initState({ pipelineDir: dir, correlationId: 'voice-p5-abcdef', partTotal: 2, chatId: 55,
+    parts: [{ partIndex: 0, path: '/0' }, { partIndex: 1, path: '/1' }], now: 100000, dedupeKey: key });
+  // Ninguna confirma (el mensaje no llegó).
+  const res = vp.findDeliveredParts({ pipelineDir: dir, dedupeKey: key, now: 110000, ttlMs: 86400000 });
+  assert.equal(res.found, true, 'existe el estado');
+  assert.equal(res.confirmed.size, 0, 'pero nada entregado → se reenviará completo');
+});
+
+// -----------------------------------------------------------------------------
+// Escenario Gherkin (a): confirmación falló pero audios llegaron → dedup total
+// -----------------------------------------------------------------------------
+test('Gherkin (a): reintento con audios ya entregados → 0 partes a reenviar', () => {
+  const dir = sandbox();
+  const key = vp.computeDedupeKey({ chatId: 55, text: 'texto + 2 audios' });
+  // Pasada 1: 2 audios, ambos entregados (recibos `enviado`).
+  vp.initState({ pipelineDir: dir, correlationId: 'voice-a1-abcdef', partTotal: 2, chatId: 55,
+    parts: [{ partIndex: 0, path: '/0' }, { partIndex: 1, path: '/1' }], now: 100000, dedupeKey: key });
+  vp.recordPartConfirmation({ pipelineDir: dir, correlationId: 'voice-a1-abcdef', partIndex: 0 });
+  vp.recordPartConfirmation({ pipelineDir: dir, correlationId: 'voice-a1-abcdef', partIndex: 1 });
+
+  // Reintento del turno (misma respuesta): ¿qué partes hay que reenviar?
+  const delivered = vp.findDeliveredParts({ pipelineDir: dir, dedupeKey: key, now: 110000, ttlMs: 86400000 });
+  const partTotal = 2;
+  const toResend = [];
+  for (let i = 0; i < partTotal; i++) if (!delivered.confirmed.has(i)) toResend.push(i);
+  assert.deepEqual(toResend, [], 'no se reenvía ningún audio (solo faltaba el texto)');
+});
+
+// -----------------------------------------------------------------------------
+// Escenario Gherkin (b): nada entregado → se reenvía completo
+// -----------------------------------------------------------------------------
+test('Gherkin (b): mensaje que no llegó → se reenvían todas las partes', () => {
+  const dir = sandbox();
+  const key = vp.computeDedupeKey({ chatId: 55, text: 'texto + 1 audio no entregado' });
+  // No hay estado previo alguno para este dedupeKey.
+  const delivered = vp.findDeliveredParts({ pipelineDir: dir, dedupeKey: key, now: 110000, ttlMs: 86400000 });
+  const partTotal = 2;
+  const toResend = [];
+  for (let i = 0; i < partTotal; i++) if (!delivered.confirmed.has(i)) toResend.push(i);
+  assert.deepEqual(toResend, [0, 1], 'se reenvía texto + audio completos');
+});
+
+// -----------------------------------------------------------------------------
+// Dedup PARCIAL: solo 1 de 2 audios llegó → se reenvía únicamente el faltante
+// -----------------------------------------------------------------------------
+test('dedup parcial: 1 de 2 audios entregado → solo se reenvía el faltante (idempotente)', () => {
+  const dir = sandbox();
+  const key = vp.computeDedupeKey({ chatId: 55, text: 'parcial' });
+  vp.initState({ pipelineDir: dir, correlationId: 'voice-pp-abcdef', partTotal: 2, chatId: 55,
+    parts: [{ partIndex: 0, path: '/0' }, { partIndex: 1, path: '/1' }], now: 100000, dedupeKey: key });
+  vp.recordPartConfirmation({ pipelineDir: dir, correlationId: 'voice-pp-abcdef', partIndex: 1 }); // solo la 2da
+
+  const delivered = vp.findDeliveredParts({ pipelineDir: dir, dedupeKey: key, now: 110000, ttlMs: 86400000 });
+  const toResend = [];
+  for (let i = 0; i < 2; i++) if (!delivered.confirmed.has(i)) toResend.push(i);
+  assert.deepEqual(toResend, [0], 'solo se reenvía la parte 0 (la 1 ya llegó)');
+});

--- a/.pipeline/lib/voice-parts.js
+++ b/.pipeline/lib/voice-parts.js
@@ -76,7 +76,87 @@ function isValidState(obj) {
   if (!rec.isValidCorrelationId(obj.correlationId)) return false;
   if (!Number.isInteger(obj.partTotal) || obj.partTotal < 1) return false;
   if (!obj.parts || typeof obj.parts !== 'object') return false;
+  // #4903 — `dedupeKey` es OPCIONAL (backward-compat con estados previos que no lo
+  // llevan). Si está presente debe ser string no vacío; cualquier otra cosa → inválido.
+  if (obj.dedupeKey != null && (typeof obj.dedupeKey !== 'string' || obj.dedupeKey.length === 0)) return false;
   return true;
+}
+
+// -----------------------------------------------------------------------------
+// #4903 — Deduplicación cross-retry de audios ya entregados.
+//
+// Problema (incidente real cmd-1784896035259-a7b1accb): cuando la confirmación de
+// entrega de un turno falla pero los audios SÍ llegaron, el reintento re-despacha
+// la respuesta completa con un `correlationId` NUEVO — el estado fresco no conoce
+// las partes ya entregadas y las reenvía → el usuario recibe la misma serie de
+// audios 2-3 veces.
+//
+// Fix: atar el audio a una IDENTIDAD ESTABLE de la respuesta que sobreviva al
+// reintento (el `correlationId` cambia por dispatch; el texto verificado no). El
+// audio es TTS del texto de respuesta → misma (chat, texto) ⇒ mismo audio lógico,
+// mismo split de chunks ⇒ mismos `partIndex`. Antes de reenviar, se consultan los
+// estados (activos + archivados) con el mismo `dedupeKey` y se omiten las partes
+// ya confirmadas (entregadas). PURA.
+// -----------------------------------------------------------------------------
+function computeDedupeKey({ chatId, text }) {
+  const norm = String(text == null ? '' : text).replace(/\s+/g, ' ').trim();
+  if (norm.length === 0) return null;
+  const h = crypto.createHash('sha256').update(`${chatId == null ? '' : chatId}\n${norm}`).digest('hex');
+  return `vk_${h.slice(0, 32)}`;
+}
+
+// isFullyDelivered — PURA: todas las partes registradas están confirmadas y hay al
+// menos `partTotal` partes registradas (respuesta entregada completa).
+function isFullyDelivered(state) {
+  if (!isValidState(state)) return false;
+  for (let i = 0; i < state.partTotal; i++) {
+    const p = state.parts[String(i)];
+    if (!p || !p.confirmed) return false;
+  }
+  return true;
+}
+
+// confirmedIndexes — PURA: Set de índices de parte confirmados en un estado.
+function confirmedIndexes(state) {
+  const out = new Set();
+  if (!state || !state.parts || typeof state.parts !== 'object') return out;
+  for (const [k, p] of Object.entries(state.parts)) {
+    if (p && p.confirmed) {
+      const n = Number(k);
+      if (Number.isInteger(n) && n >= 0) out.add(n);
+    }
+  }
+  return out;
+}
+
+// findDeliveredParts — I/O acotado: busca en estados ACTIVOS + ARCHIVADOS los que
+// comparten `dedupeKey` dentro de la ventana `ttlMs` y consolida qué índices de
+// parte ya fueron entregados (confirmados). Base de la deduplicación cross-retry:
+// al reintentar un turno, los audios ya entregados no se reenvían (CA-1/CA-2). Un
+// `dedupeKey` fuera de ventana o inexistente → `{ found:false, confirmed:∅ }`.
+function findDeliveredParts({ pipelineDir, dedupeKey, now, ttlMs }) {
+  const res = { found: false, partTotal: 0, confirmed: new Set() };
+  if (!dedupeKey || typeof dedupeKey !== 'string') return res;
+  const nowMs = Number.isFinite(now) ? now : Date.now();
+  const ttl = Number.isFinite(ttlMs) ? ttlMs : 86400000;
+  const dirs = [voicePartsDir(pipelineDir), archivedVoicePartsDir(pipelineDir)];
+  for (const dir of dirs) {
+    let files;
+    try {
+      files = fs.readdirSync(dir).filter((f) => !f.startsWith('.') && f.endsWith('.json'));
+    } catch { continue; }
+    for (const f of files) {
+      let obj;
+      try { obj = JSON.parse(fs.readFileSync(path.join(dir, f), 'utf8')); } catch { continue; }
+      if (!isValidState(obj) || obj.dedupeKey !== dedupeKey) continue;
+      const createdMs = Date.parse(obj.createdAt);
+      if (Number.isFinite(createdMs) && (nowMs - createdMs) > ttl) continue; // fuera de ventana
+      res.found = true;
+      if (obj.partTotal > res.partTotal) res.partTotal = obj.partTotal;
+      for (const idx of confirmedIndexes(obj)) res.confirmed.add(idx);
+    }
+  }
+  return res;
 }
 
 function readState(dir, correlationId) {
@@ -114,7 +194,7 @@ function archiveState(dir, archivedDir, correlationId) {
 // initState — crea el estado al producir la respuesta de voz. `parts` es
 // `[{ partIndex, path, enqueuedAt? }]`. Persiste y devuelve el estado.
 // -----------------------------------------------------------------------------
-function buildInitialState({ correlationId, partTotal, chatId, parts, now }) {
+function buildInitialState({ correlationId, partTotal, chatId, parts, now, dedupeKey }) {
   if (!rec.isValidCorrelationId(correlationId)) {
     throw new Error(`voice-parts: correlationId inválido: ${JSON.stringify(correlationId)}`);
   }
@@ -131,6 +211,8 @@ function buildInitialState({ correlationId, partTotal, chatId, parts, now }) {
     notified: false,
     parts: {},
   };
+  // #4903 — identidad estable de la respuesta para dedup cross-retry (opcional).
+  if (typeof dedupeKey === 'string' && dedupeKey.length > 0) state.dedupeKey = dedupeKey;
   for (const p of (parts || [])) {
     const idx = rec.coercePartInt(p.partIndex);
     if (idx == null || idx >= pt) continue; // acotado (SEC-R2)
@@ -138,14 +220,16 @@ function buildInitialState({ correlationId, partTotal, chatId, parts, now }) {
       path: typeof p.path === 'string' ? p.path : null,
       enqueuedAt: typeof p.enqueuedAt === 'string' && p.enqueuedAt.length > 0 ? p.enqueuedAt : createdAt,
       retries: 0,
-      confirmed: false,
+      // #4903 — una parte puede nacer ya `confirmed` cuando se sabe que fue
+      // entregada en una pasada anterior (dedup): no se reenvía, solo se contabiliza.
+      confirmed: p.confirmed === true,
     };
   }
   return state;
 }
 
-function initState({ pipelineDir, correlationId, partTotal, chatId, parts, now }) {
-  const state = buildInitialState({ correlationId, partTotal, chatId, parts, now });
+function initState({ pipelineDir, correlationId, partTotal, chatId, parts, now, dedupeKey }) {
+  const state = buildInitialState({ correlationId, partTotal, chatId, parts, now, dedupeKey });
   writeState(voicePartsDir(pipelineDir), state);
   return state;
 }
@@ -376,4 +460,9 @@ module.exports = {
   planSweep,
   formatMissingNotice,
   sweepVoiceStates,
+  // #4903 — dedup cross-retry
+  computeDedupeKey,
+  isFullyDelivered,
+  confirmedIndexes,
+  findDeliveredParts,
 };

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -15216,9 +15216,20 @@ INSTRUCCIÓN: Reelaborá tu respuesta tomando en cuenta las contradicciones dete
               prevProvider = finalProvider;
             }
             if (voiceBuffers.length > 0) {
-              const { correlationId: voiceCid, enqueued } = dispatchVoiceParts(voiceBuffers, chatId, path.join(LOG_DIR, 'media'));
-              enviado = enqueued > 0;
-              if (enviado) log('telegram', `[chat] ${enqueued} parte(s) de audio encoladas con recibo por chunk (cid=${voiceCid})`);
+              // #4903 — dedupeKey estable por (chat, texto de respuesta): el audio es
+              // TTS del `outboundText` ya verificado, así que sobrevive al reintento del
+              // turno (el correlationId cambia por dispatch; el texto no). Permite omitir
+              // audios ya entregados cuando solo falló la confirmación de entrega del texto.
+              const voiceDedupeKey = voiceParts.computeDedupeKey({ chatId, text: outboundText });
+              const { correlationId: voiceCid, enqueued, skipped } = dispatchVoiceParts(
+                voiceBuffers, chatId, path.join(LOG_DIR, 'media'), { dedupeKey: voiceDedupeKey });
+              // Voz entregada si se encoló algo nuevo O si ya estaba entregada (dedup).
+              enviado = enqueued > 0 || skipped > 0;
+              if (enqueued > 0) {
+                log('telegram', `[chat] ${enqueued} parte(s) de audio encoladas con recibo por chunk (cid=${voiceCid})${skipped > 0 ? `, ${skipped} omitida(s) por ya-entregadas` : ''}`);
+              } else if (skipped > 0) {
+                log('telegram', `[chat] audio ya entregado en pasada anterior: ${skipped} parte(s) omitidas por dedup, sin reenvío (CA-1 #4903)`);
+              }
             }
             // EP1-H4 (#3919, CA-2): aviso consolidado de degradación TTS. Solo si
             // se esperaba voz (esAudio) y hubo al menos un chunk fallido. Pasa por
@@ -15469,16 +15480,47 @@ function enqueueTelegramVoice(audioPath, opts = {}) {
 // acoplar TTS acá) como `[{ buffer, spokenLabel? }]` y devuelve el correlationId
 // padre + cuántas partes se encolaron. El estado de contabilidad se persiste
 // para que el sweep de reconciliación detecte/reenvíe faltantes.
-function dispatchVoiceParts(buffers, chatId, mediaDir) {
-  if (!Array.isArray(buffers) || buffers.length === 0) return { correlationId: null, enqueued: 0 };
-  const correlationId = telegramReceipt.generateCorrelationId('voice');
+function dispatchVoiceParts(buffers, chatId, mediaDir, opts = {}) {
+  if (!Array.isArray(buffers) || buffers.length === 0) return { correlationId: null, enqueued: 0, skipped: 0 };
   const partTotal = buffers.length;
   const nowMs = Date.now();
   const nowIso = new Date(nowMs).toISOString();
+
+  // #4903 — Deduplicación cross-retry: si esta MISMA respuesta (mismo `dedupeKey`,
+  // derivado de chat+texto) ya tuvo partes entregadas en una pasada anterior (aun
+  // si la confirmación de entrega del turno falló), NO las reenviamos. El audio es
+  // TTS del texto → mismo texto ⇒ mismo split ⇒ mismos `partIndex`, así que la
+  // dedup por índice es sólida. Distingue "no llegó nada" (delivered.confirmed=∅ →
+  // se reenvía todo) de "la confirmación falló pero el contenido llegó".
+  const dedupeKey = (typeof opts.dedupeKey === 'string' && opts.dedupeKey.length > 0) ? opts.dedupeKey : null;
+  let delivered = { found: false, confirmed: new Set() };
+  if (dedupeKey) {
+    try {
+      const outboundCfg = resolveTelegramOutboundConfig(loadConfig());
+      const ttlMs = Number.isFinite(outboundCfg.stale_ttl_ms) ? outboundCfg.stale_ttl_ms : 86400000;
+      delivered = voiceParts.findDeliveredParts({ pipelineDir: PIPELINE, dedupeKey, now: nowMs, ttlMs });
+    } catch (e) {
+      log('telegram', `[voice] dedup lookup falló (best-effort, se reenvía normal): ${e.message}`);
+    }
+  }
+
+  const correlationId = telegramReceipt.generateCorrelationId('voice');
   try { fs.mkdirSync(mediaDir, { recursive: true }); } catch { /* best-effort */ }
   const stateParts = [];
+  const preConfirmed = [];
   let enqueued = 0;
+  let skipped = 0;
   for (let idx = 0; idx < buffers.length; idx++) {
+    // #4903 — parte ya entregada en una pasada anterior (mismo dedupeKey): se OMITE
+    // el reenvío. Se registra pre-confirmada en el nuevo estado para que el sweep no
+    // la trate como faltante (contabilidad coherente, CA-2).
+    if (delivered.confirmed.has(idx)) {
+      stateParts.push({ partIndex: idx, path: null, enqueuedAt: nowIso, confirmed: true });
+      preConfirmed.push(idx);
+      skipped++;
+      log('telegram', `[voice] parte ${idx + 1}/${partTotal} OMITIDA por ya-entregada en pasada previa (dedup, cid=${correlationId})`);
+      continue;
+    }
     const audioPath = path.join(mediaDir, `tts-${nowMs}-${correlationId}-${idx}.ogg`);
     try {
       fs.writeFileSync(audioPath, buffers[idx].buffer);
@@ -15493,21 +15535,34 @@ function dispatchVoiceParts(buffers, chatId, mediaDir) {
       log('telegram', `Audio TTS parte ${idx + 1}/${partTotal} encolada (recibo por chunk, cid=${correlationId})`);
     }
   }
-  if (enqueued > 0) {
-    try {
-      voiceParts.initState({
-        pipelineDir: PIPELINE,
-        correlationId,
-        partTotal,
-        chatId,
-        parts: stateParts,
-        now: nowMs,
-      });
-    } catch (e) {
-      log('telegram', `[voice] no se pudo inicializar estado de contabilidad (cid=${correlationId}): ${e.message}`);
+
+  // #4903 — Toda la respuesta ya estaba entregada (nada nuevo que encolar): no
+  // creamos estado nuevo ni reenviamos. El texto (que es lo que falló) lo maneja el
+  // caller aparte. Log explícito de qué se omitió (CA-4).
+  if (enqueued === 0) {
+    if (skipped > 0) {
+      log('telegram', `[voice] respuesta ya entregada previamente: ${skipped}/${partTotal} parte(s) omitidas por dedup, sin reenvío (cid=${correlationId})`);
     }
+    return { correlationId: null, enqueued: 0, skipped };
   }
-  return { correlationId, enqueued };
+
+  try {
+    voiceParts.initState({
+      pipelineDir: PIPELINE,
+      correlationId,
+      partTotal,
+      chatId,
+      parts: stateParts,
+      now: nowMs,
+      dedupeKey,
+    });
+    if (preConfirmed.length > 0) {
+      log('telegram', `[voice] ${enqueued} parte(s) encoladas, ${skipped} omitidas por dedup (cid=${correlationId}, dedupeKey=${dedupeKey})`);
+    }
+  } catch (e) {
+    log('telegram', `[voice] no se pudo inicializar estado de contabilidad (cid=${correlationId}): ${e.message}`);
+  }
+  return { correlationId, enqueued, skipped };
 }
 
 // #3484 CA-UX-1 — sendChatActionTyping: refresca el indicador "escribiendo..."


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 3 archivos · +379 -23

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:passed` aplicado por delivery

## Closes

Closes #4903
