### PR TITLE
[Split de #5451] Guardas contra re-commit de paths sensibles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,65 @@
-# Secrets — defensa en profundidad. La ubicacion oficial de credenciales es
+# =============================================================================
+# Secrets — inventario cerrado de paths sensibles (#5463, split de #5451).
+#
+# Defensa en profundidad. La ubicacion oficial de credenciales es
 # ~/.claude/secrets/ (home del usuario, fuera del repo); estos patrones
 # bloquean cualquier intento accidental de crear esos paths dentro del repo.
+#
+# ⚠️ Fuente unica de verdad: `.pipeline/lib/sensitive-paths.js`. Este bloque, el
+# scanner de `.husky/pre-commit` y la suite
+# `.pipeline/lib/__tests__/credential-path-guards.test.js` derivan del MISMO
+# inventario. Un alta se hace en el modulo; el test falla si esta lista no lo
+# refleja. No editar solo aca.
+#
+# `.gitignore` NO desindexa lo ya trackeado: el test verifica ademas, con
+# `git ls-files`, que ninguno de estos paths este en el indice.
+# =============================================================================
+
+# -- Stores de credenciales -------------------------------------------------
 .claude/secrets/
 **/.claude/secrets/
+.claude/.credentials.json
+**/.claude/.credentials.json
 secrets.json
 **/secrets.json
 .env
 .env.*
 !.env.example
+# Copias dentro del repo de los stores del pipeline (bot_token + chat_id y las
+# API keys de providers). Detectadas por el inventario del spike #5216 — son la
+# via mas corta de fuga porque el pipeline escribe en el root donde corre.
+.pipeline/credentials.json
+.pipeline/telegram-config.json
+# Cuarto almacen (respaldo ad-hoc) relevado por #5216.
+.intrale-api-keys.json
+**/.intrale-api-keys.json
+# Perfiles del AWS CLI: el vault no reemplaza ~/.aws, pero una copia adentro del
+# arbol es fuga directa de access key + secret.
+.aws/credentials
+**/.aws/credentials
+# Config de npm: suele traer `_authToken` del registry.
+.npmrc
+**/.npmrc
+# Configs de Firebase/Google con API keys de la app (hoy no existen — preventivo).
+**/google-services.json
+**/GoogleService-Info.plist
+
+# -- Material criptografico -------------------------------------------------
+*.pem
+*.p12
+*.pfx
+*.jks
+*.keystore
+*.ppk
+id_rsa
+id_rsa.*
+id_ed25519
+id_ed25519.*
+
+# -- Estado del Commander (puede arrastrar secretos pegados por el operador) --
+# (#3310) El scanner de pre-commit ya los pasaba por el sanitizer, pero la regla
+# de ignore faltaba: la segunda capa no puede ser la unica.
+.pipeline/commander-session.json
 
 # Build outputs
 build/

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -60,16 +60,23 @@ elif [ "$EXIT" != "0" ]; then
 fi
 
 # =============================================================================
-# Issue #3310 CA-5 — Secret-scan defensivo sobre archivos de estado del pipeline.
+# Issue #3310 CA-5 — Secret-scan defensivo · inventario alineado en #5463.
 #
-# Aunque `.pipeline/commander-session.json`, `commander-history.jsonl` y
-# `.pipeline/servicios/**/*.json` están en `.gitignore`, si alguien los
-# des-ignora por error este escáner bloquea el commit antes de que el secreto
-# llegue a la rama. Reusa el mismo `sanitizer.js` del runtime.
+# Segunda capa de contención de paths sensibles. La primera es `.gitignore`;
+# este escáner cubre el caso de que alguien (humano o agente) des-ignore un path
+# o lo fuerce al índice con `git add -f`.
+#
+# ⚠️ El inventario NO se declara acá ni en `.gitignore`: los tres consumidores
+# derivan de `.pipeline/lib/sensitive-paths.js` (#5463). Antes esta capa cubría
+# sólo el estado del Commander (#3310) mientras `.gitignore` cubría otro
+# conjunto, y los dos stores de credenciales del pipeline
+# (`.pipeline/credentials.json`, `.pipeline/telegram-config.json`) no estaban en
+# ninguno. Alta nueva → editar el módulo, no esta lista.
 #
 # El helper Node devuelve:
-#   - exit 0 → OK (no hay secretos detectados)
-#   - exit 1 → BLOQUEAR (secretos encontrados o sanitizer falló — fail-closed)
+#   - exit 0 → OK (ni paths del inventario en el índice ni secretos detectados)
+#   - exit 1 → BLOQUEAR (path sensible staged, secretos encontrados, o el
+#              sanitizer falló — fail-closed)
 # =============================================================================
 if [ -f ".pipeline/lib/precommit-secret-scan.js" ]; then
   node .pipeline/lib/precommit-secret-scan.js

--- a/.pipeline/commander-session.json
+++ b/.pipeline/commander-session.json
@@ -1,6 +1,0 @@
-{
-  "context": "Conversación libre. Último mensaje: \"Pero entonces el esquí que está fallando es el barra doc y está fallando cuando lo usamos desde tele\". Respuesta: \"Análisis listo. Te paso el diagnóstico crudo.\n\n🔍 **El problema está confirmado en el audit log — y \"",
-  "lastCommand": "chat",
-  "lastTimestamp": "2026-05-26T22:52:07.814Z",
-  "pendingAction": null
-}

--- a/.pipeline/lib/__tests__/credential-path-guards.test.js
+++ b/.pipeline/lib/__tests__/credential-path-guards.test.js
@@ -181,7 +181,7 @@ test('el inventario no clasifica archivos legítimos del repo como sensibles', (
         'docs/pipeline/inventario-credenciales.md',
         '.pipeline/lib/sensitive-paths.js',
         '.pipeline/agent-models.json',
-        '.claude/hooks/telegram-config.json',
+        '.claude/hooks/telegram-sanitizer.js',
         'app/composeApp/build.gradle.kts',
     ];
 
@@ -190,6 +190,97 @@ test('el inventario no clasifica archivos legítimos del repo como sensibles', (
             inventario.clasificarPath(p), null,
             `"${p}" fue clasificado como sensible — el inventario está de más`,
         );
+    }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CA-3 (regresión) · `.claude/hooks/telegram-config.json`
+//
+// Este path estuvo fuera del inventario y, peor, la suite lo fijaba como
+// "legítimo" afirmando `clasificarPath(p) === null`. Es portador de credenciales
+// (`bot_token`/`chat_id`/`openai_api_key`), está TRACKEADO, NO está ignorado, y
+// es el único path del repo donde el re-commit de una credencial ya ocurrió (11
+// commits del historial con un bot_token de formato real; #5226 registró además
+// valores reales de Google OAuth en su working copy). Con `isSensitive()`
+// devolviendo null, restaurar el token y hacer `git add` pasaba por las DOS
+// capas sin bloqueo.
+//
+// Como el archivo debe seguir versionado hasta el destrackeo de #5226, la
+// entrada usa `requiereIgnore: false` + `escaneaContenido: true` (mismo patrón
+// que `servicios-state`): la contención es el sanitizer, no el ignore.
+// ─────────────────────────────────────────────────────────────────────────────
+test('el config de Telegram de los hooks está en el inventario y se cubre por contenido', () => {
+    const rel = '.claude/hooks/telegram-config.json';
+
+    const clase = inventario.clasificarPath(rel);
+    assert.ok(clase, `"${rel}" no está en el inventario — el scanner nunca lo mira (ver #5226)`);
+    assert.strictEqual(clase.id, 'claude-hooks-telegram-config');
+    assert.strictEqual(clase.clase, 'credencial');
+    assert.strictEqual(
+        clase.escaneaContenido, true,
+        'sin escaneo de contenido no queda ninguna capa cubriendo el path',
+    );
+    assert.strictEqual(
+        clase.requiereIgnore, false,
+        'el archivo está trackeado a propósito: exigir ignore taparía un archivo versionado',
+    );
+
+    // La capa que efectivamente lo cubre: el scanner de pre-commit.
+    assert.strictEqual(
+        scanner.isSensitive(rel), 'claude-hooks-telegram-config',
+        'el scanner de pre-commit no reconoce el path',
+    );
+
+    // El matcher es exacto: no se lleva puesto el resto de `.claude/hooks/`.
+    assert.strictEqual(inventario.clasificarPath('.claude/hooks/telegram-sanitizer.js'), null);
+    assert.strictEqual(inventario.clasificarPath('.claude/hooks/activity-logger.js'), null);
+});
+
+test('el scanner corre el sanitizer sobre el config de Telegram de los hooks staged', () => {
+    // Canario con la FORMA de un bot token (para que el sanitizer lo cace) pero
+    // transparentemente falso: no aporta un valor ni un patrón útil a nadie.
+    const CANARIO = '000000:CANARIO-5463-NO-ES-UN-TOKEN-REAL-XXX';
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'guardas-5463-hooks-'));
+
+    try {
+        assert.strictEqual(git(['init', '-q'], { cwd: tmp }).rc, 0, 'no se pudo iniciar el repo temporal');
+        git(['config', 'user.email', 'test@intrale'], { cwd: tmp });
+        git(['config', 'user.name', 'test'], { cwd: tmp });
+        git(['config', 'commit.gpgsign', 'false'], { cwd: tmp });
+        git(['commit', '-q', '--allow-empty', '--no-verify', '-m', 'init'], { cwd: tmp });
+
+        fs.mkdirSync(path.join(tmp, '.claude', 'hooks'), { recursive: true });
+        fs.writeFileSync(
+            path.join(tmp, '.claude', 'hooks', 'telegram-config.json'),
+            JSON.stringify({ bot_token: CANARIO, chat_id: '12345' }, null, 2),
+        );
+        // Sin `-f`: el path NO está ignorado (ese es justamente el agujero), así
+        // que un `git add` común lo stagea. Es el escenario real del defecto.
+        git(['add', '.claude/hooks/telegram-config.json'], { cwd: tmp });
+
+        const r = spawnSync('node', [path.join(REPO_ROOT, '.pipeline', 'lib', 'precommit-secret-scan.js')], {
+            cwd: tmp,
+            encoding: 'utf8',
+        });
+
+        assert.strictEqual(
+            r.status, 1,
+            'el scanner dejó pasar una credencial restaurada en .claude/hooks/telegram-config.json',
+        );
+
+        const salida = (r.stdout || '') + (r.stderr || '');
+        assert.ok(salida.includes('.claude/hooks/telegram-config.json'), 'el bloqueo no nombra el path ofensor');
+        assert.ok(salida.includes('claude-hooks-telegram-config'), 'el bloqueo no atribuye la entrada del inventario');
+        // Prueba de que pasó por el sanitizer (nivel 2) y no por el bloqueo seco
+        // de path staged (nivel 1, que no aplica porque requiereIgnore es false).
+        assert.ok(
+            salida.includes('[REDACTED:TELEGRAM_BOT_TOKEN]'),
+            'el sanitizer no corrió sobre el archivo: no hay placeholder de redacción',
+        );
+        // CA-5: el bloqueo nombra el path y el patrón, nunca el valor.
+        assert.ok(!salida.includes(CANARIO), 'el bloqueo volcó el contenido del archivo sensible');
+    } finally {
+        try { fs.rmSync(tmp, { recursive: true, force: true }); } catch { /* best effort */ }
     }
 });
 
@@ -268,6 +359,44 @@ test('el scanner bloquea un path sensible staged sin volcar su contenido', () =>
         assert.ok(salida.includes('.pipeline/credentials.json'), 'el bloqueo no nombra el path ofensor');
         assert.ok(!salida.includes(CANARIO), 'el bloqueo volcó contenido del archivo sensible');
         assert.ok(salida.includes('sensitive-paths.js'), 'el bloqueo no orienta al inventario');
+    } finally {
+        try { fs.rmSync(tmp, { recursive: true, force: true }); } catch { /* best effort */ }
+    }
+});
+
+// Regresión: `sanitize()` normaliza CRLF→LF. El scanner comparaba el contenido
+// crudo contra el sanitizado, así que un archivo del inventario con finales de
+// línea de Windows — el caso por default en este repo — se reportaba como
+// "secreto detectado" sin un solo patrón redactado. Un bloqueo falso sobre un
+// archivo limpio empuja al operador a `--no-verify`, que apaga las dos capas.
+test('el scanner no bloquea un archivo del inventario limpio con finales de línea CRLF', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'guardas-5463-crlf-'));
+
+    try {
+        git(['init', '-q'], { cwd: tmp });
+        git(['config', 'user.email', 'test@intrale'], { cwd: tmp });
+        git(['config', 'user.name', 'test'], { cwd: tmp });
+        git(['config', 'core.autocrlf', 'false'], { cwd: tmp });
+        git(['commit', '-q', '--allow-empty', '--no-verify', '-m', 'init'], { cwd: tmp });
+
+        fs.mkdirSync(path.join(tmp, '.claude', 'hooks'), { recursive: true });
+        // Config legítima, sin credenciales, escrita con CRLF.
+        const limpio = JSON.stringify(
+            { bot_token: '', chat_id: '', permission_timeout_min: 30 }, null, 2,
+        ).replace(/\n/g, '\r\n');
+        fs.writeFileSync(path.join(tmp, '.claude', 'hooks', 'telegram-config.json'), limpio);
+        git(['add', '.claude/hooks/telegram-config.json'], { cwd: tmp });
+
+        const r = spawnSync('node', [path.join(REPO_ROOT, '.pipeline', 'lib', 'precommit-secret-scan.js')], {
+            cwd: tmp,
+            encoding: 'utf8',
+        });
+
+        assert.strictEqual(
+            r.status, 0,
+            'el scanner bloqueó un archivo limpio sólo por venir en CRLF: ' +
+            ((r.stdout || '') + (r.stderr || '')),
+        );
     } finally {
         try { fs.rmSync(tmp, { recursive: true, force: true }); } catch { /* best effort */ }
     }

--- a/.pipeline/lib/__tests__/credential-path-guards.test.js
+++ b/.pipeline/lib/__tests__/credential-path-guards.test.js
@@ -1,0 +1,297 @@
+// =============================================================================
+// credential-path-guards.test.js — Issue #5463 (split de #5451)
+//
+// Verifica las guardas contra re-commit de paths sensibles. El inventario es
+// `.pipeline/lib/sensitive-paths.js`; acá se comprueba que las DOS capas de
+// contención lo respeten de verdad, contra git, no contra una lista paralela:
+//
+//   CA-1 · `git check-ignore -v --no-index <path>` devuelve rc=0 e identifica la
+//          regla aplicable, para cada path sensible del inventario.
+//   CA-2 · `git ls-files` confirma que ninguno de esos paths está trackeado
+//          (`.gitignore` NO desindexa lo que ya entró al índice).
+//   CA-3 · `.gitignore` y el scanner de `.husky/pre-commit` cubren el MISMO
+//          inventario.
+//   CA-4 · `.env.example` sigue permitido.
+//   CA-5 · La evidencia no incluye contenido de archivos sensibles ni dumps de
+//          entorno: el bloqueo del scanner nombra el path y la razón, nunca lo
+//          que hay adentro.
+//
+// Nota sobre `check-ignore -v`: con `-v` git devuelve rc=0 también cuando la
+// regla que matchea es una NEGACIÓN (`!.env.example` sale con rc=0). Por eso
+// cada aserción de "está ignorado" chequea además que el patrón devuelto no
+// empiece con `!` — leer sólo el exit code da un verde falso.
+// =============================================================================
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const inventario = require('../sensitive-paths');
+const scanner = require('../precommit-secret-scan');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
+const GITIGNORE = path.join(REPO_ROOT, '.gitignore');
+
+const CON_IGNORE = inventario.SENSITIVE_PATHS.filter((e) => e.requiereIgnore);
+
+function git(args, opts = {}) {
+    const r = spawnSync('git', args, {
+        cwd: opts.cwd || REPO_ROOT,
+        encoding: 'utf8',
+        maxBuffer: 50 * 1024 * 1024,
+    });
+    return { rc: r.status, stdout: r.stdout || '', stderr: r.stderr || '' };
+}
+
+/**
+ * Corre `git check-ignore -v --no-index` sobre un path y parsea la salida
+ * `<source>:<line>:<pattern>\t<pathname>`.
+ */
+function checkIgnore(rel) {
+    const r = git(['check-ignore', '-v', '--no-index', '--', rel]);
+    const linea = r.stdout.split('\n').find(Boolean) || '';
+    const [origen, ...resto] = linea.split('\t');
+    const partes = origen.split(':');
+    const patron = partes.slice(2).join(':');
+    return {
+        rc: r.rc,
+        salida: linea,
+        fuente: partes[0] || '',
+        numeroLinea: partes[1] || '',
+        patron,
+        negada: patron.startsWith('!'),
+        pathname: (resto[0] || '').trim(),
+    };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CA-1 — cada path sensible está ignorado y la regla es identificable.
+// ─────────────────────────────────────────────────────────────────────────────
+test('cada path sensible del inventario da rc=0 en check-ignore y expone la regla aplicable', () => {
+    assert.ok(CON_IGNORE.length >= 10, 'el inventario quedó sospechosamente corto');
+
+    for (const entrada of CON_IGNORE) {
+        assert.ok(entrada.muestras.length > 0, `${entrada.id}: sin muestras para verificar`);
+
+        for (const muestra of entrada.muestras) {
+            const res = checkIgnore(muestra);
+            assert.strictEqual(
+                res.rc, 0,
+                `${entrada.id}: "${muestra}" NO está ignorado (rc=${res.rc}). Falta la regla en .gitignore.`,
+            );
+            assert.ok(
+                res.patron.length > 0,
+                `${entrada.id}: check-ignore no identificó regla para "${muestra}"`,
+            );
+            assert.ok(
+                !res.negada,
+                `${entrada.id}: "${muestra}" matchea una regla de NEGACIÓN (${res.patron}) — queda versionable`,
+            );
+            assert.ok(
+                res.fuente.endsWith('.gitignore'),
+                `${entrada.id}: la regla de "${muestra}" viene de "${res.fuente}", no de un .gitignore versionado`,
+            );
+        }
+    }
+});
+
+test('cada regla declarada en el inventario existe como línea exacta en .gitignore', () => {
+    const lineas = fs.readFileSync(GITIGNORE, 'utf8')
+        .split('\n')
+        .map((l) => l.replace(/\r$/, '').trim());
+
+    for (const entrada of CON_IGNORE) {
+        for (const regla of entrada.reglas) {
+            assert.ok(
+                lineas.includes(regla),
+                `${entrada.id}: la regla "${regla}" no está en .gitignore`,
+            );
+        }
+    }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CA-2 — ninguno de esos paths está trackeado.
+// ─────────────────────────────────────────────────────────────────────────────
+test('ningún path sensible del inventario está trackeado por git', () => {
+    for (const entrada of CON_IGNORE) {
+        for (const spec of entrada.pathspecs) {
+            const r = git(['ls-files', '--', spec]);
+            assert.strictEqual(r.rc, 0, `${entrada.id}: git ls-files falló para "${spec}": ${r.stderr}`);
+            const trackeados = r.stdout.split('\n').filter(Boolean);
+            assert.deepStrictEqual(
+                trackeados, [],
+                `${entrada.id}: hay paths sensibles en el índice (${spec}). ` +
+                'Sacarlos con `git rm --cached` — .gitignore no desindexa lo ya trackeado.',
+            );
+        }
+    }
+});
+
+test('el barrido completo del índice no contiene ningún path del inventario que requiera ignore', () => {
+    const r = git(['ls-files']);
+    assert.strictEqual(r.rc, 0, `git ls-files falló: ${r.stderr}`);
+
+    const ofensores = r.stdout.split('\n').filter(Boolean).filter((p) => {
+        const c = inventario.clasificarPath(p);
+        return c && c.requiereIgnore;
+    });
+
+    assert.deepStrictEqual(
+        ofensores, [],
+        `paths sensibles trackeados: ${ofensores.join(', ')}`,
+    );
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CA-3 — .gitignore y el scanner de pre-commit cubren el mismo inventario.
+// ─────────────────────────────────────────────────────────────────────────────
+test('el scanner de pre-commit reconoce todas las muestras del inventario', () => {
+    for (const entrada of inventario.SENSITIVE_PATHS) {
+        for (const muestra of entrada.muestras) {
+            assert.strictEqual(
+                scanner.isSensitive(muestra), entrada.id,
+                `el scanner de pre-commit no reconoce "${muestra}" (esperado ${entrada.id})`,
+            );
+        }
+    }
+});
+
+test('el scanner deriva su inventario del módulo compartido, sin lista paralela', () => {
+    const idsScanner = scanner.SENSITIVE_PATTERNS.map((p) => p.name).sort();
+    const idsInventario = inventario.SENSITIVE_PATHS
+        .filter((e) => e.escaneaContenido)
+        .map((e) => e.id)
+        .sort();
+
+    assert.deepStrictEqual(
+        idsScanner, idsInventario,
+        'el inventario del pre-commit divergió del módulo compartido',
+    );
+});
+
+test('el inventario no clasifica archivos legítimos del repo como sensibles', () => {
+    const legitimos = [
+        'README.md',
+        '.env.example',
+        'docs/pipeline/inventario-credenciales.md',
+        '.pipeline/lib/sensitive-paths.js',
+        '.pipeline/agent-models.json',
+        '.claude/hooks/telegram-config.json',
+        'app/composeApp/build.gradle.kts',
+    ];
+
+    for (const p of legitimos) {
+        assert.strictEqual(
+            inventario.clasificarPath(p), null,
+            `"${p}" fue clasificado como sensible — el inventario está de más`,
+        );
+    }
+});
+
+test('cada entrada del inventario está bien formada y con id único', () => {
+    const ids = new Set();
+    for (const e of inventario.SENSITIVE_PATHS) {
+        assert.ok(e.id && !ids.has(e.id), `id duplicado o ausente: ${e.id}`);
+        ids.add(e.id);
+        assert.ok(['credencial', 'cripto', 'estado'].includes(e.clase), `${e.id}: clase inválida`);
+        assert.ok(typeof e.motivo === 'string' && e.motivo.length > 20, `${e.id}: motivo insuficiente`);
+        assert.strictEqual(typeof e.test, 'function', `${e.id}: sin matcher`);
+        if (e.requiereIgnore) {
+            assert.ok(e.reglas.length > 0, `${e.id}: requiereIgnore sin reglas declaradas`);
+            assert.ok(e.pathspecs.length > 0, `${e.id}: requiereIgnore sin pathspecs para ls-files`);
+        }
+    }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CA-4 — la excepción .env.example sigue viva.
+// ─────────────────────────────────────────────────────────────────────────────
+test('.env.example sigue permitido pese a la regla .env.*', () => {
+    // Sin `-v`: rc=1 significa "no ignorado". Con `-v` daría rc=0 mostrando la
+    // regla de negación, que es justamente el verde falso que evitamos.
+    const r = git(['check-ignore', '--no-index', '--', '.env.example']);
+    assert.strictEqual(r.rc, 1, '.env.example quedó ignorado — se perdió la excepción');
+
+    const detalle = checkIgnore('.env.example');
+    assert.ok(detalle.negada, `la regla que aplica a .env.example debería ser negada, es "${detalle.patron}"`);
+
+    // Y el hermano genérico sigue ignorado.
+    const otro = checkIgnore('.env.produccion');
+    assert.strictEqual(otro.rc, 0, '.env.produccion debería estar ignorado');
+    assert.ok(!otro.negada, '.env.produccion matchea una negación');
+});
+
+test('las excepciones declaradas se reconocen y no se clasifican como sensibles', () => {
+    for (const exc of inventario.EXCEPCIONES) {
+        assert.ok(inventario.esExcepcion(exc.path), `no se reconoce la excepción ${exc.path}`);
+        assert.strictEqual(inventario.clasificarPath(exc.path), null, `${exc.path} clasificado como sensible`);
+    }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CA-5 — el bloqueo del scanner no filtra contenido sensible.
+// ─────────────────────────────────────────────────────────────────────────────
+test('el scanner bloquea un path sensible staged sin volcar su contenido', () => {
+    // Canario deliberadamente NO realista: no imita el formato de ninguna
+    // credencial, así el fixture no aporta un patrón útil a nadie.
+    const CANARIO = 'CANARIO-5463-CONTENIDO-QUE-NO-DEBE-APARECER';
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'guardas-5463-'));
+
+    try {
+        assert.strictEqual(git(['init', '-q'], { cwd: tmp }).rc, 0, 'no se pudo iniciar el repo temporal');
+        git(['config', 'user.email', 'test@intrale'], { cwd: tmp });
+        git(['config', 'user.name', 'test'], { cwd: tmp });
+        git(['config', 'commit.gpgsign', 'false'], { cwd: tmp });
+        git(['commit', '-q', '--allow-empty', '--no-verify', '-m', 'init'], { cwd: tmp });
+
+        fs.mkdirSync(path.join(tmp, '.pipeline'), { recursive: true });
+        fs.writeFileSync(
+            path.join(tmp, '.pipeline', 'credentials.json'),
+            JSON.stringify({ nota: CANARIO }, null, 2),
+        );
+        // `-f` simula exactamente el caso peligroso: alguien forzando al índice
+        // un path que .gitignore cubre.
+        git(['add', '-f', '.pipeline/credentials.json'], { cwd: tmp });
+
+        const r = spawnSync('node', [path.join(REPO_ROOT, '.pipeline', 'lib', 'precommit-secret-scan.js')], {
+            cwd: tmp,
+            encoding: 'utf8',
+        });
+
+        assert.strictEqual(r.status, 1, 'el scanner no bloqueó un path sensible staged');
+        const salida = (r.stdout || '') + (r.stderr || '');
+        assert.ok(salida.includes('.pipeline/credentials.json'), 'el bloqueo no nombra el path ofensor');
+        assert.ok(!salida.includes(CANARIO), 'el bloqueo volcó contenido del archivo sensible');
+        assert.ok(salida.includes('sensitive-paths.js'), 'el bloqueo no orienta al inventario');
+    } finally {
+        try { fs.rmSync(tmp, { recursive: true, force: true }); } catch { /* best effort */ }
+    }
+});
+
+test('el scanner deja pasar un commit sin paths sensibles', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'guardas-5463-ok-'));
+
+    try {
+        git(['init', '-q'], { cwd: tmp });
+        git(['config', 'user.email', 'test@intrale'], { cwd: tmp });
+        git(['config', 'user.name', 'test'], { cwd: tmp });
+        git(['commit', '-q', '--allow-empty', '--no-verify', '-m', 'init'], { cwd: tmp });
+
+        fs.writeFileSync(path.join(tmp, '.env.example'), 'API_BASE_URL=\nLOG_LEVEL=info\n');
+        git(['add', '.env.example'], { cwd: tmp });
+
+        const r = spawnSync('node', [path.join(REPO_ROOT, '.pipeline', 'lib', 'precommit-secret-scan.js')], {
+            cwd: tmp,
+            encoding: 'utf8',
+        });
+
+        assert.strictEqual(r.status, 0, `el scanner bloqueó un commit legítimo: ${r.stderr}`);
+    } finally {
+        try { fs.rmSync(tmp, { recursive: true, force: true }); } catch { /* best effort */ }
+    }
+});

--- a/.pipeline/lib/precommit-secret-scan.js
+++ b/.pipeline/lib/precommit-secret-scan.js
@@ -150,9 +150,20 @@ function main() {
         const content = readStagedContent(rel);
         if (content == null || content.length === 0) continue;
 
+        // El sanitizer normaliza CRLF→LF como efecto colateral. Comparar el
+        // contenido crudo contra el sanitizado marcaba como "secreto detectado"
+        // a CUALQUIER archivo con finales de línea de Windows — sin un solo
+        // patrón redactado, y en este repo el CRLF es el caso por default. El
+        // operador veía "(sanitizer redactó algo pero no se identificó)" sobre
+        // un archivo limpio, y el camino de salida obvio pasaba a ser
+        // `--no-verify`, que desactiva las DOS capas. Normalizamos ANTES de
+        // comparar para que la señal sea "el sanitizer redactó algo", no "el
+        // archivo venía en CRLF".
+        const normalizado = content.replace(/\r\n/g, '\n');
+
         let sanitized;
         try {
-            sanitized = sanitize(content);
+            sanitized = sanitize(normalizado);
         } catch (e) {
             // Fail-closed: si el sanitizer tira, asumimos que hay algo raro
             // que justifica bloquear el commit.
@@ -165,7 +176,7 @@ function main() {
             continue;
         }
 
-        if (sanitized !== content) {
+        if (sanitized !== normalizado) {
             findings.push({
                 path: rel,
                 kind,

--- a/.pipeline/lib/precommit-secret-scan.js
+++ b/.pipeline/lib/precommit-secret-scan.js
@@ -1,17 +1,26 @@
 #!/usr/bin/env node
 // =============================================================================
-// precommit-secret-scan.js — Issue #3310 CA-5
+// precommit-secret-scan.js — Issue #3310 CA-5 · ampliado por #5463
 //
 // Red de seguridad para evitar que estado interno del pipeline con secretos
-// llegue al repo. Hoy estos archivos están en `.gitignore`, pero si alguien
+// llegue al repo. Estos archivos están en `.gitignore`, pero si alguien
 // (humano o agente) los des-ignora por error, este script bloquea el commit
 // antes de que la fuga toque la rama.
 //
-// Cubre los paths donde el commander persiste mensajes de Telegram en disco:
+// #5463 — el inventario dejó de vivir acá: ahora sale de
+// `.pipeline/lib/sensitive-paths.js`, la MISMA fuente que alimenta `.gitignore`
+// y la suite `credential-path-guards.test.js`. Antes esta lista y la de
+// `.gitignore` divergían en silencio (los dos stores de credenciales del
+// pipeline no estaban en ninguna de las dos).
 //
-//   - `.pipeline/commander-session.json`
-//   - `.pipeline/commander-history.jsonl`
-//   - `.pipeline/servicios/**/*.json`
+// Dos niveles de bloqueo:
+//
+//   1. **Path del inventario staged** (`requiereIgnore: true`) → bloquea SIEMPRE,
+//      haya o no secretos detectables. Que el archivo esté en el índice ya es
+//      el defecto: significa que alguien des-ignoró un path sensible.
+//   2. **Contenido con secretos** → bloquea si el sanitizer redacta algo. Cubre
+//      también las entradas de sólo-contenido (`.pipeline/servicios/**/*.json`,
+//      que mezcla estado efímero con artefactos trackeados legítimos).
 //
 // Estrategia: lee cada archivo staged que matchee el glob y lo pasa por
 // `sanitizer.sanitize()`. Si la salida difiere del input, hay al menos un
@@ -43,14 +52,15 @@ const path = require('path');
 const { execSync } = require('child_process');
 
 const { sanitize } = require('../sanitizer');
+const { SENSITIVE_PATHS, clasificarPath } = require('./sensitive-paths');
 
-// Paths sensibles relativos al root del repo. Los matcheamos con startsWith
-// + endsWith para evitar dependencias de globbing externo.
-const SENSITIVE_PATTERNS = [
-    { name: 'commander-session', test: (p) => p === '.pipeline/commander-session.json' },
-    { name: 'commander-history', test: (p) => p === '.pipeline/commander-history.jsonl' },
-    { name: 'servicios-state',    test: (p) => p.startsWith('.pipeline/servicios/') && p.endsWith('.json') },
-];
+// Inventario derivado (#5463): la forma `{ name, test }` se conserva por compat
+// con los consumidores previos, pero las entradas salen del módulo compartido.
+// Agregar un path acá NO es el camino: se agrega en `sensitive-paths.js` y las
+// tres capas (ignore / pre-commit / test) lo heredan juntas.
+const SENSITIVE_PATTERNS = SENSITIVE_PATHS
+    .filter((e) => e.escaneaContenido)
+    .map((e) => ({ name: e.id, test: e.test }));
 
 function listStagedFiles() {
     // Lista archivos staged en el commit (added/copied/modified/renamed).
@@ -121,6 +131,22 @@ function main() {
         const kind = isSensitive(rel);
         if (!kind) continue;
 
+        // ── Nivel 1 (#5463): el path pertenece al inventario que DEBE estar
+        // ignorado. Que aparezca staged ya es el defecto — no hace falta que el
+        // sanitizer encuentre nada. Fail-closed sin leer el contenido: el
+        // mensaje nombra el path y la razón, nunca lo que hay adentro.
+        const clase = clasificarPath(rel);
+        if (clase && clase.requiereIgnore) {
+            findings.push({
+                path: rel,
+                kind,
+                staged_sensible: true,
+                motivo: clase.motivo,
+                redactions: {},
+            });
+            continue;
+        }
+
         const content = readStagedContent(rel);
         if (content == null || content.length === 0) continue;
 
@@ -154,18 +180,22 @@ function main() {
     const lines = [];
     lines.push('');
     lines.push('━'.repeat(72));
-    lines.push('🚨 pre-commit BLOQUEADO: secretos detectados en archivos sensibles');
+    lines.push('🚨 pre-commit BLOQUEADO: paths sensibles en el commit');
     lines.push('━'.repeat(72));
     lines.push('');
-    lines.push('Issue #3310: el commit toca archivos de estado del pipeline que');
-    lines.push('NO deberían vivir en git (están en .gitignore por una razón) y');
-    lines.push('encima contienen lo que parecen ser credenciales en plaintext.');
+    lines.push('El commit toca archivos del inventario cerrado de paths sensibles');
+    lines.push('(.pipeline/lib/sensitive-paths.js): o están en el índice cuando');
+    lines.push('deberían estar ignorados (#5463), o su contenido matchea patrones');
+    lines.push('de credencial en plaintext (#3310).');
     lines.push('');
 
     for (const f of findings) {
         lines.push(`  ✗ ${f.path}`);
         lines.push(`      tipo: ${f.kind}`);
-        if (f.error) {
+        if (f.staged_sensible) {
+            lines.push('      causa: path del inventario sensible presente en el índice');
+            lines.push(`      motivo: ${f.motivo}`);
+        } else if (f.error) {
             lines.push(`      sanitizer falló: ${f.error}`);
         } else {
             const tally = Object.entries(f.redactions);
@@ -188,11 +218,18 @@ function main() {
         lines.push(`       git restore --staged ${shellQuote(f.path)}`);
     }
     lines.push('');
-    lines.push('  2. Si estos paths NO deberían estar en git, asegurate de que');
-    lines.push('     sigan en .gitignore. Si los des-ignoraste a propósito,');
-    lines.push('     pensá si realmente querés exponer ese estado.');
+    lines.push('  2. Si alguno YA estaba trackeado, sacalo también del índice:');
+    for (const f of findings) {
+        if (f.staged_sensible) lines.push(`       git rm --cached ${shellQuote(f.path)}`);
+    }
     lines.push('');
-    lines.push('  3. Si el contenido legítimo del archivo coincidentemente');
+    lines.push('  3. Verificá que la regla de ignore exista y aplique:');
+    lines.push('       git check-ignore -v --no-index <path>');
+    lines.push('     El inventario y sus reglas viven en');
+    lines.push('     .pipeline/lib/sensitive-paths.js — un alta se hace ahí y');
+    lines.push('     .gitignore + este scanner + los tests la heredan juntos.');
+    lines.push('');
+    lines.push('  4. Si el contenido legítimo del archivo coincidentemente');
     lines.push('     matchea un patrón de secret (falso positivo), reportalo en');
     lines.push('     #3310 con el patrón concreto para ajustar la heurística.');
     lines.push('');

--- a/.pipeline/lib/sensitive-paths.js
+++ b/.pipeline/lib/sensitive-paths.js
@@ -1,0 +1,340 @@
+#!/usr/bin/env node
+// =============================================================================
+// sensitive-paths.js — Issue #5463 (split de #5451, épico #5428)
+//
+// **Inventario cerrado de paths sensibles del repositorio.** Fuente única de
+// verdad compartida por las tres capas de contención:
+//
+//   1. `.gitignore`                       — evita que el archivo entre al índice.
+//   2. `.husky/pre-commit` (scanner)      — segunda capa: bloquea el commit aunque
+//                                           alguien des-ignore el path.
+//   3. `.pipeline/lib/__tests__/credential-path-guards.test.js` — verifica ambas
+//                                           capas contra ESTE inventario.
+//
+// Antes de #5463 cada capa tenía su propia lista hardcodeada y divergían: el
+// scanner cubría tres paths de estado del commander (#3310) mientras que
+// `.gitignore` cubría otros; `.pipeline/credentials.json` y
+// `.pipeline/telegram-config.json` — los dos stores de credenciales que el
+// inventario del spike #5216 marca como "dentro del repo" — no estaban en
+// ninguna de las dos. Cualquier alta futura se hace ACÁ y las tres capas la
+// heredan.
+//
+// Invariantes que sostiene el test:
+//   - Toda entrada con `requiereIgnore: true` da `rc=0` en
+//     `git check-ignore -v --no-index <muestra>` con una regla NO negada.
+//   - Ninguna de esas muestras está trackeada (`git ls-files`).
+//   - Toda entrada del inventario es reconocida por `clasificarPath()`, que es
+//     lo que consume el scanner de pre-commit.
+//   - `.env.example` sigue permitido (excepción explícita).
+//
+// Sobre la evidencia: este módulo declara PATHS y REGLAS, nunca contenido. Los
+// tests y el scanner tampoco imprimen contenido de archivos sensibles — sólo el
+// path y la regla de `.gitignore` que lo cubre.
+// =============================================================================
+'use strict';
+
+/**
+ * Clases del inventario:
+ *   - `credencial`  → almacena material de autenticación (tokens, API keys, OAuth).
+ *   - `cripto`      → material criptográfico (claves privadas, keystores).
+ *   - `estado`      → estado runtime del pipeline que puede arrastrar secretos en
+ *                     su contenido (mensajes de Telegram, respuestas de providers).
+ *
+ * Campos:
+ *   - `reglas`          → strings que DEBEN existir como línea de `.gitignore`.
+ *   - `muestras`        → paths concretos con los que se verifica `check-ignore`.
+ *   - `pathspecs`       → pathspecs para `git ls-files` (verificación de no-trackeo).
+ *   - `requiereIgnore`  → si `.gitignore` debe cubrirlo (siempre true salvo caso
+ *                         documentado).
+ *   - `escaneaContenido`→ si el scanner de pre-commit debe pasarlo por el sanitizer.
+ *   - `test(rel)`       → matcher explícito sobre el path relativo al root del repo
+ *                         (con `/` como separador). Explícito a propósito: nada de
+ *                         glob casero, que es donde estas guardas fallan callado.
+ */
+const SENSITIVE_PATHS = Object.freeze([
+    {
+        id: 'env-dotfiles',
+        clase: 'credencial',
+        reglas: ['.env', '.env.*'],
+        muestras: ['.env', '.env.produccion'],
+        pathspecs: ['.env', ':(glob).env.*', ':(glob)**/.env'],
+        requiereIgnore: true,
+        escaneaContenido: true,
+        motivo: 'Variables de entorno con credenciales de backend/QA. `.env.example` es la única excepción.',
+        test: (p) => {
+            const base = basename(p);
+            if (base === '.env.example') return false;
+            return base === '.env' || base.startsWith('.env.');
+        },
+    },
+    {
+        id: 'secrets-json',
+        clase: 'credencial',
+        reglas: ['secrets.json', '**/secrets.json'],
+        muestras: ['secrets.json', '.pipeline/secrets.json'],
+        pathspecs: [':(glob)**/secrets.json'],
+        requiereIgnore: true,
+        escaneaContenido: true,
+        motivo: 'Nombre canónico de volcado de secretos. Nunca se versiona, en ningún nivel del árbol.',
+        test: (p) => basename(p) === 'secrets.json',
+    },
+    {
+        id: 'claude-secrets-store',
+        clase: 'credencial',
+        reglas: ['.claude/secrets/', '**/.claude/secrets/'],
+        muestras: ['.claude/secrets/credentials.json'],
+        pathspecs: [':(glob)**/.claude/secrets/**'],
+        requiereIgnore: true,
+        escaneaContenido: true,
+        motivo: 'Store canónico de credenciales (~/.claude/secrets/). Si aparece dentro del repo es una copia indebida.',
+        test: (p) => p === '.claude/secrets' || p.startsWith('.claude/secrets/') || p.includes('/.claude/secrets/'),
+    },
+    {
+        id: 'claude-oauth-credentials',
+        clase: 'credencial',
+        reglas: ['.claude/.credentials.json', '**/.claude/.credentials.json'],
+        muestras: ['.claude/.credentials.json'],
+        pathspecs: [':(glob)**/.claude/.credentials.json'],
+        requiereIgnore: true,
+        escaneaContenido: true,
+        motivo: 'Sesión OAuth de Claude Code (token de acceso vivo del plan Max).',
+        test: (p) => p === '.claude/.credentials.json' || p.endsWith('/.claude/.credentials.json'),
+    },
+    {
+        id: 'pipeline-credentials',
+        clase: 'credencial',
+        reglas: ['.pipeline/credentials.json'],
+        muestras: ['.pipeline/credentials.json'],
+        pathspecs: ['.pipeline/credentials.json'],
+        requiereIgnore: true,
+        escaneaContenido: true,
+        motivo: 'Copia dentro del repo del store de credenciales del pipeline (API keys de providers). Alta explícita de #5451.',
+        test: (p) => p === '.pipeline/credentials.json',
+    },
+    {
+        id: 'pipeline-telegram-config',
+        clase: 'credencial',
+        reglas: ['.pipeline/telegram-config.json'],
+        muestras: ['.pipeline/telegram-config.json'],
+        pathspecs: ['.pipeline/telegram-config.json'],
+        requiereIgnore: true,
+        escaneaContenido: true,
+        motivo: 'Config de Telegram del pipeline: bot_token + chat_id. Alta explícita de #5451.',
+        test: (p) => p === '.pipeline/telegram-config.json',
+    },
+    {
+        id: 'qa-telegram-config',
+        clase: 'credencial',
+        reglas: ['qa/scripts/telegram-config.json'],
+        muestras: ['qa/scripts/telegram-config.json'],
+        pathspecs: ['qa/scripts/telegram-config.json'],
+        requiereIgnore: true,
+        escaneaContenido: true,
+        motivo: 'Config de Telegram del runner de QA (SEC-3, #4173).',
+        test: (p) => p === 'qa/scripts/telegram-config.json',
+    },
+    {
+        id: 'api-keys-backup',
+        clase: 'credencial',
+        reglas: ['.intrale-api-keys.json', '**/.intrale-api-keys.json'],
+        muestras: ['.intrale-api-keys.json'],
+        pathspecs: [':(glob)**/.intrale-api-keys.json'],
+        requiereIgnore: true,
+        escaneaContenido: true,
+        motivo: 'Respaldo ad-hoc de API keys detectado por el spike #5216 (cuarto almacén, no declarado en el épico).',
+        test: (p) => basename(p) === '.intrale-api-keys.json',
+    },
+    {
+        id: 'aws-credentials',
+        clase: 'credencial',
+        reglas: ['.aws/credentials', '**/.aws/credentials'],
+        muestras: ['.aws/credentials'],
+        pathspecs: [':(glob)**/.aws/credentials'],
+        requiereIgnore: true,
+        escaneaContenido: true,
+        motivo: 'Perfiles del AWS CLI (access key + secret). El vault no reemplaza ~/.aws, pero una copia en el repo es fuga directa.',
+        test: (p) => p === '.aws/credentials' || p.endsWith('/.aws/credentials'),
+    },
+    {
+        id: 'service-account',
+        clase: 'credencial',
+        reglas: ['**/service-account*.json'],
+        muestras: ['service-account.json', 'qa/scripts/service-account-drive.json'],
+        pathspecs: [':(glob)**/service-account*.json'],
+        requiereIgnore: true,
+        escaneaContenido: true,
+        motivo: 'Service accounts de Google (clave privada embebida en el JSON).',
+        test: (p) => /^service-account.*\.json$/.test(basename(p)),
+    },
+    {
+        id: 'google-app-config',
+        clase: 'credencial',
+        reglas: ['**/google-services.json', '**/GoogleService-Info.plist'],
+        muestras: ['app/composeApp/google-services.json', 'app/iosApp/GoogleService-Info.plist'],
+        pathspecs: [':(glob)**/google-services.json', ':(glob)**/GoogleService-Info.plist'],
+        requiereIgnore: true,
+        escaneaContenido: true,
+        motivo: 'Configs de Firebase/Google con API keys de la app. Hoy no existen (verificado por #5216); la regla es preventiva.',
+        test: (p) => basename(p) === 'google-services.json' || basename(p) === 'GoogleService-Info.plist',
+    },
+    {
+        id: 'npmrc',
+        clase: 'credencial',
+        reglas: ['.npmrc', '**/.npmrc'],
+        muestras: ['.npmrc'],
+        pathspecs: [':(glob)**/.npmrc'],
+        requiereIgnore: true,
+        escaneaContenido: true,
+        motivo: 'Config de npm: suele traer `_authToken` del registry. El repo no versiona ninguno.',
+        test: (p) => basename(p) === '.npmrc',
+    },
+    {
+        id: 'claves-privadas',
+        clase: 'cripto',
+        reglas: ['*.pem', '*.p12', '*.pfx', '*.jks', '*.keystore', '*.ppk', 'id_rsa', 'id_rsa.*', 'id_ed25519', 'id_ed25519.*'],
+        muestras: [
+            'muestra-guardas-5463.pem',
+            'muestra-guardas-5463.p12',
+            'muestra-guardas-5463.pfx',
+            'muestra-guardas-5463.jks',
+            'muestra-guardas-5463.keystore',
+            'muestra-guardas-5463.ppk',
+            'id_rsa',
+            'id_ed25519',
+        ],
+        pathspecs: [
+            ':(glob)**/*.pem', ':(glob)**/*.p12', ':(glob)**/*.pfx',
+            ':(glob)**/*.jks', ':(glob)**/*.keystore', ':(glob)**/*.ppk',
+            ':(glob)**/id_rsa', ':(glob)**/id_rsa.*',
+            ':(glob)**/id_ed25519', ':(glob)**/id_ed25519.*',
+        ],
+        requiereIgnore: true,
+        escaneaContenido: true,
+        motivo: 'Material criptográfico (claves privadas, keystores de firma). Contención pedida por #5451.',
+        test: (p) => {
+            const base = basename(p);
+            if (/\.(pem|p12|pfx|jks|keystore|ppk)$/i.test(base)) return true;
+            return /^id_(rsa|ed25519)(\..*)?$/.test(base);
+        },
+    },
+    {
+        id: 'commander-session',
+        clase: 'estado',
+        reglas: ['.pipeline/commander-session.json'],
+        muestras: ['.pipeline/commander-session.json'],
+        pathspecs: ['.pipeline/commander-session.json'],
+        requiereIgnore: true,
+        escaneaContenido: true,
+        motivo: 'Sesión viva del Commander: transcripción de Telegram, puede arrastrar secretos pegados por el operador (#3310).',
+        test: (p) => p === '.pipeline/commander-session.json',
+    },
+    {
+        id: 'commander-history',
+        clase: 'estado',
+        reglas: ['.pipeline/commander-history.jsonl'],
+        muestras: ['.pipeline/commander-history.jsonl'],
+        pathspecs: ['.pipeline/commander-history.jsonl'],
+        requiereIgnore: true,
+        escaneaContenido: true,
+        motivo: 'Historial append-only del Commander, mismo riesgo que la sesión (#3310).',
+        test: (p) => p === '.pipeline/commander-history.jsonl',
+    },
+    {
+        id: 'servicios-state',
+        clase: 'estado',
+        // Sin `reglas`: NO exige cobertura de `.gitignore`. `.pipeline/servicios/`
+        // mezcla estado efímero (ya ignorado por fase: `pendiente/`, `trabajando/`,
+        // `listo/`, `procesado/`) con artefactos trackeados legítimos
+        // (`condenser-fired-*.json`). Un ignore amplio acá dejaría archivos
+        // versionados tapados por una regla — peor que no tenerla. El destrackeo
+        // de lo que sobra es de #5226; hasta entonces la contención de esta
+        // entrada es el escaneo de contenido del pre-commit, heredado de #3310.
+        reglas: [],
+        // Las muestras sólo se usan para verificar el matcher y la cobertura del
+        // scanner: al ser `requiereIgnore: false`, el test no les corre check-ignore.
+        muestras: ['.pipeline/servicios/github/estado-runtime.json'],
+        pathspecs: [],
+        requiereIgnore: false,
+        escaneaContenido: true,
+        motivo: 'Estado de los servicios del pipeline (respuestas de providers, mensajes). Cobertura por contenido, no por ignore (ver comentario).',
+        test: (p) => p.startsWith('.pipeline/servicios/') && p.endsWith('.json'),
+    },
+]);
+
+/**
+ * Excepciones explícitas: paths que matchean una regla del inventario pero que
+ * DEBEN seguir versionados. Se verifican en el test para que ningún endurecimiento
+ * futuro los tape por accidente.
+ */
+const EXCEPCIONES = Object.freeze([
+    {
+        path: '.env.example',
+        regla: '!.env.example',
+        motivo: 'Plantilla sin valores reales; es la documentación de qué variables hay que definir.',
+    },
+]);
+
+function basename(p) {
+    const norm = String(p || '').replace(/\\/g, '/');
+    const i = norm.lastIndexOf('/');
+    return i === -1 ? norm : norm.slice(i + 1);
+}
+
+/** Normaliza a path relativo con `/`, sin `./` inicial. */
+function normalizar(rel) {
+    return String(rel || '').replace(/\\/g, '/').replace(/^\.\//, '');
+}
+
+/**
+ * Clasifica un path relativo al root del repo contra el inventario.
+ * @returns {{id: string, clase: string, requiereIgnore: boolean, escaneaContenido: boolean, motivo: string}|null}
+ */
+function clasificarPath(rel) {
+    const p = normalizar(rel);
+    if (!p) return null;
+    for (const entrada of SENSITIVE_PATHS) {
+        let hit = false;
+        try {
+            hit = entrada.test(p);
+        } catch (_e) {
+            // Un matcher que tira no puede volver permisivo el inventario: se
+            // ignora esa entrada y siguen las demás (las otras capas cubren).
+            hit = false;
+        }
+        if (hit) {
+            return {
+                id: entrada.id,
+                clase: entrada.clase,
+                requiereIgnore: entrada.requiereIgnore,
+                escaneaContenido: entrada.escaneaContenido,
+                motivo: entrada.motivo,
+            };
+        }
+    }
+    return null;
+}
+
+/** true si el path está declarado como excepción versionable. */
+function esExcepcion(rel) {
+    const p = normalizar(rel);
+    return EXCEPCIONES.some((e) => e.path === p || p.endsWith('/' + e.path));
+}
+
+/** Todas las reglas que `.gitignore` tiene que contener, aplanadas y deduplicadas. */
+function reglasRequeridas() {
+    const out = [];
+    for (const e of SENSITIVE_PATHS) {
+        if (!e.requiereIgnore) continue;
+        for (const r of e.reglas) if (!out.includes(r)) out.push(r);
+    }
+    return out;
+}
+
+module.exports = {
+    SENSITIVE_PATHS,
+    EXCEPCIONES,
+    clasificarPath,
+    esExcepcion,
+    reglasRequeridas,
+    __forTestsOnly__: { basename, normalizar },
+};

--- a/.pipeline/lib/sensitive-paths.js
+++ b/.pipeline/lib/sensitive-paths.js
@@ -44,8 +44,12 @@
  *   - `reglas`          → strings que DEBEN existir como línea de `.gitignore`.
  *   - `muestras`        → paths concretos con los que se verifica `check-ignore`.
  *   - `pathspecs`       → pathspecs para `git ls-files` (verificación de no-trackeo).
- *   - `requiereIgnore`  → si `.gitignore` debe cubrirlo (siempre true salvo caso
- *                         documentado).
+ *   - `requiereIgnore`  → si `.gitignore` debe cubrirlo. `false` SÓLO para paths
+ *                         hoy trackeados legítimamente, donde un ignore taparía
+ *                         un archivo versionado: ahí la contención es el escaneo
+ *                         de contenido. Cada caso lleva su comentario y el issue
+ *                         que se ocupa del destrackeo (`servicios-state`,
+ *                         `claude-hooks-telegram-config` → #5226).
  *   - `escaneaContenido`→ si el scanner de pre-commit debe pasarlo por el sanitizer.
  *   - `test(rel)`       → matcher explícito sobre el path relativo al root del repo
  *                         (con `/` como separador). Explícito a propósito: nada de
@@ -132,6 +136,33 @@ const SENSITIVE_PATHS = Object.freeze([
         escaneaContenido: true,
         motivo: 'Config de Telegram del runner de QA (SEC-3, #4173).',
         test: (p) => p === 'qa/scripts/telegram-config.json',
+    },
+    {
+        id: 'claude-hooks-telegram-config',
+        clase: 'credencial',
+        // Sin `reglas` / `requiereIgnore: false`: este archivo ESTÁ TRACKEADO hoy
+        // y los hooks de Telegram lo leen del repo, así que un ignore acá taparía
+        // un archivo versionado (mismo antipatrón que evita `servicios-state`).
+        // El destrackeo + la regla de ignore son responsabilidad de #5226; hasta
+        // que eso ocurra la contención de esta entrada es el escaneo de contenido
+        // del pre-commit, que es justamente la capa que faltaba.
+        //
+        // Por qué entra igual al inventario: es portador de credenciales
+        // (`bot_token`, `chat_id`, `openai_api_key`) y es el ÚNICO path del repo
+        // donde el re-commit de una credencial ya ocurrió — 11 commits del
+        // historial llevan un `bot_token` de formato real. El propio archivo lo
+        // documenta en `_secrets_note` ("NO restaurar credenciales aquí - quedan
+        // trackeadas en git") y #5226 registró que su working copy llegó a tener
+        // valores reales de Google OAuth. Dejarlo fuera del inventario hacía que
+        // `isSensitive()` devolviera null y que NINGUNA de las dos capas mirara
+        // el archivo: restaurar el token real + `git add` pasaba limpio.
+        reglas: [],
+        muestras: ['.claude/hooks/telegram-config.json'],
+        pathspecs: [],
+        requiereIgnore: false,
+        escaneaContenido: true,
+        motivo: 'Config de Telegram de los hooks de Claude Code: bot_token + chat_id + openai_api_key. Trackeado a la espera del destrackeo de #5226; cobertura por contenido, no por ignore (ver comentario).',
+        test: (p) => p === '.claude/hooks/telegram-config.json' || p.endsWith('/.claude/hooks/telegram-config.json'),
     },
     {
         id: 'api-keys-backup',

--- a/dictamen-5463.md
+++ b/dictamen-5463.md
@@ -1,0 +1,34 @@
+## Dictamen de integridad técnica — issue #5463
+
+**Alcance evaluado:** rama `agent/5463-pipeline-dev` @ `905303622`, diff vs `origin/main` (7 archivos, +943/-38).
+
+### Adherencia al diseño/diagramas
+
+**Adherente.** La verificación formal de adherencia contra receta firmada es **N/A**: el gate architect corre con `enabled: false` / `gate_mode: dry-run`, por lo que Fase 1 nunca produjo sección `## Detalles Técnicos` firmada contra la cual comparar el diff (`evaluateGate` → `decision: aprobado`, `skipped: true`, `gate_mode: disabled`). En ausencia de receta, se evaluó la implementación contra el diseño declarado en el issue (D1..D6 de #5339, CA-5 y guardas de CA-6 del padre #5451).
+
+Los cuatro cambios requeridos por el issue están implementados y verificados empíricamente:
+
+- Inventario sensible ampliado con `.pipeline/credentials.json` y `.pipeline/telegram-config.json` (`.gitignore:31-32`), más material criptográfico, `.aws/credentials`, `.npmrc` y configs Firebase/Google.
+- Excepción `!.env.example` preservada y efectiva (`check-ignore` la resuelve por la regla negada `.gitignore:27`, pese a `.env.*`).
+- `.husky/pre-commit` alineado: dejó de declarar lista propia y deriva del módulo compartido.
+- Suite `credential-path-guards.test.js` (426 líneas) ejercitando `git check-ignore -v --no-index` + `git ls-files`: **15/15 verde**.
+
+La decisión estructural de fondo — un **inventario cerrado como fuente única de verdad** en `.pipeline/lib/sensitive-paths.js` del que derivan las tres capas (ignore / scanner / tests) — es la respuesta correcta al defecto de origen: antes cada capa tenía su lista hardcodeada y divergían, y los dos stores de credenciales del pipeline no estaban en ninguna.
+
+### Desvíos vs. diseño
+
+Ninguno que contradiga el diseño. Dos observaciones registradas, ambas coherentes:
+
+- `.pipeline/commander-session.json` se **elimina del índice** en el diff. No es un archivo espurio: es exactamente lo que exige el CA "`git ls-files` confirma que ninguno de esos paths está trackeado". Es un archivo de estado runtime regenerado localmente por el Commander, no una fuente versionada.
+- El módulo incorpora entradas con `requiereIgnore: false` (`claude-hooks-telegram-config`, `servicios-state`), que **no** son un desvío sino una decisión explícita y comentada: son paths hoy trackeados legítimamente donde un ignore taparía un archivo versionado; su contención pasa a ser escaneo de contenido.
+
+### Deuda técnica / riesgos introducidos
+
+- **Deuda heredada, explicitada y con dueño:** `claude-hooks-telegram-config` (bot_token + chat_id + openai_api_key) sigue **trackeado**, cubierto sólo por escaneo de contenido hasta que #5226 haga el destrackeo. La implementación no lo oculta — lo documenta en el módulo con el issue responsable. Es la exposición residual real de esta entrega y queda fuera de su alcance.
+- **Riesgo de deriva a futuro:** el valor del diseño depende de que las altas se hagan en el módulo y no en `.gitignore`. Mitigado estructuralmente: el test falla si `.gitignore` no refleja el inventario, y hay un test específico ("el scanner deriva su inventario del módulo compartido, sin lista paralela") que impide reintroducir listas paralelas.
+- **Efecto colateral menor:** al destrackear `commander-session.json`, un `reset --hard` de respawn ya no lo restaura desde el repo. Sin impacto operativo — el Commander lo regenera, y su contenido (mensajes pegados por el operador) era precisamente el vector de fuga.
+- **Sin deuda de higiene de evidencia:** el módulo declara paths y reglas, nunca contenido; los tests y el scanner tampoco vuelcan contenido de archivos sensibles. Cumple el CA "la evidencia no incluye contenido de archivos sensibles ni dumps de entorno".
+
+### Integridad estructural
+
+**Sólida.** El cambio reduce superficie en vez de agregarla: sustituye tres listas divergentes por una fuente única con matchers explícitos (`test(rel)` por entrada, sin glob casero — que es justamente donde estas guardas fallan en silencio). Mantiene el comportamiento fail-closed del scanner y respeta la defensa en profundidad: `.gitignore` como primera capa, pre-commit como segunda ante `git add -f` o des-ignore. La cobertura de tests es proporcional al riesgo (15 casos incluyendo CRLF, excepciones, y no-clasificación de archivos legítimos como falsos positivos). No introduce dependencias nuevas ni refactor invasivo fuera del perímetro del issue.

--- a/docs/pipeline/inventario-credenciales.md
+++ b/docs/pipeline/inventario-credenciales.md
@@ -208,6 +208,13 @@ materializa. Por eso la contención es doble:
   exista. Vive dentro de `.git/`, así que sobrevive el `reset --hard` y el `clean` que el
   root vivo hace en cada respawn.
 
+**Guardas contra re-commit (#5463).** El inventario de paths sensibles dejó de estar
+duplicado entre `.gitignore` y el scanner de `.husky/pre-commit`: ambos —más la suite
+`.pipeline/lib/__tests__/credential-path-guards.test.js`— derivan de
+`.pipeline/lib/sensitive-paths.js`. Un alta se hace en ese módulo y las tres capas la
+heredan; el test falla si alguna se desalinea, si un path del inventario queda trackeado
+(`git ls-files`) o si `.env.example` deja de estar permitido.
+
 Verificar `check-ignore` únicamente en el worktree del agente da un **falso positivo de
 contención**: da `rc=0` ahí mientras el artefacto queda expuesto en el root vivo.
 


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 8 archivos · +977 -38

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:passed` aplicado por delivery

## Closes

Closes #5463
