### PR TITLE
Ejecución solo por olas: fail-closed cuando no hay allowlist

### DIFF
--- a/.pipeline/lib/__tests__/partial-pause.test.js
+++ b/.pipeline/lib/__tests__/partial-pause.test.js
@@ -28,11 +28,49 @@ test('getPipelineMode retorna running cuando no hay ningún marker', () => {
     assert.deepEqual(state.allowedIssues, []);
 });
 
-test('isIssueAllowed retorna true para cualquier issue cuando pipeline está running', () => {
+// #5060 — ejecución solo por olas. Sin allowlist no hay ola vigente que acote
+// el dispatch, así que el gate deniega en vez de permitir. Antes de este fix
+// devolvía `true` para todo, y eso hizo que al cerrarse la ola 8 el pipeline
+// dispatchara ~100 issues del backlog histórico (incidente 2026-07-26).
+test('isIssueAllowed deniega todo issue cuando no hay allowlist (fail-closed #5060)', () => {
     resetFs();
+    delete process.env.PIPELINE_ALLOW_UNSCOPED_DISPATCH;
+    assert.equal(pp.getPipelineMode().mode, 'running');
+    assert.equal(pp.isIssueAllowed(2490), false);
+    assert.equal(pp.isIssueAllowed('2491'), false);
+    assert.equal(pp.isIssueAllowed('#9999'), false);
+});
+
+test('el escape hatch PIPELINE_ALLOW_UNSCOPED_DISPATCH=1 reabre el dispatch sin ola (#5060)', () => {
+    resetFs();
+    process.env.PIPELINE_ALLOW_UNSCOPED_DISPATCH = '1';
+    try {
+        assert.equal(pp.isIssueAllowed(2490), true);
+        assert.equal(pp.isIssueAllowed('#9999'), true);
+    } finally {
+        delete process.env.PIPELINE_ALLOW_UNSCOPED_DISPATCH;
+    }
+    // Al apagarlo vuelve a fail-closed, sin estado pegajoso entre llamadas.
+    assert.equal(pp.isIssueAllowed(2490), false);
+});
+
+test('allowlist que queda vacía tras la poda no reabre el backlog (#5060)', () => {
+    resetFs();
+    delete process.env.PIPELINE_ALLOW_UNSCOPED_DISPATCH;
+    pp.setPartialPause([2490, 2491], { source: 'telegram' });
     assert.equal(pp.isIssueAllowed(2490), true);
-    assert.equal(pp.isIssueAllowed('2491'), true);
-    assert.equal(pp.isIssueAllowed('#9999'), true);
+    // Esto es exactamente lo que hace la poda convergente #4753 al cerrar la ola.
+    pp.setPartialPause([], { source: 'wave-promote:autoresolve-reductive', authorizedBy: 'wave-promote' });
+    assert.equal(pp.getPipelineMode().mode, 'running');
+    assert.equal(pp.isIssueAllowed(2490), false);
+    assert.equal(pp.isIssueAllowed(9999), false);
+});
+
+test('los skills del control-plane siguen habilitados sin allowlist (#5060)', () => {
+    resetFs();
+    delete process.env.PIPELINE_ALLOW_UNSCOPED_DISPATCH;
+    // El fail-closed acota el BACKLOG, no los harnesses de diagnóstico.
+    assert.equal(pp.isSkillAllowed('multi-provider-smoke-test'), true);
 });
 
 test('setPartialPause con [2490, 2491] activa partial_pause', () => {
@@ -166,10 +204,11 @@ test('isIssueAllowed(null|undefined|"abc") retorna false sin error', () => {
 // a callers que iteran muchos issues en un mismo tick (counters de cola)
 // reutilizar la misma decisión sin pagar IO por elemento.
 
-test('isIssueAllowedInState — modo running deja pasar todo', () => {
+test('isIssueAllowedInState — modo running deniega sin allowlist (#5060)', () => {
+    delete process.env.PIPELINE_ALLOW_UNSCOPED_DISPATCH;
     const state = { mode: 'running', allowedIssues: [] };
-    assert.equal(pp.isIssueAllowedInState(2490, state), true);
-    assert.equal(pp.isIssueAllowedInState('#9999', state), true);
+    assert.equal(pp.isIssueAllowedInState(2490, state), false);
+    assert.equal(pp.isIssueAllowedInState('#9999', state), false);
 });
 
 test('isIssueAllowedInState — modo paused bloquea todo', () => {

--- a/.pipeline/lib/partial-pause.js
+++ b/.pipeline/lib/partial-pause.js
@@ -1,7 +1,7 @@
 // V3 Partial pause — pausa del pipeline con allowlist explícita de issues (#2490).
 //
 // Tres estados del pipeline:
-//   - running        → procesa todo (sin archivos de control)
+//   - running        → sin archivos de control (ver #5060: NO es barra libre)
 //   - paused         → .pipeline/.paused existe → no procesa nada
 //   - partial_pause  → .pipeline/.partial-pause.json existe → procesa solo issues del allowlist
 //
@@ -9,7 +9,9 @@
 // .partial-pause.json, .paused gana (más restrictivo).
 //
 // La tabla de verdad de isIssueAllowed(issue):
-//   running          → true
+//   running          → false (#5060: ejecución solo por olas; sin allowlist no
+//                      hay ola vigente que acote el dispatch. Escape hatch de
+//                      diagnóstico: PIPELINE_ALLOW_UNSCOPED_DISPATCH=1)
 //   paused           → false
 //   partial_pause    → issue in allowedIssues
 //
@@ -207,6 +209,41 @@ function getPipelineMode() {
     };
 }
 
+// -----------------------------------------------------------------------------
+// #5060 — Ejecución SOLO por olas (fail-closed sin allowlist).
+//
+// Incidente 2026-07-26: al cerrarse la ola 8, la poda convergente (#4753)
+// llamó `setPartialPause([])`, que con lista vacía delega en
+// `clearPartialPause()` y BORRA `.partial-pause.json`. Sin ese archivo el modo
+// caía a `running` y `isIssueAllowedInState()` devolvía `true` para cualquier
+// issue: el Pulpo perdió su único freno y dispatchó ~320 agentes sobre ~100
+// issues del backlog histórico, que a su vez generaron 97 issues nuevos.
+//
+// El alcance de la ola NO se enforza en `waves.json` (registro semántico) sino
+// en esta allowlist. Por eso "sin allowlist" pasa a significar **denegar**, no
+// **permitir**: el estado natural del pipeline es acotado a la ola vigente.
+//
+// El escape hatch existe para diagnóstico/recuperación, apagado por default y
+// con warning en cada uso — jamás debe quedar prendido en operación normal.
+// -----------------------------------------------------------------------------
+function unscopedDispatchEnabled() {
+    return process.env.PIPELINE_ALLOW_UNSCOPED_DISPATCH === '1';
+}
+
+// Warning una sola vez por proceso: el gate se consulta por issue y por tick,
+// loguear en cada llamada inundaría el log del Pulpo.
+let unscopedWarned = false;
+function warnUnscopedOnce() {
+    if (unscopedWarned) return;
+    unscopedWarned = true;
+    try {
+        console.warn(
+            '[partial-pause] ⚠️  PIPELINE_ALLOW_UNSCOPED_DISPATCH=1 — dispatch SIN filtro de ola. ' +
+            'Escape hatch de diagnóstico (#5060): el pipeline puede tomar cualquier issue del backlog.'
+        );
+    } catch { /* best-effort: el warning nunca rompe el gate */ }
+}
+
 /**
  * Determina si un issue puede procesarse según el estado actual.
  * @param {number|string} issue
@@ -223,6 +260,11 @@ function isIssueAllowed(issue) {
  * de cola, reconciler) y no quieren pagar el costo de releer el filesystem
  * por cada uno. La política es la misma que `isIssueAllowed`.
  *
+ * Tabla de verdad (#5060 cambia la primera fila):
+ *   running        → false, salvo `PIPELINE_ALLOW_UNSCOPED_DISPATCH=1`
+ *   paused         → false
+ *   partial_pause  → issue ∈ allowedIssues
+ *
  * @param {number|string} issue
  * @param {ReturnType<typeof getPipelineMode>} state
  * @returns {boolean}
@@ -231,7 +273,12 @@ function isIssueAllowedInState(issue, state) {
     const n = normalizeIssue(issue);
     if (!n) return false;
     if (!state || state.mode === 'paused') return false;
-    if (state.mode === 'running') return true;
+    // #5060 — sin allowlist NO hay ola vigente que acote el dispatch: fail-closed.
+    if (state.mode === 'running') {
+        if (!unscopedDispatchEnabled()) return false;
+        warnUnscopedOnce();
+        return true;
+    }
     return Array.isArray(state.allowedIssues) && state.allowedIssues.includes(n);
 }
 
@@ -242,10 +289,16 @@ function isIssueAllowedInState(issue, state) {
 // componentes que no son issues concretos pero quieren correr en ventanas de
 // pausa (ej. multi-provider-smoke-test, harnesses de diagnóstico futuros).
 //
-// Política exactamente análoga:
+// Política:
 //   running         → true (no hay pausa)
 //   paused          → false (halt total)
 //   partial_pause   → skill ∈ allowedSkills
+//
+// #5060 — NO se le aplica el fail-closed de `isIssueAllowedInState`. El gate de
+// issues acota el BACKLOG a la ola vigente; los skills de acá son componentes
+// del control-plane (smoke-test de providers, harnesses de diagnóstico) que no
+// consumen backlog y deben seguir corriendo entre olas. Denegarlos dejaría al
+// pipeline sin diagnóstico justo cuando no hay ola activa.
 // -----------------------------------------------------------------------------
 function isSkillAllowed(skillName) {
     return isSkillAllowedInState(skillName, getPipelineMode());
@@ -869,5 +922,9 @@ module.exports = {
     evaluateAndAudit,
     // #4030 — saneado de metadata de ola (expuesto para tests).
     sanitizeWaveMetaForWrite,
+    // #5060 — estado del escape hatch de dispatch sin ola. Lo consulta el Pulpo
+    // para declarar la causa del wave-stall watchdog (#4708/#4709) cuando el
+    // dispatch está detenido por falta de ola y no por halt humano.
+    unscopedDispatchEnabled,
     _paths: () => ({ PARTIAL_FILE: partialFile(), PAUSE_FILE: pauseFile() }),
 };

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -1481,6 +1481,7 @@ function listWorkFiles(dir) {
  *
  * Causas reconocidas (interino hasta #4709 unifique el registro):
  *   - halt humano (.paused / .partial-pause.json)   → kind 'human-halt'
+ *   - sin ola vigente que acote el dispatch (#5060) → kind 'wave-empty'
  *   - ventana de reposo / night-window              → kind 'night-window'
  *   - cuota agotada                                 → kind 'quota'
  *   - presión de recursos (ORANGE/RED)              → kind 'resource-pressure'
@@ -1495,6 +1496,13 @@ function readDeclaredCauseForWave(cfgRoot, waves) {
   try {
     const mode = partialPause.getPipelineMode().mode;
     if (mode && mode !== 'running') return declare('human-halt');
+    // #5060 — `running` ya no es barra libre: sin allowlist no hay ola vigente
+    // y el dispatch está fail-closed. Es una espera legítima (falta promover la
+    // ola siguiente), NO una ola estancada — declararla evita que el wave-stall
+    // watchdog (#4708/#4709) alerte por algo que el operador ya controla.
+    if (mode === 'running' && !partialPause.unscopedDispatchEnabled()) {
+      return declare('wave-empty');
+    }
   } catch { /* fail-closed */ }
 
   // 2. Ventana de reposo / madrugada — no alertar de noche (CA-2).
@@ -16139,8 +16147,13 @@ function autoResolveReductiveDesyncByClosure(probe, opts = {}) {
   // `realignActiveWaveDispatch` corta en `empty_expansion` ANTES de podar (fail-
   // safe para no vaciar una allowlist viva por un realign). Pero acá la poda ES
   // la convergencia correcta: marcamos los cerrados `completed` en waves.json y
-  // dejamos la allowlist vacía (una allowlist vacía == running, NO frena — ver
-  // feedback_partial-pause-empty-not-block). Sin esto, el desync reincidiría.
+  // dejamos la allowlist vacía. Sin esto, el desync reincidiría.
+  //
+  // #5060 — la allowlist vacía YA NO significa "procesa todo": desde el fix de
+  // ejecución-solo-por-olas equivale a dispatch detenido (fail-closed). Ese es
+  // el estado correcto al cerrarse una ola, pero es INVISIBLE para el operador
+  // si no se avisa: en el incidente 2026-07-26 el pipeline quedó suelto sin que
+  // nadie lo notara durante 10 horas. Por eso la poda ahora notifica el cierre.
   if (r && r.reason === 'empty_expansion') {
     const waves = require('./lib/waves');
     const closed = divergent.filter((n) => { try { return isClosed(n) === true; } catch { return false; } });
@@ -16155,15 +16168,29 @@ function autoResolveReductiveDesyncByClosure(probe, opts = {}) {
     } catch (e) {
       return { ok: false, reason: 'prune_failed', error: e.message };
     }
-    // Limpiar la allowlist de los extras cerrados: queda vacía (== running).
+    // Limpiar la allowlist de los extras cerrados: queda vacía → dispatch
+    // detenido hasta que se promueva la ola siguiente (#5060).
     try {
       partialPause.setPartialPause([], {
         source: 'wave-promote:autoresolve-reductive',
         authorizedBy: 'wave-promote',
-        justification: 'ola sin issues abiertos tras poda de cerrados (#4753): allowlist vacía == running',
+        justification: 'ola sin issues abiertos tras poda de cerrados (#4753): allowlist vacía = dispatch detenido (#5060)',
       });
     } catch { /* best-effort: la poda de waves.json ya convergió el probe */ }
     const active = (() => { try { return waves.getActiveWave(); } catch { return null; } })();
+    // #5060 — avisar al operador que la ola cerró y el pipeline quedó a la
+    // espera. Best-effort: la notificación NUNCA rompe la convergencia.
+    try {
+      const nombre = active && active.name ? ` — ${active.name}` : '';
+      sendTelegram(
+        `🌊 Ola ${active ? active.number : '?'}${nombre} cerrada: todos sus issues están completos.\n\n` +
+        `El dispatch queda DETENIDO (allowlist vacía = ejecución solo por olas, #5060). ` +
+        `Promové la ola siguiente para que el pipeline vuelva a tomar trabajo.`
+      );
+    } catch (e) {
+      log('pulpo', `[poda-convergente] no se pudo notificar el cierre de ola: ${e.message}`);
+    }
+    log('pulpo', `[poda-convergente] ola ${active ? active.number : '?'} sin abiertos → allowlist vacía; dispatch DETENIDO hasta promover la siguiente (#5060)`);
     return { ok: true, allowlist: [], activeWave: active && active.number, prunedFromWave: pruned };
   }
 

--- a/docs/pipeline/pausa-parcial.md
+++ b/docs/pipeline/pausa-parcial.md
@@ -6,13 +6,47 @@ Documenta los tres estados del pipeline (running, paused, partial_pause), cómo 
 
 | Estado | Marker en `.pipeline/` | Comportamiento |
 |---|---|---|
-| `running` | (ninguno) | Procesa todo, intake/lanzamiento/barrido normales. |
+| `running` | (ninguno) | **No dispatcha ningún issue** (#5060). Sin allowlist no hay ola vigente que acote el trabajo. |
 | `paused` | `.paused` | Bloquea TODO lanzamiento. Solo Telegram queda activo. |
 | `partial_pause` | `.partial-pause.json` | Procesa exclusivamente los issues listados en `allowed_issues`. |
 
 **Precedencia**: `paused` > `partial_pause` > `running`. Si coexisten `.paused` y `.partial-pause.json`, gana el más restrictivo.
 
 API canónica: `lib/partial-pause.js` exporta `getPipelineMode()`, `isIssueAllowed(n)`, `setPartialPause(list, opts)`, `clearPartialPause()`, `resumeAll()`.
+
+## Ejecución solo por olas (#5060)
+
+El pipeline **no tiene un modo "procesar todo el backlog"**. El único camino para
+que un issue se dispatche es estar en `allowed_issues`, que se puebla al promover
+una ola. Sin allowlist, `isIssueAllowed()` deniega.
+
+Esto cambió tras el incidente del 2026-07-26. Hasta entonces `running` significaba
+barra libre: al cerrarse la ola 8, la poda convergente (#4753) ejecutó
+`setPartialPause([])`, que con lista vacía borra el marker, y el Pulpo quedó sin
+filtro durante ~10 horas — ~320 agentes sobre ~100 issues del backlog histórico,
+que a su vez generaron 97 issues nuevos en cadena.
+
+El alcance de la ola **no se enforza en `waves.json`** (ese archivo es el registro
+semántico de qué contiene la ola); se enforza en esta allowlist. Por eso "sin
+allowlist" tiene que significar *denegar*, no *permitir*.
+
+### Consecuencias operativas
+
+- Al cerrarse una ola el dispatch queda **detenido**, y la poda convergente lo
+  avisa por Telegram. Hay que promover la ola siguiente para que el pipeline
+  vuelva a tomar trabajo.
+- El wave-stall watchdog (#4708/#4709) declara la causa `wave-empty` en ese
+  estado, así que no alerta por una espera que el operador ya controla.
+- `isSkillAllowed()` **no** cambió: los skills del control-plane (smoke-test de
+  providers, harnesses de diagnóstico) no consumen backlog y deben poder correr
+  entre olas.
+
+### Escape hatch
+
+`PIPELINE_ALLOW_UNSCOPED_DISPATCH=1` reabre el dispatch sin ola. Es para
+diagnóstico y recuperación, está apagado por default y loguea una advertencia en
+cada arranque que lo use. **No debe quedar prendido en operación normal**: es
+exactamente el comportamiento que causó el incidente.
 
 ## Shape del marker `.partial-pause.json`
 


### PR DESCRIPTION
## Problema

El 2026-07-26 a las 01:42 el pipeline empezó a dispatchar issues del backlog histórico sin relación con la ola activa: **~320 agentes sobre ~100 issues** (#741, #1094-#1125, #2460, #3908, #4337…) durante 10 horas, que generaron **97 issues nuevos en cadena** (#4963–#5059).

## Causa raíz

La ola 8 se cerró y la poda convergente (#4753) ejecutó `setPartialPause([])`. Con lista vacía esa función delega en `clearPartialPause()` y **borra `.pipeline/.partial-pause.json`**.

Sin ese marker:
- `getPipelineMode()` → `mode: 'running'`
- `isIssueAllowedInState()` → **`true` para cualquier issue**

El alcance de la ola no se enforza en `waves.json` (registro semántico) sino en la allowlist. Vaciarla equivalía a barra libre.

El detector de desync #3518 CA-6 no salta porque tras la poda ambos lados quedan consistentes (cero abiertos ↔ allowlist vacía): la condición peligrosa es justamente la que considera sana.

## Cambios

| Archivo | Qué |
|---|---|
| `lib/partial-pause.js` | `isIssueAllowedInState()` deniega en modo `running`. Escape hatch `PIPELINE_ALLOW_UNSCOPED_DISPATCH=1` apagado por default, con warning único por proceso. Exporta `unscopedDispatchEnabled()`. |
| `pulpo.js` | La poda convergente notifica por Telegram el cierre de ola + dispatch detenido. `readDeclaredCauseForWave()` declara `wave-empty`. |
| `docs/pipeline/pausa-parcial.md` | Contrato de modos actualizado: sección "Ejecución solo por olas" con el incidente, consecuencias operativas y escape hatch. |
| `lib/__tests__/partial-pause.test.js` | 4 tests nuevos + 2 actualizados. |

### Decisiones

- **`isSkillAllowedInState()` no cambia.** El fail-closed acota el *backlog*; los skills de acá son control-plane (smoke-test de providers, harnesses de diagnóstico) y deben poder correr entre olas. Denegarlos dejaría al pipeline sin diagnóstico justo cuando no hay ola activa.
- **Escape hatch por env var** en vez de eliminar el camino por completo: hace falta una escotilla para diagnóstico y recuperación, pero explícita, apagada por default y logueada.
- **Se mantiene el literal `mode: 'running'`** para no romper los ~10 callers de UI (`dashboard`, `telegram-reports`) que lo usan como "estado normal, sin badge de pausa". Lo que cambia es su semántica en el gate, no su nombre.

## Falso positivo cubierto

Sin `wave-empty`, el wave-stall watchdog (#4708/#4709) habría empezado a alertar cada vez que una ola cierra — la ola queda sin progreso y `mode` sigue siendo `running`, así que no había causa declarada. Coherente con el criterio de #4709: no alertar por modo ola.

## Tests

566 pass / 0 fail sobre toda la suite que toca `partial-pause`, `waves`, `wave-dispatch`, `desync` y `qa-priority-window`.

```
node --test $(grep -rln "partial-pause|isIssueAllowed|getPipelineMode|wave-dispatch|realignActiveWave|readDeclaredCause" .pipeline/lib/__tests__/ .pipeline/tests/)
ℹ tests 566 · pass 566 · fail 0
```

## QA

`qa:skipped` — cambio de infra del pipeline sin superficie de producto de usuario. La verificación es la suite de tests + el comportamiento observable en el propio pipeline (dispatch detenido sin ola).

Closes #5060
