### PR TITLE
[Split de #5698] Detectar modelos muertos en la cadena antes de que maten agentes

### DIFF
--- a/.pipeline/lib/__tests__/dashboard-onboarding-route.test.js
+++ b/.pipeline/lib/__tests__/dashboard-onboarding-route.test.js
@@ -69,7 +69,28 @@ test('#4851: onboarding conserva 5 pasos y expone los campos del descriptor comp
     assert.ok(res.body.includes('data-provider-id="nvidia-nim"'));
     assert.ok(res.body.includes('function owMoveProvider('));
     assert.ok(res.body.includes('function owProviderKey('));
-    assert.ok(!/groq/i.test(res.body), 'Groq/groq no debe aparecer en UI/script del wizard');
+
+    // El invariante de #4851 es "el wizard no OFRECE Groq como provider", no
+    // "el string groq no existe en ningun byte de la respuesta".
+    //
+    // Desde #5876 la vista inlinea el sprite compartido (`assets/icons/sprite.svg`)
+    // dentro de un `<div aria-hidden>` para que `<use href="#ic-pause-lock">` del
+    // banner de desync resuelva sin pedir el SVG por HTTP. Ese sprite es un asset
+    // global de todo el dashboard y trae un simbolo `ic-provider-groq` porque
+    // `groq` sigue siendo un provider id de primera clase en el resto del pipeline
+    // (credentials, redact, provider-balancer, validate-free-exclusions) y tiene
+    // sus propios tokens `--provider-groq*` en design-tokens.css. Es decir: el
+    // simbolo no es residuo del wizard y no se borra desde aca.
+    //
+    // Por eso el assert corre sobre el documento SIN el sprite: cubre el SSR del
+    // wizard, su script cliente y el shell, que es exactamente donde Groq no
+    // puede aparecer.
+    const SPRITE_BLOCK = /<div aria-hidden="true"[^>]*>\s*<!--[\s\S]*?<\/svg>\s*<\/div>/;
+    assert.match(res.body, SPRITE_BLOCK, 'la vista debe seguir inlineando el sprite compartido (#5876)');
+    const bodySinSprite = res.body.replace(SPRITE_BLOCK, '');
+    assert.ok(bodySinSprite.length < res.body.length, 'el sprite debe haberse recortado antes del assert');
+    assert.ok(bodySinSprite.includes('id="ow-form"'), 'recortar el sprite no debe llevarse el wizard');
+    assert.ok(!/groq/i.test(bodySinSprite), 'Groq/groq no debe aparecer en UI/script del wizard');
 });
 
 test('CA-S1: onboarding es un slug de la allowlist (partial desde loopback no da 400)', () => {

--- a/.pipeline/lib/__tests__/fixtures/agent-models-catalog-check.json
+++ b/.pipeline/lib/__tests__/fixtures/agent-models-catalog-check.json
@@ -1,0 +1,49 @@
+{
+  "_doc": "Fixture de #5888 (CA-1/CA-12). Copia LOCAL — esta parte del split NO edita el agent-models.json real (R-K). Cada modelo entra por UNA sola de las 4 fuentes, para que el test pueda demostrar que ninguna se saltea.",
+  "default_provider": "anthropic",
+  "providers": {
+    "anthropic": {
+      "model": "claude-opus-4-7"
+    },
+    "openai-codex": {
+      "model": "gpt-5.5"
+    },
+    "gemini-google": {
+      "_fuente": "1 (providers[].model) y 2 (alternative_models[])",
+      "model": "gemini-3-flash-preview",
+      "alternative_models": ["gemini-2.5-flash"]
+    },
+    "cerebras": {
+      "_fuente": "1 + 2. `zai-glm-4.7` NO está en el catálogo del fixture: es el caso 'alternative_model muerto'.",
+      "model": "gpt-oss-120b",
+      "alternative_models": ["zai-glm-4.7"]
+    },
+    "nvidia-nim": {
+      "_fuente": "el default del provider está VIVO; el modelo muerto entra sólo por el fallback de un skill (fuente 4).",
+      "model": "deepseek-ai/deepseek-r1"
+    },
+    "kimi-moonshot": {
+      "_fuente": "fuera de alcance por D-1 (#5892). No debe aparecer nunca en el cruce.",
+      "model": "kimi-k2-6"
+    },
+    "deterministic": {
+      "model": "deterministic"
+    }
+  },
+  "skills": {
+    "guru": {
+      "_fuente": "3 (skills[].model_override) — sobre gemini-google.",
+      "provider": "gemini-google",
+      "model_override": "gemini-2.5-pro",
+      "fallbacks": []
+    },
+    "security": {
+      "_fuente": "4 (fallbacks[].model_override) — ACÁ vive el modelo muerto, y en ningún otro lado. Es el caso que motivó la historia: deepseek-v4-pro mató agentes estando configurado como fallback.",
+      "provider": "anthropic",
+      "model_override": "claude-opus-4-7",
+      "fallbacks": [
+        { "provider": "nvidia-nim", "model_override": "deepseek-ai/deepseek-v4-pro" }
+      ]
+    }
+  }
+}

--- a/.pipeline/lib/__tests__/fixtures/catalog-cerebras.json
+++ b/.pipeline/lib/__tests__/fixtures/catalog-cerebras.json
@@ -1,0 +1,9 @@
+{
+  "object": "list",
+  "data": [
+    { "id": "gpt-oss-120b", "object": "model", "created": 1751830839, "owned_by": "Cerebras" },
+    { "id": "llama-3.3-70b", "object": "model", "created": 1733443200, "owned_by": "Meta" },
+    { "id": "qwen-3-235b-a22b-instruct-2507", "object": "model", "created": 1753731447, "owned_by": "Alibaba" },
+    { "id": "llama3.1-8b", "object": "model", "created": 1721692800, "owned_by": "Meta" }
+  ]
+}

--- a/.pipeline/lib/__tests__/fixtures/catalog-gemini.json
+++ b/.pipeline/lib/__tests__/fixtures/catalog-gemini.json
@@ -1,0 +1,40 @@
+{
+  "models": [
+    {
+      "name": "models/gemini-3-flash-preview",
+      "version": "001",
+      "displayName": "Gemini 3 Flash Preview",
+      "description": "Modelo rapido multimodal.",
+      "inputTokenLimit": 1048576,
+      "outputTokenLimit": 65536,
+      "supportedGenerationMethods": ["generateContent", "countTokens"]
+    },
+    {
+      "name": "models/gemini-2.5-flash",
+      "version": "001",
+      "displayName": "Gemini 2.5 Flash",
+      "description": "Modelo estable de generacion previa.",
+      "inputTokenLimit": 1048576,
+      "outputTokenLimit": 65536,
+      "supportedGenerationMethods": ["generateContent", "countTokens"]
+    },
+    {
+      "name": "models/gemini-2.5-pro",
+      "version": "001",
+      "displayName": "Gemini 2.5 Pro",
+      "description": "Modelo de razonamiento.",
+      "inputTokenLimit": 1048576,
+      "outputTokenLimit": 65536,
+      "supportedGenerationMethods": ["generateContent", "countTokens"]
+    },
+    {
+      "name": "models/text-embedding-004",
+      "version": "004",
+      "displayName": "Text Embedding 004",
+      "description": "Embeddings.",
+      "inputTokenLimit": 2048,
+      "outputTokenLimit": 1,
+      "supportedGenerationMethods": ["embedContent"]
+    }
+  ]
+}

--- a/.pipeline/lib/__tests__/fixtures/catalog-nvidia.json
+++ b/.pipeline/lib/__tests__/fixtures/catalog-nvidia.json
@@ -1,0 +1,10 @@
+{
+  "object": "list",
+  "data": [
+    { "id": "meta/llama-3.3-70b-instruct", "object": "model", "created": 735790403, "owned_by": "system", "root": "meta/llama-3.3-70b-instruct", "parent": null },
+    { "id": "qwen/qwen3-coder-480b-a35b-instruct", "object": "model", "created": 735790403, "owned_by": "system", "root": "qwen/qwen3-coder-480b-a35b-instruct", "parent": null },
+    { "id": "deepseek-ai/deepseek-r1", "object": "model", "created": 735790403, "owned_by": "system", "root": "deepseek-ai/deepseek-r1", "parent": null },
+    { "id": "moonshotai/kimi-k2-instruct", "object": "model", "created": 735790403, "owned_by": "system", "root": "moonshotai/kimi-k2-instruct", "parent": null },
+    { "id": "nvidia/llama-3.1-nemotron-70b-instruct", "object": "model", "created": 735790403, "owned_by": "system", "root": "nvidia/llama-3.1-nemotron-70b-instruct", "parent": null }
+  ]
+}

--- a/.pipeline/lib/__tests__/multi-provider-health-cron.test.js
+++ b/.pipeline/lib/__tests__/multi-provider-health-cron.test.js
@@ -389,7 +389,11 @@ test('runOnce: el snapshot NO contiene fingerprint, masked ni body excerpt', asy
     });
     const serialized = JSON.stringify(result.snapshot);
     assert.ok(!serialized.includes('VERY_SECRET'), 'snapshot no debe contener la API key');
-    assert.ok(!/fingerprint|masked|body_excerpt|bodyExcerpt/i.test(serialized), 'snapshot no debe contener fingerprint/masked/body');
+    // #5888 S-D — el cruce de catálogo suma un SEGUNDO buffer (hasta 1 MiB) que
+    // vive dentro de `live-ping.js`. Este invariante se ensancha para cubrirlo:
+    // si algún día `catalogRaw` se filtrara al snapshot, acá se ve.
+    assert.ok(!/fingerprint|masked|body_excerpt|bodyExcerpt|catalogRaw|catalog_raw/i.test(serialized),
+        'snapshot no debe contener fingerprint/masked/body/catálogo crudo');
 });
 
 test('runOnce: persiste snapshot a state/multi-provider-health.json', async () => {

--- a/.pipeline/lib/__tests__/multi-provider-live-ping.test.js
+++ b/.pipeline/lib/__tests__/multi-provider-live-ping.test.js
@@ -298,3 +298,33 @@ test('Gemini-Google usa header x-goog-api-key, NUNCA query string (SR-2)', () =>
     assert.ok(headers['x-goog-api-key'], 'Gemini debe usar header x-goog-api-key');
     assert.ok(!('key' in headers), 'no debe haber clave "key" suelta en headers');
 });
+
+// -----------------------------------------------------------------------------
+// #5888 — No-regresión del ping SIN `expectModels`.
+//
+// El cruce de catálogo suma un parámetro opcional a `ping()`. El ping manual del
+// dashboard (`api.js`, path FACTURABLE protegido por el throttle de #3965) NO lo
+// pasa: su shape de retorno tiene que seguir siendo byte por byte el de HEAD, y
+// no puede bajar un catálogo de hasta 1 MiB por proveedor (R-J).
+// -----------------------------------------------------------------------------
+test('#5888 R-J: ping sin expectModels devuelve exactamente el shape de HEAD', async () => {
+    const dir = tmpDir();
+    const f = path.join(dir, 'config.json');
+    writeKeys(f, { cerebras_api_key: 'csk_test_aaaaaaaaaaaaaaaaaaaa' });
+    const r = await livePing.ping({
+        provider: 'cerebras',
+        secretsPath: f,
+        httpImpl: fakeHttp({ status: 200, body: '{"object":"list","data":[{"id":"gpt-oss-120b"}]}' }),
+    });
+    assert.deepEqual(Object.keys(r).sort(), ['latency_ms', 'ok', 'provider', 'reason', 'statusCode']);
+    assert.equal('catalog_check' in r, false);
+    assert.equal(r.ok, true);
+    assert.equal(r.reason, 'authenticated');
+});
+
+test('#5888: la URL de Gemini incorpora ?pageSize=1000 sin dejar de ser literal (cond. 8)', () => {
+    const spec = livePing.PROVIDER_PING_ENDPOINTS['gemini-google'];
+    assert.equal(spec.url, 'https://generativelanguage.googleapis.com/v1beta/models?pageSize=1000');
+    // Sigue sin nada derivado de config ni de env.
+    assert.ok(!/process\.env/.test(String(spec.url)));
+});

--- a/.pipeline/lib/__tests__/multi-provider-model-catalog-check.test.js
+++ b/.pipeline/lib/__tests__/multi-provider-model-catalog-check.test.js
@@ -1,0 +1,1004 @@
+// =============================================================================
+// multi-provider-model-catalog-check.test.js — #5888
+//
+// Barrera que detecta un modelo configurado que ya no está en el catálogo vivo
+// de su provider, ANTES de que mate agentes.
+//
+// Contexto de por qué existe: `deepseek-ai/deepseek-v4-pro` llegó a EOL el
+// 2026-08-07 y nadie se enteró hasta que agentes sanos empezaron a morir con
+// HTTP 410 y el pulpo los sintetizó como rechazos de código.
+//
+// CERO RED (CA-12): todo el HTTP va por un `httpImpl` inyectado y los catálogos
+// salen de fixtures locales con la forma REAL de cada provider.
+// =============================================================================
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const crypto = require('node:crypto');
+const { EventEmitter } = require('node:events');
+
+const livePing = require('../multi-provider/live-ping');
+const healthAlerts = require('../multi-provider/health-alerts');
+const healthCron = require('../multi-provider/health-cron');
+const dispatch = require('../agent-launcher/dispatch-with-fallback');
+const providersView = require('../../views/dashboard/providers');
+
+const FIXTURES = path.join(__dirname, 'fixtures');
+const readFixture = (f) => JSON.parse(fs.readFileSync(path.join(FIXTURES, f), 'utf8'));
+const rawFixture = (f) => fs.readFileSync(path.join(FIXTURES, f), 'utf8');
+
+const CATALOG_NVIDIA = readFixture('catalog-nvidia.json');
+const CATALOG_GEMINI = readFixture('catalog-gemini.json');
+const CATALOG_CEREBRAS = readFixture('catalog-cerebras.json');
+const AGENT_MODELS = readFixture('agent-models-catalog-check.json');
+
+const DEAD_MODEL = 'deepseek-ai/deepseek-v4-pro';
+
+const SPEC_NVIDIA = livePing.PROVIDER_PING_ENDPOINTS['nvidia-nim'];
+const SPEC_GEMINI = livePing.PROVIDER_PING_ENDPOINTS['gemini-google'];
+const SPEC_CEREBRAS = livePing.PROVIDER_PING_ENDPOINTS.cerebras;
+
+function tmpDir() { return fs.mkdtempSync(path.join(os.tmpdir(), 'mp-catalog-')); }
+
+// Resultado crudo de `doRequest` tal como lo recibe `crossCheckCatalog`.
+function reqResult({ statusCode = 200, body = null, truncated = false } = {}) {
+    return {
+        statusCode,
+        bodyExcerpt: '',
+        catalogRaw: body === null ? null : Buffer.from(typeof body === 'string' ? body : JSON.stringify(body), 'utf8'),
+        catalogTruncated: truncated,
+    };
+}
+
+// -----------------------------------------------------------------------------
+// Fake HTTP con streaming real: emite el body por chunks, respeta `destroy()`
+// y emite `'close'` (NO `'end'`) cuando lo destruyen — que es exactamente lo
+// que hace `http.IncomingMessage` y el motivo de R-F.
+// -----------------------------------------------------------------------------
+function fakeHttp({ status = 200, body = '', chunkSize = 0, error = null } = {}) {
+    const calls = [];
+    return {
+        calls,
+        request(opts, cb) {
+            calls.push(opts);
+            const req = new EventEmitter();
+            req.write = () => {};
+            req.destroy = (e) => { req.emit('error', e || new Error('destroyed')); };
+            req.end = () => {
+                process.nextTick(() => {
+                    if (error) { req.emit('error', error); return; }
+                    const res = new EventEmitter();
+                    res.statusCode = status;
+                    res.destroyed = false;
+                    res.destroy = () => {
+                        if (res.destroyed) return;
+                        res.destroyed = true;
+                        setImmediate(() => res.emit('close'));
+                    };
+                    const buf = Buffer.from(body, 'utf8');
+                    const size = chunkSize > 0 ? chunkSize : Math.max(buf.length, 1);
+                    let off = 0;
+                    const pump = () => {
+                        if (res.destroyed) return;
+                        if (off >= buf.length) { res.emit('end'); return; }
+                        const c = buf.subarray(off, off + size);
+                        off += size;
+                        res.emit('data', c);
+                        setImmediate(pump);
+                    };
+                    cb(res);
+                    setImmediate(pump);
+                });
+            };
+            return req;
+        },
+    };
+}
+
+function secretsWith(dir, keys) {
+    const f = path.join(dir, 'config.json');
+    fs.writeFileSync(f, JSON.stringify(keys));
+    return f;
+}
+
+test.beforeEach(() => livePing._resetPingThrottle());
+
+// =============================================================================
+// CA-1 — El cruce detecta el modelo muerto donde realmente mata: el fallback
+// =============================================================================
+
+test('CA-1: el modelo muerto se detecta aunque exista SÓLO como fallbacks[].model_override', () => {
+    const byProvider = healthCron.configuredModelsByProvider(AGENT_MODELS);
+    const nvidia = byProvider.get('nvidia-nim');
+    assert.ok(nvidia, 'nvidia-nim debe tener modelos configurados');
+    assert.ok(nvidia.has(DEAD_MODEL), 'el modelo del fallback debe entrar al cruce');
+    // Y en el fixture NO está en ningún otro lado: si el cruce sólo mirara
+    // `providers[].model` este assert fallaría.
+    assert.notEqual(AGENT_MODELS.providers['nvidia-nim'].model, DEAD_MODEL);
+
+    const out = livePing._crossCheckCatalog({
+        spec: SPEC_NVIDIA,
+        result: reqResult({ body: CATALOG_NVIDIA }),
+        expectModels: Array.from(nvidia).sort(),
+    });
+    assert.equal(out.ok, true);
+    const dead = out.models.filter((m) => !m.alive).map((m) => m.model_id);
+    assert.deepEqual(dead, [DEAD_MODEL]);
+});
+
+test('CA-1: `configuredModelsByProvider` cubre las 4 fuentes, una por fuente', () => {
+    const by = healthCron.configuredModelsByProvider(AGENT_MODELS);
+    // fuente 1 — providers[].model
+    assert.ok(by.get('cerebras').has('gpt-oss-120b'));
+    // fuente 2 — providers[].alternative_models[]
+    assert.ok(by.get('cerebras').has('zai-glm-4.7'));
+    // fuente 3 — skills[].model_override
+    assert.ok(by.get('gemini-google').has('gemini-2.5-pro'));
+    // fuente 4 — skills[].fallbacks[].model_override
+    assert.ok(by.get('nvidia-nim').has(DEAD_MODEL));
+});
+
+test('CA-1: el cruce es por par (provider, model_id) — un id de Cerebras no se busca en NVIDIA', () => {
+    // `gpt-oss-120b` vive en Cerebras y NO está en el catálogo de NVIDIA. Si el
+    // cruce usara el id suelto contra un catálogo global, lo marcaría muerto.
+    const enNvidia = livePing._crossCheckCatalog({
+        spec: SPEC_NVIDIA,
+        result: reqResult({ body: CATALOG_NVIDIA }),
+        expectModels: Array.from(healthCron.configuredModelsByProvider(AGENT_MODELS).get('nvidia-nim')),
+    });
+    assert.equal(enNvidia.models.some((m) => m.model_id === 'gpt-oss-120b'), false,
+        'un modelo de Cerebras no debe siquiera evaluarse contra el catálogo de NVIDIA');
+
+    const enCerebras = livePing._crossCheckCatalog({
+        spec: SPEC_CEREBRAS,
+        result: reqResult({ body: CATALOG_CEREBRAS }),
+        expectModels: ['gpt-oss-120b'],
+    });
+    assert.deepEqual(enCerebras.models, [{ model_id: 'gpt-oss-120b', alive: true }]);
+});
+
+test('CA-1: `expectModelsForPing` sólo cubre los 3 providers en alcance y usa el mapeo de nombres', () => {
+    const m = healthCron.expectModelsForPing(AGENT_MODELS);
+    assert.deepEqual(Array.from(m.keys()).sort(), ['cerebras', 'gemini-google', 'nvidia-nim']);
+    assert.equal(m.has('kimi-moonshot'), false, 'D-1: kimi-moonshot fuera de alcance');
+    assert.equal(m.has('anthropic'), false);
+    assert.equal(m.has('openai'), false);
+});
+
+// =============================================================================
+// CA-2 — El catálogo se parsea con la forma REAL de cada provider
+// =============================================================================
+
+test('CA-2/G-1: con el catálogo Gemini real (models[].name con prefijo), gemini-3-flash-preview NO se marca ausente', () => {
+    const out = livePing._crossCheckCatalog({
+        spec: SPEC_GEMINI,
+        result: reqResult({ body: CATALOG_GEMINI }),
+        expectModels: ['gemini-3-flash-preview', 'gemini-2.5-flash', 'gemini-2.5-pro'],
+    });
+    assert.equal(out.ok, true);
+    assert.deepEqual(out.models.filter((m) => !m.alive), [],
+        'sin normalizar el prefijo `models/`, TODO modelo vivo se reportaría muerto');
+});
+
+test('CA-2: NVIDIA y Cerebras usan `data[].id` plano; Gemini usa `models[].name`', () => {
+    assert.deepEqual(SPEC_NVIDIA.catalogExtract(CATALOG_CEREBRAS), CATALOG_CEREBRAS.data.map((m) => m.id));
+    assert.deepEqual(SPEC_GEMINI.catalogExtract(CATALOG_GEMINI),
+        CATALOG_GEMINI.models.map((m) => m.name.replace(/^models\//, '')));
+    // Cruzar extractores da vacío — por eso cada provider tiene el suyo.
+    assert.deepEqual(SPEC_CEREBRAS.catalogExtract(CATALOG_GEMINI), []);
+});
+
+test('CA-2/G-2/R-H: `nextPageToken` no vacío ⇒ model_check_unavailable, jamás not_in_catalog', () => {
+    const paginado = { ...CATALOG_GEMINI, nextPageToken: 'CAESBk1PUkU=' };
+    const out = livePing._crossCheckCatalog({
+        spec: SPEC_GEMINI,
+        result: reqResult({ body: paginado }),
+        expectModels: ['gemini-3-flash-preview'],
+    });
+    assert.equal(out.ok, false);
+    assert.equal(out.reason_code, 'model_check_unavailable');
+    assert.equal(out.detail, 'paginated');
+    assert.deepEqual(out.models, []);
+});
+
+test('CA-2: la URL de Gemini lleva ?pageSize=1000 literal y sigue hardcodeada (cond. 8)', () => {
+    assert.match(SPEC_GEMINI.url, /^https:\/\/generativelanguage\.googleapis\.com\/v1beta\/models\?pageSize=1000$/);
+    for (const [prov, spec] of Object.entries(livePing.PROVIDER_PING_ENDPOINTS)) {
+        assert.equal(typeof spec.url, 'string', `${prov}: url literal`);
+        assert.match(spec.url, /^https:\/\//, `${prov}: solo HTTPS`);
+    }
+});
+
+// =============================================================================
+// CA-3 — Matriz fail-open exhaustiva, UNA FILA POR CASO
+// =============================================================================
+
+test('CA-3 fila 1: 200 + catálogo completo + id presente ⇒ vigente, sin alerta', () => {
+    const out = livePing._crossCheckCatalog({
+        spec: SPEC_CEREBRAS, result: reqResult({ body: CATALOG_CEREBRAS }), expectModels: ['gpt-oss-120b'],
+    });
+    assert.equal(out.ok, true);
+    assert.equal(out.reason_code, null);
+    assert.deepEqual(out.models, [{ model_id: 'gpt-oss-120b', alive: true }]);
+});
+
+test('CA-3 fila 2: 200 + catálogo completo + id ausente ⇒ model_not_in_catalog', () => {
+    const out = livePing._crossCheckCatalog({
+        spec: SPEC_CEREBRAS, result: reqResult({ body: CATALOG_CEREBRAS }), expectModels: ['zai-glm-4.7'],
+    });
+    assert.equal(out.ok, true);
+    assert.deepEqual(out.models, [{ model_id: 'zai-glm-4.7', alive: false }]);
+    const built = healthCron.buildCatalogCheck(out, '2026-08-13T13:00:00.000Z');
+    assert.equal(built.state, 'not_in_catalog');
+    assert.equal(built.reason_code, 'model_not_in_catalog');
+});
+
+test('CA-3 fila 3: body no parseable ⇒ model_check_unavailable', () => {
+    const out = livePing._crossCheckCatalog({
+        spec: SPEC_NVIDIA, result: reqResult({ body: '<html><body>502 Bad Gateway</body></html>' }), expectModels: [DEAD_MODEL],
+    });
+    assert.equal(out.reason_code, 'model_check_unavailable');
+    assert.equal(out.detail, 'unparseable');
+});
+
+test('CA-3 fila 4: body truncado ⇒ model_check_unavailable', () => {
+    const out = livePing._crossCheckCatalog({
+        spec: SPEC_NVIDIA, result: reqResult({ body: CATALOG_NVIDIA, truncated: true }), expectModels: [DEAD_MODEL],
+    });
+    assert.equal(out.reason_code, 'model_check_unavailable');
+    assert.equal(out.detail, 'truncated');
+});
+
+for (const status of [401, 403, 429, 500]) {
+    test(`CA-3 fila 5: HTTP ${status} ⇒ model_check_unavailable (nunca dead)`, () => {
+        const out = livePing._crossCheckCatalog({
+            spec: SPEC_NVIDIA, result: reqResult({ statusCode: status, body: CATALOG_NVIDIA }), expectModels: [DEAD_MODEL],
+        });
+        assert.equal(out.ok, false);
+        assert.equal(out.reason_code, 'model_check_unavailable');
+        assert.equal(out.detail, 'http_status');
+        assert.deepEqual(out.models, []);
+    });
+}
+
+test('CA-3 fila 6: timeout / error de red ⇒ model_check_unavailable, nunca dead', async () => {
+    const dir = tmpDir();
+    const secretsPath = secretsWith(dir, { nvidia_nim_api_key: 'nvapi-aaaaaaaaaaaaaaaaaaaaaa' });
+    const r = await livePing.ping({
+        provider: 'nvidia-nim',
+        secretsPath,
+        httpImpl: fakeHttp({ error: Object.assign(new Error('Timeout'), { code: 'ETIMEDOUT' }) }),
+        expectModels: [DEAD_MODEL],
+    });
+    assert.equal(r.reason, 'timeout');
+    assert.equal(r.catalog_check.reason_code, 'model_check_unavailable');
+    assert.equal(r.catalog_check.detail, 'request_failed');
+    assert.deepEqual(r.catalog_check.models, []);
+});
+
+test('CA-3 fila 7: provider sin key configurada ⇒ model_check_unavailable (no "todo bien")', () => {
+    // El ping corta antes del HTTP (`no_key_configured`), así que no hay
+    // `catalog_check` en el resultado. El cron lo traduce a "no verificable".
+    const built = healthCron.buildCatalogCheck(undefined, '2026-08-13T13:00:00.000Z');
+    assert.equal(built.state, 'unavailable');
+    assert.equal(built.reason_code, 'model_check_unavailable');
+});
+
+test('CA-3/R-G: catálogo vacío ⇒ model_check_unavailable, NO "todos los modelos muertos"', () => {
+    // Un provider que cambia el shape de su respuesta devolvería `[]` y marcaría
+    // TODOS los modelos como muertos: alerta masiva falsa que entrena al
+    // operador a ignorar la barrera. Es también la defensa de la cond. 1.
+    for (const body of [{ data: [] }, { object: 'list' }, {}]) {
+        const out = livePing._crossCheckCatalog({
+            spec: SPEC_NVIDIA, result: reqResult({ body }), expectModels: [DEAD_MODEL, 'deepseek-ai/deepseek-r1'],
+        });
+        assert.equal(out.reason_code, 'model_check_unavailable');
+        assert.equal(out.detail, 'empty_catalog');
+        assert.deepEqual(out.models, []);
+    }
+});
+
+test('CA-3: el extractor que lanza ⇒ model_check_unavailable, no propaga la excepción', () => {
+    const specRoto = { catalogExtract: () => { throw new Error('shape cambiado'); } };
+    const out = livePing._crossCheckCatalog({
+        spec: specRoto, result: reqResult({ body: CATALOG_NVIDIA }), expectModels: [DEAD_MODEL],
+    });
+    assert.equal(out.reason_code, 'model_check_unavailable');
+    assert.equal(out.detail, 'extractor_error');
+});
+
+test('CA-3: NINGUNA ruta de la matriz produce not_in_catalog sin catálogo completo', () => {
+    const rutas = [
+        reqResult({ statusCode: 401, body: CATALOG_NVIDIA }),
+        reqResult({ statusCode: 403, body: CATALOG_NVIDIA }),
+        reqResult({ statusCode: 500, body: CATALOG_NVIDIA }),
+        reqResult({ body: 'no-json' }),
+        reqResult({ body: CATALOG_NVIDIA, truncated: true }),
+        reqResult({ body: { data: [] } }),
+        reqResult({ body: { ...CATALOG_NVIDIA, nextPageToken: 'x' } }),
+        reqResult({ body: null }),
+    ];
+    for (const r of rutas) {
+        const built = healthCron.buildCatalogCheck(
+            livePing._crossCheckCatalog({ spec: SPEC_NVIDIA, result: r, expectModels: [DEAD_MODEL] }),
+            '2026-08-13T13:00:00.000Z',
+        );
+        assert.notEqual(built.state, 'not_in_catalog');
+        assert.equal(built.reason_code, 'model_check_unavailable');
+    }
+});
+
+// =============================================================================
+// CA-4 — Los reason codes sobreviven al sanitize y NO gatean el provider
+// =============================================================================
+
+test('CA-4/cond.3: sanitizeReasonCode NO colapsa los codes nuevos a `unknown`', () => {
+    // Sin esto la alerta se emitiría igual y los tests pasarían aparentando
+    // funcionar — `sanitizeReasonCode` colapsa en silencio, sin error ni log.
+    assert.equal(healthAlerts.sanitizeReasonCode('model_not_in_catalog'), 'model_not_in_catalog');
+    assert.equal(healthAlerts.sanitizeReasonCode('model_check_unavailable'), 'model_check_unavailable');
+});
+
+test('CA-4/R-C/S-E: pertenencia ASIMÉTRICA — ∈ ALLOWED_REASON_CODES y ∉ DURABLE_RED_REASONS', () => {
+    for (const code of ['model_not_in_catalog', 'model_check_unavailable']) {
+        assert.equal(healthAlerts.ALLOWED_REASON_CODES.has(code), true, `${code} debe sobrevivir al sanitize`);
+        assert.equal(dispatch.DURABLE_RED_REASONS.has(code), false,
+            `${code} NO puede ser rojo durable: sacaría al provider ENTERO de la cascada de fallback por un solo modelo caído`);
+    }
+});
+
+// =============================================================================
+// CA-5 / CA-16 — Un modelo muerto no pone rojo al provider
+// =============================================================================
+
+test('CA-5: un evento de modelo no cambia `state` ni `reason_code` del provider en el snapshot', async () => {
+    const dir = tmpDir();
+    const secretsPath = secretsWith(dir, { nvidia_nim_api_key: 'nvapi-aaaaaaaaaaaaaaaaaaaaaa' });
+    const result = await healthCron.runOnce({
+        stateDir: path.join(dir, 'state'),
+        auditDir: path.join(dir, 'audit'),
+        secretsPath,
+        checkCatalog: true,
+        agentModelsConfig: AGENT_MODELS,
+        pingImpl: async ({ provider, expectModels }) => ({
+            ok: true,
+            reason: 'authenticated',
+            statusCode: 200,
+            provider,
+            catalog_check: livePing._crossCheckCatalog({
+                spec: SPEC_NVIDIA, result: reqResult({ body: CATALOG_NVIDIA }), expectModels: expectModels || [],
+            }),
+        }),
+        cliProbe: () => false,
+        telegramSender: () => true,
+        dedupFile: path.join(dir, 'dedup.json'),
+        skipAudit: true,
+    });
+    const nvidia = result.snapshot.providers.find((p) => p.provider === 'nvidia-nim');
+    assert.equal(nvidia.state, 'green', 'NVIDIA sigue sirviendo el resto de su catálogo');
+    assert.equal(nvidia.reason_code, 'authenticated', 'el eje de salud queda intacto');
+    assert.equal(nvidia.catalog_check.state, 'not_in_catalog', 'el evento viaja por el eje de modelo');
+    assert.equal(nvidia.catalog_check.reason_code, 'model_not_in_catalog');
+});
+
+// =============================================================================
+// CA-6 / S-A — sanitizeModelId y la alerta degradada
+// =============================================================================
+
+test('CA-6/S-A: sanitizeModelId rechaza metacaracteres Markdown, HTML, mayúsculas y >64', () => {
+    const malos = [
+        'model`whoami`', 'model[x](http://evil)', 'a*b*c', 'model_id_con_guion_bajo',
+        'Model-Mayus', '<script>alert(1)</script>', '', '-empieza-con-guion',
+        'a'.repeat(65), 'modelo con espacios', 'model\nid', 'model;rm -rf /',
+        null, undefined, 42, {},
+    ];
+    for (const m of malos) {
+        assert.equal(healthAlerts.sanitizeModelId(m), null, `debe rechazar: ${String(m).slice(0, 40)}`);
+    }
+    // Los 6 ids reales del config + el del vendor con `/` deben pasar.
+    for (const m of ['claude-opus-4-7', 'gpt-5.5', 'gemini-3-flash-preview', 'gpt-oss-120b',
+        'zai-glm-4.7', 'kimi-k2-6', DEAD_MODEL]) {
+        assert.equal(healthAlerts.sanitizeModelId(m), m, `debe aceptar: ${m}`);
+    }
+});
+
+test('CA-6/S-A: con sanitizeModelId → null la alerta IGUAL se emite, sin el id crudo', () => {
+    const dir = tmpDir();
+    const crudo = 'evil`[click](http://evil)`';
+    const decision = healthAlerts.decideModelEvent({
+        provider: 'nvidia-nim',
+        modelId: crudo,
+        providerState: 'green',
+        now: Date.parse('2026-08-13T13:00:00.000Z'),
+        dedupFile: path.join(dir, 'dedup.json'),
+    });
+    assert.equal(decision.shouldEmit, true, 'fail-closed no significa silencio');
+    assert.equal(decision.payload.model_id, null);
+    const texto = healthCron.formatAlertText(decision.payload);
+    assert.equal(texto.includes(crudo), false, 'jamás el id crudo');
+    assert.equal(texto.includes('evil'), false);
+    assert.match(texto, /identificador no representable/);
+    assert.match(texto, /^⚠️/);
+});
+
+test('CA-6/CA-17: el texto de la alerta afirma que el provider sigue sano y nombra la consecuencia', () => {
+    const dir = tmpDir();
+    const decision = healthAlerts.decideModelEvent({
+        provider: 'nvidia-nim',
+        modelId: DEAD_MODEL,
+        providerState: 'green',
+        now: Date.parse('2026-08-13T13:00:00.000Z'),
+        dedupFile: path.join(dir, 'dedup.json'),
+    });
+    const texto = healthCron.formatAlertText(decision.payload);
+    assert.match(texto, /^⚠️ \*Modelo fuera de catálogo\*/, 'la severidad la fija el eje-modelo, no el estado del provider');
+    assert.ok(texto.includes('🟢 SANO'), 'el estado del provider se conserva, subordinado');
+    assert.ok(texto.includes(DEAD_MODEL));
+    assert.ok(texto.includes('como primario o como fallback'), 'el fallback es el caso que el operador no deduce solo');
+    assert.ok(texto.includes('van a fallar al despachar'), 'nombra la consecuencia, no sólo el hecho');
+    // UX-5: NO puede leerse como el mensaje rutinario de salud.
+    assert.equal(/🩺 \*Multi-Provider Health\*/.test(texto), false);
+    assert.equal(/`nvidia-nim` → `GREEN`/.test(texto), false);
+});
+
+test('CA-17/R-D: la key de dedup del evento de modelo no colisiona con la del eje de salud', () => {
+    const dir = tmpDir();
+    const dedupFile = path.join(dir, 'dedup.json');
+    const t0 = Date.parse('2026-08-13T13:00:00.000Z');
+
+    const d1 = healthAlerts.decideModelEvent({ provider: 'nvidia-nim', modelId: DEAD_MODEL, providerState: 'green', now: t0, dedupFile });
+    assert.equal(d1.shouldEmit, true);
+    healthAlerts.recordModelEvent({ provider: 'nvidia-nim', modelId: DEAD_MODEL, sent: true, now: t0, dedupFile });
+
+    // Dentro de la ventana de 24h no se repite (condición persistente, 1/día).
+    const d2 = healthAlerts.decideModelEvent({ provider: 'nvidia-nim', modelId: DEAD_MODEL, providerState: 'green', now: t0 + 6 * 3600e3, dedupFile });
+    assert.equal(d2.shouldEmit, false);
+    assert.equal(d2.reasonNoEmit, 'dedup_window');
+
+    // …pero la alerta de SALUD del mismo provider sigue libre de emitir.
+    const salud = healthAlerts.decide({ provider: 'nvidia-nim', state: 'red', reasonCode: 'invalid_credentials', now: t0 + 60e3, dedupFile });
+    assert.equal(salud.shouldEmit, true, 'el evento de modelo no puede suprimir la alerta de salud');
+
+    // Y pasadas 24h el recordatorio vuelve.
+    const d3 = healthAlerts.decideModelEvent({ provider: 'nvidia-nim', modelId: DEAD_MODEL, providerState: 'green', now: t0 + 25 * 3600e3, dedupFile });
+    assert.equal(d3.shouldEmit, true);
+});
+
+test('CA-17/D-3: model_check_unavailable NO emite a Telegram', () => {
+    const dir = tmpDir();
+    const enviados = [];
+    const snapshot = {
+        ts: '2026-08-13T13:00:00.000Z',
+        providers: [{
+            provider: 'nvidia-nim', state: 'green', reason_code: 'authenticated',
+            catalog_check: { state: 'unavailable', checked_at: '2026-08-13T13:00:00.000Z', reason_code: 'model_check_unavailable', models: [] },
+        }],
+    };
+    healthCron.emitAlerts({
+        snapshot, prevSnapshot: null,
+        telegramSender: (p) => { enviados.push(p); return true; },
+        dedupFile: path.join(dir, 'dedup.json'),
+        now: Date.parse('2026-08-13T13:00:00.000Z'),
+    });
+    assert.deepEqual(enviados, [], 'la ausencia de señal no es un evento: alertar por ella entrena a ignorar el canal');
+});
+
+// =============================================================================
+// CA-7 / cond. 1 — Alerta, NUNCA auto-mutación
+// =============================================================================
+
+test('CA-7: el flujo completo con catálogo vacío no modifica ningún archivo de config', async () => {
+    const dir = tmpDir();
+    const configFile = path.join(dir, 'agent-models.json');
+    fs.writeFileSync(configFile, JSON.stringify(AGENT_MODELS, null, 2));
+    const hashAntes = crypto.createHash('sha256').update(fs.readFileSync(configFile)).digest('hex');
+
+    const secretsPath = secretsWith(dir, {
+        nvidia_nim_api_key: 'nvapi-aaaaaaaaaaaaaaaaaaaaaa',
+        cerebras_api_key: 'csk_test_aaaaaaaaaaaaaaaaaaaa',
+    });
+    await healthCron.runOnce({
+        stateDir: path.join(dir, 'state'),
+        auditDir: path.join(dir, 'audit'),
+        secretsPath,
+        checkCatalog: true,
+        agentModelsConfig: JSON.parse(fs.readFileSync(configFile, 'utf8')),
+        // Catálogo vacío: el peor caso — sin fail-open marcaría TODO muerto.
+        httpImpl: fakeHttp({ status: 200, body: JSON.stringify({ object: 'list', data: [] }) }),
+        cliProbe: () => false,
+        telegramSender: () => true,
+        dedupFile: path.join(dir, 'dedup.json'),
+        skipAudit: true,
+    });
+
+    const hashDespues = crypto.createHash('sha256').update(fs.readFileSync(configFile)).digest('hex');
+    assert.equal(hashDespues, hashAntes, 'un catálogo vacío no puede DoSear el pipeline mutando su config');
+});
+
+// =============================================================================
+// CA-10 — Cadencia desacoplada del health-ping
+// =============================================================================
+
+test('CA-10: isCatalogCheckDue — nunca corrió ⇒ debido; dentro del TTL ⇒ no', () => {
+    const dir = tmpDir();
+    const stateFile = path.join(dir, 'state.json');
+    const ttlMs = 6 * 3600e3;
+    assert.equal(healthCron.isCatalogCheckDue({ stateFile, ttlMs }), true);
+
+    const now = Date.parse('2026-08-13T13:00:00.000Z');
+    fs.writeFileSync(stateFile, JSON.stringify({ last_catalog_check_at: now }));
+    assert.equal(healthCron.isCatalogCheckDue({ stateFile, now: now + 5 * 60e3, ttlMs }), false, 'el tick de 5 min no re-descarga');
+    assert.equal(healthCron.isCatalogCheckDue({ stateFile, now: now + 5 * 3600e3, ttlMs }), false);
+    assert.equal(healthCron.isCatalogCheckDue({ stateFile, now: now + 6 * 3600e3, ttlMs }), true);
+});
+
+test('CA-10: el TTL de catálogo tiene piso de 6h — un config equivocado no puede bajarlo', () => {
+    assert.equal(healthCron.CATALOG_CHECK_DEFAULT_HOURS, 6);
+    assert.equal(healthCron.CATALOG_CHECK_MIN_HOURS, 6);
+    // El health-ping sigue en 5 min, sin tocar.
+    assert.equal(healthCron.DEFAULT_INTERVAL_MINUTES, 5);
+});
+
+test('CA-10: dos ticks dentro del TTL ⇒ UNA sola descarga de catálogo', async () => {
+    const dir = tmpDir();
+    const stateDir = path.join(dir, 'state');
+    const secretsPath = secretsWith(dir, { nvidia_nim_api_key: 'nvapi-aaaaaaaaaaaaaaaaaaaaaa' });
+    const conCatalogo = [];
+    const pingImpl = async ({ provider, expectModels }) => {
+        if (Array.isArray(expectModels) && expectModels.length) conCatalogo.push(provider);
+        return { ok: true, reason: 'authenticated', statusCode: 200, provider };
+    };
+    const base = {
+        stateDir, auditDir: path.join(dir, 'audit'), secretsPath,
+        agentModelsConfig: AGENT_MODELS, pingImpl, cliProbe: () => false,
+        telegramSender: () => true, dedupFile: path.join(dir, 'dedup.json'),
+        skipAudit: true, jitter: 0, catalogTtlMs: 6 * 3600e3,
+    };
+    const t0 = Date.parse('2026-08-13T13:00:00.000Z');
+    await healthCron.tickIfDue({ ...base, now: t0 });
+    await healthCron.tickIfDue({ ...base, now: t0 + 10 * 60e3 });   // 10 min después
+    assert.deepEqual(conCatalogo, ['nvidia-nim'], 'el 2do tick no vuelve a bajar el catálogo');
+
+    // Fuera del TTL sí vuelve a descargar.
+    await healthCron.tickIfDue({ ...base, now: t0 + 7 * 3600e3 });
+    assert.deepEqual(conCatalogo, ['nvidia-nim', 'nvidia-nim']);
+});
+
+test('CA-10/R-E: carry-over — el tick intermedio conserva el catalog_check previo', async () => {
+    const dir = tmpDir();
+    const stateDir = path.join(dir, 'state');
+    const secretsPath = secretsWith(dir, { nvidia_nim_api_key: 'nvapi-aaaaaaaaaaaaaaaaaaaaaa' });
+    const pingImpl = async ({ provider, expectModels }) => ({
+        ok: true, reason: 'authenticated', statusCode: 200, provider,
+        ...(Array.isArray(expectModels) && expectModels.length
+            ? {
+                catalog_check: livePing._crossCheckCatalog({
+                    spec: SPEC_NVIDIA, result: reqResult({ body: CATALOG_NVIDIA }), expectModels,
+                }),
+            }
+            : {}),
+    });
+    const base = {
+        stateDir, auditDir: path.join(dir, 'audit'), secretsPath,
+        agentModelsConfig: AGENT_MODELS, pingImpl, cliProbe: () => false,
+        telegramSender: () => true, dedupFile: path.join(dir, 'dedup.json'),
+        skipAudit: true, jitter: 0, catalogTtlMs: 6 * 3600e3,
+    };
+    const t0 = Date.parse('2026-08-13T13:00:00.000Z');
+    const r1 = await healthCron.tickIfDue({ ...base, now: t0 });
+    const cc1 = r1.snapshot.providers.find((p) => p.provider === 'nvidia-nim').catalog_check;
+    assert.equal(cc1.state, 'not_in_catalog');
+
+    const r2 = await healthCron.tickIfDue({ ...base, now: t0 + 10 * 60e3 });
+    const cc2 = r2.snapshot.providers.find((p) => p.provider === 'nvidia-nim').catalog_check;
+    assert.deepEqual(cc2, cc1, 'sin carry-over la celda parpadearía a "nunca verificada" cada 5 min');
+});
+
+test('CA-10: el comentario obsoleto de la cadencia ya no dice 15min', () => {
+    const src = fs.readFileSync(path.join(__dirname, '..', 'multi-provider', 'live-ping.js'), 'utf8');
+    assert.equal(/corren cada 15\s*min/.test(src), false, '#4402 bajó el default a 5 min');
+});
+
+// =============================================================================
+// CA-11 — Contención de los datos que vienen del tercero
+// =============================================================================
+
+test('CA-11/R-A: el catálogo del tercero NO aparece en el retorno de ping(), ni en el snapshot, ni en la alerta', async () => {
+    const dir = tmpDir();
+    const secretsPath = secretsWith(dir, { nvidia_nim_api_key: 'nvapi-aaaaaaaaaaaaaaaaaaaaaa' });
+    // Marcador que sólo existe en el body del tercero, en ningún id nuestro.
+    const MARCADOR = 'MARCADOR_SOLO_DEL_TERCERO';
+    const bodyRemoto = JSON.stringify({
+        object: 'list',
+        data: [...CATALOG_NVIDIA.data, { id: 'vendor/otro-modelo', owned_by: MARCADOR }],
+    });
+
+    const r = await livePing.ping({
+        provider: 'nvidia-nim', secretsPath,
+        httpImpl: fakeHttp({ status: 200, body: bodyRemoto }),
+        expectModels: [DEAD_MODEL],
+    });
+    const serializado = JSON.stringify(r);
+    assert.equal(serializado.includes(MARCADOR), false, 'nada del body crudo sale del módulo');
+    assert.equal(serializado.includes('vendor/otro-modelo'), false, 'ni siquiera los ids remotos que no son nuestros');
+    assert.equal('catalogRaw' in r, false);
+    assert.deepEqual(r.catalog_check.models, [{ model_id: DEAD_MODEL, alive: false }],
+        'sólo `{model_id, alive}` con ids NUESTROS');
+
+    const result = await healthCron.runOnce({
+        stateDir: path.join(dir, 'state'), auditDir: path.join(dir, 'audit'), secretsPath,
+        checkCatalog: true, agentModelsConfig: AGENT_MODELS,
+        httpImpl: fakeHttp({ status: 200, body: bodyRemoto }),
+        cliProbe: () => false,
+        telegramSender: () => true,
+        dedupFile: path.join(dir, 'dedup.json'), skipAudit: true,
+    });
+    const snapSer = JSON.stringify(result.snapshot);
+    assert.equal(snapSer.includes(MARCADOR), false, 'ni en el snapshot');
+    assert.equal(/catalogRaw|catalog_raw|bodyExcerpt|body_excerpt/i.test(snapSer), false);
+    for (const a of result.alerts) {
+        assert.equal(JSON.stringify(a.payload).includes(MARCADOR), false, 'ni en el payload de alerta');
+    }
+});
+
+test('CA-11/R-B: el fragmento del body no-JSON no viaja en `detail` ni en nada que salga', async () => {
+    // `JSON.parse` embebe un fragmento del body en su mensaje:
+    // `Unexpected token '<', "<html><ti"... is not valid JSON`.
+    const dir = tmpDir();
+    const secretsPath = secretsWith(dir, { nvidia_nim_api_key: 'nvapi-aaaaaaaaaaaaaaaaaaaaaa' });
+    const SECRETO = 'FRAGMENTO_QUE_NO_DEBE_SALIR';
+    const r = await livePing.ping({
+        provider: 'nvidia-nim', secretsPath,
+        httpImpl: fakeHttp({ status: 200, body: `<html><title>${SECRETO}</title></html>` }),
+        expectModels: [DEAD_MODEL],
+    });
+    assert.equal(r.catalog_check.detail, 'unparseable');
+    assert.equal(JSON.stringify(r).includes(SECRETO), false);
+    assert.ok(livePing.CATALOG_UNAVAILABLE_DETAILS.includes(r.catalog_check.detail),
+        '`detail` es un enum cerrado nuestro');
+});
+
+test('CA-11/S-B: un catálogo con clave `__proto__` no rompe la detección ni contamina Object.prototype', () => {
+    const envenenado = {
+        object: 'list',
+        data: [
+            { id: '__proto__' },
+            { id: 'constructor' },
+            { id: 'deepseek-ai/deepseek-r1' },
+        ],
+    };
+    const out = livePing._crossCheckCatalog({
+        spec: SPEC_NVIDIA, result: reqResult({ body: envenenado }), expectModels: [DEAD_MODEL, 'deepseek-ai/deepseek-r1'],
+    });
+    assert.equal(out.ok, true);
+    assert.deepEqual(out.models, [
+        { model_id: DEAD_MODEL, alive: false },
+        { model_id: 'deepseek-ai/deepseek-r1', alive: true },
+    ], 'con un objeto plano indexado por id, `__proto__` daría "vivo" a cualquier modelo para siempre');
+    assert.equal({}.polluted, undefined);
+    assert.equal(Object.prototype.polluted, undefined);
+});
+
+test('CA-11/S-C/R-F: un stream que supera MAX_CATALOG_BYTES destruye el socket y la promesa RESUELVE', async () => {
+    const dir = tmpDir();
+    const secretsPath = secretsWith(dir, { nvidia_nim_api_key: 'nvapi-aaaaaaaaaaaaaaaaaaaaaa' });
+    // Body > 1 MiB, en chunks de 256 KiB.
+    const gigante = '{"data":[' + '{"id":"x"},'.repeat(120_000) + '{"id":"y"}]}';
+    assert.ok(Buffer.byteLength(gigante) > livePing.MAX_CATALOG_BYTES);
+    const t0 = Date.now();
+    const r = await livePing.ping({
+        provider: 'nvidia-nim', secretsPath,
+        httpImpl: fakeHttp({ status: 200, body: gigante, chunkSize: 256 * 1024 }),
+        expectModels: [DEAD_MODEL],
+    });
+    // Si `res.destroy()` no emitiera `'close'` y no tuviéramos el handler, esto
+    // colgaría hasta TIMEOUT_MS (8s) y degradaría todo el health-cron.
+    assert.ok(Date.now() - t0 < livePing.TIMEOUT_MS, 'la promesa no puede colgar hasta el timeout');
+    assert.equal(r.catalog_check.reason_code, 'model_check_unavailable');
+    assert.equal(r.catalog_check.detail, 'truncated');
+});
+
+test('CA-11/D-5: el bodyExcerpt que sale del módulo sigue ≤512B (no creció respecto de HEAD)', async () => {
+    assert.equal(livePing.MAX_BODY_EXCERPT === undefined, true, 'MAX_BODY_EXCERPT sigue sin exportarse');
+    const src = fs.readFileSync(path.join(__dirname, '..', 'multi-provider', 'live-ping.js'), 'utf8');
+    assert.match(src, /const MAX_BODY_EXCERPT = 512;/, 'el cap del excerpt de error NO se amplió');
+    assert.equal(typeof livePing.doRequest, 'undefined', 'R-A: doRequest sigue sin exportarse');
+});
+
+test('CA-11: ningún model_id se concatena a una URL de ping', async () => {
+    const dir = tmpDir();
+    const secretsPath = secretsWith(dir, { nvidia_nim_api_key: 'nvapi-aaaaaaaaaaaaaaaaaaaaaa' });
+    const http = fakeHttp({ status: 200, body: JSON.stringify(CATALOG_NVIDIA) });
+    await livePing.ping({ provider: 'nvidia-nim', secretsPath, httpImpl: http, expectModels: [DEAD_MODEL] });
+    assert.equal(http.calls.length, 1);
+    const { path: reqPath, hostname } = http.calls[0];
+    assert.equal(reqPath, '/v1/models');
+    assert.equal(hostname, 'integrate.api.nvidia.com');
+    assert.equal(reqPath.includes('deepseek'), false);
+});
+
+// =============================================================================
+// No-regresión del ping manual (R-J) — sin expectModels, shape idéntico a HEAD
+// =============================================================================
+
+test('R-J: el ping SIN expectModels no baja catálogo y devuelve el shape de HEAD', async () => {
+    const dir = tmpDir();
+    const secretsPath = secretsWith(dir, { nvidia_nim_api_key: 'nvapi-aaaaaaaaaaaaaaaaaaaaaa' });
+    const r = await livePing.ping({
+        provider: 'nvidia-nim', secretsPath,
+        httpImpl: fakeHttp({ status: 200, body: JSON.stringify(CATALOG_NVIDIA) }),
+    });
+    assert.deepEqual(Object.keys(r).sort(), ['latency_ms', 'ok', 'provider', 'reason', 'statusCode'].sort());
+    assert.equal('catalog_check' in r, false, 'el ping manual del dashboard no puede bajar catálogo (path facturable)');
+    assert.equal(r.ok, true);
+    assert.equal(r.reason, 'authenticated');
+});
+
+test('R-J: expectModels vacío se comporta como ausente', async () => {
+    const dir = tmpDir();
+    const secretsPath = secretsWith(dir, { cerebras_api_key: 'csk_test_aaaaaaaaaaaaaaaaaaaa' });
+    const r = await livePing.ping({
+        provider: 'cerebras', secretsPath,
+        httpImpl: fakeHttp({ status: 200, body: JSON.stringify(CATALOG_CEREBRAS) }),
+        expectModels: [],
+    });
+    assert.equal('catalog_check' in r, false);
+});
+
+// =============================================================================
+// CA-13 — El alcance queda escrito, no implícito
+// =============================================================================
+
+test('CA-13/D-1: alcance explícito y mapeo openai ↔ openai-codex', () => {
+    assert.deepEqual(healthCron.CATALOG_CHECK_PROVIDERS.slice().sort(), ['cerebras', 'gemini-google', 'nvidia-nim']);
+    for (const fuera of ['kimi-moonshot', 'anthropic', 'openai-codex', 'openai']) {
+        assert.equal(healthCron.CATALOG_CHECK_PROVIDERS.includes(fuera), false, `${fuera} fuera de alcance`);
+    }
+    assert.equal(healthCron.PING_TO_CONFIG_PROVIDER.openai, 'openai-codex');
+    // Los specs excluidos NO tienen extractor, y la razón está escrita en código.
+    assert.equal(typeof livePing.PROVIDER_PING_ENDPOINTS.anthropic.catalogExtract, 'undefined');
+    assert.equal(typeof livePing.PROVIDER_PING_ENDPOINTS.openai.catalogExtract, 'undefined');
+    const src = fs.readFileSync(path.join(__dirname, '..', 'multi-provider', 'live-ping.js'), 'utf8');
+    assert.ok(src.includes('kimi-moonshot') && src.includes('#5892'),
+        'la exclusión de kimi-moonshot debe estar escrita con su referencia');
+});
+
+// =============================================================================
+// CA-9 / CA-18 / CA-16 / CA-15 — Superficie visible al operador
+// =============================================================================
+
+test('CA-9/D-6: ALLOWED_REASON_CODES ⊆ keys(REASON_LABEL) — cierra la clase entera de UX-1', () => {
+    const sinEtiqueta = [...healthAlerts.ALLOWED_REASON_CODES]
+        .filter((c) => !Object.prototype.hasOwnProperty.call(providersView.REASON_LABEL, c));
+    assert.deepEqual(sinEtiqueta, [],
+        'un reason code sin etiqueta se muestra en inglés crudo al operador (precedente #4869)');
+});
+
+test('CA-9/D-6: el reason code nuevo tampoco cae al default silencioso de provider-pause-cause', () => {
+    // TERCER consumidor de reason codes con copy propia (`REASON_TABLE`). Su
+    // invariante existe por la misma razón que el de REASON_LABEL: un código sin
+    // fila cae a "motivo desconocido" sin que nadie se entere. Lo dejamos
+    // explícito acá para que la relación entre los tres sets quede escrita.
+    const ppc = require('../provider-pause-cause');
+    const dir = tmpDir();
+    fs.mkdirSync(dir, { recursive: true });
+    for (const code of ['model_not_in_catalog', 'model_check_unavailable']) {
+        fs.writeFileSync(path.join(dir, 'multi-provider-health.json'), JSON.stringify({
+            ts: '2026-08-13T13:00:00.000Z',
+            providers: [{ provider: 'cerebras', label: 'Cerebras', state: 'red', reason_code: code }],
+        }));
+        const res = ppc.classifyPauseCause(['cerebras'], { stateDir: dir, now: Date.parse('2026-08-13T13:00:00.000Z') });
+        assert.notEqual(res.providers[0].text, 'motivo desconocido', `${code} no puede caer al default`);
+        assert.notEqual(res.providers[0].cause, 'auth',
+            `${code} no es causa de auth: encabezaría el mensaje como si el proveedor estuviera inutilizable`);
+    }
+});
+
+test('CA-18: ninguna etiqueta de REASON_LABEL contiene guion bajo', () => {
+    const crudas = Object.entries(providersView.REASON_LABEL).filter(([, v]) => v.includes('_'));
+    assert.deepEqual(crudas, [], 'un `_` en la etiqueta delata el fallback de reasonHuman, no una traducción');
+});
+
+test('CA-18: las 7 etiquetas coinciden LITERAL con la tabla acordada con ux', () => {
+    const tabla = {
+        rate_limited: 'rate limit (429)',
+        unknown: 'causa desconocida',
+        network_error: 'error de red',
+        cli_binary_undeclared: 'binario CLI no declarado',
+        cli_license_unavailable: 'CLI sin licencia activa',
+        model_not_in_catalog: 'modelo fuera de catálogo',
+        model_check_unavailable: 'vigencia no verificable',
+    };
+    for (const [code, label] of Object.entries(tabla)) {
+        assert.equal(providersView.REASON_LABEL[code], label, `etiqueta de ${code}`);
+        assert.equal(providersView.reasonHuman(code), label);
+    }
+});
+
+// Modelo mínimo de una fila, con los campos que consume el render.
+function filaProv(over = {}) {
+    return {
+        key: 'nvidia-nim', disabledKey: 'nvidia-nim', name: 'NVIDIA NIM', accent: 'var(--provider-nvidia-nim)',
+        tier: 'FREE', tierKind: 'free', tierIcon: '🟩', masked: 'nvapi-…aaaa', fingerprint: 'abc123',
+        keyStatus: 'present', editable: true, reason: null, authMode: 'api_key', freeTierNotes: null,
+        healthState: 'green', healthReason: 'authenticated', catalogCheck: null, quota: null,
+        lastChecked: '2026-08-13T13:00:00.000Z', loadPct: 10, dispatches24h: 3, hasTraffic: true,
+        models: [], disabled: false, ...over,
+    };
+}
+
+const CC_FUERA = {
+    state: 'not_in_catalog', checked_at: '2026-08-13T09:00:00.000Z',
+    reason_code: 'model_not_in_catalog',
+    models: [{ model_id: DEAD_MODEL, alive: false }, { model_id: 'deepseek-ai/deepseek-r1', alive: true }],
+};
+
+test('CA-16/UX-4: el eje de modelo vive en prov-col-models; prov-col-health queda limpio', () => {
+    const html = providersView.renderProviderRow(filaProv({ catalogCheck: CC_FUERA }), Date.parse('2026-08-13T13:00:00.000Z'));
+    const health = html.slice(html.indexOf('prov-col-health'), html.indexOf('prov-col-models'));
+    for (const token of ['model_not_in_catalog', 'model_check_unavailable', 'modelo fuera de catálogo', 'vigencia no verificable', DEAD_MODEL]) {
+        assert.equal(health.includes(token), false,
+            `prov-col-health no puede contener "${token}": el operador lo leería como la causa de la salud del provider`);
+    }
+    const models = html.slice(html.indexOf('prov-col-models'));
+    assert.ok(models.includes('modelo fuera de catálogo'));
+    assert.ok(models.includes(DEAD_MODEL));
+    // Y la salud sigue diciendo lo suyo, intacta.
+    assert.ok(health.includes('autenticado'));
+});
+
+test('CA-8/CA-18/UX-4: los 4 estados de la celda de vigencia, con antigüedad relativa e ISO en title', () => {
+    const now = Date.parse('2026-08-13T13:00:00.000Z');
+    const v = (cc) => providersView.renderVigenciaLine(filaProv({ catalogCheck: cc }), now);
+
+    const vigente = v({ state: 'verified', checked_at: '2026-08-13T09:00:00.000Z', reason_code: null, models: [{ model_id: 'deepseek-ai/deepseek-r1', alive: true }] });
+    assert.ok(vigente.includes('verificado hace 4 h'), vigente);
+
+    const fuera = v(CC_FUERA);
+    assert.ok(fuera.includes('modelo fuera de catálogo · verificado hace 4 h'), fuera);
+    assert.ok(fuera.includes('is-model-warn'), 'tratamiento de advertencia, no de caído');
+    assert.ok(fuera.includes('prov-model-dead'), 'el id afectado va marcado, no como texto suelto');
+    assert.equal(fuera.includes('deepseek-ai/deepseek-r1'), false, 'sólo se marcan los ausentes');
+
+    const nover = v({ state: 'unavailable', checked_at: '2026-08-13T01:00:00.000Z', reason_code: 'model_check_unavailable', models: [] });
+    assert.ok(nover.includes('vigencia no verificable · último intento hace 12 h'), nover);
+    assert.equal(nover.includes('is-model-ok'), false, 'nunca verde: no sabemos, no está bien');
+
+    const nunca = v({ state: 'never', checked_at: null, reason_code: null, models: [] });
+    assert.ok(nunca.includes('vigencia nunca verificada'), nunca);
+    assert.equal(nunca.includes('hace'), false, '"no verificable hace —" no comunica nada');
+
+    // ISO en el title (CA-18), no en el texto visible.
+    assert.ok(/title="[^"]*13\/08\/2026[^"]*"/.test(fuera), fuera);
+    // Provider fuera de alcance: la celda no inventa una vigencia que nadie verifica.
+    assert.equal(providersView.renderVigenciaLine(filaProv({ catalogCheck: null }), now), '');
+});
+
+test('CA-8: `— sin catálogo —` pasa a `— sin catálogo local —` (es otro eje que la vigencia)', () => {
+    const html = providersView.renderCatalogCell(filaProv({ models: [] }), Date.now());
+    assert.ok(html.includes('— sin catálogo local —'));
+});
+
+test('CA-8: la antigüedad real llega hasta el HTML de la pantalla, no sólo al helper', () => {
+    // Regresión encontrada por la evidencia visual: `providers.map(renderProviderRow)`
+    // pasa el ÍNDICE del array como 2do argumento. Como el índice es un número
+    // finito, `relativeTime` lo tomaba como el `now` de referencia y TODA la
+    // columna decía "verificado ahora". Un panel que siempre dice "ahora" es
+    // peor que uno mudo: el operador le cree.
+    const now = Date.parse('2026-08-13T13:00:00.000Z');
+    const model = {
+        providers: [
+            filaProv({ key: 'anthropic', name: 'Claude', catalogCheck: null }),
+            filaProv({ catalogCheck: CC_FUERA }),
+        ],
+        meta: {
+            total: 2, healthy: 2, degraded: [],
+            modelsOutOfCatalog: [{ providerKey: 'nvidia-nim', providerName: 'NVIDIA NIM', modelId: DEAD_MODEL }],
+            absorber: { name: 'Claude', loadPct: 10 }, defaultProvider: 'anthropic',
+            defaultChain: ['Claude'], agents: [], healthTs: null, dispatchTotal: 5,
+        },
+    };
+    const html = providersView.bodyHtml(model, now);
+    assert.ok(html.includes('verificado hace 4 h'), 'la antigüedad real debe llegar al HTML');
+    assert.equal(html.includes('verificado ahora'), false);
+});
+
+test('CA-15/UX-3: 5 providers verdes + 1 modelo fuera de catálogo ⇒ el banner NO dice TODO OK y sí nombra el par', () => {
+    const meta = {
+        total: 5, healthy: 5, degraded: [],
+        modelsOutOfCatalog: [{ providerKey: 'nvidia-nim', providerName: 'NVIDIA NIM', modelId: DEAD_MODEL }],
+        absorber: { name: 'Claude', loadPct: 41 }, defaultProvider: 'anthropic',
+        defaultChain: [], agents: [], healthTs: null, dispatchTotal: 120,
+    };
+    const html = providersView.renderMissionBanner(meta);
+    assert.equal(html.includes('TODO OK'), false);
+    assert.equal(html.includes('está sana'), false);
+    assert.ok(html.includes('1 MODELO FUERA DE CATÁLOGO'));
+    assert.ok(html.includes(DEAD_MODEL) && html.includes('NVIDIA NIM'), 'nombra el par (provider, model_id)');
+    assert.ok(html.includes('como primario o como fallback'));
+    assert.ok(html.includes('is-model-warn'), 'advertencia, no caído: no afirma que ningún provider esté abajo');
+    assert.equal(html.includes('PROVEEDOR CAÍDO'), false);
+    assert.equal(html.includes('PROVEEDORES CAÍDOS'), false);
+    // CA-19 — la región describe ambos ejes.
+    assert.ok(/role="region" aria-label="[^"]*modelos[^"]*"/.test(html), html.slice(0, 400));
+
+    // Plural.
+    meta.modelsOutOfCatalog.push({ providerKey: 'cerebras', providerName: 'Cerebras', modelId: 'zai-glm-4.7' });
+    assert.ok(providersView.renderMissionBanner(meta).includes('2 MODELOS FUERA DE CATÁLOGO'));
+});
+
+test('CA-15/CA-17: model_check_unavailable NO altera el banner', () => {
+    const meta = {
+        total: 5, healthy: 5, degraded: [], modelsOutOfCatalog: [],
+        absorber: { name: 'Claude', loadPct: 41 }, defaultProvider: 'anthropic',
+        defaultChain: [], agents: [], healthTs: null, dispatchTotal: 120,
+    };
+    const html = providersView.renderMissionBanner(meta);
+    assert.ok(html.includes('TODO OK'), 'sin evidencia de modelo muerto, el banner no cambia');
+    assert.equal(html.includes('is-model-warn'), false);
+});
+
+test('CA-15: con un provider degradado Y un modelo fuera de catálogo, ninguno de los dos ejes tapa al otro', () => {
+    const meta = {
+        total: 5, healthy: 4,
+        degraded: [{ name: 'Cerebras', healthReason: 'invalid_credentials' }],
+        modelsOutOfCatalog: [{ providerKey: 'nvidia-nim', providerName: 'NVIDIA NIM', modelId: DEAD_MODEL }],
+        absorber: { name: 'Claude', loadPct: 41 }, defaultProvider: 'anthropic',
+        defaultChain: [], agents: [], healthTs: null, dispatchTotal: 120,
+    };
+    const html = providersView.renderMissionBanner(meta);
+    assert.ok(html.includes('credencial inválida'), 'el eje de salud sigue visible');
+    assert.ok(html.includes(DEAD_MODEL), 'el eje de modelo también');
+    assert.equal(html.includes('TODO OK'), false);
+});
+
+// =============================================================================
+// Integración end-to-end del flujo (sin red)
+// =============================================================================
+
+test('E2E: catálogo real de NVIDIA sin el modelo del fallback ⇒ snapshot + alerta con el par', async () => {
+    const dir = tmpDir();
+    const secretsPath = secretsWith(dir, { nvidia_nim_api_key: 'nvapi-aaaaaaaaaaaaaaaaaaaaaa' });
+    const enviados = [];
+    const result = await healthCron.runOnce({
+        stateDir: path.join(dir, 'state'), auditDir: path.join(dir, 'audit'), secretsPath,
+        checkCatalog: true, agentModelsConfig: AGENT_MODELS,
+        httpImpl: fakeHttp({ status: 200, body: rawFixture('catalog-nvidia.json') }),
+        cliProbe: () => false,
+        telegramSender: (p) => { enviados.push(p); return true; },
+        dedupFile: path.join(dir, 'dedup.json'), skipAudit: true,
+        now: Date.parse('2026-08-13T13:00:00.000Z'),
+    });
+
+    const nvidia = result.snapshot.providers.find((p) => p.provider === 'nvidia-nim');
+    assert.equal(nvidia.state, 'green');
+    assert.equal(nvidia.catalog_check.state, 'not_in_catalog');
+    assert.deepEqual(nvidia.catalog_check.models.filter((m) => !m.alive), [{ model_id: DEAD_MODEL, alive: false }]);
+
+    const alerta = enviados.find((p) => p.event === 'model_not_in_catalog');
+    assert.ok(alerta, 'debe emitirse la alerta del eje de modelo');
+    assert.equal(alerta.provider, 'nvidia-nim');
+    assert.equal(alerta.model_id, DEAD_MODEL);
+    assert.equal(alerta.provider_state, 'green');
+    assert.match(healthCron.formatAlertText(alerta), /^⚠️/);
+});
+
+test('E2E: los providers fuera de alcance no llevan catalog_check en el snapshot', async () => {
+    const dir = tmpDir();
+    const secretsPath = secretsWith(dir, { nvidia_nim_api_key: 'nvapi-aaaaaaaaaaaaaaaaaaaaaa' });
+    const result = await healthCron.runOnce({
+        stateDir: path.join(dir, 'state'), auditDir: path.join(dir, 'audit'), secretsPath,
+        checkCatalog: true, agentModelsConfig: AGENT_MODELS,
+        httpImpl: fakeHttp({ status: 200, body: rawFixture('catalog-nvidia.json') }),
+        cliProbe: () => false, telegramSender: () => true,
+        dedupFile: path.join(dir, 'dedup.json'), skipAudit: true,
+    });
+    for (const p of result.snapshot.providers) {
+        const enAlcance = healthCron.CATALOG_CHECK_PROVIDERS.includes(p.provider);
+        assert.equal('catalog_check' in p, enAlcance, `${p.provider}: catalog_check sólo si está en alcance`);
+    }
+});

--- a/.pipeline/lib/multi-provider/health-alerts.js
+++ b/.pipeline/lib/multi-provider/health-alerts.js
@@ -65,6 +65,21 @@ const ALLOWED_REASON_CODES = Object.freeze(new Set([
     // dispatch lo trate como rojo DURABLE y saltee el provider (no lo colapses
     // a 'unknown', que el dispatch interpreta como rojo transitorio → fail-open).
     'cli_license_unavailable',
+    // #5888 — eje de VIGENCIA DE MODELO, distinto del eje de salud del provider.
+    //
+    // Deben estar acá porque `sanitizeReasonCode` colapsa a `'unknown'` todo lo
+    // que no esté en este set, SIN error ni log: la alerta se emitiría igual y
+    // los tests pasarían aparentando funcionar (cond. 3 / R-3).
+    //
+    // Y deben quedar FUERA de `DURABLE_RED_REASONS`
+    // (`agent-launcher/dispatch-with-fallback.js:749`) — exactamente lo
+    // contrario de lo que documenta el bloque de `cli_license_unavailable` acá
+    // arriba. Razón: un modelo muerto NO invalida al provider. NVIDIA sigue
+    // sirviendo el resto de su catálogo; si estos codes entraran a
+    // DURABLE_RED_REASONS, el health-gate del dispatch (`:818`) sacaría a NVIDIA
+    // ENTERA de la cascada de fallback por un solo modelo caído (CA-4 / R-C).
+    'model_not_in_catalog',    // catálogo leído COMPLETO y el modelo no está.
+    'model_check_unavailable', // no se pudo verificar. Ausencia de señal, no evidencia.
 ]));
 
 // Estados válidos del provider (espejan los CA-3 / narrativa UX).
@@ -102,6 +117,30 @@ function sanitizeProvider(provider) {
     // Solo aceptamos providers que matcheen el patrón seguro (lowercase + dash).
     if (typeof provider !== 'string' || !/^[a-z][a-z0-9-]{0,32}$/.test(provider)) return null;
     return provider;
+}
+
+// #5888 S-A / CA-6 — Allowlist de charset para el `model_id` que viaja al
+// operador (texto de Telegram en Markdown + panel del dashboard).
+//
+// El id que llega acá es NUESTRO (sale de `agent-models.json`, no del catálogo
+// remoto), pero `agent-models.json` lo escriben AGENTES: esto es defensa en
+// profundidad, no teatro.
+//
+// El charset excluye deliberadamente los metacaracteres de Markdown — backtick,
+// `[`, `]`, `(`, `)`, `*`, `_` — porque el sink es un mensaje con
+// `parse_mode: 'Markdown'`: un id con backticks podría cerrar el bloque de
+// código y hacer que un humano CON AUTORIDAD lea texto inyectado como si fuera
+// del pipeline. Mismo estilo fail-closed que `sanitizeProvider`: devuelve
+// `null`, NUNCA el crudo. El llamador emite igual, con texto genérico (CA-6).
+//
+// Validado contra los 6 ids reales del config: `claude-opus-4-7`, `gpt-5.5`,
+// `gemini-3-flash-preview`, `gpt-oss-120b`, `zai-glm-4.7`, `kimi-k2-6` y
+// `deepseek-ai/deepseek-v4-pro` (la `/` del vendor es el motivo de incluirla).
+const MODEL_ID_RE = /^[a-z0-9][a-z0-9./-]{0,63}$/;
+
+function sanitizeModelId(modelId) {
+    if (typeof modelId !== 'string' || !MODEL_ID_RE.test(modelId)) return null;
+    return modelId;
 }
 
 /**
@@ -297,6 +336,88 @@ function recordMultiDown({ sent, now = Date.now(), dedupFile = HOME_DEDUP_FILE, 
     try { writeJsonAtomic(dedupFile, store, fsImpl); } catch { /* best-effort */ }
 }
 
+// -----------------------------------------------------------------------------
+// #5888 — Evento de VIGENCIA DE MODELO (CA-1/CA-6/CA-17).
+//
+// Función PROPIA, no se reusa `decide()` (R-D). La key de dedup de `decide()`
+// es `provider|state`; si el evento de modelo la compartiera, o suprimiría la
+// alerta de salud del provider, o repetiría la de modelo en cada tick. Acá la
+// key es `provider|model|<id>` — no colisiona con ningún `provider|<state>`
+// porque `model` no es un estado válido (`ALLOWED_STATES` = green/yellow/red).
+//
+// Ventana propia de 24h: un modelo fuera de catálogo es una condición
+// PERSISTENTE (no se arregla sola), así que el back-off exponencial del eje de
+// salud no aplica. 1 recordatorio por día es lo que mantiene la barrera visible
+// sin entrenar al operador a ignorar el canal.
+// -----------------------------------------------------------------------------
+const MODEL_ALERT_DEDUP_MS = 24 * 60 * 60 * 1000;
+
+// Sentinela para el id que NO sobrevivió a `sanitizeModelId` (S-A fail-closed).
+// La alerta se emite igual — degradada, sin el id — pero necesita una key de
+// dedup estable para no floodear.
+const UNREPRESENTABLE_MODEL_KEY = '__unrepresentable__';
+
+/**
+ * Decide si un modelo fuera de catálogo merece emisión a Telegram.
+ *
+ * @param {object} params
+ * @param {string} params.provider — provider gestionado (`nvidia-nim`, …).
+ * @param {string} params.modelId — id configurado. Si no pasa el sanitize, la
+ *   alerta se emite IGUAL con `model_id: null` (nunca el crudo, nunca se omite).
+ * @param {string} [params.providerState] — estado de salud del provider. Viaja
+ *   en el payload SÓLO para que el texto pueda decir "sigue sano" sin mentir;
+ *   NO se usa para decidir si emitir (cond. 4: los ejes son independientes).
+ * @returns {{ shouldEmit: boolean, reasonNoEmit?: string, payload?: object, nextEligibleAt?: number }}
+ */
+function decideModelEvent({ provider, modelId, providerState, now = Date.now(), dedupFile = HOME_DEDUP_FILE, fsImpl = fs } = {}) {
+    const p = sanitizeProvider(provider);
+    if (!p) return { shouldEmit: false, reasonNoEmit: 'invalid_input' };
+    const m = sanitizeModelId(modelId);
+    const s = sanitizeState(providerState);
+
+    const store = tryReadJson(dedupFile, fsImpl) || { alerts: {} };
+    if (!store.alerts || typeof store.alerts !== 'object') store.alerts = {};
+
+    const key = `${p}|model|${m || UNREPRESENTABLE_MODEL_KEY}`;
+    const prev = store.alerts[key];
+    if (prev && (now - (prev.last_sent_at || 0)) < MODEL_ALERT_DEDUP_MS) {
+        return {
+            shouldEmit: false,
+            reasonNoEmit: 'dedup_window',
+            nextEligibleAt: prev.last_sent_at + MODEL_ALERT_DEDUP_MS,
+        };
+    }
+
+    // Payload metadata-only (CA-11): sólo lo que el operador necesita leer.
+    // NADA del body del provider — el catálogo remoto ni siquiera salió de
+    // `live-ping.js`, lo que llega acá es un id de NUESTRO config.
+    const payload = {
+        event: 'model_not_in_catalog',
+        provider: p,
+        model_id: m,               // `null` ⇒ el texto cae a la rama genérica.
+        provider_state: s,         // `null` si el estado no era válido.
+        reason_code: 'model_not_in_catalog',
+        observed_at: new Date(now).toISOString(),
+    };
+    return { shouldEmit: true, payload: redact.redactValue(payload) };
+}
+
+function recordModelEvent({ provider, modelId, sent, now = Date.now(), dedupFile = HOME_DEDUP_FILE, fsImpl = fs } = {}) {
+    const p = sanitizeProvider(provider);
+    if (!p || !sent) return;
+    const m = sanitizeModelId(modelId);
+    const store = tryReadJson(dedupFile, fsImpl) || { alerts: {} };
+    if (!store.alerts || typeof store.alerts !== 'object') store.alerts = {};
+    const key = `${p}|model|${m || UNREPRESENTABLE_MODEL_KEY}`;
+    const prev = store.alerts[key];
+    store.alerts[key] = {
+        last_sent_at: now,
+        consecutive_count: ((prev && prev.consecutive_count) || 0) + 1,
+    };
+    try { writeJsonAtomic(dedupFile, store, fsImpl); }
+    catch { /* best-effort: si no podemos escribir, próxima decisión re-emite */ }
+}
+
 module.exports = {
     HOME_DEDUP_FILE,
     DEDUP_WINDOW_MS,
@@ -312,4 +433,10 @@ module.exports = {
     sanitizeProvider,
     sanitizeState,
     sanitizeReasonCode,
+    // #5888 — eje de vigencia de modelo.
+    MODEL_ALERT_DEDUP_MS,
+    UNREPRESENTABLE_MODEL_KEY,
+    sanitizeModelId,
+    decideModelEvent,
+    recordModelEvent,
 };

--- a/.pipeline/lib/multi-provider/health-cron.js
+++ b/.pipeline/lib/multi-provider/health-cron.js
@@ -67,6 +67,19 @@ function readDefaultProvider() {
     return 'anthropic';
 }
 
+// #5888 — Config de agentes completa (providers + skills). Lectura defensiva:
+// si `agent-models.json` no se puede leer, el cruce de catálogo queda sin
+// modelos que verificar y la barrera no corre — nunca marca modelos como
+// muertos por no poder leer su propia config (cond. 1/2, fail-open).
+function readAgentModelsConfig() {
+    try {
+        // eslint-disable-next-line global-require
+        const am = require('./agent-models-rw');
+        const cfg = am.readConfig();
+        return (cfg && typeof cfg === 'object') ? cfg : {};
+    } catch { return {}; }
+}
+
 // Alias provider-key (cron) → default_provider key. El cron usa 'openai' para
 // Codex; el default_provider de agent-models usa 'openai-codex'. Comparamos
 // normalizando para no flipear a rojo al primario si fuera Codex.
@@ -97,9 +110,35 @@ const JITTER_RANGE_MS = 60 * 1000;                  // ±60s alrededor del slot
 const WEEKLY_CHECK_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000;
 const LOCK_STALE_MS = 5 * 60 * 1000;                // si el lock tiene >5min, lo robamos
 const SNAPSHOT_FILENAME = 'multi-provider-health.json';
-const STATE_FILENAME = 'multi-provider-health-state.json'; // tracking interno: last_tick, last_weekly_check
+// tracking interno: last_tick_at, last_weekly_check_at, last_catalog_check_at (#5888).
+const STATE_FILENAME = 'multi-provider-health-state.json';
 const LOCK_FILENAME = 'multi-provider-health.lock';
 const AUDIT_FILENAME = 'multi-provider-health.jsonl';
+
+// -----------------------------------------------------------------------------
+// #5888 D-4 / CA-10 — Cadencia PROPIA de la verificación de catálogo.
+//
+// El health-ping sigue en 5 min (barato, `/models` no consume cuota). El cruce
+// de catálogo baja hasta 1 MiB de body por provider: correrlo cada 5 min sería
+// desproporcionado para una condición que cambia con frecuencia trimestral.
+// TTL default 6h, con piso duro de 6h (`MIN`) para que un config equivocado no
+// pueda convertirlo en un ping de catálogo cada minuto.
+// -----------------------------------------------------------------------------
+const CATALOG_CHECK_DEFAULT_HOURS = 6;
+const CATALOG_CHECK_MIN_HOURS = 6;
+const CATALOG_CHECK_MAX_HOURS = 168;   // 7 días
+
+// Providers en alcance del cruce (cond. 9 + D-1). Escrito, no implícito (CA-13).
+// `anthropic` / `openai` quedan fuera porque corren por CLI-OAuth y `ping()`
+// hace short-circuit antes del HTTP; `kimi-moonshot` queda fuera por D-1 (no
+// está en MANAGED_KEYS ni en PROVIDER_PING_ENDPOINTS — ref. #5892).
+const CATALOG_CHECK_PROVIDERS = Object.freeze(['nvidia-nim', 'gemini-google', 'cerebras']);
+
+// #5888 G-7/CA-13 — El cron nombra a Codex `openai`; `agent-models.json` lo
+// nombra `openai-codex`. El mapeo queda EXPLÍCITO para que el día que Codex
+// entre al alcance del cruce no se saltee en silencio por un nombre que no
+// matchea.
+const PING_TO_CONFIG_PROVIDER = Object.freeze({ openai: 'openai-codex' });
 
 function jitterMs(rangeMs = JITTER_RANGE_MS, rng = Math.random) {
     return Math.floor((rng() * 2 - 1) * rangeMs);
@@ -151,6 +190,30 @@ function readTickIntervalMs({ configPath } = {}) {
     // un segundo cinturón explícito (RS-5.5).
     minutes = Math.min(Math.max(minutes, MIN_INTERVAL_MINUTES), MAX_INTERVAL_MINUTES);
     return Math.max(minutes * 60 * 1000, HARD_FLOOR_MS);
+}
+
+// -----------------------------------------------------------------------------
+// #5888 CA-10 — TTL de la verificación de catálogo, leído por el MISMO resolver
+// de config que `readTickIntervalMs()` (#5172: este módulo no decide qué archivo
+// es la config; el entorno aporta DIRECTORIO, el nombre lo pone el resolver).
+//
+// A diferencia de `readTickIntervalMs`, acá el error de config NO se propaga:
+// un config roto ya hace fallar el tick entero por `readTickIntervalMs` mucho
+// antes de llegar acá. Lo que sí atajamos es el valor ausente/no numérico → 6h.
+// -----------------------------------------------------------------------------
+function readCatalogTtlMs({ configPath } = {}) {
+    let hours = CATALOG_CHECK_DEFAULT_HOURS;
+    // eslint-disable-next-line global-require
+    const configResolver = require('../config-resolver');
+    const cfg = configResolver.resolve(configPath ? { configPath } : {});
+    const v = cfg
+        && cfg.multi_provider
+        && cfg.multi_provider.health
+        && cfg.multi_provider.health.catalog_check_hours;
+    if (typeof v === 'number' && Number.isFinite(v)) hours = v;
+    if (!Number.isFinite(hours)) hours = CATALOG_CHECK_DEFAULT_HOURS;
+    hours = Math.min(Math.max(hours, CATALOG_CHECK_MIN_HOURS), CATALOG_CHECK_MAX_HOURS);
+    return hours * 60 * 60 * 1000;
 }
 
 // -----------------------------------------------------------------------------
@@ -259,6 +322,97 @@ function isWeeklyDue({ stateFile, now = Date.now(), fsImpl = fs } = {}) {
     return (now - st.last_weekly_check_at) >= WEEKLY_CHECK_INTERVAL_MS;
 }
 
+// #5888 CA-10 — espejo exacto de `isWeeklyDue`, con su propia key de estado.
+// Sin esto, los ticks de 5 min bajarían el catálogo 288 veces por día.
+function isCatalogCheckDue({ stateFile, now = Date.now(), fsImpl = fs, ttlMs } = {}) {
+    const st = readJson(stateFile, fsImpl);
+    if (!st || typeof st.last_catalog_check_at !== 'number') return true;
+    const ttl = Number.isFinite(ttlMs) ? ttlMs : readCatalogTtlMs();
+    return (now - st.last_catalog_check_at) >= ttl;
+}
+
+// -----------------------------------------------------------------------------
+// #5888 CA-1 — Los pares `(provider, model_id)` configurados, de las 4 fuentes.
+//
+// NO reimplementamos la resolución de la cadena: `agent-models-validate.
+// resolveSkillChain(config, skill)` ya devuelve `{provider, model, source}`
+// cubriendo `skills[].provider` + `model_override`, el default del provider y
+// `fallbacks[].model_override`. Sólo falta `providers[].alternative_models[]`.
+//
+// La fuente de verdad es `agent-models.json`, NUNCA `model-catalog.js`: ese
+// catálogo local devuelve `null` para los 3 providers en alcance (G-8), así que
+// el cruce se auto-vaciaría y la barrera quedaría muda.
+//
+// El caso que motivó la historia es justamente el fallback: `deepseek-v4-pro`
+// mató agentes estando configurado como fallback, no como primario.
+// -----------------------------------------------------------------------------
+function configuredModelsByProvider(config) {
+    const out = new Map();  // provider (key de config) -> Set<model_id>
+    const add = (prov, model) => {
+        if (typeof prov !== 'string' || typeof model !== 'string' || !model) return;
+        if (!out.has(prov)) out.set(prov, new Set());
+        out.get(prov).add(model);
+    };
+    const providers = (config && config.providers && typeof config.providers === 'object')
+        ? config.providers : {};
+    for (const [prov, def] of Object.entries(providers)) {
+        add(prov, def && def.model);                                       // fuente 1
+        const alts = Array.isArray(def && def.alternative_models) ? def.alternative_models : [];
+        for (const alt of alts) add(prov, alt);                            // fuente 2
+    }
+    const skills = (config && config.skills && typeof config.skills === 'object')
+        ? config.skills : {};
+    for (const skill of Object.keys(skills)) {
+        let chain = [];
+        // eslint-disable-next-line global-require
+        try { chain = require('../agent-models-validate').resolveSkillChain(config, skill) || []; }
+        catch { chain = []; }
+        for (const link of chain) add(link && link.provider, link && link.model);  // fuentes 3 y 4
+    }
+    return out;
+}
+
+/**
+ * Modelos a verificar por provider de PING (no de config). Devuelve un Map
+ * `providerDePing -> string[]`, ya restringido a `CATALOG_CHECK_PROVIDERS`.
+ */
+function expectModelsForPing(config) {
+    const byConfigKey = configuredModelsByProvider(config);
+    const out = new Map();
+    for (const pingProvider of CATALOG_CHECK_PROVIDERS) {
+        const configKey = PING_TO_CONFIG_PROVIDER[pingProvider] || pingProvider;
+        const set = byConfigKey.get(configKey);
+        if (set && set.size > 0) out.set(pingProvider, Array.from(set).sort());
+    }
+    return out;
+}
+
+// #5888 (e) — Shape persistido en el snapshot. Sólo `{model_id, alive}` sale del
+// pipeline de datos: el `detail` interno de `crossCheckCatalog` se descarta acá
+// (es diagnóstico del módulo, no información para el snapshot ni el audit).
+function buildCatalogCheck(catalogCheck, checkedAtIso) {
+    const never = { state: 'never', checked_at: null, reason_code: null, models: [] };
+    if (!catalogCheck || typeof catalogCheck !== 'object') {
+        // Se pidió el cruce pero no hubo resultado (provider sin key, skipped,
+        // OAuth): ausencia de señal, reportable — no "todo bien" (D-3/CA-3).
+        return { state: 'unavailable', checked_at: checkedAtIso, reason_code: 'model_check_unavailable', models: [] };
+    }
+    if (catalogCheck.ok !== true) {
+        return { state: 'unavailable', checked_at: checkedAtIso, reason_code: 'model_check_unavailable', models: [] };
+    }
+    const models = (Array.isArray(catalogCheck.models) ? catalogCheck.models : [])
+        .filter((m) => m && typeof m.model_id === 'string')
+        .map((m) => ({ model_id: m.model_id, alive: m.alive === true }));
+    if (models.length === 0) return never;
+    const dead = models.filter((m) => !m.alive);
+    return {
+        state: dead.length > 0 ? 'not_in_catalog' : 'verified',
+        checked_at: checkedAtIso,
+        reason_code: dead.length > 0 ? 'model_not_in_catalog' : null,
+        models,
+    };
+}
+
 // -----------------------------------------------------------------------------
 // Cálculo de estado por provider
 // -----------------------------------------------------------------------------
@@ -316,7 +470,7 @@ function listManagedAndPingable() {
 // Snapshot build + alerts
 // -----------------------------------------------------------------------------
 
-async function pingAllProviders({ providers, prevSnapshot, secretsPath, fsImpl = fs, httpImpl, pingImpl, cliProbe, quotaAssessImpl, defaultProvider, now } = {}) {
+async function pingAllProviders({ providers, prevSnapshot, secretsPath, fsImpl = fs, httpImpl, pingImpl, cliProbe, quotaAssessImpl, defaultProvider, now, checkCatalog = false, expectModelsByProvider = null } = {}) {
     const prevByProvider = {};
     if (prevSnapshot && Array.isArray(prevSnapshot.providers)) {
         for (const p of prevSnapshot.providers) prevByProvider[p.provider] = p;
@@ -335,6 +489,12 @@ async function pingAllProviders({ providers, prevSnapshot, secretsPath, fsImpl =
     for (const spec of providers) {
         const keyInfo = secretsRw.listKeys({ secretsPath, fsImpl }).find(k => k.provider === spec.provider);
         const prev = prevByProvider[spec.provider] || {};
+        // #5888 — ¿este provider está en alcance del cruce de catálogo, y toca?
+        const inCatalogScope = CATALOG_CHECK_PROVIDERS.includes(spec.provider);
+        const expectModels = (checkCatalog && inCatalogScope && expectModelsByProvider
+            && Array.isArray(expectModelsByProvider.get(spec.provider)))
+            ? expectModelsByProvider.get(spec.provider)
+            : [];
         let pingResult = null;
         // #3802 — Providers CLI-OAuth (Claude Code / Codex): validar la CLI, no
         // la API key. Pinear la key da falso rojo porque el pipeline NO la usa.
@@ -348,6 +508,10 @@ async function pingAllProviders({ providers, prevSnapshot, secretsPath, fsImpl =
                     secretsPath,
                     fsImpl,
                     httpImpl,
+                    // #5888 — `expectModels` sólo para providers EN ALCANCE y sólo
+                    // cuando venció el TTL de 6h. Sin él, `ping()` se comporta
+                    // exactamente como en HEAD (no baja catálogo — R-J).
+                    expectModels: expectModels.length > 0 ? expectModels : undefined,
                 });
             } catch (e) {
                 pingResult = { ok: false, reason: 'network_error', provider: spec.provider };
@@ -386,6 +550,22 @@ async function pingAllProviders({ providers, prevSnapshot, secretsPath, fsImpl =
             } catch { /* fail-open: mantenemos el estado login-based */ }
         }
 
+        // #5888 R-E — CARRY-OVER obligatorio. El health-ping corre cada 5 min y
+        // el cruce de catálogo cada 6h: sin esto, los ~71 ticks intermedios
+        // resetearían la celda del panel a "nunca verificada" y el operador
+        // dejaría de creerle. `catalog_check` se OMITE del snapshot para los
+        // providers fuera de alcance (no existe el campo, no es "never").
+        let catalogCheck;
+        if (expectModels.length > 0) {
+            catalogCheck = buildCatalogCheck(pingResult && pingResult.catalog_check, new Date(nowMs).toISOString());
+        } else if (inCatalogScope) {
+            const carried = (prev.catalog_check && typeof prev.catalog_check === 'object')
+                ? prev.catalog_check : null;
+            catalogCheck = carried || { state: 'never', checked_at: null, reason_code: null, models: [] };
+        } else {
+            catalogCheck = null;
+        }
+
         results.push({
             provider: spec.provider,
             label: spec.label,
@@ -406,6 +586,10 @@ async function pingAllProviders({ providers, prevSnapshot, secretsPath, fsImpl =
             // #3802 — el frontend usa esto para mostrar "CLI/OAuth" en vez de
             // sugerir que falta una API key cuando el provider corre por CLI.
             auth_mode: spec.auth_mode === 'oauth' ? 'oauth' : 'api_key',
+            // #5888 CA-5/R-C — EJE SEPARADO. `state` y `reason_code` de arriba
+            // son la salud del PROVIDER y no los toca nadie desde acá: un modelo
+            // muerto no pone rojo a NVIDIA, que sigue sirviendo su catálogo.
+            ...(catalogCheck ? { catalog_check: catalogCheck } : {}),
         });
     }
     return results;
@@ -479,6 +663,38 @@ function emitAlerts({ snapshot, prevSnapshot, telegramSender, dedupFile, fsImpl 
                 if (okSend) sent.push({ kind: 'invalid_key', provider: p.provider, payload: decision.payload });
             }
         }
+
+        // #5888 Trigger 4: modelo configurado fuera del catálogo del provider.
+        //
+        // SÓLO `model_not_in_catalog`. `model_check_unavailable` NO emite a
+        // Telegram (D-3/UX-5/CA-17): es ausencia de señal, no un evento —
+        // alertar por él entrenaría al operador a ignorar el canal, que es
+        // exactamente cómo mueren las barreras. Su lugar es el panel.
+        const cc = p.catalog_check;
+        if (cc && cc.state === 'not_in_catalog') {
+            const dead = (Array.isArray(cc.models) ? cc.models : []).filter(m => m && m.alive === false);
+            for (const m of dead) {
+                const decision = healthAlerts.decideModelEvent({
+                    provider: p.provider,
+                    modelId: m.model_id,
+                    providerState: p.state,
+                    now,
+                    dedupFile,
+                    fsImpl,
+                });
+                if (!decision.shouldEmit) continue;
+                const okSend = telegramSender ? !!telegramSender(decision.payload) : true;
+                healthAlerts.recordModelEvent({
+                    provider: p.provider,
+                    modelId: m.model_id,
+                    sent: okSend,
+                    now,
+                    dedupFile,
+                    fsImpl,
+                });
+                if (okSend) sent.push({ kind: 'model_not_in_catalog', provider: p.provider, payload: decision.payload });
+            }
+        }
     }
 
     // Trigger 2: multi-down (3+ free providers en rojo).
@@ -509,6 +725,34 @@ function formatAlertText(payload) {
     if (payload.event === 'multi_down') {
         const provs = Array.isArray(payload.providers_red) ? payload.providers_red.join(', ') : '?';
         return `🩺 *Multi-Down* — ${payload.red_count} free providers en rojo: \`${provs}\`. Pipeline opera con red de respaldo reducida.\nObservado: ${payload.observed_at}`;
+    }
+    // #5888 UX-5/CA-17 — Rama propia del eje de MODELO, ANTES de la genérica.
+    //
+    // La genérica elige el emoji por el estado del PROVIDER: con provider sano +
+    // modelo muerto saldría `🩺 … 🟢 nvidia-nim → GREEN`, y en un canal que el
+    // operador escanea por emoji 🟢 significa "ignorar". La única alerta que
+    // produce esta barrera llegaría camuflada de buena noticia.
+    //
+    // Acá la severidad la fija el eje-modelo (⚠️ en la cabecera). El estado del
+    // provider se conserva pero SUBORDINADO, dentro de la frase que aclara que
+    // sigue sano — así el mensaje no miente en ninguna dirección (cond. 4). Y
+    // nombra la CONSECUENCIA, no sólo el hecho: el operador no tiene por qué
+    // deducir que un fallback roto no se nota hasta que cae el primario.
+    if (payload.event === 'model_not_in_catalog') {
+        const emoji = payload.provider_state === 'red' ? '🔴'
+            : payload.provider_state === 'yellow' ? '🟡' : '🟢';
+        const est = payload.provider_state === 'red' ? 'CAÍDO'
+            : payload.provider_state === 'yellow' ? 'DEGRADADO' : 'SANO';
+        if (!payload.model_id) {
+            // S-A fail-closed: `sanitizeModelId` devolvió `null`. La alerta se
+            // emite IGUAL — nunca el id crudo, nunca el silencio.
+            return `⚠️ *Modelo fuera de catálogo* — \`${payload.provider}\` sigue ${emoji} ${est}, pero uno de sus `
+                 + `modelos configurados ya no aparece en su catálogo (identificador no representable).\n`
+                 + `Revisar el panel de providers.\nObservado: ${payload.observed_at}`;
+        }
+        return `⚠️ *Modelo fuera de catálogo* — \`${payload.provider}\` sigue ${emoji} ${est}, pero `
+             + `\`${payload.model_id}\` ya no aparece en su catálogo. Los agentes que lo tengan configurado `
+             + `—como primario o como fallback— van a fallar al despachar.\nObservado: ${payload.observed_at}`;
     }
     const stateEmoji = payload.state === 'red' ? '🔴' : payload.state === 'yellow' ? '🟡' : '🟢';
     const reason = payload.reason_code || 'unknown';
@@ -554,6 +798,18 @@ async function runOnce(opts = {}) {
 
     const providers = listManagedAndPingable();
     const prevSnapshot = readJson(snapshotFile, fsImpl);
+
+    // #5888 — El cruce de catálogo corre SÓLO cuando el llamador lo pide
+    // (`tickIfDue` lo hace cuando venció el TTL de 6h). Default `false`: los
+    // consumidores existentes de `runOnce` (CLI, tests, api.js) no cambian de
+    // comportamiento ni bajan catálogo.
+    const checkCatalog = opts.checkCatalog === true;
+    let expectModelsByProvider = null;
+    if (checkCatalog) {
+        const cfg = opts.agentModelsConfig || readAgentModelsConfig();
+        expectModelsByProvider = expectModelsForPing(cfg);
+    }
+
     const providerResults = await pingAllProviders({
         providers,
         prevSnapshot,
@@ -565,6 +821,8 @@ async function runOnce(opts = {}) {
         quotaAssessImpl: opts.quotaAssessImpl,
         defaultProvider: opts.defaultProvider,
         now,
+        checkCatalog,
+        expectModelsByProvider,
     });
     const snapshot = buildSnapshot({ providers: providerResults, now });
 
@@ -633,6 +891,8 @@ async function runOnce(opts = {}) {
         last_tick_at: now,
     };
     if (opts.markWeekly) newState.last_weekly_check_at = now;
+    // #5888 CA-10 — TTL propio del cruce de catálogo (espeja `markWeekly`).
+    if (opts.markCatalogCheck) newState.last_catalog_check_at = now;
     writeJsonAtomic(stateFile, newState, fsImpl);
 
     return { snapshot, alerts, providers_pinged: providerResults.length };
@@ -662,7 +922,14 @@ async function tickIfDue(opts = {}) {
     }
     try {
         const markWeekly = isWeeklyDue({ stateFile, now, fsImpl });
-        return await runOnce({ ...opts, now, markWeekly, stateDir });
+        // #5888 CA-10 — El health-ping sigue en 5 min sin tocar; el cruce de
+        // catálogo tiene su propio TTL (6h). Se pasa como `checkCatalog` (¿bajo
+        // el catálogo en esta corrida?) Y como `markCatalogCheck` (¿reseteo el
+        // TTL?): si sólo se marcara, el próximo tick creería que ya verificó.
+        const checkCatalog = opts.checkCatalog !== undefined
+            ? opts.checkCatalog
+            : isCatalogCheckDue({ stateFile, now, fsImpl, ttlMs: opts.catalogTtlMs });
+        return await runOnce({ ...opts, now, markWeekly, stateDir, checkCatalog, markCatalogCheck: checkCatalog });
     } finally {
         releaseLock({ lockFile, fsImpl });
     }
@@ -688,6 +955,17 @@ module.exports = {
     tickIfDue,
     isTickDue,
     isWeeklyDue,
+    // #5888 — eje de vigencia de modelo (cadencia propia + cruce de config).
+    CATALOG_CHECK_DEFAULT_HOURS,
+    CATALOG_CHECK_MIN_HOURS,
+    CATALOG_CHECK_MAX_HOURS,
+    CATALOG_CHECK_PROVIDERS,
+    PING_TO_CONFIG_PROVIDER,
+    readCatalogTtlMs,
+    isCatalogCheckDue,
+    configuredModelsByProvider,
+    expectModelsForPing,
+    buildCatalogCheck,
     listManagedAndPingable,
     classifyState,
     updateRateLimitCounter,

--- a/.pipeline/lib/multi-provider/live-ping.js
+++ b/.pipeline/lib/multi-provider/live-ping.js
@@ -109,6 +109,17 @@ const PROVIDER_PING_ENDPOINTS = Object.freeze({
         }),
         interpret: (status, bodyExcerpt) =>
             classifyForLivePing('anthropic', status, bodyExcerpt),
+        // #5888 CA-13 — SIN `catalogExtract` por diseño. Los tres providers
+        // excluidos del cruce de catálogo, con su razón escrita:
+        //   - `anthropic`  : corre por CLI-OAuth (Claude Code MAX). `ping()`
+        //     hace short-circuit por `probeCliProvider` y nunca llega acá, así
+        //     que no hay body de catálogo que parsear.
+        //   - `openai`     : idem (Codex CLI-OAuth). Su key de config es
+        //     `openai-codex` (ver PING_TO_CONFIG_PROVIDER en health-cron.js).
+        //   - `kimi-moonshot` (D-1, ref. #5892): NO tiene entrada acá ni en
+        //     `MANAGED_KEYS`, así que `listManagedAndPingable()` jamás lo
+        //     pingea. Incluirlo exige resolver antes la inconsistencia de
+        //     config de #5892. Queda fuera POR DECISIÓN, no por accidente.
     },
     openai: {
         url: 'https://api.openai.com/v1/models',
@@ -119,6 +130,8 @@ const PROVIDER_PING_ENDPOINTS = Object.freeze({
         }),
         interpret: (status, bodyExcerpt) =>
             classifyForLivePing('openai', status, bodyExcerpt),
+        // #5888 CA-13 — sin `catalogExtract` (ver bloque de exclusiones en el
+        // spec de `anthropic`, arriba).
     },
     // ─── Free providers — red de salvataje del pipeline (#3260 SR-2 / SR-7).
     //
@@ -126,8 +139,14 @@ const PROVIDER_PING_ENDPOINTS = Object.freeze({
     //   - URL **literal hardcoded** (anti-SSRF). Prohibido leer de
     //     `agent-models.json`, env vars o body de request.
     //   - Endpoint de **listado de modelos** (no completion) — los pings del
-    //     cron de CA-1 corren cada 15min y la validación semanal de keys (CA-2).
+    //     cron de CA-1 corren cada 5 min (#4402 cambió el default de 15 a 5;
+    //     `health-cron.DEFAULT_INTERVAL_MINUTES = 5`, configurable por
+    //     `config.yaml`) y la validación semanal de keys (CA-2).
     //     Un completion consume cuota, `/models` no.
+    //   - #5888 — si el endpoint es de listado, el spec suma `catalogExtract`:
+    //     recibe el JSON YA PARSEADO y devuelve `string[]` con los ids vivos.
+    //     Se usa SOLO dentro de este módulo (`crossCheckCatalog`) — el catálogo
+    //     del tercero nunca sale de acá (CA-11).
     //   - Header de auth en `Authorization` / `x-api-key` / `x-goog-api-key`,
     //     **nunca en query string** (defense-in-depth contra leaks en logs;
     //     `key` ya está en `SENSITIVE_QUERY_KEYS` para protegerlo igualmente).
@@ -144,6 +163,11 @@ const PROVIDER_PING_ENDPOINTS = Object.freeze({
         headers: (key) => ({ 'authorization': `Bearer ${key}` }),
         interpret: (status, bodyExcerpt) =>
             classifyForLivePing('nvidia-nim', status, bodyExcerpt),
+        // #5888 CA-2 — API OpenAI-compatible: `data[].id` plano (con prefijo de
+        // vendor incluido en el propio id, ej. `deepseek-ai/deepseek-v4-pro`).
+        catalogExtract: (json) => (Array.isArray(json && json.data) ? json.data : [])
+            .map((m) => ((m && typeof m.id === 'string') ? m.id : null))
+            .filter(Boolean),
     },
     // Groq fue descontinuado (#3353, mayo 2026): la organización dueña de las
     // keys fue bloqueada por Groq sin aviso ("organization_restricted") y la
@@ -154,12 +178,21 @@ const PROVIDER_PING_ENDPOINTS = Object.freeze({
         // Google AI Studio v1beta. La key viaja en el header `x-goog-api-key`,
         // no en query (SR-2). Lo llamamos 'gemini-google' (no 'gemini' a
         // secas) porque Vertex AI tiene OAuth distinto y se sumaría aparte.
-        url: 'https://generativelanguage.googleapis.com/v1beta/models',
+        // #5888 G-2/R-H — `?pageSize=1000` va en la URL **literal** de este
+        // módulo (el default de la API es 50 y truncaría el catálogo). Sigue
+        // siendo hardcodeada: nada derivado de config ni de env (cond. 8).
+        // `doRequest` manda `url.pathname + url.search`, así que la query viaja.
+        url: 'https://generativelanguage.googleapis.com/v1beta/models?pageSize=1000',
         method: 'GET',
         body: () => null,
         headers: (key) => ({ 'x-goog-api-key': key }),
         interpret: (status, bodyExcerpt) =>
             classifyForLivePing('gemini-google', status, bodyExcerpt),
+        // #5888 CA-2/G-1 — Gemini devuelve `models[].name` con prefijo
+        // `models/`. Sin normalizarlo, TODO modelo vivo se reportaría ausente.
+        catalogExtract: (json) => (Array.isArray(json && json.models) ? json.models : [])
+            .map((m) => ((m && typeof m.name === 'string') ? m.name.replace(/^models\//, '') : null))
+            .filter(Boolean),
     },
     cerebras: {
         url: 'https://api.cerebras.ai/v1/models',
@@ -168,11 +201,22 @@ const PROVIDER_PING_ENDPOINTS = Object.freeze({
         headers: (key) => ({ 'authorization': `Bearer ${key}` }),
         interpret: (status, bodyExcerpt) =>
             classifyForLivePing('cerebras', status, bodyExcerpt),
+        // #5888 CA-2 — OpenAI-compatible: `data[].id` plano, sin prefijo.
+        catalogExtract: (json) => (Array.isArray(json && json.data) ? json.data : [])
+            .map((m) => ((m && typeof m.id === 'string') ? m.id : null))
+            .filter(Boolean),
     },
 });
 
 const TIMEOUT_MS = 8_000;
 const MAX_BODY_EXCERPT = 512;
+// #5888 cond. 5+7 / D-5 — `MAX_BODY_EXCERPT` NO se amplía: el excerpt de error
+// que SALE del módulo sigue siendo de 512B. El catálogo se acumula en un
+// SEGUNDO buffer, privado, que se consume y se descarta dentro de `ping()`.
+// 1 MiB alcanza holgado para los catálogos de los 3 providers en alcance; al
+// superarlo cortamos el stream (`res.destroy()`) y el cruce queda `unavailable`
+// (nunca `not_in_catalog` sobre un catálogo incompleto).
+const MAX_CATALOG_BYTES = 1 << 20; // 1 MiB
 
 // -----------------------------------------------------------------------------
 // #3965 CA-4 — Throttle server-side de la acción "probar proveedor ahora".
@@ -206,7 +250,59 @@ function isAllowedProvider(provider) {
     return Object.prototype.hasOwnProperty.call(PROVIDER_PING_ENDPOINTS, provider);
 }
 
-async function ping({ provider, secretsPath, fsImpl, httpImpl, nowMs, minIntervalMs, cliProbe } = {}) {
+// -----------------------------------------------------------------------------
+// #5888 — Cruce de catálogo (CA-1/CA-2/CA-3). PRIVADA: el catálogo del tercero
+// entra acá y sale convertido en `[{ model_id, alive }]` con NUESTROS ids.
+//
+// Fail-open exhaustivo (CA-3): cualquier resultado que no sea "catálogo completo
+// leído" devuelve `model_check_unavailable`. JAMÁS `model_not_in_catalog` sobre
+// un catálogo parcial, vacío o no parseable — un catálogo vacío marcaría TODOS
+// los modelos como muertos y entrenaría al operador a ignorar la barrera (R-G).
+//
+// `detail` es un ENUM CERRADO NUESTRO. PROHIBIDO propagar `e.message`: el
+// mensaje de `JSON.parse` embebe un fragmento del body del tercero (R-B) —
+// `Unexpected token '<', "<html>..."`. Por eso el `catch` va SIN binding.
+// -----------------------------------------------------------------------------
+const CATALOG_UNAVAILABLE_DETAILS = Object.freeze([
+    'http_status',      // la respuesta no fue 200
+    'request_failed',   // timeout / error de red — no hubo respuesta
+    'truncated',        // el body superó MAX_CATALOG_BYTES
+    'unparseable',      // no es JSON
+    'paginated',        // vino `nextPageToken`: el catálogo está incompleto
+    'extractor_error',  // el provider cambió el shape y el extractor lanzó
+    'empty_catalog',    // 0 ids: shape cambiado, no "todos muertos" (R-G)
+]);
+
+function catalogUnavailable(detail) {
+    return { ok: false, reason_code: 'model_check_unavailable', detail, models: [] };
+}
+
+function crossCheckCatalog({ spec, result, expectModels }) {
+    if (!result || result.statusCode !== 200) return catalogUnavailable('http_status');
+    if (result.catalogTruncated || !result.catalogRaw) return catalogUnavailable('truncated');
+    let json;
+    try { json = JSON.parse(result.catalogRaw.toString('utf8')); }
+    catch { return catalogUnavailable('unparseable'); }  // catch SIN binding, a propósito (R-B)
+    if (json && typeof json.nextPageToken === 'string' && json.nextPageToken) {
+        return catalogUnavailable('paginated');          // G-2: catálogo parcial ≠ muerte
+    }
+    let ids;
+    try { ids = spec.catalogExtract(json); }
+    catch { return catalogUnavailable('extractor_error'); }
+    if (!Array.isArray(ids) || ids.length === 0) return catalogUnavailable('empty_catalog');
+    // S-B: `Set` con igualdad exacta de string. NUNCA un objeto plano indexado
+    // por id del tercero (`__proto__` silenciaría la barrera para siempre), y
+    // nunca un `RegExp` construido con el id remoto.
+    const alive = new Set(ids.filter((x) => typeof x === 'string'));
+    return {
+        ok: true,
+        reason_code: null,
+        detail: null,
+        models: expectModels.map((id) => ({ model_id: id, alive: alive.has(id) })),
+    };
+}
+
+async function ping({ provider, secretsPath, fsImpl, httpImpl, nowMs, minIntervalMs, cliProbe, expectModels } = {}) {
     if (!isAllowedProvider(provider)) {
         return { ok: false, reason: 'unknown_provider', provider };
     }
@@ -251,12 +347,18 @@ async function ping({ provider, secretsPath, fsImpl, httpImpl, nowMs, minInterva
     _lastPingAt[provider] = now;
     _inFlight[provider] = true;
     const spec = PROVIDER_PING_ENDPOINTS[provider];
+    // #5888 — el catálogo SÓLO se baja cuando el llamador pide el cruce y el
+    // spec sabe extraerlo. Sin `expectModels` el comportamiento es idéntico a
+    // HEAD (el ping manual del dashboard y `api.js` no bajan catálogo — R-J).
+    const wantsCatalog = Array.isArray(expectModels)
+        && expectModels.length > 0
+        && typeof spec.catalogExtract === 'function';
     const startedAt = Date.now();
     let result;
     try {
-        result = await doRequest(spec, key, httpImpl);
+        result = await doRequest(spec, key, httpImpl, { collectCatalog: wantsCatalog });
     } catch (e) {
-        return {
+        const failed = {
             ok: false,
             reason: e.code === 'ETIMEDOUT' || e.code === 'ESOCKETTIMEDOUT'
                 ? 'timeout'
@@ -264,19 +366,37 @@ async function ping({ provider, secretsPath, fsImpl, httpImpl, nowMs, minInterva
             provider,
             latency_ms: Date.now() - startedAt,
         };
+        // CA-3 — timeout / error de red ⇒ `model_check_unavailable`, nunca `dead`.
+        if (wantsCatalog) failed.catalog_check = catalogUnavailable('request_failed');
+        return failed;
     } finally {
         _inFlight[provider] = false;
     }
     const interpretation = spec.interpret(result.statusCode, result.bodyExcerpt || '');
-    return {
+    const out = {
         ...interpretation,
         provider,
         statusCode: result.statusCode,
         latency_ms: Date.now() - startedAt,
     };
+    if (wantsCatalog) {
+        // El buffer del catálogo se consume acá y queda fuera de scope: lo único
+        // que sobrevive es `[{ model_id, alive }]` con ids NUESTROS (CA-11/R-A).
+        out.catalog_check = crossCheckCatalog({ spec, result, expectModels });
+    }
+    return out;
 }
 
-function doRequest(spec, key, httpImpl) {
+// #5888 S-C/R-F — `doRequest` acumula DOS buffers independientes:
+//   - `errChunks`: el excerpt de error que SALE del módulo. Sigue capado en
+//     512B, ahora con recorte a nivel de CHUNK (antes el guard evaluaba
+//     `received < MAX` ANTES de acumular, así que un chunk de 1MB entraba
+//     entero al buffer) y con `res.destroy()` para dejar de drenar el socket.
+//   - `catChunks`: el catálogo. Privado, sólo si `collectCatalog` y `200`
+//     (nunca acumulamos bodies de error — S-D).
+// `res.destroy()` NO emite `'end'` (R-F): sin el handler de `'close'` la
+// promesa nunca resolvería y TODOS los pings colgarían hasta `TIMEOUT_MS`.
+function doRequest(spec, key, httpImpl, { collectCatalog = false } = {}) {
     return new Promise((resolve, reject) => {
         let url;
         try { url = new URL(spec.url); }
@@ -298,18 +418,41 @@ function doRequest(spec, key, httpImpl) {
             headers,
             timeout: TIMEOUT_MS,
         }, (res) => {
-            let chunks = [];
-            let received = 0;
-            res.on('data', c => {
-                if (received < MAX_BODY_EXCERPT) {
-                    chunks.push(c);
-                    received += c.length;
+            const errChunks = []; let errReceived = 0;
+            const catChunks = []; let catReceived = 0; let catTruncated = false;
+            const wantsCatalog = collectCatalog === true
+                && typeof spec.catalogExtract === 'function'
+                && res.statusCode === 200;
+            const destroyRes = () => { if (typeof res.destroy === 'function') res.destroy(); };
+            res.on('data', (c) => {
+                if (errReceived < MAX_BODY_EXCERPT) {
+                    const room = MAX_BODY_EXCERPT - errReceived;
+                    errChunks.push(c.length > room ? c.subarray(0, room) : c);
+                    errReceived += Math.min(c.length, room);
+                }
+                if (wantsCatalog && !catTruncated) {
+                    const room = MAX_CATALOG_BYTES - catReceived;
+                    if (c.length >= room) {
+                        catChunks.push(c.subarray(0, room));
+                        catTruncated = true;
+                        destroyRes();
+                    } else {
+                        catChunks.push(c);
+                        catReceived += c.length;
+                    }
+                } else if (!wantsCatalog && errReceived >= MAX_BODY_EXCERPT) {
+                    destroyRes();
                 }
             });
-            res.on('end', () => {
-                const bodyExcerpt = Buffer.concat(chunks).toString('utf8').slice(0, MAX_BODY_EXCERPT);
-                resolve({ statusCode: res.statusCode, bodyExcerpt });
+            const finish = () => resolve({
+                statusCode: res.statusCode,
+                bodyExcerpt: Buffer.concat(errChunks).toString('utf8').slice(0, MAX_BODY_EXCERPT),
+                catalogRaw: (wantsCatalog && !catTruncated) ? Buffer.concat(catChunks) : null,
+                catalogTruncated: catTruncated,
             });
+            res.on('end', finish);
+            // R-F: `res.destroy()` no emite `'end'`. El 2do `resolve` es no-op.
+            res.on('close', finish);
         });
         req.on('error', reject);
         req.on('timeout', () => {
@@ -330,4 +473,10 @@ module.exports = {
     _resetPingThrottle,
     // Exportado para tests del refactor #3486.
     _classifyForLivePing: classifyForLivePing,
+    // #5888 — cap del buffer privado de catálogo + la función del cruce. R-A:
+    // `doRequest` SIGUE sin exportarse, así que `catalogRaw` no tiene forma de
+    // salir del módulo.
+    MAX_CATALOG_BYTES,
+    CATALOG_UNAVAILABLE_DETAILS,
+    _crossCheckCatalog: crossCheckCatalog,
 };

--- a/.pipeline/lib/provider-pause-cause.js
+++ b/.pipeline/lib/provider-pause-cause.js
@@ -180,6 +180,24 @@ const REASON_TABLE = Object.freeze({
     timeout: { text: () => 'sin respuesta a tiempo', cause: CAUSE_TRANSITORIA },
     network_error: { text: () => 'error de red', cause: CAUSE_TRANSITORIA },
     unknown: { text: () => REASON_LABEL_DEFAULT, cause: CAUSE_TRANSITORIA },
+
+    // #5888 — Códigos del eje de VIGENCIA DE MODELO. En condiciones normales
+    // NUNCA llegan acá: viven en `catalog_check.reason_code` del snapshot, no en
+    // el `reason_code` de salud del provider que lee este módulo (CA-5/R-C).
+    //
+    // Igual llevan copy, por dos razones. Primera, el invariante de UX-3 (un
+    // código sin fila cae al default silencioso "motivo desconocido", que es
+    // justo el modo de falla que este módulo vino a eliminar). Segunda, si
+    // alguna vez alguien los escribiera en el eje equivocado, el texto que ve el
+    // operador tiene que seguir siendo cierto y no acusar al proveedor de estar
+    // caído: NINGUNO de los dos es motivo de pausa del proveedor.
+    //
+    // Por eso ambos van a CAUSE_TRANSITORIA y no a CAUSE_AUTH: CAUSE_AUTH es la
+    // causa DOMINANTE (prioridad 0) y encabezaría el mensaje como si el
+    // proveedor estuviera inutilizable, cuando sigue sirviendo el resto de su
+    // catálogo.
+    model_not_in_catalog: { text: () => 'con un modelo fuera de catálogo', cause: CAUSE_TRANSITORIA },
+    model_check_unavailable: { text: () => 'con la vigencia de sus modelos sin verificar', cause: CAUSE_TRANSITORIA },
 });
 
 /**

--- a/.pipeline/views/dashboard/components.js
+++ b/.pipeline/views/dashboard/components.js
@@ -175,6 +175,45 @@ function renderAgentPill(opts) {
     return `<span class="agent-pill"${titleAttr}>${inner}</span>`;
 }
 
+// -----------------------------------------------------------------------------
+// #5888 — Formateo de antigüedad, compartido.
+//
+// Vivían en `historial.js:147-176` (#3963). Se mueven acá — el módulo común de
+// render que las pantallas ya requieren— porque `providers.js` necesita la misma
+// lectura "hace N h" para la vigencia de catálogo, y hacer que una pantalla
+// requiera el módulo de OTRA pantalla sería peor que duplicar el formateo.
+// `historial.js` las re-exporta para no romper su API pública ni sus tests.
+// -----------------------------------------------------------------------------
+
+// Timestamp humano relativo: "ahora", "hace 5 min", "hace 2 h", "hace 3 d".
+// El operador necesita saber SI ESTÁ FRESCO, no la hora exacta; el absoluto va
+// al `title=` (ver `absTime`).
+function relativeTime(ts, now) {
+    let t = ts;
+    if (typeof t === 'string') t = Date.parse(t);
+    if (!Number.isFinite(t) || t <= 0) return '';
+    const ref = Number.isFinite(now) ? now : Date.now();
+    let diff = ref - t;
+    if (diff < 0) diff = 0;
+    const min = Math.floor(diff / 60000);
+    if (min < 1) return 'ahora';
+    if (min < 60) return `hace ${min} min`;
+    const h = Math.floor(min / 60);
+    if (h < 24) return `hace ${h} h`;
+    const d = Math.floor(h / 24);
+    return `hace ${d} d`;
+}
+
+// Timestamp absoluto formateado (es-AR) para el atributo `title=`.
+function absTime(ts) {
+    let t = ts;
+    if (typeof t === 'string') t = Date.parse(t);
+    if (!Number.isFinite(t) || t <= 0) return '';
+    return new Date(t).toLocaleString('es-AR', {
+        day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit',
+    });
+}
+
 module.exports = {
     SEVERITY_ICON,
     SEVERITIES,
@@ -183,4 +222,7 @@ module.exports = {
     renderStatusBadge,
     renderKpiCard,
     renderAgentPill,
+    // #5888 — helpers de tiempo compartidos (origen: historial.js).
+    relativeTime,
+    absTime,
 };

--- a/.pipeline/views/dashboard/historial.js
+++ b/.pipeline/views/dashboard/historial.js
@@ -46,6 +46,10 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 const { escapeHtmlText, escapeHtmlAttr } = require('../../lib/escape-html.js');
+// #5888 — `relativeTime` / `absTime` se mudaron al módulo compartido de render
+// (`providers.js` necesita el mismo formateo "hace N h" para la vigencia de
+// catálogo). Acá se re-exportan para no romper la API pública de historial.
+const { relativeTime, absTime } = require('./components');
 // #3963 — el cómputo (filtros/agrupación/paginación/agregados) vive en el lib;
 // la vista solo lo invoca y renderiza. Si el módulo no carga (caso edge), el
 // render degrada a string vacío.
@@ -141,35 +145,11 @@ function renderHistCard(h, persona, orderIdx, fmtDuration, ghBaseUrl) {
 
 // -----------------------------------------------------------------------------
 // #3963 — Helpers del timeline.
+//
+// `relativeTime` / `absTime` se movieron a `components.js` (#5888): las requiere
+// también el eje de vigencia de catálogo de `providers.js`. Se importan arriba y
+// se re-exportan abajo — el comportamiento y la firma no cambian.
 // -----------------------------------------------------------------------------
-
-// Timestamp humano relativo (CA-5): "ahora", "hace 5 min", "hace 2 h",
-// "hace 3 d". Se mantiene el timestamp absoluto en `title=` para precisión.
-function relativeTime(ts, now) {
-    let t = ts;
-    if (typeof t === 'string') t = Date.parse(t);
-    if (!Number.isFinite(t) || t <= 0) return '';
-    const ref = Number.isFinite(now) ? now : Date.now();
-    let diff = ref - t;
-    if (diff < 0) diff = 0;
-    const min = Math.floor(diff / 60000);
-    if (min < 1) return 'ahora';
-    if (min < 60) return `hace ${min} min`;
-    const h = Math.floor(min / 60);
-    if (h < 24) return `hace ${h} h`;
-    const d = Math.floor(h / 24);
-    return `hace ${d} d`;
-}
-
-// Timestamp absoluto formateado (es-AR) para el atributo `title=`.
-function absTime(ts) {
-    let t = ts;
-    if (typeof t === 'string') t = Date.parse(t);
-    if (!Number.isFinite(t) || t <= 0) return '';
-    return new Date(t).toLocaleString('es-AR', {
-        day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit',
-    });
-}
 
 // URL segura para `href` de links externos (PR): solo https hacia github.com.
 // Evita `javascript:` y esquemas raros. Se escapa igualmente en el atributo.

--- a/.pipeline/views/dashboard/providers.js
+++ b/.pipeline/views/dashboard/providers.js
@@ -37,7 +37,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 const { escapeHtmlText, escapeHtmlAttr } = require('../../lib/escape-html.js');
-const { renderStatusBadge } = require('./components');
+const { renderStatusBadge, relativeTime, absTime } = require('./components');
 const { renderNavTabsSsr, loadIconSprite } = require('./nav-tabs');
 
 // #5724 CA-4 — Banner del bloqueo de dispatch por divergencia allowlist<->ola.
@@ -102,6 +102,17 @@ const HEALTH_LABEL = Object.freeze({ green: 'SANO', yellow: 'DEGRADADO', red: 'C
 
 // Traducción legible de los reason_code del health-cron (allowlist; lo demás se
 // muestra tal cual, escapado).
+//
+// #5888 D-6/CA-9/CA-18 — INVARIANTE: `ALLOWED_REASON_CODES` (health-alerts.js)
+// debe ser SUBCONJUNTO de las claves de este objeto, y ninguna etiqueta puede
+// contener `_`. Hay un test que lo verifica, y ese test es lo que impide que se
+// repita el precedente de #4869: ahí `cli_license_unavailable` entró a
+// `ALLOWED_REASON_CODES` y nunca acá, así que el operador leía literalmente
+// "cli license unavailable" en un panel que por lo demás está todo en español
+// (el fallback de `reasonHuman` sólo saca guiones bajos). Cuando entró #5888
+// había 5 códigos vivos en esa situación, no 1.
+//
+// Copy acordado con `ux` — NO cambiar sin actualizar la tabla de la definición.
 const REASON_LABEL = Object.freeze({
     cli_oauth_ok: 'OAuth CLI OK',
     authenticated: 'autenticado',
@@ -113,6 +124,15 @@ const REASON_LABEL = Object.freeze({
     no_key_configured: 'sin key configurada',
     unknown_provider: 'provider desconocido',
     cli_unavailable: 'CLI no disponible',
+    // #5888 CA-9 — los 5 huérfanos que ya estaban vivos sin etiqueta.
+    rate_limited: 'rate limit (429)',          // espeja FORBIDDEN (403): el código es lo que se googlea
+    unknown: 'causa desconocida',
+    network_error: 'error de red',             // distinto de `timeout de red`, que ya existía
+    cli_binary_undeclared: 'binario CLI no declarado',  // config faltante, no una caída
+    cli_license_unavailable: 'CLI sin licencia activa', // #4869: instalado pero no habilitado
+    // #5888 CA-8 — eje de VIGENCIA DE MODELO (no es salud del provider).
+    model_not_in_catalog: 'modelo fuera de catálogo',   // nombra lo observado (D-2), no un EOL inferido
+    model_check_unavailable: 'vigencia no verificable', // dice que NO SABEMOS, no que esté bien (D-3)
 });
 function reasonHuman(code) {
     if (!code) return '—';
@@ -270,7 +290,21 @@ function buildProvidersModel() {
             authMode: h.auth_mode || (k.editable === false ? 'oauth' : null),
             freeTierNotes: k.free_tier_notes || h.free_tier_notes || null,
             healthState: state,
+            // #5888 CA-16/R-C — `healthReason` queda INTACTO, reservado al eje de
+            // salud del provider. Los reason codes del eje de modelo NO se
+            // escriben acá: si lo hicieran, el operador leería
+            // "NVIDIA NIM · SANO · modelo fuera de catálogo" en un mismo renglón
+            // cuyo `title` dice "Causa reportada por el health-cron", e
+            // interpretaría el modelo muerto como la causa de la salud del
+            // provider — contradiciendo CA-5 en la superficie visible aunque el
+            // modelo de datos la respete. Peor: pisaría la causa real de salud
+            // cuando el provider ADEMÁS esté degradado.
             healthReason: h.reason_code || null,
+            // #5888 — eje de vigencia de catálogo, independiente de la salud.
+            // `null` para los providers fuera de alcance (anthropic / openai):
+            // el health-cron ni siquiera escribe el campo para ellos, así que la
+            // fila no muestra una vigencia que nadie verifica.
+            catalogCheck: (h.catalog_check && typeof h.catalog_check === 'object') ? h.catalog_check : null,
             // #4283 — discriminante de cuota real (#4202). Independiente del
             // estado de login: distingue "logueado" de "logueado + con cuota"
             // (CA-5). Shape seguro { adapterStatus, status, pct } — sin secretos.
@@ -286,8 +320,29 @@ function buildProvidersModel() {
 
     // Diagnóstico de la cadena.
     const total = providers.length;
+    // #5888 CA-5 — la fórmula de `degraded` / `healthy` NO cambia: el eje de
+    // modelo viaja aparte, en `modelsOutOfCatalog`. (El defecto de que los
+    // providers en `unknown` no entren a ninguno de los dos es #5895, fuera de
+    // alcance de este issue.)
     const degraded = providers.filter((p) => p.healthState === 'yellow' || p.healthState === 'red');
     const healthy = providers.filter((p) => p.healthState === 'green').length;
+
+    // #5888 UX-3/CA-15 — eje SEPARADO: pares (provider, model_id) configurados
+    // que ya no aparecen en el catálogo vivo de su provider. Alimenta el banner
+    // de misión, que sin esto afirmaría "TODO OK · Los 5 proveedores responden"
+    // con un modelo muerto — el mismo modo de falla que la historia elimina,
+    // con otra ropa. `model_check_unavailable` NO entra acá (no es evidencia de
+    // nada; se ve en la fila y nada más).
+    const modelsOutOfCatalog = [];
+    for (const p of providers) {
+        const cc = p.catalogCheck;
+        if (!cc || cc.state !== 'not_in_catalog') continue;
+        for (const m of (Array.isArray(cc.models) ? cc.models : [])) {
+            if (m && m.alive === false && typeof m.model_id === 'string') {
+                modelsOutOfCatalog.push({ providerKey: p.key, providerName: p.name, modelId: m.model_id });
+            }
+        }
+    }
     // Quién absorbe el fallback: el provider con mayor carga 24h.
     let absorber = null;
     for (const p of providers) {
@@ -312,6 +367,8 @@ function buildProvidersModel() {
             total,
             healthy,
             degraded,
+            // #5888 CA-15 — eje de modelo, separado de `degraded`.
+            modelsOutOfCatalog,
             absorber,
             defaultProvider: agents.defaultProvider,
             defaultChain: PROVIDER_ORDER.map((k) => PROVIDER_META[k].name),
@@ -404,12 +461,68 @@ function renderKeyCell(p) {
         + `<span aria-hidden="true">∅</span> sin key</div>`;
 }
 
-function renderCatalogCell(p) {
-    if (!p.models || p.models.length === 0) {
-        return `<div class="prov-models prov-models-empty">— sin catálogo —</div>`;
+/**
+ * #5888 UX-4/CA-8/CA-19 — Línea de VIGENCIA del catálogo. Vive en
+ * `prov-col-models` (no en `prov-col-health`): ésta es la celda semánticamente
+ * correcta para el eje de modelo, y está libre para los 3 providers en alcance
+ * porque `model-catalog.js` devuelve `null` para sus ids (G-8).
+ *
+ * Cuatro estados. La antigüedad va RELATIVA ("hace 4 h") porque lo que el
+ * operador necesita saber es si el dato está fresco, no la hora exacta; el ISO
+ * va al `title`. `vigencia nunca verificada` es un texto propio y necesario:
+ * "no verificable hace —" no comunica nada, y D-3 pide que la ausencia de señal
+ * se vea.
+ *
+ * WCAG 1.4.1: el estado lo dice el TEXTO por sí solo — el color sólo refuerza.
+ */
+function renderVigenciaLine(p, now) {
+    const cc = p.catalogCheck;
+    if (!cc || typeof cc !== 'object') return '';   // provider fuera de alcance del cruce.
+    const state = cc.state;
+    const rel = relativeTime(cc.checked_at, now);
+    const iso = cc.checked_at ? absTime(cc.checked_at) : '';
+
+    if (state === 'not_in_catalog') {
+        const dead = (Array.isArray(cc.models) ? cc.models : []).filter((m) => m && m.alive === false);
+        const chips = dead
+            .map((m) => `<span class="prov-model prov-model-dead" aria-label="${escapeHtmlAttr('modelo fuera de catálogo: ' + m.model_id)}">`
+                + `<span aria-hidden="true">⚠</span>${escapeHtmlText(m.model_id)}</span>`)
+            .join('');
+        const txt = `modelo fuera de catálogo${rel ? ` · verificado ${rel}` : ''}`;
+        return `<div class="prov-vigencia is-model-warn"`
+            + ` title="${escapeHtmlAttr('Última verificación de catálogo: ' + (iso || 'sin dato'))}">`
+            + `<span class="prov-vigencia-txt">${escapeHtmlText(txt)}</span>`
+            + `<span class="prov-vigencia-models">${chips}</span></div>`;
     }
-    const chips = p.models.map((m) => `<span class="prov-model">${escapeHtmlText(m)}</span>`).join('<span class="prov-model-sep" aria-hidden="true">·</span>');
-    return `<div class="prov-models" title="${escapeHtmlAttr('Modelos disponibles para ' + p.name)}">${chips}</div>`;
+    if (state === 'unavailable') {
+        const txt = `vigencia no verificable${rel ? ` · último intento ${rel}` : ''}`;
+        return `<div class="prov-vigencia is-model-info"`
+            + ` title="${escapeHtmlAttr('Último intento de verificación: ' + (iso || 'sin dato'))}">`
+            + `<span class="prov-vigencia-txt">${escapeHtmlText(txt)}</span></div>`;
+    }
+    if (state === 'verified') {
+        const txt = rel ? `verificado ${rel}` : 'verificado';
+        return `<div class="prov-vigencia is-model-ok"`
+            + ` title="${escapeHtmlAttr('Última verificación de catálogo: ' + (iso || 'sin dato'))}">`
+            + `<span class="prov-vigencia-txt">${escapeHtmlText(txt)}</span></div>`;
+    }
+    // 'never' (o cualquier estado no reconocido): la ausencia de señal se ve.
+    return `<div class="prov-vigencia is-model-info"`
+        + ` title="${escapeHtmlAttr('El cruce contra el catálogo del proveedor todavía no corrió para ' + p.name)}">`
+        + `<span class="prov-vigencia-txt">vigencia nunca verificada</span></div>`;
+}
+
+function renderCatalogCell(p, now) {
+    // `— sin catálogo local —` (antes `— sin catálogo —`) queda SÓLO para "no hay
+    // catálogo local declarado en model-catalog.js", que es un eje distinto de
+    // la vigencia y hoy se confundía con ella.
+    const chips = (!p.models || p.models.length === 0)
+        ? `<div class="prov-models prov-models-empty">— sin catálogo local —</div>`
+        : `<div class="prov-models" title="${escapeHtmlAttr('Modelos disponibles para ' + p.name)}">`
+            + p.models.map((m) => `<span class="prov-model">${escapeHtmlText(m)}</span>`)
+                .join('<span class="prov-model-sep" aria-hidden="true">·</span>')
+            + `</div>`;
+    return chips + renderVigenciaLine(p, now);
 }
 
 function renderKillSwitch(p) {
@@ -430,7 +543,7 @@ function renderKillSwitch(p) {
  * Una fila por proveedor (mockup v2). Toda la info — key, salud, tier, catálogo,
  * kill-switch — en una sola línea legible, sin solapas.
  */
-function renderProviderRow(p) {
+function renderProviderRow(p, now) {
     const sev = HEALTH_SEVERITY[p.healthState] || 'info';
     const healthLabel = HEALTH_LABEL[p.healthState] || 'SIN DATOS';
     const reasonTxt = reasonHuman(p.healthReason);
@@ -451,7 +564,7 @@ function renderProviderRow(p) {
     <span class="prov-health-reason" title="${escapeHtmlAttr('Causa reportada por el health-cron')}">${escapeHtmlText(reasonTxt)}</span>
     ${renderQuotaBar(p)}
   </div>
-  <div class="prov-col prov-col-models">${renderCatalogCell(p)}</div>
+  <div class="prov-col prov-col-models">${renderCatalogCell(p, now)}</div>
   <div class="prov-col prov-col-kill">${renderKillSwitch(p)}</div>
 </article>`;
 }
@@ -461,19 +574,48 @@ function renderProviderRow(p) {
  */
 function renderMissionBanner(meta) {
     const degradedCount = meta.degraded.length;
-    const calm = degradedCount === 0;
-    const cls = 'prov-mission' + (calm ? ' is-calm' : ' is-degraded');
+    // #5888 UX-3/CA-15 — El eje de modelo entra al banner SIN contradecir CA-5.
+    //
+    // Sin esto, el elemento de mayor jerarquía visual del panel —lo primero que
+    // el operador lee, y muchas veces lo único— afirmaría "La cadena de
+    // providers está sana · TODO OK · Los 5 proveedores responden" mientras un
+    // modelo configurado está muerto y los agentes que lo usan van a fallar al
+    // despachar. La etiqueta correcta de CA-8 estaría tres niveles más abajo,
+    // en la fila, sin nada que empuje a mirarla.
+    const outOfCatalog = Array.isArray(meta.modelsOutOfCatalog) ? meta.modelsOutOfCatalog : [];
+    const modelWarn = degradedCount === 0 && outOfCatalog.length > 0;
+    const calm = degradedCount === 0 && outOfCatalog.length === 0;
+    // Tratamiento de ADVERTENCIA, no de caído: la cadena efectivamente sigue
+    // operativa. Afirmar que un provider está abajo violaría CA-5.
+    const cls = 'prov-mission' + (calm ? ' is-calm' : modelWarn ? ' is-model-warn' : ' is-degraded');
+    const modelList = outOfCatalog.map((m) => `${m.modelId} (${m.providerName})`).join(', ');
 
     let ttl, chip, desc;
     if (calm) {
         ttl = 'La cadena de providers está sana';
         chip = 'TODO OK';
         desc = `Los ${meta.total} proveedores responden. La cadena de fallback puede absorber caídas sin intervención.`;
+    } else if (modelWarn) {
+        ttl = 'La cadena responde, pero hay modelos fuera de catálogo';
+        chip = outOfCatalog.length === 1
+            ? '1 MODELO FUERA DE CATÁLOGO'
+            : `${outOfCatalog.length} MODELOS FUERA DE CATÁLOGO`;
+        // "o como fallback" no es adorno: es el caso que motivó la historia y el
+        // que el operador NO deduce solo — un fallback roto no se nota hasta que
+        // cae el primario.
+        desc = `Los ${meta.total} proveedores responden. Modelos afectados: ${modelList}. `
+            + `Los agentes que los tengan configurados —como primario o como fallback— van a fallar al despachar.`;
     } else {
         const names = meta.degraded.map((p) => `${p.name} (${reasonHuman(p.healthReason)})`).join(', ');
         ttl = 'La cadena de providers está degradada';
         chip = degradedCount === 1 ? '1 PROVEEDOR CAÍDO' : `${degradedCount} PROVEEDORES CAÍDOS`;
         desc = `Afectados: ${names}. La cadena sigue operativa por fallback, pero con menos redundancia.`;
+        // Provider degradado Y modelo fuera de catálogo: los dos ejes conviven,
+        // ninguno tapa al otro.
+        if (outOfCatalog.length > 0) {
+            desc += ` Además, modelos fuera de catálogo: ${modelList} — los agentes que los tengan `
+                + `configurados, como primario o como fallback, van a fallar al despachar.`;
+        }
     }
 
     const abs = meta.absorber;
@@ -485,15 +627,18 @@ function renderMissionBanner(meta) {
         ? `absorbe una porción alta de la cadena`
         : `reparto de carga saludable`;
 
-    const badgeN = calm ? String(meta.healthy) : String(degradedCount);
-    const badgeK = calm ? 'SANOS' : 'CAÍDOS';
+    // En la rama de advertencia el contador cuenta MODELOS, no providers: decir
+    // "N CAÍDOS de 5 PROVIDERS" con los 5 verdes sería mentir (CA-5).
+    const badgeN = modelWarn ? String(outOfCatalog.length) : calm ? String(meta.healthy) : String(degradedCount);
+    const badgeK = modelWarn ? 'MODELOS' : calm ? 'SANOS' : 'CAÍDOS';
+    const badgeS = modelWarn ? 'FUERA DE CATÁLOGO' : `DE ${String(meta.total)} PROVIDERS`;
 
     return `
-<div class="${cls}" id="prov-mission" role="region" aria-label="Diagnóstico de la cadena de proveedores">
+<div class="${cls}" id="prov-mission" role="region" aria-label="Diagnóstico de la cadena de proveedores y vigencia de sus modelos">
   <div class="prov-btag">
     <div class="prov-btag-n">${escapeHtmlText(badgeN)}</div>
     <div class="prov-btag-k">${escapeHtmlText(badgeK)}</div>
-    <div class="prov-btag-s">DE ${escapeHtmlText(String(meta.total))} PROVIDERS</div>
+    <div class="prov-btag-s">${escapeHtmlText(badgeS)}</div>
   </div>
   <div class="prov-mtext">
     <div class="prov-m-ttl">${escapeHtmlText(ttl)}<span class="prov-m-chip">${escapeHtmlText(chip)}</span></div>
@@ -502,7 +647,7 @@ function renderMissionBanner(meta) {
       <div class="prov-wm">
         <div class="prov-wm-l">🟢 PROVEEDORES SANOS</div>
         <div class="prov-wm-v">${escapeHtmlText(String(meta.healthy))} <span class="u">de ${escapeHtmlText(String(meta.total))}</span></div>
-        <div class="prov-wm-s">${calm ? 'cadena completa' : escapeHtmlText(meta.degraded.map((p) => p.name).join(', ') + ' fuera')}</div>
+        <div class="prov-wm-s">${(calm || modelWarn) ? 'cadena completa' : escapeHtmlText(meta.degraded.map((p) => p.name).join(', ') + ' fuera')}</div>
       </div>
       <div class="prov-wm">
         <div class="prov-wm-l">⚖ ABSORBE EL FALLBACK</div>
@@ -521,6 +666,9 @@ function renderMissionBanner(meta) {
       <div class="prov-reco-l">${calm ? '✓ SIN ACCIÓN PENDIENTE' : '⚠ ACCIÓN SUGERIDA'}</div>
       <div class="prov-reco-t">${calm
           ? 'Monitorear. La cadena tiene redundancia para absorber una caída.'
+          : modelWarn
+          ? escapeHtmlText('Actualizar en agent-models.json: ' + outOfCatalog.map((m) => m.modelId).join(', ')
+              + '. La cadena sigue operativa mientras tanto.')
           : escapeHtmlText('Revisar ' + meta.degraded.map((p) => p.name).join(', ') + ' (terminal Windows / health-run). El resto cubre el fallback.')}</div>
     </div>
   </div>
@@ -548,8 +696,14 @@ function renderAgentStrip(meta) {
 </section>`;
 }
 
-function bodyHtml(model) {
-    const rows = model.providers.map(renderProviderRow).join('');
+function bodyHtml(model, now) {
+    // #5888 — `now` EXPLÍCITO, nunca `.map(renderProviderRow)` a secas: `map`
+    // pasa el ÍNDICE del array como 2do argumento, y un índice es un número
+    // finito, así que `relativeTime` lo tomaría como timestamp de referencia y
+    // TODA la columna de vigencia diría "ahora". Un panel que siempre dice
+    // "verificado ahora" es peor que uno que no dice nada: el operador le cree.
+    const ref = Number.isFinite(now) ? now : Date.now();
+    const rows = model.providers.map((p) => renderProviderRow(p, ref)).join('');
     return `
 ${renderMissionBanner(model.meta)}
 <section class="in-section" aria-labelledby="providers-title">
@@ -691,10 +845,14 @@ const PANEL_CSS = `
   background: var(--in-bg-3); border: 1px solid var(--in-border); border-radius: 14px; padding: 18px 22px; }
 .prov-mission.is-degraded { border-color: var(--in-bad); box-shadow: inset 3px 0 0 var(--in-bad); }
 .prov-mission.is-calm { border-color: var(--in-ok); box-shadow: inset 3px 0 0 var(--in-ok); }
+/* #5888 UX-3 — severidad PROPIA del eje de modelo: advertencia (--in-warn), no
+   caído (--in-bad). La cadena efectivamente sigue operativa (CA-5). */
+.prov-mission.is-model-warn { border-color: var(--in-warn); box-shadow: inset 3px 0 0 var(--in-warn); }
 .prov-btag { display: flex; flex-direction: column; align-items: center; justify-content: center;
   min-width: 120px; padding: 12px 16px; border-radius: 12px; background: var(--in-bg-2); border: 1px solid var(--in-border); }
 .prov-mission.is-degraded .prov-btag { background: var(--in-bad-soft); border-color: var(--in-bad); }
 .prov-mission.is-calm .prov-btag { background: var(--in-ok-soft); border-color: var(--in-ok); }
+.prov-mission.is-model-warn .prov-btag { background: var(--in-warn-soft); border-color: var(--in-warn); }
 .prov-btag-n { font-size: 42px; font-weight: 900; line-height: 1; }
 .prov-btag-k { font-size: 12px; font-weight: 800; letter-spacing: 1px; margin-top: 4px; }
 .prov-btag-s { font-size: 9.5px; font-weight: 700; color: var(--in-fg-dim); letter-spacing: .6px; margin-top: 3px; }
@@ -704,6 +862,8 @@ const PANEL_CSS = `
   background: var(--in-bg-2); border: 1px solid var(--in-border); color: var(--in-fg-dim); }
 .prov-mission.is-degraded .prov-m-chip { background: var(--in-bad-soft); border-color: var(--in-bad); color: var(--in-bad); }
 .prov-mission.is-calm .prov-m-chip { background: var(--in-ok-soft); border-color: var(--in-ok); color: var(--in-ok); }
+.prov-mission.is-model-warn .prov-m-chip { background: var(--in-warn-soft); border-color: var(--in-warn); color: var(--in-warn); }
+.prov-mission.is-model-warn .prov-reco { border-color: var(--in-warn); }
 .prov-m-desc { font-size: 13px; color: var(--in-fg-dim); line-height: 1.5; }
 .prov-wmetrics { display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; margin-top: 6px; }
 .prov-wm { background: var(--in-bg-2); border: 1px solid var(--in-border); border-radius: 10px; padding: 10px 12px; }
@@ -759,6 +919,20 @@ const PANEL_CSS = `
   border: 1px solid var(--in-border); border-radius: 6px; padding: 2px 7px; }
 .prov-model-sep { color: var(--in-fg-soft); }
 .prov-models-empty { font-size: 11px; color: var(--in-fg-soft); }
+/* #5888 UX-4/CA-19 — Eje de VIGENCIA DE CATÁLOGO. Vive en prov-col-models, no
+   en prov-col-health: son ejes distintos y mezclarlos hace leer el modelo muerto
+   como la causa de la salud del provider. El significado lo lleva el TEXTO
+   (WCAG 1.4.1); el color y el ⚠ del chip sólo refuerzan. Sin colores nuevos:
+   reusa las parejas MIZPÁ ya validadas en AA sobre tema oscuro. */
+.prov-col-models { display: flex; flex-direction: column; gap: 5px; }
+.prov-vigencia { display: flex; align-items: center; gap: 7px; flex-wrap: wrap; font-size: 10.5px; font-weight: 600; }
+.prov-vigencia-txt { white-space: normal; }
+.prov-vigencia.is-model-ok { color: var(--in-fg-dim); }
+.prov-vigencia.is-model-info { color: var(--in-info); }
+.prov-vigencia.is-model-warn { color: var(--in-warn); font-weight: 700; }
+.prov-vigencia-models { display: flex; gap: 5px; flex-wrap: wrap; }
+.prov-model-dead { display: inline-flex; align-items: center; gap: 4px;
+  color: var(--in-warn); background: var(--in-warn-soft); border-color: var(--in-warn); }
 .prov-kill { display: inline-flex; align-items: center; gap: 7px; font-size: 11px; font-weight: 800; letter-spacing: .5px;
   padding: 7px 12px; border-radius: 9px; cursor: pointer; border: 1px solid var(--in-border); background: var(--in-bg-2); color: var(--in-fg); }
 .prov-kill-dot { width: 9px; height: 9px; border-radius: 50%; flex: none; }
@@ -965,5 +1139,10 @@ module.exports = {
     renderMissionBanner,
     renderAgentStrip,
     renderInert,
+    // #5888 — expuestos para los tests del eje de modelo (CA-9/CA-15/CA-16/CA-18).
+    renderCatalogCell,
+    renderVigenciaLine,
+    REASON_LABEL,
+    reasonHuman,
     slug: 'providers',
 };


### PR DESCRIPTION
## Resumen

- Entrega automatizada por pipeline V3 (delivery determinístico)
- Cambios: 15 archivos · +1986 -65

## Plan de pruebas

- [x] Pipeline V3 ejecutó builder + tester (gates verdes)
- [x] QA: `qa:passed` aplicado por delivery

## Closes

Closes #5888
