### PR TITLE
fix(pipeline): el Pulpo ya no entra en bucle de muerte con la cola llena (Closes #5070)

### DIFF
--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -7087,8 +7087,11 @@ function brazoLanzamientoImpl(config, _dcMark, _dcState) {
   // Ordenar candidatos: feature priority (menor=mejor) > fase inversa (mayor idx=más avanzada=primero).
   // #3938 — la prioridad se calcula en la frontera (acceso a labels/config) y el
   // orden puro (priority asc > fase inversa) se delega a brazo-lanzamiento-core.
+  const ppStateForPriority = partialPause.getPipelineMode();
   for (const c of candidates) {
-    c.priority = calcularPrioridad(issueFromFile(c.archivo.name), config);
+    const issueNum = issueFromFile(c.archivo.name);
+    if (!partialPause.isIssueAllowedInState(issueNum, ppStateForPriority)) { c.priority = 999; continue; }
+    c.priority = calcularPrioridad(issueNum, config);
   }
   candidates.sort(brazoLanzamientoCore.compareCandidates);
 


### PR DESCRIPTION
## Problema

Desde el 2026-07-27 01:35 UTC el Commander de Telegram dejó de responder y el despacho de agentes se detuvo. 12 horas de caída total.

**Causa raíz:** en `brazoLanzamientoImpl` la prioridad se calculaba para **todos** los candidatos de la cola, antes del gate de allowlist que los descarta. `calcularPrioridad` → `getIssueLabels` → `getIssueInfo` → `ghThrottle()`, un busy-wait **síncrono** de 2s por issue más la latencia real de `gh issue view`.

Con 121 issues únicos en cola (todo el backlog entró a las colas al cerrarse la ola, ver #4753):

- 121 × ~3s = **>300s por ciclo**
- Umbral del watchdog de liveness: **180s**
- El watchdog mataba al Pulpo antes de que terminara su primer ciclo
- El cache de labels vive en memoria → cada respawn arrancaba en frío
- **Bucle de muerte infinito:** kill-respawn cada 4 min durante 9 horas

Además, al ser `ghThrottle` un busy-wait síncrono, congelaba el event loop entero. Por eso el Commander (async, fire-and-forget desde `mainLoop`) quedaba clavado y nunca atendía los mensajes.

## Fix

Filtrar por allowlist **antes** de resolver la prioridad. Los issues fuera de la ola se saltan igual en el gate 0a del loop de despacho, así que consultarles los labels es trabajo 100% descartado.

Con #5060 (`fail-closed` sin allowlist) el fix cubre también el caso sin ola activa: si no hay allowlist no se despacha nada, entonces no hace falta resolver ninguna prioridad → 0 llamadas a `gh`.

**Resultado medido:** de 121 llamadas `gh` (>300s) a 4 (<10s por ciclo).

## Verificación

`pulpo-liveness.log` post-fix — el patrón kill-respawn se cortó:

```
[11:13:14] decision=kill-respawn hbAgeMs=190826
[11:15:14] decision=skip         hbAgeMs=115844
[11:23:17] decision=skip         hbAgeMs=31144
[11:25:14] decision=skip         hbAgeMs=10582
```

El heartbeat vuelve a escribirse en cada tick (10-31s de antigüedad contra 190-236s antes).

## QA

`qa:skipped` — cambio interno del orquestador del pipeline, sin impacto en producto de usuario (no toca backend, app ni ninguna superficie de cliente). La evidencia funcional es el log de liveness de arriba.

Closes #5070

🤖 Generated with [Claude Code](https://claude.com/claude-code)