### PR TITLE
[auto] Evitar re-notificación tras escalación fallida

### DIFF
--- a/.pipeline/__tests__/stuck-reconciler-wiring-5396.test.js
+++ b/.pipeline/__tests__/stuck-reconciler-wiring-5396.test.js
@@ -441,6 +441,44 @@ test('CA-4 e2e: issue de la ola escala UNA vez; el segundo tick sobre el mismo e
     assert.deepEqual(fs.readdirSync(path.join(dir, 'desarrollo', 'verificacion', 'listo')), ['5209.qa']);
 });
 
+test('rebote review: reportHumanBlock fallido no contabiliza ni notifica una escalación inexistente', () => {
+    const dir = tmpPipeline();
+    fs.writeFileSync(
+        path.join(dir, 'desarrollo', 'verificacion', 'listo', '5209.qa'),
+        'issue: 5209\nfase: verificacion\npipeline: desarrollo\nresultado: rechazado\n',
+    );
+    fs.utimesSync(
+        path.join(dir, 'desarrollo', 'verificacion', 'listo', '5209.qa'),
+        new Date(NOW - HOUR), new Date(NOW - HOUR),
+    );
+    writeTitleCache(dir, {
+        5209: { title: 'bloqueo imposible', state: 'OPEN', labels: ['Ready'], fetchedAt: NOW - 60000 },
+    });
+    const sent = [];
+    const deps = buildStuckReconcilerDeps({
+        config: CONFIG, PIPELINE: dir, ROOT: dir,
+        pauseFile: path.join(dir, '.paused'),
+        ppMode: { mode: 'partial_pause', allowedIssues: [5209] }, nowMs: NOW,
+        parallelPhases: [{ pipeline: 'desarrollo', fase: 'verificacion' }],
+        deps: {
+            log: () => { },
+            sendTelegramWithMarkup: (...args) => sent.push(args),
+            humanBlock: {
+                buildBlockedActionMarkup: () => null,
+                reportHumanBlock: () => { throw new Error('filesystem sin escritura'); },
+            },
+        },
+    });
+
+    const res = runStuckPhaseReconciler(deps, {
+        maxRequeueAttempts: 2, capPerTick: 5, staleThresholdMs: 15 * 60 * 1000,
+    });
+    assert.equal(res.escalated, 0, 'no informa una escalación que no ocurrió');
+    assert.equal(res.skipped, 1);
+    assert.equal(sent.length, 0, 'sin marker/label no notifica al operador');
+    assert.deepEqual(fs.readdirSync(path.join(dir, 'desarrollo', 'verificacion', 'bloqueado-humano')), []);
+});
+
 test('CA-3 e2e: el mismo issue fuera de la ola no escala ni notifica nunca', () => {
     const dir = tmpPipeline();
     fs.writeFileSync(

--- a/.pipeline/__tests__/stuck-reconciler-wiring-5396.test.js
+++ b/.pipeline/__tests__/stuck-reconciler-wiring-5396.test.js
@@ -1,0 +1,535 @@
+// =============================================================================
+// stuck-reconciler-wiring-5396.test.js — #5396, requisito SEC-0
+//
+// POR QUÉ ESTE ARCHIVO EXISTE
+// ---------------------------
+// Los tests del reconciler mockeaban `allowed: true` / `hasNeedsHuman: false` y
+// pasaban en verde mientras producción seguía rota: el defecto no estaba en la
+// decisión sino en el CABLEADO, que vivía inline en `pulpo.js` y por lo tanto no
+// era testeable (16k líneas con side-effects al requerirlas).
+//
+// Acá se verifica la POLÍTICA REAL contra `buildStuckReconcilerDeps`, con el
+// `ppMode` que devuelve el `partialPause.getPipelineMode()` de verdad, leído de
+// un `.partial-pause.json` serializado en un tmpdir. Si alguien vuelve a
+// reimplementar la allowlist a mano, estos tests se ponen rojos.
+// =============================================================================
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const partialPause = require('../lib/partial-pause');
+const { buildStuckReconcilerDeps, evaluateSilenceHealth } = require('../lib/stuck-reconciler-deps');
+const { runStuckPhaseReconciler } = require('../lib/stuck-phase-reconciler-runner');
+
+const NOW = 1_800_000_000_000;
+const HOUR = 3600000;
+
+const CONFIG = {
+    pipelines: {
+        desarrollo: {
+            fases: ['dev', 'validacion', 'verificacion', 'aprobacion'],
+            skills_por_fase: { verificacion: ['qa', 'tester'] },
+        },
+    },
+};
+
+function tmpPipeline() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'stuck-wiring-5396-'));
+    for (const fase of CONFIG.pipelines.desarrollo.fases) {
+        for (const st of ['pendiente', 'trabajando', 'listo', 'bloqueado-humano']) {
+            fs.mkdirSync(path.join(dir, 'desarrollo', fase, st), { recursive: true });
+        }
+    }
+    fs.mkdirSync(path.join(dir, 'servicios', 'github', 'pendiente'), { recursive: true });
+    return dir;
+}
+
+/** Corre `fn` con `PIPELINE_DIR_OVERRIDE` apuntando al tmpdir (y lo restaura). */
+function withPipelineDir(dir, fn) {
+    const prevDir = process.env.PIPELINE_DIR_OVERRIDE;
+    const prevEscape = process.env.PIPELINE_ALLOW_UNSCOPED_DISPATCH;
+    process.env.PIPELINE_DIR_OVERRIDE = dir;
+    delete process.env.PIPELINE_ALLOW_UNSCOPED_DISPATCH;
+    try { return fn(); } finally {
+        if (prevDir === undefined) delete process.env.PIPELINE_DIR_OVERRIDE;
+        else process.env.PIPELINE_DIR_OVERRIDE = prevDir;
+        if (prevEscape === undefined) delete process.env.PIPELINE_ALLOW_UNSCOPED_DISPATCH;
+        else process.env.PIPELINE_ALLOW_UNSCOPED_DISPATCH = prevEscape;
+    }
+}
+
+function writeTitleCache(dir, entries) {
+    fs.writeFileSync(path.join(dir, '.issue-title-cache.json'), JSON.stringify(entries));
+}
+
+function buildDeps(dir, over = {}) {
+    return buildStuckReconcilerDeps({
+        config: CONFIG,
+        PIPELINE: dir,
+        ROOT: dir,
+        pauseFile: path.join(dir, '.paused'),
+        ppMode: over.ppMode !== undefined ? over.ppMode : partialPause.getPipelineMode(),
+        nowMs: NOW,
+        deps: { log: () => { }, ...(over.deps || {}) },
+    });
+}
+
+// -----------------------------------------------------------------------------
+// CA-3 / SEC-0 — filtro de ola contra el cableado real
+// -----------------------------------------------------------------------------
+
+test('CA-3 anti-regresión: issue EN allowedIssues durante partial_pause → isAllowed true', () => {
+    // Éste es el test que el bug `allowed_issues` (snake) vs `allowedIssues`
+    // (camel) hacía fallar: el lambda viejo devolvía false para TODOS los issues
+    // durante la ola, dejando el self-healing muerto justo cuando hace falta.
+    const dir = tmpPipeline();
+    fs.writeFileSync(path.join(dir, '.partial-pause.json'), JSON.stringify({
+        allowed_issues: [5209, 5211, 5242],
+        created_at: new Date(NOW).toISOString(),
+        source: 'test-5396',
+    }));
+
+    withPipelineDir(dir, () => {
+        const ppMode = partialPause.getPipelineMode();
+        assert.equal(ppMode.mode, 'partial_pause', 'precondición: el modo real es partial_pause');
+        assert.deepEqual(ppMode.allowedIssues, [5209, 5211, 5242]);
+        assert.equal(ppMode.allowed_issues, undefined, 'el objeto normalizado NO expone snake_case');
+
+        const deps = buildDeps(dir, { ppMode });
+        assert.equal(deps.isAllowed(5209), true, 'un issue de la ola SÍ debe poder escalar');
+        assert.equal(deps.isAllowed('5211'), true, 'acepta el issue como string');
+        assert.equal(deps.isAllowed(742), false, 'residuo de julio fuera de la ola');
+    });
+});
+
+test('CA-3: modo running sin escape hatch → isAllowed false para cualquier issue', () => {
+    // Sin allowlist no hay ola vigente que acote el barrido (#5060): fail-closed.
+    // Antes, fuera de `partial_pause` el lambda devolvía true y el reconciler
+    // escalaba TODO el backlog histórico (22 de 25 issues eran residuo).
+    const dir = tmpPipeline();
+    withPipelineDir(dir, () => {
+        const ppMode = partialPause.getPipelineMode();
+        assert.equal(ppMode.mode, 'running');
+        const deps = buildDeps(dir, { ppMode });
+        for (const n of [742, 1094, 5209]) {
+            assert.equal(deps.isAllowed(n), false, `#${n} no debe barrerse fuera de ola`);
+        }
+    });
+});
+
+test('CA-3: modo paused → isAllowed false', () => {
+    const dir = tmpPipeline();
+    fs.writeFileSync(path.join(dir, '.paused'), 'test');
+    withPipelineDir(dir, () => {
+        const ppMode = partialPause.getPipelineMode();
+        assert.equal(ppMode.mode, 'paused');
+        assert.equal(buildDeps(dir, { ppMode }).isAllowed(5209), false);
+    });
+});
+
+test('CA-3: isAllowed rechaza entradas basura sin explotar', () => {
+    const dir = tmpPipeline();
+    withPipelineDir(dir, () => {
+        const deps = buildDeps(dir, { ppMode: partialPause.getPipelineMode() });
+        for (const bad of [null, undefined, 0, -1, 'abc', {}]) {
+            assert.equal(deps.isAllowed(bad), false);
+        }
+    });
+});
+
+// -----------------------------------------------------------------------------
+// CA-1 / CA-2 / SEC-1 / SEC-2 — origen de la supresión
+// -----------------------------------------------------------------------------
+
+test('CA-1: marker físico en bloqueado-humano/ → "marker" (fuente de verdad)', () => {
+    const dir = tmpPipeline();
+    fs.writeFileSync(path.join(dir, 'desarrollo', 'verificacion', 'bloqueado-humano', '5209.reconciler'), '');
+    assert.equal(buildDeps(dir).hasNeedsHuman(5209), 'marker');
+});
+
+test('CA-1: orden de label sin drenar en la cola → "cola"', () => {
+    const dir = tmpPipeline();
+    fs.writeFileSync(path.join(dir, 'servicios', 'github', 'pendiente', '5209-needs-human-block-1.json'), '{}');
+    assert.equal(buildDeps(dir).hasNeedsHuman(5209), 'cola');
+});
+
+test('CA-1: cola drenada + label ya aplicado en GitHub → "cache-label" (el dedupe sobrevive)', () => {
+    // Éste es el corazón del bug: drenada la cola, el dedupe viejo se apagaba y
+    // el mismo issue se re-escalaba y re-notificaba cada 10 minutos.
+    const dir = tmpPipeline();
+    writeTitleCache(dir, {
+        5209: { title: 'algo', state: 'OPEN', labels: ['Ready', 'needs-human'], fetchedAt: NOW - 60000 },
+    });
+    assert.equal(buildDeps(dir).hasNeedsHuman(5209), 'cache-label');
+});
+
+test('CA-1: precedencia marker > cola > cache', () => {
+    const dir = tmpPipeline();
+    fs.writeFileSync(path.join(dir, 'desarrollo', 'verificacion', 'bloqueado-humano', '5209.reconciler'), '');
+    fs.writeFileSync(path.join(dir, 'servicios', 'github', 'pendiente', '5209-needs-human-x.json'), '{}');
+    writeTitleCache(dir, { 5209: { state: 'OPEN', labels: ['needs-human'], fetchedAt: NOW } });
+    assert.equal(buildDeps(dir).hasNeedsHuman(5209), 'marker');
+});
+
+test('SEC-2: entrada con fetchedAt vencido → "cache-desconocida" (fail-closed)', () => {
+    const dir = tmpPipeline();
+    writeTitleCache(dir, {
+        5209: { title: 'algo', state: 'OPEN', labels: ['needs-human'], fetchedAt: NOW - (3 * HOUR) },
+    });
+    // Reusa `title-cache-freshness.needsRefetch` (TTL 1h) — sin TTL nuevo.
+    assert.equal(buildDeps(dir).hasNeedsHuman(5209), 'cache-desconocida');
+});
+
+test('CA-2: sin entrada en caché → "cache-desconocida", nunca false', () => {
+    const dir = tmpPipeline();
+    writeTitleCache(dir, {});
+    assert.equal(buildDeps(dir).hasNeedsHuman(5209), 'cache-desconocida');
+});
+
+test('CA-2: caché ilegible o ausente → "cache-desconocida" (no explota)', () => {
+    const dir = tmpPipeline();
+    assert.equal(buildDeps(dir).hasNeedsHuman(5209), 'cache-desconocida', 'archivo ausente');
+    fs.writeFileSync(path.join(dir, '.issue-title-cache.json'), '{ json roto');
+    assert.equal(buildDeps(dir).hasNeedsHuman(5209), 'cache-desconocida', 'JSON corrupto');
+});
+
+test('SEC-1: sólo una entrada FRESCA y sin el label devuelve false (habilita escalar)', () => {
+    const dir = tmpPipeline();
+    writeTitleCache(dir, {
+        5209: { title: 'algo', state: 'OPEN', labels: ['Ready', 'bug'], fetchedAt: NOW - 60000 },
+    });
+    assert.equal(buildDeps(dir).hasNeedsHuman(5209), false);
+});
+
+test('SEC-1: la caché nunca habilita un escalado por ausencia de datos', () => {
+    const dir = tmpPipeline();
+    // Entrada pre-#3905 sin `state` → `needsRefetch` true → desconocida.
+    writeTitleCache(dir, { 5209: { title: 'algo', labels: [], fetchedAt: NOW } });
+    assert.equal(buildDeps(dir).hasNeedsHuman(5209), 'cache-desconocida');
+});
+
+test('isIssueOpen y issueTitle leen la misma caché con criterios distintos', () => {
+    const dir = tmpPipeline();
+    writeTitleCache(dir, {
+        5209: { title: '  Titulo con espacios  ', state: 'OPEN', labels: [], fetchedAt: NOW - 60000 },
+        5211: { title: 'Cerrado', state: 'CLOSED', labels: [], fetchedAt: NOW - (5 * HOUR) },
+    });
+    const deps = buildDeps(dir);
+    assert.equal(deps.isIssueOpen(5209), true);
+    assert.equal(deps.isIssueOpen(5211), false);
+    assert.equal(deps.issueTitle(5209), 'Titulo con espacios');
+    assert.equal(deps.issueTitle(5211), null, 'entrada stale → sin título (no miente)');
+});
+
+// -----------------------------------------------------------------------------
+// Causa raíz 3 / CA-5 / CA-6 — el escalado planta el marker por su dueño
+// -----------------------------------------------------------------------------
+
+test('CA-5: escalate delega en reportHumanBlock (no encola el label a mano)', () => {
+    const dir = tmpPipeline();
+    const calls = [];
+    const deps = buildDeps(dir, {
+        deps: { humanBlock: { reportHumanBlock: (o) => { calls.push(o); return {}; } } },
+    });
+
+    deps.escalate(5209, 'ambigüedad (rechazo/cancelado/corrupto)', {
+        pipeline: 'desarrollo', fase: 'verificacion',
+    });
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].issue, 5209);
+    assert.equal(calls[0].skill, 'reconciler');
+    assert.equal(calls[0].phase, 'verificacion');
+    assert.equal(calls[0].pipeline, 'desarrollo');
+    assert.match(calls[0].question, /¿Cómo destrabo #5209 en desarrollo\/verificacion\?/);
+
+    // CA-6 / riesgo #1 — LOS DOS parámetros son necesarios: la guarda de
+    // `reportHumanBlock` es `if (!pipeline || opts.moveFromActive !== false)`.
+    // Sin ellos movería el deliverable de `listo/` y destruiría la evidencia.
+    assert.equal(calls[0].moveFromActive, false);
+    assert.ok(calls[0].pipeline, 'pipeline explícito → no busca marker activo');
+
+    // Riesgo #6 — no debe quedar el enqueue manual del label.
+    const cola = fs.readdirSync(path.join(dir, 'servicios', 'github', 'pendiente'));
+    assert.deepEqual(cola, [], 'el label lo encola reportHumanBlock, no el dep');
+});
+
+test('CA-6: sin pipeline/fase explícitos NO escala (protege la evidencia)', () => {
+    const dir = tmpPipeline();
+    const calls = [];
+    const deps = buildDeps(dir, {
+        deps: { humanBlock: { reportHumanBlock: (o) => calls.push(o) } },
+    });
+    deps.escalate(5209, 'motivo', {});
+    deps.escalate(5209, 'motivo', { pipeline: 'desarrollo' });
+    deps.escalate(5209, 'motivo', { fase: 'verificacion' });
+    assert.equal(calls.length, 0, 'fail-closed: mejor no escalar que mover el deliverable');
+});
+
+test('SEC-5.2: escalate valida el issue como entero positivo antes del path.join', () => {
+    const dir = tmpPipeline();
+    const calls = [];
+    const deps = buildDeps(dir, {
+        deps: { humanBlock: { reportHumanBlock: (o) => calls.push(o) } },
+    });
+    for (const bad of ['../../etc/passwd', -1, 0, 1.5, 'abc', null, undefined]) {
+        deps.escalate(bad, 'motivo', { pipeline: 'desarrollo', fase: 'verificacion' });
+    }
+    assert.equal(calls.length, 0);
+});
+
+test('escalate best-effort: un reportHumanBlock que tira no propaga la excepción', () => {
+    const dir = tmpPipeline();
+    const deps = buildDeps(dir, {
+        deps: { humanBlock: { reportHumanBlock: () => { throw new Error('disco lleno'); } } },
+    });
+    assert.doesNotThrow(() => deps.escalate(5209, 'motivo', { pipeline: 'desarrollo', fase: 'verificacion' }));
+});
+
+// -----------------------------------------------------------------------------
+// CA-8 / CA-UX-1 / CA-UX-5 — la notificación
+// -----------------------------------------------------------------------------
+
+function notifyHarness(dir, over = {}) {
+    const sent = [];
+    const deps = buildDeps(dir, {
+        deps: {
+            sendTelegramWithMarkup: (text, markup, opts) => sent.push({ text, markup, opts }),
+            humanBlock: { buildBlockedActionMarkup: (i) => ({ inline_keyboard: [[{ text: 'ok', url: `u/${i}` }]] }) },
+            ...over,
+        },
+    });
+    return { sent, deps };
+}
+
+test('CA-8: la notificación viaja en texto plano (sin parse_mode)', () => {
+    const { sent, deps } = notifyHarness(tmpPipeline());
+    deps.notify('🙋 #5209 necesita tu decisión', { issue: 5209, action: 'escalate' });
+    assert.equal(sent.length, 1);
+    assert.equal(sent[0].opts.plain, true, 'plain=true omite parse_mode en el payload');
+    assert.equal(sent[0].opts.parseMode, undefined);
+});
+
+test('CA-UX-1: el escalado llega con los botones de acción rápida', () => {
+    // `sendTelegramPlain` NO sirve acá: hardcodea el markup a null y mata los
+    // botones. `reply_markup` es independiente del dialecto de parseo.
+    const { sent, deps } = notifyHarness(tmpPipeline());
+    deps.notify('🙋 #5209', { issue: 5209, action: 'escalate' });
+    assert.ok(sent[0].markup, 'debe llevar reply_markup');
+    assert.ok(Array.isArray(sent[0].markup.inline_keyboard));
+});
+
+test('CA-UX-1: si el markup no se puede armar, se envía igual el texto', () => {
+    const { sent, deps } = notifyHarness(tmpPipeline(), {
+        humanBlock: { buildBlockedActionMarkup: () => undefined },
+    });
+    deps.notify('🙋 #5209', { issue: 5209, action: 'escalate' });
+    assert.equal(sent.length, 1, 'sin botones, pero la alerta llega');
+    assert.equal(sent[0].markup, null);
+});
+
+test('CA-UX-1: un buildBlockedActionMarkup que tira no bloquea la alerta', () => {
+    const { sent, deps } = notifyHarness(tmpPipeline(), {
+        humanBlock: { buildBlockedActionMarkup: () => { throw new Error('token no firmable'); } },
+    });
+    deps.notify('🙋 #5209', { issue: 5209, action: 'escalate' });
+    assert.equal(sent.length, 1);
+});
+
+test('el requeue notifica sin botones (los quick-actions son del bloqueo)', () => {
+    const { sent, deps } = notifyHarness(tmpPipeline());
+    deps.notify('🔧 re-encolé qa de #5209', { issue: 5209, action: 'requeue' });
+    assert.equal(sent[0].markup, null);
+});
+
+test('CA-UX-5: notify no dispara audio TTS — sólo encola texto', () => {
+    const dir = tmpPipeline();
+    const sent = [];
+    const deps = buildDeps(dir, {
+        deps: {
+            sendTelegramWithMarkup: (t, m, o) => sent.push({ t, m, o }),
+            humanBlock: { buildBlockedActionMarkup: () => undefined },
+        },
+    });
+    deps.notify('🙋 #5209', { issue: 5209, action: 'escalate' });
+    assert.equal(sent.length, 1, 'un único saliente de texto; el audio queda para el circuit breaker');
+});
+
+test('sin sender cableado, notify es no-op (nunca tumba el tick)', () => {
+    const deps = buildDeps(tmpPipeline());
+    assert.doesNotThrow(() => deps.notify('hola', { issue: 5209, action: 'escalate' }));
+});
+
+// -----------------------------------------------------------------------------
+// CA-4 end-to-end — dos ticks consecutivos sobre el MISMO estado
+// -----------------------------------------------------------------------------
+
+/**
+ * Tick completo por el cableado real, sobre un sandbox. El `humanBlock` de
+ * mentira planta el marker en el tmpdir (es lo único que el módulo real hace y
+ * que el dedupe del tick siguiente necesita ver).
+ */
+function tickHarness(dir, ppMode) {
+    const sent = [];
+    const deps = buildStuckReconcilerDeps({
+        config: CONFIG, PIPELINE: dir, ROOT: dir,
+        pauseFile: path.join(dir, '.paused'),
+        ppMode, nowMs: NOW,
+        parallelPhases: [{ pipeline: 'desarrollo', fase: 'verificacion' }],
+        deps: {
+            log: () => { },
+            sendTelegramWithMarkup: (text, markup, opts) => sent.push({ text, markup, opts }),
+            readYamlSafe: (p) => {
+                try {
+                    const out = {};
+                    for (const line of fs.readFileSync(p, 'utf8').split('\n')) {
+                        const m = line.match(/^(\w+):\s*(.+)$/);
+                        if (m) out[m[1]] = m[2].trim();
+                    }
+                    return out;
+                } catch { return {}; }
+            },
+            humanBlock: {
+                buildBlockedActionMarkup: (i) => ({ inline_keyboard: [[{ text: 'ok', url: `u/${i}` }]] }),
+                reportHumanBlock: ({ issue, skill, phase, pipeline, moveFromActive }) => {
+                    assert.equal(moveFromActive, false, 'jamás mover el deliverable de listo/');
+                    assert.ok(pipeline, 'pipeline explícito obligatorio');
+                    fs.writeFileSync(path.join(dir, pipeline, phase, 'bloqueado-humano', `${issue}.${skill}`), '');
+                },
+            },
+        },
+    });
+    const res = runStuckPhaseReconciler(deps, { maxRequeueAttempts: 2, capPerTick: 5, staleThresholdMs: 15 * 60 * 1000 });
+    return { res, sent };
+}
+
+test('CA-4 e2e: issue de la ola escala UNA vez; el segundo tick sobre el mismo estado calla', () => {
+    const dir = tmpPipeline();
+    // Issue varado: `qa` entregó rechazo, `tester` nunca entregó, nada vivo.
+    fs.writeFileSync(
+        path.join(dir, 'desarrollo', 'verificacion', 'listo', '5209.qa'),
+        'issue: 5209\nfase: verificacion\npipeline: desarrollo\nresultado: rechazado\n',
+    );
+    fs.utimesSync(
+        path.join(dir, 'desarrollo', 'verificacion', 'listo', '5209.qa'),
+        new Date(NOW - HOUR), new Date(NOW - HOUR),
+    );
+    writeTitleCache(dir, {
+        5209: { title: 'algo varado', state: 'OPEN', labels: ['Ready'], fetchedAt: NOW - 60000 },
+    });
+    const ppMode = { mode: 'partial_pause', allowedIssues: [5209] };
+
+    const t1 = tickHarness(dir, ppMode);
+    assert.equal(t1.res.escalated, 1, 'primer tick: escala');
+    assert.equal(t1.sent.length, 1, 'exactamente UNA notificación');
+    assert.equal(t1.sent[0].opts.plain, true, 'texto plano (CA-8)');
+    assert.ok(t1.sent[0].markup, 'con botones (CA-UX-1)');
+    assert.match(t1.sent[0].text, /algo varado/, 'con el título de la caché (CA-UX-2)');
+
+    // El marker quedó plantado → el dedupe del tick siguiente lo ve.
+    const t2 = tickHarness(dir, ppMode);
+    assert.equal(t2.res.escalated, 0, 'segundo tick: NO re-escala');
+    assert.equal(t2.sent.length, 0, 'y NO re-notifica — fin del loop de #5396');
+    assert.equal(t2.res.suppressed.dedupe, 1);
+
+    // CA-6: la evidencia sigue ahí después de los dos ticks.
+    assert.deepEqual(fs.readdirSync(path.join(dir, 'desarrollo', 'verificacion', 'listo')), ['5209.qa']);
+});
+
+test('CA-3 e2e: el mismo issue fuera de la ola no escala ni notifica nunca', () => {
+    const dir = tmpPipeline();
+    fs.writeFileSync(
+        path.join(dir, 'desarrollo', 'verificacion', 'listo', '742.qa'),
+        'issue: 742\nfase: verificacion\npipeline: desarrollo\nresultado: rechazado\n',
+    );
+    fs.utimesSync(
+        path.join(dir, 'desarrollo', 'verificacion', 'listo', '742.qa'),
+        new Date(NOW - HOUR), new Date(NOW - HOUR),
+    );
+    writeTitleCache(dir, {
+        742: { title: 'residuo de julio', state: 'OPEN', labels: ['Ready'], fetchedAt: NOW - 60000 },
+    });
+
+    // Pipeline SIN pausa parcial: antes de #5396 acá se barría todo el backlog.
+    const { res, sent } = tickHarness(dir, { mode: 'running', allowedIssues: [] });
+    assert.equal(res.escalated, 0);
+    assert.equal(sent.length, 0, 'el operador no se entera de residuo fuera de ola');
+    assert.equal(res.evaluados, 1, 'pero SÍ se evaluó (queda auditado, CA-7)');
+    assert.equal(res.suppressed.ola, 1);
+});
+
+// -----------------------------------------------------------------------------
+// CA-7 / CA-UX-3 / riesgo #2 — señal de vida del silencio
+// -----------------------------------------------------------------------------
+
+test('CA-7: 6 ticks mudos consecutivos con evaluados > 0 emiten la señal de vida', () => {
+    let prev = null;
+    const agg = { evaluados: 4, escalados: 0, requeued: 0, suprimidos_por_ola: 1, suprimidos_por_cache: 3 };
+    const emitidos = [];
+    for (let i = 1; i <= 8; i++) {
+        const r = evaluateSilenceHealth(prev, agg);
+        if (r.emitSignal) emitidos.push(i);
+        prev = r.next;
+    }
+    assert.deepEqual(emitidos, [6], 'una sola señal, en el 6º tick de la racha');
+});
+
+test('CA-UX-3: silencio explicado 100% por el filtro de ola → NO se emite señal', () => {
+    let prev = null;
+    const agg = { evaluados: 3, escalados: 0, requeued: 0, suprimidos_por_ola: 3, suprimidos_por_cache: 0 };
+    for (let i = 0; i < 20; i++) {
+        const r = evaluateSilenceHealth(prev, agg);
+        assert.equal(r.emitSignal, false, 'acotar a la ola es lo correcto, no una anomalía');
+        prev = r.next;
+    }
+});
+
+test('CA-7: cualquier acción resetea la racha', () => {
+    let prev = null;
+    const mudo = { evaluados: 2, escalados: 0, requeued: 0, suprimidos_por_cache: 2 };
+    for (let i = 0; i < 5; i++) prev = evaluateSilenceHealth(prev, mudo).next;
+    assert.equal(prev.streak, 5);
+
+    prev = evaluateSilenceHealth(prev, { evaluados: 2, escalados: 1, requeued: 0 }).next;
+    assert.equal(prev.streak, 0, 'escalar reinicia el contador');
+    assert.equal(prev.signaled, false);
+});
+
+test('CA-7: un tick sin issues varados no cuenta como silencio sospechoso', () => {
+    const r = evaluateSilenceHealth({ streak: 5, signaled: false }, { evaluados: 0, escalados: 0, requeued: 0 });
+    assert.equal(r.emitSignal, false);
+    assert.equal(r.next.streak, 0, 'no había nada que hacer: no es una anomalía');
+});
+
+test('CA-UX-3: la señal se emite como máximo una vez por racha', () => {
+    let prev = null;
+    const agg = { evaluados: 5, escalados: 0, requeued: 0, suprimidos_por_ola: 1, suprimidos_por_dedupe: 4 };
+    let count = 0;
+    for (let i = 0; i < 30; i++) {
+        const r = evaluateSilenceHealth(prev, agg);
+        if (r.emitSignal) count++;
+        prev = r.next;
+    }
+    assert.equal(count, 1);
+});
+
+test('CA-7: la señal vuelve a estar disponible tras una racha nueva', () => {
+    let prev = null;
+    const mudo = { evaluados: 3, escalados: 0, requeued: 0, suprimidos_por_dedupe: 3 };
+    for (let i = 0; i < 6; i++) prev = evaluateSilenceHealth(prev, mudo).next;
+    assert.equal(prev.signaled, true);
+
+    prev = evaluateSilenceHealth(prev, { evaluados: 1, escalados: 1, requeued: 0 }).next;
+    let reEmit = false;
+    for (let i = 0; i < 6; i++) {
+        const r = evaluateSilenceHealth(prev, mudo);
+        if (r.emitSignal) reEmit = true;
+        prev = r.next;
+    }
+    assert.equal(reEmit, true, 'una racha nueva puede volver a avisar');
+});

--- a/.pipeline/__tests__/stuck-reconciler-wiring-5396.test.js
+++ b/.pipeline/__tests__/stuck-reconciler-wiring-5396.test.js
@@ -238,12 +238,19 @@ test('CA-5: escalate delega en reportHumanBlock (no encola el label a mano)', ()
     });
 
     deps.escalate(5209, 'ambigüedad (rechazo/cancelado/corrupto)', {
-        pipeline: 'desarrollo', fase: 'verificacion',
+        pipeline: 'desarrollo', fase: 'verificacion', skills: ['tester'],
     });
 
     assert.equal(calls.length, 1);
     assert.equal(calls[0].issue, 5209);
-    assert.equal(calls[0].skill, 'reconciler');
+    // #5396 rev-1 — skill REAL de la fase, no el sintético `reconciler`.
+    assert.equal(calls[0].skill, 'tester');
+    assert.ok(
+        CONFIG.pipelines.desarrollo.skills_por_fase.verificacion.includes(calls[0].skill),
+        'el skill del marker debe pertenecer a skills_por_fase[fase]',
+    );
+    // La procedencia self-healing ya no viaja en el nombre del skill: va en el reason.
+    assert.match(calls[0].reason, /^\[self-healing\] /);
     assert.equal(calls[0].phase, 'verificacion');
     assert.equal(calls[0].pipeline, 'desarrollo');
     assert.match(calls[0].question, /¿Cómo destrabo #5209 en desarrollo\/verificacion\?/);
@@ -570,4 +577,224 @@ test('CA-7: la señal vuelve a estar disponible tras una racha nueva', () => {
         prev = r.next;
     }
     assert.equal(reEmit, true, 'una racha nueva puede volver a avisar');
+});
+
+// -----------------------------------------------------------------------------
+// #5396 rev-1 — CICLO DE DESTRABE: el marker debe ser DESPACHABLE
+//
+// Rechazo de `aprobacion` (rev-1): el marker se plantaba con el skill sintético
+// `reconciler`, que no existe en `skills_por_fase[fase]`. Al destrabar
+// (`unblockIssue`, o los botones 'Aprobar (unblock)' / 'Priorizar' que agrega
+// este mismo PR), el work-item caía en `pendiente/` y entraba al despacho, donde
+// el INVARIANTE skill∈fase de `pulpo.js:8596` lo rebotaba a `pendiente/` SIN
+// registrar cooldown y mandaba un Telegram por tick.
+//
+// Estos tests recorren el ciclo COMPLETO contra el `human-block` real y aplican
+// el mismo predicado del invariante del Pulpo sobre el resultado.
+// -----------------------------------------------------------------------------
+
+/**
+ * Predicado del INVARIANTE de `pulpo.js:8596-8605`, replicado textualmente:
+ *   const permitidos = config.pipelines[pipeline].skills_por_fase[fase] || [];
+ *   if (!permitidos.includes(skill)) → rebote a pendiente/ + Telegram por tick
+ */
+function pulpoDispatchInvariant(config, pipeline, fase, skill) {
+    const spf = ((config.pipelines || {})[pipeline] || {}).skills_por_fase || {};
+    const permitidos = spf[fase] || [];
+    return permitidos.includes(skill);
+}
+
+/** Crea un REPO root aislado y carga un `human-block` fresco apuntado ahí. */
+function withRealHumanBlock(fn) {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'stuck-unblock-5396-'));
+    const pipelineDir = path.join(root, '.pipeline');
+    for (const fase of CONFIG.pipelines.desarrollo.fases) {
+        for (const st of ['pendiente', 'trabajando', 'listo', 'bloqueado-humano']) {
+            fs.mkdirSync(path.join(pipelineDir, 'desarrollo', fase, st), { recursive: true });
+        }
+    }
+    fs.mkdirSync(path.join(pipelineDir, 'servicios', 'github', 'pendiente'), { recursive: true });
+    fs.mkdirSync(path.join(root, '.claude'), { recursive: true });
+
+    const prev = {
+        claude: process.env.CLAUDE_PROJECT_DIR,
+        repo: process.env.PIPELINE_REPO_ROOT,
+    };
+    process.env.CLAUDE_PROJECT_DIR = root;
+    process.env.PIPELINE_REPO_ROOT = root;
+    // `human-block` congela PIPELINE_DIR al requerirse → hay que cargarlo fresco.
+    const mods = ['../lib/human-block', '../lib/traceability'];
+    for (const m of mods) delete require.cache[require.resolve(m)];
+    const humanBlock = require('../lib/human-block');
+    try {
+        return fn({ root, pipelineDir, humanBlock });
+    } finally {
+        if (prev.claude === undefined) delete process.env.CLAUDE_PROJECT_DIR;
+        else process.env.CLAUDE_PROJECT_DIR = prev.claude;
+        if (prev.repo === undefined) delete process.env.PIPELINE_REPO_ROOT;
+        else process.env.PIPELINE_REPO_ROOT = prev.repo;
+        for (const m of mods) delete require.cache[require.resolve(m)];
+    }
+}
+
+test('rev-1: escalate -> unblockIssue -> el work-item pasa el invariante skill-en-fase', () => {
+    withRealHumanBlock(({ pipelineDir, humanBlock }) => {
+        const deps = buildStuckReconcilerDeps({
+            config: CONFIG,
+            PIPELINE: pipelineDir,
+            ROOT: pipelineDir,
+            pauseFile: path.join(pipelineDir, '.paused'),
+            ppMode: { mode: 'running' },
+            nowMs: NOW,
+            deps: { log: () => { }, humanBlock },
+        });
+
+        // 1) El reconciler escala: `tester` quedó `rechazado` (ambiguo).
+        const ok = deps.escalate(5209, 'ambiguedad (rechazo/cancelado/corrupto): tester:rejected', {
+            pipeline: 'desarrollo', fase: 'verificacion', skills: ['tester'],
+        });
+        assert.equal(ok, true, 'la escalacion debe registrarse');
+
+        const bloqDir = path.join(pipelineDir, 'desarrollo', 'verificacion', 'bloqueado-humano');
+        const bloqueados = fs.readdirSync(bloqDir);
+        assert.ok(bloqueados.includes('5209.tester'), `marker esperado 5209.tester, hay: ${bloqueados}`);
+        assert.ok(!bloqueados.includes('5209.reconciler'), 'el skill sintetico ya no se planta');
+
+        // 2) El operador destraba — es lo que hacen los quick-actions de Telegram
+        //    via executeQuickAction -> reactivateAllBlocked -> unblockIssue.
+        const r = humanBlock.unblockIssue({ issue: 5209, guidance: 're-corre tester', unlocker: 'test' });
+        assert.equal(r.ok, true);
+        assert.equal(r.to_phase, 'verificacion');
+
+        // 3) El work-item resultante ENTRA al despacho: el invariante lo acepta.
+        const skill = require('../lib/workfile-name').skillFromFile(path.basename(r.marker_path));
+        assert.equal(skill, 'tester');
+        assert.equal(
+            pulpoDispatchInvariant(CONFIG, 'desarrollo', 'verificacion', skill),
+            true,
+            'el invariante de pulpo.js debe aceptar el skill del marker destrabado',
+        );
+
+        const pendientes = fs.readdirSync(path.join(pipelineDir, 'desarrollo', 'verificacion', 'pendiente'));
+        assert.ok(pendientes.includes('5209.tester'));
+    });
+});
+
+test('rev-1: con el work-item ya destrabado en pendiente/, el tick NO re-escala', () => {
+    // Verifica la afirmacion de la doc (CA-9): el marker destrabado cuenta como
+    // `liveSkills` -> el detector dice `trabajo-vivo` -> decision `none`. Sin
+    // esto habria una ventana de doble escalado entre el unblock y el spawn.
+    const dir = tmpPipeline();
+    writeTitleCache(dir, {
+        5209: { state: 'OPEN', title: 'destrabado', labels: [], fetchedAt: new Date(NOW).toISOString() },
+    });
+    const fase = path.join(dir, 'desarrollo', 'verificacion');
+    fs.writeFileSync(path.join(fase, 'listo', '5209.tester'), 'resultado: rechazado\n');
+    const old = (NOW - HOUR) / 1000;
+    fs.utimesSync(path.join(fase, 'listo', '5209.tester'), old, old);
+    // Estado post-unblock: el work-item ya volvio a pendiente/.
+    fs.writeFileSync(path.join(fase, 'pendiente', '5209.tester'), '');
+    fs.writeFileSync(path.join(fase, 'pendiente', '5209.tester.guidance.txt'), 're-corre');
+
+    const escalations = [];
+    const sent = [];
+    const deps = buildDeps(dir, {
+        ppMode: { mode: 'running' },
+        deps: {
+            sendTelegramWithMarkup: (t) => sent.push(t),
+            humanBlock: { reportHumanBlock: (o) => { escalations.push(o); return {}; } },
+        },
+    });
+    deps.isAllowed = () => true;
+    deps.readYaml = () => ({ resultado: 'rechazado' });
+
+    const res = runStuckPhaseReconciler(deps, {});
+    assert.equal(res.escalated, 0, 'no re-escala sobre un work-item ya destrabado');
+    assert.equal(escalations.length, 0);
+    assert.equal(sent.length, 0, 'y por lo tanto no notifica');
+});
+
+test('rev-1 regresion: el skill sintetico "reconciler" habria rebotado contra el invariante', () => {
+    // Test de contraste — documenta EXACTAMENTE el defecto que motivo el rechazo.
+    assert.equal(
+        pulpoDispatchInvariant(CONFIG, 'desarrollo', 'verificacion', 'reconciler'),
+        false,
+        'precondicion del bug: `reconciler` nunca fue un skill despachable',
+    );
+    assert.equal(pulpoDispatchInvariant(CONFIG, 'desarrollo', 'verificacion', 'tester'), true);
+});
+
+test('rev-1: el skill del marker se valida contra skills_por_fase, no se cree el que le pasan', () => {
+    const dir = tmpPipeline();
+    const calls = [];
+    const deps = buildDeps(dir, {
+        deps: { humanBlock: { reportHumanBlock: (o) => { calls.push(o); return {}; } } },
+    });
+
+    // Un skill que NO pertenece a la fase (de otra fase, sintetico, o un nombre
+    // raro salido de un archivo) se descarta y cae al fallback determinista.
+    deps.escalate(5209, 'motivo', {
+        pipeline: 'desarrollo', fase: 'verificacion', skills: ['review', 'reconciler', '../../etc'],
+    });
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].skill, 'qa', 'fallback: primer skill de skills_por_fase[verificacion]');
+    assert.ok(pulpoDispatchInvariant(CONFIG, 'desarrollo', 'verificacion', calls[0].skill));
+});
+
+test('rev-1: "estado indeterminado" (sin skills imputados) igual planta un marker despachable', () => {
+    const dir = tmpPipeline();
+    const calls = [];
+    const deps = buildDeps(dir, {
+        deps: { humanBlock: { reportHumanBlock: (o) => { calls.push(o); return {}; } } },
+    });
+    deps.escalate(5209, 'estado indeterminado', { pipeline: 'desarrollo', fase: 'verificacion', skills: [] });
+    assert.equal(calls.length, 1);
+    assert.ok(pulpoDispatchInvariant(CONFIG, 'desarrollo', 'verificacion', calls[0].skill));
+});
+
+test('rev-1 fail-closed: fase sin skills_por_fase NO escala (marker sin salida seria spam)', () => {
+    const dir = tmpPipeline();
+    const calls = [];
+    const logs = [];
+    const deps = buildDeps(dir, {
+        deps: {
+            log: (_t, m) => logs.push(m),
+            humanBlock: { reportHumanBlock: (o) => calls.push(o) },
+        },
+    });
+    // `aprobacion` existe en `fases` pero CONFIG no le define skills_por_fase.
+    const ok = deps.escalate(5209, 'motivo', { pipeline: 'desarrollo', fase: 'aprobacion', skills: ['review'] });
+    assert.equal(ok, false);
+    assert.equal(calls.length, 0, 'mejor no escalar que dejar un bloqueo sin salida');
+    assert.ok(logs.some((m) => /sin skills_por_fase/.test(m)), 'el silencio queda logueado');
+});
+
+test('rev-1 e2e: el escalado del tick real deja un marker despachable', () => {
+    // Cierra el ciclo por el RUNNER (no llamando a `escalate` a mano): un
+    // deliverable `rechazado` de `tester` viejo -> escalate -> marker `5209.tester`.
+    const dir = tmpPipeline();
+    writeTitleCache(dir, {
+        5209: { state: 'OPEN', title: 'issue de la ola', labels: [], fetchedAt: new Date(NOW).toISOString() },
+    });
+    const listo = path.join(dir, 'desarrollo', 'verificacion', 'listo');
+    fs.writeFileSync(path.join(listo, '5209.tester'), 'resultado: rechazado\n');
+    const old = (NOW - HOUR) / 1000;
+    fs.utimesSync(path.join(listo, '5209.tester'), old, old);
+
+    const escalations = [];
+    const deps = buildDeps(dir, {
+        ppMode: { mode: 'running' },
+        deps: { humanBlock: { reportHumanBlock: (o) => { escalations.push(o); return {}; } } },
+    });
+    deps.isAllowed = () => true;                        // issue de la ola
+    deps.readYaml = () => ({ resultado: 'rechazado' }); // verdict del deliverable
+    deps.nowMs = NOW;
+
+    const res = runStuckPhaseReconciler(deps, {});
+    assert.equal(res.escalated, 1, `esperaba 1 escalacion, hubo ${JSON.stringify(res)}`);
+    assert.equal(escalations.length, 1);
+    assert.equal(escalations[0].skill, 'tester', 'el skill ambiguo real, no `reconciler`');
+    assert.ok(pulpoDispatchInvariant(CONFIG, 'desarrollo', 'verificacion', escalations[0].skill));
+    assert.equal(escalations[0].moveFromActive, false, 'CA-6: la evidencia de listo/ no se toca');
+    assert.ok(fs.existsSync(path.join(listo, '5209.tester')), 'el deliverable sigue en listo/');
 });

--- a/.pipeline/lib/__tests__/_stuck-escalate-child-5396.js
+++ b/.pipeline/lib/__tests__/_stuck-escalate-child-5396.js
@@ -62,6 +62,10 @@ try {
 
     out({
         ok: true,
+        // #5396 rev-1 — El test deriva de acá el skill que `escalate` DEBE elegir
+        // para el marker, en vez de hardcodearlo. Es la misma lista que valida el
+        // invariante skill∈fase de `pulpo.js`.
+        skillsPorFase: config.pipelines.desarrollo.skills_por_fase.verificacion,
         listo: rd(listoDir),
         listoContenido: (() => {
             try { return fs.readFileSync(path.join(listoDir, '5209.qa'), 'utf8'); } catch { return null; }

--- a/.pipeline/lib/__tests__/_stuck-escalate-child-5396.js
+++ b/.pipeline/lib/__tests__/_stuck-escalate-child-5396.js
@@ -1,0 +1,88 @@
+// =============================================================================
+// _stuck-escalate-child-5396.js — worker del test de #5396.
+//
+// `human-block.js` resuelve su `PIPELINE_DIR` desde `traceability.REPO_ROOT`, que
+// se calcula UNA VEZ al cargar el módulo a partir de `CLAUDE_PROJECT_DIR`. Para
+// ejercitar el escalado real contra un FS de mentira (y NO contra el `.pipeline`
+// de producción) hay que hacerlo en un proceso aparte con esa env var apuntando
+// al tmpdir. De ahí este worker.
+//
+// Uso: node _stuck-escalate-child-5396.js <tmpRoot>   → imprime JSON por stdout.
+// El prefijo `_` lo excluye del descubrimiento de `node --test`.
+// =============================================================================
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const tmpRoot = process.argv[2];
+const out = (o) => { process.stdout.write(JSON.stringify(o)); process.exit(0); };
+
+try {
+    const trace = require('../traceability');
+
+    // GUARDA DURA (riesgo #3): si `REPO_ROOT` no resolvió al tmpdir, ABORTAR sin
+    // escribir nada. Un fallo acá con el root de producción plantaría un marker
+    // real en `.pipeline/` — el test debe fallar ruidoso, nunca ensuciar.
+    if (path.resolve(trace.REPO_ROOT) !== path.resolve(tmpRoot)) {
+        out({ ok: false, error: `REPO_ROOT divergente: ${trace.REPO_ROOT} != ${tmpRoot}` });
+    }
+
+    const humanBlock = require('../human-block');
+    const { buildStuckReconcilerDeps } = require('../stuck-reconciler-deps');
+
+    const PIPELINE = path.join(tmpRoot, '.pipeline');
+    const config = {
+        pipelines: {
+            desarrollo: {
+                fases: ['dev', 'verificacion'],
+                skills_por_fase: { verificacion: ['qa', 'tester'] },
+            },
+        },
+    };
+
+    const deps = buildStuckReconcilerDeps({
+        config, PIPELINE, ROOT: tmpRoot,
+        pauseFile: path.join(PIPELINE, '.paused'),
+        ppMode: { mode: 'partial_pause', allowedIssues: [5209] },
+        nowMs: Date.now(),
+        deps: { log: () => { } },
+    });
+
+    // Escalado real: planta el marker + encola el label vía `reportHumanBlock`.
+    deps.escalate(5209, 'ambigüedad (rechazo/cancelado/corrupto)', {
+        pipeline: 'desarrollo', fase: 'verificacion',
+    });
+
+    const listoDir = path.join(PIPELINE, 'desarrollo', 'verificacion', 'listo');
+    const blockedDir = path.join(PIPELINE, 'desarrollo', 'verificacion', 'bloqueado-humano');
+    const colaDir = path.join(PIPELINE, 'servicios', 'github', 'pendiente');
+    const rd = (d) => { try { return fs.readdirSync(d); } catch { return []; } };
+
+    out({
+        ok: true,
+        listo: rd(listoDir),
+        listoContenido: (() => {
+            try { return fs.readFileSync(path.join(listoDir, '5209.qa'), 'utf8'); } catch { return null; }
+        })(),
+        bloqueados: rd(blockedDir),
+        cola: rd(colaDir),
+        // `listBlockedIssues()` es lo que `servicio-reconciler` usa para armar
+        // `blockedByIssue` y saltear el issue en `reconcileLabelToFilesystem`.
+        listBlocked: humanBlock.listBlockedIssues().map((b) => ({
+            issue: b.issue, skill: b.skill, phase: b.phase, pipeline: b.pipeline,
+        })),
+        // Segunda pasada: el escalado debe ser idempotente (no duplica marker).
+        segundaPasada: (() => {
+            deps.escalate(5209, 'ambigüedad (rechazo/cancelado/corrupto)', {
+                pipeline: 'desarrollo', fase: 'verificacion',
+            });
+            return { bloqueados: rd(blockedDir), listo: rd(listoDir) };
+        })(),
+        // El dedupe ahora ve el marker → el tick siguiente se calla.
+        hasNeedsHumanTrasEscalar: deps.hasNeedsHuman(5209),
+    });
+} catch (e) {
+    out({ ok: false, error: String((e && e.stack) || e) });
+}

--- a/.pipeline/lib/__tests__/stuck-escalate-no-oscilacion-5396.test.js
+++ b/.pipeline/lib/__tests__/stuck-escalate-no-oscilacion-5396.test.js
@@ -53,6 +53,25 @@ function escalarEnSandbox() {
     return { res, tmpRoot, deliverable };
 }
 
+/**
+ * Nombre del marker que `escalate` DEBE plantar, DERIVADO del sandbox.
+ *
+ * #5396 rev-1 — el marker dejó de ser el skill sintético `<issue>.reconciler` y
+ * pasa a ser un skill DESPACHABLE, validado contra `skills_por_fase[fase]` (la
+ * misma lista que usa el invariante skill∈fase de `pulpo.js`). El worker escala
+ * SIN imputar skills (`meta.skills` vacío), así que la regla que aplica es el
+ * fallback determinista documentado en `escalate`: el PRIMER skill de la fase.
+ *
+ * Se deriva en vez de hardcodear para que el test exprese el CONTRATO y no un
+ * literal: si el sandbox cambia sus `skills_por_fase`, el test sigue siendo
+ * válido en lugar de romperse (o peor, pasar por casualidad).
+ */
+function markerEsperado(res) {
+    const permitidos = res.skillsPorFase || [];
+    assert.ok(permitidos.length > 0, 'el sandbox debe declarar skills_por_fase para la fase escalada');
+    return `5209.${permitidos[0]}`;
+}
+
 test('CA-6 (bloqueante): escalar NO destruye el deliverable de listo/', () => {
     // Riesgo #1 — `reportHumanBlock` mueve el work-item activo (y `listo` está
     // entre los estados activos) salvo que reciba `pipeline` explícito Y
@@ -64,7 +83,10 @@ test('CA-6 (bloqueante): escalar NO destruye el deliverable de listo/', () => {
 
 test('causa raíz 3: escalar planta el marker físico en bloqueado-humano/', () => {
     const { res } = escalarEnSandbox();
-    assert.ok(res.bloqueados.includes('5209.reconciler'), `marker ausente: ${JSON.stringify(res.bloqueados)}`);
+    assert.ok(
+        res.bloqueados.includes(markerEsperado(res)),
+        `marker ausente: se esperaba ${markerEsperado(res)} en ${JSON.stringify(res.bloqueados)}`,
+    );
 });
 
 test('CA-5: el label lo encola reportHumanBlock (un solo comando, sin doble)', () => {
@@ -134,7 +156,11 @@ test('anti-regresión: SIN marker el mismo escenario SÍ encola remove-label (el
     assert.equal(sinMarker[0].issue, 5209);
 
     const conMarker = [];
-    reconcileLabelToFilesystem(ghIssues, new Map([[5209, [{ issue: 5209, skill: 'reconciler' }]]]), {
+    // El `skill` acá es irrelevante para el guard (corta por PRESENCIA de entrada
+    // en el mapa), pero se usa `qa` —un skill real de `skills_por_fase`— para no
+    // contradecir lo que planta `escalate` desde #5396 rev-1. Un `reconciler`
+    // acá describiría un marker que el código ya no genera.
+    reconcileLabelToFilesystem(ghIssues, new Map([[5209, [{ issue: 5209, skill: 'qa' }]]]), {
         ...staleOpts,
         enqueueLabelRemove: (issue, label) => conMarker.push({ issue, label }),
     });
@@ -149,7 +175,7 @@ test('CA-4: el escalado es idempotente — el segundo tick no duplica el marker'
     const markers = res.segundaPasada.bloqueados.filter(
         (n) => n.startsWith('5209.') && !n.endsWith('.reason.json'),
     );
-    assert.deepEqual(markers, ['5209.reconciler'], 'un marker por (issue, skill), no uno por tick');
+    assert.deepEqual(markers, [markerEsperado(res)], 'un marker por (issue, skill), no uno por tick');
     assert.deepEqual(res.segundaPasada.listo, ['5209.qa'], 'el deliverable sobrevive a los dos escalados');
 });
 

--- a/.pipeline/lib/__tests__/stuck-escalate-no-oscilacion-5396.test.js
+++ b/.pipeline/lib/__tests__/stuck-escalate-no-oscilacion-5396.test.js
@@ -1,0 +1,174 @@
+// =============================================================================
+// stuck-escalate-no-oscilacion-5396.test.js — #5396, causa raíz 3 + riesgo #1
+//
+// El `escalate` viejo encolaba SÓLO el label `needs-human` y nunca creaba el
+// marker físico. Sin marker, `servicio-reconciler.reconcileLabelToFilesystem`
+// veía un `needs-human` fantasma, le aplicaba `isNeedsHumanStaleByProgress()`
+// (#4222), encolaba `remove-label` ~30s después… y en el tick siguiente el
+// reconciler lo volvía a poner. Add/remove en loop, sobre el mismo issue.
+//
+// Estos tests corren contra el FILESYSTEM REAL (tmpdir) porque el punto es
+// justamente que el marker se escriba donde el otro reconciler lo va a buscar.
+// =============================================================================
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const { reconcileLabelToFilesystem, decidirFasePlaceholder } = require('../../servicio-reconciler');
+
+const CHILD = path.join(__dirname, '_stuck-escalate-child-5396.js');
+
+/**
+ * Monta un repo de mentira con un deliverable en `listo/` y corre el escalado
+ * real en un proceso hijo (ver el worker: `human-block` fija su root al cargar).
+ */
+function escalarEnSandbox() {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'stuck-escalate-5396-'));
+    const PIPELINE = path.join(tmpRoot, '.pipeline');
+    for (const fase of ['dev', 'verificacion']) {
+        for (const st of ['pendiente', 'trabajando', 'listo', 'bloqueado-humano']) {
+            fs.mkdirSync(path.join(PIPELINE, 'desarrollo', fase, st), { recursive: true });
+        }
+    }
+    fs.mkdirSync(path.join(PIPELINE, 'servicios', 'github', 'pendiente'), { recursive: true });
+
+    // La EVIDENCIA que el detector usa para decidir: no puede desaparecer.
+    const deliverable = 'issue: 5209\nfase: verificacion\npipeline: desarrollo\nresultado: rechazado\n';
+    fs.writeFileSync(path.join(PIPELINE, 'desarrollo', 'verificacion', 'listo', '5209.qa'), deliverable);
+
+    const r = spawnSync(process.execPath, [CHILD, tmpRoot], {
+        encoding: 'utf8',
+        timeout: 30000,
+        env: { ...process.env, CLAUDE_PROJECT_DIR: tmpRoot, PIPELINE_REPO_ROOT: tmpRoot },
+    });
+    assert.equal(r.status, 0, `worker falló: ${r.stderr || r.stdout}`);
+    const res = JSON.parse(r.stdout);
+    assert.ok(res.ok, `worker abortó: ${res.error}`);
+    return { res, tmpRoot, deliverable };
+}
+
+test('CA-6 (bloqueante): escalar NO destruye el deliverable de listo/', () => {
+    // Riesgo #1 — `reportHumanBlock` mueve el work-item activo (y `listo` está
+    // entre los estados activos) salvo que reciba `pipeline` explícito Y
+    // `moveFromActive: false`. Sin eso, el escalado se comía la evidencia.
+    const { res, deliverable } = escalarEnSandbox();
+    assert.deepEqual(res.listo, ['5209.qa'], 'el deliverable sigue en listo/');
+    assert.equal(res.listoContenido, deliverable, 'y sigue intacto, no vaciado');
+});
+
+test('causa raíz 3: escalar planta el marker físico en bloqueado-humano/', () => {
+    const { res } = escalarEnSandbox();
+    assert.ok(res.bloqueados.includes('5209.reconciler'), `marker ausente: ${JSON.stringify(res.bloqueados)}`);
+});
+
+test('CA-5: el label lo encola reportHumanBlock (un solo comando, sin doble)', () => {
+    // Riesgo #6 — si sobreviviera el `writeFileSync` manual habría DOS órdenes.
+    const { res } = escalarEnSandbox();
+    const labels = res.cola.filter((n) => n.includes('needs-human'));
+    assert.equal(labels.length, 1, `se esperaba una sola orden de label: ${JSON.stringify(res.cola)}`);
+});
+
+test('CA-5: con el marker presente, reconcileLabelToFilesystem SALTEA el issue', () => {
+    // Éste es el eslabón que cierra el bucle add/remove: `blockedByIssue` se arma
+    // desde `listBlockedIssues()` y el `continue` de la línea 490 evita que
+    // `isNeedsHumanStaleByProgress` encole el `remove-label`.
+    const { res } = escalarEnSandbox();
+    assert.ok(res.listBlocked.some((b) => b.issue === 5209), 'listBlockedIssues() debe verlo');
+
+    const blockedByIssue = new Map();
+    for (const b of res.listBlocked) {
+        if (!blockedByIssue.has(b.issue)) blockedByIssue.set(b.issue, []);
+        blockedByIssue.get(b.issue).push(b);
+    }
+
+    const removidos = [];
+    const ghIssues = [{ number: 5209, labels: ['Ready', 'needs-human', 'area:pipeline'] }];
+    reconcileLabelToFilesystem(ghIssues, blockedByIssue, {
+        enqueueLabelRemove: (issue, label) => removidos.push({ issue, label }),
+        logStaleOrder: () => { },
+    });
+
+    assert.deepEqual(removidos, [], 'no debe encolar remove-label: el bloqueo es real');
+});
+
+test('anti-regresión: SIN marker el mismo escenario SÍ encola remove-label (el bug viejo)', () => {
+    // Demuestra que el test anterior no pasa por casualidad. El escalado viejo
+    // sólo encolaba el label, así que `blockedByIssue` quedaba vacío: acá se
+    // reproduce ese estado y el `remove-label` aparece — la otra mitad del par
+    // add/remove que el operador veía oscilar en `svc-github.log`.
+    //
+    // El veredicto de avance físico se inyecta (`globalOrder` + `findFurthest`)
+    // para que el caso sea determinístico y la función corte en la rama stale,
+    // que hace `continue` SIN escribir placeholders en el filesystem.
+    // El orden DEBE contener la fase que elige `decidirFasePlaceholder` para
+    // estos labels (definicion/analisis); si no, `placeholderIdx` es -1, el
+    // veredicto sale `stale: false` y la función cae a escribir el placeholder
+    // en el filesystem real.
+    assert.deepEqual(
+        decidirFasePlaceholder(['Ready', 'needs-human', 'area:pipeline']),
+        { pipeline: 'definicion', phase: 'analisis', skill: 'guru' },
+    );
+    const globalOrder = [
+        { pipeline: 'definicion', phase: 'analisis' },
+        { pipeline: 'desarrollo', phase: 'verificacion' },
+    ];
+    const staleOpts = {
+        globalOrder,
+        findFurthest: () => 1, // el issue progresó más allá del placeholder
+        logStaleOrder: () => { },
+    };
+    const ghIssues = [{ number: 5209, labels: ['Ready', 'needs-human', 'area:pipeline'] }];
+
+    const sinMarker = [];
+    reconcileLabelToFilesystem(ghIssues, new Map(), {
+        ...staleOpts,
+        enqueueLabelRemove: (issue, label) => sinMarker.push({ issue, label }),
+    });
+    assert.equal(sinMarker.length, 1, 'sin marker se dispara el remove-label');
+    assert.equal(sinMarker[0].issue, 5209);
+
+    const conMarker = [];
+    reconcileLabelToFilesystem(ghIssues, new Map([[5209, [{ issue: 5209, skill: 'reconciler' }]]]), {
+        ...staleOpts,
+        enqueueLabelRemove: (issue, label) => conMarker.push({ issue, label }),
+    });
+    assert.deepEqual(conMarker, [], 'con marker el guard corta antes: se acabó la oscilación');
+});
+
+test('CA-4: el escalado es idempotente — el segundo tick no duplica el marker', () => {
+    const { res } = escalarEnSandbox();
+    // `reportHumanBlock` escribe el marker `<issue>.<skill>` más su artefacto
+    // `<marker>.reason.json` (metadata del bloqueo, que `listBlockedIssues`
+    // filtra). Sólo contamos markers reales.
+    const markers = res.segundaPasada.bloqueados.filter(
+        (n) => n.startsWith('5209.') && !n.endsWith('.reason.json'),
+    );
+    assert.deepEqual(markers, ['5209.reconciler'], 'un marker por (issue, skill), no uno por tick');
+    assert.deepEqual(res.segundaPasada.listo, ['5209.qa'], 'el deliverable sobrevive a los dos escalados');
+});
+
+test('CA-1: tras escalar, hasNeedsHuman devuelve "marker" y el tick siguiente calla', () => {
+    const { res } = escalarEnSandbox();
+    assert.equal(res.hasNeedsHumanTrasEscalar, 'marker');
+});
+
+test('riesgo #3: el worker aborta si human-block resuelve a otro root', () => {
+    // Guarda de seguridad del propio test: nunca debe escribir en el `.pipeline`
+    // real. Si `REPO_ROOT` no coincide con el sandbox, el worker sale sin tocar
+    // nada y reporta el error.
+    const otro = fs.mkdtempSync(path.join(os.tmpdir(), 'stuck-otro-root-'));
+    const r = spawnSync(process.execPath, [CHILD, path.join(otro, 'inexistente')], {
+        encoding: 'utf8',
+        timeout: 30000,
+        env: { ...process.env, CLAUDE_PROJECT_DIR: otro, PIPELINE_REPO_ROOT: otro },
+    });
+    const res = JSON.parse(r.stdout);
+    assert.equal(res.ok, false);
+    assert.match(res.error, /REPO_ROOT divergente/);
+});

--- a/.pipeline/lib/stuck-phase-reconciler-dedupe-5396.test.js
+++ b/.pipeline/lib/stuck-phase-reconciler-dedupe-5396.test.js
@@ -204,7 +204,13 @@ test('CA-6: executeDecisions pasa pipeline y fase explícitos a escalate', () =>
     executeDecisions([d], deps);
 
     assert.equal(calls.escalate.length, 1);
-    assert.deepEqual(calls.escalate[0].meta, { pipeline: 'desarrollo', fase: 'verificacion' });
+    assert.equal(calls.escalate[0].meta.pipeline, 'desarrollo');
+    assert.equal(calls.escalate[0].meta.fase, 'verificacion');
+
+    // #5396 rev-1 — además viajan los skills REALES que motivaron la escalación.
+    // El cableado elige entre ellos el que planta en el marker, para que al
+    // destrabar el work-item tenga un camino de dispatch válido (skill∈fase).
+    assert.ok(Array.isArray(calls.escalate[0].meta.skills), 'meta.skills es un array');
 });
 
 // -----------------------------------------------------------------------------

--- a/.pipeline/lib/stuck-phase-reconciler-dedupe-5396.test.js
+++ b/.pipeline/lib/stuck-phase-reconciler-dedupe-5396.test.js
@@ -317,3 +317,60 @@ test('línea roja: ninguna supresión produce una acción de aprobación', () =>
         assert.ok(!('resultado' in d));
     }
 });
+
+// -----------------------------------------------------------------------------
+// #5396 — un bloqueo humano vigente gana sobre el re-encolado
+//
+// Antes de este issue el dedupe sólo cubría el carril `escalate`: `escalate`
+// encolaba el label y casi nunca existía un marker físico, así que el carril
+// `requeue` con bloqueo vivo era teórico. Ahora `escalate` planta marker vía
+// `reportHumanBlock` con `moveFromActive: false` — el deliverable sigue en
+// `listo/` y el issue se sigue evaluando tick a tick —, y `bloqueado-humano/`
+// no es ni deliverable-state ni live-state para el runner. Resultado: un issue
+// esperando decisión humana podía re-encolarse y spawnear un agente encima.
+// -----------------------------------------------------------------------------
+
+/**
+ * Issue varado cuyo análisis da `requeue` (no `escalate`): `qa` entregó aprobado
+ * hace rato y `tester` nunca corrió. Sin ambigüedad ⇒ el detector re-encola el
+ * faltante, que es el único caso de auto-remediación que la línea roja permite.
+ */
+function requeueIssue(over = {}) {
+    return stuckIssue({
+        deliverables: [
+            { skill: 'qa', state: 'listo', yaml: { resultado: 'aprobado' }, mtimeMs: NOW - HOUR },
+        ],
+        ...over,
+    });
+}
+
+test('sanity: sin bloqueo humano, el skill faltante SÍ se re-encola', () => {
+    const d = only([requeueIssue()]);
+    assert.equal(d.action, 'requeue', 'el carril requeue debe seguir vivo (si no, el test de abajo no prueba nada)');
+    assert.deepEqual(d.skills, ['tester']);
+});
+
+test('#5396: issue con marker de bloqueo humano NO se re-encola (none, dedupe)', () => {
+    const d = only([requeueIssue({ hasNeedsHuman: true, needsHumanSource: 'marker' })]);
+    assert.equal(d.action, 'none', 'un issue esperando decisión humana no se toca');
+    assert.equal(d.reason, 'bloqueado-humano (dedupe: marker)');
+    assert.equal(d.suppression, 'dedupe');
+});
+
+test('#5396: el bloqueo bloquea el requeue también con la caché desconocida (fail-closed)', () => {
+    const d = only([requeueIssue({ hasNeedsHuman: true, needsHumanSource: 'cache-desconocida' })]);
+    assert.equal(d.action, 'none');
+    assert.equal(d.reason, 'cache-desconocida');
+    assert.equal(d.suppression, 'cache');
+});
+
+test('#5396: ejecutar la decisión no escribe work-item ni notifica', () => {
+    const d = only([requeueIssue({ hasNeedsHuman: true, needsHumanSource: 'marker' })]);
+    const s = spyDeps();
+    const res = executeDecisions([d], s.deps);
+    assert.equal(s.calls.requeue.length, 0, 'no spawnea agente sobre un issue bloqueado');
+    assert.equal(s.calls.escalate.length, 0, 'ya estaba escalado: no re-escala');
+    assert.equal(s.calls.notify.length, 0, 'y sobre todo no re-notifica');
+    assert.equal(res.requeued, 0);
+    assert.equal((res.suppressed || {}).dedupe, 1, 'queda contabilizado como supresión por dedupe');
+});

--- a/.pipeline/lib/stuck-phase-reconciler-dedupe-5396.test.js
+++ b/.pipeline/lib/stuck-phase-reconciler-dedupe-5396.test.js
@@ -1,0 +1,319 @@
+// =============================================================================
+// stuck-phase-reconciler-dedupe-5396.test.js — #5396
+//
+// El self-healing de fases varadas re-escalaba y re-notificaba el MISMO issue
+// cada 10 minutos: 36 notificaciones para 8 decisiones reales (78% de ruido).
+// Dos defectos de cableado:
+//   1. el dedupe miraba sólo señales TRANSITORIAS (cola de GitHub sin drenar);
+//      drenada la cola, volvía a escalar en cada tick.
+//   2. el filtro de ola sólo aplicaba bajo pausa parcial; fuera de pausa barría
+//      todo el backlog histórico.
+//
+// Estos tests son PUROS (planReconciliation / executeDecisions), sin FS.
+// El cableado real se verifica en `__tests__/stuck-reconciler-wiring-5396.test.js`.
+// =============================================================================
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+
+const {
+    planReconciliation,
+    executeDecisions,
+    buildEscalationMessage,
+} = require('./stuck-phase-reconciler');
+
+const HOUR = 3600000;
+const NOW = 1_800_000_000_000;
+
+/**
+ * Issue varado "canónico": un skill entregó rechazo, el otro nunca entregó y no
+ * hay trabajo vivo. El detector decide `escalate` (ambigüedad → humano).
+ */
+function stuckIssue(over = {}) {
+    return {
+        issue: 5209,
+        pipeline: 'desarrollo',
+        fase: 'verificacion',
+        requiredSkills: ['qa', 'tester'],
+        deliverables: [
+            { skill: 'qa', state: 'listo', yaml: { resultado: 'rechazado' }, mtimeMs: NOW - HOUR },
+        ],
+        liveSkills: new Set(),
+        liveElsewhere: false,
+        hasNeedsHuman: false,
+        needsHumanSource: null,
+        retryCounts: {},
+        allowed: true,
+        active: true,
+        ...over,
+    };
+}
+
+function plan(issues) {
+    return planReconciliation({ issues, nowMs: NOW, staleThresholdMs: 15 * 60 * 1000 });
+}
+function only(issues) {
+    const { decisions } = plan(issues);
+    assert.equal(decisions.length, 1, 'se esperaba una sola decisión');
+    return decisions[0];
+}
+
+/** Shell de IO con spies; `escalate`/`notify` registran cada llamada. */
+function spyDeps(over = {}) {
+    const calls = { escalate: [], notify: [], requeue: [], audit: [] };
+    return {
+        calls,
+        deps: {
+            escalate: (issue, reason, meta) => calls.escalate.push({ issue, reason, meta }),
+            notify: (msg, meta) => calls.notify.push({ msg, meta }),
+            requeueWorkItem: (p, f, s, i) => calls.requeue.push({ p, f, s, i }),
+            audit: (rec) => calls.audit.push(rec),
+            ...over,
+        },
+    };
+}
+
+// -----------------------------------------------------------------------------
+// CA-1 — el dedupe sobrevive al drenado de la cola
+// -----------------------------------------------------------------------------
+
+test('CA-1: issue ya escalado con marker y cola drenada → none con dedupe: marker, sin notificar', () => {
+    const d = only([stuckIssue({ hasNeedsHuman: true, needsHumanSource: 'marker' })]);
+    assert.equal(d.action, 'none');
+    assert.equal(d.reason, 'ya-escalado (dedupe: marker)');
+    assert.equal(d.suppression, 'dedupe');
+
+    const { calls, deps } = spyDeps();
+    const res = executeDecisions([d], deps);
+    assert.equal(calls.notify.length, 0, 'un issue ya escalado NO debe re-notificar');
+    assert.equal(calls.escalate.length, 0);
+    assert.equal(res.suppressed.dedupe, 1);
+});
+
+test('CA-1: el origen de la supresión queda explícito para cada fuente', () => {
+    for (const src of ['marker', 'cola', 'cache-label']) {
+        const d = only([stuckIssue({ hasNeedsHuman: true, needsHumanSource: src })]);
+        assert.equal(d.reason, `ya-escalado (dedupe: ${src})`, `fuente ${src}`);
+        assert.equal(d.suppression, 'dedupe');
+    }
+});
+
+test('CA-1: dep legacy que devuelve boolean sigue deduplicando (compat)', () => {
+    // `needsHumanSource: null` = dep viejo. No debe escalar igual.
+    const d = only([stuckIssue({ hasNeedsHuman: true, needsHumanSource: null })]);
+    assert.equal(d.action, 'none');
+    assert.match(d.reason, /dedupe/);
+});
+
+// -----------------------------------------------------------------------------
+// CA-2 — fail-closed ante caché desconocida o vencida
+// -----------------------------------------------------------------------------
+
+test('CA-2: caché ausente o stale → none con razón cache-desconocida, sin notificar', () => {
+    const d = only([stuckIssue({ hasNeedsHuman: true, needsHumanSource: 'cache-desconocida' })]);
+    assert.equal(d.action, 'none');
+    assert.equal(d.reason, 'cache-desconocida');
+    assert.equal(d.suppression, 'cache', 'se contabiliza aparte del dedupe legítimo');
+
+    const { calls } = (() => {
+        const s = spyDeps();
+        executeDecisions([d], s.deps);
+        return s;
+    })();
+    assert.equal(calls.notify.length, 0, 'fail-closed va hacia el SILENCIO, no hacia el ruido');
+});
+
+test('CA-2: la caché nunca habilita un escalado — sólo suprime de más', () => {
+    // `false` = entrada FRESCA que explícitamente NO tiene el label → sí escala.
+    const escala = only([stuckIssue({ hasNeedsHuman: false, needsHumanSource: null })]);
+    assert.equal(escala.action, 'escalate');
+    // Cualquier string (incluida la desconocida) suprime.
+    const suprime = only([stuckIssue({ hasNeedsHuman: true, needsHumanSource: 'cache-desconocida' })]);
+    assert.equal(suprime.action, 'none');
+});
+
+test('CA-2: el tope de reintentos también respeta el fail-closed de caché', () => {
+    const d = only([stuckIssue({
+        requiredSkills: ['qa'],
+        deliverables: [{ skill: 'qa', state: 'listo', yaml: { resultado: 'rechazado' }, mtimeMs: NOW - HOUR }],
+        retryCounts: { qa: 99 },
+        hasNeedsHuman: true,
+        needsHumanSource: 'cache-desconocida',
+    })]);
+    assert.equal(d.action, 'none');
+    assert.equal(d.suppression, 'cache');
+});
+
+// -----------------------------------------------------------------------------
+// CA-3 — filtro de ola siempre activo
+// -----------------------------------------------------------------------------
+
+test('CA-3: issue varado fuera de la allowlist → none por ola, sin notificar', () => {
+    const d = only([stuckIssue({ issue: 742, allowed: false })]);
+    assert.equal(d.action, 'none');
+    assert.match(d.reason, /^fuera-de-allowlist/);
+    assert.equal(d.suppression, 'ola');
+
+    const { calls, deps } = spyDeps();
+    const res = executeDecisions([d], deps);
+    assert.equal(calls.notify.length, 0, 'el residuo fuera de ola no molesta al operador');
+    assert.equal(res.suppressed.ola, 1);
+});
+
+test('CA-3: el filtro de ola gana sobre cualquier análisis del detector', () => {
+    // Aunque el issue esté perfectamente varado, fuera de ola no se toca.
+    const d = only([stuckIssue({ allowed: false, hasNeedsHuman: false })]);
+    assert.equal(d.action, 'none');
+    assert.equal(d.suppression, 'ola');
+});
+
+// -----------------------------------------------------------------------------
+// CA-4 — escalada única dentro de la ola
+// -----------------------------------------------------------------------------
+
+test('CA-4: issue varado de la ola escala UNA vez y el tick siguiente calla', () => {
+    // Tick 1: sin marker todavía.
+    const t1 = only([stuckIssue()]);
+    assert.equal(t1.action, 'escalate');
+
+    const s1 = spyDeps();
+    executeDecisions([t1], s1.deps);
+    assert.equal(s1.calls.escalate.length, 1);
+    assert.equal(s1.calls.notify.length, 1, 'exactamente UNA notificación');
+
+    // Tick 2: `escalate` plantó el marker → el dep lo reporta.
+    const t2 = only([stuckIssue({ hasNeedsHuman: true, needsHumanSource: 'marker' })]);
+    assert.equal(t2.action, 'none');
+
+    const s2 = spyDeps();
+    executeDecisions([t2], s2.deps);
+    assert.equal(s2.calls.notify.length, 0, 'el segundo tick NO vuelve a notificar');
+});
+
+// -----------------------------------------------------------------------------
+// CA-6 — escalar no destruye evidencia (contrato del shell)
+// -----------------------------------------------------------------------------
+
+test('CA-6: executeDecisions pasa pipeline y fase explícitos a escalate', () => {
+    // Sin `pipeline` explícito, `reportHumanBlock` buscaría el work-item activo
+    // y MOVERÍA el deliverable de `listo/` — la evidencia que el detector usa.
+    const d = only([stuckIssue()]);
+    const { calls, deps } = spyDeps();
+    executeDecisions([d], deps);
+
+    assert.equal(calls.escalate.length, 1);
+    assert.deepEqual(calls.escalate[0].meta, { pipeline: 'desarrollo', fase: 'verificacion' });
+});
+
+// -----------------------------------------------------------------------------
+// CA-7 / SEC-3 — el silencio es observable
+// -----------------------------------------------------------------------------
+
+test('CA-7: el agregado del tick distingue las tres causas de supresión', () => {
+    const { decisions } = plan([
+        stuckIssue({ issue: 742, allowed: false }),                                          // ola
+        stuckIssue({ issue: 1094, allowed: false }),                                         // ola
+        stuckIssue({ issue: 5209, hasNeedsHuman: true, needsHumanSource: 'cache-desconocida' }), // cache
+        stuckIssue({ issue: 5211, hasNeedsHuman: true, needsHumanSource: 'marker' }),         // dedupe
+        stuckIssue({ issue: 5242, active: false }),                                          // cerrado
+    ]);
+    const { deps } = spyDeps();
+    const res = executeDecisions(decisions, deps);
+
+    assert.equal(res.evaluados, 5);
+    assert.equal(res.escalated, 0);
+    assert.equal(res.requeued, 0);
+    assert.deepEqual(res.suppressed, { ola: 2, cache: 1, dedupe: 1, cerrado: 1, otro: 0 });
+});
+
+test('CA-7: un tick con evaluados > 0 y cero acciones deja rastro auditable', () => {
+    const d = only([stuckIssue({ allowed: false })]);
+    const { calls, deps } = spyDeps();
+    const res = executeDecisions([d], deps);
+
+    assert.equal(res.evaluados, 1);
+    assert.equal(res.escalated + res.requeued, 0);
+    const rec = calls.audit.find((r) => r && r.action === 'none');
+    assert.ok(rec, 'el `none` se audita aunque no notifique');
+    assert.equal(rec.suppression, 'ola', 'la causa del silencio queda en el registro');
+});
+
+test('CA-7: tick sin issues devuelve el agregado en cero (no undefined)', () => {
+    const { deps } = spyDeps();
+    const res = executeDecisions([], deps);
+    assert.equal(res.evaluados, 0);
+    assert.deepEqual(res.suppressed, { ola: 0, cache: 0, dedupe: 0, cerrado: 0, otro: 0 });
+});
+
+// -----------------------------------------------------------------------------
+// CA-UX-2 / CA-8 — el mensaje de escalación
+// -----------------------------------------------------------------------------
+
+test('CA-UX-2: el mensaje trae número, título, fase y la pregunta de destrabe', () => {
+    const msg = buildEscalationMessage(
+        { issue: 5209, pipeline: 'desarrollo', fase: 'verificacion', reason: 'ambigüedad' },
+        'fix(pipeline): algo que se varó',
+    );
+    assert.match(msg, /#5209/);
+    assert.match(msg, /fix\(pipeline\): algo que se varó/);
+    assert.match(msg, /desarrollo\/verificacion/);
+    assert.match(msg, /¿Cómo destrabo #5209\?/);
+    assert.ok(msg.split('\n').length >= 4, 'estructura por saltos de línea, no por Markdown');
+});
+
+test('CA-UX-2: sin título fresco en caché el mensaje sale igual (no inventa)', () => {
+    const msg = buildEscalationMessage(
+        { issue: 742, pipeline: 'desarrollo', fase: 'verificacion', reason: 'ambigüedad' },
+        null,
+    );
+    assert.match(msg, /#742/);
+    assert.ok(!msg.includes('📌'), 'no emite línea de título vacía');
+});
+
+test('CA-8: el mensaje no usa sintaxis Markdown para estructurar', () => {
+    const msg = buildEscalationMessage(
+        { issue: 5209, pipeline: 'desarrollo', fase: 'verificacion', reason: 'skill `raro`' },
+        'titulo',
+    );
+    assert.ok(!/\*\*|__|\[.+\]\(.+\)/.test(msg), 'sin negritas ni links Markdown');
+});
+
+test('CA-8: el reason se normaliza a una línea (viene de un nombre de archivo)', () => {
+    const msg = buildEscalationMessage(
+        { issue: 5209, pipeline: 'desarrollo', fase: 'verificacion', reason: 'linea1\nlinea2\n\nlinea3' },
+        null,
+    );
+    const infoLine = msg.split('\n').find((l) => l.startsWith('ℹ️'));
+    assert.equal(infoLine, 'ℹ️ linea1 linea2 linea3');
+});
+
+test('el título se usa sólo si `issueTitle` lo provee (dep opcional)', () => {
+    const d = only([stuckIssue()]);
+    const s = spyDeps();
+    executeDecisions([d], { ...s.deps, issueTitle: () => 'Titulo desde caché fresca' });
+    assert.match(s.calls.notify[0].msg, /Titulo desde caché fresca/);
+});
+
+test('un `issueTitle` que tira no rompe la notificación', () => {
+    const d = only([stuckIssue()]);
+    const s = spyDeps();
+    executeDecisions([d], { ...s.deps, issueTitle: () => { throw new Error('cache rota'); } });
+    assert.equal(s.calls.notify.length, 1, 'igual notifica: mejor sin título que sin alerta');
+});
+
+// -----------------------------------------------------------------------------
+// Línea roja (PO) — el fix es sobre a quién se avisa, nunca sobre auto-resolver
+// -----------------------------------------------------------------------------
+
+test('línea roja: ninguna supresión produce una acción de aprobación', () => {
+    const { decisions } = plan([
+        stuckIssue({ issue: 742, allowed: false }),
+        stuckIssue({ issue: 5209, hasNeedsHuman: true, needsHumanSource: 'cache-desconocida' }),
+    ]);
+    for (const d of decisions) {
+        assert.equal(d.action, 'none', 'suprimir = callarse, nunca completar la fase');
+        assert.ok(!('resultado' in d));
+    }
+});

--- a/.pipeline/lib/stuck-phase-reconciler-runner.js
+++ b/.pipeline/lib/stuck-phase-reconciler-runner.js
@@ -71,6 +71,12 @@ function buildIssuesContext(deps) {
             // flujo normal, no el reconciler.
             if (data.deliverables.length === 0) continue;
             const retryKey = `${issue}|${fase}`;
+            // #5396 — `hasNeedsHuman` ya no es booleano: devuelve el ORIGEN de la
+            // supresión (`'marker'|'cola'|'cache-label'|'cache-desconocida'|false`)
+            // para que el dedupe sea auditable y `cache-desconocida` (fail-closed)
+            // se distinga de un dedupe legítimo. Un dep legacy que devuelva boolean
+            // sigue funcionando: `needsHumanSource` queda en null.
+            const nh = deps.hasNeedsHuman(issue);
             out.push({
                 issue: Number(issue),
                 pipeline, fase,
@@ -78,7 +84,8 @@ function buildIssuesContext(deps) {
                 deliverables: data.deliverables,
                 liveSkills: data.liveSkills,
                 liveElsewhere: !!deps.issueLiveElsewhere(issue, pipeline, fase),
-                hasNeedsHuman: !!deps.hasNeedsHuman(issue),
+                hasNeedsHuman: !!nh,
+                needsHumanSource: (typeof nh === 'string' && nh) ? nh : null,
                 retryCounts: (deps.retryState && deps.retryState[retryKey]) || {},
                 allowed: deps.isAllowed ? !!deps.isAllowed(issue) : true,
                 // active: solo actuar sobre issues confirmados OPEN (no residuo
@@ -100,7 +107,14 @@ function runStuckPhaseReconciler(deps, opts = {}) {
 
     const issues = buildIssuesContext(deps);
     if (issues.length === 0) {
-        return { requeued: 0, escalated: 0, skipped: 0, decisions: [] };
+        // #5396 CA-7 — el agregado viaja SIEMPRE, incluso en el tick vacío: el
+        // caller loguea `evaluados: 0` y así se distingue "no había nada varado"
+        // de "el reconciler está muerto".
+        return {
+            requeued: 0, escalated: 0, skipped: 0, decisions: [],
+            evaluados: 0,
+            suppressed: { ola: 0, cache: 0, dedupe: 0, cerrado: 0, otro: 0 },
+        };
     }
 
     const { decisions, retryUpdates } = planReconciliation({
@@ -118,6 +132,7 @@ function runStuckPhaseReconciler(deps, opts = {}) {
         notify: deps.notify,
         audit: deps.audit,
         workItemExists: deps.workItemExists,
+        issueTitle: deps.issueTitle,
     });
 
     // Persistir contadores de reintento (merge). Clave de retryUpdates:

--- a/.pipeline/lib/stuck-phase-reconciler.js
+++ b/.pipeline/lib/stuck-phase-reconciler.js
@@ -37,6 +37,29 @@ const { analyzeStuckIssue } = require('./stuck-phase-detector');
 const DEFAULT_MAX_REQUEUE_ATTEMPTS = 2;
 const DEFAULT_CAP_PER_TICK = 5;
 const MONO_SKILL_PHASES = new Set(['dev', 'build', 'entrega']);
+// #5396 CA-7 — causas de silencio que el tick reporta por separado.
+const SUPPRESSION_BUCKETS = new Set(['ola', 'cache', 'dedupe', 'cerrado', 'otro']);
+
+/** Normaliza texto libre a una línea (el `reason` interpola nombres de archivo). */
+function oneLine(s, max = 220) {
+    return String(s == null ? '' : s).replace(/\s+/g, ' ').trim().slice(0, max);
+}
+
+/**
+ * #5396 CA-UX-2 — mensaje de escalación legible para el operador: número,
+ * título (sólo si hay entrada FRESCA en caché), fase y la pregunta concreta de
+ * destrabe. Sin Markdown — la estructura la dan los saltos de línea y los emojis
+ * (CA-8/SEC-4: el `reason` interpola un skill derivado de un nombre de archivo,
+ * contenido no confiable, y viaja en texto plano).
+ */
+function buildEscalationMessage(d, title) {
+    const lines = [`🙋 Self-healing: #${d.issue} necesita tu decisión`];
+    if (title) lines.push(`📌 ${oneLine(title, 120)}`);
+    lines.push(`📂 ${d.pipeline ? `${d.pipeline}/` : ''}${d.fase}`);
+    lines.push(`❓ ¿Cómo destrabo #${d.issue}? (rechazo / cancelado / corrupto)`);
+    lines.push(`ℹ️ ${oneLine(d.reason)}`);
+    return lines.join('\n');
+}
 
 /**
  * Decide la acción efectiva para UN issue aplicando las guardas.
@@ -47,18 +70,21 @@ function decideForIssue(it, cfg) {
 
     // Guard mono-skill (Arq P0-1)
     if (cfg.monoSkillPhases.has(it.fase) || it.isMonoSkill) {
-        return base('none', 'fase-mono-skill');
+        return base('none', 'fase-mono-skill', { suppression: 'otro' });
     }
     // Guard cross-phase (Arq P0-2)
     if (it.liveElsewhere) {
-        return base('none', 'vivo-en-otra-fase');
+        return base('none', 'vivo-en-otra-fase', { suppression: 'otro' });
     }
     // Guard allowlist: solo la OLA ACTUAL. Los issues fuera de la allowlist son
     // backlog dormido que el operador excluyó a propósito — el reconciler NO los
     // toca (ni requeue ni escalate), sino spamea needs-human sobre issues muertos.
     // (Hallazgo del dry-run contra estado real; endurece PO SG-5.)
+    // #5396 CA-3 — el filtro de ola ahora aplica SIEMPRE (antes `isAllowed` sólo
+    // se poblaba bajo pausa parcial y fuera de pausa el reconciler barría todo el
+    // backlog histórico). `suppression: 'ola'` distingue este silencio del resto.
     if (it.allowed === false) {
-        return base('none', 'fuera-de-allowlist (backlog dormido, no tocar)');
+        return base('none', 'fuera-de-allowlist (backlog dormido, no tocar)', { suppression: 'ola' });
     }
     // Guard issue-cerrado: las fases se llenan de RESIDUO de issues ya CLOSED/
     // mergeados (work-items stub). Escalar/re-encolar un issue cerrado es ruido.
@@ -66,7 +92,7 @@ function decideForIssue(it, cfg) {
     // notFound, o desconocido) → no tocar. (Hallazgo del dry-run: #4510/#4533/#4536
     // CLOSED con residuo se escalaban.)
     if (it.active !== true) {
-        return base('none', 'issue-cerrado-o-inactivo (residuo, no tocar)');
+        return base('none', 'issue-cerrado-o-inactivo (residuo, no tocar)', { suppression: 'cerrado' });
     }
 
     const analysis = analyzeStuckIssue({
@@ -77,10 +103,25 @@ function decideForIssue(it, cfg) {
         staleThresholdMs: Number.isFinite(it.staleThresholdMs) ? it.staleThresholdMs : cfg.staleThresholdMs,
     });
 
-    if (analysis.action === 'none') return base('none', analysis.reason);
+    if (analysis.action === 'none') return base('none', analysis.reason, { suppression: 'otro' });
+
+    // #5396 CA-1/CA-2 — el dedupe deja explícito DE DÓNDE viene la supresión.
+    // `needsHumanSource` es el origen que reporta el dep `hasNeedsHuman`:
+    //   'marker'            → marker físico en `bloqueado-humano/` (fuente de verdad)
+    //   'cola'              → orden de label todavía sin drenar
+    //   'cache-label'       → entrada FRESCA del title-cache con el label puesto
+    //   'cache-desconocida' → entrada ausente o stale ⇒ fail-closed hacia el
+    //                          SILENCIO, nunca hacia el ruido (CA-2)
+    const dedupe = (prefix) => {
+        const src = it.needsHumanSource;
+        if (src === 'cache-desconocida') {
+            return base('none', 'cache-desconocida', { suppression: 'cache' });
+        }
+        return base('none', `${prefix} (dedupe: ${src || 'desconocido'})`, { suppression: 'dedupe' });
+    };
 
     if (analysis.action === 'escalate') {
-        if (it.hasNeedsHuman) return base('none', 'ya-escalado (dedupe)');
+        if (it.hasNeedsHuman) return dedupe('ya-escalado');
         return base('escalate', analysis.reason, { consumesTick: true });
     }
 
@@ -90,12 +131,12 @@ function decideForIssue(it, cfg) {
     const capped = skills.filter((s) => (retryCounts[s] || 0) >= cfg.maxRequeueAttempts);
     if (capped.length > 0) {
         // Skill(s) agotaron reintentos → escalar (no re-encolar para siempre, Arq P0-3).
-        if (it.hasNeedsHuman) return base('none', 'tope-reintentos + ya-escalado (dedupe)');
+        if (it.hasNeedsHuman) return dedupe('tope-reintentos + ya-escalado');
         return base('escalate', `tope de reintentos (${cfg.maxRequeueAttempts}) alcanzado para: ${capped.join(',')}`, { consumesTick: true });
     }
     // Pausa: no re-encolar (no spawnear), PO SG-5. El escalate SÍ sigue permitido
     // para issues de la ola (ya filtrados por allowlist arriba).
-    if (cfg.paused) return base('none', 'pipeline-en-pausa (no re-encola)');
+    if (cfg.paused) return base('none', 'pipeline-en-pausa (no re-encola)', { suppression: 'otro' });
 
     return base('requeue', analysis.reason, { skills, consumesTick: true });
 }
@@ -136,11 +177,11 @@ function planReconciliation(ctx = {}) {
 
         // Cap por tick: solo las acciones REALES (escalate/requeue) consumen cupo.
         if (d.consumesTick && actionsThisTick >= cfg.capPerTick) {
-            decisions.push({ ...base, action: 'none', reason: 'cap-por-tick-alcanzado' });
+            decisions.push({ ...base, action: 'none', reason: 'cap-por-tick-alcanzado', suppression: 'otro' });
             continue;
         }
 
-        decisions.push({ ...base, action: d.action, skills: d.skills, reason: d.reason });
+        decisions.push({ ...base, action: d.action, skills: d.skills, reason: d.reason, suppression: d.suppression });
         if (d.consumesTick) {
             actionsThisTick += 1;
             if (d.action === 'requeue') {
@@ -164,12 +205,21 @@ function planReconciliation(ctx = {}) {
  *   @param {(msg)=>void} [deps.notify]
  *   @param {(record)=>void} [deps.audit]
  *   @param {(pipeline,fase,skill,issue)=>boolean} [deps.workItemExists] re-check idempotente
- * @returns {{requeued:number, escalated:number, skipped:number}}
+ *   @param {(issue)=>string|null} [deps.issueTitle] título para el mensaje (CA-UX-2)
+ * @returns {{requeued:number, escalated:number, skipped:number, evaluados:number,
+ *            suppressed:{ola:number,cache:number,dedupe:number,cerrado:number,otro:number}}}
  */
 function executeDecisions(decisions, deps = {}) {
     let requeued = 0, escalated = 0, skipped = 0;
+    // #5396 CA-7 (SEC-3) — desglose de POR QUÉ el tick estuvo callado. Sin esto,
+    // "no notificó nada" es indistinguible entre "todo sano" y "el self-healing
+    // está muerto" — que es exactamente el estado que nadie detectó en producción.
+    const suppressed = { ola: 0, cache: 0, dedupe: 0, cerrado: 0, otro: 0 };
     const audit = (rec) => { try { if (deps.audit) deps.audit(rec); } catch { /* best-effort */ } };
-    const notify = (msg) => { try { if (deps.notify) deps.notify(msg); } catch { /* best-effort */ } };
+    const notify = (msg, meta) => { try { if (deps.notify) deps.notify(msg, meta); } catch { /* best-effort */ } };
+    const titleOf = (issue) => {
+        try { return (deps.issueTitle && deps.issueTitle(issue)) || null; } catch { return null; }
+    };
 
     for (const d of (decisions || [])) {
         if (d.action === 'requeue') {
@@ -186,25 +236,38 @@ function executeDecisions(decisions, deps = {}) {
             }
             requeued += 1;
             audit({ action: 'requeue', issue: d.issue, fase: d.fase, skills: d.skills, reason: d.reason });
-            notify(`🔧 Self-healing: re-encolé ${(d.skills || []).join(',')} de #${d.issue} (${d.fase}) — ${d.reason}`);
+            notify(
+                `🔧 Self-healing: re-encolé ${(d.skills || []).join(',')} de #${d.issue} (${d.fase}) — ${d.reason}`,
+                { issue: d.issue, fase: d.fase, pipeline: d.pipeline, action: 'requeue' },
+            );
         } else if (d.action === 'escalate') {
-            try { deps.escalate(d.issue, d.reason); } catch (e) { audit({ ...d, error: String(e && e.message).slice(0, 120) }); }
+            // El escalate necesita `pipeline`/`fase` explícitos: sin ellos
+            // `reportHumanBlock` buscaría el work-item activo y podría MOVER el
+            // deliverable de `listo/`, destruyendo la evidencia (riesgo #1).
+            try { deps.escalate(d.issue, d.reason, { pipeline: d.pipeline, fase: d.fase }); }
+            catch (e) { audit({ ...d, error: String(e && e.message).slice(0, 120) }); }
             escalated += 1;
             audit({ action: 'escalate', issue: d.issue, fase: d.fase, reason: d.reason });
-            notify(`🙋 Self-healing: #${d.issue} (${d.fase}) necesita tu decisión — ${d.reason}`);
+            notify(buildEscalationMessage(d, titleOf(d.issue)), {
+                issue: d.issue, fase: d.fase, pipeline: d.pipeline, action: 'escalate',
+            });
         } else {
             skipped += 1;
+            const bucket = SUPPRESSION_BUCKETS.has(d.suppression) ? d.suppression : 'otro';
+            suppressed[bucket] += 1;
             // Los `none` se auditan a nivel debug (razón) pero no notifican.
-            audit({ action: 'none', issue: d.issue, fase: d.fase, reason: d.reason });
+            audit({ action: 'none', issue: d.issue, fase: d.fase, reason: d.reason, suppression: bucket });
         }
     }
-    return { requeued, escalated, skipped };
+    return { requeued, escalated, skipped, suppressed, evaluados: (decisions || []).length };
 }
 
 module.exports = {
     planReconciliation,
     executeDecisions,
     decideForIssue,
+    buildEscalationMessage,
+    SUPPRESSION_BUCKETS,
     MONO_SKILL_PHASES,
     DEFAULT_MAX_REQUEUE_ATTEMPTS,
     DEFAULT_CAP_PER_TICK,

--- a/.pipeline/lib/stuck-phase-reconciler.js
+++ b/.pipeline/lib/stuck-phase-reconciler.js
@@ -32,13 +32,45 @@
 
 'use strict';
 
-const { analyzeStuckIssue } = require('./stuck-phase-detector');
+const { analyzeStuckIssue, classifySkill } = require('./stuck-phase-detector');
 
 const DEFAULT_MAX_REQUEUE_ATTEMPTS = 2;
 const DEFAULT_CAP_PER_TICK = 5;
 const MONO_SKILL_PHASES = new Set(['dev', 'build', 'entrega']);
 // #5396 CA-7 — causas de silencio que el tick reporta por separado.
 const SUPPRESSION_BUCKETS = new Set(['ola', 'cache', 'dedupe', 'cerrado', 'otro']);
+// #5396 rev-1 — estados que el detector considera AMBIGUOS y por los que escala.
+// Son los mismos que `analyzeStuckIssue` agrupa en su rama `escalate`.
+const AMBIGUOUS_STATUSES = new Set(['rejected', 'cancelled', 'corrupt']);
+
+/**
+ * #5396 rev-1 — skills REALES de la fase que motivaron la escalación.
+ *
+ * POR QUÉ EXISTE
+ * --------------
+ * El marker de bloqueo se plantaba con un skill sintético (`reconciler`) que no
+ * pertenece a `skills_por_fase[fase]`. Al destrabar (`unblockIssue` o los
+ * quick-actions de Telegram) el marker se mueve a `pendiente/` y entra al
+ * despacho del Pulpo, donde el INVARIANTE skill∈fase lo rebota y manda un
+ * Telegram POR TICK — exactamente el ruido que este issue viene a eliminar.
+ *
+ * Devolver los skills ambiguos reales (`rejected`/`cancelled`/`corrupt`) le da
+ * al marker un camino de dispatch válido: son los mismos que el carril
+ * `requeue` ya usa, y al destrabar re-corre el agente que quedó sin veredicto.
+ *
+ * Se reusa `classifySkill` (ya exportado por el detector) en vez de parsear el
+ * `reason`: CA-10 exige que `stuck-phase-detector.js` NO aparezca en el diff.
+ *
+ * @returns {string[]} subconjunto ORDENADO de `requiredSkills` (determinista)
+ */
+function ambiguousSkillsOf(it) {
+    const required = Array.isArray(it.requiredSkills) ? it.requiredSkills : [];
+    const deliverables = Array.isArray(it.deliverables) ? it.deliverables : [];
+    const live = it.liveSkills instanceof Set
+        ? it.liveSkills
+        : new Set(Array.isArray(it.liveSkills) ? it.liveSkills : []);
+    return required.filter((s) => AMBIGUOUS_STATUSES.has(classifySkill(s, deliverables, live).status));
+}
 
 /** Normaliza texto libre a una línea (el `reason` interpola nombres de archivo). */
 function oneLine(s, max = 220) {
@@ -122,7 +154,11 @@ function decideForIssue(it, cfg) {
 
     if (analysis.action === 'escalate') {
         if (it.hasNeedsHuman) return dedupe('ya-escalado');
-        return base('escalate', analysis.reason, { consumesTick: true });
+        // #5396 rev-1 — `skills` viaja hasta el dep `escalate` para que el marker
+        // se plante con un skill REAL de la fase (camino de dispatch válido al
+        // destrabar). Puede venir vacío en el caso 'estado indeterminado'; el
+        // cableado resuelve el fallback contra `skills_por_fase`.
+        return base('escalate', analysis.reason, { consumesTick: true, skills: ambiguousSkillsOf(it) });
     }
 
     // requeue
@@ -132,7 +168,10 @@ function decideForIssue(it, cfg) {
     if (capped.length > 0) {
         // Skill(s) agotaron reintentos → escalar (no re-encolar para siempre, Arq P0-3).
         if (it.hasNeedsHuman) return dedupe('tope-reintentos + ya-escalado');
-        return base('escalate', `tope de reintentos (${cfg.maxRequeueAttempts}) alcanzado para: ${capped.join(',')}`, { consumesTick: true });
+        // #5396 rev-1 — los skills que agotaron reintentos SON los del carril
+        // requeue: ya están en `skills_por_fase[fase]`, así que el marker que se
+        // planta con ellos es despachable al destrabar.
+        return base('escalate', `tope de reintentos (${cfg.maxRequeueAttempts}) alcanzado para: ${capped.join(',')}`, { consumesTick: true, skills: capped });
     }
     // #5396 — un issue con bloqueo humano vigente NO se re-encola. Antes de este
     // issue el dedupe sólo cubría el carril `escalate`, porque `escalate` encolaba
@@ -261,6 +300,10 @@ function executeDecisions(decisions, deps = {}) {
                 // #5396 retorna true/false explícitamente.
                 escalationSucceeded = deps.escalate(d.issue, d.reason, {
                     pipeline: d.pipeline, fase: d.fase,
+                    // #5396 rev-1 — skills reales que motivaron la escalación. El
+                    // cableado elige entre ellos el que planta en el marker, para
+                    // que al destrabar el work-item tenga dispatch válido.
+                    skills: d.skills || [],
                 }) !== false;
             } catch (e) {
                 audit({ ...d, error: String(e && e.message).slice(0, 120) });
@@ -291,6 +334,8 @@ module.exports = {
     executeDecisions,
     decideForIssue,
     buildEscalationMessage,
+    ambiguousSkillsOf,
+    AMBIGUOUS_STATUSES,
     SUPPRESSION_BUCKETS,
     MONO_SKILL_PHASES,
     DEFAULT_MAX_REQUEUE_ATTEMPTS,

--- a/.pipeline/lib/stuck-phase-reconciler.js
+++ b/.pipeline/lib/stuck-phase-reconciler.js
@@ -134,6 +134,16 @@ function decideForIssue(it, cfg) {
         if (it.hasNeedsHuman) return dedupe('tope-reintentos + ya-escalado');
         return base('escalate', `tope de reintentos (${cfg.maxRequeueAttempts}) alcanzado para: ${capped.join(',')}`, { consumesTick: true });
     }
+    // #5396 — un issue con bloqueo humano vigente NO se re-encola. Antes de este
+    // issue el dedupe sólo cubría el carril `escalate`, porque `escalate` encolaba
+    // el label y casi nunca existía un marker físico. Ahora que `escalate` planta
+    // marker vía `reportHumanBlock` (con `moveFromActive: false`, o sea el
+    // deliverable sigue en `listo/` y el issue se sigue evaluando), el carril
+    // `requeue` pasó a ser alcanzable con un bloqueo vivo: spawnearía un agente
+    // sobre un issue que está esperando decisión humana. Eso viola la línea roja
+    // del issue ("ante duda: humano"), así que el bloqueo gana sobre el reintento.
+    if (it.hasNeedsHuman) return dedupe('bloqueado-humano');
+
     // Pausa: no re-encolar (no spawnear), PO SG-5. El escalate SÍ sigue permitido
     // para issues de la ola (ya filtrados por allowlist arriba).
     if (cfg.paused) return base('none', 'pipeline-en-pausa (no re-encola)', { suppression: 'otro' });

--- a/.pipeline/lib/stuck-phase-reconciler.js
+++ b/.pipeline/lib/stuck-phase-reconciler.js
@@ -201,7 +201,7 @@ function planReconciliation(ctx = {}) {
  * @param {Array} decisions  salida de planReconciliation
  * @param {object} deps
  *   @param {(pipeline,fase,skill,issue)=>void} deps.requeueWorkItem  (idempotente por nombre)
- *   @param {(issue,reason)=>void} deps.escalate  (agrega needs-human, idempotente)
+ *   @param {(issue,reason)=>boolean|void} deps.escalate  false si no pudo registrar needs-human
  *   @param {(msg)=>void} [deps.notify]
  *   @param {(record)=>void} [deps.audit]
  *   @param {(pipeline,fase,skill,issue)=>boolean} [deps.workItemExists] re-check idempotente
@@ -244,8 +244,22 @@ function executeDecisions(decisions, deps = {}) {
             // El escalate necesita `pipeline`/`fase` explícitos: sin ellos
             // `reportHumanBlock` buscaría el work-item activo y podría MOVER el
             // deliverable de `listo/`, destruyendo la evidencia (riesgo #1).
-            try { deps.escalate(d.issue, d.reason, { pipeline: d.pipeline, fase: d.fase }); }
-            catch (e) { audit({ ...d, error: String(e && e.message).slice(0, 120) }); }
+            let escalationSucceeded = false;
+            try {
+                // `false` es un fallo observable. Se conserva compatibilidad con
+                // deps anteriores que no retornaban valor; el cableado real de
+                // #5396 retorna true/false explícitamente.
+                escalationSucceeded = deps.escalate(d.issue, d.reason, {
+                    pipeline: d.pipeline, fase: d.fase,
+                }) !== false;
+            } catch (e) {
+                audit({ ...d, error: String(e && e.message).slice(0, 120) });
+            }
+            if (!escalationSucceeded) {
+                audit({ ...d, error: 'no se pudo registrar el bloqueo humano' });
+                skipped += 1;
+                continue;
+            }
             escalated += 1;
             audit({ action: 'escalate', issue: d.issue, fase: d.fase, reason: d.reason });
             notify(buildEscalationMessage(d, titleOf(d.issue)), {

--- a/.pipeline/lib/stuck-phase-reconciler.test.js
+++ b/.pipeline/lib/stuck-phase-reconciler.test.js
@@ -171,6 +171,15 @@ test('execute escalate: llama escalate + notifica', () => {
     assert.equal(res.escalated, 1);
     assert.equal(deps.calls.notify.length, 1);
 });
+test('execute escalate: si no registra el bloqueo, no contabiliza ni notifica', () => {
+    const deps = mockDeps();
+    deps.escalate = () => false;
+    const res = executeDecisions([{ action: 'escalate', issue: 4534, pipeline: 'desarrollo', fase: 'validacion', reason: 'ambiguo' }], deps);
+    assert.equal(res.escalated, 0);
+    assert.equal(res.skipped, 1);
+    assert.equal(deps.calls.notify.length, 0);
+    assert.ok(deps.calls.audit.some((a) => a.error === 'no se pudo registrar el bloqueo humano'));
+});
 test('execute none: audita pero NO notifica', () => {
     const deps = mockDeps();
     executeDecisions([{ action: 'none', issue: 1, fase: 'validacion', reason: 'reciente' }], deps);

--- a/.pipeline/lib/stuck-reconciler-deps.js
+++ b/.pipeline/lib/stuck-reconciler-deps.js
@@ -280,7 +280,7 @@ function buildStuckReconcilerDeps(opts = {}) {
             // SEC-5.2 — validar ANTES del path.join que hace reportHumanBlock.
             if (!Number.isInteger(n) || n <= 0) {
                 log('reconciler', `escalate: issue inválido (${String(issue).slice(0, 40)}) — ignorado`);
-                return;
+                return false;
             }
             const phase = String(meta.fase || '').trim();
             const pipeline = String(meta.pipeline || '').trim();
@@ -288,7 +288,7 @@ function buildStuckReconcilerDeps(opts = {}) {
                 // Fail-closed: sin pipeline explícito, `reportHumanBlock` haría
                 // `findActiveMarker` y podría mover el deliverable de `listo/`.
                 log('reconciler', `escalate #${n}: falta pipeline/fase explícitos — no se escala (protege evidencia)`);
-                return;
+                return false;
             }
             try {
                 humanBlock.reportHumanBlock({
@@ -302,8 +302,10 @@ function buildStuckReconcilerDeps(opts = {}) {
                     // `precondition` omitido → normalizePrecondition ⇒ HUMAN_JUDGMENT
                     // (fail-closed, #4748): nunca auto-re-evaluable.
                 });
+                return true;
             } catch (e) {
                 log('reconciler', `error escalando #${n}: ${e && e.message}`);
+                return false;
             }
         },
 

--- a/.pipeline/lib/stuck-reconciler-deps.js
+++ b/.pipeline/lib/stuck-reconciler-deps.js
@@ -36,6 +36,10 @@
 //    el `reason` interpola un `skill` derivado de un nombre de archivo.
 //  - SEC-5.2: `escalate` valida el issue como entero positivo ANTES del
 //    `path.join` que hace `reportHumanBlock`.
+//  - #5396 rev-1: el skill del marker SIEMPRE pertenece a
+//    `skills_por_fase[fase]` — la misma lista que valida el invariante de
+//    dispatch de `pulpo.js`. Un marker con skill no despachable convierte la
+//    vía de destrabe en un generador de spam de Telegram por tick.
 //  - Línea roja (PO): nada de esto resuelve la ambigüedad solo. El fix es sobre
 //    A QUIÉN se le avisa y CUÁNTAS VECES, nunca sobre auto-completar una fase.
 // =============================================================================
@@ -61,9 +65,23 @@ const DEFAULT_PARALLEL_PHASES = Object.freeze([
 ]);
 
 const NEEDS_HUMAN_LABEL = 'needs-human';
-// Skill sintético del marker que planta el reconciler. Nombre fijo y explícito
-// (riesgo #5): `listBlockedIssues()` y el dashboard parsean `<issue>.<skill>`.
-const RECONCILER_SKILL = 'reconciler';
+// #5396 rev-1 — El marker YA NO usa un skill sintético.
+//
+// Antes se plantaba `<issue>.reconciler`. Ese nombre no existe en
+// `skills_por_fase[fase]`, así que al destrabar (`unblockIssue`, o los botones
+// 'Aprobar (unblock)' / 'Priorizar' de la propia notificación) el marker caía en
+// `pendiente/` y entraba al despacho, donde el INVARIANTE skill∈fase de
+// `pulpo.js` lo rebotaba a `pendiente/` SIN registrar cooldown y mandaba un
+// Telegram "⛔ Pipeline bloqueó lanzamiento de reconciler:#N" en CADA tick.
+// O sea: la vía de salida del bloqueo generaba exactamente el spam que este
+// issue viene a eliminar.
+//
+// Ahora el skill sale de los skills REALES que motivaron la escalación (los
+// mismos que usa el carril `requeue`) y se valida contra `skills_por_fase[fase]`
+// antes de plantar el marker. La procedencia se conserva en el `reason` con el
+// prefijo `[self-healing]`, que es lo que el dashboard y `listBlockedIssues()`
+// muestran junto al `<issue>.<skill>`.
+const SELF_HEALING_REASON_PREFIX = '[self-healing]';
 const DEFAULT_SILENT_STREAK_THRESHOLD = 6; // ≈1h con ticks de 10 min
 
 function labelNameOf(l) {
@@ -129,6 +147,15 @@ function buildStuckReconcilerDeps(opts = {}) {
     const titleCachePath = path.join(PIPELINE, '.issue-title-cache.json');
     const stuckStateFile = path.join(PIPELINE, '.stuck-reconciler-state.json');
     const allPhasesOf = (p) => (config.pipelines && config.pipelines[p] && config.pipelines[p].fases) || [];
+    // MISMA fuente que el INVARIANTE skill∈fase de `pulpo.js:8596`
+    // (`config.pipelines[pipeline].skills_por_fase[fase]`). Que `escalate` valide
+    // contra esta lista es lo que garantiza que el marker sea despachable al
+    // destrabar: si acá entra, el invariante del Pulpo no lo puede rebotar.
+    const skillsOfPhase = (p, f) => {
+        const spf = config.pipelines && config.pipelines[p] && config.pipelines[p].skills_por_fase;
+        const list = spf && spf[f];
+        return Array.isArray(list) ? list : [];
+    };
 
     // ---- lectores del title-cache (hint, nunca autoridad — SEC-1) -----------
     const readTitleCache = () => {
@@ -172,9 +199,7 @@ function buildStuckReconcilerDeps(opts = {}) {
     return {
         nowMs,
         parallelPhases,
-        requiredSkillsFor: (p, f) => (config.pipelines && config.pipelines[p]
-            && config.pipelines[p].skills_por_fase
-            && config.pipelines[p].skills_por_fase[f]) || [],
+        requiredSkillsFor: skillsOfPhase,
         listPhaseFiles: (p, f, state) => {
             const dir = path.join(fasePath(p, f), state);
             return (listWorkFiles(dir) || []).map((wf) => {
@@ -290,14 +315,40 @@ function buildStuckReconcilerDeps(opts = {}) {
                 log('reconciler', `escalate #${n}: falta pipeline/fase explícitos — no se escala (protege evidencia)`);
                 return false;
             }
+
+            // #5396 rev-1 — ELEGIR UN SKILL CON CAMINO DE DISPATCH VÁLIDO.
+            //
+            // El marker termina en `pendiente/<issue>.<skill>` cuando el operador
+            // destraba (`unblockIssue` / quick-actions). Si ese `<skill>` no está
+            // en `skills_por_fase[fase]`, `pulpo.js` lo rebota contra el
+            // INVARIANTE y notifica por Telegram en cada tick, sin cooldown.
+            // Por eso el skill se valida contra la MISMA lista que usa el
+            // invariante, y si no hay ninguno válido NO se escala (fail-closed:
+            // mejor un log ruidoso que un bloqueo sin salida que spamea).
+            const permitidos = skillsOfPhase(pipeline, phase);
+            const candidatos = Array.isArray(meta.skills) ? meta.skills.map((s) => String(s || '').trim()) : [];
+            // 1º el skill ambiguo/agotado que motivó la escalación (re-corre justo
+            // el que quedó sin veredicto); 2º fallback determinista al primero de
+            // la fase, para el caso 'estado indeterminado' que no imputa skill.
+            const blockSkill = candidatos.find((s) => permitidos.includes(s)) || permitidos[0] || null;
+            if (!blockSkill) {
+                log('reconciler', `escalate #${n}: ${pipeline}/${phase} sin skills_por_fase — no se escala (el marker no tendría dispatch al destrabar)`);
+                return false;
+            }
+
             try {
                 humanBlock.reportHumanBlock({
                     issue: n,
-                    skill: RECONCILER_SKILL,
+                    // Skill REAL de la fase (no el sintético `reconciler`): al
+                    // destrabar, el work-item es despachable.
+                    skill: blockSkill,
                     phase,
                     pipeline,                 // explícito → no busca marker activo
                     moveFromActive: false,    // ⚠️ no mover el deliverable de `listo/`
-                    reason: String(reason || 'fase varada').slice(0, 500),
+                    // El prefijo conserva la PROCEDENCIA que antes daba el nombre
+                    // del skill sintético (riesgo #5): el dashboard y
+                    // `listBlockedIssues()` muestran el reason junto al marker.
+                    reason: `${SELF_HEALING_REASON_PREFIX} ${String(reason || 'fase varada')}`.slice(0, 500),
                     question: `¿Cómo destrabo #${n} en ${pipeline}/${phase}? (rechazo / cancelado / corrupto)`,
                     // `precondition` omitido → normalizePrecondition ⇒ HUMAN_JUDGMENT
                     // (fail-closed, #4748): nunca auto-re-evaluable.
@@ -380,5 +431,5 @@ module.exports = {
     evaluateSilenceHealth,
     DEFAULT_PARALLEL_PHASES,
     DEFAULT_SILENT_STREAK_THRESHOLD,
-    RECONCILER_SKILL,
+    SELF_HEALING_REASON_PREFIX,
 };

--- a/.pipeline/lib/stuck-reconciler-deps.js
+++ b/.pipeline/lib/stuck-reconciler-deps.js
@@ -1,0 +1,382 @@
+// =============================================================================
+// stuck-reconciler-deps.js — Cableado de dependencias del reconciler de fases
+// varadas (#5396, extraído de `pulpo.js`).
+//
+// POR QUÉ EXISTE ESTE MÓDULO (SEC-0)
+// -----------------------------------
+// El objeto `deps` vivía inline en `pulpo.js` (16k líneas, con side-effects al
+// requerirlo). Eso hacía IMPOSIBLE testear el cableado real: los tests mockeaban
+// `allowed: true` y "pasaban" mientras producción seguía rota. Acá el cableado es
+// importable y verificable sin cargar el Pulpo entero.
+//
+// LOS TRES DEFECTOS QUE ARREGLA (#5396)
+// --------------------------------------
+//  1. `isAllowed` reimplementaba a mano la política de ola leyendo
+//     `ppMode.allowed_issues` (snake) cuando `getPipelineMode()` normaliza a
+//     `allowedIssues` (camel). Efecto real: fail-OPEN fuera de ola (barría todo
+//     el backlog histórico) y fail-CLOSED dentro de ola (self-healing muerto
+//     justo cuando hace falta). Ahora delega en la API canónica
+//     `partialPause.isIssueAllowedInState` (#5060).
+//  2. `hasNeedsHuman` sólo miraba señales TRANSITORIAS (cola de GitHub sin
+//     drenar + marker). Drenada la cola, el dedupe se apagaba y el mismo issue
+//     se re-escalaba y re-notificaba en cada tick. Ahora devuelve el ORIGEN de
+//     la supresión y consulta además el title-cache como hint fresco.
+//  3. `escalate` encolaba SÓLO el label y nunca creaba el marker físico. Sin
+//     marker, `servicio-reconciler.js` lo veía como `needs-human` fantasma,
+//     encolaba `remove-label` ~30s después y se cerraba un bucle add/remove.
+//     Ahora el bloqueo lo registra su dueño: `humanBlock.reportHumanBlock`.
+//
+// INVARIANTES DE SEGURIDAD
+// ------------------------
+//  - SEC-1: el marker físico es la FUENTE DE VERDAD; el title-cache es un HINT
+//    que sólo puede SUPRIMIR de más, jamás habilitar un escalado.
+//  - SEC-2: la frescura del cache se resuelve reusando `title-cache-freshness`
+//    (`needsRefetch`), sin inventar un TTL nuevo.
+//  - SEC-4: las notificaciones viajan en texto PLANO (sin `parse_mode`) porque
+//    el `reason` interpola un `skill` derivado de un nombre de archivo.
+//  - SEC-5.2: `escalate` valida el issue como entero positivo ANTES del
+//    `path.join` que hace `reportHumanBlock`.
+//  - Línea roja (PO): nada de esto resuelve la ambigüedad solo. El fix es sobre
+//    A QUIÉN se le avisa y CUÁNTAS VECES, nunca sobre auto-completar una fase.
+// =============================================================================
+
+'use strict';
+
+const fsDefault = require('fs');
+const path = require('path');
+
+const partialPauseDefault = require('./partial-pause');
+const humanBlockDefault = require('./human-block');
+const processLivenessDefault = require('./process-liveness');
+const { needsRefetch: needsRefetchDefault } = require('./title-cache-freshness');
+
+// Fases PARALELAS de `desarrollo` (todos los skills deben estar, modelo
+// `resultado: aprobado`). Mono-skill (dev/build/entrega) quedan afuera. Las de
+// `definicion` (analisis/criterios) también: sus deliverables son dossiers que
+// NO usan `resultado: aprobado`, así que el detector los malinterpretaría.
+const DEFAULT_PARALLEL_PHASES = Object.freeze([
+    { pipeline: 'desarrollo', fase: 'validacion' },
+    { pipeline: 'desarrollo', fase: 'verificacion' },
+    { pipeline: 'desarrollo', fase: 'aprobacion' },
+]);
+
+const NEEDS_HUMAN_LABEL = 'needs-human';
+// Skill sintético del marker que planta el reconciler. Nombre fijo y explícito
+// (riesgo #5): `listBlockedIssues()` y el dashboard parsean `<issue>.<skill>`.
+const RECONCILER_SKILL = 'reconciler';
+const DEFAULT_SILENT_STREAK_THRESHOLD = 6; // ≈1h con ticks de 10 min
+
+function labelNameOf(l) {
+    if (typeof l === 'string') return l;
+    return (l && typeof l.name === 'string') ? l.name : null;
+}
+
+/**
+ * Cablea las dependencias reales del reconciler de fases varadas.
+ *
+ * Todo lo específico del Pulpo (helpers de paths, logger, sender de Telegram)
+ * entra por `deps` para que el cableado sea importable desde un test sin
+ * arrastrar `pulpo.js`. Los módulos de política (`partialPause`, `humanBlock`,
+ * `titleCacheFreshness`) se requieren acá por default y son sobreescribibles.
+ *
+ * @param {object} opts
+ * @param {object} opts.config           config.yaml ya parseado
+ * @param {string} opts.PIPELINE         raíz de `.pipeline`
+ * @param {string} opts.ROOT             raíz del repo (para los heartbeats)
+ * @param {string} opts.pauseFile        path del `.paused`
+ * @param {object} opts.ppMode           salida de `partialPause.getPipelineMode()`
+ * @param {number} [opts.nowMs]
+ * @param {number} [opts.staleMs]        umbral de liveness por mtime
+ * @param {Array}  [opts.parallelPhases]
+ * @param {object} [opts.deps]           inyecciones (fs, log, notify, helpers…)
+ * @returns {object} deps para `runStuckPhaseReconciler`
+ */
+function buildStuckReconcilerDeps(opts = {}) {
+    const config = opts.config || {};
+    const PIPELINE = opts.PIPELINE;
+    const ROOT = opts.ROOT;
+    const ppMode = opts.ppMode;
+    const nowMs = Number.isFinite(opts.nowMs) ? opts.nowMs : Date.now();
+    const staleMs = Number.isFinite(opts.staleMs) ? opts.staleMs : 15 * 60 * 1000;
+    const parallelPhases = Array.isArray(opts.parallelPhases) && opts.parallelPhases.length
+        ? opts.parallelPhases
+        : DEFAULT_PARALLEL_PHASES;
+
+    const d = opts.deps || {};
+    const fs = d.fs || fsDefault;
+    const partialPause = d.partialPause || partialPauseDefault;
+    const humanBlock = d.humanBlock || humanBlockDefault;
+    const processLiveness = d.processLiveness || processLivenessDefault;
+    const needsRefetch = d.needsRefetch || needsRefetchDefault;
+    const log = typeof d.log === 'function' ? d.log : () => { };
+    // Sender de Telegram con markup: `(text, replyMarkup, opts)`. Sin él, no se
+    // notifica (best-effort: nunca tumba el tick).
+    const sendTelegramWithMarkup = typeof d.sendTelegramWithMarkup === 'function'
+        ? d.sendTelegramWithMarkup
+        : null;
+
+    const fasePath = d.fasePath || ((p, f) => path.join(PIPELINE, p, f));
+    const listWorkFiles = d.listWorkFiles || ((dir) => {
+        try {
+            return fs.readdirSync(dir)
+                .filter((f) => !f.startsWith('.') && !f.endsWith('.gitkeep'))
+                .map((f) => ({ name: f, path: path.join(dir, f) }));
+        } catch { return []; }
+    });
+    const readYamlSafe = d.readYamlSafe || (() => ({}));
+
+    const ghQueueDir = path.join(PIPELINE, 'servicios', 'github', 'pendiente');
+    const titleCachePath = path.join(PIPELINE, '.issue-title-cache.json');
+    const stuckStateFile = path.join(PIPELINE, '.stuck-reconciler-state.json');
+    const allPhasesOf = (p) => (config.pipelines && config.pipelines[p] && config.pipelines[p].fases) || [];
+
+    // ---- lectores del title-cache (hint, nunca autoridad — SEC-1) -----------
+    const readTitleCache = () => {
+        try { return JSON.parse(fs.readFileSync(titleCachePath, 'utf8')); }
+        catch { return null; }
+    };
+    const readTitleCacheEntry = (issue) => {
+        const cache = readTitleCache();
+        if (!cache || typeof cache !== 'object') return null;
+        const e = cache[String(issue)];
+        return (e && typeof e === 'object') ? e : null;
+    };
+    /** Entrada sólo si es FRESCA según `needsRefetch` (SEC-2). */
+    const readFreshEntry = (issue) => {
+        const e = readTitleCacheEntry(issue);
+        if (!e) return null;
+        try { if (needsRefetch(e, { now: nowMs })) return null; }
+        catch { return null; } // predicado roto → tratar como desconocida
+        return e;
+    };
+
+    // ---- señales de "ya escalado" ------------------------------------------
+    /** Marker físico en `<pipeline>/<fase>/bloqueado-humano/<issue>.*` */
+    const hasBlockMarker = (issue) => {
+        for (const p of Object.keys(config.pipelines || {})) {
+            for (const f of allPhasesOf(p)) {
+                try {
+                    const entries = fs.readdirSync(path.join(fasePath(p, f), 'bloqueado-humano'));
+                    if (entries.some((n) => n.startsWith(issue + '.'))) return true;
+                } catch { /* dir ausente */ }
+            }
+        }
+        return false;
+    };
+    /** Orden de label todavía sin drenar en la cola del servicio-github. */
+    const hasQueuedLabel = (issue) => {
+        try { return fs.readdirSync(ghQueueDir).some((n) => n.startsWith(issue + '-needs-human')); }
+        catch { return false; }
+    };
+
+    return {
+        nowMs,
+        parallelPhases,
+        requiredSkillsFor: (p, f) => (config.pipelines && config.pipelines[p]
+            && config.pipelines[p].skills_por_fase
+            && config.pipelines[p].skills_por_fase[f]) || [],
+        listPhaseFiles: (p, f, state) => {
+            const dir = path.join(fasePath(p, f), state);
+            return (listWorkFiles(dir) || []).map((wf) => {
+                let mtimeMs = 0;
+                try { mtimeMs = fs.statSync(wf.path).mtimeMs; } catch { /* ausente */ }
+                return { name: wf.name, mtimeMs };
+            });
+        },
+        readYaml: (p, f, state, name) => readYamlSafe(path.join(fasePath(p, f), state, name)),
+        issueLiveElsewhere: (issue, p, currentFase) => {
+            for (const f of allPhasesOf(p)) {
+                if (f === currentFase) continue;
+                for (const st of ['pendiente', 'trabajando']) {
+                    try {
+                        if (fs.readdirSync(path.join(fasePath(p, f), st)).some((n) => n.startsWith(issue + '.'))) return true;
+                    } catch { /* dir ausente */ }
+                }
+            }
+            return false;
+        },
+
+        // #5396 CA-1/CA-2 — devuelve el ORIGEN de la supresión, no un booleano.
+        // Precedencia: marker (verdad) > cola > cache fresca (hint) > desconocida.
+        // El `false` (no suprimir) SÓLO se alcanza con una entrada de cache FRESCA
+        // que explícitamente NO tiene el label: la caché nunca habilita un
+        // escalado por ausencia de datos.
+        // @returns {false|'marker'|'cola'|'cache-label'|'cache-desconocida'}
+        hasNeedsHuman: (issue) => {
+            if (hasBlockMarker(issue)) return 'marker';
+            if (hasQueuedLabel(issue)) return 'cola';
+            const entry = readFreshEntry(issue);
+            if (!entry) return 'cache-desconocida'; // fail-closed: no re-escalar
+            const labels = Array.isArray(entry.labels) ? entry.labels : [];
+            return labels.map(labelNameOf).includes(NEEDS_HUMAN_LABEL) ? 'cache-label' : false;
+        },
+
+        // #5396 CA-3 — API canónica de la ola (#5060). Reemplaza la
+        // reimplementación a mano que leía `allowed_issues` (snake) sobre un
+        // objeto normalizado a `allowedIssues` (camel).
+        //   running       → false salvo PIPELINE_ALLOW_UNSCOPED_DISPATCH=1
+        //   paused        → false
+        //   partial_pause → issue ∈ allowedIssues
+        isAllowed: (issue) => partialPause.isIssueAllowedInState(issue, ppMode),
+
+        // Solo actuar sobre issues confirmados OPEN. Cerrado/notFound/desconocido
+        // → no tocar (residuo).
+        isIssueOpen: (issue) => {
+            const e = readTitleCacheEntry(issue);
+            return !!(e && e.state === 'OPEN');
+        },
+
+        // CA-UX-2 — título para que la notificación sea legible. Sólo si la
+        // entrada está fresca; si no, el mensaje va sin título (nunca miente).
+        issueTitle: (issue) => {
+            const e = readFreshEntry(issue);
+            return (e && typeof e.title === 'string' && e.title.trim()) ? e.title.trim() : null;
+        },
+
+        isPaused: () => { try { return fs.existsSync(opts.pauseFile); } catch { return false; } },
+
+        // #4622 (CA-4): un `trabajando/` reciente ya NO alcanza como prueba de
+        // vida. Se cruza el latido `agent-<issue>.heartbeat`: si su pid está
+        // muerto (o su identidad no matchea por reuso de PID), el skill NO cuenta
+        // como vivo. Sin latido legible, cae al criterio de mtime (compat).
+        livenessOk: (name, mtimeMs) => {
+            const recent = (nowMs - mtimeMs) < staleMs;
+            if (!recent) return false; // viejo → muerto, sin importar el latido
+            const issue = String(name).split('.')[0];
+            const hbPath = path.join(ROOT, '.claude', 'hooks', `agent-${issue}.heartbeat`);
+            let hb;
+            try { hb = JSON.parse(fs.readFileSync(hbPath, 'utf8')); }
+            catch { return recent; }
+            return processLiveness.isAgentAlive(hb && hb.pid, {
+                startedAt: hb && hb.pid_started_at,
+                branch: hb && hb.branch,
+                session: hb && hb.session,
+            });
+        },
+
+        loadRetryState: () => { try { return JSON.parse(fs.readFileSync(stuckStateFile, 'utf8')); } catch { return {}; } },
+        saveRetryState: (s) => { try { fs.writeFileSync(stuckStateFile, JSON.stringify(s, null, 2)); } catch { /* best-effort */ } },
+
+        requeueWorkItem: (p, f, skill, issue) => {
+            const dir = path.join(fasePath(p, f), 'pendiente');
+            fs.mkdirSync(dir, { recursive: true });
+            fs.writeFileSync(path.join(dir, `${issue}.${skill}`), `issue: ${issue}\nfase: ${f}\npipeline: ${p}\n`);
+        },
+
+        // #5396 causa raíz 3 — registrar el bloqueo por su DUEÑO. `reportHumanBlock`
+        // planta el marker físico (que es lo que `servicio-reconciler.js:490`
+        // respeta para NO encolar `remove-label`) y encola el label él mismo.
+        // Ya no se escribe el label a mano: eso dejaba el gate sin marker y
+        // cerraba el bucle add/remove.
+        //
+        // ⚠️ Riesgo #1: `reportHumanBlock` MUEVE el work-item activo (incluido el
+        // de `listo/`) hacia `bloqueado-humano/` salvo que reciba `pipeline`
+        // explícito Y `moveFromActive: false`. Un issue varado tiene justamente
+        // sus deliverables en `listo/` — moverlos destruiría la evidencia que el
+        // detector usa. Los DOS parámetros son obligatorios (la guarda es
+        // `if (!pipeline || opts.moveFromActive !== false)`).
+        escalate: (issue, reason, meta = {}) => {
+            const n = Number(issue);
+            // SEC-5.2 — validar ANTES del path.join que hace reportHumanBlock.
+            if (!Number.isInteger(n) || n <= 0) {
+                log('reconciler', `escalate: issue inválido (${String(issue).slice(0, 40)}) — ignorado`);
+                return;
+            }
+            const phase = String(meta.fase || '').trim();
+            const pipeline = String(meta.pipeline || '').trim();
+            if (!phase || !pipeline) {
+                // Fail-closed: sin pipeline explícito, `reportHumanBlock` haría
+                // `findActiveMarker` y podría mover el deliverable de `listo/`.
+                log('reconciler', `escalate #${n}: falta pipeline/fase explícitos — no se escala (protege evidencia)`);
+                return;
+            }
+            try {
+                humanBlock.reportHumanBlock({
+                    issue: n,
+                    skill: RECONCILER_SKILL,
+                    phase,
+                    pipeline,                 // explícito → no busca marker activo
+                    moveFromActive: false,    // ⚠️ no mover el deliverable de `listo/`
+                    reason: String(reason || 'fase varada').slice(0, 500),
+                    question: `¿Cómo destrabo #${n} en ${pipeline}/${phase}? (rechazo / cancelado / corrupto)`,
+                    // `precondition` omitido → normalizePrecondition ⇒ HUMAN_JUDGMENT
+                    // (fail-closed, #4748): nunca auto-re-evaluable.
+                });
+            } catch (e) {
+                log('reconciler', `error escalando #${n}: ${e && e.message}`);
+            }
+        },
+
+        workItemExists: (p, f, skill, issue) => {
+            for (const st of ['pendiente', 'trabajando']) {
+                try { if (fs.existsSync(path.join(fasePath(p, f), st, `${issue}.${skill}`))) return true; } catch { /* no-op */ }
+            }
+            return false;
+        },
+
+        // CA-8 / CA-UX-1 — texto PLANO (sin `parse_mode`, el reason interpola un
+        // skill derivado de un nombre de archivo) PERO con los botones de acción
+        // rápida. `reply_markup` es independiente del dialecto de parseo, así que
+        // `sendTelegramWithMarkup(text, markup, { plain: true })` cumple ambos.
+        // `sendTelegramPlain` NO sirve: hardcodea el markup a null y mata los botones.
+        // Si el markup no se puede firmar, se envía igual el texto (CA-UX-1).
+        notify: (msg, meta = {}) => {
+            if (!sendTelegramWithMarkup) return;
+            let markup = null;
+            const n = Number(meta.issue);
+            if (meta.action === 'escalate' && Number.isInteger(n) && n > 0) {
+                try { markup = humanBlock.buildBlockedActionMarkup(n) || null; }
+                catch { markup = null; }
+            }
+            try { sendTelegramWithMarkup(msg, markup, { plain: true }); }
+            catch { /* best-effort: notificar nunca tumba el tick */ }
+        },
+
+        audit: (rec) => log('reconciler', typeof rec === 'string' ? rec : JSON.stringify(rec)),
+    };
+}
+
+/**
+ * PURO — evalúa la racha de silencio del reconciler (CA-7 / CA-UX-3).
+ *
+ * Riesgo #2: fail-closed por caché + filtro de ola siempre activo + allowlist
+ * vacía tras la poda de fin de ola componen un self-healing 100% mudo *por
+ * diseño*. Ese es exactamente el estado de producción que nadie notó. Esta
+ * función es lo que impide que CA-1…CA-4 se "cumplan" apagando el reconciler.
+ *
+ * CA-UX-3: NO se emite señal si la totalidad del silencio se explica por el
+ * filtro de ola (es el comportamiento correcto, no una anomalía), y se emite
+ * como máximo UNA vez por racha.
+ *
+ * @param {object|null} prev  estado previo `{ streak, signaled }`
+ * @param {object} agg        `{ evaluados, escalados, requeued, suprimidos_por_ola }`
+ * @param {object} [opts]     `{ threshold }`
+ * @returns {{ next: {streak:number, signaled:boolean}, emitSignal: boolean }}
+ */
+function evaluateSilenceHealth(prev, agg = {}, opts = {}) {
+    const threshold = Number.isFinite(opts.threshold) && opts.threshold > 0
+        ? opts.threshold : DEFAULT_SILENT_STREAK_THRESHOLD;
+    const evaluados = Number(agg.evaluados) || 0;
+    const acciones = (Number(agg.escalados) || 0) + (Number(agg.requeued) || 0);
+
+    // Hubo acción (o no había nada que evaluar) → racha reseteada.
+    if (evaluados === 0 || acciones > 0) {
+        return { next: { streak: 0, signaled: false }, emitSignal: false };
+    }
+
+    const streak = ((prev && Number(prev.streak)) || 0) + 1;
+    const alreadySignaled = !!(prev && prev.signaled);
+    // CA-UX-3 — silencio explicado 100% por el filtro de ola: es lo esperado.
+    const explainedByWave = (Number(agg.suprimidos_por_ola) || 0) >= evaluados;
+    const emitSignal = streak >= threshold && !alreadySignaled && !explainedByWave;
+
+    return { next: { streak, signaled: alreadySignaled || emitSignal }, emitSignal };
+}
+
+module.exports = {
+    buildStuckReconcilerDeps,
+    evaluateSilenceHealth,
+    DEFAULT_PARALLEL_PHASES,
+    DEFAULT_SILENT_STREAK_THRESHOLD,
+    RECONCILER_SKILL,
+};

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -225,6 +225,9 @@ const { resolveReboteDestino } = require('./lib/rebote-destino');
 const partialPauseDeps = require('./lib/partial-pause-deps');
 // #4614 — self-healing de fases varadas (reconciler).
 const { runStuckPhaseReconciler } = require('./lib/stuck-phase-reconciler-runner');
+// #5396 — el cableado de deps del reconciler vive en su propio módulo para que
+// el test pueda verificarlo SIN cargar pulpo.js (16k líneas con side-effects).
+const { buildStuckReconcilerDeps, evaluateSilenceHealth } = require('./lib/stuck-reconciler-deps');
 // #4622 — liveness real del pid + identidad (anti-heartbeat-zombi). Fuente única
 // compartida con canonical-facts y el hook activity-logger.
 const processLiveness = require('./lib/process-liveness');
@@ -16838,14 +16841,43 @@ function pollQuotaFlag() {
 let _lastStuckReconcilerAt = 0;
 const STUCK_RECONCILER_INTERVAL_MS = 10 * 60 * 1000;
 const STUCK_STALE_MS = 15 * 60 * 1000;
+// #5396 CA-7 / riesgo #2 — señal de vida del self-healing. El fix compone tres
+// silencios legítimos (fail-closed por caché, filtro de ola siempre activo,
+// allowlist vacía entre olas) que juntos pueden dejar al reconciler 100% mudo
+// *por diseño*. Sin esta señal, "apagarlo del todo" satisface CA-1…CA-4 y nadie
+// se entera — que es exactamente lo que venía pasando.
+//
+// La racha vive en su PROPIO archivo: `.stuck-reconciler-state.json` está
+// indexado por `issue|fase` y mezclar acá un contador global lo corrompería.
+// CA-UX-4: los contadores por tick van al log, NO a Telegram; sólo la señal de
+// vida (una vez por racha) notifica.
+const STUCK_HEALTH_FILE = path.join(PIPELINE, '.stuck-reconciler-health.json');
+function emitStuckReconcilerLiveness(agg) {
+  try {
+    let prev = null;
+    try { prev = JSON.parse(fs.readFileSync(STUCK_HEALTH_FILE, 'utf8')); } catch { /* primera vez */ }
+    const { next, emitSignal } = evaluateSilenceHealth(prev, agg);
+    try { fs.writeFileSync(STUCK_HEALTH_FILE, JSON.stringify(next, null, 2)); } catch { /* best-effort */ }
+    if (!emitSignal) return;
+    // Texto plano (SEC-4) y sin audio TTS (CA-UX-5: el audio queda reservado al
+    // circuit breaker; esto es una señal de diagnóstico, no una emergencia).
+    sendTelegramPlain(
+      `🔇 Self-healing mudo hace ${next.streak} ticks seguidos\n`
+      + `Evaluó ${agg.evaluados} issue(s) varado(s) y no actuó en ninguno.\n`
+      + `Supresiones: ola=${agg.suprimidos_por_ola} cache=${agg.suprimidos_por_cache} dedupe=${agg.suprimidos_por_dedupe}\n`
+      + `Revisá .pipeline/logs/pulpo.log (canal "reconciler") si no lo esperabas.`
+    );
+  } catch (e) {
+    log('reconciler', `señal de vida (best-effort) falló: ${e && e.message}`);
+  }
+}
+
 function runStuckReconcilerTick() {
   if (Date.now() - _lastStuckReconcilerAt < STUCK_RECONCILER_INTERVAL_MS) return;
   _lastStuckReconcilerAt = Date.now();
   try {
     const config = loadConfig();
     if (!config || !config.pipelines) return;
-    const STUCK_STATE_FILE = path.join(PIPELINE, '.stuck-reconciler-state.json');
-    const ghQueueDir = path.join(PIPELINE, 'servicios', 'github', 'pendiente');
     const ppMode = partialPause.getPipelineMode();
     // Fases PARALELAS de `desarrollo` (todos los skills deben estar, modelo
     // `resultado: aprobado`). Mono-skill (dev/build/entrega) quedan afuera. Las
@@ -16857,106 +16889,36 @@ function runStuckReconcilerTick() {
       { pipeline: 'desarrollo', fase: 'verificacion' },
       { pipeline: 'desarrollo', fase: 'aprobacion' },
     ];
-    const allPhasesOf = (p) => (config.pipelines?.[p]?.fases) || [];
 
-    const deps = {
-      nowMs: Date.now(),
-      parallelPhases,
-      requiredSkillsFor: (p, f) => (config.pipelines?.[p]?.skills_por_fase?.[f]) || [],
-      listPhaseFiles: (p, f, state) => {
-        const dir = path.join(fasePath(p, f), state);
-        return (listWorkFiles(dir) || []).map((wf) => {
-          let mtimeMs = 0;
-          try { mtimeMs = fs.statSync(wf.path).mtimeMs; } catch { /* ausente */ }
-          return { name: wf.name, mtimeMs };
-        });
+    // #5396 (SEC-0) — el cableado vive en `lib/stuck-reconciler-deps.js` para que
+    // un test pueda verificar la POLÍTICA REAL (allowlist de ola, dedupe por
+    // marker/caché, escalado vía human-block) sin cargar este archivo.
+    const deps = buildStuckReconcilerDeps({
+      config, PIPELINE, ROOT, pauseFile: PAUSE_FILE, ppMode,
+      nowMs: Date.now(), staleMs: STUCK_STALE_MS, parallelPhases,
+      deps: {
+        fs, partialPause, humanBlock, processLiveness,
+        fasePath, listWorkFiles, readYamlSafe, log, sendTelegramWithMarkup,
       },
-      readYaml: (p, f, state, name) => readYamlSafe(path.join(fasePath(p, f), state, name)),
-      issueLiveElsewhere: (issue, p, currentFase) => {
-        for (const f of allPhasesOf(p)) {
-          if (f === currentFase) continue;
-          for (const st of ['pendiente', 'trabajando']) {
-            try {
-              if (fs.readdirSync(path.join(fasePath(p, f), st)).some((n) => n.startsWith(issue + '.'))) return true;
-            } catch { /* dir ausente */ }
-          }
-        }
-        return false;
-      },
-      hasNeedsHuman: (issue) => {
-        try {
-          if (fs.readdirSync(ghQueueDir).some((n) => n.startsWith(issue + '-needs-human'))) return true;
-        } catch { /* ausente */ }
-        for (const p of Object.keys(config.pipelines || {})) {
-          for (const f of allPhasesOf(p)) {
-            try {
-              if (fs.readdirSync(path.join(fasePath(p, f), 'bloqueado-humano')).some((n) => n.startsWith(issue + '.'))) return true;
-            } catch { /* ausente */ }
-          }
-        }
-        return false;
-      },
-      isAllowed: (issue) => ppMode.mode !== 'partial_pause' || (ppMode.allowed_issues || []).includes(Number(issue)),
-      // Solo actuar sobre issues confirmados OPEN (el title-cache trae el estado
-      // real de GitHub). Cerrado/notFound/desconocido → no tocar (residuo).
-      isIssueOpen: (issue) => {
-        try {
-          const cache = JSON.parse(fs.readFileSync(path.join(PIPELINE, '.issue-title-cache.json'), 'utf8'));
-          const e = cache[String(issue)];
-          return !!(e && e.state === 'OPEN');
-        } catch { return false; }
-      },
-      isPaused: () => { try { return fs.existsSync(PAUSE_FILE); } catch { return false; } },
-      // #4622 (CA-4): un `trabajando/` reciente ya NO alcanza como prueba de vida.
-      // Cruzamos el latido `agent-<issue>.heartbeat`: si su pid está muerto (o su
-      // identidad no matchea por reuso de PID), el skill NO cuenta como vivo → el
-      // reconciler lo trata como fase varada y decide requeue/escalate. Si no hay
-      // latido legible, caemos al criterio de mtime (compat: work-item recién
-      // creado que todavía no escribió su primer heartbeat).
-      livenessOk: (name, mtimeMs) => {
-        const recent = (Date.now() - mtimeMs) < STUCK_STALE_MS;
-        if (!recent) return false; // viejo → muerto, sin importar el latido
-        const issue = String(name).split('.')[0];
-        const hbPath = path.join(ROOT, '.claude', 'hooks', `agent-${issue}.heartbeat`);
-        let hb;
-        try { hb = JSON.parse(fs.readFileSync(hbPath, 'utf8')); }
-        catch { return recent; } // sin latido legible → mtime manda (compat)
-        return processLiveness.isAgentAlive(hb && hb.pid, {
-          startedAt: hb && hb.pid_started_at,
-          branch: hb && hb.branch,
-          session: hb && hb.session,
-        });
-      },
-      loadRetryState: () => { try { return JSON.parse(fs.readFileSync(STUCK_STATE_FILE, 'utf8')); } catch { return {}; } },
-      saveRetryState: (s) => { try { fs.writeFileSync(STUCK_STATE_FILE, JSON.stringify(s, null, 2)); } catch { /* best-effort */ } },
-      requeueWorkItem: (p, f, skill, issue) => {
-        const dir = path.join(fasePath(p, f), 'pendiente');
-        fs.mkdirSync(dir, { recursive: true });
-        fs.writeFileSync(path.join(dir, `${issue}.${skill}`), `issue: ${issue}\nfase: ${f}\npipeline: ${p}\n`);
-      },
-      escalate: (issue, reason) => {
-        try {
-          fs.mkdirSync(ghQueueDir, { recursive: true });
-          fs.writeFileSync(
-            path.join(ghQueueDir, `${issue}-needs-human-stuck-${Date.now()}.json`),
-            JSON.stringify({ action: 'label', issue: parseInt(issue, 10), label: 'needs-human' })
-          );
-        } catch (e) { log('reconciler', `error encolando needs-human #${issue}: ${e.message}`); }
-      },
-      workItemExists: (p, f, skill, issue) => {
-        for (const st of ['pendiente', 'trabajando']) {
-          try { if (fs.existsSync(path.join(fasePath(p, f), st, `${issue}.${skill}`))) return true; } catch { /* no-op */ }
-        }
-        return false;
-      },
-      notify: (msg) => { try { sendTelegram(msg); } catch { /* best-effort */ } },
-      audit: (rec) => log('reconciler', typeof rec === 'string' ? rec : JSON.stringify(rec)),
-    };
+    });
 
     const res = runStuckPhaseReconciler(deps, { maxRequeueAttempts: 2, capPerTick: 5, staleThresholdMs: STUCK_STALE_MS });
-    if (res.requeued || res.escalated) {
-      log('reconciler', `🔧 self-healing tick: requeue=${res.requeued} escalate=${res.escalated} skip=${res.skipped}`);
-    }
+
+    // #5396 CA-7 — el agregado se loguea SIEMPRE, no sólo cuando hubo acción.
+    // Un tick silencioso puede significar "todo sano" o "el self-healing está
+    // muerto"; sin estas tres causas de supresión desglosadas son indistinguibles
+    // (fue exactamente lo que pasó en producción y nadie se enteró).
+    const sup = res.suppressed || {};
+    const agg = {
+      evaluados: res.evaluados || 0,
+      suprimidos_por_ola: sup.ola || 0,
+      suprimidos_por_cache: sup.cache || 0,
+      suprimidos_por_dedupe: sup.dedupe || 0,
+      escalados: res.escalated || 0,
+      requeued: res.requeued || 0,
+    };
+    log('reconciler', `🔧 self-healing tick: ${JSON.stringify(agg)}`);
+    emitStuckReconcilerLiveness(agg);
   } catch (e) {
     log('reconciler', `tick error (no tumba el loop): ${e && e.message}`);
   }

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -16877,7 +16877,14 @@ function runStuckReconcilerTick() {
   _lastStuckReconcilerAt = Date.now();
   try {
     const config = loadConfig();
-    if (!config || !config.pipelines) return;
+    // #5396 CA-7 — este early-return NO puede ser mudo. Un `config.yaml` ilegible
+    // o corrupto dejaría el self-healing apagado para siempre y sin rastro, que es
+    // exactamente el modo de falla que CA-7 existe para hacer visible (pasó en
+    // producción y nadie se enteró). El log es la única señal de que el tick corrió.
+    if (!config || !config.pipelines) {
+      log('reconciler', '🔧 self-healing tick abortado: config sin `pipelines` (¿config.yaml ilegible?)');
+      return;
+    }
     const ppMode = partialPause.getPipelineMode();
     // Fases PARALELAS de `desarrollo` (todos los skills deben estar, modelo
     // `resultado: aprobado`). Mono-skill (dev/build/entrega) quedan afuera. Las

--- a/docs/pipeline/self-healing-fases-varadas.md
+++ b/docs/pipeline/self-healing-fases-varadas.md
@@ -114,6 +114,16 @@ Mientras el marker exista, `reconcileLabelToFilesystem` **saltea** el issue
 mecanismo que cortó la oscilación add/remove que se veía en `svc-github.log`
 como el par `Label "needs-human" → #N` / `removido de #N` cada ~30 s.
 
+> **El bloqueo también frena el re-encolado.** `bloqueado-humano/` no es ni
+> deliverable-state ni live-state para el runner, y el marker se planta sin
+> mover el deliverable de `listo/`: el issue **se sigue evaluando** en cada
+> tick. Por eso el guard de dedupe cubre los dos carriles, no sólo `escalate`
+> — un issue con bloqueo vigente decide `none` con razón
+> `bloqueado-humano (dedupe: <origen>)` en lugar de re-encolar el skill que
+> falta. Sin eso, el reconciler spawnearía un agente encima de un issue que
+> está esperando decisión humana, que es exactamente lo que la línea roja
+> ("ante duda: humano") prohíbe.
+
 Sin una de estas vías, el marker acumula bloqueo sin salida. Si ves un issue
 bloqueado que ya no corresponde:
 

--- a/docs/pipeline/self-healing-fases-varadas.md
+++ b/docs/pipeline/self-healing-fases-varadas.md
@@ -89,7 +89,7 @@ cat .pipeline/.stuck-reconciler-health.json
 
 Cuando el reconciler escala, `humanBlock.reportHumanBlock()` deja:
 
-- el **marker** `<pipeline>/<fase>/bloqueado-humano/<issue>.reconciler`,
+- el **marker** `<pipeline>/<fase>/bloqueado-humano/<issue>.<skill>`,
 - su metadata `<marker>.reason.json` (motivo, pregunta, precondición),
 - una orden de label `needs-human` en la cola del servicio-github,
 - una notificación de Telegram **con botones de acción rápida**.
@@ -98,16 +98,46 @@ Cuando el reconciler escala, `humanBlock.reportHumanBlock()` deja:
 > deliverable de `listo/` **no se mueve**. Esa evidencia es lo que el detector
 > usa para decidir; moverla rompería el diagnóstico.
 
+### Qué `<skill>` lleva el marker (y por qué importa)
+
+El `<skill>` **no** es un nombre sintético: sale de los skills reales que
+motivaron la escalación y se valida contra `skills_por_fase[fase]` —
+exactamente la misma lista que usa el INVARIANTE de dispatch de `pulpo.js`.
+
+| Caso | `<skill>` elegido |
+|---|---|
+| Ambigüedad (`rechazado` / `cancelado` / ilegible) | El primer skill ambiguo de la fase (`tester`, `qa`, …) |
+| Tope de reintentos del carril `requeue` | El primer skill que agotó los reintentos |
+| `estado indeterminado` (no imputa skill) | Fallback determinista: primer skill de `skills_por_fase[fase]` |
+| La fase no declara `skills_por_fase` | **No se escala** (fail-closed) + log `sin skills_por_fase` |
+
+La procedencia self-healing viaja en el `reason`, con prefijo `[self-healing]`.
+
+> **Por qué no un skill sintético.** Una versión previa plantaba
+> `<issue>.reconciler`. Ese nombre no existe en `skills_por_fase`, así que al
+> destrabar el work-item entraba al despacho y el invariante skill∈fase lo
+> rebotaba a `pendiente/` **sin registrar cooldown**, emitiendo un Telegram
+> `⛔ Pipeline bloqueó lanzamiento de reconciler:#N` en **cada tick**. O sea: la
+> vía de salida del bloqueo generaba justo el spam que este mecanismo elimina.
+> Con un skill real, destrabar re-corre el agente que quedó sin veredicto.
+
 **El `needs-human` tiene dos dueños** (`escalate` lo pone, `servicio-reconciler`
 lo saca), y por eso importa quién lo quita y cuándo:
 
-| Vía | Quién la dispara | Efecto |
+| Vía | Quién la dispara | Efecto concreto al destrabar |
 |---|---|---|
-| Botones de la notificación (`buildBlockedActionMarkup`) | El operador, desde Telegram | Resuelve el bloqueo por el handler de quick-actions. |
-| `humanBlock.unblockIssue({ issue, guidance, unlocker })` | Operador / brazo de desbloqueo | Reactiva el work-item con la guía del humano. |
-| `humanBlock.dismissBlockedIssue({ issue })` | Operador | Descarta el bloqueo sin reactivar (el issue no va más). |
+| Botones de la notificación (`buildBlockedActionMarkup`) | El operador, desde Telegram | `executeQuickAction` → `reactivateAllBlocked` → `unblockIssue` (misma mecánica que la fila siguiente). |
+| `humanBlock.unblockIssue({ issue, guidance, unlocker })` | Operador / brazo de desbloqueo | **`rename`** del marker a `<pipeline>/<fase>/pendiente/<issue>.<skill>` + `<marker>.guidance.txt` con la guía, y borra el `.reason.json`. El Pulpo lo despacha en el tick siguiente: el `<skill>` está en `skills_por_fase[fase]`, así que **pasa el invariante** y el agente re-corre. |
+| `humanBlock.dismissBlockedIssue({ issue })` | Operador | Borra marker + `.reason.json`. **No** reactiva: el issue no vuelve a la cola. |
 | Archivado por TTL del servicio-reconciler (#3186) | Automático | Poda markers vencidos. |
 | `reconcileLabelToFilesystem` (#4222) | Automático | **Sólo si NO hay marker**: limpia labels `needs-human` fantasma. |
+
+> El `.guidance.txt` que deja `unblockIssue` **no** se despacha como work-item:
+> `listWorkFiles` lo filtra vía `isMarkerArtifact` (`pulpo.js:1548-1554`).
+
+> **Mientras el work-item destrabado está en `pendiente/`, el reconciler no lo
+> vuelve a tocar**: el runner lo cuenta como `liveSkills`, el detector devuelve
+> `trabajo-vivo` y la decisión es `none`. No hay ventana de doble escalado.
 
 Mientras el marker exista, `reconcileLabelToFilesystem` **saltea** el issue
 (`blockedByIssue.has(...) → continue`) y no encola `remove-label`. Ése es el

--- a/docs/pipeline/self-healing-fases-varadas.md
+++ b/docs/pipeline/self-healing-fases-varadas.md
@@ -1,0 +1,153 @@
+# Self-healing de fases varadas — operación y salida del bloqueo
+
+> Contexto: #4614 (reconciler original), #4222 (guarda anti bloqueo fantasma),
+> #5060 (ejecución sólo por olas), **#5396** (fin del re-escalado en loop).
+> Código: `.pipeline/lib/stuck-phase-detector.js`,
+> `.pipeline/lib/stuck-phase-reconciler.js`,
+> `.pipeline/lib/stuck-phase-reconciler-runner.js`,
+> `.pipeline/lib/stuck-reconciler-deps.js`.
+
+## Qué hace
+
+Cada 10 minutos el Pulpo corre un tick que busca **fases paralelas varadas** de
+`desarrollo` (`validacion`, `verificacion`, `aprobacion`): issues cuyos
+deliverables quedaron a medias y sin ningún agente vivo trabajando.
+
+Ante una fase varada sólo puede hacer dos cosas:
+
+- **re-encolar** el skill que falta (vuelve a correr el agente), o
+- **escalar a un humano** (`needs-human` + notificación de Telegram).
+
+> **Línea roja.** El reconciler **nunca** resuelve la ambigüedad por su cuenta.
+> Jamás escribe `resultado: aprobado`. Ante duda: humano. Y si no se le puede
+> avisar, queda ruidoso en el log — nunca silencioso.
+
+## Cuándo NO escala (las cuatro causas de silencio)
+
+`#5396` acotó a quién se le avisa. Un tick puede terminar sin notificar nada por
+cuatro motivos distintos, y **el log los distingue**:
+
+| Causa | Razón en el log | Qué significa |
+|---|---|---|
+| `ola` | `fuera-de-allowlist (backlog dormido, no tocar)` | El issue no está en la ola vigente. Residuo de olas viejas: se audita, no se toca. |
+| `cache` | `cache-desconocida` | No hay entrada fresca del issue en `.issue-title-cache.json`. **Fail-closed**: ante la duda, callarse. |
+| `dedupe` | `ya-escalado (dedupe: marker\|cola\|cache-label)` | Ya se escaló antes. El sufijo dice de dónde salió la evidencia. |
+| `cerrado` | `issue-cerrado-o-inactivo (residuo, no tocar)` | El issue está CLOSED en GitHub. |
+
+El filtro de ola aplica **siempre**, no sólo bajo pausa parcial. La política es
+la canónica de `partialPause.isIssueAllowedInState()`:
+
+- `running` → deniega todo (sin allowlist no hay ola que acote el barrido, #5060);
+- `paused` → deniega todo;
+- `partial_pause` → sólo los issues de `allowedIssues`.
+
+### Precedencia del dedupe
+
+`hasNeedsHuman()` devuelve el **origen** de la supresión, en este orden:
+
+1. **`marker`** — archivo en `<pipeline>/<fase>/bloqueado-humano/<issue>.<skill>`.
+   Es la **fuente de verdad**.
+2. **`cola`** — orden de label todavía sin drenar en `servicios/github/pendiente/`.
+3. **`cache-label`** — entrada **fresca** del title-cache que ya trae `needs-human`.
+4. **`cache-desconocida`** — entrada ausente o vencida según
+   `title-cache-freshness.needsRefetch()` → **no re-escalar**.
+
+El title-cache es un **hint, nunca autoridad**: sólo puede suprimir de más, jamás
+habilitar un escalado.
+
+## Observabilidad: cómo saber que sigue vivo
+
+El riesgo de este diseño es obvio: tres silencios legítimos compuestos
+(fail-closed por caché + filtro de ola + allowlist vacía entre olas) dejan el
+self-healing **100% mudo por diseño**, y nadie se entera. Por eso:
+
+- **Todos** los ticks loguean el agregado, hubo acción o no:
+
+  ```
+  [reconciler] 🔧 self-healing tick: {"evaluados":7,"suprimidos_por_ola":4,
+    "suprimidos_por_cache":2,"suprimidos_por_dedupe":1,"escalados":0,"requeued":0}
+  ```
+
+- Si hay **6 ticks consecutivos** (≈1 h) con `evaluados > 0` y cero acciones, se
+  manda **una sola** notificación de señal de vida. La racha vive en
+  `.pipeline/.stuck-reconciler-health.json` (separado de
+  `.stuck-reconciler-state.json`, que está indexado por `issue|fase`).
+- **No** se emite esa señal si el silencio se explica 100% por el filtro de ola
+  (`suprimidos_por_ola == evaluados`): acotar a la ola es lo correcto, no una
+  anomalía.
+- Los contadores por tick van al **log**, no a Telegram. Sólo la señal de vida
+  notifica, y sin audio TTS (el audio queda reservado al circuit breaker).
+
+Para auditar a mano:
+
+```bash
+grep 'self-healing tick' .pipeline/logs/pulpo.log | tail -20
+cat .pipeline/.stuck-reconciler-health.json
+```
+
+## Salida operativa del bloqueo (CA-9 · riesgo #4/#5.3)
+
+Cuando el reconciler escala, `humanBlock.reportHumanBlock()` deja:
+
+- el **marker** `<pipeline>/<fase>/bloqueado-humano/<issue>.reconciler`,
+- su metadata `<marker>.reason.json` (motivo, pregunta, precondición),
+- una orden de label `needs-human` en la cola del servicio-github,
+- una notificación de Telegram **con botones de acción rápida**.
+
+> El marker se planta con `moveFromActive: false` y `pipeline` explícito: el
+> deliverable de `listo/` **no se mueve**. Esa evidencia es lo que el detector
+> usa para decidir; moverla rompería el diagnóstico.
+
+**El `needs-human` tiene dos dueños** (`escalate` lo pone, `servicio-reconciler`
+lo saca), y por eso importa quién lo quita y cuándo:
+
+| Vía | Quién la dispara | Efecto |
+|---|---|---|
+| Botones de la notificación (`buildBlockedActionMarkup`) | El operador, desde Telegram | Resuelve el bloqueo por el handler de quick-actions. |
+| `humanBlock.unblockIssue({ issue, guidance, unlocker })` | Operador / brazo de desbloqueo | Reactiva el work-item con la guía del humano. |
+| `humanBlock.dismissBlockedIssue({ issue })` | Operador | Descarta el bloqueo sin reactivar (el issue no va más). |
+| Archivado por TTL del servicio-reconciler (#3186) | Automático | Poda markers vencidos. |
+| `reconcileLabelToFilesystem` (#4222) | Automático | **Sólo si NO hay marker**: limpia labels `needs-human` fantasma. |
+
+Mientras el marker exista, `reconcileLabelToFilesystem` **saltea** el issue
+(`blockedByIssue.has(...) → continue`) y no encola `remove-label`. Ése es el
+mecanismo que cortó la oscilación add/remove que se veía en `svc-github.log`
+como el par `Label "needs-human" → #N` / `removido de #N` cada ~30 s.
+
+Sin una de estas vías, el marker acumula bloqueo sin salida. Si ves un issue
+bloqueado que ya no corresponde:
+
+```bash
+# ver todos los bloqueos vivos
+node -e "console.log(require('./.pipeline/lib/human-block').listBlockedIssues())"
+```
+
+## El defecto que esto arregla (#5396)
+
+Antes, el operador recibía cada 10 minutos escalaciones de issues de julio que
+no estaba mirando: **36 notificaciones para 8 decisiones reales (78% de ruido)**,
+y de 25 issues escalados sólo 3 eran de la ola activa. Tres causas:
+
+1. **El dedupe miraba señales transitorias.** Cola de GitHub drenada → el guard
+   se apagaba → mismo issue re-escalado en cada tick.
+2. **El filtro de ola sólo aplicaba bajo pausa parcial.** Fuera de pausa barría
+   todo el backlog histórico. Peor: el lambda leía `ppMode.allowed_issues`
+   (snake) sobre un objeto normalizado a `allowedIssues` (camel), así que
+   *durante* la ola denegaba **todos** los issues — la alarma estaba muerta justo
+   cuando hacía falta.
+3. **El escalado no plantaba el marker**, sólo encolaba el label → el otro
+   reconciler lo veía como fantasma y lo borraba ~30 s después.
+
+## Tests
+
+```bash
+node --test .pipeline/lib/stuck-phase-reconciler*.test.js
+node --test .pipeline/__tests__/stuck-reconciler-wiring-5396.test.js
+node --test .pipeline/lib/__tests__/stuck-escalate-no-oscilacion-5396.test.js
+node --test .pipeline/lib/__tests__/servicio-reconciler.test.js
+```
+
+`stuck-reconciler-wiring-5396.test.js` es el importante: verifica la **política
+real** de `buildStuckReconcilerDeps` (no un `allowed: true` mockeado). El objeto
+`deps` se extrajo de `pulpo.js` a `lib/stuck-reconciler-deps.js` justamente para
+que ese test sea posible sin cargar 16k líneas con side-effects.


### PR DESCRIPTION
## Resumen
- hace observable el resultado de `reportHumanBlock`
- evita contabilizar y notificar escalaciones cuyo marker/label no pudo registrarse
- agrega cobertura unitaria y end-to-end para el fallo de filesystem indicado en review

## Verificación
- `node --test ...`: 140/140 tests verdes
- `./gradlew check --no-daemon`: BUILD SUCCESSFUL (344 tareas)
- `bash .pipeline/smoke-test.sh`: SMOKE TEST OK

Closes #5396