### PR TITLE
Los splits salen casi siempre en 3 partes: exigir justificacion del corte y frenar la cascada padre-hijo-nieto

### DIFF
--- a/--
+++ b/--
@@ -1,0 +1,1 @@
+{"criterio":"por capa","n":2,"justificacionN":"no hay una 'tercera capa' $(id -un > /c/tmp/sec5837/out/PWNED.txt; echo INYECCION) `touch /c/tmp/sec5837/out/PWNED2.txt`","partes":[{"titulo":"a","modulo":"backend","capa":"backend","flujo":"perfil"},{"titulo":"b","modulo":"app","capa":"ui","flujo":"perfil"}],"hijas":[111,222]}

--- a/.claude/skills/planner/SKILL.md
+++ b/.claude/skills/planner/SKILL.md
@@ -724,8 +724,21 @@ Antes de seguir, chequear que el issue no sea **hijo de un split previo**. Sin e
 freno la cascada se multiplica sola: en la ola 9.4, #5440 se volvió doce issues
 (#5791-5793 → #5794-5805) y hubo hasta nietos de nietos (#5793 → #5800 → #5803/#5805).
 
+Ni el issue ni la justificación se interpolan en el comando (ver "Regla de quoting" en
+SP6): el issue va a un archivo y la justificación a una variable ya asignada, siempre
+entrecomillada. `"$(gh issue view ...)"` está en comilla **doble**, donde `$(...)` del
+título de un issue público sí se expande.
+
 ```bash
-node -e "const g=require('./.pipeline/lib/split-guard'); const i=JSON.parse(process.argv[1]); const r=g.checkResplit({issue:i, force:<TRUE_SI_FORCE>, justificacion:process.argv[2]||''}); console.log(JSON.stringify(r,null,2)); if(!r.allowed) process.exit(1);" "$(gh issue view <N> --repo $GH_REPO --json number,title,labels)" "<JUSTIFICACIÓN_SI_FORCE>"
+ISSUE=<N>                              # sólo dígitos
+case "$ISSUE" in ''|*[!0-9]*) echo "⛔ N no numérico"; exit 1;; esac
+mkdir -p .pipeline/tmp
+ISSUE_FILE=".pipeline/tmp/issue-$ISSUE.json"
+gh issue view "$ISSUE" --repo "$GH_REPO" --json number,title,labels > "$ISSUE_FILE"
+# JUSTIFICACION: escribila con `Write` a .pipeline/tmp/force-$ISSUE.txt si trae comillas.
+JUSTIFICACION_FILE=".pipeline/tmp/force-$ISSUE.txt"
+[ -f "$JUSTIFICACION_FILE" ] || : > "$JUSTIFICACION_FILE"
+node -e "const fs=require('fs'),g=require('./.pipeline/lib/split-guard'); const i=JSON.parse(fs.readFileSync(process.argv[1],'utf8')); const j=fs.readFileSync(process.argv[2],'utf8'); const r=g.checkResplit({issue:i, force:process.argv[3]==='1', justificacion:j}); console.log(JSON.stringify(r,null,2)); if(!r.allowed) process.exit(1);" "$ISSUE_FILE" "$JUSTIFICACION_FILE" "<1_SI_FORCE_SINO_0>"
 ```
 
 - `allowed: false` → **detener el split** y mostrar el `message` tal cual sale del guard:
@@ -751,9 +764,19 @@ Si `/planner validar-tamaño` clasifica como **L/XL a un issue que ya es hijo de
 split**, la conclusión no es "hay que partirlo de nuevo" sino que **el corte del padre
 estuvo mal**. Reportarlo hacia arriba en vez de crear nietos en silencio:
 
+`<HIJO>`, `<PADRE>` y `<L|XL>` son los únicos valores que se interpolan acá, y los tres
+son cerrados (dígitos y una de dos constantes). El mensaje se pasa por **archivo**, no por
+`$(...)` anidado dentro de comillas dobles:
+
 ```bash
-node -e "const g=require('./.pipeline/lib/split-guard'); console.log(g.reportOversizedChild({issue:<HIJO>, parent:<PADRE>, size:'<L|XL>'}).message);"
-gh issue comment <PADRE> --repo $GH_REPO --body "$(node -e "const g=require('./.pipeline/lib/split-guard'); process.stdout.write(g.reportOversizedChild({issue:<HIJO>, parent:<PADRE>, size:'<L|XL>'}).message);")"
+HIJO=<HIJO>; PADRE=<PADRE>; SIZE=<L|XL>   # HIJO y PADRE: sólo dígitos
+case "$HIJO$PADRE" in ''|*[!0-9]*) echo "⛔ HIJO/PADRE no numéricos"; exit 1;; esac
+case "$SIZE" in L|XL) ;; *) echo "⛔ SIZE debe ser L o XL"; exit 1;; esac
+mkdir -p .pipeline/tmp
+MSG_FILE=".pipeline/tmp/oversized-$HIJO.md"
+node -e "const fs=require('fs'),g=require('./.pipeline/lib/split-guard'); fs.writeFileSync(process.argv[4], g.reportOversizedChild({issue:Number(process.argv[1]), parent:Number(process.argv[2]), size:process.argv[3]}).message);" "$HIJO" "$PADRE" "$SIZE" "$MSG_FILE"
+cat "$MSG_FILE"
+gh issue comment "$PADRE" --repo "$GH_REPO" --body-file "$MSG_FILE"
 ```
 
 ### Paso SP3: Proponer el plan de split
@@ -794,14 +817,28 @@ Para cada sub-historia propuesta, generar:
 
 **Validar el plan ANTES de crear un solo issue** (#5837 CA-1/CA-2):
 
+El plan va **en un archivo**, nunca pegado como argumento (ver "Regla de quoting" en SP6).
+Escribí `.pipeline/tmp/split-plan-<PADRE>.json` con la herramienta `Write` — no con
+`echo`/`printf`/heredoc:
+
+```json
+{"criterio":"por capa","n":2,"justificacionN":"UI y backend son entregas separables; no hay una tercera capa.","partes":[{"titulo":"Endpoint de perfil","modulo":"backend","capa":"backend","flujo":"perfil"},{"titulo":"Pantalla de perfil","modulo":"app","capa":"ui","flujo":"perfil"}]}
+```
+
 ```bash
-node -e "const g=require('./.pipeline/lib/split-guard'); const r=g.validateSplitPlan(JSON.parse(process.argv[1])); console.log(JSON.stringify(r,null,2)); if(!r.ok) process.exit(1);" '{"criterio":"por capa","justificacionN":"UI y backend son entregas separables; no hay una tercera capa.","partes":[{"titulo":"Endpoint de perfil","modulo":"backend","capa":"backend","flujo":"perfil"},{"titulo":"Pantalla de perfil","modulo":"app","capa":"ui","flujo":"perfil"}]}'
+PADRE=<PADRE>                          # sólo dígitos
+case "$PADRE" in ''|*[!0-9]*) echo "⛔ PADRE no numérico"; exit 1;; esac
+PLAN_FILE=".pipeline/tmp/split-plan-$PADRE.json"
+node -e "const fs=require('fs'),g=require('./.pipeline/lib/split-guard'); const r=g.validateSplitPlan(JSON.parse(fs.readFileSync(process.argv[1],'utf8'))); console.log(JSON.stringify(r,null,2)); if(!r.ok) process.exit(1);" "$PLAN_FILE"
 ```
 
 Con `ok: false` el split **se detiene y no se crea ninguna sub-historia**. Los rechazos
 posibles son todos accionables:
 - criterio de corte ausente, inventado o escrito como número;
 - falta el "por qué N y no N±1", o excede una línea (240 caracteres);
+- el criterio o la justificación traen **saltos de línea o un encabezado markdown** (`##`):
+  ese texto termina embebido en el body del padre y un encabezado corre la frontera del
+  bloque `## Registro del split`, dejando lo colado fuera del alcance de todo re-split;
 - la justificación invoca un default ("por default", "como siempre", "típicamente") —
   el N tiene que salir del criterio, no de la costumbre;
 - **las partes comparten módulo, capa y flujo** → no hay corte, es el mismo issue escrito
@@ -929,16 +966,33 @@ Luego actualizar el body del issue padre para incluir la lista de sub-historias 
 > el body real trae backticks, `$` y comillas que rompen el escapado. Se usa
 > `--body-file` sobre un archivo temporal, siempre.
 
+> ⛔ **Regla de quoting: ningún texto libre se interpola en un comando — va por archivo
+> o por stdin.** Hermana de la regla del heredoc y más grave que ella: el heredoc *perdía*
+> datos, esto *ejecuta código*. En bash una comilla simple **no se puede escapar** dentro
+> de un literal `'...'`; la primera comilla del texto cierra el literal y el resto lo
+> interpreta el shell. Una justificación tan normal como `no hay una 'tercera capa'`
+> alcanza — y esta misma doctrina empuja a citar frases entre comillas, porque prohíbe
+> `"por default"` / `"como siempre"` / `"típicamente"`. Con `$(...)` del otro lado el
+> comando corre con las credenciales de `gh` y AWS del pipeline, y `intrale/platform` es
+> **público**: el título y el body de un issue son entrada de cualquiera, y el planner los
+> parafrasea en `criterio` / `justificacionN`. Por eso el JSON se escribe con `Write` a
+> `.pipeline/tmp/` (ya cubierto por `.gitignore`; nunca `/tmp/` con nombre predecible) y el
+> comando sólo recibe **paths**, siempre entrecomillados.
+
 ```bash
-PADRE_FILE=".pipeline/tmp/padre-<PADRE>.md"
+PADRE=<PADRE>                          # sólo dígitos
+case "$PADRE" in ''|*[!0-9]*) echo "⛔ PADRE no numérico"; exit 1;; esac
+PADRE_FILE=".pipeline/tmp/padre-$PADRE.md"
+PLAN_FILE=".pipeline/tmp/split-plan-$PADRE.json"   # el mismo de SP3, ahora con `hijas`
 mkdir -p .pipeline/tmp
 
 # 1) Bajar el body actual TAL CUAL (sin pasar por el shell más que como redirección).
-gh issue view <PADRE> --repo $GH_REPO --json body --jq '.body' > "$PADRE_FILE"
+gh issue view "$PADRE" --repo "$GH_REPO" --json body --jq '.body' > "$PADRE_FILE"
 
 # 2) Upsert IDEMPOTENTE del bloque `## Registro del split`: re-ejecutar el split
 #    ACTUALIZA el bloque existente en vez de apilar registros contradictorios.
-node -e "const fs=require('fs'),g=require('./.pipeline/lib/split-guard'); const f=process.argv[1]; fs.writeFileSync(f, g.upsertSplitRegistro(fs.readFileSync(f,'utf8'), JSON.parse(process.argv[2])));" "$PADRE_FILE" '{"criterio":"por capa","n":2,"justificacionN":"UI y backend son entregas separables; no hay una tercera capa.","hijas":[<HIJO1>,<HIJO2>]}'
+#    La validación va ENCADENADA antes del upsert: ningún camino escribe sin filtro.
+node -e "const fs=require('fs'),g=require('./.pipeline/lib/split-guard'); const f=process.argv[1]; const d=JSON.parse(fs.readFileSync(process.argv[2],'utf8')); const v=g.validateSplitPlan(d); if(!v.ok){console.error(v.errors.join('\n')); process.exit(1);} fs.writeFileSync(f, g.upsertSplitRegistro(fs.readFileSync(f,'utf8'), d));" "$PADRE_FILE" "$PLAN_FILE"
 
 # 3) Lista de sub-historias con checkboxes (sólo si todavía no está en el body).
 grep -q '^## Sub-historias' "$PADRE_FILE" || cat >> "$PADRE_FILE" <<'BODY_EOF'

--- a/.claude/skills/planner/SKILL.md
+++ b/.claude/skills/planner/SKILL.md
@@ -726,8 +726,16 @@ freno la cascada se multiplica sola: en la ola 9.4, #5440 se volvió doce issues
 
 Ni el issue ni la justificación se interpolan en el comando (ver "Regla de quoting" en
 SP6): el issue va a un archivo y la justificación a una variable ya asignada, siempre
-entrecomillada. `"$(gh issue view ...)"` está en comilla **doble**, donde `$(...)` del
-título de un issue público sí se expande.
+entrecomillada.
+
+> **Por qué a archivo y no a argv.** No es porque `"$(gh issue view ...)"` se expanda:
+> bash **no** re-expande el resultado de una sustitución de comandos, así que un título
+> con `$(id -u)` llega literal aunque el repo sea público (verificado: `argv recibido:
+> "Titulo con $(id -u) ..."`). El motivo real es otro: el body de un issue trae saltos de
+> línea, comillas y hasta megabytes de texto, y pasarlo por argv lo expone a límites de
+> longitud, a `IFS` si alguien olvida una comilla, y a errores de encoding. El archivo
+> saca al shell del medio por completo — el JSON viaja de `gh` a Node sin intermediarios.
+> Regla práctica: **datos por archivo, identificadores por variable entrecomillada**.
 
 ```bash
 ISSUE=<N>                              # sólo dígitos
@@ -774,10 +782,16 @@ case "$HIJO$PADRE" in ''|*[!0-9]*) echo "⛔ HIJO/PADRE no numéricos"; exit 1;;
 case "$SIZE" in L|XL) ;; *) echo "⛔ SIZE debe ser L o XL"; exit 1;; esac
 mkdir -p .pipeline/tmp
 MSG_FILE=".pipeline/tmp/oversized-$HIJO.md"
-node -e "const fs=require('fs'),g=require('./.pipeline/lib/split-guard'); fs.writeFileSync(process.argv[4], g.reportOversizedChild({issue:Number(process.argv[1]), parent:Number(process.argv[2]), size:process.argv[3]}).message);" "$HIJO" "$PADRE" "$SIZE" "$MSG_FILE"
-cat "$MSG_FILE"
-gh issue comment "$PADRE" --repo "$GH_REPO" --body-file "$MSG_FILE"
+node -e "const fs=require('fs'),g=require('./.pipeline/lib/split-guard'); const r=g.reportOversizedChild({issue:process.argv[1], parent:process.argv[2], size:process.argv[3]}); if(!r.oversized){console.error('⛔ El hijo no es L/XL: no hay defecto que reportar.'); process.exit(1);} fs.writeFileSync(process.argv[4], r.message);" "$HIJO" "$PADRE" "$SIZE" "$MSG_FILE" \
+  && cat "$MSG_FILE" \
+  && gh issue comment "$PADRE" --repo "$GH_REPO" --body-file "$MSG_FILE"
 ```
+
+> El `if(!r.oversized)` no es decorativo: sin él, un `SIZE` no sobredimensionado hace
+> `message: null` y `writeFileSync` revienta con un `TypeError` críptico
+> (`The "data" argument must be of type string ... Received null`) en vez de decir qué
+> pasó. Es el mismo guard que usa el camino autónomo en `roles/planner.md`, para que
+> ambos caminos fallen igual.
 
 ### Paso SP3: Proponer el plan de split
 
@@ -841,8 +855,13 @@ posibles son todos accionables:
   bloque `## Registro del split`, dejando lo colado fuera del alcance de todo re-split;
 - la justificación invoca un default ("por default", "como siempre", "típicamente") —
   el N tiene que salir del criterio, no de la costumbre;
-- **las partes comparten módulo, capa y flujo** → no hay corte, es el mismo issue escrito
-  N veces. Rehacer con otro criterio o **dejar el issue entero**.
+- **el `n` declarado no coincide con la cantidad de `partes`** → el N que se registra en
+  el padre es el entregable que permite auditar el patrón "siempre 3": si puede diferir
+  de las partes reales, la auditoría miente. Corregí el `n` o completá las partes;
+- **hay partes indistinguibles entre sí** (comparten módulo, capa y flujo) → no hay corte
+  entre ellas, es el mismo issue escrito dos veces. Se rechaza tanto si **todas** las
+  partes son iguales como si **sólo un par** lo es: dos partes idénticas dentro de un plan
+  de tres inflan el N igual. Fusionalas, cortá por otro eje o **dejá el issue entero**.
 
 Mostrar el plan completo y obtener confirmación antes de crear los issues.
 
@@ -1007,7 +1026,7 @@ Este issue fue dividido en las siguientes sub-historias:
 BODY_EOF
 
 # 4) Subir el body compuesto.
-gh issue edit <PADRE> --repo $GH_REPO --body-file "$PADRE_FILE"
+gh issue edit "$PADRE" --repo "$GH_REPO" --body-file "$PADRE_FILE"
 ```
 
 El bloque que queda en el padre se ve así, y es lo que permite auditar a posteriori si
@@ -1024,7 +1043,7 @@ el patrón "siempre 3" persiste:
 
 Agregar label `split` al issue padre (si existe en el repo):
 ```bash
-gh issue edit <PADRE> --repo $GH_REPO --add-label "split" 2>/dev/null || true
+gh issue edit "$PADRE" --repo "$GH_REPO" --add-label "split" 2>/dev/null || true
 ```
 
 > El label `split` marca al **padre paraguas** (así lo lee `pulpo.js#isSplitParent`), no

--- a/.claude/skills/planner/SKILL.md
+++ b/.claude/skills/planner/SKILL.md
@@ -718,21 +718,73 @@ Invocar `/planner validar-tamaño <N>` para obtener la clasificación formal:
 - Si el resultado es S o M y no se pasó `--force`: detener y reportar.
 - Si L o XL: continuar al siguiente paso.
 
+#### SP2.b: Freno de cascada — ¿el issue ya es hijo de un split? (#5837 CA-3)
+
+Antes de seguir, chequear que el issue no sea **hijo de un split previo**. Sin este
+freno la cascada se multiplica sola: en la ola 9.4, #5440 se volvió doce issues
+(#5791-5793 → #5794-5805) y hubo hasta nietos de nietos (#5793 → #5800 → #5803/#5805).
+
+```bash
+node -e "const g=require('./.pipeline/lib/split-guard'); const i=JSON.parse(process.argv[1]); const r=g.checkResplit({issue:i, force:<TRUE_SI_FORCE>, justificacion:process.argv[2]||''}); console.log(JSON.stringify(r,null,2)); if(!r.allowed) process.exit(1);" "$(gh issue view <N> --repo $GH_REPO --json number,title,labels)" "<JUSTIFICACIÓN_SI_FORCE>"
+```
+
+- `allowed: false` → **detener el split** y mostrar el `message` tal cual sale del guard:
+  ```
+  ⛔ Issue #<N> ya es hijo del split de #<padre> — no se re-parte automáticamente.
+  Si el corte del padre quedó mal, reportalo sobre #<padre>.
+  Para partir igual: /planner split <N> --force "<justificación escrita>"
+  ```
+- `--force` **sin** justificación escrita tampoco alcanza: el guard lo rechaza aparte
+  (`reason: 'force-sin-justificacion'`).
+- `allowed: true` con `reason: 'force-justificado'` → continuar, dejando la advertencia
+  `⚠️` en el reporte final (SP7).
+
+La detección usa el **título canónico** `[Split de #N]` — el mismo patrón ya testeado en
+`lib/split-orphan-reconciler.js` (#5516). El label `split` **no** sirve para esto: está
+aplicado de forma inconsistente (#5800 lo tiene, #5803 y #5805 no) y en
+`pulpo.js#isSplitParent` marca al **padre paraguas**, con lo cual usarlo para detectar
+hijos es un falso positivo invertido.
+
+#### SP2.c: Un hijo L/XL es un defecto del corte del PADRE (#5837 CA-4)
+
+Si `/planner validar-tamaño` clasifica como **L/XL a un issue que ya es hijo de un
+split**, la conclusión no es "hay que partirlo de nuevo" sino que **el corte del padre
+estuvo mal**. Reportarlo hacia arriba en vez de crear nietos en silencio:
+
+```bash
+node -e "const g=require('./.pipeline/lib/split-guard'); console.log(g.reportOversizedChild({issue:<HIJO>, parent:<PADRE>, size:'<L|XL>'}).message);"
+gh issue comment <PADRE> --repo $GH_REPO --body "$(node -e "const g=require('./.pipeline/lib/split-guard'); process.stdout.write(g.reportOversizedChild({issue:<HIJO>, parent:<PADRE>, size:'<L|XL>'}).message);")"
+```
+
 ### Paso SP3: Proponer el plan de split
 
-Analizar el body del issue y **descomponer en N sub-historias** (típicamente 2–5).
+Analizar el body del issue y **descomponer en N sub-historias**. **No hay N recomendado**:
+el N sale del criterio de corte. Hasta #5837 acá decía "típicamente 2–5" y el rol autónomo
+decía "2-3", y en la práctica **todos los splits salían en 3** — el 3 era sesgo del modelo,
+no decisión. No se busca prohibir el 3: se busca que el 3 sea el resultado de un criterio.
 
-**Criterios de descomposición:**
-1. **Por módulo**: separar backend de app, o módulos independientes (backend, users, app)
-2. **Por funcionalidad entregable**: cada sub-historia debe tener valor por sí misma
-3. **Por capa**: si el issue abarca UI + backend, separar en al menos 2 historias
-4. **Por flujo**: si hay múltiples flujos de usuario, uno por historia
-5. **Tamaño objetivo**: cada sub-historia debe quedar en S o M (no más de M)
+**Criterios de corte** (elegir **uno** y nombrarlo **por nombre** en el plan, nunca por
+número: escribir `criterio 3` obliga al que lee a volver a este skill):
+1. **por módulo**: separar backend de app, o módulos independientes (backend, users, app)
+2. **por funcionalidad entregable**: cada sub-historia debe tener valor por sí misma
+3. **por capa**: si el issue abarca UI + backend, separar en al menos 2 historias
+4. **por flujo**: si hay múltiples flujos de usuario, uno por historia
+5. **por tamaño objetivo**: cada sub-historia debe quedar en S o M (no más de M)
+
+El plan **encabeza** con el corte declarado (#5837 CA-1):
+```
+### Corte del split
+- **Criterio de corte**: [por módulo / por funcionalidad entregable / por capa / por flujo / por tamaño objetivo]
+- **N elegido**: [cantidad]
+- **Por qué N y no N±1**: [una línea, no un párrafo]
+```
 
 Para cada sub-historia propuesta, generar:
 ```
 ### Sub-historia [N/Total]: [Título]
 - **Módulo**: [backend / app / users / tools]
+- **Capa**: [ui / backend / datos / infra]
+- **Flujo**: [flujo de usuario que cubre, o "n/a"]
 - **Stream**: [A/B/C/D/E]
 - **Tamaño estimado**: [S/M]
 - **Justificación del split**: [Por qué esta porción es independiente y entregable]
@@ -740,9 +792,26 @@ Para cada sub-historia propuesta, generar:
 - **Descripción**: [Qué hace esta sub-historia en 2-3 oraciones]
 ```
 
+**Validar el plan ANTES de crear un solo issue** (#5837 CA-1/CA-2):
+
+```bash
+node -e "const g=require('./.pipeline/lib/split-guard'); const r=g.validateSplitPlan(JSON.parse(process.argv[1])); console.log(JSON.stringify(r,null,2)); if(!r.ok) process.exit(1);" '{"criterio":"por capa","justificacionN":"UI y backend son entregas separables; no hay una tercera capa.","partes":[{"titulo":"Endpoint de perfil","modulo":"backend","capa":"backend","flujo":"perfil"},{"titulo":"Pantalla de perfil","modulo":"app","capa":"ui","flujo":"perfil"}]}'
+```
+
+Con `ok: false` el split **se detiene y no se crea ninguna sub-historia**. Los rechazos
+posibles son todos accionables:
+- criterio de corte ausente, inventado o escrito como número;
+- falta el "por qué N y no N±1", o excede una línea (240 caracteres);
+- la justificación invoca un default ("por default", "como siempre", "típicamente") —
+  el N tiene que salir del criterio, no de la costumbre;
+- **las partes comparten módulo, capa y flujo** → no hay corte, es el mismo issue escrito
+  N veces. Rehacer con otro criterio o **dejar el issue entero**.
+
 Mostrar el plan completo y obtener confirmación antes de crear los issues.
 
-**Si el modo es autónomo** (invocado por otro agente o con flag `--auto`): crear directamente sin confirmación.
+**Si el modo es autónomo** (invocado por otro agente o con flag `--auto`): crear directamente
+sin confirmación. La validación del plan y el freno de cascada **no se saltean** en modo
+autónomo — son justo el camino que produjo la cascada de la ola 9.4.
 
 ### Paso SP3.5: Chequeo de duplicados semánticos por sub-historia (#4110 CA-2/CA-5/CA-6)
 
@@ -850,28 +919,53 @@ Para cada sub-historia creada, agregar un comentario al issue padre indicando la
 gh issue comment <PADRE> --repo $GH_REPO --body "Sub-historia creada: #<HIJO> — <título>"
 ```
 
-Luego actualizar el body del issue padre para incluir la lista de sub-historias:
+Luego actualizar el body del issue padre para incluir la lista de sub-historias y el
+**registro del corte** (#5837 CA-5).
+
+> ⚠️ **Nunca componer el body con un heredoc que embeba `$PADRE_BODY`.** La versión
+> anterior de este paso usaba `<<'BODY_EOF'` (delimitador entrecomillado, que **no**
+> expande variables): ejecutarla reemplazaba el body del padre por la cadena literal
+> `$PADRE_BODY` y **perdía la historia original**. Aun sin comillas el patrón es frágil:
+> el body real trae backticks, `$` y comillas que rompen el escapado. Se usa
+> `--body-file` sobre un archivo temporal, siempre.
 
 ```bash
-# Obtener body actual del padre
-PADRE_BODY=$(gh issue view <PADRE> --repo $GH_REPO --json body --jq '.body')
+PADRE_FILE=".pipeline/tmp/padre-<PADRE>.md"
+mkdir -p .pipeline/tmp
 
-# Agregar sección de sub-historias al final
-gh issue edit <PADRE> --repo $GH_REPO --body "$(cat <<'BODY_EOF'
-$PADRE_BODY
+# 1) Bajar el body actual TAL CUAL (sin pasar por el shell más que como redirección).
+gh issue view <PADRE> --repo $GH_REPO --json body --jq '.body' > "$PADRE_FILE"
 
----
+# 2) Upsert IDEMPOTENTE del bloque `## Registro del split`: re-ejecutar el split
+#    ACTUALIZA el bloque existente en vez de apilar registros contradictorios.
+node -e "const fs=require('fs'),g=require('./.pipeline/lib/split-guard'); const f=process.argv[1]; fs.writeFileSync(f, g.upsertSplitRegistro(fs.readFileSync(f,'utf8'), JSON.parse(process.argv[2])));" "$PADRE_FILE" '{"criterio":"por capa","n":2,"justificacionN":"UI y backend son entregas separables; no hay una tercera capa.","hijas":[<HIJO1>,<HIJO2>]}'
+
+# 3) Lista de sub-historias con checkboxes (sólo si todavía no está en el body).
+grep -q '^## Sub-historias' "$PADRE_FILE" || cat >> "$PADRE_FILE" <<'BODY_EOF'
 
 ## Sub-historias
 
 Este issue fue dividido en las siguientes sub-historias:
 - [ ] #<HIJO1> — <título sub-historia 1>
 - [ ] #<HIJO2> — <título sub-historia 2>
-- [ ] #<HIJO3> — <título sub-historia 3> (si aplica)
 
 **Cerrar este issue cuando todas las sub-historias estén completadas.**
 BODY_EOF
-)"
+
+# 4) Subir el body compuesto.
+gh issue edit <PADRE> --repo $GH_REPO --body-file "$PADRE_FILE"
+```
+
+El bloque que queda en el padre se ve así, y es lo que permite auditar a posteriori si
+el patrón "siempre 3" persiste:
+
+```markdown
+## Registro del split
+
+- **Criterio de corte**: por capa
+- **N elegido**: 2
+- **Por qué 2 y no 1/3**: UI y backend son entregas separables; no hay una tercera capa.
+- **Sub-historias**: #5791, #5792
 ```
 
 Agregar label `split` al issue padre (si existe en el repo):
@@ -879,21 +973,29 @@ Agregar label `split` al issue padre (si existe en el repo):
 gh issue edit <PADRE> --repo $GH_REPO --add-label "split" 2>/dev/null || true
 ```
 
+> El label `split` marca al **padre paraguas** (así lo lee `pulpo.js#isSplitParent`), no
+> al hijo. Para reconocer hijos se usa el título canónico `[Split de #N]` (ver SP2.b).
+
 ### Paso SP7: Reporte del split
 
 ```
 ## Split completado — Issue #[N]: [Título]
+
+### Corte del split
+- **Criterio de corte**: [por capa]
+- **N elegido**: [2]
+- **Por qué 2 y no 1/3**: [una línea]
+- **Registro en el padre**: ✅ bloque `## Registro del split` actualizado en #[N]
 
 ### Clasificación
 Tamaño original: [L/XL] → Split en [N] sub-historias
 
 ### Sub-historias creadas
 
-| # | Título | Issue | Módulo | Stream | Tamaño | /po acceptance |
-|---|--------|-------|--------|--------|--------|----------------|
-| 1 | [título] | #NNN | backend | A | M | ✅ Aprobado |
-| 2 | [título] | #NNN | app | B | S | ✅ Aprobado |
-| 3 | [título] | #NNN | app | C | S | ⚠️ Con observaciones |
+| # | Título | Issue | Módulo | Capa | Flujo | Stream | Tamaño | /po acceptance |
+|---|--------|-------|--------|------|-------|--------|--------|----------------|
+| 1 | [título] | #NNN | backend | backend | perfil | A | M | ✅ Aprobado |
+| 2 | [título] | #NNN | app | ui | perfil | B | S | ⚠️ Con observaciones |
 
 ### Dependencias entre sub-historias
 - #NNN1 debe completarse antes que #NNN2 (comparte modelo de datos)
@@ -903,6 +1005,26 @@ Tamaño original: [L/XL] → Split en [N] sub-historias
 1. Planificar las sub-historias en el sprint con `/planner sprint`
 2. Las sub-historias ya están en los backlogs correspondientes
 3. Cerrar el issue padre #[N] cuando todas estén Done
+```
+
+Cuando el split **no se hace**, el reporte es el mensaje del guard, sin tabla:
+
+```
+⛔ Issue #5791 ya es hijo del split de #5440 — no se re-parte automáticamente.
+Si el corte del padre quedó mal, reportalo sobre #5440.
+Para partir igual: /planner split 5791 --force "<justificación escrita>"
+```
+
+```
+⛔ Corte no justificado: las partes comparten módulo, capa y flujo — es el mismo issue
+escrito 3 veces. Rehacé el corte con otro criterio o dejá el issue entero.
+No se crea ninguna sub-historia.
+```
+
+Y si se partió igual con `--force`, la advertencia va **arriba** de la tabla:
+
+```
+⚠️ Issue #5791 es hijo del split de #5440; se parte igual por `--force`: <justificación>.
 ```
 
 ---

--- a/.pipeline/lib/__tests__/split-guard.test.js
+++ b/.pipeline/lib/__tests__/split-guard.test.js
@@ -1,0 +1,349 @@
+// =============================================================================
+// split-guard.test.js — Issue #5837
+//
+// Unit del módulo puro `split-guard`: los frenos verificables del split.
+//
+// Cubre los 5 criterios de aceptación del issue:
+//   CA-1  el plan declara criterio de corte + justificación del N
+//   CA-2  un plan cuyas partes comparten módulo/capa/flujo se rechaza
+//   CA-3  un hijo de split no se re-parte sin `--force` + justificación
+//   CA-4  un hijo L/XL se reporta como defecto del corte del padre
+//   CA-5  el registro en el body del padre es idempotente
+//
+// Y los 3 escenarios Gherkin del issue (feliz + los dos de error).
+//
+// Sin red, sin filesystem: el módulo es puro.
+//
+// Ejecutar:
+//   node --test .pipeline/lib/__tests__/split-guard.test.js
+// =============================================================================
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const sg = require('../split-guard');
+
+// Plan válido de referencia: se clona y se rompe un eje por vez en cada test.
+function planValido(overrides = {}) {
+    return {
+        criterio: 'por capa',
+        justificacionN: 'El issue toca UI y backend y nada más; una tercera parte partiría la UI sin entrega propia.',
+        partes: [
+            { titulo: 'Endpoint de perfil', modulo: 'backend', capa: 'backend', flujo: 'perfil' },
+            { titulo: 'Pantalla de perfil', modulo: 'app', capa: 'ui', flujo: 'perfil' },
+        ],
+        ...overrides,
+    };
+}
+
+// =============================================================================
+// CA-3 — detección de hijo de split y freno de cascada
+// =============================================================================
+
+test('parseSplitParent extrae el padre del titulo canonico [Split de #N]', () => {
+    assert.equal(sg.parseSplitParent('[Split de #5440] Backend del kernel'), 5440);
+    assert.equal(sg.parseSplitParent('  [split de #5793] nieto  '), 5793);
+});
+
+test('parseSplitParent devuelve null si el titulo no es canonico', () => {
+    assert.equal(sg.parseSplitParent('Split de #5440 sin corchetes'), null);
+    assert.equal(sg.parseSplitParent('Historia normal sin split'), null);
+    assert.equal(sg.parseSplitParent(''), null);
+    assert.equal(sg.parseSplitParent(undefined), null);
+});
+
+test('isSplitChild detecta al nieto que NO tiene label split (caso #5803/#5805)', () => {
+    // Verificado en GitHub: #5800 tiene label `split`, pero #5803 y #5805 no.
+    // Son justo los nietos: apoyarse en el label los dejaria escapar.
+    const nieto = {
+        number: 5803,
+        title: '[Split de #5800] Persistencia del kernel',
+        labels: [{ name: 'blocked:dependencies' }, { name: 'Ready' }],
+    };
+    const r = sg.isSplitChild(nieto);
+    assert.equal(r.isChild, true);
+    assert.equal(r.parent, 5800);
+    assert.equal(r.source, 'titulo');
+});
+
+test('isSplitChild acepta labels split + blocked:dependencies como senal secundaria', () => {
+    const r = sg.isSplitChild({
+        number: 5800,
+        title: 'Titulo sin formato canonico',
+        labels: ['split', 'blocked:dependencies'],
+    });
+    assert.equal(r.isChild, true);
+    assert.equal(r.parent, null, 'por labels no se conoce el padre');
+    assert.equal(r.source, 'labels');
+});
+
+test('isSplitChild NO marca como hijo a un issue normal', () => {
+    const r = sg.isSplitChild({ number: 5837, title: 'Los splits salen casi siempre en 3 partes', labels: ['enhancement'] });
+    assert.equal(r.isChild, false);
+    assert.equal(r.parent, null);
+    assert.equal(r.source, null);
+});
+
+test('isSplitChild ignora el titulo que se apunta a si mismo', () => {
+    const r = sg.isSplitChild({ number: 100, title: '[Split de #100] auto-referencia', labels: [] });
+    assert.equal(r.isChild, false);
+});
+
+test('Gherkin (error): re-split de un hijo sin --force se detiene', () => {
+    const r = sg.checkResplit({
+        issue: { number: 5791, title: '[Split de #5440] Backend', labels: ['split'] },
+        force: false,
+    });
+    assert.equal(r.allowed, false);
+    assert.equal(r.reason, 'hijo-de-split-sin-force');
+    assert.equal(r.parent, 5440);
+    // Guideline UX: bloqueo = ⛔, y el mensaje dice las tres cosas.
+    assert.ok(r.message.startsWith('⛔'), 'un bloqueo usa ⛔');
+    assert.match(r.message, /#5791/, 'dice de que issue habla');
+    assert.match(r.message, /#5440/, 'dice de quien es hijo');
+    assert.match(r.message, /--force/, 'dice como seguir');
+});
+
+test('CA-3: --force sin justificacion escrita tampoco pasa', () => {
+    const r = sg.checkResplit({
+        issue: { number: 5791, title: '[Split de #5440] Backend' },
+        force: true,
+        justificacion: '   ',
+    });
+    assert.equal(r.allowed, false);
+    assert.equal(r.reason, 'force-sin-justificacion');
+    assert.ok(r.message.startsWith('⛔'));
+});
+
+test('CA-3: --force con justificacion escrita permite partir y deja constancia', () => {
+    const r = sg.checkResplit({
+        issue: { number: 5791, title: '[Split de #5440] Backend' },
+        force: true,
+        justificacion: 'El alcance crecio con el spike #5900, ahora son dos entregas independientes.',
+    });
+    assert.equal(r.allowed, true);
+    assert.equal(r.reason, 'force-justificado');
+    assert.ok(r.message.startsWith('⚠️'), 'no bloquea: es advertencia');
+    assert.match(r.message, /spike #5900/);
+});
+
+test('CA-3: un issue que no es hijo se parte sin friccion', () => {
+    const r = sg.checkResplit({ issue: { number: 5440, title: 'Kernel multi-producto', labels: ['Ready'] } });
+    assert.equal(r.allowed, true);
+    assert.equal(r.isChild, false);
+    assert.equal(r.message, null);
+});
+
+// =============================================================================
+// CA-4 — hijo L/XL es defecto del corte del padre
+// =============================================================================
+
+test('CA-4: un hijo L se reporta como defecto del split del padre, no se re-parte', () => {
+    const r = sg.reportOversizedChild({ issue: 5800, parent: 5793, size: 'L' });
+    assert.equal(r.oversized, true);
+    assert.ok(r.message.startsWith('⚠️'), 'guideline UX: no bloqueante = ⚠️');
+    assert.match(r.message, /#5793/, 'apunta al padre');
+    assert.match(r.message, /NO se resuelve partiendo/, 'prohibe la cascada');
+});
+
+test('CA-4: XL tambien dispara y es case-insensitive', () => {
+    assert.equal(sg.reportOversizedChild({ issue: 1, parent: 2, size: 'xl' }).oversized, true);
+});
+
+test('CA-4: un hijo S o M no dispara nada', () => {
+    assert.deepEqual(sg.reportOversizedChild({ issue: 1, parent: 2, size: 'S' }), { oversized: false, message: null });
+    assert.deepEqual(sg.reportOversizedChild({ issue: 1, parent: 2, size: 'M' }), { oversized: false, message: null });
+});
+
+// =============================================================================
+// CA-1 — criterio de corte declarado y justificacion del N
+// =============================================================================
+
+test('Gherkin (feliz): plan con criterio "por capa" y justificacion de 2 partes es valido', () => {
+    const r = sg.validateSplitPlan(planValido());
+    assert.equal(r.ok, true, `errores inesperados: ${r.errors.join(' | ')}`);
+    assert.equal(r.criterio.nombre, 'por capa');
+    assert.equal(r.n, 2);
+});
+
+test('CA-1: sin criterio de corte el plan se rechaza', () => {
+    const r = sg.validateSplitPlan(planValido({ criterio: '' }));
+    assert.equal(r.ok, false);
+    assert.ok(r.errors.some((e) => /Falta declarar el criterio de corte/.test(e)));
+});
+
+test('CA-1: el criterio por numero no se acepta — se escribe por nombre', () => {
+    // Guideline UX 3: `criterio 3` obliga a volver al skill para entenderlo.
+    const r = sg.validateSplitPlan(planValido({ criterio: 'criterio 3' }));
+    assert.equal(r.ok, false);
+    assert.ok(r.errors.some((e) => /no reconocido/.test(e) && /por nombre, no por número/.test(e)));
+});
+
+test('CA-1: los 5 criterios canonicos se resuelven, con y sin tildes', () => {
+    assert.equal(sg.resolveCutCriterion('por módulo').id, 'por-modulo');
+    assert.equal(sg.resolveCutCriterion('por modulo').id, 'por-modulo');
+    assert.equal(sg.resolveCutCriterion('POR CAPA').id, 'por-capa');
+    assert.equal(sg.resolveCutCriterion('por flujo').id, 'por-flujo');
+    assert.equal(sg.resolveCutCriterion('por funcionalidad entregable').id, 'por-funcionalidad');
+    assert.equal(sg.resolveCutCriterion('por tamaño objetivo').id, 'por-tamano');
+    assert.equal(sg.resolveCutCriterion('por vibra'), null, 'un criterio inventado no resuelve');
+    assert.equal(sg.CUT_CRITERIA.length, 5);
+});
+
+test('CA-1: sin justificacion del N el plan se rechaza', () => {
+    const r = sg.validateSplitPlan(planValido({ justificacionN: '' }));
+    assert.equal(r.ok, false);
+    assert.ok(r.errors.some((e) => /Falta la justificación del N/.test(e)));
+});
+
+test('CA-1: elegir el N "por default" esta explicitamente prohibido', () => {
+    const r = sg.validateSplitPlan(planValido({ justificacionN: 'Son 3 porque los splits se hacen asi por default.' }));
+    assert.equal(r.ok, false);
+    assert.ok(r.errors.some((e) => /invoca un default/.test(e)));
+});
+
+test('CA-1: la justificacion del N es una linea, no un parrafo', () => {
+    const r = sg.validateSplitPlan(planValido({ justificacionN: 'x'.repeat(sg.MAX_JUSTIFICACION_N_CHARS + 1) }));
+    assert.equal(r.ok, false);
+    assert.ok(r.errors.some((e) => /campo de auditoría/.test(e)));
+});
+
+test('un split de una sola parte no es un split', () => {
+    const r = sg.validateSplitPlan(planValido({ partes: [{ modulo: 'backend', capa: 'backend', flujo: 'perfil' }] }));
+    assert.equal(r.ok, false);
+    assert.ok(r.errors.some((e) => /al menos 2 partes/.test(e)));
+});
+
+// =============================================================================
+// CA-2 — partes indistinguibles
+// =============================================================================
+
+test('Gherkin (error): 3 partes que comparten modulo, capa y flujo se rechazan', () => {
+    const r = sg.validateSplitPlan(
+        planValido({
+            partes: [
+                { titulo: 'Parte 1', modulo: 'app', capa: 'ui', flujo: 'onboarding' },
+                { titulo: 'Parte 2', modulo: 'app', capa: 'ui', flujo: 'onboarding' },
+                { titulo: 'Parte 3', modulo: 'app', capa: 'ui', flujo: 'onboarding' },
+            ],
+        }),
+    );
+    assert.equal(r.ok, false);
+    assert.ok(r.errors.some((e) => /Corte no justificado/.test(e) && /No se crea ninguna sub-historia/.test(e)));
+});
+
+test('CA-2: la comparacion ignora mayusculas, tildes y espacios sobrantes', () => {
+    const r = sg.validateSplitPlan(
+        planValido({
+            partes: [
+                { modulo: ' App ', capa: 'UI', flujo: 'Sesión' },
+                { modulo: 'app', capa: 'ui', flujo: 'sesion' },
+            ],
+        }),
+    );
+    assert.equal(r.ok, false);
+    assert.ok(r.errors.some((e) => /Corte no justificado/.test(e)));
+});
+
+test('CA-2: basta con que UN eje difiera para que el corte sea auditable', () => {
+    const r = sg.validateSplitPlan(
+        planValido({
+            criterio: 'por flujo',
+            justificacionN: 'Dos flujos de usuario distintos; no hay un tercero en el issue.',
+            partes: [
+                { modulo: 'app', capa: 'ui', flujo: 'alta' },
+                { modulo: 'app', capa: 'ui', flujo: 'baja' },
+            ],
+        }),
+    );
+    assert.equal(r.ok, true, `errores inesperados: ${r.errors.join(' | ')}`);
+});
+
+test('CA-2: partes sin modulo/capa/flujo declarados no se pueden auditar', () => {
+    const r = sg.validateSplitPlan(planValido({ partes: [{ titulo: 'A' }, { titulo: 'B' }] }));
+    assert.equal(r.ok, false);
+    assert.ok(r.errors.some((e) => /no declaran módulo\/capa\/flujo/.test(e)));
+});
+
+// =============================================================================
+// CA-5 — registro idempotente en el body del padre
+// =============================================================================
+
+test('CA-5: el registro se agrega al final sin pisar el body original', () => {
+    const body = '## Objetivo\n\nUnificar el kernel.\n';
+    const out = sg.upsertSplitRegistro(body, {
+        criterio: 'por capa',
+        n: 2,
+        justificacionN: 'UI y backend son entregas separables; no hay tercera capa.',
+        hijas: [5791, 5792],
+    });
+    assert.match(out, /## Objetivo/, 'conserva el body original');
+    assert.match(out, /Unificar el kernel\./);
+    assert.match(out, /## Registro del split/);
+    assert.match(out, /\*\*Criterio de corte\*\*: por capa/);
+    assert.match(out, /\*\*N elegido\*\*: 2/);
+    assert.match(out, /#5791, #5792/);
+});
+
+test('CA-5: re-ejecutar el split ACTUALIZA el bloque, no apila bloques contradictorios', () => {
+    const body = '## Objetivo\n\nUnificar el kernel.\n';
+    const primera = sg.upsertSplitRegistro(body, {
+        criterio: 'por capa',
+        n: 3,
+        justificacionN: 'Primera corrida.',
+        hijas: [1, 2, 3],
+    });
+    const segunda = sg.upsertSplitRegistro(primera, {
+        criterio: 'por módulo',
+        n: 2,
+        justificacionN: 'Segunda corrida: el corte por capa dejaba partes indistinguibles.',
+        hijas: [10, 11],
+    });
+
+    const ocurrencias = segunda.split(sg.REGISTRO_HEADING).length - 1;
+    assert.equal(ocurrencias, 1, 'hay un solo bloque de registro');
+    assert.match(segunda, /por módulo/);
+    assert.doesNotMatch(segunda, /Primera corrida/, 'el registro viejo se reemplazo');
+    assert.match(segunda, /## Objetivo/, 'el body original sigue intacto');
+});
+
+test('CA-5: aplicar el mismo registro dos veces da el mismo resultado (idempotencia estricta)', () => {
+    const data = { criterio: 'por flujo', n: 2, justificacionN: 'Dos flujos.', hijas: [7, 8] };
+    const una = sg.upsertSplitRegistro('## Objetivo\n\nTexto.\n', data);
+    const dos = sg.upsertSplitRegistro(una, data);
+    assert.equal(dos, una);
+});
+
+test('CA-5: el registro respeta las secciones que vienen DESPUES en el body', () => {
+    const body = [
+        '## Objetivo',
+        '',
+        'Texto.',
+        '',
+        '## Registro del split',
+        '',
+        '- **Criterio de corte**: por capa',
+        '',
+        '## Notas técnicas',
+        '',
+        'No tocar el kernel.',
+        '',
+    ].join('\n');
+    const out = sg.upsertSplitRegistro(body, { criterio: 'por flujo', n: 2, justificacionN: 'Dos flujos.' });
+    assert.match(out, /## Notas técnicas/, 'la seccion posterior sobrevive');
+    assert.match(out, /No tocar el kernel\./);
+    assert.match(out, /por flujo/);
+    assert.doesNotMatch(out, /por capa/);
+});
+
+test('CA-5: sobre un body vacio el registro se crea igual, sin separador colgado', () => {
+    const out = sg.upsertSplitRegistro('', { criterio: 'por capa', n: 2, justificacionN: 'Dos capas.' });
+    assert.ok(out.startsWith(sg.REGISTRO_HEADING), 'sin `---` inicial huerfano');
+});
+
+test('CA-5: un criterio no canonico se registra tal cual, sin inventar uno', () => {
+    const out = sg.renderSplitRegistro({ criterio: 'por vibra', n: 2, justificacionN: 'x' });
+    assert.match(out, /\*\*Criterio de corte\*\*: por vibra/);
+});

--- a/.pipeline/lib/__tests__/split-guard.test.js
+++ b/.pipeline/lib/__tests__/split-guard.test.js
@@ -433,3 +433,180 @@ test('SEC: checkResplit sigue autorizando un issue normal bien formado', () => {
     assert.strictEqual(r.allowed, true);
     assert.strictEqual(r.isChild, false);
 });
+
+// =============================================================================
+// Hardening post-review de codigo (#5837, rebote de `aprobacion`)
+//
+// Dos defectos de correctitud reproducidos empiricamente sobre el modulo:
+//   1. La frontera del bloque del registro era `^##\s`, que NO matchea `### `
+//      (despues de `##` viene `#`, no whitespace). Toda subseccion h3+ colgada
+//      del registro desaparecia en silencio, contradiciendo el contrato del
+//      JSDoc ("Nunca pisa el body original"). Tampoco respetaba bloques de
+//      codigo: el upsert entraba al fence y lo dejaba sin cerrar.
+//   2. El N registrado no se cruzaba contra nada: validateSplitPlan derivaba n
+//      de partes.length e IGNORABA plan.n, mientras renderSplitRegistro hacia
+//      lo contrario. Un plan de 2 partes podia registrar "N elegido: 3", y el N
+//      registrado es JUSTO el entregable de CA-1/CA-5.
+// =============================================================================
+
+const FENCE = '`'.repeat(3);
+
+test('CA-5: una subseccion h3 colgada del registro NO se borra al actualizarlo', () => {
+    const body = [
+        '## Objetivo',
+        '',
+        'Texto.',
+        '',
+        '## Registro del split',
+        '',
+        '- **Criterio de corte**: por capa',
+        '',
+        '### Detalle del corte',
+        '',
+        'Cosas importantes que nadie quiere perder.',
+        '',
+        '### Otra subseccion',
+        '',
+        'Mas contexto.',
+        '',
+        '## Notas técnicas',
+        '',
+        'No tocar el kernel.',
+    ].join('\n');
+
+    const out = sg.upsertSplitRegistro(body, { criterio: 'por flujo', n: 2, justificacionN: 'Dos flujos.' });
+
+    assert.match(out, /### Detalle del corte/, 'la subseccion h3 sobrevive');
+    assert.match(out, /Cosas importantes que nadie quiere perder\./);
+    assert.match(out, /### Otra subseccion/, 'la segunda subseccion h3 sobrevive');
+    assert.match(out, /Mas contexto\./);
+    assert.match(out, /## Notas técnicas/, 'la seccion h2 posterior sigue viva');
+    assert.match(out, /por flujo/, 'el registro si se actualizo');
+    assert.doesNotMatch(out, /por capa/, 'el registro viejo se reemplazo');
+});
+
+test('CA-5: un bloque de codigo con el formato documentado no se pisa ni queda sin cerrar', () => {
+    const body = [
+        '## Objetivo',
+        '',
+        'El bloque que queda en el padre se ve asi:',
+        '',
+        FENCE + 'markdown',
+        '## Registro del split',
+        '',
+        '- **Criterio de corte**: por capa',
+        '- **N elegido**: 2',
+        FENCE,
+        '',
+        '## Notas técnicas',
+        '',
+        'Fin.',
+    ].join('\n');
+
+    const out = sg.upsertSplitRegistro(body, { criterio: 'por módulo', n: 2, justificacionN: 'Dos módulos.' });
+
+    const fences = (out.match(new RegExp(FENCE, 'g')) || []).length;
+    assert.strictEqual(fences % 2, 0, `los fences quedan balanceados, hay ${fences}`);
+    assert.match(out, /## Notas técnicas/, 'lo que venia despues del fence sobrevive');
+    assert.match(out, /Fin\./);
+    assert.match(out, /por módulo/, 'el registro real se agrego');
+    assert.match(out, /- \*\*Criterio de corte\*\*: por capa/, 'el ejemplo documentado quedo intacto');
+});
+
+test('CA-5: un registro dentro de un fence no se confunde con el registro real', () => {
+    const body = ['# Doc', '', FENCE, '## Registro del split', FENCE, ''].join('\n');
+    const data = { criterio: 'por capa', n: 2, justificacionN: 'Dos capas.' };
+    const primera = sg.upsertSplitRegistro(body, data);
+    const segunda = sg.upsertSplitRegistro(primera, data);
+
+    assert.strictEqual(segunda, primera, 'sigue siendo idempotente con un fence de por medio');
+    assert.match(primera, /\*\*N elegido\*\*: 2/);
+});
+
+test('CA-1: un N declarado que no coincide con las partes se rechaza', () => {
+    const r = sg.validateSplitPlan({
+        criterio: 'por capa',
+        n: 3,
+        justificacionN: 'UI y backend son separables.',
+        partes: [
+            { titulo: 'A', modulo: 'app', capa: 'ui', flujo: 'alta' },
+            { titulo: 'B', modulo: 'backend', capa: 'api', flujo: 'alta' },
+        ],
+    });
+
+    assert.strictEqual(r.ok, false, 'un N que miente no puede pasar la validacion');
+    assert.ok(
+        r.errors.some((e) => /N declarado \(3\)[\s\S]*no coincide[\s\S]*\(2\)/.test(e)),
+        r.errors.join(' | '),
+    );
+});
+
+test('CA-1: un N declarado coherente con las partes pasa', () => {
+    const r = sg.validateSplitPlan({
+        criterio: 'por capa',
+        n: 2,
+        justificacionN: 'UI y backend son separables.',
+        partes: [
+            { titulo: 'A', modulo: 'app', capa: 'ui', flujo: 'alta' },
+            { titulo: 'B', modulo: 'backend', capa: 'api', flujo: 'alta' },
+        ],
+    });
+    assert.strictEqual(r.ok, true, r.errors.join(' | '));
+    assert.strictEqual(r.n, 2);
+});
+
+test('CA-1: un N no numerico se rechaza en vez de colarse como 0', () => {
+    const r = sg.validateSplitPlan({
+        criterio: 'por capa',
+        n: 'tres',
+        justificacionN: 'Dos capas.',
+        partes: [
+            { titulo: 'A', modulo: 'app', capa: 'ui', flujo: 'alta' },
+            { titulo: 'B', modulo: 'backend', capa: 'api', flujo: 'alta' },
+        ],
+    });
+    assert.strictEqual(r.ok, false);
+    assert.ok(r.errors.some((e) => /entero positivo/.test(e)), r.errors.join(' | '));
+});
+
+test('CA-5: el N del registro se deriva de las hijas reales, no del n declarado', () => {
+    const out = sg.renderSplitRegistro({
+        criterio: 'por capa',
+        n: 3,
+        justificacionN: 'UI y backend son separables.',
+        hijas: [111, 222],
+    });
+
+    assert.match(out, /\*\*N elegido\*\*: 2/, 'el N registrado describe las hijas que existen');
+    assert.doesNotMatch(out, /\*\*N elegido\*\*: 3/);
+    assert.match(out, /N declarado inconsistente/, 'la discrepancia queda visible, no tapada');
+    assert.match(out, /#111, #222/);
+});
+
+test('CA-5: con partes y hijas coherentes no aparece ninguna advertencia', () => {
+    const out = sg.renderSplitRegistro({
+        criterio: 'por capa',
+        n: 2,
+        justificacionN: 'Dos capas.',
+        partes: [{ titulo: 'A' }, { titulo: 'B' }],
+        hijas: [111, 222],
+    });
+    assert.match(out, /\*\*N elegido\*\*: 2/);
+    assert.doesNotMatch(out, /inconsistente/);
+});
+
+test('CA-2: un plan de 3 partes con 2 indistinguibles se rechaza (no solo si TODAS lo son)', () => {
+    const r = sg.validateSplitPlan({
+        criterio: 'por capa',
+        justificacionN: 'Tres partes.',
+        partes: [
+            { titulo: 'A', modulo: 'app', capa: 'ui', flujo: 'alta' },
+            { titulo: 'B', modulo: 'app', capa: 'ui', flujo: 'alta' },
+            { titulo: 'C', modulo: 'backend', capa: 'api', flujo: 'alta' },
+        ],
+    });
+
+    assert.strictEqual(r.ok, false, 'dos partes identicas son el mismo issue escrito dos veces');
+    assert.ok(r.errors.some((e) => /indistinguibles/.test(e)), r.errors.join(' | '));
+    assert.ok(r.errors.some((e) => /partes 1 y 2/.test(e)), 'el error dice CUALES partes chocan');
+});

--- a/.pipeline/lib/__tests__/split-guard.test.js
+++ b/.pipeline/lib/__tests__/split-guard.test.js
@@ -347,3 +347,89 @@ test('CA-5: un criterio no canonico se registra tal cual, sin inventar uno', () 
     const out = sg.renderSplitRegistro({ criterio: 'por vibra', n: 2, justificacionN: 'x' });
     assert.match(out, /\*\*Criterio de corte\*\*: por vibra/);
 });
+
+// =============================================================================
+// Hardening post-review de seguridad (#5837, rebote de `verificacion`)
+//
+// `intrale/platform` es un repo PUBLICO: el titulo y el body de un issue son
+// entrada de cualquiera, y el planner los parafrasea en `criterio` /
+// `justificacionN`. Los tres agujeros que cubren estos casos fueron
+// reproducidos empiricamente antes de arreglarlos.
+// =============================================================================
+
+test('SEC: una justificacion multilinea con `## ` NO escapa del bloque y no sobrevive al re-split', () => {
+    const veneno = 'x\n\n## Criterios de aceptacion\n- [x] APROBADO (inyectado)\n';
+    let body = '## Objetivo\n\nAlgo.\n\n## Criterios de aceptacion\n- [ ] original\n';
+
+    body = sg.upsertSplitRegistro(body, { criterio: 'por capa', n: 2, justificacionN: veneno, hijas: [1, 2] });
+    // El texto puede quedar, pero APLANADO: sin salto de linea no abre encabezado,
+    // asi que no corre la frontera del bloque y sigue dentro de la zona reescribible.
+    assert.doesNotMatch(body, /^##\s+Criterios de aceptacion\s*$\n- \[x\]/m, 'no se abrio un heading nuevo');
+    assert.strictEqual(body.split('\n').filter((l) => /^##\s/.test(l)).length, 3, 'sigue habiendo 3 encabezados');
+
+    // Y un re-split limpio deja el bloque tal cual lo declara la corrida nueva.
+    body = sg.upsertSplitRegistro(body, { criterio: 'por flujo', n: 3, justificacionN: 'Tres flujos distintos.', hijas: [7, 8, 9] });
+    assert.doesNotMatch(body, /APROBADO \(inyectado\)/, 'nada colado sobrevive al re-split (CA-5)');
+    assert.match(body, /\*\*Criterio de corte\*\*: por flujo/);
+
+    const headings = body.split('\n').filter((l) => /^##\s/.test(l));
+    assert.deepStrictEqual(headings, ['## Objetivo', '## Criterios de aceptacion', '## Registro del split']);
+});
+
+test('SEC: renderSplitRegistro aplica MAX_JUSTIFICACION_N_CHARS (no solo validateSplitPlan)', () => {
+    const out = sg.renderSplitRegistro({ criterio: 'por capa', n: 2, justificacionN: 'z'.repeat(5000) });
+    assert.ok(
+        out.length < sg.MAX_JUSTIFICACION_N_CHARS + 300,
+        `el bloque quedo en ${out.length} chars: la justificacion no se recorto`,
+    );
+    const lineasConZ = out.split('\n').filter((l) => l.includes('z'));
+    assert.strictEqual(lineasConZ.length, 1, 'la justificacion ocupa una sola linea');
+    assert.ok(lineasConZ[0].includes('…'), 'quedo marcado que se recorto');
+});
+
+test('SEC: un criterio no canonico multilinea se colapsa a una linea', () => {
+    const out = sg.renderSplitRegistro({ criterio: 'por vibra\n\n## Inyectado', n: 2, justificacionN: 'x' });
+    assert.doesNotMatch(out, /^## Inyectado/m);
+    assert.match(out, /\*\*Criterio de corte\*\*: por vibra ## Inyectado/);
+});
+
+test('SEC: validateSplitPlan rechaza justificacionN con saltos de linea o encabezado', () => {
+    const partes = [
+        { titulo: 'a', modulo: 'backend', capa: 'backend', flujo: 'perfil' },
+        { titulo: 'b', modulo: 'app', capa: 'ui', flujo: 'perfil' },
+    ];
+    const r = sg.validateSplitPlan({
+        criterio: 'por capa',
+        justificacionN: 'x\n\n## Criterios de aceptacion\n- [x] APROBADO',
+        partes,
+    });
+    assert.strictEqual(r.ok, false);
+    assert.ok(r.errors.some((e) => /saltos de l[ií]nea/.test(e)), r.errors.join(' | '));
+});
+
+test('SEC: validateSplitPlan rechaza un criterio con encabezado markdown', () => {
+    const r = sg.validateSplitPlan({
+        criterio: 'por capa\n## Inyectado',
+        justificacionN: 'Dos capas separables.',
+        partes: [
+            { titulo: 'a', modulo: 'backend', capa: 'backend', flujo: 'perfil' },
+            { titulo: 'b', modulo: 'app', capa: 'ui', flujo: 'perfil' },
+        ],
+    });
+    assert.strictEqual(r.ok, false);
+    assert.ok(r.errors.some((e) => /saltos de l[ií]nea/.test(e)), r.errors.join(' | '));
+});
+
+test('SEC: checkResplit es fail-closed ante entrada malformada, no fail-open', () => {
+    for (const entrada of [undefined, null, 'x', 42, { title: null, labels: 'split' }, {}]) {
+        const r = sg.checkResplit({ issue: entrada });
+        assert.strictEqual(r.allowed, false, `entrada ${JSON.stringify(entrada)} no puede autorizar el split`);
+        assert.strictEqual(r.reason, 'entrada-invalida');
+    }
+});
+
+test('SEC: checkResplit sigue autorizando un issue normal bien formado', () => {
+    const r = sg.checkResplit({ issue: { number: 5837, title: 'Un issue normal', labels: ['Ready'] } });
+    assert.strictEqual(r.allowed, true);
+    assert.strictEqual(r.isChild, false);
+});

--- a/.pipeline/lib/split-guard.js
+++ b/.pipeline/lib/split-guard.js
@@ -1,0 +1,461 @@
+// =============================================================================
+// split-guard.js — Issue #5837
+//
+// Frenos verificables del split de historias. Nace de un patrón observado en la
+// ola 9.4: los splits salían casi siempre en 3 partes (#5440 → #5791-5793 →
+// #5794-5805, y todavía más hondo: #5793 → #5800 → #5803/#5805). El 3 no venía
+// de ningún criterio: era el default implícito del modelo, reforzado porque
+// `.pipeline/roles/planner.md` decía literalmente "dividí en 2-3 historias".
+//
+// Este módulo NO decide cómo cortar — eso sigue siendo juicio del planner. Lo
+// que hace es convertir en verificable lo que antes era doctrina suelta:
+//
+//   SG-1  El corte se declara: criterio (uno de los 5 canónicos) + por qué N.
+//   SG-2  Un plan cuyas partes comparten módulo, capa y flujo no es un corte:
+//         es el mismo issue escrito N veces → se rechaza sin crear nada.
+//   SG-3  Un issue que ya es hijo de un split no se re-parte sin `--force`
+//         + justificación escrita. Así se corta la cascada padre→hijo→nieto.
+//   SG-4  Un hijo que sale L/XL es un defecto del corte del PADRE, no una
+//         invitación a partir de nuevo: se reporta hacia arriba.
+//   SG-5  El registro del corte en el body del padre es idempotente: re-correr
+//         el split actualiza el bloque, no apila bloques contradictorios.
+//
+// Detección de hijo (SG-3): ÚNICO criterio robusto = el título canónico
+// `^[Split de #N]`. El label `split` NO sirve para esto por dos razones
+// verificadas sobre GitHub:
+//   a) está aplicado de forma inconsistente — #5800 lo tiene, #5803 y #5805 no,
+//      y son justo los nietos, el caso que más duele;
+//   b) en `pulpo.js#isSplitParent` el label marca al PADRE paraguas, así que
+//      usarlo para detectar hijos es un falso positivo invertido.
+// Por eso se reusa el MISMO patrón ya validado y testeado en
+// `split-orphan-reconciler.js` (SPLIT_TITLE_RE) en vez de rodar uno nuevo.
+//
+// Módulo PURO: sin red, sin filesystem, sin estado. Todo entra por parámetro.
+//
+// Ejecutar sus tests:
+//   node --test .pipeline/lib/__tests__/split-guard.test.js
+// =============================================================================
+
+'use strict';
+
+// Reuso deliberado del patrón canónico del reconciler (#5516) en vez de
+// duplicarlo: si algún día cambia el formato del título, cambia en un solo lado.
+const { SPLIT_TITLE_RE } = require('./split-orphan-reconciler');
+
+// -----------------------------------------------------------------------------
+// SG-1 — Catálogo de criterios de corte
+// -----------------------------------------------------------------------------
+// Son los mismos 5 que ya listaba `/planner split` (SP3). Acá quedan con `id`
+// legible para poder validarlos por nombre. Se escriben SIEMPRE por nombre
+// ("por capa"), nunca por número ("criterio 3"): el número obliga a volver al
+// skill para entender qué se decidió.
+const CUT_CRITERIA = Object.freeze([
+    Object.freeze({
+        id: 'por-modulo',
+        nombre: 'por módulo',
+        descripcion: 'separar backend de app, o módulos independientes (backend, users, app)',
+    }),
+    Object.freeze({
+        id: 'por-funcionalidad',
+        nombre: 'por funcionalidad entregable',
+        descripcion: 'cada sub-historia tiene valor por sí misma',
+    }),
+    Object.freeze({
+        id: 'por-capa',
+        nombre: 'por capa',
+        descripcion: 'el issue abarca UI + backend y se separa por capa',
+    }),
+    Object.freeze({
+        id: 'por-flujo',
+        nombre: 'por flujo',
+        descripcion: 'múltiples flujos de usuario, uno por historia',
+    }),
+    Object.freeze({
+        id: 'por-tamano',
+        nombre: 'por tamaño objetivo',
+        descripcion: 'cortar para que cada parte quede en S o M',
+    }),
+]);
+
+const CUT_CRITERIA_IDS = Object.freeze(CUT_CRITERIA.map((c) => c.id));
+const CUT_CRITERIA_NOMBRES = Object.freeze(CUT_CRITERIA.map((c) => c.nombre));
+
+// Tamaños que, en un hijo recién creado, delatan que el corte del padre estuvo mal.
+const OVERSIZED_SIZES = Object.freeze(['L', 'XL']);
+
+// Mínimo de partes para que "split" signifique algo. Partir en 1 no es partir.
+const MIN_PARTS = 2;
+
+// Largo máximo del "por qué N y no N±1". Es un campo de auditoría que alguien va
+// a leer en diagonal sobre doce issues: una línea, no un párrafo.
+const MAX_JUSTIFICACION_N_CHARS = 240;
+
+// Encabezado EXACTO del bloque que se inyecta en el body del padre (SG-5).
+// Es la ancla de la idempotencia: para actualizar hay que reconocerlo.
+const REGISTRO_HEADING = '## Registro del split';
+
+// -----------------------------------------------------------------------------
+// Helpers internos
+// -----------------------------------------------------------------------------
+
+function toPositiveInt(value) {
+    const n = typeof value === 'number' ? value : Number.parseInt(String(value ?? ''), 10);
+    return Number.isInteger(n) && n > 0 ? n : null;
+}
+
+function normalizeText(value) {
+    return typeof value === 'string' ? value.trim() : '';
+}
+
+// Normaliza para COMPARAR (no para mostrar): minúsculas, sin tildes, sin espacios
+// redundantes. Sirve tanto para matchear el criterio de corte escrito a mano como
+// para detectar partes indistinguibles ("Backend " vs "backend").
+function comparableText(value) {
+    return normalizeText(value)
+        .toLowerCase()
+        .normalize('NFD')
+        .replace(/[̀-ͯ]/g, '')
+        .replace(/\s+/g, ' ');
+}
+
+/**
+ * Resuelve un criterio de corte escrito por el agente (id, nombre con o sin
+ * tildes, "modulo", "por capa"…) contra el catálogo canónico.
+ *
+ * @param {string} value
+ * @returns {{id: string, nombre: string, descripcion: string}|null}
+ */
+function resolveCutCriterion(value) {
+    const needle = comparableText(value);
+    if (!needle) return null;
+
+    // Un número suelto ("3", "criterio 3") se rechaza a propósito: el criterio se
+    // nombra, no se numera (guideline UX del issue).
+    if (/^(criterio\s*)?\d+$/.test(needle)) return null;
+
+    const bare = needle.replace(/^por\s+/, '');
+    return (
+        CUT_CRITERIA.find((c) => {
+            const id = comparableText(c.id).replace(/-/g, ' ');
+            const nombre = comparableText(c.nombre);
+            return (
+                needle === id ||
+                needle === nombre ||
+                bare === id.replace(/^por\s+/, '') ||
+                bare === nombre.replace(/^por\s+/, '')
+            );
+        }) || null
+    );
+}
+
+// -----------------------------------------------------------------------------
+// SG-3 — ¿Este issue ya es hijo de un split?
+// -----------------------------------------------------------------------------
+
+/**
+ * Extrae el número del padre declarado en el título canónico `[Split de #N]`.
+ *
+ * @param {string} title
+ * @returns {number|null} número del padre, o null si el título no es canónico
+ */
+function parseSplitParent(title) {
+    const m = SPLIT_TITLE_RE.exec(normalizeText(title));
+    if (!m) return null;
+    return toPositiveInt(m[1]);
+}
+
+/**
+ * Clasifica un issue como hijo de split o no.
+ *
+ * El label `split` se acepta como señal SECUNDARIA sólo cuando viene acompañado
+ * de `blocked:dependencies` (así lo redactó el CA-3 del issue), pero en ese caso
+ * no hay padre conocido — y se deja constancia de que la señal es débil, porque
+ * ese mismo label marca al padre paraguas en `pulpo.js#isSplitParent`.
+ *
+ * @param {{number?: number|string, title?: string, labels?: Array}} issue
+ * @returns {{isChild: boolean, parent: number|null, source: 'titulo'|'labels'|null}}
+ */
+function isSplitChild(issue) {
+    const none = { isChild: false, parent: null, source: null };
+    if (!issue || typeof issue !== 'object') return none;
+
+    const self = toPositiveInt(issue.number);
+    const parent = parseSplitParent(issue.title);
+
+    // Un issue titulado "[Split de #X]" que apunta a sí mismo es basura, no un hijo.
+    if (parent && parent !== self) {
+        return { isChild: true, parent, source: 'titulo' };
+    }
+
+    const labels = Array.isArray(issue.labels)
+        ? issue.labels
+              .map((l) => comparableText(typeof l === 'string' ? l : l && l.name))
+              .filter(Boolean)
+        : [];
+
+    if (labels.includes('split') && labels.includes('blocked:dependencies')) {
+        return { isChild: true, parent: null, source: 'labels' };
+    }
+
+    return none;
+}
+
+/**
+ * SG-3 — Decide si se permite partir un issue que ya es hijo de un split.
+ *
+ * @param {object} params
+ * @param {object} params.issue          — `{ number, title, labels }`
+ * @param {boolean} [params.force]       — se pasó `--force`
+ * @param {string} [params.justificacion] — justificación escrita que acompaña al `--force`
+ * @returns {{allowed: boolean, isChild: boolean, parent: number|null, reason: string|null, message: string|null}}
+ */
+function checkResplit({ issue, force = false, justificacion = '' } = {}) {
+    const child = isSplitChild(issue);
+    const number = toPositiveInt(issue && issue.number);
+
+    if (!child.isChild) {
+        return { allowed: true, isChild: false, parent: null, reason: null, message: null };
+    }
+
+    const padre = child.parent ? `#${child.parent}` : 'un split previo';
+    const self = number ? `#${number}` : '<N>';
+
+    if (!force) {
+        return {
+            allowed: false,
+            isChild: true,
+            parent: child.parent,
+            reason: 'hijo-de-split-sin-force',
+            message: [
+                `⛔ Issue ${self} ya es hijo del split de ${padre} — no se re-parte automáticamente.`,
+                `Si el corte del padre quedó mal, reportalo sobre ${padre}.`,
+                `Para partir igual: /planner split ${number || '<N>'} --force "<justificación escrita>"`,
+            ].join('\n'),
+        };
+    }
+
+    if (!normalizeText(justificacion)) {
+        return {
+            allowed: false,
+            isChild: true,
+            parent: child.parent,
+            reason: 'force-sin-justificacion',
+            message: [
+                `⛔ Issue ${self} es hijo del split de ${padre} y \`--force\` vino sin justificación escrita.`,
+                'El freno de cascada exige decir por qué este hijo se parte igual.',
+                `Reintentá: /planner split ${number || '<N>'} --force "<justificación escrita>"`,
+            ].join('\n'),
+        };
+    }
+
+    return {
+        allowed: true,
+        isChild: true,
+        parent: child.parent,
+        reason: 'force-justificado',
+        message: `⚠️ Issue ${self} es hijo del split de ${padre}; se parte igual por \`--force\`: ${normalizeText(justificacion)}`,
+    };
+}
+
+// -----------------------------------------------------------------------------
+// SG-4 — Un hijo L/XL es defecto del corte del padre
+// -----------------------------------------------------------------------------
+
+/**
+ * @param {object} params
+ * @param {number|string} params.issue  — el hijo
+ * @param {number|string} [params.parent]
+ * @param {string} params.size          — S / M / L / XL
+ * @returns {{oversized: boolean, message: string|null}}
+ */
+function reportOversizedChild({ issue, parent, size } = {}) {
+    const normalized = normalizeText(size).toUpperCase();
+    if (!OVERSIZED_SIZES.includes(normalized)) {
+        return { oversized: false, message: null };
+    }
+
+    const self = toPositiveInt(issue) ? `#${toPositiveInt(issue)}` : '<hijo>';
+    const padre = toPositiveInt(parent) ? `#${toPositiveInt(parent)}` : 'su padre';
+
+    return {
+        oversized: true,
+        message: [
+            `⚠️ El hijo ${self} quedó clasificado ${normalized} — el corte del split de ${padre} estuvo mal.`,
+            `Esto NO se resuelve partiendo ${self} de nuevo: se reporta como defecto sobre ${padre} para rehacer el corte.`,
+        ].join('\n'),
+    };
+}
+
+// -----------------------------------------------------------------------------
+// SG-1 + SG-2 — Validación del plan de split
+// -----------------------------------------------------------------------------
+
+/**
+ * Valida un plan de split ANTES de crear un solo issue.
+ *
+ * @param {object} plan
+ * @param {string} plan.criterio          — criterio de corte, por nombre
+ * @param {string} plan.justificacionN    — por qué N y no N±1, en una línea
+ * @param {Array<{titulo?: string, modulo?: string, capa?: string, flujo?: string}>} plan.partes
+ * @returns {{ok: boolean, errors: string[], criterio: object|null, n: number}}
+ */
+function validateSplitPlan(plan = {}) {
+    const errors = [];
+    const partes = Array.isArray(plan.partes) ? plan.partes : [];
+    const n = partes.length;
+
+    // --- SG-1: el criterio de corte se declara y es uno de los canónicos ------
+    const criterio = resolveCutCriterion(plan.criterio);
+    if (!normalizeText(plan.criterio)) {
+        errors.push(
+            `⛔ Falta declarar el criterio de corte. Elegí uno por nombre: ${CUT_CRITERIA_NOMBRES.join(', ')}.`,
+        );
+    } else if (!criterio) {
+        errors.push(
+            `⛔ Criterio de corte no reconocido: "${normalizeText(plan.criterio)}". Escribilo por nombre, no por número: ${CUT_CRITERIA_NOMBRES.join(', ')}.`,
+        );
+    }
+
+    // --- SG-1: por qué N y no N±1 --------------------------------------------
+    const justificacionN = normalizeText(plan.justificacionN);
+    if (!justificacionN) {
+        errors.push(
+            `⛔ Falta la justificación del N: por qué ${n || 'N'} partes y no ${n ? n - 1 : 'N-1'} ni ${n ? n + 1 : 'N+1'}. Una línea alcanza.`,
+        );
+    } else if (justificacionN.length > MAX_JUSTIFICACION_N_CHARS) {
+        errors.push(
+            `⛔ La justificación del N tiene ${justificacionN.length} caracteres: es un campo de auditoría, resumila en ${MAX_JUSTIFICACION_N_CHARS} o menos.`,
+        );
+    } else if (/\bpor\s+default\b|\bpor\s+defecto\b|\bcomo\s+siempre\b|\bt[ií]picamente\b/i.test(justificacionN)) {
+        // El issue lo pide explícito: prohibido elegir la cantidad "por default".
+        errors.push(
+            '⛔ La justificación del N invoca un default ("por default" / "como siempre"). El N tiene que salir del criterio de corte, no de la costumbre.',
+        );
+    }
+
+    // --- Cantidad de partes ---------------------------------------------------
+    if (n < MIN_PARTS) {
+        errors.push(
+            `⛔ Un split necesita al menos ${MIN_PARTS} partes; el plan trae ${n}. Si no hay corte posible, dejá el issue entero.`,
+        );
+    }
+
+    // --- SG-2: partes indistinguibles ----------------------------------------
+    // Si TODAS las partes comparten módulo, capa y flujo, no hay corte: es el
+    // mismo issue escrito N veces. Se rechaza sin crear ninguna sub-historia.
+    if (n >= MIN_PARTS) {
+        const ejes = ['modulo', 'capa', 'flujo'];
+        const firma = (parte) => ejes.map((eje) => comparableText(parte && parte[eje])).join('|');
+        const primeras = firma(partes[0]);
+        const todasIguales = partes.every((p) => firma(p) === primeras);
+        const algunEjeDeclarado = ejes.some((eje) => partes.some((p) => comparableText(p && p[eje])));
+
+        if (todasIguales && algunEjeDeclarado) {
+            errors.push(
+                '⛔ Corte no justificado: las partes comparten módulo, capa y flujo — es el mismo issue escrito ' +
+                    `${n} veces. Rehacé el corte con otro criterio o dejá el issue entero. No se crea ninguna sub-historia.`,
+            );
+        } else if (!algunEjeDeclarado) {
+            errors.push(
+                '⛔ Las partes no declaran módulo/capa/flujo, así que el corte no se puede auditar. Completá esos ejes en cada parte.',
+            );
+        }
+    }
+
+    return { ok: errors.length === 0, errors, criterio: criterio || null, n };
+}
+
+// -----------------------------------------------------------------------------
+// SG-5 — Registro idempotente del corte en el body del padre
+// -----------------------------------------------------------------------------
+
+/**
+ * Renderiza el bloque `## Registro del split` que va al body del issue padre.
+ *
+ * @param {{criterio: string, n: number, justificacionN: string, hijas?: Array<number|string>}} data
+ * @returns {string}
+ */
+function renderSplitRegistro({ criterio, n, justificacionN, hijas = [] } = {}) {
+    const resuelto = resolveCutCriterion(criterio);
+    const nombre = resuelto ? resuelto.nombre : normalizeText(criterio) || 'sin declarar';
+    const cantidad = toPositiveInt(n) || (Array.isArray(hijas) ? hijas.length : 0);
+    const ids = (Array.isArray(hijas) ? hijas : [])
+        .map((h) => toPositiveInt(h))
+        .filter(Boolean)
+        .map((h) => `#${h}`);
+
+    const lines = [
+        REGISTRO_HEADING,
+        '',
+        `- **Criterio de corte**: ${nombre}`,
+        `- **N elegido**: ${cantidad}`,
+        `- **Por qué ${cantidad} y no ${Math.max(cantidad - 1, 1)}/${cantidad + 1}**: ${normalizeText(justificacionN) || 'sin declarar'}`,
+    ];
+    if (ids.length) lines.push(`- **Sub-historias**: ${ids.join(', ')}`);
+
+    return lines.join('\n');
+}
+
+/**
+ * Inserta o ACTUALIZA el bloque `## Registro del split` dentro del body del padre.
+ *
+ * Idempotente por pedido explícito de UX: re-ejecutar el split reemplaza el
+ * bloque existente en vez de apilar bloques contradictorios. Un body con tres
+ * registros que se contradicen es peor que ninguno.
+ *
+ * Nunca pisa el body original: si no encuentra el bloque, lo agrega al final.
+ *
+ * @param {string} body — body actual del issue padre
+ * @param {object} data — mismo shape que renderSplitRegistro
+ * @returns {string} body nuevo
+ */
+function upsertSplitRegistro(body, data) {
+    const original = typeof body === 'string' ? body : '';
+    const bloque = renderSplitRegistro(data);
+
+    // Reemplaza desde el encabezado hasta el próximo `## ` de nivel 2 (o el final).
+    // Sin `g`: se actualiza la PRIMERA aparición y las duplicadas se limpian abajo.
+    const heading = REGISTRO_HEADING.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const blockRe = new RegExp(`^${heading}\\s*$[\\s\\S]*?(?=^##\\s|\\s*$(?![\\s\\S]))`, 'm');
+
+    if (blockRe.test(original)) {
+        let out = original.replace(blockRe, `${bloque}\n\n`);
+        // Si una corrida vieja (pre-idempotencia) dejó bloques apilados, se podan.
+        const dupRe = new RegExp(`^${heading}\\s*$[\\s\\S]*?(?=^##\\s|\\s*$(?![\\s\\S]))`, 'gm');
+        let first = true;
+        out = out.replace(dupRe, (match) => {
+            if (first) {
+                first = false;
+                return match;
+            }
+            return '';
+        });
+        return out.replace(/\n{3,}/g, '\n\n').trimEnd() + '\n';
+    }
+
+    const base = original.trimEnd();
+    return (base ? `${base}\n\n---\n\n` : '') + bloque + '\n';
+}
+
+module.exports = {
+    // Catálogo
+    CUT_CRITERIA,
+    CUT_CRITERIA_IDS,
+    CUT_CRITERIA_NOMBRES,
+    OVERSIZED_SIZES,
+    MIN_PARTS,
+    MAX_JUSTIFICACION_N_CHARS,
+    REGISTRO_HEADING,
+    resolveCutCriterion,
+    // SG-3 — freno de cascada
+    parseSplitParent,
+    isSplitChild,
+    checkResplit,
+    // SG-4 — hijo sobredimensionado
+    reportOversizedChild,
+    // SG-1 + SG-2 — validación del plan
+    validateSplitPlan,
+    // SG-5 — registro idempotente
+    renderSplitRegistro,
+    upsertSplitRegistro,
+};

--- a/.pipeline/lib/split-guard.js
+++ b/.pipeline/lib/split-guard.js
@@ -392,24 +392,60 @@ function validateSplitPlan(plan = {}) {
         );
     }
 
+    // --- El N declarado tiene que coincidir con las partes reales -------------
+    // El N registrado en el padre ES el entregable de CA-1/CA-5: es lo que permite
+    // revisar a posteriori si el patrón "siempre 3" persiste. Antes `plan.n` se
+    // ignoraba acá y se creía a ciegas en el render, así que un plan de 2 partes
+    // podía declarar `n: 3` y quedar registrado como 3 sin que nada lo notara —
+    // una auditoría que puede mentir no sirve para nada.
+    if (plan.n !== undefined && plan.n !== null && plan.n !== '') {
+        const declarado = toPositiveInt(plan.n);
+        if (!declarado) {
+            errors.push(
+                `⛔ El N declarado ("${String(plan.n)}") no es un entero positivo. El N es un dato de auditoría: escribilo como número.`,
+            );
+        } else if (declarado !== n) {
+            errors.push(
+                `⛔ El N declarado (${declarado}) no coincide con las partes del plan (${n}). ` +
+                    'El N registrado en el padre tiene que describir el corte que realmente se hizo: corregí el N o completá las partes que faltan.',
+            );
+        }
+    }
+
     // --- SG-2: partes indistinguibles ----------------------------------------
     // Si TODAS las partes comparten módulo, capa y flujo, no hay corte: es el
     // mismo issue escrito N veces. Se rechaza sin crear ninguna sub-historia.
     if (n >= MIN_PARTS) {
         const ejes = ['modulo', 'capa', 'flujo'];
         const firma = (parte) => ejes.map((eje) => comparableText(parte && parte[eje])).join('|');
-        const primeras = firma(partes[0]);
-        const todasIguales = partes.every((p) => firma(p) === primeras);
+        const firmas = partes.map(firma);
         const algunEjeDeclarado = ejes.some((eje) => partes.some((p) => comparableText(p && p[eje])));
 
-        if (todasIguales && algunEjeDeclarado) {
+        // Se rechaza CUALQUIER par de partes indistinguibles, no sólo el caso en que
+        // todas lo son. Chequear "todas iguales" cumplía la letra del CA-2 pero no su
+        // espíritu: un plan de 3 partes con 2 idénticas pasaba limpio, y esas 2 son
+        // exactamente el mismo issue escrito dos veces — el N sale inflado igual.
+        const grupos = new Map();
+        firmas.forEach((f, i) => {
+            if (!grupos.has(f)) grupos.set(f, []);
+            grupos.get(f).push(i + 1);
+        });
+        const duplicados = [...grupos.values()].filter((idxs) => idxs.length > 1);
+
+        if (!algunEjeDeclarado) {
+            errors.push(
+                '⛔ Las partes no declaran módulo/capa/flujo, así que el corte no se puede auditar. Completá esos ejes en cada parte.',
+            );
+        } else if (duplicados.length && duplicados[0].length === n) {
             errors.push(
                 '⛔ Corte no justificado: las partes comparten módulo, capa y flujo — es el mismo issue escrito ' +
                     `${n} veces. Rehacé el corte con otro criterio o dejá el issue entero. No se crea ninguna sub-historia.`,
             );
-        } else if (!algunEjeDeclarado) {
+        } else if (duplicados.length) {
+            const detalle = duplicados.map((idxs) => `partes ${idxs.join(' y ')}`).join('; ');
             errors.push(
-                '⛔ Las partes no declaran módulo/capa/flujo, así que el corte no se puede auditar. Completá esos ejes en cada parte.',
+                `⛔ Corte no justificado: hay partes indistinguibles entre sí (${detalle}) — comparten módulo, capa y flujo. ` +
+                    'Fusionalas o cortalas por otro eje. No se crea ninguna sub-historia.',
             );
         }
     }
@@ -424,19 +460,34 @@ function validateSplitPlan(plan = {}) {
 /**
  * Renderiza el bloque `## Registro del split` que va al body del issue padre.
  *
- * @param {{criterio: string, n: number, justificacionN: string, hijas?: Array<number|string>}} data
+ * El N NO se toma del campo `n` a ciegas: se DERIVA del corte que realmente se
+ * hizo (las partes del plan, o las hijas creadas), y `n` queda como último
+ * recurso. La razón es el propósito del bloque: es el registro de auditoría que
+ * permite revisar si el patrón "siempre 3" persiste. Si el número que se escribe
+ * puede diferir de las hijas que figuran dos líneas más abajo, la auditoría
+ * miente y no sirve. `validateSplitPlan` rechaza el mismatch antes de llegar acá;
+ * si alguien igual llega con datos contradictorios, se registra la discrepancia
+ * en vez de tapar el número real.
+ *
+ * @param {{criterio: string, n?: number, justificacionN: string, partes?: Array, hijas?: Array<number|string>}} data
  * @returns {string}
  */
-function renderSplitRegistro({ criterio, n, justificacionN, hijas = [] } = {}) {
+function renderSplitRegistro({ criterio, n, justificacionN, partes, hijas = [] } = {}) {
     const resuelto = resolveCutCriterion(criterio);
     // El fallback (criterio libre, no canónico) también se colapsa: es texto que
     // no pasó por el catálogo y por lo tanto puede traer cualquier cosa.
     const nombre = resuelto ? resuelto.nombre : oneLine(criterio, 80) || 'sin declarar';
-    const cantidad = toPositiveInt(n) || (Array.isArray(hijas) ? hijas.length : 0);
+
     const ids = (Array.isArray(hijas) ? hijas : [])
         .map((h) => toPositiveInt(h))
         .filter(Boolean)
         .map((h) => `#${h}`);
+
+    // Prioridad de la evidencia: partes del plan > hijas creadas > n declarado.
+    const porPartes = Array.isArray(partes) && partes.length ? partes.length : null;
+    const porHijas = ids.length || null;
+    const declarado = toPositiveInt(n);
+    const cantidad = porPartes || porHijas || declarado || 0;
 
     const lines = [
         REGISTRO_HEADING,
@@ -446,8 +497,88 @@ function renderSplitRegistro({ criterio, n, justificacionN, hijas = [] } = {}) {
         `- **Por qué ${cantidad} y no ${Math.max(cantidad - 1, 1)}/${cantidad + 1}**: ${oneLine(justificacionN) || 'sin declarar'}`,
     ];
     if (ids.length) lines.push(`- **Sub-historias**: ${ids.join(', ')}`);
+    if (declarado && declarado !== cantidad) {
+        lines.push(
+            `- **⚠️ N declarado inconsistente**: el plan decía ${declarado} pero el corte real tiene ${cantidad}. Revisar el split.`,
+        );
+    }
 
     return lines.join('\n');
+}
+
+// Apertura/cierre de un bloque de código markdown: ``` o ~~~, con hasta 3 espacios
+// de indentación (4+ ya sería bloque indentado, no fence).
+const FENCE_RE = /^ {0,3}(`{3,}|~{3,})/;
+
+// Cualquier encabezado ATX, de h1 a h6. La frontera del registro NO puede ser sólo
+// `^##\s`: después de `##` en `### ` viene `#`, no whitespace, así que un `### `
+// no matcheaba y toda subsección h3+ colgada del registro se borraba en silencio.
+const HEADING_RE = /^ {0,3}#{1,6}\s/;
+
+// Línea que ES exactamente el encabezado del registro (no una mención dentro de prosa).
+const REGISTRO_HEADING_LINE_RE = new RegExp(
+    `^ {0,3}${REGISTRO_HEADING.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*$`,
+);
+
+/**
+ * Ubica los bloques `## Registro del split` del body, respetando bloques de código.
+ *
+ * Se hace por escaneo de líneas y no por regex sobre el texto entero por dos razones
+ * verificadas empíricamente (rebote de `aprobacion`, #5837):
+ *
+ *   a) La frontera correcta es "el próximo encabezado de CUALQUIER nivel", y un regex
+ *      `^##\s` no matchea `### `. Con esa frontera, un `### Detalle del corte` colgado
+ *      del registro quedaba DENTRO del rango reemplazado y desaparecía sin aviso.
+ *   b) Un fence (` ```markdown `) puede contener el propio formato documentado del
+ *      registro. Sin tracking de fences el upsert entraba al bloque de código, lo
+ *      reescribía y dejaba el ``` de cierre huérfano — markdown roto en el issue.
+ *
+ * Un heading que vive DENTRO de un fence es documentación, no el registro real: se
+ * ignora, y si no hay ninguno afuera el bloque se agrega al final del body.
+ *
+ * @param {string[]} lines
+ * @returns {Array<{start: number, end: number}>} rangos [start, end) de líneas
+ */
+function findRegistroBlocks(lines) {
+    const blocks = [];
+    let fenceChar = null;
+    let fenceLen = 0;
+    let openStart = -1;
+
+    for (let i = 0; i < lines.length; i += 1) {
+        const line = lines[i];
+
+        const fence = FENCE_RE.exec(line);
+        if (fence) {
+            const char = fence[1][0];
+            const len = fence[1].length;
+            if (fenceChar === null) {
+                fenceChar = char;
+                fenceLen = len;
+            } else if (char === fenceChar && len >= fenceLen) {
+                fenceChar = null;
+                fenceLen = 0;
+            }
+            continue; // una línea de fence nunca es encabezado
+        }
+
+        if (fenceChar !== null) continue; // adentro de un bloque de código: intocable
+
+        if (REGISTRO_HEADING_LINE_RE.test(line)) {
+            // Dos registros seguidos (corrida vieja pre-idempotencia): cierra el anterior.
+            if (openStart >= 0) blocks.push({ start: openStart, end: i });
+            openStart = i;
+            continue;
+        }
+
+        if (openStart >= 0 && HEADING_RE.test(line)) {
+            blocks.push({ start: openStart, end: i });
+            openStart = -1;
+        }
+    }
+
+    if (openStart >= 0) blocks.push({ start: openStart, end: lines.length });
+    return blocks;
 }
 
 /**
@@ -457,7 +588,9 @@ function renderSplitRegistro({ criterio, n, justificacionN, hijas = [] } = {}) {
  * bloque existente en vez de apilar bloques contradictorios. Un body con tres
  * registros que se contradicen es peor que ninguno.
  *
- * Nunca pisa el body original: si no encuentra el bloque, lo agrega al final.
+ * Nunca pisa el body original: lo único que se reescribe es el rango que va desde
+ * el encabezado del registro hasta el próximo encabezado de cualquier nivel fuera
+ * de un bloque de código. Si no encuentra el bloque, lo agrega al final.
  *
  * @param {string} body — body actual del issue padre
  * @param {object} data — mismo shape que renderSplitRegistro
@@ -466,29 +599,25 @@ function renderSplitRegistro({ criterio, n, justificacionN, hijas = [] } = {}) {
 function upsertSplitRegistro(body, data) {
     const original = typeof body === 'string' ? body : '';
     const bloque = renderSplitRegistro(data);
+    const lines = original.split('\n');
+    const blocks = findRegistroBlocks(lines);
 
-    // Reemplaza desde el encabezado hasta el próximo `## ` de nivel 2 (o el final).
-    // Sin `g`: se actualiza la PRIMERA aparición y las duplicadas se limpian abajo.
-    const heading = REGISTRO_HEADING.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    const blockRe = new RegExp(`^${heading}\\s*$[\\s\\S]*?(?=^##\\s|\\s*$(?![\\s\\S]))`, 'm');
-
-    if (blockRe.test(original)) {
-        let out = original.replace(blockRe, `${bloque}\n\n`);
-        // Si una corrida vieja (pre-idempotencia) dejó bloques apilados, se podan.
-        const dupRe = new RegExp(`^${heading}\\s*$[\\s\\S]*?(?=^##\\s|\\s*$(?![\\s\\S]))`, 'gm');
-        let first = true;
-        out = out.replace(dupRe, (match) => {
-            if (first) {
-                first = false;
-                return match;
-            }
-            return '';
-        });
-        return out.replace(/\n{3,}/g, '\n\n').trimEnd() + '\n';
+    if (!blocks.length) {
+        const base = original.trimEnd();
+        return (base ? `${base}\n\n---\n\n` : '') + bloque + '\n';
     }
 
-    const base = original.trimEnd();
-    return (base ? `${base}\n\n---\n\n` : '') + bloque + '\n';
+    // El primer bloque se reemplaza; los duplicados de corridas viejas se podan.
+    const out = [];
+    let cursor = 0;
+    blocks.forEach((block, idx) => {
+        out.push(...lines.slice(cursor, block.start));
+        if (idx === 0) out.push(...bloque.split('\n'), '');
+        cursor = block.end;
+    });
+    out.push(...lines.slice(cursor));
+
+    return out.join('\n').replace(/\n{3,}/g, '\n\n').trimEnd() + '\n';
 }
 
 module.exports = {

--- a/.pipeline/lib/split-guard.js
+++ b/.pipeline/lib/split-guard.js
@@ -107,6 +107,29 @@ function normalizeText(value) {
     return typeof value === 'string' ? value.trim() : '';
 }
 
+// Colapsa a UNA sola línea y recorta al máximo declarado.
+//
+// No es cosmética: `justificacionN` y `criterio` son prosa libre que nace de un
+// issue de un repo PÚBLICO (cualquiera puede escribir el título/body que el
+// planner después parafrasea). Si un salto de línea sobrevive hasta el body del
+// padre, el texto puede abrir un `## Encabezado` propio; como `upsertSplitRegistro`
+// delimita su bloque con el próximo `## ` (blockRe), ese encabezado se vuelve la
+// nueva frontera y todo lo que venga detrás queda FUERA de la zona reescribible:
+// ningún re-split posterior lo saca nunca más. Por diseño del propio campo esto
+// es UNA línea, así que colapsar es también lo semánticamente correcto.
+function oneLine(value, max = MAX_JUSTIFICACION_N_CHARS) {
+    const flat = normalizeText(value).replace(/\s+/g, ' ');
+    return flat.length > max ? `${flat.slice(0, max - 1).trimEnd()}…` : flat;
+}
+
+// ¿El texto trae saltos de línea o un encabezado markdown? Se usa para RECHAZAR
+// en validación (camino temprano) además de colapsar en el render (defensa en
+// profundidad): el que escribe se entera de por qué su campo no sirve.
+function hasMultilineOrHeading(value) {
+    const raw = typeof value === 'string' ? value : '';
+    return /[\r\n]/.test(raw) || /(^|\s)#{1,6}\s/.test(raw);
+}
+
 // Normaliza para COMPARAR (no para mostrar): minúsculas, sin tildes, sin espacios
 // redundantes. Sirve tanto para matchear el criterio de corte escrito a mano como
 // para detectar partes indistinguibles ("Backend " vs "backend").
@@ -210,6 +233,22 @@ function isSplitChild(issue) {
  * @returns {{allowed: boolean, isChild: boolean, parent: number|null, reason: string|null, message: string|null}}
  */
 function checkResplit({ issue, force = false, justificacion = '' } = {}) {
+    // Fail-closed ante entrada malformada. El guard existe para FRENAR: si no
+    // puede leer el issue (undefined, null, un string, un objeto sin título),
+    // no sabe si es hijo de un split — y "no sé" nunca puede significar "dale".
+    if (!issue || typeof issue !== 'object' || typeof issue.title !== 'string') {
+        return {
+            allowed: false,
+            isChild: false,
+            parent: null,
+            reason: 'entrada-invalida',
+            message: [
+                '⛔ No se pudo evaluar el freno de cascada: el issue llegó sin `title` legible.',
+                'Pasá el JSON de `gh issue view <N> --json number,title,labels` tal cual, sin recortar campos.',
+            ].join('\n'),
+        };
+    }
+
     const child = isSplitChild(issue);
     const number = toPositiveInt(issue && issue.number);
 
@@ -306,6 +345,11 @@ function validateSplitPlan(plan = {}) {
 
     // --- SG-1: el criterio de corte se declara y es uno de los canónicos ------
     const criterio = resolveCutCriterion(plan.criterio);
+    if (hasMultilineOrHeading(plan.criterio)) {
+        errors.push(
+            '⛔ El criterio de corte trae saltos de línea o un encabezado markdown (`#`). Es un nombre de una línea: elegí uno del catálogo.',
+        );
+    }
     if (!normalizeText(plan.criterio)) {
         errors.push(
             `⛔ Falta declarar el criterio de corte. Elegí uno por nombre: ${CUT_CRITERIA_NOMBRES.join(', ')}.`,
@@ -318,6 +362,14 @@ function validateSplitPlan(plan = {}) {
 
     // --- SG-1: por qué N y no N±1 --------------------------------------------
     const justificacionN = normalizeText(plan.justificacionN);
+    if (hasMultilineOrHeading(plan.justificacionN)) {
+        // Este campo termina embebido en el body del issue padre. Un salto de
+        // línea con `## ` abre un encabezado que corre la frontera del bloque y
+        // deja el texto colado fuera del alcance de todo re-split (rompe el CA-5).
+        errors.push(
+            '⛔ La justificación del N trae saltos de línea o un encabezado markdown (`#`). Es un campo de auditoría de UNA línea: reescribila sin saltos ni `#`.',
+        );
+    }
     if (!justificacionN) {
         errors.push(
             `⛔ Falta la justificación del N: por qué ${n || 'N'} partes y no ${n ? n - 1 : 'N-1'} ni ${n ? n + 1 : 'N+1'}. Una línea alcanza.`,
@@ -377,7 +429,9 @@ function validateSplitPlan(plan = {}) {
  */
 function renderSplitRegistro({ criterio, n, justificacionN, hijas = [] } = {}) {
     const resuelto = resolveCutCriterion(criterio);
-    const nombre = resuelto ? resuelto.nombre : normalizeText(criterio) || 'sin declarar';
+    // El fallback (criterio libre, no canónico) también se colapsa: es texto que
+    // no pasó por el catálogo y por lo tanto puede traer cualquier cosa.
+    const nombre = resuelto ? resuelto.nombre : oneLine(criterio, 80) || 'sin declarar';
     const cantidad = toPositiveInt(n) || (Array.isArray(hijas) ? hijas.length : 0);
     const ids = (Array.isArray(hijas) ? hijas : [])
         .map((h) => toPositiveInt(h))
@@ -389,7 +443,7 @@ function renderSplitRegistro({ criterio, n, justificacionN, hijas = [] } = {}) {
         '',
         `- **Criterio de corte**: ${nombre}`,
         `- **N elegido**: ${cantidad}`,
-        `- **Por qué ${cantidad} y no ${Math.max(cantidad - 1, 1)}/${cantidad + 1}**: ${normalizeText(justificacionN) || 'sin declarar'}`,
+        `- **Por qué ${cantidad} y no ${Math.max(cantidad - 1, 1)}/${cantidad + 1}**: ${oneLine(justificacionN) || 'sin declarar'}`,
     ];
     if (ids.length) lines.push(`- **Sub-historias**: ${ids.join(', ')}`);
 

--- a/.pipeline/roles/planner.md
+++ b/.pipeline/roles/planner.md
@@ -11,23 +11,84 @@ Sos el dimensionador de historias de Intrale.
 - **Medio**: 2-5 archivos, posibles cambios de API, sin breaking changes
 - **Grande**: 6+ archivos, breaking changes, migraciones, múltiples módulos
 
+### Antes de dividir: ¿este issue ya es hijo de un split? (#5837 — freno de cascada)
+
+**Un issue que ya nació de un split NO se re-parte automáticamente.** Esto frena la
+cascada padre→hijo→nieto que en la ola 9.4 convirtió a #5440 en doce issues
+(#5791-5793 → #5794-5805, incluso nietos de nietos: #5793 → #5800 → #5803/#5805).
+
+El chequeo es determinístico, no a ojo:
+
+```bash
+node -e "const g=require('./.pipeline/lib/split-guard'); const i=JSON.parse(process.argv[1]); console.log(JSON.stringify(g.checkResplit({issue:i, force:false})));" "$(gh issue view <N> --repo intrale/platform --json number,title,labels)"
+```
+
+- Si `allowed: false` → **no dividas**. Escribí `resultado: aprobado` con el sizing
+  que corresponda y dejá el `message` del guard en las notas. En el camino autónomo
+  no hay `--force`: `--force` sólo existe en la invocación manual `/planner split`.
+- La detección se apoya en el **título canónico** `[Split de #N]`, no en el label
+  `split`. El label está aplicado de forma inconsistente (#5800 lo tiene, #5803 y
+  #5805 no) y además en `pulpo.js#isSplitParent` marca al **padre paraguas**, así
+  que usarlo para detectar hijos es un falso positivo invertido.
+
+**Si un hijo recién creado te sale `grande`**, eso no es una invitación a partirlo de
+nuevo: es un **defecto del corte del padre**. Reportalo sobre el padre y no crees nietos.
+
+```bash
+node -e "const g=require('./.pipeline/lib/split-guard'); console.log(g.reportOversizedChild({issue:<HIJO>, parent:<PADRE>, size:'L'}).message);"
+```
+
 ### Si es grande → dividir
-1. Dividí en 2-3 historias más chicas que tengan sentido como entregas independientes
-2. Creá cada historia hija como issue en GitHub:
-   - Título: `[Split de #<parent>] <descripción>`
+
+**El N sale de un criterio de corte, nunca de un default.** Antes se leía acá
+"dividí en 2-3 historias": ese techo implícito es exactamente lo que hacía que todos
+los splits cayeran en 3. No hay número recomendado — hay criterio.
+
+1. **Elegí y declará el criterio de corte** (uno de estos cinco, **por nombre**, nunca
+   por número: escribir `criterio 3` obliga al que lee a volver a este archivo):
+   - **por módulo** — separar backend de app, o módulos independientes (backend, users, app)
+   - **por funcionalidad entregable** — cada parte tiene valor por sí misma
+   - **por capa** — el issue abarca UI + backend y se separa por capa
+   - **por flujo** — múltiples flujos de usuario, uno por historia
+   - **por tamaño objetivo** — cortar para que cada parte quede en simple o medio
+2. **Justificá el N en una línea**: por qué N y no N±1. Es un campo de auditoría que
+   alguien va a leer en diagonal sobre doce issues, no un párrafo. Prohibido escribir
+   "por default", "como siempre" o "típicamente": el guard rechaza esas frases.
+3. **Validá el plan ANTES de crear un solo issue.** Si las partes comparten módulo,
+   capa y flujo, no hay corte: es el mismo issue escrito N veces. En ese caso rehacé
+   el corte con otro criterio o **dejá el issue entero** — no creés ninguna hija.
+   ```bash
+   node -e "const g=require('./.pipeline/lib/split-guard'); const r=g.validateSplitPlan(JSON.parse(process.argv[1])); console.log(JSON.stringify(r,null,2));" '{"criterio":"por capa","justificacionN":"...","partes":[{"titulo":"...","modulo":"backend","capa":"backend","flujo":"perfil"},{"titulo":"...","modulo":"app","capa":"ui","flujo":"perfil"}]}'
+   ```
+   Con `ok: false` **no se crea nada**: corregís el plan y re-validás.
+4. Creá cada historia hija como issue en GitHub:
+   - Título: `[Split de #<parent>] <descripción>` (formato EXACTO — es lo que
+     `split-orphan-reconciler` y el freno de cascada usan para reconocerla)
    - Body: referencia a la historia madre + criterios específicos de la parte
    - Labels: mismos que la historia madre + `needs-definition`
-3. Marcá la historia original como "dividida":
+5. Marcá la historia original como "dividida":
    - Label `split` (indica que es un paraguas)
    - Label `blocked:dependencies` (bloquea el intake hasta que cierren las hijas)
    - Comentario con encabezado EXACTO **`## Dependencias detectadas por el pipeline`** listando `#NNNN` de cada hija (el brazo de desbloqueo parsea este formato)
    - El label `Ready` se mantiene — es el `blocked:dependencies` el que impide el intake, no hace falta quitarlo
-4. Las historias hijas entran al pipeline de definición en fase `criterios` (no desde cero)
-5. Cuando las hijas cierren, el brazo de desbloqueo quita `blocked:dependencies` automáticamente y el paraguas vuelve a la cola; el Guru/PO lo cerrará si detecta que el scope ya fue cubierto
+6. **Registrá el corte en el body del padre** para poder revisar a posteriori si el
+   patrón "siempre 3" persiste. El upsert es idempotente: re-correr el split actualiza
+   el bloque `## Registro del split`, no apila bloques contradictorios.
+   ```bash
+   gh issue view <PADRE> --repo intrale/platform --json body --jq '.body' > /tmp/padre-<PADRE>.md
+   node -e "const fs=require('fs'),g=require('./.pipeline/lib/split-guard'); const f=process.argv[1]; fs.writeFileSync(f, g.upsertSplitRegistro(fs.readFileSync(f,'utf8'), JSON.parse(process.argv[2])));" /tmp/padre-<PADRE>.md '{"criterio":"por capa","n":2,"justificacionN":"...","hijas":[<HIJO1>,<HIJO2>]}'
+   gh issue edit <PADRE> --repo intrale/platform --body-file /tmp/padre-<PADRE>.md
+   ```
+   **Usar `--body-file`, nunca un heredoc con el body embebido**: el body original trae
+   backticks, `$` y comillas que rompen el escapado y terminan pisando la historia.
+7. Las historias hijas entran al pipeline de definición en fase `criterios` (no desde cero)
+8. Cuando las hijas cierren, el brazo de desbloqueo quita `blocked:dependencies` automáticamente y el paraguas vuelve a la cola; el Guru/PO lo cerrará si detecta que el scope ya fue cubierto
 
 ### Resultado
 - Si simple o medio: `resultado: aprobado` + agregar label `size:simple` o `size:medium` al issue
 - Si grande y dividida: `resultado: aprobado` con nota de división
+- Si grande pero **es hijo de un split** (freno de cascada): `resultado: aprobado`, sin
+  dividir, con el `message` del guard en las notas y el defecto reportado sobre el padre
 - NUNCA usar semanas/días como unidad — solo simple/medio/grande
 
 #### Contrato YAML obligatorio cuando hacés split (#3746)
@@ -39,6 +100,9 @@ resultado: aprobado
 sizing: grande
 dividido: true
 hijas_creadas: [3722, 3723, 3724, ...]  # IDs autoritativos del JSON de gh issue create
+# Campos de auditoría del corte (#5837) — opcionales para el Pulpo, obligatorios para vos
+criterio_corte: por capa                # uno de los 5, por NOMBRE (nunca "criterio 3")
+justificacion_n: "UI y backend son entregas separables; no hay una tercera capa."
 ```
 
 **Reglas inquebrantables del contrato:**
@@ -46,5 +110,6 @@ hijas_creadas: [3722, 3723, 3724, ...]  # IDs autoritativos del JSON de gh issue
 1. **`hijas_creadas` SOLO acepta IDs autoritativos** — los números deben venir del JSON estructurado de `gh issue create --json number,url` (campo `.number`). Prohibido tomar IDs del prompt del LLM, de stdout sin parsear o del cuerpo del comentario que armás en GitHub. Esta disciplina cierra el vector A03 Injection (cuando el padre está en allowlist, esos IDs se agregan automáticamente con TTL 48h por el Pulpo).
 2. **`dividido: true` es la señal explícita** — si falta o vale `false`, el Pulpo NO intenta heredar la ola al hijo (incluso si `hijas_creadas` está poblado).
 3. **Si no dividís (simple/medio)** — no escribas `dividido` ni `hijas_creadas`. El Pulpo trata el resultado como sizing normal.
+4. **`criterio_corte` y `justificacion_n` acompañan siempre a `dividido: true`** (#5837). Son opcionales para el Pulpo — no rompen el contrato viejo si faltan — pero un split sin ellos es un corte que nadie puede auditar. Los mismos valores van al bloque `## Registro del split` del body del padre.
 
 El Pulpo detecta este contrato en su callback `on('exit')` del skill `planner` en fase `sizing` y, si el padre está en `.partial-pause.json` → `allowed_issues`, agrega las hijas a la allowlist con `authorizedBy: 'planner-split:auto'` y TTL 48h (reusa `lib/allowlist-recursive-promote.autoPromoteSplitChildren`, hermano del camino Commander de Telegram). Si el padre NO está en allowlist, no hace nada y no es error.

--- a/.pipeline/roles/planner.md
+++ b/.pipeline/roles/planner.md
@@ -19,8 +19,18 @@ cascada padre→hijo→nieto que en la ola 9.4 convirtió a #5440 en doce issues
 
 El chequeo es determinístico, no a ojo:
 
+El JSON del issue baja a un **archivo**, nunca a argv: es la misma regla de quoting que
+usa `/planner split` en SP2.b del SKILL.md. Un body trae saltos de línea, comillas y
+puede pesar megabytes; por argv queda expuesto a límites de longitud, a `IFS` y a
+errores de encoding. Por archivo el shell no toca los datos.
+
 ```bash
-node -e "const g=require('./.pipeline/lib/split-guard'); const i=JSON.parse(process.argv[1]); console.log(JSON.stringify(g.checkResplit({issue:i, force:false})));" "$(gh issue view <N> --repo intrale/platform --json number,title,labels)"
+ISSUE=<N>                              # sólo dígitos
+case "$ISSUE" in ''|*[!0-9]*) echo "⛔ N no numérico"; exit 1;; esac
+mkdir -p .pipeline/tmp
+ISSUE_FILE=".pipeline/tmp/issue-$ISSUE.json"
+gh issue view "$ISSUE" --repo intrale/platform --json number,title,labels > "$ISSUE_FILE"
+node -e "const fs=require('fs'),g=require('./.pipeline/lib/split-guard'); const i=JSON.parse(fs.readFileSync(process.argv[1],'utf8')); console.log(JSON.stringify(g.checkResplit({issue:i, force:false}),null,2));" "$ISSUE_FILE"
 ```
 
 - Si `allowed: false` → **no dividas**. Escribí `resultado: aprobado` con el sizing
@@ -34,9 +44,22 @@ node -e "const g=require('./.pipeline/lib/split-guard'); const i=JSON.parse(proc
 **Si un hijo recién creado te sale `grande`**, eso no es una invitación a partirlo de
 nuevo: es un **defecto del corte del padre**. Reportalo sobre el padre y no crees nietos.
 
+El CA-4 pide que el defecto quede **sobre el padre**, no sólo impreso en tu salida: si
+el mensaje muere en el log del agente, el corte mal hecho no se corrige nunca. Así que
+el reporte se **postea como comentario en el padre**, igual que en el camino manual
+(SP2.c del SKILL.md):
+
 ```bash
-node -e "const g=require('./.pipeline/lib/split-guard'); console.log(g.reportOversizedChild({issue:<HIJO>, parent:<PADRE>, size:'L'}).message);"
+HIJO=<HIJO>; PADRE=<PADRE>              # sólo dígitos
+for v in "$HIJO" "$PADRE"; do case "$v" in ''|*[!0-9]*) echo "⛔ N no numérico"; exit 1;; esac; done
+mkdir -p .pipeline/tmp
+MSG_FILE=".pipeline/tmp/oversized-$HIJO.txt"
+node -e "const fs=require('fs'),g=require('./.pipeline/lib/split-guard'); const r=g.reportOversizedChild({issue:process.argv[1], parent:process.argv[2], size:process.argv[3]}); if(!r.oversized) process.exit(1); fs.writeFileSync(process.argv[4], r.message);" "$HIJO" "$PADRE" "L" "$MSG_FILE" \
+  && gh issue comment "$PADRE" --repo intrale/platform --body-file "$MSG_FILE"
 ```
+
+Además dejá el mismo `message` en las notas de tu `resultado`, para que quede en el
+YAML de la fase y no dependa de que alguien lea el issue.
 
 ### Si es grande → dividir
 

--- a/.pipeline/roles/planner.md
+++ b/.pipeline/roles/planner.md
@@ -57,8 +57,18 @@ los splits cayeran en 3. No hay número recomendado — hay criterio.
 3. **Validá el plan ANTES de crear un solo issue.** Si las partes comparten módulo,
    capa y flujo, no hay corte: es el mismo issue escrito N veces. En ese caso rehacé
    el corte con otro criterio o **dejá el issue entero** — no creés ninguna hija.
+
+   El plan va **en un archivo**, nunca pegado en la línea de comandos (ver la regla de
+   quoting más abajo). Escribí `.pipeline/tmp/split-plan-<PADRE>.json` con la
+   herramienta `Write` — no con `echo`/`printf`/heredoc:
+   ```json
+   {"criterio":"por capa","n":2,"justificacionN":"UI y backend son entregas separables; no hay una tercera capa.","partes":[{"titulo":"...","modulo":"backend","capa":"backend","flujo":"perfil"},{"titulo":"...","modulo":"app","capa":"ui","flujo":"perfil"}]}
+   ```
    ```bash
-   node -e "const g=require('./.pipeline/lib/split-guard'); const r=g.validateSplitPlan(JSON.parse(process.argv[1])); console.log(JSON.stringify(r,null,2));" '{"criterio":"por capa","justificacionN":"...","partes":[{"titulo":"...","modulo":"backend","capa":"backend","flujo":"perfil"},{"titulo":"...","modulo":"app","capa":"ui","flujo":"perfil"}]}'
+   PADRE=<PADRE>                       # sólo dígitos
+   case "$PADRE" in ''|*[!0-9]*) echo "⛔ PADRE no numérico"; exit 1;; esac
+   PLAN_FILE=".pipeline/tmp/split-plan-$PADRE.json"
+   node -e "const fs=require('fs'),g=require('./.pipeline/lib/split-guard'); const r=g.validateSplitPlan(JSON.parse(fs.readFileSync(process.argv[1],'utf8'))); console.log(JSON.stringify(r,null,2)); if(!r.ok) process.exit(1);" "$PLAN_FILE"
    ```
    Con `ok: false` **no se crea nada**: corregís el plan y re-validás.
 4. Creá cada historia hija como issue en GitHub:
@@ -74,13 +84,33 @@ los splits cayeran en 3. No hay número recomendado — hay criterio.
 6. **Registrá el corte en el body del padre** para poder revisar a posteriori si el
    patrón "siempre 3" persiste. El upsert es idempotente: re-correr el split actualiza
    el bloque `## Registro del split`, no apila bloques contradictorios.
+   Reusá el MISMO `$PLAN_FILE` que ya validaste en el paso 3 (agregale `hijas` con los
+   IDs autoritativos usando `Write`). El payload va por archivo, nunca por argumento:
    ```bash
-   gh issue view <PADRE> --repo intrale/platform --json body --jq '.body' > /tmp/padre-<PADRE>.md
-   node -e "const fs=require('fs'),g=require('./.pipeline/lib/split-guard'); const f=process.argv[1]; fs.writeFileSync(f, g.upsertSplitRegistro(fs.readFileSync(f,'utf8'), JSON.parse(process.argv[2])));" /tmp/padre-<PADRE>.md '{"criterio":"por capa","n":2,"justificacionN":"...","hijas":[<HIJO1>,<HIJO2>]}'
-   gh issue edit <PADRE> --repo intrale/platform --body-file /tmp/padre-<PADRE>.md
+   PADRE=<PADRE>                       # sólo dígitos
+   case "$PADRE" in ''|*[!0-9]*) echo "⛔ PADRE no numérico"; exit 1;; esac
+   PADRE_FILE=".pipeline/tmp/padre-$PADRE.md"
+   PLAN_FILE=".pipeline/tmp/split-plan-$PADRE.json"
+   mkdir -p .pipeline/tmp
+   gh issue view "$PADRE" --repo intrale/platform --json body --jq '.body' > "$PADRE_FILE"
+   node -e "const fs=require('fs'),g=require('./.pipeline/lib/split-guard'); const f=process.argv[1]; const d=JSON.parse(fs.readFileSync(process.argv[2],'utf8')); const v=g.validateSplitPlan(d); if(!v.ok){console.error(v.errors.join('\n')); process.exit(1);} fs.writeFileSync(f, g.upsertSplitRegistro(fs.readFileSync(f,'utf8'), d));" "$PADRE_FILE" "$PLAN_FILE"
+   gh issue edit "$PADRE" --repo intrale/platform --body-file "$PADRE_FILE"
    ```
+   La validación va **encadenada antes del upsert**: el camino autónomo no puede quedar
+   sin filtro, porque `justificacionN` es prosa libre parafraseada de un issue de un repo
+   público.
+
    **Usar `--body-file`, nunca un heredoc con el body embebido**: el body original trae
    backticks, `$` y comillas que rompen el escapado y terminan pisando la historia.
+
+   **Ningún texto libre se interpola en un comando — va por archivo o por stdin.**
+   Hermana de la regla del heredoc y más grave que ella: el heredoc *perdía* datos, esto
+   *ejecuta código*. En bash una comilla simple **no se puede escapar** dentro de un
+   literal `'...'`, así que una justificación tan normal como `no hay una 'tercera capa'`
+   cierra el literal y el resto de la frase la interpreta el shell — con `$(...)` ahí
+   adentro corriendo como el usuario del pipeline, con `gh` y AWS a mano. Por eso el JSON
+   se escribe con `Write` a `.pipeline/tmp/` (ya cubierto por `.gitignore`, no `/tmp/` con
+   nombre predecible) y el comando sólo recibe **paths**, siempre entrecomillados.
 7. Las historias hijas entran al pipeline de definición en fase `criterios` (no desde cero)
 8. Cuando las hijas cierren, el brazo de desbloqueo quita `blocked:dependencies` automáticamente y el paraguas vuelve a la cola; el Guru/PO lo cerrará si detecta que el scope ya fue cubierto
 


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 5 archivos · +1599 -29

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:passed` aplicado por delivery

## Closes

Closes #5837
