### PR TITLE
[BUG] Telegram reenvia el mismo audio varias veces: el sweep de voz reencola partes que todavia estan en vuelo

### DIFF
--- a/.pipeline/config.yaml
+++ b/.pipeline/config.yaml
@@ -1006,6 +1006,30 @@ telegram_outbound:
   sweep_stagger_ms: 3000    # Escalonado entre fallidos reencolados por el barredor — SEC-3
 
 # =============================================================================
+# #5573 — Política de reenvío de PARTES DE AUDIO (sweep de chunks TTS, #4750)
+# =============================================================================
+# SEPARADA de `telegram_outbound` (texto) a propósito. La latencia real de
+# entrega de un `.ogg` medida en producción es ~62-74s (upload multipart +
+# procesamiento serial de la cola + sleep anti rate-limit de 1200ms por
+# adjunto), contra los 5s de base que usa el texto. Reusar la política de texto
+# es lo que produjo el bug: reenvíos disparados sobre envíos todavía en vuelo →
+# el operador recibía el mismo audio 2-4 veces, y cada reenvío alargaba la cola
+# de las partes que faltaban (bola de nieve).
+#
+# `backoff_base_ms` es PROVISIONAL: se recalibra con el p50/p95 real que emite
+# `audit/telegram-voice-delivery.jsonl`. No es una constante mágica.
+#
+# Valores fuera de rango caen al default — nunca rompen el sweep.
+telegram_voice_outbound:
+  max_retries: 3            # Menos agresivo que texto: cada reenvío alarga la cola
+  backoff_base_ms: 150000   # 2.5 min > p95 observado (~74s), con margen bajo carga
+  backoff_max_ms: 900000    # Tope del backoff por intento (15 min)
+  stale_ttl_ms: 86400000    # TTL de descarte del estado de contabilidad (24h)
+  in_flight_max_ms: 600000  # SEC-A: techo absoluto de la supresión por "en vuelo" (10 min).
+                            # Sin este techo, un job atascado en trabajando/ suprimiría
+                            # el reenvío para siempre → hueco silencioso (rompe #4750).
+
+# =============================================================================
 # Notificación de entregables del pipeline (#3414)
 # =============================================================================
 # Cuando un skill notificable (guru, po, ux, planner) cierra una fase del

--- a/.pipeline/lib/__tests__/fixtures/config-snapshot-pre-particion.json
+++ b/.pipeline/lib/__tests__/fixtures/config-snapshot-pre-particion.json
@@ -1,7 +1,7 @@
 {
   "_doc": "#5174 · CA-2 — snapshot REDACTADO (path -> tipo, NUNCA el valor) de la configuracion resuelta ANTES de partir config.yaml en kernel + producto. Generado desde .pipeline/config.yaml en el commit 14a454441 (entrega B, pre-particion). Sirve para demostrar que la particion no perdio ni cambio ninguna clave. Si un cambio LEGITIMO agrega o quita una clave top-level, regenerar con: node .pipeline/lib/__tests__/fixtures/regen-config-snapshot.js",
-  "_generadoDesde": "1d1ca5493",
-  "_claves": 445,
+  "_generadoDesde": "4fb73f62d",
+  "_claves": 451,
   "snapshot": [
     "admission_gate: object(3)",
     "admission_gate.bootstrap_cap: number",
@@ -393,6 +393,12 @@
     "telegram_outbound.max_retries: number",
     "telegram_outbound.stale_ttl_ms: number",
     "telegram_outbound.sweep_stagger_ms: number",
+    "telegram_voice_outbound: object(5)",
+    "telegram_voice_outbound.backoff_base_ms: number",
+    "telegram_voice_outbound.backoff_max_ms: number",
+    "telegram_voice_outbound.in_flight_max_ms: number",
+    "telegram_voice_outbound.max_retries: number",
+    "telegram_voice_outbound.stale_ttl_ms: number",
     "timeouts: object(5)",
     "timeouts.agent_timeout_default_minutes: number",
     "timeouts.agent_timeout_overrides: object(9)",

--- a/.pipeline/lib/__tests__/reconcile-voice-chunks.test.js
+++ b/.pipeline/lib/__tests__/reconcile-voice-chunks.test.js
@@ -170,3 +170,158 @@ test('planSweep: estado stale se fuerza terminal y avisa', () => {
   assert.ok(plan.notify, 'avisa la parte faltante');
   assert.deepEqual(plan.notify.partNumbers, [1]);
 });
+
+// =============================================================================
+// #5573 — Señal EN VUELO: no reencolar una parte cuyo envío sigue en la cola.
+//
+// El bug: `planSweep` usaba la política de reintentos de TEXTO (backoff base 5s)
+// contra una latencia real de entrega de `.ogg` de ~62-74s, y no distinguía
+// "todavía en la cola de svc-telegram" de "perdido". Resultado: reenvíos sobre
+// envíos en vuelo → el operador recibía el mismo audio 2-4 veces.
+// =============================================================================
+
+// Política de voz para los tests (espeja `telegram_voice_outbound` de config.yaml).
+const VOICE_CFG = {
+  max_retries: 3,
+  backoff_base_ms: 150000,
+  backoff_max_ms: 900000,
+  stale_ttl_ms: 86400000,
+  in_flight_max_ms: 600000,
+};
+
+const T0 = 1700000000000;
+
+test('#5573 CA-5: parte en vuelo NO se reencola aunque venza el backoff', () => {
+  const s = vp.buildInitialState({
+    correlationId: 'voice-if1-abcdef', partTotal: 2, chatId: 7,
+    parts: [{ partIndex: 0, path: '/a.ogg' }, { partIndex: 1, path: '/b.ogg' }],
+    now: T0,
+  });
+  s.parts['0'].confirmed = true; // la 0 ya llegó; la 1 sigue viajando
+
+  const plan = vp.planSweep(s, {
+    now: T0 + 30000,          // 30s: con la política de TEXTO (base 5s) el backoff ya venció
+    maxRetries: 3,
+    backoffBaseMs: 5000,      // ← la política VIEJA, la que producía el duplicado
+    backoffMaxMs: 300000,
+    staleTtlMs: 86400000,
+    inFlight: new Set([1]),   // ← la señal nueva: el dropfile sigue vivo en la cola
+    inFlightMaxMs: VOICE_CFG.in_flight_max_ms,
+  });
+
+  assert.deepEqual(plan.resends, [], 'una parte en vuelo NO se reenvía');
+  assert.equal(plan.terminal, false, 'el estado sigue abierto esperando la confirmación');
+  assert.equal(plan.notify, null, 'no avisa faltante prematuramente');
+  // Invariantes: una parte en vuelo no puede ensuciar el backoff ni la métrica.
+  assert.equal(plan.state.parts['1'].retries, 0, 'no incrementa retries');
+  assert.equal(plan.state.parts['1'].enqueuedAt, s.parts['1'].enqueuedAt, 'no pisa enqueuedAt');
+  assert.equal(plan.state.parts['1'].firstEnqueuedAt, s.parts['1'].firstEnqueuedAt,
+    'firstEnqueuedAt es el ancla inmutable de la latencia');
+});
+
+test('#5573: sin la señal de en-vuelo el mismo caso SI reencola (el fix es el que corta)', () => {
+  const s = vp.buildInitialState({
+    correlationId: 'voice-if2-abcdef', partTotal: 2, chatId: 7,
+    parts: [{ partIndex: 0, path: '/a.ogg' }, { partIndex: 1, path: '/b.ogg' }],
+    now: T0,
+  });
+  s.parts['0'].confirmed = true;
+  // Misma llamada que el test anterior pero sin `inFlight` = comportamiento previo.
+  const plan = vp.planSweep(s, {
+    now: T0 + 30000, maxRetries: 3, backoffBaseMs: 5000, backoffMaxMs: 300000, staleTtlMs: 86400000,
+  });
+  assert.equal(plan.resends.length, 1, 'la política vieja reenvía a los 30s → duplicado');
+  assert.equal(plan.resends[0].partIndex, 1);
+});
+
+test('#5573 CA-3: parte fuera de la cola y sin recibo SI se reencola (no se debilita #4750)', () => {
+  const s = vp.buildInitialState({
+    correlationId: 'voice-if3-abcdef', partTotal: 2, chatId: 7,
+    parts: [{ partIndex: 0, path: '/a.ogg' }, { partIndex: 1, path: '/b.ogg' }],
+    now: T0,
+  });
+  s.parts['0'].confirmed = true;
+
+  const plan = vp.planSweep(s, {
+    now: T0 + VOICE_CFG.backoff_base_ms + 1, // backoff de VOZ vencido
+    maxRetries: VOICE_CFG.max_retries,
+    backoffBaseMs: VOICE_CFG.backoff_base_ms,
+    backoffMaxMs: VOICE_CFG.backoff_max_ms,
+    staleTtlMs: VOICE_CFG.stale_ttl_ms,
+    inFlight: new Set(),                     // el job ya no está en la cola: pérdida real
+    inFlightMaxMs: VOICE_CFG.in_flight_max_ms,
+  });
+  assert.equal(plan.resends.length, 1, 'pérdida real → reenvío');
+  assert.equal(plan.resends[0].partIndex, 1);
+  assert.equal(plan.state.parts['1'].retries, 1);
+});
+
+test('#5573 SEC-A: parte en vuelo mas alla del techo absoluto se reencola igual', () => {
+  const s = vp.buildInitialState({
+    correlationId: 'voice-if4-abcdef', partTotal: 1, chatId: 7,
+    parts: [{ partIndex: 0, path: '/a.ogg' }], now: T0,
+  });
+  // Un job atascado en trabajando/ (nada lo barre con el servicio vivo:
+  // recoverOrphans corre SOLO al boot) no puede suprimir la entrega para siempre.
+  const plan = vp.planSweep(s, {
+    now: T0 + 11 * 60000, // 11 min > in_flight_max_ms (10 min)
+    maxRetries: VOICE_CFG.max_retries,
+    backoffBaseMs: VOICE_CFG.backoff_base_ms,
+    backoffMaxMs: VOICE_CFG.backoff_max_ms,
+    staleTtlMs: VOICE_CFG.stale_ttl_ms,
+    inFlight: new Set([0]),                    // sigue "en vuelo"…
+    inFlightMaxMs: VOICE_CFG.in_flight_max_ms, // …pero venció el techo
+  });
+  assert.equal(plan.resends.length, 1, 'el techo absoluto vence a la señal de en-vuelo');
+  assert.equal(plan.resends[0].partIndex, 0);
+});
+
+test('#5573 R10: estado sin firstEnqueuedAt (pre-fix) cae a enqueuedAt para el techo', () => {
+  const s = vp.buildInitialState({
+    correlationId: 'voice-if5-abcdef', partTotal: 1, chatId: 7,
+    parts: [{ partIndex: 0, path: '/a.ogg' }], now: T0,
+  });
+  delete s.parts['0'].firstEnqueuedAt; // estado escrito por la versión anterior
+  assert.equal(vp.isValidState(s), true, 'un estado viejo NO se invalida (iría a cuarentena)');
+
+  // Dentro del techo → sigue suprimido.
+  const dentro = vp.planSweep(s, {
+    now: T0 + 60000, maxRetries: 3, backoffBaseMs: 5000, backoffMaxMs: 300000,
+    staleTtlMs: 86400000, inFlight: new Set([0]), inFlightMaxMs: 600000,
+  });
+  assert.deepEqual(dentro.resends, [], 'fallback a enqueuedAt: todavía dentro del techo');
+
+  // Pasado el techo → se reenvía igual.
+  const fuera = vp.planSweep(s, {
+    now: T0 + 11 * 60000, maxRetries: 3, backoffBaseMs: 5000, backoffMaxMs: 300000,
+    staleTtlMs: 86400000, inFlight: new Set([0]), inFlightMaxMs: 600000,
+  });
+  assert.equal(fuera.resends.length, 1, 'fallback a enqueuedAt: techo vencido → reenvío');
+});
+
+test('#5573 Gherkin: 3 audios a ~70s de latencia real → ninguna parte se reencola (retries 0)', () => {
+  let s = vp.buildInitialState({
+    correlationId: 'voice-if6-abcdef', partTotal: 3, chatId: 7,
+    parts: [{ partIndex: 0, path: '/a.ogg' }, { partIndex: 1, path: '/b.ogg' }, { partIndex: 2, path: '/c.ogg' }],
+    now: T0,
+  });
+  // El sweep corre cada 10s mientras las 3 partes están en vuelo; confirman a los ~70s.
+  const inFlight = new Set([0, 1, 2]);
+  for (let t = 10000; t <= 70000; t += 10000) {
+    const plan = vp.planSweep(s, {
+      now: T0 + t,
+      maxRetries: VOICE_CFG.max_retries,
+      backoffBaseMs: VOICE_CFG.backoff_base_ms,
+      backoffMaxMs: VOICE_CFG.backoff_max_ms,
+      staleTtlMs: VOICE_CFG.stale_ttl_ms,
+      inFlight,
+      inFlightMaxMs: VOICE_CFG.in_flight_max_ms,
+    });
+    assert.deepEqual(plan.resends, [], `tick ${t / 1000}s: sin reenvíos`);
+    assert.equal(plan.terminal, false, `tick ${t / 1000}s: estado abierto`);
+    s = plan.state;
+  }
+  for (const i of ['0', '1', '2']) {
+    assert.equal(s.parts[i].retries, 0, `la parte ${i} llega con retries 0 (el operador recibe 1 audio)`);
+  }
+});

--- a/.pipeline/lib/__tests__/voice-inflight-5573.test.js
+++ b/.pipeline/lib/__tests__/voice-inflight-5573.test.js
@@ -1,0 +1,234 @@
+// =============================================================================
+// Tests de la señal "EN VUELO" del sweep de audio (#5573)
+//
+// BUG QUE CUBREN
+//
+// El sweep de chunks de voz (#4750) sólo miraba el reloj: "hace más de
+// `backoff` que encolé esta parte y no confirmó ⇒ se perdió, la reenvío". Con la
+// política de TEXTO (base 5s → 5/10/20s) contra la latencia real de entrega de un
+// `.ogg` (~62-74s medidos en producción), el sweep disparaba reenvíos mientras el
+// envío ORIGINAL seguía en la cola de `svc-telegram`. El operador recibía el
+// mismo audio 2-4 veces, y cada reenvío alargaba la cola de las partes que
+// faltaban (bola de nieve).
+//
+// El fix agrega una señal empírica: `scanInFlightParts` mira qué dropfiles de
+// audio siguen vivos en `pendiente/` ∪ `trabajando/` y `planSweep` no reencola
+// esas partes. Estos tests cubren el lado con I/O (el lado puro de `planSweep`
+// vive en `reconcile-voice-chunks.test.js`).
+//
+// Sin red, sin credenciales: `fs` temporal con `mkdtempSync`.
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const vp = require('../voice-parts');
+
+function sandbox() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'voice-inflight-'));
+}
+
+function queueDir(root, sub) {
+  const d = path.join(root, 'servicios', 'telegram', sub);
+  fs.mkdirSync(d, { recursive: true });
+  return d;
+}
+
+// Escribe un dropfile de voz con el nombre REAL que produce `enqueueTelegramVoice`
+// (`<epochMs>-voice-<correlationId>-p<idx>.json`): el nombre es lo único que
+// `scanInFlightParts` lee, para no parsear N JSON por tick.
+function dropVoice(dir, correlationId, partIndex, ts = 1700000000000) {
+  const name = `${ts}-voice-${correlationId}-p${partIndex}.json`;
+  fs.writeFileSync(path.join(dir, name), JSON.stringify({
+    voice: '/tmp/tts.ogg',
+    _correlationId: correlationId,
+    _partIndex: partIndex,
+    _partTotal: 2,
+  }));
+  return name;
+}
+
+const CID = 'voice-1785927634994-c0d2aa07'; // formato real de generateCorrelationId('voice')
+
+// -----------------------------------------------------------------------------
+// scanInFlightParts
+// -----------------------------------------------------------------------------
+test('#5573 scanInFlightParts detecta dropfiles en pendiente y en trabajando', () => {
+  const root = sandbox();
+  dropVoice(queueDir(root, 'pendiente'), CID, 0);
+  dropVoice(queueDir(root, 'trabajando'), CID, 1); // ya tomado por el consumidor
+
+  const map = vp.scanInFlightParts({ pipelineDir: root });
+  assert.ok(map.has(CID), 'el correlationId aparece en el mapa');
+  assert.deepEqual([...map.get(CID)].sort(), [0, 1],
+    'ambas colas cuentan como "en vuelo": el job existe, no se perdió');
+});
+
+test('#5573 CA-3 scanInFlightParts IGNORA fallido/ (es pérdida real, debe reenviarse)', () => {
+  const root = sandbox();
+  queueDir(root, 'pendiente');
+  queueDir(root, 'trabajando');
+  dropVoice(queueDir(root, 'fallido'), CID, 0);
+
+  const map = vp.scanInFlightParts({ pipelineDir: root });
+  assert.equal(map.size, 0,
+    'fallido/ es terminal hasta el barredor de boot: NO suprime el reenvío');
+});
+
+test('#5573 R3/SEC-B scanInFlightParts ignora un dropfile con correlationId invalido', () => {
+  const root = sandbox();
+  const pend = queueDir(root, 'pendiente');
+  // `pendiente/` es un bus con muchos escritores: un dropfile forjado no puede
+  // suprimir la entrega de una respuesta en vuelo. El nombre nunca es fuente de
+  // verdad — se valida con la misma regex del bus de recibos.
+  fs.writeFileSync(path.join(pend, '1700000000000-voice-../../etc-p0.json'.replace(/\//g, '_')), '{}');
+  fs.writeFileSync(path.join(pend, '1700000000000-voice-ab-p0.json'), '{}');        // cid corto (<6)
+  fs.writeFileSync(path.join(pend, '1700000000000-voice-con espacio!-p0.json'), '{}'); // chars fuera de la regex
+  dropVoice(pend, CID, 0); // este sí es válido
+
+  const map = vp.scanInFlightParts({ pipelineDir: root });
+  assert.deepEqual([...map.keys()], [CID], 'sólo entra el correlationId válido');
+  assert.deepEqual([...map.get(CID)], [0]);
+});
+
+test('#5573 scanInFlightParts ignora dropfiles de texto y de formato legacy', () => {
+  const root = sandbox();
+  const pend = queueDir(root, 'pendiente');
+  fs.writeFileSync(path.join(pend, '1700000000000-cmd.json'), '{}');       // texto
+  fs.writeFileSync(path.join(pend, '1700000000000-voice-p0.json'), '{}');  // legacy pre-#5573, sin cid
+
+  const map = vp.scanInFlightParts({ pipelineDir: root });
+  assert.equal(map.size, 0,
+    'un dropfile que no matchea degrada al comportamiento previo (a lo sumo un duplicado), nunca a supresión');
+});
+
+test('#5573 R2/SEC-C scanInFlightParts devuelve vacio si el directorio no existe', () => {
+  const root = sandbox(); // sin servicios/telegram/
+  const map = vp.scanInFlightParts({ pipelineDir: root });
+  assert.equal(map.size, 0,
+    'un error de I/O NO cuenta como "en vuelo": fail-open a la entrega, nunca hueco silencioso');
+});
+
+test('#5573 R4 scanInFlightParts ve el job aunque se mueva de cola durante el escaneo', () => {
+  const root = sandbox();
+  const pend = queueDir(root, 'pendiente');
+  const trab = queueDir(root, 'trabajando');
+  const name = dropVoice(pend, CID, 0);
+
+  // Simula el race real: el consumidor mueve pendiente/ → trabajando/ justo entre
+  // la 1ra y la 2da lectura. El escaneo hace la unión de TRES lecturas
+  // (pendiente → trabajando → pendiente), así que el archivo cae en al menos una.
+  const realReaddir = fs.readdirSync;
+  let calls = 0;
+  fs.readdirSync = function patched(dir, ...rest) {
+    calls += 1;
+    if (calls === 1) {
+      // 1ra lectura (pendiente): el archivo todavía no se movió → devuelve vacío
+      // como si el move hubiese ocurrido un instante antes.
+      try { fs.renameSync(path.join(pend, name), path.join(trab, name)); } catch { /* ya movido */ }
+      return [];
+    }
+    return realReaddir.call(fs, dir, ...rest);
+  };
+  let map;
+  try {
+    map = vp.scanInFlightParts({ pipelineDir: root });
+  } finally {
+    fs.readdirSync = realReaddir;
+  }
+  assert.ok(map.has(CID), 'la 2da lectura (trabajando) lo encuentra: no hay falso "perdido"');
+  assert.deepEqual([...map.get(CID)], [0]);
+});
+
+// -----------------------------------------------------------------------------
+// sweepVoiceStates — integración: estado en disco + cola real + enqueue inyectado
+// -----------------------------------------------------------------------------
+const VOICE_CFG = {
+  max_retries: 3,
+  backoff_base_ms: 150000,
+  backoff_max_ms: 900000,
+  stale_ttl_ms: 86400000,
+  in_flight_max_ms: 600000,
+};
+
+test('#5573 CA-2 sweepVoiceStates NO reencola cuando la parte sigue en la cola', () => {
+  const root = sandbox();
+  const T0 = 1700000000000;
+  vp.initState({
+    pipelineDir: root, correlationId: CID, partTotal: 2, chatId: 42,
+    parts: [{ partIndex: 0, path: '/a.ogg' }, { partIndex: 1, path: '/b.ogg' }],
+    now: T0,
+  });
+  // Las 2 partes siguen vivas en la cola.
+  const pend = queueDir(root, 'pendiente');
+  dropVoice(pend, CID, 0);
+  dropVoice(pend, CID, 1);
+
+  const resends = [];
+  // `now` muy pasado el backoff de voz: sin la señal de en-vuelo esto reenviaría.
+  const res = vp.sweepVoiceStates({
+    pipelineDir: root, now: T0 + 300000, config: VOICE_CFG,
+    enqueue: (a) => resends.push(a), notify: () => {},
+  });
+
+  assert.equal(resends.length, 0, 'ninguna parte en vuelo se reencola');
+  assert.equal(res.resent, 0);
+  assert.equal(res.closed, 0, 'el estado sigue abierto esperando confirmación');
+
+  const st = vp.readState(vp.voicePartsDir(root), CID);
+  assert.equal(st.parts['0'].retries, 0, 'no ensucia retries');
+  assert.equal(st.parts['1'].retries, 0);
+});
+
+test('#5573 CA-3 sweepVoiceStates SI reencola cuando el dropfile ya no esta en la cola', () => {
+  const root = sandbox();
+  const T0 = 1700000000000;
+  vp.initState({
+    pipelineDir: root, correlationId: CID, partTotal: 2, chatId: 42,
+    parts: [{ partIndex: 0, path: '/a.ogg' }, { partIndex: 1, path: '/b.ogg' }],
+    now: T0,
+  });
+  const pend = queueDir(root, 'pendiente');
+  queueDir(root, 'trabajando');
+  dropVoice(pend, CID, 0); // sólo la parte 0 sigue viva; la 1 desapareció sin recibo
+
+  const resends = [];
+  vp.sweepVoiceStates({
+    pipelineDir: root, now: T0 + VOICE_CFG.backoff_base_ms + 1, config: VOICE_CFG,
+    enqueue: (a) => resends.push(a), notify: () => {},
+  });
+
+  assert.equal(resends.length, 1, 'la pérdida real se reenvía (garantía de #4750 intacta)');
+  assert.equal(resends[0].partIndex, 1);
+  assert.equal(resends[0].correlationId, CID);
+});
+
+test('#5573 sweepVoiceStates: la supresion es POR correlationId, no global', () => {
+  const root = sandbox();
+  const T0 = 1700000000000;
+  const OTRO = 'voice-1785927600000-deadbeef';
+  vp.initState({
+    pipelineDir: root, correlationId: CID, partTotal: 1, chatId: 42,
+    parts: [{ partIndex: 0, path: '/a.ogg' }], now: T0,
+  });
+  vp.initState({
+    pipelineDir: root, correlationId: OTRO, partTotal: 1, chatId: 42,
+    parts: [{ partIndex: 0, path: '/z.ogg' }], now: T0,
+  });
+  // Sólo la parte 0 de CID está en vuelo. La de OTRO se perdió.
+  dropVoice(queueDir(root, 'pendiente'), CID, 0);
+  queueDir(root, 'trabajando');
+
+  const resends = [];
+  vp.sweepVoiceStates({
+    pipelineDir: root, now: T0 + VOICE_CFG.backoff_base_ms + 1, config: VOICE_CFG,
+    enqueue: (a) => resends.push(a), notify: () => {},
+  });
+
+  assert.equal(resends.length, 1, 'un cid en vuelo no suprime el reenvío de otro');
+  assert.equal(resends[0].correlationId, OTRO);
+});

--- a/.pipeline/lib/__tests__/voice-outbound-policy-5573.test.js
+++ b/.pipeline/lib/__tests__/voice-outbound-policy-5573.test.js
@@ -1,0 +1,197 @@
+// =============================================================================
+// Tests de la política de reenvío PROPIA de voz + traza de entrega (#5573)
+//
+// CONTEXTO
+//
+// Hasta #5573 el sweep de chunks de audio reusaba `telegram_outbound` — la
+// política de TEXTO (backoff base 5s). La latencia real de entrega de un `.ogg`
+// es ~62-74s, así que el sweep reenviaba sobre envíos todavía en vuelo y el
+// operador recibía el mismo audio 2-4 veces. Estos tests fijan que la política de
+// voz existe, es independiente de la de texto, y clampea config rota.
+//
+// Además cubren `voice-delivery-audit.js`: la traza append-only que hace
+// DETECTABLE un duplicado (el recibo `<cid>-p<idx>.json` se sobrescribe, así que
+// antes los envíos intermedios eran invisibles) y que aporta la serie de latencia
+// con la que se recalibra el backoff.
+//
+// Sin red, sin credenciales.
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const yaml = require('js-yaml');
+
+const oc = require('../telegram-outbound-config');
+const audit = require('../voice-delivery-audit');
+
+function sandbox() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'voice-audit-'));
+}
+
+// -----------------------------------------------------------------------------
+// CA-4: política de voz configurable y separada de la de texto
+// -----------------------------------------------------------------------------
+test('#5573 CA-4: resolveVoiceOutboundConfig es INDEPENDIENTE de telegram_outbound', () => {
+  const cfg = {
+    telegram_outbound: { max_retries: 5, backoff_base_ms: 5000, backoff_max_ms: 300000 },
+    telegram_voice_outbound: { max_retries: 2, backoff_base_ms: 120000, in_flight_max_ms: 300000 },
+  };
+  const voz = oc.resolveVoiceOutboundConfig(cfg);
+  const texto = oc.resolveOutboundConfig(cfg);
+
+  assert.equal(voz.max_retries, 2, 'la voz lee su propia sección');
+  assert.equal(voz.backoff_base_ms, 120000);
+  assert.equal(voz.in_flight_max_ms, 300000);
+  assert.equal(texto.max_retries, 5, 'la cola de texto NO se ve afectada');
+  assert.equal(texto.backoff_base_ms, 5000);
+  assert.equal(texto.in_flight_max_ms, undefined, 'in_flight_max_ms es exclusivo de voz');
+});
+
+test('#5573: tocar telegram_outbound no altera la politica de voz (y viceversa)', () => {
+  const soloTexto = oc.resolveVoiceOutboundConfig({
+    telegram_outbound: { max_retries: 99, backoff_base_ms: 100 },
+  });
+  assert.deepEqual(soloTexto, oc.VOICE_OUTBOUND_DEFAULTS,
+    'sin sección de voz cae a los defaults de VOZ, nunca a los de texto');
+  assert.notEqual(soloTexto.backoff_base_ms, oc.OUTBOUND_DEFAULTS.backoff_base_ms,
+    'los defaults de voz y de texto son distintos a propósito (5s vs 2.5min)');
+});
+
+test('#5573: resolveVoiceOutboundConfig clampea valores invalidos al default', () => {
+  const casos = [
+    { telegram_voice_outbound: { max_retries: 0 } },              // fuera de rango (min 1)
+    { telegram_voice_outbound: { max_retries: 'muchos' } },       // no numérico
+    { telegram_voice_outbound: { backoff_base_ms: -1 } },
+    { telegram_voice_outbound: { in_flight_max_ms: 1 } },         // < 60000
+    { telegram_voice_outbound: { in_flight_max_ms: 99999999 } },  // > 3600000
+    { telegram_voice_outbound: null },
+    {},
+    null,
+  ];
+  for (const c of casos) {
+    const r = oc.resolveVoiceOutboundConfig(c);
+    assert.ok(Number.isFinite(r.max_retries) && r.max_retries >= 1, `max_retries sano: ${JSON.stringify(c)}`);
+    assert.ok(r.backoff_base_ms >= 1000, `backoff_base_ms sano: ${JSON.stringify(c)}`);
+    assert.ok(r.in_flight_max_ms >= 60000 && r.in_flight_max_ms <= 3600000,
+      `in_flight_max_ms acotado: ${JSON.stringify(c)}`);
+  }
+  // Config rota nunca deja el techo de supresión en un valor que produzca un
+  // hueco silencioso permanente ni un reenvío inmediato.
+  assert.equal(oc.resolveVoiceOutboundConfig({ telegram_voice_outbound: { in_flight_max_ms: 0 } }).in_flight_max_ms,
+    oc.VOICE_OUTBOUND_DEFAULTS.in_flight_max_ms);
+});
+
+test('#5573: el config.yaml REAL trae telegram_voice_outbound con backoff > latencia de un ogg', () => {
+  const raw = fs.readFileSync(path.join(__dirname, '..', '..', 'config.yaml'), 'utf8');
+  const cfg = yaml.load(raw);
+  assert.ok(cfg.telegram_voice_outbound, 'la sección existe en el config.yaml versionado');
+  const r = oc.resolveVoiceOutboundConfig(cfg);
+  // p95 observado en el incidente: ~74s. El backoff tiene que estar por encima o
+  // el sweep vuelve a reenviar sobre envíos en vuelo.
+  assert.ok(r.backoff_base_ms > 74000,
+    `backoff_base_ms (${r.backoff_base_ms}) debe superar la latencia real de un .ogg (~74s)`);
+  assert.ok(r.in_flight_max_ms >= 60000, 'el techo de supresión está configurado');
+  assert.notEqual(r.backoff_base_ms, oc.resolveOutboundConfig(cfg).backoff_base_ms,
+    'la política de voz NO es la de texto');
+});
+
+// -----------------------------------------------------------------------------
+// Traza append-only: duplicado detectable + latencia medible
+// -----------------------------------------------------------------------------
+const CID = 'voice-1785927634994-c0d2aa07';
+
+test('#5573 CA-3: dos eventos sent del mismo (cid, parte) hacen el duplicado DETECTABLE', () => {
+  const root = sandbox();
+  // El recibo se sobrescribe por parte; el JSONL no. Simulamos el incidente real:
+  // la parte 0 se envió 4 veces (original + 3 reenvíos), la 1 y la 2 una sola vez.
+  for (let attempt = 0; attempt < 4; attempt++) {
+    audit.appendVoiceDeliveryEvent(root, {
+      event: audit.EVENT_SENT, correlationId: CID, partIndex: 0, partTotal: 3,
+      messageId: 93990 + attempt, attempt,
+    });
+  }
+  audit.appendVoiceDeliveryEvent(root, {
+    event: audit.EVENT_SENT, correlationId: CID, partIndex: 1, partTotal: 3, messageId: 93996,
+  });
+
+  const events = audit.readVoiceDeliveryEvents(root);
+  assert.equal(events.length, 5, 'append-only: ninguna línea pisa a la anterior');
+
+  const dups = audit.findDuplicateSends(events);
+  assert.equal(dups.length, 1, 'sólo la parte 0 está duplicada');
+  assert.deepEqual(dups[0], { correlationId: CID, partIndex: 0, sends: 4 },
+    'los 4 envíos de la parte 0 quedan trazados (antes eran invisibles)');
+});
+
+test('#5573 cambio 4: los eventos confirmed dan p50/p95 de latencia real', () => {
+  const root = sandbox();
+  const muestras = [62000, 65000, 70000, 74000, 120000];
+  muestras.forEach((latencyMs, i) => {
+    audit.appendVoiceDeliveryEvent(root, {
+      event: audit.EVENT_CONFIRMED, correlationId: CID, partIndex: i, partTotal: muestras.length,
+      latencyMs, retries: 0,
+    });
+  });
+
+  const stats = audit.computeLatencyStats(audit.readVoiceDeliveryEvents(root));
+  assert.equal(stats.count, 5);
+  assert.equal(stats.p50, 70000);
+  assert.equal(stats.p95, 120000);
+  assert.equal(stats.max, 120000);
+  // Este es el dato con el que se recalibra `backoff_base_ms` (hoy provisional).
+});
+
+test('#5573 SEC-E: el evento sólo lleva IDs y timings, nunca contenido del chat', () => {
+  const ev = audit.buildEvent({
+    event: audit.EVENT_SENT, correlationId: CID, partIndex: 0, partTotal: 2, messageId: 1,
+    // Campos que un caller descuidado podría colar: deben quedar FUERA.
+    text: 'contenido secreto de la respuesta',
+    voicePath: 'C:/tmp/tts.ogg',
+    chatId: 12345,
+  });
+  assert.deepEqual(Object.keys(ev).sort(),
+    ['correlationId', 'event', 'messageId', 'partIndex', 'partTotal', 'ts'],
+    'whitelist estricta de campos');
+  assert.equal(ev.text, undefined);
+  assert.equal(ev.voicePath, undefined);
+  assert.equal(ev.chatId, undefined);
+});
+
+test('#5573: buildEvent es fail-closed ante datos invalidos (no ensucia la serie)', () => {
+  assert.equal(audit.buildEvent({ event: 'otro', correlationId: CID, partIndex: 0, partTotal: 1 }), null,
+    'evento fuera del vocabulario');
+  assert.equal(audit.buildEvent({ event: audit.EVENT_SENT, correlationId: '../etc', partIndex: 0, partTotal: 1 }), null,
+    'correlationId inválido (path-traversal)');
+  assert.equal(audit.buildEvent({ event: audit.EVENT_SENT, correlationId: CID, partIndex: -1, partTotal: 1 }), null,
+    'partIndex negativo');
+  assert.equal(audit.buildEvent({ event: audit.EVENT_SENT, correlationId: CID }), null,
+    'sin dims de parte');
+  // Latencia negativa (reloj corrido) se omite en vez de contaminar el p50/p95.
+  const ev = audit.buildEvent({
+    event: audit.EVENT_CONFIRMED, correlationId: CID, partIndex: 0, partTotal: 1, latencyMs: -5,
+  });
+  assert.ok(ev, 'el evento igual se emite');
+  assert.equal(ev.latencyMs, undefined, 'pero sin la muestra imposible');
+});
+
+test('#5573: auditar NUNCA rompe la entrega (directorio no escribible → false, no throw)', () => {
+  // pipelineDir inválido: el append falla y se traga el error.
+  assert.doesNotThrow(() => {
+    const ok = audit.appendVoiceDeliveryEvent('\0ruta-invalida', {
+      event: audit.EVENT_SENT, correlationId: CID, partIndex: 0, partTotal: 1,
+    });
+    assert.equal(ok, false);
+  });
+  assert.deepEqual(audit.readVoiceDeliveryEvents('\0ruta-invalida'), [],
+    'leer una traza inexistente devuelve vacío, no lanza');
+});
+
+test('#5573: computeLatencyStats y findDuplicateSends toleran series vacias o corruptas', () => {
+  assert.deepEqual(audit.computeLatencyStats([]), { count: 0, p50: null, p95: null, max: null });
+  assert.deepEqual(audit.computeLatencyStats(null), { count: 0, p50: null, p95: null, max: null });
+  assert.deepEqual(audit.findDuplicateSends([null, {}, { event: 'sent' }]), []);
+});

--- a/.pipeline/lib/config-schema.js
+++ b/.pipeline/lib/config-schema.js
@@ -211,6 +211,9 @@ const SIDE_MAP = Object.freeze({
     sherlock_wait_budget_ms: 'kernel',
     telegram_burst_window_ms: 'kernel',
     telegram_outbound: 'kernel',
+    // #5573 — política de reenvío de las PARTES DE AUDIO, separada de la de texto.
+    // Es mecanismo de entrega del canal, no producto → kernel.
+    telegram_voice_outbound: 'kernel',
     deliverable_notifications: 'kernel',
     'deliverable_notifications.skills': 'producto',       // whitelist de skills del producto
     'deliverable_notifications.attachments_per_skill': 'producto',
@@ -455,6 +458,10 @@ const SCHEMA = {
         telegram_burst_window_ms: { type: 'number', minimum: 0 },
 
         telegram_outbound: OBJ(),
+        // #5573 — la raíz está CERRADA: `telegram_voice_outbound` en config.yaml
+        // SIN esta declaración deja el pipeline arrancando pausado por
+        // ConfigSchemaViolation. Va en el MISMO commit que la sección nueva.
+        telegram_voice_outbound: OBJ(),
         deliverable_notifications: OBJ(),
         cua: OBJ(),
         kernel: OBJ(),

--- a/.pipeline/lib/telegram-outbound-config.js
+++ b/.pipeline/lib/telegram-outbound-config.js
@@ -42,4 +42,54 @@ function resolveOutboundConfig(rawPipelineConfig) {
   };
 }
 
-module.exports = { OUTBOUND_DEFAULTS, resolveOutboundConfig };
+// =============================================================================
+// #5573 — Política de reenvío de PARTES DE AUDIO, separada de la de texto.
+// =============================================================================
+//
+// Por qué separada: hasta #5573 el sweep de chunks de voz (#4750) reusaba
+// `resolveOutboundConfig` — la política de TEXTO. Pero la latencia real de
+// entrega de un `.ogg` medida en producción es de ~62-74s (upload multipart +
+// procesamiento serial de la cola + sleep anti rate-limit de 1200ms por
+// adjunto), contra los 5s de base del texto. Con backoff 5s→10s→20s el sweep
+// disparaba reenvíos sobre envíos TODAVÍA EN VUELO y el operador recibía el
+// mismo audio 2-4 veces. Peor: cada reenvío se encola en la MISMA cola,
+// alargando la latencia de las partes que faltan → bola de nieve.
+//
+// La cola de TEXTO no cambia: `resolveOutboundConfig` queda intacta.
+const VOICE_OUTBOUND_DEFAULTS = {
+  max_retries: 3,            // menos agresivo que texto: cada reenvío alarga la cola
+  backoff_base_ms: 150000,   // 2.5 min > p95 observado (~74s), con margen bajo carga
+  backoff_max_ms: 900000,    // 15 min
+  stale_ttl_ms: 86400000,    // 24h — igual que texto
+  in_flight_max_ms: 600000,  // SEC-A: techo de la supresión por "en vuelo" (10 min)
+};
+
+// resolveVoiceOutboundConfig — mismo patrón de clamping defensivo que
+// `resolveOutboundConfig`: valor inválido/ausente/fuera de rango → default.
+// Config rota nunca rompe el sweep.
+//
+// NOTA: `backoff_base_ms` es PROVISIONAL. Se recalibra con el p50/p95 real que
+// emite el JSONL de `lib/voice-delivery-audit.js`; no es una constante mágica.
+function resolveVoiceOutboundConfig(rawPipelineConfig) {
+  const cfg = (rawPipelineConfig || {}).telegram_voice_outbound || {};
+  const num = (v, def, min, max) => {
+    const n = Number(v);
+    if (!Number.isFinite(n) || n < min || n > max) return def;
+    return n;
+  };
+  return {
+    max_retries: num(cfg.max_retries, VOICE_OUTBOUND_DEFAULTS.max_retries, 1, 100),
+    backoff_base_ms: num(cfg.backoff_base_ms, VOICE_OUTBOUND_DEFAULTS.backoff_base_ms, 1000, 1800000),
+    backoff_max_ms: num(cfg.backoff_max_ms, VOICE_OUTBOUND_DEFAULTS.backoff_max_ms, 1000, 3600000),
+    stale_ttl_ms: num(cfg.stale_ttl_ms, VOICE_OUTBOUND_DEFAULTS.stale_ttl_ms, 60000, 30 * 86400000),
+    in_flight_max_ms: num(cfg.in_flight_max_ms, VOICE_OUTBOUND_DEFAULTS.in_flight_max_ms, 60000, 3600000),
+  };
+}
+
+module.exports = {
+  OUTBOUND_DEFAULTS,
+  resolveOutboundConfig,
+  // #5573 — política propia de voz
+  VOICE_OUTBOUND_DEFAULTS,
+  resolveVoiceOutboundConfig,
+};

--- a/.pipeline/lib/voice-delivery-audit.js
+++ b/.pipeline/lib/voice-delivery-audit.js
@@ -1,0 +1,203 @@
+// =============================================================================
+// voice-delivery-audit.js — Traza append-only de entrega de partes de voz (#5573)
+// =============================================================================
+//
+// PROBLEMA QUE RESUELVE
+//
+// 1. Duplicados invisibles. El recibo por parte (`<cid>-p<idx>.json`) se
+//    SOBRESCRIBE en cada envío: sólo sobrevive el último `message_id`. Cuando el
+//    sweep reenviaba una parte que seguía en vuelo, el operador recibía el audio
+//    2-4 veces y en disco no quedaba rastro de los envíos intermedios. Un
+//    `(correlationId, partIndex)` con más de un evento `sent` en este JSONL ES,
+//    por definición, un duplicado entregado — detectable en auditoría.
+//
+// 2. Backoff calibrado a ojo. `telegram_voice_outbound.backoff_base_ms` se fijó
+//    con una medición manual puntual (~62-74s). El evento `confirmed` lleva
+//    `latencyMs` desde `firstEnqueuedAt`, así que el p50/p95 real se computa
+//    offline sobre la serie y la política se recalibra con dato.
+//
+// DECISIONES DE DISEÑO (no negociables)
+//
+//   - APPEND-ONLY, nunca read-modify-write (SEC-D). La alternativa "acumular los
+//     message_id dentro del recibo" obligaría a un RMW desde DOS procesos
+//     (svc-telegram escribe recibos, el commander los reconcilia) → race que
+//     puede PERDER una confirmación → reenvío eterno, agravando el mismo bug que
+//     este issue viene a matar. Por eso `receiptFileName` no se toca: el nombre
+//     `<cid>-p<idx>.json` es contrato con el reconciliador.
+//
+//   - SÓLO IDENTIFICADORES Y TIMINGS (SEC-E / R7). Prohibido el texto de la
+//     respuesta, el path del `.ogg` y cualquier contenido del chat. El JSONL vive
+//     en disco con retención de 30 días: cuanto menos haya adentro, menor el
+//     blast radius. `redact: true` en la rotación como segunda barrera.
+//
+//   - BEST-EFFORT SIEMPRE. Auditar NUNCA puede romper una entrega: todo va
+//     envuelto en try/catch y cualquier fallo se traga en silencio.
+// =============================================================================
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const rotation = require('./jsonl-rotation');
+const rec = require('./telegram-receipt');
+
+const AUDIT_BASENAME = 'telegram-voice-delivery';
+const RETENTION_DAYS = 30;
+
+const EVENT_SENT = 'sent';
+const EVENT_CONFIRMED = 'confirmed';
+const VALID_EVENTS = [EVENT_SENT, EVENT_CONFIRMED];
+
+function auditDir(pipelineDir) {
+  return path.join(pipelineDir, 'audit');
+}
+
+function auditFilePath(pipelineDir) {
+  return path.join(auditDir(pipelineDir), `${AUDIT_BASENAME}.jsonl`);
+}
+
+// -----------------------------------------------------------------------------
+// buildEvent — PURA. Normaliza y ACOTA el evento fail-closed: devuelve `null` si
+// no cumple el contrato mínimo, en vez de escribir una línea basura que después
+// envenene el cómputo de p50/p95.
+//
+// Los campos numéricos opcionales sólo se emiten si son enteros >= 0. Nada de
+// campos libres: la whitelist de abajo es el contrato completo (SEC-E).
+// -----------------------------------------------------------------------------
+function buildEvent(ev = {}) {
+  if (!VALID_EVENTS.includes(ev.event)) return null;
+  if (!rec.isValidCorrelationId(ev.correlationId)) return null;
+  const partIndex = rec.coercePartInt(ev.partIndex);
+  const partTotal = rec.coercePartInt(ev.partTotal);
+  if (partIndex == null || partTotal == null) return null;
+
+  const out = {
+    ts: typeof ev.ts === 'string' && ev.ts.length > 0 ? ev.ts : new Date().toISOString(),
+    event: ev.event,
+    correlationId: ev.correlationId,
+    partIndex,
+    partTotal,
+  };
+  // `messageId` viene de Telegram: puede ser un entero grande, no se coerciona
+  // con `coercePartInt` (que exige >= 0 y es para dims de parte).
+  if (Number.isFinite(ev.messageId)) out.messageId = ev.messageId;
+  const attempt = rec.coercePartInt(ev.attempt);
+  if (attempt != null) out.attempt = attempt;
+  const retries = rec.coercePartInt(ev.retries);
+  if (retries != null) out.retries = retries;
+  // Latencia negativa = reloj corrido o `firstEnqueuedAt` corrupto → se omite
+  // antes que contaminar la serie con un outlier imposible.
+  if (Number.isFinite(ev.latencyMs) && ev.latencyMs >= 0) out.latencyMs = Math.round(ev.latencyMs);
+  return out;
+}
+
+// -----------------------------------------------------------------------------
+// appendVoiceDeliveryEvent — I/O best-effort. Rota si hace falta y appendea UNA
+// línea. Nunca lanza.
+// -----------------------------------------------------------------------------
+function appendVoiceDeliveryEvent(pipelineDir, ev) {
+  const line = buildEvent(ev);
+  if (!line) return false;
+  try {
+    const dir = auditDir(pipelineDir);
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    const filePath = auditFilePath(pipelineDir);
+    rotation.rotateIfNeeded({ path: filePath, redact: true });
+    fs.appendFileSync(filePath, `${JSON.stringify(line)}\n`);
+    return true;
+  } catch {
+    // Auditar nunca rompe la entrega.
+    return false;
+  }
+}
+
+// -----------------------------------------------------------------------------
+// cleanupVoiceDeliveryArchives — retención de 30 días de los `.gz` rotados
+// (cierra el requisito de rotación de SEC-E). Se llama en el mismo tick del
+// sweep. Best-effort.
+// -----------------------------------------------------------------------------
+function cleanupVoiceDeliveryArchives(pipelineDir) {
+  try {
+    return rotation.cleanupOldArchives({
+      dir: auditDir(pipelineDir),
+      basename: AUDIT_BASENAME,
+      retentionDays: RETENTION_DAYS,
+    });
+  } catch {
+    return { deleted: 0 };
+  }
+}
+
+// -----------------------------------------------------------------------------
+// computeLatencyStats — PURA. p50/p95 sobre una serie de eventos `confirmed`.
+// Es la herramienta con la que se recalibra `backoff_base_ms` (cambio 4 de
+// #5573): hoy ese valor es provisional y se fijó con una medición manual.
+//
+// Acepta las líneas ya parseadas (el caller decide de dónde salen: archivo
+// activo, `.gz` rotado, o un array de test).
+// -----------------------------------------------------------------------------
+function computeLatencyStats(events) {
+  const samples = (events || [])
+    .filter((e) => e && e.event === EVENT_CONFIRMED && Number.isFinite(e.latencyMs) && e.latencyMs >= 0)
+    .map((e) => e.latencyMs)
+    .sort((a, b) => a - b);
+  if (samples.length === 0) return { count: 0, p50: null, p95: null, max: null };
+  // Percentil por nearest-rank: índice = ceil(p * n) - 1, acotado al rango.
+  const at = (p) => samples[Math.min(samples.length - 1, Math.max(0, Math.ceil(p * samples.length) - 1))];
+  return {
+    count: samples.length,
+    p50: at(0.5),
+    p95: at(0.95),
+    max: samples[samples.length - 1],
+  };
+}
+
+// -----------------------------------------------------------------------------
+// findDuplicateSends — PURA. Devuelve los `(correlationId, partIndex)` con más de
+// un evento `sent`: cada uno es un audio que el operador recibió repetido. Es la
+// consulta de auditoría que este issue habilita (antes el dato no existía).
+// -----------------------------------------------------------------------------
+function findDuplicateSends(events) {
+  const counts = new Map();
+  for (const e of (events || [])) {
+    if (!e || e.event !== EVENT_SENT) continue;
+    if (!Number.isInteger(e.partIndex)) continue;
+    const key = `${e.correlationId}#${e.partIndex}`;
+    counts.set(key, (counts.get(key) || 0) + 1);
+  }
+  const out = [];
+  for (const [key, count] of counts) {
+    if (count <= 1) continue;
+    const sep = key.lastIndexOf('#');
+    out.push({ correlationId: key.slice(0, sep), partIndex: Number(key.slice(sep + 1)), sends: count });
+  }
+  return out.sort((a, b) => b.sends - a.sends);
+}
+
+// readVoiceDeliveryEvents — I/O best-effort: parsea el JSONL ACTIVO (no los
+// `.gz`). Líneas corruptas se saltean, nunca rompen la lectura.
+function readVoiceDeliveryEvents(pipelineDir) {
+  let raw;
+  try { raw = fs.readFileSync(auditFilePath(pipelineDir), 'utf8'); } catch { return []; }
+  const out = [];
+  for (const line of raw.split('\n')) {
+    if (!line.trim()) continue;
+    try { out.push(JSON.parse(line)); } catch { /* línea corrupta: se saltea */ }
+  }
+  return out;
+}
+
+module.exports = {
+  AUDIT_BASENAME,
+  RETENTION_DAYS,
+  EVENT_SENT,
+  EVENT_CONFIRMED,
+  auditDir,
+  auditFilePath,
+  buildEvent,
+  appendVoiceDeliveryEvent,
+  cleanupVoiceDeliveryArchives,
+  computeLatencyStats,
+  findDuplicateSends,
+  readVoiceDeliveryEvents,
+};

--- a/.pipeline/lib/voice-parts.js
+++ b/.pipeline/lib/voice-parts.js
@@ -15,8 +15,14 @@
 // El Commander, en su tick de reconciliación:
 //   1. lee los recibos por-parte y marca la parte confirmada en el estado, y
 //   2. barre los estados: si falta una parte tras el timeout la reenvía (tope N
-//      reintentos + backoff, misma política que texto — #4082); si se agotan los
-//      reintentos avisa al usuario en el chat del padre (nunca hueco silencioso).
+//      reintentos + backoff, política PROPIA de voz — `telegram_voice_outbound`,
+//      #5573); si se agotan los reintentos avisa al usuario en el chat del padre
+//      (nunca hueco silencioso).
+//
+// #5573 — El sweep además distingue "todavía en vuelo" de "perdido": una parte
+// cuyo dropfile sigue vivo en la cola de svc-telegram NO se reenvía (ver
+// `scanInFlightParts` + `planSweep(opts.inFlight)`), con un techo absoluto para
+// que un job atascado no suprima la entrega para siempre.
 //
 // Reglas fail-closed (espeja telegram-receipt.js):
 //   - Una parte se marca `confirmed` SOLO por un recibo `enviado` con message_id
@@ -79,6 +85,17 @@ function isValidState(obj) {
   // #4903 — `dedupeKey` es OPCIONAL (backward-compat con estados previos que no lo
   // llevan). Si está presente debe ser string no vacío; cualquier otra cosa → inválido.
   if (obj.dedupeKey != null && (typeof obj.dedupeKey !== 'string' || obj.dedupeKey.length === 0)) return false;
+  // #5573 — `firstEnqueuedAt` por parte es OPCIONAL (R10: retrocompat con los
+  // estados YA en disco al desplegar; invalidarlos los mandaría a cuarentena y
+  // perdería entregas en vuelo). Si está presente debe ser string no vacío; el
+  // consumidor cae a `enqueuedAt` cuando falta.
+  if (obj.parts && typeof obj.parts === 'object' && !Array.isArray(obj.parts)) {
+    for (const p of Object.values(obj.parts)) {
+      if (!p || typeof p !== 'object') continue;
+      if (p.firstEnqueuedAt != null
+        && (typeof p.firstEnqueuedAt !== 'string' || p.firstEnqueuedAt.length === 0)) return false;
+    }
+  }
   return true;
 }
 
@@ -216,9 +233,15 @@ function buildInitialState({ correlationId, partTotal, chatId, parts, now, dedup
   for (const p of (parts || [])) {
     const idx = rec.coercePartInt(p.partIndex);
     if (idx == null || idx >= pt) continue; // acotado (SEC-R2)
+    const enqueuedAt = typeof p.enqueuedAt === 'string' && p.enqueuedAt.length > 0 ? p.enqueuedAt : createdAt;
     state.parts[String(idx)] = {
       path: typeof p.path === 'string' ? p.path : null,
-      enqueuedAt: typeof p.enqueuedAt === 'string' && p.enqueuedAt.length > 0 ? p.enqueuedAt : createdAt,
+      enqueuedAt,
+      // #5573 — ancla INMUTABLE del primer encolado. `enqueuedAt` se pisa en cada
+      // reenvío (planSweep), así que no sirve ni para el techo absoluto de
+      // supresión por "en vuelo" (SEC-A) ni para medir la latencia real de entrega
+      // punta a punta. `firstEnqueuedAt` no se toca nunca después de nacer.
+      firstEnqueuedAt: enqueuedAt,
       retries: 0,
       // #4903 — una parte puede nacer ya `confirmed` cuando se sabe que fue
       // entregada en una pasada anterior (dedup): no se reenvía, solo se contabiliza.
@@ -276,6 +299,17 @@ function recordPartConfirmation({ pipelineDir, correlationId, partIndex }) {
 // Terminal:
 //   - todas confirmadas → terminal, sin aviso.
 //   - ninguna pendiente y hay fallidas → terminal + aviso consolidado (una vez).
+//
+// #5573 — Señal EN VUELO. El backoff solo mide "cuánto hace que encolé", no
+// distingue "perdido" de "todavía en la cola de svc-telegram". Con la latencia
+// real de un `.ogg` (~62-74s medidos) contra un backoff de texto de 5s, el sweep
+// disparaba reenvíos sobre envíos aún en vuelo → el operador recibía el mismo
+// audio 2-4 veces. `opts.inFlight` (Set de partIndex con dropfile vivo en la
+// cola) suprime el reenvío de esas partes. `opts.inFlightMaxMs` es el TECHO
+// ABSOLUTO de esa supresión, medido desde `firstEnqueuedAt`: sin él, un job
+// atascado en `trabajando/` (nada lo barre con el servicio vivo — `recoverOrphans`
+// corre SOLO al boot) suprimiría el reenvío para siempre, degradando la garantía
+// de #4750 a un hueco silencioso permanente.
 // -----------------------------------------------------------------------------
 function planSweep(state, opts = {}) {
   const now = Number.isFinite(opts.now) ? opts.now : Date.now();
@@ -283,6 +317,10 @@ function planSweep(state, opts = {}) {
   const base = Number.isFinite(opts.backoffBaseMs) ? opts.backoffBaseMs : 5000;
   const maxBackoff = Number.isFinite(opts.backoffMaxMs) ? opts.backoffMaxMs : 300000;
   const staleTtl = Number.isFinite(opts.staleTtlMs) ? opts.staleTtlMs : 86400000;
+  // #5573 — partes con dropfile vivo en `pendiente/` ∪ `trabajando/`. Ausente o
+  // mal tipado → Set vacío = comportamiento previo (nunca supresión por accidente).
+  const inFlight = opts.inFlight instanceof Set ? opts.inFlight : new Set();
+  const inFlightMaxMs = Number.isFinite(opts.inFlightMaxMs) ? opts.inFlightMaxMs : 600000;
 
   // Clon defensivo: no mutamos el estado del caller.
   const s = JSON.parse(JSON.stringify(state));
@@ -301,6 +339,21 @@ function planSweep(state, opts = {}) {
     allConfirmed = false;
 
     if (stale) { failedIdx.push(i); continue; }
+
+    // #5573 / SEC-A — techo absoluto de la supresión por "en vuelo", anclado en el
+    // PRIMER encolado (no en `enqueuedAt`, que los reenvíos pisan). R10: si el
+    // estado viene de antes del fix y no trae `firstEnqueuedAt`, cae a `enqueuedAt`.
+    const firstMs = Date.parse(p.firstEnqueuedAt || p.enqueuedAt);
+    const heldTooLong = Number.isFinite(firstMs) && (now - firstMs) >= inFlightMaxMs;
+
+    if (inFlight.has(i) && !heldTooLong) {
+      // Sigue en la cola: NO es una pérdida. No se reencola, NO se incrementa
+      // `retries` ni se pisa `enqueuedAt` (hacerlo corrompe el backoff y la
+      // métrica de latencia). Cuenta como pendiente → el estado no cierra terminal
+      // ni dispara el aviso de faltante prematuramente.
+      anyPending = true;
+      continue;
+    }
 
     const retries = Number.isInteger(p.retries) ? p.retries : 0;
     const backoff = Math.min(maxBackoff, base * Math.pow(2, retries));
@@ -364,6 +417,62 @@ function formatMissingNotice(partNumbers, partTotal) {
 }
 
 // -----------------------------------------------------------------------------
+// #5573 — scanInFlightParts: qué partes de audio siguen VIVAS en la cola de
+// `svc-telegram`. I/O (NO pura, a diferencia de `planSweep`, que recibe el Set ya
+// armado y sigue siendo el activo testeable del módulo).
+//
+// "En vuelo" ≡ existe un dropfile de esa parte en `pendiente/` ∪ `trabajando/`.
+// `fallido/` NO cuenta: es terminal hasta el barredor de boot ⇒ pérdida real, y
+// el reenvío debe ocurrir (CA-3, no se debilita #4750).
+//
+// UNIÓN DE TRES LECTURAS, en orden `pendiente → trabajando → pendiente`. La regla
+// es leer el ORIGEN antes que el DESTINO, y la cola se mueve en AMBOS sentidos
+// (`pendiente→trabajando` al tomar el job; `trabajando→pendiente` al reintentar
+// con `_nextRetryAt`). Con un solo par de lecturas, un archivo que se mueve entre
+// medio no aparece en ninguna → falso "perdido" → justo el duplicado que este
+// issue viene a matar. Con las tres, un move en cualquier dirección cae en al
+// menos una lectura: es imposible que se escape por el race.
+//
+// Devuelve Map<correlationId, Set<partIndex>>.
+// -----------------------------------------------------------------------------
+function scanInFlightParts({ pipelineDir }) {
+  const base = path.join(pipelineDir, 'servicios', 'telegram');
+  const pendienteDir = path.join(base, 'pendiente');
+  const trabajandoDir = path.join(base, 'trabajando');
+  const map = new Map();
+
+  for (const dir of [pendienteDir, trabajandoDir, pendienteDir]) {
+    let names;
+    try {
+      names = fs.readdirSync(dir);
+    } catch {
+      // SEC-C / R2 — un error de I/O NO cuenta como "en vuelo". Fail-OPEN hacia la
+      // entrega (a lo sumo un duplicado), fail-CLOSED hacia la confirmación. Tratar
+      // un readdir roto como "en vuelo" convertiría una falla de disco en supresión
+      // de entrega, que es exactamente el hueco silencioso que #4750 prohíbe.
+      continue;
+    }
+    for (const name of names) {
+      // Única lectura del nombre. Un dropfile que no matchea (texto, o formato
+      // legacy pre-#5573 sin cid) se ignora → degrada al comportamiento actual
+      // (a lo sumo un duplicado), NUNCA a supresión. R10: cubre la ventana de deploy.
+      const m = /^\d+-voice-(.+)-p(\d+)\.json$/.exec(name);
+      if (!m) continue;
+      const cid = m[1];
+      const idx = rec.coercePartInt(m[2]);
+      // SEC-B / R3 — `pendiente/` es un bus con muchos escritores: un dropfile
+      // forjado podría suprimir la parte de una respuesta en vuelo. Se valida
+      // SIEMPRE. El nombre no es fuente de verdad ni se concatena a ningún
+      // `path.join` de salida: sólo se usa para matchear contra el estado.
+      if (!rec.isValidCorrelationId(cid) || idx == null) continue;
+      if (!map.has(cid)) map.set(cid, new Set());
+      map.get(cid).add(idx);
+    }
+  }
+  return map;
+}
+
+// -----------------------------------------------------------------------------
 // sweepVoiceStates — orquesta el barrido de TODOS los estados (I/O + DI). Lee
 // cada estado, corre `planSweep`, ejecuta los reenvíos vía `enqueue(...)`, avisa
 // vía `notify(...)` y archiva los terminales. Las dependencias se inyectan para
@@ -384,6 +493,13 @@ function sweepVoiceStates({ pipelineDir, now, config = {}, enqueue, notify, logF
   const nowMs = Number.isFinite(now) ? now : Date.now();
   let resent = 0; let notified = 0; let closed = 0; let quarantined = 0;
 
+  // #5573 / SEC-G — escaneo de la cola UNA SOLA VEZ por barrido (nunca por estado)
+  // y sólo si hay estados de voz vivos: sin esto, cada tick pagaría 3 readdir por
+  // estado. `files.length === 0` ya devolvió arriba si el dir no existe.
+  const inFlightByCid = files.length > 0
+    ? (() => { try { return scanInFlightParts({ pipelineDir }); } catch { return new Map(); } })()
+    : new Map();
+
   for (const f of files) {
     const correlationId = f.replace(/\.json$/, '');
     const state = readState(dir, correlationId);
@@ -403,6 +519,9 @@ function sweepVoiceStates({ pipelineDir, now, config = {}, enqueue, notify, logF
       backoffBaseMs: config.backoff_base_ms,
       backoffMaxMs: config.backoff_max_ms,
       staleTtlMs: config.stale_ttl_ms,
+      // #5573 — partes de ESTE correlationId todavía vivas en la cola.
+      inFlight: inFlightByCid.get(state.correlationId) || new Set(),
+      inFlightMaxMs: config.in_flight_max_ms,
     });
 
     for (const r of plan.resends) {
@@ -460,6 +579,8 @@ module.exports = {
   planSweep,
   formatMissingNotice,
   sweepVoiceStates,
+  // #5573 — señal "en vuelo" (anti reenvío sobre envío no perdido)
+  scanInFlightParts,
   // #4903 — dedup cross-retry
   computeDedupeKey,
   isFullyDelivered,

--- a/.pipeline/pulpo.js
+++ b/.pipeline/pulpo.js
@@ -259,7 +259,13 @@ const telegramReceipt = require('./lib/telegram-receipt');
 // reenvía (tope N reintentos + backoff); avisa al usuario si se agotan. Reutiliza
 // la política de reintentos de salientes de #4082 (módulo puro compartido).
 const voiceParts = require('./lib/voice-parts');
-const { resolveOutboundConfig: resolveTelegramOutboundConfig } = require('./lib/telegram-outbound-config');
+// #5573 — traza append-only de entrega de partes de voz (duplicados + latencia).
+const voiceDeliveryAudit = require('./lib/voice-delivery-audit');
+const {
+  resolveOutboundConfig: resolveTelegramOutboundConfig,
+  // #5573 — política de reenvío PROPIA de las partes de audio (no la de texto).
+  resolveVoiceOutboundConfig: resolveTelegramVoiceOutboundConfig,
+} = require('./lib/telegram-outbound-config');
 // #3414 — Notificación Telegram de entregables del pipeline (human-in-the-loop
 // opcional). Se invoca desde `brazoBarrido` cuando un skill notificable cierra
 // fase OK. Default OFF (rollout gradual via config.yaml → deliverable_notifications.enabled).
@@ -10608,6 +10614,27 @@ function reconcileTelegramReceipts(opts = {}) {
       // El sweep (más abajo) cierra la respuesta cuando todas las partes confirman.
       if (voiceParts.isVoicePartReceipt(receipt)) {
         if (receipt.status === telegramReceipt.STATUS_ENVIADO) {
+          // #5573 (cambio 4) — muestra de LATENCIA REAL de entrega del chunk. Se
+          // lee el estado ANTES de confirmar porque `firstEnqueuedAt` (el ancla
+          // inmutable del primer encolado) y `retries` viven ahí. Esta serie es la
+          // que permite recalibrar `telegram_voice_outbound.backoff_base_ms`, hoy
+          // provisional (~62-74s medidos a mano). Best-effort: si algo falla acá,
+          // la confirmación igual ocurre.
+          let latencySample = null;
+          try {
+            const st = voiceParts.readState(voiceParts.voicePartsDir(pipelineDir), receipt.correlationId);
+            const part = st && st.parts ? st.parts[String(receipt.partIndex)] : null;
+            if (part) {
+              const firstMs = Date.parse(part.firstEnqueuedAt || part.enqueuedAt);
+              const atMs = Date.parse(receipt.at);
+              latencySample = {
+                latencyMs: (Number.isFinite(firstMs) && Number.isFinite(atMs)) ? (atMs - firstMs) : undefined,
+                retries: Number.isInteger(part.retries) ? part.retries : 0,
+                partTotal: st.partTotal,
+              };
+            }
+          } catch { /* best-effort */ }
+
           try {
             voiceParts.recordPartConfirmation({
               pipelineDir,
@@ -10616,6 +10643,18 @@ function reconcileTelegramReceipts(opts = {}) {
             });
           } catch (e) {
             log('telegram', `[reconcile] no se pudo confirmar chunk (${receipt.correlationId} p${receipt.partIndex}): ${e.message}`);
+          }
+
+          if (latencySample) {
+            voiceDeliveryAudit.appendVoiceDeliveryEvent(pipelineDir, {
+              ts: receipt.at,
+              event: voiceDeliveryAudit.EVENT_CONFIRMED,
+              correlationId: receipt.correlationId,
+              partIndex: receipt.partIndex,
+              partTotal: latencySample.partTotal != null ? latencySample.partTotal : receipt.partTotal,
+              latencyMs: latencySample.latencyMs,
+              retries: latencySample.retries,
+            });
           }
         }
         // Un recibo `fallido` de chunk se archiva sin confirmar: el sweep reintenta
@@ -10654,11 +10693,17 @@ function reconcileTelegramReceipts(opts = {}) {
     log('telegram', `[reconcile] error (best-effort): ${e.message}`);
   }
   // #4750 — Sweep de contabilidad de chunks de audio: SIEMPRE (aun sin recibos
-  // nuevos). Detecta partes que no confirmaron dentro del timeout y las reenvía
-  // (tope N reintentos + backoff, misma política que texto — #4082); si se agotan
-  // los reintentos avisa al usuario en el chat del padre (nunca hueco silencioso).
+  // nuevos). Detecta partes que no confirmaron dentro del timeout y las reenvía;
+  // si se agotan los reintentos avisa al usuario en el chat del padre (nunca
+  // hueco silencioso).
+  //
+  // #5573 — Política PROPIA de voz (`telegram_voice_outbound`), NO la de texto.
+  // La latencia real de un `.ogg` es ~62-74s contra los 5s de base del texto:
+  // reusar la política de texto disparaba reenvíos sobre envíos todavía en vuelo
+  // y el operador recibía el mismo audio 2-4 veces. El sweep además consulta qué
+  // partes siguen vivas en la cola (`scanInFlightParts`) y no las reencola.
   try {
-    const outboundCfg = resolveTelegramOutboundConfig(loadConfig());
+    const outboundCfg = resolveTelegramVoiceOutboundConfig(loadConfig());
     voiceParts.sweepVoiceStates({
       pipelineDir,
       now: Date.now(),
@@ -10670,6 +10715,9 @@ function reconcileTelegramReceipts(opts = {}) {
       notify: (text) => { try { sendTelegramPlain(text); } catch { /* best-effort */ } },
       logFn: (m) => log('telegram', `[voice-sweep] ${m}`),
     });
+    // #5573 (SEC-E) — retención de 30 días de los `.gz` rotados de la traza de
+    // entrega. Mismo tick del sweep, best-effort.
+    voiceDeliveryAudit.cleanupVoiceDeliveryArchives(pipelineDir);
   } catch (e) {
     log('telegram', `[voice-sweep] error (best-effort): ${e.message}`);
   }
@@ -15693,7 +15741,12 @@ function enqueueTelegramVoice(audioPath, opts = {}) {
   const pi = telegramReceipt.coercePartInt(partIndex);
   const pt = telegramReceipt.coercePartInt(partTotal);
   const svcDir = path.join(PIPELINE, 'servicios', 'telegram', 'pendiente');
-  const filename = `${Date.now()}-voice-p${pi}.json`;
+  // #5573 — el `correlationId` va EN EL NOMBRE del dropfile para que el sweep
+  // (`voiceParts.scanInFlightParts`) sepa qué partes siguen vivas en la cola sin
+  // abrir y parsear cada JSON en cada tick. `correlationId` ya pasó por
+  // `isValidCorrelationId` arriba (regex `[A-Za-z0-9._-]{6,128}` + anti `..`), así
+  // que componer un nombre de archivo con él es seguro.
+  const filename = `${Date.now()}-voice-${correlationId}-p${pi}.json`;
   // #4796 — Fix de ORIGEN: normalizar a forward-slashes ANTES de serializar. En
   // Windows los `\` pueden perderse si la ruta atraviesa una segunda ronda de
   // parse/serialize (incidente 2026-07-19: `C:\…\tts.ogg` → `C:WorkspacesIntrale…ogg`,

--- a/.pipeline/servicio-telegram.js
+++ b/.pipeline/servicio-telegram.js
@@ -111,6 +111,8 @@ const MAX_SEND_RETRIES = 5;
 // sweep de chunks de audio del Commander (#4750) use EXACTAMENTE los mismos
 // valores (SEC-R4: no inventar valores nuevos, alinear con #4082).
 const { OUTBOUND_DEFAULTS, resolveOutboundConfig } = require('./lib/telegram-outbound-config');
+// #5573 — traza append-only de entrega de partes de voz (duplicados + latencia).
+const voiceDeliveryAudit = require('./lib/voice-delivery-audit');
 function loadOutboundConfig() {
   return resolveOutboundConfig(loadPipelineConfig());
 }
@@ -152,6 +154,21 @@ function writeSentReceiptIfAny(data, messageIds) {
     telegramReceipt.writeReceipt(RECIBOS, fields);
   } catch (e) {
     log(`No se pudo escribir recibo enviado (${data._correlationId}): ${e.message}`);
+  }
+  // #5573 — traza APPEND-ONLY del envío del chunk. El recibo `<cid>-p<idx>.json`
+  // se SOBRESCRIBE en cada envío, así que un reenvío duplicado no dejaba ninguna
+  // huella (sólo sobrevivía el último message_id). Acá cada envío suma una línea:
+  // más de un evento `sent` para el mismo (correlationId, partIndex) ES un audio
+  // que el operador recibió repetido. Best-effort: auditar no rompe la entrega.
+  if (fields.partIndex != null) {
+    voiceDeliveryAudit.appendVoiceDeliveryEvent(PIPELINE, {
+      event: voiceDeliveryAudit.EVENT_SENT,
+      correlationId: fields.correlationId,
+      partIndex: fields.partIndex,
+      partTotal: fields.partTotal,
+      messageId: Array.isArray(messageIds) && Number.isFinite(messageIds[0]) ? messageIds[0] : undefined,
+      attempt: telegramReceipt.coercePartInt(data._telegramAttempts),
+    });
   }
 }
 
@@ -439,11 +456,25 @@ function handleSendFailure(file, trabajandoPath, err) {
       // error → cero superficie de leak de BOT_TOKEN (SEC-1).
       if (telegramReceipt.isValidCorrelationId(cur._correlationId)) {
         try {
-          telegramReceipt.writeReceipt(RECIBOS, {
+          const failFields = {
             correlationId: cur._correlationId,
             status: telegramReceipt.STATUS_FALLIDO,
             messageIds: [],
-          });
+          };
+          // #5573 — propagar la dimensión de CHUNK también al recibo `fallido`.
+          // Hasta acá el fallo de una parte de audio aterrizaba como `<cid>.json`
+          // (nombre de recibo de TEXTO) en vez de `<cid>-p<idx>.json`, así que el
+          // reconciliador lo metía en el historial conversacional en lugar de
+          // tratarlo como chunk. Misma validación fail-closed que
+          // `writeSentReceiptIfAny` (SEC-R2): dims corruptas → se escribe el
+          // recibo SIN dims (comportamiento previo), nunca con un valor sin acotar
+          // del que se derive un nombre de archivo.
+          if (telegramReceipt.hasPartDims({ partIndex: cur._partIndex, partTotal: cur._partTotal })
+            && telegramReceipt.isValidPartDims(cur._partIndex, cur._partTotal)) {
+            failFields.partIndex = telegramReceipt.coercePartInt(cur._partIndex);
+            failFields.partTotal = telegramReceipt.coercePartInt(cur._partTotal);
+          }
+          telegramReceipt.writeReceipt(RECIBOS, failFields);
         } catch (e) {
           log(`No se pudo escribir recibo fallido (${cur._correlationId}): ${e.message}`);
         }

--- a/docs/pipeline/contrato-kernel-adaptador.md
+++ b/docs/pipeline/contrato-kernel-adaptador.md
@@ -223,6 +223,7 @@ Reparto: **39 kernel · 12 autoridad · 9 producto**.
 | 58 | `commander_products` (1823) | obj | **autoridad** | D-2: incluye `default_product` y el alta de productos con sus operadores. |
 | 59 | `vault` (1318) | obj | kernel | #5352: direcciona secretos de infraestructura por host (`prefix`/`projectId`/`hostId`); es mecanismo, se muda al kernel sin conocer el producto. Reutiliza `kernel.region`. |
 | 60 | `worktree_provenance` | obj | kernel | Allowlist de identidades para verificar procedencia de ramas en auto-recovery; mecanismo de seguridad del motor. |
+| 61 | `telegram_voice_outbound` | obj | kernel | #5573: política de reenvío de las PARTES DE AUDIO, separada de `telegram_outbound` (texto) porque la latencia real de un `.ogg` es ~62-74s contra los 5s del texto. Es transporte de salida del motor; mecanismo. |
 
 #### 2.4.1. Matriz de precedencia
 


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 12 archivos · +1096 -14

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:passed` aplicado por delivery

## Closes

Closes #5573
