### PR TITLE
fix(pulpo): no resolver prioridad de issues fuera de la allowlist

### DIFF
--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -7087,8 +7087,26 @@ function brazoLanzamientoImpl(config, _dcMark, _dcState) {
   // Ordenar candidatos: feature priority (menor=mejor) > fase inversa (mayor idx=más avanzada=primero).
   // #3938 — la prioridad se calcula en la frontera (acceso a labels/config) y el
   // orden puro (priority asc > fase inversa) se delega a brazo-lanzamiento-core.
+  //
+  // Los issues fuera de la allowlist se saltan en el loop de despacho (gate 0a,
+  // más abajo) sin llegar nunca a lanzarse. Resolverles la prioridad implica un
+  // `gh issue view` por issue con busy-wait SÍNCRONO de 2s (ghThrottle): con el
+  // backlog completo en cola (121 issues el 2026-07-27) el ciclo tardaba >300s,
+  // superaba el umbral de 180s del watchdog de liveness y el Pulpo era matado
+  // ANTES de terminar su primer ciclo. Como el caché de labels vive en memoria,
+  // cada respawn arrancaba en frío → bucle de muerte infinito: el loop principal
+  // nunca completaba una iteración y el busy-wait congelaba el event loop, así
+  // que el Commander (async) tampoco atendía los mensajes de Telegram.
+  //
+  // Prioridad neutra para los no-allowed: no se despachan igual, y el orden
+  // relativo de los que sí se despachan no cambia.
+  // Estado leído UNA vez para todo el lote (#2957): `isIssueAllowedInState` es
+  // la variante pura pensada para callers que iteran muchos issues por tick.
+  const ppStateForPriority = partialPause.getPipelineMode();
   for (const c of candidates) {
-    c.priority = calcularPrioridad(issueFromFile(c.archivo.name), config);
+    const issueNum = issueFromFile(c.archivo.name);
+    if (!partialPause.isIssueAllowedInState(issueNum, ppStateForPriority)) { c.priority = 999; continue; }
+    c.priority = calcularPrioridad(issueNum, config);
   }
   candidates.sort(brazoLanzamientoCore.compareCandidates);
 


### PR DESCRIPTION
## Contexto

Caida total del pipeline durante 12 horas (2026-07-27 01:35 UTC → 13:20 UTC): el Commander de Telegram no respondia ningun audio y no se despachaba ningun agente.

## Causa raiz

En `brazoLanzamientoImpl` la prioridad se resolvia para **todos** los candidatos de la cola, antes del gate de allowlist que los descarta. `calcularPrioridad` → `getIssueLabels` → `getIssueInfo` → `ghThrottle()`, un **busy-wait sincrono de 2s** por issue.

Con 121 issues unicos en cola: 121 × ~3s = **>300s por ciclo**, contra un umbral de watchdog de **180s**. El Pulpo era matado antes de completar su primer ciclo, y como el cache de labels vive en memoria, cada respawn arrancaba en frio → **bucle de muerte infinito** (kill-respawn cada 4 min durante 9 horas).

El busy-wait, al ser sincrono, congelaba el event loop entero: por eso el Commander (fire-and-forget async desde `mainLoop`) quedaba clavado en su ventana de consolidacion.

### Stack capturado con el inspector de Node sobre el proceso colgado

```
at ghThrottle           — pulpo.js:655
at getIssueInfo         — pulpo.js:6318
at getIssueLabels       — pulpo.js:6337
at calcularPrioridad    — pulpo.js:6422
at brazoLanzamientoImpl — pulpo.js:7091
at brazoLanzamiento     — pulpo.js:6993
at mainLoop             — pulpo.js:18720
```

## Cambio

Filtrar por allowlist antes de resolver la prioridad. Los issues fuera de la ola se saltan igual en el gate 0a del loop de despacho, asi que consultarles los labels es trabajo 100% descartado. Se usa `isIssueAllowedInState` (variante pura, estado leido una sola vez para todo el lote) en lugar de `isIssueAllowed`, que releeria el filesystem por candidato.

Con #5060 (fail-closed sin allowlist) el fix cubre tambien el caso sin ola activa: sin allowlist no se despacha nada, entonces no hace falta resolver ninguna prioridad → 0 llamadas a `gh`.

El orden relativo de los candidatos que si se despachan no cambia: los no-allowed reciben prioridad neutra (999) y se saltan igual.

## Verificacion en vivo

Pulpo lanzado con el fix aplicado:

```
[11:21:35] [commander] 3 mensaje(s) pendiente(s)
[11:21:35] [commander] Ventana de consolidacion (5000ms)...
[11:21:41] [commander] Tomado: 1785118129250-88564.json → trabajando/
[11:21:41] [commander] Tomado: 1785118992185-88565.json → trabajando/
[11:21:41] [commander] Tomado: 1785146704633-88567.json → trabajando/
[11:21:41] [commander] Total mensajes consolidados: 3
[11:22:30] [commander] Preprocesado: "¿Me pasas del estado de la ola actual?..."
```

Heartbeat volvio a actualizarse cada 30s (antes se congelaba a los 4s del arranque). Los 3 audios encolados desde ayer fueron retomados y transcriptos.

Medido: de 121 llamadas `gh` (>300s por ciclo) a 4 (<10s).

## QA

`qa:skipped` — cambio de infra pura del pipeline (`.pipeline/pulpo.js`), sin impacto en el producto de usuario (ni app ni backend). La verificacion es la recuperacion del ciclo del Pulpo y del Commander, documentada arriba con evidencia de log.

## Hallazgos secundarios (issues aparte, no incluidos en este PR)

1. **`watchdog.ps1` respawnea el Pulpo sin redirigir stdout** (`Start-Process` sin `-RedirectStandardOutput`), por lo que todas las lineas de `log()` (que usa `console.log`) se pierden. `pulpo.log` solo mostraba lo escrito con `appendFileSync`, lo que hacia parecer que el Pulpo ni siquiera llegaba a `mainLoop()`. Esto fue lo que mas costo del diagnostico.
2. **El cache de labels es solo en memoria** (TTL 10 min) y no sobrevive respawns. Un prefetch en lote (una query GraphQL por lotes de ~50 issues) eliminaria el riesgo de fondo.
3. **`ghThrottle` usa busy-wait sincrono**, que bloquea el event loop completo y arrastra al Commander con el.

Closes #5070

🤖 Generated with [Claude Code](https://claude.com/claude-code)