### PR TITLE
[BUG] El reset --hard de syncWithMain deja los servicios vivos con código viejo: el dashboard cae en fail-closed por config nueva y la ola pierde todos los estados

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -207,6 +207,13 @@ scripts/planner-plan.json
 .pipeline/human-block-reminder-state.json
 .pipeline/human-block-reminder-state.json.*.tmp
 .pipeline/last-restart.json
+# #5646 — registro de servicios que quedaron con codigo viejo tras un
+# `reset --hard` y guard de ronda del restart selectivo. Estado runtime puro:
+# versionarlos haria que el propio reset los pise (mismo problema que waves.json).
+.pipeline/stale-services.json
+.pipeline/stale-services.json.*.tmp
+.pipeline/last-selective-restart.json
+.pipeline/last-selective-restart.json.tmp
 .pipeline/listener-offset.json
 .pipeline/commander-history.jsonl
 .pipeline/commander-summary.json

--- a/.pipeline/dashboard.js
+++ b/.pipeline/dashboard.js
@@ -494,6 +494,17 @@ function restartComponent(name) {
 // Map en memoria por target que rechaza ráfagas < 5s (DoS auto-infligido).
 const _opsRestartHandler = require('./lib/ops-restart-handler');
 const _opsRestartRateLimiter = _opsRestartHandler.makeRateLimiter(5000);
+// #5646 (CA-9) — Cota AGREGADA: el rate-limiter de arriba es por target, así que
+// al reiniciar N componentes afectados en vez de sólo el pulpo, N targets
+// distintos pasarían la misma ráfaga. Esta cota corta el total por ventana; lo
+// que no entra queda pendiente en `stale-services.json` y lo toma el watchdog.
+const _opsRestartAggregateLimiter = _opsRestartHandler.makeAggregateLimiter(4, 60000);
+// #5646 — Marcador de servicios con código viejo. Require defensivo: si no
+// carga, el endpoint sigue funcionando como antes (restart del pulpo) y lo dice.
+let _staleServices = null;
+try { _staleServices = require('./lib/stale-services'); } catch { /* opcional */ }
+let _runtimeBoot = null;
+try { _runtimeBoot = require('./lib/runtime-boot'); } catch { /* opcional */ }
 // #4460 — Gate de defensa-en-profundidad (loopback + Origin/Referer +
 // Content-Type) para el restart del modelo operativo. Require defensivo: si no
 // carga, el endpoint dedicado responde 503 (nunca ejecuta restart sin gate).
@@ -12188,6 +12199,17 @@ function handleRequest(req, res) {
     req.on('end', () => {
       try {
         const parsed = body ? JSON.parse(body) : {};
+        // #5646 (CA-9 / REQ-SEC-5646-4) — del body se lee SÓLO `actor`. El
+        // conjunto de componentes a reiniciar se computa SERVER-SIDE a partir
+        // del diff del sync: una lista de componentes en el request se ignora
+        // por completo. Aceptarla convertiría este endpoint en un selector
+        // arbitrario de procesos a matar, a un request de distancia.
+        //
+        // #5646 (CA-3) — el HEAD previo se lee ANTES de `syncOperativoTree`:
+        // esa llamada PISA el boot marker (`operativo-sync.js`), así que
+        // después ya no queda ninguna referencia previa recuperable.
+        const _prevMarker = _runtimeBoot ? _runtimeBoot.readBootMarker({ pipelineDir: PIPELINE }) : null;
+        const _prevSha = (_prevMarker && _prevMarker.sha) ? _prevMarker.sha : null;
         // #4460 (fix rebote rev-1) — PASO CLAVE: avanzar el working tree a
         // origin/main ANTES de respawnear el Pulpo. Sin esto el restart es un
         // no-op respecto de aplicar entregas: `restartComponent` sólo hace
@@ -12197,8 +12219,10 @@ function handleRequest(req, res) {
         // drift desaparece (CA-4/CA-7). Si el sync falla, se reporta y NO se
         // reescribe el marker (el banner persiste, honesto con el operador).
         let syncMsg = '';
+        let _headSha = null;
         if (_operativoSync) {
           const sync = _operativoSync.syncOperativoTree({ repoRoot: ROOT, pipelineDir: PIPELINE });
+          _headSha = (typeof sync.sha === 'string') ? sync.sha : null;
           syncMsg = sync.ok
             ? `sync✓ ${sync.msg}`
             : `sync✗ ${sync.msg} (restart de todos modos, cambios NO aplicados hasta próximo sync)`;
@@ -12207,33 +12231,107 @@ function handleRequest(req, res) {
           syncMsg = 'sync no disponible (operativo-sync.js no cargó)';
           log('Action: restart-operativo sync → módulo operativo-sync no disponible');
         }
-        // Restart selectivo del Pulpo (el dashboard no puede matarse a sí mismo;
-        // no existe componente 'dashboard' en COMPONENTS). Tras el sync previo,
-        // el Pulpo relanzado relee el código nuevo del modelo operativo.
-        const decision = _opsRestartHandler.runRestart(
-          {
-            target: 'pulpo',
-            source: 'restart-operativo-4460',
-            sourceIp: (req.socket && req.socket.remoteAddress) || '',
-            actor: parsed.actor || '',
-          },
-          {
-            allowlist: COMPONENTS.map(c => c.name),
-            restartFn: restartComponent,
-            rateLimiter: _opsRestartRateLimiter,
-            audit: opsRestartAudit
-              ? (rec) => opsRestartAudit.appendOpsRestartAudit(rec, { pipelineDir: PIPELINE })
-              : null,
+
+        // #5646 (CA-3) — El sync avanzó el código EN DISCO de todos los
+        // servicios; los que siguen vivos quedaron con el código viejo en su
+        // require-cache. Se marcan acá y el ejecutor los relanza: los que están
+        // en COMPONENTS, este mismo endpoint; el resto (incluido el propio
+        // `dashboard`, que no puede matarse a sí mismo) queda pendiente en disco
+        // y lo relanza el watchdog, único ejecutor externo (REQ-SEC-5646-5).
+        let _afectados = [];
+        if (_staleServices && _headSha) {
+          try {
+            // Sin `prevSha` NO se puede caer al boot marker: `syncOperativoTree`
+            // ya lo pisó con el HEAD nuevo, así que el diff daría vacío y
+            // dejaría servicios stale invisibles (fail-open). Se marca todo el
+            // registro, que es el comportamiento conservador correcto.
+            const aff = _prevSha
+              ? _staleServices.computeAffectedComponents({
+                prevSha: _prevSha,
+                headSha: _headSha,
+                repoRoot: ROOT,
+                pipelineDir: PIPELINE,
+              })
+              : {
+                components: _staleServices.ALL_COMPONENTS.slice(),
+                reasons: _staleServices.ALL_COMPONENTS.map(n => ({ component: n, path: '(estado desconocido)' })),
+                headSha: _headSha,
+              };
+            _afectados = aff.components;
+            const mark = _staleServices.markAffected(_afectados, { sha: aff.headSha, reasons: aff.reasons });
+            for (const r of aff.reasons) {
+              if (!mark.marked.includes(r.component)) continue;
+              log(`restart selectivo: ${r.component} quedó con código viejo — cambio en ${r.path}`);
+            }
+            if (!_afectados.length) log('restart selectivo: sin componentes afectados por el reset');
+          } catch (e) {
+            log(`restart selectivo: no se pudo computar el conjunto afectado (${(e && e.message || '').slice(0, 80)})`);
           }
-        );
-        log(`Action: restart-operativo pulpo → ${decision.body.ok ? '✓' : '✗'} (${decision.status}) ${decision.body.msg}`);
+        }
+
+        // Targets: SIEMPRE el pulpo (contrato del botón, #4460) más los
+        // afectados que estén en la allowlist estática. El orden es el de
+        // COMPONENTS, nunca el del diff.
+        const _allowlist = COMPONENTS.map(c => c.name);
+        const _targets = _allowlist.filter(n => n === 'pulpo' || _afectados.includes(n));
+        // Cota AGREGADA por ventana (CA-9): sin esto una request pasa de matar 1
+        // proceso a matar N. Lo que no entra sigue pendiente en disco → watchdog.
+        const _cupos = _opsRestartAggregateLimiter.grant(_targets.length);
+        if (_cupos === 0) {
+          const msg429 = 'restart ignorado: se alcanzó la cota de restarts por minuto (anti-bucle). '
+            + 'Los servicios pendientes los relanza el watchdog en su próximo ciclo.';
+          log(`Action: restart-operativo → (429) ${msg429}`);
+          res.writeHead(429, { 'Content-Type': 'application/json' });
+          return res.end(JSON.stringify({ ok: false, msg: `${syncMsg} | ${msg429}`, applied: false }));
+        }
+        const _ejecutables = _targets.slice(0, _cupos);
+        const _diferidos = _targets.slice(_cupos);
+
+        const _resultados = [];
+        for (const _target of _ejecutables) {
+          const decision = _opsRestartHandler.runRestart(
+            {
+              target: _target,
+              source: 'restart-operativo-4460',
+              sourceIp: (req.socket && req.socket.remoteAddress) || '',
+              actor: parsed.actor || '',
+            },
+            {
+              allowlist: _allowlist,
+              restartFn: restartComponent,
+              rateLimiter: _opsRestartRateLimiter,
+              audit: opsRestartAudit
+                ? (rec) => opsRestartAudit.appendOpsRestartAudit(rec, { pipelineDir: PIPELINE })
+                : null,
+            }
+          );
+          log(`Action: restart-operativo ${_target} → ${decision.body.ok ? '✓' : '✗'} (${decision.status}) ${decision.body.msg}`);
+          // El pendiente se baja SÓLO con el restart confirmado (CA-5): si falló,
+          // el componente sigue marcado y lo toma el watchdog.
+          if (decision.body.ok && _staleServices) {
+            try { _staleServices.clearComponent(_target, { pipelineDir: PIPELINE }); } catch { /* best-effort */ }
+          }
+          _resultados.push({ target: _target, decision });
+        }
+        if (_diferidos.length) {
+          log(`restart selectivo: diferidos al watchdog por cota — ${_diferidos.join(', ')}`);
+        }
+
+        // El resultado que gobierna la respuesta HTTP es el del pulpo (contrato
+        // original del botón); el resto se resume en el mensaje.
+        const _principal = (_resultados.find(r => r.target === 'pulpo') || _resultados[0]).decision;
+        const _otros = _resultados.filter(r => r.target !== 'pulpo');
+        const _extraMsg = _otros.length
+          ? ` | además: ${_otros.map(r => `${r.target} ${r.decision.body.ok ? '✓' : '✗'}`).join(', ')}`
+          : '';
+        const _pendMsg = _diferidos.length ? ` | diferidos al watchdog: ${_diferidos.join(', ')}` : '';
         // Combinar el resultado del sync con el del restart para que el operador
         // sepa si los cambios se aplicaron (sync✓) o sólo se respawneó (sync✗).
-        const combined = Object.assign({}, decision.body, {
-          msg: `${syncMsg} | ${decision.body.msg}`,
-          applied: !!(decision.body.ok && /^sync✓/.test(syncMsg)),
+        const combined = Object.assign({}, _principal.body, {
+          msg: `${syncMsg} | ${_principal.body.msg}${_extraMsg}${_pendMsg}`,
+          applied: !!(_principal.body.ok && /^sync✓/.test(syncMsg)),
         });
-        res.writeHead(decision.status, { 'Content-Type': 'application/json' });
+        res.writeHead(_principal.status, { 'Content-Type': 'application/json' });
         return res.end(JSON.stringify(combined));
       } catch (e) {
         res.writeHead(400, { 'Content-Type': 'application/json' });

--- a/.pipeline/lib/ops-restart-handler.js
+++ b/.pipeline/lib/ops-restart-handler.js
@@ -33,6 +33,41 @@ function makeRateLimiter(minIntervalMs) {
     };
 }
 
+// #5646 (CA-9 / REQ-SEC-5646-4) — Cota AGREGADA de restarts por ventana.
+//
+// `makeRateLimiter` limita POR TARGET: al pasar de reiniciar 1 componente a N,
+// N targets distintos pasan la misma ráfaga y una sola request se convierte en
+// "matar todos los servicios del pipeline" — un amplificador de DoS
+// auto-infligido. Esta cota es transversal: cuenta restarts totales en la
+// ventana, sin importar el target.
+//
+// Los componentes que no entran quedan pendientes en `stale-services.json` y los
+// relanza el watchdog en su ciclo: la cota RETRASA, no pierde trabajo (CA-5).
+//
+// `now` inyectable para tests.
+function makeAggregateLimiter(maxPerWindow, windowMs) {
+    const max = typeof maxPerWindow === 'number' && maxPerWindow > 0 ? maxPerWindow : 4;
+    const win = typeof windowMs === 'number' && windowMs > 0 ? windowMs : 60000;
+    let events = [];
+    return {
+        /**
+         * Reserva hasta `count` cupos. Devuelve cuántos quedaron concedidos
+         * (0..count). Los concedidos ya quedan consumidos en la ventana.
+         */
+        grant(count, now) {
+            const t = typeof now === 'number' ? now : Date.now();
+            events = events.filter(ts => (t - ts) < win);
+            const room = Math.max(0, max - events.length);
+            const granted = Math.max(0, Math.min(room, typeof count === 'number' ? count : 0));
+            for (let i = 0; i < granted; i++) events.push(t);
+            return granted;
+        },
+        _snapshot() { return events.slice(); },
+        maxPerWindow: max,
+        windowMs: win,
+    };
+}
+
 /**
  * Decide y (si corresponde) ejecuta el restart de un servicio.
  *
@@ -79,4 +114,4 @@ function runRestart(params, deps) {
     return { status: 200, body: { ok: !!(result && result.ok), msg: (result && result.msg) || '' } };
 }
 
-module.exports = { makeRateLimiter, runRestart };
+module.exports = { makeRateLimiter, makeAggregateLimiter, runRestart };

--- a/.pipeline/lib/ops-restart-handler.test.js
+++ b/.pipeline/lib/ops-restart-handler.test.js
@@ -6,7 +6,7 @@
 const { test } = require('node:test');
 const assert = require('node:assert');
 
-const { makeRateLimiter, runRestart } = require('./ops-restart-handler');
+const { makeRateLimiter, makeAggregateLimiter, runRestart } = require('./ops-restart-handler');
 
 const ALLOW = ['pulpo', 'listener', 'svc-drive', 'svc-github'];
 
@@ -91,4 +91,50 @@ test('audit recibe source declarativo + sourceIp objetivo, no bloquea si tira', 
         { allowlist: ALLOW, restartFn: () => ({ ok: true, msg: 'ok' }), audit: () => { throw new Error('disk full'); } }
     );
     assert.strictEqual(res2.status, 200);
+});
+
+// ===========================================================================
+// #5646 (CA-9 / REQ-SEC-5646-4) — cota AGREGADA por ventana.
+// El rate-limiter de arriba es POR TARGET: con N componentes afectados, N
+// targets distintos pasan la misma rafaga y una request se vuelve "matar todos
+// los servicios del pipeline". Esta cota es transversal.
+// ===========================================================================
+
+test('#5646 cota agregada: N targets distintos NO esquivan el limite (el rate-limit por target si)', () => {
+    const rl = makeRateLimiter(5000);
+    // Prueba de que el limitador por target NO alcanza: 9 targets distintos
+    // pasan todos en la misma rafaga.
+    const pasaron = ['pulpo', 'listener', 'svc-telegram', 'svc-github', 'svc-drive',
+        'svc-emulador', 'svc-reconciler', 'outbox-drain', 'dashboard']
+        .filter(t => !rl.isRateLimited(t, 1000));
+    assert.strictEqual(pasaron.length, 9, 'el limitador por target no frena la amplificacion');
+
+    // La cota agregada si: concede a lo sumo `max` por ventana.
+    const agg = makeAggregateLimiter(4, 60000);
+    assert.strictEqual(agg.grant(9, 1000), 4, 'sobre 9 pedidos concede 4');
+    assert.strictEqual(agg.grant(9, 2000), 0, 'dentro de la ventana ya no quedan cupos');
+});
+
+test('#5646 cota agregada: la ventana se libera con el tiempo (retrasa, no pierde)', () => {
+    const agg = makeAggregateLimiter(4, 60000);
+    assert.strictEqual(agg.grant(4, 1000), 4);
+    assert.strictEqual(agg.grant(1, 30000), 0, 'a mitad de ventana sigue cortado');
+    assert.strictEqual(agg.grant(4, 62000), 4, 'pasada la ventana vuelve a conceder');
+});
+
+test('#5646 cota agregada: concede parcialmente y el resto queda para el watchdog', () => {
+    const agg = makeAggregateLimiter(4, 60000);
+    assert.strictEqual(agg.grant(3, 1000), 3);
+    // Sólo queda 1 cupo: se concede 1 de los 3 pedidos; los otros 2 se difieren.
+    assert.strictEqual(agg.grant(3, 1500), 1);
+    assert.strictEqual(agg.grant(1, 1600), 0);
+});
+
+test('#5646 cota agregada: valores invalidos caen a defaults seguros, nunca a "sin limite"', () => {
+    const agg = makeAggregateLimiter(0, -1);
+    assert.strictEqual(agg.maxPerWindow, 4);
+    assert.strictEqual(agg.windowMs, 60000);
+    assert.strictEqual(agg.grant(100, 0), 4, 'jamas concede ilimitado');
+    // grant con basura no rompe ni concede de mas.
+    assert.strictEqual(makeAggregateLimiter(2, 1000).grant('muchos', 0), 0);
 });

--- a/.pipeline/lib/stale-services.js
+++ b/.pipeline/lib/stale-services.js
@@ -1,0 +1,545 @@
+'use strict';
+
+// =============================================================================
+// stale-services.js — Marcador de servicios que quedaron con CÓDIGO VIEJO
+// después de un `git reset --hard` (#5646).
+// -----------------------------------------------------------------------------
+// PROBLEMA que resuelve:
+//   `watchdog.ps1` hace `fetch origin main` + `reset --hard FETCH_HEAD` sobre el
+//   repo principal en dos caminos (liveness pre-respawn y pre-loop de servicios
+//   caídos) y relanza SÓLO los servicios caídos. Los servicios vivos siguen con
+//   el código anterior en el require-cache de Node. Cuando un merge agrega una
+//   sección nueva a `config.yaml` **y** su declaración en `config-schema.js`, el
+//   dashboard vivo valida CONFIG NUEVA contra SCHEMA VIEJO → fail-closed →
+//   "⛔ Configuración inválida" y la ola pierde todos los estados.
+//
+// DISEÑO (una sola línea de decisión):
+//   - Los emisores de reset (watchdog, restart.js, endpoint del dashboard) SÓLO
+//     MARCAN qué componentes quedaron con código viejo. No ejecutan restarts.
+//   - El watchdog es el ÚNICO EJECUTOR del restart selectivo: ya corre cada 2
+//     min, ya tiene el contrato de spawn de PowerShell, y es externo al
+//     dashboard (que no puede matarse a sí mismo) — REQ-SEC-5646-5, sin
+//     inventar un relanzador genérico que acepte paths o command lines.
+//   - La marca PERSISTE en disco y se limpia SÓLO tras spawn confirmado: si el
+//     relanzamiento falla, el componente sigue pendiente el ciclo siguiente
+//     (cierra el fail-open de REQ-SEC-5646-7).
+//
+// Contrato de seguridad:
+//   - REQ-SEC-5646-1: git se invoca con `execFileSync('git', [args])` (array,
+//     sin shell). El `prevSha` se obtiene vía `runtime-boot.readBootMarker()`
+//     (valida SHA_RE) o se valida acá con la MISMA regex antes de llegar a los
+//     argv. Un SHA que no valida NUNCA se pasa a git: se devuelve
+//     `unknown:true` + TODOS los componentes (fail-closed conservador), jamás
+//     `components: []`.
+//   - REQ-SEC-5646-2: el mapeo diff→componente devuelve NOMBRES de componente,
+//     nunca paths ejecutables. El script a spawnear se resuelve siempre desde
+//     el registro estático de acá / `$ScriptMap` del watchdog.
+//   - REQ-SEC-5646-3: el CLI falla cerrado — JSON válido en stdout con exit 0,
+//     o stdout VACÍO con exit ≠ 0. Nunca stack traces mezclados con JSON.
+//   - REQ-SEC-5646-8: los paths salen del contenido del commit → se sanitizan
+//     (strip CR/LF + secuencias ANSI + truncado) antes de tocar un log.
+//   - REQ-SEC-5646-6: este módulo NO toca la validación de config. El bug es la
+//     frescura del código, no el fail-closed.
+//
+// Vocabulario (UX G-2): "código viejo" en texto para el operador, `stale` como
+// identificador técnico en JSON/código.
+// =============================================================================
+
+const fs = require('fs');
+const path = require('path');
+const runtimeBoot = require('./runtime-boot');
+
+const STATE_FILENAME = 'stale-services.json';
+const STATE_VERSION = 1;
+
+// Longitud fija de truncado de paths en logs (REQ-SEC-5646-8).
+const LOG_PATH_MAX = 120;
+
+// ---------------------------------------------------------------------------
+// Registro canónico de componentes (CA-4).
+// Es la UNIÓN de `restart.js:COMPONENTS` (8, con `dashboard`, sin
+// `outbox-drain`) y `dashboard.js:COMPONENTS` (8, con `outbox-drain`, sin
+// `dashboard` porque no puede matarse a sí mismo). Ninguna de las dos listas
+// contiene a la otra → el registro canónico es de 9.
+// El orden ES el orden de relanzamiento del watchdog: primero el motor, después
+// los adaptadores, y el dashboard al final (es la ventana del operador).
+// ---------------------------------------------------------------------------
+const COMPONENT_REGISTRY = [
+    { name: 'pulpo', script: 'pulpo.js' },
+    { name: 'listener', script: 'listener-telegram.js' },
+    { name: 'svc-telegram', script: 'servicio-telegram.js' },
+    { name: 'svc-github', script: 'servicio-github.js' },
+    { name: 'svc-drive', script: 'servicio-drive.js' },
+    { name: 'svc-emulador', script: 'servicio-emulador.js' },
+    { name: 'svc-reconciler', script: 'servicio-reconciler.js' },
+    { name: 'outbox-drain', script: 'outbox-drain.js' },
+    { name: 'dashboard', script: 'dashboard.js' },
+];
+
+const ALL_COMPONENTS = COMPONENT_REGISTRY.map(c => c.name);
+
+// Paths (relativos al root del repo, separador `/` como los emite git) que
+// afectan a TODOS los componentes.
+const PIPELINE_PREFIX = '.pipeline/';
+const SHARED_LIB_PREFIX = '.pipeline/lib/';
+const SHARED_CONFIG = '.pipeline/config.yaml';
+
+// ---------------------------------------------------------------------------
+// Sanitizado de paths para log (REQ-SEC-5646-8 / CA-7).
+// Los paths salen de `git diff`, o sea del CONTENIDO DEL COMMIT: un path con un
+// salto de línea embebido permite falsificar líneas en el log que el operador
+// usa justamente para diagnosticar este tipo de incidente.
+// ---------------------------------------------------------------------------
+function sanitizePathForLog(p) {
+    if (typeof p !== 'string') return '';
+    let s = p;
+    // Secuencias ANSI CSI (colores, movimiento de cursor): ESC [ ... letra final.
+    s = s.replace(/\u001b\[[0-9;?]*[ -/]*[@-~]/g, '');
+    // Resto de secuencias de escape de dos chars: ESC + un char.
+    s = s.replace(/\u001b[@-Z\\-_]/g, '');
+    // Cualquier control char (CR, LF, TAB, NUL, backspace, DEL) -> espacio: es lo
+    // que permitiria falsificar una linea entera del log del operador.
+    s = s.replace(/[\u0000-\u001f\u007f]/g, ' ');
+    s = s.replace(/\s+/g, ' ').trim();
+    if (s.length > LOG_PATH_MAX) s = s.slice(0, LOG_PATH_MAX - 1) + '\u2026';
+    return s;
+}
+
+// ---------------------------------------------------------------------------
+// Mapeo diff → componentes. ESTÁTICO y CONSERVADOR (CA-2, guru §5): nada de
+// grafo de imports — ningún proceso puede inspeccionar el `require.cache` de
+// otro, así que cualquier inferencia fina sería adivinanza.
+//
+//   `.pipeline/lib/**`          → todos
+//   `.pipeline/config.yaml`     → todos
+//   `.pipeline/<script propio>` → sólo ese componente
+//   cualquier otra cosa         → nadie
+// ---------------------------------------------------------------------------
+function componentsForPath(p) {
+    if (typeof p !== 'string' || !p) return [];
+    // git emite siempre `/`; normalizamos por si el caller pasó separador Windows.
+    const rel = p.replace(/\\/g, '/').replace(/^\.\//, '');
+    if (!rel.startsWith(PIPELINE_PREFIX)) return [];
+    if (rel.startsWith(SHARED_LIB_PREFIX)) return ALL_COMPONENTS.slice();
+    if (rel === SHARED_CONFIG) return ALL_COMPONENTS.slice();
+    const tail = rel.slice(PIPELINE_PREFIX.length);
+    const hit = COMPONENT_REGISTRY.find(c => c.script === tail);
+    return hit ? [hit.name] : [];
+}
+
+/**
+ * Cruza una lista de paths del diff contra el registro y devuelve los
+ * componentes afectados + el path que motivó cada uno.
+ *
+ * UX G-1: se guarda UN path por componente (el primero que lo motivó), no el
+ * diff entero: con casi todo merge tocando `.pipeline/lib/**` la lista completa
+ * es ruido que entierra la señal.
+ *
+ * @param {string[]} paths
+ * @returns {{ components: string[], reasons: Array<{component:string, path:string}> }}
+ */
+function mapPathsToComponents(paths) {
+    const firstReason = new Map();
+    for (const raw of (Array.isArray(paths) ? paths : [])) {
+        for (const name of componentsForPath(raw)) {
+            if (!firstReason.has(name)) firstReason.set(name, sanitizePathForLog(raw));
+        }
+    }
+    // Orden canónico del registro (= orden de relanzamiento), no orden del diff.
+    const components = ALL_COMPONENTS.filter(n => firstReason.has(n));
+    return {
+        components,
+        reasons: components.map(n => ({ component: n, path: firstReason.get(n) })),
+    };
+}
+
+function _resolvePipelineDir(opts) {
+    const o = opts || {};
+    if (typeof o.pipelineDir === 'string' && o.pipelineDir) return o.pipelineDir;
+    return path.resolve(__dirname, '..');
+}
+
+function _resolveRepoRoot(opts) {
+    const o = opts || {};
+    if (typeof o.repoRoot === 'string' && o.repoRoot) return o.repoRoot;
+    return path.resolve(_resolvePipelineDir(o), '..');
+}
+
+function _statePath(opts) {
+    return path.join(_resolvePipelineDir(opts), STATE_FILENAME);
+}
+
+// ---------------------------------------------------------------------------
+// Cómputo de afectados (CA-2 + CA-8).
+// ---------------------------------------------------------------------------
+/**
+ * Calcula qué componentes quedaron con código viejo tras un reset.
+ *
+ * @param {object} [opts] — {
+ *     prevSha,      // HEAD ANTES del reset. Si falta/no valida → readBootMarker.
+ *     headSha,      // HEAD DESPUÉS del reset. Si falta → `git rev-parse HEAD`.
+ *     repoRoot, pipelineDir,
+ *     exec,         // inyectable para test: (args:string[]) => string (stdout)
+ *   }
+ * @returns {{ ok:boolean, unknown:boolean, components:string[],
+ *             reasons:Array<{component:string,path:string}>, prevSha:string|null,
+ *             headSha:string|null, msg:string }}
+ *   NUNCA lanza. Ante cualquier duda devuelve `unknown:true` con TODOS los
+ *   componentes (fail-closed conservador): un restart de más es ruido, un
+ *   servicio stale invisible es el bug de este issue.
+ */
+function computeAffectedComponents(opts) {
+    const o = opts || {};
+    const repoRoot = _resolveRepoRoot(o);
+    const exec = typeof o.exec === 'function'
+        ? o.exec
+        : (args) => {
+            const { execFileSync } = require('node:child_process');
+            // Array de argumentos, SIN shell (REQ-SEC-5646-1). Molde de
+            // lib/operativo-sync.js — nunca el execSync-con-string de restart.js.
+            return execFileSync('git', args, {
+                cwd: repoRoot, encoding: 'utf8', timeout: 30000, windowsHide: true,
+                maxBuffer: 8 * 1024 * 1024,
+            });
+        };
+
+    const unknownResult = (msg, prevSha, headSha) => ({
+        ok: true,
+        unknown: true,
+        components: ALL_COMPONENTS.slice(),
+        reasons: ALL_COMPONENTS.map(n => ({ component: n, path: '(estado desconocido)' })),
+        prevSha: prevSha || null,
+        headSha: headSha || null,
+        msg,
+    });
+
+    // 1. prevSha. Prohibido parsear runtime-boot.json a mano: readBootMarker ya
+    //    valida SHA_RE y nunca lanza. Un prevSha explícito se valida con la
+    //    MISMA regex antes de acercarse a los argv de git: un valor tipo
+    //    `--upload-pack=...` o `-x` cambiaría la semántica del comando aunque
+    //    no haya shell de por medio (argument injection).
+    let prevSha = null;
+    if (typeof o.prevSha === 'string' && runtimeBoot.SHA_RE.test(o.prevSha)) {
+        prevSha = o.prevSha;
+    } else if (o.prevSha != null) {
+        return unknownResult('prevSha inválido (no hex 7-40): estado desconocido', null, null);
+    } else {
+        const marker = runtimeBoot.readBootMarker({ pipelineDir: _resolvePipelineDir(o) });
+        if (marker && runtimeBoot.SHA_RE.test(marker.sha)) prevSha = marker.sha;
+    }
+    if (!prevSha) {
+        return unknownResult('sin referencia previa (marker ausente o corrupto): estado desconocido', null, null);
+    }
+
+    // 2. headSha. Mismo tratamiento.
+    let headSha = null;
+    if (typeof o.headSha === 'string' && runtimeBoot.SHA_RE.test(o.headSha)) {
+        headSha = o.headSha;
+    } else if (o.headSha != null) {
+        return unknownResult('headSha inválido (no hex 7-40): estado desconocido', prevSha, null);
+    } else {
+        try {
+            headSha = String(exec(['rev-parse', 'HEAD'])).trim();
+        } catch (e) {
+            return unknownResult(`no se pudo resolver HEAD: ${_msg(e)}`, prevSha, null);
+        }
+        if (!runtimeBoot.SHA_RE.test(headSha)) {
+            return unknownResult('HEAD resuelto no es hex: estado desconocido', prevSha, null);
+        }
+    }
+
+    // 3. Sin movimiento → nadie quedó con código viejo. Es el único camino que
+    //    puede devolver la lista vacía con certeza.
+    if (prevSha === headSha) {
+        return {
+            ok: true, unknown: false, components: [], reasons: [],
+            prevSha, headSha, msg: 'el reset no movió el HEAD: sin componentes afectados',
+        };
+    }
+
+    // 4. Diff. `-z` para que los paths raros (espacios, unicode, CR/LF) vengan
+    //    NUL-separados y sin quoting propio de git (REQ-SEC-5646-8).
+    let out;
+    try {
+        out = exec(['diff', '--name-only', '-z', prevSha, headSha]);
+    } catch (e) {
+        return unknownResult(`git diff falló: ${_msg(e)}`, prevSha, headSha);
+    }
+    const paths = String(out == null ? '' : out).split('\0').filter(Boolean);
+    const mapped = mapPathsToComponents(paths);
+    return {
+        ok: true,
+        unknown: false,
+        components: mapped.components,
+        reasons: mapped.reasons,
+        prevSha,
+        headSha,
+        msg: mapped.components.length
+            ? `${mapped.components.length} componente(s) con código viejo tras el reset`
+            : 'sin componentes afectados por el reset',
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Persistencia del registro de pendientes (CA-5).
+// Escritura ATÓMICA temp+rename, mismo contrato que runtime-boot.js: el archivo
+// es la única memoria de "a quién falta reiniciar" entre ciclos del watchdog.
+// ---------------------------------------------------------------------------
+function _readState(opts) {
+    let raw;
+    try {
+        raw = fs.readFileSync(_statePath(opts), 'utf8');
+    } catch {
+        return { version: STATE_VERSION, pending: {} };
+    }
+    let parsed;
+    try {
+        parsed = JSON.parse(raw);
+    } catch {
+        // Corrupto → se trata como vacío. No crasheamos al watchdog por esto;
+        // el próximo reset vuelve a marcar lo que corresponda.
+        return { version: STATE_VERSION, pending: {} };
+    }
+    if (!parsed || typeof parsed !== 'object' || !parsed.pending || typeof parsed.pending !== 'object') {
+        return { version: STATE_VERSION, pending: {} };
+    }
+    // Filtro defensivo: sólo nombres del registro canónico sobreviven a la
+    // lectura (REQ-SEC-5646-2 — el archivo del FS es dato no confiable).
+    const pending = {};
+    for (const name of ALL_COMPONENTS) {
+        const e = parsed.pending[name];
+        if (e && typeof e === 'object') {
+            pending[name] = {
+                sha: typeof e.sha === 'string' && runtimeBoot.SHA_RE.test(e.sha) ? e.sha : null,
+                path: sanitizePathForLog(typeof e.path === 'string' ? e.path : ''),
+                markedAt: typeof e.markedAt === 'string' ? e.markedAt : null,
+            };
+        }
+    }
+    return { version: STATE_VERSION, pending };
+}
+
+function _writeState(state, opts) {
+    const target = _statePath(opts);
+    const payload = JSON.stringify({ version: STATE_VERSION, pending: state.pending }, null, 2) + '\n';
+    const tmp = target + '.' + process.pid + '.tmp';
+    try {
+        fs.writeFileSync(tmp, payload, { encoding: 'utf8' });
+        fs.renameSync(tmp, target); // atómico en el mismo filesystem
+        return { ok: true };
+    } catch (e) {
+        try { fs.unlinkSync(tmp); } catch { /* noop */ }
+        return { ok: false, msg: _msg(e) };
+    }
+}
+
+/**
+ * Marca componentes como "con código viejo". Idempotente y ADITIVO: no pisa una
+ * marca anterior que todavía no se pudo relanzar (si un componente quedó
+ * pendiente de un reset previo, sigue pendiente).
+ *
+ * @param {string[]} names — nombres del registro canónico (los demás se ignoran).
+ * @param {object} [meta] — { sha, reasons: [{component, path}] }.
+ * @param {object} [opts] — { pipelineDir }.
+ * @returns {{ ok:boolean, marked:string[], msg?:string }}  NUNCA lanza.
+ */
+function markAffected(names, meta, opts) {
+    const m = meta || {};
+    const list = Array.isArray(names) ? names.filter(n => ALL_COMPONENTS.includes(n)) : [];
+    if (!list.length) return { ok: true, marked: [] };
+    const reasonByComp = new Map(
+        (Array.isArray(m.reasons) ? m.reasons : [])
+            .filter(r => r && typeof r.component === 'string')
+            .map(r => [r.component, sanitizePathForLog(r.path)])
+    );
+    const sha = typeof m.sha === 'string' && runtimeBoot.SHA_RE.test(m.sha) ? m.sha : null;
+    let state;
+    try {
+        state = _readState(opts);
+    } catch (e) {
+        return { ok: false, marked: [], msg: _msg(e) };
+    }
+    const markedAt = new Date().toISOString();
+    const marked = [];
+    for (const name of list) {
+        if (state.pending[name]) continue; // ya pendiente: no pisar el motivo original
+        state.pending[name] = {
+            sha,
+            path: reasonByComp.get(name) || '(sin path)',
+            markedAt,
+        };
+        marked.push(name);
+    }
+    if (!marked.length) return { ok: true, marked: [] };
+    const w = _writeState(state, opts);
+    return { ok: !!w.ok, marked: w.ok ? marked : [], msg: w.msg };
+}
+
+/**
+ * Lee los componentes pendientes de relanzar.
+ * @returns {{ ok:boolean, components:string[], reasons:Array<{component,path,sha,markedAt}> }}
+ */
+function readPending(opts) {
+    let state;
+    try {
+        state = _readState(opts);
+    } catch {
+        return { ok: true, components: [], reasons: [] };
+    }
+    const components = ALL_COMPONENTS.filter(n => state.pending[n]);
+    return {
+        ok: true,
+        components,
+        reasons: components.map(n => ({
+            component: n,
+            path: state.pending[n].path || '(sin path)',
+            sha: state.pending[n].sha || null,
+            markedAt: state.pending[n].markedAt || null,
+        })),
+    };
+}
+
+/**
+ * Limpia UN componente del registro de pendientes. Se invoca SÓLO tras spawn
+ * confirmado (CA-5): si el relanzamiento falla, el componente sigue pendiente el
+ * ciclo siguiente en vez de desaparecer en silencio.
+ */
+function clearComponent(name, opts) {
+    if (typeof name !== 'string' || !ALL_COMPONENTS.includes(name)) {
+        return { ok: false, cleared: false, msg: 'componente fuera del registro canónico' };
+    }
+    let state;
+    try {
+        state = _readState(opts);
+    } catch (e) {
+        return { ok: false, cleared: false, msg: _msg(e) };
+    }
+    if (!state.pending[name]) return { ok: true, cleared: false, msg: 'no estaba pendiente' };
+    delete state.pending[name];
+    const w = _writeState(state, opts);
+    return { ok: !!w.ok, cleared: !!w.ok, msg: w.msg };
+}
+
+/**
+ * Limpia varios componentes. Pensado para `restart.js`, que tras `launchAll()`
+ * ya relanzó un subconjunto conocido: se limpia SÓLO ese subconjunto real, nunca
+ * el registro entero (P-1 de guru / CA-3 corregido por PO — `outbox-drain` no
+ * está en `COMPONENTS` de restart.js y limpiarlo lo dejaría stale para siempre).
+ */
+function clearComponents(names, opts) {
+    const list = Array.isArray(names) ? names.filter(n => ALL_COMPONENTS.includes(n)) : [];
+    const cleared = [];
+    for (const n of list) {
+        const r = clearComponent(n, opts);
+        if (r.cleared) cleared.push(n);
+    }
+    return { ok: true, cleared };
+}
+
+/**
+ * Línea de log para el operador (UX G-1): qué pasó / por qué / con qué reset.
+ * Causa antes del efecto, UN path (el que motivó), nombre del componente tal
+ * como aparece en el panel de servicios del dashboard.
+ */
+function formatRestartLogLine(component, reasonPath, prevSha, headSha) {
+    const p = sanitizePathForLog(reasonPath || '') || '(sin path)';
+    const from = typeof prevSha === 'string' ? prevSha.slice(0, 9) : '?';
+    const to = typeof headSha === 'string' ? headSha.slice(0, 9) : '?';
+    return `restart selectivo: ${component} reiniciado — cambio en ${p} (reset ${from} -> ${to})`;
+}
+
+function _msg(e) {
+    return ((e && e.message) || String(e) || 'error desconocido').slice(0, 160);
+}
+
+module.exports = {
+    COMPONENT_REGISTRY,
+    ALL_COMPONENTS,
+    STATE_FILENAME,
+    LOG_PATH_MAX,
+    sanitizePathForLog,
+    componentsForPath,
+    mapPathsToComponents,
+    computeAffectedComponents,
+    markAffected,
+    readPending,
+    clearComponent,
+    clearComponents,
+    formatRestartLogLine,
+    // internos para test
+    _statePath,
+};
+
+// ---------------------------------------------------------------------------
+// CLI — consumido por `watchdog.ps1` (frontera Node → PowerShell).
+//
+// Contrato FAIL-CLOSED (REQ-SEC-5646-3): o JSON válido en stdout con exit 0, o
+// stdout VACÍO con exit ≠ 0. PowerShell no tiene que adivinar si la salida es
+// JSON o un stack trace. Todo lo humano va a stderr.
+//
+//   node lib/stale-services.js --json                → pendientes actuales
+//   node lib/stale-services.js --mark [--prev <sha>] → computa y marca
+//   node lib/stale-services.js --clear <componente>  → limpia uno (post-spawn)
+// ---------------------------------------------------------------------------
+const CLI_FLAGS = ['--json', '--mark', '--prev', '--clear'];
+
+if (require.main === module) {
+    let payload = null;
+    try {
+        const argv = process.argv.slice(2);
+        // Argv ESTRICTO: cualquier flag desconocida o un `--clear`/`--prev` sin
+        // valor abortan. Fail-closed: es preferible que el watchdog vea "sin
+        // datos" a que interprete un default silencioso como "no hay nada que
+        // reiniciar" (que es exactamente el fail-open de este issue).
+        for (let i = 0; i < argv.length; i++) {
+            const a = argv[i];
+            if (!CLI_FLAGS.includes(a)) {
+                if (i > 0 && (argv[i - 1] === '--prev' || argv[i - 1] === '--clear')) continue; // es el valor
+                throw new Error(`argumento no reconocido: ${String(a).slice(0, 40)}`);
+            }
+            if ((a === '--prev' || a === '--clear') && (i + 1 >= argv.length || CLI_FLAGS.includes(argv[i + 1]))) {
+                throw new Error(`${a} requiere un valor`);
+            }
+        }
+        const flag = (name) => argv.includes(name);
+        const valueOf = (name) => {
+            const i = argv.indexOf(name);
+            return (i >= 0 && i + 1 < argv.length) ? argv[i + 1] : null;
+        };
+        // Dir del estado. Se puede aislar para test sin tocar el `.pipeline` real.
+        const cliOpts = process.env.STALE_SERVICES_DIR
+            ? { pipelineDir: process.env.STALE_SERVICES_DIR }
+            : {};
+
+        if (flag('--mark')) {
+            const prevArg = valueOf('--prev');
+            const res = computeAffectedComponents(
+                Object.assign({}, cliOpts, prevArg != null ? { prevSha: prevArg } : {})
+            );
+            const mark = markAffected(res.components, { sha: res.headSha, reasons: res.reasons }, cliOpts);
+            payload = {
+                ok: !!mark.ok,
+                unknown: !!res.unknown,
+                affected: res.components,
+                marked: mark.marked,
+                reasons: res.reasons,
+                prevSha: res.prevSha,
+                headSha: res.headSha,
+                msg: res.msg,
+            };
+        } else if (flag('--clear')) {
+            const name = valueOf('--clear');
+            const res = clearComponent(name, cliOpts);
+            payload = { ok: !!res.ok, cleared: !!res.cleared, component: name, msg: res.msg || '' };
+        } else {
+            const pend = readPending(cliOpts);
+            payload = { ok: true, components: pend.components, reasons: pend.reasons };
+        }
+    } catch (e) {
+        // stdout queda VACÍO a propósito.
+        process.stderr.write(`stale-services: ${_msg(e)}\n`);
+        process.exit(1);
+    }
+    process.stdout.write(JSON.stringify(payload));
+    process.exit(0);
+}

--- a/.pipeline/lib/stale-services.test.js
+++ b/.pipeline/lib/stale-services.test.js
@@ -1,0 +1,607 @@
+'use strict';
+
+// Tests de stale-services.js (#5646) — restart selectivo de servicios que
+// quedaron con CÓDIGO VIEJO tras un `git reset --hard`.
+// Cubre CA-2, CA-4, CA-5, CA-7, CA-8, CA-9 y CA-10.
+// node --test .pipeline/lib/stale-services.test.js
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const stale = require('./stale-services');
+const runtimeBoot = require('./runtime-boot');
+
+const PIPELINE_DIR = path.resolve(__dirname, '..');
+const REPO_ROOT = path.resolve(PIPELINE_DIR, '..');
+
+function tmpDir(prefix) {
+    return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function git(args, cwd) {
+    return execFileSync('git', args, { cwd, encoding: 'utf8', windowsHide: true }).trim();
+}
+
+// ===========================================================================
+// CA-2 — mapeo diff -> componente: estático, conservador y documentado.
+// ===========================================================================
+
+test('CA-2: un cambio en .pipeline/lib/** marca a TODOS los componentes', () => {
+    const r = stale.componentsForPath('.pipeline/lib/config-schema.js');
+    assert.deepStrictEqual(r, stale.ALL_COMPONENTS);
+    assert.strictEqual(r.length, 9, 'el registro canónico es de 9 componentes');
+});
+
+test('CA-2: un cambio en .pipeline/config.yaml marca a TODOS los componentes', () => {
+    assert.deepStrictEqual(stale.componentsForPath('.pipeline/config.yaml'), stale.ALL_COMPONENTS);
+});
+
+test('CA-2: un cambio en servicio-drive.js marca SÓLO a svc-drive', () => {
+    assert.deepStrictEqual(stale.componentsForPath('.pipeline/servicio-drive.js'), ['svc-drive']);
+    assert.deepStrictEqual(stale.componentsForPath('.pipeline/dashboard.js'), ['dashboard']);
+    assert.deepStrictEqual(stale.componentsForPath('.pipeline/outbox-drain.js'), ['outbox-drain']);
+});
+
+test('CA-2: un diff enteramente fuera de .pipeline/ no marca a nadie', () => {
+    const paths = ['app/composeApp/src/Main.kt', 'docs/pipeline/x.md', 'README.md', 'users/build.gradle.kts'];
+    const r = stale.mapPathsToComponents(paths);
+    assert.deepStrictEqual(r.components, []);
+    assert.deepStrictEqual(r.reasons, []);
+});
+
+test('CA-2: un archivo nuevo dentro de .pipeline/ que no es de ningún componente no marca a nadie', () => {
+    // REQ-SEC-5646-2: un commit que agregue `.pipeline/loquesea.js` no debe poder
+    // inducir su ejecución por el solo hecho de aparecer en el diff.
+    assert.deepStrictEqual(stale.componentsForPath('.pipeline/loquesea.js'), []);
+    assert.deepStrictEqual(stale.componentsForPath('.pipeline/roles/_base.md'), []);
+});
+
+test('CA-2/UX G-1: se guarda UN path por componente (el primero que lo motivó), no el diff entero', () => {
+    const r = stale.mapPathsToComponents([
+        '.pipeline/lib/config-schema.js',
+        '.pipeline/lib/waves.js',
+        '.pipeline/lib/otro.js',
+    ]);
+    assert.strictEqual(r.reasons.length, 9);
+    for (const reason of r.reasons) {
+        assert.strictEqual(reason.path, '.pipeline/lib/config-schema.js');
+    }
+});
+
+// ===========================================================================
+// CA-8 / REQ-SEC-5646-1 — el prevSha nunca llega a los argv de git sin validar.
+// ===========================================================================
+
+test('CA-8: prevSha tampereado (--upload-pack=...) NUNCA llega a los argv de git', () => {
+    const calls = [];
+    const res = stale.computeAffectedComponents({
+        prevSha: '--upload-pack=/tmp/evil.sh',
+        headSha: 'abc1234',
+        repoRoot: '/fake',
+        pipelineDir: '/fake',
+        exec: (args) => { calls.push(args); return ''; },
+    });
+    assert.strictEqual(calls.length, 0, 'git no se invocó en absoluto');
+    assert.strictEqual(res.unknown, true, 'estado desconocido');
+    // Fail-closed conservador: JAMÁS `components: []` ante un SHA que no valida.
+    assert.deepStrictEqual(res.components, stale.ALL_COMPONENTS);
+});
+
+test('CA-8: prevSha no-hex (mayúsculas, guiones, texto) también se rechaza antes de git', () => {
+    for (const malo of ['ABC1234', '-x', 'HEAD~1', 'main', '../../etc/passwd', 'abc123']) {
+        const calls = [];
+        const res = stale.computeAffectedComponents({
+            prevSha: malo, headSha: 'abc1234', repoRoot: '/fake', pipelineDir: '/fake',
+            exec: (args) => { calls.push(args); return ''; },
+        });
+        assert.strictEqual(calls.length, 0, `git invocado con prevSha inválido: ${malo}`);
+        assert.strictEqual(res.unknown, true, `prevSha inválido aceptado: ${malo}`);
+    }
+});
+
+test('CA-8: headSha tampereado tampoco llega a git', () => {
+    const calls = [];
+    const res = stale.computeAffectedComponents({
+        prevSha: 'abc1234', headSha: '--exec=rm -rf /', repoRoot: '/fake', pipelineDir: '/fake',
+        exec: (args) => { calls.push(args); return ''; },
+    });
+    assert.strictEqual(calls.length, 0);
+    assert.strictEqual(res.unknown, true);
+    assert.deepStrictEqual(res.components, stale.ALL_COMPONENTS);
+});
+
+test('CA-8: git se invoca SIEMPRE con array de argumentos y con -z (nunca string de shell)', () => {
+    const calls = [];
+    const res = stale.computeAffectedComponents({
+        prevSha: 'aaaaaaa', headSha: 'bbbbbbb', repoRoot: '/fake', pipelineDir: '/fake',
+        exec: (args) => {
+            assert.ok(Array.isArray(args), 'args siempre es array, nunca string de shell');
+            calls.push(args);
+            return '.pipeline/servicio-drive.js\u0000';
+        },
+    });
+    assert.deepStrictEqual(calls[0], ['diff', '--name-only', '-z', 'aaaaaaa', 'bbbbbbb']);
+    assert.deepStrictEqual(res.components, ['svc-drive']);
+    assert.strictEqual(res.unknown, false);
+});
+
+test('CA-8: sin marker ni prevSha -> unknown + TODOS (jamás "no hay afectados")', () => {
+    const dir = tmpDir('stale-nomarker-');
+    const res = stale.computeAffectedComponents({
+        repoRoot: dir, pipelineDir: dir,
+        exec: () => { throw new Error('no debería llamarse'); },
+    });
+    assert.strictEqual(res.unknown, true);
+    assert.deepStrictEqual(res.components, stale.ALL_COMPONENTS);
+});
+
+test('CA-8: marker corrupto en runtime-boot.json -> unknown + TODOS', () => {
+    const dir = tmpDir('stale-markercorrupto-');
+    fs.writeFileSync(path.join(dir, 'runtime-boot.json'), '{"sha":"--upload-pack=x"}', 'utf8');
+    const calls = [];
+    const res = stale.computeAffectedComponents({
+        repoRoot: dir, pipelineDir: dir, exec: (a) => { calls.push(a); return ''; },
+    });
+    assert.strictEqual(calls.length, 0, 'el sha tampereado del marker no llegó a git');
+    assert.strictEqual(res.unknown, true);
+    assert.deepStrictEqual(res.components, stale.ALL_COMPONENTS);
+});
+
+test('el único camino con lista vacía CIERTA es "el reset no movió el HEAD"', () => {
+    const res = stale.computeAffectedComponents({
+        prevSha: 'abc1234', headSha: 'abc1234', repoRoot: '/fake', pipelineDir: '/fake',
+        exec: () => { throw new Error('no debería llamarse'); },
+    });
+    assert.strictEqual(res.unknown, false);
+    assert.deepStrictEqual(res.components, []);
+});
+
+test('git diff que falla -> unknown + TODOS (no se asume "sin afectados")', () => {
+    const res = stale.computeAffectedComponents({
+        prevSha: 'aaaaaaa', headSha: 'bbbbbbb', repoRoot: '/fake', pipelineDir: '/fake',
+        exec: () => { throw new Error('fatal: bad object'); },
+    });
+    assert.strictEqual(res.unknown, true);
+    assert.deepStrictEqual(res.components, stale.ALL_COMPONENTS);
+});
+
+// ===========================================================================
+// CA-7 / REQ-SEC-5646-8 — log injection: los paths salen del commit.
+// ===========================================================================
+
+test('CA-7: un path con CR/LF embebido no puede falsificar líneas de log', () => {
+    const hostil = '.pipeline/lib/a.js\r\n[2026-08-06 12:00:00] restart selectivo: TODO OK';
+    const limpio = stale.sanitizePathForLog(hostil);
+    assert.ok(!limpio.includes('\r'), 'sin CR');
+    assert.ok(!limpio.includes('\n'), 'sin LF');
+    assert.ok(!/\r|\n/.test(limpio));
+    // El texto queda, pero en UNA sola línea: no puede simular otra entrada.
+    assert.strictEqual(limpio.split('\n').length, 1);
+});
+
+test('CA-7: se quitan secuencias ANSI y cualquier control char', () => {
+    const ESC = '\u001b';
+    const hostil = `.pipeline/${ESC}[31mlib${ESC}[0m/a.js\u0000\u0007\t b`;
+    const limpio = stale.sanitizePathForLog(hostil);
+    assert.strictEqual(limpio, '.pipeline/lib/a.js b');
+    assert.ok(!limpio.includes(ESC));
+});
+
+test('CA-7: el path se trunca a longitud fija', () => {
+    const largo = '.pipeline/lib/' + 'a'.repeat(500) + '.js';
+    const limpio = stale.sanitizePathForLog(largo);
+    assert.strictEqual(limpio.length, stale.LOG_PATH_MAX);
+    assert.ok(limpio.endsWith('…'), 'marca visible de truncado');
+});
+
+test('CA-7: el path sanitizado es el que termina en el registro y en la línea de log', () => {
+    const dir = tmpDir('stale-log-');
+    const hostil = '.pipeline/lib/x.js\r\nFALSA LINEA';
+    const mapped = stale.mapPathsToComponents([hostil]);
+    assert.ok(!/\r|\n/.test(mapped.reasons[0].path));
+    stale.markAffected(['dashboard'], { sha: 'abc1234', reasons: mapped.reasons }, { pipelineDir: dir });
+    const pend = stale.readPending({ pipelineDir: dir });
+    assert.ok(!/\r|\n/.test(pend.reasons[0].path), 'lo persistido tampoco tiene control chars');
+    const linea = stale.formatRestartLogLine('dashboard', hostil, 'aaaaaaa1', 'bbbbbbb2');
+    assert.strictEqual(linea.split('\n').length, 1);
+    // UX G-1: causa antes del efecto, nombre del componente como en el panel.
+    assert.ok(linea.startsWith('restart selectivo: dashboard reiniciado — cambio en '));
+});
+
+// ===========================================================================
+// CA-5 — el pendiente persiste y se limpia SÓLO tras spawn confirmado.
+// ===========================================================================
+
+test('CA-5: el pendiente NO se limpia si el spawn falló (sigue en disco el ciclo siguiente)', () => {
+    const dir = tmpDir('stale-pend-');
+    stale.markAffected(['dashboard', 'svc-drive'], {
+        sha: 'abc1234',
+        reasons: [
+            { component: 'dashboard', path: '.pipeline/lib/config-schema.js' },
+            { component: 'svc-drive', path: '.pipeline/lib/config-schema.js' },
+        ],
+    }, { pipelineDir: dir });
+
+    // Simulación del ejecutor: `svc-drive` spawnea OK -> se limpia.
+    // `dashboard` FALLA -> NO se llama a clearComponent.
+    stale.clearComponent('svc-drive', { pipelineDir: dir });
+
+    const pend = stale.readPending({ pipelineDir: dir });
+    assert.deepStrictEqual(pend.components, ['dashboard'],
+        'el componente cuyo relanzamiento falló sigue pendiente');
+    assert.strictEqual(pend.reasons[0].path, '.pipeline/lib/config-schema.js');
+});
+
+test('CA-5: el registro sobrevive entre procesos (persiste en disco, no en memoria)', () => {
+    const dir = tmpDir('stale-persist-');
+    stale.markAffected(['listener'], { sha: 'abc1234', reasons: [{ component: 'listener', path: '.pipeline/config.yaml' }] }, { pipelineDir: dir });
+    const raw = JSON.parse(fs.readFileSync(path.join(dir, stale.STATE_FILENAME), 'utf8'));
+    assert.ok(raw.pending.listener, 'quedó escrito en stale-services.json');
+    assert.strictEqual(raw.pending.listener.path, '.pipeline/config.yaml');
+});
+
+test('CA-5: markAffected es aditivo — no pisa el motivo original de un pendiente vivo', () => {
+    const dir = tmpDir('stale-aditivo-');
+    stale.markAffected(['pulpo'], { sha: 'aaaaaaa', reasons: [{ component: 'pulpo', path: '.pipeline/pulpo.js' }] }, { pipelineDir: dir });
+    const segunda = stale.markAffected(['pulpo'], { sha: 'bbbbbbb', reasons: [{ component: 'pulpo', path: '.pipeline/lib/otro.js' }] }, { pipelineDir: dir });
+    assert.deepStrictEqual(segunda.marked, [], 'no se re-marca lo ya pendiente');
+    const pend = stale.readPending({ pipelineDir: dir });
+    assert.strictEqual(pend.reasons[0].path, '.pipeline/pulpo.js', 'conserva el motivo original');
+});
+
+test('CA-5: un nombre fuera del registro canónico no se puede marcar ni limpiar', () => {
+    const dir = tmpDir('stale-allow-');
+    const r = stale.markAffected(['claude.exe', '../../evil', 'pulpo'], { sha: 'abc1234', reasons: [] }, { pipelineDir: dir });
+    assert.deepStrictEqual(r.marked, ['pulpo']);
+    assert.deepStrictEqual(stale.readPending({ pipelineDir: dir }).components, ['pulpo']);
+    const c = stale.clearComponent('../../evil', { pipelineDir: dir });
+    assert.strictEqual(c.ok, false);
+});
+
+test('CA-5: un stale-services.json tampereado con nombres desconocidos se ignora al leer', () => {
+    const dir = tmpDir('stale-tamper-');
+    fs.writeFileSync(path.join(dir, stale.STATE_FILENAME), JSON.stringify({
+        version: 1,
+        pending: { 'pulpo': { sha: 'abc1234', path: 'x' }, 'rm -rf': { sha: 'abc1234', path: 'y' } },
+    }), 'utf8');
+    assert.deepStrictEqual(stale.readPending({ pipelineDir: dir }).components, ['pulpo']);
+});
+
+test('CA-3: clearComponents limpia SÓLO la lista relanzada — outbox-drain sigue pendiente', () => {
+    // P-1 de guru / corrección vinculante de PO: `launchAll()` de restart.js
+    // itera sus 8 COMPONENTS, que NO incluyen `outbox-drain`. Limpiar el
+    // registro entero lo dejaría stale en silencio y para siempre.
+    const dir = tmpDir('stale-outbox-');
+    stale.markAffected(stale.ALL_COMPONENTS, { sha: 'abc1234', reasons: [] }, { pipelineDir: dir });
+    const relanzadosPorRestartJs = [
+        'pulpo', 'listener', 'svc-telegram', 'svc-github', 'svc-drive',
+        'svc-emulador', 'svc-reconciler', 'dashboard',
+    ];
+    stale.clearComponents(relanzadosPorRestartJs, { pipelineDir: dir });
+    assert.deepStrictEqual(stale.readPending({ pipelineDir: dir }).components, ['outbox-drain'],
+        'outbox-drain queda pendiente para el watchdog');
+});
+
+// ===========================================================================
+// CA-4 — el registro de componentes está completo y no se desincroniza.
+// ===========================================================================
+
+function parseScriptMapDelWatchdog() {
+    const src = fs.readFileSync(path.join(PIPELINE_DIR, 'watchdog.ps1'), 'utf8');
+    const m = src.match(/\$ScriptMap\s*=\s*@\{([\s\S]*?)\n\}/);
+    assert.ok(m, 'se encontró el bloque $ScriptMap en watchdog.ps1');
+    const map = {};
+    for (const linea of m[1].split('\n')) {
+        const e = linea.match(/'([^']+)'\s*=\s*'([^']+)'/);
+        if (e) map[e[1]] = e[2];
+    }
+    return map;
+}
+
+function parseComponentsDeNode(file) {
+    const src = fs.readFileSync(path.join(PIPELINE_DIR, file), 'utf8');
+    const m = src.match(/const COMPONENTS = \[([\s\S]*?)\n\];/);
+    assert.ok(m, `se encontró el bloque COMPONENTS en ${file}`);
+    return [...m[1].matchAll(/name:\s*'([^']+)'/g)].map(x => x[1]);
+}
+
+test('CA-4: $ScriptMap de watchdog.ps1 cubre TODO el registro canónico (9 componentes)', () => {
+    const map = parseScriptMapDelWatchdog();
+    const nombres = Object.keys(map).sort();
+    assert.deepStrictEqual(nombres, stale.ALL_COMPONENTS.slice().sort(),
+        'si esto falla, un componente marcado stale no tendría ejecutor (fail-open silencioso)');
+    for (const c of stale.COMPONENT_REGISTRY) {
+        assert.strictEqual(map[c.name], c.script, `script de ${c.name} desincronizado`);
+    }
+});
+
+test('CA-4: el registro canónico es exactamente la unión de restart.js y dashboard.js', () => {
+    const deRestart = parseComponentsDeNode('restart.js');
+    const deDashboard = parseComponentsDeNode('dashboard.js');
+    const union = [...new Set([...deRestart, ...deDashboard])].sort();
+    assert.deepStrictEqual(union, stale.ALL_COMPONENTS.slice().sort());
+    // Precondición del issue: ninguna lista contiene a la otra.
+    assert.ok(!deRestart.includes('outbox-drain'), 'restart.js no lanza outbox-drain');
+    assert.ok(!deDashboard.includes('dashboard'), 'el dashboard no puede matarse a sí mismo');
+});
+
+test('CA-4: todos los scripts del registro existen en disco', () => {
+    for (const c of stale.COMPONENT_REGISTRY) {
+        assert.ok(fs.existsSync(path.join(PIPELINE_DIR, c.script)), `falta ${c.script}`);
+    }
+});
+
+// ===========================================================================
+// CA-8 / REQ-SEC-5646-3 — contrato del CLI (frontera Node -> PowerShell).
+// ===========================================================================
+
+function runCli(args, dir) {
+    const r = require('node:child_process').spawnSync(
+        process.execPath,
+        [path.join(PIPELINE_DIR, 'lib', 'stale-services.js'), ...args],
+        { encoding: 'utf8', windowsHide: true, env: { ...process.env, STALE_SERVICES_DIR: dir } }
+    );
+    return { status: r.status, stdout: r.stdout || '', stderr: r.stderr || '' };
+}
+
+test('CA-8: CLI --json devuelve JSON parseable con exit 0', () => {
+    const dir = tmpDir('stale-cli-');
+    stale.markAffected(['dashboard'], { sha: 'abc1234', reasons: [{ component: 'dashboard', path: '.pipeline/lib/x.js' }] }, { pipelineDir: dir });
+    const r = runCli(['--json'], dir);
+    assert.strictEqual(r.status, 0);
+    const parsed = JSON.parse(r.stdout); // no debe lanzar
+    assert.deepStrictEqual(parsed.components, ['dashboard']);
+    assert.strictEqual(parsed.reasons[0].path, '.pipeline/lib/x.js');
+});
+
+test('CA-8: CLI --clear baja el pendiente y devuelve JSON con exit 0', () => {
+    const dir = tmpDir('stale-cliclear-');
+    stale.markAffected(['dashboard', 'pulpo'], { sha: 'abc1234', reasons: [] }, { pipelineDir: dir });
+    const r = runCli(['--clear', 'dashboard'], dir);
+    assert.strictEqual(r.status, 0);
+    assert.strictEqual(JSON.parse(r.stdout).cleared, true);
+    assert.deepStrictEqual(stale.readPending({ pipelineDir: dir }).components, ['pulpo']);
+});
+
+test('CA-8: CLI con argumento no reconocido -> stdout VACÍO y exit != 0 (nunca stack trace mezclado)', () => {
+    const dir = tmpDir('stale-clibad-');
+    for (const args of [['--loquesea'], ['--clear'], ['--prev'], ['; rm -rf /']]) {
+        const r = runCli(args, dir);
+        assert.notStrictEqual(r.status, 0, `debía fallar: ${args.join(' ')}`);
+        assert.strictEqual(r.stdout, '', `stdout debe quedar vacío: ${args.join(' ')}`);
+    }
+});
+
+test('CA-8: CLI --json sobre un registro inexistente devuelve lista vacía, no crashea', () => {
+    const dir = tmpDir('stale-clivacio-');
+    const r = runCli(['--json'], dir);
+    assert.strictEqual(r.status, 0);
+    assert.deepStrictEqual(JSON.parse(r.stdout).components, []);
+});
+
+// ===========================================================================
+// CA-1/CA-2 — escenario integrado sobre un repo git hermético.
+// ===========================================================================
+
+function repoHermetico() {
+    const dir = tmpDir('stale-repo-');
+    git(['init', '-q', '-b', 'main'], dir);
+    git(['config', 'user.email', 'test@intrale.com'], dir);
+    git(['config', 'user.name', 'Test'], dir);
+    git(['config', 'commit.gpgsign', 'false'], dir);
+    fs.mkdirSync(path.join(dir, '.pipeline', 'lib'), { recursive: true });
+    fs.writeFileSync(path.join(dir, '.pipeline', 'lib', 'config-schema.js'), 'v1\n');
+    fs.writeFileSync(path.join(dir, '.pipeline', 'config.yaml'), 'a: 1\n');
+    fs.writeFileSync(path.join(dir, '.pipeline', 'servicio-drive.js'), 'v1\n');
+    fs.writeFileSync(path.join(dir, 'README.md'), 'v1\n');
+    git(['add', '-A'], dir);
+    git(['commit', '-q', '-m', 'base'], dir);
+    return { dir, shaA: git(['rev-parse', 'HEAD'], dir) };
+}
+
+test('CA-1: escenario del incidente — merge que agrega una sección de config marca a TODOS', () => {
+    const { dir, shaA } = repoHermetico();
+    // Commit B: sección nueva en config.yaml + su declaración en config-schema.js
+    // (exactamente el patrón de `telegram_voice_outbound` y `human_block_reminder`).
+    fs.writeFileSync(path.join(dir, '.pipeline', 'config.yaml'), 'a: 1\nhuman_block_reminder:\n  enabled: true\n');
+    fs.writeFileSync(path.join(dir, '.pipeline', 'lib', 'config-schema.js'), 'v2 human_block_reminder\n');
+    git(['add', '-A'], dir);
+    git(['commit', '-q', '-m', 'feat: seccion nueva'], dir);
+    const shaB = git(['rev-parse', 'HEAD'], dir);
+
+    const res = stale.computeAffectedComponents({ prevSha: shaA, headSha: shaB, repoRoot: dir, pipelineDir: dir });
+    assert.strictEqual(res.unknown, false);
+    assert.deepStrictEqual(res.components, stale.ALL_COMPONENTS,
+        'el dashboard vivo con schema viejo queda marcado -> el watchdog lo relanza');
+    assert.ok(res.reasons.every(r => r.path.startsWith('.pipeline/')));
+
+    // El ciclo completo: marcar -> leer pendientes -> el ejecutor los toma.
+    stale.markAffected(res.components, { sha: res.headSha, reasons: res.reasons }, { pipelineDir: dir });
+    assert.deepStrictEqual(stale.readPending({ pipelineDir: dir }).components, stale.ALL_COMPONENTS);
+});
+
+test('CA-2: escenario integrado — reset sin cambios relevantes NO marca a nadie (cero restarts)', () => {
+    const { dir, shaA } = repoHermetico();
+    fs.writeFileSync(path.join(dir, 'README.md'), 'v2\n');
+    fs.mkdirSync(path.join(dir, 'app'), { recursive: true });
+    fs.writeFileSync(path.join(dir, 'app', 'Main.kt'), 'fun main() {}\n');
+    git(['add', '-A'], dir);
+    git(['commit', '-q', '-m', 'docs: nada del pipeline'], dir);
+    const shaB = git(['rev-parse', 'HEAD'], dir);
+
+    const res = stale.computeAffectedComponents({ prevSha: shaA, headSha: shaB, repoRoot: dir, pipelineDir: dir });
+    assert.strictEqual(res.unknown, false);
+    assert.deepStrictEqual(res.components, [], 'cero restarts');
+    const mark = stale.markAffected(res.components, { sha: res.headSha, reasons: res.reasons }, { pipelineDir: dir });
+    assert.deepStrictEqual(mark.marked, []);
+    assert.deepStrictEqual(stale.readPending({ pipelineDir: dir }).components, []);
+});
+
+test('CA-2: escenario integrado — cambio de un solo servicio marca sólo a ese servicio', () => {
+    const { dir, shaA } = repoHermetico();
+    fs.writeFileSync(path.join(dir, '.pipeline', 'servicio-drive.js'), 'v2\n');
+    git(['add', '-A'], dir);
+    git(['commit', '-q', '-m', 'fix: drive'], dir);
+    const shaB = git(['rev-parse', 'HEAD'], dir);
+    const res = stale.computeAffectedComponents({ prevSha: shaA, headSha: shaB, repoRoot: dir, pipelineDir: dir });
+    assert.deepStrictEqual(res.components, ['svc-drive']);
+    assert.deepStrictEqual(res.reasons, [{ component: 'svc-drive', path: '.pipeline/servicio-drive.js' }]);
+});
+
+test('CA-8: el boot marker real del pipeline se lee vía runtime-boot (no se parsea a mano)', () => {
+    // Guard de regresión sobre REQ-SEC-5646-1: el módulo no debe leer
+    // runtime-boot.json por su cuenta.
+    const src = fs.readFileSync(path.join(PIPELINE_DIR, 'lib', 'stale-services.js'), 'utf8');
+    assert.ok(src.includes("require('./runtime-boot')"), 'usa el módulo canónico');
+    assert.ok(!/readFileSync\([^)]*runtime-boot\.json/.test(src), 'no parsea el marker a mano');
+    assert.ok(!src.includes('execSync('), 'no usa execSync con string de shell');
+    assert.strictEqual(typeof runtimeBoot.SHA_RE.test, 'function');
+});
+
+// ===========================================================================
+// CA-9 — el endpoint HTTP no amplía su blast radius.
+// ===========================================================================
+
+function bloqueEndpointRestartOperativo() {
+    const src = fs.readFileSync(path.join(PIPELINE_DIR, 'dashboard.js'), 'utf8');
+    const ini = src.indexOf("req.url === '/api/ops/restart-operativo'");
+    assert.ok(ini > 0, 'se encontró el endpoint restart-operativo');
+    const fin = src.indexOf("req.url === '/api/gate-signature/csrf-token'", ini);
+    assert.ok(fin > ini, 'se delimitó el bloque del endpoint');
+    return src.slice(ini, fin);
+}
+
+test('CA-3: el endpoint lee readBootMarker ANTES de syncOperativoTree (que pisa el marker)', () => {
+    const bloque = bloqueEndpointRestartOperativo();
+    // Se comparan los CALL SITES reales, no las menciones en comentarios.
+    const iMarker = bloque.indexOf('_runtimeBoot.readBootMarker(');
+    const iSync = bloque.indexOf('_operativoSync.syncOperativoTree(');
+    assert.ok(iMarker > 0, 'el endpoint lee el boot marker');
+    assert.ok(iSync > 0, 'el endpoint sincroniza el tree');
+    assert.ok(iMarker < iSync,
+        'si el marker se lee después del sync ya no hay prevSha recuperable (operativo-sync lo pisa)');
+});
+
+test('CA-9: el conjunto se computa server-side — el body sólo aporta `actor`', () => {
+    const bloque = bloqueEndpointRestartOperativo();
+    assert.ok(bloque.includes('computeAffectedComponents'), 'el conjunto sale del diff, no del request');
+    const usosDelBody = [...bloque.matchAll(/parsed\.(\w+)/g)].map(m => m[1]);
+    assert.deepStrictEqual([...new Set(usosDelBody)], ['actor'],
+        'del body del request no se lee nada más que `actor`');
+});
+
+test('CA-9: el endpoint conserva gate + CSRF + rate-limit + audit y suma la cota agregada', () => {
+    const bloque = bloqueEndpointRestartOperativo();
+    for (const control of ['checkGate', 'requireCSRF', '_opsRestartRateLimiter', 'appendOpsRestartAudit']) {
+        assert.ok(bloque.includes(control), `se perdió el control ${control}`);
+    }
+    assert.ok(bloque.includes('_opsRestartAggregateLimiter.grant'),
+        'cota agregada por ventana (el rate-limiter por target no alcanza con N targets)');
+});
+
+test('CA-3: el propio dashboard no está en la allowlist ejecutable del endpoint', () => {
+    // No puede matarse a sí mismo: queda pendiente en disco y lo relanza el
+    // watchdog, único ejecutor externo (REQ-SEC-5646-5).
+    const deDashboard = parseComponentsDeNode('dashboard.js');
+    assert.ok(!deDashboard.includes('dashboard'));
+    const map = parseScriptMapDelWatchdog();
+    assert.strictEqual(map['dashboard'], 'dashboard.js', 'pero el watchdog SÍ puede relanzarlo');
+});
+
+// ===========================================================================
+// CA-6 — el watchdog es el único ejecutor y no puede entrar en crash-loop.
+// ===========================================================================
+
+function fuenteWatchdog() {
+    return fs.readFileSync(path.join(PIPELINE_DIR, 'watchdog.ps1'), 'utf8');
+}
+
+test('CA-6: el watchdog tiene guard de ventana propio para el restart selectivo', () => {
+    const src = fuenteWatchdog();
+    assert.ok(src.includes('$StaleGuardFile'), 'existe el guard de ronda');
+    assert.ok(/\$StaleGuardWindowSeconds\s*=\s*90/.test(src), 'ventana de 90s, molde de last-restart.json');
+    assert.ok(/\$StaleMaxPerRound\s*=\s*\d+/.test(src), 'cota de componentes por ronda');
+    assert.ok(src.includes('last-restart.json'), 'sigue respetando el stand-by de restart.js');
+});
+
+test('CA-6: el watchdog hace double-check pre-spawn antes de relanzar un stale', () => {
+    const src = fuenteWatchdog();
+    const ini = src.indexOf('function Invoke-StaleRestarts');
+    assert.ok(ini > 0);
+    const bloque = src.slice(ini);
+    assert.ok(bloque.includes('Get-FreshServicePid'), 'el PID sale de un scan fresco del SO, no de un archivo');
+    assert.ok(bloque.includes('no se spawnea otra'), 'no spawnea si sigue habiendo una instancia viva');
+    assert.ok(bloque.includes('no esta corriendo'),
+        'un componente apagado no se "reinicia": no tiene codigo viejo en memoria y este bloque no lo levanta');
+});
+
+test('CA-8: la frontera Node -> PowerShell usa ConvertFrom-Json y allowlist, nunca Invoke-Expression', () => {
+    const src = fuenteWatchdog();
+    assert.ok(src.includes('ConvertFrom-Json'));
+    // Sólo código ejecutable: los comentarios pueden nombrar lo prohibido.
+    const codigo = src.split(/\r?\n/).filter(l => !/^\s*#/.test(l)).join('\n');
+    assert.ok(!/Invoke-Expression|\biex\b/.test(codigo), 'prohibido Invoke-Expression');
+    assert.ok(src.includes('$ScriptMap.ContainsKey($name)'), 'valida el nombre contra la allowlist estática');
+    assert.ok(/Start-Process -FilePath 'node' -ArgumentList @\(\$scriptPath\)/.test(src),
+        'spawn con array de argumentos');
+});
+
+test('CA-3: los DOS resets del watchdog capturan el HEAD previo y marcan', () => {
+    const src = fuenteWatchdog();
+    const resets = [...src.matchAll(/reset --hard FETCH_HEAD/g)];
+    assert.strictEqual(resets.length, 2, 'siguen siendo los dos emisores conocidos');
+    for (const m of resets) {
+        const contexto = src.slice(Math.max(0, m.index - 600), m.index + 400);
+        assert.ok(/Get-RepoHead/.test(contexto), 'captura el HEAD previo al reset');
+        assert.ok(/Invoke-StaleMark/.test(contexto), 'marca los afectados tras el reset');
+    }
+});
+
+test('CA-5: el watchdog limpia el pendiente SÓLO después del spawn confirmado', () => {
+    const src = fuenteWatchdog();
+    const ini = src.indexOf('function Invoke-StaleRestarts');
+    const bloque = src.slice(ini);
+    const iSpawn = bloque.indexOf("Start-Process -FilePath 'node'");
+    const iClear = bloque.lastIndexOf('Invoke-StaleClear $name');
+    assert.ok(iSpawn > 0 && iClear > iSpawn, 'el clear del camino de relanzamiento va DESPUÉS del spawn');
+    // Y no hay ningún clear entre el Stop-Process y el spawn: si el proceso se
+    // mató pero el spawn falló, el componente tiene que seguir pendiente.
+    const entre = bloque.slice(bloque.indexOf('Stop-Process'), iSpawn);
+    assert.ok(!entre.includes('Invoke-StaleClear'), 'no se limpia entre el kill y el spawn');
+    assert.ok(bloque.includes('sigue pendiente'), 'los caminos de falla dejan el componente pendiente');
+});
+
+// ===========================================================================
+// CA-3 — restart.js no cambia su contrato y limpia sólo lo que relanzó.
+// ===========================================================================
+
+test('CA-3: restart.js conserva el contrato killAll -> syncWithMain -> reexec -> launchAll', () => {
+    const src = fs.readFileSync(path.join(PIPELINE_DIR, 'restart.js'), 'utf8');
+    const m = /killAll\(\);\r?\n\s*if \(!flagNoSync\) syncWithMain\(\);/.exec(src);
+    assert.ok(m, 'killAll seguido de syncWithMain intacto');
+    const iKill = m.index;
+    assert.ok(src.indexOf('reexecIfSelfChanged();', iKill) > iKill);
+    assert.ok(src.indexOf('limpiarPendientesRelanzados(launchAll());', iKill) > iKill);
+});
+
+test('CA-3: restart.js deriva la limpieza de lo efectivamente lanzado, no de una constante', () => {
+    const src = fs.readFileSync(path.join(PIPELINE_DIR, 'restart.js'), 'utf8');
+    assert.ok(src.includes('limpiarPendientesRelanzados(launchAll())'),
+        'la lista sale del retorno de launchAll()');
+    assert.ok(!/clearComponents\(\s*COMPONENTS/.test(src), 'nunca se limpia el registro entero');
+    assert.ok(/return lanzados;/.test(src), 'launchAll devuelve lo que realmente lanzó');
+});
+
+test('CA-6/REQ-SEC-5646-6: no se relaja la validación de config en ningún archivo tocado', () => {
+    // Fuera de alcance explícito: ignorar claves desconocidas, degradar el
+    // fail-closed o hot-reloadear el require-cache del schema.
+    const src = fs.readFileSync(path.join(PIPELINE_DIR, 'lib', 'stale-services.js'), 'utf8');
+    assert.ok(!/require\(['"][^'"]*config-schema/.test(src), 'el fix no importa el validador de config');
+    assert.ok(!/delete require\.cache/.test(src), 'no invalida el require-cache de nadie');
+    const wd = fuenteWatchdog();
+    assert.ok(!/delete require\.cache/.test(wd));
+});

--- a/.pipeline/restart.js
+++ b/.pipeline/restart.js
@@ -105,7 +105,68 @@ function sleep(ms) {
 
 // --- SYNC: actualizar repo principal con main ---
 
+// #5646 — Marca en `stale-services.json` los componentes cuyo código cambió con
+// el reset. NUNCA lanza: el sync no puede romperse por el marcado.
+// Los paths que se loguean vienen del contenido del commit y ya salen
+// sanitizados del helper (REQ-SEC-5646-8): un path con CR/LF embebido no puede
+// falsificar líneas en `pulpo.log`.
+function marcarComponentesConCodigoViejo(prevHead, head) {
+  try {
+    const stale = require('./lib/stale-services');
+    const res = stale.computeAffectedComponents({
+      prevSha: prevHead || undefined,
+      headSha: head,
+      repoRoot: ROOT,
+      pipelineDir: PIPELINE,
+    });
+    if (!res.components.length) {
+      // CA-2 / UX G-1: el caso "no afectó a nadie" también deja una línea; sin
+      // ella, el log silencioso es indistinguible de "no corrió".
+      log('restart selectivo: sin componentes afectados por el reset');
+      return;
+    }
+    const mark = stale.markAffected(res.components, { sha: res.headSha, reasons: res.reasons });
+    for (const r of res.reasons) {
+      if (!mark.marked.includes(r.component)) continue;
+      log(`restart selectivo: ${r.component} quedó con código viejo — cambio en ${r.path}`);
+    }
+  } catch (e) {
+    log(`Warning: no se pudo marcar servicios con código viejo: ${(e && e.message || '').slice(0, 80)}`);
+  }
+}
+
+// #5646 (CA-3, corregido por PO sobre P-1 de guru) — Baja del registro de
+// pendientes SÓLO los componentes que `launchAll()` relanzó de verdad. La lista
+// se DERIVA de lo efectivamente lanzado, no de una constante duplicada: limpiar
+// el registro entero desmarcaría `outbox-drain` (que no está en COMPONENTS de
+// este archivo) sin haberlo relanzado jamás → quedaría con código viejo, en
+// silencio y para siempre, que es el fail-open que cierra CA-5.
+function limpiarPendientesRelanzados(lanzados) {
+  if (!Array.isArray(lanzados) || !lanzados.length) return;
+  try {
+    const stale = require('./lib/stale-services');
+    const res = stale.clearComponents(lanzados);
+    if (res.cleared.length) {
+      log(`restart selectivo: ${res.cleared.join(', ')} relanzados por restart.js — pendiente dado de baja`);
+    }
+    const restantes = stale.readPending();
+    if (restantes.components.length) {
+      log(`restart selectivo: siguen pendientes para el watchdog: ${restantes.components.join(', ')}`);
+    }
+  } catch (e) {
+    log(`Warning: no se pudieron limpiar pendientes: ${(e && e.message || '').slice(0, 80)}`);
+  }
+}
+
 function syncWithMain() {
+  // #5646 — HEAD ANTES del reset. Es la referencia contra la que se calcula qué
+  // componentes quedaron con código viejo. Se captura acá (no después) porque
+  // el `reset --hard` de abajo la destruye. Best-effort: si no se puede
+  // resolver, el marcado usa el boot marker como referencia.
+  let prevHead = null;
+  try {
+    prevHead = execSync('git rev-parse HEAD', { cwd: ROOT, timeout: 10000, windowsHide: true, encoding: 'utf8' }).trim();
+  } catch { /* sin referencia previa: se resuelve más abajo con el boot marker */ }
   try {
     execSync('git fetch origin main', { cwd: ROOT, timeout: 30000, windowsHide: true });
     // #4577 GATE 3 — INVARIANTE log-antes-de-mutar (RS-2/RS-6): registrar el
@@ -139,6 +200,13 @@ function syncWithMain() {
     // trata como estado desconocido, nunca como "sin pendientes").
     try {
       const head = execSync('git rev-parse HEAD', { cwd: ROOT, timeout: 10000, windowsHide: true, encoding: 'utf8' }).trim();
+      // #5646 — Marcar qué componentes quedaron con código viejo por este reset.
+      // `restart.js` relanza los suyos en `launchAll()` y los baja del registro
+      // ahí mismo; lo que queda pendiente (típicamente `outbox-drain`, que NO
+      // está en COMPONENTS de este archivo) lo relanza el watchdog. Va ANTES de
+      // `writeBootMarker` sólo por orden de lectura: el cómputo usa `prevHead`
+      // explícito, no el marker.
+      marcarComponentesConCodigoViejo(prevHead, head);
       const res = require('./lib/runtime-boot').writeBootMarker(head, { pipelineDir: PIPELINE });
       if (res && res.ok) log(`Boot marker actualizado: ${head.slice(0, 8)}`);
     } catch (e2) {
@@ -350,12 +418,16 @@ function freeDashboardPortOrAdvance() {
 
 // --- LAUNCH ---
 
+// #5646 — Devuelve los nombres de los componentes efectivamente lanzados. El
+// caller usa ESA lista (no una constante duplicada) para bajar pendientes del
+// registro de "código viejo": lo que no se lanzó, no se desmarca.
 function launchAll() {
   log('=== START ===');
 
   const logsDir = path.join(PIPELINE, 'logs');
   if (!fs.existsSync(logsDir)) fs.mkdirSync(logsDir, { recursive: true });
 
+  const lanzados = [];
   for (const comp of COMPONENTS) {
     // #4664 — pulpo y dashboard son los entrypoints del motor que migraron a
     // `core/` del kernel: se resuelven vía kernel-resolver (kernel migrado vs
@@ -387,10 +459,12 @@ function launchAll() {
     child.unref();
     fs.closeSync(logFd);
 
+    lanzados.push(comp.name);
     log(`  ${comp.name}: PID ${child.pid}`);
   }
 
   sleep(3000);
+  return lanzados;
 }
 
 // --- SMOKE TEST + TAG pipeline-stable + AUTO-ROLLBACK ---
@@ -617,7 +691,11 @@ switch (action) {
       try { fs.unlinkSync(path.join(PIPELINE, '.paused')); } catch {}
     }
     freeDashboardPortOrAdvance(); // #4308 — puerto 3200 libre antes de relanzar
-    launchAll();
+    // #5646 — Estos componentes acaban de arrancar leyendo el código de disco:
+    // se bajan del registro de "código viejo" para que el watchdog no los
+    // reinicie de nuevo un minuto después. Lo que restart.js NO lanza (p. ej.
+    // `outbox-drain`) queda pendiente a propósito.
+    limpiarPendientesRelanzados(launchAll());
     const ok = status();
     log(ok ? '=== Pipeline operativo ===' : '=== Revisar componentes ===');
 
@@ -636,7 +714,7 @@ switch (action) {
         log('Primer smoke test FAIL — reintento tras limpieza de stragglers');
         killAll();
         freeDashboardPortOrAdvance(); // #4308 — puerto 3200 libre antes de relanzar
-        launchAll();
+        limpiarPendientesRelanzados(launchAll());
         sleep(5000);
         smoke = runSmokeTest();
         if (smoke.ok) log('Segundo smoke test OK tras retry — pipeline recuperado sin rollback');

--- a/.pipeline/runtime-boot.json
+++ b/.pipeline/runtime-boot.json
@@ -1,4 +1,4 @@
 {
-  "sha": "8bd162fde256250d79ab5632ea0e90d46ccf23be",
-  "startedAt": "2026-07-25T17:22:42.920Z"
+  "sha": "c2fb2cb8d67807c37615a4f8d92f959ddbff6bef",
+  "startedAt": "2026-08-08T02:13:58.737Z"
 }

--- a/.pipeline/watchdog.ps1
+++ b/.pipeline/watchdog.ps1
@@ -68,6 +68,38 @@ $Services = @(
     @{ Name = 'dashboard';     Script = 'dashboard.js' }
 )
 
+# #5646 (CA-4) — Registro CANONICO de componentes: union de `restart.js:COMPONENTS`
+# (8, con dashboard, sin outbox-drain) y `dashboard.js:COMPONENTS` (8, con
+# outbox-drain, sin dashboard) = 9. Es el unico mapa nombre -> script que este
+# ejecutor acepta (allowlist estatica, REQ-SEC-5646-2): ningun nombre que venga
+# del JSON del helper se usa si no esta aca.
+# Se declara ANTES del loop de servicios caidos porque tambien lo consume el
+# restart selectivo del final. Hay un test que lo compara contra las dos listas
+# de Node y falla si divergen (`lib/stale-services.test.js`).
+$ScriptMap = @{
+    'pulpo'          = 'pulpo.js'
+    'listener'       = 'listener-telegram.js'
+    'svc-telegram'   = 'servicio-telegram.js'
+    'svc-github'     = 'servicio-github.js'
+    'svc-drive'      = 'servicio-drive.js'
+    'svc-emulador'   = 'servicio-emulador.js'
+    'svc-reconciler' = 'servicio-reconciler.js'
+    'outbox-drain'   = 'outbox-drain.js'
+    'dashboard'      = 'dashboard.js'
+}
+
+# #5646 — Helper compartido y guard anti crash-loop del restart selectivo.
+$StaleHelper = "$PipelineDir\lib\stale-services.js"
+$StaleGuardFile = "$PipelineDir\last-selective-restart.json"
+# Ventana del guard: mismo molde que `last-restart.json` (90s). Como el watchdog
+# corre cada 2 min, permite a lo sumo una ronda de restart selectivo por ciclo.
+$StaleGuardWindowSeconds = 90
+# Cota de componentes por ronda: casi todo merge del pipeline toca
+# `.pipeline/lib/**`, asi que la regla conservadora marca casi todo. Espaciar el
+# relanzamiento en varias rondas evita la tormenta (CA-6). Lo que no entra en
+# esta ronda sigue pendiente en disco y lo toma el ciclo siguiente.
+$StaleMaxPerRound = 4
+
 # Un único scan del SO, reutilizado para todos los componentes.
 try {
     $allNodeProcs = Get-CimInstance -ClassName Win32_Process -Filter "Name='node.exe'" -ErrorAction Stop
@@ -103,6 +135,75 @@ function Get-ServicePid($Script) {
         }
     }
     return $null
+}
+
+# #5646 — HEAD actual del repo principal, validado como hex 7-40. Devuelve ''
+# si git no responde o la salida no es un SHA. Se captura ANTES de cada
+# `reset --hard` para saber contra que comparar el diff.
+function Get-RepoHead {
+    try {
+        $out = & git -C $RepoRoot rev-parse HEAD 2>$null
+        if ($LASTEXITCODE -ne 0 -or -not $out) { return '' }
+        $sha = ([string]$out).Trim()
+        if ($sha -match '^[0-9a-f]{7,40}$') { return $sha }
+    } catch {}
+    return ''
+}
+
+# #5646 (CA-3) — Tras un `reset --hard`, MARCA que servicios vivos quedaron con
+# codigo viejo. No reinicia nada aca: marcar y ejecutar son pasos separados, y el
+# ejecutor unico es el loop del final de este mismo script.
+#
+# Frontera Node -> PowerShell (REQ-SEC-5646-3): el helper devuelve JSON valido en
+# stdout con exit 0, o stdout vacio con exit != 0. Se parsea con ConvertFrom-Json,
+# NUNCA con Invoke-Expression, y nada del JSON se interpola en una command line.
+function Invoke-StaleMark($PrevSha) {
+    if (-not (Test-Path $StaleHelper)) { return }
+    if (-not $PrevSha) {
+        # Sin referencia previa confiable no marcamos: el mismo git que fallo al
+        # resolver HEAD es el que tendria que haber hecho el reset. Queda
+        # registrado para que el operador lo vea (nunca silencioso).
+        Write-Log "  restart selectivo: no se pudo leer el HEAD previo al reset — no se marco nada"
+        return
+    }
+    try {
+        $env:NODE_PATH = "$RepoRoot\node_modules"
+        $raw = & node $StaleHelper --mark --prev $PrevSha 2>$null
+        if ($LASTEXITCODE -ne 0 -or -not $raw) {
+            Write-Log "  restart selectivo: el marcador no devolvio datos, skip"
+            return
+        }
+        $parsed = $raw | ConvertFrom-Json
+        if (-not $parsed) { return }
+        $marcados = @($parsed.marked)
+        if ($marcados.Count -eq 0) {
+            # CA-2 / UX G-1: el caso "no afecto a nadie" tambien deja una linea.
+            # Sin ella, un log silencioso es indistinguible de un watchdog que no corrio.
+            Write-Log "  restart selectivo: sin componentes afectados por el reset"
+            return
+        }
+        foreach ($r in @($parsed.reasons)) {
+            if (-not $r) { continue }
+            if ($marcados -notcontains $r.component) { continue }
+            Write-Log ("  restart selectivo: " + $r.component + " quedo con codigo viejo - cambio en " + $r.path)
+        }
+    } catch {
+        Write-Log "  restart selectivo: ERROR al marcar - $_"
+    }
+}
+
+# #5646 (CA-5) — Baja UN componente del registro de pendientes. Se invoca SOLO
+# tras spawn CONFIRMADO: si el relanzamiento fallo, el componente sigue pendiente
+# el ciclo siguiente en vez de desaparecer en silencio (fail-open de REQ-SEC-5646-7).
+function Invoke-StaleClear($Name) {
+    if (-not (Test-Path $StaleHelper)) { return }
+    if (-not $ScriptMap.ContainsKey($Name)) { return }
+    try {
+        $env:NODE_PATH = "$RepoRoot\node_modules"
+        & node $StaleHelper --clear $Name 2>$null | Out-Null
+    } catch {
+        Write-Log "  restart selectivo: no se pudo limpiar el pendiente de $Name - $_"
+    }
 }
 
 # #4154 — Liveness real del Pulpo (detección de zombi).
@@ -174,15 +275,23 @@ function Invoke-PulpoLivenessCheck {
 
     # Sincronizar con main antes de relanzar (scripts actualizados), igual que
     # el path de proceso ausente.
+    # #5646 — El reset actualiza el codigo EN DISCO de TODOS los servicios, pero
+    # aca solo se respawnea el pulpo: los demas siguen vivos con el codigo viejo
+    # en su require-cache. Capturamos el HEAD previo para poder marcarlos.
+    $prevHead = Get-RepoHead
     try {
         git -C $RepoRoot fetch origin main 2>$null
         git -C $RepoRoot reset --hard FETCH_HEAD 2>$null
     } catch {}
+    Invoke-StaleMark $prevHead
 
     $env:NODE_PATH = "$RepoRoot\node_modules"
     try {
         $proc = Start-Process -FilePath 'node' -ArgumentList @("$PipelineDir\pulpo.js") -WorkingDirectory $RepoRoot -WindowStyle Hidden -PassThru
         Write-Log "  pulpo-liveness : pulpo respawneado PID $($proc.Id)"
+        # El pulpo acaba de arrancar con el codigo de disco: ya no tiene codigo
+        # viejo, aunque el reset de recien lo hubiera marcado.
+        Invoke-StaleClear 'pulpo'
     } catch {
         Write-Log "  pulpo-liveness : ERROR al respawnear pulpo - $($_.Exception.Message)"
     }
@@ -197,53 +306,196 @@ foreach ($svc in $Services) {
     }
 }
 
-if ($dead.Count -eq 0) {
-    exit 0
-}
-
-$deadList = $dead -join ', '
-Write-Log "Servicios caidos detectados: $deadList"
-
-$ScriptMap = @{
-    'pulpo'        = 'pulpo.js'
-    'listener'     = 'listener-telegram.js'
-    'svc-telegram' = 'servicio-telegram.js'
-    'svc-github'   = 'servicio-github.js'
-    'svc-drive'    = 'servicio-drive.js'
-    'dashboard'    = 'dashboard.js'
-}
-
-# Sincronizar con main antes de levantar (para tener scripts actualizados)
-try {
-    git -C $RepoRoot fetch origin main 2>$null
-    git -C $RepoRoot reset --hard FETCH_HEAD 2>$null
-} catch {}
-
 $NodeModules = "$RepoRoot\node_modules"
 $env:NODE_PATH = $NodeModules
 
-foreach ($svcName in $dead) {
-    $script = $ScriptMap[$svcName]
-    if (-not $script) { continue }
-    $scriptPath = "$PipelineDir\$script"
-    if (-not (Test-Path $scriptPath)) {
-        Write-Log "  $svcName : script no encontrado ($scriptPath)"
-        continue
-    }
+if ($dead.Count -gt 0) {
+    $deadList = $dead -join ', '
+    Write-Log "Servicios caidos detectados: $deadList"
 
-    # Double-check justo antes de spawnear: el primer scan podria ser stale
-    # de 1-2s y el servicio puede haber arrancado en ese interin (por ejemplo,
-    # restart.js que largo los procesos entre que hicimos el scan y ahora).
-    if (Test-ServiceAlive $script) {
-        Write-Log "  $svcName : ya arranco entre el scan y el spawn, skip"
-        continue
-    }
-
+    # Sincronizar con main antes de levantar (para tener scripts actualizados)
+    # #5646 — Este reset tambien avanza el codigo de los servicios que estan
+    # VIVOS y que este loop no toca: quedan con el codigo viejo en memoria. Por
+    # eso capturamos el HEAD previo y marcamos los afectados; el relanzamiento
+    # real lo hace el bloque de restart selectivo del final.
+    $prevHeadDead = Get-RepoHead
     try {
-        $proc = Start-Process -FilePath 'node' -ArgumentList @($scriptPath) -WorkingDirectory $RepoRoot -WindowStyle Hidden -PassThru
-        Write-Log ("  " + $svcName + " : levantado PID " + $proc.Id)
-    } catch {
-        $errMsg = $_.Exception.Message
-        Write-Log ("  " + $svcName + " : ERROR al levantar - " + $errMsg)
+        git -C $RepoRoot fetch origin main 2>$null
+        git -C $RepoRoot reset --hard FETCH_HEAD 2>$null
+    } catch {}
+    Invoke-StaleMark $prevHeadDead
+
+    foreach ($svcName in $dead) {
+        $script = $ScriptMap[$svcName]
+        if (-not $script) { continue }
+        $scriptPath = "$PipelineDir\$script"
+        if (-not (Test-Path $scriptPath)) {
+            Write-Log "  $svcName : script no encontrado ($scriptPath)"
+            continue
+        }
+
+        # Double-check justo antes de spawnear: el primer scan podria ser stale
+        # de 1-2s y el servicio puede haber arrancado en ese interin (por ejemplo,
+        # restart.js que largo los procesos entre que hicimos el scan y ahora).
+        if (Test-ServiceAlive $script) {
+            Write-Log "  $svcName : ya arranco entre el scan y el spawn, skip"
+            continue
+        }
+
+        try {
+            $proc = Start-Process -FilePath 'node' -ArgumentList @($scriptPath) -WorkingDirectory $RepoRoot -WindowStyle Hidden -PassThru
+            Write-Log ("  " + $svcName + " : levantado PID " + $proc.Id)
+            # Arranco con el codigo de disco: si estaba marcado, ya no aplica.
+            Invoke-StaleClear $svcName
+        } catch {
+            $errMsg = $_.Exception.Message
+            Write-Log ("  " + $svcName + " : ERROR al levantar - " + $errMsg)
+        }
     }
 }
+
+# =============================================================================
+# #5646 — RESTART SELECTIVO de servicios con codigo viejo.
+# -----------------------------------------------------------------------------
+# Este bloque es el UNICO EJECUTOR del restart de servicios stale (REQ-SEC-5646-5):
+# el dashboard no puede matarse a si mismo y no queremos inventar un relanzador
+# generico que acepte paths o command lines. Corre SIEMPRE (haya o no servicios
+# caidos) porque el pendiente pudo haberlo dejado marcado `restart.js` o el
+# endpoint `/api/ops/restart-operativo`, no solo este script.
+#
+# Precondiciones ya garantizadas arriba: el guard de `last-restart.json` (90s)
+# corta el script antes de llegar aca si hay un restart.js en curso.
+# =============================================================================
+function Get-FreshServicePid($Script) {
+    try {
+        $procs = Get-CimInstance -ClassName Win32_Process -Filter "Name='node.exe'" -ErrorAction Stop
+    } catch {
+        return $null
+    }
+    foreach ($p in $procs) {
+        if ($p.CommandLine -and $p.CommandLine -like "*$Script*") {
+            try {
+                $proc = Get-Process -Id $p.ProcessId -ErrorAction Stop
+                if ($proc.ProcessName -eq 'node') { return [int]$p.ProcessId }
+            } catch {}
+        }
+    }
+    return $null
+}
+
+function Invoke-StaleRestarts {
+    if (-not (Test-Path $StaleHelper)) { return }
+
+    # Cota anti crash-loop (CA-6): molde del guard de `last-restart.json`.
+    if (Test-Path $StaleGuardFile) {
+        try {
+            $age = (Get-Date) - (Get-Item $StaleGuardFile).LastWriteTime
+            if ($age.TotalSeconds -lt $StaleGuardWindowSeconds) {
+                Write-Log "  restart selectivo: ronda reciente ($([int]$age.TotalSeconds)s) — en stand-by"
+                return
+            }
+        } catch {}
+    }
+
+    $pendientes = @()
+    $motivos = @{}
+    try {
+        $env:NODE_PATH = "$RepoRoot\node_modules"
+        $raw = & node $StaleHelper --json 2>$null
+        if ($LASTEXITCODE -ne 0 -or -not $raw) {
+            Write-Log "  restart selectivo: sin datos del marcador, skip"
+            return
+        }
+        # Parseo declarativo: nada del JSON se evalua como codigo ni se
+        # interpola en una command line (ver contrato al inicio del archivo).
+        $parsed = $raw | ConvertFrom-Json
+        if (-not $parsed) { return }
+        $pendientes = @($parsed.components)
+        foreach ($r in @($parsed.reasons)) {
+            if ($r -and $r.component) { $motivos[[string]$r.component] = [string]$r.path }
+        }
+    } catch {
+        Write-Log "  restart selectivo: ERROR al leer pendientes - $_"
+        return
+    }
+
+    if ($pendientes.Count -eq 0) { return }
+
+    $hechos = 0
+    foreach ($name in $pendientes) {
+        if ($hechos -ge $StaleMaxPerRound) {
+            Write-Log "  restart selectivo: cota de $StaleMaxPerRound por ronda alcanzada — el resto sigue pendiente"
+            break
+        }
+        # Allowlist estatica: un nombre que no este en el mapa NO se ejecuta
+        # (REQ-SEC-5646-2/3). El script a spawnear sale SIEMPRE de aca, jamas
+        # del JSON ni del diff.
+        if (-not $ScriptMap.ContainsKey($name)) {
+            Write-Log "  restart selectivo: '$name' fuera de la allowlist, descartado"
+            continue
+        }
+        $script = $ScriptMap[$name]
+        $scriptPath = "$PipelineDir\$script"
+        if (-not (Test-Path $scriptPath)) {
+            Write-Log "  restart selectivo: $name — script no encontrado, sigue pendiente"
+            continue
+        }
+
+        $motivo = $motivos[[string]$name]
+        if (-not $motivo) { $motivo = '(sin path)' }
+
+        # 1. Matar la instancia vieja (PID del scan del SO, nunca de un archivo).
+        #    Si el componente NO esta corriendo, no hay nada stale: un proceso
+        #    que no existe no tiene codigo viejo en memoria, y cuando arranque
+        #    va a leer el disco actual. Se baja el pendiente y NO se spawnea:
+        #    levantar un servicio que estaba deliberadamente apagado no es
+        #    trabajo de este bloque (de eso se ocupa el loop de caidos, con su
+        #    propia lista de servicios criticos).
+        $viejoPid = Get-FreshServicePid $script
+        if (-not $viejoPid) {
+            Write-Log "  restart selectivo: $name no esta corriendo — nada que reiniciar, pendiente dado de baja"
+            Invoke-StaleClear $name
+            continue
+        }
+        try {
+            Stop-Process -Id $viejoPid -Force -ErrorAction Stop
+            try { Wait-Process -Id $viejoPid -Timeout 10 -ErrorAction SilentlyContinue } catch {}
+        } catch {
+            Write-Log "  restart selectivo: $name — no se pudo terminar el PID $viejoPid, sigue pendiente"
+            continue
+        }
+        # Dar aire a que el SO libere puerto/handles antes de relanzar.
+        Start-Sleep -Milliseconds 1500
+
+        # 2. Double-check pre-spawn (molde de la linea del loop de caidos): si
+        #    quedo o volvio a arrancar una instancia, NO spawneamos una segunda.
+        if (Get-FreshServicePid $script) {
+            Write-Log "  restart selectivo: $name — sigue habiendo una instancia viva, no se spawnea otra"
+            continue
+        }
+
+        # 3. Relanzar con el contrato de spawn existente.
+        try {
+            $proc = Start-Process -FilePath 'node' -ArgumentList @($scriptPath) -WorkingDirectory $RepoRoot -WindowStyle Hidden -PassThru
+            Write-Log ("restart selectivo: " + $name + " reiniciado — cambio en " + $motivo + " (PID " + $proc.Id + ")")
+            $hechos++
+            # 4. Recien con el spawn CONFIRMADO se baja el pendiente (CA-5).
+            Invoke-StaleClear $name
+        } catch {
+            Write-Log ("  restart selectivo: " + $name + " — ERROR al relanzar, sigue pendiente - " + $_.Exception.Message)
+        }
+    }
+
+    if ($hechos -gt 0) {
+        try {
+            $g = @{ ts = (Get-Date).ToString('o'); count = $hechos } | ConvertTo-Json -Compress
+            $tmp = "$StaleGuardFile.tmp"
+            $g | Out-File -FilePath $tmp -Encoding utf8 -NoNewline
+            Move-Item -Path $tmp -Destination $StaleGuardFile -Force
+        } catch {
+            Write-Log "  restart selectivo: WARN no se pudo escribir el guard de ronda: $_"
+        }
+    }
+}
+
+Invoke-StaleRestarts

--- a/docs/pipeline/watchdog.md
+++ b/docs/pipeline/watchdog.md
@@ -162,6 +162,107 @@ de proceso (SEC-5).
 
 ---
 
+## 4.bis Restart selectivo de servicios con código viejo (#5646)
+
+### El problema
+
+El watchdog hace `git fetch origin main` + `git reset --hard FETCH_HEAD` en **dos**
+caminos: antes de respawnear un Pulpo zombi, y antes del loop de servicios caídos.
+Ese reset actualiza el código **en disco de todos los servicios**, pero el
+watchdog sólo relanza los que estaban caídos. Los que siguen vivos quedan con el
+código anterior en el `require.cache` de Node — *código viejo*.
+
+Eso rompe a los servicios que releen datos de disco en caliente pero validan con
+código cacheado. El caso confirmado (dos incidentes en dos días) es el dashboard:
+
+- `.pipeline/config.yaml` se relee en cada validación (`reload: true`).
+- `.pipeline/lib/config-schema.js` quedó congelado desde el arranque del proceso.
+- Un merge que agrega una sección **a los dos archivos a la vez** deja el disco
+  coherente, pero el proceso valida **config nueva contra schema viejo** →
+  `clave no permitida: '<seccion>'` → fail-closed → la ola pierde todos los estados.
+
+El fail-closed **no es el defecto**: es un control funcionando. El defecto es la
+deriva entre código en memoria y datos en disco.
+
+### El diseño: marcar y ejecutar están separados
+
+- **Los emisores de reset sólo MARCAN.** `watchdog.ps1` (sus dos resets),
+  `restart.js:syncWithMain()` y el endpoint `POST /api/ops/restart-operativo`
+  computan qué componentes quedaron con código viejo y lo anotan en
+  `.pipeline/stale-services.json`.
+- **El watchdog es el ÚNICO EJECUTOR** del restart de servicios stale. Ya corre
+  cada 2 min, ya tiene el contrato de spawn correcto, y es externo al dashboard
+  (que no puede matarse a sí mismo). No existe un relanzador genérico que acepte
+  paths o command lines.
+- **La marca persiste hasta que el restart se confirma.** Si el relanzamiento
+  falla, el componente sigue pendiente el ciclo siguiente.
+
+### Mapeo diff → componente (estático y conservador)
+
+| Path del diff                | Componentes afectados |
+|------------------------------|-----------------------|
+| `.pipeline/lib/**`           | todos                 |
+| `.pipeline/config.yaml`      | todos                 |
+| `.pipeline/<script propio>`  | sólo ese componente   |
+| cualquier otra cosa          | ninguno               |
+
+Nada de grafo de imports: ningún proceso puede inspeccionar el `require.cache`
+de otro, así que cualquier inferencia más fina sería adivinanza. Ante duda
+(SHA previo ausente, corrupto o no-hexadecimal; `git diff` que falla) el helper
+devuelve `unknown: true` con **todos** los componentes — nunca la lista vacía.
+
+### Registro canónico de componentes (9)
+
+Es la **unión** de `restart.js:COMPONENTS` (8, con `dashboard`, sin
+`outbox-drain`) y `dashboard.js:COMPONENTS` (8, con `outbox-drain`, sin
+`dashboard`). Vive en `lib/stale-services.js` y `watchdog.ps1:$ScriptMap` lo
+replica; hay un test que falla si divergen — un componente marcado stale sin
+entrada en el mapa del ejecutor sería un fail-open silencioso.
+
+`restart.js` limpia los pendientes **sólo de lo que `launchAll()` relanzó de
+verdad** (lista derivada del retorno, no de una constante duplicada). Por eso
+`outbox-drain` queda pendiente a propósito: lo relanza el watchdog.
+
+### Cotas y guardas
+
+- `last-selective-restart.json`, ventana **90 s** (molde de `last-restart.json`).
+- Máximo **4 componentes por ronda**; el resto queda pendiente para el ciclo
+  siguiente. Casi todo merge del pipeline toca `.pipeline/lib/**`, así que
+  reiniciar varios servicios varias veces por día es el camino feliz, no un
+  incidente: no hay notificación al operador en ese caso.
+- Un componente que **no está corriendo** no se "reinicia": no tiene código
+  viejo en memoria y este bloque no levanta servicios apagados. Se le baja el
+  pendiente y listo.
+- El endpoint HTTP tiene además una **cota agregada** (4 por minuto, en
+  `lib/ops-restart-handler.js:makeAggregateLimiter`): el rate-limiter existente
+  es por *target*, así que con N componentes N targets distintos pasaban la misma
+  ráfaga. El conjunto se computa **server-side**; una lista de componentes en el
+  body del request se ignora.
+
+### Cómo se lee en el log
+
+```
+restart selectivo: dashboard reiniciado — cambio en .pipeline/lib/config-schema.js (PID 1234)
+restart selectivo: sin componentes afectados por el reset
+```
+
+Causa antes del efecto, nombre del componente **como aparece en el panel**
+(`svc-drive`, no `servicio-drive.js`), **un** path (el que motivó el restart, no
+el diff entero). El caso "no reinicié nada" también deja línea: sin ella, el log
+silencioso es indistinguible de un watchdog que no corrió.
+
+Los paths salen del contenido del commit, así que se sanitizan antes de tocar el
+log: `git diff --name-only -z`, strip de CR/LF y secuencias ANSI, truncado a 120
+chars. Un path con salto de línea embebido no puede falsificar líneas.
+
+### Fuera de alcance (rechazar en review)
+
+Relajar `config-schema.js` a "ignorar claves desconocidas", degradar el
+fail-closed del dashboard, o hot-reloadear el require-cache del schema. El bug es
+la frescura del código; ahí es donde pega el fix.
+
+---
+
 ## 5. Archivos involucrados
 
 | Archivo                              | Rol                                                |
@@ -173,6 +274,10 @@ de proceso (SEC-5).
 | `.pipeline/config.yaml`              | `watchdog.pulpo_liveness_kill_seconds`.            |
 | `.pipeline/test/pulpo-liveness.test.js` | Tests `node --test` de la decisión y el runner. |
 | `lib/commander-deterministic.js`     | Read-side de `/salud` (lee `tick.timestamp`).      |
+| `.pipeline/lib/stale-services.js`    | #5646 — registro canónico, mapeo diff→componente, marcado/limpieza y CLI del restart selectivo. |
+| `.pipeline/stale-services.json`      | #5646 — pendientes de relanzar (estado runtime, no versionado). |
+| `.pipeline/last-selective-restart.json` | #5646 — guard de ronda del restart selectivo (90 s). |
+| `.pipeline/lib/stale-services.test.js` | #5646 — tests `node --test` del helper y de los contratos del watchdog/endpoint. |
 
 ---
 
@@ -190,6 +295,16 @@ tail -f .pipeline/logs/pulpo-liveness.log
 
 # Kills de zombi registrados por el watchdog (ts, pid, lag)
 grep "pulpo-liveness" .pipeline/logs/watchdog.log
+
+# #5646 — ¿Qué servicios quedaron con código viejo y todavía no se relanzaron?
+cat .pipeline/stale-services.json
+node .pipeline/lib/stale-services.js --json
+
+# #5646 — Historia de restarts selectivos (qué componente y qué path lo motivó)
+grep "restart selectivo" .pipeline/logs/watchdog.log
+
+# #5646 — ¿El dashboard cayó en fail-closed por config nueva vs schema viejo?
+grep "CONFIG INVÁLIDA" .pipeline/logs/dashboard.log
 ```
 
 ### Generalización pendiente


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 10 archivos · +1849 -66

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:passed` aplicado por delivery

## Closes

Closes #5646
