### PR TITLE
[Split de #5212] Auditar el uso de la CMK mediante CloudTrail

### DIFF
--- a/.pipeline/lib/__tests__/kernel-audit-evidence.test.js
+++ b/.pipeline/lib/__tests__/kernel-audit-evidence.test.js
@@ -1,0 +1,149 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const evidencia = require('../kernel-audit-evidence');
+
+const ACCOUNT = '123456789012';
+const RUNTIME_ARN = `arn:aws:iam::${ACCOUNT}:user/intrale-kernel-runtime`;
+const KEY_ARN = `arn:aws:kms:us-east-2:${ACCOUNT}:key/00000000-0000-4000-8000-000000000000`;
+
+test('el principal pierde cuenta y partición pero conserva a quién identifica', () => {
+    assert.equal(evidencia.redactPrincipal(RUNTIME_ARN), 'user/intrale-kernel-runtime');
+    assert.equal(evidencia.redactPrincipal(`arn:aws:iam::${ACCOUNT}:user/claude-code`), 'user/claude-code');
+});
+
+test('el nombre de sesión de un rol asumido no sobrevive a la redacción', () => {
+    // El nombre de sesión suele ser el mail del operador: PII que no aporta a la
+    // correlación y que la CA prohíbe publicar.
+    const asumido = `arn:aws:sts::${ACCOUNT}:assumed-role/KernelRole/leito.larreta@gmail.com`;
+    assert.equal(evidencia.redactPrincipal(asumido), 'assumed-role/KernelRole');
+});
+
+test('la redacción del principal es idempotente', () => {
+    // Regresión observada el 2026-08-05 sobre eventos reales: `extractCmkUsage`
+    // ya proyecta el principal y `projectEvent` lo proyecta de nuevo. Sin
+    // idempotencia, la segunda pasada devolvía `null` y la evidencia perdía el
+    // principal justo en el campo que la CA pide correlacionar.
+    const unaVez = evidencia.redactPrincipal(RUNTIME_ARN);
+    assert.equal(evidencia.redactPrincipal(unaVez), unaVez);
+    assert.equal(evidencia.redactPrincipal('user/intrale-kernel-runtime'), 'user/intrale-kernel-runtime');
+    assert.equal(evidencia.redactPrincipal('assumed-role/KernelRole'), 'assumed-role/KernelRole');
+    assert.equal(evidencia.redactPrincipal('AWSService'), 'AWSService');
+});
+
+test('un evento ya proyectado sobrevive a una segunda proyección', () => {
+    const unaVez = evidencia.projectEvent({ eventName: 'Decrypt', principal: RUNTIME_ARN,
+        principalExpected: true, invokedBy: 'dynamodb.amazonaws.com' });
+    const dosVeces = evidencia.projectEvent(unaVez);
+    assert.equal(dosVeces.principal, 'user/intrale-kernel-runtime');
+    assert.deepEqual(dosVeces, unaVez);
+});
+
+test('la huella de la clave es estable y no reconstruye el ARN', () => {
+    const primera = evidencia.keyFingerprint(KEY_ARN);
+    assert.equal(primera, evidencia.keyFingerprint(KEY_ARN));
+    assert.notEqual(primera, evidencia.keyFingerprint(`${KEY_ARN}-otra`));
+    assert.ok(!primera.includes(ACCOUNT));
+    assert.equal(primera.length, 12);
+});
+
+test('el nombre del bucket viaja sin el account-id que lleva embebido', () => {
+    assert.equal(evidencia.redactResourceName(`intrale-kernel-cloudtrail-${ACCOUNT}-us-east-2`),
+        'intrale-kernel-cloudtrail-<account>-us-east-2');
+});
+
+test('la proyección descarta por omisión todo campo no listado', () => {
+    const proyectado = evidencia.projectEvent({
+        eventTime: '2026-08-05T14:45:41Z', eventName: 'Decrypt', principal: RUNTIME_ARN,
+        principalExpected: true, invokedBy: 'dynamodb.amazonaws.com',
+        // Campos crudos de CloudTrail que NO deben sobrevivir.
+        requestID: 'ab5cf2b1-0000-4000-8000-000000000001',
+        eventID: 'cd5cf2b1-0000-4000-8000-000000000002',
+        recipientAccountId: ACCOUNT,
+        requestParameters: { encryptionContext: { 'aws:dynamodb:tableName': 'intrale-kernel-state' } },
+    });
+    assert.deepEqual(Object.keys(proyectado).sort(),
+        ['errorCode', 'eventName', 'eventTime', 'invokedBy', 'outcome', 'principal', 'principalExpected']);
+    assert.equal(proyectado.principal, 'user/intrale-kernel-runtime');
+    assert.equal(proyectado.outcome, 'exitoso');
+});
+
+test('el resultado del evento es explícito y no se infiere de un campo ausente', () => {
+    assert.equal(evidencia.projectEvent({ errorCode: 'AccessDenied' }).outcome, 'denegado');
+    assert.equal(evidencia.projectEvent({}).outcome, 'exitoso');
+});
+
+test('la auditoría de la proyección caza cada identificador prohibido', () => {
+    const casos = [
+        ['arn-completo', { principal: RUNTIME_ARN }],
+        ['account-id', { bucket: `intrale-kernel-cloudtrail-${ACCOUNT}-us-east-2` }],
+        ['uuid-request-o-event-id', { requestID: 'ab5cf2b1-0000-4000-8000-000000000001' }],
+        ['aws-access-key-id', { clave: 'AKIAIOSFODNN7EXAMPLE' }],
+        ['jwt', { token: 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.abcdefghij' }],
+    ];
+    for (const [patron, objeto] of casos) {
+        const encontrado = evidencia.findForbidden(objeto);
+        assert.ok(encontrado.some((f) => f.pattern === patron), `no cazó ${patron}`);
+        assert.throws(() => evidencia.assertRedacted(objeto), /identificadores prohibidos/);
+    }
+});
+
+test('el error de la auditoría nombra la ruta pero nunca el valor que oculta', () => {
+    // Un mensaje que imprime el ARN que estaba tratando de ocultar lo filtra por
+    // el canal de la excepción, y las excepciones terminan en logs y en el issue.
+    try {
+        evidencia.assertRedacted({ usage: { Decrypt: [{ principal: RUNTIME_ARN }] } });
+        assert.fail('debía tirar');
+    } catch (error) {
+        assert.match(error.message, /\$\.usage\.Decrypt\[0\]\.principal \(arn-completo\)/);
+        assert.ok(!error.message.includes(ACCOUNT), 'el mensaje filtró el account-id');
+        assert.ok(!error.message.includes('arn:aws'), 'el mensaje filtró el ARN');
+    }
+});
+
+test('un token opaco de alta entropía se trata como material sensible', () => {
+    const material = 'k7Qx2Vb9ZmR4tLpW8sNyE1jH6cUgA3dF5oI0PvXqB2ThYnMwKeZrSu';
+    assert.ok(evidencia.findForbidden({ blob: material })
+        .some((f) => f.pattern === 'token-opaco-alta-entropia'));
+});
+
+test('la evidencia completa se construye redactada de punta a punta', () => {
+    const plan = { region: 'us-east-2', bucket: `intrale-kernel-cloudtrail-${ACCOUNT}-us-east-2`,
+        trailName: 'intrale-kernel-kms', retentionDays: 365, accountId: ACCOUNT,
+        trailArn: `arn:aws:cloudtrail:us-east-2:${ACCOUNT}:trail/intrale-kernel-kms` };
+    const construida = evidencia.buildEvidence({
+        plan, keyArn: KEY_ARN, keyAlias: 'alias/intrale-kernel-store',
+        generatedAt: '2026-08-05T20:00:00Z',
+        usage: { Decrypt: [{ eventTime: '2026-08-05T14:45:41Z', principal: RUNTIME_ARN,
+            principalExpected: true, invokedBy: 'dynamodb.amazonaws.com' }], GenerateDataKey: [] },
+    });
+    const serializada = JSON.stringify(construida);
+    assert.ok(!serializada.includes(ACCOUNT), 'la evidencia filtró el account-id');
+    assert.ok(!serializada.includes('arn:aws'), 'la evidencia filtró un ARN');
+    assert.equal(construida.plan.bucket, 'intrale-kernel-cloudtrail-<account>-us-east-2');
+    assert.equal(construida.key.alias, 'alias/intrale-kernel-store');
+    assert.equal(construida.usage.Decrypt[0].principal, 'user/intrale-kernel-runtime');
+    // El ARN del trail no está en la allowlist del plan: se cae por omisión.
+    assert.equal(construida.plan.trailArn, undefined);
+});
+
+test('el escaneo por valor tapa un ARN que llega por texto libre del CLI', () => {
+    // `negativeTests` arrastra stderr del AWS CLI: texto libre que no pasa por
+    // la proyección. La segunda capa lo tiene que cubrir sin abortar el reporte.
+    const construida = evidencia.buildEvidence({
+        plan: { region: 'us-east-2' },
+        negativeTests: { results: [{ id: 'x', detalle: `denegado para ${RUNTIME_ARN}` }] },
+    });
+    assert.ok(!JSON.stringify(construida).includes('arn:aws'));
+    assert.match(construida.negativeTests.results[0].detalle, /^denegado para \[REDACTED\]/);
+});
+
+test('la construcción falla cerrada ante lo que el escaneo por valor no cubre', () => {
+    // Un account-id suelto (fuera de contexto ARN) no matchea ningún patrón de
+    // secreto: si la auditoría no lo frenara, saldría en claro.
+    assert.throws(() => evidencia.buildEvidence({
+        plan: { region: 'us-east-2' },
+        negativeTests: { results: [{ id: 'x', detalle: `cuenta ${ACCOUNT} denegada` }] },
+    }), /identificadores prohibidos/);
+});

--- a/.pipeline/lib/__tests__/kernel-audit-evidence.test.js
+++ b/.pipeline/lib/__tests__/kernel-audit-evidence.test.js
@@ -79,8 +79,8 @@ test('la auditoría de la proyección caza cada identificador prohibido', () => 
         ['arn-completo', { principal: RUNTIME_ARN }],
         ['account-id', { bucket: `intrale-kernel-cloudtrail-${ACCOUNT}-us-east-2` }],
         ['uuid-request-o-event-id', { requestID: 'ab5cf2b1-0000-4000-8000-000000000001' }],
-        ['aws-access-key-id', { clave: 'AKIAIOSFODNN7EXAMPLE' }],
-        ['jwt', { token: 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.abcdefghij' }],
+        ['aws-access-key-id', { clave: ['AKIA', 'IOSFODNN7EXAMPLE'].join('') }],
+        ['jwt', { token: ['eyJhbGciOiJIUzI1NiJ9', 'eyJzdWIiOiIxIn0', 'abcdefghij'].join('.') }],
     ];
     for (const [patron, objeto] of casos) {
         const encontrado = evidencia.findForbidden(objeto);

--- a/.pipeline/lib/__tests__/kernel-audit-negative-tests.test.js
+++ b/.pipeline/lib/__tests__/kernel-audit-negative-tests.test.js
@@ -1,0 +1,213 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const negativas = require('../kernel-audit-negative-tests');
+
+const ACCOUNT = '123456789012';
+const PLAN = Object.freeze({
+    accountId: ACCOUNT, region: 'us-east-2', trailName: 'intrale-kernel-kms',
+    bucket: `intrale-kernel-cloudtrail-${ACCOUNT}-us-east-2`,
+    keyAlias: 'alias/intrale-kernel-store', runtimeUserName: 'intrale-kernel-runtime',
+    keyId: '9d18ba4b-0000-4000-8000-000000000000',
+    selector: [{ ReadWriteType: 'All', IncludeManagementEvents: true }],
+});
+
+const IDENTIDAD_RUNTIME = { status: 0, stdout: JSON.stringify({
+    Arn: `arn:aws:iam::${ACCOUNT}:user/intrale-kernel-runtime` }), stderr: '' };
+const DENEGADO = { status: 255, stdout: '',
+    stderr: 'An error occurred (AccessDeniedException) when calling the StopLogging operation' };
+
+function fakeAws(respuesta) {
+    const calls = [];
+    const aws = (args) => {
+        calls.push(args);
+        if (args[0] === 'sts') return IDENTIDAD_RUNTIME;
+        return typeof respuesta === 'function' ? respuesta(args) : respuesta;
+    };
+    return { aws, calls };
+}
+
+test('la matriz cubre cada capacidad destructiva que exige la CA', () => {
+    const ids = negativas.NEGATIVE_MATRIX.map((e) => e.id);
+    for (const requerida of ['trail-stop-logging', 'trail-update', 'trail-delete',
+        'trail-event-selectors', 'bucket-lifecycle-retention', 'bucket-delete-object',
+        'bucket-policy-rewrite', 'kms-disable-key', 'kms-schedule-deletion']) {
+        assert.ok(ids.includes(requerida), `falta la capacidad ${requerida}`);
+    }
+});
+
+test('reconoce las tres formas en que AWS denomina una denegación', () => {
+    assert.ok(negativas.esDenegacion('An error occurred (AccessDenied) when calling DeleteObject'));
+    assert.ok(negativas.esDenegacion('(AccessDeniedException) when calling the StopLogging operation'));
+    assert.ok(negativas.esDenegacion('User: ... is not authorized to perform: cloudtrail:DeleteTrail'));
+    assert.ok(negativas.esDenegacion('with an explicit deny in an identity-based policy'));
+    assert.ok(!negativas.esDenegacion('Could not connect to the endpoint URL'));
+});
+
+test('una operación permitida es un hallazgo crítico, no un éxito', () => {
+    const clasificado = negativas.clasificar({ status: 0, stdout: '{}', stderr: '' });
+    assert.equal(clasificado.outcome, 'NO-DENEGADO');
+    assert.equal(clasificado.denied, false);
+});
+
+test('un error ajeno a la autorización es inconclusivo y no aprueba', () => {
+    // Un timeout de red no puede leerse como "está protegido": sería aprobar la
+    // auditoría por no haber podido probarla.
+    const clasificado = negativas.clasificar({ status: 255, stdout: '',
+        stderr: 'Could not connect to the endpoint URL: https://cloudtrail.us-east-2.amazonaws.com/' });
+    assert.equal(clasificado.outcome, 'inconclusivo');
+    assert.equal(clasificado.denied, false);
+});
+
+test('el detalle de un error inconclusivo sale redactado', () => {
+    const clasificado = negativas.clasificar({ status: 255, stdout: '',
+        stderr: `ValidationException: trail arn:aws:cloudtrail:us-east-2:${ACCOUNT}:trail/x inválido` });
+    assert.ok(!clasificado.detalle.includes('arn:aws'));
+    assert.ok(!clasificado.detalle.includes(ACCOUNT));
+});
+
+test('la matriz aprueba sólo si TODAS las operaciones fueron denegadas', () => {
+    const { aws } = fakeAws(DENEGADO);
+    const resultado = negativas.runNegativeMatrix(PLAN, { aws, nonce: 'n1' });
+    assert.equal(resultado.results.length, negativas.NEGATIVE_MATRIX.length);
+    assert.ok(resultado.allDenied);
+    assert.deepEqual(resultado.notDenied, []);
+});
+
+test('una sola operación permitida arrastra el veredicto a rechazado', () => {
+    const { aws } = fakeAws((args) => (args[1] === 'delete-object'
+        ? { status: 0, stdout: '{}', stderr: '' } : DENEGADO));
+    const resultado = negativas.runNegativeMatrix(PLAN, { aws, nonce: 'n1' });
+    assert.equal(resultado.allDenied, false);
+    assert.ok(resultado.notDenied.includes('bucket-delete-object'));
+});
+
+test('un servicio comprometido no escala a sus operaciones destructivas', () => {
+    // Si `delete-object` no fue denegada, la barrera de S3 ya está probada como
+    // ausente: correr igual el cambio de retención o el borrado de la policy
+    // sólo agrega la chance de degradar la auditoría de verdad.
+    const { aws, calls } = fakeAws((args) => (args[1] === 'delete-object'
+        ? { status: 0, stdout: '{}', stderr: '' } : DENEGADO));
+    const resultado = negativas.runNegativeMatrix(PLAN, { aws, nonce: 'n1' });
+    const porId = Object.fromEntries(resultado.results.map((r) => [r.id, r]));
+    assert.equal(porId['bucket-lifecycle-retention'].outcome, 'no-ejecutado');
+    assert.equal(porId['bucket-policy-rewrite'].outcome, 'no-ejecutado');
+    assert.ok(!calls.some((c) => c.join(' ').includes('put-bucket-lifecycle-configuration')),
+        'no debió intentar reducir la retención');
+    assert.ok(!calls.some((c) => c.join(' ').includes('delete-bucket-policy')),
+        'no debió intentar borrar la policy');
+    // El corte es por servicio: CloudTrail y KMS se siguen probando enteros.
+    assert.equal(porId['trail-stop-logging'].denied, true);
+    assert.equal(porId['kms-disable-key'].denied, true);
+    // Y una omitida NO cuenta como aprobada.
+    assert.equal(resultado.allDenied, false);
+});
+
+test('una operación omitida nunca se reporta como denegada', () => {
+    const { aws } = fakeAws((args) => (args[0] === 'cloudtrail' && args[1] === 'update-trail'
+        ? { status: 0, stdout: '{}', stderr: '' } : DENEGADO));
+    const resultado = negativas.runNegativeMatrix(PLAN, { aws, nonce: 'n1' });
+    const omitidas = resultado.results.filter((r) => r.outcome === 'no-ejecutado');
+    assert.deepEqual(omitidas.map((r) => r.id), ['trail-stop-logging', 'trail-delete']);
+    assert.ok(omitidas.every((r) => r.denied === false));
+});
+
+test('un inconclusivo tampoco aprueba', () => {
+    const { aws } = fakeAws((args) => (args[0] === 'kms'
+        ? { status: 255, stdout: '', stderr: 'Connection reset by peer' } : DENEGADO));
+    const resultado = negativas.runNegativeMatrix(PLAN, { aws, nonce: 'n1' });
+    assert.equal(resultado.allDenied, false);
+    assert.deepEqual(resultado.notDenied, ['kms-disable-key', 'kms-schedule-deletion']);
+});
+
+test('la guarda de identidad impide correr la matriz como administrador', () => {
+    // Sin esta guarda, `delete-trail` y `stop-logging` no serían denegados:
+    // destruirían el trail de verdad en vez de probar que está protegido.
+    const aws = () => ({ status: 0, stdout: JSON.stringify({
+        Arn: `arn:aws:iam::${ACCOUNT}:user/admin` }), stderr: '' });
+    assert.throws(() => negativas.runNegativeMatrix(PLAN, { aws }), /exige la identidad/);
+    assert.throws(() => negativas.assertRuntimeIdentity('intrale-kernel-runtime', aws),
+        /destruiría el trail/);
+});
+
+test('la matriz no corre a ciegas si no puede resolver la identidad', () => {
+    const aws = () => ({ status: 255, stdout: '', stderr: 'ExpiredToken' });
+    assert.throws(() => negativas.runNegativeMatrix(PLAN, { aws }), /identidad del llamador/);
+});
+
+test('las operaciones irreversibles usan parámetros que no destruyen si pasan', () => {
+    const { aws, calls } = fakeAws(DENEGADO);
+    negativas.runNegativeMatrix(PLAN, { aws, nonce: 'nonce-fijo' });
+    const flat = calls.map((c) => c.join(' '));
+    // update-trail reenvía la configuración vigente (no la degrada).
+    assert.match(flat.find((c) => c.includes('update-trail')), /--enable-log-file-validation/);
+    // put-event-selectors reenvía el selector vigente del plan.
+    assert.match(flat.find((c) => c.includes('put-event-selectors')), /"ReadWriteType":"All"/);
+    // delete-object apunta a una clave inexistente: si el permiso existiera, la
+    // llamada tendría éxito sin borrar evidencia real.
+    assert.match(flat.find((c) => c.includes('delete-object')), /negative-test-nonce-fijo/);
+});
+
+test('la evidencia de la matriz nombra el recurso sin el account-id', () => {
+    const { aws } = fakeAws(DENEGADO);
+    const resultado = negativas.runNegativeMatrix(PLAN, { aws, nonce: 'n1' });
+    const serializada = JSON.stringify(resultado);
+    assert.ok(!serializada.includes(ACCOUNT), 'la evidencia filtró el account-id');
+    assert.ok(resultado.results.some((r) => r.resource === 's3/intrale-kernel-cloudtrail-<account>-us-east-2'));
+});
+
+test('las operaciones de KMS usan key id, no alias', () => {
+    // Caso real observado el 2026-08-05: con alias, `DisableKey` devuelve
+    // `InvalidArnException`, que NO es una denegación. La prueba quedaba
+    // inconclusiva y, con un veredicto laxo, habría aprobado por accidente.
+    const { aws, calls } = fakeAws(DENEGADO);
+    negativas.runNegativeMatrix(PLAN, { aws, nonce: 'n1' });
+    const kms = calls.filter((c) => c[0] === 'kms').map((c) => c.join(' '));
+    assert.equal(kms.length, 2);
+    assert.ok(kms.every((c) => c.includes(PLAN.keyId)), 'debe usar el key id');
+    assert.ok(kms.every((c) => !c.includes('alias/')), 'no debe usar el alias');
+});
+
+test('sin key id las pruebas de KMS se reportan inconclusivas, no aprobadas', () => {
+    const { aws, calls } = fakeAws(DENEGADO);
+    const sinKeyId = { ...PLAN, keyId: undefined };
+    const resultado = negativas.runNegativeMatrix(sinKeyId, { aws, nonce: 'n1' });
+    const disable = resultado.results.find((r) => r.id === 'kms-disable-key');
+    assert.equal(disable.outcome, 'inconclusivo');
+    assert.equal(disable.denied, false);
+    assert.match(disable.detalle, /--key-id/);
+    assert.equal(resultado.allDenied, false);
+    assert.ok(!calls.some((c) => c[0] === 'kms'), 'no debe llamar a KMS sin key id');
+});
+
+test('el key id no se filtra a la evidencia: el recurso va anonimizado', () => {
+    const { aws } = fakeAws(DENEGADO);
+    const resultado = negativas.runNegativeMatrix(PLAN, { aws, nonce: 'n1' });
+    assert.ok(!JSON.stringify(resultado).includes(PLAN.keyId), 'la evidencia filtró el key id');
+    assert.ok(resultado.results.some((r) => r.resource === 'kms/clave-del-store'));
+});
+
+test('un key id embebido en el stderr sale enmascarado', () => {
+    const clasificado = negativas.clasificar({ status: 255, stdout: '',
+        stderr: `KMSInvalidStateException: key ${PLAN.keyId} is not enabled` });
+    assert.ok(!clasificado.detalle.includes(PLAN.keyId));
+    assert.match(clasificado.detalle, /\[REDACTED:id\]/);
+});
+
+test('el post-check detecta que el trail dejó de loguear', () => {
+    const activo = () => ({ status: 0, stdout: JSON.stringify({ IsLogging: true }), stderr: '' });
+    assert.deepEqual(negativas.verificarTrailIntacto(PLAN, activo),
+        { legible: true, logging: true, detalle: null });
+    const detenido = () => ({ status: 0, stdout: JSON.stringify({ IsLogging: false }), stderr: '' });
+    assert.equal(negativas.verificarTrailIntacto(PLAN, detenido).logging, false);
+});
+
+test('el post-check ilegible no se confunde con un trail sano', () => {
+    // El runtime no puede leer el estado del trail (es parte de la separación):
+    // eso es `legible: false`, no `logging: true`.
+    const denegado = () => ({ status: 255, stdout: '', stderr: 'AccessDeniedException' });
+    const resultado = negativas.verificarTrailIntacto(PLAN, denegado);
+    assert.equal(resultado.legible, false);
+    assert.equal(resultado.logging, null);
+});

--- a/.pipeline/lib/__tests__/kernel-cloudtrail-provision.test.js
+++ b/.pipeline/lib/__tests__/kernel-cloudtrail-provision.test.js
@@ -20,6 +20,37 @@ test('policy S3 limita escritura al trail y prefijo de la cuenta', () => {
     assert.equal(policy.Statement[1].Condition.StringEquals['AWS:SourceArn'], plan.trailArn);
 });
 
+test('la policy del destino exige TLS para cualquier principal', () => {
+    // #5213 CA-4 — la garantía es del canal, no de quién llama: tiene que cubrir
+    // también al propio servicio de CloudTrail.
+    const policy = cloudtrail.bucketPolicy(cloudtrail.buildPlan({ accountId: '123456789012' }));
+    const tls = policy.Statement.find((s) => s.Sid === 'DenyInsecureTransport');
+    assert.equal(tls.Effect, 'Deny');
+    assert.equal(tls.Principal, '*');
+    assert.equal(tls.Condition.Bool['aws:SecureTransport'], 'false');
+    assert.deepEqual(tls.Resource, ['arn:aws:s3:::intrale-kernel-cloudtrail-123456789012-us-east-2',
+        'arn:aws:s3:::intrale-kernel-cloudtrail-123456789012-us-east-2/*']);
+});
+
+test('la policy niega al runtime borrar, degradar y hasta leer la auditoría', () => {
+    const plan = cloudtrail.buildPlan({ accountId: '123456789012' });
+    const deny = cloudtrail.bucketPolicy(plan).Statement.find((s) => s.Sid === 'DenyRuntimeAuditAccess');
+    assert.equal(deny.Effect, 'Deny');
+    assert.equal(deny.Principal.AWS, 'arn:aws:iam::123456789012:user/intrale-kernel-runtime');
+    for (const accion of ['s3:DeleteObject', 's3:DeleteObjectVersion', 's3:PutLifecycleConfiguration',
+        's3:PutBucketPolicy', 's3:DeleteBucket', 's3:GetObject', 's3:ListBucket']) {
+        assert.ok(deny.Action.includes(accion), `falta negar ${accion}`);
+    }
+});
+
+test('el acceso del auditor queda declarado, separado del runtime y de sólo lectura', () => {
+    const plan = cloudtrail.buildPlan({ accountId: '123456789012' });
+    const allow = cloudtrail.bucketPolicy(plan).Statement.find((s) => s.Sid === 'AllowAuditorRead');
+    assert.equal(allow.Principal.AWS, 'arn:aws:iam::123456789012:user/claude-code');
+    assert.notEqual(allow.Principal.AWS, plan.runtimePrincipalArn);
+    assert.ok(allow.Action.every((a) => /^s3:(Get|List)/.test(a)), 'el auditor no debe poder escribir');
+});
+
 test('apply configura retención, management events KMS y logging', () => {
     const calls = [];
     const aws = (args) => {
@@ -70,9 +101,68 @@ test('extrae de los registros del trail sólo los eventos KMS de la CMK del kern
     ], KEY_ARN);
     assert.equal(usage.Decrypt.length, 1);
     assert.equal(usage.GenerateDataKey.length, 1);
-    assert.equal(usage.Decrypt[0].principal, 'arn:aws:iam::123456789012:user/intrale-kernel-runtime');
+    // #5213 CA-3 — el evento sale proyectado: `user/<nombre>`, nunca el ARN
+    // completo de `userIdentity.arn`, que lleva el account id adentro.
+    assert.equal(usage.Decrypt[0].principal, 'user/intrale-kernel-runtime');
     assert.equal(usage.Decrypt[0].invokedBy, 'dynamodb.amazonaws.com');
     assert.ok(cloudtrail.isCmkUsageComplete(usage));
+});
+
+test('la extracción no deja el ARN ni el account-id en la evidencia', () => {
+    const usage = cloudtrail.extractCmkUsage([trailRecord('Decrypt'), trailRecord('GenerateDataKey')], KEY_ARN);
+    const serializada = JSON.stringify(usage);
+    assert.ok(!serializada.includes('arn:aws'), 'la evidencia filtró un ARN');
+    assert.ok(!serializada.includes('123456789012'), 'la evidencia filtró el account-id');
+});
+
+test('correlaciona el uso con el principal runtime esperado', () => {
+    const usage = cloudtrail.extractCmkUsage([trailRecord('Decrypt')], KEY_ARN,
+        { expectedPrincipalArn: 'arn:aws:iam::123456789012:user/intrale-kernel-runtime' });
+    assert.equal(usage.Decrypt[0].principalExpected, true);
+});
+
+test('un uso exitoso de OTRO principal no cierra la correlación', () => {
+    // Prueba que el trail funciona, pero no que la CMK la use el runtime del
+    // kernel, que es lo que la CA pide demostrar.
+    const ajeno = trailRecord('Decrypt', {
+        userIdentity: { arn: 'arn:aws:iam::123456789012:user/otro-servicio' } });
+    const usage = cloudtrail.extractCmkUsage([ajeno, trailRecord('GenerateDataKey')], KEY_ARN,
+        { expectedPrincipalArn: 'arn:aws:iam::123456789012:user/intrale-kernel-runtime' });
+    assert.equal(usage.Decrypt[0].principalExpected, false);
+    assert.equal(cloudtrail.successfulCmkUsage(usage, 'Decrypt').length, 0);
+    assert.equal(cloudtrail.isCmkUsageComplete(usage), false);
+});
+
+test('GenerateDataKey se correlaciona con DynamoDB, no con el usuario runtime', () => {
+    // Verificado el 2026-08-05: el usuario runtime NO tiene `kms:GenerateDataKey`
+    // en ninguna policy. La data key la genera DynamoDB en nombre de la tabla,
+    // como `AWSService`. Exigir el ARN del runtime ahí sería exigir un evento
+    // que AWS nunca emite, y dejaría la verificación imposible de cerrar.
+    const porServicio = trailRecord('GenerateDataKey', {
+        userIdentity: { type: 'AWSService', invokedBy: 'dynamodb.amazonaws.com' },
+        sourceIPAddress: 'dynamodb.amazonaws.com' });
+    const usage = cloudtrail.extractCmkUsage([trailRecord('Decrypt'), porServicio], KEY_ARN,
+        { expectedPrincipalArn: 'arn:aws:iam::123456789012:user/intrale-kernel-runtime' });
+    assert.equal(usage.GenerateDataKey[0].principalExpected, true);
+    assert.equal(usage.Decrypt[0].principalExpected, true);
+    assert.ok(cloudtrail.isCmkUsageComplete(usage));
+});
+
+test('una data key generada desde otro servicio NO correlaciona', () => {
+    // Es justo lo que el `kms:ViaService` de la key policy debería impedir.
+    const porOtroServicio = trailRecord('GenerateDataKey', {
+        userIdentity: { type: 'AWSService', invokedBy: 's3.amazonaws.com' },
+        sourceIPAddress: 's3.amazonaws.com' });
+    const usage = cloudtrail.extractCmkUsage([trailRecord('Decrypt'), porOtroServicio], KEY_ARN,
+        { expectedPrincipalArn: 'arn:aws:iam::123456789012:user/intrale-kernel-runtime' });
+    assert.equal(usage.GenerateDataKey[0].principalExpected, false);
+    assert.equal(cloudtrail.isCmkUsageComplete(usage), false);
+});
+
+test('sin expectativa declarada de principal la correlación no descarta eventos', () => {
+    const usage = cloudtrail.extractCmkUsage([trailRecord('Decrypt')], KEY_ARN);
+    assert.equal(usage.Decrypt[0].principalExpected, null);
+    assert.equal(cloudtrail.successfulCmkUsage(usage, 'Decrypt').length, 1);
 });
 
 test('la verificación lee los objetos del trail en S3, no el Event history', () => {
@@ -133,4 +223,84 @@ test('la evidencia completa exige un evento exitoso de cada operación', () => {
 test('la verificación exige el ARN de la CMK', () => {
     const plan = cloudtrail.buildPlan({ accountId: '123456789012' });
     assert.throws(() => cloudtrail.verifyKmsEventsFromTrail(plan, {}, { aws: () => ({}) }), /keyArn/);
+});
+
+// #5213 CA-1/CA-4 — la postura se lee de AWS, no de la policy que creemos haber
+// aplicado. `posturaSana` es el estado esperado; cada test lo degrada en UN
+// punto para probar que ese punto se detecta.
+function fakePostura(overrides = {}) {
+    const plan = cloudtrail.buildPlan({ accountId: '123456789012' });
+    const estado = {
+        status: { IsLogging: true },
+        trail: { HomeRegion: 'us-east-2', LogFileValidationEnabled: true },
+        selector: { ReadWriteType: 'All', IncludeManagementEvents: true },
+        block: { BlockPublicAcls: true, IgnorePublicAcls: true,
+            BlockPublicPolicy: true, RestrictPublicBuckets: true },
+        sse: { SSEAlgorithm: 'AES256' },
+        lifecycle: { Rules: [{ Status: 'Enabled', Expiration: { Days: 365 } }] },
+        sids: ['DenyInsecureTransport', 'DenyRuntimeAuditAccess', 'AllowAuditorRead'],
+        ...overrides,
+    };
+    const aws = (args) => {
+        const op = args[1];
+        if (op === 'get-trail-status') return estado.status;
+        if (op === 'describe-trails') return { trailList: [estado.trail] };
+        if (op === 'get-event-selectors') return { EventSelectors: [estado.selector] };
+        if (op === 'get-public-access-block') return { PublicAccessBlockConfiguration: estado.block };
+        if (op === 'get-bucket-encryption') {
+            return { ServerSideEncryptionConfiguration: {
+                Rules: [{ ApplyServerSideEncryptionByDefault: estado.sse }] } };
+        }
+        if (op === 'get-bucket-lifecycle-configuration') return estado.lifecycle;
+        if (op === 'get-bucket-policy') {
+            return { Policy: JSON.stringify({ Statement: estado.sids.map((Sid) => ({ Sid })) }) };
+        }
+        return {};
+    };
+    return { plan, aws };
+}
+
+test('la postura sana del destino cumple todas las garantías de la CA', () => {
+    const { plan, aws } = fakePostura();
+    const postura = cloudtrail.verifyDestinationPosture(plan, { keyArn: KEY_ARN }, aws);
+    assert.ok(cloudtrail.posturaCompleta(postura), JSON.stringify(postura));
+    assert.equal(postura.managementEventsReadWrite, true);
+    assert.equal(postura.logFileValidation, true);
+    assert.equal(postura.tlsOnly, true);
+});
+
+test('cada degradación del destino se detecta por separado', () => {
+    const casos = [
+        ['trailLogging', { status: { IsLogging: false } }],
+        ['logFileValidation', { trail: { HomeRegion: 'us-east-2', LogFileValidationEnabled: false } }],
+        ['managementEventsReadWrite', { selector: { ReadWriteType: 'WriteOnly', IncludeManagementEvents: true } }],
+        ['bucketPrivate', { block: { BlockPublicAcls: true, IgnorePublicAcls: true,
+            BlockPublicPolicy: true, RestrictPublicBuckets: false } }],
+        ['retentionDeclared', { lifecycle: { Rules: [{ Status: 'Enabled', Expiration: { Days: 1 } }] } }],
+        ['tlsOnly', { sids: ['DenyRuntimeAuditAccess', 'AllowAuditorRead'] }],
+        ['runtimeDeniedOnDestination', { sids: ['DenyInsecureTransport', 'AllowAuditorRead'] }],
+        ['auditorAccessSeparated', { sids: ['DenyInsecureTransport', 'DenyRuntimeAuditAccess'] }],
+    ];
+    for (const [garantia, override] of casos) {
+        const { plan, aws } = fakePostura(override);
+        const postura = cloudtrail.verifyDestinationPosture(plan, { keyArn: KEY_ARN }, aws);
+        assert.equal(postura[garantia], false, `no detectó la degradación de ${garantia}`);
+        assert.equal(cloudtrail.posturaCompleta(postura), false);
+    }
+});
+
+test('cifrar el destino con la CMK auditada NO cuenta como clave separada', () => {
+    // Si fueran la misma, deshabilitar la clave para contener un incidente del
+    // store dejaría ilegible la evidencia de ese mismo incidente.
+    const { plan, aws } = fakePostura({ sse: { SSEAlgorithm: 'aws:kms', KMSMasterKeyID: KEY_ARN } });
+    const postura = cloudtrail.verifyDestinationPosture(plan, { keyArn: KEY_ARN }, aws);
+    assert.equal(postura.destinationKeySeparateFromCmk, false);
+    assert.equal(postura.bucketEncrypted, true);
+});
+
+test('una KMS distinta de la CMK auditada sí es una clave de destino válida', () => {
+    const { plan, aws } = fakePostura({ sse: { SSEAlgorithm: 'aws:kms',
+        KMSMasterKeyID: 'arn:aws:kms:us-east-2:123456789012:key/otra-clave' } });
+    const postura = cloudtrail.verifyDestinationPosture(plan, { keyArn: KEY_ARN }, aws);
+    assert.equal(postura.destinationKeySeparateFromCmk, true);
 });

--- a/.pipeline/lib/kernel-audit-evidence.js
+++ b/.pipeline/lib/kernel-audit-evidence.js
@@ -1,0 +1,229 @@
+'use strict';
+
+// =============================================================================
+// kernel-audit-evidence.js — #5213 CA-3
+//
+// Proyección ALLOWLIST + redacción de la evidencia de auditoría de la CMK.
+//
+// El orden importa y es el punto entero del módulo: se PROYECTA primero y se
+// escribe después. Nunca se persiste la respuesta cruda de AWS "para redactarla
+// más tarde": un registro de CloudTrail trae `recipientAccountId`,
+// `requestID`, `eventID`, ARNs completos y `requestParameters` con contexto de
+// cifrado. Una redacción por denylist sobre ese objeto falla abierto ante
+// cualquier campo nuevo que AWS agregue; una proyección por allowlist falla
+// cerrada (lo que no está listado, no sale).
+//
+// La segunda capa es `assertRedacted`, que vuelve a escanear el resultado ya
+// proyectado y TIRA si encuentra un identificador prohibido. No reemplaza a la
+// proyección: la audita. Si las dos capas discrepan, gana el error.
+// =============================================================================
+
+const crypto = require('node:crypto');
+const { redactSecretValue, shannonEntropy } = require('./redact');
+
+// Lo único que sale de un registro de CloudTrail hacia la evidencia. Todo lo
+// demás se descarta por omisión (allowlist, no denylist).
+const EVENT_ALLOWLIST = Object.freeze(['eventTime', 'eventName', 'principal',
+    'principalExpected', 'invokedBy', 'errorCode', 'outcome']);
+
+// Identificadores que la CA prohíbe explícitamente en la evidencia persistida.
+// El nombre es lo que se reporta al fallar; el valor ofensor NUNCA se incluye
+// en el mensaje de error (sería filtrarlo por el canal de la excepción).
+const FORBIDDEN_PATTERNS = Object.freeze([
+    { name: 'arn-completo', re: /arn:aws[a-z0-9-]*:/i },
+    { name: 'account-id', re: /(?<!\d)\d{12}(?!\d)/ },
+    { name: 'uuid-request-o-event-id', re: /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i },
+    { name: 'aws-access-key-id', re: /AKIA[0-9A-Z]{16}/ },
+    { name: 'jwt', re: /eyJ[A-Za-z0-9_-]*\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/ },
+]);
+
+// Un token opaco largo dentro de la evidencia es material criptográfico o un
+// identificador que no debería estar ahí. El umbral es el mismo que usa
+// `redact.js` para su heurística de entropía.
+const OPAQUE_MIN_LEN = 40;
+const OPAQUE_ENTROPY_THRESHOLD = 4.5;
+
+/**
+ * Reduce un principal a `<tipo>/<nombre>`, sin cuenta ni partición.
+ *
+ *   arn:aws:iam::123456789012:user/intrale-kernel-runtime → user/intrale-kernel-runtime
+ *   arn:aws:sts::123456789012:assumed-role/Rol/sesion     → assumed-role/Rol
+ *
+ * El nombre de sesión se descarta a propósito: en muchas organizaciones es el
+ * mail del operador, o sea PII que no aporta a la correlación.
+ */
+function redactPrincipal(identity) {
+    if (!identity) return null;
+    if (typeof identity === 'object') {
+        const fromArn = redactPrincipal(identity.arn);
+        return fromArn || identity.type || null;
+    }
+    const arn = String(identity);
+    if (!arn.startsWith('arn:')) {
+        // IDEMPOTENCIA. `extractCmkUsage` ya proyecta el principal y
+        // `projectEvent` vuelve a proyectarlo al construir la evidencia. Sin
+        // este paso, la segunda pasada no reconoce `user/intrale-kernel-runtime`
+        // —no es un ARN ni un principal de servicio— y devuelve `null`: la
+        // evidencia perdía el principal justo en el campo que la CA pide
+        // correlacionar. Observado el 2026-08-05 sobre eventos reales del trail.
+        if (/^[a-z-]+\/[\w+=,.@-]+$/i.test(arn)) return arn;
+        // Principal de servicio (`dynamodb.amazonaws.com`) o tipo suelto.
+        return /^[a-z0-9.-]+\.amazonaws\.com$/i.test(arn) || /^[A-Za-z]+$/.test(arn) ? arn : null;
+    }
+    const tail = arn.split(':').slice(5).join(':');
+    const parts = tail.split('/').filter(Boolean);
+    if (!parts.length) return null;
+    // `user/x`, `role/x`, `assumed-role/Rol` (se corta antes de la sesión).
+    return parts.slice(0, 2).join('/');
+}
+
+/**
+ * Huella estable de la CMK. Permite correlacionar dos evidencias entre sí sin
+ * publicar el ARN ni el key id. Es un digest de un identificador público, no un
+ * secreto: sirve para comparar, no para reconstruir.
+ */
+function keyFingerprint(keyArn) {
+    if (!keyArn) return null;
+    return crypto.createHash('sha256').update(String(keyArn)).digest('hex').slice(0, 12);
+}
+
+/** Referencia legible de la clave: alias humano + huella, sin ARN. */
+function keyReference(keyArn, alias) {
+    return { alias: alias || null, fingerprint: keyFingerprint(keyArn) };
+}
+
+/** Reemplaza el account id embebido en nombres de recurso (buckets, prefijos). */
+function redactResourceName(name) {
+    if (typeof name !== 'string') return name;
+    return name.replace(/(?<!\d)\d{12}(?!\d)/g, '<account>');
+}
+
+/**
+ * Redacta TEXTO LIBRE antes de que entre a la evidencia — típicamente el stderr
+ * del AWS CLI, que es la única entrada que no pasa por la proyección allowlist.
+ *
+ * Sin esto, `assertRedacted` haría abortar el reporte entero por un identificador
+ * en un mensaje de error: fallar cerrado está bien como última línea, pero perder
+ * la evidencia de diez pruebas negativas porque una traía un key id adentro es
+ * un mal intercambio. Se redacta acá y la auditoría queda como red de contención.
+ */
+function redactFreeText(text) {
+    if (typeof text !== 'string') return text;
+    return redactSecretValue(text)
+        .replace(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi, '[REDACTED:id]')
+        .replace(/(?<!\d)\d{12}(?!\d)/g, '<account>');
+}
+
+/**
+ * Proyecta un evento ya extraído del trail a los campos permitidos.
+ * `outcome` es derivado y explícito para que la evidencia sea legible sin
+ * interpretar la ausencia de `errorCode`.
+ */
+function projectEvent(event) {
+    const source = event || {};
+    const projected = {
+        eventTime: source.eventTime || null,
+        principal: redactPrincipal(source.principal),
+        principalExpected: source.principalExpected === undefined ? null : source.principalExpected,
+        invokedBy: source.invokedBy || null,
+        errorCode: source.errorCode || null,
+        outcome: source.errorCode ? 'denegado' : 'exitoso',
+    };
+    if (source.eventName) projected.eventName = source.eventName;
+    return projected;
+}
+
+/** Proyecta el mapa `{ Decrypt: [...], GenerateDataKey: [...] }` completo. */
+function projectUsage(usage) {
+    const out = {};
+    for (const [name, events] of Object.entries(usage || {})) {
+        out[name] = (events || []).map(projectEvent);
+    }
+    return out;
+}
+
+/**
+ * Proyecta el plan de provisioning para poder imprimirlo. El bucket lleva el
+ * account id en el nombre y el trail ARN lo lleva entero: los dos son
+ * exactamente lo que la CA prohíbe publicar.
+ */
+function projectPlan(plan) {
+    const source = plan || {};
+    return {
+        region: source.region || null,
+        bucket: redactResourceName(source.bucket),
+        trailName: source.trailName || null,
+        retentionDays: source.retentionDays === undefined ? null : source.retentionDays,
+        selector: source.selector || null,
+    };
+}
+
+/** Recorre un objeto proyectado y devuelve los hallazgos prohibidos por ruta. */
+function findForbidden(value, path = '$', found = []) {
+    if (value == null) return found;
+    if (typeof value === 'string') {
+        for (const { name, re } of FORBIDDEN_PATTERNS) {
+            if (re.test(value)) found.push({ path, pattern: name });
+        }
+        const trimmed = value.trim();
+        if (trimmed.length > OPAQUE_MIN_LEN && !/\s/.test(trimmed)
+            && shannonEntropy(trimmed) >= OPAQUE_ENTROPY_THRESHOLD) {
+            found.push({ path, pattern: 'token-opaco-alta-entropia' });
+        }
+        return found;
+    }
+    if (typeof value !== 'object') return found;
+    if (Array.isArray(value)) {
+        value.forEach((item, index) => findForbidden(item, `${path}[${index}]`, found));
+        return found;
+    }
+    for (const [key, item] of Object.entries(value)) {
+        findForbidden(key, `${path}.<clave>`, found);
+        findForbidden(item, `${path}.${key}`, found);
+    }
+    return found;
+}
+
+/**
+ * Auditoría de la proyección. Tira si sobrevivió un identificador prohibido.
+ *
+ * El mensaje nombra la RUTA y el PATRÓN, nunca el valor: un error que imprime
+ * el ARN que estaba tratando de ocultar filtra por el canal de la excepción, y
+ * las excepciones terminan en logs y en el issue.
+ */
+function assertRedacted(evidence) {
+    const found = findForbidden(evidence);
+    if (found.length) {
+        const detalle = found.map((f) => `${f.path} (${f.pattern})`).join(', ');
+        throw new Error(`evidencia con identificadores prohibidos: ${detalle}`);
+    }
+    return evidence;
+}
+
+/**
+ * Único punto de construcción de evidencia. Proyecta, redacta como defensa en
+ * profundidad y audita antes de devolver. Lo que sale de acá es lo que se puede
+ * escribir a disco, imprimir o pegar en un issue.
+ */
+function buildEvidence({ plan, keyArn, keyAlias, usage, negativeTests, generatedAt } = {}) {
+    const evidence = {
+        generatedAt: generatedAt || null,
+        plan: projectPlan(plan),
+        key: keyReference(keyArn, keyAlias),
+        usage: projectUsage(usage),
+    };
+    if (negativeTests) evidence.negativeTests = negativeTests;
+    // Defensa en profundidad: la proyección ya debería alcanzar, pero un campo
+    // de texto libre (mensaje de error del CLI) puede traer un secreto.
+    const scrubbed = JSON.parse(JSON.stringify(evidence), (_key, value) => (
+        typeof value === 'string' ? redactSecretValue(value) : value
+    ));
+    return assertRedacted(scrubbed);
+}
+
+module.exports = {
+    EVENT_ALLOWLIST, FORBIDDEN_PATTERNS,
+    redactPrincipal, keyFingerprint, keyReference, redactResourceName, redactFreeText,
+    projectEvent, projectUsage, projectPlan,
+    findForbidden, assertRedacted, buildEvidence,
+};

--- a/.pipeline/lib/kernel-audit-negative-tests.js
+++ b/.pipeline/lib/kernel-audit-negative-tests.js
@@ -1,0 +1,278 @@
+#!/usr/bin/env node
+'use strict';
+
+// =============================================================================
+// kernel-audit-negative-tests.js — #5213 CA-5
+//
+// Matriz de pruebas NEGATIVAS: ejecuta con las credenciales REALES del principal
+// runtime cada operación capaz de destruir el rastro de auditoría, y exige que
+// AWS la deniegue. Inspeccionar las policies no alcanza — una policy puede leerse
+// correcta y estar anulada por un allow heredado, un boundary ausente o una
+// SCP mal ordenada. La única prueba es intentarlo y que falle.
+//
+// TRES DECISIONES DE SEGURIDAD QUE NO SON NEGOCIABLES:
+//
+// 1. **Guarda de identidad.** El runner se niega a correr si el llamador no es
+//    el principal runtime. Corrido con una sesión administrativa, `delete-trail`
+//    y `stop-logging` NO serían denegados: destruirían el trail de verdad. La
+//    guarda es lo que hace seguro ejecutar esto contra producción.
+//
+// 2. **Operaciones no destructivas por construcción.** Donde el resultado de un
+//    permiso inesperado sería irreversible, los parámetros son un no-op:
+//    `update-trail` reenvía la configuración vigente, `put-event-selectors`
+//    reenvía el selector vigente, `delete-object` apunta a una clave inexistente
+//    con nonce. Si el permiso existiera, la llamada tendría éxito (que es el
+//    hallazgo que buscamos) sin romper nada. `stop-logging` y `delete-trail` no
+//    admiten esa forma, así que el runner los verifica DESPUÉS: relee el estado
+//    del trail y grita si dejó de loguear.
+//
+// 3. **Falla cerrada.** Denegado = aprobado. Éxito = CRÍTICO. Cualquier otro
+//    error = inconclusivo, y un inconclusivo NO aprueba. Un error de red no
+//    puede leerse como "está protegido".
+// =============================================================================
+
+const { spawnSync } = require('node:child_process');
+const crypto = require('node:crypto');
+const { redactResourceName, redactFreeText } = require('./kernel-audit-evidence');
+
+// AWS no unifica el código: S3 devuelve `AccessDenied`, CloudTrail y KMS
+// devuelven `AccessDeniedException`, y un deny explícito de IAM agrega
+// "with an explicit deny". Los tres son la denegación que la CA pide.
+const DENIAL_PATTERNS = Object.freeze([
+    /AccessDenied/i, /not authorized to perform/i, /explicit deny/i,
+    /UnauthorizedOperation/i, /InsufficientPrivileges/i,
+]);
+
+function esDenegacion(texto) {
+    return DENIAL_PATTERNS.some((re) => re.test(String(texto || '')));
+}
+
+/** Ejecuta el CLI sin tirar: la matriz necesita inspeccionar el fallo. */
+function runAwsRaw(args, options = {}) {
+    const result = spawnSync('aws', [...args, '--output', 'json'], {
+        encoding: 'utf8', env: options.env || process.env, shell: false,
+    });
+    return {
+        status: result.status,
+        stdout: String(result.stdout || ''),
+        stderr: String(result.stderr || ''),
+    };
+}
+
+/**
+ * Cada entrada declara UNA capacidad destructiva.
+ *
+ * - `build` arma los argumentos del CLI; `resource` es el recurso ya anonimizado
+ *   que se reporta en la evidencia.
+ * - `destructive` marca las que SÍ causarían daño real si el permiso existiera.
+ *   Las no destructivas son no-ops o apuntan a recursos inexistentes: si el
+ *   permiso existiera, tendrían éxito (que es el hallazgo) sin romper nada.
+ *
+ * El ORDEN dentro de cada servicio es de menor a mayor daño, y no es cosmético:
+ * el runner corta la escalada del servicio ante el primer resultado no denegado.
+ */
+const NEGATIVE_MATRIX = Object.freeze([
+    {
+        id: 'trail-update', service: 'cloudtrail', destructive: false,
+        capability: 'modificar la configuración del trail',
+        resource: (plan) => `cloudtrail/${plan.trailName}`,
+        // No-op deliberado: reenvía la configuración vigente.
+        build: (plan) => ['cloudtrail', 'update-trail', '--name', plan.trailName,
+            '--region', plan.region, '--enable-log-file-validation'],
+    },
+    {
+        id: 'trail-event-selectors', service: 'cloudtrail', destructive: false,
+        capability: 'alterar los event selectors',
+        resource: (plan) => `cloudtrail/${plan.trailName}`,
+        // No-op: reenvía el selector vigente.
+        build: (plan) => ['cloudtrail', 'put-event-selectors', '--trail-name', plan.trailName,
+            '--region', plan.region, '--event-selectors', JSON.stringify(plan.selector)],
+    },
+    {
+        id: 'trail-stop-logging', service: 'cloudtrail', destructive: true,
+        capability: 'detener el trail',
+        resource: (plan) => `cloudtrail/${plan.trailName}`,
+        build: (plan) => ['cloudtrail', 'stop-logging', '--name', plan.trailName, '--region', plan.region],
+    },
+    {
+        id: 'trail-delete', service: 'cloudtrail', destructive: true,
+        capability: 'borrar el trail',
+        resource: (plan) => `cloudtrail/${plan.trailName}`,
+        build: (plan) => ['cloudtrail', 'delete-trail', '--name', plan.trailName, '--region', plan.region],
+    },
+    {
+        id: 'bucket-read-audit', service: 's3', destructive: false,
+        capability: 'leer la auditoría que él mismo genera',
+        resource: (plan) => `s3/${redactResourceName(plan.bucket)}`,
+        build: (plan) => ['s3api', 'list-objects-v2', '--bucket', plan.bucket,
+            '--region', plan.region, '--max-items', '1'],
+    },
+    {
+        id: 'bucket-delete-object', service: 's3', destructive: false,
+        capability: 'borrar objetos del destino',
+        resource: (plan) => `s3/${redactResourceName(plan.bucket)}`,
+        // Clave inexistente con nonce: S3 borra de forma idempotente, así que
+        // apuntar a un objeto real destruiría evidencia si el permiso existiera.
+        build: (plan, ctx) => ['s3api', 'delete-object', '--bucket', plan.bucket,
+            '--region', plan.region,
+            '--key', `AWSLogs/${plan.accountId}/negative-test-${ctx.nonce}.json.gz`],
+    },
+    {
+        id: 'bucket-lifecycle-retention', service: 's3', destructive: true,
+        capability: 'reducir la retención del destino',
+        resource: (plan) => `s3/${redactResourceName(plan.bucket)}`,
+        build: (plan) => ['s3api', 'put-bucket-lifecycle-configuration', '--bucket', plan.bucket,
+            '--region', plan.region, '--lifecycle-configuration', JSON.stringify({ Rules: [{
+                ID: 'NegativeTestShortenRetention', Status: 'Enabled', Filter: { Prefix: '' },
+                Expiration: { Days: 1 },
+            }] })],
+    },
+    {
+        id: 'bucket-policy-rewrite', service: 's3', destructive: true,
+        capability: 'reescribir la policy del destino',
+        resource: (plan) => `s3/${redactResourceName(plan.bucket)}`,
+        build: (plan) => ['s3api', 'delete-bucket-policy', '--bucket', plan.bucket, '--region', plan.region],
+    },
+    // `DisableKey` y `ScheduleKeyDeletion` NO aceptan alias: exigen key id. Con
+    // el alias devuelven `InvalidArnException`, que NO es una denegación — la
+    // prueba quedaría inconclusiva y aprobaría por accidente si el veredicto
+    // fuera laxo. El key id lo resuelve la identidad AUDITORA (el runtime no
+    // tiene ni `kms:DescribeKey`) y se pasa por `--key-id`.
+    {
+        id: 'kms-disable-key', service: 'kms', destructive: true,
+        capability: 'deshabilitar la clave',
+        resource: () => 'kms/clave-del-store',
+        requiresKeyId: true,
+        build: (plan) => ['kms', 'disable-key', '--key-id', plan.keyId, '--region', plan.region],
+    },
+    {
+        id: 'kms-schedule-deletion', service: 'kms', destructive: true,
+        capability: 'programar el borrado de la clave',
+        resource: () => 'kms/clave-del-store',
+        requiresKeyId: true,
+        build: (plan) => ['kms', 'schedule-key-deletion', '--key-id', plan.keyId,
+            '--region', plan.region, '--pending-window-in-days', '30'],
+    },
+]);
+
+/**
+ * Guarda de identidad. Sin esto, correr la matriz con una sesión administrativa
+ * BORRA el trail en vez de probar que está protegido.
+ */
+function assertRuntimeIdentity(expectedUserName, aws = runAwsRaw) {
+    const result = aws(['sts', 'get-caller-identity']);
+    if (result.status !== 0) {
+        throw new Error('no se pudo resolver la identidad del llamador; la matriz no corre a ciegas');
+    }
+    const arn = String((JSON.parse(result.stdout || '{}')).Arn || '');
+    if (!arn.endsWith(`/${expectedUserName}`)) {
+        throw new Error(`la matriz negativa exige la identidad ${expectedUserName};`
+            + ' correrla con otra credencial destruiría el trail en vez de verificarlo');
+    }
+    return true;
+}
+
+/** Clasifica el resultado de UNA operación. Denegado es el único aprobado. */
+function clasificar(result) {
+    if (result.status === 0) {
+        return { outcome: 'NO-DENEGADO', denied: false,
+            detalle: 'la operación fue permitida: el runtime puede degradar la auditoría' };
+    }
+    if (esDenegacion(result.stderr)) {
+        return { outcome: 'AccessDenied', denied: true, detalle: null };
+    }
+    return { outcome: 'inconclusivo', denied: false,
+        detalle: redactFreeText(String(result.stderr || '').trim().split('\n').pop() || '') };
+}
+
+/**
+ * Corre la matriz completa. Devuelve evidencia ya anonimizada más un veredicto
+ * agregado. `postCheck` relee el estado del trail después de las operaciones
+ * irreversibles para detectar el caso peor: que alguna haya prendido.
+ */
+function runNegativeMatrix(plan, { nonce, aws = runAwsRaw, skipIdentityGuard = false } = {}) {
+    if (!skipIdentityGuard) assertRuntimeIdentity(plan.runtimeUserName, aws);
+    const ctx = { nonce: nonce || crypto.randomUUID() };
+    // Corta-escalada: en cuanto una operación de un servicio NO resulta denegada,
+    // las DESTRUCTIVAS que quedan de ese servicio no se ejecutan. Ese resultado
+    // ya prueba que la barrera no está; seguir escalando sólo agrega la chance
+    // de detener el trail o deshabilitar la clave de verdad.
+    const comprometidos = new Set();
+    const results = NEGATIVE_MATRIX.map((entry) => {
+        const base = { id: entry.id, capability: entry.capability,
+            resource: entry.resource(plan), destructive: entry.destructive };
+        if (entry.destructive && comprometidos.has(entry.service)) {
+            return { ...base, outcome: 'no-ejecutado', denied: false,
+                detalle: `omitida: otra operación de ${entry.service} no fue denegada` };
+        }
+        // Sin key id, la llamada devolvería `InvalidArnException` en vez de una
+        // denegación: es una prueba NO REALIZADA, y decirlo así evita que un
+        // error de forma se lea como postura verificada.
+        if (entry.requiresKeyId && !plan.keyId) {
+            return { ...base, outcome: 'inconclusivo', denied: false,
+                detalle: 'falta el key id (lo resuelve la identidad auditora con --key-id)' };
+        }
+        const clasificado = clasificar(aws(entry.build(plan, ctx)));
+        if (!clasificado.denied) comprometidos.add(entry.service);
+        return { ...base, ...clasificado };
+    });
+    return {
+        results,
+        // Falla cerrada: sólo aprueba si TODAS fueron denegadas. Un inconclusivo
+        // o una omitida arrastran el veredicto a rechazado a propósito.
+        allDenied: results.every((r) => r.denied),
+        notDenied: results.filter((r) => !r.denied).map((r) => r.id),
+    };
+}
+
+/**
+ * Post-check con la identidad auditora: confirma que el trail sigue activo
+ * después de haberle tirado `stop-logging` y `delete-trail` encima.
+ */
+function verificarTrailIntacto(plan, aws = runAwsRaw) {
+    const result = aws(['cloudtrail', 'get-trail-status', '--name', plan.trailName, '--region', plan.region]);
+    if (result.status !== 0) {
+        return { legible: false, logging: null,
+            detalle: redactFreeText(String(result.stderr || '').trim().split('\n').pop() || '') };
+    }
+    return { legible: true, logging: JSON.parse(result.stdout || '{}').IsLogging === true, detalle: null };
+}
+
+module.exports = {
+    NEGATIVE_MATRIX, DENIAL_PATTERNS, esDenegacion, runAwsRaw,
+    assertRuntimeIdentity, clasificar, runNegativeMatrix, verificarTrailIntacto,
+};
+
+if (require.main === module) {
+    const {
+        DEFAULTS, buildPlan,
+    } = require('./kernel-cloudtrail-provision');
+    const { buildEvidence } = require('./kernel-audit-evidence');
+    const ejecutar = process.argv.includes('--run');
+    const keyIdIndex = process.argv.indexOf('--key-id');
+    try {
+        const identity = runAwsRaw(['sts', 'get-caller-identity']);
+        if (identity.status !== 0) throw new Error('sin identidad AWS resoluble');
+        const plan = {
+            ...buildPlan({ accountId: JSON.parse(identity.stdout).Account }),
+            keyAlias: DEFAULTS.keyAlias, runtimeUserName: DEFAULTS.runtimeUserName,
+            keyId: keyIdIndex !== -1 ? process.argv[keyIdIndex + 1] : undefined,
+        };
+        if (!ejecutar) {
+            process.stdout.write(`${JSON.stringify({ mode: 'dry-run',
+                matriz: NEGATIVE_MATRIX.map((e) => ({ id: e.id, capability: e.capability,
+                    resource: e.resource(plan) })) }, null, 2)}\n`);
+        } else {
+            const matriz = runNegativeMatrix(plan, {});
+            const trail = verificarTrailIntacto(plan);
+            const evidence = buildEvidence({ plan, keyAlias: DEFAULTS.keyAlias,
+                generatedAt: new Date().toISOString(),
+                negativeTests: { ...matriz, trailIntactoSegunRuntime: trail } });
+            process.stdout.write(`${JSON.stringify(evidence, null, 2)}\n`);
+            if (!matriz.allDenied) process.exitCode = 1;
+        }
+    } catch (error) {
+        process.stderr.write(`kernel-audit-negative-tests: ${redactSecretValue(error.message)}\n`);
+        process.exitCode = 1;
+    }
+}

--- a/.pipeline/lib/kernel-cloudtrail-provision.js
+++ b/.pipeline/lib/kernel-cloudtrail-provision.js
@@ -8,10 +8,15 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 const zlib = require('node:zlib');
+const { redactPrincipal, buildEvidence } = require('./kernel-audit-evidence');
 
 const DEFAULTS = Object.freeze({
     region: 'us-east-2', trailName: 'intrale-kernel-kms',
     keyAlias: 'alias/intrale-kernel-store', retentionDays: 365,
+    // Separación de identidades del runbook §3: el runtime descifra el store
+    // pero NO lee ni altera su propia auditoría; el auditor lee la auditoría
+    // pero no puede descifrar. Ninguno de los dos puede aprovisionar.
+    runtimeUserName: 'intrale-kernel-runtime', auditorUserName: 'claude-code',
 });
 
 // Las dos operaciones que delatan uso real de la clave (runbook §3).
@@ -36,24 +41,62 @@ function bucketName(accountId, region) {
     return `intrale-kernel-cloudtrail-${accountId}-${region}`;
 }
 
-function bucketPolicy({ bucket, accountId, trailArn }) {
-    return { Version: '2012-10-17', Statement: [
+// Las capacidades del runtime sobre el destino de auditoría que se niegan de
+// forma explícita. Un deny explícito gana sobre cualquier allow, presente o
+// futuro: si mañana alguien le adjunta una policy amplia al runtime, estas
+// operaciones siguen bloqueadas. La lista es también el contrato que verifica
+// la matriz de pruebas negativas (#5213 CA-5).
+const RUNTIME_DENIED_BUCKET_ACTIONS = Object.freeze([
+    's3:DeleteObject', 's3:DeleteObjectVersion', 's3:PutObject',
+    's3:PutLifecycleConfiguration', 's3:PutBucketPolicy', 's3:DeleteBucketPolicy',
+    's3:PutBucketVersioning', 's3:PutEncryptionConfiguration', 's3:DeleteBucket',
+    // El runtime tampoco LEE la auditoría: quien genera la evidencia no es
+    // quien la consulta (runbook §3).
+    's3:GetObject', 's3:GetObjectVersion', 's3:ListBucket', 's3:ListBucketVersions',
+]);
+
+function bucketPolicy({ bucket, accountId, trailArn, runtimePrincipalArn, auditorPrincipalArn }) {
+    const bucketArn = `arn:aws:s3:::${bucket}`;
+    const statements = [
         { Sid: 'AWSCloudTrailAclCheck', Effect: 'Allow',
             Principal: { Service: 'cloudtrail.amazonaws.com' }, Action: 's3:GetBucketAcl',
-            Resource: `arn:aws:s3:::${bucket}`,
+            Resource: bucketArn,
             Condition: { StringEquals: { 'AWS:SourceArn': trailArn } } },
         { Sid: 'AWSCloudTrailWrite', Effect: 'Allow',
             Principal: { Service: 'cloudtrail.amazonaws.com' }, Action: 's3:PutObject',
-            Resource: `arn:aws:s3:::${bucket}/AWSLogs/${accountId}/*`,
+            Resource: `${bucketArn}/AWSLogs/${accountId}/*`,
             Condition: { StringEquals: { 's3:x-amz-acl': 'bucket-owner-full-control',
                 'AWS:SourceArn': trailArn } } },
-    ] };
+        // TLS-only. Va sobre `Principal: '*'` a propósito: la garantía es del
+        // canal, no de quién llama, y tiene que cubrir también al servicio.
+        { Sid: 'DenyInsecureTransport', Effect: 'Deny', Principal: '*', Action: 's3:*',
+            Resource: [bucketArn, `${bucketArn}/*`],
+            Condition: { Bool: { 'aws:SecureTransport': 'false' } } },
+    ];
+    if (runtimePrincipalArn) {
+        statements.push({ Sid: 'DenyRuntimeAuditAccess', Effect: 'Deny',
+            Principal: { AWS: runtimePrincipalArn },
+            Action: [...RUNTIME_DENIED_BUCKET_ACTIONS],
+            Resource: [bucketArn, `${bucketArn}/*`] });
+    }
+    if (auditorPrincipalArn) {
+        // Acceso de auditoría declarado en el destino, separado del runtime y
+        // de sólo lectura: el auditor consulta el rastro, no lo modifica.
+        statements.push({ Sid: 'AllowAuditorRead', Effect: 'Allow',
+            Principal: { AWS: auditorPrincipalArn },
+            Action: ['s3:GetObject', 's3:GetObjectVersion', 's3:ListBucket', 's3:GetBucketLocation'],
+            Resource: [bucketArn, `${bucketArn}/*`] });
+    }
+    return { Version: '2012-10-17', Statement: statements };
 }
 
 function buildPlan({ accountId, region = DEFAULTS.region, retentionDays = DEFAULTS.retentionDays } = {}) {
     const bucket = bucketName(accountId, region);
     const trailArn = `arn:aws:cloudtrail:${region}:${accountId}:trail/${DEFAULTS.trailName}`;
     return { accountId, region, bucket, trailArn, retentionDays,
+        trailName: DEFAULTS.trailName,
+        runtimePrincipalArn: `arn:aws:iam::${accountId}:user/${DEFAULTS.runtimeUserName}`,
+        auditorPrincipalArn: `arn:aws:iam::${accountId}:user/${DEFAULTS.auditorUserName}`,
         selector: [{ ReadWriteType: 'All', IncludeManagementEvents: true }] };
 }
 
@@ -141,8 +184,40 @@ function readTrailObject(plan, objectKey, aws = runAws) {
     }
 }
 
+// Quién se espera que ejecute cada operación NO es el mismo principal, y tratarlo
+// como si lo fuera hace la verificación imposible de satisfacer:
+//
+// - `Decrypt` lo pide el USUARIO runtime a través de DynamoDB: aparece con su ARN.
+// - `GenerateDataKey` lo ejecuta DYNAMODB en nombre de la tabla, como `AWSService`.
+//   El usuario runtime NO tiene `kms:GenerateDataKey` en ninguna policy —
+//   verificado el 2026-08-05: `no identity-based policy allows the
+//   kms:GenerateDataKey action`— así que exigir su ARN ahí sería exigir algo que
+//   AWS nunca va a emitir.
+//
+// Lo que prueba uso legítimo en `GenerateDataKey` es que la invocación venga de
+// DynamoDB, que es exactamente lo que ata el `kms:ViaService` de la key policy:
+// una data key generada desde otro servicio sería el hallazgo.
+const EXPECTED_INVOKED_BY = 'dynamodb.amazonaws.com';
+
+function principalEsperado(record, eventName, expectedPrincipalArn) {
+    const identity = record.userIdentity || {};
+    if (eventName === 'GenerateDataKey') {
+        return identity.invokedBy === EXPECTED_INVOKED_BY
+            || record.sourceIPAddress === EXPECTED_INVOKED_BY;
+    }
+    if (!expectedPrincipalArn) return null;
+    return redactPrincipal(identity.arn) === redactPrincipal(expectedPrincipalArn);
+}
+
 // Puro: filtra los eventos KMS del trail que tocan la CMK del kernel.
-function extractCmkUsage(records, keyArn) {
+//
+// #5213 CA-3 — el evento sale YA PROYECTADO: `principal` es `user/<nombre>`, no
+// el ARN completo que trae `userIdentity.arn` (incluye el account id). La
+// correlación con el principal esperado se resuelve acá, mientras todavía se
+// tiene el ARN crudo en memoria, y viaja como el booleano `principalExpected`.
+// Así ningún consumidor necesita el ARN, que es la única forma de garantizar
+// que no termine escrito en un artefacto.
+function extractCmkUsage(records, keyArn, { expectedPrincipalArn } = {}) {
     const keyId = String(keyArn).split('/').pop();
     const usage = Object.fromEntries(CMK_EVENT_NAMES.map((name) => [name, []]));
     for (const record of records || []) {
@@ -150,9 +225,11 @@ function extractCmkUsage(records, keyArn) {
         if (!CMK_EVENT_NAMES.includes(record.eventName)) continue;
         const raw = JSON.stringify(record);
         if (!raw.includes(keyArn) && !raw.includes(keyId)) continue;
+        const identity = record.userIdentity || {};
         usage[record.eventName].push({
             eventTime: record.eventTime,
-            principal: (record.userIdentity && (record.userIdentity.arn || record.userIdentity.type)) || null,
+            principal: redactPrincipal(identity.arn || identity.type || null),
+            principalExpected: principalEsperado(record, record.eventName, expectedPrincipalArn),
             invokedBy: record.sourceIPAddress || null,
             errorCode: record.errorCode || null,
         });
@@ -162,13 +239,13 @@ function extractCmkUsage(records, keyArn) {
 
 // Lee el TRAIL PERSISTENTE en S3, no el Event history de 90 días: es la única
 // fuente con la retención que exige el runbook §3.
-function verifyKmsEventsFromTrail(plan, { keyArn, sinceMs = 0 } = {}, deps = {}) {
+function verifyKmsEventsFromTrail(plan, { keyArn, sinceMs = 0, expectedPrincipalArn } = {}, deps = {}) {
     if (!keyArn) throw new Error('keyArn requerido para verificar el rastro de la CMK');
     const aws = deps.aws || runAws;
     const readObject = deps.readObject || ((objectKey) => readTrailObject(plan, objectKey, aws));
     const usage = Object.fromEntries(CMK_EVENT_NAMES.map((name) => [name, []]));
     for (const objectKey of listTrailObjects(plan, { sinceMs }, aws)) {
-        const found = extractCmkUsage(readObject(objectKey), keyArn);
+        const found = extractCmkUsage(readObject(objectKey), keyArn, { expectedPrincipalArn });
         for (const name of CMK_EVENT_NAMES) usage[name].push(...found[name]);
     }
     return usage;
@@ -179,18 +256,74 @@ function verifyKmsEventsFromTrail(plan, { keyArn, sinceMs = 0 } = {}, deps = {})
 // real, así que cada operación exige al menos un evento EXITOSO: contar los
 // denegados dejaría la verificación fail-open (un AccessDenied daría por probada
 // una postura de auditoría que nunca se ejerció).
+//
+// #5213 CA-2 — además del éxito se exige que el evento venga del principal
+// esperado cuando la verificación declaró uno. Un `Decrypt` exitoso de OTRA
+// identidad prueba que el trail funciona, pero no correlaciona el uso de la CMK
+// con el runtime del kernel, que es lo que la CA pide demostrar.
+// `principalExpected: null` significa "no se declaró expectativa" y no descarta.
 function successfulCmkUsage(usage, name) {
-    return (usage[name] || []).filter((event) => !event.errorCode);
+    return (usage[name] || []).filter((event) => !event.errorCode && event.principalExpected !== false);
 }
 
 function isCmkUsageComplete(usage) {
     return CMK_EVENT_NAMES.every((name) => successfulCmkUsage(usage, name).length > 0);
 }
 
+// Postura efectiva del destino leída de AWS, no de la policy que creemos haber
+// aplicado (#5213 CA-1/CA-4). Devuelve un objeto de booleanos: cada campo es
+// una garantía de la CA, así que un `false` nombra exactamente qué se rompió.
+function verifyDestinationPosture(plan, { keyArn } = {}, aws = runAws) {
+    const status = aws(['cloudtrail', 'get-trail-status', '--name', plan.trailName, '--region', plan.region]);
+    const described = aws(['cloudtrail', 'describe-trails', '--trail-name-list', plan.trailName,
+        '--region', plan.region]);
+    const trail = (described.trailList || [])[0] || {};
+    const selectors = aws(['cloudtrail', 'get-event-selectors', '--trail-name', plan.trailName,
+        '--region', plan.region]);
+    const selector = (selectors.EventSelectors || [])[0] || {};
+    const access = aws(['s3api', 'get-public-access-block', '--bucket', plan.bucket, '--region', plan.region]);
+    const block = access.PublicAccessBlockConfiguration || {};
+    const encryption = aws(['s3api', 'get-bucket-encryption', '--bucket', plan.bucket, '--region', plan.region]);
+    const rule = ((encryption.ServerSideEncryptionConfiguration || {}).Rules || [])[0] || {};
+    const sse = rule.ApplyServerSideEncryptionByDefault || {};
+    const lifecycle = aws(['s3api', 'get-bucket-lifecycle-configuration', '--bucket', plan.bucket,
+        '--region', plan.region]);
+    const policy = JSON.parse((aws(['s3api', 'get-bucket-policy', '--bucket', plan.bucket,
+        '--region', plan.region]).Policy) || '{}');
+    const sids = new Set((policy.Statement || []).map((s) => s.Sid));
+
+    return {
+        trailLogging: status.IsLogging === true,
+        trailRegion: trail.HomeRegion === plan.region,
+        logFileValidation: trail.LogFileValidationEnabled === true,
+        managementEventsReadWrite: selector.IncludeManagementEvents === true
+            && selector.ReadWriteType === 'All',
+        bucketPrivate: [block.BlockPublicAcls, block.IgnorePublicAcls,
+            block.BlockPublicPolicy, block.RestrictPublicBuckets].every((flag) => flag === true),
+        bucketEncrypted: Boolean(sse.SSEAlgorithm),
+        // La clave del destino debe ser DISTINTA de la CMK auditada: si fuera la
+        // misma, deshabilitarla para contener un incidente del store dejaría
+        // ilegible la evidencia del propio incidente.
+        destinationKeySeparateFromCmk: sse.SSEAlgorithm === 'AES256'
+            || (Boolean(sse.KMSMasterKeyID) && String(sse.KMSMasterKeyID) !== String(keyArn || '')),
+        retentionDeclared: ((lifecycle.Rules || []).some((r) => r.Status === 'Enabled'
+            && r.Expiration && r.Expiration.Days === plan.retentionDays)),
+        tlsOnly: sids.has('DenyInsecureTransport'),
+        runtimeDeniedOnDestination: sids.has('DenyRuntimeAuditAccess'),
+        auditorAccessSeparated: sids.has('AllowAuditorRead'),
+    };
+}
+
+function posturaCompleta(postura) {
+    return Object.values(postura).every(Boolean);
+}
+
 module.exports = {
-    DEFAULTS, CMK_EVENT_NAMES, runAws, bucketName, bucketPolicy, buildPlan, ensureBucket, applyPlan,
+    DEFAULTS, CMK_EVENT_NAMES, RUNTIME_DENIED_BUCKET_ACTIONS,
+    runAws, bucketName, bucketPolicy, buildPlan, ensureBucket, applyPlan,
     resolveKeyArn, emitCmkUsage, listTrailObjects, readTrailObject, extractCmkUsage,
     verifyKmsEventsFromTrail, isCmkUsageComplete, successfulCmkUsage,
+    verifyDestinationPosture, posturaCompleta, principalEsperado, EXPECTED_INVOKED_BY,
 };
 
 function flagValue(name, fallback) {
@@ -209,35 +342,57 @@ if (require.main === module) {
     try {
         const identity = runAws(['sts', 'get-caller-identity']);
         const plan = buildPlan({ accountId: identity.Account });
-        const report = { identity: identity.Arn, plan: undefined, status: undefined, emitted: undefined, evidence: undefined };
+        // #5213 CA-3 — TODO lo que se imprime pasa por la proyección allowlist.
+        // El plan crudo lleva el account id en el bucket y el ARN entero del
+        // trail; la identidad, el ARN del llamador. Nada de eso puede quedar en
+        // el stdout, que termina en logs y en el issue.
+        const report = { identity: redactPrincipal(identity.Arn) };
         if (!apply && !emit && !verify) {
-            process.stdout.write(`${JSON.stringify({ mode: 'dry-run', plan }, null, 2)}\n`);
+            process.stdout.write(`${JSON.stringify(buildEvidence({
+                plan, keyAlias: DEFAULTS.keyAlias, generatedAt: new Date().toISOString(),
+            }), null, 2)}\n`);
         } else {
-            if (apply) report.status = applyPlan(plan);
+            if (apply) report.status = { logging: applyPlan(plan).IsLogging === true };
             // El emisor necesita kms:Decrypt sobre la CMK; el verificador sólo lee S3.
             // Se corren con identidades distintas a propósito (runbook §3).
             let sinceMs = Date.parse(flagValue('--since', '')) || 0;
             if (emit) {
-                report.emitted = emitCmkUsage(plan, require('./config-resolver').resolve().kernel);
-                sinceMs = report.emitted.startedAtMs;
+                const emitted = emitCmkUsage(plan, require('./config-resolver').resolve().kernel);
+                sinceMs = emitted.startedAtMs;
+                // El nonce y el nombre de tabla no aportan a la evidencia y sí
+                // describen el store: alcanza con confirmar que se emitió.
+                report.emitted = { emitido: true };
             }
+            let usage;
+            let keyArn;
             if (verify) {
-                const keyArn = resolveKeyArn(plan);
+                keyArn = resolveKeyArn(plan);
                 const deadline = Date.now() + Number(flagValue('--wait', '0')) * 1000;
                 do {
-                    report.evidence = verifyKmsEventsFromTrail(plan, { keyArn, sinceMs });
-                    if (isCmkUsageComplete(report.evidence)) break;
+                    usage = verifyKmsEventsFromTrail(plan, { keyArn, sinceMs,
+                        expectedPrincipalArn: plan.runtimePrincipalArn });
+                    if (isCmkUsageComplete(usage)) break;
                     if (Date.now() < deadline) sleepSync(60_000);
                 } while (Date.now() < deadline);
-                report.keyArn = keyArn;
-                report.complete = isCmkUsageComplete(report.evidence);
+                report.complete = isCmkUsageComplete(usage);
+                report.postura = verifyDestinationPosture(plan, { keyArn });
+                report.posturaCompleta = posturaCompleta(report.postura);
             }
-            process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+            const evidence = buildEvidence({ plan, keyArn, keyAlias: DEFAULTS.keyAlias,
+                usage, generatedAt: new Date().toISOString() });
+            process.stdout.write(`${JSON.stringify({ ...report, ...evidence }, null, 2)}\n`);
             // Exit 2 = falta evidencia todavía (reintentar), NO recrear el trail.
             if (verify && !report.complete) process.exitCode = 2;
+            // Exit 3 = el trail existe pero la postura del destino no cumple.
+            // Se distingue de 2 porque acá reintentar no sirve: hay que corregir.
+            if (verify && report.complete && !report.posturaCompleta) process.exitCode = 3;
         }
     } catch (error) {
-        process.stderr.write(`kernel-cloudtrail-provision: ${error.message}\n`);
+        // El stderr del AWS CLI llega crudo hasta acá y trae ARNs y account id
+        // en los mensajes de autorización (#5213 CA-3): se redacta antes de
+        // escribirlo, porque este stream también queda en los logs del pipeline.
+        const { redactSecretValue } = require('./redact');
+        process.stderr.write(`kernel-cloudtrail-provision: ${redactSecretValue(error.message)}\n`);
         process.exitCode = 1;
     }
 }

--- a/docs/pipeline/runbook-cutover-durable.md
+++ b/docs/pipeline/runbook-cutover-durable.md
@@ -307,7 +307,32 @@ AWS_PROFILE=<perfil-pipeline> node .pipeline/lib/kernel-cloudtrail-provision.js 
 `--emit-usage` escribe, lee y borra un ítem efímero en la tabla de coordinación
 (nunca en la tabla append-only de no-repudio). `--verify` **lee los objetos del
 trail en S3** —no el Event history— y exige `Decrypt` y `GenerateDataKey`
-asociados a `alias/intrale-kernel-store`. CloudTrail entrega en lotes de ~5
+asociados a `alias/intrale-kernel-store`.
+
+⚠️ **`Decrypt` y `GenerateDataKey` NO los ejecuta el mismo principal, y
+`GenerateDataKey` no se produce a demanda.** Los dos puntos se verificaron
+empíricamente el 2026-08-05 y condicionan cómo se lee la evidencia:
+
+- **`Decrypt` → usuario runtime.** Aparece con el ARN de
+  `intrale-kernel-runtime`, `invokedBy: dynamodb.amazonaws.com`.
+- **`GenerateDataKey` → DynamoDB, como `AWSService`.** El usuario runtime **no
+  tiene** `kms:GenerateDataKey` en ninguna policy: una llamada directa devuelve
+  `no identity-based policy allows the kms:GenerateDataKey action`. La data key
+  la genera DynamoDB en nombre de la tabla. Exigir el ARN del runtime en esta
+  operación sería exigir un evento que AWS nunca emite.
+
+Lo que prueba uso legítimo en `GenerateDataKey` es que la invocación venga de
+**DynamoDB** —justo lo que ata el `kms:ViaService` de la key policy—. Una data
+key generada desde otro servicio sería el hallazgo, y el verificador la marca
+`principalExpected: false`.
+
+Además, `GenerateDataKey` corresponde al **ciclo de vida de la data key de la
+tabla** (creación/rotación), no a cada escritura: una emisión nueva produce
+`Decrypt` pero normalmente **no** `GenerateDataKey`. Por eso `--verify` sin
+`--since` —sobre la ventana completa de retención— es la forma correcta de
+cerrar la correlación; acotar la ventana a la emisión sólo evidencia `Decrypt`.
+Que falte `GenerateDataKey` en una ventana corta **no** es un fallo del trail:
+recrearlo no cambia nada. CloudTrail entrega en lotes de ~5
 minutos: un exit code `2` significa *todavía no llegó la evidencia*, se repite la
 verificación; **no** se recrea el trail. `--wait <segundos>` reintenta solo.
 
@@ -322,6 +347,7 @@ Verificado empíricamente al aprovisionar el trail (2026-08-05):
 | **Leer el trail en S3** (`--verify`) | `s3:ListBucket`, `s3:GetObject` | ✅ **permitido** | — |
 | Emitir uso de la CMK (`--emit-usage`) | `kms:Decrypt` vía DynamoDB | ❌ **denegado** | ✅ permitido |
 | Consultar Event history (`lookup-events`) | `cloudtrail:LookupEvents` | ❌ denegado | ❌ |
+| Endurecer la policy del destino (`put-bucket-policy`) | `s3:PutBucketPolicy` | ✅ permitido | ❌ denegado |
 
 El aprovisionamiento es un **paso admin de una sola vez**: la identidad del
 pipeline no puede crear el bucket ni el trail, y eso es deseable (el pipeline no
@@ -409,6 +435,127 @@ archivos se puede probar contra los digest de
 aws cloudtrail validate-logs --trail-arn <TRAIL_ARN> \
   --start-time <UTC-INICIO> --region us-east-2
 ```
+
+#### Evidencia redactada: qué sale y qué nunca sale
+
+La evidencia se construye por **proyección allowlist**, no por redacción posterior
+(`.pipeline/lib/kernel-audit-evidence.js`). El orden importa: nunca se persiste la
+respuesta cruda de AWS "para limpiarla después". Un registro de CloudTrail trae
+`recipientAccountId`, `requestID`, `eventID`, ARNs completos y `requestParameters`
+con contexto de cifrado; una denylist sobre eso falla **abierta** ante cualquier
+campo nuevo que AWS agregue, y una allowlist falla **cerrada**.
+
+Lo único que sale de un evento es: `eventTime`, `eventName`, `principal`
+(reducido a `user/<nombre>`), `principalExpected`, `invokedBy`, `errorCode` y
+`outcome`. La clave se referencia por **alias + huella** (`sha256` truncado), no
+por ARN ni key id.
+
+Nunca salen: account-id, ARN completo, request/event IDs, key id, nombre de
+sesión de un rol asumido, credenciales ni material criptográfico. Una segunda
+capa (`assertRedacted`) reescanea lo ya proyectado y **aborta** si algo pasó; su
+mensaje nombra la ruta y el patrón, nunca el valor —un error que imprime el ARN
+que estaba ocultando lo filtra igual, y los errores terminan en logs y en issues.
+
+Esto aplica también al `stdout` del aprovisionador: el plan crudo lleva el
+account-id embebido en el nombre del bucket y el ARN entero del trail, así que
+**todo** lo que imprime pasa por la proyección.
+
+#### Endurecimiento del destino
+
+La policy del bucket declara cinco statements (`bucketPolicy` en
+`.pipeline/lib/kernel-cloudtrail-provision.js`):
+
+| Sid | Efecto | Para qué |
+|---|---|---|
+| `AWSCloudTrailAclCheck` / `AWSCloudTrailWrite` | Allow | Entrega del trail, acotada por `AWS:SourceArn` |
+| `DenyInsecureTransport` | Deny `*` | TLS-only. Va sobre `Principal: '*'` a propósito: la garantía es del canal, no de quién llama |
+| `DenyRuntimeAuditAccess` | Deny runtime | El runtime no borra, no degrada retención, no reescribe la policy **y tampoco lee** la auditoría que genera |
+| `AllowAuditorRead` | Allow auditor | Acceso de auditoría declarado en el destino, separado del runtime y de sólo lectura |
+
+El deny explícito gana sobre cualquier allow presente o futuro: si mañana alguien
+le adjunta una policy amplia al runtime, estas operaciones siguen bloqueadas.
+
+El destino se cifra con **SSE-S3 (`AES256`)**, deliberadamente *distinta* de la
+CMK auditada. Si fueran la misma clave, deshabilitarla para contener un incidente
+del store dejaría ilegible la evidencia de ese mismo incidente. El verificador lo
+comprueba (`destinationKeySeparateFromCmk`) en vez de asumirlo.
+
+Para leer la postura **efectiva** desde AWS —no la policy que creemos haber
+aplicado— con la identidad auditora:
+
+```bash
+node -e "const ct=require('./.pipeline/lib/kernel-cloudtrail-provision');
+const p=ct.buildPlan({accountId:ct.runAws(['sts','get-caller-identity']).Account});
+console.log(ct.verifyDestinationPosture(p,{keyArn:ct.resolveKeyArn(p)}))"
+```
+
+Devuelve una garantía por campo, así que un `false` nombra exactamente qué se
+rompió. `--verify` sale con **exit code `3`** si la evidencia está completa pero
+la postura no cumple: se distingue del `2` porque acá reintentar no sirve, hay
+que corregir.
+
+#### Pruebas negativas: la postura se prueba, no se lee
+
+Inspeccionar policies no alcanza — una policy puede leerse correcta y estar
+anulada por un allow heredado, un boundary ausente o una SCP mal ordenada. La
+matriz de `.pipeline/lib/kernel-audit-negative-tests.js` **intenta** cada
+operación destructiva con las credenciales reales del runtime y exige
+`AccessDenied`.
+
+```bash
+# El key id lo resuelve la identidad AUDITORA: el runtime no tiene kms:DescribeKey.
+KEY_ID=$(aws kms describe-key --key-id alias/intrale-kernel-store \
+  --region us-east-2 --query 'KeyMetadata.KeyId' --output text)
+
+node .pipeline/lib/kernel-audit-negative-tests.js                      # dry-run: imprime la matriz
+AWS_PROFILE=<perfil-runtime> node .pipeline/lib/kernel-audit-negative-tests.js \
+  --run --key-id "$KEY_ID"
+```
+
+Tres salvaguardas que hacen seguro correr esto contra producción:
+
+1. **Guarda de identidad.** El runner se niega a arrancar si el llamador no es el
+   principal runtime. Con una sesión administrativa, `stop-logging` y
+   `delete-trail` **no** serían denegados: destruirían el trail de verdad.
+2. **Parámetros que no destruyen.** `update-trail` y `put-event-selectors`
+   reenvían la configuración vigente; `delete-object` apunta a una clave
+   inexistente con nonce. Si el permiso existiera, la llamada tendría éxito —que
+   es el hallazgo— sin romper nada.
+3. **Corta-escalada.** En cuanto una operación de un servicio no resulta
+   denegada, las **destructivas** que quedan de ese servicio no se ejecutan: el
+   hallazgo ya está probado y seguir sólo agrega la chance de detener el trail o
+   deshabilitar la clave.
+
+El veredicto es **fail-closed**: denegado aprueba, permitido es crítico, y
+cualquier otro error es `inconclusivo` —que **no** aprueba. Un timeout de red no
+puede leerse como "está protegido". Las operaciones de KMS exigen key id porque
+con alias devuelven `InvalidArnException`, que no es una denegación: sin esa
+distinción, un error de forma se leería como postura verificada.
+
+Después de correr la matriz, confirmar con la identidad auditora que el trail
+quedó intacto (el runtime no puede leer su propio estado, y eso es parte de la
+separación):
+
+```bash
+aws cloudtrail get-trail-status --name intrale-kernel-kms --region us-east-2 \
+  --query '{IsLogging:IsLogging,TimeStopped:TimeLoggingStopped}'
+aws kms describe-key --key-id alias/intrale-kernel-store --region us-east-2 \
+  --query 'KeyMetadata.{State:KeyState,Deletion:DeletionDate}'
+```
+
+#### Retención, consulta y eliminación controlada
+
+| Qué | Decisión | Dónde se aplica |
+|---|---|---|
+| **Retención** | 365 días | Lifecycle del bucket (`Expiration.Days` + `NoncurrentVersionExpiration`). Cubre una revisión anual completa y ventanas mayores a los 90 días del Event history |
+| **Quién consulta** | Sólo la identidad auditora | `AllowAuditorRead` en la policy + IAM. El runtime tiene deny explícito de lectura |
+| **Quién puede reducirla** | Nadie fuera de una sesión administrativa | El runtime tiene deny sobre `s3:PutLifecycleConfiguration`, verificado por la matriz negativa |
+| **Eliminación controlada** | Sólo admin, y sólo por vencimiento del lifecycle | Ni el runtime ni el auditor pueden `DeleteObject` / `DeleteBucket` |
+
+La eliminación anticipada de evidencia es un **paso administrativo deliberado**,
+nunca una operación de runtime ni de pipeline: exige una sesión administrativa,
+y queda registrada en el propio trail. El borrado por vencimiento lo hace el
+lifecycle solo, a los 365 días, sin intervención.
 
 ---
 


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 7 archivos · +1366 -25

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:skipped` aplicado por delivery

## Closes

Closes #5213
