### PR TITLE
[BUG] restart.js preserva la autoría de la pausa total en vez de borrarla

### DIFF
--- a/.pipeline/lib/__tests__/partial-pause-audit.test.js
+++ b/.pipeline/lib/__tests__/partial-pause-audit.test.js
@@ -494,3 +494,36 @@ test('partialPauseAuditSlice mapea entries a estados visuales correctos', () => 
     assert.ok(visuals.includes('subsystem'));
     assert.ok(visuals.includes('rejected'));
 });
+
+// -----------------------------------------------------------------------------
+// #5399 — `restart:preserve-pause`: sin este valor en el enum cerrado, la entry
+// de preservación de pausa quedaba como `action: 'reject'` y el CA de auditoría
+// fallaba en silencio.
+// -----------------------------------------------------------------------------
+
+test('restart:preserve-pause es un authorizedBy valido del enum cerrado', () => {
+    const r = audit.validateAuthorizedBy('restart:preserve-pause');
+    assert.equal(r.valid, true);
+    assert.equal(r.normalized, 'restart:preserve-pause');
+    assert.equal(audit.AUTHORIZED_BY_STATIC.includes('restart:preserve-pause'), true);
+});
+
+test('una mutacion con restart:preserve-pause se aplica y no se rechaza', () => {
+    const r = audit.appendMutation({
+        source: 'restart',
+        action: 'write',
+        previous: [5399],
+        current: [5399],
+        authorizedBy: 'restart:preserve-pause',
+        justification: 'restart preservo pausa heredada (source=config-corruption-halt)',
+        extra: { full_pause: true, preserved: true, inherited_source: 'config-corruption-halt' },
+    });
+    assert.equal(r.ok, true);
+    assert.equal(r.validation.valid, true);
+    const last = audit.tail(1)[0];
+    assert.equal(last.action, 'write');
+    assert.equal(last.authorized_by, 'restart:preserve-pause');
+    assert.equal(last.authorized_by_rejected_reason, undefined);
+    // Preservar la pausa NO toca la allowlist: sin removals, el gate no se ensancha.
+    assert.deepEqual(last.diff, { added: [], removed: [] });
+});

--- a/.pipeline/lib/__tests__/partial-pause.test.js
+++ b/.pipeline/lib/__tests__/partial-pause.test.js
@@ -369,3 +369,91 @@ test('#4832: source config-corruption-halt como substring pero no exacto → man
     writePauseFile(JSON.stringify({ source: 'config-corruption-halt-manual' }));
     assert.equal(pp.readFullPauseOrigin().source, 'manual');
 });
+
+// -----------------------------------------------------------------------------
+// #5399 — endurecimiento del lector + allowlist positiva de auto-levantado.
+// -----------------------------------------------------------------------------
+
+test('#5399: readFullPauseOrigin rechaza objetos con __proto__ sin contaminar el prototipo', () => {
+    resetFs();
+    // Payload clásico de prototype pollution. Un `{ ...defaults, ...parsed }` o
+    // un deep-merge acá contaminaría Object.prototype para todo el proceso.
+    writePauseFile('{"source":"config-corruption-halt","__proto__":{"polluted":"si"},'
+        + '"constructor":{"prototype":{"polluted2":"si"}}}');
+    const origin = pp.readFullPauseOrigin();
+    assert.equal(origin.source, 'config-corruption-halt');
+    assert.equal(({}).polluted, undefined, 'Object.prototype quedó limpio');
+    assert.equal(({}).polluted2, undefined, 'Object.prototype quedó limpio');
+    assert.equal(Object.prototype.polluted, undefined);
+});
+
+test('#5399: readFullPauseOrigin devuelve el source literal en rawSource sin relajar el veredicto', () => {
+    resetFs();
+    writePauseFile(JSON.stringify({
+        source: 'dashboard:wizard:pausa',
+        ts: '2026-08-02T08:00:00.000Z',
+        detail: 'pausa del wizard',
+    }));
+    const origin = pp.readFullPauseOrigin();
+    // Veredicto fail-closed intacto (contrato #4832)...
+    assert.equal(origin.source, 'manual');
+    // ...pero la autoría literal viaja para que el restart la copie verbatim.
+    assert.equal(origin.rawSource, 'dashboard:wizard:pausa');
+    assert.equal(origin.ts, '2026-08-02T08:00:00.000Z');
+    assert.equal(origin.detail, 'pausa del wizard');
+});
+
+test('#5399: isAutoLiftableSource decide por pertenencia exacta a la allowlist positiva', () => {
+    assert.equal(pp.isAutoLiftableSource('config-corruption-halt'), true);
+    // Todo lo demás es false — incluido lo "no humano" (prohibido decidir por negación).
+    for (const v of ['manual', 'unknown', 'telegram', 'restart', 'kernel-cutover-degraded-halt',
+        'config-corruption-halt-manual', 'CONFIG-CORRUPTION-HALT', ' config-corruption-halt',
+        '', null, undefined, 0, 1, true, {}, [], ['config-corruption-halt']]) {
+        assert.equal(pp.isAutoLiftableSource(v), false, `${JSON.stringify(v)} no es auto-levantable`);
+    }
+    assert.deepEqual([...pp.AUTO_LIFTABLE_SOURCES], ['config-corruption-halt']);
+    assert.equal(Object.isFrozen(pp.AUTO_LIFTABLE_SOURCES), true);
+});
+
+test('#5399: setFullPause persiste el source recibido en vez de descartarlo', () => {
+    resetFs();
+    const res = pp.setFullPause({
+        source: 'dashboard:wizard:pausa',
+        authorizedBy: 'pause:dashboard',
+        justification: 'el operador pausó desde el wizard',
+    });
+    assert.equal(res.ok, true);
+    assert.equal(res.source, 'dashboard:wizard:pausa');
+    assert.equal(res.autoLiftable, false);
+    const { PAUSE_FILE } = pp._paths();
+    const marker = JSON.parse(fs.readFileSync(PAUSE_FILE, 'utf8'));
+    assert.equal(marker.source, 'dashboard:wizard:pausa');
+    assert.ok(marker.ts, 'el marker deja de ser un ISO pelado y lleva ts propio');
+    assert.equal(marker.detail, 'el operador pausó desde el wizard');
+    // El modo del pipeline sigue siendo `paused` (nada del contrato viejo se rompe).
+    assert.equal(pp.getPipelineMode().mode, 'paused');
+    // Y la autoría no habilita auto-levantado.
+    assert.equal(pp.readFullPauseOrigin().source, 'manual');
+    assert.equal(pp.readFullPauseOrigin().rawSource, 'dashboard:wizard:pausa');
+});
+
+test('#5399: setFullPause sin source explícito degrada a unknown, nunca a auto-levantable', () => {
+    resetFs();
+    const res = pp.setFullPause({ justification: 'sin autoría declarada' });
+    assert.equal(res.source, 'unknown');
+    assert.equal(res.autoLiftable, false);
+    assert.equal(pp.readFullPauseOrigin().source, 'manual');
+});
+
+test('#5399: setFullPause sanitiza el detail antes de persistirlo en el marker', () => {
+    resetFs();
+    pp.setFullPause({
+        source: 'telegram',
+        authorizedBy: 'commander:leo',
+        justification: 'pausa por incidente, token AKIAIOSFODNN7EXAMPLE en el log',
+    });
+    const { PAUSE_FILE } = pp._paths();
+    const marker = JSON.parse(fs.readFileSync(PAUSE_FILE, 'utf8'));
+    assert.equal(marker.detail.includes('AKIAIOSFODNN7EXAMPLE'), false,
+        'el marker no persiste el secreto crudo');
+});

--- a/.pipeline/lib/__tests__/pause-notice-5399.test.js
+++ b/.pipeline/lib/__tests__/pause-notice-5399.test.js
@@ -1,0 +1,224 @@
+'use strict';
+
+// =============================================================================
+// #5399 · UX-1/UX-2/UX-3 — el dato de autoría de la pausa llega al canal que el
+// operador realmente lee, y lo hace sin mentirle.
+//
+// Contexto del defecto que estos tests blindan: tras el `/restart` del
+// 2026-08-02 el operador recibió "🚀 Pipeline reiniciado y listo (modo pausado)
+// — Todo en marcha para nuevas pruebas" sobre un pipeline que estuvo 1h33 sin
+// despachar. Nadie miró porque el sistema avisó que estaba todo bien.
+//
+// `buildRestartNotice` es PURA: no hace falta tmpdir ni mocks.
+// =============================================================================
+
+const test = require('node:test');
+const assert = require('node:assert');
+
+const pauseNotice = require('../pause-notice');
+const partialPause = require('../partial-pause');
+
+// Emojis que comunican éxito. Con el pipeline frenado son mentira (UX-1).
+const EMOJIS_DE_EXITO = ['🚀', '✅'];
+
+function assertSinEmojiDeExito(msg) {
+    for (const emoji of EMOJIS_DE_EXITO) {
+        assert.ok(!msg.includes(emoji),
+            `el copy de una pausa activa no puede llevar ${emoji}: ${msg}`);
+    }
+}
+
+function assertNoInstruyeBorrarMarker(msg) {
+    // UX-2 — este issue convierte `.paused` en el portador de la autoría:
+    // mandar a borrarlo a mano es instruir a destruir el dato que crea.
+    assert.ok(!/\.paused/.test(msg), `el copy no debe nombrar el marker: ${msg}`);
+    assert.ok(!/\brm\b|borrar|eliminar/i.test(msg), `el copy no debe instruir un borrado: ${msg}`);
+}
+
+// -----------------------------------------------------------------------------
+// UX-1 — el operador distingue "esperá y se levanta sola" de "esto no arranca solo"
+// -----------------------------------------------------------------------------
+
+test('#5399 UX-1: una pausa automatica recuperable se comunica como auto-levantable y sin emoji de exito', () => {
+    const msg = pauseNotice.buildRestartNotice({
+        mode: 'pausado',
+        pauseActive: true,
+        source: 'config-corruption-halt',
+        autoLiftable: true,
+        preserved: true,
+    });
+
+    assertSinEmojiDeExito(msg);
+    assert.ok(msg.includes('PAUSADO'), 'el operador tiene que ver que quedó pausado');
+    assert.ok(msg.includes('heredada'), 'tiene que decir que la pausa viene de antes del restart');
+    assert.ok(/se levanta sola/i.test(msg), 'tiene que decir que no requiere intervención');
+    assert.ok(!/\/reanudar/.test(msg), 'no puede pedir destrabe sobre una pausa que se levanta sola');
+    assertNoInstruyeBorrarMarker(msg);
+});
+
+test('#5399 UX-1: una pausa humana se comunica como bloqueante y nombra /reanudar', () => {
+    const msg = pauseNotice.buildRestartNotice({
+        mode: 'pausado',
+        pauseActive: true,
+        source: 'telegram',
+        autoLiftable: false,
+        preserved: true,
+    });
+
+    assertSinEmojiDeExito(msg);
+    assert.ok(msg.includes('/reanudar'), 'el destrabe se nombra por su comando');
+    assert.ok(!/se levanta sola/i.test(msg), 'una pausa humana NO se levanta sola');
+    assertNoInstruyeBorrarMarker(msg);
+});
+
+test('#5399 UX-1: el copy de una pausa automatica difiere del de una humana', () => {
+    const auto = pauseNotice.buildRestartNotice({
+        mode: 'pausado', pauseActive: true,
+        source: 'config-corruption-halt', autoLiftable: true, preserved: true,
+    });
+    const humana = pauseNotice.buildRestartNotice({
+        mode: 'pausado', pauseActive: true,
+        source: 'telegram', autoLiftable: false, preserved: true,
+    });
+
+    // Es EL criterio verificable que dejó `ux`: disparar el restart con cada
+    // pausa y confirmar que el texto recibido difiere.
+    assert.notStrictEqual(auto, humana);
+});
+
+test('#5399 UX-1: el restart completo que si despacha conserva el copy de exito', () => {
+    const msg = pauseNotice.buildRestartNotice({ mode: 'completo', pauseActive: false });
+
+    assert.ok(msg.includes('🚀'), 'el cohete se reserva para el restart que sí despacha');
+    assert.ok(!/PAUSADO/.test(msg));
+});
+
+test('#5399 UX-1: si la pausa heredada ya se auto-levanto durante el arranque, el copy lo dice', () => {
+    // Escenario central de la historia: el marker sobrevivió al restart con
+    // autoría automática y `loadConfig()` lo levantó solo. El operador pidió un
+    // restart PAUSADO y sin embargo el pipeline despacha: tiene que enterarse.
+    const msg = pauseNotice.buildRestartNotice({ mode: 'pausado', pauseActive: false });
+
+    assert.ok(/ya se levant/i.test(msg), 'tiene que avisar que la pausa se levantó sola');
+    assert.ok(/despach/i.test(msg), 'tiene que decir que volvió a despachar');
+    assertNoInstruyeBorrarMarker(msg);
+});
+
+test('#5399 UX-1: un restart completo sobre un pipeline que quedo pausado no miente con el cohete', () => {
+    // Divergencia real entre lo pedido y el estado del filesystem: el marker
+    // manda. `pauseActive` sale de `existsSync`, no de last-restart.json.
+    const msg = pauseNotice.buildRestartNotice({
+        mode: 'completo', pauseActive: true, source: 'manual', autoLiftable: false,
+    });
+
+    assertSinEmojiDeExito(msg);
+    assert.ok(msg.includes('PAUSADO'));
+});
+
+// -----------------------------------------------------------------------------
+// UX-1 (segunda mitad) — nunca exponer el enum crudo
+// -----------------------------------------------------------------------------
+
+test('#5399 UX-1: el copy traduce la autoria y nunca vuelca el enum crudo', () => {
+    for (const source of Object.keys(pauseNotice.PAUSE_SOURCE_LABELS)) {
+        const msg = pauseNotice.buildRestartNotice({
+            mode: 'pausado', pauseActive: true, source,
+            autoLiftable: partialPause.isAutoLiftableSource(source), preserved: true,
+        });
+        const label = pauseNotice.PAUSE_SOURCE_LABELS[source];
+        assert.ok(msg.includes(label),
+            `el copy no usa el label humano de "${source}": ${msg}`);
+        // Los identificadores internos con guiones (`config-corruption-halt`,
+        // `kernel-cutover-degraded-halt`) no significan nada para el operador:
+        // no pueden aparecer literales. Los sources de una sola palabra
+        // (`wizard`, `telegram`) sí pueden estar DENTRO del label humano, que es
+        // castellano legible — ahí no hay enum expuesto.
+        if (source.includes('-')) {
+            assert.ok(!msg.includes(source),
+                `el copy expone el enum interno "${source}" en vez de traducirlo: ${msg}`);
+        }
+    }
+});
+
+test('#5399 UX-1: un source desconocido cae al label generico en vez de volcarse crudo', () => {
+    // El marker es un archivo que cualquier proceso del host puede escribir: su
+    // contenido no es una fuente confiable de copy para el operador.
+    const inyectado = 'source-inventado-por-otro-proceso';
+    const msg = pauseNotice.buildRestartNotice({
+        mode: 'pausado', pauseActive: true, source: inyectado, autoLiftable: false,
+    });
+
+    assert.ok(!msg.includes(inyectado), `volcó el source crudo: ${msg}`);
+    assert.ok(msg.includes(pauseNotice.PAUSE_SOURCE_LABEL_FALLBACK));
+    assert.ok(msg.includes('/reanudar'), 'lo no identificado es fail-closed: destrabe explícito');
+});
+
+test('#5399 UX-1: un source no-string no rompe el copy', () => {
+    for (const source of [null, undefined, 42, {}, [], true]) {
+        const msg = pauseNotice.buildRestartNotice({
+            mode: 'pausado', pauseActive: true, source, autoLiftable: false,
+        });
+        assert.ok(msg.includes(pauseNotice.PAUSE_SOURCE_LABEL_FALLBACK));
+        assertSinEmojiDeExito(msg);
+    }
+});
+
+// -----------------------------------------------------------------------------
+// UX-2 — ningún texto nuevo instruye borrar el marker
+// -----------------------------------------------------------------------------
+
+test('#5399 UX-2: ningun copy nuevo instruye borrar el marker de pausa', () => {
+    const combinaciones = [
+        { mode: 'pausado', pauseActive: true, source: 'config-corruption-halt', autoLiftable: true, preserved: true },
+        { mode: 'pausado', pauseActive: true, source: 'kernel-cutover-degraded-halt', autoLiftable: false, preserved: true },
+        { mode: 'pausado', pauseActive: true, source: 'telegram', autoLiftable: false, preserved: false },
+        { mode: 'pausado', pauseActive: true, source: 'unknown', autoLiftable: false, preserved: true },
+        { mode: 'pausado', pauseActive: false },
+        { mode: 'completo', pauseActive: false },
+        { mode: 'completo', pauseActive: true, source: 'manual', autoLiftable: false },
+        {},
+    ];
+    for (const opts of combinaciones) {
+        assertNoInstruyeBorrarMarker(pauseNotice.buildRestartNotice(opts));
+    }
+});
+
+// -----------------------------------------------------------------------------
+// UX-3 — el estado degradado no se comunica como falla
+// -----------------------------------------------------------------------------
+
+test('#5399 UX-3: el camino degradado sin preservedFrom no se comunica como error', () => {
+    // Lock no adquirido: el marker original quedó intacto (preservación
+    // correcta), sólo faltó anotar `preservedFrom`. El operador no debe leer
+    // esto como una falla que lo empuje a intervenir a mano.
+    const msg = pauseNotice.buildRestartNotice({
+        mode: 'pausado', pauseActive: true,
+        source: 'config-corruption-halt', autoLiftable: true, preserved: false,
+    });
+
+    assert.ok(!/error|fall(o|ó|a)|no se pudo|⚠|❌/i.test(msg),
+        `el camino degradado no puede leerse como falla: ${msg}`);
+    assert.ok(/se levanta sola/i.test(msg),
+        'la autoría se preservó igual: el auto-levantado se sigue comunicando');
+    assertNoInstruyeBorrarMarker(msg);
+});
+
+// -----------------------------------------------------------------------------
+// CA-8 — el copy no participa de la decisión de auto-levantado
+// -----------------------------------------------------------------------------
+
+test('#5399 CA-8: el copy no promete auto-levantado sobre una pausa deliberadamente no recuperable', () => {
+    // Regresión #5135: `kernel-cutover-degraded-halt` es automática pero exige
+    // rollback manual. `autoLiftable` lo decide `isAutoLiftableSource`, no el
+    // hecho de que la autoría sea automática.
+    const source = 'kernel-cutover-degraded-halt';
+    assert.strictEqual(partialPause.isAutoLiftableSource(source), false);
+
+    const msg = pauseNotice.buildRestartNotice({
+        mode: 'pausado', pauseActive: true, source,
+        autoLiftable: partialPause.isAutoLiftableSource(source), preserved: true,
+    });
+
+    assert.ok(!/se levanta sola/i.test(msg), 'no puede prometer un auto-levantado que el gate no hace');
+    assert.ok(msg.includes('/reanudar'));
+});

--- a/.pipeline/lib/__tests__/restart-preserve-pause-5399.test.js
+++ b/.pipeline/lib/__tests__/restart-preserve-pause-5399.test.js
@@ -1,0 +1,349 @@
+// =============================================================================
+// #5399 — restart.js reescribía `.paused` con un ISO pelado y borraba la
+// autoría de la pausa: el pipeline quedaba pausado para siempre.
+//
+// Evidencia del defecto (2026-08-02): tras un `/restart` a las 09:28 el
+// pipeline estuvo 1h33 sin despachar. No fue cuota ni recursos: fue una pausa
+// automática que, al perder su `source`, se leyó como manual y por eso el
+// auto-recovery de #4832 nunca la levantó.
+//
+// Un test nombrado por cada escenario Gherkin de `po` (CA-2..CA-6, CA-9, CA-13)
+// más el endurecimiento de parsing (CA-10). Todo aislado a un tmpdir vía
+// PIPELINE_DIR_OVERRIDE: no toca el `.paused` real ni el audit log real.
+//
+// NOTA: no se hace `require('../../restart.js')` a propósito — es un script con
+// side effects (mata procesos, lanza componentes). Lo que se ejerce es la rama
+// viva que ese script invoca: `preserveFullPause` / `setFullPause`.
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+// Aislar el módulo a un tmp dir ANTES de requerirlo.
+const TMP_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'v3-restart-preserve-5399-'));
+process.env.PIPELINE_DIR_OVERRIDE = TMP_DIR;
+fs.mkdirSync(path.join(TMP_DIR, 'audit'), { recursive: true });
+
+// Mockear notify-telegram: los tests no deben spamear el canal real.
+const notifyMod = require.resolve('../notify-telegram');
+require.cache[notifyMod] = {
+    id: notifyMod, filename: notifyMod, loaded: true,
+    exports: { notifyTelegram() {} },
+};
+
+delete require.cache[require.resolve('../partial-pause')];
+delete require.cache[require.resolve('../partial-pause-audit')];
+const pp = require('../partial-pause');
+const audit = require('../partial-pause-audit');
+
+const { PAUSE_FILE, PARTIAL_FILE } = pp._paths();
+const AUDIT_FILE = audit._paths().AUDIT_FILE;
+
+function resetFs() {
+    try { fs.unlinkSync(PAUSE_FILE); } catch {}
+    try { fs.unlinkSync(PARTIAL_FILE); } catch {}
+    try { fs.unlinkSync(PAUSE_FILE + '.lock'); } catch {}
+}
+
+function writeMarker(content) {
+    fs.writeFileSync(PAUSE_FILE, typeof content === 'string' ? content : JSON.stringify(content));
+}
+
+function readMarker() {
+    return JSON.parse(fs.readFileSync(PAUSE_FILE, 'utf8'));
+}
+
+function auditEntries() {
+    let raw = '';
+    try { raw = fs.readFileSync(AUDIT_FILE, 'utf8'); } catch { return []; }
+    return raw.split('\n').filter(l => l.trim()).map(l => {
+        try { return JSON.parse(l); } catch { return null; }
+    }).filter(Boolean);
+}
+
+// -----------------------------------------------------------------------------
+// Escenario: restart preserva una pausa automatica recuperable y el pipeline se
+// reanuda solo. (CA-2, CA-3)
+// -----------------------------------------------------------------------------
+test('restart preserva una pausa automatica recuperable y el pipeline se reanuda solo', () => {
+    resetFs();
+    const original = {
+        source: 'config-corruption-halt',
+        ts: '2026-08-02T09:20:00.000Z',
+        detail: 'YAML invalido (linea 3, col 1)',
+    };
+    writeMarker(original);
+
+    const res = pp.preserveFullPause();
+
+    assert.equal(res.ok, true, 'la preservacion se aplico');
+    assert.equal(res.existed, true);
+    // CA-2: verbatim. El mismo source y el MISMO ts que antes del restart.
+    const after = readMarker();
+    assert.equal(after.source, original.source);
+    assert.equal(after.ts, original.ts);
+    assert.equal(after.detail, original.detail);
+    // Constancia de que fue heredada por el restart.
+    assert.equal(after.preservedFrom.by, 'restart');
+    assert.ok(typeof after.preservedFrom.at === 'string' && after.preservedFrom.at.length > 0);
+    // CA-3: sigue siendo candidata a auto-levantado — que es lo que el Pulpo
+    // consulta en su ciclo de ~30s para reanudar el dispatch.
+    assert.equal(pp.readFullPauseOrigin().source, 'config-corruption-halt');
+    assert.equal(pp.isAutoLiftableSource(pp.readFullPauseOrigin().source), true);
+    assert.equal(res.autoLiftable, true);
+});
+
+// -----------------------------------------------------------------------------
+// Escenario: restart preserva una pausa humana y no la levanta solo. (CA-4)
+// -----------------------------------------------------------------------------
+test('restart preserva una pausa humana y no la levanta solo', () => {
+    resetFs();
+    const original = {
+        source: 'telegram',
+        ts: '2026-08-02T08:00:00.000Z',
+        detail: 'pausa total solicitada por el operador via /pausar',
+    };
+    writeMarker(original);
+
+    const res = pp.preserveFullPause();
+
+    assert.equal(res.ok, true);
+    const after = readMarker();
+    // La autoria humana viaja verbatim: no se degrada ni se sintetiza.
+    assert.equal(after.source, 'telegram');
+    assert.equal(after.ts, original.ts);
+    assert.equal(after.preservedFrom.by, 'restart');
+    // Y NO se auto-levanta: requiere destrabe explicito.
+    assert.equal(res.autoLiftable, false);
+    assert.equal(pp.isAutoLiftableSource(after.source), false);
+    assert.equal(pp.readFullPauseOrigin().source, 'manual');
+});
+
+// -----------------------------------------------------------------------------
+// Escenario: una pausa automatica deliberadamente no recuperable sigue sin
+// levantarse. Regresion #5135 — `kernel-cutover-degraded-halt` es automatica
+// pero exige rollback manual. (CA-5)
+// -----------------------------------------------------------------------------
+test('una pausa automatica deliberadamente no recuperable sigue sin levantarse', () => {
+    resetFs();
+    writeMarker({
+        source: 'kernel-cutover-degraded-halt',
+        ts: '2026-08-02T07:00:00.000Z',
+        detail: 'encendido durable abortado: el store degrado a filesystem',
+    });
+
+    const res = pp.preserveFullPause();
+
+    assert.equal(res.ok, true);
+    const after = readMarker();
+    // Se preserva (no se pierde el registro del abort)...
+    assert.equal(after.source, 'kernel-cutover-degraded-halt');
+    assert.equal(after.ts, '2026-08-02T07:00:00.000Z');
+    // ...pero NO entra a la allowlist positiva de auto-levantado.
+    assert.equal(res.autoLiftable, false);
+    assert.equal(pp.isAutoLiftableSource('kernel-cutover-degraded-halt'), false);
+    assert.equal(pp.AUTO_LIFTABLE_SOURCES.includes('kernel-cutover-degraded-halt'), false);
+    // Y el lector fail-closed la reporta como manual → el Pulpo no la levanta.
+    assert.equal(pp.readFullPauseOrigin().source, 'manual');
+});
+
+// -----------------------------------------------------------------------------
+// Escenario: archivo de pausa en formato viejo. (CA-6, CA-10)
+// -----------------------------------------------------------------------------
+test('archivo de pausa en formato viejo no rompe el arranque', () => {
+    const casos = [
+        { nombre: 'ISO plano legacy', contenido: '2026-08-02T09:28:00.000Z' },
+        { nombre: 'vacio', contenido: '   ' },
+        { nombre: 'JSON malformado', contenido: '{ source: "config-corruption-halt"' },
+        { nombre: 'array', contenido: '["config-corruption-halt"]' },
+        { nombre: 'null literal', contenido: 'null' },
+        { nombre: 'primitivo numerico', contenido: '42' },
+        { nombre: 'primitivo string JSON', contenido: '"config-corruption-halt"' },
+        { nombre: 'marker gigante (>64KB)', contenido: JSON.stringify({
+            source: 'config-corruption-halt',
+            ts: '2026-08-02T09:00:00.000Z',
+            detail: 'x'.repeat(70 * 1024),
+        }) },
+    ];
+    for (const caso of casos) {
+        resetFs();
+        writeMarker(caso.contenido);
+        // No tira: el arranque sobrevive.
+        const origin = pp.readFullPauseOrigin();
+        assert.equal(origin.source, 'manual', `${caso.nombre} → manual (fail-closed)`);
+        assert.equal(pp.isAutoLiftableSource(origin.source), false, `${caso.nombre} → no auto-levantable`);
+        // CA-6: deja registro de que la autoria no pudo determinarse.
+        assert.ok(origin.undetermined, `${caso.nombre} → deja motivo de autoria indeterminada`);
+
+        // Y preservarlo tampoco rompe ni promueve.
+        const res = pp.preserveFullPause();
+        assert.equal(res.ok, true, `${caso.nombre} → preservacion sin throw`);
+        assert.equal(res.autoLiftable, false, `${caso.nombre} → sigue sin auto-levantarse`);
+        assert.equal(readMarker().source, 'manual', `${caso.nombre} → marker queda manual`);
+        assert.ok(readMarker().undetermined, `${caso.nombre} → el marker registra la indeterminacion`);
+    }
+});
+
+test('el marker gigante se rechaza sin parsearlo y preserva el tamano acotado', () => {
+    resetFs();
+    assert.equal(pp.MAX_PAUSE_MARKER_BYTES, 64 * 1024);
+    writeMarker({ source: 'config-corruption-halt', detail: 'y'.repeat(80 * 1024) });
+    const origin = pp.readFullPauseOrigin();
+    assert.equal(origin.source, 'manual');
+    assert.equal(origin.undetermined, 'marker_demasiado_grande');
+    assert.equal(origin.raw, null, 'ni siquiera se leyo el contenido');
+});
+
+// -----------------------------------------------------------------------------
+// Escenario: el restart nunca promueve la autoria de una pausa. (CA-9)
+// -----------------------------------------------------------------------------
+test('el restart nunca promueve la autoria de una pausa', () => {
+    const markersNoAutoLevantables = [
+        JSON.stringify({ source: 'telegram', ts: '2026-08-01T10:00:00.000Z' }),
+        JSON.stringify({ source: 'dashboard:wizard:pausa', ts: '2026-08-01T10:00:00.000Z' }),
+        JSON.stringify({ source: 'manual', ts: '2026-08-01T10:00:00.000Z' }),
+        JSON.stringify({ source: 'kernel-cutover-degraded-halt', ts: '2026-08-01T10:00:00.000Z' }),
+        // Cuasi-match: substring, prefijo, sufijo y variantes de caja.
+        JSON.stringify({ source: 'config-corruption-halt-manual' }),
+        JSON.stringify({ source: 'x-config-corruption-halt' }),
+        JSON.stringify({ source: 'CONFIG-CORRUPTION-HALT' }),
+        JSON.stringify({ source: ' config-corruption-halt ' }),
+        // Tipos no-string en `source`.
+        JSON.stringify({ source: 1 }),
+        JSON.stringify({ source: true }),
+        JSON.stringify({ source: { toString: 'config-corruption-halt' } }),
+        JSON.stringify({ source: ['config-corruption-halt'] }),
+        JSON.stringify({ ts: '2026-08-01T10:00:00.000Z' }),
+        '2026-08-01T10:00:00.000Z',
+        '',
+    ];
+    for (const m of markersNoAutoLevantables) {
+        resetFs();
+        writeMarker(m);
+        const res = pp.preserveFullPause();
+        // Assert sobre CONTENIDO del marker, no sobre existsSync.
+        const after = readMarker();
+        assert.equal(pp.isAutoLiftableSource(after.source), false,
+            `marker ${m.slice(0, 60)} NO debe quedar auto-levantable`);
+        assert.equal(res.autoLiftable, false, `resultado de ${m.slice(0, 60)} no auto-levantable`);
+        assert.equal(pp.readFullPauseOrigin().source, 'manual',
+            `relectura de ${m.slice(0, 60)} sigue siendo manual`);
+    }
+});
+
+test('preservar N veces es idempotente sobre la autoria y el timestamp (re-exec #2880)', () => {
+    resetFs();
+    writeMarker({
+        source: 'config-corruption-halt',
+        ts: '2026-08-02T09:20:00.000Z',
+        detail: 'YAML invalido',
+    });
+    for (let i = 0; i < 4; i++) pp.preserveFullPause();
+    const after = readMarker();
+    assert.equal(after.source, 'config-corruption-halt');
+    assert.equal(after.ts, '2026-08-02T09:20:00.000Z', 'el ts original sobrevive N re-ejecuciones');
+    assert.equal(after.preservedFrom.by, 'restart');
+    assert.equal(pp.isAutoLiftableSource(after.source), true);
+});
+
+test('preservar sin pausa previa no crea una pausa de la nada', () => {
+    resetFs();
+    const res = pp.preserveFullPause();
+    assert.equal(res.ok, false);
+    assert.equal(res.existed, false);
+    assert.equal(fs.existsSync(PAUSE_FILE), false, 'no se materializo ningun marker');
+});
+
+// -----------------------------------------------------------------------------
+// Escenario: cada preservacion deja auditoria aplicada. (CA-13)
+// -----------------------------------------------------------------------------
+test('cada preservacion deja auditoria aplicada', () => {
+    resetFs();
+    const antes = auditEntries().length;
+    writeMarker({
+        source: 'config-corruption-halt',
+        ts: '2026-08-02T09:20:00.000Z',
+        detail: 'YAML invalido',
+    });
+
+    pp.preserveFullPause();
+
+    const entries = auditEntries();
+    assert.ok(entries.length > antes, 'se agrego al menos una entry');
+    const entry = entries[entries.length - 1];
+    // CA-13: la entry se APLICA (write), no se rechaza por enum.
+    assert.equal(entry.action, 'write');
+    assert.notEqual(entry.action, 'reject');
+    assert.equal(entry.authorized_by, 'restart:preserve-pause');
+    assert.equal(entry.authorized_by_rejected_reason, undefined,
+        'el authorizedBy no fue rechazado por el enum');
+    // Identifica la autoria heredada.
+    assert.equal(entry.inherited_source, 'config-corruption-halt');
+    assert.equal(entry.inherited_ts, '2026-08-02T09:20:00.000Z');
+    assert.equal(entry.preserved, true);
+    assert.equal(entry.full_pause, true);
+    assert.equal(entry.auto_liftable, true);
+    // Preservar NO toca la allowlist: sin removals, el gate no se ensancha.
+    assert.deepEqual(entry.diff, { added: [], removed: [] });
+});
+
+test('la auditoria de una pausa legacy registra que la autoria no pudo determinarse', () => {
+    resetFs();
+    writeMarker('2026-08-02T09:28:00.000Z');
+    pp.preserveFullPause();
+    const entries = auditEntries();
+    const entry = entries[entries.length - 1];
+    assert.equal(entry.action, 'write');
+    assert.equal(entry.authorized_by, 'restart:preserve-pause');
+    assert.equal(entry.authorship_undetermined, 'marker_legacy_no_json');
+    assert.equal(entry.auto_liftable, false);
+});
+
+// -----------------------------------------------------------------------------
+// `--paused` sin pausa previa = pausa NUEVA del operador → humana.
+// -----------------------------------------------------------------------------
+test('restart --paused sin pausa previa crea una pausa humana no auto-levantable', () => {
+    resetFs();
+    const res = pp.setFullPause({
+        source: 'restart',
+        authorizedBy: 'restart:preserve-pause',
+        justification: 'restart --paused (pausa nueva solicitada por el operador)',
+    });
+    assert.equal(res.ok, true);
+    assert.equal(res.existedBefore, false);
+    assert.equal(res.autoLiftable, false);
+    const after = readMarker();
+    assert.equal(after.source, 'restart');
+    assert.ok(after.ts);
+    assert.equal(pp.readFullPauseOrigin().source, 'manual');
+});
+
+test('un marker legacy conserva su timestamp original al preservarse', () => {
+    resetFs();
+    writeMarker('2026-08-02T09:28:00.000Z');
+    const res = pp.preserveFullPause();
+    assert.equal(res.ok, true);
+    const after = readMarker();
+    // El ISO plano se rescata como `ts`: el operador sigue viendo desde cuándo
+    // está pausado el pipeline, aunque la autoría no se pueda determinar.
+    assert.equal(after.ts, '2026-08-02T09:28:00.000Z');
+    assert.equal(after.source, 'manual');
+    assert.equal(after.undetermined, 'marker_legacy_no_json');
+    assert.equal(res.autoLiftable, false);
+});
+
+test('un marker legacy ilegible como fecha no inventa un timestamp falso', () => {
+    resetFs();
+    writeMarker('no soy una fecha');
+    const res = pp.preserveFullPause();
+    assert.equal(res.ok, true);
+    const after = readMarker();
+    assert.equal(after.source, 'manual');
+    assert.ok(after.ts, 'cae a `now` en vez de quedar sin ts');
+    assert.equal(Number.isFinite(Date.parse(after.ts)), true);
+    assert.equal(res.autoLiftable, false);
+});

--- a/.pipeline/lib/partial-pause-audit.js
+++ b/.pipeline/lib/partial-pause-audit.js
@@ -71,6 +71,13 @@ const AUTHORIZED_BY_STATIC = Object.freeze([
     'resume:dashboard',      // /dashboard/wave/resume → resumeAll
     'dispatch:dashboard',    // /dashboard/wave/dispatch → realign de la ola activa
     'dashboard:roadmap:allowlist', // #4437: editor de allowlist en la ventana Roadmap
+    // #5399 — restart.js preservando la pausa total (`.paused`) a través de un
+    // reinicio. NO habilita removals de allowlist: `preserveFullPause` audita con
+    // `previous === current`, así que su diff nunca tiene `removed`. Sin este
+    // valor en el enum, `validateAuthorizedBy` devolvía `authorized_by_not_in_enum`
+    // y la entry de preservación quedaba como `action: 'reject'` — el CA-13
+    // fallaba en silencio. Prohibido usarlo en un call-site que mute la allowlist.
+    'restart:preserve-pause',
 ]);
 
 // `recursive-deps:from-<N>` donde N es el número del issue padre (>0).

--- a/.pipeline/lib/partial-pause.js
+++ b/.pipeline/lib/partial-pause.js
@@ -783,51 +783,131 @@ function resumeAll(opts = {}) {
 }
 
 // -----------------------------------------------------------------------------
-// #4832 — Lectura del ORIGEN de la pausa total (`.paused`), fail-closed.
+// #4832 / #5399 — Lectura del ORIGEN de la pausa total (`.paused`), fail-closed.
 //
 // Distingue una pausa AUTO-GENERADA por corrupción de config.yaml
 // (`haltOnConfigCorruption` escribe el marker como JSON
 // `{ source: 'config-corruption-halt', ... }`) de una pausa MANUAL del operador
 // (marker legacy = ISO plano, o cualquier otro contenido).
 //
-// Regla fail-closed (SEC / A08 fail-closed): sólo devuelve
-// `source: 'config-corruption-halt'` cuando el marker parsea como JSON válido
-// **y** `parsed.source === 'config-corruption-halt'`. CUALQUIER otro caso
-// (ISO plano legacy, JSON malformado, `source` distinto, string vacío,
-// archivo ilegible, o inexistente) → `manual`/`unknown`, es decir NUNCA
-// auto-recuperable. Esto garantiza que un auto-recovery ingenuo jamás pise una
-// pausa que el operador puso a propósito (CA-3).
+// Regla fail-closed (SEC / A08 fail-closed): sólo devuelve un `source`
+// AUTO-LEVANTABLE cuando el marker parsea como JSON válido **y** `parsed.source`
+// pertenece por igualdad exacta a `AUTO_LIFTABLE_SOURCES`. CUALQUIER otro caso
+// (ISO plano legacy, JSON malformado, array/null/primitivo, marker gigante,
+// `source` distinto, string vacío, archivo ilegible, o inexistente) →
+// `manual`/`unknown`, es decir NUNCA auto-recuperable. Esto garantiza que un
+// auto-recovery ingenuo jamás pise una pausa que el operador puso a propósito
+// (CA-3 de #4832, CA-8/CA-10 de #5399).
 //
-// @returns {{ source: 'config-corruption-halt'|'manual'|'unknown', raw: string|null }}
+// #5399 — El retorno se enriquece de forma ADITIVA (`source` y `raw` siguen
+// exactamente con la semántica anterior, así que `pulpo.js` y
+// `lib/operational-state.js` no rompen):
+//   - `rawSource`: el string de autoría LITERAL del marker (o null si no se pudo
+//     determinar). Es lo que `preserveFullPause` copia verbatim; devolverlo
+//     nunca puede promover autoría porque sale del disco tal cual.
+//   - `ts` / `detail` / `preservedFrom`: metadata original del marker.
+//   - `undetermined`: motivo por el que la autoría no pudo determinarse
+//     (null cuando sí se determinó). CA-6: deja registro.
+//
+// @returns {{
+//   source: 'config-corruption-halt'|'manual'|'unknown',
+//   rawSource: string|null, ts: string|null, detail: string|null,
+//   preservedFrom: object|null, undetermined: string|null, raw: string|null
+// }}
 // -----------------------------------------------------------------------------
+
+// #5399 CA-8 (SEC-1) — Allowlist POSITIVA de autorías auto-levantables. La
+// pertenencia se evalúa por igualdad exacta contra este conjunto cerrado.
+// **Prohibido** decidir el auto-levantado por negación (`source !== 'human'`):
+// eso invierte el default y reanuda dispatch que el operador frenó a propósito.
+//
+// `kernel-cutover-degraded-halt` (`pulpo.js`, #5135) NO entra acá a propósito:
+// es una pausa automática cuya NO-recuperación es deliberada (exige rollback
+// manual). Ver el test de regresión nombrado en
+// `__tests__/restart-preserve-pause-5399.test.js`.
+const AUTO_LIFTABLE_SOURCES = Object.freeze(['config-corruption-halt']);
+
+// #5399 CA-10 (SEC-3) — cap de tamaño ANTES de `JSON.parse`. Un marker de 64KB
+// ya es tres órdenes de magnitud más grande que cualquier marker legítimo.
+const MAX_PAUSE_MARKER_BYTES = 64 * 1024;
+
+// Caps defensivos de los campos que copiamos verbatim: el marker es un archivo
+// que cualquier proceso del host puede escribir, no una fuente confiable.
+const MAX_PAUSE_TS_LEN = 64;
+const MAX_PAUSE_SOURCE_LEN = 100;
+
+/**
+ * ¿Esta autoría habilita el auto-levantado de la pausa total?
+ *
+ * Pertenencia exacta a `AUTO_LIFTABLE_SOURCES` (CA-8 / SEC-1). Cualquier valor
+ * no-string, desconocido o ambiguo → `false` (fail-closed).
+ *
+ * @param {unknown} source
+ * @returns {boolean}
+ */
+function isAutoLiftableSource(source) {
+    return typeof source === 'string' && AUTO_LIFTABLE_SOURCES.includes(source);
+}
+
 function readFullPauseOrigin() {
+    const empty = {
+        source: 'unknown', rawSource: null, ts: null, detail: null,
+        preservedFrom: null, undetermined: null, raw: null,
+    };
     let raw = null;
     try {
         if (!fs.existsSync(pauseFile())) {
-            return { source: 'unknown', raw: null };
+            return { ...empty, undetermined: 'marker_ausente' };
+        }
+        const st = fs.statSync(pauseFile());
+        if (st.size > MAX_PAUSE_MARKER_BYTES) {
+            // Marker desproporcionado → fail-closed sin parsear (SEC-3).
+            return { ...empty, source: 'manual', undetermined: 'marker_demasiado_grande' };
         }
         raw = fs.readFileSync(pauseFile(), 'utf8');
     } catch {
         // Ilegible → fail-closed (no auto-recuperable).
-        return { source: 'manual', raw: null };
+        return { ...empty, source: 'manual', undetermined: 'marker_ilegible' };
     }
     const trimmed = typeof raw === 'string' ? raw.trim() : '';
     if (!trimmed) {
         // Vacío → manual (fail-closed).
-        return { source: 'manual', raw };
+        return { ...empty, source: 'manual', undetermined: 'marker_vacio', raw };
     }
     let parsed;
     try {
         parsed = JSON.parse(trimmed);
     } catch {
         // No es JSON (ej. ISO plano legacy) → manual (fail-closed).
-        return { source: 'manual', raw };
+        return { ...empty, source: 'manual', undetermined: 'marker_legacy_no_json', raw };
     }
-    if (parsed && typeof parsed === 'object' && parsed.source === 'config-corruption-halt') {
-        return { source: 'config-corruption-halt', raw };
+    // SEC-3: sólo objeto plano. Array / null / primitivo → fail-closed.
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        return { ...empty, source: 'manual', undetermined: 'marker_no_es_objeto', raw };
+    }
+    // SEC-3: lectura CAMPO POR CAMPO. Prohibido `{ ...defaults, ...parsed }` /
+    // `Object.assign` / deep-merge: son el vector de prototype pollution vía
+    // `__proto__` / `constructor.prototype`.
+    const rawSource = (typeof parsed.source === 'string' && parsed.source.length <= MAX_PAUSE_SOURCE_LEN)
+        ? parsed.source : null;
+    const ts = (typeof parsed.ts === 'string' && parsed.ts.length <= MAX_PAUSE_TS_LEN)
+        ? parsed.ts : null;
+    const detail = typeof parsed.detail === 'string' ? parsed.detail : null;
+    const preservedFrom = (parsed.preservedFrom && typeof parsed.preservedFrom === 'object'
+        && !Array.isArray(parsed.preservedFrom)) ? parsed.preservedFrom : null;
+    if (isAutoLiftableSource(rawSource)) {
+        return { source: rawSource, rawSource, ts, detail, preservedFrom, undetermined: null, raw };
     }
     // JSON válido pero con otro source (o sin source) → manual (fail-closed).
-    return { source: 'manual', raw };
+    return {
+        source: 'manual',
+        rawSource,
+        ts,
+        detail,
+        preservedFrom,
+        undetermined: rawSource ? null : 'marker_sin_source',
+        raw,
+    };
 }
 
 /**
@@ -842,11 +922,26 @@ function readFullPauseOrigin() {
  * `previous == current` con `extra.full_pause: true` para trazabilidad. Write
  * atómico bajo lock del marker `.paused`.
  *
+ * #5399 CA-1 — el marker deja de ser un timestamp ISO pelado y pasa a ser el
+ * mismo objeto estructurado que escribe `haltOnConfigCorruption`
+ * (`{ source, ts, detail }`). Antes de este cambio `opts.source` se recibía y
+ * se DESCARTABA: por eso toda pausa del wizard/dashboard quedaba indistinguible
+ * de una legacy y se degradaba a autoría desconocida. El campo que decide el
+ * auto-levantado sigue siendo `source` (contrato de `readFullPauseOrigin`), y
+ * como los sources humanos no están en `AUTO_LIFTABLE_SOURCES`, persistirlos
+ * gana trazabilidad sin habilitar ningún auto-levantado nuevo.
+ *
  * @param {{ source?: string, authorizedBy?: string, justification?: string, extra?: Object }} [opts]
- * @returns {{ ok: boolean, existedBefore: boolean }}
+ * @returns {{ ok: boolean, existedBefore: boolean, source: string, autoLiftable: boolean }}
  */
 function setFullPause(opts = {}) {
     const previous = readPreviousAllowlist();
+    const source = typeof opts.source === 'string' && opts.source.trim()
+        ? opts.source.trim().slice(0, MAX_PAUSE_SOURCE_LEN)
+        : 'unknown';
+    // CA-12 (SEC-5/SEC-6): el detalle se sanitiza ANTES de persistirlo, no sólo
+    // al auditarlo — el marker lo leen el dashboard y `/status`.
+    const detail = audit.sanitizeJustification(opts.justification || '').sanitized;
     audit.appendMutation({
         source: opts.source || 'unknown',
         action: 'write',
@@ -858,14 +953,142 @@ function setFullPause(opts = {}) {
     });
     return withLockSync(pauseFile(), () => {
         const existedBefore = fs.existsSync(pauseFile());
-        atomicWriteFile(pauseFile(), new Date().toISOString());
-        return { ok: true, existedBefore };
+        atomicWriteFile(pauseFile(), JSON.stringify({
+            source,
+            ts: new Date().toISOString(),
+            detail,
+        }));
+        return { ok: true, existedBefore, source, autoLiftable: isAutoLiftableSource(source) };
     }, {
         component: 'full-pause-lock',
         timeoutMs: LOCK_TIMEOUT_MS,
         maxRetries: LOCK_MAX_RETRIES,
         notify: notifyTelegram,
     });
+}
+
+/**
+ * Rescata el timestamp de un marker legacy (ISO plano, sin metadatos). Devuelve
+ * null si el contenido no es una fecha parseable — nunca inventa un valor.
+ *
+ * @param {string|null} raw
+ * @returns {string|null}
+ */
+function legacyIsoFromRaw(raw) {
+    if (typeof raw !== 'string') return null;
+    const trimmed = raw.trim();
+    if (!trimmed || trimmed.length > MAX_PAUSE_TS_LEN) return null;
+    const t = Date.parse(trimmed);
+    if (!Number.isFinite(t)) return null;
+    return new Date(t).toISOString();
+}
+
+/**
+ * #5399 — Preserva la pausa total vigente A TRAVÉS de un `/restart`.
+ *
+ * El bug que arregla: `restart.js` conservaba la pausa (correcto: un restart no
+ * es un destrabe implícito) pero la reescribía con `new Date().toISOString()`,
+ * destruyendo el metadato de origen. Sin autoría, `readFullPauseOrigin` la lee
+ * como `manual` y el auto-recovery de #4832 nunca la levanta — el pipeline
+ * quedaba pausado para siempre (evidencia real: 1h33 sin despachar el
+ * 2026-08-02).
+ *
+ * Copia VERBATIM `source` + `ts` + `detail` del marker vigente y sólo agrega
+ * `preservedFrom`. NUNCA sintetiza ni promueve autoría (CA-9 / SEC-4): los
+ * valores salen del disco tal cual, así que humana/desconocida jamás pueden
+ * salir auto-levantables.
+ *
+ * Idempotente frente al re-exec de `restart.js` (#2880): el marker se lee del
+ * disco DENTRO del lock, en el momento del write. N re-ejecuciones pisan
+ * `preservedFrom` pero dejan `source`/`ts` intactos.
+ *
+ * Degradación segura: si el lock no se puede adquirir (Pulpo viejo agonizando),
+ * NO se escribe ni se borra nada — el marker original queda intacto, que ya es
+ * la preservación correcta. Sólo se pierde la anotación de `preservedFrom`.
+ *
+ * @param {{ authorizedBy?: string }} [opts]
+ * @returns {{ ok: boolean, existed: boolean, source?: string, autoLiftable?: boolean,
+ *             undetermined?: string|null, lockFailed?: boolean, reason?: string }}
+ */
+function preserveFullPause(opts = {}) {
+    const previous = readPreviousAllowlist();
+    const authorizedBy = opts.authorizedBy || 'restart:preserve-pause';
+    try {
+        return withLockSync(pauseFile(), () => {
+            // Dentro del lock: sin TOCTOU entre el read y el write.
+            if (!fs.existsSync(pauseFile())) {
+                return { ok: false, existed: false, reason: 'sin_pausa_previa' };
+            }
+            const origin = readFullPauseOrigin();
+            // `origin.rawSource` viene LITERAL del disco; `origin.source` viene
+            // fail-closed del lector. Copiar el literal cuando existe conserva la
+            // autoría exacta (CA-2) y no puede promover nada: si el literal fuera
+            // auto-levantable, `origin.source` ya lo sería. Sin literal
+            // (marker legacy/ilegible) cae al veredicto fail-closed → 'manual'.
+            const inheritedSource = origin.rawSource || origin.source || 'manual';
+            const marker = {
+                source: inheritedSource,
+                // Un marker legacy no tiene `ts`, pero SÍ es (casi siempre) un ISO
+                // plano: rescatarlo conserva desde cuándo está pausado el pipeline,
+                // que es el dato que el operador mira. Sólo si tampoco parsea como
+                // fecha caemos a `now`.
+                ts: origin.ts || legacyIsoFromRaw(origin.raw) || new Date().toISOString(),
+                // CA-12: sanitizado antes de persistir y de auditar; nunca crudo.
+                detail: audit.sanitizeJustification(origin.detail || '').sanitized,
+                preservedFrom: { by: 'restart', at: new Date().toISOString() },
+            };
+            if (origin.undetermined) marker.undetermined = origin.undetermined;
+            const autoLiftable = isAutoLiftableSource(marker.source);
+            // Invariante del módulo: auditar ANTES de escribir. Preservar la
+            // pausa NO toca la allowlist → `previous === current`, sin removals,
+            // así que este `authorizedBy` no ensancha el gate de removals.
+            audit.appendMutation({
+                source: 'restart',
+                action: 'write',
+                previous,
+                current: previous,
+                authorizedBy,
+                justification: `restart preservo pausa heredada (source=${marker.source}`
+                    + `${origin.undetermined ? `, autoria_indeterminada=${origin.undetermined}` : ''})`,
+                extra: {
+                    full_pause: true,
+                    preserved: true,
+                    inherited_source: marker.source,
+                    inherited_ts: marker.ts,
+                    auto_liftable: autoLiftable,
+                    authorship_undetermined: origin.undetermined || null,
+                },
+            });
+            atomicWriteFile(pauseFile(), JSON.stringify(marker));
+            return {
+                ok: true,
+                existed: true,
+                source: marker.source,
+                autoLiftable,
+                undetermined: origin.undetermined || null,
+            };
+        }, {
+            component: 'full-pause-lock',
+            timeoutMs: LOCK_TIMEOUT_MS,
+            maxRetries: LOCK_MAX_RETRIES,
+            notify: notifyTelegram,
+        });
+    } catch (err) {
+        // Lock no adquirido: dejamos el marker ORIGINAL intacto (no escribir, no
+        // borrar). Sigue siendo preservación correcta — nunca borrado.
+        const origin = readFullPauseOrigin();
+        let existed = false;
+        try { existed = fs.existsSync(pauseFile()); } catch { /* best-effort */ }
+        return {
+            ok: false,
+            existed,
+            source: origin.rawSource || origin.source,
+            autoLiftable: isAutoLiftableSource(origin.rawSource || origin.source),
+            undetermined: origin.undetermined || null,
+            lockFailed: true,
+            reason: `lock_no_adquirido: ${(err && err.message) || 'desconocido'}`,
+        };
+    }
 }
 
 /**
@@ -915,8 +1138,14 @@ module.exports = {
     // #3741 — pausa total gateada (wizard de pausa, scope full).
     setFullPause,
     clearFullPause,
+    // #5399 — preservación de la pausa total a través de un /restart (verbatim).
+    preserveFullPause,
     // #4832 — lectura fail-closed del origen de la pausa total (auto vs manual).
     readFullPauseOrigin,
+    // #5399 CA-8 — allowlist positiva de autorías auto-levantables.
+    isAutoLiftableSource,
+    AUTO_LIFTABLE_SOURCES,
+    MAX_PAUSE_MARKER_BYTES,
     // #3625 — exportados para callers que quieran leer estado raw y para tests.
     readPreviousAllowlist,
     evaluateAndAudit,

--- a/.pipeline/lib/pause-notice.js
+++ b/.pipeline/lib/pause-notice.js
@@ -1,0 +1,148 @@
+'use strict';
+
+// =============================================================================
+// pause-notice.js — Copy para el operador sobre el estado de la pausa total
+// (#5399 · UX-1/UX-2/UX-3).
+//
+// EL PROBLEMA QUE RESUELVE
+// ------------------------
+// El 2026-08-02 el pipeline quedó 1h33 sin despachar tras un `/restart`, y el
+// único mensaje que el operador recibió fue:
+//
+//     🚀 *Pipeline reiniciado y listo* (modo pausado)
+//     _Todo en marcha para nuevas pruebas._
+//
+// El `(modo pausado)` estaba, pero el copy que lo rodeaba lo cancelaba: una
+// confirmación de éxito con emoji de cohete sobre un pipeline que no iba a
+// despachar nada. Nadie miró porque **el sistema avisó que estaba todo bien**.
+//
+// #5399 hace que la autoría de la pausa sobreviva al restart; este módulo hace
+// que ese dato llegue al canal que el operador realmente lee (Telegram). El log
+// de `restart.js` NO alcanza: `/restart` desde Telegram spawnea el proceso
+// detached con stdout redirigido a `logs/restart-spawn.log`.
+//
+// DISEÑO — espejo de `lib/dispatch-cause.js`:
+//   1. Funciones PURAS, sin I/O y sin dependencias: el caller lee el marker y
+//      pasa los datos ya resueltos. Testeable sin tmpdir ni mocks.
+//   2. Mapa cerrado de labels humanos: NUNCA se expone el enum crudo
+//      (`config-corruption-halt` no significa nada para el operador), igual que
+//      `dispatch-cause.js:87`. Un `source` desconocido cae al fallback genérico
+//      en vez de volcarse tal cual — el marker es un archivo que cualquier
+//      proceso del host puede escribir, no una fuente confiable de copy.
+//   3. El copy da TRES datos y nada más, en este orden (guía de `ux`):
+//      qué pasa → por qué → qué tiene que hacer el operador.
+//
+// GUARDRAILS DE COPY (bloqueantes, verificados por test)
+//   - UX-1: con el pipeline pausado, nada de emoji de éxito (🚀/✅). El cohete
+//     queda reservado para el restart COMPLETO que sí despacha.
+//   - UX-2: ningún texto instruye borrar `.pipeline/.paused`. Este issue
+//     convierte el marker en el portador de la autoría: mandar a borrarlo a mano
+//     es instruir a destruir el dato que la historia crea. El destrabe se nombra
+//     por su comando (`/reanudar`).
+//   - UX-3: el camino degradado (lock no adquirido ⇒ no quedó anotado
+//     `preservedFrom`) NO se comunica como falla. La pausa se preservó bien; un
+//     texto tipo error empuja al `rm` manual que UX-2 prohíbe.
+// =============================================================================
+
+// Labels humanos de la autoría de la pausa. Clave = `source` del marker.
+// NUNCA exponer el enum crudo al operador (mismo criterio que
+// `dispatch-cause.js:LABELS`).
+const PAUSE_SOURCE_LABELS = Object.freeze({
+    // Automáticas.
+    'config-corruption-halt': 'el config.yaml no parseaba',
+    'kernel-cutover-degraded-halt': 'el cutover del kernel quedó degradado',
+    // Humanas explícitas.
+    'telegram': 'la pusiste vos con /pausar',
+    'restart': 'la pediste vos al reiniciar',
+    'wizard': 'la pusiste vos desde el wizard',
+    'dashboard': 'la pusiste vos desde el dashboard',
+    'commander': 'la puso el commander a pedido tuyo',
+    // Fail-closed del lector.
+    'manual': 'la puso una persona',
+    'unknown': 'no quedó registrado quién la puso',
+});
+
+// Un `source` fuera del mapa jamás se vuelca crudo: el operador no lee enums, y
+// el marker no es una fuente confiable de texto.
+const PAUSE_SOURCE_LABEL_FALLBACK = 'no se pudo identificar el origen';
+
+// Qué tiene que hacer el operador. Es la parte accionable del copy.
+const RESOLUCION_AUTO_CONFIG = 'Se levanta sola cuando el config vuelva a parsear. No hace falta que hagas nada.';
+const RESOLUCION_AUTO_GENERICA = 'Se levanta sola cuando la causa se resuelva. No hace falta que hagas nada.';
+const RESOLUCION_MANUAL = 'Sigue frenado hasta que mandes /reanudar.';
+
+/**
+ * Traduce el `source` del marker a lenguaje de operador.
+ *
+ * @param {unknown} source `source` literal del marker (o null).
+ * @returns {string} label humano, nunca el enum crudo.
+ */
+function labelForSource(source) {
+    if (typeof source !== 'string') return PAUSE_SOURCE_LABEL_FALLBACK;
+    return Object.prototype.hasOwnProperty.call(PAUSE_SOURCE_LABELS, source)
+        ? PAUSE_SOURCE_LABELS[source]
+        : PAUSE_SOURCE_LABEL_FALLBACK;
+}
+
+/**
+ * Qué tiene que hacer el operador con esta pausa.
+ *
+ * @param {{ source?: string|null, autoLiftable?: boolean }} [opts]
+ * @returns {string}
+ */
+function resolucionParaPausa(opts = {}) {
+    if (!opts.autoLiftable) return RESOLUCION_MANUAL;
+    return opts.source === 'config-corruption-halt'
+        ? RESOLUCION_AUTO_CONFIG
+        : RESOLUCION_AUTO_GENERICA;
+}
+
+/**
+ * Construye el mensaje de confirmación de restart que recibe el operador por
+ * Telegram (UX-1). Función PURA.
+ *
+ * IMPORTANTE — `autoLiftable` lo decide el caller con
+ * `partialPause.isAutoLiftableSource(origin.source)`, es decir sobre el veredicto
+ * FAIL-CLOSED del lector, no sobre el `source` literal. Este módulo sólo redacta:
+ * no participa de la decisión de auto-levantado (CA-8).
+ *
+ * @param {Object} [opts]
+ * @param {'pausado'|'completo'} [opts.mode] Modo con el que se pidió el restart.
+ * @param {boolean} [opts.pauseActive] ¿Hay marker `.paused` vivo AHORA?
+ * @param {string|null} [opts.source] `source` literal del marker (para el label).
+ * @param {boolean} [opts.autoLiftable] ¿Esa pausa se auto-levanta?
+ * @param {boolean} [opts.preserved] ¿El marker trae `preservedFrom` del restart?
+ * @returns {string} mensaje listo para `sendTelegram` (markdown de Telegram).
+ */
+function buildRestartNotice(opts = {}) {
+    const mode = opts.mode === 'pausado' ? 'pausado' : 'completo';
+    const pauseActive = !!opts.pauseActive;
+
+    // Caso feliz: el pipeline despacha. Acá SÍ va el cohete.
+    if (!pauseActive && mode === 'completo') {
+        return '🚀 *Pipeline reiniciado y listo* (modo completo)\n'
+            + '_Todo en marcha para nuevas pruebas._';
+    }
+
+    // Se pidió pausado pero ya no hay pausa: la heredada se auto-levantó dentro
+    // del arranque (exactamente lo que #5399 viene a habilitar). Es buena
+    // noticia y hay que decirlo, porque el operador esperaba un pipeline frenado.
+    if (!pauseActive) {
+        return '🚀 *Pipeline reiniciado* — la pausa que traía ya se levantó sola\n'
+            + '_Volvió a despachar. No hace falta que hagas nada._';
+    }
+
+    // Pausado de verdad: nada de emoji de éxito (UX-1).
+    const label = labelForSource(opts.source);
+    const resolucion = resolucionParaPausa({ source: opts.source, autoLiftable: !!opts.autoLiftable });
+    const origen = opts.preserved ? 'pausa heredada' : 'pausa activa';
+    return `⏸️ *Pipeline reiniciado en modo PAUSADO* — ${origen} (${label})\n${resolucion}`;
+}
+
+module.exports = {
+    buildRestartNotice,
+    labelForSource,
+    resolucionParaPausa,
+    PAUSE_SOURCE_LABELS,
+    PAUSE_SOURCE_LABEL_FALLBACK,
+};

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -98,6 +98,8 @@ const productControlDrainer = require('./lib/product-control-drainer'); // #4801
 const kernelScheduler = require('./lib/kernel-scheduler');
 // #2490 — Pausa parcial con allowlist explícita de issues
 const partialPause = require('./lib/partial-pause');
+// #5399 UX-1 — Copy de operador sobre el estado de la pausa total (funciones puras).
+const pauseNotice = require('./lib/pause-notice');
 // #3518 CA-6 — Detector de desync waves.json ↔ .partial-pause.json
 const desyncDetector = require('./lib/desync-detector');
 // #4439 CA-3 — Predicado de "origen legítimo y reciente" anclado en audit #3625
@@ -1389,9 +1391,15 @@ function loadConfig() {
   // Fail-closed: readFullPauseOrigin devuelve 'config-corruption-halt' SÓLO si
   // el marker es JSON válido con ese source; cualquier ambigüedad → 'manual'
   // → NO se auto-levanta (respeta CA-3 y la pausa deliberada del operador).
+  //
+  // #5399 — la decisión pasa por `isAutoLiftableSource`: pertenencia EXACTA a la
+  // allowlist positiva `AUTO_LIFTABLE_SOURCES` del módulo dueño del estado, en
+  // vez de una comparación literal duplicada acá. Prohibido ampliar el set por
+  // negación (`source !== 'human'`) — `kernel-cutover-degraded-halt` es
+  // automática pero su no-recuperación es deliberada (#5135).
   try {
     if (fs.existsSync(PAUSE_FILE) &&
-        partialPause.readFullPauseOrigin().source === 'config-corruption-halt') {
+        partialPause.isAutoLiftableSource(partialPause.readFullPauseOrigin().source)) {
       // #5174 · CA-5 — llegar acá significa que `configResolver.resolve()` NO
       // lanzó, y post-partición eso exige que los DOS archivos hayan parseado y
       // que el documento mergeado valide. Corregir uno solo no levanta la pausa:
@@ -11320,7 +11328,26 @@ function cmdIntake(args, config) {
 }
 
 function cmdPausar() {
-  fs.writeFileSync(PAUSE_FILE, new Date().toISOString());
+  // #5399 — antes escribía un ISO pelado, así que la pausa MÁS COMÚN del
+  // operador quedaba indistinguible de un marker legacy y se degradaba a
+  // autoría desconocida. Ruteamos por el dueño del estado para que la autoría
+  // humana quede EXPLÍCITA (y no meramente inferida por fail-closed). `telegram`
+  // no está en AUTO_LIFTABLE_SOURCES → sigue exigiendo destrabe explícito.
+  // La centralización de los escritores restantes (dashboard) es #5406.
+  try {
+    partialPause.setFullPause({
+      source: 'telegram',
+      authorizedBy: 'commander:leo',
+      justification: 'pausa total solicitada por el operador vía /pausar',
+    });
+  } catch (e) {
+    // Degradación segura: si el lock no se puede tomar, la pausa igual se
+    // aplica — el halt del operador nunca puede quedar sin efecto.
+    try { fs.writeFileSync(PAUSE_FILE, JSON.stringify({
+      source: 'telegram', ts: new Date().toISOString(),
+      detail: 'pausa total solicitada por el operador vía /pausar (fallback sin lock)',
+    })); } catch { /* best-effort */ }
+  }
   paused = true;
   return '⏸️ Pulpo PAUSADO. Usar /reanudar para continuar.';
 }
@@ -18448,9 +18475,39 @@ async function mainLoop() {
       const TWO_MINUTES = 2 * 60 * 1000;
       if (data.source === 'telegram' && !data.notified && ageMs < TWO_MINUTES) {
         const mode = data.mode || (data.paused ? 'pausado' : 'completo');
-        sendTelegram(`🚀 *Pipeline reiniciado y listo* (modo ${mode})\n_Todo en marcha para nuevas pruebas._`);
+        // #5399 · UX-1 — este es el ÚNICO canal que el operador lee de verdad:
+        // el `log()` de restart.js va a `logs/restart-spawn.log` (spawn detached
+        // con stdout redirigido), así que cumplir CA-7 sólo ahí no evita el
+        // incidente. El 2026-08-02 el mensaje que llegó fue "🚀 Pipeline
+        // reiniciado y listo — Todo en marcha" sobre un pipeline que no despachó
+        // durante 1h33: el sistema avisó que estaba todo bien.
+        //
+        // El estado se lee del FILESYSTEM (fuente de verdad), no de
+        // last-restart.json: si la pausa heredada ya se auto-levantó durante
+        // este arranque (loadConfig → clearFullPause), el marker ya no está y el
+        // operador tiene que enterarse de que SÍ está despachando.
+        let pauseActive = false;
+        try { pauseActive = fs.existsSync(PAUSE_FILE); } catch { /* fail-open al copy de pausa */ }
+        let origin = null;
+        if (pauseActive) {
+          try { origin = partialPause.readFullPauseOrigin(); } catch { /* copy degradado, nunca throw */ }
+        }
+        // `autoLiftable` se decide sobre `origin.source` (veredicto FAIL-CLOSED
+        // del lector), NUNCA sobre `rawSource`: el literal sólo alimenta el label
+        // humano. Así el copy no puede prometer un auto-levantado que el gate de
+        // CA-8 no va a hacer.
+        const notice = pauseNotice.buildRestartNotice({
+          mode,
+          pauseActive,
+          source: origin ? (origin.rawSource || origin.source) : null,
+          autoLiftable: !!(origin && partialPause.isAutoLiftableSource(origin.source)),
+          preserved: !!(origin && origin.preservedFrom),
+        });
+        sendTelegram(notice);
         fs.writeFileSync(lastRestartPath, JSON.stringify({ ...data, notified: true }, null, 2));
-        log('pulpo', `Restart ${mode} confirmado via Telegram (solicitado hace ${Math.round(ageMs / 1000)}s)`);
+        log('pulpo', `Restart ${mode} confirmado via Telegram (solicitado hace ${Math.round(ageMs / 1000)}s)`
+          + ` — pausa activa=${pauseActive}`
+          + (origin ? ` autoria=${origin.rawSource || origin.source} heredada=${!!origin.preservedFrom}` : ''));
       }
     }
   } catch (e) {

--- a/.pipeline/restart.js
+++ b/.pipeline/restart.js
@@ -567,8 +567,52 @@ switch (action) {
     // launchAll() para que la versión nueva sea la que lance los componentes.
     reexecIfSelfChanged();
     if (flagPaused) {
-      fs.writeFileSync(path.join(PIPELINE, '.paused'), new Date().toISOString());
-      log('Modo PAUSADO — solo Telegram + dashboard activos (intake/lanzamiento deshabilitados)');
+      // #5399 — el restart YA NO reescribe el marker con un ISO pelado: eso
+      // destruía la autoría de la pausa y la volvía indistinguible de una
+      // manual, así que el auto-recovery de #4832 nunca la levantaba (1h33 sin
+      // despachar el 2026-08-02). Ruteamos por el dueño del estado
+      // (`lib/partial-pause.js`), que escribe bajo lock + atómico (CA-11).
+      // `require` LAZY: `stop`/`status` no pagan el costo de arrastrar
+      // file-lock + waves + audit-log + Telegram en el arranque.
+      const partialPause = require('./lib/partial-pause');
+      let res = null;
+      try {
+        if (wasPausedBefore) {
+          // El marker se lee del disco DENTRO del lock, no desde memoria: así la
+          // operación es idempotente ante el re-exec de #2880.
+          res = partialPause.preserveFullPause();
+        } else {
+          // `--paused` sin pausa previa = pausa NUEVA pedida por el operador → humana.
+          res = partialPause.setFullPause({
+            source: 'restart',
+            authorizedBy: 'restart:preserve-pause',
+            justification: 'restart --paused (pausa nueva solicitada por el operador)',
+          });
+        }
+      } catch (e) {
+        // Nunca abortamos el restart por no poder anotar la preservación: el
+        // marker original queda intacto, que ya es la preservación correcta.
+        // UX-3: no se comunica como falla. La pausa siguió preservada; lo único
+        // que faltó es el rastro del restart. Un texto de error empuja a una
+        // intervención manual sobre un estado sano.
+        log(`La pausa quedó preservada, pero no se pudo anotar el rastro del restart (${e.message})`);
+      }
+      // CA-7 — el operador tiene que poder distinguir "esperá 30s y se levanta
+      // sola" de "esto no se levanta hasta que lo destrabes a mano".
+      const autoLiftable = !!(res && res.autoLiftable);
+      const autoria = (res && res.source) || 'unknown';
+      const heredada = wasPausedBefore ? 'heredada' : 'nueva';
+      let extra = autoLiftable
+        ? 'se auto-levanta cuando la causa se resuelva'
+        : 'requiere destrabe explícito';
+      // UX-3 — el camino degradado NO es una falla: la pausa se preservó bien,
+      // sólo no quedó anotado `preservedFrom`. Redactarlo como error empuja al
+      // `rm .pipeline/.paused` manual, que destruye justo la autoría que este
+      // issue crea (UX-2).
+      if (res && res.lockFailed) extra += '; preservada tal cual, sin anotar el rastro del restart';
+      if (res && res.undetermined) extra += `; autoría no determinable (${res.undetermined})`;
+      log(`Modo PAUSADO — pausa ${heredada} (autoría: ${autoria}; ${extra}) — `
+        + 'solo Telegram + dashboard activos (intake/lanzamiento deshabilitados)');
     } else {
       try { fs.unlinkSync(path.join(PIPELINE, '.paused')); } catch {}
     }


### PR DESCRIPTION
## Qué resuelve

`restart.js` reescribía `.pipeline/.paused` con un timestamp ISO pelado, destruyendo la autoría de la pausa. Sin marca de origen, el resto del sistema leía toda pausa como "manual" y **nunca la levantaba sola**, aunque su causa automática ya estuviera resuelta. Evidencia real: 2026-08-02, 1h33 sin despacho tras un `/restart`.

## Cambios

- **`lib/partial-pause.js`** — `readFullPauseOrigin()` endurecido (lectura campo por campo, cap de 64KB antes de `JSON.parse`, rechazo de array/null/primitivo) y retorno enriquecido (`source`, `ts`, `detail`, `preservedFrom`). Nueva `preserveFullPause()` que copia **verbatim** autoría/timestamp/razón y sólo agrega `preservedFrom`. Nueva allowlist positiva `AUTO_LIFTABLE_SOURCES` + `isAutoLiftableSource()`. `setFullPause()` ahora persiste el `source` recibido en vez de descartarlo.
- **`lib/partial-pause-audit.js`** — `restart:preserve-pause` agregado al enum cerrado de `authorizedBy` (sin esto la auditoría quedaba en `action: 'reject'` silencioso).
- **`restart.js`** — rutea por `preserveFullPause()` (require lazy) en vez del `writeFileSync` plano; log que distingue "se auto-levanta" de "requiere destrabe explícito".
- **`pulpo.js`** — la comparación literal contra `'config-corruption-halt'` pasa a `isAutoLiftableSource(origin.source)`.
- **`lib/pause-notice.js`** (nuevo) — copy para el operador en Telegram, con los guardrails UX-1/UX-2/UX-3 verificados por test.

## Diseño defensivo

- **Fail-closed por allowlist positiva**: nada de `if (source !== 'human')`. Sólo pertenencia exacta a `AUTO_LIFTABLE_SOURCES` habilita auto-levantado.
- **Sin promoción de autoría**: `preserveFullPause` sólo copia lo que el lector fail-closed ya devolvió. Humana/desconocida jamás salen auto-levantables.
- **Regresión #5135 cubierta**: `kernel-cutover-degraded-halt` es automática pero deliberadamente no recuperable — no entra a la allowlist, con test que lo assertea.
- **Idempotente ante re-exec (#2880)**: el marker se lee del disco dentro del lock, no se captura en memoria.
- **Degradación por lock**: si expira, se deja el marker original intacto (nunca borrado) y se loguea.

## Verificación

```
npm run test:pipeline → tests 10699 · pass 10695 · fail 0 · skipped 4
node --test .pipeline/lib/__tests__/restart-preserve-pause-5399.test.js → 13/13
```

Verificación manual del marker:
```
$ printf '{"source":"config-corruption-halt","ts":"2026-01-01T00:00:00Z","detail":"x"}' > $TMPD/.paused
$ preserveFullPause()
{"ok":true,"existed":true,"source":"config-corruption-halt","autoLiftable":true}
$ cat $TMPD/.paused
{"source":"config-corruption-halt","ts":"2026-01-01T00:00:00Z","detail":"x","preservedFrom":{"by":"restart","at":"2026-08-03T10:33:48.387Z"}}
```
`source` y `ts` conservados verbatim, `preservedFrom` agregado.

Diff limpio: 9 archivos, todos bajo `.pipeline/`, sin espurios (`_tmp/` = 0).

Closes #5399

🤖 Generated with [Claude Code](https://claude.com/claude-code)
