### PR TITLE
[Split de #5401] Endurecer el camino de merge de entrega: CODEOWNERS fail-closed, SHA pinneado y procedencia del PR

### DIFF
--- a/.pipeline/skills-deterministicos/__tests__/codeowners.test.js
+++ b/.pipeline/skills-deterministicos/__tests__/codeowners.test.js
@@ -153,3 +153,150 @@ test('caso real Intrale — .pipeline/* y .github/* requieren @leitolarreta', ()
         [],
     );
 });
+
+// ============================================================================
+// #5420 — loadCodeownersFromRef: carga FAIL-CLOSED desde una ref git.
+// ============================================================================
+//
+// Invariante central: un fallo de carga NUNCA puede verse como `rules: []`. El
+// gate de merge de delivery.js interpretaba la lista vacía como "este PR no
+// tiene owners humanos" y auto-mergeaba — fail-open. Estos tests fijan que todo
+// borde de error devuelva `{ ok:false }` y que `rules` ni siquiera exista.
+
+// fakeGitShow — ejecutor inyectable con la firma de spawnSync. `responses` mapea
+// el path pedido dentro de la ref al resultado que devuelve `git show`.
+function fakeGitShow(responses, calls = []) {
+    return (cmd, argv) => {
+        calls.push({ cmd, argv });
+        const spec = argv[1] || '';
+        const rel = spec.slice(spec.indexOf(':') + 1);
+        const r = responses[rel];
+        if (!r) return { status: 128, stdout: '', stderr: `fatal: path '${rel}' does not exist in 'origin/main'` };
+        if (typeof r === 'function') return r();
+        return r;
+    };
+}
+
+test('#5420 — loadCodeownersFromRef: lee .github/CODEOWNERS desde la ref y devuelve ok:true', () => {
+    const calls = [];
+    const res = codeowners.loadCodeownersFromRef('/repo', 'origin/main', {
+        spawnImpl: fakeGitShow({
+            '.github/CODEOWNERS': { status: 0, stdout: '/.github/   @leitolarreta\n', stderr: '' },
+        }, calls),
+    });
+    assert.equal(res.ok, true);
+    assert.equal(res.source, '.github/CODEOWNERS');
+    assert.equal(res.ref, 'origin/main');
+    assert.equal(res.rules.length, 1);
+    assert.deepEqual(res.rules[0].owners, ['@leitolarreta']);
+    // Argumentos exactos: sin shell, ref y path en un solo token `ref:path`.
+    assert.deepEqual(calls[0].argv, ['show', 'origin/main:.github/CODEOWNERS']);
+});
+
+test('#5420 CA-1 — archivo AUSENTE en la ref devuelve {ok:false}, NUNCA []', () => {
+    const res = codeowners.loadCodeownersFromRef('/repo', 'origin/main', {
+        spawnImpl: fakeGitShow({}), // ninguna ruta candidata existe
+    });
+    assert.equal(res.ok, false);
+    assert.ok(res.reason.includes('no se pudo cargar CODEOWNERS'));
+    // La trampa que este issue cierra: nada de listas vacías.
+    assert.equal(res.rules, undefined);
+    assert.notDeepEqual(res, { ok: true, rules: [] });
+});
+
+test('#5420 CA-2 — `git show` que FALLA (exit != 0) devuelve {ok:false}', () => {
+    const res = codeowners.loadCodeownersFromRef('/repo', 'origin/main', {
+        spawnImpl: fakeGitShow({
+            '.github/CODEOWNERS': { status: 128, stdout: '', stderr: "fatal: invalid object name 'origin/main'." },
+        }),
+    });
+    assert.equal(res.ok, false);
+    assert.equal(res.rules, undefined);
+    assert.ok(/exit=128/.test(res.reason));
+});
+
+test('#5420 — `git show` que lanza excepción (spawn roto) devuelve {ok:false}', () => {
+    const res = codeowners.loadCodeownersFromRef('/repo', 'origin/main', {
+        spawnImpl: () => { throw new Error('ENOENT git'); },
+    });
+    assert.equal(res.ok, false);
+    assert.equal(res.rules, undefined);
+    assert.ok(/ENOENT git/.test(res.reason));
+});
+
+test('#5420 — res.error (timeout de spawnSync) devuelve {ok:false}', () => {
+    const res = codeowners.loadCodeownersFromRef('/repo', 'origin/main', {
+        spawnImpl: () => ({ error: new Error('spawnSync git ETIMEDOUT'), status: null, stdout: '', stderr: '' }),
+    });
+    assert.equal(res.ok, false);
+    assert.equal(res.rules, undefined);
+    assert.ok(/ETIMEDOUT/.test(res.reason));
+});
+
+test('#5420 — ejecutor que devuelve basura (sin objeto) devuelve {ok:false}', () => {
+    const res = codeowners.loadCodeownersFromRef('/repo', 'origin/main', { spawnImpl: () => null });
+    assert.equal(res.ok, false);
+    assert.equal(res.rules, undefined);
+});
+
+test('#5420 — CODEOWNERS presente pero SIN reglas parseables es {ok:false} (no autorización implícita)', () => {
+    const res = codeowners.loadCodeownersFromRef('/repo', 'origin/main', {
+        spawnImpl: fakeGitShow({
+            '.github/CODEOWNERS': { status: 0, stdout: '# sólo comentarios\n\n', stderr: '' },
+            'CODEOWNERS': { status: 0, stdout: '   \n', stderr: '' },
+            'docs/CODEOWNERS': { status: 0, stdout: '', stderr: '' },
+        }),
+    });
+    assert.equal(res.ok, false);
+    assert.equal(res.rules, undefined);
+    assert.ok(/sin reglas parseables/.test(res.reason));
+});
+
+test('#5420 — cae a la ruta siguiente si la primera no existe en la ref', () => {
+    const res = codeowners.loadCodeownersFromRef('/repo', 'origin/main', {
+        spawnImpl: fakeGitShow({
+            'CODEOWNERS': { status: 0, stdout: '/.pipeline/   @leitolarreta\n', stderr: '' },
+        }),
+    });
+    assert.equal(res.ok, true);
+    assert.equal(res.source, 'CODEOWNERS');
+});
+
+test('#5420 — ref inválida (metacaracteres) se rechaza sin ejecutar git', () => {
+    let invoked = 0;
+    for (const bad of ['main; rm -rf /', 'origin/main:.github/x', '', '--upload-pack=evil', null, 'a b']) {
+        const res = codeowners.loadCodeownersFromRef('/repo', bad, {
+            spawnImpl: () => { invoked++; return { status: 0, stdout: '/x @leitolarreta', stderr: '' }; },
+        });
+        assert.equal(res.ok, false, `ref ${JSON.stringify(bad)} debería rechazarse`);
+    }
+    assert.equal(invoked, 0, 'una ref inválida nunca debe llegar a ejecutar git');
+});
+
+test('#5420 — repoRoot ausente devuelve {ok:false}', () => {
+    assert.equal(codeowners.loadCodeownersFromRef('', 'origin/main').ok, false);
+    assert.equal(codeowners.loadCodeownersFromRef(null, 'origin/main').ok, false);
+});
+
+test('#5420 — la reason redacta credenciales y colapsa saltos de línea', () => {
+    const res = codeowners.loadCodeownersFromRef('/repo', 'origin/main', {
+        spawnImpl: fakeGitShow({
+            '.github/CODEOWNERS': {
+                status: 128, stdout: '',
+                stderr: 'fatal: auth failed\nremote: token=ghp_abcdefghijklmnop1234 rechazado',
+            },
+        }),
+    });
+    assert.equal(res.ok, false);
+    assert.ok(!/ghp_abcdefghijklmnop1234/.test(res.reason), 'la reason no puede filtrar el token');
+    assert.ok(!/[\r\n]/.test(res.reason), 'la reason no puede tener saltos de línea');
+});
+
+test('#5420 — loadCodeowners (local) sigue devolviendo [] para consumidores existentes', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'co-compat-'));
+    try {
+        assert.deepEqual(codeowners.loadCodeowners(tmp), []);
+    } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+    }
+});

--- a/.pipeline/skills-deterministicos/__tests__/delivery-merge-4658.test.js
+++ b/.pipeline/skills-deterministicos/__tests__/delivery-merge-4658.test.js
@@ -28,15 +28,36 @@ test('#4658 CA-2 — classifyMergeFailure: HTTP 405 (not mergeable) = conflicto 
     assert.equal(c.httpStatus, 405);
 });
 
-test('#4658 CA-2 — classifyMergeFailure: HTTP 409 (head changed) = conflicto real', () => {
+// #5420 — reclasificado: con el `sha` pinneado en el PUT, un 409 "head branch
+// was modified" ya no es un conflicto terminal sino la protección funcionando.
+// Sigue frenando el merge (conflict=true → nunca se mergea a ciegas), pero ahora
+// es REINTENTABLE: el gate vuelve a tomar snapshot y reevalúa todo. El escalado
+// llega recién si el head sigue moviéndose tras el retry.
+test('#4658/#5420 CA-2 — classifyMergeFailure: HTTP 409 (head changed) frena el merge y es REINTENTABLE', () => {
     const c = delivery.classifyMergeFailure({ exit_code: 1, stderr: 'HTTP 409: Head branch was modified. Review and try the merge again.' });
     assert.equal(c.conflict, true);
     assert.equal(c.httpStatus, 409);
+    assert.equal(c.retryable, true);
+    assert.equal(c.kind, 'head-changed');
+});
+
+test('#5420 — classifyMergeFailure: HTTP 409 de conflicto REAL sigue siendo terminal (no reintentable)', () => {
+    const c = delivery.classifyMergeFailure({ exit_code: 1, stderr: 'HTTP 409: Merge conflict' });
+    assert.equal(c.conflict, true);
+    assert.equal(c.retryable, false);
+    assert.equal(c.kind, 'not-mergeable');
+});
+
+test('#5420 — classifyMergeFailure: 405 not-mergeable NUNCA es reintentable', () => {
+    const c = delivery.classifyMergeFailure({ exit_code: 1, stderr: 'gh: Pull Request is not mergeable (HTTP 405)' });
+    assert.equal(c.retryable, false);
+    assert.equal(c.kind, 'not-mergeable');
 });
 
 test('#4658 — classifyMergeFailure: deteccion textual sin codigo HTTP explicito', () => {
     const c = delivery.classifyMergeFailure({ exit_code: 1, stdout: '{"message":"Merge conflict"}' });
     assert.equal(c.conflict, true);
+    assert.equal(c.retryable, false);
 });
 
 test('#4658 — classifyMergeFailure: fallo generico (5xx/red) NO es conflicto -> rebote tecnico normal', () => {

--- a/.pipeline/skills-deterministicos/__tests__/delivery-merge-5401.test.js
+++ b/.pipeline/skills-deterministicos/__tests__/delivery-merge-5401.test.js
@@ -1,0 +1,426 @@
+// #5420 (split de #5401, bloque B) — Camino de merge endurecido de la fase de
+// entrega: CODEOWNERS fail-closed desde origin/main, SHA pinneado en el PUT y
+// procedencia de la rama verificada antes de mergear.
+//
+// Qué fija esta suite: ninguna ruta puede terminar en merge sin haber
+// CONFIRMADO owners, procedencia y SHA observado. Todo borde degradado (gh que
+// falla, JSON inválido, CODEOWNERS ilegible, procedencia no acreditable,
+// respuesta sin `merged:true`) tiene que bloquear y escalar — nunca mergear.
+//
+// Sin red ni gh real: `attemptMergeWithGates` recibe sus dependencias
+// inyectadas, así que las decisiones se validan de forma determinística.
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+// Aislar REPO_ROOT (delivery escribe audit + cola Telegram centrales acá).
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'v3-delivery5401-'));
+fs.mkdirSync(path.join(TMP, '.claude', 'hooks'), { recursive: true });
+fs.mkdirSync(path.join(TMP, '.pipeline', 'logs'), { recursive: true });
+process.env.PIPELINE_REPO_ROOT = TMP;
+process.env.CLAUDE_PROJECT_DIR = TMP;
+
+delete require.cache[require.resolve('../delivery')];
+const delivery = require('../delivery');
+const codeowners = require('../lib/codeowners');
+const humanBlock = require('../../lib/human-block');
+
+// ── Fakes ──────────────────────────────────────────────────────────────────
+
+const HEAD_SHA = 'a1b2c3d4e5f60718293a4b5c6d7e8f9012345678';
+const HEAD_SHA_2 = 'ffeeddccbbaa00998877665544332211aabbccdd';
+
+function snapshotOk(over = {}) {
+    return {
+        ok: true,
+        labels: ['qa:skipped'],
+        files: ['.pipeline/skills-deterministicos/delivery.js'],
+        headRefOid: HEAD_SHA,
+        headRefName: 'agent/5401-pipeline-dev',
+        ...over,
+    };
+}
+
+// CODEOWNERS real del repo (subconjunto): `.github/` exige owner humano,
+// `.pipeline/` NO. Es la fuente contra la que se evalúan los paths del PR.
+const REMOTE_CODEOWNERS = [
+    '# CODEOWNERS de origin/main',
+    '/.github/        @leitolarreta',
+    '/docs/           @writer-team',
+].join('\n');
+
+function ownersFromRemote(content = REMOTE_CODEOWNERS) {
+    // Usa el loader REAL contra un `git show` fake: prueba de que el gate no
+    // depende de ninguna copia local del archivo.
+    return () => codeowners.loadCodeownersFromRef('/worktree-podado', 'origin/main', {
+        spawnImpl: (cmd, argv) => {
+            const spec = argv[1] || '';
+            const rel = spec.slice(spec.indexOf(':') + 1);
+            if (rel !== '.github/CODEOWNERS') {
+                return { status: 128, stdout: '', stderr: `fatal: path '${rel}' does not exist` };
+            }
+            return { status: 0, stdout: content, stderr: '' };
+        },
+    });
+}
+
+// mergeOk / mergeFail — fakes del PUT que además registran con qué SHA se llamó.
+function recordingMerge(responder, calls) {
+    return (opts) => {
+        calls.push(opts);
+        return responder(opts, calls.length);
+    };
+}
+
+const MERGED_OK = { exit_code: 0, stdout: JSON.stringify({ sha: 'merge-sha-123', merged: true, message: 'ok' }), stderr: '' };
+const HEAD_CHANGED_409 = {
+    exit_code: 1, stdout: '',
+    stderr: 'gh: HTTP 409: Head branch was modified. Review and try the merge again. (https://api.github.com/...)',
+};
+
+function baseDeps(over = {}) {
+    return {
+        prNumber: 777,
+        getSnapshot: () => snapshotOk(),
+        loadOwners: ownersFromRemote(),
+        verifyOrigin: () => ({ ok: true, reason: 'author-allowlisted:bot@intrale.com' }),
+        mergePR: () => MERGED_OK,
+        logAppend: () => {},
+        ...over,
+    };
+}
+
+// ── CA / repro #5395: gates verdes + procedencia OK ⇒ merge completado ──────
+
+test('#5420 repro #5395 — worktree local podado + gates verdes + procedencia verificada ⇒ MERGE completado sin needs-human', () => {
+    const calls = [];
+    // El worktree local no tiene CODEOWNERS (podado): el loader lee de origin/main.
+    const out = delivery.attemptMergeWithGates(baseDeps({
+        mergePR: recordingMerge(() => MERGED_OK, calls),
+    }));
+    assert.equal(out.status, 'merged');
+    assert.equal(out.sha, 'merge-sha-123');
+    assert.equal(out.attempt, 1);
+    assert.equal(calls.length, 1);
+});
+
+test('#5420 CA — el PUT del merge viaja con el SHA observado al evaluar los gates', () => {
+    const calls = [];
+    const out = delivery.attemptMergeWithGates(baseDeps({
+        mergePR: recordingMerge(() => MERGED_OK, calls),
+    }));
+    assert.equal(out.status, 'merged');
+    assert.equal(calls[0].sha, HEAD_SHA, 'el sha del PUT debe ser el del snapshot de los gates');
+    assert.equal(calls[0].prNumber, 777);
+});
+
+// ── CA: CODEOWNERS fail-closed ─────────────────────────────────────────────
+
+test('#5420 CA — CODEOWNERS no cargable ⇒ merge BLOQUEADO (no continúa con lista vacía)', () => {
+    const calls = [];
+    const out = delivery.attemptMergeWithGates(baseDeps({
+        loadOwners: () => codeowners.loadCodeownersFromRef('/repo', 'origin/main', {
+            spawnImpl: () => ({ status: 128, stdout: '', stderr: 'fatal: invalid object name' }),
+        }),
+        mergePR: recordingMerge(() => MERGED_OK, calls),
+    }));
+    assert.equal(out.status, 'blocked');
+    assert.equal(out.gate, 'codeowners');
+    assert.equal(calls.length, 0, 'no se puede intentar el merge sin CODEOWNERS');
+});
+
+test('#5420 CA — PR que toca .github/workflows/ SIN copia local queda bloqueado por CODEOWNERS de origin/main', () => {
+    const calls = [];
+    const out = delivery.attemptMergeWithGates(baseDeps({
+        getSnapshot: () => snapshotOk({ files: ['.github/workflows/ci.yml'] }),
+        mergePR: recordingMerge(() => MERGED_OK, calls),
+    }));
+    assert.equal(out.status, 'needs-human');
+    assert.deepEqual(out.owners, ['@leitolarreta']);
+    assert.equal(calls.length, 0, 'un PR con owner humano nunca llega al PUT');
+});
+
+test('#5420 — un CODEOWNERS remoto VACÍO no autoriza el merge (fail-closed)', () => {
+    const calls = [];
+    const out = delivery.attemptMergeWithGates(baseDeps({
+        loadOwners: ownersFromRemote('# archivo sin reglas\n'),
+        getSnapshot: () => snapshotOk({ files: ['.github/workflows/ci.yml'] }),
+        mergePR: recordingMerge(() => MERGED_OK, calls),
+    }));
+    assert.equal(out.status, 'blocked');
+    assert.equal(out.gate, 'codeowners');
+    assert.equal(calls.length, 0);
+});
+
+// ── CA: procedencia (contra-test de seguridad) ─────────────────────────────
+
+test('#5420 CA contra-test — procedencia NO verificada + gates verdes ⇒ NO mergea y escala', () => {
+    const calls = [];
+    const out = delivery.attemptMergeWithGates(baseDeps({
+        verifyOrigin: () => ({ ok: false, reason: 'author-not-allowlisted:evil@attacker.test' }),
+        mergePR: recordingMerge(() => MERGED_OK, calls),
+    }));
+    assert.equal(out.status, 'blocked');
+    assert.equal(out.gate, 'provenance');
+    assert.ok(/evil@attacker\.test/.test(out.reason));
+    assert.equal(calls.length, 0, 'sin procedencia acreditada no se puede llamar al merge');
+});
+
+test('#5420 — procedencia que lanza/devuelve basura tampoco habilita el merge', () => {
+    for (const bad of [null, undefined, {}, { ok: 'true' }, { ok: 1 }]) {
+        const calls = [];
+        const out = delivery.attemptMergeWithGates(baseDeps({
+            verifyOrigin: () => bad,
+            mergePR: recordingMerge(() => MERGED_OK, calls),
+        }));
+        assert.equal(out.status, 'blocked', `verifyOrigin=${JSON.stringify(bad)} debe bloquear`);
+        assert.equal(out.gate, 'provenance');
+        assert.equal(calls.length, 0);
+    }
+});
+
+test('#5420 — la procedencia se verifica sobre la rama del SNAPSHOT, no sobre una rama arbitraria', () => {
+    const vistos = [];
+    delivery.attemptMergeWithGates(baseDeps({
+        getSnapshot: () => snapshotOk({ headRefName: 'agent/9999-otro' }),
+        verifyOrigin: (b) => { vistos.push(b); return { ok: true, reason: 'ok' }; },
+    }));
+    assert.deepEqual(vistos, ['agent/9999-otro']);
+});
+
+// ── CA: snapshot fail-closed (TOCTOU cerrado) ──────────────────────────────
+
+test('#5420 — snapshot degradado (gh falla) ⇒ bloqueo, sin merge', () => {
+    const calls = [];
+    const out = delivery.attemptMergeWithGates(baseDeps({
+        getSnapshot: () => ({ ok: false, reason: 'gh pr view exit=1' }),
+        mergePR: recordingMerge(() => MERGED_OK, calls),
+    }));
+    assert.equal(out.status, 'blocked');
+    assert.equal(out.gate, 'snapshot');
+    assert.equal(calls.length, 0);
+});
+
+test('#5420 — getPRSnapshot: gh OK devuelve labels, files, head y rama en UNA sola llamada', () => {
+    const calls = [];
+    const snap = delivery.getPRSnapshot(777, {
+        ghImpl: (argv, opts) => {
+            calls.push({ argv, opts });
+            return {
+                exit_code: 0,
+                stdout: JSON.stringify({
+                    labels: [{ name: 'qa:skipped' }, { name: 'Ready' }],
+                    files: [{ path: '.pipeline/pulpo.js' }],
+                    headRefOid: HEAD_SHA,
+                    headRefName: 'agent/5401-pipeline-dev',
+                }),
+                stderr: '',
+            };
+        },
+        cwd: '/w',
+    });
+    assert.equal(snap.ok, true);
+    assert.deepEqual(snap.labels, ['qa:skipped', 'Ready']);
+    assert.deepEqual(snap.files, ['.pipeline/pulpo.js']);
+    assert.equal(snap.headRefOid, HEAD_SHA);
+    assert.equal(snap.headRefName, 'agent/5401-pipeline-dev');
+    assert.equal(calls.length, 1, 'labels, files, head y rama salen de una única lectura (sin TOCTOU)');
+    assert.deepEqual(calls[0].argv.slice(0, 4), ['pr', 'view', '777', '--json']);
+    assert.equal(calls[0].argv[4], 'labels,files,headRefOid,headRefName');
+});
+
+test('#5420 — getPRSnapshot: bordes degradados son {ok:false}, nunca listas vacías', () => {
+    const casos = [
+        ['gh exit != 0', { exit_code: 1, stdout: '', stderr: 'HTTP 502' }],
+        ['JSON inválido', { exit_code: 0, stdout: '<html>error</html>', stderr: '' }],
+        ['JSON no-objeto', { exit_code: 0, stdout: '"texto"', stderr: '' }],
+        ['sin headRefOid', { exit_code: 0, stdout: JSON.stringify({ labels: [], files: [{ path: 'a.js' }], headRefName: 'b' }), stderr: '' }],
+        ['headRefOid basura', { exit_code: 0, stdout: JSON.stringify({ files: [{ path: 'a.js' }], headRefOid: 'no-es-un-sha', headRefName: 'b' }), stderr: '' }],
+        ['sin headRefName', { exit_code: 0, stdout: JSON.stringify({ files: [{ path: 'a.js' }], headRefOid: HEAD_SHA }), stderr: '' }],
+        ['sin archivos', { exit_code: 0, stdout: JSON.stringify({ files: [], headRefOid: HEAD_SHA, headRefName: 'b' }), stderr: '' }],
+    ];
+    for (const [nombre, res] of casos) {
+        const snap = delivery.getPRSnapshot(1, { ghImpl: () => res });
+        assert.equal(snap.ok, false, `${nombre} debe ser ok:false`);
+        assert.equal(snap.files, undefined, `${nombre} no puede devolver archivos`);
+        assert.ok(snap.reason, `${nombre} debe explicar por qué`);
+    }
+    // gh que lanza excepción tampoco puede degradar a vacío.
+    const boom = delivery.getPRSnapshot(1, { ghImpl: () => { throw new Error('spawn ENOENT'); } });
+    assert.equal(boom.ok, false);
+});
+
+// ── CA: gate de QA sobre el snapshot ───────────────────────────────────────
+
+test('#5420 — sin label qa:passed/qa:skipped no se mergea (gate QA sobre el snapshot)', () => {
+    const calls = [];
+    const out = delivery.attemptMergeWithGates(baseDeps({
+        getSnapshot: () => snapshotOk({ labels: ['Ready'] }),
+        mergePR: recordingMerge(() => MERGED_OK, calls),
+    }));
+    assert.equal(out.status, 'no-qa-gate');
+    assert.equal(calls.length, 0);
+});
+
+// ── CA: head movido ⇒ 409 ⇒ reintento (no escalada inmediata) ──────────────
+
+test('#5420 CA — head movido responde 409, NO mergea y REINTENTA en vez de escalar', () => {
+    const calls = [];
+    let snapshots = 0;
+    const out = delivery.attemptMergeWithGates(baseDeps({
+        getSnapshot: () => {
+            snapshots++;
+            return snapshotOk({ headRefOid: snapshots === 1 ? HEAD_SHA : HEAD_SHA_2 });
+        },
+        mergePR: recordingMerge((_o, n) => (n === 1 ? HEAD_CHANGED_409 : MERGED_OK), calls),
+    }));
+    assert.equal(out.status, 'merged', 'el segundo intento, con el head nuevo, mergea');
+    assert.equal(out.attempt, 2);
+    assert.equal(snapshots, 2, 'el reintento toma un snapshot NUEVO');
+    assert.equal(calls[0].sha, HEAD_SHA);
+    assert.equal(calls[1].sha, HEAD_SHA_2, 'el reintento usa el SHA nuevo, no el viejo');
+});
+
+test('#5420 CA — el reintento REEVALÚA todos los gates (no reusa el veredicto anterior)', () => {
+    const gates = { owners: 0, provenance: 0 };
+    let snapshots = 0;
+    const out = delivery.attemptMergeWithGates(baseDeps({
+        getSnapshot: () => {
+            snapshots++;
+            // En el 2º intento el head trae un cambio sobre .github/ → owner humano.
+            return snapshotOk(snapshots === 1
+                ? {}
+                : { headRefOid: HEAD_SHA_2, files: ['.github/workflows/ci.yml'] });
+        },
+        loadOwners: () => { gates.owners++; return ownersFromRemote()(); },
+        verifyOrigin: () => { gates.provenance++; return { ok: true, reason: 'ok' }; },
+        mergePR: () => HEAD_CHANGED_409,
+    }));
+    assert.equal(out.status, 'needs-human', 'el gate de owners se reevalúa contra el head nuevo');
+    assert.equal(gates.owners, 2);
+    assert.equal(gates.provenance, 1, 'el 2º intento frena en owners, antes de procedencia');
+});
+
+test('#5420 — el retry tiene tope: head que sigue moviéndose escala como conflicto', () => {
+    const calls = [];
+    const out = delivery.attemptMergeWithGates(baseDeps({
+        mergePR: recordingMerge(() => HEAD_CHANGED_409, calls),
+    }));
+    assert.equal(out.status, 'conflict');
+    assert.equal(calls.length, delivery.MAX_MERGE_ATTEMPTS);
+    assert.equal(calls.length, 2, 'máximo explícito de 2 intentos');
+    assert.equal(out.classification.kind, 'head-changed');
+});
+
+test('#5420 — conflicto REAL (405 not mergeable) escala de una, sin reintentar', () => {
+    const calls = [];
+    const out = delivery.attemptMergeWithGates(baseDeps({
+        mergePR: recordingMerge(() => ({ exit_code: 1, stdout: '', stderr: 'gh: Pull Request is not mergeable (HTTP 405)' }), calls),
+    }));
+    assert.equal(out.status, 'conflict');
+    assert.equal(out.classification.retryable, false);
+    assert.equal(calls.length, 1, 'un conflicto real no se reintenta');
+});
+
+test('#5420 — fallo genérico de infra (5xx) sigue siendo error técnico, no conflicto', () => {
+    const out = delivery.attemptMergeWithGates(baseDeps({
+        mergePR: () => ({ exit_code: 1, stdout: '', stderr: 'HTTP 502 Bad Gateway' }),
+    }));
+    assert.equal(out.status, 'error');
+    assert.equal(out.classification.conflict, false);
+});
+
+// ── CA: éxito SÓLO con merged:true ─────────────────────────────────────────
+
+test('#5420 CA — needs-human se omite SÓLO con merged:true; cualquier otro desenlace bloquea', () => {
+    const respuestas = [
+        ['merged:false', { exit_code: 0, stdout: JSON.stringify({ merged: false, message: 'Base branch was modified' }), stderr: '' }],
+        ['campo merged ausente', { exit_code: 0, stdout: JSON.stringify({ sha: 'x', message: 'ok' }), stderr: '' }],
+        ['merged como string', { exit_code: 0, stdout: JSON.stringify({ merged: 'true' }), stderr: '' }],
+        ['JSON inválido', { exit_code: 0, stdout: 'no soy json', stderr: '' }],
+        ['body vacío', { exit_code: 0, stdout: '', stderr: '' }],
+        ['JSON no-objeto', { exit_code: 0, stdout: 'null', stderr: '' }],
+    ];
+    for (const [nombre, res] of respuestas) {
+        const out = delivery.attemptMergeWithGates(baseDeps({ mergePR: () => res }));
+        assert.equal(out.status, 'blocked', `${nombre} NO puede contar como merge`);
+        assert.equal(out.gate, 'merge-unconfirmed');
+        assert.equal(out.sha, undefined, `${nombre} no puede registrar SHA de merge`);
+    }
+    // Y el único caso que sí cuenta:
+    const ok = delivery.attemptMergeWithGates(baseDeps({ mergePR: () => MERGED_OK }));
+    assert.equal(ok.status, 'merged');
+});
+
+test('#5420 — confirmMergeResponse: merged:true sin sha sigue siendo merge confirmado', () => {
+    const c = delivery.confirmMergeResponse({ exit_code: 0, stdout: JSON.stringify({ merged: true }) });
+    assert.equal(c.ok, true);
+    assert.equal(c.sha, null);
+});
+
+// ── Orden de los gates (un gate temprano corta los siguientes) ─────────────
+
+test('#5420 — orden de gates: snapshot → QA → CODEOWNERS → owners → procedencia → merge', () => {
+    const orden = [];
+    delivery.attemptMergeWithGates(baseDeps({
+        getSnapshot: () => { orden.push('snapshot'); return snapshotOk(); },
+        loadOwners: () => { orden.push('owners'); return ownersFromRemote()(); },
+        verifyOrigin: () => { orden.push('provenance'); return { ok: true, reason: 'ok' }; },
+        mergePR: () => { orden.push('merge'); return MERGED_OK; },
+    }));
+    assert.deepEqual(orden, ['snapshot', 'owners', 'provenance', 'merge']);
+});
+
+// ── Escalado: el motivo tiene que leerse como BLOQUEO HUMANO ───────────────
+
+test('#5420 — el motivo de bloqueo lo clasifica el pulpo como human-block (no rebote a dev)', () => {
+    for (const gate of ['codeowners', 'provenance', 'snapshot', 'merge-unconfirmed', 'retry-exhausted']) {
+        const motivo = delivery.buildGateBlockMotivo({
+            prNumber: 777, branch: 'agent/5401-pipeline-dev', gate, reason: 'detalle técnico',
+        });
+        assert.ok(
+            humanBlock.isHumanBlockReason(motivo),
+            `el motivo del gate ${gate} debe clasificar como bloqueo humano, no como rebote técnico`,
+        );
+        assert.ok(motivo.includes('#777'));
+    }
+});
+
+test('#5420 — el motivo de bloqueo sanea el detalle (sin secrets ni CRLF)', () => {
+    const motivo = delivery.buildGateBlockMotivo({
+        prNumber: 1, branch: 'agent/1-x', gate: 'codeowners',
+        reason: 'fatal: auth\r\nremote: token=ghp_abcdefghijklmnop1234',
+    });
+    assert.ok(!/ghp_abcdefghijklmnop1234/.test(motivo), 'no puede filtrar el token');
+    assert.ok(!/[\r\n]/.test(motivo), 'no puede romper el formato del marker');
+});
+
+test('#5420 — el escalado del gate deja audit fail-closed y encola aviso al operador', () => {
+    const logs = [];
+    const esc = delivery.escalateMergeGateBlock({
+        issue: 5401, prNumber: 777, branch: 'agent/5401-pipeline-dev',
+        gate: 'provenance', reason: 'author-not-allowlisted:evil@attacker.test',
+        logAppend: (m) => logs.push(m),
+    });
+    assert.ok(humanBlock.isHumanBlockReason(esc.motivo));
+    const cola = path.join(TMP, '.pipeline', 'servicios', 'telegram', 'pendiente');
+    const drops = fs.existsSync(cola) ? fs.readdirSync(cola) : [];
+    assert.ok(drops.length >= 1, 'tiene que quedar al menos un aviso encolado para el operador');
+    const textos = drops.map((f) => JSON.parse(fs.readFileSync(path.join(cola, f), 'utf8')).text).join('\n');
+    assert.ok(/procedencia/i.test(textos), 'el aviso explica qué gate no se pudo verificar');
+    assert.ok(!/evil@attacker\.test/.test(esc.motivo) || /evil@attacker\.test/.test(esc.motivo), 'motivo construido');
+});
+
+test('#5420 — el mensaje al operador no promete auto-merge por silencio', () => {
+    const msg = delivery.buildGateBlockEscalation({
+        issue: 5401, prNumber: 777, branch: 'agent/5401-pipeline-dev',
+        gate: 'codeowners', reason: 'no se pudo cargar CODEOWNERS',
+    });
+    assert.ok(/fail-closed/i.test(msg));
+    assert.ok(/INTACTO/.test(msg), 'aclara que main no se tocó');
+    assert.ok(/NO va a auto-mergear/i.test(msg));
+});

--- a/.pipeline/skills-deterministicos/delivery.js
+++ b/.pipeline/skills-deterministicos/delivery.js
@@ -13,6 +13,15 @@ const absencePolicy = require('../lib/operator-absence-policy');
 const absenceAudit = require('../lib/operator-absence-audit');
 const operatorGate = require('../lib/operator-gate');
 const { sanitizeReason } = require('../lib/kernel-actions-audit');
+// #5420 — Verificación de procedencia de la rama del PR antes de mergear.
+// Se CONSUME la implementación canónica (#5419): es `git fetch` + `git log`
+// contra la allowlist de committers, no necesita worktree y no se duplica acá.
+const { verifyRemoteBranchOrigin } = require('../lib/worktree-resolver');
+
+// #5420 — Ref desde la que se carga CODEOWNERS para el gate de merge. Fija a
+// `origin/main` a propósito: el head del PR podría estar modificando el propio
+// CODEOWNERS para sacarse del gate, y el worktree local puede estar podado.
+const OWNERS_REF = 'origin/main';
 
 // REPO_ROOT: ubicación central donde el pulpo escribe logs/heartbeats/markers.
 // Siempre apunta al checkout principal del monorepo (no al worktree del agente),
@@ -174,6 +183,74 @@ function getPRChangedPaths(prNumber) {
     } catch { return []; }
 }
 
+// ============================================================================
+// #5420 — Snapshot único del PR para el gate crítico de merge.
+// ============================================================================
+//
+// Antes, el gate leía labels (`getPRLabels`) y paths (`getPRChangedPaths`) en
+// llamadas separadas, y el PUT de merge no fijaba ningún SHA. Eso deja una
+// ventana TOCTOU: entre "leí los labels" y "mergeé" el head del PR puede
+// moverse, y se termina mergeando un árbol que NUNCA pasó los gates.
+//
+// `getPRSnapshot` toma labels, files, rama y SHA del head en UNA sola llamada.
+// Ese snapshot es la única fuente de verdad del intento: los gates se evalúan
+// sobre él y el PUT viaja con `sha=<headRefOid>` del mismo snapshot.
+//
+// Fail-closed en todos los bordes: gh que falla, JSON inválido, head sin SHA o
+// sin rama, y PR sin archivos → `{ ok:false, reason }`. NUNCA se degrada a
+// listas vacías (una lista de archivos vacía haría que CODEOWNERS no matchee
+// nada y el PR pase como "sin owners humanos").
+function getPRSnapshot(prNumber, { ghImpl = git.runGh, cwd = WORK_DIR } = {}) {
+    let res;
+    try {
+        res = ghImpl(
+            ['pr', 'view', String(prNumber), '--json', 'labels,files,headRefOid,headRefName'],
+            { cwd, timeoutMs: 60 * 1000 },
+        );
+    } catch (e) {
+        return { ok: false, reason: `gh pr view lanzó excepción: ${codeowners.sanitizeRefReason(e && e.message, 120)}` };
+    }
+    if (!res || typeof res !== 'object') {
+        return { ok: false, reason: 'gh pr view sin resultado' };
+    }
+    if (res.exit_code !== 0) {
+        const detail = codeowners.sanitizeRefReason(res.stderr || res.stdout, 160);
+        return { ok: false, reason: `gh pr view exit=${res.exit_code}${detail ? `: ${detail}` : ''}` };
+    }
+    let parsed;
+    try {
+        parsed = JSON.parse(res.stdout);
+    } catch {
+        return { ok: false, reason: 'gh pr view devolvió JSON inválido' };
+    }
+    if (!parsed || typeof parsed !== 'object') {
+        return { ok: false, reason: 'gh pr view devolvió un JSON que no es objeto' };
+    }
+
+    const headRefOid = typeof parsed.headRefOid === 'string' ? parsed.headRefOid.trim() : '';
+    const headRefName = typeof parsed.headRefName === 'string' ? parsed.headRefName.trim() : '';
+    if (!/^[0-9a-f]{7,40}$/i.test(headRefOid)) {
+        return { ok: false, reason: 'headRefOid ausente o con formato inesperado' };
+    }
+    if (!headRefName) {
+        return { ok: false, reason: 'headRefName ausente' };
+    }
+
+    const labels = Array.isArray(parsed.labels)
+        ? parsed.labels.map((l) => (l && typeof l.name === 'string' ? l.name : null)).filter(Boolean)
+        : [];
+    const files = Array.isArray(parsed.files)
+        ? parsed.files.map((f) => (f && typeof f.path === 'string' ? f.path : null)).filter(Boolean)
+        : [];
+    // Un PR SIEMPRE toca archivos: una lista vacía es una lectura degradada, no
+    // un PR inocuo. Tratarla como "no matchea CODEOWNERS" sería fail-open.
+    if (!files.length) {
+        return { ok: false, reason: 'gh pr view no devolvió archivos del PR (lectura degradada)' };
+    }
+
+    return { ok: true, labels, files, headRefOid, headRefName };
+}
+
 function applyNeedsHumanLabel(issue, prNumber, owners, repoRoot) {
     const lbl = git.runGh(
         ['issue', 'edit', String(issue), '--add-label', 'needs-human'],
@@ -207,23 +284,190 @@ function tmpFile(prefix, content) {
 // Ese caso NO es un fallo de infra ni un rebote técnico: es un conflicto de
 // merge genuino que debe ESCALAR al operador (no rebotar a dev en loop). Todo
 // otro exit_code != 0 (red, auth, timeout, 5xx) sigue siendo rebote técnico.
+//
+// #5420 — Con el `sha` pinneado en el PUT (ver `attemptMergeWithGates`), el 409
+// deja de ser un único caso: GitHub responde 409 tanto ante un conflicto real
+// como cuando el head se movió entre la lectura de los gates y el merge. Ese
+// segundo caso NO es "no mergeable": es exactamente la protección funcionando,
+// y corresponde REINTENTAR con un snapshot nuevo (reevaluando todos los gates),
+// no escalar al operador. Se distingue por el mensaje, no por el status pelado:
+// un 409 ambiguo se mantiene como conflicto terminal (fail-closed).
+//
+// Shape: { conflict, retryable, kind, httpStatus, reason }.
+//   kind: 'ok' | 'head-changed' | 'not-mergeable' | 'generic'
 function classifyMergeFailure(res = {}) {
-    if (!res || res.exit_code === 0) return { conflict: false, httpStatus: null, reason: 'ok' };
+    if (!res || res.exit_code === 0) {
+        return { conflict: false, retryable: false, kind: 'ok', httpStatus: null, reason: 'ok' };
+    }
     const text = `${res.stderr || ''}\n${res.stdout || ''}`;
     const httpMatch = text.match(/\bHTTP\s+(\d{3})\b/i);
     const httpStatus = httpMatch ? parseInt(httpMatch[1], 10) : null;
+
+    const notMergeableText = /\bnot\s+mergeable\b/i.test(text) || /\bmerge\s+conflict\b/i.test(text);
+    // Señales de "el head se movió": mensaje canónico de GitHub ante `sha` viejo.
+    const headChangedText = !notMergeableText && (
+        /\bhead\s+branch\s+was\s+modified\b/i.test(text)
+        || /\bbase\s+branch\s+was\s+modified\b/i.test(text)
+        || /\bhead\s+(?:branch\s+)?sha\b[^\n]*\b(?:did\s+not|does\s+not|doesn't)\s+match\b/i.test(text)
+    );
+    if (headChangedText) {
+        return {
+            conflict: true,
+            retryable: true,
+            kind: 'head-changed',
+            httpStatus,
+            reason: httpStatus ? `http_${httpStatus}_head_changed` : 'head_changed_text',
+        };
+    }
+
     // 405/409 son las señales autoritativas de "no mergeable" del merge squash.
     if (httpStatus === 405 || httpStatus === 409) {
-        return { conflict: true, httpStatus, reason: `http_${httpStatus}` };
+        return { conflict: true, retryable: false, kind: 'not-mergeable', httpStatus, reason: `http_${httpStatus}` };
     }
     // Defensa textual: gh puede envolver el status en el cuerpo del error.
-    if (/\bnot\s+mergeable\b/i.test(text)
-        || /\bmerge\s+conflict\b/i.test(text)
-        || /\bhead\s+branch\s+was\s+modified\b/i.test(text)
-        || /\bbase\s+branch\s+was\s+modified\b/i.test(text)) {
-        return { conflict: true, httpStatus, reason: 'not_mergeable_text' };
+    if (notMergeableText) {
+        return { conflict: true, retryable: false, kind: 'not-mergeable', httpStatus, reason: 'not_mergeable_text' };
     }
-    return { conflict: false, httpStatus, reason: 'generic_error' };
+    return { conflict: false, retryable: false, kind: 'generic', httpStatus, reason: 'generic_error' };
+}
+
+// #5420 — Confirmación ESTRICTA del PUT de merge. Un exit_code 0 no alcanza:
+// la respuesta tiene que ser JSON válido con `merged === true`. Cualquier otra
+// cosa (no-JSON, `merged:false`, campo ausente) es fallo — no habilita el DELETE
+// de la rama, no registra SHA y no omite la escalada a `needs-human`.
+//
+// `transportOk` distingue "la llamada HTTP salió bien pero el merge no ocurrió"
+// (no reintentable: no es un problema de SHA ni de red) de "la llamada falló"
+// (que sí pasa por `classifyMergeFailure`).
+function confirmMergeResponse(res = {}) {
+    if (!res || typeof res !== 'object' || res.exit_code !== 0) {
+        return { ok: false, transportOk: false, sha: null, reason: 'gh api merge terminó con error' };
+    }
+    let parsed;
+    try {
+        parsed = JSON.parse(res.stdout);
+    } catch {
+        return { ok: false, transportOk: true, sha: null, reason: 'respuesta del merge no es JSON válido' };
+    }
+    if (!parsed || typeof parsed !== 'object') {
+        return { ok: false, transportOk: true, sha: null, reason: 'respuesta del merge no es un objeto JSON' };
+    }
+    if (parsed.merged !== true) {
+        return {
+            ok: false,
+            transportOk: true,
+            sha: null,
+            reason: `respuesta del merge sin merged:true (merged=${JSON.stringify(parsed.merged)})`,
+        };
+    }
+    const sha = typeof parsed.sha === 'string' && parsed.sha.trim() ? parsed.sha.trim() : null;
+    return { ok: true, transportOk: true, sha, reason: 'merged' };
+}
+
+// Máximo de intentos del gate de merge. 2 = el intento original + UN reintento
+// ante head movido. No más: reintentar en loop contra un head que se mueve solo
+// quema cuota y esconde un problema real.
+const MAX_MERGE_ATTEMPTS = 2;
+
+// ============================================================================
+// #5420 — Gate de merge: unidad testeable con dependencias inyectadas.
+// ============================================================================
+//
+// Evalúa, EN ORDEN y sobre un snapshot único por intento:
+//
+//   1. snapshot del PR válido            → si no, bloquea (no adivina)
+//   2. gate de QA (labels del snapshot)  → si falta, deja el PR abierto
+//   3. CODEOWNERS desde `origin/main`    → si no carga, bloquea (fail-closed)
+//   4. owners humanos sobre los files    → si hay, needs-human
+//   5. procedencia de la rama del head   → si no verifica, bloquea
+//   6. PUT del merge con `sha` pinneado  → éxito SÓLO con merged:true
+//
+// Ningún paso puede saltearse degradando a vacío: cada lectura fallida bloquea
+// y escala. Ante `head-changed` se reintenta UNA vez, y el reintento vuelve a
+// empezar por el paso 1 — nunca reusa labels, paths, rama ni SHA del intento
+// anterior (si el head se movió, los gates anteriores ya no valen nada).
+//
+// Devuelve `{ status, ... }` con status ∈
+//   'merged' | 'no-qa-gate' | 'needs-human' | 'blocked' | 'conflict' | 'error'
+function attemptMergeWithGates({
+    prNumber,
+    getSnapshot,
+    loadOwners,
+    verifyOrigin,
+    mergePR,
+    logAppend,
+    maxAttempts = MAX_MERGE_ATTEMPTS,
+} = {}) {
+    const log = typeof logAppend === 'function' ? logAppend : () => {};
+    const attemptsMax = Number.isInteger(maxAttempts) && maxAttempts > 0 ? maxAttempts : MAX_MERGE_ATTEMPTS;
+
+    for (let attempt = 1; attempt <= attemptsMax; attempt++) {
+        // (1) Snapshot único: labels + files + rama + SHA del head, atómico.
+        const snapshot = getSnapshot(prNumber);
+        if (!snapshot || snapshot.ok !== true) {
+            const reason = (snapshot && snapshot.reason) || 'snapshot no disponible';
+            log(`[delivery] gate merge: snapshot del PR no disponible (${reason}) — merge bloqueado`);
+            return { status: 'blocked', gate: 'snapshot', reason, attempt };
+        }
+
+        // (2) Gate de QA sobre los labels del MISMO snapshot que se va a mergear.
+        if (!hasQaGate(snapshot.labels)) {
+            return { status: 'no-qa-gate', snapshot, attempt };
+        }
+
+        // (3) CODEOWNERS desde origin/main. `ok:false` = no pude leer → bloqueo.
+        //     Jamás se interpreta como "este PR no tiene owners".
+        const owners = loadOwners();
+        if (!owners || owners.ok !== true) {
+            const reason = (owners && owners.reason) || 'CODEOWNERS no cargable';
+            log(`[delivery] gate merge: CODEOWNERS no cargable (${reason}) — merge bloqueado`);
+            return { status: 'blocked', gate: 'codeowners', reason, snapshot, attempt };
+        }
+
+        // (4) Owners humanos sobre los paths del snapshot.
+        const humanOwners = codeowners.getHumanOwners(owners.rules, snapshot.files);
+        if (humanOwners.length) {
+            log(`[delivery] gate merge: CODEOWNERS humano ${humanOwners.join(' ')} — merge bloqueado`);
+            return { status: 'needs-human', owners: humanOwners, snapshot, attempt };
+        }
+
+        // (5) Procedencia del head del PR: el primer commit sobre main tiene que
+        //     venir de un committer conocido. Sin red o sin commits → bloqueo.
+        const provenance = verifyOrigin(snapshot.headRefName);
+        if (!provenance || provenance.ok !== true) {
+            const reason = (provenance && provenance.reason) || 'procedencia no verificable';
+            log(`[delivery] gate merge: procedencia de ${snapshot.headRefName} NO verificada (${reason}) — merge bloqueado`);
+            return { status: 'blocked', gate: 'provenance', reason, snapshot, attempt };
+        }
+
+        // (6) Merge con el SHA observado al evaluar los gates. Si el head se
+        //     movió, GitHub responde 409 y NO mergea nada.
+        const mergeRes = mergePR({ prNumber, sha: snapshot.headRefOid, headRefName: snapshot.headRefName });
+        const confirmed = confirmMergeResponse(mergeRes);
+        if (confirmed.ok) {
+            return { status: 'merged', sha: confirmed.sha, snapshot, attempt };
+        }
+        if (confirmed.transportOk) {
+            // HTTP OK pero semánticamente no mergeado: no reintentamos (no es un
+            // problema de SHA) y no habilitamos el camino de éxito.
+            log(`[delivery] gate merge: ${confirmed.reason} — merge NO confirmado`);
+            return { status: 'blocked', gate: 'merge-unconfirmed', reason: confirmed.reason, snapshot, attempt };
+        }
+
+        const classification = classifyMergeFailure(mergeRes);
+        if (classification.retryable && attempt < attemptsMax) {
+            log(`[delivery] gate merge: head movido (${classification.reason}) — reintento ${attempt + 1}/${attemptsMax} reevaluando todos los gates`);
+            continue;
+        }
+        if (classification.conflict) {
+            return { status: 'conflict', classification, mergeRes, snapshot, attempt };
+        }
+        return { status: 'error', classification, mergeRes, snapshot, attempt };
+    }
+
+    // Inalcanzable con attemptsMax >= 1 (la última vuelta siempre retorna), pero
+    // si algo cambia, el default es bloquear — nunca caer en éxito implícito.
+    return { status: 'blocked', gate: 'retry-exhausted', reason: 'reintentos agotados sin merge confirmado', attempt: attemptsMax };
 }
 
 // shouldEscalateLocalMerge — decisión PURA sobre el pre-check `git.isMergeable`.
@@ -356,11 +600,10 @@ function authorizeOperatorResponse(chatId, allowlist) {
 //   2) Telegram fail-closed reusando buildFailClosedMessage de #4632 (CA-3) +
 //      mensaje con opciones (UX), ambos a la cola CENTRAL.
 // Devuelve { motivo } (human-block) para que el caller lo escriba en el marker.
-function escalateMergeConflict({ issue, prNumber, branch, httpStatus, conflictExcerpt, timestamp, logAppend } = {}) {
-    const log = typeof logAppend === 'function' ? logAppend : () => {};
-    const motivo = buildConflictMotivo({ prNumber, branch, httpStatus });
-
-    // (1) Audit central, tamper-evident. Override best-effort del pipelineDir.
+// auditFailClosedDecision — registro tamper-evident de una decisión fail-closed
+// del gate de merge. Extraído para que el conflicto real (#4658) y el bloqueo de
+// gate (#5420) compartan exactamente el mismo camino de auditoría.
+function auditFailClosedDecision({ issue, motivo, extra, timestamp, log } = {}) {
     const savedOverride = process.env.PIPELINE_DIR_OVERRIDE;
     try {
         process.env.PIPELINE_DIR_OVERRIDE = path.join(REPO_ROOT, '.pipeline');
@@ -372,18 +615,35 @@ function escalateMergeConflict({ issue, prNumber, branch, httpStatus, conflictEx
             decision: 'fail-closed',
             reason: motivo,
             timestamp: timestamp || new Date().toISOString(),
-            extra: {
-                pr: prNumber || null,
-                branch: branch || null,
-                http_status: httpStatus || null,
-                conflict_excerpt: conflictExcerpt ? String(conflictExcerpt).slice(0, 500) : null,
-            },
+            extra: extra || {},
         });
-        log(`[delivery] audit fail-closed ${auditRes.ok ? 'OK' : `falló: ${auditRes.error}`}`);
+        if (typeof log === 'function') {
+            log(`[delivery] audit fail-closed ${auditRes.ok ? 'OK' : `falló: ${auditRes.error}`}`);
+        }
+        return auditRes;
     } finally {
         if (savedOverride === undefined) delete process.env.PIPELINE_DIR_OVERRIDE;
         else process.env.PIPELINE_DIR_OVERRIDE = savedOverride;
     }
+}
+
+function escalateMergeConflict({ issue, prNumber, branch, httpStatus, conflictExcerpt, timestamp, logAppend } = {}) {
+    const log = typeof logAppend === 'function' ? logAppend : () => {};
+    const motivo = buildConflictMotivo({ prNumber, branch, httpStatus });
+
+    // (1) Audit central, tamper-evident. Override best-effort del pipelineDir.
+    auditFailClosedDecision({
+        issue,
+        motivo,
+        timestamp,
+        log,
+        extra: {
+            pr: prNumber || null,
+            branch: branch || null,
+            http_status: httpStatus || null,
+            conflict_excerpt: conflictExcerpt ? String(conflictExcerpt).slice(0, 500) : null,
+        },
+    });
 
     // (2a) Notificación fail-closed canónica (reusa infra #4632, CA-3). Sólo
     //      construimos el TEXTO (puro, sin dependencia de path) y lo encolamos
@@ -404,6 +664,109 @@ function escalateMergeConflict({ issue, prNumber, branch, httpStatus, conflictEx
     const optionsMsg = buildMergeConflictEscalation({ issue, prNumber, branch, httpStatus, conflictExcerpt });
     const enq = enqueueOperatorTelegram(optionsMsg);
     log(`[delivery] escalado operador ${enq.ok ? 'encolado' : `falló: ${enq.error}`}`);
+
+    return { motivo };
+}
+
+// ============================================================================
+// #5420 — Escalado de un gate de merge que no pudo confirmarse.
+// ============================================================================
+//
+// Distinto del conflicto de merge real (#4658): acá `main` y el PR están sanos,
+// lo que falló es la CAPACIDAD DE VERIFICAR (no se pudo leer CODEOWNERS desde
+// origin/main, no se pudo acreditar la procedencia de la rama, el snapshot vino
+// degradado, o el PUT respondió sin `merged:true`). La política es la misma:
+// fail-closed y al operador — nunca mergear sobre una verificación que no se
+// pudo hacer.
+
+const GATE_BLOCK_LABELS = {
+    snapshot: 'no se pudo leer el estado del PR (labels/archivos/head)',
+    codeowners: 'no se pudo cargar CODEOWNERS desde origin/main',
+    provenance: 'no se pudo acreditar la procedencia de la rama del PR',
+    'merge-unconfirmed': 'GitHub respondió sin confirmar el merge',
+    'retry-exhausted': 'se agotaron los reintentos sin merge confirmado',
+};
+
+// Motivo pensado para que el pulpo lo clasifique como BLOQUEO HUMANO
+// (human-block.js → HUMAN_BLOCK_PATTERNS) y NO como rebote técnico a dev:
+// incluye "Merge bloqueado" y "requiere intervención humana" a propósito.
+// Doble saneo del texto libre que viaja al marker y a Telegram:
+//   1. `sanitizeRefReason` (#5420) — redacta tokens gh_/JWT/`token=` y colapsa
+//      saltos de línea. `sanitizeReason` NO cubre los tokens de GitHub.
+//   2. `sanitizeReason` (audit canónico) — redacta claves AWS y escapa CRLF.
+// Van encadenados a propósito: cada capa tapa lo que la otra no ve.
+function sanitizeGateText(value, max = 240) {
+    return sanitizeReason(codeowners.sanitizeRefReason(value, max)).sanitized;
+}
+
+function buildGateBlockMotivo({ prNumber, branch, gate, reason } = {}) {
+    const pr = prNumber ? `PR #${prNumber}` : 'el PR';
+    const rama = branch ? ` (rama ${sanitizeGateText(branch, 120)})` : '';
+    const que = GATE_BLOCK_LABELS[gate] || `gate ${sanitizeGateText(gate || 'desconocido', 60)}`;
+    const detalle = reason ? ` Detalle: ${sanitizeGateText(reason, 240)}.` : '';
+    return (
+        `Merge bloqueado en ${pr}${rama} — requiere intervención humana: ${que}.${detalle} `
+        + `Delivery frenado fail-closed: el pipeline NO mergea sin poder verificar owners, procedencia y SHA. `
+        + `main quedó intacto.`
+    );
+}
+
+function buildGateBlockEscalation({ issue, prNumber, branch, gate, reason } = {}) {
+    const safe = (v) => sanitizeGateText(v, 300).replace(/[\r\n]+/g, ' ');
+    const que = GATE_BLOCK_LABELS[gate] || `gate ${safe(gate)}`;
+    const lines = [
+        '🛑 GATE · Delivery frenado: no pude VERIFICAR el merge — necesito que decidas',
+        `Issue/PR: #${safe(issue)} / ${prNumber ? `PR #${safe(prNumber)}` : '(sin PR)'}  ·  Rama: ${safe(branch)}`,
+        `Qué falló: ${que}.`,
+        reason ? `Detalle: ${safe(reason).slice(0, 240)}` : '',
+        '',
+        'No es un conflicto de merge: el PR puede estar perfecto. Lo que no pude hacer es *comprobar* que',
+        'se cumplen los gates de seguridad, y mergear sin esa comprobación sería saltearlos.',
+        '`main` quedó INTACTO. Nada se mergeó. Esta espera es intencional (fail-closed).',
+        '',
+        'Opciones:',
+        '• *resolver* — revisás y mergeás el PR vos.',
+        '• *abortar* — se descarta este delivery.',
+        '• *reintentar* — se reintenta el delivery completo (sirve si fue un corte de red).',
+        '',
+        `Cómo responder: comentá en el issue "resolver #${safe(issue)}", "abortar #${safe(issue)}" o "reintentar #${safe(issue)}".`,
+        'El pipeline NO va a auto-mergear por silencio (gate no delegable).',
+    ].filter((l) => l !== '');
+    return lines.join('\n');
+}
+
+// Devuelve { motivo } (human-block) para que el caller lo escriba en el marker.
+function escalateMergeGateBlock({ issue, prNumber, branch, gate, reason, timestamp, logAppend } = {}) {
+    const log = typeof logAppend === 'function' ? logAppend : () => {};
+    const motivo = buildGateBlockMotivo({ prNumber, branch, gate, reason });
+
+    auditFailClosedDecision({
+        issue,
+        motivo,
+        timestamp,
+        log,
+        extra: {
+            pr: prNumber || null,
+            branch: branch || null,
+            gate_bloqueado: gate || null,
+            block_reason: reason ? String(reason).slice(0, 500) : null,
+        },
+    });
+
+    try {
+        const failClosedText = absencePolicy.buildFailClosedMessage({
+            issue,
+            gate: 'delivery-merge',
+            clase: 'merge-a-main',
+            reason: absencePolicy.REASONS.GATE_NO_DELEGABLE,
+        });
+        enqueueOperatorTelegram(failClosedText);
+    } catch (e) {
+        log(`[delivery] aviso: no se pudo encolar fail-closed: ${((e && e.message) || '').slice(0, 120)}`);
+    }
+
+    const enq = enqueueOperatorTelegram(buildGateBlockEscalation({ issue, prNumber, branch, gate, reason }));
+    log(`[delivery] escalado operador (gate ${gate}) ${enq.ok ? 'encolado' : `falló: ${enq.error}`}`);
 
     return { motivo };
 }
@@ -769,96 +1132,121 @@ async function main() {
 
         // ── Fase 5: auto-merge si gate QA presente ────────────────────
         t = phaseStart();
-        const finalLabels = getPRLabels(prNumber);
-        labelsApplied = Array.from(new Set([...labelsApplied, ...finalLabels]));
-
-        // #2652 — Detección de CODEOWNERS humano: si el PR toca paths protegidos
-        // por un owner humano (ej. @leitolarreta), NO mergear automáticamente.
-        // En su lugar: aplicar label `needs-human` al issue + comentar el PR
-        // explicitando los owners requeridos. Esto evita merges silenciosos
-        // sobre `.pipeline/` o `.github/` que requieren review manual.
-        const ownerRules = codeowners.loadCodeowners(WORK_DIR);
-        const changedForOwners = getPRChangedPaths(prNumber);
-        const humanOwners = ownerRules.length && changedForOwners.length
-            ? codeowners.getHumanOwners(ownerRules, changedForOwners)
-            : [];
-        if (humanOwners.length) {
-            logAppend(`[delivery] CODEOWNERS humano detectado: ${humanOwners.join(' ')} — bloqueando auto-merge`);
-        }
 
         if (!args.autoMerge) {
+            const finalLabels = getPRLabels(prNumber);
+            labelsApplied = Array.from(new Set([...labelsApplied, ...finalLabels]));
             logAppend(`[delivery] auto-merge desactivado por flag — PR queda abierto`);
             motivo = `PR #${prNumber} creado/actualizado. Auto-merge desactivado.`;
-        } else if (!hasQaGate(finalLabels)) {
-            // Sin gate QA → no mergeamos ciegamente; el delivery termina OK pero deja el PR abierto.
-            motivo = `PR #${prNumber} creado pero sin label qa:passed/qa:skipped — merge bloqueado.`;
-            logAppend(`[delivery] ${motivo}`);
-        } else if (humanOwners.length) {
-            applyNeedsHumanLabel(issue, prNumber, humanOwners, WORK_DIR);
-            labelsApplied = Array.from(new Set([...labelsApplied, 'needs-human']));
-            motivo = `PR #${prNumber} requiere review humano de ${humanOwners.join(' ')} — merge bloqueado, label needs-human aplicado.`;
-            logAppend(`[delivery] ${motivo}`);
         } else {
-            // #2801 — merge vía API REST de GitHub (server-side) en lugar de
-            // `gh pr merge` (que ejecuta git ops locales). Razón: cuando otro
-            // worktree del mismo repo tiene `main` checked-out, `gh pr merge`
-            // intenta hacer `git checkout main` localmente y falla con
-            // "fatal: 'main' is already used by worktree at <otro path>".
-            // La API REST hace todo del lado del servidor — el estado local
-            // del repo no importa.
-            const mergeRes = git.runGh([
-                'api', '-X', 'PUT', `repos/{owner}/{repo}/pulls/${prNumber}/merge`,
-                '-f', 'merge_method=squash',
-                '-f', `commit_title=${issueTitle} (#${prNumber})`,
-            ], { cwd: WORK_DIR, timeoutMs: 3 * 60 * 1000 });
-            if (mergeRes.exit_code !== 0) {
-                // #4658 — Discriminar el CONFLICTO DE MERGE REAL (405 not-mergeable
-                // / 409 head-changed) de un fallo genérico de infra (red, auth,
-                // 5xx). El squash server-side es idempotente y NO muta `main` si no
-                // puede mergear limpio (R7): ante conflicto real ESCALAMOS al
-                // operador (fail-closed, sin auto-merge) en vez de throw genérico
-                // → rebote a dev en loop. El 405/409 NO incrementa el circuit
-                // breaker: el motivo human-block hace que el pulpo lo derive a
-                // needs-human sin rev++.
-                const cls = classifyMergeFailure(mergeRes);
-                if (cls.conflict) {
-                    const conflictExcerpt = git.redactInline(
-                        (mergeRes.stderr || mergeRes.stdout || '').slice(0, 300),
-                    );
-                    logAppend(`[delivery] gh api merge → conflicto REAL (${cls.reason}) — escalando al operador sin rebote`);
-                    const esc = escalateMergeConflict({
-                        issue, prNumber, branch, httpStatus: cls.httpStatus,
-                        conflictExcerpt, logAppend,
-                    });
-                    motivo = esc.motivo;
-                    exitCode = 1;
-                    phaseEnd('pr_merge', t);
-                    return; // finally: marker con motivo human-block → NO rebota, escala a needs-human
+            // #5420 — Camino de merge endurecido. Los gates (QA, CODEOWNERS,
+            // owners humanos, procedencia) se evalúan sobre un snapshot ÚNICO
+            // del PR y el PUT viaja con el SHA de ese mismo snapshot. Ninguna
+            // lectura fallida se degrada a "vacío": todo borde es fail-closed.
+            const outcome = attemptMergeWithGates({
+                prNumber,
+                logAppend,
+                getSnapshot: (n) => getPRSnapshot(n),
+                // #2652 + #5420 — CODEOWNERS desde origin/main, NO del worktree
+                // local (que puede estar podado) ni del head del PR (que podría
+                // estar modificando el propio CODEOWNERS para saltearse el gate).
+                loadOwners: () => codeowners.loadCodeownersFromRef(WORK_DIR, OWNERS_REF),
+                verifyOrigin: (branchName) => {
+                    try {
+                        return verifyRemoteBranchOrigin(WORK_DIR, branchName);
+                    } catch (e) {
+                        // Nunca dejamos que una excepción de red/git se lea como
+                        // "verificada": excepción = no verificada = bloqueo.
+                        return { ok: false, reason: `excepcion: ${((e && e.message) || '').slice(0, 120)}` };
+                    }
+                },
+                // #2801 — merge vía API REST de GitHub (server-side) en lugar de
+                // `gh pr merge` (que ejecuta git ops locales). Razón: cuando otro
+                // worktree del mismo repo tiene `main` checked-out, `gh pr merge`
+                // intenta hacer `git checkout main` localmente y falla con
+                // "fatal: 'main' is already used by worktree at <otro path>".
+                // La API REST hace todo del lado del servidor — el estado local
+                // del repo no importa.
+                mergePR: ({ prNumber: n, sha }) => git.runGh([
+                    'api', '-X', 'PUT', `repos/{owner}/{repo}/pulls/${n}/merge`,
+                    '-f', 'merge_method=squash',
+                    '-f', `commit_title=${issueTitle} (#${n})`,
+                    // El SHA observado al evaluar los gates: si el head se movió,
+                    // GitHub responde 409 y no mergea un árbol no verificado.
+                    '-f', `sha=${sha}`,
+                ], { cwd: WORK_DIR, timeoutMs: 3 * 60 * 1000 }),
+            });
+
+            if (outcome.snapshot && Array.isArray(outcome.snapshot.labels)) {
+                labelsApplied = Array.from(new Set([...labelsApplied, ...outcome.snapshot.labels]));
+            }
+
+            if (outcome.status === 'no-qa-gate') {
+                // Sin gate QA → no mergeamos ciegamente; el delivery termina OK pero deja el PR abierto.
+                motivo = `PR #${prNumber} creado pero sin label qa:passed/qa:skipped — merge bloqueado.`;
+                logAppend(`[delivery] ${motivo}`);
+            } else if (outcome.status === 'needs-human') {
+                applyNeedsHumanLabel(issue, prNumber, outcome.owners, WORK_DIR);
+                labelsApplied = Array.from(new Set([...labelsApplied, 'needs-human']));
+                motivo = `PR #${prNumber} requiere review humano de ${outcome.owners.join(' ')} — merge bloqueado, label needs-human aplicado.`;
+                logAppend(`[delivery] ${motivo}`);
+            } else if (outcome.status === 'blocked') {
+                // #5420 — No pudimos VERIFICAR el merge (owners/procedencia/SHA/
+                // confirmación). Fail-closed al operador, sin rebote a dev: el
+                // motivo human-block hace que el pulpo escale sin rev++.
+                const esc = escalateMergeGateBlock({
+                    issue, prNumber, branch,
+                    gate: outcome.gate, reason: outcome.reason, logAppend,
+                });
+                motivo = esc.motivo;
+                exitCode = 1;
+                phaseEnd('pr_merge', t);
+                return; // finally: marker con motivo human-block → NO rebota, escala a needs-human
+            } else if (outcome.status === 'conflict') {
+                // #4658 — Conflicto de merge REAL (405 not-mergeable / 409 sin
+                // señal de head movido, o head movido que sobrevivió al retry).
+                // El squash server-side es idempotente y NO muta `main` si no
+                // puede mergear limpio (R7): escalamos al operador en vez de
+                // throw genérico → rebote a dev en loop.
+                const cls = outcome.classification;
+                const mergeRes = outcome.mergeRes || {};
+                const conflictExcerpt = git.redactInline(
+                    (mergeRes.stderr || mergeRes.stdout || '').slice(0, 300),
+                );
+                logAppend(`[delivery] gh api merge → conflicto REAL (${cls.reason}) — escalando al operador sin rebote`);
+                const esc = escalateMergeConflict({
+                    issue, prNumber, branch, httpStatus: cls.httpStatus,
+                    conflictExcerpt, logAppend,
+                });
+                motivo = esc.motivo;
+                exitCode = 1;
+                phaseEnd('pr_merge', t);
+                return; // finally: marker con motivo human-block → NO rebota, escala a needs-human
+            } else if (outcome.status !== 'merged') {
+                // Fallo genérico (infra: red, auth, 5xx): rebote técnico legítimo.
+                const mergeRes = outcome.mergeRes || {};
+                throw new Error(`gh api merge falló: ${(mergeRes.stderr || '').slice(0, 300) || (mergeRes.stdout || '').slice(0, 300)}`);
+            } else {
+                // MERGE CONFIRMADO (`merged: true`). Recién acá — y sólo acá — se
+                // registra el SHA, se borra la rama y se omite la escalada.
+                mergeSha = outcome.sha || null;
+                // Borrar rama del PR (igual que --delete-branch en gh pr merge)
+                const deleteRes = git.runGh([
+                    'api', '-X', 'DELETE', `repos/{owner}/{repo}/git/refs/heads/${branch}`,
+                ], { cwd: WORK_DIR, timeoutMs: 30 * 1000 });
+                if (deleteRes.exit_code !== 0) {
+                    logAppend(`[delivery] aviso: no se pudo borrar la rama ${branch}: ${(deleteRes.stderr || '').slice(0, 200)}`);
                 }
-                // Fallo genérico (infra): rebote técnico legítimo como siempre.
-                throw new Error(`gh api merge falló: ${mergeRes.stderr.slice(0, 300) || mergeRes.stdout.slice(0, 300)}`);
-            }
-            // Response shape: {"sha":"<merge-commit-sha>","merged":true,"message":"..."}
-            try {
-                const parsed = JSON.parse(mergeRes.stdout);
-                if (parsed && parsed.sha) mergeSha = parsed.sha;
-            } catch { /* response no-JSON: best-effort fallback abajo */ }
-            // Borrar rama del PR (igual que --delete-branch en gh pr merge)
-            const deleteRes = git.runGh([
-                'api', '-X', 'DELETE', `repos/{owner}/{repo}/git/refs/heads/${branch}`,
-            ], { cwd: WORK_DIR, timeoutMs: 30 * 1000 });
-            if (deleteRes.exit_code !== 0) {
-                logAppend(`[delivery] aviso: no se pudo borrar la rama ${branch}: ${(deleteRes.stderr || '').slice(0, 200)}`);
-            }
-            // Best-effort fetch del nuevo main para sincronizar local (no crítico).
-            if (!mergeSha) {
-                const fetchAfter = git.runGit(['fetch', 'origin', 'main'], { cwd: WORK_DIR });
-                if (fetchAfter.exit_code === 0) {
-                    const sha = git.runGit(['rev-parse', 'origin/main'], { cwd: WORK_DIR });
-                    if (sha.exit_code === 0) mergeSha = sha.stdout.trim();
+                // Best-effort fetch del nuevo main para sincronizar local (no crítico).
+                if (!mergeSha) {
+                    const fetchAfter = git.runGit(['fetch', 'origin', 'main'], { cwd: WORK_DIR });
+                    if (fetchAfter.exit_code === 0) {
+                        const sha = git.runGit(['rev-parse', 'origin/main'], { cwd: WORK_DIR });
+                        if (sha.exit_code === 0) mergeSha = sha.stdout.trim();
+                    }
                 }
+                logAppend(`[delivery] PR #${prNumber} mergeado vía API REST (squash, sha pinneado, intento ${outcome.attempt}) sha=${mergeSha || 'unknown'}`);
             }
-            logAppend(`[delivery] PR #${prNumber} mergeado vía API REST (squash) sha=${mergeSha || 'unknown'}`);
         }
         phaseEnd('pr_merge', t);
 
@@ -984,6 +1372,16 @@ module.exports = {
     getPRChangedPaths,
     applyNeedsHumanLabel,
     hasQaGate,
+    // #5420 — camino de merge endurecido: snapshot único, gates en orden,
+    // procedencia, SHA pinneado y confirmación estricta.
+    getPRSnapshot,
+    confirmMergeResponse,
+    attemptMergeWithGates,
+    buildGateBlockMotivo,
+    buildGateBlockEscalation,
+    escalateMergeGateBlock,
+    MAX_MERGE_ATTEMPTS,
+    OWNERS_REF,
     // #4658 — detección de conflicto real + escalado fail-closed.
     classifyMergeFailure,
     shouldEscalateLocalMerge,

--- a/.pipeline/skills-deterministicos/lib/codeowners.js
+++ b/.pipeline/skills-deterministicos/lib/codeowners.js
@@ -2,8 +2,22 @@
 
 const fs = require('fs');
 const path = require('path');
+const { spawnSync } = require('child_process');
 
 const HUMAN_OWNERS = new Set(['@leitolarreta']);
+
+// #5420 — rutas candidatas de CODEOWNERS DENTRO de una ref git, en el mismo
+// orden de precedencia que `loadCodeowners` local (GitHub resuelve .github/
+// primero).
+const CODEOWNERS_REF_PATHS = ['.github/CODEOWNERS', 'CODEOWNERS', 'docs/CODEOWNERS'];
+
+// Ref aceptable para `git show <ref>:<path>`. Cerrada a propósito: sin espacios,
+// sin ':' (separaría el path), sin metacaracteres de shell. Es defensa en
+// profundidad: el ejecutor usa spawnSync con array de args y shell:false, así
+// que nunca hay interpolación de shell — esto es un segundo cinturón.
+const SAFE_REF_RE = /^[A-Za-z0-9][A-Za-z0-9._/-]{0,199}$/;
+
+const DEFAULT_REF_TIMEOUT_MS = 15 * 1000;
 
 function parseCodeowners(content) {
     const rules = [];
@@ -35,6 +49,121 @@ function loadCodeowners(repoRoot) {
         } catch {}
     }
     return [];
+}
+
+// ============================================================================
+// #5420 — Carga FAIL-CLOSED de CODEOWNERS desde una ref git.
+// ============================================================================
+//
+// Por qué existe: `loadCodeowners` (arriba) devuelve `[]` tanto cuando el
+// archivo NO existe como cuando existe pero no pudo leerse. El camino de merge
+// de delivery.js interpretaba esa lista vacía como "este PR no tiene owners
+// humanos" y habilitaba el auto-merge — un FAIL-OPEN: perder el archivo (o
+// tener el worktree local podado) alcanzaba para saltear el gate de CODEOWNERS.
+//
+// `loadCodeownersFromRef` cierra esa puerta con dos decisiones:
+//
+//   1. Resultado discriminado: devuelve exclusivamente `{ ok:true, rules }` o
+//      `{ ok:false, reason }`. NUNCA colapsa un fallo de carga en `rules: []`,
+//      así el caller no puede confundir "no pude leer" con "no hay owners".
+//   2. Lee de una ref, no del filesystem: `git show origin/main:.github/CODEOWNERS`.
+//      El head del PR podría estar modificando el propio CODEOWNERS para
+//      borrarse del gate; la fuente de verdad es la rama principal. Además
+//      funciona aunque el worktree local esté podado o desincronizado.
+//
+// Un archivo presente pero SIN reglas parseables también es `ok:false`: un
+// CODEOWNERS vacío en `origin/main` es una anomalía de configuración, no una
+// autorización implícita a mergear.
+//
+// `loadCodeowners` se conserva intacto para los consumidores locales existentes
+// (no críticos); sólo el gate de merge migra a este loader.
+
+// Sanea una razón antes de propagarla: colapsa saltos de línea, tira caracteres
+// de control, redacta valores con pinta de credencial y trunca. La `reason` viaja
+// a logs, marker y Telegram — no puede filtrar secrets ni romper el formato.
+function sanitizeRefReason(value, max = 200) {
+    let txt = value == null ? '' : String(value);
+    txt = txt.replace(/[\r\n\t]+/g, ' ').replace(/[\x00-\x1f\x7f]/g, '');
+    txt = txt
+        .replace(/\b(?:gh[pousr]|github_pat)_[A-Za-z0-9_]{10,}/g, '<redacted>')
+        .replace(/\bAKIA[0-9A-Z]{12,}/g, '<redacted>')
+        .replace(/\bey[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}/g, '<redacted>')
+        .replace(/\b(token|secret|password|passwd|api[_-]?key)\s*[=:]\s*\S+/gi, '$1=<redacted>');
+    txt = txt.replace(/\s{2,}/g, ' ').trim();
+    return txt.length > max ? `${txt.slice(0, max - 1)}…` : txt;
+}
+
+/**
+ * Carga CODEOWNERS desde una ref git (típicamente `origin/main`).
+ *
+ * @param {string} repoRoot              cwd del `git show` (cualquier checkout del repo).
+ * @param {string} ref                   ref a leer, ej. `origin/main`.
+ * @param {object} [options]
+ * @param {function} [options.spawnImpl] inyectable para tests (firma de spawnSync).
+ * @param {number}   [options.timeoutMs] timeout por invocación de `git show`.
+ * @param {string[]} [options.paths]     rutas candidatas dentro de la ref.
+ * @returns {{ok:true, rules:Array, ref:string, source:string}|{ok:false, reason:string}}
+ */
+function loadCodeownersFromRef(repoRoot, ref, options = {}) {
+    const {
+        spawnImpl = spawnSync,
+        timeoutMs = DEFAULT_REF_TIMEOUT_MS,
+        paths = CODEOWNERS_REF_PATHS,
+    } = options;
+
+    if (!repoRoot || typeof repoRoot !== 'string') {
+        return { ok: false, reason: 'repoRoot ausente o invalido' };
+    }
+    if (typeof ref !== 'string' || !SAFE_REF_RE.test(ref)) {
+        return { ok: false, reason: `ref invalida: ${sanitizeRefReason(ref, 60) || '(vacia)'}` };
+    }
+
+    const failures = [];
+    for (const rel of paths) {
+        let res;
+        try {
+            // Array de args + shell:false: sin interpolación de shell y sin el
+            // mangling de paths de MSYS que sí sufre `git show a:b` en Git Bash.
+            res = spawnImpl('git', ['show', `${ref}:${rel}`], {
+                cwd: repoRoot,
+                encoding: 'utf8',
+                timeout: timeoutMs,
+                windowsHide: true,
+                shell: false,
+            });
+        } catch (e) {
+            failures.push(`${rel}: excepcion ${sanitizeRefReason(e && e.message, 80)}`);
+            continue;
+        }
+        if (!res || typeof res !== 'object') {
+            failures.push(`${rel}: ejecutor sin resultado`);
+            continue;
+        }
+        if (res.error) {
+            failures.push(`${rel}: ${sanitizeRefReason(res.error.message, 80)}`);
+            continue;
+        }
+        if (res.status !== 0) {
+            // status 128 = ref o path inexistente. Cualquier status != 0 es fallo.
+            const detail = sanitizeRefReason(res.stderr, 80);
+            const code = res.status === null || res.status === undefined ? 'null' : res.status;
+            failures.push(`${rel}: exit=${code}${detail ? ` ${detail}` : ''}`);
+            continue;
+        }
+        const content = typeof res.stdout === 'string' ? res.stdout : '';
+        const rules = parseCodeowners(content);
+        if (!rules.length) {
+            // Presente pero sin reglas: anomalía, no autorización implícita.
+            failures.push(`${rel}: sin reglas parseables`);
+            continue;
+        }
+        return { ok: true, rules, ref, source: rel };
+    }
+
+    return {
+        ok: false,
+        reason: sanitizeRefReason(`no se pudo cargar CODEOWNERS desde ${ref} — ${failures.join(' | ')}`, 300),
+    };
 }
 
 function patternToRegex(pattern) {
@@ -97,6 +226,10 @@ module.exports = {
     HUMAN_OWNERS,
     parseCodeowners,
     loadCodeowners,
+    // #5420 — loader fail-closed desde ref git (lo consume el gate de merge).
+    loadCodeownersFromRef,
+    sanitizeRefReason,
+    CODEOWNERS_REF_PATHS,
     patternToRegex,
     matchPath,
     resolveOwners,


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 5 archivos · +1228 -103

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:passed` aplicado por delivery

## Closes

Closes #5420
