### PR TITLE
[Split de #5424] Detectar y persistir la cuota semanal desde el frame final

### DIFF
--- a/.pipeline/agent-models.json
+++ b/.pipeline/agent-models.json
@@ -21,7 +21,8 @@
       "quota_error_types": [
         "usage_limit_error",
         "weekly_quota_exhausted",
-        "snapshot_threshold_90"
+        "snapshot_threshold_90",
+        "weekly_limit_content_channel"
       ],
       "resets_at_cap_max_days": 7,
       "supports_tool_use": true,

--- a/.pipeline/lib/__tests__/anthropic-usage.test.js
+++ b/.pipeline/lib/__tests__/anthropic-usage.test.js
@@ -194,3 +194,82 @@ test('getUsage con autoRefresh:true dispara el spawn cuando el cache está viejo
     assert.equal(spawned, 1);
     u._resetRefreshingForTesting();
 });
+
+// ---------------------------------------------------------------------------
+// #5455 — parseResetToIso: formatos reales del aviso semanal + fail-closed.
+//
+// Antes de #5455 el helper devolvía null para los DOS formatos reales
+// observados (hora sola "9pm" y mes/día "Aug 9, 9pm"), así que "reusar
+// parseResetToIso" no alcanzaba. Reloj fijo en todos los casos: el helper
+// resuelve en hora LOCAL (parse imperfecto por diseño, sin libs de timezone),
+// por eso las aserciones comparan contra Date locales construidos igual.
+// ---------------------------------------------------------------------------
+
+// 3-ago-2026, 12:00 hora local.
+const REF_MEDIODIA = new Date(2026, 7, 3, 12, 0, 0).getTime();
+
+function isoLocal(y, m, d, h, min) {
+    return new Date(y, m, d, h, min, 0, 0).toISOString();
+}
+
+test('#5455 · hora sola futura del mismo día → esa hora de hoy', () => {
+    const u = fresh();
+    // 21:00 aún no pasó respecto de las 12:00.
+    assert.equal(u.parseResetToIso('9pm', REF_MEDIODIA), isoLocal(2026, 7, 3, 21, 0));
+});
+
+test('#5455 · hora sola ya pasada → rollover al día siguiente', () => {
+    const u = fresh();
+    // 22:00 como referencia: las 21:00 ya pasaron → próxima ocurrencia mañana.
+    const ref = new Date(2026, 7, 3, 22, 0, 0).getTime();
+    assert.equal(u.parseResetToIso('9pm', ref), isoLocal(2026, 7, 4, 21, 0));
+});
+
+test('#5455 · hora sola en formato 24h ("21:00") también resuelve', () => {
+    const u = fresh();
+    assert.equal(u.parseResetToIso('21:00', REF_MEDIODIA), isoLocal(2026, 7, 3, 21, 0));
+});
+
+test('#5455 · mes/día futuro de /usage ("Aug 9, 9pm") → ese día del año en curso', () => {
+    const u = fresh();
+    assert.equal(u.parseResetToIso('Aug 9, 9pm', REF_MEDIODIA), isoLocal(2026, 7, 9, 21, 0));
+});
+
+test('#5455 · mes/día ya pasado → próxima ocurrencia (año siguiente)', () => {
+    const u = fresh();
+    // Jul 12 de 2026 ya pasó respecto del 3-ago-2026 → 2027.
+    assert.equal(u.parseResetToIso('Jul 12, 8:59pm', REF_MEDIODIA), isoLocal(2027, 6, 12, 20, 59));
+});
+
+test('#5455 · la TZ entre paréntesis y el prefijo "resets" se descartan', () => {
+    const u = fresh();
+    const esperado = isoLocal(2026, 7, 3, 21, 0);
+    assert.equal(u.parseResetToIso('9pm (America/Buenos_Aires)', REF_MEDIODIA), esperado);
+    assert.equal(u.parseResetToIso('resets 9pm (America/Buenos_Aires)', REF_MEDIODIA), esperado);
+});
+
+test('#5455 · reset inválido devuelve null, sin inventar fecha', () => {
+    const u = fresh();
+    for (const raw of ['banana', '', '   ', 'Feb 31, 9pm', '13pm', '25:00', '9pm x']) {
+        assert.equal(u.parseResetToIso(raw, REF_MEDIODIA), null, `debe ser null: ${JSON.stringify(raw)}`);
+    }
+});
+
+test('#5455 · REGRESIÓN: tokens numéricos sueltos NO se resuelven a fechas inventadas', () => {
+    // Date.parse es tan permisivo que resolvía estos tokens a fechas PASADAS
+    // ("9" → 2001-09-01, "2020" → 2020-01-01). Como el helper ahora recibe el
+    // reset capturado del canal de CONTENIDO (controlable por el modelo), un
+    // aviso truncado como "...· resets 9" habría producido un resetsAt en el
+    // pasado y, tras el clamp, un gate de 5 minutos en vez del gate corto
+    // esperado. El fallback legacy exige ahora un token de mes conocido.
+    const u = fresh();
+    for (const raw of ['9', '12', '99', '2020', '0', '00', '1 2', '9 9', 'x 9']) {
+        assert.equal(u.parseResetToIso(raw, REF_MEDIODIA), null, `debe ser null: ${JSON.stringify(raw)}`);
+    }
+});
+
+test('#5455 · refMs inválido no rompe: cae al reloj real y devuelve ISO o null', () => {
+    const u = fresh();
+    const out = u.parseResetToIso('Aug 9, 9pm', NaN);
+    assert.ok(out === null || !Number.isNaN(Date.parse(out)));
+});

--- a/.pipeline/lib/__tests__/quota-exhausted-content-channel-5455.test.js
+++ b/.pipeline/lib/__tests__/quota-exhausted-content-channel-5455.test.js
@@ -299,7 +299,7 @@ test('#5455 · detectWeeklyLimitContentChannelFromLog encuentra el frame en el l
         JSON.stringify({ type: 'result', result: AVISO_SEMANAL }),
     ].join('\n');
 
-    const r = q.detectWeeklyLimitContentChannelFromLog(log, { now: NOW });
+    const r = q.detectWeeklyLimitContentChannelFromLog(log, { now: NOW, providerId: 'anthropic' });
     assert.ok(r, 'debe encontrar el frame final');
     assert.equal(r.errorType, 'weekly_limit_content_channel');
     assert.equal(r.source, q.WEEKLY_LIMIT_CONTENT_SOURCE);
@@ -317,13 +317,63 @@ test('#5455 · el barrido del log ignora menciones y frames que no son `result`'
         JSON.stringify({ type: 'result', result: `Te explico: "${AVISO_SEMANAL}" significa corte semanal.` }),
     ].join('\n');
 
-    assert.equal(q.detectWeeklyLimitContentChannelFromLog(log, { now: NOW }), null);
+    assert.equal(q.detectWeeklyLimitContentChannelFromLog(log, { now: NOW, providerId: 'anthropic' }), null);
 });
 
 test('#5455 · el barrido es defensivo ante entradas vacias o no-string', () => {
     const q = freshModule(newTmpDir());
 
     for (const raw of ['', null, undefined, 42, {}]) {
-        assert.equal(q.detectWeeklyLimitContentChannelFromLog(raw), null, `entrada: ${String(raw)}`);
+        assert.equal(
+            q.detectWeeklyLimitContentChannelFromLog(raw, { now: NOW, providerId: 'anthropic' }),
+            null,
+            `entrada: ${String(raw)}`,
+        );
     }
+});
+
+// -----------------------------------------------------------------------------
+// SCOPE ANTHROPIC enforced (fix del rechazo de #5455)
+//
+// El barrido forzaba `providerId: DEFAULT_PROVIDER` hardcodeado, así que
+// matcheaba con CUALQUIER provider y el caller persistía el tipo dedicado con el
+// provider que realmente corrió. Ahora el providerId real es obligatorio.
+// -----------------------------------------------------------------------------
+
+test('#5455 · el barrido NO matchea con un provider que no es Anthropic', () => {
+    const q = freshModule(newTmpDir());
+    const log = JSON.stringify({ type: 'result', result: AVISO_SEMANAL });
+
+    // Precondición: el MISMO log matchea con Anthropic.
+    assert.ok(q.detectWeeklyLimitContentChannelFromLog(log, { now: NOW, providerId: 'anthropic' }),
+        'precondición: el log es un match legítimo para Anthropic');
+
+    for (const p of ['openai-codex', 'openai', 'gemini', 'ollama']) {
+        assert.equal(
+            q.detectWeeklyLimitContentChannelFromLog(log, { now: NOW, providerId: p }),
+            null,
+            `el tipo dedicado de Anthropic no debe aterrizar sobre ${p}`,
+        );
+    }
+});
+
+test('#5455 · el barrido es fail-closed si no se declara el provider', () => {
+    const q = freshModule(newTmpDir());
+    const log = JSON.stringify({ type: 'result', result: AVISO_SEMANAL });
+
+    // Sin providerId no hay default implícito: un caller que se olvide de
+    // declararlo obtiene "no match", nunca un flag espurio de Anthropic.
+    for (const opts of [{ now: NOW }, { now: NOW, providerId: '' }, { now: NOW, providerId: null }]) {
+        assert.equal(q.detectWeeklyLimitContentChannelFromLog(log, opts), null,
+            `sin provider declarado debe fallar cerrado: ${JSON.stringify(opts)}`);
+    }
+});
+
+test('#5455 · el barrido acepta el alias de Anthropic ya canonicalizado', () => {
+    const q = freshModule(newTmpDir());
+    const log = JSON.stringify({ type: 'result', result: AVISO_SEMANAL });
+
+    const r = q.detectWeeklyLimitContentChannelFromLog(log, { now: NOW, providerId: 'anthropic-claude' });
+    assert.ok(r, 'el alias debe canonicalizar a `anthropic` y matchear');
+    assert.equal(r.errorType, 'weekly_limit_content_channel');
 });

--- a/.pipeline/lib/__tests__/quota-exhausted-content-channel-5455.test.js
+++ b/.pipeline/lib/__tests__/quota-exhausted-content-channel-5455.test.js
@@ -1,0 +1,329 @@
+// =============================================================================
+// quota-exhausted-content-channel-5455.test.js — Canal de CONTENIDO de Anthropic
+// (#5455, hija de #5424).
+//
+// `quota-exhausted.js` documenta como invariante que está PROHIBIDO matchear
+// contra campos controlados por el modelo. #5424 demostró que existe UN caso
+// real sin otro canal: al cortar por límite SEMANAL, el CLI de Anthropic emite
+// el aviso como frame final `type:'result'` SIN `is_error` ni `error_type`, así
+// que el path estructural lo descarta, el flag nunca se persiste y el fallback
+// pre-spawn vuelve a elegir Anthropic (incidente 2026-08-02, ~1h sin Commander).
+//
+// Esta suite fija las compensaciones que hacen aceptable la excepción — quitar
+// cualquiera reabre el DoS auto-infligido por contenido inducido:
+//   1. scope Anthropic (allowlist + providerId explícito)
+//   2. frame COMPLETO (regex anclado; una mención embebida no matchea)
+//   3. shapes cerrados (string, o bloques exclusivamente textuales)
+//   4. cota dura de 200 caracteres
+//   5. regex anclado con cuantificadores acotados
+//   6. tipo dedicado `weekly_limit_content_channel`
+//   8. procedencia explícita + excerpt redactado
+//
+// La compensación 7 (TTL efectivo ≤ 60 min) y el bypass del veto de #4865 se
+// cubren en `quota-exhausted-reconcile-4865.test.js`, donde vive el reconcile.
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { seedPipelineConfig } = require('./_test-helpers');
+
+function freshModule(tmpDir) {
+    process.env.PIPELINE_DIR_OVERRIDE = tmpDir;
+    delete require.cache[require.resolve('../quota-exhausted')];
+    return require('../quota-exhausted');
+}
+
+function newTmpDir() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'v3-quota-content-5455-'));
+    // #5172: el sandbox ES el `.pipeline/` del test; sin `config.yaml` la
+    // lectura de config es un fallo tipado. Documento mínimo.
+    seedPipelineConfig(dir);
+    return dir;
+}
+
+// Texto real del incidente y sus variantes observadas.
+const AVISO_SEMANAL = "You've hit your weekly limit · resets 9pm (America/Buenos_Aires)";
+const AVISO_CON_FECHA = "You've hit your weekly limit · resets Aug 9, 9pm (America/Buenos_Aires)";
+const AVISO_PELADO = "You've hit your weekly limit";
+
+// Reloj fijo: el reset se parsea con `parseResetToIso`, que es sensible al reloj.
+const NOW = Date.parse('2026-08-03T12:00:00Z');
+
+function anthropicAllowlist(q) {
+    return q.KNOWN_QUOTA_ERROR_TYPES_BY_PROVIDER.anthropic;
+}
+
+// Envuelve el detector con los defaults del caso feliz, para que cada test
+// exprese sólo lo que cambia.
+function detectar(q, result, opts = {}) {
+    const { allowlist, ...rest } = opts;
+    return q._detectAnthropicContentChannel(
+        { type: 'result', result },
+        allowlist === undefined ? anthropicAllowlist(q) : allowlist,
+        { providerId: 'anthropic', now: NOW, ...rest },
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Casos POSITIVOS — el aviso real, en sus shapes y variantes observadas
+// -----------------------------------------------------------------------------
+
+test('#5455 · frame string del aviso semanal → match con tipo, procedencia y reset', () => {
+    const q = freshModule(newTmpDir());
+
+    const r = detectar(q, AVISO_SEMANAL);
+    assert.ok(r, 'el aviso real debe matchear');
+    assert.equal(r.matched, true);
+    assert.equal(r.errorType, 'weekly_limit_content_channel');
+    assert.equal(r.errorType, q.WEEKLY_LIMIT_CONTENT_ERROR_TYPE);
+    assert.equal(r.source, q.WEEKLY_LIMIT_CONTENT_SOURCE, 'procedencia auditable');
+    assert.ok(r.resetsAt && !Number.isNaN(Date.parse(r.resetsAt)), 'reset parseado a ISO');
+});
+
+test('#5455 · variantes reales: con mes/dia, pelado y apostrofe tipografico', () => {
+    const q = freshModule(newTmpDir());
+
+    assert.ok(detectar(q, AVISO_CON_FECHA), 'con mes/dia debe matchear');
+    assert.ok(detectar(q, AVISO_SEMANAL.replace("'", '’')), 'apostrofe curly');
+
+    const pelado = detectar(q, AVISO_PELADO);
+    assert.ok(pelado, 'sin clausula de reset debe matchear igual');
+    assert.equal(pelado.resetsAt, null, 'sin reset en el texto → null, sin inventar fecha');
+});
+
+test('#5455 · whitespace exterior no invalida el match (trim solo exterior)', () => {
+    const q = freshModule(newTmpDir());
+
+    assert.ok(detectar(q, `\n\t   ${AVISO_SEMANAL}   \n`), 'debe matchear tras trim');
+});
+
+test('#5455 · bloques EXCLUSIVAMENTE textuales → match (shape array)', () => {
+    const q = freshModule(newTmpDir());
+
+    const r = detectar(q, [
+        { type: 'text', text: "You've hit your weekly limit" },
+        { type: 'text', text: ' · resets 9pm (America/Buenos_Aires)' },
+    ]);
+    assert.ok(r, 'bloques textuales concatenados deben matchear');
+    assert.equal(r.errorType, 'weekly_limit_content_channel');
+});
+
+// -----------------------------------------------------------------------------
+// Casos NEGATIVOS — el vector de DoS auto-infligido
+// -----------------------------------------------------------------------------
+
+test('#5455 · mencion embebida en una respuesta larga NO activa el gate', () => {
+    const q = freshModule(newTmpDir());
+
+    // EL caso de DoS: un agente que explica el incidente (o un comentario /
+    // handoff que lo cite) no debe gatear a Anthropic.
+    const largo = `Claro, te explico: cuando aparece "${AVISO_SEMANAL}" el pipeline `
+        + 'debe persistir el flag y caer a Codex en el turno siguiente.';
+    assert.equal(detectar(q, largo), null);
+});
+
+test('#5455 · contenido extra alrededor del aviso NO matchea (frame completo)', () => {
+    const q = freshModule(newTmpDir());
+
+    assert.equal(detectar(q, `${AVISO_SEMANAL} and also more text here`), null, 'sufijo');
+    assert.equal(detectar(q, `Nota: ${AVISO_SEMANAL}`), null, 'prefijo');
+});
+
+test('#5455 · contenido por encima de 200 caracteres NO matchea (cota dura)', () => {
+    const q = freshModule(newTmpDir());
+
+    assert.equal(q.WEEKLY_LIMIT_CONTENT_MAX_CHARS, 200);
+    const largo = `${AVISO_PELADO} ${'x'.repeat(201 - AVISO_PELADO.length - 1)}`;
+    assert.equal(largo.length, 201, 'el caso debe medir exactamente 201');
+    assert.equal(detectar(q, largo), null);
+
+    // El regex anclado es una cota AUN mas estricta: ningun aviso valido llega
+    // a 200 chars. La cota es defensa en profundidad — garantiza que el regex
+    // nunca corra sobre entradas grandes (anti-ReDoS).
+    assert.ok(AVISO_CON_FECHA.length < q.WEEKLY_LIMIT_CONTENT_MAX_CHARS);
+});
+
+test('#5455 · un solo bloque no textual invalida TODO el frame (fail-closed)', () => {
+    const q = freshModule(newTmpDir());
+
+    // No se filtran los bloques textuales "que sirven": eso permitiria esconder
+    // el aviso dentro de una respuesta con uso de herramientas.
+    assert.equal(detectar(q, [
+        { type: 'text', text: AVISO_SEMANAL },
+        { type: 'tool_use', id: 'x', name: 'Bash', input: {} },
+    ]), null, 'bloque tool_use');
+    assert.equal(detectar(q, [
+        { type: 'text', text: AVISO_SEMANAL },
+        { type: 'image', source: {} },
+    ]), null, 'bloque image');
+    assert.equal(detectar(q, [{ type: 'text', text: 123 }]), null, 'text no-string');
+    assert.equal(detectar(q, []), null, 'array vacio');
+    assert.equal(detectar(q, [null]), null, 'bloque null');
+});
+
+test('#5455 · mas bloques que el maximo permitido → fail-closed', () => {
+    const q = freshModule(newTmpDir());
+
+    const demasiados = Array.from(
+        { length: q.WEEKLY_LIMIT_CONTENT_MAX_BLOCKS + 1 },
+        () => ({ type: 'text', text: 'a' }),
+    );
+    assert.equal(detectar(q, demasiados), null);
+});
+
+test('#5455 · shapes no contemplados de `result` → null', () => {
+    const q = freshModule(newTmpDir());
+
+    for (const raw of [undefined, null, 42, true, { text: AVISO_SEMANAL }]) {
+        assert.equal(q._normalizeAnthropicResultContent(raw), null, `shape: ${String(raw)}`);
+    }
+    assert.equal(q._normalizeAnthropicResultContent(AVISO_SEMANAL), AVISO_SEMANAL, 'string pasa');
+});
+
+// -----------------------------------------------------------------------------
+// Scope — el path es Anthropic-only por construccion
+// -----------------------------------------------------------------------------
+
+test('#5455 · un provider distinto de anthropic NO activa el path', () => {
+    const q = freshModule(newTmpDir());
+
+    assert.equal(detectar(q, AVISO_SEMANAL, { providerId: 'openai-codex' }), null);
+    assert.equal(detectar(q, AVISO_SEMANAL, { providerId: 'cerebras' }), null);
+    // El alias canonico si es aceptado (mismo provider, otro id).
+    assert.ok(detectar(q, AVISO_SEMANAL, { providerId: 'anthropic-claude' }));
+});
+
+test('#5455 · sin el tipo en la allowlist del provider en uso, el path no aplica', () => {
+    const q = freshModule(newTmpDir());
+
+    assert.equal(detectar(q, AVISO_SEMANAL, { allowlist: ['usage_limit_error'] }), null);
+    assert.equal(detectar(q, AVISO_SEMANAL, { allowlist: null }), null);
+});
+
+test('#5455 · un evento que no es `result` nunca llega al canal de contenido', () => {
+    const q = freshModule(newTmpDir());
+
+    const al = anthropicAllowlist(q);
+    for (const type of ['assistant', 'system', 'user']) {
+        const r = q._detectAnthropic({ type, result: AVISO_SEMANAL }, al, { providerId: 'anthropic' });
+        assert.equal(r.matched, false, `type=${type} no debe matchear`);
+    }
+});
+
+test('#5455 · el tipo dedicado esta en la meta-allowlist SOLO para anthropic', () => {
+    const q = freshModule(newTmpDir());
+
+    const tipo = q.WEEKLY_LIMIT_CONTENT_ERROR_TYPE;
+    const mapa = q.KNOWN_QUOTA_ERROR_TYPES_BY_PROVIDER;
+    assert.ok(mapa.anthropic.includes(tipo), 'anthropic debe declararlo');
+    for (const [prov, tipos] of Object.entries(mapa)) {
+        if (prov === 'anthropic') continue;
+        assert.ok(!tipos.includes(tipo), `${prov} NO debe declarar el tipo dedicado`);
+    }
+});
+
+test('#5455 · el tipo dedicado esta sincronizado con agent-models.json', () => {
+    const q = freshModule(newTmpDir());
+
+    // Drift entre la meta-allowlist y el JSON hace fail-fast al boot
+    // (`agent-models-validate.js`), asi que ambos deben cambiar juntos.
+    const modelsPath = path.join(__dirname, '..', '..', 'agent-models.json');
+    const models = JSON.parse(fs.readFileSync(modelsPath, 'utf8'));
+    const declarados = models.providers.anthropic.quota_error_types;
+    assert.ok(
+        declarados.includes(q.WEEKLY_LIMIT_CONTENT_ERROR_TYPE),
+        'agent-models.json debe declarar weekly_limit_content_channel para anthropic',
+    );
+    for (const t of declarados) {
+        assert.ok(
+            q.KNOWN_QUOTA_ERROR_TYPES_BY_PROVIDER.anthropic.includes(t),
+            `${t} debe estar en la meta-allowlist hardcodeada`,
+        );
+    }
+});
+
+// -----------------------------------------------------------------------------
+// Procedencia, redaccion y convivencia con el path estructural
+// -----------------------------------------------------------------------------
+
+test('#5455 · el excerpt persistido es el contenido normalizado y redactado', () => {
+    const q = freshModule(newTmpDir());
+
+    const r = detectar(q, `   ${AVISO_SEMANAL}   `);
+    assert.equal(r.rawExcerpt, AVISO_SEMANAL, 'sin whitespace exterior');
+    assert.ok(!/[\r\n]/.test(r.rawExcerpt), 'sin saltos de linea (anti log-injection)');
+    assert.ok(r.rawExcerpt.length <= q.WEEKLY_LIMIT_CONTENT_MAX_CHARS);
+});
+
+test('#5455 · el path estructural de siempre sigue intacto', () => {
+    const q = freshModule(newTmpDir());
+
+    const r = q._detectAnthropic(
+        {
+            type: 'result',
+            is_error: true,
+            error_type: 'usage_limit_error',
+            resets_at: '2026-08-03T20:00:00Z',
+        },
+        anthropicAllowlist(q),
+        { providerId: 'anthropic' },
+    );
+    assert.equal(r.matched, true);
+    assert.equal(r.errorType, 'usage_limit_error', 'el canal de contenido no lo pisa');
+});
+
+test('#5455 · _detectAnthropic sin opts conserva el contrato previo', () => {
+    const q = freshModule(newTmpDir());
+
+    // Los callers legacy no pasan `opts`; el detector no debe romper.
+    const r = q._detectAnthropic({ type: 'result', result: AVISO_SEMANAL }, anthropicAllowlist(q));
+    assert.equal(r.matched, true, 'sin providerId el scope lo ancla la allowlist');
+    assert.equal(r.errorType, 'weekly_limit_content_channel');
+});
+
+// -----------------------------------------------------------------------------
+// Barrido del log crudo — fuente compartida por adapter y dispatcher
+// -----------------------------------------------------------------------------
+
+test('#5455 · detectWeeklyLimitContentChannelFromLog encuentra el frame en el log crudo', () => {
+    const q = freshModule(newTmpDir());
+
+    const log = [
+        'no soy json',
+        JSON.stringify({ type: 'system', subtype: 'init' }),
+        JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'hola' }] } }),
+        JSON.stringify({ type: 'result', result: AVISO_SEMANAL }),
+    ].join('\n');
+
+    const r = q.detectWeeklyLimitContentChannelFromLog(log, { now: NOW });
+    assert.ok(r, 'debe encontrar el frame final');
+    assert.equal(r.errorType, 'weekly_limit_content_channel');
+    assert.equal(r.source, q.WEEKLY_LIMIT_CONTENT_SOURCE);
+    assert.ok(r.resetsAt, 'debe traer el reset ya parseado');
+});
+
+test('#5455 · el barrido del log ignora menciones y frames que no son `result`', () => {
+    const q = freshModule(newTmpDir());
+
+    const log = [
+        JSON.stringify({
+            type: 'assistant',
+            message: { content: [{ type: 'text', text: AVISO_SEMANAL }] },
+        }),
+        JSON.stringify({ type: 'result', result: `Te explico: "${AVISO_SEMANAL}" significa corte semanal.` }),
+    ].join('\n');
+
+    assert.equal(q.detectWeeklyLimitContentChannelFromLog(log, { now: NOW }), null);
+});
+
+test('#5455 · el barrido es defensivo ante entradas vacias o no-string', () => {
+    const q = freshModule(newTmpDir());
+
+    for (const raw of ['', null, undefined, 42, {}]) {
+        assert.equal(q.detectWeeklyLimitContentChannelFromLog(raw), null, `entrada: ${String(raw)}`);
+    }
+});

--- a/.pipeline/lib/__tests__/quota-exhausted-reconcile-4865.test.js
+++ b/.pipeline/lib/__tests__/quota-exhausted-reconcile-4865.test.js
@@ -268,3 +268,244 @@ test('#4865 · reconcile fail-closed si el adapter lanza excepción', () => {
     assert.equal(r.veto, false);
     assert.equal(r.reason, 'adapter_threw');
 });
+
+// =============================================================================
+// #5455 — ÚNICA excepción al veto `provider_healthy_fresh`: el aviso semanal de
+// Anthropic recibido por el canal de CONTENIDO.
+//
+// Por qué existe la excepción: durante el incidente real (2026-08-02) el adapter
+// canónico reportaba `ok/pct:3` MIENTRAS Anthropic ya había cortado por límite
+// semanal — el corte no se refleja en `/usage` a tiempo. El reconcile de #4865,
+// correcto para señales por substring, vetaría entonces la única señal fidedigna
+// que existe para este corte.
+//
+// El bypass exige las DOS condiciones a la vez (provider canónico `anthropic` Y
+// `weekly_limit_content_channel`) y se aplica con el MISMO predicado en SET
+// (`setFlag`) y en GET (`shouldGateSpawn`). Exceptuar sólo el SET escribiría un
+// slot que el GET ignora con el adapter sano: el turno siguiente volvería a
+// elegir Anthropic y el gate no serviría de nada.
+// =============================================================================
+
+const CONTENT_TYPE = 'weekly_limit_content_channel';
+const HEALTHY_FRESH_LOW = { adapterStatus: 'ok', pct: 3, status: 'normal' };
+
+// -----------------------------------------------------------------------------
+// SET — setFlag persiste el subtipo dedicado pese al adapter sano
+// -----------------------------------------------------------------------------
+
+test('#5455 · SET: setFlag persiste weekly_limit_content_channel con el adapter sano/fresco', () => {
+    const tmp = newTmpDir();
+    const q = freshModule(tmp);
+
+    const res = q.setFlag({
+        errorType: CONTENT_TYPE,
+        provider: 'anthropic',
+        agent: 'commander',
+        // pct:3 reproduce exactamente lo observado durante el incidente.
+        _quotaAdapters: fakeAdapters(HEALTHY_FRESH_LOW),
+    });
+
+    assert.notEqual(res.vetoed, true, 'el subtipo dedicado NO debe ser vetado');
+
+    const flag = readFlag(tmp);
+    assert.ok(flag, 'el flag debe escribirse pese al adapter sano');
+    const slot = flag.providers['anthropic'];
+    assert.ok(slot, 'debe existir el slot de anthropic');
+    assert.equal(slot.pattern_matched, CONTENT_TYPE);
+
+    // El bypass queda trazable en la auditoría (procedencia del incidente).
+    const audit = readAuditLines(tmp);
+    const bypass = audit.find((a) => a.event === 'flag_set_veto_bypassed');
+    assert.ok(bypass, 'debe auditar el bypass explícitamente');
+    assert.equal(bypass.provider, 'anthropic');
+    assert.equal(bypass.error_type, CONTENT_TYPE);
+    assert.ok(!audit.some((a) => a.event === 'flag_set_vetoed'),
+        'no debe auditar un veto que no ocurrió');
+});
+
+test('#5455 · SET: el veto sigue INTACTO para usage_limit_error con adapter sano', () => {
+    const tmp = newTmpDir();
+    const q = freshModule(tmp);
+
+    const res = q.setFlag({
+        errorType: 'usage_limit_error',
+        provider: 'anthropic',
+        _quotaAdapters: fakeAdapters(HEALTHY_FRESH_LOW),
+    });
+
+    assert.equal(res.vetoed, true, 'el bypass NO se amplía a otros tipos');
+    assert.equal(readFlag(tmp), null);
+});
+
+test('#5455 · SET: el veto sigue INTACTO para los demás tipos de anthropic', () => {
+    for (const errorType of ['weekly_quota_exhausted', 'snapshot_threshold_90']) {
+        const tmp = newTmpDir();
+        const q = freshModule(tmp);
+        const res = q.setFlag({
+            errorType,
+            provider: 'anthropic',
+            _quotaAdapters: fakeAdapters(HEALTHY_FRESH_LOW),
+        });
+        assert.equal(res.vetoed, true, errorType + ' debe seguir vetado');
+        assert.equal(readFlag(tmp), null, errorType + ' no debe escribir flag');
+    }
+});
+
+test('#5455 · SET: otro provider con el MISMO tipo sigue vetado (scope Anthropic)', () => {
+    const tmp = newTmpDir();
+    const q = freshModule(tmp);
+
+    const res = q.setFlag({
+        errorType: CONTENT_TYPE,
+        provider: 'openai-codex',
+        _quotaAdapters: fakeAdapters(HEALTHY_FRESH_LOW),
+    });
+
+    assert.equal(res.vetoed, true, 'el bypass no se amplía a otros providers');
+    assert.equal(readFlag(tmp), null);
+});
+
+// -----------------------------------------------------------------------------
+// GET — shouldGateSpawn HONRA el slot dedicado pese al adapter sano
+// -----------------------------------------------------------------------------
+
+test('#5455 · GET: shouldGateSpawn honra el slot del canal de contenido con adapter sano', () => {
+    const tmp = newTmpDir();
+    const q = freshModule(tmp);
+
+    q.setFlag({
+        errorType: CONTENT_TYPE,
+        provider: 'anthropic',
+        _quotaAdapters: fakeAdapters(HEALTHY_FRESH_LOW),
+    });
+    assert.ok(readFlag(tmp), 'precondición: slot dedicado activo');
+
+    const gated = q.shouldGateSpawn('commander', {
+        provider: 'anthropic',
+        _quotaAdapters: fakeAdapters(HEALTHY_FRESH_LOW),
+    });
+    assert.equal(gated, true, 'el gate debe honrarse: sin esto el turno vuelve a Anthropic');
+
+    const audit = readAuditLines(tmp);
+    assert.ok(audit.some((a) => a.event === 'gate_veto_bypassed' && a.provider === 'anthropic'),
+        'debe auditar el bypass del GET');
+    assert.ok(!audit.some((a) => a.event === 'gate_vetoed'),
+        'no debe auditar un veto que no ocurrió');
+});
+
+test('#5455 · GET: el veto sigue INTACTO para un slot usage_limit_error con adapter sano', () => {
+    const tmp = newTmpDir();
+    const q = freshModule(tmp);
+
+    // Se siembra con NO_DATA (fail-closed) para que el slot exista.
+    q.setFlag({
+        errorType: 'usage_limit_error',
+        provider: 'anthropic',
+        _quotaAdapters: fakeAdapters(NO_DATA),
+    });
+
+    const gated = q.shouldGateSpawn('commander', {
+        provider: 'anthropic',
+        _quotaAdapters: fakeAdapters(HEALTHY_FRESH_LOW),
+    });
+    assert.equal(gated, false, 'el veto de #4865 debe conservarse para los demás tipos');
+});
+
+test('#5455 · SET+GET end-to-end: persistir y consultar con el adapter sano en ambos puntos', () => {
+    const tmp = newTmpDir();
+    const q = freshModule(tmp);
+    const healthy = () => fakeAdapters(HEALTHY_FRESH_LOW);
+
+    // SET con adapter sano.
+    const res = q.setFlag({ errorType: CONTENT_TYPE, provider: 'anthropic', _quotaAdapters: healthy() });
+    assert.notEqual(res.vetoed, true);
+
+    // GET con adapter sano → gatea Anthropic…
+    assert.equal(q.shouldGateSpawn('commander', { provider: 'anthropic', _quotaAdapters: healthy() }),
+        true, 'Anthropic queda gateado');
+    // …y NO gatea al provider de fallback, que es el punto de toda la historia.
+    assert.equal(q.shouldGateSpawn('commander', { provider: 'openai-codex', _quotaAdapters: healthy() }),
+        false, 'el turno siguiente debe poder caer a Codex');
+});
+
+// -----------------------------------------------------------------------------
+// TTL efectivo — clamp duro a 60 minutos
+// -----------------------------------------------------------------------------
+
+const HOUR_MS = 60 * 60 * 1000;
+
+test('#5455 · TTL: un reset a 7 días se clampea a 60 minutos', () => {
+    const tmp = newTmpDir();
+    const q = freshModule(tmp);
+
+    const now = Date.now();
+    q.setFlag({
+        errorType: CONTENT_TYPE,
+        provider: 'anthropic',
+        resetsAt: new Date(now + 7 * 24 * HOUR_MS).toISOString(),
+        _quotaAdapters: fakeAdapters(HEALTHY_FRESH_LOW),
+    });
+
+    const slot = readFlag(tmp).providers['anthropic'];
+    const ms = Date.parse(slot.resets_at);
+    assert.ok(ms <= now + HOUR_MS + 5000,
+        'resets_at debe caer dentro de 60 min; fue ' + slot.resets_at);
+});
+
+test('#5455 · TTL: el clamp de 60 min vive en setFlag y gana sobre el maxDays del caller', () => {
+    const tmp = newTmpDir();
+    const q = freshModule(tmp);
+
+    const now = Date.now();
+    // Un call-site futuro que "olvide" el maxDays correcto no puede persistir
+    // este tipo con el default de 7 días: la garantía es del escritor único.
+    q.setFlag({
+        errorType: CONTENT_TYPE,
+        provider: 'anthropic',
+        resetsAt: new Date(now + 7 * 24 * HOUR_MS).toISOString(),
+        maxDays: 7,
+        _quotaAdapters: fakeAdapters(HEALTHY_FRESH_LOW),
+    });
+
+    const slot = readFlag(tmp).providers['anthropic'];
+    assert.ok(Date.parse(slot.resets_at) <= now + HOUR_MS + 5000,
+        'el maxDays del caller no debe prolongar el gate; fue ' + slot.resets_at);
+});
+
+test('#5455 · TTL: los demás tipos conservan su TTL largo (el clamp no se derrama)', () => {
+    const tmp = newTmpDir();
+    const q = freshModule(tmp);
+
+    const now = Date.now();
+    q.setFlag({
+        errorType: 'usage_limit_error',
+        provider: 'anthropic',
+        resetsAt: new Date(now + 5 * 24 * HOUR_MS).toISOString(),
+        _quotaAdapters: fakeAdapters(NO_DATA),
+    });
+
+    const slot = readFlag(tmp).providers['anthropic'];
+    assert.ok(Date.parse(slot.resets_at) > now + 24 * HOUR_MS,
+        'el clamp de 60 min es exclusivo del canal de contenido');
+});
+
+// -----------------------------------------------------------------------------
+// Predicado compartido — unidad
+// -----------------------------------------------------------------------------
+
+test('#5455 · isWeeklyLimitContentChannel exige provider Y tipo simultáneamente', () => {
+    const tmp = newTmpDir();
+    const q = freshModule(tmp);
+
+    assert.equal(q.isWeeklyLimitContentChannel('anthropic', CONTENT_TYPE), true);
+    // Alias canónico del adapter.
+    assert.equal(q.isWeeklyLimitContentChannel('anthropic-claude', CONTENT_TYPE), true);
+    // Falta una de las dos condiciones.
+    assert.equal(q.isWeeklyLimitContentChannel('openai-codex', CONTENT_TYPE), false);
+    assert.equal(q.isWeeklyLimitContentChannel('anthropic', 'usage_limit_error'), false);
+    assert.equal(q.isWeeklyLimitContentChannel('anthropic', 'weekly_quota_exhausted'), false);
+    // Entradas degeneradas fallan cerradas.
+    assert.equal(q.isWeeklyLimitContentChannel('', CONTENT_TYPE), false);
+    assert.equal(q.isWeeklyLimitContentChannel('anthropic', null), false);
+    assert.equal(q.isWeeklyLimitContentChannel('anthropic', undefined), false);
+});

--- a/.pipeline/lib/agent-launcher/__tests__/quota-content-channel-5455.test.js
+++ b/.pipeline/lib/agent-launcher/__tests__/quota-content-channel-5455.test.js
@@ -1,0 +1,194 @@
+// =============================================================================
+// quota-content-channel-5455.test.js — Propagación end-to-end del canal de
+// CONTENIDO de Anthropic (#5455) por adapter y dispatcher.
+//
+// El matcher en sí y su matriz positiva/negativa viven en
+// `lib/__tests__/quota-exhausted-content-channel-5455.test.js`; el bypass del
+// veto y el clamp de TTL en `lib/__tests__/quota-exhausted-reconcile-4865.test.js`.
+// Acá se cubre exclusivamente lo que esas suites no pueden ver: que el
+// resultado DISCRIMINADO del detector llegue intacto hasta `setFlag`.
+//
+// Cobertura:
+//   1. Adapter: `resetsAt` parseado del TEXTO (el frame no trae `resets_at`),
+//      más `source` y `rawExcerpt` redactado.
+//   2. Adapter: el contrato previo de los matches ESTRUCTURALES queda intacto.
+//   3. Dispatcher: persiste vía `setFlag` con `errorType` dedicado, `resetsAt`
+//      y `maxDays: 1/24` — NO degrada al "default safe" `allowlist[0]`.
+//   4. Dispatcher: uso EXCLUSIVO de `setFlag`, sin escritura directa del JSON.
+//   5. Dispatcher: una mención embebida no activa el tipo dedicado.
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const dispatcher = require('../dispatch-with-fallback');
+const anthropicAdapter = require('../providers/anthropic');
+const quota = require('../../quota-exhausted');
+
+const CONTENT_TYPE = 'weekly_limit_content_channel';
+
+// Texto REAL del incidente 2026-08-02 (frame final, sin `is_error` ni
+// `error_type`: por eso el path estructural no lo ve).
+const AVISO = "You've hit your weekly limit · resets 9pm (America/Buenos_Aires)";
+
+function tmpDir() {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'cc5455-'));
+}
+
+function writeLog(lines) {
+    const dir = tmpDir();
+    const p = path.join(dir, 'agent.log');
+    fs.writeFileSync(p, lines.join('\n'));
+    return p;
+}
+
+const contentFrame = (result) => JSON.stringify({ type: 'result', subtype: 'success', result });
+
+// Envuelve el módulo real de cuota interceptando SÓLO `setFlag`. Todo lo demás
+// (detector, allowlists, sanitización) es el código de producción: si el spy
+// registra una llamada, el path real la produjo.
+function spyQuota() {
+    const calls = [];
+    const spy = Object.create(quota);
+    spy.setFlag = (input) => { calls.push(input); return { flagPath: '/tmp/spy', payload: {} }; };
+    spy._setCalls = calls;
+    return spy;
+}
+
+// -----------------------------------------------------------------------------
+// 1-2. Adapter — providers/anthropic.js
+// -----------------------------------------------------------------------------
+
+test('#5455 adapter · propaga resetsAt parseado del texto, source y rawExcerpt', () => {
+    const logPath = writeLog([contentFrame(AVISO)]);
+
+    const r = anthropicAdapter.detectQuotaExhausted(logPath, null, quota);
+
+    assert.equal(r.matched, true);
+    assert.equal(r.errorType, CONTENT_TYPE);
+    assert.equal(r.source, 'anthropic-result-content', 'procedencia auditable');
+    assert.ok(r.rawExcerpt, 'debe propagar el excerpt redactado');
+
+    // El frame NO trae `evt.resets_at`: si hay ISO, salió del parseo del texto.
+    assert.equal(r.evt.resets_at, undefined, 'precondición: el frame no trae resets_at');
+    assert.ok(r.resetsAt, 'resetsAt debe venir parseado del texto del aviso');
+    assert.ok(!Number.isNaN(Date.parse(r.resetsAt)), 'resetsAt debe ser un ISO válido');
+});
+
+test('#5455 adapter · un aviso sin reset propaga resetsAt nulo, sin inventar fecha', () => {
+    const logPath = writeLog([contentFrame("You've hit your weekly limit")]);
+
+    const r = anthropicAdapter.detectQuotaExhausted(logPath, null, quota);
+
+    assert.equal(r.matched, true);
+    assert.equal(r.errorType, CONTENT_TYPE);
+    // `r.resetsAt` cae a `evt.resets_at`, que no existe → undefined/null.
+    assert.ok(r.resetsAt == null, 'sin reset en el texto no se inventa fecha');
+});
+
+test('#5455 adapter · el contrato de los matches ESTRUCTURALES queda intacto', () => {
+    const resetsAt = '2026-08-10T12:00:00.000Z';
+    const logPath = writeLog([JSON.stringify({
+        type: 'result',
+        is_error: true,
+        error_type: 'usage_limit_error',
+        resets_at: resetsAt,
+    })]);
+
+    const r = anthropicAdapter.detectQuotaExhausted(logPath, null, quota);
+
+    assert.equal(r.matched, true);
+    assert.equal(r.errorType, 'usage_limit_error');
+    assert.equal(r.resetsAt, resetsAt, 'sigue viniendo de evt.resets_at');
+    assert.equal(r.source, undefined, 'el path estructural no agrega procedencia');
+});
+
+// -----------------------------------------------------------------------------
+// 3-5. Dispatcher — dispatch-with-fallback.js
+// -----------------------------------------------------------------------------
+
+function runExit(rawOutput, pipelineDir, quotaModule) {
+    return dispatcher.onSpawnExit({
+        skill: 'commander',
+        issue: 5455,
+        provider: 'anthropic',
+        transport: 'cli',
+        rawOutput,
+        exitCode: 0,
+        durationMs: 5000,
+        firstByteAt: 100,
+        pipelineDir,
+        quotaModule,
+    });
+}
+
+test('#5455 dispatcher · persiste el tipo dedicado con resetsAt y maxDays de 60 min', () => {
+    const dir = tmpDir();
+    const spy = spyQuota();
+
+    const res = runExit(contentFrame(AVISO), dir, spy);
+
+    assert.equal(res.errorClass, 'quota_exhausted');
+    assert.equal(res.flagSet, true);
+    assert.equal(spy._setCalls.length, 1, 'debe persistir exactamente una vez');
+
+    const call = spy._setCalls[0];
+    assert.equal(call.provider, 'anthropic');
+    // El punto del incidente: sin el path dedicado, `_selectErrorTypeForFlag`
+    // degrada al "default safe" `allowlist[0]` (`usage_limit_error`), que el
+    // reconcile de #4865 VETA con el adapter sano.
+    assert.equal(call.errorType, CONTENT_TYPE, 'no debe degradar a usage_limit_error');
+    assert.ok(call.resetsAt, 'el reset viaja YA parseado desde el detector');
+    assert.ok(!Number.isNaN(Date.parse(call.resetsAt)));
+    assert.equal(call.maxDays, quota.WEEKLY_LIMIT_CONTENT_MAX_DAYS);
+    assert.equal(call.maxDays, 1 / 24, 'TTL de 60 minutos');
+    assert.ok(call.rawExcerpt, 'excerpt redactado presente');
+});
+
+test('#5455 dispatcher · NO escribe quota-exhausted.json fuera de setFlag', () => {
+    const dir = tmpDir();
+    const spy = spyQuota();
+
+    runExit(contentFrame(AVISO), dir, spy);
+
+    // `setFlag` está interceptado (no escribe). Si apareciera el archivo, algún
+    // path lo habría escrito a mano — prohibido por el CA.
+    assert.equal(fs.existsSync(path.join(dir, 'quota-exhausted.json')), false,
+        'setFlag debe ser el ÚNICO escritor del flag');
+});
+
+test('#5455 dispatcher · una mención embebida NO activa el tipo dedicado', () => {
+    const dir = tmpDir();
+    const spy = spyQuota();
+
+    // Respuesta larga que MENCIONA el aviso: es contenido controlable por el
+    // modelo y no debe poder inducir el gate global de Anthropic.
+    const largo = 'Analicé el incidente y encontré que el CLI emite el texto '
+        + `"${AVISO}" como frame final. Propongo detectarlo con un matcher anclado.`;
+    const res = runExit(contentFrame(largo), dir, spy);
+
+    const dedicado = spy._setCalls.filter((c) => c.errorType === CONTENT_TYPE);
+    assert.equal(dedicado.length, 0, 'la mención embebida no debe persistir el tipo dedicado');
+    assert.equal(res.errorClass !== 'quota_exhausted' || spy._setCalls.length === 0
+        || spy._setCalls[0].errorType !== CONTENT_TYPE, true);
+});
+
+test('#5455 dispatcher · el frame estructural conserva el selector genérico', () => {
+    const dir = tmpDir();
+    const spy = spyQuota();
+
+    runExit(JSON.stringify({
+        type: 'result',
+        is_error: true,
+        error_type: 'usage_limit_error',
+    }), dir, spy);
+
+    assert.equal(spy._setCalls.length, 1);
+    const call = spy._setCalls[0];
+    assert.equal(call.errorType, 'usage_limit_error');
+    assert.equal(call.maxDays, undefined, 'el clamp de 60 min es exclusivo del canal de contenido');
+});

--- a/.pipeline/lib/agent-launcher/__tests__/quota-content-channel-5455.test.js
+++ b/.pipeline/lib/agent-launcher/__tests__/quota-content-channel-5455.test.js
@@ -16,6 +16,8 @@
 //      y `maxDays: 1/24` — NO degrada al "default safe" `allowlist[0]`.
 //   4. Dispatcher: uso EXCLUSIVO de `setFlag`, sin escritura directa del JSON.
 //   5. Dispatcher: una mención embebida no activa el tipo dedicado.
+//   6. Dispatcher: SCOPE ANTHROPIC enforced — el tipo dedicado no aterriza
+//      sobre un provider no-Anthropic aunque el frame venga inyectado en su log.
 // =============================================================================
 'use strict';
 
@@ -111,14 +113,14 @@ test('#5455 adapter · el contrato de los matches ESTRUCTURALES queda intacto', 
 // 3-5. Dispatcher — dispatch-with-fallback.js
 // -----------------------------------------------------------------------------
 
-function runExit(rawOutput, pipelineDir, quotaModule) {
+function runExit(rawOutput, pipelineDir, quotaModule, provider = 'anthropic', exitCode = 0) {
     return dispatcher.onSpawnExit({
         skill: 'commander',
         issue: 5455,
-        provider: 'anthropic',
+        provider,
         transport: 'cli',
         rawOutput,
-        exitCode: 0,
+        exitCode,
         durationMs: 5000,
         firstByteAt: 100,
         pipelineDir,
@@ -191,4 +193,69 @@ test('#5455 dispatcher · el frame estructural conserva el selector genérico', 
     const call = spy._setCalls[0];
     assert.equal(call.errorType, 'usage_limit_error');
     assert.equal(call.maxDays, undefined, 'el clamp de 60 min es exclusivo del canal de contenido');
+});
+
+// -----------------------------------------------------------------------------
+// 6. SCOPE ANTHROPIC enforced en el dispatcher (fix del rechazo de #5455)
+//
+// El barrido corría SIN comprobar el provider del spawn y el errorType
+// resultante se persistía con el provider que realmente corrió. Un agente sobre
+// un provider no-Anthropic puede ser inducido a imprimir una línea con forma de
+// frame (el pipeline ingiere texto de GitHub hacia los agentes, y en los CLIs
+// no-Anthropic el log crudo es texto plano, así que la línea entra literal).
+// Si esa corrida además fallaba por cuota, la falla quedaba clasificada como el
+// corte semanal de Anthropic y su gate se acortaba a 60 min en vez de su TTL
+// real. `setFlag` no valida membresía de allowlist, así que el tipo espurio se
+// persistía tal cual.
+// -----------------------------------------------------------------------------
+
+// Ruido de cuota para que el veredicto sea quota_exhausted/rate_limit: el
+// barrido sólo corre bajo ese veredicto, así que el caso hay que construirlo.
+const RUIDO_CUOTA = [
+    'stream error: rate limit exceeded',
+    '429 Too Many Requests',
+    'quota exceeded for this org',
+].join('\n');
+
+test('#5455 dispatcher · el tipo dedicado NO aterriza sobre un provider no-Anthropic', () => {
+    const dir = tmpDir();
+    const spy = spyQuota();
+
+    // Log de un spawn de Codex con la línea del aviso semanal INYECTADA.
+    const raw = `${RUIDO_CUOTA}\n${contentFrame(AVISO)}`;
+    const res = runExit(raw, dir, spy, 'openai-codex', 1);
+
+    // Precondición: el veredicto es de cuota, o sea el barrido llegó a correr.
+    assert.ok(res.errorClass === 'quota_exhausted' || res.errorClass === 'rate_limit',
+        `precondición: el barrido sólo corre bajo veredicto de cuota (fue ${res.errorClass})`);
+    assert.equal(spy._setCalls.length, 1, 'debe persistir el flag genérico igual');
+
+    const call = spy._setCalls[0];
+    assert.equal(call.provider, 'openai-codex');
+    assert.notEqual(call.errorType, CONTENT_TYPE,
+        'el tipo dedicado de Anthropic no debe persistirse con otro provider');
+
+    // El tipo persistido debe pertenecer a la allowlist DEL provider que corrió.
+    const allowlist = quota.KNOWN_QUOTA_ERROR_TYPES_BY_PROVIDER['openai-codex'] || [];
+    assert.ok(allowlist.includes(call.errorType),
+        `el errorType debe salir del selector genérico (allowlist de openai-codex), fue: ${call.errorType}`);
+
+    // El clamp de 60 min es exclusivo del canal de contenido: no debe filtrarse
+    // y sub-gatear a Codex por debajo de su TTL real.
+    assert.equal(call.maxDays, undefined, 'no debe aplicar el clamp de 60 min de Anthropic');
+});
+
+test('#5455 dispatcher · el mismo log inyectado SÍ matchea cuando el provider es Anthropic', () => {
+    const dir = tmpDir();
+    const spy = spyQuota();
+
+    // Control del test anterior: el gate discrimina por provider, no rompe el
+    // canal de contenido legítimo.
+    const raw = `${RUIDO_CUOTA}\n${contentFrame(AVISO)}`;
+    runExit(raw, dir, spy, 'anthropic', 1);
+
+    assert.equal(spy._setCalls.length, 1);
+    assert.equal(spy._setCalls[0].provider, 'anthropic');
+    assert.equal(spy._setCalls[0].errorType, CONTENT_TYPE);
+    assert.equal(spy._setCalls[0].maxDays, quota.WEEKLY_LIMIT_CONTENT_MAX_DAYS);
 });

--- a/.pipeline/lib/agent-launcher/dispatch-with-fallback.js
+++ b/.pipeline/lib/agent-launcher/dispatch-with-fallback.js
@@ -447,8 +447,17 @@ function onSpawnExit(opts = {}) {
                 // caso del incidente. El barrido usa el log CRUDO porque
                 // `verdict.evidence` viene truncado/redactado y no es JSON
                 // re-parseable de forma confiable.
+                //
+                // SCOPE ANTHROPIC (fix del rechazo de #5455): se pasa el
+                // provider REAL del spawn. El detector lo EXIGE y devuelve null
+                // si no canonicaliza a `anthropic`, así que el tipo dedicado no
+                // puede aterrizar sobre un provider ajeno a su allowlist por una
+                // línea con forma de frame inyectada en un log de texto plano.
+                // El gate se declara acá además de en el detector (defensa en
+                // profundidad): este es el punto donde el errorType se PERSISTE
+                // con `provider`, y `setFlag` no valida membresía de allowlist.
                 const contentChannel = (typeof _quota.detectWeeklyLimitContentChannelFromLog === 'function')
-                    ? _quota.detectWeeklyLimitContentChannelFromLog(rawOutput, { now: _now })
+                    ? _quota.detectWeeklyLimitContentChannelFromLog(rawOutput, { now: _now, providerId: provider })
                     : null;
                 const errorType = contentChannel
                     ? contentChannel.errorType

--- a/.pipeline/lib/agent-launcher/dispatch-with-fallback.js
+++ b/.pipeline/lib/agent-launcher/dispatch-with-fallback.js
@@ -439,12 +439,35 @@ function onSpawnExit(opts = {}) {
         // race conditions.
         if (verdict.errorClass === 'quota_exhausted' || verdict.errorClass === 'rate_limit') {
             try {
-                const errorType = _selectErrorTypeForFlag(provider, verdict, _quota);
+                // #5455 — El canal de contenido de Anthropic se resuelve ANTES
+                // del selector genérico. Sin esto, `_selectErrorTypeForFlag` no
+                // encuentra `error_type` en el frame (no lo tiene) y degrada al
+                // "default safe" = `allowlist[0]` (`usage_limit_error`), que el
+                // reconcile de #4865 VETA con el adapter sano — exactamente el
+                // caso del incidente. El barrido usa el log CRUDO porque
+                // `verdict.evidence` viene truncado/redactado y no es JSON
+                // re-parseable de forma confiable.
+                const contentChannel = (typeof _quota.detectWeeklyLimitContentChannelFromLog === 'function')
+                    ? _quota.detectWeeklyLimitContentChannelFromLog(rawOutput, { now: _now })
+                    : null;
+                const errorType = contentChannel
+                    ? contentChannel.errorType
+                    : _selectErrorTypeForFlag(provider, verdict, _quota);
                 if (errorType && typeof _quota.setFlag === 'function') {
                     _quota.setFlag({
                         provider,
                         errorType,
-                        rawExcerpt: safeEvidence,
+                        // El reset viaja YA parseado desde el detector; nunca se
+                        // escribe el JSON a mano. `setFlag` clampea igual el TTL
+                        // efectivo de este tipo a 60 minutos (`maxDays` es
+                        // redundante-por-contrato, la garantía vive en setFlag).
+                        ...(contentChannel
+                            ? {
+                                ...(contentChannel.resetsAt ? { resetsAt: contentChannel.resetsAt } : {}),
+                                maxDays: _quota.WEEKLY_LIMIT_CONTENT_MAX_DAYS,
+                            }
+                            : {}),
+                        rawExcerpt: contentChannel ? contentChannel.rawExcerpt : safeEvidence,
                         agent: skill || null,
                     });
                     flagSet = true;

--- a/.pipeline/lib/agent-launcher/providers/anthropic.js
+++ b/.pipeline/lib/agent-launcher/providers/anthropic.js
@@ -198,12 +198,23 @@ function detectQuotaExhausted(logPath, cfg, quotaExhaustedModule, fsImpl, parser
         const allowlist = (quotaExhaustedModule.KNOWN_QUOTA_ERROR_TYPES_BY_PROVIDER || {})['anthropic']
             || (cfg && cfg.error_types)
             || [];
-        const r = quotaExhaustedModule._detectAnthropic(evt, allowlist);
+        const r = quotaExhaustedModule._detectAnthropic(evt, allowlist, {
+            providerId: 'anthropic',
+        });
         if (r && r.matched) {
+            // #5455 — El canal de contenido devuelve un resultado DISCRIMINADO
+            // con `resetsAt` ya parseado desde el texto del aviso (el frame no
+            // trae `evt.resets_at`), más `source`/`rawExcerpt` redactado. Los
+            // propagamos para que el caller pueda persistir vía `setFlag` sin
+            // volver a parsear nada. Para los matches estructurales de siempre,
+            // `r.resetsAt` es `undefined` y cae a `evt.resets_at` (contrato
+            // previo intacto).
             return {
                 matched: true,
                 errorType: r.errorType,
-                resetsAt: evt.resets_at,
+                resetsAt: r.resetsAt != null ? r.resetsAt : evt.resets_at,
+                ...(r.source ? { source: r.source } : {}),
+                ...(r.rawExcerpt ? { rawExcerpt: r.rawExcerpt } : {}),
                 rawLine: line,
                 evt,
             };

--- a/.pipeline/lib/anthropic-usage.js
+++ b/.pipeline/lib/anthropic-usage.js
@@ -103,18 +103,157 @@ function parseUsageOutput(text) {
 // parseResetToIso — best-effort de "Jul 12, 9pm (America/Buenos_Aires)" → ISO.
 //
 // El texto de /usage no trae año y la TZ va entre paréntesis; el parse es
-// imperfecto por diseño. Devolvemos ISO cuando Date lo entiende, sino null (el
-// raw se conserva aparte). NO es dato crítico — los resets son informativos.
+// imperfecto por diseño. Devolvemos ISO cuando el texto es interpretable, sino
+// null (el raw se conserva aparte).
+//
+// #5455 — ESTE ES EL ÚNICO PARSER DE RESET del pipeline. El detector del canal
+// de contenido de Anthropic (`quota-exhausted.js`) delega acá en vez de crear un
+// segundo parser: el aviso semanal trae el reset en los mismos formatos que
+// `/usage`. Antes de #5455 el helper devolvía `null` para los dos formatos
+// reales observados —hora sola ("9pm") y mes/día sin minutos ("Aug 9, 9pm")—
+// porque `Date.parse` no los entiende; por eso se agregan dos paths
+// estructurados ANTES del fallback legacy:
+//
+//   1. MES/DÍA (+ hora opcional): "Aug 9, 9pm", "Jul 12, 8:59pm". El texto no
+//      trae año → se asume el del reloj de referencia y, si la fecha ya pasó,
+//      se elige la próxima ocurrencia (año siguiente). Cubre el wrap Dic→Ene.
+//   2. HORA SOLA: "9pm", "21:00". Se resuelve sobre el día del reloj de
+//      referencia y, si esa hora YA PASÓ, rollover al día siguiente (CA: "elige
+//      la próxima ocurrencia").
+//
+// El reloj es inyectable vía `refMs` (tests determinísticos). Toda entrada no
+// interpretable devuelve `null` — NUNCA se inventa una fecha. Aguas abajo,
+// `setFlag`/`capResetsAt` clampean igual el TTL efectivo, así que un reset
+// textual jamás prolonga un gate por sí solo.
+//
+// La TZ entre paréntesis se descarta y el cálculo queda en hora local, igual
+// que antes de #5455 (parse imperfecto por diseño, sin libs de timezone).
 // -----------------------------------------------------------------------------
+const _MONTH_INDEX = Object.freeze({
+    jan: 0, feb: 1, mar: 2, apr: 3, may: 4, jun: 5,
+    jul: 6, aug: 7, sep: 8, oct: 9, nov: 10, dec: 11,
+});
+
+// Cuantificadores acotados en ambos regex (defensa ReDoS): el input puede venir
+// del canal de contenido del modelo vía #5455.
+const _TIME_ONLY_RE = /^(\d{1,2})(?::(\d{2}))?\s{0,2}(am|pm)?$/i;
+const _MONTH_DAY_RE = /^([a-z]{3,9})\.?\s{1,2}(\d{1,2})\s{0,2},?\s{0,2}(.{0,20})$/i;
+
+const _DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Normaliza hora + meridiano a hora 24h. Devuelve null si es inválida.
+ */
+function _toHour24(hourRaw, meridiem) {
+    const h = Number(hourRaw);
+    if (!Number.isInteger(h)) return null;
+    if (meridiem) {
+        if (h < 1 || h > 12) return null;
+        return (h % 12) + (meridiem.toLowerCase() === 'pm' ? 12 : 0);
+    }
+    return h >= 0 && h <= 23 ? h : null;
+}
+
+/**
+ * Parsea "9pm" / "8:59 pm" / "21:00" → { hour, minute } o null.
+ * `requireQualifier` exige minutos o meridiano, para que un número suelto
+ * ("9") NO se interprete como hora (fail-closed).
+ */
+function _parseTimeOfDay(text, requireQualifier) {
+    const m = _TIME_ONLY_RE.exec(String(text).trim());
+    if (!m) return null;
+    if (requireQualifier && !m[2] && !m[3]) return null;
+    const hour = _toHour24(m[1], m[3]);
+    if (hour === null) return null;
+    const minute = m[2] ? Number(m[2]) : 0;
+    if (!Number.isInteger(minute) || minute > 59) return null;
+    return { hour, minute };
+}
+
+/**
+ * #5455 — ¿El texto contiene un token de mes conocido ("jul", "august", …)?
+ *
+ * Guarda de entrada del fallback legacy `Date.parse` (ver más abajo). Recorre
+ * sólo secuencias alfabéticas de 3+ letras y compara su prefijo de 3 contra
+ * `_MONTH_INDEX`. Cuantificador acotado: el input puede venir del canal de
+ * contenido del modelo.
+ */
+function _hasKnownMonthToken(text) {
+    const tokens = String(text).match(/[a-z]{3,9}/gi);
+    if (!tokens) return false;
+    return tokens.some((t) => _MONTH_INDEX[t.slice(0, 3).toLowerCase()] !== undefined);
+}
+
 function parseResetToIso(raw, refMs) {
     if (typeof raw !== 'string' || raw.length === 0) return null;
     // Descartar el paréntesis de TZ (no interpretable por Date sin libs).
     const noTz = raw.replace(/\s*\([^)]*\)\s*$/, '').trim();
     if (!noTz) return null;
+    // Tolerar el prefijo "resets " del texto crudo (CLI y /usage lo anteponen).
+    const body = noTz.replace(/^resets?\s+/i, '').trim();
+    if (!body) return null;
     const ref = Number.isFinite(refMs) ? new Date(refMs) : new Date();
+    const refTs = ref.getTime();
+    if (!Number.isFinite(refTs)) return null;
+
+    // 1. Mes/día explícito (+ hora opcional).
+    const md = _MONTH_DAY_RE.exec(body);
+    if (md) {
+        const month = _MONTH_INDEX[md[1].slice(0, 3).toLowerCase()];
+        const day = Number(md[2]);
+        const tail = md[3] ? md[3].trim() : '';
+        if (month !== undefined && Number.isInteger(day) && day >= 1 && day <= 31) {
+            // Sin hora → medianoche; con hora → debe parsear o el input es inválido.
+            const time = tail ? _parseTimeOfDay(tail, false) : { hour: 0, minute: 0 };
+            if (time) {
+                const build = (y) => new Date(y, month, day, time.hour, time.minute, 0, 0);
+                let d = build(ref.getFullYear());
+                // Rechazar días que no existen en el mes ("Feb 31" → marzo).
+                if (d.getMonth() === month && d.getDate() === day) {
+                    if (d.getTime() < refTs) {
+                        const next = build(ref.getFullYear() + 1);
+                        if (next.getMonth() === month && next.getDate() === day) d = next;
+                    }
+                    return new Date(d.getTime()).toISOString();
+                }
+                return null;
+            }
+            return null;
+        }
+    }
+
+    // 2. Hora sola → próxima ocurrencia (rollover al día siguiente si ya pasó).
+    const timeOnly = _parseTimeOfDay(body, true);
+    if (timeOnly) {
+        let d = new Date(
+            ref.getFullYear(), ref.getMonth(), ref.getDate(),
+            timeOnly.hour, timeOnly.minute, 0, 0,
+        );
+        if (d.getTime() <= refTs) d = new Date(d.getTime() + _DAY_MS);
+        return d.toISOString();
+    }
+
+    // 3. Fallback legacy: delegar en Date.parse para shapes no contemplados.
+    //
+    // #5455 — GUARDA DE ENTRADA. `Date.parse` es extremadamente permisivo con
+    // tokens numéricos sueltos y los resuelve a fechas PASADAS e inventadas:
+    //   "9" → 2001-09-01 · "2020" → 2020-01-01 · "9 9" → 2001-09-09
+    // Antes de #5455 esto sólo veía texto de `/usage` (siempre con mes), pero
+    // ahora el helper también recibe el reset capturado del canal de CONTENIDO,
+    // que es controlable por el modelo: un aviso truncado como
+    // "...· resets 9" produciría un `resetsAt` en el pasado y, tras el clamp de
+    // `capResetsAt`, un gate de 5 minutos en vez del gate corto esperado.
+    // El CA exige `null` ante un reset inválido, sin inventar fecha.
+    //
+    // Los dos formatos REALES ya los resuelven los paths estructurados de
+    // arriba, así que este fallback queda sólo para variantes con nombre de mes
+    // que `Date.parse` sepa interpretar. Exigimos entonces un token de mes
+    // conocido y fallamos cerrado ante cualquier otra cosa; un input sin mes no
+    // es un formato de reset de Anthropic, es ruido.
+    if (!_hasKnownMonthToken(body)) return null;
     const year = ref.getUTCFullYear();
     // Date.parse necesita un espacio antes de am/pm: "8:59pm" → "8:59 pm".
-    const spaced = noTz.replace(/(\d)\s*(am|pm)\b/i, '$1 $2');
+    const spaced = body.replace(/(\d)\s*(am|pm)\b/i, '$1 $2');
     // "Jul 12, 8:59 pm" → "Jul 12, 2026 8:59 pm"
     const withYear = spaced.replace(/,/, `, ${year}`);
     let ts = Date.parse(withYear);

--- a/.pipeline/lib/quota-exhausted.js
+++ b/.pipeline/lib/quota-exhausted.js
@@ -1532,15 +1532,31 @@ const _WEEKLY_LIMIT_SCAN_MAX_LINE_CHARS = 8192;
  * que NO es JSON re-parseable de forma confiable. La fuente correcta es el log
  * crudo.
  *
- * Anthropic-only por construcción: usa la allowlist canónica de `anthropic`.
+ * SCOPE ANTHROPIC — ENFORCED, no "por construcción" (fix del rechazo de #5455).
+ * Antes esta función forzaba `providerId: DEFAULT_PROVIDER` hardcodeado: eso
+ * sólo decidía QUÉ allowlist se consultaba, no SOBRE QUÉ PROVIDER aterrizaba el
+ * flag. El caller persistía el `errorType` devuelto con el provider que
+ * realmente corrió, así que un spawn de `openai-codex` podía terminar con
+ * `weekly_limit_content_channel` — un tipo ajeno a SU allowlist — vía una línea
+ * con forma de frame inyectada en el log (el pipeline ingiere texto de GitHub
+ * hacia los agentes, y en los CLIs no-Anthropic el log crudo es texto plano).
+ *
+ * Ahora el providerId REAL es obligatorio y se valida contra el canónico:
+ * fail-closed (sin provider, o provider != `anthropic` => `null`). El default
+ * implícito se eliminó a propósito: un caller que se olvide de declararlo debe
+ * obtener "no match", nunca un flag espurio de Anthropic.
  *
  * @param {string} rawText contenido crudo del log del spawn.
- * @param {object} [opts] `{ now }` reloj inyectable para el parseo del reset.
+ * @param {object} [opts] `{ now, providerId }`. `providerId` es OBLIGATORIO y
+ *                        debe canonicalizar a `anthropic`; `now` es el reloj
+ *                        inyectable para el parseo del reset.
  * @returns {{matched: true, errorType: string, resetsAt: string|null,
  *            source: string, rawExcerpt: string}|null}
  */
 function detectWeeklyLimitContentChannelFromLog(rawText, opts = {}) {
     if (typeof rawText !== 'string' || !rawText) return null;
+    // SCOPE ANTHROPIC enforced: el barrido no corre para ningún otro provider.
+    if (canonicalProvider(opts.providerId) !== DEFAULT_PROVIDER) return null;
     const allowlist = KNOWN_QUOTA_ERROR_TYPES_BY_PROVIDER[DEFAULT_PROVIDER] || [];
     if (!allowlist.includes(WEEKLY_LIMIT_CONTENT_ERROR_TYPE)) return null;
     const lines = rawText.split('\n');

--- a/.pipeline/lib/quota-exhausted.js
+++ b/.pipeline/lib/quota-exhausted.js
@@ -158,6 +158,73 @@ const DEFAULT_ERROR_TYPES = Object.freeze([
     'snapshot_threshold_90',
 ]);
 
+// -----------------------------------------------------------------------------
+// #5455 — EXCEPCIÓN ACOTADA AL CANAL DE CONTENIDO (Anthropic-only)
+//
+// Este módulo documenta como invariante que está PROHIBIDO matchear contra
+// campos controlados por el modelo (canal de contenido). #5424 demostró que
+// existe UN caso real donde el CLI de Anthropic no tiene otro canal: al cortar
+// por límite SEMANAL emite el aviso como frame final `type:'result'` SIN
+// `is_error` ni `error_type`. Sin detectarlo, el flag nunca se persiste, el
+// fallback pre-spawn del Commander vuelve a elegir Anthropic y el operador
+// queda sin canal (incidente 2026-08-02, ~1h sin Commander).
+//
+// La excepción se abre con TODAS estas compensaciones simultáneas — quitar
+// cualquiera reabre el vector de DoS auto-infligido por contenido inducido
+// (prompt/comentario/handoff que imite el aviso):
+//
+//   1. SCOPE ANTHROPIC. El tipo vive SÓLO en `KNOWN_QUOTA_ERROR_TYPES_BY_PROVIDER
+//      .anthropic`; `agent-models-validate.js` hace fail-fast al boot si otro
+//      provider lo declara. Además `_detectAnthropic` acepta un `providerId`
+//      explícito y descarta el path si el canónico no es `anthropic`.
+//   2. FRAME COMPLETO. Sólo `evt.type === 'result'`, y el contenido COMPLETO
+//      normalizado debe coincidir con el aviso. Una mención embebida en una
+//      respuesta larga NO matchea (el regex está anclado `^...$`).
+//   3. SHAPES CERRADOS. `result` string, o array de bloques EXCLUSIVAMENTE
+//      `{type:'text', text:string}`. Cualquier bloque mixto/no textual falla
+//      cerrado.
+//   4. LÍMITE DE LONGITUD. Trim exterior y rechazo por encima de 200 chars —
+//      el regex NUNCA corre sobre más de 200 caracteres (garantía anti-ReDoS).
+//   5. REGEX ANCLADO con cuantificadores acotados, sin `.*` y sin construirse
+//      desde input externo.
+//   6. TIPO DEDICADO. Se persiste como `weekly_limit_content_channel`, jamás
+//      como un tipo estructural. El bypass del veto `provider_healthy_fresh`
+//      (ver `isWeeklyLimitContentChannel`) depende de provider Y tipo a la vez.
+//   7. TTL EFECTIVO ≤ 60 MIN. `setFlag` clampea este tipo a `maxDays = 1/24`
+//      aunque el texto anuncie un reset semanal y aunque el caller pase otro
+//      `maxDays`. Un falso positivo cuesta como máximo una hora de gate.
+//   8. PROCEDENCIA + REDACCIÓN. El resultado lleva `source` explícito y el
+//      excerpt pasa por `sanitizeRawExcerpt` (redact central) antes de
+//      persistirse o loguearse.
+// -----------------------------------------------------------------------------
+const WEEKLY_LIMIT_CONTENT_ERROR_TYPE = 'weekly_limit_content_channel';
+
+// Procedencia auditable del match (compensación 8).
+const WEEKLY_LIMIT_CONTENT_SOURCE = 'anthropic-result-content';
+
+// Compensación 4: cota dura del contenido normalizado. El regex sólo corre
+// sobre entradas ya validadas por debajo de este límite.
+const WEEKLY_LIMIT_CONTENT_MAX_CHARS = 200;
+
+// Compensación 3: cota de bloques del shape array (defensa anti-DoS de memoria
+// al concatenar). Un aviso real es 1 bloque; 8 es holgado y sigue acotado.
+const WEEKLY_LIMIT_CONTENT_MAX_BLOCKS = 8;
+
+// Compensación 7: TTL efectivo máximo, en días (1/24 == 60 minutos). Coincide
+// con MIN_TTL_DAYS, el piso del clamp de `resolveMaxDays`.
+const WEEKLY_LIMIT_CONTENT_MAX_DAYS = 1 / 24;
+
+// Compensación 5: regex ANCLADO al frame completo. Cuantificadores acotados,
+// sin `.*`, sin alternancias anidadas y sin construcción dinámica. Cubre el
+// texto real del incidente y sus variantes de apóstrofe/sufijo:
+//   "You've hit your weekly limit · resets 9pm (America/Buenos_Aires)"
+//   "You've hit your weekly limit · resets Aug 9, 9pm (America/Buenos_Aires)"
+//   "You've hit your weekly limit"
+// El grupo 1 captura el reset crudo (incluida la TZ entre paréntesis) para
+// delegarlo a `parseResetToIso`; NO se interpreta la TZ acá.
+const _ANTHROPIC_WEEKLY_LIMIT_CONTENT_PATTERN =
+    /^you['’]?ve\s{1,3}hit\s{1,3}your\s{1,3}weekly\s{1,3}limit(?:\s{0,3}[·•]?\s{0,3}resets\s{1,3}([a-z0-9][a-z0-9 ,:]{0,39}(?:\([a-z0-9_+\-/]{1,40}\))?))?\s{0,3}\.?$/i;
+
 // #3077 SEC-2: meta-allowlist hardcoded de tipos de error de cuota por
 // provider. Si agent-models.json declara un valor fuera de este set, el caller
 // (lib/agent-models-validate.js → validateCrossReferences) hace fail-fast al
@@ -173,6 +240,10 @@ const KNOWN_QUOTA_ERROR_TYPES_BY_PROVIDER = Object.freeze({
         'weekly_quota_exhausted',
         // Internos (#3013 snapshot integration)
         'snapshot_threshold_90',
+        // #5455 — Canal de CONTENIDO (excepción acotada documentada arriba).
+        // Anthropic-ONLY por diseño: ningún otro provider puede declararlo sin
+        // que `agent-models-validate.js` falle al boot.
+        WEEKLY_LIMIT_CONTENT_ERROR_TYPE,
         // Reservados para futuras extensiones documentadas
         'plan_max_reset_required',
     ]),
@@ -857,6 +928,39 @@ const RECONCILE_PROVIDER_ALIAS = Object.freeze({
     'anthropic-claude': 'anthropic',
 });
 
+/**
+ * #5455 — Normaliza un id de provider al canónico del adapter.
+ */
+function canonicalProvider(provider) {
+    const raw = typeof provider === 'string' ? provider.trim() : '';
+    if (!raw) return '';
+    return RECONCILE_PROVIDER_ALIAS[raw] || raw;
+}
+
+/**
+ * #5455 — PREDICADO EXACTO compartido por `setFlag` (SET) y `shouldGateSpawn`
+ * (GET) para la ÚNICA excepción al veto `provider_healthy_fresh` de #4865.
+ *
+ * Existe porque el adapter canónico reportó `ok/pct:3` DURANTE el incidente
+ * real: el corte semanal de Anthropic no se refleja en `/usage` a tiempo, así
+ * que el reconcile —correcto para señales por substring— vetaría la única
+ * señal fidedigna que existe para este corte. Exceptuar sólo el SET produciría
+ * un slot que el GET ignora (y el turno siguiente nunca caería a Codex), por
+ * eso el predicado es UNO SOLO y se aplica en ambos puntos.
+ *
+ * Requiere las DOS condiciones a la vez. Ningún otro tipo (incluido
+ * `usage_limit_error`) ni ningún otro provider evita el veto.
+ *
+ * @param {string} provider        id del provider (acepta alias).
+ * @param {string} patternMatched  `errorType` en SET / `pattern_matched` del
+ *                                 slot activo en GET.
+ * @returns {boolean}
+ */
+function isWeeklyLimitContentChannel(provider, patternMatched) {
+    return canonicalProvider(provider) === DEFAULT_PROVIDER
+        && patternMatched === WEEKLY_LIMIT_CONTENT_ERROR_TYPE;
+}
+
 function metricsDir() {
     return path.join(pipelineDir(), 'metrics');
 }
@@ -1010,7 +1114,24 @@ function setFlag(opts = {}) {
     // positivo → vetamos el set y auditamos la discrepancia (no fail-open: sólo
     // vetamos con dato fresco; sin dato, se persiste igual — fail-closed).
     const reconciliation = reconcileWithCanonicalSource(provider, opts);
-    if (reconciliation.veto) {
+    // #5455 — ÚNICA excepción al veto: el aviso del canal de contenido de
+    // Anthropic (ver `isWeeklyLimitContentChannel`). Se audita explícitamente
+    // para que el bypass quede trazable, y el TTL queda clampeado a 60 min más
+    // abajo, así un eventual falso positivo cuesta como máximo una hora.
+    const bypassVeto = reconciliation.veto
+        && isWeeklyLimitContentChannel(provider, errorType);
+    if (bypassVeto && opts.auditLogEnabled !== false) {
+        appendAudit({
+            event: 'flag_set_veto_bypassed',
+            agent: opts.agent || null,
+            provider,
+            model,
+            error_type: errorType,
+            raw_excerpt: `reconcile veto bypassed (#5455 content channel): adapter_status=${reconciliation.adapterStatus} pct=${reconciliation.pct}`,
+            flag_set: true,
+        }, { now });
+    }
+    if (reconciliation.veto && !bypassVeto) {
         if (opts.auditLogEnabled !== false) {
             appendAudit({
                 event: 'flag_set_vetoed',
@@ -1038,7 +1159,15 @@ function setFlag(opts = {}) {
         effectiveResetsAt = now + CODEX_USAGE_LIMIT_RESET_MS;
     }
     // #4731 — TTL configurable por proveedor (clampeado). Prioriza opts.maxDays.
-    const maxDays = resolveMaxDays(provider, opts);
+    let maxDays = resolveMaxDays(provider, opts);
+    // #5455 (compensación 7) — El tipo del canal de contenido tiene un TTL
+    // efectivo máximo de 60 minutos, INDEPENDIENTE de lo que anuncie el texto,
+    // de `config.yaml:ttl_by_provider` y de lo que pase el caller. El clamp vive
+    // acá (escritor único) y no en el caller: así ningún call-site futuro puede
+    // persistir este tipo con el default de 7 días por olvido.
+    if (isWeeklyLimitContentChannel(provider, errorType)) {
+        maxDays = Math.min(maxDays, WEEKLY_LIMIT_CONTENT_MAX_DAYS);
+    }
     const cap = capResetsAt(effectiveResetsAt, { maxDays, now });
     const slot = {
         exhausted: true,
@@ -1273,9 +1402,179 @@ function resolveMaxDays(provider, opts = {}) {
     return Math.min(MAX_TTL_DAYS, Math.max(MIN_TTL_DAYS, days));
 }
 
-function _detectAnthropic(evt, allowlist) {
+// #5455 — Cota dura de acumulación al concatenar bloques. Es una defensa de
+// MEMORIA, no un criterio de match: cualquier contenido que la supere ya está
+// muy por encima de `WEEKLY_LIMIT_CONTENT_MAX_CHARS` y sería rechazado igual
+// tras el `trim()`. Existe para no materializar un string gigante antes de
+// medirlo.
+const _WEEKLY_LIMIT_CONTENT_ACCUM_CAP = WEEKLY_LIMIT_CONTENT_MAX_CHARS * 8;
+
+/**
+ * #5455 — Normaliza el contenido de un frame `result` de Anthropic a string.
+ *
+ * SHAPES ACEPTADOS (compensación 3, fail-closed):
+ *   - `string` — el shape del incidente real.
+ *   - `Array` de bloques EXCLUSIVAMENTE `{ type: 'text', text: string }`.
+ *
+ * Cualquier otra cosa (número, objeto suelto, array vacío, array con un bloque
+ * `tool_use`/`image`/sin `text` string, o más de `WEEKLY_LIMIT_CONTENT_MAX_BLOCKS`
+ * bloques) devuelve `null`. Un solo bloque no textual invalida TODO el frame —
+ * no se filtran los textuales y se concatenan los que "sirven", porque eso
+ * permitiría esconder el aviso dentro de una respuesta con herramientas.
+ *
+ * @returns {string|null} contenido crudo concatenado (sin trim) o null.
+ */
+function _normalizeAnthropicResultContent(raw) {
+    if (typeof raw === 'string') return raw;
+    if (!Array.isArray(raw)) return null;
+    if (raw.length === 0 || raw.length > WEEKLY_LIMIT_CONTENT_MAX_BLOCKS) return null;
+    let out = '';
+    for (const block of raw) {
+        if (!block || typeof block !== 'object' || Array.isArray(block)) return null;
+        if (block.type !== 'text' || typeof block.text !== 'string') return null;
+        out += block.text;
+        if (out.length > _WEEKLY_LIMIT_CONTENT_ACCUM_CAP) return null;
+    }
+    return out;
+}
+
+/**
+ * #5455 — Delega el reset crudo del aviso en el ÚNICO parser del pipeline
+ * (`anthropic-usage.parseResetToIso`). Require perezoso + try/catch: el
+ * detector NUNCA debe tirar, y así evitamos cualquier ciclo de require.
+ *
+ * Un reset ausente o no interpretable devuelve `null` (fail-closed, sin
+ * inventar fecha); `setFlag` aplica entonces su fallback y, en cualquier caso,
+ * clampea el TTL efectivo a 60 minutos para este tipo.
+ *
+ * @param {string|undefined} rawReset texto capturado por el regex.
+ * @param {number} [nowMs] reloj inyectable (tests determinísticos).
+ * @returns {string|null} ISO o null.
+ */
+function _parseWeeklyLimitReset(rawReset, nowMs) {
+    if (typeof rawReset !== 'string' || !rawReset.trim()) return null;
+    try {
+        const { parseResetToIso } = require('./anthropic-usage');
+        if (typeof parseResetToIso !== 'function') return null;
+        return parseResetToIso(rawReset, Number.isFinite(nowMs) ? nowMs : undefined);
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * #5455 — Detector del canal de CONTENIDO de Anthropic (excepción acotada).
+ *
+ * Devuelve el resultado DISCRIMINADO que consumen adapter/dispatcher, o `null`
+ * si no aplica (para que el caller siga con el path estructural de siempre).
+ * Nunca devuelve `{ matched: false }`: `null` significa "este path no opina".
+ *
+ * Todas las compensaciones del bloque de cabecera se aplican acá, en orden de
+ * costo creciente — el regex es lo ÚLTIMO y sólo corre sobre ≤200 caracteres.
+ *
+ * @param {object} evt        frame ya validado como `type === 'result'`.
+ * @param {string[]} allowlist quota_error_types del provider EN USO.
+ * @param {object} [opts]
+ * @param {string} [opts.providerId] provider explícito (refuerzo de scope).
+ * @param {number} [opts.now] reloj inyectable para el parseo del reset.
+ * @returns {{matched: true, errorType: string, resetsAt: string|null,
+ *            source: string, rawExcerpt: string}|null}
+ */
+function _detectAnthropicContentChannel(evt, allowlist, opts = {}) {
+    // Compensación 1 (scope por allowlist): el tipo dedicado debe estar
+    // declarado por el provider EN USO. Sólo `anthropic` puede declararlo sin
+    // que `agent-models-validate.js` falle al boot, así que esto ancla el path
+    // a Anthropic incluso cuando el caller no aporta el nombre del provider.
+    if (!Array.isArray(allowlist)) return null;
+    if (!allowlist.includes(WEEKLY_LIMIT_CONTENT_ERROR_TYPE)) return null;
+
+    // Compensación 1 (refuerzo explícito): si el caller SÍ sabe qué provider
+    // corrió y no es el canónico `anthropic`, el path no aplica. Defensa contra
+    // un provider mal configurado que copiara la allowlist de Anthropic.
+    if (opts.providerId != null
+        && canonicalProvider(opts.providerId) !== DEFAULT_PROVIDER) {
+        return null;
+    }
+
+    // Compensación 3: shapes cerrados.
+    const normalized = _normalizeAnthropicResultContent(evt.result);
+    if (normalized === null) return null;
+
+    // Compensación 2 + 4: frame COMPLETO, trim sólo exterior, cota de 200.
+    const content = normalized.trim();
+    if (!content || content.length > WEEKLY_LIMIT_CONTENT_MAX_CHARS) return null;
+
+    // Compensación 5: regex anclado, cuantificadores acotados, sobre ≤200 chars.
+    const m = _ANTHROPIC_WEEKLY_LIMIT_CONTENT_PATTERN.exec(content);
+    if (!m) return null;
+
+    return {
+        matched: true,
+        errorType: WEEKLY_LIMIT_CONTENT_ERROR_TYPE,        // compensación 6
+        resetsAt: _parseWeeklyLimitReset(m[1], opts.now),
+        source: WEEKLY_LIMIT_CONTENT_SOURCE,               // compensación 8
+        rawExcerpt: sanitizeRawExcerpt(content),           // compensación 8
+    };
+}
+
+// #5455 — Cotas del barrido de log (`detectWeeklyLimitContentChannelFromLog`).
+// El log crudo de un spawn puede ser grande; el barrido queda acotado para que
+// el detector no se vuelva un costo relevante ni un vector de DoS por tamaño.
+const _WEEKLY_LIMIT_SCAN_MAX_LINES = 5000;
+const _WEEKLY_LIMIT_SCAN_MAX_LINE_CHARS = 8192;
+
+/**
+ * #5455 — Barre un log crudo de CLI buscando el frame del canal de contenido.
+ *
+ * Existe para que adapter y dispatcher compartan UNA sola implementación y no
+ * tengan que re-parsear `verdict.evidence`: ese campo pasa por
+ * `sanitizeRawExcerpt` (redacción + truncado a `RAW_EXCERPT_MAX_CHARS`), así
+ * que NO es JSON re-parseable de forma confiable. La fuente correcta es el log
+ * crudo.
+ *
+ * Anthropic-only por construcción: usa la allowlist canónica de `anthropic`.
+ *
+ * @param {string} rawText contenido crudo del log del spawn.
+ * @param {object} [opts] `{ now }` reloj inyectable para el parseo del reset.
+ * @returns {{matched: true, errorType: string, resetsAt: string|null,
+ *            source: string, rawExcerpt: string}|null}
+ */
+function detectWeeklyLimitContentChannelFromLog(rawText, opts = {}) {
+    if (typeof rawText !== 'string' || !rawText) return null;
+    const allowlist = KNOWN_QUOTA_ERROR_TYPES_BY_PROVIDER[DEFAULT_PROVIDER] || [];
+    if (!allowlist.includes(WEEKLY_LIMIT_CONTENT_ERROR_TYPE)) return null;
+    const lines = rawText.split('\n');
+    const limit = Math.min(lines.length, _WEEKLY_LIMIT_SCAN_MAX_LINES);
+    for (let i = 0; i < limit; i++) {
+        const line = lines[i].trim();
+        // Sólo frames JSON del stream. `startsWith('{')` replica el criterio ya
+        // usado por `providers/anthropic.js`.
+        if (line.length === 0 || line.length > _WEEKLY_LIMIT_SCAN_MAX_LINE_CHARS) continue;
+        if (line.charCodeAt(0) !== 123 /* '{' */) continue;
+        let evt;
+        try { evt = JSON.parse(line); } catch { continue; }
+        if (!evt || typeof evt !== 'object' || evt.type !== 'result') continue;
+        const r = _detectAnthropicContentChannel(evt, allowlist, {
+            ...opts,
+            providerId: DEFAULT_PROVIDER,
+        });
+        if (r) return r;
+    }
+    return null;
+}
+
+function _detectAnthropic(evt, allowlist, opts = {}) {
     if (!evt || typeof evt !== 'object') return { matched: false };
     if (evt.type !== 'result') return { matched: false };
+
+    // #5455 — CANAL DE CONTENIDO (excepción acotada; ver bloque de compensaciones
+    // arriba). Corre ANTES del path estructural porque el frame real NO trae
+    // `is_error` ni `error_type` — el path estructural lo descartaría. No hay
+    // solapamiento: el regex está anclado al aviso semanal completo, así que un
+    // frame estructural legítimo nunca matchea acá y cae al path de siempre.
+    const contentMatch = _detectAnthropicContentChannel(evt, allowlist, opts);
+    if (contentMatch) return contentMatch;
+
     if (evt.is_error !== true) return { matched: false };
     const errorType = typeof evt.error_type === 'string' ? evt.error_type : null;
     if (!errorType) return { matched: false };
@@ -1471,14 +1770,37 @@ function shouldGateSpawn(skill, opts = {}) {
     // proveedores agotados, cada uno gatea sólo sus propios skills.
     if (opts.provider) {
         const slots = Array.isArray(flag.providers) ? flag.providers : [];
-        const hasSlot = slots.some((p) => p.provider === opts.provider);
-        if (!hasSlot) return false;
+        // #5455 — Seleccionamos el SLOT ACTIVO (no sólo su existencia) porque el
+        // bypass del veto depende de su `pattern_matched`.
+        const activeSlot = slots.find((p) => p && p.provider === opts.provider) || null;
+        if (!activeSlot) return false;
         // #4865 — antes de HONRAR el gate, reconciliar contra la fuente única.
         // Si el adapter canónico reporta el proveedor sano con dato fresco, el
         // slot activo es un remanente o falso positivo → NO gateamos y auditamos
         // la discrepancia. Fail-closed: sin dato fresco, honramos el flag (return
         // true), preservando el comportamiento conservador previo.
         const reconciliation = reconcileWithCanonicalSource(opts.provider, opts);
+        // #5455 — MISMO predicado exacto que en `setFlag` (SET). Sin esto, el
+        // subtipo se persistiría y el GET lo ignoraría con el adapter en
+        // `ok/pct:3`: el turno siguiente volvería a elegir Anthropic y el gate
+        // no serviría de nada. El bypass exige provider `anthropic` Y
+        // `pattern_matched === weekly_limit_content_channel` en el slot ACTIVO;
+        // cualquier otro tipo (incluido `usage_limit_error`) o cualquier otro
+        // provider conserva el veto de #4865 intacto.
+        const bypassVeto = reconciliation.veto
+            && isWeeklyLimitContentChannel(opts.provider, activeSlot.pattern_matched);
+        if (bypassVeto) {
+            appendAudit({
+                event: 'gate_veto_bypassed',
+                agent: skill || null,
+                provider: opts.provider,
+                model: null,
+                error_type: activeSlot.pattern_matched || null,
+                raw_excerpt: `reconcile veto bypassed (#5455 content channel): adapter_status=${reconciliation.adapterStatus} pct=${reconciliation.pct}`,
+                flag_set: false,
+            }, { now: Number.isFinite(opts.now) ? opts.now : undefined });
+            return true;
+        }
         if (reconciliation.veto) {
             appendAudit({
                 event: 'gate_vetoed',
@@ -1514,6 +1836,11 @@ module.exports = {
     appendAudit,
     // #4865 — reconciliación contra la fuente única de verdad por proveedor.
     reconcileWithCanonicalSource,
+    // #5455 — predicado exacto de la única excepción al veto (SET + GET).
+    isWeeklyLimitContentChannel,
+    canonicalProvider,
+    // #5455 — barrido compartido por adapter y dispatcher.
+    detectWeeklyLimitContentChannelFromLog,
 
     // Helpers expuestos para integración con pulpo.js
     capResetsAt,
@@ -1535,6 +1862,12 @@ module.exports = {
     DETERMINISTIC_SKILLS,
     KNOWN_QUOTA_ERROR_TYPES_BY_PROVIDER,
     CODEX_USAGE_LIMIT_RESET_MS,
+    // #5455 — canal de contenido (excepción acotada Anthropic-only).
+    WEEKLY_LIMIT_CONTENT_ERROR_TYPE,
+    WEEKLY_LIMIT_CONTENT_SOURCE,
+    WEEKLY_LIMIT_CONTENT_MAX_CHARS,
+    WEEKLY_LIMIT_CONTENT_MAX_BLOCKS,
+    WEEKLY_LIMIT_CONTENT_MAX_DAYS,
     MIN_TTL_DAYS,
     MAX_TTL_DAYS,
     RECONCILE_HEALTHY_MAX_PCT,
@@ -1550,4 +1883,8 @@ module.exports = {
     _detectOpenAI,
     _CLI_1M_CONTEXT_GLITCH_PATTERN,
     _CODEX_USAGE_LIMIT_PATTERN,
+    // #5455
+    _detectAnthropicContentChannel,
+    _normalizeAnthropicResultContent,
+    _ANTHROPIC_WEEKLY_LIMIT_CONTENT_PATTERN,
 };


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 9 archivos · +1509 -13

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:passed` aplicado por delivery

## Closes

Closes #5455
