### PR TITLE
Persistir el umbral de liveness del Pulpo en 270s para que el fix del bucle de muerte sobreviva al respawn

### DIFF
--- a/.pipeline/config.yaml
+++ b/.pipeline/config.yaml
@@ -410,10 +410,17 @@ watchdog:
   # umbral con el proceso vivo, lo declara zombi (loop colgado) y lo reinicia.
   # DESACOPLADO del display: /salud usa "esperado < 30s" sólo para MOSTRAR salud;
   # 30s == 1 poll_interval del Pulpo, un ciclo lento lo rozaría sin ser zombi.
-  # 90s = max(90, 3×poll_interval) evita falsos positivos (CA-4) y restart-storms
-  # (SEC-3). Override por env PULPO_LIVENESS_KILL_SECONDS (entero positivo;
+  # 270s (#5820) — subido desde 180s tras el incidente del 2026-08-11: el
+  # watchdog mató y relanzó al Pulpo 77 veces en 3h porque un ciclo real con la
+  # ola cargada supera holgadamente los 180s (pico de edad de heartbeat medido:
+  # 245s). No eran cuelgues: cada kill mataba un proceso sano y se llevaba
+  # puesta la cola de comandos de Telegram. Con 270s: 0 kills en 51 ciclos.
+  # OJO — el margen resultante es de ~25s (9%): un ciclo más pesado vuelve a
+  # disparar el falso positivo. Dimensionamiento contra la duración real de
+  # ciclo + alerta de margen: #5821.
+  # Override por env PULPO_LIVENESS_KILL_SECONDS (entero positivo;
   # inválido → default, NUNCA "nunca stale" — SEC-2).
-  pulpo_liveness_kill_seconds: 180
+  pulpo_liveness_kill_seconds: 270
 
 # =============================================================================
 # Wave-stall watchdog (#4708) — dead-man's switch de la ola


### PR DESCRIPTION
## Qué pasó

El 2026-08-11, entre las ~11:00 y las ~14:00, el watchdog de liveness mató y relanzó al Pulpo **77 veces** — una cada ~6 minutos. Ninguno era un cuelgue real: el umbral configurado (`180s`) era menor que la duración real de un ciclo del Pulpo con la ola cargada, así que el heartbeat se veía viejo y el watchdog declaraba zombi a un proceso sano.

Cada reinicio se llevaba puesta la cola de comandos de Telegram. El síntoma que llegó al operador no fue "el watchdog está matando al Pulpo", sino "el Commander no responde" — ~4 horas sin respuesta.

El valor se subió a `270s` en caliente y el bucle paró: **0 kills en 51 ciclos**. Pero el cambio quedó sin commitear, y el repo principal hace `reset --hard` en cada respawn: el archivo volvía a `180` y el bucle reaparecía sin aviso.

## Qué cambia

- `.pipeline/config.yaml` → `pulpo_liveness_kill_seconds: 270`.
- Comentario del bloque `watchdog:` reescrito: justificaba `90s = max(90, 3×poll_interval)`, un valor ya descartado dos veces. Ahora documenta el valor vigente, el incidente que lo motivó y —explícitamente— que el margen resultante es de solo ~25 s (9%).

Un solo archivo, una sola clave. Sin cambios de lógica.

## Evidencia

| Dato | Valor |
|---|---|
| Kills el 2026-08-11 con umbral 180s | 77 |
| Kills posteriores con umbral 270s | **0** en 51 ciclos |
| Pico de edad de heartbeat observado | 244993 ms (245 s) |
| Margen contra el techo de 270 s | ~25 s (**9%**) |

Fuente: `.pipeline/logs/pulpo-liveness.log`.

## Lo que este PR NO resuelve

**El margen de 9% no es un colchón, es un empate.** Una ola más grande o un build concurrente vuelven a empujar el ciclo sobre los 270 s y el bucle se repite igual. El valor sigue siendo un número elegido reactivamente (90 → 180 → 270, cada salto después de un incidente) y nada observa que el margen se está agotando.

El dimensionamiento contra la duración real de ciclo, la alerta temprana de margen y el freno anti-racha van por **#5821**.

Tampoco entran acá, y quedan en **#5820**: alinear el test `config-failclosed-runners-5172.test.js` (fija `180` como "config sana") y evaluar `DEFAULT_KILL_SECONDS = 90` en `.pipeline/lib/pulpo-liveness.js:34` — que es la mitad del valor que ya demostró ser insuficiente, y es a lo que degrada el sistema si el bloque de config se pierde.

Este PR se acota a **persistir la mitigación que ya está probada en producción**, para cortar la ventana de riesgo del próximo respawn.

Refs #5820

## QA

`qa:skipped` — cambio de configuración de infraestructura del pipeline, sin superficie de producto de usuario: no toca API, UI ni flujos de la app. La validación funcional es el propio log de liveness, adjunto arriba (0 kills en 51 ciclos con el valor nuevo ya activo en el ambiente).

🤖 Generated with [Claude Code](https://claude.com/claude-code)