### PR TITLE
[Split de #5125] Alcance del migrador, backup de descriptores y runbook de encendido/rollback

### DIFF
--- a/.pipeline/lib/__tests__/kernel-store-migrate.test.js
+++ b/.pipeline/lib/__tests__/kernel-store-migrate.test.js
@@ -20,6 +20,7 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
+const { spawnSync } = require('node:child_process');
 
 const {
   createCoordinationStore,
@@ -36,6 +37,10 @@ const {
   compareIntegrity,
   redactSecrets,
   SOURCES,
+  createBackup,
+  readSources,
+  backupDescriptors,
+  restoreDescriptors,
 } = require('../kernel-store-migrate');
 
 const CTX = 'intrale-platform';
@@ -90,7 +95,7 @@ test('migración idempotente: re-run no duplica registros', async () => {
   const src = writeSources(sourceDir);
   const store = makeStore();
 
-  const r1 = await migrateState({ apply: true, store, sourceDir, backupRoot, now: FIXED_NOW });
+  const r1 = await migrateState({ apply: true, sources: SOURCES, store, sourceDir, backupRoot, now: FIXED_NOW });
   assert.equal(r1.ok, true, r1.error);
 
   // Conteo por clave tras la 1ra corrida.
@@ -100,7 +105,7 @@ test('migración idempotente: re-run no duplica registros', async () => {
   assert.equal(countRecords(waves1.value), countRecords(src.waves));
 
   // 2da corrida idéntica: no debe duplicar ni bumpear versión (noop).
-  const r2 = await migrateState({ apply: true, store, sourceDir, backupRoot, now: FIXED_NOW + 1000 });
+  const r2 = await migrateState({ apply: true, sources: SOURCES, store, sourceDir, backupRoot, now: FIXED_NOW + 1000 });
   assert.equal(r2.ok, true, r2.error);
   assert.equal(r2.actions.waves, 'noop');
   assert.equal(r2.actions.blocked, 'noop');
@@ -148,7 +153,7 @@ test('verificación de integridad fail-closed: store que pierde un registro rech
     compareAndSet: real.compareAndSet,
   };
 
-  const res = await migrateState({ apply: true, store: lossyStore, sourceDir, backupRoot, now: FIXED_NOW });
+  const res = await migrateState({ apply: true, sources: SOURCES, store: lossyStore, sourceDir, backupRoot, now: FIXED_NOW });
   assert.equal(res.ok, false);
   assert.equal(res.code, 'integrity_mismatch');
   assert.ok(res.rollbackCmd && res.rollbackCmd.includes('--rollback'));
@@ -259,7 +264,7 @@ test('no pierde historia de waves/labels/firmas', async () => {
   const sigId = sig.signatureId;
 
   const coord = createCoordinationStore({ driver, contextProjectId: CTX, knownKeys: MIGRATION_KNOWN_KEYS, config: { kernel: { tableName: 't' } } });
-  const res = await migrateState({ apply: true, store: coord, sourceDir, backupRoot, now: FIXED_NOW });
+  const res = await migrateState({ apply: true, sources: SOURCES, store: coord, sourceDir, backupRoot, now: FIXED_NOW });
   assert.equal(res.ok, true, res.error);
 
   // waves + labels preservados con contenido idéntico.
@@ -349,9 +354,454 @@ test('migrateState --apply sin store devuelve error como dato (no throw)', async
   const sourceDir = freshTmp('nostore-src');
   const backupRoot = freshTmp('nostore-bak');
   writeSources(sourceDir);
-  const res = await migrateState({ apply: true, sourceDir, backupRoot, now: FIXED_NOW });
+  const res = await migrateState({ apply: true, sources: SOURCES, sourceDir, backupRoot, now: FIXED_NOW });
   assert.equal(res.ok, false);
   assert.equal(res.code, 'store_required');
   // el backup se hizo igual (antes de intentar escribir).
   assert.ok(res.backupDir && fs.existsSync(res.backupDir));
+});
+
+// =============================================================================
+// #5136 — Alcance del migrador, backup de descriptores y runbook
+// =============================================================================
+
+// -----------------------------------------------------------------------------
+// CA-11′ · `sources` distingue TRES casos (undefined / array incl. vacío / otra cosa)
+// -----------------------------------------------------------------------------
+
+test('CA-11′: sources vacío NO migra ninguna fuente (no cae al default SOURCES)', async () => {
+  const sourceDir = freshTmp('src-empty-arr-src');
+  const backupRoot = freshTmp('src-empty-arr-bak');
+  writeSources(sourceDir); // las 4 fuentes prohibidas EXISTEN en disco
+  const store = makeStore();
+
+  const res = await migrateState({ apply: true, sources: [], store, sourceDir, backupRoot, now: FIXED_NOW });
+
+  // `[]` llega tal cual a readSources ⇒ items = [] ⇒ `no_sources`, que es la
+  // semántica correcta de "no migres nada". La trampa vieja (`&& .length`) hacía
+  // que esto cayera al default y migrara las 4 fuentes prohibidas.
+  assert.equal(res.ok, false);
+  assert.equal(res.code, 'no_sources');
+
+  // Garantía dura de CA-11′/CA-19: NINGUNA de las 4 fuentes prohibidas se migró.
+  for (const key of ['waves', 'blocked', 'blocked-by-infra', 'health']) {
+    assert.equal(await store.getState(key), null, `sources: [] no debe migrar la clave ${key}`);
+  }
+});
+
+test('CA-11′: sources no-array devuelve sources_invalidas como dato (nunca throw)', async () => {
+  const sourceDir = freshTmp('src-bad-src');
+  const backupRoot = freshTmp('src-bad-bak');
+  writeSources(sourceDir);
+  const store = makeStore();
+
+  for (const bad of [null, {}, 'waves', 3, true]) {
+    let res;
+    // "como dato, no throw": si lanzara, este await explotaría y el test falla.
+    await assert.doesNotReject(async () => {
+      res = await migrateState({ apply: true, sources: bad, store, sourceDir, backupRoot, now: FIXED_NOW });
+    }, `sources: ${JSON.stringify(bad)} no debe lanzar excepción`);
+    assert.equal(res.ok, false, `sources: ${JSON.stringify(bad)} debe fallar`);
+    assert.equal(res.code, 'sources_invalidas', `sources: ${JSON.stringify(bad)} ⇒ sources_invalidas`);
+  }
+
+  // Y no migró nada ni escribió backup (el guard corre antes que todo).
+  for (const key of ['waves', 'blocked', 'blocked-by-infra', 'health']) {
+    assert.equal(await store.getState(key), null);
+  }
+  assert.deepEqual(fs.readdirSync(backupRoot), [], 'sources_invalidas no debe crear backup');
+});
+
+// -----------------------------------------------------------------------------
+// CA-12′ · `apply: true` exige `sources` explícitas; dry-run conserva el default
+// -----------------------------------------------------------------------------
+
+test('CA-12′: apply sin sources explícitas falla cerrado con sources_no_explicitas', async () => {
+  const sourceDir = freshTmp('noexp-src');
+  const backupRoot = freshTmp('noexp-bak');
+  writeSources(sourceDir);
+  const store = makeStore();
+
+  const res = await migrateState({ apply: true, store, sourceDir, backupRoot, now: FIXED_NOW });
+  assert.equal(res.ok, false);
+  assert.equal(res.code, 'sources_no_explicitas');
+
+  // El guard va ARRIBA del backup: no muta nada, ni siquiera el filesystem.
+  assert.deepEqual(fs.readdirSync(backupRoot), [], 'sources_no_explicitas no debe crear backup');
+  for (const key of ['waves', 'blocked', 'blocked-by-infra', 'health']) {
+    assert.equal(await store.getState(key), null);
+  }
+});
+
+test('CA-12′: dry-run sin sources conserva el default SOURCES y no muta nada', async () => {
+  const sourceDir = freshTmp('dryok-src');
+  const backupRoot = freshTmp('dryok-bak');
+  writeSources(sourceDir);
+  const store = makeStore();
+
+  const res = await migrateState({ apply: false, store, sourceDir, backupRoot, now: FIXED_NOW });
+  assert.equal(res.ok, true, res.error);
+  assert.equal(res.dryRun, true);
+
+  // El default se conserva: las 4 claves de SOURCES están en el snapshot previo.
+  assert.deepEqual(Object.keys(res.before).sort(), SOURCES.map((s) => s.key).sort());
+  // Y sigue sin escribir en el store.
+  assert.equal(await store.getState('waves'), null);
+});
+
+// -----------------------------------------------------------------------------
+// CA-12b · El CLI `--apply` falla cerrado y no migra estado prohibido (D-4/AD-2)
+// -----------------------------------------------------------------------------
+
+test('CA-12b: el CLI --apply falla cerrado, no escribe fuentes prohibidas ni crea backup', () => {
+  const migratePath = path.resolve(__dirname, '..', 'kernel-store-migrate.js');
+  const pipelineDir = path.resolve(__dirname, '..', '..'); // `.pipeline/` REAL
+  const backupDir = path.join(pipelineDir, 'backup');
+
+  // Huella ANTES: existencia+contenido de `.pipeline/backup/` y estado (mtime+
+  // size) de las 4 fuentes operativas reales que #5112 prohíbe migrar.
+  const backupExistedBefore = fs.existsSync(backupDir);
+  const backupListBefore = backupExistedBefore ? fs.readdirSync(backupDir).sort() : null;
+  const stamp = () => SOURCES.map((s) => {
+    const full = path.join(pipelineDir, s.file);
+    if (!fs.existsSync(full)) return `${s.file}:absent`;
+    const st = fs.statSync(full);
+    return `${s.file}:${st.size}:${st.mtimeMs}`;
+  }).join('|');
+  const sourcesBefore = stamp();
+
+  // Corre SIN credenciales AWS: por AD-2 el guard está antes de instanciar el
+  // store. Si este test pidiera credenciales, el guard quedó mal ubicado.
+  const run = spawnSync(process.execPath, [migratePath, '--apply'], {
+    encoding: 'utf8',
+    cwd: pipelineDir,
+    timeout: 30_000,
+  });
+
+  // (a) sale con código ≠ 0
+  assert.notEqual(run.status, 0, `--apply debe salir con código ≠ 0 (status=${run.status})`);
+  // (b) imprime el código de error y qué SÍ puebla los descriptores
+  assert.match(run.stdout, /alcance_no_implementado/, 'stdout debe nombrar alcance_no_implementado');
+  assert.match(run.stdout, /durableRegisterProduct/, 'stdout debe nombrar durableRegisterProduct');
+  // (c) NO creó ningún directorio de backup
+  assert.equal(fs.existsSync(backupDir), backupExistedBefore, '--apply no debe crear .pipeline/backup/');
+  if (backupExistedBefore) {
+    assert.deepEqual(fs.readdirSync(backupDir).sort(), backupListBefore, '--apply no debe agregar backups');
+  }
+  // (d) NO tocó ninguna de las 4 fuentes prohibidas
+  assert.equal(stamp(), sourcesBefore, '--apply no debe escribir las 4 fuentes operativas prohibidas');
+});
+
+// Nota: no se testea el dry-run del CLI por spawn a propósito. `defaultPipelineDir()`
+// resuelve al `.pipeline/` REAL (no depende del cwd), así que un spawn sin flags
+// escribiría un backup de verdad en `.pipeline/backup/` — un efecto de filesystem
+// que la suite no tenía. La no-interferencia del guard sobre el camino dry-run
+// queda cubierta por el test de función «CA-12′: dry-run sin sources conserva el
+// default SOURCES», y se verifica a mano en la pre-checklist del issue.
+
+test('CA-12b: el guard del CLI corre ANTES de instanciar el store (AD-2)', () => {
+  // Si el guard estuviera después del `require('./kernel-coordination-store')`,
+  // --apply fallaría por credenciales/instanciación en vez de por alcance, y el
+  // mensaje sería otro. Que salga EXACTAMENTE `alcance_no_implementado` —y no
+  // `[FALLA] no se pudo instanciar el store`— es la prueba de la ubicación.
+  const migratePath = path.resolve(__dirname, '..', 'kernel-store-migrate.js');
+  const run = spawnSync(process.execPath, [migratePath, '--apply'], {
+    encoding: 'utf8',
+    timeout: 30_000,
+    // Entorno sin credenciales AWS: por AD-2 el comando no las necesita.
+    env: { ...process.env, AWS_ACCESS_KEY_ID: '', AWS_SECRET_ACCESS_KEY: '', AWS_PROFILE: '' },
+  });
+  assert.match(run.stdout, /alcance_no_implementado/);
+  assert.doesNotMatch(run.stdout, /no se pudo instanciar el store/, 'el guard debe cortar ANTES del store (AD-2)');
+});
+
+// -----------------------------------------------------------------------------
+// CA-13′ · Backup de descriptores con destino y manifest propios
+// -----------------------------------------------------------------------------
+
+// Escribe N descriptores de forma determinística. Indentación 2 == la que usa
+// `backupDescriptors`, para poder comparar byte a byte en la restauración.
+function writeDescriptors(dir) {
+  const primary = { schemaVersion: '1.0', identity: { projectId: 'intrale-platform', primary: true } };
+  const second = { schemaVersion: '1.0', identity: { projectId: 'otro-producto', primary: false } };
+  fs.writeFileSync(path.join(dir, 'intrale-platform.json'), JSON.stringify(primary, null, 2));
+  fs.writeFileSync(path.join(dir, 'otro-producto.json'), JSON.stringify(second, null, 2));
+  return { primary, second };
+}
+
+test('CA-13′: backupDescriptors produce manifest con checksum sha256 canónico', () => {
+  const descriptorsDir = freshTmp('desc-src');
+  const backupRoot = freshTmp('desc-bak');
+  const d = writeDescriptors(descriptorsDir);
+
+  const res = backupDescriptors({ descriptorsDir, backupRoot, epochMs: FIXED_NOW });
+  assert.equal(res.ok, true, res.error);
+  assert.equal(res.count, 2);
+
+  // Destino bajo la raíz de backups (gitignoreada) y en subdirectorio propio.
+  assert.equal(path.basename(res.dir), 'descriptors');
+  assert.ok(res.dir.startsWith(path.resolve(backupRoot)), 'el destino debe caer dentro de backupRoot');
+
+  // Manifest propio con checksum canónico y conteo.
+  const manifest = JSON.parse(fs.readFileSync(path.join(res.dir, 'manifest.json'), 'utf8'));
+  assert.equal(manifest.kind, 'descriptors');
+  assert.equal(manifest.files['intrale-platform.json'].checksum, sha256Canonical(d.primary));
+  assert.equal(manifest.files['otro-producto.json'].checksum, sha256Canonical(d.second));
+  assert.equal(manifest.files['intrale-platform.json'].records, countRecords(d.primary));
+  assert.match(manifest.files['intrale-platform.json'].checksum, /^[a-f0-9]{64}$/);
+});
+
+test('CA-13′: los dos backups del MISMO epoch no se pisan (manifests separados e íntegros)', () => {
+  const sourceDir = freshTmp('two-src');
+  const descriptorsDir = freshTmp('two-desc');
+  const backupRoot = freshTmp('two-bak');
+  const src = writeSources(sourceDir);
+  const d = writeDescriptors(descriptorsDir);
+
+  // MISMO epochMs para los dos artefactos: `backupDirName` es puro ⇒ mismo <ts>.
+  const items = readSources(sourceDir, SOURCES);
+  const coordBk = createBackup(items, backupRoot, FIXED_NOW);
+  const descBk = backupDescriptors({ descriptorsDir, backupRoot, epochMs: FIXED_NOW });
+
+  assert.equal(coordBk.ok, true, coordBk.error);
+  assert.equal(descBk.ok, true, descBk.error);
+
+  // El de descriptores vive UN NIVEL ABAJO del de coordinación ⇒ imposible pisar
+  // el manifest.json del otro.
+  assert.equal(descBk.dir, path.join(coordBk.dir, 'descriptors'));
+
+  // Los DOS manifests quedan legibles e íntegros, y cada uno declara SU conjunto.
+  const coordManifest = JSON.parse(fs.readFileSync(path.join(coordBk.dir, 'manifest.json'), 'utf8'));
+  const descManifest = JSON.parse(fs.readFileSync(path.join(descBk.dir, 'manifest.json'), 'utf8'));
+
+  assert.deepEqual(Object.keys(coordManifest.files).sort(), SOURCES.map((s) => s.file).sort());
+  assert.deepEqual(Object.keys(descManifest.files).sort(), ['intrale-platform.json', 'otro-producto.json']);
+  assert.equal(coordManifest.files['waves.json'].checksum, sha256Canonical(src.waves));
+  assert.equal(descManifest.files['otro-producto.json'].checksum, sha256Canonical(d.second));
+  // Ningún archivo de descriptores se coló en el manifest de coordinación.
+  assert.equal(coordManifest.files['intrale-platform.json'], undefined);
+});
+
+test('CA-13′: el backup de descriptores no es world-readable (POSIX)', () => {
+  const descriptorsDir = freshTmp('descperm-src');
+  const backupRoot = freshTmp('descperm-bak');
+  writeDescriptors(descriptorsDir);
+
+  const res = backupDescriptors({ descriptorsDir, backupRoot, epochMs: FIXED_NOW });
+  assert.equal(res.ok, true, res.error);
+
+  // Mismo patrón de skip que ya usa la suite: en Windows el bit de modo no aplica.
+  if (process.platform !== 'win32') {
+    const dirMode = fs.statSync(res.dir).mode & 0o777;
+    assert.equal(dirMode & 0o077, 0, `dir de backup no debe ser accesible por grupo/otros (mode=${dirMode.toString(8)})`);
+    for (const f of ['intrale-platform.json', 'manifest.json']) {
+      const fileMode = fs.statSync(path.join(res.dir, f)).mode & 0o777;
+      assert.equal(fileMode & 0o077, 0, `${f} no debe ser accesible por grupo/otros (mode=${fileMode.toString(8)})`);
+    }
+  }
+});
+
+test('CA-13′: sin descriptores falla cerrado (un backup vacío no es un backup)', () => {
+  const descriptorsDir = freshTmp('descempty-src'); // vacío
+  const backupRoot = freshTmp('descempty-bak');
+  const res = backupDescriptors({ descriptorsDir, backupRoot, epochMs: FIXED_NOW });
+  assert.equal(res.ok, false);
+  assert.equal(res.code, 'descriptors_absent');
+  assert.match(res.error, /durableRegisterProduct/, 'debe decir qué SÍ puebla los descriptores');
+});
+
+// -----------------------------------------------------------------------------
+// CA-13b · El backup de descriptores se puede RESTAURAR (D-5 / AD-3)
+// -----------------------------------------------------------------------------
+
+test('CA-13b: backup → restore devuelve los descriptores íntegros byte a byte', () => {
+  const descriptorsDir = freshTmp('rt-desc');
+  const backupRoot = freshTmp('rt-bak');
+  const d = writeDescriptors(descriptorsDir);
+  const originalBytes = fs.readFileSync(path.join(descriptorsDir, 'intrale-platform.json'));
+
+  const bk = backupDescriptors({ descriptorsDir, backupRoot, epochMs: FIXED_NOW });
+  assert.equal(bk.ok, true, bk.error);
+
+  // Destruir/corromper los descriptores en disco (simula el cutover salido mal).
+  fs.writeFileSync(path.join(descriptorsDir, 'intrale-platform.json'), JSON.stringify({ pwned: true }, null, 2));
+  fs.unlinkSync(path.join(descriptorsDir, 'otro-producto.json'));
+
+  const rs = restoreDescriptors({ fromDir: bk.dir, targetDir: descriptorsDir, backupRoot });
+  assert.equal(rs.ok, true, rs.error);
+  assert.deepEqual(rs.restored.sort(), ['intrale-platform.json', 'otro-producto.json']);
+
+  // Íntegros: byte a byte y por checksum canónico.
+  assert.deepEqual(fs.readFileSync(path.join(descriptorsDir, 'intrale-platform.json')), originalBytes);
+  const back = JSON.parse(fs.readFileSync(path.join(descriptorsDir, 'otro-producto.json'), 'utf8'));
+  assert.equal(sha256Canonical(back), sha256Canonical(d.second));
+});
+
+test('CA-13b: el round-trip preserva los bytes exactos (CRLF e indentación original)', () => {
+  // Los descriptores están VERSIONADOS en git y en Windows vienen con CRLF. Si el
+  // backup/restore re-serializara con JSON.stringify, devolvería un archivo
+  // semánticamente igual pero byte-distinto, ensuciando el `git diff` justo
+  // cuando el operador está tratando de volver atrás del cutover.
+  const descriptorsDir = freshTmp('bytes-desc');
+  const backupRoot = freshTmp('bytes-bak');
+
+  // Formato deliberadamente NO canónico: CRLF, indentación de 4 y newline final.
+  const exotic = '{\r\n    "schemaVersion": "1.0",\r\n    "identity": { "projectId": "intrale-platform" }\r\n}\r\n';
+  const target = path.join(descriptorsDir, 'intrale-platform.json');
+  fs.writeFileSync(target, exotic);
+  const originalBytes = fs.readFileSync(target);
+
+  const bk = backupDescriptors({ descriptorsDir, backupRoot, epochMs: FIXED_NOW });
+  assert.equal(bk.ok, true, bk.error);
+  // El backup ya guarda los bytes crudos, no una re-serialización.
+  assert.deepEqual(fs.readFileSync(path.join(bk.dir, 'intrale-platform.json')), originalBytes);
+
+  fs.writeFileSync(target, JSON.stringify({ pwned: true }, null, 2));
+  const rs = restoreDescriptors({ fromDir: bk.dir, targetDir: descriptorsDir, backupRoot });
+  assert.equal(rs.ok, true, rs.error);
+
+  assert.deepEqual(fs.readFileSync(target), originalBytes, 'la restauración debe devolver los bytes EXACTOS');
+  // Y el checksum del manifest sigue siendo canónico (indiferente al formato).
+  const manifest = JSON.parse(fs.readFileSync(path.join(bk.dir, 'manifest.json'), 'utf8'));
+  assert.equal(
+    manifest.files['intrale-platform.json'].checksum,
+    sha256Canonical(JSON.parse(exotic)),
+    'el checksum es canónico, no un hash de los bytes',
+  );
+});
+
+test('CA-13b: entradas fuera del conjunto cerrado se rechazan fail-closed y no escriben nada', () => {
+  const backupRoot = freshTmp('zsd-bak');
+  const targetDir = freshTmp('zsd-tgt');
+
+  // Cada entrada ataca una contención distinta: '..' (identidad de basename),
+  // subdirectorio (separador de ruta), extensión ajena (gramática cerrada).
+  for (const evilKey of ['../evil.json', 'sub/dir.json', 'x.txt']) {
+    const fromDir = path.join(backupRoot, `bk-${evilKey.replace(/[^a-z0-9]/gi, '_')}`, 'descriptors');
+    fs.mkdirSync(fromDir, { recursive: true });
+
+    // El atacante controla contenido Y checksum: por eso el checksum NO frena un
+    // Zip-Slip, y la gramática cerrada es lo único que contiene.
+    const payload = { pwned: true };
+    const checksum = sha256Canonical(payload);
+    const readTarget = path.resolve(fromDir, evilKey);
+    fs.mkdirSync(path.dirname(readTarget), { recursive: true });
+    fs.writeFileSync(readTarget, JSON.stringify(payload));
+    fs.writeFileSync(
+      path.join(fromDir, 'manifest.json'),
+      JSON.stringify({ schemaVersion: '1.0', kind: 'descriptors', files: { [evilKey]: { present: true, checksum } } }),
+    );
+
+    const escapedWrite = path.resolve(targetDir, evilKey);
+    const existedBefore = fs.existsSync(escapedWrite);
+    const targetBefore = fs.readdirSync(targetDir).sort();
+
+    const rs = restoreDescriptors({ fromDir, targetDir, backupRoot });
+
+    try { fs.unlinkSync(readTarget); } catch { /* noop */ }
+
+    assert.equal(rs.ok, false, `"${evilKey}" debe ser rechazada`);
+    assert.equal(rs.code, 'unsafe_descriptor_entry', `"${evilKey}" ⇒ unsafe_descriptor_entry`);
+    // No escribió NADA: ni fuera de targetDir ni adentro.
+    if (!existedBefore) {
+      assert.equal(fs.existsSync(escapedWrite), false, `"${evilKey}" no debe escribir fuera de targetDir`);
+    }
+    assert.deepEqual(fs.readdirSync(targetDir).sort(), targetBefore, `"${evilKey}" no debe escribir dentro de targetDir`);
+  }
+});
+
+test('CA-13b: backup de descriptores corrupto se rechaza (no reintroduce estado dañado)', () => {
+  const descriptorsDir = freshTmp('dcorrupt-src');
+  const backupRoot = freshTmp('dcorrupt-bak');
+  writeDescriptors(descriptorsDir);
+  const bk = backupDescriptors({ descriptorsDir, backupRoot, epochMs: FIXED_NOW });
+  assert.equal(bk.ok, true, bk.error);
+
+  // Alterar el archivo del backup SIN actualizar el manifest ⇒ checksum no coincide.
+  fs.writeFileSync(path.join(bk.dir, 'intrale-platform.json'), JSON.stringify({ tampered: true }, null, 2));
+  const before = fs.readFileSync(path.join(descriptorsDir, 'intrale-platform.json'));
+
+  const rs = restoreDescriptors({ fromDir: bk.dir, targetDir: descriptorsDir, backupRoot });
+  assert.equal(rs.ok, false);
+  assert.equal(rs.code, 'descriptors_backup_corrupt');
+  // Validación en dos pasos: si UNA entrada falla, no se escribió NINGUNA.
+  assert.deepEqual(fs.readFileSync(path.join(descriptorsDir, 'intrale-platform.json')), before);
+});
+
+test('CA-13b: restore fuera de la raíz de backups se rechaza (anti path-traversal)', () => {
+  const backupRoot = freshTmp('drt-bak');
+  const evil = path.join(backupRoot, '..', '..', 'etc');
+  const rs = restoreDescriptors({ fromDir: evil, backupRoot });
+  assert.equal(rs.ok, false);
+  assert.equal(rs.code, 'descriptors_from_out_of_root');
+});
+
+// -----------------------------------------------------------------------------
+// CA-23 · Los mensajes de error nuevos dicen causa + acción + la trampa (UX-7)
+// -----------------------------------------------------------------------------
+
+test('CA-23: sources_invalidas y sources_no_explicitas dicen causa, acción y la trampa', async () => {
+  const sourceDir = freshTmp('copy-src');
+  const backupRoot = freshTmp('copy-bak');
+  writeSources(sourceDir);
+
+  const invalid = await migrateState({ apply: true, sources: null, sourceDir, backupRoot, now: FIXED_NOW });
+  assert.equal(invalid.code, 'sources_invalidas');
+  assert.match(invalid.error, /debe ser un array/, 'causa');
+  assert.match(invalid.error, /Omitilo|pasá \[\]/, 'acción siguiente');
+  assert.match(invalid.error, /trampa/i, 'la trampa: [] no es "usar el default"');
+
+  const noExp = await migrateState({ apply: true, sourceDir, backupRoot, now: FIXED_NOW });
+  assert.equal(noExp.code, 'sources_no_explicitas');
+  assert.match(noExp.error, /requiere declarar 'sources' explícitamente/, 'causa');
+  assert.match(noExp.error, /apply: false/, 'acción siguiente');
+  assert.match(noExp.error, /No pases SOURCES/, 'la trampa, nombrada explícitamente');
+  assert.match(noExp.error, /waves, blocked, blocked-by-infra, health/, 'nombra las 4 fuentes prohibidas');
+  // AD-1: el flag `--sources` NO existe; el copy no puede mandar a un camino inexistente.
+  assert.doesNotMatch(noExp.error, /--sources/, 'no debe mencionar un flag --sources (AD-1)');
+  assert.doesNotMatch(noExp.error, /--apply/, 'no debe mandar a reintentar --apply de otra forma (AD-1)');
+});
+
+test('CA-23: alcance_no_implementado dice causa, acción y la trampa', () => {
+  const migratePath = path.resolve(__dirname, '..', 'kernel-store-migrate.js');
+  const run = spawnSync(process.execPath, [migratePath, '--apply'], { encoding: 'utf8', timeout: 30_000 });
+  const out = run.stdout;
+  assert.match(out, /Qué pasó:/, 'causa');
+  assert.match(out, /Qué hacer ahora:/, 'acción siguiente');
+  assert.match(out, /La trampa:/, 'la trampa');
+  assert.match(out, /SOURCES/, 'nombra la trampa concreta: pasar SOURCES');
+  assert.match(out, /durableRegisterProduct/, 'nombra lo que SÍ puebla descriptores/catálogo');
+});
+
+// -----------------------------------------------------------------------------
+// CA-24 · Un solo léxico: nunca `descriptor#*`, siempre las claves reales
+// -----------------------------------------------------------------------------
+
+test('CA-24: el migrador y el runbook usan las claves reales, nunca descriptor#*', () => {
+  const repoRoot = path.resolve(__dirname, '..', '..', '..');
+  const targets = [
+    path.join(repoRoot, '.pipeline', 'lib', 'kernel-store-migrate.js'),
+    path.join(repoRoot, 'docs', 'pipeline', 'runbook-cutover-durable.md'),
+  ];
+  for (const f of targets) {
+    assert.ok(fs.existsSync(f), `debe existir ${f}`);
+    const content = fs.readFileSync(f, 'utf8');
+    assert.equal(content.includes('descriptor#*'), false, `${path.basename(f)} no debe usar descriptor#* (CA-24)`);
+    assert.ok(content.includes('descriptor#self'), `${path.basename(f)} debe usar la clave real descriptor#self`);
+    assert.ok(content.includes('catalog#index'), `${path.basename(f)} debe usar la clave real catalog#index`);
+  }
+});
+
+// -----------------------------------------------------------------------------
+// CA-17′ · Cero datos reales en el runbook (vive en git)
+// -----------------------------------------------------------------------------
+
+test('CA-17′: el runbook no filtra ARNs, account-ids ni access key ids', () => {
+  const repoRoot = path.resolve(__dirname, '..', '..', '..');
+  const runbook = path.join(repoRoot, 'docs', 'pipeline', 'runbook-cutover-durable.md');
+  const content = fs.readFileSync(runbook, 'utf8');
+  const leaks = content.split('\n')
+    .map((line, i) => ({ line, n: i + 1 }))
+    .filter(({ line }) => /arn:aws|[0-9]{12}|AKIA[0-9A-Z]{16}/.test(line));
+  assert.deepEqual(leaks, [], `el runbook no debe contener datos reales: ${JSON.stringify(leaks)}`);
 });

--- a/.pipeline/lib/kernel-store-migrate.js
+++ b/.pipeline/lib/kernel-store-migrate.js
@@ -64,6 +64,59 @@ const MIGRATION_KNOWN_KEYS = Object.freeze(SOURCES.map((s) => s.key));
 const BACKUP_DIR_MODE = 0o700;
 const BACKUP_FILE_MODE = 0o600;
 
+// Directorio de descriptores de producto (#4821). Es el ORIGEN REAL del alcance
+// del cutover: 1:N con `product#<id>` en el store durable. No está en SOURCES.
+const DESCRIPTORS_DIR_NAME = 'descriptors';
+
+// Gramática cerrada de nombre de descriptor. Es LITERAL y está hard-codeada a
+// propósito (AD-3/R15): NUNCA se deriva del manifest, de un glob ni de un
+// readdir del backup. El manifest es contenido no confiable y no puede
+// ampliarla. Es el invariante que protege CA-13b.
+const DESCRIPTOR_NAME_RE = /^[A-Za-z0-9._-]+\.json$/;
+
+// -----------------------------------------------------------------------------
+// Copy de errores (CA-23 · UX-7)
+//
+// Estos mensajes son UI: se leen en una terminal, en el medio de la operación y
+// sin el código de error al lado. Cada uno dice QUÉ PASÓ, QUÉ HACER AHORA y
+// —donde aplique— CUÁL ES LA CORRECCIÓN INTUITIVA QUE ESTÁ PROHIBIDA.
+// -----------------------------------------------------------------------------
+
+function errSourcesInvalidas(received) {
+  return (
+    "sources_invalidas: 'sources' debe ser un array de {file,key} u omitirse. " +
+    `Recibido: ${Object.prototype.toString.call(received)}. ` +
+    'Omitilo para usar el default en dry-run, o pasá [] para no migrar ninguna fuente. ' +
+    'Ojo con la trampa: [] NO significa "usar el default" — significa "no migres nada", ' +
+    'y se respeta tal cual.'
+  );
+}
+
+// Nota (AD-1): este código es un error de API, no de CLI. El operador nunca lo
+// ve, porque `--apply` corta antes con `alcance_no_implementado`. Por eso el
+// mensaje NO menciona ningún flag `--sources` (no existe) ni manda a reintentar
+// `--apply` de otra forma: no hay tal camino.
+const ERR_SOURCES_NO_EXPLICITAS =
+  "sources_no_explicitas: migrateState({ apply: true }) requiere declarar 'sources' " +
+  'explícitamente. No pases SOURCES: son las 4 fuentes operativas (waves, blocked, ' +
+  'blocked-by-infra, health) que #5112 prohíbe migrar. Para ver el reporte sin mutar ' +
+  'nada, invocá con apply: false.';
+
+const ERR_ALCANCE_NO_IMPLEMENTADO =
+  'alcance_no_implementado: --apply no puede migrar nada todavía, así que no toca nada.\n' +
+  '\n' +
+  'Qué pasó: el alcance real del cutover (descriptor#self, product#<id>, catalog#index, ' +
+  'signature#, audit#, claim#) todavía NO tiene ruta de migración en este módulo. Las 4 ' +
+  'fuentes que este migrador sí sabe mover (waves, blocked, blocked-by-infra, health) son ' +
+  'justo las que #5112 prohíbe migrar.\n' +
+  '\n' +
+  'Qué hacer ahora: los descriptores y el catálogo se pueblan por durableRegisterProduct ' +
+  '(.pipeline/lib/project-bootstrap.js, #4821) — no por este migrador. Para ver el reporte ' +
+  'del estado de coordinación sin mutar nada, corré este mismo comando SIN flags (dry-run).\n' +
+  '\n' +
+  'La trampa: no "destrabes" esto pasando SOURCES al migrador. Eso migraría exactamente las ' +
+  '4 fuentes operativas prohibidas, que es el falso verde que #5136 existe para evitar.';
+
 // -----------------------------------------------------------------------------
 // Utilidades puras
 // -----------------------------------------------------------------------------
@@ -361,6 +414,32 @@ function buildReport({ mode, items, before, after, actions, backupDir, integrity
  * Migra el estado de coordinación JSON → store durable. Fail-closed, errores
  * como dato (NUNCA throw). Modo default: dry-run (no escribe).
  *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * QUÉ MIGRA ESTA FUNCIÓN, Y QUÉ NO (CA-14′ · D-6 · #5136)
+ * ─────────────────────────────────────────────────────────────────────────────
+ * ESTA FUNCIÓN **NO** PUEBLA LOS DESCRIPTORES NI EL CATÁLOGO DE PRODUCTOS.
+ *
+ * Los descriptores y el catálogo los puebla `durableRegisterProduct`
+ * (`.pipeline/lib/project-bootstrap.js`, #4821). El migrador nunca escribe esas
+ * claves: no hay un solo `putProduct`/`putDescriptor` en este módulo.
+ *
+ * Las claves reales del alcance del cutover, con su nombre literal:
+ *
+ *   - `descriptor#self`  — SINGULAR por partición: cada partición de proyecto
+ *     tiene exactamente UN descriptor propio bajo esa SK fija.
+ *   - `product#<id>`     — uno por producto registrado.
+ *   - `catalog#index`    — índice del catálogo, SK fija y única.
+ *
+ * Relación 1:N: el directorio `.pipeline/descriptors/` tiene N archivos y cada
+ * uno se proyecta a UN `product#<id>` distinto en el store durable, mientras que
+ * `descriptor#self` sigue siendo uno solo por partición. Por eso el backup del
+ * alcance real es `backupDescriptors()` (CA-13′) y no `createBackup()`.
+ *
+ * `SOURCES` (arriba, la constante) son las 4 fuentes OPERATIVAS de coordinación
+ * —waves, blocked, blocked-by-infra, health— que #5112 **prohíbe migrar** en el
+ * cutover. Son justamente lo que esta función sabe mover, y por eso el CLI
+ * `--apply` está bloqueado con `alcance_no_implementado` (D-4).
+ *
  * @param {object} opts
  * @param {object}  opts.store        instancia de `createCoordinationStore` (#4744). REQUERIDA para --apply.
  * @param {boolean} [opts.apply=false] false = dry-run (no escribe); true = persiste.
@@ -368,14 +447,35 @@ function buildReport({ mode, items, before, after, actions, backupDir, integrity
  * @param {string}  [opts.sourceDir]   dir de las 4 fuentes JSON (default `.pipeline/`).
  * @param {string}  [opts.backupRoot]  raíz de backups (default `.pipeline/backup/`).
  * @param {number}  [opts.now]         epoch ms para el <timestamp> del backup (default Date.now()).
- * @param {Array}   [opts.sources]     override de fuentes (para tests).
+ * @param {Array}   [opts.sources]     DECLARACIÓN DE ALCANCE (ya no es un "override para tests").
+ *   Con CA-12′ pasa a ser el contrato: quien muta estado declara qué muta. Tres casos:
+ *     - `undefined` → default `SOURCES`, y SÓLO en dry-run (con `apply:true` ⇒ `sources_no_explicitas`).
+ *     - array, INCLUIDO el vacío → se respeta tal cual; `[]` no migra ninguna fuente.
+ *     - cualquier otra cosa (null, {}, string, number) → `{ ok:false, code:'sources_invalidas' }`.
  * @returns {Promise<{ ok:boolean, code?:string, error?:string, report?:string, backupDir?:string, before?:object, after?:object }>}
  */
 async function migrateState(opts = {}) {
   const apply = opts.apply === true;
   const sourceDir = opts.sourceDir || defaultPipelineDir();
   const backupRoot = opts.backupRoot || path.join(defaultPipelineDir(), 'backup');
-  const sources = Array.isArray(opts.sources) && opts.sources.length ? opts.sources : SOURCES;
+
+  // CA-11′ (D-7 / GURU-10) — `sources` tiene TRES casos, no dos. El guard
+  // `Array.isArray` no se borra: se convierte en un error como DATO en vez de un
+  // fallback silencioso. Nunca throw (contrato del módulo).
+  if (opts.sources !== undefined && !Array.isArray(opts.sources)) {
+    return { ok: false, code: 'sources_invalidas', error: errSourcesInvalidas(opts.sources) };
+  }
+  // CA-12′ (SEC-10) — con `apply`, el alcance se DECLARA. Va acá arriba, ANTES
+  // del backup: es una operación que muta estado, manda el fail-closed.
+  if (apply && opts.sources === undefined) {
+    return { ok: false, code: 'sources_no_explicitas', error: ERR_SOURCES_NO_EXPLICITAS };
+  }
+  // ⚠️ NO reintroducir `&& opts.sources.length`: ésa es exactamente la trampa de
+  // CA-11′ — un array vacío es falsy por `.length` y caía al default, migrando
+  // las 4 fuentes que #5112 prohíbe migrar. Un `[]` llega tal cual a
+  // `readSources`, que devuelve `items = []` ⇒ `no_sources`, que es la semántica
+  // correcta de "no migres nada".
+  const sources = opts.sources !== undefined ? opts.sources : SOURCES;
   const epochMs = Number.isFinite(opts.now) ? opts.now : Date.now();
 
   // 0) Leer fuentes.
@@ -535,6 +635,317 @@ function rollbackState(opts = {}) {
 }
 
 // -----------------------------------------------------------------------------
+// Backup / restore de DESCRIPTORES (CA-13′ / CA-13b · #5136)
+//
+// `createBackup` respalda las 4 fuentes OPERATIVAS de coordinación, que son
+// justo las que #5112 prohíbe migrar. El origen del ALCANCE REAL del cutover es
+// `.pipeline/descriptors/` (1:N con `product#<id>`), que NO está en `SOURCES` —
+// o sea que hoy el alcance real no tiene ni backup ni ruta de restauración.
+// Estos dos helpers cierran ese hueco, con los mismos controles vigentes
+// (0700/0600, sha256 canónico, `assertWithin`) y en DESTINO PROPIO con MANIFEST
+// PROPIO, de modo que nunca puedan pisar el `manifest.json` de `createBackup`
+// para el mismo epoch (GURU-11: `backupDirName` es puro ⇒ mismo epoch, mismo dir).
+//
+// `rollbackState` y su `allowedFiles` NO se tocan (AD-3): su blindaje
+// anti-Zip-Slip funciona PORQUE el set es cerrado y literal.
+// -----------------------------------------------------------------------------
+
+function defaultDescriptorsDir() {
+  return path.join(defaultPipelineDir(), DESCRIPTORS_DIR_NAME);
+}
+
+/**
+ * Respalda `.pipeline/descriptors/` bajo `<backupRoot>/<ts>/descriptors/`, con
+ * manifest propio. Fail-closed, errores como dato (NUNCA throw).
+ *
+ * @param {object} opts
+ * @param {string} [opts.descriptorsDir] origen (default `.pipeline/descriptors/`).
+ * @param {string} [opts.backupRoot]     raíz de backups (default `.pipeline/backup/`).
+ * @param {number} [opts.epochMs]        epoch ms del <timestamp> (default Date.now()).
+ * @returns {{ ok:boolean, code?:string, error?:string, dir?:string, manifest?:object, count?:number }}
+ */
+function backupDescriptors(opts = {}) {
+  const descriptorsDir = opts.descriptorsDir || defaultDescriptorsDir();
+  const backupRoot = opts.backupRoot || path.join(defaultPipelineDir(), 'backup');
+  const epochMs = Number.isFinite(opts.epochMs) ? opts.epochMs : Date.now();
+
+  // 0) Enumerar descriptores con la MISMA gramática cerrada que usa la
+  //    restauración. Orden estable para que el manifest sea determinístico.
+  let names;
+  try {
+    names = fs.existsSync(descriptorsDir)
+      ? fs.readdirSync(descriptorsDir).filter((n) => DESCRIPTOR_NAME_RE.test(n)).sort()
+      : [];
+  } catch (e) {
+    return {
+      ok: false,
+      code: 'descriptors_backup_read_failed',
+      error: `descriptors_backup_read_failed: no se pudo listar ${descriptorsDir}: ${e.message}. `
+        + 'Qué hacer ahora: verificá que el directorio exista y sea legible por el usuario que corre el cutover, y reintentá ANTES de tocar el store.',
+    };
+  }
+  // Fail-closed: un backup vacío que devuelve ok es exactamente el falso verde
+  // que esta historia existe para evitar. Sin descriptores no hay qué respaldar,
+  // y el operador tiene que enterarse ANTES del cutover, no después.
+  if (names.length === 0) {
+    return {
+      ok: false,
+      code: 'descriptors_absent',
+      error: `descriptors_absent: no hay ningún descriptor .json en ${descriptorsDir}, así que no hay nada que respaldar. `
+        + 'Qué hacer ahora: NO sigas con el cutover. Un backup de descriptores vacío no protege nada. '
+        + 'Los descriptores los puebla durableRegisterProduct (.pipeline/lib/project-bootstrap.js, #4821): verificá que el bootstrap del proyecto haya corrido.',
+    };
+  }
+
+  // 1) Destino PROPIO: `<backupRoot>/<ts>/descriptors/`. Un nivel por debajo del
+  //    dir de `createBackup`, así los dos manifests conviven para el mismo epoch.
+  const parentDir = path.join(backupRoot, backupDirName(epochMs));
+  const dir = path.join(parentDir, DESCRIPTORS_DIR_NAME);
+  if (!assertWithin(backupRoot, dir)) {
+    return {
+      ok: false,
+      code: 'descriptors_backup_out_of_root',
+      error: `descriptors_backup_out_of_root: el destino de backup ${dir} cae fuera de ${backupRoot} (rechazado). `
+        + 'Qué hacer ahora: revisá `backupRoot`; no se escribe nada fuera de la raíz de backups.',
+    };
+  }
+  try {
+    fs.mkdirSync(backupRoot, { recursive: true, mode: BACKUP_DIR_MODE });
+    fs.mkdirSync(parentDir, { recursive: true, mode: BACKUP_DIR_MODE });
+    fs.mkdirSync(dir, { recursive: true, mode: BACKUP_DIR_MODE });
+    // mkdir respeta umask; el chmod explícito es el que garantiza el modo.
+    try { fs.chmodSync(parentDir, BACKUP_DIR_MODE); } catch (_) { /* best-effort */ }
+    try { fs.chmodSync(dir, BACKUP_DIR_MODE); } catch (_) { /* best-effort */ }
+  } catch (e) {
+    return {
+      ok: false,
+      code: 'descriptors_backup_mkdir_failed',
+      error: `descriptors_backup_mkdir_failed: no se pudo crear ${dir}: ${e.message}. `
+        + 'Qué hacer ahora: liberá espacio o corregí permisos sobre .pipeline/backup/ y reintentá ANTES del cutover.',
+    };
+  }
+
+  // 2) Copiar cada descriptor + checksum canónico.
+  const manifest = { schemaVersion: '1.0', kind: 'descriptors', createdAt: epochMs, files: {} };
+  for (const name of names) {
+    const src = assertWithin(descriptorsDir, path.join(descriptorsDir, name));
+    const dest = assertWithin(dir, path.join(dir, name));
+    if (!src || !dest) {
+      return {
+        ok: false,
+        code: 'descriptors_backup_out_of_root',
+        error: `descriptors_backup_out_of_root: "${name}" escapa del directorio permitido (rechazado). `
+          + 'Qué hacer ahora: revisá el contenido de .pipeline/descriptors/; no se respalda nada fuera de ese directorio.',
+      };
+    }
+    // Se respalda el archivo BYTE A BYTE (Buffer, sin re-serializar). Los
+    // descriptores están versionados en git y con CRLF: re-serializarlos haría
+    // que la restauración devuelva un archivo semánticamente igual pero
+    // byte-distinto, ensuciando el `git diff` justo cuando el operador está
+    // tratando de volver atrás. El checksum, en cambio, es CANÓNICO (indiferente
+    // al formato), igual que en `createBackup`.
+    let raw;
+    let value;
+    try {
+      raw = fs.readFileSync(src);
+      value = JSON.parse(raw.toString('utf8'));
+    } catch (e) {
+      return {
+        ok: false,
+        code: 'descriptors_backup_read_failed',
+        error: `descriptors_backup_read_failed: no se pudo leer/parsear ${name}: ${e.message}. `
+          + 'Qué hacer ahora: NO sigas con el cutover. Un descriptor ilegible no se puede respaldar con checksum, '
+          + 'y sin checksum la restauración no puede garantizar que lo que vuelve es lo que había. Arreglá el archivo y reintentá.',
+      };
+    }
+    try {
+      fs.writeFileSync(dest, raw, { mode: BACKUP_FILE_MODE });
+      try { fs.chmodSync(dest, BACKUP_FILE_MODE); } catch (_) { /* best-effort */ }
+    } catch (e) {
+      return {
+        ok: false,
+        code: 'descriptors_backup_write_failed',
+        error: `descriptors_backup_write_failed: no se pudo escribir el backup de ${name}: ${e.message}. `
+          + 'Qué hacer ahora: liberá espacio o corregí permisos sobre .pipeline/backup/ y reintentá ANTES del cutover.',
+      };
+    }
+    manifest.files[name] = {
+      present: true,
+      checksum: sha256Canonical(value),
+      records: countRecords(value),
+    };
+  }
+
+  // 3) Manifest PROPIO, dentro del subdirectorio. Nunca pisa el de createBackup.
+  try {
+    fs.writeFileSync(path.join(dir, 'manifest.json'), JSON.stringify(manifest, null, 2), { mode: BACKUP_FILE_MODE });
+    try { fs.chmodSync(path.join(dir, 'manifest.json'), BACKUP_FILE_MODE); } catch (_) { /* best-effort */ }
+  } catch (e) {
+    return {
+      ok: false,
+      code: 'descriptors_manifest_failed',
+      error: `descriptors_manifest_failed: no se pudo escribir el manifest de descriptores: ${e.message}. `
+        + 'Qué hacer ahora: NO sigas con el cutover. Sin manifest no hay checksums, y sin checksums el backup no es restaurable.',
+    };
+  }
+
+  return { ok: true, dir, manifest, count: names.length };
+}
+
+/**
+ * Restaura descriptores desde un backup producido por `backupDescriptors`,
+ * verificando PRIMERO el checksum de cada entrada (no reintroducir estado
+ * corrupto · A05). Fail-closed, errores como dato (NUNCA throw).
+ *
+ * Contención anti-Zip-Slip (AD-3 / R15): como los basenames son dinámicos (1:N
+ * con `product#<id>`), el conjunto cerrado NO puede ser una lista literal de
+ * nombres — es una GRAMÁTICA cerrada, hard-codeada, que el manifest no puede
+ * ampliar. Triple contención independiente: identidad de basename, regex
+ * literal, y `assertWithin` sobre ORIGEN y DESTINO.
+ *
+ * Valida TODAS las entradas antes de escribir ninguna: si una sola se rechaza,
+ * no se escribe nada (fail-closed real, no "a medias").
+ *
+ * @param {object} opts
+ * @param {string} opts.fromDir      dir del backup (`.pipeline/backup/<ts>/descriptors/`).
+ * @param {string} [opts.targetDir]  destino (default `.pipeline/descriptors/`).
+ * @param {string} [opts.backupRoot] raíz permitida (default `.pipeline/backup/`).
+ * @returns {{ ok:boolean, code?:string, error?:string, restored?:string[], fromDir?:string, targetDir?:string }}
+ */
+function restoreDescriptors(opts = {}) {
+  const backupRoot = opts.backupRoot || path.join(defaultPipelineDir(), 'backup');
+  const targetDir = opts.targetDir || defaultDescriptorsDir();
+
+  if (!opts.fromDir || typeof opts.fromDir !== 'string') {
+    return {
+      ok: false,
+      code: 'descriptors_from_required',
+      error: 'descriptors_from_required: falta indicar el directorio del backup de descriptores. '
+        + 'Qué hacer ahora: pasá `fromDir` apuntando a .pipeline/backup/<timestamp>/descriptors/ (el subdirectorio, no el <timestamp> pelado).',
+    };
+  }
+  // Anti path-traversal: `fromDir` DEBE resolver dentro de backupRoot.
+  const fromDir = assertWithin(backupRoot, opts.fromDir);
+  if (!fromDir) {
+    return {
+      ok: false,
+      code: 'descriptors_from_out_of_root',
+      error: `descriptors_from_out_of_root: el origen cae fuera de ${backupRoot} (posible path-traversal, rechazado). `
+        + 'Qué hacer ahora: sólo se restaura desde .pipeline/backup/; copiá el backup adentro de esa raíz si viene de otro lado.',
+    };
+  }
+  if (!fs.existsSync(fromDir)) {
+    return {
+      ok: false,
+      code: 'descriptors_from_not_found',
+      error: `descriptors_from_not_found: no existe el backup ${fromDir}. `
+        + 'Qué hacer ahora: listá .pipeline/backup/ y elegí un <timestamp> que tenga subdirectorio descriptors/. '
+        + 'Ojo con la trampa: el backup de coordinación y el de descriptores son artefactos DISTINTOS; restaurar uno no restaura el otro.',
+    };
+  }
+
+  let manifest;
+  try {
+    manifest = JSON.parse(fs.readFileSync(path.join(fromDir, 'manifest.json'), 'utf8'));
+  } catch (e) {
+    return {
+      ok: false,
+      code: 'descriptors_manifest_unreadable',
+      error: `descriptors_manifest_unreadable: manifest ilegible en ${fromDir}: ${e.message}. `
+        + 'Qué hacer ahora: NO restaures sin manifest — sin checksums no se puede verificar qué vuelve. Elegí otro backup.',
+    };
+  }
+
+  // Paso 1: VALIDAR TODO (gramática + checksum). Sin escribir una sola línea.
+  const planned = [];
+  for (const file of Object.keys((manifest && manifest.files) || {})) {
+    const meta = manifest.files[file];
+    if (!meta || !meta.present) continue;
+
+    // El contenido del manifest NO es de confianza: quien controla el backup
+    // controla la clave Y su checksum. Por eso el checksum no frena un Zip-Slip
+    // y la gramática cerrada es la que contiene.
+    const unsafe = file !== path.basename(file)
+      || file === '.' || file === '..'
+      || !DESCRIPTOR_NAME_RE.test(file);
+    if (unsafe) {
+      return {
+        ok: false,
+        code: 'unsafe_descriptor_entry',
+        error: `unsafe_descriptor_entry: entrada de manifest no permitida "${file}" — sólo se aceptan basenames <nombre>.json sin separadores de ruta (posible path-traversal, rechazado). `
+          + 'Qué hacer ahora: descartá ese backup, es sospechoso. No se restauró nada.',
+      };
+    }
+    // Defensa en profundidad: origen Y destino deben quedar adentro.
+    const src = assertWithin(fromDir, path.join(fromDir, file));
+    const dst = assertWithin(targetDir, path.join(targetDir, file));
+    if (!src || !dst) {
+      return {
+        ok: false,
+        code: 'unsafe_descriptor_entry',
+        error: `unsafe_descriptor_entry: la entrada "${file}" escapa del directorio permitido (posible path-traversal, rechazado). `
+          + 'Qué hacer ahora: descartá ese backup. No se restauró nada.',
+      };
+    }
+
+    // Se leen los bytes crudos: se verifica el checksum CANÓNICO sobre el valor
+    // parseado (fail-closed, indiferente al formato) pero se restaura el archivo
+    // BYTE A BYTE, para no ensuciar el `git diff` de un archivo versionado.
+    let raw;
+    let value;
+    try {
+      raw = fs.readFileSync(src);
+      value = JSON.parse(raw.toString('utf8'));
+    } catch (e) {
+      return {
+        ok: false,
+        code: 'descriptors_backup_file_unreadable',
+        error: `descriptors_backup_file_unreadable: archivo de backup ilegible ${file}: ${e.message}. `
+          + 'Qué hacer ahora: elegí otro backup. No se restauró nada.',
+      };
+    }
+    const actual = sha256Canonical(value);
+    if (actual !== meta.checksum) {
+      return {
+        ok: false,
+        code: 'descriptors_backup_corrupt',
+        error: `descriptors_backup_corrupt: el checksum de ${file} no coincide (esperado ${meta.checksum}, actual ${actual}) — NO se restaura estado corrupto. `
+          + 'Qué hacer ahora: elegí otro <timestamp> de backup. No se restauró nada.',
+      };
+    }
+    planned.push({ file, dst, raw });
+  }
+
+  // Paso 2: recién ahora, escribir.
+  try {
+    fs.mkdirSync(targetDir, { recursive: true });
+  } catch (e) {
+    return {
+      ok: false,
+      code: 'descriptors_restore_mkdir_failed',
+      error: `descriptors_restore_mkdir_failed: no se pudo crear ${targetDir}: ${e.message}. `
+        + 'Qué hacer ahora: corregí permisos sobre .pipeline/ y reintentá. No se restauró nada.',
+    };
+  }
+  const restored = [];
+  for (const p of planned) {
+    try {
+      fs.writeFileSync(p.dst, p.raw);
+      restored.push(p.file);
+    } catch (e) {
+      return {
+        ok: false,
+        code: 'descriptors_restore_write_failed',
+        error: `descriptors_restore_write_failed: no se pudo restaurar ${p.file}: ${e.message}. `
+          + `Qué hacer ahora: corregí permisos y reintentá. Restauración PARCIAL: ya volvieron [${restored.join(', ') || 'ninguno'}].`,
+      };
+    }
+  }
+
+  return { ok: true, restored, fromDir, targetDir };
+}
+
+// -----------------------------------------------------------------------------
 // CLI
 // -----------------------------------------------------------------------------
 
@@ -567,8 +978,36 @@ async function main() {
     return;
   }
 
+  // ───────────────────────────────────────────────────────────────────────────
+  // D-4 / CA-12b / AD-2 (#5136) · Guard de alcance del CLI.
+  //
+  // El alcance real del cutover (descriptor#self / product#<id> / catalog#index /
+  // signature# / audit# / claim#) todavía NO tiene ruta de migración en este
+  // módulo, y `SOURCES` son justo las 4 fuentes operativas que #5112 prohíbe
+  // migrar. Hasta que esa ruta exista, `--apply` dice la verdad y no toca nada.
+  //
+  // Va ACÁ, y no más abajo, por dos motivos duros (AD-2):
+  //   (a) un comando que no puede hacer nada NO debe exigir credenciales AWS;
+  //   (b) `defaultPipelineDir()` resuelve al `.pipeline/` REAL del repo, así que
+  //       un guard puesto después de `migrateState({ apply:true })` escribiría un
+  //       backup real en `.pipeline/backup/` antes de fallar. Acá el efecto de
+  //       filesystem es CERO, que es lo que hace ejecutable y seguro al test CLI.
+  //
+  // ⚠️ PUNTO DE REACTIVACIÓN — NO BORRAR el bloque de abajo (R14). Queda
+  // inalcanzable desde el CLI a propósito, no es dead code accidental: es el
+  // punto exacto donde se reengancha el `--apply` cuando aterrice la ruta de
+  // migración del alcance real.
+  // ───────────────────────────────────────────────────────────────────────────
+  process.stdout.write(ERR_ALCANCE_NO_IMPLEMENTADO + '\n');
+  // `exitCode` en vez de `process.exit()`: en Windows stdout hacia un pipe es
+  // asíncrono y `process.exit()` puede truncar el mensaje. Salir naturalmente
+  // garantiza el flush, y el código de salida sigue siendo ≠ 0 (CA-12b).
+  process.exitCode = 1;
+  return;
+
   // --apply: instanciar el store real. Se hace lazy para no requerir credenciales
   // en dry-run/rollback ni en el import del módulo (los tests inyectan su store).
+  // eslint-disable-next-line no-unreachable
   let store;
   try {
     const { createCoordinationStore } = require('./kernel-coordination-store');
@@ -607,4 +1046,7 @@ module.exports = {
   createBackup,
   readSources,
   parseArgs,
+  // Backup/restore del ALCANCE REAL del cutover (#5136 · CA-13′/CA-13b).
+  backupDescriptors,
+  restoreDescriptors,
 };

--- a/docs/pipeline/ola-puente-kernel-multiproducto.md
+++ b/docs/pipeline/ola-puente-kernel-multiproducto.md
@@ -388,8 +388,13 @@ extiende la allowlist del coordination store (`MIGRATION_KNOWN_KEYS`) con `block
 # 1) Dry-run (DEFAULT, seguro): genera backup + reporte proyectado, NO escribe al store.
 node .pipeline/lib/kernel-store-migrate.js
 
-# 2) Aplicar: escribe idempotente al store, verifica integridad fail-closed, reporta.
-node .pipeline/lib/kernel-store-migrate.js --apply     # (--commit es alias)
+# 2) Aplicar: BLOQUEADO hoy. Falla SIEMPRE con `alcance_no_implementado` y no toca nada.
+#    El alcance real del cutover (descriptor#self / product#<id> / catalog#index /
+#    signature# / audit# / claim#) todavía no tiene ruta de migración en este módulo,
+#    y las 4 fuentes de arriba son justo las que #5112 prohíbe migrar (#5136 · D-4).
+#    Lo que SÍ puebla descriptores y catálogo es `durableRegisterProduct`
+#    (.pipeline/lib/project-bootstrap.js, #4821), no el migrador.
+node .pipeline/lib/kernel-store-migrate.js --apply     # (--commit es alias) → exit 1
 
 # 3) Rollback: restaura los JSON desde un backup VERIFICADO por checksum.
 node .pipeline/lib/kernel-store-migrate.js --rollback --from .pipeline/backup/<timestamp>

--- a/docs/pipeline/runbook-cutover-durable.md
+++ b/docs/pipeline/runbook-cutover-durable.md
@@ -1,0 +1,501 @@
+# Runbook — Cutover al store durable del kernel
+
+> **Para el operador que está por encender `kernel.durable`, o que ya lo encendió
+> y algo se rompió.** Este documento se lee **antes** de tocar nada, y empieza por
+> cómo volver atrás porque eso es lo que hace falta cuando el cutover sale mal.
+>
+> Historia que lo crea: #5136 (split de #5125 ← #5112 ← #5107 · Ola 9.4 · E2).
+
+## 0 · Antes de empezar
+
+### Qué cubre y qué no
+
+Cubre el **encendido del store durable del kernel** (`kernel.durable: false → true`
+en `.pipeline/config.yaml`) y su vuelta atrás: qué respaldar antes, en qué orden
+avanzar, qué reconciliar después y cómo desandar cada paso.
+
+**No** cubre el aprovisionamiento de las tablas de DynamoDB ni la ejecución del
+cutover en sí: eso es #5126 (Bloque B). Este runbook lo **prescribe**; #5126 lo
+**ejecuta**. No hay circularidad: si estás leyendo esto para ejecutar el cutover,
+la fuente de los pasos operativos es este archivo, y el issue que los corre es #5126.
+
+**Cero datos reales.** Este archivo vive en git. Todo lo que parezca un
+identificador de cuenta, un nombre de tabla o un ARN está escrito como
+`<placeholder>` y **se resuelve en el momento**, nunca se commitea.
+
+### Léxico único
+
+Un concepto, un identificador literal, un término en criollo. Sin sinónimos.
+
+| Identificador literal | En criollo | Qué es |
+|---|---|---|
+| `kernel.durable` | *el switch durable* | Flag de `.pipeline/config.yaml` que enciende el store durable. Default `false`. |
+| `kernel.cutover_window` | *la ventana de cutover* | Clave que declara la ventana de mantenimiento del cutover. **Todavía no existe** (la crea #5135). |
+| `kernel.tableName` | *la tabla de no-repudio* | Tabla con `descriptor#self`, `product#<id>`, `catalog#index`, `signature#` y `audit#`. |
+| `kernel.coordinationTableName` | *la tabla de coordinación* | Segunda tabla, donde viven los `claim#` desde #5124. Es la única que admite `DeleteItem`. |
+| `descriptor#self` | *el descriptor propio* | SK fija: **uno solo por partición de proyecto**. |
+| `product#<id>` | *el producto* | Uno por producto registrado. Relación **1:N** con los archivos de `.pipeline/descriptors/`. |
+| `catalog#index` | *el índice del catálogo* | SK fija y única. |
+| `durableRegisterProduct` | *el poblador* | Función de `.pipeline/lib/project-bootstrap.js` (#4821). Es lo único que puebla descriptores y catálogo. |
+| *fuentes de coordinación* | — | Los 4 JSON operativos: `waves.json`, `blocked-issues.json`, `blocked-by-infra.json`, `infra-health.json`. |
+
+> **Ojo con el falso amigo.** El migrador `kernel-store-migrate.js` sabe mover las
+> **fuentes de coordinación**, que son exactamente las que #5112 **prohíbe migrar**
+> en el cutover. El **alcance real** del cutover (`descriptor#self`, `product#<id>`,
+> `catalog#index`) lo puebla `durableRegisterProduct`, no el migrador. Por eso
+> `node .pipeline/lib/kernel-store-migrate.js --apply` está bloqueado y falla
+> siempre con `alcance_no_implementado`. Es a propósito.
+
+### Cómo verificar que estás parado donde creés
+
+Antes de leer una línea más, confirmá en qué estado está el switch durable y si
+ya existe algún backup:
+
+```bash
+grep -n "durable:" .pipeline/config.yaml
+ls -1 .pipeline/backup/ 2>/dev/null | tail -3 || echo "SIN BACKUPS"
+```
+
+Salida esperada **antes** del cutover — el switch apagado y, si nunca corriste el
+dry-run, ningún backup todavía:
+
+```
+  durable: false     # default OFF -- todo sigue en FS, cero llamadas AWS
+SIN BACKUPS
+```
+
+Si `durable:` ya dice `true`, **no estás antes del cutover: estás en el medio de
+uno**. Saltá directo a §1 (rollback) antes de tocar cualquier otra cosa.
+
+---
+
+## 1 · Rollback primero — cómo volver atrás
+
+Antes de encender nada, tenés que saber que podés apagarlo. Y tenés que saber que
+**los artefactos de backup son dos, separados, y restaurar uno NO restaura el otro.**
+
+### Qué restaura el comando automático y qué queda manual
+
+| Qué | Cómo se restaura | ¿Automático? |
+|---|---|---|
+| Las 4 **fuentes de coordinación** (`waves.json`, `blocked-issues.json`, `blocked-by-infra.json`, `infra-health.json`) | `kernel-store-migrate.js --rollback --from <dir>` | ✅ Sí, un comando |
+| Los **descriptores** de `.pipeline/descriptors/` (origen de `product#<id>`) | Helper `restoreDescriptors()` — artefacto y manifest **distintos** | ⚠️ Sí, pero es **otro** comando |
+| `kernel.durable` de vuelta en `false` | Edición manual de `.pipeline/config.yaml` + `node .pipeline/restart.js` | ❌ **Manual** |
+| Ítems ya escritos en la **tabla de no-repudio** (`signature#`, `audit#`) | **No se borran nunca** — son append-only por diseño | ❌ **Manual**, por reconciliación (§2) |
+| Ítems de la **tabla de coordinación** (`claim#`) | Se vencen solos por lease, o `release()` | ❌ **Manual** |
+
+> **Sin esta tabla, esta sección mentiría por omisión.** El rollback automático
+> cubre archivos locales. **No deshace escrituras ya hechas al store durable.**
+
+### Los dos backups se toman ANTES, con el mismo instante
+
+```bash
+# 1) Backup de las fuentes de coordinación (lo hace solo el dry-run del migrador).
+node .pipeline/lib/kernel-store-migrate.js
+# → deja .pipeline/backup/<timestamp>/ con manifest.json
+
+# 2) Backup de los descriptores — artefacto PROPIO, manifest PROPIO.
+node -e "const m=require('./.pipeline/lib/kernel-store-migrate');
+         const r=m.backupDescriptors({});
+         console.log(r.ok ? r.dir : r.error);"
+# → deja .pipeline/backup/<timestamp>/descriptors/ con SU manifest.json
+```
+
+Los dos artefactos conviven bajo el mismo `<timestamp>`: el de descriptores vive
+un nivel **abajo**, en su propio subdirectorio, así que nunca se pisan.
+
+### Cómo verificar el rollback de las fuentes de coordinación
+
+```bash
+node .pipeline/lib/kernel-store-migrate.js --rollback --from .pipeline/backup/<timestamp>
+```
+
+Salida esperada (comparación visual, no interpretativa):
+
+```
+===== MIGRACIÓN ESTADO DE COORDINACIÓN [ROLLBACK] =====
+
+--- BACKUP ---
+[OK] backup en: .pipeline/backup/<timestamp>
+
+--- MIGRACIÓN ---
+clave              | fuente                 | presente | registros | acción
+waves              | waves.json             | sí       | 0         | ausente
+blocked            | blocked-issues.json    | sí       | 0         | ausente
+blocked-by-infra   | blocked-by-infra.json  | sí       | 0         | ausente
+health             | infra-health.json      | sí       | 0         | ausente
+
+--- RESULTADO ---
+[OK] estado restaurado desde el backup.
+```
+
+Si en vez de eso ves `backup_corrupt`, **frená**: el backup no coincide con su
+checksum y el comando **no restauró nada** (es fail-closed a propósito). Elegí
+otro `<timestamp>`. Si ves `from_out_of_root`, el `--from` que pasaste cae fuera
+de `.pipeline/backup/` y se rechazó por path-traversal.
+
+### Cómo verificar el rollback de los descriptores
+
+Es **otro comando**. Correr el de arriba y suponer que los descriptores volvieron
+es el error más caro de esta sección.
+
+```bash
+node -e "const m=require('./.pipeline/lib/kernel-store-migrate');
+         const r=m.restoreDescriptors({ fromDir:'.pipeline/backup/<timestamp>/descriptors' });
+         console.log(JSON.stringify(r,null,2));"
+```
+
+Salida esperada:
+
+```json
+{
+  "ok": true,
+  "restored": [
+    "intrale-platform.json"
+  ],
+  "fromDir": "<ruta-absoluta>/.pipeline/backup/<timestamp>/descriptors",
+  "targetDir": "<ruta-absoluta>/.pipeline/descriptors"
+}
+```
+
+`"ok": false` con `descriptors_backup_corrupt` significa que **no se restauró
+ninguno** (valida todo antes de escribir algo). Con `unsafe_descriptor_entry`, el
+manifest traía una entrada fuera del conjunto cerrado de nombres: **descartá ese
+backup**, es sospechoso.
+
+---
+
+## 2 · Reconciliación de firmas (`signature#`) y auditoría (`audit#`)
+
+Los ítems `signature#` y `audit#` de la **tabla de no-repudio** son **append-only**.
+El rollback no los borra, y no debe. Si el cutover se abortó a mitad de camino,
+lo que queda no es "estado sucio a limpiar" sino **evidencia a reconciliar**.
+
+Este es el procedimiento que **#5126 ejecuta** (CA-B6). Acá se prescribe:
+
+1. **Congelá la ventana.** No dejes que entren firmas nuevas mientras reconciliás
+   (ver §5).
+2. **Listá lo escrito durante la ventana**, acotando por el instante de apertura
+   del cutover, no por "todo".
+3. **Cruzá contra el registro local** de lo que el pipeline creía haber firmado.
+4. **Clasificá cada divergencia** en una de tres, y sólo tres:
+   - *escrita y conocida* → nada que hacer;
+   - *escrita y desconocida localmente* → **no la borres**; anotala en el issue
+     del cutover con su `signatureId` y seguí;
+   - *conocida localmente y no escrita* → se re-firma después de encender, no durante.
+5. **Dejá el resultado por escrito** en el issue del cutover antes de avanzar al
+   bloque siguiente. Una reconciliación que no quedó escrita no ocurrió.
+
+> **Nunca** intentes "limpiar" la tabla de no-repudio con un borrado masivo. La
+> policy IAM no concede `DeleteItem` sobre esa tabla justamente para que esto no
+> sea posible (#5124 · `docs/pipeline/kernel-iam-policy.md`).
+
+### Cómo verificar la reconciliación de `signature#` y `audit#`
+
+```bash
+gh issue view <issue-del-cutover> --json comments \
+  --jq '[.comments[] | select(.body | test("reconciliaci"))] | length'
+```
+
+Salida esperada — al menos un comentario de reconciliación registrado:
+
+```
+1
+```
+
+Si devuelve `0`, la reconciliación **no está documentada**: no avances al bloque
+siguiente hasta que lo esté.
+
+---
+
+## 3 · Clave de cifrado del store: CMK de KMS, no clave AWS-owned
+
+**Decisión: se usa una CMK de KMS.** No una clave AWS-owned. No es preferencia
+estética, y el motivo va escrito porque es el que sostiene el resto del runbook:
+
+- Una clave **AWS-owned no tiene key policy** → no hay dónde declarar quién
+  puede descifrar.
+- **No registra uso en CloudTrail** → §2 se queda sin ancla de auditoría: no
+  podés demostrar quién leyó qué durante la ventana.
+- **No se puede deshabilitar** → el rollback se queda **sin kill-switch
+  criptográfico**. Si perdés control del acceso, con una AWS-owned no tenés
+  ninguna palanca; con una CMK deshabilitás la clave y todo el store queda ilegible
+  en un solo movimiento.
+
+Controles mínimos, no negociables:
+
+- **Principals explícitos en la key policy. NUNCA `"*"`.** Ni en `Principal` ni
+  como comodín efectivo.
+- **`kms:ViaService` restringido a DynamoDB** de la región del store
+  (`dynamodb.<region>.amazonaws.com`), para que la clave no sirva desde otro servicio.
+- **Rotación anual habilitada.**
+- **CloudTrail sobre `Decrypt` y `GenerateDataKey`**, que son las dos operaciones
+  que delatan uso real de la clave.
+
+### Cómo verificar que la clave es una CMK y no una AWS-owned
+
+```bash
+aws kms describe-key --key-id <alias-o-id-de-la-cmk> \
+  --query 'KeyMetadata.{Manager:KeyManager,State:KeyState,Rotation:MultiRegion}'
+```
+
+Salida esperada:
+
+```json
+{
+    "Manager": "CUSTOMER",
+    "State": "Enabled",
+    "Rotation": false
+}
+```
+
+`"Manager": "AWS"` significa que estás mirando una clave **AWS-owned/AWS-managed**:
+**frená el cutover** y creá la CMK antes de seguir.
+
+### Cómo verificar la key policy y el rastro en CloudTrail
+
+```bash
+aws kms get-key-policy --key-id <alias-o-id-de-la-cmk> --policy-name default \
+  --output text | grep -c '"Principal": *{ *"AWS": *"\*"'
+aws kms get-key-rotation-status --key-id <alias-o-id-de-la-cmk>
+```
+
+Salida esperada:
+
+```
+0
+{
+    "KeyRotationEnabled": true
+}
+```
+
+El `0` es el que importa: **cero principals comodín**. Cualquier número mayor a
+cero es un bloqueante duro del cutover. Si `KeyRotationEnabled` es `false`,
+habilitá la rotación antes de avanzar.
+
+---
+
+## 4 · Orden de bloques: CA-0 → Bloque A → Bloque B
+
+El orden **no es negociable**, y cada bloque tiene una puerta de salida:
+
+1. **CA-0** — precondiciones de infraestructura. Las tablas existen, la CMK existe
+   (§3), la policy IAM está aplicada. Sin CA-0, el Bloque B no arranca.
+2. **Bloque A** — **código, sin AWS** (#5124, ya mergeado). Sacar los `claim#` de
+   la tabla de no-repudio y arreglar el reclamo de lease. Puerta de salida: el
+   código de Bloque A tiene que estar **mergeado en el `main` que vas a poner en
+   producción**, no sólo "hecho".
+3. **Bloque B** — **cutover, requiere CA-0** (#5126, abierto). Provisionar, migrar,
+   verificar paridad, encender `kernel.durable` y ensayar el rollback.
+
+> **Prohibido tocar `kernel.durable` antes de que Bloque A esté mergeado.** Es el
+> orden que fijó el `po` en #5112 y no admite atajos: con el claim viejo todavía
+> vivo, el primer agente que muera con un claim tomado deja esa fase trabada para
+> siempre (ver `docs/pipeline/kernel-iam-policy.md`).
+
+### Cómo verificar el orden de bloques antes de avanzar
+
+```bash
+git log --oneline -1 origin/main
+grep -n "coordinationTableName" .pipeline/config.yaml
+```
+
+Salida esperada — el `main` contiene Bloque A y la clave de la tabla de
+coordinación ya está declarada:
+
+```
+<sha-corto> [Split de #5112] Bloque A (1/2): sacar los claims de la particion de no-repudio y arreglar el reclamo de lease (#5153)
+  coordinationTableName: ""   # requerido para el driver real (fail-closed sin ella)
+```
+
+Si el `grep` no devuelve nada, Bloque A **no está** en ese `main`: **frená el
+cutover** y mergeá #5124 antes de seguir.
+
+---
+
+## 5 · La ventana de cutover: `kernel.cutover_window`
+
+**Quién abre:** el operador que ejecuta #5126, y **sólo** él. La apertura se
+anuncia en el issue del cutover antes de tocar nada.
+**Quién cierra:** el **mismo** operador, después de que §2 quedó documentada. No
+se delega el cierre.
+
+**Qué pasa si queda abierta:** el pipeline sigue tratando el estado como si
+estuviera en mantenimiento — la degradación durable no se reporta como falla y
+las escrituras siguen entrando sin el gate de la ventana. En criollo: **la ventana
+abierta es un falso verde permanente.** Cerrarla es parte del cutover, no una
+tarea de limpieza posterior.
+
+> ⚠️ **`kernel.cutover_window` todavía NO existe en `.pipeline/config.yaml`.** La
+> crea la historia hermana **#5135**, que está abierta.
+>
+> **Qué hacer mientras tanto —** mientras #5135 no esté mergeada:
+> 1. **Frená el cutover en este paso.** No hay ventana que abrir, así que no hay
+>    forma de declarar mantenimiento ni de detectar que quedó abierta.
+> 2. **Escalá a #5135** dejando comentario en el issue del cutover con el `sha` de
+>    `main` que verificaste. No improvises la clave a mano: dos historias tocando
+>    `.pipeline/config.yaml` es conflicto garantizado, y **está prohibido
+>    implementarla desde acá**.
+
+### Cómo verificar si `kernel.cutover_window` quedó abierta
+
+Esta pregunta se responde con un comando, no con un párrafo:
+
+```bash
+grep -n "cutover_window" .pipeline/config.yaml || echo "AUSENTE"
+```
+
+Salida esperada **hoy** (#5135 todavía no mergeada — la clave no existe):
+
+```
+AUSENTE
+```
+
+Salida esperada **una vez que #5135 mergee, con la ventana CERRADA**:
+
+```
+  cutover_window: false
+```
+
+Salida que exige acción — **la ventana quedó ABIERTA**:
+
+```
+  cutover_window: true
+```
+
+Si ves `true`, cerrala (ponela en `false`) y corré `node .pipeline/restart.js`.
+Si ves `AUSENTE` y estabas por ejecutar el cutover, aplicá el "qué hacer mientras
+tanto" de arriba.
+
+---
+
+## 6 · Qué NO es el gancho de verificación del cutover
+
+**`kernel-parity.js` no verifica este cutover.** Es la trampa más fácil de este
+runbook, porque buscar "paridad" en el repo lleva derecho ahí.
+
+`.pipeline/lib/kernel-parity.js` es la verificación de paridad **de la Ola 9.1**
+(#4665): compara **blobs de git** entre el tag `pre-ola9-migracion` y un SHA
+congelado. **No lee el store, no conoce `kernel.durable` y no toca DynamoDB.** Que
+dé verde no dice absolutamente nada sobre el cutover durable.
+
+**No lo toques.** No lo extiendas, no lo "adaptes" para que también mire el store:
+es un verificador de otra ola y romperlo deja a 9.1 sin su prueba.
+
+La verificación real del cutover es la de §2 (reconciliación) más la paridad
+funcional que ejecuta #5126.
+
+### Cómo verificar que `kernel-parity.js` no fue tocado
+
+```bash
+git diff --stat origin/main -- .pipeline/lib/kernel-parity.js .pipeline/lib/kernel-parity-92.js
+```
+
+Salida esperada — **vacía**, sin una sola línea:
+
+```
+```
+
+Cualquier línea de salida significa que el diff del cutover tocó un verificador de
+otra ola: **revertí ese cambio** antes de avanzar.
+
+---
+
+## 7 · Decisión de CA-A1 — resuelta en #5124
+
+CA-A1 preguntaba cómo acotar los permisos de `claim#` cuando IAM no sabe scopear
+por prefijo de **sort key**. **La decisión está tomada y mergeada** (#5124,
+cerrado): **Opción B′-1 — separación por `Resource`.**
+
+- Los `claim#` se mudaron a la **tabla de coordinación** (`kernel.coordinationTableName`).
+- La **tabla de no-repudio** dejó de contener `claim#`, así que el `Deny` sobre
+  ella ya **no necesita `Condition`** — y un `Deny` sin condición no puede volver
+  a quedar inerte por un cambio de schema.
+- **Descartada** la PK dedicada (`<projectId>#coord`): el contrato de datos no
+  admite `#` en la PK y habría costado el chequeo anti-IDOR.
+
+La justificación completa está en `docs/pipeline/kernel-iam-policy.md`
+(§ "Qué cambió en #5124"). **No la repliques acá ni la reinterpretes**: si alguna
+vez divergen, manda ese documento.
+
+> **Qué hacer si el `main` que vas a poner en producción NO contiene #5124 —**
+> **frená el cutover en este paso** y mergeá Bloque A primero (§4 tiene el comando
+> que lo verifica). Encender `kernel.durable` sin #5124 reintroduce el claim roto,
+> que traba fases de forma permanente.
+
+### Cómo verificar el estado de la decisión de CA-A1
+
+```bash
+grep -c "Opción B′-1" docs/pipeline/kernel-iam-policy.md
+```
+
+Salida esperada — la decisión está documentada:
+
+```
+1
+```
+
+Si devuelve `0`, estás en un checkout que no tiene #5124: no avances (§4).
+
+---
+
+## Si algo sale mal
+
+### "Corrí `--apply` y me dijo `alcance_no_implementado`"
+
+Es el comportamiento correcto, no un bug. `--apply` está **bloqueado a propósito**
+(#5136 · D-4): el alcance real del cutover no tiene ruta de migración en ese módulo,
+y lo único que ese migrador sabe mover son las **fuentes de coordinación**, que
+#5112 prohíbe migrar. **No lo "destrabes" pasando `SOURCES`**: eso migraría
+exactamente las 4 fuentes prohibidas. Los descriptores y el catálogo los puebla
+`durableRegisterProduct`.
+
+### "Restauré el backup pero los descriptores siguen rotos"
+
+Restauraste **un** artefacto. Son **dos**. Corré también el `restoreDescriptors()`
+de §1 — la tabla del principio dice exactamente qué cubre cada uno.
+
+### "El cutover quedó a mitad y no sé qué se escribió"
+
+No borres nada de la tabla de no-repudio. Andá a §2 y reconciliá: `signature#` y
+`audit#` son append-only, y lo que quedó es evidencia, no basura.
+
+### "Encendí `kernel.durable` y el pipeline no arranca"
+
+Ponelo en `false`, corré `node .pipeline/restart.js` y recién ahí diagnosticá. El
+switch durable es lo primero que se apaga, siempre. Si el error menciona
+`coordinationTableName`, te falta CA-0 (§4): la segunda tabla no está aprovisionada
+y el store de coordinación falla fail-closed al primer claim.
+
+### Cómo verificar que el pipeline volvió a un estado sano
+
+```bash
+grep -n "durable:" .pipeline/config.yaml
+node .pipeline/lib/kernel-store-migrate.js --rollback --from .pipeline/backup/<timestamp> \
+  | tail -2
+```
+
+Salida esperada — el switch durable apagado y el rollback confirmado:
+
+```
+  durable: false     # default OFF -- todo sigue en FS, cero llamadas AWS
+[OK] estado restaurado desde el backup.
+```
+
+Si `durable:` sigue en `true`, el pipeline **no** volvió atrás todavía.
+
+---
+
+## Referencias
+
+- **#5136** — esta historia: alcance del migrador, backup de descriptores y este runbook.
+- **#5135** — hermana: sink fail-loud de degradación durable y `kernel.cutover_window`. **Abierta.**
+- **#5126** — Bloque B: provisionar, migrar, verificar paridad, encender durable y ensayar el rollback. **Abierta.**
+- **#5124** — Bloque A: los `claim#` fuera de la partición de no-repudio. **Cerrada y mergeada.**
+- **#5112 / #5107** — historia madre y épico de la Ola 9.4 (E2).
+- `docs/pipeline/kernel-iam-policy.md` — decisión de CA-A1 y policy IAM del kernel.
+- `docs/pipeline/ola-puente-kernel-multiproducto.md` — diseño del kernel multi-producto y modos del migrador.
+- `docs/pipeline/spike-estado-remoto-hallazgos.md` — §2/§3/§4/§5.3, base documental del cutover.
+- `docs/runbooks/credential-rotation.md` — formato de referencia de este runbook.
+- `.pipeline/lib/kernel-store-migrate.js` — migrador, `backupDescriptors()` y `restoreDescriptors()`.
+- `.pipeline/lib/project-bootstrap.js` — `durableRegisterProduct`, el poblador real (#4821).


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 4 archivos · +1407 -9

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:passed` aplicado por delivery

## Closes

Closes #5136
