### PR TITLE
[BUG] El guard de puerto del restart hace fail-open cuando no puede leer la CommandLine: el ocupante del 3200 sobrevive y bloquea todo arranque

### DIFF
--- a/.pipeline/lib/__tests__/port-guard-5722.test.js
+++ b/.pipeline/lib/__tests__/port-guard-5722.test.js
@@ -1,0 +1,380 @@
+// =============================================================================
+// Tests port-guard — #5722
+//
+// El guard de puerto del restart hacía fail-open cuando no podía leer la
+// CommandLine del ocupante: lo perdonaba, el dashboard no podía hacer listen y
+// el pipeline quedó 20 horas sin despachar agentes.
+//
+// DIFERENCIA CLAVE CON EL TEST ANTERIOR (#4308): aquel reimplementaba el
+// `onHolder` dentro del propio test, así que verificaba una copia y nunca
+// ejecutó la línea que falló en producción. Estos tests importan y ejercitan
+// EL GUARD REAL (`lib/port-guard.js`), inyectándole las dependencias del SO.
+//
+//   CA-1 → holder node.exe con CommandLine ilegible: se clasifica del pipeline
+//          y SE MATA (antes se perdonaba).
+//   CA-2 → puerto que nunca se libera: free=false + alerta con PID, qué se
+//          intentó y comando de destrabe; distinta severidad si es ajeno.
+//   CA-3 → taskkill falla o "tiene éxito" dejando el proceso vivo: escala a
+//          `wmic call terminate`; el veredicto sale de pidAlive, no del exit code.
+//   CA-5 → selección de PIDs de killAll: el opaco corroborado se mata, el opaco
+//          sin corroborar no.
+//   CA-6 → holder genuinamente ajeno: NO se mata (el fix no puede degenerar en
+//          "matar cualquier cosa que toque el 3200").
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const guard = require('../port-guard');
+const pid = require('../../pid-discovery');
+
+// --- Helpers ---------------------------------------------------------------
+
+// Tabla de procesos "vivos" simulada. `commandLine: ''` modela el caso del
+// incidente: node.exe cuya CommandLine es ilegible por permisos.
+function fakeProcessTable(rows) {
+  return (p) => rows.find((r) => r.pid === p) || null;
+}
+
+// Simula el SO: `taskkill` no puede con ciertos PIDs (Acceso denegado), pero
+// `wmic call terminate` sí. Registra los comandos ejecutados.
+function fakeOs({ vivos = [], inmunesATaskkill = [], taskkillSilencioso = false } = {}) {
+  const alive = new Set(vivos);
+  const comandos = [];
+  return {
+    comandos,
+    alive,
+    exec(cmd) {
+      comandos.push(cmd);
+      const m = cmd.match(/(?:\/PID |ProcessId=)(\d+)/);
+      const target = m ? parseInt(m[1], 10) : null;
+      if (cmd.startsWith('taskkill')) {
+        if (inmunesATaskkill.includes(target)) {
+          // taskkillSilencioso modela el caso peor: el comando "sale bien" pero
+          // el proceso sigue vivo. Si no, tira el "Acceso denegado" real.
+          if (taskkillSilencioso) return '';
+          const err = new Error('ERROR: no se puede terminar el proceso');
+          err.stderr = 'ERROR: Acceso denegado.';
+          throw err;
+        }
+        alive.delete(target);
+        return '';
+      }
+      if (cmd.startsWith('wmic')) {
+        alive.delete(target); // verificado efectivo en el incidente
+        return 'ReturnValue = 0;';
+      }
+      return '';
+    },
+    pidAlive: (p) => alive.has(p),
+  };
+}
+
+// Sustituye pid.findPidByPort por una secuencia. waitForPortFree lo resuelve
+// vía module.exports, así que esta sustitución impacta sus llamadas internas.
+function withFindPidByPortSequence(sequence, fn) {
+  const original = pid.findPidByPort;
+  let i = 0;
+  pid.findPidByPort = () => {
+    const v = i < sequence.length ? sequence[i] : sequence[sequence.length - 1];
+    i++;
+    return v;
+  };
+  try {
+    return fn();
+  } finally {
+    pid.findPidByPort = original;
+  }
+}
+
+// Ejecuta el guard REAL contra un SO simulado.
+function runGuard({ port = 3200, tabla = [], os, secuenciaPuerto, attempts = 3 }) {
+  const logs = [];
+  let res;
+  withFindPidByPortSequence(secuenciaPuerto, () => {
+    res = guard.freeDashboardPort(port, {
+      waitForPortFree: pid.waitForPortFree,
+      processForPid: fakeProcessTable(tabla),
+      pidAlive: os.pidAlive,
+      exec: os.exec,
+      log: (m) => logs.push(m),
+      sleep: () => {},           // sin sleeps reales
+      selfPid: 999999,
+      platform: 'win32',
+      attempts,
+      delayMs: 0,
+    });
+  });
+  return { res, logs };
+}
+
+// --- CA-1: el fail-open del incidente ---------------------------------------
+
+test('CA-1 · un holder node.exe con CommandLine ILEGIBLE se trata como del pipeline y SE MATA', () => {
+  // Reproduce el incidente: PID 17168, node.exe, CommandLine vacía por permisos.
+  const os = fakeOs({ vivos: [17168] });
+  const { res, logs } = runGuard({
+    tabla: [{ pid: 17168, name: 'node.exe', commandLine: '', creationDate: '' }],
+    os,
+    // holder la primera vuelta; una vez muerto, el puerto queda libre.
+    secuenciaPuerto: [17168, null],
+  });
+
+  assert.equal(res.free, true, 'el puerto termina libre: el guard convergió');
+  assert.equal(res.holder.kind, guard.HOLDER_OPAQUE_NODE,
+    'se clasifica como node opaco, NO como ajeno');
+  assert.ok(os.comandos.some((c) => c.includes('17168')),
+    'se intentó terminar el PID que retenía el puerto');
+  assert.ok(!os.alive.has(17168), 'el ocupante quedó efectivamente muerto');
+  assert.ok(logs.some((l) => /CommandLine ilegible/.test(l)),
+    'el log explicita por qué se lo trató como del pipeline (auditoría)');
+});
+
+test('CA-1 · classifyHolder distingue "no es node" de "es node con CommandLine ilegible"', () => {
+  const processForPid = fakeProcessTable([
+    { pid: 100, name: 'node.exe', commandLine: '' },                       // opaco
+    { pid: 200, name: 'node.exe', commandLine: 'node C:\\...\\.pipeline\\dashboard.js' },
+    { pid: 300, name: 'node.exe', commandLine: 'node C:\\otra-app\\server.js' },
+  ]);
+  const deps = { processForPid, selfPid: 999999 };
+
+  assert.equal(classify(100), guard.HOLDER_OPAQUE_NODE, 'node.exe opaco ≠ ajeno');
+  assert.equal(classify(200), guard.HOLDER_PIPELINE);
+  assert.equal(classify(300), guard.HOLDER_FOREIGN, 'node.exe legible y ajeno');
+  assert.equal(classify(400), guard.HOLDER_FOREIGN, 'ausente del scan ⇒ no es node');
+  assert.equal(classify(999999), guard.HOLDER_SELF, 'nunca se mata a sí mismo');
+
+  function classify(p) { return guard.classifyHolder(p, deps).kind; }
+});
+
+// --- CA-6: no degenerar en "matar cualquier cosa" ---------------------------
+
+test('CA-6 · un holder genuinamente ajeno (no es node) NO se mata, y el guard no converge', () => {
+  const os = fakeOs({ vivos: [4242] });
+  const { res, logs } = runGuard({
+    tabla: [],                      // 4242 no está en el scan de node ⇒ ajeno
+    os,
+    secuenciaPuerto: [4242],        // nunca se libera
+  });
+
+  assert.equal(res.free, false);
+  assert.equal(res.holder.kind, guard.HOLDER_FOREIGN);
+  assert.deepEqual(os.comandos, [], 'no se ejecutó NINGÚN comando de kill contra un ajeno');
+  assert.ok(os.alive.has(4242), 'el proceso ajeno sigue vivo');
+  assert.ok(logs.some((l) => /no se mata por diseño/.test(l)));
+});
+
+test('CA-6 · un node.exe ajeno con CommandLine legible tampoco se mata', () => {
+  const os = fakeOs({ vivos: [9999] });
+  const { res } = runGuard({
+    tabla: [{ pid: 9999, name: 'node.exe', commandLine: 'node C:\\Program Files\\Foo\\server.js' }],
+    os,
+    secuenciaPuerto: [9999],
+  });
+
+  assert.equal(res.holder.kind, guard.HOLDER_FOREIGN);
+  assert.deepEqual(os.comandos, [], 'CommandLine legible y ajena ⇒ no se toca');
+  assert.ok(os.alive.has(9999));
+});
+
+// --- CA-3: fallback wmic verificado por pidAlive ----------------------------
+
+test('CA-3 · si taskkill da "Acceso denegado", se escala a `wmic call terminate`', () => {
+  const os = fakeOs({ vivos: [17168], inmunesATaskkill: [17168] });
+
+  const res = guard.terminateProcess(17168, {
+    exec: os.exec, pidAlive: os.pidAlive, sleep: () => {}, platform: 'win32',
+  });
+
+  assert.equal(res.killed, true, 'el fallback lo terminó');
+  assert.equal(res.intentos.length, 2, 'primero taskkill, después wmic');
+  assert.equal(res.intentos[0].label, 'taskkill /F /T');
+  assert.match(res.intentos[0].error, /Acceso denegado/,
+    'el error NO se traga: es la señal que justifica el fallback');
+  assert.equal(res.intentos[0].alive, true, 'tras taskkill seguía vivo');
+  assert.equal(res.intentos[1].label, 'wmic call terminate');
+  assert.equal(res.intentos[1].alive, false);
+  assert.ok(os.comandos[1].includes('wmic process where "ProcessId=17168" call terminate'));
+});
+
+test('CA-3 · el veredicto sale de pidAlive, no del exit code: taskkill "exitoso" pero proceso vivo igual escala', () => {
+  // El caso más traicionero: el comando no falla, pero no mata nada. Un guard
+  // que confiara en el exit code daría por terminado un proceso vivo.
+  const os = fakeOs({ vivos: [15636], inmunesATaskkill: [15636], taskkillSilencioso: true });
+
+  const res = guard.terminateProcess(15636, {
+    exec: os.exec, pidAlive: os.pidAlive, sleep: () => {}, platform: 'win32',
+  });
+
+  assert.equal(res.intentos[0].error, null, 'taskkill no reportó error alguno');
+  assert.equal(res.intentos[0].alive, true, 'pero el proceso seguía vivo');
+  assert.equal(res.killed, true);
+  assert.equal(res.intentos[1].label, 'wmic call terminate', 'se escaló igual');
+});
+
+test('CA-3 · si ninguna estrategia termina el proceso, killed=false con el detalle de lo intentado', () => {
+  const os = fakeOs({ vivos: [7777] });
+  os.exec = (cmd) => { os.comandos.push(cmd); throw new Error('Acceso denegado'); };
+
+  const res = guard.terminateProcess(7777, {
+    exec: os.exec, pidAlive: os.pidAlive, sleep: () => {}, platform: 'win32',
+  });
+
+  assert.equal(res.killed, false);
+  assert.deepEqual(res.intentos.map((i) => i.label), ['taskkill /F /T', 'wmic call terminate']);
+  assert.ok(res.intentos.every((i) => i.alive === true));
+});
+
+// --- CA-2: abort ruidoso ----------------------------------------------------
+
+test('CA-2 · si el puerto sigue tomado tras el backoff, el guard NO reporta éxito', () => {
+  const os = fakeOs({ vivos: [17168] });
+  os.exec = (cmd) => { os.comandos.push(cmd); throw new Error('Acceso denegado'); };
+
+  const { res } = runGuard({
+    tabla: [{ pid: 17168, name: 'node.exe', commandLine: '' }],
+    os,
+    secuenciaPuerto: [17168],   // nunca se libera
+    attempts: 3,
+  });
+
+  assert.equal(res.free, false, 'no se avanza a un arranque condenado');
+  assert.equal(res.holder.pid, 17168, 'el holder viaja al caller para la alerta');
+  assert.ok(res.holder.intentos.length >= 2, 'se registró lo que se intentó');
+});
+
+test('CA-2 · la alerta del holder del pipeline es 🚨, dice qué se intentó y trae el comando de destrabe con el PID', () => {
+  const holder = {
+    pid: 17168,
+    kind: guard.HOLDER_OPAQUE_NODE,
+    name: 'node.exe',
+    commandLine: null,
+    intentos: [
+      { label: 'taskkill /F /T', alive: true, error: 'Acceso denegado' },
+      { label: 'wmic call terminate', alive: true, error: null },
+    ],
+  };
+  const alerta = guard.buildAbortAlert({ port: 3200, holder, platform: 'win32', attempts: 6, delayMs: 500 });
+
+  assert.equal(alerta.foreign, false);
+  assert.match(alerta.telegram, /🚨/, 'severidad de incidente: es un bug nuestro');
+  assert.match(alerta.telegram, /puerto 3200/);
+  assert.match(alerta.telegram, /17168/, 'el operador no tiene que buscar el PID en un log');
+  assert.match(alerta.telegram, /CommandLine ilegible/);
+  assert.match(alerta.telegram, /taskkill \/F \/T, wmic call terminate/, 'qué se intentó');
+  assert.match(alerta.telegram, /wmic process where "ProcessId=17168" call terminate/,
+    'comando de destrabe con el PID ya interpolado');
+  assert.ok(!/se avanza igual/.test(alerta.telegram + alerta.logText),
+    'desaparece el copy que mentía tranquilizando');
+});
+
+test('CA-2/CA-6 · la alerta del holder ajeno usa ⚠️ y NO ofrece matarlo', () => {
+  const holder = { pid: 4242, kind: guard.HOLDER_FOREIGN, name: null, commandLine: null };
+  const alerta = guard.buildAbortAlert({ port: 3200, holder, platform: 'win32' });
+
+  assert.equal(alerta.foreign, true);
+  assert.match(alerta.telegram, /⚠️/, 'no es incidente propio: severidad distinta');
+  assert.ok(!/🚨/.test(alerta.telegram), 'los dos desenlaces no comparten severidad');
+  assert.match(alerta.telegram, /ajeno/);
+  assert.ok(!/call terminate/.test(alerta.telegram),
+    'no se le sugiere al operador matar un proceso que no es nuestro');
+});
+
+test('CA-2 · el exit code del abort es propio y distinto del genérico', () => {
+  assert.equal(guard.EXIT_PORT_BLOCKED, 3);
+  assert.notEqual(guard.EXIT_PORT_BLOCKED, 1);
+});
+
+// --- CA-5: fail-open gemelo de killAll() ------------------------------------
+
+test('CA-5 · un node del pipeline con CommandLine ilegible declarado en un .pid NO escapa del kill', () => {
+  const { pids, opacos } = guard.selectPipelinePidsToKill({
+    processes: [
+      { pid: 111, name: 'node.exe', commandLine: '' },                 // pulpo opaco
+      { pid: 222, name: 'node.exe', commandLine: 'node .pipeline/servicio-github.js' },
+    ],
+    scriptNames: ['pulpo.js', 'servicio-github.js'],
+    declaredPids: new Map([[111, 'pulpo.pid']]),
+    selfPid: 999999,
+  });
+
+  assert.ok(pids.includes(111), 'el opaco corroborado por su .pid se mata (antes se perdonaba)');
+  assert.ok(pids.includes(222));
+  assert.deepEqual(opacos, [{ pid: 111, motivo: 'declarado en pulpo.pid' }],
+    'queda registrado por qué se lo mató');
+});
+
+test('CA-5 · un node opaco SIN corroboración no se mata: el fix no puede llevarse puestos procesos ajenos', () => {
+  const { pids, opacos } = guard.selectPipelinePidsToKill({
+    processes: [
+      { pid: 555, name: 'node.exe', commandLine: '' },   // opaco, nadie lo reclama
+      { pid: 666, name: 'node.exe', commandLine: 'node C:\\editor\\lsp-server.js' },
+    ],
+    scriptNames: ['pulpo.js'],
+    declaredPids: new Map(),
+    selfPid: 999999,
+  });
+
+  assert.deepEqual(pids, [], 'sin corroboración de ownership no se toca nada');
+  assert.deepEqual(opacos, []);
+});
+
+test('CA-5 · un node opaco que retiene el puerto del dashboard se mata aunque no tenga .pid', () => {
+  const { pids, opacos } = guard.selectPipelinePidsToKill({
+    processes: [{ pid: 17168, name: 'node.exe', commandLine: '' }],
+    scriptNames: ['dashboard.js'],
+    declaredPids: new Map(),
+    dashOwner: 17168,
+    selfPid: 999999,
+  });
+
+  assert.deepEqual(pids, [17168]);
+  assert.deepEqual(opacos, [{ pid: 17168, motivo: 'retiene el puerto del dashboard' }]);
+});
+
+test('CA-5 · nunca se selecciona el propio PID del restart', () => {
+  const { pids } = guard.selectPipelinePidsToKill({
+    processes: [{ pid: 999999, name: 'node.exe', commandLine: 'node .pipeline/restart.js' }],
+    scriptNames: ['restart.js'],
+    declaredPids: new Map([[999999, 'pulpo.pid']]),
+    dashOwner: 999999,
+    selfPid: 999999,
+  });
+  assert.deepEqual(pids, [], 'el restart no se suicida');
+});
+
+// --- Contrato de pid-discovery ---------------------------------------------
+
+test('el parser de wmic conserva el node.exe con CommandLine vacía y propaga `name`', () => {
+  // Filas como las del incidente: el ocupante del 3200 aparece en el scan pero
+  // su CommandLine viene vacía. Si el parser la descartara —o tirara `name`—,
+  // el guard no tendría con qué distinguirla de un proceso ajeno.
+  const csv = [
+    'Node,CommandLine,CreationDate,Name,ProcessId',
+    'HOST,,20260810023409.000000-180,node.exe,17168',
+    'HOST,node  C:\\\\repo\\\\.pipeline\\\\dashboard.js,20260810023409.000000-180,node.exe,15636',
+    'HOST,C:\\\\Windows\\\\explorer.exe,20260810023409.000000-180,explorer.exe,4242',
+  ].join('\n');
+
+  const filas = pid._parseWmicCsv(csv);
+  const opaco = filas.find((f) => f.pid === 17168);
+
+  assert.ok(opaco, 'la fila con CommandLine vacía NO se descarta');
+  assert.equal(opaco.name, 'node.exe', '`name` se propaga al registro');
+  assert.equal(opaco.commandLine, '', 'CommandLine vacía, no ausente');
+  assert.ok(filas.find((f) => f.pid === 15636), 'la fila legible sigue funcionando');
+  assert.equal(filas.find((f) => f.pid === 4242), undefined, 'lo que no es node.exe no entra al scan');
+
+  // Y el guard, alimentado con esas filas reales, toma la decisión correcta.
+  const processForPid = (p) => filas.find((f) => f.pid === p) || null;
+  assert.equal(guard.classifyHolder(17168, { processForPid, selfPid: 1 }).kind,
+    guard.HOLDER_OPAQUE_NODE);
+  assert.equal(guard.classifyHolder(4242, { processForPid, selfPid: 1 }).kind,
+    guard.HOLDER_FOREIGN, 'explorer.exe no está en el scan ⇒ ajeno');
+});
+
+test('processForPid está exportada y devuelve null para un PID inválido', () => {
+  assert.equal(typeof pid.processForPid, 'function');
+  assert.equal(pid.processForPid(0), null);
+});

--- a/.pipeline/lib/port-guard.js
+++ b/.pipeline/lib/port-guard.js
@@ -1,0 +1,344 @@
+// port-guard.js — Decisión de ownership y terminación de procesos del pipeline (#5722)
+//
+// POR QUÉ EXISTE ESTE MÓDULO
+//
+// El guard vivía inline en `restart.js`, un script de 737 líneas con side
+// effects en el require y sin `module.exports`: no se podía importar. El test
+// que supuestamente lo cubría reimplementaba el `onHolder` dentro del propio
+// test, así que el test verde nunca ejecutó la línea que falló en producción.
+// Por eso el fail-open pasó desapercibido durante el incidente del 2026-08-09,
+// en el que el pipeline quedó 20 horas sin despachar agentes.
+//
+// EL FAIL-OPEN QUE SE CIERRA ACÁ
+//
+// El guard anterior decidía "¿es del pipeline?" leyendo la CommandLine. Cuando
+// esa lectura fallaba (permisos) asumía que NO era del pipeline y lo perdonaba.
+// Es exactamente al revés de lo que conviene: el proceso que ocupa el puerto
+// del dashboard es, por definición, el que impide arrancar. Perdonarlo garantiza
+// que el restart no pueda converger nunca.
+//
+// Todas las dependencias del sistema (scan de procesos, kill, sleep, log) se
+// inyectan: el módulo es puro respecto del SO y los tests ejercitan ESTE código,
+// no una copia.
+
+'use strict';
+
+// --- CLASIFICACIÓN DEL OCUPANTE ---
+
+// El propio restart.js. Nunca se mata a sí mismo.
+const HOLDER_SELF = 'self';
+// node.exe con CommandLine legible que matchea el pipeline. Se mata.
+const HOLDER_PIPELINE = 'pipeline';
+// node.exe presente en el scan pero con CommandLine ILEGIBLE. Se trata como del
+// pipeline cuando retiene el puerto configurado del dashboard (CA-1): imagen
+// `node.exe` + retener justo ese puerto son las dos señales alternativas.
+const HOLDER_OPAQUE_NODE = 'opaque-node';
+// No aparece en el scan de procesos node ⇒ imagen distinta de node.exe, o
+// node.exe con CommandLine legible y ajena. NO se mata (CA-6).
+const HOLDER_FOREIGN = 'foreign';
+
+// Exit code propio para "puerto bloqueado, no reintentar en loop" (CA-2). Un
+// `exit(1)` genérico se confunde con cualquier otro fallo y habilita el
+// crash-loop que este issue quiere evitar.
+const EXIT_PORT_BLOCKED = 3;
+
+// Marcadores de CommandLine que identifican un proceso del pipeline.
+const PIPELINE_CMD_MARKERS = ['dashboard.js', '.pipeline'];
+
+function _isPipelineCmd(cmd) {
+  return PIPELINE_CMD_MARKERS.some((m) => cmd.includes(m));
+}
+
+// classifyHolder(pid, { processForPid, selfPid }) → { pid, kind, name, commandLine }
+//
+// `processForPid` debe respetar el contrato de pid-discovery: `null` significa
+// EXCLUSIVAMENTE "no es un proceso node". Un registro con `commandLine` vacía
+// significa "es node pero su CommandLine es ilegible" — que NO es evidencia de
+// que sea ajeno.
+function classifyHolder(pid, { processForPid, selfPid } = {}) {
+  if (pid === selfPid) {
+    return { pid, kind: HOLDER_SELF, name: null, commandLine: null };
+  }
+
+  const proc = typeof processForPid === 'function' ? processForPid(pid) : null;
+
+  // Ausente del scan de node ⇒ ajeno de verdad. Única rama que perdona.
+  if (!proc) {
+    return { pid, kind: HOLDER_FOREIGN, name: null, commandLine: null };
+  }
+
+  const name = proc.name || null;
+  const cmd = (proc.commandLine || '').trim();
+
+  if (cmd && _isPipelineCmd(cmd)) {
+    return { pid, kind: HOLDER_PIPELINE, name, commandLine: cmd };
+  }
+  if (cmd) {
+    // node.exe con CommandLine legible que no es del pipeline: ajeno legítimo.
+    return { pid, kind: HOLDER_FOREIGN, name, commandLine: cmd };
+  }
+  // CommandLine ilegible. Antes esto caía en "no es del pipeline" y sobrevivía.
+  return { pid, kind: HOLDER_OPAQUE_NODE, name, commandLine: null };
+}
+
+// ¿Este holder se puede matar? Sólo procesos del pipeline (legibles u opacos).
+function isKillable(kind) {
+  return kind === HOLDER_PIPELINE || kind === HOLDER_OPAQUE_NODE;
+}
+
+// --- TERMINACIÓN CON FALLBACK VERIFICADO ---
+
+// Comando manual que se le ofrece al operador cuando todo falló. Es el mismo
+// que se verificó efectivo durante el incidente.
+function manualKillCommand(pid, platform) {
+  return platform === 'win32'
+    ? `wmic process where "ProcessId=${pid}" call terminate`
+    : `kill -9 ${pid}`;
+}
+
+function _strategiesFor(pid, platform) {
+  if (platform === 'win32') {
+    return [
+      { label: 'taskkill /F /T', cmd: `taskkill /PID ${pid} /F /T` },
+      // CA-3: verificado en el incidente — `wmic ... call terminate` termina
+      // procesos donde `taskkill`/`Stop-Process` devuelven "Acceso denegado".
+      { label: 'wmic call terminate', cmd: `wmic process where "ProcessId=${pid}" call terminate` },
+    ];
+  }
+  return [
+    { label: 'kill -TERM', cmd: `kill -TERM ${pid}` },
+    { label: 'kill -KILL', cmd: `kill -KILL ${pid}` },
+  ];
+}
+
+// terminateProcess(pid, deps) → { killed, intentos: [{ label, alive, error }] }
+//
+// CA-3. Dos reglas que el código anterior violaba:
+//
+//   1. NO se traga el error. Antes era `stdio:'ignore'` + `catch {}`: el
+//      "Acceso denegado" desaparecía y no había evento del cual colgar el
+//      fallback.
+//   2. NO se confía en el exit code. `taskkill` puede reportar éxito y dejar el
+//      proceso vivo. La comprobación fidedigna es `pidAlive(pid)` DESPUÉS del
+//      intento — por eso se escala aunque el comando "haya salido bien".
+function terminateProcess(pid, deps = {}) {
+  const {
+    exec,
+    pidAlive,
+    sleep = () => {},
+    platform = process.platform,
+    settleMs = 200,
+  } = deps;
+
+  const intentos = [];
+  if (!pid) return { killed: false, intentos };
+
+  for (const s of _strategiesFor(pid, platform)) {
+    let error = null;
+    try {
+      exec(s.cmd);
+    } catch (e) {
+      // Se REGISTRA en vez de tragarse: es la señal que dispara el fallback.
+      error = (e && (e.stderr ? String(e.stderr) : e.message)) || String(e);
+      error = error.trim().split('\n')[0].slice(0, 200);
+    }
+    // Dar un instante al SO para reflejar la terminación antes de verificar.
+    sleep(settleMs);
+    const alive = pidAlive(pid);
+    intentos.push({ label: s.label, alive, error });
+    if (!alive) return { killed: true, intentos };
+  }
+
+  return { killed: false, intentos };
+}
+
+// --- GUARD DEL PUERTO DEL DASHBOARD ---
+
+// freeDashboardPort(port, deps) → { free, port, holder }
+//
+// `holder` es la última clasificación observada (con `intentos` de terminación
+// si se intentó matarlo). Cuando `free` es false, es lo que el caller necesita
+// para construir la alerta de CA-2.
+function freeDashboardPort(port, deps = {}) {
+  const {
+    waitForPortFree,
+    processForPid,
+    pidAlive,
+    exec,
+    log = () => {},
+    sleep = () => {},
+    selfPid = process.pid,
+    platform = process.platform,
+    attempts = 6,
+    delayMs = 500,
+  } = deps;
+
+  let holder = null;
+
+  const onHolder = (pid) => {
+    const h = classifyHolder(pid, { processForPid, selfPid });
+    holder = h;
+
+    // Auditoría ANTES de matar: PID + imagen + CommandLine + veredicto.
+    log(`  [puerto ${port}] holder PID ${pid} img=${h.name || '<desconocida>'} `
+      + `cmd=${h.commandLine || '<ilegible>'} → ${h.kind}`);
+
+    if (h.kind === HOLDER_SELF) return;
+
+    if (h.kind === HOLDER_FOREIGN) {
+      // CA-6: un ocupante genuinamente ajeno sigue sin matarse. La salida
+      // correcta es el abort ruidoso del caller, que escala a humano.
+      log(`  [puerto ${port}] PID ${pid} es un proceso ajeno — no se mata por diseño`);
+      return;
+    }
+
+    if (h.kind === HOLDER_OPAQUE_NODE) {
+      log(`  [puerto ${port}] PID ${pid} es node con CommandLine ilegible y retiene `
+        + 'el puerto del dashboard — se trata como del pipeline (#5722)');
+    }
+
+    const res = terminateProcess(pid, { exec, pidAlive, sleep, platform });
+    h.intentos = res.intentos;
+    if (res.killed) {
+      const via = res.intentos[res.intentos.length - 1].label;
+      log(`  [puerto ${port}] PID ${pid} terminado vía ${via}`);
+    } else {
+      const detalle = res.intentos.map((i) => `${i.label}${i.error ? ` (${i.error})` : ''}`).join(' → ');
+      log(`  [puerto ${port}] PID ${pid} NO se pudo terminar: ${detalle}`);
+    }
+  };
+
+  const free = waitForPortFree(port, { attempts, delayMs, onHolder });
+  return { free, port, holder };
+}
+
+// --- COPY DEL ABORT (CA-2) ---
+//
+// El mensaje lo lee un humano con el pipeline caído, posiblemente de
+// madrugada. Tiene que responder tres preguntas sin abrir un log: qué pasó (en
+// consecuencia, no en implementación), qué se intentó, y qué hacer.
+
+function _intentosResumen(holder, platform) {
+  const intentos = (holder && holder.intentos) || [];
+  if (!intentos.length) return 'no se intentó terminarlo (proceso ajeno)';
+  return intentos.map((i) => i.label).join(', ');
+}
+
+// buildAbortAlert({ port, holder, platform, attempts, delayMs })
+//   → { telegram, logText, foreign }
+function buildAbortAlert({ port, holder, platform = process.platform, attempts = 6, delayMs = 500 } = {}) {
+  const pid = holder && holder.pid;
+  const kind = (holder && holder.kind) || HOLDER_FOREIGN;
+  const foreign = kind === HOLDER_FOREIGN;
+  const img = (holder && holder.name) || 'desconocida';
+  const backoff = `backoff ${attempts}×${delayMs}ms`;
+
+  // Los dos desenlaces NO comparten texto: "bug nuestro, urgente" y "proceso
+  // ajeno, correcto por diseño pero necesita humano" son situaciones distintas
+  // y el operador tiene que separarlas de un vistazo.
+  let titulo;
+  let detalle;
+  if (foreign) {
+    titulo = `⚠️ *Pipeline restart ABORTADO — puerto ${port} ocupado por un proceso ajeno*`;
+    detalle = pid
+      ? `Holder PID ${pid} (${img}): no es del pipeline, no se mata por diseño.`
+      : 'No se pudo identificar al ocupante del puerto.';
+  } else {
+    const cmdTxt = kind === HOLDER_OPAQUE_NODE ? 'CommandLine ilegible' : 'proceso del pipeline';
+    titulo = `🚨 *Pipeline restart ABORTADO — puerto ${port} ocupado*`;
+    detalle = `Holder PID ${pid} (${img}, ${cmdTxt}), del pipeline pero no se pudo terminar.`;
+  }
+
+  const cuerpo = [
+    titulo,
+    detalle,
+    `Se agotaron: ${backoff}, ${_intentosResumen(holder, platform)}.`,
+    'El arranque se detuvo: seguir habría dejado el dashboard sin escuchar.',
+  ];
+
+  if (pid && !foreign) {
+    cuerpo.push('', 'Para destrabar a mano:', `\`${manualKillCommand(pid, platform)}\``);
+  } else if (pid) {
+    cuerpo.push('', `Revisar quién retiene el puerto ${port} y liberarlo antes de reintentar el restart.`);
+  }
+
+  const telegram = cuerpo.join('\n');
+
+  const logText = pid
+    ? `  [puerto ${port}] ABORT — holder PID ${pid} (${img}, ${kind}) sigue tomando el puerto `
+      + `tras ${backoff}. No se relanza: el arranque estaría condenado. `
+      + (foreign ? 'Ocupante ajeno: requiere intervención humana.'
+                 : `Destrabe manual: ${manualKillCommand(pid, platform)}`)
+    : `  [puerto ${port}] ABORT — el puerto sigue tomado tras ${backoff} y no se pudo `
+      + 'identificar al ocupante. No se relanza.';
+
+  return { telegram, logText, foreign };
+}
+
+// --- SELECCIÓN DE PIDs PARA EL KILL PRINCIPAL (CA-5) ---
+//
+// Fail-open gemelo, mismo origen: `killAll()` hacía `if (!p.commandLine)
+// continue`, así que un node.exe del pipeline con CommandLine ilegible escapaba
+// del kill principal en silencio. Quedaba tapado sólo para el holder del puerto
+// del dashboard; pulpo y servicios sobrevivían — el mismo modo de falla de #5704.
+//
+// El cierre es ACOTADO a propósito: matar todo node.exe opaco sería destructivo
+// (se llevaría puestos editores, MCP servers y agentes). Un proceso opaco se
+// mata sólo si hay corroboración de ownership del propio pipeline:
+//   - su PID está declarado en un archivo `.pid` que escribió un componente, o
+//   - retiene el puerto del dashboard.
+//
+// selectPipelinePidsToKill({...}) → { pids: number[], opacos: [{ pid, motivo }] }
+function selectPipelinePidsToKill({
+  processes = [],
+  scriptNames = [],
+  declaredPids = new Map(),
+  dashOwner = null,
+  selfPid = process.pid,
+} = {}) {
+  const pids = new Set();
+  const opacos = [];
+  const names = [...scriptNames];
+
+  for (const p of processes) {
+    if (!p || !p.pid || p.pid === selfPid) continue;
+    const cmd = (p.commandLine || '').trim();
+
+    if (!cmd) {
+      // CommandLine ilegible: se decide por corroboración, no perdonando.
+      let motivo = null;
+      if (declaredPids.has(p.pid)) motivo = `declarado en ${declaredPids.get(p.pid)}`;
+      else if (dashOwner && p.pid === dashOwner) motivo = 'retiene el puerto del dashboard';
+      if (motivo) {
+        pids.add(p.pid);
+        opacos.push({ pid: p.pid, motivo });
+      }
+      continue;
+    }
+
+    const matchByPath = cmd.includes('.pipeline');
+    const matchByScript = names.some((s) => cmd.includes(s));
+    if (matchByPath || matchByScript) pids.add(p.pid);
+  }
+
+  // El ocupante del puerto del dashboard entra aunque no haya matcheado arriba
+  // (caso borde: respawn del watchdog entre el scan y el kill).
+  if (dashOwner && dashOwner !== selfPid) pids.add(dashOwner);
+
+  return { pids: [...pids], opacos };
+}
+
+module.exports = {
+  HOLDER_SELF,
+  HOLDER_PIPELINE,
+  HOLDER_OPAQUE_NODE,
+  HOLDER_FOREIGN,
+  EXIT_PORT_BLOCKED,
+  classifyHolder,
+  isKillable,
+  terminateProcess,
+  freeDashboardPort,
+  buildAbortAlert,
+  manualKillCommand,
+  selectPipelinePidsToKill,
+};

--- a/.pipeline/pid-discovery.js
+++ b/.pipeline/pid-discovery.js
@@ -10,7 +10,10 @@
 //   findPidByScript(scriptFile) → idem
 //   findPidByPort(port)       → pid | null  (socket LISTENING)
 //   pidAlive(pid)             → boolean
-//   scanNodeProcesses()       → [{ pid, commandLine, creationDate }]  (cacheado 2s)
+//   processForPid(pid)        → { pid, name, commandLine, creationDate } | null
+//                               (null ⇒ NO es un proceso node; presente con
+//                                commandLine '' ⇒ node con CommandLine ilegible)
+//   scanNodeProcesses()       → [{ pid, name, commandLine, creationDate }]  (cacheado 2s)
 //   invalidateCache()         → fuerza refresh del próximo scan
 //   SCRIPT_MAP                → mapa nombre → scriptfile
 
@@ -56,7 +59,10 @@ function _parseWmicCsv(stdout) {
     if (name.toLowerCase() !== 'node.exe') continue;
     const creationDate = parts[parts.length - 3] || '';
     const commandLine = parts.slice(1, -3).join(',');
-    processes.push({ pid, commandLine, creationDate });
+    // #5722 — `name` se propaga al registro. Antes se usaba sólo para filtrar y
+    // se tiraba: sin él, un `node.exe` cuya CommandLine vino vacía por permisos
+    // era indistinguible de un proceso ajeno, y el guard del puerto lo perdonaba.
+    processes.push({ pid, name, commandLine, creationDate });
   }
   return processes;
 }
@@ -69,7 +75,10 @@ function _parsePsOutput(stdout) {
     if (!m) continue;
     const cmd = m[3];
     if (!cmd.includes('node')) continue;
-    processes.push({ pid: parseInt(m[1], 10), commandLine: cmd, creationDate: m[2] });
+    // #5722 — mismo contrato que la rama Windows: el registro expone `name`
+    // (imagen del ejecutable) además de la CommandLine completa.
+    const name = (cmd.trim().split(/\s+/)[0] || '').split(/[\\/]/).pop();
+    processes.push({ pid: parseInt(m[1], 10), name, commandLine: cmd, creationDate: m[2] });
   }
   return processes;
 }
@@ -197,6 +206,27 @@ function commandLineForPid(pid) {
   return p ? p.commandLine : null;
 }
 
+// processForPid(pid) → { pid, name, commandLine, creationDate } | null   (#5722)
+//
+// Existe porque `commandLineForPid` devuelve `null` en DOS situaciones que son
+// opuestas para decidir ownership, y las vuelve indistinguibles:
+//
+//   a) el PID no es un proceso node        ⇒ ajeno de verdad, no tocarlo
+//   b) el PID es node.exe pero su CommandLine vino vacía (ilegible por
+//      permisos)                            ⇒ NO es evidencia de que sea ajeno
+//
+// Confundir (b) con (a) es el fail-open que dejó el pipeline 20 h sin despachar:
+// el ocupante del puerto del dashboard era `node.exe` opaco y se lo perdonaba.
+//
+// Contrato: `null` significa EXCLUSIVAMENTE (a) — el PID no aparece en el scan
+// de procesos node. Si aparece, el registro se devuelve entero y el caller
+// decide mirando `name` y `commandLine` (que puede ser `''` en el caso b).
+// No ejecuta comandos nuevos: sólo lee el resultado del scan ya cacheado.
+function processForPid(pid) {
+  if (!pid) return null;
+  return scanNodeProcesses().find(x => x.pid === pid) || null;
+}
+
 // waitForPortFree(port, { attempts, delayMs, onHolder }) → boolean
 // Espera de forma ACOTADA a que `port` quede libre (sin proceso LISTENING).
 // En cada vuelta: invalida cache, consulta findPidByPort(port); si está libre
@@ -231,4 +261,9 @@ module.exports = {
   invalidateCache,
   waitForPortFree,
   commandLineForPid,
+  processForPid,
+  // Expuestos para tests (#5722): el parser es donde nace la señal `name` y
+  // donde se decide conservar la fila de un node.exe con CommandLine ilegible.
+  _parseWmicCsv,
+  _parsePsOutput,
 };

--- a/.pipeline/restart.js
+++ b/.pipeline/restart.js
@@ -21,9 +21,12 @@ const {
   pidAlive,
   invalidateCache,
   waitForPortFree,
-  commandLineForPid,
+  processForPid,
   SCRIPT_MAP,
 } = require('./pid-discovery');
+// #5722 — la decisión de ownership y la terminación con fallback verificado
+// viven en un módulo importable para que los tests ejerciten el guard REAL.
+const portGuard = require('./lib/port-guard');
 const { clearAllMarkers } = require('./lib/ready-marker');
 const { annotateAndMoveOrphans } = require('./lib/restart-orphan-annotator');
 // #4664 (Ola 9.1 · cutover de wiring) — el arranque del motor (pulpo/dashboard)
@@ -244,6 +247,33 @@ function reexecIfSelfChanged() {
 
 // --- KILL: drástico — matar todo lo que sea del pipeline ---
 
+// #5722 — PIDs que los propios componentes declararon al arrancar. Es la
+// corroboración de ownership que permite matar un node.exe opaco sin caer en
+// "matar cualquier node.exe", que se llevaría puestos editores, MCP servers y
+// agentes. Devuelve Map<pid, archivo> (el archivo va al log, para auditoría).
+function readDeclaredPipelinePids() {
+  const map = new Map();
+  for (const comp of COMPONENTS) {
+    try {
+      const raw = fs.readFileSync(path.join(PIPELINE, comp.pid), 'utf8').trim();
+      const pid = parseInt(raw, 10);
+      if (pid && !Number.isNaN(pid) && pid !== process.pid) map.set(pid, comp.pid);
+    } catch {}
+  }
+  return map;
+}
+
+// #5722 (CA-3) — terminación con fallback verificado, compartida por killAll()
+// y el guard del puerto.
+function killPipelineProcess(pid) {
+  return portGuard.terminateProcess(pid, {
+    pidAlive,
+    sleep,
+    platform: process.platform,
+    exec: (cmd) => execSync(cmd, { timeout: 8000, stdio: 'pipe', windowsHide: true }),
+  });
+}
+
 function killAll() {
   log('=== STOP ===');
 
@@ -258,31 +288,42 @@ function killAll() {
   // aparece en la CommandLine. Por eso matcheamos por CUALQUIERA de: path
   // `.pipeline` en la CommandLine, o nombre de script conocido del pipeline.
   const scriptNames = new Set(Object.values(SCRIPT_MAP));
-  for (const p of scanNodeProcesses()) {
-    if (!p.commandLine) continue;
-    if (p.pid === process.pid) continue;
-    const cmd = p.commandLine;
-    const matchByPath = cmd.includes('.pipeline');
-    const matchByScript = [...scriptNames].some(s => cmd.includes(s));
-    if (!matchByPath && !matchByScript) continue;
-    pidsToKill.add(p.pid);
-  }
 
   // Además, mata lo que escuche en el puerto del dashboard aunque su
   // commandLine no coincida (casos borde: proceso respawneado por watchdog
   // entre el scan y el kill).
   const dashPort = parseInt(process.env.DASHBOARD_PORT || '3200', 10);
   const dashOwner = findPidByPort(dashPort);
-  if (dashOwner && dashOwner !== process.pid) pidsToKill.add(dashOwner);
+
+  // #5722 (CA-5) — Se lee ANTES de borrar los .pid de más abajo. Los componentes
+  // escriben su propio PID al arrancar, así que estos archivos corroboran
+  // ownership de un node.exe cuya CommandLine es ilegible. Sin esta señal, el
+  // `if (!p.commandLine) continue` anterior dejaba escapar del kill principal a
+  // pulpo/servicios opacos, en silencio — el mismo modo de falla de #5704.
+  const declaredPids = readDeclaredPipelinePids();
+
+  const seleccion = portGuard.selectPipelinePidsToKill({
+    processes: scanNodeProcesses(),
+    scriptNames: [...scriptNames],
+    declaredPids,
+    dashOwner,
+    selfPid: process.pid,
+  });
+  for (const pid of seleccion.pids) pidsToKill.add(pid);
+  for (const o of seleccion.opacos) {
+    log(`  PID ${o.pid}: node con CommandLine ilegible, ${o.motivo} — se mata igual (#5722)`);
+  }
 
   if (pidsToKill.size === 0) {
     log('  No hay procesos del pipeline corriendo');
   } else {
     for (const pid of pidsToKill) {
-      try {
-        execSync(`taskkill /PID ${pid} /F /T`, { timeout: 5000, stdio: 'ignore' });
-        log(`  Killed PID ${pid}`);
-      } catch {}
+      // #5722 (CA-3) — con fallback a `wmic call terminate` y verificación por
+      // pidAlive: `taskkill` puede reportar éxito (o "Acceso denegado" tragado)
+      // y dejar el proceso vivo.
+      const res = killPipelineProcess(pid);
+      if (res.killed) log(`  Killed PID ${pid} (${res.intentos[res.intentos.length - 1].label})`);
+      else log(`  PID ${pid} NO se pudo terminar: ${res.intentos.map(i => i.label).join(' → ')}`);
     }
     log(`  ${pidsToKill.size} proceso(s) eliminado(s)`);
   }
@@ -362,16 +403,22 @@ function killAll() {
 
   // Verificar que no quede nada (discovery fresco, no cache).
   invalidateCache();
-  const survivors = scanNodeProcesses().filter(p =>
-    p.commandLine && p.commandLine.includes('.pipeline') &&
-    !p.commandLine.includes('restart.js') &&
-    p.pid !== process.pid
-  );
+  // #5722 — misma regla que arriba: un superviviente con CommandLine ilegible
+  // no se perdona si el pipeline declaró ese PID. `declaredPids` se leyó al
+  // inicio de killAll(), antes de borrar los .pid.
+  const survivors = scanNodeProcesses().filter(p => {
+    if (!p.pid || p.pid === process.pid) return false;
+    const cmd = (p.commandLine || '').trim();
+    if (!cmd) return declaredPids.has(p.pid);
+    return cmd.includes('.pipeline') && !cmd.includes('restart.js');
+  });
   if (survivors.length > 0) {
     log('  Quedan procesos vivos — segundo intento:');
     for (const p of survivors) {
-      try { execSync(`taskkill /PID ${p.pid} /F /T`, { timeout: 5000, stdio: 'ignore' }); } catch {}
-      log(`    Force killed PID ${p.pid}`);
+      const res = killPipelineProcess(p.pid);
+      log(res.killed
+        ? `    Force killed PID ${p.pid} (${res.intentos[res.intentos.length - 1].label})`
+        : `    PID ${p.pid} SIGUE VIVO tras ${res.intentos.map(i => i.label).join(' → ')}`);
     }
   }
 }
@@ -384,36 +431,56 @@ function killAll() {
 // dashboard nuevo choca con EADDRINUSE, el smoke test falla 2× y se dispara un
 // rollback espurio a `pipeline-stable`.
 //
-// onHolder (SEC-2 / CA-2): antes de re-matar valida ownership por commandLine
-// (solo procesos del pipeline: `dashboard.js` o `.pipeline`), LOGUEA PID +
-// commandLine ANTES de matar (auditoría), y mata SOLO por PID numérico vía
-// taskkill (SEC-1 / CA-6: nada de `$(...)`, `fkill <puerto>` ni interpolar
-// salida de netstat). Un proceso ajeno que casualmente tome el puerto NO se
-// mata. Si el backoff se agota, degradamos al comportamiento actual (avanzar +
-// retry EADDRINUSE del dashboard) — nunca peor que hoy (CA-3).
-function freeDashboardPortOrAdvance() {
+// onHolder (SEC-2): antes de re-matar valida ownership, LOGUEA PID + imagen +
+// commandLine ANTES de matar (auditoría), y mata SOLO por PID numérico (SEC-1 /
+// CA-6: nada de `$(...)`, `fkill <puerto>` ni interpolar salida de netstat). Un
+// proceso ajeno que casualmente tome el puerto NO se mata.
+//
+// #5722 — La decisión de ownership se delega a `lib/port-guard`, que distingue
+// "no es un proceso node" (ajeno, se perdona) de "es node.exe con CommandLine
+// ilegible" (se trata como del pipeline). Y si el backoff se agota, esto ya NO
+// degrada a "avanzar igual": aborta ruidoso. Avanzar hacia un arranque que se
+// sabe condenado es lo que costó 20 h de pipeline caído — la supuesta "red
+// secundaria" del retry EADDRINUSE nunca existió, porque el puerto seguía tomado.
+const PORT_GUARD_ATTEMPTS = 6;
+const PORT_GUARD_DELAY_MS = 500;
+
+function freeDashboardPortOrAbort() {
   const dashPort = parseInt(process.env.DASHBOARD_PORT || '3200', 10);
-  const onHolder = (pid) => {
-    if (pid === process.pid) return;
-    const cmd = commandLineForPid(pid);
-    const owned = !!cmd && (cmd.includes('dashboard.js') || cmd.includes('.pipeline'));
-    log(`  [puerto ${dashPort}] holder PID ${pid} cmd=${cmd || '<desconocido>'}`); // auditoría ANTES de matar
-    if (!owned) {
-      log(`  [puerto ${dashPort}] PID ${pid} no es del pipeline — no se mata`);
-      return;
-    }
-    try {
-      execSync(`taskkill /PID ${pid} /F /T`, { timeout: 5000, stdio: 'ignore' });
-      log(`  [puerto ${dashPort}] Re-killed PID ${pid}`);
-    } catch {}
-  };
-  const free = waitForPortFree(dashPort, { attempts: 6, delayMs: 500, onHolder });
-  if (free) {
+  const res = portGuard.freeDashboardPort(dashPort, {
+    waitForPortFree,
+    processForPid,
+    pidAlive,
+    selfPid: process.pid,
+    platform: process.platform,
+    attempts: PORT_GUARD_ATTEMPTS,
+    delayMs: PORT_GUARD_DELAY_MS,
+    log,
+    sleep,
+    // stdio 'pipe' (no 'ignore'): necesitamos el stderr del "Acceso denegado"
+    // para poder reportarlo. El fallback igual se decide con pidAlive.
+    exec: (cmd) => execSync(cmd, { timeout: 8000, stdio: 'pipe', windowsHide: true }),
+  });
+
+  if (res.free) {
     log(`  [puerto ${dashPort}] libre antes de launchAll()`);
-  } else {
-    log(`  [puerto ${dashPort}] sigue tomado tras backoff — se avanza igual (retry EADDRINUSE del dashboard como red secundaria)`);
+    return true;
   }
-  return free;
+
+  // CA-2 — fallar explícito y ruidoso. NO se encadena a rollback: volver a una
+  // revisión anterior deja el mismo holder vivo y reproduce el loop del incidente.
+  const alerta = portGuard.buildAbortAlert({
+    port: dashPort,
+    holder: res.holder,
+    platform: process.platform,
+    attempts: PORT_GUARD_ATTEMPTS,
+    delayMs: PORT_GUARD_DELAY_MS,
+  });
+  log(alerta.logText);
+  enqueueTelegramAlert(alerta.telegram);
+  // Exit code propio: permite que watchdog/supervisor distingan "puerto
+  // bloqueado, no reintentar en loop" de "falló otra cosa".
+  process.exit(portGuard.EXIT_PORT_BLOCKED);
 }
 
 // --- LAUNCH ---
@@ -690,7 +757,7 @@ switch (action) {
     } else {
       try { fs.unlinkSync(path.join(PIPELINE, '.paused')); } catch {}
     }
-    freeDashboardPortOrAdvance(); // #4308 — puerto 3200 libre antes de relanzar
+    freeDashboardPortOrAbort(); // #4308/#5722 — puerto 3200 libre, o abortar ruidoso
     // #5646 — Estos componentes acaban de arrancar leyendo el código de disco:
     // se bajan del registro de "código viejo" para que el watchdog no los
     // reinicie de nuevo un minuto después. Lo que restart.js NO lanza (p. ej.
@@ -713,7 +780,10 @@ switch (action) {
       if (!smoke.ok && !flagNoRollback) {
         log('Primer smoke test FAIL — reintento tras limpieza de stragglers');
         killAll();
-        freeDashboardPortOrAdvance(); // #4308 — puerto 3200 libre antes de relanzar
+        // #5722 — si acá el puerto sigue tomado, esto aborta ruidoso y NO cae al
+        // rollback de más abajo: el rollback no libera un puerto ocupado, sólo
+        // reproduce el loop del incidente.
+        freeDashboardPortOrAbort(); // #4308/#5722
         limpiarPendientesRelanzados(launchAll());
         sleep(5000);
         smoke = runSmokeTest();


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 4 archivos · +883 -54

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:skipped` aplicado por delivery

## Closes

Closes #5722
