### PR TITLE
[Ola 9.4] Fix de particion del catalogo del kernel: se escribe en el tenant y se lee del control-plane

### DIFF
--- a/.pipeline/lib/__tests__/kernel-catalog-partition-5204.test.js
+++ b/.pipeline/lib/__tests__/kernel-catalog-partition-5204.test.js
@@ -1,0 +1,298 @@
+'use strict';
+
+// =============================================================================
+// kernel-catalog-partition-5204.test.js — El catálogo del kernel se escribe y se
+// lee en la MISMA partición (#5204 · bloqueaba el CA-B5 del cutover durable de
+// #5126).
+//
+// EL DEFECTO QUE CUBRE
+// --------------------
+// (a) `contextProjectId` no se propagaba: el `bootDeps` que arma el drenador de
+//     onboarding sólo llevaba `registryPath`/`probeAccess`, así que con
+//     `kernel.durable:true` el alta moría en `KernelStoreContextError`.
+// (b) El catálogo se escribía en la partición del TENANT (`putProduct` →
+//     `addToCatalog` con `PK = contextProjectId`) y el boot lo leía en la del
+//     CONTROL-PLANE. Un catálogo poblado desde un tenant era INVISIBLE para
+//     `bootProducts()`: `listProducts()` devolvía `[]` y no se instanciaba ningún
+//     pipeline.
+//
+// Los tests recorren el camino REAL en los dos sentidos: escriben por el alta
+// (`processOnboard` → `runBootstrapAsync` → `durableRegisterProduct`) y leen por
+// el boot (`kernel-supervisor.bootProducts`), sin cortocircuitar ninguno.
+// =============================================================================
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const bootstrapLib = require('../project-bootstrap');
+const drainLib = require('../product-control-drain');
+const ks = require('../kernel-store');
+const supervisorLib = require('../kernel-supervisor');
+const { CONTROL_PLANE_PROJECT_ID } = require('../project-descriptor');
+const { createInMemoryDynamoDriver } = require('../provisioner-infra');
+
+const TENANT = 'acme-store';
+const TABLE = 'kernel-store-test';
+const SPEC = {
+  type: 'dynamodb_table',
+  tableName: TABLE,
+  keys: [
+    { name: 'PK', attributeType: 'S', keyType: 'HASH' },
+    { name: 'SK', attributeType: 'S', keyType: 'RANGE' },
+  ],
+};
+
+function validDescriptor(projectId = TENANT) {
+  return {
+    schemaVersion: '1.0',
+    identity: { projectId, name: 'ACME Store' },
+    repositories: [{ id: 'main', url: 'https://github.com/acme/store', role: 'primary' }],
+    board: {
+      ref: 'https://github.com/orgs/acme/projects/1',
+      admissionLabels: ['Ready'],
+      routing: [{ label: 'area:backend', capability: 'backend' }],
+    },
+    capabilities: [{ interface: 'backend', skills: ['backend-dev'] }],
+    authority: { signers: ['leitolarreta'], gates: { gate2: 'enforce' } },
+  };
+}
+
+function onboardRequest(projectId = TENANT) {
+  return { type: 'product_onboard_request', projectId, descriptor: validDescriptor(projectId) };
+}
+
+// Tabla ÚNICA compartida por todas las particiones (como en producción: una tabla,
+// muchas PK). Sin esto el test no podría distinguir "otra partición" de "otra tabla".
+function makeWorld() {
+  const driver = createInMemoryDynamoDriver();
+  const config = { kernel: { tableName: TABLE } };
+  const storeFor = (o = {}) => ks.createKernelStore({
+    driver,
+    config,
+    contextProjectId: o.contextProjectId,
+    allowedNamespaces: o.allowedNamespaces,
+    onAlert: o.onAlert,
+  });
+  return { driver, config, storeFor };
+}
+
+// Lee el ítem CRUDO de una partición concreta (sin pasar por el store, que sólo
+// sabe leer la suya). Es lo que permite afirmar DÓNDE quedó escrito el catálogo.
+async function rawItem(driver, pk, sk) {
+  try {
+    const res = await driver.getItem(SPEC, { PK: pk, SK: sk });
+    return (res && res.item) || null;
+  } catch (e) {
+    // El driver in-memory exige la tabla creada; si el alta se cortó fail-closed
+    // ANTES de cualquier escritura, la tabla ni existe. Eso ES la ausencia buscada.
+    if (/tabla inexistente/i.test(String(e && e.message))) return null;
+    throw e;
+  }
+}
+
+// -----------------------------------------------------------------------------
+// CA-1 — el alta real propaga contextProjectId y completa sin KernelStoreContextError
+// -----------------------------------------------------------------------------
+
+test('CA-1: alta durable por el camino real del drenador completa sin KernelStoreContextError', async () => {
+  const { driver, storeFor } = makeWorld();
+  const drain = drainLib.createProductControlDrain({
+    // El descriptor es `existing` (trae url): no toca `gh`.
+    execFileSync: () => { throw new Error('gh no debe invocarse en este camino'); },
+    kernelDurable: true,
+    kernelConfig: { durable: true, tableName: TABLE, region: null },
+    createStore: storeFor,
+    probeAccess: () => true,
+  });
+
+  const res = await drain.processOnboard(onboardRequest());
+  assert.equal(res.ok, true, `el alta durable debe completar: ${JSON.stringify(res)}`);
+  assert.equal(res.stage, 'registered');
+  assert.equal(res.projectId, TENANT);
+
+  // Y persistió de verdad: el producto quedó indexado en el control-plane.
+  const catalog = await rawItem(driver, CONTROL_PLANE_PROJECT_ID, 'catalog#index');
+  assert.ok(catalog, 'el catálogo debe existir tras el alta');
+  assert.deepEqual(catalog.body.productIds, [TENANT]);
+});
+
+test('CA-1: sin contextProjectId propagado el alta durable falla fail-closed (regresión del defecto (a))', async () => {
+  const { storeFor } = makeWorld();
+  const drain = drainLib.createProductControlDrain({
+    execFileSync: () => { throw new Error('gh no debe invocarse'); },
+    kernelDurable: true,
+    kernelConfig: { durable: true, tableName: TABLE, region: null },
+    createStore: storeFor,
+    probeAccess: () => true,
+    // Simula el bug: el resolver no entrega contexto ⇒ el write path corta.
+    resolveContextProjectId: () => null,
+  });
+  const res = await drain.processOnboard(onboardRequest());
+  assert.equal(res.ok, false, 'sin contexto el alta NO puede completar en silencio');
+  assert.equal(res.stage, 'register-durable');
+});
+
+// -----------------------------------------------------------------------------
+// CA-2 — lo que escribe el alta es EXACTAMENTE lo que enumera el boot
+// -----------------------------------------------------------------------------
+
+test('CA-2: un producto dado de alta queda visible para bootProducts() (escribe alta, lee boot)', async () => {
+  const { driver, storeFor } = makeWorld();
+  const drain = drainLib.createProductControlDrain({
+    execFileSync: () => { throw new Error('gh no debe invocarse'); },
+    kernelDurable: true,
+    kernelConfig: { durable: true, tableName: TABLE, region: null },
+    createStore: storeFor,
+    probeAccess: () => true,
+  });
+  const alta = await drain.processOnboard(onboardRequest());
+  assert.equal(alta.ok, true, JSON.stringify(alta));
+
+  // El boot construye SU catálogo como en `pulpo.js`: partición del control-plane.
+  const catalogStore = storeFor({
+    contextProjectId: CONTROL_PLANE_PROJECT_ID,
+    allowedNamespaces: [CONTROL_PLANE_PROJECT_ID],
+  });
+  const spawned = [];
+  const supervisor = supervisorLib.createKernelSupervisor({
+    catalogStore,
+    storeFactory: storeFor,
+    drainOnboardQueue: false,
+    spawn: (ctx) => { spawned.push(ctx.projectId); return { pid: 1 }; },
+  });
+
+  // El alta deja el producto en `onboarding` (INACTIVO hasta OK humano): el boot
+  // lo VE en el catálogo y lo saltea por estado, no por invisibilidad. Ésa es la
+  // distinción que el defecto (b) borraba — antes ni siquiera aparecía.
+  const visto = await supervisor.bootProducts();
+  assert.deepEqual(visto.spawned, []);
+  assert.deepEqual(
+    visto.skipped.map((s) => `${s.projectId}:${s.reason}`),
+    [`${TENANT}:inactivo`],
+    'el producto recién dado de alta debe aparecer en el catálogo que lee el boot',
+  );
+
+  // Activado (OK humano), el MISMO catálogo lo instancia: roundtrip completo.
+  await catalogStore.putProduct({ productId: TENANT, name: 'ACME Store', status: 'active' });
+  const boot2 = await supervisor.bootProducts();
+  assert.deepEqual(boot2.spawned, [TENANT]);
+  assert.deepEqual(spawned, [TENANT]);
+
+  // Y la hidratación por instancia encuentra el descriptor en la partición del
+  // TENANT (no en la del control-plane): cada entidad en su namespace.
+  const ctx = supervisor.getInstance(TENANT);
+  assert.ok(ctx && ctx.descriptor, 'la instancia debe hidratar su descriptor');
+  assert.equal(ctx.descriptor.identity.projectId, TENANT);
+  assert.ok(await rawItem(driver, TENANT, 'descriptor#self'), 'descriptor#self vive en la partición del tenant');
+});
+
+// -----------------------------------------------------------------------------
+// CA-4 — regresión de partición: el catálogo NO puede volver a la partición del
+// tenant. Este test falla si alguien vuelve a usar un único store para las tres
+// entidades.
+// -----------------------------------------------------------------------------
+
+test('CA-4: catalog#index y product# se escriben en el control-plane, NUNCA en la partición del tenant', async () => {
+  const { driver, storeFor } = makeWorld();
+  const res = await bootstrapLib.runBootstrapAsync({
+    descriptor: validDescriptor(),
+    mode: 'full',
+    deps: {
+      kernelDurable: true,
+      kernelConfig: { durable: true, tableName: TABLE, region: null },
+      contextProjectId: TENANT,
+      createStore: storeFor,
+      probeAccess: () => true,
+    },
+  });
+  assert.equal(res.ok, true, JSON.stringify(res.errors || res));
+  assert.equal(res.register.catalogProjectId, CONTROL_PLANE_PROJECT_ID);
+
+  // Partición del CONTROL-PLANE: catálogo + producto (lo que enumera el boot).
+  assert.ok(await rawItem(driver, CONTROL_PLANE_PROJECT_ID, 'catalog#index'), 'catalog#index en el control-plane');
+  assert.ok(await rawItem(driver, CONTROL_PLANE_PROJECT_ID, `product#${TENANT}`), `product#${TENANT} en el control-plane`);
+
+  // Partición del TENANT: SÓLO el descriptor. Si el catálogo reaparece acá, el
+  // boot vuelve a leer `[]` y ningún pipeline se instancia.
+  assert.ok(await rawItem(driver, TENANT, 'descriptor#self'), 'descriptor#self en la partición del tenant');
+  assert.equal(await rawItem(driver, TENANT, 'catalog#index'), null, 'el catálogo NO puede vivir en la partición del tenant');
+  assert.equal(await rawItem(driver, TENANT, `product#${TENANT}`), null, 'el producto NO puede vivir en la partición del tenant');
+});
+
+// -----------------------------------------------------------------------------
+// CA-3 — el aislamiento por tenant se mantiene
+// -----------------------------------------------------------------------------
+
+test('CA-3: un contexto ajeno no puede registrar el producto de otro (ni ensuciar el catálogo global)', async () => {
+  const { driver, storeFor } = makeWorld();
+  const res = await bootstrapLib.runBootstrapAsync({
+    descriptor: validDescriptor(TENANT),          // identidad: acme-store
+    mode: 'full',
+    deps: {
+      kernelDurable: true,
+      kernelConfig: { durable: true, tableName: TABLE, region: null },
+      contextProjectId: 'other-tenant',           // credencial: otro tenant
+      createStore: storeFor,
+      probeAccess: () => true,
+    },
+  });
+  assert.equal(res.ok, false, 'un contexto ajeno no debe poder registrar el producto');
+  assert.equal(res.stage, 'register-durable');
+  // Fail-closed ANTES de escribir: el catálogo global queda intacto (si el corte
+  // ocurriera recién en putDescriptor, acá habría una entrada huérfana).
+  assert.equal(await rawItem(driver, CONTROL_PLANE_PROJECT_ID, 'catalog#index'), null, 'el catálogo global no debe ensuciarse');
+  assert.equal(await rawItem(driver, TENANT, 'descriptor#self'), null, 'no debe escribirse el descriptor del tenant ajeno');
+});
+
+test('CA-3: el control-plane es un id reservado — no puede darse de alta como producto', async () => {
+  const { storeFor } = makeWorld();
+  const res = await bootstrapLib.runBootstrapAsync({
+    descriptor: validDescriptor(CONTROL_PLANE_PROJECT_ID),
+    mode: 'full',
+    deps: {
+      kernelDurable: true,
+      kernelConfig: { durable: true, tableName: TABLE, region: null },
+      contextProjectId: CONTROL_PLANE_PROJECT_ID,
+      createStore: storeFor,
+      probeAccess: () => true,
+    },
+  });
+  assert.equal(res.ok, false, 'la partición del kernel no es un tenant');
+  assert.equal(res.stage, 'register-durable');
+});
+
+test('CA-3: el alta no sobreescribe el descriptor de un producto ya registrado', async () => {
+  const { storeFor } = makeWorld();
+  const deps = {
+    kernelDurable: true,
+    kernelConfig: { durable: true, tableName: TABLE, region: null },
+    contextProjectId: TENANT,
+    createStore: storeFor,
+    probeAccess: () => true,
+  };
+  const first = await bootstrapLib.runBootstrapAsync({ descriptor: validDescriptor(), mode: 'full', deps });
+  assert.equal(first.ok, true, JSON.stringify(first.errors || first));
+  const second = await bootstrapLib.runBootstrapAsync({ descriptor: validDescriptor(), mode: 'full', deps });
+  assert.equal(second.ok, false, 'un alta repetida no puede pisar el descriptor existente');
+  assert.equal(second.stage, 'register-durable');
+});
+
+// -----------------------------------------------------------------------------
+// Fail-closed de cableado: un alta "durable" sin store real no puede reportar OK
+// escribiendo a un store efímero que muere con el proceso.
+// -----------------------------------------------------------------------------
+
+test('sin store durable inyectado el alta NO reporta éxito (nada de escribir a un store efímero)', async () => {
+  const res = await bootstrapLib.runBootstrapAsync({
+    descriptor: validDescriptor(),
+    mode: 'full',
+    deps: {
+      kernelDurable: true,
+      kernelConfig: { durable: true, tableName: TABLE, region: null },
+      contextProjectId: TENANT,
+      probeAccess: () => true,
+    },
+  });
+  assert.equal(res.ok, false);
+  assert.equal(res.stage, 'register-durable');
+});

--- a/.pipeline/lib/__tests__/product-control-drain.test.js
+++ b/.pipeline/lib/__tests__/product-control-drain.test.js
@@ -60,7 +60,7 @@ function makeFakeGh({ viewExists = false, createThrows = null } = {}) {
 // CA-1 — create crea el repo, completa la URL limpia y registra en full
 // -----------------------------------------------------------------------------
 
-test('CA-1: provenance:create crea el repo y completa la URL limpia en el registro', () => {
+test('CA-1: provenance:create crea el repo y completa la URL limpia en el registro', async () => {
   const gh = makeFakeGh({ viewExists: false });
   let registered = null;
   const drain = drainLib.createProductControlDrain({
@@ -68,7 +68,7 @@ test('CA-1: provenance:create crea el repo y completa la URL limpia en el regist
     runBootstrap: (a) => { registered = a; return { ok: true, stage: 'registered' }; },
     allowedOrgs: ['intrale'],
   });
-  const res = drain.processOnboard(onboardRequest({ id: 'main', role: 'primary', provenance: 'create', create: { name: 'store', org: 'intrale', visibility: 'private' } }));
+  const res = await drain.processOnboard(onboardRequest({ id: 'main', role: 'primary', provenance: 'create', create: { name: 'store', org: 'intrale', visibility: 'private' } }));
   assert.equal(res.ok, true, JSON.stringify(res));
   assert.equal(res.created, true);
   assert.equal(res.url, 'https://github.com/intrale/store');
@@ -78,25 +78,25 @@ test('CA-1: provenance:create crea el repo y completa la URL limpia en el regist
   assert.equal(registered.registerMeta.repoOrigin, 'created');
 });
 
-test('CA-SEC-1: gh se invoca SIEMPRE con array de args (nunca string/shell)', () => {
+test('CA-SEC-1: gh se invoca SIEMPRE con array de args (nunca string/shell)', async () => {
   const gh = makeFakeGh({ viewExists: false });
   const drain = drainLib.createProductControlDrain({ execFileSync: gh.exec, runBootstrap: () => ({ ok: true }), allowedOrgs: ['intrale'] });
-  drain.processOnboard(onboardRequest({ id: 'main', role: 'primary', provenance: 'create', create: { name: 'store', org: 'intrale' } }));
+  await drain.processOnboard(onboardRequest({ id: 'main', role: 'primary', provenance: 'create', create: { name: 'store', org: 'intrale' } }));
   assert.ok(gh.calls.length >= 2);
   assert.deepEqual(gh.calls.find((c) => c[2] === 'create'), ['gh', 'repo', 'create', 'intrale/store', '--private']);
 });
 
-test('CA-SEC-3: visibilidad default private; public sólo con elección explícita', () => {
+test('CA-SEC-3: visibilidad default private; public sólo con elección explícita', async () => {
   const ghPriv = makeFakeGh({ viewExists: false });
   const dPriv = drainLib.createProductControlDrain({ execFileSync: ghPriv.exec, runBootstrap: () => ({ ok: true }), allowedOrgs: ['intrale'] });
   // sin visibility ⇒ private
-  dPriv.processOnboard(onboardRequest({ id: 'main', role: 'primary', provenance: 'create', create: { name: 'store', org: 'intrale' } }));
+  await dPriv.processOnboard(onboardRequest({ id: 'main', role: 'primary', provenance: 'create', create: { name: 'store', org: 'intrale' } }));
   assert.ok(ghPriv.calls.some((c) => c.includes('--private')));
   assert.ok(!ghPriv.calls.some((c) => c.includes('--public')));
 
   const ghPub = makeFakeGh({ viewExists: false });
   const dPub = drainLib.createProductControlDrain({ execFileSync: ghPub.exec, runBootstrap: () => ({ ok: true }), allowedOrgs: ['intrale'] });
-  dPub.processOnboard(onboardRequest({ id: 'main', role: 'primary', provenance: 'create', create: { name: 'store', org: 'intrale', visibility: 'public' } }));
+  await dPub.processOnboard(onboardRequest({ id: 'main', role: 'primary', provenance: 'create', create: { name: 'store', org: 'intrale', visibility: 'public' } }));
   assert.ok(ghPub.calls.some((c) => c.includes('--public')));
 });
 
@@ -104,20 +104,20 @@ test('CA-SEC-3: visibilidad default private; public sólo con elección explíci
 // CA-SEC-2 — org fuera de la allowlist ⇒ rechazo sin invocar gh
 // -----------------------------------------------------------------------------
 
-test('CA-SEC-2: org fuera de la allowlist se rechaza SIN invocar gh (A01)', () => {
+test('CA-SEC-2: org fuera de la allowlist se rechaza SIN invocar gh (A01)', async () => {
   const gh = makeFakeGh({ viewExists: false });
   const drain = drainLib.createProductControlDrain({ execFileSync: gh.exec, runBootstrap: () => ({ ok: true }), allowedOrgs: ['intrale'] });
-  const res = drain.processOnboard(onboardRequest({ id: 'main', role: 'primary', provenance: 'create', create: { name: 'store', org: 'evilcorp' } }));
+  const res = await drain.processOnboard(onboardRequest({ id: 'main', role: 'primary', provenance: 'create', create: { name: 'store', org: 'evilcorp' } }));
   assert.equal(res.ok, false);
   assert.equal(res.stage, 'create-spec');
   assert.equal(gh.calls.length, 0, 'no debe invocar gh con org fuera de allowlist');
 });
 
-test('CA-SEC-1: create.name con metacaracteres de shell es rechazado antes de invocar gh', () => {
+test('CA-SEC-1: create.name con metacaracteres de shell es rechazado antes de invocar gh', async () => {
   const gh = makeFakeGh({ viewExists: false });
   const drain = drainLib.createProductControlDrain({ execFileSync: gh.exec, runBootstrap: () => ({ ok: true }), allowedOrgs: ['intrale'] });
   // Este descriptor no pasa validateDescriptor (create.name inválido) ⇒ stage validation.
-  const res = drain.processOnboard(onboardRequest({ id: 'main', role: 'primary', provenance: 'create', create: { name: 'foo;rm -rf /', org: 'intrale' } }));
+  const res = await drain.processOnboard(onboardRequest({ id: 'main', role: 'primary', provenance: 'create', create: { name: 'foo;rm -rf /', org: 'intrale' } }));
   assert.equal(res.ok, false);
   assert.equal(gh.calls.length, 0);
 });
@@ -126,29 +126,29 @@ test('CA-SEC-1: create.name con metacaracteres de shell es rechazado antes de in
 // CA-4 — idempotencia y estado consistente ante fallo
 // -----------------------------------------------------------------------------
 
-test('CA-4: repo ya existente ⇒ NO se re-crea (idempotencia)', () => {
+test('CA-4: repo ya existente ⇒ NO se re-crea (idempotencia)', async () => {
   const gh = makeFakeGh({ viewExists: true });
   const drain = drainLib.createProductControlDrain({ execFileSync: gh.exec, runBootstrap: () => ({ ok: true }), allowedOrgs: ['intrale'] });
-  const res = drain.processOnboard(onboardRequest({ id: 'main', role: 'primary', provenance: 'create', create: { name: 'store', org: 'intrale' } }));
+  const res = await drain.processOnboard(onboardRequest({ id: 'main', role: 'primary', provenance: 'create', create: { name: 'store', org: 'intrale' } }));
   assert.equal(res.ok, true);
   assert.equal(res.created, false);
   assert.ok(!gh.calls.some((c) => c[2] === 'create'), 'no debe llamar create si el repo ya existe');
 });
 
-test('CA-4: 422 name already exists durante create se maneja idempotente (sin estado a medias)', () => {
+test('CA-4: 422 name already exists durante create se maneja idempotente (sin estado a medias)', async () => {
   const gh = makeFakeGh({ viewExists: false, createThrows: 'GraphQL: Name already exists on this account (HTTP 422)' });
   let registered = false;
   const drain = drainLib.createProductControlDrain({ execFileSync: gh.exec, runBootstrap: () => { registered = true; return { ok: true }; }, allowedOrgs: ['intrale'] });
-  const res = drain.processOnboard(onboardRequest({ id: 'main', role: 'primary', provenance: 'create', create: { name: 'store', org: 'intrale' } }));
+  const res = await drain.processOnboard(onboardRequest({ id: 'main', role: 'primary', provenance: 'create', create: { name: 'store', org: 'intrale' } }));
   assert.equal(res.ok, true);
   assert.equal(registered, true, 'debe registrar el producto (URL completada), no dejarlo a medias');
 });
 
-test('CA-4: fallo de creación (permiso) NO registra el producto (no queda a medias)', () => {
+test('CA-4: fallo de creación (permiso) NO registra el producto (no queda a medias)', async () => {
   const gh = makeFakeGh({ viewExists: false, createThrows: 'HTTP 403: Resource not accessible' });
   let registered = false;
   const drain = drainLib.createProductControlDrain({ execFileSync: gh.exec, runBootstrap: () => { registered = true; return { ok: true }; }, allowedOrgs: ['intrale'] });
-  const res = drain.processOnboard(onboardRequest({ id: 'main', role: 'primary', provenance: 'create', create: { name: 'store', org: 'intrale' } }));
+  const res = await drain.processOnboard(onboardRequest({ id: 'main', role: 'primary', provenance: 'create', create: { name: 'store', org: 'intrale' } }));
   assert.equal(res.ok, false);
   assert.equal(res.stage, 'create-repo');
   assert.equal(registered, false, 'no debe registrar si la creación falló');
@@ -158,11 +158,11 @@ test('CA-4: fallo de creación (permiso) NO registra el producto (no queda a med
 // provenance:existing — no toca gh; inyecta el probe real (repo-probe) explícitamente
 // -----------------------------------------------------------------------------
 
-test('existing: no invoca gh y registra vía runBootstrap full (inyecta probe real CA-2)', () => {
+test('existing: no invoca gh y registra vía runBootstrap full (inyecta probe real CA-2)', async () => {
   const gh = makeFakeGh({ viewExists: true });
   let bootArg = null;
   const drain = drainLib.createProductControlDrain({ execFileSync: gh.exec, runBootstrap: (a) => { bootArg = a; return { ok: true }; } });
-  const res = drain.processOnboard(onboardRequest({ id: 'main', url: 'https://github.com/acme/store', role: 'primary' }));
+  const res = await drain.processOnboard(onboardRequest({ id: 'main', url: 'https://github.com/acme/store', role: 'primary' }));
   assert.equal(res.ok, true);
   assert.equal(res.repoOrigin, 'existing');
   assert.equal(gh.calls.length, 0, 'existing no crea repos');
@@ -175,7 +175,7 @@ test('existing: no invoca gh y registra vía runBootstrap full (inyecta probe re
 // drainOnce — lee/mueve archivos de la cola con fs real (tmp)
 // -----------------------------------------------------------------------------
 
-test('drainOnce procesa la cola, mueve el pedido a procesado y deja sidecar de resultado', () => {
+test('drainOnce procesa la cola, mueve el pedido a procesado y deja sidecar de resultado', async () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'pcd-'));
   const queueDir = path.join(tmp, 'pendiente');
   const doneDir = path.join(tmp, 'procesado');
@@ -191,7 +191,7 @@ test('drainOnce procesa la cola, mueve el pedido a procesado y deja sidecar de r
     queueDir, doneDir,
     now: () => ts++,
   });
-  const summary = drain.drainOnce();
+  const summary = await drain.drainOnce();
   assert.equal(summary.processed, 1);
   assert.equal(summary.results[0].ok, true);
   // La cola quedó vacía; el pedido se movió a procesado con su sidecar.
@@ -201,19 +201,19 @@ test('drainOnce procesa la cola, mueve el pedido a procesado y deja sidecar de r
   assert.ok(done.some((n) => n.endsWith('.result.json')));
 });
 
-test('drainOnce sobre cola inexistente ⇒ 0 procesados (defensivo, no lanza)', () => {
+test('drainOnce sobre cola inexistente ⇒ 0 procesados (defensivo, no lanza)', async () => {
   const drain = drainLib.createProductControlDrain({ queueDir: path.join(os.tmpdir(), 'no', 'existe', 'q'), execFileSync: () => '' });
-  const summary = drain.drainOnce();
+  const summary = await drain.drainOnce();
   assert.equal(summary.processed, 0);
 });
 
-test('drainOnce ignora pedidos que no son onboard (no los mueve)', () => {
+test('drainOnce ignora pedidos que no son onboard (no los mueve)', async () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'pcd-'));
   const queueDir = path.join(tmp, 'pendiente');
   fs.mkdirSync(queueDir, { recursive: true });
   fs.writeFileSync(path.join(queueDir, 'start-acme-1.json'), JSON.stringify({ type: 'product_control_request', action: 'start' }), 'utf8');
   const drain = drainLib.createProductControlDrain({ queueDir, doneDir: path.join(tmp, 'done'), execFileSync: () => '' });
-  const summary = drain.drainOnce();
+  const summary = await drain.drainOnce();
   assert.equal(summary.results[0].stage, 'skip');
   assert.equal(fs.readdirSync(queueDir).length, 1, 'el start/pause queda para el kernel de instancias');
 });

--- a/.pipeline/lib/kernel-store.js
+++ b/.pipeline/lib/kernel-store.js
@@ -51,7 +51,7 @@ const {
   ConditionalCheckFailedError,
 } = require('./provisioner-infra');
 const projectDescriptor = require('./project-descriptor');
-const { validateDescriptor, isSafeId, isReservedProjectId, redactAjvErrors } = projectDescriptor;
+const { validateDescriptor, isSafeId, isReservedProjectId, redactAjvErrors, CONTROL_PLANE_PROJECT_ID } = projectDescriptor;
 const { detectInjection } = require('./handoff');
 const { parseSecretRef } = require('./credentials');
 
@@ -669,6 +669,11 @@ module.exports = {
   SCHEMA_PATH,
   SCHEMA_VERSION,
   ENTITY,
+  // #5204 — re-export por ergonomía: los callers del store (boot, alta durable,
+  // drainer) necesitan la MISMA constante de partición del control-plane. La
+  // autoridad sigue siendo `project-descriptor.js` (donde vive la política de
+  // ids reservados); acá sólo se reexporta para no obligar a importar dos libs.
+  CONTROL_PLANE_PROJECT_ID,
   KernelStoreError,
   KernelStoreValidationError,
   KernelStoreIsolationError,

--- a/.pipeline/lib/product-control-drain.js
+++ b/.pipeline/lib/product-control-drain.js
@@ -67,7 +67,15 @@ const DEFAULT_ALLOWED_ORGS = Object.freeze(['intrale']);
  * @param {object} [deps]
  * @param {object}   [deps.fsImpl]         impl de fs (default: node:fs).
  * @param {function} [deps.execFileSync]   ejecutor de `gh` (default: child_process).
- * @param {function} [deps.runBootstrap]   registro fail-closed (default: project-bootstrap).
+ * @param {function} [deps.runBootstrap]   registro fail-closed (default: `runBootstrapAsync`
+ *                                          de project-bootstrap — con `kernel.durable:false`
+ *                                          se comporta idéntico al camino FS · CA-6).
+ * @param {function} [deps.resolveContextProjectId] (#5204) resuelve el `contextProjectId`
+ *                                          del alta a partir del descriptor YA validado.
+ *                                          Default: la identidad del producto que se está
+ *                                          creando (ver nota de CA-9 más abajo).
+ * @param {object}   [deps.storeDriver]     driver durable a inyectar al write path.
+ * @param {function} [deps.createStore]     factory de store durable (override de tests).
  * @param {string}   [deps.queueDir]       cola de pedidos (default: product-control/pendiente).
  * @param {string}   [deps.doneDir]        destino de procesados (default: product-control/procesado).
  * @param {string}   [deps.registryPath]   path del registry (pasado a runBootstrap).
@@ -81,7 +89,28 @@ const DEFAULT_ALLOWED_ORGS = Object.freeze(['intrale']);
 function createProductControlDrain(deps = {}) {
   const _fs = deps.fsImpl || fs;
   const exec = deps.execFileSync || execFileSync;
-  const runBootstrap = typeof deps.runBootstrap === 'function' ? deps.runBootstrap : bootstrap.runBootstrap;
+  // #5204 — el default pasa a ser el entry ASÍNCRONO. `runBootstrap` (sync) NUNCA
+  // toma el write path durable: con `kernel.durable:true` el alta por este camino
+  // se registraba sólo en filesystem y el producto no existía para el boot. Con
+  // el flag OFF (default) `runBootstrapAsync` hace exactamente lo mismo que antes
+  // (mismo registro FS, mismo shape de resultado · CA-6), así que la paridad se
+  // mantiene. Un `runBootstrap` sync inyectado por tests sigue funcionando: el
+  // resultado se `await`ea igual.
+  const runBootstrap = typeof deps.runBootstrap === 'function' ? deps.runBootstrap : bootstrap.runBootstrapAsync;
+  // #5204 · CA-9 — contexto de partición del alta. El alta la ejecuta el KERNEL
+  // (control-plane) y su efecto es CREAR la partición del tenant nuevo: no existe
+  // todavía una instancia con credencial propia de la cual derivarlo. Por eso el
+  // default es la identidad del descriptor YA validado fail-closed (schema +
+  // isSafeId + no reservado), y `durableRegisterProduct` vuelve a exigir que el
+  // contexto coincida con esa identidad antes de escribir nada.
+  //
+  // La propiedad anti tenant-hopping se conserva donde importa: un caller que SÍ
+  // tiene contexto propio (una instancia ya viva) lo inyecta por
+  // `deps.resolveContextProjectId` y entonces un descriptor de otro tenant queda
+  // rechazado por el propio write path.
+  const resolveContextProjectId = typeof deps.resolveContextProjectId === 'function'
+    ? deps.resolveContextProjectId
+    : (d) => (d && d.identity && d.identity.projectId) || null;
   // Probe de alcance REAL (CA-2) para repos existentes-de-URL. Inyección explícita
   // least-privilege (alineado con la arquitectura de `repo-probe.js`); ya no se
   // delega a un auto-cableado por default de runBootstrap.
@@ -224,10 +253,13 @@ function createProductControlDrain(deps = {}) {
    * Procesa UN pedido de onboarding (objeto ya parseado). No lee ni mueve archivos:
    * es la unidad testeable pura. Devuelve el resultado del pedido.
    *
+   * ASÍNCRONA desde #5204: el registro puede tomar el write path durable, que es
+   * async. Con `kernel.durable:false` resuelve en el mismo tick lógico que antes.
+   *
    * @param {object} request  `{ type:'product_onboard_request', descriptor, ... }`
-   * @returns {{ok:boolean, projectId?:string, stage:string, created?:boolean, url?:string, reason?:string}}
+   * @returns {Promise<{ok:boolean, projectId?:string, stage:string, created?:boolean, url?:string, reason?:string}>}
    */
-  function processOnboard(request) {
+  async function processOnboard(request) {
     if (!request || request.type !== 'product_onboard_request') {
       return { ok: false, stage: 'type', reason: 'pedido no es product_onboard_request' };
     }
@@ -281,7 +313,20 @@ function createProductControlDrain(deps = {}) {
         // Camino "usar existente": alcance verificado por red (least-privilege).
         bootDeps.probeAccess = probeAccess;
       }
-      boot = runBootstrap({
+      // #5204 · defecto (a) — el write path durable exige `contextProjectId`
+      // fail-closed. Sin propagarlo, un alta con `kernel.durable:true` moría en
+      // `KernelStoreContextError` y ningún producto llegaba a registrarse.
+      const contextProjectId = resolveContextProjectId(resolved);
+      if (contextProjectId) bootDeps.contextProjectId = contextProjectId;
+      // Cableado de persistencia. Se propaga SÓLO si el caller lo inyectó: con el
+      // flag OFF no hace falta y con el flag ON su ausencia la corta el write path
+      // (jamás escribe a un store efímero creyendo que persistió).
+      if (deps.storeDriver) bootDeps.storeDriver = deps.storeDriver;
+      if (typeof deps.createStore === 'function') bootDeps.createStore = deps.createStore;
+      if (typeof deps.kernelDurable === 'boolean') bootDeps.kernelDurable = deps.kernelDurable;
+      if (deps.kernelConfig && typeof deps.kernelConfig === 'object') bootDeps.kernelConfig = deps.kernelConfig;
+      if (typeof deps.onAlert === 'function') bootDeps.onAlert = deps.onAlert;
+      boot = await runBootstrap({
         descriptor: resolved,
         mode: 'full',
         registerMeta: { repoOrigin, repos: repos.map((r) => r && r.url).filter(Boolean) },
@@ -305,8 +350,14 @@ function createProductControlDrain(deps = {}) {
    * Drena la cola una vez: procesa cada `*.json` de `queueDir`, mueve el pedido a
    * `doneDir` con el resultado anexado. Aislado: un pedido corrupto no frena a los
    * demás. Devuelve el resumen `{ processed, results }`.
+   *
+   * ASÍNCRONA desde #5204 (arrastre de `processOnboard`, que puede tomar el write
+   * path durable). El lifecycle de archivos no cambió: se procesa y se mueve uno
+   * por uno, en orden, sin concurrencia.
+   *
+   * @returns {Promise<{processed:number, results:Array}>}
    */
-  function drainOnce() {
+  async function drainOnce() {
     let names = [];
     try {
       names = _fs.readdirSync(queueDir).filter((n) => n.endsWith('.json'));
@@ -336,7 +387,7 @@ function createProductControlDrain(deps = {}) {
       }
       let res;
       try {
-        res = processOnboard(request);
+        res = await processOnboard(request);
       } catch (err) {
         res = { ok: false, stage: 'exception', reason: err.message };
         onAlert({ stage: 'drain-exception', errors: [{ detail: err.message }] });
@@ -398,7 +449,11 @@ module.exports = {
 // -----------------------------------------------------------------------------
 if (require.main === module) {
   const drain = createProductControlDrain({ log: (m) => process.stdout.write(m + '\n') });
-  const summary = drain.drainOnce();
-  process.stdout.write(JSON.stringify({ processed: summary.processed, ok: summary.results.filter((r) => r.ok).length }, null, 2) + '\n');
-  process.exit(0);
+  drain.drainOnce().then((summary) => {
+    process.stdout.write(JSON.stringify({ processed: summary.processed, ok: summary.results.filter((r) => r.ok).length }, null, 2) + '\n');
+    process.exit(0);
+  }).catch((e) => {
+    process.stderr.write(`error inesperado drenando la cola: ${e && e.message ? e.message : e}\n`);
+    process.exit(1);
+  });
 }

--- a/.pipeline/lib/project-bootstrap.js
+++ b/.pipeline/lib/project-bootstrap.js
@@ -22,6 +22,9 @@ const path = require('node:path');
 const { execFileSync } = require('node:child_process');
 
 const descriptorLib = require('./project-descriptor');
+// #5204 — partición del control-plane (catálogo global que enumera el boot). Se
+// toma de la MISMA autoridad que decide los ids reservados: nunca un literal local.
+const { CONTROL_PLANE_PROJECT_ID } = descriptorLib;
 
 // -----------------------------------------------------------------------------
 // SSRF (CA-D3 · requisito de seguridad #4). `repositories[].url` y `board.ref`
@@ -343,6 +346,24 @@ function sanitizeOperatorError(err) {
 // CA-9 (anti tenant-hopping): `contextProjectId` DEBE derivar de la credencial de
 // la instancia (inyectado por el caller), NUNCA del descriptor/request del wizard.
 // El store valida `item.projectId === contextProjectId` como defensa en profundidad.
+//
+// #5204 — DOS PARTICIONES, NO UNA. El alta escribe TRES entidades y NO todas viven
+// en el mismo namespace:
+//
+//   `product#<id>` + `catalog#index` → partición del CONTROL-PLANE. Es el índice
+//       GLOBAL que enumera `kernel-supervisor.bootProducts()` vía su `catalogStore`
+//       (construido con `CONTROL_PLANE_PROJECT_ID`). Escribirlos en la partición
+//       del tenant los volvía INVISIBLES para el boot: `listProducts()` devolvía
+//       `[]` y no se instanciaba ningún pipeline (defecto (b) del issue).
+//   `descriptor#self` → partición del TENANT. Es el estado propio del producto y
+//       el boot lo lee por instancia (`ctx.store.getDescriptor`), ligado al
+//       `contextProjectId` de ESE tenant. Ahí se queda.
+//
+// El aislamiento por tenant NO se relaja: el descriptor se sigue escribiendo con un
+// store ligado al `contextProjectId` de la credencial, y `putDescriptor` reejecuta
+// `assertSameProject`. Además este write path exige explícitamente que el contexto
+// coincida con la identidad del descriptor ANTES de tocar el control-plane, de modo
+// que un contexto ajeno no puede inyectar entradas en el catálogo global.
 // -----------------------------------------------------------------------------
 async function durableRegisterProduct(entry, descriptor, deps = {}) {
   // CA-9: el contexto de tenant proviene de la credencial de la instancia, no del
@@ -351,16 +372,46 @@ async function durableRegisterProduct(entry, descriptor, deps = {}) {
   if (!contextProjectId) {
     throw new KernelStoreContextError('contextProjectId ausente: debe derivar de la credencial de la instancia (CA-9), nunca del descriptor');
   }
+  // #5204 · A01 — el control-plane NO es un tenant: nadie da de alta un producto
+  // "dentro" de la partición del kernel. Se corta antes de construir ningún store.
+  if (descriptorLib.isReservedProjectId(contextProjectId)) {
+    throw new KernelStoreContextError('contextProjectId reservado: la partición del control-plane no puede darse de alta como producto');
+  }
+  // #5204 · CA-9 explícito en el write path. El store ya rechaza escribir la
+  // partición de otro (`assertSameProject`), pero esa defensa recién actúa en
+  // `putDescriptor` — y el catálogo GLOBAL se escribe antes. Sin este corte, un
+  // contexto que no es el del producto podía dejar una entrada en el catálogo del
+  // control-plane y recién después fallar. Se valida ANTES de cualquier escritura.
+  const descriptorProjectId = descriptor && descriptor.identity && descriptor.identity.projectId;
+  if (descriptorProjectId !== contextProjectId) {
+    throw new KernelStoreContextError('contextProjectId no coincide con la identidad del descriptor (anti tenant-hopping · CA-9)');
+  }
+  if (entry && entry.projectId !== contextProjectId) {
+    throw new KernelStoreContextError('el producto a registrar no pertenece al contexto de la instancia (anti tenant-hopping · CA-9)');
+  }
+  // #5204 — sin cableado de persistencia real un alta "durable" escribiría a un
+  // store en memoria que muere con el proceso: alta OK para el operador, producto
+  // inexistente para el boot. Fail-closed antes que fail-silent.
+  if (typeof deps.createStore !== 'function' && !deps.storeDriver) {
+    throw new KernelStoreContextError('alta durable sin store inyectado: el caller debe proveer createStore o storeDriver');
+  }
   const kernelCfg = deps.kernelConfig || readKernelConfig(deps);
   const factory = typeof deps.createStore === 'function'
     ? deps.createStore
     : require('./kernel-store').createKernelStore;
-  const store = factory({
-    contextProjectId,
-    config: { kernel: { tableName: kernelCfg.tableName, region: kernelCfg.region } },
+  const storeConfig = { kernel: { tableName: kernelCfg.tableName, region: kernelCfg.region } };
+  const buildStore = (ctx, allowedNamespaces) => factory({
+    contextProjectId: ctx,
+    allowedNamespaces,
+    config: storeConfig,
     driver: deps.storeDriver,
     onAlert: deps.onAlert,
   });
+
+  // Partición del tenant: SÓLO el descriptor#self del producto.
+  const tenantStore = buildStore(contextProjectId);
+  // Partición del control-plane: producto + catálogo global (lo que lee el boot).
+  const controlStore = buildStore(CONTROL_PLANE_PROJECT_ID, [CONTROL_PLANE_PROJECT_ID]);
 
   // CA-10: validación explícita antes de persistir (además de la que reejecuta el
   // store). Fail-closed: si el descriptor no valida, no se escribe nada.
@@ -369,11 +420,25 @@ async function durableRegisterProduct(entry, descriptor, deps = {}) {
     throw new KernelStoreContextError(`descriptor inválido antes de persistir (CA-10): ${dres.stage}`);
   }
 
+  // Unicidad autoritativa (paridad con el camino FS, que rechaza `duplicate`): un
+  // alta NUNCA pisa el descriptor de un producto ya registrado.
+  const already = await tenantStore.getDescriptor(contextProjectId);
+  if (already) {
+    throw new KernelStoreContextError('el producto ya está registrado: el alta no sobreescribe su descriptor');
+  }
+
   // CA-3: producto + catálogo primero (atómico interno, orden fail-safe); el
   // descriptor#self se escribe al final para no dejar huérfanos indexados.
-  const put = await store.putProduct({ productId: entry.projectId, name: entry.name, status: 'onboarding' });
-  await store.putDescriptor(descriptor);
-  return { status: 'onboarding', durable: true, sk: put.sk, contextProjectId };
+  const put = await controlStore.putProduct({ productId: entry.projectId, name: entry.name, status: 'onboarding' });
+  await tenantStore.putDescriptor(descriptor);
+  return {
+    status: 'onboarding',
+    durable: true,
+    sk: put.sk,
+    contextProjectId,
+    // Partición donde quedó indexado el producto: la MISMA que enumera el boot.
+    catalogProjectId: CONTROL_PLANE_PROJECT_ID,
+  };
 }
 
 // Error interno del write path durable (no expone detalle al operador).

--- a/.pipeline/lib/project-descriptor.js
+++ b/.pipeline/lib/project-descriptor.js
@@ -112,7 +112,20 @@ function redactAjvErrors(ajvErrors) {
 // de workspace/estado (requisito #2 · A01).
 // -----------------------------------------------------------------------------
 const SAFE_ID_RE = /^[a-z0-9][a-z0-9-]{1,63}$/;
-const RESERVED_PROJECT_IDS = Object.freeze(new Set(['intrale-platform']));
+
+// #5204 — Partición del CONTROL-PLANE del kernel. No es un tenant: es el
+// namespace propio del kernel donde viven el catálogo (`catalog#index`) y los
+// ítems `product#<id>` que el boot (`bootProducts`) enumera. El descriptor de
+// cada producto sigue viviendo en la partición de SU tenant.
+//
+// Vive acá (y no en `kernel-store.js`) porque es la misma autoridad que decide
+// qué ids están reservados: si el control-plane no fuera reservado, un alta con
+// `identity.projectId = 'kernel-control-plane'` obtendría un store ligado a la
+// partición del kernel y podría reescribir el catálogo entero desde el camino
+// de tenant. Reservarlo cierra esa puerta en el único lugar donde ya se decide
+// la política de ids.
+const CONTROL_PLANE_PROJECT_ID = 'kernel-control-plane';
+const RESERVED_PROJECT_IDS = Object.freeze(new Set(['intrale-platform', CONTROL_PLANE_PROJECT_ID]));
 
 function isSafeId(id) {
   if (typeof id !== 'string') return false;
@@ -828,6 +841,7 @@ module.exports = {
   canonicalize,
   isSafeId,
   RESERVED_PROJECT_IDS,
+  CONTROL_PLANE_PROJECT_ID,
   isReservedProjectId,
   isSafeWorktreePath,
   collectPathTraversalHits,

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -18197,12 +18197,16 @@ async function mainLoop() {
   try {
     const cfg = loadConfig();
     if (cfg && cfg.kernel && cfg.kernel.durable === true) {
+      // Require LAZY (igual que el resto del bloque): con `durable:false` no se
+      // carga Ajv ni el schema del store. Se sube acá porque la constante de
+      // partición del control-plane la necesitan el catálogo Y el log.
+      const kernelStoreLib = require('./lib/kernel-store');
       // Constructor LAZY del store durable: sólo se instancia con el flag ON, de
       // modo que con `durable:false` NO se construye ningún driver ni se toca AWS.
       const buildDurableStore = (contextProjectId, allowedNamespaces, onAlert) => {
         const { createAwsCliRunner, createAwsCliDynamoDriver } = require('./lib/provisioner-infra');
         const { buildAwsScopedEnv } = require('./lib/kernel-provision');
-        const { createKernelStore } = require('./lib/kernel-store');
+        const { createKernelStore } = kernelStoreLib;
         const env = buildAwsScopedEnv(process.env, cfg.kernel.region);
         const { run } = createAwsCliRunner(env);
         const driver = createAwsCliDynamoDriver({ run });
@@ -18279,7 +18283,14 @@ async function mainLoop() {
         },
         // Catálogo del control-plane: `listProducts()` lee el índice global (no una
         // partición de tenant), por eso usa un contextProjectId dedicado y seguro.
-        buildCatalogStore: () => buildDurableStore('kernel-control-plane', ['kernel-control-plane']),
+        // #5204 — la partición sale de la CONSTANTE compartida, nunca de un literal:
+        // el alta durable (`durableRegisterProduct`) escribe `product#`/`catalog#index`
+        // en esta misma partición. Cuando eran dos literales distintos, el catálogo se
+        // escribía en la partición del tenant y el boot lo leía acá: invisible.
+        buildCatalogStore: () => buildDurableStore(
+          kernelStoreLib.CONTROL_PLANE_PROJECT_ID,
+          [kernelStoreLib.CONTROL_PLANE_PROJECT_ID],
+        ),
         // Store por instancia: MISMO driver durable ligado a cada tenant con su
         // propio `projectId` derivado del registro (A01 — nunca en banda).
         buildStoreFactory: () => (o) => buildDurableStore(o.contextProjectId, o.allowedNamespaces, o.onAlert),

--- a/docs/pipeline/runbook-cutover-durable.md
+++ b/docs/pipeline/runbook-cutover-durable.md
@@ -33,9 +33,10 @@ Un concepto, un identificador literal, un término en criollo. Sin sinónimos.
 | `kernel.cutover_window` | *la ventana de cutover* | Clave que declara la ventana de mantenimiento del cutover. **Todavía no existe** (la crea #5135). |
 | `kernel.tableName` | *la tabla de no-repudio* | Tabla con `descriptor#self`, `product#<id>`, `catalog#index`, `signature#` y `audit#`. |
 | `kernel.coordinationTableName` | *la tabla de coordinación* | Segunda tabla, donde viven los `claim#` desde #5124. Es la única que admite `DeleteItem`. |
-| `descriptor#self` | *el descriptor propio* | SK fija: **uno solo por partición de proyecto**. |
-| `product#<id>` | *el producto* | Uno por producto registrado. Relación **1:N** con los archivos de `.pipeline/descriptors/`. |
-| `catalog#index` | *el índice del catálogo* | SK fija y única. |
+| `descriptor#self` | *el descriptor propio* | SK fija: **uno solo por partición de proyecto**. Vive en la **partición del tenant**. |
+| `product#<id>` | *el producto* | Uno por producto registrado. Relación **1:N** con los archivos de `.pipeline/descriptors/`. Vive en la **partición del control-plane**. |
+| `catalog#index` | *el índice del catálogo* | SK fija y única. Vive en la **partición del control-plane**. |
+| `kernel-control-plane` | *la partición del control-plane* | PK reservada del kernel (no es un tenant). Ahí viven `product#<id>` y `catalog#index`: es **la única partición que enumera el boot**. |
 | `durableRegisterProduct` | *el poblador* | Función de `.pipeline/lib/project-bootstrap.js` (#4821). Es lo único que puebla descriptores y catálogo. |
 | *fuentes de coordinación* | — | Los 4 JSON operativos: `waves.json`, `blocked-issues.json`, `blocked-by-infra.json`, `infra-health.json`. |
 


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 8 archivos · +497 -48

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:passed` aplicado por delivery

## Closes

Closes #5204
