### PR TITLE
[Split de #5207] Provisionar las tablas DynamoDB para el cutover durable

### DIFF
--- a/.pipeline/config.yaml
+++ b/.pipeline/config.yaml
@@ -1407,21 +1407,35 @@ cua:
 # de este archivo público (mismo criterio que cua.operator_chat_ids).
 #
 # `normalizeConfig` (lib/kernel-store.js) EXIGE `tableName` no vacío para el
-# driver real: con `durable: true` y `tableName: ""` falla fail-closed. Dejar
-# `tableName`/`region` vacíos mientras `durable: false` es correcto y esperado.
+# driver real: con `durable: true` y `tableName: ""` falla fail-closed.
+#
+# #5210 — Las tres claves (`tableName`/`coordinationTableName`/`region`) ya están
+# POBLADAS contra las tablas reales, y `durable` sigue en `false`. No es una
+# contradicción: poblar nombres es declarativo, `durable` es el único switch del
+# camino AWS. Verificable con `node .pipeline/lib/kernel-table-verify.js`.
 #
 # La tabla + policy IAM (least-privilege, append-only sobre signature#*/audit#*)
 # se aprovisiona con un PASO ADMIN separado (lib/kernel-provision.js +
 # docs/pipeline/kernel-iam-policy.json), NUNCA en el boot normal del pulpo.
 kernel:
-  tableName: ""      # requerido para el driver real (normalizeConfig lo exige)
+  # #5210 CA-1 — Tabla de NO-REPUDIO ya aprovisionada en AWS (ACTIVE, SSE KMS,
+  # deletion protection ON). Poblarla NO enciende nada: todo el camino durable
+  # está gateado por `durable === true` (pulpo.js bootKernelDurable + el
+  # constructor LAZY del store), así que con `durable: false` no se construye
+  # driver ni se emite una sola llamada a DynamoDB. Evidencia redactada y gap de
+  # verificación: docs/pipeline/kernel-tablas-cutover-5210.md.
+  tableName: "intrale-kernel-state"      # requerido para el driver real (normalizeConfig lo exige)
   # #5124 — SEGUNDA tabla, distinta de `tableName`. Desde que la coordinación salió
   # de la partición de no-repudio (Opción B′-1), el claim de fase vive acá y esta
   # tabla es la única que admite `DeleteItem` en la policy IAM. Sin esta clave,
   # `kernel-coordination-store.js` falla fail-closed con el driver real (al primer
   # claim, no en el boot). Aprovisionarla es alcance del cutover (#5126).
-  coordinationTableName: ""   # requerido para el driver real (fail-closed sin ella)
-  region: ""         # región AWS destino (vacío mientras durable:false)
+  #
+  # #5210 — DEBE ser distinta de `tableName`: la política de inmutabilidad
+  # (append-only sobre signature#*/audit#*) es de la tabla de no-repudio y NO se
+  # aplica acá; coordinación conserva `DeleteItem` para liberar claims.
+  coordinationTableName: "intrale-kernel-coordination"   # requerido para el driver real (fail-closed sin ella)
+  region: "us-east-2"         # región AWS destino (ambas tablas viven acá)
   durable: false     # default OFF -- todo sigue en FS, cero llamadas AWS
   # #5135 CA-1 -- Ventana de cutover SUPERVISADA. Default OFF (fail-closed: solo
   # el booleano `true` exacto la abre).

--- a/.pipeline/lib/__tests__/kernel-fase-fs-sin-dynamo-5210.test.js
+++ b/.pipeline/lib/__tests__/kernel-fase-fs-sin-dynamo-5210.test.js
@@ -1,0 +1,180 @@
+'use strict';
+
+// =============================================================================
+// kernel-fase-fs-sin-dynamo-5210.test.js — CA-5 de #5210.
+//
+// LA PREGUNTA QUE RESPONDE
+// ------------------------
+// #5210 pobló `kernel.tableName`, `kernel.coordinationTableName` y
+// `kernel.region` en `config.yaml`. Antes estaban vacíos, y esa vacuidad
+// funcionaba como una segunda red: aunque algo intentara hablar con DynamoDB,
+// `normalizeConfig` fallaba fail-closed por falta de tabla. Esa red ya no está.
+//
+// Entonces: ¿el pipeline sigue completando una fase 100% desde filesystem, sin
+// una sola llamada a AWS? Este test lo prueba **con un sensor**, no por lectura
+// de código.
+//
+// CÓMO SE MIDE
+// ------------
+// Todo el camino a DynamoDB de este repo sale por la AWS CLI
+// (`createAwsCliDynamoDriver` → `spawn('aws', …)`, provisioner-infra.js). Se
+// instrumenta `child_process` (`spawn`/`spawnSync`/`exec`/`execFile`/`execSync`)
+// y se registra cualquier invocación de `aws`. El ciclo de fase se ejecuta con
+// `fs.rename` real sobre un directorio temporal — el mismo mecanismo que usa el
+// pulpo (pendiente/ → trabajando/ → listo/ → procesado/).
+//
+// El test NO levanta un pulpo: hacerlo pisaría el pipeline en producción.
+// Ejercita el mismo movimiento de archivos y el mismo evaluador de completitud.
+// =============================================================================
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const childProcess = require('node:child_process');
+
+const yaml = require('js-yaml');
+const { evaluateParallelPhaseCompletion } = require('../phase-completion');
+
+const CONFIG_PATH = path.join(__dirname, '..', '..', 'config.yaml');
+const FASES = ['pendiente', 'trabajando', 'listo', 'procesado'];
+
+/**
+ * Instala el sensor sobre child_process y devuelve `{ awsCalls, restore }`.
+ * Cualquier intento de hablar con AWS queda registrado (y bloqueado).
+ */
+function instalarSensorAws() {
+    const awsCalls = [];
+    const originales = {};
+    const METODOS = ['spawn', 'spawnSync', 'exec', 'execFile', 'execSync'];
+
+    for (const m of METODOS) {
+        originales[m] = childProcess[m];
+        childProcess[m] = function interceptado(cmd, ...rest) {
+            const linea = String(cmd || '');
+            const args = Array.isArray(rest[0]) ? rest[0].join(' ') : '';
+            const full = `${linea} ${args}`;
+            if (/(^|[\\/\s])aws(\.exe)?($|\s)/i.test(full) || /dynamodb|\bkms\b/i.test(full)) {
+                awsCalls.push({ metodo: m, comando: full.trim() });
+                throw new Error(`SENSOR: llamada AWS no esperada durante la fase FS: ${full.trim()}`);
+            }
+            return originales[m].call(this, cmd, ...rest);
+        };
+    }
+
+    return {
+        awsCalls,
+        restore() {
+            for (const m of METODOS) childProcess[m] = originales[m];
+        },
+    };
+}
+
+function crearFaseTmp() {
+    const raiz = fs.mkdtempSync(path.join(os.tmpdir(), 'fase-5210-'));
+    for (const d of FASES) fs.mkdirSync(path.join(raiz, d), { recursive: true });
+    return raiz;
+}
+
+/** Mueve un archivo de trabajo entre carpetas de estado con rename atómico. */
+function mover(raiz, archivo, desde, hacia) {
+    const origen = path.join(raiz, desde, archivo);
+    const destino = path.join(raiz, hacia, archivo);
+    fs.renameSync(origen, destino);
+    return destino;
+}
+
+// -----------------------------------------------------------------------------
+
+test('CA-5: una fase completa el ciclo pendiente→procesado desde filesystem sin tocar AWS', () => {
+    // La config REAL, con las tres claves ya pobladas: es el escenario que
+    // introduce este issue, no un fixture conveniente.
+    const cfg = yaml.load(fs.readFileSync(CONFIG_PATH, 'utf8')).kernel;
+    assert.equal(cfg.durable, false, 'precondición: el camino durable sigue apagado');
+    assert.ok(cfg.tableName, 'precondición: la tabla de no-repudio ESTÁ configurada');
+    assert.ok(cfg.coordinationTableName, 'precondición: la tabla de coordinación ESTÁ configurada');
+    assert.ok(cfg.region, 'precondición: la región ESTÁ configurada');
+
+    const sensor = instalarSensorAws();
+    const raiz = crearFaseTmp();
+    try {
+        const archivo = '5210.pipeline-dev';
+        const trabajo = { issue: 5210, fase: 'dev', pipeline: 'desarrollo' };
+
+        // 1. Encolado en pendiente/
+        fs.writeFileSync(path.join(raiz, 'pendiente', archivo), yaml.dump(trabajo), 'utf8');
+
+        // 2. El agente lo toma → trabajando/
+        mover(raiz, archivo, 'pendiente', 'trabajando');
+        assert.ok(fs.existsSync(path.join(raiz, 'trabajando', archivo)));
+
+        // 3. El agente escribe su resultado y sale → listo/
+        fs.writeFileSync(
+            path.join(raiz, 'trabajando', archivo),
+            yaml.dump({ ...trabajo, resultado: 'aprobado' }),
+            'utf8',
+        );
+        mover(raiz, archivo, 'trabajando', 'listo');
+
+        // 4. El evaluador de completitud decide con lo que hay EN DISCO.
+        const enListo = yaml.load(fs.readFileSync(path.join(raiz, 'listo', archivo), 'utf8'));
+        const evaluacion = evaluateParallelPhaseCompletion({
+            skillsRequeridos: ['pipeline-dev'],
+            listo: [{ skill: 'pipeline-dev', yaml: enListo }],
+            procesado: [],
+            pendienteSkills: [],
+            trabajandoSkills: [],
+        });
+        assert.equal(evaluacion.todosCompletos, true, 'la fase debe cerrar con el artefacto aprobado');
+        assert.deepEqual(evaluacion.skillsCompletados, ['pipeline-dev']);
+        assert.equal(evaluacion.origenPorSkill['pipeline-dev'], 'listo');
+
+        // 5. Promoción → procesado/
+        mover(raiz, archivo, 'listo', 'procesado');
+        assert.ok(fs.existsSync(path.join(raiz, 'procesado', archivo)));
+        assert.ok(!fs.existsSync(path.join(raiz, 'listo', archivo)));
+
+        // El veredicto del criterio: cero llamadas a AWS en todo el ciclo.
+        assert.deepEqual(sensor.awsCalls, [], 'la fase no debe emitir NINGUNA llamada a DynamoDB/AWS');
+    } finally {
+        sensor.restore();
+        fs.rmSync(raiz, { recursive: true, force: true });
+    }
+});
+
+test('CA-5: cargar la config del kernel no dispara por sí sola ninguna llamada AWS', () => {
+    // Poblar los nombres es declarativo. Si `require` + lectura de config
+    // alcanzaran para abrir una conexión, este test lo delataría.
+    const sensor = instalarSensorAws();
+    try {
+        delete require.cache[require.resolve('../project-bootstrap')];
+        const bootstrap = require('../project-bootstrap');
+        const cfg = bootstrap.readKernelConfig({});
+        assert.equal(cfg.durable, false);
+        assert.ok(cfg.tableName, 'la tabla está configurada…');
+
+        const verify = require('../kernel-table-verify');
+        const leida = verify.readKernelTablesConfig({ configPath: CONFIG_PATH });
+        assert.equal(leida.durable, false, '…y el switch durable sigue apagado');
+
+        assert.deepEqual(sensor.awsCalls, [], 'leer config NUNCA debe hablar con AWS');
+    } finally {
+        sensor.restore();
+    }
+});
+
+test('CA-5: el sensor detecta de verdad una llamada AWS (contra-prueba)', () => {
+    // Un sensor que no dispara nunca no prueba nada. Se verifica que reacciona.
+    const sensor = instalarSensorAws();
+    try {
+        assert.throws(
+            () => childProcess.spawn('aws', ['dynamodb', 'describe-table', '--table-name', 'x']),
+            /SENSOR: llamada AWS no esperada/,
+        );
+        assert.equal(sensor.awsCalls.length, 1);
+        assert.match(sensor.awsCalls[0].comando, /dynamodb describe-table/);
+    } finally {
+        sensor.restore();
+    }
+});

--- a/.pipeline/lib/__tests__/kernel-table-verify-5210.test.js
+++ b/.pipeline/lib/__tests__/kernel-table-verify-5210.test.js
@@ -1,0 +1,374 @@
+'use strict';
+
+// =============================================================================
+// kernel-table-verify-5210.test.js — Verificador read-only de las tablas del
+// kernel (#5210).
+//
+// Cobertura por criterio:
+//   CA-1 : config.yaml real tiene las tres claves pobladas y `durable:false`.
+//   CA-2 : `summarizeTable` sólo aprueba con los cuatro controles OBSERVADOS.
+//   CA-3 : `classifyDeny` separa implicitDeny de explicitDeny (decide el remedio)
+//          y ningún gap puede declararse cumplido (`assertNoUnverifiedClaims`).
+//   CA-4 : la tabla de coordinación se mantiene DISTINTA de la de no-repudio.
+//   CA-5 : con `durable:false` el pipeline no construye store ni toca DynamoDB.
+//   CA-7 : allowlist read-only — el módulo no puede aprovisionar nada.
+//   A03/A05/A09 : sin shell, sin hardcode, con redacción.
+//
+// Los fakes evitan cualquier llamada real a AWS: la suite corre offline.
+// =============================================================================
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const v = require('../kernel-table-verify');
+
+const CONFIG_PATH = path.join(__dirname, '..', '..', 'config.yaml');
+
+// --- Fixtures ---------------------------------------------------------------
+
+const ACCT = '123456789012';
+const KEY_ARN = `arn:aws:kms:us-east-2:${ACCT}:key/aaaa1111-bbbb-2222-cccc-333344445555`;
+
+function describeTablePayload(overrides = {}) {
+    return {
+        Table: {
+            TableName: 'intrale-kernel-state',
+            TableStatus: 'ACTIVE',
+            TableArn: `arn:aws:dynamodb:us-east-2:${ACCT}:table/intrale-kernel-state`,
+            BillingModeSummary: { BillingMode: 'PAY_PER_REQUEST' },
+            SSEDescription: { Status: 'ENABLED', SSEType: 'KMS', KMSMasterKeyArn: KEY_ARN },
+            DeletionProtectionEnabled: true,
+            ...overrides,
+        },
+    };
+}
+
+// Mensajes REALES del AWS CLI (capturados con el perfil `kernel-runtime`,
+// con el account id sustituido). Se guardan textuales a propósito: si AWS
+// cambia el wording, esta suite lo detecta antes que una auditoría.
+const DENY_IMPLICITO = `An error occurred (AccessDeniedException) when calling the DescribeContinuousBackups operation: `
+    + `User: arn:aws:iam::${ACCT}:user/intrale-kernel-runtime is not authorized to perform: `
+    + `dynamodb:DescribeContinuousBackups on resource: arn:aws:dynamodb:us-east-2:${ACCT}:table/intrale-kernel-state `
+    + `because no identity-based policy allows the dynamodb:DescribeContinuousBackups action`;
+
+const DENY_EXPLICITO = `An error occurred (AccessDeniedException) when calling the LookupEvents operation: `
+    + `User: arn:aws:iam::${ACCT}:user/intrale-kernel-runtime is not authorized to perform: `
+    + `cloudtrail:LookupEvents with an explicit deny in an identity-based policy: `
+    + `arn:aws:iam::${ACCT}:policy/IntraleKernelStore`;
+
+const CFG_OK = {
+    tableName: 'intrale-kernel-state',
+    coordinationTableName: 'intrale-kernel-coordination',
+    region: 'us-east-2',
+    durable: false,
+};
+
+/**
+ * Runner fake: responde describe-table con éxito y deniega todo lo demás.
+ * Registra cada comando para poder afirmar QUÉ se invocó (y qué no).
+ */
+function fakeAwsRunner(opts = {}) {
+    const calls = [];
+    return {
+        profile: 'kernel-runtime',
+        calls,
+        async run(args) {
+            calls.push(args.join(' '));
+            const verb = `${args[0]} ${args[1]}`;
+            if (verb === 'dynamodb describe-table') {
+                const idx = args.indexOf('--table-name');
+                const name = args[idx + 1];
+                if (opts.tablaFaltante === name) {
+                    return { code: 255, stdout: '', stderr: `An error occurred (ResourceNotFoundException): Requested resource not found` };
+                }
+                return {
+                    code: 0,
+                    stdout: JSON.stringify(describeTablePayload({
+                        TableName: name,
+                        TableArn: `arn:aws:dynamodb:us-east-2:${ACCT}:table/${name}`,
+                        ...(opts.tableOverrides || {}),
+                    })),
+                    stderr: '',
+                };
+            }
+            if (verb === 'cloudtrail lookup-events' || verb === 'kms list-aliases') {
+                return { code: 254, stdout: '', stderr: DENY_EXPLICITO };
+            }
+            return { code: 254, stdout: '', stderr: DENY_IMPLICITO };
+        },
+    };
+}
+
+// --- CA-3: clasificación del deny -------------------------------------------
+
+test('CA-3: un deny por falta de Allow se clasifica implicitDeny', () => {
+    const r = v.classifyDeny(DENY_IMPLICITO);
+    assert.equal(r.type, 'implicitDeny');
+    assert.equal(r.action, 'dynamodb:DescribeContinuousBackups');
+    assert.equal(r.policy, null, 'un implicitDeny no nombra policy: no hay Deny que editar');
+});
+
+test('CA-3: un Deny explícito se clasifica explicitDeny y nombra la policy', () => {
+    const r = v.classifyDeny(DENY_EXPLICITO);
+    assert.equal(r.type, 'explicitDeny');
+    assert.equal(r.action, 'cloudtrail:LookupEvents');
+    assert.match(r.policy, /policy\/IntraleKernelStore$/);
+    // La distinción no es cosmética: con explicitDeny agregar permisos NO
+    // destraba nada, y confundirlo manda al operador a una remediación inútil.
+    assert.notEqual(r.type, 'implicitDeny');
+});
+
+test('CA-3: sin denegación devuelve none, y un error ajeno no se disfraza de deny', () => {
+    assert.equal(v.classifyDeny('').type, 'none');
+    assert.equal(v.classifyDeny('An error occurred (ResourceNotFoundException)').type, 'error');
+});
+
+test('CA-3: un NotFound NO es evidencia de permisos (no se clasifica como deny)', () => {
+    // Trampa metodológica real: la primera corrida del PO contra un key ID
+    // enmascarado devolvió NotFoundException y podía leerse como "no tengo
+    // permiso". Son cosas distintas y el verificador no debe confundirlas.
+    const r = v.classifyDeny('An error occurred (NotFoundException) when calling the DescribeKey operation');
+    assert.equal(r.type, 'error');
+    assert.equal(r.action, null);
+});
+
+// --- CA-3: prohibido declarar cumplido lo no observado ----------------------
+
+test('CA-3: assertNoUnverifiedClaims aborta si un gap se marca como verificado', () => {
+    const report = { gaps: [{ control: 'PITR', verified: true }] };
+    assert.throws(() => v.assertNoUnverifiedClaims(report), /sin evidencia observada/);
+    // Y el render se apoya en el mismo fusible: un verde falso nunca llega a un doc.
+    assert.throws(() => v.renderMarkdown({ ...report, config: CFG_OK, perfil: 'x', tables: [] }), /sin evidencia observada/);
+});
+
+test('CA-3: los gaps del reporte real quedan en verified:null, nunca en true', async () => {
+    const report = await v.verifyKernelTables({ runner: fakeAwsRunner(), config: CFG_OK });
+    assert.ok(report.gaps.length > 0, 'debe sondear los controles no verificables');
+    for (const g of report.gaps) {
+        assert.notEqual(g.verified, true, `el control "${g.control}" no puede declararse cumplido`);
+        assert.equal(g.verified, null);
+    }
+    const controles = report.gaps.map((g) => g.control).join(' | ');
+    assert.match(controles, /PITR/);
+    assert.match(controles, /CMK/);
+    assert.match(controles, /CloudTrail/);
+    assert.doesNotThrow(() => v.assertNoUnverifiedClaims(report));
+});
+
+test('CA-3: cada gap trae la remediación que corresponde a su tipo de deny', async () => {
+    const report = await v.verifyKernelTables({ runner: fakeAwsRunner(), config: CFG_OK });
+    const explicito = report.gaps.find((g) => g.deny === 'explicitDeny');
+    const implicito = report.gaps.find((g) => g.deny === 'implicitDeny');
+    assert.match(explicito.remediacion, /NO alcanza/);
+    assert.match(implicito.remediacion, /agregando el permiso read-only/);
+});
+
+// --- CA-2: sólo se aprueba lo observado -------------------------------------
+
+test('CA-2: una tabla ACTIVE con SSE KMS y deletion protection queda verificada', () => {
+    const s = v.summarizeTable(describeTablePayload(), { tableName: 'intrale-kernel-state', region: 'us-east-2' });
+    assert.equal(s.verified, true);
+    assert.deepEqual(s.missing, []);
+    assert.equal(s.status, 'ACTIVE');
+    assert.equal(s.sse.type, 'KMS');
+    assert.equal(s.deletionProtection, true);
+});
+
+test('CA-2: SSE administrado por AWS (sin SSEDescription) NO se aprueba', () => {
+    // Una tabla sin `SSEDescription` está cifrada con la clave propia de DynamoDB,
+    // que NO es lo que el criterio pide demostrar.
+    const s = v.summarizeTable(describeTablePayload({ SSEDescription: undefined }));
+    assert.equal(s.verified, false);
+    assert.match(s.missing.join(' '), /SSEDescription\.Status esperado ENABLED/);
+});
+
+test('CA-2: deletion protection ausente se reporta "no observado", no false', () => {
+    const payload = describeTablePayload();
+    delete payload.Table.DeletionProtectionEnabled;
+    const s = v.summarizeTable(payload);
+    assert.equal(s.deletionProtection, null, 'ausente ≠ false: asumir el default sería inferir');
+    assert.equal(s.verified, false);
+    assert.match(s.missing.join(' '), /observado ausente/);
+});
+
+test('CA-2: una tabla que no está ACTIVE o con SSE distinto de KMS falla', () => {
+    assert.equal(v.summarizeTable(describeTablePayload({ TableStatus: 'CREATING' })).verified, false);
+    const aes = v.summarizeTable(describeTablePayload({
+        SSEDescription: { Status: 'ENABLED', SSEType: 'AES256' },
+    }));
+    assert.equal(aes.verified, false);
+    assert.match(aes.missing.join(' '), /SSEType esperado KMS/);
+});
+
+test('CA-2: describe-table sin Table => no existe, no verificada', () => {
+    const s = v.summarizeTable({}, { tableName: 'intrale-kernel-state' });
+    assert.equal(s.exists, false);
+    assert.equal(s.verified, false);
+});
+
+test('CA-2: una tabla de otra región no se da por buena', () => {
+    const s = v.summarizeTable(describeTablePayload(), { region: 'us-west-1' });
+    assert.equal(s.verified, false);
+    assert.match(s.missing.join(' '), /región esperada us-west-1/);
+});
+
+test('CA-2: si una tabla no existe el reporte global NO queda verificable', async () => {
+    const runner = fakeAwsRunner({ tablaFaltante: 'intrale-kernel-coordination' });
+    const report = await v.verifyKernelTables({ runner, config: CFG_OK });
+    assert.equal(report.verificable, false);
+    const coord = report.tables.find((t) => t.rol === 'coordinación');
+    assert.equal(coord.exists, false);
+});
+
+// --- A09: redacción ---------------------------------------------------------
+
+test('A09: la redacción borra el account id pero preserva región y recurso', () => {
+    const out = v.redactAwsEvidence(`arn:aws:dynamodb:us-east-2:${ACCT}:table/intrale-kernel-state`);
+    assert.ok(!out.includes(ACCT), 'el account id no puede quedar en la evidencia');
+    assert.match(out, /<ACCT>/);
+    // Sin región ni nombre de tabla la evidencia no probaría nada — por eso NO
+    // se usa `redactSecretValue`, que borra el ARN entero.
+    assert.match(out, /us-east-2/);
+    assert.match(out, /table\/intrale-kernel-state/);
+});
+
+test('A09: el UUID de la CMK se trunca conservando el prefijo correlacionable', () => {
+    const out = v.redactAwsEvidence(KEY_ARN);
+    assert.ok(!out.includes('333344445555'), 'el UUID completo de la clave no se publica');
+    assert.match(out, /key\/aaaa1111-<REDACTED>/);
+});
+
+test('A09: una credencial embebida se redacta aunque venga junto a un ARN', () => {
+    const out = v.redactAwsEvidence(`user AKIAIOSFODNN7EXAMPLE en arn:aws:iam::${ACCT}:user/intrale-kernel-runtime`);
+    assert.ok(!out.includes('AKIAIOSFODNN7EXAMPLE'));
+    assert.ok(!out.includes(ACCT));
+});
+
+test('A09: el reporte completo no filtra account id ni UUID de clave', async () => {
+    const report = await v.verifyKernelTables({ runner: fakeAwsRunner(), config: CFG_OK });
+    const dump = JSON.stringify(report);
+    assert.ok(!dump.includes(ACCT), 'account id filtrado en el reporte');
+    assert.ok(!dump.includes('333344445555'), 'UUID de CMK filtrado en el reporte');
+    // El markdown se renderiza desde el mismo reporte ya redactado.
+    assert.ok(!v.renderMarkdown(report).includes(ACCT));
+});
+
+// --- CA-7 / A03: allowlist read-only ----------------------------------------
+
+test('CA-7: el runner rechaza cualquier comando que no sea de lectura', async () => {
+    const spawnSpy = () => { throw new Error('no debería spawnear'); };
+    const runner = v.createReadOnlyAwsRunner({ spawn: spawnSpy });
+    // Aprovisionar es alcance de #5203, no de este módulo.
+    await assert.rejects(
+        () => runner.run(['dynamodb', 'create-table', '--table-name', 'x']),
+        /fuera de la allowlist read-only/,
+    );
+    await assert.rejects(() => runner.run(['dynamodb', 'delete-table']), /allowlist/);
+    await assert.rejects(() => runner.run(['dynamodb', 'update-continuous-backups']), /allowlist/);
+    await assert.rejects(() => runner.run(['kms', 'create-key']), /allowlist/);
+});
+
+test('CA-7: la allowlist sólo contiene verbos de lectura', () => {
+    for (const cmd of v.READONLY_COMMANDS) {
+        assert.match(cmd, /^(dynamodb|kms|cloudtrail) (describe|list|get|lookup)-/, `verbo mutante en la allowlist: ${cmd}`);
+    }
+});
+
+test('CA-7: la verificación real sólo emitió comandos de lectura', async () => {
+    const runner = fakeAwsRunner();
+    await v.verifyKernelTables({ runner, config: CFG_OK });
+    assert.ok(runner.calls.length > 0);
+    for (const call of runner.calls) {
+        const verb = call.split(' ').slice(0, 2).join(' ');
+        assert.ok(v.READONLY_COMMANDS.includes(verb), `comando no permitido: ${verb}`);
+    }
+});
+
+test('A03: el spawn se hace sin shell y con args como array', async () => {
+    let capturado = null;
+    const fakeSpawn = (cmd, args, opts) => {
+        capturado = { cmd, args, opts };
+        return {
+            stdout: { on: (_e, cb) => cb('{}') },
+            stderr: { on: () => {} },
+            on: (evt, cb) => { if (evt === 'close') cb(0); },
+        };
+    };
+    const runner = v.createReadOnlyAwsRunner({ spawn: fakeSpawn, profile: 'kernel-runtime' });
+    await runner.run(['dynamodb', 'describe-table', '--table-name', 'intrale-kernel-state']);
+    assert.equal(capturado.cmd, 'aws');
+    assert.equal(capturado.opts.shell, false, 'shell:true habilitaría inyección de comandos');
+    assert.ok(Array.isArray(capturado.args));
+    assert.deepEqual(capturado.args.slice(-4), ['--profile', 'kernel-runtime', '--output', 'json']);
+});
+
+// --- A05 / CA-4: config fail-closed y separación de tablas ------------------
+
+test('A05: sin config no se verifica nada (fail-closed, sin hardcode)', () => {
+    assert.throws(
+        () => v.readKernelTablesConfig({ kernelConfig: {} }),
+        /faltan claves de config/,
+    );
+    assert.throws(
+        () => v.readKernelTablesConfig({ kernelConfig: { tableName: 'a', coordinationTableName: 'b' } }),
+        /kernel\.region/,
+    );
+});
+
+test('CA-4: dos tablas iguales es fail-closed (coordinación no hereda la inmutabilidad)', () => {
+    assert.throws(
+        () => v.readKernelTablesConfig({
+            kernelConfig: { tableName: 'misma', coordinationTableName: 'misma', region: 'us-east-2' },
+        }),
+        /MISMA tabla/,
+    );
+});
+
+test('CA-4: el verificador sondea el TTL de coordinación, no el de no-repudio', () => {
+    const probes = v.buildGapProbes(CFG_OK, KEY_ARN);
+    const ttl = probes.filter((p) => p.args[1] === 'describe-time-to-live');
+    assert.equal(ttl.length, 1, 'el TTL sólo aplica a la tabla de coordinación');
+    assert.ok(ttl[0].args.includes('intrale-kernel-coordination'));
+    // La tabla de no-repudio NO debe tener TTL: un TTL ahí sería una ruta de
+    // borrado sobre evidencia append-only.
+    assert.ok(!ttl[0].args.includes('intrale-kernel-state'));
+});
+
+// --- CA-1 / CA-5: config.yaml real ------------------------------------------
+
+test('CA-1: config.yaml real tiene las tres claves pobladas y tablas distintas', () => {
+    const cfg = v.readKernelTablesConfig({ configPath: CONFIG_PATH });
+    assert.ok(cfg.tableName.length > 0);
+    assert.ok(cfg.coordinationTableName.length > 0);
+    assert.ok(cfg.region.length > 0);
+    assert.notEqual(cfg.tableName, cfg.coordinationTableName);
+});
+
+test('CA-5: config.yaml real mantiene kernel.durable en false', () => {
+    const cfg = v.readKernelTablesConfig({ configPath: CONFIG_PATH });
+    assert.equal(cfg.durable, false, 'poblar los nombres NO debe encender el camino durable');
+});
+
+test('CA-5: con durable:false el bootstrap resuelve por filesystem y no instancia el store', async () => {
+    // Contra-prueba del riesgo real de esta historia: ahora que `tableName` y
+    // `region` tienen valor, ¿alcanza eso para que algo hable con DynamoDB?
+    // No: el único switch es `durable`.
+    const bootstrap = require('../project-bootstrap');
+    const cfg = bootstrap.readKernelConfig({});
+    assert.equal(cfg.durable, false);
+    assert.ok(cfg.tableName, 'la tabla está configurada…');
+    assert.equal(cfg.durable, false, '…y aun así el camino durable sigue apagado');
+
+    // Y el store durable ni siquiera se construye.
+    let storeInstanciado = false;
+    await bootstrap.durableRegisterProduct(
+        { projectId: 'demo' },
+        {},
+        {
+            kernelConfig: { durable: false, tableName: cfg.tableName, region: cfg.region },
+            createKernelStore: () => { storeInstanciado = true; return {}; },
+        },
+    ).catch(() => {});
+    assert.equal(storeInstanciado, false, 'durable:false NUNCA debe instanciar el store durable');
+});

--- a/.pipeline/lib/kernel-table-verify.js
+++ b/.pipeline/lib/kernel-table-verify.js
@@ -1,0 +1,590 @@
+'use strict';
+
+// =============================================================================
+// kernel-table-verify.js — Verificador READ-ONLY de las tablas del kernel (#5210)
+//
+// CONTEXTO
+// --------
+// Las dos tablas del cutover durable (no-repudio + coordinación) YA están
+// aprovisionadas en AWS (decisión del operador del 30/07). Lo que faltaba no era
+// crearlas sino **probar su postura de seguridad y documentar honestamente lo que
+// el perfil acotado NO deja probar**. Eso es exactamente lo que hace este módulo.
+//
+// QUÉ NO ES (CA-7 · límite explícito con #5203)
+// ---------------------------------------------
+// **NO aprovisiona nada.** No crea tablas, no crea/rota la CMK, no toca IAM. Ese
+// camino vive en `kernel-aws-bootstrap.js` / `kernel-cmk-provision.js` (PR #5203,
+// todavía abierto) y en `kernel-provision.js` (main). Reimplementarlo acá
+// generaría conflicto al mergear ese PR. Este módulo sólo OBSERVA.
+//
+// LA IDEA CENTRAL: un AccessDenied NO es un hallazgo, es un GAP (CA-3)
+// --------------------------------------------------------------------
+// El perfil `kernel-runtime` es deliberadamente acotado y no puede leer PITR, la
+// CMK ni CloudTrail. La tentación es tratar "no pude verificarlo" como "está
+// bien" — es la falla de auditoría clásica. Acá se corta de raíz:
+//
+//   - `summarizeTable` sólo emite `verified: true` sobre campos OBSERVADOS en el
+//     `describe-table`. Ningún control se infiere.
+//   - Los controles no observables salen en `gaps[]` con `verified: null` — nunca
+//     `true`, nunca `false`. `null` es "no sé", y eso es un estado legítimo.
+//   - `assertNoUnverifiedClaims` es un fusible: si alguien mutara un gap a
+//     `verified: true`, el render TIRA en vez de imprimir un verde falso.
+//
+// implicitDeny vs explicitDeny: la distinción que decide el remedio
+// -----------------------------------------------------------------
+// No es trivia IAM, cambia quién destraba y cómo:
+//   - implicitDeny  → falta un `Allow`. Se destraba agregando permisos read-only.
+//   - explicitDeny  → hay un `Deny` en `policy/IntraleKernelStore`. Un `Deny`
+//     explícito GANA sobre cualquier `Allow` posterior: agregar permisos NO
+//     alcanza, hay que editar esa policy con un principal con gestión IAM.
+// Confundirlos manda al operador a una remediación que no puede funcionar.
+//
+// SEGURIDAD
+// ---------
+//   - **Allowlist de comandos** (`READONLY_COMMANDS`): cualquier verbo fuera de
+//     la lista es rechazado ANTES de spawnear. Sin `shell:true`, args como array
+//     ⇒ sin inyección de comandos (A03).
+//   - **Sin hardcode** (A05): nombres/región salen EXCLUSIVAMENTE de la sección
+//     `kernel:` de `config.yaml`. Fail-closed si faltan o si las dos tablas son
+//     la misma (un fallback silencioso a tabla compartida rompería la separación
+//     de no-repudio vs coordinación).
+//   - **Redacción** (A09): account IDs y UUID de CMK se enmascaran; los patrones
+//     de secreto de `redact.js` se reaplican encima. Se PRESERVAN servicio,
+//     región y nombre de recurso: sin eso la evidencia no probaría nada.
+// =============================================================================
+
+const path = require('path');
+
+const { SECRET_VALUE_PATTERNS, REDACTION_MARKER } = require('./redact');
+
+// -----------------------------------------------------------------------------
+// Allowlist de comandos: SÓLO lectura. Fail-closed ante cualquier otra cosa.
+// -----------------------------------------------------------------------------
+
+const READONLY_COMMANDS = Object.freeze([
+    'dynamodb describe-table',
+    'dynamodb describe-continuous-backups',
+    'dynamodb describe-time-to-live',
+    'kms describe-key',
+    'kms list-aliases',
+    'kms get-key-rotation-status',
+    'cloudtrail lookup-events',
+]);
+
+const ACCOUNT_MASK = '<ACCT>';
+const DEFAULT_PROFILE = 'kernel-runtime';
+
+// -----------------------------------------------------------------------------
+// Redacción de evidencia AWS
+// -----------------------------------------------------------------------------
+
+// `redactSecretValue` (redact.js) reemplaza el ARN ENTERO por `[REDACTED]`, que
+// es correcto para un log de error pero destruye la evidencia: sin el ARN no se
+// puede probar que el SSE es KMS ni que las dos tablas son distintas. Acá se
+// enmascara SÓLO la parte sensible (account id, UUID de la clave) y se preserva
+// la topología que el criterio pide demostrar.
+const NON_TOPOLOGY_SECRET_PATTERNS = SECRET_VALUE_PATTERNS.filter((p) => !p.topology);
+
+// Account id: los 12 dígitos entre `:` dentro de un ARN, y también la forma
+// `iam::<acct>:` que aparece en los mensajes de AccessDenied.
+const ARN_ACCOUNT_RE = /(arn:aws[a-z0-9-]*:[a-z0-9-]*:[a-z0-9-]*:)(\d{12})(?=:)/g;
+const IAM_ACCOUNT_RE = /(arn:aws[a-z0-9-]*:iam::)(\d{12})(?=:)/g;
+// UUID de una CMK: se conserva el primer bloque para poder correlacionar dos
+// referencias a la MISMA clave (dato central: ambas tablas comparten key ARN)
+// sin publicar el identificador completo.
+const KMS_KEY_UUID_RE = /\bkey\/([0-9a-f]{8})-[0-9a-f-]{20,}\b/gi;
+
+/**
+ * Enmascara la topología sensible de un string de evidencia AWS.
+ * Preserva servicio/región/nombre de recurso (lo que el CA-2 exige probar).
+ * @param {string} value
+ * @returns {string}
+ */
+function redactAwsEvidence(value) {
+    if (typeof value !== 'string' || value.length === 0) return value;
+    let out = value;
+    out = out.replace(IAM_ACCOUNT_RE, `$1${ACCOUNT_MASK}`);
+    out = out.replace(ARN_ACCOUNT_RE, `$1${ACCOUNT_MASK}`);
+    out = out.replace(KMS_KEY_UUID_RE, 'key/$1-<REDACTED>');
+    // Segunda capa: credenciales reales embebidas (AKIA…, JWT, api keys). Los
+    // patrones `topology` se excluyen a propósito — ya los cubrimos arriba de
+    // forma quirúrgica y aplicarlos borraría el ARN entero.
+    for (const { re } of NON_TOPOLOGY_SECRET_PATTERNS) {
+        out = out.replace(re, REDACTION_MARKER);
+    }
+    return out;
+}
+
+/**
+ * Aplica `redactAwsEvidence` en profundidad sobre cualquier estructura.
+ * @param {*} value
+ * @returns {*}
+ */
+function redactDeep(value) {
+    if (typeof value === 'string') return redactAwsEvidence(value);
+    if (Array.isArray(value)) return value.map(redactDeep);
+    if (value && typeof value === 'object') {
+        const out = {};
+        for (const [k, v] of Object.entries(value)) out[k] = redactDeep(v);
+        return out;
+    }
+    return value;
+}
+
+// -----------------------------------------------------------------------------
+// Clasificación del deny (CA-3)
+// -----------------------------------------------------------------------------
+
+/**
+ * Clasifica el stderr de un AccessDeniedException.
+ *
+ * @param {string} text  stderr crudo del AWS CLI.
+ * @returns {{type:'explicitDeny'|'implicitDeny'|'accessDenied'|'none'|'error',
+ *            action:(string|null), policy:(string|null), message:(string|null)}}
+ *   - `explicitDeny`: hay un `Deny` en una policy nombrada ⇒ NO se destraba con Allow.
+ *   - `implicitDeny` : falta el `Allow` ⇒ se destraba con permisos read-only.
+ *   - `accessDenied` : denegado pero sin forma reconocible (conservador: no se
+ *                      afirma cuál de los dos remedios aplica).
+ *   - `none`         : no hubo denegación.
+ */
+function classifyDeny(text) {
+    const raw = typeof text === 'string' ? text : '';
+    if (!raw) return { type: 'none', action: null, policy: null, message: null };
+    if (!/AccessDenied/i.test(raw)) {
+        return { type: 'error', action: null, policy: null, message: redactAwsEvidence(raw.trim()) };
+    }
+
+    const actionMatch = raw.match(/not authorized to perform:\s*([A-Za-z0-9:*-]+)/);
+    const action = actionMatch ? actionMatch[1] : null;
+
+    // Forma explícita: "...with an explicit deny in an identity-based policy: arn:...:policy/Nombre"
+    const explicitMatch = raw.match(/with an explicit deny in[^:]*:\s*(arn:aws[^\s"'`,)\]}]*)/i);
+    if (explicitMatch) {
+        return {
+            type: 'explicitDeny',
+            action,
+            policy: redactAwsEvidence(explicitMatch[1]),
+            message: redactAwsEvidence(raw.trim()),
+        };
+    }
+    if (/explicit deny/i.test(raw)) {
+        return { type: 'explicitDeny', action, policy: null, message: redactAwsEvidence(raw.trim()) };
+    }
+
+    // Forma implícita: "...because no identity-based policy allows the X action"
+    if (/no identity-based policy allows/i.test(raw)) {
+        return { type: 'implicitDeny', action, policy: null, message: redactAwsEvidence(raw.trim()) };
+    }
+
+    return { type: 'accessDenied', action, policy: null, message: redactAwsEvidence(raw.trim()) };
+}
+
+// -----------------------------------------------------------------------------
+// Config (fail-closed, sin hardcode · A05)
+// -----------------------------------------------------------------------------
+
+const DEFAULT_CONFIG_PATH = path.join(__dirname, '..', 'config.yaml');
+
+/**
+ * Lee y valida la sección `kernel:` de config.yaml.
+ * @param {object} [opts]
+ * @param {string} [opts.configPath]
+ * @param {object} [opts.kernelConfig]  override inyectable (tests).
+ * @returns {{tableName:string, coordinationTableName:string, region:string, durable:boolean}}
+ * @throws {Error} fail-closed si falta cualquier clave o si ambas tablas coinciden.
+ */
+function readKernelTablesConfig(opts = {}) {
+    let kernel = opts.kernelConfig;
+    if (!kernel) {
+        // eslint-disable-next-line global-require
+        const yaml = require('js-yaml');
+        // eslint-disable-next-line global-require
+        const fs = require('fs');
+        const resolved = opts.configPath || DEFAULT_CONFIG_PATH;
+        const doc = yaml.load(fs.readFileSync(resolved, 'utf8')) || {};
+        kernel = (doc && typeof doc.kernel === 'object' && doc.kernel) || {};
+    }
+
+    const str = (v) => (typeof v === 'string' ? v.trim() : '');
+    const tableName = str(kernel.tableName);
+    const coordinationTableName = str(kernel.coordinationTableName);
+    const region = str(kernel.region);
+
+    const faltantes = [];
+    if (!tableName) faltantes.push('kernel.tableName');
+    if (!coordinationTableName) faltantes.push('kernel.coordinationTableName');
+    if (!region) faltantes.push('kernel.region');
+    if (faltantes.length) {
+        throw new Error(
+            `kernel-table-verify: faltan claves de config (${faltantes.join(', ')}). `
+            + 'Fail-closed: la tabla/región NUNCA se hardcodea, se define en '
+            + '.pipeline/config.yaml (sección kernel:).',
+        );
+    }
+    if (tableName === coordinationTableName) {
+        throw new Error(
+            'kernel-table-verify: kernel.tableName y kernel.coordinationTableName son la MISMA tabla. '
+            + 'Fail-closed: la de no-repudio es append-only y la de coordinación necesita DeleteItem '
+            + 'para liberar claims; compartirlas rompe esa separación.',
+        );
+    }
+    return { tableName, coordinationTableName, region, durable: kernel.durable === true };
+}
+
+// -----------------------------------------------------------------------------
+// Runner AWS CLI read-only (spawn inyectable, sin shell)
+// -----------------------------------------------------------------------------
+
+/**
+ * Runner acotado a la allowlist read-only.
+ * @param {object} [opts]
+ * @param {string} [opts.profile]  perfil AWS (default `kernel-runtime`).
+ * @param {function} [opts.spawn]  inyectable para tests.
+ * @returns {{run:function(string[]):Promise<{code:number,stdout:string,stderr:string}>}}
+ */
+function createReadOnlyAwsRunner(opts = {}) {
+    const profile = typeof opts.profile === 'string' && opts.profile ? opts.profile : DEFAULT_PROFILE;
+    const spawn = typeof opts.spawn === 'function'
+        ? opts.spawn
+        // eslint-disable-next-line global-require
+        : require('child_process').spawn;
+
+    return {
+        profile,
+        run(args) {
+            const list = Array.isArray(args) ? args.map(String) : [];
+            const verb = `${list[0]} ${list[1]}`;
+            if (!READONLY_COMMANDS.includes(verb)) {
+                // Fail-closed ANTES de spawnear: este módulo sólo observa.
+                return Promise.reject(new Error(
+                    `kernel-table-verify: comando "${verb}" fuera de la allowlist read-only. `
+                    + `Permitidos: ${READONLY_COMMANDS.join(', ')}. `
+                    + 'El aprovisionamiento NO es alcance de este módulo (#5210 CA-7).',
+                ));
+            }
+            return new Promise((resolve, reject) => {
+                const child = spawn('aws', [...list, '--profile', profile, '--output', 'json'], {
+                    shell: false, // PROHIBIDO shell:true (A03).
+                });
+                let stdout = '';
+                let stderr = '';
+                if (child.stdout) child.stdout.on('data', (d) => { stdout += d; });
+                if (child.stderr) child.stderr.on('data', (d) => { stderr += d; });
+                child.on('error', reject);
+                child.on('close', (code) => resolve({
+                    code: typeof code === 'number' ? code : 0,
+                    stdout,
+                    stderr,
+                }));
+            });
+        },
+    };
+}
+
+// -----------------------------------------------------------------------------
+// Resumen de una tabla — SÓLO campos observados (CA-2)
+// -----------------------------------------------------------------------------
+
+/**
+ * Extrae de un `describe-table` los cuatro controles verificables del CA-2.
+ * No infiere ni completa nada que no esté en el output.
+ *
+ * @param {object} describeJson  payload parseado de `aws dynamodb describe-table`.
+ * @param {object} [expected]    { tableName, region } para chequear coherencia.
+ * @returns {object} resumen redactado con `verified` y `missing[]`.
+ */
+function summarizeTable(describeJson, expected = {}) {
+    const table = (describeJson && describeJson.Table) || null;
+    if (!table) {
+        return {
+            tableName: expected.tableName || null,
+            exists: false,
+            verified: false,
+            missing: ['describe-table no devolvió `Table` (la tabla no existe o el output es inválido)'],
+        };
+    }
+
+    const sse = table.SSEDescription || {};
+    const status = table.TableStatus || null;
+    const sseStatus = sse.Status || null;
+    const sseType = sse.SSEType || null;
+    // `DeletionProtectionEnabled` ausente NO es `false` para nosotros: es "no
+    // observado". Se distinguen a propósito — asumir el default sería inferir.
+    const delProt = Object.prototype.hasOwnProperty.call(table, 'DeletionProtectionEnabled')
+        ? table.DeletionProtectionEnabled === true
+        : null;
+
+    const missing = [];
+    if (status !== 'ACTIVE') missing.push(`TableStatus esperado ACTIVE, observado ${status === null ? 'ausente' : status}`);
+    if (sseStatus !== 'ENABLED') missing.push(`SSEDescription.Status esperado ENABLED, observado ${sseStatus === null ? 'ausente' : sseStatus}`);
+    if (sseType !== 'KMS') missing.push(`SSEDescription.SSEType esperado KMS, observado ${sseType === null ? 'ausente' : sseType}`);
+    if (delProt !== true) missing.push(`DeletionProtectionEnabled esperado true, observado ${delProt === null ? 'ausente' : String(delProt)}`);
+    if (expected.tableName && table.TableName !== expected.tableName) {
+        missing.push(`TableName esperado ${expected.tableName}, observado ${table.TableName}`);
+    }
+    if (expected.region && typeof table.TableArn === 'string'
+        && !table.TableArn.includes(`:${expected.region}:`)) {
+        missing.push(`TableArn no corresponde a la región esperada ${expected.region}`);
+    }
+
+    return redactDeep({
+        tableName: table.TableName || null,
+        exists: true,
+        status,
+        tableArn: table.TableArn || null,
+        billingMode: (table.BillingModeSummary && table.BillingModeSummary.BillingMode) || null,
+        sse: { status: sseStatus, type: sseType, keyArn: sse.KMSMasterKeyArn || null },
+        deletionProtection: delProt,
+        verified: missing.length === 0,
+        missing,
+    });
+}
+
+// -----------------------------------------------------------------------------
+// Sondas del gap (CA-3): comandos que el perfil acotado NO puede correr
+// -----------------------------------------------------------------------------
+
+/**
+ * Controles que este perfil no puede observar. `verified` arranca en `null` y
+ * NUNCA sube a `true` desde acá: sólo un output real podría hacerlo, y si el
+ * comando devolviera datos el control dejaría de ser un gap.
+ */
+function buildGapProbes(cfg, keyArn) {
+    const probes = [
+        {
+            control: 'PITR (point-in-time recovery)',
+            args: ['dynamodb', 'describe-continuous-backups', '--table-name', cfg.tableName, '--region', cfg.region],
+        },
+        {
+            control: 'PITR (point-in-time recovery)',
+            args: ['dynamodb', 'describe-continuous-backups', '--table-name', cfg.coordinationTableName, '--region', cfg.region],
+        },
+        {
+            control: 'TTL de la tabla de coordinación',
+            args: ['dynamodb', 'describe-time-to-live', '--table-name', cfg.coordinationTableName, '--region', cfg.region],
+        },
+        {
+            control: 'Rastro de auditoría (CloudTrail)',
+            args: ['cloudtrail', 'lookup-events', '--region', cfg.region, '--max-results', '1'],
+        },
+    ];
+    if (keyArn) {
+        probes.push(
+            {
+                control: 'Propiedad de la CMK (gestionada propia vs aws/dynamodb)',
+                args: ['kms', 'describe-key', '--key-id', keyArn, '--region', cfg.region],
+            },
+            {
+                control: 'Propiedad de la CMK (alias)',
+                args: ['kms', 'list-aliases', '--key-id', keyArn, '--region', cfg.region],
+            },
+            {
+                control: 'Rotación de la CMK',
+                args: ['kms', 'get-key-rotation-status', '--key-id', keyArn, '--region', cfg.region],
+            },
+        );
+    }
+    return probes;
+}
+
+// -----------------------------------------------------------------------------
+// Orquestación
+// -----------------------------------------------------------------------------
+
+function parseJsonSafe(stdout) {
+    try {
+        return JSON.parse(stdout);
+    } catch (_) {
+        return null;
+    }
+}
+
+/**
+ * Corre la verificación completa: describe-table de ambas tablas + sondas del gap.
+ *
+ * @param {object} deps
+ * @param {object}  deps.runner  `{ run(args) }` (default: runner read-only real).
+ * @param {object} [deps.config] override de config (tests).
+ * @param {string} [deps.configPath]
+ * @returns {Promise<object>} reporte estructurado y ya redactado.
+ */
+async function verifyKernelTables(deps = {}) {
+    const cfg = deps.config || readKernelTablesConfig({ configPath: deps.configPath });
+    const runner = deps.runner || createReadOnlyAwsRunner({ profile: deps.profile });
+
+    const tables = [];
+    let keyArnCrudo = null;
+    const keyArnsPorTabla = [];
+
+    for (const [rol, nombre] of [['no-repudio', cfg.tableName], ['coordinación', cfg.coordinationTableName]]) {
+        const res = await runner.run(['dynamodb', 'describe-table', '--table-name', nombre, '--region', cfg.region]);
+        const json = res.code === 0 ? parseJsonSafe(res.stdout) : null;
+        if (!json) {
+            const deny = classifyDeny(res.stderr);
+            tables.push({
+                rol,
+                tableName: nombre,
+                exists: false,
+                verified: false,
+                missing: [`describe-table falló (code ${res.code}): ${deny.message || 'sin detalle'}`],
+                deny: deny.type === 'none' ? null : deny,
+            });
+            continue;
+        }
+        const crudo = json.Table && json.Table.SSEDescription && json.Table.SSEDescription.KMSMasterKeyArn;
+        if (crudo) {
+            keyArnCrudo = keyArnCrudo || crudo;
+            keyArnsPorTabla.push(crudo);
+        }
+        tables.push({ rol, ...summarizeTable(json, { tableName: nombre, region: cfg.region }) });
+    }
+
+    // Dato relevante para el operador: si ambas tablas comparten key ARN, una
+    // sola decisión sobre esa clave afecta a las dos. NO afirma nada sobre si la
+    // clave es propia o administrada por AWS — eso es justamente el gap.
+    const mismaCmk = keyArnsPorTabla.length === 2 && keyArnsPorTabla[0] === keyArnsPorTabla[1];
+
+    const gaps = [];
+    for (const probe of buildGapProbes(cfg, keyArnCrudo)) {
+        let deny;
+        try {
+            const res = await runner.run(probe.args);
+            deny = res.code === 0
+                ? { type: 'none', action: null, policy: null, message: null }
+                : classifyDeny(res.stderr);
+        } catch (e) {
+            deny = { type: 'error', action: null, policy: null, message: redactAwsEvidence(String(e && e.message)) };
+        }
+        gaps.push({
+            control: probe.control,
+            comando: redactAwsEvidence(`aws ${probe.args.join(' ')} --profile ${runner.profile || DEFAULT_PROFILE}`),
+            deny: deny.type,
+            action: deny.action,
+            policy: deny.policy,
+            // `null` = NO VERIFICADO. Nunca `true`: el criterio prohíbe declarar
+            // cumplido lo que no se pudo observar.
+            verified: deny.type === 'none' ? 'observado-revisar' : null,
+            remediacion: deny.type === 'explicitDeny'
+                ? 'Deny explícito: agregar permisos NO alcanza; hay que editar esa policy con un principal con gestión IAM.'
+                : (deny.type === 'implicitDeny'
+                    ? 'Falta un Allow: se destraba agregando el permiso read-only al perfil.'
+                    : 'Sin clasificar: revisar el mensaje crudo antes de decidir remediación.'),
+            detalle: deny.message,
+        });
+    }
+
+    return {
+        issue: 5210,
+        config: {
+            tableName: cfg.tableName,
+            coordinationTableName: cfg.coordinationTableName,
+            region: cfg.region,
+            durable: cfg.durable,
+        },
+        perfil: runner.profile || DEFAULT_PROFILE,
+        tables,
+        mismaCmkEnAmbasTablas: mismaCmk,
+        gaps,
+        verificable: tables.length === 2 && tables.every((t) => t.verified === true),
+        // Recordatorio embebido en el propio artefacto: quien lea el JSON no
+        // necesita leer el issue para saber que los gaps no son aprobaciones.
+        nota: 'Los ítems de `gaps` con `verified: null` NO están verificados. Prohibido declararlos cumplidos (#5210 CA-3).',
+    };
+}
+
+/**
+ * Fusible: aborta si algún gap fue marcado como cumplido sin observación.
+ * Corre antes de renderizar para que un verde falso nunca llegue a un doc.
+ * @param {object} report
+ * @throws {Error}
+ */
+function assertNoUnverifiedClaims(report) {
+    const gaps = (report && report.gaps) || [];
+    for (const g of gaps) {
+        if (g.verified === true) {
+            throw new Error(
+                `kernel-table-verify: el control "${g.control}" está marcado como verificado sin evidencia observada. `
+                + 'Prohibido declarar PITR/CMK/CloudTrail cumplidos sin haberlos podido observar (#5210 CA-3).',
+            );
+        }
+    }
+    return true;
+}
+
+/**
+ * Render markdown del reporte (ya redactado).
+ * @param {object} report
+ * @returns {string}
+ */
+function renderMarkdown(report) {
+    assertNoUnverifiedClaims(report);
+    const l = [];
+    l.push('## Verificación de tablas del kernel (#5210)');
+    l.push('');
+    l.push(`- Perfil AWS: \`${report.perfil}\``);
+    l.push(`- Región: \`${report.config.region}\``);
+    l.push(`- \`kernel.durable\`: \`${report.config.durable}\``);
+    l.push('');
+    l.push('### Verificable (CA-2)');
+    l.push('');
+    l.push('| Tabla | Rol | Existe | Status | SSE | Tipo | Deletion protection | Veredicto |');
+    l.push('|---|---|---|---|---|---|---|---|');
+    for (const t of report.tables) {
+        l.push(`| \`${t.tableName}\` | ${t.rol} | ${t.exists ? 'sí' : 'NO'} | ${t.status || '—'} `
+            + `| ${(t.sse && t.sse.status) || '—'} | ${(t.sse && t.sse.type) || '—'} `
+            + `| ${t.deletionProtection === null ? 'no observado' : String(t.deletionProtection)} `
+            + `| ${t.verified ? 'OK' : 'FALLA'} |`);
+    }
+    l.push('');
+    l.push('### Gap de verificación — NO verificado (CA-3)');
+    l.push('');
+    l.push('| Control | Comando | Tipo de deny | Se destraba con permisos |');
+    l.push('|---|---|---|---|');
+    for (const g of report.gaps) {
+        const destrababa = g.deny === 'explicitDeny' ? 'NO (Deny explícito)' : (g.deny === 'implicitDeny' ? 'sí (falta Allow)' : '—');
+        l.push(`| ${g.control} | \`${g.comando}\` | \`${g.deny}\` | ${destrababa} |`);
+    }
+    l.push('');
+    l.push('> Ningún control de esta tabla está verificado. No pueden declararse cumplidos.');
+    return l.join('\n');
+}
+
+module.exports = {
+    READONLY_COMMANDS,
+    DEFAULT_PROFILE,
+    ACCOUNT_MASK,
+    redactAwsEvidence,
+    redactDeep,
+    classifyDeny,
+    readKernelTablesConfig,
+    createReadOnlyAwsRunner,
+    summarizeTable,
+    buildGapProbes,
+    verifyKernelTables,
+    assertNoUnverifiedClaims,
+    renderMarkdown,
+};
+
+// -----------------------------------------------------------------------------
+// CLI: node .pipeline/lib/kernel-table-verify.js [--json] [--profile <p>]
+// -----------------------------------------------------------------------------
+if (require.main === module) {
+    const argv = process.argv.slice(2);
+    const asJson = argv.includes('--json');
+    const pIdx = argv.indexOf('--profile');
+    const profile = pIdx >= 0 ? argv[pIdx + 1] : undefined;
+
+    verifyKernelTables({ profile })
+        .then((report) => {
+            process.stdout.write(asJson
+                ? `${JSON.stringify(report, null, 2)}\n`
+                : `${renderMarkdown(report)}\n`);
+            // Exit 1 si lo verificable NO da OK. Los gaps no cambian el exit
+            // code: no poder observar un control no es una falla del control.
+            process.exitCode = report.verificable ? 0 : 1;
+        })
+        .catch((e) => {
+            process.stderr.write(`kernel-table-verify: ${redactAwsEvidence(String(e && e.message))}\n`);
+            process.exitCode = 2;
+        });
+}

--- a/docs/pipeline/kernel-tablas-cutover-5210.md
+++ b/docs/pipeline/kernel-tablas-cutover-5210.md
@@ -1,0 +1,241 @@
+# Tablas DynamoDB del cutover durable — evidencia y gap de verificación (#5210)
+
+> **Alcance.** Las dos tablas del kernel **ya estaban aprovisionadas** en AWS
+> cuando se abrió este trabajo (decisión del operador del 30/07 19:12). Lo que
+> faltaba no era crearlas sino **probar su postura de seguridad** y documentar
+> con honestidad **lo que el perfil acotado no deja probar**. Este documento es
+> ese resultado.
+>
+> No activa persistencia durable: `kernel.durable` sigue en `false`.
+
+Reproducir la verificación:
+
+```bash
+node .pipeline/lib/kernel-table-verify.js          # markdown
+node .pipeline/lib/kernel-table-verify.js --json   # reporte estructurado
+```
+
+El verificador es **read-only por construcción**: tiene una allowlist de siete
+comandos `describe`/`list`/`get`/`lookup` y rechaza cualquier otro *antes* de
+spawnear. No crea tablas, no toca la CMK, no toca IAM — ese camino vive en
+[#5203](https://github.com/intrale/platform/pull/5203)
+(`kernel-aws-bootstrap.js`, `kernel-cmk-provision.js`) y no se reimplementa acá.
+
+---
+
+## 1. Configuración (CA-1)
+
+`.pipeline/config.yaml`, sección `kernel:`
+
+| Clave | Valor |
+|---|---|
+| `kernel.tableName` | `intrale-kernel-state` (no-repudio) |
+| `kernel.coordinationTableName` | `intrale-kernel-coordination` (coordinación) |
+| `kernel.region` | `us-east-2` |
+| `kernel.durable` | `false` |
+
+**Poblar los nombres no enciende nada.** Es la duda razonable que deja este
+cambio, así que conviene ser explícito: el único switch del camino AWS es
+`kernel.durable`. Con `false`, `pulpo.js` ni entra al bloque de boot durable, el
+constructor del store es *lazy* y nunca se instancia un driver. Los nombres son
+declarativos; `durable` es el interruptor. Hay dos tests que lo fijan
+(`CA-5: config.yaml real mantiene kernel.durable en false` y
+`CA-5: con durable:false el bootstrap resuelve por filesystem…`).
+
+---
+
+## 2. Evidencia verificable (CA-2)
+
+Perfil `kernel-runtime`, región `us-east-2`. Account IDs y el UUID completo de la
+clave KMS van enmascarados; se preservan servicio, región y nombre de recurso
+porque sin eso la evidencia no probaría nada.
+
+| Tabla | Rol | Existe | `TableStatus` | `SSEDescription.Status` | `SSEType` | `DeletionProtectionEnabled` |
+|---|---|---|---|---|---|---|
+| `intrale-kernel-state` | no-repudio | sí | `ACTIVE` | `ENABLED` | `KMS` | `true` |
+| `intrale-kernel-coordination` | coordinación | sí | `ACTIVE` | `ENABLED` | `KMS` | `true` |
+
+```
+$ aws dynamodb describe-table --table-name intrale-kernel-state \
+    --region us-east-2 --profile kernel-runtime
+{
+  "TableName": "intrale-kernel-state",
+  "TableStatus": "ACTIVE",
+  "TableArn": "arn:aws:dynamodb:us-east-2:<ACCT>:table/intrale-kernel-state",
+  "BillingModeSummary": { "BillingMode": "PAY_PER_REQUEST" },
+  "SSEDescription": {
+    "Status": "ENABLED",
+    "SSEType": "KMS",
+    "KMSMasterKeyArn": "arn:aws:kms:us-east-2:<ACCT>:key/9d18ba4b-<REDACTED>"
+  },
+  "DeletionProtectionEnabled": true
+}
+
+$ aws dynamodb describe-table --table-name intrale-kernel-coordination \
+    --region us-east-2 --profile kernel-runtime
+{
+  "TableName": "intrale-kernel-coordination",
+  "TableStatus": "ACTIVE",
+  "TableArn": "arn:aws:dynamodb:us-east-2:<ACCT>:table/intrale-kernel-coordination",
+  "BillingModeSummary": { "BillingMode": "PAY_PER_REQUEST" },
+  "SSEDescription": {
+    "Status": "ENABLED",
+    "SSEType": "KMS",
+    "KMSMasterKeyArn": "arn:aws:kms:us-east-2:<ACCT>:key/9d18ba4b-<REDACTED>"
+  },
+  "DeletionProtectionEnabled": true
+}
+```
+
+**Separación física confirmada:** dos `TableArn` distintos, misma región, sin
+fallback a tabla compartida. `readKernelTablesConfig` falla *fail-closed* si
+alguien llegara a apuntar las dos claves a la misma tabla.
+
+**Ambas tablas comparten el mismo key ARN.** Es un hecho observado y vale
+registrarlo porque tiene consecuencia operativa: una sola decisión sobre esa
+clave afecta a las dos tablas. Ojo con la lectura de más — que exista un key ARN
+concreto **no distingue** una CMK gestionada propia de la clave administrada por
+AWS (`aws/dynamodb`), que también expone un ARN con UUID. Esa distinción es
+exactamente lo que la sección siguiente **no** puede cerrar.
+
+---
+
+## 3. Gap de verificación — NO verificado (CA-3)
+
+Estos controles **no se pudieron observar** con `kernel-runtime`. No están
+verificados: no se declaran cumplidos ni incumplidos. Se documentan con el
+comando exacto y el tipo de denegación.
+
+| Control | Comando | Tipo de deny | ¿Se destraba agregando permisos? |
+|---|---|---|---|
+| PITR — tabla de no-repudio | `aws dynamodb describe-continuous-backups --table-name intrale-kernel-state --region us-east-2 --profile kernel-runtime` | `implicitDeny` | **Sí** — falta un `Allow` |
+| PITR — tabla de coordinación | `aws dynamodb describe-continuous-backups --table-name intrale-kernel-coordination --region us-east-2 --profile kernel-runtime` | `implicitDeny` | **Sí** — falta un `Allow` |
+| TTL de coordinación | `aws dynamodb describe-time-to-live --table-name intrale-kernel-coordination --region us-east-2 --profile kernel-runtime` | `implicitDeny` | **Sí** — falta un `Allow` |
+| Propiedad de la CMK | `aws kms describe-key --key-id <CMK> --region us-east-2 --profile kernel-runtime` | `implicitDeny` | **Sí** — falta un `Allow` |
+| Rotación de la CMK | `aws kms get-key-rotation-status --key-id <CMK> --region us-east-2 --profile kernel-runtime` | `implicitDeny` | **Sí** — falta un `Allow` |
+| Alias de la CMK | `aws kms list-aliases --key-id <CMK> --region us-east-2 --profile kernel-runtime` | **`explicitDeny`** en `policy/IntraleKernelStore` | **No** |
+| Rastro CloudTrail | `aws cloudtrail lookup-events --region us-east-2 --profile kernel-runtime` | **`explicitDeny`** en `policy/IntraleKernelStore` | **No** |
+
+Mensajes crudos (redactados):
+
+```
+$ aws dynamodb describe-continuous-backups --table-name intrale-kernel-state ...
+AccessDeniedException: User: arn:aws:iam::<ACCT>:user/intrale-kernel-runtime is not
+  authorized to perform: dynamodb:DescribeContinuousBackups on resource:
+  arn:aws:dynamodb:us-east-2:<ACCT>:table/intrale-kernel-state
+  because no identity-based policy allows the action              [implicitDeny]
+
+$ aws kms describe-key --key-id <CMK> ...
+AccessDeniedException: ... not authorized to perform: kms:DescribeKey ...
+  because no identity-based policy allows the action              [implicitDeny]
+
+$ aws kms list-aliases --key-id <CMK> ...
+AccessDeniedException: ... not authorized to perform: kms:ListAliases on resource: *
+  with an explicit deny in an identity-based policy:
+  arn:aws:iam::<ACCT>:policy/IntraleKernelStore                   [explicitDeny]
+
+$ aws cloudtrail lookup-events --region us-east-2 ...
+AccessDeniedException: ... not authorized to perform: cloudtrail:LookupEvents
+  with an explicit deny in an identity-based policy:
+  arn:aws:iam::<ACCT>:policy/IntraleKernelStore                   [explicitDeny]
+```
+
+### Por qué la distinción importa
+
+No es trivia de IAM: **cambia quién puede destrabarlo y cómo**.
+
+- **`implicitDeny`** — no hay ningún `Allow` que cubra la acción. Se resuelve
+  agregando el permiso de sólo lectura al perfil.
+- **`explicitDeny`** — hay un `Deny` en `policy/IntraleKernelStore`. Un `Deny`
+  explícito **gana sobre cualquier `Allow`**, así que agregar permisos **no hace
+  nada**: hay que editar esa policy con un principal con gestión IAM.
+
+Tratar los dos casos igual manda al operador a una remediación que, en dos de
+los siete controles, no puede funcionar.
+
+### La regla que este documento hace cumplir
+
+Queda **prohibido** declarar PITR, propiedad de la CMK o rastro CloudTrail como
+cumplidos sin haberlos observado. No es sólo una convención escrita: el
+verificador marca esos controles con `verified: null` (que significa *no sé*, y
+es un estado legítimo distinto de `false`) y `assertNoUnverifiedClaims` **tira**
+si alguien mutara un gap a `verified: true` — el render aborta antes de imprimir
+un verde falso. Está cubierto por tests.
+
+El destrabe de los permisos de verificación se sigue por separado; no es alcance
+de este issue.
+
+### Nota metodológica
+
+Un `NotFoundException` **no es evidencia de permisos**. La primera corrida contra
+un key ID enmascarado devolvió `NotFound`, que puede leerse como denegación y no
+lo es. Hay que repetir con el ARN real tomado de `SSEDescription.KMSMasterKeyArn`
+— ahí sí aparece el `AccessDeniedException`. El verificador distingue los dos
+casos (`classifyDeny` devuelve `error`, no un tipo de deny) y hay un test que lo
+fija.
+
+---
+
+## 4. Retención y borrado de la tabla de coordinación (CA-4)
+
+La tabla de coordinación **no hereda la política de inmutabilidad** de la de
+no-repudio, y eso es deliberado: necesita `DeleteItem` para liberar claims. La
+separación está en
+[`kernel-iam-policy.md`](kernel-iam-policy.md); acá va sólo la postura de
+retención.
+
+| Aspecto | Tabla de no-repudio | Tabla de coordinación |
+|---|---|---|
+| Borrado normal | **Ninguno.** `Deny` incondicional sobre las 7 acciones de mutación | **Sí**, `DeleteItem` acotado por `Resource` a esta tabla |
+| TTL de DynamoDB | No debe configurarse (sería una ruta de borrado sobre evidencia) | **No configurado** — ver abajo |
+| Vencimiento | No aplica | Por **lease de aplicación**, no por TTL |
+| Retención | Indefinida (no-repudio) | Acotada por el conjunto de claves, no por el tiempo |
+
+### El vencimiento es de aplicación, no de DynamoDB
+
+`claim(key, { owner, leaseMs })` escribe `expiresAt = now + leaseMs` **dentro del
+ítem** y `leaseMs > 0` es obligatorio (un lease sin vencimiento sería un lock
+huérfano permanente). Cuando un claim vence, el siguiente `claim()` lo **reclama
+por update optimista** — lo sobrescribe, no espera a que nadie lo borre. El
+resultado es que un claim vencido nunca bloquea: el vencimiento es efectivo en el
+instante en que otro proceso lo necesita, sin depender de la latencia de barrido
+de un TTL.
+
+`release(key, { expectedOwner })` hace el `DeleteItem` real, condicionado a
+ownership: un proceso no puede liberar el claim de otro.
+
+### Por qué no hay TTL configurado, y por qué está bien
+
+DynamoDB TTL sirve para tablas que **acumulan** ítems. Esta no: el espacio de
+claves es acotado (un ítem por fase/ola/health), así que los claims se
+**sobrescriben** en lugar de apilarse. Sumar un TTL agregaría una segunda ruta de
+borrado —con su propia latencia de barrido, que AWS no garantiza inmediata— sobre
+un mecanismo que ya vence de forma determinística en el `claim()`. Sería más
+superficie, no más garantía.
+
+**Esto es una decisión de diseño documentada, no una observación.** Con
+`kernel-runtime`, `dynamodb:DescribeTimeToLive` da `implicitDeny` (ver §3), así
+que el estado real del TTL en AWS **no está verificado**. Si el destrabe de
+permisos revelara un TTL configurado sobre la tabla de coordinación, hay que
+revisar esta postura; y si apareciera uno sobre la tabla de **no-repudio**, es un
+hallazgo a escalar — sería una ruta de borrado sobre evidencia append-only.
+
+### Procedimiento de limpieza
+
+1. **Camino normal:** el dueño del claim llama `release(key, { expectedOwner })`.
+   Es el único borrado esperado en régimen.
+2. **Claim colgado** (el dueño murió sin liberar): no requiere intervención. El
+   lease vence y el próximo `claim()` lo reclama.
+3. **Purga manual** (excepcional, sólo operador): `DeleteItem` sobre las claves de
+   coordinación afectadas, con la ventana de cutover cerrada. Nunca sobre la
+   tabla de no-repudio — ahí el `Deny` incondicional lo impide por diseño, y es
+   la garantía que hay que preservar.
+
+---
+
+## 5. Qué NO cubre este documento
+
+- Activación durable (`kernel.durable: true`) — fuera de alcance.
+- IAM de runtime, auditoría CloudTrail y migración de datos — fuera de alcance.
+- Aprovisionamiento de tablas y CMK — vive en #5203, no se duplica acá (CA-7).
+- El destrabe de los permisos de verificación de §3 — se sigue por separado.


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 5 archivos · +1404 -5

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:passed` aplicado por delivery

## Closes

Closes #5210
