### PR TITLE
[auto] Integrar vault en credentials.js (Closes #5353)

### DIFF
--- a/.pipeline/_tmp/5353-fix-verificacion.js
+++ b/.pipeline/_tmp/5353-fix-verificacion.js
@@ -1,0 +1,78 @@
+// Verificación del fix rev-1 de #5353 (rechazo de seguridad B2).
+//
+// Reproduce los tres casos del rechazo CONTRA EL CÓDIGO CORREGIDO:
+//   1. La raíz de la config la fija el código: PIPELINE_REPO_ROOT / _DIR_OVERRIDE /
+//      _STATE_DIR ya no eligen qué config.yaml manda.
+//   2. Con `vault.enabled: true` y raíz desviada por entorno, el ancla NO vuelve
+//      al régimen de process.env.
+//   3. Config ilegible => estado INDETERMINADO (no "vault apagado") y el ancla
+//      falla cerrada.
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+
+// El atacante desvía las TRES env vars de raíz.
+const DESVIADA = 'C:\\ruta\\inexistente\\del\\atacante';
+process.env.PIPELINE_DIR_OVERRIDE = DESVIADA;
+process.env.PIPELINE_STATE_DIR = DESVIADA;
+process.env.PIPELINE_REPO_ROOT = DESVIADA;
+
+const cred = require(path.join(ROOT, '.pipeline', 'lib', 'credentials.js'));
+const og = require(path.join(ROOT, '.pipeline', 'lib', 'operator-gate.js'));
+
+const driver = {
+  kind: 'fake', calls: [],
+  getParametersByPathSync() { this.calls.push('p'); return { parameters: [] }; },
+  getSecretValueSync() { this.calls.push('s'); return null; },
+  async getParametersByPath() { return { parameters: [] }; },
+  async getSecretValue() { return null; },
+};
+const sinArchivos = {
+  canonicalPath: path.join(os.tmpdir(), 'no-existe-5353', 'credentials.json'),
+  legacyPath: path.join(os.tmpdir(), 'no-existe-5353', 'telegram-config.json'),
+};
+
+function correr(titulo, opts) {
+  cred._resetVaultCache();
+  const env = { TELEGRAM_LEO_OPERATOR_CHAT_ID: '666666666', OPENAI_API_KEY: 'AMBIENTE-OPENAI' };
+  const logs = [];
+  const r = cred.loadIntoEnv({ ...sinArchivos, env, logger: (m) => logs.push(String(m)), ...opts });
+  console.log('\n=== ' + titulo + ' ===');
+  console.log('result.vault             =', JSON.stringify(r.vault));
+  console.log('ancla en env DESPUES     =', JSON.stringify(env.TELEGRAM_LEO_OPERATOR_CHAT_ID));
+  console.log('missing incluye el ancla =', r.missing.includes('TELEGRAM_LEO_OPERATOR_CHAT_ID'));
+  console.log('allowlist de firmantes   =', JSON.stringify([...og.resolveOperatorAllowlist(env)]));
+  console.log('no-ancla OPENAI_API_KEY  =', JSON.stringify(env.OPENAI_API_KEY), '(', r.sources.OPENAI_API_KEY, ')');
+  for (const l of logs) console.log('  | ' + l.slice(0, 130));
+}
+
+// --- 1/2: config REAL del checkout, pero con vault.enabled true (copia de prep) ---
+const DEST = path.join(os.tmpdir(), 'sec5353fix');
+fs.mkdirSync(path.join(DEST, '.pipeline'), { recursive: true });
+let yamlSrc = fs.readFileSync(path.join(ROOT, '.pipeline', 'config.yaml'), 'utf8');
+const i = yamlSrc.indexOf('\nvault:');
+yamlSrc = yamlSrc.slice(0, i) + yamlSrc.slice(i)
+  .replace(/\n  enabled: false/, '\n  enabled: true')
+  .replace(/\n  hostId: ""/, '\n  hostId: "hostA"');
+fs.writeFileSync(path.join(DEST, '.pipeline', 'config.yaml'), yamlSrc);
+fs.copyFileSync(path.join(ROOT, 'pipeline.config.json'), path.join(DEST, 'pipeline.config.json'));
+
+correr('CASO A/B · vault.enabled TRUE + raiz desviada por entorno', {
+  pipelineDir: path.join(DEST, '.pipeline'), vaultDriver: driver,
+});
+
+// --- 3: config ilegible en la raíz que manda ---
+const ROTA = fs.mkdtempSync(path.join(os.tmpdir(), 'sec5353-rota-'));
+fs.mkdirSync(path.join(ROTA, '.pipeline'));
+fs.writeFileSync(path.join(ROTA, '.pipeline', 'config.yaml'), 'no: [es yaml\n  valido: {{{\n');
+correr('CASO C · config ILEGIBLE (indeterminado, no "vault apagado")', {
+  pipelineDir: path.join(ROTA, '.pipeline'), vaultDriver: driver,
+});
+
+// --- 4: camino productivo, sin ningun arg: la raiz la fija el codigo ---
+const leido = cred._readVaultConfig({}, () => {});
+console.log('\n=== CAMINO PRODUCTIVO (sin args, con las 3 env vars desviadas) ===');
+console.log('indeterminado            =', leido.indeterminado);
+console.log('vault.enabled leido      =', leido.cfg && leido.cfg.enabled, '(config REAL del checkout)');

--- a/.pipeline/_tmp/5353-sec-anchor.js
+++ b/.pipeline/_tmp/5353-sec-anchor.js
@@ -1,0 +1,50 @@
+// Prueba empírica: ¿el ancla de autorización (B2) se puede des-proteger
+// seteando una variable de entorno de RESOLUCIÓN DE CONFIG?
+//
+// Uso: node 5353-sec-anchor.js <repoRootParaCredentials>
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+process.env.PIPELINE_REPO_ROOT = process.argv[2];
+
+const cred = require(path.join(ROOT, '.pipeline', 'lib', 'credentials.js'));
+cred._resetVaultCache();
+
+// Driver inyectado: NO hay AWS de por medio. Devuelve el namespace VACÍO, o sea
+// "el ancla no está en el vault".
+const driver = {
+  kind: 'fake',
+  getParametersByPathSync() { return { parameters: [] }; },
+  getSecretValueSync() { return null; },
+  async getParametersByPath() { return { parameters: [] }; },
+  async getSecretValue() { return null; },
+};
+
+// Ambiente destino: el atacante dejó preseteada el ancla de autorización.
+const env = { TELEGRAM_LEO_OPERATOR_CHAT_ID: '666666666' };
+
+const logs = [];
+const res = cred.loadIntoEnv({
+  env,
+  logger: (m) => logs.push(m),
+  vaultDriver: driver,
+  canonicalPath: path.join(ROOT, '.pipeline', '_tmp', 'no-existe-credentials.json'),
+  legacyPath: path.join(ROOT, '.pipeline', '_tmp', 'no-existe-legacy.json'),
+});
+
+console.log('PIPELINE_REPO_ROOT       =', process.env.PIPELINE_REPO_ROOT);
+console.log('result.vault             =', JSON.stringify(res.vault));
+console.log('ancla en env DESPUES     =', JSON.stringify(env.TELEGRAM_LEO_OPERATOR_CHAT_ID));
+console.log('source del ancla         =', res.sources.TELEGRAM_LEO_OPERATOR_CHAT_ID);
+console.log('missing incluye el ancla =', res.missing.includes('TELEGRAM_LEO_OPERATOR_CHAT_ID'));
+
+const { createGate } = (() => {
+  try { return require(path.join(ROOT, '.pipeline', 'lib', 'operator-gate.js')); }
+  catch (_) { return {}; }
+})();
+const og = require(path.join(ROOT, '.pipeline', 'lib', 'operator-gate.js'));
+if (typeof og.resolveOperatorAllowlist === 'function') {
+  console.log('allowlist de firmantes   =', JSON.stringify([...og.resolveOperatorAllowlist(env)]));
+}
+console.log('--- logs ---');
+for (const l of logs) console.log('  ' + l.slice(0, 160));

--- a/.pipeline/_tmp/5353-sec-comment.md
+++ b/.pipeline/_tmp/5353-sec-comment.md
@@ -1,0 +1,24 @@
+## ✅ Auditoría de seguridad — APROBADO
+
+**Rama auditada:** `agent/5353-pipeline-dev` @ `171e75ccf` (diff `origin/main...HEAD`; no hay PR abierto asociado actualmente).
+
+El bypass crítico B2.7 reportado en la pasada anterior quedó cerrado y fue revalidado empíricamente:
+
+```text
+$ node .pipeline/_tmp/5353-fix-verificacion.js
+raíz desviada por entorno → ancla = undefined; missing = true; allowlist = []
+config ilegible           → vault.indeterminado = true; ancla = undefined; allowlist = []
+camino productivo         → lee la config real del checkout
+```
+
+La raíz autoritativa ahora se fija en código (`credentials.js:328-332`) y la config ilegible activa el fail-closed del ancla antes de cualquier salida temprana (`credentials.js:583-597`). No encontré nuevos vectores de inyección, bypass de autorización, exposición de secretos ni secrets hardcodeados.
+
+```text
+$ node --test <5 suites focalizadas de credentials/vault/wizard>
+tests 65 · pass 65 · fail 0
+
+$ node .pipeline/lib/credentials.js
+exit 0; sólo nombres/estados, sin valores
+```
+
+No se modificaron manifests de dependencias. Reporte completo persistido como entregable sensible (`sensible: true`); no se publica en Drive. No se crearon recomendaciones adicionales.

--- a/.pipeline/_tmp/5353-sec-fix.js
+++ b/.pipeline/_tmp/5353-sec-fix.js
@@ -1,0 +1,18 @@
+// ¿Anclar la raíz de config (como ya hace pulpo.js) neutraliza el vector?
+const path = require('path');
+const ROOT = path.resolve(__dirname, '..', '..');
+process.env.PIPELINE_REPO_ROOT = 'C:\\ruta\\inexistente\\del\\atacante';
+const cr = require(path.join(ROOT, '.pipeline', 'lib', 'config-resolver.js'));
+
+try {
+  const cfg = cr.resolve({});
+  console.log('resolve({})                       -> OK  vault.enabled=' + cfg.vault.enabled);
+} catch (e) {
+  console.log('resolve({})                       -> THROW ' + e.name);
+}
+try {
+  const cfg = cr.resolve({ pipelineDir: path.join(ROOT, '.pipeline') });
+  console.log('resolve({pipelineDir: <checkout>}) -> OK  vault.enabled=' + cfg.vault.enabled);
+} catch (e) {
+  console.log('resolve({pipelineDir: <checkout>}) -> THROW ' + e.name);
+}

--- a/.pipeline/_tmp/5353-sec-leak.js
+++ b/.pipeline/_tmp/5353-sec-leak.js
@@ -1,0 +1,28 @@
+// Cruce del dry-run del CLI contra los valores reales del store de credenciales.
+const { execFileSync } = require('node:child_process');
+const fs = require('fs'), os = require('os'), path = require('path');
+const ROOT = path.resolve(__dirname, '..', '..');
+
+let stdout = '', stderr = '';
+try {
+  stdout = execFileSync(process.execPath, [path.join(ROOT, '.pipeline', 'lib', 'credentials.js')],
+    { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+} catch (e) {
+  stdout = String(e.stdout || ''); stderr = String(e.stderr || '');
+}
+const salida = stdout + stderr;
+
+const store = JSON.parse(fs.readFileSync(path.join(os.homedir(), '.claude', 'secrets', 'credentials.json'), 'utf8'));
+const vals = [];
+(function walk(o) {
+  for (const k of Object.keys(o || {})) {
+    const v = o[k];
+    if (v && typeof v === 'object') walk(v);
+    else if (typeof v === 'string' && v.length >= 10) vals.push(v);
+  }
+})(store);
+const fugas = vals.filter((v) => salida.includes(v));
+console.log('valores del store chequeados (len>=10):', vals.length);
+console.log('FUGAS en la salida del dry-run       :', fugas.length);
+console.log('salida (primeros 400 chars):');
+console.log(stdout.replace(/\s+/g, ' ').slice(0, 400));

--- a/.pipeline/_tmp/5353-sec-prep.js
+++ b/.pipeline/_tmp/5353-sec-prep.js
@@ -1,0 +1,26 @@
+// Preparación de escenario para la auditoría de seguridad de #5353.
+// Copia la config del checkout a un directorio temporal y enciende `vault.enabled`.
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const DEST = path.join(os.tmpdir(), 'sec5353');
+fs.mkdirSync(path.join(DEST, '.pipeline'), { recursive: true });
+
+let yamlSrc = fs.readFileSync(path.join(ROOT, '.pipeline', 'config.yaml'), 'utf8');
+const antes = yamlSrc;
+// Encender SOLO la clave `enabled` de la sección `vault:`.
+const i = yamlSrc.indexOf('\nvault:');
+if (i < 0) throw new Error('no se encontró la sección vault:');
+const cabeza = yamlSrc.slice(0, i);
+let cola = yamlSrc.slice(i);
+cola = cola.replace(/\n  enabled: false/, '\n  enabled: true');
+cola = cola.replace(/\n  hostId: ""/, '\n  hostId: "hostA"');
+yamlSrc = cabeza + cola;
+if (yamlSrc === antes) throw new Error('no se pudo encender vault.enabled');
+
+fs.writeFileSync(path.join(DEST, '.pipeline', 'config.yaml'), yamlSrc);
+fs.copyFileSync(path.join(ROOT, 'pipeline.config.json'), path.join(DEST, 'pipeline.config.json'));
+console.log('DEST=' + DEST);
+console.log(yamlSrc.slice(yamlSrc.indexOf('\nvault:'), yamlSrc.indexOf('\nvault:') + 260));

--- a/.pipeline/_tmp/5353-sec-silent.js
+++ b/.pipeline/_tmp/5353-sec-silent.js
@@ -1,0 +1,9 @@
+// Variante SILENCIOSA: la raíz apuntada por PIPELINE_REPO_ROOT tiene una config
+// válida que declara `vault.enabled: false`. No hay ni un WARN.
+const fs = require('fs'), os = require('os'), path = require('path');
+const DEST = path.join(os.tmpdir(), 'sec5353b');
+const ROOT = path.resolve(__dirname, '..', '..');
+fs.mkdirSync(path.join(DEST, '.pipeline'), { recursive: true });
+fs.copyFileSync(path.join(ROOT, '.pipeline', 'config.yaml'), path.join(DEST, '.pipeline', 'config.yaml'));
+fs.copyFileSync(path.join(ROOT, 'pipeline.config.json'), path.join(DEST, 'pipeline.config.json'));
+console.log('raiz alternativa preparada (vault.enabled: false, config VALIDA):', DEST);

--- a/.pipeline/_tmp/5353-security-comment-final.md
+++ b/.pipeline/_tmp/5353-security-comment-final.md
@@ -1,0 +1,28 @@
+## ✅ Auditoría de seguridad — APROBADO
+
+**Rama auditada:** `agent/5353-pipeline-dev` @ `208581550` (diff `origin/main...HEAD`; no hay PR abierto asociado).
+
+Revisé el delta posterior a la aprobación anterior (`171e75ccf..HEAD`). El único cambio nuevo está en `.pipeline/lib/__tests__/quota-setflag-config-corrupta-5172.test.js`: fija el reloj y el candidato de reset para eliminar dependencia del calendario. No modifica código productivo, autenticación, autorización ni dependencias.
+
+La corrección del bypass B2.7 sigue cerrada en el HEAD actual:
+
+```text
+$ node .pipeline/_tmp/5353-fix-verificacion.js
+raíz desviada por entorno → ancla = undefined; missing = true; allowlist = []
+config ilegible           → ancla = undefined; missing = true; allowlist = []
+camino productivo         → lee la config real del checkout
+```
+
+Verificación ejecutada en esta pasada:
+
+```text
+$ node --test <6 suites focalizadas de credentials/vault/wizard/quota>
+tests 70 · pass 70 · fail 0
+
+$ node .pipeline/lib/credentials.js
+exit 0; sólo nombres, fuentes y estados, sin valores de secretos
+```
+
+El escaneo de líneas agregadas encontró únicamente canarios ficticios de tests. No cambiaron manifests de dependencias. Sin hallazgos de inyección, bypass de autorización, exposición de datos sensibles ni secretos reales hardcodeados.
+
+Reporte de auditoría persistido como entregable sensible (`sensible: true`), sin publicación pública. No se crearon recomendaciones adicionales.

--- a/.pipeline/_tmp/5353-security-report.md
+++ b/.pipeline/_tmp/5353-security-report.md
@@ -1,0 +1,19 @@
+## Reporte de auditoría de seguridad — issue #5353
+
+**Veredicto:** sin hallazgos
+
+**Alcance auditado:** rama `agent/5353-pipeline-dev` en `2085815507d138e4d30526a9099f0db9e47134e8`; diff `origin/main...HEAD`, con revisión específica del delta `171e75ccf..HEAD`. Archivos de vault, credenciales, configuración y tests asociados.
+
+### Hallazgos
+
+Sin hallazgos.
+
+La corrección B2.7 continúa fail-closed: una raíz desviada por variables de entorno o una configuración ilegible elimina `TELEGRAM_LEO_OPERATOR_CHAT_ID`, registra el ancla como faltante y deja vacía la allowlist. El commit posterior a la auditoría previa sólo inyecta reloj y reset deterministas en `.pipeline/lib/__tests__/quota-setflag-config-corrupta-5172.test.js`; no modifica código productivo ni dependencias.
+
+### Evidencia
+
+- Seis suites focalizadas: 70 tests, 70 aprobados, 0 fallidos.
+- Arnés B2.7: raíz desviada y config ilegible producen `ancla = undefined`, `missing = true`, `allowlist = []`.
+- CLI dry-run: salida con nombres, fuentes y estados; sin valores de secretos.
+- Escaneo de líneas agregadas: únicamente canarios ficticios de tests; sin credenciales reales hardcodeadas.
+- Manifiestos de dependencias sin cambios.

--- a/.pipeline/config.yaml
+++ b/.pipeline/config.yaml
@@ -1346,6 +1346,33 @@ vault:
   # `shared/` NO es el default: lo que no esté acá se busca en el namespace del
   # host (`hosts/<hostId>/`), que es lo que mantiene el aislamiento entre hosts.
   shared_secrets: []
+  # ---------------------------------------------------------------------------
+  # #5353 · B1 — ventana de bootstrap sobre el archivo de credenciales
+  # ---------------------------------------------------------------------------
+  # Con el gate del vault ABIERTO, la única puerta que queda al archivo
+  # (`~/.claude/secrets/credentials.json`). Existe para que una migración al
+  # vault no obligue a subir los 13 secretos en el mismo minuto en que se
+  # enciende el gate. NO es un fallback de resiliencia:
+  #
+  #   - B1.2 · Un error del driver (red, timeout, credenciales, permisos,
+  #     secreto ausente) NUNCA la habilita. Un fallback disparado por error de
+  #     red es fail-open disfrazado: cualquiera que degrade la red desactiva el
+  #     control entero.
+  #   - B1.7/B2.4 · Nunca alcanza a las anclas de autorización
+  #     (`auth_anchor: true`), ni encendida ni dentro de la ventana.
+  #   - B1.4 · Si el archivo resuelve DENTRO del árbol del repo, se rechaza
+  #     igual (coherente con #5218, que no se relaja por esto).
+  #   - B1.6 · Cada valor que resuelve por acá emite WARN con el NOMBRE de la
+  #     variable (jamás el valor) y reporta `source: file-bootstrap`, nunca
+  #     `vault`.
+  #
+  # Fail-closed: sólo el booleano `true` exacto la abre.
+  bootstrap_fallback: false
+  # B1.5 — OBLIGATORIA cuando `bootstrap_fallback: true`. Fecha ISO-8601 de
+  # caducidad: pasada esa fecha la ventana NO se aplica aunque el flag siga en
+  # `true`. Sin esto, "bootstrap temporal" se vuelve permanente por olvido, que
+  # es exactamente el modo de falla que la ventana existe para evitar.
+  bootstrap_fallback_until: ""
 
 # =============================================================================
 # #5067 — Entrega cross-repo: el entregable puede vivir en un repo hermano

--- a/.pipeline/lib/__tests__/credentials-vault-5353.test.js
+++ b/.pipeline/lib/__tests__/credentials-vault-5353.test.js
@@ -32,6 +32,7 @@ const {
   SOURCE,
   vaultScopePlan,
   _resetVaultCache,
+  _readVaultConfig,
 } = credentials;
 const { buildParameterPath, createInMemoryVaultDriver } = require('../secret-vault');
 const { resolveOperatorAllowlist } = require('../operator-gate');
@@ -628,6 +629,113 @@ test('B2.6 · para las 12 no-ancla la precedencia de process.env NO cambia', () 
   assert.equal(r.sources.OPENAI_API_KEY, SOURCE.ENV_PREEXISTING);
   // La única que cambia de régimen es el ancla.
   assert.deepEqual(r.hydrated, [ANCLA_ENV]);
+});
+
+// =============================================================================
+// B2.7 (rev-1) — el ENTORNO no puede desactivar el régimen del ancla
+//
+// Vector cerrado: `readVaultConfig` resolvía con `resolve({})`, así que
+// `PIPELINE_REPO_ROOT` / `PIPELINE_DIR_OVERRIDE` / `PIPELINE_STATE_DIR` elegían
+// qué config.yaml era la autoridad. Quien puede escribir el ancla en el ambiente
+// puede escribir ESAS, desviar la lectura a una carpeta vacía (o propia), dejar
+// el gate en "apagado" y quedarse como firmante del gate del operador.
+// =============================================================================
+
+/** Corre `fn` con las tres env vars de raíz apuntando a `valor`, y las restaura. */
+function conRaizDesviadaPorEntorno(valor, fn) {
+  const VARS = ['PIPELINE_DIR_OVERRIDE', 'PIPELINE_STATE_DIR', 'PIPELINE_REPO_ROOT'];
+  const previas = VARS.map((v) => [v, process.env[v]]);
+  for (const v of VARS) process.env[v] = valor;
+  try { return fn(); } finally {
+    for (const [v, prev] of previas) {
+      if (prev === undefined) delete process.env[v]; else process.env[v] = prev;
+    }
+  }
+}
+
+test('B2.7 · con vault.enabled true en la config real, una raiz de config desviada por entorno NO devuelve el ancla al regimen de process.env', () => {
+  const repoRoot = path.resolve(__dirname, '..', '..', '..');
+  const real = require('../config-resolver').resolve({
+    pipelineDir: path.join(repoRoot, '.pipeline'),
+  });
+
+  const leido = conRaizDesviadaPorEntorno(
+    path.join(os.tmpdir(), 'cred-vault-5353-raiz-del-atacante-inexistente'),
+    () => _readVaultConfig({}, capturarLogs()),
+  );
+
+  // La desviación NO tuvo efecto: se leyó la config real del checkout. Antes del
+  // fix esto tiraba ConfigParseViolation, el catch devolvía null, `resolverVault`
+  // lo colapsaba con "vault apagado" y el ancla preseteada sobrevivía.
+  assert.equal(leido.indeterminado, false,
+    'la raiz la fija el codigo: la desviacion por entorno no eligio la autoridad');
+  assert.ok(leido.cfg, 'se leyo la seccion vault: de la config REAL');
+  assert.equal(leido.cfg.enabled, real.vault.enabled,
+    'el gate resuelto es el que dice la config commiteada, no el que dice el entorno');
+  assert.equal(leido.cfg.prefix, real.vault.prefix);
+  assert.equal(leido.cfg.projectId, real.vault.projectId);
+});
+
+test('B2.7 · una config ilegible NO se colapsa con "vault apagado": el ancla falla CERRADA y las 12 no-ancla quedan identicas', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cred-vault-5353-cfg-rota-'));
+  const pipelineDir = path.join(dir, '.pipeline');
+  fs.mkdirSync(pipelineDir);
+  fs.writeFileSync(path.join(pipelineDir, 'config.yaml'), 'esto: [no es yaml\n  valido: {{{\n');
+
+  // El atacante dejó su chat id preseteado, y una API key cualquiera también.
+  const env = { [ANCLA_ENV]: '666666666', OPENAI_API_KEY: 'AMBIENTE-OPENAI' };
+  const logger = capturarLogs();
+  const driver = driverConSeed();
+
+  try {
+    // Con archivo presente para que el loop de precedencia corra completo: así
+    // se ve que el ancla tampoco sale del ARCHIVO, y que las no-ancla resuelven
+    // exactamente como con el gate cerrado.
+    const r = conArchivosTmp(({ canonicalPath, legacyPath }) => cargar({
+      canonicalPath, legacyPath, env, logger, pipelineDir, vaultDriver: driver,
+    }), {
+      canonical: {
+        telegram: { bot_token: 'ARCHIVO-BOT', chat_id: '42', leo_operator_chat_id: '777777777' },
+      },
+    });
+
+    assert.equal(driver.calls.length, 0, 'sin config legible no se abre el gate ni se toca el driver');
+    assert.equal(r.vault.enabled, false);
+    assert.equal(r.vault.indeterminado, true,
+      '"no pude leer la config" es un estado propio, distinto de "el operador apago el vault"');
+
+    // El ancla: fail-closed, igual que cuando el gate está abierto y falta (B2.4).
+    assert.ok(!(ANCLA_ENV in env),
+      'un error de lectura de config no puede devolverle el ancla al ambiente');
+    assert.ok(r.missing.includes(ANCLA_ENV));
+    assert.equal(r.sources[ANCLA_ENV], SOURCE.MISSING);
+    assert.ok(!r.hydrated.includes(ANCLA_ENV), 'ni del ambiente ni del archivo');
+    assert.equal(resolveOperatorAllowlist(env).size, 0, 'cero firmantes: el gate del operador no autoriza a nadie');
+    assert.match(logger.texto(), /no se pudo leer config\.yaml para el vault/);
+    // El WARN nombra la variable, nunca el valor (B2.3).
+    assert.ok(!logger.texto().includes('666666666'), 'el log jamas lleva el valor del ancla');
+    assert.ok(!logger.texto().includes('777777777'));
+
+    // Las no-ancla: camino IDÉNTICO al del gate cerrado.
+    assert.equal(env.OPENAI_API_KEY, 'AMBIENTE-OPENAI', 'process.env preseteado sigue ganando');
+    assert.equal(r.sources.OPENAI_API_KEY, SOURCE.ENV_PREEXISTING);
+    assert.ok(r.skipped_existing.includes('OPENAI_API_KEY'));
+    assert.ok(!r.missing.includes('OPENAI_API_KEY'));
+    assert.equal(env.TELEGRAM_BOT_TOKEN, 'ARCHIVO-BOT', 'las no-ancla siguen resolviendo del archivo');
+    assert.equal(r.sources.TELEGRAM_BOT_TOKEN, 'canonical');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('B2.7 · con la config LEGIBLE el estado nunca es indeterminado (vault.enabled false sigue siendo identico al actual)', () => {
+  const r = cargar({
+    ...sinArchivos(), env: {}, logger: () => {},
+    vaultConfig: configVault({ enabled: false }), vaultDriver: driverConSeed(),
+  });
+  assert.equal(r.vault.enabled, false);
+  assert.equal(r.vault.indeterminado, false,
+    'apagar el vault a proposito NO activa el fail-closed del ancla');
 });
 
 // =============================================================================

--- a/.pipeline/lib/__tests__/credentials-vault-5353.test.js
+++ b/.pipeline/lib/__tests__/credentials-vault-5353.test.js
@@ -1,0 +1,744 @@
+// =============================================================================
+// Tests de la integración del vault en credentials.js (#5353 — split 3/3 de #5338)
+// node --test  (entra por el glob existente de `npm run test:pipeline`)
+// =============================================================================
+//
+// Cobertura, por CA:
+//   B1.1–B1.8  semántica de la ventana de bootstrap y del fail-closed
+//   B2.1–B2.6  precedencia de las anclas de autorización
+//   B3-A.1/.3  namespace desde config y `hostId` inválido nombrado
+//   D-SYNC-1/7/8  sync, memoización por namespace, gate cerrado
+//   UX-2/UX-3/UX-6  origen por variable, dry-run legible, contrato de QA
+//   SEC-2      los hijos no ganan el scope `aws` para hablar con el vault
+//   Gherkin 1/2/3 de #5338, con el 1 reescrito según B1.8
+//
+// Ningún test toca red, AWS ni `process.env` real: el driver se inyecta y el
+// ambiente destino es siempre un objeto scratch.
+// =============================================================================
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const credentials = require('../credentials');
+const {
+  loadIntoEnv,
+  ENV_MAPPING,
+  ENV_DESCRIPTORS,
+  VAULT_BACKENDS,
+  SOURCE,
+  vaultScopePlan,
+  _resetVaultCache,
+} = credentials;
+const { buildParameterPath, createInMemoryVaultDriver } = require('../secret-vault');
+const { resolveOperatorAllowlist } = require('../operator-gate');
+
+// -----------------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------------
+
+const PREFIX = '/intrale';
+const PROJECT = 'intrale';
+const HOST = 'hostTest';
+
+const ANCLA_DOTPATH = 'telegram.leo_operator_chat_id';
+const ANCLA_ENV = ENV_MAPPING[ANCLA_DOTPATH];
+const CHAT_ID_DEL_VAULT = '111222333';
+
+function configVault(over = {}) {
+  return {
+    enabled: true,
+    prefix: PREFIX,
+    projectId: PROJECT,
+    hostId: HOST,
+    cache_ttl_seconds: 300,
+    required_scopes: ['telegram', 'providers', 'google_drive'],
+    shared_secrets: ['telegram', 'providers', 'google_drive'],
+    bootstrap_fallback: false,
+    bootstrap_fallback_until: '',
+    region: 'us-east-2',
+    ...over,
+  };
+}
+
+function rutaScope(scope, tier = 'shared') {
+  return buildParameterPath({ prefix: PREFIX, projectId: PROJECT, hostId: HOST, scope, tier });
+}
+
+/**
+ * Namespace completo: los 13 valores del descriptor repartidos por scope y
+ * backend, tal como los provisionaría #5338.
+ */
+function seedCompleto({ conAncla = true } = {}) {
+  const telegram = { bot_token: 'VAULT-BOT', chat_id: '42' };
+  if (conAncla) telegram.leo_operator_chat_id = CHAT_ID_DEL_VAULT;
+  return {
+    parameters: {
+      [rutaScope('telegram')]: telegram,
+      [rutaScope('providers')]: {
+        openai: { api_key: 'VAULT-OPENAI' },
+        anthropic: { api_key: 'VAULT-ANTHROPIC' },
+        google: { api_key: 'VAULT-GEMINI' },
+        cerebras: { api_key: 'VAULT-CEREBRAS' },
+        nvidia: { api_key: 'VAULT-NVIDIA' },
+        moonshot: { api_key: 'VAULT-MOONSHOT' },
+      },
+      [rutaScope('google_drive')]: {
+        oauth_client_id: 'VAULT-GD-ID',
+        oauth_client_secret: 'VAULT-GD-SECRET',
+        drive_folder_id: 'VAULT-GD-FOLDER',
+      },
+    },
+    secrets: {
+      [buildParameterPath({ prefix: PREFIX, projectId: PROJECT, scope: 'google_drive', tier: 'rotating' })]:
+        { oauth_refresh_token: 'VAULT-GD-REFRESH' },
+    },
+  };
+}
+
+/** Driver in-memory con contador de invocaciones. */
+function driverConSeed(seed = seedCompleto()) {
+  return createInMemoryVaultDriver(seed);
+}
+
+/** Driver que siempre deniega (simula AccessDenied de IAM). */
+function driverQueDeniega(mensaje = 'AccessDenied: no identity-based policy allows ssm:GetParametersByPath') {
+  const calls = [];
+  const explotar = () => {
+    calls.push({ op: 'deny' });
+    const err = new Error(mensaje);
+    err.name = 'VaultCliError';
+    err.code = 'VAULT_CLI';
+    throw err;
+  };
+  return {
+    kind: 'deniega',
+    calls,
+    getParametersByPathSync: explotar,
+    getSecretValueSync: explotar,
+    async getParametersByPath() { return explotar(); },
+    async getSecretValue() { return explotar(); },
+  };
+}
+
+/** Directorio temporal FUERA del árbol del repo, con archivos de credenciales. */
+function conArchivosTmp(fn, { canonical = null, legacy = null } = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cred-vault-5353-'));
+  const canonicalPath = path.join(dir, 'credentials.json');
+  const legacyPath = path.join(dir, 'telegram-config.json');
+  if (canonical) fs.writeFileSync(canonicalPath, JSON.stringify(canonical, null, 2));
+  if (legacy) fs.writeFileSync(legacyPath, JSON.stringify(legacy, null, 2));
+  try { return fn({ canonicalPath, legacyPath, dir }); }
+  finally { fs.rmSync(dir, { recursive: true, force: true }); }
+}
+
+/** Paths inexistentes (fuera del repo) para los casos "sin ningún archivo". */
+function sinArchivos() {
+  const dir = path.join(os.tmpdir(), 'cred-vault-5353-inexistente');
+  return {
+    canonicalPath: path.join(dir, 'credentials.json'),
+    legacyPath: path.join(dir, 'telegram-config.json'),
+  };
+}
+
+function capturarLogs() {
+  const lineas = [];
+  const logger = (m) => lineas.push(String(m));
+  logger.lineas = lineas;
+  logger.texto = () => lineas.join('\n');
+  return logger;
+}
+
+/** Envoltorio: siempre invalida la memoización de módulo antes de correr. */
+function cargar(opts) {
+  _resetVaultCache();
+  return loadIntoEnv(opts);
+}
+
+// =============================================================================
+// Retrocompat del descriptor (G1) y superficie de exports
+// =============================================================================
+
+test('ENV_MAPPING sigue siendo el mapa plano dotPath -> envVar tras introducir el descriptor', () => {
+  assert.equal(typeof ENV_MAPPING, 'object');
+  assert.ok(Object.isFrozen(ENV_MAPPING), 'sigue congelado');
+  assert.equal(Object.keys(ENV_MAPPING).length, 13, 'las 13 de siempre (no 17)');
+
+  // Plano de verdad: `Object.entries` devuelve strings, no descriptores. Es lo
+  // que rompería `listProviders()` (wizards/providers/index.js:73) en silencio.
+  for (const [dotPath, envVar] of Object.entries(ENV_MAPPING)) {
+    assert.equal(typeof envVar, 'string', `${dotPath} no es string`);
+    assert.equal(envVar, ENV_DESCRIPTORS[dotPath].env, `${dotPath} no deriva del descriptor`);
+  }
+
+  // Ni `Proxy` ni getter lazy: los consumidores lo recorren directo.
+  for (const dotPath of Object.keys(ENV_MAPPING)) {
+    const d = Object.getOwnPropertyDescriptor(ENV_MAPPING, dotPath);
+    assert.equal(typeof d.get, 'undefined', `${dotPath} está detrás de un getter`);
+    assert.equal(d.enumerable, true);
+  }
+  assert.deepEqual(Object.values(ENV_MAPPING).sort(),
+    Object.values(ENV_DESCRIPTORS).map((d) => d.env).sort());
+});
+
+test('los 10 simbolos historicos siguen exportados y loadIntoEnv sigue sync (D-SYNC-1)', () => {
+  for (const simbolo of ['loadIntoEnv', 'CANONICAL_PATH', 'LEGACY_PATH', 'ENV_MAPPING',
+    'LEGACY_MAPPING', 'isPlaceholderOrEmpty', 'getNested', 'parseSecretRef',
+    'resolveScopedRefs', 'redactScoped']) {
+    assert.ok(simbolo in credentials, `falta el export histórico ${simbolo}`);
+  }
+  assert.equal(loadIntoEnv.constructor.name, 'Function');
+  const r = cargar({ ...sinArchivos(), env: {}, logger: () => {}, vaultConfig: null });
+  assert.equal(typeof r.then, 'undefined', 'el retorno no puede ser thenable');
+});
+
+test('todo descriptor declara backend valido, env, shared y auth_anchor', () => {
+  for (const [dotPath, d] of Object.entries(ENV_DESCRIPTORS)) {
+    assert.ok(VAULT_BACKENDS.includes(d.backend), `${dotPath}: backend inválido "${d.backend}"`);
+    assert.equal(typeof d.env, 'string');
+    assert.equal(typeof d.shared, 'boolean');
+    assert.equal(typeof d.auth_anchor, 'boolean');
+  }
+  // El plan de scopes agrupa por backend y no pide una llamada por variable.
+  assert.deepEqual(vaultScopePlan(), {
+    ssm: ['telegram', 'providers', 'google_drive'],
+    secretsmanager: ['google_drive'],
+  });
+  // `file-only` es un backend soportado: quien lo declare no va al vault.
+  assert.deepEqual(
+    vaultScopePlan({ 'x.y': { env: 'X', backend: 'file-only', shared: true, auth_anchor: false } }),
+    { ssm: [], secretsmanager: [] },
+  );
+});
+
+test('B2.1 · el inventario de anclas de autorizacion es exactamente una', () => {
+  const anclas = Object.entries(ENV_DESCRIPTORS)
+    .filter(([, d]) => d.auth_anchor)
+    .map(([dotPath]) => dotPath);
+
+  // Este test rompe A PROPÓSITO si alguien agrega un ancla nueva: cambiar la
+  // precedencia de una variable que decide autorización no puede pasar sin que
+  // alguien lo mire.
+  assert.deepEqual(anclas, [ANCLA_DOTPATH]);
+  assert.equal(ENV_DESCRIPTORS[ANCLA_DOTPATH].env, 'TELEGRAM_LEO_OPERATOR_CHAT_ID');
+});
+
+// =============================================================================
+// D-SYNC-8 — gate cerrado: comportamiento IDÉNTICO al de antes de #5353
+// =============================================================================
+
+test('D-SYNC-8 · con vault.enabled false el driver no se invoca ni una vez y el resultado es identico al actual', () => {
+  const driver = driverConSeed();
+  conArchivosTmp(({ canonicalPath, legacyPath }) => {
+    const env = {};
+    const r = cargar({
+      canonicalPath, legacyPath, env, logger: () => {},
+      vaultConfig: configVault({ enabled: false }), vaultDriver: driver,
+    });
+
+    assert.equal(driver.calls.length, 0, 'ni una invocación al driver');
+    assert.equal(r.source, 'canonical');
+    assert.equal(r.vault.enabled, false);
+    assert.deepEqual(r.missing, []);
+    assert.equal(env.TELEGRAM_BOT_TOKEN, 'ARCHIVO-BOT', 'el valor sale del archivo, no del vault');
+    assert.deepEqual(r.hydrated.sort(), ['TELEGRAM_BOT_TOKEN', 'TELEGRAM_CHAT_ID'].sort());
+    // Las arrays históricas no cambian de forma.
+    for (const k of ['hydrated', 'skipped_existing', 'skipped_empty']) {
+      assert.ok(Array.isArray(r[k]));
+      for (const v of r[k]) assert.equal(typeof v, 'string');
+    }
+  }, { canonical: { telegram: { bot_token: 'ARCHIVO-BOT', chat_id: '42' } } });
+});
+
+test('D-SYNC-8 · con la config del vault ausente tampoco se toca el driver', () => {
+  const driver = driverConSeed();
+  const r = cargar({
+    ...sinArchivos(), env: {}, logger: () => {}, vaultConfig: null, vaultDriver: driver,
+  });
+  assert.equal(driver.calls.length, 0);
+  assert.equal(r.source, 'none');
+  assert.equal(r.vault.enabled, false);
+});
+
+// =============================================================================
+// Escenarios Gherkin de #5338
+// =============================================================================
+
+test('Gherkin 1 · en configuracion por defecto el arranque no depende de ningun archivo, dentro ni fuera del repo', () => {
+  // B1.8 — redacción vigente: la ventana de bootstrap es una excepción
+  // explícita, flagueada y caducable; el default es "vault y nada más".
+  const env = {};
+  const driver = driverConSeed();
+  const r = cargar({
+    ...sinArchivos(), env, logger: () => {},
+    vaultConfig: configVault(), vaultDriver: driver,
+  });
+
+  assert.equal(r.vault.enabled, true);
+  assert.equal(r.source, SOURCE.VAULT);
+  assert.equal(r.hydrated.length, 13, 'las 13 salieron del vault, sin ningún archivo');
+  assert.deepEqual(r.missing, []);
+  for (const envVar of Object.values(ENV_MAPPING)) {
+    assert.equal(r.sources[envVar], SOURCE.VAULT, `${envVar} no vino del vault`);
+  }
+  assert.equal(env.TELEGRAM_BOT_TOKEN, 'VAULT-BOT');
+  assert.equal(env.GOOGLE_OAUTH_REFRESH_TOKEN, 'VAULT-GD-REFRESH', 'el tier rotating también');
+});
+
+test('Gherkin 2 · acceso cruzado denegado se propaga como fallo, jamas como valor vacio', () => {
+  const env = {};
+  const driver = driverQueDeniega();
+  const logger = capturarLogs();
+
+  conArchivosTmp(({ canonicalPath, legacyPath }) => {
+    const r = cargar({
+      canonicalPath, legacyPath, env, logger,
+      vaultConfig: configVault(), vaultDriver: driver,
+    });
+
+    assert.ok(driver.calls.length > 0, 'se intentó leer');
+    assert.equal(r.vault.error.code, 'VAULT_CLI');
+    assert.equal(r.missing.length, 13, 'las 13 quedan fail-closed');
+    assert.equal(r.hydrated.length, 0);
+    // CA-22 / B1.2 — el fallo NO degrada al archivo, aunque el archivo exista y
+    // tenga los valores. La denegación queda registrada.
+    assert.equal(env.TELEGRAM_BOT_TOKEN, undefined, 'ni cadena vacía ni valor del archivo');
+    assert.ok(!('TELEGRAM_BOT_TOKEN' in env), 'la var queda SIN SETEAR, no en ""');
+    assert.match(logger.texto(), /el vault no pudo resolverse/);
+    assert.match(logger.texto(), /NO se cae al archivo/);
+  }, { canonical: { telegram: { bot_token: 'ARCHIVO-BOT' } } });
+});
+
+test('Gherkin 3 · secreto faltante falla cerrado nombrando el secreto, sin valor vacio ni default', () => {
+  const env = {};
+  const logger = capturarLogs();
+  // El scope `providers` existe pero le falta la entrada de openai.
+  const seed = seedCompleto();
+  delete seed.parameters[rutaScope('providers')].openai;
+
+  const r = cargar({
+    ...sinArchivos(), env, logger,
+    vaultConfig: configVault(), vaultDriver: driverConSeed(seed),
+  });
+
+  assert.deepEqual(r.missing, ['OPENAI_API_KEY']);
+  assert.equal(r.sources.OPENAI_API_KEY, SOURCE.MISSING);
+  assert.ok(!('OPENAI_API_KEY' in env), 'sin setear: ni "" ni un default');
+  assert.match(logger.texto(), /falta el secreto "providers\/openai\/api_key"/,
+    'el error nombra el path lógico del secreto');
+  assert.match(logger.texto(), /Proximo paso/, 'UX-1: nombra la remediación');
+  // SEC-5 — el mensaje no filtra valores del vault.
+  assert.ok(!logger.texto().includes('VAULT-ANTHROPIC'));
+  // Y el resto sí se hidrató: el fail-closed es por variable, no global.
+  assert.equal(env.ANTHROPIC_API_KEY, 'VAULT-ANTHROPIC');
+});
+
+// =============================================================================
+// D-SYNC-7 — memoización por namespace
+// =============================================================================
+
+test('D-SYNC-7 · N llamadas consecutivas pagan una sola resolucion del vault', () => {
+  const driver = driverConSeed();
+  const base = {
+    ...sinArchivos(), logger: () => {},
+    vaultConfig: configVault(), vaultDriver: driver,
+  };
+
+  _resetVaultCache();
+  loadIntoEnv({ ...base, env: {} });
+  const trasLaPrimera = driver.calls.length;
+  assert.ok(trasLaPrimera > 0);
+
+  // `cerebras-runner.js:96` y `nvidia-nim-runner.js:90` llaman a esto POR
+  // LANZAMIENTO DE AGENTE: sin memoización cada launch pagaría la AWS CLI.
+  for (let i = 0; i < 5; i += 1) loadIntoEnv({ ...base, env: {} });
+  assert.equal(driver.calls.length, trasLaPrimera, '5 llamadas más, cero invocaciones más');
+
+  // Presupuesto: una batch por tier de SSM (SEC-3) + una por scope rotating.
+  assert.ok(trasLaPrimera <= 3, `presupuesto excedido: ${trasLaPrimera} invocaciones`);
+});
+
+test('D-SYNC-7 · la memoizacion tiene TTL: vencido, se vuelve a resolver', () => {
+  const driver = driverConSeed();
+  let ahora = 1_000_000;
+  const base = {
+    ...sinArchivos(), logger: () => {}, env: {},
+    vaultConfig: configVault({ cache_ttl_seconds: 60 }), vaultDriver: driver,
+    now: () => ahora,
+  };
+
+  _resetVaultCache();
+  loadIntoEnv({ ...base, env: {} });
+  const trasLaPrimera = driver.calls.length;
+
+  ahora += 59_000;
+  loadIntoEnv({ ...base, env: {} });
+  assert.equal(driver.calls.length, trasLaPrimera, 'dentro del TTL sale de la memo');
+
+  // Sin TTL, revocar un secreto en el vault no surtiría efecto hasta el
+  // restart — y para el ancla eso es seguir aceptando a un firmante removido.
+  ahora += 2_000;
+  loadIntoEnv({ ...base, env: {} });
+  assert.ok(driver.calls.length > trasLaPrimera, 'vencido el TTL vuelve a leer');
+});
+
+test('D-SYNC-7 · un fallo del vault NO se memoiza (se puede recuperar sin reiniciar)', () => {
+  const driver = driverQueDeniega();
+  const base = {
+    ...sinArchivos(), logger: () => {}, vaultConfig: configVault(), vaultDriver: driver,
+  };
+  _resetVaultCache();
+  loadIntoEnv({ ...base, env: {} });
+  const tras1 = driver.calls.length;
+  loadIntoEnv({ ...base, env: {} });
+  assert.ok(driver.calls.length > tras1, 'el fallo se reintenta: `aws login` surte efecto sin restart');
+});
+
+// =============================================================================
+// B1 — la ventana de bootstrap
+// =============================================================================
+
+test('B1.3 · sin el flag no hay fallback: lo que falta en el vault queda sin setear aunque este en el archivo', () => {
+  const env = {};
+  const seed = seedCompleto();
+  delete seed.parameters[rutaScope('providers')].cerebras;
+
+  conArchivosTmp(({ canonicalPath, legacyPath }) => {
+    const r = cargar({
+      canonicalPath, legacyPath, env, logger: () => {},
+      vaultConfig: configVault(), vaultDriver: driverConSeed(seed),
+    });
+    assert.deepEqual(r.missing, ['CEREBRAS_API_KEY']);
+    assert.ok(!('CEREBRAS_API_KEY' in env), 'el archivo lo tenía y NO se usó');
+  }, { canonical: { providers: { cerebras: { api_key: 'ARCHIVO-CEREBRAS' } } } });
+});
+
+test('B1.5/B1.6 · con la ventana ACTIVA el valor sale del archivo, con WARN y source file-bootstrap', () => {
+  const env = {};
+  const logger = capturarLogs();
+  const seed = seedCompleto();
+  delete seed.parameters[rutaScope('providers')].cerebras;
+  const ahora = Date.parse('2026-08-01T00:00:00Z');
+
+  conArchivosTmp(({ canonicalPath, legacyPath }) => {
+    const r = cargar({
+      canonicalPath, legacyPath, env, logger, now: () => ahora,
+      vaultConfig: configVault({
+        bootstrap_fallback: true,
+        bootstrap_fallback_until: '2026-09-01T00:00:00Z',
+      }),
+      vaultDriver: driverConSeed(seed),
+    });
+
+    assert.equal(env.CEREBRAS_API_KEY, 'ARCHIVO-CEREBRAS');
+    assert.equal(r.sources.CEREBRAS_API_KEY, SOURCE.FILE_BOOTSTRAP,
+      'B1.6: el source del fallback NUNCA es `vault`');
+    assert.deepEqual(r.missing, []);
+    // El resto sigue viniendo del vault.
+    assert.equal(r.sources.ANTHROPIC_API_KEY, SOURCE.VAULT);
+    // UX-4 — avisa mientras está activa, nombrando la variable y jamás el valor.
+    assert.match(logger.texto(), /ventana de bootstrap del vault ACTIVA hasta 2026-09-01/);
+    assert.match(logger.texto(), /CEREBRAS_API_KEY se resolvio por la ventana de bootstrap/);
+    assert.ok(!logger.texto().includes('ARCHIVO-CEREBRAS'), 'el valor nunca se loguea');
+  }, { canonical: { providers: { cerebras: { api_key: 'ARCHIVO-CEREBRAS' } } } });
+});
+
+test('B1.5 · la ventana caducada no se aplica aunque el flag siga en true', () => {
+  const seed = seedCompleto();
+  delete seed.parameters[rutaScope('providers')].cerebras;
+  const cfg = configVault({
+    bootstrap_fallback: true,
+    bootstrap_fallback_until: '2026-09-01T00:00:00Z',
+  });
+
+  conArchivosTmp(({ canonicalPath, legacyPath }) => {
+    // Un día ANTES del vencimiento: aplica.
+    const antes = {};
+    cargar({
+      canonicalPath, legacyPath, env: antes, logger: () => {},
+      now: () => Date.parse('2026-08-31T00:00:00Z'),
+      vaultConfig: cfg, vaultDriver: driverConSeed(seed),
+    });
+    assert.equal(antes.CEREBRAS_API_KEY, 'ARCHIVO-CEREBRAS');
+
+    // Un día DESPUÉS: no aplica, con el mismo flag encendido.
+    const despues = {};
+    const logger = capturarLogs();
+    const r = cargar({
+      canonicalPath, legacyPath, env: despues, logger,
+      now: () => Date.parse('2026-09-02T00:00:00Z'),
+      vaultConfig: cfg, vaultDriver: driverConSeed(seed),
+    });
+    assert.ok(!('CEREBRAS_API_KEY' in despues), '"bootstrap temporal" no puede volverse permanente');
+    assert.deepEqual(r.missing, ['CEREBRAS_API_KEY']);
+    assert.match(logger.texto(), /ventana de bootstrap del vault CADUCO/);
+  }, { canonical: { providers: { cerebras: { api_key: 'ARCHIVO-CEREBRAS' } } } });
+});
+
+test('B1.5 · el flag encendido sin fecha de caducidad NO abre la ventana', () => {
+  const seed = seedCompleto();
+  delete seed.parameters[rutaScope('providers')].cerebras;
+  const logger = capturarLogs();
+
+  conArchivosTmp(({ canonicalPath, legacyPath }) => {
+    const env = {};
+    const r = cargar({
+      canonicalPath, legacyPath, env, logger,
+      vaultConfig: configVault({ bootstrap_fallback: true, bootstrap_fallback_until: '' }),
+      vaultDriver: driverConSeed(seed),
+    });
+    assert.deepEqual(r.missing, ['CEREBRAS_API_KEY']);
+    assert.match(logger.texto(), /sin `vault.bootstrap_fallback_until`/);
+  }, { canonical: { providers: { cerebras: { api_key: 'ARCHIVO-CEREBRAS' } } } });
+});
+
+test('B1.4 · un archivo DENTRO del arbol del repo rechaza la ventana aunque el flag este encendido', () => {
+  const seed = seedCompleto();
+  delete seed.parameters[rutaScope('providers')].cerebras;
+  const logger = capturarLogs();
+  const env = {};
+
+  // Path dentro del repo: no hace falta que exista, la validación es del path.
+  const dentro = path.join(__dirname, '..', '..', '_tmp', 'credentials-5353.json');
+  const r = cargar({
+    canonicalPath: dentro, legacyPath: dentro, env, logger,
+    vaultConfig: configVault({
+      bootstrap_fallback: true,
+      bootstrap_fallback_until: '2099-01-01T00:00:00Z',
+    }),
+    vaultDriver: driverConSeed(seed),
+  });
+
+  assert.deepEqual(r.missing, ['CEREBRAS_API_KEY']);
+  assert.match(logger.texto(), /DENTRO del arbol del repo/);
+  assert.match(logger.texto(), /5218/, 'la razón nombra el guardrail que no se relaja');
+});
+
+test('B1.2 · un error del driver NUNCA habilita el fallback a archivo, ni con la ventana abierta', () => {
+  const env = {};
+  const logger = capturarLogs();
+
+  conArchivosTmp(({ canonicalPath, legacyPath }) => {
+    const r = cargar({
+      canonicalPath, legacyPath, env, logger,
+      vaultConfig: configVault({
+        bootstrap_fallback: true,
+        bootstrap_fallback_until: '2099-01-01T00:00:00Z',
+      }),
+      vaultDriver: driverQueDeniega('ExpiredToken: the security token included in the request is expired'),
+    });
+
+    // Un fallback disparado por error de red o de sesión es fail-open
+    // disfrazado: cualquiera que degrade la red desactiva el control entero.
+    assert.equal(r.missing.length, 13);
+    assert.equal(r.hydrated.length, 0);
+    assert.ok(!('TELEGRAM_BOT_TOKEN' in env));
+    assert.ok(!logger.texto().includes('ventana de bootstrap del vault ACTIVA'),
+      'la ventana ni siquiera se evalúa cuando el vault falló');
+  }, { canonical: { telegram: { bot_token: 'ARCHIVO-BOT', chat_id: '42' } } });
+});
+
+test('B1.7 · la ventana de bootstrap nunca alcanza al ancla de autorizacion', () => {
+  const env = {};
+  const seed = seedCompleto({ conAncla: false });
+
+  conArchivosTmp(({ canonicalPath, legacyPath }) => {
+    const r = cargar({
+      canonicalPath, legacyPath, env, logger: () => {},
+      vaultConfig: configVault({
+        bootstrap_fallback: true,
+        bootstrap_fallback_until: '2099-01-01T00:00:00Z',
+      }),
+      vaultDriver: driverConSeed(seed),
+    });
+
+    assert.ok(r.missing.includes(ANCLA_ENV), 'el ancla queda fail-closed');
+    assert.ok(!(ANCLA_ENV in env), 'aunque el archivo la tuviera y la ventana estuviera abierta');
+    assert.equal(resolveOperatorAllowlist(env).size, 0);
+  }, { canonical: { telegram: { leo_operator_chat_id: 'ARCHIVO-ANCLA' } } });
+});
+
+// =============================================================================
+// B2 — anclas de autorización
+// =============================================================================
+
+test('B2.2/B2.3 · el ancla se resuelve solo desde el vault y el shadowing se loguea sin el valor', () => {
+  const env = { [ANCLA_ENV]: '999999999' };   // valor preseteado en el ambiente
+  const logger = capturarLogs();
+
+  const r = cargar({
+    ...sinArchivos(), env, logger,
+    vaultConfig: configVault(), vaultDriver: driverConSeed(),
+  });
+
+  assert.equal(env[ANCLA_ENV], CHAT_ID_DEL_VAULT, 'el vault gana, sin excepción');
+  assert.equal(r.sources[ANCLA_ENV], SOURCE.VAULT);
+  assert.ok(!r.skipped_existing.includes(ANCLA_ENV), 'la rama skipped_existing se invierte para el ancla');
+  assert.match(logger.texto(), new RegExp(`${ANCLA_ENV}.*SOBRESCRITA`));
+  // Prohibido loguear el valor, un prefijo, un sufijo o un hash: el espacio de
+  // valores de un chat_id es chico y un hash se revierte por fuerza bruta.
+  assert.ok(!logger.texto().includes('999999999'), 'no se loguea el valor preexistente');
+  assert.ok(!logger.texto().includes(CHAT_ID_DEL_VAULT), 'ni el del vault');
+});
+
+test('B2.3 · si el valor preexistente COINCIDE con el del vault no se emite warning de shadowing', () => {
+  const env = { [ANCLA_ENV]: CHAT_ID_DEL_VAULT };
+  const logger = capturarLogs();
+  cargar({ ...sinArchivos(), env, logger, vaultConfig: configVault(), vaultDriver: driverConSeed() });
+  assert.ok(!logger.texto().includes('SOBRESCRITA'));
+});
+
+test('B2.4/B2.5a · sin el ancla en el vault la var queda sin setear y la allowlist de firmantes es vacia', () => {
+  const env = { [ANCLA_ENV]: '999999999' };
+  const logger = capturarLogs();
+
+  const r = cargar({
+    ...sinArchivos(), env, logger,
+    vaultConfig: configVault(), vaultDriver: driverConSeed(seedCompleto({ conAncla: false })),
+  });
+
+  assert.ok(r.missing.includes(ANCLA_ENV));
+  assert.ok(!(ANCLA_ENV in env), 'el valor del ambiente se DESCARTA: si no, el shadowing seguiría vivo');
+  assert.equal(resolveOperatorAllowlist(env).size, 0, 'fail-closed correcto del gate del operador');
+  assert.match(logger.texto(), /falta el ancla de autorizacion "telegram\/leo_operator_chat_id"/);
+});
+
+test('B2.5a · con el ancla en el vault la allowlist de firmantes tiene exactamente un miembro', () => {
+  const env = {};
+  cargar({ ...sinArchivos(), env, logger: () => {}, vaultConfig: configVault(), vaultDriver: driverConSeed() });
+  // Se reporta el TAMAÑO, jamás el contenido.
+  assert.equal(resolveOperatorAllowlist(env).size, 1);
+});
+
+test('B2.6 · para las 12 no-ancla la precedencia de process.env NO cambia', () => {
+  const env = {};
+  for (const [dotPath, envVar] of Object.entries(ENV_MAPPING)) {
+    if (dotPath !== ANCLA_DOTPATH) env[envVar] = `AMBIENTE-${envVar}`;
+  }
+
+  const r = cargar({
+    ...sinArchivos(), env, logger: () => {}, vaultConfig: configVault(), vaultDriver: driverConSeed(),
+  });
+
+  assert.equal(r.skipped_existing.length, 12, 'las 12 no-ancla siguen ganando por ambiente');
+  assert.equal(env.OPENAI_API_KEY, 'AMBIENTE-OPENAI_API_KEY');
+  assert.equal(r.sources.OPENAI_API_KEY, SOURCE.ENV_PREEXISTING);
+  // La única que cambia de régimen es el ancla.
+  assert.deepEqual(r.hydrated, [ANCLA_ENV]);
+});
+
+// =============================================================================
+// B3-A — namespace y hostId (lado código, sin AWS)
+// =============================================================================
+
+test('B3-A.1 · el namespace se construye desde config y no hay camino fuera del propio', () => {
+  const r = cargar({
+    ...sinArchivos(), env: {}, logger: () => {},
+    vaultConfig: configVault(), vaultDriver: driverConSeed(),
+  });
+  assert.equal(r.vault.namespace, `${PREFIX}/${PROJECT}#${HOST}`);
+
+  // El seed del host A no alimenta al host B: cambia el namespace, cambia el path.
+  const otro = cargar({
+    ...sinArchivos(), env: {}, logger: () => {},
+    vaultConfig: configVault({ hostId: 'otroHost' }), vaultDriver: driverConSeed(),
+  });
+  assert.equal(otro.vault.namespace, `${PREFIX}/${PROJECT}#otroHost`);
+  assert.equal(otro.hydrated.length, 13,
+    'los scopes de este inventario son shared: el aislamiento por host lo prueba secret-vault.test.js');
+});
+
+test('B3-A.3 · hostId vacio con el gate abierto falla nombrando vault.hostId', () => {
+  const logger = capturarLogs();
+  const r = cargar({
+    ...sinArchivos(), env: {}, logger,
+    vaultConfig: configVault({ hostId: '' }), vaultDriver: driverConSeed(),
+  });
+  assert.equal(r.vault.error.code, 'VAULT_CONFIG_INVALID');
+  assert.match(logger.texto(), /vault\.hostId/, 'el mensaje nombra la CLAVE de config, no el regex');
+  assert.equal(r.hydrated.length, 0, 'fail-closed: no se hidrata nada con config inválida');
+});
+
+// =============================================================================
+// UX / contrato de QA / seguridad
+// =============================================================================
+
+test('UX-6 · loadIntoEnv({env: scratch}) no escribe en process.env y tolera el fallo', () => {
+  // Contrato vivo de `qa/scripts/qa-narration.js:78` y `qa-video-share.js:119`:
+  // compartir el video de QA no puede pasar a depender de AWS.
+  // Se compara contra el snapshot previo, no contra `undefined`: en el host del
+  // pipeline el ambiente real YA viene hidratado, y afirmar `undefined` haría
+  // pasar el test por la razón equivocada en un entorno limpio.
+  const antes = Object.fromEntries(
+    Object.values(ENV_MAPPING).map((v) => [v, process.env[v]]),
+  );
+
+  const scratch = {};
+  const r = cargar({
+    ...sinArchivos(), env: scratch, logger: () => {},
+    vaultConfig: configVault(), vaultDriver: driverConSeed(),
+  });
+  assert.equal(scratch.TELEGRAM_BOT_TOKEN, 'VAULT-BOT');
+  for (const envVar of Object.values(ENV_MAPPING)) {
+    assert.equal(process.env[envVar], antes[envVar],
+      `el ambiente real del proceso cambió en ${envVar}`);
+  }
+  assert.notEqual(process.env.TELEGRAM_BOT_TOKEN, 'VAULT-BOT',
+    'ningún valor del vault se filtró a process.env');
+  assert.equal(r.hydrated.length, 13);
+
+  // Y con el vault caído tampoco lanza: devuelve el resultado degradado.
+  const scratch2 = {};
+  assert.doesNotThrow(() => cargar({
+    ...sinArchivos(), env: scratch2, logger: () => {},
+    vaultConfig: configVault(), vaultDriver: driverQueDeniega(),
+  }));
+  assert.deepEqual(scratch2, {});
+});
+
+test('UX-3 · el resultado distingue "no configurada" de "vacia a proposito" y nunca lleva valores', () => {
+  conArchivosTmp(({ canonicalPath, legacyPath }) => {
+    const r = cargar({
+      canonicalPath, legacyPath, env: {}, logger: () => {}, vaultConfig: null,
+    });
+    assert.equal(r.sources.TELEGRAM_BOT_TOKEN, SOURCE.CANONICAL);
+    assert.equal(r.sources.TELEGRAM_CHAT_ID, SOURCE.EMPTY, 'presente pero vacía a propósito');
+    assert.equal(r.sources.OPENAI_API_KEY, SOURCE.MISSING, 'no configurada');
+    // Las dos siguen cayendo en `skipped_empty`: la forma histórica no cambia.
+    assert.ok(r.skipped_empty.includes('TELEGRAM_CHAT_ID'));
+    assert.ok(r.skipped_empty.includes('OPENAI_API_KEY'));
+
+    // El objeto de resultado es 100% nombres: se puede loguear entero.
+    const serializado = JSON.stringify(r);
+    assert.ok(!serializado.includes('ARCHIVO-BOT'), 'ningún valor en el resultado');
+  }, { canonical: { telegram: { bot_token: 'ARCHIVO-BOT', chat_id: '   ' } } });
+});
+
+test('SEC-2 · ningun skill gana el scope `aws` para resolver el vault por su cuenta', () => {
+  // La resolución vive en el proceso padre; los hijos reciben valores ya
+  // filtrados por `build-child-env.js`. Si un skill ganara el scope `aws`,
+  // podría leer el namespace entero salteándose el scoping por capability.
+  const modelos = require('../../agent-models.json');
+  const conAws = Object.entries(modelos.skills || {})
+    .filter(([, cfg]) => Array.isArray(cfg.requires_credentials) && cfg.requires_credentials.includes('aws'))
+    .map(([skill]) => skill);
+  assert.deepEqual(conAws, []);
+
+  // Y `credentials.js` no propaga credenciales AWS al ambiente destino.
+  const env = {};
+  cargar({ ...sinArchivos(), env, logger: () => {}, vaultConfig: configVault(), vaultDriver: driverConSeed() });
+  for (const k of ['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY', 'AWS_SESSION_TOKEN', 'AWS_PROFILE']) {
+    assert.ok(!(k in env), `${k} no puede llegar al ambiente hidratado`);
+  }
+});
+
+test('config.yaml trae las dos claves de la ventana de bootstrap, apagadas', () => {
+  const yaml = require('js-yaml');
+  const cfg = yaml.load(fs.readFileSync(path.join(__dirname, '..', '..', 'config.yaml'), 'utf8'));
+  assert.equal(cfg.vault.enabled, false, 'el gate se commitea CERRADO');
+  assert.equal(cfg.vault.bootstrap_fallback, false, 'la ventana se commitea CERRADA');
+  assert.equal(cfg.vault.bootstrap_fallback_until, '');
+});

--- a/.pipeline/lib/__tests__/fixtures/config-snapshot-pre-particion.json
+++ b/.pipeline/lib/__tests__/fixtures/config-snapshot-pre-particion.json
@@ -1,7 +1,7 @@
 {
   "_doc": "#5174 · CA-2 — snapshot REDACTADO (path -> tipo, NUNCA el valor) de la configuracion resuelta ANTES de partir config.yaml en kernel + producto. Generado desde .pipeline/config.yaml en el commit 14a454441 (entrega B, pre-particion). Sirve para demostrar que la particion no perdio ni cambio ninguna clave. Si un cambio LEGITIMO agrega o quita una clave top-level, regenerar con: node .pipeline/lib/__tests__/fixtures/regen-config-snapshot.js",
-  "_generadoDesde": "c02004295",
-  "_claves": 437,
+  "_generadoDesde": "baaed3937",
+  "_claves": 439,
   "snapshot": [
     "admission_gate: object(3)",
     "admission_gate.bootstrap_cap: number",
@@ -408,7 +408,9 @@
     "timeouts.intake_interval_seconds: number",
     "timeouts.orphan_timeout_minutes: number",
     "timeouts.poll_interval_seconds: number",
-    "vault: object(7)",
+    "vault: object(9)",
+    "vault.bootstrap_fallback: boolean",
+    "vault.bootstrap_fallback_until: string",
     "vault.cache_ttl_seconds: number",
     "vault.enabled: boolean",
     "vault.hostId: string",

--- a/.pipeline/lib/__tests__/quota-setflag-config-corrupta-5172.test.js
+++ b/.pipeline/lib/__tests__/quota-setflag-config-corrupta-5172.test.js
@@ -31,10 +31,8 @@ const { seedProductManifest } = require('./_test-helpers');
 const QUOTA_MOD = path.join(__dirname, '..', 'quota-exhausted.js');
 
 const YAML_CORRUPTO = 'foo: [1, 2\n  bar: : :\n';
-// `resets_at_cap_max_days: 1` está DELIBERADAMENTE por debajo de la distancia al
-// próximo reset semanal: así el fallback semanal queda fuera del cap y
-// `capResetsAt` devuelve exactamente el techo (`cap_max`). Eso vuelve el TTL
-// determinista y discrimina "se aplicó la config" de "se usó el default de 7d".
+// El reloj y el candidato de reset se fijan más abajo. Así el test no depende
+// de cuánto falta, en el calendario real, para el próximo reset semanal.
 const YAML_SANO_TTL = 'quota_detector:\n  resets_at_cap_max_days: 1\n';
 
 /**
@@ -69,8 +67,17 @@ const BASE = { errorType: 'usage_limit_reached', provider: 'anthropic', auditLog
 
 // Para MEDIR el TTL hace falta un errorType que NO sea `usage_limit_reached`:
 // ese es el cap rolling de Codex (1h fija), donde `maxDays` sólo acota y no
-// define. Sin `resetsAt`, el resto cae exactamente al cap => el TTL es medible.
-const BASE_TTL = { errorType: 'rate_limit_error', provider: 'anthropic', auditLogEnabled: false };
+// define. Un `resetsAt` fijo permite comparar ambos caps con reloj hermético.
+const TEST_NOW = Date.UTC(2026, 0, 1, 12, 0, 0);
+const BASE_TTL = {
+    errorType: 'rate_limit_error',
+    provider: 'anthropic',
+    auditLogEnabled: false,
+    now: TEST_NOW,
+    // Con config corrupta, el default de 7d acepta este candidato de 3d. Con
+    // config sana, el cap de 1d lo rechaza y fija el techo configurado.
+    resetsAt: TEST_NOW + 3 * 86400000,
+};
 
 test('config corrupta + setFlag SIN maxDays => el flag SE ESCRIBE (no fail-open)', () => {
     const r = correrSetFlag(YAML_CORRUPTO, BASE);
@@ -85,8 +92,7 @@ function ttlEnDias(r, desde) {
 }
 
 test('config corrupta => el TTL queda acotado por el default conservador de 7d', () => {
-    const ahora = Date.now();
-    const dias = ttlEnDias(correrSetFlag(YAML_CORRUPTO, BASE_TTL), ahora);
+    const dias = ttlEnDias(correrSetFlag(YAML_CORRUPTO, BASE_TTL), TEST_NOW);
     // Sin config legible el techo es DEFAULT_MAX_RESETS_AT_DAYS; dentro de ese
     // techo `capResetsAt` puede elegir el reset semanal, así que se acota el
     // rango en vez de fijar un valor: lo que importa es que NO hay flag eterno.
@@ -100,17 +106,15 @@ test('config corrupta + maxDays explícito => sigue funcionando (contrato #3077 
 });
 
 test('config SANA => el TTL configurado se sigue aplicando (no se degradó a default)', () => {
-    const ahora = Date.now();
     const r = correrSetFlag(YAML_SANO_TTL, BASE_TTL);
     assert.strictEqual(r.threw, null);
-    const dias = ttlEnDias(r, ahora);
+    const dias = ttlEnDias(r, TEST_NOW);
     assert.ok(dias > 0.95 && dias < 1.05, `TTL esperado ~1d (config), obtenido ${dias.toFixed(2)}d`);
 });
 
 test('config corrupta vs SANA => el techo difiere (prueba que la config SÍ se lee cuando es legible)', () => {
-    const ahora = Date.now();
-    const conCorrupta = ttlEnDias(correrSetFlag(YAML_CORRUPTO, BASE_TTL), ahora);
-    const conSana = ttlEnDias(correrSetFlag(YAML_SANO_TTL, BASE_TTL), ahora);
+    const conCorrupta = ttlEnDias(correrSetFlag(YAML_CORRUPTO, BASE_TTL), TEST_NOW);
+    const conSana = ttlEnDias(correrSetFlag(YAML_SANO_TTL, BASE_TTL), TEST_NOW);
     assert.ok(
         conCorrupta > conSana,
         `la degradación debe ser observable: corrupta=${conCorrupta.toFixed(2)}d sana=${conSana.toFixed(2)}d`

--- a/.pipeline/lib/__tests__/secret-vault-sync-5353.test.js
+++ b/.pipeline/lib/__tests__/secret-vault-sync-5353.test.js
@@ -1,0 +1,315 @@
+// =============================================================================
+// Tests de la superficie SYNC de secret-vault.js (#5353 — split 3/3 de #5338)
+// node --test  (entra por el glob existente de `npm run test:pipeline`)
+// =============================================================================
+//
+// Por qué es un archivo NUEVO y no un append a `secret-vault.test.js`:
+// D1.5 / D-SYNC-4 exigen que la suite de #5352 quede verde **sin modificarse**
+// —si un test suyo necesita cambiar, es señal de que se rompió su contrato—.
+// Un archivo aparte convierte esa CA en algo verificable de un vistazo:
+//
+//   $ git diff origin/main -- .pipeline/lib/__tests__/secret-vault.test.js
+//   (vacío)
+//
+// Ninguno de estos tests requiere red ni cuenta AWS.
+// =============================================================================
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const util = require('node:util');
+
+const {
+    VAULT_ERROR_CODES,
+    createInMemoryVaultDriver,
+    createAwsCliVaultDriver,
+    createSecretVault,
+} = require('../secret-vault');
+
+// -----------------------------------------------------------------------------
+// Helpers (deliberadamente propios: no se importa nada de secret-vault.test.js)
+// -----------------------------------------------------------------------------
+
+const PREFIX = '/intrale';
+const PROJECT = 'intrale';
+const HOST = 'hostSync';
+
+const TELEGRAM = { bot_token: 'CANARIO-TELEGRAM', chat_id: '42' };
+const AWS_SCOPE = { AWS_ACCESS_KEY_ID: 'CANARIO-AKIA' };
+
+function configVault(over = {}) {
+    return {
+        enabled: true,
+        prefix: PREFIX,
+        projectId: PROJECT,
+        hostId: HOST,
+        cache_ttl_seconds: 300,
+        required_scopes: ['telegram', 'aws'],
+        shared_secrets: ['telegram'],
+        ...over,
+    };
+}
+
+function seed() {
+    return {
+        [`${PREFIX}/${PROJECT}/shared/telegram`]: TELEGRAM,
+        [`${PREFIX}/${PROJECT}/hosts/${HOST}/aws`]: AWS_SCOPE,
+    };
+}
+
+/**
+ * Código del módulo SIN comentarios.
+ *
+ * Los greps de prohibición tienen que correr sobre el CÓDIGO: el módulo
+ * documenta explícitamente qué está prohibido (`Atomics.wait`,
+ * `worker_threads`, `deasync`, `@aws-sdk/*`), así que un grep sobre el archivo
+ * crudo se dispararía con el propio texto de la prohibición.
+ */
+function codigoSinComentarios(archivo) {
+    return fs.readFileSync(archivo, 'utf8')
+        .replace(/\/\*[\s\S]*?\*\//g, ' ')       // bloques /* ... */
+        .split(/\r?\n/)
+        .filter((linea) => !linea.trim().startsWith('//'))
+        .join('\n');
+}
+
+const FUENTE_VAULT = () => codigoSinComentarios(path.join(__dirname, '..', 'secret-vault.js'));
+
+/** Captura la falla de un thunk sync o de una promesa, con la misma forma. */
+async function fallaDe(fn) {
+    try {
+        const r = await fn();
+        return { lanzo: false, valor: r };
+    } catch (err) {
+        return { lanzo: true, name: err.name, code: err.code, message: err.message };
+    }
+}
+
+// =============================================================================
+// D1.2 — la superficie sync existe y NO devuelve Promise
+// =============================================================================
+
+test('D1.2 · resolveNamespaceSync y resolveScopeSync son sync y no devuelven Promise', () => {
+    const vault = createSecretVault({
+        config: configVault(),
+        driver: createInMemoryVaultDriver({ parameters: seed() }),
+    });
+
+    assert.equal(typeof vault.resolveNamespaceSync, 'function');
+    assert.equal(typeof vault.resolveScopeSync, 'function');
+    assert.equal(vault.resolveNamespaceSync.constructor.name, 'Function');
+    assert.equal(vault.resolveScopeSync.constructor.name, 'Function');
+
+    const ns = vault.resolveNamespaceSync();
+    assert.ok(!(ns instanceof Promise), 'el retorno sync no puede ser una Promise');
+    assert.equal(typeof ns.then, 'undefined', 'ni siquiera thenable');
+    assert.equal(ns.enabled, true);
+    assert.deepEqual(Object.keys(ns.scopes).sort(), ['aws', 'telegram']);
+
+    // D-SYNC-4 — la API async de #5352 no cambia de forma.
+    assert.equal(vault.resolveNamespace.constructor.name, 'AsyncFunction');
+    assert.equal(vault.resolveScope.constructor.name, 'AsyncFunction');
+});
+
+test('D1.5 · los gemelos sync NO alteran la superficie enumerable que #5352 congeló', () => {
+    const vault = createSecretVault({
+        config: configVault(),
+        driver: createInMemoryVaultDriver({ parameters: seed() }),
+    });
+
+    // El test 8 de #5352 afirma exactamente esto. Si los métodos sync fueran
+    // enumerables, esa suite rompería y habría que editarla — justo lo prohibido.
+    assert.deepEqual(
+        Object.keys(vault).sort(),
+        ['clearCache', 'resolveNamespace', 'resolveScope'],
+    );
+    assert.ok(!util.inspect(vault).includes('Sync'), 'tampoco aparecen en el inspect');
+    // Pero son públicos y accesibles.
+    assert.equal(typeof vault.resolveNamespaceSync, 'function');
+});
+
+// =============================================================================
+// D1.3 — port sync en los DOS drivers
+// =============================================================================
+
+test('D1.3 · los dos drivers exponen getParametersByPathSync / getSecretValueSync', () => {
+    const inMemory = createInMemoryVaultDriver({ parameters: seed() });
+    const awsCli = createAwsCliVaultDriver({ run: () => '{"Parameters":[]}' });
+
+    for (const driver of [inMemory, awsCli]) {
+        assert.equal(typeof driver.getParametersByPathSync, 'function', driver.kind);
+        assert.equal(typeof driver.getSecretValueSync, 'function', driver.kind);
+        const res = driver.getParametersByPathSync(`${PREFIX}/${PROJECT}/shared/`, {});
+        assert.ok(!(res instanceof Promise), `${driver.kind} devolvió Promise en el port sync`);
+        assert.ok(Array.isArray(res.parameters));
+    }
+
+    // El de aws-cli se apoya en el runner que YA era sync: sin dep nueva.
+    assert.equal(FUENTE_VAULT().includes('@aws-sdk'), false,
+        'no se agregó ninguna dependencia @aws-sdk/*');
+    assert.equal(
+        Object.keys(require('../../../package.json').dependencies).some((d) => d.startsWith('@aws-sdk')),
+        false,
+        '`package.json` no gana ninguna dependencia @aws-sdk/*',
+    );
+});
+
+test('D1.3 · el port sync del driver aws-cli consume NextToken igual que el async', async () => {
+    const paginas = [
+        JSON.stringify({
+            Parameters: [{ Name: `${PREFIX}/${PROJECT}/shared/telegram`, Value: '{}' }],
+            NextToken: 'p2',
+        }),
+        JSON.stringify({
+            Parameters: [{ Name: `${PREFIX}/${PROJECT}/shared/aws`, Value: '{}' }],
+        }),
+    ];
+    const hacerDriver = () => {
+        let i = 0;
+        return createAwsCliVaultDriver({ run: () => paginas[i++] });
+    };
+
+    const sync = hacerDriver().getParametersByPathSync(`${PREFIX}/${PROJECT}/shared/`, {});
+    const asinc = await hacerDriver().getParametersByPath(`${PREFIX}/${PROJECT}/shared/`, {});
+
+    assert.equal(sync.parameters.length, 2, 'el camino sync también agotó la paginación');
+    assert.deepEqual(sync, asinc, 'misma paginación, mismo resultado');
+});
+
+// =============================================================================
+// D1.4 — paridad sync/async: MISMO valor y MISMA falla (BLOQUEANTE)
+// =============================================================================
+
+test('D1.4 · para el mismo seed, sync y async devuelven exactamente el mismo valor', async () => {
+    const vaultA = createSecretVault({
+        config: configVault(), driver: createInMemoryVaultDriver({ parameters: seed() }),
+    });
+    const vaultB = createSecretVault({
+        config: configVault(), driver: createInMemoryVaultDriver({ parameters: seed() }),
+    });
+
+    assert.deepEqual(vaultA.resolveNamespaceSync(), await vaultB.resolveNamespace());
+    assert.deepEqual(
+        vaultA.resolveScopeSync({ scopes: ['telegram'] }),
+        await vaultB.resolveScope({ scopes: ['telegram'] }),
+    );
+});
+
+test('D1.4 · paridad sync/async sobre las TRES fallas terminales', async () => {
+    // Cada caso arma dos vaults gemelos (uno por camino) sobre el mismo seed.
+    const casos = [
+        {
+            nombre: VAULT_ERROR_CODES.SECRET_MISSING,
+            driver: () => createInMemoryVaultDriver({ parameters: {} }),
+            config: () => configVault(),
+        },
+        {
+            nombre: VAULT_ERROR_CODES.CLI,
+            // G-2: un scope cuyo valor no es JSON válido ⇒ VaultCliError.
+            driver: () => createInMemoryVaultDriver({
+                parameters: {
+                    [`${PREFIX}/${PROJECT}/shared/telegram`]: 'esto-no-es-json',
+                    [`${PREFIX}/${PROJECT}/hosts/${HOST}/aws`]: AWS_SCOPE,
+                },
+            }),
+            config: () => configVault(),
+        },
+        {
+            nombre: VAULT_ERROR_CODES.TRUNCATED_RESPONSE,
+            // Un exit 0 con JSON cortado es truncación, no "vault vacío".
+            driver: () => createAwsCliVaultDriver({ run: () => '{"Parameters":[' }),
+            config: () => configVault({ required_scopes: ['telegram'], shared_secrets: ['telegram'] }),
+        },
+    ];
+
+    for (const caso of casos) {
+        const vSync = createSecretVault({ config: caso.config(), driver: caso.driver() });
+        const vAsync = createSecretVault({ config: caso.config(), driver: caso.driver() });
+
+        const fSync = await fallaDe(() => vSync.resolveNamespaceSync());
+        const fAsync = await fallaDe(() => vAsync.resolveNamespace());
+
+        assert.ok(fSync.lanzo, `${caso.nombre}: el camino sync no falló`);
+        assert.ok(fAsync.lanzo, `${caso.nombre}: el camino async no falló`);
+        assert.equal(fSync.code, caso.nombre, `${caso.nombre}: código del camino sync`);
+        assert.equal(fSync.code, fAsync.code, `${caso.nombre}: mismo código`);
+        assert.equal(fSync.name, fAsync.name, `${caso.nombre}: misma clase`);
+        assert.equal(fSync.message, fAsync.message, `${caso.nombre}: mismo mensaje`);
+    }
+});
+
+// =============================================================================
+// D-SYNC-3 — un solo cuerpo ⇒ una sola caché
+// =============================================================================
+
+test('D-SYNC-3 · la caché es compartida: lo que puebla el camino sync lo ve el async', async () => {
+    const driver = createInMemoryVaultDriver({ parameters: seed() });
+    const vault = createSecretVault({ config: configVault(), driver });
+
+    vault.resolveNamespaceSync();
+    const trasSync = driver.calls.length;
+    assert.ok(trasSync > 0, 'la primera lectura sí pega al driver');
+
+    await vault.resolveNamespace();
+    assert.equal(driver.calls.length, trasSync, 'el camino async salió de la caché del sync');
+
+    vault.clearCache();
+    await vault.resolveNamespace();
+    const trasAsync = driver.calls.length;
+    assert.ok(trasAsync > trasSync, 'tras clearCache el async vuelve a leer');
+
+    vault.resolveNamespaceSync();
+    assert.equal(driver.calls.length, trasAsync, 'y ahora el sync sale de la caché del async');
+});
+
+// =============================================================================
+// D-SYNC-6 — driver sin port sync ⇒ fail-closed NOMBRANDO el método
+// =============================================================================
+
+test('D-SYNC-6 · un driver sin port sync falla nombrando el metodo faltante', () => {
+    const soloAsync = {
+        kind: 'solo-async',
+        async getParametersByPath() { return { parameters: [] }; },
+        async getSecretValue() { return null; },
+    };
+    const vault = createSecretVault({ config: configVault(), driver: soloAsync });
+
+    assert.throws(() => vault.resolveNamespaceSync(), (err) => {
+        assert.equal(err.code, VAULT_ERROR_CODES.CONFIG_INVALID);
+        assert.match(err.message, /getParametersByPathSync/, 'el mensaje nombra el método faltante');
+        assert.match(err.message, /solo-async/, 'y el driver que lo incumple');
+        return true;
+    });
+
+    // Nunca devuelve vacío: el fail-closed es lanzar, no `{}`.
+    assert.throws(() => vault.resolveScopeSync({ scopes: ['telegram'] }));
+});
+
+test('D-SYNC-6 · el modulo no usa ningun hack de espera bloqueante', () => {
+    const fuente = FUENTE_VAULT();
+    for (const prohibido of ['Atomics.wait', 'worker_threads', 'deasync', '@aws-sdk']) {
+        assert.equal(fuente.includes(prohibido), false, `el módulo usa \`${prohibido}\``);
+    }
+    // Tampoco se spawnea un Node hijo para simular sincronía.
+    assert.equal(/execFileSync\(\s*['"]node['"]/.test(fuente), false);
+});
+
+// =============================================================================
+// D-SYNC-8 — con el gate cerrado, cero invocaciones en AMBOS caminos
+// =============================================================================
+
+test('D-SYNC-8 · con vault.enabled:false ningun camino invoca el driver', async () => {
+    const driver = createInMemoryVaultDriver({ parameters: seed() });
+    const vault = createSecretVault({ config: configVault({ enabled: false }), driver });
+
+    assert.deepEqual(vault.resolveNamespaceSync(), {
+        enabled: false, namespace: null, scopes: {}, tiers: {},
+    });
+    assert.deepEqual(vault.resolveScopeSync({ scopes: ['telegram'] }), {});
+    await vault.resolveNamespace();
+    await vault.resolveScope({ scopes: ['telegram'] });
+
+    assert.equal(driver.calls.length, 0, 'ni una invocación con el gate cerrado');
+});

--- a/.pipeline/lib/config-schema.js
+++ b/.pipeline/lib/config-schema.js
@@ -466,6 +466,12 @@ const SCHEMA = {
                 cache_ttl_seconds: { type: 'number', minimum: 1, maximum: 300 },
                 required_scopes: { type: 'array', items: { type: 'string' } },
                 shared_secrets: { type: 'array', items: { type: 'string' } },
+                // #5353 · B1 — se tipan por el mismo motivo que `enabled`: son
+                // fail-closed. Un `bootstrap_fallback: "false"` string sería
+                // truthy para el YAML y sólo se descubriría el día que la
+                // ventana se abriera sola.
+                bootstrap_fallback: { type: 'boolean' },
+                bootstrap_fallback_until: { type: 'string' },
             },
         },
 

--- a/.pipeline/lib/credentials.js
+++ b/.pipeline/lib/credentials.js
@@ -21,6 +21,29 @@
 //   1. process.env ya seteado → respetar, no sobrescribir
 //   2. credentials.json (canonical)
 //   3. telegram-config.json (legacy, fallback con warning)
+//
+// -----------------------------------------------------------------------------
+// #5353 — el vault de AWS pasa a ser la FUENTE PRIMARIA (gate `vault.enabled`)
+// -----------------------------------------------------------------------------
+//
+// Con `vault.enabled: false` (default commiteado en `config.yaml`) todo lo de
+// arriba sigue EXACTAMENTE igual y no se emite una sola llamada AWS: el módulo
+// `secret-vault.js` ni siquiera se carga. Con el gate abierto, la precedencia
+// pasa a ser:
+//
+//   1. `process.env` preseteado → gana, SALVO para las anclas de autorización
+//      (B2.2: ahí gana el vault, sin excepción, y el shadowing se loguea).
+//   2. El **vault** (`secret-vault.js`, camino SYNC — D-SYNC-1/D1.6).
+//   3. La ventana de bootstrap sobre el archivo, SÓLO si el operador la
+//      encendió a mano y no caducó (B1.3/B1.5). Jamás automática ante un error
+//      del driver (B1.2), jamás para un ancla (B1.7/B2.4).
+//   4. Nada más: **fail-closed** nombrando el secreto faltante. La variable
+//      queda SIN SETEAR — nunca cadena vacía, nunca un default (B1.1).
+//
+// `loadIntoEnv()` sigue siendo **sync** (D-SYNC-1). No es cosmética: sus dos
+// call-sites de arranque (`pulpo.js:18`, `restart.js:47`) son de nivel de
+// módulo y su razón de ser es el ORDEN (#3311); CommonJS no tiene top-level
+// `await`, así que volverla async destruiría la garantía, no la firma.
 // =============================================================================
 
 'use strict';
@@ -32,28 +55,80 @@ const path = require('path');
 const CANONICAL_PATH = path.join(os.homedir(), '.claude', 'secrets', 'credentials.json');
 const LEGACY_PATH = path.join(os.homedir(), '.claude', 'secrets', 'telegram-config.json');
 
-// Mapeo canónico: dot-path en credentials.json → env var que esperan los CLIs.
-// Mantener ordenado por categoría para facilitar el code-review.
-const ENV_MAPPING = Object.freeze({
+// Raíz del repo — se usa para B1.4 (el archivo de la ventana de bootstrap tiene
+// que estar FUERA del árbol versionado, coherente con #5218).
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+
+// -----------------------------------------------------------------------------
+// Descriptor de credenciales (#5353) — ENV_MAPPING se DERIVA de acá
+// -----------------------------------------------------------------------------
+//
+// Cada entrada describe de dónde sale el valor y qué tratamiento merece:
+//
+//   env         nombre de la env var que esperan los CLIs.
+//   backend     'ssm' → Parameter Store · 'secretsmanager' → Secrets Manager
+//               (tier `rotating`) · 'file-only' → nunca va al vault.
+//               La clasificación NO la inventa este módulo: sale de la tabla
+//               firmada en `docs/pipeline/vault-secretos-aws.md` (#5351), que
+//               manda a Secrets Manager sólo lo que rota FUERA del rol de
+//               provisión. Hoy eso es un único valor.
+//   shared      tier de provisión declarado: `shared/` (común a todos los
+//               hosts) vs `hosts/<hostId>/`. Es la INTENCIÓN de alta; en
+//               runtime la membresía autoritativa es `vault.shared_secrets`
+//               (secret-vault.js), que es enumerada a propósito.
+//   auth_anchor el valor no es un secreto: es la fuente de una decisión de
+//               AUTORIZACIÓN. Cambia la precedencia (B2) — ver más abajo.
+//
+// El scope del vault es el primer segmento del dot-path (`telegram`,
+// `providers`, `google_drive`): las claves top-level del namespace de
+// credenciales, mismo vocabulario que `resolveScopedRefs` (G-1 de #5352).
+const VAULT_BACKENDS = Object.freeze(['ssm', 'secretsmanager', 'file-only']);
+
+const ENV_DESCRIPTORS = Object.freeze({
   // Telegram bot
-  'telegram.bot_token':            'TELEGRAM_BOT_TOKEN',
-  'telegram.chat_id':              'TELEGRAM_CHAT_ID',
+  'telegram.bot_token': {
+    env: 'TELEGRAM_BOT_TOKEN', backend: 'ssm', shared: true, auth_anchor: false,
+  },
+  'telegram.chat_id': {
+    env: 'TELEGRAM_CHAT_ID', backend: 'ssm', shared: true, auth_anchor: false,
+  },
   // Chat del operador (Leo) para handlers proactivos (mockup UX, etc. — #3384).
   // Si no está configurada, el handler correspondiente se autodeshabilita.
-  'telegram.leo_operator_chat_id': 'TELEGRAM_LEO_OPERATOR_CHAT_ID',
+  //
+  // B2.1 — ÚNICA ancla de autorización del inventario. No es una API key: es la
+  // única fuente de `resolveOperatorAllowlist()` (`operator-gate.js:78-85`), que
+  // alimenta `authorizedSigners` en `pulpo.js`. Quien pueda escribir esta var en
+  // el ambiente del Pulpo se auto-agrega a la allowlist de firmantes; por eso
+  // con el gate abierto se resuelve EXCLUSIVAMENTE desde el vault (B2.2) y no
+  // tiene fallback de ningún tipo (B2.4).
+  'telegram.leo_operator_chat_id': {
+    env: 'TELEGRAM_LEO_OPERATOR_CHAT_ID', backend: 'ssm', shared: true, auth_anchor: true,
+  },
   // Providers IA (allowlist en agent-models-validate.js:ALLOWED_CREDENTIAL_ENV_VARS)
-  'providers.openai.api_key':      'OPENAI_API_KEY',
-  'providers.anthropic.api_key':   'ANTHROPIC_API_KEY',
-  'providers.google.api_key':      'GEMINI_API_KEY',
+  'providers.openai.api_key': {
+    env: 'OPENAI_API_KEY', backend: 'ssm', shared: true, auth_anchor: false,
+  },
+  'providers.anthropic.api_key': {
+    env: 'ANTHROPIC_API_KEY', backend: 'ssm', shared: true, auth_anchor: false,
+  },
+  'providers.google.api_key': {
+    env: 'GEMINI_API_KEY', backend: 'ssm', shared: true, auth_anchor: false,
+  },
   // providers.groq.api_key se removió en #3353 — Groq descontinuado.
-  'providers.cerebras.api_key':    'CEREBRAS_API_KEY',
-  'providers.nvidia.api_key':      'NVIDIA_NIM_API_KEY',
+  'providers.cerebras.api_key': {
+    env: 'CEREBRAS_API_KEY', backend: 'ssm', shared: true, auth_anchor: false,
+  },
+  'providers.nvidia.api_key': {
+    env: 'NVIDIA_NIM_API_KEY', backend: 'ssm', shared: true, auth_anchor: false,
+  },
   // #4880 — Kimi (Moonshot). Drop-in de Claude Code contra el endpoint
   // Anthropic-compat: autentica con su token en `ANTHROPIC_AUTH_TOKEN` (var
   // distinta de `ANTHROPIC_API_KEY`, la OAuth/Max real). Fuente única en
   // credentials.json; jamás por Telegram (SEC-5). El valor nunca se loguea (el
   // loader sólo lista nombres de var).
-  'providers.moonshot.api_key':    'ANTHROPIC_AUTH_TOKEN',
+  'providers.moonshot.api_key': {
+    env: 'ANTHROPIC_AUTH_TOKEN', backend: 'ssm', shared: true, auth_anchor: false,
+  },
   // #5172 — Google Drive (persistencia de evidencia de QA).
   //
   // Hasta ahora estas credenciales vivían SÓLO en el archivo versionado
@@ -63,11 +138,40 @@ const ENV_MAPPING = Object.freeze({
   // "Google Drive no configurado" hasta que el operador las recargaba a mano.
   // Migradas al store externo (que sobrevive al reset) para cerrar ese ciclo.
   // El refresh_token es un secreto: el loader sólo lista NOMBRES de var.
-  'google_drive.oauth_client_id':     'GOOGLE_OAUTH_CLIENT_ID',
-  'google_drive.oauth_client_secret': 'GOOGLE_OAUTH_CLIENT_SECRET',
-  'google_drive.oauth_refresh_token': 'GOOGLE_OAUTH_REFRESH_TOKEN',
-  'google_drive.drive_folder_id':     'GOOGLE_DRIVE_FOLDER_ID',
+  'google_drive.oauth_client_id': {
+    env: 'GOOGLE_OAUTH_CLIENT_ID', backend: 'ssm', shared: true, auth_anchor: false,
+  },
+  'google_drive.oauth_client_secret': {
+    env: 'GOOGLE_OAUTH_CLIENT_SECRET', backend: 'ssm', shared: true, auth_anchor: false,
+  },
+  // El ÚNICO ocupante de Secrets Manager hoy: lo emite un tercero con su propio
+  // ciclo de refresh (Google lo renueva y puede invalidarlo sin que nadie lo
+  // escriba desde el rol de provisión) — regla (a) de la tabla de #5351.
+  'google_drive.oauth_refresh_token': {
+    env: 'GOOGLE_OAUTH_REFRESH_TOKEN', backend: 'secretsmanager', shared: true, auth_anchor: false,
+  },
+  'google_drive.drive_folder_id': {
+    env: 'GOOGLE_DRIVE_FOLDER_ID', backend: 'ssm', shared: true, auth_anchor: false,
+  },
 });
+
+// Retrocompat OBLIGATORIA (G1): el mapa plano `dotPath -> envVar` se DERIVA del
+// descriptor, nunca se duplica a mano. Sigue siendo un objeto plano CONGELADO
+// —no un `Proxy`, no un getter lazy— porque sus consumidores lo recorren con
+// `Object.entries()` / `Object.values()` / `Object.keys()` directo:
+//
+//   .pipeline/lib/wizards/providers/index.js:73  ← PRODUCCIÓN. `listProviders()`
+//        filtra `providers.*.api_key` sobre este mapa. Si desapareciera,
+//        devolvería `[]` SIN lanzar excepción y el wizard de providers del
+//        dashboard quedaría vacío: falla silenciosa, por eso tiene test propio.
+//   .pipeline/lib/__tests__/credentials.test.js, credentials-google-drive.test.js,
+//   kimi-provider-4880.test.js, .pipeline/tests/dashboard/wizard-providers-flow.test.js
+//
+// (Ojo: `hydrate-provider-env.js:35` declara OTRO `ENV_MAPPING` local y
+// homónimo, sin relación con éste. Un `grep` lo trae; no es parte de esto.)
+const ENV_MAPPING = Object.freeze(Object.fromEntries(
+  Object.entries(ENV_DESCRIPTORS).map(([dotPath, d]) => [dotPath, d.env]),
+));
 
 // Mapeo legacy: telegram-config.json usa flat keys (no nested). Solo cubre las
 // que existían en ese formato — providers nuevos (google/cerebras/nvidia) no
@@ -103,15 +207,280 @@ function readJsonFile(filePath) {
   return JSON.parse(raw);
 }
 
+// =============================================================================
+// Integración con el vault (#5353) — fuente primaria, sync, memoizada
+// =============================================================================
+
+// UX-2 — el origen se reporta POR VARIABLE. Un único `source` global no permite
+// diagnosticar la ventana de bootstrap: con 13 vars y 4 orígenes posibles,
+// "source: canonical" no dice cuál vino de dónde. `result.source` se conserva
+// igual (retrocompat), pero la respuesta fina vive en `result.sources`.
+const SOURCE = Object.freeze({
+  VAULT:           'vault',
+  FILE_BOOTSTRAP:  'file-bootstrap',
+  CANONICAL:       'canonical',
+  LEGACY:          'legacy',
+  ENV_PREEXISTING: 'env-preexisting',
+  EMPTY:           'empty',    // UX-3: presente en la fuente, pero vacía o placeholder
+  MISSING:         'missing',  // UX-3: no configurada en ninguna fuente
+});
+
+// D-SYNC-7 — memoización por namespace A NIVEL DE MÓDULO. No es una
+// optimización: `loadIntoEnv` NO se llama sólo en el boot. `action-token.js:77`
+// la llama por resolución de token y `cerebras-runner.js:96` /
+// `nvidia-nim-runner.js:90` POR LANZAMIENTO DE AGENTE. Sin esto, cada launch
+// pagaría el arranque de un proceso Python de la AWS CLI (~1-2 s).
+//
+// El TTL sale de `vault.cache_ttl_seconds` (tope duro de 300 s en el módulo del
+// vault, SEC-6): un caché sin vencimiento en un proceso que vive días
+// convertiría una revocación en el vault en algo que no surte efecto hasta el
+// restart — y para el ancla de autorización eso significa seguir aceptando a un
+// firmante des-autorizado.
+//
+// Sin negative caching: un fallo NO se memoiza, para que `aws login` surta
+// efecto sin reiniciar el Pulpo.
+let _vaultMemo = null;   // { clave, expiraEn, payload }
+
+/** Invalidación explícita. Exportada SÓLO para los tests. */
+function _resetVaultCache() {
+  _vaultMemo = null;
+}
+
+/** `providers.openai.api_key` → `{ scope: 'providers', subPath: 'openai.api_key' }`. */
+function splitDotPath(dotPath) {
+  const i = dotPath.indexOf('.');
+  return i < 0
+    ? { scope: dotPath, subPath: '' }
+    : { scope: dotPath.slice(0, i), subPath: dotPath.slice(i + 1) };
+}
+
 /**
- * Lee credentials.json y popula `env` con las credenciales mapeadas.
+ * Agrupa los scopes que hay que pedirle al vault, por backend. Es una función
+ * pura para que el test la ejerza sin tocar red ni config.
+ *
+ * D5 (#5352) — el vault resuelve SÓLO los scopes declarados, y `scopes` es un
+ * puñado (3), no 13: no existe un camino que hidrate variable por variable.
+ *
+ * @returns {{ssm: string[], secretsmanager: string[]}}
+ */
+function vaultScopePlan(descriptors = ENV_DESCRIPTORS) {
+  const plan = { ssm: [], secretsmanager: [] };
+  for (const [dotPath, d] of Object.entries(descriptors)) {
+    if (!VAULT_BACKENDS.includes(d.backend)) {
+      throw new Error(`[credentials] descriptor "${dotPath}": backend desconocido "${d.backend}"`);
+    }
+    // `file-only` nunca va al vault: se resuelve por el camino del archivo.
+    if (d.backend === 'file-only') continue;
+    const { scope } = splitDotPath(dotPath);
+    if (!plan[d.backend].includes(scope)) plan[d.backend].push(scope);
+  }
+  return plan;
+}
+
+/** ¿El path cae DENTRO del árbol del repo? (B1.4, coherente con #5218) */
+function estaDentroDelRepo(p) {
+  const rel = path.relative(REPO_ROOT, path.resolve(p));
+  return rel !== '' && !rel.startsWith('..') && !path.isAbsolute(rel);
+}
+
+/**
+ * Lee la sección `vault:` de config.yaml (+ `kernel.region`, que el vault
+ * REUTILIZA por diseño de #5352).
+ *
+ * Si la config no se puede leer, el gate queda CERRADO: el default commiteado
+ * es `enabled: false`, así que degradar a "vault apagado" deja el pipeline
+ * exactamente como corre hoy, y el dueño real de la corrupción de config
+ * (`pulpo.js`, vía `config-resolver`) la trata con su propia política de halt.
+ */
+function readVaultConfig(opts, logger) {
+  if (opts.vaultConfig !== undefined) return opts.vaultConfig;   // inyección de tests
+  try {
+    const cfg = require('./config-resolver').resolve({});
+    if (!cfg || !cfg.vault) return null;
+    return { ...cfg.vault, region: cfg.kernel && cfg.kernel.region };
+  } catch (e) {
+    logger('[credentials] WARN: no se pudo leer config.yaml para el vault '
+      + `(${(e && e.name) || 'error'}); el gate del vault queda CERRADO y se usa el archivo`);
+    return null;
+  }
+}
+
+/**
+ * Evalúa la ventana de bootstrap de B1 sobre el archivo de credenciales.
+ *
+ * Es la ÚNICA puerta al archivo cuando el gate del vault está abierto, y está
+ * cerrada por default. Todas las condiciones tienen que darse a la vez.
+ */
+function evaluarVentanaBootstrap(cfg, { canonicalPath, legacyPath, ahora, logger }) {
+  // B1.3 — flag deliberado. Fail-closed: sólo el booleano `true` exacto.
+  if (!cfg || cfg.bootstrap_fallback !== true) {
+    return { activo: false, motivo: 'flag-apagado' };
+  }
+
+  // B1.5 — `until` OBLIGATORIO. Sin fecha, "bootstrap temporal" se vuelve
+  // permanente por olvido, que es justo lo que la ventana existe para evitar.
+  const hasta = typeof cfg.bootstrap_fallback_until === 'string'
+    ? cfg.bootstrap_fallback_until.trim() : '';
+  if (!hasta) {
+    logger('[credentials] ERROR: `vault.bootstrap_fallback: true` sin '
+      + '`vault.bootstrap_fallback_until`. Impacto: la ventana de bootstrap NO se '
+      + 'aplica y las variables que falten en el vault quedan sin setear. '
+      + 'Proximo paso: poner una fecha ISO-8601 de caducidad o apagar el flag');
+    return { activo: false, motivo: 'until-ausente' };
+  }
+  const vence = Date.parse(hasta);
+  if (!Number.isFinite(vence)) {
+    logger(`[credentials] ERROR: \`vault.bootstrap_fallback_until\` no es una fecha ISO-8601 valida ("${hasta}"). `
+      + 'Impacto: la ventana de bootstrap NO se aplica. Proximo paso: corregir la fecha en config.yaml');
+    return { activo: false, motivo: 'until-invalido' };
+  }
+  if (ahora > vence) {
+    // B1.5 — caduca sola, aunque el flag siga en `true`.
+    logger(`[credentials] WARN: la ventana de bootstrap del vault CADUCO el ${hasta}. `
+      + 'Impacto: el fallback al archivo ya no se aplica y lo que falte en el vault queda sin setear. '
+      + 'Proximo paso: subir los secretos faltantes al vault y apagar `vault.bootstrap_fallback`');
+    return { activo: false, motivo: 'caducada' };
+  }
+
+  // B1.4 — el archivo del fallback tiene que estar FUERA del árbol del repo,
+  // aunque el flag esté encendido. No relajamos #5218 por la ventana.
+  for (const p of [canonicalPath, legacyPath]) {
+    if (estaDentroDelRepo(p)) {
+      logger(`[credentials] ERROR: el archivo de credenciales resuelve DENTRO del arbol del repo (${p}). `
+        + 'Impacto: la ventana de bootstrap se RECHAZA aunque el flag este encendido (#5218). '
+        + 'Proximo paso: mover el store fuera del repo (~/.claude/secrets/)');
+      return { activo: false, motivo: 'archivo-en-repo' };
+    }
+  }
+
+  // UX-4 — avisa MIENTRAS está activa, y avisa ANTES de caducar (no después de
+  // que el arranque falle).
+  const diasRestantes = Math.floor((vence - ahora) / 86400000);
+  logger(`[credentials] WARN: ventana de bootstrap del vault ACTIVA hasta ${hasta} `
+    + `(quedan ${diasRestantes} dia/s). Impacto: las variables ausentes del vault se leen del archivo `
+    + 'y se reportan con source `file-bootstrap`, nunca `vault`. '
+    + 'Proximo paso: subir esos secretos al vault antes de la fecha');
+  if (diasRestantes <= 3) {
+    logger('[credentials] WARN: la ventana de bootstrap del vault esta POR CADUCAR. '
+      + 'Impacto: al vencer, toda variable que siga faltando en el vault quedara sin setear '
+      + 'y el componente que la necesite fallara. Proximo paso: completar la migracion al vault YA');
+  }
+  return { activo: true, vence, hasta };
+}
+
+/**
+ * Resuelve el namespace del vault por el camino SYNC, memoizado por namespace.
+ *
+ * @returns {{enabled:boolean, namespace:string|null, payload:object|null, error:object|null}}
+ */
+function resolverVault(opts, logger) {
+  const cfg = readVaultConfig(opts, logger);
+
+  // D-SYNC-8 — con el gate cerrado no se construye el vault, no se carga
+  // `secret-vault.js` y no se toca el driver ni una vez. El comportamiento
+  // productivo queda IDÉNTICO al de antes de #5353.
+  if (!cfg || cfg.enabled !== true) {
+    return { enabled: false, namespace: null, payload: null, error: null, cfg };
+  }
+
+  const ahora = typeof opts.now === 'function' ? opts.now() : Date.now();
+  const clave = `${cfg.prefix}/${cfg.projectId}#${cfg.hostId}`;
+  if (_vaultMemo && _vaultMemo.clave === clave && _vaultMemo.expiraEn > ahora) {
+    return { enabled: true, namespace: clave, payload: _vaultMemo.payload, error: null, cfg };
+  }
+
+  const sv = require('./secret-vault');
+  try {
+    const driver = opts.vaultDriver || (() => {
+      // SEC-2 — el ambiente de origen del runner es EXPLÍCITO y es el del
+      // proceso padre. `opts.env` es el ambiente DESTINO (los scripts de QA
+      // pasan un scratch descartable); la identidad AWS no sale de ahí.
+      const runner = sv.createAwsCliVaultRunner(process.env, cfg.region);
+      return sv.createAwsCliVaultDriver({ run: runner.run });
+    })();
+
+    // B3-A.1/B3-A.3 — el namespace se construye desde config y `validateVaultConfig`
+    // rechaza un `hostId` vacío o inválido NOMBRANDO `vault.hostId`.
+    const vault = sv.createSecretVault({
+      config: cfg,
+      driver,
+      // CA-23 — al logger del vault sólo llegan NOMBRES de scope.
+      logger: {
+        info: (msg, meta) => logger(`[credentials] ${msg} ${JSON.stringify(meta || {})}`),
+        warn: (msg, meta) => logger(`[credentials] WARN: ${msg} ${JSON.stringify(meta || {})}`),
+      },
+    });
+
+    const plan = vaultScopePlan(ENV_DESCRIPTORS);
+    const payload = { ssm: {}, secretsmanager: {} };
+    // D1.6 — sólo el camino SYNC. Dos llamadas batch como máximo para `ssm`
+    // (SEC-3) y una por scope para `rotating`.
+    if (plan.ssm.length) {
+      payload.ssm = vault.resolveScopeSync({ scopes: plan.ssm });
+    }
+    if (plan.secretsmanager.length) {
+      payload.secretsmanager = vault.resolveScopeSync({
+        scopes: plan.secretsmanager, tier: 'rotating',
+      });
+    }
+
+    const ttlMs = (typeof cfg.cache_ttl_seconds === 'number' ? cfg.cache_ttl_seconds : 300) * 1000;
+    _vaultMemo = { clave, expiraEn: ahora + ttlMs, payload };
+    return { enabled: true, namespace: clave, payload, error: null, cfg };
+  } catch (err) {
+    // CA-22 — un fallo del vault se PROPAGA como fallo, jamás se degrada a
+    // vacío ni habilita el fallback al archivo (B1.2). El mensaje ya viene
+    // redactado por `secret-vault.js` (SEC-1/SEC-5: nombra el path lógico y la
+    // remediación, nunca el ARN, el account id ni el stdout de la CLI).
+    //
+    // UX-5 — se narra causa + impacto + próximo paso, no un stack trace.
+    logger(`[credentials] ERROR: el vault no pudo resolverse (${(err && err.code) || (err && err.name) || 'error'}). `
+      + `Causa: ${(err && err.message) || 'desconocida'}. `
+      + 'Impacto: las credenciales respaldadas por el vault quedan SIN SETEAR (fail-closed); '
+      + 'NO se cae al archivo. Proximo paso: revisar la remediacion que nombra la causa y reintentar');
+    return {
+      enabled: true,
+      namespace: clave,
+      payload: null,
+      error: { name: (err && err.name) || 'Error', code: (err && err.code) || null, message: (err && err.message) || '' },
+      cfg,
+    };
+  }
+}
+
+/** Extrae el valor de una variable del payload ya resuelto del vault. */
+function valorDelVault(estado, dotPath, desc) {
+  if (!estado.payload) return undefined;
+  const { scope, subPath } = splitDotPath(dotPath);
+  const porBackend = estado.payload[desc.backend];
+  const scopeObj = porBackend && porBackend[scope];
+  if (!scopeObj) return undefined;
+  return subPath ? getNested(scopeObj, subPath) : scopeObj;
+}
+
+// Índice inverso del mapping legacy (`TELEGRAM_BOT_TOKEN` → `bot_token`), para
+// poder leer del archivo legacy aun cuando la iteración va por el descriptor.
+const LEGACY_KEY_BY_ENV = Object.freeze(Object.fromEntries(
+  Object.entries(LEGACY_MAPPING).map(([flat, envVar]) => [envVar, flat]),
+));
+
+/**
+ * Popula `env` con las credenciales mapeadas. **Sync** (D-SYNC-1): el retorno
+ * es el objeto de resultado, nunca una `Promise`.
+ *
+ * Fuentes, en orden: `process.env` preexistente (salvo anclas) → vault →
+ * ventana de bootstrap sobre el archivo → fail-closed.
  *
  * @param {object} [opts]
  * @param {function} [opts.logger=console.log] Logger para warnings/errors.
  * @param {string}   [opts.canonicalPath]      Path del archivo canónico (override para tests).
  * @param {string}   [opts.legacyPath]         Path del archivo legacy (override para tests).
  * @param {object}   [opts.env=process.env]    Env target (override para tests).
- * @returns {{source: 'canonical'|'legacy'|'none', hydrated: string[], skipped_existing: string[], skipped_empty: string[]}}
+ * @param {object}   [opts.vaultConfig]        Sección `vault:` inyectada (tests).
+ * @param {object}   [opts.vaultDriver]        Driver del vault inyectado (tests).
+ * @param {function} [opts.now]                Reloj inyectable en ms (tests de la ventana B1.5).
+ * @returns {{source: string, hydrated: string[], skipped_existing: string[],
+ *           skipped_empty: string[], missing: string[], sources: object, vault: object}}
  */
 function loadIntoEnv(opts = {}) {
   const logger = typeof opts.logger === 'function' ? opts.logger : console.log;
@@ -119,7 +488,22 @@ function loadIntoEnv(opts = {}) {
   const legacyPath = opts.legacyPath || LEGACY_PATH;
   const env = opts.env || process.env;
 
-  const result = { source: 'none', hydrated: [], skipped_existing: [], skipped_empty: [] };
+  const result = {
+    source: 'none',
+    hydrated: [], skipped_existing: [], skipped_empty: [],
+    // Campos NUEVOS (#5353). `hydrated` / `skipped_existing` / `skipped_empty`
+    // no cambian de forma: siguen siendo arrays de NOMBRES de env var.
+    missing: [],   // B1.1 — fail-closed: quedaron SIN SETEAR
+    sources: {},   // UX-2 — origen por variable
+    vault: { enabled: false, namespace: null, error: null },
+  };
+
+  const vaultEstado = resolverVault(opts, logger);
+  result.vault = {
+    enabled: vaultEstado.enabled,
+    namespace: vaultEstado.namespace,
+    error: vaultEstado.error,
+  };
 
   let data = null;
   let usingMapping = null;
@@ -142,30 +526,157 @@ function loadIntoEnv(opts = {}) {
       logger(`[credentials] WARN: usando archivo legacy ${legacyPath}. Migrar a ${canonicalPath} (ver docs/runbooks/credential-rotation.md)`);
     } catch (e) {
       logger(`[credentials] ERROR: legacy ${legacyPath} es JSON invalido (${e.message}); process.env queda como esta`);
-      return result;
+      if (!vaultEstado.enabled) return result;
     }
   }
 
   if (!data) {
-    logger(`[credentials] WARN: no se encontro ${canonicalPath} ni ${legacyPath}; process.env queda como esta`);
-    return result;
+    if (!vaultEstado.enabled) {
+      // Con el gate cerrado, sin archivo no hay nada que hacer: exactamente el
+      // mismo mensaje y el mismo camino de salida que antes de #5353.
+      logger(`[credentials] WARN: no se encontro ${canonicalPath} ni ${legacyPath}; process.env queda como esta`);
+      return result;
+    }
+    // Con el gate abierto la ausencia del archivo es el estado ESPERADO
+    // (Gherkin 1 / B1.8): la fuente primaria es el vault. Decir "process.env
+    // queda como esta" acá sería falso — el vault sí va a hidratar.
+    logger('[credentials] no hay archivo de credenciales local; se resuelve todo contra el vault '
+      + '(estado esperado con `vault.enabled: true`)');
   }
 
-  for (const [sourceKey, envVar] of Object.entries(usingMapping)) {
-    if (env[envVar] && String(env[envVar]).length > 0) {
+  // B1.2 — la ventana de bootstrap sólo se evalúa con el gate del vault
+  // ABIERTO, y NUNCA se evalúa si el vault falló: un error de red, de sesión o
+  // de permisos no puede habilitar la lectura del archivo (sería fail-open
+  // disfrazado, activable por cualquiera que degrade la red).
+  const bootstrap = (vaultEstado.enabled && !vaultEstado.error)
+    ? evaluarVentanaBootstrap(vaultEstado.cfg, {
+        canonicalPath, legacyPath, logger,
+        ahora: typeof opts.now === 'function' ? opts.now() : Date.now(),
+      })
+    : { activo: false, motivo: vaultEstado.error ? 'vault-fallido' : 'gate-cerrado' };
+
+  /** Valor de la variable en el archivo, con el mapping que corresponda. */
+  const leerDelArchivo = (dotPath, envVar) => {
+    if (!data) return undefined;
+    if (usingMapping === LEGACY_MAPPING) {
+      const flat = LEGACY_KEY_BY_ENV[envVar];
+      return flat === undefined ? undefined : data[flat];
+    }
+    return dotPath ? getNested(data, dotPath) : undefined;
+  };
+
+  // Con el gate cerrado y archivo legacy se itera el mapping legacy, igual que
+  // antes de #5353. En cualquier otro caso manda el descriptor.
+  const entradas = (!vaultEstado.enabled && usingMapping === LEGACY_MAPPING)
+    ? Object.values(LEGACY_MAPPING).map((envVar) => ({ dotPath: null, envVar }))
+    : Object.entries(ENV_MAPPING).map(([dotPath, envVar]) => ({ dotPath, envVar }));
+
+  let huboVault = false;
+  let huboBootstrap = false;
+
+  for (const { dotPath, envVar } of entradas) {
+    const desc = dotPath ? ENV_DESCRIPTORS[dotPath] : null;
+    // B2.1 — el ancla sólo cambia de régimen con el gate ABIERTO.
+    const esAncla = vaultEstado.enabled && !!(desc && desc.auth_anchor);
+    const preexistente = !!(env[envVar] && String(env[envVar]).length > 0);
+
+    // B2.6 — para las 12 no-ancla la precedencia NO cambia: `process.env`
+    // preseteado sigue ganando. Esta hija no es el lugar para reordenar la
+    // precedencia de las API keys.
+    if (preexistente && !esAncla) {
       result.skipped_existing.push(envVar);
+      result.sources[envVar] = SOURCE.ENV_PREEXISTING;
       continue;
     }
-    const raw = (usingMapping === ENV_MAPPING)
-      ? getNested(data, sourceKey)
-      : data[sourceKey];
+
+    // ---- Fuente primaria: el vault ----
+    if (vaultEstado.enabled && desc && desc.backend !== 'file-only') {
+      const valor = valorDelVault(vaultEstado, dotPath, desc);
+      if (!isPlaceholderOrEmpty(valor)) {
+        // B2.3 — el shadowing se ve en el log. SÓLO el nombre de la variable:
+        // prohibido el valor, un prefijo, un sufijo o un hash. Es un chat_id, y
+        // un hash sobre un espacio de valores chico se revierte por fuerza bruta.
+        if (esAncla && preexistente && String(env[envVar]) !== String(valor)) {
+          logger(`[credentials] WARN: ${envVar} venia preseteada en el ambiente con un valor DISTINTO `
+            + 'al del vault y fue SOBRESCRITA. Causa: es un ancla de autorizacion y se resuelve solo '
+            + 'desde el vault (B2.2). Impacto: la allowlist de firmantes del gate del operador '
+            + 'queda definida por el vault. Proximo paso: quitar esa variable del ambiente del host');
+        }
+        env[envVar] = String(valor);
+        result.hydrated.push(envVar);
+        result.sources[envVar] = SOURCE.VAULT;
+        huboVault = true;
+        continue;
+      }
+
+      // SEC-5 — el mensaje nombra el PATH LÓGICO del secreto
+      // (`providers/openai/api_key`), nunca el ARN, el account id ni el valor.
+      const faltante = dotPath.replace(/\./g, '/');
+
+      // B1.7 / B2.4 — las anclas NO tienen fallback: ni a archivo (ni con el
+      // flag encendido ni dentro de la ventana), ni a `process.env`, ni default.
+      if (esAncla) {
+        if (preexistente) {
+          // Sin esto, cerrar el shadowing no cerraría nada: el valor del
+          // ambiente seguiría sosteniendo la allowlist de firmantes.
+          delete env[envVar];
+          logger(`[credentials] WARN: ${envVar} estaba preseteada en el ambiente y se DESCARTO. `
+            + 'Causa: el vault no tiene el ancla de autorizacion, y un ancla no puede venir del ambiente (B2.4). '
+            + 'Impacto: el gate del operador queda con cero firmantes (fail-closed). '
+            + `Proximo paso: subir "${faltante}" al vault`);
+        }
+        result.missing.push(envVar);
+        result.sources[envVar] = SOURCE.MISSING;
+        logger(`[credentials] ERROR: falta el ancla de autorizacion "${faltante}" en el vault. `
+          + `Impacto: ${envVar} queda SIN SETEAR y el gate del operador no autoriza a nadie. `
+          + `Proximo paso: subir "${faltante}" al vault (ver docs/pipeline/vault-secretos-aws.md)`);
+        continue;
+      }
+
+      // B1.3 / B1.5 — la ventana de bootstrap es la única puerta al archivo, y
+      // sólo si el operador la encendió a mano y no caducó.
+      if (bootstrap.activo) {
+        const raw = leerDelArchivo(dotPath, envVar);
+        if (!isPlaceholderOrEmpty(raw)) {
+          env[envVar] = String(raw);
+          result.hydrated.push(envVar);
+          // B1.6 — el source del fallback es `file-bootstrap`. NUNCA `vault`.
+          result.sources[envVar] = SOURCE.FILE_BOOTSTRAP;
+          huboBootstrap = true;
+          logger(`[credentials] WARN: ${envVar} se resolvio por la ventana de bootstrap, no por el vault. `
+            + `Proximo paso: subir "${faltante}" al vault antes de que la ventana caduque`);
+          continue;
+        }
+      }
+
+      // B1.1 — fail-closed NOMBRANDO el secreto faltante. La variable queda SIN
+      // SETEAR: nunca cadena vacía, nunca un default.
+      result.missing.push(envVar);
+      result.sources[envVar] = SOURCE.MISSING;
+      logger(`[credentials] ERROR: falta el secreto "${faltante}" en el vault. `
+        + `Impacto: ${envVar} queda SIN SETEAR (fail-closed) y el componente que la use fallara. `
+        + `Proximo paso: subir "${faltante}" al vault (ver docs/pipeline/vault-secretos-aws.md)`);
+      continue;
+    }
+
+    // ---- Camino del archivo (gate cerrado, o backend `file-only`) ----
+    const raw = leerDelArchivo(dotPath, envVar);
     if (isPlaceholderOrEmpty(raw)) {
       result.skipped_empty.push(envVar);
+      // UX-3 — "no configurada" y "vacia a proposito" dejan de ser lo mismo.
+      result.sources[envVar] = (raw === undefined || raw === null) ? SOURCE.MISSING : SOURCE.EMPTY;
       continue;
     }
     env[envVar] = String(raw);
     result.hydrated.push(envVar);
+    result.sources[envVar] = (usingMapping === LEGACY_MAPPING) ? SOURCE.LEGACY : SOURCE.CANONICAL;
   }
+
+  // `result.source` conserva su forma de siempre y gana el valor `'vault'`
+  // cuando alguna variable salió efectivamente del vault. La respuesta fina, por
+  // variable, está en `result.sources` (UX-2).
+  if (huboVault) result.source = SOURCE.VAULT;
+  else if (huboBootstrap) result.source = SOURCE.FILE_BOOTSTRAP;
 
   return result;
 }
@@ -259,6 +770,7 @@ function redactScoped(resolved) {
 }
 
 module.exports = {
+  // Los 10 símbolos históricos — ninguno se quita ni cambia de forma.
   loadIntoEnv,
   CANONICAL_PATH,
   LEGACY_PATH,
@@ -269,17 +781,31 @@ module.exports = {
   parseSecretRef,
   resolveScopedRefs,
   redactScoped,
+  // Agregados por #5353.
+  ENV_DESCRIPTORS,
+  VAULT_BACKENDS,
+  SOURCE,
+  vaultScopePlan,
+  _resetVaultCache,
 };
 
 // CLI: dry-run que imprime resumen sin valores. Útil para diagnóstico operativo.
 //   node .pipeline/lib/credentials.js
+//
+// UX-3 — `sources` distingue "no configurada" (`missing`) de "vacia a
+// proposito" (`empty`), que antes caían las dos en `skipped_empty` y eran
+// indistinguibles. Sigue sin imprimir un solo VALOR: sólo nombres de variable y
+// etiquetas de origen (SEC-5).
 if (require.main === module) {
   const result = loadIntoEnv({ logger: (m) => process.stderr.write(m + '\n') });
   process.stdout.write(JSON.stringify({
     source: result.source,
+    vault: result.vault,
     hydrated_count: result.hydrated.length,
     hydrated: result.hydrated,
     skipped_existing: result.skipped_existing,
     skipped_empty: result.skipped_empty,
+    missing: result.missing,
+    sources: result.sources,
   }, null, 2) + '\n');
 }

--- a/.pipeline/lib/credentials.js
+++ b/.pipeline/lib/credentials.js
@@ -173,6 +173,14 @@ const ENV_MAPPING = Object.freeze(Object.fromEntries(
   Object.entries(ENV_DESCRIPTORS).map(([dotPath, d]) => [dotPath, d.env]),
 ));
 
+// B2.7 — nombres de las env vars que son anclas de autorización, derivados del
+// descriptor (no se duplica el inventario). Es un Set por NOMBRE porque el
+// camino del mapping legacy itera sin `dotPath`, y ahí no hay descriptor del que
+// leer `auth_anchor`: sin esto, el fail-closed del ancla tendría un agujero.
+const ANCHOR_ENV_VARS = Object.freeze(new Set(
+  Object.values(ENV_DESCRIPTORS).filter((d) => d.auth_anchor).map((d) => d.env),
+));
+
 // Mapeo legacy: telegram-config.json usa flat keys (no nested). Solo cubre las
 // que existían en ese formato — providers nuevos (google/cerebras/nvidia) no
 // se cargan del legacy porque no existían cuando ese archivo era canónico.
@@ -287,21 +295,57 @@ function estaDentroDelRepo(p) {
  * Lee la sección `vault:` de config.yaml (+ `kernel.region`, que el vault
  * REUTILIZA por diseño de #5352).
  *
- * Si la config no se puede leer, el gate queda CERRADO: el default commiteado
- * es `enabled: false`, así que degradar a "vault apagado" deja el pipeline
- * exactamente como corre hoy, y el dueño real de la corrupción de config
- * (`pulpo.js`, vía `config-resolver`) la trata con su propia política de halt.
+ * B2.7 (rev-1) — DOS decisiones de seguridad viven acá:
+ *
+ * 1. La RAÍZ de la config se fija en código (`REPO_ROOT`), igual que hace el
+ *    Pulpo (`pulpo.js`, `resolve({pipelineDir: PIPELINE})`). `resolve({})` deja
+ *    que el ENTORNO elija qué `config.yaml` es la autoridad
+ *    (`PIPELINE_DIR_OVERRIDE` / `PIPELINE_STATE_DIR` / `PIPELINE_REPO_ROOT`), y
+ *    esa es exactamente la capacidad que B2 asume en el adversario: quien puede
+ *    escribir `TELEGRAM_LEO_OPERATOR_CHAT_ID` puede escribir `PIPELINE_REPO_ROOT`,
+ *    desviar la lectura a una carpeta suya y apagar el gate del vault desde
+ *    afuera — con el gate apagado el ancla vuelve al régimen de `process.env` y
+ *    el atacante queda como firmante del gate del operador. Fijar la raíz cierra
+ *    el vector entero. `opts.pipelineDir` sigue disponible porque es un
+ *    ARGUMENTO (código), no entorno — la misma distinción que documenta
+ *    `config-resolver.js` para su propio orden de precedencia.
+ *
+ * 2. "No pude leer la config" NO es "vault apagado". Son estados distintos con
+ *    políticas opuestas: `enabled: false` es una decisión deliberada y commiteada;
+ *    un error de lectura es una condición NO gobernada. Colapsarlos es fail-open
+ *    disfrazado — el mismo razonamiento que el código ya aplica a B1.2 para el
+ *    error de red del driver. Por eso el retorno es un TRI-estado y el
+ *    indeterminado se propaga hasta la precedencia del ancla.
+ *
+ * @returns {{cfg: object|null, indeterminado: boolean, causa: string|null}}
  */
 function readVaultConfig(opts, logger) {
-  if (opts.vaultConfig !== undefined) return opts.vaultConfig;   // inyección de tests
+  // Inyección de tests: una config provista por firma es una decisión conocida,
+  // nunca un indeterminado.
+  if (opts.vaultConfig !== undefined) {
+    return { cfg: opts.vaultConfig, indeterminado: false, causa: null };
+  }
+  const pipelineDir = opts.pipelineDir
+    ? path.resolve(opts.pipelineDir)
+    : path.join(REPO_ROOT, '.pipeline');
   try {
-    const cfg = require('./config-resolver').resolve({});
-    if (!cfg || !cfg.vault) return null;
-    return { ...cfg.vault, region: cfg.kernel && cfg.kernel.region };
+    const cfg = require('./config-resolver').resolve({ pipelineDir });
+    // Config LEÍDA y sin sección `vault:` es una decisión conocida (el vault no
+    // está configurado), no un indeterminado: gate cerrado y nada más.
+    if (!cfg || !cfg.vault) return { cfg: null, indeterminado: false, causa: null };
+    return {
+      cfg: { ...cfg.vault, region: cfg.kernel && cfg.kernel.region },
+      indeterminado: false,
+      causa: null,
+    };
   } catch (e) {
-    logger('[credentials] WARN: no se pudo leer config.yaml para el vault '
-      + `(${(e && e.name) || 'error'}); el gate del vault queda CERRADO y se usa el archivo`);
-    return null;
+    const causa = (e && e.name) || 'error';
+    logger(`[credentials] WARN: no se pudo leer config.yaml para el vault (${causa}). `
+      + 'Impacto: el gate del vault queda CERRADO para los 12 secretos (se usa el archivo), '
+      + 'pero las anclas de autorizacion fallan CERRADAS: no se puede probar que el vault este '
+      + 'apagado a proposito, y un error de lectura no puede devolverle el ancla al ambiente (B2.7). '
+      + `Proximo paso: reparar ${path.join(pipelineDir, 'config.yaml')}`);
+    return { cfg: null, indeterminado: true, causa };
   }
 }
 
@@ -371,16 +415,29 @@ function evaluarVentanaBootstrap(cfg, { canonicalPath, legacyPath, ahora, logger
 /**
  * Resuelve el namespace del vault por el camino SYNC, memoizado por namespace.
  *
- * @returns {{enabled:boolean, namespace:string|null, payload:object|null, error:object|null}}
+ * @returns {{enabled:boolean, indeterminado:boolean, namespace:string|null,
+ *            payload:object|null, error:object|null}}
  */
 function resolverVault(opts, logger) {
-  const cfg = readVaultConfig(opts, logger);
+  const { cfg, indeterminado, causa } = readVaultConfig(opts, logger);
 
   // D-SYNC-8 — con el gate cerrado no se construye el vault, no se carga
   // `secret-vault.js` y no se toca el driver ni una vez. El comportamiento
   // productivo queda IDÉNTICO al de antes de #5353.
+  //
+  // B2.7 — `indeterminado` viaja aparte de `enabled`. Para los 12 no-ancla el
+  // camino es el mismo que con el gate cerrado (por eso `enabled: false`); lo
+  // que cambia es SÓLO la precedencia del ancla, que falla cerrada.
   if (!cfg || cfg.enabled !== true) {
-    return { enabled: false, namespace: null, payload: null, error: null, cfg };
+    return {
+      enabled: false,
+      indeterminado: !!indeterminado,
+      causaIndeterminado: causa || null,
+      namespace: null,
+      payload: null,
+      error: null,
+      cfg,
+    };
   }
 
   const ahora = typeof opts.now === 'function' ? opts.now() : Date.now();
@@ -477,6 +534,9 @@ const LEGACY_KEY_BY_ENV = Object.freeze(Object.fromEntries(
  * @param {string}   [opts.legacyPath]         Path del archivo legacy (override para tests).
  * @param {object}   [opts.env=process.env]    Env target (override para tests).
  * @param {object}   [opts.vaultConfig]        Sección `vault:` inyectada (tests).
+ * @param {string}   [opts.pipelineDir]        Raíz de `.pipeline` para resolver config.yaml.
+ *                                             Por default se fija en código (`REPO_ROOT`):
+ *                                             el ENTORNO no elige la autoridad (B2.7).
  * @param {object}   [opts.vaultDriver]        Driver del vault inyectado (tests).
  * @param {function} [opts.now]                Reloj inyectable en ms (tests de la ventana B1.5).
  * @returns {{source: string, hydrated: string[], skipped_existing: string[],
@@ -501,9 +561,41 @@ function loadIntoEnv(opts = {}) {
   const vaultEstado = resolverVault(opts, logger);
   result.vault = {
     enabled: vaultEstado.enabled,
+    // B2.7 — visible para quien audite el arranque: `enabled:false` con
+    // `indeterminado:true` NO es "el operador apagó el vault", es "no se pudo
+    // leer la config", y las anclas se trataron como fail-closed.
+    indeterminado: !!vaultEstado.indeterminado,
     namespace: vaultEstado.namespace,
     error: vaultEstado.error,
   };
+
+  // B2.7 — fail-closed de las anclas cuando el gate quedó INDETERMINADO (no se
+  // pudo leer config.yaml). Va ACÁ, antes de cualquier salida temprana: los
+  // caminos "no hay archivo de credenciales" y "el legacy es JSON inválido"
+  // retornan sin llegar al loop de precedencia, y ahí el ancla preseteada
+  // sobreviviría intacta — que es exactamente el bypass que hay que cerrar.
+  //
+  // No se puede probar que el vault esté apagado a propósito, así que el ancla
+  // NO vuelve al régimen de `process.env`: se descarta y se cuenta como
+  // faltante, igual que cuando el gate está abierto y el vault no la tiene
+  // (B2.4). Las 12 no-ancla no se tocan: su camino sigue siendo el del gate
+  // cerrado, idéntico al de antes de #5353.
+  const anclasCerradas = new Set();
+  if (vaultEstado.indeterminado) {
+    for (const envVar of ANCHOR_ENV_VARS) {
+      if (env[envVar] && String(env[envVar]).length > 0) {
+        delete env[envVar];
+        logger(`[credentials] WARN: ${envVar} estaba preseteada en el ambiente y se DESCARTO. `
+          + 'Causa: no se pudo leer config.yaml, asi que no hay forma de probar que el vault este '
+          + 'apagado a proposito, y un ancla de autorizacion no puede venir del ambiente (B2.7). '
+          + 'Impacto: el gate del operador queda con cero firmantes (fail-closed). '
+          + 'Proximo paso: reparar config.yaml y, si el vault esta encendido, subir el ancla al vault');
+      }
+      result.missing.push(envVar);
+      result.sources[envVar] = SOURCE.MISSING;
+      anclasCerradas.add(envVar);
+    }
+  }
 
   let data = null;
   let usingMapping = null;
@@ -579,6 +671,9 @@ function loadIntoEnv(opts = {}) {
     // B2.1 — el ancla sólo cambia de régimen con el gate ABIERTO.
     const esAncla = vaultEstado.enabled && !!(desc && desc.auth_anchor);
     const preexistente = !!(env[envVar] && String(env[envVar]).length > 0);
+
+    // B2.7 — el ancla ya se cerró arriba, antes de las salidas tempranas.
+    if (anclasCerradas.has(envVar)) continue;
 
     // B2.6 — para las 12 no-ancla la precedencia NO cambia: `process.env`
     // preseteado sigue ganando. Esta hija no es el lugar para reordenar la
@@ -787,6 +882,10 @@ module.exports = {
   SOURCE,
   vaultScopePlan,
   _resetVaultCache,
+  // B2.7 — expuesto SÓLO para el test que verifica que la raíz de la config la
+  // fija el código y no el entorno. No tiene call-site productivo fuera de
+  // `resolverVault`.
+  _readVaultConfig: readVaultConfig,
 };
 
 // CLI: dry-run que imprime resumen sin valores. Útil para diagnóstico operativo.

--- a/.pipeline/lib/secret-vault.js
+++ b/.pipeline/lib/secret-vault.js
@@ -6,6 +6,13 @@
 // (SSM Parameter Store / Secrets Manager) por **scope declarado**, con allowlist
 // de verbos read-only, caché en memoria por namespace y fail-closed explícito.
 //
+// AMPLIACIÓN DE #5353 (hija 3) — superficie SYNC sobre el MISMO núcleo:
+//   `resolveNamespaceSync` / `resolveScopeSync` y el port sync de los dos
+//   drivers. No es un gemelo duplicado: la lógica se escribe una sola vez como
+//   generador y dos conductores la ejecutan (ver "un solo cuerpo, dos
+//   conductores"). La API async de #5352 no cambia — sigue declarada `async`,
+//   sigue devolviendo `Promise`, y su suite queda verde sin editarse (D1.5).
+//
 // LO QUE ESTE MÓDULO **NO** HACE (a propósito):
 //   - NO escribe en el ambiente del proceso (CA-8). Esa decisión — precedencia y
 //     semántica de degradación de `loadIntoEnv` — vive en la hija 3 (#5353) y
@@ -490,12 +497,85 @@ function assertArgsSeguros(args) {
 }
 
 // -----------------------------------------------------------------------------
+// D1.1 / D-SYNC-3 (#5353) — un solo cuerpo, dos conductores
+// -----------------------------------------------------------------------------
+//
+// `credentials.js` hidrata el ambiente en el arranque del Pulpo y de
+// `restart.js` con llamadas A NIVEL DE MÓDULO (`pulpo.js:18`, `restart.js:47`)
+// cuya razón de ser es el ORDEN (#3311): CommonJS no tiene top-level `await`,
+// así que volver async ese camino no cambiaría una firma, destruiría la
+// garantía. Este módulo tiene que ofrecer, entonces, una superficie SYNC.
+//
+// La salida NO es un gemelo duplicado. Duplicar la caché, la allowlist, la
+// paginación y el fail-closed reintroduce exactamente la "cobertura ilusoria"
+// que G-2 documenta: los tests corren contra un camino y producción usa el
+// otro. La lógica se escribe UNA sola vez como generador — cada `yield` es un
+// PEDIDO al transporte, y el núcleo no sabe ni le importa si lo van a resolver
+// de forma sync o async. Los dos conductores de abajo son lo único que se
+// escribe dos veces.
+//
+// Habilitante: el transporte real YA ES SYNC (`execFileSync`, ver
+// `createAwsCliVaultRunner`), o sea que la asincronía de la API pública es
+// cosmética — ninguno de los `await` de este módulo espera I/O real.
+
+/**
+ * Conduce el núcleo resolviendo cada pedido de forma SÍNCRONA.
+ *
+ * @param {Generator} generador núcleo que `yield`ea pedidos al transporte
+ * @param {function} ejecutar   traductor `pedido -> valor` (sin promesas)
+ */
+function conducirSync(generador, ejecutar) {
+    let paso = generador.next();
+    while (!paso.done) {
+        let valor;
+        try {
+            valor = ejecutar(paso.value);
+        } catch (err) {
+            paso = generador.throw(err);
+            continue;
+        }
+        if (valor && typeof valor.then === 'function') {
+            // D-SYNC-6 — una Promise en el camino sync se rechaza de frente.
+            // PROHIBIDO esperarla con `Atomics.wait`, `worker_threads`, un Node
+            // hijo o `deasync`: todos convierten un problema de contrato en un
+            // bloqueo del event loop del Pulpo.
+            throw new VaultConfigError('vault.driver',
+                `\`${paso.value.op}\` devolvió una Promise en el camino sync. `
+                + 'Remediación: el camino sync exige un transporte sync '
+                + '(ver createAwsCliVaultRunner)');
+        }
+        paso = generador.next(valor);
+    }
+    return paso.value;
+}
+
+/** Conduce EL MISMO núcleo resolviendo cada pedido con `await`. */
+async function conducirAsync(generador, ejecutar) {
+    let paso = generador.next();
+    while (!paso.done) {
+        let valor;
+        try {
+            valor = await ejecutar(paso.value);
+        } catch (err) {
+            paso = generador.throw(err);
+            continue;
+        }
+        paso = generador.next(valor);
+    }
+    return paso.value;
+}
+
+// -----------------------------------------------------------------------------
 // Drivers (port/adapter) — AMBOS devuelven la MISMA forma (G-2)
 // -----------------------------------------------------------------------------
 //
 // Port:
 //   getParametersByPath(root) -> Promise<{ parameters: Array<{name, value}> }>
 //   getSecretValue(name)      -> Promise<{ name, value } | null>
+//
+// Port sync (D1.3), mismo contrato sin la envoltura de Promise:
+//   getParametersByPathSync(root) -> { parameters: Array<{name, value}> }
+//   getSecretValueSync(name)      -> { name, value } | null
 //
 // `value` es SIEMPRE un string con JSON serializado. El parseo vive arriba, en
 // `resolveScope`, para que los dos drivers no puedan divergir de tipo.
@@ -523,25 +603,38 @@ function createInMemoryVaultDriver({ parameters = {}, secrets = {} } = {}) {
 
     const calls = [];
 
+    // D1.3 — el cuerpo es UNO solo y ya era sync; las variantes async quedan
+    // como envoltorios finos. Así el fake no puede divergir entre caminos.
+    function leerParametros(root) {
+        calls.push({ op: 'getParametersByPath', root });
+        const out = [];
+        for (const [name, value] of store) {
+            if (name.startsWith(root)) out.push({ name, value });
+        }
+        // Orden estable: la resolución no puede depender del orden de inserción.
+        out.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+        return { parameters: out };
+    }
+
+    function leerSecreto(name) {
+        calls.push({ op: 'getSecretValue', name });
+        if (!secretStore.has(name)) return null;
+        return { name, value: secretStore.get(name) };
+    }
+
     return {
         kind: 'in-memory',
         calls,
 
+        getParametersByPathSync: leerParametros,
+        getSecretValueSync: leerSecreto,
+
         async getParametersByPath(root) {
-            calls.push({ op: 'getParametersByPath', root });
-            const out = [];
-            for (const [name, value] of store) {
-                if (name.startsWith(root)) out.push({ name, value });
-            }
-            // Orden estable: la resolución no puede depender del orden de inserción.
-            out.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
-            return { parameters: out };
+            return leerParametros(root);
         },
 
         async getSecretValue(name) {
-            calls.push({ op: 'getSecretValue', name });
-            if (!secretStore.has(name)) return null;
-            return { name, value: secretStore.get(name) };
+            return leerSecreto(name);
         },
     };
 }
@@ -571,56 +664,81 @@ function createAwsCliVaultDriver({ run } = {}) {
         }
     }
 
+    // D1.1 — la paginación se escribe UNA vez. El `yield` es el pedido al
+    // runner; quién lo espera (o no) lo decide el conductor.
+    function* nucleoGetParametersByPath(root, opts) {
+        const scopes = opts.scopes || [];
+        const parameters = [];
+        let token = null;
+        let pagina = 0;
+        do {
+            // SEC-4: ningún flag de paginación acotada — la allowlist de
+            // flags no los admite. La paginación se sigue a mano hasta
+            // agotar `NextToken`, así que nunca se devuelve media respuesta.
+            const args = ['get-parameters-by-path', '--path', root, '--recursive', '--with-decryption'];
+            if (token) args.push('--starting-token', token);
+            const json = parsear(yield { op: 'run', service: 'ssm', args }, { root, scopes });
+            for (const p of Array.isArray(json.Parameters) ? json.Parameters : []) {
+                parameters.push({ name: p.Name, value: p.Value });
+            }
+            token = json.NextToken || null;
+            pagina += 1;
+            if (token && pagina >= MAX_PAGES) {
+                // Nunca devolver un resultado parcial en silencio: un scope
+                // que quedó en la página 51 se vería como «secreto ausente».
+                throw new VaultTruncatedResponseError({
+                    root, reason: `NextToken sin consumir tras ${pagina} páginas`, scopes,
+                });
+            }
+        } while (token);
+        return { parameters };
+    }
+
+    function* nucleoGetSecretValue(name, opts) {
+        const scopes = opts.scopes || [];
+        let raw;
+        try {
+            // D9 — `--version-stage AWSCURRENT` explícito y SIN `--version-id`:
+            // fijar una versión concreta congela el secreto y la rotación deja
+            // de tener efecto sin que nada falle.
+            raw = yield {
+                op: 'run',
+                service: 'secretsmanager',
+                args: ['get-secret-value', '--secret-id', name, '--version-stage', 'AWSCURRENT'],
+            };
+        } catch (err) {
+            if (err && err.name === 'VaultCliError' && /ResourceNotFound/i.test(err.message)) {
+                return null;
+            }
+            throw err;
+        }
+        const json = parsear(raw, { root: name, scopes });
+        if (json.SecretString == null) return null;
+        return { name, value: String(json.SecretString) };
+    }
+
+    // El traductor es el mismo para los dos caminos: `run` ya es sync en
+    // producción, y el conductor async sigue aceptando un runner que devuelva
+    // Promise (retrocompat del port original).
+    const ejecutar = (pedido) => run(pedido.service, pedido.args);
+
     return {
         kind: 'aws-cli',
 
+        getParametersByPathSync(root, opts = {}) {
+            return conducirSync(nucleoGetParametersByPath(root, opts), ejecutar);
+        },
+
+        getSecretValueSync(name, opts = {}) {
+            return conducirSync(nucleoGetSecretValue(name, opts), ejecutar);
+        },
+
         async getParametersByPath(root, opts = {}) {
-            const scopes = opts.scopes || [];
-            const parameters = [];
-            let token = null;
-            let pagina = 0;
-            do {
-                // SEC-4: ningún flag de paginación acotada — la allowlist de
-                // flags no los admite. La paginación se sigue a mano hasta
-                // agotar `NextToken`, así que nunca se devuelve media respuesta.
-                const args = ['get-parameters-by-path', '--path', root, '--recursive', '--with-decryption'];
-                if (token) args.push('--starting-token', token);
-                const json = parsear(await run('ssm', args), { root, scopes });
-                for (const p of Array.isArray(json.Parameters) ? json.Parameters : []) {
-                    parameters.push({ name: p.Name, value: p.Value });
-                }
-                token = json.NextToken || null;
-                pagina += 1;
-                if (token && pagina >= MAX_PAGES) {
-                    // Nunca devolver un resultado parcial en silencio: un scope
-                    // que quedó en la página 51 se vería como «secreto ausente».
-                    throw new VaultTruncatedResponseError({
-                        root, reason: `NextToken sin consumir tras ${pagina} páginas`, scopes,
-                    });
-                }
-            } while (token);
-            return { parameters };
+            return conducirAsync(nucleoGetParametersByPath(root, opts), ejecutar);
         },
 
         async getSecretValue(name, opts = {}) {
-            const scopes = opts.scopes || [];
-            let raw;
-            try {
-                // D9 — `--version-stage AWSCURRENT` explícito y SIN `--version-id`:
-                // fijar una versión concreta congela el secreto y la rotación deja
-                // de tener efecto sin que nada falle.
-                raw = await run('secretsmanager', [
-                    'get-secret-value', '--secret-id', name, '--version-stage', 'AWSCURRENT',
-                ]);
-            } catch (err) {
-                if (err && err.name === 'VaultCliError' && /ResourceNotFound/i.test(err.message)) {
-                    return null;
-                }
-                throw err;
-            }
-            const json = parsear(raw, { root: name, scopes });
-            if (json.SecretString == null) return null;
-            return { name, value: String(json.SecretString) };
+            return conducirAsync(nucleoGetSecretValue(name, opts), ejecutar);
         },
     };
 }
@@ -719,7 +837,35 @@ function createSecretVault({ config, driver, logger, now } = {}) {
         logger[nivel](msg, meta);   // CA-23: `meta` sólo lleva NOMBRES de scope
     }
 
+    // D-SYNC-6 — el camino sync exige el port sync del driver. Si falta, se
+    // falla cerrado NOMBRANDO el método: nunca se devuelve vacío y nunca se
+    // espera la Promise con un hack de bloqueo.
+    function ejecutarSync(pedido) {
+        const metodo = pedido.op === 'getParametersByPath'
+            ? 'getParametersByPathSync'
+            : 'getSecretValueSync';
+        if (!driver || typeof driver[metodo] !== 'function') {
+            throw new VaultConfigError('vault.driver',
+                `el driver "${(driver && driver.kind) || 'desconocido'}" no expone \`${metodo}\`, `
+                + 'que el camino sync exige. Remediación: usar `createAwsCliVaultDriver` o '
+                + '`createInMemoryVaultDriver`, o agregar el port sync al driver inyectado');
+        }
+        return pedido.op === 'getParametersByPath'
+            ? driver.getParametersByPathSync(pedido.root, pedido.opts)
+            : driver.getSecretValueSync(pedido.name, pedido.opts);
+    }
+
+    function ejecutarAsync(pedido) {
+        return pedido.op === 'getParametersByPath'
+            ? driver.getParametersByPath(pedido.root, pedido.opts)
+            : driver.getSecretValue(pedido.name, pedido.opts);
+    }
+
     /**
+     * Núcleo ÚNICO de la resolución del namespace (D1.1 / D-SYNC-3): caché,
+     * TTL, tiers, presupuesto de llamadas, fail-closed y taxonomía de errores
+     * viven acá una sola vez. Los dos caminos públicos lo conducen.
+     *
      * Resuelve el namespace completo con A LO SUMO DOS llamadas batch (SEC-3):
      * una a `<prefix>/<projectId>/shared/` y otra a
      * `<prefix>/<projectId>/hosts/<hostId>/`. Nunca una llamada por variable, y
@@ -727,9 +873,8 @@ function createSecretVault({ config, driver, logger, now } = {}) {
      *
      * @param {object} [opts]
      * @param {string[]} [opts.scopes] subconjunto de `required_scopes`
-     * @returns {Promise<{enabled:boolean, namespace:string|null, scopes:object, tiers:object}>}
      */
-    async function resolveNamespace(opts = {}) {
+    function* nucleoResolveNamespace(opts = {}) {
         if (!enabled) {
             // CA-25 / test 15 — ni una llamada al driver.
             return { enabled: false, namespace: null, scopes: {}, tiers: {} };
@@ -764,7 +909,9 @@ function createSecretVault({ config, driver, logger, now } = {}) {
                 const root = buildParameterPath({
                     prefix: cfg.prefix, projectId: cfg.projectId, hostId: cfg.hostId, tier, root: true,
                 });
-                const res = await driver.getParametersByPath(root, { scopes: scopesDelTier });
+                const res = yield {
+                    op: 'getParametersByPath', root, opts: { scopes: scopesDelTier },
+                };
                 const params = (res && Array.isArray(res.parameters)) ? res.parameters : [];
                 if (res && res.nextToken) {
                     // Un driver que devuelve un token sin consumir está entregando
@@ -837,14 +984,14 @@ function createSecretVault({ config, driver, logger, now } = {}) {
     }
 
     /**
-     * Devuelve SÓLO los scopes declarados, ya parseados desde JSON (G-2).
+     * Núcleo ÚNICO de `resolveScope` (D1.1). Devuelve SÓLO los scopes
+     * declarados, ya parseados desde JSON (G-2).
      *
      * @param {object} args
      * @param {string[]} args.scopes
      * @param {'shared'|'host'|'rotating'} [args.tier] `rotating` va a Secrets Manager
-     * @returns {Promise<object>} mapa `scope -> objeto`
      */
-    async function resolveScope({ scopes, tier } = {}) {
+    function* nucleoResolveScope({ scopes, tier } = {}) {
         if (!enabled) return {};
         if (tier === 'rotating') {
             const pedidos = normalizarScopes(scopes);
@@ -855,7 +1002,7 @@ function createSecretVault({ config, driver, logger, now } = {}) {
                 });
                 let res;
                 try {
-                    res = await driver.getSecretValue(name, { scopes: [scope] });
+                    res = yield { op: 'getSecretValue', name, opts: { scopes: [scope] } };
                 } catch (err) {
                     invalidarSiEsAuth(err);
                     throw err;
@@ -865,8 +1012,37 @@ function createSecretVault({ config, driver, logger, now } = {}) {
             }
             return out;
         }
-        const res = await resolveNamespace({ scopes });
+        const res = yield* nucleoResolveNamespace({ scopes });
         return res.scopes;
+    }
+
+    // -------------------------------------------------------------------------
+    // Superficie pública — dos caminos, un solo cuerpo (D1.1 / D1.2 / D-SYNC-2)
+    // -------------------------------------------------------------------------
+    //
+    // D1.5 / D-SYNC-4: las async siguen DECLARADAS `async` (su
+    // `constructor.name` sigue siendo `AsyncFunction` y siguen devolviendo
+    // `Promise`), así que la superficie observable de #5352 no cambia y su
+    // suite queda verde sin editarse.
+
+    /** @returns {Promise<{enabled:boolean, namespace:string|null, scopes:object, tiers:object}>} */
+    async function resolveNamespace(opts = {}) {
+        return conducirAsync(nucleoResolveNamespace(opts), ejecutarAsync);
+    }
+
+    /** @returns {Promise<object>} mapa `scope -> objeto` */
+    async function resolveScope(args = {}) {
+        return conducirAsync(nucleoResolveScope(args), ejecutarAsync);
+    }
+
+    /** Gemelo sync: MISMO cuerpo, mismos errores, mismos códigos (D1.4). */
+    function resolveNamespaceSync(opts = {}) {
+        return conducirSync(nucleoResolveNamespace(opts), ejecutarSync);
+    }
+
+    /** Gemelo sync: MISMO cuerpo, mismos errores, mismos códigos (D1.4). */
+    function resolveScopeSync(args = {}) {
+        return conducirSync(nucleoResolveScope(args), ejecutarSync);
     }
 
     /** SEC-6(c) — invalidación explícita, idempotente. */
@@ -894,6 +1070,21 @@ function createSecretVault({ config, driver, logger, now } = {}) {
             return `SecretVault ${render(forma, { ...(options || {}), depth: null })}`;
         },
     };
+
+    // D1.2 / D1.5 — los gemelos sync se cuelgan como propiedades NO
+    // ENUMERABLES a propósito. El test 8 de #5352 congela la superficie
+    // enumerable del vault (`Object.keys(vault).sort()` === los 3 de siempre)
+    // como parte de CA-20/SEC-6(d), y esa suite tiene que quedar verde SIN
+    // editarse. Non-enumerable satisface las dos cosas a la vez: el método es
+    // público, invocable y testeable, y `Object.keys` / `JSON.stringify` /
+    // `util.inspect` siguen viendo exactamente la forma que #5352 firmó.
+    Object.defineProperty(vault, 'resolveNamespaceSync', {
+        value: resolveNamespaceSync, enumerable: false, writable: false, configurable: false,
+    });
+    Object.defineProperty(vault, 'resolveScopeSync', {
+        value: resolveScopeSync, enumerable: false, writable: false, configurable: false,
+    });
+
     return vault;
 }
 

--- a/docs/pipeline/vault-secretos-aws.md
+++ b/docs/pipeline/vault-secretos-aws.md
@@ -691,6 +691,32 @@ módulo `secret-vault.js` ni siquiera se carga.
 Poner `vault.enabled: true` es una decisión de operación, y **no se aprueba sin
 esta lista completa**:
 
+0. ⛔ **BLOQUEANTE ABIERTO — de dónde saca el vault sus PROPIAS credenciales AWS.**
+   Hoy **no hay respuesta**, y encender el gate sin cerrarlo deja el pipeline con
+   **cero credenciales**. Es el huevo-y-la-gallina del vault: para leer el vault
+   hacen falta credenciales AWS, y hoy viven en el archivo que el vault viene a
+   reemplazar. Verificado sobre `HEAD c10524e4d`:
+
+   - `ENV_DESCRIPTORS` (`credentials.js`) **no tiene ni una entrada del scope
+     `aws`** ⇒ `loadIntoEnv()` nunca hidrata `AWS_ACCESS_KEY_ID` /
+     `AWS_SECRET_ACCESS_KEY` al ambiente.
+   - `createAwsCliVaultRunner` (`secret-vault.js`) hace fail-closed si esas dos
+     no están ⇒ con el gate abierto, `vault.error = VAULT_CONFIG_INVALID` y las
+     **13** variables salen en `missing`.
+   - No hay escape en runtime: la ventana de bootstrap se desactiva justamente
+     por haber error del vault (B1.2), así que ni encendiéndola se recupera. La
+     única salida es editar `config.yaml` a mano y reiniciar.
+   - Incoherencia adicional: `AWS_PROFILE` **sí** está en el allowlist de
+     `build-child-env.js`, y `~/.aws/{config,credentials,login}` muestra que la
+     autenticación real de este host es **por perfil (`aws login`)** — pero el
+     guard exige las dos variables de clave estática, así que rechaza el único
+     mecanismo de auth que el host tiene. El propio mensaje de error sugiere
+     «Remediación: `aws login`», que **no** satisface el guard que lo emitió.
+
+   Cerrar esto es una decisión de criterio (¿el vault se autentica por perfil?
+   ¿por rol de instancia? ¿las claves del vault son el único secreto que sigue
+   viviendo en archivo, y con qué blast radius?), del mismo rango que B1/B2/B3 y
+   **no la cierra el dev por su cuenta**. Seguimiento: #5393.
 1. **#5211 cerrado** — la policy IAM aplicada por host. Sin esto no hay nada que
    leer y todo secreto sale fail-closed.
 2. **#5212 cerrado** — auditoría CloudTrail de la CMK (G-5).

--- a/docs/pipeline/vault-secretos-aws.md
+++ b/docs/pipeline/vault-secretos-aws.md
@@ -737,6 +737,30 @@ esta lista completa**:
    y `vault.shared_secrets` la membresía que corresponda. El vault sólo resuelve
    scopes declarados: uno faltante es fail-closed, no una lectura silenciosa.
 7. **G-6 a G-9 verificados** con control positivo en la misma corrida (B3.6).
+8. **El ancla no se apaga desde el ambiente** (B2.7 — rev-1 de la auditoría de
+   seguridad). El régimen del ancla depende de `vault.enabled`, así que quien
+   pueda elegir **qué `config.yaml` es la autoridad** puede apagar el control
+   entero — y eso es exactamente la capacidad que B2 asume en el adversario
+   (poder escribir variables de entorno). Dos invariantes lo cierran, y las dos
+   se verifican en `credentials-vault-5353.test.js`:
+
+   - La raíz de la config la fija el **código** (`REPO_ROOT`), igual que hace
+     `pulpo.js`. `PIPELINE_REPO_ROOT`, `PIPELINE_DIR_OVERRIDE` y
+     `PIPELINE_STATE_DIR` **no** eligen la autoridad para `credentials.js`.
+     Antes sí lo hacían: bastaba apuntar una de ellas a una carpeta vacía para
+     que el gate se leyera como apagado y el chat id preseteado en el ambiente
+     sobreviviera como firmante del gate del operador.
+   - «No se pudo leer la config» **no es** «el vault está apagado». Es un estado
+     propio (`result.vault.indeterminado: true`) y ante él las **anclas** fallan
+     cerradas: se descartan del ambiente y se cuentan en `missing`. Las 12
+     no-ancla siguen el camino del gate cerrado, idéntico al actual. Colapsar
+     los dos estados es fail-open disfrazado, el mismo razonamiento que B1.2
+     aplica al error de red del driver.
+
+   Verificación al encender: `result.vault.indeterminado === false` en el boot.
+   Si sale `true`, el `config.yaml` que manda no se está leyendo y el gate del
+   operador quedó **sin firmantes** a propósito — se repara la config, no se
+   repuebla la variable a mano.
 
 La ventana de bootstrap (`vault.bootstrap_fallback` +
 `bootstrap_fallback_until`) existe para el punto 3 y **sólo** para eso: permite

--- a/docs/pipeline/vault-secretos-aws.md
+++ b/docs/pipeline/vault-secretos-aws.md
@@ -498,17 +498,33 @@ sería el verde falso que esa disciplina existe para impedir.
 | **G-3** | Costo real facturado | `null` | requiere Cost Explorer sobre la cuenta; acá sólo hay precios de lista y un volumen medido en el host | un mes de facturación tras aplicar |
 | **G-4** | Enforcement efectivo de la policy (que `AccessDenied` ocurra donde el diseño dice) | `null` | la policy **no está aplicada**: es un artefacto de diseño | #5211 al aplicarla, con las pruebas negativas de § Aplicación |
 | **G-5** | Registro en CloudTrail del intento denegado | `null` | la auditoría de la CMK todavía no está configurada | #5212 |
+| **G-6** | B3.2 de #5353 — principal **distinguible por host**: `sts get-caller-identity` devuelve un principal distinto e identificable desde cada uno de los dos hosts | `null` | hay principals IAM no-root operativos, pero ninguno tiene concedido el prefijo del vault; la identidad por host todavía no existe como tal | #5211, al aplicar una policy por `HOST` |
+| **G-7** | B3.3 de #5353 (= CA-5 de #5338) — **multi-host**: dos hosts leen el mismo secreto compartido, sin copiar archivos entre máquinas | `null` | no hay nada aprovisionado que leer: `ssm:DescribeParameters` y `secretsmanager:ListSecrets` deniegan para los dos perfiles del host | #5211, tras el paso admin de § Aplicación |
+| **G-8** | B3.4 de #5353 (= CA-3 de #5338) — **aislamiento**: un host que intenta leer el namespace ajeno es denegado | `null` | hoy el `AccessDenied` saldría porque **ninguna** policy concede nada (y para `kernel-runtime`, por un `Deny` explícito de `IntraleKernelStore`), no porque el aislamiento funcione | #5211 — y sólo cuenta con el **control positivo** de G-9 en la misma corrida |
+| **G-9** | B3.6 de #5353 — **control positivo obligatorio**: la prueba negativa de G-8 sólo vale si el mismo host lee **su propio** namespace con ÉXITO en la misma corrida | `null` | ídem G-8 | #5211. Sin esto, un `AccessDenied` genérico se firmaría como "aislamiento verificado" siendo un falso positivo |
+
+> **G-6 a G-9 los aporta #5353** (integración del vault en `credentials.js`). El
+> **lado código** de B3 sí quedó cerrado y testeado ahí, sin AWS y con driver
+> inyectado (B3-A.1 el namespace sale de config, B3-A.2 la denegación es
+> fail-closed con la variable sin setear, B3-A.3 un `hostId` inválido falla
+> nombrando `vault.hostId`). Lo que viaja acá como gap es exclusivamente el
+> **lado cuenta**, que no es observable hasta que #5211 aplique la policy.
+> Estos cuatro gaps **no bloquean #5353**; bloquean el cierre del épico #5215.
 
 ```jsonc
 // Forma en que estos gaps deben viajar a cualquier reporte automatizado.
 // Ningún gap puede salir con verified: true; el fusible de kernel-table-verify
 // (assertNoUnverifiedClaims) tira en vez de imprimir un verde falso.
 "gaps": [
-  { "id": "G-1", "control": "kms:DescribeKey",      "verified": null, "blockedBy": "#5211" },
-  { "id": "G-2", "control": "kms:ListAliases",      "verified": null, "blockedBy": "#5211" },
-  { "id": "G-3", "control": "costo real facturado", "verified": null, "blockedBy": "#5211" },
-  { "id": "G-4", "control": "enforcement IAM",      "verified": null, "blockedBy": "#5211" },
-  { "id": "G-5", "control": "auditoría CloudTrail", "verified": null, "blockedBy": "#5212" }
+  { "id": "G-1", "control": "kms:DescribeKey",           "verified": null, "blockedBy": "#5211" },
+  { "id": "G-2", "control": "kms:ListAliases",           "verified": null, "blockedBy": "#5211" },
+  { "id": "G-3", "control": "costo real facturado",      "verified": null, "blockedBy": "#5211" },
+  { "id": "G-4", "control": "enforcement IAM",           "verified": null, "blockedBy": "#5211" },
+  { "id": "G-5", "control": "auditoría CloudTrail",      "verified": null, "blockedBy": "#5212" },
+  { "id": "G-6", "control": "principal por host",        "verified": null, "blockedBy": "#5211" },
+  { "id": "G-7", "control": "lectura multi-host",        "verified": null, "blockedBy": "#5211" },
+  { "id": "G-8", "control": "aislamiento de namespace",  "verified": null, "blockedBy": "#5211" },
+  { "id": "G-9", "control": "control positivo de G-8",   "verified": null, "blockedBy": "#5211" }
 ]
 ```
 
@@ -649,8 +665,9 @@ diseño. Sin esta tabla el operador queda ciego.
   necesita para no rediseñar está en § `path#namespace` (el esquema de referencia
   sin tocar el parser) y § Jerarquía (la barra inicial como discriminador de
   servicio). No debe aflojar la clase de caracteres del namespace.
-- **Hija 3 — `.pipeline/lib/credentials.js`.** La integración en el cliente. La
-  tabla de § Clasificación dice, secreto por secreto, dónde buscar cada uno.
+- **Hija 3 — `.pipeline/lib/credentials.js`.** ✅ **Entregada (#5353).** La
+  integración en el cliente, con el gate `vault.enabled` cerrado. Ver §
+  Encendido del gate.
 - **#5211 — mínimo privilegio IAM/KMS.** Aplica esta policy. Las pruebas negativas
   de § Aplicación cierran G-4; el `kms:DescribeKey` de un principal con lectura de
   KMS cierra G-1 y G-2.
@@ -662,3 +679,41 @@ diseño. Sin esta tabla el operador queda ciego.
 
 Mientras la policy no esté aplicada, este documento es un artefacto de diseño sin
 blast radius: no hay ningún permiso concedido ni ningún secreto en la cuenta.
+
+## Encendido del gate (`vault.enabled: true`) — #5353
+
+«El código es correcto» y «la cuenta está lista» son dos verdades distintas, con
+dueños distintos. #5353 entrega la primera con el gate **cerrado**: con
+`vault.enabled: false` (default commiteado en `config.yaml`) el comportamiento
+del pipeline es idéntico al previo y **no se emite una sola llamada AWS** — el
+módulo `secret-vault.js` ni siquiera se carga.
+
+Poner `vault.enabled: true` es una decisión de operación, y **no se aprueba sin
+esta lista completa**:
+
+1. **#5211 cerrado** — la policy IAM aplicada por host. Sin esto no hay nada que
+   leer y todo secreto sale fail-closed.
+2. **#5212 cerrado** — auditoría CloudTrail de la CMK (G-5).
+3. **Altas hechas** — los 13 valores de `ENV_DESCRIPTORS`
+   (`.pipeline/lib/credentials.js`) provisionados según la tabla de §
+   Clasificación: doce en `shared/` de Parameter Store y
+   `google_drive.oauth_refresh_token` en `rotating/` de Secrets Manager.
+4. **El ancla poblada** — `telegram.leo_operator_chat_id` (B2.5b). Es la única
+   fuente de la allowlist de firmantes del gate del operador
+   (`operator-gate.js`), y con el gate abierto se resuelve **exclusivamente**
+   desde el vault, sin fallback. Encender sin poblarla deja al operador sin
+   poder firmar nada. Verificación: `resolveOperatorAllowlist(env).size >= 1`
+   tras el boot — se reporta **el tamaño**, jamás el contenido.
+5. **`vault.hostId` seteado** al `os.hostname()` de la máquina. Se commitea
+   vacío a propósito (CA-29); con el gate abierto, vacío o inválido falla
+   nombrando la clave.
+6. **`vault.required_scopes`** declara `telegram`, `providers` y `google_drive`,
+   y `vault.shared_secrets` la membresía que corresponda. El vault sólo resuelve
+   scopes declarados: uno faltante es fail-closed, no una lectura silenciosa.
+7. **G-6 a G-9 verificados** con control positivo en la misma corrida (B3.6).
+
+La ventana de bootstrap (`vault.bootstrap_fallback` +
+`bootstrap_fallback_until`) existe para el punto 3 y **sólo** para eso: permite
+encender el gate antes de terminar todas las altas. Nunca se activa por un error
+del driver, nunca alcanza al ancla, y caduca sola. No es un mecanismo de
+resiliencia — si el vault falla, el pipeline degrada fail-closed y lo narra.


### PR DESCRIPTION
## Resumen
- Integra el vault AWS como fuente primaria de secretos en `credentials.js`.
- Conserva la compatibilidad de `ENV_MAPPING`, el contrato síncrono y el aislamiento por scope.
- Aplica fail-closed a las anclas de autorización y documenta el encendido seguro.

## Checklist
- [x] Base del PR en `main`
- [x] Título con formato `[auto] ... (Closes #<n>)`.
- [x] Cuerpo incluye `Closes #<n>`.
- [x] PR asignado a @leitolarreta.

## Evidencias
- Tests: 70/70 tests Node focalizados; `./gradlew check --no-daemon` → BUILD SUCCESSFUL.
- Smoke: `.pipeline/smoke-test.sh` → SMOKE TEST OK; pulpo, dashboard y svc-telegram OK; HTTP 200.
- Notas: rebote de aprobación corregido mediante la publicación formal de este PR. Los warnings de antigüedad de `last-restart` y mensajes runtime son preexistentes.

Closes #5353