### PR TITLE
fix(commander): el turno ya no se corta por duración total, sólo por cuelgue real

### DIFF
--- a/.pipeline/lib/__tests__/commander-inflight-fallback.test.js
+++ b/.pipeline/lib/__tests__/commander-inflight-fallback.test.js
@@ -182,7 +182,7 @@ test('CA-7 — primaryDurationMs >= budget dispara global_budget_exceeded', () =
         const d = inflight.decideInflightFallback({
             primaryProvider: 'anthropic',
             primaryErrorClass: 'timeout_no_new_bytes_30s',
-            primaryDurationMs: 601_000, // #4329 — excede budget default 600s
+            primaryDurationMs: 3_601_000, // excede el techo anti-zombi (60 min)
             primaryPartialOutput: '',
             attemptIndex: 0,
             budgetMs: inflight.TURN_BUDGET_MS,
@@ -193,14 +193,15 @@ test('CA-7 — primaryDurationMs >= budget dispara global_budget_exceeded', () =
         assert.equal(d.shouldRetry, false);
         assert.equal(d.reason, 'global_budget_exceeded');
         assert.equal(d.budgetRemainingMs, 0);
-        assert.match(d.cannedResponse, /⏱️/);
-        // #4329 CA-3 — el mensaje ya no debe mencionar "90s".
+        assert.match(d.cannedResponse, /trabada/);
+        // El mensaje ya no debe mencionar "90s" ni culpar al reloj.
         assert.doesNotMatch(d.cannedResponse, /90s/);
+        assert.doesNotMatch(d.cannedResponse, /tard[oó] m[aá]s de/);
         const audit = readAuditLines(dir);
         const ev = audit.find(e => e.event === 'inflight_fallback_global_timeout');
         assert.ok(ev, 'falta evento global_timeout');
-        assert.equal(ev.primary_duration_ms, 601_000);
-        assert.equal(ev.budget_ms, 600_000);
+        assert.equal(ev.primary_duration_ms, 3_601_000);
+        assert.equal(ev.budget_ms, 3_600_000);
     } finally { cleanup(dir); }
 });
 
@@ -770,7 +771,7 @@ test('re-exports desde commander/multi-provider apuntan al módulo dedicado', ()
     assert.equal(typeof mp.precheckCommanderProviderRanking, 'function');
     assert.equal(typeof mp.makePrecheckHandle, 'function');
     assert.equal(typeof mp.formatInflightFallbackNotice, 'function');
-    assert.equal(mp.INFLIGHT_BUDGET_MS, 600 * 1000); // #4329 — budget efectivo (default 600s)
+    assert.equal(mp.INFLIGHT_BUDGET_MS, 60 * 60 * 1000); // budget efectivo (techo anti-zombi, 60 min)
     assert.equal(mp.MAX_INFLIGHT_FALLBACKS, 1);
 });
 
@@ -778,10 +779,10 @@ test('re-exports desde commander/multi-provider apuntan al módulo dedicado', ()
 // #4329 — Budget del turno del Commander: resolver env + clamp + copy sincronizado
 // -----------------------------------------------------------------------------
 
-test('#4329 CA-1 — resolveTurnBudgetMs sin env → 600000 (default 600s)', () => {
-    assert.equal(inflight.resolveTurnBudgetMs({}), 600_000);
-    assert.equal(inflight.DEFAULT_BUDGET_MS, 600_000);
-    assert.equal(inflight.TURN_BUDGET_MS, 600_000);
+test('#4329 CA-1 — resolveTurnBudgetMs sin env → 60 min (techo anti-zombi, ya no 10 min)', () => {
+    assert.equal(inflight.resolveTurnBudgetMs({}), 60 * 60 * 1000);
+    assert.equal(inflight.DEFAULT_BUDGET_MS, 60 * 60 * 1000);
+    assert.equal(inflight.TURN_BUDGET_MS, 60 * 60 * 1000);
 });
 
 test('#4329 CA-2 — resolveTurnBudgetMs con env válido → valor configurado', () => {
@@ -790,24 +791,26 @@ test('#4329 CA-2 — resolveTurnBudgetMs con env válido → valor configurado',
 });
 
 test('#4329 CA-5 (SR-1) — resolveTurnBudgetMs fail-closed ante env inválido', () => {
+    const DEF = 60 * 60 * 1000;
     for (const bad of ['', 'abc', '0', '-5', 'NaN', '  ', undefined]) {
         assert.equal(
             inflight.resolveTurnBudgetMs({ COMMANDER_TURN_BUDGET_MS: bad }),
-            600_000,
-            `env inválido ${JSON.stringify(bad)} debe caer al default 600s`,
+            DEF,
+            `env inválido ${JSON.stringify(bad)} debe caer al default`,
         );
     }
     // Sin la clave definida.
-    assert.equal(inflight.resolveTurnBudgetMs({ OTRA: 'x' }), 600_000);
+    assert.equal(inflight.resolveTurnBudgetMs({ OTRA: 'x' }), DEF);
 });
 
 test('#4329 CA-6 (SR-2) — resolveTurnBudgetMs clampea al techo MAX_BUDGET_MS', () => {
-    assert.equal(inflight.MAX_BUDGET_MS, 30 * 60 * 1000);
-    assert.equal(inflight.resolveTurnBudgetMs({ COMMANDER_TURN_BUDGET_MS: '999999999' }), 1_800_000);
+    const MAX = 4 * 60 * 60 * 1000;
+    assert.equal(inflight.MAX_BUDGET_MS, MAX);
+    assert.equal(inflight.resolveTurnBudgetMs({ COMMANDER_TURN_BUDGET_MS: '999999999' }), MAX);
     // Exactamente en el techo → se mantiene.
-    assert.equal(inflight.resolveTurnBudgetMs({ COMMANDER_TURN_BUDGET_MS: String(1_800_000) }), 1_800_000);
+    assert.equal(inflight.resolveTurnBudgetMs({ COMMANDER_TURN_BUDGET_MS: String(MAX) }), MAX);
     // Justo por encima → clamp.
-    assert.equal(inflight.resolveTurnBudgetMs({ COMMANDER_TURN_BUDGET_MS: String(1_800_001) }), 1_800_000);
+    assert.equal(inflight.resolveTurnBudgetMs({ COMMANDER_TURN_BUDGET_MS: String(MAX + 1) }), MAX);
 });
 
 test('#4329 CA-7 (SR-3) — LATE_RESPONSE_TTL_MS estrictamente mayor al peor budget', () => {
@@ -819,15 +822,73 @@ test('#4329 CA-7 (SR-3) — LATE_RESPONSE_TTL_MS estrictamente mayor al peor bud
 test('#4329 CA-3 — cannedInflightBudgetTimeoutResponse no dice "90s" y refleja minutos', () => {
     const def = inflight.cannedInflightBudgetTimeoutResponse();
     assert.doesNotMatch(def, /90s/);
-    assert.match(def, /10 min/); // 600000ms → 10 min
+    assert.match(def, /60 min/); // 3600000ms → 60 min
     // Budget custom en minutos.
     assert.match(inflight.cannedInflightBudgetTimeoutResponse(300_000), /5 min/);
     // Budget < 60s → expresado en segundos (guideline UX, evita "0 min").
     const chico = inflight.cannedInflightBudgetTimeoutResponse(30_000);
     assert.match(chico, /30s/);
     assert.doesNotMatch(chico, /0 min/);
-    // Argumento inválido → cae al default 600s (10 min).
-    assert.match(inflight.cannedInflightBudgetTimeoutResponse('nope'), /10 min/);
+    // Argumento inválido → cae al default.
+    assert.match(inflight.cannedInflightBudgetTimeoutResponse('nope'), /60 min/);
+});
+
+// -----------------------------------------------------------------------------
+// Corte del turno por INACTIVIDAD (reemplaza el corte por duración total).
+//
+// Contexto: el operador pidió explícitamente sacar el corte a los 10 min y el
+// mensaje "tardó más de 10 min y corté" — un pedido que avanza no se corta, y
+// para informar están las notificaciones parciales cada 2 min.
+// -----------------------------------------------------------------------------
+
+test('idle watchdog — resolveIdleTimeoutMs default 10 min, fail-closed y clampeado', () => {
+    assert.equal(inflight.DEFAULT_IDLE_TIMEOUT_MS, 10 * 60 * 1000);
+    assert.equal(inflight.resolveIdleTimeoutMs(undefined), 10 * 60 * 1000);
+    for (const bad of ['', 'abc', '0', '-5', 'NaN', '  ', null]) {
+        assert.equal(
+            inflight.resolveIdleTimeoutMs(bad),
+            10 * 60 * 1000,
+            `env inválido ${JSON.stringify(bad)} nunca desactiva el corte`,
+        );
+    }
+    assert.equal(inflight.resolveIdleTimeoutMs('120000'), 120_000);
+    // Clamp: un env desmedido no reintroduce el cuelgue infinito.
+    assert.equal(inflight.resolveIdleTimeoutMs('999999999'), inflight.MAX_IDLE_TIMEOUT_MS);
+});
+
+test('idle watchdog — resolveAbsoluteMaxMs default 60 min, fail-closed y clampeado', () => {
+    assert.equal(inflight.DEFAULT_ABSOLUTE_MAX_MS, 60 * 60 * 1000);
+    assert.equal(inflight.resolveAbsoluteMaxMs(undefined), 60 * 60 * 1000);
+    for (const bad of ['', 'abc', '0', '-5', 'NaN', null]) {
+        assert.equal(inflight.resolveAbsoluteMaxMs(bad), 60 * 60 * 1000);
+    }
+    assert.equal(inflight.resolveAbsoluteMaxMs('900000'), 900_000);
+    assert.equal(inflight.resolveAbsoluteMaxMs('999999999'), inflight.MAX_ABSOLUTE_MAX_MS);
+});
+
+test('idle watchdog — el techo absoluto es > que el idle (el cuelgue corta antes que el techo)', () => {
+    assert.ok(inflight.DEFAULT_ABSOLUTE_MAX_MS > inflight.DEFAULT_IDLE_TIMEOUT_MS);
+    assert.ok(inflight.MAX_ABSOLUTE_MAX_MS >= inflight.MAX_IDLE_TIMEOUT_MS);
+});
+
+test('pulpo.js ya NO corta el turno del Commander por duración total de 10 min', () => {
+    const fs = require('node:fs');
+    const path = require('node:path');
+    const pulpoSrc = fs.readFileSync(path.join(__dirname, '..', '..', 'pulpo.js'), 'utf8');
+
+    // El hard timeout absoluto de 10 min quedó eliminado.
+    assert.doesNotMatch(
+        pulpoSrc,
+        /const\s+HARD_TIMEOUT_MS\s*=/,
+        'HARD_TIMEOUT_MS (corte por duración total) no debe volver',
+    );
+    // Y en su lugar el turno se corta por inactividad + techo anti-zombi.
+    assert.match(pulpoSrc, /IDLE_TIMEOUT_MS\s*=\s*inflightFallback\.resolveIdleTimeoutMs/);
+    assert.match(pulpoSrc, /ABSOLUTE_MAX_MS\s*=\s*inflightFallback\.resolveAbsoluteMaxMs/);
+    // El watchdog no debe matar mientras haya una herramienta en vuelo.
+    assert.match(pulpoSrc, /if\s*\(pendingToolUses\.size\s*>\s*0\)\s*return;/);
+    // Las notificaciones parciales (cada 2 min) siguen siendo el canal de aviso.
+    assert.match(pulpoSrc, /\}, 120000\);/);
 });
 
 test('#4329 SR-4 — pulpo.js deriva HARD_NON_ANTH_MS del budget, no del literal 90*1000', () => {

--- a/.pipeline/lib/commander/inflight-fallback.js
+++ b/.pipeline/lib/commander/inflight-fallback.js
@@ -92,21 +92,70 @@ const crypto = require('node:crypto');
 const path = require('node:path');
 
 const COMMANDER_SKILL = 'telegram-commander';
-// #4329 — budget global del turno del Commander. Subido de 90s → 600s (10 min)
-// para no cortar investigación en vivo. Configurable por env
-// `COMMANDER_TURN_BUDGET_MS`, fail-closed (SR-1) + clamp superior (SR-2).
-const DEFAULT_BUDGET_MS = 600 * 1000;        // 600s / 10 min (era 90s)
-const MAX_BUDGET_MS = 30 * 60 * 1000;        // techo duro: 30 min (SR-2, no eliminar el breaker)
+// Budget global del turno del Commander.
+//
+// Historia: 90s (#3475) → 600s / 10 min (#4329, "no cortar investigación en
+// vivo") → 60 min (acá).
+//
+// Por qué se sube de nuevo: el corte a los 10 min seguía matando pedidos
+// LEGÍTIMOS y largos (builds, QA E2E, auditorías, releases) y le mandaba al
+// operador un "tardó más de 10 min y corté" que no le sirve para nada — él
+// espera la respuesta, no un aviso de que dejamos de trabajar. El feedback del
+// operador es explícito: mientras el turno avanza NO se corta; para informar
+// están las notificaciones parciales que salen cada 2 min (`progressTimer` en
+// `pulpo.js`).
+//
+// El breaker NO se elimina: lo que corta ahora es un **cuelgue real** —
+// inactividad sostenida sin stream ni herramienta en vuelo, evaluada por el
+// watchdog de `pulpo.js` (`COMMANDER_IDLE_TIMEOUT_MS`). Este budget queda como
+// techo anti-zombi de último recurso, deliberadamente alto para no volver a
+// pisar trabajo real.
+//
+// Configurable por env `COMMANDER_TURN_BUDGET_MS`, fail-closed (SR-1) + clamp
+// superior (SR-2).
+const DEFAULT_BUDGET_MS = 60 * 60 * 1000;    // 60 min (era 600s / 10 min)
+const MAX_BUDGET_MS = 4 * 60 * 60 * 1000;    // techo duro: 4h (SR-2, no eliminar el breaker)
 const MAX_INFLIGHT_FALLBACKS = 1;   // 1 fallback in-flight + el intento primario = 2 totales
+
+// -----------------------------------------------------------------------------
+// Watchdog de INACTIVIDAD del turno (reemplaza el corte por duración total).
+//
+// `IDLE_TIMEOUT_MS`  — tiempo sin NINGUNA señal de vida (line del stream) y sin
+//                      herramienta en vuelo tras el cual se considera cuelgue.
+//                      Un turno que trabaja 40 min nunca lo alcanza.
+// `ABSOLUTE_MAX_MS`  — red final anti-zombi: aún con actividad aparente, el
+//                      turno no puede vivir para siempre (el Commander es un
+//                      proceso de días; un child huérfano filtraría memoria).
+//
+// Ambos fail-closed: valor no numérico / NaN / <= 0 → default (nunca desactivan
+// el corte), y clamp superior para que un env mal seteado no reintroduzca el
+// cuelgue infinito.
+// -----------------------------------------------------------------------------
+const DEFAULT_IDLE_TIMEOUT_MS = 10 * 60 * 1000;   // 10 min SIN actividad
+const MAX_IDLE_TIMEOUT_MS = 30 * 60 * 1000;
+const DEFAULT_ABSOLUTE_MAX_MS = 60 * 60 * 1000;   // 60 min de vida del turno
+const MAX_ABSOLUTE_MAX_MS = 4 * 60 * 60 * 1000;
+
+function _resolveClamped(raw, def, max) {
+    const v = Number(raw);
+    const base = (Number.isFinite(v) && v > 0) ? v : def;
+    return Math.min(base, max);
+}
+
+function resolveIdleTimeoutMs(raw) {
+    return _resolveClamped(raw, DEFAULT_IDLE_TIMEOUT_MS, MAX_IDLE_TIMEOUT_MS);
+}
+
+function resolveAbsoluteMaxMs(raw) {
+    return _resolveClamped(raw, DEFAULT_ABSOLUTE_MAX_MS, MAX_ABSOLUTE_MAX_MS);
+}
 
 // resolveTurnBudgetMs — resuelve el budget del turno desde el env, una sola vez
 // a nivel módulo. SR-1 fail-closed: no numérico / NaN / <=0 / vacío → default
-// 600s (nunca desactiva el corte). SR-2 clamp: por encima del techo → clamp al
+// 60 min (nunca desactiva el corte). SR-2 clamp: por encima del techo → clamp al
 // techo, no al valor crudo (un env mal configurado no reintroduce el cuelgue).
 function resolveTurnBudgetMs(env = process.env) {
-    const v = Number(env && env.COMMANDER_TURN_BUDGET_MS);
-    const base = (Number.isFinite(v) && v > 0) ? v : DEFAULT_BUDGET_MS;
-    return Math.min(base, MAX_BUDGET_MS);
+    return _resolveClamped(env && env.COMMANDER_TURN_BUDGET_MS, DEFAULT_BUDGET_MS, MAX_BUDGET_MS);
 }
 // Budget efectivo del turno (env-resuelto + clampeado). Lo derivan tanto el
 // ciclo lógico como el kill duro de `pulpo.js` (SR-4: un único valor).
@@ -199,12 +248,17 @@ function cannedInflightExhaustedResponse({ requestId }) {
 }
 
 // -----------------------------------------------------------------------------
-// cannedInflightBudgetTimeoutResponse — Mensaje cuando el budget global SR-5
-// se agotó antes de poder completar el ciclo. Distinto de exhausted porque
-// puede haber sido un primario lento, no necesariamente fallido.
-// #4329 (CA-3): el umbral se deriva del budget efectivo, sin literal "90s".
-// Para budgets < 60s (posible vía env) se expresa en segundos, para no mostrar
-// "más de 0 min" (guideline UX).
+// cannedInflightBudgetTimeoutResponse — Mensaje cuando el techo anti-zombi del
+// turno se agotó antes de poder completar el ciclo.
+//
+// Con el budget de 60 min este caso YA NO es "tardaste mucho": un turno que
+// avanza manda notificaciones parciales cada 2 min y nunca llega acá. Llegar
+// acá significa que la ejecución quedó trabada. El copy lo dice así — el
+// operador necesita saber que se colgó, no que le cortamos por reloj.
+//
+// El umbral se sigue derivando del budget efectivo (sin literal hardcodeado).
+// Para budgets < 60s (posible vía env en tests) se expresa en segundos, para no
+// mostrar "más de 0 min" (guideline UX).
 // -----------------------------------------------------------------------------
 function cannedInflightBudgetTimeoutResponse(budgetMs = TURN_BUDGET_MS) {
     const ms = (Number.isFinite(budgetMs) && budgetMs > 0) ? budgetMs : DEFAULT_BUDGET_MS;
@@ -212,8 +266,8 @@ function cannedInflightBudgetTimeoutResponse(budgetMs = TURN_BUDGET_MS) {
         ? `${Math.round(ms / 60000)} min`
         : `${Math.round(ms / 1000)}s`;
     return (
-        `⏱️ Tu pedido tardó más de ${umbral} en completarse y corté para no dejarte esperando. ` +
-        'Reformulá con algo más puntual o probá de nuevo en un momento.'
+        `⚠️ La ejecución de tu pedido quedó trabada y la corté recién ahora, tras ${umbral}. ` +
+        'No es que haya tardado de más: se colgó. Pedímelo de nuevo y lo retomo.'
     );
 }
 
@@ -659,6 +713,13 @@ module.exports = {
     MAX_BUDGET_MS,
     TURN_BUDGET_MS,
     resolveTurnBudgetMs,
+    // Watchdog de inactividad (reemplaza el corte por duración total)
+    DEFAULT_IDLE_TIMEOUT_MS,
+    MAX_IDLE_TIMEOUT_MS,
+    DEFAULT_ABSOLUTE_MAX_MS,
+    MAX_ABSOLUTE_MAX_MS,
+    resolveIdleTimeoutMs,
+    resolveAbsoluteMaxMs,
     MAX_INFLIGHT_FALLBACKS,
     LATE_RESPONSE_TTL_MS,
 

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -12575,8 +12575,24 @@ function ejecutarClaude(prompt, textoOriginal, trace, fallbackParts) {
     let attemptGlitch = false;
     const startTime = Date.now();
 
-    // Límite absoluto: 10 minutos — si Claude no terminó, matar y resolver
-    const HARD_TIMEOUT_MS = 10 * 60 * 1000;
+    // El turno del Commander YA NO se corta por duración total.
+    //
+    // Antes había un `HARD_TIMEOUT_MS = 10 min` absoluto: cualquier pedido que
+    // trabajara más de eso moría y el operador recibía un "tardó más de 10 min y
+    // corté". Eso mataba trabajo legítimo (builds, QA E2E, auditorías, releases)
+    // justo cuando el operador estaba esperando el resultado. Para mantenerlo
+    // informado mientras el turno avanza están las notificaciones parciales que
+    // salen cada 2 min (`progressTimer`, más abajo).
+    //
+    // Lo que corta ahora es un CUELGUE REAL, no el reloj:
+    //   - `IDLE_TIMEOUT_MS`: nada de actividad (ningún line del JSON-stream) y
+    //     ninguna herramienta en vuelo durante ese lapso. Un turno que avanza
+    //     resetea el contador con cada line, así que nunca lo alcanza.
+    //   - `ABSOLUTE_MAX_MS`: red final anti-zombi. El Commander es un proceso de
+    //     días; un child huérfano que "parezca vivo" no puede quedar para siempre.
+    // Ambos fail-closed + clampeados en `inflight-fallback.js` (SR-1 / SR-2).
+    const IDLE_TIMEOUT_MS = inflightFallback.resolveIdleTimeoutMs(process.env.COMMANDER_IDLE_TIMEOUT_MS);
+    const ABSOLUTE_MAX_MS = inflightFallback.resolveAbsoluteMaxMs(process.env.COMMANDER_ABSOLUTE_MAX_MS);
 
     // #3418 CA-3 — watchdog específico para Skill /doc y /planner. Trackeamos
     // cada `tool_use` cuyo `name === 'Skill'` y limpiamos cuando llega el
@@ -12595,7 +12611,9 @@ function ejecutarClaude(prompt, textoOriginal, trace, fallbackParts) {
     // Sirve para pausar el stream-gap detector mientras una herramienta larga
     // (Bash/gradlew de 120-300s) está corriendo: en ese tramo no llegan lines
     // nuevos, pero es actividad legítima, no un cuelgue. NO tiene watchdog propio
-    // (el HARD_TIMEOUT de 10min sigue siendo el límite duro para tools no-Skill).
+    // (el watchdog de inactividad sigue siendo el límite para tools no-Skill:
+    // mientras haya una tool en vuelo NO cuenta como cuelgue, y el techo
+    // absoluto anti-zombi corta igual en el peor caso).
     const pendingToolUses = new Set(); // tool_use_id
     // #4530 CA-3 — umbral efectivo del stream-gap, resuelto una vez por turn
     // desde el env con fail-closed 180s + clamp [180s, 600s].
@@ -12624,7 +12642,8 @@ function ejecutarClaude(prompt, textoOriginal, trace, fallbackParts) {
     // prohibición YA NO aplica: el split shadow/exec está completo. #3886 reconcilió
     // este comentario con el runtime.
     //
-    // CA-A5: HARD_TIMEOUT 10min intocado.
+    // CA-A5: el corte duro del turno (hoy watchdog de inactividad) intocado por
+    // los detectores shadow.
     // CA-A6: SKILL_WATCHDOG_MS intocado; pendingSkillCalls NUNCA se muta acá.
     // (No confundir con la ocurrencia `CA-S7` del debounce en ~pulpo.js:11592,
     //  que es de otro subsistema y queda intacta.)
@@ -12743,7 +12762,7 @@ function ejecutarClaude(prompt, textoOriginal, trace, fallbackParts) {
       if (resolved) return;
       resolved = true;
       clearInterval(progressTimer);
-      clearTimeout(hardTimer);
+      clearInterval(hardTimer);
       clearInterval(skillWatchdogTimer);
       // #3577 CA-S3 — cleanup determinístico de los timers shadow para evitar
       // handle leak en el Commander (proceso de larga vida, días).
@@ -12894,8 +12913,8 @@ function ejecutarClaude(prompt, textoOriginal, trace, fallbackParts) {
               // #3418 CA-3 — arrancar reloj del watchdog SOLO para
               // tool_use cuyo `name === 'Skill'` Y el `input.skill` esté
               // en la allowlist (`doc`/`planner`). Para otras tools
-              // (Bash, Read, Edit, etc.) el HARD_TIMEOUT de 10min sigue
-              // siendo el único límite.
+              // (Bash, Read, Edit, etc.) el watchdog de inactividad + el
+              // techo absoluto son el único límite.
               if (b.name === 'Skill' && b.id) {
                 const skillName = b.input && typeof b.input.skill === 'string' ? b.input.skill : null;
                 const watched = skillName && (skillName === 'doc' || skillName === 'planner');
@@ -13104,14 +13123,30 @@ function ejecutarClaude(prompt, textoOriginal, trace, fallbackParts) {
       log('commander', `Progreso: ${msg}`);
     }, 120000);
 
-    // Hard timeout: si nada resolvió en 10 min, forzar finalización
-    const hardTimer = setTimeout(() => {
-      if (!resolved) {
-        log('commander', `HARD TIMEOUT (${HARD_TIMEOUT_MS / 60000}min) — matando Claude`);
+    // Watchdog de INACTIVIDAD (reemplaza el hard timeout absoluto de 10 min).
+    // Corre cada 15s y sólo mata si el turno está efectivamente colgado:
+    //   - sin ningún line del stream desde hace >= IDLE_TIMEOUT_MS, Y
+    //   - sin ninguna herramienta en vuelo (un `Bash`/gradlew de 20 min no emite
+    //     lines pero es actividad legítima — `pendingToolUses` lo cubre),
+    // o bien si se superó el techo absoluto anti-zombi.
+    // Mientras el turno avanza, `lastLineAt` se refresca y esto nunca dispara.
+    const hardTimer = setInterval(() => {
+      if (resolved) return;
+      const now = Date.now();
+      if (now - startTime >= ABSOLUTE_MAX_MS) {
+        log('commander', `TECHO ABSOLUTO (${Math.round(ABSOLUTE_MAX_MS / 60000)}min) — matando Claude`);
         killProc();
         finish(null, 'hard-timeout');
+        return;
       }
-    }, HARD_TIMEOUT_MS);
+      if (pendingToolUses.size > 0) return;       // herramienta trabajando: no es cuelgue
+      const idleMs = now - Math.max(lastLineAt || 0, startTime);
+      if (idleMs >= IDLE_TIMEOUT_MS) {
+        log('commander', `TURNO COLGADO: ${Math.round(idleMs / 1000)}s sin actividad ni herramienta en vuelo — matando Claude`);
+        killProc();
+        finish(null, 'idle-timeout');
+      }
+    }, 15000);
 
     // #3418 CA-3 — Skill watchdog: revisa cada 5s si hay algún Skill
     // (`/doc` o `/planner`) cuya emisión de `tool_use` excede los 60s sin


### PR DESCRIPTION
## Problema

El Commander mataba cualquier turno que superara los **10 minutos** (`HARD_TIMEOUT_MS`) y le devolvía al operador:

> ⏱️ Tu pedido tardó más de 10 min en completarse y corté para no dejarte esperando.

Eso mataba trabajo **legítimo y largo** (builds, QA E2E, auditorías de seguridad, releases del kernel) justo cuando el operador estaba esperando el resultado. El aviso no le sirve: él quiere la respuesta, no que dejemos de trabajar.

## Solución

El corte pasa de ser **por reloj** a ser **por cuelgue real**.

### `pulpo.js`
- Se elimina el `HARD_TIMEOUT_MS = 10 min` absoluto.
- Entra un **watchdog de inactividad** que corre cada 15s y sólo mata si:
  - no llegó ningún line del JSON-stream desde hace `IDLE_TIMEOUT_MS` (10 min), **y**
  - no hay ninguna herramienta en vuelo (`pendingToolUses` cubre el `Bash`/gradlew de 20 min que no emite lines pero es actividad legítima).
- Se mantiene un **techo absoluto anti-zombi** (`ABSOLUTE_MAX_MS`, 60 min): el Commander es un proceso de días, un child huérfano que "parezca vivo" no puede quedar para siempre.

### `lib/commander/inflight-fallback.js`
- Budget del turno: 10 min → **60 min** (techo duro 4h).
- Nuevos helpers `resolveIdleTimeoutMs` / `resolveAbsoluteMaxMs`, **fail-closed** (env inválido → default, nunca desactivan el corte) + **clamp superior** (env mal seteado no reintroduce el cuelgue infinito).
- El copy del timeout deja de decir "tardaste mucho" y pasa a decir que **se colgó** — que es lo único que puede pasar ahora para llegar ahí.

### Fix colateral
El timer pasó a `setInterval` pero el cleanup seguía llamando `clearTimeout` → handle leak en un proceso de larga vida. Corregido.

## Verificación

`node --test .pipeline/lib/__tests__/commander-inflight-fallback.test.js` → **44/44 en verde**, incluye un test que verifica sobre el fuente que `pulpo.js` ya no corta el turno por duración total.

## Nota operativa

El operador sigue informado mientras el turno avanza vía las **notificaciones parciales cada 2 min** (`progressTimer`), que no se tocan.

Requiere reinicio del Pulpo para tomar efecto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)