### PR TITLE
[Split de #5698] Erradicar deepseek-v4-pro y migrar NVIDIA a un sucesor verificado vivo

### DIFF
--- a/.pipeline/agent-models.json
+++ b/.pipeline/agent-models.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./agent-models.schema.json",
-  "_doc": "Configuración multi-proveedor del pipeline V3 — issue #3072 (H1) + #3077 (H5) + #3221 (sign-off Leo 2026-05-15 por agente) + #3258 (skill virtual `telegram-commander`). Documento canónico: docs/pipeline/multi-provider.md. Para agregar/cambiar un provider, primero editar agent-models.schema.json (allowlist de launcher/model) y después este archivo. El boot del pulpo valida con Ajv 2020-12 y aborta si no matchea — ver lib/agent-models-validate.js (#3081 S3). Los strings de 'quota_error_types' se cross-validan contra la meta-allowlist hardcoded en lib/quota-exhausted.js (KNOWN_QUOTA_ERROR_TYPES_BY_PROVIDER) — agregar un valor fuera de esa meta-allowlist hace boot fail-fast (SEC-2 de #3077). Los `fallbacks[]` por skill respetan el orden sign-off Leo 2026-05-15 (memoria project_multi-provider-per-agent-order); los skills con Gemini EXCLUIDO procesan secrets/código fuente sensible (TOS AI Studio entrena con prompts free). El skill virtual `telegram-commander` (#3258) NO está en `skills_por_fase` — es consumido por pulpo.js (commander chat de Telegram) vía lib/commander/multi-provider.js para el dispatch con fallback chain. Reorden 2026-06-02 (sign-off Leo por voz): (A) devs (backend/pipeline/android/web) + security sacan Cerebras del fallback y meten nvidia-nim — Cerebras no soporta tool_use y no puede editar archivos; NVIDIA es free + tool_use. (B) default global de chain = Claude → Codex → Gemini → Cerebras (Cerebras queda como tail solo en skills de chat/verificación que no requieren tool_use). Corrección de runtime: el modelo Cerebras pasa de `llama-3.3-70b` (muerto, no está en free tier) a `gpt-oss-120b` (verificado GET /v1/models + smoke #3794); alternative_models → `zai-glm-4.7`. telegram-commander suma nvidia-nim al final para alinear el JSON con el código de #3796. Reorden de modelos 2026-06-02 (sign-off Leo por voz): telegram-commander baja su primario de claude-opus-4-7 → claude-sonnet-4-7 y su fallback Codex de gpt-5-codex → gpt-5 (es el cerebro, conserva calidad pero ahorra ~5x vs Opus sin pérdida relevante en chat/operación). telegram-sherlock MANTIENE claude-haiku-4-5 como primario (es el piso de calidad del verificador y NO se baja — un verificador flojo aprueba cualquier cosa) y baja solo su fallback Codex de gpt-5 → gpt-5-mini (verificación no necesita el tope). gpt-5-mini se agregó a ALLOWED_MODELS_BY_LAUNCHER.codex en lib/agent-models-validate.js. Reorden Grupo B 2026-06-02 (sign-off Leo por voz): qa/po/ux bajan de claude-opus-4-7 → claude-sonnet-4-7 (no escriben código de producción — evalúan, validan video por frames+capturas y redactan criterios; la capacidad de visión de Sonnet es la misma que Opus, ahorro ~5x sin pérdida relevante). refinar tenía un bug de config: solo declaraba `provider:anthropic` sin model_override → heredaba el default claude-opus-4-7 y SIN fallbacks; ahora explicita claude-sonnet-4-7 + fallbacks [codex gpt-5, cerebras gpt-oss-120b]. Grupo A (backend/pipeline/android/web-dev + security) MANTIENE claude-opus-4-7 — su output va a main y un dev flojo genera rebotes que cuestan más que el ahorro. CORRECCIÓN DE NOMBRES DE MODELOS 2026-06-04 (sign-off Leo por voz, verificado en vivo contra cada CLI/API): los nombres configurados arriba estaban desactualizados y rotos. (1) `claude-sonnet-4-7` NO existe en el catálogo Anthropic → reemplazado por `claude-sonnet-4-6` (13 refs). (2) Codex con cuenta ChatGPT rechaza `gpt-5-codex`/`gpt-5`/`gpt-5-mini` con 400 ('not supported when using Codex with a ChatGPT account'); catálogo real = gpt-5.5 (frontier, strongest agentic coding), gpt-5.4, gpt-5.4-mini → mapeo preservando tiering: skills de código (gpt-5-codex) → gpt-5.5, eval/chat (gpt-5) → gpt-5.4, verificador Sherlock (gpt-5-mini) → gpt-5.4-mini; el `model` default del provider openai-codex pasa a gpt-5.5. (3) `gemini-1.5-flash` (alternative_models) fue retirado de Google → `gemini-2.5-flash`. Cerebras (gpt-oss-120b, zai-glm-4.7) y NVIDIA (deepseek-v4-pro) verificados vigentes, sin cambios. La allowlist ALLOWED_MODELS_BY_LAUNCHER en lib/agent-models-validate.js se actualizó en sincronía. claude-opus-4-7 se mantiene (vigente y funcional; existe claude-opus-4-8 más nuevo pero el cambio queda fuera de alcance por ser decisión de costo/calidad, no un fix).",
+  "_doc": "Configuración multi-proveedor del pipeline V3 — issue #3072 (H1) + #3077 (H5) + #3221 (sign-off Leo 2026-05-15 por agente) + #3258 (skill virtual `telegram-commander`). Documento canónico: docs/pipeline/multi-provider.md. Para agregar/cambiar un provider, primero editar agent-models.schema.json (allowlist de launcher/model) y después este archivo. El boot del pulpo valida con Ajv 2020-12 y aborta si no matchea — ver lib/agent-models-validate.js (#3081 S3). Los strings de 'quota_error_types' se cross-validan contra la meta-allowlist hardcoded en lib/quota-exhausted.js (KNOWN_QUOTA_ERROR_TYPES_BY_PROVIDER) — agregar un valor fuera de esa meta-allowlist hace boot fail-fast (SEC-2 de #3077). Los `fallbacks[]` por skill respetan el orden sign-off Leo 2026-05-15 (memoria project_multi-provider-per-agent-order); los skills con Gemini EXCLUIDO procesan secrets/código fuente sensible (TOS AI Studio entrena con prompts free). El skill virtual `telegram-commander` (#3258) NO está en `skills_por_fase` — es consumido por pulpo.js (commander chat de Telegram) vía lib/commander/multi-provider.js para el dispatch con fallback chain. Reorden 2026-06-02 (sign-off Leo por voz): (A) devs (backend/pipeline/android/web) + security sacan Cerebras del fallback y meten nvidia-nim — Cerebras no soporta tool_use y no puede editar archivos; NVIDIA es free + tool_use. (B) default global de chain = Claude → Codex → Gemini → Cerebras (Cerebras queda como tail solo en skills de chat/verificación que no requieren tool_use). Corrección de runtime: el modelo Cerebras pasa de `llama-3.3-70b` (muerto, no está en free tier) a `gpt-oss-120b` (verificado GET /v1/models + smoke #3794); alternative_models → `zai-glm-4.7`. telegram-commander suma nvidia-nim al final para alinear el JSON con el código de #3796. Reorden de modelos 2026-06-02 (sign-off Leo por voz): telegram-commander baja su primario de claude-opus-4-7 → claude-sonnet-4-7 y su fallback Codex de gpt-5-codex → gpt-5 (es el cerebro, conserva calidad pero ahorra ~5x vs Opus sin pérdida relevante en chat/operación). telegram-sherlock MANTIENE claude-haiku-4-5 como primario (es el piso de calidad del verificador y NO se baja — un verificador flojo aprueba cualquier cosa) y baja solo su fallback Codex de gpt-5 → gpt-5-mini (verificación no necesita el tope). gpt-5-mini se agregó a ALLOWED_MODELS_BY_LAUNCHER.codex en lib/agent-models-validate.js. Reorden Grupo B 2026-06-02 (sign-off Leo por voz): qa/po/ux bajan de claude-opus-4-7 → claude-sonnet-4-7 (no escriben código de producción — evalúan, validan video por frames+capturas y redactan criterios; la capacidad de visión de Sonnet es la misma que Opus, ahorro ~5x sin pérdida relevante). refinar tenía un bug de config: solo declaraba `provider:anthropic` sin model_override → heredaba el default claude-opus-4-7 y SIN fallbacks; ahora explicita claude-sonnet-4-7 + fallbacks [codex gpt-5, cerebras gpt-oss-120b]. Grupo A (backend/pipeline/android/web-dev + security) MANTIENE claude-opus-4-7 — su output va a main y un dev flojo genera rebotes que cuestan más que el ahorro. CORRECCIÓN DE NOMBRES DE MODELOS 2026-06-04 (sign-off Leo por voz, verificado en vivo contra cada CLI/API): los nombres configurados arriba estaban desactualizados y rotos. (1) `claude-sonnet-4-7` NO existe en el catálogo Anthropic → reemplazado por `claude-sonnet-4-6` (13 refs). (2) Codex con cuenta ChatGPT rechaza `gpt-5-codex`/`gpt-5`/`gpt-5-mini` con 400 ('not supported when using Codex with a ChatGPT account'); catálogo real = gpt-5.5 (frontier, strongest agentic coding), gpt-5.4, gpt-5.4-mini → mapeo preservando tiering: skills de código (gpt-5-codex) → gpt-5.5, eval/chat (gpt-5) → gpt-5.4, verificador Sherlock (gpt-5-mini) → gpt-5.4-mini; el `model` default del provider openai-codex pasa a gpt-5.5. (3) `gemini-1.5-flash` (alternative_models) fue retirado de Google → `gemini-2.5-flash`. Cerebras (gpt-oss-120b, zai-glm-4.7) verificado vigente, sin cambios; el modelo NVIDIA de entonces quedó desactualizado y fue re-verificado y migrado el 2026-08-13 (ver la entrada de #5887 al final de este doc). La allowlist ALLOWED_MODELS_BY_LAUNCHER en lib/agent-models-validate.js se actualizó en sincronía. claude-opus-4-7 se mantiene (vigente y funcional; existe claude-opus-4-8 más nuevo pero el cambio queda fuera de alcance por ser decisión de costo/calidad, no un fix). Migración NVIDIA 2026-08-13 (#5887, parte 1 del split de #5698): el modelo que tenía configurado el provider nvidia-nim llegó a end-of-life el 2026-08-07T09:00:00Z y devolvía HTTP 410 en toda invocación, matando sin trabajo a cualquier agente que cayera a NVIDIA en su cadena de fallback. Sucesor: deepseek-ai/deepseek-v4-flash-0731, aplicado al `model` del provider y a los 6 `model_override` (android-dev, web-dev, security, guru, telegram-commander, telegram-sherlock). Verificación en vivo del 2026-08-13 contra integrate.api.nvidia.com, en la misma pasada de implementación: (a) GET /v1/models devolvió HTTP 200 con deepseek-ai/deepseek-v4-flash-0731 presente en el catálogo (102 modelos) y el id anterior ausente; (b) POST /v1/chat/completions con tools[] devolvió HTTP 200 con finish_reason=tool_calls y tool_calls[0].function.name=read_file — tool_use medido en vivo, no heredado de la capability declarada del provider. Pin con sufijo de fecha (-0731), nunca alias flotante. Las tres barreras de modelo (ALLOWED_MODELS_BY_LAUNCHER en lib/agent-models-validate.js, PROVIDER_MODELS_ALLOWLIST en lib/multi-provider/completion-client.js y DEFAULT_MODEL en lib/agent-launcher/runners/nvidia-nim-runner.js) se actualizaron por reemplazo en el mismo commit: el id viejo se quitó, no sólo se agregó el nuevo, para que ninguna reintroducción futura pase silenciosa.",
   "default_provider": "anthropic",
   "providers": {
     "anthropic": {
@@ -138,7 +138,7 @@
     },
     "nvidia-nim": {
       "launcher": "nvidia-nim",
-      "model": "deepseek-ai/deepseek-v4-pro",
+      "model": "deepseek-ai/deepseek-v4-flash-0731",
       "spawn_args_template": [
         "--model",
         "{model}",
@@ -263,7 +263,7 @@
         },
         {
           "provider": "nvidia-nim",
-          "model_override": "deepseek-ai/deepseek-v4-pro"
+          "model_override": "deepseek-ai/deepseek-v4-flash-0731"
         }
       ]
     },
@@ -284,7 +284,7 @@
         },
         {
           "provider": "nvidia-nim",
-          "model_override": "deepseek-ai/deepseek-v4-pro"
+          "model_override": "deepseek-ai/deepseek-v4-flash-0731"
         }
       ]
     },
@@ -310,7 +310,7 @@
         },
         {
           "provider": "nvidia-nim",
-          "model_override": "deepseek-ai/deepseek-v4-pro"
+          "model_override": "deepseek-ai/deepseek-v4-flash-0731"
         }
       ]
     },
@@ -431,7 +431,7 @@
         },
         {
           "provider": "nvidia-nim",
-          "model_override": "deepseek-ai/deepseek-v4-pro"
+          "model_override": "deepseek-ai/deepseek-v4-flash-0731"
         }
       ]
     },
@@ -537,7 +537,7 @@
         },
         {
           "provider": "nvidia-nim",
-          "model_override": "deepseek-ai/deepseek-v4-pro"
+          "model_override": "deepseek-ai/deepseek-v4-flash-0731"
         }
       ],
       "balancing": {
@@ -564,7 +564,7 @@
         },
         {
           "provider": "nvidia-nim",
-          "model_override": "deepseek-ai/deepseek-v4-pro"
+          "model_override": "deepseek-ai/deepseek-v4-flash-0731"
         }
       ]
     }

--- a/.pipeline/lib/__tests__/agent-models-capability-validate.test.js
+++ b/.pipeline/lib/__tests__/agent-models-capability-validate.test.js
@@ -162,7 +162,7 @@ test('CA-3 / SEC-3 · provider SIN capabilities declaradas en rol agéntico ⇒ 
   // Provider capaz de tool_use pero sin declarar `capabilities` → fail-closed.
   cfg.providers.nocap = {
     launcher: 'nvidia-nim',
-    model: 'deepseek-ai/deepseek-v4-pro',
+    model: 'deepseek-ai/deepseek-v4-flash-0731',
     spawn_args_template: ['--model', '{model}', '{user_prompt}'],
     output_parser: 'openai-sse',
     quota_error_types: ['rate_limit_exceeded'],

--- a/.pipeline/lib/__tests__/completion-client.test.js
+++ b/.pipeline/lib/__tests__/completion-client.test.js
@@ -195,7 +195,7 @@ test('complete NVIDIA NIM éxito devuelve schema normalizado', async () => {
     writeKeys(f, { nvidia_nim_api_key: 'nvapi-test-1234567890abcdef0000' });
     const r = await completion.complete({
         provider: 'nvidia-nim',
-        model: 'deepseek-ai/deepseek-v4-pro',
+        model: 'deepseek-ai/deepseek-v4-flash-0731',
         prompt: 'ping',
         secretsPath: f,
         httpImpl: fakeHttp({
@@ -203,7 +203,7 @@ test('complete NVIDIA NIM éxito devuelve schema normalizado', async () => {
             body: JSON.stringify({
                 choices: [{ message: { content: 'pong nvidia' } }],
                 usage: { prompt_tokens: 10, completion_tokens: 2 },
-                model: 'deepseek-ai/deepseek-v4-pro',
+                model: 'deepseek-ai/deepseek-v4-flash-0731',
             }),
         }),
     });
@@ -555,8 +555,8 @@ test('PROVIDER_MODELS_ALLOWLIST incluye los modelos que usa producción (snapsho
         'cerebras/llama-3.3-70b en producción debe estar allowlisted');
     assert.ok(completion.isAllowedModel('gemini-google', 'gemini-2.0-flash'),
         'gemini-google/gemini-2.0-flash en producción debe estar allowlisted');
-    assert.ok(completion.isAllowedModel('nvidia-nim', 'deepseek-ai/deepseek-v4-pro'),
-        'nvidia-nim/deepseek-ai/deepseek-v4-pro en producción debe estar allowlisted');
+    assert.ok(completion.isAllowedModel('nvidia-nim', 'deepseek-ai/deepseek-v4-flash-0731'),
+        'nvidia-nim/deepseek-ai/deepseek-v4-flash-0731 en producción debe estar allowlisted');
 });
 
 // =============================================================================

--- a/.pipeline/lib/__tests__/dashboard-onboarding-route.test.js
+++ b/.pipeline/lib/__tests__/dashboard-onboarding-route.test.js
@@ -69,7 +69,20 @@ test('#4851: onboarding conserva 5 pasos y expone los campos del descriptor comp
     assert.ok(res.body.includes('data-provider-id="nvidia-nim"'));
     assert.ok(res.body.includes('function owMoveProvider('));
     assert.ok(res.body.includes('function owProviderKey('));
-    assert.ok(!/groq/i.test(res.body), 'Groq/groq no debe aparecer en UI/script del wizard');
+    // #5724 rev-3 empezó a inlinear el sprite de íconos COMPLETO en el documento
+    // de la vista (el banner de desync usa `<use href="#ic-pause-lock">` y sin el
+    // sprite en el documento el símbolo no resuelve). Ese sprite es compartido por
+    // todo el dashboard y trae `ic-provider-groq` + su comentario: Groq sigue vivo
+    // como provider free en la vista multi-provider, así que el ícono debe seguir
+    // existiendo. Lo que #4851 prohíbe es que Groq aparezca como OPCIÓN del wizard,
+    // no que el sprite compartido pierda su símbolo — por eso la aserción se evalúa
+    // sobre el documento con el sprite descontado, más un chequeo explícito de que
+    // no hay provider `groq` ofrecido en el orden de providers.
+    let sprite = '';
+    try { sprite = require('../../views/dashboard/nav-tabs').loadIconSprite(); } catch { /* sin sprite: se evalúa el documento entero */ }
+    const bodySinSprite = sprite ? res.body.split(sprite).join('') : res.body;
+    assert.ok(!/groq/i.test(bodySinSprite), 'Groq/groq no debe aparecer en UI/script del wizard');
+    assert.ok(!res.body.includes('data-provider-id="groq"'), 'Groq no debe ser opción del orden de providers');
 });
 
 test('CA-S1: onboarding es un slug de la allowlist (partial desde loopback no da 400)', () => {

--- a/.pipeline/lib/__tests__/sherlock-verifier.test.js
+++ b/.pipeline/lib/__tests__/sherlock-verifier.test.js
@@ -119,7 +119,7 @@ function defaultConfigLoader(over = {}) {
 const CHAIN_HTTP = [
     { provider: 'cerebras', model: 'llama-3.3-70b' },
     { provider: 'gemini-google', model: 'gemini-2.0-flash' },
-    { provider: 'nvidia-nim', model: 'deepseek-ai/deepseek-v4-pro' },
+    { provider: 'nvidia-nim', model: 'deepseek-ai/deepseek-v4-flash-0731' },
 ];
 
 // #3484 — chain con Anthropic primero (orden aprobado por Leo 2026-05-22).
@@ -324,7 +324,7 @@ test('T-5: 5 turnos paralelos con commanderProvider variado — sameProvider cor
     const chain = [
         { provider: 'cerebras', model: 'llama-3.3-70b' },
         { provider: 'gemini-google', model: 'gemini-2.0-flash' },
-        { provider: 'nvidia-nim', model: 'deepseek-ai/deepseek-v4-pro' },
+        { provider: 'nvidia-nim', model: 'deepseek-ai/deepseek-v4-flash-0731' },
     ];
     // Mezcla de providers — los HTTP coinciden a veces con el primero
     // del chain (cerebras), generando same_provider=true cuando aplica.
@@ -1898,7 +1898,7 @@ test('#3501 CA-18 (rev #3921): sin alternative_models NO hay swap intra-provider
         quotaModule: fakeQuotaAllPass(),
         dispatchModule: fakeDispatcher({ providerChain: [
             { provider: 'cerebras', model: 'llama-3.3-70b' },
-            { provider: 'nvidia-nim', model: 'deepseek-ai/deepseek-v4-pro' },
+            { provider: 'nvidia-nim', model: 'deepseek-ai/deepseek-v4-flash-0731' },
         ]}),
         residencyModule: fakeResidencyOk(),
     });
@@ -1906,7 +1906,7 @@ test('#3501 CA-18 (rev #3921): sin alternative_models NO hay swap intra-provider
     // a nvidia-nim (el commander cerebras queda excluido por defecto).
     assert.equal(result.modelSwap.swapped, false, 'sin alternative_models → NO swap intra-provider');
     assert.equal(result.sherlockProvider, 'nvidia-nim', '#3921: cross-provider por defecto enruta al siguiente provider, no al commander');
-    assert.equal(result.sherlockModel, 'deepseek-ai/deepseek-v4-pro');
+    assert.equal(result.sherlockModel, 'deepseek-ai/deepseek-v4-flash-0731');
     assert.equal(result.sameProvider, false, '#3921: commander excluido por defecto → cross-provider');
     assert.equal(result.sameModel, false);
     // Evento sherlock_model_swap NO debe aparecer en este caso.
@@ -1919,7 +1919,7 @@ test('#3501 CA-18 (rev #3921): sin alternative_models NO hay swap intra-provider
         sherlockModel: result.sherlockModel,
         modelSwap: result.modelSwap,
     });
-    assert.equal(footer, 'Verificado por: nvidia-nim/deepseek-ai/deepseek-v4-pro');
+    assert.equal(footer, 'Verificado por: nvidia-nim/deepseek-ai/deepseek-v4-flash-0731');
     assert.ok(!/swap desde/.test(footer));
 });
 
@@ -2647,7 +2647,7 @@ test('#3921 SEC-6: que falle el PRIMER alternativo NO alcanza para caer a same-p
         dispatchModule: fakeDispatcher({ providerChain: [
             { provider: 'anthropic', model: 'claude-opus-4-7' },
             { provider: 'gemini-google', model: 'gemini-2.0-flash' },
-            { provider: 'nvidia-nim', model: 'deepseek-ai/deepseek-v4-pro' },
+            { provider: 'nvidia-nim', model: 'deepseek-ai/deepseek-v4-flash-0731' },
         ]}),
         residencyModule: fakeResidencyOk(),
     });
@@ -2684,7 +2684,7 @@ test('#3921 CA-4/SEC-1: alternativo residency-blocked recien priorizado se desca
         dispatchModule: fakeDispatcher({ providerChain: [
             { provider: 'cerebras', model: 'llama-3.3-70b' },
             { provider: 'gemini-google', model: 'gemini-2.0-flash' },
-            { provider: 'nvidia-nim', model: 'deepseek-ai/deepseek-v4-pro' },
+            { provider: 'nvidia-nim', model: 'deepseek-ai/deepseek-v4-flash-0731' },
         ]}),
         residencyModule: fakeResidencyBlockFor(['gemini-google']),
     });
@@ -2709,7 +2709,7 @@ test('#3921 CA-5/SEC-5: cascada + fallback same-provider terminan dentro del cap
         dispatchModule: fakeDispatcher({ providerChain: [
             { provider: 'cerebras', model: 'llama-3.3-70b' },
             { provider: 'gemini-google', model: 'gemini-2.0-flash' },
-            { provider: 'nvidia-nim', model: 'deepseek-ai/deepseek-v4-pro' },
+            { provider: 'nvidia-nim', model: 'deepseek-ai/deepseek-v4-flash-0731' },
         ]}),
         residencyModule: fakeResidencyOk(),
     });

--- a/.pipeline/lib/agent-launcher/providers/nvidia-nim.js
+++ b/.pipeline/lib/agent-launcher/providers/nvidia-nim.js
@@ -150,11 +150,14 @@ function _parseNvidiaJson(raw) {
 // -----------------------------------------------------------------------------
 // parseTokensFromLog — mapea el `usage` OpenAI al shape canónico del pulpo.
 //
-// Shape capturado en smoke real (2026-06-01, deepseek-v4-pro):
+// Shape re-capturado en smoke real (2026-08-13, deepseek-v4-flash-0731 — #5887,
+// tras el end-of-life del modelo con el que se capturó el shape original el
+// 2026-06-01):
 //   { "choices": [...], "usage": {
-//       "prompt_tokens": 17, "completion_tokens": 2, "total_tokens": 19,
-//       "prompt_tokens_details": { "cached_tokens": N } | null,
-//       "reasoning_tokens": 0 } }
+//       "prompt_tokens": 11, "completion_tokens": 2, "total_tokens": 13 } }
+// `prompt_tokens_details.cached_tokens` y `reasoning_tokens` son opcionales: el
+// sucesor los omite cuando valen 0, así que el mapeo de abajo los trata como
+// ausentes-o-null y no asume su presencia.
 //
 // Mapeo:
 //   prompt_tokens                      → input

--- a/.pipeline/lib/agent-launcher/runners/nvidia-nim-runner.js
+++ b/.pipeline/lib/agent-launcher/runners/nvidia-nim-runner.js
@@ -12,7 +12,7 @@
 //
 // Contrato de argv (lo arma `buildSpawn` del adapter, traduciendo los args
 // estilo Claude del pulpo):
-//   --model <id>            modelo NVIDIA (ej: deepseek-ai/deepseek-v4-pro)
+//   --model <id>            modelo NVIDIA (ej: deepseek-ai/deepseek-v4-flash-0731)
 //   --system-file <path>    archivo con el system prompt (opcional)
 //   --prompt <text>         prompt del usuario
 //   --max-tokens <n>        cap de salida (opcional, default 4096)
@@ -39,7 +39,11 @@ const path = require('node:path');
 
 const ENDPOINT_HOST = 'integrate.api.nvidia.com';
 const ENDPOINT_PATH = '/v1/chat/completions';
-const DEFAULT_MODEL = 'deepseek-ai/deepseek-v4-pro';
+// #5887 — el modelo DeepSeek anterior llegó a end-of-life el 2026-08-07 (HTTP 410
+// en toda invocación). Este default es la última barrera: `providers/nvidia-nim.js`
+// sólo pasa `--model` si viene seteado, así que un spawn sin modelo explícito cae
+// acá. Reemplazado por V4-Flash-0731, verificado vivo el 2026-08-13.
+const DEFAULT_MODEL = 'deepseek-ai/deepseek-v4-flash-0731';
 const DEFAULT_MAX_TOKENS = 4096;
 
 // -----------------------------------------------------------------------------

--- a/.pipeline/lib/agent-models-validate.js
+++ b/.pipeline/lib/agent-models-validate.js
@@ -192,13 +192,18 @@ const ALLOWED_MODELS_BY_LAUNCHER = Object.freeze({
     'zai-glm-4.7',
   ]),
   // #3243 — NVIDIA NIM expone modelos hosted con naming `vendor/model`. La
-  // allowlist se inicializa con los 2 modelos sign-off del issue (DeepSeek
-  // V4-Pro para razonamiento/código y Kimi K2.6 para agentic loops). El
+  // allowlist se inicializa con los 2 modelos sign-off del issue (DeepSeek para
+  // razonamiento/código y Kimi K2.6 para agentic loops). El
   // catálogo crece editando esta lista — fuente única de verdad cross-validada
   // contra `provider.model` y `skills.<x>.model_override`. `gpt-oss-120b` queda
   // pendiente de validar disponibilidad/cuota antes de sumarse.
+  // #5887 — el modelo DeepSeek original llegó a end-of-life el 2026-08-07 y
+  // devolvía HTTP 410; se reemplaza (no se agrega al lado) por el flash pineado,
+  // verificado vivo el 2026-08-13 con GET /v1/models + POST /v1/chat/completions
+  // con tools[] → finish_reason=tool_calls. Comparación exacta contra strings
+  // literales: sin wildcard, sin prefix-match, sin bypass por env var.
   'nvidia-nim': Object.freeze([
-    'deepseek-ai/deepseek-v4-pro',
+    'deepseek-ai/deepseek-v4-flash-0731',
     'moonshotai/kimi-k2-instruct',
   ]),
   // launchers sin allowlist explícita → cualquier string `model` es válido.

--- a/.pipeline/lib/multi-provider/__tests__/completion-client-data-residency.test.js
+++ b/.pipeline/lib/multi-provider/__tests__/completion-client-data-residency.test.js
@@ -106,7 +106,7 @@ test('#4404 · negativo: path excluido (application.conf) → data_residency_blo
     const { impl, state } = fakeHttp({ status: 200 });
     const r = await completion.complete({
         provider: 'nvidia-nim',
-        model: 'deepseek-ai/deepseek-v4-pro',
+        model: 'deepseek-ai/deepseek-v4-flash-0731',
         prompt: 'analizá esto',
         // Excluido para non_anthropic por el sidecar real (**/application.conf).
         paths: ['users/src/main/resources/application.conf'],

--- a/.pipeline/lib/multi-provider/completion-client.js
+++ b/.pipeline/lib/multi-provider/completion-client.js
@@ -134,7 +134,10 @@ const PROVIDER_COMPLETION_ENDPOINTS = Object.freeze({
 // El `model` viaja como field del body JSON (no en la URL) → NO abre SSRF, pero
 // igual filtramos. Los modelos en producción salen de `.pipeline/agent-models.json`
 // (snapshot 2026-05-19): cerebras=llama-3.3-70b, gemini-google=gemini-2.0-flash,
-// nvidia-nim=deepseek-ai/deepseek-v4-pro. Si la lista se queda corta, agregar
+// nvidia-nim=deepseek-ai/deepseek-v4-flash-0731 (#5887, 2026-08-13: el
+// modelo deepseek anterior llegó a end-of-life el 2026-08-07 y devolvía HTTP 410
+// — se reemplaza, no se deja al lado, para que ninguna reintroducción pase
+// silenciosa por esta barrera). Si la lista se queda corta, agregar
 // acá + test.
 const PROVIDER_MODELS_ALLOWLIST = Object.freeze({
     cerebras: Object.freeze([
@@ -156,7 +159,7 @@ const PROVIDER_MODELS_ALLOWLIST = Object.freeze({
         'gemini-2.5-pro',
     ]),
     'nvidia-nim': Object.freeze([
-        'deepseek-ai/deepseek-v4-pro',
+        'deepseek-ai/deepseek-v4-flash-0731',
         'deepseek-ai/deepseek-r1',
         'meta/llama-3.1-8b-instruct',
         'meta/llama-3.1-70b-instruct',

--- a/.pipeline/tests/agent-launcher.test.js
+++ b/.pipeline/tests/agent-launcher.test.js
@@ -545,7 +545,7 @@ test('launchAgent con provider nvidia-nim spawnea el runner Node con args traduc
     const fsi = fakeFs([modelsPath], {
         [modelsPath]: JSON.stringify({
             skills: {
-                guru: { provider: 'nvidia-nim', model: 'deepseek-ai/deepseek-v4-pro' },
+                guru: { provider: 'nvidia-nim', model: 'deepseek-ai/deepseek-v4-flash-0731' },
             },
         }),
     });
@@ -563,7 +563,7 @@ test('launchAgent con provider nvidia-nim spawnea el runner Node con args traduc
             issue: 1,
             args: ['-p', 'probe', '--system-prompt-file', '/tmp/sys.md', '--output-format', 'stream-json'],
             cwd: ROOT,
-            env: { NVIDIA_NIM_MODEL: 'deepseek-ai/deepseek-v4-pro' },
+            env: { NVIDIA_NIM_MODEL: 'deepseek-ai/deepseek-v4-flash-0731' },
             PIPELINE,
             ROOT,
             fsImpl: fsi,
@@ -577,7 +577,7 @@ test('launchAgent con provider nvidia-nim spawnea el runner Node con args traduc
     assert.equal(call.cmd, '/fake/node');
     assert.equal(call.args[0], '/fake/nvidia-nim-runner.js');
     assert.ok(call.args.includes('--model'));
-    assert.ok(call.args.includes('deepseek-ai/deepseek-v4-pro'));
+    assert.ok(call.args.includes('deepseek-ai/deepseek-v4-flash-0731'));
     assert.ok(call.args.includes('--system-file'));
     assert.ok(call.args.includes('/tmp/sys.md'));
     assert.ok(call.args.includes('--prompt'));
@@ -598,7 +598,7 @@ test('nvidia-nim parseTokensFromLog mapea usage OpenAI (prompt/completion/cached
     const logPath = '/tmp/nvidia.json';
     const payload = JSON.stringify({
         id: 'cmpl-1',
-        model: 'deepseek-ai/deepseek-v4-pro',
+        model: 'deepseek-ai/deepseek-v4-flash-0731',
         choices: [{ message: { role: 'assistant', content: 'OK' } }],
         usage: {
             prompt_tokens: 100,

--- a/.pipeline/tests/health-gate-3809.test.js
+++ b/.pipeline/tests/health-gate-3809.test.js
@@ -137,7 +137,7 @@ function modelsWithChain(primary, fallbacks) {
             'openai-codex': { model: 'gpt-5-codex' },
             'gemini-google': { model: 'gemini-2.0-flash' },
             cerebras: { model: 'gpt-oss-120b' },
-            'nvidia-nim': { model: 'deepseek-ai/deepseek-v4-pro' },
+            'nvidia-nim': { model: 'deepseek-ai/deepseek-v4-flash-0731' },
         },
         skills: {
             'test-skill': { provider: primary, fallbacks },
@@ -238,7 +238,7 @@ test('A10 · rojo FRESCO y DURABLE (no_key_configured/forbidden) → gateado', (
 test('B1 · fallback rojo-fresco se saltea y se usa el siguiente + audit fallback_health_gated', () => {
     const models = modelsWithChain('anthropic', [
         { provider: 'cerebras', model_override: 'gpt-oss-120b' },
-        { provider: 'nvidia-nim', model_override: 'deepseek-ai/deepseek-v4-pro' },
+        { provider: 'nvidia-nim', model_override: 'deepseek-ai/deepseek-v4-flash-0731' },
     ]);
     const audit = fakeAuditLog();
     const snap = healthSnapshot([
@@ -374,7 +374,7 @@ test('B4 · healthReader que tira → fail-open (no rompe la resolución)', () =
 test('C1 · audit fallback_health_gated NO contiene API keys ni tokens', () => {
     const models = modelsWithChain('anthropic', [
         { provider: 'cerebras', model_override: 'gpt-oss-120b' },
-        { provider: 'nvidia-nim', model_override: 'deepseek-ai/deepseek-v4-pro' },
+        { provider: 'nvidia-nim', model_override: 'deepseek-ai/deepseek-v4-flash-0731' },
     ]);
     const audit = fakeAuditLog();
     const snap = healthSnapshot([

--- a/.pipeline/tests/smoke/nvidia-adapter.smoke.js
+++ b/.pipeline/tests/smoke/nvidia-adapter.smoke.js
@@ -23,7 +23,7 @@ const credentials = require('../../lib/credentials.js');
 
 const TIMEOUT_MS = 120_000;
 const PROMPT = 'Responde exactamente con la palabra OK y nada mas. No expliques nada.';
-const MODEL = process.env.NVIDIA_NIM_MODEL || 'deepseek-ai/deepseek-v4-pro';
+const MODEL = process.env.NVIDIA_NIM_MODEL || 'deepseek-ai/deepseek-v4-flash-0731';
 
 async function main() {
     // Hidratar la API key como lo hace el pulpo al boot.

--- a/docs/pipeline/auditoria-3803-multi-provider.md
+++ b/docs/pipeline/auditoria-3803-multi-provider.md
@@ -177,7 +177,7 @@ y los evaluadores (qa/po/ux).
 
 | Agente | Cadena |
 |--------|--------|
-| `backend-dev` | Opus → Codex `gpt-5-codex` → NVIDIA `deepseek-v4-pro` |
+| `backend-dev` | Opus → Codex `gpt-5-codex` → NVIDIA `deepseek-v4-flash-0731` |
 | `pipeline-dev` | Opus → Codex `gpt-5-codex` → NVIDIA |
 | `security` | Opus → Codex `gpt-5-codex` → NVIDIA |
 | `android-dev` | Opus → Codex `gpt-5-codex` → Gemini `2.0-flash` → NVIDIA |
@@ -253,6 +253,13 @@ condicionan la afirmación "funciona en todos los órdenes". Se atacan de a poco
 ### Deuda obsoleta de modelos en config base (validar contra catálogo real del provider)
 - **Cerebras** — runtime ya corregido a `gpt-oss-120b` (`llama-3.3-70b` estaba muerto: 404, fuera
   del free tier). Pueden quedar referencias obsoletas en configs/docs base sin tocar; limpiar al pasar.
-- **NVIDIA NIM** — el string `deepseek-ai/deepseek-v4-pro` configurado debería validarse contra el
+- **NVIDIA NIM** — el string DeepSeek configurado debería validarse contra el
   catálogo free real de NVIDIA NIM (análogo al caso Cerebras). **Leo lo marcó como no urgente** —
   se documenta para que quede registrado, no bloquea.
+  **Resuelto el 2026-08-13 (#5887), y la deuda se cobró:** el modelo DeepSeek que esta
+  auditoría señaló llegó a end-of-life el 2026-08-07T09:00:00Z y empezó a devolver HTTP 410 en toda
+  invocación, matando sin trabajo a todo agente que cayera a NVIDIA en su cadena de fallback.
+  Migrado a `deepseek-ai/deepseek-v4-flash-0731`, verificado vivo contra el catálogo real en la misma
+  pasada (`GET /v1/models` → presente, id viejo ausente) y con tool_use medido
+  (`POST /v1/chat/completions` con `tools[]` → `finish_reason: tool_calls`). La detección automatizada
+  de modelo muerto — que es lo que hubiera evitado los 6 días de sangrado — quedó como CA-5 de #5698.

--- a/docs/pipeline/multi-provider.md
+++ b/docs/pipeline/multi-provider.md
@@ -533,7 +533,7 @@ Convenciones:
 | `ux` | claude / opus-4-7 | openai-codex / gpt-5 | gemini-google / gemini-2.0-flash | cerebras / llama-3.3-70b | Vision (mockups/screenshots) — Gemini OK |
 | `doc` | claude / sonnet-4-7 | openai-codex / gpt-5-codex | cerebras / llama-3.3-70b | — | Gemini **EXCLUIDO** (estrategia de producto) |
 | `planner` | claude / sonnet-4-7 | openai-codex / gpt-5-codex | cerebras / llama-3.3-70b | — | Gemini **EXCLUIDO** (roadmap/estrategia) |
-| `guru` | claude / sonnet-4-7 | openai-codex / gpt-5-codex | cerebras / llama-3.3-70b | nvidia-nim / deepseek-v4-pro | Gemini **EXCLUIDO** (fragmentos código) |
+| `guru` | claude / sonnet-4-7 | openai-codex / gpt-5-codex | cerebras / llama-3.3-70b | nvidia-nim / deepseek-v4-flash-0731 | Gemini **EXCLUIDO** (fragmentos código) |
 | `ops` | claude / sonnet-4-7 | openai-codex / gpt-5-codex | cerebras / llama-3.3-70b | — | Gemini **EXCLUIDO sí o sí** (procesa API keys / AWS creds / Cognito) |
 | `perf` | claude / sonnet-4-7 | openai-codex / gpt-5-codex | gemini-google / gemini-2.0-flash | cerebras / llama-3.3-70b | Sin secrets — Gemini OK |
 | `auth` | claude / sonnet-4-7 | openai-codex / gpt-5-codex | cerebras / llama-3.3-70b | — | Gemini **EXCLUIDO** (config interna del entorno) |
@@ -1129,7 +1129,7 @@ Si por error pegaste una key directamente en el chat:
 4. **Issue de scrubbing retroactivo**: si querés limpiar el historial existente, ver [#3317](https://github.com/intrale/platform/issues/3317) (necesita aprobación humana, `needs-human`).
 ### 8.9 NVIDIA NIM — guía operativa específica (#3243)
 
-NVIDIA NIM es uno de los 3 free providers vivos (junto con Gemini y Cerebras, post #3353). Hostea ~80 modelos OpenAI-compatible en `integrate.api.nvidia.com`, con catálogo enfocado en razonamiento (DeepSeek V4-Pro, SWE-bench 80.6%) y agentic loops (Kimi K2.6, tool use 96.6%) — complementario a los llamas de Cerebras y a Gemini 2.0 Flash.
+NVIDIA NIM es uno de los 3 free providers vivos (junto con Gemini y Cerebras, post #3353). Hostea ~80 modelos OpenAI-compatible en `integrate.api.nvidia.com`, con catálogo enfocado en razonamiento (DeepSeek V4-Flash-0731 desde #5887; el V4 anterior con SWE-bench 80.6% fue retirado del catálogo) y agentic loops (Kimi K2.6, tool use 96.6%) — complementario a los llamas de Cerebras y a Gemini 2.0 Flash.
 
 **Cómo obtener la API key:**
 
@@ -1142,8 +1142,10 @@ NVIDIA NIM es uno de los 3 free providers vivos (junto con Gemini y Cerebras, po
 
 | Modelo | Capabilities | Context window | Uso recomendado |
 |--------|--------------|----------------|-----------------|
-| `deepseek-ai/deepseek-v4-pro` | `reasoning`, `coding`, `long_context` | 1M tokens | Razonamiento técnico, análisis de código de gran escala (SWE-bench Verified 80.6%, LiveCodeBench 93.5%) |
+| `deepseek-ai/deepseek-v4-flash-0731` | `reasoning`, `coding`, `long_context` | no verificada | Razonamiento técnico y análisis de código. **Sin benchmarks verificados**: los números que figuraban acá (SWE-bench Verified 80.6%, LiveCodeBench 93.5%) y la ventana de 1M tokens eran del modelo DeepSeek retirado y **no** se heredan a este modelo — no medir ≠ suponer (#5887). |
 | `moonshotai/kimi-k2-instruct` | `agentic`, `tool_use`, `long_context` | 128K tokens | Loops agentic con muchos tool calls (tool use success 96.6%, long-horizon 13h / 300 sub-agents) |
+
+> **Migración 2026-08-13 (#5887).** El modelo DeepSeek que este provider tenía configurado llegó a end-of-life el 2026-08-07T09:00:00Z y devolvía HTTP 410 en toda invocación, matando sin trabajo a todo agente que cayera a NVIDIA en su cadena de fallback. Sucesor verificado **en vivo** ese mismo día contra `integrate.api.nvidia.com`: (a) `GET /v1/models` → HTTP 200, `deepseek-ai/deepseek-v4-flash-0731` presente en el catálogo (102 modelos) y el id anterior **ausente**; (b) `POST /v1/chat/completions` con `tools[]` → HTTP 200, `finish_reason: tool_calls`, `tool_calls[0].function.name = read_file`. La (b) no es opcional: la capability `agentic-tool-use` se **declara** en el provider, no se mide, y un sucesor sin tool_use bootearía gates de confianza (`security`, `telegram-sherlock`) que no pueden leer archivos y fallan en abierto. Pin con sufijo de fecha (`-0731`), nunca alias flotante.
 
 Para agregar más modelos del catálogo NVIDIA NIM (ej. `gpt-oss-120b` opcional), seguir sección 3.2: editar `ALLOWED_MODELS_BY_LAUNCHER['nvidia-nim']` en `lib/agent-models-validate.js` + agregar entry en `agent-models.json` con el namespace `vendor/model`. El boot del pulpo cross-valida.
 
@@ -1158,7 +1160,7 @@ NVIDIA **NO publica** rate limits ni monthly quota del free tier. Las decisiones
 
 NVIDIA NIM permite que **partners** (3rd parties) hosteen modelos del catálogo en infra propia. Antes de flippear el provider a `activo` en runtime:
 
-- Verificar en `build.nvidia.com` que `deepseek-ai/deepseek-v4-pro` y `moonshotai/kimi-k2-instruct` aparecen como **"NVIDIA-direct"** (no "NIM Partner redeploy").
+- Verificar en `build.nvidia.com` que `deepseek-ai/deepseek-v4-flash-0731` y `moonshotai/kimi-k2-instruct` aparecen como **"NVIDIA-direct"** (no "NIM Partner redeploy").
 - Si alguno es partner, documentar el hop adicional acá y validar contra la matriz de policy TOS/DPA de #3084 antes de activar.
 - Estado actual: **pendiente de verificación** (al merge de #3243 los modelos quedan declarados como "configurados pero inactivos" hasta completar este check + la fila TOS/DPA en #3084).
 
@@ -1168,13 +1170,13 @@ NVIDIA NIM permite que **partners** (3rd parties) hosteen modelos del catálogo 
 |----------|------------------|------|---------|--------|
 | Gemini | `gemini-2.0-flash` | Generalista (sin código sensible — TOS entrena) | 1M | sin namespace |
 | Cerebras | `llama-3.3-70b` | Velocidad inference | 128K | sin namespace |
-| **NVIDIA NIM** | **`deepseek-v4-pro` / `kimi-k2`** | **Razonamiento / agentic** | **1M (DeepSeek)** | **`vendor/model`** |
+| **NVIDIA NIM** | **`deepseek-v4-flash-0731` / `kimi-k2`** | **Razonamiento / agentic** | **no verificada (DeepSeek)** | **`vendor/model`** |
 
 NVIDIA NIM aporta razonamiento de calidad alta en free tier — Cerebras es velocidad sobre llama, Gemini es generalista. Es **complementario**, no redundante. (Groq fue descontinuado en #3353.)
 
 **Asignación de skills (al merge de #3243):**
 
-- `guru` (análisis técnico): `nvidia-nim` queda como **último fallback** con `deepseek-ai/deepseek-v4-pro`. Anthropic sigue primero (sign-off Leo 2026-05-15).
+- `guru` (análisis técnico): `nvidia-nim` queda como **último fallback** con `deepseek-ai/deepseek-v4-flash-0731` (se migró tras el end-of-life del modelo DeepSeek anterior; ver #5887). Anthropic sigue primero (sign-off Leo 2026-05-15).
 - Resto de skills: sin asignación todavía. Promover NVIDIA NIM arriba en otros skills requiere sign-off humano explícito.
 
 ---


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 15 archivos · +87 -50

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:passed` aplicado por delivery

## Closes

Closes #5887
