### PR TITLE
El fix del bucle de muerte del Pulpo vive solo en memoria: persistir pulpo_liveness_kill_seconds en main

### DIFF
--- a/.pipeline/config.yaml
+++ b/.pipeline/config.yaml
@@ -410,10 +410,27 @@ watchdog:
   # umbral con el proceso vivo, lo declara zombi (loop colgado) y lo reinicia.
   # DESACOPLADO del display: /salud usa "esperado < 30s" sólo para MOSTRAR salud;
   # 30s == 1 poll_interval del Pulpo, un ciclo lento lo rozaría sin ser zombi.
-  # 90s = max(90, 3×poll_interval) evita falsos positivos (CA-4) y restart-storms
-  # (SEC-3). Override por env PULPO_LIVENESS_KILL_SECONDS (entero positivo;
-  # inválido → default, NUNCA "nunca stale" — SEC-2).
-  pulpo_liveness_kill_seconds: 180
+  #
+  # #5820 — El umbral NO se deriva de poll_interval: se dimensiona contra la
+  # duración REAL de un ciclo del Pulpo, que con la ola actual está muy por
+  # encima del poll. Incidente 2026-08-11 (~11:00–14:00): con 180s el watchdog
+  # mató y relanzó al Pulpo 77 veces (una cada ~6 min) sin que hubiera un cuelgue
+  # real — el ciclo simplemente tardaba más que el umbral. Cada reinicio se
+  # llevaba puesta la cola de comandos de Telegram, así que el Commander quedó
+  # sin responder ~4 horas.
+  #   Medición del log .pipeline/logs/pulpo-liveness.log tras subir a 270:
+  #     · killSeconds=180 → 77 líneas decision=kill el 2026-08-11
+  #     · killSeconds=270 → 0 líneas decision=kill en 68 ciclos
+  #     · máx. hbAgeMs observado bajo el umbral nuevo: 244993 ms (245 s)
+  # El margen contra el techo de 270 s es de ~25 s (9%): este valor PERSISTE la
+  # mitigación medida, pero el dimensionamiento del colchón se rediseña aparte
+  # (#5821). Si volvés a ver kills sin cuelgue real, es ese issue, no este valor.
+  #
+  # Override por env PULPO_LIVENESS_KILL_SECONDS (entero positivo; inválido →
+  # default del módulo, NUNCA "nunca stale" — SEC-2). El default de
+  # lib/pulpo-liveness.js se mantiene alineado con este valor para que perder el
+  # bloque `watchdog:` no degrade a un umbral MÁS agresivo que el vigente.
+  pulpo_liveness_kill_seconds: 270
 
 # =============================================================================
 # Wave-stall watchdog (#4708) — dead-man's switch de la ola

--- a/.pipeline/lib/__tests__/config-failclosed-runners-5172.test.js
+++ b/.pipeline/lib/__tests__/config-failclosed-runners-5172.test.js
@@ -9,8 +9,14 @@
 //
 // El rechazo de la fase `aprobacion` señaló que la separación estaba sólo en el
 // TEXTO DEL LOG: ambas ramas caían al mismo `return {}`, así que un config
-// corrupto reducía el umbral de kill del Pulpo de 180s (config.yaml) a 90s
-// (default del módulo) — degradación en dirección DESTRUCTIVA.
+// corrupto reducía el umbral de kill del Pulpo al default del módulo —
+// degradación en dirección DESTRUCTIVA.
+//
+// #5820 — Los umbrales de los fixtures se recalibraron: el valor vigente de
+// config.yaml es 270s y el default del módulo se elevó a 270s para que perder
+// el bloque `watchdog:` no degrade a un umbral MÁS agresivo que el vigente.
+// Los fixtures ya no fijan 180s (el valor que causó el bucle de muerte del
+// 2026-08-11) como ejemplo de "config sana".
 //
 // Por qué el harness copia el runner a un directorio temporal
 // -----------------------------------------------------------
@@ -82,13 +88,25 @@ const SHIMS_LIVENESS_COMPLETOS = {
     'config-resolver': path.join(REAL_LIB, 'config-resolver.js'),
 };
 
-// Zombi "obvio" para el default de 90s: 120s de lag con el PID cruzado. Está
-// POR DEBAJO de los 180s que declara config.yaml, así que discrimina exactamente
-// la degradación destructiva: con el default mata, con el umbral real no.
+// #5820 — Umbral vigente del pipeline: lo declara `watchdog.pulpo_liveness_kill_seconds`
+// en config.yaml Y el `DEFAULT_KILL_SECONDS` del módulo, alineados a propósito
+// para que perder el bloque de config no degrade a un umbral más agresivo.
+const UMBRAL_VIGENTE_S = 270;
+
+// Lag que vence el default: discrimina la degradación destructiva. Con los
+// defaults aplicados mata; con el fail-closed activo NO mata.
+const LAG_ZOMBI_MS = (UMBRAL_VIGENTE_S + 30) * 1000;
+
+// Ciclo lento REAL de un Pulpo sano: 245s es el máximo `hbAgeMs` medido en
+// .pipeline/logs/pulpo-liveness.log bajo el umbral de 270s (244993 ms), sin un
+// solo kill. Debe resolver a skip: es el escenario que con 180s producía los
+// 77 falsos positivos del 2026-08-11.
+const LAG_CICLO_LENTO_MS = 245 * 1000;
+
 function hechosZombi(extra) {
     return Object.assign({
         PLV_HB_EXISTS: '1',
-        PLV_HB_AGE_MS: String(120 * 1000),
+        PLV_HB_AGE_MS: String(LAG_ZOMBI_MS),
         PLV_HB_CONTENT: '{"pid":34567,"timestamp":"2020-01-01T00:00:00.000Z"}',
         PLV_SO_PID: '34567',
         PLV_LOG_DIR: fs.mkdtempSync(path.join(os.tmpdir(), 'p5172-log-')),
@@ -102,7 +120,7 @@ test('liveness — config corrupta => FAIL-CLOSED: ACTION:skip (no mata con umbr
     assert.strictEqual(out, 'ACTION:skip');
 });
 
-test('liveness — config-resolver ausente (MODULE_NOT_FOUND) => FAIL-SOFT a defaults: mata a los 90s', () => {
+test('liveness — config-resolver ausente (MODULE_NOT_FOUND) => FAIL-SOFT a defaults: mata al vencer el default', () => {
     // Mismo config corrupto, pero sin el resolver: la degradación a defaults es
     // legítima porque no hay evidencia de que la config difiera del default.
     const dir = armarPipelineFalso(RUNNER_LIVENESS, YAML_CORRUPTO, {
@@ -126,14 +144,73 @@ test('liveness — config corrupta + env basura => FAIL-CLOSED (un env inválido
     assert.strictEqual(out, 'ACTION:skip');
 });
 
-test('liveness — config SANA con umbral 180s => no mata a los 120s (control del test anterior)', () => {
+// #5820 — Gherkin "un ciclo lento del Pulpo no dispara un kill": con el umbral
+// vigente (270s), un heartbeat de 245s de antigüedad es un Pulpo sano lento, no
+// un zombi. Con el valor viejo (180s) esto era un kill: es el falso positivo que
+// produjo 77 reinicios y dejó al Commander caído 4h el 2026-08-11.
+test(`liveness — config SANA con el umbral vigente (${UMBRAL_VIGENTE_S}s) => ciclo lento de 245s NO se mata`, () => {
     const dir = armarPipelineFalso(
         RUNNER_LIVENESS,
-        'watchdog:\n  pulpo_liveness_kill_seconds: 180\n',
+        `watchdog:\n  pulpo_liveness_kill_seconds: ${UMBRAL_VIGENTE_S}\n`,
+        SHIMS_LIVENESS_COMPLETOS
+    );
+    const out = correr(
+        dir,
+        RUNNER_LIVENESS,
+        hechosZombi({ PLV_HB_AGE_MS: String(LAG_CICLO_LENTO_MS) })
+    );
+    assert.strictEqual(out, 'ACTION:skip');
+});
+
+// Control del fail-soft: prueba que el umbral SALE DE LA CONFIG y no del default.
+// Con un valor de config mayor al default, un lag que vencería el default debe
+// resolver a skip. Si el runner ignorara la config, acá mataría.
+test('liveness — config SANA con umbral mayor al default => se aplica el de config, no el default', () => {
+    const dir = armarPipelineFalso(
+        RUNNER_LIVENESS,
+        `watchdog:\n  pulpo_liveness_kill_seconds: ${UMBRAL_VIGENTE_S * 2}\n`,
         SHIMS_LIVENESS_COMPLETOS
     );
     const out = correr(dir, RUNNER_LIVENESS, hechosZombi());
     assert.strictEqual(out, 'ACTION:skip');
+});
+
+// #5820 — Gherkin "config sin el bloque watchdog no degrada a un umbral más
+// agresivo". Sin la clave, el runner cae al DEFAULT_KILL_SECONDS del módulo; ese
+// default está alineado con el umbral vigente, así que un ciclo lento de 245s
+// sigue siendo skip. Con el default viejo (90s) esto era un kill instantáneo:
+// perder el bloque de config dejaba el pipeline PEOR que el valor ya descartado.
+test('liveness — config sin `pulpo_liveness_kill_seconds` => el default no es más agresivo que el vigente', () => {
+    const { DEFAULT_KILL_SECONDS } = require(path.join(REAL_LIB, 'pulpo-liveness.js'));
+    assert.ok(
+        DEFAULT_KILL_SECONDS >= UMBRAL_VIGENTE_S,
+        `el default del módulo (${DEFAULT_KILL_SECONDS}s) no puede ser menor que el umbral vigente (${UMBRAL_VIGENTE_S}s)`
+    );
+
+    const dir = armarPipelineFalso(
+        RUNNER_LIVENESS,
+        'watchdog:\n  stale_minutes: 6\n',
+        SHIMS_LIVENESS_COMPLETOS
+    );
+    const out = correr(
+        dir,
+        RUNNER_LIVENESS,
+        hechosZombi({ PLV_HB_AGE_MS: String(LAG_CICLO_LENTO_MS) })
+    );
+    assert.strictEqual(out, 'ACTION:skip');
+});
+
+// #5820 — Guarda de regresión contra el `reset --hard` del repo principal: el
+// valor mitigado tiene que vivir COMMITEADO en config.yaml, no sólo en el
+// working tree. Si alguien lo baja (o se pierde en un respawn), esto se pone
+// rojo antes de que vuelva el bucle de muerte.
+test('liveness — config.yaml real declara el umbral vigente y coincide con el default del módulo', () => {
+    const configResolver = require(path.join(REAL_LIB, 'config-resolver.js'));
+    const { DEFAULT_KILL_SECONDS } = require(path.join(REAL_LIB, 'pulpo-liveness.js'));
+    const cfg = configResolver.resolve({ pipelineDir: PIPELINE_DIR });
+
+    assert.strictEqual(cfg.watchdog.pulpo_liveness_kill_seconds, UMBRAL_VIGENTE_S);
+    assert.strictEqual(DEFAULT_KILL_SECONDS, UMBRAL_VIGENTE_S);
 });
 
 // -----------------------------------------------------------------------------

--- a/.pipeline/lib/pulpo-liveness.js
+++ b/.pipeline/lib/pulpo-liveness.js
@@ -27,11 +27,27 @@
 
 'use strict';
 
-// Umbral de kill por default: 90s. Desacoplado del "esperado < 30s" que /salud
-// usa para *mostrar* salud. 30s == 1 poll_interval del Pulpo; un ciclo lento
-// (precheck de red, brazo pesado) puede rozarlo sin ser zombi. 90s = max(90,
-// 3×poll_interval) evita falsos positivos (CA-4) y restart-storms (SEC-3).
-const DEFAULT_KILL_SECONDS = 90;
+// Umbral de kill por default: 270s. Desacoplado del "esperado < 30s" que /salud
+// usa para *mostrar* salud (30s == 1 poll_interval del Pulpo).
+//
+// #5820 — Por qué 270 y no 90. El default original (90s = max(90,
+// 3×poll_interval)) derivaba el umbral del POLL, no de la duración real de un
+// ciclo del Pulpo. El incidente del 2026-08-11 midió esa diferencia: con 180s
+// —el DOBLE del default— el watchdog mató al Pulpo 77 veces en ~3h sin que
+// hubiera un cuelgue real, y el máximo hbAgeMs de un Pulpo sano medido después
+// fue 244993 ms (245 s). Un default de 90s es, entonces, casi 3× más agresivo
+// que un umbral que YA se demostró insuficiente.
+//
+// Esto importa porque el default NO es sólo un camino de emergencia: se aplica
+// por vía normal cuando config.yaml no aporta el valor (bloque `watchdog:`
+// ausente — ver pulpo-liveness-run.js, caso D-4 de #5172 — o clave ausente /
+// inválida). Con 90s, perder el bloque de config dejaba el umbral MÁS agresivo
+// que el vigente y reabría el bucle de muerte en silencio. El default se
+// mantiene alineado con `watchdog.pulpo_liveness_kill_seconds` de config.yaml
+// para que la degradación nunca sea en dirección destructiva (SEC-3).
+//
+// Si se sube el valor de config.yaml, subir también este default.
+const DEFAULT_KILL_SECONDS = 270;
 
 /**
  * Valida el umbral de kill en segundos (SEC-2).

--- a/.pipeline/pulpo-liveness-run.js
+++ b/.pipeline/pulpo-liveness-run.js
@@ -90,11 +90,15 @@ function loadWatchdogConfig() {
     // (incluido un bug del resolver) NO debe hacerse pasar por corrupción.
     if (isConfigViolation(err)) {
       // FAIL-CLOSED: config corrupta. NO se degrada a los defaults del liveness.
-      // Motivo medido: config.yaml declara `pulpo_liveness_kill_seconds: 180` y
-      // el default del módulo es 90s, así que caer al default REDUCE A LA MITAD
-      // el umbral de kill del Pulpo — degradación en dirección DESTRUCTIVA
-      // (mata antes, habilita restart-storms; SEC-3). Se propaga un sentinel y
-      // el caller emite ACTION:skip: nunca se mata con un umbral degradado.
+      // Motivo: si el archivo es ilegible NO SABEMOS qué umbral declaró el
+      // operador, y el default del módulo puede ser más chico que ese valor
+      // (nada impide configurar un umbral holgado para una ola pesada). Aplicar
+      // el default sería degradar en dirección DESTRUCTIVA — mata antes de
+      // tiempo y habilita restart-storms (SEC-3), que es exactamente el bucle de
+      // muerte medido en el incidente del 2026-08-11 (#5820: 77 kills en ~3h
+      // sobre un Pulpo sano, con el Commander caído 4h de arrastre).
+      // Se propaga un sentinel y el caller emite ACTION:skip: nunca se mata con
+      // un umbral que no podemos confirmar.
       // SEC-1: el error tipado ya viene redactado ({archivo, causa, linea,
       // columna}); NUNCA se loguea el `.message` crudo de js-yaml.
       log(
@@ -102,7 +106,9 @@ function loadWatchdogConfig() {
           `${err && err.linea != null ? `, linea=${err.linea}` : ''}` +
           `${err && err.columna != null ? `, columna=${err.columna}` : ''}) — ` +
           'NO se aplican los defaults del liveness y NO se mata al Pulpo ' +
-          '(el default de 90s es la mitad del umbral configurado: degradar sería destructivo)'
+          '(sin config legible no se puede confirmar el umbral que declaró el operador; ' +
+          'aplicar el default podría matar antes de tiempo). ' +
+          'Arreglá config.yaml o fijá PULPO_LIVENESS_KILL_SECONDS para reactivar el liveness'
       );
       return { __configViolation: true };
     }
@@ -172,8 +178,8 @@ function main() {
   // no hay umbral confiable: se propaga un umbral no finito y `decide()` devuelve
   // 'skip' por su primitiva ya existente ("umbral inválido => no matar").
   // Ojo: `parseKillSeconds` NUNCA devuelve null (un fallback inválido cae al
-  // default de 90s), así que no sirve para detectar "el operador fijó el env".
-  // Ese chequeo tiene que ser sobre el valor crudo.
+  // DEFAULT_KILL_SECONDS del módulo), así que no sirve para detectar "el
+  // operador fijó el env". Ese chequeo tiene que ser sobre el valor crudo.
   if (cfg.__configViolation && !hasExplicitKillSecondsOverride()) {
     log(
       'ACTION:skip por FAIL-CLOSED de configuración — sin PULPO_LIVENESS_KILL_SECONDS ' +

--- a/.pipeline/test/pulpo-liveness.test.js
+++ b/.pipeline/test/pulpo-liveness.test.js
@@ -26,7 +26,10 @@ const path = require('node:path');
 const liveness = require('../lib/pulpo-liveness');
 
 const SEC = 1000;
-const KILL_MS = 90 * SEC; // umbral default
+// #5820 — El umbral default se elevó de 90s a 270s: 90s era casi 3× más
+// agresivo que los 180s que ya habían producido 77 falsos kills el 2026-08-11,
+// y el default se aplica por vía normal cuando config.yaml no aporta el valor.
+const KILL_MS = liveness.DEFAULT_KILL_SECONDS * SEC; // umbral default
 
 function baseFacts(over = {}) {
   return Object.assign(
@@ -40,6 +43,15 @@ function baseFacts(over = {}) {
     over
   );
 }
+
+// --- contrato del default (#5820) -------------------------------------------
+
+test('DEFAULT_KILL_SECONDS — vale 270s y nunca degrada por debajo del umbral vigente', () => {
+  // Fijado explícitamente (no derivado) para que bajarlo requiera tocar el test:
+  // el default se aplica por vía NORMAL cuando config.yaml no trae la clave, así
+  // que un default agresivo reabre el bucle de muerte del 2026-08-11 en silencio.
+  assert.strictEqual(liveness.DEFAULT_KILL_SECONDS, 270);
+});
 
 // --- parseKillSeconds (SEC-2) -----------------------------------------------
 
@@ -175,7 +187,7 @@ test('runner — zombi confirmado (vencido + pid cruza) => ACTION:kill-respawn',
     PLV_HB_AGE_MS: String(KILL_MS + 5000),
     PLV_HB_CONTENT: '{"pid":34567,"timestamp":"2020-01-01T00:00:00.000Z"}',
     PLV_SO_PID: '34567',
-    PULPO_LIVENESS_KILL_SECONDS: '90',
+    PULPO_LIVENESS_KILL_SECONDS: String(liveness.DEFAULT_KILL_SECONDS),
     PLV_LOG_DIR: require('node:os').tmpdir(),
   });
   assert.strictEqual(out, 'ACTION:kill-respawn');
@@ -215,8 +227,8 @@ test('runner — sin heartbeat => ACTION:skip', () => {
 });
 
 test('runner — umbral inválido por env => default, no falso kill con lag moderado (SEC-2)', () => {
-  // lag 60s: con default 90s NO es zombi. Umbral inválido no debe volverlo "nunca stale"
-  // ni "siempre stale": cae al default 90s => skip.
+  // lag 60s: está por debajo del default vigente, así que NO es zombi. Un umbral
+  // inválido no debe volverlo "nunca stale" ni "siempre stale": cae al default => skip.
   const out = runRunner({
     PLV_HB_EXISTS: '1',
     PLV_HB_AGE_MS: '60000',

--- a/docs/pipeline/watchdog.md
+++ b/docs/pipeline/watchdog.md
@@ -126,16 +126,44 @@ mata**, registra la discrepancia. Tras el kill, respawnea con el mismo
 
 ## 3. Umbral de kill (anti falso positivo)
 
-`config.yaml → watchdog.pulpo_liveness_kill_seconds` (default **90s**).
+`config.yaml → watchdog.pulpo_liveness_kill_seconds` (default **270s**).
 
 **Desacoplado del display.** `/salud` usa "esperado < 30s" sólo para *mostrar*
 salud; 30s == 1 `poll_interval` del Pulpo, y un ciclo lento (precheck de red,
-brazo pesado) podría rozarlo sin ser zombi. El umbral de *kill* es holgado:
-`max(90, 3×poll_interval)`. Esto, junto con el guard de `last-restart.json < 90s`
-y la auditoría de cada kill, evita **restart-storms** (SEC-3).
+brazo pesado) podría rozarlo sin ser zombi.
+
+**El umbral NO se deriva de `poll_interval`.** Se dimensiona contra la duración
+REAL de un ciclo del Pulpo, que con la ola actual está muy por encima del poll.
+Lo midió el incidente del **2026-08-11** (~11:00–14:00): con `180s` el watchdog
+mató y relanzó al Pulpo **77 veces** (una cada ~6 min) sin que hubiera un cuelgue
+real — el ciclo simplemente tardaba más que el umbral. Cada reinicio se llevaba
+puesta la cola de comandos de Telegram, así que el Commander quedó sin responder
+~4 h. Medición posterior sobre `.pipeline/logs/pulpo-liveness.log`:
+
+| `killSeconds` | Resultado                                      |
+|---------------|------------------------------------------------|
+| `180`         | 77 × `decision=kill` el 2026-08-11             |
+| `270`         | 0 × `decision=kill` en 68 ciclos               |
+
+Máximo `hbAgeMs` observado en un Pulpo sano: **244993 ms (245 s)**. El margen
+contra el techo de 270 s es de ~25 s (**~9%**): el valor vigente *persiste* la
+mitigación medida, pero **no** resuelve el dimensionamiento del colchón — eso se
+rediseña en **#5821**. Si volvés a ver kills sin cuelgue real, es ese issue y no
+este valor.
+
+El guard de `last-restart.json < 90s` y la auditoría de cada kill son lo que
+evita **restart-storms** (SEC-3). Son un mecanismo distinto de este umbral: su
+ventana de 90 s no se mueve junto con `pulpo_liveness_kill_seconds`.
 
 - Override por env: `PULPO_LIVENESS_KILL_SECONDS` (entero positivo).
 - Valor inválido → cae al default. **Nunca** degrada a "nunca stale" (SEC-2).
+- **Invariante:** `watchdog.pulpo_liveness_kill_seconds` (`config.yaml`) y
+  `DEFAULT_KILL_SECONDS` (`lib/pulpo-liveness.js`) **se mueven juntos**. El
+  default no es sólo un camino de emergencia: se aplica por vía normal cuando el
+  bloque `watchdog:` falta (caso D-4 de #5172) o la clave está ausente/inválida.
+  Si se desalinean hacia abajo, perder el bloque de config degrada a un umbral
+  **más agresivo** que el vigente y reabre el bucle de muerte en silencio. Al
+  subir uno, subir el otro.
 
 ### Semáforo recomendado en `/salud` (UX, CA-5)
 


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 6 archivos · +190 -34

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:passed` aplicado por delivery

## Closes

Closes #5820
