### PR TITLE
[Split de #5425] Implementar port SSM de provisi?n segura e idempotente

### DIFF
--- a/.pipeline/lib/__tests__/secret-vault-sync-5353.test.js
+++ b/.pipeline/lib/__tests__/secret-vault-sync-5353.test.js
@@ -146,14 +146,25 @@ test('D1.3 · los dos drivers exponen getParametersByPathSync / getSecretValueSy
         assert.ok(Array.isArray(res.parameters));
     }
 
-    // El de aws-cli se apoya en el runner que YA era sync: sin dep nueva.
+    // El de aws-cli se apoya en el runner que YA era sync: sin dep nueva. Ésta
+    // sigue siendo la garantía FUERTE del camino de LECTURA y no se toca: el
+    // módulo del runtime no menciona el SDK ni indirectamente.
     assert.equal(FUENTE_VAULT().includes('@aws-sdk'), false,
         'no se agregó ninguna dependencia @aws-sdk/*');
-    assert.equal(
-        Object.keys(require('../../../package.json').dependencies).some((d) => d.startsWith('@aws-sdk')),
-        false,
-        '`package.json` no gana ninguna dependencia @aws-sdk/*',
-    );
+
+    // #5465 (2/3 de #5425) incorpora `@aws-sdk/client-ssm` para el port de
+    // PROVISIÓN, que es otro módulo (`vault-provisioner.js`), otro proceso y
+    // otra identidad. La guarda original de #5353 se escribió contra TODO
+    // `package.json` para demostrar que la superficie sync de lectura no
+    // necesitaba SDK; esa intención se conserva ACOTANDO la aserción a una
+    // allowlist, en vez de prohibir el paquete a nivel repo. Así sigue fallando
+    // si alguien mete `client-secrets-manager` u otro cliente en el runtime.
+    const SDK_PERMITIDOS = ['@aws-sdk/client-ssm'];
+    const sdkDeclarados = Object.keys(require('../../../package.json').dependencies)
+        .filter((d) => d.startsWith('@aws-sdk'))
+        .sort();
+    assert.deepEqual(sdkDeclarados, [...SDK_PERMITIDOS].sort(),
+        'el único `@aws-sdk/*` admitido es el cliente SSM del port de provisión (#5465)');
 });
 
 test('D1.3 · el port sync del driver aws-cli consume NextToken igual que el async', async () => {

--- a/.pipeline/lib/__tests__/secret-vault.test.js
+++ b/.pipeline/lib/__tests__/secret-vault.test.js
@@ -20,8 +20,11 @@ const util = require('node:util');
 const {
     VAULT_READONLY_COMMANDS,
     VAULT_ERROR_CODES,
+    VAULT_TIERS,
+    VAULT_TIER_SERVICE,
     MAX_CACHE_TTL_SECONDS,
     buildParameterPath,
+    validateVaultNamespace,
     createInMemoryVaultDriver,
     createAwsCliVaultDriver,
     createAwsCliVaultRunner,
@@ -976,4 +979,192 @@ test('CA-24 · config.yaml trae la sección vault: con el gate cerrado y hostId 
         driver: createInMemoryVaultDriver({ parameters: {} }),
     });
     assert.match(util.inspect(vault), /enabled: false/);
+});
+
+// =============================================================================
+// #5464 (1/3 de #5425) — validación canónica del namespace, exportada
+// =============================================================================
+//
+// Estos tests fijan por regresión las dos mitades del split: que el helper
+// exportado construye por la implementación canónica (no por una copia), y que
+// exportarlo NO abrió la frontera read-only del runtime.
+
+test('5464-1 · shared y host se construyen con la implementación canónica', () => {
+    const base = { prefix: PREFIX, projectId: PROJECT, hostId: HOST_A };
+
+    const compartido = validateVaultNamespace({ ...base, scope: 'telegram', tier: 'shared' });
+    const porHost = validateVaultNamespace({ ...base, scope: 'aws', tier: 'host' });
+
+    // Mismo path que `buildParameterPath`: es EL MISMO constructor, no un gemelo.
+    assert.equal(compartido.path, buildParameterPath({ ...base, scope: 'telegram', tier: 'shared' }));
+    assert.equal(porHost.path, buildParameterPath({ ...base, scope: 'aws', tier: 'host' }));
+    assert.equal(compartido.path, '/intrale/intrale/shared/telegram');
+    assert.equal(porHost.path, '/intrale/intrale/hosts/hostA/aws');
+
+    // Descriptor completo: tier, destino y namespace explícitos.
+    assert.equal(compartido.service, 'ssm');
+    assert.equal(porHost.service, 'ssm');
+    assert.equal(compartido.tier, 'shared');
+    assert.equal(porHost.hostId, HOST_A);
+    assert.equal(compartido.hostId, null, 'shared no está segmentado por host');
+    assert.equal(compartido.scope, 'telegram');
+    assert.equal(compartido.root, false);
+    assert.ok(Object.isFrozen(compartido), 'el descriptor no se muta después de validar');
+
+    // Raíces recursivas: las mismas que usa el barrido batch del runtime.
+    const raizCompartida = validateVaultNamespace({ ...base, tier: 'shared', root: true });
+    const raizHost = validateVaultNamespace({ ...base, tier: 'host', root: true });
+    assert.equal(raizCompartida.path, '/intrale/intrale/shared/');
+    assert.equal(raizHost.path, `/intrale/intrale/hosts/${HOST_A}/`);
+    assert.equal(raizHost.scope, null, 'una raíz no tiene nombre lógico');
+    assert.equal(raizHost.root, true);
+
+    // SEC-3 — la raíz a nivel proyecto sigue siendo INCONSTRUIBLE por acá.
+    for (const p of [raizCompartida.path, raizHost.path, compartido.path, porHost.path]) {
+        assert.notEqual(p, `${PREFIX}/${PROJECT}/`);
+    }
+});
+
+test('5464-2 · prefijos, segmentos y nombres fuera del proyecto se rechazan antes de todo acceso remoto', () => {
+    const base = { prefix: PREFIX, projectId: PROJECT, hostId: HOST_A, tier: 'shared' };
+
+    // Testigos de que el rechazo es ANTERIOR a cualquier I/O: si el helper
+    // tocara el driver o la CLI, estos contadores dejarían de ser 0.
+    const driver = createInMemoryVaultDriver({ parameters: seedHostA() });
+    let spawns = 0;
+    const runner = createAwsCliVaultRunner(
+        { AWS_ACCESS_KEY_ID: 'k', AWS_SECRET_ACCESS_KEY: 's' },
+        'us-east-2',
+        { execFileSync: () => { spawns += 1; return '{}'; } },
+    );
+
+    const invalidos = [
+        // nombre lógico fuera del proyecto
+        ...['../otro', 'a/b', '', 'host.local', null, undefined, 'con espacio']
+            .map((scope) => [{ ...base, scope }, /vault\.scope/]),
+        // prefijo fuera del proyecto
+        ...['intrale', '/intrale/', '/', '', '/intrale/../etc', '/intra le', null]
+            .map((prefix) => [{ ...base, prefix, scope: 'telegram' }, /vault\.prefix/]),
+        // namespace fuera del proyecto
+        [{ ...base, projectId: 'pro/yecto', scope: 'telegram' }, /vault\.projectId/],
+        [{ ...base, projectId: '..', scope: 'telegram' }, /vault\.projectId/],
+        [{ ...base, tier: 'host', hostId: '../hostB', scope: 'telegram' }, /vault\.hostId/],
+        [{ ...base, tier: 'host', hostId: '', scope: 'telegram' }, /vault\.hostId/],
+        // tier inválido: nunca se infiere de la presencia de hostId
+        ...[undefined, null, '', 'SHARED', 'rotante', 42]
+            .map((tier) => [{ ...base, tier, scope: 'telegram' }, /vault\.tier/]),
+        // `root` ambiguo: la raíz recursiva se pide explícitamente
+        [{ ...base, root: 'true' }, /vault\.root/],
+        [{ ...base, root: 1, scope: 'telegram' }, /vault\.root/],
+    ];
+
+    for (const [args, clave] of invalidos) {
+        assert.throws(() => validateVaultNamespace(args), (e) => {
+            assert.equal(e.name, 'VaultConfigError', `no es error tipado: ${util.inspect(args)}`);
+            assert.equal(e.code, VAULT_ERROR_CODES.CONFIG_INVALID);
+            assert.match(e.message, clave);
+            // El mensaje nombra la CLAVE de config, nunca el regex crudo.
+            assert.ok(!e.message.includes('A-Za-z0-9'), 'el regex crudo no sale del módulo');
+            return true;
+        }, `entrada inválida no rechazada: ${util.inspect(args)}`);
+    }
+
+    // Sin argumentos tampoco devuelve un descriptor a medias: falla cerrado.
+    assert.throws(() => validateVaultNamespace(), /vault\.tier/);
+
+    assert.equal(driver.calls.length, 0, 'validar no leyó del driver');
+    assert.equal(spawns, 0, 'validar no spawneó la CLI');
+});
+
+test('5464-3 · rotating sigue reconocido por el runtime, sin incorporar escritura', async () => {
+    const rotativo = validateVaultNamespace({
+        prefix: PREFIX, projectId: PROJECT, scope: 'google_drive', tier: 'rotating',
+    });
+
+    assert.equal(rotativo.path, 'intrale/intrale/rotating/google_drive');
+    assert.ok(!rotativo.path.startsWith('/'), 'Secrets Manager: SIN barra inicial');
+    assert.equal(rotativo.service, 'secretsmanager');
+    assert.equal(rotativo.hostId, null);
+    // Secrets Manager se lee por nombre exacto: no hay raíz recursiva.
+    assert.throws(
+        () => validateVaultNamespace({ prefix: PREFIX, projectId: PROJECT, tier: 'rotating', root: true }),
+        /vault\.tier/,
+    );
+
+    // El destino por tier está declarado para TODOS los tiers y para ninguno
+    // más: un tier nuevo sin destino rompe acá en vez de mandar el pedido al
+    // servicio equivocado en producción.
+    assert.deepEqual(Object.keys(VAULT_TIER_SERVICE).sort(), [...VAULT_TIERS].sort());
+    assert.ok(Object.isFrozen(VAULT_TIER_SERVICE));
+    for (const service of Object.values(VAULT_TIER_SERVICE)) {
+        assert.ok(['ssm', 'secretsmanager'].includes(service));
+    }
+
+    // Y el camino de LECTURA de `rotating` sigue funcionando por Secrets Manager.
+    const vault = createSecretVault({
+        config: configVault({ required_scopes: ['google_drive'], shared_secrets: [] }),
+        driver: createInMemoryVaultDriver({
+            secrets: { [rotativo.path]: { refresh_token: 'CANARIO-GD' } },
+        }),
+    });
+    const res = await vault.resolveScope({ scopes: ['google_drive'], tier: 'rotating' });
+    assert.deepEqual(res.google_drive, { refresh_token: 'CANARIO-GD' });
+});
+
+test('5464-4 · exportar el validador no agregó verbos de escritura al runtime', () => {
+    const fs = require('node:fs');
+    const path = require('node:path');
+    const fuente = fs.readFileSync(path.join(__dirname, '..', 'secret-vault.js'), 'utf8');
+    const escrituras = ['put-parameter', 'put-secret-value', 'create-secret',
+        'delete-parameter', 'update-secret', 'label-parameter-version'];
+
+    // La allowlist sigue siendo EXACTAMENTE la de #5352.
+    assert.deepEqual([...VAULT_READONLY_COMMANDS], [
+        'ssm get-parameters-by-path', 'ssm get-parameter', 'secretsmanager get-secret-value',
+    ]);
+    for (const verbo of escrituras) {
+        assert.ok(!VAULT_READONLY_COMMANDS.some((c) => c.includes(verbo)),
+            `la allowlist incorporó escritura: ${verbo}`);
+    }
+
+    // El runner los rechaza por COMPORTAMIENTO, sin spawnear.
+    let spawns = 0;
+    const runner = createAwsCliVaultRunner(
+        { AWS_ACCESS_KEY_ID: 'k', AWS_SECRET_ACCESS_KEY: 's' },
+        'us-east-2',
+        { execFileSync: () => { spawns += 1; return '{}'; } },
+    );
+    for (const verbo of escrituras) {
+        assert.throws(() => runner.run('ssm', [verbo, '--name', 'x']), /allowlist read-only/,
+            `verbo de escritura no rechazado: ${verbo}`);
+        assert.throws(() => runner.run('secretsmanager', [verbo]), /allowlist read-only/);
+    }
+    assert.equal(spawns, 0, 'ningún verbo de escritura llegó a spawnear');
+
+    // Los drivers del runtime siguen exponiendo SÓLO lectura.
+    for (const driver of [
+        createInMemoryVaultDriver({ parameters: seedHostA() }),
+        createAwsCliVaultDriver({ run: () => '{}' }),
+    ]) {
+        const metodos = Object.keys(driver).filter((k) => typeof driver[k] === 'function');
+        assert.deepEqual(metodos.sort(), [
+            'getParametersByPath', 'getParametersByPathSync', 'getSecretValue', 'getSecretValueSync',
+        ], `el driver ${driver.kind} expone métodos fuera del contrato de lectura`);
+    }
+
+    // Los regex NO se exportan: exportarlos habilitaría la copia que el helper
+    // viene a evitar (el consumidor debe pasar por `validateVaultNamespace`).
+    const exportado = require('../secret-vault');
+    for (const [clave, valor] of Object.entries(exportado)) {
+        assert.ok(!(valor instanceof RegExp), `se exportó un regex crudo: ${clave}`);
+    }
+
+    // El módulo tampoco nombra un verbo de escritura fuera de un comentario.
+    for (const linea of fuente.split('\n')) {
+        const codigo = linea.trim();
+        if (codigo.startsWith('//') || codigo.startsWith('*')) continue;
+        for (const verbo of escrituras) {
+            assert.ok(!codigo.includes(verbo), `verbo de escritura en el código: ${codigo}`);
+        }
+    }
 });

--- a/.pipeline/lib/__tests__/vault-provisioner.test.js
+++ b/.pipeline/lib/__tests__/vault-provisioner.test.js
@@ -1,0 +1,544 @@
+// =============================================================================
+// Tests de lib/vault-provisioner.js (#5465 — split 2/3 de #5425)
+// node --test  (entra por el glob existente de `npm run test:pipeline`)
+// =============================================================================
+//
+// NINGÚN test requiere red, cuenta AWS ni `@aws-sdk/client-ssm` instalado: el
+// port se ejerce con un fake propio y el adapter real se ejerce inyectando los
+// constructores de comando. Ese último es el que evita la "cobertura ilusoria":
+// sin él, todo correría contra el fake y el adapter que va a producción quedaría
+// sin una sola aserción sobre la forma de los comandos que emite.
+//
+// El fake es PROPIO a propósito: `createInMemoryVaultDriver` pertenece al
+// runtime de LECTURA y ampliarlo con verbos de escritura sería mover la frontera
+// que este split viene a sostener.
+// =============================================================================
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const util = require('node:util');
+
+const {
+    VAULT_PROVISION_STATES,
+    VAULT_PROVISION_ERROR_CODES,
+    VaultProvisionError,
+    createVaultProvisioner,
+    createAwsSsmProvisionDriver,
+} = require('../vault-provisioner');
+
+// -----------------------------------------------------------------------------
+// Constantes y fakes
+// -----------------------------------------------------------------------------
+
+const CMK = 'arn:aws:kms:us-east-1:111122223333:key/1a2b3c4d-0000-0000-0000-abcdefabcdef';
+const PRINCIPAL_PROVISION = 'arn:aws:sts::111122223333:assumed-role/intrale-vault-provisioning/op';
+const PRINCIPAL_RUNTIME = 'arn:aws:sts::111122223333:assumed-role/intrale-pipeline-runtime/agent';
+
+// Canario: si aparece en CUALQUIER superficie observable, hay fuga.
+const CANARIO = 'CANARIO-valor-secreto-9f3a1c7e';
+
+const CONFIG_BASE = Object.freeze({
+    prefix: '/intrale',
+    projectId: 'platform',
+    hostId: 'ws-01',
+    kmsKeyId: CMK,
+    provisioningPrincipal: PRINCIPAL_PROVISION,
+});
+
+/**
+ * Fake del port SSM. Cuenta llamadas y guarda los argumentos exactos para poder
+ * afirmar sobre ellos. Devuelve campos DE MÁS (`Value`, `$metadata`) en la
+ * metadata justamente para probar que la proyección por allowlist los descarta.
+ */
+function fakeSsmPort({ inicial = null, fallarEn = null } = {}) {
+    let store = inicial ? { ...inicial } : null;
+    const llamadas = { get: 0, put: 0, meta: 0, ultimoGet: null, ultimoPut: null };
+
+    return {
+        llamadas,
+        verStore: () => (store ? { ...store } : null),
+
+        async getParameter({ Name, WithDecryption }) {
+            llamadas.get += 1;
+            llamadas.ultimoGet = { Name, WithDecryption };
+            if (fallarEn === 'get') {
+                const e = new Error(`boom del SDK con el valor ${CANARIO} adentro`);
+                e.name = 'InternalServerError';
+                e.$metadata = { httpStatusCode: 500, requestId: 'req-1' };
+                throw e;
+            }
+            return store ? { ...store } : null;
+        },
+
+        async putParameter(params) {
+            llamadas.put += 1;
+            llamadas.ultimoPut = { ...params };
+            if (fallarEn === 'put') {
+                const e = new Error(`boom del SDK con el valor ${CANARIO} adentro`);
+                e.name = 'ThrottlingException';
+                e.$metadata = { httpStatusCode: 400, requestId: 'req-2' };
+                throw e;
+            }
+            store = {
+                Value: params.Value,
+                Type: params.Type,
+                Version: store ? store.Version + 1 : 1,
+            };
+            return { Version: store.Version };
+        },
+
+        async getParameterMetadata() {
+            llamadas.meta += 1;
+            if (!store) return null;
+            // Campos de más, a propósito.
+            return {
+                Type: store.Type,
+                Version: store.Version,
+                Value: store.Value,
+                $metadata: { httpStatusCode: 200, requestId: 'req-3' },
+            };
+        },
+    };
+}
+
+function fakeIdentity(arn, { fallar = false } = {}) {
+    return {
+        async resolveArn() {
+            if (fallar) throw new Error(`STS falló con sesión ${CANARIO}`);
+            return arn;
+        },
+    };
+}
+
+function fakeOverwriteAuthority(respuesta) {
+    const estado = { llamadas: 0, ultimo: null };
+    return {
+        estado,
+        async authorize({ path }) {
+            estado.llamadas += 1;
+            estado.ultimo = { path };
+            if (typeof respuesta === 'function') return respuesta({ path });
+            return respuesta;
+        },
+    };
+}
+
+function armar({ ssm, identityArn = PRINCIPAL_PROVISION, autoriza = false, config = {} } = {}) {
+    const puerto = ssm || fakeSsmPort();
+    const authority = fakeOverwriteAuthority(autoriza);
+    const prov = createVaultProvisioner({
+        ssm: puerto,
+        identity: fakeIdentity(identityArn),
+        overwriteAuthority: authority,
+        config: { ...CONFIG_BASE, ...config },
+    });
+    return { prov, ssm: puerto, authority };
+}
+
+/** Junta todas las superficies observables de un error o resultado. */
+function superficies(x) {
+    const partes = [util.inspect(x, { depth: 10 })];
+    if (x && typeof x === 'object') {
+        if (typeof x.message === 'string') partes.push(x.message);
+        if (typeof x.stack === 'string') partes.push(x.stack);
+        if (x.cause !== undefined) partes.push(util.inspect(x.cause, { depth: 10 }));
+        try { partes.push(JSON.stringify(x)); } catch { /* circular: ya cubierto por inspect */ }
+    }
+    return partes.join('\n');
+}
+
+// -----------------------------------------------------------------------------
+// 1-3 — Estados idempotentes
+// -----------------------------------------------------------------------------
+
+test('crea el parámetro con SecureString, CMK explícita y Overwrite:true', async () => {
+    const { prov, ssm } = armar();
+
+    const r = await prov.provisionSecret({ tier: 'shared', scope: 'telegram-token', value: 's3cr3t' });
+
+    assert.equal(r.estado, VAULT_PROVISION_STATES.CREATED);
+    assert.equal(r.path, '/intrale/platform/shared/telegram-token');
+    assert.equal(ssm.llamadas.put, 1);
+    // Los cuatro campos POSITIVOS de la escritura.
+    assert.equal(ssm.llamadas.ultimoPut.Type, 'SecureString');
+    assert.equal(ssm.llamadas.ultimoPut.KeyId, CMK);
+    assert.equal(ssm.llamadas.ultimoPut.Overwrite, true);
+    assert.equal(ssm.llamadas.ultimoPut.Name, '/intrale/platform/shared/telegram-token');
+});
+
+test('una repetición idéntica devuelve `sin cambios` sin ejecutar PutParameter ni subir versión', async () => {
+    const ssm = fakeSsmPort({ inicial: { Value: 's3cr3t', Type: 'SecureString', Version: 7 } });
+    const { prov } = armar({ ssm });
+
+    const r = await prov.provisionSecret({ tier: 'shared', scope: 'telegram-token', value: 's3cr3t' });
+
+    assert.equal(r.estado, VAULT_PROVISION_STATES.UNCHANGED);
+    assert.equal(ssm.llamadas.put, 0, 'no debe escribir');
+    assert.equal(r.metadata.Version, 7, 'la versión no aumenta');
+});
+
+test('un valor distinto CON capability devuelve `sobrescrito` y avanza la versión', async () => {
+    const ssm = fakeSsmPort({ inicial: { Value: 'viejo', Type: 'SecureString', Version: 4 } });
+    const { prov, authority } = armar({ ssm, autoriza: true });
+
+    const r = await prov.provisionSecret({ tier: 'shared', scope: 'telegram-token', value: 'nuevo' });
+
+    assert.equal(r.estado, VAULT_PROVISION_STATES.OVERWRITTEN);
+    assert.equal(r.metadata.Version, 5);
+    assert.equal(ssm.llamadas.put, 1);
+    assert.equal(authority.estado.llamadas, 1);
+    assert.equal(authority.estado.ultimo.path, '/intrale/platform/shared/telegram-token');
+});
+
+// -----------------------------------------------------------------------------
+// 4 — Autorización: NO la decide el caller (REQ-SEC-5465-1)
+// -----------------------------------------------------------------------------
+
+test('un valor distinto SIN capability no escribe y falla con OVERWRITE_DENIED', async () => {
+    const ssm = fakeSsmPort({ inicial: { Value: 'viejo', Type: 'SecureString', Version: 4 } });
+    const { prov } = armar({ ssm, autoriza: false });
+
+    await assert.rejects(
+        () => prov.provisionSecret({ tier: 'shared', scope: 'telegram-token', value: 'nuevo' }),
+        (e) => e.code === VAULT_PROVISION_ERROR_CODES.OVERWRITE_DENIED,
+    );
+    assert.equal(ssm.llamadas.put, 0);
+});
+
+test('la capability sólo autoriza con `true` estricto: un truthy no alcanza', async () => {
+    const ssm = fakeSsmPort({ inicial: { Value: 'viejo', Type: 'SecureString', Version: 1 } });
+    const prov = createVaultProvisioner({
+        ssm,
+        identity: fakeIdentity(PRINCIPAL_PROVISION),
+        overwriteAuthority: { async authorize() { return 'sí'; } },
+        config: CONFIG_BASE,
+    });
+
+    await assert.rejects(
+        () => prov.provisionSecret({ tier: 'shared', scope: 'x', value: 'nuevo' }),
+        (e) => e.code === VAULT_PROVISION_ERROR_CODES.OVERWRITE_DENIED,
+    );
+    assert.equal(ssm.llamadas.put, 0);
+});
+
+test('el payload es cerrado: `allowOverwrite` o `kmsKeyId` propios son rechazo, no campos ignorados', async () => {
+    const { prov, ssm } = armar();
+
+    for (const extra of [{ allowOverwrite: true }, { kmsKeyId: 'arn:aws:kms:otra' }, { principal: PRINCIPAL_PROVISION }]) {
+        await assert.rejects(
+            () => prov.provisionSecret({ tier: 'shared', scope: 'x', value: 'v', ...extra }),
+            (e) => e.code === VAULT_PROVISION_ERROR_CODES.PAYLOAD_INVALID,
+        );
+    }
+    assert.equal(ssm.llamadas.get, 0, 'ni siquiera se lee');
+    assert.equal(ssm.llamadas.put, 0);
+});
+
+// -----------------------------------------------------------------------------
+// 5-7 — Rechazos previos a cualquier llamada AWS
+// -----------------------------------------------------------------------------
+
+test('la identidad runtime se rechaza sin emitir una sola llamada a SSM', async () => {
+    const ssm = fakeSsmPort();
+    const { prov } = armar({ ssm, identityArn: PRINCIPAL_RUNTIME });
+
+    await assert.rejects(
+        () => prov.provisionSecret({ tier: 'shared', scope: 'x', value: 'v' }),
+        (e) => e.code === VAULT_PROVISION_ERROR_CODES.IDENTITY_DENIED,
+    );
+    assert.equal(ssm.llamadas.get, 0);
+    assert.equal(ssm.llamadas.put, 0);
+});
+
+test('una identidad no verificable (STS falla o devuelve vacío) falla cerrado', async () => {
+    for (const identity of [fakeIdentity(PRINCIPAL_PROVISION, { fallar: true }), fakeIdentity('')]) {
+        const ssm = fakeSsmPort();
+        const prov = createVaultProvisioner({
+            ssm,
+            identity,
+            overwriteAuthority: fakeOverwriteAuthority(true),
+            config: CONFIG_BASE,
+        });
+        await assert.rejects(
+            () => prov.provisionSecret({ tier: 'shared', scope: 'x', value: 'v' }),
+            (e) => e.code === VAULT_PROVISION_ERROR_CODES.IDENTITY_DENIED,
+        );
+        assert.equal(ssm.llamadas.get, 0);
+    }
+});
+
+test('sin CMK explícita el provisionador no se construye (falla cerrado)', () => {
+    for (const kmsKeyId of [undefined, '', null]) {
+        assert.throws(
+            () => createVaultProvisioner({
+                ssm: fakeSsmPort(),
+                identity: fakeIdentity(PRINCIPAL_PROVISION),
+                overwriteAuthority: fakeOverwriteAuthority(true),
+                config: { ...CONFIG_BASE, kmsKeyId },
+            }),
+            (e) => e.code === VAULT_PROVISION_ERROR_CODES.CMK_INVALID,
+        );
+    }
+});
+
+test('un path inválido se rechaza antes de cualquier acceso remoto', async () => {
+    const ssm = fakeSsmPort();
+    const { prov } = armar({ ssm });
+
+    for (const scope of ['../otro-proyecto', 'con/barra', '', 'punto.punto']) {
+        await assert.rejects(() => prov.provisionSecret({ tier: 'shared', scope, value: 'v' }));
+    }
+    assert.equal(ssm.llamadas.get, 0);
+    assert.equal(ssm.llamadas.put, 0);
+});
+
+test('el tier `rotating` se rechaza: vive en Secrets Manager, no en este port', async () => {
+    const ssm = fakeSsmPort();
+    const { prov } = armar({ ssm });
+
+    await assert.rejects(
+        () => prov.provisionSecret({ tier: 'rotating', scope: 'x', value: 'v' }),
+        (e) => e.code === VAULT_PROVISION_ERROR_CODES.TIER_UNSUPPORTED,
+    );
+    assert.equal(ssm.llamadas.get, 0);
+    assert.equal(ssm.llamadas.put, 0);
+});
+
+// -----------------------------------------------------------------------------
+// 8 — Verificación posterior (REQ-SEC-5465-6)
+// -----------------------------------------------------------------------------
+
+test('la verificación posterior proyecta SÓLO Type y Version', async () => {
+    const { prov } = armar();
+    const r = await prov.provisionSecret({ tier: 'shared', scope: 'x', value: 'v' });
+
+    assert.deepEqual(Object.keys(r.metadata).sort(), ['Type', 'Version']);
+    assert.deepEqual(Object.keys(r).sort(), ['estado', 'metadata', 'path', 'scope', 'tier']);
+    assert.equal(r.metadata.Type, 'SecureString');
+});
+
+test('la verificación posterior no descifra: pide metadata sin WithDecryption', async () => {
+    const ssm = fakeSsmPort();
+    const { prov } = armar({ ssm });
+    await prov.provisionSecret({ tier: 'shared', scope: 'x', value: 'v' });
+
+    assert.equal(ssm.llamadas.meta, 1, 'usa el método de metadata, no un get descifrado');
+    // La única lectura descifrada es la comparación previa, en memoria.
+    assert.equal(ssm.llamadas.get, 1);
+    assert.equal(ssm.llamadas.ultimoGet.WithDecryption, true);
+});
+
+test('si el parámetro no queda como SecureString, la verificación falla cerrada', async () => {
+    const ssm = fakeSsmPort();
+    // El backend "acepta" el put pero degrada el tipo.
+    const original = ssm.putParameter.bind(ssm);
+    ssm.putParameter = async (p) => original({ ...p, Type: 'String' });
+
+    const { prov } = armar({ ssm });
+    await assert.rejects(
+        () => prov.provisionSecret({ tier: 'shared', scope: 'x', value: 'v' }),
+        (e) => e.code === VAULT_PROVISION_ERROR_CODES.VERIFY_FAILED,
+    );
+});
+
+test('un parámetro preexistente en texto plano NO cuenta como `sin cambios`', async () => {
+    // Mismo valor, pero `String`: está expuesto y hay que repararlo. Reparar es
+    // sobrescribir, y sobrescribir exige capability.
+    const ssm = fakeSsmPort({ inicial: { Value: 'v', Type: 'String', Version: 2 } });
+    const { prov } = armar({ ssm, autoriza: true });
+
+    const r = await prov.provisionSecret({ tier: 'shared', scope: 'x', value: 'v' });
+
+    assert.equal(r.estado, VAULT_PROVISION_STATES.OVERWRITTEN);
+    assert.equal(ssm.llamadas.ultimoPut.Type, 'SecureString');
+});
+
+// -----------------------------------------------------------------------------
+// 9 — Concurrencia por nombre (REQ-SEC-5465-4)
+// -----------------------------------------------------------------------------
+
+test('dos writers concurrentes sobre el mismo nombre se serializan: un solo Put', async () => {
+    const ssm = fakeSsmPort();
+    const { prov } = armar({ ssm, autoriza: true });
+
+    const [a, b] = await Promise.all([
+        prov.provisionSecret({ tier: 'shared', scope: 'x', value: 'mismo' }),
+        prov.provisionSecret({ tier: 'shared', scope: 'x', value: 'mismo' }),
+    ]);
+
+    assert.equal(ssm.llamadas.put, 1, 'el segundo ve el valor del primero y no reescribe');
+    const estados = [a.estado, b.estado].sort();
+    assert.deepEqual(estados, [VAULT_PROVISION_STATES.CREATED, VAULT_PROVISION_STATES.UNCHANGED].sort());
+    assert.equal(ssm.verStore().Version, 1, 'sin falso doble bump de versión');
+});
+
+test('una falla en un nombre no traba las provisiones siguientes de ese nombre', async () => {
+    const ssm = fakeSsmPort();
+    const { prov } = armar({ ssm });
+
+    await assert.rejects(() => prov.provisionSecret({ tier: 'shared', scope: 'x', value: 42 }));
+    const r = await prov.provisionSecret({ tier: 'shared', scope: 'x', value: 'ok' });
+    assert.equal(r.estado, VAULT_PROVISION_STATES.CREATED);
+});
+
+// -----------------------------------------------------------------------------
+// 10 — Canario de no fuga (REQ-SEC-5465-5)
+// -----------------------------------------------------------------------------
+
+test('el valor no aparece en el resultado de una provisión exitosa', async () => {
+    const { prov } = armar();
+    const r = await prov.provisionSecret({ tier: 'shared', scope: 'x', value: CANARIO });
+
+    assert.ok(!superficies(r).includes(CANARIO), 'el valor se filtró en el resultado');
+});
+
+test('el valor no aparece en los errores de GetParameter ni de PutParameter', async () => {
+    for (const fallarEn of ['get', 'put']) {
+        const ssm = fakeSsmPort({ fallarEn });
+        const { prov } = armar({ ssm });
+
+        const err = await prov
+            .provisionSecret({ tier: 'shared', scope: 'x', value: CANARIO })
+            .then(() => null, (e) => e);
+
+        assert.ok(err instanceof VaultProvisionError, `${fallarEn}: debe traducirse a VaultProvisionError`);
+        assert.equal(err.code, VAULT_PROVISION_ERROR_CODES.BACKEND);
+        const s = superficies(err);
+        assert.ok(!s.includes(CANARIO), `${fallarEn}: el valor se filtró`);
+        assert.ok(!s.includes('$metadata'), `${fallarEn}: se filtró la respuesta AWS`);
+        assert.ok(!s.includes('requestId'), `${fallarEn}: se filtró el requestId`);
+        assert.equal(err.cause, undefined, `${fallarEn}: no debe encadenar el error del SDK`);
+    }
+});
+
+test('el valor no aparece cuando falla la verificación de identidad', async () => {
+    const prov = createVaultProvisioner({
+        ssm: fakeSsmPort(),
+        identity: fakeIdentity(PRINCIPAL_PROVISION, { fallar: true }),
+        overwriteAuthority: fakeOverwriteAuthority(true),
+        config: CONFIG_BASE,
+    });
+
+    const err = await prov
+        .provisionSecret({ tier: 'shared', scope: 'x', value: CANARIO })
+        .then(() => null, (e) => e);
+
+    assert.ok(!superficies(err).includes(CANARIO));
+});
+
+test('el error de identidad denegada no filtra el ARN efectivo recibido', async () => {
+    const { prov } = armar({ identityArn: PRINCIPAL_RUNTIME });
+
+    const err = await prov
+        .provisionSecret({ tier: 'shared', scope: 'x', value: 'v' })
+        .then(() => null, (e) => e);
+
+    assert.ok(!superficies(err).includes(PRINCIPAL_RUNTIME),
+        'el ARN efectivo no debe terminar en un log compartido');
+});
+
+// -----------------------------------------------------------------------------
+// 11 — Paridad del adapter real (evita cobertura ilusoria)
+// -----------------------------------------------------------------------------
+
+test('el adapter real emite GetParameter/PutParameter con la forma exacta esperada', async () => {
+    const emitidos = [];
+    class FakeGetParameterCommand {
+        constructor(input) { this.tipo = 'get'; this.input = input; emitidos.push(this); }
+    }
+    class FakePutParameterCommand {
+        constructor(input) { this.tipo = 'put'; this.input = input; emitidos.push(this); }
+    }
+
+    const client = {
+        async send(cmd) {
+            if (cmd.tipo === 'put') return { Version: 3 };
+            return { Parameter: { Value: 'v', Type: 'SecureString', Version: 3 }, $metadata: { requestId: 'r' } };
+        },
+    };
+
+    const driver = createAwsSsmProvisionDriver({
+        client,
+        commands: {
+            GetParameterCommand: FakeGetParameterCommand,
+            PutParameterCommand: FakePutParameterCommand,
+        },
+    });
+
+    await driver.putParameter({
+        Name: '/intrale/platform/shared/x', Value: 'v', Type: 'SecureString', KeyId: CMK, Overwrite: true,
+    });
+    assert.deepEqual(emitidos.at(-1).input, {
+        Name: '/intrale/platform/shared/x', Value: 'v', Type: 'SecureString', KeyId: CMK, Overwrite: true,
+    });
+
+    await driver.getParameter({ Name: '/intrale/platform/shared/x', WithDecryption: true });
+    assert.equal(emitidos.at(-1).input.WithDecryption, true);
+
+    const meta = await driver.getParameterMetadata({ Name: '/intrale/platform/shared/x' });
+    assert.equal(emitidos.at(-1).input.WithDecryption, false, 'la verificación NO descifra');
+    assert.deepEqual(Object.keys(meta).sort(), ['Type', 'Version'], 'proyecta sólo Type y Version');
+});
+
+test('el adapter real traduce ParameterNotFound a null, no a excepción', async () => {
+    class FakeGetParameterCommand { constructor(input) { this.input = input; } }
+    const client = {
+        async send() {
+            const e = new Error('no está');
+            e.name = 'ParameterNotFound';
+            throw e;
+        },
+    };
+    const driver = createAwsSsmProvisionDriver({
+        client,
+        commands: { GetParameterCommand: FakeGetParameterCommand, PutParameterCommand: class {} },
+    });
+
+    assert.equal(await driver.getParameter({ Name: '/x', WithDecryption: true }), null);
+});
+
+test('el adapter real no devuelve la respuesta cruda de AWS', async () => {
+    class FakeGetParameterCommand { constructor(input) { this.input = input; } }
+    const client = {
+        async send() {
+            return {
+                Parameter: { Value: CANARIO, Type: 'SecureString', Version: 1, ARN: 'arn:aws:ssm:...' },
+                $metadata: { httpStatusCode: 200, requestId: 'req-x' },
+            };
+        },
+    };
+    const driver = createAwsSsmProvisionDriver({
+        client,
+        commands: { GetParameterCommand: FakeGetParameterCommand, PutParameterCommand: class {} },
+    });
+
+    const r = await driver.getParameter({ Name: '/x', WithDecryption: true });
+    assert.deepEqual(Object.keys(r).sort(), ['Type', 'Value', 'Version']);
+    assert.ok(!Object.prototype.hasOwnProperty.call(r, '$metadata'));
+    assert.ok(!Object.prototype.hasOwnProperty.call(r, 'ARN'));
+});
+
+// -----------------------------------------------------------------------------
+// 12 — Frontera read-only intacta
+// -----------------------------------------------------------------------------
+
+test('el runtime de lectura sigue sin exponer verbos de escritura', () => {
+    const secretVault = require('../secret-vault');
+
+    assert.deepEqual(
+        [...secretVault.VAULT_READONLY_COMMANDS].sort(),
+        ['secretsmanager get-secret-value', 'ssm get-parameter', 'ssm get-parameters-by-path'].sort(),
+        'la allowlist read-only no incorpora escritura',
+    );
+    const driver = secretVault.createInMemoryVaultDriver({});
+    assert.equal(typeof driver.putParameter, 'undefined', 'el driver de lectura no aprovisiona');
+});
+
+test('el tier `host` construye el path segmentado por host con el validador canónico', async () => {
+    const { prov } = armar();
+    const r = await prov.provisionSecret({ tier: 'host', scope: 'db-pass', value: 'v' });
+
+    assert.equal(r.path, '/intrale/platform/hosts/ws-01/db-pass');
+    assert.equal(r.tier, 'host');
+});

--- a/.pipeline/lib/secret-vault.js
+++ b/.pipeline/lib/secret-vault.js
@@ -13,7 +13,16 @@
 //   conductores"). La API async de #5352 no cambia — sigue declarada `async`,
 //   sigue devolviendo `Promise`, y su suite queda verde sin editarse (D1.5).
 //
+// AMPLIACIÓN DE #5464 (1/3 de #5425) — se EXPORTA la validación canónica del
+//   namespace (`validateVaultNamespace`) para que el tramo de provisión la
+//   reutilice en vez de copiar los regex. Es un envoltorio PURO sobre
+//   `buildParameterPath`: no agrega reglas, no agrega verbos y no amplía los
+//   privilegios del runtime — la allowlist read-only queda idéntica.
+//
 // LO QUE ESTE MÓDULO **NO** HACE (a propósito):
+//   - NO escribe en el vault. `VAULT_READONLY_COMMANDS` sigue siendo la lista
+//     congelada de #5352 (tres verbos de lectura) y ningún driver de acá expone
+//     escritura: escribir es del rol de provisión, no del runtime que lee.
 //   - NO escribe en el ambiente del proceso (CA-8). Esa decisión — precedencia y
 //     semántica de degradación de `loadIntoEnv` — vive en la hija 3 (#5353) y
 //     toca `credentials.js`. Acá no se importa nada que mute el ambiente.
@@ -360,6 +369,79 @@ function assertPrefix(clave, value) {
             `inválido (${describeTipo(value)}): debe empezar con "/" y no terminar en "/" `
             + '(ejemplo válido: `/intrale`)');
     }
+}
+
+// -----------------------------------------------------------------------------
+// #5464 (1/3 de #5425) — validación CANÓNICA del namespace, exportable
+// -----------------------------------------------------------------------------
+//
+// El tramo de provisión (#5425) necesita resolver y validar el mismo nombre
+// lógico que el runtime lee, pero vive en OTRO proceso, con OTRA identidad y
+// con un port de ESCRITURA propio. Sin un punto de entrada exportado, ese
+// tramo termina copiando `SEGMENT_RE` / `PREFIX_RE` o concatenando el path a
+// mano: dos copias del esquema que divergen en silencio el día que una cambia.
+//
+// Por eso esto NO es una segunda implementación: `validateVaultNamespace` es un
+// envoltorio fino sobre `buildParameterPath`, que sigue siendo el único lugar
+// donde vive el esquema y el único que corre los regex. Acá no hay un regex
+// nuevo, ni una concatenación de path, ni una regla de validación propia — si
+// la hubiera, sería exactamente la duplicación que este split viene a evitar.
+//
+// Y NO amplía privilegios: es una función PURA (sin I/O, sin ambiente, sin
+// driver). No toca `VAULT_READONLY_COMMANDS`, no agrega verbos, no expone los
+// regex crudos (exportarlos habilitaría justamente la copia que se quiere
+// impedir). El `service` que devuelve es el destino de LECTURA que el tier ya
+// implica en `buildParameterPath`; quién escribe y con qué verbo es decisión
+// del provisionador, fuera de este módulo.
+
+// Destino AWS por tier. Se declara UNA vez y se cubre por test contra
+// `VAULT_TIERS`: un tier nuevo sin destino declarado rompe la suite en vez de
+// devolver `undefined` y mandar el pedido a un servicio equivocado.
+const VAULT_TIER_SERVICE = Object.freeze({
+    shared: 'ssm',
+    host: 'ssm',
+    rotating: 'secretsmanager',
+});
+
+/**
+ * Valida prefijo, namespace (`projectId` / `hostId`), tier y nombre lógico, y
+ * devuelve el descriptor canónico del destino. Fail-closed: si algo no valida,
+ * lanza `VaultConfigError` y NO devuelve un descriptor a medias — el consumidor
+ * no llega a emitir la llamada remota.
+ *
+ * Mismos argumentos, mismos errores y mismas claves de config que
+ * `buildParameterPath`: es el mismo contrato, con la salida enriquecida.
+ *
+ * @param {object} args  igual que `buildParameterPath`
+ * @returns {Readonly<{tier:string, service:'ssm'|'secretsmanager', path:string,
+ *                     root:boolean, prefix:string, projectId:string,
+ *                     hostId:string|null, scope:string|null}>}
+ */
+function validateVaultNamespace({ prefix, projectId, hostId, scope, tier, root = false } = {}) {
+    // `root` decide si el nombre lógico es obligatorio, así que un truthy
+    // ambiguo (`'false'`, `1`) cambiaría la validación sin que nadie lo note.
+    if (typeof root !== 'boolean') {
+        throw new VaultConfigError('vault.root',
+            `debe ser booleano (recibido: ${describeTipo(root)}); `
+            + 'la raíz recursiva se pide EXPLÍCITAMENTE, nunca por un valor truthy');
+    }
+
+    // Única fuente del esquema y de los regex: si esto no lanza, el path es
+    // válido por construcción.
+    const path = buildParameterPath({ prefix, projectId, hostId, scope, tier, root });
+
+    return Object.freeze({
+        tier,
+        service: VAULT_TIER_SERVICE[tier],
+        path,
+        root,
+        prefix,
+        projectId,
+        // `hostId` sólo pertenece al descriptor si el tier lo usó: devolverlo
+        // en `shared` sugeriría que el path está segmentado por host y no lo está.
+        hostId: tier === 'host' ? hostId : null,
+        scope: root ? null : scope,
+    });
 }
 
 // -----------------------------------------------------------------------------
@@ -1126,6 +1208,11 @@ module.exports = {
     VAULT_ERROR_CODES,
     MAX_CACHE_TTL_SECONDS,
     buildParameterPath,
+    // #5464 — validación canónica reutilizable por el tramo de provisión
+    // (#5425). Los regex NO se exportan a propósito: exportarlos habilitaría
+    // la copia que este helper viene a evitar.
+    VAULT_TIER_SERVICE,
+    validateVaultNamespace,
     createInMemoryVaultDriver,
     createAwsCliVaultDriver,
     createAwsCliVaultRunner,

--- a/.pipeline/lib/vault-provisioner.js
+++ b/.pipeline/lib/vault-provisioner.js
@@ -1,0 +1,488 @@
+// =============================================================================
+// vault-provisioner.js — port de PROVISIÓN del vault (#5465, 2/3 de #5425)
+// =============================================================================
+//
+// QUÉ ES: el port de ESCRITURA sobre SSM. Aprovisiona `SecureString` con CMK
+// explícita, de forma idempotente, sin filtrar el valor por ninguna superficie.
+//
+// POR QUÉ VIVE FUERA DE `secret-vault.js`: ese módulo es el runtime de LECTURA.
+// Su allowlist (`VAULT_READONLY_COMMANDS`) está congelada en tres verbos de
+// lectura y la policy IAM del runtime tiene un `Deny` explícito sobre
+// `ssm:PutParameter` (`docs/pipeline/vault-iam-policy.json`). Escribir es otro
+// rol, otra identidad y otro proceso: mezclarlo acá ampliaría los privilegios
+// del runtime, que es exactamente lo que el split viene a evitar.
+//
+// LO QUE ESTE MÓDULO **NO** HACE (a propósito):
+//   - NO valida namespaces por su cuenta. El nombre sale EXCLUSIVAMENTE de
+//     `validateVaultNamespace` (#5464): no hay regex, ni concatenación de path,
+//     ni reglas propias acá. Si las hubiera, serían la copia que el split evita.
+//   - NO acepta la CMK ni la autorización de sobrescritura dentro del payload
+//     que trae el secreto. Ambas vienen de config/capability inyectadas por el
+//     composition root (ver "Modelo de autorización").
+//   - NO devuelve, loguea ni serializa el valor, su hash, la respuesta cruda de
+//     AWS, `$metadata`, `cause` ni el stack del SDK (ver "Frontera de fuga").
+//   - NO importa `@aws-sdk/client-ssm` en el tope. El SDK se carga en forma
+//     perezosa y sólo dentro del adapter real, para que los tests corran contra
+//     el fake sin depender de que el paquete esté instalado.
+//
+// MODELO DE AUTORIZACIÓN (REQ-SEC-5465-1 / -2)
+//   La autorización NO es un booleano del request. Un `allowOverwrite: true`
+//   viajando junto al secreto es autoautorización: el caller se firma el propio
+//   permiso. Acá son dos colaboradores separados e inyectados:
+//     - `identity.resolveArn()`  — principal EFECTIVO, de fuente confiable
+//       (STS). Se compara contra `config.provisioningPrincipal`. Ausente, no
+//       verificable o distinto ⇒ falla ANTES de cualquier llamada a SSM.
+//     - `overwriteAuthority.authorize({ path })` — capability construida por el
+//       composition root del operador. Sólo `true` estricto habilita sobrescribir.
+//   Además el payload es CERRADO: sólo admite `tier`, `scope` y `value`. Una
+//   clave de más (`kmsKeyId`, `allowOverwrite`, `principal`) es rechazo, no un
+//   campo ignorado en silencio.
+//
+// FRONTERA DE FUGA (REQ-SEC-5465-5)
+//   Todo lo que sale de acá se construye por ALLOWLIST, nunca por omisión:
+//   `{ estado, tier, scope, path, metadata: { Type, Version } }`. Los errores
+//   son `VaultProvisionError` con un `code` estable y un mensaje redactado a
+//   mano; jamás se adjunta `cause` ni se reenvía el error del SDK, porque el
+//   error de AWS puede arrastrar el request completo — y el request lleva el
+//   valor.
+//
+// IDEMPOTENCIA Y CONCURRENCIA (REQ-SEC-5465-4)
+//   SSM `PutParameter` NO ofrece compare-and-swap por versión: la secuencia
+//   `Get -> comparar -> Put` es idempotente para ejecución SERIAL, y nada más.
+//   Este módulo serializa por nombre DENTRO del proceso (ver `serializarPorPath`)
+//   para que dos llamadas concurrentes no se pisen. Entre PROCESOS distintos no
+//   hay exclusión posible con la API de SSM: el contrato no promete idempotencia
+//   fuerte y el composition root debe serializar si abre varios provisionadores.
+// =============================================================================
+'use strict';
+
+const { validateVaultNamespace } = require('./secret-vault');
+
+// -----------------------------------------------------------------------------
+// Contrato público
+// -----------------------------------------------------------------------------
+
+/**
+ * Estados terminales de una provisión. Son los ÚNICOS valores que puede tomar
+ * `estado` en el resultado.
+ */
+const VAULT_PROVISION_STATES = Object.freeze({
+    CREATED: 'creado',
+    UNCHANGED: 'sin cambios',
+    OVERWRITTEN: 'sobrescrito',
+});
+
+/**
+ * Códigos de falla. Se discriminan por `code` (no por clase) siguiendo la misma
+ * convención que `VaultConfigError` en `secret-vault.js`.
+ */
+const VAULT_PROVISION_ERROR_CODES = Object.freeze({
+    PAYLOAD_INVALID: 'VAULT_PROVISION_PAYLOAD_INVALID',
+    VALUE_INVALID: 'VAULT_PROVISION_VALUE_INVALID',
+    TIER_UNSUPPORTED: 'VAULT_PROVISION_TIER_UNSUPPORTED',
+    CMK_INVALID: 'VAULT_PROVISION_CMK_INVALID',
+    IDENTITY_DENIED: 'VAULT_PROVISION_IDENTITY_DENIED',
+    OVERWRITE_DENIED: 'VAULT_PROVISION_OVERWRITE_DENIED',
+    VERIFY_FAILED: 'VAULT_PROVISION_VERIFY_FAILED',
+    BACKEND: 'VAULT_PROVISION_BACKEND',
+});
+
+/**
+ * Falla terminal de provisión. El mensaje se escribe a mano y describe la
+ * REMEDIACIÓN; nunca interpola el valor, el hash ni la respuesta de AWS.
+ *
+ * No lleva `cause` deliberadamente: encadenar el error del SDK arrastraría el
+ * request (y con él, el secreto) a cualquier `util.inspect` o logger.
+ */
+class VaultProvisionError extends Error {
+    constructor(code, detalle) {
+        super(`vault-provisioner: ${detalle}.`);
+        this.name = 'VaultProvisionError';
+        this.code = code;
+    }
+}
+
+// Campos admitidos en el payload de provisión. Cerrado a propósito: ver
+// "Modelo de autorización".
+const CAMPOS_PAYLOAD = Object.freeze(['tier', 'scope', 'value']);
+
+// El único `Type` que este port escribe. No es configurable: un `String` en
+// texto plano sería el bug que todo el módulo previene.
+const TIPO_SEGURO = 'SecureString';
+
+// -----------------------------------------------------------------------------
+// Provisionador
+// -----------------------------------------------------------------------------
+
+/**
+ * Crea el port de provisión.
+ *
+ * @param {object}   deps
+ * @param {object}   deps.ssm     port de escritura. Tres métodos, todos async:
+ *   - `getParameter({ Name, WithDecryption })` -> `{ Value, Type, Version }`, o
+ *     `null` si el parámetro NO existe. El adapter traduce `ParameterNotFound`
+ *     a `null`: "no existe" es un estado del flujo, no una excepción.
+ *   - `putParameter({ Name, Value, Type, KeyId, Overwrite })` -> `{ Version }`.
+ *   - `getParameterMetadata({ Name })` -> `{ Type, Version }` SIN descifrar.
+ * @param {object}   deps.identity            `{ resolveArn(): Promise<string> }`.
+ * @param {object}   deps.overwriteAuthority  `{ authorize({ path }): Promise<boolean> }`.
+ * @param {object}   deps.config
+ * @param {string}   deps.config.prefix
+ * @param {string}   deps.config.projectId
+ * @param {string}   [deps.config.hostId]               requerido sólo en tier `host`.
+ * @param {string}   deps.config.kmsKeyId               CMK permitida. Obligatoria.
+ * @param {string}   deps.config.provisioningPrincipal  ARN autorizado a escribir.
+ */
+function createVaultProvisioner({ ssm, identity, overwriteAuthority, config } = {}) {
+    assertPuerto('ssm', ssm, ['getParameter', 'putParameter', 'getParameterMetadata']);
+    assertPuerto('identity', identity, ['resolveArn']);
+    assertPuerto('overwriteAuthority', overwriteAuthority, ['authorize']);
+
+    if (config == null || typeof config !== 'object') {
+        throw new VaultProvisionError(VAULT_PROVISION_ERROR_CODES.PAYLOAD_INVALID,
+            'requiere `config` con prefix, projectId, kmsKeyId y provisioningPrincipal');
+    }
+
+    // La CMK se fija al CONSTRUIR, no por request: así no hay forma de que
+    // llegue junto al secreto (REQ-SEC-5465-3).
+    const kmsKeyId = config.kmsKeyId;
+    if (typeof kmsKeyId !== 'string' || kmsKeyId === '') {
+        throw new VaultProvisionError(VAULT_PROVISION_ERROR_CODES.CMK_INVALID,
+            'requiere `config.kmsKeyId` (CMK explícita): sin CMK no se escribe — '
+            + 'la clave administrada por defecto de AWS no es una CMK del proyecto');
+    }
+
+    const provisioningPrincipal = config.provisioningPrincipal;
+    if (typeof provisioningPrincipal !== 'string' || provisioningPrincipal === '') {
+        throw new VaultProvisionError(VAULT_PROVISION_ERROR_CODES.IDENTITY_DENIED,
+            'requiere `config.provisioningPrincipal`: el principal autorizado se '
+            + 'declara en config, no se infiere del caller');
+    }
+
+    // Serialización por nombre. Ver "Idempotencia y concurrencia".
+    const cadenasPorPath = new Map();
+
+    function serializarPorPath(path, tarea) {
+        const previa = cadenasPorPath.get(path) || Promise.resolve();
+        // `.then(tarea, tarea)`: la tarea siguiente corre aunque la anterior
+        // haya fallado — una falla no debe trabar el nombre para siempre.
+        const actual = previa.then(tarea, tarea);
+        // La cadena de espera nunca rechaza, si no un fallo propagaría a los
+        // que esperan detrás.
+        const espera = actual.then(() => {}, () => {});
+        cadenasPorPath.set(path, espera);
+        espera.then(() => {
+            // Sólo el último de la fila limpia: si otro ya encoló, el Map debe
+            // seguir apuntando a esa cadena más nueva.
+            if (cadenasPorPath.get(path) === espera) cadenasPorPath.delete(path);
+        });
+        return actual;
+    }
+
+    /**
+     * Aprovisiona un secreto. Payload CERRADO: `{ tier, scope, value }`.
+     *
+     * @returns {Promise<Readonly<{estado:string, tier:string, scope:string,
+     *                             path:string, metadata:Readonly<{Type:string, Version:number}>}>>}
+     */
+    async function provisionSecret(payload) {
+        // --- 1. Payload cerrado -------------------------------------------------
+        if (payload == null || typeof payload !== 'object' || Array.isArray(payload)) {
+            throw new VaultProvisionError(VAULT_PROVISION_ERROR_CODES.PAYLOAD_INVALID,
+                'el payload debe ser un objeto `{ tier, scope, value }`');
+        }
+        const sobrantes = Object.keys(payload).filter((k) => !CAMPOS_PAYLOAD.includes(k));
+        if (sobrantes.length > 0) {
+            // Nombrar las claves sobrantes es seguro: son NOMBRES de campo, no
+            // valores. Y es la única forma de que el error sea accionable.
+            throw new VaultProvisionError(VAULT_PROVISION_ERROR_CODES.PAYLOAD_INVALID,
+                `el payload sólo admite ${CAMPOS_PAYLOAD.join(', ')} — sobran: `
+                + `${sobrantes.join(', ')}. La CMK y la autorización de sobrescritura `
+                + 'NO viajan con el secreto: vienen de config y de la capability inyectada');
+        }
+
+        const { tier, scope, value } = payload;
+
+        // --- 2. Valor (sin ecos) ------------------------------------------------
+        if (typeof value !== 'string' || value === '') {
+            // `typeof` y nada más: describir el valor lo filtraría.
+            throw new VaultProvisionError(VAULT_PROVISION_ERROR_CODES.VALUE_INVALID,
+                `el valor debe ser una cadena no vacía (recibido: ${typeof value})`);
+        }
+
+        // --- 3. Nombre canónico (#5464) ----------------------------------------
+        // `validateVaultNamespace` es fail-closed: si el prefijo, el namespace,
+        // el tier o el nombre lógico no validan, lanza `VaultConfigError` y no
+        // devuelve descriptor a medias. Se deja propagar tal cual: nombra la
+        // clave de config, no el valor, y ya es accionable.
+        const descriptor = validateVaultNamespace({
+            prefix: config.prefix,
+            projectId: config.projectId,
+            hostId: config.hostId,
+            scope,
+            tier,
+        });
+
+        // --- 4. Tier soportado --------------------------------------------------
+        // `rotating` vive en Secrets Manager, con otra API y otro ciclo de
+        // rotación. Este port es SSM: fallar es más honesto que mandar un
+        // `PutParameter` a un nombre que pertenece a otro servicio.
+        if (descriptor.service !== 'ssm') {
+            throw new VaultProvisionError(VAULT_PROVISION_ERROR_CODES.TIER_UNSUPPORTED,
+                `el tier \`${descriptor.tier}\` se resuelve en \`${descriptor.service}\` y este `
+                + 'port sólo aprovisiona SSM: la rotación de Secrets Manager es otro flujo');
+        }
+
+        const path = descriptor.path;
+
+        // --- 5. Identidad efectiva (antes de TODA llamada a SSM) ----------------
+        // Se resuelve ANTES de tocar la red con el secreto en mano. Cualquier
+        // ambigüedad es rechazo: fail-closed.
+        let arn;
+        try {
+            arn = await identity.resolveArn();
+        } catch {
+            // El error de STS se descarta entero: puede traer contexto de la
+            // sesión que no corresponde propagar.
+            throw new VaultProvisionError(VAULT_PROVISION_ERROR_CODES.IDENTITY_DENIED,
+                'no se pudo verificar la identidad efectiva contra STS: sin principal '
+                + 'verificado no se escribe');
+        }
+        if (typeof arn !== 'string' || arn === '') {
+            throw new VaultProvisionError(VAULT_PROVISION_ERROR_CODES.IDENTITY_DENIED,
+                'la identidad efectiva no es verificable (STS devolvió un principal vacío)');
+        }
+        if (arn !== provisioningPrincipal) {
+            // NO se interpola el ARN recibido: en un runtime comprometido el
+            // mensaje termina en un log compartido. Alcanza con decir que no
+            // coincide y cuál es la clave de config a revisar.
+            throw new VaultProvisionError(VAULT_PROVISION_ERROR_CODES.IDENTITY_DENIED,
+                'la identidad efectiva no es el principal de provisión declarado en '
+                + '`config.provisioningPrincipal`: el runtime read-only no escribe, '
+                + 'y declararse "provisioning" no alcanza');
+        }
+
+        // --- 6. Sección serializada por nombre ---------------------------------
+        return serializarPorPath(path, () => ejecutar({ descriptor, path, value }));
+    }
+
+    async function ejecutar({ descriptor, path, value }) {
+        // --- Lectura de comparación -------------------------------------------
+        // Se descifra SÓLO en memoria y sólo para comparar. El valor leído no
+        // sale de esta función ni se persiste como hash (un hash de un secreto
+        // de baja entropía es un oráculo offline).
+        const actual = await conBackend('leer el parámetro',
+            () => ssm.getParameter({ Name: path, WithDecryption: true }));
+
+        if (actual != null && typeof actual !== 'object') {
+            throw new VaultProvisionError(VAULT_PROVISION_ERROR_CODES.BACKEND,
+                'la lectura de comparación devolvió una forma inesperada');
+        }
+
+        // Un parámetro preexistente que NO sea `SecureString` está en texto
+        // plano: aunque el valor coincida, NO es "sin cambios" — hay que
+        // repararlo, y reparar es sobrescribir (requiere autorización).
+        const existe = actual != null;
+        const esIgual = existe
+            && actual.Value === value
+            && actual.Type === TIPO_SEGURO;
+
+        if (esIgual) {
+            // CA: una repetición idéntica NO ejecuta `PutParameter` y NO
+            // aumenta la versión. Se proyecta la metadata que ya se tenía.
+            return proyectar(descriptor, path, VAULT_PROVISION_STATES.UNCHANGED, {
+                Type: actual.Type,
+                Version: actual.Version,
+            });
+        }
+
+        // --- Autorización de sobrescritura -------------------------------------
+        let estado = VAULT_PROVISION_STATES.CREATED;
+        let versionPrevia = null;
+
+        if (existe) {
+            versionPrevia = actual.Version;
+            let autorizado;
+            try {
+                autorizado = await overwriteAuthority.authorize({ path });
+            } catch {
+                throw new VaultProvisionError(VAULT_PROVISION_ERROR_CODES.OVERWRITE_DENIED,
+                    'la capability de sobrescritura falló al evaluar: se deniega por defecto');
+            }
+            // `=== true` estricto: un truthy (`'no'`, `1`, `{}`) no autoriza.
+            if (autorizado !== true) {
+                throw new VaultProvisionError(VAULT_PROVISION_ERROR_CODES.OVERWRITE_DENIED,
+                    'el nombre ya tiene un valor distinto y la capability no autorizó '
+                    + 'sobrescribirlo: la autorización la otorga el composition root del '
+                    + 'operador, no el pedido');
+            }
+            estado = VAULT_PROVISION_STATES.OVERWRITTEN;
+        }
+
+        // --- Escritura ----------------------------------------------------------
+        // Los cuatro campos son POSITIVOS y fijos: `SecureString`, la CMK de
+        // config, `Overwrite: true` y el nombre canónico. Ninguno sale del payload.
+        await conBackend('escribir el parámetro', () => ssm.putParameter({
+            Name: path,
+            Value: value,
+            Type: TIPO_SEGURO,
+            KeyId: kmsKeyId,
+            Overwrite: true,
+        }));
+
+        // --- Verificación posterior (sin descifrar) -----------------------------
+        const meta = await conBackend('verificar el parámetro escrito',
+            () => ssm.getParameterMetadata({ Name: path }));
+
+        if (meta == null || typeof meta !== 'object') {
+            throw new VaultProvisionError(VAULT_PROVISION_ERROR_CODES.VERIFY_FAILED,
+                'la verificación posterior no devolvió metadata');
+        }
+        if (meta.Type !== TIPO_SEGURO) {
+            throw new VaultProvisionError(VAULT_PROVISION_ERROR_CODES.VERIFY_FAILED,
+                `la verificación posterior esperaba Type \`${TIPO_SEGURO}\` y encontró otro: `
+                + 'el parámetro NO quedó cifrado y debe revisarse a mano');
+        }
+        if (!Number.isInteger(meta.Version) || meta.Version < 1) {
+            throw new VaultProvisionError(VAULT_PROVISION_ERROR_CODES.VERIFY_FAILED,
+                'la verificación posterior devolvió una versión que no es un entero válido');
+        }
+        // Una sobrescritura DEBE avanzar la versión. Si no avanzó, el `Put` no
+        // impactó (o impactó otro writer): fallar cerrado.
+        if (versionPrevia != null && !(meta.Version > versionPrevia)) {
+            throw new VaultProvisionError(VAULT_PROVISION_ERROR_CODES.VERIFY_FAILED,
+                'la sobrescritura no avanzó la versión del parámetro: la escritura no '
+                + 'impactó o hubo otro writer sobre el mismo nombre');
+        }
+
+        return proyectar(descriptor, path, estado, meta);
+    }
+
+    return Object.freeze({ provisionSecret });
+}
+
+// -----------------------------------------------------------------------------
+// Helpers internos
+// -----------------------------------------------------------------------------
+
+/**
+ * Proyección por ALLOWLIST del resultado público. Se construyen campos uno por
+ * uno: nunca `{ ...respuesta }`, porque un spread arrastra lo que AWS agregue
+ * mañana (incluido `Value` y `$metadata`).
+ */
+function proyectar(descriptor, path, estado, meta) {
+    return Object.freeze({
+        estado,
+        tier: descriptor.tier,
+        scope: descriptor.scope,
+        path,
+        metadata: Object.freeze({
+            Type: meta.Type,
+            Version: meta.Version,
+        }),
+    });
+}
+
+/**
+ * Ejecuta una llamada al backend y traduce CUALQUIER error a un
+ * `VaultProvisionError` genérico. El error original se descarta entero —
+ * no se encadena, no se inspecciona y no se loguea — porque el error del SDK
+ * puede traer el request completo, y el request lleva el valor.
+ */
+async function conBackend(accion, fn) {
+    try {
+        return await fn();
+    } catch (err) {
+        // Se rescata SÓLO el `name`/`code` si son cadenas cortas y conocidas;
+        // ante la duda, nada. Nunca el `message` del SDK.
+        const codigo = typeof err?.name === 'string' && /^[A-Za-z]{1,60}$/.test(err.name)
+            ? ` (${err.name})`
+            : '';
+        throw new VaultProvisionError(VAULT_PROVISION_ERROR_CODES.BACKEND,
+            `falló al ${accion}${codigo}`);
+    }
+}
+
+function assertPuerto(nombre, puerto, metodos) {
+    if (puerto == null || typeof puerto !== 'object') {
+        throw new VaultProvisionError(VAULT_PROVISION_ERROR_CODES.PAYLOAD_INVALID,
+            `requiere el port \`${nombre}\` inyectado`);
+    }
+    for (const m of metodos) {
+        if (typeof puerto[m] !== 'function') {
+            throw new VaultProvisionError(VAULT_PROVISION_ERROR_CODES.PAYLOAD_INVALID,
+                `el port \`${nombre}\` debe exponer \`${m}()\``);
+        }
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Adapter real sobre @aws-sdk/client-ssm
+// -----------------------------------------------------------------------------
+
+/**
+ * Adapta el cliente del SDK al port `ssm` que espera `createVaultProvisioner`.
+ *
+ * `commands` se puede inyectar para poder verificar POR TEST la forma exacta de
+ * los comandos emitidos (Type, KeyId, Overwrite, WithDecryption) sin depender de
+ * que `@aws-sdk/client-ssm` esté instalado. Sin ese punto de inyección los tests
+ * sólo probarían el fake y el adapter que va a producción quedaría sin cubrir —
+ * la "cobertura ilusoria" que la suite de `secret-vault` ya evita con su test de
+ * paridad de drivers.
+ *
+ * @param {object} deps
+ * @param {{ send: Function }} deps.client
+ * @param {{ GetParameterCommand: Function, PutParameterCommand: Function }} [deps.commands]
+ */
+function createAwsSsmProvisionDriver({ client, commands } = {}) {
+    if (client == null || typeof client.send !== 'function') {
+        throw new VaultProvisionError(VAULT_PROVISION_ERROR_CODES.PAYLOAD_INVALID,
+            'requiere un `client` de SSM con `send()`');
+    }
+
+    // Carga PEREZOSA: importar el SDK en el tope obligaría a instalarlo para
+    // correr cualquier test que sólo usa el fake.
+    const { GetParameterCommand, PutParameterCommand } = commands
+        || require('@aws-sdk/client-ssm');
+
+    return Object.freeze({
+        async getParameter({ Name, WithDecryption }) {
+            try {
+                const res = await client.send(new GetParameterCommand({ Name, WithDecryption }));
+                const p = res?.Parameter;
+                if (p == null) return null;
+                // Proyección explícita: nada de devolver `res` entero.
+                return { Value: p.Value, Type: p.Type, Version: p.Version };
+            } catch (err) {
+                // "No existe" es un estado del flujo, no una excepción.
+                if (err?.name === 'ParameterNotFound') return null;
+                throw err;
+            }
+        },
+
+        async putParameter({ Name, Value, Type, KeyId, Overwrite }) {
+            const res = await client.send(new PutParameterCommand({
+                Name, Value, Type, KeyId, Overwrite,
+            }));
+            return { Version: res?.Version };
+        },
+
+        async getParameterMetadata({ Name }) {
+            // `WithDecryption: false` — la verificación posterior NO descifra.
+            const res = await client.send(new GetParameterCommand({
+                Name, WithDecryption: false,
+            }));
+            const p = res?.Parameter;
+            if (p == null) return null;
+            return { Type: p.Type, Version: p.Version };
+        },
+    });
+}
+
+module.exports = {
+    VAULT_PROVISION_STATES,
+    VAULT_PROVISION_ERROR_CODES,
+    VaultProvisionError,
+    createVaultProvisioner,
+    createAwsSsmProvisionDriver,
+};

--- a/docs/pipeline/vault-secretos-aws.md
+++ b/docs/pipeline/vault-secretos-aws.md
@@ -431,6 +431,35 @@ admitir barras.** Aflojarlo rompería la allowlist —un `namespace` con `/` pod
 apuntar fuera del scope autorizado— y es exactamente la defensa anti-IDOR que el
 kernel ya tiene escrita.
 
+### Punto de entrada canónico para quien NO lee — #5464
+
+El tramo de provisión (#5425) resuelve el **mismo** nombre lógico que el runtime,
+pero corre en otro proceso, con otra identidad y con un port de escritura propio.
+Para que no termine copiando los regex ni concatenando el path a mano,
+`secret-vault.js` exporta `validateVaultNamespace(...)`:
+
+```js
+const { validateVaultNamespace } = require('.pipeline/lib/secret-vault');
+
+validateVaultNamespace({ prefix, projectId, hostId, scope, tier });
+// -> { tier, service: 'ssm'|'secretsmanager', path, root, prefix, projectId, hostId, scope }  (congelado)
+```
+
+- **No es una segunda implementación.** Es un envoltorio *puro* sobre
+  `buildParameterPath`, que sigue siendo el único lugar donde vive el esquema y
+  el único que corre `SEGMENT_RE` / `PREFIX_RE`. Mismos argumentos, mismos
+  errores (`VaultConfigError` con la clave de config) y misma semántica de
+  `root`; lo único que agrega es el descriptor enriquecido.
+- **`service` sale de `VAULT_TIER_SERVICE`**, declarado una sola vez y cubierto
+  por test contra `VAULT_TIERS`: un tier nuevo sin destino declarado rompe la
+  suite en vez de mandar el pedido al servicio equivocado.
+- **Los regex no se exportan a propósito.** Exportarlos habilitaría justamente la
+  copia que este punto de entrada viene a evitar.
+- **No amplía privilegios.** Es una función sin I/O, sin ambiente y sin driver:
+  `VAULT_READONLY_COMMANDS` queda idéntica y ningún driver de este módulo expone
+  escritura. Con qué verbo se escribe es decisión del provisionador, fuera de
+  `secret-vault.js`.
+
 ## Costo por escenario
 
 Precios de lista públicos de AWS para la región de referencia de precios

--- a/docs/pipeline/vault-secretos-aws.md
+++ b/docs/pipeline/vault-secretos-aws.md
@@ -796,3 +796,73 @@ La ventana de bootstrap (`vault.bootstrap_fallback` +
 encender el gate antes de terminar todas las altas. Nunca se activa por un error
 del driver, nunca alcanza al ancla, y caduca sola. No es un mecanismo de
 resiliencia — si el vault falla, el pipeline degrada fail-closed y lo narra.
+
+## Provisión (escritura) — `vault-provisioner.js`, #5465
+
+El módulo `secret-vault.js` **lee** y nada más. La **escritura** vive en
+`.pipeline/lib/vault-provisioner.js`: otro módulo, otro proceso y otra
+identidad. No es una separación estética — la policy del runtime tiene un
+`Deny` explícito sobre `ssm:PutParameter` (ver `vault-iam-policy.json`), así que
+el runtime no podría escribir aunque se lo pidieran.
+
+### Qué garantiza
+
+- Toda escritura es `SecureString`, con **CMK explícita** y `Overwrite: true`.
+  Sin CMK el provisionador **no se construye**: la clave administrada por
+  defecto de AWS no es una CMK del proyecto.
+- El nombre sale **exclusivamente** de `validateVaultNamespace` (#5464). Acá no
+  hay regex, ni concatenación de path, ni reglas propias.
+- La identidad efectiva se resuelve contra **STS** y se compara con
+  `config.provisioningPrincipal`. Ausente, no verificable o distinta ⇒ falla
+  **antes** de emitir una sola llamada a SSM. Declararse «provisioning» no
+  alcanza.
+- El tier `rotating` se rechaza: resuelve en Secrets Manager, que es otro flujo.
+
+### Autorización: no la firma el caller
+
+La CMK y el permiso de sobrescritura **no viajan en el payload**. Un
+`allowOverwrite: true` junto al secreto sería autoautorización. Son dos
+colaboradores inyectados por el composition root del operador:
+
+- `identity.resolveArn()` — principal efectivo, de fuente confiable.
+- `overwriteAuthority.authorize({ path })` — capability separada. Sólo `true`
+  estricto habilita sobrescribir.
+
+El payload es **cerrado** (`tier`, `scope`, `value`): una clave de más es
+rechazo, no un campo ignorado en silencio.
+
+### Estados e idempotencia
+
+| Estado | Cuándo | `PutParameter` |
+|---|---|---|
+| `creado` | el nombre no existía | sí |
+| `sin cambios` | mismo valor y ya era `SecureString` | **no** (la versión no sube) |
+| `sobrescrito` | valor distinto **y** capability autorizó | sí (la versión avanza) |
+
+Un parámetro preexistente en texto plano **no** cuenta como `sin cambios`:
+está expuesto y repararlo es sobrescribir, con capability.
+
+> **Concurrencia — leer antes de asumir idempotencia fuerte.** SSM
+> `PutParameter` **no** ofrece compare-and-swap por versión. La secuencia
+> `Get → comparar → Put` es idempotente para ejecución **serial** y nada más. El
+> provisionador serializa por nombre **dentro del proceso**; entre procesos
+> distintos no hay exclusión posible con la API de SSM. Si el composition root
+> abre varios provisionadores sobre el mismo nombre, la serialización es
+> responsabilidad suya. La verificación posterior exige que la versión **avance**
+> en una sobrescritura, así que un writer pisado falla cerrado en vez de
+> reportar un éxito falso.
+
+### Qué sale del módulo
+
+Sólo `{ estado, tier, scope, path, metadata: { Type, Version } }`, construido por
+allowlist campo por campo. Nunca el valor, su hash, la respuesta cruda de AWS,
+`$metadata`, `cause` ni el stack del SDK: el error del SDK puede arrastrar el
+request, y el request lleva el secreto. La verificación posterior lee metadata
+**sin descifrar** y comprueba `Type === 'SecureString'` y una `Version` entera.
+
+### Dependencia
+
+`@aws-sdk/client-ssm` entra fijado por lockfile y **sólo** para este port. Se
+carga en forma perezosa dentro del adapter real, así que la suite corre sin
+tenerlo instalado. El camino de lectura sigue sin SDK: usa la AWS CLI y
+`secret-vault-sync-5353.test.js` lo sigue verificando.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "intrale-platform-pipeline",
       "dependencies": {
+        "@aws-sdk/client-ssm": "3.1101.0",
         "ajv": "^8.20.0",
         "canvas": "^3.2.1",
         "js-yaml": "^4.1.1",
@@ -13,6 +14,359 @@
       },
       "devDependencies": {
         "husky": "^9.1.7"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm": {
+      "version": "3.1101.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.1101.0.tgz",
+      "integrity": "sha512-8R5aywNT7ccoTFsbqKB+XIh5LA+XgqlB0PnICFplZUM8NfJIENip9LTXv6weFIuruqiAe2gMS0K2pjO2gP+gUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.4",
+        "@aws-sdk/credential-provider-node": "^3.972.76",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.977.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.5.tgz",
+      "integrity": "sha512-O5otOc1c6UZh5HsHAaPdYBcUUR9HL6mtnKqvc8nxN/CKDGUBUpsdh0q8K04Uz/dd1i0TaGyIQuQNqoO7+ad2TQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/xml-builder": "^3.972.37",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.31.1",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.16.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.66",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.66.tgz",
+      "integrity": "sha512-bOzP2+zdJ0XrghywB4FaJXtGZCx9yS0AGps+VJ5yEgg30wVyHNmVDBwVDXcRypzQY5iLGCS3NSn0nsuISqjFCQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.5",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.68",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.68.tgz",
+      "integrity": "sha512-lkunS8X+H6V76WE+t/uGQm/U8v0JXK5mLfNFTUAMlE1kqaCjwlmqKJrgCVtqjK/vqnlrSWsLK4Lr4NANBWlfTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.5",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.973.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.11.tgz",
+      "integrity": "sha512-KoDEolYtLHG/8C+IiZpXbJWyBOMkrHV+j66Kb9PBXmLv5euGb7aELvuCmLenoGAV6gBW2wM7TsG/1e5iulH4kA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.5",
+        "@aws-sdk/credential-provider-env": "^3.972.66",
+        "@aws-sdk/credential-provider-http": "^3.972.68",
+        "@aws-sdk/credential-provider-login": "^3.972.73",
+        "@aws-sdk/credential-provider-process": "^3.972.66",
+        "@aws-sdk/credential-provider-sso": "^3.973.10",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.72",
+        "@aws-sdk/nested-clients": "^3.997.40",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.73",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.73.tgz",
+      "integrity": "sha512-tjsxMkTAFkmiV9ycmymapb9nLECWVOwFs0bZMQ9gB9bnbY8/HwfukHZlWbXZZp7qkPU6EXAfOcMm3DioFFEywA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.5",
+        "@aws-sdk/nested-clients": "^3.997.40",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.77",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.77.tgz",
+      "integrity": "sha512-l4nitYCN/Ls57vtUfdextCjTjW41JD7lQiAnuR0RTbdByFc/6OmEAzwGd+lrp6CUtiXGQL1FCaYiamfHASrwBw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.66",
+        "@aws-sdk/credential-provider-http": "^3.972.68",
+        "@aws-sdk/credential-provider-ini": "^3.973.11",
+        "@aws-sdk/credential-provider-process": "^3.972.66",
+        "@aws-sdk/credential-provider-sso": "^3.973.10",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.72",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.66",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.66.tgz",
+      "integrity": "sha512-YOnX6bIhdjx0QfaENu2PB0eFm5MEc9ft8XNGQ+NxMfeLSq9aE+XjWCwDupEnV4UWv5ZFpBLJbTREIx7KNOoqpQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.5",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.973.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.10.tgz",
+      "integrity": "sha512-IsXnQ35j5VE+3ZK6aIhT5ypB+Jim3zRwVz0nYuVwyBKZyu/SYx+O2/LQpng8c2EiuwyqceabsDlYrICHDlJPsA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.5",
+        "@aws-sdk/nested-clients": "^3.997.40",
+        "@aws-sdk/token-providers": "3.1102.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.72",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.72.tgz",
+      "integrity": "sha512-nj9Zlsy7ya+fy+jhWTJwgfr7YdtDM4xHyZvgKuftuny0UgROVx9lxwvsWJSLvpKk4lig0m0tHng3k1fEnt0LeA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.5",
+        "@aws-sdk/nested-clients": "^3.997.40",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.40",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.40.tgz",
+      "integrity": "sha512-hEdHT0PBR4fkGxWhwKG5EtEYKnAM7HKkp0vD10ufk4YcXejH4r4q6G/XhPzjUc6Yxo5kBS2vHg7llj4ViR9VTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.5",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.43",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.43.tgz",
+      "integrity": "sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1102.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1102.0.tgz",
+      "integrity": "sha512-Ua700vVvM1q105yABSUQWkCK6FeTrNfU6ORGetJe5BzkZWY7QhkF7SVTOlmDGWRDNd6jbyY0Dv5e+E4bMBEmLg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.5",
+        "@aws-sdk/nested-clients": "^3.997.40",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.974.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
+      "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.37.tgz",
+      "integrity": "sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.31.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.31.1.tgz",
+      "integrity": "sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.4.16",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.16.tgz",
+      "integrity": "sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.6.13",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.13.tgz",
+      "integrity": "sha512-4fW86pEUOMbrD5nkbyl/tTvPHHWJFbuB2odl6ps9lWfHoXf9HWh3Q/Smh59qH1g7+c/BSZghX6bbUk4gsiMs8A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.9.13",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.13.tgz",
+      "integrity": "sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.6.12",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.12.tgz",
+      "integrity": "sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/ajv": {
@@ -72,6 +426,12 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
       "integrity": "sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw==",
+      "license": "MIT"
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
       "license": "MIT"
     },
     "node_modules/buffer": {
@@ -610,6 +970,12 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "smoke:commander": "node .pipeline/tests/smoke/commander-degraded.smoke.js"
   },
   "dependencies": {
+    "@aws-sdk/client-ssm": "3.1101.0",
     "ajv": "^8.20.0",
     "canvas": "^3.2.1",
     "js-yaml": "^4.1.1",


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 8 archivos · +1793 -6

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:passed` aplicado por delivery

## Closes

Closes #5465
